### PR TITLE
Added print_with_color, message(), warning()

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -288,3 +288,34 @@ function _atexit()
         end
     end
 end
+
+# Have colors passed as simple symbols: :black, :red, ...
+function print_with_color(msg::String, color::Symbol)
+    color_list = {:green => "\033[1m\033[32m",
+                  :black => "\033[1m\033[30m",
+                  :red => "\033[1m\033[31m",
+                  :green => "\033[1m\033[32m",
+                  :yellow => "\033[1m\033[33m",
+                  :magenta => "\033[1m\033[35m",
+                  :cyan => "\033[1m\033[36m",
+                  :white => "\033[1m\033[37m"}
+    if Base._jl_have_color
+        default = Base._jl_answer_color()
+        printed_color = get(color_list, color, default)
+        print(OUTPUT_STREAM, strcat(printed_color, msg, default))
+    else
+        print(OUTPUT_STREAM, msg)
+    end
+    return
+end
+
+# Use colors to print messages and warnings in the REPL
+function message(msg::String)
+    print_with_color(strcat("MESSAGE: ", msg, "\n"), :green)
+    return
+end
+
+function warning(msg::String)
+    print_with_color(strcat("WARNING: ", msg, "\n"), :red)
+    return
+end

--- a/base/client.jl
+++ b/base/client.jl
@@ -310,12 +310,12 @@ function print_with_color(msg::String, color::Symbol)
 end
 
 # Use colors to print messages and warnings in the REPL
-function message(msg::String)
+function info(msg::String)
     print_with_color(strcat("MESSAGE: ", msg, "\n"), :green)
     return
 end
 
-function warning(msg::String)
+function warn(msg::String)
     print_with_color(strcat("WARNING: ", msg, "\n"), :red)
     return
 end

--- a/base/export.jl
+++ b/base/export.jl
@@ -936,8 +936,8 @@ export
     unescape_string,
     base,
     print_with_color,
-    message,
-    warning,
+    info,
+    warn,
 
 # statistics and random numbers
     betarnd,

--- a/base/export.jl
+++ b/base/export.jl
@@ -935,7 +935,10 @@ export
     unescape_chars,
     unescape_string,
     base,
-    
+    print_with_color,
+    message,
+    warning,
+
 # statistics and random numbers
     betarnd,
     chi2rnd,


### PR DESCRIPTION
To allow users to print colored text and status messages, this adds three functions:
- `print_with_color("Some text", :green)` provides the basic interface
- `message("Things are going well")` extends R's `message()` with color
- `warning("Things are going badly")` extends R's `warning()` with color
