### PR TITLE
RFC: ccall with julia types as structs

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -84,7 +84,7 @@ end
 type WeakRef
     value
     WeakRef() = WeakRef(nothing)
-    WeakRef(v::ANY) = ccall(:jl_gc_new_weakref, WeakRef, (Any,), v)
+    WeakRef(v::ANY) = ccall(:jl_gc_new_weakref, Any, (Any,), v)::WeakRef
 end
 
 ccall(:jl_get_system_hooks, Void, ())
@@ -99,8 +99,8 @@ uint(x::Uint) = x
 
 names(m::Module, all::Bool) = ccall(:jl_module_names, Array{Symbol,1}, (Any,Int32), m, all)
 names(m::Module) = names(m,false)
-module_name(m::Module) = ccall(:jl_module_name, Symbol, (Any,), m)
-module_parent(m::Module) = ccall(:jl_module_parent, Module, (Any,), m)
+module_name(m::Module) = ccall(:jl_module_name, Any, (Any,), m)::Symbol
+module_parent(m::Module) = ccall(:jl_module_parent, Any, (Any,), m)::Module
 function names(v)
     if typeof(v) === CompositeKind
         return v.names

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -124,7 +124,7 @@ one(x)  = oftype(x,1)
 
 sizeof(T::Type) = error(string("size of type ",T," unknown"))
 sizeof(T::BitsKind) = div(T.nbits,8)
-sizeof(T::CompositeKind) = T.sizeof
+sizeof(T::CompositeKind) = if isleaftype(T) T.sizeof else error("type does not have a native sizeof") end
 sizeof(x) = sizeof(typeof(x))
 
 # copying immutable things

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -124,6 +124,7 @@ one(x)  = oftype(x,1)
 
 sizeof(T::Type) = error(string("size of type ",T," unknown"))
 sizeof(T::BitsKind) = div(T.nbits,8)
+sizeof(T::CompositeKind) = T.sizeof
 sizeof(x) = sizeof(typeof(x))
 
 # copying immutable things

--- a/base/process.jl
+++ b/base/process.jl
@@ -302,7 +302,7 @@ function reinit_stdio()
     STDOUT.buffer = PipeString()
     STDERR.buffer = PipeString()
     for stream in (STDIN,STDOUT,STDERR)
-        ccall(:jl_uv_associate_julia_struct,Void,(Ptr{Void},TTY),stream.handle,stream)
+        ccall(:jl_uv_associate_julia_struct,Void,(Ptr{Void},Any),stream.handle,stream)
     end
 end
 

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -70,7 +70,7 @@ type TcpSocket <: Socket
                                WaitTask[],false,WaitTask[],false,WaitTask[])
     function TcpSocket()
         this = TcpSocket(C_NULL,false)
-        this.handle = ccall(:jl_make_tcp,Ptr{Void},(Ptr{Void},TcpSocket),
+        this.handle = ccall(:jl_make_tcp,Ptr{Void},(Ptr{Void},Any),
                             globalEventLoop(),this)
         if (this.handle == C_NULL)
             error("Failed to start reading: ",_uv_lasterror())
@@ -94,7 +94,7 @@ type UdpSocket <: Socket
                                false,WaitTask[],false,WaitTask[])
     function UdpSocket()
         this = UdpSocket(C_NULL,false)
-        this.handle = ccall(:jl_make_tcp,Ptr{Void},(Ptr{Void},UdpSocket),
+        this.handle = ccall(:jl_make_tcp,Ptr{Void},(Ptr{Void},Any),
                             globalEventLoop(),this)
         this
     end
@@ -179,7 +179,7 @@ function getaddrinfo_callback(cb, addrinfo::Ptr{Void}, status::Int32)
 end
 
 jl_getaddrinfo(loop::Ptr{Void},host::ByteString,service::Ptr{Void},cb::Function) =
-    ccall(:jl_getaddrinfo,Int32,(Ptr{Void}, Ptr{Uint8}, Ptr{Uint8}, Function),
+    ccall(:jl_getaddrinfo,Int32,(Ptr{Void}, Ptr{Uint8}, Ptr{Uint8}, Any),
           loop,      host,       service,    cb)
 
 getaddrinfo(cb::Function,host::ASCIIString) = 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -65,7 +65,7 @@ make_stdout_stream() = _uv_tty2tty(ccall(:jl_stdout_stream, Ptr{Void}, ()))
 function _uv_tty2tty(handle::Ptr{Void})
     tty = TTY(handle,true)
     tty.line_buffered = false
-    ccall(:jl_uv_associate_julia_struct,Void,(Ptr{Void},TTY),handle,tty)
+    ccall(:jl_uv_associate_julia_struct,Void,(Ptr{Void},Any),handle,tty)
     tty
 end
 
@@ -266,7 +266,7 @@ type SingleAsyncWork <: AsyncWork
             return new(cb,C_NULL)
         end
         this=new(cb)
-        this.handle=ccall(:jl_make_async,Ptr{Void},(Ptr{Void},SingleAsyncWork),loop,this)
+        this.handle=ccall(:jl_make_async,Ptr{Void},(Ptr{Void},Any),loop,this)
         this
     end
 end
@@ -276,7 +276,7 @@ type IdleAsyncWork <: AsyncWork
     handle::Ptr{Void}
     function IdleAsyncWork(loop::Ptr{Void},cb::Function)
         this=new(cb)
-        this.handle=ccall(:jl_make_idle,Ptr{Void},(Ptr{Void},IdleAsyncWork),loop,this)
+        this.handle=ccall(:jl_make_idle,Ptr{Void},(Ptr{Void},Any),loop,this)
         this
     end
 end
@@ -286,7 +286,7 @@ type TimeoutAsyncWork <: AsyncWork
     handle::Ptr{Void}
     function TimeoutAsyncWork(loop::Ptr{Void},cb::Function)
         this=new(cb)
-        this.handle=ccall(:jl_make_timer,Ptr{Void},(Ptr{Void},TimeoutAsyncWork),loop,this)
+        this.handle=ccall(:jl_make_timer,Ptr{Void},(Ptr{Void},Any),loop,this)
         this
     end
 end
@@ -337,8 +337,8 @@ run_event_loop() = run_event_loop(globalEventLoop())
 malloc_pipe() = c_malloc(_sizeof_uv_pipe)
 function link_pipe(read_end::Ptr{Void},readable_julia_only::Bool,write_end::Ptr{Void},writeable_julia_only::Bool,pipe::AsyncStream)
     #make the pipe an unbuffered stream for now
-    ccall(:jl_init_pipe, Ptr{Void}, (Ptr{Void},Bool,Bool,AsyncStream), read_end, 0, readable_julia_only, pipe)
-    ccall(:jl_init_pipe, Ptr{Void}, (Ptr{Void},Bool,Bool,AsyncStream), write_end, 1, readable_julia_only, pipe)
+    ccall(:jl_init_pipe, Ptr{Void}, (Ptr{Void},Bool,Bool,Any), read_end, 0, readable_julia_only, pipe)
+    ccall(:jl_init_pipe, Ptr{Void}, (Ptr{Void},Bool,Bool,Any), write_end, 1, readable_julia_only, pipe)
     error = ccall(:uv_pipe_link, Int, (Ptr{Void}, Ptr{Void}), read_end, write_end)
     if error != 0 # don't use assert here as $string isn't be defined yet
         error("uv_pipe_link failed")

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -314,7 +314,7 @@ end # baremodule Base
 
 using Base
 
-let JL_PRIVATE_LIBDIR = getenv("JL_PRIVATE_LIBDIR")
+let JL_PRIVATE_LIBDIR = try getenv("JL_PRIVATE_LIBDIR") catch e "lib/julia" end
 # create system image file
 ccall(:jl_save_system_image, Void, (Ptr{Uint8},),
       "$JULIA_HOME/../$JL_PRIVATE_LIBDIR/sys.ji")

--- a/base/task.jl
+++ b/base/task.jl
@@ -1,6 +1,6 @@
 show(io::IO, t::Task) = print(io, "Task")
 
-current_task() = ccall(:jl_get_current_task, Task, ())
+current_task() = ccall(:jl_get_current_task, Any, ())::Task
 istaskdone(t::Task) = t.done
 
 function task_local_storage()

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -487,6 +487,10 @@ DLLEXPORT void *jl_array_ptr(jl_array_t *a)
 {
     return a->data;
 }
+DLLEXPORT void *jl_value_ptr(jl_value_t *a)
+{
+    return (void*)a;
+}
 
 // printing -------------------------------------------------------------------
 

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -380,6 +380,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     Type *lrt = julia_struct_to_llvm(rt);
     if (lrt == NULL) {
         JL_GC_POP();
+        emit_error("ccall: return type doesn't correspond to a C type", ctx);
         return literal_pointer_val(jl_nothing);
     }
     size_t i;
@@ -423,6 +424,11 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         Type *t = julia_struct_to_llvm(tti);
         if (t == NULL) {
             JL_GC_POP();
+            std::stringstream msg;
+            msg << "ccall: the type of argument ";
+            msg << i+1;
+            msg << " doesn't correspond to a C type";
+            emit_error(msg.str(), ctx);
             return literal_pointer_val(jl_nothing);
         }
         fargt.push_back(t);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -307,8 +307,8 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         jl_value_t *ptr_ty = expr_type(args[1], ctx);
         Value *arg1 = emit_unboxed(args[1], ctx);
         if (!jl_is_cpointer_type(ptr_ty)) {
-            emit_typecheck(arg1, (jl_value_t*)jl_voidpointer_type,
-                           "ccall: function argument not a pointer or valid constant expression", ctx);
+            emit_cpointercheck(arg1, 
+                    "ccall: function argument not a pointer or valid, constant expression", ctx);
         }
         jl_ptr = emit_unbox(T_size, T_psize, arg1);
     }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -60,13 +60,13 @@ static Value *literal_pointer_val(void *p)
 
 // --- mapping between julia and llvm types ---
 
-static Type *julia_type_to_llvm(jl_value_t *jt, bool exact_struct=false)
+static Type *julia_type_to_llvm(jl_value_t *jt)
 {
     if (jt == (jl_value_t*)jl_bool_type) return T_int1;
     if (jt == (jl_value_t*)jl_float32_type) return T_float32;
     if (jt == (jl_value_t*)jl_float64_type) return T_float64;
     if (jl_is_cpointer_type(jt)) {
-        Type *lt = julia_type_to_llvm(jl_tparam0(jt), exact_struct);
+        Type *lt = julia_type_to_llvm(jl_tparam0(jt));
         if (lt == NULL)
             return NULL;
         if (lt == T_void)
@@ -82,7 +82,11 @@ static Type *julia_type_to_llvm(jl_value_t *jt, bool exact_struct=false)
         else          return Type::getIntNTy(getGlobalContext(), nb);
     }
     if (jt == (jl_value_t*)jl_bottom_type) return T_void;
-    if (exact_struct && jl_is_struct_type(jt)) {
+    return jl_pvalue_llvmt;
+}
+
+static Type *julia_struct_to_llvm(jl_value_t *jt) {
+    if (jl_is_struct_type(jt) && jl_is_leaf_type(jt)) {
         jl_struct_type_t *jst = (jl_struct_type_t*)jt;
         if (jst->struct_decl == NULL) {
             size_t ntypes = jl_tuple_len(jst->types);
@@ -91,8 +95,6 @@ static Type *julia_type_to_llvm(jl_value_t *jt, bool exact_struct=false)
             for(i = 0; i < ntypes; i++) {
                 jl_value_t *ty = jl_tupleref(jst->types, i);
                 Type *lty = julia_type_to_llvm(ty);
-                //if (isa<StructType>(lty))
-                //    jl_error("Structs cannot contain other Structs directly");
                 latypes.push_back(lty);
             }
             jst->struct_decl = (void*)StructType::create(latypes, jst->name->name->name);
@@ -100,7 +102,7 @@ static Type *julia_type_to_llvm(jl_value_t *jt, bool exact_struct=false)
         Type *t = (Type*)jst->struct_decl;
         return t;
     }
-    return jl_pvalue_llvmt;
+    return julia_type_to_llvm(jt);
 }
 
 // NOTE: llvm cannot express all julia types (for example unsigned),

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -86,10 +86,14 @@ static Type *julia_type_to_llvm(jl_value_t *jt)
 }
 
 static Type *julia_struct_to_llvm(jl_value_t *jt) {
-    if (jl_is_struct_type(jt) && jl_is_leaf_type(jt)) {
+    if (jl_is_struct_type(jt) &&
+            (((jl_struct_type_t*)(jt))->name != jl_array_typename) &&
+            jl_is_leaf_type(jt)) {
         jl_struct_type_t *jst = (jl_struct_type_t*)jt;
         if (jst->struct_decl == NULL) {
             size_t ntypes = jl_tuple_len(jst->types);
+            if (ntypes == 0)
+                return NULL;
             std::vector<Type *> latypes(0);
             size_t i;
             for(i = 0; i < ntypes; i++) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -698,3 +698,25 @@ static Value *boxed(Value *v, jl_value_t *jt)
     int nb = jl_bitstype_nbits(jt);
     return allocate_box_dynamic(literal_pointer_val(jt), nb, v);
 }
+
+
+static void emit_cpointercheck(Value *x, const std::string &msg,
+                           jl_codectx_t *ctx)
+{
+    Value *t = emit_typeof(x);
+    emit_typecheck(t, (jl_value_t*)jl_bits_kind, msg, ctx);
+
+    Value *istype =
+        builder.CreateICmpEQ(emit_nthptr(t, offsetof(jl_bits_type_t,name)/sizeof(char*)),
+                literal_pointer_val((jl_value_t*)jl_pointer_type->name));
+    BasicBlock *failBB = BasicBlock::Create(getGlobalContext(),"fail",ctx->f);
+    BasicBlock *passBB = BasicBlock::Create(getGlobalContext(),"pass");
+    builder.CreateCondBr(istype, passBB, failBB);
+    builder.SetInsertPoint(failBB);
+
+    emit_type_error(x, (jl_value_t*)jl_pointer_type, msg, ctx);
+
+    builder.CreateBr(passBB);
+    ctx->f->getBasicBlockList().push_back(passBB);
+    builder.SetInsertPoint(passBB);
+}

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -86,9 +86,9 @@ static Type *julia_type_to_llvm(jl_value_t *jt)
 }
 
 static Type *julia_struct_to_llvm(jl_value_t *jt) {
-    if (jl_is_struct_type(jt) &&
-            (((jl_struct_type_t*)(jt))->name != jl_array_typename) &&
-            jl_is_leaf_type(jt)) {
+    if (jl_is_struct_type(jt) && !jl_is_array_type(jt)) {
+        if (!jl_is_leaf_type(jt))
+           return NULL;
         jl_struct_type_t *jst = (jl_struct_type_t*)jt;
         if (jst->struct_decl == NULL) {
             size_t ntypes = jl_tuple_len(jst->types);
@@ -99,6 +99,8 @@ static Type *julia_struct_to_llvm(jl_value_t *jt) {
             for(i = 0; i < ntypes; i++) {
                 jl_value_t *ty = jl_tupleref(jst->types, i);
                 Type *lty = julia_type_to_llvm(ty);
+                if (lty == jl_pvalue_llvmt)
+                    return NULL;
                 latypes.push_back(lty);
             }
             jst->struct_decl = (void*)StructType::create(latypes, jst->name->name->name);

--- a/src/dump.c
+++ b/src/dump.c
@@ -439,6 +439,7 @@ static jl_value_t *jl_deserialize_tag_type(ios_t *s, jl_struct_type_t *kind, int
         st->env = jl_deserialize_value(s);
         st->linfo = (jl_lambda_info_t*)jl_deserialize_value(s);
         st->fptr = jl_deserialize_fptr(s);
+        st->struct_decl = NULL;
         if (st->name == jl_array_type->name) {
             // builtin types are not serialized, so their caches aren't
             // explicitly saved. so we reconstruct the caches of builtin

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -165,7 +165,7 @@ static Value *emit_unbox(Type *to, Type *pto, Value *x)
             return builder.CreateZExt(x, T_int8);
         if (x->getType()->isPointerTy() && !to->isPointerTy())
             return builder.CreatePtrToInt(x, to);
-        assert(x->getType() == to);
+        if (x->getType() != to) jl_error("unbox: T != typeof(x)");
         return x;
     }
     Value *p = bitstype_pointer(x);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -397,16 +397,29 @@ static Value *emit_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t *ctx)
     jl_value_t *ety = jl_tparam0(aty);
     if(jl_is_typevar(ety))
         jl_error("pointerref: invalid pointer");
-    if (!jl_is_bits_type(ety)) {
-        ety = (jl_value_t*)jl_any_type;
-    }
     if ((jl_bits_type_t*)expr_type(i, ctx) != jl_long_type) {
         jl_error("pointerref: invalid index type");
     }
-    //Value *idx = builder.CreateIntCast(auto_unbox(i,ctx), T_size, false); //TODO: use this instead (and remove assert jl_is_long)?
+    Value *thePtr = auto_unbox(e,ctx);
     Value *idx = emit_unbox(T_size, T_psize, emit_unboxed(i, ctx));
     Value *im1 = builder.CreateSub(idx, ConstantInt::get(T_size, 1));
-    return typed_load(auto_unbox(e, ctx), im1, ety, ctx);
+    if (!jl_is_bits_type(ety)) {
+        if (!jl_is_struct_type(ety) || jl_is_array_type(ety) || !jl_is_leaf_type(ety))
+            jl_error("pointerref: invalid pointer type");
+        uint64_t size = ((jl_struct_type_t*)ety)->size;
+        Value *strct =
+            builder.CreateCall(jlallocobj_func,
+                               ConstantInt::get(T_size,
+                                    sizeof(void*)+size));
+        builder.CreateStore(literal_pointer_val((jl_value_t*)ety),
+                            emit_nthptr_addr(strct, (size_t)0));
+        im1 = builder.CreateMul(im1, ConstantInt::get(T_size, size));
+        thePtr = builder.CreateGEP(builder.CreateBitCast(thePtr, T_pint8), im1);
+        builder.CreateMemCpy(builder.CreateBitCast(emit_nthptr_addr(strct, (size_t)1), T_pint8),
+                            thePtr, size, 1);
+        return mark_julia_type(strct, ety);
+    }
+    return typed_load(thePtr, im1, ety, ctx);
 }
 
 static Value *emit_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *i, jl_codectx_t *ctx) {
@@ -420,7 +433,7 @@ static Value *emit_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *i, jl_co
     if (!jl_subtype(xty, ety, 0))
         jl_error("pointerset: type mismatch in assign");
     if (!jl_is_bits_type(ety)) {
-        ety = (jl_value_t*)jl_any_type;
+        jl_error("pointerset: invalid pointer type"); //ety = (jl_value_t*)jl_any_type;
     }
     if ((jl_bits_type_t*)expr_type(i, ctx) != jl_long_type) {
         jl_error("pointerset: invalid index type");

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2378,16 +2378,22 @@ void jl_init_types(void)
     jl_struct_kind->name->primary = (jl_value_t*)jl_struct_kind;
     jl_struct_kind->super = (jl_tag_type_t*)jl_type_type;
     jl_struct_kind->parameters = jl_null;
-    jl_struct_kind->names = jl_tuple(10, jl_symbol("fptr"),
-                                     jl_symbol("env"), jl_symbol("code"),
-                                     jl_symbol("name"), jl_symbol("super"),
+    jl_struct_kind->names = jl_tuple(11, jl_symbol("fptr"),
+                                     jl_symbol("env"),
+                                     jl_symbol("code"),
+                                     jl_symbol("name"),
+                                     jl_symbol("super"),
                                      jl_symbol("parameters"),
-                                     jl_symbol("names"), jl_symbol("types"),
-                                     jl_symbol(""), jl_symbol(""));
-    jl_struct_kind->types = jl_tuple(10, jl_any_type, jl_any_type, jl_any_type,
+                                     jl_symbol("names"),
+                                     jl_symbol("types"),
+                                     jl_symbol("ctor_factory"),
+                                     jl_symbol("instance"),
+                                     jl_symbol("sizeof"));
+    jl_struct_kind->types = jl_tuple(11, jl_any_type, jl_any_type, jl_any_type,
                                      jl_typename_type, jl_type_type,
                                      jl_tuple_type, jl_tuple_type,
-                                     jl_tuple_type, jl_any_type, jl_any_type);
+                                     jl_tuple_type, jl_any_type, jl_any_type,
+                                     jl_any_type); //types will be fixed later
     jl_struct_kind->fptr = jl_f_no_function;
     jl_struct_kind->env = (jl_value_t*)jl_null;
     jl_struct_kind->linfo = NULL;
@@ -2665,6 +2671,7 @@ void jl_init_types(void)
                                              jl_tuple(1,jl_bottom_type));
     jl_voidpointer_type = (jl_bits_type_t*)pointer_void;
     jl_tupleset(jl_struct_kind->types, 0, pointer_void);
+    jl_tupleset(jl_struct_kind->types, 10, jl_int32_type);
     jl_tupleset(jl_function_type->types, 0, pointer_void);
 
     jl_compute_struct_offsets(jl_struct_kind);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1726,7 +1726,8 @@ static jl_type_t *inst_type_w_(jl_value_t *t, jl_value_t **env, size_t n,
             nst->linfo = NULL;
             nst->ctor_factory = st->ctor_factory;
             nst->instance = NULL;
-            nst->uid = 0;
+            nst->uid = 0;    
+            nst->struct_decl = NULL;
             nst->super = (jl_tag_type_t*)inst_type_w_((jl_value_t*)st->super, env,n,stack);
             jl_tuple_t *ftypes = st->types;
             if (ftypes != NULL) {
@@ -2371,6 +2372,7 @@ void jl_init_types(void)
     jl_tag_kind->ctor_factory = NULL;
     jl_tag_kind->instance = NULL;
     jl_tag_kind->uid = jl_assign_type_uid();
+    jl_tag_kind->struct_decl = NULL;
 
     jl_struct_kind->name = jl_new_typename(jl_symbol("CompositeKind"));
     jl_struct_kind->name->primary = (jl_value_t*)jl_struct_kind;
@@ -2392,6 +2394,7 @@ void jl_init_types(void)
     jl_struct_kind->ctor_factory = NULL;
     jl_struct_kind->instance = NULL;
     jl_struct_kind->uid = jl_assign_type_uid();
+    jl_struct_kind->struct_decl = NULL;
 
     jl_typename_type->name = jl_new_typename(jl_symbol("TypeName"));
     jl_typename_type->name->primary = (jl_value_t*)jl_typename_type;
@@ -2408,6 +2411,7 @@ void jl_init_types(void)
     jl_typename_type->linfo = NULL;
     jl_typename_type->ctor_factory = NULL;
     jl_typename_type->instance = NULL;
+    jl_typename_type->struct_decl = NULL;
 
     jl_sym_type->name = jl_new_typename(jl_symbol("Symbol"));
     jl_sym_type->name->primary = (jl_value_t*)jl_sym_type;
@@ -2421,6 +2425,7 @@ void jl_init_types(void)
     jl_sym_type->ctor_factory = NULL;
     jl_sym_type->instance = NULL;
     jl_sym_type->uid = jl_assign_type_uid();
+    jl_sym_type->struct_decl = NULL;
 
     // now they can be used to create the remaining base kinds and types
     jl_union_kind = jl_new_struct_type(jl_symbol("UnionKind"),

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -274,6 +274,7 @@
     jl_uv_*;
     jl_wrap_raw_dl_handle;
     jl_write;
+    jl_value_ptr;
     jl_zero_denormals;
     julia_free;
     julia_home;

--- a/src/julia.h
+++ b/src/julia.h
@@ -237,10 +237,10 @@ typedef struct {
     // to create a set of constructors for this sort of type
     jl_value_t *ctor_factory;
     jl_value_t *instance;  // for singletons
-    // hidden fields:
-    uint32_t uid;
     uint32_t size;
+    // hidden fields:
     uint32_t alignment;  // strictest alignment over all fields
+    uint32_t uid;
     void *struct_decl;  //llvm::Value*
     jl_fielddesc_t fields[1];
 } jl_struct_type_t;

--- a/src/julia.h
+++ b/src/julia.h
@@ -241,6 +241,7 @@ typedef struct {
     uint32_t uid;
     uint32_t size;
     uint32_t alignment;  // strictest alignment over all fields
+    void *struct_decl;  //llvm::Value*
     jl_fielddesc_t fields[1];
 } jl_struct_type_t;
 
@@ -768,6 +769,7 @@ DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc);
 DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec);
 DLLEXPORT void jl_array_grow_beg(jl_array_t *a, size_t inc);
 DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec);
+DLLEXPORT void *jl_value_ptr(jl_value_t *a);
 void jl_cell_1d_push(jl_array_t *a, jl_value_t *item);
 
 // system information

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -544,7 +544,7 @@ DLLEXPORT void getlocalip(char *buf, size_t len)
             buf[len]=0;
 #endif
 
-            if (strcmp(buf,"127.0.0.1"))
+            if (strcmp(buf,"127.0.0.1")) //TODO: use (ifa.internal == false)
                 break;
             //printf("%s IP Address %s\n", ifa->ifa_name, addressBuffer);
         }

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ core numbers strings unicode corelib hashing remote \
 arrayops linalg fft dct sparse bitarray suitesparse arpack \
 random math functional bigint bigfloat combinatorics \
 statistics glpk linprog poly file Rmath remote zlib image \
-iostring gzip integers spawn ccall
+iostring gzip integers spawn ccall parallel
 
 $(TESTS) ::
 	$(QUIET_JULIA) $(JULIA_EXECUTABLE) ./runtests.jl $@

--- a/test/core.jl
+++ b/test/core.jl
@@ -457,9 +457,9 @@ begin
     @test a == [11,99,13]
     a2 = Any[101,102,103]
     p2 = pointer(a2)
-    @test unsafe_ref(p2) == 101
-    unsafe_assign(p2, 909, 3)
-    @test a2 == [101,102,909]
+    @test_fails unsafe_ref(p2) == 101
+    @test_fails unsafe_assign(p2, 909, 3)
+    @test a2 == [101,102,103]
 end
 
 # issue #1287, combinations of try, catch, return

--- a/test/default.jl
+++ b/test/default.jl
@@ -27,3 +27,4 @@ runtests("statistics")
 # io, etc.
 runtests("iostring")
 runtests("spawn")
+runtests("parallel")

--- a/test/default.jl
+++ b/test/default.jl
@@ -27,4 +27,4 @@ runtests("statistics")
 # io, etc.
 runtests("iostring")
 runtests("spawn")
-runtests("parallel")
+#runtests("parallel")

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -1,0 +1,9 @@
+addprocs_local(1)
+
+@test myid() == 1
+@test fetch(@spawnat 2 myid()) == 2
+
+d = drand(100,100)
+s = convert(Array, d[1:150, 1:150])
+a = convert(Array, d)
+@test a[1:150,1:150] == s


### PR DESCRIPTION
This adds syntax and support for passing julia types to ccall functions, either as StructTypes (by-value) or Pointers to StructTypes (by-reference).

Some example/test code:

``` julia
ccall((:cptest,"ztest"), Void, (StructPtr{ComplexPair{Int}},), ComplexPair(122,3))
ccall((:cptest,"ztest"), Void, (StructPtr{ComplexPair{Int}},), &ComplexPair(122,3))
ccall((:cgptest,"ztest"), Void, (StructPtr{ComplexPair{Float64}},), &ComplexPair(2.,3))

ccall((:cgtest,"ztest"), Void, (Struct{ComplexPair{Float64}},), ComplexPair(2.,3))
ccall((:ctest,"ztest"), Void, (Struct{ComplexPair{Int}},), ComplexPair(2,3))

ccall((:sptest,"ztest"), Void, (Struct{ASCIIString},), "asdf")
```

compile the following library with `gcc ztest.c -shared -o ztest.so -g -Wall` or `gcc ztest.c -shared -o ztest.dylib -g -Wall` depending on your platform:

``` c
#include <stdio.h>
#include <complex.h>
#include <stdint.h>
#include <inttypes.h>
typedef struct {
    long real;
    long imag;
} complex_t;
void ctest(complex_t a) {
    //Unpack a ComplexPair{Int} struct
    printf("%ld + %ld i\n", a.real, a.imag);
    return;
}
void cgtest(complex double a) {
    //Unpack a ComplexPair{Float64} struct
    printf("%g + %g i\n", creal(a), cimag(a));
    return;
}
void cgptest(complex double *a) {
    //Unpack a ComplexPair{Float64} struct
    printf("%g + %g i\n", creal(*a), cimag(*a));
    return;
}
void cptest(complex_t *a) {
    //Unpack a ComplexPair{Int} struct pointer
    printf("%ld + %ld i\n", a->real, a->imag);
    return;
}
void stest(char *x) {
    //Print an Array
    printf("%s\n", x);
}
void sptest(struct { struct { void* t; char* x } *x } x ) {
    //Unpack an ASCIIString
    printf("%s\n", x.x->x);
}
```
