### PR TITLE
Speed up convolution. 

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@ JULIAHOME = $(abspath ..)
 include ../Make.inc
 
 TESTS = core keywordargs numbers strings unicode corelib hashing remote iostring \
-arrayops linalg blas fft dct sparse bitarray random math functional bigint \
+arrayops linalg blas fft dsp sparse bitarray random math functional bigint \
 sorting statistics spawn parallel arpack bigfloat file zlib all git pkg pkg2 suitesparse
 
 $(TESTS) ::

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -1,3 +1,9 @@
+# Convolution
+a = [1., 2., 1., 2.]
+b = [1., 2., 3.]
+@test_approx_eq conv(a, b) [1., 4., 8., 10., 7., 6.]
+@test_approx_eq conv(complex(a, ones(4)), complex(b)) complex([1., 4., 8., 10., 7., 6.], [1. 3. 6. 6. 5. 3.])
+
 # Discrete cosine transform (DCT) tests
 
 a = rand(8,11) + im*rand(8,11)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 testnames = ["core", "keywordargs", "numbers", "strings", "unicode", "corelib",
              "hashing", "remote", "iostring", "arrayops", "linalg", "blas",
-             "fft", "dct", "sparse", "bitarray", "random", "math", "functional",
+             "fft", "dsp", "sparse", "bitarray", "random", "math", "functional",
              "bigint", "sorting", "statistics", "spawn", "parallel",
              "arpack", "bigfloat", "file", "zlib", "perf", "suitesparse"]
 


### PR DESCRIPTION
Pad vectors such that the length is product of small primes and use `rfft` for real convolution. Rename dct tests to dsp and add convolution tests.
