### PR TITLE
RFC: Add contributor details to package listing

### DIFF
--- a/doc/listpkg.jl
+++ b/doc/listpkg.jl
@@ -6,21 +6,23 @@ Pkg.add("JSON")
 require("JSON")
 end
 
-function gen_listpkg()
-	local gh_auth
-	try 
+try 
+	  global gh_auth
 		gh_auth = ENV["GH_AUTH"]
-	catch e
+catch e
 		error ("Please provide a Github OAuth Token as environment variable GH_AUTH")
-	end
+end
+
+function gen_listpkg()
+
 	Pkg.update()
 	io=open("packages/packagelist.rst","w+");
 	print(io, "********************\n Available Packages  \n********************\n\n")
 	cd(julia_pkgdir()) do 
-	for pkg in Metadata.each_package()
+	for pkg in Pkg.Metadata.each_package()
 		print(" Processing $(pkg)\n")
-		url = (Metadata.pkg_url(pkg))
-		maxv = Metadata.versions([pkg])[end]
+		url = (Pkg.Metadata.pkg_url(pkg))
+		maxv = Pkg.Metadata.versions([pkg])[end]
 		url_reg = r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?"
 		gh_path_reg_git=r"^/(.*)?/(.*)?.git$"
 		gh_path_reg_http=r"^/(.*)?/(.*)?$"
@@ -28,38 +30,31 @@ function gen_listpkg()
 		host=m.captures[4]
 		path=m.captures[5]
 		scheme=m.captures[2]
-		fullname = "Unkown"
-		avatar = "Not on Github"
-		desc = "Not provided"
-		homepage = nothing
-		html_url = url
-		user_url = url
+		u=get_user_details_default()
 
 		if ismatch(r"github\.com", host)
 			m2 = match(gh_path_reg_git, path)
 			user=m2.captures[1]
 			repo=m2.captures[2]
+			u=get_user_details_gh(user)
 			gh_repo_url = "https://api.github.com/repos/$(user)/$(repo)?access_token=$(gh_auth)"
-			gh_user_url = "https://api.github.com/users/$(user)?access_token=$(gh_auth)"
+			gh_contrib_url = "https://api.github.com/repos/$(user)/$(repo)/contributors?access_token=$(gh_auth)"
 			#print("processing $gh_repo_url")
 			gh_repo=JSON.parse(readall(download_file(gh_repo_url)))
 			#print("processing $gh_user_url")
-			gh_user=JSON.parse(readall(download_file(gh_user_url)))
-			#Sometimes name is missing, sometimes it is null in the JSON
-			fullname = get(gh_user, "name", user)
-			if fullname == nothing; fullname = user; end
-			avatar = gh_user["avatar_url"]
-			user_url = gh_user["html_url"]
+			gh_contrib=JSON.parse(readall(download_file(gh_contrib_url)))
+			
+
 			desc = get(gh_repo, "description", "No description provided")
 			homepage = get(gh_repo, "homepage", nothing)
 			html_url = gh_repo["html_url"]
 		end
 		print(io, "`$(pkg) <$(html_url)>`_\n"); 
 		print(io, "_"^(length("`$(pkg) <$(html_url)>`_")) * "\n\n")
-		print(io, "  .. image:: $(avatar)\n     :height: 80px\n     :width: 80px\n     :align: right\n     :alt: $(fullname)\n\n")
+		print(io, "  .. image:: $(u[:avatar])\n     :height: 80px\n     :width: 80px\n     :align: right\n     :alt: $(u[:fullname])\n     :target: $(u[:url])\n\n")
 		print(io, "  Current Version: ``$(maxv.version)``\n\n"); 
 		print(io, "  $(desc) \n\n")
-		print(io, "  Maintainer: `$(fullname) <$user_url>`_\n\n") 
+		print(io, "  Maintainer: `$(u[:fullname]) <$(u[:url])>`_\n\n") 
 		
 		if homepage != nothing && length(chomp(homepage)) > 0
 			print(io, "  More Info: `<$(homepage)>`_ \n\n")
@@ -68,7 +63,7 @@ function gen_listpkg()
 		ver_dir = "METADATA/$pkg/versions/$(maxv.version)/requires"
 		any_ver = "Any Version"
 		if isfile(ver_dir)
-			vset = Metadata.parse_requires(ver_dir)
+			vset = Pkg.Metadata.parse_requires(ver_dir)
 			if length(vset) > 0
 				for deps in vset
 					print(io, "      $(deps.package)"); print(io, " "^(15-length(deps.package))); print(io, "$(length(deps.versions)>0 ? deps.versions : any_ver)\n")
@@ -80,9 +75,61 @@ function gen_listpkg()
 			print(io, "      None\n")
 		end
 		print(io, "\n")
-	end  #for
+
+		if ismatch(r"github\.com", host)
+			print(io, "  Contributors:\n\n")
+			for contributor in gh_contrib 
+				c_user = get(contributor, "login", "")
+				u=get_user_details_gh(c_user)
+				print(io, "    .. image:: $(u[:avatar])\n        :height: 40px\n        :width: 40px\n")
+				print(io, "        :alt: $(u[:fullname])\n        :target: $(u[:url])\n\n")
+			end  #for contributor
+		end
+
+		print(io, "----\n\n")
+	end  #for pkg
 	end  #cd
 	close(io)
 end #function
+
+global user_cache = Dict{String, Dict}()
+
+function get_user_details_default()
+	u=Dict{Symbol, String}()
+	u[:login] = "Unknown"
+	u[:fullname] = "Unknown"
+	u[:avatar] = "Not provided"
+	u[:url] = "Not provided"
+
+end
+
+function get_user_details_gh(user)
+
+	if !has(user_cache, user)
+		gh_user_url = "https://api.github.com/users/$(user)?access_token=$(gh_auth)"
+		gh_user=JSON.parse(readall(download_file(gh_user_url)))
+		fullname = get(gh_user, "name", user)
+		if fullname == nothing; fullname = user; end
+		avatar = 
+		user_url = gh_user["html_url"]
+
+	  u=Dict{Symbol, String}()
+
+	  u[:login] = user
+	  u[:avatar] = gh_user["avatar_url"]
+	  #Sometimes name is missing, sometimes it is null in the JSON
+	  if get(gh_user, "name", user) == nothing
+	  	u[:fullname] = user
+	  else
+	  	u[:fullname] = get(gh_user, "name", user)
+	  end
+	  u[:url] = gh_user["html_url"]
+
+	  user_cache[user] = u
+	end
+
+	return user_cache[user]
+
+end #function 
 
 gen_listpkg()

--- a/doc/packages/packagelist.rst
+++ b/doc/packages/packagelist.rst
@@ -10,6 +10,7 @@ __________________________________________________________
      :width: 80px
      :align: right
      :alt: Carlo Baldassi
+     :target: https://github.com/carlobaldassi
 
   Current Version: ``0.0.0``
 
@@ -22,6 +23,88 @@ __________________________________________________________
       Options        Any Version
       TextWrap       Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/80502de63c1b21d8f3ba663d72ba5be2?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Carlo Baldassi
+        :target: https://github.com/carlobaldassi
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+----
+
+`Benchmark <https://github.com/johnmyleswhite/Benchmark.jl>`_
+_____________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
+
+  Current Version: ``0.0.0``
+
+  A package for benchmarking code and packages 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      DataFrames     Any Version
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+    .. image:: https://secure.gravatar.com/avatar/fa3b781987ef53c4d3b8397f2239e519?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Diego Javier Zea
+        :target: https://github.com/diegozea
+
+----
+
+`BinDeps <https://github.com/loladiro/BinDeps.jl>`_
+___________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/ed9f9395e60acde24eb4bb89fe2154aa?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Keno Fischer
+     :target: https://github.com/loladiro
+
+  Current Version: ``0.0.0``
+
+  Tool for building binary dependencies for Julia modules 
+
+  Maintainer: `Keno Fischer <https://github.com/loladiro>`_
+
+  Dependencies::
+
+      None
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/ed9f9395e60acde24eb4bb89fe2154aa?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Keno Fischer
+        :target: https://github.com/loladiro
+
+----
+
 `Cairo <https://github.com/JuliaLang/Cairo.jl>`_
 ________________________________________________
 
@@ -30,6 +113,7 @@ ________________________________________________
      :width: 80px
      :align: right
      :alt: The Julia Language
+     :target: https://github.com/JuliaLang
 
   Current Version: ``0.0.0``
 
@@ -39,7 +123,48 @@ ________________________________________________
 
   Dependencies::
 
+      BinDeps        Any Version
       Color          Any Version
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/ed9f9395e60acde24eb4bb89fe2154aa?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Keno Fischer
+        :target: https://github.com/loladiro
+
+    .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Mike Nolta
+        :target: https://github.com/nolta
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+    .. image:: https://secure.gravatar.com/avatar/42c8c4ab92de3390bcd2f637ef6ca16c?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Kevin Squire
+        :target: https://github.com/kmsquire
+
+    .. image:: https://secure.gravatar.com/avatar/b4b8db23d8096b722483a57d21b7d65d?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Jeff Bezanson
+        :target: https://github.com/JeffBezanson
+
+    .. image:: https://secure.gravatar.com/avatar/dfc3b0fbb59c9444153823fd35dbd13b?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Westley Argentum Hennigh
+        :target: https://github.com/WestleyArgentum
+
+----
 
 `Calculus <https://github.com/johnmyleswhite/Calculus.jl>`_
 ___________________________________________________________
@@ -49,6 +174,7 @@ ___________________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -60,6 +186,22 @@ ___________________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+    .. image:: https://secure.gravatar.com/avatar/f5c61e85dfa465686adc24e0bffba42a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Avik Sengupta
+        :target: https://github.com/aviks
+
+----
+
 `Calendar <https://github.com/nolta/Calendar.jl>`_
 __________________________________________________
 
@@ -68,6 +210,7 @@ __________________________________________________
      :width: 80px
      :align: right
      :alt: Mike Nolta
+     :target: https://github.com/nolta
 
   Current Version: ``0.0.0``
 
@@ -79,6 +222,22 @@ __________________________________________________
 
       ICU            Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Mike Nolta
+        :target: https://github.com/nolta
+
+    .. image:: https://secure.gravatar.com/avatar/f5c61e85dfa465686adc24e0bffba42a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Avik Sengupta
+        :target: https://github.com/aviks
+
+----
+
 `Clustering <https://github.com/johnmyleswhite/Clustering.jl>`_
 _______________________________________________________________
 
@@ -87,6 +246,7 @@ _______________________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -98,6 +258,16 @@ _______________________________________________________________
 
       DataFrames     Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `Color <https://github.com/JuliaLang/Color.jl>`_
 ________________________________________________
 
@@ -106,6 +276,7 @@ ________________________________________________
      :width: 80px
      :align: right
      :alt: The Julia Language
+     :target: https://github.com/JuliaLang
 
   Current Version: ``0.0.0``
 
@@ -117,6 +288,16 @@ ________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+----
+
 `Compose <https://github.com/dcjones/Compose.jl>`_
 __________________________________________________
 
@@ -125,6 +306,7 @@ __________________________________________________
      :width: 80px
      :align: right
      :alt: Daniel Jones
+     :target: https://github.com/dcjones
 
   Current Version: ``0.0.0``
 
@@ -136,6 +318,28 @@ __________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/fd97b03d16e1aa4c404391216d81c1d5?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Daniel Jones
+        :target: https://github.com/dcjones
+
+    .. image:: https://secure.gravatar.com/avatar/2989a078f4caff6fb86fa30e59bd9aa9?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tim Holy
+        :target: https://github.com/timholy
+
+    .. image:: https://secure.gravatar.com/avatar/dfc3b0fbb59c9444153823fd35dbd13b?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Westley Argentum Hennigh
+        :target: https://github.com/WestleyArgentum
+
+----
+
 `DataFrames <https://github.com/HarlanH/DataFrames.jl>`_
 ________________________________________________________
 
@@ -144,6 +348,7 @@ ________________________________________________________
      :width: 80px
      :align: right
      :alt: Harlan Harris
+     :target: https://github.com/HarlanH
 
   Current Version: ``0.0.0``
 
@@ -155,6 +360,124 @@ ________________________________________________________
 
       Options        Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+    .. image:: https://secure.gravatar.com/avatar/9f1a68b9e623be5da422b44e733fa8bc?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Harlan Harris
+        :target: https://github.com/HarlanH
+
+    .. image:: https://secure.gravatar.com/avatar/1a4672a0ae94c24f02517dea26097f58?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Chris DuBois
+        :target: https://github.com/doobwa
+
+    .. image:: https://secure.gravatar.com/avatar/55e277a715ee2afd0d29c309174eca02?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Viral B. Shah
+        :target: https://github.com/ViralBShah
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+    .. image:: https://secure.gravatar.com/avatar/25ce2ab2f5e673e46208c1188a39e6ca?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: milktrader
+        :target: https://github.com/milktrader
+
+    .. image:: https://secure.gravatar.com/avatar/2989a078f4caff6fb86fa30e59bd9aa9?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tim Holy
+        :target: https://github.com/timholy
+
+    .. image:: https://secure.gravatar.com/avatar/b4b8db23d8096b722483a57d21b7d65d?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Jeff Bezanson
+        :target: https://github.com/JeffBezanson
+
+    .. image:: https://secure.gravatar.com/avatar/16d8443194c380ca93a77fb8530a5aee?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: pao
+        :target: https://github.com/pao
+
+    .. image:: https://secure.gravatar.com/avatar/a27d23ce4c080f3307cc6507f6fdfe87?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: dmbates
+        :target: https://github.com/dmbates
+
+    .. image:: https://secure.gravatar.com/avatar/903acb22f47a901577ee48d3962d5858?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tom Short
+        :target: https://github.com/tshort
+
+    .. image:: https://secure.gravatar.com/avatar/80502de63c1b21d8f3ba663d72ba5be2?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Carlo Baldassi
+        :target: https://github.com/carlobaldassi
+
+    .. image:: https://secure.gravatar.com/avatar/2cbc175271c0dbdaf0aa8f68af6c13d4?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Glen Hertz
+        :target: https://github.com/GlenHertz
+
+    .. image:: https://secure.gravatar.com/avatar/8af4d5971a2308b86a94f58fb98129c5?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Jameson Nash
+        :target: https://github.com/vtjnash
+
+    .. image:: https://secure.gravatar.com/avatar/42c8c4ab92de3390bcd2f637ef6ca16c?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Kevin Squire
+        :target: https://github.com/kmsquire
+
+    .. image:: https://secure.gravatar.com/avatar/b0cf54b8431443687735cb486599ea9c?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Miles
+        :target: https://github.com/mlubin
+
+    .. image:: https://secure.gravatar.com/avatar/1af2db0b26142fd0c7ab082f3d445f73?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Ian Fiske
+        :target: https://github.com/ianfiske
+
+    .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Mike Nolta
+        :target: https://github.com/nolta
+
+    .. image:: https://secure.gravatar.com/avatar/02abdd20ef026f24d96035a407912df0?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Andreas Noack Jensen
+        :target: https://github.com/andreasnoackjensen
+
+----
+
 `Debug <https://github.com/toivoh/Debug.jl>`_
 _____________________________________________
 
@@ -163,6 +486,7 @@ _____________________________________________
      :width: 80px
      :align: right
      :alt: toivoh
+     :target: https://github.com/toivoh
 
   Current Version: ``0.0.0``
 
@@ -174,6 +498,76 @@ _____________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/8d3d3934c39b52f48c35a0cc536edae7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: toivoh
+        :target: https://github.com/toivoh
+
+----
+
+`DecisionTree <https://github.com/bensadeghi/DecisionTree.jl>`_
+_______________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/e0da736cf64e454db46b4446f1f58ed5?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Ben Sadeghi
+     :target: https://github.com/bensadeghi
+
+  Current Version: ``0.0.0``
+
+  Decision Tree Classifier in Julia 
+
+  Maintainer: `Ben Sadeghi <https://github.com/bensadeghi>`_
+
+  Dependencies::
+
+      None
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/e0da736cf64e454db46b4446f1f58ed5?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Ben Sadeghi
+        :target: https://github.com/bensadeghi
+
+----
+
+`DimensionalityReduction <https://github.com/johnmyleswhite/DimensionalityReduction.jl>`_
+_________________________________________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
+
+  Current Version: ``0.0.0``
+
+  Methods for dimensionality reduction: PCA, ICA, NMF 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      DataFrames     Any Version
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `Distributions <https://github.com/JuliaStats/Distributions.jl>`_
 _________________________________________________________________
 
@@ -182,6 +576,7 @@ _________________________________________________________________
      :width: 80px
      :align: right
      :alt: JuliaStats
+     :target: https://github.com/JuliaStats
 
   Current Version: ``0.0.0``
 
@@ -193,6 +588,28 @@ _________________________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+    .. image:: https://secure.gravatar.com/avatar/a27d23ce4c080f3307cc6507f6fdfe87?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: dmbates
+        :target: https://github.com/dmbates
+
+    .. image:: https://secure.gravatar.com/avatar/02abdd20ef026f24d96035a407912df0?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Andreas Noack Jensen
+        :target: https://github.com/andreasnoackjensen
+
+----
+
 `Example <https://github.com/JuliaLang/Example.jl>`_
 ____________________________________________________
 
@@ -201,6 +618,7 @@ ____________________________________________________
      :width: 80px
      :align: right
      :alt: The Julia Language
+     :target: https://github.com/JuliaLang
 
   Current Version: ``0.0.0``
 
@@ -212,6 +630,16 @@ ____________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+----
+
 `FITSIO <https://github.com/nolta/FITSIO.jl>`_
 ______________________________________________
 
@@ -220,6 +648,7 @@ ______________________________________________
      :width: 80px
      :align: right
      :alt: Mike Nolta
+     :target: https://github.com/nolta
 
   Current Version: ``0.0.0``
 
@@ -231,6 +660,46 @@ ______________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Mike Nolta
+        :target: https://github.com/nolta
+
+----
+
+`FastaRead <https://github.com/carlobaldassi/FastaRead.jl>`_
+____________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/80502de63c1b21d8f3ba663d72ba5be2?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Carlo Baldassi
+     :target: https://github.com/carlobaldassi
+
+  Current Version: ``0.0.0``
+
+  A fast FASTA reader for Julia 
+
+  Maintainer: `Carlo Baldassi <https://github.com/carlobaldassi>`_
+
+  Dependencies::
+
+      None
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/80502de63c1b21d8f3ba663d72ba5be2?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Carlo Baldassi
+        :target: https://github.com/carlobaldassi
+
+----
+
 `FileFind <https://github.com/johnmyleswhite/FileFind.jl>`_
 ___________________________________________________________
 
@@ -239,6 +708,7 @@ ___________________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -250,6 +720,16 @@ ___________________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `GLM <https://github.com/JuliaStats/GLM.jl>`_
 _____________________________________________
 
@@ -258,6 +738,7 @@ _____________________________________________
      :width: 80px
      :align: right
      :alt: JuliaStats
+     :target: https://github.com/JuliaStats
 
   Current Version: ``0.0.0``
 
@@ -270,24 +751,27 @@ _____________________________________________
       DataFrames     Any Version
       Distributions  Any Version
 
-`GLU <https://github.com/rennis250/GLU.jl>`_
-____________________________________________
+  Contributors:
 
-  .. image:: https://secure.gravatar.com/avatar/3753123303ea2852accbce22339f67b4?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
-     :height: 80px
-     :width: 80px
-     :align: right
-     :alt: Robert Ennis
+    .. image:: https://secure.gravatar.com/avatar/a27d23ce4c080f3307cc6507f6fdfe87?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: dmbates
+        :target: https://github.com/dmbates
 
-  Current Version: ``0.0.0``
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
 
-  Julia interface to GLU 
+    .. image:: https://secure.gravatar.com/avatar/1a4672a0ae94c24f02517dea26097f58?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Chris DuBois
+        :target: https://github.com/doobwa
 
-  Maintainer: `Robert Ennis <https://github.com/rennis250>`_
-
-  Dependencies::
-
-      GetC           Any Version
+----
 
 `GLUT <https://github.com/rennis250/GLUT.jl>`_
 ______________________________________________
@@ -297,6 +781,7 @@ ______________________________________________
      :width: 80px
      :align: right
      :alt: Robert Ennis
+     :target: https://github.com/rennis250
 
   Current Version: ``0.0.0``
 
@@ -306,9 +791,12 @@ ______________________________________________
 
   Dependencies::
 
-      GLU            Any Version
       GetC           Any Version
       OpenGL         Any Version
+
+  Contributors:
+
+----
 
 `Gadfly <https://github.com/dcjones/Gadfly.jl>`_
 ________________________________________________
@@ -318,6 +806,7 @@ ________________________________________________
      :width: 80px
      :align: right
      :alt: Daniel Jones
+     :target: https://github.com/dcjones
 
   Current Version: ``0.0.0``
 
@@ -334,6 +823,34 @@ ________________________________________________
       Distributions  Any Version
       Iterators      Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/fd97b03d16e1aa4c404391216d81c1d5?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Daniel Jones
+        :target: https://github.com/dcjones
+
+    .. image:: https://secure.gravatar.com/avatar/2989a078f4caff6fb86fa30e59bd9aa9?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tim Holy
+        :target: https://github.com/timholy
+
+    .. image:: https://secure.gravatar.com/avatar/f5c61e85dfa465686adc24e0bffba42a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Avik Sengupta
+        :target: https://github.com/aviks
+
+    .. image:: https://secure.gravatar.com/avatar/a27d23ce4c080f3307cc6507f6fdfe87?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: dmbates
+        :target: https://github.com/dmbates
+
+----
+
 `GetC <https://github.com/rennis250/GetC.jl>`_
 ______________________________________________
 
@@ -342,6 +859,7 @@ ______________________________________________
      :width: 80px
      :align: right
      :alt: Robert Ennis
+     :target: https://github.com/rennis250
 
   Current Version: ``0.0.0``
 
@@ -353,6 +871,10 @@ ______________________________________________
 
       None
 
+  Contributors:
+
+----
+
 `Graphs <https://github.com/johnmyleswhite/Graphs.jl>`_
 _______________________________________________________
 
@@ -361,6 +883,7 @@ _______________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -372,6 +895,16 @@ _______________________________________________________
 
       DataFrames     Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `Grid <https://github.com/timholy/Grid.jl>`_
 ____________________________________________
 
@@ -380,6 +913,7 @@ ____________________________________________
      :width: 80px
      :align: right
      :alt: Tim Holy
+     :target: https://github.com/timholy
 
   Current Version: ``0.0.0``
 
@@ -391,6 +925,16 @@ ____________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/2989a078f4caff6fb86fa30e59bd9aa9?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tim Holy
+        :target: https://github.com/timholy
+
+----
+
 `HDF5 <https://github.com/timholy/HDF5.jl>`_
 ____________________________________________
 
@@ -399,6 +943,7 @@ ____________________________________________
      :width: 80px
      :align: right
      :alt: Tim Holy
+     :target: https://github.com/timholy
 
   Current Version: ``0.0.0``
 
@@ -410,6 +955,22 @@ ____________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/2989a078f4caff6fb86fa30e59bd9aa9?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tim Holy
+        :target: https://github.com/timholy
+
+    .. image:: https://secure.gravatar.com/avatar/9524ef56c2823a59d54f9226a7ef08ba?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Simon Kornblith
+        :target: https://github.com/simonster
+
+----
+
 `HTTP <https://github.com/dirk/HTTP.jl>`_
 _________________________________________
 
@@ -418,8 +979,9 @@ _________________________________________
      :width: 80px
      :align: right
      :alt: Dirk Gadsden
+     :target: https://github.com/dirk
 
-  Current Version: ``0.0.0``
+  Current Version: ``0.0.4``
 
   HTTP library (server, client, parser) for the Julia language 
 
@@ -429,6 +991,16 @@ _________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/d9c8c5a29b60871d14846a382d50626a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Dirk Gadsden
+        :target: https://github.com/dirk
+
+----
+
 `HypothesisTests <https://github.com/simonster/HypothesisTests.jl>`_
 ____________________________________________________________________
 
@@ -437,6 +1009,7 @@ ____________________________________________________________________
      :width: 80px
      :align: right
      :alt: Simon Kornblith
+     :target: https://github.com/simonster
 
   Current Version: ``0.0.0``
 
@@ -448,6 +1021,16 @@ ____________________________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/9524ef56c2823a59d54f9226a7ef08ba?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Simon Kornblith
+        :target: https://github.com/simonster
+
+----
+
 `ICU <https://github.com/nolta/ICU.jl>`_
 ________________________________________
 
@@ -456,6 +1039,7 @@ ________________________________________
      :width: 80px
      :align: right
      :alt: Mike Nolta
+     :target: https://github.com/nolta
 
   Current Version: ``0.0.0``
 
@@ -467,6 +1051,22 @@ ________________________________________
 
       UTF16          Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Mike Nolta
+        :target: https://github.com/nolta
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+----
+
 `IniFile <https://github.com/JuliaLang/IniFile.jl>`_
 ____________________________________________________
 
@@ -475,6 +1075,7 @@ ____________________________________________________
      :width: 80px
      :align: right
      :alt: The Julia Language
+     :target: https://github.com/JuliaLang
 
   Current Version: ``0.0.0``
 
@@ -486,6 +1087,28 @@ ____________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/62df30beab9c2a6f3fe3f86995e94387?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: David de Laat
+        :target: https://github.com/daviddelaat
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+    .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Mike Nolta
+        :target: https://github.com/nolta
+
+----
+
 `Iterators <https://github.com/JuliaLang/Iterators.jl>`_
 ________________________________________________________
 
@@ -494,6 +1117,7 @@ ________________________________________________________
      :width: 80px
      :align: right
      :alt: The Julia Language
+     :target: https://github.com/JuliaLang
 
   Current Version: ``0.0.0``
 
@@ -505,6 +1129,22 @@ ________________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+    .. image:: https://secure.gravatar.com/avatar/fd97b03d16e1aa4c404391216d81c1d5?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Daniel Jones
+        :target: https://github.com/dcjones
+
+----
+
 `Ito <https://github.com/aviks/Ito.jl>`_
 ________________________________________
 
@@ -513,6 +1153,7 @@ ________________________________________
      :width: 80px
      :align: right
      :alt: Avik Sengupta
+     :target: https://github.com/aviks
 
   Current Version: ``0.0.0``
 
@@ -527,6 +1168,22 @@ ________________________________________
       Calendar       Any Version
       Distributions  Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/f5c61e85dfa465686adc24e0bffba42a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Avik Sengupta
+        :target: https://github.com/aviks
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+----
+
 `JSON <https://github.com/aviks/JSON.jl>`_
 __________________________________________
 
@@ -535,6 +1192,7 @@ __________________________________________
      :width: 80px
      :align: right
      :alt: Avik Sengupta
+     :target: https://github.com/aviks
 
   Current Version: ``0.0.0``
 
@@ -546,6 +1204,94 @@ __________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/f5c61e85dfa465686adc24e0bffba42a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Avik Sengupta
+        :target: https://github.com/aviks
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+    .. image:: https://secure.gravatar.com/avatar/62df30beab9c2a6f3fe3f86995e94387?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: David de Laat
+        :target: https://github.com/daviddelaat
+
+    .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Mike Nolta
+        :target: https://github.com/nolta
+
+    .. image:: https://secure.gravatar.com/avatar/fd97b03d16e1aa4c404391216d81c1d5?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Daniel Jones
+        :target: https://github.com/dcjones
+
+    .. image:: https://secure.gravatar.com/avatar/dfc3b0fbb59c9444153823fd35dbd13b?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Westley Argentum Hennigh
+        :target: https://github.com/WestleyArgentum
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+    .. image:: https://secure.gravatar.com/avatar/b4b8db23d8096b722483a57d21b7d65d?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Jeff Bezanson
+        :target: https://github.com/JeffBezanson
+
+    .. image:: https://secure.gravatar.com/avatar/fa183b064e6ddfafab783d3de300c72a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: S Wade
+        :target: https://github.com/swadey
+
+----
+
+`KLDivergence <https://github.com/johnmyleswhite/KLDivergence.jl>`_
+___________________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
+
+  Current Version: ``0.0.0``
+
+  KL-divergence estimation in Julia 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      Distributions  Any Version
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `LM <https://github.com/JuliaStats/LM.jl>`_
 ___________________________________________
 
@@ -554,6 +1300,7 @@ ___________________________________________
      :width: 80px
      :align: right
      :alt: JuliaStats
+     :target: https://github.com/JuliaStats
 
   Current Version: ``0.0.0``
 
@@ -566,6 +1313,22 @@ ___________________________________________
       DataFrames     Any Version
       Distributions  Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+    .. image:: https://secure.gravatar.com/avatar/02abdd20ef026f24d96035a407912df0?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Andreas Noack Jensen
+        :target: https://github.com/andreasnoackjensen
+
+----
+
 `Languages <https://github.com/johnmyleswhite/Languages.jl>`_
 _____________________________________________________________
 
@@ -574,6 +1337,7 @@ _____________________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -585,6 +1349,16 @@ _____________________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `Loss <https://github.com/johnmyleswhite/Loss.jl>`_
 ___________________________________________________
 
@@ -593,6 +1367,7 @@ ___________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -604,6 +1379,16 @@ ___________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `MAT <https://github.com/simonster/MAT.jl>`_
 ____________________________________________
 
@@ -612,6 +1397,7 @@ ____________________________________________
      :width: 80px
      :align: right
      :alt: Simon Kornblith
+     :target: https://github.com/simonster
 
   Current Version: ``0.0.0``
 
@@ -623,6 +1409,22 @@ ____________________________________________
 
       HDF5           Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/9524ef56c2823a59d54f9226a7ef08ba?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Simon Kornblith
+        :target: https://github.com/simonster
+
+    .. image:: https://secure.gravatar.com/avatar/2989a078f4caff6fb86fa30e59bd9aa9?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tim Holy
+        :target: https://github.com/timholy
+
+----
+
 `MCMC <https://github.com/doobwa/MCMC.jl>`_
 ___________________________________________
 
@@ -631,6 +1433,7 @@ ___________________________________________
      :width: 80px
      :align: right
      :alt: Chris DuBois
+     :target: https://github.com/doobwa
 
   Current Version: ``0.0.0``
 
@@ -642,6 +1445,28 @@ ___________________________________________
 
       Options        Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/1a4672a0ae94c24f02517dea26097f58?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Chris DuBois
+        :target: https://github.com/doobwa
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+    .. image:: https://secure.gravatar.com/avatar/5c06e9faa0d7bd205f81d10e825d7e4a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: nfoti
+        :target: https://github.com/nfoti
+
+----
+
 `Mongrel2 <https://github.com/aviks/Mongrel2.jl>`_
 __________________________________________________
 
@@ -650,6 +1475,7 @@ __________________________________________________
      :width: 80px
      :align: right
      :alt: Avik Sengupta
+     :target: https://github.com/aviks
 
   Current Version: ``0.0.0``
 
@@ -662,6 +1488,52 @@ __________________________________________________
       JSON           Any Version
       ZMQ            Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/f5c61e85dfa465686adc24e0bffba42a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Avik Sengupta
+        :target: https://github.com/aviks
+
+    .. image:: https://secure.gravatar.com/avatar/baff1969663ebce1d743a43a2bbaa00e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Nathan Wienert
+        :target: https://github.com/natew
+
+----
+
+`Mustache <https://github.com/jverzani/Mustache.jl>`_
+_____________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/8f514187144b1b19b0205fce41284d32?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: john verzani
+     :target: https://github.com/jverzani
+
+  Current Version: ``0.0.0``
+
+  Port of mustache.js to julia 
+
+  Maintainer: `john verzani <https://github.com/jverzani>`_
+
+  Dependencies::
+
+      DataFrames     Any Version
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/8f514187144b1b19b0205fce41284d32?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: john verzani
+        :target: https://github.com/jverzani
+
+----
+
 `NHST <https://github.com/johnmyleswhite/NHST.jl>`_
 ___________________________________________________
 
@@ -670,6 +1542,7 @@ ___________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -681,6 +1554,16 @@ ___________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `Named <https://github.com/HarlanH/Named.jl>`_
 ______________________________________________
 
@@ -689,6 +1572,7 @@ ______________________________________________
      :width: 80px
      :align: right
      :alt: Harlan Harris
+     :target: https://github.com/HarlanH
 
   Current Version: ``0.0.0``
 
@@ -700,6 +1584,16 @@ ______________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/9f1a68b9e623be5da422b44e733fa8bc?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Harlan Harris
+        :target: https://github.com/HarlanH
+
+----
+
 `ODBC <https://github.com/karbarcca/ODBC>`_
 ___________________________________________
 
@@ -708,6 +1602,7 @@ ___________________________________________
      :width: 80px
      :align: right
      :alt: Jacob Quinn
+     :target: https://github.com/karbarcca
 
   Current Version: ``0.0.0``
 
@@ -719,6 +1614,22 @@ ___________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/1214b9051c4ae96c1ca5c5e6cc25716e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Jacob Quinn
+        :target: https://github.com/karbarcca
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `OpenGL <https://github.com/rennis250/OpenGL.jl>`_
 __________________________________________________
 
@@ -727,6 +1638,7 @@ __________________________________________________
      :width: 80px
      :align: right
      :alt: Robert Ennis
+     :target: https://github.com/rennis250
 
   Current Version: ``0.0.0``
 
@@ -738,6 +1650,10 @@ __________________________________________________
 
       GetC           Any Version
 
+  Contributors:
+
+----
+
 `Optim <https://github.com/johnmyleswhite/Optim.jl>`_
 _____________________________________________________
 
@@ -746,6 +1662,7 @@ _____________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -761,6 +1678,34 @@ _____________________________________________________
       Distributions  Any Version
       Options        Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+    .. image:: https://secure.gravatar.com/avatar/449044e4f0ed377b21409488cddafc45?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Blake Johnson
+        :target: https://github.com/blakejohnson
+
+    .. image:: https://secure.gravatar.com/avatar/2989a078f4caff6fb86fa30e59bd9aa9?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tim Holy
+        :target: https://github.com/timholy
+
+    .. image:: https://secure.gravatar.com/avatar/02abdd20ef026f24d96035a407912df0?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Andreas Noack Jensen
+        :target: https://github.com/andreasnoackjensen
+
+----
+
 `Options <https://github.com/JuliaLang/Options.jl>`_
 ____________________________________________________
 
@@ -769,6 +1714,7 @@ ____________________________________________________
      :width: 80px
      :align: right
      :alt: The Julia Language
+     :target: https://github.com/JuliaLang
 
   Current Version: ``0.0.0``
 
@@ -780,6 +1726,40 @@ ____________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/2989a078f4caff6fb86fa30e59bd9aa9?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tim Holy
+        :target: https://github.com/timholy
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+    .. image:: https://secure.gravatar.com/avatar/9f1a68b9e623be5da422b44e733fa8bc?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Harlan Harris
+        :target: https://github.com/HarlanH
+
+    .. image:: https://secure.gravatar.com/avatar/80502de63c1b21d8f3ba663d72ba5be2?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Carlo Baldassi
+        :target: https://github.com/carlobaldassi
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `PLX <https://github.com/simonster/PLX.jl>`_
 ____________________________________________
 
@@ -788,6 +1768,7 @@ ____________________________________________
      :width: 80px
      :align: right
      :alt: Simon Kornblith
+     :target: https://github.com/simonster
 
   Current Version: ``0.0.0``
 
@@ -799,6 +1780,16 @@ ____________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/9524ef56c2823a59d54f9226a7ef08ba?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Simon Kornblith
+        :target: https://github.com/simonster
+
+----
+
 `PatternDispatch <https://github.com/toivoh/PatternDispatch.jl>`_
 _________________________________________________________________
 
@@ -807,6 +1798,7 @@ _________________________________________________________________
      :width: 80px
      :align: right
      :alt: toivoh
+     :target: https://github.com/toivoh
 
   Current Version: ``0.0.0``
 
@@ -818,6 +1810,16 @@ _________________________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/8d3d3934c39b52f48c35a0cc536edae7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: toivoh
+        :target: https://github.com/toivoh
+
+----
+
 `Profile <https://github.com/timholy/Profile.jl>`_
 __________________________________________________
 
@@ -826,6 +1828,7 @@ __________________________________________________
      :width: 80px
      :align: right
      :alt: Tim Holy
+     :target: https://github.com/timholy
 
   Current Version: ``0.0.0``
 
@@ -837,6 +1840,22 @@ __________________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/2989a078f4caff6fb86fa30e59bd9aa9?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tim Holy
+        :target: https://github.com/timholy
+
+    .. image:: https://secure.gravatar.com/avatar/449044e4f0ed377b21409488cddafc45?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Blake Johnson
+        :target: https://github.com/blakejohnson
+
+----
+
 `ProjectTemplate <https://github.com/johnmyleswhite/ProjectTemplate.jl>`_
 _________________________________________________________________________
 
@@ -845,6 +1864,7 @@ _________________________________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -857,6 +1877,16 @@ _________________________________________________________________________
       DataFrames     Any Version
       JSON           Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `RDatasets <https://github.com/johnmyleswhite/RDatasets.jl>`_
 _____________________________________________________________
 
@@ -865,6 +1895,7 @@ _____________________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -876,6 +1907,46 @@ _____________________________________________________________
 
       DataFrames     Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
+`Resampling <https://github.com/johnmyleswhite/Resampling.jl>`_
+_______________________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
+
+  Current Version: ``0.0.0``
+
+  Tools for resampling data in Julia 
+
+  Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
+
+  Dependencies::
+
+      DataFrames     Any Version
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `Rif <https://github.com/lgautier/Rif.jl>`_
 ___________________________________________
 
@@ -884,6 +1955,7 @@ ___________________________________________
      :width: 80px
      :align: right
      :alt: Laurent Gautier
+     :target: https://github.com/lgautier
 
   Current Version: ``0.0.0``
 
@@ -895,6 +1967,22 @@ ___________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/8e5422a173711c086b685140dbc498fe?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Laurent Gautier
+        :target: https://github.com/lgautier
+
+    .. image:: https://secure.gravatar.com/avatar/4fca794da0cf08804f99048d3c8b39c1?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Check your git settings!
+        :target: https://github.com/invalid-email-address
+
+----
+
 `SDL <https://github.com/rennis250/SDL.jl>`_
 ____________________________________________
 
@@ -903,6 +1991,7 @@ ____________________________________________
      :width: 80px
      :align: right
      :alt: Robert Ennis
+     :target: https://github.com/rennis250
 
   Current Version: ``0.0.0``
 
@@ -912,9 +2001,12 @@ ____________________________________________
 
   Dependencies::
 
-      GLU            Any Version
       GetC           Any Version
       OpenGL         Any Version
+
+  Contributors:
+
+----
 
 `Sims <https://github.com/tshort/Sims.jl>`_
 ___________________________________________
@@ -924,6 +2016,7 @@ ___________________________________________
      :width: 80px
      :align: right
      :alt: Tom Short
+     :target: https://github.com/tshort
 
   Current Version: ``0.0.0``
 
@@ -935,6 +2028,16 @@ ___________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/903acb22f47a901577ee48d3962d5858?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tom Short
+        :target: https://github.com/tshort
+
+----
+
 `Sound <https://github.com/JuliaLang/Sound.jl>`_
 ________________________________________________
 
@@ -943,6 +2046,7 @@ ________________________________________________
      :width: 80px
      :align: right
      :alt: The Julia Language
+     :target: https://github.com/JuliaLang
 
   Current Version: ``0.0.0``
 
@@ -954,6 +2058,16 @@ ________________________________________________
 
       Options        Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+----
+
 `TextAnalysis <https://github.com/johnmyleswhite/TextAnalysis.jl>`_
 ___________________________________________________________________
 
@@ -962,6 +2076,7 @@ ___________________________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -975,6 +2090,16 @@ ___________________________________________________________________
       FileFind       Any Version
       Languages      Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
+
 `TextWrap <https://github.com/carlobaldassi/TextWrap.jl>`_
 __________________________________________________________
 
@@ -983,6 +2108,7 @@ __________________________________________________________
      :width: 80px
      :align: right
      :alt: Carlo Baldassi
+     :target: https://github.com/carlobaldassi
 
   Current Version: ``0.0.0``
 
@@ -994,6 +2120,22 @@ __________________________________________________________
 
       Options        Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+    .. image:: https://secure.gravatar.com/avatar/80502de63c1b21d8f3ba663d72ba5be2?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Carlo Baldassi
+        :target: https://github.com/carlobaldassi
+
+----
+
 `Thyme <https://github.com/milktrader/Thyme.jl>`_
 _________________________________________________
 
@@ -1002,6 +2144,7 @@ _________________________________________________
      :width: 80px
      :align: right
      :alt: milktrader
+     :target: https://github.com/milktrader
 
   Current Version: ``0.0.0``
 
@@ -1015,6 +2158,16 @@ _________________________________________________
       DataFrames     Any Version
       UTF16          Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/25ce2ab2f5e673e46208c1188a39e6ca?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: milktrader
+        :target: https://github.com/milktrader
+
+----
+
 `Tk <https://github.com/JuliaLang/Tk.jl>`_
 __________________________________________
 
@@ -1023,6 +2176,7 @@ __________________________________________
      :width: 80px
      :align: right
      :alt: The Julia Language
+     :target: https://github.com/JuliaLang
 
   Current Version: ``0.0.0``
 
@@ -1032,7 +2186,42 @@ __________________________________________
 
   Dependencies::
 
+      BinDeps        Any Version
       Cairo          Any Version
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/ed9f9395e60acde24eb4bb89fe2154aa?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Keno Fischer
+        :target: https://github.com/loladiro
+
+    .. image:: https://secure.gravatar.com/avatar/b4b8db23d8096b722483a57d21b7d65d?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Jeff Bezanson
+        :target: https://github.com/JeffBezanson
+
+    .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Mike Nolta
+        :target: https://github.com/nolta
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+    .. image:: https://secure.gravatar.com/avatar/55e277a715ee2afd0d29c309174eca02?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Viral B. Shah
+        :target: https://github.com/ViralBShah
+
+----
 
 `Trie <https://github.com/JuliaLang/Trie.jl>`_
 ______________________________________________
@@ -1042,6 +2231,7 @@ ______________________________________________
      :width: 80px
      :align: right
      :alt: The Julia Language
+     :target: https://github.com/JuliaLang
 
   Current Version: ``0.0.0``
 
@@ -1053,6 +2243,16 @@ ______________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+----
+
 `UTF16 <https://github.com/nolta/UTF16.jl>`_
 ____________________________________________
 
@@ -1061,6 +2261,7 @@ ____________________________________________
      :width: 80px
      :align: right
      :alt: Mike Nolta
+     :target: https://github.com/nolta
 
   Current Version: ``0.0.0``
 
@@ -1072,6 +2273,22 @@ ____________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Mike Nolta
+        :target: https://github.com/nolta
+
+    .. image:: https://secure.gravatar.com/avatar/21aeae1f260365557523718bc19640f7?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Stefan Karpinski
+        :target: https://github.com/StefanKarpinski
+
+----
+
 `Winston <https://github.com/nolta/Winston.jl>`_
 ________________________________________________
 
@@ -1080,6 +2297,7 @@ ________________________________________________
      :width: 80px
      :align: right
      :alt: Mike Nolta
+     :target: https://github.com/nolta
 
   Current Version: ``0.0.0``
 
@@ -1094,6 +2312,34 @@ ________________________________________________
       IniFile        Any Version
       Tk             Any Version
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/1b65c4698da5f30310e14aaee8f3f24e?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Mike Nolta
+        :target: https://github.com/nolta
+
+    .. image:: https://secure.gravatar.com/avatar/b4b8db23d8096b722483a57d21b7d65d?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Jeff Bezanson
+        :target: https://github.com/JeffBezanson
+
+    .. image:: https://secure.gravatar.com/avatar/42c8c4ab92de3390bcd2f637ef6ca16c?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Kevin Squire
+        :target: https://github.com/kmsquire
+
+    .. image:: https://secure.gravatar.com/avatar/dfc3b0fbb59c9444153823fd35dbd13b?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Westley Argentum Hennigh
+        :target: https://github.com/WestleyArgentum
+
+----
+
 `ZMQ <https://github.com/aviks/ZMQ.jl>`_
 ________________________________________
 
@@ -1102,6 +2348,7 @@ ________________________________________
      :width: 80px
      :align: right
      :alt: Avik Sengupta
+     :target: https://github.com/aviks
 
   Current Version: ``0.0.0``
 
@@ -1113,6 +2360,16 @@ ________________________________________
 
       None
 
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/f5c61e85dfa465686adc24e0bffba42a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Avik Sengupta
+        :target: https://github.com/aviks
+
+----
+
 `kNN <https://github.com/johnmyleswhite/kNN.jl>`_
 _________________________________________________
 
@@ -1121,6 +2378,7 @@ _________________________________________________
      :width: 80px
      :align: right
      :alt: John Myles White
+     :target: https://github.com/johnmyleswhite
 
   Current Version: ``0.0.0``
 
@@ -1131,4 +2389,14 @@ _________________________________________________
   Dependencies::
 
       DataFrames     Any Version
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/b6b704f26ffe0d91e6317a1c069d4303?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: John Myles White
+        :target: https://github.com/johnmyleswhite
+
+----
 


### PR DESCRIPTION
As discussed in #1935 , here is a revised package listing that displays avatars for all contributors in a package, ordered by the number of contributions.  Each image links back to the user's github page. 

Thoughts welcome. I've attached an image of what it looks like. Any changes you might wish? Should I remove the maintainer image (keep only the text link), and show only the contributor images? 

The code will not win any awards for elegance, but it works for now. 

Please dont merge yet. 
