### PR TITLE
OSX App Launch Fix

### DIFF
--- a/contrib/mac/app/script
+++ b/contrib/mac/app/script
@@ -30,7 +30,7 @@ osascript 2>&1>/dev/null <<EOF
       tell application "System Events" to tell process "Terminal" to keystroke "n" using command down
     end if
     do script ("exec bash -c \"PATH=${ROOT}/julia/bin:${PATH} GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'\"") in front window
-    end tell
+  end tell
 EOF
 
 # Quit the Julia.application immediately after startup (ie. quitting

--- a/contrib/mac/app/script
+++ b/contrib/mac/app/script
@@ -24,14 +24,13 @@ ROOT="${0%/script}"
 # 20071007 removed: open -a /Applications/Utilities/Terminal.app
 osascript 2>&1>/dev/null <<EOF
   tell application "System Events" to set ProcessList to get name of every process
-  tell application "Terminal" 
+  tell application "Terminal"
     activate
-    if ProcessList contains "Terminal" then
-      do script ("exec bash -c \"PATH=${ROOT}/julia/bin:${PATH} GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'\"")
-    else
-      do script ("exec bash -c \"PATH=${ROOT}/julia/bin:${PATH} GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'\"") in front window
+    if (ProcessList contains "Terminal") or ((count of every window) is less than 1) then
+      tell application "System Events" to tell process "Terminal" to keystroke "n" using command down
     end if
-  end tell
+    do script ("exec bash -c \"PATH=${ROOT}/julia/bin:${PATH} GIT_EXEC_PATH=${ROOT}/julia/libexec/git-core GIT_TEMPLATE_DIR=${ROOT}/julia/share/git-core exec '${ROOT}/julia/bin/julia'\"") in front window
+    end tell
 EOF
 
 # Quit the Julia.application immediately after startup (ie. quitting


### PR DESCRIPTION
The applescript for launching a new Terminal on OSX to run julia is a little fragile. It may not actually run julia sometimes (seen on OSX 10.7.5 Lion with zsh as default shell)

The guaranteed way to ensure that julia does actually run is to spawn a new Terminal window manually and run the bash command `in front window`.

Tested on OSX 10.7.5 Lion.
