### PR TITLE
Add Woodbury determinant

### DIFF
--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -901,10 +901,11 @@ end
 
 lud!{T}(A::Tridiagonal{T}) = LUTridiagonal{T}(Lapack.gttrf!(A.dl,A.d,A.du)...)
 lud{T}(A::Tridiagonal{T}) =
-    LUTridiagonal{T}(Lapack.gttrf!(copy(A.dl),copy(A.d),copy(A.du))...)
+ LUTridiagonal{T}(Lapack.gttrf!(copy(A.dl),copy(A.d),copy(A.du))...)
 lu(A::Tridiagonal) = factors(lud(A))
 
 function det(lu::LUTridiagonal)
+    n = length(lu.d)
     prod(lu.d) * (bool(sum(lu.ipiv .!= 1:n) % 2) ? -1 : 1)
 end
 
@@ -987,6 +988,12 @@ function \(W::Woodbury, R::StridedVecOrMat)
     AinvR = W.A\R
     return AinvR - W.A\(W.U*(W.Cp*(W.V*AinvR)))
 end
+function det(W::Woodbury)
+    det(W.A)*det(W.C)/det(W.Cp)
+end
+    
+
+
 # Allocation-free solver for arbitrary strides (requires that W.A has a
 # non-aliasing "solve" routine, e.g., is Tridiagonal)
 function solve(x::AbstractArray, xrng::Ranges{Int}, W::Woodbury, rhs::AbstractArray, rhsrng::Ranges{Int})

--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -900,8 +900,8 @@ end
 #show(io, lu::LUTridiagonal) = print(io, "LU decomposition of ", summary(lu.lu))
 
 lud!{T}(A::Tridiagonal{T}) = LUTridiagonal{T}(Lapack.gttrf!(A.dl,A.d,A.du)...)
-lud{T}(A::Tridiagonal{T}) =
- LUTridiagonal{T}(Lapack.gttrf!(copy(A.dl),copy(A.d),copy(A.du))...)
+lud{T}(A::Tridiagonal{T}) = 
+    LUTridiagonal{T}(Lapack.gttrf!(copy(A.dl),copy(A.d),copy(A.du))...)
 lu(A::Tridiagonal) = factors(lud(A))
 
 function det(lu::LUTridiagonal)
@@ -991,8 +991,6 @@ end
 function det(W::Woodbury)
     det(W.A)*det(W.C)/det(W.Cp)
 end
-    
-
 
 # Allocation-free solver for arbitrary strides (requires that W.A has a
 # non-aliasing "solve" routine, e.g., is Tridiagonal)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -16,6 +16,7 @@ begin
     @assert norm(b - apd * (capd\b)) < Eps
     @assert norm(apd * inv(capd) - eye(n)) < Eps
     @assert norm(a*(capd\(a'*b)) - b) < Eps  # least squares soln for square a
+    @assert_approx_eq det(capd) det(apd)
 
     l     = factors(chold(apd, false))      # lower Cholesky factor
     @assert norm(l*l' - apd) < Eps
@@ -212,6 +213,7 @@ begin
     Tlu = lud(T)
     x = Tlu\v
     @assert norm(x - invFv) < Eps
+    @assert_approx_eq det(T) det(F)
 
     # symmetric tridiagonal
     Ts = SymTridiagonal(d, dl)
@@ -237,6 +239,7 @@ begin
 
     @assert norm(W*v - F*v) < Eps
     @assert norm(W\v - F\v) < Eps
+    @assert_approx_eq det(W) det(F)
 
     sqd  = rand(n,n)
     sqz  = complex(sqd)


### PR DESCRIPTION
This adds a `det` method for the `Woodbury` matrix type using the [matrix determinant lemma](http://en.wikipedia.org/wiki/Matrix_determinant_lemma). Also fixes a problem with `LUTridiagonal` determinants. Includes tests.
