### PR TITLE
(re-)fix bash export command in Binary Installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ For example, if you are on an OS X (Darwin) x86/64 system, do the following:
 
 You can either run the `julia` executable using its full path in the directory created above, or add that directory to your executable path so that you can run the julia program from anywhere (in the current shell session):
 
-    export PATH="$(pwd):$PATH"
+    export PATH="$(pwd)/julia:$PATH"
 
 Now you should be able to run julia like this:
 


### PR DESCRIPTION
In my last pull request I proposed to "harmonize" the two bash export commands that were used in this file, but actually the context of the second one is different (it isn't suggested to cd into the julia directory before, while in the first example it is). This commit restores the correct command. Sorry for the confusion.
