### PR TITLE
RFC: Use LAPACK to estimate 1 and Inf norm. Change norm to return Float.

### DIFF
--- a/base/lapack.jl
+++ b/base/lapack.jl
@@ -1519,4 +1519,75 @@ for (syevr, elty, relty) in
 end
 syevr!(A::StridedMatrix, Z::StridedMatrix) = syevr!('V', 'A', 'U', A, 0.0, 0.0, 0, 0, Z, -1.0)
 syevr!{T}(A::StridedMatrix{T}) = syevr!('N', 'A', 'U', A, 0.0, 0.0, 0, 0, zeros(T,0,0), -1.0)
+
+# Estimate condition number
+for (gecon, elty) in
+    ((:dgecon_,:Float64),
+     (:sgecon_,:Float32))
+    @eval begin
+        function gecon!(normtype::BlasChar, A::StridedMatrix{$elty}, anorm::$elty)
+#                   SUBROUTINE DGECON( NORM, N, A, LDA, ANORM, RCOND, WORK, IWORK,
+#      $                   INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          NORM
+#       INTEGER            INFO, LDA, N
+#       DOUBLE PRECISION   ANORM, RCOND
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            IWORK( * )
+#       DOUBLE PRECISION   A( LDA, * ), WORK( * )
+            chkstride1(A)
+            n = size(A, 2)
+            lda = max(1, size(A, 1))
+            rcond = Array($elty, 1)
+            work = Array($elty, 4n)
+            iwork = Array(BlasInt, n)
+            info = Array(BlasInt, 1)
+            ccall(($(string(gecon)),liblapack), Void,
+                (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, 
+                    Ptr{$elty}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt},
+                    Ptr{BlasInt}),
+                &normtype, &n, A, &lda,
+                &anorm, rcond, work, iwork,
+                info)
+            if info[1] != 0 throw(LapackException(info[1])) end
+            return rcond[1]
+        end
+    end
+end
+for (gecon, elty, relty) in
+    ((:zgecon_,:Complex128,:Float64),
+     (:cgecon_,:Complex64,:Float32))
+    @eval begin
+        function gecon!(normtype::BlasChar, A::StridedMatrix{$elty}, anorm::$relty)
+            chkstride1(A)
+#       SUBROUTINE ZGECON( NORM, N, A, LDA, ANORM, RCOND, WORK, RWORK,
+#      $                   INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          NORM
+#       INTEGER            INFO, LDA, N
+#       DOUBLE PRECISION   ANORM, RCOND
+# *     ..
+# *     .. Array Arguments ..
+#       DOUBLE PRECISION   RWORK( * )
+#       COMPLEX*16         A( LDA, * ), WORK( * )
+            chkstride1(A)
+            n = size(A, 2)
+            lda = max(1, size(A, 1))
+            rcond = Array($relty, 1)
+            work = Array($elty, 2n)
+            rwork = Array(BlasInt, 2n)
+            info = Array(BlasInt, 1)
+            ccall(($(string(gecon)),liblapack), Void,
+                (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, 
+                    Ptr{$relty}, Ptr{$relty}, Ptr{$elty}, Ptr{$relty},
+                    Ptr{BlasInt}),
+                &normtype, &n, A, &lda, 
+                &anorm, rcond, work, rwork,
+                info)
+            if info[1] < 0 throw(LapackException(info[1])) end
+            return rcond[1]
+        end
+    end
+end
 end # module

--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -809,6 +809,22 @@ end
 null{T<:Integer}(A::StridedMatrix{T}) = null(float(A))
 null(a::StridedVector) = null(reshape(a, length(a), 1))
 
+function cond(A::StridedMatrix, p) 
+    if p == 2
+        v = svdvals(A)
+        maxv = max(v)
+        cnd = maxv == 0.0 ? Inf : maxv / min(v)
+    elseif p == 1 || p == Inf
+        m, n = size(A)
+        if m != n; error("Use 2-norm for non-square matrices"); end
+        cnd = 1 / LAPACK.gecon!(p == 1 ? '1' : 'I', lud(A).lu, norm(A, p))
+    else
+        error("Norm type must be 1, 2 or Inf")
+    end
+    return cnd
+end
+cond(A::StridedMatrix) = cond(A, 2)
+
 #### Specialized matrix types ####
 
 ## Symmetric tridiagonal matrices

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -95,6 +95,12 @@ for elty in (Float32, Float64, Complex64, Complex128)
         # Complex vector rhs
         x = a\complex(b)
         @assert_approx_eq a*x complex(b)
+
+        # Test cond
+        @assert_approx_eq_eps cond(a, 1) 4.837320054554436e+02 0.01
+        @assert_approx_eq_eps cond(a, 2) 1.960057871514615e+02 0.01
+        @assert_approx_eq_eps cond(a, Inf) 3.757017682707787e+02 0.01
+        @assert_approx_eq_eps cond(a[:,1:5]) 10.233059337453463 0.01
 end
 a = [ones(20) 1:20 1:20]
 b = reshape(eye(8, 5), 20, 2)
@@ -115,7 +121,7 @@ for elty in (Float32, Float64, Complex64, Complex128)
         # symmetric, positive definite
         @assert_approx_eq inv(convert(Matrix{elty}, [6. 2; 2 1])) convert(Matrix{elty}, [0.5 -1; -1 3])
         # symmetric, negative definite
-        @assert_approx_eq inv(convert(Matrix{elty}, [1. 2; 2 1])) convert(Matrix{elty}, [-1. 2; 2 -1]/3)
+        @assert_approx_eq inv(convert(Matrix{elty}, [1. 2; 2 1])) convert(Matrix{elty}, [-1. 2; 2 -1]/3)               
 end
 
 ## Test Julia fallbacks to BLAS routines


### PR DESCRIPTION
Inspired by the discussion of `cond`, I have added a wrapper for the LAPACK subroutine for 1 and Inf norms. It is faster. Most of the code is now in linalg_dense.jl as it is only valid for `StridedArray`. The norm functions now return floats for all input types.
