### PR TITLE
Fill the array passed into IOString's read in addition to returning it

### DIFF
--- a/extras/iostring.jl
+++ b/extras/iostring.jl
@@ -22,7 +22,8 @@ function read{T}(from::IOString, a::Array{T})
             throw(EOFError())
         end
         from.ptr += nb
-        return reshape(reinterpret(T, from.data[from.ptr-nb:from.ptr-1]), size(a))
+        a[:] = reshape(reinterpret(T, from.data[from.ptr-nb:from.ptr-1]), size(a))
+        return a
     else
         error("Read from IOString only supports bits types or arrays of bits types; got $T.")
     end


### PR DESCRIPTION
When reading an array from an IOStream, the array passed into the function is filled with the data. Doing the same from an IOStream returns a new array, but leaves the passed in one untouched.

Note: this could probably be made optimized to not create a temporary array. But, this patch at least corrects the method behavior.
