### PR TITLE
Some patches currently applied to the Debian package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ clean: | $(CLEAN_TARGETS)
 			rm -f julia-$${buildtype}-$${repltype}; \
 		done \
 	done
+	@rm -f julia
 	@rm -f *~ *# *.tar.gz
 	@rm -fr $(BUILD)/$(JL_PRIVATE_LIBDIR)
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -330,7 +330,7 @@ distclean-pcre:
 
 ## Grisu floating-point printing library ##
 
-GRISU_OPTS = -O3 -fvisibility=hidden $(fPIC)
+GRISU_OPTS = $(CXXFLAGS) -O3 -fvisibility=hidden $(fPIC)
 
 compile-double-conversion: double-conversion-$(GRISU_VER)/src/libgrisu_.$(SHLIB_EXT)
 install-double-conversion: $(BUILD)/lib/libgrisu.$(SHLIB_EXT)
@@ -352,7 +352,7 @@ double-conversion-$(GRISU_VER)/src/libgrisu.$(SHLIB_EXT): double-conversion-$(GR
 	$(CXX) -c $(GRISU_OPTS) -o src/fixed-dtoa.o -Isrc src/fixed-dtoa.cc && \
 	$(CXX) -c $(GRISU_OPTS) -o src/strtod.o -Isrc src/strtod.cc && \
 	$(CXX) -c $(GRISU_OPTS) -o src/libdouble-conversion.o -I.. -Isrc ../double_conversion_wrapper.cpp && \
-	$(CXX) $(GRISU_OPTS) src/*.o -shared -dead_strip -o src/libgrisu.$(SHLIB_EXT)
+	$(CXX) $(GRISU_OPTS) src/*.o $(LDFLAGS) -shared -dead_strip -o src/libgrisu.$(SHLIB_EXT)
 $(BUILD)/lib/libgrisu.$(SHLIB_EXT): double-conversion-$(GRISU_VER)/src/libgrisu.$(SHLIB_EXT)
 	cp -f $< $@
 	$(INSTALL_NAME_CMD)libgrisu.dylib $@
@@ -435,7 +435,7 @@ random/jl_random.c: random/dsfmt-$(DSFMT_VER).tar.gz
 	touch $@
 $(LIBRANDOM_OBJ_SOURCE): random/jl_random.c random/randmtzig.c
 	cd random && \
-	$(CC) $(LIBRANDOM_CFLAGS) jl_random.c -o librandom.$(SHLIB_EXT) && \
+	$(CC) $(CPPFLAGS) $(LIBRANDOM_CFLAGS) $(LDFLAGS) jl_random.c -o librandom.$(SHLIB_EXT) && \
 	$(INSTALL_NAME_CMD)librandom.$(SHLIB_EXT) librandom.$(SHLIB_EXT)
 
 $(LIBRANDOM_OBJ_TARGET): $(LIBRANDOM_OBJ_SOURCE)
@@ -702,7 +702,7 @@ SUITESPARSE_LIB = -L$(BUILD)/lib -lcholmod -lumfpack -lspqr $(RPATH_ORIGIN)
 endif
 
 $(BUILD)/lib/libsuitesparse_wrapper.$(SHLIB_EXT): SuiteSparse_wrapper.c $(SUITESPARSE_OBJ_TARGET)
-	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(SUITESPARSE_INC) SuiteSparse_wrapper.c -o $(BUILD)/lib/libsuitesparse_wrapper.$(SHLIB_EXT) $(SUITESPARSE_LIB)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(SUITESPARSE_INC) SuiteSparse_wrapper.c -o $(BUILD)/lib/libsuitesparse_wrapper.$(SHLIB_EXT) $(SUITESPARSE_LIB)
 	$(INSTALL_NAME_CMD)libsuitesparse_wrapper.$(SHLIB_EXT) $@
 	touch $@
 install-suitesparse-wrapper: $(BUILD)/lib/libsuitesparse_wrapper.$(SHLIB_EXT)
@@ -849,7 +849,7 @@ GMPW_LIB = -L$(BUILD)/lib/ -lgmp
 endif
 
 $(BUILD)/lib/libgmp_wrapper.$(SHLIB_EXT): gmp_wrapper.c $(GMP_OBJ_TARGET) | $(BUILD)/lib
-	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GMPW_INC) gmp_wrapper.c -o $(BUILD)/lib/libgmp_wrapper.$(SHLIB_EXT) $(RPATH_ORIGIN) $(GMPW_LIB)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GMPW_INC) gmp_wrapper.c -o $(BUILD)/lib/libgmp_wrapper.$(SHLIB_EXT) $(RPATH_ORIGIN) $(GMPW_LIB)
 	$(INSTALL_NAME_CMD)libgmp_wrapper.$(SHLIB_EXT) $@
 	touch $@
 install-gmp-wrapper: $(BUILD)/lib/libgmp_wrapper.$(SHLIB_EXT)
@@ -902,7 +902,7 @@ endif
 
 
 $(BUILD)/lib/libglpk_wrapper.$(SHLIB_EXT): glpk_wrapper.c $(GLPK_OBJ_TARGET)
-	$(CC) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GLPKW_INC) glpk_wrapper.c $(GLPKW_LIB) -o $(BUILD)/lib/libglpk_wrapper.$(SHLIB_EXT) $(RPATH_ORIGIN)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(GLPKW_INC) glpk_wrapper.c $(GLPKW_LIB) -o $(BUILD)/lib/libglpk_wrapper.$(SHLIB_EXT) $(RPATH_ORIGIN)
 	$(INSTALL_NAME_CMD)libglpk_wrapper.$(SHLIB_EXT) $@
 	touch $@
 install-glpk-wrapper: $(BUILD)/lib/libglpk_wrapper.$(SHLIB_EXT) glpk_wrapper.c

--- a/deps/Rmath/src/Makefile
+++ b/deps/Rmath/src/Makefile
@@ -34,15 +34,15 @@ endif
 default: release
 
 %.o: %.c
-	$(QUIET_CC) $(CC) $(fPIC) -std=gnu99 -I../include -DMATHLIB_STANDALONE -DNDEBUG -O3 -c $< -o $@
+	$(QUIET_CC) $(CC) $(CPPFLAGS) $(CFLAGS) $(fPIC) -std=gnu99 -I../include -DMATHLIB_STANDALONE -DNDEBUG -O3 -c $< -o $@
 %.do: %.c
-	$(QUIET_CC) $(CC) $(fPIC) -std=gnu99 -I../include -DMATHLIB_STANDALONE -g  -c $< -o $@
+	$(QUIET_CC) $(CC) $(CPPFLAGS) $(CFLAGS) $(fPIC) -std=gnu99 -I../include -DMATHLIB_STANDALONE -g  -c $< -o $@
 
 release debug: libRmath.$(SHLIB_EXT)
 
 libRmath.$(SHLIB_EXT): $(XOBJS)
 	rm -rf $@
-	$(QUIET_LINK) $(CC) -shared -o $@ $^ -L$(BUILD)/lib -lrandom $(RPATH_ORIGIN)
+	$(QUIET_LINK) $(CC) $(LDFLAGS) -shared -o $@ $^ -L$(BUILD)/lib -lrandom $(RPATH_ORIGIN)
 
 clean:
 	rm -f *.o *.do *.a *.$(SHLIB_EXT) core* *~ *#

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -46,6 +46,7 @@ help:
 
 clean:
 	-rm -rf $(BUILDDIR)/*
+	-rm -f sphinx/*.pyc
 
 clean-jquery:
 	-rm -f $(JQUERYDEST)

--- a/extras/Makefile
+++ b/extras/Makefile
@@ -20,4 +20,4 @@ webrepl_msgtypes_h.jl: ../ui/webserver/message_types.h
 	$(QUIET_PERL) $(CC) -E -Dnotdefined $^ > $@
 
 clean:
-	rm -f glpk_h.jl julia_message_types_h.jl
+	rm -f glpk_h.jl webrepl_msgtypes_h.jl

--- a/src/Makefile
+++ b/src/Makefile
@@ -43,13 +43,13 @@ release debug: %: libjulia-%
 HEADERS = julia.h $(wildcard support/*.h) $(JULIAHOME)/deps/libuv/include/uv.h
 
 %.o: %.c $(HEADERS)
-	$(QUIET_CC) $(CC) $(CFLAGS) $(SHIPFLAGS) -c $< -o $@
+	$(QUIET_CC) $(CC) $(CPPFLAGS) $(CFLAGS) $(SHIPFLAGS) -c $< -o $@
 %.do: %.c $(HEADERS)
-	$(QUIET_CC) $(CC) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@
+	$(QUIET_CC) $(CC) $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@
 %.o: %.cpp $(HEADERS)
-	$(QUIET_CC) $(CXX) $(CXXFLAGS) $(SHIPFLAGS) $(shell $(LLVM_CONFIG) --cppflags) -c $< -o $@
+	$(QUIET_CC) $(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SHIPFLAGS) $(shell $(LLVM_CONFIG) --cppflags) -c $< -o $@
 %.do: %.cpp $(HEADERS)
-	$(QUIET_CC) $(CXX) $(CXXFLAGS) $(DEBUGFLAGS) $(shell $(LLVM_CONFIG) --cppflags) -c $< -o $@
+	$(QUIET_CC) $(CXX) $(CPPFLAGS) $(CXXFLAGS) $(DEBUGFLAGS) $(shell $(LLVM_CONFIG) --cppflags) -c $< -o $@
 
 ast.o ast.do: julia_flisp.boot.inc flisp/*.h
 

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -33,9 +33,9 @@ debug: $(EXENAME)-debug
 HEADERS = $(wildcard *.h) $(JULIAHOME)/deps/libuv/include/uv.h
 
 %.o: %.c $(HEADERS)
-	$(QUIET_CC) $(CC) $(SHIPFLAGS) -c $< -o $@
+	$(QUIET_CC) $(CC) $(CPPFLAGS) $(SHIPFLAGS) -c $< -o $@
 %.do: %.c $(HEADERS)
-	$(QUIET_CC) $(CC) $(DEBUGFLAGS) -c $< -o $@
+	$(QUIET_CC) $(CC) $(CPPFLAGS) $(DEBUGFLAGS) -c $< -o $@
 
 flisp.o:   flisp.c cvalues.c types.c flisp.h print.c read.c equal.c
 flisp.do:  flisp.c cvalues.c types.c flisp.h print.c read.c equal.c
@@ -59,7 +59,7 @@ $(EXENAME)-debug: $(DOBJS) $(LIBFILES) $(LIBTARGET)-debug.a flmain.do
 	./$(EXENAME)-debug unittest.lsp
 
 $(EXENAME): $(OBJS) $(LIBFILES) $(LIBTARGET).a flmain.o
-	$(QUIET_CC) $(CC) $(SHIPFLAGS) $(OBJS) flmain.o -o $(EXENAME) $(LIBS) $(LIBTARGET).a $(OSLIBS)
+	$(QUIET_CC) $(CC) $(SHIPFLAGS) $(OBJS) flmain.o $(LDFLAGS) -o $(EXENAME) $(LIBS) $(LIBTARGET).a $(OSLIBS)
 	./$(EXENAME) unittest.lsp
 
 clean:

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -31,9 +31,9 @@ default: release
 HEADERS = $(wildcard *.h) $(JULIAHOME)/deps/libuv/include/uv.h
 
 %.o: %.c $(HEADERS)
-	$(QUIET_CC) $(CC) $(SHIPFLAGS) -c $< -o $@
+	$(QUIET_CC) $(CC) $(CPPFLAGS) $(SHIPFLAGS) -c $< -o $@
 %.do: %.c $(HEADERS)
-	$(QUIET_CC) $(CC) $(DEBUGFLAGS) -c $< -o $@
+	$(QUIET_CC) $(CC) $(CPPFLAGS) $(DEBUGFLAGS) -c $< -o $@
 
 release debug: libsupport.a
 

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -17,9 +17,9 @@ release debug:
 	$(MAKE) julia-$@
 
 %.o: %.c repl.h
-	$(QUIET_CC) $(CC) $(CFLAGS) $(SHIPFLAGS) -c $< -o $@
+	$(QUIET_CC) $(CC) $(CPPFLAGS) $(CFLAGS) $(SHIPFLAGS) -c $< -o $@
 %.do: %.c repl.h
-	$(QUIET_CC) $(CC) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@
+	$(QUIET_CC) $(CC) $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@
 
 julia-release-basic: $(BUILD)/bin/julia-release-basic
 julia-debug-basic: $(BUILD)/bin/julia-debug-basic

--- a/ui/webserver/Makefile
+++ b/ui/webserver/Makefile
@@ -16,9 +16,9 @@ endif
 WEBSERVER_SRCS = webserver.cpp server.cpp jsoncpp.cpp
 
 %.o: %.c
-	$(QUIET_CC)$(CC) $(CFLAGS) $(SHIPFLAGS) -c $< -o $@
+	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) $(SHIPFLAGS) -c $< -o $@
 %.do: %.c
-	$(QUIET_CC)$(CC) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@
+	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@
 
 	
 LAUNCH_SCRIPT = launch-julia-webserver
@@ -32,10 +32,10 @@ release debug:
 	$(MAKE) julia-$@
 
 $(BUILD)/bin/julia-release-webserver: $(WEBSERVER_SRCS)
-	$(QUIET_LINK) $(CXX) $(CXXFLAGS) -o $@ $(SHIPFLAGS) $(WEBSERVER_SRCS) $(LIBS)
+	$(QUIET_LINK) $(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $(SHIPFLAGS) $(LDFLAGS) $(WEBSERVER_SRCS) $(LIBS)
 
 $(BUILD)/bin/julia-debug-webserver: $(WEBSERVER_SRCS)
-	$(QUIET_LINK) $(CXX) $(CXXFLAGS) -o $@ $(DEBUGFLAGS) $(WEBSERVER_SRCS) $(LIBS)
+	$(QUIET_LINK) $(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $(DEBUGFLAGS) $(LDFLAGS) $(WEBSERVER_SRCS) $(LIBS)
 	
 $(BUILD)/bin/$(LAUNCH_SCRIPT): $(LAUNCH_SCRIPT)
 	cp $< $@


### PR DESCRIPTION
Injecting CPPFLAGS/CFLAGS/CXXFLAGS/LDFLAGS everywhere is important for Debian, in order to enable hardening (see http://wiki.debian.org/Hardening )
