### PR TITLE
Fixes the det function for CholeskyDense

### DIFF
--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -384,8 +384,8 @@ factors(C::CholeskyDense) = C.LR
 
 function det(C::CholeskyDense)
     ff = C.LR
-    dd = 0.
-    for i in 1:size(ff,1) dd += ff[i,i]^2 end
+    dd = 1.
+    for i in 1:size(ff,1) dd *= ff[i,i]^2 end
     dd
 end
     


### PR DESCRIPTION
The `det` function for the `CholeskyDense` type should be the product of the square of the diagonal elements (the previous function had it as the sum).
