### PR TITLE
Added `length` for Set, IntSet and HashTable

### DIFF
--- a/j/intset.j
+++ b/j/intset.j
@@ -124,6 +124,7 @@ end
 numel(s::IntSet) =
     int(ccall(:bitvector_count, Uint64, (Ptr{Uint32}, Uint64, Uint64),
               s.bits, uint64(0), uint64(s.limit)))
+length(s::IntSet) = numel(s)
 
 function show(s::IntSet)
     print("intset(")

--- a/j/set.j
+++ b/j/set.j
@@ -12,6 +12,7 @@ show(s::Set) = (show(typeof(s)); show_comma_array(s,'(',')'))
 
 isempty(s::Set) = isempty(s.hash)
 numel(s::Set)  = numel(s.hash)
+length(s::Set) = numel(s::Set)
 eltype{T}(s::Set{T}) = T
 
 has(s::Set, x) = has(s.hash, x)

--- a/j/table.j
+++ b/j/table.j
@@ -306,6 +306,7 @@ next(t::HashTable, i) = ((n, nxt) = next(t.used, i);
 
 isempty(t::HashTable) = done(t, start(t))
 numel(t::HashTable) = numel(t.used)-numel(t.deleted)
+length(t::HashTable) = numel(t::HashTable)
 
 function add_weak_key(t::HashTable, k, v)
     if is(t.deleter, identity)


### PR DESCRIPTION
The absence of `length` for those types caused errors when using comprehensions such as :

```
h = {1=>1, 2=>2}
[k | (k,v) = h]
```
