### PR TITLE
Changed top-level bracket rule to not consume when transpose tick is present

### DIFF
--- a/contrib/Julia.tmbundle/Syntaxes/Julia.tmLanguage
+++ b/contrib/Julia.tmbundle/Syntaxes/Julia.tmLanguage
@@ -64,7 +64,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(?:\(|\)|\[|\]|\{|\}|,)</string>
+					<string>(?:\(|\)|\[|\]|\{|\}|,)(?!('|(?:\.'))*\.?')</string>
 					<key>name</key>
 					<string>keyword.bracket.julia</string>
 				</dict>
@@ -295,48 +295,38 @@
 					<string>(\w+)(('|(\.'))*\.?')</string>
 				</dict>
 				<dict>
-					<key>begin</key>
-					<string>\[</string>
-					<key>end</key>
-					<string>\]((?:'|(?:\.'))*\.?')</string>
-					<key>endCaptures</key>
+					<key>captures</key>
 					<dict>
 						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.bracket.end.julia</string>
+						</dict>
+						<key>2</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.operator.transposed-matrix.julia</string>
 						</dict>
 					</dict>
-					<key>name</key>
-					<string>test</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>$self</string>
-						</dict>
-					</array>
+					<key>match</key>
+					<string>(\])((?:'|(?:\.'))*\.?')</string>
 				</dict>
 				<dict>
-					<key>begin</key>
-					<string>\(</string>
-					<key>end</key>
-					<string>\)(('|(\.'))*\.?')</string>
-					<key>endCaptures</key>
+					<key>captures</key>
 					<dict>
 						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.bracket.end.julia</string>
+						</dict>
+						<key>2</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.operator.transposed-parens.julia</string>
 						</dict>
 					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>$self</string>
-						</dict>
-					</array>
+					<key>match</key>
+					<string>(\))((?:'|(?:\.'))*\.?')</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Fixes #2992

This seems to solve the transpose tick problem while also not introducing the syntax-blocking (like the last fix). Can others confirm before we merge this time?
