### PR TITLE
Add search_sorted* for ranges

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -376,7 +376,7 @@ function ($search_sorted_last)($(args...), a::Vector, x, lo::Int, hi::Int)
     hi = hi+1
     while lo < hi-1
         i = (lo+hi)>>>1
-        if isless(x,a[i])
+        if $(lt(:(x), :(a[i])))
             hi = i
         else
             lo = i
@@ -396,7 +396,7 @@ function ($search_sorted_first)($(args...), a::Vector, x, lo::Int, hi::Int)
     hi = hi+1
     while lo < hi-1
         i = (lo+hi)>>>1
-        if isless(a[i],x)
+        if $(lt(:(a[i]), :(x)))
             lo = i
         else
             hi = i

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -410,6 +410,20 @@ end
 
 end; end # @eval / for
 
+search_sorted_last_r{T <: Real}(a::Union(Range{T}, Range1{T}), x::Real) = search_sorted_last(a, x)
+search_sorted_first_r{T <: Real}(a::Union(Range{T}, Range1{T}), x::Real) = search_sorted_first(a, x)
+search_sorted_r{T <: Real}(a::Union(Range{T}, Range1{T}), x::Real) = search_sorted(a, x)
+search_sorted{T <: Real}(a::Union(Range{T}, Range1{T}), x::Real) = search_sorted_first(a, x)
+
+search_sorted_last{T <: Real}(a::Union(Range{T}, Range1{T}), x::Real) =
+    max(min(int(fld(x - a[1], step(a))) + 1, length(a)), 0)
+
+function search_sorted_first{T <: Real}(a::Union(Range{T}, Range1{T}), x::Real)
+    n = x - a[1]
+    s = step(a)
+    max(min(int(fld(n, s)) + (rem(n, s) != 0), length(a)), 0) + 1
+end
+
 ## external sorting functions ##
 
 sort!{T<:Real}(a::AbstractVector{T})  = quicksort!(a, 1, length(a))

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -19,6 +19,31 @@
 @test search_sorted_last([1, 1, 2, 2, 3, 3], 4) == 6
 @test search_sorted_last([1.0, 1, 2, 2, 3, 3], 2.5) == 4
 
+rg = 49:57; rgv = [rg]
+rg_r = 57:-1:49; rgv_r = [rg_r]
+for i = 47:59
+    @test search_sorted_first(rg, i) == search_sorted_first(rgv, i)
+    @test search_sorted_last(rg, i) == search_sorted_last(rgv, i)
+    @test search_sorted_first_r(rg_r, i) == search_sorted_first_r(rgv_r, i)
+    @test search_sorted_last_r(rg_r, i) == search_sorted_last_r(rgv_r, i)
+end
+rg = 1:2:17; rgv = [rg]
+rg_r = 17:-2:1; rgv_r = [rg_r]
+for i = -1:19
+    @test search_sorted_first(rg, i) == search_sorted_first(rgv, i)
+    @test search_sorted_last(rg, i) == search_sorted_last(rgv, i)
+    @test search_sorted_first_r(rg_r, i) == search_sorted_first_r(rgv_r, i)
+    @test search_sorted_last_r(rg_r, i) == search_sorted_last_r(rgv_r, i)
+end
+rg = -3:0.5:2; rgv = [rg]
+rg_r = 2:-0.5:-3; rgv_r = [rg_r]
+for i = -5:.5:4
+    @test search_sorted_first(rg, i) == search_sorted_first(rgv, i)
+    @test search_sorted_last(rg, i) == search_sorted_last(rgv, i)
+    @test search_sorted_first_r(rg_r, i) == search_sorted_first_r(rgv_r, i)
+    @test search_sorted_last_r(rg_r, i) == search_sorted_last_r(rgv_r, i)
+end
+
 a = randi(10000, 1000)
 
 # insertion_sort


### PR DESCRIPTION
This PR incorporates #1786, but adds `search_sorted_first` and `search_sorted_last` for ranges and the appropriate aliases. Among other things, this means that `histc([1, 2, 2, 3], 1:3)` now works.
