### PR TITLE
RFC: a couple of file api tweaks

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -71,13 +71,7 @@ function file_path(components...)
     join(components, os_separator)
 end
 
-function fullfile(pathname::String, basename::String, ext::String)
-    if isempty(pathname)
-        return basename * ext
-    else
-        return pathname * os_separator * basename * ext
-    end
-end
+const fullfile = file_path
 
 # Test for an absolute path
 function isrooted(path::String)

--- a/base/file.jl
+++ b/base/file.jl
@@ -145,7 +145,7 @@ end
 
 # Get the full, real path to a file, including dereferencing
 # symlinks.
-function real_path(fname::String)
+function realpath(fname::String)
     fname = tilde_expand(fname)
     sp = ccall(:realpath, Ptr{Uint8}, (Ptr{Uint8}, Ptr{Uint8}), fname, C_NULL)
     if sp == C_NULL

--- a/base/util.jl
+++ b/base/util.jl
@@ -199,7 +199,7 @@ end
 
 function find_in_path(fname)
     if fname[1] == '/'
-        return real_path(fname)
+        return realpath(fname)
     end
     for pfx in LOAD_PATH
         if pfx != "" && pfx[end] != '/'
@@ -208,10 +208,10 @@ function find_in_path(fname)
             pfxd = strcat(pfx,fname)
         end
         if is_file_readable(pfxd)
-            return real_path(pfxd)
+            return realpath(pfxd)
         end
     end
-    return real_path(fname)
+    return realpath(fname)
 end
 
 begin


### PR DESCRIPTION
- Change `fullfile` to match matlab:
  
  ``` jlcon
  julia> fullfile("a","b","c")
  "a/bc"
  ```
  
  ``` matlab
  >> fullfile('a','b','c')
  
  ans =
  
  a/b/c
  ```
  
  In other words, define `const fullfile = file_path`.
- Rename `real_path -> realpath`, as it's a call to the POSIX `realpath` function, and that's what python, ruby, and perl call it.
