### PR TITLE
RFC: utility function for DArray scheduling (ensures current thread starts last)

### DIFF
--- a/base/darray.jl
+++ b/base/darray.jl
@@ -129,6 +129,29 @@ myindexes(s::SubDArray) = pieceindexes(s, s.parent.localpiece)
 
 myindexes(s::SubDArray, locl) = pieceindexes(s, s.parent.localpiece, locl)
 
+# Utility function to help get other processes started on their piece
+# before tackling a big job.
+# Example (out is a DArray):
+#   order = permute_to_last(out.pmap,myid())
+#   @sync begin
+#       for i in order
+#           @spawnat out.pmap[i] myfunc(out,...)
+#       end
+#   end
+function permute_to_last{T}(v::Vector{T},val::T)
+    iother = Int[]
+    iindx = Int[]
+    for i = 1:length(v)
+        if v[i] == val
+            push(iindx,i)
+        else
+            push(iother,i)
+        end
+    end
+    [iother,iindx]
+end
+
+
 localize(d::DArray) = d.locl
 
 localize(s::SubDArray) = sub(localize(s.parent), myindexes(s, true))


### PR DESCRIPTION
There may be a better way to do this, and if so please let me know. But since I didn't see it, I thought it would be clearer simply to show the code.

When working with DArrays, it's common to have a @spawnat command inside a loop over the different pieces of the DArray. If the process launching all these threads owns one or more of the pieces, it shouldn't get started on its own task(s) until it has gotten all the other cores started on theirs. This little utility function helps.
