### PR TITLE
deep copying Functions (and allow overriding)

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -1,14 +1,18 @@
 # deep copying
-deepcopy(x) = _deepcopy(x, ObjectIdDict())
 
-_deepcopy(x::Union(Symbol,Function,LambdaStaticData,
-                   TopNode,QuoteNode,BitsKind,CompositeKind,AbstractKind,
-                   UnionKind), stackdict::ObjectIdDict) = x
-_deepcopy(x::Tuple, stackdict::ObjectIdDict) =
-    ntuple(length(x), i->_deepcopy(x[i], stackdict))
-_deepcopy(x::Module, stackdict::ObjectIdDict) = error("deepcopy of Modules not supported")
+# Note: deepcopy_internal(::Any, ::ObjectIdDict) is
+#       only exposed for specialization by libraries
 
-function _deepcopy(x, stackdict::ObjectIdDict)
+deepcopy(x) = deepcopy_internal(x, ObjectIdDict())
+
+deepcopy_internal(x::Union(Symbol,LambdaStaticData,TopNode,QuoteNode,
+                  BitsKind,CompositeKind,AbstractKind,UnionKind),
+                  stackdict::ObjectIdDict) = x
+deepcopy_internal(x::Tuple, stackdict::ObjectIdDict) =
+    ntuple(length(x), i->deepcopy_internal(x[i], stackdict))
+deepcopy_internal(x::Module, stackdict::ObjectIdDict) = error("deepcopy of Modules not supported")
+
+function deepcopy_internal(x, stackdict::ObjectIdDict)
     if has(stackdict, x)
         return stackdict[x]
     end
@@ -17,14 +21,11 @@ end
 
 _deepcopy_t(x, T::BitsKind, stackdict::ObjectIdDict) = x
 function _deepcopy_t(x, T::CompositeKind, stackdict::ObjectIdDict)
-    nf = length(T.names)
-
     ret = ccall(:jl_new_struct_uninit, Any, (Any,), T)
     stackdict[x] = ret
-    for i=1:nf
+    for f in T.names
         try
-            ccall(:jl_set_nth_field, Any, (Any, Int, Any),
-                  ret, i-1, _deepcopy(x.(T.names[i]), stackdict))
+            ret.(f) = deepcopy_internal(x.(f), stackdict)
         catch err
             # we ignore undefined references errors
             if !isa(err, UndefRefError)
@@ -38,7 +39,7 @@ _deepcopy_t(x, T, stackdict::ObjectIdDict) =
     error("deepcopy of objects of type ", T, " not supported")
 
 
-function _deepcopy(x::Array, stackdict::ObjectIdDict)
+function deepcopy_internal(x::Array, stackdict::ObjectIdDict)
     if has(stackdict, x)
         return stackdict[x]
     end
@@ -55,7 +56,7 @@ function _deepcopy_array_t(x, T, stackdict::ObjectIdDict)
             for i=i0:length(x)
                 # NOTE: this works around the performance problem caused by all
                 # the doubled definitions of assign()
-                arrayset(dest, i, _deepcopy(x[i], stackdict))
+                arrayset(dest, i, deepcopy_internal(x[i], stackdict))
             end
             break
         catch err

--- a/base/export.jl
+++ b/base/export.jl
@@ -907,6 +907,7 @@ export
 # object identity and equality
     copy,
     deepcopy,
+    deepcopy_internal,
     isequal,
     isless,
     identity,

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -142,6 +142,15 @@
    an array produces a new array whose elements are deep-copies of the
    original elements.
 
+   While it isn't normally necessary, user-defined types can override
+   the default 'deepcopy' behavior by defining a specialized version
+   of the function 'deepcopy_internal(x::T, dict::ObjectIdDict)'
+   (which shouldn't otherwise be used), where 'T' is the type to be
+   specialized for, and 'dict' keeps track of objects copied so far
+   within the recursion. Within the definition, 'deepcopy_internal'
+   should be used in place of 'deepcopy', and the 'dict' variable
+   should be updated as appropriate before returning.
+
 "),
 
 (E"All Objects",E"convert",E"convert(type, x)
@@ -1808,21 +1817,35 @@ collection[key...] = value
 
 "),
 
+(E"Linear Algebra",E"lu",E"lu(A) -> LU
+
+   Compute LU factorization. LU is an 'LU factorization' type that can
+   be used as an ordinary matrix.
+
+"),
+
 (E"Linear Algebra",E"chol",E"chol(A)
 
    Compute Cholesky factorization
 
 "),
 
-(E"Linear Algebra",E"lu",E"lu(A) -> L, U, p
+(E"Linear Algebra",E"qr",E"qr(A)
 
-   Compute LU factorization
+   Compute QR factorization
 
 "),
 
-(E"Linear Algebra",E"qr",E"qr(A) -> Q, R, p
+(E"Linear Algebra",E"qrp",E"qrp(A)
 
-   Compute QR factorization
+   Compute QR factorization with pivoting
+
+"),
+
+(E"Linear Algebra",E"factors",E"factors(D)
+
+   Return the factors of a decomposition D. For an LU decomposition,
+   factors(LU) -> L, U, p
 
 "),
 
@@ -1859,6 +1882,20 @@ collection[key...] = value
 (E"Linear Algebra",E"diagm",E"diagm(v)
 
    Construct a diagonal matrix from a vector
+
+"),
+
+(E"Linear Algebra",E"Tridiagonal",E"Tridiagonal(dl, d, du)
+
+   Construct a tridiagonal matrix from the lower diagonal, diagonal,
+   and upper diagonal
+
+"),
+
+(E"Linear Algebra",E"Woodbury",E"Woodbury(A, U, C, V)
+
+   Construct a matrix in a form suitable for applying the Woodbury
+   matrix identity
 
 "),
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -85,6 +85,8 @@ All Objects
 
    Create a deep copy of ``x``: everything is copied recursively, resulting in a fully independent object. For example, deep-copying an array produces a new array whose elements are deep-copies of the original elements.
 
+   While it isn't normally necessary, user-defined types can override the default ``deepcopy`` behavior by defining a specialized version of the function ``deepcopy_internal(x::T, dict::ObjectIdDict)`` (which shouldn't otherwise be used), where ``T`` is the type to be specialized for, and ``dict`` keeps track of objects copied so far within the recursion. Within the definition, ``deepcopy_internal`` should be used in place of ``deepcopy``, and the ``dict`` variable should be updated as appropriate before returning.
+
 .. function:: convert(type, x)
 
    Try to convert ``x`` to the given type.

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -149,7 +149,7 @@ jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
                        (char*)v + offs);
 }
 
-DLLEXPORT jl_value_t *jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
+jl_value_t *jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
 {
     jl_struct_type_t *st = (jl_struct_type_t*)jl_typeof(v);
     size_t offs = jl_field_offset(st,i) + sizeof(void*);

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -168,7 +168,6 @@
     jl_set_current_module;
     jl_set_current_output_stream_obj;
     jl_set_global;
-    jl_set_nth_field;
     jl_set_timeval;
     jl_show;
     jl_show_any;


### PR DESCRIPTION
I changed my mind about deep-copying Functions: I think they should be deep-copied (explanation below), but even though I couldn't find any issue with doing that, I'm not 100% sure that it's completely safe, and that's the reason for the pull request.

The patch also allows overriding the default behaviour, exposing `deepcopy_internal` for that purpose. I'm not convinced about that name, but couldn't think of anything better.

The reason for deep-copying functions is that closures won't work properly otherwise. Example:

```
julia> type P
           i::Int
           incr::Function
           function P(i::Int)
               p = new(i)
               p.incr = ()->(p.i += 1)
               p
           end
       end

julia> p = P(0); p.i
0

julia> p.incr() # ok, not my favourite idiom either...
1

julia> q = deepcopy(p);

julia> q.incr() # increments p rather than q
2

julia> p.i
2

julia> q.i
1
```

The patch makes this work (just by removing Functions from the special group of immutables).
