### PR TITLE
Functions to get row and column vectors of matrices

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -70,6 +70,9 @@ reshape(a::AbstractArray, dims::Int...) = reshape(a, dims)
 
 vec(a::AbstractArray) = reshape(a,max(size(a)))
 
+rowvec{T}(a::AbstractArray{T,2}, i::Int) = vec(a[i,:])
+colvec{T}(a::AbstractArray{T,2}, i::Int) = vec(a[:,i])
+
 function squeeze(A::AbstractArray)
     d = ()
     for i = size(A)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1175,6 +1175,18 @@ Indexing, Assignment, and Concatenation
 
    Remove singleton dimensions from the shape of array ``A``
 
+.. function:: vec(A)
+
+   Make a vector out of an array with only one non-singleton dimension.
+
+.. function:: rowvec(A, i)
+
+   Return the ith row of matrix A as a vector.
+
+.. function:: colvec(A, i)
+
+   Return the ith column of matrix A as a vector.
+
 Linear Algebra
 --------------
 


### PR DESCRIPTION
Add two functions for returning row an column vectors of matrices.
rowvec(A,i) returns the ith row of A as a Vector and similarly
colvec(A,i) returns the ith column. This is to work around the
fact that matrix slices are not Vectors. See issue #934.
