### PR TITLE
Attempt avx compilation for fftw

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -584,6 +584,7 @@ fftw-$(FFTW_VER)-single/configure: fftw-$(FFTW_VER).tar.gz
 	touch $@
 fftw-$(FFTW_VER)-single/config.status: fftw-$(FFTW_VER)-single/configure
 	cd fftw-$(FFTW_VER)-single && \
+	./configure --prefix=$(abspath $(USR)) $(FFTW_CONFIG) --enable-avx --enable-single CC="$(CC)" CXX="$(CXX)" || \
 	./configure --prefix=$(abspath $(USR)) $(FFTW_CONFIG) --enable-single CC="$(CC)" CXX="$(CXX)" && \
 	$(MAKE) clean
 	touch $@
@@ -609,6 +610,7 @@ fftw-$(FFTW_VER)-double/configure: fftw-$(FFTW_VER).tar.gz
 	touch $@
 fftw-$(FFTW_VER)-double/config.status: fftw-$(FFTW_VER)-double/configure
 	cd fftw-$(FFTW_VER)-double && \
+	./configure --prefix=$(abspath $(USR)) $(FFTW_CONFIG) --enable-avx CC="$(CC)" CXX="$(CXX)" || \
 	./configure --prefix=$(abspath $(USR)) $(FFTW_CONFIG) CC="$(CC)" CXX="$(CXX)" && \
 	$(MAKE) clean
 	touch $@


### PR DESCRIPTION
Enables compilation of FFTW with AVX instructions enabled.  Works on both AVX-capable and non-AVX-capable platforms.  Closes #1710
