### PR TITLE
RFC: A _working_ fix to Kronecker product

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -181,7 +181,7 @@ function kron(a::Matrix, b::Vector)
   res
 end
 
-function kron(a::Matrix, b::Matrix)
+function kron(a::Vector, b::Matrix)
   res = kron(a,b[:,1])
   for i=2:size(b,2)
     res = hcat(res, kron(a,b[:,i]))
@@ -189,8 +189,12 @@ function kron(a::Matrix, b::Matrix)
   res
 end
 
-function kron(a::Vector, b::Matrix)
-  kron(a',b')'
+function kron(a::Matrix, b::Matrix)
+  res = kron(a[:,1],b)
+  for i=2:size(a,2)
+    res = hcat(res, kron(a[:,i],b))
+  end
+  res
 end
 
 kron(a::Number, b::Number) = a * b 

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -171,7 +171,7 @@ function trace{T}(A::Matrix{T})
     return t
 end
 
-kron(a::Vector, b::Vector) = [ a[i]*b[j] for i=1:length(a), j=1:length(b) ]
+kron(a::Vector, b::Vector) = vec([ a[i]*b[j] for j=1:length(b), i=1:length(a) ])
 
 function kron{T,S}(a::Matrix{T}, b::Matrix{S})
     R = Array(promote_type(T,S), size(a,1)*size(b,1), size(a,2)*size(b,2))

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -173,6 +173,10 @@ end
 
 kron(a::Vector, b::Vector)=vec(kron(reshape(a,length(a),1),reshape(b,length(b),1)))
 
+kron(a::Matrix, b::Vector)=kron(a,reshape(b,length(b),1))
+
+kron(a::Vector, b::Matrix)=kron(reshape(a,length(a),1),b)
+
 function kron{T,S}(a::Matrix{T}, b::Matrix{S})
     R = Array(promote_type(T,S), size(a,1)*size(b,1), size(a,2)*size(b,2))
 

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -171,30 +171,24 @@ function trace{T}(A::Matrix{T})
     return t
 end
 
-kron(a::Vector, b::Vector) = vec([ a[i]*b[j] for j=1:length(b), i=1:length(a) ])
+kron(a::Vector, b::Vector)=vec(kron(reshape(a,length(a),1),reshape(b,length(b),1)))
 
-function kron(a::Matrix, b::Vector)
-  res = kron(a[:,1],b)
-  for i=2:size(a,2)
-    res = hcat(res, kron(a[:,i],b))
-  end
-  res
-end
+function kron{T,S}(a::Matrix{T}, b::Matrix{S})
+    R = Array(promote_type(T,S), size(a,1)*size(b,1), size(a,2)*size(b,2))
 
-function kron(a::Vector, b::Matrix)
-  res = kron(a,b[:,1])
-  for i=2:size(b,2)
-    res = hcat(res, kron(a,b[:,i]))
-  end
-  res
-end
-
-function kron(a::Matrix, b::Matrix)
-  res = kron(a[:,1],b)
-  for i=2:size(a,2)
-    res = hcat(res, kron(a[:,i],b))
-  end
-  res
+    m = 1
+    for j = 1:size(a,2)
+        for l = 1:size(b,2)
+            for i = 1:size(a,1)
+                aij = a[i,j]
+                for k = 1:size(b,1)
+                    R[m] = aij*b[k,l]
+                    m += 1
+                end
+            end
+        end
+    end
+    R
 end
 
 kron(a::Number, b::Number) = a * b 

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -173,29 +173,31 @@ end
 
 kron(a::Vector, b::Vector) = vec([ a[i]*b[j] for j=1:length(b), i=1:length(a) ])
 
-function kron{T,S}(a::Matrix{T}, b::Matrix{S})
-    R = Array(promote_type(T,S), size(a,1)*size(b,1), size(a,2)*size(b,2))
-
-    m = 1
-    for j = 1:size(a,2)
-        for l = 1:size(b,2)
-            for i = 1:size(a,1)
-                aij = a[i,j]
-                for k = 1:size(b,1)
-                    R[m] = aij*b[k,l]
-                    m += 1
-                end
-            end
-        end
-    end
-    R
+function kron(a::Matrix, b::Vector)
+  res = kron(a[:,1],b)
+  for i=2:size(a,2)
+    res = hcat(res, kron(a[:,i],b))
+  end
+  res
 end
 
-kron(a::Number, b::Number) = a * b
-kron(a::Vector, b::Number) = a * b
-kron(a::Number, b::Vector) = a * b
-kron(a::Matrix, b::Number) = a * b
-kron(a::Number, b::Matrix) = a * b
+function kron(a::Matrix, b::Matrix)
+  res = kron(a,b[:,1])
+  for i=2:size(b,2)
+    res = hcat(res, kron(a,b[:,i]))
+  end
+  res
+end
+
+function kron(a::Vector, b::Matrix)
+  kron(a',b')'
+end
+
+kron(a::Number, b::Number) = a * b 
+kron(a::Vector, b::Number) = a * b 
+kron(a::Number, b::Vector) = a * b 
+kron(a::Matrix, b::Number) = a * b 
+kron(a::Number, b::Matrix) = a * b 
 
 randsym(n) = symmetrize!(randn(n,n))
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -395,14 +395,15 @@ end
 let
   a = [1, 2, 3]
   b = [4, 5, 6]
-  @test kron(a,b) == [4,5,6,8,10,12,12,15,18] 
-  @test kron(a',b') == [4 5 6 8 10 12 12 15 18]
-  @test kron(a,b')  == [4 5 6; 8 10 12; 12 15 18]
-  @test kron(a',b)  == [4 8 12; 5 10 15; 6 12 18]
-  @test kron(a,eye(2)) == [1 0; 0 1; 2 0; 0 2; 3 0; 0 3]
-  @test kron(eye(2),a) == [ 1 0; 2 0; 3 0; 0 1; 0 2; 0 3]
-  @test kron(eye(2),2) == 2*eye(2)
-  @test kron(3,eye(3)) == 3*eye(3)
-  @test kron(a,2) == [2, 4, 6]
-  @test kron(b',2) == [8 10 12]
+  @test kron(eye(2),eye(2)) == eye(4)
+  @test kron(a,b) == [4,5,6,8,10,12,12,15,18]             
+  @test kron(a',b') == [4 5 6 8 10 12 12 15 18]           
+  @test kron(a,b')  == [4 5 6; 8 10 12; 12 15 18]         
+  @test kron(a',b)  == [4 8 12; 5 10 15; 6 12 18]         
+  @test kron(a,eye(2)) == [1 0; 0 1; 2 0; 0 2; 3 0; 0 3]  
+  @test kron(eye(2),a) == [ 1 0; 2 0; 3 0; 0 1; 0 2; 0 3] 
+  @test kron(eye(2),2) == 2*eye(2)                        
+  @test kron(3,eye(3)) == 3*eye(3)                        
+  @test kron(a,2) == [2, 4, 6]                            
+  @test kron(b',2) == [8 10 12]                              
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -390,3 +390,19 @@ let
     N = 3
     @test_approx_eq log(det(eye(N))) logdet(eye(N))
 end
+
+# issue 2637
+let
+  a = [1, 2, 3]
+  b = [4, 5, 6]
+  @test kron(a,b) == [4,5,6,8,10,12,12,15,18] 
+  @test kron(a',b') == [4 5 6 8 10 12 12 15 18]
+  @test kron(a,b')  == [4 5 6; 8 10 12; 12 15 18]
+  @test kron(a',b)  == [4 8 12; 5 10 15; 6 12 18]
+  @test kron(a,eye(2)) == [1 0; 0 1; 2 0; 0 2; 3 0; 0 3]
+  @test kron(eye(2),a) == [ 1 0; 2 0; 3 0; 0 1; 0 2; 0 3]
+  @test kron(eye(2),2) == 2*eye(2)
+  @test kron(3,eye(3)) == 3*eye(3)
+  @test kron(a,2) == [2, 4, 6]
+  @test kron(b',2) == [8 10 12]
+end


### PR DESCRIPTION
Fix to Issue #2637, and also added support for product of Matrix and Vector

In essence, the Vector Vector Kronecker product was written as an array comprehension, but array comprehensions return 2D arrays, so I added an explicit vectorization after the list comprehension and reordered the comprehension indices to get the proper result.

Tests were added covering all these cases.

Previous pull request #2643 had bug in the implementation of Matrix/Vector Kronecker product, which should have been caught by the tests added if I had run them properly.
