### PR TITLE
Add missing sparse LU transpose solve operators

### DIFF
--- a/base/linalg/umfpack.jl
+++ b/base/linalg/umfpack.jl
@@ -254,6 +254,10 @@ end
 
 (\){T<:UMFVTypes}(fact::UmfpackLU{T}, b::Vector{T}) = solve(fact, b)
 (\){Ts<:UMFVTypes,Tb<:Number}(fact::UmfpackLU{Ts}, b::Vector{Tb}) = fact\convert(Vector{Ts},b)
+At_ldiv_B{T<:UMFVTypes}(fact::UmfpackLU{T}, b::Vector{T}) = solve(fact, b, UMFPACK_Aat)
+At_ldiv_B{Ts<:UMFVTypes,Tb<:Number}(fact::UmfpackLU{Ts}, b::Vector{Tb}) = fact.'\convert(Vector{Ts},b)
+Ac_ldiv_B{T<:UMFVTypes}(fact::UmfpackLU{T}, b::Vector{T}) = solve(fact, b, UMFPACK_At)
+Ac_ldiv_B{Ts<:UMFVTypes,Tb<:Number}(fact::UmfpackLU{Ts}, b::Vector{Tb}) = fact'\convert(Vector{Ts},b)
 
 ### Solve directly with matrix
 

--- a/test/suitesparse.jl
+++ b/test/suitesparse.jl
@@ -21,6 +21,12 @@ x = lua\b
 
 @test norm(A*x-b,1) < eps(1e4)
 
+b = [8., 20., 13., 6., 17.]
+x = lua'\b
+@test_approx_eq x float([1:5])
+
+@test norm(A'*x-b,1) < eps(1e4)
+
 using Base.LinAlg.CHOLMOD
 
 # based on deps/SuiteSparse-4.0.2/CHOLMOD/Demo/


### PR DESCRIPTION
Quick fix to add missing transpose solve operators with UmfpackLU objects. 

@dmbates
