### PR TITLE
hist2 implementations

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -838,6 +838,7 @@ export
     cor,
     cov,
     hist,
+    hist2d,
     histrange,
     mean,
     median,

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -137,6 +137,31 @@ end
 hist(A::AbstractMatrix, n::Integer) = hist(A,histrange(A,n))
 hist(A::AbstractMatrix) = hist(A,iceil(log2(size(A,1)))+1) # Sturges' formula 
 
+function hist2d(v::AbstractMatrix, edg1::AbstractVector, edg2::AbstractVector)
+    @assert size(v,2) == 2
+    n = length(edg1)-1
+    m = length(edg2)-1
+    h = zeros(Int, n, m)
+    for i = 1:size(v,1)
+        x = searchsortedfirst(edg1, v[i, 1])-1
+        y = searchsortedfirst(edg2, v[i, 2])-1
+        if 1 <= x <= n && 1 <= y <= m
+            h[x,y] += 1
+        end
+    end
+    edg1,edg2,h
+end
+hist2d(v::AbstractMatrix, edg::AbstractVector) = hist2d(v, edg, edg)
+function hist2d(v::AbstractMatrix, n::Integer)
+    m = size(v,1)
+    hist2d(v, histrange(sub(v, 1:m, 1),n), histrange(sub(v, 1:m, 2),n))
+end
+function hist2d(v::AbstractMatrix, n1::Integer, n2::Integer)
+    m = size(v,1)
+    hist2d(v, histrange(sub(v, 1:m,1),n1), histrange(sub(v, 1:m,2),n2))
+end
+hist2d(v::AbstractMatrix) = hist2d(v, iceil(log2(size(v,1)))+1) # Sturges' formula
+
 ## pearson covariance functions ##
 
 typealias AbstractVecOrMat{T} Union(AbstractVector{T}, AbstractMatrix{T})


### PR DESCRIPTION
Should the hist2 function return [y,x] or [n,m] order? (or follow numpy's lead and make it a parameter of the function)?
