### PR TITLE
Collects all linear algebra errors into linalg/exceptions.jl

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -148,6 +148,7 @@ else
     blas_int(x) = int32(x)
 end
 
+include("linalg/exceptions.jl")
 include("linalg/generic.jl")
 
 include("linalg/blas.jl")

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -27,6 +27,7 @@ export copy!,
 const libblas = Base.libblas_name
 
 import ..LinAlg: BlasFloat, BlasChar, BlasInt, blas_int
+import LAPACK: DimensionMismatch
 
 # SUBROUTINE DCOPY(N,DX,INCX,DY,INCY)
 for (fname, elty) in ((:dcopy_,:Float64), (:scopy_,:Float32),

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -26,8 +26,7 @@ export copy!,
 
 const libblas = Base.libblas_name
 
-import ..LinAlg: BlasFloat, BlasChar, BlasInt, blas_int
-import LAPACK: DimensionMismatch
+import ..LinAlg: BlasFloat, BlasChar, BlasInt, blas_int, DimensionMismatch
 
 # SUBROUTINE DCOPY(N,DX,INCX,DY,INCY)
 for (fname, elty) in ((:dcopy_,:Float64), (:scopy_,:Float32),
@@ -105,7 +104,8 @@ for (fname, elty, relty) in ((:zdotc_,:Complex128,:Float64), (:cdotc_,:Complex64
 end
 function dot{T<:BlasFloat}(DX::Array{T}, DY::Array{T})
     n = length(DX)
-    if n != length(DY) throw(DimensionMismatch) end
+    if n != length(DY) throw(DimensionMismatch("Cannot form dot product of vectors of different lengths: ",
+        size(DX), " and ", size(DY))) end
     return dot(n, DX, 1, DY, 1)
 end
 

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -414,7 +414,7 @@ sqrtm(a::Number) = isreal(a) ? (b = sqrt(complex(a)); imag(b) == 0 ? real(b) : b
 
 function det(A::Matrix)
     m, n = size(A)
-    if m != n; throw(LAPACK.DimensionMismatch("det only defined for square matrices")); end
+    if m != n; throw(DimensionMismatch("det only defined for square matrices")); end
     if istriu(A) | istril(A); return det(Triangular(A, 'U', false)); end
     return det(lufact(A))
 end

--- a/base/linalg/exceptions.jl
+++ b/base/linalg/exceptions.jl
@@ -1,0 +1,22 @@
+export LAPACKException, SingularException, PosDefException,
+    RankDeficientException, DimensionMismatch
+
+type LAPACKException <: Exception
+    info::BlasInt
+end
+
+type SingularException <: Exception
+    info::BlasInt
+end
+
+type PosDefException <: Exception
+    info::BlasInt
+end
+
+type RankDeficientException <: Exception
+    info::BlasInt
+end
+
+type DimensionMismatch <: Exception
+    name::ASCIIString
+end

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -46,7 +46,7 @@ end
     
 function inv(C::Cholesky)
     Ci, info = LAPACK.potri!(C.uplo, copy(C.UL))
-    if info != 0; throw(LAPACK.SingularException(info)); end 
+    if info != 0; throw(SingularException(info)); end 
     symmetrize_conj!(Ci, C.uplo)
 end
 
@@ -93,12 +93,12 @@ function getindex{T<:BlasFloat}(C::CholeskyPivoted{T}, d::Symbol)
 end
 
 function \{T<:BlasFloat}(C::CholeskyPivoted{T}, B::StridedVector{T})
-    if C.rank < size(C.UL, 1); throw(LAPACK.RankDeficientException(C.info)); end
+    if C.rank < size(C.UL, 1); throw(RankDeficientException(C.info)); end
     LAPACK.potrs!(C.uplo, C.UL, copy(B)[C.piv])[invperm(C.piv)]
 end
 
 function \{T<:BlasFloat}(C::CholeskyPivoted{T}, B::StridedMatrix{T})
-    if C.rank < size(C.UL, 1); throw(LAPACK.RankDeficientException(C.info)); end
+    if C.rank < size(C.UL, 1); throw(RankDeficientException(C.info)); end
     LAPACK.potrs!(C.uplo, C.UL, copy(B)[C.piv,:])[invperm(C.piv),:]
 end
 
@@ -113,9 +113,9 @@ function det{T}(C::CholeskyPivoted{T})
 end
     
 function inv(C::CholeskyPivoted)
-    if C.rank < size(C.UL, 1) throw(LAPACK.RankDeficientException(C.info)) end
+    if C.rank < size(C.UL, 1) throw(RankDeficientException(C.info)) end
     Ci, info = LAPACK.potri!(C.uplo, copy(C.UL))
-    if info != 0 throw(LAPACK.RankDeficientException(info)) end
+    if info != 0 throw(RankDeficientException(info)) end
     ipiv = invperm(C.piv)
     (symmetrize!(Ci, C.uplo))[ipiv, ipiv]
 end
@@ -177,12 +177,12 @@ function det{T}(A::LU{T})
 end
 
 function (\)(A::LU, B::StridedVecOrMat)
-    if A.info > 0; throw(LAPACK.SingularException(A.info)); end
+    if A.info > 0; throw(SingularException(A.info)); end
     LAPACK.getrs!('N', A.factors, A.ipiv, copy(B))
 end
 
 function inv(A::LU)
-    if A.info > 0; return throw(LAPACK.SingularException(A.info)); end
+    if A.info > 0; return throw(SingularException(A.info)); end
     LAPACK.getri!(copy(A.factors), A.ipiv)
 end
 
@@ -241,7 +241,7 @@ function *{T<:BlasFloat}(A::QRPackedQ{T}, B::StridedVecOrMat{T})
     elseif m == size(A.vs, 2)
         Bc = [B; zeros(T, size(A.vs, 1) - m, n)]
     else
-        throw(LAPACK.DimensionMismatch(""))
+        throw(DimensionMismatch(""))
     end
     LAPACK.gemqrt!('L', 'N', A.vs, A.T, Bc)
 end
@@ -255,7 +255,7 @@ function A_mul_Bc{T<:BlasFloat}(A::StridedVecOrMat{T}, B::QRPackedQ{T})
     elseif n == size(B.vs, 2)
         Ac = [B zeros(T, m, size(B.vs, 1) - n)]
     else
-        throw(LAPACK.DimensionMismatch(""))
+        throw(DimensionMismatch(""))
     end
     LAPACK.gemqrt!('R', iscomplex(B.vs[1]) ? 'C' : 'T', B.vs, B.T, Ac)
 end
@@ -270,7 +270,7 @@ type QRPivoted{T} <: Factorization{T}
     function QRPivoted(hh::Matrix{T}, tau::Vector{T}, jpvt::Vector{BlasInt})
         m, n = size(hh)
         if length(tau) != min(m,n) || length(jpvt) != n
-            throw(LAPACK.DimensionMismatch(""))
+            throw(DimensionMismatch(""))
         end
         new(hh,tau,jpvt)
     end
@@ -335,7 +335,7 @@ function *{T<:BlasFloat}(A::QRPivotedQ{T}, B::StridedVecOrMat{T})
     elseif m == size(A.hh, 2)
         Bc = [B; zeros(T, size(A.hh, 1) - m, n)]
     else
-        throw(LAPACK.DimensionMismatch(""))
+        throw(DimensionMismatch(""))
     end
     LAPACK.ormqr!('L', 'N', A.hh, A.tau, Bc)
 end
@@ -349,7 +349,7 @@ function A_mul_Bc{T<:BlasFloat}(A::StridedVecOrMat{T}, B::QRPivotedQ{T})
     elseif n == size(B.hh, 2)
         Ac = [B zeros(T, m, size(B.hh, 1) - n)]
     else
-        throw(LAPACK.DimensionMismatch(""))
+        throw(DimensionMismatch(""))
     end
     LAPACK.ormqr!('R', iscomplex(B.hh[1]) ? 'C' : 'T', B.hh, B.tau, Ac)
 end
@@ -363,7 +363,7 @@ type Hessenberg{T} <: Factorization{T}
     hh::Matrix{T}
     tau::Vector{T}
     function Hessenberg(hh::Matrix{T}, tau::Vector{T})
-        if size(hh, 1) != size(hh, 2) throw(LAPACK.DimensionMismatch("")) end
+        if size(hh, 1) != size(hh, 2) throw(DimensionMismatch("")) end
         return new(hh, tau)
     end
 end

--- a/base/linalg/hermitian.jl
+++ b/base/linalg/hermitian.jl
@@ -4,7 +4,7 @@ type Hermitian{T<:BlasFloat} <: AbstractMatrix{T}
     S::Matrix{T}
     uplo::Char
     function Hermitian(S::Matrix{T}, uplo::Char)
-        if size(S, 1) != size(S, 2) throw(LAPACK.DimensionMismatch("Matrix must be square")); end
+        if size(S, 1) != size(S, 2) throw(DimensionMismatch("Matrix must be square")); end
         return new(S, uplo)
     end
 end
@@ -25,7 +25,7 @@ ctranspose(A::Hermitian) = A
 
 function \(A::Hermitian, B::StridedVecOrMat)
     r, _, _, info = LAPACK.sysv!(A.uplo, copy(A.S), copy(B))
-    if info > 0 throw(LAPACK.SingularException(info)) end
+    if info > 0 throw(SingularException(info)) end
     return r
 end
 

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -5,26 +5,6 @@ const liblapack = Base.liblapack_name
 
 import ..LinAlg: BlasFloat, BlasChar, BlasInt, blas_int
 
-type LAPACKException <: Exception
-    info::BlasInt
-end
-
-type SingularException <: Exception
-    info::BlasInt
-end
-
-type PosDefException <: Exception
-    info::BlasInt
-end
-
-type RankDeficientException <: Exception
-    info::BlasInt
-end
-
-type DimensionMismatch <: Exception
-    name::ASCIIString
-end
-
 function chkstride1(A::StridedVecOrMat...)
     for a in A
         if stride(a,1) != 1 error("LAPACK: Matrix must have contiguous columns") end

--- a/base/linalg/rectfullpacked.jl
+++ b/base/linalg/rectfullpacked.jl
@@ -44,6 +44,6 @@ end
 
 function inv(A::CholeskyDenseRFP)
     B, info = LAPACK.pftri!(A.transr, A.uplo, copy(A.data))
-    if info > 0 throw(LAPACK.SingularException(info)) end
+    if info > 0 throw(SingularException(info)) end
     return B
 end

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -4,7 +4,7 @@ type Triangular{T<:BlasFloat} <: AbstractMatrix{T}
     uplo::Char
     unitdiag::Char
     function Triangular(A::Matrix{T}, uplo::Char, unitdiag::Char)
-        if size(A, 1) != size(A, 2) throw(LAPACK.DimensionMismatch("Matrix must be square")) end
+        if size(A, 1) != size(A, 2) throw(DimensionMismatch("Matrix must be square")) end
         return new(A, uplo, unitdiag)
     end
 end
@@ -45,17 +45,17 @@ A_mul_Bc{T<:Union(Float64, Float32)}(A::StridedMatrix{T}, B::Triangular{T}) = BL
 
 function \(A::Triangular, B::StridedVecOrMat)
     r, info = LAPACK.trtrs!(A.uplo, 'N', A.unitdiag, A.UL, copy(B))
-    if info > 0 throw(LAPACK.SingularException(info)) end
+    if info > 0 throw(SingularException(info)) end
     return r
 end
 function Ac_ldiv_B{T<:Union(Float64, Float32)}(A::Triangular{T}, B::StridedVecOrMat{T}) 
     r, info = LAPACK.trtrs!(A.uplo, 'T', A.unitdiag, A.UL, copy(B))
-    if info > 0 throw(LAPACK.SingularException(info)) end
+    if info > 0 throw(SingularException(info)) end
     return r
 end
 function Ac_ldiv_B{T<:Union(Complex128, Complex64)}(A::Triangular{T}, B::StridedVecOrMat{T})
     r, info = LAPACK.trtrs!(A.uplo, 'C', A.unitdiag, A.UL, copy(B))
-    if info > 0 throw(LAPACK.SingularException(info)) end
+    if info > 0 throw(SingularException(info)) end
     return r
 end
 /{T<:BlasFloat}(A::StridedVecOrMat{T}, B::Triangular{T}) = BLAS.trsm!('R', B.uplo, 'N', B.unitdiag, one(T), B.UL, copy(A))


### PR DESCRIPTION
In #2962 I found that linalg/blas.jl uses exceptions that are only defined within the LAPACK module. It would make more sense to take the exceptions out of linalg/lapack.jl so that they can be referenced more easily in the linear algebra functions.
- [x] FIXED ~~Currently this doesn't quite seem to work; I get an error when I try to compile this:~~

```
LoadError("sysimg.jl",159,LoadError("linalg.jl",154,LoadError("linalg/blas.jl",30,ErrorException("in yield: Scheduler not defined"))))
```
