### PR TITLE
RFC: add ENV for locale

### DIFF
--- a/base/help.jl
+++ b/base/help.jl
@@ -27,15 +27,14 @@ function decor_help_desc(func::String, mfunc::String, desc::String)
 end
 
 function helpdb_filename()
-    root = "$JULIA_HOME/../share/julia"
-    file = "helpdb.jl"
-    for loc in [Base.locale()]
-        fn = joinpath(root, loc, file)
-        if isfile(fn)
-            return fn
-        end
+    loc = (Base.locale() == "") ? "" : "_$(Base.locale())"
+    file = "$JULIA_HOME/../share/julia/helpdb"
+    ext = ".jl"
+    fn = "$(file)$(loc)$(ext)"
+    if isfile(fn)
+        return fn
     end
-    joinpath(root, file)
+    joinpath(file, ext)
 end
 
 function init_help()

--- a/base/i18n.jl
+++ b/base/i18n.jl
@@ -2,20 +2,14 @@ module I18n
 
 export locale
 
-LOCALE = nothing
 CALLBACKS = Function[]
 
 function locale()
-    if LOCALE === nothing
-        # XXX:TBD return default locale
-        return ""
-    end
-    LOCALE
+    get(ENV, "JULIA_LOCALE", "")
 end
 
 function locale(s::ByteString)
-    global LOCALE = s
-    # XXX:TBD call setlocale
+    ENV["JULIA_LOCALE"] = s
     for cb in CALLBACKS
         cb()
     end


### PR DESCRIPTION
add ENV["JULIA_LOCALE"], so we could make use of ENV 
i18n helpdb is put byside of original `helpdb.jl`

```
$ ls usr/share/julia/
base  doc  examples  extras  helpdb.jl  helpdb_zh_CN.jl  test  ui
```

```
julia> ENV["JULIA_LOCALE"]="zh_CN"
"zh_CN"

julia> help(sin)
Loading help data...
Base.sin(x)

   计算 "x" 的正弦值，其中 "x" 的单位为弧度。 # This is Chinese ... 

julia> Base.locale("")

julia> help(sin)
Loading help data...
Base.sin(x)

   Compute sine of "x", where "x" is in radians

julia> Base.locale("zh_CN")

julia> help(sin)
Loading help data...
Base.sin(x)

   计算 "x" 的正弦值，其中 "x" 的单位为弧度。

julia>
```
