### PR TITLE
RFC: Add a post install hook for packages

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -252,10 +252,25 @@ function _resolve()
                 Git.autoconfig_pushurl()
             end
             run(`git add -- $pkg`)
+            _postinstall(pkg)
         end
     end
 end
 resolve() = cd(_resolve,julia_pkgdir())
+
+function _postinstall(pkg)
+	@eval module ($(symbol(randstring(20))))
+              p=$pkg
+              try 
+                pf="$(julia_pkgdir())/"*$(pkg)*"/src/postinstall.jl"
+		if isfile(pf)
+                   include(pf)
+                end
+	      catch e
+                  print("Error running postinstall script. Package is still installed. Use Pkg.rm(...) to remove.\n\n$e")
+	      end
+       end
+end
 
 # clone a new package repo from a URL
 


### PR DESCRIPTION
This change: 

Loads a file named postinstall.jl from within the ./src/ directory of the package. The package directory is the cwd when this file is loaded. 

The file is also loaded from within an anonymous module to ensure that the main module context is not corrupted. I think this is a good idea to ensure that running a module just after install is no different from running it later. Of course, in a dynamic language like Julia its no guarantee, but nonetheless, its some protection. 

Let me know what you think. My metaprogramming chops aren't the best. 
