### PR TITLE
cwd() = pwd() 

### DIFF
--- a/base/export.jl
+++ b/base/export.jl
@@ -1236,6 +1236,7 @@ export
 # filesystem operations
     cd,
     pwd,
+    cwd,
     is_file_readable,
     ls,
     cp,

--- a/base/file.jl
+++ b/base/file.jl
@@ -8,6 +8,10 @@ function pwd()
     bytestring(p)
 end
 
+@windows_only begin
+cwd() = pwd()
+end
+
 cd(dir::String) = system_error(:chdir, ccall(:chdir,Int32,(Ptr{Uint8},),dir) == -1)
 cd() = cd(ENV["HOME"])
 


### PR DESCRIPTION
On my windows build cwd() is undefined and pwd() works just fine...

Maybe this is in order?
