### PR TITLE
Added subtypes functions, updated help, docs

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -915,6 +915,7 @@ export
     promote_rule,
     promote_type,
     super,
+    subtypes,
     typeintersect,
     typejoin,
 

--- a/base/help.jl
+++ b/base/help.jl
@@ -152,11 +152,20 @@ function help_for(fname::String, obj)
     end
     if !found
         if isa(obj, DataType)
-            print("DataType: ")
+            print("DataType   : ")
             repl_show(obj)
             println()
+            println("  supertype: ", super(obj))
+            if obj.abstract
+                st = subtypes(obj)
+                if length(st) > 0
+                    print("  subtypes : ")
+                    showcompact(st)
+                    println()
+                end
+            end
             if length(obj.names) > 0
-                println("  fields: ", obj.names)
+                println("  fields   : ", obj.names)
             end
         elseif isgeneric(obj)
             repl_show(obj); println()
@@ -206,9 +215,11 @@ help(t::Module) = help(string(t))
 function help(x)
     show(x)
     t = typeof(x)
-    println(" is of type $t")
-    if isa(t,DataType) && length(t.names)>0
-        println("  which has fields $(t.names)")
+    if isa(t,DataType)
+        println(" is of type")
+        help(t)
+    else
+        println(" is of type $t")
     end
 end
 

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -229,6 +229,12 @@
 
 "),
 
+("Types","Base","super","super(T::DataType)
+
+   Return the supertype of DataType T
+
+"),
+
 ("Types","Base","subtype","subtype(type1, type2)
 
    True if and only if all values of \"type1\" are also of \"type2\".
@@ -240,6 +246,22 @@
 ("Types","Base","<:","<:(T1, T2)
 
    Subtype operator, equivalent to \"subtype(T1,T2)\".
+
+"),
+
+("Types","Base","subtypes","subtypes(T::DataType)
+
+   Return a list of immediate subtypes of DataType T.  Note that all
+   currently loaded subtypes are included, including those not visible
+   in the current module.
+
+"),
+
+("Types","Base","subtypetree","subtypetree(T::DataType)
+
+   Return a nested list of all subtypes of DataType T.  Note that all
+   currently loaded subtypes are included, including those not visible
+   in the current module.
 
 "),
 
@@ -330,6 +352,25 @@
 
    Determine the declared type of a named field in a value of
    composite type.
+
+"),
+
+("Types","Base","isimmutable","isimmutable(T)
+
+   True if T is immutable.  See *Immutable Composite Types* for a
+   discussion of immutability.
+
+"),
+
+("Types","Base","isabstract","isabstract(T)
+
+   True if T is an abstract type.
+
+"),
+
+("Types","Base","isbits","isbits(T)
+
+   True if T is a bits type (e.g., Uint8, Int64, Float64).
 
 "),
 
@@ -1709,6 +1750,15 @@
 ("Mathematical Functions","Base",">>>",">>>(x, n)
 
    Unsigned right shift operator.
+
+"),
+
+("Mathematical Functions","Base",":",":(start[, step], stop)
+
+   Range operator. \"a:b\" constructs a range from \"a\" to \"b\" with
+   a step size of 1, and \"a:s:b\" is similar but uses a step size of
+   \"s\". These syntaxes call the function \"colon\". The colon is
+   also used in indexing to select whole dimensions.
 
 "),
 
@@ -4583,7 +4633,10 @@
 ("C Interface","Base","cglobal","cglobal((symbol, library) or ptr[, Type=Void])
 
    Obtain a pointer to a global variable in a C-exported shared
-   library,
+   library, specified exactly as in \"ccall\".  Returns a
+   \"Ptr{Type}\", defaulting to \"Ptr{Void}\" if no Type argument is
+   supplied.  The values can be read or written by \"unsafe_load\" or
+   \"unsafe_store!\", respectively.
 
 "),
 

--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -6,7 +6,7 @@
 
 Julia ships with predefined types representing both complex and rational
 numbers, and supports all :ref:`standard mathematical operations
-<man-mathematical-operations>` on them. :ref:`man-promotions`
+<man-mathematical-operations>` on them. :ref:`man-conversion-and-promotion`
 are defined so that operations on any combination of
 predefined numeric types, whether primitive or composite, behave as
 expected.
@@ -144,7 +144,7 @@ versus ``-1 + 0im`` even though ``-1 == -1 + 0im``::
     julia> sqrt(-1 + 0im)
     0.0 + 1.0im
 
-The :ref:`literal numeric coefficient notation <numeric-literal-coefficients>`
+The :ref:`literal numeric coefficient notation <man-numeric-literal-coefficients>`
 does work when constructing complex number from variables. Instead, the
 multiplication must be explicitly written out::
 

--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -197,7 +197,7 @@ The last point is potentially surprising and thus worth noting::
     julia> NaN > NaN
     false
 
-and can cause especial headaches with :ref:`Arrays`::
+and can cause especial headaches with :ref:`Arrays <man-arrays>`::
 
     julia> [1 NaN] == [1 NaN]
     false

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -376,6 +376,8 @@ Types <#man-parametric-types>`_ and on :ref:`man-methods`, and is
 sufficiently important to be addressed in its own section:
 :ref:`man-constructors`.
 
+.. _man-immutable-composite-types:
+
 Immutable Composite Types
 -------------------------
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -128,6 +128,10 @@ All Objects
 Types
 -----
 
+.. function:: super(T::DataType)
+
+   Return the supertype of DataType T
+
 .. function:: subtype(type1, type2)
 
    True if and only if all values of ``type1`` are also of ``type2``. Can also be written using the ``<:`` infix operator as ``type1 <: type2``.
@@ -135,6 +139,14 @@ Types
 .. function:: <:(T1, T2)
 
    Subtype operator, equivalent to ``subtype(T1,T2)``.
+
+.. function:: subtypes(T::DataType)
+
+   Return a list of immediate subtypes of DataType T.  Note that all currently loaded subtypes are included, including those not visible in the current module.
+
+.. function:: subtypetree(T::DataType)
+
+   Return a nested list of all subtypes of DataType T.  Note that all currently loaded subtypes are included, including those not visible in the current module.
 
 .. function:: typemin(type)
 
@@ -186,6 +198,18 @@ Types
 .. function:: fieldtype(value, name::Symbol)
 
    Determine the declared type of a named field in a value of composite type.
+
+.. function:: isimmutable(v)
+
+   True if value ``v`` is immutable.  See :ref:`man-immutable-composite-types` for a discussion of immutability.
+
+.. function:: isabstract(T)
+
+   True if ``T`` is an abstract type.
+
+.. function:: isbits(T)
+
+   True if ``T`` is a bits type (e.g., Uint8, Int64, Float64).
 
 Generic Functions
 -----------------
@@ -1117,7 +1141,7 @@ Mathematical Functions
 
    Unsigned right shift operator.
 
-.. function:: :(start, [step], stop)
+.. function:: \:(start, [step], stop)
 
    Range operator. ``a:b`` constructs a range from ``a`` to ``b`` with a step size of 1,
    and ``a:s:b`` is similar but uses a step size of ``s``. These syntaxes call the
@@ -3021,10 +3045,7 @@ C Interface
 
 .. function:: cglobal((symbol, library) or ptr [, Type=Void])
 
-   Obtain a pointer to a global variable in a C-exported shared library,
-specified exactly as in ``ccall``.  Returns a ``Ptr{Type}``, defaulting
-to ``Ptr{Void}`` if no Type argument is supplied.  The values can be
-read or written by ``unsafe_load`` or ``unsafe_store!``, respectively.
+   Obtain a pointer to a global variable in a C-exported shared library, specified exactly as in ``ccall``.  Returns a ``Ptr{Type}``, defaulting to ``Ptr{Void}`` if no Type argument is supplied.  The values can be read or written by ``unsafe_load`` or ``unsafe_store!``, respectively.
 
 .. function:: cfunction(fun::Function, RetType::Type, (ArgTypes...))
    


### PR DESCRIPTION
- Added ~~isabstract(T),~~ `subtypes(T)`, `subtypetree(T)`
- Updated `help(x::DataType)` to print super, subtype info
- Doc fixes/updates.

Prompted by a suggestion by Stefan in #3116
