### PR TITLE
WIP: linalg reorganization

### DIFF
--- a/base/blas.jl
+++ b/base/blas.jl
@@ -51,7 +51,7 @@ end
 #      INTEGER INCX,INCY,N
 #*     .. Array Arguments ..
 #      DOUBLE PRECISION DX(*),DY(*)
-for (fname, elty) in ((:daxpy_,:Float64), (:saxpy_,:Float32),
+for (fname, elty) in ((:daxpy_,:Float64),    (:saxpy_,:Float32),
                       (:zaxpy_,:Complex128), (:caxpy_,:Complex64))
     @eval begin
         function axpy!(n::Integer, a::($elty),

--- a/base/export.jl
+++ b/base/export.jl
@@ -622,7 +622,6 @@ export
     check_bounds, 
 
 # linear algebra
-    axpy,
     chol,
     chold,
     chold!,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -1,42 +1,4 @@
-## linalg.jl: Basic Linear Algebra interface specifications and
-## specialized matrix types
-
-#
-# This file mostly contains commented functions which are supposed
-# to be defined in type-specific linalg_<type>.jl files.
-#
-# It defines functions in cases where sufficiently few assumptions about
-# storage can be made.
-
-#Ac_mul_B(x::AbstractVector, y::AbstractVector)
-#At_mul_B{T<:Real}(x::AbstractVector{T}, y::AbstractVector{T})
-
-#dot(x::AbstractVector, y::AbstractVector)
-
-#cross(a::AbstractVector, b::AbstractVector)
-
-#(*){T,S}(A::AbstractMatrix{T}, B::AbstractVector{S})
-#(*){T,S}(A::AbstractVector{S}, B::AbstractMatrix{T})
-#(*){T,S}(A::AbstractMatrix{T}, B::AbstractMatrix{S})
-
-function axpy{TA<:Number, T<:LapackScalar}(alpha::TA, x::Array{T}, y::Array{T})
-    if length(x) != length(y)
-        error("Inputs should be of the same length")
-    end
-    Blas.axpy!(length(x), convert(T, alpha), x, 1, y, 1)
-    return y
-end
-
-function axpy{TA<:Number, T<:LapackScalar, TI<:Integer}(alpha::TA, x::Array{T}, rx::Union(Range1{TI},Range{TI}), y::Array{T}, ry::Union(Range1{TI},Range{TI}))
-    if length(rx) != length(ry)
-        error("Ranges should be of the same length")
-    end
-    if min(rx) < 1 || max(rx) > length(x) || min(ry) < 1 || max(ry) > length(y)
-        throw(BoundsError())
-    end
-    Blas.axpy!(length(rx), convert(T, alpha), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
-    return y
-end
+## copy_to
 
 function copy_to{T<:LapackScalar}(dest::Ptr{T}, src::Ptr{T}, n::Integer)
     if n < 200
@@ -49,9 +11,7 @@ end
 
 function copy_to{T<:LapackScalar}(dest::Array{T}, src::Array{T})
     n = numel(src)
-    if n > numel(dest)
-        throw(BoundsError())
-    end
+    if n > numel(dest); throw(BoundsError()); end
     if n < 200
         Blas.copy!(n, src, 1, dest, 1)
     else
@@ -60,7 +20,10 @@ function copy_to{T<:LapackScalar}(dest::Array{T}, src::Array{T})
     dest
 end
 
-function copy_to{T<:LapackScalar,TI<:Integer}(dest::Array{T}, rdest::Union(Range1{TI},Range{TI}), src::Array{T}, rsrc::Union(Range1{TI},Range{TI}))
+function copy_to{T<:LapackScalar,TI<:Integer}(dest::Array{T}, 
+                                              rdest::Union(Range1{TI},Range{TI}), 
+                                              src::Array{T}, 
+                                              rsrc::Union(Range1{TI},Range{TI}))
     if min(rdest) < 1 || max(rdest) > length(dest) || min(rsrc) < 1 || max(rsrc) > length(src)
         throw(BoundsError())
     end


### PR DESCRIPTION
I plan to accomplish the following on this branch, before merging it in:
1. We have a bunch of code to deal with matrix multiplication, which dispatches to julia written code or the BLAS. Much of this is in `linalg.jl`. I will create a `matmul.jl` and put all multiplication related stuff in there.
2. I am thinking of a better place for `copy_to` that is currently in `linalg.jl`. Perhaps it should go to `array.jl` or to `deepcopy.jl`.
3. Consolidate all the various `linalg*.jl` and `factorizations.jl` into `linalg.jl`.
4. Clean up the interface in `blas.jl` so that julia wrappers around BLAS functions do not need to pass information such as length of arrays and sizes that can be inferred from the array metadata, along the lines of what was done in `lapack.jl`.
5. General cleanup and pruning of unused stuff, and anything else that may come up in discussions here.
6. I am still debating whether all of this should live in a LinAlg module, like DSP and RNG (still in extras).
