### PR TITLE
Fix tranposed arrays in Julia.tmbundle.

### DIFF
--- a/contrib/Julia.tmbundle/Syntaxes/Julia.tmLanguage
+++ b/contrib/Julia.tmbundle/Syntaxes/Julia.tmLanguage
@@ -303,7 +303,7 @@
 					<key>begin</key>
 					<string>\[</string>
 					<key>end</key>
-					<string>\)((?:'|(?:\.'))*\.?')</string>
+					<string>\]((?:'|(?:\.'))*\.?')</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Expressions such as `A[i]'` were interpreted as starting a string.
