### PR TITLE
Update fixup-libgfortran.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ dist: cleanall
 	-$(MAKE) -C deps clean-openblas
 	$(MAKE) install OPENBLAS_DYNAMIC_ARCH=1
 ifeq ($(OS), Darwin)
-	-./contrib/fixup-libgfortran.sh $(PREFIX)/$(JL_LIBDIR) /usr/local/lib
+	-./contrib/fixup-libgfortran.sh $(PREFIX)/$(JL_LIBDIR) $(PREFIX)/$(JL_PRIVATE_LIBDIR)
 endif
 	tar zcvf julia-$(JULIA_COMMIT)-$(OS)-$(ARCH).tar.gz julia-$(JULIA_COMMIT)
 	rm -fr julia-$(JULIA_COMMIT)

--- a/contrib/fixup-libgfortran.sh
+++ b/contrib/fixup-libgfortran.sh
@@ -1,16 +1,35 @@
-# Run as: fixup-libgfortran.sh <$PREFIX/lib> <libgfortran location>
+#!/bin/sh
+# Run as: fixup-libgfortran.sh <$JL_LIBDIR> <$JL_PRIVATE_LIBDIR>
 
-#! /bin/sh
+if [[ ! -f "$1/libopenblas.dylib" ]]; then
+    echo "ERROR: Could not open $1/libopenblas.dylib" >&2
+fi
 
-cd $1
+# First, discover where libgfortran is
+LIBGFORTRAN_DIR=$(dirname $(otool -L $1/libopenblas.dylib | grep libgfortran | cut -d' ' -f1 | xargs))
+echo "Found libgfortran in $LIBGFORTRAN_DIR"
 
 for name in gcc_s.1 gfortran.3 quadmath.0; do
-    cp $2/lib$name.dylib .
-    install_name_tool -id @rpath/lib$name.dylib lib$name.dylib
+    cp $LIBGFORTRAN_DIR/lib$name.dylib $1
+    install_name_tool -id @rpath/lib$name.dylib $1/lib$name.dylib
 done
 
-for name in quadmath.0 gfortran.3 openblas arpack amos; do
-    install_name_tool -change $2/libgfortran.3.dylib @rpath/libgfortran.3.dylib lib$name.dylib
-    install_name_tool -change $2/libquadmath.0.dylib @rpath/libquadmath.0.dylib lib$name.dylib
-    install_name_tool -change $2/libgcc_s.1.dylib @rpath/libgcc_s.1.dylib lib$name.dylib
+
+# Do the JL_LIBDIR libraries...
+cd $1
+for name in quadmath.0 gfortran.3 openblas arpack; do
+    install_name_tool -change $LIBGFORTRAN_DIR/libgfortran.3.dylib @rpath/libgfortran.3.dylib lib$name.dylib
+    install_name_tool -change $LIBGFORTRAN_DIR/libquadmath.0.dylib @rpath/libquadmath.0.dylib lib$name.dylib
+    install_name_tool -change $LIBGFORTRAN_DIR/libgcc_s.1.dylib @rpath/libgcc_s.1.dylib lib$name.dylib
+done
+
+# Go back to the root
+cd - >/dev/null
+
+# Next, do the JL_PRIVATE_LIBDIR libraries
+cd $2
+for name in openlibm; do
+    install_name_tool -change $LIBGFORTRAN_DIR/libgfortran.3.dylib @rpath/libgfortran.3.dylib lib$name.dylib
+    install_name_tool -change $LIBGFORTRAN_DIR/libquadmath.0.dylib @rpath/libquadmath.0.dylib lib$name.dylib
+    install_name_tool -change $LIBGFORTRAN_DIR/libgcc_s.1.dylib @rpath/libgcc_s.1.dylib lib$name.dylib
 done


### PR DESCRIPTION
Changeup fixup-libgfortran.sh to autodetect the path of libgfortran from use of otool, and to also fixup openlibm.

Closes https://github.com/JuliaLang/julia/issues/1599
