### PR TITLE
allow newlines in EnvHash values

### DIFF
--- a/j/env.j
+++ b/j/env.j
@@ -58,7 +58,7 @@ function next(::EnvHash, i)
         error("environ: index out of range")
     end
     env::ByteString
-    m = match(r"^(.*?)=(.*)$", env)
+    m = match(r"^(.*?)=(.*)$"s, env)
     if m == nothing
         error("malformed environment entry: $env")
     end


### PR DESCRIPTION
EnvHash() crashes on several of my boxes

```
julia> EnvHash()
...
malformed environment entry: module=() {  eval `/usr/bin/modulecmd bash $*`
}
```

because one of my environment variables contains a newline

```
$ python
>>> os.environ['module']
'() {  eval `/usr/bin/modulecmd bash $*`\n}'
```
