### PR TITLE
RFC: Added vector constructor to Dict()/dict(); dict doc updates

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -228,7 +228,7 @@ type Dict{K,V} <: Associative{K,V}
         new(fill!(cell(n), _jl_secret_table_token), Array(V,n),
             0, 0, identity)
     end
-    function Dict(ks::Tuple, vs::Tuple)
+    function Dict(ks::Union(Tuple, Vector), vs::Union(Tuple, Vector))
         n = length(ks)
         h = Dict{K,V}(n)
         for i=1:n
@@ -263,10 +263,10 @@ function deserialize{K,V}(s, T::Type{Dict{K,V}})
 end
 
 # syntax entry point
-dict{K,V}(ks::(K...), vs::(V...)) = Dict{K,V}    (ks, vs)
-dict{K}  (ks::(K...), vs::Tuple ) = Dict{K,Any}  (ks, vs)
-dict{V}  (ks::Tuple , vs::(V...)) = Dict{Any,V}  (ks, vs)
-dict     (ks::Tuple , vs::Tuple)  = Dict{Any,Any}(ks, vs)
+dict{K,V}(ks::Union((K...), Vector{K}), vs::Union((V...), Vector{V})) = Dict{K,V}    (ks, vs)
+dict{K}  (ks::Union((K...), Vector{K}), vs::Union(Tuple, Vector))     = Dict{K,Any}  (ks, vs)
+dict{V}  (ks::Union(Tuple, Vector) , vs::Union((V...), Vector{V}))    = Dict{Any,V}  (ks, vs)
+dict     (ks::Union(Tuple, Vector) , vs::Union(Tuple, Vector))        = Dict{Any,Any}(ks, vs)
 
 hashindex(key, sz) = (int(hash(key)) & (sz-1)) + 1
 

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -645,6 +645,50 @@ collection[key...] = value
 
 "),
 
+(E"Associative Collections",E"keys",E"keys(collection)
+
+   Return an array of all keys in a collection.
+
+"),
+
+(E"Associative Collections",E"values",E"values(collection)
+
+   Return an array of all values in a collection.
+
+"),
+
+(E"Associative Collections",E"pairs",E"pairs(collection)
+
+   Return an array of all (key, value) tuples in a collection.
+
+"),
+
+(E"Associative Collections",E"merge",E"merge(collection, others...)
+
+   Construct a merged collection from the given collections.
+
+"),
+
+(E"Associative Collections",E"merge!",E"merge!(collection, others...)
+
+   Update collection with pairs from the other collections
+
+"),
+
+(E"Associative Collections",E"filter",E"filter(function, collection)
+
+   Return a copy of collection, removing (key, value) pairs for which
+   function is false.
+
+"),
+
+(E"Associative Collections",E"filter!",E"filter!(function, collection)
+
+   Update collection, removing (key, value) pairs for which function
+   is false.
+
+"),
+
 (E"Set-Like Collections",E"add",E"add(collection, key)
 
    Add an element to a set-like collection.

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -308,6 +308,34 @@ Dicts can be created using a literal syntax: ``{"A"=>1, "B"=>2}``
 
    Delete all keys from a collection.
 
+.. function:: keys(collection)
+
+   Return an array of all keys in a collection.
+
+.. function:: values(collection)
+
+   Return an array of all values in a collection.
+
+.. function:: pairs(collection)
+
+   Return an array of all (key, value) tuples in a collection.
+
+.. function:: merge(collection, others...)
+
+   Construct a merged collection from the given collections.
+
+.. function:: merge!(collection, others...)
+
+   Update collection with pairs from the other collections
+
+.. function:: filter(function, collection)
+
+   Return a copy of collection, removing (key, value) pairs for which function is false.
+
+.. function:: filter!(function, collection)
+
+   Update collection, removing (key, value) pairs for which function is false.
+
 Fully implemented by: ``ObjectIdDict``, ``Dict``, ``WeakKeyDict``.
 
 Partially implemented by: ``IntSet``, ``Set``, ``EnvHash``, ``FDSet``, ``Array``.


### PR DESCRIPTION
Currently, dicts can be constructed iteratively or via a pair of tuples.  This small patch allows initialization via a pair of arrays.  

There may be better ways to do this but this seemed the simplest.  Not sure of the effect on performance.

Edit: Added dict documentation updates.
