### PR TITLE
fixes compilation issue with julia function uint8() on Apple

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -697,14 +697,14 @@ UIBOX_FUNC(uint64, uint64_t, 3)
 #endif
 
 static jl_value_t *boxed_int8_cache[256];
-jl_value_t *jl_box_int8(int8_t x)
+jl_value_t *jl_box_int8(int32_t x)
 {
     return boxed_int8_cache[(uint8_t)x];
 }
 static jl_value_t *boxed_uint8_cache[256];
-jl_value_t *jl_box_uint8(uint8_t x)
+jl_value_t *jl_box_uint8(uint32_t x)
 {
-    return boxed_uint8_cache[x];
+    return boxed_uint8_cache[(uint8_t)x];
 }
 
 void jl_init_int32_int64_cache(void)

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -718,8 +718,8 @@ static void add_intrinsic(const std::string &name, intrinsic f)
 }
 
 #define ADD_I(name) add_intrinsic(#name, name)
-#define BOX_F(ct)                                                       \
-    box_##ct##_func = boxfunc_llvm(ft1arg(jl_pvalue_llvmt, T_##ct),     \
+#define BOX_F(ct,jl_ct)                                                       \
+    box_##ct##_func = boxfunc_llvm(ft1arg(jl_pvalue_llvmt, T_##jl_ct),     \
                                    "jl_box_"#ct, (void*)&jl_box_##ct);
 
 extern "C" void jl_init_intrinsic_functions()
@@ -762,12 +762,12 @@ extern "C" void jl_init_intrinsic_functions()
     ADD_I(copysign_float32); ADD_I(copysign_float64);
     ADD_I(ccall);
     
-    BOX_F(int8);  BOX_F(uint8);
-    BOX_F(int16); BOX_F(uint16);
-    BOX_F(int32); BOX_F(uint32);
-    BOX_F(int64); BOX_F(uint64);
-    BOX_F(float32); BOX_F(float64);
-    BOX_F(char);
+    BOX_F(int8,int32);  BOX_F(uint8,uint32);
+    BOX_F(int16,int16); BOX_F(uint16,uint16);
+    BOX_F(int32,int32); BOX_F(uint32,uint32);
+    BOX_F(int64,int64); BOX_F(uint64,uint64);
+    BOX_F(float32,float32); BOX_F(float64,float64);
+    BOX_F(char,char);
 
     box8_func  = boxfunc_llvm(ft2arg(jl_pvalue_llvmt, jl_pvalue_llvmt, T_int8),
                               "jl_box8", (void*)*jl_box8);

--- a/src/julia.h
+++ b/src/julia.h
@@ -575,8 +575,8 @@ void jl_add_method(jl_function_t *gf, jl_tuple_t *types, jl_function_t *meth);
 jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_binding_t *bnd,
                           jl_tuple_t *argtypes, jl_function_t *f);
 jl_value_t *jl_box_bool(int8_t x);
-jl_value_t *jl_box_int8(int8_t x);
-jl_value_t *jl_box_uint8(uint8_t x);
+jl_value_t *jl_box_int8(int32_t x);
+jl_value_t *jl_box_uint8(uint32_t x);
 jl_value_t *jl_box_int16(int16_t x);
 jl_value_t *jl_box_uint16(uint16_t x);
 DLLEXPORT jl_value_t *jl_box_int32(int32_t x);


### PR DESCRIPTION
make compilation work with Apple LLVM compiler by having jl_box_int8() and jl_box_uint8() work with full size integers (one register) and forcing the bit cast in C (also generates less assembly code overall!)

this _should_ make everything work with the default Apple compiler
