### PR TITLE
Fix mpz_probab_prime_p call

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -223,6 +223,6 @@ function show(io::IO, x::BigInt)
 end
 
 ndigits(x::BigInt) = ccall((:__gmpz_sizeinbase,:libgmp), Culong, (Ptr{BigInt}, Int32), &x, 10)
-isprime(x::BigInt) = ccall((:__gmpz_probab_prime_p,:libgmp), Cint, (Ptr{BigInt},), &x) > 0
+isprime(x::BigInt, reps=25) = ccall((:__gmpz_probab_prime_p,:libgmp), Cint, (Ptr{BigInt}, Cint), &x, reps) > 0
 
 end # module

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -164,6 +164,13 @@ end
 @test binomial(BigInt(-53), 42) == BigInt("959509335087854414441273718")
 @test binomial(BigInt(113), BigInt(42)) == BigInt("18672199984318438125634054194360")
 
+@test isprime(BigInt(1000000007))
+@test isprime(BigInt(1000000007), 1)
+@test isprime(BigInt(10000000019))
+@test isprime(BigInt("359334085968622831041960188598043661065388726959079837"))
+@test !isprime(BigInt(1))
+@test !isprime(BigInt(10000000020))
+
 # Large Fibonacci to exercise BigInt
 # from Bill Hart, https://groups.google.com/group/julia-dev/browse_frm/thread/798e2d1322daf633
 function mul(a::Vector{BigInt}, b::Vector{BigInt})


### PR DESCRIPTION
The number of tests to use wasn't there. I'm using 25 as a default, as it is
the recommended amount, but now it is also available as an extra
argument.
Actually, I'm a bit surprised to see that it was working even without an argument.
