### PR TITLE
RFC: Convert Array to binary representation

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -305,6 +305,13 @@ function digits{T<:Integer}(n::Integer, base::T=10, pad::Int=1)
     return a
 end
 
+function array2binary{T<:Integer}(a::Array{T},num_bits::Int)
+    am = size(a,1)
+    an = size(a,2)
+    b = mapreduce( (x) -> digits(x, 2, num_bits), vcat, a)
+    reshape(permutedims(reshape(b, num_bits, am, an), [2 1 3]), am, num_bits*an);
+end
+
 const PRIMES = [
     2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
     73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151,

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -305,7 +305,7 @@ function digits{T<:Integer}(n::Integer, base::T=10, pad::Int=1)
     return a
 end
 
-function array2binary{T<:Integer}(a::Array{T},num_bits::Int)
+function array2binary{T<:Integer}(a::VecOrMat{T},num_bits::Int)
     am = size(a,1)
     an = size(a,2)
     b = mapreduce( (x) -> digits(x, 2, num_bits), vcat, a)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1721,6 +1721,12 @@ Mathematical Functions
 .. function:: ndigits(n, b)
 
    Compute the number of digits in number ``n`` written in base ``b``.
+   
+.. function:: array2binary(A,pad)
+
+   Convert Integer Array to binary representation, each number uses ``pad`` bits.
+   
+   **Example**: ``array2binary([1 2; 3 4], 3) ==[1 0 0 0 1 0; 1 1 0 0 0 1]``
 
 Data Formats
 ------------


### PR DESCRIPTION
This is Matlab's `toBinary()`, it exists in Matlab's `biterr()`. Needed in Communication.
However, Maybe we should implement a `digits()` for Array too, corresponding to Matlab's `de2bi()`?

At the moment, Julia's digits() only applies to number.
