### PR TITLE
Added support, bindings for readdir() using libuv.

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -237,3 +237,38 @@ function download_file(url::String)
   run(`curl -o $filename $url`)
   filename
 end
+
+function readdir(path::String)
+  path = tilde_expand(path)
+
+  # Allocate space for uv_fs_t struct
+  uv_readdir_req = zeros(Uint8, ccall(:jl_sizeof_uv_fs_t, Int, ()))
+
+  # defined in sys.c, to call uv_fs_readdir
+  file_count = ccall(:jl_readdir, Int, (Ptr{Uint8}, Ptr{Uint8}), 
+                     bytestring(path), uv_readdir_req)
+
+  if file_count < 0
+    error("Unable to read directory $path.")
+  end
+
+  # The list of dir entries is returned as a contiguous sequence of null-terminated
+  # strings, the first of which is pointed to by ptr in uv_readdir_req.
+  # The following lines extracts those strings into dirent
+  entries = String[]
+  offset = 0
+
+  for i = 1:file_count
+    entry = bytestring(ccall(:jl_uv_fs_t_ptr_offset, Ptr{Uint8}, 
+                             (Ptr{Uint8}, Int), uv_readdir_req, offset))
+    push(entries, entry)
+    offset += strlen(entry) + 1   # offset to the next entry
+  end
+
+  # Clean up the request string
+  ccall(:jl_uv_fs_req_cleanup, Void, (Ptr{Uint8},), uv_readdir_req)
+
+  entries
+end
+
+readdir() = readdir(".")

--- a/base/file.jl
+++ b/base/file.jl
@@ -239,8 +239,6 @@ function download_file(url::String)
 end
 
 function readdir(path::String)
-  path = tilde_expand(path)
-
   # Allocate space for uv_fs_t struct
   uv_readdir_req = zeros(Uint8, ccall(:jl_sizeof_uv_fs_t, Int, ()))
 
@@ -271,4 +269,5 @@ function readdir(path::String)
   entries
 end
 
+readdir(cmd::Cmd) = readdir(string(cmd)[2:end-1])
 readdir() = readdir(".")

--- a/base/file.jl
+++ b/base/file.jl
@@ -260,7 +260,7 @@ function readdir(path::String)
     entry = bytestring(ccall(:jl_uv_fs_t_ptr_offset, Ptr{Uint8}, 
                              (Ptr{Uint8}, Int), uv_readdir_req, offset))
     push(entries, entry)
-    offset += strlen(entry) + 1   # offset to the next entry
+    offset += length(entry) + 1   # offset to the next entry
   end
 
   # Clean up the request string

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -174,7 +174,7 @@ export
     split_path, tilde_expand, mtime, ctime, stat, lstat, isfifo, ispath,
     ischardev, isdir, isblockdev, isfile, islink, issocket, issetuid,
     issetgid, issticky, isreadable, iswriteable, isexecutable, uperm,
-    gperm, operm, 
+    gperm, operm, readdir,
     # external processes
     cmd_stdin_stream,cmd_stdout_stream,cmds,connect,dup2,exec,fork,getpid,
     ignorestatus,make_pipe,other,output,pipeline_error,

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -70,6 +70,11 @@
     jl_sizeof_off_t;
     jl_sizeof_ios_t;
     jl_stdout_stream;
+    jl_sizeof_uv_fs_t;
+    jl_uv_fs_req_cleanup;
+    jl_readdir;
+    jl_uv_fs_t_ptr;
+    jl_uv_fs_t_ptr_offset;
     jl_sizeof_stat;
     jl_stat;
     jl_lstat;

--- a/src/sys.c
+++ b/src/sys.c
@@ -106,6 +106,22 @@ DLLEXPORT jl_value_t *jl_stdout_stream(void)
     return (jl_value_t*)a;
 }
 
+// --- dir/file stuff ---
+
+DLLEXPORT int jl_sizeof_uv_fs_t(void) { return sizeof(uv_fs_t); }
+DLLEXPORT void jl_uv_fs_req_cleanup(uv_fs_t* req) {
+  uv_fs_req_cleanup(req);
+}
+
+DLLEXPORT int jl_readdir(const char* path, uv_fs_t* readdir_req)
+{
+  // Note that the flags field is mostly ignored by libuv
+  return uv_fs_readdir(uv_default_loop(), readdir_req, path, 0 /*flags*/, NULL);
+}
+
+DLLEXPORT char* jl_uv_fs_t_ptr(uv_fs_t* req) {return req->ptr; }
+DLLEXPORT char* jl_uv_fs_t_ptr_offset(uv_fs_t* req, int offset) {return req->ptr + offset; }
+
 // --- stat ---
 DLLEXPORT int jl_sizeof_stat(void) { return sizeof(struct stat); }
 


### PR DESCRIPTION
Get a list of entries in a directory.  

With the libuv interface, it's not currently possible to get any additional information (vs., with readdir() on unix, you can get read a dirent struct, which includes the file type).  So all additional information will have to come from stat().  But at least it should be portable.  (I am not set up on Windows.  Could someone please test there?)  

Comments/concerns/suggestions welcome.

Kevin
