### PR TITLE
Improve JSON parsing performance

### DIFF
--- a/extras/json.jl
+++ b/extras/json.jl
@@ -18,12 +18,10 @@ function parse(strng::String)
     # String delimiters and escape characters are identified beforehand to improve speed
     len_esc::Int = 0
     index_esc::Int = 1
-    esc_locations::Array{Int64,1}  = Array(Int, 0)
-    for m in each_match(r"[\"\\\\]", strng)
-        len_esc = len_esc+1
-        push(esc_locations, m.offset)
-    end    
-    # esc = regexp(str, "[\"\\\\]"); index_esc = 1; len_esc = length(esc);  #TODO Enable for speed
+
+    esc_locations::Array{Int64,1}  = map(x->x.offset, [each_match(r"[\"\\\\]", strng)...])
+    len_esc=length(esc_locations)  
+
 
     function parse_object()
         parse_char('{')

--- a/extras/json.jl
+++ b/extras/json.jl
@@ -3,14 +3,14 @@
 #Original BSD Licence, (c) 2011, François Glineur
 
 
-module Json
+module JSON
 
 using Base
 
-export parse_json
+export parse
 
 
-function parse_json(strng::String)
+function parse(strng::String)
 
     pos::Int = 1
     len::Int = length(strng)

--- a/test/json.jl
+++ b/test/json.jl
@@ -46,5 +46,5 @@ u=parse_json(unicode)
 @assert u["অলিম্পিকস"]["রেকর্ড"][2]["Marathon"] == "জনি হেইস"
 
 #Uncomment while doing timing tests
-@time for i=1:100 ; parse_json(d) ; end
+#@time for i=1:100 ; parse_json(d) ; end
 

--- a/test/json.jl
+++ b/test/json.jl
@@ -1,15 +1,14 @@
 load("json")
-using Json
 
 load("test/json_samples")
 
 
-@assert parse_json(a) != nothing
-@assert parse_json(b) != nothing
-@assert parse_json(c) != nothing
-@assert parse_json(d) != nothing
+@assert JSON.parse(a) != nothing
+@assert JSON.parse(b) != nothing
+@assert JSON.parse(c) != nothing
+@assert JSON.parse(d) != nothing
 
-j=parse_json(e) 
+j=JSON.parse(e) 
 @assert  j!= nothing
 typeof(j) == Dict{String, Any}
 @assert length(j) == 1
@@ -24,27 +23,27 @@ typeof(j["menu"]) == Dict{String, Any}
 
 
 
-@assert parse_json(gmaps) != nothing
-@assert parse_json(colors1) != nothing
-@assert parse_json(colors2) != nothing
-@assert parse_json(colors3) != nothing
-@assert parse_json(twitter) != nothing
-@assert parse_json(facebook) != nothing
+@assert JSON.parse(gmaps) != nothing
+@assert JSON.parse(colors1) != nothing
+@assert JSON.parse(colors2) != nothing
+@assert JSON.parse(colors3) != nothing
+@assert JSON.parse(twitter) != nothing
+@assert JSON.parse(facebook) != nothing
 
-k=parse_json(flickr)
+k=JSON.parse(flickr)
 @assert k!= nothing
 @assert k["totalItems"] == 222
 @assert k["items"][1]["description"][12] == '\"'
-@assert parse_json(youtube) != nothing
-@assert parse_json(iphone) != nothing
-@assert parse_json(customer) != nothing
-@assert parse_json(product) != nothing
-@assert parse_json(interop) != nothing
+@assert JSON.parse(youtube) != nothing
+@assert JSON.parse(iphone) != nothing
+@assert JSON.parse(customer) != nothing
+@assert JSON.parse(product) != nothing
+@assert JSON.parse(interop) != nothing
 
-u=parse_json(unicode) 
+u=JSON.parse(unicode) 
 @assert u!=nothing
 @assert u["অলিম্পিকস"]["রেকর্ড"][2]["Marathon"] == "জনি হেইস"
 
 #Uncomment while doing timing tests
-#@time for i=1:100 ; parse_json(d) ; end
+#@time for i=1:100 ; JSON.parse(d) ; end
 


### PR DESCRIPTION
Improve JSON parsing performance by about 30% (and more when values are long strings) by using a regex to pre-calculate string delimiters and escape characters. 
