### PR TITLE
Absolute paths in require

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -181,7 +181,29 @@ function mtime(filename::ASCIIString)
 end
 
 function abs_path(fname::String)
-    readchomp(`readlink --canonicalize-missing $fname`)
+    if fname[1] == '/'
+        comp = split(fname, '/')
+    else
+        comp = [split(cwd(), '/'), fname('/')]
+    end
+    @assert comp[1] == ""
+    i = 2
+    while i <= length(comp)
+        if comp[i] == "."
+            del(comp, i)
+            continue
+        elseif comp[i] == ".."
+            if i <= 2
+                error("invalid path")
+            end
+            i -= 1
+            del(comp, i)
+            del(comp, i)
+            continue
+        end
+        i += 1
+    end
+    return join(comp, '/')
 end
 
 # Core functions: stat and friends

--- a/base/file.jl
+++ b/base/file.jl
@@ -180,6 +180,10 @@ function mtime(filename::ASCIIString)
     end
 end
 
+function abs_path(fname::String)
+    readchomp(`readlink --canonicalize-missing $fname`)
+end
+
 # Core functions: stat and friends
 # Allocate a buffer for storing the results
 function statbuf_allocate()

--- a/extras/bigfloat.jl
+++ b/extras/bigfloat.jl
@@ -1,6 +1,6 @@
 _jl_libgmp_wrapper = dlopen("libgmp_wrapper")
 
-load("bigint.jl")
+require("bigint.jl")
 
 type BigFloat <: Float
 	mpf::Ptr{Void}

--- a/extras/glpk.jl
+++ b/extras/glpk.jl
@@ -2,7 +2,7 @@
 ### GLPK API Wrapper
 ###
 
-# note: be sure to load "sparse.jl" before this file
+require("sparse.jl")
 
 ## Shared library interface setup
 #{{{

--- a/extras/linalg_bitarray.jl
+++ b/extras/linalg_bitarray.jl
@@ -1,5 +1,7 @@
 ## linalg_bitarray.jl: Basic Linear Algebra functions for BitArrays ##
 
+require("bitarray.jl")
+
 function dot{T,S}(x::BitVector{T}, y::BitVector{S})
     # simplest way to mimic Array dot behavior
     s = zero(one(T) * one(S))

--- a/extras/linprog.jl
+++ b/extras/linprog.jl
@@ -3,7 +3,7 @@
 ## for optimization and constraint satisfaction problems
 ##
 
-# note: be sure to load "sparse.jl" and "glpk.jl" before this file
+require("glpk.jl")
 
 # General notes: the interface is provided as a collection of
 # high-level functions which use the glpk library.

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,9 +5,10 @@ default all extra unicode::
 	@$(MAKE) -sC unicode
 
 TESTS = default all extra \
-core numbers strings corelib hashing arrayops statistics \
-combinatorics glpk linprog sparse lapack fft arpack random unicode \
-special bigint bigfloat bitarray distributions factorizations
+core numbers strings unicode corelib hashing \
+arrayops lapack factorizations fft arpack bitarray \
+random special functional bigint distributions combinatorics statistics \
+integers sparse glpk linprog sparse bigfloat poly file Rmath
 
 $(TESTS) ::
 	$(QUIET_JULIA) $(JULIA_EXECUTABLE) ./runtests.jl $@

--- a/test/arpack.jl
+++ b/test/arpack.jl
@@ -1,4 +1,5 @@
-load("../extras/arpack.jl")
+cd("../extras") do
+require("arpack.jl")
 
 # arpack
 begin
@@ -13,3 +14,5 @@ asym = a+a'+n*eye(n)
 (d,v) = eigs(a,3)
 @assert abs(sum(a*v[:,2]-d[2]*v[:,2])) < 1e-8
 end
+
+end # cd

--- a/test/bigfloat.jl
+++ b/test/bigfloat.jl
@@ -1,5 +1,6 @@
+cd("../extras") do
+require("bigfloat.jl")
 
-load ("../extras/bigfloat.jl")
 a=BigFloat("12.34567890121")
 b=BigFloat("12.34567890122")
 
@@ -29,3 +30,4 @@ d = BigFloat("-24.69135780242")
 
 @assert abs((BigFloat(3)/BigFloat(2)) - BigFloat(1.5)) < 0.00000000001
 
+end # cd

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -1,5 +1,5 @@
 cd("../extras") do
-require("../extras/bigint.jl")
+require("bigint.jl")
 
 a=BigInt("123456789012345678901234567890")
 b=BigInt("123456789012345678901234567891")

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -1,5 +1,6 @@
+cd("../extras") do
+require("../extras/bigint.jl")
 
-load ("../extras/bigint.jl")
 a=BigInt("123456789012345678901234567890")
 b=BigInt("123456789012345678901234567891")
 
@@ -44,3 +45,4 @@ ee = typemax(Int64)
 @assert a+int32(1) == b
 @assert a+int64(1) == b
 
+end # cd

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1,6 +1,3 @@
-load("../extras/bitarray.jl")
-load("../extras/linalg_bitarray.jl")
-
 macro check_bit_operation(func, RetT, args)
     quote
         r1 = eval(($func)(($args)...))
@@ -20,6 +17,9 @@ macro timesofar(str)
         t0 = $t1
     end
 end
+
+cd("../extras") do
+require("linalg_bitarray.jl")
 
 TT = Uint8
 S = promote_type(TT, Int)
@@ -438,4 +438,6 @@ end
 #b1 = bitrand(TT, n1, n2)
 #@check_bit_operation diff Array{S} (b1,)
 
-@ timesofar "linalg"
+@timesofar "linalg"
+
+end # do

--- a/test/extra.jl
+++ b/test/extra.jl
@@ -8,5 +8,3 @@ runtests("file")
 #runtests("Rmath") # disabled due to pipe bug
 
 runtests("perf")
-#runtests("perf_cat")
-#runtests("arrayperf")

--- a/test/extra.jl
+++ b/test/extra.jl
@@ -1,1 +1,12 @@
+runtests("integers")
+runtests("sparse")
+runtests("glpk")
+runtests("linprog")
+runtests("bigfloat")
+runtests("poly")
+runtests("file")
+#runtests("Rmath") # disabled due to pipe bug
+
 runtests("perf")
+#runtests("perf_cat")
+#runtests("arrayperf")

--- a/test/glpk.jl
+++ b/test/glpk.jl
@@ -1,6 +1,5 @@
-cd("../extras")
-load("sparse.jl")
-load("glpk.jl")
+cd("../extras") do
+require("glpk.jl")
 
 # Same example as in the GLPK manual
 
@@ -52,3 +51,5 @@ tol = 1e-10
 @assert abs(x1 - 100. / 3) < tol
 @assert abs(x2 - 200. / 3) < tol
 @assert abs(x3) < tol
+
+end # cd

--- a/test/linprog.jl
+++ b/test/linprog.jl
@@ -1,8 +1,7 @@
 ### Linear programming
 
-load("../extras/sparse.jl")
-load("../extras/glpk.jl")
-load("../extras/linprog.jl")
+cd("../extras") do
+require("linprog.jl")
 
 ## Simplex method
 
@@ -92,3 +91,5 @@ colkind = int32([ GLP_BV for i = 1 : 9 ])
 @assert isequal(x, [ 0.; 0.; 1. ;
                      0.; 1.; 0. ;
                      1.; 0.; 0. ])
+
+end # cd

--- a/test/poly.jl
+++ b/test/poly.jl
@@ -1,5 +1,6 @@
 # assert file to test polynomial
-load("extras/poly.jl")
+cd("../extras") do
+require("poly.jl")
 
 
 pNULL = Polynomial(Float32[])
@@ -51,3 +52,4 @@ a_roots = copy(pN.a)
 @assert p2 - 2 == -2 + p2 == Polynomial([1,-1])
 @assert 2 - p2 == Polynomial([-1,1])
 
+end # cd

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -1,7 +1,5 @@
-include("../extras/sparse.jl")
-include("../extras/linalg_sparse.jl")
-include("../extras/linalg_suitesparse.jl")
-
+cd("../extras") do
+require("linalg_suitesparse.jl")
 
 # check matrix operations
 se33 = speye(3)
@@ -43,3 +41,5 @@ for i = 1 : 10
     a = sprand(5, 4, 0.5)
     @assert all([a[1:2,1:2] a[1:2,3:4]; a[3:5,1] [a[3:4,2:4]; a[5,2:4]]] == a)
 end
+
+end # cd

--- a/test/special.jl
+++ b/test/special.jl
@@ -1,4 +1,5 @@
-load("../extras/specfun.jl")
+cd("../extras") do
+require("specfun.jl")
 
 # airy
 @assert_approx_eq airy(1.8) 0.0470362
@@ -77,3 +78,5 @@ y33 = bessely(3,3.)
 @assert_approx_eq zeta(0) -0.5
 @assert_approx_eq zeta(2) pi^2/6
 @assert_approx_eq zeta(4) pi^4/90
+
+end # cd


### PR DESCRIPTION
Currently, `require` uses the provided file name to determine if the file was already loaded. A better approach is to use the full absolute path, so that there are no issues when changing directories etc. (I noticed those issues when testing).

This is basically what this commit does (plus some housekeeping stuff); however, I'm afraid the way I implemented `abs_path` is very linux-specific:

``` Julia
function abs_path(fname::String)
    readchomp(`readlink --canonicalize-missing $fname`)
end
```

I don't know if this works on Darwin/BSD/etc. (let alone Windows). Since this is also indirectly used in `load`, I'm afraid it could make a lot of people unhappy.
Any comments/suggestions on how to get the same functionality in a more portable way?

EDIT:  `abs_path` code rewritten.
