### PR TITLE
Modify openblas interface bitwidth check

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -133,7 +133,8 @@ typealias BlasFloat Union(Float64,Float32,Complex128,Complex64)
 typealias BlasChar Char
 
 function check_openblas()
-    if Base.libblas_name == "libopenblas"
+    libblas = dlopen( Base.libblas_name )
+    if dlsym_e( libblas, :openblas_get_config ) != 0
         openblas_config = bytestring( ccall((:openblas_get_config, Base.libblas_name), Ptr{Uint8}, () ))
         openblas64 = ismatch(r".*USE64BITINT.*", openblas_config)
         if Base.USE_LIB64 != openblas64


### PR DESCRIPTION
Now supports OpenBLAS compilations where openblas is named `libblas.dylib`.  This should be the case for anyone using the Julia-deps PPA, for instance.
