### PR TITLE
RFC: add unsafe_pointer_to_any (fixes #2458)

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1124,6 +1124,7 @@ export
     strerror,
     unsafe_ref,
     unsafe_assign,
+    unsafe_pointer_to_any,
 
 # Macros
     @str,

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -37,6 +37,9 @@ unsafe_assign(p::Ptr{Any}, x::ANY, i::Integer) = pointerset(p, x, int(i))
 unsafe_assign{T}(p::Ptr{T}, x, i::Integer) = pointerset(p, convert(T, x), int(i))
 unsafe_assign{T}(p::Ptr{T}, x) = unsafe_assign(p, convert(T,x), 1)
 
+# convert a boxed jl_value_t* to Any
+unsafe_pointer_to_any(p::Ptr) = pointerany(p)
+
 integer(x::Ptr) = convert(Uint, x)
 unsigned(x::Ptr) = convert(Uint, x)
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -33,7 +33,7 @@ namespace JL_I {
         abs_float, copysign_float,
         flipsign_int,
         // pointer access
-        pointerref, pointerset,
+        pointerref, pointerset, pointerany,
         // checked arithmetic
         checked_sadd, checked_uadd, checked_ssub, checked_usub,
         checked_smul, checked_umul,
@@ -487,6 +487,14 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         if (nargs!=3)
             jl_error("pointerset: wrong number of arguments");
         return emit_pointerset(args[1], args[2], args[3], ctx);
+    }
+    if (f == pointerany) {
+        if (nargs != 1)
+            jl_error("pointerany: wrong number of arguments");
+        if (!jl_is_cpointer_type(expr_type(args[1], ctx)))
+            jl_error("pointerany: argument must be pointer type");
+        return builder.CreateBitCast(emit_unboxed(args[1], ctx),
+                                     jl_pvalue_llvmt);
     }
     if (nargs < 1) jl_error("invalid intrinsic call");
     Value *x = auto_unbox(args[1], ctx);
@@ -1082,7 +1090,7 @@ extern "C" void jl_init_intrinsic_functions(void)
     ADD_I(fptrunc32); ADD_I(fpext64);
     ADD_I(abs_float); ADD_I(copysign_float);
     ADD_I(flipsign_int);
-    ADD_I(pointerref); ADD_I(pointerset);
+    ADD_I(pointerref); ADD_I(pointerset); ADD_I(pointerany);
     ADD_I(checked_sadd); ADD_I(checked_uadd);
     ADD_I(checked_ssub); ADD_I(checked_usub);
     ADD_I(checked_smul); ADD_I(checked_umul);

--- a/test/core.jl
+++ b/test/core.jl
@@ -473,6 +473,9 @@ begin
     @test a2 == [101,102,103]
 end
 
+@test unsafe_pointer_to_any(ccall(:jl_call1, Ptr{Void}, (Any,Any),
+                                  x -> x+1, 314158)) == 314159
+
 # issue #1287, combinations of try, catch, return
 begin
     local f, g


### PR DESCRIPTION
This adds a function `unsafe_pointer_to_any(p::Ptr)` that takes a boxed `jl_value_t*` and converts it back to a Julia `Any`.  It works by adding a new `pointerany` intrinsic.

This is useful in callback functions, because raw `jl_value_t*` pointers to boxed Julia types can be passed as `void*` to C functions by declaring the argument as `Any`, but there was previously no way to undo this conversion to get back the native Julia object.

In particular, it should be quite useful in implementing closures, as discussed [on the mailing list](https://groups.google.com/forum/#!topic/julia-dev/9FRwq3hVwgA).
