### PR TITLE
rewrote ends_with (base/string.jl) runs 10x faster on my machine

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -261,8 +261,8 @@ end
 begins_with(a::String, c::Char) = length(a) > 0 && a[1] == c
 
 # TODO: better ends_with
-ends_with(a::String, b::String) = begins_with(reverse(a),reverse(b))
-ends_with(a::String, c::Char) = length(a) > 0 && a[end] == c
+ends_with(s::String, z::String) = (strlen(s) >= strlen(z)) && (z == s[(thisind(s,end)-strlen(z)+1):])
+ends_with(s::String, c::Char)   = (length(s) > 0) && (c == s[thisind(s,end)])
 
 # faster comparisons for byte strings
 


### PR DESCRIPTION
Following Stefan's dev note, I use str[ thisind(str,end) .. ] to index the final character of the string.
I chose length(str) when testing for a  non-empty string, and strlen(str) when counting characters.
Without understanding why, I followed the order used in string.jl, 
   placing ends_with(String,String) before ends_with(String,Char).
I left intact the comment # TODO: better ends_with 
