### PR TITLE
Portuguese documentation should now work without the /en/latest

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,5 +19,5 @@ Translations
 ============
 
 * `简体中文 <http://julia-zh-cn.readthedocs.org/>`_
-* `Português brasileiro <http://julia-pt-br.readthedocs.org/en/latest/>`_
+* `Português brasileiro <http://julia-pt-br.readthedocs.org/>`_
 * `Español latino <http://julia-es-la.readthedocs.org/>`_


### PR DESCRIPTION
Now the three links to translations are standardized.
