### PR TITLE
user-friendly show(::IOStream)

### DIFF
--- a/j/start_image.j
+++ b/j/start_image.j
@@ -2,8 +2,8 @@
 
 const stdout_stream = make_stdout_stream()
 set_current_output_stream(stdout_stream)
-const stdin_stream = fdio(ccall(:jl_stdin, Int32, ()))
-const stderr_stream = fdio(ccall(:jl_stderr, Int32, ()))
+const stdin_stream = make_stdin_stream()
+const stderr_stream = make_stderr_stream()
 
 # restore shared library handles
 


### PR DESCRIPTION
```
julia> f = open("README.md")
IOStream(<file README.md>)

julia> close(f)

julia> f
IOStream(<closed>)

julia> stderr_stream
IOStream(<stderr>)
```
