### PR TITLE
Python benchmark

### DIFF
--- a/test/perf/perf.py
+++ b/test/perf/perf.py
@@ -21,18 +21,16 @@ def qsort_kernel(a, lo, hi):
     i = lo
     j = hi
     while i < hi:
-        pivot = a[int((lo+hi)/2)]
+        pivot = a[(lo+hi) // 2]
         while i <= j:
             while a[i] < pivot:
-                i = i+1
+                i += 1
             while a[j] > pivot:
-                j = j-1
+                j -= 1
             if i <= j:
-                t = a[i]
-                a[i] = a[j]
-                a[j] = t
-                i = i+1
-                j = j-1
+                a[i], a[j] = a[j], a[i]
+                i += 1
+                j -= 1
         if lo < j:
             qsort_kernel(a, lo, j)
         lo = i
@@ -66,25 +64,18 @@ def randmatmul(n):
 ## mandelbrot ##
 
 def mandel(z):
-    n = 0
     c = z
     for n in range(0,79):
         if abs(z) > 2:
             n -= 1
             break
-        z = z**2 + c
+        z = z*z + c
     return n + 1
 
 def mandelperf():
     r1 = numpy.arange(-2.0, 0.5, 0.1)
     r2 = numpy.arange(-1.0, 1.0, 0.1)
-    M = numpy.zeros((len(r1)*len(r2)))
-    count = 0
-    for r in r1:
-        for i in r2:
-            M[count] = mandel(complex(r,i))
-            count += 1
-    return M
+    return [mandel(complex(r, i)) for r in r1 for i in r2]
 
 def pisum():
     for j in range(500):

--- a/test/perf/perf.py
+++ b/test/perf/perf.py
@@ -40,9 +40,9 @@ def randmatstat(t):
 ## randmatmul ##
 
 def randmatmul(n):
-    A = matrix(numpy.random.rand(n,n))
-    B = matrix(numpy.random.rand(n,n))
-    return A*B
+    A = numpy.random.rand(n,n)
+    B = numpy.random.rand(n,n)
+    return numpy.dot(A,B)
 
 ## mandelbrot ##
 

--- a/test/perf/perf.py
+++ b/test/perf/perf.py
@@ -87,12 +87,10 @@ def mandelperf():
     return M
 
 def pisum():
-    sum = 0.0
-    for j in range(1, 500):
-        sum = 0.0
-        for k in range(1, 10000):
-            sum += 1.0/(k*k)
-    return sum
+    for j in range(500):
+        k = numpy.arange(10000) + 1
+        total = numpy.sum(1. / (k * k))
+    return total
 
 def print_perf(name, time):
     print("python," + name + "," + str(time*1000))

--- a/test/perf/perf.py
+++ b/test/perf/perf.py
@@ -18,24 +18,7 @@ def fib(n):
 ## quicksort ##
 
 def qsort_kernel(a, lo, hi):
-    i = lo
-    j = hi
-    while i < hi:
-        pivot = a[(lo+hi) // 2]
-        while i <= j:
-            while a[i] < pivot:
-                i += 1
-            while a[j] > pivot:
-                j -= 1
-            if i <= j:
-                a[i], a[j] = a[j], a[i]
-                i += 1
-                j -= 1
-        if lo < j:
-            qsort_kernel(a, lo, j)
-        lo = i
-        j = hi
-    return a
+    return numpy.sort(a[lo:hi], kind="quicksort")
 
 ## randmatstat ##
 


### PR DESCRIPTION
Dear Julia developers,

After seeing how poorly Python performs in [your benchmark](http://julialang.org/), I decided to check out its code that you claim gives "a sense for how easy or difficult numerical programming in each language is". I found that your Python code is not quite idiomatic, is ambiguous about its use of NumPy (which practically any Python number crunching program will use) and therefore misrepresents Python's performance for numeric tasks.

I've taken the liberty of submitting four possible improvements in this PR.

The first contains a rewritten `pisum` benchmark using NumPy idioms, which makes it an order of magnitude faster on my machine, after correction of the mistake that the benchmark runs its outer loop 499 times instead of 500.

The second is a micro-optimization achieved by using ordinary Python idioms throughout the code.

The third replaces the quicksort benchmark with a call to NumPy's version of quicksort. No Python programmer would actually write a sorting routine themselves in pure Python, since the language is simply not intended to be used this way, and it goes against the "batteries included" philosophy.

The fourth prevents two expensive copies in `randmatmul`.

(I also think the `fib` benchmark is particularly flawed, as it's not representative of any practical numerical algorithm that I know of. Python in particular is _not_ optimized for recursion and iteration is preferred throughout.)

You're free to cherry-pick any selection of the commits in this branch, but I do urge you to hedge the claims pertaining to your benchmarks more carefully. I also wish you the best of luck with the interesting language you are developing.
