### PR TITLE
Disassemble of LLVM code for a method

### DIFF
--- a/extras/ldump.jl
+++ b/extras/ldump.jl
@@ -1,0 +1,7 @@
+
+function llvm_dump(f, types)
+    lambda = getmethods(f, types)[1][3]
+    llvm_dump_lambda(lambda)
+end
+
+

--- a/extras/tdump.jl
+++ b/extras/tdump.jl
@@ -1,0 +1,8 @@
+
+function lambda_dump(f, types)
+    lambda = getmethods(f, types)[1][3]
+    # ccall(:jl_dump_lambda_info, Void, (Ptr{Void},), &lambda)
+    llvm_dump(lambda)
+end
+
+f1(x::Int) = x + 55

--- a/extras/tdump.jl
+++ b/extras/tdump.jl
@@ -1,8 +1,0 @@
-
-function lambda_dump(f, types)
-    lambda = getmethods(f, types)[1][3]
-    # ccall(:jl_dump_lambda_info, Void, (Ptr{Void},), &lambda)
-    llvm_dump(lambda)
-end
-
-f1(x::Int) = x + 55

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -12,6 +12,7 @@ JL_CALLABLE(jl_f_typeof);
 JL_CALLABLE(jl_f_subtype);
 JL_CALLABLE(jl_f_isa);
 JL_CALLABLE(jl_f_typeassert);
+JL_CALLABLE(jl_f_llvm_dump);
 JL_CALLABLE(jl_f_apply);
 JL_CALLABLE(jl_f_top_eval);
 JL_CALLABLE(jl_f_isbound);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -194,6 +194,29 @@ JL_CALLABLE(jl_f_typeassert)
     return args[0];
 }
 
+JL_CALLABLE(jl_f_llvm_dump)
+{
+    JL_NARGS(llvm_dump, 1, 1);
+    jl_lambda_info_t *li = (jl_lambda_info_t*) args[0];
+
+    printf("*** Name: %s\n", li->name->name);
+
+    if (li == NULL)
+        printf("NULL lambda info\n");
+    else if (li->functionObject == NULL) {
+        printf("NULL functionObject, attempt to compile\n");
+        jl_compile_li(li);
+        if (li->functionObject != NULL)
+            jl_llvm_dump(li);
+        else
+            printf("Still no functionObject\n");
+    }
+    else
+        jl_llvm_dump(li);
+
+    return jl_nothing;
+}
+
 static jl_function_t *jl_append_any_func;
 
 JL_CALLABLE(jl_f_apply)
@@ -834,6 +857,7 @@ void jl_init_primitives(void)
     add_builtin_func("subtype", jl_f_subtype);
     add_builtin_func("isa", jl_f_isa);
     add_builtin_func("typeassert", jl_f_typeassert);
+    add_builtin_func("llvm_dump", jl_f_llvm_dump);
     add_builtin_func("apply", jl_f_apply);
     add_builtin_func("throw", jl_f_throw);
     add_builtin_func("tuple", jl_f_tuple);
@@ -844,7 +868,7 @@ void jl_init_primitives(void)
     add_builtin_func("eval", jl_f_top_eval);
     add_builtin_func("isbound", jl_f_isbound);
     add_builtin_func("yieldto", jl_f_yieldto);
-    
+
     // functions for internal use
     add_builtin_func("convert_default", jl_f_convert_default);
     add_builtin_func("convert_tuple", jl_f_convert_tuple);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -196,23 +196,21 @@ JL_CALLABLE(jl_f_typeassert)
 
 JL_CALLABLE(jl_f_llvm_dump)
 {
-    JL_NARGS(llvm_dump, 1, 1);
+    JL_NARGS(llvm_dump_lambda, 1, 1);
+    JL_TYPECHK(llvm_dump_lambda, lambda_info, args[0]);
     jl_lambda_info_t *li = (jl_lambda_info_t*) args[0];
 
-    printf("*** Name: %s\n", li->name->name);
-
     if (li == NULL)
-        printf("NULL lambda info\n");
+        return jl_nothing;
     else if (li->functionObject == NULL) {
-        printf("NULL functionObject, attempt to compile\n");
         jl_compile_li(li);
         if (li->functionObject != NULL)
-            jl_llvm_dump(li);
+            return jl_cstr_to_string((char*) jl_llvm_dump(li));
         else
-            printf("Still no functionObject\n");
+            return jl_nothing;
     }
     else
-        jl_llvm_dump(li);
+        return jl_cstr_to_string((char*) jl_llvm_dump(li));
 
     return jl_nothing;
 }
@@ -857,7 +855,7 @@ void jl_init_primitives(void)
     add_builtin_func("subtype", jl_f_subtype);
     add_builtin_func("isa", jl_f_isa);
     add_builtin_func("typeassert", jl_f_typeassert);
-    add_builtin_func("llvm_dump", jl_f_llvm_dump);
+    add_builtin_func("llvm_dump_lambda", jl_f_llvm_dump);
     add_builtin_func("apply", jl_f_apply);
     add_builtin_func("throw", jl_f_throw);
     add_builtin_func("tuple", jl_f_tuple);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Support/IRBuilder.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Config/llvm-config.h"
 #include <setjmp.h>
 #include <string>
@@ -198,11 +199,14 @@ extern "C" void jl_generate_fptr(jl_function_t *f)
     f->fptr = li->fptr;
 }
 
-extern "C" void jl_llvm_dump(jl_lambda_info_t *li)
+extern "C" const char* jl_llvm_dump(jl_lambda_info_t *li)
 {
+    std::string code;
+    llvm::raw_string_ostream stream(code);
     assert(li->functionObject);
     Function *llvmf = (Function*) li->functionObject;
-    llvmf->dump();
+    llvmf->print(stream);
+    return stream.str().c_str();
 }
 
 extern "C" void jl_compile(jl_function_t *f)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -146,12 +146,6 @@ static Function *box64_func;
   - try using fastcc to get tail calls
 */
 
-extern "C" DLLEXPORT void jl_dump_lambda_info(jl_lambda_info_t *lambda)
-{
-    printf("**********");
-    printf("Name: %s\n", lambda->name->name);
-}
-
 // --- entry point ---
 
 static void emit_function(jl_lambda_info_t *lam, Function *f);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -188,7 +188,7 @@ extern "C" void jl_generate_fptr(jl_function_t *f)
         JL_SIGATOMIC_BEGIN();
         li->fptr = (jl_fptr_t)jl_ExecutionEngine->getPointerToFunction(llvmf);
         JL_SIGATOMIC_END();
-        //llvmf->deleteBody();
+        llvmf->deleteBody();
     }
     f->fptr = li->fptr;
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -145,6 +145,12 @@ static Function *box64_func;
   - try using fastcc to get tail calls
 */
 
+extern "C" DLLEXPORT void jl_dump_lambda_info(jl_lambda_info_t *lambda)
+{
+    printf("**********");
+    printf("Name: %s\n", lambda->name->name);
+}
+
 // --- entry point ---
 
 static void emit_function(jl_lambda_info_t *lam, Function *f);
@@ -187,14 +193,31 @@ extern "C" void jl_generate_fptr(jl_function_t *f)
         JL_SIGATOMIC_BEGIN();
         li->fptr = (jl_fptr_t)jl_ExecutionEngine->getPointerToFunction(llvmf);
         JL_SIGATOMIC_END();
-        llvmf->deleteBody();
+        //llvmf->deleteBody();
     }
     f->fptr = li->fptr;
+}
+
+extern "C" void jl_llvm_dump(jl_lambda_info_t *li)
+{
+    assert(li->functionObject);
+    Function *llvmf = (Function*) li->functionObject;
+    llvmf->dump();
 }
 
 extern "C" void jl_compile(jl_function_t *f)
 {
     jl_lambda_info_t *li = f->linfo;
+    if (li->functionObject == NULL) {
+        // objective: assign li->functionObject
+        li->inCompile = 1;
+        (void)to_function(li);
+        li->inCompile = 0;
+    }
+}
+
+extern "C" void jl_compile_li(jl_lambda_info_t *li)
+{
     if (li->functionObject == NULL) {
         // objective: assign li->functionObject
         li->inCompile = 1;
@@ -714,7 +737,7 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
         // first, then do hand-over-hand to track the tuple.
         Value *arg1 = boxed(emit_expr(args[1], ctx));
         make_gcroot(arg1, ctx);
-        Value *tup = 
+        Value *tup =
             builder.CreateCall(jlallocobj_func,
                                ConstantInt::get(T_size,
                                                 sizeof(void*)*(nargs+2)));
@@ -1192,7 +1215,7 @@ static Value *emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed,
             BasicBlock *bb = (*ctx->labels)[labelname];
             assert(bb);
             builder.CreateBr(bb);
-            BasicBlock *after = BasicBlock::Create(getGlobalContext(), 
+            BasicBlock *after = BasicBlock::Create(getGlobalContext(),
                                                    "br", ctx->f);
             builder.SetInsertPoint(after);
         }
@@ -1502,9 +1525,9 @@ static void emit_function(jl_lambda_info_t *lam, Function *f)
             filename = ((jl_sym_t*)jl_exprarg(stmt, 1))->name;
         }
     }
-	
+
     // TODO: Fix when moving to new LLVM version
-    dbuilder->createCompileUnit(0x01, filename, ".", "julia", true, "", 0); 
+    dbuilder->createCompileUnit(0x01, filename, ".", "julia", true, "", 0);
     llvm::DIArray EltTypeArray = dbuilder->getOrCreateArray(ArrayRef<Value*>());
     DIFile fil = dbuilder->createFile(filename, ".");
     DISubprogram SP =
@@ -1516,10 +1539,10 @@ static void emit_function(jl_lambda_info_t *lam, Function *f)
                                  dbuilder->createSubroutineType(fil,EltTypeArray),
                                  false, true,
                                  0, true, f);
-    
+
     // set initial line number
     builder.SetCurrentDebugLocation(DebugLoc::get(lno, 0, (MDNode*)SP, NULL));
-    
+
     /*
     // check for stack overflow (the slower way)
     Value *cur_sp =
@@ -2104,18 +2127,18 @@ static void init_julia_llvm_env(Module *m)
     // set up optimization passes
     FPM = new FunctionPassManager(jl_Module);
     FPM->add(new TargetData(*jl_ExecutionEngine->getTargetData()));
-    
+
     // list of passes from vmkit
     FPM->add(createCFGSimplificationPass()); // Clean up disgusting code
     FPM->add(createPromoteMemoryToRegisterPass());// Kill useless allocas
-    
+
     FPM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.
     FPM->add(createScalarReplAggregatesPass()); // Break up aggregate allocas
     FPM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.
     FPM->add(createJumpThreadingPass());        // Thread jumps.
     FPM->add(createCFGSimplificationPass());    // Merge & remove BBs
     //FPM->add(createInstructionCombiningPass()); // Combine silly seq's
-    
+
     //FPM->add(createCFGSimplificationPass());    // Merge & remove BBs
     FPM->add(createReassociatePass());          // Reassociate expressions
     //FPM->add(createEarlyCSEPass()); //// ****
@@ -2123,17 +2146,17 @@ static void init_julia_llvm_env(Module *m)
     FPM->add(createLoopRotatePass());           // Rotate loops.
     FPM->add(createLICMPass());                 // Hoist loop invariants
     FPM->add(createLoopUnswitchPass());         // Unswitch loops.
-    FPM->add(createInstructionCombiningPass()); 
+    FPM->add(createInstructionCombiningPass());
     FPM->add(createIndVarSimplifyPass());       // Canonicalize indvars
     //FPM->add(createLoopDeletionPass());         // Delete dead loops
     FPM->add(createLoopUnrollPass());           // Unroll small loops
     //FPM->add(createLoopStrengthReducePass());   // (jwb added)
-    
+
     FPM->add(createInstructionCombiningPass()); // Clean up after the unroller
     FPM->add(createGVNPass());                  // Remove redundancies
-    //FPM->add(createMemCpyOptPass());            // Remove memcpy / form memset  
+    //FPM->add(createMemCpyOptPass());            // Remove memcpy / form memset
     FPM->add(createSCCPPass());                 // Constant prop with SCCP
-    
+
     // Run instcombine after redundancy elimination to exploit opportunities
     // opened up by them.
     //FPM->add(createSinkingPass()); ////////////// ****
@@ -2149,7 +2172,7 @@ static void init_julia_llvm_env(Module *m)
 
 extern "C" void jl_init_codegen(void)
 {
-    
+
     InitializeNativeTarget();
     jl_Module = new Module("julia", jl_LLVMContext);
 
@@ -2166,11 +2189,11 @@ extern "C" void jl_init_codegen(void)
     jl_ExecutionEngine = builder.create(jl_TargetMachine=builder.selectTarget());
 #ifdef DEBUG
     jl_TargetMachine->Options.JITEmitDebugInfo = true;
-#endif 
+#endif
     jl_TargetMachine->Options.NoFramePointerElim = true;
     jl_TargetMachine->Options.NoFramePointerElimNonLeaf = true;
 #endif
-    
+
     dbuilder = new DIBuilder(*jl_Module);
 
     init_julia_llvm_env(jl_Module);

--- a/src/dump.c
+++ b/src/dump.c
@@ -813,7 +813,7 @@ void jl_restore_system_image(char *fname)
     tagtype_list = jl_alloc_cell_1d(0);
 
     jl_array_type->env = jl_deserialize_value(&f);
-    
+
     jl_core_module = (jl_module_t*)jl_deserialize_value(&f);
     jl_current_module = (jl_module_t*)jl_deserialize_value(&f);
     jl_base_module = (jl_module_t*)jl_get_global(jl_core_module,
@@ -956,7 +956,7 @@ void jl_init_serializer(void)
                      jl_symbol("T"), jl_symbol("S"),
                      jl_symbol("X"), jl_symbol("Y"),
                      jl_symbol("add_int"), jl_symbol("sub_int"),
-                     jl_symbol("mul_int"), 
+                     jl_symbol("mul_int"),
                      jl_symbol("add_float"), jl_symbol("sub_float"),
                      jl_symbol("mul_float"), jl_symbol("unbox8"),
                      jl_symbol("unbox32"), jl_symbol("unbox64"),
@@ -1055,23 +1055,23 @@ void jl_init_serializer(void)
     VALUE_TAGS = (ptrint_t)ptrhash_get(&ser_tag, jl_null);
 
     void *fptrs[] = { jl_f_new_expr, jl_f_new_box,
-                      jl_f_throw, jl_f_is, 
-                      jl_f_no_function, jl_f_typeof, 
-                      jl_f_subtype, jl_f_isa, 
-                      jl_f_typeassert, jl_f_apply, 
-                      jl_f_top_eval, jl_f_isbound, 
-                      jl_f_tuple, jl_f_tupleref, 
-                      jl_f_tuplelen, jl_f_get_field, 
-                      jl_f_set_field, jl_f_field_type, 
-                      jl_f_arraylen, jl_f_arrayref, 
-                      jl_f_arrayset, jl_f_arraysize, 
+                      jl_f_throw, jl_f_is,
+                      jl_f_no_function, jl_f_typeof,
+                      jl_f_subtype, jl_f_isa,
+                      jl_f_typeassert, jl_f_llvm_dump, jl_f_apply,
+                      jl_f_top_eval, jl_f_isbound,
+                      jl_f_tuple, jl_f_tupleref,
+                      jl_f_tuplelen, jl_f_get_field,
+                      jl_f_set_field, jl_f_field_type,
+                      jl_f_arraylen, jl_f_arrayref,
+                      jl_f_arrayset, jl_f_arraysize,
                       jl_f_instantiate_type,
                       jl_f_convert_default, jl_f_convert_tuple,
-                      jl_trampoline, jl_f_new_type_constructor, 
-                      jl_f_typevar, jl_f_union, 
-                      jl_f_methodexists, jl_f_applicable, 
-                      jl_f_invoke, jl_apply_generic, 
-                      jl_unprotect_stack, jl_f_task, 
+                      jl_trampoline, jl_f_new_type_constructor,
+                      jl_f_typevar, jl_f_union,
+                      jl_f_methodexists, jl_f_applicable,
+                      jl_f_invoke, jl_apply_generic,
+                      jl_unprotect_stack, jl_f_task,
                       jl_f_yieldto, jl_f_ctor_trampoline,
                       NULL };
     i=2;

--- a/src/julia.h
+++ b/src/julia.h
@@ -768,7 +768,9 @@ DLLEXPORT void *jl_dlsym(uv_lib_t *handle, char *symbol);
 
 // compiler
 void jl_compile(jl_function_t *f);
+void jl_compile_li(jl_lambda_info_t *li);
 void jl_generate_fptr(jl_function_t *f);
+void jl_llvm_dump(jl_lambda_info_t *li);
 void jl_delete_function(jl_lambda_info_t *li);
 DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v);
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);
@@ -978,8 +980,8 @@ DLLEXPORT int jl_cpu_cores(void);
 #define JL_STDOUT ios_stdout
 #define JL_STDERR ios_stderr
 #define JL_PRINTF ios_printf
-#define JL_PUTC	  ios_putc
-#define JL_PUTS	  ios_puts
+#define JL_PUTC           ios_putc
+#define JL_PUTS           ios_puts
 #define JL_WRITE  ios_write
 #define jl_exit   exit
 #define JL_STREAM ios_t

--- a/src/julia.h
+++ b/src/julia.h
@@ -770,7 +770,7 @@ DLLEXPORT void *jl_dlsym(uv_lib_t *handle, char *symbol);
 void jl_compile(jl_function_t *f);
 void jl_compile_li(jl_lambda_info_t *li);
 void jl_generate_fptr(jl_function_t *f);
-void jl_llvm_dump(jl_lambda_info_t *li);
+const char* jl_llvm_dump(jl_lambda_info_t *li);
 void jl_delete_function(jl_lambda_info_t *li);
 DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v);
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);


### PR DESCRIPTION
This is a slightly improved version of the LLVM disassemble code I wrote in a gist. I don't know if it should be merged as is, but decided to create a pull request to discuss it anyway. 

The Julia front-end llvm_dump must be loaded from ldump.jl in extras. The builtin function llvm_dump_lambda returns a Julia string with the LLVM code, given the LambdaStaticData for the method (jl_lambda_info_t on the C side). It compiles (or recompiles) the method if the LLVM functionObject is NULL. I don't know if this has any impact on the whole of code generation. 

The code is returned as a Julia string that can then be printed, written to a file, etc. It's still missing some checks (if the function is a builtin, for example, it won't have a LLVM function object), but I hope this is useful as a starting point. 
