### PR TITLE
RFC: Conversion from Float64 to BigFloat should go via string

### DIFF
--- a/extras/bigfloat.jl
+++ b/extras/bigfloat.jl
@@ -141,9 +141,7 @@ function string(x::BigFloat)
 	ret
 end
 
-function show(x::BigFloat) 
-	print (string(x))
-end	
+show(io, b::BigFloat) = print(io, string(b))
 
 function _jl_BigFloat_clear(x::BigFloat) 
 	ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpf_clear), Void, (Ptr{Void},), x.mpf)

--- a/extras/bigfloat.jl
+++ b/extras/bigfloat.jl
@@ -13,14 +13,6 @@ type BigFloat <: Float
 		b
 	end
 
-	function BigFloat(x::Float64) 
-		z = _jl_BigFloat_init()
-		ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpf_set_d), Void, (Ptr{Void}, Float64), z, x)
-		b = new(z)
-		finalizer(b, _jl_BigFloat_clear)
-		b
-	end
-	
 	function BigFloat(x::Uint) 
 		z = _jl_BigFloat_init()
 		ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpf_set_ui), Void, (Ptr{Void}, Uint), z, x)
@@ -51,6 +43,7 @@ type BigFloat <: Float
 		b
 	end
 end
+BigFloat(x::Float64) = BigFloat(string(x))
 
 convert(::Type{BigFloat}, x::Int8)   = BigFloat(int(x))
 convert(::Type{BigFloat}, x::Int16)  = BigFloat(int(x))


### PR DESCRIPTION
otherwise trash bits are converted. With existing code, the following behaviour is exhibited, which is incorrect. 

``` julia
julia> f=5.4
5.4

julia> BigFloat(f)
5.40000000000000035527

julia> BigFloat(f/2)
2.70000000000000017764

julia> BigFloat(f/4)
1.35000000000000008882

julia> BigFloat(string(f))
5.4

julia> BigFloat(string(f/2))
2.7

julia> BigFloat(string(f/4))
1.35

```
