### PR TITLE
Automatically launch browser on Windows

### DIFF
--- a/ui/webserver/launch-julia-webserver.bat
+++ b/ui/webserver/launch-julia-webserver.bat
@@ -16,6 +16,7 @@ goto julia
 
 :julia
 echo "Connect to http://localhost:2000/ for the web REPL."
+start http://localhost:2000
 julia-release-webserver -p 2001 
 
 :end


### PR DESCRIPTION
Not sure if people think this would be helpful, but this will automagically open a browser to the julia web REPL when people double-click the `.bat` file.  Similar things could be done on OSX/Linux, but it seemed to me the most important place to start with something like this is Windows
