### PR TITLE
RFC: multithreading?

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ override CXXFLAGS += $(JCXXFLAGS)
 
 SRCS = \
 	jltypes gf ast builtins module codegen interpreter \
-	alloc dlload sys init task array dump toplevel
+	alloc dlload sys init task thread array dump toplevel
 
 FLAGS = \
 	-D_GNU_SOURCE \

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -39,6 +39,8 @@ JL_CALLABLE(jl_apply_generic);
 JL_CALLABLE(jl_unprotect_stack);
 JL_CALLABLE(jl_f_task);
 JL_CALLABLE(jl_f_yieldto);
+JL_CALLABLE(jl_f_thread_create);
+JL_CALLABLE(jl_f_thread_join);
 JL_CALLABLE(jl_f_ctor_trampoline);
 
 #endif

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -844,6 +844,8 @@ void jl_init_primitives(void)
     add_builtin_func("eval", jl_f_top_eval);
     add_builtin_func("isbound", jl_f_isbound);
     add_builtin_func("yieldto", jl_f_yieldto);
+    add_builtin_func("thread_create", jl_f_thread_create);
+    add_builtin_func("thread_join", jl_f_thread_join);
     
     // functions for internal use
     add_builtin_func("convert_default", jl_f_convert_default);

--- a/src/dump.c
+++ b/src/dump.c
@@ -1072,7 +1072,8 @@ void jl_init_serializer(void)
                       jl_f_methodexists, jl_f_applicable, 
                       jl_f_invoke, jl_apply_generic, 
                       jl_unprotect_stack, jl_f_task, 
-                      jl_f_yieldto, jl_f_ctor_trampoline,
+                      jl_f_yieldto, jl_f_thread_create, jl_f_thread_join,
+		      jl_f_ctor_trampoline,
                       NULL };
     i=2;
     while (fptrs[i-2] != NULL) {

--- a/src/thread.c
+++ b/src/thread.c
@@ -1,5 +1,6 @@
 #include "julia.h"
 #include "uv.h"
+#define USE_THREADS    // comment out if you want to disable threading
 
 const int sizeof_uv_thread_t = sizeof(uv_thread_t);
 
@@ -26,12 +27,13 @@ JL_CALLABLE(jl_f_thread_create)
   thread_data.nargs = nargs-1;
 
   jl_array_t *jl_threadid = jl_alloc_array_1d(jl_array_uint8_type, sizeof_uv_thread_t);
-  /*
+#ifdef USE_THREADS
   if (uv_thread_create((uv_thread_t *) jl_array_data(jl_threadid), _function_pack_apply, &thread_data) != 0)
     jl_error("thread_create: error launching thread");
-  */
+#else
   JL_PRINTF(JL_STDOUT, "You want a new thread, but I'm going to fake it.\n");
   _function_pack_apply((void*) &thread_data);
+#endif
 
   return (jl_value_t*)jl_threadid;
 }
@@ -41,11 +43,12 @@ JL_CALLABLE(jl_f_thread_join)
   JL_NARGS(thread_join, 1, 1);
   JL_TYPECHK(thread_join, array, args[0]);
 
-  /*
+#ifdef USE_THREADS
   if (uv_thread_join((uv_thread_t *) jl_array_data(args[0])) != 0)
     jl_error("thread_join: error joining thread");
-  */
+#else
   JL_PRINTF(JL_STDOUT, "I'd be happy to join that for you, if there were anything to join.\n");
+#endif
   
   return (jl_value_t*)jl_null;
 }

--- a/src/thread.c
+++ b/src/thread.c
@@ -1,0 +1,51 @@
+#include "julia.h"
+#include "uv.h"
+
+const int sizeof_uv_thread_t = sizeof(uv_thread_t);
+
+typedef struct _function_pack_t {
+  jl_function_t *F;
+  jl_value_t   **args;
+  uint32_t       nargs;
+  jl_value_t    *ret;
+} function_pack_t;
+
+void _function_pack_apply(void *vp)
+{
+  function_pack_t *fp = (function_pack_t *) vp;
+  fp->ret = jl_apply(fp->F, fp->args, fp->nargs);
+} 
+
+JL_CALLABLE(jl_f_thread_create)
+{
+  JL_NARGSV(thread_create, 1);
+  JL_TYPECHK(thread_create, function, args[0]);
+  function_pack_t thread_data;
+  thread_data.F = (jl_function_t*) args[0];
+  thread_data.args = args+1;
+  thread_data.nargs = nargs-1;
+
+  jl_array_t *jl_threadid = jl_alloc_array_1d(jl_array_uint8_type, sizeof_uv_thread_t);
+  /*
+  if (uv_thread_create((uv_thread_t *) jl_array_data(jl_threadid), _function_pack_apply, &thread_data) != 0)
+    jl_error("thread_create: error launching thread");
+  */
+  JL_PRINTF(JL_STDOUT, "You want a new thread, but I'm going to fake it.\n");
+  _function_pack_apply((void*) &thread_data);
+
+  return (jl_value_t*)jl_threadid;
+}
+
+JL_CALLABLE(jl_f_thread_join)
+{
+  JL_NARGS(thread_join, 1, 1);
+  JL_TYPECHK(thread_join, array, args[0]);
+
+  /*
+  if (uv_thread_join((uv_thread_t *) jl_array_data(args[0])) != 0)
+    jl_error("thread_join: error joining thread");
+  */
+  JL_PRINTF(JL_STDOUT, "I'd be happy to join that for you, if there were anything to join.\n");
+  
+  return (jl_value_t*)jl_null;
+}


### PR DESCRIPTION
I decided to test whether it would be possible to use pthreads (actually, libuv threads) with Julia. I was motivated to do this to avoid the overhead of creating DArrays. For example, if one wanted to create a parallel version of the "sum(v::Vector)" function, in most cases it might not be worth it do break into a DArray, do a parallel sum, and then recombine. I'm particularly motivated by the needs of the image library.

The result of my experiment is a segfault. Is this a "deep" problem, or am I doing something wrong? Or are there doable changes that could be made in Julia, e.g., suspending garbage collection?

A gist with the Julia test function is here https://gist.github.com/3033117

To get the segfault :-) you have to re-enable the calls to `uv_thread_create` and `uv_thread_join` (and best to disable the call to `jl_apply`).
