### PR TITLE
Docs: Dict{K,V}() instead of Dict{K,V}(n)

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -310,9 +310,9 @@ Dicts can be created using a literal syntax: ``{"A"=>1, "B"=>2}``. Use of curly 
 As with arrays, ``Dicts`` may be created with comprehensions. For example,
 ``{i => f(i) for i = 1:10}``.
 
-.. function:: Dict{K,V}(n)
+.. function:: Dict{K,V}()
 
-   Construct a hashtable with keys of type K and values of type V and intial size of n
+   Construct a hashtable with keys of type K and values of type V
 
 .. function:: has(collection, key)
 


### PR DESCRIPTION
Dict does not seem to take an initial size any more:

```
julia> x = Dict{ASCIIString,Any}(10)
ERROR: no method Dict(Int64,)

julia> x = Dict{ASCIIString,Any}()
Dict{ASCIIString,Any}()
```
