### PR TITLE
Add a note in readme about OpenBLAS build failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ On some Linux distributions (for instance Ubuntu 11.10) you may need to change h
 
 On Ubuntu, you may also need to install the package `libncurses5-dev`.
 
+If OpenBLAS fails to build in `getarch_2nd.c`, you need to specify the architecture of your processor in Make.inc.
+
 <a name="Directories"/>
 ## Directories
 


### PR DESCRIPTION
It took me some time to find out that I had to specify my processor architecture in Make.inc to get rid of OpenBLAS compilation error. So I think it is a good idea to add a line about it in the readme.
