### PR TITLE
Specify a llvm-config in Make.user when USE_SYSTEM_LLVM=1

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -185,7 +185,7 @@ LIBUNWIND=$(BUILD)/lib/libunwind-generic.a $(BUILD)/lib/libunwind.a
 endif
 
 ifeq ($(USE_SYSTEM_LLVM), 1)
-LLVM_CONFIG=llvm-config
+LLVM_CONFIG ?= llvm-config
 else
 LLVM_CONFIG=$(LLVMROOT)/bin/llvm-config
 endif


### PR DESCRIPTION
There are more then one instances of LLVM installed on my box and the default version is 3.0, I want(must) use version 3.2 for compiling Julia, with this commit, it can be done easily by putting these lines in `Make.user`:

```
USE_SYSTEM_LLVM = 1
LLVM_CONFIG = /usr/lib/llvm-3.2/bin/llvm-config
```
