### PR TITLE
add option to dlopen with RTLD_GLOBAL (fixes issue #2312)

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -123,7 +123,8 @@ const isimmutable = x->(isa(x,Tuple) || isa(x,Symbol) ||
 dlsym(hnd, s::String) = ccall(:jl_dlsym, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
 dlsym(hnd, s::Symbol) = ccall(:jl_dlsym, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
 dlsym_e(hnd, s::Union(Symbol,String)) = ccall(:jl_dlsym_e, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
-dlopen(s::String) = ccall(:jl_load_dynamic_library, Ptr{Void}, (Ptr{Uint8},), s)
+dlopen(s::String, isglobal::Bool) = ccall(:jl_load_dynamic_library, Ptr{Void}, (Ptr{Uint8},Int32), s, isglobal)
+dlopen(s::String) = dlopen(s, false)
 dlclose(p::Ptr) = ccall(:uv_dlclose,Void,(Ptr{Void},),p)
 
 cfunction(f::Function, r, a) =

--- a/base/base.jl
+++ b/base/base.jl
@@ -123,8 +123,8 @@ const isimmutable = x->(isa(x,Tuple) || isa(x,Symbol) ||
 dlsym(hnd, s::String) = ccall(:jl_dlsym, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
 dlsym(hnd, s::Symbol) = ccall(:jl_dlsym, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
 dlsym_e(hnd, s::Union(Symbol,String)) = ccall(:jl_dlsym_e, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
-dlopen(s::String, isglobal::Bool) = ccall(:jl_load_dynamic_library, Ptr{Void}, (Ptr{Uint8},Int32), s, isglobal)
-dlopen(s::String) = dlopen(s, false)
+dlopen(s::String) = ccall(:jl_load_dynamic_library, Ptr{Void}, (Ptr{Uint8},Int32), s, 0)
+dlopen_global(s::String) = ccall(:jl_load_dynamic_library, Ptr{Void}, (Ptr{Uint8},Int32), s, 1)
 dlclose(p::Ptr) = ccall(:uv_dlclose,Void,(Ptr{Void},),p)
 
 cfunction(f::Function, r, a) =

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1087,6 +1087,7 @@ export
 # C interface
     c_free,
     dlopen,
+    dlopen_global,
     dlclose,
     dlsym,
     dlsym_e,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3007,11 +3007,11 @@ C Interface
 
    Load a shared library, returning an opaque handle.
 
-   Optionally, one can pass a second argument via
-   ``dlopen(libfile::String, isglobal::Bool)``, which specifies whether
-   the libraries symbols are to be made available globally to other
-   shared libraries, corresponding to the ``RTLD_GLOBAL`` flag on Unix
-   systems.
+   There is also a variant :func:`dlopen_global` of this function,
+   which has the same argument and return value but attempts (on Unix)
+   to open the library in a way that makes the library's symbols available
+   to other shared libraries.  (This corresponds to the ``RTLD_GLOBAL`` flag
+   in the POSIX :func:`dlopen` function.)
 
 .. function:: dlsym(handle, sym)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3007,9 +3007,16 @@ C Interface
 
    Load a shared library, returning an opaque handle.
 
+   Optionally, one can pass a second argument via
+   ``dlopen(libfile::String, isglobal::Bool)``, which specifies whether
+   the libraries symbols are to be made available globally to other
+   shared libraries, corresponding to the ``RTLD_GLOBAL`` flag on Unix
+   systems.
+
 .. function:: dlsym(handle, sym)
 
-   Look up a symbol from a shared library handle, return callable function pointer on success.
+   Look up a symbol from a shared library handle, return callable
+   function pointer (via :func:`ccall`) on success.
 
 .. function:: dlsym_e(handle, sym)
    

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -70,7 +70,7 @@ static void *add_library_sym(char *name, char *lib)
     else {
         hnd = libMap[lib];
         if (hnd == NULL) {
-            hnd = jl_load_dynamic_library(lib);
+            hnd = jl_load_dynamic_library(lib, 0);
             if (hnd != NULL)
             libMap[lib] = hnd;
             else

--- a/src/init.c
+++ b/src/init.c
@@ -370,7 +370,7 @@ void julia_init(char *imageFile)
 {
     jl_page_size = getPageSize();
     jl_find_stack_bottom();
-    jl_dl_handle = jl_load_dynamic_library(NULL);
+    jl_dl_handle = jl_load_dynamic_library(NULL, 0);
 #ifdef __WIN32__
     uv_dlopen("ntdll.dll",jl_ntdll_handle); //bypass julia's pathchecking for system dlls
     uv_dlopen("Kernel32.dll",jl_kernel32_handle);

--- a/src/julia.h
+++ b/src/julia.h
@@ -896,7 +896,7 @@ DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
 void jl_add_standard_imports(jl_module_t *m);
 
 // external libraries
-DLLEXPORT uv_lib_t *jl_load_dynamic_library(char *fname);
+DLLEXPORT uv_lib_t *jl_load_dynamic_library(char *fname, int global);
 DLLEXPORT void *jl_dlsym_e(uv_lib_t *handle, char *symbol);
 DLLEXPORT void *jl_dlsym(uv_lib_t *handle, char *symbol);
 DLLEXPORT uv_lib_t *jl_wrap_raw_dl_handle(void *handle);


### PR DESCRIPTION
In this patch, Julia's  `dlopen` now has ~~an optional boolean second argument~~ _a variant_ `dlopen_global`, which loads the shared library globally if possible (so that its symbols are available to any subsequently loaded shared library), needed to fix #2312. 

~~Alternatively, instead of the optional second argument I could just rename that version to `dlopen_global`.  Let me know what you prefer.~~  _Update: I renamed it this way below._

Works on Linux (and should work on other POSIX systems).  It's not clear if Windows supports or needs this option; the flag currently does nothing on Windows.
