### PR TITLE
BigFloat string and eps, close #3056

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -21,7 +21,7 @@ import
         isinf, isnan, ldexp, log, log2, log10, max, min, mod, modf, nextfloat,
         prevfloat, promote_rule, rem, round, show, showcompact, sum, sqrt,
         string, trunc, get_precision, exp10, expm1, gamma, lgamma, digamma,
-        erf, erfc, zeta, log1p, airyai, iceil, ifloor, itrunc,
+        erf, erfc, zeta, log1p, airyai, iceil, ifloor, itrunc, eps,
     # import trigonometric functions
         sin, cos, tan, sec, csc, cot, acos, asin, atan, cosh, sinh, tanh,
         sech, csch, coth, acosh, asinh, atanh, atan2
@@ -702,6 +702,8 @@ function string(x::BigFloat)
         end
     end
 end
+
+eps(::Type{BigFloat}) = nextfloat(BigFloat(1)) - BigFloat(1)
 
 show(io::IO, b::BigFloat) = print(io, string(b) * " with $(get_precision(b)) bits of precision")
 showcompact(io::IO, b::BigFloat) = print(io, string(b))

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -696,7 +696,7 @@ function string(x::BigFloat)
     lng = 128
     for i = 1:2
         z = Array(Uint8, lng)
-        lng = ccall((:mpfr_snprintf,:libmpfr), Int32, (Ptr{Uint8}, Culong, Ptr{Uint8}, Ptr{BigFloat}...), z, lng, "%.Re", &x)
+        lng = ccall((:mpfr_snprintf,:libmpfr), Int32, (Ptr{Uint8}, Culong, Ptr{Uint8}, Ptr{BigFloat}...), z, lng, "%.Re", &x) + 1
         if lng < 128 || i == 2
             return bytestring(convert(Ptr{Uint8}, z[1:lng]))
         end

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -294,6 +294,12 @@ z = BigInt("9223372036854775809")
 @test typeof(iround(Int, x)) == Int && iround(Int, x) == 42
 @test typeof(iround(Uint, x)) == Uint && iround(Uint, x) == 0x2a
 
+# string representation
+str = "1.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000012e+00"
+with_bigfloat_precision(406) do
+    @test string(nextfloat(BigFloat(1))) == str
+end
+
 # factorial
 with_bigfloat_precision(256) do
     x = BigFloat(42)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -300,6 +300,10 @@ with_bigfloat_precision(406) do
     @test string(nextfloat(BigFloat(1))) == str
 end
 
+# eps
+x = eps(BigFloat)
+@test BigFloat(1) + x == BigFloat(1) + prevfloat(x)
+
 # factorial
 with_bigfloat_precision(256) do
     x = BigFloat(42)


### PR DESCRIPTION
The previous string representation used to chomp the last character if the number needed more than 128 characters (see #3056), and we didn't have an `eps(::Type{BigFloat})` function available.
