### PR TITLE
isequal for Set and Dict (implementation and tests)

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -440,6 +440,20 @@ next(t::Dict, i) = ((t.keys[i],t.vals[i]), skip_deleted(t.keys,i+1))
 isempty(t::Dict) = (t.count == 0)
 length(t::Dict) = t.count
 
+# Used as default value arg to get in isequal: something that will
+# never be found in any dictionary.
+const _MISSING = gensym()
+
+function isequal(l::Dict, r::Dict)
+    if ! (length(l) == length(r))  return false end
+    for (key, value) in l
+        if ! isequal(value, get(r, key, _MISSING))
+            return false
+        end
+    end
+    true
+end
+
 # weak key dictionaries
 
 function add_weak_key(t::Dict, k, v)
@@ -491,3 +505,4 @@ function next{K}(t::WeakKeyDict{K}, i)
     ((kv[1].value::K,kv[2]), i)
 end
 length(t::WeakKeyDict) = length(t.ht)
+

--- a/base/set.jl
+++ b/base/set.jl
@@ -72,3 +72,5 @@ setdiff(a::Set, b::Set) = del_each(copy(a),b)
 |(s::Set...) = union(s...)
 (&)(s::Set...) = intersect(s...)
 -(a::Set, b::Set) = setdiff(a,b)
+
+isequal(l::Set, r::Set) = length(l) == length(r) == length(intersect(l,r))

--- a/test/corelib.jl
+++ b/test/corelib.jl
@@ -148,7 +148,7 @@ macro assert_raises(ExcType, expression)
     end
 end
 
-@assert  isequal({}, {})
+@assert  isequal(Dict(), Dict())
 @assert  isequal({1 => 1}, {1 => 1})
 @assert !isequal({1 => 1}, {})
 @assert !isequal({1 => 1}, {1 => 2})

--- a/test/corelib.jl
+++ b/test/corelib.jl
@@ -134,12 +134,6 @@ end
 
 # #################### set ####################
 
-# Is there any good reason why sets (and dicts) do not implement
-# isequal? I'm providing a quick'n'dirty implementation here to help
-# with the following tests. Will suggest implementation of isequal for
-# sets and dicts, in a later pull request.
-isequal(l::Set,r::Set) = length(l) == length(r) == length(intersect(l,r))
-
 # show
 
 # isempty
@@ -277,4 +271,47 @@ for data_in in ((7,8,4,5),
         @assert has(s,e)
     end
 end
+
+# isequal
+@assert  isequal(Set(), Set())
+@assert !isequal(Set(), Set(1))
+@assert  isequal(Set{Any}(1,2), Set{Int}(1,2))
+@assert !isequal(Set{Any}(1,2), Set{Int}(1,2,3))
+
+# Helper for writing tests about error conditions, used in the
+# following tests
+macro assert_raises(ExcType, expression)
+    quote
+        try
+            $expression
+        catch e
+            if ! (typeof(e) <: $ExcType)
+                println("Error        : ",        e )
+                println("Type of error: ", typeof(e))
+                println("Expected     : ", $ExcType)
+                @assert false
+            end
+        end
+    end
+end
+
+# Comparison of unrelated types seems rather inconsistent
+
+# Not sure whether the behaviour of isequal (as demonstrated below) on
+# sets of unrelated types, is desirable, but it's what there is at the
+# moment.
+@assert                    isequal(Set{Int}(), Set{String}())
+@assert_raises TypeError   isequal(Set{Int}(),    Set{String}{""})
+@assert                   !isequal(Set{String}(), Set{Int}(0))
+@assert_raises MethodError isequal(Set{Int}(1),   Set{String}())
+
+@assert   isequal(Set{Any}(1,2,3), Set{Int}(1,2,3))
+@assert   isequal(Set{Int}(1,2,3), Set{Any}(1,2,3))
+
+@assert  !isequal(Set{Any}(1,2,3), Set{Int}(1,2,3,4))
+@assert  !isequal(Set{Int}(1,2,3), Set{Any}(1,2,3,4))
+
+@assert  !isequal(Set{Any}(1,2,3,4), Set{Int}(1,2,3))
+@assert  !isequal(Set{Int}(1,2,3,4), Set{Any}(1,2,3))
+
 # ########## end of set tests ##########


### PR DESCRIPTION
Implementation and tests for isequal(::Set, ::Set) and isequal(::Dict, ::Dict)

The behaviour of comparison of Sets and Dicts containing unrelated types probably needs more thinking about: what should be allowed, what should fail, what should the failure mode be.

In the process of writing the tests, I wrote an @assert_raises macro, to help write tests about error conditions. This macro is defined among the tests in test/corelib.jl. Clearly, it needs to go somewhere else, but I'm not sure where. (Surely, something like it exists already.)
