### PR TITLE
RFC: Include doc, examples and test in `make install` step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,13 @@ include $(JULIAHOME)/Make.inc
 all: default
 default: release
 
-DIRS = $(BUILD)/bin $(BUILD)/etc $(BUILD)/lib/julia
+DIRS = $(BUILD)/bin $(BUILD)/etc $(BUILD)/lib/julia $(BUILD)/share/julia
 
 $(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
-$(foreach link,extras base ui,$(eval $(call symlink_target,$(link),$(BUILD)/lib/julia)))
+$(foreach link,extras base ui test,$(eval $(call symlink_target,$(link),$(BUILD)/lib/julia)))
+$(foreach link,doc examples,$(eval $(call symlink_target,$(link),$(BUILD)/share/julia)))
 
-debug release: | $(DIRS) $(BUILD)/lib/julia/extras $(BUILD)/lib/julia/base $(BUILD)/lib/julia/ui
+debug release: | $(DIRS) $(BUILD)/lib/julia/extras $(BUILD)/lib/julia/base $(BUILD)/lib/julia/ui $(BUILD)/lib/julia/test $(BUILD)/share/julia/doc $(BUILD)/share/julia/examples
 	@$(MAKE) -s julia-$@
 	@$(MAKE) JULIA_EXECUTABLE=$(JULIA_EXECUTABLE_$@) -s $(BUILD)/lib/julia/sys.ji
 
@@ -36,6 +37,7 @@ OPENBLASNAME=openblas
 endif
 PREFIX ?= julia-$(JULIA_COMMIT)
 install: release
+	@$(MAKE) -sC test/unicode
 	mkdir -p $(PREFIX)/{sbin,bin,etc,lib/julia,share/julia}
 	cp $(BUILD)/bin/*julia* $(PREFIX)/bin
 	cd $(PREFIX)/bin && ln -s julia-release-$(DEFAULT_REPL) julia
@@ -45,6 +47,7 @@ install: release
 	-cp $(BUILD)/lib/mod* $(PREFIX)/lib
 	-cp $(BUILD)/sbin/* $(PREFIX)/sbin
 	-cp $(BUILD)/etc/* $(PREFIX)/etc
+	-cp $(BUILD)/share/* $(PREFIX)/share
 ifeq ($(OS), WINNT)
 	-cp dist/windows/* $(PREFIX)
 ifeq ($(shell uname),MINGW32_NT-6.1)


### PR DESCRIPTION
This is something that we've been doing in the Homebrew Formulae, and thought would be nice to merge back into the mainline Makefiles.  Essentially, this links {doc,examples} -> $BUILD/share/ and {test} -> $BUILD/lib/julia.  Also, `make -sC test/unicode` is done during the `make install` step so that all tests are ready to go anytime you want to `julia runtests.jl all` them.

I have this put as an RFC as this makes a lot of sense with the way I do my julia installs, but it may not make a lot of sense to other people, so I'm curious to hear your thoughts.
