### PR TITLE
memory efficient filter(Function, Associative)

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -85,7 +85,16 @@ function filter!(f::Function, d::Associative)
     end
     return d
 end
-filter(f::Function, d::Associative) = filter!(f,copy(d))
+function filter(f::Function, as::Associative)
+    as_type = typeof(as)
+    result = as_type{as_type.parameters}()
+    for (k,v) in as
+        if f(k,v)
+            result[k] = v
+        end
+    end
+    return result
+end
 
 keytype{K,V}(a::Associative{K, V}) = K
 valtype{K,V}(a::Associative{K, V}) = V


### PR DESCRIPTION
I don't like that this relies on the Associative type having a default constructor...

The previous version only counted on `copy`, which means that a composite type that provided the Associative interface but could not be constructed by default (maybe had more things dynamically added) could still work...

So I'm not sure if this is a good idea.
