### PR TITLE
two/three-argument round()

### DIFF
--- a/base/export.jl
+++ b/base/export.jl
@@ -467,6 +467,7 @@ export
     sign,
     signbit,
     signed,
+    signif,
     significand,
     sin,
     sinc,

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -57,3 +57,15 @@ end
 @vectorize_1arg Real isnan
 @vectorize_1arg Real isinf
 @vectorize_1arg Real isfinite
+
+# ported from Matlab File Exchange roundsd: http://www.mathworks.com/matlabcentral/fileexchange/26212
+# if method's not round, ceil, floor, or trunc, you're on your own
+function round(x::Real, digits, method)
+	if x != 0
+		og = 10 ^ floor(log10(abs(x)) - digits + 1)
+		method(x / og) * og
+	else
+		0
+	end
+end
+round(x, digits) = round(x, digits, round)

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -59,13 +59,13 @@ end
 @vectorize_1arg Real isfinite
 
 # ported from Matlab File Exchange roundsd: http://www.mathworks.com/matlabcentral/fileexchange/26212
-# if method's not round, ceil, floor, or trunc, you're on your own
-function round(x::Real, digits, method)
-	if x != 0
-		og = 10 ^ floor(log10(abs(x)) - digits + 1)
-		method(x / og) * og
-	else
-		0
-	end
-end
-round(x, digits) = round(x, digits, round)
+_round_og(x, digits) = 10. ^ floor(log10(abs(x)) - digits + 1.)
+for f in (:round, :ceil, :floor, :trunc)
+    @eval begin
+        function ($f)(x, digits)
+            og = _round_og(x, digits)
+            ($f)(x / og) * og
+        end
+    end #eval
+end # for
+


### PR DESCRIPTION
Note not vectorized. 
Also, arguably should be two-arg ceil/floor/trunc too? (calling three-arg round)
Is the performance hit for arg checking worthwhile?

``` julia
julia> round(pi)
3.0

julia> round(pi, 5)
3.1416

julia> round(123.456, 5)
123.46000000000001

julia> round(123.456, 2)
120.0

julia> round(123.456, 4, round)
123.5

julia> round(123.456, 4, floor)
123.4

julia> round(123.456, 4, ceil)
123.5

julia> round(123.456, 4, trunc)
123.4

julia> round(-123.456, 4, round)
-123.5

julia> round(-123.456, 4, floor)
-123.5

julia> round(-123.456, 4, ceil)
-123.4

julia> round(-123.456, 4, trunc)
-123.4

julia> round(123.456, 4, sin) # meaningless -- doesn't check args
0.008580721236705982

julia> round(123.456, 2.5) # YMMV
123.0

```
