### PR TITLE
adds sizeof to rational.jl and improves sizeof coverage in complex.jl 

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -179,20 +179,20 @@ promote_rule(::Type{ImaginaryUnit}, ::Type{Float32}) = Complex64
 
 ## sizeof for ComplexPair{T}, T in (Uint,Int)x(8,16,32,64,128) ##
 
-sizeof(::Type{ComplexPair{Int8}})    =  2
-sizeof(::Type{ComplexPair{Uint8}})   =  2
-sizeof(::Type{ComplexPair{Int16}})   =  4
-sizeof(::Type{ComplexPair{Uint16}})  =  4
-sizeof(::Type{ComplexPair{Int32}})   =  8
-sizeof(::Type{ComplexPair{Uint32}})  =  8
-sizeof(::Type{ComplexPair{Int64}})   = 16
-sizeof(::Type{ComplexPair{Uint64}})  = 16
-sizeof(::Type{ComplexPair{Int128}})  = 32
-sizeof(::Type{ComplexPair{Uint128}}) = 32
+sizeof(::Type{ComplexPair{Uint8}})   = 2*sizeof(Uint8)
+sizeof(::Type{ComplexPair{Int8}})    = 2*sizeof(Int8)
+sizeof(::Type{ComplexPair{Uint16}})  = 2*sizeof(Uint16)
+sizeof(::Type{ComplexPair{Int16}})   = 2*sizeof(Int16)
+sizeof(::Type{ComplexPair{Uint32}})  = 2*sizeof(Uint32)
+sizeof(::Type{ComplexPair{Int32}})   = 2*sizeof(Int32)
+sizeof(::Type{ComplexPair{Uint64}})  = 2*sizeof(Uint64)
+sizeof(::Type{ComplexPair{Int64}})   = 2*sizeof(Int64)
+sizeof(::Type{ComplexPair{Uint128}}) = 2*sizeof(Uint128)
+sizeof(::Type{ComplexPair{Int128}})  = 2*sizeof(Int128)
 
 ## sizeof for ImaginaryUnit ##
 
-sizeof(::Type{ImaginaryUnit}) = 8     # subtype of Complex{Int32}
+sizeof(::Type{ImaginaryUnit}) = 2*sizeof(Int32) # subtypes Complex{Int32}
 
 
 ## generic functions of complex numbers ##

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -177,6 +177,24 @@ promote_rule(::Type{ImaginaryUnit}, ::Type{Float64}) = Complex128
 promote_rule(::Type{ImaginaryUnit}, ::Type{Float32}) = Complex64
 
 
+## sizeof for ComplexPair{T}, T in (Uint,Int)x(8,16,32,64,128) ##
+
+sizeof(::Type{ComplexPair{Int8}})    =  2
+sizeof(::Type{ComplexPair{Uint8}})   =  2
+sizeof(::Type{ComplexPair{Int16}})   =  4
+sizeof(::Type{ComplexPair{Uint16}})  =  4
+sizeof(::Type{ComplexPair{Int32}})   =  8
+sizeof(::Type{ComplexPair{Uint32}})  =  8
+sizeof(::Type{ComplexPair{Int64}})   = 16
+sizeof(::Type{ComplexPair{Uint64}})  = 16
+sizeof(::Type{ComplexPair{Int128}})  = 32
+sizeof(::Type{ComplexPair{Uint128}}) = 32
+
+## sizeof for ImaginaryUnit ##
+
+sizeof(::Type{ImaginaryUnit}) = 8     # subtype of Complex{Int32}
+
+
 ## generic functions of complex numbers ##
 
 convert(::Type{Complex}, z::Complex) = z

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -87,6 +87,23 @@ hash(x::Rational) = integer_valued(x) ? hash(x.num) :
                     float64_valued(x) ? hash(float64(x)) :
                     bitmix(hash(x.num),hash(x.den))
 
+
+
+## sizeof for Rational{T}, T in (Uint,Int)x(8,16,32,64,128) ##
+
+sizeof(::Type{Rational{Int8}})    =  2
+sizeof(::Type{Rational{Uint8}})   =  2
+sizeof(::Type{Rational{Int16}})   =  4
+sizeof(::Type{Rational{Uint16}})  =  4
+sizeof(::Type{Rational{Int32}})   =  8
+sizeof(::Type{Rational{Uint32}})  =  8
+sizeof(::Type{Rational{Int64}})   = 16
+sizeof(::Type{Rational{Uint64}})  = 16
+sizeof(::Type{Rational{Int128}})  = 32
+sizeof(::Type{Rational{Uint128}}) = 32
+
+
+
 -(x::Rational) = (-x.num) // x.den
 +(x::Rational, y::Rational) = (x.num*y.den + x.den*y.num) // (x.den*y.den)
 -(x::Rational, y::Rational) = (x.num*y.den - x.den*y.num) // (x.den*y.den)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -91,16 +91,16 @@ hash(x::Rational) = integer_valued(x) ? hash(x.num) :
 
 ## sizeof for Rational{T}, T in (Uint,Int)x(8,16,32,64,128) ##
 
-sizeof(::Type{Rational{Int8}})    =  2
-sizeof(::Type{Rational{Uint8}})   =  2
-sizeof(::Type{Rational{Int16}})   =  4
-sizeof(::Type{Rational{Uint16}})  =  4
-sizeof(::Type{Rational{Int32}})   =  8
-sizeof(::Type{Rational{Uint32}})  =  8
-sizeof(::Type{Rational{Int64}})   = 16
-sizeof(::Type{Rational{Uint64}})  = 16
-sizeof(::Type{Rational{Int128}})  = 32
-sizeof(::Type{Rational{Uint128}}) = 32
+sizeof(::Type{Rational{Uint8}})   = 2*sizeof(Uint8)
+sizeof(::Type{Rational{Int8}})    = 2*sizeof(Int8)
+sizeof(::Type{Rational{Uint16}})  = 2*sizeof(Uint16)
+sizeof(::Type{Rational{Int16}})   = 2*sizeof(Int16)
+sizeof(::Type{Rational{Uint32}})  = 2*sizeof(Uint32)
+sizeof(::Type{Rational{Int32}})   = 2*sizeof(Int32)
+sizeof(::Type{Rational{Uint64}})  = 2*sizeof(Uint64)
+sizeof(::Type{Rational{Int64}})   = 2*sizeof(Int64)
+sizeof(::Type{Rational{Uint128}}) = 2*sizeof(Uint128)
+sizeof(::Type{Rational{Int128}})  = 2*sizeof(Int128)
 
 
 


### PR DESCRIPTION
in ./base/rational.jl
defined sizeof(::Type{Rational{T}}), T in (Uint,Int)x(8,16,32,64,128)
fixes sizeof(Rational(3,7)) unknown

in ./base/complex.jl
defined sizeof(::Type{ComplexPair{T}}), T in (Uint,Int)x(8,16,32,64,128)
defined sizeof(::Type{ImaginaryUnit})
fixes sizeof(complex(3,5)) unknown
