### PR TITLE
Convert Herz to Hertz (for rates)

### DIFF
--- a/extras/units.jl
+++ b/extras/units.jl
@@ -252,11 +252,11 @@ _unit_gen_dict(utable[2:end])
 end
 
 # Rate units
-type Herz <: UnitBase end
+type Hertz <: UnitBase end
 let
   # Unit       RefUnit     ToRef        show      pshow     lshow   fshow
 const utable = {
-  (Herz,       Herz,        1,          "Hz",     "Hz",     "Hz",   "Herz")
+  (Hertz,      Hertz,      1,           "Hz",     "Hz",     "Hz",   "Hertz")
 }
 _unit_gen_func_multiplicative(utable)
 _unit_gen_dict_with_prefix(utable)


### PR DESCRIPTION
For frequency "Hertz" is much more common than "Herz".

Being a "Hertz" I thought this commit would be authoritative :) 
