### PR TITLE
Show full file paths in method table

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1218,9 +1218,6 @@ static void print_methlist(char *name, jl_methlist_t *ml)
             long lno = jl_unbox_long(li->line);
             if (lno > 0) {
                 char *fname = ((jl_sym_t*)li->file)->name;
-                char *sep = strrchr(fname, '/');
-                if (sep)
-                    fname = sep+1;
                 ios_printf(s, " at %s:%d", fname, lno);
             }
         }


### PR DESCRIPTION
It's useful to always be able to reliably find the file listed in the
methods table (i.e. when showing a function in the REPL); especially
since some terminals (like iterm2) can make these into clickable links
that open your editor.
