### PR TITLE
fix rst markup in doc/manual/types.rst

### DIFF
--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -570,8 +570,8 @@ subtypes of each other::
 
 This last point is very important:
 
-    **Even though ``Float64 <: Real`` we DO NOT have
-    ``Point{Float64} <: Point{Real}``.**
+    **Even though** ``Float64 <: Real`` **we DO NOT have**
+    ``Point{Float64} <: Point{Real}``\ **.**
 
 In other words, in the parlance of type theory, Julia's type parameters
 are *invariant*, rather than being covariant (or even contravariant).


### PR DESCRIPTION
In rst markup, inline literals (i.e. code samples)
can't be nested inside strong emphasis (bold).
The backticks were showing in the rendered output.
