### PR TITLE
Fix strptime

### DIFF
--- a/base/libc.jl
+++ b/base/libc.jl
@@ -18,7 +18,7 @@ end
 
 strptime(timestr::ByteString) = strptime("%c", timestr)
 function strptime(fmt::ByteString, timestr::ByteString)
-    tmstruct = Array(Int32, 14)
+    tmstruct = zeros(Int32, 14)
     r = ccall(:strptime, Ptr{Uint8}, (Ptr{Uint8}, Ptr{Uint8}, Ptr{Int32}),
               timestr, fmt, tmstruct)
     if r == C_NULL


### PR DESCRIPTION
strptime only updates the portion of the tm struct corresponding to the format string, and doesn't zero the rest of it, so we should zero the memory corresponding to the struct before use
