### PR TITLE
Added empty search extension for loading framework binaries

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -18,8 +18,8 @@ static char *extensions[] = { ".so" };
 #define GET_FUNCTION_FROM_MODULE dlsym
 #define CLOSE_MODULE dlclose
 typedef void * module_handle_t;
-static char *extensions[] = { ".dylib", ".bundle" };
-#define N_EXTENSIONS 2
+static char *extensions[] = { "", ".dylib", ".bundle" };
+#define N_EXTENSIONS 3
 #endif
 
 #include "julia.h"


### PR DESCRIPTION
Framework binaries (e.g. /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation) do not have a .dylib or a .bundle extension, and thus dlopen would fail to 'find' the library.
