### PR TITLE
make sub() behave like ref()

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -1,4 +1,4 @@
-# subarrays ##
+## subarrays ##
 
 type SubArray{T,N,A<:AbstractArray,I<:(RangeIndex...,)} <: AbstractArray{T,N}
     parent::A
@@ -51,8 +51,7 @@ function sub{T,N}(A::AbstractArray{T,N}, i::NTuple{N,RangeIndex})
     L = length(i)
     while L > 0 && isa(i[L], Int); L-=1; end
     i0 = map(j -> isa(j, Int) ? (j:j) : j, i[1:L])
-    i1 = i[L+1:end]
-    i = ntuple(length(i), k->(k<=L ? i0[k] : i1[k-L]))
+    i = ntuple(length(i), k->(k<=L ? i0[k] : i[k]))
     SubArray{T,L,typeof(A),typeof(i)}(A, i)
 end
 sub(A::AbstractArray, i::RangeIndex...) =

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -1,4 +1,4 @@
-## subarrays ##
+e# subarrays ##
 
 type SubArray{T,N,A<:AbstractArray,I<:(RangeIndex...,)} <: AbstractArray{T,N}
     parent::A
@@ -7,11 +7,13 @@ type SubArray{T,N,A<:AbstractArray,I<:(RangeIndex...,)} <: AbstractArray{T,N}
     strides::Array{Int,1}
     first_index::Int
 
-    #linear indexing constructor
-    if N == 1 && length(I) == 1 && A <: Array
+    #linear indexing constructor (scalar)
+    if N == 0 && length(I) == 1 && A <: Array
         function SubArray(p::A, i::(Int,))
-            new(p, i, (length(i[1]),), [1], i[1])
+            new(p, i, (), Int[], i[1])
         end
+    #linear indexing constructor (ranges)
+    elseif N == 1 && length(I) == 1 && A <: Array
         function SubArray(p::A, i::(Range1{Int},))
             new(p, i, (length(i[1]),), [1], first(i[1]))
         end
@@ -42,23 +44,29 @@ end
 
 #linear indexing sub (may want to rename as slice)
 function sub{T,N}(A::Array{T,N}, i::(RangeIndex,))
-    SubArray{T,1,typeof(A),typeof(i)}(A, i)
+    SubArray{T,(isa(i[1], Int) ? 0 : 1),typeof(A),typeof(i)}(A, i)
 end
 
 function sub{T,N}(A::AbstractArray{T,N}, i::NTuple{N,RangeIndex})
-    i = map(j -> isa(j, Int) ? (j:j) : j, i)
-    SubArray{T,N,typeof(A),typeof(i)}(A, i)
+    L = length(i)
+    while L > 0 && isa(i[L], Int); L-=1; end
+    i0 = map(j -> isa(j, Int) ? (j:j) : j, i[1:L])
+    i1 = i[L+1:end]
+    i = ntuple(length(i), k->(k<=L ? i0[k] : i1[k-L]))
+    SubArray{T,L,typeof(A),typeof(i)}(A, i)
 end
 sub(A::AbstractArray, i::RangeIndex...) =
     sub(A, i)
 function sub(A::SubArray, i::RangeIndex...)
+    L = length(i)
+    while L > 0 && isa(i[L], Int); L-=1; end
     j = 1
     newindexes = Array(RangeIndex,length(A.indexes))
     for k = 1:length(A.indexes)
         if isa(A.indexes[k], Int)
             newindexes[k] = A.indexes[k]
         else
-            newindexes[k] = A.indexes[k][isa(i[j],Int) ? (i[j]:i[j]) : i[j]]
+            newindexes[k] = A.indexes[k][(isa(i[j],Int) && j<=L) ? (i[j]:i[j]) : i[j]]
             j += 1
         end
     end

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -1,4 +1,4 @@
-e# subarrays ##
+# subarrays ##
 
 type SubArray{T,N,A<:AbstractArray,I<:(RangeIndex...,)} <: AbstractArray{T,N}
     parent::A


### PR DESCRIPTION
i.e. drop trailing singleton dimensions, as discussed [here](https://groups.google.com/forum/?fromgroups#!topic/julia-dev/GNZ4w78sZ94).

Example:

```
julia> a = rand(2, 3, 2)
2x3x2 Float64 Array:
[:, :, 1] =
 0.121652  0.232535  0.0812166
 0.347117  0.224052  0.885407 

[:, :, 2] =
 0.626699  0.342665  0.163809
 0.253675  0.659507  0.922081

julia> sub(a, 1:2, 2, 1)
2-element SubArray of 2x3x2 Float64 Array:
 0.232535
 0.224052
```

I think it's correct, but since it's not a trivial change, I'll leave it here for review/further discussion instead of pushing it directly.
Also, there's still a difference in behaviour, since `sub` still only allows either 1 index or the same number of indices as the parent array, but I think it was decided it's `ref` which has to change in that case.
