### PR TITLE
Fix: position() after skip() did not report correct position.

### DIFF
--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -470,6 +470,7 @@ off_t ios_skip(ios_t *s, off_t offs)
         off_t fdpos = lseek(s->fd, offs, SEEK_CUR);
         if (fdpos == (off_t)-1)
             return fdpos;
+        s->fpos = fdpos;
         s->bpos = s->size = 0;
         s->_eof = 0;
     }


### PR DESCRIPTION
Same fix as in https://github.com/JuliaLang/julia/commit/47dd251ffbbcb4dd9813d0bd1db8dc3f63c3a374#src/support/ios.c and https://github.com/JuliaLang/julia/commit/5482a049f2106caf871480037b0d1d609984f992#src/support/ios.c but this time for skip(). I believe this is the last occurence.
