### PR TITLE
Small fixes to ccall documentation.

### DIFF
--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -219,6 +219,7 @@ translated to Julia types as follows.
 -  ``unsigned long long`` ⟺ ``Uint64``
 -  ``float`` ⟺ ``Float32``
 -  ``double`` ⟺ ``Float64``
+-  ``void`` ⟺ ``Void``
 
 *Note:* the ``bool`` type is only defined by C++, where it is 8 bits
 wide. In C, however, ``int`` is often used for boolean values. Since

--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -252,11 +252,11 @@ can be called via the following Julia code::
 Non-constant Function Specifications
 ------------------------------------
 
-A ``(library, name)`` function specification must be a constant expression.
+A ``(name, library)`` function specification must be a constant expression.
 However, it is possible to use computed values as function names by staging
 through ``eval`` as follows:
 
-    @eval ccall((:lib, $(strcat("a","b"))), ...
+    @eval ccall(($(strcat("a","b")),"lib"), ...
 
 This expression constructs a name using ``strcat``, then substitutes this
 name into a new ``ccall`` expression, which is then evaluated. Keep in mind that

--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -251,11 +251,11 @@ can be called via the following Julia code::
 Non-constant Function Specifications
 ------------------------------------
 
-A ``(name, library)`` function specification must be a constant expression.
+A ``(library, name)`` function specification must be a constant expression.
 However, it is possible to use computed values as function names by staging
 through ``eval`` as follows:
 
-    @eval ccall(($(strcat("a","b")), :lib), ...
+    @eval ccall((:lib, $(strcat("a","b"))), ...
 
 This expression constructs a name using ``strcat``, then substitutes this
 name into a new ``ccall`` expression, which is then evaluated. Keep in mind that

--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -238,9 +238,10 @@ A C function declared to return ``void`` will give ``nothing`` in Julia.
 *Note:* Although ``wchar_t`` is technically system-dependent, on all the
 systems we currently support (UNIX), it is 32-bit.
 
-C functions that take an arguments of the type ``char**`` can be called
-by using a ``Ptr{Ptr{Uint8}}`` type within Julia. For example, C
-functions of the form::
+For string arguments (``char*``) the Julia type should be ``Ptr{Uint8}``,
+not ``String``. C functions that take an arguments of the type ``char**``
+can be called by using a ``Ptr{Ptr{Uint8}}`` type within Julia. For example, 
+C functions of the form::
 
     int main(int argc, char **argv);
 

--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -239,7 +239,7 @@ A C function declared to return ``void`` will give ``nothing`` in Julia.
 systems we currently support (UNIX), it is 32-bit.
 
 For string arguments (``char*``) the Julia type should be ``Ptr{Uint8}``,
-not ``String``. C functions that take an arguments of the type ``char**``
+not ``ASCIIString``. C functions that take an argument of the type ``char**``
 can be called by using a ``Ptr{Ptr{Uint8}}`` type within Julia. For example, 
 C functions of the form::
 


### PR DESCRIPTION
1. In the "Non-constant Function Specifications" section of the ccall documentation, it had :lib instead of "lib"
2. I explicitly mention the mapping of "void" to "Void". Its implicitly as there are examples in the page that use it for the return type, but its nice to have it written there.
3. I explicitly mention that you should use Ptr{Uint8} rather than String, and fix a typo in the sentence about char**.
