### PR TITLE
Remove octal literals misfeature

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -177,7 +177,7 @@
 	       (read-digs)
 	       (disallow #\.)))
     (let* ((s (get-output-string str))
-	   (n (string->number s)))
+	   (n (string->number s (if (eq? pred char-hex?) 16 10))))
       (if n
 	  (if (eq? pred char-hex?)
 	      (sized-uint-literal n s)


### PR DESCRIPTION
Currently Julia has octal integer literals, like this:
`julia> 010
8`

Since they are not mentioned in the manual (as opposed to hex literals) I assume they are an accident, inherited from femtolisp's one-argument `string->number` implementation.

So here's my try at fixing this.
