### PR TITLE
force linking of Julia binary during successive installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ install: release
 		mkdir -p $(PREFIX)/$$subdir ; \
 	done
 	cp $(BUILD)/bin/*julia* $(PREFIX)/bin
-	cd $(PREFIX)/bin && ln -s julia-release-$(DEFAULT_REPL) julia
+	cd $(PREFIX)/bin && ln -sf julia-release-$(DEFAULT_REPL) julia
 	-for suffix in $(JL_LIBS) ; do \
 		cp -a $(BUILD)/lib/lib$${suffix}.* $(PREFIX)/$(JL_PRIVATE_LIBDIR) ; \
 	done


### PR DESCRIPTION
Very small change to the Makefile.  Without forcing the "make install" process to link the Julia binary, it fails on my Fedora 17 system with the complaint, "Symbolic link already exists."

--Rob
