### PR TITLE
bug fix: throw error if fft is passed repeated dimensions

### DIFF
--- a/base/fftw.jl
+++ b/base/fftw.jl
@@ -175,6 +175,9 @@ execute_r2r{T<:fftwSingle}(plan, X::StridedArray{T}, Y::StridedArray{T}) =
     ccall((:fftwf_execute_r2r,libfftwf), Void, 
           (Ptr{Void},Ptr{T},Ptr{T}), plan, X, Y)
 
+execute{T<:fftwReal}(plan, X::StridedArray{T}, Y::StridedArray{T}) =
+    execute_r2r(plan, X, Y)
+
 # Destroy plan
 
 destroy_plan(precision::fftwTypeDouble, plan) =
@@ -251,7 +254,12 @@ end
 # Compute dims and howmany for FFTW guru planner
 function dims_howmany(X::StridedArray, Y::StridedArray, 
                       sz::Array{Int,1}, region)
-    reg = [region...]
+    reg = sort([region...])
+    for i = 1:length(reg)-1
+        if reg[i] == reg[i+1]
+            throw(ArgumentError("each dimension can be transformed at most once"))
+        end
+    end
     ist = [strides(X)...]
     ost = [strides(Y)...]
     dims = [sz[reg] ist[reg] ost[reg]]'


### PR DESCRIPTION
For example, `fft(X, (1,1))` currently segfaults.  The patch throws an error if a given transform dimension is listed more than once in the list of dimensions to transform.

(The patch also adds an additional `execute` internal convenience function for use in an upcoming package.)
