### PR TITLE
add backtrace to warn and info

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -5,7 +5,7 @@ macro deprecate(old,new)
         Expr(:toplevel,
             Expr(:export,esc(old)),
             :(function $(esc(old))(args...)
-                  warn_once(string($oldname," is deprecated, use ",$newname," instead."))
+                  warn_once(string($oldname," is deprecated, use ",$newname," instead."); depth=1)
                   $(esc(new))(args...)
               end))
     elseif isa(old,Expr) && old.head == :call
@@ -14,7 +14,7 @@ macro deprecate(old,new)
         Expr(:toplevel,
             Expr(:export,esc(old.args[1])),
             :($(esc(old)) = begin
-                  warn_once(string($oldcall," is deprecated, use ",$newcall," instead."))
+                  warn_once(string($oldcall," is deprecated, use ",$newcall," instead."); depth=1)
                   $(esc(new))
               end))
     else
@@ -119,12 +119,12 @@ end
 @deprecate  unsetenv(var)           delete!(ENV,var)
 
 function svd(a::StridedMatrix, vecs::Bool, thin::Bool)
-    warn_once("The second argument ``vecs`` is no longer supported. Use svd(a, thin) instead.")
+    warn_once("The second argument ``vecs`` is no longer supported. Use svd(a, thin) instead."; depth=1)
     svd(a, thin)
 end
 
 function svdt(a::StridedMatrix, vecs::Bool, thin::Bool)
-    warn_once("The second argument ``vecs`` is no longer supported. Use svdt(a, thin) instead.")
+    warn_once("The second argument ``vecs`` is no longer supported. Use svdt(a, thin) instead."; depth=1)
     svdt(a, thin)
 end
 

--- a/base/error.jl
+++ b/base/error.jl
@@ -63,5 +63,25 @@ print_with_color(color::Symbol, msg::String...) =
 
 # use colors to print messages and warnings in the REPL
 
-info(msg::String...) = (print_with_color(:blue, STDERR, "MESSAGE: ", msg...); show_backtrace(STDERR, backtrace()); println(STDERR))
-warn(msg::String...) = (print_with_color(:red,  STDERR, "WARNING: ", msg...); show_backtrace(STDERR, backtrace()); println(STDERR))
+function info(msg::String...; depth=0)
+    stack::Range1{Int} = 3 +
+        if isa(depth,Int)
+            depth:depth
+        else
+            depth
+        end
+    with_output_color(print, :blue, STDERR, "MESSAGE: ", msg...)
+    with_output_color(show_backtrace, :blue, STDERR, backtrace(), stack)
+    println(STDERR)
+end
+function warn(msg::String...; depth=0)
+    stack::Range1{Int} = 3 +
+        if isa(depth,Int)
+            depth:depth
+        else
+            depth
+        end
+    with_output_color(print, :red,  STDERR, "WARNING: ", msg...)
+    with_output_color(show_backtrace, :red, STDERR, backtrace(), stack)
+    println(STDERR)
+end

--- a/base/error.jl
+++ b/base/error.jl
@@ -63,5 +63,5 @@ print_with_color(color::Symbol, msg::String...) =
 
 # use colors to print messages and warnings in the REPL
 
-info(msg::String...) = print_with_color(:blue, STDERR, "MESSAGE: ", msg..., "\n")
-warn(msg::String...) = print_with_color(:red,  STDERR, "WARNING: ", msg..., "\n")
+info(msg::String...) = (print_with_color(:blue, STDERR, "MESSAGE: ", msg...); show_backtrace(STDERR, backtrace()); println(STDERR))
+warn(msg::String...) = (print_with_color(:red,  STDERR, "WARNING: ", msg...); show_backtrace(STDERR, backtrace()); println(STDERR))

--- a/base/error.jl
+++ b/base/error.jl
@@ -75,7 +75,7 @@ function info(msg::String...; depth=0)
     println(STDERR)
 end
 function warn(msg::String...; depth=0)
-    stack::Range1{Int} = 3 +
+    stack::Range1{Int} = 2 +
         if isa(depth,Int)
             depth:depth
         else

--- a/base/repl.jl
+++ b/base/repl.jl
@@ -82,7 +82,7 @@ function show_trace_entry(io, fname, file, line, n)
     end
 end
 
-function show_backtrace(io::IO, t)
+function show_backtrace(io::IO, t, set=1:typemax(Int))
     # we may not declare :eval_user_input
     # directly so that we get a compile error
     # in case its name changes in the future
@@ -94,6 +94,7 @@ function show_backtrace(io::IO, t)
     n = 1
     lastfile = ""; lastline = -11; lastname = symbol("#")
     local fname, file, line
+    count = 0
     for i = 1:length(t)
         lkup = ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Int32), t[i], 0)
         if lkup === ()
@@ -102,6 +103,8 @@ function show_backtrace(io::IO, t)
         fname, file, line = lkup
         if i == 1 && fname == :error; continue; end
         if fname == eval_function; break; end
+        count += 1
+        if !contains(set, count); continue; end
         if file != lastfile || line != lastline || fname != lastname
             if lastline != -11
                 show_trace_entry(io, lastname, lastfile, lastline, n)

--- a/base/util.jl
+++ b/base/util.jl
@@ -184,11 +184,11 @@ less(f::Function, t) = less(functionloc(f,t)...)
 # print a warning only once
 
 const have_warned = (ByteString=>Bool)[]
-function warn_once(msg::String...)
+function warn_once(msg::String...; depth=0)
     msg = bytestring(msg...)
     haskey(have_warned,msg) && return
     have_warned[msg] = true
-    warn(msg)
+    warn(msg; depth=depth+2)
 end
 
 # openblas utility routines

--- a/base/util.jl
+++ b/base/util.jl
@@ -188,7 +188,7 @@ function warn_once(msg::String...; depth=0)
     msg = bytestring(msg...)
     haskey(have_warned,msg) && return
     have_warned[msg] = true
-    warn(msg; depth=depth+2)
+    warn(msg; depth=depth+1)
 end
 
 # openblas utility routines


### PR DESCRIPTION
This adds backtraces to warn and info to make it easier to track down the offending line of code. e.g:

```
julia> using Winston
WARNING: has(d,k) is deprecated, use haskey(d,k) instead.
 in read at /Users/jameson/.julia/IniFile/src/IniFile.jl:42
```

Any concerns or should I go ahead and merge?
