### PR TITLE
Add explicit Base. imports to extras/cairo.jl

### DIFF
--- a/extras/cairo.jl
+++ b/extras/cairo.jl
@@ -6,6 +6,8 @@ using Base
 using Color
 using Openlib
 
+import Base.fill, Base.get, Base.open, Base.close, Base.symbol
+
 export CairoSurface, finish, destroy, status,
     CAIRO_FORMAT_ARGB32,
     CAIRO_FORMAT_RGB24,


### PR DESCRIPTION
Fix errors like the following when loading `cairo.jl`:

```
julia> load("cairo.jl")
error in method definition: function Base.fill must be explicitly imported to be extended
 in load_now at util.jl:231
 in load_now at util.jl:245
 in require at util.jl:174
at /home/lulu/dev/julia/extras/cairo.jl:200
 in load_now at util.jl:231
 in load_now at util.jl:245
 in require at util.jl:174
 in load_now at util.jl:256
 in require at util.jl:174
```
