### PR TITLE
insert for dict

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -425,6 +425,8 @@ end
 
 has(h::Dict, key) = (ht_keyindex(h, key) >= 0)
 
+insert{K,V}(h::Dict{K,V}, key, val) = h[key] = val
+
 function key{K,V}(h::Dict{K,V}, key, deflt)
     index = ht_keyindex(h, key)
     return (index<0) ? deflt : h.keys[index]::K


### PR DESCRIPTION
If this was omitted by design (say, with the hope of minimizing the number of ways to do the same thing) then it's no big deal.

I find it convenient and intuitive, however, so I'm advocating for its inclusion in the hopes that it was merely overlooked.
