### PR TITLE
Fix typo in sysimg

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -123,7 +123,7 @@ export
     remote_call,remote_call_fetch,remote_call_wait,remote_do,repeat,
     repl_show,replace,repmat,reshape,reverse,reverse!,rfft,rfftn,rot180,rot90,
     rotl90,rotr90,round,rpad,rr2id,rref,rstrip,run,safe_char,scan,search,
-    searchsorted,sec,secd,sech,seek,select,select!,select_read,serialize,
+    search_sorted,sec,secd,sech,seek,select,select!,select_read,serialize,
     setenv,setfield,setsuccess,shift,show,showall,showcompact,shuffle,shuffle!,
     sign,signbit,signed,significand,similar,sin,sinc,sind,sinh,size,sizeof,skip,
     sleep,slice,slicedim,sort,sort!,sort_by,sort_by!,sortperm,sortr,sortr!,


### PR DESCRIPTION
Probably got missed when searchsorted was renamed to search_sorted.
