### PR TITLE
Fix findnext on BitArrays

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1478,9 +1478,9 @@ end
 function findnext(B::BitArray, start::Integer)
     Bc = B.chunks
 
-    chunk_start = div(start-1, 64)+1
-    within_chunk_start = start-1-chunk_start*64
-    mask = _msk64-((1<<within_chunk_start)-1)
+    chunk_start = @_div64(start-1)+1
+    within_chunk_start = @_mod64(start-1)
+    mask = _msk64 << within_chunk_start
 
     if Bc[chunk_start] & mask != 0
         return (chunk_start-1) << 6 + trailing_zeros(Bc[chunk_start] & mask) + 1
@@ -1503,9 +1503,9 @@ function findnextnot(B::BitArray, start::Integer)
         return 0
     end
 
-    chunk_start = div(start-1, 64)+1
-    within_chunk_start = start-1-chunk_start*64
-    mask = (1<<within_chunk_start)-1
+    chunk_start = @_div64(start-1)+1
+    within_chunk_start = @_mod64(start-1)
+    mask = ~(_msk64 << within_chunk_start)
 
     if Bc[chunk_start] | mask != _msk64
         return (chunk_start-1) << 6 + trailing_ones(Bc[chunk_start] | mask) + 1

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -517,6 +517,20 @@ b1 = randbool(v1)
 
 @check_bit_operation find Vector{Int} (b1,)
 
+b1 = trues(v1)
+for i = 0:v1-1
+    @test findfirst(b1 >> i) == i+1
+    @test Base.findfirstnot(~(b1 >> i)) == i+1
+end
+
+for i = 3:v1-1
+    for j = 2:i
+        submask = b1 << (v1-j+1)
+        @test findnext((b1 >> i) | submask,j) == i+1
+        @test Base.findnextnot((~(b1 >> i)) $ submask,j) == i+1
+    end
+end
+
 b1 = randbool(n1, n2)
 @check_bit_operation findn_nzs (Vector{Int}, Vector{Int}, BitArray) (b1,)
 


### PR DESCRIPTION
`findnext` on `BitArrays` did not properly mask lower bits in the starting chunk.  
Fixed here, and added tests.
