### PR TITLE
[bugfix] Fixing large matrices transpose

### DIFF
--- a/jl/array.jl
+++ b/jl/array.jl
@@ -1253,7 +1253,7 @@ end
 
 function transpose{T<:Union(Float64,Float32,Complex128,Complex64)}(A::Matrix{T})
     if numel(A) > 50000
-        return _jl_fftw_transpose(A)
+        return _jl_fftw_transpose(reshape(A, size(A, 2), size(A, 1)))
     else
         return [ A[j,i] | i=1:size(A,2), j=1:size(A,1) ]
     end

--- a/jl/signal_fftw.jl
+++ b/jl/signal_fftw.jl
@@ -229,8 +229,8 @@ for (libname, fname, elty) in ((:_jl_libfftw ,"fftw_plan_guru_r2r",:Float64),
                                (:_jl_libfftwf,"fftwf_plan_guru_r2r",:Float32))
     @eval begin
         function _jl_fftw_transpose(X::Matrix{$elty})
+            P = similar(X)
             (n1, n2) = size(X)
-            P = similar(X, n2, n1)
             plan = ccall(dlsym($libname, $fname), Ptr{Void},
                          (Int32, Ptr{Int32}, Int32, Ptr{Int32}, Ptr{$elty}, Ptr{$elty}, Ptr{Int32}, Uint32),
                          0, C_NULL, 2, int32([n1,n2,1,n2,1,n1]), X, P, [_jl_FFTW_HC2R], _jl_FFTW_ESTIMATE | _jl_FFTW_PRESERVE_INPUT)
@@ -245,8 +245,8 @@ for (libname, fname, celty) in ((:_jl_libfftw ,"fftw_plan_guru_dft",:Complex128)
                                 (:_jl_libfftwf,"fftwf_plan_guru_dft",:Complex64))
     @eval begin
         function _jl_fftw_transpose(X::Matrix{$celty})
+            P = similar(X)
             (n1, n2) = size(X)
-            P = similar(X, n2, n1)
             plan = ccall(dlsym($libname, $fname), Ptr{Void},
                          (Int32, Ptr{Int32}, Int32, Ptr{Int32}, Ptr{$celty}, Ptr{$celty}, Int32, Uint32),
                          0, C_NULL, 2, int32([n1,n2,1,n2,1,n1]), X, P, _jl_FFTW_FORWARD, _jl_FFTW_ESTIMATE | _jl_FFTW_PRESERVE_INPUT)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -144,3 +144,11 @@ v[2,1,1,1] = 32.0
 v[2,2,1,1] = 40.0
 
 @assert isequal(v,sum(z,(3,4)))
+
+## large matrices transpose ##
+
+for i = 1 : 5
+    a = rand(200, 300)
+
+    @assert isequal(a', permute(a, (2, 1)))
+end


### PR DESCRIPTION
Large matrices (>50000 elements) transpose is still broken.
This reverts commit 6cd4d366faf6d0dc71004b6edc0a3df32cae35a9 and fixes the issue. Maybe it's not elegant, but it works. Also, I have added some tests in test/arrayops.jl.

before the fix:

```
julia> a = rand(200, 300);

julia> all(a' == permute(a, (2, 1)))
false
```

after the fix:

```
julia> all(a' == permute(a, (2, 1)))
true
```
