### PR TITLE
Add syntax highlighting definition for Gedit

### DIFF
--- a/contrib/julia.lang
+++ b/contrib/julia.lang
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ This file is part of GtkSourceView
+
+ Authors: Waldir Pimenta
+ Copyright (C) 2013 Waldir Pimenta <waldir@email.com>
+
+ GtkSourceView is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ GtkSourceView is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
+<language id="julia" _name="Julia" version="2.0" _section="Scientific" >
+
+  <metadata>
+    <property name="mimetypes" >text/x-julia;application/x-julia</property>
+    <property name="globs" >*.jl</property>
+    <property name="line-comment-start" >#</property>
+  </metadata>
+
+  <!--
+  The full list of available styles can be found in the `def.lang` file:
+  https://git.gnome.org/browse/gtksourceview/tree/data/language-specs/def.lang
+  -->
+  <styles></styles>
+
+  <definitions>
+    <context id="julia">
+      <include>
+
+        <context id="comment" ref="def:shell-like-comment" />
+
+        <context id="string" style-ref="def:string" >
+          <start>"</start>
+          <end>"</end>
+          <include>
+            <context ref="def:escape" />
+          </include>
+        </context>
+
+        <context id="number" style-ref="def:number">
+          <keyword>0b[01]+(im)?</keyword>                            <!-- binary -->
+          <keyword>0o[0-7]+(im)?</keyword>                           <!-- octal -->
+          <keyword>(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?(im)?</keyword> <!-- decimal -->
+          <keyword>0x[0-9a-fA-F]+(im)?</keyword>                     <!-- hexadecimal -->
+        </context>
+
+        <context id="boolean" style-ref="def:boolean">
+          <keyword>true|false</keyword>
+        </context>
+
+        <context id="special-constant" style-ref="def:special-constant">
+          <keyword>C_NULL|Inf|NaN|Inf32|NaN32|nothing</keyword>
+        </context>
+
+        <context id="operators" style-ref="def:operator">
+          <!-- Single-character operators -->
+          <keyword>\*\+-/\&amp;\|&lt;&gt;~$!^=,;:@</keyword>
+          <!-- Multi-character operators -->
+          <keyword>\.\.\.</keyword>
+          <keyword>::</keyword>
+          <keyword>&gt;&gt;&gt;</keyword>
+          <keyword>&gt;&gt;</keyword>
+          <keyword>&lt;&lt;</keyword>
+          <keyword>==</keyword>
+          <keyword>!=</keyword>
+          <keyword>&lt;=</keyword>
+          <keyword>&gt;=</keyword>
+          <keyword>&amp;&amp;</keyword>
+          <keyword>\|\|</keyword>
+          <keyword>\.\*</keyword>
+          <keyword>\.^</keyword>
+          <keyword>\./</keyword>
+          <keyword>\.'</keyword>
+          <keyword>\+=</keyword>
+          <keyword>-=</keyword>
+          <keyword>\*=</keyword>
+          <keyword>/=</keyword>
+          <keyword>&amp;=</keyword>
+          <keyword>\|=</keyword>
+          <keyword>\$=</keyword>
+          <keyword>&gt;&gt;&gt;=</keyword>
+          <keyword>&gt;&gt;=</keyword>
+          <keyword>&lt;&lt;=</keyword>
+        </context>
+
+        <context id="character" style-ref="def:character">
+          <keyword>'[^\']|\\.'</keyword>
+          <keyword>'\\[0-7]{1,3}'</keyword>
+          <keyword>'\x[0-9a-fA-F]{1,2}'</keyword>
+          <keyword>'\u[0-9a-fA-F]{1,3}'</keyword>
+          <keyword>'\u[0-9a-cA-C][0-9a-fA-F]{3}'</keyword>
+          <keyword>'\u[dD][0-7][0-9a-fA-F]{2}'</keyword>
+          <keyword>'\U[0-9a-fA-F]{1,5}'</keyword>
+          <keyword>'\U10[0-9a-fA-F]{4}'</keyword>
+        </context>
+
+        <context id="blocks" style-ref="def:keyword">
+          <keyword>begin</keyword>
+          <keyword>do</keyword>
+          <keyword>for</keyword>
+          <keyword>function</keyword>
+          <keyword>if</keyword>
+          <keyword>immutable</keyword>
+          <keyword>let</keyword>
+          <keyword>quote</keyword>
+          <keyword>try</keyword>
+          <keyword>type</keyword>
+          <keyword>while</keyword>
+          <keyword>catch</keyword>
+          <keyword>finally</keyword>
+          <keyword>else</keyword>
+          <keyword>elseif</keyword>
+          <keyword>end</keyword>
+        </context>
+
+        <context id="keywords" style-ref="def:keyword">
+          <keyword>abstract</keyword>
+          <keyword>bitstype</keyword>
+          <keyword>break</keyword>
+          <keyword>ccall</keyword>
+          <keyword>const</keyword>
+          <keyword>continue</keyword>
+          <keyword>export</keyword>
+          <keyword>global</keyword>
+          <keyword>import</keyword>
+          <keyword>importall</keyword>
+          <keyword>in</keyword>
+          <keyword>local</keyword>
+          <keyword>macro</keyword>
+          <keyword>module</keyword>
+          <keyword>baremodule</keyword>
+          <keyword>return</keyword>
+          <keyword>typealias</keyword>
+          <keyword>using</keyword>
+          <keyword>@\w+</keyword>
+        </context>
+
+        <context id="types" style-ref="def:type">
+          <keyword>Any|None|Nothing|Void</keyword>
+          <keyword>Type(Constructor|Name|Var|_Array)?|(Union|Data|NonTuple)Type</keyword>
+          <keyword>(Abstract|Strided|Bit)?(Array|Matrix|Vector)</keyword>
+          <keyword>Abstract(Cmd|RNG|SparseMatrix)</keyword>
+          <keyword>(Abstract|Strided)?VecOrMat</keyword>
+          <keyword>SparseMatrixCSC</keyword>
+          <keyword>(D|Sub((Or)?D)?)Array</keyword>
+          <keyword>Chars?</keyword>
+          <keyword>(ASCII|Byte|Char|Generic|Rep|Rev|Rope|Sub|UTF8)?String</keyword>
+          <keyword>Bool</keyword>
+          <keyword>Number</keyword>
+          <keyword>Real</keyword>
+          <keyword>Rational</keyword>
+          <keyword>ImaginaryUnit</keyword>
+          <keyword>Signed|Unsigned</keyword>
+          <keyword>Int(eger|Set|8|16|32|64|128)?</keyword>
+          <keyword>Uint(8|16|32|64|128)?</keyword>
+          <keyword>Float(ingPoint|32|64)</keyword>
+          <keyword>Complex(Pair|64|128)?</keyword>
+          <keyword>Big(Int|Float)</keyword>
+          <keyword>C(float|double|ptrdiff_t|u?(int|long(long)?|char|short)|s?size_t|wchar_t)</keyword>
+          <keyword>(Argument|Bounds|Divide|Domain|EOF|Inexact|Key|Load|Memory|Method|Parse|(Stack)?Overflow|System|Type|UV|UndefRef)Error</keyword>
+          <keyword>(Error|Interrupt|Disconnect)?Exception</keyword>
+          <keyword>(And|Or)Cmds</keyword>
+          <keyword>Associative</keyword>
+          <keyword>AsyncStream</keyword>
+          <keyword>Bidiagonal</keyword>
+          <keyword>Box</keyword>
+          <keyword>BunchKaufman</keyword>
+          <keyword>CPUinfo</keyword>
+          <keyword>CallStack</keyword>
+          <keyword>Callback</keyword>
+          <keyword>Cholesky</keyword>
+          <keyword>CholeskyPivoted</keyword>
+          <keyword>Cmd(Redirect)?</keyword>
+          <keyword>Colon</keyword>
+          <keyword>Diagonal</keyword>
+          <keyword>Dict</keyword>
+          <keyword>DirectIndexString</keyword>
+          <keyword>EachLine</keyword>
+          <keyword>Eigen</keyword>
+          <keyword>EmptyCallStack</keyword>
+          <keyword>Enumerate</keyword>
+          <keyword>EnvHash</keyword>
+          <keyword>Executable</keyword>
+          <keyword>Expr(Node)?</keyword>
+          <keyword>FDWatcher</keyword>
+          <keyword>Factorization</keyword>
+          <keyword>File(Monitor|Offset)</keyword>
+          <keyword>Filter</keyword>
+          <keyword>(Intrinsic)?Function</keyword>
+          <keyword>(Getfield|Goto|Label|LineNumber|Quote)Node</keyword>
+          <keyword>Hermitian</keyword>
+          <keyword>Hessenberg</keyword>
+          <keyword>IO(Buffer|Str(eam|ing))?</keyword>
+          <keyword>InetAddr</keyword>
+          <keyword>IpAddr|IPv[46]</keyword>
+          <keyword>(Key|Value)Iterator</keyword>
+          <keyword>LU|(LU|LDLT|Sym)?Tridiagonal</keyword>
+          <keyword>LambdaStaticData</keyword>
+          <keyword>LocalProcess</keyword>
+          <keyword>Long(Expr|Symbol|Tuple)</keyword>
+          <keyword>MersenneTwister</keyword>
+          <keyword>Method(Table)?</keyword>
+          <keyword>MmapArrayInfo</keyword>
+          <keyword>Module</keyword>
+          <keyword>NTuple</keyword>
+          <keyword>NamedPipe</keyword>
+          <keyword>NotFound</keyword>
+          <keyword>OS_FD</keyword>
+          <keyword>ObjectIdDict</keyword>
+          <keyword>PollingFileWatcher</keyword>
+          <keyword>Process(Chain(OrNot)?|Group)?</keyword>
+          <keyword>Ptr</keyword>
+          <keyword>QR(Pivoted)?</keyword>
+          <keyword>Range(s|1|Index|VecIntList)?</keyword>
+          <keyword>RawOrBoxedHandle</keyword>
+          <keyword>Redirectable</keyword>
+          <keyword>Regex(Match(Iterator)?)?</keyword>
+          <keyword>RemoteRef</keyword>
+          <keyword>Rest</keyword>
+          <keyword>Reverse</keyword>
+          <keyword>(Generalized)?(SVD|Schur)</keyword>
+          <keyword>Set</keyword>
+          <keyword>Socket</keyword>
+          <keyword>SpawnNullStream</keyword>
+          <keyword>Stat</keyword>
+          <keyword>StateUpdate</keyword>
+          <keyword>StaticVarInfo</keyword>
+          <keyword>Symbol(Node)?</keyword>
+          <keyword>TTY</keyword>
+          <keyword>Task</keyword>
+          <keyword>TcpSocket</keyword>
+          <keyword>TmStruct</keyword>
+          <keyword>Top(Node)?</keyword>
+          <keyword>Triangular</keyword>
+          <keyword>UV(Handle|PollingWatcher|Stream)</keyword>
+          <keyword>UdpSocket</keyword>
+          <keyword>Undef(RefTag)?</keyword>
+          <keyword>VarTable</keyword>
+          <keyword>Vararg</keyword>
+          <keyword>VersionNumber</keyword>
+          <keyword>Wait(For|Task)</keyword>
+          <keyword>Weak(KeyDict|Ref)</keyword>
+          <keyword>Woodbury</keyword>
+          <keyword>(Timeout|Idle|Single)?AsyncWork</keyword>
+          <keyword>Work(er|Item)</keyword>
+          <keyword>Zip</keyword>
+        </context>
+
+      </include>    
+    </context>
+
+  </definitions>
+
+</language>
+


### PR DESCRIPTION
Gedit is the default text editor in Ubuntu.
I also submitted this file to Gnome's bug tracker: https://bugzilla.gnome.org/show_bug.cgi?id=700410
If accepted, it will be distributed by default with Gedit.
