### PR TITLE
RFC: Methods for checking required() and installed() packages

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -161,6 +161,15 @@ end
 required() = cd_pkgdir() do
     parse_requires("REQUIRE")
 end
+required(pkg::String) = cd_pkgdir() do
+    req = required()
+    for vset in req
+        if isequal(vset.package, pkg)
+            return vset.versions
+        end
+    end
+    return nothing
+end
 
 installed() = cd_pkgdir() do
     h = Dict{String,Union(VersionNumber,String)}()
@@ -171,6 +180,11 @@ installed() = cd_pkgdir() do
     end
     return h
 end
+installed(pkg::String) = cd_pkgdir() do
+    get(installed(), pkg, nothing)
+end
+
+
 
 # update packages from requirements
 

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -161,6 +161,15 @@ end
 required() = cd_pkgdir() do
     parse_requires("REQUIRE")
 end
+required(pkg::String) = cd_pkgdir() do
+    req = required()
+    for vset in req
+        if isequal(vset.package, pkg)
+            return vset.versions
+        end
+    end
+    return Nothing
+end
 
 installed() = cd_pkgdir() do
     h = Dict{String,Union(VersionNumber,String)}()
@@ -171,6 +180,11 @@ installed() = cd_pkgdir() do
     end
     return h
 end
+installed(pkg::String) = cd_pkgdir() do
+    get(installed(), pkg, Nothing)
+end
+
+
 
 # update packages from requirements
 


### PR DESCRIPTION
I thought I wanted status(pkg_name), and maybe that's still useful, but I think really I'm just interested in the version of a package and whether a package was manually added (required) or included by necessity (another packaged needed it).

Basically, I want it to be easy to say:

```
if required(pkg) != Nothing
    blarg....

if contains(required(pkg), specific_version_number)
    blarg....
```

Worth including by default? Or is there an easy way to do this that I missed?
