### PR TITLE
Install system image too!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,8 @@ install: release
 	-for suffix in $(JL_PRIVATE_LIBS) ; do \
 		cp $(BUILD)/$(JL_PRIVATE_LIBDIR)/lib$${suffix}.$(SHLIB_EXT) $(PREFIX)/$(JL_PRIVATE_LIBDIR) ; \
 	done
+	# Copy system image
+	cp $(BUILD)/$(JL_PRIVATE_LIBDIR)/sys.ji $(PREFIX)/$(JL_PRIVATE_LIBDIR)
 	# Copy in all .jl sources as well
 	-cp -R -L $(BUILD)/share/julia $(PREFIX)/share/
 ifeq ($(OS), WINNT)


### PR DESCRIPTION
This installs the system image as well (this got dropped when moving `sys.ji` to `$(JL_PRIVATE_LIBDIR)` from `share/julia/`), so when you `make install` you don't get hit with "system image not found".

I'll submit a pull request to have travis run a testall after installing as well, so we don't run into these kinds of problems again.
