### PR TITLE
small fix for printf formatting of fixed precision reals (was broken for numbers less than 1.0)

### DIFF
--- a/base/printf.jl
+++ b/base/printf.jl
@@ -319,7 +319,7 @@ function _gen_f(flags::ASCIIString, width::Int, precision::Int, c::Char)
         end
     else
         if width > 1
-            padding = :($width-pt-neg)
+            padding = :($width-(pt > 0 ? pt : 1)-neg)
         end
     end
     # print space padding


### PR DESCRIPTION
- example code

``` julia
  @printf("[%3d, freq: %7.2f] %20.10f %20.10f %20.10f %20.10f\n", ...)
```
- original output
  
  <pre>
  [  0, freq:    0.00]         0.0000000000         0.0000000000          0.2267079565          0.2259631493
  [  1, freq:     0.50]          0.2326789510          0.2233023158                0.0000005542              0.0000248324
  [  2, freq:    1.00]         -0.3726641464         -0.3280467195          0.1073405732          0.1057050951
  [  3, freq:    1.50]         -0.7122304568         -0.2090250640               0.0000051333               0.0000044973
  </pre>
- new output
  
  <pre>
  [  0, freq:    0.00]         0.0000000000         0.0000000000         0.2267079565         0.2259631493
  [  1, freq:    0.50]         0.2326789510         0.2233023158         0.0000005542         0.0000248324
  [  2, freq:    1.00]        -0.3726641464        -0.3280467195         0.1073405732         0.1057050951
  [  3, freq:    1.50]        -0.7122304568        -0.2090250640         0.0000051333         0.0000044973
  </pre>
