### PR TITLE
Added zip() and enumerate() utility functions for iterators.

### DIFF
--- a/jl/iterator.jl
+++ b/jl/iterator.jl
@@ -22,3 +22,8 @@ function done(ci::ShivaIterator, state)
     end
     false
 end
+
+zip(xs::AbstractArray, ys::AbstractArray) = [(xs[i], ys[i]) | i in 1:min(length(xs), length(ys))]
+zip(xss::AbstractArray...) = [map((v)->ref(v, i), xss) | i in 1:min(map(length, xss))]
+
+enumerate(j::AbstractArray) = zip(1:length(j), j)


### PR DESCRIPTION
I may not have selected the best types for these functions. If there's a more general iterable supertype we should probably use that instead.
