### PR TITLE
Added right matrix division

### DIFF
--- a/jl/linalg_lapack.jl
+++ b/jl/linalg_lapack.jl
@@ -661,3 +661,5 @@ function (\){T<:Union(Float64,Float32,Complex128,Complex64)}(A::StridedMatrix{T}
 end
 
 (\){T1<:Real, T2<:Real}(A::StridedMatrix{T1}, B::StridedVecOrMat{T2}) = (\)(float64(A), float64(B))
+
+(/){T1<:Real, T2<:Real}(A::StridedVecOrMat{T1}, B::StridedVecOrMat{T2}) = (B' \ A')'


### PR DESCRIPTION
I noticed there's no right matrix division in linarg_lapack. I added that just by defining `A / B = (B' \ A')'`. I'm not sure whether there's a better way to do this; however, transposition times are likely negligible compared to the elimination process. In fact, I tested both expressions in matlab and I found no difference in performance or result (exact floating-point equality) between the two, possibly meaning that it uses the same definition as above.
