### PR TITLE
RFC: access to sigatomic_begin/end in Julia for non-interrupt-safe C calls

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1139,6 +1139,8 @@ export
     unsafe_assign,
     unsafe_pointer_to_objref,
     pointer_from_objref,
+    disable_sigint,
+    reenable_sigint,
 
 # Macros
     @b_str,

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -166,3 +166,15 @@ DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, char *fld)
     }
     return v;
 }
+
+DLLEXPORT void jl_sigatomic_begin(void)
+{
+    JL_SIGATOMIC_BEGIN();
+}
+
+DLLEXPORT void jl_sigatomic_end(void)
+{
+    if (jl_defer_signal == 0)
+        jl_error("sigatomic_end called in non-sigatomic region");
+    JL_SIGATOMIC_END();
+}

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -120,6 +120,8 @@
     jl_get_field;
     jl_call1;
     jl_call2;
+    jl_sigatomic_begin;
+    jl_sigatomic_end;
     jl_init;
     jl_ascii_string_type;
     jl_utf8_string_type;


### PR DESCRIPTION
See also issue #2622.  This adds Julia-callable `sigatomic_begin`/`end` functions to temporarily defer `SIGINT` (ctrl-c) handling, which is essential for long-running C calls that are not interrupt safe.  These are wrapped in a higher-level `disable_sigint() do ... end` construct.  Moreover, it also allows one to re-enable `SIGINT` handling _within_ a disabled region, e.g. for Julia callbacks that can catch the exception.

(This will enable my PyCall module, for example, to defer interrupts during Python calls, which are [not interrupt safe](https://github.com/stevengj/PyCall.jl/issues/15).  But if the Python has a Julia callback, that Julia callback can still catch `InterruptException`s, convert them to Python `KeyboardInterrupt` exceptions which are propagated back through Python and returned to the top-level Julia caller, which converts it back to an `InterruptException`.)

As mentioned in #2622, in the long run we will almost certainly want to make sigatomic the default for _all_ `ccall` invocations (since C code cannot generally be assumed to be interrupt-safe), and if this is done directly in the LLVM code generation it can be much more efficient than calling `disable_sigint` from Julia.  However, even when that is implemented, we will _still_ want "manual" access to `sigatomic_begin/end` in Julia in order to re-enable interrupts in callbacks as I mentioned above.
