### PR TITLE
Fix search_sorted_*r and search_sorted_*by

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -376,7 +376,7 @@ function ($search_sorted_last)($(args...), a::Vector, x, lo::Int, hi::Int)
     hi = hi+1
     while lo < hi-1
         i = (lo+hi)>>>1
-        if isless(x,a[i])
+        if $(lt(:(x), :(a[i])))
             hi = i
         else
             lo = i
@@ -396,7 +396,7 @@ function ($search_sorted_first)($(args...), a::Vector, x, lo::Int, hi::Int)
     hi = hi+1
     while lo < hi-1
         i = (lo+hi)>>>1
-        if isless(a[i],x)
+        if $(lt(:(a[i]), :(x)))
             lo = i
         else
             hi = i


### PR DESCRIPTION
`search_sorted_r` and `search_sorted_by` and their variants were introduced by #1691. At the moment, these functions do the same thing as `search_sorted` (`search_sorted_by` takes another argument, but this argument is ignored). This is presumably because the `isless` call needs to be turned into an expression using `lt`.

With this patch, the `_r` variants of these functions become a little confusing. `search_sorted_first_r` finds the index of the last value of a reverse-sorted vector >= x (rather than the first), and `search_sorted_last_r` finds the index of the first value of a reverse-sorted vector <= x (rather than the last). Maybe we should swap or change the names (or get rid of these variants entirely).
