### PR TITLE
added is_initialized() and made init() fail smoothly

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -50,10 +50,9 @@ status(pkg::String) = print_pkg_status(pkg, "$(julia_pkgdir())/$pkg")
 # create a new empty packge repository
 
 function init(meta::String)
+    if is_initialized() return end
+
     dir = julia_pkgdir()
-    if isdir(dir)
-        error("Package directory $dir already exists.")
-    end
     try
         run(`mkdir -p $dir`)
         cd(dir) do
@@ -83,6 +82,8 @@ function init(meta::String)
     end
 end
 init() = init(DEFAULT_META)
+
+is_initialized() = isdir(julia_pkgdir())
 
 # get/set the origin url for package repo
 


### PR DESCRIPTION
I don't know how you're going to feel about this, but let me explain:

I would like some way to programmatically know whether or not to call `init` (without trigging an error). It doesn't have the most amazing name in the world, but `is_initialized` does this.

In addition / alternatively, I would like to be able to call `init` without turning into a nervous wreck over whether it will fail or not, so I changed it to simply bail out. I don't know of a situation where this causes problems, especially considering that you still know whether you created a repo based on output, but I could have missed something.
