### PR TITLE
add scrollbar to html docs sidebar

### DIFF
--- a/doc/_themes/julia/layout.html
+++ b/doc/_themes/julia/layout.html
@@ -10,15 +10,17 @@
     <div class="sphinxsidebar">
       <div class="sphinxsidebarview">
         <div class="sphinxsidebarwrapper">
-          <div class="sphinxsidebarcontent">
-            {#- new style sidebar: explicitly include/exclude templates #}
-            {%- for sidebartemplate in sidebars %}
-            {%- include sidebartemplate %}
-            {%- endfor %}
-          </div>
           <div class="sphinxsidebarbutton">
             <div id="sidebarbutton">
             <span>&laquo;</span>
+            </div>
+          </div>
+          <div class="sphinxsidebarcontentwrapper">
+            <div class="sphinxsidebarcontent">
+              {#- new style sidebar: explicitly include/exclude templates #}
+              {%- for sidebartemplate in sidebars %}
+              {%- include sidebartemplate %}
+              {%- endfor %}
             </div>
           </div>
         </div>

--- a/doc/_themes/julia/static/julia.css_t
+++ b/doc/_themes/julia/static/julia.css_t
@@ -178,13 +178,11 @@ div.sphinxsidebar {
   padding-top: 15px;
   padding-bottom: 15px;
   height: auto;
-  overflow: hidden;
 }
 
 div.sphinxsidebarview {
   border-radius: 5px;
-  overflow-y: scroll;
-  overflow-x: hidden;
+  height: 100%;
 }
 
 div.sphinxsidebarview::-webkit-scrollbar {
@@ -193,19 +191,23 @@ div.sphinxsidebarview::-webkit-scrollbar {
 }
 
 div.sphinxsidebarwrapper {
-  background-color: {{ theme_sidebttbgcolor }};
   border-radius: 5px;
   margin: 0;
   padding: 0;
   margin-left: {{ theme_sidebarlmarg|toint }}px;
-  display: table;
+  height: 100%;
+}
+
+div.sphinxsidebarcontentwrapper {
+  border-radius: 5px 0 0 5px;
+  height: 100%;
+  overflow: auto;
+
 }
 
 div.sphinxsidebarcontent {
   background-color: {{ theme_sidebarbgcolor }};
-  border-radius: 5px 0 0 5px;
   padding: 10px 5px 10px 10px;
-  display: table-cell;
   vertical-align: middle;
 }
 
@@ -218,7 +220,7 @@ div.sphinxsidebarbutton {
   width: 12px;
   height: 100%;
   margin: auto;
-  display: table-cell;
+  float: right;
 }
 
 div.sphinxsidebarbutton:hover {

--- a/doc/_themes/julia/static/sidebar.js
+++ b/doc/_themes/julia/static/sidebar.js
@@ -27,6 +27,7 @@ $(function() {
   var sidebarcontent = $('.sphinxsidebarcontent');
   var sidebarbuttondiv = $('.sphinxsidebarbutton');
   var sidebarbutton = $('#sidebarbutton');
+  var searchq = $('.search [name=q]');
 
   var uncollapsed_height = 0;
 
@@ -73,7 +74,9 @@ $(function() {
     var isc = sidebar_is_collapsed();
     if (isc)
       expand_sidebar();
-    uncollapsed_height = sidebarcontent.height();
+    uncollapsed_height = Math.min(
+            sidebarcontent.outerHeight(),
+            sidebarcontent.parent().height() );
     if (isc)
       collapse_sidebar();
   }
@@ -90,6 +93,7 @@ $(function() {
     var buttonscroll = sidebarview.scrollTop();
     var newmargin = (Math.min(barheight, $(window).height() - barpad - bartop) - buttonheight) / 2 + buttonscroll;
     sidebarbutton.css('margin-top', newmargin);
+    searchq.css('width', sidebarcontent.width() - 50);
   }
 
   function collapse_sidebar() {
@@ -108,7 +112,8 @@ $(function() {
     footerwrapper.css(newmargins);
     sidebarbuttondiv.css({
       'height': newheight,
-      'border-radius': '5px'
+      'border-radius': '5px',
+      'float': '',
     });
     sidebarbutton.find('span').text('»');
     sidebarbuttondiv.attr('title', _('Expand sidebar'));
@@ -123,16 +128,16 @@ $(function() {
     };
     bodywrapper.css(newmargins);
     footerwrapper.css(newmargins);
-    sidebar.css('width', ssb_width_expanded);
+    sidebar.css('width', '');
     sidebarcontent.show();
+    compute_uncollapsed_height();
     sidebarbuttondiv.css({
-      'height': '',
-      'border-radius': '0 5px 5px 0'
+      'height': uncollapsed_height,
+      'border-radius': '0 5px 5px 0',
+      'float': 'right',
     });
     sidebarbutton.find('span').text('«');
     sidebarbuttondiv.attr('title', _('Collapse sidebar'));
-    sidebarview.css('height', sidebar.height());
-    sidebar.css('width', sidebarview[0].scrollWidth);
     set_button_margin();
     sidebarview.scrollTop(barscroll);
     document.cookie = 'sidebar=expanded';
@@ -163,9 +168,10 @@ $(function() {
   function set_sidebar_pos() {
     var bodyoff = viewOffsetTop(body);
     sidebar.css('top', Math.max(bodyoff,0));
-    sidebarview.css('height', sidebar.height());
     if (!sidebar_is_collapsed()) {
-      sidebar.css('width', sidebarview[0].scrollWidth);
+      sidebar.css('width', '');
+      compute_uncollapsed_height();
+      sidebarbuttondiv.css('height', uncollapsed_height);
     } else {
       var newheight = get_collapsed_height();
       sidebarbuttondiv.css('height', newheight);
@@ -174,12 +180,10 @@ $(function() {
   }
 
   prepare_sidebar_button();
-  sidebarview.css('height', sidebar.height());
-  sidebarview.css('width', sidebar.width());
-  sidebar.css('width', sidebarview[0].scrollWidth);
   set_state_from_cookie();
   compute_uncollapsed_height();
   set_sidebar_pos();
+  sidebar.css('margin-left','auto');
   $(window).scroll(set_sidebar_pos);
   sidebarview.scroll(set_button_margin);
   $(window).resize(set_sidebar_pos);


### PR DESCRIPTION
Adds a scrollbar to the html documentation sidebar, when necessary, to the left of the closure button bar. Otherwise, I tried to keep the style unchanged.

It's possible to easily make the following additional changes, if desired, separately or together:
1) Always pin the box to the top of the window. (comment out line 170 `sidebar.css('top', Math.max(bodyoff,0));`)

2) Full height expansion of sidebar to available height (requires a tweak to background-color in css, and the removal of a few lines of javascript)
