### PR TITLE
Large file support on 32-bit.

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -30,7 +30,7 @@ USECLANG = 0
 ifeq ($(USEGCC),1)
 CC = gcc
 CXX = g++
-JCFLAGS = -std=gnu99 -pipe -fPIC -fno-strict-aliasing
+JCFLAGS = -std=gnu99 -pipe -fPIC -fno-strict-aliasing -D_FILE_OFFSET_BITS=64
 JCXXFLAGS = -pipe -fPIC -fno-rtti
 DEBUGFLAGS = -ggdb3 -DDEBUG
 SHIPFLAGS = -O3 -DNDEBUG -falign-functions -momit-leaf-frame-pointer

--- a/base/io.jl
+++ b/base/io.jl
@@ -1,5 +1,12 @@
+const sizeof_off_t = int(ccall(:jl_sizeof_off_t, Int32, ()))
 const sizeof_ios_t = int(ccall(:jl_sizeof_ios_t, Int32, ()))
 const sizeof_fd_set = int(ccall(:jl_sizeof_fd_set, Int32, ()))
+
+if sizeof_off_t == 4
+    typealias FileOffset Int32
+else
+    typealias FileOffset Int64
+end
 
 type IOStream
     # NOTE: for some reason the order of these field is significant!?
@@ -47,7 +54,7 @@ function open(fname::String, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::Bool)
              s.ios, cstring(fname), rd, wr, cr, tr) == C_NULL
         error("could not open file ", fname)
     end
-    if ff && ccall(:ios_seek_end, Uint, (Ptr{Void},), s.ios) != 0
+    if ff && ccall(:ios_seek_end, FileOffset, (Ptr{Void},), s.ios) != 0
         error("error seeking to end of file ", fname)
     end
     return s
@@ -247,14 +254,14 @@ truncate(s::IOStream, n::Integer) =
     ccall(:ios_trunc, Uint, (Ptr{Void}, Uint), s.ios, n)
 
 seek(s::IOStream, n::Integer) =
-    (ccall(:ios_seek, Int, (Ptr{Void}, Int), s.ios, n)==0 ||
+    (ccall(:ios_seek, FileOffset, (Ptr{Void}, FileOffset), s.ios, n)==0 ||
      error("seek failed"))
 
 skip(s::IOStream, delta::Integer) =
-    (ccall(:ios_skip, Int, (Ptr{Void}, Int), s.ios, delta)==0 ||
+    (ccall(:ios_skip, FileOffset, (Ptr{Void}, FileOffset), s.ios, delta)==0 ||
      error("skip failed"))
 
-position(s::IOStream) = ccall(:ios_pos, Int, (Ptr{Void},), s.ios)
+position(s::IOStream) = ccall(:ios_pos, FileOffset, (Ptr{Void},), s.ios)
 
 type IOTally
     nbytes::Int

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -59,6 +59,7 @@
     jl_array_grow_beg;
     jl_array_del_beg;
     jl_array_ptr;
+    jl_sizeof_off_t;
     jl_sizeof_ios_t;
     jl_stdout_stream;
     ios_fd;

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -25,10 +25,10 @@ typedef struct {
     int errcode;
 
     char *buf;        // start of buffer
-    size_t maxsize;   // space allocated to buffer
-    size_t size;      // length of valid data in buf, >=ndirty
-    size_t bpos;      // current position in buffer
-    size_t ndirty;    // # bytes at &buf[0] that need to be written
+    off_t maxsize;    // space allocated to buffer
+    off_t size;       // length of valid data in buf, >=ndirty
+    off_t bpos;       // current position in buffer
+    off_t ndirty;     // # bytes at &buf[0] that need to be written
 
     off_t fpos;       // cached file pos
     size_t lineno;    // current line number

--- a/src/sys.c
+++ b/src/sys.c
@@ -66,6 +66,8 @@ DLLEXPORT size_t jl_ios_size(ios_t *s)
     return s->size;
 }
 
+DLLEXPORT int jl_sizeof_off_t(void) { return sizeof(off_t); }
+
 DLLEXPORT long jl_ios_fd(ios_t *s)
 {
     return s->fd;


### PR DESCRIPTION
To test, you need to do the following from the base julia directory:

rm src/flisp/.o src/flisp/.a src/support/.o src/support/.a
make clean
make

(If you merge this, one concern is that all use users may have to execute those lines.)

This defaults to 64-bit support, but if you don't like that, you can disable it by getting rid of the -D_FILE_OFFSET_BITS=64 addition to CFLAGs in Make.inc.
