### PR TITLE
RFC: Pkg scaffolding and versioning API

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -278,6 +278,23 @@ function commit(f::Function, msg::String)
     end
 end
 
+# set package remote in METADATA
+
+pkg_origin(pkg::String, remote::String) = cd_pkgdir() do
+    for line in each_line(`git --git-dir=$(file_path(pkg,".git")) remote -v`)
+        m = match(r"^(\S*)\s*(\S*)\s*\(fetch\)", line)
+        if m != nothing && m.captures[1] == remote
+            cd(file_path("METADATA", pkg)) do
+                open("url", "w") do io
+                    println(io, m.captures[2])
+                end
+            end
+            return
+        end
+    end
+end
+pkg_origin(pkg) = pkg_origin(pkg, "origin")
+
 # push & pull package repos to/from remotes
 
 push() = cd_pkgdir() do

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -486,6 +486,11 @@ to prepare METADATA with the details for your package."
     end
 end
 
+# Remove local traces of a package (broken due to a bad .new(), for instance)
+obliterate(package_name::String) = cd_pkgdir() do
+    run(`rm -rf $(package_name) $(file_path("METADATA", package_name))`)
+end
+
 # If a package contains data, make it easy to find its location
 function package_directory(package_name::String)
   if has(ENV, "JULIA_PKGDIR")


### PR DESCRIPTION
[original title: Pkg.skeleton() creates package directory in current directory]

Pkg.skeleton creates a directory in the current working directory, which is typically the directory that julia is started from. It should instead create the new directory within the package directory (typically .julia)
