### PR TITLE
RFC: io: Add support for fixed-size structs to `read`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -95,6 +95,7 @@ end
 read(s::IO, ::Type{Bool})    = (read(s,Uint8)!=0)
 read(s::IO, ::Type{Float32}) = box(Float32,unbox(Int32,read(s,Int32)))
 read(s::IO, ::Type{Float64}) = box(Float64,unbox(Int64,read(s,Int64)))
+read(s::IO, c::CompositeKind) = c(ntuple(length(c.types), x->read(s, c.types[x]))...)
 
 read{T}(s::IO, t::Type{T}, d1::Int, dims::Int...) =
     read(s, t, tuple(d1,dims...))


### PR DESCRIPTION
`read` is called for each field in the composite type. The result of
each `read` is stored in a tuple and then passed to the composite
type's constructor.

It only works if all of a composite type's fields are typed and supported by `read`. If a field's type is unspecified or unsupported by `read`, an error will occur.

It's not as powerful as [StrPack.jl](https://strpackjl.readthedocs.org/en/latest/), but it should be useful for many common scenarios such as parsing a simple binary file format.
