### PR TITLE
Minor cosmetic improvements for showing of AST:s

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -228,7 +228,6 @@ function show_unquoted(io::IO, ex::Expr, indent::Int)
         print(io, head, ' ')
         show_list(io, args, ", ", indent)
     elseif is(head, :macrocall) && nargs >= 1
-        print(io, '@')
         show_list(io, args, ' ', indent)
     elseif is(head, :typealias) && nargs == 2
         print(io, "typealias ")

--- a/base/show.jl
+++ b/base/show.jl
@@ -96,7 +96,7 @@ show_quoted(  io::IO, x)         = show_quoted(io, x, 0)
 show_quoted(  io::IO, x, indent) = show(io, x)
 show_unquoted(x)                 = show_unquoted(OUTPUT_STREAM, x)
 show_unquoted(io::IO, x)         = show_unquoted(io, x, 0)
-show_unquoted(io::IO, x, indent) = show(io, x)
+show_unquoted(io::IO, x, indent) = (print(io,"\$("); show(io,x); print(io,')'))
 
 ## Quoted AST printing ##
 
@@ -178,6 +178,10 @@ function show_enclosed_list(io::IO, op, items, sep, cl, indent)
 end
 
 ## Unquoted AST printing ##
+
+show_unquoted(io::IO, sym::Symbol, indent::Int) = print(io, sym)
+show_unquoted(io::IO, x::Number, indent::Int)   = show(io, x)
+show_unquoted(io::IO, x::String, indent::Int)   = show(io, x)
 
 const _expr_infix_wide = Set(:(=), :(+=), :(-=), :(*=), :(/=), :(\=), :(&=), 
     :(|=), :($=), :(>>>=), :(>>=), :(<<=), :(&&), :(||))


### PR DESCRIPTION
Fixes:
- Show wrongly interpolated AST:s such as `:(x=$[1])` differently from correct AST:s such as `:(x=[1])`, so you can see that they are fishy.
- Get rid of some superfluous quoting in the fallback for exprs that we don't know how to show,
  such as `expr(:foo, 1, :x)`.
- (Added: ) Get rid of superfluous `@` when showing macro invocations. 

Before:

```
julia> [:(x=$[1]), :(x=[1])]
2-element Expr Array:
 :( x = [1] )
 :( x = [1] )

julia> expr(:foo, 1, :x)
:( $(expr(:foo, :( 1 ), :x)) )
```

After:

```
julia> [:(x=$[1]), :(x=[1])]
2-element Expr :Array:
 :( x = $([1]) )
 :( x = [1] )   

julia> expr(:foo, 1, :x)
:( $(expr(:foo, 1, :x)) )
```

I would like to reduce quoting in the last example further to show it as `expr(:foo, 1, :x)` instead, but I haven't figured out a good way to do that yet. 
