### PR TITLE
Ensure make uses bash instead of dash

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -10,6 +10,9 @@ USRINC = $(USR)/include
 LLVMROOT = $(USR)
 BUILD = $(USR)
 
+# Fix problems with Ubuntu using dash instead of bash
+SHELL = /bin/bash
+
 OS = $(shell uname)
 ARCH = $(shell uname -m)
 


### PR DESCRIPTION
This allows us to rollback [my previous pull request](https://github.com/JuliaLang/julia/pull/1429) getting rid of the globbing shell syntax, and just use that from now on.
