### PR TITLE
Bitarray update

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -479,7 +479,7 @@ function show(v::AbstractVector{Any})
     print_matrix(X, 1, tty_cols(), "{", ", ", "}", "  ...  ", ":", 5, 5)
 end
 
-function show{T}(v::AbstractVector{T})
+function show(v::AbstractVector)
     print(summary(v))
     println(":")
     print_matrix(reshape(v,(length(v),1)))

--- a/extras/bitarray.jl
+++ b/extras/bitarray.jl
@@ -123,6 +123,16 @@ function copy_to(dest::BitArray, src::BitArray)
     return dest
 end
 
+function reshape{N}(B::BitArray, dims::NTuple{N,Int})
+    if prod(dims) != numel(B)
+        error("reshape: invalid dimensions")
+    end
+    Br = BitArray{N}()
+    Br.chunks = B.chunks
+    Br.dims = [i::Int | i=dims]
+    return Br
+end
+
 bitzeros(args...) = fill!(BitArray(args...), 0)
 bitones(args...) = fill!(BitArray(args...), 1)
 
@@ -1109,7 +1119,7 @@ end
 
 ## Transpose ##
 
-transpose(B::BitVector) = reshape(B, 1, length(B))
+transpose(B::BitVector) = reshape(copy(B), 1, length(B))
 function transpose(B::BitMatrix)
     l1 = size(B, 1)
     l2 = size(B, 2)

--- a/extras/bitarray.jl
+++ b/extras/bitarray.jl
@@ -289,13 +289,16 @@ end
 let ref_cache = nothing
 global ref
 function ref(B::BitArray, I::Indices...)
-    X = similar(B, map(length, I)::Dims)
+    i = length(I)
+    while 1 > 0 && isa(I[i],Integer); i-=1; end
+    d = map(length, I)::Dims
+    X = similar(B, d[1:i])
 
     if is(ref_cache,nothing)
         ref_cache = HashTable()
     end
     gen_cartesian_map(ref_cache, ivars -> quote
-            X[storeind] = B[$(ivars...)];
+            X[storeind] = B[$(ivars...)]
             storeind += 1
         end, I, (:B, :X, :storeind), B, X, 1)
     return X

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -83,6 +83,7 @@ i1 = randbit(n1, n2)
 
 ## Indexing ##
 
+b1 = bitrand(n1, n2)
 m1 = randi(n1)
 m2 = randi(n2)
 b2 = bitrand(m1, m2)
@@ -91,7 +92,18 @@ b2 = bitrand(m1, m2)
 b2 = bitrand(m1, m2)
 @check_bit_operation2 assign Array{Int} b1 b2 1:m1 n2-m2+1:n2
 
+for p1 = [randi(v1) 1 63 64 65 127 128 129 191 192 193]
+    for p2 = [randi(v1) 1 63 64 65 127 128 129 191 192 193]
+        for n = 0 : min(v1 - p1 + 1, v1 - p2 + 1)
+            b1 = bitrand(v1)
+            b2 = bitrand(v1)
+            @check_bit_operation_allint copy_to Array{Int} (b1, p1, b2, p2, n)
+        end
+    end
+end
+
 # logical indexing
+b1 = bitrand(n1, n2)
 b2 = bitrand(n1, n2)
 t2 = convert(Array{Bool}, b2)
 @assert isequal(int(b1[t2]), int(b1)[t2])

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -301,8 +301,10 @@ for k = 1 : 4
     @check_bit_operation1 rotl90 Array{Int} b1 k
 end
 
-b1 = bitrand(v1)
-@check_bit_operation1 reverse Array{Int} b1
+for m = 0 : v1
+    b1 = bitrand(m)
+    @check_bit_operation1 reverse Array{Int} b1
+end
 
 @timesofar "datamove"
 


### PR DESCRIPTION
Here is a bunch of updates for bitarrays:
- more efficient code for `reverse` and `vcat`
- fixed `reshape` behaviour to match that of Arrays rather than that of AbstractArrays (i.e. the data is shared between the result and the origin, rather than being copied)
- added a generalized `copy_to` with positions and number of elements to copy, just like the one for Arrays
- general code polish
- adopted the changes in behaviour from commit 0cd86dcda00a7a41c55952677de43ad6a466527f

About the last point: as you can see, I had to modify `show.jl`. This is because when calling `show(::BitVector)`, given the choice between `show(::AbstractArray)` and `show{T}(::AbstractVector{T})`, Julia was invoking the former, even though `BitVector` is `<: AbstractVector{Int}`. I guess that's a bug?
Also, I haven't found a way to force `invoke` to use the parametrized version. (The modification I did should be harmless though.)
