### PR TITLE
RFC: Updated parser to improve debugging experience

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -464,7 +464,7 @@
 		  (if (and allow-empty (memv (require-token s) ops))
 		      '()
 		      (if (memv #\newline ops)
-			  (let ((loc (line-number-node s)))
+			  (let ((loc (line-number-filename-node s)))
 			    ;; note: line-number must happen before (down s)
 			    (list (down s) loc))
 			  (list (down s)))))
@@ -490,7 +490,7 @@
 				  (memv (peek-token s) ops)))
 			 (loop ex #f)
 			 (if (memv #\newline ops)
-			     (let ((loc (line-number-node s)))
+			     (let ((loc (line-number-filename-node s)))
 			       (loop (list* (down s) loc ex) #f))
 			     (loop (cons (down s) ex) #f)))))))))
 
@@ -865,7 +865,7 @@
 	 ((elseif)
 	  `(if ,test ,then
 	       ;; line number for elseif condition
-	       (block ,(line-number-node s)
+	       (block ,(line-number-filename-node s)
 		      ,(parse-resword s 'if))))
 	 ((else)    (list 'if test then (parse-resword s 'begin)))
 	 (else      (error (string "unexpected " nxt))))))


### PR DESCRIPTION
The parser creates a `line-number-filename-node` for all lines in a julia file rather than just those in functions (see julia-parser.scm).  This addresses issue #1636 and is necessary for the Debug.jl package to print source lines while debugging.  With this parser update the debugging experience feels like using gdb or pdb.

I am requesting inclusion into julia-0.1 because currently Debug.jl is segfaulting when run on recent commits on the master branch.  However, the parser update could be incorporated into master as well and Debug.jl will be fixed eventually.

I should note that the code builds and passes all tests on my machine.

Any comments are greatly appreciated.

Thanks.
