### PR TITLE
Remove linking to ApplicationServices framework on OSX, closes #1642

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -252,7 +252,7 @@ OSLIBS += -lkvm -lrt -Wl,--export-dynamic -Wl,--version-script=$(JULIAHOME)/src/
 endif
 
 ifeq ($(OS), Darwin)
-OSLIBS += -ldl -Wl,-w -framework ApplicationServices
+OSLIBS += -ldl -Wl,-w -framework CoreFoundation -framework CoreServices
 JLDFLAGS =
 endif
 


### PR DESCRIPTION
Just uses the two frameworks we really need, CoreServices and CoreFoundation.
