### PR TITLE
Use find_in_path when including files from command-line arguments

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -252,7 +252,7 @@ function process_options(args::Array{Any,1})
             repl = false
             # remove julia's arguments
             ARGS = args[i+1:end]
-            include(args[i])
+            include(Base.find_in_path(args[i]))
             break
         else
             error("unknown option: ", args[i])


### PR DESCRIPTION
Submitting as a pull request, given the 0.1 moratorium. It would be nice to have, as it's one of the issues I'm encountering in upgrading my lab to pre-0.1.
