### PR TITLE
fftw tweak: use >>1 to divide integers by 2 and round down, not ifloor

### DIFF
--- a/base/fftw.jl
+++ b/base/fftw.jl
@@ -532,7 +532,7 @@ for (Tr,Tc) in ((:Float32,:Complex64),(:Float64,:Complex128))
         function rfft(X::StridedArray{$Tr}, region)
             d1 = region[1]
             osize = [size(X)...]
-            osize[d1] = ifloor(osize[d1]/2) + 1
+            osize[d1] = osize[d1]>>1 + 1
             Y = Array($Tc, osize...)
             p = Plan(X, Y, region, ESTIMATE, NO_TIMELIMIT)
             execute($Tr, p.plan)
@@ -549,7 +549,7 @@ for (Tr,Tc) in ((:Float32,:Complex64),(:Float64,:Complex128))
                            flags::Unsigned, tlim::Real)
             d1 = region[1]
             osize = [size(X)...]
-            osize[d1] = ifloor(osize[d1]/2) + 1
+            osize[d1] = osize[d1]>>1 + 1
             Y = Array($Tc, osize...)
             p = Plan(X, Y, region, flags, tlim)
             return Z::StridedArray{$Tr} -> begin
@@ -566,7 +566,7 @@ for (Tr,Tc) in ((:Float32,:Complex64),(:Float64,:Complex128))
 
         function brfft(X::StridedArray{$Tc}, d::Integer, region::Integer)
             osize = [size(X)...]
-            @assert osize[region] == ifloor(d/2) + 1
+            @assert osize[region] == d>>1 + 1
             osize[region] = d
             Y = Array($Tr, osize...)
             p = Plan(X, Y, region, ESTIMATE | PRESERVE_INPUT, NO_TIMELIMIT)
@@ -579,7 +579,7 @@ for (Tr,Tc) in ((:Float32,:Complex64),(:Float64,:Complex128))
         function brfftd(X::StridedArray{$Tc}, d::Integer, region) 
             d1 = region[1]
             osize = [size(X)...]
-            @assert osize[d1] == ifloor(d/2) + 1
+            @assert osize[d1] == d>>1 + 1
             osize[d1] = d
             Y = Array($Tr, osize...)
             p = Plan(X, Y, region, ESTIMATE, NO_TIMELIMIT)
@@ -604,7 +604,7 @@ for (Tr,Tc) in ((:Float32,:Complex64),(:Float64,:Complex128))
         function plan_brfft(X::StridedArray{$Tc}, d::Integer, region::Integer,
                             flags::Unsigned, tlim::Real)
             osize = [size(X)...]
-            @assert osize[region] == ifloor(d/2) + 1
+            @assert osize[region] == d>>1 + 1
             osize[region] = d
             Y = Array($Tr, osize...)
             p = Plan(X, Y, region, flags | PRESERVE_INPUT, tlim)
@@ -623,7 +623,7 @@ for (Tr,Tc) in ((:Float32,:Complex64),(:Float64,:Complex128))
             end
             d1 = region[1]
             osize = [size(X)...]
-            @assert osize[d1] == ifloor(d/2) + 1
+            @assert osize[d1] == d>>1 + 1
             osize[d1] = d
             Y = Array($Tr, osize...)
             X = copy(X)


### PR DESCRIPTION
Extremely minor patch.
