### PR TITLE
types as C-structs

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -51,7 +51,7 @@ unsafe_store!{T}(p::Ptr{T}, x) = pointerset(p, convert(T,x), 1)
 # convert a raw Ptr to an object reference, and vice-versa
 unsafe_pointer_to_objref(x::Ptr) = ccall(:jl_value_ptr, Any, (Ptr{Void},), x)
 pointer_from_objref(x::ANY) = ccall(:jl_value_ptr, Ptr{Void}, (Any,), x)
-data_pointer_from_objref(x::ANY) = pointer_from_objref(x)::Ptr{Void}+Core.sizeof(Int)
+data_pointer_from_objref(x::ANY) = pointer_from_objref(x)::Ptr{Void}
 
 eltype{T}(::Type{Ptr{T}}) = T
 

--- a/doc/devdocs/eval.rst
+++ b/doc/devdocs/eval.rst
@@ -1,0 +1,195 @@
+******************
+Eval of Julia code
+******************
+
+One of the hardest parts about learning how the Julia Language runs code is learning
+how all of the pieces work together to execute a block of code.
+
+Each chunk of code typically makes a trip through many esoteric acronyms such as (in no particular order),
+`flisp`, `AST`, `C++`, `LLVM`, `eval`, `typeinf`, `macroexpand`, `sysimg` (or `system image`), `bootstrapping`,
+`compile`, `parse`, `execute`, `JIT`, `interpret`, `box`, `unbox`, `intrinsic function`, `primitive function`
+before turning into the desired result (hopefully).
+
+Julia Execution
+---------------
+
+The 10,000 foot view of the whole process is as follows:
+
+.. sidebar:: Definitions
+
+   REPL
+     REPL stands for Read-Eval-Print Loop.
+     It's just what we call the command line environment for short.
+
+   AST
+     Abstract Syntax Tree
+     The AST is the digital representation of the code structure.
+     In this form the code has been tokenized for meaning
+     so that it is more suitable for manipulation and execution.
+
+1. The user starts `julia`
+2. The C function `main()` from `ui/repl.c` gets called.
+   This funcion processes the command line arguments, filling in the `jl_compileropts` struct and setting the variable :code:`ARGS`.
+   It then initializes Julia (by calling `julia_init in task.c <https://github.com/JuliaLang/julia/blob/master/src/task.c>`_,
+   which may load a previously compiled sysimg_).
+   Finally, it passes off control to Julia by calling `Base._start() <https://github.com/JuliaLang/julia/blob/master/base/client.jl>`_.
+#. When `_start()` takes over control, the subsequent sequence of commands depends on the command line arguments given.
+   For example, if a filename was supplied, it will proceed to execute that file. Otherwise, it will start an interactive REPL.
+#. Skipping the details about how the REPL interacts with the user,
+   let's just say the program ends up with a block of code that it wants to run.
+#. If the block of code to run is in a file, `jl_load(char *filename) <https://github.com/JuliaLang/julia/blob/master/src/toplevel.c>`_
+   gets invoked to load the file and parse_ it. Each fragment of code is then passed to `eval` to execute.
+#. Each fragment of code (or AST), is handed off to `eval` to turn into results.
+#. `eval` takes each code fragment and tries to run it in `jl_toplevel_eval_flex() <https://github.com/JuliaLang/julia/blob/master/src/toplevel.c>`_.
+#. `jl_toplevel_eval_flex` decides whether the code is a "toplevel" action (such as `using` or `module`), which would be invalid inside a function.
+   If so, it passes off the code to the toplevel interpretor.
+#. `jl_toplevel_eval_flex` then expands_ the code to eliminate any macros and to "lower" the AST to make it simpler to execute.
+#. `jl_toplevel_eval_flex` then uses some simple heuristics to decide whether to JIT compiler the AST or to interprete it directly.
+#. The bulk of the work to interpret code is handled by `eval in interpreter.c <https://github.com/JuliaLang/julia/blob/master/src/interpreter.c>`_.
+#. If instead, the code is compiled, the bulk of the work is handled by `codegen.cpp`.
+   Whenever a Julia function is called for the first time with a given set of argument types, `type inference`_ will be run on that function.
+   This information is used by the codegen_ step to generate faster code.
+#. Eventually, the user quits the REPL, or the end of the program is reached, and the `_start()` method returns.
+#. Just before exiting, `main()` calls `jl_atexit_hook() <https://github.com/JuliaLang/julia/blob/master/src/init.c>`_.
+   This calls `Base._atexit()` (which calls any functions registered to `atexit` inside Julia).
+   Then it calls `jl_gc_run_all_finalizers() <https://github.com/JuliaLang/julia/blob/master/src/gc.c>`_.
+   Finally, it gracefully cleans up all libuv handles and waits for them to flush and close.
+
+.. _parse:
+
+Parsing
+-------
+
+The Julia parser is a small lisp program written in femtolisp,
+the source-code for which is distributed inside Julia in `src/flisp <https://github.com/JuliaLang/julia/tree/master/src/flisp>`_.
+
+The interface functions for this are primarily defined in `jlfrontend.scm <https://github.com/JuliaLang/julia/blob/master/src/jlfrontend.scm>`_.
+The code in `ast.c <https://github.com/JuliaLang/julia/blob/master/src/ast.c>`_ handles this handoff on the Julia side.
+
+The other relevant files at this stage are `julia-parser.scm <https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm>`_,
+which handles tokenizing Julia code and turning it into an AST,
+and `julia-syntax.scm <https://github.com/JuliaLang/julia/blob/master/src/julia-syntax.scm>`_,
+which handles transforming complex AST representations into simpler, "lowered" AST representations which are more suitible for analysis and execution.
+
+.. _expands:
+
+Macro Expansion
+---------------
+
+When the eval encounters a macro, it expands that AST node before attempting to evalutate the expression.
+Macro expansion involves a handoff from eval (in Julia), to the parser function `jl-macroexpand` (written in `flisp`)
+to the Julia macro itself (written in - what else - `Julia`) via `fl_invoke_julia_macro`, and back.
+
+Typically, macro expansion is invoked as a first step during a call to `expand`/`jl_expand`,
+although it can also be invoked directly by a call to `macroexpand`/`jl_macroexpand`.
+
+.. _type inference:
+
+Type Inference
+--------------
+
+Type inference is implemented in Julia by `typeinf() in inference.jl <https://github.com/JuliaLang/julia/blob/master/base/inference.jl>`_.
+Type inference is the process of examing a Julia function and determining bounds for the types of each of its variables,
+as well as bounds on the type of the return value from the function.
+This enables may future optimizations, such as unboxing of known immutable values,
+and compile-time hoisting of various run-time operations such as computing field offsets and function pointers.
+Type inference may also include other steps such as constant propagation and inlining.
+
+.. _codegen:
+
+JIT Code Generation
+-------------------
+
+.. sidebar:: More Definitions
+
+    JIT
+      Just-In-Time Compilation
+      The process of generating native-machine code into memory right when it is needed.
+
+    LLVM
+      Low-Level Virtual Machine (a compiler)
+      The Julia JIT compiler is a program/library called libLLVM.
+      Codegen in Julia refers both to the process of taking a Julia AST and turning it into LLVM instructions,
+      and the process of LLVM optimizing that and turning it into native assembly instructions.
+
+    C++
+      The programming language that LLVM is implemented in,
+      which means that codegen is also implemented in this language.
+      The rest of Julia's library is implemented in C,
+      in part because it's smaller feature set makes it more usable as a cross-language interface layer.
+
+    box
+      This term is used to describe the process of taking a value and allocating a wrapper around the data
+      that is tracked by the garbage collector (gc) and is tagged with the object's type.
+
+    unbox
+      The reverse of boxing a value. This operation enables more efficient manipulation of data
+      when the type of that data is fully known at compile-time (through type inference).
+
+    generic function
+      A Julia function composed of multiple "methods" that are selected for dynamic dispatch based on the argument type-signature
+
+    anonymous function or "method"
+      A Julia function without a name and without type-dispatch capabilities
+
+    primitive function
+      A function implemented in C but exposed in Julia as a named function "method"
+      (albeit without generic function dispatch capabilities, similar to a anonymous function)
+
+    intrinsic function
+      A low-level operation exposed as a function in Julia.
+      These pseudo-functions implement operations on raw bits such as add and sign extend
+      that cannot be expressed directly in any other way.
+      Since the operate on bits directly, they must be compiled into a function
+      and surrounded by a call to `Core.Intrinsics.box(T, ...)` to reassign type information to the value.
+
+Codegen is the process of turning a Julia AST into native machine code.
+
+The JIT environment is initialized by an early call to `jl_init_codegen in codegen.cpp <https://github.com/JuliaLang/julia/blob/master/src/codegen.cpp>`_.
+
+On demand, a Julia method is converted into a native function by the function `emit_function(jl_lambda_info_t*)`.
+(note, when using the MCJIT (in LLVM v3.4+), each function must be JIT into a new module.)
+This function recursively calls `emit_expr` until the entire function has been emitted.
+
+Much of the remaining bulk of this file is devoted to various manual optimizations of specific code patterns.
+For example, `emit_known_call` knows how to inline many of the primitive functions
+(defined in `builtins.c <https://github.com/JuliaLang/julia/blob/master/src/builtins.c>`_) for various combinations of argument types.
+
+Other parts of codegen are handled by various helper files:
+
+`debuginfo.cpp <https://github.com/JuliaLang/julia/blob/master/src/debuginfo.cpp>`_
+  Handles backtraces for JIT functions
+
+`ccall.cpp <https://github.com/JuliaLang/julia/blob/master/src/ccall.cpp>`_
+  Handles the ccall and llvmcall FFI, along with various `abi_*.cpp` files
+
+`intrinsics.cpp <https://github.com/JuliaLang/julia/blob/master/src/intrinsics.cpp>`_
+  Handles the emmission of various low-level intrinsic functions
+
+.. _sysimg:
+
+System Image
+------------
+
+.. sidebar:: Bootstrapping
+
+    The process of creating a new system image is called "bootstrapping".
+
+    The etymology of this word comes from the phrase "pulling one's self up by the bootstraps",
+    and refers to the idea of starting from a very limited set of available functions and definitions
+    and ending with the creation of a full-featured environment.
+
+The system image is a precompiled archive of a set of Julia files.
+The `sys.ji` file distributed with Julia is one such system image,
+generated by executing the file `sysimg.jl <https://github.com/JuliaLang/julia/blob/master/base/sysimg.jl>`_,
+and serializing the resulting environment (including Types, Functions, Modules, and all other defined values)
+into a file. Therefore, it contains a frozen version of the "Main", "Core", and "Base" modules (and whatever else was in the environment at the end of bootstrapping).
+This serializer/deserializer is implemented by `jl_save_system_image/jl_restore_system_image in dump.c <https://github.com/JuliaLang/julia/blob/master/src/dump.c>`
+
+If there is no sysimg file (:code:`jl_compileropts.image_file == NULL`),
+this also implies that `--build` was given on the command line,
+so the final result should be a new sysimg file.
+During Julia initialization, minimal "Core" and "Main" modules are created.
+Then a file named "boot.jl" is evaluated from the current directory.
+Julia then evaluates any file given as a command line argument until it reaches the end.
+Finally, it saves the resulting environment to a "sysimg" file for use as a starting point for a future Julia run.

--- a/doc/devdocs/init.rst
+++ b/doc/devdocs/init.rst
@@ -1,5 +1,5 @@
 ***********************************
-Initialisation of the Julia runtime
+Initialization of the Julia runtime
 ***********************************
 
 How does the Julia runtime execute :code:`julia -e 'println("Hello World!")'` ?

--- a/doc/devdocs/julia.rst
+++ b/doc/devdocs/julia.rst
@@ -10,6 +10,7 @@
    :maxdepth: 1
 
    init
+   eval
    object
    cartesian
    meta

--- a/doc/devdocs/object.rst
+++ b/doc/devdocs/object.rst
@@ -5,84 +5,170 @@ Memory layout of Julia Objects
 Object layout (jl_value_t)
 --------------------------
 
-.. sidebar:: `special case. <https://github.com/JuliaLang/julia/blob/master/src/jltypes.c#L2897>`_
+The :code:`jl_value_t` struct is the name for a block of memory owned by the Julia Garbage Collector,
+representing the data associated with a Julia object in memory.
+Absent any type information, it is simply an opaque pointer::
 
-    :code:`jl_tuple_type->type = jl_tuple_type`
+    typedef struct jl_value_t* jl_pvalue_t;
 
-The :code:`jl_value_t` struct defines the minimal header for a Julia
-object in memory.
-The :code:`type` field points to a
-`jl_datatype_t <http://github.com/JuliaLang/julia/blob/master/src/julia.h#L204>`_ object,
-(the jl_typeof() macro should be used to query it)::
-
-    typedef struct _jl_value_t {
-        struct _jl_value_t *type;
-    } jl_value_t;
-
-    #define jl_typeof(v) (((jl_value_t*)(v))->type)
-
-
-The layout of the rest of the object is dependant on its type.
-
-e.g. a :func:`Base.tuple` object has an array of pointers to the
-objects contained by the tuple::
+Each :code:`jl_value_t` struct is contained in a :code:`jl_typetag_t` struct that contains metadata information
+about the Julia object, such as its type and garbage-collector (gc) reachability::
 
     typedef struct {
-        struct _jl_value_t *type;
-        size_t length;
-        jl_value_t *data[];
-    } jl_tuple_t;
+        opaque metadata;
+        jl_value_t value;
+    } jl_typetag_t;
 
-e.g. a "boxed" uint16_t (created by :func:`jl_box_uint16`) is stored as
-follows (assuming machine is 64-bit)::
+The type of any julia object is an instance of a leaf :func:`jl_datatype_t` object.
+The :func:`jl_typeof` function can be used to query for it::
+
+    jl_value_t *jl_typeof(jl_value_t *v);
+
+The layout of the object is dependant on its type.
+Reflection methods can be used to inspect that layout.
+A field can be accessed by calling one of the get-field methods::
+
+    jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i);
+    jl_value_t *jl_get_field(jl_value_t *o, char *fld);
+
+If the field types are known, a priori, to be all pointers,
+the values can also be extracted directly as an array access::
+
+    jl_value_t *v = value->fieldptr[n];
+
+As an example, a "boxed" uint16_t is stored as follows::
 
     struct {
-        struct _jl_value_t *type; -- 8 bytes
-        uint16_t data;            -- 2 bytes
-                                  -- 6 bytes padding
+        oqaque metadata;
+        struct {
+          uint16_t data;            -- 2 bytes
+        } jl_value_t;
     };
 
-Structs for the built-in types are `defined in julia.h <http://github.com/JuliaLang/julia/blob/master/src/julia.h#L69>`_. The corresponding global jl_datatype_t objects are created by `jl_init_types() <http://github.com/JuliaLang/julia/blob/master/src/jltypes.c#L2887>`_.
+This object is created by :func:`jl_box_uint16`.
+Note that the ``jl_value_t*`` pointer references the data portion,
+not the metadata at the top of the struct.
 
+A value may be stored "unboxed" in many circumstances
+(just the data, without the metadata, and possibly not even stored but just kept in registers),
+so it is unsafe to assume that a the address of a box is a unique identifier.
+The "egal" test (corresponding to the `is` function in Julia),
+should instead be used to compare two unknown objects for equivalence::
 
-Garbage collector mark bit
---------------------------
+    int jl_egal(jl_value_t *a, jl_value_t *b);
 
-The garbage collector uses the low bit of the :code:`jl_value_t.type`
-pointer as a flag to mark reachable objects (see :code:`gcval_t`).
-During each mark/sweep cycle, the gc sets the mark bit of each
-reachable object, deallocates objects that are not marked, then
-clears the mark bits. While the mark/sweep is in progress the
-:code:`jl_value_t.type` pointer is altered by the mark bit. The gc
-uses the :func:`gc_typeof` macro to retrieve the original type
-pointer::
+This optimization should be relatively transparant to the API,
+since the object will be "boxed" on-demand, whenever a :code:`jl_value_t*` is needed.
 
-    #define gc_typeof(v) ((jl_value_t*)(((uptrint_t)jl_typeof(v))&~1UL))
+Note that modification of a jl_value_t* in memory is permitted only if the object is mutable.
+Otherwise, modification of the value may corrupt the program and the result will be undefined.
+The mutability property of a value can be queried for with::
 
+    int jl_is_mutable(jl_value_t *v);
+
+If the object being stored is a :code:`jl_value_t*`, the Julia garbage-collector must be notified also::
+
+    void gc_wb(jl_value_t *parent, jl_value_t *ptr);
+
+However, the embedding section of the manual is also required reading at this point,
+for covering other details of boxing and unboxing various types,
+and understanding the gc-interactions.
+
+Mirror structs for some of the built-in types are `defined in julia.h <http://github.com/JuliaLang/julia/blob/master/src/julia.h>`_.
+The corresponding global ``jl_datatype_t`` objects are created by `jl_init_types in jltypes.c <http://github.com/JuliaLang/julia/blob/master/src/jltypes.c>`_.
+
+Garbage collector mark bits
+---------------------------
+
+The garbage collector uses several bits from the metadata portion of the :code:`jl_typetag_t`
+to track each object in the system.
+Further details about this algorithm can be found in the comments of the `garbage-collector implementation in gc.c
+<http://github.com/JuliaLang/julia/blob/master/src/gc.c>`_.
 
 Object allocation
 -----------------
 
-Storage for new objects is allocated by :func:`newobj` in julia_internal.h::
+Most new objects are allocated by :func:`jl_new_structv`::
 
-    STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
-    {
-        jl_value_t *jv = (jl_value_t*)allocobj((1+nfields) * sizeof(void*));
-        jv->type = type;
-        return jv;
-    }
+    jl_value_t *jl_new_struct(jl_datatype_t *type, ...);
+    jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args, uint32_t na);
+
+Although, `isbits` objects can be also constructed directly from memory::
+
+    jl_value_t *jl_new_bits(jl_value_t *bt, void *data)
+
+And some objects have special constructors that must be used instead of the above functions:
+
+Types::
+
+    jl_datatype_t *jl_apply_type(jl_datatype_t *tc, jl_tuple_t *params);
+    jl_datatype_t *jl_apply_array_type(jl_datatype_t *type, size_t dim);
+    jl_uniontype_t *jl_new_uniontype(jl_tuple_t *types);
+
+While these are the most commonly used options, there are more low-level constructors too,
+which you can find declared in `julia.h <http://github.com/JuliaLang/julia/blob/master/src/julia.h>`_.
+These are used in :func:`jl_init_types` to create the initial types needed to bootstrap the creation of the Julia system image.
+
+Tuples::
+
+    jl_tuple_t *jl_tuple(size_t n, ...);
+    jl_tuple_t *jl_tuplev(size_t n, jl_value_t **v);
+    jl_tuple_t *jl_alloc_tuple(size_t n);
+
+The representation of tuples is highly unique in the Julia object representation ecosystem.
+In some cases, a :func:`Base.tuple` object may be an array of pointers to the
+objects contained by the tuple equivalent to::
+
+    typedef struct {
+        size_t length;
+        jl_value_t *data[length];
+    } jl_tuple_t;
+
+However, in other cases, the tuple may be converted to an anonymous :func:`isbits` type
+and stored unboxed, or it may not stored at all (if it is not being used in a generic context as a :code:`jl_value_t*`).
+
+Symbols::
+
+    jl_sym_t *jl_symbol(const char *str);
+
+Functions and LambdaStaticData::
+
+    jl_function_t *jl_new_generic_function(jl_sym_t *name);
+    jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_tuple_t *sparams);
+    jl_function_t *jl_new_closure(jl_fptr_t proc, jl_value_t *env, jl_lambda_info_t *li);
+
+Arrays::
+
+    jl_array_t *jl_new_array(jl_value_t *atype, jl_tuple_t *dims);
+    jl_array_t *jl_new_arrayv(jl_value_t *atype, ...);
+    jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr);
+    jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc);
+    jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr, size_t nc, size_t z);
+    jl_array_t *jl_alloc_cell_1d(size_t n);
+
+Note that many of these have alternative allocation functions for various special-purposes.
+The list here reflects the more common usages, but a more complete list can be found by reading the `julia.h header file
+<http://github.com/JuliaLang/julia/blob/master/src/julia.h>`_.
+
+Internal to Julia, storage is typically allocated by :func:`newstruct` (or :func:`newobj` for the special types)::
+
+    jl_value_t *newstruct(jl_value_t *type);
+    jl_value_t *newobj(jl_value_t *type, size_t nfields);
+
+And at the lowest level, memory is getting allocated by a call to the garbage collector (in gc.c),
+then tagged with its type::
+
+    jl_value_t *allocobj(size_t nbytes);
+    void jl_set_typeof(jl_value_t *v, jl_datatype_t *type);
 
 .. sidebar:: :ref:`man-singleton-types`
 
-
     Singleton types have only one instance and no data fields.
-    Singleton instances use only 8 bytes.
+    Singleton instances have a size of 0 bytes,
+    and consist only of their metadata.
     e.g. :data:`nothing::Void`.
 
     See :ref:`man-singleton-types` and :ref:`man-nothing`
 
-Note that all objects are allocated in multiples of 8 bytes, so the
-smallest object size is 16 bytes (8 byte type pointer + 8 bytes
-data).  :func:`allocobj` in gc.c allocates memory for new objects.
-Memory is allocated from a pool for objects up to 2048 bytes, or
-by malloc() otherwise.
+Note that all objects are allocated in multiples of 4 bytes and aligned to the platform pointer size.
+Memory is allocated from a pool for smaller objects, or directly with malloc() for large objects.

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -3055,6 +3055,13 @@ Any[
 
 "),
 
+("Base","reenable_sigint","reenable_sigint(f::Function)
+
+   Re-enable Ctrl-C handler during execution of a function.
+   Temporarily reverses the effect of \"disable_sigint\".
+
+"),
+
 ("Base","errno","errno([code])
 
    Get the value of the C library's \"errno\". If an argument is
@@ -3082,32 +3089,24 @@ Any[
 
 ("Base","Ptr{T}","Ptr{T}
 
-   A simple pointer to an arbitrary memory location. The type objects
-   expected at the memory location is represented by the type
-   parameter. However, no guarantee is made or implied that the memory
-   is actually valid, or that it actually represents the data of the
-   specified type.
-
-   \"C_NULL\" represents a generic, invalid or \"NULL\" pointer.
+   A memory address referring to data of type \"T\". However, there is
+   no guarantee that the memory is actually valid, or that it actually
+   represents data of the specified type.
 
 "),
 
 ("Base","Ref{T}","Ref{T}
 
-   Effectively, this represents and creates a managed pointer. The
-   type of objects it can contain is specified by the type parameter.
-   This type is guaranteed to point to valid, Julia-allocated memory
-   of the correct type (per the type parameter).
+   An object that safely references data of type \"T\". This type is
+   guaranteed to point to valid, Julia-allocated memory of the correct
+   type. The underlying data is protected from freeing by the garbage
+   collector as long as the \"Ref\" itself is referenced.
 
-   When passed to a *ccall* argument (either as a *Ptr* or *Ref*
-   type), the *Ref* object will be implicitly converted to a pointer
-   to the data region of that type.
+   When passed as a \"ccall\" argument (either as a \"Ptr\" or \"Ref\"
+   type), a \"Ref\" object will be converted to a native pointer to
+   the data it references.
 
-   The \"Ref\" type is useful for creating garbage-collector safe
-   pointers and returning values from a function (esp. a c-function),
-   for example.
-
-   There is no generic invalid or \"NULL\" Ref object.
+   There is no invalid (NULL) \"Ref\".
 
 "),
 
@@ -5299,9 +5298,10 @@ Millisecond(v)
 
 "),
 
-("Base","cp","cp(src::AbstractString, dst::AbstractString)
+("Base","cp","cp(src::AbstractString, dst::AbstractString; recursive=false)
 
-   Copy a file from *src* to *dest*.
+   Copy a file from *src* to *dest*. Passing \"recursive=true\" will
+   enable recursive copying of directories.
 
 "),
 
@@ -10649,7 +10649,9 @@ popdisplay(d::Display)
 ("Base","significand","significand(x)
 
    Extract the significand(s) (a.k.a. mantissa), in binary
-   representation, of a floating-point number or array.
+   representation, of a floating-point number or array. If \"x\" is a
+   non-zero finite number, than the result will be a number of the
+   same type on the interval [1,2). Otherwise \"x\" is returned.
 
       julia> significand(15.2)/15.2
       0.125
@@ -11333,11 +11335,12 @@ popdisplay(d::Display)
    \"max_parallel\" : specifies the maximum number of workers
    connected to in parallel at a host. Defaults to 10.
 
-   \"dir\" :  specifies the location of the julia binaries on the
-   worker nodes. Defaults to JULIA_HOME.
+   \"dir\" :  specifies the working directory on the workers. Defaults
+   to the host's current directory (as found by *pwd()*)
 
    \"exename\" :  name of the julia executable. Defaults to
-   \"./julia\" or \"./julia-debug\" as the case may be.
+   \"\$JULIA_HOME/julia\" or \"\$JULIA_HOME/julia-debug\" as the case
+   may be.
 
    \"exeflags\" :  additional flags passed to the worker processes.
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -160,10 +160,7 @@ static jl_value_t *jl_new_bits_internal(jl_value_t *dt, void *data, size_t *len)
     if (bt == jl_int32_type)   return jl_box_int32(*(int32_t*)data);
     if (bt == jl_float64_type) return jl_box_float64(*(double*)data);
 
-    jl_value_t *v =
-        (jl_value_t*)allocobj((NWORDS(LLT_ALIGN(nb,sizeof(void*)))+1)*
-                              sizeof(void*));
-    v->type = (jl_value_t*)bt;
+    jl_value_t *v = (jl_value_t*)newobj((jl_value_t*)bt, NWORDS(nb));
     switch (nb) {
     case  1: *(int8_t*)   jl_data_ptr(v) = *(int8_t*)data;    break;
     case  2: *(int16_t*)  jl_data_ptr(v) = *(int16_t*)data;   break;
@@ -251,7 +248,7 @@ jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
     assert(i < jl_tuple_len(st->names));
-    size_t offs = jl_field_offset(st,i) + sizeof(void*);
+    size_t offs = jl_field_offset(st,i);
     if (st->fields[i].isptr) {
         return *(jl_value_t**)((char*)v + offs);
     }
@@ -263,7 +260,7 @@ jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i)
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
     if (i >= jl_tuple_len(st->names))
         jl_bounds_error_int(v, i+1);
-    size_t offs = jl_field_offset(st,i) + sizeof(void*);
+    size_t offs = jl_field_offset(st,i);
     if (st->fields[i].isptr) {
         jl_value_t *fval = *(jl_value_t**)((char*)v + offs);
         if (fval == NULL)
@@ -276,7 +273,7 @@ jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i)
 void jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
-    size_t offs = jl_field_offset(st,i) + sizeof(void*);
+    size_t offs = jl_field_offset(st,i);
     if (st->fields[i].isptr) {
         *(jl_value_t**)((char*)v + offs) = rhs;
         if(rhs != NULL) gc_wb(v, rhs);
@@ -289,7 +286,7 @@ void jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
 int jl_field_isdefined(jl_value_t *v, size_t i)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
-    size_t offs = jl_field_offset(st,i) + sizeof(void*);
+    size_t offs = jl_field_offset(st,i);
     if (st->fields[i].isptr) {
         return *(jl_value_t**)((char*)v + offs) != NULL;
     }
@@ -320,7 +317,7 @@ DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args, uin
     }
     for(size_t i=na; i < nf; i++) {
         if (type->fields[i].isptr)
-            *(jl_value_t**)((char*)jv+jl_field_offset(type,i)+sizeof(void*)) = NULL;
+            *(jl_value_t**)((char*)jl_data_ptr(jv)+jl_field_offset(type,i)) = NULL;
     }
     return jv;
 }
@@ -330,7 +327,7 @@ DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type)
     if (type->instance != NULL) return type->instance;
     jl_value_t *jv = newstruct(type);
     if (type->size > 0)
-        memset(&((void**)jv)[1], 0, type->size);
+        memset(jl_data_ptr(jv), 0, type->size);
     return jv;
 }
 
@@ -359,11 +356,11 @@ DLLEXPORT jl_tuple_t *jl_tuplev(size_t n, jl_value_t **v)
 jl_tuple_t *jl_tuple1(void *a)
 {
 #ifdef OVERLAP_TUPLE_LEN
-    jl_tuple_t *t = (jl_tuple_t*)alloc_2w();
+    jl_tuple_t *t = (jl_tuple_t*)alloc_1w();
 #else
-    jl_tuple_t *t = (jl_tuple_t*)alloc_3w();
+    jl_tuple_t *t = (jl_tuple_t*)alloc_2w();
 #endif
-    t->type = (jl_value_t*)jl_tuple_type;
+    jl_set_typeof(t, jl_tuple_type);
     jl_tuple_set_len_unsafe(t, 1);
     jl_tupleset(t, 0, a);
     return t;
@@ -372,11 +369,11 @@ jl_tuple_t *jl_tuple1(void *a)
 jl_tuple_t *jl_tuple2(void *a, void *b)
 {
 #ifdef OVERLAP_TUPLE_LEN
-    jl_tuple_t *t = (jl_tuple_t*)alloc_3w();
+    jl_tuple_t *t = (jl_tuple_t*)alloc_2w();
 #else
-    jl_tuple_t *t = (jl_tuple_t*)alloc_4w();
+    jl_tuple_t *t = (jl_tuple_t*)alloc_3w();
 #endif
-    t->type = (jl_value_t*)jl_tuple_type;
+    jl_set_typeof(t, jl_tuple_type);
     jl_tuple_set_len_unsafe(t, 2);
     jl_tupleset(t, 0, a);
     jl_tupleset(t, 1, b);
@@ -433,8 +430,8 @@ jl_tuple_t *jl_tuple_fill(size_t n, jl_value_t *v)
 DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t fptr, jl_value_t *env,
                                         jl_lambda_info_t *linfo)
 {
-    jl_function_t *f = (jl_function_t*)alloc_4w();
-    f->type = (jl_value_t*)jl_function_type;
+    jl_function_t *f = (jl_function_t*)alloc_3w(); assert(NWORDS(sizeof(jl_function_t))==3);
+    jl_set_typeof(f, jl_function_type);
     f->fptr = (fptr!=NULL ? fptr : linfo->fptr);
     f->env = env;
     f->linfo = linfo;
@@ -446,7 +443,7 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_tuple_t *sparams)
 {
     jl_lambda_info_t *li =
         (jl_lambda_info_t*)newobj((jl_value_t*)jl_lambda_info_type,
-                                  LAMBDA_INFO_NW);
+                                  NWORDS(sizeof(jl_lambda_info_t)));
     li->ast = ast;
     li->file = null_sym;
     li->line = 0;
@@ -498,23 +495,23 @@ static jl_sym_t *mk_symbol(const char *str)
 #endif
     jl_sym_t *sym;
     size_t len = strlen(str);
-    size_t nb = (sizeof(jl_sym_t)+len+1+7)&-8;
+    size_t nb = (sizeof(jl_typetag_t)+sizeof(jl_sym_t)+len+1+7)&-8;
 
     if (nb >= SYM_POOL_SIZE) {
         jl_exceptionf(jl_argumenterror_type, "Symbol length exceeds maximum length");
     }
 
 #ifdef MEMDEBUG
-    sym = (jl_sym_t*)malloc(nb);
+    sym = (jl_sym_t*)((jl_typetag_t*)malloc(nb))->value;
 #else
     if (sym_pool == NULL || pool_ptr+nb > sym_pool+SYM_POOL_SIZE) {
         sym_pool = (char*)malloc(SYM_POOL_SIZE);
         pool_ptr = sym_pool;
     }
-    sym = (jl_sym_t*)pool_ptr;
+    sym = (jl_sym_t*)((jl_typetag_t*)malloc(nb))->value;
     pool_ptr += nb;
 #endif
-    sym->type = (jl_value_t*)jl_sym_type;
+    jl_set_typeof(sym, jl_sym_type);
     sym->left = sym->right = NULL;
     sym->hash = hash_symbol(str, len);
     strcpy(&sym->name[0], str);
@@ -524,7 +521,7 @@ static jl_sym_t *mk_symbol(const char *str)
 static void unmark_symbols_(jl_sym_t *root)
 {
     while (root != NULL) {
-        root->type = (jl_value_t*)(((uptrint_t)root->type)&~3UL);
+        jl_set_typeof(root, jl_sym_type);
         unmark_symbols_(root->left);
         root = root->right;
     }
@@ -618,7 +615,7 @@ DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len)
 
 jl_typename_t *jl_new_typename(jl_sym_t *name)
 {
-    jl_typename_t *tn=(jl_typename_t*)newobj((jl_value_t*)jl_typename_type, 6);
+    jl_typename_t *tn=(jl_typename_t*)newobj((jl_value_t*)jl_typename_type, NWORDS(sizeof(jl_typename_t)));
     tn->name = name;
     tn->module = jl_current_module;
     tn->primary = NULL;
@@ -640,8 +637,7 @@ jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields)
 {
     return (jl_datatype_t*)
         newobj((jl_value_t*)jl_datatype_type,
-               NWORDS(sizeof(jl_datatype_t) - sizeof(void*) +
-                      nfields*sizeof(jl_fielddesc_t)));
+               NWORDS(sizeof(jl_datatype_t) + nfields*sizeof(jl_fielddesc_t)));
 }
 
 void jl_compute_field_offsets(jl_datatype_t *st)
@@ -765,7 +761,7 @@ jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
 
 jl_uniontype_t *jl_new_uniontype(jl_tuple_t *types)
 {
-    jl_uniontype_t *t = (jl_uniontype_t*)newobj((jl_value_t*)jl_uniontype_type,1);
+    jl_uniontype_t *t = (jl_uniontype_t*)newobj((jl_value_t*)jl_uniontype_type,NWORDS(sizeof(jl_uniontype_t)));
     // don't make unions of 1 type; Union(T)==T
     assert(jl_tuple_len(types) != 1);
     t->types = types;
@@ -776,7 +772,7 @@ jl_uniontype_t *jl_new_uniontype(jl_tuple_t *types)
 
 jl_typector_t *jl_new_type_ctor(jl_tuple_t *params, jl_value_t *body)
 {
-    jl_typector_t *tc = (jl_typector_t*)newobj((jl_value_t*)jl_typector_type,2);
+    jl_typector_t *tc = (jl_typector_t*)newobj((jl_value_t*)jl_typector_type,NWORDS(sizeof(jl_typector_t)));
     tc->parameters = params;
     tc->body = body;
     return (jl_typector_t*)tc;
@@ -790,7 +786,7 @@ jl_value_t *jl_box##nb(jl_datatype_t *t, int##nb##_t x)        \
     assert(jl_isbits(t));                                      \
     assert(jl_datatype_size(t) == sizeof(x));                  \
     jl_value_t *v = (jl_value_t*)alloc_##nw##w();              \
-    v->type = (jl_value_t*)t;                                  \
+    jl_set_typeof(v, t);                                       \
     *(int##nb##_t*)jl_data_ptr(v) = x;                         \
     return v;                                                  \
 }
@@ -828,7 +824,7 @@ UNBOX_FUNC(gensym, ssize_t)
 jl_value_t *pfx##_##typ(c_type x)                 \
 {                                                 \
     jl_value_t *v = (jl_value_t*)alloc_##nw##w(); \
-    v->type = (jl_value_t*)jl_##typ##_type;       \
+    jl_set_typeof(v, jl_##typ##_type);            \
     *(c_type*)jl_data_ptr(v) = x;                 \
     return v;                                     \
 }
@@ -850,7 +846,7 @@ jl_value_t *jl_box_##typ(c_type x)                      \
     if ((u##c_type)idx < (u##c_type)NBOX_C)             \
         return boxed_##typ##_cache[idx];                \
     jl_value_t *v = (jl_value_t*)alloc_##nw##w();       \
-    v->type = (jl_value_t*)jl_##typ##_type;             \
+    jl_set_typeof(v, jl_##typ##_type);                  \
     *(c_type*)jl_data_ptr(v) = x;                       \
     return v;                                           \
 }
@@ -861,7 +857,7 @@ jl_value_t *jl_box_##typ(c_type x)                 \
     if (x < NBOX_C)                                \
         return boxed_##typ##_cache[x];             \
     jl_value_t *v = (jl_value_t*)alloc_##nw##w();  \
-    v->type = (jl_value_t*)jl_##typ##_type;        \
+    jl_set_typeof(v, jl_##typ##_type);             \
     *(c_type*)jl_data_ptr(v) = x;                  \
     return v;                                      \
 }
@@ -954,8 +950,8 @@ jl_expr_t *jl_exprn(jl_sym_t *head, size_t n)
 {
     jl_array_t *ar = n==0 ? (jl_array_t*)jl_an_empty_cell : jl_alloc_cell_1d(n);
     JL_GC_PUSH1(&ar);
-    jl_expr_t *ex = (jl_expr_t*)alloc_4w();
-    ex->type = (jl_value_t*)jl_expr_type;
+    jl_expr_t *ex = (jl_expr_t*)alloc_3w(); assert(NWORDS(sizeof(jl_expr_t))==3);
+    jl_set_typeof(ex, jl_expr_type);
     ex->head = head;
     ex->args = ar;
     ex->etype = (jl_value_t*)jl_any_type;
@@ -971,8 +967,8 @@ JL_CALLABLE(jl_f_new_expr)
     JL_GC_PUSH1(&ar);
     for(size_t i=0; i < nargs-1; i++)
         jl_cellset(ar, i, args[i+1]);
-    jl_expr_t *ex = (jl_expr_t*)alloc_4w();
-    ex->type = (jl_value_t*)jl_expr_type;
+    jl_expr_t *ex = (jl_expr_t*)alloc_3w(); assert(NWORDS(sizeof(jl_expr_t))==3);
+    jl_set_typeof(ex, jl_expr_type);
     ex->head = (jl_sym_t*)args[0];
     ex->args = ar;
     ex->etype = (jl_value_t*)jl_any_type;

--- a/src/array.c
+++ b/src/array.c
@@ -14,6 +14,9 @@
 extern "C" {
 #endif
 
+#define JL_ARRAY_ALIGN(jl_value, nbytes) (LLT_ALIGN((jl_value)+sizeof(jl_typetag_t), nbytes)-sizeof(jl_typetag_t))
+
+
 // array constructors ---------------------------------------------------------
 
 static inline int store_unboxed(jl_value_t *el_type)
@@ -69,16 +72,15 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
     }
 
     int ndimwords = jl_array_ndimwords(ndims);
-    size_t tsz = sizeof(jl_array_t);
-    tsz += ndimwords*sizeof(size_t);
+    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), 16);
     if (tot <= ARRAY_INLINE_NBYTES) {
         if (isunboxed && elsz >= 4)
-            tsz = (tsz+15)&-16; // align data area 16
+            tsz = JL_ARRAY_ALIGN(tsz, 16); // align data area 16
         size_t doffs = tsz;
         tsz += tot;
-        tsz = (tsz+15)&-16; // align whole object 16
+        tsz = JL_ARRAY_ALIGN(tsz, 16); // align whole object 16
         a = (jl_array_t*)allocobj(tsz);
-        a->type = atype;
+        jl_set_typeof(a, atype);
         a->how = 0;
         data = (char*)a + doffs;
         if (tot > 0 && !isunboxed) {
@@ -86,10 +88,10 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
         }
     }
     else {
-        tsz = (tsz+15)&-16; // align whole object size 16
+        tsz = JL_ARRAY_ALIGN(tsz, 16); // align whole object 16
         a = (jl_array_t*)allocobj(tsz);
         JL_GC_PUSH1(&a);
-        a->type = atype;
+        jl_set_typeof(a, atype);
         // temporarily initialize to make gc-safe
         a->data = NULL;
         a->how = 2;
@@ -99,7 +101,7 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
             memset(data, 0, tot);
         JL_GC_POP();
     }
-    a->pooled = tsz <= 2048;
+    a->pooled = tsz + sizeof(jl_typetag_t) <= 2048;
 
     a->data = data;
     if (elsz == 1) ((char*)data)[tot-1] = '\0';
@@ -148,10 +150,10 @@ jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data, jl_tuple_t *di
     size_t ndims = jl_tuple_len(dims);
 
     int ndimwords = jl_array_ndimwords(ndims);
-    int tsz = (sizeof(jl_array_t) + sizeof(void*) + ndimwords*sizeof(size_t) + 15)&-16;
+    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t) + sizeof(void*), 16);
     a = (jl_array_t*)allocobj(tsz);
-    a->type = atype;
-    a->pooled = tsz <= 2048;
+    jl_set_typeof(a, atype);
+    a->pooled = tsz + sizeof(jl_typetag_t) <= 2048;
     a->ndims = ndims;
     a->offset = 0;
     a->data = NULL;
@@ -214,10 +216,12 @@ jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data, size_t nel,
         elsz = jl_datatype_size(el_type);
     else
         elsz = sizeof(void*);
-    int tsz = (sizeof(jl_array_t)+jl_array_ndimwords(1)*sizeof(size_t)+15)&-16;
+
+    int ndimwords = jl_array_ndimwords(1);
+    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), 16);
     a = (jl_array_t*)allocobj(tsz);
-    a->pooled = tsz <= 2048;
-    a->type = atype;
+    jl_set_typeof(a, atype);
+    a->pooled = tsz + sizeof(jl_typetag_t) <= 2048;
     a->data = data;
 #ifdef STORE_ARRAY_LEN
     a->length = nel;
@@ -265,10 +269,10 @@ jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data, jl_tuple_t *dims,
         elsz = sizeof(void*);
 
     int ndimwords = jl_array_ndimwords(ndims);
-    int tsz = (sizeof(jl_array_t) + ndimwords*sizeof(size_t)+15)&-16;
+    int tsz = JL_ARRAY_ALIGN(sizeof(jl_array_t) + ndimwords*sizeof(size_t), 16);
     a = (jl_array_t*)allocobj(tsz);
-    a->pooled = tsz <= 2048;
-    a->type = atype;
+    jl_set_typeof(a, atype);
+    a->pooled = tsz + sizeof(jl_typetag_t) <= 2048;
     a->data = data;
 #ifdef STORE_ARRAY_LEN
     a->length = nel;
@@ -340,8 +344,8 @@ jl_value_t *jl_array_to_string(jl_array_t *a)
     // TODO: check type of array?
     jl_datatype_t *string_type = u8_isvalid((char*)a->data, jl_array_len(a)) == 1 ? // ASCII
         jl_ascii_string_type : jl_utf8_string_type;
-    jl_value_t *s = (jl_value_t*)alloc_2w();
-    s->type = (jl_value_t*)string_type;
+    jl_value_t *s = (jl_value_t*)alloc_1w();
+    jl_set_typeof(s, string_type);
     jl_set_nth_field(s, 0, (jl_value_t*)a);
     return s;
 }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1217,8 +1217,8 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
     else if (jl_typeof(v) == NULL) {
         n += jl_printf(out, "<?::#null>");
     }
-    else if ((uptrint_t)v->type < 4096U) {
-        n += jl_printf(out, "<?::#%d>", (int)(uptrint_t)v->type);
+    else if (jl_typetagof(v)->type_bits < 4096U) {
+        n += jl_printf(out, "<?::#%d>", (int)jl_typetagof(v)->type_bits);
     }
     else if (jl_is_lambda_info(v)) {
         jl_lambda_info_t *li = (jl_lambda_info_t*)v;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -777,31 +777,71 @@ static Value *mark_julia_type(Value *v, jl_value_t *jt)
     return v;
 }
 
-// --- generating various error checks ---
+// --- generating various field accessors ---
 
-static jl_value_t *llvm_type_to_julia(Type *t, bool err=true);
+static Value *emit_nthptr_addr(Value *v, ssize_t n)
+{
+    return builder.CreateGEP(builder.CreateBitCast(v, jl_ppvalue_llvmt),
+                             ConstantInt::get(T_size, (ssize_t)n));
+}
+
+static Value *emit_nthptr_addr(Value *v, Value *idx)
+{
+    return builder.CreateGEP(builder.CreateBitCast(v, jl_ppvalue_llvmt), idx);
+}
+
+static Value *emit_nthptr(Value *v, ssize_t n, MDNode *tbaa)
+{
+    // p = (jl_value_t**)v; p[n]
+    Value *vptr = emit_nthptr_addr(v, n);
+    return tbaa_decorate(tbaa,builder.CreateLoad(vptr, false));
+}
+
+static Value *emit_nthptr(Value *v, Value *idx, MDNode *tbaa)
+{
+    // p = (jl_value_t**)v; p[n]
+    Value *vptr = emit_nthptr_addr(v, idx);
+    return tbaa_decorate(tbaa,builder.CreateLoad(vptr, false));
+}
+
+static Value *emit_nthptr_recast(Value *v, ssize_t n, MDNode *tbaa, Type* ptype) {
+    // p = (jl_value_t**)v; *(ptype)&p[n]
+    Value *vptr = emit_nthptr_addr(v, n);
+    return tbaa_decorate(tbaa,builder.CreateLoad(builder.CreateBitCast(vptr,ptype), false));
+}
+
+static Value *emit_typeptr_addr(Value *p)
+{
+   ssize_t offset = offsetof(jl_typetag_t,type) - offsetof(jl_typetag_t,value);
+   offset /= (signed)sizeof(jl_value_t*); // important: division must be signed
+   return emit_nthptr_addr(p, offset);
+}
 
 static Value *emit_typeof(Value *p)
 {
     // given p, a jl_value_t*, compute its type tag
     if (p->getType() == jl_pvalue_llvmt) {
         Value *tt = builder.CreateBitCast(p, jl_ppvalue_llvmt);
-        tt = builder.
-            CreateLoad(builder.CreateGEP(tt,ConstantInt::get(T_size,0)),
-                       false);
-        tt = builder.
-            CreateIntToPtr(builder. CreateAnd(builder.CreatePtrToInt(tt, T_int64), ConstantInt::get(T_int64,~(uptrint_t)3)),  jl_pvalue_llvmt);
+        tt = builder.CreateLoad(emit_typeptr_addr(tt), false);
 #ifdef OVERLAP_TUPLE_LEN
-        tt = builder.
-            CreateIntToPtr(builder.
-                           CreateAnd(builder.CreatePtrToInt(tt, T_int64),
-                                     ConstantInt::get(T_int64,0x000ffffffffffffe)),
-                           jl_pvalue_llvmt);
+        tt = builder.CreateIntToPtr(builder.CreateAnd(
+                    builder.CreatePtrToInt(tt, T_int64),
+                    ConstantInt::get(T_int64,0x000ffffffffffffe)),
+                jl_pvalue_llvmt);
+#else
+        tt = builder.CreateIntToPtr(builder.CreateAnd(
+                    builder.CreatePtrToInt(tt, T_size),
+                    ConstantInt::get(T_size,~(uptrint_t)3)),
+                jl_pvalue_llvmt);
 #endif
         return tt;
     }
     return literal_pointer_val(julia_type_of(p));
 }
+
+// --- generating various error checks ---
+
+static jl_value_t *llvm_type_to_julia(Type *t, bool err=true);
 
 static void just_emit_error(const std::string &txt, jl_codectx_t *ctx)
 {
@@ -952,37 +992,6 @@ static Value *emit_bounds_check(Value *a, jl_value_t *ty, Value *i, Value *len, 
 
 // --- loading and storing ---
 
-static Value *emit_nthptr_addr(Value *v, size_t n)
-{
-    return builder.CreateGEP(builder.CreateBitCast(v, jl_ppvalue_llvmt),
-                             ConstantInt::get(T_size, n));
-}
-
-static Value *emit_nthptr_addr(Value *v, Value *idx)
-{
-    return builder.CreateGEP(builder.CreateBitCast(v, jl_ppvalue_llvmt), idx);
-}
-
-static Value *emit_nthptr(Value *v, size_t n, MDNode *tbaa)
-{
-    // p = (jl_value_t**)v; p[n]
-    Value *vptr = emit_nthptr_addr(v, n);
-    return tbaa_decorate(tbaa,builder.CreateLoad(vptr, false));
-}
-
-static Value *emit_nthptr(Value *v, Value *idx, MDNode *tbaa)
-{
-    // p = (jl_value_t**)v; p[n]
-    Value *vptr = emit_nthptr_addr(v, idx);
-    return tbaa_decorate(tbaa,builder.CreateLoad(vptr, false));
-}
-
-static Value *emit_nthptr_recast(Value *v, size_t n, MDNode *tbaa, Type* ptype) {
-    // p = (jl_value_t**)v; *(ptype)&p[n]
-    Value *vptr = emit_nthptr_addr(v, n);
-    return tbaa_decorate(tbaa,builder.CreateLoad(builder.CreateBitCast(vptr,ptype), false));
-}
-
 static Value *ghostValue(jl_value_t *ty);
 
 static Value *typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
@@ -1130,11 +1139,11 @@ static Value *emit_tuplelen(Value *t,jl_value_t *jt)
     Type *ty = t->getType();
     if (ty == jl_pvalue_llvmt) { //boxed
 #ifdef OVERLAP_TUPLE_LEN
-        Value *lenbits = emit_nthptr(t, (size_t)0);
+        Value *lenbits = builder.CreateLoad(emit_typeptr_addr(t));
         return builder.CreateLShr(builder.CreatePtrToInt(lenbits, T_int64),
                                   ConstantInt::get(T_int32, 52));
 #else
-        return emit_nthptr_recast(t, 1, tbaa_tuplelen, T_psize);
+        return emit_nthptr_recast(t, offsetof(jl_tuple_t,length)/sizeof(jl_value_t*), tbaa_tuplelen, T_psize);
 #endif
     }
     else { //unboxed
@@ -1142,7 +1151,7 @@ static Value *emit_tuplelen(Value *t,jl_value_t *jt)
     }
 }
 
-static Value *emit_tupleset(Value *tuple, Value *ival, Value *x, jl_value_t *jt, jl_codectx_t *ctx)
+static Value *emit_tupleset(Value *tuple, Value *ival0, Value *x, jl_value_t *jt, jl_codectx_t *ctx)
 {
     if (tuple == NULL) {
         // A typecheck must have caught this one
@@ -1153,17 +1162,17 @@ static Value *emit_tupleset(Value *tuple, Value *ival, Value *x, jl_value_t *jt,
     if (ty == jl_pvalue_llvmt) { //boxed
 #ifdef OVERLAP_TUPLE_LEN
         Value *slot = builder.CreateGEP(builder.CreateBitCast(tuple, jl_ppvalue_llvmt),
-                                        ival);
+                                        ival0);
 #else
         Value *slot = builder.CreateGEP(builder.CreateBitCast(tuple, jl_ppvalue_llvmt),
-                                        builder.CreateAdd(ConstantInt::get(T_size,1),ival));
+                                        builder.CreateAdd(ConstantInt::get(T_size,1),ival0));
 #endif
         builder.CreateStore(x,slot);
         return tuple;
     }
-    ConstantInt *idx = dyn_cast<ConstantInt>(ival);
+    ConstantInt *idx = dyn_cast<ConstantInt>(ival0);
     assert(idx != NULL && "tuplesets must use constant indices");
-    unsigned ci = (unsigned)idx->getZExtValue()-1;
+    unsigned ci = (unsigned)idx->getZExtValue();
     if (ty->isVectorTy()) {
         return mark_julia_type(builder.CreateInsertElement(tuple,x,ConstantInt::get(T_int32,ci)), jt);
     }
@@ -1190,7 +1199,7 @@ static Value *allocate_box_dynamic(Value *jlty, Value *nb, Value *v);
 static void jl_add_linfo_root(jl_lambda_info_t *li, jl_value_t *val);
 
 // Julia semantics
-static Value *emit_tupleref(Value *tuple, Value *ival, jl_value_t *jt, jl_codectx_t *ctx)
+static Value *emit_tupleref(Value *tuple, Value *ival0, jl_value_t *jt, jl_codectx_t *ctx)
 {
     if (tuple == NULL) {
         // A typecheck must have caught this one
@@ -1200,38 +1209,38 @@ static Value *emit_tupleref(Value *tuple, Value *ival, jl_value_t *jt, jl_codect
     Type *ty = tuple->getType();
     if (ty == jl_pvalue_llvmt) { //boxed
 #ifdef OVERLAP_TUPLE_LEN
-        Value *slot = builder.CreateGEP(builder.CreateBitCast(tuple, jl_ppvalue_llvmt),ival);
+        Value *slot = builder.CreateGEP(builder.CreateBitCast(tuple, jl_ppvalue_llvmt),ival0);
 #else
         Value *slot = builder.CreateGEP(builder.CreateBitCast(tuple, jl_ppvalue_llvmt),
-                                        builder.CreateAdd(ConstantInt::get(T_size,1),ival));
+                                        builder.CreateAdd(ConstantInt::get(T_size,1),ival0));
 #endif
         return builder.CreateLoad(slot);
     }
-    ConstantInt *idx = dyn_cast<ConstantInt>(ival);
-    unsigned ci = idx ? (unsigned)idx->getZExtValue()-1 : (unsigned)-1;
+    ConstantInt *idx = dyn_cast<ConstantInt>(ival0);
+    unsigned ci = idx ? (unsigned)idx->getZExtValue() : (unsigned)-1;
     if (ty->isVectorTy()) {
-        Type *ity = ival->getType();
+        Type *ity = ival0->getType();
         assert(ity->isIntegerTy());
         IntegerType *iity = dyn_cast<IntegerType>(ity);
         // ExtractElement needs i32 *sigh*
         if (iity->getBitWidth() > 32)
-            ival = builder.CreateTrunc(ival,T_int32);
+            ival0 = builder.CreateTrunc(ival0,T_int32);
         else if (iity->getBitWidth() < 32)
-            ival = builder.CreateZExt(ival,T_int32);
-        Value *v = builder.CreateExtractElement(tuple,builder.CreateSub(ival,ConstantInt::get(T_int32,1)));
+            ival0 = builder.CreateZExt(ival0,T_int32);
+        Value *v = builder.CreateExtractElement(tuple,ival0);
         if (idx) {
             v = mark_julia_type(v,jl_tupleref(jt,ci));
         }
         else {
             if (sizeof(void*) != 4)
-                ival = builder.CreateZExt(ival,T_size);
+                ival0 = builder.CreateZExt(ival0,T_size);
             if (is_tupletype_homogeneous((jl_tuple_t*)jt)) {
                 v = mark_julia_type(v, jl_t0(jt));
             }
             else {
                 jl_add_linfo_root(ctx->linfo, jt);
                 v = allocate_box_dynamic(emit_tupleref(literal_pointer_val(jt),
-                                                       ival, jl_typeof(jt), ctx),
+                                                       ival0, jl_typeof(jt), ctx),
                                          ConstantInt::get(T_size,ty->getScalarSizeInBits()/8), v);
             }
         }
@@ -1268,14 +1277,14 @@ static Value *emit_tupleref(Value *tuple, Value *ival, jl_value_t *jt, jl_codect
         tbaa_decorate(tbaa_user, builder.CreateStore(tuple,tempSpace));
         Value *idxs[2];
         idxs[0] = ConstantInt::get(T_size,0);
-        idxs[1] = builder.CreateSub(ival,ConstantInt::get(T_size,1));
+        idxs[1] = ival0;
         Value *v = builder.CreateGEP(tempSpace,ArrayRef<Value*>(&idxs[0],2));
         if (idx) {
             v = mark_julia_type(tbaa_decorate(tbaa_user, builder.CreateLoad(v)), jl_tupleref(jt,ci));
         }
         else {
             jl_add_linfo_root(ctx->linfo, jt);
-            Value *lty = emit_tupleref(literal_pointer_val(jt), ival, jl_typeof(jt), ctx);
+            Value *lty = emit_tupleref(literal_pointer_val(jt), ival0, jl_typeof(jt), ctx);
             size_t i, l = jl_tuple_len(jt);
             if (is_tupletype_homogeneous((jl_tuple_t*)jt) && jl_isbits(jl_t0(jt))) {
                 v = mark_julia_type(tbaa_decorate(tbaa_user, builder.CreateLoad(v)), jl_t0(jt));
@@ -1307,20 +1316,20 @@ static Value *emit_tupleref(Value *tuple, Value *ival, jl_value_t *jt, jl_codect
     BasicBlock *after = BasicBlock::Create(getGlobalContext(),"after_switch",ctx->f);
     BasicBlock *deflt = BasicBlock::Create(getGlobalContext(),"default_case",ctx->f);
     // Create the switch
-    SwitchInst *sw = builder.CreateSwitch(ival,deflt,n);
+    SwitchInst *sw = builder.CreateSwitch(ival0,deflt,n);
     // Anything else is a bounds error
     builder.SetInsertPoint(deflt);
     Value *tmp = builder.CreateAlloca(ty);
     builder.CreateStore(tuple, tmp);
     jl_add_linfo_root(ctx->linfo, jt);
-    builder.CreateCall3(prepare_call(jluboundserror_func), builder.CreatePointerCast(tmp, T_pint8), literal_pointer_val(jt), ival);
+    builder.CreateCall3(prepare_call(jluboundserror_func), builder.CreatePointerCast(tmp, T_pint8), literal_pointer_val(jt), ival0);
     builder.CreateUnreachable();
     size_t ntuple = jl_tuple_len(jt);
     PHINode *ret = PHINode::Create(jl_pvalue_llvmt, ntuple);
     // Now for the cases
     for (size_t i = 0, j = 0; i < ntuple; ++i) {
         BasicBlock *blk = BasicBlock::Create(getGlobalContext(),"case",ctx->f);
-        sw->addCase(ConstantInt::get((IntegerType*)T_size,i+1),blk);
+        sw->addCase(ConstantInt::get((IntegerType*)T_size,i),blk);
         builder.SetInsertPoint(blk);
         jl_value_t *jltype = jl_tupleref(jt,i);
         Type *ty = julia_struct_to_llvm(jltype);
@@ -1359,19 +1368,7 @@ static Value *emit_n_varargs(jl_codectx_t *ctx)
 
 static Value *emit_arraysize(Value *t, Value *dim)
 {
-#ifdef STORE_ARRAY_LEN
-#ifdef _P64
-    int o = 3;
-#else
-    int o = 4;
-#endif
-#else
-#ifdef _P64
-    int o = 2;
-#else
-    int o = 3;
-#endif
-#endif
+    int o = offsetof(jl_array_t, nrows)/sizeof(void*) - 1;
     Value *dbits =
         emit_nthptr(t, builder.CreateAdd(dim,
                                          ConstantInt::get(dim->getType(), o)), tbaa_arraysize);
@@ -1402,7 +1399,7 @@ static Value *emit_arraylen_prim(Value *t, jl_value_t *ty)
 {
 #ifdef STORE_ARRAY_LEN
     (void)ty;
-    Value* addr = builder.CreateStructGEP(builder.CreateBitCast(t,jl_parray_llvmt), 2);
+    Value* addr = builder.CreateStructGEP(builder.CreateBitCast(t,jl_parray_llvmt), 1); //index (not offset) of length field in jl_parray_llvmt
     return tbaa_decorate(tbaa_arraylen, builder.CreateLoad(addr, false));
 #else
     jl_value_t *p1 = jl_tparam1(ty);
@@ -1434,7 +1431,7 @@ static Value *emit_arraylen(Value *t, jl_value_t *ex, jl_codectx_t *ctx)
 
 static Value *emit_arrayptr(Value *t)
 {
-    Value* addr = builder.CreateStructGEP(builder.CreateBitCast(t,jl_parray_llvmt), 1);
+    Value* addr = builder.CreateStructGEP(builder.CreateBitCast(t,jl_parray_llvmt), 0); //index (not offset) of data field in jl_parray_llvmt
     return tbaa_decorate(tbaa_arrayptr, builder.CreateLoad(addr, false));
 }
 
@@ -1466,8 +1463,7 @@ static void assign_arrayvar(jl_arrayvar_t &av, Value *ar)
 
 static Value *data_pointer(Value *x)
 {
-    return builder.CreateGEP(builder.CreateBitCast(x, jl_ppvalue_llvmt),
-                             ConstantInt::get(T_size, 1));
+    return builder.CreateBitCast(x, jl_ppvalue_llvmt);
 }
 
 static Value *emit_array_nd_index(Value *a, jl_value_t *ex, size_t nd, jl_value_t **args,
@@ -1543,7 +1539,7 @@ static Value *tpropagate(Value *a, Value *b)
 
 static Value *init_bits_value(Value *newv, Value *jt, Type *t, Value *v)
 {
-    builder.CreateStore(jt, builder.CreateBitCast(newv, jl_ppvalue_llvmt));
+    builder.CreateStore(jt, builder.CreateBitCast(emit_typeptr_addr(newv), jl_ppvalue_llvmt));
     builder.CreateStore(v , builder.CreateBitCast(data_pointer(newv),
                                                   PointerType::get(t,0)));
     return newv;
@@ -1556,9 +1552,7 @@ static Value *allocate_box_dynamic(Value *jlty, Value *nb, Value *v)
     if (v->getType()->isPointerTy()) {
         v = builder.CreatePtrToInt(v, T_size);
     }
-    Value *newv = builder.CreateCall(prepare_call(jlallocobj_func),
-                                     builder.CreateAdd(nb,
-                                                       ConstantInt::get(T_size, sizeof(void*))));
+    Value *newv = builder.CreateCall(prepare_call(jlallocobj_func), nb);
     // TODO: make sure this is rooted. I think it is.
     return init_bits_value(newv, jlty, v->getType(), v);
 }
@@ -1706,9 +1700,9 @@ static Value *boxed(Value *v, jl_codectx_t *ctx, jl_value_t *jt)
         make_gcroot(tpl,ctx);
         for (size_t i = 0; i < n; ++i) {
             jl_value_t *jti = jl_tupleref(jt,i);
-            Value *vi = emit_tupleref(v, ConstantInt::get(T_size,i+1), jt, ctx);
+            Value *vi = emit_tupleref(v, ConstantInt::get(T_size,i), jt, ctx);
             Value *boxedvi = boxed(vi, ctx, jti);
-            emit_tupleset(tpl, ConstantInt::get(T_size,i+1), boxedvi, jt, ctx);
+            emit_tupleset(tpl, ConstantInt::get(T_size,i), boxedvi, jt, ctx);
         }
         ctx->argDepth = last_depth;
         return tpl;
@@ -1727,9 +1721,9 @@ static Value *boxed(Value *v, jl_codectx_t *ctx, jl_value_t *jt)
     if (jb == jl_float64_type) {
         // manually inline alloc & init of Float64 box. cheap, I know.
 #ifdef _P64
-        Value *newv = builder.CreateCall(prepare_call(jlalloc2w_func));
+        Value *newv = builder.CreateCall(prepare_call(jlalloc1w_func));
 #else
-        Value *newv = builder.CreateCall(prepare_call(jlalloc3w_func));
+        Value *newv = builder.CreateCall(prepare_call(jlalloc2w_func));
 #endif
         return init_bits_value(newv, literal_pointer_val(jt), t, v);
     }
@@ -1765,7 +1759,7 @@ static void emit_cpointercheck(Value *x, const std::string &msg,
     emit_typecheck(t, (jl_value_t*)jl_datatype_type, msg, ctx);
 
     Value *istype =
-        builder.CreateICmpEQ(emit_nthptr(t, offsetof(jl_datatype_t,name)/sizeof(char*), tbaa_datatype),
+        builder.CreateICmpEQ(emit_nthptr(t, (ssize_t)(offsetof(jl_datatype_t,name)/sizeof(char*)), tbaa_datatype),
                              literal_pointer_val((jl_value_t*)jl_pointer_type->name));
     BasicBlock *failBB = BasicBlock::Create(getGlobalContext(),"fail",ctx->f);
     BasicBlock *passBB = BasicBlock::Create(getGlobalContext(),"pass");
@@ -1782,12 +1776,12 @@ static void emit_cpointercheck(Value *x, const std::string &msg,
 // allocation for known size object
 static Value* emit_allocobj(size_t static_size)
 {
-    if (static_size == sizeof(void*)*2)
+    if (static_size == sizeof(void*)*1)
+        return builder.CreateCall(prepare_call(jlalloc1w_func));
+    else if (static_size == sizeof(void*)*2)
         return builder.CreateCall(prepare_call(jlalloc2w_func));
     else if (static_size == sizeof(void*)*3)
         return builder.CreateCall(prepare_call(jlalloc3w_func));
-    else if (static_size == sizeof(void*)*4)
-        return builder.CreateCall(prepare_call(jlalloc4w_func));
     else
         return builder.CreateCall(prepare_call(jlallocobj_func),
                        ConstantInt::get(T_size, static_size));
@@ -1796,10 +1790,8 @@ static Value* emit_allocobj(size_t static_size)
 // if ptr is NULL this emits a write barrier _back_
 static void emit_write_barrier(jl_codectx_t* ctx, Value *parent, Value *ptr)
 {
-    /*    builder.CreateCall2(wbfunc, builder.CreateBitCast(parent, jl_pvalue_llvmt), builder.CreateBitCast(ptr, jl_pvalue_llvmt));
-          return;*/
-    parent = builder.CreateBitCast(parent, T_psize);
-    Value* parent_type = builder.CreateLoad(parent);
+    Value* parenttag = builder.CreateBitCast(emit_typeptr_addr(parent), T_psize);
+    Value* parent_type = builder.CreateLoad(parenttag);
     Value* parent_mark_bits = builder.CreateAnd(parent_type, 1);
 
     // the branch hint does not seem to make it to the generated code
@@ -1812,7 +1804,7 @@ static void emit_write_barrier(jl_codectx_t* ctx, Value *parent, Value *ptr)
     builder.CreateCondBr(parent_marked, barrier_may_trigger, cont);
 
     builder.SetInsertPoint(barrier_may_trigger);
-    Value* ptr_mark_bit = builder.CreateAnd(builder.CreateLoad(builder.CreateBitCast(ptr, T_psize)), 1);
+    Value* ptr_mark_bit = builder.CreateAnd(builder.CreateLoad(builder.CreateBitCast(emit_typeptr_addr(ptr), T_psize)), 1);
     Value* ptr_not_marked = builder.CreateICmpEQ(ptr_mark_bit, ConstantInt::get(T_size, 0));
     builder.CreateCondBr(ptr_not_marked, barrier_trigger, cont);
     builder.SetInsertPoint(barrier_trigger);
@@ -1836,15 +1828,15 @@ static void emit_checked_write_barrier(jl_codectx_t *ctx, Value *parent, Value *
     builder.SetInsertPoint(cont);
 }
 
-static void emit_setfield(jl_datatype_t *sty, Value *strct, size_t idx,
+static void emit_setfield(jl_datatype_t *sty, Value *strct, size_t idx0,
                           Value *rhs, jl_codectx_t *ctx, bool checked, bool wb)
 {
     if (sty->mutabl || !checked) {
         Value *addr =
             builder.CreateGEP(builder.CreateBitCast(strct, T_pint8),
-                              ConstantInt::get(T_size, sty->fields[idx].offset + sizeof(void*)));
-        jl_value_t *jfty = jl_tupleref(sty->types, idx);
-        if (sty->fields[idx].isptr) {
+                              ConstantInt::get(T_size, sty->fields[idx0].offset));
+        jl_value_t *jfty = jl_tupleref(sty->types, idx0);
+        if (sty->fields[idx0].isptr) {
             rhs = boxed(rhs, ctx);
             builder.CreateStore(rhs,
                                 builder.CreateBitCast(addr, jl_ppvalue_llvmt));
@@ -1907,9 +1899,9 @@ static Value *emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, j
             if (might_need_root(args[1]) || fval->getType() != jl_pvalue_llvmt)
                 make_gcroot(f1, ctx);
         }
-        Value *strct = emit_allocobj(sizeof(void*)+sty->size);
+        Value *strct = emit_allocobj(sty->size);
         builder.CreateStore(literal_pointer_val((jl_value_t*)ty),
-                            emit_nthptr_addr(strct, (size_t)0));
+                            emit_typeptr_addr(strct));
         if (f1) {
             if (!jl_subtype(expr_type(args[1],ctx), jl_t0(sty->types), 0))
                 emit_typecheck(f1, jl_t0(sty->types), "new", ctx);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -306,9 +306,9 @@ static Function *jlenter_func;
 static Function *jlleave_func;
 static Function *jlegal_func;
 static Function *jlallocobj_func;
+static Function *jlalloc1w_func;
 static Function *jlalloc2w_func;
 static Function *jlalloc3w_func;
-static Function *jlalloc4w_func;
 static Function *jl_alloc_tuple_func;
 static Function *jlsubtype_func;
 static Function *setjmp_func;
@@ -345,7 +345,7 @@ static Function *show_execution_point_func;
 static std::vector<Type *> two_pvalue_llvmt;
 static std::vector<Type *> three_pvalue_llvmt;
 
-extern "C" DLLEXPORT void gc_wb_slow(void* parent, void* ptr)
+extern "C" DLLEXPORT void gc_wb_slow(jl_value_t* parent, jl_value_t* ptr)
 {
     gc_wb(parent, ptr);
 }
@@ -1624,9 +1624,9 @@ static Value *emit_lambda_closure(jl_value_t *expr, jl_codectx_t *ctx)
         if (vari.closureidx != -1) {
             int idx = vari.closureidx;
 #ifdef OVERLAP_TUPLE_LEN
-            val = emit_nthptr((Value*)ctx->envArg, idx+1, tbaa_tuplelen);
+            val = emit_nthptr((Value*)ctx->envArg, idx, tbaa_tuplelen);
 #else
-            val = emit_nthptr((Value*)ctx->envArg, idx+2, tbaa_tuplelen);
+            val = emit_nthptr((Value*)ctx->envArg, idx+1, tbaa_tuplelen);
 #endif
         }
         else {
@@ -1709,8 +1709,7 @@ static Value *emit_getfield(jl_value_t *expr, jl_sym_t *name, jl_codectx_t *ctx)
             if (strct->getType() == jl_pvalue_llvmt) {
                 Value *addr =
                     builder.CreateGEP(builder.CreateBitCast(strct, T_pint8),
-                                      ConstantInt::get(T_size,
-                                                       sty->fields[idx].offset + sizeof(void*)));
+                                      ConstantInt::get(T_size, sty->fields[idx].offset));
                 JL_GC_POP();
                 MDNode *tbaa = sty->mutabl ? tbaa_user : tbaa_immut;
                 if (sty->fields[idx].isptr) {
@@ -2021,7 +2020,11 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
     else if (f->fptr == &jl_f_apply && nargs==3 && ctx->vaStack &&
              symbol_eq(args[3], ctx->vaName) && expr_type(args[2],ctx) == (jl_value_t*)jl_function_type) {
         Value *theF = emit_expr(args[2],ctx);
-        Value *theFptr = emit_nthptr_recast(theF,1, tbaa_func, jl_pfptr_llvmt);
+        Value *theFptr = emit_nthptr_recast(
+                theF,
+                offsetof(jl_function_t,fptr)/sizeof(void*),
+                tbaa_func,
+                jl_pfptr_llvmt);
         Value *nva = emit_n_varargs(ctx);
 #ifdef _P64
         nva = builder.CreateTrunc(nva, T_int32);
@@ -2058,7 +2061,7 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                 if (idx > 0 && (idx < tlen || (idx == tlen && !isseqt))) {
                     // known to be in bounds
                     JL_GC_POP();
-                    return emit_tupleref(arg1,ConstantInt::get(T_size,idx),tty,ctx);
+                    return emit_tupleref(arg1,ConstantInt::get(T_size,idx-1),tty,ctx);
                 }
                 if (idx==0 || (!isseqt && idx > tlen)) {
                     // known to be out of bounds
@@ -2088,9 +2091,9 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                 unbox = true;
                 jl_add_linfo_root(ctx->linfo, tty);
             }
-            emit_bounds_check(arg1, unbox ? tty : NULL, idx, tlen, ctx);
+            Value *idx0 = emit_bounds_check(arg1, unbox ? tty : NULL, idx, tlen, ctx);
             JL_GC_POP();
-            return emit_tupleref(arg1,idx,tty,ctx);
+            return emit_tupleref(arg1,idx0,tty,ctx);
         }
     }
     else if (f->fptr == &jl_f_tuple) {
@@ -2128,7 +2131,7 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                         }
                         assert(tpl != NULL);
                         Value *elt = emit_unbox(ety,emit_unboxed(args[i+1],ctx),jl_tupleref(rt1,i));
-                        tpl = emit_tupleset(tpl,ConstantInt::get(T_size,i+1),elt,rt1,ctx);
+                        tpl = emit_tupleset(tpl,ConstantInt::get(T_size,i),elt,rt1,ctx);
                     }
                     JL_GC_POP();
                     if (ty->isEmptyTy())
@@ -2146,15 +2149,15 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
             make_gcroot(arg1, ctx);
         bool rooted = false;
 #ifdef OVERLAP_TUPLE_LEN
-        size_t nwords = nargs+1;
+        size_t nwords = nargs;
 #else
-        size_t nwords = nargs+2;
+        size_t nwords = nargs+1;
 #endif
         Value *tup = emit_allocobj(sizeof(void*)*nwords);
 #ifdef OVERLAP_TUPLE_LEN
-        builder.CreateStore(arg1, emit_nthptr_addr(tup, 1));
+        builder.CreateStore(arg1, emit_nthptr_addr(tup, 0));
 #else
-        builder.CreateStore(arg1, emit_nthptr_addr(tup, 2));
+        builder.CreateStore(arg1, emit_nthptr_addr(tup, 1));
         emit_write_barrier(ctx, tup, arg1);
 #endif
         ctx->argDepth = last_depth;
@@ -2163,22 +2166,14 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
             CreateStore(builder.
                         CreateOr(builder.CreatePtrToInt(literal_pointer_val((jl_value_t*)jl_tuple_type), T_int64),
                                  ConstantInt::get(T_int64, nargs<<52)),
-                        builder.CreateBitCast(emit_nthptr_addr(tup, (size_t)0),
-                                              T_pint64));
+                        builder.CreateBitCast(emit_typeptr_addr(tup), T_pint64));
 #else
-        builder.CreateStore(literal_pointer_val((jl_value_t*)jl_tuple_type),
-                            emit_nthptr_addr(tup, (size_t)0));
+        builder.CreateStore(literal_pointer_val((jl_value_t*)jl_tuple_type), emit_typeptr_addr(tup));
         builder.CreateStore(ConstantInt::get(T_size, nargs),
-                            builder.CreateBitCast(emit_nthptr_addr(tup, (size_t)1), T_psize));
-#endif
-#ifdef OVERLAP_TUPLE_LEN
-        size_t offs = 1;
-#else
-        size_t offs = 2;
+                            builder.CreateBitCast(tup, T_psize));
 #endif
         for(i=1; i < nargs; i++) {
-            builder.CreateStore(V_null,
-                                emit_nthptr_addr(tup, i+offs));
+            builder.CreateStore(V_null, emit_nthptr_addr(tup, i+TUPLE_DATA_OFFSET));
         }
         for(i=1; i < nargs; i++) {
             if (might_need_root(args[i+1]) && !rooted) {
@@ -2191,7 +2186,7 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                 rooted = true;
             }
             Value *argi = boxed(argval,ctx);
-            builder.CreateStore(argi, emit_nthptr_addr(tup, i+offs));
+            builder.CreateStore(argi, emit_nthptr_addr(tup, i+TUPLE_DATA_OFFSET));
             emit_write_barrier(ctx, tup, argi);
         }
         ctx->argDepth = last_depth;
@@ -2360,12 +2355,10 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                 if (llvm_st == jl_pvalue_llvmt) {
                     if (is_structtype_all_pointers(stt)) {
                         idx = emit_bounds_check(strct, NULL, idx, ConstantInt::get(T_size, nfields), ctx);
-                        Value *fld =
-                            tbaa_decorate(tbaa_user, builder.
-                            CreateLoad(builder.
-                                       CreateGEP(builder.
-                                                 CreateBitCast(strct, jl_ppvalue_llvmt),
-                                                 builder.CreateAdd(idx,ConstantInt::get(T_size,1)))));
+                        Value *fld = tbaa_decorate(tbaa_user, builder.CreateLoad(
+                                    builder.CreateGEP(
+                                        builder.CreateBitCast(strct, jl_ppvalue_llvmt),
+                                        idx)));
                         if ((unsigned)stt->ninitialized != jl_tuple_len(stt->types)) {
                             null_pointer_check(fld, ctx);
                         }
@@ -2393,7 +2386,7 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                     // frobbing the stack
                     Value *fld;
                     if (nfields == 0) {
-                        emit_bounds_check(tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlnull_var))),
+                        idx = emit_bounds_check(tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlnull_var))),
                                 NULL, idx, ConstantInt::get(T_size, nfields), ctx);
                         fld = UndefValue::get(jl_pvalue_llvmt);
                     }
@@ -2409,8 +2402,7 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                             jl_add_linfo_root(ctx->linfo, (jl_value_t*)stt);
                         }
                         idx = emit_bounds_check(tempSpace, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
-                        Value *ptr = builder.CreateGEP(tempSpace, ConstantInt::get(T_size, 0));
-                        fld = typed_load(ptr, idx, jt, ctx, stt->mutabl ? tbaa_user : tbaa_immut);
+                        fld = typed_load(tempSpace, idx, jt, ctx, stt->mutabl ? tbaa_user : tbaa_immut);
                         builder.CreateCall(Intrinsic::getDeclaration(jl_Module,Intrinsic::stackrestore),
                                            stacksave);
                     }
@@ -2636,7 +2628,7 @@ static Value *emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx, jl_
 #endif
             // extract pieces of the function object
             // TODO: try extractvalue instead
-            theFptr = emit_nthptr_recast(theFunc, 1, tbaa_func, jl_pfptr_llvmt);
+            theFptr = emit_nthptr_recast(theFunc, offsetof(jl_function_t,fptr)/sizeof(void*), tbaa_func, jl_pfptr_llvmt);
             theF = theFunc;
         }
         else {
@@ -2670,7 +2662,7 @@ static Value *emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx, jl_
             myargs = builder.CreateGEP(ctx->argTemp,
                                        ConstantInt::get(T_size, argStart+1+ctx->argSpaceOffs));
         }
-        theFptr = emit_nthptr_recast(theFunc, 1, tbaa_func, jl_pfptr_llvmt);
+        theFptr = emit_nthptr_recast(theFunc, offsetof(jl_function_t,fptr)/sizeof(void*), tbaa_func, jl_pfptr_llvmt);
         Value *r1 = builder.CreateCall3(prepare_call(theFptr), theFunc, myargs,
                                         ConstantInt::get(T_int32,nargs));
         builder.CreateBr(mergeBB1);
@@ -2760,21 +2752,21 @@ static Value *var_binding_pointer(jl_sym_t *s, jl_binding_t **pbnd,
         assert(((Value*)ctx->envArg)->getType() == jl_pvalue_llvmt);
         if (isBoxed(s, ctx)) {
 #ifdef OVERLAP_TUPLE_LEN
-            return emit_nthptr_addr(emit_nthptr((Value*)ctx->envArg, idx+1, tbaa_tuplelen), 1);
+            return builder.CreatePointerCast(emit_nthptr((Value*)ctx->envArg, idx, tbaa_tuplelen), jl_ppvalue_llvmt);
 #else
-            return emit_nthptr_addr(emit_nthptr((Value*)ctx->envArg, idx+2, tbaa_tuplelen), 1);
+            return builder.CreatePointerCast(emit_nthptr((Value*)ctx->envArg, idx+1, tbaa_tuplelen), jl_ppvalue_llvmt);
 #endif
         }
 #ifdef OVERLAP_TUPLE_LEN
-        return emit_nthptr_addr((Value*)ctx->envArg, idx+1);
+        return emit_nthptr_addr((Value*)ctx->envArg, idx);
 #else
-        return emit_nthptr_addr((Value*)ctx->envArg, idx+2);
+        return emit_nthptr_addr((Value*)ctx->envArg, idx+1);
 #endif
     }
     Value *l = vi.memvalue;
     if (l == NULL) return NULL;
     if (isBoxed(s, ctx)) {
-        return emit_nthptr_addr(builder.CreateLoad(l,false), 1);
+        return builder.CreatePointerCast(builder.CreateLoad(l,false), jl_ppvalue_llvmt);
     }
     return l;
 }
@@ -2898,9 +2890,8 @@ static Value *emit_assignment(Value *bp, jl_value_t *r, jl_value_t *declType, bo
         }
         else {
             rval = boxed(emit_expr(r, ctx, true),ctx,rt);
-            if (!is_stack(bp)) {
-                Value* box = builder.CreateGEP(bp, ConstantInt::get(T_size, -1));
-                emit_write_barrier(ctx, box, rval);
+            if (!is_stack(bp)) { // bp is a jl_box_t*
+                emit_write_barrier(ctx, bp, rval);
             }
         }
         if (builder.GetInsertBlock()->getTerminator() == NULL) {
@@ -3185,8 +3176,8 @@ static Value *emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed,
             }
             else {
                 bp = var_binding_pointer((jl_sym_t*)mn, &bnd, false, ctx);
-                if (isBoxed((jl_sym_t*)mn, ctx)) {
-                    bp_owner = builder.CreateBitCast(emit_nthptr_addr(bp, -1), jl_pvalue_llvmt);
+                if (isBoxed((jl_sym_t*)mn, ctx)) { // bp is a jl_box_t*
+                    bp_owner = builder.CreateBitCast(bp, jl_pvalue_llvmt);
                 }
             }
         }
@@ -3643,7 +3634,6 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
         if (isref & (2<<i)) {
             if (!jl_isbits(jargty)) {
                 val = builder.CreatePointerCast(val, jl_pvalue_llvmt);
-                val = builder.CreateConstGEP1_32(val, (unsigned)-1); // rewind to type-tag
             }
             else {
                 Type *t = julia_type_to_llvm(jargty);
@@ -3667,8 +3657,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
             if (at == jl_pvalue_llvmt) {
                 Value *mem = emit_new_struct(jargty, 1, NULL, &ctx);
                 if (mem->getType() == jl_pvalue_llvmt) {
-                    builder.CreateStore(val, builder.CreateBitCast(
-                                emit_nthptr_addr(mem, (size_t)1), val->getType()->getPointerTo()));
+                    builder.CreateStore(val, builder.CreateBitCast(mem, val->getType()->getPointerTo()));
                     val = mem;
                 }
                 else {
@@ -3717,7 +3706,6 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     finalize_gc_frame(&ctx);
 
     if (isref&1) {
-        //r = builder.CreateConstGEP1_32(r, 1); // skip type-tag -- broken if you do, broken if you don't
         builder.CreateRet(r);
     }
     else {
@@ -4337,7 +4325,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
 
     // fetch env out of function object if we need it
     if (hasCapt) {
-        ctx.envArg = emit_nthptr(fArg, 2, tbaa_func);
+        ctx.envArg = emit_nthptr(fArg, offsetof(jl_function_t,env)/sizeof(jl_value_t*), tbaa_func);
     }
 
     // step 8. set up GC frame
@@ -4770,14 +4758,10 @@ extern "C" void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig)
 
 extern "C" DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v)
 {
-    jl_value_t *box = (jl_value_t*)alloc_2w();
-#ifdef OVERLAP_TUPLE_LEN
-    box->type = (size_t)jl_box_any_type;
-#else
-    box->type = jl_box_any_type;
-#endif
-    if (v) gc_wb(box, v);
-    ((jl_value_t**)box)[1] = v;
+    jl_value_t *box = (jl_value_t*)alloc_1w();
+    jl_set_typeof(box, jl_box_any_type);
+    // if (v) gc_wb(box, v); // write block not needed: box was just allocated
+    box->fieldptr[0] = v;
     return box;
 }
 
@@ -4901,9 +4885,9 @@ static void init_julia_llvm_env(Module *m)
     assert(jl_func_sig != NULL);
     jl_pfptr_llvmt = PointerType::get(PointerType::get(jl_func_sig, 0), 0);
 
-    Type* vaelts[] = {valueStructElts[0], T_pint8
+    Type* vaelts[] = {T_pint8
 #ifdef STORE_ARRAY_LEN
-                                        , T_size
+                      , T_size
 #endif
     };
     Type* jl_array_llvmt =
@@ -5104,13 +5088,14 @@ static void init_julia_llvm_env(Module *m)
         jlcall_func_to_llvm("jl_apply_generic", (void*)&jl_apply_generic, m);
     jlgetfield_func = jlcall_func_to_llvm("jl_f_get_field", (void*)&jl_f_get_field, m);
 
-    std::vector<Type *> wbargs(0);
-    wbargs.push_back(jl_pvalue_llvmt);
-    wbargs.push_back(jl_pvalue_llvmt);
     queuerootfun = Function::Create(FunctionType::get(T_void, args_1ptr, false),
                                     Function::ExternalLinkage,
                                     "gc_queue_root", m);
     add_named_global(queuerootfun, (void*)&gc_queue_root);
+
+    std::vector<Type *> wbargs(0);
+    wbargs.push_back(jl_pvalue_llvmt);
+    wbargs.push_back(jl_pvalue_llvmt);
     wbfunc = Function::Create(FunctionType::get(T_void, wbargs, false),
                               Function::ExternalLinkage,
                               "gc_wb_slow", m);
@@ -5246,6 +5231,12 @@ static void init_julia_llvm_env(Module *m)
     add_named_global(jlallocobj_func, (void*)&allocobj);
 
     std::vector<Type*> empty_args(0);
+    jlalloc1w_func =
+        Function::Create(FunctionType::get(jl_pvalue_llvmt, empty_args, false),
+                         Function::ExternalLinkage,
+                         "alloc_1w", m);
+    add_named_global(jlalloc1w_func, (void*)&alloc_1w);
+
     jlalloc2w_func =
         Function::Create(FunctionType::get(jl_pvalue_llvmt, empty_args, false),
                          Function::ExternalLinkage,
@@ -5257,12 +5248,6 @@ static void init_julia_llvm_env(Module *m)
                          Function::ExternalLinkage,
                          "alloc_3w", m);
     add_named_global(jlalloc3w_func, (void*)&alloc_3w);
-
-    jlalloc4w_func =
-        Function::Create(FunctionType::get(jl_pvalue_llvmt, empty_args, false),
-                         Function::ExternalLinkage,
-                         "alloc_4w", m);
-    add_named_global(jlalloc4w_func, (void*)&alloc_4w);
 
     std::vector<Type*> atargs(0);
     atargs.push_back(T_size);

--- a/src/gc.c
+++ b/src/gc.c
@@ -408,8 +408,10 @@ static inline int gc_setmark_pool(void *o, int mark_mode)
 }
 
 
-static inline int gc_setmark(void *o, int sz, int mark_mode)
+static inline int gc_setmark(jl_value_t *v, int sz, int mark_mode)
 {
+    jl_typetag_t *o = jl_typetagof(v);
+    sz += sizeof(jl_typetag_t);
 #ifdef MEMDEBUG
     return gc_setmark_big(o, mark_mode);
 #endif
@@ -419,7 +421,7 @@ static inline int gc_setmark(void *o, int sz, int mark_mode)
         return gc_setmark_big(o, mark_mode);
 }
 
-#define gc_typeof(v) ((jl_value_t*)(((uptrint_t)jl_typeof(v))&(~(uintptr_t)3)))
+#define gc_typeof(v) jl_typeof(v)
 #define gc_val_buf(o) ((buff_t*)(((void**)(o))-1))
 
 inline void gc_setmark_buf(void *o, int mark_mode)
@@ -600,7 +602,7 @@ void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz, int isaligned, jl_
 {
     maybe_collect();
 
-    if (gc_bits(owner) == GC_MARKED) {
+    if (gc_bits(jl_typetagof(owner)) == GC_MARKED) {
         perm_scanned_bytes += sz - oldsz;
         live_bytes += sz - oldsz;
     }
@@ -658,8 +660,8 @@ static arraylist_t weak_refs;
 
 DLLEXPORT jl_weakref_t *jl_gc_new_weakref(jl_value_t *value)
 {
-    jl_weakref_t *wr = (jl_weakref_t*)alloc_2w();
-    wr->type = (jl_value_t*)jl_weakref_type;
+    jl_weakref_t *wr = (jl_weakref_t*)alloc_1w();
+    jl_set_typeof(wr, jl_weakref_type);
     wr->value = value;
     arraylist_push(&weak_refs, wr);
     return wr;
@@ -676,9 +678,9 @@ static void sweep_weak_refs(void)
         return;
     do {
         wr = (jl_weakref_t*)lst[n];
-        if (gc_marked(wr)) {
+        if (gc_marked(jl_typetagof(wr))) {
             // weakref itself is alive
-            if (!gc_marked(wr->value))
+            if (!gc_marked(jl_typetagof(wr->value)))
                 wr->value = (jl_value_t*)jl_nothing;
             n++;
         }
@@ -932,7 +934,7 @@ static void sweep_malloced_arrays(void)
     mallocarray_t **pma = &mallocarrays;
     while (ma != NULL) {
         mallocarray_t *nxt = ma->next;
-        if (gc_marked(ma->a)) {
+        if (gc_marked(jl_typetagof(ma->a))) {
             pma = &ma->next;
         }
         else {
@@ -1349,27 +1351,31 @@ void reset_remset(void)
     remset->len = 0;
 }
 
-DLLEXPORT void gc_queue_root(void *ptr)
+DLLEXPORT void gc_queue_root(jl_value_t *ptr)
 {
-    assert(gc_bits(ptr) != GC_QUEUED);
-    gc_bits(ptr) = GC_QUEUED;
+    jl_typetag_t *o = jl_typetagof(ptr);
+    assert(gc_bits(o) != GC_QUEUED);
+    gc_bits(o) = GC_QUEUED;
     arraylist_push(remset, ptr);
 }
-void gc_queue_binding(void *bnd)
+
+void gc_queue_binding(jl_binding_t *bnd)
 {
-    assert(gc_bits(bnd) != GC_QUEUED);
-    gc_bits(bnd) = GC_QUEUED;
-    arraylist_push(&rem_bindings, (void*)((void**)bnd + 1));
+    buff_t *buf = gc_val_buf(bnd);
+    assert(gc_bits(buf) != GC_QUEUED);
+    gc_bits(buf) = GC_QUEUED;
+    arraylist_push(&rem_bindings, bnd);
 }
 
 static int push_root(jl_value_t *v, int d, int);
-static inline int gc_push_root(void *v, int d)
+static inline int gc_push_root(void *v, int d) // v isa jl_value_t*
 {
-    assert((v) != NULL);
-    verify_val(v);
-    int bits = gc_bits(v);
-    if (!gc_marked(v)) {
-        return push_root((jl_value_t*)(v),d, bits);
+    assert(v != NULL);
+    jl_typetag_t* o = jl_typetagof(v);
+    verify_val(o);
+    int bits = gc_bits(o);
+    if (!gc_marked(o)) {
+        return push_root((jl_value_t*)v, d, bits);
     }
     return bits;
 }
@@ -1377,12 +1383,13 @@ static inline int gc_push_root(void *v, int d)
 void jl_gc_setmark(jl_value_t *v) // TODO rename this as it is misleading now
 {
     //    int64_t s = perm_scanned_bytes;
-    if (!gc_marked(v)) {
+    jl_typetag_t *o = jl_typetagof(v);
+    if (!gc_marked(o)) {
         //        objprofile_count(jl_typeof(v), 1, 16);
 #ifdef MEMDEBUG
-        gc_setmark_big(v, GC_MARKED_NOESC);
+        gc_setmark_big(o, GC_MARKED_NOESC);
 #else
-        gc_setmark_pool(v, GC_MARKED_NOESC);
+        gc_setmark_pool(o, GC_MARKED_NOESC);
 #endif
     }
     //    perm_scanned_bytes = s;
@@ -1421,7 +1428,7 @@ __attribute__((noinline)) static int gc_mark_module(jl_module_t *m, int d)
     for(i=1; i < m->bindings.size; i+=2) {
         if (table[i] != HT_NOTFOUND) {
             jl_binding_t *b = (jl_binding_t*)table[i];
-            gc_setmark_buf(b, gc_bits(m));
+            gc_setmark_buf(b, gc_bits(jl_typetagof(m)));
 #ifdef GC_VERIFY
             void* vb = gc_val_buf(b);
             verify_parent("module", m, &vb, "binding_buff");
@@ -1453,7 +1460,7 @@ static void gc_mark_task_stack(jl_task_t *ta, int d)
 {
     if (ta->stkbuf != NULL || ta == jl_current_task) {
         if (ta->stkbuf != NULL) {
-            gc_setmark_buf(ta->stkbuf, gc_bits(ta));
+            gc_setmark_buf(ta->stkbuf, gc_bits(jl_typetagof(ta)));
         }
 #ifdef COPY_STACKS
         ptrint_t offset;
@@ -1510,7 +1517,7 @@ static int push_root(jl_value_t *v, int d, int bits)
     int refyoung = 0;
 
     if (vt == (jl_value_t*)jl_weakref_type) {
-        bits = gc_setmark(v, jl_datatype_size(jl_weakref_type), GC_MARKED_NOESC);
+        bits = gc_setmark(v, sizeof(jl_weakref_t), GC_MARKED_NOESC);
         goto ret;
     }
     if ((jl_is_datatype(vt) && ((jl_datatype_t*)vt)->pointerfree)) {
@@ -1543,27 +1550,28 @@ static int push_root(jl_value_t *v, int d, int bits)
     }
     else if (((jl_datatype_t*)(vt))->name == jl_array_typename) {
         jl_array_t *a = (jl_array_t*)v;
+        jl_typetag_t *o = jl_typetagof(v);
         int todo = !(bits & GC_MARKED);
         if (a->pooled)
             MARK(a,
 #ifdef MEMDEBUG
-                 bits = gc_setmark_big(a, GC_MARKED_NOESC);
+                 bits = gc_setmark_big(o, GC_MARKED_NOESC);
 #else
-                 bits = gc_setmark_pool(a, GC_MARKED_NOESC);
+                 bits = gc_setmark_pool(o, GC_MARKED_NOESC);
 #endif
                  if (a->how == 2 && todo) {
-                     objprofile_count(MATY, gc_bits(a) == GC_MARKED, array_nbytes(a));
-                     if (gc_bits(a) == GC_MARKED)
+                     objprofile_count(MATY, gc_bits(o) == GC_MARKED, array_nbytes(a));
+                     if (gc_bits(o) == GC_MARKED)
                          perm_scanned_bytes += array_nbytes(a);
                      else
                          scanned_bytes += array_nbytes(a);
                  });
         else
             MARK(a,
-                 bits = gc_setmark_big(a, GC_MARKED_NOESC);
+                 bits = gc_setmark_big(o, GC_MARKED_NOESC);
                  if (a->how == 2 && todo) {
-                     objprofile_count(MATY, gc_bits(a) == GC_MARKED, array_nbytes(a));
-                     if (gc_bits(a) == GC_MARKED)
+                     objprofile_count(MATY, gc_bits(o) == GC_MARKED, array_nbytes(a));
+                     if (gc_bits(o) == GC_MARKED)
                          perm_scanned_bytes += array_nbytes(a);
                      else
                          scanned_bytes += array_nbytes(a);
@@ -1578,7 +1586,7 @@ static int push_root(jl_value_t *v, int d, int bits)
             void* val_buf = gc_val_buf((char*)a->data - a->offset*a->elsize);
             verify_parent("array", v, &val_buf, "buffer ('loc' addr is meaningless)");
 #endif
-            gc_setmark_buf((char*)a->data - a->offset*a->elsize, gc_bits(v));
+            gc_setmark_buf((char*)a->data - a->offset*a->elsize, gc_bits(o));
         }
         if (a->ptrarray && a->data!=NULL) {
             size_t l = jl_array_len(a);
@@ -1633,7 +1641,7 @@ static int push_root(jl_value_t *v, int d, int bits)
         jl_fielddesc_t* fields = dt->fields;
         for(int i=0; i < nf; i++) {
             if (fields[i].isptr) {
-                jl_value_t **slot = (jl_value_t**)((char*)v + fields[i].offset + sizeof(void*));
+                jl_value_t **slot = (jl_value_t**)((char*)v + fields[i].offset);
                 jl_value_t *fld = *slot;
                 if (fld) {
                     verify_parent("object", v, slot, "field(%d)", i);
@@ -1676,8 +1684,10 @@ static void visit_mark_stack_inc(int mark_mode)
 {
     while(mark_sp > 0 && !should_timeout()) {
         jl_value_t* v = mark_stack[--mark_sp];
-        assert(gc_bits(v) == GC_QUEUED || gc_bits(v) == GC_MARKED || gc_bits(v) == GC_MARKED_NOESC);
-        push_root(v, 0, gc_bits(v));
+        assert(gc_bits(jl_typetagof(v)) == GC_QUEUED ||
+               gc_bits(jl_typetagof(v)) == GC_MARKED ||
+               gc_bits(jl_typetagof(v)) == GC_MARKED_NOESC);
+        push_root(v, 0, gc_bits(jl_typetagof(v)));
     }
 }
 
@@ -1758,9 +1768,9 @@ static void post_mark(arraylist_t *list, int dryrun)
     for(size_t i=0; i < list->len; i+=2) {
         jl_value_t *v = (jl_value_t*)list->items[i];
         jl_value_t *fin = (jl_value_t*)list->items[i+1];
-        int isfreed = !gc_marked(v);
+        int isfreed = !gc_marked(jl_typetagof(v));
         gc_push_root(fin, 0);
-        int isold = list == &finalizer_list && gc_bits(v) == GC_MARKED && gc_bits(fin) == GC_MARKED;
+        int isold = list == &finalizer_list && gc_bits(jl_typetagof(v)) == GC_MARKED && gc_bits(jl_typetagof(fin)) == GC_MARKED;
         if (!dryrun && (isfreed || isold)) {
             // remove from this list
             if (i < list->len - 2) {
@@ -2065,10 +2075,9 @@ void jl_gc_collect(int full)
         reset_remset();
         // avoid counting remembered objects & bindings twice in perm_scanned_bytes
         for(int i = 0; i < last_remset->len; i++) {
-            uintptr_t item = (uintptr_t)last_remset->items[i];
-            void* ptr = (void*)(item & ~(uintptr_t)1);
-            objprofile_count(jl_typeof(ptr), 2, 0);
-            gc_bits(ptr) = GC_MARKED;
+            jl_value_t *item = (jl_value_t*)last_remset->items[i];
+            objprofile_count(jl_typeof(item), 2, 0);
+            gc_bits(jl_typetagof(item)) = GC_MARKED;
         }
         for (int i = 0; i < rem_bindings.len; i++) {
             void *ptr = rem_bindings.items[i];
@@ -2076,9 +2085,8 @@ void jl_gc_collect(int full)
         }
 
         for (int i = 0; i < last_remset->len; i++) {
-            uintptr_t item = (uintptr_t)last_remset->items[i];
-            void* ptr = (void*)(item & ~(uintptr_t)1);
-            push_root((jl_value_t*)ptr, 0, gc_bits(ptr));
+            jl_value_t *item = (jl_value_t*)last_remset->items[i];
+            push_root(item, 0, GC_MARKED);
         }
 
         // 2. mark every object in a remembered binding
@@ -2189,7 +2197,7 @@ void jl_gc_collect(int full)
             // so that we don't trigger the barrier again on them.
             if (sweep_mask == GC_MARKED_NOESC) {
                 for (int i = 0; i < remset->len; i++) {
-                    gc_bits(((uintptr_t)remset->items[i] & ~(uintptr_t)1)) = GC_QUEUED;
+                    gc_bits(jl_typetagof(remset->items[i])) = GC_QUEUED;
                 }
                 for (int i = 0; i < rem_bindings.len; i++) {
                     void *ptr = rem_bindings.items[i];
@@ -2292,51 +2300,54 @@ void *reallocb(void *b, size_t sz)
     }
 }
 
-DLLEXPORT void *allocobj(size_t sz)
+#define jl_valueof(v) (((jl_typetag_t*)(v))->value)
+
+DLLEXPORT jl_value_t *allocobj(size_t sz)
 {
+    sz += sizeof(void*);
 #ifdef MEMDEBUG
-    return alloc_big(sz);
+    return jl_valueof(alloc_big(sz));
 #endif
     if (sz <= 2048)
-        return pool_alloc(&pools[szclass(sz)]);
+        return jl_valueof(pool_alloc(&pools[szclass(sz)]));
     else
-        return alloc_big(sz);
+        return jl_valueof(alloc_big(sz));
 }
 
-DLLEXPORT void *alloc_2w(void)
+DLLEXPORT jl_value_t *alloc_1w(void)
 {
 #ifdef MEMDEBUG
-    return alloc_big(2*sizeof(void*));
+    return jl_valueof(alloc_big(2*sizeof(void*)));
 #endif
 #ifdef _P64
-    return _pool_alloc(&pools[2], 2*sizeof(void*));
+    return jl_valueof(_pool_alloc(&pools[2], 2*sizeof(void*)));
 #else
-    return _pool_alloc(&pools[0], 2*sizeof(void*));
+    return jl_valueof(_pool_alloc(&pools[0], 2*sizeof(void*)));
 #endif
 }
 
-DLLEXPORT void *alloc_3w(void)
+DLLEXPORT jl_value_t *alloc_2w(void)
 {
 #ifdef MEMDEBUG
-    return alloc_big(3*sizeof(void*));
+    return jl_valueof(alloc_big(3*sizeof(void*)));
 #endif
 #ifdef _P64
-    return _pool_alloc(&pools[4], 3*sizeof(void*));
+    return jl_valueof(_pool_alloc(&pools[4], 3*sizeof(void*)));
 #else
-    return _pool_alloc(&pools[1], 3*sizeof(void*));
+    return jl_valueof(_pool_alloc(&pools[1], 3*sizeof(void*)));
 #endif
 
 }
 
-DLLEXPORT void *alloc_4w(void)
+DLLEXPORT jl_value_t *alloc_3w(void)
 {
 #ifdef MEMDEBUG
-    return alloc_big(4*sizeof(void*));
+    return jl_valueof(alloc_big(4*sizeof(void*)));
 #endif
 #ifdef _P64
-    return _pool_alloc(&pools[6], 4*sizeof(void*));
+    return jl_valueof(_pool_alloc(&pools[6], 4*sizeof(void*)));
 #else
-    return pool_alloc(&pools[2]);
+    return jl_valueof(pool_alloc(&pools[2]));
 #endif
 }
 
@@ -2510,7 +2521,7 @@ static void big_obj_stats(void)
 
     mallocarray_t *ma = mallocarrays;
     while (ma != NULL) {
-        if (gc_marked(ma->a)) {
+        if (gc_marked(jl_typetagof(ma->a))) {
             nused++;
             nbytes += array_nbytes(ma->a);
         }

--- a/src/gf.c
+++ b/src/gf.c
@@ -22,7 +22,7 @@ extern "C" {
 static jl_methtable_t *new_method_table(jl_sym_t *name)
 {
     jl_methtable_t *mt = (jl_methtable_t*)allocobj(sizeof(jl_methtable_t));
-    mt->type = (jl_value_t*)jl_methtable_type;
+    jl_set_typeof(mt, jl_methtable_type);
     mt->name = name;
     mt->defs = (jl_methlist_t*)JL_NULL;
     mt->cache = (jl_methlist_t*)JL_NULL;
@@ -1291,7 +1291,7 @@ jl_methlist_t *jl_method_list_insert(jl_methlist_t **pml, jl_tuple_t *type,
         l = l->next;
     }
     jl_methlist_t *newrec = (jl_methlist_t*)allocobj(sizeof(jl_methlist_t));
-    newrec->type = (jl_value_t*)jl_method_type;
+    jl_set_typeof(newrec, jl_method_type);
     newrec->sig = type;
     newrec->tvars = tvars;
     newrec->va = (jl_tuple_len(type) > 0 &&

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -277,6 +277,17 @@ DLLEXPORT const char* jl_ver_string(void)
    return JULIA_VERSION_STRING;
 }
 
+// Create function versions of some useful macros
+#undef jl_typetagof
+DLLEXPORT jl_typetag_t *jl_typetagof(jl_value_t *v) {
+    return jl_typetagof__MACRO(v);
+}
+
+#undef jl_typeof
+DLLEXPORT jl_value_t *jl_typeof(jl_value_t *v) {
+    return jl_typeof__MACRO(v);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2974,13 +2974,13 @@ void jl_init_types(void)
 {
     // create base objects
     jl_datatype_type = jl_new_uninitialized_datatype(10);
-    jl_datatype_type->type = (jl_value_t*)jl_datatype_type;
+    jl_set_typeof(jl_datatype_type, jl_datatype_type);
     jl_typename_type = jl_new_uninitialized_datatype(4);
     jl_sym_type = jl_new_uninitialized_datatype(0);
     jl_symbol_type = jl_sym_type;
 
     jl_tuple_type = jl_alloc_tuple(1);
-    jl_tuple_type->type = (jl_value_t*)jl_tuple_type;
+    jl_set_typeof(jl_tuple_type, jl_tuple_type);
 #ifdef OVERLAP_TUPLE_LEN
     jl_tuple_set_len_unsafe(jl_tuple_type, 1);
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -13,22 +13,22 @@ STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
     jl_value_t *jv = NULL;
     switch (nfields) {
     case 1:
-        jv = (jl_value_t*)alloc_2w(); break;
+        jv = (jl_value_t*)alloc_1w(); break;
     case 2:
-        jv = (jl_value_t*)alloc_3w(); break;
+        jv = (jl_value_t*)alloc_2w(); break;
     case 3:
-        jv = (jl_value_t*)alloc_4w(); break;
+        jv = (jl_value_t*)alloc_3w(); break;
     default:
-        jv = (jl_value_t*)allocobj((1+nfields) * sizeof(void*));
+        jv = (jl_value_t*)allocobj(nfields * sizeof(void*));
     }
-    jv->type = type;
+    jl_set_typeof(jv, type);
     return jv;
 }
 
 STATIC_INLINE jl_value_t *newstruct(jl_datatype_t *type)
 {
-    jl_value_t *jv = (jl_value_t*)allocobj(sizeof(void*) + type->size);
-    jv->type = (jl_value_t*)type;
+    jl_value_t *jv = (jl_value_t*)allocobj(type->size);
+    jl_set_typeof(jv, type);
     return jv;
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -17,7 +17,7 @@ jl_module_t *jl_current_module=NULL;
 jl_module_t *jl_new_module(jl_sym_t *name)
 {
     jl_module_t *m = (jl_module_t*)allocobj(sizeof(jl_module_t));
-    m->type = (jl_value_t*)jl_module_type;
+    jl_set_typeof(m, jl_module_type);
     JL_GC_PUSH1(&m);
     assert(jl_is_symbol(name));
     m->name = name;

--- a/src/task.c
+++ b/src/task.c
@@ -817,7 +817,7 @@ DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
 {
     size_t pagesz = jl_page_size;
     jl_task_t *t = (jl_task_t*)allocobj(sizeof(jl_task_t));
-    t->type = (jl_value_t*)jl_task_type;
+    jl_set_typeof(t, jl_task_type);
     ssize = LLT_ALIGN(ssize, pagesz);
     t->ssize = ssize;
     t->current_module = NULL;
@@ -923,7 +923,7 @@ void jl_init_tasks(void *stack, size_t ssize)
     runnable_sym = jl_symbol("runnable");
 
     jl_current_task = (jl_task_t*)allocobj(sizeof(jl_task_t));
-    jl_current_task->type = (jl_value_t*)jl_task_type;
+    jl_set_typeof(jl_current_task, jl_task_type);
 #ifdef COPY_STACKS
     jl_current_task->ssize = 0;  // size of saved piece
     jl_current_task->bufsz = 0;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -422,7 +422,7 @@ static int true_main(int argc, char *argv[])
         int i;
         for (i=0; i < argc; i++) {
             jl_value_t *s = (jl_value_t*)jl_cstr_to_string(argv[i]);
-            s->type = (jl_value_t*)jl_utf8_string_type;
+            jl_set_typeof(s,jl_utf8_string_type);
             jl_arrayset(args, s, i);
         }
     }


### PR DESCRIPTION
This is a first pass at giving pointers to julia types easy compatibility with C. This is done by "hiding" the type and GC information before the data, and shifting all references in the julia source by 1 to match. What this would mean for the user is that

``` julia
type A
  a::Int
end
type B
  a::A
end
```

can be passed to a C function expecting:

``` c
typedef struct _A {
  int a;
} A;
typedef struct _B {
  *A a;
} B;
```

If the user is receiving data from C (e.g. anything not created by Julia's GC), then they must instead declare it as `Ptr{A}` and access with unsafe_ref (I'm wondering if it might be more appropriate to introduce another type for this purpose, but thats a separate issue I'll go into later).

If @JeffBezanson approves of this, I'll go back through and clean this up some to make it ready to merge. TODO items include:
- [x] remove some casts that are now no-ops
- [x] figure out what emit_arraysize is doing (and replace with offsetof for better maintainability)
- [x] finish fixing OVERLAP_TUPLE_LEN
- [x] stop over-allocating types by sizeof(void*) bytes in alloc_big, and check if there's double counting anywhere else (or conversely, fully move it to alloc_big)
- [x] document how to use & how to avoid getting burned
