### PR TITLE
RFC: change include to search relative to parent file, not cwd

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1129,6 +1129,15 @@ function findfirst(testf::Function, A)
     return 0
 end
 
+function findlast(testf::Function, A)
+    for i = length(A):-1:1
+        if testf(A[i])
+            return i
+        end
+    end
+    return 0
+end
+
 function find(testf::Function, A::StridedArray)
     # use a dynamic-length array to store the indexes, then copy to a non-padded
     # array for the return


### PR DESCRIPTION
I think it would be better if `include` resolved paths relative to the calling file, not the current working directory. That way modules could write

```
include("subfile.jl")
```

instead of

```
include(find_in_path("Module/src/subfile.jl"))
```
