### PR TITLE
Add a conversion method from BigInt to FloatingPoint

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -96,6 +96,7 @@ BigFloat(x::Rational) = BigFloat(num(x)) / BigFloat(den(x))
 
 convert(::Type{BigFloat}, x::Rational) = BigFloat(x) # to resolve ambiguity
 convert(::Type{BigFloat}, x::Real) = BigFloat(x)
+convert(::Type{FloatingPoint}, x::BigInt) = BigFloat(x)
 
 
 convert(::Type{Int64}, x::BigFloat) = int64(convert(Clong, x))
@@ -110,7 +111,7 @@ function convert(::Type{Clong}, x::BigFloat)
 end
 convert(::Type{Uint64}, x::BigFloat) = uint64(convert(Culong, x))
 convert(::Type{Uint32}, x::BigFloat) = uint32(convert(Culong, x))
-function convert(::Type{Culong}, x::BigFloat) 
+function convert(::Type{Culong}, x::BigFloat)
     fits = ccall((:mpfr_fits_ulong_p, :libmpfr), Int32, (Ptr{BigFloat}, Int32), &x, ROUNDING_MODE[end]) != 0
     if integer_valued(x) && fits
         ccall((:mpfr_get_ui,:libmpfr), Culong, (Ptr{BigFloat}, Int32), &x, ROUNDING_MODE[end])
@@ -118,7 +119,7 @@ function convert(::Type{Culong}, x::BigFloat)
         throw(InexactError())
     end
 end
-function convert(::Type{BigInt}, x::BigFloat) 
+function convert(::Type{BigInt}, x::BigFloat)
     if integer_valued(x)
         z = BigInt()
         ccall((:mpfr_get_z,:libmpfr), Int32, (Ptr{BigInt}, Ptr{BigFloat}, Int32), &z, &x, ROUNDING_MODE[end])

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -106,9 +106,17 @@ y = BigFloat(1)
 
 # convert to
 @test convert(BigFloat, 1//2) == BigFloat("0.5")
+@test typeof(convert(BigFloat, 1//2)) == BigFloat
 @test convert(BigFloat, 0.5) == BigFloat("0.5")
+@test typeof(convert(BigFloat, 0.5)) == BigFloat
 @test convert(BigFloat, 40) == BigFloat("40")
+@test typeof(convert(BigFloat, 40)) == BigFloat
 @test convert(BigFloat, float32(0.5)) == BigFloat("0.5")
+@test typeof(convert(BigFloat, float32(0.5))) == BigFloat
+@test convert(BigFloat, BigInt("9223372036854775808")) == BigFloat("9223372036854775808")
+@test typeof(convert(BigFloat, BigInt("9223372036854775808"))) == BigFloat
+@test convert(FloatingPoint, BigInt("9223372036854775808")) == BigFloat("9223372036854775808")
+@test typeof(convert(FloatingPoint, BigInt("9223372036854775808"))) == BigFloat
 
 # convert from
 @test convert(Float64, BigFloat(0.5)) == 0.5


### PR DESCRIPTION
This will be very useful in the future, as it solves #2930 for BigInts (`float(x)` uses `convert(FloatingPoint, x)`), so `float(BigInt(1)im)` now works.
