### PR TITLE
[RFC] c callbacks from Julia (proof-of-concept)

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -31,6 +31,9 @@ function pointer_to_array{T,N}(p::Ptr{T}, dims::NTuple{N,Int}, own::Bool)
     ccall(:jl_ptr_to_array, Array{T,N}, (Any, Ptr{T}, Any, Int32),
           Array{T,N}, p, dims, own)
 end
+ref(p::Ptr, i::Int) = arrayref(p,i)
+ref(p::Ptr, i::Integer) = arrayref(p,int(i))
+ref(p::Ptr) = arrayref(p,1)
 
 integer(x::Ptr) = convert(Uint, x)
 unsigned(x::Ptr) = convert(Uint, x)

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,7 +60,7 @@ julia_flisp.boot: julia-parser.scm julia-syntax.scm \
 	match.scm utils.scm jlfrontend.scm mk_julia_flisp_boot.scm flisp/libflisp.a
 	$(QUIET_FLISP) flisp/flisp ./mk_julia_flisp_boot.scm
 
-codegen.o codegen.do: intrinsics.cpp debuginfo.cpp cgutils.cpp ccall.cpp
+codegen.o codegen.do: intrinsics.cpp debuginfo.cpp cgutils.cpp ccall.cpp ccallback.cpp
 builtins.o builtins.do: table.c
 
 support/libsupport.a: support/*.h support/*.c

--- a/src/array.c
+++ b/src/array.c
@@ -363,14 +363,35 @@ jl_value_t *jl_arrayref(jl_array_t *a, size_t i)
 JL_CALLABLE(jl_f_arrayref)
 {
     JL_NARGS(arrayref, 2, 2);
-    JL_TYPECHK(arrayref, array, args[0]);
     JL_TYPECHK(arrayref, long, args[1]);
-    jl_array_t *a = (jl_array_t*)args[0];
-    size_t i = jl_unbox_long(args[1])-1;
-    if (i >= a->length) {
-        jl_errorf("ref array[%d]: index out of range", i+1);
+    if (jl_is_pointer(args[0])) {
+        void *a = (void*)jl_unbox_long(args[0]);
+        size_t i = jl_unbox_long(args[1])-1;
+        jl_type_t *el_type = (jl_type_t*)jl_tparam0(jl_typeof(args[0]));
+        jl_value_t *elt;
+        if (jl_is_bits_type(el_type)) {
+            size_t elsize = ((jl_bits_type_t*)el_type)->nbits/8;
+            elt = jl_new_bits((jl_bits_type_t*)el_type,
+                              &((char*)a)[i*elsize]);
+        }
+        else {
+            elt = ((jl_value_t**)a)[i];
+            if (elt == NULL) {
+                jl_raise(jl_undefref_exception);
+            }
+        }
+        return elt;
+    } else if (jl_is_array(args[0])) {
+        jl_array_t *a = (jl_array_t*)args[0];
+        size_t i = jl_unbox_long(args[1])-1;
+        if (i >= a->length) {
+            jl_errorf("ref array[%d]: index out of range", i+1);
+        }
+        return jl_arrayref(a, i);
+    } else {
+        jl_type_error("arrayref", (jl_value_t*)jl_array_type, args[0]);
+        return NULL;
     }
-    return jl_arrayref(a, i);
 }
 
 void jl_arrayset(jl_array_t *a, size_t i, jl_value_t *rhs)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -358,3 +358,5 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         return literal_pointer_val((jl_value_t*)jl_nothing);
     return mark_julia_type(result, rt);
 }
+
+

--- a/src/ccallback.cpp
+++ b/src/ccallback.cpp
@@ -1,0 +1,170 @@
+
+//make_callback(f::Function, rt::Any, tt::Tuple, call_conv::Union(Symbol,Nothing))
+extern "C" DLLEXPORT void *ccallback(jl_function_t *f, jl_value_t *rt, jl_tuple_t *tt, jl_sym_t *call_conv) {
+    JL_TYPECHK(make_callback, type, rt);
+    JL_TYPECHK(make_callback, tuple, (jl_value_t*)tt);
+    JL_TYPECHK(make_callback, type, (jl_value_t*)tt);
+
+    char *name;
+    if (f->linfo != NULL) {
+        size_t name_len = strlen(f->linfo->name->name) + 3;
+        name = (char*)alloca(name_len);
+        memcpy(name, f->linfo->name->name, name_len - 3);
+        memcpy(name + name_len - 3, "_cb", 4);
+    } else {
+        name = (char*)alloca(3);
+        memcpy(name,"_cb",4);
+    }
+
+    jl_codectx_t ctx;
+    ctx.f = NULL;
+    ctx.vars = NULL;
+    //ctx.arguments = &argumentMap;
+    ctx.passedArguments = NULL;
+    ctx.closureEnv = NULL;
+    ctx.isAssigned = NULL;
+    ctx.isCaptured = NULL;
+    ctx.escapes = NULL;
+    ctx.volatilevars = NULL;
+    ctx.declTypes = NULL;
+    ctx.labels = NULL;
+    ctx.savestates = NULL;
+    ctx.jmpbufs = NULL;
+    ctx.module = (f->linfo != NULL ? f->linfo->module : NULL);
+    ctx.ast = NULL;
+    ctx.sp = NULL;
+    ctx.linfo = f->linfo;
+    ctx.argArray = NULL;
+    ctx.argCount = 0;
+    ctx.funcName = name;
+    ctx.vaName = NULL;
+    ctx.vaStack = false;
+
+    Type *lrt = julia_type_to_llvm(rt, &ctx);
+    if (lrt == NULL) {
+        return literal_pointer_val(jl_nothing);
+    }
+    std::vector<Type *> fargt(0);
+    std::vector<jl_value_t *> fargjt(0);
+    std::vector<Type *> fargt_sig(0);
+    size_t i;
+    bool isVa = false;
+    int n_roots = jl_tuple_len(tt);
+    for(i=0; i < n_roots; i++) {
+        jl_value_t *tti = jl_tupleref(tt,i);
+        if (jl_is_seq_type(tti)) {
+            isVa = true;
+            tti = jl_tparam0(tti);
+        }
+        Type *t = julia_type_to_llvm(tti, &ctx);
+        if (t == NULL) {
+            return literal_pointer_val(jl_nothing);
+        }
+        fargt.push_back(t);
+        fargjt.push_back(tti);
+        if (!isVa)
+            fargt_sig.push_back(t);
+    }
+    
+    // check for calling convention specifier
+    CallingConv::ID cc = CallingConv::C;
+    if (call_conv == jl_symbol("stdcall")) {
+        cc = CallingConv::X86_StdCall;
+    } else if (call_conv == jl_symbol("cdecl")) {
+        cc = CallingConv::C;
+    } else if (call_conv == jl_symbol("fastcall")) {
+        cc = CallingConv::X86_FastCall;
+    } else if (call_conv != NULL && (jl_value_t*)call_conv != jl_nothing) {
+        jl_error("callback: invalid call convention");
+        return literal_pointer_val(jl_nothing);
+    }
+
+    Function *llvmf =
+        Function::Create(FunctionType::get(lrt, fargt_sig, isVa),
+                         Function::ExternalLinkage,
+                         name, jl_Module);
+    if (cc != CallingConv::C)
+        llvmf->setCallingConv(cc);
+    BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", llvmf);
+    builder.SetInsertPoint(b0);
+    
+    // TODO: Fix when moving to new LLVM version
+    const char * const filename = "callback.cpp";
+    dbuilder->createCompileUnit(0x01, filename, ".", "julia", true, "", 0); 
+    llvm::DIArray EltTypeArray = dbuilder->getOrCreateArray(ArrayRef<Value*>());
+    DIFile fil = dbuilder->createFile(filename, ".");
+    DISubprogram SP =
+        dbuilder->createFunction((DIDescriptor)dbuilder->getCU(),
+                                 name,
+                                 name,
+                                 fil,
+                                 0,
+                                 dbuilder->createSubroutineType(fil,EltTypeArray),
+                                 false, true,
+                                 0, true, f);
+    builder.SetCurrentDebugLocation(DebugLoc::get(0, 0, (MDNode*)SP, NULL));
+
+    // Emit return value boxes
+    ctx.argDepth = 0;
+    //ctx.maxDepth = 0;
+    ctx.argSpace = n_roots;
+#ifdef JL_GC_MARKSWEEP
+    AllocaInst *gcframe = NULL;
+#endif
+    Value *myargs;
+    Function::arg_iterator AI = llvmf->arg_begin();
+    std::vector<jl_value_t *>::iterator AIt = fargjt.begin();
+    if (n_roots > 0) {
+        ctx.argTemp = builder.CreateAlloca(jl_pvalue_llvmt,
+                                           ConstantInt::get(T_int32, n_roots));
+#ifdef JL_GC_MARKSWEEP
+        // create gc frame
+        gcframe = builder.CreateAlloca(T_gcframe, 0);
+        builder.CreateStore(builder.CreateBitCast(ctx.argTemp,
+                                                  PointerType::get(jl_ppvalue_llvmt,0)),
+                            builder.CreateConstGEP2_32(gcframe, 0, 0));
+        builder.CreateStore(ConstantInt::get(T_size, n_roots),
+                            builder.CreateConstGEP2_32(gcframe, 0, 1));
+        builder.CreateStore(ConstantInt::get(T_int32, 0),
+                            builder.CreateConstGEP2_32(gcframe, 0, 2));
+        builder.CreateStore(builder.CreateLoad(jlpgcstack_var, false),
+                            builder.CreateConstGEP2_32(gcframe, 0, 3));
+        builder.CreateStore(gcframe, jlpgcstack_var, false);
+        // initialize stack roots to null
+        for(i=0; i < (size_t)n_roots; i++) {
+            Value *argTempi = builder.CreateConstGEP1_32(ctx.argTemp,i);
+            builder.CreateStore(V_null, argTempi);
+        }
+#endif
+         // box values for function arguments
+        for(i=0; i < (size_t)n_roots; i++) {
+            Value *lv = builder.CreateConstGEP1_32(ctx.argTemp,i);
+            //LoadInst *theArg = builder.CreateLoad(argPtr, false);
+            Value *theArg = AI++;
+            //mark_julia_type(theArg, *AIt++);
+            builder.CreateStore(boxed(theArg), lv);
+        }
+        myargs = ctx.argTemp;
+    }
+    else {
+        ctx.argTemp = NULL;
+        myargs = Constant::getNullValue(jl_ppvalue_llvmt);
+    }
+    Value *result = builder.CreateCall3(jlapplygeneric_func, literal_pointer_val((jl_value_t*)f), myargs,
+                                        ConstantInt::get(T_int32,n_roots));
+#ifdef JL_GC_MARKSWEEP
+    // JL_GC_POP();
+    if (n_roots > 0) {
+        builder.CreateStore(builder.CreateLoad(builder.CreateConstGEP2_32(gcframe, 0, 3), false),
+                jlpgcstack_var);
+    }
+#endif
+    Value *retval = (lrt == jl_pvalue_llvmt ? result : emit_unbox(lrt, PointerType::get(lrt, 0), result));
+    builder.CreateRet(retval);
+    FPM->run(*llvmf);
+    void *fptr = jl_ExecutionEngine->getPointerToFunction(llvmf);
+    //llvmf->dump();
+    llvmf->deleteBody();
+    return fptr;
+}
+

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1025,7 +1025,7 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                 return mark_julia_type(elt, ety);
             }
         } else if (jl_is_cpointer_type(aty) && ity == (jl_value_t*)jl_long_type) {
-			jl_value_t *ety = jl_tparam0(aty);
+            jl_value_t *ety = jl_tparam0(aty);
             if (!jl_is_typevar(ety)) {
                 if (!jl_is_bits_type(ety)) {
                     ety = (jl_value_t*)jl_any_type;
@@ -1050,8 +1050,8 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                 if (isbool)
                     return builder.CreateTrunc(elt, T_int1);
                 return mark_julia_type(elt, ety);
-			}
-		}
+            }
+        }
     }
     else if (f->fptr == &jl_f_arrayset && nargs==3) {
         jl_value_t *aty = expr_type(args[1], ctx); rt1 = aty;

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -228,6 +228,7 @@
     jl_register_toplevel_eh;
     jl_dump_function;
     uv_exepath;
+    ccallback;
   local:
     *;
 };


### PR DESCRIPTION
reference issue #1096

This is a proof-of-concept showing a more complete interop between Julia and C code, allowing the creation of Julia callbacks that can be passed to arbitrary C code. There are several optimizations that can be made (i.e. I would like to make this an intrinsic so that it doesn't have to generate code at run-time), but the intended interface would be the same.

Here's some example code that I've been using for testing:

``` julia
ccallback(f::Function,t::Type,a::Tuple) = ccall(:ccallback, Ptr{Void}, (Function,Type,Tuple,Ptr{Void}), f, t, a, C_NULL)

f64 = ccall(:ccallback, Ptr{Void}, (Function,Type,Tuple,Nothing), float64, Float64, (Int,), nothing)
ccall(f64, Float64, (Int,), 1)

sh = ccall(:ccallback, Ptr{Void}, (Function,Type,Tuple,Nothing), show, Any, (Int,), nothing)
ccall(sh, Nothing, (Int,), 1)

sorti(a,b) = (b[] - a[])
qsort{T}(a::Vector{T}, f::Function) = ccall(:qsort, Void, (Ptr{T}, Int, Int, Ptr{Void}), a, length(a), sizeof(T), ccallback(f, Int32, (Ptr{T},Ptr{T})))
x = [3,12,5,25,2]
qsort(x,sorti)


add_one = ccall(:ccallback, Ptr{Void}, (Function,Type,Tuple,Nothing), square, Int, (Int,), nothing)
x = ccall(:compute_something, Uint, (Ptr{Void},), add_one)
# in C
#extern "C" DLLEXPORT long compute_something(long (*x)(long)) {
#    return x(-2)+1;
#}
```

Note that the garbage collector is not fully aware of the operation of these callbacks. Do not allow a julia object parameter to go out of scope.
