### PR TITLE
add -fstack-protector-all to DEBUG build (including JIT code)

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -34,7 +34,7 @@ override OS = WINNT
 override ARCH = i686
 override OPENBLAS_DYNAMIC_ARCH = 1
 override CROSS_COMPILE=$(XC_HOST)-
-export WINEPATH := '$(BUILD)/lib/julia;$(BUILD)/lib;$(shell $(CROSS_COMPILE)gcc -print-search-dirs | grep programs | sed "s/^programs: =//" | sed "s/:/;/g");C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin'
+export WINEPATH := '$(BUILD)/lib/julia;$(BUILD)/lib;$(shell $(CROSS_COMPILE)gcc -print-search-dirs | grep programs | sed "s/^programs: =//" | sed "s/:/;/g");C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin;$(BUILD)/Git/bin'
 else
 $(error "unknown XC_HOST variable set")
 endif
@@ -105,7 +105,7 @@ CC = $(CROSS_COMPILE)gcc
 CXX = $(CROSS_COMPILE)g++
 JCFLAGS = -std=gnu99 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64
 JCXXFLAGS = -pipe $(fPIC) -fno-rtti
-DEBUGFLAGS = -ggdb3 -DDEBUG
+DEBUGFLAGS = -ggdb3 -DDEBUG -fstack-protector-all
 SHIPFLAGS = -O3 -DNDEBUG -falign-functions
 ifneq ($(ARCH), ppc64)
   SHIPFLAGS += -momit-leaf-frame-pointer
@@ -117,7 +117,7 @@ CC = $(CROSS_COMPILE)clang
 CXX = $(CROSS_COMPILE)clang++
 JCFLAGS = -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64
 JCXXFLAGS = -pipe $(fPIC) -fno-rtti
-DEBUGFLAGS = -g -DDEBUG
+DEBUGFLAGS = -g -DDEBUG -fstack-protector-all
 SHIPFLAGS = -O3 -DNDEBUG
 ifeq ($(OS), Darwin)
 CC += -mmacosx-version-min=10.6

--- a/src/init.c
+++ b/src/init.c
@@ -366,7 +366,7 @@ void init_stdio()
     JL_STDIN = init_stdio_handle(0,1);
 }
 
-void julia_init(char *imageFile)
+void real_julia_init(char *imageFile)
 {
     jl_page_size = getPageSize();
     jl_find_stack_bottom();
@@ -496,6 +496,19 @@ void julia_init(char *imageFile)
 #ifdef JL_GC_MARKSWEEP
     jl_gc_enable();
 #endif
+}
+extern void * __stack_chk_guard;
+void julia_init(char *imageFile)
+{
+    unsigned char * p = (unsigned char *) &__stack_chk_guard;
+    /* If you have the ability to generate random numbers in your kernel then use them */
+    p[sizeof(__stack_chk_guard)-1] = 255;
+    p[sizeof(__stack_chk_guard)-2] = '\n';
+    p[0] = 0;
+    real_julia_init(imageFile);
+    p[sizeof(__stack_chk_guard)-1] = 0;
+    p[sizeof(__stack_chk_guard)-2] = 0;
+    p[0] = 0;
 }
 
 DLLEXPORT void jl_install_sigint_handler()


### PR DESCRIPTION
this adds stack corruption checking code to julia under debug build conditions. I think it is safe to merge, but figured someone (Jeff?) should confirm first.

external libraries, such as libopenblas, are not altered by this. it is theoretically possible to do targeted testing by adding `CFLAGS=-fstack-protector-all` and `LDFLAGS=-lssp` to a specific build in deps (although the library name varies and sometimes does not exist, and it could instead be specified that the __stack_chk_guard and __stack_chk_fail symbols are undefined until runtime)
