### PR TITLE
Split installation of libraries, move non-libraries to share/

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -4,7 +4,6 @@ JULIA_VERSION = $(shell cat $(JULIAHOME)/VERSION)
 JULIA_COMMIT = $(shell git rev-parse --short=10 HEAD)
 
 USR = $(JULIAHOME)/usr
-USRLIB = $(USR)/lib
 USRBIN = $(USR)/bin
 USRINC = $(USR)/include
 LLVMROOT = $(USR)
@@ -79,7 +78,7 @@ endif
 endif
 
 # if not absolute, then relative to JULIA_HOME
-JCFLAGS += '-DJL_SYSTEM_IMAGE_PATH="../lib/julia/sys.ji"'
+JCFLAGS += '-DJL_SYSTEM_IMAGE_PATH="../share/julia/sys.ji"'
 
 # OPENBLAS build options
 OPENBLAS_DYNAMIC_ARCH=0
@@ -126,7 +125,7 @@ endif
 ifeq ($(USE_SYSTEM_LIBUNWIND), 1)
 LIBUNWIND=-lunwind-generic -lunwind
 else
-LIBUNWIND=$(USRLIB)/libunwind-generic.a $(USRLIB)/libunwind.a
+LIBUNWIND=$(USR)/$(JL_LIBDIR)/libunwind-generic.a $(USR)/$(JL_LIBDIR)/libunwind.a
 endif
 
 ifeq ($(USE_SYSTEM_LLVM), 1)
@@ -138,19 +137,19 @@ endif
 ifeq ($(USE_SYSTEM_READLINE), 1)
 READLINE = -lreadline 
 else
-READLINE = $(USR)/lib/libreadline.a
+READLINE = $(USR)/$(JL_LIBDIR)/libreadline.a
 endif
 
 ifneq ($(OS),WINNT)
 READLINE += -lncurses
 else
-READLINE += $(USR)/lib/libhistory.a
+READLINE += $(USR)/$(JL_LIBDIR)/libhistory.a
 endif
 
 ifeq ($(USE_SYSTEM_PCRE), 1)
 PCRE_CONFIG = pcre-config
 else
-PCRE_CONFIG = $(USR)/bin/pcre-config
+PCRE_CONFIG = $(USRBIN)/pcre-config
 endif
 
 ifeq ($(USE_SYSTEM_BLAS), 1)
@@ -163,10 +162,10 @@ LIBBLASNAME = libblas
 endif
 else
 ifeq ($(OS), WINNT)
-LIBBLAS = $(USRLIB)/libopenblas-r0.2.2.$(SHLIB_EXT) #necessary due to some stupid Windows behavoir - will try yto fix soon
+LIBBLAS = $(USR)/$(JL_LIBDIR)/libopenblas-r0.2.2.$(SHLIB_EXT) #necessary due to some stupid Windows behavoir - will try yto fix soon
 LIBBLASNAME = libopenblas-r0.2.2
 else
-LIBBLAS = -L$(USRLIB) -lopenblas
+LIBBLAS = -L$(USR)/$(JL_LIBDIR) -lopenblas
 LIBBLASNAME = libopenblas
 endif
 endif
@@ -202,7 +201,7 @@ ifeq ($(OS), Linux)
 INSTALL_NAME_CMD = true -ignore
 INSTALL_NAME_CHANGE_CMD = true -ignore
 SHLIB_EXT = so
-RPATH = -Wl,-rpath,'$$ORIGIN/../lib'
+RPATH = -Wl,-rpath,'$$ORIGIN/../$(JL_LIBDIR)' -Wl,-rpath,'$$ORIGIN/../$(JL_PRIVATE_LIBDIR)'
 RPATH_ORIGIN = -Wl,-rpath,'$$ORIGIN'
 OSLIBS += -ldl -lrt -Wl,--export-dynamic -Wl,--version-script=$(JULIAHOME)/src/julia.expmap -Wl,--no-whole-archive $(LIBUNWIND)
 WHOLE_ARCHIVE = -Wl,--whole-archive
@@ -214,7 +213,7 @@ ifeq ($(OS), FreeBSD)
 INSTALL_NAME_CMD = true -ignore
 INSTALL_NAME_CHANGE_CMD = true -ignore
 SHLIB_EXT = so
-RPATH = -Wl,-rpath,'$$ORIGIN/../lib' -Wl,-z,origin
+RPATH = -Wl,-rpath,'$$ORIGIN/../$(JL_LIBDIR)' -Wl,-rpath,'$$ORIGIN/../$(JL_PRIVATE_LIBDIR)' -Wl,-z,origin
 RPATH_ORIGIN = -Wl,-rpath,'$$ORIGIN' -Wl,-z,origin
 WHOLE_ARCHIVE = -Wl,--whole-archive
 NO_WHOLE_ARCHIVE = -Wl,--no-whole-archive
@@ -225,7 +224,7 @@ endif
 ifeq ($(OS), Darwin)
 INSTALL_NAME_CMD = install_name_tool -id $(INSTALL_NAME_ID_DIR)
 INSTALL_NAME_CHANGE_CMD = install_name_tool -change
-RPATH = -Wl,-rpath,@executable_path/../lib
+RPATH = -Wl,-rpath,'@executable_path/../$(JL_LIBDIR)' -Wl,-rpath,'@executable_path/../$(JL_PRIVATE_LIBDIR)'
 SHLIB_EXT = dylib
 OSLIBS += -ldl -Wl,-w -framework ApplicationServices
 WHOLE_ARCHIVE = -Xlinker -all_load
@@ -265,6 +264,21 @@ LIBBLAS = -L$(ATLAS_LIBDIR) -lsatlas
 LIBLAPACK = $(LIBBLAS)
 LIBBLASNAME = libsatlas
 LIBLAPACKNAME = $(LIBBLASNAME)
+endif
+
+# List of "private" libraries, e.g. ones that get installed to lib/julia
+JL_PRIVATE_LIBS = openlibm julia-release suitesparse_wrapper tk_wrapper gmp_wrapper glpk_wrapper random
+JL_LIBS = Rmath amd arpack cholmod colamd fftw3 fftw3f fftw3_threads fftw3f_threads glpk gmp grisu history $(OPENBLASNAME) pcre readline spqr umfpack z
+
+# Directories where said libraries get installed to
+JL_PRIVATE_LIBDIR = lib/julia
+JL_LIBDIR = lib
+
+# If we're on debian, default to arch-dependent library dirs
+ifeq ($(USE_DEBIAN), 1)
+MULTIARCH = $(shell gcc -print-multiarch)
+JL_PRIVATE_LIBDIR = lib/$(MULTIARCH)/julia
+JL_LIBDIR = lib/$(MULTIARCH)/
 endif
 
 # Make tricks

--- a/Make.inc
+++ b/Make.inc
@@ -267,8 +267,8 @@ LIBLAPACKNAME = $(LIBBLASNAME)
 endif
 
 # List of "private" libraries, e.g. ones that get installed to lib/julia
-JL_PRIVATE_LIBS = openlibm julia-release suitesparse_wrapper tk_wrapper gmp_wrapper glpk_wrapper random
-JL_LIBS = Rmath amd arpack cholmod colamd fftw3 fftw3f fftw3_threads fftw3f_threads glpk gmp grisu history $(OPENBLASNAME) pcre readline spqr umfpack z
+JL_PRIVATE_LIBS = Rmath openlibm julia-release suitesparse_wrapper tk_wrapper gmp_wrapper glpk_wrapper random
+JL_LIBS = amd arpack cholmod colamd fftw3 fftw3f fftw3_threads fftw3f_threads glpk gmp grisu history $(OPENBLASNAME) pcre readline spqr umfpack z
 
 # Directories where said libraries get installed to
 JL_PRIVATE_LIBDIR = lib/julia

--- a/Makefile
+++ b/Makefile
@@ -4,20 +4,19 @@ include $(JULIAHOME)/Make.inc
 all: default
 default: release
 
-DIRS = $(BUILD)/bin $(BUILD)/etc $(BUILD)/lib/julia $(BUILD)/share/julia
+DIRS = $(BUILD)/bin $(BUILD)/etc $(BUILD)/$(JL_LIBDIR) $(BUILD)/$(JL_PRIVATE_LIBDIR) $(BUILD)/share/julia
 
 $(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
-$(foreach link,extras base ui test,$(eval $(call symlink_target,$(link),$(BUILD)/lib/julia)))
-$(foreach link,doc examples,$(eval $(call symlink_target,$(link),$(BUILD)/share/julia)))
+$(foreach link,extras base ui test doc examples,$(eval $(call symlink_target,$(link),$(BUILD)/share/julia)))
 
 MAKEs = $(MAKE)
 ifeq ($(USE_QUIET), 1)
 MAKEs += -s
 endif
 
-debug release: | $(DIRS) $(BUILD)/lib/julia/extras $(BUILD)/lib/julia/base $(BUILD)/lib/julia/ui $(BUILD)/lib/julia/test $(BUILD)/share/julia/doc $(BUILD)/share/julia/examples
+debug release: | $(DIRS) $(BUILD)/share/julia/extras $(BUILD)/share/julia/base $(BUILD)/share/julia/ui $(BUILD)/share/julia/test $(BUILD)/share/julia/doc $(BUILD)/share/julia/examples
 	@$(MAKEs) julia-$@
-	@$(MAKEs) JULIA_EXECUTABLE=$(JULIA_EXECUTABLE_$@) $(BUILD)/lib/julia/sys.ji
+	@$(MAKEs) JULIA_EXECUTABLE=$(JULIA_EXECUTABLE_$@) $(BUILD)/share/julia/sys.ji
 
 julia-debug julia-release:
 	@$(MAKEs) -C deps
@@ -27,13 +26,13 @@ julia-debug julia-release:
 	@$(MAKEs) -C ui $@
 	@ln -sf $(BUILD)/bin/$@-$(DEFAULT_REPL) julia
 
-$(BUILD)/lib/julia/helpdb.jl: doc/helpdb.jl | $(BUILD)/lib/julia
+$(BUILD)/share/julia/helpdb.jl: doc/helpdb.jl | $(BUILD)/share/julia
 	@cp $< $@
 
 # use sys.ji if it exists, otherwise run two stages
-$(BUILD)/lib/julia/sys.ji: VERSION base/*.jl $(BUILD)/lib/julia/helpdb.jl
+$(BUILD)/share/julia/sys.ji: VERSION base/*.jl $(BUILD)/share/julia/helpdb.jl
 	$(QUIET_JULIA) cd base && \
-	(test -f $(BUILD)/lib/julia/sys.ji || $(JULIA_EXECUTABLE) -bf sysimg.jl) && $(JULIA_EXECUTABLE) -f sysimg.jl || echo "Note: this error is usually fixed by running 'make clean'."
+	(test -f $(BUILD)/share/julia/sys.ji || $(JULIA_EXECUTABLE) -bf sysimg.jl) && $(JULIA_EXECUTABLE) -f sysimg.jl || echo "Note: this error is usually fixed by running 'make clean'."
 
 ifeq ($(OS), WINNT)
 OPENBLASNAME=openblas-r0.1.1
@@ -43,25 +42,28 @@ endif
 PREFIX ?= julia-$(JULIA_COMMIT)
 install: release
 	@$(MAKEs) -C test/unicode
-	@for subdir in "sbin" "bin" "etc" "lib/julia" "share/julia" ; do \
+	@for subdir in "sbin" "bin" "etc" $(JL_LIBDIR) $(JL_PRIVATE_LIBDIR) "share/julia" ; do \
 		mkdir -p $(PREFIX)/$$subdir ; \
 	done
 	cp $(BUILD)/bin/*julia* $(PREFIX)/bin
 	cd $(PREFIX)/bin && ln -s julia-release-$(DEFAULT_REPL) julia
-	cp -R -L $(BUILD)/lib/julia/* $(PREFIX)/lib/julia
-	-for suffix in "Rmath" "amd" "arpack" "cholmod" "colamd" "openlibm" "fftw3" "fftw3f" "fftw3_threads" "fftw3f_threads" "glpk" "glpk_wrapper" "gmp" "gmp_wrapper" "grisu" "history" "julia-release" "$(OPENBLASNAME)" "openlibm" "pcre" "random" "readline" "suitesparse_wrapper" "tk_wrapper" "spqr" "umfpack" "z" ; do \
-		cp $(BUILD)/lib/lib$${suffix}.$(SHLIB_EXT) $(PREFIX)/lib ; \
+	-for suffix in $(JL_LIBS) ; do \
+		cp $(BUILD)/$(JL_LIBDIR)/lib$${suffix}.$(SHLIB_EXT) $(PREFIX)/$(JL_LIBDIR) ; \
 	done
-# Web-REPL stuff
-	-cp $(BUILD)/lib/mod* $(PREFIX)/lib
+	-for suffix in $(JL_PRIVATE_LIBS) ; do \
+		cp $(BUILD)/$(JL_PRIVATE_LIBDIR)/lib$${suffix}.$(SHLIB_EXT) $(PREFIX)/$(JL_PRIVATE_LIBDIR) ; \
+	done
+	# Web-REPL stuff
+	-cp -R -L $(BUILD)/$(JL_LIBDIR)/lighttpd $(PREFIX)/$(JL_LIBDIR)
 	-cp $(BUILD)/sbin/* $(PREFIX)/sbin
 	-cp $(BUILD)/etc/* $(PREFIX)/etc
-	-cp -R -L $(BUILD)/share/* $(PREFIX)/share
+	# Copy in all .jl sources as well
+	-cp -R -L $(BUILD)/share/julia $(PREFIX)/share/
 ifeq ($(OS), WINNT)
 	-cp dist/windows/* $(PREFIX)
 ifeq ($(shell uname),MINGW32_NT-6.1)
 	-for dllname in "libgfortran-3" "libquadmath-0" "libgcc_s_dw2-1" "libstdc++-6,pthreadgc2" ; do \
-		cp /mingw/bin/$${dllname}.dll $(PREFIX)/lib ; \
+		cp /mingw/bin/$${dllname}.dll $(PREFIX)/$(JL_LIBDIR) ; \
 	done
 endif
 endif
@@ -71,7 +73,7 @@ dist: cleanall
 	-$(MAKE) -C deps clean-openblas
 	$(MAKE) install OPENBLAS_DYNAMIC_ARCH=1
 ifeq ($(OS), Darwin)
-	-./contrib/fixup-libgfortran.sh $(PREFIX)/lib /usr/local/lib
+	-./contrib/fixup-libgfortran.sh $(PREFIX)/$(JL_LIBDIR) /usr/local/lib
 endif
 	tar zcvf julia-$(JULIA_COMMIT)-$(OS)-$(ARCH).tar.gz julia-$(JULIA_COMMIT)
 	rm -fr julia-$(JULIA_COMMIT)
@@ -82,7 +84,7 @@ deb:
 debclean:
 	fakeroot debian/rules clean
 
-h2j: $(BUILD)/lib/libLLVM*.a $(BUILD)/lib/libclang*.a src/h2j.cpp
+h2j: $(BUILD)/$(JL_LIBDIR)/libLLVM*.a $(BUILD)/$(JL_LIBDIR)/libclang*.a src/h2j.cpp
 	$(QUIET_CC) g++ -O2 -fno-rtti -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -Iinclude $^ -o $@
 
 clean: | $(CLEAN_TARGETS)
@@ -98,7 +100,8 @@ clean: | $(CLEAN_TARGETS)
 		done \
 	done
 	@rm -f *~ *# *.tar.gz
-	@rm -fr $(BUILD)/lib/julia
+	@rm -fr $(BUILD)/$(JL_LIBDIR)
+	@rm -fr $(BUILD)/$(JL_PRIVATE_LIBDIR)
 
 cleanall: clean
 	@$(MAKE) -C src clean-flisp clean-support

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ default: release
 DIRS = $(BUILD)/bin $(BUILD)/etc $(BUILD)/$(JL_LIBDIR) $(BUILD)/$(JL_PRIVATE_LIBDIR) $(BUILD)/share/julia
 
 $(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
-$(foreach link,extras base ui test doc examples,$(eval $(call symlink_target,$(link),$(BUILD)/share/julia)))
+$(foreach link,extras base test doc examples,$(eval $(call symlink_target,$(link),$(BUILD)/share/julia)))
 
 MAKEs = $(MAKE)
 ifeq ($(USE_QUIET), 1)
 MAKEs += -s
 endif
 
-debug release: | $(DIRS) $(BUILD)/share/julia/extras $(BUILD)/share/julia/base $(BUILD)/share/julia/ui $(BUILD)/share/julia/test $(BUILD)/share/julia/doc $(BUILD)/share/julia/examples
+debug release: | $(DIRS) $(BUILD)/share/julia/extras $(BUILD)/share/julia/base $(BUILD)/share/julia/test $(BUILD)/share/julia/doc $(BUILD)/share/julia/examples
 	@$(MAKEs) julia-$@
 	@$(MAKEs) JULIA_EXECUTABLE=$(JULIA_EXECUTABLE_$@) $(BUILD)/share/julia/sys.ji
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -230,10 +230,10 @@ function _start()
         global const LOAD_PATH = ByteString[
             ".",
             julia_pkgdir(),
-            abs_path("$JULIA_HOME/../lib/julia"),
-            abs_path("$JULIA_HOME/../lib/julia/base"),
-            abs_path("$JULIA_HOME/../lib/julia/extras"),
-            abs_path("$JULIA_HOME/../lib/julia/ui"),
+            abs_path("$JULIA_HOME/../share/julia"),
+            abs_path("$JULIA_HOME/../share/julia/base"),
+            abs_path("$JULIA_HOME/../share/julia/extras"),
+            abs_path("$JULIA_HOME/../share/julia/ui"),
         ]
 
         (quiet,repl,startup) = process_options(ARGS)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -279,4 +279,4 @@ using Base
 
 # create system image file
 ccall(:jl_save_system_image, Void, (Ptr{Uint8},Ptr{Uint8}),
-      "$JULIA_HOME/../lib/julia/sys.ji", "start_image.jl")
+      "$JULIA_HOME/../share/julia/sys.ji", "start_image.jl")

--- a/base/util.jl
+++ b/base/util.jl
@@ -300,7 +300,7 @@ function _jl_init_help()
            _jl_help_module_dict, _jl_help_function_dict
     if _jl_help_category_dict == nothing
         println("Loading help data...")
-        helpdb = evalfile("$JULIA_HOME/../lib/julia/helpdb.jl")
+        helpdb = evalfile("$JULIA_HOME/../share/julia/helpdb.jl")
         _jl_help_category_list = {}
         _jl_help_category_dict = Dict()
         _jl_help_module_dict = Dict()

--- a/contrib/repackage_system_suitesparse3.make
+++ b/contrib/repackage_system_suitesparse3.make
@@ -6,18 +6,18 @@ include $(JULIAHOME)/Make.inc
 all: default
 
 default:
-	mkdir -p $(USRLIB)
+	mkdir -p $(USR)/$(JL_LIBDIR)
 	mkdir -p $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib
 	cd $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib && \
 	rm -f *.a && \
 	cp -f $(shell find /lib /usr/lib /usr/local/lib $(shell eval $(JULIAHOME)/contrib/filterArgs.sh $(LDFLAGS)) -name libamd.a -o -name libcolamd.a -o -name libcholmod.a -o -name libumfpack.a -o -name libspqr.a 2>/dev/null) . && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(USRLIB)/libamd.$(SHLIB_EXT) && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libcolamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(USRLIB)/libcolamd.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) -L$(USRLIB) -lcolamd -lamd $(LIBBLAS) && \
-	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(USRLIB)/libcholmod.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libumfpack.$(SHLIB_EXT) $(LDFLAGS) -L$(USRLIB) -lcholmod -lcolamd -lamd $(LIBBLAS) && \
-	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(USRLIB)/libumfpack.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libspqr.$(SHLIB_EXT) $(LDFLAGS) -L$(USRLIB) -lcholmod -lcolamd -lamd $(LIBBLAS) && \
-	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(USRLIB)/libspqr.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
+	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -lcolamd -lamd $(LIBBLAS) && \
+	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -lcholmod -lcolamd -lamd $(LIBBLAS) && \
+	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -lcholmod -lcolamd -lamd $(LIBBLAS) && \
+	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT)

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -6,19 +6,19 @@ include $(JULIAHOME)/Make.inc
 all: default
 
 default:
-	mkdir -p $(USRLIB)
+	mkdir -p $(USR)/$(JL_LIBDIR)
 	mkdir -p $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib
 	cd $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib && \
 	rm -f *.a && \
 	cp -f $(shell find /lib /usr/lib /usr/local/lib $(shell eval $(JULIAHOME)/contrib/filterArgs.sh $(LDFLAGS)) -name libamd.a -o -name libcolamd.a -o -name libcholmod.a -o -name libumfpack.a -o -name libspqr.a -o -name libsuitesparseconfig.a 2>/dev/null) . && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(USRLIB)/libamd.$(SHLIB_EXT) && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libcolamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(USRLIB)/libcolamd.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) -L$(USRLIB) -L. -lcolamd -lccolamd -lcamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(USRLIB)/libcholmod.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libumfpack.$(SHLIB_EXT) $(LDFLAGS) -L$(USRLIB) -L. -lcholmod -lcolamd -lcamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(USRLIB)/libumfpack.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libspqr.$(SHLIB_EXT) $(LDFLAGS) -L$(USRLIB) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(USRLIB)/libspqr.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
+	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -L. -lcolamd -lccolamd -lcamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -L. -lcholmod -lcolamd -lcamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT)
 	

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -373,7 +373,7 @@ distclean-openlibm: clean-openlibm
 
 ## Rmath ##
 
-RMATH_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libRmath.$(SHLIB_EXT)
+RMATH_OBJ_TARGET = $(USR)/$(JL_PRIVATE_LIBDIR)/libRmath.$(SHLIB_EXT)
 RMATH_OBJ_SOURCE = Rmath/src/libRmath.$(SHLIB_EXT)
 
 compile-rmath: $(RMATH_OBJ_SOURCE)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -97,7 +97,7 @@ $(USR): $(DIRS)
 
 ## LLVM ##
 
-LLVM_OBJ_TARGET = $(USRLIB)/libLLVM-$(LLVM_VER).$(SHLIB_EXT)
+LLVM_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libLLVM-$(LLVM_VER).$(SHLIB_EXT)
 ifeq ($(OS),WINNT)
 	LLVM_OBJ_SOURCE = llvm-$(LLVM_VER)/Release/bin/LLVM-$(LLVM_VER).$(SHLIB_EXT)
 else
@@ -177,7 +177,7 @@ $(LLVM_OBJ_SOURCE): llvm-$(LLVM_VER)/configure | llvm_python_workaround
 $(LLVM_OBJ_TARGET): $(LLVM_OBJ_SOURCE) | llvm_python_workaround
 	export PATH=$(abspath llvm-$(LLVM_VER)/python2_path):$$PATH && \
 	$(MAKE) -C llvm-$(LLVM_VER) install
-	$(INSTALL_NAME_CMD)libLLVM-$(LLVM_VER).$(SHLIB_EXT) $(USRLIB)/libLLVM-$(LLVM_VER).$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libLLVM-$(LLVM_VER).$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libLLVM-$(LLVM_VER).$(SHLIB_EXT)
 	touch $@
 
 clean-llvm:
@@ -188,7 +188,7 @@ distclean-llvm:
 
 ## GNU readline ##
 
-READLINE_OBJ_TARGET = $(USRLIB)/libreadline.$(SHLIB_EXT)
+READLINE_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libreadline.$(SHLIB_EXT)
 READLINE_OBJ_SOURCE = readline-$(READLINE_VER)/shlib/libreadline.$(READLINE_VER).$(SHLIB_EXT)
 
 READLINE_OPTS = --disable-shared --enable-static
@@ -245,9 +245,9 @@ $(READLINE_OBJ_SOURCE): readline-$(READLINE_VER)/configure
 	touch $@
 $(READLINE_OBJ_TARGET): $(READLINE_OBJ_SOURCE)
 	$(MAKE) -C readline-$(READLINE_VER) install
-	chmod +w $(USRLIB)/libreadline.* $(USRLIB)/libhistory.*
-	$(INSTALL_NAME_CMD)libreadline.$(SHLIB_EXT) $(USRLIB)/libreadline.$(SHLIB_EXT) 
-	$(INSTALL_NAME_CMD)libhistory.dylib $(USRLIB)/libhistory.dylib
+	chmod +w $(USR)/$(JL_LIBDIR)/libreadline.* $(USR)/$(JL_LIBDIR)/libhistory.*
+	$(INSTALL_NAME_CMD)libreadline.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libreadline.$(SHLIB_EXT) 
+	$(INSTALL_NAME_CMD)libhistory.dylib $(USR)/$(JL_LIBDIR)/libhistory.dylib
 	touch $@
 
 clean-readline:
@@ -266,7 +266,7 @@ else
 UV_CFLAGS = CFLAGS="-g -fPIC"
 endif
 
-UV_OBJ_TARGET = $(USRLIB)/uv.a
+UV_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/uv.a
 UV_OBJ_SOURCE = libuv/uv.a
 
 libuv/Makefile:
@@ -275,18 +275,18 @@ $(UV_OBJ_SOURCE): libuv/Makefile
 	$(MAKE) -C libuv $(UV_CFLAGS) CC="$(CC)"
 $(UV_OBJ_TARGET): $(UV_OBJ_SOURCE)
 	mkdir -p $(USR)/include
-	cp $(UV_OBJ_SOURCE) $(USRLIB)/
+	cp $(UV_OBJ_SOURCE) $(USR)/$(JL_LIBDIR)/
 	cp -r libuv/include/* $(USR)/include
 install-uv: $(UV_OBJ_TARGET)
 
 clean-uv:
 	$(MAKE) -C libuv clean
-	rm -f $(USRLIB)/uv.a $(USR)/include/uv.h
+	rm -f $(USR)/$(JL_LIBDIR)/uv.a $(USR)/include/uv.h
 distclean-uv: clean-uv
 
 ## PCRE ##
 
-PCRE_OBJ_TARGET = $(USRLIB)/libpcre.$(SHLIB_EXT)
+PCRE_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libpcre.$(SHLIB_EXT)
 
 compile-pcre: install-pcre
 install-pcre: $(PCRE_OBJ_TARGET)
@@ -303,8 +303,8 @@ $(PCRE_OBJ_TARGET): pcre-$(PCRE_VER)/config.status
 	$(MAKE) -C pcre-$(PCRE_VER) install
 	$(INSTALL_NAME_CMD)libpcre.dylib $@
 ifeq ($(OS),WINNT)
-	-rm $(USRLIB)/libpcre.dll
-	mv $(USRBIN)/libpcre-1.dll $(USRLIB)/libpcre.dll
+	-rm $(USR)/$(JL_LIBDIR)/libpcre.dll
+	mv $(USRBIN)/libpcre-1.dll $(USR)/$(JL_LIBDIR)/libpcre.dll
 endif
 	touch $@
 
@@ -319,7 +319,7 @@ distclean-pcre:
 GRISU_OPTS = -O3 -fvisibility=hidden $(fPIC)
 
 compile-double-conversion: double-conversion-$(GRISU_VER)/src/libgrisu_.$(SHLIB_EXT)
-install-double-conversion: $(USRLIB)/libgrisu.$(SHLIB_EXT)
+install-double-conversion: $(USR)/$(JL_LIBDIR)/libgrisu.$(SHLIB_EXT)
 
 double-conversion-$(GRISU_VER).tar.gz:
 	$(WGET) http://double-conversion.googlecode.com/files/double-conversion-$(GRISU_VER).tar.gz
@@ -339,7 +339,7 @@ double-conversion-$(GRISU_VER)/src/libgrisu.$(SHLIB_EXT): double-conversion-$(GR
 	$(CXX) -c $(GRISU_OPTS) -o src/strtod.o -Isrc src/strtod.cc && \
 	$(CXX) -c $(GRISU_OPTS) -o src/libdouble-conversion.o -I.. -Isrc ../double_conversion_wrapper.cpp && \
 	$(CXX) $(GRISU_OPTS) src/*.o -shared -dead_strip -o src/libgrisu.$(SHLIB_EXT)
-$(USRLIB)/libgrisu.$(SHLIB_EXT): double-conversion-$(GRISU_VER)/src/libgrisu.$(SHLIB_EXT)
+$(USR)/$(JL_LIBDIR)/libgrisu.$(SHLIB_EXT): double-conversion-$(GRISU_VER)/src/libgrisu.$(SHLIB_EXT)
 	cp -f $< $@
 	$(INSTALL_NAME_CMD)libgrisu.dylib $@
 
@@ -355,14 +355,14 @@ ifeq ($(OS), WINNT) #needs more advanced detection once 64bit build is possible
 OPENLIBM_FLAGS = ARCH=i386
 endif
 
-OPENLIBM_OBJ_TARGET = $(USRLIB)/libopenlibm.$(SHLIB_EXT)
+OPENLIBM_OBJ_TARGET = $(USR)/$(JL_PRIVATE_LIBDIR)/libopenlibm.$(SHLIB_EXT)
 OPENLIBM_OBJ_SOURCE = openlibm/libopenlibm.$(SHLIB_EXT)
 
 openlibm/Makefile:
 	(cd .. && git submodule update --init)
 $(OPENLIBM_OBJ_SOURCE): openlibm/Makefile
 	$(MAKE) -C openlibm $(OPENLIBM_FLAGS) CC="$(CC)" FC="$(FC)" USECLANG=$(USECLANG) USEGCC=$(USEGCC)
-$(OPENLIBM_OBJ_TARGET): $(OPENLIBM_OBJ_SOURCE) | $(USRLIB)
+$(OPENLIBM_OBJ_TARGET): $(OPENLIBM_OBJ_SOURCE) | $(USR)/$(JL_PRIVATE_LIBDIR)
 	cp $< $@
 install-openlibm: $(OPENLIBM_OBJ_TARGET)
 
@@ -373,7 +373,7 @@ distclean-openlibm: clean-openlibm
 
 ## Rmath ##
 
-RMATH_OBJ_TARGET = $(USRLIB)/libRmath.$(SHLIB_EXT)
+RMATH_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libRmath.$(SHLIB_EXT)
 RMATH_OBJ_SOURCE = Rmath/src/libRmath.$(SHLIB_EXT)
 
 compile-rmath: $(RMATH_OBJ_SOURCE)
@@ -393,7 +393,7 @@ distclean-rmath: clean-rmath
 
 ## LIBRANDOM ##
 
-LIBRANDOM_OBJ_TARGET = $(USRLIB)/librandom.$(SHLIB_EXT)
+LIBRANDOM_OBJ_TARGET = $(USR)/$(JL_PRIVATE_LIBDIR)/librandom.$(SHLIB_EXT)
 LIBRANDOM_OBJ_SOURCE = random/librandom.$(SHLIB_EXT)
 
 LIBRANDOM_CFLAGS = $(CFLAGS) -O3 -finline-functions -fomit-frame-pointer -DNDEBUG -fno-strict-aliasing --param max-inline-insns-single=1800 -Wmissing-prototypes -Wall  -std=c99 -DDSFMT_MEXP=19937 $(fPIC) -shared -DDSFMT_DO_NOT_USE_OLD_NAMES
@@ -444,7 +444,7 @@ endif
 #endif
 
 compile-openblas: $(OPENBLAS_OBJ_SOURCE)
-install-openblas: $(USRLIB)/libopenblas.$(SHLIB_EXT)
+install-openblas: $(USR)/$(JL_LIBDIR)/libopenblas.$(SHLIB_EXT)
 
 openblas-$(OPENBLAS_VER).tar.gz:
 	$(WGET_DASH_O) $@ https://github.com/xianyi/OpenBLAS/tarball/$(OPENBLAS_VER) 
@@ -455,9 +455,9 @@ openblas-$(OPENBLAS_VER)/Makefile: openblas-$(OPENBLAS_VER).tar.gz
 	touch $@
 $(OPENBLAS_OBJ_SOURCE): openblas-$(OPENBLAS_VER)/Makefile
 	$(MAKE) -C openblas-$(OPENBLAS_VER) CC="$(CC)" FC="$(FC)" FFLAGS="$(FFLAGS) $(JFFLAGS)" USE_THREAD=$(OPENBLAS_USE_THREAD) TARGET=$(OPENBLAS_TARGET_ARCH) $(OPENBLAS_BUILD_OPTS)
-$(USRLIB)/libopenblas.$(SHLIB_EXT): $(OPENBLAS_OBJ_SOURCE) | $(USRLIB)
-	cp -f openblas-$(OPENBLAS_VER)/libopenblas.$(SHLIB_EXT) $(USRLIB)
-	$(INSTALL_NAME_CMD)libopenblas.$(SHLIB_EXT) $(USRLIB)/libopenblas.$(SHLIB_EXT)
+$(USR)/$(JL_LIBDIR)/libopenblas.$(SHLIB_EXT): $(OPENBLAS_OBJ_SOURCE) | $(USR)/$(JL_LIBDIR)
+	cp -f openblas-$(OPENBLAS_VER)/libopenblas.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)
+	$(INSTALL_NAME_CMD)libopenblas.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libopenblas.$(SHLIB_EXT)
 
 clean-openblas:
 	$(MAKE) -C openblas-$(OPENBLAS_VER) clean
@@ -467,7 +467,7 @@ distclean-openblas:
 ## LAPACK ##
 
 ifeq ($(USE_SYSTEM_LAPACK), 0)
-LAPACK_OBJ_TARGET = $(USRLIB)/liblapack.$(SHLIB_EXT)
+LAPACK_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/liblapack.$(SHLIB_EXT)
 LAPACK_OBJ_SOURCE = lapack-$(LAPACK_VER)/liblapack.$(SHLIB_EXT)
 else
 LAPACK_OBJ_TARGET =
@@ -501,7 +501,7 @@ distclean-lapack:
 
 ## ARPACK ##
 
-ARPACK_OBJ_TARGET = $(USRLIB)/libarpack.$(SHLIB_EXT)
+ARPACK_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libarpack.$(SHLIB_EXT)
 ARPACK_OBJ_SOURCE = arpack-ng_$(ARPACK_VER)/libarpack.$(SHLIB_EXT)
 
 compile-arpack: $(ARPACK_OBJ_SOURCE)
@@ -517,10 +517,10 @@ $(ARPACK_OBJ_SOURCE): arpack-ng_$(ARPACK_VER)/configure $(OPENBLAS_OBJ_SOURCE)
 	cd arpack-ng_$(ARPACK_VER) && \
 	./configure  --prefix=$(abspath $(USR)) --with-blas="$(LIBBLAS)" --with-lapack="$(LIBLAPACK)" --disable-mpi --enable-shared F77="$(FC)" MPIF77="$(FC)" CC="$(CC)" CXX="$(CXX)"
 	touch $@
-$(ARPACK_OBJ_TARGET): $(ARPACK_OBJ_SOURCE) | $(USRLIB)
+$(ARPACK_OBJ_TARGET): $(ARPACK_OBJ_SOURCE) | $(USR)/$(JL_LIBDIR)
 	cd arpack-ng_$(ARPACK_VER) && \
 	$(MAKE) install F77="$(FC)" MPIF77="$(FC)"
-	$(INSTALL_NAME_CMD)libarpack.$(SHLIB_EXT) $(USRLIB)/libarpack.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libarpack.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libarpack.$(SHLIB_EXT)
 	touch $@
 
 clean-arpack:
@@ -531,8 +531,8 @@ distclean-arpack:
 
 ## FFTW ##
 
-FFTW_SINGLE_OBJ_TARGET = $(USRLIB)/libfftw3f.3.$(SHLIB_EXT)
-FFTW_DOUBLE_OBJ_TARGET = $(USRLIB)/libfftw3.3.$(SHLIB_EXT)
+FFTW_SINGLE_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libfftw3f.3.$(SHLIB_EXT)
+FFTW_DOUBLE_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libfftw3.3.$(SHLIB_EXT)
 
 compile-fftw: compile-fftw-single compile-fftw-double
 compile-fftw-single: install-fftw-single
@@ -564,12 +564,12 @@ fftw-$(FFTW_VER)-single/config.status: fftw-$(FFTW_VER)-single/configure
 	touch $@
 $(FFTW_SINGLE_OBJ_TARGET): fftw-$(FFTW_VER)-single/config.status
 	$(MAKE) -C fftw-$(FFTW_VER)-single install
-	$(INSTALL_NAME_CMD)libfftw3f.dylib $(USRLIB)/libfftw3f.dylib
-	$(INSTALL_NAME_CMD)libfftw3f_threads.$(SHLIB_EXT) $(USRLIB)/libfftw3f_threads.$(SHLIB_EXT)
-	$(INSTALL_NAME_CHANGE_CMD) $(USRLIB)/libfftw3f.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3f.dylib $(USRLIB)/libfftw3f_threads.dylib
+	$(INSTALL_NAME_CMD)libfftw3f.dylib $(USR)/$(JL_LIBDIR)/libfftw3f.dylib
+	$(INSTALL_NAME_CMD)libfftw3f_threads.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libfftw3f_threads.$(SHLIB_EXT)
+	$(INSTALL_NAME_CHANGE_CMD) $(USR)/$(JL_LIBDIR)/libfftw3f.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3f.dylib $(USR)/$(JL_LIBDIR)/libfftw3f_threads.dylib
 ifeq ($(OS),WINNT)
-	-rm $(USRLIB)/libfftw3f.dll
-	mv $(USRBIN)/libfftw3f-3.dll $(USRLIB)/libfftw3f.dll
+	-rm $(USR)/$(JL_LIBDIR)/libfftw3f.dll
+	mv $(USRBIN)/libfftw3f-3.dll $(USR)/$(JL_LIBDIR)/libfftw3f.dll
 endif
 	touch $@
 
@@ -584,12 +584,12 @@ fftw-$(FFTW_VER)-double/config.status: fftw-$(FFTW_VER)-double/configure
 	touch $@
 $(FFTW_DOUBLE_OBJ_TARGET): fftw-$(FFTW_VER)-double/config.status
 	$(MAKE) -C fftw-$(FFTW_VER)-double install
-	$(INSTALL_NAME_CMD)libfftw3.$(SHLIB_EXT) $(USRLIB)/libfftw3.$(SHLIB_EXT) 
-	$(INSTALL_NAME_CMD)libfftw3_threads.$(SHLIB_EXT) $(USRLIB)/libfftw3_threads.$(SHLIB_EXT) 
-	$(INSTALL_NAME_CHANGE_CMD) $(USRLIB)/libfftw3.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3.dylib $(USRLIB)/libfftw3_threads.dylib
+	$(INSTALL_NAME_CMD)libfftw3.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libfftw3.$(SHLIB_EXT) 
+	$(INSTALL_NAME_CMD)libfftw3_threads.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libfftw3_threads.$(SHLIB_EXT) 
+	$(INSTALL_NAME_CHANGE_CMD) $(USR)/$(JL_LIBDIR)/libfftw3.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3.dylib $(USR)/$(JL_LIBDIR)/libfftw3_threads.dylib
 ifeq ($(OS),WINNT)
-	-rm $(USRLIB)/libfftw3.dll
-	mv $(USRBIN)/libfftw3-3.dll $(USRLIB)/libfftw3.dll
+	-rm $(USR)/$(JL_LIBDIR)/libfftw3.dll
+	mv $(USRBIN)/libfftw3-3.dll $(USR)/$(JL_LIBDIR)/libfftw3.dll
 endif
 	touch $@
 
@@ -608,17 +608,17 @@ distclean-fftw:
 
 ifeq ($(USE_SYSTEM_SUITESPARSE), 0)
 SUITESPARSE_OBJ_SOURCE = SuiteSparse-$(SUITESPARSE_VER)/UMFPACK/Lib/libumfpack.a
-SUITESPARSE_OBJ_TARGET = $(USRLIB)/libumfpack.$(SHLIB_EXT)
+SUITESPARSE_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT)
 endif
 
 ifeq ($(OS), Darwin)
-SUITE_SPARSE_LIB = -lm -Wl,-rpath,'$(USRLIB)'
+SUITE_SPARSE_LIB = -lm -Wl,-rpath,'$(USR)/$(JL_LIBDIR)'
 else
-SUITE_SPARSE_LIB = -lm -lrt -Wl,-rpath,'$(USRLIB)'
+SUITE_SPARSE_LIB = -lm -lrt -Wl,-rpath,'$(USR)/$(JL_LIBDIR)'
 endif
 
 compile-suitesparse: $(SUITESPARSE_OBJ_SOURCE)
-install-suitesparse: $(SUITESPARSE_OBJ_TARGET) $(USRLIB)/libsuitesparse_wrapper.$(SHLIB_EXT)
+install-suitesparse: $(SUITESPARSE_OBJ_TARGET) $(USR)/$(JL_PRIVATE_LIBDIR)/libsuitesparse_wrapper.$(SHLIB_EXT)
 
 SuiteSparse-$(SUITESPARSE_VER).tar.gz:
 	$(WGET) http://www.cise.ufl.edu/research/sparse/SuiteSparse/SuiteSparse-$(SUITESPARSE_VER).tar.gz
@@ -628,7 +628,7 @@ SuiteSparse-$(SUITESPARSE_VER)/Makefile: SuiteSparse-$(SUITESPARSE_VER).tar.gz
 	touch $@
 $(SUITESPARSE_OBJ_SOURCE): $(OPENBLAS_OBJ_SOURCE) SuiteSparse-$(SUITESPARSE_VER)/Makefile
 	cd SuiteSparse-$(SUITESPARSE_VER) && \
-	$(MAKE) CC="$(CC)" CXX="$(CXX)" BLAS="$(LIBBLAS)" LAPACK="$(LIBLAPACK)" INSTALL_LIB="$(USRLIB)" INSTALL_INCLUDE="$(USRINC)" LIB="$(SUITE_SPARSE_LIB)"
+	$(MAKE) CC="$(CC)" CXX="$(CXX)" BLAS="$(LIBBLAS)" LAPACK="$(LIBLAPACK)" INSTALL_LIB="$(USR)/$(JL_LIBDIR)" INSTALL_INCLUDE="$(USRINC)" LIB="$(SUITE_SPARSE_LIB)"
 	touch $@
 
 ifeq ($(USE_SYSTEM_SUITESPARSE), 0)
@@ -637,16 +637,16 @@ $(SUITESPARSE_OBJ_TARGET): $(SUITESPARSE_OBJ_SOURCE)
 	cd SuiteSparse-$(SUITESPARSE_VER)/lib && \
 	rm -f *.a && \
 	cp -f `find .. -name libamd.a -o -name libcolamd.a -o -name libcholmod.a -o -name libumfpack.a -o -name libsuitesparseconfig.a -o -name libspqr.a 2>/dev/null` . && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(USRLIB)/libamd.$(SHLIB_EXT) && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libcolamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(USRLIB)/libcolamd.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libcholmod.$(SHLIB_EXT) -L$(USRLIB) -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(USRLIB)/libcholmod.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libumfpack.$(SHLIB_EXT) -L$(USRLIB) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(USRLIB)/libumfpack.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(USRLIB)/libspqr.$(SHLIB_EXT) -L$(USRLIB) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(USRLIB)/libspqr.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
+	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) -L$(USR)/$(JL_LIBDIR) -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) -L$(USR)/$(JL_LIBDIR) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT) -L$(USR)/$(JL_LIBDIR) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT)
 endif
 
 clean-suitesparse:
@@ -662,22 +662,22 @@ SUITESPARSE_INC = -I /usr/include/suitesparse
 SUITESPARSE_LIB = -lumfpack -lcholmod -lamd -lcamd -lcolamd -lspqr
 else
 SUITESPARSE_INC = -I SuiteSparse-$(SUITESPARSE_VER)/CHOLMOD/Include -I SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse_config -I SuiteSparse-$(SUITESPARSE_VER)/SPQR/Include
-SUITESPARSE_LIB = -L$(USRLIB) -lcholmod -lumfpack -lspqr $(RPATH_ORIGIN)
+SUITESPARSE_LIB = -L$(USR)/$(JL_LIBDIR) -lcholmod -lumfpack -lspqr $(RPATH_ORIGIN)
 endif
 
-$(USRLIB)/libsuitesparse_wrapper.$(SHLIB_EXT): SuiteSparse_wrapper.c $(SUITESPARSE_OBJ_TARGET)
-	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(SUITESPARSE_INC) SuiteSparse_wrapper.c -o $(USRLIB)/libsuitesparse_wrapper.$(SHLIB_EXT) $(SUITESPARSE_LIB)
+$(USR)/$(JL_PRIVATE_LIBDIR)/libsuitesparse_wrapper.$(SHLIB_EXT): SuiteSparse_wrapper.c $(SUITESPARSE_OBJ_TARGET)
+	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(SUITESPARSE_INC) SuiteSparse_wrapper.c -o $(USR)/$(JL_PRIVATE_LIBDIR)/libsuitesparse_wrapper.$(SHLIB_EXT) $(SUITESPARSE_LIB)
 	$(INSTALL_NAME_CMD)libsuitesparse_wrapper.$(SHLIB_EXT) $@
 	touch $@
-install-suitesparse-wrapper: $(USRLIB)/libsuitesparse_wrapper.$(SHLIB_EXT)
+install-suitesparse-wrapper: $(USR)/$(JL_PRIVATE_LIBDIR)/libsuitesparse_wrapper.$(SHLIB_EXT)
 
 clean-suitesparse-wrapper:
-	rm -f $(SUITESPARSE_OBJ_TARGET) $(USRLIB)/libsuitesparse_wrapper.$(SHLIB_EXT)
+	rm -f $(SUITESPARSE_OBJ_TARGET) $(USR)/$(JL_PRIVATE_LIBDIR)/libsuitesparse_wrapper.$(SHLIB_EXT)
 distclean-suitesparse-wrapper: clean-suitesparse-wrapper
 
 ## CLP ##
 
-CLP_OBJ_TARGET = $(USRLIB)/libClp.$(SHLIB_EXT)
+CLP_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libClp.$(SHLIB_EXT)
 
 compile-clp: install-clp
 install-clp: $(CLP_OBJ_TARGET)
@@ -704,7 +704,7 @@ distclean-clp:
 ## UNWIND ##
 
 ifeq ($(USE_SYSTEM_LIBUNWIND), 0)
-LIBUNWIND_TARGET_OBJ = $(USRLIB)/libunwind.a
+LIBUNWIND_TARGET_OBJ = $(USR)/$(JL_LIBDIR)/libunwind.a
 LIBUNWIND_TARGET_SOURCE = libunwind-$(UNWIND_VER)/src/.libs/libunwind.a
 else
 LIBUNWIND_TARGET_OBJ = 
@@ -757,8 +757,9 @@ lighttpd-$(LIGHTTPD_VER)/configure: lighttpd-$(LIGHTTPD_VER).tar.gz
 	tar zxf $<
 	touch $@
 lighttpd-$(LIGHTTPD_VER)/config.status: lighttpd-$(LIGHTTPD_VER)/configure
+	mkdir -p $(USR)/$(JL_LIBDIR)/lighttpd && \
 	cd lighttpd-$(LIGHTTPD_VER) && \
-	./configure --prefix=$(abspath $(USR)) --without-pcre --without-zlib --without-bzip2 CC="$(CC)" CXX="$(CXX)"
+	./configure --prefix=$(USR) --libdir=$(USR)/$(JL_LIBDIR)/lighttpd --without-pcre --without-zlib --without-bzip2 CC="$(CC)" CXX="$(CXX)"
 $(LIGHTTPD_OBJ_TARGET): lighttpd-$(LIGHTTPD_VER)/config.status
 	$(MAKE) -C lighttpd-$(LIGHTTPD_VER) install
 	touch $@
@@ -772,7 +773,7 @@ distclean-lighttpd:
 ## GMP ##
 
 ifeq ($(USE_SYSTEM_GMP), 0)
-GMP_OBJ_TARGET = $(USRLIB)/libgmp.$(SHLIB_EXT)
+GMP_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libgmp.$(SHLIB_EXT)
 else
 GMP_OBJ_TARGET = 
 endif
@@ -808,17 +809,17 @@ GMPW_INC =
 GMPW_LIB = -lgmp
 else
 GMPW_INC = -I $(USRINC)
-GMPW_LIB = -L$(USRLIB)/ -lgmp
+GMPW_LIB = -L$(USR)/$(JL_LIBDIR)/ -lgmp
 endif
 
-$(USRLIB)/libgmp_wrapper.$(SHLIB_EXT): gmp_wrapper.c $(GMP_OBJ_TARGET) | $(USRLIB)
-	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GMPW_INC) gmp_wrapper.c -o $(USRLIB)/libgmp_wrapper.$(SHLIB_EXT) -Wl,-rpath,$(USRLIB) $(GMPW_LIB)
+$(USR)/$(JL_PRIVATE_LIBDIR)/libgmp_wrapper.$(SHLIB_EXT): gmp_wrapper.c $(GMP_OBJ_TARGET) | $(USR)/$(JL_PRIVATE_LIBDIR)
+	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GMPW_INC) gmp_wrapper.c -o $(USR)/$(JL_PRIVATE_LIBDIR)/libgmp_wrapper.$(SHLIB_EXT) '-Wl,-rpath,$$ORIGIN/../$(JL_LIBDIR)' $(GMPW_LIB)
 	$(INSTALL_NAME_CMD)libgmp_wrapper.$(SHLIB_EXT) $@
 	touch $@
-install-gmp-wrapper: $(USRLIB)/libgmp_wrapper.$(SHLIB_EXT)
+install-gmp-wrapper: $(USR)/$(JL_PRIVATE_LIBDIR)/libgmp_wrapper.$(SHLIB_EXT)
 
 clean-gmp-wrapper:
-	rm -f $(GMP_OBJ_TARGET) $(USRLIB)/libgmp_wrapper.$(SHLIB_EXT)
+	rm -f $(GMP_OBJ_TARGET) $(USR)/$(JL_PRIVATE_LIBDIR)/libgmp_wrapper.$(SHLIB_EXT)
 distclean-gmp-wrapper: clean-gmp-wrapper
 
 ## GLPK ##
@@ -826,11 +827,11 @@ distclean-gmp-wrapper: clean-gmp-wrapper
 ifeq ($(USE_SYSTEM_GLPK), 1)
 GLPK_OBJ_TARGET =
 else
-GLPK_OBJ_TARGET = $(USRLIB)/libglpk.$(SHLIB_EXT)
+GLPK_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libglpk.$(SHLIB_EXT)
 endif
 
 compile-glpk: install-glpk
-install-glpk: $(GLPK_OBJ_TARGET) $(USRLIB)/libglpk_wrapper.$(SHLIB_EXT)
+install-glpk: $(GLPK_OBJ_TARGET) $(USR)/$(JL_PRIVATE_LIBDIR)/libglpk_wrapper.$(SHLIB_EXT)
 
 glpk-$(GLPK_VER).tar.gz:
 	$(WGET) http://ftp.gnu.org/gnu/glpk/$@
@@ -860,19 +861,18 @@ GLPKW_INC = -I /usr/include/
 GLPKW_LIB = -lglpk
 else
 GLPKW_INC = -I $(USRINC)
-GLPKW_LIB = -L$(USRLIB)/ -lglpk
+GLPKW_LIB = -L$(USR)/$(JL_LIBDIR) -lglpk
 endif
 
 
-$(USRLIB)/libglpk_wrapper.$(SHLIB_EXT): glpk_wrapper.c $(GLPK_OBJ_TARGET)
-	mkdir -p $(USRLIB)
-	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GLPKW_INC) glpk_wrapper.c $(GLPKW_LIB) -o $(USRLIB)/libglpk_wrapper.$(SHLIB_EXT) -Wl,-rpath,$(USRLIB)
+$(USR)/$(JL_PRIVATE_LIBDIR)/libglpk_wrapper.$(SHLIB_EXT): glpk_wrapper.c $(GLPK_OBJ_TARGET)
+	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GLPKW_INC) glpk_wrapper.c $(GLPKW_LIB) -o $(USR)/$(JL_PRIVATE_LIBDIR)/libglpk_wrapper.$(SHLIB_EXT) '-Wl,-rpath,$$ORIGIN/../$(JL_LIBDIR)'
 	$(INSTALL_NAME_CMD)libglpk_wrapper.$(SHLIB_EXT) $@
 	touch $@
-install-glpk-wrapper: $(USRLIB)/libglpk_wrapper.$(SHLIB_EXT) glpk_wrapper.c
+install-glpk-wrapper: $(USR)/$(JL_PRIVATE_LIBDIR)/libglpk_wrapper.$(SHLIB_EXT) glpk_wrapper.c
 
 clean-glpk-wrapper:
-	rm -f $(GLPK_OBJ_TARGET) $(USRLIB)/libglpk_wrapper.$(SHLIB_EXT)
+	rm -f $(GLPK_OBJ_TARGET) $(USR)/$(JL_PRIVATE_LIBDIR)/libglpk_wrapper.$(SHLIB_EXT)
 distclean-glpk-wrapper: clean-glpk-wrapper
 
 ## ZLIB ##
@@ -880,7 +880,7 @@ distclean-glpk-wrapper: clean-glpk-wrapper
 ifeq ($(USE_SYSTEM_ZLIB), 1)
 ZLIB_OBJ_TARGET =
 else
-ZLIB_OBJ_TARGET = $(USRLIB)/libz.$(SHLIB_EXT)
+ZLIB_OBJ_TARGET = $(USR)/$(JL_LIBDIR)/libz.$(SHLIB_EXT)
 ZLIB_CFLAGS = CFLAGS="$(CFLAGS) -D_FILE_OFFSET_BITS=64"
 endif
 
@@ -912,17 +912,16 @@ distclean-zlib:
 ## Tk wrapper ##
 
 TKW_INC = -I $(USRINC) -I /usr/include/tcl -I $(JULIAHOME)/src -I $(JULIAHOME)/src/support
-TKW_LIB = -ltcl8.5 -ltk8.5 -L$(USRLIB)/ -ljulia-release
+TKW_LIB = -ltcl8.5 -ltk8.5 -L$(USR)/$(JL_PRIVATE_LIBDIR)/ -ljulia-release
 
-$(USRLIB)/libtk_wrapper.$(SHLIB_EXT): tk_wrapper.c
-	mkdir -p $(USRLIB)
-	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(TKW_INC) tk_wrapper.c $(TKW_LIB) -o $(USRLIB)/libtk_wrapper.$(SHLIB_EXT) -Wl,-rpath,$(USRLIB)
+$(USR)/$(JL_PRIVATE_LIBDIR)/libtk_wrapper.$(SHLIB_EXT): tk_wrapper.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(TKW_INC) tk_wrapper.c $(TKW_LIB) -o $(USR)/$(JL_PRIVATE_LIBDIR)/libtk_wrapper.$(SHLIB_EXT) '-Wl,-rpath,$$ORIGIN/../$(JL_PRIVATE_LIBDIR)'
 	$(INSTALL_NAME_CMD)libtk_wrapper.$(SHLIB_EXT) $@
 	touch $@
-install-tk-wrapper: $(USRLIB)/libtk_wrapper.$(SHLIB_EXT) tk_wrapper.c
+install-tk-wrapper: $(USR)/$(JL_PRIVATE_LIBDIR)/libtk_wrapper.$(SHLIB_EXT) tk_wrapper.c
 
 clean-tk-wrapper:
-	rm -f $(USRLIB)/libtk_wrapper.$(SHLIB_EXT)
+	rm -f $(USR)/$(JL_PRIVATE_LIBDIR)/libtk_wrapper.$(SHLIB_EXT)
 distclean-tk-wrapper: clean-tk-wrapper
 
 ## phony targets ##

--- a/deps/Rmath/src/Makefile
+++ b/deps/Rmath/src/Makefile
@@ -42,7 +42,7 @@ release debug: libRmath.$(SHLIB_EXT)
 
 libRmath.$(SHLIB_EXT): $(XOBJS)
 	rm -rf $@
-	$(QUIET_LINK) $(CC) -shared -o $@ $^ -L$(USRLIB) -lrandom $(RPATH_ORIGIN)
+	$(QUIET_LINK) $(CC) -shared -o $@ $^ -L$(USR)/$(JL_PRIVATE_LIBDIR) -lrandom $(RPATH_ORIGIN)
 
 clean:
 	rm -f *.o *.do *.a *.$(SHLIB_EXT) core* *~ *#

--- a/deps/lighttpd.conf
+++ b/deps/lighttpd.conf
@@ -1,4 +1,4 @@
-server.document-root = "../lib/julia/website"
+server.document-root = "../share/julia/website"
 
 server.port = 2000
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ FLAGS = \
 	-I$(shell $(LLVM_CONFIG) --includedir) \
 	-I$(JULIAHOME)/deps/libuv/include -I$(JULIAHOME)/usr/include
 
-LIBS = $(shell $(LLVM_CONFIG) --libfiles) $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a -L$(USR)/lib $(USRLIB)/uv.a $(OSLIBS) -lpthread $(shell $(LLVM_CONFIG) --ldflags)
+LIBS = $(shell $(LLVM_CONFIG) --libfiles) $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a -L$(USR)/lib $(USR)/$(JL_LIBDIR)/uv.a $(OSLIBS) -lpthread $(shell $(LLVM_CONFIG) --ldflags)
 
 ifneq ($(MAKECMDGOALS),debug)
 TARGET =
@@ -69,24 +69,24 @@ support/libsupport.a: support/*.h support/*.c
 flisp/libflisp.a: flisp/*.h flisp/*.c support/libsupport.a
 	$(MAKE) -C flisp
 
-$(USRLIB)/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
+$(USR)/$(JL_PRIVATE_LIBDIR)/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
 	$(QUIET_LINK) $(CXX) $(DEBUGFLAGS) $(DOBJS) -shared -o $@ $(LIBS) $(LDFLAGS)
 	$(INSTALL_NAME_CMD)libjulia-debug.$(SHLIB_EXT) $@
 libjulia-debug.a: julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
 	rm -f $@
 	$(QUIET_LINK) ar -rcs $@ $(DOBJS)
-libjulia-debug: $(USRLIB)/libjulia-debug.$(SHLIB_EXT)
+libjulia-debug: $(USR)/$(JL_PRIVATE_LIBDIR)/libjulia-debug.$(SHLIB_EXT)
 
-$(USRLIB)/libjulia-release.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
+$(USR)/$(JL_PRIVATE_LIBDIR)/libjulia-release.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
 	$(QUIET_LINK) $(CXX) $(SHIPFLAGS) $(OBJS) $(LIBS) -shared -o $@ $(LDFLAGS)
 	$(INSTALL_NAME_CMD)libjulia-release.$(SHLIB_EXT) $@
 libjulia-release.a: julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
 	rm -f $@
 	$(QUIET_LINK) ar -rcs $@ $(OBJS)
-libjulia-release: $(USRLIB)/libjulia-release.$(SHLIB_EXT)
+libjulia-release: $(USR)/$(JL_PRIVATE_LIBDIR)/libjulia-release.$(SHLIB_EXT)
 
 clean:
-	rm -f $(USRLIB)/libjulia*
+	rm -f $(USR)/$(JL_PRIVATE_LIBDIR)/libjulia*
 	rm -f julia_flisp.boot julia_flisp.boot.inc
 	rm -f *.do *.o *~ *# *.$(SHLIB_EXT) *.a
 

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -14,7 +14,7 @@ SRCS = flisp.c builtins.c string.c equalhash.c table.c iostream.c \
 OBJS = $(SRCS:%.c=%.o)
 DOBJS = $(SRCS:%.c=%.do)
 LLTDIR = ../support
-LLT = $(LLTDIR)/libsupport.a $(USRLIB)/uv.a
+LLT = $(LLTDIR)/libsupport.a $(USR)/$(JL_LIBDIR)/uv.a
 
 FLAGS = -Wall -Wno-strict-aliasing -I$(LLTDIR) $(CFLAGS) \
 	-DUSE_COMPUTED_GOTO $(HFILEDIRS:%=-I%) $(LIBDIRS:%=-L%) -fvisibility=hidden

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -11,12 +11,12 @@ DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
 JLDFLAGS +=  $(shell $(LLVM_CONFIG) --ldflags) $(OSLIBS) -lpthread $(LDFLAGS) $(RPATH)
 
-julia-release julia-debug: %: %-basic %-readline | $(USR)/lib/julia/website
+julia-release julia-debug: %: %-basic %-readline | $(USR)/share/julia/website
 	@$(MAKE) -C webserver $@
 
-$(eval $(call symlink_target,website,$(USR)/lib/julia))
+$(eval $(call symlink_target,website,$(USR)/share/julia))
 
-release debug: | $(USR)/lib/julia/website
+release debug: | $(USR)/share/julia/website
 	$(MAKE) julia-$@
 
 %.o: %.c repl.h
@@ -30,14 +30,14 @@ julia-release-readline: $(USRBIN)/julia-release-readline
 julia-debug-readline: $(USRBIN)/julia-debug-readline
 
 $(USRBIN)/julia-release-basic: repl.o repl-basic.o
-	$(QUIET_LINK) $(CXX) $(SHIPFLAGS) $^ -o $@ -L$(USRLIB) $(JLDFLAGS) -ljulia-release
+	$(QUIET_LINK) $(CXX) $(SHIPFLAGS) $^ -o $@ -L$(USR)/$(JL_PRIVATE_LIBDIR) -L$(USR)/$(JL_PRIVATE_LIBDIR) $(JLDFLAGS) -ljulia-release
 $(USRBIN)/julia-debug-basic: repl.do repl-basic.do
-	$(QUIET_LINK) $(CXX) $(DEBUGFLAGS) $^ -o $@ -L$(USRLIB) $(JLDFLAGS) -ljulia-debug
+	$(QUIET_LINK) $(CXX) $(DEBUGFLAGS) $^ -o $@ -L$(USR)/$(JL_PRIVATE_LIBDIR) -L$(USR)/$(JL_PRIVATE_LIBDIR) $(JLDFLAGS) -ljulia-debug
 
 $(USRBIN)/julia-release-readline: repl.o repl-readline.o
-	$(QUIET_LINK) $(CXX) $(SHIPFLAGS) $^ -o $@ $(READLINE) -L$(USRLIB) $(JLDFLAGS) -ljulia-release
+	$(QUIET_LINK) $(CXX) $(SHIPFLAGS) $^ -o $@ $(READLINE) -L$(USR)/$(JL_LIBDIR) -L$(USR)/$(JL_PRIVATE_LIBDIR) $(JLDFLAGS) -ljulia-release
 $(USRBIN)/julia-debug-readline: repl.do repl-readline.do
-	$(QUIET_LINK) $(CXX) $(DEBUGFLAGS) $^ -o $@ $(READLINE) -L$(USRLIB) $(JLDFLAGS) -ljulia-debug
+	$(QUIET_LINK) $(CXX) $(DEBUGFLAGS) $^ -o $@ $(READLINE) -L$(USR)/$(JL_LIBDIR) -L$(USR)/$(JL_PRIVATE_LIBDIR) $(JLDFLAGS) -ljulia-debug
 
 clean: | $(CLEAN_TARGETS)
 	$(MAKE) -C webserver $@

--- a/ui/webserver/Makefile
+++ b/ui/webserver/Makefile
@@ -4,7 +4,7 @@ include $(JULIAHOME)/Make.inc
 override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
 
-LIBS = -lpthread $(USRLIB)/uv.a 
+LIBS = -lpthread $(USR)/$(JL_LIBDIR)/uv.a 
 ifeq ($(OS), Linux)
 LIBS += -lrt 
 endif


### PR DESCRIPTION
This is a pretty huge, monolithic commit (don't really see how to split it up sanely).  It reorganizes a fair amount of the build process, allowing for the flexibility to satisfy #1560.  Namely, it:
- Moves all non-code related files to `<prefix>/share/`.  This includes .jl files as well as webserver errata.
- Defines two new environment variables, $(JL_LIBDIR) and $(JL_PRIVATE_LIBDIR).  By default, these are set to `lib/` and `lib/julia/`, respectively.  If necessary, you can define them to be anything you want (I have some code in `Make.inc` to set them to `lib/<multiarch>` in the case of `USE_DEBIAN=1`, for example)
- Moves all `lighttpd` modules into `$(JL_LIBDIR)/lighttpd/`.  This matches up better with other package managers.

Comments and testing are highly appreciated.  I've tested this on an ubuntu box and an OSX box through homebrew, let me know if this breaks anything!
