### PR TITLE
allow x[1] for scalar x

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -20,6 +20,8 @@ ndims(x::Number) = 0
 ndims{T<:Number}(::Type{T}) = 0
 length(x::Number) = 1
 ref(x::Number) = x
+ref(x::Number, i::Integer) = i == 1 ? x : throw(BoundsError())
+ref(x::Number, i::Real) = ref(x, to_index(i))
 
 signbit(x::Real) = int(x < 0)
 sign(x::Real) = x < 0 ? -one(x) : x > 0 ? one(x) : x


### PR DESCRIPTION
to be consistent with the treatment of 0-dimensional arrays; note that `ndims(x)==0` and `length(x)==numel(x)==1` for scalar `x`.

See also the discussion in issue #1829.
