### PR TITLE
fix typo in jl/client.jl

### DIFF
--- a/jl/client.jl
+++ b/jl/client.jl
@@ -157,7 +157,7 @@ function process_options(args::Array{Any,1})
             addprocs_ssh(machines)
         elseif args[i]=="-v" || args[i]=="--version"
             println("julia version $VERSION")
-            println(jl_commit_string)
+            println(_jl_commit_string)
             exit(0)
         elseif args[i][1]!='-'
             # program


### PR DESCRIPTION
Fixes the following bug:

```
$ julia --version
julia version 0.0.0-prerelease
in process_options: jl_commit_string not defined
```
