### PR TITLE
New library features for strings and ranges

### DIFF
--- a/jl/ascii.jl
+++ b/jl/ascii.jl
@@ -9,6 +9,7 @@ ref(s::ASCIIString, i::Int) = char(s.data[i])
 ## overload methods for efficiency ##
 
 ref(s::ASCIIString, r::Range1{Int}) = ASCIIString(ref(s.data,r))
+ref(s::ASCIIString, indx::Array{Int,1}) = ASCIIString(s.data[indx])
 strchr(s::ASCIIString, c::Char) = c < 0x80 ? memchr(s.data, c) : 0
 strcat(a::ASCIIString, b::ASCIIString, c::ASCIIString...) = ASCIIString(memcat(a,b,c...))
 

--- a/jl/range.jl
+++ b/jl/range.jl
@@ -67,6 +67,12 @@ last{T}(r::Range1{T}) = r.start + oftype(T,r.len-1)
 step(r::Range)  = r.step
 step(r::Range1) = one(r.start)
 
+copy(r::Range) = Range(copy(r.start),
+                       copy(r.step),
+                       copy(r.len))
+copy(r::Range1) = Range1(copy(r.start),
+                         copy(r.len))
+
 function ref{T}(r::Range{T}, i::Integer)
     if !(1 <= i <= r.len); error(BoundsError); end
     r.start + oftype(T,i-1)*step(r)


### PR DESCRIPTION
These commits support more generic indexing on ASCIIStrings and deep-copy on range types. I'm not certain the last one is really desired, but I'm sure you'll decide.
