### PR TITLE
RFC: Load "unconventional" libraries (*nix)

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -20,7 +20,7 @@ static char *extensions[] = { "", ".dylib" };
 static char *extensions[] = { ".dll" };
 #define N_EXTENSIONS 1
 #else
-static char *extensions[] = { ".so", "" };
+static char *extensions[] = { ".so.1", ".so", "" };
 #define N_EXTENSIONS 2
 #endif
 


### PR DESCRIPTION
(I still feel like this is a hack-y solution.)

Different implementations of the "same" library can coexist, but they can cause problems for Julia.  For instance, my Fedora machine uses the nvidia closed-source drivers, but retains the open-source nouveau drivers as a backup.  This produces two OpenGL libraries:
- Open-source - /usr/lib64/libGL.so
- Closed-source - /usr/lib64/nvidia/libGL.so.1

When told to open the "libGL" library, Julia uses the /usr/lib64/libGL.so library, since ".so.1" is not an element in the extensions list (src/dlload.c).  Using ldd on compiled C-OpenGL code showed that they linked to /usr/lib64/nvidia/libGL.so.1.  Adding ".so.1" to the head of the extensions list in src/dlload.c fixes this problem\* and should (hopefully) fix problems with any other "unconventional" libraries.

--Rob
- I was wrong in my julia-dev post, the position of ".so.1" in the extensions list does matter.
