### PR TITLE
RFC: Add @get!

### DIFF
--- a/base/export.jl
+++ b/base/export.jl
@@ -1294,6 +1294,7 @@ export
     unsetenv,
     
 # Macros
+    @get!,
     @v_str,
     @unexpected,
     @assert,

--- a/test/corelib.jl
+++ b/test/corelib.jl
@@ -181,6 +181,17 @@ d4[1001] = randstring(3)
 @test !isequal({1 => 2}, {"dog" => "bone"})
 @test isequal(Dict{Int, Int}(), Dict{String, String}())
 
+#@get!
+let
+    d = {8=>19}
+    def = {}
+    f = x->(push(def,x); x)
+    @test @get!(d,  8, f(5)) == 19
+    @test @get!(d, 19, f(2)) == 2
+    @test d == {8=>19, 19=>2}
+    @test def == [2]
+end
+
 # ############# end of dict tests #############
 
 # #################### set ####################


### PR DESCRIPTION
As per [this discussion.](https://groups.google.com/d/topic/julia-dev/PdLI60AnKac/discussion) 
Already, `get(d::Associative, key, default)` returns the value at `key` if one exists, or `default` otherwise.

This patch adds `get!`, `@get`, and `@get!`:
- `get!` and `@get!` assign `default` to `d[key]` if it's not present.  
  They return `d[key]` (i.e. the converted value).
- `@get` and `@get!` evaluate `default` only if `key` is missing.

Thoughts? I think that at least `@get!` would provide a useful addition to `Base`.

**Edit:** I removed everything but `@get!` (and made it avoid the extra lookup when applied to a `Dict`)
