### PR TITLE
Upgrade Travis to use llvm-3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ compiler:
 notifications:
     email: false
 before_install:
-    - BUILDOPTS="LLVM_CONFIG=llvm-config-3.1 USE_QUIET=0"; for lib in LLVM ZLIB SUITESPARSE ARPACK BLAS FFTW LAPACK LIGHTTPD GMP PCRE LIBUNWIND READLINE GLPK; do export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1"; done
+    - BUILDOPTS="LLVM_CONFIG=llvm-config-3.2 USE_QUIET=0"; for lib in LLVM ZLIB SUITESPARSE ARPACK BLAS FFTW LAPACK LIGHTTPD GMP PCRE LIBUNWIND READLINE GLPK; do export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1"; done
     - sudo apt-get update -qq -y
     - sudo apt-get install zlib1g-dev
     - sudo add-apt-repository ppa:staticfloat/julia-deps -y
     - sudo apt-get update -qq -y
-    - sudo apt-get install gfortran llvm-3.1-dev libsuitesparse-dev libncurses5-dev libopenblas-dev libarpack2-dev libfftw3-dev libpcre3-dev libglpk-dev lighttpd libgmp-dev libunwind7-dev libreadline-dev -y
+    - sudo apt-get install gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev libarpack2-dev libfftw3-dev libpcre3-dev libglpk-dev lighttpd libgmp-dev libunwind7-dev libreadline-dev -y
 script:
     - make $BUILDOPTS PREFIX=/tmp/julia install
     - cd .. && mv julia julia2


### PR DESCRIPTION
This upgrades Travis to use `llvm-3.2`, and announces the release of the `llvm-3.2` .deb available from the [`julia-deps` PPA](https://launchpad.net/~staticfloat/+archive/julia-deps/), compiled to not include `libffi` (as opposed to `llvm-3.1`).
