### PR TITLE
More GMP documentation

### DIFF
--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -2291,6 +2291,24 @@ airyaiprime(x)
 
 "),
 
+(E"Numbers",E"Base",E"BigInt",E"BigInt(x)
+
+   Create an arbitrary precision integer. \"x\" may be an \"Int\" (or
+   anything that can be converted to an \"Int\") or a \"String\". The
+   usual mathematical operators are defined for this type, and results
+   are promoted to a \"BigInt\".
+
+"),
+
+(E"Numbers",E"Base",E"BigFloat",E"BigFloat(x)
+
+   Create an arbitrary precision floating point number. \"x\" may be
+   an \"Integer\", a \"Float64\", a \"String\" or a \"BigInt\". The
+   usual mathematical operators are defined for this type, and results
+   are promoted to a \"BigFloat\".
+
+"),
+
 (E"Random Numbers",E"Base",E"srand",E"srand([rng], seed)
 
    Seed the RNG with a \"seed\", which may be an unsigned integer or a

--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -320,7 +320,7 @@ the "Father of Floating-Point". Of particular interest may be `An
 Interview with the Old Man of
 Floating-Point <http://www.cs.berkeley.edu/~wkahan/ieee754status/754story.html>`_.
 
-.. _man_arbitrary_precision_arithmetic
+.. _man_arbitrary_precision_arithmetic:
 
 Arbitrary Precision Arithmetic
 ------------------------------
@@ -330,7 +330,7 @@ Julia wraps the `GNU Multiple Precision Arithmetic Library, GMP <http://gmplib.o
 The `BigInt` and `BigFloat` types are available in Julia for arbitrary precision 
 integer and floating point numbers respectively. 
 
-Constructors exist to create these types from primitive numerical types, or from ``String``s. 
+Constructors exist to create these types from primitive numerical types, or from ``String``. 
 Once created, they participate in arithmetic with all other numeric types thanks to Julia's 
 type promotion and conversion mechanism. ::
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -160,16 +160,16 @@ Generic Functions
 Iteration
 ---------
 
-Sequential iteration is implemented by the methods ``start``, ``done``, and ``next``. The general ``for`` loop:
+Sequential iteration is implemented by the methods ``start``, ``done``, and ``next``. The general ``for`` loop::
 
-    for i = I
+   for i = I
       # body
-    end
+   end
 
-is translated to:
+is translated to::
 
-    state = start(I)
-    while !done(I, state)
+   state = start(I)
+   while !done(I, state)
       (i, state) = next(I, state)
       # body
     end
@@ -1360,6 +1360,16 @@ Numbers
 .. function:: mantissa(f)
 
    Get the mantissa of a floating-point number
+
+.. function:: BigInt(x)
+
+   Create an arbitrary precision integer. ``x`` may be an ``Int`` (or anything that can be converted to an ``Int``) or a ``String``. 
+   The usual mathematical operators are defined for this type, and results are promoted to a ``BigInt``. 
+
+.. function:: BigFloat(x)
+
+   Create an arbitrary precision floating point number. ``x`` may be an ``Integer``, a ``Float64``, a ``String`` or a ``BigInt``. The 
+   usual mathematical operators are defined for this type, and results are promoted to a ``BigFloat``.
 
 Random Numbers
 --------------


### PR DESCRIPTION
Add BigFloat and BigInt to stdlib docs, and hence helpdb.jl. Help is now available at the REPL. 

``` jlcon
julia> help("BigFloat")
Loading help data...
Base.BigFloat(x)

   Create an arbitrary precision floating point number. "x" may be
   an "Integer", a "Float64", a "String" or a "BigInt". The
   usual mathematical operators are defined for this type, and results
   are promoted to a "BigFloat".

```

per #2111
