### PR TITLE
Converting isnanf() calls into isnan() calls

### DIFF
--- a/external/fdlibm/e_scalbf.c
+++ b/external/fdlibm/e_scalbf.c
@@ -28,7 +28,7 @@ scalbf(float x, int fn)
 float
 scalbf(float x, float fn)
 {
-	if (isnanf(x)||isnanf(fn)) return x*fn;
+	if (isnan(x)||isnan(fn)) return x*fn;
 	if (!finitef(fn)) {
 	    if(fn>(float)0.0) return x*fn;
 	    else       return x/(-fn);


### PR DESCRIPTION
Fixes missing `isnanf()` symbols as reported in [#387](https://github.com/JuliaLang/julia/issues/387)
