### PR TITLE
basic imshow and working ppmwrite

### DIFF
--- a/examples/image.j
+++ b/examples/image.j
@@ -93,3 +93,10 @@ function imwrite(I, file::String)
     close(stream)
     wait(cmd)
 end
+
+function imshow(img)
+    tmp::String = "./tmp.ppm"
+    ppmwrite(img, tmp)
+    cmd = `feh $tmp`
+    spawn(cmd)
+end

--- a/examples/image.j
+++ b/examples/image.j
@@ -40,10 +40,9 @@ function ppmwrite(img, file::String)
     n, m = size(img)
     write(s, "$m $n 255\n")
     for i=1:n, j=1:m
-        p = img[i, j]
-        write(s, uint8(redval(p)))
-        write(s, uint8(greenval(p)))
-        write(s, uint8(blueval(p)))
+        write(s, uint8(img[i,j,1]))
+        write(s, uint8(img[i,j,2]))
+        write(s, uint8(img[i,j,3]))
     end
 
     close(s)


### PR DESCRIPTION
ppmwrite now writes all channels to disk, not just the blue channel.
The imshow function is really very basic: It writes the image to disk and shows it using feh.
