### PR TITLE
Add an option to methodswith for showing methods with args that inherit from the given type

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -56,9 +56,11 @@ Getting Around
 
    Show all methods of ``f`` with their argument types.
 
-.. function:: methodswith(typ)
+.. function:: methodswith(typ[, showparents])
 
-   Show all methods with an argument of type ``typ``.
+   Show all methods with an argument of type ``typ``. If optional
+   ``showparents`` is ``true``, also show arguments with a parent type
+   of ``typ``, excluding type ``Any``.  
 
 All Objects
 -----------


### PR DESCRIPTION
Per Daniel Espeset's request here:

https://groups.google.com/d/msg/julia-dev/MsLmuTw1Mr0/1ABEnFigBLIJ
