### PR TITLE
RFC: @expect macro, extended version

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -69,6 +69,10 @@ type ShowError <: Exception
     err::Exception
 end
 
+type AssertionError <: Exception
+    msg::String
+end
+
 show(io, bt::BackTrace) = show(io,bt.e)
 
 function show(io, se::ShowError)

--- a/base/error.jl
+++ b/base/error.jl
@@ -19,8 +19,31 @@ system_error(p, b::Bool) = b ? throw(SystemError(string(p))) : nothing
 ## assertion functions and macros ##
 
 assert(x) = assert(x,'?')
-assert(x,labl) = x ? nothing : error("assertion failed: ", labl)
+assert(x,labl) = x ? nothing : throw(AssertionError(string(labl)))
 
-macro assert(ex)
-    :($(esc(ex)) ? nothing : error("assertion failed: ", $(string(ex))))
+# @assert is for things that should never happen
+macro assert(e)
+    :($(esc(e)) ? nothing : throw(AssertionError($(sprint(show_unquoted,e)))))
+end
+
+# @expect is for things that might happen
+# if e.g. a function is called with the wrong arguments
+# usage:
+#                                         # x > 5 ==>
+#    @expect x <= 5                       # error("expected: (x <= 5) == true")
+#    @expect x <= 5 KeyError(x)           # error(KeyError(5))
+#    @expect x <= 5 msg ArgumentError(msg) 
+#    # fails ==> error(ArgumentError("expected: (x <= 5) == true"))
+macro expect(args...)
+    code_expect(args...)
+end
+code_expect(pred) =  (msym = gensym(); code_expect(pred, msym,     msym))
+code_expect(pred, err)               = code_expect(pred, gensym(), err)
+function code_expect(pred, msym::Symbol, err)
+    msg = string("expected ", sprint(show_unquoted,pred), " == true")    
+    esc(:( if !($pred)
+        let $msym = $(expr(:quote, msg))
+            error($err)
+        end
+    end))
 end

--- a/base/export.jl
+++ b/base/export.jl
@@ -105,6 +105,7 @@ export
     
 # Exceptions
     ArgumentError,
+    AssertionError,
     BackTrace,
     DisconnectException,
     ErrorException,
@@ -1267,6 +1268,7 @@ export
     @v_str,
     @unexpected,
     @assert,
+    @expect,
     @r_str,
     @str,
     @S_str,

--- a/base/show.jl
+++ b/base/show.jl
@@ -318,6 +318,7 @@ show(io, ::StackOverflowError) = print(io, "error: stack overflow")
 show(io, ::UndefRefError) = print(io, "access to undefined reference")
 show(io, ::EOFError) = print(io, "read: end of file")
 show(io, e::ErrorException) = print(io, e.msg)
+show(io, e::AssertionError) = print(io, "assertion failed: ", e.msg)
 show(io, e::KeyError) = print(io, "key not found: $(e.key)")
 show(io, e::InterruptException) = nothing
 


### PR DESCRIPTION
Alternative, extended version on #1594.
- Make `assert`/`@assert` always throw an `AssertionError`, so that a catcher can distinguish such an
  internal error from invocation errors.
- Make `@expect` take an optional second argument to be passed to `error`,  
  to facilitate easy and descriptive reporting of invocation errors.

Examples:

```
julia> function psquare(x)
           @expect x>=0 DomainError
           x^2       
       end

julia> psquare(-4)
DomainError()
 in anonymous at no file:38
 in psquare at none:37

julia> function psquare(x)
           @expect x>=0 msg ArgumentError(msg)
           x^2
       end

julia> psquare(-4)
ArgumentError("expected (x>=0) == true")
 in anonymous at no file:38
 in psquare at none:37
```

**Edit:** Made the user name the `msg` variable if desired, instead of calling it `_msg`.
