### PR TITLE
When calling help on undocumented DataTypes, show more information.

### DIFF
--- a/base/help.jl
+++ b/base/help.jl
@@ -151,7 +151,14 @@ function help_for(fname::String, obj)
         end
     end
     if !found
-        if isgeneric(obj)
+        if isa(obj, DataType)
+            print("DataType: ")
+            repl_show(obj)
+            println()
+            if length(obj.names) > 0
+                println("  fields: ", obj.names)
+            end
+        elseif isgeneric(obj)
             repl_show(obj); println()
         else
             println("No help information found.")


### PR DESCRIPTION
Right now, when calling help on undocumented types, all that is returned is the type name itself.  This patch adds slightly more information:

``` julia
julia> IOStream
IOStream

julia> help(IOStream)
DataType: IOStream
  fields: (:handle,:ios,:name)

julia> DataType
DataType

julia> help(DataType)
DataType: DataType
  fields: (:fptr,:env,:code,:name,:super,:parameters,:names,:types,:ctor_factory,:instance,:size,:abstract,:mutable,:pointerfree)
```
