### PR TITLE
fix for deserializing Dict

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -203,7 +203,7 @@ function serialize(s, t::Dict)
     end
 end
 
-function deserialize(s, T::Type{Dict})
+function deserialize{K,V}(s, T::Type{Dict{K,V}})
     n = read(s, Int32)
     t = T(n)
     for i = 1:n


### PR DESCRIPTION
I was getting errors from deserializing Dicts.  I traced the problem down to the deserializing code in dict.jl not getting called because Type{Dict{Any,Any}} is not a subtype of Type{Dict}.  I think this fixes it, but someone who knows something about the serializing/deserializing code should check it.
