### PR TITLE
RFC/WIP: Modularize strpack

### DIFF
--- a/extras/strpack.jl
+++ b/extras/strpack.jl
@@ -1,7 +1,18 @@
-load("iostring.jl")
-load("lru.jl")
+module StrPack
 
-bswap(c::Char) = identity(c) # white lie which won't work for multibyte characters
+export Struct, struct
+export pack, unpack, sizeof
+export DataAlign
+export align_default, align_packed, align_packmax, align_structpack, align_table
+export align_x86_pc_linux_gnu, align_native
+export show_struct_layout
+
+import Base.*
+
+require("iostring.jl")
+require("lru.jl")
+
+bswap(c::Char) = identity(c) # white lie which won't work for multibyte characters in UTF-16 or UTF-32
 
 # Represents data endianness
 abstract Endianness
@@ -540,3 +551,5 @@ align_native = align_table(align_default, let
      Float64 => float64align,
      ]
 end)
+
+end

--- a/extras/strpack.jl
+++ b/extras/strpack.jl
@@ -106,37 +106,6 @@ function calcsize(types)
     size
 end
 
-# Generate an anonymous composite type from a list of its element types
-function gen_typelist(types::Array)
-    xprs = {}
-    for (typ, dims, name) in types
-        fn = !isa(name, Nothing) ? symbol(name) : gensym("field$(length(xprs)+1)")
-        xpr = if dims == 1
-            :(($fn)::($typ))
-        else
-            if typ != ASCIIString
-                sz = length(dims)
-                :(($fn)::Array{($typ),($sz)})
-            else
-                :(($fn)::($typ))
-            end
-        end
-        push(xprs, xpr)
-    end
-    xprs         
-end
-function gen_type(types)
-    @gensym struct
-    fields = gen_typelist(types)
-    typedef = quote
-        type $struct
-            $(fields...)
-        end
-        $struct
-    end
-    eval(typedef)
-end
-
 # Generate an unpack function for a composite type
 function gen_readers(convert::Function, types::Array, stream::Symbol, offset::Symbol, strategy::Symbol)
     xprs, rvars = {}, {}


### PR DESCRIPTION
Looks like strpack may needs some "esc"s in it. I may get to this myself, but in the meantime I thought I'd report it.

``` julia
module MyMod
import Base.*

load("strpack.jl")

type TestStruct
    int1::Int32
    float1::Float32
end
TestStruct(i, f) = TestStruct(convert(Int32, i), convert(Float32, f))

function test()
    io = IOString()
    t = TestStruct(2, 3.2)
    pack(io, t)
end

export test
end # module
```

``` julia
julia> import MyMod.*

julia> test()
in anonymous: DataAlign not defined
 in anonymous at no file
 in pack at /home/tim/src/julia/extras/strpack.jl:334
 in test at /tmp/strpmod.jl:15
```

Commenting out the 3 lines that create this as a module lets everything work properly.

Presumably, strpack itself should be converted to a module. It also depends on iostring.jl and lru.jl, so I wouldn't want to make drastic changes without consulting @pao .
