### PR TITLE
Add in USE_SYSTEM_LIBUV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - sudo apt-get install zlib1g-dev
     - sudo add-apt-repository ppa:staticfloat/julia-deps -y
     - sudo apt-get update -qq -y
-    - sudo apt-get install patchelf gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libreadline-dev libdouble-conversion-dev libopenlibm-dev librmath-dev libuv-dev -y
+    - sudo apt-get install patchelf gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libreadline-dev libdouble-conversion-dev libopenlibm-dev librmath-dev libuv-julia-dev -y
 script:
     - make $BUILDOPTS PREFIX=/tmp/julia install
     - cd .. && mv julia julia2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ compiler:
 notifications:
     email: false
 before_install:
-    - BUILDOPTS="LLVM_CONFIG=llvm-config-3.2 USE_QUIET=0 USE_LIB64=0"; for lib in LLVM ZLIB SUITESPARSE ARPACK BLAS FFTW LAPACK GMP PCRE LIBUNWIND READLINE GRISU OPENLIBM RMATH; do export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1"; done
+    - BUILDOPTS="LLVM_CONFIG=llvm-config-3.2 USE_QUIET=0 USE_LIB64=0"; for lib in LLVM ZLIB SUITESPARSE ARPACK BLAS FFTW LAPACK GMP PCRE LIBUNWIND READLINE GRISU OPENLIBM RMATH LIBUV; do export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1"; done
     - sudo apt-get update -qq -y
     - sudo apt-get install zlib1g-dev
     - sudo add-apt-repository ppa:staticfloat/julia-deps -y
     - sudo apt-get update -qq -y
-    - sudo apt-get install patchelf gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libreadline-dev libdouble-conversion-dev libopenlibm-dev librmath-dev -y
+    - sudo apt-get install patchelf gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libreadline-dev libdouble-conversion-dev libopenlibm-dev librmath-dev libuv-dev -y
 script:
     - make $BUILDOPTS PREFIX=/tmp/julia install
     - cd .. && mv julia julia2

--- a/Make.inc
+++ b/Make.inc
@@ -247,7 +247,7 @@ LIBMNAME = libopenlibm
 endif
 
 ifeq ($(USE_SYSTEM_LIBUV), 1)
-  LIBUV = /usr/lib/libuv.a
+  LIBUV = /usr/lib/libuv-julia.a
   LIBUV_INC = /usr/include
 else
   LIBUV = $(BUILD)/lib/libuv.a

--- a/Make.inc
+++ b/Make.inc
@@ -165,6 +165,7 @@ USE_SYSTEM_SUITESPARSE=0
 USE_SYSTEM_ZLIB=0
 USE_SYSTEM_GRISU=0
 USE_SYSTEM_RMATH=0
+USE_SYSTEM_LIBUV=0
 
 ifeq (exists, $(shell [ -e $(JULIAHOME)/Make.user ] && echo exists ))
 include $(JULIAHOME)/Make.user
@@ -243,6 +244,14 @@ LIBMNAME = libm
 else
 LIBM = -lopenlibm
 LIBMNAME = libopenlibm
+endif
+
+ifeq ($(USE_SYSTEM_LIBUV), 1)
+  LIBUV = /usr/lib/libuv.a
+  LIBUV_INC = /usr/include
+else
+  LIBUV = $(BUILD)/lib/libuv.a
+  LIBUV_INC = $(JULIAHOME)/deps/libuv/include
 endif
 
 ifeq ($(USE_MKL), 1)

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,11 @@ install: release
 	-for suffix in $(JL_PRIVATE_LIBS) ; do \
 		cp -a $(BUILD)/lib/lib$${suffix}*.$(SHLIB_EXT)* $(PREFIX)/$(JL_PRIVATE_LIBDIR) ; \
 	done
+ifeq ($(USE_SYSTEM_LIBUV),0)
 	cp -a $(BUILD)/lib/libuv.a $(PREFIX)/$(JL_PRIVATE_LIBDIR)
-	cp -a src/julia.h $(BUILD)/include/uv* $(PREFIX)/include/julia
+	cp -a $(BUILD)/include/uv* $(PREFIX)/include/julia
+endif
+	cp -a src/julia.h $(PREFIX)/include/julia
 	# Copy system image
 	cp $(BUILD)/$(JL_PRIVATE_LIBDIR)/sys.ji $(PREFIX)/$(JL_PRIVATE_LIBDIR)
 	# Copy in all .jl sources as well

--- a/base/Makefile
+++ b/base/Makefile
@@ -15,7 +15,7 @@ file_constants.jl: ../src/file_constants.h
 	$(QUIET_PERL) ${CC} -E -P -DJULIA ../src/file_constants.h | perl -nle 'print "$$1 0o$$2" if /^(\s*const\s+[A-z_]+\s+=)\s+(0[0-9]*)\s*$$/; print "$$1" if /^\s*(const\s+[A-z_]+\s+=\s+([1-9]|0x)[0-9A-z]*)\s*$$/' > $@
 
 uv_constants.jl: ../src/uv_constants.h
-	$(QUIET_PERL) ${CC} -E -P -I"../deps/libuv/include" -DJULIA ../src/uv_constants.h | tail -n 5 > $@
+	$(QUIET_PERL) ${CC} -E -P "-I$(LIBUV_INC)" -DJULIA ../src/uv_constants.h | tail -n 5 > $@
 
 build_h.jl: ../Make.inc ../src/os_detect.h
 	$(QUIET_PERL) $(CC) -E -P -DJULIA ../src/os_detect.h | grep OS_NAME > $@

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -25,9 +25,13 @@ endif
 # prevent installing libs into usr/lib64 on opensuse
 unexport CONFIG_SITE
 
-STAGE1_DEPS = uv random double-conversion
+STAGE1_DEPS = random double-conversion
 STAGE2_DEPS =
 STAGE3_DEPS = suitesparse-wrapper
+
+ifeq ($(USE_SYSTEM_LIBUV), 0)
+STAGE1_DEPS += uv
+endif
 
 ifeq ($(USE_SYSTEM_RMATH), 0)
 STAGE1_DEPS += Rmath

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,9 +13,9 @@ FLAGS = \
 	-Wall -Wno-strict-aliasing -fno-omit-frame-pointer \
 	-Iflisp -Isupport -fvisibility=hidden -fno-common \
 	-I$(shell $(LLVM_CONFIG) --includedir) \
-	-I$(JULIAHOME)/deps/libuv/include -I$(JULIAHOME)/usr/include
+	-I$(LIBUV_INC) -I$(JULIAHOME)/usr/include
 
-LIBS = $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a -L$(BUILD)/lib $(BUILD)/lib/libuv.a $(shell $(LLVM_CONFIG) --libs) $(NO_WHOLE_ARCHIVE) $(shell $(LLVM_CONFIG) --ldflags) $(OSLIBS)
+LIBS = $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a -L$(BUILD)/lib $(LIBUV) $(shell $(LLVM_CONFIG) --libs) $(NO_WHOLE_ARCHIVE) $(shell $(LLVM_CONFIG) --ldflags) $(OSLIBS)
 
 ifneq ($(MAKECMDGOALS),debug)
 TARGET =
@@ -40,7 +40,7 @@ default: release
 
 release debug: %: libjulia-%
 
-HEADERS = julia.h $(wildcard support/*.h) $(JULIAHOME)/deps/libuv/include/uv.h
+HEADERS = julia.h $(wildcard support/*.h) $(LIBUV_INC)/uv.h
 
 %.o: %.c $(HEADERS)
 	$(QUIET_CC) $(CC) $(CPPFLAGS) $(CFLAGS) $(SHIPFLAGS) -c $< -o $@
@@ -69,7 +69,7 @@ support/libsupport.a: support/*.h support/*.c
 flisp/libflisp.a: flisp/*.h flisp/*.c support/libsupport.a
 	$(MAKE) -C flisp
 
-$(BUILD)/$(JL_LIBDIR)/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a $(BUILD)/lib/libuv.a
+$(BUILD)/$(JL_LIBDIR)/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a $(LIBUV)
 	$(QUIET_LINK) $(CXX) $(DEBUGFLAGS) $(DOBJS) $(RPATH_ORIGIN) -shared -o $@ $(LDFLAGS) $(LIBS)
 	$(INSTALL_NAME_CMD)libjulia-debug.$(SHLIB_EXT) $@
 libjulia-debug.a: julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
@@ -83,7 +83,7 @@ else
   SONAME =
 endif
 
-$(BUILD)/$(JL_LIBDIR)/libjulia-release.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a $(BUILD)/lib/libuv.a
+$(BUILD)/$(JL_LIBDIR)/libjulia-release.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a $(LIBUV)
 	$(QUIET_LINK) $(CXX) $(SHIPFLAGS) $(OBJS) $(RPATH_ORIGIN) -shared -o $@ $(LDFLAGS) $(LIBS) $(SONAME)
 	$(INSTALL_NAME_CMD)libjulia-release.$(SHLIB_EXT) $@
 libjulia-release.a: julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -14,7 +14,7 @@ SRCS = flisp.c builtins.c string.c equalhash.c table.c iostream.c \
 OBJS = $(SRCS:%.c=%.o)
 DOBJS = $(SRCS:%.c=%.do)
 LLTDIR = ../support
-LLT = $(LLTDIR)/libsupport.a $(BUILD)/lib/libuv.a
+LLT = $(LLTDIR)/libsupport.a $(LIBUV)
 
 FLAGS = -Wall -Wno-strict-aliasing -I$(LLTDIR) $(CFLAGS) \
 	-DUSE_COMPUTED_GOTO $(HFILEDIRS:%=-I%) $(LIBDIRS:%=-L%) -fvisibility=hidden
@@ -33,7 +33,7 @@ release: $(EXENAME)
 
 debug: $(EXENAME)-debug
 
-HEADERS = $(wildcard *.h) $(JULIAHOME)/deps/libuv/include/uv.h
+HEADERS = $(wildcard *.h) $(LIBUV_INC)/uv.h
 
 %.o: %.c $(HEADERS)
 	$(QUIET_CC) $(CC) $(CPPFLAGS) $(SHIPFLAGS) -c $< -o $@


### PR DESCRIPTION
- Adds in makefile macros for LIBUV resources to allow for a nonexistant deps/libuv folder
- Adds libuv-dev package installation in Travis
- Incidentally, allows compilation with a completely missing `deps/libuv`, if `libuv-dev` is installed from distro. :)
