### PR TITLE
add Diagonal AbstractMatrix type

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -118,6 +118,7 @@ export
     SVDDense,
     Hermitian,
     Triangular,
+    Diagonal,
     InsertionSort,
     QuickSort,
     MergeSort,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -24,6 +24,7 @@ export
     SVDDense,
     Hermitian,
     Triangular,
+    Diagonal,
 
 # Functions
     chol,
@@ -152,6 +153,7 @@ include("linalg/triangular.jl")
 include("linalg/hermitian.jl")
 include("linalg/woodbury.jl")
 include("linalg/tridiag.jl")
+include("linalg/diagonal.jl")
 include("linalg/rectfullpacked.jl")
 
 include("linalg/bitarray.jl")

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -29,14 +29,12 @@ isposdef(D::Diagonal) = all(D.diag .> 0)
 
 *(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag .* Db.diag)
 *(D::Diagonal, V::Vector) = D.diag .* V
-*(V::Vector,D::Diagonal) = V .* D.diag
 *(A::Matrix, D::Diagonal) = diagmm(A,D.diag)
 *(D::Diagonal, A::Matrix) = diagmm(D.diag,A)
 
 \(Da::Diagonal, Db::Diagonal) = Diagonal(Db.diag ./ Da.diag )
 /(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag ./ Db.diag )
 \(D::Diagonal, V::Vector) = V ./ D.diag
-/(V::Vector, D::Diagonal) = V ./ D.diag
 function \(D::Diagonal, A::Matrix)
     m, n = size(A)
     if m != length(D.diag)

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -1,0 +1,84 @@
+## Diagonal matrices
+
+type Diagonal{T} <: AbstractMatrix{T}
+    diag::Vector{T}
+end
+
+size(D::Diagonal) = (length(D.diag),length(D.diag))
+size(D::Diagonal,d::Integer) = d<1 ? error("dimension out of range") : (d<=2 ? length(D.diag) : 1)
+
+convert{T}(::Type{Matrix{T}}, D::Diagonal{T}) = diagm(D.diag)
+convert{T}(::Type{SymTridiagonal{T}}, D::Diagonal{T}) = SymTridiagonal(D.diag,zeros(T,length(D.diag)-1))
+convert{T}(::Type{Tridiagonal{T}}, D::Diagonal{T}) = Tridiagonal(zeros(T,length(D.diag)-1),D.diag,zeros(T,length(D.diag)-1))
+
+full(D::Diagonal) = diagm(D.diag)
+function show(io::IO, D::Diagonal)
+    println(io, summary(D), ":")
+    print(io, "diag: ")
+    print_matrix(io, (D.diag)')
+end
+
+ishermitian(D::Diagonal) = true
+issym(D::Diagonal) = true
+isposdef(D::Diagonal) = all(D.diag .> 0)
+
+==(Da::Diagonal, Db::Diagonal) = Da.diag == Db.diag
+
++(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag + Db.diag)
+-(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag - Db.diag)
+
+*(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag .* Db.diag)
+*(D::Diagonal, V::Vector) = D.diag .* V
+*(V::Vector,D::Diagonal) = V .* D.diag
+*(A::Matrix, D::Diagonal) = diagmm(A,D.diag)
+*(D::Diagonal, A::Matrix) = diagmm(D.diag,A)
+
+\(Da::Diagonal, Db::Diagonal) = Diagonal(Db.diag ./ Da.diag )
+/(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag ./ Db.diag )
+\(D::Diagonal, V::Vector) = V ./ D.diag
+/(V::Vector, D::Diagonal) = V ./ D.diag
+function \(D::Diagonal, A::Matrix)
+    m, n = size(A)
+    if m != length(D.diag)
+        error("argument dimensions do not match")
+    end
+    C = Array(promote_type(eltype(A),eltype(D.diag)),size(A))
+    for i = 1:m
+        di = D.diag[i]
+        for j = 1:n
+            C[i,j] = A[i,j] / di
+        end
+    end
+    return C
+end
+function /(A::Matrix, D::Diagonal)
+    m, n = size(A)
+    if n != length(D.diag)
+        error("argument dimensions do not match")
+    end
+    C = Array(promote_type(eltype(A),eltype(D.diag)),size(A))
+    for j = 1:n
+        dj = D.diag[j]
+        for i = 1:m
+            C[i,j] = A[i,j] / dj
+        end
+    end
+    return C
+end
+
+conj(D::Diagonal) = Diagonal(conj(D.diag))
+transpose(D::Diagonal) = D
+ctranspose(D::Diagonal) = conj(D)
+
+diag(D::Diagonal) = D.diag
+det(D::Diagonal) = prod(D.diag)
+logdet(D::Diagonal) = sum(log(D.diag))
+inv(D::Diagonal) = Diagonal(1 ./ D.diag)
+
+eigvals(D::Diagonal) = sort(D.diag)
+
+expm(D::Diagonal) = Diagonal(exp(D.diag))
+sqrtm(D::Diagonal) = Diagonal(sqrt(D.diag))
+
+# identity matrices via eye(Diagonal{type},n)
+eye{T}(::Type{Diagonal{T}}, n::Int) = Diagonal(ones(T,n))

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -330,6 +330,15 @@ for elty in (Float32, Float64, Complex64, Complex128)
         @test_approx_eq W\v F\v
         @test_approx_eq det(W) det(F)
 
+        # Diagonal
+        D = Diagonal(d)
+        DM = diagm(d)
+        @test_approx_eq D*v DM*v
+        @test_approx_eq D*U DM*U
+        @test_approx_eq D\v DM\v
+        @test_approx_eq D\U DM\U
+        @test_approx_eq det(D) det(DM)   
+
         # Test det(A::Matrix)
         # In the long run, these tests should step through Strang's
         #  axiomatic definition of determinants.


### PR DESCRIPTION
This adds a new type `Diagonal` representing a diagonal matrix. The key benefits
- Allows a more Julia-like interface to `diagmm` by using `D * A`, and defines the analogous `D\A` methods.
- Can be used as the easily-invertible matrix in a `Woodbury` type
