### PR TITLE
Put platform defines around read_sonames() and jl_lookup_soname()

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -3,6 +3,7 @@
 // --- library symbol lookup ---
 
 // map from "libX" to full soname "libX.so.ver"
+#if !defined(__APPLE__) && !defined(_WIN32)
 static std::map<std::string, std::string> sonameMap;
 static bool got_sonames = false;
 
@@ -46,6 +47,7 @@ extern "C" const char *jl_lookup_soname(char *pfx, size_t n)
     }
     return NULL;
 }
+#endifs
 
 // map from user-specified lib names to handles
 static std::map<std::string, void*> libMap;

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -31,7 +31,9 @@ static char *extensions[] = { ".so", "" };
 
 extern char *julia_home;
 
+#if !defined(__APPLE__) && !defined(_WIN32)
 char *jl_lookup_soname(char *pfx, size_t n);
+#endif
 
 int jl_uv_dlopen(const char* filename, uv_lib_t* lib)
 {


### PR DESCRIPTION
Hopefully closes #1722 (can't test, don't have that old of a mac).  Also, it looks like travis is experiencing an outage right now.  Perhaps the travis build will eventually pass, until then we'll have to revert to manually testing.  (Passed on OSX 10.8 and Ubuntu 12.04, but this error wasn't reported on either of those platforms, it was reported on OSX 10.6)
