### PR TITLE
Fix enum.jl and convert to use immutables

### DIFF
--- a/extras/enum.jl
+++ b/extras/enum.jl
@@ -1,16 +1,13 @@
 macro enum(T,syms...)
-    N = int(Int.nbits)
-    T = esc(T)
-    sh = Expr(:block)
-    sh.args = {:(if x===$sym return print($(string(sym))) end) for sym in syms}
     blk = quote
-        bitstype ($N) ($T)
+        immutable ($T)
+            n::Int
+        end
         $(esc(:symbols))(_::Type{$T}) = $syms
-        $(esc(:isequal))(a::($T), b::($T)) = eq_int(unbox($T,a),unbox($T,b))
-        $(esc(:show))(io::IO, x::($T)) = $sh
+        Base.show(io::IO, x::($T)) = print($(esc(:symbols))(($T))[x.n+1])
     end
     for (i,sym) in enumerate(syms)
-        push!(blk.args, :(const $(esc(sym)) = box($T,unbox(Int,$(i-1)))))
+        push!(blk.args, :(const $(esc(sym)) = $(T)($(i-1))))
     end
     push!(blk.args, :nothing)
     blk.head = :toplevel


### PR DESCRIPTION
It seems like `enum.jl` was broken for quite a while because `Int.nbits` is undefined. This suggests that no one is actually using it and so maybe it makes more sense to remove it than to fix it, but here's a working version that uses an immutable in place of a creating a new BitsKind.
