### PR TITLE
Fix mapslice on functions that return scalars.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1415,6 +1415,9 @@ function mapslices(f::Function, A::AbstractArray, dims::AbstractVector)
     # determine result size and allocate
     Rsize = copy(dimsA)
     # TODO: maybe support removing dimensions
+    if isempty(size(r1))
+        r1 = [r1]
+    end
     Rsize[dims] = [size(r1)...]
     R = similar(r1, tuple(Rsize...))
 


### PR DESCRIPTION
"Alternate" implementations of the stats functions now work. For example:

```
a = reshape(1:24, 4, 3, 2)
mapslices(mean, a, 3)
```
