### PR TITLE
Provides LAPACK.stein!() and hooks in SymTridiagonal

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -568,6 +568,7 @@ export
     eigfact!,
     eigs,
     eigvals,
+    eigvecs,
     expm,
     sqrtm,
     eye,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -48,6 +48,7 @@ export
     eigfact!,
     eigs,
     eigvals,
+    eigvecs,
     expm,
     sqrtm,
     eye,

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -429,6 +429,9 @@ function eig(A::Union(Number, StridedMatrix))
     return F[:values], F[:vectors]
 end
 
+#Calculates eigenvectors
+eigvecs(A::Union(Number, StridedMatrix)) = eigfact(A)[:vectors]
+
 function eigvals(A::StridedMatrix)
     if ishermitian(A) return eigvals(Hermitian(A)) end
     if iscomplex(A) return LAPACK.geev!('N', 'N', copy(A))[1] end

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -72,6 +72,8 @@ eig(m::SymTridiagonal) = LAPACK.stegr!('V', copy(m.dv), copy(m.ev))
 eigvals(m::SymTridiagonal, il::Int, iu::Int) = LAPACK.stebz!('I', 'E', 0.0, 0.0, il, iu, -1.0, copy(m.dv), copy(m.ev))[1]
 eigvals(m::SymTridiagonal, vl::Float64, vu::Float64) = LAPACK.stebz!('V', 'E', vl, vu, 0, 0, -1.0, copy(m.dv), copy(m.ev))[1]
 eigvals(m::SymTridiagonal) = LAPACK.stebz!('A', 'E', 0.0, 0.0, 0, 0, -1.0, copy(m.dv), copy(m.ev))[1]
+#Compute selected eigenvectors only
+eigvecs{Index <: Integer}(m::SymTridiagonal, eigval_idx::Vector{Index}) = LAPACK.stein!(m.dv, m.ev, eigval_idx)
 
 ## Tridiagonal matrices ##
 type Tridiagonal{T} <: AbstractMatrix{T}


### PR DESCRIPTION
stein!() calculates selected eigenvectors of a symmetric tridiagonal matrix.

Also defines new base function eigvals() which by default is a simple wrapper around eig() but allows for stein!() to be called without any associated eigenvalue computations.
