### PR TITLE
RFC: fixed options and turned into a module

### DIFF
--- a/test/test_options.jl
+++ b/test/test_options.jl
@@ -1,62 +1,44 @@
 test_context("Options for functions")
 
+require("options.jl")
+import OptionsMod.*
+
 test_group("basic functionality")
-oo = options(:a, true, :b, 7)
-@test length(oo.keys) == 2
+oo = Options(:a, true, :b, 7)
+@test length(oo.key2index) == 2
 @test oo[:a] == true
 @test oo[:b] > 6
 @test oo[:c] == nothing
-@test sprint(show, oo) == "a = true, b = 7"
+@test sprint(show, oo) == "a = true, b = 7 (CheckError)"
 
-test_group("adding defaults")
-uu = add_defaults!(oo, :a, false, :b, 0, :c, "cat")
-@test oo[:a] == true
-@test oo[:b] == 7
-@test oo[:c] == "cat"
-@test length(uu.keys) == 0
-uu2 = add_defaults!(oo, :a, false, :c, "cat", :etc)
-@test length(uu2.keys) == 1
-@test uu2[:b] == 7
-# TODO: when test.jl allows for catching exceptions, add one for the above w/out :etc
+test_group("other constructors")
+oo2 = Options(CheckWarn, :(a=true), :(b=7))
+@test oo2[:a] == true
+oo3 = @options a=true b=7
+@test oo3[:b] == 7
+
+
+test_group("changing options")
+oo2[:b] = 6
+oo2[:c] = "cat"
+@test oo2[:b] < 7
+@test oo2[:c] == "cat"
 
 test_group("simple example")
 function f1(a, b, o::Options)
-    add_defaults!(o, :op, "plus")
-    let op = o[:op]
-        if op == "plus"
-            return a + b
-        else
-            return a - b
-        end
+	@defaults o op="plus"
+    if op == "plus"
+        return a + b
+    else
+        return a - b
     end
+	@check_used o
 end
-f1(a, b) = f1(a, b, options())
+f1(a, b) = f1(a, b, Options())
 @test f1(3, 2) == 5
-@test f1(3, 2, options(:op, "plus")) == 5
-@test f1(3, 2, options(:op, "other")) == 1
+@test f1(3, 2, Options(:op, "plus")) == 5
+@test f1(3, 2, Options(:op, "other")) == 1
 
-test_group("example with etc")
-function f2(a, b, o::Options)
-    etc = add_defaults!(o, :op, "plus", :etc)
-    let op = o[:op]
-        if op == "plus"
-            return a + f2b(b, etc)
-        else
-            return a - f2b(b, etc)
-        end
-    end
-end
-f2(a, b) = f2(a, b, options())
-function f2b(x, o::Options)
-    add_defaults!(o, :double, false)
-    let double = o[:double]
-        return double ? x*2 : x
-    end
-end
-@test f2(3, 2) == 5
-@test f2(3, 2, options(:op, "plus")) == 5
-@test f2(3, 2, options(:op, "plus", :double, false)) == 5
-@test f2(3, 2, options(:op, "plus", :double, true)) == 7
 
     
 


### PR DESCRIPTION
- the new macro namespace rules clobbered extras/options.jl -- I _think_ I fixed it
- `load("test.jk"); tests("test/test_options.jl")` now works
- needs review, especially from @timholy (Tim, the whole options-checking mechanism seems overly complex to me, so I'm not totally sure it's working the way you expect...)
