### PR TITLE
BigInt Right Shift

### DIFF
--- a/deps/gmp_wrapper.c
+++ b/deps/gmp_wrapper.c
@@ -88,6 +88,10 @@ extern void jl_mpz_lshift(mpz_t* rop, mpz_t* base, unsigned long int count) {
   mpz_mul_2exp(*rop, *base, count);
 }
 
+extern void jl_mpz_rshift(mpz_t* rop, mpz_t* base, unsigned long int count) {
+  mpz_div_2exp(*rop, *base, count);
+}
+
 extern void jl_mpz_pow_ui(mpz_t* rop, mpz_t* base, unsigned long int exp) {
   mpz_pow_ui(*rop, *base, exp);
 }

--- a/extras/bigint.jl
+++ b/extras/bigint.jl
@@ -105,6 +105,14 @@ end
 <<(x::BigInt, c::Int32)   = c<0 ? throw(DomainError()) : x<<uint(c)
 <<(x::BigInt, c::Integer) = c<0 ? throw(DomainError()) : x<<uint(c)
 
+function >>(x::BigInt, c::Uint)
+    z = BigInt_init()
+    ccall((:jl_mpz_rshift, :libgmp_wrapper), Void, (Ptr{Void}, Ptr{Void}, Uint), z, x.mpz, c)
+    BigInt(z)
+end
+>>(x::BigInt, c::Int32)   = c<0 ? throw(DomainError()) : x>>uint(c)
+>>(x::BigInt, c::Integer) = c<0 ? throw(DomainError()) : x>>uint(c)
+
 function div(x::BigInt, y::BigInt)
     z = BigInt_init()
     ccall((:jl_mpz_div, :libgmp_wrapper), Void, (Ptr{Void}, Ptr{Void}, Ptr{Void}),z,x.mpz,y.mpz)

--- a/extras/gmp.jl
+++ b/extras/gmp.jl
@@ -9,6 +9,7 @@ import
     Base./,
     Base.<,
     Base.<<,
+    Base.>>,
     Base.<=,
     Base.==,
     Base.>,


### PR DESCRIPTION
I've added the right shift operator to BigInt using GNU's mpz_div_2exp method defined here:
http://web.mit.edu/gnu/doc/html/gmp_4.html
