### PR TITLE
Add GMP-based BigInt versions for factorial() and binomial()

### DIFF
--- a/deps/gmp_wrapper.c
+++ b/deps/gmp_wrapper.c
@@ -92,6 +92,18 @@ extern void _jl_mpz_sqrt(mpz_t* rop, mpz_t* op) {
     mpz_sqrt(*rop, *op);
 }
 
+extern void _jl_mpz_fac_ui(mpz_t* rop, unsigned long int op) {
+  mpz_fac_ui(*rop, op);
+}
+
+extern void _jl_mpz_bin_ui(mpz_t* rop, mpz_t* n, unsigned long int k) {
+  mpz_bin_ui(*rop, *n, k);
+}
+
+extern void _jl_mpz_bin_uiui(mpz_t* rop, unsigned long int n, unsigned long int k) {
+  mpz_bin_uiui(*rop, n, k);
+}
+
 extern char*  _jl_mpz_printf(mpz_t* rop) {
   char* pp;
   int s = gmp_asprintf(&pp, "%Zd", *rop);

--- a/deps/gmp_wrapper.c
+++ b/deps/gmp_wrapper.c
@@ -28,6 +28,10 @@ extern void _jl_mpz_set_ui(mpz_t* rop, unsigned long int op) {
   mpz_set_ui(*rop, op);
 } 
 
+extern unsigned long _jl_mpz_get_ui(mpz_t* rop) {
+  return mpz_get_ui(*rop);
+} 
+
 extern void _jl_mpz_set_si(mpz_t* rop, long int op) {
   mpz_set_si(*rop, op);
 } 

--- a/extras/bigint.jl
+++ b/extras/bigint.jl
@@ -49,9 +49,12 @@ convert(::Type{BigInt}, x::Uint) = BigInt(x)
 
 if WORD_SIZE == 64
     convert(::Type{BigInt}, x::Int32) = BigInt(int(x))
+    convert(::Type{BigInt}, x::Uint32) = BigInt(uint(x))
 else
     BigInt(l::Int64) = BigInt(string(l))
+    BigInt(l::Uint64) = BigInt(string(l))
     convert(::Type{BigInt}, x::Int64) = BigInt(string(x))
+    convert(::Type{BigInt}, x::Uint64) = BigInt(string(x))
 end
 
 convert(::Type{Int}, n::BigInt) =
@@ -89,6 +92,7 @@ function lshift(x::BigInt, c::Uint)
     ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpz_lshift), Void, (Ptr{Void}, Ptr{Void}, Uint), z, x.mpz, c)
     BigInt(z)
 end
+lshift(x::BigInt, c::Integer) = lshift(x, uint(c))
 
 function -(x::BigInt, y::BigInt)
     z= _jl_bigint_init()
@@ -136,6 +140,7 @@ function pow(x::BigInt, y::Uint)
     ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpz_pow_ui), Void, (Ptr{Void}, Ptr{Void}, Uint), z, x.mpz, y)
     BigInt(z)
 end
+pow(x::BigInt, y::Integer) = pow(x, uint(y))
 
 function gcd(x::BigInt, y::BigInt)
     z = _jl_bigint_init()
@@ -154,8 +159,9 @@ function gcdext(a::BigInt, b::BigInt)
     BigInt(g), BigInt(s), BigInt(t)
 end
 
-function factorial(n::Uint)
+function factorial(bn::BigInt)
     z = _jl_bigint_init()
+    n = uint(bn)
     ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpz_fac_ui), Void,
         (Ptr{Void}, Uint), z, n)
     BigInt(z)
@@ -167,13 +173,7 @@ function binomial(n::BigInt, k::Uint)
         (Ptr{Void}, Ptr{Void}, Uint), z, n.mpz, k)
     BigInt(z)
 end
-
-function binomial(n::Uint, k::Uint)
-    z = _jl_bigint_init()
-    ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpz_bin_uiui), Void,
-        (Ptr{Void}, Uint, Uint), z, n, k)
-    BigInt(z)
-end
+binomial(n::BigInt, k::Integer) = binomial(n, uint(k))
 
 ==(x::BigInt, y::BigInt) = cmp(x,y) == 0
 <=(x::BigInt, y::BigInt) = cmp(x,y) <= 0

--- a/extras/bigint.jl
+++ b/extras/bigint.jl
@@ -127,6 +127,27 @@ function gcdext(a::BigInt, b::BigInt)
     BigInt(g), BigInt(s), BigInt(t)
 end
 
+function factorial(n::Uint)
+    z = _jl_bigint_init()
+    ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpz_fac_ui), Void,
+        (Ptr{Void}, Uint), z, n)
+    BigInt(z)
+end
+
+function binomial(n::BigInt, k::Uint)
+    z = _jl_bigint_init()
+    ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpz_bin_ui), Void,
+        (Ptr{Void}, Ptr{Void}, Uint), z, n.mpz, k)
+    BigInt(z)
+end
+
+function binomial(n::Uint, k::Uint)
+    z = _jl_bigint_init()
+    ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpz_bin_uiui), Void,
+        (Ptr{Void}, Uint, Uint), z, n, k)
+    BigInt(z)
+end
+
 ==(x::BigInt, y::BigInt) = cmp(x,y) == 0
 <=(x::BigInt, y::BigInt) = cmp(x,y) <= 0
 >=(x::BigInt, y::BigInt) = cmp(x,y) >= 0

--- a/extras/bigint.jl
+++ b/extras/bigint.jl
@@ -18,6 +18,19 @@ type BigInt <: Integer
         finalizer(b, _jl_bigint_clear)
         b
     end
+    BigInt{T<:Signed}(x::T) = BigInt(int(x))
+    BigInt(x::Int128) = BigInt(string(x))
+
+    function BigInt(x::Uint)
+        z = _jl_bigint_init()
+        ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpz_set_ui), Void,
+            (Ptr{Void}, Uint), z, x)
+        b = new(z)
+        finalizer(b, _jl_bigint_clear)
+        b
+    end
+    BigInt{T<:Unsigned}(x::T) = BigInt(uint(x))
+    BigInt(x::Uint128) = BigInt(string(x))
 
     function BigInt(z::Ptr{Void})
         b = new(z)
@@ -30,6 +43,10 @@ convert(::Type{BigInt}, x::Int8) = BigInt(int(x))
 convert(::Type{BigInt}, x::Int16) = BigInt(int(x))
 convert(::Type{BigInt}, x::Int) = BigInt(x)
 
+convert(::Type{BigInt}, x::Uint8) = BigInt(uint(x))
+convert(::Type{BigInt}, x::Uint16) = BigInt(uint(x))
+convert(::Type{BigInt}, x::Uint) = BigInt(x)
+
 if WORD_SIZE == 64
     convert(::Type{BigInt}, x::Int32) = BigInt(int(x))
 else
@@ -40,10 +57,20 @@ end
 convert(::Type{Int}, n::BigInt) =
     ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpz_get_si), Int, (Ptr{Void},), n.mpz)
 
+convert(::Type{Uint}, n::BigInt) =
+    ccall(dlsym(_jl_libgmp_wrapper, :_jl_mpz_get_ui), Uint, (Ptr{Void},), n.mpz)
+
 promote_rule(::Type{BigInt}, ::Type{Int8}) = BigInt
 promote_rule(::Type{BigInt}, ::Type{Int16}) = BigInt
 promote_rule(::Type{BigInt}, ::Type{Int32}) = BigInt
 promote_rule(::Type{BigInt}, ::Type{Int64}) = BigInt
+promote_rule(::Type{BigInt}, ::Type{Int128}) = BigInt
+
+promote_rule(::Type{BigInt}, ::Type{Uint8}) = BigInt
+promote_rule(::Type{BigInt}, ::Type{Uint16}) = BigInt
+promote_rule(::Type{BigInt}, ::Type{Uint32}) = BigInt
+promote_rule(::Type{BigInt}, ::Type{Uint64}) = BigInt
+promote_rule(::Type{BigInt}, ::Type{Uint128}) = BigInt
 
 function +(x::BigInt, y::BigInt)
     z= _jl_bigint_init()

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -45,4 +45,8 @@ ee = typemax(Int64)
 @assert a+int32(1) == b
 @assert a+int64(1) == b
 
+@assert factorial(uint(40)) == BigInt("815915283247897734345611269596115894272000000000")
+@assert binomial(BigInt(-53), uint(42)) == BigInt("959509335087854414441273718")
+@assert binomial(uint(113), uint(42)) == BigInt("18672199984318438125634054194360")
+
 end # cd

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -45,8 +45,8 @@ ee = typemax(Int64)
 @assert a+int32(1) == b
 @assert a+int64(1) == b
 
-@assert factorial(uint(40)) == BigInt("815915283247897734345611269596115894272000000000")
-@assert binomial(BigInt(-53), uint(42)) == BigInt("959509335087854414441273718")
-@assert binomial(uint(113), uint(42)) == BigInt("18672199984318438125634054194360")
+@assert factorial(BigInt(40)) == BigInt("815915283247897734345611269596115894272000000000")
+@assert binomial(BigInt(-53), 42) == BigInt("959509335087854414441273718")
+@assert binomial(BigInt(113), BigInt(42)) == BigInt("18672199984318438125634054194360")
 
 end # cd


### PR DESCRIPTION
Adds `factorial(n::Uint)`, `binomial(n::Uint, k::Uint)` and `binomial(n::BigInt, k::Uint)` methods, i.e. methods for calculating large factorials and binomial coefficients via GMP returning BigInts.

Another alternative is to name them `factorialbig()/binomialbig()` or something like that to make it clear that they return BigInts.
