### PR TITLE
`parse_lines(str, line_delim)`

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -890,6 +890,35 @@ function parse(str::String)
     return ex
 end
 
+function parse_lines(str::String, line_delim::Char)
+    lines = split(str, line_delim)
+    parsed_exprs = {}
+    curr_str = ""
+
+    for i = 1:length(lines)
+      curr_str = string(curr_str, lines[i], "\n")
+      ex = Base.parse_input_line(curr_str)
+
+      if ex == nothing
+         continue
+
+      elseif isa(ex, Expr)
+
+        if ex.head == :error
+          return {ex}
+        elseif ex.head == :continue
+          continue
+        end
+
+      end
+
+      curr_str = ""
+      push!(parsed_exprs, ex)
+    end
+
+    return parsed_exprs
+end
+
 ## miscellaneous string functions ##
 
 function lpad(s::String, n::Integer, p::String)


### PR DESCRIPTION
It seems like at least a couple different things (the repl, the studio ide) independently take user input, break it into lines, and then massage those lines into expressions.

Unfortunately, we can't quite use `parse(str, pos)` in a loop because line breaks _might_ signal the end of an expression. Using `parse` we'll just get a `ParseError("extra token after end of expression")`

I really would like to use `parse(str, pos)`... I just don't quite see a way...
