### PR TITLE
Reinstate searchsorted(), returning a range

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -50,7 +50,6 @@ end
 @deprecate  nCr             binomial
 @deprecate  julia_pkgdir    Pkg.dir
 @deprecate  tintersect      typeintersect
-@deprecate  searchsorted    searchsortedfirst
 @deprecate  choose          first
 @deprecate  system          run
 @deprecate  order           sortperm

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -524,6 +524,7 @@ export
     rot180,
     rotl90,
     rotr90,
+    searchsorted,
     searchsortedfirst,
     searchsortedlast,
     select,

--- a/doc/stdlib/sort.rst
+++ b/doc/stdlib/sort.rst
@@ -156,11 +156,10 @@ Sorting-related Functions
 
 .. function:: searchsorted(a, x[, ord])
 
-   Returns the index of the first value of ``a`` equal to or
-   succeeding ``x``, according to ordering ``ord`` (default:
-   ``Sort.Forward``).
-
-   Alias for ``searchsortedfirst()``
+   Returns the range of indices of ``a`` equal to ``x``, assuming ``a``
+   is sorted according to ordering ``ord`` (default:
+   ``Sort.Forward``).  Returns an empty range located at the insertion
+   point if ``a`` does not contain ``x``.
 
 .. function:: searchsortedfirst(a, x[, ord])
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -18,6 +18,11 @@
 @test searchsortedlast([1, 1, 2, 2, 3, 3], 2) == 4
 @test searchsortedlast([1, 1, 2, 2, 3, 3], 4) == 6
 @test searchsortedlast([1.0, 1, 2, 2, 3, 3], 2.5) == 4
+@test searchsorted([1, 1, 2, 2, 3, 3], 0) == 1:0
+@test searchsorted([1, 1, 2, 2, 3, 3], 1) == 1:2
+@test searchsorted([1, 1, 2, 2, 3, 3], 2) == 3:4
+@test searchsorted([1, 1, 2, 2, 3, 3], 4) == 7:6
+@test searchsorted([1.0, 1, 2, 2, 3, 3], 2.5) == 5:4
 
 rg = 49:57; rgv = [rg]
 rg_r = 57:-1:49; rgv_r = [rg_r]


### PR DESCRIPTION
- Returns the range of indices in a sorted array equal to a given value
- Returns an empty range located at the insert location if the value is not
  in the array

Includes tests and documentation updates.

This is slightly more efficient than calling `searchsortedfirst()` and `searchsortedlast()` separately.  I vaguely recall a request for this, but I can't find the original.
