### PR TITLE
Fixed zlib tests, properly integrated with `make test`

### DIFF
--- a/test/extra.jl
+++ b/test/extra.jl
@@ -4,5 +4,6 @@ runtests("bigfloat")
 runtests("poly")
 runtests("file")
 runtests("Rmath")
+runtests("zlib")
 
 runtests("perf")


### PR DESCRIPTION
Fixes #1238.

```
~/src/julia/test$ make zlib
    JULIA test/zlib
     * zlib
    SUCCESS
~/src/julia/test$ make all
    JULIA test/all
     * all
     * core
     * numbers
     * strings
     * unicode
     * corelib
     * hashing
     * remote
     * arrayops
     * lapack
     * factorizations
     * fft
     * sparse
     * arpack
     * bitarray
     * random
     * special
     * functional
     * bigint
     * distributions
     * combinatorics
     * statistics
     * glpk
     * linprog
     * bigfloat
     * poly
     * file
     * Rmath
     * zlib
     * perf
    SUCCESS
```
