### PR TITLE
An R-like apply function

### DIFF
--- a/j/array.j
+++ b/j/array.j
@@ -1186,6 +1186,30 @@ prod(A::StridedArray{Bool}, region::Region) =
 
 ## map over arrays ##
 
+## along an axis
+function amap(f::Function, A::StridedArray, axis::Integer)
+    dimsA = size(A)
+    ndimsA = ndims(A)
+    axis_size = dimsA[axis]
+
+    if axis_size == 0
+        return f(A)
+    end
+
+    idx = ntuple(ndimsA, j -> j == axis ? 1 : 1:dimsA[j])
+    r = f(slice(A, idx))
+    R = Array(typeof(r), axis_size)
+    R[1] = r
+
+    for i = 2:axis_size
+        idx = ntuple(ndimsA, j -> j == axis ? i : 1:dimsA[j])
+        R[i] = f(slice(A, idx))
+    end
+
+    return R
+end
+
+
 ## 1 argument
 function map_to(dest::StridedArray, f, A::StridedArray)
     for i=1:numel(A)


### PR DESCRIPTION
To facilitate discussion, here's my first pass at a function to map another function across an axis of an array, as per Issue #492.

This is comparable to the `apply` function in R, or the `apply_along_axis` function in numpy, letting you do things like `amap(sum, x, 1)` to sum the columns of a matrix, for example.

One thing to consider is whether a special case should be added if the function being applied returns an array of the same size it was applied to. With this version, `amap(identity, x, 1)` will return an array of arrays, when applied to a matrix `x`, rather than a reproducing `x`.

Both the numpy and R function do have this special case, but it slightly complicates the semantics, so I'm ambivalent. You can do this now (sub-optimally, perhaps) with `apply(hcat, amap(identity, x, 1))`.

Of course any suggestions for a better name than `amap` are welcomed. The numpy `apply_along_axis` seems a little verbose, and the R `apply` conflicts with an existing function.
