### PR TITLE
Updates to ambiguous warning output

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1032,14 +1032,15 @@ static void check_ambiguous(jl_methlist_t *ml, jl_tuple_t *type,
         char *n = fname->name;
         jl_value_t *errstream = jl_stderr_obj();
         JL_STREAM *s = JL_STDERR;
-        JL_PRINTF(s, "Warning: New definition %s", n);
+        JL_PRINTF(s, "Warning: New definition \n    %s", n);
         jl_show(errstream, (jl_value_t*)type);
-        JL_PRINTF(s, " is ambiguous with %s", n);
+        print_func_loc(s, linfo);
+        JL_PRINTF(s, "\nis ambiguous with \n    %s", n);
         jl_show(errstream, (jl_value_t*)sig);
         print_func_loc(s, oldmeth->func->linfo);
-        JL_PRINTF(s, ".\n         Make sure %s", n);
+        JL_PRINTF(s, ".\nMake sure \n    %s", n);
         jl_show(errstream, isect);
-        JL_PRINTF(s, " is defined first.\n");
+        JL_PRINTF(s, "\nis defined first.\n");
     done_chk_amb:
         JL_GC_POP();
     }


### PR DESCRIPTION
- Re-added source line numbers for new ambiguous definition.  These existed previously, but were lost in some merge.
- Cleaned up formatting

Old (minimal line wrapping, no line number on new def):

``` julia
julia> using DataFrames
Warning: New definition getindex(DataArray{T<:Number,N},Union(Ranges{T},BitArray{1},Array{T,1})) is ambiguous with getindex(DataArray{T,N},Union(Array{Bool,1},BitArray{1})) at /scratch1/tmp/kmsquire/.julia/DataFrames/src/dataarray.jl:337.
         Make sure getindex(DataArray{T<:Number,N},Union(Array{Bool,1},BitArray{1})) is defined first.
```

New (more line wrapping, line number added)

``` julia
julia> using DataFrames
Warning: New definition 
    getindex(DataArray{T<:Number,N},Union(Array{T,1},BitArray{1},Ranges{T})) at /scratch1/tmp/kmsquire/.julia/DataFrames/src/dataarray.jl:362
is ambiguous with 
    getindex(DataArray{T,N},Union(BitArray{1},Array{Bool,1})) at /scratch1/tmp/kmsquire/.julia/DataFrames/src/dataarray.jl:337.
Make sure 
    getindex(DataArray{T<:Number,N},Union(BitArray{1},Array{Bool,1}))
is defined first.
```
