### PR TITLE
[RFC] Added typed array comprehensions

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -290,9 +290,9 @@
 	  ((special-char? c)    (read-char port))
 
 	  ((char-numeric? c)    (read-number port #f #f))
-	  
+
 	  ((eqv? c #\#)         (skip-to-eol port) (next-token port s))
-	  
+
 	  ; . is difficult to handle; it could start a number or operator
 	  ((and (eqv? c #\.)
 		(let ((c (read-char port))
@@ -307,7 +307,7 @@
 					 (symbol->string
 					  (read-operator port nextc)))))
 			(else '|.|)))))
-	  
+
 	  ((opchar? c)  (read-operator port c))
 
 	  ((identifier-char? c) (accum-julia-symbol c port))
@@ -735,9 +735,9 @@
 			   (loop `(call ,ex ,(parse-do s) ,@al)))
 			 (loop `(call ,ex ,@al)))))
 		  ((#\[ )   (take-token s)
-	           ; ref is syntax, so we can distinguish
-	           ; a[i] = x  from
-	           ; ref(a,i) = x
+		   ; ref is syntax, so we can distinguish
+		   ; a[i] = x  from
+		   ; ref(a,i) = x
 		   (loop (list* 'ref ex
 				(with-end-symbol
 				 (parse-arglist s #\] )))))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -326,7 +326,7 @@
 	 `(block
 	   (global ,name)
 	   (const ,name)
-	   (composite_type ,name (tuple ,@params) 
+	   (composite_type ,name (tuple ,@params)
 			   (tuple ,@(map (lambda (x) `',x) field-names))
 			   (null) ,super (tuple ,@field-types))
 	   (call
@@ -1097,7 +1097,7 @@
 
     ;; Evaluate the comprehension
     `(scope-block
-      (block 
+      (block
        (= ,oneresult (tuple))
        ,(evaluate-one ranges)
        (= ,result (call (top Array) (call (top eltype) ,oneresult)
@@ -1183,8 +1183,8 @@
       ;; Evaluate the comprehension
       `(block
 	,@(map make-assignment rs (map caddr ranges))
-        (scope-block
-	(block 
+	(scope-block
+	(block
 	 ,@(map (lambda (r) `(local ,r))
 		(apply append (map (lambda (r) (lhs-vars (cadr r))) ranges)))
 	 (= ,result (call (top Array) (top Any) ,@(compute-dims rs)))
@@ -1551,7 +1551,7 @@ So far only the second case can actually occur.
 	     (let* ((env (append (lam:vars e) env))
 		    (body (add-local-decls (caddr e) env)))
 	       (list 'lambda (cadr e) body)))
-	    
+
 	    ((eq? (car e) 'scope-block)
 	     (let* ((glob (declared-global-vars (cadr e)))
 		    (vars (find-locals
@@ -1656,7 +1656,7 @@ So far only the second case can actually occur.
 	       bod)))
 	  (else (map (lambda (e) (remove-scope-blocks e context usedv))
 		     e))))
-  
+
   (cond ((not (pair? e))   e)
 	((quoted? e)       e)
 	((eq? (car e)      'lambda)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1158,9 +1158,9 @@
 	   ,(construct-loops (reverse loopranges))
 	   ,result)))))))
 
-   ;; cell array comprehensions
+   ;; typed array comprehensions
    (pattern-lambda
-    (cell-comprehension expr . ranges)
+    (typed-comprehension atype expr . ranges)
     (let ( (result (gensy))
 	   (ri (gensy))
 	   (rs (map (lambda (x) (gensy)) ranges)) )
@@ -1187,7 +1187,7 @@
 	(block
 	 ,@(map (lambda (r) `(local ,r))
 		(apply append (map (lambda (r) (lhs-vars (cadr r))) ranges)))
-	 (= ,result (call (top Array) (top Any) ,@(compute-dims rs)))
+	 (= ,result (call (top Array) ,atype ,@(compute-dims rs)))
 	 (= ,ri 1)
 	 ,(construct-loops (reverse ranges) (reverse rs))
 	 ,result)))))


### PR DESCRIPTION
For example:

```
julia> Integer[i^2 for i=1:3]
3-element Integer Array:
 1
 4
 9
```

This was discussed in #947 and [this thread](https://groups.google.com/forum/#!msg/julia-dev/IJkh1sUXq1A/GaLLQgQxu6kJ) on the dev list (and maybe somewhere else).

To my mind, this is also the last obstacle in removing the curly notation for Arrays and using it for Dicts, since with this the notation `Any[...]` can be used everywhere in place of `{...}` (unless I forgot something).

Everything seems in order and working to me, but I learned LISP along the way and it would surely be safer if someone (@JeffBezanson) had a good look.
