### PR TITLE
Make memio rereadable.

### DIFF
--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -789,6 +789,7 @@ ios_t *ios_mem(ios_t *s, size_t initsize)
 {
     _ios_init(s);
     s->bm = bm_mem;
+    s->rereadable = 1;
     _buf_realloc(s, initsize);
     return s;
 }


### PR DESCRIPTION
I was messing around with memio, and found that re-reading or overwriting stuff I had previously written wasn't working.  I don't think this patch should hurt anything...

Aside: @pao (and anyone else interested), it struck me that memio might make a good basis for an alternative to strpack.jl.  Values could be serialized/deserialized just like reading from/writing to a file, and the read/write functions could take care of data alignment issues according to stream position.  Current io read/write functions already handle endianness.  The patch submitted here would allow the same struct to be deserialized after the function call by rewinding and reading values.  

There are details that would need to be worked out, and I don't have time to work on this right now, but I thought I would throw the idea out there in case someone wanted to explore.
