### PR TITLE
Call Grisu.print_shortest in dlmwrite

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -165,7 +165,7 @@ function dlmwrite(io, a::Matrix, dlm::Char)
         for j = 1:nc
             elt = a[i,j]
             if isa(elt,Float)
-                print_shortest(io, elt)
+                Grisu.print_shortest(io, elt)
             else
                 print(io, elt)
             end


### PR DESCRIPTION
print_shortest got moved into the Grisu module so add the Grisu. prefix
when calling it from dlmwrite to avoid a print_shortest not defined
error message.
