### PR TITLE
Make $PATH changes permanent in Linux (Ubuntu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Once it is built, you can either run the `julia` executable using its full path 
 
 In bash:
 
-    export PATH="$(pwd):$PATH"
+    echo "export PATH='$(pwd):$PATH'" >> ~/.bashrc
     
 In csh / tcsh:
 
@@ -195,7 +195,7 @@ For example, if you are on an OS X (Darwin) x86/64 system, do the following:
 
 You can either run the `julia` executable using its full path in the directory created above, or add that directory to your executable path so that you can run the julia program from anywhere:
 
-    export PATH="$(pwd)/julia:$PATH"
+    echo "export PATH='$(pwd):$PATH'" >> ~/.bashrc
 
 Now you should be able to run julia like this:
 


### PR DESCRIPTION
Maybe this isn't true for other distributions (I'm no Linux guru), but in Ubuntu the only way to make the export command's changes to $PATH stick is to add it to .bashrc so that it is executed every time a shell is started. Since Ubuntu is the distribution with more users, it makes sense to at least mention this method.
