### PR TITLE
Fix for issue #1550

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -201,6 +201,7 @@ end
 
 function find_in_path(name::String)
     name[1] == '/' && return realpath(name)
+    is_file_readable(name) && return realpath(name)
     base = name
     if ends_with(name,".jl")
         base = match(r"^(.*)\.jl$",name).captures[1]


### PR DESCRIPTION
In require(name), see if "name" is a path to a file before searching LOAD_PATH.  This allows writing hash-bang scripts in Julia without the .jl extension, since the .jl extension will be appended (if missing) when searching LOAD_PATH.
