### PR TITLE
Changed sleep() to call start_timer() with int64s

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -279,7 +279,7 @@ end
 function sleep(sec::Real)
     timer = TimeoutAsyncWork(status->tasknotify([wt], status))
     wt = WaitTask(timer, false)
-    start_timer(timer, iround(sec*1000), 0)
+    start_timer(timer, int64(iround(sec*1000)), int64(0))
     args = yield(wt)
     stop_timer(timer)
     if isa(args,InterruptException)


### PR DESCRIPTION
On my 32-bit system I was getting 
`ERROR: no method start_timer(TimeoutAsyncWork,Int32,Int32)`
when using `sleep()`. Changed call to start_timer to use int64s
