### PR TITLE
Fix segfault in REPL tab completion on OSX

### DIFF
--- a/ui/repl-readline.c
+++ b/ui/repl-readline.c
@@ -430,23 +430,26 @@ static int symtab_get_matches(jl_sym_t *tree, const char *str, char **answer)
         name = t;
     }
 
-    plen = strlen(name);
-
-    while (tree != NULL) {
-        x = common_prefix(name, tree->name);
-        if (x == plen) {
-            ios_mem(&ans, 0);
-            symtab_search(tree, &count, &ans, module, str, name, plen);
-            size_t nb;
-            *answer = ios_takebuf(&ans, &nb);
-            break;
-        }
-        else {
-            x = strcmp(name, tree->name);
-            if (x < 0)
-                tree = tree->left;
-            else
-                tree = tree->right;
+    if (name)
+    {
+        plen = strlen(name);
+    
+        while (tree != NULL) {
+            x = common_prefix(name, tree->name);
+            if (x == plen) {
+                ios_mem(&ans, 0);
+                symtab_search(tree, &count, &ans, module, str, name, plen);
+                size_t nb;
+                *answer = ios_takebuf(&ans, &nb);
+                break;
+            }
+            else {
+                x = strcmp(name, tree->name);
+                if (x < 0)
+                    tree = tree->left;
+                else
+                    tree = tree->right;
+            }
         }
     }
 


### PR DESCRIPTION
On OSX, hitting TAB after having entered `sum(` would result in a
segmentation fault. (Curiously, on linux this would not cause any
problems).

Adding a check for name!=NULL in repl-readline.c fixed the problem.
