### PR TITLE
Removed BitArray type parameter

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -6,17 +6,12 @@ macro _div64(l) quote $(esc(l)) >>> 6 end end
 macro _mod64(l) quote $(esc(l)) & 63 end end
 macro _msk_end(l) quote @_mskr @_mod64 $(esc(l)) end end
 _jl_num_bit_chunks(n::Int) = @_div64 (n+63)
-function _jl_check_is_valid_bit{T}(x::T)
-    if !(isequal(x, zero(T)) || isequal(x, one(T)))
-        error("invalid BitArray value")
-    end
-end
 
 ## BitArray
 
 # notes: bits are stored in contiguous chunks
 #        unused bits must always be set to 0
-type BitArray{T<:Integer, N} <: AbstractArray{T, N}
+type BitArray{N} <: AbstractArray{Bool, N}
     chunks::Vector{Uint64}
     dims::Vector{Int}
     function BitArray(dims::Int...)
@@ -33,21 +28,18 @@ type BitArray{T<:Integer, N} <: AbstractArray{T, N}
     end
 end
 
-BitArray{T}(::Type{T}) = BitArray{T,1}(0)
-BitArray() = BitArray(Bool, 0)
-BitArray{T}(::Type{T}, dims::Dims) = BitArray{T, max(length(dims), 1)}(dims...)
-BitArray(dims::Dims) = BitArray(Bool, dims)
-BitArray{T}(::Type{T}, dims::Int...) = BitArray{T, max(length(dims), 1)}(dims...)
-BitArray(dims::Int...) = BitArray(Bool, dims...)
+BitArray() = BitArray(0)
+BitArray(dims::Dims) = BitArray{max(length(dims), 1)}(dims...)
+BitArray(dims::Int...) = BitArray{max(length(dims), 1)}(dims...)
 
-typealias BitVector{T} BitArray{T,1}
-typealias BitMatrix{T} BitArray{T,2}
+typealias BitVector BitArray{1}
+typealias BitMatrix BitArray{2}
 
 ## utility functions ##
 
 length(B::BitArray) = prod(B.dims)
-eltype{T}(B::BitArray{T}) = T
-ndims{T,N}(B::BitArray{T,N}) = N
+eltype(B::BitArray) = Bool
+ndims{N}(B::BitArray{N}) = N
 numel(B::BitArray) = prod(B.dims)
 size(B::BitArray) = tuple(B.dims...)
 
@@ -127,61 +119,42 @@ end
 
 ## similar, fill, copy_to etc ##
 
-similar{T}(B::BitArray{T}) = BitArray(T, B.dims...)
-similar{T}(B::BitArray{T}, dims::Int...) = BitArray(T, dims)
-similar{T}(B::BitArray{T}, dims::Dims) = BitArray(T, dims...)
+similar(B::BitArray) = BitArray(B.dims...)
+similar(B::BitArray, dims::Int...) = BitArray(dims)
+similar(B::BitArray, dims::Dims) = BitArray(dims...)
 
-similar{S<:Integer}(B::BitArray, T::Type{S}, dims::Dims) = BitArray(T, dims)
-# changing type to a non-Integer returns an Array
+similar(B::BitArray, T::Type{Bool}, dims::Dims) = BitArray(dims)
+# changing type to a non-Bool returns an Array
 # (this triggers conversions like float(bitvector) etc.)
 similar(B::BitArray, T::Type, dims::Dims) = Array(T, dims)
 
-function fill!{T<:Integer}(B::BitArray{T}, x::Number)
-    y = convert(T, x)
-    if isequal(y, zero(T))
-        Bc = B.chunks
+function fill!(B::BitArray, x)
+    y = convert(Bool, x)
+    Bc = B.chunks
+    if !y
         for i = 1 : length(B.chunks)
             Bc[i] = uint64(0)
         end
-    elseif isequal(y, one(T))
+    else
         if length(B) == 0
             return B
         end
-        Bc = B.chunks
         for i = 1 : length(B.chunks) - 1
             Bc[i] = _msk64
         end
-        B.chunks[end] = @_msk_end length(B)
-    else
-        error("invalid BitArray value")
+        Bc[end] = @_msk_end length(B)
     end
     return B
 end
 
-fill!(B::BitArray, x) = fill!(B, int(x))
+falses(args...) = fill!(BitArray(args...), false)
+trues(args...) = fill!(BitArray(args...), true)
 
-bitzeros{T}(::Type{T}, args...) = fill!(BitArray(T, args...), 0)
-bitones{T}(::Type{T}, args...) = fill!(BitArray(T, args...), 1)
-
-trues(args...) = bitones(Bool, args...)
-falses(args...) = bitzeros(Bool, args...)
-
-biteye{T}(::Type{T}, n::Integer) = biteye(T, n, n)
-function biteye{T}(::Type{T}, m::Integer, n::Integer)
-    a = bitzeros(T, m, n)
-    for i = 1:min(m,n)
-        a[i,i] = one(T)
-    end
-    return a
-end
-biteye(n::Integer) = biteye(Bool, n)
-biteye(m::Integer, n::Integer) = biteye(Bool, m, n)
-
-function one{T}(x::BitMatrix{T})
+function one(x::BitMatrix)
     m, n = size(x)
-    a = bitzeros(T,size(x))
+    a = falses(size(x))
     for i = 1 : min(m,n)
-        a[i,i] = one(T)
+        a[i,i] = true
     end
     return a
 end
@@ -215,20 +188,20 @@ function copy_to(dest::BitArray, pos_d::Integer, src::BitArray, pos_s::Integer, 
     return dest
 end
 
-function reshape{T,N}(B::BitArray{T}, dims::NTuple{N,Int})
+function reshape{N}(B::BitArray, dims::NTuple{N,Int})
     if prod(dims) != numel(B)
         error("reshape: invalid dimensions")
     end
-    Br = BitArray{T,N}()
+    Br = BitArray{N}()
     Br.chunks = B.chunks
-    Br.dims = [i::Int for i in dims]
+    Br.dims = Int[i for i in dims]
     return Br
 end
 
 ## Conversions ##
 
-convert{T,S,n}(::Type{Array{T}}, B::BitArray{S,n}) = convert(Array{T,n},B)
-function convert{T,S,n}(::Type{Array{T,n}}, B::BitArray{S,n})
+convert{T,N}(::Type{Array{T}}, B::BitArray{N}) = convert(Array{T,N},B)
+function convert{T,N}(::Type{Array{T,N}}, B::BitArray{N})
     A = Array(T, size(B))
     for i = 1:length(A)
         A[i] = B[i]
@@ -236,40 +209,31 @@ function convert{T,S,n}(::Type{Array{T,n}}, B::BitArray{S,n})
     return A
 end
 
-convert{T,S,n}(::Type{BitArray{S}}, A::AbstractArray{T,n}) = convert(BitArray{S,n},A)
-function convert{T,S,n}(::Type{BitArray{S,n}}, A::AbstractArray{T,n})
-    B = BitArray(S, size(A))
+convert{T,N}(::Type{BitArray}, A::AbstractArray{T,N}) = convert(BitArray{N},A)
+function convert{T,N}(::Type{BitArray{N}}, A::AbstractArray{T,N})
+    B = BitArray(size(A))
     for i = 1:length(B)
         B[i] = A[i]
     end
     return B
 end
 
-convert{T<:Integer,n}(::Type{BitArray{T,n}}, B::BitArray{T,n}) = B
-convert{T<:Integer,S<:Integer,n}(::Type{BitArray{T,n}}, B::BitArray{S,n}) =
-    copy_to(similar(B, T), B)
+convert{N}(::Type{BitArray{N}}, B::BitArray{N}) = B
 
-# this version keeps dimensionality
-# (it's an extension of Array's behavior, which only does this for Vectors)
-function reinterpret{T<:Integer,S<:Integer,N}(::Type{T}, B::BitArray{S,N})
-    A = BitArray{T,N}()
-    A.dims = copy(B.dims)
-    A.chunks = B.chunks
-    return A
-end
-function reinterpret{T<:Integer,S<:Integer,N}(::Type{T}, B::BitArray{S}, dims::NTuple{N,Int})
+reinterpret{N}(::Type{Bool}, B::BitArray, dims::NTuple{N,Int}) = reinterpret(B, dims)
+function reinterpret{N}(B::BitArray, dims::NTuple{N,Int})
     if prod(dims) != numel(B)
         error("reinterpret: invalid dimensions")
     end
-    A = BitArray{T,N}()
+    A = BitArray{N}()
     A.dims = [i::Int for i in dims]
     A.chunks = B.chunks
     return A
 end
 
 # shorthand forms BitArray <-> Array
-bitunpack{T,n}(B::BitArray{T,n}) = convert(Array{T,n}, B)
-bitpack{T,n}(A::Array{T,n}) = convert(BitArray{T,n}, A)
+bitunpack{N}(B::BitArray{N}) = convert(Array{Bool,N}, B)
+bitpack{T,N}(A::AbstractArray{T,N}) = convert(BitArray{N}, A)
 
 ## Random ##
 
@@ -278,11 +242,11 @@ function bitarray_rand_fill!(B::BitArray)
         return B
     end
     Bc = B.chunks
-    for i = 1 : length(B.chunks) - 1
+    for i = 1 : length(Bc) - 1
         Bc[i] = randi(Uint64)
     end
     msk = @_msk_end length(B)
-    B.chunks[end] = msk & randi(Uint64)
+    Bc[end] = msk & randi(Uint64)
     return B
 end
 
@@ -295,16 +259,16 @@ end
 
 ## Indexing: ref ##
 
-function ref{T<:Integer}(B::BitArray{T}, i::Integer)
+function ref(B::BitArray, i::Integer)
     if i < 1 || i > length(B)
         throw(BoundsError())
     end
     i1, i2 = _jl_get_chunks_id(i)
-    return (B.chunks[i1] >>> i2) & one(Uint64) == one(Uint64) ? one(T) : zero(T)
+    return (B.chunks[i1] >>> i2) & one(Uint64) == one(Uint64)
 end
 
 # 0d bitarray
-ref{T<:Integer}(B::BitArray{T,0}) = B[1]
+ref(B::BitArray{0}) = B[1]
 
 ref(B::BitArray, i0::Integer, i1::Integer) = B[i0 + size(B,1)*(i1-1)]
 ref(B::BitArray, i0::Integer, i1::Integer, i2::Integer) =
@@ -312,9 +276,8 @@ ref(B::BitArray, i0::Integer, i1::Integer, i2::Integer) =
 ref(B::BitArray, i0::Integer, i1::Integer, i2::Integer, i3::Integer) =
     B[i0 + size(B,1)*((i1-1) + size(B,2)*((i2-1) + size(B,3)*(i3-1)))]
 
-# note: although unused, the T here is necessary, otherwhise
 #       ref(::BitArray, ::Integer) is shadowed (?)
-function ref{T<:Integer}(B::BitArray{T}, I::Integer...)
+function ref(B::BitArray, I::Integer...)
     ndims = length(I)
     index = I[1]
     stride = 1
@@ -335,7 +298,7 @@ let ref_cache = nothing
         if ndims(B) < 1 + length(I)
             error("wrong number of dimensions in ref")
         end
-        X = similar(B, ref_shape(I0, I...))
+        X = BitArray(ref_shape(I0, I...))
         nI = ndims(X)
 
         I = map(x->(isa(x,Integer) ? (x:x) : x), I[1:nI-1])
@@ -392,7 +355,7 @@ end
 # note: the Range1{Int} case is still handled by the version above
 #       (which is fine)
 function ref{T<:Integer}(B::BitArray, I::AbstractVector{T})
-    X = similar(B, length(I))
+    X = BitArray(length(I))
     ind = 1
     for i in I
         X[ind] = B[i]
@@ -405,7 +368,7 @@ let ref_cache = nothing
     global ref
     function ref(B::BitArray, I::Indices...)
         I = indices(I)
-        X = similar(B, ref_shape(I...))
+        X = BitArray(ref_shape(I...))
 
         if is(ref_cache,nothing)
             ref_cache = Dict()
@@ -422,7 +385,7 @@ end
 
 function _jl_ref_bool_1d(B::BitArray, I::AbstractArray{Bool})
     n = sum(I)
-    out = similar(B, n)
+    out = BitArray(n)
     c = 1
     for i = 1:numel(I)
         if I[i]
@@ -433,47 +396,44 @@ function _jl_ref_bool_1d(B::BitArray, I::AbstractArray{Bool})
     out
 end
 
-# note : type specifiers needed to gain precedence over ref(::BitArray, ::Indices...)
-ref{T<:Integer}(B::BitVector{T}, I::AbstractVector{Bool}) = _jl_ref_bool_1d(B, I)
-ref{T<:Integer}(B::BitVector{T}, I::AbstractArray{Bool}) = _jl_ref_bool_1d(B, I)
-ref{T<:Integer}(B::BitArray{T}, I::AbstractVector{Bool}) = _jl_ref_bool_1d(B, I)
-ref{T<:Integer}(B::BitArray{T}, I::AbstractArray{Bool}) = _jl_ref_bool_1d(B, I)
+ref(B::BitVector, I::AbstractVector{Bool}) = _jl_ref_bool_1d(B, I)
+ref(B::BitVector, I::AbstractArray{Bool}) = _jl_ref_bool_1d(B, I)
+ref(B::BitArray, I::AbstractVector{Bool}) = _jl_ref_bool_1d(B, I)
+ref(B::BitArray, I::AbstractArray{Bool}) = _jl_ref_bool_1d(B, I)
 
-ref{T<:Integer}(B::BitMatrix{T}, I::Integer, J::AbstractVector{Bool}) = B[I, find(J)]
-ref{T<:Integer}(B::BitMatrix{T}, I::AbstractVector{Bool}, J::Integer) = B[find(I), J]
-ref{T<:Integer}(B::BitMatrix{T}, I::AbstractVector{Bool}, J::AbstractVector{Bool}) = B[find(I), find(J)]
-ref{T<:Integer,S<:Integer}(B::BitMatrix{T}, I::AbstractVector{S}, J::AbstractVector{Bool}) = B[I, find(J)]
-ref{T<:Integer,S<:Integer}(B::BitMatrix{T}, I::AbstractVector{Bool}, J::AbstractVector{S}) = B[find(I), J]
+ref(B::BitMatrix, I::Integer, J::AbstractVector{Bool}) = B[I, find(J)]
+ref(B::BitMatrix, I::AbstractVector{Bool}, J::Integer) = B[find(I), J]
+ref(B::BitMatrix, I::AbstractVector{Bool}, J::AbstractVector{Bool}) = B[find(I), find(J)]
+ref{T<:Integer}(B::BitMatrix, I::AbstractVector{T}, J::AbstractVector{Bool}) = B[I, find(J)]
+ref{T<:Integer}(B::BitMatrix, I::AbstractVector{Bool}, J::AbstractVector{T}) = B[find(I), J]
 
 ## Indexing: assign ##
 
-function assign{T<:Integer}(B::BitArray{T}, x::Number, i::Integer)
+function assign(B::BitArray, x, i::Integer)
     if i < 1 || i > length(B)
         throw(BoundsError())
     end
     i1, i2 = _jl_get_chunks_id(i)
     u = uint64(1)
-    y = convert(T, x)
-    if isequal(y, zero(T))
+    y = convert(Bool, x)
+    if !y
         B.chunks[i1] &= ~(u << i2)
-    elseif isequal(y, one(T))
-        B.chunks[i1] |= (u << i2)
     else
-        error("invalid BitArray value")
+        B.chunks[i1] |= (u << i2)
     end
     return B
 end
 
-assign(B::BitArray, x::Number, i0::Integer, i1::Integer) =
+assign(B::BitArray, x, i0::Integer, i1::Integer) =
     B[i0 + size(B,1)*(i1-1)] = x
 
-assign(B::BitArray, x::Number, i0::Integer, i1::Integer, i2::Integer) =
+assign(B::BitArray, x, i0::Integer, i1::Integer, i2::Integer) =
     B[i0 + size(B,1)*((i1-1) + size(B,2)*(i2-1))] = x
 
-assign(B::BitArray, x::Number, i0::Integer, i1::Integer, i2::Integer, i3::Integer) =
+assign(B::BitArray, x, i0::Integer, i1::Integer, i2::Integer, i3::Integer) =
     B[i0 + size(B,1)*((i1-1) + size(B,2)*((i2-1) + size(B,3)*(i3-1)))] = x
 
-function assign(B::BitArray, x::Number, I0::Integer, I::Integer...)
+function assign(B::BitArray, x, I0::Integer, I::Integer...)
     index = I0
     stride = 1
     for k = 1:length(I)
@@ -558,44 +518,40 @@ function assign(B::BitArray, X::BitArray, I0::Range1{Int}, I::Union(Integer, Ran
     _jl_assign_array2bitarray_ranges(B, X, I0, I...)
 end
 
-function assign{T<:Integer}(B::BitArray, x::Number, I::AbstractVector{T})
-    for i in I
-        B[i] = x
-    end
-    return B
-end
-
-function assign{T<:Number,S<:Integer}(B::BitArray, X::AbstractArray{T}, I::AbstractVector{S})
+function assign{T<:Integer}(B::BitArray, X::AbstractArray, I::AbstractVector{T})
     if length(X) != length(I); error("argument dimensions must match"); end
-    for i = 1:length(I)
-        B[I[i]] = X[i]
+    count = 1
+    for i in I
+        B[i] = X[count]
+        count += 1
     end
     return B
 end
 
-let assign_cache = nothing
-    global assign
-    function assign(B::BitArray, x::Number, I0::Indices, I::Indices...)
-        I0 = indices(I0)
-        I = indices(I)
-        if is(assign_cache,nothing)
-            assign_cache = Dict()
-        end
-        gen_cartesian_map(assign_cache, ivars->:(B[$(ivars...)] = x),
-            tuple(I0, I...),
-            (:B, :x),
-            B, x)
-        return B
+function assign(B::BitArray, X::AbstractArray, i0::Integer)
+    if length(X) != 1
+        error("argument dimensions must match")
     end
+    return B[i0] = X[1]
 end
 
-# note: use of T<:Integer in the following is to disambiguate
-assign{T<:Integer,S<:Number}(B::BitArray{T}, X::AbstractArray{S}, I0::Integer) =
-    (B[I0] = X[1])
+function assign(B::BitArray, X::AbstractArray, i0::Integer, i1::Integer)
+    if length(X) != 1
+        error("argument dimensions must match")
+    end
+    return B[i0, i1] = X[1]
+end
+
+function assign(B::BitArray, X::AbstractArray, I0::Integer, I::Integer...)
+    if length(X) != 1
+        error("argument dimensions must match")
+    end
+    return B[I0, I...] = X[1]
+end
 
 let assign_cache = nothing
     global assign
-    function assign{T<:Integer,S<:Number}(B::BitArray{T}, X::AbstractArray{S}, I0::Indices, I::Indices...)
+    function assign(B::BitArray, X::AbstractArray, I0::Indices, I::Indices...)
         I0 = indices(I0)
         I = indices(I)
         nel = length(I0)
@@ -627,9 +583,32 @@ let assign_cache = nothing
     end
 end
 
+function assign{T<:Integer}(B::BitArray, x, I::AbstractVector{T})
+    for i in I
+        B[i] = x
+    end
+    return B
+end
+
+let assign_cache = nothing
+    global assign
+    function assign(B::BitArray, x, I0::Indices, I::Indices...)
+        I0 = indices(I0)
+        I = indices(I)
+        if is(assign_cache,nothing)
+            assign_cache = Dict()
+        end
+        gen_cartesian_map(assign_cache, ivars->:(B[$(ivars...)] = x),
+            tuple(I0, I...),
+            (:B, :x),
+            B, x)
+        return B
+    end
+end
+
 # logical indexing
 
-function _jl_assign_bool_scalar_1d(A::BitArray, x::Number, I::AbstractArray{Bool})
+function _jl_assign_bool_scalar_1d(A::BitArray, x, I::AbstractArray{Bool})
     n = sum(I)
     for i = 1:numel(I)
         if I[i]
@@ -639,7 +618,7 @@ function _jl_assign_bool_scalar_1d(A::BitArray, x::Number, I::AbstractArray{Bool
     A
 end
 
-function _jl_assign_bool_vector_1d{T<:Number}(A::BitArray, X::AbstractArray{T}, I::AbstractArray{Bool})
+function _jl_assign_bool_vector_1d(A::BitArray, X::AbstractArray, I::AbstractArray{Bool})
     n = sum(I)
     c = 1
     for i = 1:numel(I)
@@ -651,48 +630,46 @@ function _jl_assign_bool_vector_1d{T<:Number}(A::BitArray, X::AbstractArray{T}, 
     A
 end
 
-assign{T<:Number}(A::BitArray, X::AbstractArray{T}, I::AbstractVector{Bool}) = _jl_assign_bool_vector_1d(A, X, I)
-assign{T<:Number}(A::BitArray, X::AbstractArray{T}, I::AbstractArray{Bool}) = _jl_assign_bool_vector_1d(A, X, I)
-assign(A::BitArray, x::Number, I::AbstractVector{Bool}) = _jl_assign_bool_scalar_1d(A, x, I)
-assign(A::BitArray, x::Number, I::AbstractArray{Bool}) = _jl_assign_bool_scalar_1d(A, x, I)
+assign(A::BitArray, X::AbstractArray, I::AbstractVector{Bool}) = _jl_assign_bool_vector_1d(A, X, I)
+assign(A::BitArray, X::AbstractArray, I::AbstractArray{Bool}) = _jl_assign_bool_vector_1d(A, X, I)
+assign(A::BitArray, x, I::AbstractVector{Bool}) = _jl_assign_bool_scalar_1d(A, x, I)
+assign(A::BitArray, x, I::AbstractArray{Bool}) = _jl_assign_bool_scalar_1d(A, x, I)
 
-# note: use of T<:Integer in the following is to disambiguate
-assign{T<:Integer,S<:Number}(A::BitMatrix{T}, x::AbstractArray{S}, I::Integer, J::AbstractVector{Bool}) =
+assign(A::BitMatrix, x::AbstractArray, I::Integer, J::AbstractVector{Bool}) =
     (A[I,find(J)] = x)
 
-assign{T<:Integer}(A::BitMatrix{T}, x::Number, I::Integer, J::AbstractVector{Bool}) =
+assign(A::BitMatrix, x, I::Integer, J::AbstractVector{Bool}) =
     (A[I,find(J)] = x)
 
-assign{T<:Integer,S<:Number}(A::BitMatrix{T}, x::AbstractArray{S}, I::AbstractVector{Bool}, J::Integer) =
+assign(A::BitMatrix, x::AbstractArray, I::AbstractVector{Bool}, J::Integer) =
     (A[find(I),J] = x)
 
-assign{T<:Integer}(A::BitMatrix{T}, x::Number, I::AbstractVector{Bool}, J::Integer) =
+assign(A::BitMatrix, x, I::AbstractVector{Bool}, J::Integer) =
     (A[find(I),J] = x)
 
-assign{T<:Integer,S<:Number}(A::BitMatrix{T}, x::AbstractArray{S}, I::AbstractVector{Bool}, J::AbstractVector{Bool}) =
+assign(A::BitMatrix, x::AbstractArray, I::AbstractVector{Bool}, J::AbstractVector{Bool}) =
     (A[find(I),find(J)] = x)
 
-assign{T<:Integer}(A::BitMatrix{T}, x::Number, I::AbstractVector{Bool}, J::AbstractVector{Bool}) =
+assign(A::BitMatrix, x, I::AbstractVector{Bool}, J::AbstractVector{Bool}) =
     (A[find(I),find(J)] = x)
 
-assign{T<:Integer,S<:Number,R<:Integer}(A::BitMatrix{T}, x::AbstractArray{S}, I::AbstractVector{R}, J::AbstractVector{Bool}) =
+assign{T<:Integer}(A::BitMatrix, x::AbstractArray, I::AbstractVector{T}, J::AbstractVector{Bool}) =
     (A[I,find(J)] = x)
 
-assign{T<:Integer,R<:Integer}(A::BitMatrix{T}, x::Number, I::AbstractVector{R}, J::AbstractVector{Bool}) =
+assign{T<:Integer}(A::BitMatrix, x, I::AbstractVector{T}, J::AbstractVector{Bool}) =
     (A[I,find(J)] = x)
 
-assign{T<:Integer,S<:Number,R<:Integer}(A::BitMatrix{T}, x::AbstractArray{S}, I::AbstractVector{Bool}, J::AbstractVector{R}) =
+assign{T<:Integer}(A::BitMatrix, x::AbstractArray, I::AbstractVector{Bool}, J::AbstractVector{T}) =
     (A[find(I),J] = x)
 
-assign{T<:Integer,R<:Integer}(A::BitMatrix{T}, x::Number, I::AbstractVector{Bool}, J::AbstractVector{R}) =
+assign{T<:Integer}(A::BitMatrix, x, I::AbstractVector{Bool}, J::AbstractVector{T}) =
     (A[find(I),J] = x)
 
 ## Dequeue functionality ##
 
-function push{T<:Integer}(B::BitVector{T}, item)
+function push(B::BitVector, item)
     # convert first so we don't grow the bitarray if the assignment won't work
-    item = convert(T, item)
-    _jl_check_is_valid_bit(item)
+    item = convert(Bool, item)
 
     l = @_mod64 length(B)
     if l == 0
@@ -700,11 +677,13 @@ function push{T<:Integer}(B::BitVector{T}, item)
         B.chunks[end] = uint64(0)
     end
     B.dims[1] += 1
-    B[end] = item
+    if item
+        B[end] = true
+    end
     return B
 end
 
-function append!{T<:Integer}(B::BitVector{T}, items::BitVector{T})
+function append!(B::BitVector, items::BitVector)
     n0 = length(B)
     n1 = length(items)
     if n1 == 0
@@ -721,9 +700,8 @@ function append!{T<:Integer}(B::BitVector{T}, items::BitVector{T})
     return B
 end
 
-append!{T<:Integer}(B::BitVector{T}, items::BitVector) = append!(B, reinterpret(T, items))
-append!{T<:Integer}(B::BitVector{T}, items::AbstractVector{T}) = append!(B, bitpack(items))
-append!{T<:Integer}(A::Vector{T}, items::BitVector{T}) = append!(A, bitunpack(items))
+append!(B::BitVector, items::AbstractVector{Bool}) = append!(B, bitpack(items))
+append!(A::Vector{Bool}, items::BitVector) = append!(A, bitunpack(items))
 
 function grow(B::BitVector, n::Integer)
     n0 = length(B)
@@ -748,7 +726,7 @@ function pop(B::BitVector)
         error("pop: BitArray is empty")
     end
     item = B[end]
-    B[end] = 0
+    B[end] = false
 
     l = @_mod64 length(B)
     if l == 1
@@ -759,9 +737,8 @@ function pop(B::BitVector)
     return item
 end
 
-function enqueue{T<:Integer}(B::BitVector{T}, item)
-    item = convert(T, item)
-    _jl_check_is_valid_bit(item)
+function enqueue(B::BitVector, item)
+    item = convert(Bool, item)
 
     l = @_mod64 length(B)
     if l == 0
@@ -801,16 +778,15 @@ function shift(B::BitVector)
     return item
 end
 
-function insert{T<:Integer}(B::BitVector{T}, i::Integer, item)
+function insert(B::BitVector, i::Integer, item)
     if i < 1
         throw(BoundsError())
     end
-    item = convert(T, item)
-    _jl_check_is_valid_bit(item)
+    item = convert(Bool, item)
 
     n = length(B)
     if i > n
-        x = bitzeros(T, i - n)
+        x = falses(i - n)
         append!(B, x)
     else
         k, j = _jl_get_chunks_id(i)
@@ -911,20 +887,18 @@ end
 
 ## Unary operators ##
 
-(~)(B::BitArray) = ~bitunpack(B)
-
 (-)(B::BitArray) = -bitunpack(B)
 sign(B::BitArray) = copy(B)
 
 real(B::BitArray) = copy(B)
-imag{T}(B::BitArray{T}) = bitzeros(T, size(B))
+imag(B::BitArray) = falses(size(B))
 
 conj!(B::BitArray) = B
 conj(B::BitArray) = copy(B)
 
 function flipbits(B::BitArray)
-    Bc = B.chunks
     C = similar(B)
+    Bc = B.chunks
     if !isempty(Bc)
         Cc = C.chunks
         for i = 1:length(Bc)-1
@@ -936,11 +910,20 @@ function flipbits(B::BitArray)
     return C
 end
 
-# Bools have special treatment
-(~)(B::BitArray{Bool}) = flipbits(B)
-!(B::BitArray{Bool}) = flipbits(B)
-(-)(B::BitArray{Bool}) = copy(B)
-sign(B::BitArray{Bool}) = convert(BitArray{Int}, B)
+function flipbits!(B::BitArray)
+    Bc = B.chunks
+    if !isempty(Bc)
+        for i = 1:length(B.chunks) - 1
+            Bc[i] = ~Bc[i]
+        end
+        msk = @_msk_end length(B)
+        Bc[end] = msk & (~Bc[end])
+    end
+    return B
+end
+
+(~)(B::BitArray) = flipbits(B)
+!(B::BitArray) = flipbits(B)
 
 ## Binary arithmetic operators ##
 
@@ -952,30 +935,61 @@ for f in (:+, :-, :div, :mod, :./, :.^, :/, :\)
     end
 end
 
+function (&)(B::BitArray, x::Bool)
+    if x
+        return copy(B)
+    else
+        return falses(size(B))
+    end
+end
+(&)(x::Bool, B::BitArray) = B & x
+
+function (|)(B::BitArray, x::Bool)
+    if x
+        return trues(size(B))
+    else
+        return copy(B)
+    end
+end
+(|)(x::Bool, B::BitArray) = B | x
+
+function ($)(B::BitArray, x::Bool)
+    if x
+        return ~B
+    else
+        return copy(B)
+    end
+end
+($)(x::Bool, B::BitArray) = B $ x
+
 for f in (:&, :|, :$)
     @eval begin
-        function ($f){T<:Integer}(A::BitArray{T}, B::BitArray{T})
-            F = BitArray(T, promote_shape(size(A),size(B))...)
-            fc = F.chunks
-            ac = A.chunks
-            bc = B.chunks
-            if !isempty(ac) && !isempty(bc)
-                for i = 1:length(F.chunks) - 1
-                    fc[i] = ($f)(ac[i], bc[i])
+        function ($f)(A::BitArray, B::BitArray)
+            F = BitArray(promote_shape(size(A),size(B))...)
+            Fc = F.chunks
+            Ac = A.chunks
+            Bc = B.chunks
+            if !isempty(Ac) && !isempty(Bc)
+                for i = 1:length(Fc) - 1
+                    Fc[i] = ($f)(Ac[i], Bc[i])
                 end
                 msk = @_msk_end length(F)
-                F.chunks[end] = msk & ($f)(A.chunks[end], B.chunks[end])
+                Fc[end] = msk & ($f)(Ac[end], Bc[end])
             end
             return F
         end
+        ($f)(A::Array{Bool}, B::BitArray) = ($f)(bitpack(A), B)
+        ($f)(B::BitArray, A::Array{Bool}) = ($f)(A, B)
         ($f)(x::Number, B::BitArray) = ($f)(x, bitunpack(B))
-        ($f)(A::BitArray, x::Number) = ($f)(x, A)
+        ($f)(B::BitArray, x::Number) = ($f)(x, B)
     end
 end
 
-(.*){T<:Integer}(A::BitArray{T}, B::BitArray{T}) = A & B
+(.*)(A::BitArray, B::BitArray) = A & B
+(.*)(A::Array{Bool}, B::BitArray) = A & B
+(.*)(B::BitArray, A::Array{Bool}) = A & B
 (.*)(x::Number, B::BitArray) = x .* bitunpack(B)
-(.*)(A::BitArray, x::Number) = x .* A
+(.*)(B::BitArray, x::Number) = x .* B
 
 for f in (:+, :-, :div, :mod, :./, :.^, :.*, :&, :|, :$)
     @eval begin
@@ -984,74 +998,39 @@ for f in (:+, :-, :div, :mod, :./, :.^, :.*, :&, :|, :$)
     end
 end
 
-# specialized Bool versions
-function (&)(x::Number, B::BitArray{Bool})
-    if bool(x)
-        return copy(B)
-    else
-        return bitzeros(Bool, size(B))
-    end
-end
-function (|)(x::Number, B::BitArray{Bool})
-    if bool(x)
-        return bitones(Bool, size(B))
-    else
-        return copy(B)
-    end
-end
-function ($)(x::Number, B::BitArray{Bool})
-    if bool(x)
-        return ~B
-    else
-        return copy(B)
-    end
-end
-(.*)(x::Number, B::BitArray{Bool}) = x & B
-
 ## promotion to complex ##
 
 # TODO?
 
 ## element-wise comparison operators returning BitArray{Bool} ##
 
-for (f,scalarf,t) in ((:(.==),:(==),:Number),
-                      (:.<, :<,:Real),
-                      (:.!=,:!=,:Number),
-                      (:.<=,:<=,:Real))
+for (f,scalarf) in ((:(.==),:(==)),
+                      (:.<, :<),
+                      (:.!=,:!=),
+                      (:.<=,:<=))
     @eval begin
         function ($f)(A::AbstractArray, B::AbstractArray)
-            F = BitArray(Bool, promote_shape(size(A),size(B)))
+            F = BitArray(promote_shape(size(A),size(B)))
             for i = 1:numel(B)
                 F[i] = ($scalarf)(A[i], B[i])
             end
             return F
         end
-        ($f)(A, B::AbstractArray) =
-            reshape([ ($scalarf)(A, B[i]) for i=1:length(B)], size(B))
-        ($f)(A::AbstractArray, B) =
-            reshape([ ($scalarf)(A[i], B) for i=1:length(A)], size(A))
-
-        function ($f)(x::($t), B::BitArray)
-            F = similar(B, Bool)
+        function ($f)(A, B::AbstractArray)
+            F = BitArray(size(B))
             for i = 1:numel(F)
-                F[i] = ($scalarf)(x, B[i])
+                F[i] = ($scalarf)(A, B[i])
             end
             return F
         end
-        function ($f)(A::BitArray, x::($t))
-            F = similar(A, Bool)
+        function ($f)(A::AbstractArray, B)
+            F = BitArray(size(A))
             for i = 1:numel(F)
-                F[i] = ($scalarf)(A[i], x)
+                F[i] = ($scalarf)(A[i], B)
             end
             return F
         end
-    end
-end
 
-for f in (:(==), :(.==), :!=, :.!=, :<, :.<, :<=, :.<=)
-    @eval begin
-        ($f)(A::BitArray, B::Array) = ($f)(bitunpack(A), B)
-        ($f)(A::Array, B::BitArray) = ($f)(A, bitunpack(B))
     end
 end
 
@@ -1081,6 +1060,16 @@ function (!=)(A::BitArray, B::BitArray)
     return false
 end
 
+for f in (:(==), :!=)
+    @eval begin
+        ($f)(A::BitArray, B::AbstractArray{Bool}) = ($f)(A, bitpack(B))
+        ($f)(A::AbstractArray{Bool}, B::BitArray) = ($f)(bitpack(A), B)
+        ($f)(A::BitArray, B::AbstractArray) = ($f)(bitunpack(A), B)
+        ($f)(A::AbstractArray, B::BitArray) = ($f)(A, bitunpack(B))
+    end
+end
+
+
 ## Data movement ##
 
 # TODO some of this could be optimized
@@ -1094,7 +1083,7 @@ function slicedim(A::BitArray, d::Integer, i::Integer)
     N = numel(A)
     stride = M * d_in[d]
 
-    B = similar(A, d_out)
+    B = BitArray(d_out)
     index_offset = 1 + (i-1)*M
 
     l = 1
@@ -1165,7 +1154,7 @@ end
 
 function rotl90(A::BitMatrix)
     m,n = size(A)
-    B = similar(A,(n,m))
+    B = BitArray(n,m)
     for i=1:m, j=1:n
         B[n-j+1,i] = A[i,j]
     end
@@ -1173,7 +1162,7 @@ function rotl90(A::BitMatrix)
 end
 function rotr90(A::BitMatrix)
     m,n = size(A)
-    B = similar(A,(n,m))
+    B = BitArray(n,m)
     for i=1:m, j=1:n
         B[j,m-i+1] = A[i,j]
     end
@@ -1237,67 +1226,70 @@ end
 
 reverse(v::BitVector) = reverse!(copy(v))
 
-function (<<){T}(B::BitVector{T}, i::Int64)
+function (<<)(B::BitVector, i::Int64)
     n = length(B)
     i %= n
     if i == 0; return copy(B); end
-    A = bitzeros(T, n);
+    A = falses(n);
     _jl_copy_chunks(A.chunks, 1, B.chunks, i+1, n-i)
     return A
 end
-(<<){T}(B::BitVector{T}, i::Int32) = B << int64(i)
-(<<){T}(B::BitVector{T}, i::Integer) = B << int64(i)
+(<<)(B::BitVector, i::Int32) = B << int64(i)
+(<<)(B::BitVector, i::Integer) = B << int64(i)
 
-function (>>>){T}(B::BitVector{T}, i::Int64)
+function (>>>)(B::BitVector, i::Int64)
     n = length(B)
     i %= n
     if i == 0; return copy(B); end
-    A = bitzeros(T, n);
+    A = falses(n);
     _jl_copy_chunks(A.chunks, i+1, B.chunks, 1, n-i)
     return A
 end
-(>>>){T}(B::BitVector{T}, i::Int32) = B >>> int64(i)
-(>>>){T}(B::BitVector{T}, i::Integer) = B >>> int64(i)
+(>>>)(B::BitVector, i::Int32) = B >>> int64(i)
+(>>>)(B::BitVector, i::Integer) = B >>> int64(i)
 
 (>>)(B::BitVector, i::Int32) = B >>> i
 (>>)(B::BitVector, i::Integer) = B >>> i
 
-function rotl{T}(B::BitVector{T}, i::Integer)
+function rotl(B::BitVector, i::Integer)
     n = length(B)
     i %= n
     if i == 0; return copy(B); end
-    A = BitArray(T, n);
+    A = BitArray(n);
     _jl_copy_chunks(A.chunks, 1, B.chunks, i+1, n-i)
     _jl_copy_chunks(A.chunks, n-i+1, B.chunks, 1, i)
     return A
 end
 
-function rotr{T}(B::BitVector{T}, i::Integer)
+function rotr(B::BitVector, i::Integer)
     n = length(B)
     i %= n
     if i == 0; return copy(B); end
-    A = BitArray(T, n);
+    A = BitArray(n);
     _jl_copy_chunks(A.chunks, i+1, B.chunks, 1, n-i)
     _jl_copy_chunks(A.chunks, 1, B.chunks, n-i+1, i)
     return A
 end
 
+#TODO: rotl!, rotr!
 
 ## nnz & find ##
 
 function nnz(B::BitArray)
     n = 0
-    for i = 1:length(B.chunks)
-        n += count_ones(B.chunks[i])
+    Bc = B.chunks
+    for i = 1:length(Bc)
+        n += count_ones(Bc[i])
     end
     return n
 end
 
 # returns the index of the first non-zero element, or 0 if all zeros
 function findfirst(B::BitArray)
-    for i = 1:length(B.chunks)
-        if B.chunks[i] != 0
-            return (i-1) << 6 + trailing_zeros(B.chunks[i]) + 1
+    Bc = B.chunks
+    for i = 1:length(Bc)
+        if Bc[i] != 0
+            return (i-1) << 6 + trailing_zeros(Bc[i]) + 1
         end
     end
     return 0
@@ -1305,16 +1297,17 @@ end
 
 # aux function: same as findfirst(~B), but performed without temporaries
 function _jl_findfirstnot(B::BitArray)
-    l = length(B.chunks)
+    Bc = B.chunks
+    l = length(Bc)
     if l == 0
         return 0
     end
     for i = 1:l-1
-        if B.chunks[i] != _msk64
-            return (i-1) << 6 + trailing_ones(B.chunks[i]) + 1
+        if Bc[i] != _msk64
+            return (i-1) << 6 + trailing_ones(Bc[i]) + 1
         end
     end
-    ce = B.chunks[end]
+    ce = Bc[end]
     if ce != @_msk_end length(B)
         return (l-1) << 6 + trailing_ones(ce) + 1
     end
@@ -1322,10 +1315,10 @@ function _jl_findfirstnot(B::BitArray)
 end
 
 # returns the index of the first matching element
-function findfirst{T}(B::BitArray{T}, v)
-    if v == zero(T)
+function findfirst(B::BitArray, v)
+    if v == false
         return _jl_findfirstnot(B)
-    elseif v == one(T)
+    elseif v == true
         return findfirst(B)
     else
         return 0
@@ -1333,9 +1326,9 @@ function findfirst{T}(B::BitArray{T}, v)
 end
 
 # returns the index of the first element for which the function returns true
-function findfirst{T}(testf::Function, B::BitArray{T})
-    f0::Bool = testf(zero(T))
-    f1::Bool = testf(one(T))
+function findfirst(testf::Function, B::BitArray)
+    f0::Bool = testf(false)
+    f1::Bool = testf(true)
     if length(B) == 0 || !(f0 || f1)
         return 0
     elseif f0 && f1
@@ -1347,13 +1340,12 @@ function findfirst{T}(testf::Function, B::BitArray{T})
     end
 end
 
-function find{T<:Integer}(B::BitArray{T})
+function find(B::BitArray)
     nnzB = nnz(B)
     I = Array(Int, nnzB)
-    z = zero(T)
     count = 1
     for i = 1:length(B)
-        if B[i] != z
+        if B[i]
             I[count] = i
             count += 1
         end
@@ -1363,14 +1355,13 @@ end
 
 findn(B::BitVector) = find(B)
 
-function findn{T<:Integer}(B::BitMatrix{T})
+function findn(B::BitMatrix)
     nnzB = nnz(B)
     I = Array(Int, nnzB)
     J = Array(Int, nnzB)
-    z = zero(T)
     count = 1
     for j=1:size(B,2), i=1:size(B,1)
-        if !isequal(B[i,j], z)
+        if B[i,j]
             I[count] = i
             J[count] = j
             count += 1
@@ -1383,16 +1374,16 @@ let findn_cache = nothing
 function findn_one(ivars)
     s = { quote I[$i][count] = $(ivars[i]) end for i = 1:length(ivars)}
     quote
-    	Bind = B[$(ivars...)]
-    	if Bind != z
-    	    $(s...)
-    	    count +=1
-    	end
+        Bind = B[$(ivars...)]
+        if Bind
+            $(s...)
+            count +=1
+        end
     end
 end
 
 global findn
-function findn{T}(B::BitArray{T})
+function findn(B::BitArray)
     ndimsB = ndims(B)
     nnzB = nnz(B)
     I = ntuple(ndimsB, x->Array(Int, nnzB))
@@ -1404,22 +1395,56 @@ function findn{T}(B::BitArray{T})
         end
 
         gen_cartesian_map(findn_cache, findn_one, ranges,
-                          (:B, :I, :count, :z), B, I, 1, zero(T))
+                          (:B, :I, :count), B, I, 1)
     end
     return I
 end
 end
 
-function findn_nzs{T<:Integer}(B::BitMatrix{T})
+function findn_nzs(B::BitMatrix)
     I, J = findn(B)
-    return (I, J, bitones(T, length(I)))
+    return (I, J, trues(length(I)))
 end
 
-nonzeros{T<:Integer}(B::BitArray{T}) = bitones(T, nnz(B))
+nonzeros(B::BitArray) = trues(nnz(B))
 
 ## Reductions ##
 
 sum(A::BitArray, region::Dimspec) = areduce(+,A,region,0,Array(Int,reduced_dims(A,region)))
+
+sum(B::BitArray) = nnz(B)
+
+function all(B::BitArray)
+    if length(B) == 0
+        return true
+    end
+    Bc = B.chunks
+    for i = 1:length(Bc)-1
+        if Bc[i] != _msk64
+            return false
+        end
+    end
+    if Bc[end] != @_msk_end length(B)
+        return false
+    end
+    return true
+end
+
+function any(B::BitArray)
+    if length(B) == 0
+        return false
+    end
+    Bc = B.chunks
+    for i = 1:length(Bc)
+        if Bc[i] != 0
+            return true
+        end
+    end
+    return false
+end
+
+min(B::BitArray) = all(B)
+max(B::BitArray) = any(B)
 
 ## map over bitarrays ##
 
@@ -1528,10 +1553,10 @@ function _jl_put_8x8_chunk(B::BitMatrix, i1::Int, i2::Int, x::Uint64, m::Int, cg
     return
 end
 
-function transpose{T<:Integer}(B::BitMatrix{T})
+function transpose(B::BitMatrix)
     l1 = size(B, 1)
     l2 = size(B, 2)
-    Bt = bitzeros(T, l2, l1)
+    Bt = falses(l2, l1)
 
     cgap1 = @_div64 l1
     cinc1 = @_mod64 l1
@@ -1625,7 +1650,7 @@ function permute(B::BitArray, perm)
     end
 
     if is(permute_cache,nothing)
-	permute_cache = Dict()
+        permute_cache = Dict()
     end
 
     gen_cartesian_map(permute_cache, permute_one, ranges,
@@ -1638,24 +1663,24 @@ end # let
 
 ## Concatenation ##
 
-function hcat{T}(B::BitVector{T}...)
+function hcat(B::BitVector...)
     height = length(B[1])
     for j = 2:length(B)
         if length(B[j]) != height; error("hcat: mismatched dimensions"); end
     end
-    M = BitArray(T, height, length(B))
+    M = BitArray(height, length(B))
     for j = 1:length(B)
         _jl_copy_chunks(M.chunks, (height*(j-1))+1, B[j].chunks, 1, height)
     end
     return M
 end
 
-function vcat{T}(V::BitVector{T}...)
+function vcat(V::BitVector...)
     n = 0
     for Vk in V
         n += length(Vk)
     end
-    B = BitArray(T, n)
+    B = BitArray(n)
     j = 1
     for Vk in V
         _jl_copy_chunks(B.chunks, j, Vk.chunks, 1, length(Vk))
@@ -1664,7 +1689,7 @@ function vcat{T}(V::BitVector{T}...)
     return B
 end
 
-function hcat{T}(A::Union(BitMatrix{T},BitVector{T})...)
+function hcat(A::Union(BitMatrix,BitVector)...)
     nargs = length(A)
     nrows = size(A[1], 1)
     ncols = 0
@@ -1676,7 +1701,7 @@ function hcat{T}(A::Union(BitMatrix{T},BitVector{T})...)
         if size(Aj, 1) != nrows; error("hcat: mismatched dimensions"); end
     end
 
-    B = BitArray(T, nrows, ncols)
+    B = BitArray(nrows, ncols)
 
     pos = 1
     for k=1:nargs
@@ -1688,14 +1713,14 @@ function hcat{T}(A::Union(BitMatrix{T},BitVector{T})...)
     return B
 end
 
-function vcat{T}(A::BitMatrix{T}...)
+function vcat(A::BitMatrix...)
     nargs = length(A)
     nrows = sum(a->size(a, 1), A)::Int
     ncols = size(A[1], 2)
     for j = 2:nargs
         if size(A[j], 2) != ncols; error("vcat: mismatched dimensions"); end
     end
-    B = BitArray(T, nrows, ncols)
+    B = BitArray(nrows, ncols)
     nrowsA = [size(a, 1) for a in A]
     pos_d = 1
     pos_s = ones(Int, nargs)
@@ -1710,7 +1735,7 @@ function vcat{T}(A::BitMatrix{T}...)
 end
 
 # general case, specialized for BitArrays and Integers
-function cat{T}(catdim::Integer, X::Union(BitArray{T}, Integer)...)
+function cat(catdim::Integer, X::Union(BitArray, Integer)...)
     nargs = length(X)
     # using integers results in conversion to Array{Int}
     # (except in the all-Bool case)
@@ -1771,7 +1796,7 @@ function cat{T}(catdim::Integer, X::Union(BitArray{T}, Integer)...)
     dimsC = ntuple(ndimsC, compute_dims)::(Int...)
     typeC = promote_type(map(x->isa(x,BitArray) ? eltype(x) : typeof(x), X)...)
     if !has_integer || typeC == Bool
-        C = BitArray(typeC, dimsC)
+        C = BitArray(dimsC)
     else
         C = Array(typeC, dimsC)
     end
@@ -1795,20 +1820,9 @@ end
 
 isequal(A::BitArray, B::BitArray) = (A == B)
 
-function cumsum{T}(v::BitVector{T})
+function cumsum(v::BitVector)
     n = length(v)
-    c = Array(T, n)
-    if n == 0; return c; end
-
-    c[1] = v[1]
-    for i=2:n
-        c[i] = v[i] + c[i-1]
-    end
-    return c
-end
-function cumsum(v::BitVector{Bool})
-    n = length(v)
-    c = bitones(Bool, n)
+    c = trues(n)
     for i=1:n
         if !v[i]
             c[i] = false
@@ -1819,12 +1833,12 @@ function cumsum(v::BitVector{Bool})
     return c
 end
 
-function cumprod{T}(v::BitVector{T})
+function cumprod(v::BitVector)
     n = length(v)
-    c = bitzeros(T, n)
+    c = falses(n)
     for i=1:n
-        if v[i] == one(T)
-            c[i] = one(T)
+        if v[i]
+            c[i] = true
         else
             break
         end

--- a/base/export.jl
+++ b/base/export.jl
@@ -565,7 +565,6 @@ export
     each_row!,
     each_vec,
     each_vec!,
-    falses,
     fill,
     fill!,
     find,
@@ -641,7 +640,6 @@ export
     sub2ind,
     sum,
     sum_kbn,
-    trues,
     vcat,
     vec,
     zeros,
@@ -726,11 +724,14 @@ export
     spzeros,
 
 # bitarrays
-    biteye,
     bitpack,
-    bitshow,
     bitunpack,
+    falses,
     flipbits,
+    flipbits!,
+    rotl,
+    rotr,
+    trues,
 
 # dequeues
     append!,
@@ -1112,6 +1113,7 @@ export
     memio,
     mmap,
     mmap_array,
+    mmap_bitarray,
     mmap_grow,
     mmap_stream_settings,
     msync,

--- a/base/linalg_bitarray.jl
+++ b/base/linalg_bitarray.jl
@@ -1,6 +1,6 @@
-function dot{T,S}(x::BitVector{T}, y::BitVector{S})
+function dot(x::BitVector, y::BitVector)
     # simplest way to mimic Array dot behavior
-    s = zero(one(T) * one(S))
+    s = 0
     for i = 1 : length(x.chunks)
         s += count_ones(x.chunks[i] & y.chunks[i])
     end
@@ -10,10 +10,10 @@ end
 ## slower than the unpacked version, which is MUCH slower
 #  than blas'd (this one saves storage though, keeping it commented
 #  just in case)
-#function aTb{T,S}(A::BitMatrix{T}, B::BitMatrix{S})
+#function aTb(A::BitMatrix, B::BitMatrix)
     #(mA, nA) = size(A)
     #(mB, nB) = size(B)
-    #C = zeros(promote_type(T,S), nA, nB)
+    #C = falses(nA, nB)
     #if mA != mB; error("*: argument shapes do not match"); end
     #if mA == 0; return C; end
     #col_ch = _jl_num_bit_chunks(mA)
@@ -27,6 +27,7 @@ end
         #_jl_copy_chunks(aux_chunksA, 1, A.chunks, (i-1)*mA+1, mA)
         #for j = 1:nB
             #for k = 1:col_ch
+                ## TODO: improve
                 #C[i, j] += count_ones(aux_chunksA[k] & aux_chunksB[j][k])
             #end
         #end
@@ -36,9 +37,9 @@ end
 
 #aCb{T, S}(A::BitMatrix{T}, B::BitMatrix{S}) = aTb(A, B)
 
-function triu{T}(B::BitMatrix{T}, k::Int)
+function triu(B::BitMatrix, k::Int)
     m,n = size(B)
-    A = bitzeros(T, m,n)
+    A = falses(m,n)
     for i = max(k+1,1):n
         j = clamp((i - 1) * m + 1, 1, i * m)
         _jl_copy_chunks(A.chunks, j, B.chunks, j, min(i-k, m))
@@ -47,9 +48,9 @@ function triu{T}(B::BitMatrix{T}, k::Int)
 end
 triu(B::BitMatrix, k::Integer) = triu(B, int(k))
 
-function tril{T}(B::BitMatrix{T}, k::Int)
+function tril(B::BitMatrix, k::Int)
     m,n = size(B)
-    A = bitzeros(T, m, n)
+    A = falses(m, n)
     for i = 1:min(n, m+k)
         j = clamp((i - 1) * m + i - k, 1, i * m)
         _jl_copy_chunks(A.chunks, j, B.chunks, j, max(m-i+k+1, 0))
@@ -59,20 +60,8 @@ end
 tril(B::BitMatrix, k::Integer) = tril(B, int(k))
 
 ## Matrix multiplication and division
-
-#disambiguations
-(*){T<:Integer,S<:Integer}(A::BitMatrix{T}, B::BitVector{S}) = bitunpack(A) * bitunpack(B)
-(*){T<:Integer,S<:Integer}(A::BitVector{T}, B::BitMatrix{S}) = bitunpack(A) * bitunpack(B)
-(*){T<:Integer,S<:Integer}(A::BitMatrix{T}, B::BitMatrix{S}) = bitunpack(A) * bitunpack(B)
-(*){T<:Integer}(A::BitMatrix{T}, B::AbstractVector) = (*)(bitunpack(A), B)
-(*){T<:Integer}(A::BitVector{T}, B::AbstractMatrix) = (*)(bitunpack(A), B)
-(*){T<:Integer}(A::BitMatrix{T}, B::AbstractMatrix) = (*)(bitunpack(A), B)
-(*){T<:Integer}(A::AbstractVector, B::BitMatrix{T}) = (*)(A, bitunpack(B))
-(*){T<:Integer}(A::AbstractMatrix, B::BitVector{T}) = (*)(A, bitunpack(B))
-(*){T<:Integer}(A::AbstractMatrix, B::BitMatrix{T}) = (*)(A, bitunpack(B))
-#end disambiguations
-
-for f in (:/, :\, :*)
+#
+for f in (:/, :\)
     @eval begin
         ($f)(A::BitArray, B::BitArray) = ($f)(bitunpack(A), bitunpack(B))
         ($f)(A::BitArray, B::AbstractArray) = ($f)(bitunpack(A), B)
@@ -80,16 +69,12 @@ for f in (:/, :\, :*)
     end
 end
 
-# specialized Bool versions
-
-#disambiguations (TODO: improve!)
-(*)(A::BitMatrix{Bool}, B::BitVector{Bool}) = bitpack(bitunpack(A) * bitunpack(B))
-(*)(A::BitVector{Bool}, B::BitMatrix{Bool}) = bitpack(bitunpack(A) * bitunpack(B))
-(*)(A::BitMatrix{Bool}, B::BitMatrix{Bool}) = bitpack(bitunpack(A) * bitunpack(B))
-#end disambiguations
-
 # TODO: improve this!
-(*)(A::BitArray{Bool}, B::BitArray{Bool}) = bitpack(bitunpack(A) * bitunpack(B))
+(*)(A::BitArray, B::BitArray) = bitpack(bitunpack(A) * bitunpack(B))
+(*)(A::BitArray, B::Array{Bool}) = bitpack(bitunpack(A) * B)
+(*)(A::Array{Bool}, B::BitArray) = bitpack(A * bitunpack(B))
+(*)(A::BitArray, B::AbstractArray) = bitunpack(A) * B
+(*)(A::AbstractArray, B::BitArray) = A * bitunpack(B)
 
 ## diff and gradient
 
@@ -111,7 +96,7 @@ function diag(B::BitMatrix)
     return v
 end
 
-function diagm{T}(v::Union(BitVector{T},BitMatrix{T}))
+function diagm(v::Union(BitVector,BitMatrix))
     if isa(v, BitMatrix)
         if (size(v,1) != 1 && size(v,2) != 1)
             error("Input should be nx1 or 1xn")
@@ -119,7 +104,7 @@ function diagm{T}(v::Union(BitVector{T},BitMatrix{T}))
     end
 
     n = numel(v)
-    a = bitzeros(T, n, n)
+    a = falses(n, n)
     for i=1:n
         a[i,i] = v[i]
     end
@@ -135,10 +120,10 @@ qr(A::BitMatrix) = qr(float(A))
 
 ## kron
 
-function kron{T,S}(a::BitVector{T}, b::BitVector{S})
+function kron(a::BitVector, b::BitVector)
     m = length(a)
     n = length(b)
-    R = BitArray(promote_type(T,S), m, n)
+    R = BitArray(m, n)
     zS = zero(S)
     for j = 1:n
         if b[j] != zS
@@ -148,16 +133,15 @@ function kron{T,S}(a::BitVector{T}, b::BitVector{S})
     return R
 end
 
-function kron{T,S}(a::BitMatrix{T}, b::BitMatrix{S})
+function kron(a::BitMatrix, b::BitMatrix)
     mA,nA = size(a)
     mB,nB = size(b)
-    R = bitzeros(promote_type(T,S), mA*mB, nA*nB)
+    R = falses(mA*mB, nA*nB)
 
-    zT = zero(T)
     for i = 1:mA
         ri = (1:mB)+(i-1)*mB
         for j = 1:nA
-            if a[i,j] != zT
+            if a[i,j]
                 rj = (1:nB)+(j-1)*nB
                 R[ri,rj] = b
             end
@@ -240,17 +224,16 @@ end
 
 function findmax(a::BitArray)
     if length(a) == 0
-        return (typemin(eltype(a)), 0)
+        return (false, 0)
     end
-    m = zero(eltype(a))
-    o = one(eltype(a))
+    m = false
     mi = 1
     ti = 1
     for i=1:length(a.chunks)
         k = trailing_zeros(a.chunks[i])
         ti += k
         if k != 64
-            m = o
+            m = true
             mi = ti
             break
         end
@@ -260,17 +243,16 @@ end
 
 function findmin(a::BitArray)
     if length(a) == 0
-        return (typemax(eltype(a)), 0)
+        return (true, 0)
     end
-    m = one(eltype(a))
-    z = zero(eltype(a))
+    m = true
     mi = 1
     ti = 1
     for i=1:length(a.chunks) - 1
         k = trailing_ones(a.chunks[i])
         ti += k
         if k != 64
-            return (z, ti)
+            return (false, ti)
         end
     end
     l = (@_mod64 (length(a)-1)) + 1
@@ -278,7 +260,7 @@ function findmin(a::BitArray)
     k = trailing_ones(a.chunks[end] & msk)
     ti += k
     if k != l
-        m = z
+        m = false
         mi = ti
     end
     return (m, mi)

--- a/base/rng.jl
+++ b/base/rng.jl
@@ -81,38 +81,6 @@ end
     randmtzig_create_ziggurat_tables()
 end
 
-# macros to generate random arrays
-
-macro rand_matrix_builder(T, f)
-    f! = esc(symbol("$(f)!"))
-    f = esc(f)
-    quote
-        function ($f!)(A::Array{$T})
-            for i = 1:numel(A)
-                A[i] = ($f)()
-            end
-            return A
-        end
-        ($f)(dims::Dims) = ($f!)(Array($T, dims))
-        ($f)(dims::Int...) = ($f)(dims)
-    end
-end
-
-macro rand_matrix_builder_1arg(T, f)
-    f! = esc(symbol("$(f)!"))
-    f = esc(f)
-    quote
-        function ($f!)(arg, A::Array{$T})
-            for i = 1:numel(A)
-                A[i] = ($f)(arg)
-            end
-            return A
-        end
-        ($f)(arg::Number, dims::Dims) = ($f!)(arg, Array($T, dims))
-        ($f)(arg::Number, dims::Int...) = ($f)(arg, dims)
-    end
-end
-
 ## srand()
 
 function srand(seed::Uint32)

--- a/base/show.jl
+++ b/base/show.jl
@@ -839,7 +839,12 @@ end
 show(io, v::AbstractVector{Any}) = show_vector(io, v, "{", "}")
 show(io, v::AbstractVector)      = show_vector(io, v, "[", "]")
 
-# printing bit arrays
+# printing BitArrays
+
+summary(a::BitArray) =
+    string(dims2string(size(a)), " ", typeof(a).name)
+
+# (following functions not exported - mainly intended for debug)
 
 function _jl_print_bit_chunk(io::IO, c::Uint64, l::Integer)
     for s = 0 : l - 1

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1,5 +1,4 @@
 # for now, manually import necessary bit array functions:
-import Base.rotl, Base.rotr, Base.bitzeros, Base.bitones
 
 macro check_bit_operation(func, RetT, args)
     quote
@@ -20,15 +19,6 @@ let t0 = time()
     end
 end
 
-## wrappers for compatibility with old functions ##
-bitrand{T}(::Type{T}, dims::Dims) = rand!(BitArray(T, dims))
-bitrand{T}(::Type{T}, dims::Int...) = bitrand(T, dims)
-bitrand(dims::Dims) = rand!(BitArray(dims))
-bitrand(dims::Int...) = bitrand(dims)
-
-TT = Uint8
-SS = promote_type(TT, Int)
-
 # vectors size
 v1 = 260
 # matrices size
@@ -42,7 +32,7 @@ s4 = 4
 
 ## Conversions ##
 
-b1 = bitrand(TT, n1, n2)
+b1 = randbool(n1, n2)
 @test isequal(bitpack(bitunpack(b1)), b1)
 i1 = randi(2, n1, n2) - 1
 @test isequal(bitunpack(bitpack(i1)), i1)
@@ -56,42 +46,42 @@ timesofar("conversions")
 @check_bit_operation numel Int (b1,)
 @check_bit_operation size (Int...) (b1,)
 
-@test isequal(bitunpack(bitones(TT, n1, n2)), ones(TT, n1, n2))
-@test isequal(bitunpack(bitzeros(TT, n1, n2)), zeros(TT, n1, n2))
+@test isequal(bitunpack(trues(n1, n2)), ones(Bool, n1, n2))
+@test isequal(bitunpack(falses(n1, n2)), zeros(Bool, n1, n2))
 
-@test isequal(fill!(b1, one(TT)), bitones(TT, size(b1)))
-@test isequal(fill!(b1, zero(TT)), bitzeros(TT, size(b1)))
+@test isequal(fill!(b1, true), trues(size(b1)))
+@test isequal(fill!(b1, false), falses(size(b1)))
 
 timesofar("utils")
 
 ## Indexing ##
 
-b1 = bitrand(TT, n1, n2)
+b1 = randbool(n1, n2)
 m1 = randi(n1)
 m2 = randi(n2)
-b2 = bitrand(TT, m1, m2)
-@check_bit_operation copy_to BitArray{TT} (b1, b2)
-@check_bit_operation ref BitArray{TT} (b1, 1:m1, m2:n2)
-b2 = bitrand(TT, m1, m2)
-@check_bit_operation assign BitArray{TT} (b1, b2, 1:m1, n2-m2+1:n2)
+b2 = randbool(m1, m2)
+@check_bit_operation copy_to BitMatrix (b1, b2)
+@check_bit_operation ref BitMatrix (b1, 1:m1, m2:n2)
+b2 = randbool(m1, m2)
+@check_bit_operation assign BitMatrix (b1, b2, 1:m1, n2-m2+1:n2)
 
 for p1 = [randi(v1) 1 63 64 65 191 192 193]
     for p2 = [randi(v1) 1 63 64 65 191 192 193]
         for n = 0 : min(v1 - p1 + 1, v1 - p2 + 1)
-            b1 = bitrand(TT, v1)
-            b2 = bitrand(TT, v1)
-            @check_bit_operation copy_to BitArray{TT} (b1, p1, b2, p2, n)
+            b1 = randbool(v1)
+            b2 = randbool(v1)
+            @check_bit_operation copy_to BitVector (b1, p1, b2, p2, n)
         end
     end
 end
 
 # logical indexing
-b1 = bitrand(TT, n1, n2)
-t1 = bitrand(Bool, n1, n2)
+b1 = randbool(n1, n2)
+t1 = randbool(n1, n2)
 @test isequal(bitunpack(b1[t1]), bitunpack(b1)[t1])
 @test isequal(bitunpack(b1[t1]), bitunpack(b1)[bitunpack(t1)])
-t1 = bitrand(Bool, n1)
-t2 = bitrand(Bool, n2)
+t1 = randbool(n1)
+t2 = randbool(n2)
 @test isequal(bitunpack(b1[t1, t2]), bitunpack(b1)[t1, t2])
 @test isequal(bitunpack(b1[t1, t2]), bitunpack(b1)[bitunpack(t1), bitunpack(t2)])
 
@@ -100,9 +90,9 @@ timesofar("indexing")
 ## Dequeue functionality ##
 
 b1 = BitArray()
-i1 = Int[]
+i1 = Bool[]
 for m = 1 : v1
-    x = randi(2) - 1
+    x = randbool()
     push(b1, x)
     push(i1, x)
     @test isequal(bitunpack(b1), i1)
@@ -110,15 +100,15 @@ end
 
 for m1 = 0 : v1
     for m2 = [0, 1, 63, 64, 65, 127, 128, 129]
-        b1 = bitrand(TT, m1)
-        b2 = bitrand(TT, m2)
+        b1 = randbool(m1)
+        b2 = randbool(m2)
         i1 = bitunpack(b1)
         i2 = bitunpack(b2)
         @test isequal(bitunpack(append!(b1, b2)), append!(i1, i2))
     end
 end
 
-b1 = bitrand(TT, v1)
+b1 = randbool(v1)
 i1 = bitunpack(b1)
 for m = 1 : v1
     jb = pop(b1)
@@ -130,16 +120,16 @@ end
 
 
 b1 = BitArray()
-i1 = Int[]
+i1 = Bool[]
 for m = 1 : v1
-    x = randi(2) - 1
+    x = randbool()
     enqueue(b1, x)
     enqueue(i1, x)
     @test isequal(bitunpack(b1), i1)
 end
 
 
-b1 = bitrand(TT, v1)
+b1 = randbool(v1)
 i1 = bitunpack(b1)
 for m = 1 : v1
     jb = shift(b1)
@@ -153,13 +143,13 @@ b1 = BitArray()
 i1 = bitunpack(b1)
 for m = 1 : v1
     j = randi(m)
-    x = randi(2) - 1
+    x = randbool()
     insert(b1, j, x)
     insert(i1, j, x)
     @test isequal(bitunpack(b1), i1)
 end
 
-b1 = bitrand(TT, v1)
+b1 = randbool(v1)
 i1 = bitunpack(b1)
 for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
     x = randi(2) - 1
@@ -168,7 +158,7 @@ for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
     @test isequal(bitunpack(b1), i1)
 end
 
-b1 = bitrand(TT, v1)
+b1 = randbool(v1)
 i1 = bitunpack(b1)
 for m = v1 : -1 : 1
     j = randi(m)
@@ -178,7 +168,7 @@ for m = v1 : -1 : 1
 end
 @test length(b1) == 0
 
-b1 = bitrand(TT, v1)
+b1 = randbool(v1)
 i1 = bitunpack(b1)
 for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
     del(b1, j)
@@ -186,7 +176,7 @@ for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
     @test isequal(bitunpack(b1), i1)
 end
 
-b1 = bitrand(TT, v1)
+b1 = randbool(v1)
 i1 = bitunpack(b1)
 for m1 = 1 : v1
     for m2 = m1 : v1
@@ -198,7 +188,7 @@ for m1 = 1 : v1
     end
 end
 
-b1 = bitrand(TT, v1)
+b1 = randbool(v1)
 i1 = bitunpack(b1)
 del_all(b1)
 del_all(i1)
@@ -208,134 +198,117 @@ timesofar("dequeue")
 
 ## Unary operators ##
 
-b1 = bitrand(TT, n1, n2)
-@check_bit_operation (~) Array{TT} (b1,)
-@check_bit_operation (-) Array{TT} (b1,)
-@check_bit_operation sign BitArray{TT} (b1,)
-@check_bit_operation real BitArray{TT} (b1,)
-@check_bit_operation imag BitArray{TT} (b1,)
-@check_bit_operation conj BitArray{TT} (b1,)
-
-b1 = bitrand(Bool, n1, n2)
-@check_bit_operation (~) BitArray{Bool} (b1,)
-@check_bit_operation (!) BitArray{Bool} (b1,)
-@check_bit_operation (-) BitArray{Bool} (b1,)
-@check_bit_operation sign BitArray{Int} (b1,)
+b1 = randbool(n1, n2)
+@check_bit_operation (~) BitMatrix (b1,)
+@check_bit_operation (!) BitMatrix (b1,)
+#@check_bit_operation (-) Matrix{Int} (b1,)
+@check_bit_operation sign BitMatrix (b1,)
+@check_bit_operation real BitMatrix (b1,)
+@check_bit_operation imag BitMatrix (b1,)
+@check_bit_operation conj BitMatrix (b1,)
 
 b0 = falses(0)
-@check_bit_operation (~) BitArray{Bool} (b0,)
-@check_bit_operation (!) BitArray{Bool} (b0,)
-@check_bit_operation (-) BitArray{Bool} (b0,)
-@check_bit_operation sign BitArray{Int} (b0,)
+@check_bit_operation (~) BitVector (b0,)
+@check_bit_operation (!) BitVector (b0,)
+#@check_bit_operation (-) Vector{Int} (b0,)
+@check_bit_operation sign BitVector (b0,)
 
 timesofar("unary arithmetic")
 
 ## Binary arithmetic operators ##
 
-b1 = bitrand(TT, n1, n2)
-b2 = bitrand(TT, n1, n2)
-@check_bit_operation (&) BitArray{TT} (b1, b2)
-@check_bit_operation (|) BitArray{TT} (b1, b2)
-@check_bit_operation ($) BitArray{TT} (b1, b2)
-@check_bit_operation (-) Array{TT} (b1, b2)
-@check_bit_operation (.*) BitArray{TT} (b1, b2)
-@check_bit_operation (./) Array{Float64} (b1, b2)
-@check_bit_operation (.^) Array{Float64} (b1, b2)
+b1 = randbool(n1, n2)
+b2 = randbool(n1, n2)
+@check_bit_operation (&) BitMatrix (b1, b2)
+@check_bit_operation (|) BitMatrix (b1, b2)
+@check_bit_operation ($) BitMatrix (b1, b2)
+@check_bit_operation (-) Matrix{Int} (b1, b2)
+@check_bit_operation (.*) BitMatrix (b1, b2)
+@check_bit_operation (./) Matrix{Float64} (b1, b2)
+@check_bit_operation (.^) Matrix{Float64} (b1, b2)
 
-b2 = bitones(TT, n1, n2)
-@check_bit_operation div Array{TT} (b1, b2)
-@check_bit_operation mod Array{TT} (b1, b2)
+b2 = trues(n1, n2)
+@check_bit_operation div Matrix{Int} (b1, b2)
+@check_bit_operation mod Matrix{Bool} (b1, b2)
 
 while true
     global b1
-    b1 = bitrand(TT, n1, n1)
+    b1 = randbool(n1, n1)
     if abs(det(float64(b1))) > 1e-6
         break
     end
 end
-b2 = bitrand(TT, n1, n1)
+b2 = randbool(n1, n1)
 
-@check_bit_operation (*) Array{TT} (b1, b2)
-@check_bit_operation (/) Array{Float64} (b1, b1)
-@check_bit_operation (\) Array{Float64} (b1, b1)
+@check_bit_operation (*) BitMatrix (b1, b2)
+@check_bit_operation (/) Matrix{Float64} (b1, b1)
+@check_bit_operation (\) Matrix{Float64} (b1, b1)
 
-b1 = bitrand(TT, n1, n2)
+b1 = randbool(n1, n2)
 b2 = randi(10, n1, n2)
-@check_bit_operation (&) Array{SS} (b1, b2)
-@check_bit_operation (|) Array{SS} (b1, b2)
-@check_bit_operation ($) Array{SS} (b1, b2)
-@check_bit_operation (-) Array{SS} (b1, b2)
-@check_bit_operation (.*) Array{SS} (b1, b2)
-@check_bit_operation (./) Array{Float64} (b1, b2)
-@check_bit_operation (.^) Array{Float64} (b1, b2)
-@check_bit_operation div Array{SS} (b1, b2)
-@check_bit_operation mod Array{SS} (b1, b2)
+@check_bit_operation (&) Matrix{Int} (b1, b2)
+@check_bit_operation (|) Matrix{Int} (b1, b2)
+@check_bit_operation ($) Matrix{Int} (b1, b2)
+@check_bit_operation (-) Matrix{Int} (b1, b2)
+@check_bit_operation (.*) Matrix{Int} (b1, b2)
+@check_bit_operation (./) Matrix{Float64} (b1, b2)
+@check_bit_operation (.^) Matrix{Float64} (b1, b2)
+@check_bit_operation div Matrix{Int} (b1, b2)
+@check_bit_operation mod Matrix{Int} (b1, b2)
 
-while true
-    global b1
-    b1 = bitrand(TT, n1, n1)
-    if abs(det(float64(b1))) > 1e-6
-        break
-    end
-end
-b2 = bitunpack(b1)
-@check_bit_operation (*) Array{TT} (b1, b2)
-@check_bit_operation (/) Array{Float64} (b1, b2)
-@check_bit_operation (\) Array{Float64} (b1, b2)
-
-b1 = bitrand(Bool, n1, n2)
-b2 = bitrand(Bool, n1, n2)
-@check_bit_operation (&) BitArray{Bool} (b1, b2)
-@check_bit_operation (|) BitArray{Bool} (b1, b2)
-@check_bit_operation ($) BitArray{Bool} (b1, b2)
-@check_bit_operation (.*) BitArray{Bool} (b1, b2)
-@check_bit_operation (*) BitArray{Bool} (b1, b1')
+b1 = randbool(n1, n2)
+b2 = randbool(n1, n2)
+@check_bit_operation (&) BitMatrix (b1, b2)
+@check_bit_operation (|) BitMatrix (b1, b2)
+@check_bit_operation ($) BitMatrix (b1, b2)
+@check_bit_operation (.*) BitMatrix (b1, b2)
+@check_bit_operation (*) BitMatrix (b1, b1')
 
 b0 = falses(0)
-@check_bit_operation (&) BitArray{Bool} (b0, b0)
-@check_bit_operation (|) BitArray{Bool} (b0, b0)
-@check_bit_operation ($) BitArray{Bool} (b0, b0)
-@check_bit_operation (.*) BitArray{Bool} (b0, b0)
-@check_bit_operation (*) BitArray{Bool} (b0, b0')
+@check_bit_operation (&) BitVector (b0, b0)
+@check_bit_operation (|) BitVector (b0, b0)
+@check_bit_operation ($) BitVector (b0, b0)
+@check_bit_operation (.*) BitVector (b0, b0)
+@check_bit_operation (*) BitMatrix (b0, b0')
 
 timesofar("binary arithmetic")
 
 ## Binary comparison operators ##
 
-b1 = bitrand(TT, n1, n2)
-b2 = bitrand(TT, n1, n2)
-@check_bit_operation (.==) BitArray{Bool} (b1, b2)
-@check_bit_operation (.!=) BitArray{Bool} (b1, b2)
-@check_bit_operation (.<) BitArray{Bool} (b1, b2)
-@check_bit_operation (.<=) BitArray{Bool} (b1, b2)
+b1 = randbool(n1, n2)
+b2 = randbool(n1, n2)
+@check_bit_operation (.==) BitMatrix (b1, b2)
+@check_bit_operation (.!=) BitMatrix (b1, b2)
+@check_bit_operation (.<) BitMatrix (b1, b2)
+@check_bit_operation (.<=) BitMatrix (b1, b2)
 
 timesofar("binary comparison")
 
 ## Data movement ##
 
-b1 = bitrand(TT, s1, s2, s3, s4)
+b1 = randbool(s1, s2, s3, s4)
 for d = 1 : 4
     j = randi(size(b1, d))
     #for j = 1 : size(b1, d)
-        @check_bit_operation slicedim BitArray{TT} (b1, d, j)
+        @check_bit_operation slicedim BitArray{4} (b1, d, j)
     #end
-    @check_bit_operation flipdim BitArray{TT} (b1, d)
+    @check_bit_operation flipdim BitArray{4} (b1, d)
 end
 
-b1 = bitrand(TT, n1, n2)
+b1 = randbool(n1, n2)
 for k = 1 : 4
-    @check_bit_operation rotl90 BitArray{TT} (b1, k)
+    @check_bit_operation rotl90 BitMatrix (b1, k)
 end
 
 for m = 0 : v1
-    b1 = bitrand(TT, m)
-    @check_bit_operation reverse BitArray{TT} (b1,)
+    b1 = randbool(m)
+    @check_bit_operation reverse BitVector (b1,)
 end
 
-b1 = bitrand(TT, v1)
+b1 = randbool(v1)
 for m = [randi(v1)-1 0 1 63 64 65 191 192 193 v1-1]
-    @test isequal(b1 << m, [ b1[m+1:end]; bitzeros(TT, m) ])
-    @test isequal(b1 >>> m, [ bitzeros(TT, m); b1[1:end-m] ])
+    @test isequal(b1 << m, [ b1[m+1:end]; falses(m) ])
+    @test isequal(b1 >>> m, [ falses(m); b1[1:end-m] ])
     @test isequal(rotl(b1, m), [ b1[m+1:end]; b1[1:m] ])
     @test isequal(rotr(b1, m), [ b1[end-m+1:end]; b1[1:end-m] ])
 end
@@ -344,38 +317,52 @@ timesofar("datamove")
 
 ## nnz & find ##
 
-b1 = bitrand(TT, v1)
+b1 = randbool(v1)
 @check_bit_operation nnz Int (b1,)
 
 @check_bit_operation findfirst Int (b1,)
-@check_bit_operation findfirst Int (bitones(TT, v1),)
-@check_bit_operation findfirst Int (bitzeros(TT, v1),)
+@check_bit_operation findfirst Int (trues(v1),)
+@check_bit_operation findfirst Int (falses(v1),)
 
-@check_bit_operation findfirst Int (b1, one(TT))
-@check_bit_operation findfirst Int (b1, zero(TT))
+@check_bit_operation findfirst Int (b1, true)
+@check_bit_operation findfirst Int (b1, false)
 @check_bit_operation findfirst Int (b1, 3)
 
-@check_bit_operation findfirst Int (x->bool(x), b1)
-@check_bit_operation findfirst Int (x->!bool(x), b1)
+@check_bit_operation findfirst Int (x->x, b1)
+@check_bit_operation findfirst Int (x->!x, b1)
 @check_bit_operation findfirst Int (x->true, b1)
 @check_bit_operation findfirst Int (x->false, b1)
 
-@check_bit_operation find Array{Int} (b1,)
+@check_bit_operation find Vector{Int} (b1,)
 
-b1 = bitrand(TT, n1, n2)
-@check_bit_operation findn_nzs (Array{Int}, Array{Int}, BitArray{TT}) (b1,)
+b1 = randbool(n1, n2)
+@check_bit_operation findn_nzs (Vector{Int}, Vector{Int}, BitArray) (b1,)
 
 timesofar("nnz&find")
 
 ## Reductions ##
 
-b1 = bitrand(TT, s1, s2, s3, s4)
-m1 = randi(s1)
-m2 = randi(s3)
-@check_bit_operation max BitArray{TT} (b1, (), (m1, m2))
-@check_bit_operation min BitArray{TT} (b1, (), (m1, m2))
-@check_bit_operation sum Array{Int} (b1, (m1, m2))
-@check_bit_operation prod BitArray{TT} (b1, (m1, m2))
+b1 = randbool(s1, s2, s3, s4)
+m1 = 1
+m2 = 3
+@check_bit_operation max BitArray{4} (b1, (), (m1, m2))
+@check_bit_operation min BitArray{4} (b1, (), (m1, m2))
+#@check_bit_operationV any BitArray{4} (b1, (m1, m2)) # ??? fails
+#@check_bit_operation all BitArray{4} (b1, (m1, m2)) # ??? fails
+@check_bit_operation sum Array{Int,4} (b1, (m1, m2))
+
+@check_bit_operation max Bool (b1,)
+@check_bit_operation min Bool (b1,)
+@check_bit_operation any Bool (b1,)
+@check_bit_operation all Bool (b1,)
+@check_bit_operation sum Int (b1,)
+
+b0 = falses(0)
+@check_bit_operation max Bool (b0,)
+@check_bit_operation min Bool (b0,)
+@check_bit_operation any Bool (b0,)
+@check_bit_operation all Bool (b0,)
+@check_bit_operation sum Int (b0,)
 
 timesofar("reductions")
 
@@ -389,13 +376,13 @@ timesofar("reductions")
 
 ## Transpose ##
 
-b1 = bitrand(TT, v1)
-@check_bit_operation transpose BitArray{TT} (b1,)
+b1 = randbool(v1)
+@check_bit_operation transpose BitMatrix (b1,)
 
 for m1 = 0 : n1
     for m2 = 0 : n2
-        b1 = bitrand(TT, m1, m2)
-        @check_bit_operation transpose BitArray{TT} (b1,)
+        b1 = randbool(m1, m2)
+        @check_bit_operation transpose BitMatrix (b1,)
     end
 end
 
@@ -403,44 +390,41 @@ timesofar("transpose")
 
 ## Permute ##
 
-b1 = bitrand(TT, s1, s2, s3, s4)
+b1 = randbool(s1, s2, s3, s4)
 p = randperm(4)
-@check_bit_operation permute BitArray{TT} (b1, p)
+@check_bit_operation permute BitArray{4} (b1, p)
 
 timesofar("permute")
 
 ## Concatenation ##
 
-b1 = bitrand(TT, v1)
-b2 = bitrand(TT, v1)
-@check_bit_operation hcat BitArray{TT} (b1, b2)
+b1 = randbool(v1)
+b2 = randbool(v1)
+@check_bit_operation hcat BitMatrix (b1, b2)
 for m = 1 : v1 - 1
-    @check_bit_operation vcat BitArray{TT} (b1[1:m], b1[m+1:end])
+    @check_bit_operation vcat BitVector (b1[1:m], b1[m+1:end])
 end
 
-b1 = bitrand(TT, n1, n2)
-b2 = bitrand(TT, n1)
-b3 = bitrand(TT, n1, n2)
-b4 = bitrand(TT, 1, n2)
-@check_bit_operation hcat BitArray{TT} (b1, b2, b3)
-@check_bit_operation vcat BitArray{TT} (b1, b4, b3)
+b1 = randbool(n1, n2)
+b2 = randbool(n1)
+b3 = randbool(n1, n2)
+b4 = randbool(1, n2)
+@check_bit_operation hcat BitMatrix (b1, b2, b3)
+@check_bit_operation vcat BitMatrix (b1, b4, b3)
 
-b1 = bitrand(TT, s1, s2, s3, s4)
-b2 = bitrand(TT, s1, s3, s3, s4)
-b3 = bitrand(TT, s1, s2, s3, s1)
-@check_bit_operation cat BitArray{TT} (2, b1, b2)
-@check_bit_operation cat BitArray{TT} (4, b1, b3)
-@check_bit_operation cat BitArray{TT} (6, b1, b1)
+b1 = randbool(s1, s2, s3, s4)
+b2 = randbool(s1, s3, s3, s4)
+b3 = randbool(s1, s2, s3, s1)
+@check_bit_operation cat BitArray{4} (2, b1, b2)
+@check_bit_operation cat BitArray{4} (4, b1, b3)
+@check_bit_operation cat BitArray{6} (6, b1, b1)
 
-b1 = bitrand(TT, 1, v1, 1)
-@check_bit_operation cat Array{SS} (2, 0, b1, 1, 1, b1)
-@check_bit_operation cat Array{SS} (2, 3, b1, 4, 5, b1)
+b1 = randbool(1, v1, 1)
+@check_bit_operation cat Array{Int,3} (2, 0, b1, 1, 1, b1)
+@check_bit_operation cat Array{Int,3} (2, 3, b1, 4, 5, b1)
+@check_bit_operation cat BitArray{3} (2, false, b1, true, true, b1)
 
-b1 = bitrand(Bool, 1, v1, 1)
-@check_bit_operation cat BitArray{Bool} (2, false, b1, true, true, b1)
-@check_bit_operation cat Array{Int} (2, 3, b1, 4, 5, b1)
-
-b1 = bitrand(TT, n1, n2)
+b1 = randbool(n1, n2)
 for m1 = 1 : n1 - 1
     for m2 = 1 : n2 - 1
         @test isequal([b1[1:m1,1:m2] b1[1:m1,m2+1:end]; b1[m1+1:end,1:m2] b1[m1+1:end,m2+1:end]], b1)
@@ -451,21 +435,19 @@ timesofar("cat")
 
 # Linear algebra
 
-b1 = bitrand(TT, v1)
-b2 = bitrand(TT, v1)
-@check_bit_operation dot typeof(one(TT) * one(TT)) (b1, b2)
-b2 = bitrand(Bool, v1)
-@check_bit_operation dot typeof(one(TT) * true) (b1, b2)
+b1 = randbool(v1)
+b2 = randbool(v1)
+@check_bit_operation dot Int (b1, b2)
 
-b1 = bitrand(TT, n1, n2)
+b1 = randbool(n1, n2)
 for k = -max(n1,n2) : max(n1,n2)
-    @check_bit_operation tril BitArray{TT} (b1, k)
-    @check_bit_operation triu BitArray{TT} (b1, k)
+    @check_bit_operation tril BitMatrix (b1, k)
+    @check_bit_operation triu BitMatrix (b1, k)
 end
 
-#b1 = bitrand(TT, v1)
-#@check_bit_operation diff Array{SS} (b1,)
-#b1 = bitrand(TT, n1, n2)
-#@check_bit_operation diff Array{SS} (b1,)
+#b1 = randbool(v1)
+#@check_bit_operation diff Vector{Int} (b1,)
+#b1 = randbool(n1, n2)
+#@check_bit_operation diff Vector{Int} (b1,)
 
 timesofar("linalg")


### PR DESCRIPTION
This would close #1660, if it wasn't close already... (I didn't notice).
Anyway, this is a version in which BitArrays no longer have the type parameter, and they just hold Bools.
I also renamed them to `BoolArray` (it's of course easy to change it back); there are still a couple of functions using the prefix `bit-` though: `bitpack` and `bitunpack`.
I did a bit of clean-up as well (more is still needed) and fixed a couple of issues.
I was wondering if it makes sense to keep linalg_boolarray at all, it probably could be just removed.
