### PR TITLE
RFC: add complex-valued tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,8 @@ include ../Make.inc
 
 TESTS = core keywordargs numbers strings unicode corelib hashing remote iostring \
 arrayops linalg blas fft dsp sparse bitarray random math functional bigint \
-sorting statistics spawn parallel arpack bigfloat file zlib all git pkg pkg2 suitesparse
+sorting statistics spawn parallel arpack bigfloat file zlib all git pkg pkg2 \
+suitesparse complex
 
 $(TESTS) ::
 	$(QUIET_JULIA) $(JULIA_EXECUTABLE) ./runtests.jl $@

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,3 +1,15 @@
+# TODO:
+# ^ (cpow)
+#  equivalent to exp(y*log(x))
+#    except for 0^0?
+#  conj(x)^conj(y) = conj(x^y)
+
+# cos (based on cosh)
+# tan (based on tanh)
+# asin (based on asinh)
+# atan (based on atanh)
+
+
 
 # sqrt: 
 # tests special values from csqrt man page
@@ -107,6 +119,8 @@
 @test isequal(exp(complex(Inf,0.0)), complex(Inf,0.0))
 @test isequal(exp(complex(Inf,-0.0)), complex(Inf,-0.0))
 
+@test isequal(exp(complex(-Inf,0.0)), complex(0.0,0.0))
+@test isequal(exp(complex(-Inf,-0.0)), complex(0.0,-0.0))
 @test isequal(exp(complex(-Inf,5.0)), complex(cos(5.0)*0.0,sin(5.0)*0.0))
 @test isequal(exp(complex(-Inf,-5.0)), complex(cos(5.0)*0.0,sin(5.0)*-0.0))
 
@@ -130,6 +144,15 @@
 @test isequal(exp(complex(NaN,5.0)), complex(NaN,NaN))
 
 @test isequal(exp(complex(NaN,NaN)), complex(NaN,NaN))
+
+# ^ (cpow)
+#  equivalent to exp(y*log(x))
+#    except for 0^0?
+#  conj(x)^conj(y) = conj(x^y)
+@test isequal(complex(0.0,0.0)^complex(0.0,0.0), complex(1.0,0.0))
+
+@test isequal(complex(0.0,-0.0)^complex(0.0,-0.0), complex(1.0,-0.0))
+
 
 
 # sinh: has properties
@@ -178,6 +201,60 @@
 @test isequal(sinh(complex(NaN,5.0)),complex(NaN,NaN))
 
 @test isequal(sinh(complex(NaN,NaN)),complex(NaN,NaN))
+
+
+
+# sin: defined in terms of sinh
+#  sin(z) = -i*sinh(i*z)
+#  i.e. if sinh(a+ib) = x+iy
+#    then  sin(b-ia) = y-ix
+
+@test isequal(sin(complex(0.0,-0.0)),complex(0.0,-0.0))
+@test isequal(sin(complex(-0.0,-0.0)),complex(-0.0,-0.0))
+@test isequal(sin(complex(0.0,0.0)),complex(0.0,0.0))
+@test isequal(sin(complex(-0.0,0.0)),complex(-0.0,0.0))
+
+# raise invalid flag
+@test_fails sin(complex(Inf,0.0)) #complex(NaN,0.0)
+@test_fails sin(complex(-Inf,0.0)) #complex(NaN,0.0)
+@test_fails sin(complex(Inf,-0.0)) #complex(NaN,-0.0)
+@test_fails sin(complex(-Inf,-0.0)) #complex(NaN,-0.0)
+
+@test isequal(sin(complex(NaN,0.0)),complex(NaN,0.0))
+@test isequal(sin(complex(NaN,-0.0)),complex(NaN,-0.0))
+
+# raise invalid flag
+@test_fails sin(complex(Inf,5.0)) #complex(NaN,NaN)
+
+@test isequal(sin(complex(NaN,5.0)),complex(NaN,NaN))
+
+@test isequal(sin(complex(0.0,Inf)),complex(0.0,Inf))
+@test isequal(sin(complex(-0.0,Inf)),complex(-0.0,Inf))
+@test isequal(sin(complex(0.0,-Inf)),complex(0.0,-Inf))
+@test isequal(sin(complex(-0.0,-Inf)),complex(-0.0,-Inf))
+
+@test isequal(sin(complex(5.0,Inf)),complex(sin(5.0)*Inf,cos(5.0)*Inf))
+@test isequal(sin(complex(5.0,-Inf)),complex(sin(5.0)*Inf,cos(5.0)*-Inf))
+
+# raise invalid flag
+@test_fails sin(complex(Inf,Inf)) #complex(Inf,NaN)
+@test_fails sin(complex(Inf,-Inf)) #complex(Inf,NaN)
+@test_fails sin(complex(-Inf,Inf)) #complex(-Inf,NaN)
+@test_fails sin(complex(-Inf,-Inf)) #complex(-Inf,NaN)
+
+@test isequal(sin(complex(NaN,Inf)),complex(NaN,Inf))
+@test isequal(sin(complex(NaN,-Inf)),complex(NaN,-Inf))
+
+@test isequal(sin(complex(0.0,NaN)),complex(0.0,NaN))
+@test isequal(sin(complex(-0.0,NaN)),complex(-0.0,NaN))
+
+@test isequal(sin(complex(5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(sin(complex(NaN,NaN)),complex(NaN,NaN))
+
+
+
+
 
 
 # cosh: has properties
@@ -274,3 +351,186 @@
 @test isequal(tanh(complex(NaN,-5.0)),complex(NaN,NaN))
 
 @test isequal(tanh(complex(NaN,NaN)),complex(NaN,NaN))
+
+
+
+# acosh
+#  acosh(conj(z)) = conj(acosh(z))
+@test isequal(acosh(complex(0.0,0.0)),complex(0.0,pi/2))
+@test isequal(acosh(complex(0.0,-0.0)),complex(0.0,-pi/2))
+@test isequal(acosh(complex(-0.0,0.0)),complex(0.0,pi/2))
+@test isequal(acosh(complex(-0.0,-0.0)),complex(0.0,-pi/2))
+
+@test isequal(acosh(complex(0.0,Inf)),complex(Inf,pi/2))
+@test isequal(acosh(complex(0.0,-Inf)),complex(Inf,-pi/2))
+@test isequal(acosh(complex(5.0,Inf)),complex(Inf,pi/2))
+@test isequal(acosh(complex(5.0,-Inf)),complex(Inf,-pi/2))
+
+@test isequal(acosh(complex(5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(acosh(complex(-Inf,0.0)),complex(Inf,pi))
+@test isequal(acosh(complex(-Inf,-0.0)),complex(Inf,-pi))
+@test isequal(acosh(complex(-Inf,5.0)),complex(Inf,pi))
+@test isequal(acosh(complex(-Inf,-5.0)),complex(Inf,-pi))
+
+@test isequal(acosh(complex(Inf,0.0)),complex(Inf,0.0))
+@test isequal(acosh(complex(Inf,-0.0)),complex(Inf,-0.0))
+@test isequal(acosh(complex(Inf,5.0)),complex(Inf,0.0))
+@test isequal(acosh(complex(Inf,-5.0)),complex(Inf,-0.0))
+
+@test isequal(acosh(complex(-Inf,Inf)),complex(Inf,3*pi/4))
+@test isequal(acosh(complex(-Inf,-Inf)),complex(Inf,-3*pi/4))
+
+@test isequal(acosh(complex(Inf,Inf)),complex(Inf,pi/4))
+@test isequal(acosh(complex(Inf,-Inf)),complex(Inf,-pi/4))
+
+@test isequal(acosh(complex(Inf,NaN)),complex(Inf,NaN))
+@test isequal(acosh(complex(-Inf,NaN)),complex(Inf,NaN))
+
+@test isequal(acosh(complex(NaN,Inf)),complex(Inf,NaN))
+@test isequal(acosh(complex(NaN,-Inf)),complex(Inf,NaN))
+
+@test isequal(acosh(complex(NaN,NaN)),complex(NaN,NaN))
+
+
+# acos
+#  acos(conj(z)) = conj(acos(z))
+@test isequal(acos(complex(0.0,0.0)),complex(pi/2,-0.0))
+@test isequal(acos(complex(0.0,-0.0)),complex(pi/2,0.0))
+@test isequal(acos(complex(-0.0,0.0)),complex(pi/2,-0.0))
+@test isequal(acos(complex(-0.0,-0.0)),complex(pi/2,0.0))
+
+@test isequal(acos(complex(0.0,NaN)),complex(pi/2,NaN))
+@test isequal(acos(complex(-0.0,NaN)),complex(pi/2,NaN))
+
+@test isequal(acos(complex(0.0,Inf)),complex(pi/2,-Inf))
+@test isequal(acos(complex(0.0,-Inf)),complex(pi/2,Inf))
+@test isequal(acos(complex(5.0,Inf)),complex(pi/2,-Inf))
+@test isequal(acos(complex(5.0,-Inf)),complex(pi/2,Inf))
+
+@test isequal(acos(complex(5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(acos(complex(-Inf,0.0)),complex(pi,-Inf))
+@test isequal(acos(complex(-Inf,-0.0)),complex(pi,Inf))
+@test isequal(acos(complex(-Inf,5.0)),complex(pi,-Inf))
+@test isequal(acos(complex(-Inf,-5.0)),complex(pi,Inf))
+
+@test isequal(acos(complex(Inf,0.0)),complex(0.0,-Inf))
+@test isequal(acos(complex(Inf,-0.0)),complex(0.0,Inf))
+@test isequal(acos(complex(Inf,5.0)),complex(0.0,-Inf))
+@test isequal(acos(complex(Inf,-5.0)),complex(0.0,Inf))
+
+@test isequal(acos(complex(-Inf,Inf)),complex(3*pi/4,-Inf))
+@test isequal(acos(complex(-Inf,-Inf)),complex(3*pi/4,Inf))
+
+@test isequal(acos(complex(Inf,Inf)),complex(pi/4,-Inf))
+@test isequal(acos(complex(Inf,-Inf)),complex(pi/4,Inf))
+
+@test isequal(acos(complex(Inf,NaN)),complex(NaN,Inf))
+@test isequal(acos(complex(-Inf,NaN)),complex(NaN,Inf))
+
+@test isequal(acos(complex(NaN,0.0)),complex(NaN,NaN))
+@test isequal(acos(complex(NaN,5.0)),complex(NaN,NaN))
+
+@test isequal(acos(complex(NaN,Inf)),complex(NaN,-Inf))
+@test isequal(acos(complex(NaN,-Inf)),complex(NaN,Inf))
+
+@test isequal(acos(complex(NaN,NaN)),complex(NaN,NaN))
+
+
+
+# asinh
+#  asinh(conj(z)) = conj(asinh(z))
+#  asinh(-z) = -asinh(z)
+@test isequal(asinh(complex(0.0,0.0)),complex(0.0,0.0))
+@test isequal(asinh(complex(0.0,-0.0)),complex(0.0,-0.0))
+@test isequal(asinh(complex(-0.0,0.0)),complex(-0.0,0.0))
+@test isequal(asinh(complex(-0.0,-0.0)),complex(-0.0,-0.0))
+
+@test isequal(asinh(complex(0.0,Inf)),complex(Inf,pi/2))
+@test isequal(asinh(complex(0.0,-Inf)),complex(Inf,-pi/2))
+@test isequal(asinh(complex(-0.0,Inf)),complex(-Inf,pi/2))
+@test isequal(asinh(complex(-0.0,-Inf)),complex(-Inf,-pi/2))
+
+@test isequal(asinh(complex(5.0,Inf)),complex(Inf,pi/2))
+@test isequal(asinh(complex(5.0,-Inf)),complex(Inf,-pi/2))
+@test isequal(asinh(complex(-5.0,Inf)),complex(-Inf,pi/2))
+@test isequal(asinh(complex(-5.0,-Inf)),complex(-Inf,-pi/2))
+
+@test isequal(asinh(complex(0.0,NaN)),complex(NaN,NaN))
+@test isequal(asinh(complex(5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(asinh(complex(Inf,Inf)),complex(Inf,pi/4))
+@test isequal(asinh(complex(Inf,-Inf)),complex(Inf,-pi/4))
+@test isequal(asinh(complex(-Inf,Inf)),complex(-Inf,pi/4))
+@test isequal(asinh(complex(-Inf,-Inf)),complex(-Inf,-pi/4))
+
+@test isequal(asinh(complex(Inf,NaN)),complex(Inf,NaN))
+@test isequal(asinh(complex(-Inf,NaN)),complex(-Inf,NaN))
+
+@test isequal(asinh(complex(NaN,0.0)),complex(NaN,0.0))
+@test isequal(asinh(complex(NaN,-0.0)),complex(NaN,-0.0))
+
+@test isequal(asinh(complex(NaN,5.0)),complex(NaN,NaN))
+
+@test isequal(asinh(complex(NaN,Inf)),complex(Inf,NaN))
+@test isequal(asinh(complex(NaN,-Inf)),complex(Inf,NaN))
+
+@test isequal(asinh(complex(NaN,NaN)),complex(NaN,NaN))
+
+
+# atanh
+#  atanh(conj(z)) = conj(atanh(z))
+#  atang(-z) = -atanh(z)
+
+@test isequal(atanh(complex(0.0,0.0)),complex(0.0,0.0))
+@test isequal(atanh(complex(0.0,-0.0)),complex(0.0,-0.0))
+@test isequal(atanh(complex(-0.0,0.0)),complex(-0.0,0.0))
+@test isequal(atanh(complex(-0.0,-0.0)),complex(-0.0,-0.0))
+
+@test isequal(atanh(complex(0.0,NaN)),complex(0.0,NaN))
+@test isequal(atanh(complex(-0.0,NaN)),complex(-0.0,NaN))
+
+# raise divide-by-zero flag
+@test isequal(atanh(complex(1.0,0.0)),complex(Inf,0.0))
+
+@test isequal(atanh(complex(0.0,Inf)),complex(0.0,pi/2))
+@test isequal(atanh(complex(0.0,-Inf)),complex(0.0,-pi/2))
+@test isequal(atanh(complex(-0.0,Inf)),complex(-0.0,pi/2))
+@test isequal(atanh(complex(-0.0,-Inf)),complex(-0.0,-pi/2))
+
+@test isequal(atanh(complex(5.0,Inf)),complex(0.0,pi/2))
+@test isequal(atanh(complex(5.0,-Inf)),complex(0.0,-pi/2))
+@test isequal(atanh(complex(-5.0,Inf)),complex(-0.0,pi/2))
+@test isequal(atanh(complex(-5.0,-Inf)),complex(-0.0,-pi/2))
+
+@test isequal(atanh(complex(5.0,NaN)),complex(NaN,NaN))
+@test isequal(atanh(complex(-5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(atanh(complex(Inf,0.0)),complex(0.0,pi/2))
+@test isequal(atanh(complex(Inf,-0.0)),complex(0.0,-pi/2))
+@test isequal(atanh(complex(-Inf,0.0)),complex(-0.0,pi/2))
+@test isequal(atanh(complex(-Inf,-0.0)),complex(-0.0,-pi/2))
+
+@test isequal(atanh(complex(Inf,5.0)),complex(0.0,pi/2))
+@test isequal(atanh(complex(Inf,-5.0)),complex(0.0,-pi/2))
+@test isequal(atanh(complex(-Inf,5.0)),complex(-0.0,pi/2))
+@test isequal(atanh(complex(-Inf,-5.0)),complex(-0.0,-pi/2))
+
+@test isequal(atanh(complex(Inf,Inf)),complex(0.0,pi/2))
+@test isequal(atanh(complex(Inf,-Inf)),complex(0.0,-pi/2))
+@test isequal(atanh(complex(-Inf,Inf)),complex(-0.0,pi/2))
+@test isequal(atanh(complex(-Inf,-Inf)),complex(-0.0,-pi/2))
+
+@test isequal(atanh(complex(Inf,NaN)),complex(0.0,NaN))
+@test isequal(atanh(complex(-Inf,NaN)),complex(-0.0,NaN))
+
+@test isequal(atanh(complex(NaN,0.0)),complex(NaN,NaN))
+@test isequal(atanh(complex(NaN,-0.0)),complex(NaN,NaN))
+@test isequal(atanh(complex(NaN,5.0)),complex(NaN,NaN))
+@test isequal(atanh(complex(NaN,-5.0)),complex(NaN,NaN))
+
+@test isequal(atanh(complex(NaN,Inf)),complex(0,pi/2))
+@test isequal(atanh(complex(NaN,-Inf)),complex(0,-pi/2))
+
+@test isequal(atanh(complex(NaN,NaN)),complex(NaN,NaN))

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,15 +1,3 @@
-# TODO:
-# ^ (cpow)
-#  equivalent to exp(y*log(x))
-#    except for 0^0?
-#  conj(x)^conj(y) = conj(x^y)
-
-# cos (based on cosh)
-# tan (based on tanh)
-# asin (based on asinh)
-# atan (based on atanh)
-
-
 
 # sqrt: 
 # tests special values from csqrt man page
@@ -222,6 +210,9 @@
 #  sin(z) = -i*sinh(i*z)
 #  i.e. if sinh(a+ib) = x+iy
 #    then  sin(b-ia) = y-ix
+#  sin(conj(z)) = conj(sin(z))
+#  sin(-z) = -sin(z)
+
 
 @test isequal(sin(complex(0.0,-0.0)),complex(0.0,-0.0))
 @test isequal(sin(complex(-0.0,-0.0)),complex(-0.0,-0.0))
@@ -320,6 +311,59 @@
 @test isequal(cosh(complex(NaN,NaN)),complex(NaN,NaN))
 
 
+# cos
+#  cos(z) = cosh(iz)
+#   i.e cos(b-ia) = cosh(a+ib)
+#   and cos(b+ia) = cosh(a-ib)
+#  cos(conj(z)) = conj(cos(z))
+#  cos(-z) = cos(z)
+
+@test isequal(cos(complex(0.0,0.0)),complex(1.0,-0.0))
+@test isequal(cos(complex(0.0,-0.0)),complex(1.0,0.0))
+@test isequal(cos(complex(-0.0,0.0)),complex(1.0,0.0))
+@test isequal(cos(complex(-0.0,-0.0)),complex(1.0,-0.0))
+
+# raise invalid flag
+@test_fails cos(complex(Inf,0.0)) #complex(NaN,-0.0)
+@test_fails cos(complex(-Inf,0.0)) #complex(NaN,0.0)
+
+@test isequal(cos(complex(NaN,0.0)),complex(NaN,0.0))
+@test isequal(cos(complex(NaN,-0.0)),complex(NaN,0.0))
+
+# raise invalid flag
+@test_fails cos(complex(Inf,5.0)) #complex(NaN,NaN)
+
+@test isequal(cos(complex(NaN,5.0)),complex(NaN,NaN))
+
+@test isequal(cos(complex(0.0,-Inf)),complex(Inf,0.0))
+@test isequal(cos(complex(-0.0,-Inf)),complex(Inf,-0.0))
+@test isequal(cos(complex(-0.0,Inf)),complex(Inf,0.0))
+@test isequal(cos(complex(0.0,Inf)),complex(Inf,-0.0))
+
+@test isequal(cos(complex(5.0,-Inf)),complex(cos(5.0)*Inf,sin(5.0)*Inf))
+@test isequal(cos(complex(-5.0,-Inf)),complex(cos(5.0)*Inf,sin(5.0)*-Inf))
+@test isequal(cos(complex(-5.0,Inf)),complex(cos(5.0)*Inf,sin(5.0)*Inf))
+@test isequal(cos(complex(5.0,Inf)),complex(cos(5.0)*Inf,sin(5.0)*-Inf))
+
+# raise invalid flag
+@test_fails cos(complex(Inf,Inf)) #complex(Inf,NaN)
+@test_fails cos(complex(Inf,-Inf)) #complex(Inf,NaN)
+@test_fails cos(complex(-Inf,-Inf)) #complex(Inf,NaN)
+@test_fails cos(complex(-Inf,Inf)) #complex(Inf,NaN)
+
+@test isequal(cos(complex(NaN,Inf)),complex(Inf,NaN))
+@test isequal(cos(complex(NaN,-Inf)),complex(Inf,NaN))
+
+@test isequal(cos(complex(0.0,NaN)),complex(NaN,0.0))
+@test isequal(cos(complex(-0.0,NaN)),complex(NaN,-0.0))
+
+@test isequal(cos(complex(5.0,NaN)),complex(NaN,NaN))
+@test isequal(cos(complex(-5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(cos(complex(NaN,NaN)),complex(NaN,NaN))
+
+
+
 
 # tanh
 #  tanh(conj(z)) = conj(tanh(z))
@@ -365,6 +409,39 @@
 @test isequal(tanh(complex(NaN,-5.0)),complex(NaN,NaN))
 
 @test isequal(tanh(complex(NaN,NaN)),complex(NaN,NaN))
+
+# tan
+#  tan(z) = -i tanh(iz)
+@test_fails tan(complex(Inf,5.0)) #complex(NaN,NaN)
+
+@test isequal(tan(complex(NaN,5.0)),complex(NaN,NaN))
+
+@test isequal(tan(complex(0.0,Inf)),complex(0.0,1.0))
+@test isequal(tan(complex(-0.0,Inf)),complex(-0.0,1.0))
+@test isequal(tan(complex(0.0,-Inf)),complex(0.0,-1.0))
+@test isequal(tan(complex(-0.0,-Inf)),complex(-0.0,-1.0))
+
+@test isequal(tan(complex(5.0,Inf)),complex(sin(2*5.0)*0.0,1.0))
+@test isequal(tan(complex(-5.0,Inf)),complex(sin(2*5.0)*-0.0,1.0))
+@test isequal(tan(complex(5.0,-Inf)),complex(sin(2*5.0)*0.0,-1.0))
+@test isequal(tan(complex(-5.0,-Inf)),complex(sin(2*5.0)*-0.0,-1.0))
+
+@test isequal(tan(complex(Inf,Inf)),complex(0.0,1.0))
+@test isequal(tan(complex(-Inf,Inf)),complex(-0.0,1.0))
+@test isequal(tan(complex(Inf,-Inf)),complex(0.0,-1.0))
+@test isequal(tan(complex(-Inf,-Inf)),complex(-0.0,-1.0))
+
+@test isequal(tan(complex(NaN,Inf)),complex(0.0,1.0))
+@test isequal(tan(complex(NaN,-Inf)),complex(0.0,-1.0))
+
+@test isequal(tan(complex(0.0,NaN)),complex(0.0,NaN))
+@test isequal(tan(complex(-0.0,NaN)),complex(-0.0,NaN))
+
+@test isequal(tan(complex(5.0,NaN)),complex(NaN,NaN))
+@test isequal(tan(complex(-5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(tan(complex(NaN,NaN)),complex(NaN,NaN))
+
 
 
 
@@ -493,6 +570,46 @@
 @test isequal(asinh(complex(NaN,NaN)),complex(NaN,NaN))
 
 
+# asin
+#  asin(z) = -i*asinh(iz)
+@test isequal(asin(complex(0.0,0.0)),complex(0.0,0.0))
+@test isequal(asin(complex(0.0,-0.0)),complex(0.0,-0.0))
+@test isequal(asin(complex(-0.0,0.0)),complex(-0.0,0.0))
+@test isequal(asin(complex(-0.0,-0.0)),complex(-0.0,-0.0))
+
+@test isequal(asin(complex(Inf,0.0)),complex(pi/2,Inf))
+@test isequal(asin(complex(-Inf,0.0)),complex(-pi/2,Inf))
+@test isequal(asin(complex(Inf,-0.0)),complex(pi/2,-Inf))
+@test isequal(asin(complex(-Inf,-0.0)),complex(-pi/2,-Inf))
+
+@test isequal(asin(complex(Inf,5.0)),complex(pi/2,Inf))
+@test isequal(asin(complex(-Inf,5.0)),complex(-pi/2,Inf))
+@test isequal(asin(complex(Inf,-5.0)),complex(pi/2,-Inf))
+@test isequal(asin(complex(-Inf,-5.0)),complex(-pi/2,-Inf))
+
+@test isequal(asin(complex(NaN,0.0)),complex(NaN,NaN))
+@test isequal(asin(complex(NaN,5.0)),complex(NaN,NaN))
+
+@test isequal(asin(complex(Inf,Inf)),complex(pi/4,Inf))
+@test isequal(asin(complex(Inf,-Inf)),complex(pi/4,-Inf))
+@test isequal(asin(complex(-Inf,Inf)),complex(-pi/4,Inf))
+@test isequal(asin(complex(-Inf,-Inf)),complex(-pi/4,-Inf))
+
+@test isequal(asin(complex(NaN,Inf)),complex(NaN,Inf))
+@test isequal(asin(complex(NaN,-Inf)),complex(NaN,-Inf))
+
+@test isequal(asin(complex(0.0,NaN)),complex(0.0,NaN))
+@test isequal(asin(complex(-0.0,NaN)),complex(-0.0,NaN))
+
+@test isequal(asin(complex(5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(asin(complex(Inf,NaN)),complex(NaN,Inf))
+@test isequal(asin(complex(-Inf,NaN)),complex(NaN,Inf))
+
+@test isequal(asin(complex(NaN,NaN)),complex(NaN,NaN))
+
+
+
 # atanh
 #  atanh(conj(z)) = conj(atanh(z))
 #  atang(-z) = -atanh(z)
@@ -544,7 +661,63 @@
 @test isequal(atanh(complex(NaN,5.0)),complex(NaN,NaN))
 @test isequal(atanh(complex(NaN,-5.0)),complex(NaN,NaN))
 
-@test isequal(atanh(complex(NaN,Inf)),complex(0,pi/2))
-@test isequal(atanh(complex(NaN,-Inf)),complex(0,-pi/2))
+@test isequal(atanh(complex(NaN,Inf)),complex(0.0,pi/2))
+@test isequal(atanh(complex(NaN,-Inf)),complex(0.0,-pi/2))
 
 @test isequal(atanh(complex(NaN,NaN)),complex(NaN,NaN))
+
+
+# atan
+#  atan(z) = -i*tanh(iz)
+
+@test isequal(atan(complex(0.0,0.0)),complex(0.0,0.0))
+@test isequal(atan(complex(0.0,-0.0)),complex(0.0,-0.0))
+@test isequal(atan(complex(-0.0,0.0)),complex(-0.0,0.0))
+@test isequal(atan(complex(-0.0,-0.0)),complex(-0.0,-0.0))
+
+@test isequal(atan(complex(NaN,0.0)),complex(NaN,0.0))
+@test isequal(atan(complex(NaN,-0.0)),complex(NaN,-0.0))
+
+# raise divide-by-zero flag
+@test isequal(atan(complex(0.0,1.0)),complex(0.0,Inf))
+
+@test isequal(atan(complex(Inf,0.0)),complex(pi/2,0.0))
+@test isequal(atan(complex(-Inf,0.0)),complex(-pi/2,0.0))
+@test isequal(atan(complex(Inf,-0.0)),complex(pi/2,-0.0))
+@test isequal(atan(complex(-Inf,-0.0)),complex(-pi/2,-0.0))
+
+@test isequal(atan(complex(Inf,5.0)),complex(pi/2,0.0))
+@test isequal(atan(complex(-Inf,5.0)),complex(-pi/2,0.0))
+@test isequal(atan(complex(Inf,-5.0)),complex(pi/2,-0.0))
+@test isequal(atan(complex(-Inf,-5.0)),complex(-pi/2,-0.0))
+
+@test isequal(atan(complex(NaN,5.0)),complex(NaN,NaN))
+@test isequal(atan(complex(NaN,-5.0)),complex(NaN,NaN))
+
+@test isequal(atan(complex(0.0,Inf)),complex(pi/2,0.0))
+@test isequal(atan(complex(-0.0,Inf)),complex(-pi/2,0.0))
+@test isequal(atan(complex(0.0,-Inf)),complex(pi/2,-0.0))
+@test isequal(atan(complex(-0.0,-Inf)),complex(-pi/2,-0.0))
+
+@test isequal(atan(complex(5.0,Inf)),complex(pi/2,0.0))
+@test isequal(atan(complex(-5.0,Inf)),complex(-pi/2,0.0))
+@test isequal(atan(complex(5.0,-Inf)),complex(pi/2,-0.0))
+@test isequal(atan(complex(-5.0,-Inf)),complex(-pi/2,-0.0))
+
+@test isequal(atan(complex(Inf,Inf)),complex(pi/2,0.0))
+@test isequal(atan(complex(Inf,-Inf)),complex(pi/2,-0.0))
+@test isequal(atan(complex(-Inf,Inf)),complex(-pi/2,0.0))
+@test isequal(atan(complex(-Inf,-Inf)),complex(-pi/2,-0.0))
+
+@test isequal(atan(complex(NaN,Inf)),complex(NaN,0.0))
+@test isequal(atan(complex(NaN,-Inf)),complex(NaN,-0.0))
+
+@test isequal(atan(complex(0.0,NaN)),complex(NaN,NaN))
+@test isequal(atan(complex(-0.0,NaN)),complex(NaN,NaN))
+@test isequal(atan(complex(5.0,NaN)),complex(NaN,NaN))
+@test isequal(atan(complex(-5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(atan(complex(Inf,NaN)),complex(pi/2,0.0))
+@test isequal(atan(complex(-Inf,NaN)),complex(-pi/2,0.0))
+
+@test isequal(atan(complex(NaN,NaN)),complex(NaN,NaN))

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,0 +1,41 @@
+
+# sqrt: 
+# tests special values from csqrt man page
+# as well as conj(sqrt(z)) = sqrt(conj(z))
+@test isequal(sqrt(complex(0.0,0.0)), complex(0.0,0.0))
+@test isequal(sqrt(complex(-0.0,0.0)), complex(0.0,0.0))
+@test isequal(sqrt(complex(0.0,-0.0)), complex(0.0,-0.0))
+@test isequal(sqrt(complex(-0.0,-0.0)), complex(0.0,-0.0))
+
+@test isequal(sqrt(complex(5.0,0.0)), complex(sqrt(5.0),0.0))
+@test isequal(sqrt(complex(5.0,-0.0)), complex(sqrt(5.0),-0.0))
+
+@test isequal(sqrt(complex(-5.0,0.0)), complex(0.0,sqrt(5.0)))
+@test isequal(sqrt(complex(-5.0,-0.0)), complex(0.0,-sqrt(5.0)))
+
+@test isequal(sqrt(complex(0.0,Inf)), complex(Inf,Inf))
+@test isequal(sqrt(complex(0.0,-Inf)), complex(Inf,-Inf))
+@test isequal(sqrt(complex(NaN,Inf)), complex(Inf,Inf))
+@test isequal(sqrt(complex(NaN,-Inf)), complex(Inf,-Inf))
+@test isequal(sqrt(complex(Inf,Inf)), complex(Inf,Inf))
+@test isequal(sqrt(complex(Inf,-Inf)), complex(Inf,-Inf))
+@test isequal(sqrt(complex(-Inf,Inf)), complex(Inf,Inf))
+@test isequal(sqrt(complex(-Inf,-Inf)), complex(Inf,-Inf))
+
+@test isequal(sqrt(complex(0.0,NaN)), complex(NaN,NaN))
+
+@test isequal(sqrt(complex(-Inf,0.0)), complex(0.0,Inf))
+@test isequal(sqrt(complex(-Inf,5.0)), complex(0.0,Inf))
+@test isequal(sqrt(complex(-Inf,-0.0)), complex(0.0,-Inf))
+@test isequal(sqrt(complex(-Inf,-5.0)), complex(0.0,-Inf))
+
+@test isequal(sqrt(complex(Inf,0.0)), complex(Inf,0.0))
+@test isequal(sqrt(complex(Inf,5.0)), complex(Inf,0.0))
+@test isequal(sqrt(complex(Inf,-0.0)), complex(Inf,-0.0))
+@test isequal(sqrt(complex(Inf,-5.0)), complex(Inf,-0.0))
+
+@test isequal(sqrt(complex(-Inf,NaN)), complex(NaN,Inf))
+@test isequal(sqrt(complex(Inf,NaN)), complex(Inf,NaN))
+
+@test isequal(sqrt(complex(NaN,0.0)), complex(NaN,NaN))
+@test isequal(sqrt(complex(NaN,0.0)), complex(NaN,NaN))

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -15,8 +15,10 @@
 
 @test isequal(sqrt(complex(0.0,Inf)), complex(Inf,Inf))
 @test isequal(sqrt(complex(0.0,-Inf)), complex(Inf,-Inf))
+
 @test isequal(sqrt(complex(NaN,Inf)), complex(Inf,Inf))
 @test isequal(sqrt(complex(NaN,-Inf)), complex(Inf,-Inf))
+
 @test isequal(sqrt(complex(Inf,Inf)), complex(Inf,Inf))
 @test isequal(sqrt(complex(Inf,-Inf)), complex(Inf,-Inf))
 @test isequal(sqrt(complex(-Inf,Inf)), complex(Inf,Inf))
@@ -51,9 +53,12 @@
 @test isequal(log(complex(0.0,-1.0)),complex(0.0,-pi/2))
 
 # special values
+
+# raise divide-by-zero flag
 @test isequal(log(complex(-0.0,0.0)), complex(-Inf,pi))
 @test isequal(log(complex(-0.0,-0.0)), complex(-Inf,-pi))
 
+# raise divide-by-zero flag
 @test isequal(log(complex(0.0,0.0)), complex(-Inf,0.0))
 @test isequal(log(complex(0.0,-0.0)), complex(-Inf,-0.0))
 
@@ -84,6 +89,48 @@
 
 @test isequal(log(complex(NaN,NaN)), complex(NaN,NaN))
 
+# exp:
+#  exp(conj(z)) = conj(exp(z))
+
+@test isequal(exp(complex(0.0,0.0)), complex(1.0,0.0))
+@test isequal(exp(complex(0.0,-0.0)), complex(1.0,-0.0))
+@test isequal(exp(complex(-0.0,0.0)), complex(1.0,0.0))
+@test isequal(exp(complex(-0.0,-0.0)), complex(1.0,-0.0))
+
+# raise invalid flag
+@test_fails exp(complex(0.0,Inf) #complex(NaN,NaN)
+@test_fails exp(complex(0.0,-Inf) #complex(NaN,NaN)
+@test_fails exp(complex(5.0,Inf) #complex(NaN,NaN)
+
+@test isequal(exp(complex(0.0,NaN)), complex(NaN,NaN))
+
+@test isequal(exp(complex(Inf,0.0)), complex(Inf,0.0))
+@test isequal(exp(complex(Inf,-0.0)), complex(Inf,-0.0))
+
+@test isequal(exp(complex(-Inf,5.0)), complex(cos(5.0)*0.0,sin(5.0)*0.0))
+@test isequal(exp(complex(-Inf,-5.0)), complex(cos(5.0)*0.0,sin(5.0)*-0.0))
+
+@test isequal(exp(complex(Inf,5.0)), complex(cos(5.0)*Inf,sin(5.0)*Inf))
+@test isequal(exp(complex(Inf,-5.0)), complex(cos(5.0)*Inf,sin(5.0)*-Inf))
+
+@test isequal(exp(complex(-Inf,Inf)), complex(-0.0,0.0))
+@test isequal(exp(complex(-Inf,-Inf)), complex(-0.0,-0.0))
+
+# raise invalid flag
+@test_fails exp(complex(Inf,Inf)) #complex(-Inf,NaN)
+@test_fails exp(complex(Inf,-Inf)) #complex(-Inf,NaN)
+
+@test isequal(exp(complex(-Inf,NaN)), complex(-0.0,0.0))
+
+@test isequal(exp(complex(Inf,NaN)), complex(-Inf,NaN))
+
+@test isequal(exp(complex(NaN,0.0)), complex(NaN,0.0))
+@test isequal(exp(complex(NaN,-0.0)), complex(NaN,-0.0))
+
+@test isequal(exp(complex(NaN,5.0)), complex(NaN,NaN))
+
+@test isequal(exp(complex(NaN,NaN)), complex(NaN,NaN))
+
 
 # sinh: has properties
 #  sinh(conj(z)) = conj(sinh(z))
@@ -94,15 +141,17 @@
 @test isequal(sinh(complex(-0.0,0.0)),complex(-0.0,0.0))
 @test isequal(sinh(complex(-0.0,-0.0)),complex(-0.0,-0.0))
 
-@test isequal(sinh(complex(0.0,Inf)),complex(0.0,NaN))
-@test isequal(sinh(complex(0.0,-Inf)),complex(0.0,NaN))
-@test isequal(sinh(complex(-0.0,Inf)),complex(-0.0,NaN))
-@test isequal(sinh(complex(-0.0,-Inf)),complex(-0.0,NaN))
+# raise invalid flag
+@test_fails sinh(complex(0.0,Inf)) #complex(0.0,NaN)
+@test_fails sinh(complex(0.0,-Inf)) #complex(0.0,NaN)
+@test_fails sinh(complex(-0.0,Inf)) #complex(-0.0,NaN)
+@test_fails sinh(complex(-0.0,-Inf)) #complex(-0.0,NaN)
 
 @test isequal(sinh(complex(0.0,NaN)),complex(0.0,NaN))
 @test isequal(sinh(complex(-0.0,NaN)),complex(-0.0,NaN))
 
-@test isequal(sinh(complex(5.0,Inf)),complex(NaN,NaN))
+# raise invalid flag
+@test_fails sinh(complex(5.0,Inf)) #complex(NaN,NaN)
 
 @test isequal(sinh(complex(5.0,NaN)),complex(NaN,NaN))
 
@@ -111,13 +160,14 @@
 @test isequal(sinh(complex(-Inf,0.0)),complex(-Inf,0.0))
 @test isequal(sinh(complex(-Inf,-0.0)),complex(-Inf,-0.0))
 
-@test isequal(sinh(complex(Inf,5.0)),complex(sign(cos(5.0))*Inf,sign(sin(5.0))*Inf))
-@test isequal(sinh(complex(-Inf,5.0)),complex(sign(cos(5.0))*-Inf,sign(sin(5.0))*Inf))
+@test isequal(sinh(complex(Inf,5.0)),complex(cos(5.0)*Inf,sin(5.0)*Inf))
+@test isequal(sinh(complex(-Inf,5.0)),complex(cos(5.0)*-Inf,sin(5.0)*Inf))
 
-@test isequal(sinh(complex(Inf,Inf)),complex(Inf,NaN))
-@test isequal(sinh(complex(Inf,-Inf)),complex(Inf,NaN))
-@test isequal(sinh(complex(-Inf,Inf)),complex(-Inf,NaN))
-@test isequal(sinh(complex(-Inf,-Inf)),complex(-Inf,NaN))
+# raise invalid flag
+@test_fails sinh(complex(Inf,Inf)) #complex(Inf,NaN)
+@test_fails sinh(complex(Inf,-Inf)) #complex(Inf,NaN)
+@test_fails sinh(complex(-Inf,Inf)) #complex(-Inf,NaN)
+@test_fails sinh(complex(-Inf,-Inf)) #complex(-Inf,NaN)
 
 @test isequal(sinh(complex(Inf,NaN)),complex(Inf,NaN))
 @test isequal(sinh(complex(-Inf,NaN)),complex(-Inf,NaN))
@@ -139,13 +189,15 @@
 @test isequal(cosh(complex(-0.0,-0.0)),complex(1.0,0.0))
 @test isequal(cosh(complex(-0.0,0.0)),complex(1.0,-0.0))
 
-@test isequal(cosh(complex(0.0,Inf)),complex(NaN,0.0))
-@test isequal(cosh(complex(0.0,-Inf)),complex(NaN,-0.0))
+# raise invalid flag
+@test_fails cosh(complex(0.0,Inf)) #complex(NaN,0.0)
+@test_fails cosh(complex(0.0,-Inf)) #complex(NaN,-0.0)
 
 @test isequal(cosh(complex(0.0,NaN)),complex(NaN,0.0))
 @test isequal(cosh(complex(-0.0,NaN)),complex(NaN,0.0))
 
-@test isequal(cosh(complex(5.0,Inf)),complex(NaN,NaN))
+# raise invalid flag
+@test_fails cosh(complex(5.0,Inf)) #complex(NaN,NaN)
 
 @test isequal(cosh(complex(5.0,NaN)),complex(NaN,NaN))
 
@@ -154,15 +206,16 @@
 @test isequal(cosh(complex(-Inf,-0.0)),complex(Inf,0.0))
 @test isequal(cosh(complex(-Inf,0.0)),complex(Inf,-0.0))
 
-@test isequal(cosh(complex(Inf,5.0)),complex(sign(cos(5.0))*Inf,sign(sin(5.0))*Inf))
-@test isequal(cosh(complex(Inf,-5.0)),complex(sign(cos(5.0))*Inf,sign(sin(5.0))*-Inf))
-@test isequal(cosh(complex(-Inf,-5.0)),complex(sign(cos(5.0))*Inf,sign(sin(5.0))*Inf))
-@test isequal(cosh(complex(-Inf,5.0)),complex(sign(cos(5.0))*Inf,sign(sin(5.0))*-Inf))
+@test isequal(cosh(complex(Inf,5.0)),complex(cos(5.0)*Inf,sin(5.0)*Inf))
+@test isequal(cosh(complex(Inf,-5.0)),complex(cos(5.0)*Inf,sin(5.0)*-Inf))
+@test isequal(cosh(complex(-Inf,-5.0)),complex(cos(5.0)*Inf,sin(5.0)*Inf))
+@test isequal(cosh(complex(-Inf,5.0)),complex(cos(5.0)*Inf,sin(5.0)*-Inf))
 
-@test isequal(cosh(complex(Inf,Inf)),complex(Inf,NaN))
-@test isequal(cosh(complex(Inf,-Inf)),complex(Inf,NaN))
-@test isequal(cosh(complex(-Inf,-Inf)),complex(Inf,NaN))
-@test isequal(cosh(complex(-Inf,Inf)),complex(Inf,NaN))
+# raise invalid flag
+@test_fails cosh(complex(Inf,Inf)) #complex(Inf,NaN)
+@test_fails cosh(complex(Inf,-Inf)) #complex(Inf,NaN)
+@test_fails cosh(complex(-Inf,-Inf)) #complex(Inf,NaN)
+@test_fails cosh(complex(-Inf,Inf)) #complex(Inf,NaN)
 
 @test isequal(cosh(complex(Inf,NaN)),complex(Inf,NaN))
 @test isequal(cosh(complex(-Inf,NaN)),complex(Inf,NaN))
@@ -175,3 +228,49 @@
 
 @test isequal(cosh(complex(NaN,NaN)),complex(NaN,NaN))
 
+
+
+# tanh
+#  tanh(conj(z)) = conj(tanh(z))
+#  tanh(-z) = -tanh(z)
+@test isequal(tanh(complex(0.0,0.0)),complex(0.0,0.0))
+@test isequal(tanh(complex(0.0,-0.0)),complex(0.0,-0.0))
+@test isequal(tanh(complex(-0.0,0.0)),complex(-0.0,0.0))
+@test isequal(tanh(complex(-0.0,-0.0)),complex(-0.0,-0.0))
+
+# raise invalid flag
+@test_fails tanh(complex(0.0,Inf)) #complex(NaN,0.0)
+@test_fails tanh(complex(0.0,-Inf)) #complex(NaN,-0.0)
+
+@test isequal(tanh(complex(0.0,NaN)),complex(NaN,NaN))
+
+# raise invalid flag
+@test_fails tanh(complex(5.0,Inf)) #complex(NaN,NaN)
+
+@test isequal(tanh(complex(5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(tanh(complex(Inf,0.0)),complex(1.0,0.0))
+@test isequal(tanh(complex(Inf,-0.0)),complex(1.0,-0.0))
+@test isequal(tanh(complex(-Inf,0.0)),complex(-1.0,0.0))
+@test isequal(tanh(complex(-Inf,-0.0)),complex(-1.0,-0.0))
+
+@test isequal(tanh(complex(Inf,5.0)),complex(1.0,sin(2*5.0)*0.0))
+@test isequal(tanh(complex(Inf,-5.0)),complex(1.0,sin(2*5.0)*-0.0))
+@test isequal(tanh(complex(-Inf,5.0)),complex(-1.0,sin(2*5.0)*0.0))
+@test isequal(tanh(complex(-Inf,-5.0)),complex(-1.0,sin(2*5.0)*-0.0))
+
+@test isequal(tanh(complex(Inf,Inf)),complex(1.0,0.0))
+@test isequal(tanh(complex(Inf,-Inf)),complex(1.0,-0.0))
+@test isequal(tanh(complex(-Inf,Inf)),complex(-1.0,0.0))
+@test isequal(tanh(complex(-Inf,-Inf)),complex(-1.0,-0.0))
+
+@test isequal(tanh(complex(Inf,NaN)),complex(1.0,0.0))
+@test isequal(tanh(complex(-Inf,NaN)),complex(-1.0,0.0))
+
+@test isequal(tanh(complex(NaN,0.0)),complex(NaN,0.0))
+@test isequal(tanh(complex(NaN,-0.0)),complex(NaN,-0.0))
+
+@test isequal(tanh(complex(NaN,5.0)),complex(NaN,NaN))
+@test isequal(tanh(complex(NaN,-5.0)),complex(NaN,NaN))
+
+@test isequal(tanh(complex(NaN,NaN)),complex(NaN,NaN))

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -39,3 +39,139 @@
 
 @test isequal(sqrt(complex(NaN,0.0)), complex(NaN,NaN))
 @test isequal(sqrt(complex(NaN,0.0)), complex(NaN,NaN))
+
+
+
+# log: 
+#  log(conj(z)) = conj(log(z))
+@test isequal(log(complex(5.0,0.0)),complex(log(5.0),0.0))
+@test isequal(log(complex(5.0,-0.0)),complex(log(5.0),-0.0))
+
+@test isequal(log(complex(0.0,1.0)),complex(0.0,pi/2))
+@test isequal(log(complex(0.0,-1.0)),complex(0.0,-pi/2))
+
+# special values
+@test isequal(log(complex(-0.0,0.0)), complex(-Inf,pi))
+@test isequal(log(complex(-0.0,-0.0)), complex(-Inf,-pi))
+
+@test isequal(log(complex(0.0,0.0)), complex(-Inf,0.0))
+@test isequal(log(complex(0.0,-0.0)), complex(-Inf,-0.0))
+
+@test isequal(log(complex(0.0,Inf)), complex(Inf,pi/2))
+@test isequal(log(complex(0.0,-Inf)), complex(Inf,-pi/2))
+
+@test isequal(log(complex(0.0,NaN)), complex(NaN,NaN))
+
+@test isequal(log(complex(-Inf,5.0)), complex(Inf,pi))
+@test isequal(log(complex(-Inf,-5.0)), complex(Inf,-pi))
+
+@test isequal(log(complex(Inf,5.0)), complex(Inf,0.0))
+@test isequal(log(complex(Inf,-5.0)), complex(Inf,-0.0))
+
+@test isequal(log(complex(-Inf,Inf)), complex(Inf,3*pi/4))
+@test isequal(log(complex(-Inf,-Inf)), complex(Inf,-3*pi/4))
+
+@test isequal(log(complex(Inf,Inf)), complex(Inf,pi/4))
+@test isequal(log(complex(Inf,-Inf)), complex(Inf,-pi/4))
+
+@test isequal(log(complex(Inf,NaN)), complex(Inf,NaN))
+@test isequal(log(complex(-Inf,NaN)), complex(Inf,NaN))
+
+@test isequal(log(complex(NaN,0.0)), complex(NaN,NaN))
+
+@test isequal(log(complex(NaN,Inf)), complex(Inf,NaN))
+@test isequal(log(complex(NaN,-Inf)), complex(Inf,NaN))
+
+@test isequal(log(complex(NaN,NaN)), complex(NaN,NaN))
+
+
+# sinh: has properties
+#  sinh(conj(z)) = conj(sinh(z))
+#  sinh(-z) = -sinh(z)
+
+@test isequal(sinh(complex(0.0,0.0)),complex(0.0,0.0))
+@test isequal(sinh(complex(0.0,-0.0)),complex(0.0,-0.0))
+@test isequal(sinh(complex(-0.0,0.0)),complex(-0.0,0.0))
+@test isequal(sinh(complex(-0.0,-0.0)),complex(-0.0,-0.0))
+
+@test isequal(sinh(complex(0.0,Inf)),complex(0.0,NaN))
+@test isequal(sinh(complex(0.0,-Inf)),complex(0.0,NaN))
+@test isequal(sinh(complex(-0.0,Inf)),complex(-0.0,NaN))
+@test isequal(sinh(complex(-0.0,-Inf)),complex(-0.0,NaN))
+
+@test isequal(sinh(complex(0.0,NaN)),complex(0.0,NaN))
+@test isequal(sinh(complex(-0.0,NaN)),complex(-0.0,NaN))
+
+@test isequal(sinh(complex(5.0,Inf)),complex(NaN,NaN))
+
+@test isequal(sinh(complex(5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(sinh(complex(Inf,0.0)),complex(Inf,0.0))
+@test isequal(sinh(complex(Inf,-0.0)),complex(Inf,-0.0))
+@test isequal(sinh(complex(-Inf,0.0)),complex(-Inf,0.0))
+@test isequal(sinh(complex(-Inf,-0.0)),complex(-Inf,-0.0))
+
+@test isequal(sinh(complex(Inf,5.0)),complex(sign(cos(5.0))*Inf,sign(sin(5.0))*Inf))
+@test isequal(sinh(complex(-Inf,5.0)),complex(sign(cos(5.0))*-Inf,sign(sin(5.0))*Inf))
+
+@test isequal(sinh(complex(Inf,Inf)),complex(Inf,NaN))
+@test isequal(sinh(complex(Inf,-Inf)),complex(Inf,NaN))
+@test isequal(sinh(complex(-Inf,Inf)),complex(-Inf,NaN))
+@test isequal(sinh(complex(-Inf,-Inf)),complex(-Inf,NaN))
+
+@test isequal(sinh(complex(Inf,NaN)),complex(Inf,NaN))
+@test isequal(sinh(complex(-Inf,NaN)),complex(-Inf,NaN))
+
+@test isequal(sinh(complex(NaN,0.0)),complex(NaN,0.0))
+@test isequal(sinh(complex(NaN,-0.0)),complex(NaN,-0.0))
+
+@test isequal(sinh(complex(NaN,5.0)),complex(NaN,NaN))
+
+@test isequal(sinh(complex(NaN,NaN)),complex(NaN,NaN))
+
+
+# cosh: has properties
+#  cosh(conj(z)) = conj(cosh(z))
+#  coshh(-z) = cosh(z)
+
+@test isequal(cosh(complex(0.0,0.0)),complex(1.0,0.0))
+@test isequal(cosh(complex(0.0,-0.0)),complex(1.0,-0.0))
+@test isequal(cosh(complex(-0.0,-0.0)),complex(1.0,0.0))
+@test isequal(cosh(complex(-0.0,0.0)),complex(1.0,-0.0))
+
+@test isequal(cosh(complex(0.0,Inf)),complex(NaN,0.0))
+@test isequal(cosh(complex(0.0,-Inf)),complex(NaN,-0.0))
+
+@test isequal(cosh(complex(0.0,NaN)),complex(NaN,0.0))
+@test isequal(cosh(complex(-0.0,NaN)),complex(NaN,0.0))
+
+@test isequal(cosh(complex(5.0,Inf)),complex(NaN,NaN))
+
+@test isequal(cosh(complex(5.0,NaN)),complex(NaN,NaN))
+
+@test isequal(cosh(complex(Inf,0.0)),complex(Inf,0.0))
+@test isequal(cosh(complex(Inf,-0.0)),complex(Inf,-0.0))
+@test isequal(cosh(complex(-Inf,-0.0)),complex(Inf,0.0))
+@test isequal(cosh(complex(-Inf,0.0)),complex(Inf,-0.0))
+
+@test isequal(cosh(complex(Inf,5.0)),complex(sign(cos(5.0))*Inf,sign(sin(5.0))*Inf))
+@test isequal(cosh(complex(Inf,-5.0)),complex(sign(cos(5.0))*Inf,sign(sin(5.0))*-Inf))
+@test isequal(cosh(complex(-Inf,-5.0)),complex(sign(cos(5.0))*Inf,sign(sin(5.0))*Inf))
+@test isequal(cosh(complex(-Inf,5.0)),complex(sign(cos(5.0))*Inf,sign(sin(5.0))*-Inf))
+
+@test isequal(cosh(complex(Inf,Inf)),complex(Inf,NaN))
+@test isequal(cosh(complex(Inf,-Inf)),complex(Inf,NaN))
+@test isequal(cosh(complex(-Inf,-Inf)),complex(Inf,NaN))
+@test isequal(cosh(complex(-Inf,Inf)),complex(Inf,NaN))
+
+@test isequal(cosh(complex(Inf,NaN)),complex(Inf,NaN))
+@test isequal(cosh(complex(-Inf,NaN)),complex(Inf,NaN))
+
+@test isequal(cosh(complex(NaN,0.0)),complex(NaN,0.0))
+@test isequal(cosh(complex(NaN,-0.0)),complex(NaN,-0.0))
+
+@test isequal(cosh(complex(NaN,5.0)),complex(NaN,NaN))
+@test isequal(cosh(complex(NaN,-5.0)),complex(NaN,NaN))
+
+@test isequal(cosh(complex(NaN,NaN)),complex(NaN,NaN))
+

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -149,9 +149,23 @@
 #  equivalent to exp(y*log(x))
 #    except for 0^0?
 #  conj(x)^conj(y) = conj(x^y)
-@test isequal(complex(0.0,0.0)^complex(0.0,0.0), complex(1.0,0.0))
+@test isequal(complex(0.0,0.0)^complex(0.0,0.0), complex(1.0,-0.0))
+@test isequal(complex(0.0,-0.0)^complex(0.0,0.0), complex(1.0,-0.0))
+@test isequal(complex(0.0,0.0)^complex(0.0,-0.0), complex(1.0,0.0))
+@test isequal(complex(0.0,-0.0)^complex(0.0,-0.0), complex(1.0,0.0))
+@test isequal(complex(-0.0,0.0)^complex(0.0,0.0), complex(1.0,-0.0))
+@test isequal(complex(-0.0,-0.0)^complex(0.0,0.0), complex(1.0,-0.0))
+@test isequal(complex(-0.0,0.0)^complex(0.0,-0.0), complex(1.0,0.0))
+@test isequal(complex(-0.0,-0.0)^complex(0.0,-0.0), complex(1.0,0.0))
+@test isequal(complex(0.0,0.0)^complex(-0.0,0.0), complex(1.0,-0.0))
+@test isequal(complex(0.0,-0.0)^complex(-0.0,0.0), complex(1.0,-0.0))
+@test isequal(complex(0.0,0.0)^complex(-0.0,-0.0), complex(1.0,0.0))
+@test isequal(complex(0.0,-0.0)^complex(-0.0,-0.0), complex(1.0,0.0))
+@test isequal(complex(-0.0,0.0)^complex(-0.0,0.0), complex(1.0,-0.0))
+@test isequal(complex(-0.0,-0.0)^complex(-0.0,0.0), complex(1.0,-0.0))
+@test isequal(complex(-0.0,0.0)^complex(-0.0,-0.0), complex(1.0,0.0))
+@test isequal(complex(-0.0,-0.0)^complex(-0.0,-0.0), complex(1.0,0.0))
 
-@test isequal(complex(0.0,-0.0)^complex(0.0,-0.0), complex(1.0,-0.0))
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ testnames = ["core", "keywordargs", "numbers", "strings", "unicode", "corelib",
              "bigint", "sorting", "statistics", "spawn", "parallel",
              "arpack", "bigfloat", "file", "zlib", "perf", "suitesparse"]
 
+# Disabled: "complex"
+
 if ARGS == ["all"]
     tests = testnames
 else


### PR DESCRIPTION
I've started adding some tests for complex valued functions, to deal with branch cut issues (see #2843).

Currently just has tests for `sqrt`. All tests are taken from the [mac `csqrt` man page](http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man3/csqrtf.3.html) (it was the most specific).

Some of these tests currently fail (which I guess is the point of doing them). I'm happy to add more functions (log, trig/inverse trig, etc.).
