### PR TITLE
RFC: add ability to delete a finalizer for an object

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -95,6 +95,7 @@ isequal(w::WeakRef, v) = isequal(w.value, v)
 isequal(w, v::WeakRef) = isequal(w, v.value)
 
 finalizer(o, f::Function) = ccall(:jl_gc_add_finalizer, Void, (Any,Any), o, f)
+finalizer_del(o) = ccall(:jl_gc_remove_finalizer, Void, (Any,), o)
 
 gc() = ccall(:jl_gc_collect, Void, ())
 gc_enable() = ccall(:jl_gc_enable, Void, ())

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -118,6 +118,7 @@ export
     factor,factorial,falses,fd,fdio,fetch,fft,fft2,fft3,fft_num_threads,
     fftn,fftshift,fftw_forget_wisdom,fftwd_import_wisdom_from_filename,
     fftwf_import_wisdom_from_filename,fill,fill!,filt,filter,filter!,finalizer,
+    finalizer_del,
     find,find_in_path,findmax,findmin,findn,findn_nzs,finfer,first,
     first_utf8_byte,fld,flipdim,fliplr,flipsign,flipud,float,float32,
     float32_isvalid,float64,float64_isvalid,float64_valued,floor,flush,

--- a/src/gc.c
+++ b/src/gc.c
@@ -196,6 +196,13 @@ void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f)
     }
 }
 
+void jl_gc_remove_finalizer(jl_value_t *v)
+{
+    jl_value_t **bp = (jl_value_t**)ptrhash_bp(&finalizer_table, v);
+    if (*bp != HT_NOTFOUND)
+        ptrhash_remove(&finalizer_table, v);
+}
+
 htable_t *jl_gc_get_finalizer_table(void)
 {
     return &finalizer_table;

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -141,6 +141,7 @@
     jl_nb_available;
     jl_ios_eof;
     jl_gc_add_finalizer;
+    jl_gc_remove_finalizer;
     jl_gc_collect;
     jl_gc_lookfor;
     jl_gc_enable;

--- a/src/julia.h
+++ b/src/julia.h
@@ -910,6 +910,7 @@ void jl_gc_preserve(jl_value_t *v);
 void jl_gc_unpreserve(void);
 int jl_gc_n_preserved_values(void);
 DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f);
+DLLEXPORT void jl_gc_remove_finalizer(jl_value_t *v);
 jl_weakref_t *jl_gc_new_weakref(jl_value_t *value);
 #define jl_gc_setmark(v) (((uptrint_t*)(v))[-1]|=1)
 void jl_gc_acquire_buffer(void *b);


### PR DESCRIPTION
I've encountered a situation where I want to define a finalizer to do some cleanup in case of error while constructing a file---the finalizer frees some resources and closes the file. However, when everything succeeds, I'd like to immediately close the file so I can pass it to an external program, which will then assume control. With the finalizer, I can't control when that happens without an explicit `gc()`, which I suspect is not the best choice (?). Consequently, I'd like to remove the finalizer for that object and do the cleanup manually, at the time I want.

This code may get close, but I'm concerned about the `to_finalize` array and any gc subtleties I may have missed. Hence the RFC.

If an explicit `gc()` is in fact the better way to go, just let me know and close without merging.
