### PR TITLE
RFC: Update Zlib/GZip to new ccall() convention.

### DIFF
--- a/extras/zlib.jl
+++ b/extras/zlib.jl
@@ -48,7 +48,7 @@ load("zlib_h")
 # zlib functions
 
 # Returns the maximum size of the compressed output buffer for a given uncompressed input size
-compress_bound(input_size::Uint) = ccall(dlsym(_zlib, :compressBound), Uint, (Uint, ), input_size)
+compress_bound(input_size::Uint) = ccall((:compressBound, _zlib), Uint, (Uint, ), input_size)
 compress_bound(input_size::Integer) = compress_bound(convert(Uint, input_size))
 
 # Compress
@@ -72,7 +72,7 @@ function compress_to_buffer(source::Array{Uint8}, dest::Array{Uint8}, level::Int
     dest_buf_size = Uint[length(dest)]
 
     # Compress the input
-    ret = ccall(dlsym(_zlib, :compress2), Int32, (Ptr{Uint8}, Ptr{Uint}, Ptr{Uint}, Uint, Int32),
+    ret = ccall((:compress2, _zlib), Int32, (Ptr{Uint8}, Ptr{Uint}, Ptr{Uint}, Uint, Int32),
                 dest, dest_buf_size, source, length(source), int32(level))
 
     if ret != Z_OK
@@ -127,7 +127,7 @@ function uncompress_to_buffer(source::Array{Uint8}, dest::Array{Uint8})
     dest_buf_size = Uint[uncompressed_size]
 
     # Uncompress the input
-    ret = ccall(dlsym(_zlib, :uncompress), Int32, (Ptr{Uint}, Ptr{Uint}, Ptr{Uint}, Uint),
+    ret = ccall((:uncompress, _zlib), Int32, (Ptr{Uint}, Ptr{Uint}, Ptr{Uint}, Uint),
                 dest, dest_buf_size, source, length(source))
 
     if ret != Z_OK

--- a/test/zlib.jl
+++ b/test/zlib.jl
@@ -27,7 +27,7 @@ r = b[randi((1,256), BUFSIZE)]
 # zlibCompileFlags function.
 
 # Get compile-time option flags
-zlib_compile_flags = ccall(dlsym(Zlib._zlib, :zlibCompileFlags), Uint, ())
+zlib_compile_flags = ccall((:zlibCompileFlags, Zlib._zlib), Uint, ())
 
 # Type sizes, two bits each, 00 = 16 bits, 01 = 32, 10 = 64, 11 = other:
 #
@@ -48,7 +48,10 @@ z_off_t_sz   = 2 << ((zlib_compile_flags >> 6) & uint(3))
 @test(z_uInt_sz == sizeof(Uint32))
 @test(z_uLong_sz == sizeof(Uint))
 @test(z_voidpf_sz == sizeof(Ptr))
-@test(z_off_t_sz == sizeof(Zlib.ZFileOffset) || (dlsym(Zlib._zlib, :crc32_combine64) != C_NULL && sizeof(Zlib.ZFileOffset) == 8))
+
+let _zlib_h = dlopen("libz")
+   @test(z_off_t_sz == sizeof(Zlib.ZFileOffset) || (dlsym_e(_zlib_h, :gzopen64) != C_NULL && sizeof(Zlib.ZFileOffset) == 8))
+end
 
 ########################
 # compress/uncompress tests


### PR DESCRIPTION
As the title says.  Note that this patch still `dlopen()`'s zlib in order to use `dlsym_e()` to test for the existence of some functions.  It would be nice to get rid of the `dlopen()` calls.

~~EDIT: builds and tests fine on 64-bit.  Need to figure out why it's failing Travis-CI.~~
Should be good to go now.
