### PR TITLE
RFC: Add function to obtain native type alignment information

### DIFF
--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -183,6 +183,7 @@
     jl_module_name;
     jl_module_parent;
     jl_module_type;
+    jl_native_alignment;
     jl_nb_available;
     jl_new_array;
     jl_new_closure;

--- a/src/sys.c
+++ b/src/sys.c
@@ -18,6 +18,10 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#define __STDC_CONSTANT_MACROS
+#define __STDC_LIMIT_MACROS
+#include <llvm-c/Target.h>
+
 #ifdef __SSE__
 #include <xmmintrin.h>
 #endif
@@ -426,3 +430,16 @@ DLLEXPORT uint8_t jl_zero_denormals(uint8_t isZero)
 #endif
 }
 
+// -- processor native alignment information --
+
+DLLEXPORT void jl_native_alignment(uint_t* int8align, uint_t* int16align, uint_t* int32align, uint_t* int64align, uint_t* float32align, uint_t* float64align)
+{
+    LLVMTargetDataRef tgtdata = LLVMCreateTargetData("");
+    *int8align = LLVMPreferredAlignmentOfType(tgtdata, LLVMInt8Type());
+    *int16align = LLVMPreferredAlignmentOfType(tgtdata, LLVMInt16Type());
+    *int32align = LLVMPreferredAlignmentOfType(tgtdata, LLVMInt32Type());
+    *int64align = LLVMPreferredAlignmentOfType(tgtdata, LLVMInt64Type());
+    *float32align = LLVMPreferredAlignmentOfType(tgtdata, LLVMFloatType());
+    *float64align = LLVMPreferredAlignmentOfType(tgtdata, LLVMDoubleType());
+    LLVMDisposeTargetData(tgtdata);
+}


### PR DESCRIPTION
This handles all the libLLVM machinery outside of the Julia context.

```
julia> i8a, i16a, i32a, i64a, f32a, f64a = zeros(Uint, 1), zeros(Uint, 1), zeros(Uint, 1), zeros(Uint, 1), zeros(
Uint, 1), zeros(Uint, 1)
([0x0000000000000000],[0x0000000000000000],[0x0000000000000000],[0x0000000000000000],[0x0000000000000000],[0x0000
000000000000])

julia> ccall("jl_native_alignment", Void, (Ptr{Uint}, Ptr{Uint}, Ptr{Uint}, Ptr{Uint}, Ptr{Uint}, Ptr{Uint}), i8a, i16a, i32a, i64a, f32a, f64a)

julia> i8a
1-element Uint64 Array:
 0x0000000000000001

julia> i16a
1-element Uint64 Array:
 0x0000000000000002

julia> i32a
1-element Uint64 Array:
 0x0000000000000004

julia> i64a
1-element Uint64 Array:
 0x0000000000000008

julia> f32a
1-element Uint64 Array:
 0x0000000000000004

julia> f64a
1-element Uint64 Array:
 0x0000000000000008
```

Please proceed to beat up my API.
