### PR TITLE
Made it build on FreeBSD and added platform specifics to README.md

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -85,17 +85,22 @@ endif
 
 ifeq ($(OS), Linux)
 SHLIB_EXT = so
+OSLIBS += -ldl -Wl,--export-dynamic -Wl,--version-script=$(JULIAHOME)/src/julia.expmap $(LIBUNWIND)
+endif
+
+ifeq ($(OS), FreeBSD)
+SHLIB_EXT = so
 OSLIBS += -Wl,--export-dynamic -Wl,--version-script=$(JULIAHOME)/src/julia.expmap $(LIBUNWIND)
 endif
 
 ifeq ($(OS), Darwin)
 SHLIB_EXT = dylib
-OSLIBS += -Wl,-w -framework ApplicationServices
+OSLIBS += -ldl -Wl,-w -framework ApplicationServices 
 #CFLAGS += -fno-optimize-sibling-calls -fno-inline-functions
 endif
 
 # Libraries to link
-LIBS = $(shell $(LLVM_CONFIG) --libfiles) $(JULIAHOME)/src/flisp/libflisp.a $(JULIAHOME)/src/support/libsupport.a -L$(EXTROOT)/lib -lutil -ldl -lm $(OSLIBS) -lpthread $(shell $(LLVM_CONFIG) --ldflags)
+LIBS = $(shell $(LLVM_CONFIG) --libfiles) $(JULIAHOME)/src/flisp/libflisp.a $(JULIAHOME)/src/support/libsupport.a -L$(EXTROOT)/lib -lutil -lm $(OSLIBS) -lpthread $(shell $(LLVM_CONFIG) --ldflags)
 
 # Colors for make
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ On OS X, you may need to install `gfortran`. Either download and install [gfortr
 
 On FreeBSD the prerequisites can be installed from ports like this:
 
+    cd /usr/ports/devel/gmake
+    make install
+
     cd /usr/ports/ftp/curl
     make install
  
@@ -88,6 +91,8 @@ On FreeBSD the prerequisites can be installed from ports like this:
     ln -s /usr/local/bin/gfortran45 /usr/local/bin/gfortran
 
 Other versions of gcc are also available but gfortran45 is the one use by all the ports that depend on fortran currently.
+
+**Use the gmake command on FreeBSD instead of make**
 
 On FreeBSD two of the unit tests of flisp fail at the moment.  Until this is fixed you can comment them out:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This is the GitHub repository of Julia source code, including instructions for c
 
 - **GNU/Linux:** x86/64 (64-bit); x86 (32-bit).
 - **Darwin/OS X:** x86/64 (64-bit); x86 (32-bit).
+- **FreeBSD:** x86/64 (64-bit); x86 (32-bit).
 
 <a name="Source-Download-Compilation"/>
 ## Source Download & Compilation
@@ -74,6 +75,45 @@ On OS X, you may need to install `gfortran`. Either download and install [gfortr
     brew install gfortran
     ln -s /usr/local/bin/gfortran-4.2 /usr/local/bin/gfortran
 
+On FreeBSD the prerequisites can be installed from ports like this:
+
+    cd /usr/ports/ftp/curl
+    make install
+ 
+    cd /usr/ports/devel/libunwind
+    make install
+
+    cd /usr/ports/lang/gcc45
+    make install
+    ln -s /usr/local/bin/gfortran45 gfortran
+
+Other versions of gcc are also available but gfortran45 is the one use by all the ports that depend on fortran currently.
+
+On FreeBSD two of the unit tests of flisp fail at the moment.  Until this is fixed you can comment them out:
+
+    diff --git a/src/flisp/unittest.lsp b/src/flisp/unittest.lsp
+    index 9ebd491..3b0df0e 100644
+    --- a/src/flisp/unittest.lsp
+    +++ b/src/flisp/unittest.lsp
+    @@ -77,7 +77,7 @@
+     (assert (equal? (string 'sym #byte(65) #wchar(945) "blah") "symA\u03B1blah"))
+
+     ; NaNs
+    -(assert (equal? +nan.0 +nan.0))
+    +;;;(assert (equal? +nan.0 +nan.0))
+     (assert (not (= +nan.0 +nan.0)))
+     (assert (not (= +nan.0 -nan.0)))
+     (assert (equal? (< +nan.0 3) (> 3 +nan.0)))
+    @@ -92,7 +92,7 @@
+
+     ; -0.0 etc.
+     (assert (not (equal? 0.0 0)))
+    -(assert (equal? 0.0 0.0))
+    +;;;(assert (equal? 0.0 0.0))
+     (assert (not (equal? -0.0 0.0)))
+     (assert (not (equal? -0.0 0)))
+     (assert (not (eqv? 0.0 0)))
+
 <a name="Required-Build-Tools-External-Libraries"/>
 ## Required Build Tools & External Libraries
 
@@ -82,7 +122,7 @@ Buliding Julia requires that the following software be installed:
 - **[GNU make]**                — building dependencies.
 - **[gcc, g++, gfortran][gcc]** — compiling and linking C, C++ and Fortran code.
 - **[perl]**                    — preprocessing of header files of libraries.
-- **[wget]** or **[curl]**          — to automatically download external libraries (Linux defaults to `wget`, OS X to `curl`).
+- **[wget]** or **[curl]**          — to automatically download external libraries (Linux defaults to `wget`, OS X and FreeBSD to `curl`).
 
 With the exception of `gfortran`, these are standard on most Linux systems and on any OS X system with `Xcode` and Apple's Developer Tools installed.
 Julia uses the following external libraries, which are automatically downloaded and compiled from source (or in a few cases, included in the Julia source repository) the first time you run `make`:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ On FreeBSD the prerequisites can be installed from ports like this:
 
     cd /usr/ports/lang/gcc45
     make install
-    ln -s /usr/local/bin/gfortran45 gfortran
+    ln -s /usr/local/bin/gfortran45 /usr/local/bin/gfortran
 
 Other versions of gcc are also available but gfortran45 is the one use by all the ports that depend on fortran currently.
 

--- a/external/Makefile
+++ b/external/Makefile
@@ -27,6 +27,10 @@ ifeq ($(OS), Linux)
 LIBS += unwind
 endif
 
+ifeq ($(OS), FreeBSD)
+LIBS += unwind
+endif
+
 ifeq ($(USE_SYSTEM_READLINE), 0)
 LIBS += readline
 endif

--- a/external/Makefile
+++ b/external/Makefile
@@ -50,6 +50,11 @@ WGET = curl -kLO
 WGET_DASH_O = curl -kLo
 endif
 
+ifeq ($(OS), FreeBSD)
+WGET = curl -kLO
+WGET_DASH_O = curl -kLo
+endif
+
 default: install
 compile: $(addprefix compile-, $(LIBS))
 install: $(addprefix install-, $(LIBS))

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -3,7 +3,7 @@
 #include <assert.h>
 #include <sys/stat.h>
 
-#if defined(__linux)
+#if defined(__linux) || defined(__FreeBSD__)
 #include <unistd.h>
 #include <dlfcn.h>
 #define GET_FUNCTION_FROM_MODULE dlsym

--- a/src/init.c
+++ b/src/init.c
@@ -8,7 +8,7 @@
 #include <stdarg.h>
 #include <setjmp.h>
 #include <assert.h>
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/resource.h>
@@ -32,7 +32,7 @@ size_t jl_page_size;
 static void jl_find_stack_bottom(void)
 {
     size_t stack_size;
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
     struct rlimit rl;
     getrlimit(RLIMIT_STACK, &rl);
     stack_size = rl.rlim_cur;

--- a/src/support/dirpath.c
+++ b/src/support/dirpath.c
@@ -79,6 +79,21 @@ char *get_exename(char *buf, size_t size)
 
     return buf;
 }
+#elif defined(__FreeBSD__)
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+char *get_exename(char *buf, size_t size)
+{
+  int mib[4];
+  mib[0] = CTL_KERN;
+  mib[1] = KERN_PROC;
+  mib[2] = KERN_PROC_PATHNAME;
+  mib[3] = -1;
+  sysctl(mib, 4, buf, &size, NULL, 0);
+ 
+  return buf;
+}
 #elif defined(WIN32)
 char *get_exename(char *buf, size_t size)
 {

--- a/src/support/utf8.c
+++ b/src/support/utf8.c
@@ -26,7 +26,9 @@
 #include <malloc.h>
 #define snprintf _snprintf
 #else
+#ifndef __FreeBSD__
 #include <alloca.h>
+#endif /* __FreeBSD__ */
 #endif
 #include <assert.h>
 

--- a/ui/webserver/network.h
+++ b/ui/webserver/network.h
@@ -20,6 +20,10 @@
 	#include <netdb.h>
 #endif
 
+#ifdef __FreeBSD__
+	#include <netinet/in.h>
+#endif
+
 namespace network
 {
 	// error class for exception handling


### PR DESCRIPTION
I tested it on FreeBSD 8.2 amd64 and it seems to work besides the flisp unit tests below.

I can't test if I broke something for the other platforms but I think they should be fine.

Cheers,
-- Peer

```
--- a/src/flisp/unittest.lsp
+++ b/src/flisp/unittest.lsp
@@ -77,7 +77,7 @@
 (assert (equal? (string 'sym #byte(65) #wchar(945) "blah") "symA\u03B1blah"))

 ; NaNs
-(assert (equal? +nan.0 +nan.0))
+;;;(assert (equal? +nan.0 +nan.0))
 (assert (not (= +nan.0 +nan.0)))
 (assert (not (= +nan.0 -nan.0)))
 (assert (equal? (< +nan.0 3) (> 3 +nan.0)))
@@ -92,7 +92,7 @@

 ; -0.0 etc.
 (assert (not (equal? 0.0 0)))
-(assert (equal? 0.0 0.0))
+;;;(assert (equal? 0.0 0.0))
 (assert (not (equal? -0.0 0.0)))
 (assert (not (equal? -0.0 0)))
 (assert (not (eqv? 0.0 0)))
```
