### PR TITLE
always print error backtrace

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -419,7 +419,6 @@ void jl_load_file_expr(char *fname, jl_value_t *ast)
         jl_errorf("syntax error: %s", jl_string_data(jl_exprarg(ast,0)));
     }
     JL_TRY {
-        jl_register_toplevel_eh();
         // handle syntax error
         if (((jl_expr_t*)ast)->head == error_sym) {
             jl_interpret_toplevel_expr(ast);


### PR DESCRIPTION
When an error happens in the repl you get a full backtrace:

```
$ julia -q -L program.j
julia> test()
type CompositeKind has no field __pl_style_func
 in set at subgrid.j:690
 in page_compose at program.j:1207
 in show at program.j:1220
 in test at program.j:1441
```

But when evaluating a cmdline expr, you don't:

```
$ julia -q -L program.j -e "test()"
type CompositeKind has no field __pl_style_func
```

I'm not sure if this patch is the right approach, but it passes the test suite, and appears to do the right thing:

```
$ julia -q -L program.j -e "test()"
type CompositeKind has no field __pl_style_func
 in set at subgrid.j:690
 in page_compose at program.j:1207
 in show at program.j:1220
 in test at program.j:1441
 in process_options at /Users/nolta/julia/j/client.j:131
 in _start at /Users/nolta/julia/j/client.j:201
```
