### PR TITLE
Pkg.add_local(paths_to_local_repos)

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -185,7 +185,7 @@ end
             pkgname = pkgname[1:end-3]
         end
 
-        run(`ln -s $pkg $(string(d, "/", pkgname))`)
+        run(`ln -s $pkg $(joinpath(d, pkgname))`)
     end
 end
 

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -175,13 +175,12 @@ function add(pkgs::Union(String,VersionSet)...)
     add(pkgs_)
 end
 
-add_local(pkgs::String...) = cd_pkgdir() do
+@unix_only add_local(pkgs::String...) = cd_pkgdir() do
     d = dir()
     for pkg in pkgs
         !isdir(d) && error("No package at $pkg.")
 
         pkgname = last(split(pkg, '/'))
-        println(pkgname)
         if endswith(pkg, ".jl")
             pkgname = pkgname[1:end-3]
         end

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -175,6 +175,21 @@ function add(pkgs::Union(String,VersionSet)...)
     add(pkgs_)
 end
 
+add_local(pkgs::String...) = cd_pkgdir() do
+    d = dir()
+    for pkg in pkgs
+        !isdir(d) && error("No package at $pkg.")
+
+        pkgname = last(split(pkg, '/'))
+        println(pkgname)
+        if endswith(pkg, ".jl")
+            pkgname = pkgname[1:end-3]
+        end
+
+        run(`ln -s $pkg $(string(d, "/", pkgname))`)
+    end
+end
+
 rm(pkgs::Vector{String}) = cd_pkgdir() do
     run(`git add REQUIRE`)
     try


### PR DESCRIPTION
In the Julia package documentation it mentions using a symlink to easily add local repositories... maybe a little helper function is in order?

Personally I'd use this often and it would spare me recalling symbolic link syntax and remembering to remove the ".jl" from the end of my package repo name.

Just a thought...
