### PR TITLE
Julia CONFIG dictionary (closes #2430)

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -21,15 +21,14 @@ have_color = false
 @windows_only default_color_input = text_colors[:normal]
 color_normal = text_colors[:normal]
 
-function answer_color()
-    c = symbol(get(ENV, "JULIA_ANSWER_COLOR", ""))
-    return get(text_colors, c, default_color_answer)
-end
-
-function input_color()
-    c = symbol(get(ENV, "JULIA_INPUT_COLOR", ""))
-    return get(text_colors, c, default_color_input)
-end
+CONFIG["answer_color", :default, :getter] =
+    (default_color_answer,
+    (key,value)->get(text_colors,symbol(get(ENV, "JULIA_ANSWER_COLOR", value)),value))
+CONFIG["input_color", :default, :getter] =
+    (default_color_input,
+    (key,value)->get(text_colors,symbol(get(ENV, "JULIA_INPUT_COLOR", value)),value))
+answer_color() = CONFIG["answer_color"]
+input_color() = CONFIG["input_color"]
 
 banner() = print(have_color ? banner_color : banner_plain)
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -157,6 +157,7 @@ export
 # Global constants and variables
     ARGS,
     C_NULL,
+    CONFIG,
     CPU_CORES,
     OS_NAME,
     ENDIAN_BOM,

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,7 +4,7 @@ include ../Make.inc
 TESTS = core numbers strings unicode corelib hashing remote iostring \
 arrayops linalg blas fft dct sparse bitarray random math functional bigint \
 sorting statistics spawn parallel suitesparse arpack bigfloat file zlib image \
-all git pkg
+all git pkg env
 
 $(TESTS) ::
 	$(QUIET_JULIA) $(JULIA_EXECUTABLE) ./runtests.jl $@

--- a/test/env.jl
+++ b/test/env.jl
@@ -1,0 +1,63 @@
+using Test
+
+let
+    ENV["JULIA ENV TEST VALUE"] = x = randstring(1000)
+    @test ENV["JULIA ENV TEST VALUE"] == x
+    @test_fails ENV["julia env test value"]
+    @test has(ENV,"JULIA ENV TEST VALUE")
+    @test delete!(ENV,"JULIA ENV TEST VALUE") == x
+    @test !has(ENV,"JULIA ENV TEST VALUE")
+    @test_fails ENV["JULIA ENV TEST VALUE"]
+    @test_fails delete!(ENV,"JULIA ENV TEST VALUE")
+    count = 0
+    for (k,v) in ENV
+        count += 1
+    end
+    @test count == length(ENV)
+    @test get(ENV, "JULIA ENV TEST VALUE", nothing) == nothing
+end
+
+let
+    key = "JULIA ENV TEST VALUE = 2"
+    try delete!(CONFIG,key,:entry) end
+    CONFIG[key] = x = (randstring(1000),100,randstring)
+    @test CONFIG[key] == x
+    getcnt = 0
+    setcnt = 0
+    deletedcnt = 0
+    expect = x
+    CONFIG[key, :default, :getter, :setter, :delete] = (42,
+            (k,v)->(@test(k==key); getcnt+=1; (v,true)),
+            (k,v,hadv,newv)->(@test(k==key && newv==expect); setcnt+=1; newv),
+            (k,v)->(@test(k==key); deletedcnt+=1; return true))
+    @test getcnt == 0
+    @test setcnt == 1
+    @test deletedcnt == 0
+    expect = 42
+    @test delete!(CONFIG,key) == (x,true)
+    @test getcnt == 1
+    @test setcnt == 2
+    @test deletedcnt == 1
+    @test CONFIG[key] == (42,true)
+    @test_fails delete!(CONFIG,key)
+    @test delete!(CONFIG,key,:default) == (42,true)
+    @test getcnt == 3
+    @test setcnt == 2
+    @test deletedcnt == 2
+    expect = 1
+    CONFIG[key, :default] = 1
+    expect = 2
+    CONFIG[key] = 2
+    @test getcnt == 3
+    @test setcnt == 4
+    @test deletedcnt == 2
+    @test delete!(CONFIG,key,:default) == (2,true)
+    @test getcnt == 4
+    @test setcnt == 4
+    @test deletedcnt == 2
+    @test CONFIG[key] == (2,true)
+    delete!(CONFIG,key,:getter,:setter,:delete,:value,:entry)
+    @test getcnt == 5
+    @test setcnt == 4
+    @test deletedcnt == 2
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ testnames = ["core", "numbers", "strings", "unicode", "corelib", "hashing",
              "dct", "sparse", "bitarray", "random", "math", "functional",
              "bigint", "sorting", "statistics", "spawn", "parallel",
              "suitesparse", "arpack", "bigfloat", "file", "zlib", "image",
-             "perf"]
+             "perf", "env"]
 
 if ARGS == ["all"]
     tests = testnames


### PR DESCRIPTION
I figure the only way to get Jeff to comment on #2430 was to submit the code for it as a pull request. So this creates a CONFIG dictionary for arbitrary configuration parameters.

And assign configuration entries simply:

``` julia
CONFIG["answer_color"] = "green"
```

The user can also see the current bindings:

``` julia
show(CONFIG)
```

```
Julia Configuration:
OUTPUT_STREAM = TTY(connected,0 bytes waiting)
answer_color = "\e[1m"
gfx/backend = "gtk"
input_color = "\e[1m"
```

The standard usage of this would be to provide default values for any configuration items in the dictionary:

``` julia
CONFIG["answer_color", :default] = "blue"
```

Deleting those values resets the value to the default:

``` julia
delete!(CONFIG,"answer_color") #CONFIG["answer_color"] is reset to default (blue)
```

Other parameters can be deleted too as follows:

```
delete!(CONFIG,"answer_color", :default, :value, :getter, :setter, :delete, :entry)
```

The CONFIG object supports getter, setter, and delete notification methods. Here's an example from Base that uses a getter method to create compatibility with the old environment variables and converting the input color through the text_colors mapping:

``` julia
CONFIG["answer_color", :default, :getter] =
    (default_color_answer,
    (key,value)->get(text_colors,symbol(get(ENV, "JULIA_ANSWER_COLOR", value)),value))
CONFIG["input_color", :default, :getter] =
    (default_color_input,
    (key,value)->get(text_colors,symbol(get(ENV, "JULIA_INPUT_COLOR", value)),value))
```

Here's another example from Base at using a setter method to react to changes in the value:

``` julia
CONFIG["OUTPUT_STREAM", :default, :setter] =
    (STDOUT,
    (key,value,hadvalue,newvalue::IO) -> global OUTPUT_STREAM = newvalue)
```

Note that the setter will be called whenever the value is changed, including after a value is deleted (and reverted to default) and right after installing the setter.
