### PR TITLE
[RFC]: Detection of OpenBLAS interface bitwidth

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -133,6 +133,18 @@ typealias BlasChar Char
 if USE_LIB64
     typealias BlasInt Int64
     blas_int(x) = int64(x)
+
+    print("Autodetecting BLAS interface....");
+    # Try and autodetect BLAS library interface bitwidth
+    try
+        configstr = bytestring( ccall((:openblas_get_config, Base.libblas_name), Ptr{Uint8}, () ))
+
+        # Check to see if we have an INTERFACE64=1 anywhere in the config string
+        if !ismatch(r".*INTERFACE64\s*=\s*1", configstr)
+            warn( "OpenBLAS configured as 32-bit interface, yet Julia configured for 64-bit BLAS interface!" );
+        end
+    catch
+    end 
 else
     typealias BlasInt Int32
     blas_int(x) = int32(x)


### PR DESCRIPTION
This is my strange way of beginning discussion on the best way to incorporate this into the BLAS code.

It would be very useful to; at the least, print a warning when Julia's `USE_LIB64` setting conflicts with OpenBLAS's `INTERFACE64`, or even switch Julia's `USE_LIB64` setting to match.  This second option may not be feasible, as e.g. `arpack` and `suite-sparse`, etc... would need to match, so maybe informing the user is the best course of action here.

Where is a good place to stick this kind of code?  It would be good (in my mind) to print this out when Julia's BLAS facilities are first initialized, but maybe not every time a BLAS function is called. :)
