### PR TITLE
GC stats print bugfix (when GC_FINAL_STATS defined)

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -844,17 +844,17 @@ void *alloc_4w(void)
 #ifdef GC_FINAL_STATS
 static double process_t0;
 #include <malloc.h>
-void print_gc_stats(void)
+void jl_print_gc_stats(JL_STREAM *s)
 {
     malloc_stats();
     double ptime = clock_now()-process_t0;
-    jl_printf(JL_STDERR, "exec time\t%.5f sec\n", ptime);
-    jl_printf(JL_STDOUT, "gc time  \t%.5f sec (%2.1f%%)\n", total_gc_time,
+    jl_printf(s, "exec time\t%.5f sec\n", ptime);
+    jl_printf(s, "gc time  \t%.5f sec (%2.1f%%)\n", total_gc_time,
                (total_gc_time/ptime)*100);
     struct mallinfo mi = mallinfo();
-    jl_printf(JL_STDOUT, "malloc size\t%d MB\n", mi.uordblks/1024/1024);
-    jl_printf(JL_STDOUT, "total freed\t%llu b\n", total_freed_bytes);
-    jl_printf(JL_STDOUT, "free rate\t%.1f MB/sec\n",
+    jl_printf(s, "malloc size\t%d MB\n", mi.uordblks/1024/1024);
+    jl_printf(s, "total freed\t%llu b\n", total_freed_bytes);
+    jl_printf(s, "free rate\t%.1f MB/sec\n",
                (total_freed_bytes/total_gc_time)/1024/1024);
 }
 #endif
@@ -892,7 +892,6 @@ void jl_gc_init(void)
 #endif
 #ifdef GC_FINAL_STATS
     process_t0 = clock_now();
-    atexit(print_gc_stats);
 #endif
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -274,7 +274,6 @@ DLLEXPORT void uv_atexit_hook()
             jl_apply((jl_function_t*)f, NULL, 0);
         }
     }
-
     uv_loop_t* loop = jl_global_event_loop();
     struct uv_shutdown_queue queue = {NULL, NULL};
     uv_walk(loop, jl_uv_exitcleanup_walk, &queue);

--- a/src/init.c
+++ b/src/init.c
@@ -267,7 +267,7 @@ static void jl_uv_exitcleanup_walk(uv_handle_t* handle, void *arg) {
 }
 DLLEXPORT void uv_atexit_hook()
 {
-#if defined(JL_GC_MARKSWEEP) || defined(GC_FINAL_STATS)
+#if defined(JL_GC_MARKSWEEP) && defined(GC_FINAL_STATS)
     jl_print_gc_stats(JL_STDERR);
 #endif
     if (jl_base_module) {

--- a/src/init.c
+++ b/src/init.c
@@ -267,7 +267,9 @@ static void jl_uv_exitcleanup_walk(uv_handle_t* handle, void *arg) {
 }
 DLLEXPORT void uv_atexit_hook()
 {
-    JL_PRINT_GC_STATS;
+#if defined(JL_GC_MARKSWEEP) || defined(GC_FINAL_STATS)
+    jl_print_gc_stats(JL_STDERR);
+#endif
     if (jl_base_module) {
         jl_value_t *f = jl_get_global(jl_base_module, jl_symbol("_atexit"));
         if (f!=NULL && jl_is_function(f)) {

--- a/src/init.c
+++ b/src/init.c
@@ -142,7 +142,7 @@ static void __fastcall win_raise_exception(void* excpt)
     jl_throw(excpt);
 }
 static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guarantee __stdcall
-{   
+{
     int sig;
     //windows signals use different numbers from unix
     switch(wsig) {
@@ -267,12 +267,14 @@ static void jl_uv_exitcleanup_walk(uv_handle_t* handle, void *arg) {
 }
 DLLEXPORT void uv_atexit_hook()
 {
+    JL_PRINT_GC_STATS;
     if (jl_base_module) {
         jl_value_t *f = jl_get_global(jl_base_module, jl_symbol("_atexit"));
         if (f!=NULL && jl_is_function(f)) {
             jl_apply((jl_function_t*)f, NULL, 0);
         }
     }
+
     uv_loop_t* loop = jl_global_event_loop();
     struct uv_shutdown_queue queue = {NULL, NULL};
     uv_walk(loop, jl_uv_exitcleanup_walk, &queue);

--- a/src/julia.h
+++ b/src/julia.h
@@ -933,7 +933,7 @@ enum JL_RTLD_CONSTANT {
      JL_RTLD_LOCAL=0U, JL_RTLD_GLOBAL=1U, /* LOCAL=0 since it is the default */
      JL_RTLD_LAZY=2U, JL_RTLD_NOW=4U,
      /* Linux/glibc and MacOS X: */
-     JL_RTLD_NODELETE=8U, JL_RTLD_NOLOAD=16U, 
+     JL_RTLD_NODELETE=8U, JL_RTLD_NOLOAD=16U,
      /* Linux/glibc: */ JL_RTLD_DEEPBIND=32U,
      /* MacOS X 10.5+: */ JL_RTLD_FIRST=64U
 };
@@ -1058,6 +1058,13 @@ extern DLLEXPORT jl_gcframe_t *jl_pgcstack;
 
 #define JL_GC_POP() (jl_pgcstack = jl_pgcstack->prev)
 
+#ifdef GC_FINAL_STATS
+void jl_print_gc_stats(JL_STREAM *s);
+#define JL_PRINT_GC_STATS jl_print_gc_stats(JL_STDERR)
+#else
+#define JL_PRINT_GC_STATS
+#endif
+
 void jl_gc_init(void);
 void jl_gc_setmark(jl_value_t *v);
 DLLEXPORT void jl_gc_enable(void);
@@ -1086,6 +1093,7 @@ void *alloc_4w(void);
 #define jl_gc_preserve(v) ((void)(v))
 #define jl_gc_unpreserve()
 #define jl_gc_n_preserved_values() (0)
+#define JL_PRINT_GC_STATS
 
 static inline void *alloc_2w() { return allocobj(2*sizeof(void*)); }
 static inline void *alloc_3w() { return allocobj(3*sizeof(void*)); }

--- a/src/julia.h
+++ b/src/julia.h
@@ -1060,9 +1060,6 @@ extern DLLEXPORT jl_gcframe_t *jl_pgcstack;
 
 #ifdef GC_FINAL_STATS
 void jl_print_gc_stats(JL_STREAM *s);
-#define JL_PRINT_GC_STATS jl_print_gc_stats(JL_STDERR)
-#else
-#define JL_PRINT_GC_STATS
 #endif
 
 void jl_gc_init(void);
@@ -1093,7 +1090,6 @@ void *alloc_4w(void);
 #define jl_gc_preserve(v) ((void)(v))
 #define jl_gc_unpreserve()
 #define jl_gc_n_preserved_values() (0)
-#define JL_PRINT_GC_STATS
 
 static inline void *alloc_2w() { return allocobj(2*sizeof(void*)); }
 static inline void *alloc_3w() { return allocobj(3*sizeof(void*)); }


### PR DESCRIPTION
When `Julia` is complied with the macro `GC_FINAL_STATS` defined, the function `print_gc_stats` is registered as a process atexit hook by `atexit(3)`. But the function `uv_atexit_hook()` who closing `JL_STDERR` and `JL_STDOUT` runs before  `print_gc_stats`, and `print_gc_stats` tries to write data into the closed `JL_STDERR, JL_STDOUT`. This causes a Segmentation fault.

This commit move `print_gc_stats` into `uv_atexit_hook` to show the gc stats correctly.
