### PR TITLE
Performance improvements to expm

### DIFF
--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -248,6 +248,7 @@ function expm!{T<:LapackType}(A::StridedMatrix{T})
         else
             C = [120.,60.,12.,1.]
         end
+        C = convert(Array{T,1}, C)
         A2 = A * A
         P  = copy(I)
 #        U  = C[2] * P
@@ -286,6 +287,7 @@ function expm!{T<:LapackType}(A::StridedMatrix{T})
                    670442572800.,      33522128640.,      1323241920.,
                        40840800.,           960960.,           16380.,
                             182.,                1.]
+        CC = convert(Array{T,1}, CC)
         A2 = A * A
         A4 = A2 * A2
         A6 = A2 * A4
@@ -309,8 +311,8 @@ function expm!{T<:LapackType}(A::StridedMatrix{T})
         end
         #U = A * (A6*P1 + P2)
         #V = A6*P3 + P4
-        U = A * (BLAS.gemm!('N', 'N', 1.0, A6, P1, 1.0, P2))
-        V = BLAS.gemm!('N', 'N', 1.0, A6, P3, 1.0, P4)
+        U = A * (BLAS.gemm!('N', 'N', one(T), A6, P1, one(T), P2))
+        V = BLAS.gemm!('N', 'N', one(T), A6, P3, one(T), P4)
 
         #X  = (V-U)\(V+U)
         X = V + U

--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -226,7 +226,7 @@ end
 
 ## Destructive matrix exponential using algorithm from Higham, 2008,
 ## "Functions of Matrices: Theory and Computation", SIAM
-function expm!{T<:LapackType}(A::StridedMatrix{T})
+function expm!{T}(A::StridedMatrix{T})
     m, n = size(A)
     if m != n error("expm!: Matrix A must be square") end
     if m < 2 return exp(A) end
@@ -250,16 +250,31 @@ function expm!{T<:LapackType}(A::StridedMatrix{T})
         end
         A2 = A * A
         P  = copy(I)
-        U  = C[2] * P
-        V  = C[1] * P
+#        U  = C[2] * P
+#        V  = C[1] * P
+        U = zeros(T, n, n)
+        V = zeros(T, n, n)
+        C2 = C[2]; C1 = C[1]
+        for i=1:n
+            U[i,i] = C2
+            V[i,i] = C1
+        end
         for k in 1:(div(size(C, 1), 2) - 1)
             k2 = 2 * k
             P *= A2
-            U += C[k2 + 2] * P
-            V += C[k2 + 1] * P
+            #U += C[k2 + 2] * P
+            #V += C[k2 + 1] * P
+            Ck21 = C[k2 + 1]
+            Ck22 = C[k2 + 2]
+            for i=1:length(P)
+                U[i] += Ck22 * P[i]
+                V[i] += Ck21 * P[i]
+            end
         end
         U  = A * U
-        X  = (V - U)\(V + U)
+        #X  = (V - U)\(V + U)
+        X = V + U
+        LAPACK.gesv!(V-U, X)
     else
         s  = log2(nA/5.4)               # power of 2 later reversed by squaring
         if s > 0
@@ -274,12 +289,33 @@ function expm!{T<:LapackType}(A::StridedMatrix{T})
         A2 = A * A
         A4 = A2 * A2
         A6 = A2 * A4
-        U  = A * (A6 * (CC[14]*A6 + CC[12]*A4 + CC[10]*A2) +
-                  CC[8]*A6 + CC[6]*A4 + CC[4]*A2 + CC[2]*I)
-        V  = A6 * (CC[13]*A6 + CC[11]*A4 + CC[9]*A2) +
-                  CC[7]*A6 + CC[5]*A4 + CC[3]*A2 + CC[1]*I
-        X  = (V-U)\(V+U)
-                         
+#         U  = A * (A6 * (CC[14]*A6 + CC[12]*A4 + CC[10]*A2) +
+#                   CC[8]*A6 + CC[6]*A4 + CC[4]*A2 + CC[2]*I)
+#         V  = A6 * (CC[13]*A6 + CC[11]*A4 + CC[9]*A2) +
+#                   CC[7]*A6 + CC[5]*A4 + CC[3]*A2 + CC[1]*I
+        P1 = zeros(T, n, n)
+        P2 = zeros(T, n, n)
+        P3 = zeros(T, n, n)
+        P4 = zeros(T, n, n)
+        CC14 = CC[14]; CC12 = CC[12]; CC10 = CC[10]
+        CC8 = CC[8];   CC6 = CC[6];   CC4 = CC[4];   CC2 = CC[2];   
+        CC13 = CC[13]; CC11 = CC[11]; CC9 = CC[9]   
+        CC7 = CC[7];   CC5 = CC[5];   CC3 = CC[3];   CC1 = CC[1]
+        for i=1:length(I)
+            P1[i] += CC14*A6[i] + CC12*A4[i] + CC10*A2[i]
+            P2[i] += CC8*A6[i] + CC6*A4[i] + CC4*A2[i] + CC2*I[i]
+            P3[i] += CC13*A6[i] + CC11*A4[i] + CC9*A2[i]
+            P4[i] += CC7*A6[i] + CC5*A4[i] + CC3*A2[i] + CC1*I[i]
+        end
+        #U = A * (A6*P1 + P2)
+        #V = A6*P3 + P4
+        U = A * (BLAS.gemm!('N', 'N', 1.0, A6, P1, 1.0, P2))
+        V = BLAS.gemm!('N', 'N', 1.0, A6, P3, 1.0, P4)
+
+        #X  = (V-U)\(V+U)
+        X = V + U
+        LAPACK.gesv!(V-U, X)
+    
         if s > 0            # squaring to reverse dividing by power of 2
             for t in 1:si X *= X end
         end

--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -226,7 +226,7 @@ end
 
 ## Destructive matrix exponential using algorithm from Higham, 2008,
 ## "Functions of Matrices: Theory and Computation", SIAM
-function expm!{T}(A::StridedMatrix{T})
+function expm!{T<:LapackType}(A::StridedMatrix{T})
     m, n = size(A)
     if m != n error("expm!: Matrix A must be square") end
     if m < 2 return exp(A) end


### PR DESCRIPTION
Some devectorization and direct BLAS/LAPACK calls to get better performance in expm.

```
## New expm
julia> for j=1:length(L)
           print("N = ",L[j]," ");tic()
           for i=1:10 
               A=rand(L[j],L[j])
               myexpm(A)
           end
           t[j]=toc(); 

       end
N = 4 elapsed time: 0.000244140625 seconds
N = 5 elapsed time: 0.0002598762512207031 seconds
N = 6 elapsed time: 0.0002231597900390625 seconds
N = 7 elapsed time: 0.0002601146697998047 seconds
N = 8 elapsed time: 0.0002739429473876953 seconds
N = 16 elapsed time: 0.0006530284881591797 seconds
N = 32 elapsed time: 0.002087116241455078 seconds
N = 64 elapsed time: 0.007458925247192383 seconds
N = 128 elapsed time: 0.0708160400390625 seconds
N = 160 elapsed time: 0.09946298599243164 seconds
N = 192 elapsed time: 0.1484978199005127 seconds
N = 256 elapsed time: 0.2939589023590088 seconds
N = 384 elapsed time: 0.8072021007537842 seconds
N = 512 elapsed time: 1.784566879272461 seconds

# Old expm
julia> for j=1:length(L)
           print("N = ",L[j]," ");tic()
           for i=1:10 
               A=rand(L[j],L[j])
               expm(A)
           end
           t[j]=toc(); 

       end
N = 4 elapsed time: 0.007039070129394531 seconds
N = 5 elapsed time: 0.0002779960632324219 seconds
N = 6 elapsed time: 0.00030517578125 seconds
N = 7 elapsed time: 0.0003330707550048828 seconds
N = 8 elapsed time: 0.0003731250762939453 seconds
N = 16 elapsed time: 0.00090789794921875 seconds
N = 32 elapsed time: 0.0021610260009765625 seconds
N = 64 elapsed time: 0.029937028884887695 seconds
N = 128 elapsed time: 0.09482717514038086 seconds
N = 160 elapsed time: 0.15769004821777344 seconds
N = 192 elapsed time: 0.22134780883789062 seconds
N = 256 elapsed time: 0.4033329486846924 seconds
N = 384 elapsed time: 1.0891180038452148 seconds
N = 512 elapsed time: 2.162303924560547 seconds
```
