### PR TITLE
OBJPROFILE bugfix

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -722,7 +722,8 @@ static void big_obj_stats(void);
 extern char *jl_typename_str(jl_value_t *v);
 
 #define print_type(v) jl_print_type(v, 1)
-static void jl_print_type(jl_value_t *v, int8_t surround){
+static void jl_print_type(jl_value_t *v, int8_t surround)
+{
     if(jl_is_tuple(v)){
         if (surround) {
             JL_PUTC('(', JL_STDERR);

--- a/src/gc.c
+++ b/src/gc.c
@@ -688,7 +688,7 @@ static void gc_mark(void)
     }
 
     gc_mark_all();
-    
+
     // find unmarked objects that need to be finalized.
     // this must happen last.
     for(i=0; i < finalizer_table.size; i+=2) {
@@ -719,14 +719,19 @@ static void big_obj_stats(void);
 #endif
 
 #ifdef OBJPROFILE
+extern char *jl_typename_str(jl_value_t *v);
 static void print_obj_profile(void)
 {
-    jl_value_t *errstream = jl_stderr_obj();
     for(int i=0; i < obj_counts.size; i+=2) {
         if (obj_counts.table[i+1] != HT_NOTFOUND) {
-            jl_printf(jl_stderr, "%d ", obj_counts.table[i+1]-1);
-            jl_show(errstream, obj_counts.table[i]);
-            jl_printf(jl_stderr, "\n");
+            jl_value_t *typ = (jl_value_t*)obj_counts.table[i];
+            jl_printf(JL_STDERR, "%d ", obj_counts.table[i+1]-1);
+            if (jl_is_datatype(typ)) {
+                jl_printf(JL_STDERR, "%s ", jl_typename_str((jl_value_t*)obj_counts.table[i]));
+            } else {
+                jl_printf(JL_STDERR, "<Unknown Type> ");
+            }
+            jl_printf(JL_STDERR, "\n");
         }
     }
 }
@@ -869,7 +874,7 @@ void jl_gc_init(void)
 
                          288, 320, 352, 384, 416, 448, 480, 512,
 
-                         640, 768, 896, 1024, 
+                         640, 768, 896, 1024,
 
                          1536, 2048 };
     int i;

--- a/src/gc.c
+++ b/src/gc.c
@@ -727,7 +727,7 @@ static void print_obj_profile(void)
             jl_value_t *typ = (jl_value_t*)obj_counts.table[i];
             jl_printf(JL_STDERR, "%d ", obj_counts.table[i+1]-1);
             if (jl_is_datatype(typ)) {
-                jl_printf(JL_STDERR, "%s ", jl_typename_str((jl_value_t*)obj_counts.table[i]));
+                jl_printf(JL_STDERR, "%s ", jl_typename_str(typ));
             } else {
                 jl_printf(JL_STDERR, "<Unknown Type> ");
             }


### PR DESCRIPTION
Julia build failed when the macro `OBJPROFILE` is defined to c compiler because of these reasons:
- typo: `JL_STDERR` wrong to `jl_stderr`
- type `DataType` could not be `show`  while compiling
- the type of the objects being tracked may be something else rather than a regular `DataType`

This commit fixed the bug and deleted some trailing-whitespaces(by my editor).
