### PR TITLE
RFC:Various small fixes initiated by update of linalg tests

### DIFF
--- a/base/lapack.jl
+++ b/base/lapack.jl
@@ -1016,25 +1016,24 @@ end
 
 ## (PT) positive-definite, symmetric, tri-diagonal matrices
 ## Direct solvers for general tridiagonal and symmetric positive-definite tridiagonal
-for (ptsv, pttrf, pttrs, elty) in
-    ((:dptsv_,:dpttrf_,:dpttrs_,:Float64),
-     (:sptsv_,:spttrf_,:spttrs_,:Float32)
-#     , (:zptsv_,:zpttrf_,:zpttrs_,:Complex128)  # need to fix calling sequence.
-#     , (:cptsv_,:cpttrf_,:cpttrs_,:Complex64)   # D is real, not complex
-     )
+for (ptsv, pttrf, pttrs, elty, relty) in
+    ((:dptsv_,:dpttrf_,:dpttrs_,:Float64,:Float64),
+     (:sptsv_,:spttrf_,:spttrs_,:Float32,:Float32), 
+     (:zptsv_,:zpttrf_,:zpttrs_,:Complex128,:Float64), 
+     (:cptsv_,:cpttrf_,:cpttrs_,:Complex64,:Float32))
     @eval begin
         #       SUBROUTINE DPTSV( N, NRHS, D, E, B, LDB, INFO )
         #       .. Scalar Arguments ..
         #       INTEGER            INFO, LDB, N, NRHS
         #       .. Array Arguments ..
         #       DOUBLE PRECISION   B( LDB, * ), D( * ), E( * )
-        function ptsv!(D::Vector{$elty}, E::Vector{$elty}, B::StridedVecOrMat{$elty})
+        function ptsv!(D::Vector{$relty}, E::Vector{$elty}, B::StridedVecOrMat{$elty})
             chkstride1(B)
             n    = length(D)
             if length(E) != n - 1 || n != size(B,1) throw(LapackDimMismatch("ptsv!")) end
             info = Array(Int32, 1)
             ccall(($(string(ptsv)),liblapack), Void,
-                  (Ptr{Int32}, Ptr{Int32}, Ptr{$elty}, Ptr{$elty},
+                  (Ptr{Int32}, Ptr{Int32}, Ptr{$relty}, Ptr{$elty},
                    Ptr{$elty}, Ptr{Int32}, Ptr{Int32}),
                   &n, &size(B,2), D, E, B, &stride(B,2), info)
             if info[1] != 0 throw(LapackException(info[1])) end
@@ -1045,30 +1044,62 @@ for (ptsv, pttrf, pttrs, elty) in
         #       INTEGER            INFO, N
         #       .. Array Arguments ..
         #       DOUBLE PRECISION   D( * ), E( * )
-        function pttrf!(D::Vector{$elty}, E::Vector{$elty})
+        function pttrf!(D::Vector{$relty}, E::Vector{$elty})
             n    = length(D)
             if length(E) != (n-1) throw(LapackDimMisMatch("pttrf!")) end
             info = Array(Int32, 1)
             ccall(($(string(pttrf)),liblapack), Void,
-                  (Ptr{Int32}, Ptr{$elty}, Ptr{$elty}, Ptr{Int32}),
+                  (Ptr{Int32}, Ptr{$relty}, Ptr{$elty}, Ptr{Int32}),
                   &n, D, E, info)
             if info[1] != 0 throw(LapackException(info[1])) end
             D, E
         end
+    end
+end
+for (pttrs, elty, relty) in
+    ((:dpttrs_,:Float64,:Float64),
+     (:spttrs_,:Float32,:Float32))
+    @eval begin
         #       SUBROUTINE DPTTRS( N, NRHS, D, E, B, LDB, INFO )
         #       .. Scalar Arguments ..
         #       INTEGER            INFO, LDB, N, NRHS
         #       .. Array Arguments ..
         #       DOUBLE PRECISION   B( LDB, * ), D( * ), E( * )
-        function pttrs!(D::Vector{$elty}, E::Vector{$elty}, B::StridedVecOrMat{$elty})
+        function pttrs!(D::Vector{$relty}, E::Vector{$elty}, B::StridedVecOrMat{$elty})
             chkstride1(B)
             n    = length(D)
             if length(E) != (n-1) || size(B,1) != n throw(LapackDimMisMatch("pttrs!")) end
             info = Array(Int32, 1)
             ccall(($(string(pttrs)),liblapack), Void,
-                  (Ptr{Int32}, Ptr{Int32}, Ptr{$elty}, Ptr{$elty},
+                  (Ptr{Int32}, Ptr{Int32}, Ptr{$relty}, Ptr{$elty},
                    Ptr{$elty}, Ptr{Int32}, Ptr{Int32}),
                   &n, &size(B,2), D, E, B, &stride(B,2), info)
+            if info[1] != 0 throw(LapackException(info[1])) end
+            B
+        end
+    end
+end
+for (pttrs, elty, relty) in
+    ((:zpttrs_,:Complex128,:Float64),
+     (:cpttrs_,:Complex64,:Float32))
+    @eval begin
+#       SUBROUTINE ZPTTRS( UPLO, N, NRHS, D, E, B, LDB, INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          UPLO
+#       INTEGER            INFO, LDB, N, NRHS
+# *     ..
+# *     .. Array Arguments ..
+#       DOUBLE PRECISION   D( * )
+#       COMPLEX*16         B( LDB, * ), E( * )
+        function pttrs!(uplo::LapackChar, D::Vector{$relty}, E::Vector{$elty}, B::StridedVecOrMat{$elty})
+            chkstride1(B)
+            n    = length(D)
+            if length(E) != (n-1) || size(B,1) != n throw(LapackDimMisMatch("pttrs!")) end
+            info = Array(Int32, 1)
+            ccall(($(string(pttrs)),liblapack), Void,
+                  (Ptr{Uint8}, Ptr{Int32}, Ptr{Int32}, Ptr{$relty}, Ptr{$elty},
+                   Ptr{$elty}, Ptr{Int32}, Ptr{Int32}),
+                  &uplo, &n, &size(B,2), D, E, B, &stride(B,2), info)
             if info[1] != 0 throw(LapackException(info[1])) end
             B
         end

--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -418,9 +418,9 @@ factors(C::CholeskyDense) = C.LR
 \{T<:LapackType}(C::CholeskyDense{T}, B::StridedVecOrMat{T}) =
     LAPACK.potrs!(C.upper ? 'U' : 'L', C.LR, copy(B))
 
-function det(C::CholeskyDense)
+function det{T}(C::CholeskyDense{T})
     ff = C.LR
-    dd = 1.
+    dd = one(T)
     for i in 1:size(ff,1) dd *= abs2(ff[i,i]) end
     dd
 end
@@ -501,11 +501,11 @@ end
 size(A::LUDense) = size(A.lu)
 size(A::LUDense,n) = size(A.lu,n)
 
-function factors{T<:LapackType}(lu::LUDense{T}) 
+function factors{T}(lu::LUDense{T}) 
     LU, ipiv = lu.lu, lu.ipiv
     m, n = size(LU)
 
-    L = m >= n ? tril(LU, -1) + eye(m,n) : tril(LU, -1)[:, 1:m] + eye(m,m)
+    L = m >= n ? tril(LU, -1) + eye(T,m,n) : tril(LU, -1)[:, 1:m] + eye(T,m)
     U = m <= n ? triu(LU) : triu(LU)[1:n, :]
     P = [1:m]
     for i = 1:min(m,n)
@@ -527,10 +527,10 @@ lud{T<:Number}(A::Matrix{T}) = lud(float64(A))
 ## Matlab-compatible
 lu{T<:Number}(A::Matrix{T}) = factors(lud(A))
 
-function det(lu::LUDense)
+function det{T}(lu::LUDense{T})
     m, n = size(lu)
     if lu.info > 0; return zero(typeof(lu.lu[1])); end
-    prod(diag(lu.lu)) * (bool(sum(lu.ipiv .!= 1:n) % 2) ? -1 : 1)
+    prod(diag(lu.lu)) * (bool(sum(lu.ipiv .!= 1:n) % 2) ? -one(T) : one(T))
 end
 
 function det(A::Matrix)
@@ -636,7 +636,16 @@ function eig{T<:LapackType}(A::StridedMatrix{T}, vecs::Bool)
     n = size(A, 2)
     if n == 0; return vecs ? (zeros(T, 0), zeros(T, 0, 0)) : zeros(T, 0, 0); end
 
-    if ishermitian(A); return LAPACK.syev!(vecs ? 'V' : 'N', 'U', copy(A)); end
+    if ishermitian(A)
+        if vecs
+            Z = similar(A)
+            W = LAPACK.syevr!(copy(A), Z)
+        else
+            Z = Array(T, 0, 0)
+            W = LAPACK.syevr!(copy(A))
+        end
+        return W, Z
+    end
 
     if iscomplex(A)
         W, VR = LAPACK.geev!('N', vecs ? 'V' : 'N', copy(A))[2:3]
@@ -784,7 +793,7 @@ function SymTridiagonal{T<:Real}(dv::Vector{T}, ev::Vector{T})
     SymTridiagonal{Float64}(float64(dv),float64(ev))
 end
 function SymTridiagonal{Td<:Number,Te<:Number}(dv::Vector{Td}, ev::Vector{Te})
-    T = promote(Td,Tv)
+    T = promote(Td,Te)
     SymTridiagonal(convert(Vector{T}, dv), convert(Vector{T}, ev))
 end
 copy(S::SymTridiagonal) = SymTridiagonal(S.dv,S.ev)
@@ -1009,16 +1018,23 @@ end
 *(A::Tridiagonal, B::Tridiagonal) = A*full(B)
 
 #### Factorizations for Tridiagonal ####
-type LDLTTridiagonal{T} <: Factorization{T}
-    D::Vector{T}
+type LDLTTridiagonal{T<:LapackType,S<:LapackType} <: Factorization{T}
+    D::Vector{S}
     E::Vector{T}
+    function LDLTTridiagonal(D::Vector{S}, E::Vector{T})
+        if typeof(real(E[1])) != eltype(D) error("Wrong eltype") end
+        new(D, E)
+    end
 end
+LDLTTridiagonal{S<:LapackType,T<:LapackType}(D::Vector{S}, E::Vector{T}) = LDLTTridiagonal{T,S}(D, E)
 
-ldltd!{T<:LapackType}(A::SymTridiagonal{T}) = LDLTTridiagonal{T}(LAPACK.pttrf!(A.dv,A.ev)...)
+ldltd!{T<:LapackType}(A::SymTridiagonal{T}) = LDLTTridiagonal(LAPACK.pttrf!(real(A.dv),A.ev)...)
 ldltd{T<:LapackType}(A::SymTridiagonal{T}) = ldltd!(copy(A))
 
-(\){T<:LapackType}(C::LDLTTridiagonal{T}, B::StridedVecOrMat{T}) =
+function (\){T<:LapackType}(C::LDLTTridiagonal{T}, B::StridedVecOrMat{T})
+    if iscomplex(B) return LAPACK.pttrs!('L', C.D, C.E, copy(B)) end
     LAPACK.pttrs!(C.D, C.E, copy(B))
+end
 
 type LUTridiagonal{T} <: Factorization{T}
     dl::Vector{T}
@@ -1042,9 +1058,9 @@ lud{T}(A::Tridiagonal{T}) =
     LUTridiagonal{T}(LAPACK.gttrf!(copy(A.dl),copy(A.d),copy(A.du))...)
 lu(A::Tridiagonal) = factors(lud(A))
 
-function det(lu::LUTridiagonal)
+function det{T}(lu::LUTridiagonal{T})
     n = length(lu.d)
-    prod(lu.d) * (bool(sum(lu.ipiv .!= 1:n) % 2) ? -1 : 1)
+    prod(lu.d) * (bool(sum(lu.ipiv .!= 1:n) % 2) ? -one(T) : one(T))
 end
 
 det(A::Tridiagonal) = det(lud(A))

--- a/base/math.jl
+++ b/base/math.jl
@@ -437,41 +437,81 @@ end
 
 gamma(z::Complex) = exp(lgamma(z))
 
-# Use Algorithm AS 103 by J. M. Bernardo
-# May be slightly less precise numerically than implementation in Netlib,
-# but Bernardo's algorithm is much simpler
-function psigamma(x::Float64)
-  if x <= 0.0
-    error("x must be positive")
-  end
+# Translation of psi.c from cephes
+function digamma(x::Float64)
+  
+    EUL = 0.57721566490153286061
+    a6 = 8.33333333333333333333e-2
+    a5 = -2.10927960927960927961e-2
+    a4 = 7.57575757575757575758e-3
+    a3 = -4.16666666666666666667e-3
+    a2 = 3.96825396825396825397e-3
+    a1 = -8.33333333333333333333e-3
+    a0 = 8.33333333333333333333e-2
 
-  s = 1.0e-5
-  c = 8.5
-  s3 = 8.333333333e-2
-  s4 = 8.333333333e-3
-  s5 = 3.968253968e-3
-  d1 = -0.5772156649
+    negative = false
+    nz = 0.0
 
-  if x <= s
-    return d1 - 1.0 / x
-  end
+    if x <= 0.0
+        negative = true
+        q = x
+        p = floor(q)
+        if p == q
+            return NaN
+        end
 
-  results = 0.0
-  y = x
+        nz = q - p
+        if nz != 0.5
+            if nz > 0.5
+                p += 1.0
+                nz = q - p
+            end
+            nz = pi / tan(pi * nz)
+        else
+            nz = 0.0
+        end
+        x = 1.0 - x
+    end
 
-  while y < c
-    results -= 1.0 / y
-    y += 1.0
-  end
+    if x <= 10.0 && x == floor(x)
+        y = 0.0
+        n = x
+        for i = 1:n-1
+            w = i
+            y += 1.0 / w
+        end
+        y -= EUL
 
-  r = 1.0 / y
-  results += log(y) - 0.5 * r
-  r = r^2
-  results -= r * (s3 - r * (s4 - r * s5))
-  return results
+        if negative
+            y -= nz
+        end
+        return y
+    end
+
+    s = x
+    w = 0.0
+    while s < 10.0
+        w += 1.0 / s
+        s += 1.0
+    end
+
+    if s < 1.0e17
+        z = 1.0 / (s*s)
+        y = a0*z + a1*z^2 + a2*z^3 + a3*z^4 + a4*z^5 + a5*z^6 + a6*z^7
+    else
+        y = 0.0
+    end
+
+    y = log(s) - 0.5/s - y - w
+
+    if negative
+        y -= nz
+    end
+
+    return y
 end
-
-const digamma = psigamma
+digamma(x::Float32) = float32(digamma(float64(x)))
+digamma{T<:Real}(x::T) = digamma(float64(x))
 
 beta(x::Number, w::Number) = exp(lgamma(x)+lgamma(w)-lgamma(x+w))
 lbeta(x::Number, w::Number) = lgamma(x)+lgamma(w)-lgamma(x+w)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,358 +1,337 @@
-Eps = sqrt(eps())
+n     = 10
+srand(1234321)
+a     = rand(n,n)
+b     = rand(n)
+for elty in (Float32, Float64, Complex64, Complex128)
+    @eval begin
+        a     = convert(Matrix{$elty}, a)
+        asym  = a' + a                          # symmetric indefinite
+        apd   = a'*a                            # symmetric positive-definite
+        b     = convert(Vector{$elty}, b)
+        
+        capd  = chold(apd)                      # upper Cholesky factor
+        r     = factors(capd)
+        @assert r == chol(apd)
+        @assert_approx_eq r'*r apd
+        @assert_approx_eq b apd * (capd\b)
+        @assert_approx_eq apd * inv(capd) eye($elty, n)
+        @assert_approx_eq a*(capd\(a'*b)) b          # least squares soln for square a
+        @assert_approx_eq det(capd) det(apd)
 
-begin
-    local n
-    n     = 10
-    srand(1234321)
-    a     = rand(n,n)
-    asym  = a' + a                          # symmetric indefinite
-    apd   = a'*a                            # symmetric positive-definite
-    b     = rand(n)
+        l     = factors(chold(apd, false))      # lower Cholesky factor
+        @assert_approx_eq l*l' apd
 
-    capd  = chold(apd)                      # upper Cholesky factor
-    r     = factors(capd)
-    @assert r == chol(apd)
-    @assert norm(r'*r - apd) < Eps
-    @assert norm(b - apd * (capd\b)) < Eps
-    @assert norm(apd * inv(capd) - eye(n)) < Eps
-    @assert norm(a*(capd\(a'*b)) - b) < Eps # least squares soln for square a
-    @assert_approx_eq det(capd) det(apd)
+        cpapd = cholpd(apd)                     # pivoted Choleksy decomposition
+        @assert rank(cpapd) == n
+        @assert all(diff(diag(real(cpapd.LR))).<=0.)  # diagonal show be non-increasing
+        @assert_approx_eq b apd * (cpapd\b)
+        @assert_approx_eq apd * inv(cpapd) eye($elty, n)
 
-    l     = factors(chold(apd, false))      # lower Cholesky factor
-    @assert norm(l*l' - apd) < Eps
+        bc1   = BunchKaufman(asym)              # Bunch-Kaufman factor of indefinite matrix
+        @assert_approx_eq inv(bc1) * asym eye($elty, n)
+        @assert_approx_eq asym * (bc1\b) b
+        bc2   = BunchKaufman(apd)               # Bunch-Kaufman factors of a pos-def matrix
+        @assert_approx_eq inv(bc2) * apd eye($elty, n)
+        @assert_approx_eq apd * (bc2\b) b
 
-    cpapd = cholpd(apd)                     # pivoted Choleksy decomposition
-    @assert rank(cpapd) == n
-    @assert all(diff(diag(cpapd.LR)).<=0.)  # diagonal show be non-increasing
-    @assert norm(b - apd * (cpapd\b)) < Eps
-    @assert norm(apd * inv(cpapd) - eye(n)) < Eps
+        lua   = lud(a)                          # LU decomposition
+        l,u,p = lu(a)
+        L,U,P = factors(lua)
+        @assert l == L && u == U && p == P
+        @assert_approx_eq l*u a[p,:]
+        @assert_approx_eq l[invperm(p),:]*u a
+        @assert_approx_eq a * inv(lua) eye($elty, n)
+        @assert_approx_eq a*(lua\b) b
 
-    bc1   = BunchKaufman(asym)              # Bunch-Kaufman factor of indefinite matrix
-    @assert norm(inv(bc1) * asym - eye(n)) < Eps
-    @assert norm(asym * (bc1\b) - b) < Eps
-    bc2   = BunchKaufman(apd)               # Bunch-Kaufman factors of a pos-def matrix
-    @assert norm(inv(bc2) * apd - eye(n)) < Eps
-    @assert norm(apd * (bc2\b) - b) < Eps
+        qra   = qrd(a)                          # QR decomposition
+        q,r   = factors(qra)
+        @assert_approx_eq q'*q eye($elty, n)
+        @assert_approx_eq q*q' eye($elty, n)
+        Q,R   = qr(a)
+        @assert q == Q && r == R
+        @assert_approx_eq q*r a
+        @assert_approx_eq qra*b Q*b
+        @assert_approx_eq qra'*b Q'*b
+        @assert_approx_eq a*(qra\b) b
 
-    lua   = lud(a)                          # LU decomposition
-    l,u,p = lu(a)
-    L,U,P = factors(lua)
-    @assert l == L && u == U && p == P
-    @assert norm(l*u - a[p,:]) < Eps
-    @assert norm(l[invperm(p),:]*u - a) < Eps
-    @assert norm(a * inv(lua) - eye(n)) < Eps
-    @assert norm(a*(lua\b) - b) < Eps
+        qrpa  = qrpd(a)                         # pivoted QR decomposition
+        q,r,p = factors(qrpa)
+        @assert_approx_eq q'*q eye($elty, n)
+        @assert_approx_eq q*q' eye($elty, n)
+        Q,R,P = qrp(a)
+        @assert q == Q && r == R && p == P
+        @assert_approx_eq q*r a[:,p]
+        @assert_approx_eq q*r[:,invperm(p)] a
+        @assert_approx_eq a*(qrpa\b) b
 
-    qra   = qrd(a)                          # QR decomposition
-    q,r   = factors(qra)
-    @assert norm(q'*q - eye(n)) < Eps
-    @assert norm(q*q' - eye(n)) < Eps
-    Q,R   = qr(a)
-    @assert q == Q && r == R
-    @assert norm(q*r - a) < Eps
-    @assert norm(qra*b - Q*b) < Eps
-    @assert norm(qra'*b - Q'*b) < Eps
-    @assert norm(a*(qra\b) - b) < Eps
+        d,v   = eig(asym)                       # symmetric eigen-decomposition
+        @assert_approx_eq asym*v[:,1] d[1]*v[:,1]
+        @assert_approx_eq v*diagmm(d,v') asym
 
-    qrpa  = qrpd(a)                         # pivoted QR decomposition
-    q,r,p = factors(qrpa)
-    @assert norm(q'*q - eye(n)) < Eps
-    @assert norm(q*q' - eye(n)) < Eps
-    Q,R,P = qrp(a)
-    @assert q == Q && r == R && p == P
-    @assert norm(q*r - a[:,p]) < Eps
-    @assert norm(q*r[:,invperm(p)] - a) < Eps
-    @assert norm(a*(qrpa\b) - b) < Eps
-
-    d,v   = eig(asym)                       # symmetric eigen-decomposition
-    @assert norm(asym*v[:,1]-d[1]*v[:,1]) < Eps
-    @assert norm(v*diagmm(d,v') - asym) < Eps
-
-    d,v   = eig(a)                          # non-symmetric eigen decomposition
-    for i in 1:size(a,2) @assert norm(a*v[:,i] - d[i]*v[:,i]) < Eps end
-
-    u,s,vt = svd(a)                         # singular value decomposition
-    @assert norm(u*diagmm(s,vt) - a) < Eps
-
-    x = a \ b
-    @assert norm(a*x - b) < Eps
-
-    x = triu(a) \ b
-    @assert norm(triu(a)*x - b) < Eps
-
-    x = tril(a) \ b
-    @assert norm(tril(a)*x - b) < Eps
-
-    # Test null
-    bnull = null(b')
-    @assert norm(b'bnull) < Eps
-    @assert norm(bnull'b) < Eps
-    @assert size(null(b), 2) == 0
-
-    # Test pinv
-    pinvb = pinv(b)
-    @assert norm(b*pinvb*b - b) < Eps
-    @assert norm(pinvb*b*pinvb - pinvb) < Eps
-
-    # Complex vector rhs
-    x = a\complex(b)
-    @assert norm(a*x-complex(b)) < Eps
+        d,v   = eig(a)                          # non-symmetric eigen decomposition
+        for i in 1:size(a,2) @assert_approx_eq a*v[:,i] d[i]*v[:,i] end
     
-    # Least squares
-    a = [ones(20) 1:20 1:20]
-    b = reshape(eye(8, 5), 20, 2)
+        u,s,vt = svd(a)                         # singular value decomposition
+        @assert_approx_eq u*diagmm(s,vt) a
+    
+        x = a \ b
+        @assert_approx_eq a*x b
+    
+        x = triu(a) \ b
+        @assert_approx_eq triu(a)*x b
+    
+        x = tril(a)\b
+        @assert_approx_eq tril(a)*x b
 
-    x = a[:,1:2]\b[:,1]                             # Vector rhs
-    @assert abs(((a[:,1:2]*x-b[:,1])'*(a[:,1:2]*x-b[:,1])/20)[1] - 0.127330827) < Eps
+        # Test null
+        bnull = null(b')
+        @assert_approx_eq_eps norm(b'bnull) zero($elty) n*eps(one($elty))
+        @assert_approx_eq_eps norm(bnull'b) zero($elty) n*eps(one($elty))
+        @assert size(null(b), 2) == 0
 
-    x = a[:,1:2]\b                                  # Matrix rhs
-    @assert abs(det((a[:,1:2]*x-b)'*(a[:,1:2]*x-b)/20) - 0.0110949248) < Eps
+        # Test pinv
+        pinvb = pinv(b)
+        @assert_approx_eq b*pinvb*b b
+        @assert_approx_eq pinvb*b*pinvb pinvb
+    
+        # Complex vector rhs
+        x = a\complex(b)
+        @assert_approx_eq a*x complex(b)
+    end
+end
+a = [ones(20) 1:20 1:20]
+b = reshape(eye(8, 5), 20, 2)
+for elty in (Float32, Float64, Complex64, Complex128)
+    @eval begin
+        a = convert(Matrix{$elty}, a)
+        b = convert(Matrix{$elty}, b)
 
-    x = a\b                            # Rank deficient
-    @assert abs(det((a*x-b)'*(a*x-b)/20) - 0.0110949248) < Eps
-    x = (a + im)\(b + im)              # ...and complex
-    @assert abs(det(((a + im)*x-(b + im))'*((a + im)*x-(b + im))/20) - 0.0110949248) < Eps
+        # Least squares        
+        x = a[:,1:2]\b[:,1]                             # Vector rhs
+        @assert_approx_eq ((a[:,1:2]*x-b[:,1])'*(a[:,1:2]*x-b[:,1]))[1] convert($elty, 2.546616541353384)
+    
+        x = a[:,1:2]\b                                  # Matrix rhs
+        @assert_approx_eq det((a[:,1:2]*x-b)'*(a[:,1:2]*x-b)) convert($elty, 4.437969924812031)
+    
+        x = a\b                            # Rank deficient
+        @assert_approx_eq det((a*x-b)'*(a*x-b)) convert($elty, 4.437969924812031)
 
-    # symmetric, positive definite
-    @assert norm(inv([6. 2; 2 1]) - [0.5 -1; -1 3]) < Eps
-    # symmetric, negative definite
-    @assert norm(inv([1. 2; 2 1]) - [-1. 2; 2 -1]/3) < Eps
+        # symmetric, positive definite
+        @assert_approx_eq inv(convert(Matrix{$elty}, [6. 2; 2 1])) convert(Matrix{$elty}, [0.5 -1; -1 3])
+        # symmetric, negative definite
+        @assert_approx_eq inv(convert(Matrix{$elty}, [1. 2; 2 1])) convert(Matrix{$elty}, [-1. 2; 2 -1]/3)
+    end
+end
 
-    ## Test Julia fallbacks to BLAS routines
-    # matrices with zero dimensions
-    @assert ones(0,5)*ones(5,3) == zeros(0,3)
-    @assert ones(3,5)*ones(5,0) == zeros(3,0)
-    @assert ones(3,0)*ones(0,4) == zeros(3,4)
-    @assert ones(0,5)*ones(5,0) == zeros(0,0)
-    @assert ones(0,0)*ones(0,4) == zeros(0,4)
-    @assert ones(3,0)*ones(0,0) == zeros(3,0)
-    @assert ones(0,0)*ones(0,0) == zeros(0,0)
-    # 2x2
-    A = [1 2; 3 4]
-    B = [5 6; 7 8]
-    @assert A*B == [19 22; 43 50]
-    @assert At_mul_B(A, B) == [26 30; 38 44]
-    @assert A_mul_Bt(A, B) == [17 23; 39 53]
-    @assert At_mul_Bt(A, B) == [23 31; 34 46]
-    Ai = A+(0.5*im).*B
-    Bi = B+(2.5*im).*A[[2,1],[2,1]]
-    @assert Ai*Bi == [-21+53.5im -4.25+51.5im; -12+95.5im 13.75+85.5im]
-    @assert Ac_mul_B(Ai, Bi) == [68.5-12im 57.5-28im; 88-3im 76.5-25im]
-    @assert A_mul_Bc(Ai, Bi) == [64.5+5.5im 43+31.5im; 104-18.5im 80.5+31.5im]
-    @assert Ac_mul_Bc(Ai, Bi) == [-28.25-66im 9.75-58im; -26-89im 21-73im]
-    # 3x3
-    A = [1 2 3; 4 5 6; 7 8 9]-5
-    B = [1 0 5; 6 -10 3; 2 -4 -1]
-    @assert A*B == [-26 38 -27; 1 -4 -6; 28 -46 15]
-    @assert Ac_mul_B(A, B) == [-6 2 -25; 3 -12 -18; 12 -26 -11]
-    @assert A_mul_Bc(A, B) == [-14 0 6; 4 -3 -3; 22 -6 -12]
-    @assert Ac_mul_Bc(A, B) == [6 -8 -6; 12 -9 -9; 18 -10 -12]
-    Ai = A+(0.5*im).*B
-    Bi = B+(2.5*im).*A[[2,1,3],[2,3,1]]
-    @assert Ai*Bi == [-44.75+13im 11.75-25im -38.25+30im; -47.75-16.5im -51.5+51.5im -56+6im; 16.75-4.5im -53.5+52im -15.5im]
-    @assert Ac_mul_B(Ai, Bi) == [-21+2im -1.75+49im -51.25+19.5im; 25.5+56.5im -7-35.5im 22+35.5im; -3+12im -32.25+43im -34.75-2.5im]
-    @assert A_mul_Bc(Ai, Bi) == [-20.25+15.5im -28.75-54.5im 22.25+68.5im; -12.25+13im -15.5+75im -23+27im; 18.25+im 1.5+94.5im -27-54.5im]
-    @assert Ac_mul_Bc(Ai, Bi) == [1+2im 20.75+9im -44.75+42im; 19.5+17.5im -54-36.5im 51-14.5im; 13+7.5im 11.25+31.5im -43.25-14.5im]
-    # Generic integer matrix multiplication
-    A = [1 2 3; 4 5 6] - 3
-    B = [2 -2; 3 -5; -4 7]
-    @assert A*B == [-7 9; -4 9]
-    @assert At_mul_Bt(A, B) == [-6 -11 15; -6 -13 18; -6 -15 21]
-    A = ones(Int, 2, 100)
-    B = ones(Int, 100, 3)
-    @assert A*B == [100 100 100; 100 100 100]
-    A = randi(20, 5, 5) - 10
-    B = randi(20, 5, 5) - 10
-    @assert At_mul_B(A, B) == A'*B
-    @assert A_mul_Bt(A, B) == A*B'
-    # Preallocated
-    C = Array(Int, size(A, 1), size(B, 2))
-    @assert A_mul_B(C, A, B) == A*B
-    @assert At_mul_B(C, A, B) == A'*B
-    @assert A_mul_Bt(C, A, B) == A*B'
-    @assert At_mul_Bt(C, A, B) == A'*B'
-    # matrix algebra with subarrays of floats (stride != 1)
-    A = reshape(float64(1:20),5,4)
-    Aref = A[1:2:end,1:2:end]
-    Asub = sub(A, 1:2:5, 1:2:4)
-    b = [1.2,-2.5]
-    @assert (Aref*b) == (Asub*b)
-    @assert At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
-    @assert A_mul_Bt(Asub, Asub) == A_mul_Bt(Aref, Aref)
-    Ai = A + im
-    Aref = Ai[1:2:end,1:2:end]
-    Asub = sub(Ai, 1:2:5, 1:2:4)
-    @assert Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
-    @assert A_mul_Bc(Asub, Asub) == A_mul_Bc(Aref, Aref)
-    # syrk & herk
-    A = reshape(1:1503, 501, 3)-750.0
-    res = float64([135228751 9979252 -115270247; 9979252 10481254 10983256; -115270247 10983256 137236759])
-    @assert At_mul_B(A, A) == res
-    @assert A_mul_Bt(A',A') == res
-    cutoff = 501
-    A = reshape(1:6*cutoff,2*cutoff,3)-(6*cutoff)/2
-    Asub = sub(A, 1:2:2*cutoff, 1:3)
-    Aref = A[1:2:2*cutoff, 1:3]
-    @assert At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
-    Ai = A - im
-    Asub = sub(Ai, 1:2:2*cutoff, 1:3)
-    Aref = Ai[1:2:2*cutoff, 1:3]
-    @assert Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
-    # Matrix exponential
-    for eltype in (Float32, Float64, Complex64, Complex128)
-        @eval begin
-            A1  = convert(Matrix{$eltype}, [4 2 0; 1 4 1; 1 1 4])
-            eA1 = convert(Matrix{$eltype}, [147.866622446369 127.781085523181  127.781085523182;
-            183.765138646367 183.765138646366  163.679601723179;
-            71.797032399996  91.8825693231832 111.968106246371]')
-            @assert norm((expm(A1) - eA1) ./ eA1) < 1000*eps(real(A1[1]))
-            A2  = convert(Matrix{$eltype}, [29.87942128909879    0.7815750847907159 -2.289519314033932;
+## Test Julia fallbacks to BLAS routines
+# matrices with zero dimensions
+@assert ones(0,5)*ones(5,3) == zeros(0,3)
+@assert ones(3,5)*ones(5,0) == zeros(3,0)
+@assert ones(3,0)*ones(0,4) == zeros(3,4)
+@assert ones(0,5)*ones(5,0) == zeros(0,0)
+@assert ones(0,0)*ones(0,4) == zeros(0,4)
+@assert ones(3,0)*ones(0,0) == zeros(3,0)
+@assert ones(0,0)*ones(0,0) == zeros(0,0)
+# 2x2
+A = [1 2; 3 4]
+B = [5 6; 7 8]
+@assert A*B == [19 22; 43 50]
+@assert At_mul_B(A, B) == [26 30; 38 44]
+@assert A_mul_Bt(A, B) == [17 23; 39 53]
+@assert At_mul_Bt(A, B) == [23 31; 34 46]
+Ai = A+(0.5*im).*B
+Bi = B+(2.5*im).*A[[2,1],[2,1]]
+@assert Ai*Bi == [-21+53.5im -4.25+51.5im; -12+95.5im 13.75+85.5im]
+@assert Ac_mul_B(Ai, Bi) == [68.5-12im 57.5-28im; 88-3im 76.5-25im]
+@assert A_mul_Bc(Ai, Bi) == [64.5+5.5im 43+31.5im; 104-18.5im 80.5+31.5im]
+@assert Ac_mul_Bc(Ai, Bi) == [-28.25-66im 9.75-58im; -26-89im 21-73im]
+# 3x3
+A = [1 2 3; 4 5 6; 7 8 9]-5
+B = [1 0 5; 6 -10 3; 2 -4 -1]
+@assert A*B == [-26 38 -27; 1 -4 -6; 28 -46 15]
+@assert Ac_mul_B(A, B) == [-6 2 -25; 3 -12 -18; 12 -26 -11]
+@assert A_mul_Bc(A, B) == [-14 0 6; 4 -3 -3; 22 -6 -12]
+@assert Ac_mul_Bc(A, B) == [6 -8 -6; 12 -9 -9; 18 -10 -12]
+Ai = A+(0.5*im).*B
+Bi = B+(2.5*im).*A[[2,1,3],[2,3,1]]
+@assert Ai*Bi == [-44.75+13im 11.75-25im -38.25+30im; -47.75-16.5im -51.5+51.5im -56+6im; 16.75-4.5im -53.5+52im -15.5im]
+@assert Ac_mul_B(Ai, Bi) == [-21+2im -1.75+49im -51.25+19.5im; 25.5+56.5im -7-35.5im 22+35.5im; -3+12im -32.25+43im -34.75-2.5im]
+@assert A_mul_Bc(Ai, Bi) == [-20.25+15.5im -28.75-54.5im 22.25+68.5im; -12.25+13im -15.5+75im -23+27im; 18.25+im 1.5+94.5im -27-54.5im]
+@assert Ac_mul_Bc(Ai, Bi) == [1+2im 20.75+9im -44.75+42im; 19.5+17.5im -54-36.5im 51-14.5im; 13+7.5im 11.25+31.5im -43.25-14.5im]
+# Generic integer matrix multiplication
+A = [1 2 3; 4 5 6] - 3
+B = [2 -2; 3 -5; -4 7]
+@assert A*B == [-7 9; -4 9]
+@assert At_mul_Bt(A, B) == [-6 -11 15; -6 -13 18; -6 -15 21]
+A = ones(Int, 2, 100)
+B = ones(Int, 100, 3)
+@assert A*B == [100 100 100; 100 100 100]
+A = randi(20, 5, 5) - 10
+B = randi(20, 5, 5) - 10
+@assert At_mul_B(A, B) == A'*B
+@assert A_mul_Bt(A, B) == A*B'
+# Preallocated
+C = Array(Int, size(A, 1), size(B, 2))
+@assert A_mul_B(C, A, B) == A*B
+@assert At_mul_B(C, A, B) == A'*B
+@assert A_mul_Bt(C, A, B) == A*B'
+@assert At_mul_Bt(C, A, B) == A'*B'
+# matrix algebra with subarrays of floats (stride != 1)
+A = reshape(float64(1:20),5,4)
+Aref = A[1:2:end,1:2:end]
+Asub = sub(A, 1:2:5, 1:2:4)
+b = [1.2,-2.5]
+@assert (Aref*b) == (Asub*b)
+@assert At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
+@assert A_mul_Bt(Asub, Asub) == A_mul_Bt(Aref, Aref)
+Ai = A + im
+Aref = Ai[1:2:end,1:2:end]
+Asub = sub(Ai, 1:2:5, 1:2:4)
+@assert Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
+@assert A_mul_Bc(Asub, Asub) == A_mul_Bc(Aref, Aref)
+# syrk & herk
+A = reshape(1:1503, 501, 3)-750.0
+res = float64([135228751 9979252 -115270247; 9979252 10481254 10983256; -115270247 10983256 137236759])
+@assert At_mul_B(A, A) == res
+@assert A_mul_Bt(A',A') == res
+cutoff = 501
+A = reshape(1:6*cutoff,2*cutoff,3)-(6*cutoff)/2
+Asub = sub(A, 1:2:2*cutoff, 1:3)
+Aref = A[1:2:2*cutoff, 1:3]
+@assert At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
+Ai = A - im
+Asub = sub(Ai, 1:2:2*cutoff, 1:3)
+Aref = Ai[1:2:2*cutoff, 1:3]
+@assert Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
+
+# Matrix exponential
+for elty in (Float32, Float64, Complex64, Complex128)
+    @eval begin
+        A1  = convert(Matrix{$elty}, [4 2 0; 1 4 1; 1 1 4])
+        eA1 = convert(Matrix{$elty}, [147.866622446369 127.781085523181  127.781085523182;
+        183.765138646367 183.765138646366  163.679601723179;
+        71.797032399996  91.8825693231832 111.968106246371]')
+        @assert_approx_eq expm(A1) eA1
+
+        A2  = convert(Matrix{$elty}, 
+            [29.87942128909879    0.7815750847907159 -2.289519314033932;
             0.7815750847907159 25.72656945571064    8.680737820540137;
             -2.289519314033932   8.680737820540137  34.39400925519054])
-            eA2 = convert(Matrix{$eltype},[  5496313853692216. -18231880972008932. -30475770808579672.;
-            -18231880972008928.  60605228702222480. 101291842930249776.;
-            -30475770808579672. 101291842930249808. 169294411240850528])
-            @assert norm((expm(A2) - eA2) ./ eA2) < 1000*eps(real(A2[1]))
-            A3  = convert(Matrix{$eltype}, [-131 19 18;-390 56 54;-387 57 52])
-            eA3 = convert(Matrix{$eltype}, [-1.50964415879218 -5.6325707998812  -4.934938326092;
-            0.367879439109187 1.47151775849686  1.10363831732856;
-            0.135335281175235 0.406005843524598 0.541341126763207]')
-            @assert norm((expm(A3) - eA3) ./ eA3) < 50000*eps(real(A3[1]))
+        eA2 = convert(Matrix{$elty},
+            [  5496313853692458.0 -18231880972009236.0 -30475770808580460.0;
+             -18231880972009252.0  60605228702221920.0 101291842930249760.0;
+             -30475770808580480.0 101291842930249728.0 169294411240851968.0])
+        @assert_approx_eq expm(A2) eA2
+
+        A3  = convert(Matrix{$elty}, [-131 19 18;-390 56 54;-387 57 52])
+        eA3 = convert(Matrix{$elty}, [-1.50964415879218 -5.6325707998812  -4.934938326092;
+        0.367879439109187 1.47151775849686  1.10363831732856;
+        0.135335281175235 0.406005843524598 0.541341126763207]')
+        @assert_approx_eq expm(A3) eA3
+    end
+end
+
+# matmul for types w/o sizeof (issue #1282)
+A = Array(ComplexPair{Int},10,10)
+A[:] = complex(1,1)
+A2 = A^2
+@assert A2[1,1] == 20im
+
+# basic tridiagonal operations
+n = 5
+d = 1 + rand(n)
+dl = -rand(n-1)
+du = -rand(n-1)
+v = randn(n)
+B = randn(n,2)
+# Woodbury
+U = randn(n,2)
+V = randn(2,n)
+C = randn(2,2)
+
+for elty in (Float32, Float64, Complex64, Complex128)
+    @eval begin
+        d = convert(Vector{$elty}, d)
+        dl = convert(Vector{$elty}, dl)
+        du = convert(Vector{$elty}, du)
+        T = Tridiagonal(dl, d, du)
+        @assert size(T, 1) == n
+        @assert size(T) == (n, n)
+        F = diagm(d)
+        for i = 1:n-1
+            F[i,i+1] = du[i]
+            F[i+1,i] = dl[i]
         end
+        @assert full(T) == F
+
+        # tridiagonal linear algebra
+        v = convert(Vector{$elty}, v)
+        @assert_approx_eq T*v F*v
+        invFv = F\v
+        @assert_approx_eq T\v invFv
+        @assert_approx_eq solve(T,v) invFv
+        B = convert(Matrix{$elty}, B)
+        @assert_approx_eq solve(T, B) F\B
+        Tlu = lud(T)
+        x = Tlu\v
+        @assert_approx_eq x invFv
+        @assert_approx_eq det(T) det(F)
+
+        # symmetric tridiagonal
+        Ts = SymTridiagonal(d, dl)
+        Fs = full(Ts)
+        invFsv = Fs\v
+        Tldlt = ldltd(Ts)
+        x = Tldlt\v
+        @assert_approx_eq x invFsv
+
+        # eigenvalues/eigenvectors of symmetric tridiagonal
+        if $elty == Float32 || $elty == Float64
+            DT, VT = eig(Ts)
+            D, Vecs = eig(Fs)
+            @assert_approx_eq DT D
+            @assert_approx_eq abs(VT'Vecs) eye($elty, n)
+        end
+        
+        # Woodbury
+        U = convert(Matrix{$elty}, U)
+        V = convert(Matrix{$elty}, V)
+        C = convert(Matrix{$elty}, C)
+        W = Woodbury(T, U, C, V)
+        F = full(W)
+        @assert_approx_eq W*v F*v
+        @assert_approx_eq W\v F\v
+        @assert_approx_eq det(W) det(F)
+
+        # Test det(A::Matrix)
+        # In the long run, these tests should step through Strang's
+        #  axiomatic definition of determinants.
+        # If all axioms are satisfied and all the composition rules work,
+        #  all determinants will be correct except for floating point errors.
+        
+        # The determinant of the identity matrix should always be 1.
+        for i = 1:10
+            A = eye($elty, i)
+            @assert_approx_eq det(A) one($elty)
+        end
+        
+        # The determinant of a Householder reflection matrix should always be -1.
+        for i = 1:10
+            A = eye($elty, 10)
+            A[i, i] = -one($elty)
+            @assert_approx_eq det(A) -one($elty)
+        end
+        
+        # The determinant of a rotation matrix should always be 1.
+        for theta = convert(Vector{$elty}, pi ./ [1:4])
+            R = [cos(theta) -sin(theta);
+                 sin(theta) cos(theta)]
+            @assert_approx_eq convert($elty, det(R)) one($elty)
+        end
+        
+        # issue 1490
+        @assert_approx_eq_eps det(ones($elty, 3,3)) zero($elty) 3*eps(one($elty))
     end
-
-    # matmul for types w/o sizeof (issue #1282)
-    A = Array(ComplexPair{Int},10,10)
-    A[:] = complex(1,1)
-    A2 = A^2
-    @assert A2[1,1] == 20im
-
-    # basic tridiagonal operations
-    n = 5
-    d = 1 + rand(n)
-    dl = -rand(n-1)
-    du = -rand(n-1)
-    T = Tridiagonal(dl, d, du)
-    @assert size(T, 1) == n
-    @assert size(T) == (n, n)
-    F = diagm(d)
-    for i = 1:n-1
-        F[i,i+1] = du[i]
-        F[i+1,i] = dl[i]
-    end
-    @assert full(T) == F
-
-    # tridiagonal linear algebra
-    v = randn(n)
-    @assert norm(T*v - F*v) < Eps
-    invFv = F\v
-    @assert norm(T\v - invFv) < Eps
-    @assert norm(solve(T,v) - invFv) < Eps
-    B = randn(n,2)
-    @assert norm(solve(T, B) - F\B) < Eps
-    Tlu = lud(T)
-    x = Tlu\v
-    @assert norm(x - invFv) < Eps
-    @assert_approx_eq det(T) det(F)
-
-    # symmetric tridiagonal
-    Ts = SymTridiagonal(d, dl)
-    Fs = full(Ts)
-    invFsv = Fs\v
-    Tldlt = ldltd(Ts)
-    x = Tldlt\v
-    @assert norm(x - invFsv) < Eps
-
-    # eigenvalues/eigenvectors of symmetric tridiagonal
-    DT, VT = eig(Ts)
-    D, V = eig(Fs)
-    @assert norm(DT - D) < Eps
-    @assert norm(VT - V) < Eps
-
-
-    # Woodbury
-    U = randn(n,2)
-    V = randn(2,n)
-    C = randn(2,2)
-    W = Woodbury(T, U, C, V)
-    F = full(W)
-
-    @assert norm(W*v - F*v) < Eps
-    @assert norm(W\v - F\v) < Eps
-    @assert_approx_eq det(W) det(F)
-
-    sqd  = rand(n,n)
-    sqz  = complex(sqd)
-    mmd  = rand(3*n, n)
-    mmz  = complex(mmd)
-    symd = mmd' * mmd
-    herz = mmz' * mmz
-    bd   = rand(n)
-    bz   = complex(bd)
-                                        # Cholesky decomposition
-    chd  = chold(symd)
-    chz  = chold(herz)
-    xd   = chd \ bd
-    xz   = chz \ bz    
-    @assert norm(symd * xd - bd) < Eps
-    @assert norm(herz * xz - bz) < Eps
-                                        # LU decomposition
-    ld   = lud(sqd)
-    luz  = lud(sqz)    
-    xd   = ld  \ bd
-    xz   = luz \ bz
-    @assert norm(sqd * xd - bd) < Eps
-    @assert norm(sqz * xz - bz) < Eps
-    invd = inv(ld)
-    invz = inv(luz)
-    @assert norm(invd * sqd - eye(size(sqd, 1))) < Eps
-    @assert norm(invz * sqz - eye(size(sqz, 1))) < Eps
-
-    @assert_approx_eq det(sqd) prod(eig(sqd)[1]) # determinant
-    @assert_approx_eq det(sqz) prod(eig(sqz)[1])
-    @assert_approx_eq det(symd) prod(eig(symd)[1])
-#    @assert_approx_eq det(herz) prod(eig(herz)[1])
-
-    qd   = qrd(mmd)                      # QR and QRP decompositions
-    qrz  = qrd(mmz)
-    qpd  = qrpd(mmd)
-    qrpz = qrpd(mmz)
-    yyd  = randn(3*n)
-    yyz  = complex(yyd)
-    qyd  = qd * yyd
-    qpyd = qpd' * yyd
-    @assert abs(norm(qyd) - norm(yyd)) < Eps # Q is orthogonal
-    @assert abs(norm(qpyd) - norm(yyd)) < Eps 
-    qyz  = qrz * yyz
-    qpyz = qrz' * yyz
-    @assert abs(norm(qyz) - norm(yyz)) < Eps # Q is unitary
-    @assert abs(norm(qpyz) - norm(yyz)) < Eps # Q is unitary
-end
-
-# Test det(A::Matrix)
-# In the long run, these tests should step through Strang's
-#  axiomatic definition of determinants.
-# If all axioms are satisfied and all the composition rules work,
-#  all determinants will be correct except for floating point errors.
-
-# The determinant of the identity matrix should always be 1.
-for n = 1:10
-  A = eye(n)
-  @assert abs(det(A) - 1.0) < Eps
-end
-
-# The determinant of a Householder reflection matrix should always be -1.
-for i = 1:10
-  A = eye(10)
-  A[i, i] = -1.0
-  @assert abs(det(A) - (-1.0)) < Eps
-end
-
-# The determinant of a rotation matrix should always be 1.
-for theta = pi ./ [1:4]
-  R = [cos(theta) -sin(theta);
-       sin(theta) cos(theta)]
-  @assert abs(det(R) - 1.0) < Eps
 end
 
 # LAPACK tests
@@ -365,11 +344,11 @@ for elty in (Float32, Float64, Complex64, Complex128)
         Asym = A'A
         Z = Array($elty, 5, 5)
         vals = LAPACK.syevr!(copy(Asym), Z)
-        @assert norm(Z*diagmm(vals, Z') - Asym) < sqrt(eps(real(Asym[1])))
+        @assert_approx_eq Z*diagmm(vals, Z') Asym
         @assert all(vals .> 0.0)
-        @assert norm(LAPACK.syevr!('N','V','U',copy(Asym),0.0,1.0,4,5,zeros($elty,0,0),-1.0) - vals[vals .< 1.0]) < sqrt(eps(real(Asym[1])))
-        @assert norm(LAPACK.syevr!('N','I','U',copy(Asym),0.0,1.0,4,5,zeros($elty,0,0),-1.0) - vals[4:5]) < sqrt(eps(real(Asym[1])))
-        @assert norm(vals - LAPACK.syev!('N','U',copy(Asym))) < sqrt(eps(real(Asym[1])))
+        @assert_approx_eq LAPACK.syevr!('N','V','U',copy(Asym),0.0,1.0,4,5,zeros($elty,0,0),-1.0) vals[vals .< 1.0]
+        @assert_approx_eq LAPACK.syevr!('N','I','U',copy(Asym),0.0,1.0,4,5,zeros($elty,0,0),-1.0) vals[4:5]
+        @assert_approx_eq vals LAPACK.syev!('N','U',copy(Asym))
     end
 end
 
@@ -382,6 +361,3 @@ let
         @assert_approx_eq A[i] B[i]
     end
 end
-
-# issue 1490
-@assert_approx_eq det(ones(3,3)) 0.0

--- a/test/math.jl
+++ b/test/math.jl
@@ -1,18 +1,18 @@
 # airy
-@assert_approx_eq airy(1.8) 0.0470362
-@assert_approx_eq airyprime(1.8) -0.0685248
-@assert_approx_eq airybi(1.8) 2.59587
-@assert_approx_eq airybiprime(1.8) 2.98554
+@assert_approx_eq airy(1.8) 0.0470362168668458052247
+@assert_approx_eq airyprime(1.8) -0.0685247801186109345638
+@assert_approx_eq airybi(1.8) 2.595869356743906290060
+@assert_approx_eq airybiprime(1.8) 2.98554005084659907283
 
 # besselh
-true_h133 = 0.309063 - 0.538542im
+true_h133 = 0.30906272225525164362 - 0.53854161610503161800im
 @assert_approx_eq besselh(3,1,3) true_h133
 @assert_approx_eq besselh(-3,1,3) -true_h133
 @assert_approx_eq besselh(3,2,3) conj(true_h133)
 @assert_approx_eq besselh(-3,2,3) -conj(true_h133)
 
 # besseli
-true_i33 = 0.959754
+true_i33 = 0.95975362949600785698
 @assert_approx_eq besseli(3,3) true_i33
 @assert_approx_eq besseli(-3,3) true_i33
 @assert_approx_eq besseli(3,-3) -true_i33
@@ -37,17 +37,17 @@ j43 = besselj(4,3.)
 @assert besselj(-4,3) == j43
 @assert besselj(4,-3) == j43
 
-@assert_approx_eq j33 0.309063
-@assert_approx_eq j43 0.132034
-@assert_approx_eq besselj(0.1, -0.4) 0.820422 + 0.266571im
-@assert_approx_eq besselj(3.2, 1.3+0.6im) 0.0113531 + 0.0392772im
-@assert_approx_eq besselj(1, 3im) 3.95337im
+@assert_approx_eq j33 0.30906272225525164362
+@assert_approx_eq j43 0.13203418392461221033
+@assert_approx_eq besselj(0.1, -0.4) 0.820421842809028916 + 0.266571215948350899im
+@assert_approx_eq besselj(3.2, 1.3+0.6im) 0.01135309305831220201 + 0.03927719044393515275im
+@assert_approx_eq besselj(1, 3im) 3.953370217402609396im
 
 # besselk
-true_k33 = 0.12217
+true_k33 = 0.12217037575718356792
 @assert_approx_eq besselk(3,3) true_k33
 @assert_approx_eq besselk(-3,3) true_k33
-true_k3m3 = -0.122170 - 3.015155im
+true_k3m3 = -0.1221703757571835679 - 3.0151549516807985776im
 @assert_approx_eq besselk(3,-3) true_k3m3
 @assert_approx_eq besselk(-3,-3) true_k3m3
 
@@ -55,8 +55,8 @@ true_k3m3 = -0.122170 - 3.015155im
 y33 = bessely(3,3.)
 @assert bessely(3,3) == y33
 @assert_approx_eq bessely(-3,3) -y33
-@assert_approx_eq y33 -0.538542
-@assert_approx_eq bessely(3,-3) 0.538542 - 0.618125im
+@assert_approx_eq y33 -0.53854161610503161800
+@assert_approx_eq bessely(3,-3) 0.53854161610503161800 - 0.61812544451050328724im
 
 # beta, lbeta
 @assert_approx_eq beta(3/2,7/2) 5pi/128
@@ -66,18 +66,22 @@ y33 = bessely(3,3.)
 
 # gamma, lgamma (complex argument)
 @assert_approx_eq gamma(0.5) sqrt(pi)
-@assert_approx_eq lgamma(1.4+3.7im) -3.709402533100+2.456809050277im
+@assert_approx_eq lgamma(1.4+3.7im) -3.7094025330996841898 + 2.4568090502768651184im
 @assert_approx_eq lgamma(1.4+3.7im) log(gamma(1.4+3.7im))
 
 # digamma
 euler_mascheroni = 0.5772156649015329
-@assert_approx_eq digamma(0.1) -10.42375494041108
-@assert_approx_eq -digamma(1.0) euler_mascheroni
-@assert_approx_eq digamma(2.0) 0.4227843350984675
-@assert_approx_eq digamma(3.0) 0.9227843350984675
-@assert_approx_eq digamma(4.0) 1.256117668431801
-@assert_approx_eq digamma(5.0) 1.506117668431801
-@assert_approx_eq digamma(10.0) 2.251752589066721
+for elty in (Float32, Float64)
+	@eval begin
+		@assert_approx_eq digamma(convert($elty, 0.1)) convert($elty, -10.42375494041108)
+		@assert_approx_eq -digamma(convert($elty, 1.0)) convert($elty, euler_mascheroni)
+		@assert_approx_eq digamma(convert($elty, 2.0)) convert($elty, 0.4227843350984675)
+		@assert_approx_eq digamma(convert($elty, 3.0)) convert($elty, 0.9227843350984675)
+		@assert_approx_eq digamma(convert($elty, 4.0)) convert($elty, 1.256117668431801)
+		@assert_approx_eq digamma(convert($elty, 5.0)) convert($elty, 1.506117668431801)
+		@assert_approx_eq digamma(convert($elty, 10.0)) convert($elty, 2.251752589066721)
+	end
+end
 
 # eta, zeta
 @assert_approx_eq eta(1) log(2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,14 +4,22 @@ function runtests(name)
     load("$name")
 end
 
-function check_approx_eq(va, vb, astr, bstr)
-    diff = abs(va - vb)
-    sdiff = strcat("|", astr, " - ", bstr, "| < 1e-6")
-    if diff < 1e-6
+function check_approx_eq(va, vb, Eps, astr, bstr)
+    diff = max(abs(va - vb))
+    sdiff = strcat("|", astr, " - ", bstr, "| < ", Eps)
+    if diff < Eps
         nothing
     else
         error("assertion failed: ", sdiff, "\n  ", astr, " = ", va, "\n  ",
               bstr, " = ", vb)
+    end
+end
+
+check_approx_eq(va, vb, astr, bstr) = check_approx_eq(va, vb, 10^4*length(va)*eps(max(max(abs(va)), max(abs(vb)))) * max(1, max(abs(va)), max(abs(vb))), astr, bstr)
+
+macro assert_approx_eq_eps(a, b, c)
+    quote
+        check_approx_eq($(esc(a)), $(esc(b)), $(esc(c)), $(string(a)), $(string(b)))
     end
 end
 


### PR DESCRIPTION
Update of linalg tests to go through all four Lapack types and removed some extra complex tests. As a consequence, some changes in Lapack.jl for Float32 and complex types. Some fixes of return type in linalg. Some changes to Tridiagonal, but more work is needed here. Change of criterion in check_approx_eq to take float precision into account. This affects other tests. Hence I have added precision to the true values in the math test. Also, the return type in irfft has been corrected but in a very ugly way. Finally, change of eig to use new fast solver for symmetric problems.
