### PR TITLE
show(io::IO, x)

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -17,6 +17,8 @@ cconvert{T}(::Type{Ptr{Ptr{T}}}, a::Array) = a
 # TODO: for some reason this causes a strange type inference problem
 #cconvert(::Type{Ptr{Uint8}}, s::String) = bytestring(s)
 
+abstract IO
+
 type ErrorException <: Exception
     msg::String
 end
@@ -72,9 +74,9 @@ type ShowError <: Exception
     err::Exception
 end
 
-show(io, bt::BackTrace) = show(io,bt.e)
+show(io::IO, bt::BackTrace) = show(io,bt.e)
 
-function show(io, se::ShowError)
+function show(io::IO, se::ShowError)
     println("Error showing value of type ", typeof(se.val), ":")
     show(io, se.err)
 end

--- a/base/char.jl
+++ b/base/char.jl
@@ -63,7 +63,7 @@ sizeof(::Type{Char}) = 4
 ## printing & showing characters ##
 
 print(io::IO, c::Char) = (write(io,c); nothing)
-show(io, c::Char) = (print(io,'\''); print_escaped(io,CharString(c),"'"); print(io,'\''))
+show(io::IO, c::Char) = (print(io,'\''); print_escaped(io,CharString(c),"'"); print(io,'\''))
 
 ## libc character class testing functions ##
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -322,7 +322,7 @@ function _start()
         println()
         exit(1)
     end
-    ccall(:jl_atexit_hook, Void, ());
+    ccall(:uv_atexit_hook, Void, ())
 end
 
 const atexit_hooks = {}

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -34,8 +34,8 @@ function complex_show(io, z::Complex, compact::Bool)
         print(io, "complex(",r,",",i,")")
     end
 end
-show(io, z::Complex) = complex_show(io, z, false)
-showcompact(io, z::Complex) = complex_show(io, z, true)
+show(io::IO, z::Complex) = complex_show(io, z, false)
+showcompact(io::IO, z::Complex) = complex_show(io, z, true)
 
 convert{T<:Real}(::Type{T}, z::Complex) = (imag(z)==0 ? convert(T,real(z)) :
                                            throw(InexactError()))

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -7,7 +7,7 @@ const secret_table_token = :__c782dbf1cf4d6a2e5e3865d7e95634f2e09b5902__
 has(t::Associative, key) = !is(get(t, key, secret_table_token),
                                secret_table_token)
 
-function show{K,V}(io, t::Associative{K,V})
+function show{K,V}(io::IO, t::Associative{K,V})
     if isempty(t)
         print(io, typeof(t),"()")
     else

--- a/base/env.jl
+++ b/base/env.jl
@@ -127,7 +127,7 @@ function length(::EnvHash)
     return i
 end
 
-function show(io, ::EnvHash)
+function show(io::IO, ::EnvHash)
     for (k,v) = ENV
         println(io, "$k=$v")
     end

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -42,7 +42,7 @@ isequal(x::SymbolNode, y::SymbolNode) = is(x.name,y.name)
 isequal(x::SymbolNode, y::Symbol)     = is(x.name,y)
 isequal(x::Symbol    , y::SymbolNode) = is(x,y.name)
 
-function show(io, tv::TypeVar)
+function show(io::IO, tv::TypeVar)
     if !is(tv.lb, None)
         show(io, tv.lb)
         print(io, "<:")

--- a/base/grisu.jl
+++ b/base/grisu.jl
@@ -101,9 +101,9 @@ function _show(io, x::FloatingPoint, mode::Int32, n::Int)
     nothing
 end
 
-show(io, x::Float64) = _show(io, x, SHORTEST, 0)
-show(io, x::Float32) = _show(io, x, SHORTEST_SINGLE, 0)
-showcompact(io, x::FloatingPoint) = _show(io, x, PRECISION, 6)
+show(io::IO, x::Float64) = _show(io, x, SHORTEST, 0)
+show(io::IO, x::Float32) = _show(io, x, SHORTEST_SINGLE, 0)
+showcompact(io::IO, x::FloatingPoint) = _show(io, x, PRECISION, 6)
 
 # normal:
 #   0 < pt < len        ####.####           len+1

--- a/base/intset.jl
+++ b/base/intset.jl
@@ -134,7 +134,7 @@ end
 length(s::IntSet) = int(ccall(:bitvector_count, Uint64, (Ptr{Uint32}, Uint64, Uint64), s.bits, 0, s.limit)) +
     (s.fill1s ? typemax(Int) - s.limit : 0)
 
-function show(io, s::IntSet)
+function show(io::IO, s::IntSet)
     print(io, "IntSet(")
     first = true
     for n in s

--- a/base/io.jl
+++ b/base/io.jl
@@ -1,6 +1,5 @@
 ## core stream types ##
 
-abstract IO
 # the first argument to any IO MUST be a POINTER (to a JL_STREAM) or using show on it will cause memory corruption
 
 # Generic IO functions
@@ -232,7 +231,7 @@ end
 IOStream(name::String) = IOStream(name, true)
 
 convert(T::Type{Ptr{Void}}, s::IOStream) = convert(T, s.ios)
-show(io, s::IOStream) = print(io, "IOStream(", s.name, ")")
+show(io::IO, s::IOStream) = print(io, "IOStream(", s.name, ")")
 fd(s::IOStream) = ccall(:jl_ios_fd, Int, (Ptr{Void},), s.ios)
 close(s::IOStream) = ccall(:ios_close, Void, (Ptr{Void},), s.ios)
 flush(s::IOStream) = ccall(:ios_flush, Void, (Ptr{Void},), s.ios)

--- a/base/linalg_dense.jl
+++ b/base/linalg_dense.jl
@@ -892,7 +892,7 @@ function full(S::SymTridiagonal)
     M
 end
 
-function show(io, S::SymTridiagonal)
+function show(io::IO, S::SymTridiagonal)
     println(io, summary(S), ":")
     print(io, "diag: ")
     print_matrix(io, (S.dv)')
@@ -940,7 +940,7 @@ function Tridiagonal{Tl<:Number, Td<:Number, Tu<:Number}(dl::Vector{Tl}, d::Vect
 end
 
 size(M::Tridiagonal) = (length(M.d), length(M.d))
-function show(io, M::Tridiagonal)
+function show(io::IO, M::Tridiagonal)
     println(io, summary(M), ":")
     print(io, " sub: ")
     print_matrix(io, (M.dl)')
@@ -1203,7 +1203,7 @@ Woodbury{T}(A::AbstractMatrix{T}, U::Matrix{T}, C, V::Matrix{T}) = Woodbury{T}(A
 Woodbury{T}(A::AbstractMatrix{T}, U::Vector{T}, C, V::Matrix{T}) = Woodbury{T}(A, reshape(U, length(U), 1), C, V)
 
 size(W::Woodbury) = size(W.A)
-function show(io, W::Woodbury)
+function show(io::IO, W::Woodbury)
     println(io, summary(W), ":")
     print(io, "A: ", W.A)
     print(io, "\nU:\n")

--- a/base/process.jl
+++ b/base/process.jl
@@ -25,7 +25,7 @@ type AndCmds <: AbstractCmd
     AndCmds(a::AbstractCmd, b::AbstractCmd) = new(a,b)
 end
 
-function show(io, cmd::Cmd)
+function show(io::IO, cmd::Cmd)
     if isa(cmd.exec,Vector{ByteString})
         esc = shell_escape(cmd.exec...)
         print(io,'`')
@@ -41,7 +41,7 @@ function show(io, cmd::Cmd)
     end
 end
 
-function show(io, cmds::OrCmds)
+function show(io::IO, cmds::OrCmds)
     if isa(cmds.a, AndCmds)
         print("(")
         show(io, cmds.a)
@@ -59,7 +59,7 @@ function show(io, cmds::OrCmds)
     end
 end
 
-function show(io, cmds::AndCmds)
+function show(io::IO, cmds::AndCmds)
     if isa(cmds.a, OrCmds)
         print("(")
         show(io, cmds.a)
@@ -525,4 +525,4 @@ function wait_success(x::Union(Process,Vector{Process}))
     success(x)
 end
 
-show(io, p::Process) = print(io, "Process(", p.cmd, ", ", process_status(p), ")")
+show(io::IO, p::Process) = print(io, "Process(", p.cmd, ", ", process_status(p), ")")

--- a/base/range.jl
+++ b/base/range.jl
@@ -93,8 +93,8 @@ ref(r::Range, s::Range1{Int}) =
 ref(r::Range1, s::Range1{Int}) =
     r.len < last(s) ? error(BoundsError) : Range1(r[s.start], s.len)
 
-show(io, r::Range)  = print(io, r.start,':',r.step,':',last(r))
-show(io, r::Range1) = print(io, r.start,':',last(r))
+show(io::IO, r::Range)  = print(io, r.start,':',r.step,':',last(r))
+show(io::IO, r::Range1) = print(io, r.start,':',last(r))
 
 start(r::Ranges) = 0
 next(r::Range,  i) = (r.start + oftype(r.start,i)*step(r), i+1)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -27,7 +27,7 @@ function //(x::Complex, y::Complex)
     complex(real(xy)//yy, imag(xy)//yy)
 end
 
-function show(io, x::Rational)
+function show(io::IO, x::Rational)
     if isinf(x)
         print(io, x.num > 0 ? "Inf" : "-Inf")
     else

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -37,7 +37,7 @@ macro r_str(pattern, flags...) Regex(pattern, flags...) end
 
 copy(r::Regex) = r
 
-function show(io, re::Regex)
+function show(io::IO, re::Regex)
     imsx = PCRE.CASELESS|PCRE.MULTILINE|PCRE.DOTALL|PCRE.EXTENDED
     if (re.options & ~imsx) == DEFAULT_OPTS
         print(io, 'r')
@@ -65,7 +65,7 @@ type RegexMatch
     offsets::Vector{Int}
 end
 
-function show(io, m::RegexMatch)
+function show(io::IO, m::RegexMatch)
     print(io, "RegexMatch(")
     show(io, m.match)
     if !isempty(m.captures)

--- a/base/set.jl
+++ b/base/set.jl
@@ -8,7 +8,7 @@ Set() = Set{Any}()
 Set(x...) = Set{Any}(x...)
 Set{T}(x::T...) = Set{T}(x...)
 
-show(io, s::Set) = (show(io, typeof(s)); show_comma_array(io, s,'(',')'))
+show(io::IO, s::Set) = (show(io, typeof(s)); show_comma_array(io, s,'(',')'))
 
 isempty(s::Set) = isempty(s.hash)
 length(s::Set)  = length(s.hash)

--- a/base/sparse.jl
+++ b/base/sparse.jl
@@ -35,7 +35,7 @@ end
 size(S::SparseMatrixCSC) = (S.m, S.n)
 nnz(S::SparseMatrixCSC) = int(S.colptr[end]-1)
 
-function show(io, S::SparseMatrixCSC)
+function show(io::IO, S::SparseMatrixCSC)
     println(io, S.m, "x", S.n, " sparse matrix with ", nnz(S), " nonzeros:")
 
     half_screen_rows = div(tty_rows() - 8, 2)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -32,7 +32,7 @@ type NamedPipe <: AsyncStream
     NamedPipe() = new(C_NULL,PipeString(),false,true,false,WaitTask[],false,WaitTask[])
 end
 
-show(io,stream::NamedPipe) = print(io,"NamedPipe(",stream.open?"connected,":"disconnected,",nb_available(stream.buffer)," bytes waiting)")
+show(io::IO,stream::NamedPipe) = print(io,"NamedPipe(",stream.open?"connected,":"disconnected,",nb_available(stream.buffer)," bytes waiting)")
 
 type TTY <: AsyncStream
     handle::Ptr{Void}
@@ -46,7 +46,7 @@ type TTY <: AsyncStream
     TTY(handle,open)=new(handle,open,true,PipeString(),false,WaitTask[],false,WaitTask[])
 end
 
-show(io,stream::TTY) = print(io,"TTY(",stream.open?"connected,":"disconnected,",nb_available(stream.buffer)," bytes waiting)")
+show(io::IO,stream::TTY) = print(io,"TTY(",stream.open?"connected,":"disconnected,",nb_available(stream.buffer)," bytes waiting)")
 
 abstract Socket <: AsyncStream
 
@@ -72,7 +72,7 @@ type TcpSocket <: Socket
     end
 end
 
-show(io,sock::TcpSocket) = print(io,"TcpSocket(",sock.open?"connected,":"disconnected,",nb_available(sock.buffer)," bytes waiting)")
+show(io::IO,sock::TcpSocket) = print(io,"TcpSocket(",sock.open?"connected,":"disconnected,",nb_available(sock.buffer)," bytes waiting)")
 
 type UdpSocket <: Socket
     handle::Ptr{Void}
@@ -96,7 +96,7 @@ end
 uvtype(::AsyncStream) = UV_STREAM
 uvhandle(stream::AsyncStream) = stream.handle
 
-show(io,sock::UdpSocket) = print(io,"TcpSocket(",sock.open?"connected,":"disconnected,",nb_available(sock.buffer)," bytes waiting)")
+show(io::IO,sock::UdpSocket) = print(io,"TcpSocket(",sock.open?"connected,":"disconnected,",nb_available(sock.buffer)," bytes waiting)")
 
 copy(s::TTY) = TTY(s.handle,s.open)
 
@@ -590,7 +590,7 @@ uverrorname(err::UVError) = bytestring(ccall(:jl_uv_err_name,Ptr{Uint8},(Int32,I
 uv_error(prefix, b::Bool) = b?throw(UVError(string(prefix))):nothing
 uv_error(prefix) = uv_error(prefix, _uv_lasterror() != 0)
 
-show(io, e::UVError) = print(io, e.prefix*": "*struverror(e)*" ("*uverrorname(e)*")")
+show(io::IO, e::UVError) = print(io, e.prefix*": "*struverror(e)*" ("*uverrorname(e)*")")
 
 function getaddrinfo_callback(sock::TcpSocket,status::Int32,host::ByteString,port::Uint16,addrinfo_list::Ptr{Void})
     #println("getaddrinfo_callback")

--- a/base/task.jl
+++ b/base/task.jl
@@ -1,4 +1,4 @@
-show(io, t::Task) = print(io, "Task")
+show(io::IO, t::Task) = print(io, "Task")
 
 current_task() = ccall(:jl_get_current_task, Task, ())
 istaskdone(t::Task) = t.done

--- a/base/version.jl
+++ b/base/version.jl
@@ -58,7 +58,7 @@ function print(io::IO, v::VersionNumber)
         print_joined(io, v.build,'.')
     end
 end
-show(io, v::VersionNumber) = print(io, "v\"", v, "\"")
+show(io::IO, v::VersionNumber) = print(io, "v\"", v, "\"")
 
 convert(::Type{VersionNumber}, v::Integer) = VersionNumber(v)
 convert(::Type{VersionNumber}, v::Tuple) = VersionNumber(v...)

--- a/src/init.c
+++ b/src/init.c
@@ -214,14 +214,8 @@ static void jl_uv_exitcleanup_walk(uv_handle_t* handle, void *arg)
     if (!queue->first) queue->first = item;
     queue->last = item;
 }
-void jl_atexit_hook()
+DLLEXPORT void uv_atexit_hook()
 {
-    if (jl_base_module) {
-        jl_value_t *f = jl_get_global(jl_base_module, jl_symbol("_atexit"));
-        if (f!=NULL && jl_is_function(f)) {
-            jl_apply((jl_function_t*)f, NULL, 0);
-        }
-    }
     uv_loop_t* loop = jl_global_event_loop();
     struct uv_shutdown_queue queue = {NULL, NULL};
     uv_walk(loop, jl_uv_exitcleanup_walk, &queue);

--- a/src/task.c
+++ b/src/task.c
@@ -559,6 +559,13 @@ DLLEXPORT void gdbbacktrace()
         gdblookup(bt_data[i]);
 }
 
+DLLEXPORT void jlbacktrace()
+{
+    for(size_t i=0; i < bt_size; i++)
+        gdblookup(bt_data[i]);
+}
+
+
 // yield to exception handler
 static void NORETURN throw_internal(jl_value_t *e)
 {

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -479,14 +479,14 @@ DLLEXPORT size_t jl_sizeof_uv_pipe_t()
     return sizeof(uv_pipe_t);
 }
 
-extern void jl_atexit_hook();
+DLLEXPORT void uv_atexit_hook();
 DLLEXPORT void jl_exit(int exitcode)
 {
     /*if (jl_io_loop) {
         jl_process_events(&jl_io_loop);
     }*/
     uv_tty_reset_mode();
-    jl_atexit_hook();
+    uv_atexit_hook();
     exit(exitcode);
 }
 

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -261,7 +261,6 @@ int true_main(int argc, char *argv[])
 
     if (start_client) {
         jl_apply(start_client, NULL, 0);
-        uv_tty_reset_mode();
         //rl_cleanup_after_signal();
         return 0;
     }


### PR DESCRIPTION
this changes show to require the first argument to be declared a subtype of IO. This pull request also includes my updates to put the repl in cooked mode because I did this while trying to track down a typo that turned out to be unrelated. But I assume this is better?
