### PR TITLE
fix 2155: remove MATLAB trademark symbols, except on first occurrence.

### DIFF
--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -287,7 +287,7 @@ vector to the size of the matrix::
      1.26743   1.77988  1.13859
 
 This is wasteful when dimensions get large, so Julia offers the
-Matlab-inspired ``bsxfun``, which expands singleton dimensions in
+MATLAB-inspired ``bsxfun``, which expands singleton dimensions in
 array arguments to match the corresponding dimension in the other
 array without using extra memory, and applies the given binary
 function::

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -111,7 +111,7 @@ blocks as desired can be used. The condition expressions in the
 evaluates to ``true``, after which the associated block is evaluated,
 and no further condition expressions or blocks are evaluated.
 
-Unlike C, MATLAB®, Perl, Python, and Ruby — but like Java, and a few
+Unlike C, MATLAB, Perl, Python, and Ruby — but like Java, and a few
 other stricter, typed languages — it is an error if the value of a
 conditional expression is anything but ``true`` or ``false``::
 

--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -14,15 +14,15 @@ is::
       x + y
     end
 
-This syntax is similar to MATLAB®, but there are some significant
+This syntax is similar to MATLAB, but there are some significant
 differences:
 
--  In MATLAB®, this definition must be saved in a file, named ``f.m``,
+-  In MATLAB, this definition must be saved in a file, named ``f.m``,
    whereas in Julia, this expression can appear anywhere, including in
    an interactive session.
--  In MATLAB®, the closing ``end`` is optional, being implied by the end
+-  In MATLAB, the closing ``end`` is optional, being implied by the end
    of the file. In Julia, the terminating ``end`` is required.
--  In MATLAB®, this function would print the value ``x + y`` but would
+-  In MATLAB, this function would print the value ``x + y`` but would
    not return any value, whereas in Julia, the last expression evaluated
    is a function's return value.
 -  Expression values are never printed automatically except in
@@ -30,7 +30,7 @@ differences:
    expressions on the same line.
 
 In general, while the function definition syntax is reminiscent of
-MATLAB®, the similarity is largely superficial. Therefore, rather than
+MATLAB, the similarity is largely superficial. Therefore, rather than
 continually comparing the two, in what follows, we will simply describe
 the behavior of functions in Julia directly.
 

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -87,13 +87,13 @@ those available for the ``perl`` and ``ruby`` programs::
      -h --help                Print this message
 
 
-Major Differences From MATLAB®
-------------------------------
+Major Differences From MATLAB
+-----------------------------
 
-Julia's syntax is intended to be familiar to users of MATLAB®. However,
-Julia is in no way a MATLAB® clone: there are major syntactic and
+Julia's syntax is intended to be familiar to users of MATLAB. However,
+Julia is in no way a MATLAB clone: there are major syntactic and
 functional differences. The following are the most significant
-differences that may trip up Julia users accustomed to MATLAB®:
+differences that may trip up Julia users accustomed to MATLAB:
 
 -  Arrays are indexed with square brackets, ``A[i,j]``.
 -  The imaginary unit ``sqrt(-1)`` is represented in julia with ``im``.

--- a/doc/manual/introduction.rst
+++ b/doc/manual/introduction.rst
@@ -24,10 +24,10 @@ implemented using
 multi-paradigm, combining features of imperative, functional, and
 object-oriented programming. The syntax of Julia is similar to
 `MATLAB® <http://en.wikipedia.org/wiki/Matlab>`_ and consequently
-MATLAB® programmers should feel immediately comfortable with Julia.
-While MATLAB® is quite effective for prototyping and exploring numerical
+MATLAB programmers should feel immediately comfortable with Julia.
+While MATLAB is quite effective for prototyping and exploring numerical
 linear algebra, it has limitations for programming tasks outside of this
-relatively narrow scope. Julia keeps MATLAB®'s ease and expressiveness
+relatively narrow scope. Julia keeps MATLAB's ease and expressiveness
 for high-level numerical computing, but transcends its general
 programming limitations. To achieve this, Julia builds upon the lineage
 of mathematical programming languages, but also borrows much from

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1441,7 +1441,7 @@ Basic functions
 
 .. function:: length(A)
 
-   Returns the number of elements in A (note that this differs from Matlab where ``length(A)`` is the largest dimension of ``A``)
+   Returns the number of elements in A (note that this differs from MATLAB where ``length(A)`` is the largest dimension of ``A``)
 
 .. function:: nnz(A)
 


### PR DESCRIPTION
First occurrence is in the manual introduction.  I left the symbol for that one.  

Also, make every occurrence of MATLAB in the docs all-caps.
