### PR TITLE
don't create unnecessary global functions for ccalls

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -405,18 +405,19 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     }
 
     // make LLVM function object for the target
-    Function *llvmf;
+    Constant *llvmf;
     FunctionType *functype = FunctionType::get(lrt, fargt_sig, isVa);
-
+    
     if (fptr != NULL) {
-        llvmf = Function::Create(functype, Function::ExternalLinkage,
-                                 "ccall_", jl_Module);
-        jl_ExecutionEngine->addGlobalMapping(llvmf, fptr);
+        Type *funcptype = PointerType::get(functype,0);
+        llvmf = ConstantExpr::getIntToPtr( 
+            ConstantInt::get(funcptype, (uint64_t)fptr), 
+            funcptype);
     }
     else {
         if (f_lib != NULL)
             add_library_sym(f_name, f_lib);
-        llvmf = (Function*)jl_Module->getOrInsertFunction(f_name, functype);
+        llvmf = jl_Module->getOrInsertFunction(f_name, functype);
     }
 
     // save temp argument area stack pointer


### PR DESCRIPTION
This doesn't change much on its own, but I was interested in it because it could presumably be extended to allow for doing indirect function calls from julia, by changing the evaluation context for fptr to consider local variables:

``` julia
function ccall_void( callthis :: Ptr{Void} )
   ccall( callthis, Void, ())
end
```
