### PR TITLE
Fixing binary operators when comparing arrays with scalars

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -761,9 +761,9 @@ for (f,scalarf) in ((:(.==),:(==)), (:.<, :<), (:.!=,:!=), (:.<=,:<=))
             end
             return F
         end
-        ($f)(A, B::AbstractArray) =
+        ($scalarf)(A, B::AbstractArray) =
             reshape([ ($scalarf)(A, B[i]) for i=1:length(B)], size(B))
-        ($f)(A::AbstractArray, B) =
+        ($scalarf)(A::AbstractArray, B) =
             reshape([ ($scalarf)(A[i], B) for i=1:length(A)], size(A))
     end
 end

--- a/base/error.jl
+++ b/base/error.jl
@@ -18,8 +18,9 @@ system_error(p, b::Bool) = b ? throw(SystemError(cstring(p))) : nothing
 ## assertion functions and macros ##
 
 assert(x) = assert(x,'?')
+assert(x::AbstractArray,labl) = (map(x->assert(x,labl), x); nothing)
 assert(x,labl) = x ? nothing : error("assertion failed: ", labl)
 
 macro assert(ex)
-    :(($ex) ? nothing : error("assertion failed: ", $string(ex)))
+	:(assert(($ex), $string(ex)))
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -19,6 +19,13 @@ b = a+a
 @assert isequal(1/[1,2,5], [1.0,0.5,0.2])
 @assert isequal([1,2,3]/5, [0.2,0.4,0.6])
 
+@assert isbool(isequal([1,2,3], [1,2,3]))
+@assert isbool(isless([1,2,3], [4,5,6]))
+@assert isa([1,2,3] .< [4,5,6], AbstractArray{Bool})
+@assert isa([1,2,3] .< 4, AbstractArray{Bool})
+@assert isa([1,2,3] < 4, AbstractArray{Bool})
+@assert isa([1,2,3] > 4, AbstractArray{Bool})
+
 a = ones(2,2)
 a[1,1] = 1
 a[1,2] = 2


### PR DESCRIPTION
This pull requests fixes two bugs, the primary one that it is impossible to compare an array with a scalar without using a dot operator, despite the manual saying:

> In case of binary operators, the dot version of the operator should be used when both inputs are non-scalar, and any version of the operator may be used if one of the inputs is a scalar.

Example of this failing:

``` julia
julia> foo = rand(5)
5-element Float64 Array:
 0.57254 
 0.824372
 0.851157
 0.759111
 0.475305

julia> bar = 0.5
0.5

julia> foo < bar
no method isless(Array{Float64,1},Float64)
 in method_missing at base.jl:60
 in < at operators.jl:13

julia> foo .< bar
5-element Bool Array:
 false
 false
 false
 false
  true
```

This is caused by a bug in base/base.jl, fixed by the first commit.

In order to test that, I wanted to write a simple test case, but then I got confronted with another issue: assert not being able to assert boolean vectors, despite the manual saying:

> Here, for example, is very nearly the definition of Julia’s @assert macro (see error.jl for the actual definition, which allows @assert to work on booleans arrays as well)
> My second commit adds support for testing against boolean arrays.

The third commit adds a small test case (which ironically doesn't use the aforementioned @assert functionality any more, as I thought simply comparing arrays might be too trivial for a unit test).
