### PR TITLE
proposal: dlmread with multiple separators (and defaults)

### DIFF
--- a/jl/datafmt.jl
+++ b/jl/datafmt.jl
@@ -80,6 +80,9 @@ function _jl_dlmread_auto(a, f, dlm, nr, nc, row)
 end
 
 function _jl_dlmread_setup(fname::String, dlm::(Char...))
+    if length(dlm) == 0
+        error("dlmread: no separator characters specified")
+    end
     nr = integer(split(readall(`wc -l $fname`),' ',false)[1])
     f = open(fname)
     row = _jl_dlm_readrow(f, dlm)


### PR DESCRIPTION
I have extended dlmread behaviour to include the possibility of having multiple separators, and provided a default list (whitespace and comma, basically). In this way most of the times you don't need to guess in advance what separator was used in writing the data, you just do `dlmread(filename)` (or `dlmread(filename, type)`).

The previous behaviour is retained (i.e. doesn't break any existing code, to the best of my knowledge).

The list of separators can be passed as a tuple of `Char`s, a `Vector{Char}` or an `ASCIIString` (the latest is by far the easiest way). Everything is passed on to `split`, so duplicate entries shouldn't be a problem. Empty separator lists are rejected.
