### PR TITLE
Updates for parallel docs

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1201,13 +1201,13 @@ function pmap(f, lsts...)
     i = 1
     # function to produce the next work item from the queue.
     # in this case it's just an index.
-    next_idx() = (idx=i; i+=1; idx)
+    nextidx() = (idx=i; i+=1; idx)
     @sync begin
         for p=1:np
             if p != myid() || np == 1
-                @spawnat myid() begin
+                @async begin
                     while true
-                        idx = next_idx()
+                        idx = nextidx()
                         if idx > n
                             break
                         end

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -17,37 +17,37 @@ differences in the speed of main memory and the
 good multiprocessing environment should allow control over the
 "ownership" of a chunk of memory by a particular CPU. Julia provides a
 multiprocessing environment based on message passing to allow programs
-to run on multiple processors in separate memory domains at once.
+to run on multiple processes in separate memory domains at once.
 
 Julia's implementation of message passing is different from other
 environments such as MPI. Communication in Julia is generally
 "one-sided", meaning that the programmer needs to explicitly manage only
-one processor in a two-processor operation. Furthermore, these
+one process in a two-process operation. Furthermore, these
 operations typically do not look like "message send" and "message
 receive" but rather resemble higher-level operations like calls to user
 functions.
 
 Parallel programming in Julia is built on two primitives: *remote
 references* and *remote calls*. A remote reference is an object that can
-be used from any processor to refer to an object stored on a particular
-processor. A remote call is a request by one processor to call a certain
-function on certain arguments on another (possibly the same) processor.
+be used from any process to refer to an object stored on a particular
+process. A remote call is a request by one process to call a certain
+function on certain arguments on another (possibly the same) process.
 A remote call returns a remote reference to its result. Remote calls
-return immediately; the processor that made the call proceeds to its
+return immediately; the process that made the call proceeds to its
 next operation while the remote call happens somewhere else. You can
 wait for a remote call to finish by calling ``wait`` on its remote
 reference, and you can obtain the full value of the result using
 ``fetch``.
 
 Let's try this out. Starting with ``julia -p n`` provides ``n``
-processors on the local machine. Generally it makes sense for ``n`` to
+processes on the local machine. Generally it makes sense for ``n`` to
 equal the number of CPU cores on the machine.
 
 ::
 
     $ ./julia -p 2
 
-    julia> r = remote_call(2, rand, 2, 2)
+    julia> r = remotecall(2, rand, 2, 2)
     RemoteRef(2,1,5)
 
     julia> fetch(r)
@@ -63,35 +63,35 @@ equal the number of CPU cores on the machine.
      1.60401  1.50111
      1.17457  1.15741
 
-The first argument to ``remote_call`` is the index of the processor
+The first argument to ``remotecall`` is the index of the process
 that will do the work. Most parallel programming in Julia does not
-reference specific processors or the number of processors available,
-but ``remote_call`` is considered a low-level interface providing
-finer control. The second argument to ``remote_call`` is the function
+reference specific processes or the number of processes available,
+but ``remotecall`` is considered a low-level interface providing
+finer control. The second argument to ``remotecall`` is the function
 to call, and the remaining arguments will be passed to this
-function. As you can see, in the first line we asked processor 2 to
+function. As you can see, in the first line we asked process 2 to
 construct a 2-by-2 random matrix, and in the second line we asked it
 to add 1 to it. The result of both calculations is available in the
 two remote references, ``r`` and ``s``. The ``@spawnat`` macro
-evaluates the expression in the second argument on the processor
+evaluates the expression in the second argument on the process
 specified by the first argument.
 
 Occasionally you might want a remotely-computed value immediately. This
 typically happens when you read from a remote object to obtain data
-needed by the next local operation. The function ``remote_call_fetch``
-exists for this purpose. It is equivalent to ``fetch(remote_call(...))``
+needed by the next local operation. The function ``remotecall_fetch``
+exists for this purpose. It is equivalent to ``fetch(remotecall(...))``
 but is more efficient.
 
 ::
 
-    julia> remote_call_fetch(2, getindex, r, 1, 1)
+    julia> remotecall_fetch(2, getindex, r, 1, 1)
     0.10824216411304866
 
 Remember that ``getindex(r,1,1)`` is :ref:`equivalent <man-array-indexing>` to
 ``r[1,1]``, so this call fetches the first element of the remote
 reference ``r``.
 
-The syntax of ``remote_call`` is not especially convenient. The macro
+The syntax of ``remotecall`` is not especially convenient. The macro
 ``@spawn`` makes things easier. It operates on an expression rather than
 a function, and picks where to do the operation for you::
 
@@ -107,15 +107,15 @@ a function, and picks where to do the operation for you::
 
 Note that we used ``1+fetch(r)`` instead of ``1+r``. This is because we
 do not know where the code will run, so in general a ``fetch`` might be
-required to move ``r`` to the processor doing the addition. In this
+required to move ``r`` to the process doing the addition. In this
 case, ``@spawn`` is smart enough to perform the computation on the
-processor that owns ``r``, so the ``fetch`` will be a no-op.
+process that owns ``r``, so the ``fetch`` will be a no-op.
 
 (It is worth noting that ``@spawn`` is not built-in but defined in Julia
 as a :ref:`macro <man-macros>`. It is possible to define your
 own such constructs.)
 
-One important point is that your code must be available on any processor
+One important point is that your code must be available on any process
 that runs it. For example, type the following into the julia prompt::
 
     julia> function rand2(dims...)
@@ -135,9 +135,9 @@ that runs it. For example, type the following into the julia prompt::
 
     julia> exception on 2: in anonymous: rand2 not defined 
 
-Processor 1 knew about the function ``rand2``, but processor 2 did not.
-To make your code available to all processors, the ``require`` function will
-automatically load a source file on all currently available processors::
+Processor 1 knew about the function ``rand2``, but process 2 did not.
+To make your code available to all processes, the ``require`` function will
+automatically load a source file on all currently available processes::
 
     julia> require("myfile")
 
@@ -173,18 +173,18 @@ random matrix::
 
 The difference seems trivial, but in fact is quite significant due to
 the behavior of ``@spawn``. In the first method, a random matrix is
-constructed locally, then sent to another processor where it is squared.
+constructed locally, then sent to another process where it is squared.
 In the second method, a random matrix is both constructed and squared on
-another processor. Therefore the second method sends much less data than
+another process. Therefore the second method sends much less data than
 the first.
 
 In this toy example, the two methods are easy to distinguish and choose
 from. However, in a real program designing data movement might require
 more thought and very likely some measurement. For example, if the first
-processor needs matrix ``A`` then the first method might be better. Or,
-if computing ``A`` is expensive and only the current processor has it,
-then moving it to another processor might be unavoidable. Or, if the
-current processor has very little to do between the ``@spawn`` and
+process needs matrix ``A`` then the first method might be better. Or,
+if computing ``A`` is expensive and only the current process has it,
+then moving it to another process might be unavoidable. Or, if the
+current process has very little to do between the ``@spawn`` and
 ``fetch(Bref)`` then it might be better to eliminate the parallelism
 altogether. Or imagine ``rand(1000,1000)`` is replaced with a more
 expensive operation. Then it might make sense to add another ``@spawn``
@@ -195,8 +195,8 @@ Parallel Map and Loops
 
 Fortunately, many useful parallel computations do not require data
 movement. A common example is a monte carlo simulation, where multiple
-processors can handle independent simulation trials simultaneously. We
-can use ``@spawn`` to flip coins on two processors. First, write the
+processes can handle independent simulation trials simultaneously. We
+can use ``@spawn`` to flip coins on two processes. First, write the
 following function in ``count_heads.jl``::
 
     function count_heads(n)
@@ -219,7 +219,7 @@ results::
 
 This example, as simple as it is, demonstrates a powerful and often-used
 parallel programming pattern. Many iterations run independently over
-several processors, and then their results are combined using some
+several processes, and then their results are combined using some
 function. The combination process is called a *reduction*, since it is
 generally tensor-rank-reducing: a vector of numbers is reduced to a
 single number, or a matrix is reduced to a single row or column, etc. In
@@ -231,7 +231,7 @@ performed in.
 
 Notice that our use of this pattern with ``count_heads`` can be
 generalized. We used two explicit ``@spawn`` statements, which limits
-the parallelism to two processors. To run on any number of processors,
+the parallelism to two processes. To run on any number of processes,
 we can use a *parallel for loop*, which can be written in Julia like
 this::
 
@@ -240,7 +240,7 @@ this::
     end
 
 This construct implements the pattern of assigning iterations to
-multiple processors, and combining them with a specified reduction (in
+multiple processes, and combining them with a specified reduction (in
 this case ``(+)``). The result of each iteration is taken as the value
 of the last expression inside the loop. The whole parallel loop
 expression itself evaluates to the final answer.
@@ -248,9 +248,9 @@ expression itself evaluates to the final answer.
 Note that although parallel for loops look like serial for loops, their
 behavior is dramatically different. In particular, the iterations do not
 happen in a specified order, and writes to variables or arrays will not
-be globally visible since iterations run on different processors. Any
+be globally visible since iterations run on different processes. Any
 variables used inside the parallel loop will be copied and broadcast to
-each processor.
+each process.
 
 For example, the following code will not work as intended::
 
@@ -261,7 +261,7 @@ For example, the following code will not work as intended::
 
 Notice that the reduction operator can be omitted if it is not needed.
 However, this code will not initialize all of ``a``, since each
-processor will have a separate copy if it. Parallel for loops like these
+process will have a separate copy if it. Parallel for loops like these
 must be avoided. Fortunately, distributed arrays can be used to get
 around this limitation, as we will see in the next section.
 
@@ -274,7 +274,7 @@ the variables are read-only::
     end
 
 Here each iteration applies ``f`` to a randomly-chosen sample from a
-vector ``a`` shared by all processors.
+vector ``a`` shared by all processes.
 
 In some cases no reduction operator is needed, and we merely wish to
 apply a function to all integers in some range (or, more generally, to
@@ -297,14 +297,14 @@ numbers.
 
    Large computations are often organized around large arrays of data. In
    these cases, a particularly natural way to obtain parallelism is to
-   distribute arrays among several processors. This combines the memory
+   distribute arrays among several processes. This combines the memory
    resources of multiple machines, allowing use of arrays too large to fit
-   on one machine. Each processor operates on the part of the array it
+   on one machine. Each process operates on the part of the array it
    owns, providing a ready answer to the question of how a program should
    be divided among machines.
 
    A distributed array (or, more generally, a *global object*) is logically
-   a single array, but pieces of it are stored on different processors.
+   a single array, but pieces of it are stored on different processes.
    This means whole-array operations such as matrix multiply, scalar\*array
    multiplication, etc. use the same syntax as with local arrays, and the
    parallelism is invisible. In some cases it is possible to obtain useful
@@ -314,10 +314,10 @@ numbers.
    ``DArray`` has an element type and dimensions just like an ``Array``,
    but it also needs an additional property: the dimension along which data
    is distributed. There are many possible ways to distribute data among
-   processors, but at this time Julia keeps things simple and only allows
+   processes, but at this time Julia keeps things simple and only allows
    distributing along a single dimension. For example, if a 2-d ``DArray``
-   is distributed in dimension 1, it means each processor holds a certain
-   range of rows. If it is distributed in dimension 2, each processor holds
+   is distributed in dimension 1, it means each process holds a certain
+   range of rows. If it is distributed in dimension 2, each process holds
    a certain range of columns.
 
    Common kinds of arrays can be constructed with functions beginning with
@@ -342,29 +342,29 @@ numbers.
    In the ``drand`` call, we specified that the array should be distributed
    across dimension 3. In the first ``dzeros`` call, we specified an
    element type as well as the distributed dimension. In the second
-   ``dzeros`` call, we also specified which processors should be used to
-   store the data. When dividing data among a large number of processors,
+   ``dzeros`` call, we also specified which processes should be used to
+   store the data. When dividing data among a large number of processes,
    one often sees diminishing returns in performance. Placing ``DArray``\ s
-   on a subset of processors allows multiple ``DArray`` computations to
+   on a subset of processes allows multiple ``DArray`` computations to
    happen at once, with a higher ratio of work to communication on each
-   processor.
+   process.
 
    ``distribute(a::Array, dim)`` can be used to convert a local array to a
    distributed array, optionally specifying the distributed dimension.
    ``localize(a::DArray)`` can be used to obtain the locally-stored portion
    of a ``DArray``. ``owner(a::DArray, index)`` gives the id of the
-   processor storing the given index in the distributed dimension.
+   process storing the given index in the distributed dimension.
    ``myindexes(a::DArray)`` gives a tuple of the indexes owned by the local
-   processor. ``convert(Array, a::DArray)`` brings all the data to one
+   process. ``convert(Array, a::DArray)`` brings all the data to one
    node.
 
-   A ``DArray`` can be stored on a subset of the available processors.
+   A ``DArray`` can be stored on a subset of the available processes.
    Three properties fully describe the distribution of ``DArray`` ``d``.
-   ``d.pmap[i]`` gives the processor id that owns piece number ``i`` of the
+   ``d.pmap[i]`` gives the process id that owns piece number ``i`` of the
    array. Piece ``i`` consists of indexes ``d.dist[i]`` through
    ``d.dist[i+1]-1``. ``distdim(d)`` gives the distributed dimension. For
    convenience, ``d.localpiece`` gives the number of the piece owned by the
-   local processor (this could also be determined by searching ``d.pmap``).
+   local process (this could also be determined by searching ``d.pmap``).
    The array ``d.pmap`` is also available as ``procs(d)``.
 
    Indexing a ``DArray`` (square brackets) gathers all of the referenced
@@ -378,7 +378,7 @@ numbers.
    ``sub`` itself, naturally, does no communication and so is very
    efficient. However, this does not mean it should be viewed as an
    optimization in all cases. Many situations require explicitly moving
-   data to the local processor in order to do a fast serial operation. For
+   data to the local process in order to do a fast serial operation. For
    example, functions like matrix multiply perform many accesses to their
    input data, so it is better to have all the data available locally up
    front.
@@ -392,8 +392,8 @@ numbers.
        darray(init, type, dims, distdim, procs, dist)
 
    ``init`` is a function of three arguments that will run on each
-   processor, and should return an ``Array`` holding the local data for the
-   current processor. Its arguments are ``(T,d,da)`` where ``T`` is the
+   process, and should return an ``Array`` holding the local data for the
+   current process. Its arguments are ``(T,d,da)`` where ``T`` is the
    element type, ``d`` is the dimensions of the needed local piece, and
    ``da`` is the new ``DArray`` being constructed (though, of course, it is
    not fully initialized).
@@ -404,7 +404,7 @@ numbers.
 
    ``distdim`` is the dimension to distribute in.
 
-   ``procs`` is a vector of processor ids to use.
+   ``procs`` is a vector of process ids to use.
 
    ``dist`` is a vector giving the first index of each contiguous
    distributed piece, such that the nth piece consists of indexes
@@ -523,7 +523,7 @@ However, they can be used to wait for multiple events at the same time,
 which provides for *dynamic scheduling*. In dynamic scheduling, a
 program decides what to compute or where to compute it based on when
 other jobs finish. This is needed for unpredictable or unbalanced
-workloads, where we want to assign more work to processors only when
+workloads, where we want to assign more work to processes only when
 they finish their current tasks.
 
 As an example, consider computing the singular values of matrices of
@@ -532,29 +532,31 @@ different sizes::
     M = {rand(800,800), rand(600,600), rand(800,800), rand(600,600)}
     pmap(svd, M)
 
-If one processor handles both 800x800 matrices and another handles both
+If one process handles both 800x800 matrices and another handles both
 600x600 matrices, we will not get as much scalability as we could. The
-solution is to make a local task to "feed" work to each processor when
+solution is to make a local task to "feed" work to each process when
 it completes its current task. This can be seen in the implementation of
 ``pmap``::
 
     function pmap(f, lst)
-        np = nprocs()  # determine the number of processors available
+        np = nprocs()  # determine the number of processes available
         n = length(lst)
         results = cell(n)
         i = 1
         # function to produce the next work item from the queue.
         # in this case it's just an index.
-        next_idx() = (idx=i; i+=1; idx)
+        nextidx() = (idx=i; i+=1; idx)
         @sync begin
             for p=1:np
-                @spawnlocal begin
-                    while true
-                        idx = next_idx()
-                        if idx > n
-                            break
+                if p != myid() || np == 1 
+                    @async begin
+                        while true
+                            idx = nextidx()
+                            if idx > n
+                                break
+                            end
+                            results[idx] = remotecall_fetch(p, f, lst[idx])
                         end
-                        results[idx] = remote_call_fetch(p, f, lst[idx])
                     end
                 end
             end
@@ -562,22 +564,23 @@ it completes its current task. This can be seen in the implementation of
         results
     end
 
-``@spawnlocal`` is similar to ``@spawn``, but only runs tasks on the
-local processor. We use it to create a "feeder" task for each processor.
+``@async`` is similar to ``@spawn``, but only runs tasks on the
+local process. We use it to create a "feeder" task for each process.
 Each task picks the next index that needs to be computed, then waits for
-its processor to finish, then repeats until we run out of indexes. A
-``@sync`` block is used to wait for all the local tasks to complete, at
-which point the whole operation is done. Notice that all the feeder
-tasks are able to share state via ``next_idx()`` since they all run on
-the same processor. However, no locking is required, since the threads
-are scheduled cooperatively and not preemptively. This means context
-switches only occur at well-defined points (during the ``fetch``
-operation).
+its process to finish, then repeats until we run out of indexes. Note
+that the feeder tasks do not begin to execute until the main task
+reaches the end of the ``@sync`` block, at which point it surrenders
+control and waits for all the local tasks to complete before returning
+from the function. The feeder tasks are able to share state via
+``nextidx()`` because they all run on the same process. No locking is
+required, since the threads are scheduled cooperatively and not
+preemptively. This means context switches only occur at well-defined
+points: in this case, when ``remotecall_fetch`` is called.
 
 Sending Instructions To All Processors
 --------------------------------------
 
-It is often useful to execute a statement on all processors, particularly
+It is often useful to execute a statement on all processes, particularly
 for setup tasks such as loading source files and defining common variables.
 This can be done with the ``@everywhere`` macro::
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -2804,7 +2804,7 @@ Parallel Computing
 
 .. function:: pmap(f, c)
 
-   Transform collection ``c`` by applying ``f`` to each element in parallel.
+   Transform collection ``c`` by applying ``f`` to each element in parallel. If ``nprocs() > 1``, the calling process will be dedicated to assigning tasks. All other available processes will be used as parallel workers.
 
 .. function:: remotecall(id, func, args...)
 


### PR DESCRIPTION
I've made some updates to the parallel docs. (#3094)
- Clarify in the definition of `pmap` that one process is dedicated to assigning tasks. Previously it could be (incorrectly) assumed that there should be a speedup from 1 to 2 processes.
- Update references to deprecated functions.
- processors -> processes. I think this is clearer since we're talking about OS-level processes, not CPUs.
- Sync `pmap` with the version in the manual.
- Updates to the text describing `pmap` in the manual.
