### PR TITLE
DO NOT MERGE YET: discussion/code on memory locking

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -51,27 +51,6 @@ function reshape{T,N}(a::Array{T}, dims::NTuple{N,Int})
     ccall(:jl_reshape_array, Any, (Any, Any, Any), Array{T,N}, a, dims)::Array{T,N}
 end
 
-## Memory locking ##
-function allow_swapping{T}(src::Array{T})
-    status = ccall(:jl_munlock,Int,(Any),src)
-    println("Unlocked with status $status")
-    return status
-end
-
-type ArrayLockHolder{T}
-    var::Array{T}
-end
-allow_swapping{T}(lh::ArrayLockHolder{T}) = allow_swapping(lh.var)
-
-function prevent_swapping{T}(src::Array{T})
-    mlock = ArrayLockHolder(src)
-    finalizer(mlock,allow_swapping)
-    status = ccall(:jl_mlock,Int,(Any),src)
-    return status, mlock
-end
-
-
-
 ## Constructors ##
 
 _jl_comprehension_zeros{T,n}(oneresult::AbstractArray{T,n}, dims...) = Array(T, dims...)

--- a/base/memory.jl
+++ b/base/memory.jl
@@ -1,0 +1,18 @@
+## Memory management/Memory locking ##
+function allow_swapping{T}(src::Array{T})
+    status = ccall(:jl_munlock,Int,(Any,),src)
+    println("Unlocked with status $status")
+    return status
+end
+
+type ArrayLockHolder{T}
+    var::Array{T}
+end
+allow_swapping{T}(lh::ArrayLockHolder{T}) = allow_swapping(lh.var)
+
+function prevent_swapping{T}(src::Array{T})
+    mlock = ArrayLockHolder(src)
+    finalizer(mlock,allow_swapping)
+    status = ccall(:jl_mlock,Int,(Any,),src)
+    return status, mlock
+end

--- a/src/array.c
+++ b/src/array.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <sys/mman.h>
 #include "julia.h"
 
 // array constructors ---------------------------------------------------------
@@ -445,4 +446,14 @@ void jl_cell_1d_push(jl_array_t *a, jl_value_t *item)
     assert(jl_typeis(a, jl_array_any_type));
     jl_array_grow_end(a, 1);
     jl_cellset(a, a->length-1, item);
+}
+
+int jl_mlock(jl_array_t *a)
+{
+    return mlock(a->data, a->length*a->elsize);
+}
+
+int jl_munlock(jl_array_t *a)
+{
+    return munlock(a->data, a->length*a->elsize);
 }

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -65,6 +65,8 @@
     jl_array_grow_beg;
     jl_array_del_beg;
     jl_array_ptr;
+    jl_mlock;
+    jl_munlock;
     jl_sizeof_ios_t;
     jl_stdout_stream;
     ios_fd;

--- a/src/julia.h
+++ b/src/julia.h
@@ -631,6 +631,8 @@ DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec);
 DLLEXPORT void jl_array_grow_beg(jl_array_t *a, size_t inc);
 DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec);
 void jl_cell_1d_push(jl_array_t *a, jl_value_t *item);
+DLLEXPORT int jl_mlock(jl_array_t *a);
+DLLEXPORT int jl_munlock(jl_array_t *a);
 
 // system information
 DLLEXPORT int jl_errno(void);


### PR DESCRIPTION
I'm writing code now where the working style will be:
for i = 1:n_chunks
    Load chunk i from disk
    Work on chunk i
    Store results to disk
end

One will get better performance by making the chunks larger, BUT only if the OS does not start swapping. For that reason, I want to add support for locking array data in memory (and put the code inside a try/catch statement to reduce the chunk size if locking fails).

The attached code is an attempt to do this, but (1) it has a slightly weird issue, and (2) it may have revealed a bug.
1. The issue: the new file base/memory.jl does not get loaded automatically. It loads fine if I do it explicitly. Curiously, if I try to include the code into array.jl (before the constructor), then "make" fails at the JULIA sys0.jl line. It would be good to fix this issue before merging, but I may need a hint about the best approach.
2. The potential bug: First do load("memory.jl"), and then try running the following function:
   function mytest()
   x = Array(Int32,1000,1000,100)
   status, mlock = prevent_swapping(x)
   return 0
   end

The second output of prevent_swapping, mlock, is a variable that is supposed to trigger allow_swapping(x) when it goes out of scope. So by including it inside a function block, it should go out of scope when the function exits, and therefore call allow_swapping. Note that I included a "println" statement in allow_swapping, so I'll know when it gets called.

Here's what I get:
julia> mytest()
0

julia> mytest()
Unlocked with status 0
0

For some reason, allow_swapping doesn't get called the first time, but it does the second (and later) times. Bug?
