### PR TITLE
Add all_matches function

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -105,18 +105,8 @@ match(r::Regex, s::String) = match(r, s, start(s))
 
 function all_matches(r::Regex, s::String)
     matches = RegexMatch[]
-    p::Int = 1
-    l::Int = strlen(s)
-    while p <= l 
-        m = match(r, s)
-        if !isa(m, Nothing)
-            push(matches, m)
-            offset::Int = min(max(m.offsets) + 1, strlen(s))
-        else
-            offset::Int = min(2, strlen(s))
-        end
-        p += offset
-        s = s[offset:]
+    for m in each_match(r, s)
+        push(matches, m)
     end
     return matches
 end

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -103,6 +103,24 @@ match(r::Regex, s::String, i::Integer, o::Integer) = match(r, bytestring(s), i, 
 match(r::Regex, s::String, i::Integer) = match(r, s, i, r.options & PCRE.EXECUTE_MASK)
 match(r::Regex, s::String) = match(r, s, start(s))
 
+function all_matches(r::Regex, s::String)
+    matches = RegexMatch[]
+    p::Int = 1
+    l::Int = strlen(s)
+    while p <= l 
+        m = match(r, s)
+        if !isa(m, Nothing)
+            push(matches, m)
+            offset::Int = min(max(m.offsets) + 1, strlen(s))
+        else
+            offset::Int = min(2, strlen(s))
+        end
+        p += offset
+        s = s[offset:]
+    end
+    return matches
+end
+
 function search(str::ByteString, re::Regex, idx::Integer)
     len = length(str)
     if idx >= len+2


### PR DESCRIPTION
This should be used in cases where you want to match multiple instances of a pattern in  a string using regular expressions. This is instead of adding a g modifier, e.g. `r"abc"g`.

Addresses #1487
