### PR TITLE
RFC: slightly more robust download_file

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -259,10 +259,28 @@ end
   error("not yet implemented")
 end
 
+downloadcmd = nothing
+for checkcmd in (:curl, :wget, :fetch)
+    if system("which $checkcmd > /dev/null") == 0
+        downloadcmd = checkcmd
+        break
+    end
+end
+function download_file(url::String, filename::String)
+    if downloadcmd == :wget
+        run(`wget -O $filename $url`)
+    elseif downloadcmd == :curl
+        run(`curl -o $filename $url`)
+    elseif downloadcmd == :fetch
+        run(`fetch -f $filename $url`)
+    else
+        error("No download agent available; install curl, wget, or fetch.")
+    end
+    filename
+end
 function download_file(url::String)
   filename = tempname()
-  run(`curl -o $filename $url`)
-  filename
+  download_file(url, filename)
 end
 
 function readdir(path::String)


### PR DESCRIPTION
This supports any one of several possible download agents, and issues an error if no suitable candidate can be found.

The "danger" here (and why it's an RFC) is that this patch runs UNIX commands at Julia startup, and I felt it would be better to give people a chance to test on platforms different from mine.

Apologies to the Windows crowd; I do not know what the right thing to do here would be.
