### PR TITLE
convert arrays of strings to other type

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -1055,6 +1055,13 @@ parse_float(x::String) = float64(x)
 parse_float(::Type{Float64}, x::String) = float64(x)
 parse_float(::Type{Float32}, x::String) = float32(x)
 
+for conv in (:float, :float32, :float64,
+             :int, :int8, :int16, :int32, :int64,
+             :uint, :uint8, :uint16, :uint32, :uint64,
+             )
+    @eval ($conv){S<:String}(a::AbstractArray{S}) = map($conv, a)
+end
+
 # lexicographically compare byte arrays (used by Latin-1 and UTF-8)
 
 function lexcmp(a::Array{Uint8,1}, b::Array{Uint8,1})


### PR DESCRIPTION
Currently one can convert an array of ints to floats. It is also allowed to convert heterogenous arrays to ints and floats. However, arrays containing strings cannot be converted. Here is an example:

``` julia
float( ["1.1", "2.2"] )
no method convert(Type{ASCIIString},Int64)
 in method_missing at base.jl:60
 in float at abstractarray.jl:128
```

It seems consistent to allow arrays of strings to be converted to arrays of ints, floats, bools, etc. My current use case for this feature is to read a line from a file containing floats and to convert them to an array. I currently have to apply `float` to each element in the string array using `map`.
