### PR TITLE
RFC: Make print show ASTs unquoted

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -102,7 +102,9 @@ show_unquoted(io::IO, x, indent) = (print(io,"\$("); show(io,x); print(io,')'))
 
 typealias ExprNode Union(SymbolNode, LineNumberNode, LabelNode, GotoNode,
                          TopNode, QuoteNode)
-show(io::IO, ex::ExprNode) = show_indented(io, ex)
+
+show( io::IO, ex::Union(Expr, ExprNode)) = show_indented(io, ex)
+print(io::IO, ex::Union(Expr, ExprNode)) = show_unquoted(io, ex)
 
 function show_indented(io::IO, ex::ExprNode, indent::Int)
     default_show_quoted(io, ex, indent)
@@ -111,7 +113,6 @@ function show_indented(io::IO, ex::QuoteNode, indent::Int)
     show_indented(io, ex.value, indent)
 end
 
-show(io::IO, ex::Expr) = show_indented(io, ex)
 function show_indented(io::IO, ex::Expr, indent::Int)
     if is(ex.head, :block) || is(ex.head, :body)
         show_block(io, "quote", ex, indent); print(io, "end")


### PR DESCRIPTION
This patch makes `print` show ASTs unquoted, while `show` still shows the quoted version, e.g.

```
julia> show(:(f(x,y)=x*y))
:( f(x, y) = *(x, y) )
julia> print(:(f(x,y)=x*y))
f(x, y) = *(x, y)
```

This would be consistent with the current treatment of symbols:

```
julia> show(:x)
:x
julia> print(:x)
x
```

I think the policy for type-specific `print` methods is to provide them for types that have an intrinsic string representation. I think one could argue that the intrinsic string representation of an AST is the source code that it represents, which would also motivate the current practice of letting `print` print symbols unquoted.

It is sometimes useful to print an AST unquoted. Though `Base.show_unquoted` and `sprint(Base.show_unquoted, ex)` currently work, `print` and `string` are more terse. On the other hand, `Base.show_unquoted` will print `"foo"` as `"foo"`, so maybe it's better to accept to use it instead.

**Edit:** I thought I needed to this to make #1591 look good, but it turns out I didn't. But now that I wrote it, I might as well gather some opinions. Thoughts?
