### PR TITLE
RFC: Add method for contains(::String, ::String).

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -209,6 +209,8 @@ function search(s::String, t::String, i::Integer)
 end
 search(s::String, t::String) = search(s,t,start(s))
 
+contains(s::String, t::String) = search(s,t,start(s)) == 0:-1 ? false : true
+
 function cmp(a::String, b::String)
     i = start(a)
     j = start(b)


### PR DESCRIPTION
Currently, and somewhat confusingly::

```
contains("Hello, world.\n", "world.") == false
```

So I added a method for `contains(::String, ::String)`
that emulates `contains(::String, ::Char)`
such that the above function call now return true.

No tests were added to be consistent with the fact that
no tests exist for `contains(::String, ::Char)`.

Also, are pull requests the best for submitting these small changes?
