### PR TITLE
fix example/bigfib since bigint is now in base

### DIFF
--- a/examples/bigfib.jl
+++ b/examples/bigfib.jl
@@ -1,8 +1,6 @@
-require("extras/bigint")
 
 module BigFib
 export bigfib
-const BigInt = Main.BigInt
 
 # Large Fibonacci to exercise BigInt
 # from Bill Hart, https://groups.google.com/group/julia-dev/browse_frm/thread/798e2d1322daf633


### PR DESCRIPTION
A minor fix for example/bigfib.jl
