### PR TITLE
ODE23 Example Was Broken

### DIFF
--- a/extras/ode.jl
+++ b/extras/ode.jl
@@ -17,8 +17,8 @@
 #   ODE23 uses the Runge-Kutta (2,3) method of Bogacki and Shampine (BS23).
 #
 #   Example    
-#      tspan = [0 2*pi]
-#      y_0 = [1 0]'
+#      tspan = [0, 2*pi]
+#      y_0 = [1, 0]
 #      F = (t, y) -> [0 1; -1 0]*y
 #      ode23(F, tspan, y_0)
 #


### PR DESCRIPTION
In the example given for ODE23, the second and third parameters were specified as row vectors, but the method expected column vectors.

Might make sense to just change the function, but at least now the example runs.
