### PR TITLE
conv2 should zeropad around matrices

### DIFF
--- a/examples/image.j
+++ b/examples/image.j
@@ -308,3 +308,12 @@ end
 
 imfilter(img, filter) = imfilter(img, filter, "replicate", 0)
 imfilter(img, filter, border) = imfilter(img, filter, border, 0)
+
+function imlineardiffusion{T}(img::Array{T,2}, dt::Float, iterations::Integer)
+    u = img
+    f = imlaplacian()
+    for i = dt:dt:dt*iterations
+        u = u + dt*imfilter(u, f, "replicate")
+    end
+    u
+end

--- a/j/signal.j
+++ b/j/signal.j
@@ -91,11 +91,13 @@ end
 
 function conv2{T}(A::Matrix{T}, B::Matrix{T})
     sa, sb = size(A), size(B)
-    At = zeros(T, sa[1]+sb[1]-1, sa[2]+sb[2]-1)
-    Bt = zeros(T, sa[1]+sb[1]-1, sa[2]+sb[2]-1)
-    At[1:sa[1], 1:sa[2]] = A
-    Bt[1:sb[1], 1:sb[2]] = B
-    C = ifft2(fft2(At).*fft2(Bt))./((sa[1]+sb[1]-1)*(sa[2]+sb[2]-1))
+    At = zeros(T, sa[1]+sb[1], sa[2]+sb[2])
+    Bt = zeros(T, sa[1]+sb[1], sa[2]+sb[2])
+    #At[1:sa[1], 1:sa[2]] = A
+    #Bt[1:sb[1], 1:sb[2]] = B
+    At[int(end/2-sa[1]/2)+1:int(end/2+sa[1]/2), int(end/2-sa[2]/2)+1:int(end/2+sa[2]/2)] = A
+    Bt[int(end/2-sb[1]/2)+1:int(end/2+sb[1]/2), int(end/2-sb[2]/2)+1:int(end/2+sb[2]/2)] = B
+    C = fftshift(ifft2(fft2(At).*fft2(Bt)))./((sa[1]+sb[1]-1)*(sa[2]+sb[2]-1))
     if T <: Real
         return real(C)
     end


### PR DESCRIPTION
In my initial version of the `conv2` function that takes two matrices, the zeropadding was just done at the 'right' and the 'bottom' of the matrices. This led to the problem that the center of the filter kernel was the first element of the kernel (should of course be the center element). Now I'm zeropadding around the matrices, which works as expected.
At first I wanted to keep it similar to the existing `conv2` function which takes two vectors (this function also zeropads at the end of the vectors). Now I have the problem that separated kernels don't work, because the `conv2` function that takes two vectors leads to the same problem of the wrong center of the kernel. I wanted to check with you if this should be changed as well, because I don't want to just screw around in your code. I'm also not quite sure whats the "usual" way to implement this. In my understanding it should be zeropadded at both ends, but I wouldn't be surprised if I'm wrong.
I've also checked in the function `imlineardiffusion`, because with this function it's easy to see wether the filtering works or not, because it applies `imfilter` several times and therefore errors 'propagate' and finally lead to nasty artefacts.
