### PR TITLE
gzip/zlib fixes

### DIFF
--- a/extras/zlib.jl
+++ b/extras/zlib.jl
@@ -13,6 +13,13 @@ export
    Z_BEST_COMPRESSION,
    Z_DEFAULT_COMPRESSION,
 
+# Compression strategy constants (zlib_h.jl)
+   Z_FILTERED,
+   Z_HUFFMAN_ONLY,
+   Z_RLE,
+   Z_FIXED,
+   Z_DEFAULT_STRATEGY,
+
 # Uncompress routines
    uncompress,
    uncompress_to_buffer,
@@ -29,17 +36,13 @@ export
 # Version
    ZLIB_VERSION,
 
-# More constants and types (used by GZip)
-   Z_OK,
-   Z_STREAM_END,
-   Z_NEED_DICT,
-   Z_FILTERED,
-   Z_HUFFMAN_ONLY,
-   Z_RLE,
-   Z_FIXED,
-   Z_DEFAULT_BUFSIZE,
-   Z_BIG_BUFSIZE,
-   ZFileOffset
+# More constants and types
+   Z_OK #,
+#   Z_STREAM_END,
+#   Z_NEED_DICT,
+#   Z_DEFAULT_BUFSIZE,
+#   Z_BIG_BUFSIZE,
+#   ZFileOffset
 
 load("zlib_h")
 

--- a/test/extra.jl
+++ b/test/extra.jl
@@ -8,6 +8,6 @@ runtests("zlib")
 # runtests("options")
 runtests("image")
 # runtests("iterators")
-#runtests("gzip")
+runtests("gzip")
 
 runtests("perf")

--- a/test/gzip.jl
+++ b/test/gzip.jl
@@ -1,12 +1,13 @@
 # Testing for gzip
-cd("$JULIA_HOME/../share/julia/extras")
-require("gzip")
+require("../extras/gzip")
 
 using GZip
 
 ##########################
 # test_context("GZip tests")
 ##########################
+
+#for epoch in 1:10
 
 tmp = mktempdir()
 
@@ -241,4 +242,5 @@ str2c = gzopen(readall, unicode_gz_file);
 
 
 run(`rm -Rf $tmp`)
-cd("$JULIA_HOME/../share/julia/test")
+
+#end  # for epoch


### PR DESCRIPTION
This commit fixes issues with accessing closed files from versions of zlib earlier than 1.2.7,

It turns out that zlib 1.2.7 is much more robust/forgiving when accessing closed files, but earlier versions are not, so we explicitly test the closed state before writing.  

This is done in macros, so it's probably possible to check the version number and only do the test when the version is less than 1.2.7.

Also, remove the `Zlib` import from `gzip.jl` introduced in 827212810c, as all of the imported constants are available directly from `zlib_h.jl`
