### PR TITLE
RFC: Reverse order of outputs from enumerate, to emulate python. (fix #1430)

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -6,12 +6,12 @@ end
 enumerate(itr) = Enumerate(itr)
 
 length(e::Enumerate) = length(e.itr)
-start(e::Enumerate) = (start(e.itr), 1)
+start(e::Enumerate) = (1, start(e.itr))
 function next(e::Enumerate, state)
-    v, s = next(e.itr, state[1])
-    (v,state[2]), (s,state[2]+1)
+    v, s = next(e.itr, state[2])
+    (state[1],v), (state[1]+1,s)
 end
-done(e::Enumerate, state) = done(e.itr, state[1])
+done(e::Enumerate, state) = done(e.itr, state[2])
 
 # zip
 

--- a/base/pkgmetadata.jl
+++ b/base/pkgmetadata.jl
@@ -156,7 +156,7 @@ function resolve(reqs::Vector{VersionSet})
     G += [ older(a,b)       ? 2 : 0  for a=vers, b=vers ]
     I = find(G)
     W = zeros(Int,length(I),n)
-    for (i,r) in enumerate(I)
+    for (r,i) in enumerate(I)
         W[r,rem(i-1,n)+1] = -1
         W[r,div(i-1,n)+1] = G[i]
     end

--- a/extras/enum.jl
+++ b/extras/enum.jl
@@ -9,7 +9,7 @@ macro enum(T,syms...)
         $(esc(:isequal))(a::($T), b::($T)) = eq_int(unbox($T,a),unbox($T,b))
         $(esc(:show))(io::IO, x::($T)) = $sh
     end
-    for (sym,i) in enumerate(syms)
+    for (i,sym) in enumerate(syms)
         push(blk.args, :(const $(esc(sym)) = box($T,unbox(Int,$(i-1)))))
     end
     push(blk.args, :nothing)

--- a/extras/icu.jl
+++ b/extras/icu.jl
@@ -178,7 +178,7 @@ export UCAL_ERA,
        UCAL_MILLISECONDS_IN_DAY,
        UCAL_IS_LEAP_MONTH
 
-for (a,i) in enumerate([
+for (i,a) in enumerate([
         :UCAL_ERA,
         :UCAL_YEAR,
         :UCAL_MONTH,

--- a/test/corelib.jl
+++ b/test/corelib.jl
@@ -38,8 +38,8 @@ boo32_64() = [ foo32_64(i) for i=1:2 ]
 let a36 = boo32_64()
     @assert a36[1]==1 && a36[2]==2
 end
-@assert isequal([1,2,3], [b for (a,b) in enumerate(2:4)])
-@assert isequal([2,3,4], [a for (a,b) in enumerate(2:4)])
+@assert isequal([1,2,3], [a for (a,b) in enumerate(2:4)])
+@assert isequal([2,3,4], [b for (a,b) in enumerate(2:4)])
 
 @assert (10.^[-1])[1] == 0.1
 @assert (10.^[-1.])[1] == 0.1


### PR DESCRIPTION
Per discussion in #1430. Changes usage from e g

```
for (x,i) in enumerate(xs) ...
```

to

```
for (i,x) in enumerate(xs) ...
```

RFC: This change will break any code outside the julia repo that uses `enumerate`,
but will make it consistent with Python. Any objections to merging this now?
