### PR TITLE
modify the url in the sidebox

### DIFF
--- a/doc/_themes/julia/localtoc.html
+++ b/doc/_themes/julia/localtoc.html
@@ -7,13 +7,9 @@
     :copyright: Copyright 2007-2011 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 #}
-{%- if "manual/index"==current_page_name %}
-  <h3><a href="{{ pathto(master_doc) }}">{{ _('Main page') }}</a></h3>
-{%- elif "manual"==current_page_name[0:6] %}
+{%- if "manual"==current_page_name[0:6] and "manual/index"!=current_page_name %}
   <h3><a href="{{ pathto(master_doc) }}/../manual/">{{ _('Table Of Contents') }}</a></h3>
-{%- elif "stdlib/index"==current_page_name %}
-  <h3><a href="{{ pathto(master_doc) }}">{{ _('Main page') }}</a></h3>
-{%- elif "stdlib"==current_page_name[0:6] %}
+{%- elif "stdlib"==current_page_name[0:6] and "stdlib/index"!=current_page_name %}
   <h3><a href="{{ pathto(master_doc) }}/../stdlib/">{{ _('Table Of Contents') }}</a></h3>
 {%- else %}
   <h3><a href="{{ pathto(master_doc) }}">{{ _('Main page') }}</a></h3>

--- a/doc/_themes/julia/localtoc.html
+++ b/doc/_themes/julia/localtoc.html
@@ -7,9 +7,19 @@
     :copyright: Copyright 2007-2011 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 #}
-{%- if display_toc %}
+{%- if "manual/index"==current_page_name %}
+  <h3><a href="{{ pathto(master_doc) }}">{{ _('Main page') }}</a></h3>
+{%- elif "manual"==current_page_name[0:6] %}
   <h3><a href="{{ pathto(master_doc) }}/../manual/">{{ _('Table Of Contents') }}</a></h3>
-  {{ toc }}
+{%- elif "stdlib/index"==current_page_name %}
+  <h3><a href="{{ pathto(master_doc) }}">{{ _('Main page') }}</a></h3>
+{%- elif "stdlib"==current_page_name[0:6] %}
+  <h3><a href="{{ pathto(master_doc) }}/../stdlib/">{{ _('Table Of Contents') }}</a></h3>
 {%- else %}
   <h3><a href="{{ pathto(master_doc) }}">{{ _('Main page') }}</a></h3>
 {%- endif %}
+
+{%- if display_toc %}
+  {{ toc }}
+{%- endif %}
+

--- a/doc/_themes/julia/localtoc.html
+++ b/doc/_themes/julia/localtoc.html
@@ -8,7 +8,7 @@
     :license: BSD, see LICENSE for details.
 #}
 {%- if display_toc %}
-  <h3><a href="{{ pathto(master_doc) }}">{{ _('Table Of Contents') }}</a></h3>
+  <h3><a href="{{ pathto(master_doc) }}/../manual/">{{ _('Table Of Contents') }}</a></h3>
   {{ toc }}
 {%- else %}
   <h3><a href="{{ pathto(master_doc) }}">{{ _('Main page') }}</a></h3>


### PR DESCRIPTION
modify the url in the sidebox,
such that the url with literal `Table Of Contents` does link to 
the index page of `doc/manual`, instead of the index page of `doc`
