### PR TITLE
[strpack] remove obvious key collisions for structs cache

### DIFF
--- a/extras/strpack.jl
+++ b/extras/strpack.jl
@@ -25,7 +25,7 @@ function Struct{T}(::Type{T}, endianness)
     if !isbitsequivalent(T)
         error("Type $T is not bits-equivalent.")
     end
-    s = string(T)
+    s = canonicalize(T, endianness)
     if has(STRUCTS, s)
         return STRUCTS[s]
     end
@@ -49,6 +49,9 @@ end
 DataAlign(def::Function, agg::Function) = DataAlign((Type=>Integer)[], def, agg)
 
 canonicalize(s::String) = replace(s, r"\s|#.*$"m, "")
+
+# colons chosen since they are not allowed in struct-format strings or in type names
+canonicalize(t::Type,e::Endianness) = strcat("::", string(t), "::", string(e))
 
 # A byte of padding
 bitstype 8 PadByte


### PR DESCRIPTION
Without this change, the cache fails in the following example:

```
f = open(...)
type Qibb; ...; end

unpack(f, Qibb)  # first call is ok
unpack(f, Struct(Qibb, BigEndian()))     # these
unpack(f, Struct(Qibb, LittleEndian()))  # three
unpack(f, s"Qibb")                       # are not

# the last 3 here all try to unpack into a NativeEndian Qibb type
```
