### PR TITLE
Mac Julia launcher script assumes user's shell is bash

### DIFF
--- a/contrib/mac/app/script
+++ b/contrib/mac/app/script
@@ -27,9 +27,9 @@ osascript 2>&1>/dev/null <<EOF
   tell application "Terminal" 
     activate
     if ProcessList contains "Terminal" then
-      do script ("exec bash -c \"PATH=${ROOT}/julia/bin:${PATH} FONTCONFIG_PATH=${ROOT}/julia/etc/fonts PKG_CONFIG_PATH=${ROOT}/julia/lib/pkgconfig GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'\"")
+      do script ("exec bash -c \"PATH=${ROOT}/julia/bin:${PATH} GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'\"")
     else
-      do script ("exec bash -c \"PATH=${ROOT}/julia/bin:${PATH} FONTCONFIG_PATH=${ROOT}/julia/etc/fonts PKG_CONFIG_PATH=${ROOT}/julia/lib/pkgconfig GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'\"") in front window
+      do script ("exec bash -c \"PATH=${ROOT}/julia/bin:${PATH} GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'\"") in front window
     end if
   end tell
 EOF

--- a/contrib/mac/app/script
+++ b/contrib/mac/app/script
@@ -27,9 +27,9 @@ osascript 2>&1>/dev/null <<EOF
   tell application "Terminal" 
     activate
     if ProcessList contains "Terminal" then
-      do script ("PATH=${ROOT}/julia/bin:${PATH} GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'")
+      do script ("exec bash -c \"PATH=${ROOT}/julia/bin:${PATH} FONTCONFIG_PATH=${ROOT}/julia/etc/fonts PKG_CONFIG_PATH=${ROOT}/julia/lib/pkgconfig GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'\"")
     else
-      do script ("PATH=${ROOT}/julia/bin:${PATH} GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'") in front window
+      do script ("exec bash -c \"PATH=${ROOT}/julia/bin:${PATH} FONTCONFIG_PATH=${ROOT}/julia/etc/fonts PKG_CONFIG_PATH=${ROOT}/julia/lib/pkgconfig GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'\"") in front window
     end if
   end tell
 EOF


### PR DESCRIPTION
The Mac Julia launcher script assumes the user's shell is bash.

To reproduce the problem,
(1) use chsh to change your shell to /bin/tcsh (or, to fish shell, as I use! http://ridiculousfish.com/shell/).
(2) Double click Julia app

-> Julia won't run 
