### PR TITLE
RFC: deep_copy proposal

### DIFF
--- a/base/deep_copy.jl
+++ b/base/deep_copy.jl
@@ -1,0 +1,67 @@
+# deep copying
+deep_copy(x) = _deep_copy(x, ObjectIdDict())
+
+_deep_copy(x::Union(Symbol,Function,LambdaStaticData,
+              TopNode,QuoteNode,BitsKind,CompositeKind,AbstractKind,
+              UnionKind), stackdict::ObjectIdDict) = x
+_deep_copy(x::Tuple, stackdict::ObjectIdDict) =
+    ntuple(length(x), i->_deep_copy(x[i], stackdict))
+_deep_copy(x::Module, stackdict::ObjectIdDict) = error("deep_copy of Modules not supported")
+
+function _deep_copy(x, stackdict::ObjectIdDict)
+    if has(stackdict, x)
+        return stackdict[x]
+    end
+    _deep_copy_t(x, typeof(x), stackdict)
+end
+
+_deep_copy_t(x, T::BitsKind, stackdict::ObjectIdDict) = x
+function _deep_copy_t(x, T::CompositeKind, stackdict::ObjectIdDict)
+    nf = length(T.names)
+    dc_field(i::Int, stackdict) = _deep_copy(x.(T.names[i]), stackdict)
+
+    ret = ccall(:jl_new_struct_uninit, Any, (Any,), T)
+    stackdict[x] = ret
+    for i=1:nf
+        try
+            ccall(:jl_set_nth_field, Any, (Any, Int, Any), ret, i-1, dc_field(i, stackdict))
+        catch err
+            # we ignore undefined references errors
+            if !isa(err, UndefRefError)
+                throw(err)
+            end
+        end
+    end
+    return ret
+end
+_deep_copy_t(x, T, stackdict::ObjectIdDict) =
+    error("deep_copy of objects of type ", T, " not supported")
+
+
+function _deep_copy(x::Array, stackdict::ObjectIdDict)
+    if has(stackdict, x)
+        return stackdict[x]
+    end
+    _deep_copy_array_t(x, eltype(x), stackdict)
+end
+
+_deep_copy_array_t(x, T::BitsKind, stackdict::ObjectIdDict) = copy(x)
+function _deep_copy_array_t(x, T, stackdict::ObjectIdDict)
+    dest = similar(x)
+    stackdict[x] = dest
+    for i=1:length(x)
+        try
+            # NOTE: this works around the performance problem caused by all
+            # the doubled definitions of assign()
+            arrayset(dest, i, _deep_copy(x[i], stackdict))
+        catch err
+            # we ignore undefined references errors
+            if !isa(err, UndefRefError)
+                throw(err)
+            end
+        end
+    end
+    return dest
+end
+
+

--- a/base/export.jl
+++ b/base/export.jl
@@ -897,6 +897,7 @@ export
     
 # object identity and equality
     copy,
+    deep_copy,
     isequal,
     isless,
     identity,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -121,6 +121,7 @@ include("mmap.jl")
 include("version.jl")
 include("util.jl")
 include("datafmt.jl")
+include("deep_copy.jl")
 
 ## Load optional external libraries
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -149,7 +149,7 @@ jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
                        (char*)v + offs);
 }
 
-jl_value_t *jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
+DLLEXPORT jl_value_t *jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
 {
     jl_struct_type_t *st = (jl_struct_type_t*)jl_typeof(v);
     size_t offs = jl_field_offset(st,i) + sizeof(void*);

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -136,6 +136,7 @@
     jl_new_array;
     jl_new_closure;
     jl_new_lambda_info;
+    jl_new_struct_uninit;
     jl_new_struct;
     jl_new_structt;
     jl_nothing;
@@ -166,6 +167,7 @@
     jl_set_current_module;
     jl_set_current_output_stream_obj;
     jl_set_global;
+    jl_set_nth_field;
     jl_set_timeval;
     jl_show;
     jl_show_any;


### PR DESCRIPTION
I needed a generic deep_copy function, so I wrote one based on serialization/deserialization which seems to work well:

```
julia> a = {{1,2},{3,4}};

julia> ca = copy(a); # standard shallow copy

julia> dca = deep_copy(a);

julia> ca[1] === a[1] # at depth > 1, only the pointer was copied
true

julia> dca[1] === a[1] # in this case we have a true copy
false
```

There seem to be very few objects which cannot be copied in this way yet (e.g. regex's):

```
julia> deep_copy(r"tst")
no method write(IOStream,Ptr{None})
 in method_missing at base.jl:70
 in serialize at serialize.jl:216
 in serialize at serialize.jl:226
 in deep_copy at operators.jl:138
```

Comments?
