### PR TITLE
Adds seek_end command to seek to the end of an IOStream

### DIFF
--- a/base/export.jl
+++ b/base/export.jl
@@ -1031,6 +1031,7 @@ export
     readlines,
     readuntil,
     seek,
+    seek_end,
     select_read,
     serialize,
     skip,

--- a/base/io.jl
+++ b/base/io.jl
@@ -47,6 +47,10 @@ seek(s::IOStream, n::Integer) =
     (ccall(:ios_seek, FileOffset, (Ptr{Void}, FileOffset), s.ios, n)==0 ||
      error("seek failed"))
 
+seek_end(s::IOStream) =
+    (ccall(:ios_seek_end, FileOffset, (Ptr{Void},), s.ios)==0 ||
+     error("seek_end failed"))
+
 skip(s::IOStream, delta::Integer) =
     (ccall(:ios_skip, FileOffset, (Ptr{Void}, FileOffset), s.ios, delta)==0 ||
      error("skip failed"))

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -774,6 +774,12 @@ collection[key...] = value
 
 "),
 
+(E"I/O",E"seek_end",E"seek_end(s)
+
+   Seek a stream to the end.
+
+"),
+
 (E"I/O",E"skip",E"skip(s, offset)
 
    Seek a stream relative to the current position.

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -541,6 +541,10 @@ I/O
 
    Seek a stream to the given position.
 
+.. function:: seek_end(s)
+
+   Seek a stream to the end.
+
 .. function:: skip(s, offset)
 
    Seek a stream relative to the current position.

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -434,6 +434,7 @@ off_t ios_seek_end(ios_t *s)
         off_t fdpos = lseek(s->fd, 0, SEEK_END);
         if (fdpos == (off_t)-1)
             return fdpos;
+        s->fpos = fdpos;
         s->bpos = s->size = 0;
     }
     return 0;


### PR DESCRIPTION
Documentation and a stub for the already-implemented ios_seek_end(), and
a small change to the call to store fpos so that position() works
