### PR TITLE
^(x::Number,y::Rational) should promote y to the correct type

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -161,3 +161,5 @@ function ^(x::Rational, y::Integer)
 end
 
 ^(x::Number, y::Rational) = x^(y.num/y.den)
+^{T<:FloatingPoint}(x::T, y::Rational) = x^(convert(T,y.num)/y.den)
+^{T<:FloatingPoint}(x::Complex{T}, y::Rational) = x^(convert(T,y.num)/y.den)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1456,3 +1456,7 @@ end
 @test  isprime(0xffffffffffffffc5)
 @test !isprime(0xffffffffffffffc7)
 @test !isprime(0xffffffffffffffc9)
+
+# rational-exponent promotion rules (issue #3155):
+@test 2.0f0^(1//3) == 2.0f0^(1.0f0/3)
+@test 2^(1//3) == 2^(1/3)


### PR DESCRIPTION
`rational.jl` contains the rule:

```
^(x::Number, y::Rational) = x^(y.num/y.den)
```

which always promotes `y` to `Float64` (for `Rational{Int}`) regardless of the type of `x`.  This is too _little_ precision if `x` is a `BigFloat` (in which case the exponent should be computed in `BigFloat` precision), and is too _much_ precision if `x` is `Float32` (in which case we want a `Float32` result).

The attached patch corrects this by adding two extra definitions (and a test case):

```
+^{T<:FloatingPoint}(x::T, y::Rational) = x^(convert(T,y.num)/y.den)
+^{T<:FloatingPoint}(x::Complex{T}, y::Rational) = x^(convert(T,y.num)/y.den)
```
