### PR TITLE
Discrete rand update

### DIFF
--- a/base/distributions.jl
+++ b/base/distributions.jl
@@ -46,6 +46,7 @@ macro _jl_dist_1p(T, b)
     Ty = eval(T)
     pf = Ty <: DiscreteDistribution ? :pmf : :pdf
     lf = Ty <: DiscreteDistribution ? :logpmf : :logpdf
+    rand_type = Ty <: DiscreteDistribution ? :int : ""
     pn = Ty.names                       # parameter names
     p  = expr(:quote,pn[1])
     quote
@@ -100,8 +101,8 @@ macro _jl_dist_1p(T, b)
                   lp, d.($p), 0, 1)
         end
         function rand(d::($T))
-            ccall(dlsym(_jl_libRmath,  $rr),
-                  Float64, (Float64,), d.($p))
+            ($rand_type)(ccall(dlsym(_jl_libRmath,  $rr),
+                               Float64, (Float64,), d.($p)))
         end
     end
 end
@@ -114,6 +115,7 @@ macro _jl_dist_2p(T, b)
     Ty = eval(T)
     pf = Ty <: DiscreteDistribution ? :pmf : :pdf
     lf = Ty <: DiscreteDistribution ? :logpmf : :logpdf
+    rand_type = Ty <: DiscreteDistribution ? :int : ""
     pn = Ty.names                       # parameter names
     p1 = expr(:quote,pn[1])
     p2 = expr(:quote,pn[2])    
@@ -174,8 +176,8 @@ macro _jl_dist_2p(T, b)
                   lp, d.($p1), d.($p2), 0, 1)
         end
         function rand(d::($T))
-            ccall(dlsym(_jl_libRmath,  $rr),
-                  Float64, (Float64, Float64), d.($p1), d.($p2))
+            ($rand_type)(ccall(dlsym(_jl_libRmath,  $rr),
+                               Float64, (Float64, Float64), d.($p1), d.($p2)))
         end
     end
 end
@@ -188,6 +190,7 @@ macro _jl_dist_3p(T, b)
     Ty = eval(T)
     pf = Ty <: DiscreteDistribution ? :pmf : :pdf
     lf = Ty <: DiscreteDistribution ? :logpmf : :logpdf
+    rand_type = Ty <: DiscreteDistribution ? :int : ""
     pn = Ty.names                       # parameter names
     p1 = expr(:quote,pn[1])
     p2 = expr(:quote,pn[2])    
@@ -244,8 +247,8 @@ macro _jl_dist_3p(T, b)
                   lp, d.($p1), d.($p2), d.($p3), 0, 1)
         end
         function rand(d::($T))
-            ccall(dlsym(_jl_libRmath,  $rr),
-                  Float64, (Float64, Float64, Float64), d.($p1), d.($p2), d.($p3))
+            ($rand_type)(ccall(dlsym(_jl_libRmath,  $rr),
+                               Float64, (Float64, Float64, Float64), d.($p1), d.($p2), d.($p3)))
         end
     end
 end

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -53,3 +53,7 @@ end
 @vectorize_1arg Number abs
 @vectorize_1arg Number abs2
 @vectorize_1arg Number angle
+
+@vectorize_1arg Real isnan
+@vectorize_1arg Real isinf
+@vectorize_1arg Real isfinite


### PR DESCRIPTION
For discrete distributions, rand(d) produces Float64 samples:

``` julia
julia> load("base/distributions.jl")

julia> b = Binomial()
Binomial(1,0.5)

julia> rand(b)
0.0

julia> rand(b)
1.0

julia> typeof(ans)
Float64
```

This is a result of calling libRmath, where all functions seem to return Float64.  This patch casts the results of rand(d) for discrete distributions to integers, while leaving alone rand(d) for continuous distributions:

``` julia

julia> load("base/distributions.jl")

julia> b = Binomial()
Binomial(1,0.5)

julia> rand(b)
0

julia> rand(b)
1

julia> g = Gaussian()
Normal(0.0,1.0)

julia> rand(g)
-0.4344590431025213
```

Eventually, these functions should probably be rewritten in Julia--at least, for most of the discrete distributions, it seems wasteful to covert back and forth from integers to floats.

For the patch, `rand_type` is set either to `:int` or `""`, and then used to cast the function inside the macro.  While it produces the correct results, I'm not exactly sure what happens when `rand_type` is `""`, so feedback is appreciated.

Kevin
