### PR TITLE
docs: literal coeficient binds more tight than *

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -688,6 +688,11 @@ LIBUNWIND_TARGET_OBJ =
 LIBUNWIND_TARGET_SOURCE = 
 endif
 
+LIBUNWIND_CFLAGS = $(CFLAGS) -U_FORTIFY_SOURCE $(fPIC)
+ifeq ($(ARCH), ppc64)
+LIBUNWIND_CFLAGS += -m64
+endif
+
 compile-unwind: $(LIBUNWIND_TARGET_SOURCE)
 install-unwind: $(LIBUNWIND_TARGET_OBJ)
 
@@ -695,7 +700,7 @@ libunwind-$(UNWIND_VER).tar.gz:
 	$(WGET) http://savannah.spinellicreations.com/libunwind/libunwind-$(UNWIND_VER).tar.gz
 libunwind-$(UNWIND_VER)/Makefile: libunwind-$(UNWIND_VER).tar.gz
 	tar xfz $<
-	cd libunwind-$(UNWIND_VER) && ./configure  CFLAGS="$(CFLAGS) -U_FORTIFY_SOURCE $(fPIC)" --prefix=$(abspath $(USR)) CC="$(CC)" CXX="$(CXX)"
+	cd libunwind-$(UNWIND_VER) && ./configure  CFLAGS="$(LIBUNWIND_CFLAGS)" --prefix=$(abspath $(USR)) CC="$(CC)" CXX="$(CXX)"
 
 $(LIBUNWIND_TARGET_SOURCE): libunwind-$(UNWIND_VER)/Makefile
 	cd libunwind-$(UNWIND_VER) && $(MAKE)

--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -92,12 +92,13 @@ different types just work:
     -0.5 - 1.0im
 
     julia> 1 + 3/4im
-    1.0 + 0.75im
+    1.0 - 0.75im
 
-Note that ``3/4im`` parses as ``3/4*im``, which, since division and
-multiplication have equal precedence and are left-associative, is
-equivalent to ``(3/4)*im`` rather than the quite different value,
-``3/(4*im) == -(3/4)*im``.
+    julia> 2im^2
+    -2 + 0im
+
+Note that ``3/4im == 3/(4*im) == -(3/4*im)``, since a a literal
+coefficient binds more tightly than multiplication and division.
 
 Standard functions to manipulate complex values are provided:
 

--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -92,12 +92,14 @@ different types just work:
     -0.5 - 1.0im
 
     julia> 1 + 3/4im
-    1.0 + 0.75im
+    1.0 - 0.75im
 
-Note that ``3/4im`` parses as ``3/4*im``, which, since division and
-multiplication have equal precedence and are left-associative, is
-equivalent to ``(3/4)*im`` rather than the quite different value,
-``3/(4*im) == -(3/4)*im``.
+    julia> 2im^2
+    -2 + 0im
+
+Note that ``3/4im == 3/(4*im) == -(3/4*im)`` and ``2im^2 == 2(im^2)``; a
+literal coefficient binds more tightly than multiplication and division,
+but less tightly than exponentiation.
 
 Standard functions to manipulate complex values are provided:
 

--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -360,6 +360,13 @@ multiplication. This makes writing polynomial expressions much cleaner:
     julia> 1.5x^2 - .5x + 1
     13.0
 
+It also makes writes exponential functions more elegant:
+
+::
+
+    julia> 2^2x
+    64
+
 You can also use numeric literals as coefficients to parenthesized
 expressions:
 


### PR DESCRIPTION
fixes issue [1040][https://github.com/JuliaLang/julia/issues/1040]
Also, makes 2im^2 clear.
