### PR TITLE
bugfix: VersionNumber constructor should take Integer arguments, not just Int

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -7,7 +7,7 @@ type VersionNumber
     prerelease::Vector{Union(Int,ASCIIString)}
     build::Vector{Union(Int,ASCIIString)}
 
-    function VersionNumber(major::Int, minor::Int, patch::Int, pre::Vector, bld::Vector)
+    function VersionNumber(major::Integer, minor::Integer, patch::Integer, pre::Vector, bld::Vector)
         if major < 0 error("invalid major version: $major") end
         if minor < 0 error("invalid minor version: $minor") end
         if patch < 0 error("invalid patch version: $patch") end

--- a/test/corelib.jl
+++ b/test/corelib.jl
@@ -419,3 +419,7 @@ end
 # Ensure denormal flags functions don't segfault
 @test any(ccall("jl_zero_denormals", Uint8, (Uint8,), 1) .== [0x00 0x01])
 @test any(ccall("jl_zero_denormals", Uint8, (Uint8,), 0) .== [0x00 0x01])
+
+# VersionNumber
+@test VersionNumber(2,3,1) == VersionNumber(int8(2),uint32(3),int32(1)) == v"2.3.1"
+@test v"2.3.0" < v"2.3.1" < v"2.4.8" < v"3.7.2"


### PR DESCRIPTION
...and added some `VersionNumber` tests
