### PR TITLE
Travis: Test installed Julia as well!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ env:
 script: make $BUILDOPTS dist
 after_script:
     - make $BUILDOPTS testall
+    - make $BUILDOPTS PREFIX=/tmp/julia install
+    - cd /tmp/julia/share/julia/test && /tmp/julia/bin/julia runtests.jl all
     - echo "Packaging steps here"


### PR DESCRIPTION
This causes the travisbot to also install julia and test her there, to catch things like https://github.com/JuliaLang/julia/pull/1590 faster.  Not sure if we should test only the installed version or keep testing both like I have here.  Thoughts?
