### PR TITLE
avoid double-close of uv handles at exit

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -228,6 +228,10 @@ DLLEXPORT void uv_atexit_hook()
     struct uv_shutdown_queue_item *item = queue.first;
     while (item) {
         uv_handle_t *handle = item->h;
+        if (uv_is_closing(handle)) {
+            item = item->next;
+            continue;
+        }
         switch(handle->type) {
         case UV_TTY:
         case UV_UDP:


### PR DESCRIPTION
If uv__run_closing_handles isn't called between closing a handle and
uv_atexit_hook then uv_atexit_hook will attempt to close the handle
again, causing an assertion failure.
