### PR TITLE
Function(s) to express nearishness

### DIFF
--- a/extras/nearequal.jl
+++ b/extras/nearequal.jl
@@ -1,0 +1,24 @@
+# numerical near equality
+isclose(x, y, rtol, atol) = abs(x-y) <= atol+rtol.*max(abs(x), abs(y))
+function isclose{T1<:Float, T2<:Float}(x::T1, y::T2)
+    tol = max(eps(T1), eps(T2))
+    isclose(x, y, tol^(1/3), sqrt(tol))
+end
+isclose{T1<:Integer, T2<:Float}(x::T1, y::T2) = isclose(float(x), y)
+isclose{T1<:Float, T2<:Integer}(x::T1, y::T2) = isclose(x, float(y))
+
+isclose(X::AbstractArray, y::Number) = map(x -> isclose(x, y), X)
+isclose(x::Number, Y::AbstractArray) = map(y -> isclose(y, x), Y)
+
+function isclose(X::AbstractArray, Y::AbstractArray)
+    if size(X) != size(Y)
+        error("Arrays must have the same sizes (first is $(size(X)), second is $(size(Y))).")
+    end
+    Z = similar(X, Bool)
+    for i in 1:numel(X)
+        Z[i] = isclose(X[i], Y[i])
+    end
+    Z
+end
+
+isclose{T1<:Integer, T2<:Integer}(x::T1, y::T2) = isequal(x, y)

--- a/extras/nearequal.jl
+++ b/extras/nearequal.jl
@@ -1,5 +1,14 @@
 # numerical near equality
-isclose(x, y, rtol, atol) = abs(x-y) <= atol+rtol.*max(abs(x), abs(y))
+function isclose(x, y, rtol, atol)
+    if isnan(x) || isnan(y)
+        return isnan(x) && isnan(y)
+    end
+    if isinf(x) || isinf(y)
+        return x == y
+    end
+    abs(x-y) <= atol+rtol.*max(abs(x), abs(y))
+end
+
 function isclose{T1<:Float, T2<:Float}(x::T1, y::T2)
     tol = max(eps(T1), eps(T2))
     isclose(x, y, tol^(1/3), sqrt(tol))

--- a/extras/nearequal.jl
+++ b/extras/nearequal.jl
@@ -1,33 +1,58 @@
-# numerical near equality
+#ISCLOSE Check for nearly equal values.
+#   ISCLOSE(x::T1, y::T2) checks if x and y are nearly equal. The default tolerance is
+#   determined by the types. If tol = max(eps(T1), eps(T2)), then the values need to be
+#   within sqrt(tol)+tol^(1/3)*max(abs(x), abs(y)).
+#
+#   ISCLOSE(x, y, rtol, atol) provides specific values in place of tol^(1/3) and sqrt(tol),
+#   respectively.
+#
+#   ISCLOSE(x::T1, y::T2) where T1<:Integer and T2<:Integer is the same as ISEQUAL.
 function isclose(x, y, rtol, atol)
-    if isnan(x) || isnan(y)
-        return isnan(x) && isnan(y)
-    end
     if isinf(x) || isinf(y)
         return x == y
     end
     abs(x-y) <= atol+rtol.*max(abs(x), abs(y))
 end
 
-function isclose{T1<:Float, T2<:Float}(x::T1, y::T2)
-    tol = max(eps(T1), eps(T2))
-    isclose(x, y, tol^(1/3), sqrt(tol))
-end
-isclose{T1<:Integer, T2<:Float}(x::T1, y::T2) = isclose(float(x), y)
-isclose{T1<:Float, T2<:Integer}(x::T1, y::T2) = isclose(x, float(y))
+#ISCLOSEN Check for nearly equal values, treating NaNs as mutually equal.
+#   ISCLOSEN(x, y, ...) checks if x and y are nearly equal in the same way as ISCLOSE, but
+#   allowing NaNs to evaluate as equal. This is useful if two methods of computing the same
+#   values are being verified against one another, and that computation can produce NaNs.
+#
+#   ISCLOSEN(x, y, ...) gives the same results as ISCLOSE(x, y, ...) if neither x nor
+#   y contain NaN values.
+isclosen(x, y, rtol, atol) = isclose(x, y, rtol, atol) || (isnan(x) && isnan(y))
 
-isclose(X::AbstractArray, y::Number) = map(x -> isclose(x, y), X)
-isclose(x::Number, Y::AbstractArray) = map(y -> isclose(y, x), Y)
+for fun in (:isclose, :isclosen)
+    @eval begin
+        function ($fun){T1<:Float, T2<:Float}(x::T1, y::T2)
+            tol = max(eps(T1), eps(T2))
+            ($fun)(x, y, tol^(1/3), sqrt(tol))
+        end
+        ($fun){T1<:Integer, T2<:Float}(x::T1, y::T2) = ($fun)(float(x), y)
+        ($fun){T1<:Float, T2<:Integer}(x::T1, y::T2) = ($fun)(x, float(y))
 
-function isclose(X::AbstractArray, Y::AbstractArray)
-    if size(X) != size(Y)
-        error("Arrays must have the same sizes (first is $(size(X)), second is $(size(Y))).")
+        ($fun)(X::AbstractArray, y::Number) = map(x -> ($fun)(x, y), X)
+        ($fun)(x::Number, Y::AbstractArray) = map(y -> ($fun)(y, x), Y)
+
+        function ($fun)(X::AbstractArray, Y::AbstractArray)
+            if size(X) != size(Y)
+                error("Arrays must have the same sizes (first is $(size(X)), second is $(size(Y))).")
+            end
+            Z = similar(X, Bool)
+            for i in 1:numel(X)
+                Z[i] = ($fun)(X[i], Y[i])
+            end
+            Z
+        end
     end
-    Z = similar(X, Bool)
-    for i in 1:numel(X)
-        Z[i] = isclose(X[i], Y[i])
-    end
-    Z
 end
 
+# For integers, isclose() is just isequal() unless you specify nondefault tolerances.
 isclose{T1<:Integer, T2<:Integer}(x::T1, y::T2) = isequal(x, y)
+#isclosen() doesn't apply to two Integer types, since typeof(NaN)<:Float
+
+#ISEQUALN Check for equality, treating NaNs as mutually equal.
+#   ISEQUALN(x, y) gives the same results as ISEQUAL(x, y), unless both x and y are NaN
+#   values. In this case, ISEQUALN(x, y) returns true instead of false.
+isequaln(x, y) = isequal(x, y) || (isnan(x) && isnan(y))


### PR DESCRIPTION
This is a first shot at expressing nearishness in Julia, taking as inspiration NumPy's `allclose()` function. It doesn't handle Inf/NaN the same as `numpy.allclose()`, and doesn't handle all the possible types that R's `all.equal()` can apparently handle.

So, what is needed from those other functions here (or for specific types), noting that `isequal()` already exists to express actual equality? The single commit is the simplest thing that could possibly work, but I'll add optimized things (like mapping it to `isequal()` for integer types) before merge if I'm on the right path and this is something we want.

Whether this belongs in base/ is certainly up for discussion as well.

Input from everyone certainly helpful, but I do want to make sure @dmbates gets to see this, since he got me started thinking about it.

`numpy.allclose()` is defined at https://github.com/numpy/numpy/blob/master/numpy/core/numeric.py#L1963
