### PR TITLE
WINDOWS: fix #1822 (aligned malloc)

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -231,7 +231,7 @@ jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data, size_t nel,
 
     if (own_buffer) {
         a->ismalloc = 1;
-        jl_array_data_owner(a) = (jl_value_t*)jl_gc_acquire_buffer(data,nel*elsz);
+        jl_array_data_owner(a) = (jl_value_t*)jl_gc_acquire_buffer(data,nel*elsz,0);
     }
     else {
         a->ismalloc = 0;
@@ -277,7 +277,7 @@ jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data, jl_tuple_t *dims,
 
     if (own_buffer) {
         a->ismalloc = 1;
-        jl_array_data_owner(a) = (jl_value_t*)jl_gc_acquire_buffer(data,nel*elsz);
+        jl_array_data_owner(a) = (jl_value_t*)jl_gc_acquire_buffer(data,nel*elsz,0);
     }
     else {
         a->ismalloc = 0;

--- a/src/julia.h
+++ b/src/julia.h
@@ -86,6 +86,9 @@ typedef struct _jl_mallocptr_t {
     struct _jl_mallocptr_t *next;
     size_t sz;
     void *ptr;
+#if defined(_WIN32) && !defined(_WIN64)
+    int isaligned;
+#endif
 } jl_mallocptr_t;
 
 // how much space we're willing to waste if an array outgrows its
@@ -1080,7 +1083,7 @@ void jl_gc_unpreserve(void);
 int jl_gc_n_preserved_values(void);
 DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f);
 jl_weakref_t *jl_gc_new_weakref(jl_value_t *value);
-jl_mallocptr_t *jl_gc_acquire_buffer(void *b, size_t sz);
+jl_mallocptr_t *jl_gc_acquire_buffer(void *b, size_t sz, int isaligned);
 jl_mallocptr_t *jl_gc_managed_malloc(size_t sz);
 void *alloc_2w(void);
 void *alloc_3w(void);


### PR DESCRIPTION
@JeffBezanson Does this patch seem agreeable to you?

The summary of it is that I assumed everything in the gc was allocated by the gc, or arrived via `jl_gc_acquire_buffer`. If it was allocated by the gc, we can assume it is aligned for the call to free. If it was acquired by gc, we assume it wasn't aligned.
