### PR TITLE
RFC: Fix pkg.clone()

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -235,23 +235,13 @@ resolve() = cd(_resolve,julia_pkgdir())
 
 # clone a new package repo from a URL
 
-# TODO: this is horribly broken
-function clone(url::String)
-    dir = julia_pkgdir()
-    if isdir(dir)
-        error("Package directory $dir already exists.")
-    end
-    tmpdir = mktempdir()
-    run(`git clone $url $tmpdir`)
-    cd(tmpdir) do
-        gitdir = abs_path(readchomp(`git rev-parse --git-dir`))
-        Git.each_submodule(false) do name, path, sha1
-            cd(path) do
-                run(`git fetch-pack $gitdir $sha1`)
-            end
+function clone(url::String, pkgname::String)
+    cd_pkgdir() do
+        if isdir(pkgname)
+            error("Package directory $dir already exists.")
         end
+        run(`git submodule add $url $pkgname`)
     end
-    run(`mv $tmpdir $dir`)
 end
 
 # record all submodule commits as tags


### PR DESCRIPTION
Creating a new package is not yet as simple as we'd like. The "recipe" I wrote here:
https://github.com/JuliaLang/METADATA.jl#recipe-for-packaging-an-existing-repository
doesn't quite work (see https://github.com/JuliaLang/METADATA.jl/commit/b46f059c84c579fd3805f34be903b7a10586b1b7#commitcomment-2297864). It turns out the reason is that it's not registered as a submodule, and that in `_resolve()` the directory was not being included in the call to `Git.each_submodule`. 

To me it seems that the cleanest path forward is through `Pkg.clone()`. A comment in `pkg.jl` indicates that it is currently broken, so I took a stab at fixing it. I am no git wizard, so I'm sure I've made some mistakes here, hence the RFC. But for me it seemed to work. The two key steps were to add a second input argument (previously it was trying to clone into `.julia`, which causes an error) and to use `git submodule add`.
