### PR TITLE
better ispow2, nextpow2 and introduce prevpow2

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -133,11 +133,21 @@ function powermod(x::Integer, p::Integer, m::Integer)
     return r
 end
 
-# smallest power of 2 >= x
-nextpow2(x::Unsigned) = one(x)<<((sizeof(x)<<3)-leading_zeros(x-1))
-nextpow2(x::Integer) = oftype(x,x < 0 ? -nextpow2(unsigned(-x)) : nextpow2(unsigned(x)))
 
-ispow2(x::Integer) = (x&(x-1))==0
+# zero is not an integer power of 2
+ispow2(x::Unsigned) = (x != 0 == (x & (x-1)))
+ispow2(x::Signed  ) = (x < 0) ? ispow2(unsigned(-x)) : ispow2(unsigned(x))
+
+# largest power of 2 <= x
+prevpow2(x::Unsigned) = (one(x) >> (x==0)) << ((sizeof(x)<<3) - leading_zeros(x) - 1)
+prevpow2(x::Signed  ) =
+   oftype(x, (x < 0) ? prevpow2(unsigned(-x)) : prevpow2(unsigned(x)))
+
+# smallest power of 2 >= x
+nextpow2(x::Unsigned) = (one(x) >> (x==typemax(x)) << ((sizeof(x)<<3)-leading_zeros(x-1))
+nextpow2(x::Signed  ) =
+   oftype(x, (x < 0) ? nextpow2(unsigned(-x)) : nextpow2(unsigned(x)))
+
 
 # smallest integer n for which a^n >= x
 function nextpow(a, x)


### PR DESCRIPTION
This should be a clean pull request with changes only for ispow2, nextpow2 and adding prevpow2.
I have removed bitsizeof(x) and replaced it with (sizeof(x) << 3), pending consensus.

[bitsizeof(x) supports implementations where a byte is not an octet, e.g. a 16 bit smallest unit,
 and comports well with the existing leading_ones, etc functions that are bitcount based,
 whether or not this is worth adding bitsizeof into the base namespace is at question]

These versions are more faithful to the math than the prior versions.
They do not treat 0 as a power of two, and do not accept negative values as appropriate input.
