### PR TITLE
Define a length function over iterators.

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -1,3 +1,14 @@
+
+function length(itr)
+    n = 0
+    s = start(itr)
+    while !done(itr,s)
+        n += 1
+        v, s = next(itr,s)
+    end
+    return n
+end
+
 # enumerate
 
 type Enumerate


### PR DESCRIPTION
This is a generic `length` function that iterates an iterator and counts the number of elements, to make more convenient things like

```
num_matches = length(each_match(pattern, x))
```

The slight downside of having a `length(Any,)` is slightly more cryptic error messages in some cases:

```
> length(nothing)
no method start(Nothing,)
  in method_missing at base.jl:60
  in length at iterator.jl:4
```
