### PR TITLE
Fix s_str macro in strpack.jl

### DIFF
--- a/extras/strpack.jl
+++ b/extras/strpack.jl
@@ -325,7 +325,7 @@ function interp_struct_parse(str::String)
 end
 
 macro s_str(str)
-    interp_struct_parse(eval(_jl_interp_parse(str)))
+    interp_struct_parse(str)
 end
 
 # Julian aliases for the "object-style" calls to pack/unpack/struct


### PR DESCRIPTION
Remove eval(_jl_interp_parse()) per
https://groups.google.com/d/topic/julia-dev/20b8hrSsQG4/discussion
