### PR TITLE
RFC: Show symbols with a colon

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -228,7 +228,6 @@ function show_unquoted(io::IO, ex::Expr, indent::Int)
         print(io, head, ' ')
         show_list(io, args, ", ", indent)
     elseif is(head, :macrocall) && nargs >= 1
-        print(io, '@')
         show_list(io, args, ' ', indent)
     elseif is(head, :typealias) && nargs == 2
         print(io, "typealias ")

--- a/base/show.jl
+++ b/base/show.jl
@@ -8,7 +8,7 @@ show(io, x) = ccall(:jl_show_any, Void, (Any, Any,), io::IOStream, x)
 showcompact(io, x) = show(io, x)
 showcompact(x)     = showcompact(OUTPUT_STREAM::IOStream, x)
 
-show(io, s::Symbol) = print(io, s)
+show(io, s::Symbol) = show_indented(io, s)
 show(io, tn::TypeName) = show(io, tn.name)
 show(io, ::Nothing) = print(io, "nothing")
 show(io, b::Bool) = print(io, b ? "true" : "false")

--- a/base/show.jl
+++ b/base/show.jl
@@ -96,7 +96,7 @@ show_quoted(  io::IO, x)         = show_quoted(io, x, 0)
 show_quoted(  io::IO, x, indent) = show(io, x)
 show_unquoted(x)                 = show_unquoted(OUTPUT_STREAM, x)
 show_unquoted(io::IO, x)         = show_unquoted(io, x, 0)
-show_unquoted(io::IO, x, indent) = show(io, x)
+show_unquoted(io::IO, x, indent) = (print(io,"\$("); show(io,x); print(io,')'))
 
 ## Quoted AST printing ##
 
@@ -178,6 +178,10 @@ function show_enclosed_list(io::IO, op, items, sep, cl, indent)
 end
 
 ## Unquoted AST printing ##
+
+show_unquoted(io::IO, sym::Symbol, indent::Int) = print(io, sym)
+show_unquoted(io::IO, x::Number, indent::Int)   = show(io, x)
+show_unquoted(io::IO, x::String, indent::Int)   = show(io, x)
 
 const _expr_infix_wide = Set(:(=), :(+=), :(-=), :(*=), :(/=), :(\=), :(&=), 
     :(|=), :($=), :(>>>=), :(>>=), :(<<=), :(&&), :(||))


### PR DESCRIPTION
Currently, symbols show without a colon:

```
julia> :x
x
```

This patch changes it to

```
julia> :x
:x
```

`print` still produces the raw name when you need it, and thus `string` does as well.

I think this change would improve clarity. I put an RFC in the title because I wasn't sure if there's a reason that this hasn't been implemented already. Thoughts?

Btw, I built this patch on top of #1458, since I thought that one would be less controversial. If there's interest for a patch only changes `show` for symbols, I could fix that easily.
