### PR TITLE
Docs (Getting Around): logspace

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1147,6 +1147,10 @@ Constructors
 
    Construct a vector of ``n`` linearly-spaced elements from ``start`` to ``stop``.
 
+.. function:: logspace(start, stop, n)
+
+   Construct a vector of ``n`` logarithmically-spaced numbers from ``10^start`` to ``10^stop``.
+
 Mathematical operators and functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Added a description of `logspace` in the Getting Around section of the manual, right next to its brother `linspace`.

Just a trivial one, to get the hang of the github workflow, and to make sure that I'm not violating any expectations the project might have about contributions.
