### PR TITLE
Add `@which` macro

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1124,6 +1124,7 @@ export
     @time,
     @timed,
     @elapsed,
+    @which,
     @windows_only,
     @unix_only,
     @osx_only,


### PR DESCRIPTION
Alternative form to the `which` function, to be used directly in front of a function call. Examples.

```
@which rand(1:10)
@which 1 + im
@which a[1,2]
@which a[1] = 2
```

I find it quite useful. Any objections?
