### PR TITLE
RFC: Pretty printing for AST:s

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -68,6 +68,24 @@ end
 show_comma_array(io, itr, o, c) = show_delim_array(io, itr, o, ',', c, false)
 show(io, t::Tuple) = show_delim_array(io, t, '(', ',', ')', true)
 
+## Expr decoding helpers ##
+
+is_expr(ex, head::Symbol) = (isa(ex, Expr) && (ex.head == head))
+is_expr(ex, head::Symbol, n::Int) = is_expr(ex, head) && length(ex.args) == n
+
+is_linenumber(ex::LineNumberNode) = true
+is_linenumber(ex::Expr)           = is(ex.head, :line)
+is_linenumber(ex)                 = false
+
+is_quoted(ex::QuoteNode) = true
+is_quoted(ex::Expr)      = is_expr(ex, :quote, 1)
+is_quoted(ex)            = false
+
+unquoted(ex::QuoteNode) = ex.value
+unquoted(ex::Expr)      = ex.args[1]
+
+## AST printing ##
+
 function show_expr_type(io, ty)
     if !is(ty, Any)
         if is(ty, Function)
@@ -80,74 +98,125 @@ function show_expr_type(io, ty)
     end
 end
 
-function show(io, e::Expr)
-    hd = e.head
-    if is(hd,:call)
-        print(io, e.args[1])
-        show_comma_array(io, e.args[2:],'(',')')
-    elseif is(hd,:(=))
-        print(io, "$(e.args[1]) = $(e.args[2])")
-    elseif is(hd,:null)
+show_linenumber(io::IO, line)       = print(io,"\t#  line ",line,':')
+show_linenumber(io::IO, line, file) = print(io,"\t#  ",file,", line ",line,':')
+
+show(io::IO, e::SymbolNode) = (print(io, e.name); show_expr_type(io, e.typ))
+show(io::IO, e::LineNumberNode) = show_linenumber(io, e.line)
+show(io::IO, e::LabelNode)      = print(io, e.label, ": ")
+show(io::IO, e::GotoNode)       = print(io, "goto ", e.label)
+show(io::IO, e::TopNode)        = print(io, "top(", e.name, ')')
+show(io::IO, e::QuoteNode)      = show_quoted_expr(io, e.value)
+
+# Show arguments of a block, and then body
+function show_body(io::IO, args::Vector, body)
+    print(io, indent(
+            comma_list(args...),
+            defer_io(show_body_lines, body)
+        ))
+end
+show_body(io::IO, body)      = show_body(io, {},    body)
+show_body(io::IO, arg, body) = show_body(io, {arg}, body)
+defer_show_body(args...) = defer_io(show_body, args...)
+
+# Show the body of a :block
+function show_body_lines(io::IO, ex)
+    args = is_expr(ex, :block) ? ex.args : {ex}
+    for arg in args
+        if !is_linenumber(arg); print(io, '\n'); end
+        show(io, arg)
+    end
+end
+
+const _expr_infix = Set(
+    :(+=), :(-=), :(*=), :(/=), :(\=), :(&=), :(|=), :($=), 
+    :(>>>=), :(>>=), :(<<=),
+    :(=), :(:), :(<:), :(->), :(=>), :(&&), :(||), symbol("::"))
+const _expr_calls  = {:ref =>('[',']'), :curly =>('{','}'), :call=>('(',')')}
+const _expr_parens = {:vcat=>('[',']'), :cell1d=>('{','}')}
+
+function show(io::IO, ex::Expr)
+    head = ex.head
+    args = ex.args
+    nargs = length(args)
+
+    if is(head, :(.))
+        print(io, indent(args[1], '.'))
+        if is_quoted(args[2]); show(io, unquoted(args[2]))
+        else print(io, paren_block(defer_show(args[2])))
+        end
+    elseif has(_expr_infix, head) && nargs == 2       # infix operations
+        print(io, indent(defer_show(args[1]), head, defer_show(args[2])))
+    elseif is(head, :tuple)
+        if nargs == 1; print(io, paren_block(defer_show(args[1]), ','))
+        else           print(io, paren_block(comma_list(args...)))
+        end
+    elseif has(_expr_parens, head)                # :vcat/:cell1d
+        print(io, _expr_parens[head][1], 
+              indent(comma_list(args...)),
+              _expr_parens[head][2])
+    elseif has(_expr_calls, head) && nargs >= 1  # :call/:ref/:curly
+        show(io, args[1]); 
+        print(io, _expr_calls[head][1], 
+              indent(comma_list(args[2:end]...)),
+              _expr_calls[head][2])
+    elseif is(head, :comparison) && nargs >= 2    # :comparison
+        print(io, paren_block({defer_show(arg) for arg in args}...))
+    elseif is(head, :(...)) && nargs == 1
+        show(io, args[1]); print(io, "...")
+    elseif (nargs == 1 && contains([:return, :abstract, :const], head)) ||
+                          contains([:local, :global], head)
+        print(io, head, ' ', indent(comma_list(args...)))
+    elseif is(head, :typealias) && nargs == 2
+        print(io, head, ' ', indent(
+            defer_show(args[1]), ' ', defer_show(args[2])
+        ))
+    elseif is(head, :quote) && nargs == 1       # :quote
+        show_quoted_expr(io, args[1])
+    elseif is(head, :line) && (1 <= nargs <= 2) # :line
+        show_linenumber(io, args...)
+    elseif is(head, :if) && nargs == 3  # if/else
+        print(io, 
+            "if ",     defer_show_body(args[1], args[2]),
+            "\nelse ", defer_show_body(args[3]),
+            "\nend")
+    elseif is(head, :try) && nargs == 3 # try[/catch]
+        print(io, "try ", defer_show_body(args[1]))
+        if !(is(args[2], false) && is_expr(args[3], :block, 0))
+            print(io, "\ncatch ", defer_show_body(args[2], args[3]))
+        end
+        print(io, "\nend")
+    elseif is(head, :let)               # :let 
+        print(io, "let ", defer_show_body(args[2:end], args[1]), "\nend")
+    elseif is(head, :block)
+        print(io, "begin ", defer_show_body(ex), "\nend")
+    elseif contains([:for, :while, :function, :if, :type], head) && nargs == 2
+        print(io, head, ' ', defer_show_body(args[1], args[2]), "\nend")
+    elseif is(head, :null)
         print(io, "nothing")
-    elseif is(hd,:gotoifnot)
-        print(io, "unless $(e.args[1]) goto $(e.args[2])")
-    elseif is(hd,:return)
-        print(io, "return $(e.args[1])")
-    elseif is(hd,:string)
-        show(io, e.args[1])
-    elseif is(hd,symbol("::"))
-        show(io, e.args[1])
-        print(io, "::")
-        show(io, e.args[2])
-    elseif is(hd,:quote)
-        show_quoted_expr(io, e.args[1])
-    elseif is(hd,:body) || is(hd,:block)
-        println(io, "\nbegin")
-        for a in e.args
-            print(io, "  ")
-            show(io, a)
-            println(io)
-        end
-        println(io, "end")
-    elseif is(hd,:comparison)
-        for a in e.args
-            show(io, a)
-        end
-    elseif is(hd,:(.))
-        show(io, e.args[1])
-        print(io, '.')
-        show(io, e.args[2])
+    elseif is(head, :gotoifnot)
+        print(io, "unless ", defer_show(args[1]), " goto ",defer_show(args[2]))
+    elseif is(head, :string)
+        show(io, args[1])
     else
-        print(io, hd)
-        show_comma_array(io, e.args,'(',')')
+        print(io, head, paren_block(comma_list(args...)))
     end
-    show_expr_type(io, e.typ)
+    show_expr_type(io, ex.typ)
 end
 
-show(io, e::SymbolNode) = (print(io, e.name); show_expr_type(io, e.typ))
-show(io, e::LineNumberNode) = print(io, "line($(e.line))")
-show(io, e::LabelNode) = print(io, "$(e.label): ")
-show(io, e::GotoNode) = print(io, "goto $(e.label)")
-show(io, e::TopNode) = print(io, "top($(e.name))")
-show(io, e::QuoteNode) = show_quoted_expr(io, e.value)
-
-function show_quoted_expr(io, a1)
-    if isa(a1,Expr) && (is(a1.head,:body) || is(a1.head,:block))
-        println(io, "\nquote")
-        for a in a1.args
-            print(io, "  ")
-            show(io, a)
-            println(io, )
-        end
-        println(io, "end")
-    else
-        if isa(a1,Symbol) && !is(a1,:(:)) && !is(a1,:(==))
-            print(io, ":$a1")
-        else
-            print(io, ":($a1)")
-        end
+# show ex as if it were quoted
+function show_quoted_expr(io::IO, sym::Symbol)
+    if is(sym,:(:)) || is(sym,:(==)); print(io, ":($sym)")        
+    else                              print(io, ":$sym")        
     end
 end
+function show_quoted_expr(io::IO, ex::Expr)
+    if is(ex.head, :block); print(io, "quote ", defer_show_body(ex), "\nend")
+    else                    print(io, "quote",  paren_block(defer_show(ex)))
+    end
+end
+show_quoted_expr(io::IO, ex) = print(io, ':', paren_block(defer_show(ex)))
+
 
 function show(io, e::TypeError)
     ctx = isempty(e.context) ? "" : "in $(e.context), "
@@ -670,3 +739,71 @@ end
 
 show(io, v::AbstractVector{Any}) = show_vector(io, v, "{", "}")
 show(io, v::AbstractVector)      = show_vector(io, v, "[", "]")
+
+
+## Deferred IO for formatting etc ##
+
+# Canned io action: print(io, defer_io(f, rest_args...))
+# does the same as f(io, rest_args...)
+defer_io(f, rest_args...) = DeferredIO(f, rest_args)
+
+defer_print()        = ""
+defer_print(arg)     = arg
+defer_print(args...) = defer_io(print, args...)
+defer_show(arg)      = defer_io(show,  arg)
+
+indent(arg)          = Indented(arg)
+indent(args...)      = Indented(defer_print(args...))
+
+paren_block(args...) = defer_print('(', indent(args...), ')')
+
+comma_list()         = ""
+comma_list(args...)  = defer_io(show_comma_list, args...)
+
+
+type DeferredIO
+    f::Function
+    rest_args::Tuple
+end
+print(io::IO, d::DeferredIO) = d.f(io, d.rest_args...)
+
+type Indented
+    item  # value to be printed indented
+end
+
+function show_comma_list(io::IO, first, rest...)
+    show(io, first)
+    for arg in rest; print(io, ", "); show(io, arg); end
+end
+show_comma_list(io::IO) = nothing
+
+
+## IndentIO: indentation aware wrapper IO ##
+
+const indent_width = 4
+
+type IndentIO <: IO
+    sink::IO
+    indent::Integer  # current indentation
+end
+IndentIO(sink::IO) = IndentIO(sink, 0)
+
+print(io::IO, ind::Indented) = print(IndentIO(io), ind)
+function print(io::IndentIO, ind::Indented)
+    io.indent += indent_width
+    print(io, ind.item)
+    io.indent -= indent_width
+    nothing
+end
+function print(io::IndentIO, c::Char)
+    print(io.sink, c)
+    if (c == '\n'); print(io.sink, " "^io.indent); end
+end
+
+# Capture character output and send it to print(::IndentIO, ::Char)
+write(io::IndentIO, x::Uint8)       = print(io, char(x))
+write(io::IndentIO, s::ASCIIString) = (for c in s; print(io, c); end)
+# Work around some types that do funky stuff in show()
+show(io::IndentIO, x::Float32) = print(io, string(x))
+show(io::IndentIO, x::Float64) = print(io, string(x))
+show(io::IndentIO, x::Symbol)  = print(io, string(x))

--- a/base/show.jl
+++ b/base/show.jl
@@ -3,7 +3,8 @@
 show(x) = show(OUTPUT_STREAM::IOStream, x)
 
 print(io::IOStream, s::Symbol) = ccall(:jl_print_symbol, Void, (Ptr{Void}, Any,), io, s)
-show(io, x) = ccall(:jl_show_any, Void, (Any, Any,), io::IOStream, x)
+show(io, x) = isa(io,IOStream) ? ccall(:jl_show_any, Void, (Any,Any,), io, x) :
+              print(io, repr(x))
 
 showcompact(io, x) = show(io, x)
 showcompact(x)     = showcompact(OUTPUT_STREAM::IOStream, x)


### PR DESCRIPTION
Here's a tryout of AST prettyprinting.

I really think it should be reliable. Perhaps there exists some `show` method out there that sends outputs to `IO` in a way I haven't anticipated; if you'd stick such an object into an AST you'd probably get a no method error.

I've slimmed down the support machinery considerably, 
but you guys will have to say if I should try to slim it even more/do things in a different way.

Here's a short example: https://gist.github.com/3312906

Any feedback appreciated!

_Edit:_ Added a simple fallback for `show` on non-`IOStream` io:s. Should save some trouble testing it.
Alternatively, I could put in `default_show` as in the `recshow` RFC https://github.com/JuliaLang/julia/pull/1139.
