### PR TITLE
Extend @show: allow multiple args, return value of last

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -11,8 +11,10 @@ showcompact(x)     = showcompact(OUTPUT_STREAM::IOStream, x)
 macro show(exs...)
     blk = expr(:block)
     for ex in exs
-        push(blk.args, :(println($(sprint(show_unquoted,ex)*" => "),repr($(esc(ex))))))
+        push(blk.args, :(println($(sprint(show_unquoted,ex)*" => "),
+                                 repr(begin value=$(esc(ex)) end))))
     end
+    if !isempty(exs); push(blk.args, :value); end
     return blk
 end
 


### PR DESCRIPTION
This patch extends the `@show` macro in two ways, to make it more handy in debugging:
- Multiple arguments are allowed, e.g.
  
  ```
  x, y = 3, 4
  @show x y
  ```
  
  prints
  
  ```
  x   = 3
  y   = 4
  ```
- The value of `@show` is the value of it's last argument. Using this, `@show` can be inserted pretty much anywhere in an expression to produce a printout, e.g.
  
  ```
  f(args...) = some_computation_based_on_args
  ```
  
  can be rewritten to print out its return value like
  
  ```
  f(args...) = @show some_computation_based_on_args
  ```
  
  instead of
  
  ```
  function f(args...)
      result = some_computation_based_on_args
      @show result
      result
  end
  ```

I haven't come up with a case where it makes much sense to use both features at the same time. If anyone thinks that the value of `@show` with several arguments should be something else, please let me know.
