### PR TITLE
Optional download and build of Clang and Compiler-RT when LLVM is built. 

### DIFF
--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,5 +1,7 @@
 /root
 /llvm-*
+/clang-*
+/compiler-rt-*
 /readline-*
 !readline-win.h
 /pcre-*

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -16,6 +16,10 @@ LIGHTTPD_VER = 1.4.29
 GMP_VER=5.0.5
 GLPK_VER = 4.47
 
+## optional packages ##
+# set to 1 to get clang and compiler-rt
+BUILD_LLVM_CLANG = 0
+
 ## high-level setup ##
 
 JULIAHOME = $(abspath ..)
@@ -121,11 +125,46 @@ else
 LLVM_TAR=llvm-$(LLVM_VER).src.tar.gz
 endif
 
+ifneq ($(BUILD_LLVM_CLANG), 1)
+LLVM_CLANG_TAR=
+LLVM_COMPILER_RT_TAR=
+else
+
+ifeq ($(LLVM_VER), 3.0)
+LLVM_CLANG_TAR=clang-$(LLVM_VER).tar.gz
+LLVM_COMPILER_RT_TAR=
+else
+LLVM_CLANG_TAR=clang-$(LLVM_VER).src.tar.gz
+LLVM_COMPILER_RT_TAR=compiler-rt-$(LLVM_VER).src.tar.gz
+endif
+
+endif
+
+ifneq ($(LLVM_CLANG_TAR),)
+$(LLVM_CLANG_TAR):
+	$(WGET) http://llvm.org/releases/$(LLVM_VER)/$@
+endif
+
+ifneq ($(LLVM_COMPILER_RT_TAR),)
+$(LLVM_COMPILER_RT_TAR):
+	$(WGET) http://llvm.org/releases/$(LLVM_VER)/$@
+endif
+
+
 $(LLVM_TAR):
 	$(WGET) http://llvm.org/releases/$(LLVM_VER)/$@
-llvm-$(LLVM_VER)/configure: $(LLVM_TAR) 
+
+llvm-$(LLVM_VER)/configure: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR)
 	mkdir -p llvm-$(LLVM_VER) && \
-	tar -C llvm-$(LLVM_VER) --strip-components 1 -xf $<
+	tar -C llvm-$(LLVM_VER) --strip-components 1 -xf $(LLVM_TAR)
+ifneq ($(LLVM_CLANG_TAR),)
+	mkdir -p llvm-$(LLVM_VER)/tools/clang && \
+	tar -C llvm-$(LLVM_VER)/tools/clang --strip-components 1 -xf $(LLVM_CLANG_TAR)
+endif
+ifneq ($(LLVM_COMPILER_RT_TAR),)
+	mkdir -p llvm-$(LLVM_VER)/projects/compiler-rt && \
+	tar -C llvm-$(LLVM_VER)/projects/compiler-rt --strip-components 1 -xf $(LLVM_COMPILER_RT_TAR)
+endif
 	touch $@
 
 ## LLVM needs python 2.x, but doesn't check for it, so we have to use an ugly workaround to make it compile
@@ -152,7 +191,7 @@ clean-llvm:
 	$(MAKE) -C llvm-$(LLVM_VER) clean
 	rm -f $(USRBIN)/llvm-config
 distclean-llvm:
-	rm -rf llvm-$(LLVM_VER).tar.gz llvm-$(LLVM_VER).src.tar.gz llvm-$(LLVM_VER)
+	rm -rf llvm-$(LLVM_VER).tar.gz llvm-$(LLVM_VER).src.tar.gz clang-$(LLVM_VER).src.tar.gz clang-$(LLVM_VER).tar.gz compiler-rt-$(LLVM_VER).src.tar.gz llvm-$(LLVM_VER)
 
 ## GNU readline ##
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2261,13 +2261,18 @@ extern "C" void jl_init_codegen(void)
     llvm::NoFramePointerElim = true;
     llvm::NoFramePointerElimNonLeaf = true;
 #elif LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 1
-    EngineBuilder builder = EngineBuilder(jl_Module).setEngineKind(EngineKind::JIT);
-    jl_ExecutionEngine = builder.create(jl_TargetMachine=builder.selectTarget());
+    EngineBuilder builder = EngineBuilder(jl_Module);
+    builder.setEngineKind(EngineKind::JIT);
+    jl_TargetMachine = builder.selectTarget();
+
+    //jl_TargetMachine->Options.PrintMachineCode = true; //Print machine code produced during JIT compiling
 #ifdef DEBUG
     jl_TargetMachine->Options.JITEmitDebugInfo = true;
 #endif 
     jl_TargetMachine->Options.NoFramePointerElim = true;
     jl_TargetMachine->Options.NoFramePointerElimNonLeaf = true;
+
+    jl_ExecutionEngine = builder.create(jl_TargetMachine);
 #endif
     
     dbuilder = new DIBuilder(*jl_Module);


### PR DESCRIPTION
Added option in deps/Makefile to download and build Clang (the LLVM C/C++ compiler) and Compiler-RT used by Clang 3.1. This is activated by setting 
BUILD_LLVM_CLANG = 0 
in deps/Makefile to 
BUILD_LLVM_CLANG = 1
