### PR TITLE
add intrinsics for dereferencing pointers

### DIFF
--- a/base/export.jl
+++ b/base/export.jl
@@ -1220,6 +1220,8 @@ export
     ptr_arg_convert,
     setenv,
     strerror,
+    unsafe_ref,
+    unsafe_assign,
     unsetenv,
     
 # Macros

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -31,11 +31,17 @@ function pointer_to_array{T,N}(p::Ptr{T}, dims::NTuple{N,Int}, own::Bool)
     ccall(:jl_ptr_to_array, Array{T,N}, (Any, Ptr{T}, Any, Int32),
           Array{T,N}, p, dims, own)
 end
+unsafe_ref(p::Ptr,i::Integer) = Core.pointerref(p, int(i))
+unsafe_ref(p::Ptr) = unsafe_ref(p, 1)
+unsafe_assign(p::Ptr{Any}, x::ANY, i::Integer) = Core.pointerset(p, x, int(i))
+unsafe_assign{T}(p::Ptr{T}, x, i::Integer) = Core.pointerset(p, convert(T, x), int(i))
+unsafe_assign{T}(p::Ptr{T}, x) = unsafe_assign(p, convert(T,x), 1)
 
 integer(x::Ptr) = convert(Uint, x)
 unsigned(x::Ptr) = convert(Uint, x)
 
 @eval sizeof(::Type{Ptr}) = $div(WORD_SIZE,8)
+eltype{T}(::Ptr{T}) = T
 
 ## limited pointer arithmetic & comparison ##
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -361,3 +361,19 @@ begin
     @assert typeof(a) === SI{1,2,1}
     @assert typeof(b) === SI{1,-2,1}
 end
+
+# pull request 1270
+begin
+    local a,p, a2,p2
+    a = [11,12,13]
+    p = pointer(a)
+    @assert unsafe_ref(p, 1) == 11
+    unsafe_assign(p, 99, 2)
+    @assert a == [11,99,13]
+    a2 = Any[101,102,103]
+    p2 = pointer(a2)
+    @assert unsafe_ref(p2) == 101
+    unsafe_assign(p2, 909, 3)
+    @assert a2 == [101,102,909]
+end
+


### PR DESCRIPTION
This is intended to make use of ccall and ccallback slightly easier in some cases. This makes it idiomatic to dereference a value passed by reference from c as `x = p[]` or `x = p[1]`

The corresponding assignments also exist.

The use of both is discouraged, outside of interacting with c code.
