### PR TITLE
Updated zlib, gzip to work with system zlib.

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -118,6 +118,7 @@ const isimmutable = x->(isa(x,Tuple) || isa(x,Symbol) ||
 
 dlsym(hnd, s::String) = ccall(:jl_dlsym, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
 dlsym(hnd, s::Symbol) = ccall(:jl_dlsym, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
+dlsym_e(hnd, s::Symbol) = ccall(:jl_dlsym_e, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
 dlopen(s::String) = ccall(:jl_load_dynamic_library, Ptr{Void}, (Ptr{Uint8},), s)
 
 identity(x) = x

--- a/base/export.jl
+++ b/base/export.jl
@@ -1271,6 +1271,7 @@ export
     c_free,
     dlopen,
     dlsym,
+    dlsym_e,
     errno,
     getenv,
     hasenv,

--- a/extras/gzip.jl
+++ b/extras/gzip.jl
@@ -190,7 +190,7 @@ end
 
 # Use 64-bit functions if available
 
-if dlsym(_zlib, :gzopen64) != C_NULL
+if dlsym_e(_zlib, :gzopen64) != C_NULL
     const _gzopen = :gzopen64
     const _gzseek = :gzseek64
     const _gztell = :gztell64

--- a/extras/zlib.jl
+++ b/extras/zlib.jl
@@ -55,7 +55,7 @@ function compress_to_buffer(source::Array{Uint8}, dest::Array{Uint8}, level::Int
     dest_buf_size = Uint[length(dest)]
 
     # Compress the input
-    ret = ccall(dlsym(_zlib, :compress2), Int32, (Ptr{Uint}, Ptr{Uint}, Ptr{Uint}, Uint, Int32),
+    ret = ccall(dlsym(_zlib, :compress2), Int32, (Ptr{Uint8}, Ptr{Uint}, Ptr{Uint}, Uint, Int32),
                 dest, dest_buf_size, source, length(source), int32(level))
 
     if ret != Z_OK

--- a/extras/zlib_h.jl
+++ b/extras/zlib_h.jl
@@ -4,6 +4,9 @@ _zlib = dlopen("libz")
 
 # Constants
 
+zlib_version = bytestring(ccall(dlsym(_zlib, :zlibVersion), Ptr{Uint8}, ()))
+ZLIB_VERSION = tuple([int(c) for c in split(zlib_version, '.')]...)
+
 # Flush values
 const Z_NO_FLUSH       = int32(0)
 const Z_PARTIAL_FLUSH  = int32(1)
@@ -66,3 +69,20 @@ const Z_BIG_BUFSIZE = 131072
 # Constants for use with gzseek
 const SEEK_SET = int32(0)
 const SEEK_CUR = int32(1)
+
+# Create ZFileOffset alias
+# This is usually the same as FileOffset, 
+# unless we're on a 32-bit system and
+# 64-bit functions are not available
+
+# Get compile-time option flags
+zlib_compile_flags = ccall(dlsym(_zlib, :zlibCompileFlags), Uint, ())
+
+z_off_t_sz   = 2 << ((zlib_compile_flags >> 6) & uint(3))
+if z_off_t_sz == sizeof(FileOffset) || (sizeof(FileOffset) == 8 && dlsym_e(_zlib, :crc32_combine64) != C_NULL)
+    typealias ZFileOffset FileOffset
+elseif z_off_t_sz == 4      # 64-bit functions not available
+    typealias ZFileOffset Int32
+else
+    error("Can't figure out what to do with ZFileOffset.  sizeof(z_off_t) = ", z_off_t_sz)
+end

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -73,6 +73,7 @@
     jl_current_task;
     jl_defer_signal;
     jl_dlsym;
+    jl_dlsym_e;
     jl_dump_function;
     jl_enable_color;
     jl_enable_inference;

--- a/src/julia.h
+++ b/src/julia.h
@@ -841,6 +841,7 @@ DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
 
 // external libraries
 DLLEXPORT uv_lib_t *jl_load_dynamic_library(char *fname);
+DLLEXPORT void *jl_dlsym_e(uv_lib_t *handle, char *symbol);
 DLLEXPORT void *jl_dlsym(uv_lib_t *handle, char *symbol);
 
 // compiler

--- a/test/gzip.jl
+++ b/test/gzip.jl
@@ -91,7 +91,11 @@ pos = position(gzfile)
 ##########################
 
 # rewrite the test file
-for ch in "fhRFT "
+modes = "fhR "
+if GZip.ZLIB_VERSION >= (1,2,5,2)
+    modes = "fhRFT "
+end
+for ch in modes
     if ch == ' '
         ch = ""
     end
@@ -102,15 +106,17 @@ for ch in "fhRFT "
 
         file_size = filesize(test_compressed)
 
-        if ch == 'F' || ch == 'T'
+        #println("wb$level$ch: ", file_size)
+
+        if ch == 'T'
             @assert(file_size == length(data))
+        elseif ch == 'F'
+            @assert(file_size >= length(data))
         elseif level == 0
             @assert(file_size > length(data))
         else
             @assert(file_size < length(data))
         end
-
-        #println("wb$level$ch: ", filesize(test_compressed))
 
         # readline test
         gzf = gzopen(test_compressed)
@@ -140,7 +146,7 @@ end
 
 const BUFSIZE = 65536
 
-for level = 0:2:6
+for level = 0:3:6
     for T in [Int8,Uint8,Int16,Uint16,Int32,Uint32,Int64,Uint64,Int128,Uint128,
               Float32,Float64,Complex64,Complex128]
 
@@ -212,24 +218,24 @@ end
 
 unicode_gz_file = "$tmp/unicode_test.gz"
 
-str1 = CharString(reinterpret(Char, read(open("unicode/UTF-32LE.unicode"), Uint32, 1112065)[2:]))
-str2 = UTF8String(read(open("unicode/UTF-8.unicode"), Uint8, 4382595)[4:])
+str1 = CharString(reinterpret(Char, read(open("unicode/UTF-32LE.unicode"), Uint32, 1112065)[2:]));
+str2 = UTF8String(read(open("unicode/UTF-8.unicode"), Uint8, 4382595)[4:]);
 
 UTF32LE_gz = gzopen(unicode_gz_file, "w")
 write(UTF32LE_gz, str1)
 close(UTF32LE_gz)
 
-str1b = readall(`gunzip -c $unicode_gz_file`)
-str1c = gzopen(readall, unicode_gz_file)
+str1b = readall(`gunzip -c $unicode_gz_file`);
+str1c = gzopen(readall, unicode_gz_file);
 @assert str1 == str1b
 @assert str1 == str1c
 
-UTF8_gz = gzopen(unicode_gz_file, "w")
+UTF8_gz = gzopen(unicode_gz_file, "w");
 write(UTF8_gz, str2)
 close(UTF8_gz)
 
-str2b = readall(`gunzip -c $unicode_gz_file`)
-str2c = gzopen(readall, unicode_gz_file)
+str2b = readall(`gunzip -c $unicode_gz_file`);
+str2c = gzopen(readall, unicode_gz_file);
 @assert str2 == str2b
 @assert str2 == str2c
 

--- a/test/zlib.jl
+++ b/test/zlib.jl
@@ -48,7 +48,7 @@ z_off_t_sz   = 2 << ((zlib_compile_flags >> 6) & uint(3))
 @assert(z_uInt_sz == sizeof(Uint32))
 @assert(z_uLong_sz == sizeof(Uint))
 @assert(z_voidpf_sz == sizeof(Ptr))
-@assert(z_off_t_sz == sizeof(FileOffset))
+@assert(z_off_t_sz == sizeof(Zlib.ZFileOffset) || (dlsym(Zlib._zlib, :crc32_combine64) != C_NULL && sizeof(Zlib.ZFileOffset) == 8))
 
 ########################
 # compress/uncompress tests


### PR DESCRIPTION
- Use 64-bit functions by default if available, otherwise
  use 32-bit functions; ZFileOffset type is set accordingly
- Fix race condition in GZip.gzclose
- Export GZip.readall
- Make sure eof is set after read

The main change here is testing for the existence of 64-bit functions, for which `dlsym_e()` is now exported.  Please let me know if there is a better way to deal with this.

Edit: to clarify, `dlsym_e()` avoids an error message from `dlsym()` when the function in question does not exist.

Thanks,
   Kevin
