### PR TITLE
RFC: Fix to how eps() works on complex values and types

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -114,7 +114,7 @@ isequal(x::Real, z::Complex) = real_valued(z) && isequal(real(z),x)
 
 hash(z::Complex) = (r = hash(real(z)); real_valued(z) ? r : bitmix(r,hash(imag(z))))
 
-eps(z::Complex) = eps(abs(z))
+eps(z::Complex) = max(eps(real(z)),eps(imag(z)))
 
 conj(z::Complex) = complex(real(z),-imag(z))
 abs(z::Complex)  = hypot(real(z), imag(z))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -115,6 +115,7 @@ isequal(x::Real, z::Complex) = real_valued(z) && isequal(real(z),x)
 hash(z::Complex) = (r = hash(real(z)); real_valued(z) ? r : bitmix(r,hash(imag(z))))
 
 eps(z::Complex) = max(eps(real(z)),eps(imag(z)))
+eps{T}(::Type{Complex{T}}) = eps(T)
 
 conj(z::Complex) = complex(real(z),-imag(z))
 abs(z::Complex)  = hypot(real(z), imag(z))


### PR DESCRIPTION
The current implementation of `eps` on complex values relies on `abs`.  This leads to a problem for complex integer types, as `abs` returns a float, and thus `eps(1im)` does not fail like `eps(1)` (and it should). Similarly, `eps(Complex{Float64})` and related expressions simply fail (not being defined).

The changes in this request fix both of these issues, which become important when trying to compare complex floating point values. The docs (`doc/stdlib/base.rst` specifically) mentions only eps of real Float values & types is sensible, but it strikes me as natural to support complex Floats.
