### PR TITLE
Check length/shape compatibility of arguments to map

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1168,7 +1168,9 @@ end
 
 function map(f, A::StridedArray, B::StridedArray)
     shp = promote_shape(size(A),size(B))
-    if isempty(A); return A; end
+    if isempty(A)
+        return similar(A, eltype(A), shp)
+    end
     first = f(A[1], B[1])
     dest = similar(A, typeof(first), shp)
     return map_to2(first, dest, f, A, B)
@@ -1238,9 +1240,12 @@ function map_to2(first, dest::StridedArray, f, As::StridedArray...)
 end
 
 function map(f, As::StridedArray...)
-    if isempty(As[1]); return As[1]; end
+    shape = mapreduce(promote_shape, size, As)
+    if prod(shape) == 0
+        return similar(As[1], eltype(As[1]), shape)
+    end
     first = f(map(a->a[1], As)...)
-    dest = similar(As[1], typeof(first))
+    dest = similar(As[1], typeof(first), shape)
     return map_to2(first, dest, f, As...)
 end
 

--- a/base/cell.jl
+++ b/base/cell.jl
@@ -38,9 +38,9 @@ end
 # map cell array
 map(f, a::Array{Any,1}) = { f(a[i]) | i=1:length(a) }
 map(f, a::Array{Any,1}, b::Array{Any,1}) =
-    { f(a[i],b[i]) | i=1:min(length(a),length(b)) }
+    { f(a[i],b[i]) | i=1:length_checked_equal(a, b) }
 function map(f, as::Array{Any,1}...)
-    n = min(length, as)
+    n = length_checked_equal(as...)
     { f(map(a->a[i],as)...) | i=1:n }
 end
 

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -40,7 +40,18 @@ map(f, t::(Any,Any,Any), s::(Any,Any,Any)) =
 map(f, t::(Any,Any,Any,Any), s::(Any,Any,Any,Any)) =
     (f(t[1],s[1]), f(t[2],s[2]), f(t[3],s[3]), f(t[4],s[4]))
 # n argument function
-map(f, ts::Tuple...) = ntuple(length(ts[1]), n->f(map(t->t[n],ts)...))
+map(f, ts::Tuple...) = ntuple(length_checked_equal(ts...), 
+                              n->f(map(t->t[n],ts)...) )
+
+function length_checked_equal(args...) 
+    n = length(args[1])
+    for i=2:length(args)
+        if length(args[i]) != n
+            error("argument dimensions must match")
+        end
+    end
+    n
+end
 
 ## comparison ##
 


### PR DESCRIPTION
In tuple.jl and cell.jl, just needs to make sure all lengths are equal.
Added function `length_checked_equal(args...)` in tuple.jl for the common parts of this.
Since there's a for loop, it won't run until after int.jl is loaded. But it seems that it doesn't, boots fine.

In array.jl, uses `promote_shape` to reduce arguments shapes into result shape. Makes sure result always has this shape.

Didn't find any other map implementations in base/ with this issue.
