### PR TITLE
cleanup range searchsorted methods, remove redundant hist methods

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -157,13 +157,13 @@ for s in {:searchsortedfirst, :searchsortedlast}
     end
 end
 
-searchsortedlast{T <: Real}(a::Union(Range{T}, Range1{T}), x::Real, o::Ordering) = searchsortedlast(a, x)
-searchsortedfirst{T <: Real}(a::Union(Range{T}, Range1{T}), x::Real, o::Ordering) = searchsortedfirst(a, x)
-function searchsortedlast{T <: Real}(a::Union(Range{T}, Range1{T}), x::Real)
-    max(min(int(fld(x - a[1], step(a))) + 1, length(a)), 0)
+searchsortedlast{T <: Real}(a::Ranges{T}, x::Real, o::Ordering) = searchsortedlast(a, x)
+searchsortedfirst{T <: Real}(a::Ranges{T}, x::Real, o::Ordering) = searchsortedfirst(a, x)
+function searchsortedlast{T <: Real}(a::Ranges{T}, x::Real)
+    max(min(int(fld(x - first(a), step(a))) + 1, length(a)), 0)
 end
-function searchsortedfirst{T <: Real}(a::Union(Range{T}, Range1{T}), x::Real)
-    n = x - a[1]
+function searchsortedfirst{T <: Real}(a::Ranges{T}, x::Real)
+    n = x - first(a)
     s = step(a)
     max(min(int(fld(n, s)) + (rem(n, s) != 0), length(a)), 0) + 1
 end

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -111,17 +111,6 @@ midpoints(v::AbstractVector) = [0.5*(v[i] + v[i+1]) for i in 1:length(v)-1]
 
 
 ## hist ##
-function hist(v::AbstractVector, r::Ranges)
-    n = length(r)-1
-    h = zeros(Int, n)
-    for x in v
-        i = iceil((x-first(r))/step(r))
-        if 1 <= i <= n
-            h[i] += 1
-        end
-    end
-    r,h
-end
 hist(v::AbstractVector, n::Integer) = hist(v,histrange(v,n))
 hist(v::AbstractVector) = hist(v,iceil(log2(length(v)))+1) # Sturges' formula 
 


### PR DESCRIPTION
Slight changes to `searchsorted` methods for range types added in #2877: uses abstract types instead of unions, `first` instead of `getindex`. Also removes redundant `hist` method (now the `AbstractVector` methods should be equivalent).
