### PR TITLE
Add dump() methods for CompositeKind and AbstractKind.

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -277,10 +277,76 @@ function idump(fn::Function, io::IOStream, x::Array{Any}, n::Int, indent)
         end
     end
 end
-idump(fn::Function, io::IOStream, x::AbstractKind, n::Int, indent) = println(io, typeof(x), " ", x)
 idump(fn::Function, io::IOStream, x::Symbol, n::Int, indent) = println(io, typeof(x), " ", x)
 idump(fn::Function, io::IOStream, x::Function, n::Int, indent) = println(io, x)
 idump(fn::Function, io::IOStream, x::Array, n::Int, indent) = println(io, "Array($(eltype(x)),$(size(x)))", " ", x[1:min(4,length(x))])
+
+# Types
+idump(fn::Function, io::IOStream, x::UnionKind, n::Int, indent) = println(io, x)
+function idump(fn::Function, io::IOStream, x::CompositeKind, n::Int, indent)
+    println(io, x, "::", typeof(x), " ", " <: ", super(x))
+    if n > 0
+        for idx in 1:min(10,length(x.names))
+            if x.names[idx] != symbol("")    # prevents segfault if symbol is blank
+                try 
+                    print(io, indent, "  ", x.names[idx], "::")
+                    if isa(x.types[idx], CompositeKind) 
+                        idump(fn, io, x.types[idx], n - 1, strcat(indent, "  "))
+                    else
+                        println(x.types[idx])
+                    end
+                catch
+                    println(io)
+                end
+            end
+        end
+    end
+end
+
+# _dumptype is for displaying abstract type hierarchies like Jameson
+# Nash's wiki page: https://github.com/JuliaLang/julia/wiki/Types-Hierarchy
+
+function _dumptype(io::IOStream, x::Type, n::Int, indent)
+    # based on Jameson Nash's examples/typetree.jl
+    ## println(io, x, "::", typeof(x), " <: ", super(x))
+    println(io, x)
+    if n > 0
+        # This probably needs fixing to allow different modules to be
+        # included or to look in the equivalent of R's search path.
+        for s in [names(Core), names(Base)]  
+            t = eval(s)
+            try
+                if isa(t, TypeConstructor)
+                    if string(x.name) == split(string(t), "{")[1] ||
+                       ("Union" == split(string(t), "(")[1] &&
+                          any(map(tt -> string(x.name) == split(string(tt), "{")[1], t.body.types)))
+                        targs = join(t.parameters, ",")
+                        println(io, indent, "  ", s,
+                                length(t.parameters) > 0 ? "{$targs}" : "",
+                                " = ", t)
+                    end
+                elseif isa(t, UnionKind)
+                    if any(map(tt -> string(x.name) == split(string(tt), "{")[1], t.types))
+                        println(io, indent, "  ", s, " = ", t)
+                    end
+                elseif super(t).name == x.name
+                    if string(s) != string(t.name) # type aliases
+                        println(io, indent, "  ", s, " = ", t.name)
+                    elseif t != Any 
+                        print(io, indent, "  ")
+                        _dumptype(io, t, n - 1, strcat(indent, "  "))
+                    end
+                end
+            end
+        end
+    end
+end
+
+# For abstract types, use _dumptype only if it's a form that will be called
+# interactively.
+idump(fn::Function, io::IOStream, x::AbstractKind) = _dumptype(io, x, 5, "")
+idump(fn::Function, io::IOStream, x::AbstractKind, n::Int) = _dumptype(io, x, n, "")
+
 # defaults:
 idump(fn::Function, io::IOStream, x) = idump(idump, io, x, 5, "")  # default is 5 levels
 idump(fn::Function, io::IOStream, x, n::Int) = idump(idump, io, x, n, "")
@@ -288,12 +354,12 @@ idump(fn::Function, args...) = idump(fn, OUTPUT_STREAM::IOStream, args...)
 idump(io::IOStream, args...) = idump(idump, io, args...)
 idump(args...) = idump(idump, OUTPUT_STREAM::IOStream, args...)
 
+
 # Here are methods specifically for dump:
 dump(io::IOStream, x, n::Int) = dump(io, x, n, "")
 dump(io::IOStream, x) = dump(io, x, 5, "")  # default is 5 levels
 dump(args...) = dump(OUTPUT_STREAM::IOStream, args...)
 dump(io::IOStream, x::String, n::Int, indent) = println(io, typeof(x), " \"", x, "\"")
-dump(io::IOStream, x::Type, n::Int, indent) = println(io, typeof(x), " ", x)
 dump(io::IOStream, x, n::Int, indent) = idump(dump, io, x, n, indent)
 
 function dump(io::IOStream, x::Dict, n::Int, indent)
@@ -310,6 +376,14 @@ function dump(io::IOStream, x::Dict, n::Int, indent)
         end
     end
 end
+
+# More generic representation for common types:
+dump(io::IOStream, x::AbstractKind, n::Int, indent) = println(io, x.name)
+dump(io::IOStream, x::AbstractKind) = _dumptype(io, x, 5, "")
+dump(io::IOStream, x::AbstractKind, n::Int) = _dumptype(io, x, n, "")
+dump(io::IOStream, x::BitsKind, n::Int, indent) = println(io, x.name)
+dump(io::IOStream, x::TypeVar, n::Int, indent) = println(io, x.name)
+
 
 showall(x) = showall(OUTPUT_STREAM::IOStream, x)
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -306,45 +306,14 @@ end
 # _dumptype is for displaying abstract type hierarchies like Jameson
 # Nash's wiki page: https://github.com/JuliaLang/julia/wiki/Types-Hierarchy
 
-function _dumptype(io::IOStream, x::Type, n::Int, indent)
+function _jl_dumptype(io::IOStream, x::Type, n::Int, indent)
     # based on Jameson Nash's examples/typetree.jl
-    ## println(io, x, "::", typeof(x), " <: ", super(x))
     println(io, x)
-    if n > 0
-        # This probably needs fixing to allow different modules to be
-        # included or to look in the equivalent of R's search path.
-        for s in [names(Core), names(Base)]  
-            t = eval(s)
-            if isa(t, TypeConstructor)
-                if string(x.name) == split(string(t), "{")[1] ||
-                   ("Union" == split(string(t), "(")[1] &&
-                      any(map(tt -> string(x.name) == split(string(tt), "{")[1], t.body.types)))
-                    targs = join(t.parameters, ",")
-                    println(io, indent, "  ", s,
-                            length(t.parameters) > 0 ? "{$targs}" : "",
-                            " = ", t)
-                end
-            elseif isa(t, UnionKind)
-                if any(map(tt -> string(x.name) == split(string(tt), "{")[1], t.types))
-                    println(io, indent, "  ", s, " = ", t)
-                end
-            elseif isa(t, Type) && super(t).name == x.name
-                if string(s) != string(t.name) # type aliases
-                    println(io, indent, "  ", s, " = ", t.name)
-                elseif t != Any 
-                    print(io, indent, "  ")
-                    _dumptype(io, t, n - 1, strcat(indent, "  "))
-                end
-            end
-        end
+    if n == 0   # too deeply nested
+        return  
     end
-end
-
-function _jl_type_hierarchy(x::Type)
-    # Based on Jameson Nash's examples/typetree.jl
-    # Returns a Vector{Any} with the first element being the type
-    #   and following elements are children of that type.
-    result = {x}
+    # This probably needs fixing to allow different modules to be
+    # included or to look in the equivalent of R's search path.
     for s in [names(Core), names(Base)]  
         t = eval(s)
         if isa(t, TypeConstructor)
@@ -352,43 +321,29 @@ function _jl_type_hierarchy(x::Type)
                ("Union" == split(string(t), "(")[1] &&
                   any(map(tt -> string(x.name) == split(string(tt), "{")[1], t.body.types)))
                 targs = join(t.parameters, ",")
-                push(result, (string(s),t)) 
+                println(io, indent, "  ", s,
+                        length(t.parameters) > 0 ? "{$targs}" : "",
+                        " = ", t)
             end
         elseif isa(t, UnionKind)
             if any(map(tt -> string(x.name) == split(string(tt), "{")[1], t.types))
-                push(result, (string(s),t)) 
+                println(io, indent, "  ", s, " = ", t)
             end
         elseif isa(t, Type) && super(t).name == x.name
             if string(s) != string(t.name) # type aliases
-                push(result, (string(s),t.name)) 
+                println(io, indent, "  ", s, " = ", t.name)
             elseif t != Any 
-                nxt = _jl_type_hierarchy(t)
-                if length(nxt) > 0
-                    push(result, nxt)
-                end
+                print(io, indent, "  ")
+                _jl_dumptype(io, t, n - 1, strcat(indent, "  "))
             end
         end
     end
-    result
 end
 
 # For abstract types, use _dumptype only if it's a form that will be called
 # interactively.
-idump(fn::Function, io::IOStream, x::AbstractKind) = _dumptype(io, x, 5, "")
-idump(fn::Function, io::IOStream, x::AbstractKind, n::Int) = _dumptype(io, x, n, "")
-
-idump(fn::Function, io::IOStream, x::AbstractKind, n::Int) = idump(fn, io, x, n, "")
-idump(fn::Function, io::IOStream, x::AbstractKind) = idump(fn, io, x, 5, "")
-function idump(fn::Function, io::IOStream, x::AbstractKind, n::Int, indent)
-    tp = _jl_type_children(x)
-    Ntp = length(tp)
-    if Ntp > 0
-        println(indent, tp[1])
-        for idx in 2:length(tp)
-            idump(fn, io, tp[idx], n - 1, strcat(indent, "  "))
-        end
-    end
-end
+idump(fn::Function, io::IOStream, x::AbstractKind) = _jl_dumptype(io, x, 5, "")
+idump(fn::Function, io::IOStream, x::AbstractKind, n::Int) = _jl_dumptype(io, x, n, "")
 
 # defaults:
 idump(fn::Function, io::IOStream, x) = idump(idump, io, x, 5, "")  # default is 5 levels


### PR DESCRIPTION
These changes add better dump() methods for types. For CompositeKind's, the nested structure of the type is shown. Here are examples:

``` julia
julia> dump(SubArray)
SubArray{T,N,A<:AbstractArray{T,N},I<:(Union(Range1{Int64},Range{Int64},Int64)...,)}::CompositeKind  <: AbstractArray{T,N}
  parent::A<:AbstractArray{T,N}
  indexes::I<:(Union(Range1{Int64},Range{Int64},Int64)...,)
  dims::(Int64...,)
  strides::Array{Int64,1}::CompositeKind  <: AbstractArray{Int64,1}
  first_index::Int64

julia> dump(Expr)
Expr::CompositeKind  <: Any
  head::Symbol::CompositeKind  <: Any
  args::Array{Any,1}::CompositeKind  <: AbstractArray{Any,1}
  typ::Any
```

For abstract types, the hierarchy of abstract types is given. This attempts to replicate what Jameson Nash's wiki page shows. The code to do this is rather brute force, but it seems fast enough on my computer, even for a dump(Any). Here are examples: 

``` julia
julia> dump(Number)
Number
  Real
    Integer
      Signed
        Int64
          Region = Union((Int64...,),Int64)
          RangeIndex = Union(Range1{Int64},Range{Int64},Int64)
        Int16
        Int = Int64
        Int8
        Int32
        FileOffset = Int64
      Unsigned
        Uint64
        Uint16
        Uint8
        Uint32
        Uint = Uint64
      Char
        Chars = Union(AbstractArray{Char,1},Char)
      Bool
      Indices{T<:Integer} = Union(AbstractArray{T<:Integer,1},Integer)
    Float
      Float64
      Float32
    Rational{T<:Integer}
  Complex{T<:Real}
    ComplexPair{T<:Real}
    Complex128
    ImaginaryUnit
    Complex64

julia> dump(Number)
Number
  Real
    Integer
      Signed
        Int64
          Region = Union((Int64...,),Int64)
          RangeIndex = Union(Range1{Int64},Range{Int64},Int64)
        Int16
        Int = Int64
        Int8
        Int32
        FileOffset = Int64
      Unsigned
        Uint64
        Uint16
        Uint8
        Uint32
        Uint = Uint64
      Char
        Chars = Union(AbstractArray{Char,1},Char)
      Bool
      Indices{T<:Integer} = Union(AbstractArray{T<:Integer,1},Integer)
    Float
      Float64
      Float32
    Rational{T<:Integer}
  Complex{T<:Real}
    ComplexPair{T<:Real}
    Complex128
    ImaginaryUnit
    Complex64
```
