### PR TITLE
RFC: uv_shutdown in julia close

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1000,7 +1000,7 @@ export
     bind,
     connect,
     close,
-    is_open,
+    isopen,
     countlines,
     readcsv,
     writecsv,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1000,6 +1000,7 @@ export
     bind,
     connect,
     close,
+    is_open,
     countlines,
     readcsv,
     writecsv,

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -558,10 +558,14 @@ function link_pipe(read_end::Ptr{Void},readable_julia_only::Bool,write_end::Name
 end
 close_pipe_sync(handle::UVHandle) = ccall(:uv_pipe_close_sync,Void,(UVHandle,),handle)
 
+function is_open(stream::AsyncStream)
+    stream.open
+end
+
 function close(stream::AsyncStream)
     if stream.open
-        stream.open = false
         ccall(:jl_close_uv,Void,(Ptr{Void},),stream.handle)
+        stream.open = false
     end
 end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -558,7 +558,7 @@ function link_pipe(read_end::Ptr{Void},readable_julia_only::Bool,write_end::Name
 end
 close_pipe_sync(handle::UVHandle) = ccall(:uv_pipe_close_sync,Void,(UVHandle,),handle)
 
-function is_open(stream::AsyncStream)
+function isopen(stream::AsyncStream)
     stream.open
 end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -562,6 +562,8 @@ function isopen(stream::AsyncStream)
     stream.open
 end
 
+_uv_hook_isopen(stream::AsyncStream) = int32(isopen(stream))
+
 function close(stream::AsyncStream)
     if stream.open
         ccall(:jl_close_uv,Void,(Ptr{Void},),stream.handle)

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -300,7 +300,7 @@ DLLEXPORT void jl_close_uv(uv_handle_t *handle)
     if (uv_is_writable((uv_stream_t*)handle) && // uv_shutdown returns an error if not writable
           (handle->type == UV_NAMED_PIPE || handle->type == UV_TCP)) { 
         // Make sure that the stream has not already been marked closed in Julia.
-        jl_function_t* jl_is_open = (jl_function_t*) jl_get_global(jl_base_module, jl_symbol("is_open"));
+        jl_function_t* jl_is_open = (jl_function_t*) jl_get_global(jl_base_module, jl_symbol("isopen"));
         if ( jl_apply(jl_is_open, (jl_value_t **) &(handle->data), 1) == jl_false){
             return;
         }

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -301,6 +301,7 @@ DLLEXPORT void jl_close_uv(uv_handle_t *handle)
     int UV_CLOSING          = 0x01;   /* uv_close() called but not finished. */
     int UV_CLOSED           = 0x02;
     int UV_STREAM_SHUTTING  = 0x08;
+
     // libuv will give an error if we try to close an already closed handle.
     // If the handle is shutting down, it will be closed in the shutdown callback.
     if (handle->flags & (UV_CLOSING | UV_CLOSED | UV_STREAM_SHUTTING))

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -292,17 +292,16 @@ DLLEXPORT uv_pipe_t *jl_init_pipe(uv_pipe_t *pipe, int writable, int julia_only,
 
 DLLEXPORT void jl_close_uv(uv_handle_t *handle)
 {
-    if (!handle)
+    if (!handle || uv_is_closing(handle))
        return;
     if (handle->type==UV_TTY)
         uv_tty_set_mode((uv_tty_t*)handle,0);
 
-    if (handle->type == UV_NAMED_PIPE || handle->type == UV_TCP) { 
-        // Make sure that the stream has not already been marked closed in Julia, which would cause a hang.
-        // and has not been marked not writable by libuv (eg. by calling uv_shutdown on Windows), which would cause an abort.
+    if ( (handle->type == UV_NAMED_PIPE || handle->type == UV_TCP) && uv_is_writable( (uv_stream_t *) handle)) { 
+        // Make sure that the stream has not already been marked closed in Julia.
+        // A double shutdown would cause the process to hang on exit.
         jl_function_t* jl_is_open = (jl_function_t*) jl_get_global(jl_base_module, jl_symbol("isopen"));
-        if ( jl_apply(jl_is_open, (jl_value_t **) &(handle->data), 1) == jl_false ||
-             uv_is_writable((uv_stream_t*)handle)){ 
+        if ( jl_apply(jl_is_open, (jl_value_t **) &(handle->data), 1) == jl_false ){
             return;
         }
 
@@ -313,7 +312,7 @@ DLLEXPORT void jl_close_uv(uv_handle_t *handle)
             uv_close(handle, &closeHandle);
         }
     }
-    else{
+    else {
         uv_close(handle,&closeHandle);
     }
 }

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -297,8 +297,8 @@ DLLEXPORT void jl_close_uv(uv_handle_t *handle)
     if (handle->type==UV_TTY)
         uv_tty_set_mode((uv_tty_t*)handle,0);
 
-    if (uv_is_writable((uv_stream_t*)handle) && // uv_shutdown returns an error if not writable
-          (handle->type == UV_NAMED_PIPE || handle->type == UV_TCP)) { 
+    if ((handle->type == UV_NAMED_PIPE || handle->type == UV_TCP) && // uv_shutdown returns an error if not writable
+          uv_is_writable((uv_stream_t*)handle)) { 
         // Make sure that the stream has not already been marked closed in Julia.
         jl_function_t* jl_is_open = (jl_function_t*) jl_get_global(jl_base_module, jl_symbol("isopen"));
         if ( jl_apply(jl_is_open, (jl_value_t **) &(handle->data), 1) == jl_false){

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -41,3 +41,14 @@ if false
     @test  success(ignorestatus(`false` | `false`))
     @test  success(ignorestatus(`false` & `false`))
 end
+
+# Here we test that if we close a stream with pending writes, we don't lose the writes.
+str = ""
+for i=1:10
+  str = "$str\n $(randstring(10))"
+end
+stdout, stdin, proc = readandwrite(`cat -`)
+write(stdin, str)
+close(stdin)
+str2 = readall(stdout)
+@test str2 == str

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -44,7 +44,7 @@ end
 
 # Here we test that if we close a stream with pending writes, we don't lose the writes.
 str = ""
-for i=1:10
+for i=1:1000
   str = "$str\n $(randstring(10))"
 end
 stdout, stdin, proc = readandwrite(`cat -`)
@@ -52,3 +52,9 @@ write(stdin, str)
 close(stdin)
 str2 = readall(stdout)
 @test str2 == str
+
+# This test hangs if the end of run walk across uv streams calls shutdown on a stream that is shutting down.
+file = tempname()
+stdout, stdin, proc = readandwrite(`cat -` > file)
+write(stdin, str)
+close(stdin)


### PR DESCRIPTION
This pull request resolves issue #2443.

I create a function is_open so that I can find out whether a stream has been marked closed in Julia from the C side, and call it in jl_close_uv to make sure shutdown isn't called twice.

If shutdown is called twice, my test will hang rather than fail.  I couldn't figure out how to make that happen well.

I also didn't condense the switch statement in init.c, since I'm not sure whether those separations are still meaningful.

Thanks @vtjnash for helping me a lot with the Julia internals.
