### PR TITLE
Update library installation directories

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -210,10 +210,10 @@ ifeq ($(OS), WINNT)
   RPATH =
   RPATH_ORIGIN =
 else ifeq ($(OS), Darwin)
-  RPATH = -Wl,-rpath,'@executable_path/../$(JL_PRIVATE_LIBDIR)' -Wl,-rpath,'@executable_path/../$(JL_LIBDIR)'
+  RPATH = -Wl,-rpath,'@executable_path/../lib'
   RPATH_ORIGIN =
 else
-  RPATH = -Wl,-rpath,'$$ORIGIN/../$(JL_PRIVATE_LIBDIR)' -Wl,-rpath,'$$ORIGIN/../$(JL_LIBDIR)' -Wl,-z,origin
+  RPATH = -Wl,-rpath,'$$ORIGIN/../lib' -Wl,-z,origin
   RPATH_ORIGIN = -Wl,-rpath,'$$ORIGIN' -Wl,-z,origin
 endif
 

--- a/Make.inc
+++ b/Make.inc
@@ -11,7 +11,7 @@ JL_PRIVATE_LIBDIR = lib/julia
 JL_LIBDIR = lib
 
 # If we're on debian, default to arch-dependent library dirs
-ifeq ($(USE_DEBIAN), 1)
+ifeq ($(MULTIARCH_INSTALL), 1)
 MULTIARCH = $(shell gcc -print-multiarch)
 JL_PRIVATE_LIBDIR = lib/$(MULTIARCH)/julia
 JL_LIBDIR = lib/$(MULTIARCH)/

--- a/Make.inc
+++ b/Make.inc
@@ -3,11 +3,8 @@
 JULIA_VERSION = $(shell cat $(JULIAHOME)/VERSION)
 JULIA_COMMIT = $(shell git rev-parse --short=10 HEAD)
 
-USR = $(JULIAHOME)/usr
-USRBIN = $(USR)/bin
-USRINC = $(USR)/include
-LLVMROOT = $(USR)
-BUILD = $(USR)
+BUILD = $(JULIAHOME)/usr
+LLVMROOT = $(BUILD)
 
 # Directories where said libraries get installed to
 JL_PRIVATE_LIBDIR = lib/julia
@@ -141,7 +138,7 @@ endif
 ifeq ($(USE_SYSTEM_LIBUNWIND), 1)
 LIBUNWIND=-lunwind-generic -lunwind
 else
-LIBUNWIND=$(USR)/lib/libunwind-generic.a $(USR)/lib/libunwind.a
+LIBUNWIND=$(BUILD)/lib/libunwind-generic.a $(BUILD)/lib/libunwind.a
 endif
 
 ifeq ($(USE_SYSTEM_LLVM), 1)
@@ -153,19 +150,19 @@ endif
 ifeq ($(USE_SYSTEM_READLINE), 1)
 READLINE = -lreadline 
 else
-READLINE = $(USR)/lib/libreadline.a
+READLINE = $(BUILD)/lib/libreadline.a
 endif
 
 ifneq ($(OS),WINNT)
 READLINE += -lncurses
 else
-READLINE += $(USR)/lib/libhistory.a
+READLINE += $(BUILD)/lib/libhistory.a
 endif
 
 ifeq ($(USE_SYSTEM_PCRE), 1)
 PCRE_CONFIG = pcre-config
 else
-PCRE_CONFIG = $(USRBIN)/pcre-config
+PCRE_CONFIG = $(BUILD)/bin/pcre-config
 endif
 
 ifeq ($(USE_SYSTEM_BLAS), 1)
@@ -177,7 +174,7 @@ LIBBLAS = -lblas
 LIBBLASNAME = libblas
 endif
 else
-LIBBLAS = -L$(USR)/lib -lopenblas
+LIBBLAS = -L$(BUILD)/lib -lopenblas
 LIBBLASNAME = libopenblas
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include $(JULIAHOME)/Make.inc
 all: default
 default: release
 
-DIRS = $(BUILD)/bin $(BUILD)/$(JL_LIBDIR) $(BUILD)/$(JL_PRIVATE_LIBDIR) $(BUILD)/share/julia
+DIRS = $(BUILD)/bin $(BUILD)/lib $(BUILD)/$(JL_PRIVATE_LIBDIR) $(BUILD)/share/julia
 
 $(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
 $(foreach link,extras base test doc examples,$(eval $(call symlink_target,$(link),$(BUILD)/share/julia)))

--- a/contrib/repackage_system_suitesparse3.make
+++ b/contrib/repackage_system_suitesparse3.make
@@ -6,18 +6,18 @@ include $(JULIAHOME)/Make.inc
 all: default
 
 default:
-	mkdir -p $(USR)/$(JL_LIBDIR)
+	mkdir -p $(BUILD)/lib
 	mkdir -p $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib
 	cd $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib && \
 	rm -f *.a && \
 	cp -f $(shell find /lib /usr/lib /usr/local/lib $(shell eval $(JULIAHOME)/contrib/filterArgs.sh $(LDFLAGS)) -name libamd.a -o -name libcolamd.a -o -name libcholmod.a -o -name libumfpack.a -o -name libspqr.a 2>/dev/null) . && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -lcolamd -lamd $(LIBBLAS) && \
-	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -lcholmod -lcolamd -lamd $(LIBBLAS) && \
-	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -lcholmod -lcolamd -lamd $(LIBBLAS) && \
-	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(BUILD)/lib/libamd.$(SHLIB_EXT) && \
+	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libcolamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(BUILD)/lib/libcolamd.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libcholmod.$(SHLIB_EXT) $(LDFLAGS) -L$(BUILD)/lib -lcolamd -lamd $(LIBBLAS) && \
+	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(BUILD)/lib/libcholmod.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libumfpack.$(SHLIB_EXT) $(LDFLAGS) -L$(BUILD)/lib -lcholmod -lcolamd -lamd $(LIBBLAS) && \
+	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(BUILD)/lib/libumfpack.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libspqr.$(SHLIB_EXT) $(LDFLAGS) -L$(BUILD)/lib -lcholmod -lcolamd -lamd $(LIBBLAS) && \
+	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(BUILD)/lib/libspqr.$(SHLIB_EXT)

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -6,19 +6,19 @@ include $(JULIAHOME)/Make.inc
 all: default
 
 default:
-	mkdir -p $(USR)/$(JL_LIBDIR)
+	mkdir -p $(BUILD)/lib
 	mkdir -p $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib
 	cd $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib && \
 	rm -f *.a && \
 	cp -f $(shell find /lib /usr/lib /usr/local/lib $(shell eval $(JULIAHOME)/contrib/filterArgs.sh $(LDFLAGS)) -name libamd.a -o -name libcolamd.a -o -name libcholmod.a -o -name libumfpack.a -o -name libspqr.a -o -name libsuitesparseconfig.a 2>/dev/null) . && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -L. -lcolamd -lccolamd -lcamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -L. -lcholmod -lcolamd -lcamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT) $(LDFLAGS) -L$(USR)/$(JL_LIBDIR) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(USR)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(BUILD)/lib/libamd.$(SHLIB_EXT) && \
+	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libcolamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(BUILD)/lib/libcolamd.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libcholmod.$(SHLIB_EXT) $(LDFLAGS) -L$(BUILD)/lib -L. -lcolamd -lccolamd -lcamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(BUILD)/lib/libcholmod.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libumfpack.$(SHLIB_EXT) $(LDFLAGS) -L$(BUILD)/lib -L. -lcholmod -lcolamd -lcamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(BUILD)/lib/libumfpack.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libspqr.$(SHLIB_EXT) $(LDFLAGS) -L$(BUILD)/lib -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(BUILD)/lib/libspqr.$(SHLIB_EXT)
 	

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -82,23 +82,23 @@ STAGE2_DEPS += suitesparse
 
 LIBS = $(STAGE1_DEPS) $(STAGE2_DEPS) $(STAGE3_DEPS)
 
-default: $(USR) install
+default: $(BUILD) install
 compile: $(addprefix compile-, $(LIBS))
 install: $(addprefix install-, $(LIBS))
 cleanall: $(addprefix clean-, $(LIBS))
 distclean: $(addprefix distclean-, $(LIBS))
-	rm -rf $(USR)
+	rm -rf $(BUILD)
 
 ## PATHS ##
-DIRS = $(addprefix $(USR)/,lib include bin share etc)
+DIRS = $(addprefix $(BUILD)/,lib include bin share etc)
 
 $(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
 
-$(USR): $(DIRS)
+$(BUILD): $(DIRS)
 
 ## LLVM ##
 
-LLVM_OBJ_TARGET = $(USR)/lib/libLLVM-$(LLVM_VER).$(SHLIB_EXT)
+LLVM_OBJ_TARGET = $(BUILD)/lib/libLLVM-$(LLVM_VER).$(SHLIB_EXT)
 ifeq ($(OS),WINNT)
 	LLVM_OBJ_SOURCE = llvm-$(LLVM_VER)/Release/bin/LLVM-$(LLVM_VER).$(SHLIB_EXT)
 else
@@ -173,23 +173,23 @@ endif
 $(LLVM_OBJ_SOURCE): llvm-$(LLVM_VER)/configure | llvm_python_workaround
 	cd llvm-$(LLVM_VER) && \
 	export PATH=$(abspath llvm-$(LLVM_VER)/python2_path):$$PATH && \
-	./configure --prefix=$(abspath $(USR)) --disable-threads --enable-optimized --disable-profiling --disable-assertions --enable-shared --enable-targets=host --disable-bindings --disable-docs CC="$(CC)" CXX="$(LLVM_CXX)" && \
+	./configure --prefix=$(abspath $(BUILD)) --disable-threads --enable-optimized --disable-profiling --disable-assertions --enable-shared --enable-targets=host --disable-bindings --disable-docs CC="$(CC)" CXX="$(LLVM_CXX)" && \
 	$(MAKE)
 $(LLVM_OBJ_TARGET): $(LLVM_OBJ_SOURCE) | llvm_python_workaround
 	export PATH=$(abspath llvm-$(LLVM_VER)/python2_path):$$PATH && \
 	$(MAKE) -C llvm-$(LLVM_VER) install
-	$(INSTALL_NAME_CMD)libLLVM-$(LLVM_VER).$(SHLIB_EXT) $(USR)/lib/libLLVM-$(LLVM_VER).$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libLLVM-$(LLVM_VER).$(SHLIB_EXT) $(BUILD)/lib/libLLVM-$(LLVM_VER).$(SHLIB_EXT)
 	touch $@
 
 clean-llvm:
 	-$(MAKE) -C llvm-$(LLVM_VER) clean
-	-rm -f $(USRBIN)/llvm-config
+	-rm -f $(BUILD)/bin/llvm-config
 distclean-llvm:
 	-rm -rf llvm-$(LLVM_VER).tar.gz llvm-$(LLVM_VER).src.tar.gz clang-$(LLVM_VER).src.tar.gz clang-$(LLVM_VER).tar.gz compiler-rt-$(LLVM_VER).src.tar.gz llvm-$(LLVM_VER)
 
 ## GNU readline ##
 
-READLINE_OBJ_TARGET = $(USR)/lib/libreadline.$(SHLIB_EXT)
+READLINE_OBJ_TARGET = $(BUILD)/lib/libreadline.$(SHLIB_EXT)
 READLINE_OBJ_SOURCE = readline-$(READLINE_VER)/shlib/libreadline.$(READLINE_VER).$(SHLIB_EXT)
 
 READLINE_OPTS = --disable-shared --enable-static
@@ -215,7 +215,7 @@ readline-$(READLINE_VER)/configure: readline-$(READLINE_VER).tar.gz
 	touch $@
 $(READLINE_OBJ_SOURCE): readline-$(READLINE_VER)/configure
 	cd readline-$(READLINE_VER) && \
-	./configure --prefix=$(abspath $(USR)) $(READLINE_OPTS) CC="$(CC)" CXX="$(CXX)" && \
+	./configure --prefix=$(abspath $(BUILD)) $(READLINE_OPTS) CC="$(CC)" CXX="$(CXX)" && \
 	$(MAKE) $(READLINE_CFLAGS)
 	touch $@
 $(READLINE_OBJ_TARGET): $(READLINE_OBJ_SOURCE)
@@ -245,18 +245,18 @@ readline-$(READLINE_VER)/configure: readline-$(READLINE_VER).tar.gz
 	touch $@
 $(READLINE_OBJ_SOURCE): readline-$(READLINE_VER)/configure
 	cd readline-$(READLINE_VER) && \
-	./configure --prefix=$(abspath $(USR)) --enable-shared --enable-static --with-curses CC="$(CC)" CXX="$(CXX)" && \
+	./configure --prefix=$(abspath $(BUILD)) --enable-shared --enable-static --with-curses CC="$(CC)" CXX="$(CXX)" && \
 	$(MAKE)
 	touch $@
 $(READLINE_OBJ_TARGET): $(READLINE_OBJ_SOURCE)
 	$(MAKE) -C readline-$(READLINE_VER) install
-	chmod +w $(USR)/lib/libreadline.* $(USR)/lib/libhistory.*
+	chmod +w $(BUILD)/lib/libreadline.* $(BUILD)/lib/libhistory.*
 ifeq ($(OS), Darwin)
-	$(INSTALL_NAME_CMD)libreadline.$(SHLIB_EXT) $(USR)/lib/libreadline.$(SHLIB_EXT)
-	$(INSTALL_NAME_CMD)libhistory.dylib $(USR)/lib/libhistory.dylib
+	$(INSTALL_NAME_CMD)libreadline.$(SHLIB_EXT) $(BUILD)/lib/libreadline.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libhistory.dylib $(BUILD)/lib/libhistory.dylib
 else ifeq ($(OS), Linux)
-	for filename in $(USR)/lib/libhistory.so* $(USR)/lib/libreadline.so* ; do \
-		$(USR)/bin/patchelf --set-rpath '$$ORIGIN' $$filename ;\
+	for filename in $(BUILD)/lib/libhistory.so* $(BUILD)/lib/libreadline.so* ; do \
+		$(BUILD)/bin/patchelf --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
 	touch $@
@@ -271,7 +271,7 @@ endif
 
 ## LIBUV
 
-UV_OBJ_TARGET = $(USR)/lib/libuv.a
+UV_OBJ_TARGET = $(BUILD)/lib/libuv.a
 UV_OBJ_SOURCE = libuv/libuv.a
 
 libuv/Makefile:
@@ -288,19 +288,19 @@ ifneq ($(OS), WINNT)
 endif
 	$(MAKE) libuv.a -C libuv CC="$(CC)"
 $(UV_OBJ_TARGET): $(UV_OBJ_SOURCE)
-	mkdir -p $(USR)/include
-	cp $(UV_OBJ_SOURCE) $(USR)/lib/
-	cp -r libuv/include/* $(USR)/include
+	mkdir -p $(BUILD)/include
+	cp $(UV_OBJ_SOURCE) $(BUILD)/lib/
+	cp -r libuv/include/* $(BUILD)/include
 install-uv: $(UV_OBJ_TARGET)
 
 clean-uv:
 	-$(MAKE) -C libuv clean
-	-rm -rf $(USR)/lib/libuv.a $(USR)/include/uv.h $(USR)/include/uv-private
+	-rm -rf $(BUILD)/lib/libuv.a $(BUILD)/include/uv.h $(BUILD)/include/uv-private
 distclean-uv: clean-uv
 
 ## PCRE ##
 
-PCRE_OBJ_TARGET = $(USR)/lib/libpcre.$(SHLIB_EXT)
+PCRE_OBJ_TARGET = $(BUILD)/lib/libpcre.$(SHLIB_EXT)
 
 compile-pcre: install-pcre
 install-pcre: $(PCRE_OBJ_TARGET)
@@ -312,13 +312,13 @@ pcre-$(PCRE_VER)/configure: pcre-$(PCRE_VER).tar.bz2
 	touch $@
 pcre-$(PCRE_VER)/config.status: pcre-$(PCRE_VER)/configure
 	cd pcre-$(PCRE_VER) && \
-	./configure --prefix=$(abspath $(USR)) --enable-utf --enable-unicode-properties --enable-jit CC="$(CC)" CXX="$(CXX)"
+	./configure --prefix=$(abspath $(BUILD)) --enable-utf --enable-unicode-properties --enable-jit CC="$(CC)" CXX="$(CXX)"
 $(PCRE_OBJ_TARGET): pcre-$(PCRE_VER)/config.status
 	$(MAKE) -C pcre-$(PCRE_VER) install
 	$(INSTALL_NAME_CMD)libpcre.dylib $@
 ifeq ($(OS),WINNT)
-	-rm $(USR)/lib/libpcre.dll
-	mv $(USRBIN)/libpcre-1.dll $(USR)/lib/libpcre.dll
+	-rm $(BUILD)/lib/libpcre.dll
+	mv $(BUILD)/bin/libpcre-1.dll $(BUILD)/lib/libpcre.dll
 endif
 	touch $@
 
@@ -333,7 +333,7 @@ distclean-pcre:
 GRISU_OPTS = -O3 -fvisibility=hidden $(fPIC)
 
 compile-double-conversion: double-conversion-$(GRISU_VER)/src/libgrisu_.$(SHLIB_EXT)
-install-double-conversion: $(USR)/lib/libgrisu.$(SHLIB_EXT)
+install-double-conversion: $(BUILD)/lib/libgrisu.$(SHLIB_EXT)
 
 double-conversion-$(GRISU_VER).tar.gz:
 	$(WGET) http://double-conversion.googlecode.com/files/double-conversion-$(GRISU_VER).tar.gz
@@ -353,7 +353,7 @@ double-conversion-$(GRISU_VER)/src/libgrisu.$(SHLIB_EXT): double-conversion-$(GR
 	$(CXX) -c $(GRISU_OPTS) -o src/strtod.o -Isrc src/strtod.cc && \
 	$(CXX) -c $(GRISU_OPTS) -o src/libdouble-conversion.o -I.. -Isrc ../double_conversion_wrapper.cpp && \
 	$(CXX) $(GRISU_OPTS) src/*.o -shared -dead_strip -o src/libgrisu.$(SHLIB_EXT)
-$(USR)/lib/libgrisu.$(SHLIB_EXT): double-conversion-$(GRISU_VER)/src/libgrisu.$(SHLIB_EXT)
+$(BUILD)/lib/libgrisu.$(SHLIB_EXT): double-conversion-$(GRISU_VER)/src/libgrisu.$(SHLIB_EXT)
 	cp -f $< $@
 	$(INSTALL_NAME_CMD)libgrisu.dylib $@
 
@@ -369,7 +369,7 @@ ifeq ($(OS), WINNT) #needs more advanced detection once 64bit build is possible
 OPENLIBM_FLAGS = ARCH=i386
 endif
 
-OPENLIBM_OBJ_TARGET = $(USR)/lib/libopenlibm.$(SHLIB_EXT)
+OPENLIBM_OBJ_TARGET = $(BUILD)/lib/libopenlibm.$(SHLIB_EXT)
 OPENLIBM_OBJ_SOURCE = openlibm/libopenlibm.$(SHLIB_EXT)
 
 openlibm/Makefile:
@@ -382,7 +382,7 @@ $(OPENLIBM_OBJ_SOURCE): $(JULIAHOME)/.git/modules/deps/openlibm/HEAD
 endif
 $(OPENLIBM_OBJ_SOURCE): openlibm/Makefile
 	$(MAKE) -C openlibm $(OPENLIBM_FLAGS) CC="$(CC)" FC="$(FC)" USECLANG=$(USECLANG) USEGCC=$(USEGCC)
-$(OPENLIBM_OBJ_TARGET): $(OPENLIBM_OBJ_SOURCE) | $(USR)/lib
+$(OPENLIBM_OBJ_TARGET): $(OPENLIBM_OBJ_SOURCE) | $(BUILD)/lib
 	cp $< $@
 install-openlibm: $(OPENLIBM_OBJ_TARGET)
 
@@ -393,7 +393,7 @@ distclean-openlibm: clean-openlibm
 
 ## Rmath ##
 
-RMATH_OBJ_TARGET = $(USR)/lib/libRmath.$(SHLIB_EXT)
+RMATH_OBJ_TARGET = $(BUILD)/lib/libRmath.$(SHLIB_EXT)
 RMATH_OBJ_SOURCE = Rmath/src/libRmath.$(SHLIB_EXT)
 
 compile-rmath: $(RMATH_OBJ_SOURCE)
@@ -413,7 +413,7 @@ distclean-rmath: clean-rmath
 
 ## LIBRANDOM ##
 
-LIBRANDOM_OBJ_TARGET = $(USR)/lib/librandom.$(SHLIB_EXT)
+LIBRANDOM_OBJ_TARGET = $(BUILD)/lib/librandom.$(SHLIB_EXT)
 LIBRANDOM_OBJ_SOURCE = random/librandom.$(SHLIB_EXT)
 
 LIBRANDOM_CFLAGS = $(CFLAGS) -O3 -finline-functions -fomit-frame-pointer -DNDEBUG -fno-strict-aliasing --param max-inline-insns-single=1800 -Wmissing-prototypes -Wall  -std=c99 -DDSFMT_MEXP=19937 $(fPIC) -shared -DDSFMT_DO_NOT_USE_OLD_NAMES
@@ -464,7 +464,7 @@ endif
 #endif
 
 compile-openblas: $(OPENBLAS_OBJ_SOURCE)
-install-openblas: $(USR)/lib/libopenblas.$(SHLIB_EXT)
+install-openblas: $(BUILD)/lib/libopenblas.$(SHLIB_EXT)
 
 openblas-$(OPENBLAS_VER).tar.gz:
 	$(WGET_DASH_O) $@ https://github.com/xianyi/OpenBLAS/tarball/$(OPENBLAS_VER) 
@@ -475,9 +475,9 @@ openblas-$(OPENBLAS_VER)/Makefile: openblas-$(OPENBLAS_VER).tar.gz
 	touch $@
 $(OPENBLAS_OBJ_SOURCE): openblas-$(OPENBLAS_VER)/Makefile
 	$(MAKE) -C openblas-$(OPENBLAS_VER) $(OPENBLAS_BUILD_OPTS)
-$(USR)/lib/libopenblas.$(SHLIB_EXT): $(OPENBLAS_OBJ_SOURCE) | $(USR)/lib
-	cp -f openblas-$(OPENBLAS_VER)/libopenblas.$(SHLIB_EXT) $(USR)/lib
-	$(INSTALL_NAME_CMD)libopenblas.$(SHLIB_EXT) $(USR)/lib/libopenblas.$(SHLIB_EXT)
+$(BUILD)/lib/libopenblas.$(SHLIB_EXT): $(OPENBLAS_OBJ_SOURCE) | $(BUILD)/lib
+	cp -f openblas-$(OPENBLAS_VER)/libopenblas.$(SHLIB_EXT) $(BUILD)/lib
+	$(INSTALL_NAME_CMD)libopenblas.$(SHLIB_EXT) $(BUILD)/lib/libopenblas.$(SHLIB_EXT)
 
 clean-openblas:
 	-$(MAKE) -C openblas-$(OPENBLAS_VER) clean
@@ -487,7 +487,7 @@ distclean-openblas:
 ## LAPACK ##
 
 ifeq ($(USE_SYSTEM_LAPACK), 0)
-LAPACK_OBJ_TARGET = $(USR)/lib/liblapack.$(SHLIB_EXT)
+LAPACK_OBJ_TARGET = $(BUILD)/lib/liblapack.$(SHLIB_EXT)
 LAPACK_OBJ_SOURCE = lapack-$(LAPACK_VER)/liblapack.$(SHLIB_EXT)
 else
 LAPACK_OBJ_TARGET =
@@ -521,7 +521,7 @@ distclean-lapack:
 
 ## ARPACK ##
 
-ARPACK_OBJ_TARGET = $(USR)/lib/libarpack.$(SHLIB_EXT)
+ARPACK_OBJ_TARGET = $(BUILD)/lib/libarpack.$(SHLIB_EXT)
 ARPACK_OBJ_SOURCE = arpack-ng_$(ARPACK_VER)/libarpack.$(SHLIB_EXT)
 
 compile-arpack: $(ARPACK_OBJ_SOURCE)
@@ -535,15 +535,15 @@ arpack-ng_$(ARPACK_VER)/configure: arpack-ng_$(ARPACK_VER).tar.gz
 	touch $@
 $(ARPACK_OBJ_SOURCE): arpack-ng_$(ARPACK_VER)/configure $(OPENBLAS_OBJ_SOURCE)
 	cd arpack-ng_$(ARPACK_VER) && \
-	./configure  --prefix=$(abspath $(USR)) --with-blas="$(LIBBLAS)" --with-lapack="$(LIBLAPACK)" --disable-mpi --enable-shared F77="$(FC)" MPIF77="$(FC)" CC="$(CC)" CXX="$(CXX)"
+	./configure  --prefix=$(abspath $(BUILD)) --with-blas="$(LIBBLAS)" --with-lapack="$(LIBLAPACK)" --disable-mpi --enable-shared F77="$(FC)" MPIF77="$(FC)" CC="$(CC)" CXX="$(CXX)"
 	touch $@
-$(ARPACK_OBJ_TARGET): $(ARPACK_OBJ_SOURCE) | $(USR)/lib
+$(ARPACK_OBJ_TARGET): $(ARPACK_OBJ_SOURCE) | $(BUILD)/lib
 	cd arpack-ng_$(ARPACK_VER) && \
 	$(MAKE) install F77="$(FC)" MPIF77="$(FC)"
-	$(INSTALL_NAME_CMD)libarpack.$(SHLIB_EXT) $(USR)/lib/libarpack.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libarpack.$(SHLIB_EXT) $(BUILD)/lib/libarpack.$(SHLIB_EXT)
 ifeq ($(OS), Linux)
-	for filename in $(USR)/lib/libarpack.so* ; do \
-		$(USR)/bin/patchelf --set-rpath '$$ORIGIN' $$filename ;\
+	for filename in $(BUILD)/lib/libarpack.so* ; do \
+		$(BUILD)/bin/patchelf --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
 	touch $@
@@ -556,8 +556,8 @@ distclean-arpack:
 
 ## FFTW ##
 
-FFTW_SINGLE_OBJ_TARGET = $(USR)/lib/libfftw3f.3.$(SHLIB_EXT)
-FFTW_DOUBLE_OBJ_TARGET = $(USR)/lib/libfftw3.3.$(SHLIB_EXT)
+FFTW_SINGLE_OBJ_TARGET = $(BUILD)/lib/libfftw3f.3.$(SHLIB_EXT)
+FFTW_DOUBLE_OBJ_TARGET = $(BUILD)/lib/libfftw3.3.$(SHLIB_EXT)
 
 compile-fftw: compile-fftw-single compile-fftw-double
 compile-fftw-single: install-fftw-single
@@ -584,21 +584,21 @@ fftw-$(FFTW_VER)-single/configure: fftw-$(FFTW_VER).tar.gz
 	touch $@
 fftw-$(FFTW_VER)-single/config.status: fftw-$(FFTW_VER)-single/configure
 	cd fftw-$(FFTW_VER)-single && \
-	./configure --prefix=$(abspath $(USR)) $(FFTW_CONFIG) --enable-single CC="$(CC)" CXX="$(CXX)" && \
+	./configure --prefix=$(abspath $(BUILD)) $(FFTW_CONFIG) --enable-single CC="$(CC)" CXX="$(CXX)" && \
 	$(MAKE) clean
 	touch $@
 $(FFTW_SINGLE_OBJ_TARGET): fftw-$(FFTW_VER)-single/config.status
 	$(MAKE) -C fftw-$(FFTW_VER)-single install
 ifeq ($(OS), Darwin)
-	$(INSTALL_NAME_CMD)libfftw3f.dylib $(USR)/lib/libfftw3f.dylib
-	$(INSTALL_NAME_CMD)libfftw3f_threads.$(SHLIB_EXT) $(USR)/lib/libfftw3f_threads.$(SHLIB_EXT)
-	$(INSTALL_NAME_CHANGE_CMD) $(USR)/lib/libfftw3f.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3f.dylib $(USR)/lib/libfftw3f_threads.dylib
+	$(INSTALL_NAME_CMD)libfftw3f.dylib $(BUILD)/lib/libfftw3f.dylib
+	$(INSTALL_NAME_CMD)libfftw3f_threads.$(SHLIB_EXT) $(BUILD)/lib/libfftw3f_threads.$(SHLIB_EXT)
+	$(INSTALL_NAME_CHANGE_CMD) $(BUILD)/lib/libfftw3f.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3f.dylib $(BUILD)/lib/libfftw3f_threads.dylib
 else ifeq ($(OS),WINNT)
-	-rm $(USR)/lib/libfftw3f.dll
-	mv $(USRBIN)/libfftw3f-3.dll $(USR)/lib/libfftw3f.dll
+	-rm $(BUILD)/lib/libfftw3f.dll
+	mv $(BUILD)/bin/libfftw3f-3.dll $(BUILD)/lib/libfftw3f.dll
 else ifeq ($(OS), Linux)
-	for filename in $(USR)/lib/libfftw3f_threads.so* ; do \
-		$(USR)/bin/patchelf --set-rpath '$$ORIGIN' $$filename ;\
+	for filename in $(BUILD)/lib/libfftw3f_threads.so* ; do \
+		$(BUILD)/bin/patchelf --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
 	touch $@
@@ -609,21 +609,21 @@ fftw-$(FFTW_VER)-double/configure: fftw-$(FFTW_VER).tar.gz
 	touch $@
 fftw-$(FFTW_VER)-double/config.status: fftw-$(FFTW_VER)-double/configure
 	cd fftw-$(FFTW_VER)-double && \
-	./configure --prefix=$(abspath $(USR)) $(FFTW_CONFIG) CC="$(CC)" CXX="$(CXX)" && \
+	./configure --prefix=$(abspath $(BUILD)) $(FFTW_CONFIG) CC="$(CC)" CXX="$(CXX)" && \
 	$(MAKE) clean
 	touch $@
 $(FFTW_DOUBLE_OBJ_TARGET): fftw-$(FFTW_VER)-double/config.status
 	$(MAKE) -C fftw-$(FFTW_VER)-double install
 ifeq ($(OS), Darwin)
-	$(INSTALL_NAME_CMD)libfftw3.$(SHLIB_EXT) $(USR)/lib/libfftw3.$(SHLIB_EXT)
-	$(INSTALL_NAME_CMD)libfftw3_threads.$(SHLIB_EXT) $(USR)/lib/libfftw3_threads.$(SHLIB_EXT)
-	$(INSTALL_NAME_CHANGE_CMD) $(USR)/lib/libfftw3.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3.dylib $(USR)/lib/libfftw3_threads.dylib
+	$(INSTALL_NAME_CMD)libfftw3.$(SHLIB_EXT) $(BUILD)/lib/libfftw3.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libfftw3_threads.$(SHLIB_EXT) $(BUILD)/lib/libfftw3_threads.$(SHLIB_EXT)
+	$(INSTALL_NAME_CHANGE_CMD) $(BUILD)/lib/libfftw3.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3.dylib $(BUILD)/lib/libfftw3_threads.dylib
 else ifeq ($(OS),WINNT)
-	-rm $(USR)/lib/libfftw3.dll
-	mv $(USRBIN)/libfftw3-3.dll $(USR)/lib/libfftw3.dll
+	-rm $(BUILD)/lib/libfftw3.dll
+	mv $(BUILD)/bin/libfftw3-3.dll $(BUILD)/lib/libfftw3.dll
 else ifeq ($(OS), Linux)
-	for filename in $(USR)/lib/libfftw3_threads.so* ; do \
-		$(USR)/bin/patchelf --set-rpath '$$ORIGIN' $$filename ;\
+	for filename in $(BUILD)/lib/libfftw3_threads.so* ; do \
+		$(BUILD)/bin/patchelf --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
 	touch $@
@@ -643,7 +643,7 @@ distclean-fftw:
 
 ifeq ($(USE_SYSTEM_SUITESPARSE), 0)
 SUITESPARSE_OBJ_SOURCE = SuiteSparse-$(SUITESPARSE_VER)/UMFPACK/Lib/libumfpack.a
-SUITESPARSE_OBJ_TARGET = $(USR)/lib/libumfpack.$(SHLIB_EXT)
+SUITESPARSE_OBJ_TARGET = $(BUILD)/lib/libumfpack.$(SHLIB_EXT)
 endif
 
 SUITE_SPARSE_LIB = -lm
@@ -652,7 +652,7 @@ ifneq ($(OS), Darwin)
 endif
 
 compile-suitesparse: $(SUITESPARSE_OBJ_SOURCE)
-install-suitesparse: $(SUITESPARSE_OBJ_TARGET) $(USR)/lib/libsuitesparse_wrapper.$(SHLIB_EXT)
+install-suitesparse: $(SUITESPARSE_OBJ_TARGET) $(BUILD)/lib/libsuitesparse_wrapper.$(SHLIB_EXT)
 
 SuiteSparse-$(SUITESPARSE_VER).tar.gz:
 	$(WGET) http://www.cise.ufl.edu/research/sparse/SuiteSparse/SuiteSparse-$(SUITESPARSE_VER).tar.gz
@@ -662,7 +662,7 @@ SuiteSparse-$(SUITESPARSE_VER)/Makefile: SuiteSparse-$(SUITESPARSE_VER).tar.gz
 	touch $@
 $(SUITESPARSE_OBJ_SOURCE): $(OPENBLAS_OBJ_SOURCE) SuiteSparse-$(SUITESPARSE_VER)/Makefile
 	cd SuiteSparse-$(SUITESPARSE_VER) && \
-	$(MAKE) CC="$(CC)" CXX="$(CXX)" BLAS="$(LIBBLAS)" LAPACK="$(LIBLAPACK)" INSTALL_LIB="$(USR)/lib" INSTALL_INCLUDE="$(USRINC)" LIB="$(SUITE_SPARSE_LIB)"
+	$(MAKE) CC="$(CC)" CXX="$(CXX)" BLAS="$(LIBBLAS)" LAPACK="$(LIBLAPACK)" INSTALL_LIB="$(BUILD)/lib" INSTALL_INCLUDE="$(BUILD)/include" LIB="$(SUITE_SPARSE_LIB)"
 	touch $@
 
 ifeq ($(USE_SYSTEM_SUITESPARSE), 0)
@@ -671,16 +671,16 @@ $(SUITESPARSE_OBJ_TARGET): $(SUITESPARSE_OBJ_SOURCE)
 	cd SuiteSparse-$(SUITESPARSE_VER)/lib && \
 	rm -f *.a && \
 	cp -f `find .. -name libamd.a -o -name libcolamd.a -o -name libcholmod.a -o -name libumfpack.a -o -name libsuitesparseconfig.a -o -name libspqr.a 2>/dev/null` . && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(USR)/lib/libamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(USR)/lib/libamd.$(SHLIB_EXT) && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/lib/libcolamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(USR)/lib/libcolamd.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/lib/libcholmod.$(SHLIB_EXT) -L$(USR)/lib -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(USR)/lib/libcholmod.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/lib/libumfpack.$(SHLIB_EXT) -L$(USR)/lib -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(USR)/lib/libumfpack.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(USR)/lib/libspqr.$(SHLIB_EXT) -L$(USR)/lib -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(USR)/lib/libspqr.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(BUILD)/lib/libamd.$(SHLIB_EXT) && \
+	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libcolamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(BUILD)/lib/libcolamd.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libcholmod.$(SHLIB_EXT) -L$(BUILD)/lib -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(BUILD)/lib/libcholmod.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libumfpack.$(SHLIB_EXT) -L$(BUILD)/lib -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(BUILD)/lib/libumfpack.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/lib/libspqr.$(SHLIB_EXT) -L$(BUILD)/lib -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(BUILD)/lib/libspqr.$(SHLIB_EXT)
 endif
 
 clean-suitesparse:
@@ -696,22 +696,22 @@ SUITESPARSE_INC = -I /usr/include/suitesparse
 SUITESPARSE_LIB = -lumfpack -lcholmod -lamd -lcamd -lcolamd -lspqr
 else
 SUITESPARSE_INC = -I SuiteSparse-$(SUITESPARSE_VER)/CHOLMOD/Include -I SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse_config -I SuiteSparse-$(SUITESPARSE_VER)/SPQR/Include
-SUITESPARSE_LIB = -L$(USR)/lib -lcholmod -lumfpack -lspqr $(RPATH_ORIGIN)
+SUITESPARSE_LIB = -L$(BUILD)/lib -lcholmod -lumfpack -lspqr $(RPATH_ORIGIN)
 endif
 
-$(USR)/lib/libsuitesparse_wrapper.$(SHLIB_EXT): SuiteSparse_wrapper.c $(SUITESPARSE_OBJ_TARGET)
-	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(SUITESPARSE_INC) SuiteSparse_wrapper.c -o $(USR)/lib/libsuitesparse_wrapper.$(SHLIB_EXT) $(SUITESPARSE_LIB)
+$(BUILD)/lib/libsuitesparse_wrapper.$(SHLIB_EXT): SuiteSparse_wrapper.c $(SUITESPARSE_OBJ_TARGET)
+	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(SUITESPARSE_INC) SuiteSparse_wrapper.c -o $(BUILD)/lib/libsuitesparse_wrapper.$(SHLIB_EXT) $(SUITESPARSE_LIB)
 	$(INSTALL_NAME_CMD)libsuitesparse_wrapper.$(SHLIB_EXT) $@
 	touch $@
-install-suitesparse-wrapper: $(USR)/lib/libsuitesparse_wrapper.$(SHLIB_EXT)
+install-suitesparse-wrapper: $(BUILD)/lib/libsuitesparse_wrapper.$(SHLIB_EXT)
 
 clean-suitesparse-wrapper:
-	-rm -f $(SUITESPARSE_OBJ_TARGET) $(USR)/lib/libsuitesparse_wrapper.$(SHLIB_EXT)
+	-rm -f $(SUITESPARSE_OBJ_TARGET) $(BUILD)/lib/libsuitesparse_wrapper.$(SHLIB_EXT)
 distclean-suitesparse-wrapper: clean-suitesparse-wrapper
 
 ## CLP ##
 
-CLP_OBJ_TARGET = $(USR)/lib/libClp.$(SHLIB_EXT)
+CLP_OBJ_TARGET = $(BUILD)/lib/libClp.$(SHLIB_EXT)
 
 compile-clp: install-clp
 install-clp: $(CLP_OBJ_TARGET)
@@ -724,7 +724,7 @@ clp-$(CLP_VER)/configure: clp-$(CLP_VER).tar.gz
 	touch $@
 clp-$(CLP_VER)/config.status: clp-$(CLP_VER)/configure
 	cd clp-$(CLP_VER) && \
-	./configure --prefix=$(abspath $(USR)) CC="$(CC)" CXX="$(CXX)"
+	./configure --prefix=$(abspath $(BUILD)) CC="$(CC)" CXX="$(CXX)"
 $(CLP_OBJ_TARGET): clp-$(CLP_VER)/config.status
 	$(MAKE) -C clp-$(CLP_VER) install
 	touch $@
@@ -738,7 +738,7 @@ distclean-clp:
 ## UNWIND ##
 
 ifeq ($(USE_SYSTEM_LIBUNWIND), 0)
-LIBUNWIND_TARGET_OBJ = $(USR)/lib/libunwind.a
+LIBUNWIND_TARGET_OBJ = $(BUILD)/lib/libunwind.a
 LIBUNWIND_TARGET_SOURCE = libunwind-$(UNWIND_VER)/src/.libs/libunwind.a
 else
 LIBUNWIND_TARGET_OBJ = 
@@ -757,7 +757,7 @@ libunwind-$(UNWIND_VER).tar.gz:
 	$(WGET) http://savannah.spinellicreations.com/libunwind/libunwind-$(UNWIND_VER).tar.gz
 libunwind-$(UNWIND_VER)/Makefile: libunwind-$(UNWIND_VER).tar.gz
 	tar xfz $<
-	cd libunwind-$(UNWIND_VER) && ./configure  CFLAGS="$(LIBUNWIND_CFLAGS)" --prefix=$(abspath $(USR)) CC="$(CC)" CXX="$(CXX)"
+	cd libunwind-$(UNWIND_VER) && ./configure  CFLAGS="$(LIBUNWIND_CFLAGS)" --prefix=$(abspath $(BUILD)) CC="$(CC)" CXX="$(CXX)"
 
 $(LIBUNWIND_TARGET_SOURCE): libunwind-$(UNWIND_VER)/Makefile
 	cd libunwind-$(UNWIND_VER) && $(MAKE)
@@ -775,15 +775,15 @@ distclean-unwind:
 ## GNU LIGHTTPD ##
 
 ifeq ($(USE_SYSTEM_LIGHTTPD), 0)
-LIGHTTPD_OBJ_TARGET = $(USR)/sbin/lighttpd
+LIGHTTPD_OBJ_TARGET = $(BUILD)/sbin/lighttpd
 else
 LIGHTTPD_OBJ_TARGET = 
 endif
 
 compile-lighttpd: install-lighttpd
 install-lighttpd: $(LIGHTTPD_OBJ_TARGET) lighttpd.conf
-	mkdir -p $(USR)/etc
-	cp -f lighttpd.conf $(USR)/etc/lighttpd.conf
+	mkdir -p $(BUILD)/etc
+	cp -f lighttpd.conf $(BUILD)/etc/lighttpd.conf
 
 lighttpd-$(LIGHTTPD_VER).tar.gz:
 	$(WGET) http://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-$(LIGHTTPD_VER).tar.gz
@@ -791,9 +791,9 @@ lighttpd-$(LIGHTTPD_VER)/configure: lighttpd-$(LIGHTTPD_VER).tar.gz
 	tar zxf $<
 	touch $@
 lighttpd-$(LIGHTTPD_VER)/config.status: lighttpd-$(LIGHTTPD_VER)/configure
-	mkdir -p $(USR)/lib/lighttpd && \
+	mkdir -p $(BUILD)/lib/lighttpd && \
 	cd lighttpd-$(LIGHTTPD_VER) && \
-	./configure --prefix=$(USR) --libdir=$(USR)/lib/lighttpd --without-pcre --without-zlib --without-bzip2 CC="$(CC)" CXX="$(CXX)"
+	./configure --prefix=$(BUILD) --libdir=$(BUILD)/lib/lighttpd --without-pcre --without-zlib --without-bzip2 CC="$(CC)" CXX="$(CXX)"
 $(LIGHTTPD_OBJ_TARGET): lighttpd-$(LIGHTTPD_VER)/config.status
 	$(MAKE) -C lighttpd-$(LIGHTTPD_VER) install
 	touch $@
@@ -807,7 +807,7 @@ distclean-lighttpd:
 ## GMP ##
 
 ifeq ($(USE_SYSTEM_GMP), 0)
-GMP_OBJ_TARGET = $(USR)/lib/libgmp.$(SHLIB_EXT)
+GMP_OBJ_TARGET = $(BUILD)/lib/libgmp.$(SHLIB_EXT)
 else
 GMP_OBJ_TARGET = 
 endif
@@ -822,7 +822,7 @@ gmp-$(GMP_VER)/configure: gmp-$(GMP_VER).tar.bz2
 	touch $@
 gmp-$(GMP_VER)/config.status: gmp-$(GMP_VER)/configure
 	cd gmp-$(GMP_VER) && \
-	./configure --prefix=$(abspath $(USR)) CC="$(CC)" CXX="$(CXX)"
+	./configure --prefix=$(abspath $(BUILD)) CC="$(CC)" CXX="$(CXX)"
 $(GMP_OBJ_TARGET): gmp-$(GMP_VER)/config.status
 	$(MAKE) -C gmp-$(GMP_VER)
 	$(MAKE) -C gmp-$(GMP_VER) check
@@ -842,18 +842,18 @@ ifeq ($(USE_SYSTEM_GMP), 1)
 GMPW_INC =
 GMPW_LIB = -lgmp
 else
-GMPW_INC = -I $(USRINC)
-GMPW_LIB = -L$(USR)/lib/ -lgmp
+GMPW_INC = -I$(BUILD)/include
+GMPW_LIB = -L$(BUILD)/lib/ -lgmp
 endif
 
-$(USR)/lib/libgmp_wrapper.$(SHLIB_EXT): gmp_wrapper.c $(GMP_OBJ_TARGET) | $(USR)/lib
-	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GMPW_INC) gmp_wrapper.c -o $(USR)/lib/libgmp_wrapper.$(SHLIB_EXT) $(RPATH_ORIGIN) $(GMPW_LIB)
+$(BUILD)/lib/libgmp_wrapper.$(SHLIB_EXT): gmp_wrapper.c $(GMP_OBJ_TARGET) | $(BUILD)/lib
+	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GMPW_INC) gmp_wrapper.c -o $(BUILD)/lib/libgmp_wrapper.$(SHLIB_EXT) $(RPATH_ORIGIN) $(GMPW_LIB)
 	$(INSTALL_NAME_CMD)libgmp_wrapper.$(SHLIB_EXT) $@
 	touch $@
-install-gmp-wrapper: $(USR)/lib/libgmp_wrapper.$(SHLIB_EXT)
+install-gmp-wrapper: $(BUILD)/lib/libgmp_wrapper.$(SHLIB_EXT)
 
 clean-gmp-wrapper:
-	-rm -f $(GMP_OBJ_TARGET) $(USR)/lib/libgmp_wrapper.$(SHLIB_EXT)
+	-rm -f $(GMP_OBJ_TARGET) $(BUILD)/lib/libgmp_wrapper.$(SHLIB_EXT)
 distclean-gmp-wrapper: clean-gmp-wrapper
 
 ## GLPK ##
@@ -861,11 +861,11 @@ distclean-gmp-wrapper: clean-gmp-wrapper
 ifeq ($(USE_SYSTEM_GLPK), 1)
 GLPK_OBJ_TARGET =
 else
-GLPK_OBJ_TARGET = $(USR)/lib/libglpk.$(SHLIB_EXT)
+GLPK_OBJ_TARGET = $(BUILD)/lib/libglpk.$(SHLIB_EXT)
 endif
 
 compile-glpk: install-glpk
-install-glpk: $(GLPK_OBJ_TARGET) $(USR)/lib/libglpk_wrapper.$(SHLIB_EXT)
+install-glpk: $(GLPK_OBJ_TARGET) $(BUILD)/lib/libglpk_wrapper.$(SHLIB_EXT)
 
 glpk-$(GLPK_VER).tar.gz:
 	$(WGET) http://ftp.gnu.org/gnu/glpk/$@
@@ -875,7 +875,7 @@ glpk-$(GLPK_VER)/configure: glpk-$(GLPK_VER).tar.gz
 	touch $@
 glpk-$(GLPK_VER)/config.status: glpk-$(GLPK_VER)/configure
 	cd glpk-$(GLPK_VER) && \
-	./configure --prefix=$(abspath $(USR)) CC="$(CC)" CXX="$(CXX)"
+	./configure --prefix=$(abspath $(BUILD)) CC="$(CC)" CXX="$(CXX)"
 $(GLPK_OBJ_TARGET): glpk-$(GLPK_VER)/config.status
 	$(MAKE) -C glpk-$(GLPK_VER) install
 	$(INSTALL_NAME_CMD)libglpk.dylib $@
@@ -894,19 +894,19 @@ ifeq ($(USE_SYSTEM_GLPK), 1)
 GLPKW_INC = -I /usr/include/
 GLPKW_LIB = -lglpk
 else
-GLPKW_INC = -I $(USRINC)
-GLPKW_LIB = -L$(USR)/lib -lglpk
+GLPKW_INC = -I $(BUILD)/include
+GLPKW_LIB = -L$(BUILD)/lib -lglpk
 endif
 
 
-$(USR)/lib/libglpk_wrapper.$(SHLIB_EXT): glpk_wrapper.c $(GLPK_OBJ_TARGET)
-	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GLPKW_INC) glpk_wrapper.c $(GLPKW_LIB) -o $(USR)/lib/libglpk_wrapper.$(SHLIB_EXT) $(RPATH_ORIGIN)
+$(BUILD)/lib/libglpk_wrapper.$(SHLIB_EXT): glpk_wrapper.c $(GLPK_OBJ_TARGET)
+	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GLPKW_INC) glpk_wrapper.c $(GLPKW_LIB) -o $(BUILD)/lib/libglpk_wrapper.$(SHLIB_EXT) $(RPATH_ORIGIN)
 	$(INSTALL_NAME_CMD)libglpk_wrapper.$(SHLIB_EXT) $@
 	touch $@
-install-glpk-wrapper: $(USR)/lib/libglpk_wrapper.$(SHLIB_EXT) glpk_wrapper.c
+install-glpk-wrapper: $(BUILD)/lib/libglpk_wrapper.$(SHLIB_EXT) glpk_wrapper.c
 
 clean-glpk-wrapper:
-	-rm -f $(GLPK_OBJ_TARGET) $(USR)/lib/libglpk_wrapper.$(SHLIB_EXT)
+	-rm -f $(GLPK_OBJ_TARGET) $(BUILD)/lib/libglpk_wrapper.$(SHLIB_EXT)
 distclean-glpk-wrapper: clean-glpk-wrapper
 
 ## ZLIB ##
@@ -914,7 +914,7 @@ distclean-glpk-wrapper: clean-glpk-wrapper
 ifeq ($(USE_SYSTEM_ZLIB), 1)
 ZLIB_OBJ_TARGET =
 else
-ZLIB_OBJ_TARGET = $(USR)/lib/libz.$(SHLIB_EXT)
+ZLIB_OBJ_TARGET = $(BUILD)/lib/libz.$(SHLIB_EXT)
 ZLIB_CFLAGS = CFLAGS="$(CFLAGS) -D_FILE_OFFSET_BITS=64"
 endif
 
@@ -928,7 +928,7 @@ zlib-$(ZLIB_VER)/configure: zlib-$(ZLIB_VER).tar.gz
 	touch $@
 zlib-$(ZLIB_VER)/config.status: zlib-$(ZLIB_VER)/configure
 	cd zlib-$(ZLIB_VER) && \
-	CC="$(CC)" $(ZLIB_CFLAGS) ./configure --prefix=$(abspath $(USR))
+	CC="$(CC)" $(ZLIB_CFLAGS) ./configure --prefix=$(abspath $(BUILD))
 	touch $@
 $(ZLIB_OBJ_TARGET): zlib-$(ZLIB_VER)/config.status
 	$(MAKE) -C zlib-$(ZLIB_VER)
@@ -945,7 +945,7 @@ distclean-zlib:
 
 ## Tk wrapper ##
 
-TKW_INC = -I $(USRINC) -I $(JULIAHOME)/src -I $(JULIAHOME)/src/support
+TKW_INC = -I $(BUILD)/include -I $(JULIAHOME)/src -I $(JULIAHOME)/src/support
 TKW_LIB =
 ifeq ($(OS), Darwin)
   ifneq ($(wildcard /opt/local/bin/port),)
@@ -959,21 +959,21 @@ ifeq ($(OS), Darwin)
 else
   TKW_INC += -I/usr/include/tcl
 endif
-TKW_LIB += -ltcl8.5 -ltk8.5 -L$(USR)/lib/ -ljulia-release
+TKW_LIB += -ltcl8.5 -ltk8.5 -L$(BUILD)/lib/ -ljulia-release
 
-$(USR)/lib/libtk_wrapper.$(SHLIB_EXT): tk_wrapper.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(TKW_INC) tk_wrapper.c $(TKW_LIB) -o $(USR)/lib/libtk_wrapper.$(SHLIB_EXT)
+$(BUILD)/lib/libtk_wrapper.$(SHLIB_EXT): tk_wrapper.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(TKW_INC) tk_wrapper.c $(TKW_LIB) -o $(BUILD)/lib/libtk_wrapper.$(SHLIB_EXT)
 	$(INSTALL_NAME_CMD)libtk_wrapper.$(SHLIB_EXT) $@
 	touch $@
-install-tk-wrapper: $(USR)/lib/libtk_wrapper.$(SHLIB_EXT) tk_wrapper.c
+install-tk-wrapper: $(BUILD)/lib/libtk_wrapper.$(SHLIB_EXT) tk_wrapper.c
 
 clean-tk-wrapper:
-	-rm -f $(USR)/lib/libtk_wrapper.$(SHLIB_EXT)
+	-rm -f $(BUILD)/lib/libtk_wrapper.$(SHLIB_EXT)
 distclean-tk-wrapper: clean-tk-wrapper
 
 ## patchelf
 
-PATCHELF_TARGET = $(USR)/bin/patchelf
+PATCHELF_TARGET = $(BUILD)/bin/patchelf
 
 compile-patchelf: install-patchelf
 install-patchelf: $(PATCHELF_TARGET)
@@ -985,7 +985,7 @@ patchelf-$(PATCHELF_VER)/configure: patchelf-$(PATCHELF_VER).tar.bz2
 	touch $@
 patchelf-$(PATCHELF_VER)/config.status: patchelf-$(PATCHELF_VER)/configure
 	cd patchelf-$(PATCHELF_VER) && \
-	./configure --prefix=$(abspath $(USR)) CC="$(CC)" CXX="$(CXX)"
+	./configure --prefix=$(abspath $(BUILD)) CC="$(CC)" CXX="$(CXX)"
 $(PATCHELF_TARGET): patchelf-$(PATCHELF_VER)/config.status
 	$(MAKE) -C patchelf-$(PATCHELF_VER) install
 	touch $@

--- a/deps/Rmath/src/Makefile
+++ b/deps/Rmath/src/Makefile
@@ -42,7 +42,7 @@ release debug: libRmath.$(SHLIB_EXT)
 
 libRmath.$(SHLIB_EXT): $(XOBJS)
 	rm -rf $@
-	$(QUIET_LINK) $(CC) -shared -o $@ $^ -L$(USR)/lib -lrandom $(RPATH_ORIGIN)
+	$(QUIET_LINK) $(CC) -shared -o $@ $^ -L$(BUILD)/lib -lrandom $(RPATH_ORIGIN)
 
 clean:
 	rm -f *.o *.do *.a *.$(SHLIB_EXT) core* *~ *#

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ FLAGS = \
 	-I$(shell $(LLVM_CONFIG) --includedir) \
 	-I$(JULIAHOME)/deps/libuv/include -I$(JULIAHOME)/usr/include
 
-LIBS = $(shell $(LLVM_CONFIG) --libfiles) $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a -L$(USR)/lib $(USR)/$(JL_LIBDIR)/libuv.a $(OSLIBS) -lpthread $(shell $(LLVM_CONFIG) --ldflags)
+LIBS = $(shell $(LLVM_CONFIG) --libfiles) $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a -L$(BUILD)/lib $(BUILD)/lib/libuv.a $(OSLIBS) -lpthread $(shell $(LLVM_CONFIG) --ldflags)
 
 ifneq ($(MAKECMDGOALS),debug)
 TARGET =
@@ -69,13 +69,13 @@ support/libsupport.a: support/*.h support/*.c
 flisp/libflisp.a: flisp/*.h flisp/*.c support/libsupport.a
 	$(MAKE) -C flisp
 
-$(USR)/$(JL_LIBDIR)/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
+$(BUILD)/lib/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
 	$(QUIET_LINK) $(CXX) $(DEBUGFLAGS) $(DOBJS) -shared -o $@ $(LIBS) $(LDFLAGS)
 	$(INSTALL_NAME_CMD)libjulia-debug.$(SHLIB_EXT) $@
 libjulia-debug.a: julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
 	rm -f $@
 	$(QUIET_LINK) ar -rcs $@ $(DOBJS)
-libjulia-debug: $(USR)/$(JL_LIBDIR)/libjulia-debug.$(SHLIB_EXT)
+libjulia-debug: $(BUILD)/lib/libjulia-debug.$(SHLIB_EXT)
 
 ifeq ($(SHLIB_EXT), so)
   SONAME = -Wl,-soname=libjulia-release.so
@@ -83,16 +83,16 @@ else
   SONAME =
 endif
 
-$(USR)/$(JL_LIBDIR)/libjulia-release.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
+$(BUILD)/lib/libjulia-release.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
 	$(QUIET_LINK) $(CXX) $(SHIPFLAGS) $(OBJS) $(LIBS) -shared -o $@ $(LDFLAGS) $(SONAME)
 	$(INSTALL_NAME_CMD)libjulia-release.$(SHLIB_EXT) $@
 libjulia-release.a: julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
 	rm -f $@
 	$(QUIET_LINK) ar -rcs $@ $(OBJS)
-libjulia-release: $(USR)/$(JL_LIBDIR)/libjulia-release.$(SHLIB_EXT)
+libjulia-release: $(BUILD)/lib/libjulia-release.$(SHLIB_EXT)
 
 clean:
-	rm -f $(USR)/$(JL_LIBDIR)/libjulia*
+	rm -f $(BUILD)/lib/libjulia*
 	rm -f julia_flisp.boot julia_flisp.boot.inc
 	rm -f *.do *.o *~ *# *.$(SHLIB_EXT) *.a
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -70,7 +70,7 @@ flisp/libflisp.a: flisp/*.h flisp/*.c support/libsupport.a
 	$(MAKE) -C flisp
 
 $(BUILD)/lib/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
-	$(QUIET_LINK) $(CXX) $(DEBUGFLAGS) $(DOBJS) -shared -o $@ $(LIBS) $(LDFLAGS)
+	$(QUIET_LINK) $(CXX) $(DEBUGFLAGS) $(DOBJS) $(RPATH_ORIGIN) -shared -o $@ $(LIBS) $(LDFLAGS)
 	$(INSTALL_NAME_CMD)libjulia-debug.$(SHLIB_EXT) $@
 libjulia-debug.a: julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
 	rm -f $@
@@ -84,7 +84,7 @@ else
 endif
 
 $(BUILD)/lib/libjulia-release.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
-	$(QUIET_LINK) $(CXX) $(SHIPFLAGS) $(OBJS) $(LIBS) -shared -o $@ $(LDFLAGS) $(SONAME)
+	$(QUIET_LINK) $(CXX) $(SHIPFLAGS) $(OBJS) $(LIBS) $(RPATH_ORIGIN) -shared -o $@ $(LDFLAGS) $(SONAME)
 	$(INSTALL_NAME_CMD)libjulia-release.$(SHLIB_EXT) $@
 libjulia-release.a: julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
 	rm -f $@

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -83,21 +83,6 @@ uv_lib_t *jl_load_dynamic_library(char *modname)
         ext = extensions[i];
         path[0] = '\0';
         handle->handle = NULL;
-        if (modname[0] != '/') {
-            if (julia_home) {
-                /* try julia_home/../lib */
-                snprintf(path, PATHBUF, "%s/../lib/%s%s", julia_home, modname, ext);
-                error = jl_uv_dlopen(path, handle);
-                if (!error) goto done;
-                // if file exists but didn't load, show error details
-                struct stat sbuf;
-                if (stat(path, &sbuf) != -1) {
-                    //JL_PRINTF(JL_STDERR, "could not load module %s (%d): %s\n", modname, error, uv_dlerror(handle));
-                    //jl_errorf("could not load module %s: %s", modname, uv_dlerror(handle));
-                    goto error;
-                }
-            }
-        }
         /* try loading from standard library path */
         snprintf(path, PATHBUF, "%s%s", modname, ext);
         error = jl_uv_dlopen(path, handle);
@@ -109,7 +94,6 @@ uv_lib_t *jl_load_dynamic_library(char *modname)
     if (!error) goto done;
 #endif
 
-error:
     //JL_PRINTF(JL_STDERR, "could not load module %s (%d): %s\n", modname, error, uv_dlerror(handle));
     jl_errorf("could not load module %s: %s", modname, uv_dlerror(handle));
     uv_dlclose(handle);

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -14,7 +14,7 @@ SRCS = flisp.c builtins.c string.c equalhash.c table.c iostream.c \
 OBJS = $(SRCS:%.c=%.o)
 DOBJS = $(SRCS:%.c=%.do)
 LLTDIR = ../support
-LLT = $(LLTDIR)/libsupport.a $(USR)/$(JL_LIBDIR)/libuv.a
+LLT = $(LLTDIR)/libsupport.a $(BUILD)/lib/libuv.a
 
 FLAGS = -Wall -Wno-strict-aliasing -I$(LLTDIR) $(CFLAGS) \
 	-DUSE_COMPUTED_GOTO $(HFILEDIRS:%=-I%) $(LIBDIRS:%=-L%) -fvisibility=hidden

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -5,7 +5,7 @@ override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
 
 FLAGS = -Wall -Wno-strict-aliasing -fno-omit-frame-pointer \
-	-I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(USR)/include $(CFLAGS) 
+	-I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(BUILD)/include $(CFLAGS) 
 
 DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
@@ -21,21 +21,21 @@ release debug:
 %.do: %.c repl.h
 	$(QUIET_CC) $(CC) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@
 
-julia-release-basic: $(USRBIN)/julia-release-basic
-julia-debug-basic: $(USRBIN)/julia-debug-basic
-julia-release-readline: $(USRBIN)/julia-release-readline
-julia-debug-readline: $(USRBIN)/julia-debug-readline
+julia-release-basic: $(BUILD)/bin/julia-release-basic
+julia-debug-basic: $(BUILD)/bin/julia-debug-basic
+julia-release-readline: $(BUILD)/bin/julia-release-readline
+julia-debug-readline: $(BUILD)/bin/julia-debug-readline
 
-$(USRBIN)/julia-release-basic: repl.o repl-basic.o
-	$(QUIET_LINK) $(CXX) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(USR)/$(JL_PRIVATE_LIBDIR) -L$(USR)/$(JL_LIBDIR) $(JLDFLAGS) -ljulia-release
-$(USRBIN)/julia-debug-basic: repl.do repl-basic.do
-	$(QUIET_LINK) $(CXX) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(USR)/$(JL_PRIVATE_LIBDIR) -L$(USR)/$(JL_LIBDIR) $(JLDFLAGS) -ljulia-debug
+$(BUILD)/bin/julia-release-basic: repl.o repl-basic.o
+	$(QUIET_LINK) $(CXX) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(BUILD)/lib $(JLDFLAGS) -ljulia-release
+$(BUILD)/bin/julia-debug-basic: repl.do repl-basic.do
+	$(QUIET_LINK) $(CXX) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(BUILD)/lib $(JLDFLAGS) -ljulia-debug
 
-$(USRBIN)/julia-release-readline: repl.o repl-readline.o
-	$(QUIET_LINK) $(CXX) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ $(READLINE) -L$(USR)/$(JL_PRIVATE_LIBDIR) -L$(USR)/$(JL_LIBDIR) $(JLDFLAGS) -ljulia-release
-$(USRBIN)/julia-debug-readline: repl.do repl-readline.do
-	$(QUIET_LINK) $(CXX) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ $(READLINE) -L$(USR)/$(JL_PRIVATE_LIBDIR) -L$(USR)/$(JL_LIBDIR) $(JLDFLAGS) -ljulia-debug
+$(BUILD)/bin/julia-release-readline: repl.o repl-readline.o
+	$(QUIET_LINK) $(CXX) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ $(READLINE) -L$(BUILD)/lib $(JLDFLAGS) -ljulia-release
+$(BUILD)/bin/julia-debug-readline: repl.do repl-readline.do
+	$(QUIET_LINK) $(CXX) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ $(READLINE) -L$(BUILD)/lib $(JLDFLAGS) -ljulia-debug
 
 clean: | $(CLEAN_TARGETS)
 	rm -f *.o *.do
-	rm -f $(USRBIN)/julia-*-basic $(USRBIN)/julia-*-readline $(USRBIN)/julia
+	rm -f $(BUILD)/bin/julia-*-basic $(BUILD)/bin/julia-*-readline $(BUILD)/bin/julia

--- a/ui/webserver/Makefile
+++ b/ui/webserver/Makefile
@@ -4,7 +4,7 @@ include $(JULIAHOME)/Make.inc
 override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
 
-LIBS = -lpthread $(USR)/$(JL_LIBDIR)/libuv.a 
+LIBS = -lpthread $(BUILD)/lib/libuv.a 
 ifeq ($(OS), Linux)
 LIBS += -lrt 
 endif
@@ -26,20 +26,20 @@ ifeq ($(OS),WINNT)
 LAUNCH_SCRIPT = launch-julia-webserver.bat
 endif 
 	
-julia-release julia-debug: %: $(USRBIN)/%-webserver $(USRBIN)/$(LAUNCH_SCRIPT)
+julia-release julia-debug: %: $(BUILD)/bin/%-webserver $(BUILD)/bin/$(LAUNCH_SCRIPT)
 
 release debug:
 	$(MAKE) julia-$@
 
-$(USRBIN)/julia-release-webserver: $(WEBSERVER_SRCS)
+$(BUILD)/bin/julia-release-webserver: $(WEBSERVER_SRCS)
 	$(QUIET_LINK) $(CXX) $(CXXFLAGS) -o $@ $(SHIPFLAGS) $(WEBSERVER_SRCS) $(LIBS)
 
-$(USRBIN)/julia-debug-webserver: $(WEBSERVER_SRCS)
+$(BUILD)/bin/julia-debug-webserver: $(WEBSERVER_SRCS)
 	$(QUIET_LINK) $(CXX) $(CXXFLAGS) -o $@ $(DEBUGFLAGS) $(WEBSERVER_SRCS) $(LIBS)
 	
-$(USRBIN)/$(LAUNCH_SCRIPT): $(LAUNCH_SCRIPT)
+$(BUILD)/bin/$(LAUNCH_SCRIPT): $(LAUNCH_SCRIPT)
 	cp $< $@
 
 clean:
 	rm -f *.o *.do
-	rm -f $(USRBIN)/julia-*-webserver
+	rm -f $(BUILD)/bin/julia-*-webserver


### PR DESCRIPTION
This pull request closes https://github.com/JuliaLang/julia/issues/1653, cleans up some make variables, and completes support for compiling all libraries into `$(BUILD)/lib`, but installing them into `($PREFIX)/$(JL_PRIVATE_LIBDIR)`.

@nolta, given your input previously, will you review this?  I've tested this on 64-bit Ubuntu, 32-bit Ubuntu via travis, and OSX 10.8.2.
