### PR TITLE
my take on relative includes

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -109,7 +109,7 @@
 # type Task
 #     parent::Task
 #     last::Task
-#     tls::Any
+#     storage::Any
 #     consumers
 #     done::Bool
 #     runnable::Bool

--- a/base/export.jl
+++ b/base/export.jl
@@ -1048,7 +1048,7 @@ export
     current_task,
     istaskdone,
     produce,
-    tls,
+    task_local_storage,
 
 # time
     sleep,

--- a/base/task.jl
+++ b/base/task.jl
@@ -3,22 +3,15 @@ show(io, t::Task) = print(io, "Task")
 current_task() = ccall(:jl_get_current_task, Task, ())
 istaskdone(t::Task) = t.done
 
-# task-local storage
-function tls()
+function task_local_storage()
     t = current_task()
-    if is(t.tls, nothing)
-        t.tls = ObjectIdDict()
+    if is(t.storage, nothing)
+        t.storage = ObjectIdDict()
     end
-    (t.tls)::ObjectIdDict
+    (t.storage)::ObjectIdDict
 end
-
-function tls(key)
-    tls()[key]
-end
-
-function tls(key, val)
-    tls()[key] = val
-end
+task_local_storage(key) = task_local_storage()[key]
+task_local_storage(key, val) = (task_local_storage()[key] = val)
 
 function produce(v)
     ct = current_task()

--- a/base/util.jl
+++ b/base/util.jl
@@ -246,15 +246,18 @@ function include_from_node1(path)
     prev = get(tls, :SOURCE_PATH, nothing)
     path = (prev == nothing) ? abspath(path) : joinpath(dirname(prev),path)
     tls[:SOURCE_PATH] = path
-    if myid()==1
-        Core.include(path)
-    else
-        include_string(remote_call_fetch(1, readall, path))
-    end
-    if prev == nothing
-        delete!(tls, :SOURCE_PATH)
-    else
-        tls[:SOURCE_PATH] = prev
+    try
+        if myid()==1
+            Core.include(path)
+        else
+            include_string(remote_call_fetch(1, readall, path))
+        end
+    finally
+        if prev == nothing
+            delete!(tls, :SOURCE_PATH)
+        else
+            tls[:SOURCE_PATH] = prev
+        end
     end
     nothing
 end

--- a/base/util.jl
+++ b/base/util.jl
@@ -264,10 +264,10 @@ end
 
 function reload_path(path)
     tls = task_local_storage()
-    prev = get(tls, :SOURCE_PATH, nothing)
-    delete!(tls, :SOURCE_PATH)
     had = has(package_list, path)
     package_list[path] = time()
+    prev = get(tls, :SOURCE_PATH, nothing)
+    delete!(tls, :SOURCE_PATH)
     try
         eval(Main, :(Base.include_from_node1($path)))
     catch e
@@ -275,9 +275,10 @@ function reload_path(path)
             delete!(package_list, path)
         end
         rethrow(e)
-    end
-    if prev != nothing
-        tls[:SOURCE_PATH] = prev
+    finally
+        if prev != nothing
+            tls[:SOURCE_PATH] = prev
+        end
     end
     nothing
 end

--- a/base/util.jl
+++ b/base/util.jl
@@ -4,18 +4,18 @@ time() = ccall(:clock_now, Float64, ())
 
 function tic()
     t0 = time()
-    tls(:TIMERS, (t0, get(tls(), :TIMERS, ())))
+    task_local_storage(:TIMERS, (t0, get(task_local_storage(), :TIMERS, ())))
     return t0
 end
 
 function toq()
     t1 = time()
-    timers = get(tls(), :TIMERS, ())
+    timers = get(task_local_storage(), :TIMERS, ())
     if is(timers,())
         error("toc() without tic()")
     end
     t0 = timers[1]
-    tls(:TIMERS, timers[2])
+    task_local_storage(:TIMERS, timers[2])
     t1-t0
 end
 

--- a/extras/glpk.jl
+++ b/extras/glpk.jl
@@ -171,7 +171,7 @@ import Base.pointer, Base.assign, Base.ref
 
 ## Shared library interface setup
 #{{{
-include("$JULIA_HOME/../share/julia/extras/glpk_h.jl")
+include("glpk_h.jl")
 
 macro glpk_ccall(f, args...)
     :(ccall(($"glp_$(f)", :libglpk), $(args...)))

--- a/extras/gmp.jl
+++ b/extras/gmp.jl
@@ -31,7 +31,7 @@ import
     Base.sqrt,
     Base.string
 
-include(find_in_path("extras/bigint.jl"))
-include(find_in_path("extras/bigfloat.jl"))
+include("bigint.jl")
+include("bigfloat.jl")
 
 end # module

--- a/extras/gzip.jl
+++ b/extras/gzip.jl
@@ -69,7 +69,7 @@ export
   Z_DEFAULT_BUFSIZE,
   Z_BIG_BUFSIZE
 
-include("$JULIA_HOME/../share/julia/extras/zlib_h.jl")
+include("zlib_h.jl")
 
 # Expected line length for strings
 const GZ_LINE_BUFSIZE = 256

--- a/extras/julia_web_base.jl
+++ b/extras/julia_web_base.jl
@@ -16,7 +16,7 @@
 # [message_type::number, arg0::string, arg1::string, ...]
 
 # import the message types
-include(find_in_path("webrepl_msgtypes_h"))
+include("webrepl_msgtypes_h.jl")
 
 ###########################################
 # set up the socket connection
@@ -83,7 +83,7 @@ end
 ###########################################
 
 # load the special functions available to the web repl
-include(find_in_path("julia_web"))
+include("julia_web.jl")
 
 ###########################################
 # input event handler

--- a/extras/strpack.jl
+++ b/extras/strpack.jl
@@ -1,4 +1,4 @@
-include(find_in_path("lru"))
+include("lru.jl")
 
 import Base.isequal, Base.length, Base.ref
 

--- a/extras/suitesparse.jl
+++ b/extras/suitesparse.jl
@@ -29,7 +29,7 @@ export                                  # types
     At_ldiv_B,
     Ac_ldiv_B
 
-include(find_in_path("suitesparse_h"))
+include("suitesparse_h.jl")
 
 const libsuitesparse_wrapper = "libsuitesparse_wrapper"
 const libcholmod = "libcholmod"

--- a/extras/zlib.jl
+++ b/extras/zlib.jl
@@ -43,7 +43,7 @@ export
 #   Z_BIG_BUFSIZE,
 #   ZFileOffset
 
-include(find_in_path("zlib_h"))
+include("zlib_h.jl")
 
 # zlib functions
 

--- a/src/task.c
+++ b/src/task.c
@@ -703,17 +703,23 @@ jl_function_t *jl_unprotect_stack_func;
 void jl_init_tasks(void *stack, size_t ssize)
 {
     _probe_arch();
-    jl_task_type = jl_new_struct_type(jl_symbol("Task"), jl_any_type,
+    jl_task_type = jl_new_struct_type(jl_symbol("Task"),
+                                      jl_any_type,
                                       jl_null,
-                                      jl_tuple(6, jl_symbol("parent"),
+                                      jl_tuple(6,
+                                               jl_symbol("parent"),
                                                jl_symbol("last"),
-                                               jl_symbol("tls"),
+                                               jl_symbol("storage"),
                                                jl_symbol("consumers"),
                                                jl_symbol("done"),
                                                jl_symbol("runnable")),
-                                      jl_tuple(6, jl_any_type, jl_any_type,
-                                               jl_any_type, jl_any_type,
-                                               jl_bool_type, jl_bool_type));
+                                      jl_tuple(6,
+                                               jl_any_type,
+                                               jl_any_type,
+                                               jl_any_type,
+                                               jl_any_type,
+                                               jl_bool_type,
+                                               jl_bool_type));
     jl_tupleset(jl_task_type->types, 0, (jl_value_t*)jl_task_type);
     jl_task_type->fptr = jl_f_task;
 


### PR DESCRIPTION
This actually changes the behaviors of `require`, `reload` and `include` and passes all tests. This shouldn't break any packages but will obviate the need for the `include(find_in_path("foo"))` hack. Alternative to https://github.com/JuliaLang/julia/pull/1985.
