### PR TITLE
Added missing #bracket rule to top level patterns

### DIFF
--- a/contrib/Julia.tmbundle/Syntaxes/Julia.tmLanguage
+++ b/contrib/Julia.tmbundle/Syntaxes/Julia.tmLanguage
@@ -21,6 +21,10 @@
 	<array>
 		<dict>
 			<key>include</key>
+			<string>#bracket</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#function_decl</string>
 		</dict>
 		<dict>


### PR DESCRIPTION
We had a bracket rule, but it wasn't included in the top level patterns, so they weren't getting matched. For whatever reason, this was leading to syntax highlighting to stop altogether after enough square brackets (try putting > 125 square brackets in a .jl file). Adding the #bracket rule solves this.
