### PR TITLE
Staged bsxfun and other broadcast operations

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1,0 +1,203 @@
+module Broadcast
+
+using ..Meta.quot
+import Base.(.+), Base.(.-), Base.(.*), Base.(./) 
+export broadcast, broadcast_getindex, broadcast_setindex!
+
+
+## Broadcasting utilities ##
+
+# Calculate the broadcast shape of the arguments, or error if incompatible
+broadcast_shape() = ()
+function broadcast_shape(As::AbstractArray...)
+    nd = ndims(As[1])
+    for i = 2:length(As)
+        nd = max(nd, ndims(As[i]))
+    end
+    bshape = ones(Int, nd)
+    for A in As
+        for d = 1:ndims(A)
+            n = size(A, d)
+            if n != 1
+                if bshape[d] == 1
+                    bshape[d] = n
+                elseif bshape[d] != n
+                    error("arrays cannot be broadcast to a common size")
+                end
+            end
+        end
+    end
+    return tuple(bshape...)
+end
+
+# Check that all arguments are broadcast compatible with shape
+function check_broadcast_shape(shape::Dims, As::AbstractArray...)
+    for A in As
+        if ndims(A) > length(shape)
+            error("cannot broadcast array to have fewer dimensions")
+        end
+        for k in 1:ndims(A)
+            n, nA = shape[k], size(A, k)
+            if n != nA != 1
+                error("array cannot be broadcast to match destination")
+            end
+        end
+    end
+end
+
+# Calculate strides as will be used by the generated inner loops
+function calc_loop_strides(shape::Dims, As::AbstractArray...)
+    # squeeze out singleton dimensions in shape
+    dims = Array(Int, 0)
+    loopshape = Array(Int, 0)
+    nd = length(shape)
+    sizehint(dims, nd)
+    sizehint(loopshape, nd)
+    for i = 1:nd
+        s = shape[i]
+        if s != 1
+            push!(dims, i)
+            push!(loopshape, s)
+        end
+    end
+    nd = length(loopshape)
+
+    strides = [(size(A, d) > 1 ? stride(A, d) : 0) for A in As, d in dims]
+    # convert from regular strides to loop strides
+    for k=(nd-1):-1:1, a=1:length(As)
+        strides[a, k+1] -= strides[a, k]*loopshape[k]
+    end
+
+    tuple(loopshape...), strides
+end
+
+function broadcast_args(shape::Dims, As::(Array...))
+    loopshape, strides = calc_loop_strides(shape, As...)
+    # todo: Peel subarrays to expose their arrays and offsets
+    (loopshape, As, strides)
+end
+
+
+## Generation of inner loop instances ##
+
+function code_inner_loop(fname::Symbol, extra_args::Vector, initial,
+                         innermost::Function, narrays::Int, nd::Int)
+    arrays  = [gensym("A$a") for a=1:narrays]
+    inds    = [gensym("k$a") for a=1:narrays]
+    axes    = [gensym("i$d") for d=1:nd]
+    sizes   = [gensym("n$d") for d=1:nd]
+    strides = [gensym("s$(a)_$d") for a=1:narrays, d=1:nd]
+        
+    loop = innermost([:($arr[$ind]) for (arr, ind) in zip(arrays, inds)]...)
+    for (d, (axis, n)) in enumerate(zip(axes, sizes))
+        loop = :(
+            for $axis=1:$n
+                $loop
+                $([:($ind += $(strides[a, d]))
+                   for (a, ind) in enumerate(inds)]...)
+            end
+        )
+    end
+
+    quote
+        function $fname(shape::NTuple{$nd, Int},
+                        arrays::NTuple{$narrays, Array},
+                        strides::Matrix{Int}, $(extra_args...))
+            @assert size(strides) == ($narrays, $nd)
+            ($(sizes...),) = shape
+            $([:(if $n==0; return; end) for n in sizes]...)
+            ($(arrays...),)  = arrays
+            $([:($ind = 1) for ind in inds]...)
+            ($(strides...),) = strides
+            $initial
+            $loop
+        end
+    end
+end
+
+
+## Generation of inner loop staged functions ##
+
+function code_inner(fname::Symbol, extra_args::Vector, initial,
+                    innermost::Function)
+    quote
+        function $fname(shape::(Int...), arrays::(Array...), 
+                        strides::Matrix{Int}, $(extra_args...))
+            f = eval(code_inner_loop($(quot(fname)), $(quot(extra_args)),
+                                     $(quot(initial)), $(quot(innermost)),
+                                     length(arrays), length(shape)))
+            f(shape, arrays, strides, $(extra_args...))
+        end
+    end
+end
+
+code_foreach_inner(fname::Symbol, extra_args::Vector, innermost::Function) =
+    code_inner(fname, extra_args, quote end, innermost)
+
+function code_map!_inner(fname::Symbol, dest, extra_args::Vector, 
+                         innermost::Function)
+    @gensym k
+    code_inner(fname, {dest, extra_args...}, :($k=1),
+        (els...)->quote
+            $dest[$k] = $(innermost(:($dest[$k]), els...))
+            $k += 1
+        end)
+end
+
+
+## (Generation of) complete broadcast functions ##
+
+function code_broadcast(fname::Symbol, op)
+    inner! = gensym("$(fname)_inner!")
+    innerdef = code_map!_inner(inner!, :(result::Array), [],
+                               (dest, els...) -> :( $op($(els...)) ))
+    quote
+        $innerdef
+        function $fname(A1::Array, As::Array...)
+            As = tuple(A1, As...)
+            shape = broadcast_shape(As...)
+            result = Array(promote_type([eltype(A) for A in As]...), shape)
+            $inner!(broadcast_args(shape, As)..., result)
+            result
+        end        
+    end
+end
+
+eval(code_map!_inner(:broadcast_getindex_inner!,
+                     :(result::Array), [:(A::AbstractArray)],
+                     (dest, inds...) -> :( A[$(inds...)] )))
+function broadcast_getindex(A::AbstractArray, ind1::Array, inds::Array...)
+    inds = tuple(ind1, inds...)
+    shape = broadcast_shape(inds...)
+    result = Array(eltype(A), shape)
+    broadcast_getindex_inner!(broadcast_args(shape, inds)..., result, A)
+    result
+end
+
+eval(code_foreach_inner(:broadcast_setindex!_inner!, [:(A::AbstractArray)],
+                        (x, inds...)->:( A[$(inds...)] = $x )))
+function broadcast_setindex!(A::AbstractArray, X::Array,
+                             ind1::Array, inds::Array...)
+    Xinds = tuple(X, ind1, inds...)
+    shape = broadcast_shape(Xinds...)
+    broadcast_setindex!_inner!(broadcast_args(shape, Xinds)..., A)
+    Xinds[1]
+end
+
+
+## the actual broadcast function ##
+
+for (fname, op) in {(:.+, +), (:.-, -), (:.*, *), (:./, /)}
+    eval(code_broadcast(fname, quot(op)))
+end
+
+broadcastfuns = (Function=>Function)[]
+function get_broadcastfun(op::Function)
+    (haskey(broadcastfuns, op) ? broadcastfuns[op] :
+        (broadcastfuns[op] = eval(code_broadcast(gensym("broadcast_$(op)"), 
+                                                 quot(op)))))
+end
+broadcast(op::Function, As::Array...) = get_broadcastfun(op)(As...)
+
+
+end # module

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -469,7 +469,9 @@ export
 # arrays
     mapslices,
     reducedim,
-    bsxfun,
+    broadcast,
+    broadcast_getindex,
+    broadcast_setindex!,
     cartesianmap,
     cat,
     cell,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -471,6 +471,8 @@ export
     reducedim,
     broadcast,
     broadcast!,
+    broadcast_function,
+    broadcast!_function,
     broadcast_getindex,
     broadcast_setindex!,
     cartesianmap,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -470,6 +470,7 @@ export
     mapslices,
     reducedim,
     broadcast,
+    broadcast!,
     broadcast_getindex,
     broadcast_setindex!,
     cartesianmap,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -165,8 +165,7 @@ include("sparse.jl")
 include("linalg.jl")
 importall .LinAlg
 include("broadcast.jl")
-import .Broadcast.broadcast
-import .Broadcast.broadcast_getindex, .Broadcast.broadcast_setindex!
+importall .Broadcast
 
 # signal processing
 include("fftw.jl")

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -164,6 +164,9 @@ push!(I18n.CALLBACKS, Help.clear_cache)
 include("sparse.jl")
 include("linalg.jl")
 importall .LinAlg
+include("broadcast.jl")
+import .Broadcast.broadcast
+import .Broadcast.broadcast_getindex, .Broadcast.broadcast_setindex!
 
 # signal processing
 include("fftw.jl")

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -329,13 +329,13 @@ vector to the size of the matrix::
      0.848333  1.66714  1.3262 
      1.26743   1.77988  1.13859
 
-This is wasteful when dimensions get large, so Julia offers the
-MATLAB-inspired ``bsxfun``, which expands singleton dimensions in
+This is wasteful when dimensions get large, so Julia offers
+``broadcast``, which expands singleton dimensions in
 array arguments to match the corresponding dimension in the other
-array without using extra memory, and applies the given binary
-function::
+array without using extra memory, and applies the given
+function elementwise::
 
-    julia> bsxfun(+, a, A)
+    julia> broadcast(+, a, A)
     2x3 Float64 Array:
      0.848333  1.66714  1.3262 
      1.26743   1.77988  1.13859
@@ -344,10 +344,12 @@ function::
     1x2 Float64 Array:
      0.629799  0.754948
 
-    julia> bsxfun(+, a, b)
+    julia> broadcast(+, a, b)
     2x2 Float64 Array:
      1.31849  1.44364
      1.56107  1.68622
+
+Elementwise operators such as ``.+`` and ``.*`` perform broadcasting if necessary. There is also a ``broadcast!`` function to specify an explicit destination, and ``broadcast_getindex`` and ``broadcast_setindex!`` that broadcast the indices before indexing.
 
 Implementation
 --------------

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -2225,28 +2225,48 @@ Mathematical operators and functions
 
 All mathematical operations and functions are supported for arrays
 
-.. function:: bsxfun(fn, A, B[, C...])
+.. function:: broadcast(f, As...)
 
-   Apply binary function ``fn`` to two or more arrays, with singleton dimensions expanded.
+   Broadcasts the arrays ``As`` to a common size by expanding singleton dimensions, and returns an array of the results ``f(as...)`` for each position.
+
+.. function:: broadcast!(f, dest, As...)
+
+   Like ``broadcast``, but store the result in the ``dest`` array.
+
+.. function:: broadcast_function(f)
+
+   Returns a function ``broadcast_f`` such that ``broadcast_function(f)(As...) === broadcast(f, As...)``. Most useful in the form ``const broadcast_f = broadcast_function(f)``.
+
+.. function:: broadcast!_function(f)
+   
+   Like ``broadcast_function``, but for ``broadcast!``.
 
 Indexing, Assignment, and Concatenation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: getindex(A, ind)
+.. function:: getindex(A, inds...)
 
-   Returns a subset of array ``A`` as specified by ``ind``, which may be an ``Int``, a ``Range``, or a ``Vector``.
+   Returns a subset of array ``A`` as specified by ``inds``, where each ``ind`` may be an ``Int``, a ``Range``, or a ``Vector``.
 
-.. function:: sub(A, ind)
+.. function:: sub(A, inds...)
 
-   Returns a SubArray, which stores the input ``A`` and ``ind`` rather than computing the result immediately. Calling ``getindex`` on a SubArray computes the indices on the fly.
+   Returns a SubArray, which stores the input ``A`` and ``inds`` rather than computing the result immediately. Calling ``getindex`` on a SubArray computes the indices on the fly.
 
 .. function:: slicedim(A, d, i)
 
    Return all the data of ``A`` where the index for dimension ``d`` equals ``i``. Equivalent to ``A[:,:,...,i,:,:,...]`` where ``i`` is in position ``d``.
 
-.. function:: setindex!(A, X, ind)
+.. function:: setindex!(A, X, inds...)
 
-   Store values from array ``X`` within some subset of ``A`` as specified by ``ind``.
+   Store values from array ``X`` within some subset of ``A`` as specified by ``inds``.
+
+.. function:: broadcast_getindex(A, inds...)
+
+   Broadcasts the ``inds`` arrays to a common size like ``broadcast``, and returns an array of the results ``A[ks...]``, where ``ks`` goes over the positions in the broadcast.
+
+.. function:: broadcast_setindex!(A, X, inds...)
+
+   Broadcasts the ``X`` and ``inds`` arrays to a common size and stores the value from each position in ``X`` at the indices given by the same positions in ``inds``.
 
 .. function:: cat(dim, A...)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ TESTS = all core keywordargs numbers strings unicode corelib hashing	\
 	remote iostring arrayops linalg blas fft dsp sparse bitarray		\
 	random math functional bigint sorting statistics spawn	parallel	\
 	arpack bigfloat file git pkg pkg2 suitesparse complex version		\
-	pollfd mpfr
+	pollfd mpfr broadcast
 
 $(TESTS) ::
 	$(QUIET_JULIA) $(call spawn,$(JULIA_EXECUTABLE)) ./runtests.jl $@

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,24 +1,45 @@
-@test broadcast(+, eye(2), [1, 4]) == [2 1; 4 5]
-@test broadcast(+, eye(2), [1  4]) == [2 4; 1 5]
-@test broadcast(+, [1  0], [1, 4]) == [2 1; 5 4]
-@test broadcast(+, [1, 0], [1  4]) == [2 5; 1 4]
-@test broadcast(+, [1, 0], [1, 4]) == [2, 4]
-@test broadcast(+) == 0
-@test broadcast(*) == 1
+function as_sub(x::Vector)
+    y = Array(eltype(x), length(x)*2)
+    y = sub(y, 2:2:length(y))
+    y[:] = x[:]
+    y
+end
+function as_sub(x::Matrix)
+    y = Array(eltype(x), tuple(([size(x)...]*2)...))
+    y = sub(y, 2:2:size(y,1), 2:2:size(y,2))
+    for j=1:size(x,2)
+        for i=1:size(x,1)
+            y[i,j] = x[i,j]
+        end
+    end
+    y
+end
 
-@test eye(2) .+ [1, 4] == [2 1; 4 5]
-@test eye(2) .+ [1  4] == [2 4; 1 5]
-@test [1  0] .+ [1, 4] == [2 1; 5 4]
-@test [1, 0] .+ [1  4] == [2 5; 1 4]
-@test [1, 0] .+ [1, 4] == [2, 4]
-@test [1] .+ [] == []
-
-A = eye(2); @test broadcast!(+, A, A, [1, 4]) == [2 1; 4 5]
-A = eye(2); @test broadcast!(+, A, A, [1  4]) == [2 4; 1 5]
-A = [1  0]; @test_fails broadcast!(+, A, A, [1, 4])
-A = [1  0]; @test broadcast!(+, A, A, [1  4]) == [2 4]
-
-M = [11 12; 21 22]
-@test broadcast_getindex(M, eye(2)+1,[1, 2]) == [21 11; 12 22]
-A = zeros(2,2); broadcast_setindex!(A, [21 11; 12 22], eye(2)+1,[1, 2])
-@test A == M
+for arr in (identity, as_sub)
+    @test broadcast(+, arr(eye(2)), arr([1, 4])) == [2 1; 4 5]
+    @test broadcast(+, arr(eye(2)), arr([1  4])) == [2 4; 1 5]
+    @test broadcast(+, arr([1  0]), arr([1, 4])) == [2 1; 5 4]
+    @test broadcast(+, arr([1, 0]), arr([1  4])) == [2 5; 1 4]
+    @test broadcast(+, arr([1, 0]), arr([1, 4])) == [2, 4]
+    @test broadcast(+) == 0
+    @test broadcast(*) == 1
+    
+    @test arr(eye(2)) .+ arr([1, 4]) == arr([2 1; 4 5])
+    @test arr(eye(2)) .+ arr([1  4]) == arr([2 4; 1 5])
+    @test arr([1  0]) .+ arr([1, 4]) == arr([2 1; 5 4])
+    @test arr([1, 0]) .+ arr([1  4]) == arr([2 5; 1 4])
+    @test arr([1, 0]) .+ arr([1, 4]) == arr([2, 4])
+    @test arr([1]) .+ arr([]) == arr([])
+    
+    A = arr(eye(2)); @test broadcast!(+, A, A, arr([1, 4])) == arr([2 1; 4 5])
+    A = arr(eye(2)); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4; 1 5])
+    A = arr([1  0]); @test_fails broadcast!(+, A, A, arr([1, 4]))
+    A = arr([1  0]); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4])
+    
+    M = arr([11 12; 21 22])
+    @test broadcast_getindex(M, eye(Int, 2)+1,arr([1, 2])) == [21 11; 12 22]
+    
+    A = arr(zeros(2,2))
+    broadcast_setindex!(A, arr([21 11; 12 22]), eye(Int, 2)+1,arr([1, 2]))
+    @test A == M
+end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -11,6 +11,11 @@
 @test [1, 0] .+ [1, 4] == [2, 4]
 @test [1] .+ [] == []
 
+A = eye(2); @test broadcast!(+, A, A, [1, 4]) == [2 1; 4 5]
+A = eye(2); @test broadcast!(+, A, A, [1  4]) == [2 4; 1 5]
+A = [1  0]; @test_fails broadcast!(+, A, A, [1, 4])
+A = [1  0]; @test broadcast!(+, A, A, [1  4]) == [2 4]
+
 M = [11 12; 21 22]
 @test broadcast_getindex(M, eye(2)+1,[1, 2]) == [21 11; 12 22]
 A = zeros(2,2); broadcast_setindex!(A, [21 11; 12 22], eye(2)+1,[1, 2])

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -3,6 +3,8 @@
 @test broadcast(+, [1  0], [1, 4]) == [2 1; 5 4]
 @test broadcast(+, [1, 0], [1  4]) == [2 5; 1 4]
 @test broadcast(+, [1, 0], [1, 4]) == [2, 4]
+@test broadcast(+) == 0
+@test broadcast(*) == 1
 
 @test eye(2) .+ [1, 4] == [2 1; 4 5]
 @test eye(2) .+ [1  4] == [2 4; 1 5]

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,0 +1,17 @@
+@test broadcast(+, eye(2), [1, 4]) == [2 1; 4 5]
+@test broadcast(+, eye(2), [1  4]) == [2 4; 1 5]
+@test broadcast(+, [1  0], [1, 4]) == [2 1; 5 4]
+@test broadcast(+, [1, 0], [1  4]) == [2 5; 1 4]
+@test broadcast(+, [1, 0], [1, 4]) == [2, 4]
+
+@test eye(2) .+ [1, 4] == [2 1; 4 5]
+@test eye(2) .+ [1  4] == [2 4; 1 5]
+@test [1  0] .+ [1, 4] == [2 1; 5 4]
+@test [1, 0] .+ [1  4] == [2 5; 1 4]
+@test [1, 0] .+ [1, 4] == [2, 4]
+@test [1] .+ [] == []
+
+M = [11 12; 21 22]
+@test broadcast_getindex(M, eye(2)+1,[1, 2]) == [21 11; 12 22]
+A = zeros(2,2); broadcast_setindex!(A, [21 11; 12 22], eye(2)+1,[1, 2])
+@test A == M

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ testnames = ["core", "keywordargs", "numbers", "strings", "unicode",
              "random", "math", "functional", "bigint", "sorting",
              "statistics", "spawn", "parallel", "priorityqueue",
              "arpack", "file", "perf", "suitesparse", "version",
-             "pollfd", "mpfr"]
+             "pollfd", "mpfr", "broadcast"]
 
 # Disabled: "complex"
 


### PR DESCRIPTION
This patch adds an implementation of `bsxfun(op::Function, As::Array...)`
that generates inner loop functions depending on `op`, the number of arguments
`As`, and the dimension of the result.

The machinery is also used to provide
- broadcasting operators `.+ .- .* ./` for `Array` arguments
- `bsxfun!(op::Function, As::Array...)`, which stores the result in
  `As[1]` **Edit:** Removed this one, pending a rewrite with separate output argument.
- `get_bsxfun(op::Function)` and `get_bsxfun!(op::Function)` to instantiate a
  broadcasting operation from a given per-element operation
- `bsx_getindex(A::AbstractArray, inds::Array...)`,
  a pointwise broadcasting indexing operation as described in #2591,
  and a matching `bsx_setindex!(A::AbstractArray, X::Array, inds::Array...)`

It should be straightforward to extend the functions to work with `StridedArray` arguments instead of just `Array`, but I'm uncertain of the proper interface to work with subarrays using manual linear indexing.

The code generates inner loop functions such as

```
function bsx_plus_inner!(shape::NTuple{2,Int}, arrays::NTuple{2,Array},
                         strides::Matrix{Int}, result::Array)
    @assert (size(strides)==(2,2))
    (n1,n2) = shape
    if (n1==0); return; end
    if (n2==0); return; end
    (A1,A2) = arrays
    k1 = 1
    k2 = 1
    (s1_1,s2_1,s1_2,s2_2) = strides
    k = 1
    for i2 = 1:n2
        for i1 = 1:n1
            begin 
                result[k] = +(A1[k1],A2[k2])
                k += 1
            end
            k1 += s1_1
            k2 += s2_1
        end
        k1 += s1_2
        k2 += s2_2
    end
end
```

The example above is for `bsxfun(+, A, B)` with two-dimensional result.
A linear index is updated using strides for each array, which should allow to accomodate
both broadcasting and subarrays.

On my machine, the timing example from #2991 gives

```
elapsed time: 0.806272502 seconds  # subcol_forloop(a, b)
elapsed time: 3.1062779 seconds    # subcol_bsxfun(a, b)
elapsed time: 0.936735113 seconds  # .- from this pull request
```

i.e. the generated `.-` is only 16% slower than the handcoded example in #2991.

It's a somewhat complex piece of code (that generates code that generates code), and I think that it warrants some discussion. I could polish this forever, but I think that I need some reactions before moving forward. What do you guys think? Would something like this be useful? What parts of it?

**Edit:** Renamed `bsxfun` and `bsx` to `broadcast`.
