### PR TITLE
Update doc/manual/strings.rst

### DIFF
--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -487,7 +487,7 @@ You can search for the index of a particular character using the
     5
 
     julia> strchr("xylophone", 'z')
-    char not found
+    0
 
 You can start the search for a character at a given offset by providing
 a third argument:
@@ -501,7 +501,7 @@ a third argument:
     7
 
     julia> strchr("xylophone", 'o', 8)
-    char not found
+    0
 
 Another handy string function is ``repeat``:
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -407,7 +407,7 @@ Strings
 
 .. function:: strchr(string, char[, i])
 
-   Return the index of ``char`` in ``string``, giving an error if not found. The third argument optionally specifies a starting index.
+   Return the index of ``char`` in ``string``, giving 0 if not found. The third argument optionally specifies a starting index.
 
 .. function:: lpad(string, n, p)
 


### PR DESCRIPTION
strchr now returns 0 (instead of an error) when no matches are found.
