### PR TITLE
Update base/linalg_lapack.jl

### DIFF
--- a/base/linalg_lapack.jl
+++ b/base/linalg_lapack.jl
@@ -595,7 +595,7 @@ for (gesv, posv, gels, trtrs, elty) in
             end
             R       = triu(A[1:n,1:n])
             X       = vecb ? B[1:n] : B[1:n,:]
-            RSS     = vecb ? sum(B[(n+1):m].^2) : [sum(B[(n+1):m, i].^2) for i=1:n]
+            RSS     = vecb ? sum(B[(n+1):m].^2) : [sum(B[(n+1):m, i].^2) for i=1:nrhs]
             R, X, RSS
         end
 


### PR DESCRIPTION
Fixes a BoundsError() when solving a system AX=B where B has more than one column but less columns than A.
