### PR TITLE
Fix rgb2hsi in image.jl

### DIFF
--- a/extras/image.jl
+++ b/extras/image.jl
@@ -808,12 +808,12 @@ function rgb2hsi{T}(img::Array{T})
     G = img[:,:,2]
     B = img[:,:,3]
     H = acos((1/2*(2*R - G - B)) ./ (((R - G).^2 + (R - B).*(G - B)).^(1/2)+eps(T))) 
-    H[B > G] = 2*pi - H[B > G]
+    H[B .> G] = 2*pi - H[B .> G]
     H /= 2*pi
     rgb_sum = R + G + B
-    rgb_sum[rgb_sum == 0] = eps(T)
+    rgb_sum[rgb_sum .== 0] = eps(T)
     S = 1 - 3./(rgb_sum).*min(R, G, B)
-    H[S == 0] = 0
+    H[S .== 0] = 0
     I = 1/3*(R + G + B)
     return cat(3, H, S, I)
 end


### PR DESCRIPTION
Use element-wise array comparison operations for undefined operations.
