### PR TITLE
Fix of matrix multiplication with zero dimension matrices

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -243,6 +243,7 @@ function _jl_gemm{T<:LapackScalar}(C::StridedMatrix{T}, tA, tB,
 
     if nA != mB; error("*: argument shapes do not match"); end
 
+    if nA == 0 return zeros(T, mA, nB); end
     if mA == 2 && nA == 2 && nB == 2; return matmul2x2(C,tA,tB,A,B); end
     if mA == 3 && nA == 3 && nB == 3; return matmul3x3(C,tA,tB,A,B); end
 

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -243,7 +243,7 @@ function _jl_gemm{T<:LapackScalar}(C::StridedMatrix{T}, tA, tB,
 
     if nA != mB; error("*: argument shapes do not match"); end
 
-    if nA == 0 return zeros(T, mA, nB); end
+    if any(mA == 0, nA == 0, nB == 0) return zeros(T, mA, nB); end
     if mA == 2 && nA == 2 && nB == 2; return matmul2x2(C,tA,tB,A,B); end
     if mA == 3 && nA == 3 && nB == 3; return matmul3x3(C,tA,tB,A,B); end
 


### PR DESCRIPTION
When one of the dimensions involved in a matrix multiplication is zero a zero matrix corresponding to the outer dimension of the multiplication is returned. This is already the behaviour under Julia compiled with openblas but under MKL it has caused error.
