### PR TITLE
allow ccall to use local (non-static) function pointers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@
 *.creator
 *.user
 *.orig
+*.swp
 
 /usr

--- a/base/blas.jl
+++ b/base/blas.jl
@@ -23,7 +23,7 @@ export copy!,
        symv!,
        symv
 
-libblas = Base.libblas_name
+const libblas = Base.libblas_name
 
 # SUBROUTINE DCOPY(N,DX,INCX,DY,INCY)
 for (fname, elty) in ((:dcopy_,:Float64), (:scopy_,:Float32),

--- a/base/lapack.jl
+++ b/base/lapack.jl
@@ -1,7 +1,7 @@
 ## The LAPACK module of interfaces to LAPACK subroutines
 module LAPACK
 
-liblapack = Base.liblapack_name
+const liblapack = Base.liblapack_name
 
 typealias LapackChar Char
 type LapackException <: Exception

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -82,7 +82,7 @@ jl_sym_t *const_sym;   jl_sym_t *thunk_sym;
 jl_sym_t *anonymous_sym;  jl_sym_t *underscore_sym;
 jl_sym_t *abstracttype_sym; jl_sym_t *bitstype_sym;
 jl_sym_t *compositetype_sym; jl_sym_t *type_goto_sym;
-jl_sym_t *global_sym;
+jl_sym_t *global_sym; jl_sym_t *tuple_sym;
 
 typedef struct {
     int64_t a;

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -50,6 +50,7 @@ jl_struct_type_t *jl_typeerror_type;
 jl_struct_type_t *jl_methoderror_type;
 jl_struct_type_t *jl_loaderror_type;
 jl_bits_type_t *jl_pointer_type;
+jl_bits_type_t *jl_voidpointer_type;
 jl_value_t *jl_an_empty_cell=NULL;
 jl_value_t *jl_stackovf_exception;
 jl_value_t *jl_divbyzero_exception;
@@ -691,6 +692,7 @@ UNBOX_FUNC(uint64, uint64_t)
 UNBOX_FUNC(bool,   int8_t)
 UNBOX_FUNC(float32, float)
 UNBOX_FUNC(float64, double)
+UNBOX_FUNC(voidpointer, void*)
 
 #define BOX_FUNC(typ,c_type,pfx,nw)             \
 jl_value_t *pfx##_##typ(c_type x)               \
@@ -701,6 +703,7 @@ jl_value_t *pfx##_##typ(c_type x)               \
     return v;                                   \
 }
 BOX_FUNC(float32, float,  jl_box, 2)
+BOX_FUNC(voidpointer, void*,  jl_box, 2) //2 pointers == two words on all platforms
 #ifdef __LP64__
 BOX_FUNC(float64, double, jl_box, 2)
 #else

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -267,17 +267,17 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     jl_value_t *ptr=NULL, *rt=NULL, *at=NULL;
     Value *jl_ptr=NULL;
     JL_GC_PUSH(&ptr, &rt, &at);
-    //ptr = static_eval(args[1], ctx, true);
-    //if (ptr == NULL) {
+    ptr = static_eval(args[1], ctx, true);
+    if (ptr == NULL) {
         jl_value_t *ptr_ty = expr_type(args[1], ctx);
         if (jl_is_cpointer_type(ptr_ty)) {
             jl_ptr = emit_unbox(T_size, T_psize, emit_unboxed(args[1], ctx));
         } else {
-            ptr = jl_interpret_toplevel_expr_in(ctx->module, args[1],
-                                                &jl_tupleref(ctx->sp,0),
-                                                jl_tuple_len(ctx->sp)/2);
+            std::string msg = "in " + ctx->funcName +
+                ": ccall: function argument not a pointer or valid constant";
+            jl_error(msg.c_str());
         }
-    //}
+    }
     rt  = jl_interpret_toplevel_expr_in(ctx->module, args[2],
                                         &jl_tupleref(ctx->sp,0),
                                         jl_tuple_len(ctx->sp)/2);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -271,7 +271,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     //if (ptr == NULL) {
         jl_value_t *ptr_ty = expr_type(args[1], ctx);
         if (jl_is_cpointer_type(ptr_ty)) {
-            jl_ptr = emit_expr(args[1], ctx);
+            jl_ptr = emit_unbox(T_size, T_psize, emit_unboxed(args[1], ctx));
         } else {
             ptr = jl_interpret_toplevel_expr_in(ctx->module, args[1],
                                                 &jl_tupleref(ctx->sp,0),
@@ -428,7 +428,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     
     if (jl_ptr != NULL) {
         Type *funcptype = PointerType::get(functype,0);
-        llvmf = builder.CreateBitCast(jl_ptr, funcptype);
+        llvmf = builder.CreateIntToPtr(jl_ptr, funcptype);
     } else if (fptr != NULL) {
         Type *funcptype = PointerType::get(functype,0);
         llvmf = literal_pointer_val(fptr, funcptype);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -418,15 +418,20 @@ static jl_value_t *static_eval(jl_value_t *ex, jl_codectx_t *ctx, bool sparams)
                     size_t n = e->args->length-1;
                     if (n==0) return (jl_value_t*)jl_null;
                     jl_value_t **v = (jl_value_t**)alloca(n*sizeof(jl_value_t*));
+                    memset(v, 0, n*sizeof(jl_value_t*));
+                    JL_GC_PUSHARGS(v, n);
                     for (i = 0; i < n; i++) {
                         v[i] = static_eval(jl_exprarg(e,i+1),ctx,sparams);
-                        if (v[i] == NULL)
+                        if (v[i] == NULL) {
+                            JL_GC_POP();
                             return NULL;
+                        }
                     }
                     jl_tuple_t *tup = jl_alloc_tuple_uninit(n);
                     for(i=0; i < n; i++) {
                         jl_tupleset(tup, i, v[i]);
                     }
+                    JL_GC_POP();
                     return (jl_value_t*)tup;
                 }
             }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -402,20 +402,41 @@ static jl_value_t *static_eval(jl_value_t *ex, jl_codectx_t *ctx, bool sparams)
     if (jl_is_expr(ex)) {
         jl_expr_t *e = (jl_expr_t*)ex;
         if (e->head == call_sym || e->head == call1_sym) {
-            if (e->args->length == 3) {
-                jl_value_t *f = static_eval(jl_exprarg(e,0),ctx,sparams);
-                if (f && jl_is_function(f)) {
-                    if (((jl_function_t*)f)->fptr == &jl_f_get_field) {
-                        m = (jl_module_t*)static_eval(jl_exprarg(e,1),ctx,sparams);
-                        s = (jl_sym_t*)static_eval(jl_exprarg(e,2),ctx,sparams);
-                        if (m && jl_is_module(m) && s && jl_is_symbol(s)) {
-                            jl_binding_t *b = jl_get_binding(m, s);
-                            if (b && b->constp)
-                                return b->value;
-                        }
+            jl_value_t *f = static_eval(jl_exprarg(e,0),ctx,sparams);
+            if (f && jl_is_function(f)) {
+                jl_fptr_t fptr = ((jl_function_t*)f)->fptr;
+                if (e->args->length == 3 && fptr == &jl_f_get_field) {
+                    m = (jl_module_t*)static_eval(jl_exprarg(e,1),ctx,sparams);
+                    s = (jl_sym_t*)static_eval(jl_exprarg(e,2),ctx,sparams);
+                    if (m && jl_is_module(m) && s && jl_is_symbol(s)) {
+                        jl_binding_t *b = jl_get_binding(m, s);
+                        if (b && b->constp)
+                            return b->value;
                     }
+                } else if (fptr == &jl_f_tuple) {
+                    size_t i;
+                    size_t n = e->args->length-1;
+                    if (n==0) return (jl_value_t*)jl_null;
+                    jl_value_t **v = (jl_value_t**)alloca(n*sizeof(jl_value_t*));
+                    for (i = 0; i < n; i++) {
+                        v[i] = static_eval(jl_exprarg(e,i+1),ctx,sparams);
+                        if (v[i] == NULL)
+                            return NULL;
+                    }
+                    jl_tuple_t *tup = jl_alloc_tuple_uninit(n);
+                    for(i=0; i < n; i++) {
+                        jl_tupleset(tup, i, v[i]);
+                    }
+                    return (jl_value_t*)tup;
                 }
             }
+        // The next part is probably valid, but it is untested
+        //} else if (e->head == tuple_sym) {
+        //  size_t i;
+        //  for (i = 0; i < e->args->length; i++) 
+        //        if (static_eval(jl_exprarg(e,i), ctx, sparams) == NULL)
+        //          return NULL;
+        //  return ex;
         }
         return NULL;
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -554,7 +554,8 @@ static void max_arg_depth(jl_value_t *expr, int32_t *max, int32_t *sp,
                         }
                         else {
                             esc = true;
-                            // first 3 arguments are static
+                            // 2nd and 3d arguments are static
+                            max_arg_depth(jl_exprarg(e,1), max, sp, esc, ctx);
                             for(i=4; i < (size_t)alen; i++) {
                                 max_arg_depth(jl_exprarg(e,i), max, sp, esc, ctx);
                             }

--- a/src/dump.c
+++ b/src/dump.c
@@ -924,7 +924,7 @@ void jl_init_serializer(void)
                      jl_symbol("convert"), jl_symbol("typeassert"),
                      jl_symbol("getfield"), jl_symbol("setfield"),
                      jl_symbol("tupleref"), jl_symbol("tuplelen"),
-                     jl_symbol("apply_type"), jl_symbol("tuple"),
+                     jl_symbol("apply_type"), tuple_sym,
 
                      jl_box_int32(0), jl_box_int32(1), jl_box_int32(2),
                      jl_box_int32(3), jl_box_int32(4), jl_box_int32(5),

--- a/src/init.c
+++ b/src/init.c
@@ -322,6 +322,9 @@ void jl_get_builtin_hooks(void)
 
     jl_float32_type = (jl_bits_type_t*)core("Float32");
     jl_float64_type = (jl_bits_type_t*)core("Float64");
+    jl_voidpointer_type = (jl_bits_type_t*)
+        jl_apply_type((jl_value_t*)jl_pointer_type,
+                      jl_tuple(1,jl_bottom_type));
 
     jl_stackovf_exception =
         jl_apply((jl_function_t*)core("StackOverflowError"), NULL, 0);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2630,4 +2630,5 @@ void jl_init_types(void)
     compositetype_sym = jl_symbol("composite_type");
     type_goto_sym = jl_symbol("type_goto");
     toplevel_sym = jl_symbol("toplevel");
+    tuple_sym = jl_symbol("tuple");
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -454,7 +454,7 @@ extern jl_sym_t *const_sym;   extern jl_sym_t *thunk_sym;
 extern jl_sym_t *anonymous_sym;  extern jl_sym_t *underscore_sym;
 extern jl_sym_t *abstracttype_sym; extern jl_sym_t *bitstype_sym;
 extern jl_sym_t *compositetype_sym; extern jl_sym_t *type_goto_sym;
-extern jl_sym_t *global_sym;
+extern jl_sym_t *global_sym;  extern jl_sym_t *tuple_sym;
 
 #ifdef __LP64__
 #define NWORDS(sz) (((sz)+7)>>3)

--- a/src/julia.h
+++ b/src/julia.h
@@ -394,7 +394,7 @@ extern jl_bits_type_t *jl_int64_type;
 extern jl_bits_type_t *jl_uint64_type;
 extern jl_bits_type_t *jl_float32_type;
 extern jl_bits_type_t *jl_float64_type;
-
+extern jl_bits_type_t *jl_voidpointer_type;
 extern jl_bits_type_t *jl_pointer_type;
 
 extern jl_type_t *jl_array_uint8_type;
@@ -685,6 +685,7 @@ DLLEXPORT jl_value_t *jl_box_int64(int64_t x);
 jl_value_t *jl_box_uint64(uint64_t x);
 jl_value_t *jl_box_float32(float x);
 jl_value_t *jl_box_float64(double x);
+jl_value_t *jl_box_voidpointer(void *x);
 jl_value_t *jl_box8 (jl_bits_type_t *t, int8_t  x);
 jl_value_t *jl_box16(jl_bits_type_t *t, int16_t x);
 jl_value_t *jl_box32(jl_bits_type_t *t, int32_t x);
@@ -700,6 +701,7 @@ int64_t jl_unbox_int64(jl_value_t *v);
 uint64_t jl_unbox_uint64(jl_value_t *v);
 float jl_unbox_float32(jl_value_t *v);
 double jl_unbox_float64(jl_value_t *v);
+void *jl_unbox_voidpointer(jl_value_t *v);
 
 #ifdef __LP64__
 #define jl_box_long(x)   jl_box_int64(x)


### PR DESCRIPTION
This attempts to eval the first argument to ccall to any pointer type in the local scope before interpreting it as a toplevel expression. This allows the following to work, as a self-contained example:

``` julia
julia> function f()
    f2 = cfunction(+, Int, (Int,Int))
    ccall(f2, Int, (Int,Int), 1, 2)
end

julia> f()
3
```

I put this as RFC since I wasn't sure of the best way to select the scope fallback vs throwing an error. static_eval() seems OK with symbols, but not with with tuples in the AST.
