### PR TITLE
Replaces absolute #include path with framework-style include.

### DIFF
--- a/src/support/dirpath.c
+++ b/src/support/dirpath.c
@@ -88,8 +88,7 @@ char *get_exename(char *buf, size_t size)
     return buf;
 }
 #elif defined(__APPLE__)
-#include "/Developer/Headers/FlatCarbon/Processes.h"
-#include "/Developer/Headers/FlatCarbon/Files.h"
+#include <ApplicationServices/ApplicationServices.h>
 char *get_exename(char *buf, size_t size)
 {
     ProcessSerialNumber PSN;


### PR DESCRIPTION
The original file hard coded absolute paths for two include files. This doesn't work when the developer tools are installed somewhere else. Changing to framework-style include fixes this.

Note that the code changed is within a `#elif defined(__APPLE__)` fence, so it should not affect building on any other operating system.
