### PR TITLE
RFC: @expect macro

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -21,6 +21,12 @@ system_error(p, b::Bool) = b ? throw(SystemError(string(p))) : nothing
 assert(x) = assert(x,'?')
 assert(x,labl) = x ? nothing : error("assertion failed: ", labl)
 
+# @assert is for things that should never happen
 macro assert(ex)
     :($(esc(ex)) ? nothing : error("assertion failed: ", $(string(ex))))
+end
+# @expect is for things that might happen
+# if e.g. a function is called with the wrong arguments
+macro expect(ex)
+    :($(esc(ex)) ? nothing : error($(string("expected ", ex, " == true"))))
 end

--- a/base/export.jl
+++ b/base/export.jl
@@ -1267,6 +1267,7 @@ export
     @v_str,
     @unexpected,
     @assert,
+    @expect,
     @r_str,
     @str,
     @S_str,


### PR DESCRIPTION
I've found the `@assert` macro very useful for writing assertions in a compact and readable way. The same kind of format would be useful also when the condition to be checked is not really an assertion.

I therefore propose an analogous `@expect` macro, to e.g. check for fulfillment of preconditions to a function call. If an `@expect` fails, it is the caller of the function that is to blame,
as opposed to an assertion failure, where there is a bug in the function itself.

Compare e.g. the somewhat readable code

```
function split_fdef(fdef::Expr)
    @expect (fdef.head == :function) || (fdef.head == :(=))
    @expect length(fdef.args) == 2
    signature, body = fdef.args
    @expect is_expr(signature, :call)
    @expect length(signature.args) >= 1
    (signature, body)
end
```

to the much bulkier version without `@expect`:

```
function split_fdef(fdef::Expr)
    if !(fdef.head == :function || fdef.head == :(=))
        error("need fdef.head == :function or :(=)")
    end
    if !(length(fdef.args) == 2)
        error("length(fdef.args) != 2")
    end
    signature, body = fdef.args
    if !is_expr(signature, :call)
        error("signature.head != :call") 
    end
    if !(length(signature.args) >= 1)
        error("length(signature.args) == 0")
    end
    (signature, body)
end
```

The latter takes longer time both to write and to read.

Do people think this is a good idea? Thoughts?
