### PR TITLE
Make two-argument linspace() MATLAB-compatible.

### DIFF
--- a/jl/array.jl
+++ b/jl/array.jl
@@ -145,7 +145,7 @@ function linspace(start::Real, stop::Real, n::Integer)
     a
 end
 
-linspace(start::Real, stop::Real) = [ i | i=start:stop ]
+linspace(start::Real, stop::Real) = linspace(start, stop, 100)
 
 ## Conversions ##
 

--- a/jl/linalg_lapack.jl
+++ b/jl/linalg_lapack.jl
@@ -102,7 +102,7 @@ function lu!{T<:Union(Float32,Float64,Complex64,Complex128)}(A::StridedMatrix{T}
     info = _jl_lapack_getrf(m, n, A, stride(A,2), ipiv)
 
     if info > 0; error("matrix is singular"); end
-    P = linspace(1, m)
+    P = [i | i = 1:m]
     for i=1:min(m,n)
         t = P[i]
         P[i] = P[ipiv[i]]


### PR DESCRIPTION
The two-argument linspace() using a stride of 1 doesn't seem terribly useful, and doesn't include both endpoints if either is a non-integral float, so it's not semantically the same as the three-argument form. The patch also replaces the only two-arg linspace() in the standard library so its implementation is unchanged.
