### PR TITLE
RFC: Added xgelsd for solving rank deficient least squares problems.

### DIFF
--- a/base/lapack.jl
+++ b/base/lapack.jl
@@ -339,11 +339,11 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, gerqf, getrf, elty) in
 end
 
 ## (GE) general matrices, solvers with factorization, solver and inverse
-for (gels, gesv, getrs, getri, elty) in
-    ((:dgels_,:dgesv_,:dgetrs_,:dgetri_,:Float64),
-     (:sgels_,:sgesv_,:sgetrs_,:sgetri_,:Float32),
-     (:zgels_,:zgesv_,:zgetrs_,:zgetri_,:Complex128),
-     (:cgels_,:cgesv_,:cgetrs_,:cgetri_,:Complex64))
+for (gels, gelsd, gesv, getrs, getri, elty) in
+    ((:dgels_,:dgelsd_,:dgesv_,:dgetrs_,:dgetri_,:Float64),
+     (:sgels_,:sgelsd_,:sgesv_,:sgetrs_,:sgetri_,:Float32),
+     (:zgels_,:zgelsd_,:zgesv_,:zgetrs_,:zgetri_,:Complex128),
+     (:cgels_,:cgelsd_,:cgesv_,:cgetrs_,:cgetri_,:Complex64))
     @eval begin
         #      SUBROUTINE DGELS( TRANS, M, N, NRHS, A, LDA, B, LDB, WORK, LWORK,INFO)
         # *     .. Scalar Arguments ..
@@ -372,7 +372,44 @@ for (gels, gesv, getrs, getri, elty) in
             end
             k   = min(m, n)
             F   = m < n ? tril(A[1:k, 1:k]) : triu(A[1:k, 1:k])
-            F, isa(B, Vector) ? B[1:k] : B[1:k,:], [sum(B[(k+1):size(B,1), i].^2) for i=1:size(B,2)] 
+            F, isa(B, Vector) ? B[1:k] : B[1:k,:], [sum(B[(k+1):size(B,1), i].^2) for i=1:size(B,2)]
+        end
+        # SUBROUTINE DGELSD( M, N, NRHS, A, LDA, B, LDB, S, RCOND, RANK,
+        #      $                   WORK, LWORK, IWORK, INFO )
+        # *     .. Scalar Arguments ..
+        #       INTEGER            INFO, LDA, LDB, LWORK, M, N, NRHS, RANK
+        #       DOUBLE PRECISION   RCOND
+        # *     ..
+        # *     .. Array Arguments ..
+        #       INTEGER            IWORK( * )
+        #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), S( * ), WORK( * )
+        function gelsd!(A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
+            Lapack.chkstride1(A, B)
+            m, n  = size(A)
+            if size(B,1) != m; throw(Lapack.LapackDimMisMatch("gelsd!")); end
+            s     = Array($elty, min(m, n))
+            rcond = eps(Float32)
+            rnk   = Array(Int32, 1)
+            info  = Array(Int32, 1)
+            work  = Array($elty, 1)
+            lwork = int32(-1)
+            iwork = Array(Int32, 1)
+            for i in 1:2
+                ccall(dlsym(Base.liblapack, "dgelsd_"), Void,
+                      (Ptr{Int32}, Ptr{Int32}, Ptr{Int32},
+                       Ptr{$elty}, Ptr{Int32}, Ptr{$elty}, Ptr{Int32},
+                       Ptr{$elty}, Ptr{$elty}, Ptr{Int32}, Ptr{$elty}, 
+                       Ptr{Int32}, Ptr{Int32}, Ptr{Int32}),
+                      &m, &n, &size(B,2), A, &max(1,stride(A,2)),
+                      B, &max(1,stride(B,2)), s, &rcond, rnk, work, &lwork, iwork, info)
+                if info[1] != 0 throw(LapackException(info[1])) end
+                if lwork < 0
+                    lwork = int32(real(work[1]))
+                    work = Array($elty, lwork)
+                    iwork = Array(Int32, iwork[1])
+                end
+            end
+            isa(B, Vector) ? B[1:n] : B[1:n,:], rnk[1]
         end
         # SUBROUTINE DGESV( N, NRHS, A, LDA, IPIV, B, LDB, INFO )
         # *     .. Scalar Arguments ..

--- a/base/lapack.jl
+++ b/base/lapack.jl
@@ -395,7 +395,7 @@ for (gels, gelsd, gesv, getrs, getri, elty) in
             lwork = int32(-1)
             iwork = Array(Int32, 1)
             for i in 1:2
-                ccall(dlsym(Base.liblapack, "dgelsd_"), Void,
+                ccall(dlsym(Base.liblapack, $(string(gelsd))), Void,
                       (Ptr{Int32}, Ptr{Int32}, Ptr{Int32},
                        Ptr{$elty}, Ptr{Int32}, Ptr{$elty}, Ptr{Int32},
                        Ptr{$elty}, Ptr{$elty}, Ptr{Int32}, Ptr{$elty}, 

--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -616,7 +616,7 @@ function (\){T<:LapackType}(A::StridedMatrix{T}, B::StridedVecOrMat{T})
         if ishermitian(A) return Lapack.sysv!('U', Acopy, X)[1] end
         return Lapack.gesv!(Acopy, X)[3]
     end
-    Lapack.gels!('N', Acopy, X)[2]
+    Lapack.gelsd!(Acopy, X)[1]
 end
 
 (\){T1<:Real, T2<:Real}(A::StridedMatrix{T1}, B::StridedVecOrMat{T2}) = (\)(float64(A), float64(B))

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1238,7 +1238,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
 .. function:: \
 
-   Matrix division using a polyalgorithm. For input matrices ``A`` and ``B``, the result ``X`` is such that ``A*X == B``. For rectangular ``A``, QR factorization is used. For triangular ``A``, a triangular solve is performed. For square ``A``, Cholesky factorization is tried if the input is symmetric with a heavy diagonal. LU factorization is used in case Cholesky factorization fails or for general square inputs.
+   Matrix division using a polyalgorithm. For input matrices ``A`` and ``B``, the result ``X`` is such that ``A*X == B``. For rectangular ``A``, QR factorization is used. For triangular ``A``, a triangular solve is performed. For square ``A``, Cholesky factorization is tried if the input is symmetric with a heavy diagonal. LU factorization is used in case Cholesky factorization fails or for general square inputs. If ``size(A,1) > size(A,2)``, the result is a least squares solution of ``A*X+eps=B`` using the singular value decomposition. ``A`` does not need to have full rank.
 
 .. function:: dot
 
@@ -1276,9 +1276,17 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute eigenvalues and eigenvectors of A
 
-.. function:: svd(A) -> U, S, V
+.. function:: eigvals(A)
+
+   Returns and ``Array{Float64, 1}'' of the eigenvalues of ``A''.
+
+.. function:: svd(A) -> U, S, V'
 
    Compute the SVD of A
+
+.. function:: svdvals(A)
+
+   Returns and ``Array{Float64, 1}'' of the singular values of ``A''.
 
 .. function:: triu(M)
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -77,6 +77,19 @@ begin
     x = tril(a) \ b
     @assert norm(tril(a)*x - b) < Eps
 
+    # Least squares
+    a = [ones(20) 1:20 1:20]
+    b = reshape(eye(8, 5), 20, 2)
+
+    x = a[:,1:2]\b[:,1]                             # Vector rhs
+    @assert abs(((a[:,1:2]*x-b[:,1])'*(a[:,1:2]*x-b[:,1])/20)[1] - 0.127330827) < Eps
+    
+    x = a[:,1:2]\b                                  # Matrix rhs
+    @assert abs(det((a[:,1:2]*x-b)'*(a[:,1:2]*x-b)/20) - 0.0110949248) < Eps
+
+    x = a\b                            # Rank deficient
+    @assert abs(det((a*x-b)'*(a*x-b)/20) - 0.0110949248) < Eps
+
     # symmetric, positive definite
     @assert norm(inv([6. 2; 2 1]) - [0.5 -1; -1 3]) < Eps
     # symmetric, negative definite


### PR DESCRIPTION
The Lapack subroutine gels does not allow rank deficient matrices but gelsd does which is sometimes useful. This is also closer to Matlab behaviour. An example

julia> mX=[ones(10) 1:10 1:10];

julia> mY=eye(5,2)[:];

julia> mX\mY
3-element Float64 Array:
 -0.0  
 -1.00185e15
  1.00185e15

julia> mX[:,1:2]\mY
2-element Float64 Array:
  0.4  
 -0.0363636

julia> Lapack.gelsd!(copy(mX), copy(mY))[1]
3-element Float64 Array:
  0.4  
 -0.0181818
 -0.0181818

Should "\" call gelsd?
