### PR TITLE
typo fix in manual

### DIFF
--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -200,7 +200,7 @@ Note the evaluation behavior of chained comparisons::
 
     v(x) = (println(x); x)
 
-    julia> v(1) > v(2) <= v(3)
+    julia> v(1) < v(2) <= v(3)
     2
     1
     3


### PR DESCRIPTION
When I try out the code snippet in a REPL I get this:
julia> v(1) > v(2) <= v(3)
2
1
false

so I suppose v(1) < v(2) was intended.
