### PR TITLE
allow worker to work when a host has multiple IP addresses

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -150,7 +150,7 @@ function process_options(args::Array{Any,1})
         if args[i]=="-q" || args[i]=="--quiet"
             quiet = true
         elseif args[i]=="--worker"
-            start_worker()
+            start_worker(args[i+1])
             # doesn't return
         elseif args[i]=="-e"
             # TODO: support long options

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -876,17 +876,18 @@ end
 
 # the entry point for julia worker processes. does not return.
 # argument is descriptor to write listening port # to.
-start_worker() = start_worker(1)
-function start_worker(wrfd)
+start_worker(mode :: String) = start_worker(mode, 1)
+function start_worker(mode :: String, wrfd)
     port = [int16(9009)]
     sockfd = ccall(:open_any_tcp_port, Int32, (Ptr{Int16},), port)
     if sockfd == -1
         error("could not bind socket")
     end
     io = fdio(wrfd)
+    host = mode == "local" ? "localhost" : getipaddr()
     write(io, "julia_worker:")    # print header
     write(io, "$(dec(port[1]))#") # print port
-    write(io, getipaddr())        # print hostname
+    write(io, host)               # print hostname
     write(io, '\n')
     flush(io)
     # close stdin; workers will not use it
@@ -974,11 +975,11 @@ function ssh_tunnel(user, host, port)
 end
 
 function worker_ssh_cmd(host)
-    `ssh -n $host "bash -l -c \"cd $JULIA_HOME && ./julia-release-basic --worker\""`
+    `ssh -n $host "bash -l -c \"cd $JULIA_HOME && ./julia-release-basic --worker remote\""`
 end
 
 #function worker_ssh_cmd(host, key)
-#    `ssh -i $key -n $host "bash -l -c \"cd $JULIA_HOME && ./julia-release-basic --worker\""`
+#    `ssh -i $key -n $host "bash -l -c \"cd $JULIA_HOME && ./julia-release-basic --worker remote\""`
 #end
 
 function addprocs_ssh(machines)
@@ -1003,7 +1004,7 @@ end
 #    add_workers(PGRP, start_remote_workers(machines, map(x->worker_ssh_cmd(x[1],x[2]), cmdargs)))
 #end
 
-worker_local_cmd() = `$JULIA_HOME/julia-release-basic --worker`
+worker_local_cmd() = `$JULIA_HOME/julia-release-basic --worker local`
 
 addprocs_local(np::Integer) =
     add_workers(PGRP, start_remote_workers({ "localhost" for i=1:np },
@@ -1015,7 +1016,7 @@ function start_sge_workers(n)
     sgedir = "$home/../../SGE"
     run(`mkdir -p $sgedir`)
     qsub_cmd = `qsub -N JULIA -terse -e $sgedir -o $sgedir -t 1:$n`
-    `echo $home/julia-release-basic --worker` | qsub_cmd
+    `echo $home/julia-release-basic --worker remote` | qsub_cmd
     out = cmd_stdout_stream(qsub_cmd)
     if !success(qsub_cmd)
         error("batch queue not available (could not run qsub)")


### PR DESCRIPTION
This is the body of the email i sent to julia-dev:

I've been trying to run a couple of parallel things and I've come across two problems:
1. I'm unable to start julia with workers when I'm connected to my institute's vpn.  I get this error:

$ julia -p 4  
could not connect to 192.168.1.106:9012, errno=60                                                                                                                                                              

 in Worker at multi.jl:110  
 in Worker at multi.jl:115  
 in start_remote_workers at multi.jl:947  
 in addprocs_local at multi.jl:1008  
 in process_options at client.jl:202  
 in _start at client.jl:255

The problem seems to be that when julia launches workers, it expects them to report their IP addresses (even if the worker is started locally).  If a machine has multiple addresses, the first non loopback adapter is chosen (via a call to getipaddr() which c-calls getlocalip()), which results in:

$ julia --worker
julia_worker:9021#192.168.1.106 

The problem is that many VPNs (including our) don't allow bridging, so when the VPN is connected, connections to the primary adapter are blocked.

I worked around this by adding a mode argument to --worker:

--worker local
--worker remote

start_worker() checks this flag to decide whether to use "localhost" or the result of getipaddr().
