### PR TITLE
RFC: lapack interface: Change String to Char/Uint8 for single-char arguments

### DIFF
--- a/base/linalg_lapack.jl
+++ b/base/linalg_lapack.jl
@@ -16,7 +16,7 @@ for (gbtrf, geqrf, geqp3, getrf, potrf, elty) in
         #       INTEGER            INFO, LDA, N
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * )
-        function _jl_lapack_potrf(uplo, A::StridedMatrix{$elty})
+        function _jl_lapack_potrf(uplo::Uint8, A::StridedMatrix{$elty})
             if stride(A,1) != 1
                 error("_jl_lapack_potrf: matrix columns must have contiguous elements");
             end
@@ -27,7 +27,7 @@ for (gbtrf, geqrf, geqp3, getrf, potrf, elty) in
             ccall(dlsym(_jl_liblapack, $string(potrf)),
                   Void,
                   (Ptr{Uint8}, Ptr{Int32}, Ptr{$elty}, Ptr{Int32}, Ptr{Int32}),
-                  uplo, &n, A, &lda, info)
+                  &uplo, &n, A, &lda, info)
 ## _jl_lapack_potrf is unusual in that it does not return the
 ## factorization, which overwrites A, but instead returns the error
 ## code. A symmetric (Hermitian) matrix can fail to be positive
@@ -38,6 +38,7 @@ for (gbtrf, geqrf, geqp3, getrf, potrf, elty) in
 ## could be wrapped in a try/catch block
             return info[1]
         end
+        _jl_lapack_potrf(uplo::Char, A::StridedMatrix{$elty}) = _jl_lapack_potrf(uint8(uplo),A)
         # SUBROUTINE DGETRF( M, N, A, LDA, IPIV, INFO )
         # *     .. Scalar Arguments ..
         #       INTEGER            INFO, LDA, M, N
@@ -210,11 +211,11 @@ end
 
 ## chol! overwrites A with either the upper or lower triangular
 ## Cholesky factor (default is upper)
-chol!{T<:Union(Float32,Float64,Complex64,Complex128)}(A::StridedMatrix{T}) = chol!(A, "U")
-function chol!{T<:Union(Float32,Float64,Complex64,Complex128)}(A::StridedMatrix{T}, uplo::String)
+chol!{T<:Union(Float32,Float64,Complex64,Complex128)}(A::StridedMatrix{T}) = chol!(A, 'U')
+function chol!{T<:Union(Float32,Float64,Complex64,Complex128)}(A::StridedMatrix{T}, uplo::Char)
     info = _jl_lapack_potrf(uplo, A)
     if info != 0 error("chol: matrix is not positive definite, error $info") end
-    uppercase(uplo)[1] == 'U' ? triu(A) : tril(A)
+    uppercase(uplo) == 'U' ? triu(A) : tril(A)
 end
 
 
@@ -274,7 +275,7 @@ for (syev, geev, elty) in
         #       INTEGER            INFO, LDA, LWORK, N
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), W( * ), WORK( * )
-        function _jl_lapack_syev(jobz::String, uplo::String, A::StridedMatrix{$elty})
+        function _jl_lapack_syev(jobz::Uint8, uplo::Uint8, A::StridedMatrix{$elty})
             if stride(A,1) != 1
                 error("_jl_lapack_syev: matrix columns must have contiguous elements");
             end
@@ -296,14 +297,14 @@ for (syev, geev, elty) in
                           (Ptr{Uint8}, Ptr{Uint8}, Ptr{Int32}, Ptr{$elty},
                            Ptr{Int32}, Ptr{$elty}, Ptr{$elty}, Ptr{Int32},
                            Ptr{Rtyp}, Ptr{Int32}),
-                          jobz, uplo, &n, A, &lda, W, work, &lwork, rwork, info)
+                          &jobz, &uplo, &n, A, &lda, W, work, &lwork, rwork, info)
                 else
                     ccall(dlsym(_jl_liblapack, $string(syev)),
                           Void,
                           (Ptr{Uint8}, Ptr{Uint8}, Ptr{Int32}, Ptr{$elty},
                            Ptr{Int32}, Ptr{$elty}, Ptr{$elty}, Ptr{Int32},
                            Ptr{Int32}),
-                          jobz, uplo, &n, A, &lda, W, work, &lwork, info)
+                          &jobz, &uplo, &n, A, &lda, W, work, &lwork, info)
                 end
                 if info[1] != 0 throw(LapackException(info[1])) end
                 if lwork < 0
@@ -311,8 +312,9 @@ for (syev, geev, elty) in
                     work = Array($elty, lwork)
                 end
             end
-            uppercase(jobz)[1] == 'V' ? (W, A) : W
+            uppercase(jobz) == 'V' ? (W, A) : W
         end
+        _jl_lapack_syev(jobz::Char, uplo::Char, A::StridedMatrix{$elty}) = _jl_lapack_syev(uint8(jobz),uint8(uplo),A)
         
         #      SUBROUTINE DGEEV( JOBVL, JOBVR, N, A, LDA, WR, WI, VL, LDVL, VR,
         #      $                  LDVR, WORK, LWORK, INFO )
@@ -322,7 +324,7 @@ for (syev, geev, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), VL( LDVL, * ), VR( LDVR, * ),
         #      $                   WI( * ), WORK( * ), WR( * )
-        function _jl_lapack_geev(jobvl::String, jobvr::String, A::StridedMatrix{$elty})
+        function _jl_lapack_geev(jobvl::Uint8, jobvr::Uint8, A::StridedMatrix{$elty})
             if stride(A,1) != 1
                 error("_jl_lapack_geev: matrix columns must have contiguous elements");
             end
@@ -331,8 +333,8 @@ for (syev, geev, elty) in
                 error("_jl_lapack_geev: matrix for eigen-decomposition must be square")
             end
             lda   = stride(A, 2)
-            lvecs = uppercase(jobvl)[1] == 'V'
-            rvecs = uppercase(jobvr)[1] == 'V'
+            lvecs = uppercase(jobvl) == 'V'
+            rvecs = uppercase(jobvr) == 'V'
             VL    = Array($elty, lvecs ? (n, n) : (n, 0))
             VR    = Array($elty, rvecs ? (n, n) : (n, 0))            
             n     = n
@@ -356,7 +358,7 @@ for (syev, geev, elty) in
                            Ptr{Int32}, Ptr{$elty}, Ptr{$elty}, Ptr{Int32}, 
                            Ptr{$elty}, Ptr{Int32}, Ptr{$elty}, Ptr{Int32},
                            Ptr{Rtyp}, Ptr{Int32}),
-                          jobvl, jobvr, &n, A, &lda, W, VL, &n, VR, &n,
+                          &jobvl, &jobvr, &n, A, &lda, W, VL, &n, VR, &n,
                           work, &lwork, rwork, info)
                 else
                     ccall(dlsym(_jl_liblapack, $string(geev)),
@@ -365,7 +367,7 @@ for (syev, geev, elty) in
                            Ptr{Int32}, Ptr{$elty}, Ptr{$elty}, Ptr{$elty},
                            Ptr{Int32}, Ptr{$elty}, Ptr{Int32}, Ptr{$elty},
                            Ptr{Int32}, Ptr{Int32}),
-                          jobvl, jobvr, &n, A, &lda, WR, WI, VL, &n,
+                          &jobvl, &jobvr, &n, A, &lda, WR, WI, VL, &n,
                           VR, &n, work, &lwork, info)
                 end
                 if info[1] != 0 throw(LapackException(info[1])) end
@@ -376,16 +378,17 @@ for (syev, geev, elty) in
             end
             cmplx ? (VL, W, VR) : (VL, WR, WI, VR)
         end
+        _jl_lapack_geev(jobvl::Char, jobvr::Char, A::StridedMatrix{$elty}) = _jl_lapack_geev(uint8(jobvl),uint8(jobvr), A)
     end
 end
 
 eig{T<:Integer}(x::StridedMatrix{T}) = eig(float64(x))
 
 function eig{T<:Union(Float64,Float32,Complex128,Complex64)}(A::StridedMatrix{T})
-    if ishermitian(A) return _jl_lapack_syev("V","U",copy(A)) end
+    if ishermitian(A) return _jl_lapack_syev('V','U',copy(A)) end
                                         # Only compute right eigenvectors
-    if iscomplex(A) return _jl_lapack_geev("N","V",copy(A))[2:3] end
-    VL, WR, WI, VR = _jl_lapack_geev("N","V",copy(A))
+    if iscomplex(A) return _jl_lapack_geev('N','V',copy(A))[2:3] end
+    VL, WR, WI, VR = _jl_lapack_geev('N','V',copy(A))
     if all(WI .== 0.) return WR, VR end
     n = size(A, 2)
     evec = complex(zeros(T, n, n))
@@ -410,7 +413,7 @@ function trideig(d::Vector{Float64}, e::Vector{Float64})
           Void,
           (Ptr{Uint8}, Ptr{Int32}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64},
           Ptr{Int32}, Ptr{Float64}, Ptr{Int32}),
-          "N", &numel(d), dcopy, ecopy, &0.0, &numel(d), &0.0, &0)
+          &uint8('N'), &numel(d), dcopy, ecopy, &0.0, &numel(d), &0.0, &0)
     dcopy
 end
 
@@ -431,13 +434,13 @@ for (gesvd, gesdd, elty) in
         #      INTEGER            IWORK( * )
         #      DOUBLE PRECISION   A( LDA, * ), S( * ), U( LDU, * ),
         #                        VT( LDVT, * ), WORK( * )
-        function _jl_lapack_gesdd(jobz::String, A::StridedMatrix{$elty})
+        function _jl_lapack_gesdd(jobz::Uint8, A::StridedMatrix{$elty})
             if stride(A,1) != 1
                 error("_jl_lapack_gesdd: matrix columns must have contiguous elements");
             end
             m, n   = size(A)
             minmn  = min(m, n)
-            job    = uppercase(jobz)[1]
+            job    = uppercase(jobz)
             if job == 'A'
                 U  = Array($elty, (m, m))
                 VT = Array($elty, (n, n))
@@ -468,7 +471,7 @@ for (gesvd, gesdd, elty) in
                            Ptr{Int32}, Ptr{$elty}, Ptr{$elty}, Ptr{Int32},
                            Ptr{$elty}, Ptr{Int32}, Ptr{$elty}, Ptr{Int32},
                            Ptr{Rtyp}, Ptr{Int32}, Ptr{Int32}),
-                          jobz, &m, &n, A, &lda, S, U, &m, VT, &n,
+                          &jobz, &m, &n, A, &lda, S, U, &m, VT, &n,
                           work, &lwork, rwork, iwork, info)
                 else
                     ccall(dlsym(_jl_liblapack, $string(gesdd)),
@@ -477,7 +480,7 @@ for (gesvd, gesdd, elty) in
                            Ptr{Int32}, Ptr{$elty}, Ptr{$elty}, Ptr{Int32},
                            Ptr{$elty}, Ptr{Int32}, Ptr{$elty}, Ptr{Int32},
                            Ptr{Int32}, Ptr{Int32}),
-                          jobz, &m, &n, A, &lda, S, U, &m, VT, &n,
+                          &jobz, &m, &n, A, &lda, S, U, &m, VT, &n,
                           work, &lwork, iwork, info)
                 end
                 if info[1] != 0 throw(LapackException(info[1])) end
@@ -489,6 +492,8 @@ for (gesvd, gesdd, elty) in
             if job == 'O' if m >= n return (A, S, VT) else return (U, S, A) end end
             return (U, S, VT)
         end
+        _jl_lapack_gesdd(jobz::Char, A::StridedMatrix{$elty}) = _jl_lapack_gesvd(uint8(jobz), A)
+
 
         # SUBROUTINE DGESVD( JOBU, JOBVT, M, N, A, LDA, S, U, LDU, VT, LDVT, WORK, LWORK, INFO )
         # *     .. Scalar Arguments ..
@@ -497,15 +502,15 @@ for (gesvd, gesdd, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), S( * ), U( LDU, * ),
         #      $                   VT( LDVT, * ), WORK( * )
-        function _jl_lapack_gesvd(jobu, jobvt, A::StridedMatrix{$elty})
+        function _jl_lapack_gesvd(jobu::Uint8, jobvt::Uint8, A::StridedMatrix{$elty})
             if stride(A,1) != 1
                 error("_jl_lapack_gesvd: matrix columns must have contiguous elements");
             end
             m, n   = size(A)
             minmn  = min(m, n)          # can't map to int32 b/c of U and VT
-            j1     = uppercase(jobu)[1]
+            j1     = uppercase(jobu)
             U      = Array($elty, j1 == 'A'? (m, m):(j1 == 'S'? (m, minmn) : (m, 0)))
-            j2     = uppercase(jobvt)[1]
+            j2     = uppercase(jobvt)
             VT     = Array($elty, j2 == 'A'? (n, n):(j2 == 'S'? (n, minmn) : (n, 0)))
             lda    = stride(A, 2)
             lwork  = -1
@@ -523,7 +528,7 @@ for (gesvd, gesdd, elty) in
                            Ptr{$elty}, Ptr{Int32}, Ptr{$elty}, Ptr{$elty},
                            Ptr{Int32}, Ptr{$elty}, Ptr{Int32}, Ptr{$elty},
                            Ptr{Int32}, Ptr{Rtyp}, Ptr{Int32}),
-                          jobu, jobvt, &m, &n, A, &lda, S, U, &m, VT, &n,
+                          &jobu, &jobvt, &m, &n, A, &lda, S, U, &m, VT, &n,
                           work, &lwork, rwork, info)
                 else
                     ccall(dlsym(_jl_liblapack, $string(gesvd)),
@@ -532,7 +537,7 @@ for (gesvd, gesdd, elty) in
                            Ptr{$elty}, Ptr{Int32}, Ptr{$elty}, Ptr{$elty},
                            Ptr{Int32}, Ptr{$elty}, Ptr{Int32}, Ptr{$elty},
                            Ptr{Int32}, Ptr{Int32}),
-                          jobu, jobvt, &m, &n, A, &lda, S, U, &m, VT, &n,
+                          &jobu, &jobvt, &m, &n, A, &lda, S, U, &m, VT, &n,
                           work, &lwork, info)
                 end
                 if info[1] != 0 throw(LapackException(info[1])) end
@@ -545,14 +550,16 @@ for (gesvd, gesdd, elty) in
             if j2 == 'O' return U, S, A end
             U, S, VT
         end
+        _jl_lapack_gesvd(jobu::Char, jobvt::Char, A::StridedMatrix{$elty}) = _jl_lapack_gesvd(uint8(jobu), uint8(jobvt), A)
     end
 end
 
-function sdd{T<:Union(Float64,Float32,Complex128,Complex64)}(A::StridedMatrix{T},vecs::String)
+function sdd{T<:Union(Float64,Float32,Complex128,Complex64)}(A::StridedMatrix{T},vecs::Uint8)
     _jl_lapack_gesdd(vecs, copy(A))
 end
-sdd(A) = sdd(A, "A")
-sdd{T<:Integer}(x::StridedMatrix{T},vecs) = sdd(float64(x),vecs)
+sdd{T<:Integer}(x::StridedMatrix{T},vecs::Uint8) = sdd(float64(x),vecs)
+sdd(A,vecs::Char)=sdd(A,uint8(vecs))
+sdd(A) = sdd(A, 'A')
 
 svd(A) = svd(A,true)
 svdvals(A) = svd(A,false)[2]
@@ -560,7 +567,7 @@ svdvals(A) = svd(A,false)[2]
 svd{T<:Integer}(x::StridedMatrix{T},vecs) = svd(float64(x),vecs)
 
 function svd{T<:Union(Float64,Float32,Complex128,Complex64)}(A::StridedMatrix{T},vecs::Bool)
-    _jl_lapack_gesvd(vecs ? "A" : "N", vecs ? "A" : "N", copy(A))
+    _jl_lapack_gesvd(vecs ? 'A' : 'N', vecs ? 'A' : 'N', copy(A))
 end
 
 # direct solvers
@@ -604,7 +611,7 @@ for (gesv, posv, gels, trtrs, elty) in
         #      INTEGER            INFO, LDA, LDB, N, NRHS
         #     .. Array Arguments ..
         #      DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
-        function _jl_lapack_posv(uplo::String, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
+        function _jl_lapack_posv(uplo::Uint8, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
             if stride(A,1) != 1 || stride(B,1) != 1
                 error("_jl_lapack_posv: matrix columns must have contiguous elements");
             end
@@ -619,16 +626,18 @@ for (gesv, posv, gels, trtrs, elty) in
                   Void,
                   (Ptr{Uint8}, Ptr{Int32}, Ptr{Int32}, Ptr{$elty}, Ptr{Int32},
                    Ptr{$elty}, Ptr{Int32}, Ptr{Int32}),
-                  uplo, &n, &nrhs, A, &lda, B, &ldb, info)
+                  &uplo, &n, &nrhs, A, &lda, B, &ldb, info)
             if info[1] != 0 throw(LapackException(info[1])) end
             A, B
         end
+        _jl_lapack_posv(uplo::Char, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty}) =
+            _jl_lapack_posv(uint8(uplo), A,B)
 
         #      SUBROUTINE DGELS( TRANS, M, N, NRHS, A, LDA, B, LDB, WORK, LWORK, INFO)
         # *     .. Scalar Arguments ..
         #       CHARACTER          TRANS
         #       INTEGER            INFO, LDA, LDB, LWORK, M, N, NRHS
-        function _jl_lapack_gels(trans, A::StridedMatrix{$elty},
+        function _jl_lapack_gels(trans::Uint8, A::StridedMatrix{$elty},
                                  B::StridedVecOrMat{$elty})
             if stride(A,1) != 1 || stride(B,1) != 1
                 error("_jl_lapack_gels: matrix columns must have contiguous elements");
@@ -649,7 +658,7 @@ for (gesv, posv, gels, trtrs, elty) in
                       (Ptr{Uint8}, Ptr{Int32}, Ptr{Int32}, Ptr{Int32},
                        Ptr{$elty}, Ptr{Int32}, Ptr{$elty}, Ptr{Int32},
                        Ptr{$elty}, Ptr{Int32}, Ptr{Int32}),
-                      trans, &m, &n, &nrhs, A, &lda, B, &ldb, work, &lwork, info)
+                      &trans, &m, &n, &nrhs, A, &lda, B, &ldb, work, &lwork, info)
                 if info[1] != 0 throw(LapackException(info[1])) end
                 if lwork < 0
                     lwork = int32(real(work[1]))
@@ -661,6 +670,10 @@ for (gesv, posv, gels, trtrs, elty) in
             RSS     = vecb ? sum(B[(n+1):m].^2) : [sum(B[(n+1):m, i].^2) for i=1:n]
             R, X, RSS
         end
+        _jl_lapack_gels(trans::Char, A::StridedMatrix{$elty},
+                                 B::StridedVecOrMat{$elty}) =
+            _jl_lapack_gels(uint8(trans), A,B)
+
 
         #      SUBROUTINE DTRTRS( UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO )
         # *     .. Scalar Arguments ..
@@ -668,7 +681,7 @@ for (gesv, posv, gels, trtrs, elty) in
         #       INTEGER            INFO, LDA, LDB, N, NRHS
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
-        function _jl_lapack_trtrs(uplo::String, trans::String, diag::String,
+        function _jl_lapack_trtrs(uplo::Uint8, trans::Uint8, diag::Uint8,
                                   A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
             if stride(A,1) != 1 || stride(B,1) != 1
                 error("_jl_lapack_trtrs: matrix columns must have contiguous elements");
@@ -684,10 +697,13 @@ for (gesv, posv, gels, trtrs, elty) in
                   Void,
                   (Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{Int32}, Ptr{Int32},
                    Ptr{$elty}, Ptr{Int32}, Ptr{$elty}, Ptr{Int32}, Ptr{Int32}),
-                  uplo, trans, diag, &n, &nrhs, A, &lda, B, &ldb, info)
+                  &uplo, &trans, &diag, &n, &nrhs, A, &lda, B, &ldb, info)
             if info[1] != 0 throw(LapackException(info[1])) end
             B
         end
+        _jl_lapack_trtrs(uplo::Char, trans::Char, diag::Char,
+                         A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty}) =
+            _jl_lapack_trtrs(uint8(uplo),uint8(trans),uint8(diag),A,B)
     end
 end
 
@@ -697,12 +713,12 @@ function (\){T<:Union(Float64,Float32,Complex128,Complex64)}(A::StridedMatrix{T}
     X     = copy(B)
 
     if m == n # Square
-        if istriu(A) return _jl_lapack_trtrs("U", "N", "N", Acopy, X) end
-        if istril(A) return _jl_lapack_trtrs("L", "N", "N", Acopy, X) end
+        if istriu(A) return _jl_lapack_trtrs('U', 'N', 'N', Acopy, X) end
+        if istril(A) return _jl_lapack_trtrs('L', 'N', 'N', Acopy, X) end
                                         # Check for SPD matrix
         if ishermitian(Acopy) && all([ Acopy[i,i] > 0 for i=1:n ]) 
             try
-                _jl_lapack_posv("U", Acopy, X)
+                _jl_lapack_posv('U', Acopy, X)
                 return X
             catch e
                 if !isa(e, LapackException) throw(e) end
@@ -712,7 +728,7 @@ function (\){T<:Union(Float64,Float32,Complex128,Complex64)}(A::StridedMatrix{T}
         end
         return _jl_lapack_gesv(Acopy, X)[3]
     end
-    _jl_lapack_gels("N", Acopy, X)[2]
+    _jl_lapack_gels('N', Acopy, X)[2]
 end
 
 (\){T1<:Real, T2<:Real}(A::StridedMatrix{T1}, B::StridedVecOrMat{T2}) = (\)(float64(A), float64(B))

--- a/base/string.jl
+++ b/base/string.jl
@@ -465,6 +465,9 @@ end
 uppercase(c::Char) = ccall(:towupper, Char, (Char,), c)
 lowercase(c::Char) = ccall(:towlower, Char, (Char,), c)
 
+uppercase(c::Uint8) = ccall(:toupper, Uint8, (Uint8,), c)
+lowercase(c::Uint8) = ccall(:tolower, Uint8, (Uint8,), c)
+
 uppercase(s::String) = TransformedString((c,i)->uppercase(c), s)
 lowercase(s::String) = TransformedString((c,i)->lowercase(c), s)
 

--- a/test/lapack.jl
+++ b/test/lapack.jl
@@ -10,7 +10,7 @@ b = rand(n)
 r = chol(asym)                          # Cholesky decomposition
 @assert norm(r'*r - asym) < Eps
 
-l = chol!(copy(asym), "L")              # lower-triangular Cholesky decomposition
+l = chol!(copy(asym), 'L')              # lower-triangular Cholesky decomposition
 @assert norm(l*l' - asym) < Eps
 
 (l,u,p) = lu(a)                         # LU decomposition


### PR DESCRIPTION
I noticed that we were using Strings all over the place in the lapack interface while only the first character is needed, so I changed the API to us Chars and/or Uint8s instead. Just wanted to make sure this is ok with everybody before committing (particularly @dmbates  and @ViralBShah).
