### PR TITLE
RFC: Create a listing of all packages

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+JULIA         = ../julia
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -19,7 +20,7 @@ JQUERYURL = http://code.jquery.com/jquery-latest.js
 WGET = $(abspath ../deps)/jldownload
 
 .PHONY: help clean clean-jquery cleanall get-jquery html dirhtml singlehtml pickle json htmlhelp qthelp devhelp \
-	epub latex latexpdf text man changes linkcheck doctest gettext
+	epub latex latexpdf text man changes linkcheck doctest gettext listpkg
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -43,6 +44,7 @@ help:
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+	@echo "  listpkg    to recreate the list of available packages"
 
 clean:
 	-rm -rf $(BUILDDIR)/*
@@ -172,3 +174,6 @@ doctest:
 helpdb.jl: stdlib/*.rst sphinx/jlhelp.py sphinx/julia.py
 	$(SPHINXBUILD) -b jlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/jlhelp
 	mv $(BUILDDIR)/jlhelp/jlhelp.jl helpdb.jl
+
+listpkg: 
+	$(JULIA) listpkg.jl

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,6 +8,7 @@
 
    manual/index
    stdlib/index
+   packages/packagelist
 
 Indices and tables
 ==================

--- a/doc/listpkg.jl
+++ b/doc/listpkg.jl
@@ -54,6 +54,7 @@ function gen_listpkg()
 		end
 		print(io, "`$(pkg) <$(html_url)>`_\n"); 
 		print(io, "_"^(length("`$(pkg) <$(html_url)>`_")) * "\n\n")
+		print(io, "  .. image:: $(avatar)\n     :height: 80px\n     :width: 80px\n     :align: right\n     :alt: $(fullname)\n")
 		print(io, "  Current Version: ``$(maxv.version)``\n\n"); 
 		print(io, "  $(desc) \n\n")
 		print(io, "  Maintainer: `$(fullname) <$user_url>`_\n\n") 

--- a/doc/listpkg.jl
+++ b/doc/listpkg.jl
@@ -1,0 +1,85 @@
+require("pkg")
+try 
+require("JSON")
+catch 
+Pkg.add("JSON")
+require("JSON")
+end
+
+function gen_listpkg()
+	local gh_auth
+	try 
+		gh_auth = ENV["GH_AUTH"]
+	catch e
+		error ("Please provide a Github OAuth Token as environment variable GH_AUTH")
+	end
+	Pkg.update()
+	io=open("packages/packagelist.rst","w+");
+	print(io, "********************\n Available Packages  \n********************\n\n")
+	cd(julia_pkgdir()) do 
+	for pkg in Metadata.each_package()
+		print(" Processing $(pkg)\n")
+		url = (Metadata.pkg_url(pkg))
+		maxv = Metadata.versions([pkg])[end]
+		url_reg = r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?"
+		gh_path_reg_git=r"^/(.*)?/(.*)?.git$"
+		gh_path_reg_http=r"^/(.*)?/(.*)?$"
+		m=match(url_reg, url)
+		host=m.captures[4]
+		path=m.captures[5]
+		scheme=m.captures[2]
+		fullname = "Unkown"
+		avatar = "Not on Github"
+		desc = "Not provided"
+		homepage = nothing
+		html_url = url
+		user_url = url
+
+		if ismatch(r"github\.com", host)
+			m2 = match(gh_path_reg_git, path)
+			user=m2.captures[1]
+			repo=m2.captures[2]
+			gh_repo_url = "https://api.github.com/repos/$(user)/$(repo)?access_token=$(gh_auth)"
+			gh_user_url = "https://api.github.com/users/$(user)?access_token=$(gh_auth)"
+			#print("processing $gh_repo_url")
+			gh_repo=JSON.parse(readall(download_file(gh_repo_url)))
+			#print("processing $gh_user_url")
+			gh_user=JSON.parse(readall(download_file(gh_user_url)))
+			fullname = get(gh_user, "name", user)
+			avatar = gh_user["avatar_url"]
+			user_url = gh_user["html_url"]
+			desc = get(gh_repo, "description", "No description provided")
+			homepage = get(gh_repo, "homepage", nothing)
+			html_url = gh_repo["html_url"]
+		end
+		print(io, "`$(pkg) <$(html_url)>`_\n"); 
+		print(io, "_"^(length("`$(pkg) <$(html_url)>`_")) * "\n\n")
+		print(io, "  Current Version: ``$(maxv.version)``\n\n"); 
+		print(io, "  $(desc) \n\n")
+		print(io, "  Maintainer: `$(fullname) <$user_url>`_\n\n") 
+		
+		if homepage != nothing && length(chomp(homepage)) > 0
+			print(io, "  More Info: `<$(homepage)>`_ \n\n")
+		end
+		print(io, "  Dependencies::\n\n" )
+		ver_dir = "METADATA/$pkg/versions/$(maxv.version)/requires"
+		any_ver = "Any Version"
+		if isfile(ver_dir)
+			vset = Metadata.parse_requires(ver_dir)
+			if length(vset) > 0
+				for deps in vset
+					print(io, "      $(deps.package)"); print(io, " "^(15-length(deps.package))); print(io, "$(length(deps.versions)>0 ? deps.versions : any_ver)\n")
+				end
+			else 
+				print(io, "      None\n")
+			end
+		else 
+			print(io, "      None\n")
+		end
+		print(io, "\n")
+	end  #for
+	end  #cd
+	close(io)
+end #function
+
+gen_listpkg()

--- a/doc/packages/packagelist.rst
+++ b/doc/packages/packagelist.rst
@@ -1,0 +1,702 @@
+********************
+ Available Packages  
+********************
+
+`ArgParse <https://github.com/carlobaldassi/ArgParse.jl>`_
+__________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Package for parsing command-line arguments to Julia programs. 
+
+  Maintainer: `Carlo Baldassi <https://github.com/carlobaldassi>`_
+
+  Dependencies::
+
+      Options        Any Version
+      TextWrap       Any Version
+
+`Cairo <https://github.com/JuliaLang/Cairo.jl>`_
+________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Bindings to the Cairo graphics library. 
+
+  Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
+
+  Dependencies::
+
+      Color          Any Version
+
+`Calculus <https://github.com/johnmyleswhite/Calculus.jl>`_
+___________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Calculus functions in Julia 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      None
+
+`Calendar <https://github.com/nolta/Calendar.jl>`_
+__________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Calendar time package for Julia 
+
+  Maintainer: `Mike Nolta <https://github.com/nolta>`_
+
+  Dependencies::
+
+      ICU            Any Version
+
+`Clustering <https://github.com/johnmyleswhite/Clustering.jl>`_
+_______________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Basic functions for clustering data: k-means, dp-means, etc. 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      DataFrames     Any Version
+
+`Color <https://github.com/JuliaLang/Color.jl>`_
+________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Basic color manipulation utilities. 
+
+  Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
+
+  Dependencies::
+
+      None
+
+`Compose <https://github.com/dcjones/Compose.jl>`_
+__________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Declarative vector graphics 
+
+  Maintainer: `Daniel Jones <https://github.com/dcjones>`_
+
+  Dependencies::
+
+      None
+
+`DataFrames <https://github.com/HarlanH/DataFrames.jl>`_
+________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  library for working with tabular data in Julia 
+
+  Maintainer: `Harlan Harris <https://github.com/HarlanH>`_
+
+  Dependencies::
+
+      Options        Any Version
+
+`Debug <https://github.com/toivoh/Debug.jl>`_
+_____________________________________________
+
+  Current Version: ``0.0.0``
+
+  Prototype interactive debugger for Julia 
+
+  Maintainer: `toivoh <https://github.com/toivoh>`_
+
+  Dependencies::
+
+      None
+
+`Distributions <https://github.com/JuliaStats/Distributions.jl>`_
+_________________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  A Julia package for probability distributions and associated funtions. 
+
+  Maintainer: `JuliaStats <https://github.com/JuliaStats>`_
+
+  Dependencies::
+
+      None
+
+`Example <https://github.com/JuliaLang/Example.jl>`_
+____________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Example Julia package repo. 
+
+  Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
+
+  Dependencies::
+
+      None
+
+`FITSIO <https://github.com/nolta/FITSIO.jl>`_
+______________________________________________
+
+  Current Version: ``0.0.0``
+
+  FITS file package for Julia 
+
+  Maintainer: `Mike Nolta <https://github.com/nolta>`_
+
+  Dependencies::
+
+      None
+
+`FileFind <https://github.com/johnmyleswhite/FileFind.jl>`_
+___________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  File::Find implementation in Julia 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      None
+
+`GLU <https://github.com/rennis250/GLU.jl>`_
+____________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia interface to GLU 
+
+  Maintainer: `Robert Ennis <https://github.com/rennis250>`_
+
+  Dependencies::
+
+      GetC           Any Version
+
+`GLUT <https://github.com/rennis250/GLUT.jl>`_
+______________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia interface to GLUT 
+
+  Maintainer: `Robert Ennis <https://github.com/rennis250>`_
+
+  Dependencies::
+
+      GLU            Any Version
+      GetC           Any Version
+      OpenGL         Any Version
+
+`Gadfly <https://github.com/dcjones/Gadfly.jl>`_
+________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Crafty statistical graphics for Julia. 
+
+  Maintainer: `Daniel Jones <https://github.com/dcjones>`_
+
+  Dependencies::
+
+      Compose        Any Version
+      DataFrames     Any Version
+      Distributions  Any Version
+      Iterators      Any Version
+
+`GetC <https://github.com/rennis250/GetC.jl>`_
+______________________________________________
+
+  Current Version: ``0.0.0``
+
+  Minimal implementation of Jasper's Julia FFI 
+
+  Maintainer: `Robert Ennis <https://github.com/rennis250>`_
+
+  Dependencies::
+
+      None
+
+`Graphs <https://github.com/johnmyleswhite/Graphs.jl>`_
+_______________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Working with graphs in Julia 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      DataFrames     Any Version
+
+`Grid <https://github.com/timholy/Grid.jl>`_
+____________________________________________
+
+  Current Version: ``0.0.0``
+
+  Grid operations for the Julia language 
+
+  Maintainer: `Tim Holy <https://github.com/timholy>`_
+
+  Dependencies::
+
+      None
+
+`HDF5 <https://github.com/timholy/HDF5.jl>`_
+____________________________________________
+
+  Current Version: ``0.0.0``
+
+  HDF5 interface for the Julia language 
+
+  Maintainer: `Tim Holy <https://github.com/timholy>`_
+
+  Dependencies::
+
+      None
+
+`HTTP <https://github.com/dirk/HTTP.jl>`_
+_________________________________________
+
+  Current Version: ``0.0.0``
+
+  HTTP library (server, client, parser) for the Julia language 
+
+  Maintainer: `Dirk Gadsden <https://github.com/dirk>`_
+
+  Dependencies::
+
+      None
+
+`HypothesisTests <https://github.com/simonster/HypothesisTests.jl>`_
+____________________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  T-tests, Wilcoxon rank sum (Mann-Whitney U), signed rank, and circular statistics in Julia 
+
+  Maintainer: `Simon Kornblith <https://github.com/simonster>`_
+
+  Dependencies::
+
+      None
+
+`ICU <https://github.com/nolta/ICU.jl>`_
+________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia wrapper for the International Components for Unicode (ICU) library 
+
+  Maintainer: `Mike Nolta <https://github.com/nolta>`_
+
+  Dependencies::
+
+      UTF16          Any Version
+
+`IniFile <https://github.com/JuliaLang/IniFile.jl>`_
+____________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Reading and writing Windows-style INI files (writing not yet implemented). 
+
+  Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
+
+  Dependencies::
+
+      None
+
+`Iterators <https://github.com/JuliaLang/Iterators.jl>`_
+________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Common functional iterator patterns. 
+
+  Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
+
+  Dependencies::
+
+      None
+
+`Ito <https://github.com/aviks/Ito.jl>`_
+________________________________________
+
+  Current Version: ``0.0.0``
+
+  A Julia package for quantitative finance 
+
+  Maintainer: `Avik Sengupta <https://github.com/aviks>`_
+
+  More Info: `<http://aviks.github.com/Ito.jl/>`_ 
+
+  Dependencies::
+
+      Calendar       Any Version
+      Distributions  Any Version
+
+`JSON <https://github.com/aviks/JSON.jl>`_
+__________________________________________
+
+  Current Version: ``0.0.0``
+
+  JSON parsing and printing 
+
+  Maintainer: `Avik Sengupta <https://github.com/aviks>`_
+
+  Dependencies::
+
+      None
+
+`Languages <https://github.com/johnmyleswhite/Languages.jl>`_
+_____________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  A package for working with human languages 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      None
+
+`Loss <https://github.com/johnmyleswhite/Loss.jl>`_
+___________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Loss functions 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      None
+
+`MAT <https://github.com/simonster/MAT.jl>`_
+____________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia module for reading MATLAB files 
+
+  Maintainer: `Simon Kornblith <https://github.com/simonster>`_
+
+  Dependencies::
+
+      HDF5           Any Version
+
+`MCMC <https://github.com/doobwa/MCMC.jl>`_
+___________________________________________
+
+  Current Version: ``0.0.0``
+
+  MCMC tools for Julia 
+
+  Maintainer: `Chris DuBois <https://github.com/doobwa>`_
+
+  Dependencies::
+
+      Options        Any Version
+
+`Mongrel2 <https://github.com/aviks/Mongrel2.jl>`_
+__________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Mongrel2 handlers in Julia 
+
+  Maintainer: `Avik Sengupta <https://github.com/aviks>`_
+
+  Dependencies::
+
+      JSON           Any Version
+      ZMQ            Any Version
+
+`NHST <https://github.com/johnmyleswhite/NHST.jl>`_
+___________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Null hypothesis significance tests 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      None
+
+`Named <https://github.com/HarlanH/Named.jl>`_
+______________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia named index and named vector types 
+
+  Maintainer: `Harlan Harris <https://github.com/HarlanH>`_
+
+  Dependencies::
+
+      None
+
+`OpenGL <https://github.com/rennis250/OpenGL.jl>`_
+__________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia interface to OpenGL 
+
+  Maintainer: `Robert Ennis <https://github.com/rennis250>`_
+
+  Dependencies::
+
+      GetC           Any Version
+
+`Optim <https://github.com/johnmyleswhite/Optim.jl>`_
+_____________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Optimization functions for Julia 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  More Info: `<http://johnmyleswhite.com>`_ 
+
+  Dependencies::
+
+      Calculus       Any Version
+      Distributions  Any Version
+      Options        Any Version
+
+`Options <https://github.com/JuliaLang/Options.jl>`_
+____________________________________________________
+
+  Current Version: ``0.0.0``
+
+  A framework for providing optional arguments to functions. 
+
+  Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
+
+  Dependencies::
+
+      None
+
+`PLX <https://github.com/simonster/PLX.jl>`_
+____________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia module for reading Plexon PLX files 
+
+  Maintainer: `Simon Kornblith <https://github.com/simonster>`_
+
+  Dependencies::
+
+      None
+
+`PatternDispatch <https://github.com/toivoh/PatternDispatch.jl>`_
+_________________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Method dispatch based on pattern matching for Julia 
+
+  Maintainer: `toivoh <https://github.com/toivoh>`_
+
+  Dependencies::
+
+      None
+
+`ProjectTemplate <https://github.com/johnmyleswhite/ProjectTemplate.jl>`_
+_________________________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  ProjectTemplate for Julia 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      DataFrames     Any Version
+      JSON           Any Version
+
+`RDatasets <https://github.com/johnmyleswhite/RDatasets.jl>`_
+_____________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia package for loading many of the data sets available in R 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      DataFrames     Any Version
+
+`Rif <https://github.com/lgautier/Rif.jl>`_
+___________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia-to-R interface 
+
+  Maintainer: `Laurent Gautier <https://github.com/lgautier>`_
+
+  Dependencies::
+
+      None
+
+`SDL <https://github.com/rennis250/SDL.jl>`_
+____________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia interface to SDL 
+
+  Maintainer: `Robert Ennis <https://github.com/rennis250>`_
+
+  Dependencies::
+
+      GLU            Any Version
+      GetC           Any Version
+      OpenGL         Any Version
+
+`Sims <https://github.com/tshort/Sims.jl>`_
+___________________________________________
+
+  Current Version: ``0.0.0``
+
+  Experiments with non-causal, equation-based modeling in Julia 
+
+  Maintainer: `Tom Short <https://github.com/tshort>`_
+
+  Dependencies::
+
+      None
+
+`Sound <https://github.com/JuliaLang/Sound.jl>`_
+________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Reading and writing from WAV files (should probably be named WAV). 
+
+  Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
+
+  Dependencies::
+
+      Options        Any Version
+
+`TextAnalysis <https://github.com/johnmyleswhite/TextAnalysis.jl>`_
+___________________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia package for text analysis 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      DataFrames     Any Version
+      FileFind       Any Version
+      Languages      Any Version
+
+`TextWrap <https://github.com/carlobaldassi/TextWrap.jl>`_
+__________________________________________________________
+
+  Current Version: ``0.0.0``
+
+  Package for wrapping text into paragraphs. 
+
+  Maintainer: `Carlo Baldassi <https://github.com/carlobaldassi>`_
+
+  Dependencies::
+
+      Options        Any Version
+
+`Tk <https://github.com/JuliaLang/Tk.jl>`_
+__________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia interface to Tk windowing toolkit. 
+
+  Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
+
+  Dependencies::
+
+      Cairo          Any Version
+
+`Trie <https://github.com/JuliaLang/Trie.jl>`_
+______________________________________________
+
+  Current Version: ``0.0.0``
+
+  Implementation of the trie data structure. 
+
+  Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
+
+  Dependencies::
+
+      None
+
+`UTF16 <https://github.com/nolta/UTF16.jl>`_
+____________________________________________
+
+  Current Version: ``0.0.0``
+
+  UTF16 string type for Julia 
+
+  Maintainer: `Mike Nolta <https://github.com/nolta>`_
+
+  Dependencies::
+
+      None
+
+`Winston <https://github.com/nolta/Winston.jl>`_
+________________________________________________
+
+  Current Version: ``0.0.0``
+
+  2D plotting for Julia 
+
+  Maintainer: `Mike Nolta <https://github.com/nolta>`_
+
+  Dependencies::
+
+      Cairo          Any Version
+      Color          Any Version
+      IniFile        Any Version
+      Tk             Any Version
+
+`ZMQ <https://github.com/aviks/ZMQ.jl>`_
+________________________________________
+
+  Current Version: ``0.0.0``
+
+  Julia interface to ZMQ 
+
+  Maintainer: `Avik Sengupta <https://github.com/aviks>`_
+
+  Dependencies::
+
+      None
+

--- a/doc/packages/packagelist.rst
+++ b/doc/packages/packagelist.rst
@@ -5,6 +5,13 @@
 `ArgParse <https://github.com/carlobaldassi/ArgParse.jl>`_
 __________________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/80502de63c1b21d8f3ba663d72ba5be2?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Carlo Baldassi
+
+
   Current Version: ``0.0.0``
 
   Package for parsing command-line arguments to Julia programs. 
@@ -19,6 +26,12 @@ __________________________________________________________
 `Cairo <https://github.com/JuliaLang/Cairo.jl>`_
 ________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/d57c99557ab0dc0fa44b4c84447d0f15?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-org-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: The Julia Language
+
   Current Version: ``0.0.0``
 
   Bindings to the Cairo graphics library. 
@@ -31,6 +44,12 @@ ________________________________________________
 
 `Calculus <https://github.com/johnmyleswhite/Calculus.jl>`_
 ___________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
 
   Current Version: ``0.0.0``
 
@@ -45,6 +64,12 @@ ___________________________________________________________
 `Calendar <https://github.com/nolta/Calendar.jl>`_
 __________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Mike Nolta
+
   Current Version: ``0.0.0``
 
   Calendar time package for Julia 
@@ -57,6 +82,12 @@ __________________________________________________
 
 `Clustering <https://github.com/johnmyleswhite/Clustering.jl>`_
 _______________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
 
   Current Version: ``0.0.0``
 
@@ -71,6 +102,12 @@ _______________________________________________________________
 `Color <https://github.com/JuliaLang/Color.jl>`_
 ________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/d57c99557ab0dc0fa44b4c84447d0f15?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-org-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: The Julia Language
+
   Current Version: ``0.0.0``
 
   Basic color manipulation utilities. 
@@ -83,6 +120,12 @@ ________________________________________________
 
 `Compose <https://github.com/dcjones/Compose.jl>`_
 __________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/fd97b03d16e1aa4c404391216d81c1d5?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Daniel Jones
 
   Current Version: ``0.0.0``
 
@@ -97,6 +140,12 @@ __________________________________________________
 `DataFrames <https://github.com/HarlanH/DataFrames.jl>`_
 ________________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/9f1a68b9e623be5da422b44e733fa8bc?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Harlan Harris
+
   Current Version: ``0.0.0``
 
   library for working with tabular data in Julia 
@@ -109,6 +158,12 @@ ________________________________________________________
 
 `Debug <https://github.com/toivoh/Debug.jl>`_
 _____________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/8d3d3934c39b52f48c35a0cc536edae7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: toivoh
 
   Current Version: ``0.0.0``
 
@@ -123,6 +178,12 @@ _____________________________________________
 `Distributions <https://github.com/JuliaStats/Distributions.jl>`_
 _________________________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-org-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: JuliaStats
+
   Current Version: ``0.0.0``
 
   A Julia package for probability distributions and associated funtions. 
@@ -135,6 +196,12 @@ _________________________________________________________________
 
 `Example <https://github.com/JuliaLang/Example.jl>`_
 ____________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/d57c99557ab0dc0fa44b4c84447d0f15?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-org-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: The Julia Language
 
   Current Version: ``0.0.0``
 
@@ -149,6 +216,12 @@ ____________________________________________________
 `FITSIO <https://github.com/nolta/FITSIO.jl>`_
 ______________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Mike Nolta
+
   Current Version: ``0.0.0``
 
   FITS file package for Julia 
@@ -161,6 +234,12 @@ ______________________________________________
 
 `FileFind <https://github.com/johnmyleswhite/FileFind.jl>`_
 ___________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
 
   Current Version: ``0.0.0``
 
@@ -175,6 +254,12 @@ ___________________________________________________________
 `GLU <https://github.com/rennis250/GLU.jl>`_
 ____________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/3753123303ea2852accbce22339f67b4?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Robert Ennis
+
   Current Version: ``0.0.0``
 
   Julia interface to GLU 
@@ -187,6 +272,12 @@ ____________________________________________
 
 `GLUT <https://github.com/rennis250/GLUT.jl>`_
 ______________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/3753123303ea2852accbce22339f67b4?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Robert Ennis
 
   Current Version: ``0.0.0``
 
@@ -202,6 +293,12 @@ ______________________________________________
 
 `Gadfly <https://github.com/dcjones/Gadfly.jl>`_
 ________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/fd97b03d16e1aa4c404391216d81c1d5?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Daniel Jones
 
   Current Version: ``0.0.0``
 
@@ -219,6 +316,12 @@ ________________________________________________
 `GetC <https://github.com/rennis250/GetC.jl>`_
 ______________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/3753123303ea2852accbce22339f67b4?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Robert Ennis
+
   Current Version: ``0.0.0``
 
   Minimal implementation of Jasper's Julia FFI 
@@ -231,6 +334,12 @@ ______________________________________________
 
 `Graphs <https://github.com/johnmyleswhite/Graphs.jl>`_
 _______________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
 
   Current Version: ``0.0.0``
 
@@ -245,6 +354,12 @@ _______________________________________________________
 `Grid <https://github.com/timholy/Grid.jl>`_
 ____________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/2989a078f4caff6fb86fa30e59bd9aa9?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Tim Holy
+
   Current Version: ``0.0.0``
 
   Grid operations for the Julia language 
@@ -257,6 +372,12 @@ ____________________________________________
 
 `HDF5 <https://github.com/timholy/HDF5.jl>`_
 ____________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/2989a078f4caff6fb86fa30e59bd9aa9?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Tim Holy
 
   Current Version: ``0.0.0``
 
@@ -271,6 +392,12 @@ ____________________________________________
 `HTTP <https://github.com/dirk/HTTP.jl>`_
 _________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/d9c8c5a29b60871d14846a382d50626a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Dirk Gadsden
+
   Current Version: ``0.0.0``
 
   HTTP library (server, client, parser) for the Julia language 
@@ -283,6 +410,12 @@ _________________________________________
 
 `HypothesisTests <https://github.com/simonster/HypothesisTests.jl>`_
 ____________________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/9524ef56c2823a59d54f9226a7ef08ba?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Simon Kornblith
 
   Current Version: ``0.0.0``
 
@@ -297,6 +430,12 @@ ____________________________________________________________________
 `ICU <https://github.com/nolta/ICU.jl>`_
 ________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Mike Nolta
+
   Current Version: ``0.0.0``
 
   Julia wrapper for the International Components for Unicode (ICU) library 
@@ -309,6 +448,12 @@ ________________________________________
 
 `IniFile <https://github.com/JuliaLang/IniFile.jl>`_
 ____________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/d57c99557ab0dc0fa44b4c84447d0f15?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-org-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: The Julia Language
 
   Current Version: ``0.0.0``
 
@@ -323,6 +468,12 @@ ____________________________________________________
 `Iterators <https://github.com/JuliaLang/Iterators.jl>`_
 ________________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/d57c99557ab0dc0fa44b4c84447d0f15?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-org-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: The Julia Language
+
   Current Version: ``0.0.0``
 
   Common functional iterator patterns. 
@@ -335,6 +486,12 @@ ________________________________________________________
 
 `Ito <https://github.com/aviks/Ito.jl>`_
 ________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/f5c61e85dfa465686adc24e0bffba42a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Avik Sengupta
 
   Current Version: ``0.0.0``
 
@@ -352,6 +509,12 @@ ________________________________________
 `JSON <https://github.com/aviks/JSON.jl>`_
 __________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/f5c61e85dfa465686adc24e0bffba42a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Avik Sengupta
+
   Current Version: ``0.0.0``
 
   JSON parsing and printing 
@@ -364,6 +527,12 @@ __________________________________________
 
 `Languages <https://github.com/johnmyleswhite/Languages.jl>`_
 _____________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
 
   Current Version: ``0.0.0``
 
@@ -378,6 +547,12 @@ _____________________________________________________________
 `Loss <https://github.com/johnmyleswhite/Loss.jl>`_
 ___________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
+
   Current Version: ``0.0.0``
 
   Loss functions 
@@ -390,6 +565,12 @@ ___________________________________________________
 
 `MAT <https://github.com/simonster/MAT.jl>`_
 ____________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/9524ef56c2823a59d54f9226a7ef08ba?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Simon Kornblith
 
   Current Version: ``0.0.0``
 
@@ -404,6 +585,12 @@ ____________________________________________
 `MCMC <https://github.com/doobwa/MCMC.jl>`_
 ___________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/1a4672a0ae94c24f02517dea26097f58?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Chris DuBois
+
   Current Version: ``0.0.0``
 
   MCMC tools for Julia 
@@ -416,6 +603,12 @@ ___________________________________________
 
 `Mongrel2 <https://github.com/aviks/Mongrel2.jl>`_
 __________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/f5c61e85dfa465686adc24e0bffba42a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Avik Sengupta
 
   Current Version: ``0.0.0``
 
@@ -431,6 +624,12 @@ __________________________________________________
 `NHST <https://github.com/johnmyleswhite/NHST.jl>`_
 ___________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
+
   Current Version: ``0.0.0``
 
   Null hypothesis significance tests 
@@ -443,6 +642,12 @@ ___________________________________________________
 
 `Named <https://github.com/HarlanH/Named.jl>`_
 ______________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/9f1a68b9e623be5da422b44e733fa8bc?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Harlan Harris
 
   Current Version: ``0.0.0``
 
@@ -457,6 +662,12 @@ ______________________________________________
 `OpenGL <https://github.com/rennis250/OpenGL.jl>`_
 __________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/3753123303ea2852accbce22339f67b4?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Robert Ennis
+
   Current Version: ``0.0.0``
 
   Julia interface to OpenGL 
@@ -469,6 +680,12 @@ __________________________________________________
 
 `Optim <https://github.com/johnmyleswhite/Optim.jl>`_
 _____________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
 
   Current Version: ``0.0.0``
 
@@ -487,6 +704,12 @@ _____________________________________________________
 `Options <https://github.com/JuliaLang/Options.jl>`_
 ____________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/d57c99557ab0dc0fa44b4c84447d0f15?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-org-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: The Julia Language
+
   Current Version: ``0.0.0``
 
   A framework for providing optional arguments to functions. 
@@ -499,6 +722,12 @@ ____________________________________________________
 
 `PLX <https://github.com/simonster/PLX.jl>`_
 ____________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/9524ef56c2823a59d54f9226a7ef08ba?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Simon Kornblith
 
   Current Version: ``0.0.0``
 
@@ -513,6 +742,12 @@ ____________________________________________
 `PatternDispatch <https://github.com/toivoh/PatternDispatch.jl>`_
 _________________________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/8d3d3934c39b52f48c35a0cc536edae7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: toivoh
+
   Current Version: ``0.0.0``
 
   Method dispatch based on pattern matching for Julia 
@@ -525,6 +760,12 @@ _________________________________________________________________
 
 `ProjectTemplate <https://github.com/johnmyleswhite/ProjectTemplate.jl>`_
 _________________________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
 
   Current Version: ``0.0.0``
 
@@ -540,6 +781,12 @@ _________________________________________________________________________
 `RDatasets <https://github.com/johnmyleswhite/RDatasets.jl>`_
 _____________________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
+
   Current Version: ``0.0.0``
 
   Julia package for loading many of the data sets available in R 
@@ -553,6 +800,12 @@ _____________________________________________________________
 `Rif <https://github.com/lgautier/Rif.jl>`_
 ___________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/8e5422a173711c086b685140dbc498fe?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Laurent Gautier
+
   Current Version: ``0.0.0``
 
   Julia-to-R interface 
@@ -565,6 +818,12 @@ ___________________________________________
 
 `SDL <https://github.com/rennis250/SDL.jl>`_
 ____________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/3753123303ea2852accbce22339f67b4?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Robert Ennis
 
   Current Version: ``0.0.0``
 
@@ -581,6 +840,12 @@ ____________________________________________
 `Sims <https://github.com/tshort/Sims.jl>`_
 ___________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/903acb22f47a901577ee48d3962d5858?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Tom Short
+
   Current Version: ``0.0.0``
 
   Experiments with non-causal, equation-based modeling in Julia 
@@ -594,6 +859,12 @@ ___________________________________________
 `Sound <https://github.com/JuliaLang/Sound.jl>`_
 ________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/d57c99557ab0dc0fa44b4c84447d0f15?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-org-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: The Julia Language
+
   Current Version: ``0.0.0``
 
   Reading and writing from WAV files (should probably be named WAV). 
@@ -606,6 +877,12 @@ ________________________________________________
 
 `TextAnalysis <https://github.com/johnmyleswhite/TextAnalysis.jl>`_
 ___________________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
 
   Current Version: ``0.0.0``
 
@@ -622,6 +899,12 @@ ___________________________________________________________________
 `TextWrap <https://github.com/carlobaldassi/TextWrap.jl>`_
 __________________________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/80502de63c1b21d8f3ba663d72ba5be2?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Carlo Baldassi
+
   Current Version: ``0.0.0``
 
   Package for wrapping text into paragraphs. 
@@ -634,6 +917,12 @@ __________________________________________________________
 
 `Tk <https://github.com/JuliaLang/Tk.jl>`_
 __________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/d57c99557ab0dc0fa44b4c84447d0f15?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-org-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: The Julia Language
 
   Current Version: ``0.0.0``
 
@@ -648,6 +937,12 @@ __________________________________________
 `Trie <https://github.com/JuliaLang/Trie.jl>`_
 ______________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/d57c99557ab0dc0fa44b4c84447d0f15?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-org-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: The Julia Language
+
   Current Version: ``0.0.0``
 
   Implementation of the trie data structure. 
@@ -661,6 +956,12 @@ ______________________________________________
 `UTF16 <https://github.com/nolta/UTF16.jl>`_
 ____________________________________________
 
+  .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Mike Nolta
+
   Current Version: ``0.0.0``
 
   UTF16 string type for Julia 
@@ -673,6 +974,12 @@ ____________________________________________
 
 `Winston <https://github.com/nolta/Winston.jl>`_
 ________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Mike Nolta
 
   Current Version: ``0.0.0``
 
@@ -689,6 +996,12 @@ ________________________________________________
 
 `ZMQ <https://github.com/aviks/ZMQ.jl>`_
 ________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/f5c61e85dfa465686adc24e0bffba42a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Avik Sengupta
 
   Current Version: ``0.0.0``
 


### PR DESCRIPTION
This creates a page as part of the julia documentation suite with  the details of currently available packages as specified in the METADATA. As requested in #1896

There are a couple of issues for comments
1. This needs a Github OAuth token, since un-authenticated requests are limited to 60 per hour, which is not enough given the number of packages we have. Therefore, you need to specify the token as an environment variable GH_AUTH for the script to work. 
   
   Once the auth token is specified, run `make listpkg` to create the latest listing. Note that this will update your metadata repository, and install the JSON package if you dont have it yet. 
2.  I have checked in the resultant packagelist.rst. This is up for debate, but I thought that the requirements above should not be made mandatory for everyone who wants to build the docs locally. 

**Note**:  Read on if you don't already have an access token you can use. 

To create a github oauth token, you will need to have a registered github application. Once you have an application, you can then call 

```
curl -i -u <gh-user> -d @gh_auth https://api.github.com/authorizations
```

This will prompt for your gh password using basic authentication. `gh_auth` is a local file containing: 

``` JSON
{
  "scopes": ["public_repo"],
  "client_id":"<application client id>",
  "client_secret":"<application client secret>",
  "note": "For Julia Metadata Listings"
}
```

Registered applications and authorised token are visible within your github profile page. 

Contact me privately if you wan to use my registered app to create a token. 

To reiterate, you dont have to do all this to check out how the docs look. Just run `make html`, and you'll get a listing valid as of this writing. 
