### PR TITLE
Fixes for USE_SYSTEM_LIGHTTPD = 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ install: release
 	install -v extras/* $(DESTDIR)$(PREFIX)/share/julia/extras
 	install -v examples/*.jl $(DESTDIR)$(PREFIX)/share/julia/examples
 	install -v $(USRLIB)/*.$(SHLIB_EXT) $(DESTDIR)$(PREFIX)/share/julia/usr/lib
-	install -v $(USR)/sbin/* $(DESTDIR)$(PREFIX)/share/julia/usr/sbin
+	test -z `ls -A $(USR)/sbin/*` || install -v $(USR)/sbin/* $(DESTDIR)$(PREFIX)/share/julia/usr/sbin
 	install -v launch-julia-webserver $(DESTDIR)$(PREFIX)/share/julia
 	install -v ui/webserver/*.jl $(DESTDIR)$(PREFIX)/share/julia/ui/webserver
 	install -v ui/website/*.* $(DESTDIR)$(PREFIX)/share/julia/ui/website

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -52,10 +52,8 @@ ifeq ($(USE_SYSTEM_LLVM), 0)
 LIBS += llvm
 endif
 
-ifeq ($(USE_SYSTEM_LIGHTTPD), 0)
 ifneq ($(OS),WINNT)
 LIBS += lighttpd
-endif
 endif
 
 ifeq ($(OS),WINNT)


### PR DESCRIPTION
If `USE_SYSTEM_LIGHTTPD = 1`, then nothing gets installed into `usr/sbin/`, and the install line fails, killing the install process

Similarly, if `USE_SYSTEM_LIGHTTPD = 1`, then the conf file never gets installed, so I've set the build system to always consider lighttpd
