### PR TITLE
Small bug fix for sparse matrix multiplication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ Building julia requires 1.5GiB of diskspace and approximately 700MiB of virtual 
 
 Once it is built, you can either run the `julia` executable using its full path in the directory created above, or add that directory to your executable path so that you can run the julia program from anywhere:
 
-    export PATH="$(pwd)/julia:$PATH"
+In bash:
+
+    export PATH="$(pwd):$PATH"
+    
+In csh / tcsh:
+
+    set path= ( $path $cwd )
 
 Now you should be able to run julia like this:
 

--- a/extras/linalg_sparse.jl
+++ b/extras/linalg_sparse.jl
@@ -81,6 +81,9 @@ function (*){TvX,TiX,TvY,TiY}(X::SparseMatrixCSC{TvX,TiX}, Y::SparseMatrixCSC{Tv
         (rowval, nzval) = _jl_spa_store_reset(spa, y_col, colptr, rowval, nzval)
     end
 
+    rowval = rowval[1:(colptr[end]-1)]
+    nzval = nzval[1:(colptr[end]-1)]
+    
     SparseMatrixCSC(mX, nY, colptr, rowval, nzval)
 end
 

--- a/extras/linalg_sparse.jl
+++ b/extras/linalg_sparse.jl
@@ -81,6 +81,9 @@ function (*){TvX,TiX,TvY,TiY}(X::SparseMatrixCSC{TvX,TiX}, Y::SparseMatrixCSC{Tv
         (rowval, nzval) = _jl_spa_store_reset(spa, y_col, colptr, rowval, nzval)
     end
 
+    del(rowval, colptr[end]:length(rowval))
+    del(nzval, colptr[end]:length(nzval))
+    
     SparseMatrixCSC(mX, nY, colptr, rowval, nzval)
 end
 


### PR DESCRIPTION
After creating the result in sparse format, the vectors containing the nonzero values and the row locations of those values are incorrect.  Their length is still equal to the sum of the total nonzeros in both matrices, which is not always the case.  They need to be trimmed to be the same length as the true number of nonzero values, which can be determined by the last value of the "column pointer" vector.
