### PR TITLE
Remove double error output

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -321,7 +321,6 @@ void *init_stdio_handle(uv_file fd,int readable)
             break;
         case UV_NAMED_PIPE:
         case UV_FILE:
-            ios_printf(ios_stdout,"Using pipes/files as STDIO is not yet supported. Proceed with caution!\n");
             ios_printf(ios_stderr,"Using pipes/files as STDIO is not yet supported. Proceed with caution!\n");
             handle = malloc(sizeof(uv_pipe_t));
             uv_pipe_init(jl_io_loop, (uv_pipe_t*)handle,(readable?UV_PIPE_READABLE:UV_PIPE_WRITEABLE));


### PR DESCRIPTION
I was parsing the output of julia within a script, and this was broken by the extra line of output to stdout. I think a single error message to stderr is more appropriate (if any message is actually necessary).
