### PR TITLE
Make product iterator iterate in a more natural fashion.

### DIFF
--- a/extras/iterators.jl
+++ b/extras/iterators.jl
@@ -190,7 +190,7 @@ function start(it::Product)
         end
     end
     vs = Array(Any, n)
-    for i = 1:n
+    for i = n:-1:1
         vs[i], js[i] = next(it.xss[i], js[i])
     end
     return js, vs
@@ -201,11 +201,11 @@ function next(it::Product, state)
     ans = tuple(vs...)
 
     n = length(it.xss)
-    for i in 1:n
+    for i in n:-1:1
         if !done(it.xss[i], js[i])
             vs[i], js[i] = next(it.xss[i], js[i])
             break
-        elseif i == n
+        elseif i == 1
             vs = nothing
             break
         end


### PR DESCRIPTION
Before:

``` julia
julia> f = ['A', 'B', 'C']
4-element Char Array:
 'A'
 'B'
 'C'

julia> [product(f, f)...]
9-element (Any...,) Array:
 ('A','A')
 ('B','A')
 ('C','A')
 ('A','B')
 ('B','B')
 ('C','B')
 ('A','C')
 ('B','C')
 ('C','C')
```

After:

``` julia
julia> [product(f,f)...]
9-element (Any...,) Array:
 ('A','A')
 ('A','B')
 ('A','C')
 ('B','A')
 ('B','B')
 ('B','C')
 ('C','A')
 ('C','B')
 ('C','C')
```
