### PR TITLE
RFC: Linear indexing with multidimensional index.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -67,7 +67,7 @@ function check_bounds{T<:Integer}(sz::Int, I::Ranges{T})
     end
 end
 
-function check_bounds{T <: Real}(sz::Int, I::AbstractVector{T})
+function check_bounds{T <: Real}(sz::Int, I::AbstractArray{T})
     for i in I
         i = to_index(i)
         if i < 1 || i > sz

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -176,7 +176,7 @@ function index_shape(I...)
 end
 
 index_shape(i::Real) = ()
-index_shape(i)       = (length(i),)
+index_shape(i)       = size(i)
 index_shape(i::Real,j::Real) = ()
 index_shape(i      ,j::Real) = (length(i),)
 index_shape(i      ,j)       = (length(i),length(j))


### PR DESCRIPTION
This change makes array indexing more general and since indexing is automatically controversial, let's start the discussion.

Today indexing a[b], when a is an array and b is an array with more than 1 dimension, gives a no method error for check_bounds. In contrast Matlab produces an array of the same shape as b, or effectively reshape(a[b[:]], size(b)). I've found this indexing quite handy, especially in situations like
img_lut = lut[1 + img]
to apply a lookup table transformation to an image or
I = [1 4 5; 4 2 6; 5 6 3]
A = a[I]
to produce matrices with certain structures.

For indexing with multiple indices, e.g. a[b, c], this patch effectively gives a[b[:], c[:]]. When b and c are row or column vectors this is very reasonable. When they are full matrices it's arguable but happens to be consistent with Matlab.
