### PR TITLE
Faddeeva function tweaks

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -628,21 +628,18 @@ const Faddeeva_tmp = Array(Float64,2)
 
 # wrappers for complex Faddeeva functions; these will get a lot simpler,
 # and can call openlibm directly, once ccall supports C99 complex types.
-let
-    for f in (:erf, :erfc, :erfcx, :erfi, :Dawson)
-        fname = (f === :Dawson) ? :dawson : f
-        @eval begin
-            global $fname
-            function ($fname)(z::Complex128)
-                ccall(($(string("wrapFaddeeva_",f)),:libFaddeeva_wrapper), Void, (Ptr{Complex128},Ptr{Complex128},Float64,), Faddeeva_tmp, &z, zero(Float64))
-                return complex128(Faddeeva_tmp[1],Faddeeva_tmp[2])
-            end
-            function ($fname)(z::Complex64)
-                ccall(($(string("wrapFaddeeva_",f)),:libFaddeeva_wrapper), Void, (Ptr{Complex128},Ptr{Complex128},Float64,), Faddeeva_tmp, &complex128(z), float64(eps(Float32)))
-                return complex64(Faddeeva_tmp[1],Faddeeva_tmp[2])
-            end
-            ($fname)(z::Complex) = ($fname)(complex128(z))
+for f in (:erf, :erfc, :erfcx, :erfi, :Dawson)
+    fname = (f === :Dawson) ? :dawson : f
+    @eval begin
+        function ($fname)(z::Complex128)
+            ccall(($(string("wrapFaddeeva_",f)),:libFaddeeva_wrapper), Void, (Ptr{Complex128},Ptr{Complex128},Float64,), Faddeeva_tmp, &z, zero(Float64))
+            return complex128(Faddeeva_tmp[1],Faddeeva_tmp[2])
         end
+        function ($fname)(z::Complex64)
+            ccall(($(string("wrapFaddeeva_",f)),:libFaddeeva_wrapper), Void, (Ptr{Complex128},Ptr{Complex128},Float64,), Faddeeva_tmp, &complex128(z), float64(eps(Float32)))
+            return complex64(Faddeeva_tmp[1],Faddeeva_tmp[2])
+        end
+        ($fname)(z::Complex) = ($fname)(complex128(z))
     end
 end
 for f in (:erfcx, :erfi, :Dawson)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1024,26 +1024,31 @@ Mathematical Functions
 
 .. function:: erf(x)
 
-   Compute the error function of ``x``
+   Compute the error function of ``x``, defined by
+   :math:`\frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2} dt`
+   for arbitrary complex ``x``.
 
 .. function:: erfc(x)
 
-   Compute the complementary error function of ``x``
+   Compute the complementary error function of ``x``,
+   defined by :math:`1 - \operatorname{erf}(x)`.
 
 .. function:: erfcx(x)
 
    Compute the scaled complementary error function of ``x``,
-   defined by :math:`e^{x^2} \operatorname{erfc}(x)`
+   defined by :math:`e^{x^2} \operatorname{erfc}(x)`.  Note
+   also that :math:`\operatorname{erfcx}(-ix)` computes the
+   Faddeeva function :math:`w(x)`.
 
 .. function:: erfi(x)
 
    Compute the imaginary error function of ``x``,
-   defined by :math:`-i \operatorname{erf}(ix)`
+   defined by :math:`-i \operatorname{erf}(ix)`.
 
 .. function:: dawson(x)
 
    Compute the Dawson function (scaled imaginary error function) of ``x``,
-   defined by :math:`\frac{\pi}{2} e^{-x^2} \operatorname{erfi}(x)`
+   defined by :math:`\frac{\sqrt{\pi}}{2} e^{-x^2} \operatorname{erfi}(x)`.
 
 .. function:: real(z)
 


### PR DESCRIPTION
This patch removes an unnecessary let block around the Faddeeva wrapper definitions, and improves the error function documentation:
- Fixes a bug (missing sqrt) in the `dawson` documentation
- Notes the connection of erfcx to the Faddeeva function, in case users are looking for the latter.  (There is no real need to provide both erfcx and the Faddeeva function separately, and the former is nicer since it produces real inputs for real outputs).
- Gives the explicit definitions of erf(x) and erfc(x) and notes that erf is defined for complex x.
