### PR TITLE
load sparse.jl in glpk/linptog tests

### DIFF
--- a/extras/glpk.jl
+++ b/extras/glpk.jl
@@ -2,9 +2,11 @@
 ### GLPK API Wrapper
 ###
 
+# Note: be sure to load "sparse.jl" before this file
+
 ## Shared library interface setup
 #{{{
-include("glpk_h.jl")
+load("glpk_h.jl")
 
 _jl_libglpk = dlopen("libglpk")
 _jl_libglpk_wrapper = dlopen("libglpk_wrapper.so")

--- a/test/glpk.jl
+++ b/test/glpk.jl
@@ -1,5 +1,6 @@
 setcwd("../extras")
-include("glpk.jl")
+load("sparse.jl")
+load("glpk.jl")
 
 # Same example as in the GLPK manual
 

--- a/test/linprog.jl
+++ b/test/linprog.jl
@@ -1,7 +1,8 @@
 ### Linear programming
 
 setcwd("../extras")
-include("linprog.jl")
+load("sparse.jl")
+load("linprog.jl")
 
 ## Simplex method
 


### PR DESCRIPTION
fix glpk and linprog tests since sparse was moved to extras and it's not loaded by default anymore.
