### PR TITLE
Check whether a matrix is positive definite.

### DIFF
--- a/base/export.jl
+++ b/base/export.jl
@@ -669,6 +669,8 @@ export
     eye,
     factors,
     ishermitian,
+    isposdef,
+    isposdef!,
     issym,
     issym_rnd,
     istril,

--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -42,6 +42,17 @@ function istril(A::Matrix)
     return true
 end
 
+#Test whether a matrix is positive-definite
+
+isposdef!{T<:LapackType}(A::Matrix{T}, upper::Bool) =
+    LAPACK.potrf!(upper ? 'U' : 'L', A)[2] == 0
+isposdef!{T<:LapackType}(A::Matrix{T}) = ishermitian(A) && isposdef!(A, true)
+
+isposdef{T<:LapackType}(A::Matrix{T}, upper::Bool) = isposdef!(copy(A), upper)
+isposdef{T<:LapackType}(A::Matrix{T}) = isposdef!(copy(A))
+isposdef{T<:Number}(A::Matrix{T}, upper::Bool) = isposdef!(float64(A), upper)
+isposdef{T<:Number}(A::Matrix{T}) = isposdef!(float64(A))
+
 norm{T<:LapackType}(x::Vector{T}) = BLAS.nrm2(length(x), x, 1)
 
 function norm{T<:LapackType, TI<:Integer}(x::Vector{T}, rx::Union(Range1{TI},Range{TI}))


### PR DESCRIPTION
It uses the LAPACK potrf function, which is (as far as I know) the preferred way to check whether a matrix is positive definite.

When the second argument is true (false), it only uses the upper (lower) diagonal part. When no second argument is provided it first checks whether the matrix is hermitian.
