### PR TITLE
Fixed bug in tests for poll_fd and file watcher

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -403,7 +403,6 @@ TimeoutAsyncWork(cb::Function) = TimeoutAsyncWork(eventloop(),cb)
 close(t::TimeoutAsyncWork) = ccall(:jl_close_uv,Void,(Ptr{Void},),t.handle)
 
 function poll_fd(s, events::Integer, timeout_ms::Integer)
-    timeout_at = int64((time() * 1000)) + timeout_ms
     wt = WaitTask()
 
     fdw = FDWatcher(s)
@@ -431,7 +430,6 @@ function poll_fd(s, events::Integer, timeout_ms::Integer)
 end
 
 function poll_file(s, interval::Integer, timeout_ms::Integer)
-    timeout_at = int64((time() * 1000)) + timeout_ms
     wt = WaitTask()
 
     pfw = PollingFileWatcher(s)

--- a/test/file.jl
+++ b/test/file.jl
@@ -51,15 +51,15 @@ function test_file_poll(channel,timeout_ms)
 end
 
 function test_timeout(tval)
-    t1 = int64(time() * 1000)
+    tic()
     channel = RemoteRef()
     @async test_file_poll(channel,tval)
     tr = take(channel)
-    t2 = int64(time() * 1000)
+    t_elapsed = toq()
 
     @test tr == 0
 
-    tdiff = t2-t1
+    tdiff = t_elapsed * 1000
     @test tval <= tdiff
 end
 

--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -13,27 +13,27 @@ function test_poll(timeout_ms)
 end
 
 function test_timeout(tval)
-    t1 = int64(time() * 1000)
+    tic()
     t = Task(()->test_poll(tval))
     tr = consume(t)
-    t2 = int64(time() * 1000)
+    t_elapsed = toq()
 
     @test tr == 0
 
-    tdiff = t2-t1
+    tdiff = t_elapsed * 1000
     @test tval <= tdiff
 end
 
 function test_read(slval)
     tval = slval + 100
-    t1 = int64(time() * 1000)
+    tic()
     t = Task(()->test_poll(tval))
 
     sleep(slval/1000.0)
     @test 1 == ccall(:write, Csize_t, (Cint, Ptr{Uint8},Csize_t), pipe_fds[2], bytestring("A"), 1)
 
     tr = consume(t)
-    t2 = int64(time() * 1000)
+    t_elapsed = toq()
 
     @test tr == UV_READABLE || (UV_READABLE | UV_WRITEABLE)
 
@@ -41,7 +41,7 @@ function test_read(slval)
     @test 1 == ccall(:read, Csize_t, (Cint, Ptr{Uint8},Csize_t), pipe_fds[1], dout, 1)
     @test dout[1] == int8('A')
 
-    tdiff = t2-t1
+    tdiff = t_elapsed * 1000
 
     @test slval <= tdiff
 end


### PR DESCRIPTION
cc: @loladiro - please verify before merging.

The tests used `int64(time() * 1000)` to get time differences in milliseconds.  Since int64 is a rounding function, it could have caused inaccuracies in calculating the same.

Replaced to use tic() and toq() .

Also deleted a redundant line in stream.jl 
