### PR TITLE
Add pop and isless to sets

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -35,6 +35,8 @@ done(s::Set, state) = done(s.hash, state)
 # NOTE: manually optimized to take advantage of Dict representation
 next(s::Set, i)     = (s.hash.keys[i], skip_deleted(s.hash,i+1))
 
+pop(s::Set) = (val = s.hash.keys[start(s.hash)]; del(s.hash, val); val)
+
 union() = Set()
 union(s::Set) = copy(s)
 function union(s::Set, sets::Set...)
@@ -82,5 +84,7 @@ end
 -(a::Set, b::Set) = setdiff(a,b)
 
 isequal(l::Set, r::Set) = length(l) == length(r) == length(intersect(l,r))
+isless(l::Set, r::Set) = (length(l) < length(r)) && ((l&r) == l)
+<=(l::Set, r::Set) = isless(l,r) || isequal(l,r)
 
 unique(C) = elements(add_each(Set{eltype(C)}(), C))

--- a/test/corelib.jl
+++ b/test/corelib.jl
@@ -193,6 +193,21 @@ d4[1001] = randstring(3)
 @test !isempty(Set("banana", "apple"))
 @test !isempty(Set(1, 1:10, "pear"))
 
+# isless
+@test isless(Set(), Set(1))
+@test isless(Set(1), Set(1,2))
+@test !isless(Set(3), Set(1,2))
+@test !(Set(3) > Set(1,2))
+@test Set(1,2,3) > Set(1,2)
+@test !(Set(3) <= Set(1,2))
+@test !(Set(3) >= Set(1,2))
+@test Set(1) <= Set(1,2)
+@test Set(1,2) <= Set(1,2)
+@test Set(1,2) >= Set(1,2)
+@test Set(1,2,3) >= Set(1,2)
+@test !(Set(1,2,3) >= Set(1,2,4))
+@test !(Set(1,2,3) <= Set(1,2,4))
+
 # add, length
 s = Set()
 @test isempty(s)
@@ -323,6 +338,15 @@ for data_in in ((7,8,4,5),
     end
 end
 
+# pop
+origs = Set(1,2,3,"apple")
+s = copy(origs)
+for i in 1:numel(origs)
+    el = pop(s)
+    @test !has(s, el)
+    @test has(origs, el)
+end
+@test isempty(s)
 # isequal
 @test  isequal(Set(), Set())
 @test !isequal(Set(), Set(1))


### PR DESCRIPTION
Tests also added in test/corelib.jl.

Short example:

``` julia
origs = Set(1,2,3)
s = copy(origs)
el = pop(s)
# has(s, el) == false
# has(origs, el) == true
# s < origs == true
# s <= origs == true
# s > origs == false
```
