### PR TITLE
Fix select!([1,2],1)

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -69,6 +69,10 @@ issorted             (itr)            = issorted(itr, Forward())
 function select!(v::AbstractVector, k::Int, lo::Int, hi::Int, o::Ordering)
     lo <= k <= hi || error("select index $k is out of range $lo:$hi")
     while lo < hi
+        if hi-lo == 1 
+            lt(o, v[hi], v[lo]) && ((v[lo],v[hi]) = (v[hi], v[lo]))
+            return v[k]
+        end
         pivot = v[(lo+hi)>>>1]
         i, j = lo, hi
         while true


### PR DESCRIPTION
This came up on julia-user earlier today, and is rather subtle.  The minimal test case is

``` julia
select!([1,2],1)
```

which fails because the pivot ends up being the first element, and one of the index variables can then become zero.  

More generally, this bug occurs whenever the select range is the first two elements of an array.  `Quicksort` gets around this by using `InsertionSort` for small arrays.  

~~It's unclear to me how much overhead is introduced by the `sort2` call or if it is inlined, so feel free to make a better fix.~~ Inlined manually, as prompted by @ViralBShah.
