### PR TITLE
'a' - 32 = 65 (?)

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -42,7 +42,7 @@ promote_rule(::Type{Char}, ::Type{Uint128}) = Uint128
 
 ## character operations & comparisons ##
 
--(x::Char, y::Char) = int(x)-int(y)
+-(x::Char, y::Char) = char(int(x)-int(y))
 +(x::Char, y::Char) = char(int(x)+int(y)) # TODO: delete me
 +(x::Char, y::Int ) = char(int(x)+y)
 +(x::Int , y::Char) = y+x


### PR DESCRIPTION
```
julia> 'A' + 32
'a'

julia> 'a' - 32
65
```

Isn't consistent and can cause problem for get uppercase using `- 32`

```
-(x::Char, y::Char) = char(int(x)-int(y)) 
```

solves the problem
