### PR TITLE
Fix float range behavior

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -53,7 +53,7 @@ function colon{T<:Real}(start::T, step::T, stop::T)
             end
         else
             n = nf
-            len = iround(n)
+            len = itrunc(n)
         end
         if n >= typemax(Int)
             error("Range: length ",n," is too large")
@@ -65,11 +65,17 @@ function colon{T<:Real}(start::T, stop::T)
     if stop < start
         len = 0
     else
-        n = round(stop-start+1)
+        nf = stop - start + 1
+        if T <: FloatingPoint
+            n = round(nf)
+            len = abs(n-nf) < eps(n)*3 ? itrunc(n) : itrunc(nf)
+        else
+            n = nf
+            len = itrunc(n)
+        end
         if n >= typemax(Int)
             error("Range: length ",n," is too large")
         end
-        len = itrunc(n)
     end
     Range1(start, len)
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -764,3 +764,7 @@ i2619()
 typealias Foo2919 Int
 type Baz2919; Foo2919::Foo2919; end
 @test Baz2919(3).Foo2919 === 3
+
+# issue #2959
+@test 1.0:1.5 == 1.0:1.0:1.5 == 1.0:1.0
+@test 1.0:(.3-.1)/.1 == 1.0:2.0


### PR DESCRIPTION
Previously:

``` julia
1.0:1.5      # == 1.0:2.0
1.0:1.0:1.5  # == 1.0:1.0
```

With this patch:

``` julia
1.0:1.5      # == 1.0:1.0
1.0:1.0:1.5  # == 1.0:1.0
```

I don't think the previous behavior was intentional, since it seems to violate the principle of least surprise, but I could be wrong.
