### PR TITLE
New Vector constructor idiom using ranges

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -76,6 +76,9 @@ function ref{T}(::Type{T}, vals...)
     return a
 end
 ref{T}(::Type{T}) = Array(T,0)
+
+ref{T <: Real, S <: Ranges}(::Type{T}, r::S) = [ convert(T, x)::T | x = r ]
+
 ref{T}(::Type{T}, x) = (a=Array(T,1); a[1]=x; a)
 
 function fill!{T<:Union(Int8,Uint8)}(a::Array{T}, x::Integer)


### PR DESCRIPTION
I'm proposing a shortcut-constructor for Vectors from ranges.
The reasoning is that since things like `Int[1,2,5,3]` are already allowed, why not allow also `Int[1:5]` and the like?

From my point of view it's useful, since I'm doing stuff like `[i::Int | i=1:N]` all the time, and I don't see it interfering with anything else, but of course you might not like it.

I wrote a one-liner which does that using a comprehension with an implicit conversion (`Int[args...]` also converts its arguments, so it's consistent).

Example:

```
julia> Float[1:2:8]
[1.0, 3.0, 5.0, 7.0]
```
