### PR TITLE
Make launch-webserver correctly error out when lighttpd can't be found

### DIFF
--- a/launch-webserver
+++ b/launch-webserver
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test -x ./external/root/sbin/lighttpd || (echo "Install lighttpd with \"make -C external install-lighttpd\" " && exit 0)
+test -x ./external/root/sbin/lighttpd || { echo "Install lighttpd with \"make -C external install-lighttpd\" " && exit 0; }
 
 echo "Connect to http://localhost:2000/ for the web REPL."
 ./external/root/sbin/lighttpd -D -f ./external/lighttpd.conf &


### PR DESCRIPTION
This fixes a minor bump in the road for new users.
