### PR TITLE
RFC: @show macro

### DIFF
--- a/base/export.jl
+++ b/base/export.jl
@@ -1295,5 +1295,6 @@ export
     @L_str,
     @vectorize_1arg,
     @vectorize_2arg,
+    @show,
     @printf,
     @sprintf

--- a/base/show.jl
+++ b/base/show.jl
@@ -8,6 +8,14 @@ show(io, x) = ccall(:jl_show_any, Void, (Any, Any,), io::IOStream, x)
 showcompact(io, x) = show(io, x)
 showcompact(x)     = showcompact(OUTPUT_STREAM::IOStream, x)
 
+macro show(ex)
+    quote
+        print($(sprint(show_unquoted, ex)*"\t= "))
+        show($(esc(ex)))
+        println()
+    end
+end
+
 show(io, s::Symbol) = show_indented(io, s)
 show(io, tn::TypeName) = print(io, tn.name)
 show(io, ::Nothing) = print(io, "nothing")


### PR DESCRIPTION
Examples:

```
julia> x=23
23

julia> @show x
x   = 23

julia> @show x^2
^(x, 2) = 529
```

I've found this macro to be immensely useful in (print) debugging, i.e. instead of having to write

```
println("symbols = ", symbols)
```

I can just write

```
@show symbols
```

I think I saw something like this floating around a good number of months ago, but it doesn't appear to have made it into base. Any reason not have this kind of thing?
