### PR TITLE
add typealiases for exact C-compatible types

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -122,6 +122,25 @@ export
     MergeSort,
     TimSort,
 
+# Ccall types
+    Cchar,
+    Cuchar,
+    Cshort,
+    Cushort,
+    Cint,
+    Cuint,
+    Clong,
+    Culong,
+    Cptrdiff_t,
+    Csize_t,
+    Clonglong,
+    Culonglong,
+    Cfloat,
+    Cdouble,
+    Ccomplex_float,
+    Ccomplex_double,
+    Cstring,
+
 # Exceptions
     ArgumentError,
     DisconnectException,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -42,6 +42,7 @@ end
 ## Load essential files and libraries
 
 include("base.jl")
+include("build_h.jl")
 
 # core operations & types
 include("range.jl")
@@ -62,6 +63,29 @@ include("float.jl")
 include("reduce.jl")
 include("complex.jl")
 include("rational.jl")
+
+typealias Cchar Int8
+typealias Cuchar Int8
+typealias Cshort Int16
+typealias Cushort Uint16
+typealias Cint Int32
+typealias Cuint Uint32
+if OS_NAME == :Windows
+    typealias Clong Int32
+    typealias Culong Uint32
+else
+    typealias Clong Int
+    typealias Culong Int
+end
+typealias Cptrdiff_t Int
+typealias Csize_t Uint
+typealias Clonglong Int64
+typealias Culonglong Uint64
+typealias Cfloat Float32
+typealias Cdouble Float64
+#typealias Ccomplex_float Complex64
+#typealias Ccomplex_double Complex128
+typealias Cstring Ptr{Uint8}
 
 # core data structures (used by type inference)
 include("abstractarray.jl")
@@ -103,7 +127,6 @@ include("serialize.jl")
 include("multi.jl")
 
 # system & environment
-include("build_h.jl")
 include("osutils.jl")
 include("libc.jl")
 include("env.jl")


### PR DESCRIPTION
some more typealias's for consideration in the list that I forgot initially (in decreasing order of my interest level of actually having them added):

``` julia
typealias Cfloat Float32
typealias Cdouble Float64
typealias Cstring Ptr{Uint8}
typealias Cargv Ptr{Ptr{Uint8}}
typealias Cptr Ptr{Void}
```

(travis build fails because I'm using OS_NAME before build_h.jl got included in the sysimg. I think it should be moved much earlier)
