### PR TITLE
statistics.jl patches

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -77,13 +77,13 @@ function hist(v::StridedVector, nbins::Integer)
     end
     lo, hi = min(v), max(v)
     if lo == hi
-        lo = lo - div(nbins,2)
-        hi = hi + div(nbins,2)
+        lo -= div(nbins,2)
+        hi += div(nbins,2) + int(isodd(nbins))
     end
-    binsz = (hi-lo)/nbins
+    binsz = (hi - lo) / nbins
     for x in v
         if isfinite(x)
-            i = iround((x-lo+binsz/2)/binsz)
+            i = iround((x - lo) / binsz + 0.5)
             h[i > nbins ? nbins : i] += 1
         end
     end
@@ -96,8 +96,7 @@ function hist(A::StridedMatrix, nbins::Integer)
     m, n = size(A)
     h = Array(Int, nbins, n)
     for j=1:n
-        i = 1+(j-1)*m
-        h[:,j] = hist(sub(A, i:(i+m-1)), nbins)
+        h[:,j] = hist(sub(A, 1:m, j), nbins)
     end
     h
 end
@@ -105,6 +104,9 @@ end
 function histc(v::StridedVector, edg)
     n = length(edg)
     h = zeros(Int, n)
+    if n == 0
+        return h
+    end
     first = edg[1]
     last = edg[n]
     for x in v
@@ -123,8 +125,7 @@ function histc(A::StridedMatrix, edg)
     m, n = size(A)
     h = Array(Int, length(edg), n)
     for j=1:n
-        i = 1+(j-1)*m
-        h[:,j] = histc(sub(A, i:(i+m-1)), edg)
+        h[:,j] = histc(sub(A, 1:m, j), edg)
     end
     h
 end

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -27,7 +27,7 @@ var(v::Ranges, m::Number) = var(v, m, false)
 function var(v::AbstractVector, m::Number, uncorr::Bool)
     n = length(v)
     x = v - m
-    return (x'*x)[1] / (n - (uncorr ? 0 : 1))
+    return dot(x, x) / (n - (uncorr ? 0 : 1))
 end
 var(v::AbstractVector, m::Number) = var(v, m, false)
 var(v::AbstractArray, m::Number, uncorr::Bool) = var(reshape(v, numel(v)), m, uncorr)


### PR DESCRIPTION
I have made 2 patches to `statistics.jl` which I leave here for review/discussion.

The first one vectorizes most of the code. It gives huge speedups in the most important cases (standard numeric arrays, even sparse ones) and it seems to be faster anyway in all other cases. I think that the code is still sufficiently generic that any future proper AbstractArray implementation should provide an interface such that everything works as expected.

Note: the "spearman" variants of `cov` and `cor` were not working, and this patch desn't fix that, but the "`sub() act like ref()`" patch does (except for sparse arrays and bitarrays, for which `amap` is not defined).

The second patch adds an option not to use Bessel's correction, to all functions which use it (`var`, `std`, `cov`, `cor`). This was discussed in #711. It's done in a Matlab-friendly way, in that the option is a `Bool` which is `false` by default (yielding the current behaviour). The option name is `uncorr` (short for "uncorrected"): I don't like this name at all, but I couldn't come up with a better alternative (suggestions welcome).
