### PR TITLE
tests and docs for round/signif functions

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -724,17 +724,25 @@ Mathematical Functions
 
    Accurately compute ``exp(x)-1``
 
-.. function:: ceil(x) -> FloatingPoint
+.. function:: round(x, digits, base) -> FloatingPoint
 
-   Returns the nearest integer not less than ``x``.
+   ``round(x)`` returns the nearest integer to ``x``. ``round(x, digits)`` rounds to the specified number of digits after the decimal place, or before if negative, e.g., ``round(pi,2)`` is ``3.14``. ``round(x, digits, base)`` rounds using a different base, defaulting to 10, e.g., ``round(pi, 3, 2)`` is ``3.125``.
 
-.. function:: floor(x) -> FloatingPoint
+.. function:: ceil(x, digits, base) -> FloatingPoint
 
-   Returns the nearest integer not greater than ``x``.
+   Returns the nearest integer not less than ``x``. ``digits`` and ``base`` work as above.
 
-.. function:: trunc(x) -> FloatingPoint
+.. function:: floor(x, digits, base) -> FloatingPoint
 
-   Returns the nearest integer not greater in magnitude than ``x``.
+   Returns the nearest integer not greater than ``x``. ``digits`` and ``base`` work as above.
+
+.. function:: trunc(x, digits, base) -> FloatingPoint
+
+   Returns the nearest integer not greater in magnitude than ``x``. ``digits`` and ``base`` work as above.
+
+.. function:: iround(x) -> Integer
+
+   Returns the nearest integer to ``x``.
 
 .. function:: iceil(x) -> Integer
 
@@ -748,7 +756,11 @@ Mathematical Functions
 
    Returns the nearest integer not greater in magnitude than ``x``.
 
-``exp2`` ``ldexp`` ``round`` ``iround`` ``min`` ``max`` ``clamp`` ``abs``
+.. function:: signif(x, digits, base) -> FloatingPoint
+
+   Rounds (in the sense of ``round``) ``x`` so that there are ``digits`` significant digits, under a base ``base`` representation, default 10. E.g., ``signif(123.456, 2)`` is ``120.0``, and ``signif(357.913, 4, 2)`` is ``352.0``. 
+
+``exp2`` ``ldexp`` ``min`` ``max`` ``clamp`` ``abs``
 
 .. function:: abs2(x)
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1033,3 +1033,39 @@ end
 @assert isa(0b11111111111111111,Uint32)
 @assert isa(0b11111111111111111111111111111111,Uint32)
 @assert isa(0b111111111111111111111111111111111,Uint64)
+
+# custom rounding and significant-digit ops
+function approx_eq(a, b, tol)
+    abs(a - b) < tol
+end
+approx_eq(a, b) = approx_eq(a, b, 1e-6)
+# rounding to digits relative to the decimal point 
+@assert approx_eq(round(pi,0), 3.)
+@assert approx_eq(round(pi,1), 3.1)
+@assert approx_eq(round(10*pi,-1), 30.)
+@assert round(.1,0) == 0.
+@assert round(-.1,0) == -0.
+@assert isnan(round(NaN, 2))
+@assert isinf(round(Inf,2))
+@assert isinf(round(-Inf,2))
+# round vs trunc vs floor vs ceil
+@assert approx_eq(round(123.456,1), 123.5)
+@assert approx_eq(round(-123.456,1), -123.5)
+@assert approx_eq(trunc(123.456,1), 123.4)
+@assert approx_eq(trunc(-123.456,1), -123.4)
+@assert approx_eq(ceil(123.456,1), 123.5)
+@assert approx_eq(ceil(-123.456,1), -123.4)
+@assert approx_eq(floor(123.456,1), 123.4)
+@assert approx_eq(floor(-123.456,1), -123.5)
+# rounding in other bases
+@assert approx_eq(round(pi,2,2), 3.25)
+@assert approx_eq(round(pi,3,2), 3.125)
+@assert approx_eq(round(pi,3,5), 3.144)
+# significant digits (would be nice to have a smart vectorized
+# version of signif)
+@assert approx_eq(signif(123.456,1), 100.)
+@assert approx_eq(signif(123.456,3), 123.)
+@assert approx_eq(signif(123.456,5), 123.46)
+@assert approx_eq(signif(123.456,8,2), 123.5)
+
+


### PR DESCRIPTION
tests and documentation for #1254, as promised. Note that the docs aren't tested, as I don't have the systems installed to do so, but it looks OK via eyeball. Also note that there are round cases that should work in theory (like truncating a near-maximal float) that don't work in practice because of implementation details. I don't know whether we should care or not. 
