### PR TITLE
Change `abs(z) > 2` to `abs2(z) > 4` for 3x speedup

### DIFF
--- a/examples/shootout/mandelbrot.jl
+++ b/examples/shootout/mandelbrot.jl
@@ -8,7 +8,7 @@ const ITER = 50
 function mandel(z::Complex128)
     c = z
     for n = 1:ITER
-        if abs(z) > 2
+        if abs2(z) > 4
             return false
         end
         z = z^2 + c


### PR DESCRIPTION
As discussed yesterday [here](https://github.com/JuliaLang/julia/pull/2974#issuecomment-17240009)
