### PR TITLE
RFC: Added do-expression syntax for regex matches.

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -148,6 +148,8 @@ end
 matchall(re::Regex, str::Union(ByteString,SubString), overlap::Bool=false) =
     matchall(re, utf8(str), overlap)
 
+match(fn::Function, r::Regex, args...) = (m = match(r, args...); if m != nothing; fn(m.captures...); else nothing end)
+
 function search(str::Union(ByteString,SubString), re::Regex, idx::Integer)
     if idx > nextind(str,endof(str))
         throw(BoundsError())

--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -420,6 +420,7 @@ where each ``key`` is a symbol. Such collections can be passed as named
 arguments using a semicolon in a call, ``f(x; k...)``. Dictionaries
 can be used for this purpose.
 
+.. _man-block-syntax-for-func-args:
 
 Block Syntax for Function Arguments
 -----------------------------------


### PR DESCRIPTION
This trivial patch allows one to write regex matches like

``` julia
julia> match(r"(.+)@(.+\.[A-Za-z]{2,4})", "julia@julia.org") do id, dom
         println("id: $id")
         println("domain: $dom")
       end
id: julia
domain: julia.org

julia> match(r"(.+)@(.+\.[A-Za-z]{2,4})", "julia_at_julia.org") do id, dom
         println("id: $id")
         println("domain: $dom")
       end

julia> 
```

Also adds a short description to the manual.

(Inspired by @StefanKarpinski's match macro comment in #1448.)

Comment: I wanted to write `do (id, dom)`, but julia didn't seem to like that.  That would be more readable to me...
