### PR TITLE
start_reading in read{T}(::AsyncStream, ::Array{T, N})

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -379,6 +379,7 @@ function read{T}(this::AsyncStream, a::Array{T})
         buf = this.buffer
         assert(buf.seekable == false)
         assert(buf.maxsize >= nb)
+        start_reading(this)
         wait_readnb(this,nb)
         read(this.buffer, a)
         return a


### PR DESCRIPTION
The code snippet below is a simple `echo server`, which demonstrating a bug of `read{T}(::AsyncStream, ::Array{T, N})`  :

```
server = listen(Base.IPv4(0,0,0,0),uint16(9000))
client = Base.wait_accept(server)
p = Array(Uint8, 6)
read(client, p) ##### BUG: hangs here due to reading is not started
write(client, p)
```

And, this commit fix this :)
