### PR TITLE
Support for gensyms tagged with a string

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -8,6 +8,12 @@ symbol(a::Array{Uint8,1}) =
 gensym() = ccall(:jl_gensym, Any, ())::Symbol
 gensym(n::Integer) = ntuple(n, i->gensym())
 
+gensym(s::ASCIIString) = gensym(s.data)
+gensym(s::UTF8String) = gensym(s.data)
+gensym(a::Array{Uint8,1}) =
+    ccall(:jl_tagged_gensym, Any, (Ptr{Uint8}, Int32), a, length(a))::Symbol
+gensym(ss::Union(ASCIIString, UTF8String)...) = map(s->gensym(s), ss)
+
 type UniqueNames
     names::Array{Any,1}
     UniqueNames() = new({})

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -317,8 +317,8 @@ DLLEXPORT jl_sym_t *jl_gensym(void)
 
 DLLEXPORT jl_sym_t *jl_tagged_gensym(const char* str, int32_t len)
 {
-    static char gs_name[16];
-    char name[16+len+1];
+    static char gs_name[14];
+    char name[sizeof(gs_name)+len+3];
     char *n;
     name[0] = '#'; name[1] = '#'; name[2+len] = '#';
     memcpy(name+2, str, len);

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -315,6 +315,19 @@ DLLEXPORT jl_sym_t *jl_gensym(void)
     return jl_symbol(n);
 }
 
+DLLEXPORT jl_sym_t *jl_tagged_gensym(const char* str, int32_t len)
+{
+    static char gs_name[16];
+    char name[16+len+1];
+    char *n;
+    name[0] = '#'; name[1] = '#'; name[2+len] = '#';
+    memcpy(name+2, str, len);
+    n = uint2str(gs_name, sizeof(gs_name), gs_ctr, 10);
+    memcpy(name+3+len, n, sizeof(gs_name)-(n-gs_name));
+    gs_ctr++;
+    return jl_symbol(name);
+}
+
 // allocating types -----------------------------------------------------------
 
 jl_typename_t *jl_new_typename(jl_sym_t *name)

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -50,6 +50,7 @@
     jl_prepare_ast;
     jl_is_leaf_type;
     jl_gensym;
+    jl_tagged_gensym;
     jl_eqtable_put;
     jl_eqtable_get;
     jl_eqtable_del;

--- a/src/julia.h
+++ b/src/julia.h
@@ -548,6 +548,7 @@ jl_tuple_t *jl_tuple_fill(size_t n, jl_value_t *v);
 DLLEXPORT jl_sym_t *jl_symbol(const char *str);
 DLLEXPORT jl_sym_t *jl_symbol_n(const char *str, int32_t len);
 DLLEXPORT jl_sym_t *jl_gensym(void);
+DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len);
 jl_sym_t *jl_get_root_symbol(void);
 jl_expr_t *jl_exprn(jl_sym_t *head, size_t n);
 jl_function_t *jl_new_generic_function(jl_sym_t *name);


### PR DESCRIPTION
Error messages about gensyms are singularly unhelpful. I wrote the macro and I'm not going to figure what ##3453 is referring to. Imagine how the user of a macro must feel when the macro breaks. Then they report the error message to you saying that there's a problem with ##3453. Awesome.

This commit adds gensym(s) and gensym(ss...), which produce one or more gensyms each tagged with a string. Now my error is about ##arg1#3453. Wait, arg1? Oh, that's what I did wrong. Awesome!

I have a nefarious use for these. (Spoiler: It's struct.jl.)
