### PR TITLE
Adds expm(A::Hermitian)

### DIFF
--- a/base/linalg/hermitian.jl
+++ b/base/linalg/hermitian.jl
@@ -33,6 +33,11 @@ eigvals(A::Hermitian, vl::Real, vh::Real) = LAPACK.syevr!('N', 'V', A.uplo, copy
 eigvals(A::Hermitian) = eigvals(A, 1, size(A, 1))
 eigmax(A::Hermitian) = eigvals(A, size(A, 1), size(A, 1))[1]
 
+function expm(A::Hermitian)
+    F = eigfact(A)
+    diagmm(F[:vectors], exp(F[:values])) * F[:vectors]'
+end
+
 function sqrtm(A::Hermitian, cond::Bool)
     F = eigfact(A)
     vsqrt = sqrt(complex(F[:values]))

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -249,6 +249,11 @@ for elty in (Float32, Float64, Complex64, Complex128)
                                          0  -0.000000000000002   3.000000000000000])
 end
 
+# Hermitian matrix exponential
+A1 = randn(4,4) + im*randn(4,4)
+A2 = A1 + A1'
+@test_approx_eq expm(A2) expm(Hermitian(A2))
+
                                         # matmul for types w/o sizeof (issue #1282)
 A = Array(ComplexPair{Int},10,10)
 A[:] = complex(1,1)


### PR DESCRIPTION
Uses eigenvalue decomposition to compute expm(A). This is a stable method for
Hermitian matrices and is about 2x as fast in my testing.
