### PR TITLE
Try to find modules in PACKAGE-NAME.jl as well

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -19,6 +19,8 @@ function find_in_path(name::String)
         is_file_readable(path) && return abspath(path)
         path = string(prefix,"/",name)
         is_file_readable(path) && return abspath(path)
+        path = string(prefix,"/",name,"/src/",name)
+        is_file_readable(path) && return abspath(path)
     end
     return abspath(name)
 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -10,16 +10,16 @@ function find_in_path(name::String)
     isfile(name) && return abspath(name)
     base = name
     if endswith(name,".jl")
-        base = match(r"^(.*)\.jl$",name).captures[1]
+        base = name[1:end-3]
     else
         name = string(base,".jl")
     end
     for prefix in LOAD_PATH
-        path = string(prefix,"/",base,"/src/",name)
+        path = joinpath(prefix, name)
         is_file_readable(path) && return abspath(path)
-        path = string(prefix,"/",name)
+        path = joinpath(prefix, base, "src", name)
         is_file_readable(path) && return abspath(path)
-        path = string(prefix,"/",name,"/src/",name)
+        path = joinpath(prefix, name, "src", name)
         is_file_readable(path) && return abspath(path)
     end
     return abspath(name)


### PR DESCRIPTION
This adds a case to `find_in_path` that attempts to find directories appended with ".jl" as well.

The trend seems to be naming package repositories as PACKAGE-NAME.jl, but you then had to clone packages to a local directory stripped of the ".jl" so that files could be found.

No more!
