### PR TITLE
RFC: Use macros for separate functions on OS X and Linux

### DIFF
--- a/base/export.jl
+++ b/base/export.jl
@@ -1262,6 +1262,8 @@ export
     @elapsed,
     @windows_only,
     @unix_only,
+    @osx_only,
+    @linux_only,
     @sync,
     @spawn,
     @spawnlocal,

--- a/base/file.jl
+++ b/base/file.jl
@@ -226,14 +226,21 @@ function dir_remove(directory_name::String)
   run(`rmdir $directory_name`)
 end
 
-function tempdir()
+@linux_only function tempdir()
   chomp(readall(`mktemp -d`))
 end
 
-function tempfile()
+@osx_only function tempdir()
+  chomp(readall(`mktemp -d -t tmp`))
+end
+
+@linux_only function tempfile()
   chomp(readall(`mktemp`))
 end
 
+@osx_only function tempfile()
+  chomp(readall(`mktemp -t tmp`))
+end
 function download_file(url::String)
   filename = tempfile()
   run(`curl -o $filename $url`)

--- a/base/osutils.jl
+++ b/base/osutils.jl
@@ -16,4 +16,20 @@ macro unix_only(ex)
     end
 end
 
+macro osx_only(ex)
+    if OS_NAME == :Darwin
+        return esc(ex)
+    else
+        return :nothing
+    end
+end
+
+macro linux_only(ex)
+    if _jl_is_unix(OS_NAME) && OS_NAME != :Darwin
+        return esc(ex)
+    else
+        return :nothing
+    end
+end
+
 _jl_os_name(os::Symbol) = string(os)

--- a/test/file.jl
+++ b/test/file.jl
@@ -29,6 +29,15 @@ run(`chmod +w $filename`)
 @assert filesize(dir_name) > 0
 @assert mtime(filename) >= mtime(dir_name)
 
+#######################################################################
+# This section tests temporary file and directory creation.           #
+#######################################################################
+
+@assert isdir(tempdir()) == true
+@assert isfile(tempdir()) == false
+@assert isdir(tempfile()) == false
+@assert isfile(tempfile()) == true
+
 ############
 # Clean up #
 ############


### PR DESCRIPTION
To resolve the issues that came up in 3327b629e2, I've added macros that split apart OS X and Linux in the same way that we previously split apart Windows and Unix. For this specific case, we should ultimately not keep the resulting definitions of `tempdir` and `tempfile`, but I suspect that we will find separating OS X from Linux useful in other places as well.

Because this introduces new macros everywhere, I wanted to get people's opinions about this strategy before using it for such a small problem.
