### PR TITLE
Move sys.ji, fix make clean

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -9,6 +9,21 @@ USRINC = $(USR)/include
 LLVMROOT = $(USR)
 BUILD = $(USR)
 
+# List of "private" libraries, e.g. ones that get installed to lib/julia
+JL_PRIVATE_LIBS = Rmath openlibm julia-release suitesparse_wrapper tk_wrapper gmp_wrapper glpk_wrapper random
+JL_LIBS = amd arpack cholmod colamd fftw3 fftw3f fftw3_threads fftw3f_threads glpk gmp grisu history $(OPENBLASNAME) pcre readline spqr umfpack z
+
+# Directories where said libraries get installed to
+JL_PRIVATE_LIBDIR = lib/julia
+JL_LIBDIR = lib
+
+# If we're on debian, default to arch-dependent library dirs
+ifeq ($(USE_DEBIAN), 1)
+MULTIARCH = $(shell gcc -print-multiarch)
+JL_PRIVATE_LIBDIR = lib/$(MULTIARCH)/julia
+JL_LIBDIR = lib/$(MULTIARCH)/
+endif
+
 OS = $(shell uname)
 ARCH = $(shell uname -m)
 
@@ -78,7 +93,7 @@ endif
 endif
 
 # if not absolute, then relative to JULIA_HOME
-JCFLAGS += '-DJL_SYSTEM_IMAGE_PATH="../share/julia/sys.ji"'
+JCFLAGS += '-DJL_SYSTEM_IMAGE_PATH="../$(JL_PRIVATE_LIBDIR)/sys.ji"'
 
 # OPENBLAS build options
 OPENBLAS_DYNAMIC_ARCH=0
@@ -264,21 +279,6 @@ LIBBLAS = -L$(ATLAS_LIBDIR) -lsatlas
 LIBLAPACK = $(LIBBLAS)
 LIBBLASNAME = libsatlas
 LIBLAPACKNAME = $(LIBBLASNAME)
-endif
-
-# List of "private" libraries, e.g. ones that get installed to lib/julia
-JL_PRIVATE_LIBS = Rmath openlibm julia-release suitesparse_wrapper tk_wrapper gmp_wrapper glpk_wrapper random
-JL_LIBS = amd arpack cholmod colamd fftw3 fftw3f fftw3_threads fftw3f_threads glpk gmp grisu history $(OPENBLASNAME) pcre readline spqr umfpack z
-
-# Directories where said libraries get installed to
-JL_PRIVATE_LIBDIR = lib/julia
-JL_LIBDIR = lib
-
-# If we're on debian, default to arch-dependent library dirs
-ifeq ($(USE_DEBIAN), 1)
-MULTIARCH = $(shell gcc -print-multiarch)
-JL_PRIVATE_LIBDIR = lib/$(MULTIARCH)/julia
-JL_LIBDIR = lib/$(MULTIARCH)/
 endif
 
 # Make tricks

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ endif
 
 debug release: | $(DIRS) $(BUILD)/share/julia/extras $(BUILD)/share/julia/base $(BUILD)/share/julia/test $(BUILD)/share/julia/doc $(BUILD)/share/julia/examples
 	@$(MAKEs) julia-$@
-	@$(MAKEs) JULIA_EXECUTABLE=$(JULIA_EXECUTABLE_$@) $(BUILD)/share/julia/sys.ji
+	@export JL_PRIVATE_LIBDIR=$(JL_PRIVATE_LIBDIR) && \
+	$(MAKEs) JULIA_EXECUTABLE=$(JULIA_EXECUTABLE_$@) $(BUILD)/$(JL_PRIVATE_LIBDIR)/sys.ji
 
 julia-debug julia-release:
 	@$(MAKEs) -C deps
@@ -30,9 +31,9 @@ $(BUILD)/share/julia/helpdb.jl: doc/helpdb.jl | $(BUILD)/share/julia
 	@cp $< $@
 
 # use sys.ji if it exists, otherwise run two stages
-$(BUILD)/share/julia/sys.ji: VERSION base/*.jl $(BUILD)/share/julia/helpdb.jl
+$(BUILD)/$(JL_PRIVATE_LIBDIR)/sys.ji: VERSION base/*.jl $(BUILD)/share/julia/helpdb.jl
 	$(QUIET_JULIA) cd base && \
-	(test -f $(BUILD)/share/julia/sys.ji || $(JULIA_EXECUTABLE) -bf sysimg.jl) && $(JULIA_EXECUTABLE) -f sysimg.jl || echo "Note: this error is usually fixed by running 'make clean'."
+	(test -f $(BUILD)/$(JL_PRIVATE_LIBDIR)/sys.ji || $(JULIA_EXECUTABLE) -bf sysimg.jl) && $(JULIA_EXECUTABLE) -f sysimg.jl || echo "Note: this error is usually fixed by running 'make clean'."
 
 ifeq ($(OS), WINNT)
 OPENBLASNAME=openblas-r0.1.1
@@ -95,11 +96,11 @@ clean: | $(CLEAN_TARGETS)
 		done \
 	done
 	@rm -f *~ *# *.tar.gz
-	@rm -fr $(BUILD)/$(JL_LIBDIR)
 	@rm -fr $(BUILD)/$(JL_PRIVATE_LIBDIR)
 
 cleanall: clean
 	@$(MAKE) -C src clean-flisp clean-support
+	@rm -fr $(BUILD)/$(JL_LIBDIR)
 #	@$(MAKE) -C deps clean-uv
 
 .PHONY: default debug release julia-debug julia-release \

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -277,6 +277,7 @@ end # module Base
 
 using Base
 
+JL_PRIVATE_LIBDIR = getenv("JL_PRIVATE_LIBDIR")
 # create system image file
 ccall(:jl_save_system_image, Void, (Ptr{Uint8},Ptr{Uint8}),
-      "$JULIA_HOME/../share/julia/sys.ji", "start_image.jl")
+      "$JULIA_HOME/../$JL_PRIVATE_LIBDIR/sys.ji", "start_image.jl")

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -121,8 +121,8 @@ void parse_opts(int *argcp, char ***argvp) {
                 image_file = strdup(path);
             }
             else if (jl_stat(image_file, (char*)&stbuf) != 0) {
-                // otherwise try julia_home/../share/julia/%s
-                snprintf(path, sizeof(path), "%s%s..%sshare%sjulia%s%s",
+                // otherwise try julia_home/../lib/julia/%s
+                snprintf(path, sizeof(path), "%s%s..%slib%sjulia%s%s",
                          julia_home, PATHSEPSTRING, PATHSEPSTRING,
                          PATHSEPSTRING, PATHSEPSTRING, image_file);
                 image_file = strdup(path);


### PR DESCRIPTION
This addresses #1572, as well as the tail end of #1560.

This moves the system image to `$(JL_PRIVATE_LIBDIR)`, and changes `make clean` to only delete `$(JL_PRIVATE_LIBDIR)`, not `$(JL_LIBDIR)`, which significantly speeds up the `make clean && make`  cycle.  Deleting `$(JL_LIBDIR)` has been relegated to `make cleanall`.
