### PR TITLE
Revise documentation of floating-point Inf and -Inf values in the manual

### DIFF
--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -210,9 +210,9 @@ for ``Float32``, but you can convert values to ``Float32`` easily:
 There are three specified standard floating-point values that do not
 correspond to a point on the real number line:
 
--  ``Inf`` — positive infinity — a value larger than all finite
+-  ``Inf`` — positive infinity — a value higher than all finite
    floating-point values
--  ``-Inf`` — negative infinity — a value smaller than all finite
+-  ``-Inf`` — negative infinity — a value lower than all finite
    floating-point values
 -  ``NaN`` — not a number — a value incomparable to all floating-point
    values (including itself).


### PR DESCRIPTION
This is just a suggestion for rewording the documentation of Inf and -Inf floating-point numbers.  I think "higher" and "lower" are clearer than "larger" and "smaller", since at least to me "larger" and "smaller" refer to magnitude rather than direction.
