### PR TITLE
Fix contains(String, String) by adding a method for that type

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -176,6 +176,8 @@ search(s::String, c::Chars) = search(s,c,start(s))
 
 contains(s::String, c::Char) = (search(s,c)!=0)
 
+contains(s::String, substring::String) = ismatch(Regex(substring),s)
+
 function search(s::String, t::String, i::Integer)
     if isempty(t)
         return 1 <= i <= endof(s)+1 ? (i:i-1) :


### PR DESCRIPTION
`contains(String,String)` is currently aways false, because it refers to `contains(itr,x) at reduce.jl:173`. Each element of the iterated string is a char, which is never `isequal` to a string.

This changes `contains(String,String)` to match the behavior most languages have, where it checks if one string contains a substring.
