### PR TITLE
additions to intset

### DIFF
--- a/examples/intsetj.j
+++ b/examples/intsetj.j
@@ -7,12 +7,12 @@ himask(n::Uint32) = (~lomask(32-n))
 #start(s::IntSet) = IntSet(s)
 #done(s::IntSet, i) = isempty(i)
 #function next(s::IntSet, i)
-#	#n = ccall(:bitvector_next, Int64, (Ptr{Uint32}, Uint64, Uint64),
-#	#          s.bits, uint64(first), uint64(s.limit))
-#	#return (n, n+1)
-#	n = bitvector_next(i.bits, uint64(0), uint64(i.limit))::Int64
-#	del(i, n)
-#	return (n, i)
+#   #n = ccall(:bitvector_next, Int64, (Ptr{Uint32}, Uint64, Uint64),
+#   #          s.bits, uint64(first), uint64(s.limit))
+#   #return (n, n+1)
+#   n = bitvector_next(i.bits, uint64(0), uint64(i.limit))::Int64
+#   del(i, n)
+#   return (n, i)
 #end
 
 start(s::IntSet) = int64(0)
@@ -24,57 +24,57 @@ end
 
 
 function bitvector_next(b::Array{Uint32,1}, n0::Uint64, n::Uint64)
-	local w::Uint32
-	i = n0>>5
-	nb = n0&31
-	nw = (n+31)>>5
-	if i < nw-1 || (n&31)==0
-		w = b[i+1]>>nb
-	else
-		w = (b[i+1]&lomask(n&31))>>nb
-	end
-	if w != 0
-		nxt = int64(trailing_zeros(w) + n0)
-		return nxt
-	end
-	if i == nw-1
-		nxt = int64(n)
-		return nxt
-	end
-	i += 1
-	while i < nw-1
-		w = b[i+1]
-		if w != 0
-			nxt = int64(trailing_zeros(w) + i<<5)
-			return nxt
-		end
-		i += 1
-	end
-	w = b[i+1]
-	nb = n & 31
-	i = int64(trailing_zeros(w))
-	if nb == 0
-		nxt = int64(i + (n-32))
-		return nxt
-	end
-	if i >= nb
-		nxt = int64(n)
-		return nxt
-	end
-	nxt = int64(i + (n-nb))
-	return nxt
+    local w::Uint32
+    i = n0>>5
+    nb = n0&31
+    nw = (n+31)>>5
+    if i < nw-1 || (n&31)==0
+        w = b[i+1]>>nb
+    else
+        w = (b[i+1]&lomask(n&31))>>nb
+    end
+    if w != 0
+        nxt = int64(trailing_zeros(w) + n0)
+        return nxt
+    end
+    if i == nw-1
+        nxt = int64(n)
+        return nxt
+    end
+    i += 1
+    while i < nw-1
+        w = b[i+1]
+        if w != 0
+            nxt = int64(trailing_zeros(w) + i<<5)
+            return nxt
+        end
+        i += 1
+    end
+    w = b[i+1]
+    nb = n & 31
+    i = int64(trailing_zeros(w))
+    if nb == 0
+        nxt = int64(i + (n-32))
+        return nxt
+    end
+    if i >= nb
+        nxt = int64(n)
+        return nxt
+    end
+    nxt = int64(i + (n-nb))
+    return nxt
 end
 
 function isempty(s::IntSet)
-	!bitvector_any1(s.bits, uint64(0), uint64(s.limit))
+    !bitvector_any1(s.bits, uint64(0), uint64(s.limit))
 end
 
 function bitvector_any1(b::Array{Uint32,1}, offs::Uint64, nbits::Uint64)
     local nw::Uint32, tail::Uint32, mask::Uint32
 
     if (nbits == 0)
-		return false;
-	end
+        return false;
+    end
     nw = (offs+nbits+31)>>5;
 
     if (nw == 1)
@@ -82,35 +82,35 @@ function bitvector_any1(b::Array{Uint32,1}, offs::Uint64, nbits::Uint64)
             mask = (uint32(0xffffffff)<<offs)
         else
             mask = (lomask(nbits)<<offs)
-		end
-		if ((b[1] & mask) != 0)
-			return true
-		end
+        end
+        if ((b[1] & mask) != 0)
+            return true
+        end
         return false
-	end
+    end
 
     mask = ~lomask(offs)
     if ((b[1] & mask) != 0)
-		return true
-	end
+        return true
+    end
 
     for i = 1:nw-1
         if (b[i+1] != 0)
-			return true
-		end
-	end
+            return true
+        end
+    end
 
     tail = (offs+nbits)&31
     if (tail==0)
         if (b[nw] != 0)
-			return true
-		end
+            return true
+        end
     else
         mask = lomask(tail);
         if ((b[nw] & mask) != 0)
-			return true
-		end
-	end
+            return true
+        end
+    end
     return false
 end
 

--- a/examples/intsetj.j
+++ b/examples/intsetj.j
@@ -1,0 +1,131 @@
+lomask(n::Integer) = lomask(uint32(n))
+lomask(n::Uint32) = ((1<<n)-1)
+himask(n::Integer) = himask(uint32(n))
+himask(n::Uint32) = (~lomask(32-n))
+
+# This appears to be actually the same speed as the one below
+#start(s::IntSet) = IntSet(s)
+#done(s::IntSet, i) = isempty(i)
+#function next(s::IntSet, i)
+#	#n = ccall(:bitvector_next, Int64, (Ptr{Uint32}, Uint64, Uint64),
+#	#          s.bits, uint64(first), uint64(s.limit))
+#	#return (n, n+1)
+#	n = bitvector_next(i.bits, uint64(0), uint64(i.limit))::Int64
+#	del(i, n)
+#	return (n, i)
+#end
+
+start(s::IntSet) = int64(0)
+done(s::IntSet, i) = (next(s,i)[1] >= s.limit)
+function next(s::IntSet, i)
+    n = bitvector_next(s.bits, uint64(i), uint64(s.limit))
+    (n, n+1)
+end
+
+
+function bitvector_next(b::Array{Uint32,1}, n0::Uint64, n::Uint64)
+	local w::Uint32, i::Uint32, nb::Uint32, nw::Uint32
+	i = n0>>5
+	nb = n0&31
+	nw = (n+31)>>5
+	if i < nw-1 || (n&31)==0
+		w = b[i+1]>>nb
+	else
+		w = (b[i+1]&lomask(n&31))>>nb
+	end
+	if w != 0
+		nxt = int64(cttz_int(unbox32(w))::Int32 + n0)
+		return nxt
+	end
+	if i == nw-1
+		nxt = int64(n)
+		return nxt
+	end
+	i += 1
+	while i < nw-1
+		w = b[i+1]
+		if w != 0
+			nxt = int64(cttz_int(unbox32(w))::Int32 + i<<5)
+			return nxt
+		end
+		i += 1
+	end
+	w = b[i+1]
+	nb = n & 31
+	i = int64(cttz_int(unbox32(w))::Int32)
+	if nb == 0
+		nxt = int64(i + (n-32))
+		return nxt
+	end
+	if i >= nb
+		nxt = int64(n)
+		return nxt
+	end
+	nxt = int64(i + (n-nb))
+	return nxt
+end
+
+function isempty(s::IntSet)
+	#ccall(:bitvector_any1, Uint32, (Ptr{Uint32}, Uint64, Uint64),
+	#      s.bits, uint64(0), uint64(s.limit))==0
+	!bitvector_any1(s.bits, uint64(0), uint64(s.limit))
+end
+
+function bitvector_any1(b::Array{Uint32,1}, offs::Uint64, nbits::Uint64)
+    local nw::Uint32, tail::Uint32, mask::Uint32
+
+    if (nbits == 0)
+		return false;
+	end
+    nw = (offs+nbits+31)>>5;
+
+    if (nw == 1)
+        if (nbits == 32)
+            mask = (uint32(0xffffffff)<<offs)
+        else
+            mask = (lomask(nbits)<<offs)
+		end
+		if ((b[1] & mask) != 0)
+			return true
+		end
+        return false
+	end
+
+    mask = ~lomask(offs)
+    if ((b[1] & mask) != 0)
+		return true
+	end
+
+    for i = 1:nw-1
+        if (b[i+1] != 0)
+			return true
+		end
+	end
+
+    tail = (offs+nbits)&31
+    if (tail==0)
+        if (b[nw] != 0)
+			return true
+		end
+    else
+        mask = lomask(tail);
+        if ((b[nw] & mask) != 0)
+			return true
+		end
+	end
+    return false
+end
+
+function choose(s::IntSet)
+    n = bitvector_next(s.bits, uint64(0), uint64(s.limit))::Int64
+    if n >= s.limit
+        error("choose: set is empty")
+    end
+    return n
+end
+
+length(s::IntSet) = numel(s)
+numel(s::IntSet) =
+    int32(ccall(:bitvector_count, Uint64, (Ptr{Uint32}, Uint64, Uint64),
+                s.bits, uint64(0), uint64(s.limit)))
+

--- a/examples/intsetj.j
+++ b/examples/intsetj.j
@@ -24,7 +24,7 @@ end
 
 
 function bitvector_next(b::Array{Uint32,1}, n0::Uint64, n::Uint64)
-	local w::Uint32, i::Uint32, nb::Uint32, nw::Uint32
+	local w::Uint32
 	i = n0>>5
 	nb = n0&31
 	nw = (n+31)>>5
@@ -34,7 +34,7 @@ function bitvector_next(b::Array{Uint32,1}, n0::Uint64, n::Uint64)
 		w = (b[i+1]&lomask(n&31))>>nb
 	end
 	if w != 0
-		nxt = int64(cttz_int(unbox32(w))::Int32 + n0)
+		nxt = int64(trailing_zeros(w) + n0)
 		return nxt
 	end
 	if i == nw-1
@@ -45,14 +45,14 @@ function bitvector_next(b::Array{Uint32,1}, n0::Uint64, n::Uint64)
 	while i < nw-1
 		w = b[i+1]
 		if w != 0
-			nxt = int64(cttz_int(unbox32(w))::Int32 + i<<5)
+			nxt = int64(trailing_zeros(w) + i<<5)
 			return nxt
 		end
 		i += 1
 	end
 	w = b[i+1]
 	nb = n & 31
-	i = int64(cttz_int(unbox32(w))::Int32)
+	i = int64(trailing_zeros(w))
 	if nb == 0
 		nxt = int64(i + (n-32))
 		return nxt
@@ -66,8 +66,6 @@ function bitvector_next(b::Array{Uint32,1}, n0::Uint64, n::Uint64)
 end
 
 function isempty(s::IntSet)
-	#ccall(:bitvector_any1, Uint32, (Ptr{Uint32}, Uint64, Uint64),
-	#      s.bits, uint64(0), uint64(s.limit))==0
 	!bitvector_any1(s.bits, uint64(0), uint64(s.limit))
 end
 

--- a/j/intset.j
+++ b/j/intset.j
@@ -1,41 +1,41 @@
 type IntSet
     bits::Array{Uint32,1}
     limit::Int
-	fill1s::Bool
+    fill1s::Bool
 
     IntSet() = IntSet(1024)
-    IntSet(max::Integer) = (lim = (max+31) & -32;
-                        new(zeros(Uint32,lim>>>5), max, false))
+    IntSet(top::Integer) = (lim = (top+31) & -32;
+                        new(zeros(Uint32,lim>>>5), top, false))
 end
 function IntSet(s::IntSet)
-	s2::IntSet = IntSet(s.limit)
-	s2.fill1s = s.fill1s
-	or!(s2, s)
-	s2
+    s2::IntSet = IntSet(s.limit)
+    s2.fill1s = s.fill1s
+    or!(s2, s)
+    s2
 end
 intset(args...) = add_each(IntSet(), args)
 
-function grow(s::IntSet, max::Integer)
-	if max >= s.limit
-		lim = ((max+31) & -32)>>>5
+function grow(s::IntSet, top::Integer)
+    if top >= s.limit
+        lim = ((top+31) & -32)>>>5
         olsz = length(s.bits)
-		if olsz < lim
-       		newbits = Array(Uint32,lim)
-	        newbits[1:olsz] = s.bits
-			fill = s.fill1s ? uint32(-1) : uint32(0)
-    	    for i=(olsz+1):length(newbits); newbits[i] = fill; end
-	        s.bits = newbits
-		end
-        s.limit = max
-	end
-	s.limit
+        if olsz < lim
+            newbits = Array(Uint32,lim)
+            newbits[1:olsz] = s.bits
+            fill = s.fill1s ? uint32(-1) : uint32(0)
+            for i=(olsz+1):length(newbits); newbits[i] = fill; end
+            s.bits = newbits
+        end
+        s.limit = top
+    end
+    s.limit
 end
 
 function add(s::IntSet, n::Integer)
     if n >= s.limit
         lim = int(n + div(n,2))
-		grow(s, lim)
-	end
+        grow(s, lim)
+    end
     s.bits[n>>5 + 1] |= (1<<(n&31))
     return s
 end
@@ -66,9 +66,25 @@ function del_all(s::IntSet)
     return s
 end
 
+function toggle(s::IntSet, n::Integer)
+    if n >= s.limit
+        lim = int(n + dim(n,2))
+        grow(s, lim)
+    end
+    s.bits[n>>5 + 1] $= (1<<(n&31))
+   return s
+end
+
+function toggle_all(s::IntSet, ns)
+   for n = ns
+       toggle(s, n)
+   end
+   return s
+end
+
 function copy_to!(to::IntSet, from::IntSet)
-	del_all(to)
-	or!(to, from)
+    del_all(to)
+    or!(to, from)
 end
 
 function has(s::IntSet, n::Integer)
@@ -100,9 +116,9 @@ function choose(s::IntSet)
 end
 
 function pop(s::IntSet)
-	n = choose(s)
-	del(s, n)
-	n
+    n = choose(s)
+    del(s, n)
+    n
 end
 
 length(s::IntSet) = numel(s)
@@ -120,72 +136,72 @@ function show(s::IntSet)
         print(n)
         first = false
     end
-	if s.fill1s
-		print(", ..., Inf)")
-	else
-	    print(")")
-	end
+    if s.fill1s
+        print(", ..., Inf)")
+    else
+        print(")")
+    end
 end
 
 
 # Math functions
 function or!(s::IntSet, s2::IntSet)
-	if s2.limit > s.limit
-		grow(s, s2.limit)
-	end
-	lim = length(s2.bits)
-	for n = 1:lim
-		s.bits[n] |= s2.bits[n]
-	end
-	if s2.fill1s
-		for n=lim+1:length(s.bits)
-			s.bits[n] = uint32(-1)
-		end
-	end
-	s.fill1s |= s2.fill1s;
-	s
+    if s2.limit > s.limit
+        grow(s, s2.limit)
+    end
+    lim = length(s2.bits)
+    for n = 1:lim
+        s.bits[n] |= s2.bits[n]
+    end
+    if s2.fill1s
+        for n=lim+1:length(s.bits)
+            s.bits[n] = uint32(-1)
+        end
+    end
+    s.fill1s |= s2.fill1s;
+    s
 end
 
 function and!(s::IntSet, s2::IntSet)
-	if s2.limit > s.limit
-		grow(s, s2.limit)
-	end
-	lim = length(s2.bits)
-	for n = 1:lim
-		s.bits[n] &= s2.bits[n]
-	end
-	if ~s2.fill1s	
-		for n=lim+1:length(s.bits)
-			s.bits[n] = 0
-		end
-	end
-	s.fill1s &= s2.fill1s
-	s
+    if s2.limit > s.limit
+        grow(s, s2.limit)
+    end
+    lim = length(s2.bits)
+    for n = 1:lim
+        s.bits[n] &= s2.bits[n]
+    end
+    if ~s2.fill1s   
+        for n=lim+1:length(s.bits)
+            s.bits[n] = 0
+        end
+    end
+    s.fill1s &= s2.fill1s
+    s
 end
 
 function not!(s::IntSet)
-	for n = 1:length(s.bits)
-		s.bits[n] = ~s.bits[n]
-	end
-	s.fill1s = ~s.fill1s;
-	s
+    for n = 1:length(s.bits)
+        s.bits[n] = ~s.bits[n]
+    end
+    s.fill1s = ~s.fill1s;
+    s
 end
 
 function xor!(s::IntSet, s2::IntSet)
-	if s2.limit > s.limit
-		grow(s, s2.limit)
-	end
-	lim = length(s2.bits)
-	for n = 1:lim
-		s.bits[n] $= s2.bits[n]
-	end
-	if s2.fill1s
-		for n=lim+1:length(s.bits)
-			s.bits[n] = ~s.bits[n]
-		end
-	end
-	s.fill1s $= s2.fill1s;
-	s
+    if s2.limit > s.limit
+        grow(s, s2.limit)
+    end
+    lim = length(s2.bits)
+    for n = 1:lim
+        s.bits[n] $= s2.bits[n]
+    end
+    if s2.fill1s
+        for n=lim+1:length(s.bits)
+            s.bits[n] = ~s.bits[n]
+        end
+    end
+    s.fill1s $= s2.fill1s;
+    s
 end
 
 |(s1::IntSet, s2::IntSet) = (s1.limit >= s2.limit ? or!(IntSet(s1), s2) : or!(IntSet(s2), s1))
@@ -193,32 +209,40 @@ end
 ~(s::IntSet) = not!(IntSet(s))
 ($)(s1::IntSet, s2::IntSet) = (s1.limit >= s2.limit ? xor!(IntSet(s1), s2) : xor!(IntSet(s2), s1))
 
+union!(s1::IntSet, s2::IntSet) = or!(s1, s2)
+union(s1::IntSet, s2::IntSet) = |(s1, s2)
+intersection!(s1::IntSet, s2::IntSet) = and!(s1, s2)
+intersection(s1::IntSet, s2::IntSet) = &(s1, s2)
+complement!(s1::IntSet, s2::IntSet) = not!(s1, s2)
+complement(s1::IntSet, s2::IntSet) = ~(s1, s2)
+
+
 function ==(s1::IntSet, s2::IntSet)
-	if s1.fill1s != s2.fill1s
-		return false
-	end
-	lim1 = length(s1.bits)
-	lim2 = length(s2.bits)
-	for i = 1:min(lim1,lim2)
-		if s1.bits[i] != s2.bits[i]
-			return false
-		end
-	end
-	filln = s1.fill1s ? uint32(-1) : 0
-	if lim1 > lim2
-		for i = lim2:lim1
-			if s1.bits[i] != filln
-				return false
-			end
-		end
-	else
-		for i = lim1:lim2
-			if s2.bits[i] != filln
-				return false
-			end
-		end
-	end
-	return true
+    if s1.fill1s != s2.fill1s
+        return false
+    end
+    lim1 = length(s1.bits)
+    lim2 = length(s2.bits)
+    for i = 1:min(lim1,lim2)
+        if s1.bits[i] != s2.bits[i]
+            return false
+        end
+    end
+    filln = s1.fill1s ? uint32(-1) : 0
+    if lim1 > lim2
+        for i = lim2:lim1
+            if s1.bits[i] != filln
+                return false
+            end
+        end
+    else
+        for i = lim1:lim2
+            if s2.bits[i] != filln
+                return false
+            end
+        end
+    end
+    return true
 end
 !=(s1::IntSet, s2::IntSet) = ~(s1==s2)
 

--- a/j/intset.j
+++ b/j/intset.j
@@ -1,13 +1,15 @@
 type IntSet
     bits::Array{Uint32,1}
     limit::Int
+	fill1s::Bool
 
     IntSet() = IntSet(1024)
     IntSet(max::Integer) = (lim = (max+31) & -32;
-                        new(zeros(Uint32,lim>>>5), lim))
+                        new(zeros(Uint32,lim>>>5), max, false))
 end
 function IntSet(s::IntSet)
 	s2::IntSet = IntSet(s.limit)
+	s2.fill1s = s.fill1s
 	or!(s2, s)
 	s2
 end
@@ -15,11 +17,15 @@ intset(args...) = add_each(IntSet(), args)
 
 function grow(s::IntSet, max::Integer)
 	if max >= s.limit
+		lim = ((max+31) & -32)>>>5
         olsz = length(s.bits)
-        newbits = Array(Uint32,(max+31)>>>5)
-        newbits[1:olsz] = s.bits
-        for i=(olsz+1):length(newbits); newbits[i] = 0; end
-        s.bits = newbits
+		if olsz < lim
+       		newbits = Array(Uint32,lim)
+	        newbits[1:olsz] = s.bits
+			fill = s.fill1s ? uint32(-1) : uint32(0)
+    	    for i=(olsz+1):length(newbits); newbits[i] = fill; end
+	        s.bits = newbits
+		end
         s.limit = max
 	end
 	s.limit
@@ -28,7 +34,7 @@ end
 function add(s::IntSet, n::Integer)
     if n >= s.limit
         lim = int(n + div(n,2))
-		resize(s, lim)
+		grow(s, lim)
 	end
     s.bits[n>>5 + 1] |= (1<<(n&31))
     return s
@@ -114,53 +120,105 @@ function show(s::IntSet)
         print(n)
         first = false
     end
-    print(")")
+	if s.fill1s
+		print(", ..., Inf)")
+	else
+	    print(")")
+	end
 end
 
 
 # Math functions
 function or!(s::IntSet, s2::IntSet)
 	if s2.limit > s.limit
-		grow(s2, s.limit)
+		grow(s, s2.limit)
 	end
-	for n = 1:(s2.limit+31)>>>5
+	lim = length(s2.bits)
+	for n = 1:lim
 		s.bits[n] |= s2.bits[n]
 	end
+	if s2.fill1s
+		for n=lim+1:length(s.bits)
+			s.bits[n] = uint32(-1)
+		end
+	end
+	s.fill1s |= s2.fill1s;
 	s
 end
 
 function and!(s::IntSet, s2::IntSet)
 	if s2.limit > s.limit
-		grow(s2, s.limit)
+		grow(s, s2.limit)
 	end
-	for n = 1:(s2.limit+31)>>>5
+	lim = length(s2.bits)
+	for n = 1:lim
 		s.bits[n] &= s2.bits[n]
 	end
+	if ~s2.fill1s	
+		for n=lim+1:length(s.bits)
+			s.bits[n] = 0
+		end
+	end
+	s.fill1s &= s2.fill1s
 	s
 end
 
 function not!(s::IntSet)
-	for n = 1:(s.limit+31)>>>5
+	for n = 1:length(s.bits)
 		s.bits[n] = ~s.bits[n]
 	end
+	s.fill1s = ~s.fill1s;
 	s
 end
 
 function xor!(s::IntSet, s2::IntSet)
 	if s2.limit > s.limit
-		grow(s2, s.limit)
+		grow(s, s2.limit)
 	end
-	for n = 1:(s2.limit+31)>>>5
+	lim = length(s2.bits)
+	for n = 1:lim
 		s.bits[n] $= s2.bits[n]
 	end
+	if s2.fill1s
+		for n=lim+1:length(s.bits)
+			s.bits[n] = ~s.bits[n]
+		end
+	end
+	s.fill1s $= s2.fill1s;
 	s
 end
-
 
 |(s1::IntSet, s2::IntSet) = (s1.limit >= s2.limit ? or!(IntSet(s1), s2) : or!(IntSet(s2), s1))
 &(s1::IntSet, s2::IntSet) = (s1.limit >= s2.limit ? and!(IntSet(s1), s2) : and!(IntSet(s2), s1))
 ~(s::IntSet) = not!(IntSet(s))
 ($)(s1::IntSet, s2::IntSet) = (s1.limit >= s2.limit ? xor!(IntSet(s1), s2) : xor!(IntSet(s2), s1))
 
-
+function ==(s1::IntSet, s2::IntSet)
+	if s1.fill1s != s2.fill1s
+		return false
+	end
+	lim1 = length(s1.bits)
+	lim2 = length(s2.bits)
+	for i = 1:min(lim1,lim2)
+		if s1.bits[i] != s2.bits[i]
+			return false
+		end
+	end
+	filln = s1.fill1s ? uint32(-1) : 0
+	if lim1 > lim2
+		for i = lim2:lim1
+			if s1.bits[i] != filln
+				return false
+			end
+		end
+	else
+		for i = lim1:lim2
+			if s2.bits[i] != filln
+				return false
+			end
+		end
+	end
+	return true
+end
+!=(s1::IntSet, s2::IntSet) = ~(s1==s2)
 


### PR DESCRIPTION
I've added a few math functions to intset (and, or, not, xor) that should be generally useful, as well as a few other functions.

In addition, I've cloned the c code that implements intset's into julia to benchmark the difference. It should work for all cases, as long as the type conversions were transfered correctly. On my computer, the c implementation runs a certain benchmark involving lots of iterations over the array (and a simple add) in about 7 seconds, the julia replacement implementation takes about 10s. I've copied just the functions requiring replacement, so you can load them after starting julia and they will replace the current c functions. It will also compile as a replacement for the system intset.
Jeff, I've tagged a few things with types (the variable w and the function cttz_int) to get type inference to compile this correctly (as of a week ago). Do you know why these were necessary?
