### PR TITLE
Repair rand{T<:Integer}(r::Range1{T}) for signed types. Closes #3004.

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -146,7 +146,7 @@ function rand{T<:Integer}(r::Range1{T})
     hi = r[end]
 
     m = typemax(T)
-    s = abs(rand(T))
+    s = rand(T) & m
     if (hi-lo == m)
         return s + lo
     end
@@ -158,7 +158,7 @@ function rand{T<:Integer}(r::Range1{T})
     # note: m>=0 && r>=0
     lim = m - rem(rem(m,r)+1, r)
     while s > lim
-        s = rand(T)
+        s = rand(T) & m
     end
     return rem(s,r) + lo
 end

--- a/test/random.jl
+++ b/test/random.jl
@@ -3,3 +3,4 @@
 @test rand(Uint32) >= 0
 @test -10 <= rand(-10:-5) <= -5
 @test -10 <= rand(-10:5) <= 5
+@test min([rand(int32(1):int32(7^7)) for i = 1:100000]) > 0


### PR DESCRIPTION
This pull request restores the rand(r::Range1) function to the state before https://github.com/JuliaLang/julia/commit/6e6b05750ee572699e186b9deecdc5eee5608004#base/random.jl to solve the regression reported in #3004. There are other edge case issues in the function but I'll come back to those at a later time.

I'm not sure about the value of the testcase. Generating 100000 random numbers to test this specific problem is maybe not motivated. What this patch really needs is careful code review.
