### PR TITLE
Metaprogramming doc update (minor).

### DIFF
--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -185,7 +185,7 @@ dynamically generate arbitrary code which can then be run using
 
     julia> a = 1;
 
-    julia> ex = Expr(:call, {:+,a,:b}, Any)
+    julia> ex = Expr(:call, :+,a,:b)
     :(+(1,b))
 
     julia> a = 0; b = 2;


### PR DESCRIPTION
There seems to have been a small change in `Expr(...)` syntax not updated in the manual.

``` julia
julia> a = 1
1

julia> dump(Expr(:call, {:+,a,:b}, Any))  # Syntax in manual
Expr 
  head: Symbol call
  args: Array(Any,(2,))
    1: Array(Any,(3,))
      1: Symbol +
      2: Int64 
      3: Symbol b
    2: Any
  typ: Any

julia> dump(Expr(:call, :+,a,:b))   # Actual desired result in manual
Expr 
  head: Symbol call
  args: Array(Any,(3,))
    1: Symbol +
    2: Int64 
    3: Symbol b
  typ: Any
```
