### PR TITLE
RFC: Optionally set FZ/DAZ on SSE(2) processors

### DIFF
--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -151,6 +151,7 @@
     jl_buf_mutex_lock;
     jl_buf_mutex_unlock;
     jl_start_io_thread;
+    jl_zero_denormals;
     jl_save_system_image;
     jl_restore_system_image;
     jl_compress_ast;


### PR DESCRIPTION
A potentially serious performance bottleneck on Intel processors is getting stuck in microcode for handling subnormals, which can kill code such as IIR filters and feedback controllers. A quick source grep seems to indicate we're not doing this by default, which is good for absolute correctness, but we should have a way to set either the flush-to-zero or denormals-are-zero flags as appropriate for the x86 variant. The intrinsics are defined in `xmmintrin.h`.

Any ideas on the Right Way to make this available?
