### PR TITLE
Minor bugfixes to #1424

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -139,8 +139,8 @@ readline(s::IO) = readuntil(s, '\n')
 function readall(s::IO)
     out = memio()
     while (!eof(s))
-        c = read(s, Char)
-        write(out, c)
+        a = read(s, Uint8)
+        write(out, a)
     end
     takebuf_string(out)
 end

--- a/extras/iostring.jl
+++ b/extras/iostring.jl
@@ -38,9 +38,9 @@ skip(io::IOString, n::Integer) = io.ptr += n
 seek(io::IOString, n::Integer) = io.ptr = n+1
 seek_end(io::IOString) = io.ptr = length(io.data)+1
 position(io::IOString) = io.ptr-1
-truncate(io::IOString, n::Integer) = (grow(io.data, n-length(io.data)); ptr = min(ptr, n+1); uint(0))
+truncate(io::IOString, n::Integer) = (grow(io.data, n-length(io.data)); io.ptr = min(io.ptr, n+1); uint(0))
 eof(io::IOString) = io.ptr-1 == length(io.data)
-close(io::IOString) = (grow(io.data, 0); ptr = 1; nothing)
+close(io::IOString) = (grow(io.data, 0); io.ptr = 1; nothing)
 
 bytestring(io::IOString) = bytestring(io.data)
 


### PR DESCRIPTION
Make readall(s::IO) read Uint8 instead of Char.
IOString truncate(), close() bugfix: ptr -> io.ptr
