### PR TITLE
Quicksort R benchmark is broken. 

### DIFF
--- a/test/perf/perf.R
+++ b/test/perf/perf.R
@@ -42,31 +42,30 @@ timeit("parse_int", parseintperf, 1000)
 
 ## quicksort ##
 
-qsort_kernel = function(a, lo, hi) {
-    i = lo
-    j = hi
-    while (i < hi) {
-        pivot = a[floor((lo+hi)/2)]
-        while (i <= j) {
-            while (a[i] < pivot) i = i + 1
-            while (a[j] > pivot) j = j - 1
-            if (i <= j) {
-                t = a[i]
-                a[i] = a[j]
-                a[j] = t
-            }
-            i = i + 1;
-            j = j - 1;
-        }
-        if (lo < j) qsort_kernel(a, lo, j)
-        lo = i
-        j = hi
-    }
-    return(a)
-}
-
 qsort = function(a) {
-  return(qsort_kernel(a, 1, length(a)))
+    qsort_kernel = function(lo, hi) {
+        i = lo
+        j = hi
+        while (i < hi) {
+            pivot = a[floor((lo+hi)/2)]
+            while (i <= j) {
+                while (a[i] < pivot) i = i + 1
+                while (a[j] > pivot) j = j - 1
+                if (i <= j) {
+                    t = a[i]
+                    a[i] <<- a[j]
+                    a[j] <<- t
+                    i = i + 1;
+                    j = j - 1;
+                }
+            }
+            if (lo < j) qsort_kernel(lo, j)
+            lo = i
+            j = hi
+        }
+    }
+    qsort_kernel(1, length(a))
+    return(a)
 }
 
 sortperf = function(n) {
@@ -74,6 +73,7 @@ sortperf = function(n) {
     return(qsort(v))
 }
 
+assert(!is.unsorted(sortperf(5000)))
 timeit('quicksort', sortperf, 5000)
 
 ## mandel ##


### PR DESCRIPTION
The quicksort was written as though R passes mutable references, which it doesn't (R uses a copy-on-write scheme like Matlab/Octave). The recursive call to qsort_kernel did nothing, and produced an o(N^2) algorithm due to all the private copies of 'a' being made.

If you want to operate on an array in place, one way is to hold the array in an enclosing scope and use <<- operator.
