### PR TITLE
support * for symbol concatenation, similar to string concatenation

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -141,6 +141,9 @@ one(::Type{Function}) = identity
 map(f::Function) = (x...)->map(f, x...)
 filter(f::Function) = (x...)->filter(f, x...)
 
+# symbol concatenation
+*(a::Symbol, b::Symbol) = symbol(string(a, b))
+
 # array shape rules
 
 function promote_shape(a::(Int,), b::(Int,))


### PR DESCRIPTION
This patch overloads \* to concatenate symbols, which is a useful operation for code generation and makes sense since \* is already used to concatenate strings.
