### PR TITLE
cooked mode repl

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -122,6 +122,7 @@ function readBuffer(stream::TTY, nread)
         end
         ptr = pointer(stream.buffer.data,stream.buffer.ptr)
         skip(stream.buffer,nread)
+        #println(STDERR,stream.buffer.data[stream.buffer.ptr-nread:stream.buffer.ptr-1])
         ccall(:jl_readBuffer,Void,(Ptr{Void},Int32),ptr,nread)
     end
     return false

--- a/base/client.jl
+++ b/base/client.jl
@@ -323,7 +323,7 @@ function _start()
         println()
         exit(1)
     end
-    exit(0) #HACK: always exit using jl_exit
+    ccall(:jl_atexit_hook, Void, ());
 end
 
 const atexit_hooks = {}

--- a/src/init.c
+++ b/src/init.c
@@ -477,8 +477,6 @@ void julia_init(char *imageFile)
     }
 #endif
 
-    //atexit(jl_atexit_hook);
-
 #ifdef JL_GC_MARKSWEEP
     jl_gc_enable();
 #endif

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -59,6 +59,7 @@
     jl_arrayunset;
     jl_array_to_string;
     jl_async_send;
+    jl_atexit_hook;
     jl_backtrace_type;
     jl_base_module;
     jl_boundp;


### PR DESCRIPTION
uses the repl always in cooked mode. this closes several bugs. this should be ready to merge. tests pass, but show up red because I forgot to add jl_atexit_hook to the export map (fixed that in the show(::IO) pull request not here because I didn't feel like separating the two issues right time)
