### PR TITLE
Reorder last line of trig functions table

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1,4 +1,4 @@
-# prelimnary definitions: constants, macros
+# preliminary definitions: constants, macros
 # and functions used throughout the code
 const _msk64 = ~uint64(0)
 macro _mskr(l) :(_msk64 >>> (64-$(esc(l)))) end

--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -371,7 +371,7 @@ All the standard trigonometric and hyperbolic functions are also defined::
     sin    cos    tan    cot    sec    csc
     sinh   cosh   tanh   coth   sech   csch
     asin   acos   atan   acot   asec   acsc
-    acoth  asech  acsch  sinc   cosc   atan2
+    sinc   cosc   atan2  acoth  asech  acsch
 
 These are all single-argument functions, with the exception of
 `atan2 <http://en.wikipedia.org/wiki/Atan2>`_, which gives the angle


### PR DESCRIPTION
With this change, now each column corresponds to a family of functions.
Also, fixed typo in base/bitarray.jl
