### PR TITLE
RFC: more BigFloat special functions

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -326,6 +326,7 @@ export
     erfcinv,
     exp,
     exp2,
+    exp10,
     expm1,
     exponent,
     factor,
@@ -821,8 +822,10 @@ export
     randn,
     srand,
 
-# precision
-    exp10,
+# bigfloat & precision
+    bigfloat_pi,
+    bigfloat_eulergamma,
+    bigfloat_catalan,
     get_precision,
     get_bigfloat_precision,
     set_bigfloat_precision,

--- a/base/math.jl
+++ b/base/math.jl
@@ -6,7 +6,7 @@ export sin, cos, tan, sinh, cosh, tanh, asin, acos, atan,
        cosd, cotd, cscd, secd, sind, tand,
        acosd, acotd, acscd, asecd, asind, atand, atan2,
        radians2degrees, degrees2radians,
-       log, log2, log10, log1p, exponent, exp, exp2, expm1,
+       log, log2, log10, log1p, exponent, exp, exp2, exp10, expm1,
        cbrt, sqrt, square, erf, erfc, erfcx, erfi, dawson,
        ceil, floor, trunc, round, significand, 
        lgamma, hypot, gamma, lfact, max, min, ldexp, frexp,
@@ -108,6 +108,12 @@ for f in (:cbrt, :sinh, :cosh, :tanh, :atan, :asinh, :exp, :erf, :erfc, :exp2, :
         @vectorize_1arg Number $f
     end
 end
+
+# TODO: GNU libc has exp10 as an extension; should openlibm?
+exp10(x::Float64) = 10.0^x
+exp10(x::Float32) = 10.0f0^x
+exp10(x::Integer) = exp10(float(x))
+@vectorize_1arg Number exp10
 
 # functions that return NaN on non-NaN argument for domain error
 for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -2473,6 +2473,13 @@ stream[, offset])
 
 "),
 
+("Mathematical Functions","Base","exp10","exp10(x)
+
+
+   Compute 10^x
+
+"),
+
 ("Mathematical Functions","Base","ldexp","ldexp(x, n)
 
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1402,6 +1402,10 @@ Mathematical Functions
 
    Compute :math:`2^x`
 
+.. function:: exp10(x)
+
+   Compute :math:`10^x`
+
 .. function:: ldexp(x, n)
 
    Compute :math:`x \times 2^n`


### PR DESCRIPTION
This patch adds support for a bunch more special functions in MPFR: `expm1`, `gamma`, `lgamma`, `digamma`, `erf`, `erfc`, `zeta`, `log1p`, and `airyai`, mirroring the corresponding functions in `Base`.

It also adds new functions `bigfloat_pi`, `bigfloat_eulergamma`, and `bigfloat_catalan`, exposing the MPFR functions to compute those mathematical constants to arbitrary precision.

It also removes unnecessary NaN checks from trig functions defined over the whole real line.  The only NaN checks should be for the inverse trigonometric functions, and those functions should not throw a `DomainError` if their argument was itself NaN.

Also, `exp10` was only defined for `BigFloat`, but there is no reason not to define this for regular floating-point values as well (mirroring `log10`), so I added this to `math.jl`.

cc: @andrioni
