### PR TITLE
build: don't re-configure LLVM each make invocation

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -141,10 +141,11 @@ llvm-$(LLVM_VER)/configure: $(LLVM_TAR)
 	mkdir -p llvm-$(LLVM_VER) && \
 	tar -C llvm-$(LLVM_VER) --strip-components 1 -xf $<
 	touch $@
+	cd llvm-$(LLVM_VER) && \
+	./configure --prefix=$(abspath $(USR)) --disable-threads --enable-optimized --disable-profiling --disable-assertions --enable-shared --enable-targets=x86,x86_64 --disable-bindings --disable-docs CC=$(GCC) CXX=$(GPLUSPLUS)
 
 $(LLVM_OBJ_SOURCE): llvm-$(LLVM_VER)/configure
 	cd llvm-$(LLVM_VER) && \
-	./configure --prefix=$(abspath $(USR)) --disable-threads --enable-optimized --disable-profiling --disable-assertions --enable-shared --enable-targets=x86,x86_64 --disable-bindings --disable-docs CC=$(GCC) CXX=$(GPLUSPLUS) && \
 	$(MAKE)
 $(LLVM_OBJ_TARGET): $(LLVM_OBJ_SOURCE)
 	$(MAKE) -C llvm-$(LLVM_VER) install


### PR DESCRIPTION
When LLVM is reconfigured, it rewrites a config header, which causes
its build system to assume a great many (all?) object files are out of
date, triggering a massive and unnecessary recompile.  By moving the
configure step out of the $(LLVM_OBJ_SOURCE) target we can avoid this.
