### PR TITLE
RFC: Add metaprogramming module Base.Meta

### DIFF
--- a/base/export.jl
+++ b/base/export.jl
@@ -10,6 +10,7 @@ export
     LibRandom,
     RNG,
     Math,
+    Meta,
     
 # Types
     AbstractMatrix,

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -1,0 +1,47 @@
+module Meta
+#
+# convenience functions for metaprogramming
+#
+
+export quot, 
+       isexpr, 
+       show_sexpr
+
+quot(ex) = expr(:quote, {ex})
+
+isexpr(ex::Expr, head)          = ex.head === head
+isexpr(ex::Expr, heads::Set)    = has(heads,      ex.head)
+isexpr(ex::Expr, heads::Vector) = contains(heads, ex.head)
+isexpr(ex,       head)          = false
+
+isexpr(ex,       head, n::Int)  = isexpr(ex, head) && length(ex.args) == n
+
+
+# ---- show_sexpr: print an AST as an S-expression ----
+
+show_sexpr(ex) = show_sexpr(OUTPUT_STREAM, ex)
+show_sexpr(io::IO, ex) = show_sexpr(io, ex, 0)
+show_sexpr(io::IO, ex, indent::Int) = show(io, ex)
+
+const sexpr_indent_width = 2
+
+function show_sexpr(io::IO, ex::QuoteNode, indent::Int)
+    inner = indent + sexpr_indent_width
+    print(io, "(:quote, #QuoteNode\n", " "^inner)
+    show_sexpr(io, ex.value, inner)
+    print(io, '\n', " "^indent, ')')
+end
+function show_sexpr(io::IO, ex::Expr, indent::Int)
+    inner = indent + sexpr_indent_width
+    print(io, '(')
+    show_sexpr(io, ex.head, inner)
+    for arg in ex.args
+        print(io, ex.head === :block ? ",\n"*" "^inner : ", ")
+        show_sexpr(io, arg, inner)
+    end
+    if length(ex.args) == 0; print(io, ",)")
+    else print(io, (ex.head === :block ? "\n"*" "^indent : ""), ')')
+    end
+end
+
+end # module

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -127,11 +127,12 @@ include("combinatorics.jl")
 include("darray2.jl")
 include("mmap.jl")
 
-# utilities - version, timing, help, edit
+# utilities - version, timing, help, edit, metaprogramming
 include("version.jl")
 include("util.jl")
 include("datafmt.jl")
 include("deepcopy.jl")
+include("meta.jl")
 
 # linear algebra
 include("build_h.jl")


### PR DESCRIPTION
As per #1576.
I thought that the best way to come forward on this would be to create this pull request with some metaprogramming tools that I find essential myself. Then people can critique it. Once there's a module in `Base`, others can create pull requests with their favorite tools, and we can critique those. So critique away!

Right now, the module contains `quot`, an extended `isexpr` that can check if a node is an `Expr` with head that belongs to a given set (see the code for what those mean), and my [lispy AST printer](https://gist.github.com/4121122), slightly touched up. I find that the lispy printer has largely replaced my `ex.args[2].args[1].head` etc. exploration.
