### PR TITLE
RFC: `..` as a right-associative cons operator

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -520,7 +520,7 @@
 	   (spc (ts:space? s)))
       (cond ((and first? (eq? t '|..|))
 	     (take-token s)
-	     `(call ,t ,ex ,(parse-expr s)))
+	     `(call ,t ,ex ,(parse-cons s)))
 	    ((and range-colon-enabled (eq? t ':))
 	     (take-token s)
 	     (if (and space-sensitive spc
@@ -568,6 +568,7 @@
 (define (parse-and s)   (parse-LtoR s parse-arrow (prec-ops 3)))
 (define (parse-arrow s) (parse-RtoL s parse-ineq  (prec-ops 4)))
 (define (parse-ineq s)  (parse-comparison s (prec-ops 5)))
+(define (parse-cons s)  (parse-RtoL s parse-cond  (prec-ops 6)))
 
 ; parse left to right, combining chains of certain operators into 1 call
 ; e.g. a+b+c => (call + a b c)


### PR DESCRIPTION
I've been spending some time writing functional programming libraries for Julia and I'm finding myself in want of a right-associative cons operator. I had a quick chat with @StefanKarpinski and he suggested `..`, which is currently unused.

Current parsing

``` .jl
julia> :(x..y..rest)
ERROR: syntax: missing separator in tuple
```

Suggested parsing:

``` .jl
julia> :(x..y..rest)
:(..(x, ..(y, rest)))
```

I don't think this could break existing code since `1..2..3` currently throws a syntax error, though it could lead to confusion as it's not completely obvious why it might be right-associative.

A quick note: the change in julia-parser.scm seems to do the right thing and tests are passing, but I'm basically making changes without fully understanding the parser.
