### PR TITLE
add isapprox() to base/float and remove approx_eq() from extras/test

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -215,3 +215,7 @@ const pi = 3.14159265358979323846
 ## byte order swaps for arbitrary-endianness serialization/deserialization ##
 bswap(x::Float32) = boxf32(bswap_int(unbox32(x)))
 bswap(x::Float64) = boxf64(bswap_int(unbox64(x)))
+
+## approximate comparison based on nextfloat; default tolerance is quite close
+isapprox(a, b, tol) = abs(a-b) <= tol
+isapprox(a, b) = isapprox(a, b, 8*max(eps(float(a)), eps(float(b))))

--- a/extras/test.jl
+++ b/extras/test.jl
@@ -112,7 +112,7 @@ function _test(ex::Expr)
             tr.arg1 = eval(ex.args[1])
             tr.arg2 = eval(ex.args[3])
         elseif (ex.head == :call) # is it a helper we know about?
-            if (ex.args[1] == :approx_eq)
+            if (ex.args[1] == :isapprox)
                 tr.operation = ex.args[1]
                 tr.arg1 = eval(ex.args[2])
                 tr.arg2 = eval(ex.args[3])
@@ -138,12 +138,6 @@ end
 
 # helpful utility tests, supported by the macro
 # 
-
-function approx_eq(a, b, tol)
-    abs(a - b) < tol
-end
-approx_eq(a, b) = approx_eq(a, b, 1e-6)
-
 function prints(fn::Function, args, expected::String) 
     print_to_string(fn, args...) == expected
 end

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -809,6 +809,13 @@ end
 @assert signed(fld(typemax(Uint),typemin(Int)>>1))     == -4
 @assert signed(fld(typemax(Uint),(typemin(Int)>>1)+1)) == -5
 
+# things related to floating-point epsilon
+@assert eps(float(0)) == 5e-324
+@assert .1+.1+.1 != .3
+@assert isapprox(.1+.1+.1, .3)
+@assert !isapprox(.1+.1+.1-.3, 0)
+@assert isapprox(.1+.1+.1-.3, 0, eps(.3))
+
 @assert div(1e50,1) == 1e50
 @assert fld(1e50,1) == 1e50
 

--- a/test/test_test.jl
+++ b/test/test_test.jl
@@ -9,8 +9,7 @@ test_group("string tests")
 @test strip("\t  this should fail   \n") == "hi" #fail
 
 test_group("numeric tests")
-@test approx_eq(airy(1.8), 0.0470362)
-@test approx_eq(airy(1, 1.8), 1 + -0.0685248) # fail, using helper function
+@test isapprox(.1+.1+.1, .3)
 
 test_group("array tests")
 a = Array(Float64, 2, 2, 2, 2, 2)
@@ -34,6 +33,6 @@ test_group("printing tests")
 test_group("performance tests")
 fib(n) = n < 2 ? n : fib(n-1) + fib(n-2)
 @test fib(20) == 6765
-@test takes_less_than(fib(20), 1e-6)
+@test takes_less_than(fib(20), 1e-6) # fail
 
 # shutdown goes here


### PR DESCRIPTION
uses epsilon to determine default tolerance.
add eps() and isapprox() tests to test/numbers.jl.

See a bit of discussion here:
http://www.johnmyleswhite.com/notebook/2012/04/13/floating-point-arithmetic-and-the-descent-into-madness/comment-page-1/

I'll push docs changes if/when this is pulled.
