### PR TITLE
Range function revisions

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -141,7 +141,7 @@ isequal(r::Range1, s::Range1) = isequal(r.start,s.start) & (r.len==s.len)
 
 # TODO: isless?
 
-intersect(r::Range1, s::Range1) = max(r.start,s.start):min(last(r),last(s))
+intersect{T1<:Integer, T2<:Integer}(r::Range1{T1}, s::Range1{T2}) = max(r.start,s.start):min(last(r),last(s))
 
 intersect{T<:Integer}(i::Integer, r::Range1{T}) =
     i < first(r) ? (first(r):i) :
@@ -149,20 +149,87 @@ intersect{T<:Integer}(i::Integer, r::Range1{T}) =
 
 intersect{T<:Integer}(r::Range1{T}, i::Integer) = intersect(i, r)
 
-# TODO: general intersect?
-function intersect(r::Range1, s::Range)
-    sta = first(s)
-    ste = step(s)
-    sto = last(s)
-    lo = first(r)
-    hi = last(r)
-    i0 = max(lo, sta + ste*div((lo-sta)+ste-1, ste))
-    i1 = min(hi, sta + ste*div((hi-sta), ste))
-    i0 = max(i0, sta)
-    i1 = min(i1, sto)
-    i0:ste:i1
+function intersect{T1<:Integer, T2<:Integer}(r::Range1{T1}, s::Range{T2})
+    if length(s) == 0
+        Range1(first(r), 0)
+    elseif step(s) == 0
+        intersect(first(s), r)
+    elseif step(s) < 0
+        intersect(r, reverse(s))
+    else
+        sta = first(s)
+        ste = step(s)
+        sto = last(s)
+        lo = first(r)
+        hi = last(r)
+        i0 = max(sta, lo + mod(sta - lo, ste))
+        i1 = min(sto, hi - mod(hi - sta, ste))
+        i0:ste:i1
+    end
 end
-intersect(r::Range, s::Range1) = intersect(s, r)
+
+function intersect{T1<:Integer, T2<:Integer}(r::Range{T1}, s::Range1{T2})
+    if step(r) == 0
+        first(s) <= first(r) <= last(s) ? r : Range(first(r), 0, 0)
+    elseif step(r) < 0
+        reverse(intersect(s, reverse(r)))
+    else
+        intersect(s, r)
+    end
+end
+
+function intersect{T1<:Integer, T2<:Integer}(r::Range{T1}, s::Range{T2})
+    if length(r) == 0 || length(s) == 0
+        return Range(first(r), step(r), 0)
+    elseif step(s) < 0
+        return intersect(r, reverse(s))
+    elseif step(r) < 0
+        return reverse(intersect(reverse(r), s))
+    end
+
+    start1 = first(r)
+    step1 = step(r)
+    stop1 = last(r)
+    start2 = first(s)
+    step2 = step(s)
+    stop2 = last(s)
+    a = lcm(step1, step2)
+
+    if a == 0
+        # One or both ranges have step 0.
+        if step1 == 0 && step2 == 0
+            return start1 == start2 ? r : Range(start1, 0, 0)
+        elseif step1 == 0
+            return start2 <= start1 <= stop2 && rem(start1 - start2, step2) == 0 ? r : Range(start1, 0, 0)
+        else
+            return start1 <= start2 <= stop1 && rem(start2 - start1, step1) == 0 ? (start2:step1:start2) : Range(start1, step1, 0)
+        end
+    end
+
+    g, x, y = gcdx(step1, step2)
+
+    if rem(start1 - start2, g) != 0
+        # Unaligned, no overlap possible.
+        return Range(start1, a, 0)
+    end
+
+    z = div(start1 - start2, g)
+    b = start1 - x * z * step1
+    # Possible points of the intersection of r and s are
+    # ..., b-2a, b-a, b, b+a, b+2a, ...
+    # Determine where in the sequence to start and stop.
+    m = max(start1 + mod(b - start1, a), start2 + mod(b - start2, a))
+    n = min(stop1 - mod(stop1 - b, a), stop2 - mod(stop2 - b, a))
+    m:a:n
+end
+
+function intersect(r::Ranges, s::Ranges...)
+    i = r
+    for t in s
+        i = intersect(i, t)
+    end
+    i
+end
 
 # findin (the index of intersection)
 function findin(r::Ranges, span::Range1)

--- a/base/range.jl
+++ b/base/range.jl
@@ -232,7 +232,7 @@ function intersect(r::Ranges, s::Ranges...)
 end
 
 # findin (the index of intersection)
-function findin(r::Ranges, span::Range1)
+function findin{T1<:Integer, T2<:Integer}(r::Ranges{T1}, span::Range1{T2})
     local ifirst
     local ilast
     fspan = first(span)
@@ -243,9 +243,12 @@ function findin(r::Ranges, span::Range1)
     if sr > 0
         ifirst = fr >= fspan ? 1 : iceil((fspan-fr)/sr)+1
         ilast = lr <= lspan ? length(r) : length(r) - iceil((lr-lspan)/sr)
-    else
+    elseif sr < 0
         ifirst = fr <= lspan ? 1 : iceil((lspan-fr)/sr)+1
         ilast = lr >= fspan ? length(r) : length(r) - iceil((lr-fspan)/sr)
+    else
+        ifirst = fr >= fspan ? 1 : length(r)+1
+        ilast = fr <= lspan ? length(r) : 0
     end
     ifirst:ilast
 end

--- a/base/range.jl
+++ b/base/range.jl
@@ -344,7 +344,7 @@ reverse{T<:Real}(r::Ranges{T}) = Range(last(r), -step(r), r.len)
 ## sorting ##
 
 issorted(r::Range1) = true
-issorted(r::Ranges) = step(r) > 0
+issorted(r::Ranges) = step(r) >= 0
 
 sort(r::Range1) = r
 sort!(r::Range1) = r
@@ -368,6 +368,6 @@ end
 map(f, r::Ranges) = [ f(x) for x in r ]
 
 function contains(r::Ranges, x)
-    n = ifloor((x-first(r))/step(r))+1
+    n = step(r) == 0 ? 1 : ifloor((x-first(r))/step(r))+1
     n >= 1 && n <= length(r) && r[n] == x
 end

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -178,14 +178,20 @@ for s in {:searchsortedfirst, :searchsortedlast, :searchsorted}
     end
 end
 
-searchsortedlast{T <: Real}(a::Ranges{T}, x::Real, o::Ordering) = searchsortedlast(a, x)
-searchsortedlast{T <: Real}(a::Ranges{T}, x::Real) = max(min(int(fld(x - first(a), step(a))) + 1, length(a)), 0)
+function searchsortedlast{T <: Real}(a::Ranges{T}, x::Real, o::Ordering=Forward)
+    if step(a) == 0
+        lt(o, x, first(a)) ? 0 : length(a)
+    else
+        max(min(int(fld(x - first(a), step(a))) + 1, length(a)), 0)
+    end
+end
 
-searchsortedfirst{T <: Real}(a::Ranges{T}, x::Real, o::Ordering) = searchsortedfirst(a, x)
-function searchsortedfirst{T <: Real}(a::Ranges{T}, x::Real)
-    n = x - first(a)
-    s = step(a)
-    max(min(int(fld(n, s)) + (rem(n, s) != 0), length(a)), 0) + 1
+function searchsortedfirst{T <: Real}(a::Ranges{T}, x::Real, o::Ordering=Forward)
+    if step(a) == 0
+        lt(o, first(a), x) ? length(a) + 1 : 1
+    else
+        max(min(int(-fld(first(a) - x, step(a))), length(a)), 0) + 1
+    end
 end
 
 searchsorted{T <: Real}(a::Ranges{T}, x::Real) = searchsortedfirst(a,x):searchsortedlast(a,x)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -493,7 +493,7 @@ Set-Like Collections
 
 .. function:: intersect(s1,s2...)
 
-   Construct the intersection of two or more sets. Maintains order with arrays.
+   Construct the intersection of two or more sets. Maintains order and multiplicity of the first argument for arrays and ranges.
 
 .. function:: setdiff(s1,s2)
 

--- a/test/corelib.jl
+++ b/test/corelib.jl
@@ -36,6 +36,12 @@ let
     r = 15:-2:-38
     @test findin(r, span) == 1:6
 end
+@test isempty(findin(5+0*(1:6), 2:4))
+@test findin(5+0*(1:6), 2:5) == 1:6
+@test findin(5+0*(1:6), 2:7) == 1:6
+@test findin(5+0*(1:6), 5:7) == 1:6
+@test isempty(findin(5+0*(1:6), 6:7))
+@test findin(5+0*(1:6), 5:5) == 1:6
 
 @test intersect(1:5, 2:3) == 2:3
 @test intersect(-3:5, 2:8) == 2:5

--- a/test/corelib.jl
+++ b/test/corelib.jl
@@ -82,6 +82,12 @@ end
 @test intersect(-10:3:24, -10:3:24) == -10:3:23
 @test isempty(intersect(-11:3:24, -10:3:24))
 
+@test !contains(1:5, 3.5)
+@test contains(1:5, 3)
+@test contains(5:-1:1, 3)
+@test contains(3+0*(1:5), 3)
+@test !contains(3+0*(1:5), 4)
+
 # comprehensions
 X = [ i+2j for i=1:5, j=1:5 ]
 @test X[2,3] == 8

--- a/test/corelib.jl
+++ b/test/corelib.jl
@@ -37,6 +37,45 @@ let
     @test findin(r, span) == 1:6
 end
 
+@test intersect(1:5, 2:3) == 2:3
+@test intersect(-3:5, 2:8) == 2:5
+@test intersect(-8:-3, -8:-3) == -8:-3
+@test intersect(1:5, 5:13) == 5:5
+@test isempty(intersect(-8:-3, -2:2))
+@test isempty(intersect(-3:7, 2:1))
+@test intersect(1:11, -2:3:15) == 1:3:10
+@test intersect(1:11, -2:2:15) == 2:2:10
+@test intersect(1:11, -2:1:15) == 1:11
+@test intersect(1:11, 15:-1:-2) == 1:11
+@test intersect(1:11, 15:-4:-2) == 3:4:11
+@test intersect(-20:-5, -10:3:-2) == -10:3:-7
+@test isempty(intersect(-5:5, -6:13:20))
+@test isempty(intersect(1:11, 15:4:-2))
+@test isempty(intersect(11:1, 15:-4:-2))
+@test intersect(-5:5, 1+0*(1:3)) == 1:1
+@test isempty(intersect(-5:5, 6+0*(1:3)))
+@test intersect(-15:4:7, -10:-2) == -7:4:-3
+@test intersect(13:-2:1, -2:8) == 7:-2:1
+@test isempty(intersect(13:2:1, -2:8))
+@test isempty(intersect(13:-2:1, 8:-2))
+@test intersect(5+0*(1:4), 2:8) == 5+0*(1:4)
+@test isempty(intersect(5+0*(1:4), -7:3))
+@test intersect(0:3:24, 0:4:24) == 0:12:24
+@test intersect(0:4:24, 0:3:24) == 0:12:24
+@test intersect(0:3:24, 24:-4:0) == 0:12:24
+@test intersect(24:-3:0, 0:4:24) == 24:-12:0
+@test intersect(24:-3:0, 24:-4:0) == 24:-12:0
+@test intersect(1:3:24, 0:4:24) == 4:12:16
+@test intersect(0:6:24, 0:4:24) == 0:12:24
+@test isempty(intersect(1:6:2400, 0:4:2400))
+@test intersect(-51:5:100, -33:7:125) == -26:35:79
+@test intersect(-51:5:100, -32:7:125) == -11:35:94
+@test intersect(0:6:24, 6+0*(0:4:24)) == 6:6:6
+@test intersect(12+0*(0:6:24), 0:4:24) == Range(12, 0, 5)
+@test isempty(intersect(6+0*(0:6:24), 0:4:24))
+@test intersect(-10:3:24, -10:3:24) == -10:3:23
+@test isempty(intersect(-11:3:24, -10:3:24))
+
 # comprehensions
 X = [ i+2j for i=1:5, j=1:5 ]
 @test X[2,3] == 8

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -55,6 +55,17 @@ for i = -5:.5:4
           searchsortedlast(rgv_r, i, Sort.Reverse)
 end
 
+rg = 3+0*(1:5); rgv = [rg]
+rg_r = rg; rgv_r = [rg_r]
+for i = 2:4
+    @test searchsortedfirst(rg, i) == searchsortedfirst(rgv, i)
+    @test searchsortedlast(rg, i) == searchsortedlast(rgv, i)
+    @test searchsortedfirst(rg_r, i, Sort.Reverse) ==
+          searchsortedfirst(rgv_r, i, Sort.Reverse)
+    @test searchsortedlast(rg_r, i, Sort.Reverse) ==
+          searchsortedlast(rgv_r, i, Sort.Reverse)
+end
+
 a = rand(1:10000, 1000)
 
 for alg in [InsertionSort, MergeSort, TimSort]


### PR DESCRIPTION
This pull request makes a number of revisions to some of the functions of ranges.
- Extend intersect, findin, contains, issorted, searchsortedfirst, searchsortedlast to handle ranges of step 0. (#3053)
- Restrict intersect and findin in ranges.jl to integer ranges. Floating point ranges will fall back to the array versions of these functions. See https://groups.google.com/forum/#!topic/julia-dev/6Z6qTKTCz30
- Extend intersect to handle descending ranges. Intersect for ranges now maintains order or multiplicity of the first argument in the same way as intersect for arrays.
- Add intersect for two general ranges (previously at least one had to be Range1).
- Add intersect for multiple ranges.
- Many new tests.
- Some minor simplifications of existing code.
