### PR TITLE
WIP: make require() load at top level

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -234,4 +234,4 @@ end
 
 typealias ByteString Union(ASCIIString,UTF8String)
 
-include(fname::ByteString) = ccall(:jl_load_, Void, (Any,), fname)
+include(fname::ByteString) = ccall(:jl_load__, Void, (Any,), fname)

--- a/base/util.jl
+++ b/base/util.jl
@@ -230,7 +230,7 @@ function load_now(fname::ByteString)
     if in_load
         path = find_in_path(fname)
         push(load_dict, fname)
-        if nproc() > 1
+        if nprocs() > 1
             f = open(path)
             push(load_dict, readall(f))
             close(f)

--- a/extras/julia_web_base.jl
+++ b/extras/julia_web_base.jl
@@ -16,7 +16,7 @@
 # [message_type::number, arg0::string, arg1::string, ...]
 
 # import the message types
-load("webrepl_msgtypes_h")
+include(find_in_path("webrepl_msgtypes_h"))
 
 ###########################################
 # set up the socket connection
@@ -91,7 +91,7 @@ end
 ###########################################
 
 # load the special functions available to the web repl
-load("julia_web")
+include(find_in_path("julia_web"))
 
 ###########################################
 # input event handler

--- a/extras/ode.jl
+++ b/extras/ode.jl
@@ -28,7 +28,7 @@
 # Adapted from Cleve Moler's textbook
 # http://www.mathworks.com/moler/ncm/ode23tx.m
 
-load("poly")
+require("poly")
 
 function ode23(F::Function, tspan::AbstractVector, y_0::AbstractVector)
 

--- a/extras/strpack.jl
+++ b/extras/strpack.jl
@@ -1,4 +1,4 @@
-load("lru")
+require("lru")
 
 bswap(c::Char) = identity(c) # white lie which won't work for multibyte characters
 

--- a/extras/suitesparse.jl
+++ b/extras/suitesparse.jl
@@ -29,7 +29,7 @@ export                                  # types
     At_ldiv_B,
     Ac_ldiv_B
 
-require("suitesparse_h")
+include(find_in_path("suitesparse_h"))
 
 const libsuitesparse_wrapper = "libsuitesparse_wrapper"
 const libcholmod = "libcholmod"

--- a/extras/test.jl
+++ b/extras/test.jl
@@ -59,7 +59,7 @@ tests(filenames) = tests(filenames, test_printer_raw)
 
 function _tests_task(filenames)
     for fn = filenames
-        load(fn)
+        require(fn)
     end
 end
 

--- a/extras/zlib.jl
+++ b/extras/zlib.jl
@@ -43,7 +43,7 @@ export
 #   Z_BIG_BUFSIZE,
 #   ZFileOffset
 
-load("zlib_h")
+include(find_in_path("zlib_h"))
 
 # zlib functions
 

--- a/src/init.c
+++ b/src/init.c
@@ -174,7 +174,7 @@ void julia_init(char *imageFile)
         jl_current_module = jl_core_module;
         jl_init_intrinsic_functions();
         jl_init_primitives();
-        jl_load("boot.jl");
+        jl_load("boot.jl", 0);
         jl_get_builtin_hooks();
         jl_boot_file_loaded = 1;
         jl_init_box_caches();

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -127,6 +127,7 @@
     jl_is_rest_arg;
     jl_lisp_prompt;
     jl_load_;
+    jl_load__;
     jl_load;
     jl_load_dynamic_library;
     jl_loaderror_type;

--- a/src/julia.h
+++ b/src/julia.h
@@ -850,7 +850,7 @@ void jl_compile(jl_function_t *f);
 void jl_generate_fptr(jl_function_t *f);
 DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v);
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);
-DLLEXPORT void jl_load(const char *fname);
+DLLEXPORT void jl_load(const char *fname, int inmain);
 void jl_parse_eval_all(char *fname);
 jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam);
 jl_value_t *jl_interpret_toplevel_expr(jl_value_t *e);

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -175,7 +175,7 @@ static int exec_program(void)
             JL_EH_POP();
             return 1;
         }
-        jl_load(program);
+        jl_load(program, 0);
     }
     JL_CATCH {
         err = 1;


### PR DESCRIPTION
This is the major piece of work needed to address #1411. Please check, esp. @JeffBezanson. I'm especially worried about the module context in toplevel.c, if the imported file has errors in it. Testing did not result in a segfault, but I doubt the thoroughness of this test.

On both the C side and the julia side this is ugly, but when I tried the more obvious thing in `boot.jl` I either (1) ran into `cconvert not defined` errors (presumably the conversion of a bool to an Int32 is not yet automatizable), (2) didn't figure out a way to generate `0::Int32` in a boot.jl-safe way, or (3) got a weird warning when I said `import Core.include; include(fname::ByteString, inmain::Bool) = ...`. Hence I defined `import_main`. By this point the interface seems kinda dumb (why take a second argument to `import_main`??), but I suspect there's a  cleaner solution, so I decided to leave my fingerprints on it.

Also, a more general interface would be `import(fname, mod::Module)`, but I don't know whether that's desirable.
