### PR TITLE
RFC: extend linalg and array operations to work on Numbers when it makes sense

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1092,7 +1092,7 @@ end
 
 ## find ##
 
-function nnz(a::StridedArray)
+function nnz(a)
     n = 0
     for i = 1:numel(a)
         n += bool(a[i]) ? 1 : 0
@@ -1101,7 +1101,7 @@ function nnz(a::StridedArray)
 end
 
 # returns the index of the first non-zero element, or 0 if all zeros
-function findfirst(A::StridedArray)
+function findfirst(A)
     for i = 1:length(A)
         if A[i] != 0
             return i
@@ -1111,7 +1111,7 @@ function findfirst(A::StridedArray)
 end
 
 # returns the index of the first matching element
-function findfirst(A::StridedArray, v)
+function findfirst(A, v)
     for i = 1:length(A)
         if A[i] == v
             return i
@@ -1121,7 +1121,7 @@ function findfirst(A::StridedArray, v)
 end
 
 # returns the index of the first element for which the function returns true
-function findfirst(testf::Function, A::StridedArray)
+function findfirst(testf::Function, A)
     for i = 1:length(A)
         if testf(A[i])
             return i
@@ -1156,6 +1156,10 @@ function find(A::StridedArray)
     end
     return I
 end
+
+find(x::Number) = x == 0 ? Array(Int,0) : [1]
+find(x::Bool) = x ? [1] : Array(Int,0)
+find(testf::Function, x) = find(testf(x))
 
 findn(A::StridedVector) = find(A)
 
@@ -1241,7 +1245,9 @@ function nonzeros{T}(A::StridedArray{T})
     return V
 end
 
-function findmax(a::StridedArray)
+nonzeros(x::Number) = x == 0 ? Array(typeof(x),0) : [x]
+
+function findmax(a)
     m = typemin(eltype(a))
     mi = 0
     for i=1:length(a)
@@ -1253,7 +1259,7 @@ function findmax(a::StridedArray)
     return (m, mi)
 end
 
-function findmin(a::StridedArray)
+function findmin(a)
     m = typemax(eltype(a))
     mi = 0
     for i=1:length(a)
@@ -1264,8 +1270,9 @@ function findmin(a::StridedArray)
     end
     return (m, mi)
 end
-indmax(a::StridedArray) = findmax(a)[2]
-indmin(a::StridedArray) = findmin(a)[2]
+
+indmax(a) = findmax(a)[2]
+indmin(a) = findmin(a)[2]
 
 ## Reductions ##
 

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -74,6 +74,10 @@ function norm(A::AbstractMatrix, p)
 end
 
 norm(A::AbstractMatrix) = norm(A, 2)
+
+norm(x::Number) = abs(x)
+norm(x::Number, p) = abs(x)
+
 rank(A::AbstractMatrix, tol::Real) = sum(svdvals(A) .> tol)
 function rank(A::AbstractMatrix)
     m,n = size(A)
@@ -81,8 +85,10 @@ function rank(A::AbstractMatrix)
     sv = svdvals(A)
     sum(sv .> max(size(A,1),size(A,2))*eps(sv[1]))
 end
+rank(x::Number) = x == 0 ? 0 : 1
 
 trace(A::AbstractMatrix) = sum(diag(A))
+trace(x::Number) = x
 
 #kron(a::AbstractVector, b::AbstractVector)
 #kron{T,S}(a::AbstractMatrix{T}, b::AbstractMatrix{S})
@@ -109,6 +115,9 @@ function cond(a::AbstractMatrix, p)
     end
 end
 
+cond(x::Number) = x == 0 ? Inf : 1
+cond(x::Number, p) = cond(x)
+
 function issym(A::AbstractMatrix)
     m, n = size(A)
     if m != n; error("matrix must be square, got $(m)x$(n)"); end
@@ -120,6 +129,8 @@ function issym(A::AbstractMatrix)
     return true
 end
 
+issym(x::Number) = true
+
 function ishermitian(A::AbstractMatrix)
     m, n = size(A)
     if m != n; error("matrix must be square, got $(m)x$(n)"); end
@@ -130,6 +141,8 @@ function ishermitian(A::AbstractMatrix)
     end
     return true
 end
+
+ishermitian(x::Number) = isreal(x)
 
 function istriu(A::AbstractMatrix)
     m, n = size(A)
@@ -151,6 +164,8 @@ function istril(A::AbstractMatrix)
     return true
 end
 
+istriu(x::Number) = true
+istril(x::Number) = true
 
 function linreg{T<:Number}(X::StridedVecOrMat{T}, y::Vector{T})
     [ones(T, size(X,1)) X] \ y

--- a/base/matmul.jl
+++ b/base/matmul.jl
@@ -60,6 +60,8 @@ function dot(x::Vector, y::Vector)
     s
 end
 
+dot(x::Number, y::Number) = conj(x) * y
+
 # Matrix-vector multiplication
 
 function (*){T<:BlasFloat}(A::StridedMatrix{T},

--- a/base/number.jl
+++ b/base/number.jl
@@ -34,7 +34,6 @@ ctranspose(x::Number) = conj(x)
 inv(x::Number) = one(x)/x
 angle(z::Real) = atan2(zero(z), z)
 
-# TODO: should we really treat numbers as iterable?
 start(a::Real) = a
 next(a::Real, i) = (a, a+1)
 done(a::Real, i) = (i > a)


### PR DESCRIPTION
As discussed in JuliaLang/julia#1829 and JuliaLang/julia#1843, Julia treats a `Number` as an iterable container (supporting `for`, `ref`, `length`, etc), which makes it much easier to write polymorphic functions that can accept either `Number` or `Array` arguments.  For the same reason, it makes sense to have several functions on arrays also work for `Number`s where it makes sense and the meaning is unambiguous, e.g. `nnz` and `findmin`.

Similarly, as discussed in JuliaLang/LinearAlgebra.jl#1516, it is consistent with both mathematical principle and mathematical practice to have many of the linear-algebra functions, from `norm` to `eig`, work on `Number` arguments.   (`inv` already worked.)  Again, this makes it easier to write polymorphic functions that take `Vector`, `Matrix`, or `Number` arguments where it makes sense.
