### PR TITLE
Changed the argument names to base to be more informative in the repl.

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -287,9 +287,9 @@ function _base(symbols::Array{Uint8}, b::Int, x::Unsigned, pad::Int, neg::Bool)
     ASCIIString(a)
 end
 
-base(b::Integer     , x::Integer, pad::Integer) = _base(dig_syms,int(b),unsigned(abs(x)),pad,x<0)
-base(s::Array{Uint8}, x::Integer, pad::Integer) = _base(s,length(s),unsigned(abs(x)),pad,x<0)
-base(b::Union(Integer,Array{Uint8}), x::Integer) = base(b, x, 1)
+base(base::Integer, n::Integer, pad::Integer) = _base(dig_syms,int(base),unsigned(abs(n)),pad,n<0)
+base(symbols::Array{Uint8}, n::Integer, p::Integer) = _base(symbols,length(symbols),unsigned(abs(n)),p,n<0)
+base(base_or_symbols::Union(Integer,Array{Uint8}), n::Integer) = base(base_or_symbols, n, 1)
 
 
 for sym in (:bin, :oct, :dec, :hex)

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -2587,12 +2587,12 @@
 
 "),
 
-("Data Formats","Base","base","base(b, n[, pad])
+("Data Formats","Base","base","base(base, n[, pad])
 
    Convert an integer to a string in the given base, optionally
-   specifying a number of digits to pad to. The base \"b\" can be
-   specified as either an integer, or as a \"Uint8\" array of
-   character values to use as digit symbols.
+   specifying a number of digits to pad to. The base can be specified
+   as either an integer, or as a \"Uint8\" array of character values
+   to use as digit symbols.
 
 "),
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1677,9 +1677,9 @@ Data Formats
 
    Convert an integer to an octal string, optionally specifying a number of digits to pad to.
 
-.. function:: base(b, n, [pad])
+.. function:: base(base, n, [pad])
 
-   Convert an integer to a string in the given base, optionally specifying a number of digits to pad to. The base ``b`` can be specified as either an integer, or as a ``Uint8`` array of character values to use as digit symbols.
+   Convert an integer to a string in the given base, optionally specifying a number of digits to pad to. The base can be specified as either an integer, or as a ``Uint8`` array of character values to use as digit symbols.
 
 .. function:: bits(n)
 


### PR DESCRIPTION
Previously, `methods(base)` was less useful than it could be because all the variable names in all the methods are only single letters. This is especially true of `s` (now `symbols`).

Now, the first time an argument is used in one of the methods, it is given a full variable name. When an argument of the same type and purpose is used by another method, it is given just a single letter name. For example, `base` becomes `b`.

I also modified the documentation for `base` to reflect the change of name from `b` to `base`.
