### PR TITLE
Vectorize sinc/cosc functions

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -36,7 +36,7 @@ sinc(x::Number) = x==0 ? one(x)  : (pix=pi*x; oftype(x,sin(pix)/pix))
 sinc(x::Integer) = x==0 ? one(x) : zero(x)
 @vectorize_1arg Number sinc
 cosc(x::Number) = x==0 ? zero(x) : (pix=pi*x; oftype(x,cos(pix)/x-sin(pix)/(pix*x)))
-cosc(x::Integer) = x==0 ? zero(x) : (pix=pi*x; oftype(float(x),cos(pix)/x-sin(pix)/(pix*x)))
+cosc(x::Integer) = x==0 ? zero(float(x)) : (pix=pi*x; oftype(float(x),cos(pix)/x-sin(pix)/(pix*x)))
 @vectorize_1arg Number cosc
 
 radians2degrees(z::Real) = oftype(z, (180/pi) * z)

--- a/base/math.jl
+++ b/base/math.jl
@@ -33,7 +33,11 @@ clamp{T<:Real}(x::AbstractArray{T}, lo::Real, hi::Real) =
     reshape([clamp(xx, lo, hi) for xx in x], size(x))
 
 sinc(x::Number) = x==0 ? one(x)  : (pix=pi*x; oftype(x,sin(pix)/pix))
+sinc(x::Integer) = x==0 ? one(x) : zero(x)
+@vectorize_1arg Number sinc
 cosc(x::Number) = x==0 ? zero(x) : (pix=pi*x; oftype(x,cos(pix)/x-sin(pix)/(pix*x)))
+cosc(x::Integer) = x==0 ? zero(x) : (pix=pi*x; oftype(float(x),cos(pix)/x-sin(pix)/(pix*x)))
+@vectorize_1arg Number cosc
 
 radians2degrees(z::Real) = oftype(z, (180/pi) * z)
 degrees2radians(z::Real) = oftype(z, (pi/180) * z)

--- a/base/math.jl
+++ b/base/math.jl
@@ -34,9 +34,11 @@ clamp{T<:Real}(x::AbstractArray{T}, lo::Real, hi::Real) =
 
 sinc(x::Number) = x==0 ? one(x)  : (pix=pi*x; oftype(x,sin(pix)/pix))
 sinc(x::Integer) = x==0 ? one(x) : zero(x)
+sinc{T<:Integer}(x::Complex{T}) = sinc(convert(Complex{FloatingPoint},x))
 @vectorize_1arg Number sinc
 cosc(x::Number) = x==0 ? zero(x) : (pix=pi*x; oftype(x,cos(pix)/x-sin(pix)/(pix*x)))
-cosc(x::Integer) = x==0 ? zero(float(x)) : (pix=pi*x; oftype(float(x),cos(pix)/x-sin(pix)/(pix*x)))
+cosc(x::Integer) = cosc(convert(FloatingPoint,x))
+cosc{T<:Integer}(x::Complex{T}) = cosc(convert(Complex{FloatingPoint},x))
 @vectorize_1arg Number cosc
 
 radians2degrees(z::Real) = oftype(z, (180/pi) * z)

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -1987,13 +1987,14 @@
 
 ("Mathematical Functions","Base","sinc","sinc(x)
 
-   Compute \\sin(\\pi x) / x
+   Compute \\sin(\\pi x) / (\\pi x) if x \\neq 0, and 1 if x = 0.
 
 "),
 
 ("Mathematical Functions","Base","cosc","cosc(x)
 
-   Compute \\cos(\\pi x) / x
+   Compute \\cos(\\pi x) / x - \\sin(\\pi x) / (\\pi x^2) if x \\neq
+   0, and 0 if x = 0. This is the derivative of \"sinc(x)\".
 
 "),
 
@@ -4913,10 +4914,10 @@
 
 "),
 
-("Linear Algebra","","qr","qr(A) -> Q, R
+("Linear Algebra","","qr","qr(A[, thin]) -> Q, R
 
    Compute the QR factorization of \"A\" such that \"A = Q*R\". Also
-   see \"qrfact\".
+   see \"qrfact\". The default is to compute a thin factorization.
 
 "),
 
@@ -4940,10 +4941,11 @@
 
 "),
 
-("Linear Algebra","","qrp","qrp(A) -> Q, R, P
+("Linear Algebra","","qrp","qrp(A[, thin]) -> Q, R, P
 
    Compute the QR factorization of \"A\" with pivoting, such that
-   \"A*P = Q*R\", Also see \"qrpfact\".
+   \"A*P = Q*R\", Also see \"qrpfact\". The default is to compute a
+   thin factorization.
 
 "),
 
@@ -4986,6 +4988,28 @@
 ("Linear Algebra","","eigvals","eigvals(A)
 
    Returns the eigenvalues of \"A\".
+
+"),
+
+("Linear Algebra","","eigmax","eigmax(A)
+
+   Returns the largest eigenvalue of \"A\".
+
+"),
+
+("Linear Algebra","","eigmin","eigmin(A)
+
+   Returns the smallest eigenvalue of \"A\".
+
+"),
+
+("Linear Algebra","","eigvecs","eigvecs(A[, eigvals])
+
+   Returns the eigenvectors of \"A\".
+
+   For SymTridiagonal matrices, if the optional vector of eigenvalues
+   \"eigvals\" is specified, returns the specific corresponding
+   eigenvectors.
 
 "),
 
@@ -5032,7 +5056,7 @@
    \"F[:V]\" and \"F[:Vt]\", such that \"A = U*diagm(S)*Vt\". If
    \"thin\" is \"true\", an economy mode decomposition is returned.
    The algorithm produces \"Vt\" and hence \"Vt\" is more efficient to
-   extract than \"V\".
+   extract than \"V\". The default is to produce a thin decomposition.
 
 "),
 
@@ -5040,7 +5064,8 @@
 
    \"svdfact!\" is the same as \"svdfact\" but saves space by
    overwriting the input A, instead of creating a copy. If \"thin\" is
-   \"true\", an economy mode decomposition is returned.
+   \"true\", an economy mode decomposition is returned. The default is
+   to produce a thin decomposition.
 
 "),
 
@@ -5130,8 +5155,9 @@
 
 ("Linear Algebra","","Bidiagonal","Bidiagonal(dv, ev, isupper)
 
-   Construct an upper (isupper=true) or lower (isupper=false) bidiagonal matrix
-   from the given diagonal (dv) and off-diagonal (ev) vectors.
+   Constructs an upper (isupper=true) or lower (isupper=false)
+   bidiagonal matrix using the given diagonal (dv) and off-diagonal
+   (ev) vectors
 
 "),
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1293,11 +1293,12 @@ Mathematical Functions
 
 .. function:: sinc(x)
 
-   Compute :math:`\sin(\pi x) / x`
+   Compute :math:`\sin(\pi x) / (\pi x)` if :math:`x \neq 0`, and :math:`1` if :math:`x = 0`.
 
 .. function:: cosc(x)
 
-   Compute :math:`\cos(\pi x) / x`
+   Compute :math:`\cos(\pi x) / x - \sin(\pi x) / (\pi x^2)` if :math:`x \neq 0`, and :math:`0`
+   if :math:`x = 0`. This is the derivative of ``sinc(x)``.
 
 .. function:: degrees2radians(x)
 


### PR DESCRIPTION
Vectorize sinc/cosc function, extends definition to integers. Fix mistake in docs.
