### PR TITLE
Makefile compatible with debian/rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,19 +21,19 @@ sys.ji: VERSION sys0.ji j/stage1.j j/sysimg.j j/start_image.j j/*.j
 	$(QUIET_JULIA) ./julia `test -f sys.ji && echo stage1.j || echo -J sys0.ji stage1.j`
 
 install: release
-	install -d $(DESTDIR)/usr/share/julia/lib
-	install -d $(DESTDIR)/usr/share/julia/j
-	install -d $(DESTDIR)/usr/share/julia/contrib
-	install -d $(DESTDIR)/usr/share/julia/examples
-	install -v julia* $(DESTDIR)/usr/share/julia
-	install -v sys.ji $(DESTDIR)/usr/share/julia
-	install -v j/* $(DESTDIR)/usr/share/julia/j
-	install -v examples/*.j $(DESTDIR)/usr/share/julia/examples
-	install -v lib/libarpack.$(SHLIB_EXT) lib/libfdm.$(SHLIB_EXT) lib/libfftw3.$(SHLIB_EXT)* lib/libfftw3f.$(SHLIB_EXT)* lib/libpcre.$(SHLIB_EXT)* lib/libpcrecpp.$(SHLIB_EXT)* lib/libpcreposix.$(SHLIB_EXT)* lib/librandom.$(SHLIB_EXT) lib/liblapack.$(SHLIB_EXT) lib/libsuitesparse*$(SHLIB_EXT) lib/libgrisu.$(SHLIB_EXT) lib/libamos.$(SHLIB_EXT) $(DESTDIR)/usr/share/julia/lib
+	install -d $(DESTDIR)$(PREFIX)/share/julia/lib
+	install -d $(DESTDIR)$(PREFIX)/share/julia/j
+	install -d $(DESTDIR)$(PREFIX)/share/julia/contrib
+	install -d $(DESTDIR)$(PREFIX)/share/julia/examples
+	install -v julia* $(DESTDIR)$(PREFIX)/share/julia
+	install -v sys.ji $(DESTDIR)$(PREFIX)/share/julia
+	install -v j/* $(DESTDIR)$(PREFIX)/share/julia/j
+	install -v examples/*.j $(DESTDIR)$(PREFIX)/share/julia/examples
+	install -v lib/libarpack.$(SHLIB_EXT) lib/libfdm.$(SHLIB_EXT) lib/libfftw3.$(SHLIB_EXT)* lib/libfftw3f.$(SHLIB_EXT)* lib/libpcre.$(SHLIB_EXT)* lib/libpcrecpp.$(SHLIB_EXT)* lib/libpcreposix.$(SHLIB_EXT)* lib/librandom.$(SHLIB_EXT) lib/liblapack.$(SHLIB_EXT) lib/libsuitesparse*$(SHLIB_EXT) lib/libgrisu.$(SHLIB_EXT) lib/libamos.$(SHLIB_EXT) $(DESTDIR)$(PREFIX)/share/julia/lib
 
 dist: release
 	rm -fr dist julia-*.tar.gz
-	$(MAKE) install DESTDIR=dist
+	$(MAKE) install DESTDIR=dist PREFIX=/usr
 	cd dist/usr/share && tar zcvf ../../../julia-$(JULIA_COMMIT)-$(OS)-$(ARCH).tar.gz *
 
 deb:

--- a/debian/rules
+++ b/debian/rules
@@ -10,6 +10,9 @@
 # Modified to make a template file for a multi-binary package with separated
 # build-arch and build-indep targets  by Bill Allombert 2001
 
+# install to /usr
+export PREFIX=/usr
+
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 


### PR DESCRIPTION
`make install` will install to `$(DESTDIR)/share/...`, but the debian package will install to `$(DESTDIR)/usr/share/...`.
