### PR TITLE
Fix require() paths in tests

### DIFF
--- a/test/Rmath.jl
+++ b/test/Rmath.jl
@@ -1,4 +1,4 @@
-require("../extras/Rmath")
+require("extras/Rmath")
 
 srand(124)
 

--- a/test/arpack.jl
+++ b/test/arpack.jl
@@ -1,4 +1,4 @@
-require("$JULIA_HOME/../../extras/arpack.jl")
+require("extras/arpack")
 
 using ARPACK
 

--- a/test/gzip.jl
+++ b/test/gzip.jl
@@ -1,5 +1,5 @@
 # Testing for gzip
-require("../extras/gzip")
+require("extras/gzip")
 
 using GZip
 

--- a/test/image.jl
+++ b/test/image.jl
@@ -1,4 +1,4 @@
-require("../extras/image")
+require("extras/image")
 
 all_close(ar, v) = all(abs(ar-v) .< sqrt(eps(v)))
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -1,4 +1,4 @@
-require("../extras/iterators")
+require("extras/iterators")
 using Iterators
 
 # aux function emulating a comprehension [x for x in f]

--- a/test/options.jl
+++ b/test/options.jl
@@ -1,4 +1,4 @@
-require("../extras/options")
+require("extras/options")
 using OptionsMod
 
 oo = Options(:a, true, :b, 7)

--- a/test/sound.jl
+++ b/test/sound.jl
@@ -1,8 +1,8 @@
 ## -*-Julia-*-
 ## Test suite for Julia's sound module
 
-require("../extras/sound")
-require("../extras/options")
+require("extras/sound")
+require("extras/options")
 using Sound
 using OptionsMod
 

--- a/test/suitesparse.jl
+++ b/test/suitesparse.jl
@@ -1,4 +1,4 @@
-require("$JULIA_HOME/../../extras/suitesparse.jl")
+require("extras/suitesparse")
 
 using SuiteSparse
 

--- a/test/zlib.jl
+++ b/test/zlib.jl
@@ -1,4 +1,4 @@
-require("../extras/zlib")
+require("extras/zlib")
 
 import Zlib
 using Zlib


### PR DESCRIPTION
Don't use relative paths, use `require("extras/package")` syntax.
