### PR TITLE
Give libjulia an RPATH as well

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -70,7 +70,7 @@ flisp/libflisp.a: flisp/*.h flisp/*.c support/libsupport.a
 	$(MAKE) -C flisp
 
 $(BUILD)/$(JL_LIBDIR)/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
-	$(QUIET_LINK) $(CXX) $(DEBUGFLAGS) $(DOBJS) -shared -o $@ $(LIBS) $(LDFLAGS)
+	$(QUIET_LINK) $(CXX) $(DEBUGFLAGS) $(DOBJS) $(RPATH_ORIGIN) -shared -o $@ $(LIBS) $(LDFLAGS)
 	$(INSTALL_NAME_CMD)libjulia-debug.$(SHLIB_EXT) $@
 libjulia-debug.a: julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
 	rm -f $@
@@ -84,7 +84,7 @@ else
 endif
 
 $(BUILD)/$(JL_LIBDIR)/libjulia-release.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
-	$(QUIET_LINK) $(CXX) $(SHIPFLAGS) $(OBJS) $(LIBS) -shared -o $@ $(LDFLAGS) $(SONAME)
+	$(QUIET_LINK) $(CXX) $(SHIPFLAGS) $(OBJS) $(LIBS) $(RPATH_ORIGIN) -shared -o $@ $(LDFLAGS) $(SONAME)
 	$(INSTALL_NAME_CMD)libjulia-release.$(SHLIB_EXT) $@
 libjulia-release.a: julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
 	rm -f $@


### PR DESCRIPTION
Solves a [recent problem](https://groups.google.com/forum/?fromgroups=#!topic/julia-users/07_xUHGKAjY) encountered by a user on OpenSUSE, where Julia could not find librandom because libjulia's RPATH is empty.  Because libjulia is currently located next to all shared libraries this will work fine, but once libjulia is moved into `$(JL_LIBDIR)` from `$(JL_PRIVATE_LIBDIR)` we will likely need to amend this to add in `$(JL_PRIVATE_LIBDIR)` to its RPATH as well.
