### PR TITLE
RFC: Fix findin for String Arrays

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1328,6 +1328,16 @@ function findin(a, b)
     ind
 end
 
+function findin(a, b::String)
+    ind = Array(Int, 0)
+    for i = 1:length(a)
+        if a[i] == b
+            push!(ind, i)
+        end
+    end
+    ind
+end
+
 # Copying subregions
 function indcopy(sz::Dims, I::RangeVecIntList)
     n = length(I)

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -551,3 +551,7 @@ s = "   p"
 @test """
        $s
       """ == " $s\n"
+
+# issue #2474
+ss = fill("a",2,2)
+@test findin(ss, "a") == [1,2,3,4]


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/julia-users/KcqDAr7Sb8Q

``` julia
julia> ss = fill("a",2,2)
2x2 ASCIIString Array:
 "a"  "a"
 "a"  "a"

julia> findin(ss, "a")
0-element Int64 Array
```

The problem is that `findin` is defined as 

``` julia
function findin(a, b)
    ind = Array(Int, 0)
    bset = Set(b...)
    for i = 1:length(a)
        if has(bset, a[i])
            push!(ind, i)
        end
    end
    ind
end
```

and `bset` becomes a set of characters.
