### PR TITLE
Extends ctranspose() to Tridiagonal matrices

### DIFF
--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -117,6 +117,9 @@ copy(M::Tridiagonal) = Tridiagonal(M.dl, M.d, M.du)
 round(M::Tridiagonal) = Tridiagonal(round(M.dl), round(M.d), round(M.du))
 iround(M::Tridiagonal) = Tridiagonal(iround(M.dl), iround(M.d), iround(M.du))
 
+import Base.ctranspose
+ctranspose(M::Tridiagonal) = Tridiagonal(M.du, M.d, M.dl)
+
 ## Solvers
 
 #### Tridiagonal matrix routines ####

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -117,10 +117,9 @@ copy(M::Tridiagonal) = Tridiagonal(M.dl, M.d, M.du)
 round(M::Tridiagonal) = Tridiagonal(round(M.dl), round(M.d), round(M.du))
 iround(M::Tridiagonal) = Tridiagonal(iround(M.dl), iround(M.d), iround(M.du))
 
-import Base.transpose
+import Base.conj, Base.transpose, Base.ctranspose
+conj(M::Tridiagonal) = Tridiagonal(conj(M.du), conj(M.d), conj(M.dl))
 transpose(M::Tridiagonal) = Tridiagonal(M.du, M.d, M.dl)
-
-import Base.ctranspose
 ctranspose(M::Tridiagonal) = conj(transpose(M))
 
 ## Solvers

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -117,8 +117,11 @@ copy(M::Tridiagonal) = Tridiagonal(M.dl, M.d, M.du)
 round(M::Tridiagonal) = Tridiagonal(round(M.dl), round(M.d), round(M.du))
 iround(M::Tridiagonal) = Tridiagonal(iround(M.dl), iround(M.d), iround(M.du))
 
+import Base.transpose
+transpose(M::Tridiagonal) = Tridiagonal(M.du, M.d, M.dl)
+
 import Base.ctranspose
-ctranspose(M::Tridiagonal) = Tridiagonal(M.du, M.d, M.dl)
+ctranspose(M::Tridiagonal) = conj(transpose(M))
 
 ## Solvers
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -280,6 +280,11 @@ for elty in (Float32, Float64, Complex64, Complex128)
             F[i+1,i] = dl[i]
         end
         @test full(T) == F
+                                        # elementary operations on tridiagonals
+        @test conj(T) == Tridiagonal(conj(dl), conj(d), conj(du))
+        @test transpose(T) == Tridiagonal(du, d, du)
+        @test ctranspose(T) == Tridiagonal(conj(du), conj(d), conj(dl))
+
                                         # tridiagonal linear algebra
         v = convert(Vector{elty}, v)
         @test_approx_eq T*v F*v


### PR DESCRIPTION
This patch allows Tridiagonal matrices to be transposed.
