### PR TITLE
Dict: allways use new hash table size after rehasing. Fixes #1438

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -307,6 +307,7 @@ function assign{K,V}(h::Dict{K,V}, v, key)
 
     if h.ndel >= ((3*sz)>>2)
         rehash(h, sz)
+        sz = length(h.keys)  # yes, rehash may grow the table at this point!
     end
 
     iter = 0


### PR DESCRIPTION
The present code for `Dict` seems innocuous enough, but it seems #1438 provides an example where a `Dict` will actually grow its hash table when rehashing to clear out deleted slots. This removes the implicit assumption that it doesn't.
