### PR TITLE
Improved curl calls on FreeBSD

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -51,8 +51,8 @@ WGET_DASH_O = curl -kLo
 endif
 
 ifeq ($(OS), FreeBSD)
-WGET = curl -kLO
-WGET_DASH_O = curl -kLo
+WGET = curl -LO
+WGET_DASH_O = curl -Lo
 endif
 
 default: install


### PR DESCRIPTION
curl in its default configuration comes with certificates on FreeBSD
so we might as well verify the connections.

Tested without -k and it still builds.
