### PR TITLE
RFC: Clean up search_sorted* functions

### DIFF
--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -548,6 +548,30 @@
 
 "),
 
+(E"Iterable Collections",E"Base",E"indmax",E"indmax(itr)
+
+   Returns the index of the maximum element in a collection
+
+"),
+
+(E"Iterable Collections",E"Base",E"indmin",E"indmin(itr)
+
+   Returns the index of the minimum element in a collection
+
+"),
+
+(E"Iterable Collections",E"Base",E"findmax",E"findmax(iter)
+
+   Returns a tuple of the maximum element and its index
+
+"),
+
+(E"Iterable Collections",E"Base",E"findmin",E"findmin(iter)
+
+   Returns a tuple of the minimum element and its index
+
+"),
+
 (E"Iterable Collections",E"Base",E"sum",E"sum(itr)
 
    Sum elements of a collection
@@ -2829,6 +2853,35 @@ airyaiprime(x)
 (E"Combinatorics",E"Base",E"issorted",E"issorted(v)
 
    Test whether a vector is in ascending sorted order
+
+"),
+
+(E"Combinatorics",E"Base",E"search_sorted",E"search_sorted(a, x[, lo, hi])
+
+   Returns the index of the first value greater than or equal to \"x\"
+   in sorted sequence \"a\".  Assumes \"a\" is sorted low to high.
+
+   \"lo\" and \"hi\" optionally limit the search range.
+
+   Alias for \"search_sorted_first()\"
+
+"),
+
+(E"Combinatorics",E"Base",E"search_sorted_first",E"search_sorted_first(a, x[, lo, hi])
+
+   Returns the index of the first value greater than or equal to \"x\"
+   in sorted sequence \"a\".  Assumes \"a\" is sorted low to high.
+
+   \"lo\" and \"hi\" optionally limit the search range.
+
+"),
+
+(E"Combinatorics",E"Base",E"search_sorted_last",E"search_sorted_last(a, x[, lo, hi])
+
+   Returns the index of the last value less than or equal to \"x\" in
+   sorted sequence \"a\".  Assumes \"a\" is sorted low to high.
+
+   \"lo\" and \"hi\" optionally limit the search range.
 
 "),
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1741,6 +1741,29 @@ Combinatorics
 
    Test whether a vector is in ascending sorted order
 
+.. function:: search_sorted(a, x[, lo, hi])
+
+   Returns the index of the first value greater than or equal to ``x``
+   in sorted sequence ``a``.  Assumes ``a`` is sorted low to high.
+
+   ``lo`` and ``hi`` optionally limit the search range.
+
+   Alias for ``search_sorted_first()``
+
+.. function:: search_sorted_first(a, x[, lo, hi])
+
+   Returns the index of the first value greater than or equal to ``x``
+   in sorted sequence ``a``.  Assumes ``a`` is sorted low to high.
+
+   ``lo`` and ``hi`` optionally limit the search range.
+
+.. function:: search_sorted_last(a, x[, lo, hi])
+
+   Returns the index of the last value less than or equal to ``x``
+   in sorted sequence ``a``.  Assumes ``a`` is sorted low to high.
+
+   ``lo`` and ``hi`` optionally limit the search range.
+
 .. function:: nthperm(v, k)
 
    Compute the kth lexicographic permutation of a vector

--- a/doc/stdlib/index.rst
+++ b/doc/stdlib/index.rst
@@ -43,6 +43,7 @@ Math & Numerical
 
    blas
    glpk
+   sparse
 
 ************
 File Formats


### PR DESCRIPTION
- Use 1-based indexing for searching subarrays
- Allow to be defined on AbstractVectors
- Make search_sorted and alias for search_sorted_first
- ~~Round out functions with search_sorted_first_gt,  search_sorted_last_lt (+ tests)~~
- Added documentation
### Discussion

Recent commit df7a323 exposed a more general interface to `search_sorted*()` functions, allowing the caller to optionally specify the range to call.  This interface was inconsistent between `search_sorted()` (1-based) and `search_sorted_{first,last}()` (0-based, range 0:length(a)+1).  The first item above address this issue, using 1-based indexing; internally, 0-based indexing is still used (and this is the 'proper' way to do binary search--see http://www.tbray.org/ongoing/When/200x/2003/03/22/Binary)

Some additional deficiencies/idiosyncracies were identified (see https://github.com/JuliaLang/julia/commit/df7a323600#commitcomment-2212563) and are addressed by this commit.
