### PR TITLE
RFC: use a memio object and then pass the buffer externally

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -253,7 +253,7 @@ takebuf_string(s::IOStream) =
     ccall(:jl_takebuf_string, ByteString, (Ptr{Void},), s.ios)
 
 takebuf_array(s::IOStream) =
-    ccall(:jl_takebuf_array, ByteString, (Ptr{Void},), s.ios)
+    ccall(:jl_takebuf_array, Vector{Uint8}, (Ptr{Void},), s.ios)
 
 function takebuf_raw(s::IOStream)
     sz = position(s)

--- a/src/dump.c
+++ b/src/dump.c
@@ -873,7 +873,7 @@ DLLEXPORT
 jl_value_t *jl_compress_ast(jl_lambda_info_t *li, jl_value_t *ast)
 {
     ios_t dest;
-    jl_ios_mem(&dest, 0);
+    jl_ios_mem(&dest, 0, 1);
     int en = jl_gc_is_enabled();
     jl_gc_disable();
 
@@ -905,7 +905,7 @@ jl_value_t *jl_uncompress_ast(jl_tuple_t *data)
     jl_array_t *bytes = (jl_array_t*)jl_tupleref(data, 0);
     tree_literal_values = (jl_array_t*)jl_tupleref(data, 1);
     ios_t src;
-    jl_ios_mem(&src, 0);
+    jl_ios_mem(&src, 0, 1);
     ios_setbuf(&src, bytes->data, jl_array_len(bytes), 0);
     src.size = jl_array_len(bytes);
     int en = jl_gc_is_enabled();

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -43,7 +43,10 @@
     jl_enable_color;
     jl_takebuf_array;
     jl_takebuf_string;
+    jl_takebuf_raw;
     jl_readuntil;
+    jl_free1;
+    jl_free2;
     jl_cpu_cores;
     jl_hrtime;
     jl_cstr_to_string;

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -45,7 +45,6 @@
     jl_takebuf_string;
     jl_takebuf_raw;
     jl_readuntil;
-    jl_free1;
     jl_free2;
     jl_cpu_cores;
     jl_hrtime;

--- a/src/julia.h
+++ b/src/julia.h
@@ -986,7 +986,10 @@ DLLEXPORT void jl_register_toplevel_eh(void);
 
 DLLEXPORT jl_array_t *jl_takebuf_array(ios_t *s);
 DLLEXPORT jl_value_t *jl_takebuf_string(ios_t *s);
+DLLEXPORT void *jl_takebuf_raw(ios_t *s);
 DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim);
+DLLEXPORT void jl_free1(void *p);
+DLLEXPORT void jl_free2(void *p, void *hint);
 
 DLLEXPORT int jl_cpu_cores(void);
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -988,7 +988,6 @@ DLLEXPORT jl_array_t *jl_takebuf_array(ios_t *s);
 DLLEXPORT jl_value_t *jl_takebuf_string(ios_t *s);
 DLLEXPORT void *jl_takebuf_raw(ios_t *s);
 DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim);
-DLLEXPORT void jl_free1(void *p);
 DLLEXPORT void jl_free2(void *p, void *hint);
 
 DLLEXPORT int jl_cpu_cores(void);

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -843,11 +843,11 @@ ios_t *ios_mem(ios_t *s, size_t initsize)
     return s;
 }
 
-ios_t *jl_ios_mem(ios_t *s, size_t initsize)
+ios_t *jl_ios_mem(ios_t *s, size_t initsize, int julia_mallocated)
 {
     _ios_init(s);
     s->bm = bm_mem;
-    s->julia_alloc = 1;
+    s->julia_alloc = julia_mallocated;
     _buf_realloc(s, initsize);
     return s;
 }

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -100,7 +100,7 @@ DLLEXPORT size_t ios_readprep(ios_t *from, size_t n);
 DLLEXPORT
 ios_t *ios_file(ios_t *s, char *fname, int rd, int wr, int create, int trunc);
 DLLEXPORT ios_t *ios_mem(ios_t *s, size_t initsize);
-DLLEXPORT ios_t *jl_ios_mem(ios_t *s, size_t initsize);
+DLLEXPORT ios_t *jl_ios_mem(ios_t *s, size_t initsize, int julia_mallocated);
 ios_t *ios_str(ios_t *s, char *str);
 ios_t *ios_static_buffer(ios_t *s, char *buf, size_t sz);
 DLLEXPORT ios_t *ios_fd(ios_t *s, long fd, int isfile, int own);

--- a/src/sys.c
+++ b/src/sys.c
@@ -310,11 +310,6 @@ jl_value_t *jl_readuntil(ios_t *s, uint8_t delim)
     return str;
 }
 
-void jl_free1(void *p)
-{
-    free(p);
-}
-
 void jl_free2(void *p, void *hint)
 {
     free(p);

--- a/src/sys.c
+++ b/src/sys.c
@@ -263,6 +263,17 @@ jl_value_t *jl_takebuf_string(ios_t *s)
     return str;
 }
 
+// You can manually circumvent the garbage collector by using
+// jl_ios_mem (i.e., memio) with julia_malloc = false; in that case, the
+// returned buffer must be manually freed. To determine the size,
+// call position(s) before using this function.
+void *jl_takebuf_raw(ios_t *s)
+{
+    size_t sz;
+    void *buf = ios_takebuf(s, &sz);
+    return buf;
+}
+
 jl_value_t *jl_readuntil(ios_t *s, uint8_t delim)
 {
     jl_array_t *a;
@@ -277,7 +288,7 @@ jl_value_t *jl_readuntil(ios_t *s, uint8_t delim)
     else {
         a = jl_alloc_array_1d(jl_array_uint8_type, 80);
         ios_t dest;
-        jl_ios_mem(&dest, 0);
+        jl_ios_mem(&dest, 0, 1);
         ios_setbuf(&dest, a->data, 80, 0);
         size_t n = ios_copyuntil(&dest, s, delim);
         if (dest.buf != a->data) {
@@ -297,6 +308,16 @@ jl_value_t *jl_readuntil(ios_t *s, uint8_t delim)
     jl_fieldref(str,0) = (jl_value_t*)a;
     JL_GC_POP();
     return str;
+}
+
+void jl_free1(void *p)
+{
+    free(p);
+}
+
+void jl_free2(void *p, void *hint)
+{
+    free(p);
 }
 
 // -- syscall utilities --


### PR DESCRIPTION
This should allow you to use a memio object, grab the buffer, and then pass it to an external program that has an appropriate "free" callback. Example usage:

```
s = memio(0, true, false)
for i = 1:1000; print(s, "Hi there"); end
buf, sz = takebuf_raw(s)
ccall(:somefunction, RetVal, (SomeArgTypes, Ptr{Void}, Uint, Ptr{Void}), SomeArgVals, buf, sz, :jl_free1)
```

You'd use `:jl_free1` if the "free" callback function syntax is

```
void freefunc(void *p)
```

and `:jl_free2` if the callback syntax is

```
void freefunc(void *p, void *arg)
```

This obviously doesn't cover every single possibility, but it should get the large majority.
