### PR TITLE
RFC: move implementation of dlopen into Julia

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -110,7 +110,11 @@ const isimmutable = x->(isa(x,Tuple) || isa(x,Symbol) ||
 
 dlsym(hnd, s::String) = ccall(:jl_dlsym, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
 dlsym(hnd, s::Symbol) = ccall(:jl_dlsym, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
-dlopen(s::String) = ccall(:jl_load_dynamic_library, Ptr{Void}, (Ptr{Uint8},), s)
+jl_uv_dlopen(s::String, h::Ptr{Void}) = ccall(:jl_uv_dlopen, Int32, (Ptr{Uint8}, Ptr{Void}), s, h)
+function dlclose(handle::Ptr{Void})
+    ccall(:uv_dlclose, Void, (Ptr{Void},), handle)
+    c_free(handle)
+end
 
 identity(x) = x
 

--- a/base/dlload.jl
+++ b/base/dlload.jl
@@ -1,0 +1,63 @@
+
+if CURRENT_OS == :OSX
+    const DL_EXTENSIONS = ["", ".dylib"]
+elseif CURRENT_OS == :Windows
+    const DL_EXTENSIONS = ["", ".dll"]
+else
+    const DL_EXTENSIONS = [".so", ""]
+end
+
+const DL_LOAD_PATH = ["$JULIA_HOME/../lib", ]
+
+function dlopen(s::String)
+    handle = ccall(:malloc, Ptr{Void}, (Uint,), 
+        ccall(:jl_sizeof_uv_lib_t, Uint, ()))
+    statbuf = Array(Uint8, ccall(:jl_sizeof_stat, Int, ()))
+    @windows_only begin
+        if s[2] == ':'
+            errno = jl_uv_dlopen(s, handle)
+            if errno == 0
+                return handle
+            end
+        end
+    end
+    @unix_only begin
+        if s[1] == '/'
+            errno = jl_uv_dlopen(s, handle)
+            if errno == 0
+                ## Can't register finalizers on BitsKinds
+                #finalizer(handle, dlclose)
+                return handle
+            end
+        end
+    end
+    for ext in DL_EXTENSIONS
+        for dir in DL_LOAD_PATH
+            path = "$(dir)/$(s)$(ext)"
+            errno = jl_uv_dlopen(path, handle)
+            if errno == 0
+                return handle
+            else
+                # isfile() won't be defined yet, so we make our own
+                err = ccall(:jl_stat, Int32, (Ptr{Uint8},Ptr{Uint8}), path, statbuf)
+                if (err == 0 && ccall(:jl_stat_mode, Uint, (Ptr{Uint8},), statbuf) & 0xf000 == 0x8000)
+                    msg = "could not load module $s: " * bytestring(ccall(:uv_dlerror, Ptr{Uint8}, (Ptr{Void},), handle))
+                    dlclose(handle)
+                    error(msg)
+                end
+            end
+        end
+        path = "$s$ext"
+        errno = jl_uv_dlopen(path, handle)
+        if errno == 0
+            ## Can't register finalizers on BitsKinds
+            #finalizer(handle, dlclose)
+            return handle
+        end
+    end
+    
+    msg = "could not load module $s: " * bytestring(ccall(:uv_dlerror, Ptr{Uint8}, (Ptr{Void},), handle))
+    dlclose(handle)
+    error(msg)
+end
+

--- a/base/start_image.jl
+++ b/base/start_image.jl
@@ -1,7 +1,10 @@
 # set up non-serializable state
 
 # restore shared library handles
-_jl_lib = ccall(:jl_load_dynamic_library,Ptr{Void},(Ptr{None},),C_NULL)
+_jl_lib = ccall(:malloc, Ptr{Void}, (Uint,), 
+        ccall(:jl_sizeof_uv_lib_t, Uint, ()))
+@assert ccall(:jl_uv_dlopen, Int32, (Ptr{Void}, Ptr{Void}), C_NULL, _jl_lib) == 0
+
 @unix_only _jl_repl = _jl_lib
 @windows_only _jl_repl = ccall(:GetModuleHandleA,stdcall,Ptr{Void},(Ptr{Void},),C_NULL)
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -235,6 +235,7 @@ include("tuple.jl")
 include("cell.jl")
 include("expr.jl")
 include("error.jl")
+include("osutils.jl")
 
 # core numeric operations & types
 include("bool.jl")
@@ -244,8 +245,10 @@ include("promotion.jl")
 include("operators.jl")
 include("pointer.jl")
 
-_jl_lib = ccall(:jl_load_dynamic_library,Ptr{Void},(Ptr{None},),C_NULL)
-_jl_libfdm = dlopen("libfdm")
+_jl_lib = ccall(:malloc, Ptr{Void}, (Uint,), 
+        ccall(:jl_sizeof_uv_lib_t, Uint, ()))
+ccall(:jl_uv_dlopen, Int32, (Ptr{Void}, Ptr{Void}), C_NULL, _jl_lib)
+_jl_libfdm = ccall(:c_dlopen, Ptr{Void}, (Ptr{Uint8},), "libfdm") # dlopen isn't defined yet
 
 include("float.jl")
 include("reduce.jl")
@@ -269,6 +272,7 @@ include("char.jl")
 include("ascii.jl")
 include("utf8.jl")
 include("string.jl")
+include("dlload.jl")
 include("regex.jl")
 include("show.jl")
 include("grisu.jl")
@@ -282,7 +286,6 @@ include("serialize.jl")
 include("multi.jl")
 
 # system & environment
-include("osutils.jl")
 include("libc.jl")
 include("env.jl")
 include("errno_h.jl")

--- a/src/init.c
+++ b/src/init.c
@@ -126,7 +126,9 @@ void julia_init(char *imageFile)
 {
     jl_page_size = sysconf(_SC_PAGESIZE);
     jl_find_stack_bottom();
-    jl_dl_handle = jl_load_dynamic_library(NULL);
+	
+    jl_dl_handle = malloc(sizeof(uv_lib_t));
+	jl_uv_dlopen(NULL, jl_dl_handle);
 
 #if defined(__linux__)
     int ncores = jl_cpu_cores();

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -67,10 +67,7 @@
     jl_array_grow_beg;
     jl_array_del_beg;
     jl_array_ptr;
-    jl_sizeof_off_t;
-    jl_sizeof_ios_t;
     jl_stdout_stream;
-    jl_sizeof_stat;
     jl_stat;
     jl_lstat;
     jl_fstat;
@@ -128,8 +125,6 @@
     connect_to_host;
     open_any_tcp_port;
     getlocalip;
-    jl_sizeof_fd_set;
-    jl_sizeof_timeval;
     jl_set_timeval;
     jl_fd_clr;
     jl_fd_isset;
@@ -221,7 +216,10 @@
     jl_defer_signal;
     jl_register_toplevel_eh;
     jl_dump_function;
-    uv_exepath;
+    c_dlopen;
+    uv_*;
+    jl_uv_*;
+    jl_sizeof_*;
   local:
     *;
 };

--- a/src/julia.h
+++ b/src/julia.h
@@ -811,7 +811,7 @@ jl_function_t *jl_get_expander(jl_module_t *m, jl_sym_t *macroname);
 void jl_set_expander(jl_module_t *m, jl_sym_t *macroname, jl_function_t *f);
 
 // external libraries
-DLLEXPORT uv_lib_t *jl_load_dynamic_library(char *fname);
+DLLEXPORT int jl_uv_dlopen(const char *fname, uv_lib_t* lib);
 DLLEXPORT void *jl_dlsym(uv_lib_t *handle, char *symbol);
 
 // compiler


### PR DESCRIPTION
This should give expanded flexibility, such as allowing for run-time search paths (currently named Base.DL_LOAD_PATH), should allow issue #949 to be implemented entirely in Julia, etc.
