### PR TITLE
Convert char[] containing zeros to ASCII-String

### DIFF
--- a/base/ascii.jl
+++ b/base/ascii.jl
@@ -76,5 +76,13 @@ write(io, s::ASCIIString) = write(io, s.data)
 ascii(x) = convert(ASCIIString, x)
 convert(::Type{ASCIIString}, s::ASCIIString) = s
 convert(::Type{ASCIIString}, s::UTF8String) = ascii(s.data)
-convert(::Type{ASCIIString}, a::Array{Uint8,1}) = check_ascii(ASCIIString(a))
+function convert(::Type{ASCIIString}, a::Array{Uint8,1})
+    i = findfirst(a .== 0)
+    if i == 0
+        s = ASCIIString(a)
+    else
+        s = ASCIIString(a[1:i-1])
+    end
+    return check_ascii(s)
+end
 convert(::Type{ASCIIString}, s::String) = ascii(cstring(s))


### PR DESCRIPTION
Strings in C are simply arrays of chars with \0 at the end.

Currently, I can do
ASCIIString(zeros(Uint8,5))
=> "\0\0\0\0\0"

This is bad behavior if I want to convert a char buf[] filled in a ccall to string -- if buf contains junk after the first \0 I want to ignore that.
This might happen eg when working with network sockets.

I propose to have

```
function convert(::Type{ASCIIString}, a::Array{Uint8,1})
    i = findfirst(a .== 0)
    if i == 0
        s = ASCIIString(a)
    else
        s = ASCIIString(a[1:i-1])
    end
    return check_ascii(s)
end
```

In any case, we should check if the last uint8 in the array is the terminating \0 or a valid character.
