### PR TITLE
RFC:Linear algebra. Moore-Penrose inverse, Null Space, some methods and a restriction of inv.

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -186,22 +186,23 @@ ones(args...)               = fill!(Array(Float64, args...), float64(1))
 trues(args...)  = fill(true, args...)
 falses(args...) = fill(false, args...)
 
-eye(n::Int) = eye(n, n)
-function eye(m::Int, n::Int)
-    a = zeros(m,n)
+function eye(T::Type, m::Int, n::Int)
+    a = zeros(T,m,n)
     for i = 1:min(m,n)
-        a[i,i] = 1
+        a[i,i] = one(T)
     end
     return a
 end
+eye(m::Int, n::Int) = eye(Float64, m, n)
+eye(T::Type, n::Int) = eye(T, n, n)
+eye(n::Int) = eye(Float64, n)
+eye{T}(x::StridedMatrix{T}) = eye(T, size(x, 1), size(x, 2))
 function one{T}(x::StridedMatrix{T})
-    m, n = size(x)
-    a = zeros(T,size(x))
-    for i = 1:min(m,n)
-        a[i,i] = 1
-    end
-    return a
+    m,n = size(x)
+    if m != n; error("Multiplicative identity only defined for square matrices!"); end;
+    eye(T, m)
 end
+
 
 function linspace(start::Real, stop::Real, n::Integer)
     (start, stop) = promote(start, stop)

--- a/base/export.jl
+++ b/base/export.jl
@@ -659,6 +659,8 @@ export
     matmul2x2,
     matmul3x3,
     norm,
+    null,
+    pinv,
     qr,
     qrd!,
     qrd,

--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -628,6 +628,26 @@ end
 ##       Add rcond methods for Cholesky, LU, QR and QRP types
 ## Lower priority: Add LQ, QL and RQ factorizations
 
+## Moore-Penrose inverse
+function pinv{T<:LapackType}(A::StridedMatrix{T})
+    u,s,vt      = svd(A, true)
+    sinv        = zeros(T, length(s))
+    index       = s .> eps(T)*max(size(A))*max(s)
+    sinv[index] = 1 ./ s[index]
+    vt'diagmm(sinv, u')
+end
+pinv(A::StridedMatrix{Int}) = pinv(float(A))
+pinv(a::StridedVector) = pinv(reshape(a, length(a), 1))
+
+## Basis for null space
+function null{T<:LapackType}(A::StridedMatrix{T})
+    m,n = size(A)
+    if m >= n; return zeros(T, n, 0); end;
+    u,s,vt = svd(A)
+    vt[m+1:,:]'
+end
+null(A::StridedMatrix{Int}) = null(float(A))
+null(a::StridedVector) = null(reshape(a, length(a), 1))
 
 #### Specialized matrix types ####
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1330,7 +1330,15 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
 .. function:: inv(M)
 
-   Matrix inverse, or generalized ``1/M``
+   Matrix inverse
+
+.. function:: pinv(M)
+
+   Moore-Penrose inverse
+
+.. function:: null(M)
+
+   Basis for null space of M
 
 .. function:: repmat(A, n, m)
 

--- a/extras/sparse.jl
+++ b/extras/sparse.jl
@@ -385,8 +385,10 @@ spzeros(Tv::Type, m::Int) = spzeros(Tv, m, m)
 spzeros(Tv::Type, m::Int, n::Int) =
     SparseMatrixCSC(m, n, ones(Int32, n+1), Array(Int32, 0), Array(Tv, 0))
 
-speye(n::Int) = speye(Float64, n, n)
+speye(n::Int) = speye(Float64, n)
+speye(T::Type, n::Int) = speye(T, n, n)
 speye(m::Int, n::Int) = speye(Float64, m, n)
+speye{T}(S::SparseMatrixCSC{T}) = speye(T, size(S, 1), size(S, 2))
 
 function speye(T::Type, m::Int, n::Int)
     x = int32(min(m,n))
@@ -397,8 +399,9 @@ function speye(T::Type, m::Int, n::Int)
 end
 
 function one{T}(S::SparseMatrixCSC{T})
-    m, n = size(S)
-    return speye(T, m, n)
+    m,n = size(S)
+    if m != n; error("Multiplicative identity only defined for square matrices!"); end;
+    speye(T, m)
 end
 
 ## Transpose

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -77,6 +77,17 @@ begin
     x = tril(a) \ b
     @assert norm(tril(a)*x - b) < Eps
 
+    # Test null
+    bnull = null(b')
+    @assert norm(b'bnull) < Eps
+    @assert norm(bnull'b) < Eps
+    @assert size(null(b), 2) == 0
+
+    # Test pinv
+    pinvb = pinv(b)
+    @assert norm(b*pinvb*b - b) < Eps
+    @assert norm(pinvb*b*pinvb - pinvb) < Eps
+
     # Least squares
     a = [ones(20) 1:20 1:20]
     b = reshape(eye(8, 5), 20, 2)


### PR DESCRIPTION
Added some methods for matrix construction. Restricted one(Strdied/Sparse Matrix) to allow only square matrices which again restricted the inv(AbstractMatrix) method to only work for square matrices. Added Moore-Penrose inverse and Null space functions similar to Matlab's. Some tests for these are added and the documentation is updated. This is a new version of the pull request #1382
