### PR TITLE
eigvals for hermitian A should be consistent with other matrix classes a...

### DIFF
--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -651,11 +651,11 @@ function eig{T<:LapackType}(A::StridedMatrix{T}, vecs::Bool)
         if vecs
             Z = similar(A)
             W = LAPACK.syevr!(copy(A), Z)
+            return W, Z
         else
-            Z = Array(T, 0, 0)
             W = LAPACK.syevr!(copy(A))
+            return W
         end
-        return W, Z
     end
 
     if iscomplex(A)


### PR DESCRIPTION
...nd return only eigvals, not 2-tuple of eigvals and empty matrix.
