### PR TITLE
RFC: Fix doc for `vec`

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1670,7 +1670,7 @@ Indexing, Assignment, and Concatenation
 
 .. function:: vec(A)
 
-   Make a vector out of an array with only one non-singleton dimension.
+   Vectorize an array using column-major convention.
 
 Sparse Matrices
 ---------------


### PR DESCRIPTION
Changed to match behavior described in #2214 and introduced in 5f3dd47
