### PR TITLE
RFC: add function to access diagonal indices

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -565,6 +565,7 @@ export
     ctranspose,
     det,
     diag,
+    diagind,
     diagm,
     diff,
     dot,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -42,6 +42,7 @@ export
     ctranspose,
     det,
     diag,
+    diagind,
     diagm,
     diff,
     dot,

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -109,57 +109,24 @@ function gradient(F::Vector, h::Vector)
     return g
 end
 
-function diag{T}(A::Matrix{T}, k::Integer)
-    m, n = size(A)
-    if k >= 0 && k < n
-        nV = min(m, n-k)
-    elseif k < 0 && -k < m
-        nV = min(m+k, n)
-    else
-        throw(BoundsError())
+function diagind(A::Matrix,k::Integer=0)
+    m,n = size(A)
+    if 0 < k < n
+        return Range(k*m+1,m+1,min(m,n-k))
+    elseif 0 <= -k < m
+        return Range(1-k,m+1,min(m+k,n))
     end
-
-    V = zeros(T, nV)
-
-    if k > 0
-        for i=1:nV
-            V[i] = A[i, i+k]
-        end
-    else
-        for i=1:nV
-            V[i] = A[i-k, i]
-        end
-    end
-
-    return V
+    throw(BoundsError())
 end
 
-diag(A) = diag(A, 0)
+diag(A::Matrix, k::Integer=0) = A[diagind(A,k)]
 
-function diagm{T}(v::VecOrMat{T}, k::Integer)
-    if isa(v, Matrix)
-        if (size(v,1) != 1 && size(v,2) != 1)
-            error("Input should be nx1 or 1xn")
-        end
-    end
-
-    n = length(v)
-    if k >= 0 
-        a = zeros(T, n+k, n+k)
-        for i=1:n
-            a[i,i+k] = v[i]
-        end
-    else
-        a = zeros(T, n-k, n-k)
-        for i=1:n
-            a[i-k,i] = v[i]
-        end
-    end
-
-    return a
+function diagm{T}(v::AbstractVector{T}, k::Integer=0)
+    n = length(v) + abs(k)
+    A = zeros(T,n,n)
+    A[diagind(A,k)] = v
+    A
 end  
-
-diagm(v) = diagm(v, 0)
 
 diagm(x::Number) = (X = Array(typeof(x),1,1); X[1,1] = x; X)
 

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -4,6 +4,7 @@
 
 ("Getting Around","Base","exit","exit([code])
 
+
    Quit (or control-D at the prompt). The default exit code is zero,
    indicating that the processes completed successfully.
 
@@ -11,12 +12,14 @@
 
 ("Getting Around","Base","whos","whos([Module,] [pattern::Regex])
 
+
    Print information about global variables in a module, optionally
    restricted to those matching \"pattern\".
 
 "),
 
 ("Getting Around","Base","edit","edit(file::String[, line])
+
 
    Edit a file optionally providing a line number to edit at. Returns
    to the julia prompt when you quit the editor. If the file name ends
@@ -26,6 +29,7 @@
 
 ("Getting Around","Base","edit","edit(function[, types])
 
+
    Edit the definition of a function, optionally specifying a tuple of
    types to indicate which method to edit. When the editor exits, the
    source file containing the definition is reloaded.
@@ -33,6 +37,7 @@
 "),
 
 ("Getting Around","Base","require","require(file::String...)
+
 
    Load source files once, in the context of the \"Main\" module, on
    every active node, searching the system-wide \"LOAD_PATH\" for
@@ -46,6 +51,7 @@
 
 ("Getting Around","Base","reload","reload(file::String)
 
+
    Like \"require\", except forces loading of files regardless of
    whether they have been loaded before. Typically used when
    interactively developing libraries.
@@ -53,6 +59,7 @@
 "),
 
 ("Getting Around","Base","include","include(path::String)
+
 
    Evaluate the contents of a source file in the current context.
    During including, a task-local include path is set to the directory
@@ -65,7 +72,9 @@
 
 "),
 
-("Getting Around","Base","include_string","include_string(code::String)
+("Getting
+Around","Base","include_string","include_string(code::String)
+
 
    Like \"include\", except reads code from the given string rather
    than from a file. Since there is no file path involved, no path
@@ -75,6 +84,7 @@
 
 ("Getting Around","Base","evalfile","evalfile(path::String)
 
+
    Evaluate all expressions in the given file, and return the value of
    the last one. No other processing (path searching, fetching from
    node 1, etc.) is performed.
@@ -83,11 +93,13 @@
 
 ("Getting Around","Base","help","help(name)
 
+
    Get help for a function. \"name\" can be an object or a string.
 
 "),
 
 ("Getting Around","Base","apropos","apropos(string)
+
 
    Search documentation for functions related to \"string\".
 
@@ -95,17 +107,21 @@
 
 ("Getting Around","Base","which","which(f, args...)
 
+
    Show which method of \"f\" will be called for the given arguments.
 
 "),
 
 ("Getting Around","Base","methods","methods(f)
 
+
    Show all methods of \"f\" with their argument types.
 
 "),
 
-("Getting Around","Base","methodswith","methodswith(typ[, showparents])
+("Getting Around","Base","methodswith","methodswith(typ[,
+showparents])
+
 
    Show all methods with an argument of type \"typ\". If optional
    \"showparents\" is \"true\", also show arguments with a parent type
@@ -115,6 +131,7 @@
 
 ("All Objects","Base","is","is(x, y)
 
+
    Determine whether \"x\" and \"y\" are identical, in the sense that
    no program could distinguish them.
 
@@ -122,11 +139,13 @@
 
 ("All Objects","Base","isa","isa(x, type)
 
+
    Determine whether \"x\" is of the given type.
 
 "),
 
 ("All Objects","Base","isequal","isequal(x, y)
+
 
    True if and only if \"x\" and \"y\" have the same contents. Loosely
    speaking, this means \"x\" and \"y\" would look the same when
@@ -135,6 +154,7 @@
 "),
 
 ("All Objects","Base","isless","isless(x, y)
+
 
    Test whether \"x\" is less than \"y\". Provides a total order
    consistent with \"isequal\". Values that are normally unordered,
@@ -146,17 +166,20 @@
 
 ("All Objects","Base","typeof","typeof(x)
 
+
    Get the concrete type of \"x\".
 
 "),
 
 ("All Objects","Base","tuple","tuple(xs...)
 
+
    Construct a tuple of the given objects.
 
 "),
 
 ("All Objects","Base","ntuple","ntuple(n, f::Function)
+
 
    Create a tuple of length \"n\", computing each element as \"f(i)\",
    where \"i\" is the index of the element.
@@ -165,6 +188,7 @@
 
 ("All Objects","Base","object_id","object_id(x)
 
+
    Get a unique integer id for \"x\". \"object_id(x)==object_id(y)\"
    if and only if \"is(x,y)\".
 
@@ -172,12 +196,14 @@
 
 ("All Objects","Base","hash","hash(x)
 
+
    Compute an integer hash code such that \"isequal(x,y)\" implies
    \"hash(x)==hash(y)\".
 
 "),
 
 ("All Objects","Base","finalizer","finalizer(x, function)
+
 
    Register a function \"f(x)\" to be called when there are no
    program-accessible references to \"x\". The behavior of this
@@ -187,6 +213,7 @@
 
 ("All Objects","Base","copy","copy(x)
 
+
    Create a shallow copy of \"x\": the outer structure is copied, but
    not all internal values. For example, copying an array produces a
    new array with identically-same elements as the original.
@@ -194,6 +221,7 @@
 "),
 
 ("All Objects","Base","deepcopy","deepcopy(x)
+
 
    Create a deep copy of \"x\": everything is copied recursively,
    resulting in a fully independent object. For example, deep-copying
@@ -218,11 +246,13 @@
 
 ("All Objects","Base","convert","convert(type, x)
 
+
    Try to convert \"x\" to the given type.
 
 "),
 
 ("All Objects","Base","promote","promote(xs...)
+
 
    Convert all arguments to their common promotion type (if any), and
    return them all (as a tuple).
@@ -231,11 +261,13 @@
 
 ("Types","Base","super","super(T::DataType)
 
+
    Return the supertype of DataType T
 
 "),
 
 ("Types","Base","subtype","subtype(type1, type2)
+
 
    True if and only if all values of \"type1\" are also of \"type2\".
    Can also be written using the \"<:\" infix operator as \"type1 <:
@@ -245,11 +277,13 @@
 
 ("Types","Base","<:","<:(T1, T2)
 
+
    Subtype operator, equivalent to \"subtype(T1,T2)\".
 
 "),
 
 ("Types","Base","subtypes","subtypes(T::DataType)
+
 
    Return a list of immediate subtypes of DataType T.  Note that all
    currently loaded subtypes are included, including those not visible
@@ -259,6 +293,7 @@
 
 ("Types","Base","subtypetree","subtypetree(T::DataType)
 
+
    Return a nested list of all subtypes of DataType T.  Note that all
    currently loaded subtypes are included, including those not visible
    in the current module.
@@ -267,17 +302,20 @@
 
 ("Types","Base","typemin","typemin(type)
 
+
    The lowest value representable by the given (real) numeric type.
 
 "),
 
 ("Types","Base","typemax","typemax(type)
 
+
    The highest value representable by the given (real) numeric type.
 
 "),
 
 ("Types","Base","realmin","realmin(type)
+
 
    The smallest in absolute value non-denormal value representable by
    the given floating-point type
@@ -286,12 +324,14 @@
 
 ("Types","Base","realmax","realmax(type)
 
+
    The highest finite value representable by the given floating-point
    type
 
 "),
 
 ("Types","Base","maxintfloat","maxintfloat(type)
+
 
    The largest integer losslessly representable by the given floating-
    point type
@@ -300,12 +340,14 @@
 
 ("Types","Base","sizeof","sizeof(type)
 
+
    Size, in bytes, of the canonical binary representation of the given
    type, if any.
 
 "),
 
 ("Types","Base","eps","eps([type])
+
 
    The distance between 1.0 and the next larger representable
    floating-point value of \"type\". The only types that are sensible
@@ -316,12 +358,14 @@
 
 ("Types","Base","eps","eps(x)
 
+
    The distance between \"x\" and the next larger representable
    floating-point value of the same type as \"x\".
 
 "),
 
 ("Types","Base","promote_type","promote_type(type1, type2)
+
 
    Determine a type big enough to hold values of each argument type
    without loss, whenever possible. In some cases, where no type
@@ -334,6 +378,7 @@
 
 ("Types","Base","getfield","getfield(value, name::Symbol)
 
+
    Extract a named field from a value of composite type. The syntax
    \"a.b\" calls \"getfield(a, :b)\", and the syntax \"a.(b)\" calls
    \"getfield(a, b)\".
@@ -341,6 +386,7 @@
 "),
 
 ("Types","Base","setfield","setfield(value, name::Symbol, x)
+
 
    Assign \"x\" to a named field in \"value\" of composite type. The
    syntax \"a.b = c\" calls \"setfield(a, :b, c)\", and the syntax
@@ -350,12 +396,14 @@
 
 ("Types","Base","fieldtype","fieldtype(value, name::Symbol)
 
+
    Determine the declared type of a named field in a value of
    composite type.
 
 "),
 
 ("Types","Base","isimmutable","isimmutable(v)
+
 
    True if value \"v\" is immutable.  See *Immutable Composite Types*
    for a discussion of immutability.
@@ -364,6 +412,7 @@
 
 ("Types","Base","isbits","isbits(T)
 
+
    True if \"T\" is a \"plain data\" type, meaning it is immutable and
    contains no references to other values. Typical examples are
    numeric types such as \"Uint8\", \"Float64\", and
@@ -371,7 +420,9 @@
 
 "),
 
-("Generic Functions","Base","method_exists","method_exists(f, tuple) -> Bool
+("Generic Functions","Base","method_exists","method_exists(f, tuple)
+-> Bool
+
 
    Determine whether the given generic function has a method matching
    the given tuple of argument types.
@@ -382,12 +433,14 @@
 
 ("Generic Functions","Base","applicable","applicable(f, args...)
 
+
    Determine whether the given generic function has a method
    applicable to the given arguments.
 
 "),
 
 ("Generic Functions","Base","invoke","invoke(f, (types...), args...)
+
 
    Invoke a method for the given generic function matching the
    specified types (as a tuple), on the specified arguments. The
@@ -401,6 +454,7 @@
 
 ("Generic Functions","Base","|","|(x, f)
 
+
    Applies a function to the preceding argument which allows for easy
    function chaining.
 
@@ -410,11 +464,13 @@
 
 ("Iteration","Base","start","start(iter) -> state
 
+
    Get initial iteration state for an iterable object
 
 "),
 
 ("Iteration","Base","done","done(iter, state) -> Bool
+
 
    Test whether we are done iterating
 
@@ -422,12 +478,14 @@
 
 ("Iteration","Base","next","next(iter, state) -> item, state
 
+
    For a given iterable object and iteration state, return the current
    item and the next iteration state
 
 "),
 
 ("Iteration","Base","zip","zip(iters...)
+
 
    For a set of iterable objects, returns an iterable of tuples, where
    the \"i\"th tuple contains the \"i\"th component of each input
@@ -440,6 +498,7 @@
 
 ("Iteration","Base","enumerate","enumerate(iter)
 
+
    Return an iterator that yields \"(i, x)\" where \"i\" is an index
    starting at 1, and \"x\" is the \"ith\" value from the given
    iterator.
@@ -448,17 +507,21 @@
 
 ("General Collections","Base","isempty","isempty(collection) -> Bool
 
+
    Determine whether a collection is empty (has no elements).
 
 "),
 
-("General Collections","Base","empty!","empty!(collection) -> collection
+("General Collections","Base","empty!","empty!(collection) ->
+collection
+
 
    Remove all elements from a collection.
 
 "),
 
 ("General Collections","Base","length","length(collection) -> Integer
+
 
    For ordered, indexable collections, the maximum index \"i\" for
    which \"getindex(collection, i)\" is valid. For unordered
@@ -468,6 +531,7 @@
 
 ("General Collections","Base","endof","endof(collection) -> Integer
 
+
    Returns the last index of the collection.
 
    **Example**: \"endof([1,2,4]) = 3\"
@@ -476,11 +540,13 @@
 
 ("Iterable Collections","Base","contains","contains(itr, x) -> Bool
 
+
    Determine whether a collection contains the given value, \"x\".
 
 "),
 
 ("Iterable Collections","Base","findin","findin(a, b)
+
 
    Returns the indices of elements in collection \"a\" that appear in
    collection \"b\"
@@ -489,12 +555,14 @@
 
 ("Iterable Collections","Base","unique","unique(itr)
 
+
    Returns an array containing only the unique elements of the
    iterable \"itr\".
 
 "),
 
 ("Iterable Collections","Base","reduce","reduce(op, v0, itr)
+
 
    Reduce the given collection with the given operator, i.e.
    accumulate \"v = op(v,elt)\" for each element, where \"v\" starts
@@ -507,11 +575,13 @@
 
 ("Iterable Collections","Base","max","max(itr)
 
+
    Returns the largest element in a collection
 
 "),
 
 ("Iterable Collections","Base","min","min(itr)
+
 
    Returns the smallest element in a collection
 
@@ -519,11 +589,13 @@
 
 ("Iterable Collections","Base","indmax","indmax(itr) -> Integer
 
+
    Returns the index of the maximum element in a collection
 
 "),
 
 ("Iterable Collections","Base","indmin","indmin(itr) -> Integer
+
 
    Returns the index of the minimum element in a collection
 
@@ -531,11 +603,13 @@
 
 ("Iterable Collections","Base","findmax","findmax(itr) -> (x, index)
 
+
    Returns the maximum element and its index
 
 "),
 
 ("Iterable Collections","Base","findmin","findmin(itr) -> (x, index)
+
 
    Returns the minimum element and its index
 
@@ -543,11 +617,13 @@
 
 ("Iterable Collections","Base","sum","sum(itr)
 
+
    Returns the sum of all elements in a collection
 
 "),
 
 ("Iterable Collections","Base","prod","prod(itr)
+
 
    Returns the product of all elements of a collection
 
@@ -555,11 +631,13 @@
 
 ("Iterable Collections","Base","any","any(itr) -> Bool
 
+
    Test whether any elements of a boolean collection are true
 
 "),
 
 ("Iterable Collections","Base","all","all(itr) -> Bool
+
 
    Test whether all elements of a boolean collection are true
 
@@ -567,11 +645,13 @@
 
 ("Iterable Collections","Base","count","count(itr) -> Integer
 
+
    Count the number of boolean elements in \"itr\" which are true.
 
 "),
 
 ("Iterable Collections","Base","countp","countp(p, itr) -> Integer
+
 
    Count the number of elements in \"itr\" for which predicate \"p\"
    is true.
@@ -580,6 +660,7 @@
 
 ("Iterable Collections","Base","any","any(p, itr) -> Bool
 
+
    Determine whether any element of \"itr\" satisfies the given
    predicate.
 
@@ -587,12 +668,14 @@
 
 ("Iterable Collections","Base","all","all(p, itr) -> Bool
 
+
    Determine whether all elements of \"itr\" satisfy the given
    predicate.
 
 "),
 
 ("Iterable Collections","Base","map","map(f, c) -> collection
+
 
    Transform collection \"c\" by applying \"f\" to each element.
 
@@ -602,11 +685,13 @@
 
 ("Iterable Collections","Base","map!","map!(function, collection)
 
+
    In-place version of \"map()\".
 
 "),
 
 ("Iterable Collections","Base","mapreduce","mapreduce(f, op, itr)
+
 
    Applies function \"f\" to each element in \"itr\" and then reduces
    the result using the binary function \"op\".
@@ -617,11 +702,13 @@
 
 ("Iterable Collections","Base","first","first(coll)
 
+
    Get the first element of an ordered collection.
 
 "),
 
 ("Iterable Collections","Base","last","last(coll)
+
 
    Get the last element of an ordered collection.
 
@@ -629,12 +716,15 @@
 
 ("Iterable Collections","Base","collect","collect(collection)
 
+
    Return an array of all items in a collection. For associative
    collections, returns (key, value) tuples.
 
 "),
 
-("Indexable Collections","Base","getindex","getindex(collection, key...)
+("Indexable Collections","Base","getindex","getindex(collection,
+key...)
+
 
    Retrieve the value(s) stored at the given key or index within a
    collection. The syntax \"a[i,j,...]\" is converted by the compiler
@@ -642,7 +732,9 @@
 
 "),
 
-("Indexable Collections","Base","setindex!","setindex!(collection, value, key...)
+("Indexable Collections","Base","setindex!","setindex!(collection,
+value, key...)
+
 
    Store the given value at the given key or index within a
    collection. The syntax \"a[i,j,...] = x\" is converted by the
@@ -652,11 +744,13 @@
 
 ("Associative Collections","Base","Dict{K,V}","Dict{K,V}()
 
+
    Construct a hashtable with keys of type K and values of type V
 
 "),
 
 ("Associative Collections","Base","has","has(collection, key)
+
 
    Determine whether a collection has a mapping for a given key.
 
@@ -664,12 +758,15 @@
 
 ("Associative Collections","Base","get","get(collection, key, default)
 
+
    Return the value stored for the given key, or the given default
    value if no mapping for the key is present.
 
 "),
 
-("Associative Collections","Base","getkey","getkey(collection, key, default)
+("Associative Collections","Base","getkey","getkey(collection, key,
+default)
+
 
    Return the key matching argument \"key\" if one exists in
    \"collection\", otherwise return \"default\".
@@ -678,11 +775,13 @@
 
 ("Associative Collections","Base","delete!","delete!(collection, key)
 
+
    Delete the mapping for the given key in a collection.
 
 "),
 
 ("Associative Collections","Base","keys","keys(collection)
+
 
    Return an array of all keys in a collection.
 
@@ -690,30 +789,39 @@
 
 ("Associative Collections","Base","values","values(collection)
 
+
    Return an array of all values in a collection.
 
 "),
 
-("Associative Collections","Base","merge","merge(collection, others...)
+("Associative Collections","Base","merge","merge(collection,
+others...)
+
 
    Construct a merged collection from the given collections.
 
 "),
 
-("Associative Collections","Base","merge!","merge!(collection, others...)
+("Associative Collections","Base","merge!","merge!(collection,
+others...)
+
 
    Update collection with pairs from the other collections
 
 "),
 
-("Associative Collections","Base","filter","filter(function, collection)
+("Associative Collections","Base","filter","filter(function,
+collection)
+
 
    Return a copy of collection, removing (key, value) pairs for which
    function is false.
 
 "),
 
-("Associative Collections","Base","filter!","filter!(function, collection)
+("Associative Collections","Base","filter!","filter!(function,
+collection)
+
 
    Update collection, removing (key, value) pairs for which function
    is false.
@@ -722,12 +830,14 @@
 
 ("Associative Collections","Base","eltype","eltype(collection)
 
+
    Returns the type tuple of the (key,value) pairs contained in
    collection.
 
 "),
 
 ("Associative Collections","Base","sizehint","sizehint(s, n)
+
 
    Suggest that collection \"s\" reserve capacity for at least \"n\"
    elements. This can improve performance.
@@ -736,11 +846,13 @@
 
 ("Set-Like Collections","Base","add!","add!(collection, key)
 
+
    Add an element to a set-like collection.
 
 "),
 
 ("Set-Like Collections","Base","Set","Set(x...)
+
 
    Construct a \"Set\" with the given elements. Should be used instead
    of \"IntSet\" for sparse integer sets, or for sets of arbitrary
@@ -749,6 +861,7 @@
 "),
 
 ("Set-Like Collections","Base","IntSet","IntSet(i...)
+
 
    Construct a sorted set of the given integers. Implemented as a bit
    string, and therefore designed for dense integer sets. If the set
@@ -759,6 +872,7 @@
 
 ("Set-Like Collections","Base","union","union(s1, s2...)
 
+
    Construct the union of two or more sets. Maintains order with
    arrays.
 
@@ -766,11 +880,13 @@
 
 ("Set-Like Collections","Base","union!","union!(s, iterable)
 
+
    Union each element of \"iterable\" into set \"s\" in-place.
 
 "),
 
 ("Set-Like Collections","Base","intersect","intersect(s1, s2...)
+
 
    Construct the intersection of two or more sets. Maintains order and
    multiplicity of the first argument for arrays and ranges.
@@ -779,6 +895,7 @@
 
 ("Set-Like Collections","Base","setdiff","setdiff(s1, s2)
 
+
    Construct the set of elements in \"s1\" but not \"s2\". Maintains
    order with arrays.
 
@@ -786,11 +903,13 @@
 
 ("Set-Like Collections","Base","setdiff!","setdiff!(s, iterable)
 
+
    Remove each element of \"iterable\" from set \"s\" in-place.
 
 "),
 
 ("Set-Like Collections","Base","symdiff","symdiff(s1, s2...)
+
 
    Construct the symmetric difference of elements in the passed in
    sets or arrays. Maintains order with arrays.
@@ -799,12 +918,14 @@
 
 ("Set-Like Collections","Base","symdiff!","symdiff!(s, n)
 
+
    IntSet s is destructively modified to toggle the inclusion of
    integer \"n\".
 
 "),
 
 ("Set-Like Collections","Base","symdiff!","symdiff!(s, itr)
+
 
    For each element in \"itr\", destructively toggle its inclusion in
    set \"s\".
@@ -813,6 +934,7 @@
 
 ("Set-Like Collections","Base","symdiff!","symdiff!(s1, s2)
 
+
    Construct the symmetric difference of IntSets \"s1\" and \"s2\",
    storing the result in \"s1\".
 
@@ -820,17 +942,20 @@
 
 ("Set-Like Collections","Base","complement","complement(s)
 
+
    Returns the set-complement of IntSet s.
 
 "),
 
 ("Set-Like Collections","Base","complement!","complement!(s)
 
+
    Mutates IntSet s into its set-complement.
 
 "),
 
 ("Set-Like Collections","Base","intersect!","intersect!(s1, s2)
+
 
    Intersects IntSets s1 and s2 and overwrites the set s1 with the
    result. If needed, s1 will be expanded to the size of s2.
@@ -839,17 +964,21 @@
 
 ("Dequeues","Base","push!","push!(collection, item) -> collection
 
+
    Insert an item at the end of a collection.
 
 "),
 
 ("Dequeues","Base","pop!","pop!(collection) -> item
 
+
    Remove the last item in a collection and return it.
 
 "),
 
-("Dequeues","Base","unshift!","unshift!(collection, item) -> collection
+("Dequeues","Base","unshift!","unshift!(collection, item) ->
+collection
+
 
    Insert an item at the beginning of a collection.
 
@@ -857,11 +986,13 @@
 
 ("Dequeues","Base","shift!","shift!(collection) -> item
 
+
    Remove the first item in a collection.
 
 "),
 
 ("Dequeues","Base","insert!","insert!(collection, index, item)
+
 
    Insert an item at the given index.
 
@@ -869,11 +1000,13 @@
 
 ("Dequeues","Base","delete!","delete!(collection, index) -> item
 
+
    Remove the item at the given index, and return the deleted item.
 
 "),
 
 ("Dequeues","Base","delete!","delete!(collection, range) -> items
+
 
    Remove items at specified range, and return a collection containing
    the deleted items.
@@ -882,11 +1015,13 @@
 
 ("Dequeues","Base","resize!","resize!(collection, n) -> collection
 
+
    Resize collection to contain \"n\" elements.
 
 "),
 
 ("Dequeues","Base","append!","append!(collection, items) -> collection
+
 
    Add the elements of \"items\" to the end of a collection.
 
@@ -894,11 +1029,13 @@
 
 ("Strings","Base","length","length(s)
 
+
    The number of characters in string \"s\".
 
 "),
 
 ("Strings","Base","*","*(s, t)
+
 
    Concatenate strings.
 
@@ -908,6 +1045,7 @@
 
 ("Strings","Base","^","^(s, n)
 
+
    Repeat string \"s\" \"n\" times.
 
    **Example**: \"\"Julia \"^3 == \"Julia Julia Julia \"\"
@@ -916,17 +1054,20 @@
 
 ("Strings","Base","string","string(xs...)
 
+
    Create a string from any values using the \"print\" function.
 
 "),
 
 ("Strings","Base","repr","repr(x)
 
+
    Create a string from any value using the \"show\" function.
 
 "),
 
 ("Strings","Base","bytestring","bytestring(::Ptr{Uint8})
+
 
    Create a string from the address of a C (0-terminated) string. A
    copy is made; the ptr can be safely freed.
@@ -935,6 +1076,7 @@
 
 ("Strings","Base","bytestring","bytestring(s)
 
+
    Convert a string to a contiguous byte array representation
    appropriate for passing it to C functions.
 
@@ -942,11 +1084,13 @@
 
 ("Strings","Base","ascii","ascii(::Array{Uint8, 1})
 
+
    Create an ASCII string from a byte array.
 
 "),
 
 ("Strings","Base","ascii","ascii(s)
+
 
    Convert a string to a contiguous ASCII string (all characters must
    be valid ASCII characters).
@@ -955,11 +1099,13 @@
 
 ("Strings","Base","utf8","utf8(::Array{Uint8, 1})
 
+
    Create a UTF-8 string from a byte array.
 
 "),
 
 ("Strings","Base","utf8","utf8(s)
+
 
    Convert a string to a contiguous UTF-8 string (all characters must
    be valid UTF-8 characters).
@@ -968,12 +1114,14 @@
 
 ("Strings","Base","is_valid_ascii","is_valid_ascii(s) -> Bool
 
+
    Returns true if the string or byte vector is valid ASCII, false
    otherwise.
 
 "),
 
 ("Strings","Base","is_valid_utf8","is_valid_utf8(s) -> Bool
+
 
    Returns true if the string or byte vector is valid UTF-8, false
    otherwise.
@@ -982,12 +1130,14 @@
 
 ("Strings","Base","is_valid_char","is_valid_char(c) -> Bool
 
+
    Returns true if the given char or integer is a valid Unicode code
    point.
 
 "),
 
 ("Strings","Base","ismatch","ismatch(r::Regex, s::String)
+
 
    Test whether a string contains a match of the given regular
    expression.
@@ -996,6 +1146,7 @@
 
 ("Strings","Base","lpad","lpad(string, n, p)
 
+
    Make a string at least \"n\" characters long by padding on the left
    with copies of \"p\".
 
@@ -1003,12 +1154,14 @@
 
 ("Strings","Base","rpad","rpad(string, n, p)
 
+
    Make a string at least \"n\" characters long by padding on the
    right with copies of \"p\".
 
 "),
 
 ("Strings","Base","search","search(string, chars[, start])
+
 
    Search for the given characters within the given string. The second
    argument may be a single character, a vector or a set of
@@ -1023,6 +1176,7 @@
 
 ("Strings","Base","replace","replace(string, pat, r[, n])
 
+
    Search for the given pattern \"pat\", and replace each occurance
    with \"r\". If \"n\" is provided, replace at most \"n\" occurances.
    As with search, the second argument may be a single character, a
@@ -1032,7 +1186,9 @@
 
 "),
 
-("Strings","Base","split","split(string, [chars, [limit,] [include_empty]])
+("Strings","Base","split","split(string, [chars, [limit,]
+[include_empty]])
+
 
    Return an array of strings by splitting the given string on
    occurrences of the given character delimiters, which may be
@@ -1048,6 +1204,7 @@
 
 ("Strings","Base","strip","strip(string[, chars])
 
+
    Return \"string\" with any leading and trailing whitespace removed.
    If a string \"chars\" is provided, instead remove characters
    contained in that string.
@@ -1055,6 +1212,7 @@
 "),
 
 ("Strings","Base","lstrip","lstrip(string[, chars])
+
 
    Return \"string\" with any leading whitespace removed. If a string
    \"chars\" is provided, instead remove characters contained in that
@@ -1064,6 +1222,7 @@
 
 ("Strings","Base","rstrip","rstrip(string[, chars])
 
+
    Return \"string\" with any trailing whitespace removed. If a string
    \"chars\" is provided, instead remove characters contained in that
    string.
@@ -1072,11 +1231,13 @@
 
 ("Strings","Base","beginswith","beginswith(string, prefix)
 
+
    Returns \"true\" if \"string\" starts with \"prefix\".
 
 "),
 
 ("Strings","Base","endswith","endswith(string, suffix)
+
 
    Returns \"true\" if \"string\" ends with \"suffix\".
 
@@ -1084,17 +1245,20 @@
 
 ("Strings","Base","uppercase","uppercase(string)
 
+
    Returns \"string\" with all characters converted to uppercase.
 
 "),
 
 ("Strings","Base","lowercase","lowercase(string)
 
+
    Returns \"string\" with all characters converted to lowercase.
 
 "),
 
 ("Strings","Base","join","join(strings, delim)
+
 
    Join an array of strings into a single string, inserting the given
    delimiter between adjacent strings.
@@ -1103,11 +1267,13 @@
 
 ("Strings","Base","chop","chop(string)
 
+
    Remove the last character from a string
 
 "),
 
 ("Strings","Base","chomp","chomp(string)
+
 
    Remove a trailing newline from a string
 
@@ -1115,11 +1281,13 @@
 
 ("Strings","Base","ind2chr","ind2chr(string, i)
 
+
    Convert a byte index to a character index
 
 "),
 
 ("Strings","Base","chr2ind","chr2ind(string, i)
+
 
    Convert a character index to a byte index
 
@@ -1127,11 +1295,13 @@
 
 ("Strings","Base","isvalid","isvalid(str, i)
 
+
    Tells whether index \"i\" is valid for the given string
 
 "),
 
 ("Strings","Base","nextind","nextind(str, i)
+
 
    Get the next valid string index after \"i\". Returns
    \"endof(str)+1\" at the end of the string.
@@ -1140,12 +1310,14 @@
 
 ("Strings","Base","prevind","prevind(str, i)
 
+
    Get the previous valid string index before \"i\". Returns \"0\" at
    the beginning of the string.
 
 "),
 
 ("Strings","Base","thisind","thisind(str, i)
+
 
    Adjust \"i\" downwards until it reaches a valid index for the given
    string.
@@ -1154,6 +1326,7 @@
 
 ("Strings","Base","randstring","randstring(len)
 
+
    Create a random ASCII string of length \"len\", consisting of
    upper- and lower-case letters and the digits 0-9
 
@@ -1161,11 +1334,13 @@
 
 ("Strings","Base","charwidth","charwidth(c)
 
+
    Gives the number of columns needed to print a character.
 
 "),
 
 ("Strings","Base","strwidth","strwidth(s)
+
 
    Gives the number of columns needed to print a string.
 
@@ -1173,11 +1348,13 @@
 
 ("Strings","Base","isalnum","isalnum(c::Char)
 
+
    Tests whether a character is alphanumeric.
 
 "),
 
 ("Strings","Base","isalpha","isalpha(c::Char)
+
 
    Tests whether a character is alphabetic.
 
@@ -1185,11 +1362,13 @@
 
 ("Strings","Base","isascii","isascii(c::Char)
 
+
    Tests whether a character belongs to the ASCII character set.
 
 "),
 
 ("Strings","Base","isblank","isblank(c::Char)
+
 
    Tests whether a character is a tab or space.
 
@@ -1197,11 +1376,13 @@
 
 ("Strings","Base","iscntrl","iscntrl(c::Char)
 
+
    Tests whether a character is a control character.
 
 "),
 
 ("Strings","Base","isdigit","isdigit(c::Char)
+
 
    Tests whether a character is a numeric digit (0-9).
 
@@ -1209,11 +1390,13 @@
 
 ("Strings","Base","isgraph","isgraph(c::Char)
 
+
    Tests whether a character is printable, and not a space.
 
 "),
 
 ("Strings","Base","islower","islower(c::Char)
+
 
    Tests whether a character is a lowercase letter.
 
@@ -1221,11 +1404,13 @@
 
 ("Strings","Base","isprint","isprint(c::Char)
 
+
    Tests whether a character is printable, including space.
 
 "),
 
 ("Strings","Base","ispunct","ispunct(c::Char)
+
 
    Tests whether a character is printable, and not a space or
    alphanumeric.
@@ -1234,11 +1419,13 @@
 
 ("Strings","Base","isspace","isspace(c::Char)
 
+
    Tests whether a character is any whitespace character.
 
 "),
 
 ("Strings","Base","isupper","isupper(c::Char)
+
 
    Tests whether a character is an uppercase letter.
 
@@ -1246,11 +1433,13 @@
 
 ("Strings","Base","isxdigit","isxdigit(c::Char)
 
+
    Tests whether a character is a valid hexadecimal digit.
 
 "),
 
 ("I/O","Base","STDOUT","STDOUT
+
 
    Global variable referring to the standard out stream.
 
@@ -1258,11 +1447,13 @@
 
 ("I/O","Base","STDERR","STDERR
 
+
    Global variable referring to the standard error stream.
 
 "),
 
 ("I/O","Base","STDIN","STDIN
+
 
    Global variable referring to the standard input stream.
 
@@ -1270,12 +1461,15 @@
 
 ("I/O","Base","OUTPUT_STREAM","OUTPUT_STREAM
 
+
    The default stream used for text output, e.g. in the \"print\" and
    \"show\" functions.
 
 "),
 
-("I/O","Base","open","open(file_name[, read, write, create, truncate, append]) -> IOStream
+("I/O","Base","open","open(file_name[, read, write, create, truncate,
+append]) -> IOStream
+
 
    Open a file in a mode specified by five boolean arguments. The
    default is to open files for reading only. Returns a stream for
@@ -1284,6 +1478,7 @@
 "),
 
 ("I/O","Base","open","open(file_name[, mode]) -> IOStream
+
 
    Alternate syntax for open, where a string-based mode specifier is
    used instead of the five booleans. The values of \"mode\"
@@ -1308,6 +1503,7 @@
 
 ("I/O","Base","open","open(f::function, args...)
 
+
    Apply the function \"f\" to the result of \"open(args...)\" and
    close the resulting file descriptor upon completion.
 
@@ -1317,12 +1513,15 @@
 
 ("I/O","Base","IOBuffer","IOBuffer([size]) -> IOBuffer
 
+
    Create an in-memory I/O stream, optionally specifying how much
    initial space is needed.
 
 "),
 
-("I/O","Base","fdio","fdio([name::String], fd::Integer[, own::Bool]) -> IOStream
+("I/O","Base","fdio","fdio([name::String], fd::Integer[, own::Bool])
+-> IOStream
+
 
    Create an \"IOStream\" object from an integer file descriptor. If
    \"own\" is true, closing this object will close the underlying
@@ -1334,17 +1533,20 @@
 
 ("I/O","Base","flush","flush(stream)
 
+
    Commit all currently buffered writes to the given stream.
 
 "),
 
 ("I/O","Base","close","close(stream)
 
+
    Close an I/O stream. Performs a \"flush\" first.
 
 "),
 
 ("I/O","Base","write","write(stream, x)
+
 
    Write the canonical binary representation of a value to the given
    stream.
@@ -1353,12 +1555,14 @@
 
 ("I/O","Base","read","read(stream, type)
 
+
    Read a value of the given type from a stream, in canonical binary
    representation.
 
 "),
 
 ("I/O","Base","read","read(stream, type, dims)
+
 
    Read a series of values of the given type from a stream, in
    canonical binary representation. \"dims\" is either a tuple or a
@@ -1369,11 +1573,13 @@
 
 ("I/O","Base","position","position(s)
 
+
    Get the current position of a stream.
 
 "),
 
 ("I/O","Base","seek","seek(s, pos)
+
 
    Seek a stream to the given position.
 
@@ -1381,11 +1587,13 @@
 
 ("I/O","Base","seekstart","seekstart(s)
 
+
    Seek a stream to its beginning.
 
 "),
 
 ("I/O","Base","seekend","seekend(s)
+
 
    Seek a stream to its end.
 
@@ -1393,11 +1601,13 @@
 
 ("I/O","Base","skip","skip(s, offset)
 
+
    Seek a stream relative to the current position.
 
 "),
 
 ("I/O","Base","eof","eof(stream)
+
 
    Tests whether an I/O stream is at end-of-file. If the stream is not
    yet exhausted, this function will block to wait for more data if
@@ -1408,12 +1618,14 @@
 
 ("I/O","Base","ntoh","ntoh(x)
 
+
    Converts the endianness of a value from Network byte order (big-
    endian) to that used by the Host.
 
 "),
 
 ("I/O","Base","hton","hton(x)
+
 
    Converts the endianness of a value from that used by the Host to
    Network byte order (big-endian).
@@ -1422,6 +1634,7 @@
 
 ("I/O","Base","ltoh","ltoh(x)
 
+
    Converts the endianness of a value from Little-endian to that used
    by the Host.
 
@@ -1429,12 +1642,14 @@
 
 ("I/O","Base","htol","htol(x)
 
+
    Converts the endianness of a value from that used by the Host to
    Little-endian.
 
 "),
 
 ("Text I/O","Base","show","show(x)
+
 
    Write an informative text representation of a value to the current
    output stream. New types should overload \"show(io, x)\" where the
@@ -1444,6 +1659,7 @@
 
 ("Text I/O","Base","print","print(x)
 
+
    Write (to the default output stream) a canonical (un-decorated)
    text representation of a value if there is one, otherwise call
    \"show\".
@@ -1452,11 +1668,14 @@
 
 ("Text I/O","Base","println","println(x)
 
+
    Print (using \"print()\") \"x\" followed by a newline
 
 "),
 
-("Text I/O","Base","@printf","@printf([io::IOStream], \"%Fmt\", args...)
+("Text I/O","Base","@printf","@printf([io::IOStream], \"%Fmt\",
+args...)
+
 
    Print arg(s) using C \"printf()\" style format specification
    string. Optionally, an IOStream may be passed as the first argument
@@ -1466,17 +1685,20 @@
 
 ("Text I/O","Base","@sprintf","@sprintf(\"%Fmt\", args...)
 
+
    Return \"@printf\" formatted output as string.
 
 "),
 
 ("Text I/O","Base","showall","showall(x)
 
+
    Show x, printing all elements of arrays
 
 "),
 
 ("Text I/O","Base","dump","dump(x)
+
 
    Write a thorough text representation of a value to the current
    output stream.
@@ -1485,11 +1707,13 @@
 
 ("Text I/O","Base","readall","readall(stream)
 
+
    Read the entire contents of an I/O stream as a string.
 
 "),
 
 ("Text I/O","Base","readline","readline(stream)
+
 
    Read a single line of text, including a trailing newline character
    (if one is reached before the end of the input).
@@ -1498,11 +1722,13 @@
 
 ("Text I/O","Base","readuntil","readuntil(stream, delim)
 
+
    Read a string, up to and including the given delimiter byte.
 
 "),
 
 ("Text I/O","Base","readlines","readlines(stream)
+
 
    Read all lines as an array.
 
@@ -1510,11 +1736,13 @@
 
 ("Text I/O","Base","eachline","eachline(stream)
 
+
    Create an iterable object that will yield each line from a stream.
 
 "),
 
 ("Text I/O","Base","readdlm","readdlm(filename, delim::Char)
+
 
    Read a matrix from a text file where each line gives one row, with
    elements separated by the given delimeter. If all data is numeric,
@@ -1524,6 +1752,7 @@
 "),
 
 ("Text I/O","Base","readdlm","readdlm(filename, delim::Char, T::Type)
+
 
    Read a matrix from a text file with a given element type. If \"T\"
    is a numeric type, the result is an array of that type, with any
@@ -1535,6 +1764,7 @@
 
 ("Text I/O","Base","writedlm","writedlm(filename, array, delim::Char)
 
+
    Write an array to a text file using the given delimeter (defaults
    to comma).
 
@@ -1542,17 +1772,21 @@
 
 ("Text I/O","Base","readcsv","readcsv(filename[, T::Type])
 
+
    Equivalent to \"readdlm\" with \"delim\" set to comma.
 
 "),
 
 ("Text I/O","Base","writecsv","writecsv(filename, array)
 
+
    Equivalent to \"writedlm\" with \"delim\" set to comma.
 
 "),
 
-("Memory-mapped I/O","Base","mmap_array","mmap_array(type, dims, stream[, offset])
+("Memory-mapped I/O","Base","mmap_array","mmap_array(type, dims,
+stream[, offset])
+
 
    Create an array whose values are linked to a file, using memory-
    mapping. This provides a convenient way of working with data too
@@ -1577,6 +1811,7 @@
 
 ("Memory-mapped I/O","Base","msync","msync(array)
 
+
    Forces synchronization between the in-memory version of a memory-
    mapped array and the on-disk version. You may not need to call this
    function, because synchronization is performed at intervals
@@ -1588,11 +1823,13 @@
 
 ("Memory-mapped I/O","Base","mmap","mmap(len, prot, flags, fd, offset)
 
+
    Low-level interface to the mmap system call. See the man page.
 
 "),
 
 ("Memory-mapped I/O","Base","munmap","munmap(pointer, len)
+
 
    Low-level interface for unmapping memory (see the man page). With
    mmap_array you do not need to call this directly; the memory is
@@ -1602,11 +1839,13 @@
 
 ("Mathematical Functions","Base","-","-(x)
 
+
    Unary minus operator.
 
 "),
 
 ("Mathematical Functions","Base","+","+(x, y)
+
 
    Binary addition operator.
 
@@ -1614,11 +1853,13 @@
 
 ("Mathematical Functions","Base","-","-(x, y)
 
+
    Binary subtraction operator.
 
 "),
 
 ("Mathematical Functions","Base","*","*(x, y)
+
 
    Binary multiplication operator.
 
@@ -1626,11 +1867,13 @@
 
 ("Mathematical Functions","Base","/","/(x, y)
 
+
    Binary left-division operator.
 
 "),
 
 ("Mathematical Functions","Base","\\","\\(x, y)
+
 
    Binary right-division operator.
 
@@ -1638,11 +1881,13 @@
 
 ("Mathematical Functions","Base","^","^(x, y)
 
+
    Binary exponentiation operator.
 
 "),
 
 ("Mathematical Functions","Base",".+",".+(x, y)
+
 
    Element-wise binary addition operator.
 
@@ -1650,11 +1895,13 @@
 
 ("Mathematical Functions","Base",".-",".-(x, y)
 
+
    Element-wise binary subtraction operator.
 
 "),
 
 ("Mathematical Functions","Base",".*",".*(x, y)
+
 
    Element-wise binary multiplication operator.
 
@@ -1662,11 +1909,13 @@
 
 ("Mathematical Functions","Base","./","./(x, y)
 
+
    Element-wise binary left division operator.
 
 "),
 
 ("Mathematical Functions","Base",".\\",".\\(x, y)
+
 
    Element-wise binary right division operator.
 
@@ -1674,11 +1923,13 @@
 
 ("Mathematical Functions","Base",".^",".^(x, y)
 
+
    Element-wise binary exponentiation operator.
 
 "),
 
 ("Mathematical Functions","Base","div","div(a, b)
+
 
    Compute a/b, truncating to an integer
 
@@ -1686,11 +1937,13 @@
 
 ("Mathematical Functions","Base","fld","fld(a, b)
 
+
    Largest integer less than or equal to a/b
 
 "),
 
 ("Mathematical Functions","Base","mod","mod(x, m)
+
 
    Modulus after division, returning in the range [0,m)
 
@@ -1698,11 +1951,13 @@
 
 ("Mathematical Functions","Base","rem","rem(x, m)
 
+
    Remainder after division
 
 "),
 
 ("Mathematical Functions","Base","%","%(x, m)
+
 
    Remainder after division. The operator form of \"rem\".
 
@@ -1710,11 +1965,13 @@
 
 ("Mathematical Functions","Base","mod1","mod1(x, m)
 
+
    Modulus after division, returning in the range (0,m]
 
 "),
 
 ("Mathematical Functions","Base","//","//(num, den)
+
 
    Rational division
 
@@ -1722,11 +1979,13 @@
 
 ("Mathematical Functions","Base","num","num(x)
 
+
    Numerator of the rational representation of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","den","den(x)
+
 
    Denominator of the rational representation of \"x\"
 
@@ -1734,11 +1993,13 @@
 
 ("Mathematical Functions","Base","<<","<<(x, n)
 
+
    Left shift operator.
 
 "),
 
 ("Mathematical Functions","Base",">>",">>(x, n)
+
 
    Right shift operator.
 
@@ -1746,11 +2007,13 @@
 
 ("Mathematical Functions","Base",">>>",">>>(x, n)
 
+
    Unsigned right shift operator.
 
 "),
 
 ("Mathematical Functions","Base",":",":(start[, step], stop)
+
 
    Range operator. \"a:b\" constructs a range from \"a\" to \"b\" with
    a step size of 1, and \"a:s:b\" is similar but uses a step size of
@@ -1761,11 +2024,13 @@
 
 ("Mathematical Functions","Base","colon","colon(start[, step], stop)
 
+
    Called by \":\" syntax for constructing ranges.
 
 "),
 
 ("Mathematical Functions","Base","==","==(x, y)
+
 
    Equality comparison operator.
 
@@ -1773,11 +2038,13 @@
 
 ("Mathematical Functions","Base","!=","!=(x, y)
 
+
    Not-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base","<","<(x, y)
+
 
    Less-than comparison operator.
 
@@ -1785,11 +2052,13 @@
 
 ("Mathematical Functions","Base","<=","<=(x, y)
 
+
    Less-than-or-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base",">",">(x, y)
+
 
    Greater-than comparison operator.
 
@@ -1797,11 +2066,13 @@
 
 ("Mathematical Functions","Base",">=",">=(x, y)
 
+
    Greater-than-or-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base",".==",".==(x, y)
+
 
    Element-wise equality comparison operator.
 
@@ -1809,11 +2080,13 @@
 
 ("Mathematical Functions","Base",".!=",".!=(x, y)
 
+
    Element-wise not-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base",".<",".<(x, y)
+
 
    Element-wise less-than comparison operator.
 
@@ -1821,11 +2094,13 @@
 
 ("Mathematical Functions","Base",".<=",".<=(x, y)
 
+
    Element-wise less-than-or-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base",".>",".>(x, y)
+
 
    Element-wise greater-than comparison operator.
 
@@ -1833,11 +2108,13 @@
 
 ("Mathematical Functions","Base",".>=",".>=(x, y)
 
+
    Element-wise greater-than-or-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base","cmp","cmp(x, y)
+
 
    Return -1, 0, or 1 depending on whether \"x<y\", \"x==y\", or
    \"x>y\", respectively
@@ -1846,11 +2123,13 @@
 
 ("Mathematical Functions","Base","!","!(x)
 
+
    Boolean not
 
 "),
 
 ("Mathematical Functions","Base","~","~(x)
+
 
    Bitwise not
 
@@ -1858,11 +2137,13 @@
 
 ("Mathematical Functions","Base","&","&(x, y)
 
+
    Bitwise and
 
 "),
 
 ("Mathematical Functions","Base","|","|(x, y)
+
 
    Bitwise or
 
@@ -1870,11 +2151,13 @@
 
 ("Mathematical Functions","Base","\$","\$(x, y)
 
+
    Bitwise exclusive or
 
 "),
 
 ("Mathematical Functions","Base","sin","sin(x)
+
 
    Compute sine of \"x\", where \"x\" is in radians
 
@@ -1882,11 +2165,13 @@
 
 ("Mathematical Functions","Base","cos","cos(x)
 
+
    Compute cosine of \"x\", where \"x\" is in radians
 
 "),
 
 ("Mathematical Functions","Base","tan","tan(x)
+
 
    Compute tangent of \"x\", where \"x\" is in radians
 
@@ -1894,11 +2179,13 @@
 
 ("Mathematical Functions","Base","sind","sind(x)
 
+
    Compute sine of \"x\", where \"x\" is in degrees
 
 "),
 
 ("Mathematical Functions","Base","cosd","cosd(x)
+
 
    Compute cosine of \"x\", where \"x\" is in degrees
 
@@ -1906,11 +2193,13 @@
 
 ("Mathematical Functions","Base","tand","tand(x)
 
+
    Compute tangent of \"x\", where \"x\" is in degrees
 
 "),
 
 ("Mathematical Functions","Base","sinh","sinh(x)
+
 
    Compute hyperbolic sine of \"x\"
 
@@ -1918,11 +2207,13 @@
 
 ("Mathematical Functions","Base","cosh","cosh(x)
 
+
    Compute hyperbolic cosine of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","tanh","tanh(x)
+
 
    Compute hyperbolic tangent of \"x\"
 
@@ -1930,17 +2221,20 @@
 
 ("Mathematical Functions","Base","asin","asin(x)
 
+
    Compute the inverse sine of \"x\", where the output is in radians
 
 "),
 
 ("Mathematical Functions","Base","acos","acos(x)
 
+
    Compute the inverse cosine of \"x\", where the output is in radians
 
 "),
 
 ("Mathematical Functions","Base","atan","atan(x)
+
 
    Compute the inverse tangent of \"x\", where the output is in
    radians
@@ -1949,6 +2243,7 @@
 
 ("Mathematical Functions","Base","atan2","atan2(y, x)
 
+
    Compute the inverse tangent of \"y/x\", using the signs of both
    \"x\" and \"y\" to determine the quadrant of the return value.
 
@@ -1956,17 +2251,20 @@
 
 ("Mathematical Functions","Base","asind","asind(x)
 
+
    Compute the inverse sine of \"x\", where the output is in degrees
 
 "),
 
 ("Mathematical Functions","Base","acosd","acosd(x)
 
+
    Compute the inverse cosine of \"x\", where the output is in degrees
 
 "),
 
 ("Mathematical Functions","Base","atand","atand(x)
+
 
    Compute the inverse tangent of \"x\", where the output is in
    degrees
@@ -1975,11 +2273,13 @@
 
 ("Mathematical Functions","Base","sec","sec(x)
 
+
    Compute the secant of \"x\", where \"x\" is in radians
 
 "),
 
 ("Mathematical Functions","Base","csc","csc(x)
+
 
    Compute the cosecant of \"x\", where \"x\" is in radians
 
@@ -1987,11 +2287,13 @@
 
 ("Mathematical Functions","Base","cot","cot(x)
 
+
    Compute the cotangent of \"x\", where \"x\" is in radians
 
 "),
 
 ("Mathematical Functions","Base","secd","secd(x)
+
 
    Compute the secant of \"x\", where \"x\" is in degrees
 
@@ -1999,11 +2301,13 @@
 
 ("Mathematical Functions","Base","cscd","cscd(x)
 
+
    Compute the cosecant of \"x\", where \"x\" is in degrees
 
 "),
 
 ("Mathematical Functions","Base","cotd","cotd(x)
+
 
    Compute the cotangent of \"x\", where \"x\" is in degrees
 
@@ -2011,11 +2315,13 @@
 
 ("Mathematical Functions","Base","asec","asec(x)
 
+
    Compute the inverse secant of \"x\", where the output is in radians
 
 "),
 
 ("Mathematical Functions","Base","acsc","acsc(x)
+
 
    Compute the inverse cosecant of \"x\", where the output is in
    radians
@@ -2024,6 +2330,7 @@
 
 ("Mathematical Functions","Base","acot","acot(x)
 
+
    Compute the inverse cotangent of \"x\", where the output is in
    radians
 
@@ -2031,11 +2338,13 @@
 
 ("Mathematical Functions","Base","asecd","asecd(x)
 
+
    Compute the inverse secant of \"x\", where the output is in degrees
 
 "),
 
 ("Mathematical Functions","Base","acscd","acscd(x)
+
 
    Compute the inverse cosecant of \"x\", where the output is in
    degrees
@@ -2044,6 +2353,7 @@
 
 ("Mathematical Functions","Base","acotd","acotd(x)
 
+
    Compute the inverse cotangent of \"x\", where the output is in
    degrees
 
@@ -2051,11 +2361,13 @@
 
 ("Mathematical Functions","Base","sech","sech(x)
 
+
    Compute the hyperbolic secant of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","csch","csch(x)
+
 
    Compute the hyperbolic cosecant of \"x\"
 
@@ -2063,11 +2375,13 @@
 
 ("Mathematical Functions","Base","coth","coth(x)
 
+
    Compute the hyperbolic cotangent of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","asinh","asinh(x)
+
 
    Compute the inverse hyperbolic sine of \"x\"
 
@@ -2075,11 +2389,13 @@
 
 ("Mathematical Functions","Base","acosh","acosh(x)
 
+
    Compute the inverse hyperbolic cosine of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","atanh","atanh(x)
+
 
    Compute the inverse hyperbolic cotangent of \"x\"
 
@@ -2087,11 +2403,13 @@
 
 ("Mathematical Functions","Base","asech","asech(x)
 
+
    Compute the inverse hyperbolic secant of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","acsch","acsch(x)
+
 
    Compute the inverse hyperbolic cosecant of \"x\"
 
@@ -2099,17 +2417,20 @@
 
 ("Mathematical Functions","Base","acoth","acoth(x)
 
+
    Compute the inverse hyperbolic cotangent of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","sinc","sinc(x)
 
+
    Compute \\sin(\\pi x) / (\\pi x) if x \\neq 0, and 1 if x = 0.
 
 "),
 
 ("Mathematical Functions","Base","cosc","cosc(x)
+
 
    Compute \\cos(\\pi x) / x - \\sin(\\pi x) / (\\pi x^2) if x \\neq
    0, and 0 if x = 0. This is the derivative of \"sinc(x)\".
@@ -2118,11 +2439,13 @@
 
 ("Mathematical Functions","Base","degrees2radians","degrees2radians(x)
 
+
    Convert \"x\" from degrees to radians
 
 "),
 
 ("Mathematical Functions","Base","radians2degrees","radians2degrees(x)
+
 
    Convert \"x\" from radians to degrees
 
@@ -2130,11 +2453,13 @@
 
 ("Mathematical Functions","Base","hypot","hypot(x, y)
 
+
    Compute the \\sqrt{x^2+y^2} without undue overflow or underflow
 
 "),
 
 ("Mathematical Functions","Base","log","log(x)
+
 
    Compute the natural logarithm of \"x\"
 
@@ -2142,11 +2467,13 @@
 
 ("Mathematical Functions","Base","log2","log2(x)
 
+
    Compute the natural logarithm of \"x\" to base 2
 
 "),
 
 ("Mathematical Functions","Base","log10","log10(x)
+
 
    Compute the natural logarithm of \"x\" to base 10
 
@@ -2154,11 +2481,13 @@
 
 ("Mathematical Functions","Base","log1p","log1p(x)
 
+
    Accurate natural logarithm of \"1+x\"
 
 "),
 
 ("Mathematical Functions","Base","frexp","frexp(val, exp)
+
 
    Return a number \"x\" such that it has a magnitude in the interval
    \"[1/2, 1)\" or 0, and val = x \\times 2^{exp}.
@@ -2167,11 +2496,13 @@
 
 ("Mathematical Functions","Base","exp","exp(x)
 
+
    Compute e^x
 
 "),
 
 ("Mathematical Functions","Base","exp2","exp2(x)
+
 
    Compute 2^x
 
@@ -2179,17 +2510,20 @@
 
 ("Mathematical Functions","Base","exp10","exp10(x)
 
+
    Compute 10^x
 
 "),
 
 ("Mathematical Functions","Base","ldexp","ldexp(x, n)
 
+
    Compute x \\times 2^n
 
 "),
 
 ("Mathematical Functions","Base","modf","modf(x)
+
 
    Return a tuple (fpart,ipart) of the fractional and integral parts
    of a number. Both parts have the same sign as the argument.
@@ -2198,17 +2532,20 @@
 
 ("Mathematical Functions","Base","expm1","expm1(x)
 
+
    Accurately compute e^x-1
 
 "),
 
 ("Mathematical Functions","Base","square","square(x)
 
+
    Compute x^2
 
 "),
 
 ("Mathematical Functions","Base","round","round(x[, digits[, base]])
+
 
    \"round(x)\" returns the nearest integral value of the same type as
    \"x\" to \"x\". \"round(x, digits)\" rounds to the specified number
@@ -2221,6 +2558,7 @@
 
 ("Mathematical Functions","Base","ceil","ceil(x[, digits[, base]])
 
+
    Returns the nearest integral value of the same type as \"x\" not
    less than \"x\". \"digits\" and \"base\" work as above.
 
@@ -2228,12 +2566,14 @@
 
 ("Mathematical Functions","Base","floor","floor(x[, digits[, base]])
 
+
    Returns the nearest integral value of the same type as \"x\" not
    greater than \"x\". \"digits\" and \"base\" work as above.
 
 "),
 
 ("Mathematical Functions","Base","trunc","trunc(x[, digits[, base]])
+
 
    Returns the nearest integral value of the same type as \"x\" not
    greater in magnitude than \"x\". \"digits\" and \"base\" work as
@@ -2243,11 +2583,13 @@
 
 ("Mathematical Functions","Base","iround","iround(x) -> Integer
 
+
    Returns the nearest integer to \"x\".
 
 "),
 
 ("Mathematical Functions","Base","iceil","iceil(x) -> Integer
+
 
    Returns the nearest integer not less than \"x\".
 
@@ -2255,17 +2597,20 @@
 
 ("Mathematical Functions","Base","ifloor","ifloor(x) -> Integer
 
+
    Returns the nearest integer not greater than \"x\".
 
 "),
 
 ("Mathematical Functions","Base","itrunc","itrunc(x) -> Integer
 
+
    Returns the nearest integer not greater in magnitude than \"x\".
 
 "),
 
 ("Mathematical Functions","Base","signif","signif(x, digits[, base])
+
 
    Rounds (in the sense of \"round\") \"x\" so that there are
    \"digits\" significant digits, under a base \"base\"
@@ -2276,17 +2621,20 @@
 
 ("Mathematical Functions","Base","min","min(x, y)
 
+
    Return the minimum of \"x\" and \"y\"
 
 "),
 
 ("Mathematical Functions","Base","max","max(x, y)
 
+
    Return the maximum of \"x\" and \"y\"
 
 "),
 
 ("Mathematical Functions","Base","clamp","clamp(x, lo, hi)
+
 
    Return x if \"lo <= x <= y\". If \"x < lo\", return \"lo\". If \"x
    > hi\", return \"hi\".
@@ -2295,11 +2643,13 @@
 
 ("Mathematical Functions","Base","abs","abs(x)
 
+
    Absolute value of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","abs2","abs2(x)
+
 
    Squared absolute value of \"x\"
 
@@ -2307,11 +2657,13 @@
 
 ("Mathematical Functions","Base","copysign","copysign(x, y)
 
+
    Return \"x\" such that it has the same sign as \"y\"
 
 "),
 
 ("Mathematical Functions","Base","sign","sign(x)
+
 
    Return \"+1\" if \"x\" is positive, \"0\" if \"x == 0\", and \"-1\"
    if \"x\" is negative.
@@ -2320,12 +2672,14 @@
 
 ("Mathematical Functions","Base","signbit","signbit(x)
 
+
    Returns \"1\" if the value of the sign of \"x\" is negative,
    otherwise \"0\".
 
 "),
 
 ("Mathematical Functions","Base","flipsign","flipsign(x, y)
+
 
    Return \"x\" with its sign flipped if \"y\" is negative. For
    example \"abs(x) = flipsign(x,x)\".
@@ -2334,17 +2688,20 @@
 
 ("Mathematical Functions","Base","sqrt","sqrt(x)
 
+
    Return \\sqrt{x}
 
 "),
 
 ("Mathematical Functions","Base","cbrt","cbrt(x)
 
+
    Return x^{1/3}
 
 "),
 
 ("Mathematical Functions","Base","erf","erf(x)
+
 
    Compute the error function of \"x\", defined by
    \\frac{2}{\\sqrt{\\pi}} \\int_0^x e^{-t^2} dt for arbitrary complex
@@ -2354,12 +2711,14 @@
 
 ("Mathematical Functions","Base","erfc","erfc(x)
 
+
    Compute the complementary error function of \"x\", defined by 1 -
    \\operatorname{erf}(x).
 
 "),
 
 ("Mathematical Functions","Base","erfcx","erfcx(x)
+
 
    Compute the scaled complementary error function of \"x\", defined
    by e^{x^2} \\operatorname{erfc}(x).  Note also that
@@ -2369,12 +2728,14 @@
 
 ("Mathematical Functions","Base","erfi","erfi(x)
 
+
    Compute the imaginary error function of \"x\", defined by -i
    \\operatorname{erf}(ix).
 
 "),
 
 ("Mathematical Functions","Base","dawson","dawson(x)
+
 
    Compute the Dawson function (scaled imaginary error function) of
    \"x\", defined by \\frac{\\sqrt{\\pi}}{2} e^{-x^2}
@@ -2384,12 +2745,14 @@
 
 ("Mathematical Functions","Base","erfinv","erfinv(x)
 
+
    Compute the inverse error function of a real \"x\", defined by
    \\operatorname{erf}(\\operatorname{erfinv}(x)) = x.
 
 "),
 
 ("Mathematical Functions","Base","erfcinv","erfcinv(x)
+
 
    Compute the inverse error complementary function of a real \"x\",
    defined by \\operatorname{erfc}(\\operatorname{erfcinv}(x)) = x.
@@ -2398,17 +2761,20 @@
 
 ("Mathematical Functions","Base","real","real(z)
 
+
    Return the real part of the complex number \"z\"
 
 "),
 
 ("Mathematical Functions","Base","imag","imag(z)
 
+
    Return the imaginary part of the complex number \"z\"
 
 "),
 
 ("Mathematical Functions","Base","reim","reim(z)
+
 
    Return both the real and imaginary parts of the complex number
    \"z\"
@@ -2417,17 +2783,20 @@
 
 ("Mathematical Functions","Base","conj","conj(z)
 
+
    Compute the complex conjugate of a complex number \"z\"
 
 "),
 
 ("Mathematical Functions","Base","angle","angle(z)
 
+
    Compute the phase angle of a complex number \"z\"
 
 "),
 
 ("Mathematical Functions","Base","cis","cis(z)
+
 
    Return \"cos(z) + i*sin(z)\" if z is real. Return \"(cos(real(z)) +
    i*sin(real(z)))/exp(imag(z))\" if \"z\" is complex
@@ -2436,11 +2805,13 @@
 
 ("Mathematical Functions","Base","binomial","binomial(n, k)
 
+
    Number of ways to choose \"k\" out of \"n\" items
 
 "),
 
 ("Mathematical Functions","Base","factorial","factorial(n)
+
 
    Factorial of n
 
@@ -2448,11 +2819,13 @@
 
 ("Mathematical Functions","Base","factorial","factorial(n, k)
 
+
    Compute \"factorial(n)/factorial(k)\"
 
 "),
 
 ("Mathematical Functions","Base","factor","factor(n)
+
 
    Compute the prime factorization of an integer \"n\". Returns a
    dictionary. The keys of the dictionary correspond to the factors,
@@ -2466,17 +2839,20 @@
 
 ("Mathematical Functions","Base","gcd","gcd(x, y)
 
+
    Greatest common divisor
 
 "),
 
 ("Mathematical Functions","Base","lcm","lcm(x, y)
 
+
    Least common multiple
 
 "),
 
 ("Mathematical Functions","Base","gcdx","gcdx(x, y)
+
 
    Greatest common divisor, also returning integer coefficients \"u\"
    and \"v\" that solve \"ux+vy == gcd(x,y)\"
@@ -2485,11 +2861,13 @@
 
 ("Mathematical Functions","Base","ispow2","ispow2(n)
 
+
    Test whether \"n\" is a power of two
 
 "),
 
 ("Mathematical Functions","Base","nextpow2","nextpow2(n)
+
 
    Next power of two not less than \"n\"
 
@@ -2497,11 +2875,13 @@
 
 ("Mathematical Functions","Base","prevpow2","prevpow2(n)
 
+
    Previous power of two not greater than \"n\"
 
 "),
 
 ("Mathematical Functions","Base","nextpow","nextpow(a, n)
+
 
    Next power of \"a\" not less than \"n\"
 
@@ -2509,11 +2889,13 @@
 
 ("Mathematical Functions","Base","prevpow","prevpow(a, n)
 
+
    Previous power of \"a\" not greater than \"n\"
 
 "),
 
 ("Mathematical Functions","Base","nextprod","nextprod([a, b, c], n)
+
 
    Next integer not less than \"n\" that can be written \"a^i1 * b^i2
    * c^i3\" for integers \"i1\", \"i2\", \"i3\".
@@ -2522,6 +2904,7 @@
 
 ("Mathematical Functions","Base","prevprod","prevprod([a, b, c], n)
 
+
    Previous integer not greater than \"n\" that can be written \"a^i1
    * b^i2 * c^i3\" for integers \"i1\", \"i2\", \"i3\".
 
@@ -2529,11 +2912,13 @@
 
 ("Mathematical Functions","Base","invmod","invmod(x, m)
 
+
    Inverse of \"x\", modulo \"m\"
 
 "),
 
 ("Mathematical Functions","Base","powermod","powermod(x, p, m)
+
 
    Compute \"mod(x^p, m)\"
 
@@ -2541,11 +2926,13 @@
 
 ("Mathematical Functions","Base","gamma","gamma(x)
 
+
    Compute the gamma function of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","lgamma","lgamma(x)
+
 
    Compute the logarithm of \"gamma(x)\"
 
@@ -2553,11 +2940,13 @@
 
 ("Mathematical Functions","Base","lfact","lfact(x)
 
+
    Compute the logarithmic factorial of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","digamma","digamma(x)
+
 
    Compute the digamma function of \"x\" (the logarithmic derivative
    of \"gamma(x)\")
@@ -2566,11 +2955,13 @@
 
 ("Mathematical Functions","Base","airy","airy(k, x)
 
+
    kth derivative of the Airy function \\operatorname{Ai}(x).
 
 "),
 
 ("Mathematical Functions","Base","airyai","airyai(x)
+
 
    Airy function \\operatorname{Ai}(x).
 
@@ -2578,11 +2969,13 @@
 
 ("Mathematical Functions","Base","airyprime","airyprime(x)
 
+
    Airy function derivative \\operatorname{Ai}'(x).
 
 "),
 
 ("Mathematical Functions","Base","airyaiprime","airyaiprime(x)
+
 
    Airy function derivative \\operatorname{Ai}'(x).
 
@@ -2590,11 +2983,13 @@
 
 ("Mathematical Functions","Base","airybi","airybi(x)
 
+
    Airy function \\operatorname{Bi}(x).
 
 "),
 
 ("Mathematical Functions","Base","airybiprime","airybiprime(x)
+
 
    Airy function derivative \\operatorname{Bi}'(x).
 
@@ -2602,11 +2997,13 @@
 
 ("Mathematical Functions","Base","besselj0","besselj0(x)
 
+
    Bessel function of the first kind of order 0, J_0(x).
 
 "),
 
 ("Mathematical Functions","Base","besselj1","besselj1(x)
+
 
    Bessel function of the first kind of order 1, J_1(x).
 
@@ -2614,11 +3011,13 @@
 
 ("Mathematical Functions","Base","besselj","besselj(nu, x)
 
+
    Bessel function of the first kind of order \"nu\", J_\\nu(x).
 
 "),
 
 ("Mathematical Functions","Base","bessely0","bessely0(x)
+
 
    Bessel function of the second kind of order 0, Y_0(x).
 
@@ -2626,11 +3025,13 @@
 
 ("Mathematical Functions","Base","bessely1","bessely1(x)
 
+
    Bessel function of the second kind of order 1, Y_1(x).
 
 "),
 
 ("Mathematical Functions","Base","bessely","bessely(nu, x)
+
 
    Bessel function of the second kind of order \"nu\", Y_\\nu(x).
 
@@ -2638,17 +3039,20 @@
 
 ("Mathematical Functions","Base","hankelh1","hankelh1(nu, x)
 
+
    Bessel function of the third kind of order \"nu\", H^{(1)}_\\nu(x).
 
 "),
 
 ("Mathematical Functions","Base","hankelh2","hankelh2(nu, x)
 
+
    Bessel function of the third kind of order \"nu\", H^{(2)}_\\nu(x).
 
 "),
 
 ("Mathematical Functions","Base","besseli","besseli(nu, x)
+
 
    Modified Bessel function of the first kind of order \"nu\",
    I_\\nu(x).
@@ -2657,12 +3061,14 @@
 
 ("Mathematical Functions","Base","besselk","besselk(nu, x)
 
+
    Modified Bessel function of the second kind of order \"nu\",
    K_\\nu(x).
 
 "),
 
 ("Mathematical Functions","Base","beta","beta(x, y)
+
 
    Euler integral of the first kind \\operatorname{B}(x,y) =
    \\Gamma(x)\\Gamma(y)/\\Gamma(x+y).
@@ -2671,12 +3077,14 @@
 
 ("Mathematical Functions","Base","lbeta","lbeta(x, y)
 
+
    Natural logarithm of the beta function
    \\log(\\operatorname{B}(x,y)).
 
 "),
 
 ("Mathematical Functions","Base","eta","eta(x)
+
 
    Dirichlet eta function \\eta(s) =
    \\sum^\\infty_{n=1}(-)^{n-1}/n^{s}.
@@ -2685,11 +3093,13 @@
 
 ("Mathematical Functions","Base","zeta","zeta(x)
 
+
    Riemann zeta function \\zeta(s).
 
 "),
 
 ("Mathematical Functions","Base","bitmix","bitmix(x, y)
+
 
    Hash two integers into a single integer. Useful for constructing
    hash functions.
@@ -2698,11 +3108,13 @@
 
 ("Mathematical Functions","Base","ndigits","ndigits(n, b)
 
+
    Compute the number of digits in number \"n\" written in base \"b\".
 
 "),
 
 ("Data Formats","Base","bin","bin(n[, pad])
+
 
    Convert an integer to a binary string, optionally specifying a
    number of digits to pad to.
@@ -2711,12 +3123,14 @@
 
 ("Data Formats","Base","hex","hex(n[, pad])
 
+
    Convert an integer to a hexadecimal string, optionally specifying a
    number of digits to pad to.
 
 "),
 
 ("Data Formats","Base","dec","dec(n[, pad])
+
 
    Convert an integer to a decimal string, optionally specifying a
    number of digits to pad to.
@@ -2725,12 +3139,14 @@
 
 ("Data Formats","Base","oct","oct(n[, pad])
 
+
    Convert an integer to an octal string, optionally specifying a
    number of digits to pad to.
 
 "),
 
 ("Data Formats","Base","base","base(base, n[, pad])
+
 
    Convert an integer to a string in the given base, optionally
    specifying a number of digits to pad to. The base can be specified
@@ -2741,11 +3157,13 @@
 
 ("Data Formats","Base","bits","bits(n)
 
+
    A string giving the literal bit representation of a number.
 
 "),
 
 ("Data Formats","Base","parseint","parseint([type], str[, base])
+
 
    Parse a string as an integer in the given base (default 10),
    yielding a number of the specified type (default \"Int\").
@@ -2754,6 +3172,7 @@
 
 ("Data Formats","Base","parsefloat","parsefloat([type], str)
 
+
    Parse a string as a decimal floating point number, yielding a
    number of the specified type.
 
@@ -2761,11 +3180,13 @@
 
 ("Data Formats","Base","bool","bool(x)
 
+
    Convert a number or numeric array to boolean
 
 "),
 
 ("Data Formats","Base","int","int(x)
+
 
    Convert a number or array to the default integer type on your
    platform. Alternatively, \"x\" can be a string, which is parsed as
@@ -2775,6 +3196,7 @@
 
 ("Data Formats","Base","uint","uint(x)
 
+
    Convert a number or array to the default unsigned integer type on
    your platform. Alternatively, \"x\" can be a string, which is
    parsed as an unsigned integer.
@@ -2782,6 +3204,7 @@
 "),
 
 ("Data Formats","Base","integer","integer(x)
+
 
    Convert a number or array to integer type. If \"x\" is already of
    integer type it is unchanged, otherwise it converts it to the
@@ -2791,11 +3214,13 @@
 
 ("Data Formats","Base","signed","signed(x)
 
+
    Convert a number to a signed integer
 
 "),
 
 ("Data Formats","Base","unsigned","unsigned(x)
+
 
    Convert a number to an unsigned integer
 
@@ -2803,11 +3228,13 @@
 
 ("Data Formats","Base","int8","int8(x)
 
+
    Convert a number or array to \"Int8\" data type
 
 "),
 
 ("Data Formats","Base","int16","int16(x)
+
 
    Convert a number or array to \"Int16\" data type
 
@@ -2815,11 +3242,13 @@
 
 ("Data Formats","Base","int32","int32(x)
 
+
    Convert a number or array to \"Int32\" data type
 
 "),
 
 ("Data Formats","Base","int64","int64(x)
+
 
    Convert a number or array to \"Int64\" data type
 
@@ -2827,11 +3256,13 @@
 
 ("Data Formats","Base","int128","int128(x)
 
+
    Convert a number or array to \"Int128\" data type
 
 "),
 
 ("Data Formats","Base","uint8","uint8(x)
+
 
    Convert a number or array to \"Uint8\" data type
 
@@ -2839,11 +3270,13 @@
 
 ("Data Formats","Base","uint16","uint16(x)
 
+
    Convert a number or array to \"Uint16\" data type
 
 "),
 
 ("Data Formats","Base","uint32","uint32(x)
+
 
    Convert a number or array to \"Uint32\" data type
 
@@ -2851,11 +3284,13 @@
 
 ("Data Formats","Base","uint64","uint64(x)
 
+
    Convert a number or array to \"Uint64\" data type
 
 "),
 
 ("Data Formats","Base","uint128","uint128(x)
+
 
    Convert a number or array to \"Uint128\" data type
 
@@ -2863,17 +3298,20 @@
 
 ("Data Formats","Base","float32","float32(x)
 
+
    Convert a number or array to \"Float32\" data type
 
 "),
 
 ("Data Formats","Base","float64","float64(x)
 
+
    Convert a number or array to \"Float64\" data type
 
 "),
 
 ("Data Formats","Base","float","float(x)
+
 
    Convert a number, array, or string to a \"FloatingPoint\" data
    type. For numeric data, the smallest suitable \"FloatingPoint\"
@@ -2882,6 +3320,7 @@
 "),
 
 ("Data Formats","Base","significand","significand(x)
+
 
    Extract the significand(s) (a.k.a. mantissa), in binary
    representation, of a floating-point number or array.
@@ -2893,11 +3332,13 @@
 
 ("Data Formats","Base","exponent","exponent(x) -> Int
 
+
    Get the exponent of a normalized floating-point number.
 
 "),
 
 ("Data Formats","Base","isfloat64","isfloat64(x::Rational)
+
 
    Tests whether \"x\" or all its elements can be losslessly
    represented as a \"Float64\" data type
@@ -2906,11 +3347,13 @@
 
 ("Data Formats","Base","complex64","complex64(r, i)
 
+
    Convert to \"r+i*im\" represented as a \"Complex64\" data type
 
 "),
 
 ("Data Formats","Base","complex128","complex128(r, i)
+
 
    Convert to \"r+i*im\" represented as a \"Complex128\" data type
 
@@ -2918,11 +3361,13 @@
 
 ("Data Formats","Base","char","char(x)
 
+
    Convert a number or array to \"Char\" data type
 
 "),
 
 ("Data Formats","Base","complex","complex(r, i)
+
 
    Convert real numbers or arrays to complex
 
@@ -2930,11 +3375,13 @@
 
 ("Data Formats","Base","bswap","bswap(n)
 
+
    Byte-swap an integer
 
 "),
 
 ("Data Formats","Base","num2hex","num2hex(f)
+
 
    Get a hexadecimal string of the binary representation of a floating
    point number
@@ -2943,6 +3390,7 @@
 
 ("Data Formats","Base","hex2num","hex2num(str)
 
+
    Convert a hexadecimal string to the floating point number it
    represents
 
@@ -2950,12 +3398,15 @@
 
 ("Data Formats","Base","hex2bytes","hex2bytes(s::ASCIIString)
 
+
    Convert an arbitrarily long hexadecimal string to its binary
    representation. Returns an Array{Uint8, 1}, i.e. an array of bytes.
 
 "),
 
-("Data Formats","Base","bytes2hex","bytes2hex(bin_arr::Array{Uint8, 1})
+("Data Formats","Base","bytes2hex","bytes2hex(bin_arr::Array{Uint8,
+1})
+
 
    Convert an array of bytes to its hexadecimal representation. All
    characters are in lower-case. Returns an ASCIIString.
@@ -2963,6 +3414,7 @@
 "),
 
 ("Numbers","Base","one","one(x)
+
 
    Get the multiplicative identity element for the type of x (x can
    also specify the type itself). For matrices, returns an identity
@@ -2972,6 +3424,7 @@
 
 ("Numbers","Base","zero","zero(x)
 
+
    Get the additive identity element for the type of x (x can also
    specify the type itself).
 
@@ -2979,11 +3432,13 @@
 
 ("Numbers","Base","pi","pi
 
+
    The constant pi
 
 "),
 
 ("Numbers","Base","im","im
+
 
    The imaginary unit
 
@@ -2991,11 +3446,13 @@
 
 ("Numbers","Base","e","e
 
+
    The constant e
 
 "),
 
 ("Numbers","Base","Inf","Inf
+
 
    Positive infinity of type Float64
 
@@ -3003,11 +3460,13 @@
 
 ("Numbers","Base","Inf32","Inf32
 
+
    Positive infinity of type Float32
 
 "),
 
 ("Numbers","Base","NaN","NaN
+
 
    A not-a-number value of type Float64
 
@@ -3015,11 +3474,13 @@
 
 ("Numbers","Base","NaN32","NaN32
 
+
    A not-a-number value of type Float32
 
 "),
 
 ("Numbers","Base","isdenormal","isdenormal(f) -> Bool
+
 
    Test whether a floating point number is denormal
 
@@ -3027,11 +3488,13 @@
 
 ("Numbers","Base","isfinite","isfinite(f) -> Bool
 
+
    Test whether a number is finite
 
 "),
 
 ("Numbers","Base","isinf","isinf(f)
+
 
    Test whether a number is infinite
 
@@ -3039,11 +3502,13 @@
 
 ("Numbers","Base","isnan","isnan(f)
 
+
    Test whether a floating point number is not a number (NaN)
 
 "),
 
 ("Numbers","Base","inf","inf(f)
+
 
    Returns infinity in the same floating point type as \"f\" (or \"f\"
    can by the type itself)
@@ -3052,6 +3517,7 @@
 
 ("Numbers","Base","nan","nan(f)
 
+
    Returns NaN in the same floating point type as \"f\" (or \"f\" can
    by the type itself)
 
@@ -3059,17 +3525,20 @@
 
 ("Numbers","Base","nextfloat","nextfloat(f)
 
+
    Get the next floating point number in lexicographic order
 
 "),
 
 ("Numbers","Base","prevfloat","prevfloat(f) -> Float
 
+
    Get the previous floating point number in lexicographic order
 
 "),
 
 ("Numbers","Base","isinteger","isinteger(x)
+
 
    Test whether \"x\" or all its elements are numerically equal to
    some integer
@@ -3078,12 +3547,14 @@
 
 ("Numbers","Base","isreal","isreal(x)
 
+
    Test whether \"x\" or all its elements are numerically equal to
    some real number
 
 "),
 
 ("Numbers","Base","BigInt","BigInt(x)
+
 
    Create an arbitrary precision integer. \"x\" may be an \"Int\" (or
    anything that can be converted to an \"Int\") or a \"String\". The
@@ -3094,6 +3565,7 @@
 
 ("Numbers","Base","BigFloat","BigFloat(x)
 
+
    Create an arbitrary precision floating point number. \"x\" may be
    an \"Integer\", a \"Float64\", a \"String\" or a \"BigInt\". The
    usual mathematical operators are defined for this type, and results
@@ -3103,6 +3575,7 @@
 
 ("Numbers","Base","count_ones","count_ones(x::Integer) -> Integer
 
+
    Number of ones in the binary representation of \"x\".
 
    **Example**: \"count_ones(7) -> 3\"
@@ -3111,13 +3584,16 @@
 
 ("Numbers","Base","count_zeros","count_zeros(x::Integer) -> Integer
 
+
    Number of zeros in the binary representation of \"x\".
 
    **Example**: \"count_zeros(int32(2 ^ 16 - 1)) -> 16\"
 
 "),
 
-("Numbers","Base","leading_zeros","leading_zeros(x::Integer) -> Integer
+("Numbers","Base","leading_zeros","leading_zeros(x::Integer) ->
+Integer
+
 
    Number of zeros leading the binary representation of \"x\".
 
@@ -3127,13 +3603,16 @@
 
 ("Numbers","Base","leading_ones","leading_ones(x::Integer) -> Integer
 
+
    Number of ones leading the binary representation of \"x\".
 
    **Example**: \"leading_ones(int32(2 ^ 32 - 2)) -> 31\"
 
 "),
 
-("Numbers","Base","trailing_zeros","trailing_zeros(x::Integer) -> Integer
+("Numbers","Base","trailing_zeros","trailing_zeros(x::Integer) ->
+Integer
+
 
    Number of zeros trailing the binary representation of \"x\".
 
@@ -3141,7 +3620,9 @@
 
 "),
 
-("Numbers","Base","trailing_ones","trailing_ones(x::Integer) -> Integer
+("Numbers","Base","trailing_ones","trailing_ones(x::Integer) ->
+Integer
+
 
    Number of ones trailing the binary representation of \"x\".
 
@@ -3151,6 +3632,7 @@
 
 ("Numbers","Base","isprime","isprime(x::Integer) -> Bool
 
+
    Returns \"true\" if \"x\" is prime, and \"false\" otherwise.
 
    **Example**: \"isprime(3) -> true\"
@@ -3158,6 +3640,7 @@
 "),
 
 ("Numbers","Base","isodd","isodd(x::Integer) -> Bool
+
 
    Returns \"true\" if \"x\" is odd (that is, not divisible by 2), and
    \"false\" otherwise.
@@ -3168,6 +3651,7 @@
 
 ("Numbers","Base","iseven","iseven(x::Integer) -> Bool
 
+
    Returns \"true\" is \"x\" is even (that is, divisible by 2), and
    \"false\" otherwise.
 
@@ -3176,6 +3660,7 @@
 "),
 
 ("Random Numbers","Base","srand","srand([rng], seed)
+
 
    Seed the RNG with a \"seed\", which may be an unsigned integer or a
    vector of unsigned integers. \"seed\" can even be a filename, in
@@ -3186,6 +3671,7 @@
 
 ("Random Numbers","Base","MersenneTwister","MersenneTwister([seed])
 
+
    Create a \"MersenneTwister\" RNG object. Different RNG objects can
    have their own seeds, which may be useful for generating different
    streams of random numbers.
@@ -3194,11 +3680,13 @@
 
 ("Random Numbers","Base","rand","rand()
 
+
    Generate a \"Float64\" random number uniformly in [0,1)
 
 "),
 
 ("Random Numbers","Base","rand!","rand!([rng], A)
+
 
    Populate the array A with random number generated from the
    specified RNG.
@@ -3206,6 +3694,7 @@
 "),
 
 ("Random Numbers","Base","rand","rand(rng::AbstractRNG[, dims...])
+
 
    Generate a random \"Float64\" number or array of the size specified
    by dims, using the specified RNG object. Currently,
@@ -3216,11 +3705,14 @@
 
 ("Random Numbers","Base","rand","rand(dims or [dims...])
 
+
    Generate a random \"Float64\" array of the size specified by dims
 
 "),
 
-("Random Numbers","Base","rand","rand(Int32|Uint32|Int64|Uint64|Int128|Uint128[, dims...])
+("Random Numbers","Base","rand","rand(Int32|Uint32|Int64|Uint64|Int12
+8|Uint128[, dims...])
+
 
    Generate a random integer of the given type. Optionally, generate
    an array of random integers of the given type by specifying dims.
@@ -3228,6 +3720,7 @@
 "),
 
 ("Random Numbers","Base","rand","rand(r[, dims...])
+
 
    Generate a random integer from the inclusive interval specified by
    \"Range1 r\" (for example, \"1:n\"). Optionally, generate a random
@@ -3237,6 +3730,7 @@
 
 ("Random Numbers","Base","randbool","randbool([dims...])
 
+
    Generate a random boolean value. Optionally, generate an array of
    random boolean values.
 
@@ -3244,12 +3738,14 @@
 
 ("Random Numbers","Base","randbool!","randbool!(A)
 
+
    Fill an array with random boolean values. A may be an \"Array\" or
    a \"BitArray\".
 
 "),
 
 ("Random Numbers","Base","randn","randn(dims or [dims...])
+
 
    Generate a normally-distributed random number with mean 0 and
    standard deviation 1. Optionally generate an array of normally-
@@ -3259,11 +3755,13 @@
 
 ("Arrays","Base","ndims","ndims(A) -> Integer
 
+
    Returns the number of dimensions of A
 
 "),
 
 ("Arrays","Base","size","size(A)
+
 
    Returns a tuple containing the dimensions of A
 
@@ -3271,17 +3769,20 @@
 
 ("Arrays","Base","eltype","eltype(A)
 
+
    Returns the type of the elements contained in A
 
 "),
 
 ("Arrays","Base","iseltype","iseltype(A, T)
 
+
    Tests whether A or its elements are of type T
 
 "),
 
 ("Arrays","Base","length","length(A) -> Integer
+
 
    Returns the number of elements in A (note that this differs from
    MATLAB where \"length(A)\" is the largest dimension of \"A\")
@@ -3290,17 +3791,20 @@
 
 ("Arrays","Base","nnz","nnz(A)
 
+
    Counts the number of nonzero values in array A (dense or sparse)
 
 "),
 
 ("Arrays","Base","conj!","conj!(A)
 
+
    Convert an array to its complex conjugate in-place
 
 "),
 
 ("Arrays","Base","stride","stride(A, k)
+
 
    Returns the distance in memory (in number of elements) between
    adjacent elements in dimension k
@@ -3309,11 +3813,13 @@
 
 ("Arrays","Base","strides","strides(A)
 
+
    Returns a tuple of the memory strides in each dimension
 
 "),
 
 ("Arrays","Base","ind2sub","ind2sub(dims, index) -> subscripts
+
 
    Returns a tuple of subscripts into an array with dimensions
    \"dims\", corresponding to the linear index \"index\"
@@ -3325,6 +3831,7 @@
 
 ("Arrays","Base","sub2ind","sub2ind(dims, i, j, k...) -> index
 
+
    The inverse of \"ind2sub\", returns the linear index corresponding
    to the provided subscripts
 
@@ -3332,12 +3839,14 @@
 
 ("Arrays","Base","Array","Array(type, dims)
 
+
    Construct an uninitialized dense array. \"dims\" may be a tuple or
    a series of integer arguments.
 
 "),
 
 ("Arrays","Base","getindex","getindex(type[, elements...])
+
 
    Construct a 1-d array of the specified type. This is usually called
    with the syntax \"Type[]\". Element values can be specified using
@@ -3347,6 +3856,7 @@
 
 ("Arrays","Base","cell","cell(dims)
 
+
    Construct an uninitialized cell array (heterogeneous array).
    \"dims\" can be either a tuple or a series of integer arguments.
 
@@ -3354,11 +3864,13 @@
 
 ("Arrays","Base","zeros","zeros(type, dims)
 
+
    Create an array of all zeros of specified type
 
 "),
 
 ("Arrays","Base","ones","ones(type, dims)
+
 
    Create an array of all ones of specified type
 
@@ -3366,11 +3878,13 @@
 
 ("Arrays","Base","trues","trues(dims)
 
+
    Create a Bool array with all values set to true
 
 "),
 
 ("Arrays","Base","falses","falses(dims)
+
 
    Create a Bool array with all values set to false
 
@@ -3378,17 +3892,20 @@
 
 ("Arrays","Base","fill","fill(v, dims)
 
+
    Create an array filled with \"v\"
 
 "),
 
 ("Arrays","Base","fill!","fill!(A, x)
 
+
    Fill array \"A\" with value \"x\"
 
 "),
 
 ("Arrays","Base","reshape","reshape(A, dims)
+
 
    Create an array with the same data as the given array, but with
    different dimensions. An implementation for a particular type of
@@ -3397,6 +3914,7 @@
 "),
 
 ("Arrays","Base","similar","similar(array, element_type, dims)
+
 
    Create an uninitialized array of the same type as the given array,
    but with the specified element type and dimensions. The second and
@@ -3407,6 +3925,7 @@
 
 ("Arrays","Base","reinterpret","reinterpret(type, A)
 
+
    Construct an array with the same binary data as the given array,
    but with the specified element type
 
@@ -3414,17 +3933,20 @@
 
 ("Arrays","Base","eye","eye(n)
 
+
    n-by-n identity matrix
 
 "),
 
 ("Arrays","Base","eye","eye(m, n)
 
+
    m-by-n identity matrix
 
 "),
 
 ("Arrays","Base","linspace","linspace(start, stop, n)
+
 
    Construct a vector of \"n\" linearly-spaced elements from \"start\"
    to \"stop\".
@@ -3433,34 +3955,63 @@
 
 ("Arrays","Base","logspace","logspace(start, stop, n)
 
+
    Construct a vector of \"n\" logarithmically-spaced numbers from
    \"10^start\" to \"10^stop\".
 
 "),
 
-("Arrays","Base","bsxfun","bsxfun(fn, A, B[, C...])
+("Arrays","Base","broadcast","broadcast(f, As...)
 
-   Apply binary function \"fn\" to two or more arrays, with singleton
-   dimensions expanded.
 
-"),
-
-("Arrays","Base","getindex","getindex(A, ind)
-
-   Returns a subset of array \"A\" as specified by \"ind\", which may
-   be an \"Int\", a \"Range\", or a \"Vector\".
+   Broadcasts the arrays \"As\" to a common size by expanding
+   singleton dimensions, and returns an array of the results
+   \"f(as...)\" for each position.
 
 "),
 
-("Arrays","Base","sub","sub(A, ind)
+("Arrays","Base","broadcast!","broadcast!(f, dest, As...)
 
-   Returns a SubArray, which stores the input \"A\" and \"ind\" rather
-   than computing the result immediately. Calling \"getindex\" on a
-   SubArray computes the indices on the fly.
+
+   Like \"broadcast\", but store the result in the \"dest\" array.
+
+"),
+
+("Arrays","Base","broadcast_function","broadcast_function(f)
+
+
+   Returns a function \"broadcast_f\" such that
+   \"broadcast_function(f)(As...) === broadcast(f, As...)\". Most
+   useful in the form \"const broadcast_f = broadcast_function(f)\".
+
+"),
+
+("Arrays","Base","broadcast!_function","broadcast!_function(f)
+
+
+   Like \"broadcast_function\", but for \"broadcast!\".
+
+"),
+
+("Arrays","Base","getindex","getindex(A, inds...)
+
+
+   Returns a subset of array \"A\" as specified by \"inds\", where
+   each \"ind\" may be an \"Int\", a \"Range\", or a \"Vector\".
+
+"),
+
+("Arrays","Base","sub","sub(A, inds...)
+
+
+   Returns a SubArray, which stores the input \"A\" and \"inds\"
+   rather than computing the result immediately. Calling \"getindex\"
+   on a SubArray computes the indices on the fly.
 
 "),
 
 ("Arrays","Base","slicedim","slicedim(A, d, i)
+
 
    Return all the data of \"A\" where the index for dimension \"d\"
    equals \"i\". Equivalent to \"A[:,:,...,i,:,:,...]\" where \"i\" is
@@ -3468,14 +4019,35 @@
 
 "),
 
-("Arrays","Base","setindex!","setindex!(A, X, ind)
+("Arrays","Base","setindex!","setindex!(A, X, inds...)
+
 
    Store values from array \"X\" within some subset of \"A\" as
-   specified by \"ind\".
+   specified by \"inds\".
+
+"),
+
+("Arrays","Base","broadcast_getindex","broadcast_getindex(A, inds...)
+
+
+   Broadcasts the \"inds\" arrays to a common size like \"broadcast\",
+   and returns an array of the results \"A[ks...]\", where \"ks\" goes
+   over the positions in the broadcast.
+
+"),
+
+("Arrays","Base","broadcast_setindex!","broadcast_setindex!(A, X,
+inds...)
+
+
+   Broadcasts the \"X\" and \"inds\" arrays to a common size and
+   stores the value from each position in \"X\" at the indices given
+   by the same positions in \"inds\".
 
 "),
 
 ("Arrays","Base","cat","cat(dim, A...)
+
 
    Concatenate the input arrays along the specified dimension
 
@@ -3483,17 +4055,20 @@
 
 ("Arrays","Base","vcat","vcat(A...)
 
+
    Concatenate along dimension 1
 
 "),
 
 ("Arrays","Base","hcat","hcat(A...)
 
+
    Concatenate along dimension 2
 
 "),
 
 ("Arrays","Base","hvcat","hvcat(rows::(Int...), values...)
+
 
    Horizontal and vertical concatenation in one call. This function is
    called for block matrix syntax. The first argument specifies the
@@ -3504,11 +4079,13 @@
 
 ("Arrays","Base","flipdim","flipdim(A, d)
 
+
    Reverse \"A\" in dimension \"d\".
 
 "),
 
 ("Arrays","Base","flipud","flipud(A)
+
 
    Equivalent to \"flipdim(A,1)\".
 
@@ -3516,11 +4093,13 @@
 
 ("Arrays","Base","fliplr","fliplr(A)
 
+
    Equivalent to \"flipdim(A,2)\".
 
 "),
 
 ("Arrays","Base","circshift","circshift(A, shifts)
+
 
    Circularly shift the data in an array. The second argument is a
    vector giving the amount to shift in each dimension.
@@ -3529,11 +4108,13 @@
 
 ("Arrays","Base","find","find(A)
 
+
    Return a vector of the linear indexes of the non-zeros in \"A\".
 
 "),
 
 ("Arrays","Base","findn","findn(A)
+
 
    Return a vector of indexes for each dimension giving the locations
    of the non-zeros in \"A\".
@@ -3542,11 +4123,13 @@
 
 ("Arrays","Base","nonzeros","nonzeros(A)
 
+
    Return a vector of the non-zero values in array \"A\".
 
 "),
 
 ("Arrays","Base","findfirst","findfirst(A)
+
 
    Return the index of the first non-zero value in \"A\".
 
@@ -3554,11 +4137,13 @@
 
 ("Arrays","Base","findfirst","findfirst(A, v)
 
+
    Return the index of the first element equal to \"v\" in \"A\".
 
 "),
 
 ("Arrays","Base","findfirst","findfirst(predicate, A)
+
 
    Return the index of the first element that satisfies the given
    predicate in \"A\".
@@ -3566,6 +4151,7 @@
 "),
 
 ("Arrays","Base","permutedims","permutedims(A, perm)
+
 
    Permute the dimensions of array \"A\". \"perm\" is a vector
    specifying a permutation of length \"ndims(A)\". This is a
@@ -3576,6 +4162,7 @@
 
 ("Arrays","Base","ipermutedims","ipermutedims(A, perm)
 
+
    Like \"permutedims()\", except the inverse of the given permutation
    is applied.
 
@@ -3583,11 +4170,13 @@
 
 ("Arrays","Base","squeeze","squeeze(A, dims)
 
+
    Remove the dimensions specified by \"dims\" from array \"A\"
 
 "),
 
 ("Arrays","Base","vec","vec(Array) -> Vector
+
 
    Vectorize an array using column-major convention.
 
@@ -3595,17 +4184,20 @@
 
 ("Arrays","Base","cumprod","cumprod(A[, dim])
 
+
    Cumulative product along a dimension.
 
 "),
 
 ("Arrays","Base","cumsum","cumsum(A[, dim])
 
+
    Cumulative sum along a dimension.
 
 "),
 
 ("Arrays","Base","cumsum_kbn","cumsum_kbn(A[, dim])
+
 
    Cumulative sum along a dimension, using the Kahan-Babuska-Neumaier
    compensated summation algorithm for additional accuracy.
@@ -3614,11 +4206,13 @@
 
 ("Arrays","Base","cummin","cummin(A[, dim])
 
+
    Cumulative minimum along a dimension.
 
 "),
 
 ("Arrays","Base","cummax","cummax(A[, dim])
+
 
    Cumulative maximum along a dimension.
 
@@ -3626,11 +4220,13 @@
 
 ("Arrays","Base","diff","diff(A[, dim])
 
+
    Finite difference operator of matrix or vector.
 
 "),
 
 ("Arrays","Base","rot180","rot180(A)
+
 
    Rotate matrix \"A\" 180 degrees.
 
@@ -3638,17 +4234,20 @@
 
 ("Arrays","Base","rotl90","rotl90(A)
 
+
    Rotate matrix \"A\" left 90 degrees.
 
 "),
 
 ("Arrays","Base","rotr90","rotr90(A)
 
+
    Rotate matrix \"A\" right 90 degrees.
 
 "),
 
 ("Arrays","Base","reducedim","reducedim(f, A, dims, initial)
+
 
    Reduce 2-argument function \"f\" along dimensions of \"A\".
    \"dims\" is a vector specifying the dimensions to reduce, and
@@ -3657,6 +4256,7 @@
 "),
 
 ("Arrays","Base","mapslices","mapslices(f, A, dims)
+
 
    Transform the given dimensions of array \"A\" using function \"f\".
    \"f\" is called on each slice of \"A\" of the form
@@ -3670,6 +4270,7 @@
 
 ("Arrays","Base","sum_kbn","sum_kbn(A)
 
+
    Returns the sum of all array elements, using the Kahan-Babuska-
    Neumaier compensated summation algorithm for additional accuracy.
 
@@ -3677,11 +4278,13 @@
 
 ("Combinatorics","Base","nthperm","nthperm(v, k)
 
+
    Compute the kth lexicographic permutation of a vector.
 
 "),
 
 ("Combinatorics","Base","nthperm!","nthperm!(v, k)
+
 
    In-place version of \"nthperm()\".
 
@@ -3689,11 +4292,13 @@
 
 ("Combinatorics","Base","randperm","randperm(n)
 
+
    Construct a random permutation of the given length.
 
 "),
 
 ("Combinatorics","Base","invperm","invperm(v)
+
 
    Return the inverse permutation of v.
 
@@ -3701,11 +4306,13 @@
 
 ("Combinatorics","Base","isperm","isperm(v) -> Bool
 
+
    Returns true if v is a valid permutation.
 
 "),
 
 ("Combinatorics","Base","permute!","permute!(v, p)
+
 
    Permute vector \"v\" in-place, according to permutation \"p\".  No
    checking is done to verify that \"p\" is a permutation.
@@ -3717,11 +4324,13 @@
 
 ("Combinatorics","Base","ipermute!","ipermute!(v, p)
 
+
    Like permute!, but the inverse of the given permutation is applied.
 
 "),
 
 ("Combinatorics","Base","randcycle","randcycle(n)
+
 
    Construct a random cyclic permutation of the given length.
 
@@ -3729,11 +4338,13 @@
 
 ("Combinatorics","Base","shuffle","shuffle(v)
 
+
    Randomly rearrange the elements of a vector.
 
 "),
 
 ("Combinatorics","Base","shuffle!","shuffle!(v)
+
 
    In-place version of \"shuffle()\".
 
@@ -3741,17 +4352,20 @@
 
 ("Combinatorics","Base","reverse","reverse(v)
 
+
    Reverse vector \"v\".
 
 "),
 
 ("Combinatorics","Base","reverse!","reverse!(v) -> v
 
+
    In-place version of \"reverse()\".
 
 "),
 
 ("Combinatorics","Base","combinations","combinations(array, n)
+
 
    Generate all combinations of \"n\" elements from a given array.
    Because the number of combinations can be very large, this function
@@ -3761,6 +4375,7 @@
 "),
 
 ("Combinatorics","Base","integer_partitions","integer_partitions(n, m)
+
 
    Generate all arrays of \"m\" integers that sum to \"n\". Because
    the number of partitions can be very large, this function runs
@@ -3772,6 +4387,7 @@
 
 ("Combinatorics","Base","partitions","partitions(array)
 
+
    Generate all set partitions of the elements of an array,
    represented as arrays of arrays. Because the number of partitions
    can be very large, this function runs inside a Task to produce
@@ -3782,12 +4398,14 @@
 
 ("Statistics","Base","mean","mean(v[, region])
 
+
    Compute the mean of whole array \"v\", or optionally along the
    dimensions in \"region\".
 
 "),
 
 ("Statistics","Base","std","std(v[, region])
+
 
    Compute the sample standard deviation of a vector or array``v``,
    optionally along dimensions in \"region\". The algorithm returns an
@@ -3800,12 +4418,14 @@
 
 ("Statistics","Base","stdm","stdm(v, m)
 
+
    Compute the sample standard deviation of a vector \"v\" with known
    mean \"m\".
 
 "),
 
 ("Statistics","Base","var","var(v[, region])
+
 
    Compute the sample variance of a vector or array``v``, optionally
    along dimensions in \"region\". The algorithm will return an
@@ -3818,6 +4438,7 @@
 
 ("Statistics","Base","varm","varm(v, m)
 
+
    Compute the sample variance of a vector \"v\" with known mean
    \"m\".
 
@@ -3825,11 +4446,13 @@
 
 ("Statistics","Base","median","median(v)
 
+
    Compute the median of a vector \"v\".
 
 "),
 
 ("Statistics","Base","hist","hist(v[, n]) -> e, counts
+
 
    Compute the histogram of \"v\", optionally using approximately
    \"n\" bins. The return values are a range \"e\", which correspond
@@ -3840,6 +4463,7 @@
 
 ("Statistics","Base","hist","hist(v, e) -> e, counts
 
+
    Compute the histogram of \"v\" using a vector/range \"e\" as the
    edges for the bins. The result will be a vector of length
    \"length(e) - 1\", with the \"i``th element being ``sum(e[i] .< v
@@ -3849,6 +4473,7 @@
 
 ("Statistics","Base","histrange","histrange(v, n)
 
+
    Compute *nice* bin ranges for the edges of a histogram of \"v\",
    using approximately \"n\" bins. The resulting step sizes will be 1,
    2 or 5 multiplied by a power of 10.
@@ -3857,12 +4482,14 @@
 
 ("Statistics","Base","midpoints","midpoints(e)
 
+
    Compute the midpoints of the bins with edges \"e\". The result is a
    vector/range of length \"length(e) - 1\".
 
 "),
 
 ("Statistics","Base","quantile","quantile(v, p)
+
 
    Compute the quantiles of a vector \"v\" at a specified set of
    probability values \"p\".
@@ -3871,12 +4498,14 @@
 
 ("Statistics","Base","quantile","quantile(v)
 
+
    Compute the quantiles of a vector \"v\" at the probability values
    \"[.0, .2, .4, .6, .8, 1.0]\".
 
 "),
 
 ("Statistics","Base","cov","cov(v1[, v2])
+
 
    Compute the Pearson covariance between two vectors \"v1\" and
    \"v2\". If called with a single element \"v\", then computes
@@ -3886,6 +4515,7 @@
 
 ("Statistics","Base","cor","cor(v1[, v2])
 
+
    Compute the Pearson correlation between two vectors \"v1\" and
    \"v2\". If called with a single element \"v\", then computes
    correlation of columns of \"v\".
@@ -3893,6 +4523,7 @@
 "),
 
 ("Signal Processing","Base","fft","fft(A[, dims])
+
 
    Performs a multidimensional FFT of the array \"A\".  The optional
    \"dims\" argument specifies an iterable subset of dimensions (e.g.
@@ -3912,12 +4543,14 @@
 
 ("Signal Processing","Base","fft!","fft!(A[, dims])
 
+
    Same as \"fft()\", but operates in-place on \"A\", which must be an
    array of complex floating-point numbers.
 
 "),
 
 ("Signal Processing","Base","ifft","ifft(A[, dims])
+
 
    Multidimensional inverse FFT.
 
@@ -3932,11 +4565,13 @@
 
 ("Signal Processing","Base","ifft!","ifft!(A[, dims])
 
+
    Same as \"ifft()\", but operates in-place on \"A\".
 
 "),
 
 ("Signal Processing","Base","bfft","bfft(A[, dims])
+
 
    Similar to \"ifft()\", but computes an unnormalized inverse
    (backward) transform, which must be divided by the product of the
@@ -3949,11 +4584,14 @@
 
 ("Signal Processing","Base","bfft!","bfft!(A[, dims])
 
+
    Same as \"bfft()\", but operates in-place on \"A\".
 
 "),
 
-("Signal Processing","Base","plan_fft","plan_fft(A[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_fft","plan_fft(A[, dims[, flags[,
+timelimit]]])
+
 
    Pre-plan an optimized FFT along given dimensions (\"dims\") of
    arrays matching the shape and type of \"A\".  (The first two
@@ -3978,39 +4616,50 @@
 
 "),
 
-("Signal Processing","Base","plan_ifft","plan_ifft(A[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_ifft","plan_ifft(A[, dims[, flags[,
+timelimit]]])
+
 
    Same as \"plan_fft()\", but produces a plan that performs inverse
    transforms \"ifft()\".
 
 "),
 
-("Signal Processing","Base","plan_bfft","plan_bfft(A[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_bfft","plan_bfft(A[, dims[, flags[,
+timelimit]]])
+
 
    Same as \"plan_fft()\", but produces a plan that performs an
    unnormalized backwards transform \"bfft()\".
 
 "),
 
-("Signal Processing","Base","plan_fft!","plan_fft!(A[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_fft!","plan_fft!(A[, dims[, flags[,
+timelimit]]])
+
 
    Same as \"plan_fft()\", but operates in-place on \"A\".
 
 "),
 
-("Signal Processing","Base","plan_ifft!","plan_ifft!(A[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_ifft!","plan_ifft!(A[, dims[,
+flags[, timelimit]]])
+
 
    Same as \"plan_ifft()\", but operates in-place on \"A\".
 
 "),
 
-("Signal Processing","Base","plan_bfft!","plan_bfft!(A[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_bfft!","plan_bfft!(A[, dims[,
+flags[, timelimit]]])
+
 
    Same as \"plan_bfft()\", but operates in-place on \"A\".
 
 "),
 
 ("Signal Processing","Base","rfft","rfft(A[, dims])
+
 
    Multidimensional FFT of a real array A, exploiting the fact that
    the transform has conjugate symmetry in order to save roughly half
@@ -4028,6 +4677,7 @@
 
 ("Signal Processing","Base","irfft","irfft(A, d[, dims])
 
+
    Inverse of \"rfft()\": for a complex array \"A\", gives the
    corresponding real array whose FFT yields \"A\" in the first half.
    As for \"rfft()\", \"dims\" is an optional subset of dimensions to
@@ -4043,6 +4693,7 @@
 
 ("Signal Processing","Base","brfft","brfft(A, d[, dims])
 
+
    Similar to \"irfft()\" but computes an unnormalized inverse
    transform (similar to \"bfft()\"), which must be divided by the
    product of the sizes of the transformed dimensions (of the real
@@ -4050,7 +4701,9 @@
 
 "),
 
-("Signal Processing","Base","plan_rfft","plan_rfft(A[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_rfft","plan_rfft(A[, dims[, flags[,
+timelimit]]])
+
 
    Pre-plan an optimized real-input FFT, similar to \"plan_fft()\"
    except for \"rfft()\" instead of \"fft()\".  The first two
@@ -4059,7 +4712,9 @@
 
 "),
 
-("Signal Processing","Base","plan_irfft","plan_irfft(A, d[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_irfft","plan_irfft(A, d[, dims[,
+flags[, timelimit]]])
+
 
    Pre-plan an optimized inverse real-input FFT, similar to
    \"plan_rfft()\" except for \"irfft()\" and \"brfft()\",
@@ -4069,6 +4724,7 @@
 "),
 
 ("Signal Processing","Base","dct","dct(A[, dims])
+
 
    Performs a multidimensional type-II discrete cosine transform (DCT)
    of the array \"A\", using the unitary normalization of the DCT. The
@@ -4082,12 +4738,14 @@
 
 ("Signal Processing","Base","dct!","dct!(A[, dims])
 
+
    Same as \"dct!()\", except that it operates in-place on \"A\",
    which must be an array of real or complex floating-point values.
 
 "),
 
 ("Signal Processing","Base","idct","idct(A[, dims])
+
 
    Computes the multidimensional inverse discrete cosine transform
    (DCT) of the array \"A\" (technically, a type-III DCT with the
@@ -4102,11 +4760,14 @@
 
 ("Signal Processing","Base","idct!","idct!(A[, dims])
 
+
    Same as \"idct!()\", but operates in-place on \"A\".
 
 "),
 
-("Signal Processing","Base","plan_dct","plan_dct(A[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_dct","plan_dct(A[, dims[, flags[,
+timelimit]]])
+
 
    Pre-plan an optimized discrete cosine transform (DCT), similar to
    \"plan_fft()\" except producing a function that computes \"dct()\".
@@ -4114,13 +4775,17 @@
 
 "),
 
-("Signal Processing","Base","plan_dct!","plan_dct!(A[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_dct!","plan_dct!(A[, dims[, flags[,
+timelimit]]])
+
 
    Same as \"plan_dct()\", but operates in-place on \"A\".
 
 "),
 
-("Signal Processing","Base","plan_idct","plan_idct(A[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_idct","plan_idct(A[, dims[, flags[,
+timelimit]]])
+
 
    Pre-plan an optimized inverse discrete cosine transform (DCT),
    similar to \"plan_fft()\" except producing a function that computes
@@ -4129,13 +4794,16 @@
 
 "),
 
-("Signal Processing","Base","plan_idct!","plan_idct!(A[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","plan_idct!","plan_idct!(A[, dims[,
+flags[, timelimit]]])
+
 
    Same as \"plan_idct()\", but operates in-place on \"A\".
 
 "),
 
 ("Signal Processing","Base","FFTW","FFTW.r2r(A, kind[, dims])
+
 
    Performs a multidimensional real-input/real-output (r2r) transform
    of type \"kind\" of the array \"A\", as defined in the FFTW manual.
@@ -4163,13 +4831,16 @@
 
 ("Signal Processing","Base","FFTW","FFTW.r2r!(A, kind[, dims])
 
+
    \"FFTW.r2r!()\" is the same as \"FFTW.r2r()\", but operates in-
    place on \"A\", which must be an array of real or complex floating-
    point numbers.
 
 "),
 
-("Signal Processing","Base","FFTW","FFTW.plan_r2r(A, kind[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","FFTW","FFTW.plan_r2r(A, kind[, dims[,
+flags[, timelimit]]])
+
 
    Pre-plan an optimized r2r transform, similar to \"plan_fft()\"
    except that the transforms (and the first three arguments)
@@ -4177,7 +4848,9 @@
 
 "),
 
-("Signal Processing","Base","FFTW","FFTW.plan_r2r!(A, kind[, dims[, flags[, timelimit]]])
+("Signal Processing","Base","FFTW","FFTW.plan_r2r!(A, kind[, dims[,
+flags[, timelimit]]])
+
 
    Similar to \"plan_fft()\", but corresponds to \"FFTW.r2r!()\".
 
@@ -4185,11 +4858,13 @@
 
 ("Signal Processing","Base","fftshift","fftshift(x)
 
+
    Swap the first and second halves of each dimension of \"x\".
 
 "),
 
 ("Signal Processing","Base","fftshift","fftshift(x, dim)
+
 
    Swap the first and second halves of the given dimension of array
    \"x\".
@@ -4198,17 +4873,20 @@
 
 ("Signal Processing","Base","ifftshift","ifftshift(x[, dim])
 
+
    Undoes the effect of \"fftshift\".
 
 "),
 
 ("Signal Processing","Base","filt","filt(b, a, x)
 
+
    Apply filter described by vectors \"a\" and \"b\" to vector \"x\".
 
 "),
 
 ("Signal Processing","Base","deconv","deconv(b, a)
+
 
    Construct vector \"c\" such that \"b = conv(a,c) + r\". Equivalent
    to polynomial division.
@@ -4217,45 +4895,86 @@
 
 ("Signal Processing","Base","conv","conv(u, v)
 
+
    Convolution of two vectors. Uses FFT algorithm.
 
 "),
 
 ("Signal Processing","Base","xcorr","xcorr(u, v)
 
+
    Compute the cross-correlation of two vectors.
 
 "),
 
-("Numerical Integration","Base","quadgk","quadgk(f, a,b,c...; options)
+("Numerical Integration","Base","quadgk","quadgk(f, a, b, c...;
+reltol=sqrt(eps), abstol=0, maxevals=10^7, order=7)
+
 
    Numerically integrate the function \"f(x)\" from \"a\" to \"b\",
    and optionally over additional intervals \"b\" to \"c\" and so on.
-   Keyword options include a relative error tolerance \"reltol\" (defaults
-   to \"sqrt(eps)\"), an absolute error tolerance \"abstol\" (defaults
-   to 0), a maximum number of function evaluations \"maxevals\" (defaults
-   to \"10^7\"), and the \"order\" of the integration rule (defaults to 7).
+   Keyword options include a relative error tolerance \"reltol\"
+   (defaults to \"sqrt(eps)\" in the precision of the endpoints), an
+   absolute error tolerance \"abstol\" (defaults to 0), a maximum
+   number of function evaluations \"maxevals\" (defaults to \"10^7\"),
+   and the \"order\" of the integration rule (defaults to 7).
 
    Returns a pair \"(I,E)\" of the estimated integral \"I\" and an
-   estimated upper bound on the absolute error \"E\".
+   estimated upper bound on the absolute error \"E\".  If \"maxevals\"
+   is not exceeded then either \"E <= abstol\" or \"E <=
+   reltol*norm(I)\" will hold.  (Note that it is useful to specify a
+   positive \"abstol\" in cases where \"norm(I)\" may be zero.)
 
-   Complex-valued functions are supported, and the endpoints \"a\" etcetera
-   can also be complex (in which case the integral is performed over
-   straight-line segments in the complex plane).  If the endpoints
-   are \"BigFloat\", then the integration will be performed in that
-   precision as well (note: it is advisable to increase the integration
-   \"order\" in rough proportion to the precision, for smooth integrands).
+   The endpoints \"a\" etcetera can also be complex (in which case the
+   integral is performed over straight-line segments in the complex
+   plane).  If the endpoints are \"BigFloat\", then the integration
+   will be performed in \"BigFloat\" precision as well (note: it is
+   advisable to increase the integration \"order\" in rough proportion
+   to the precision, for smooth integrands).  More generally, the
+   precision is set by the precision of the integration endpoints
+   (promoted to floating-point types).
+
+   The integrand \"f(x)\" can return any numeric scalar, vector, or
+   matrix type, or in fact any type supporting \"+\", \"-\",
+   multiplication by real values, and a \"norm\" (i.e., any normed
+   vector space).
+
+   The algorithm is an adaptive Gauss-Kronrod integration technique:
+   the integral in each interval is estimated using a Kronrod rule
+   (\"2*order+1\" points) and the error is estimated using an embedded
+   Gauss rule (\"order\" points).   The interval with the largest
+   error is then subdivided into two intervals and the process is
+   repeated until the desired error tolerance is achieved.
+
+   These quadrature rules work best for smooth functions within each
+   interval, so if your function has a known discontinuity or other
+   singularity, it is best to subdivide your interval to put the
+   singularity at an endpoint.  For example, if \"f\" has a
+   discontinuity at \"x=0.7\" and you want to integrate from 0 to 1,
+   you should use \"quadgk(f, 0,0.7,1)\" to subdivide the interval at
+   the point of discontinuity.  The integrand is never evaluated
+   exactly at the endpoints of the intervals, so it is possible to
+   integrate functions that diverge at the endpoints as long as the
+   singularity is integrable (for example, a \"log(x)\" or
+   \"1/sqrt(x)\" singularity).
+
+   For real-valued endpoints, the starting and/or ending points may be
+   infinite.  (A coordinate transformation is performed internally to
+   map the infinite interval to a finite one.)
 
 "),
 
 ("Parallel Computing","Base","addprocs","addprocs(n)
+
 
    Add processes on the local machine. Can be used to take advantage
    of multiple cores.
 
 "),
 
-("Parallel Computing","Base","addprocs","addprocs({\"host1\", \"host2\", ...}; tunnel=false, dir=JULIA_HOME)
+("Parallel Computing","Base","addprocs","addprocs({\"host1\",
+\"host2\", ...}; tunnel=false, dir=JULIA_HOME)
+
 
    Add processes on remote machines via SSH. Requires julia to be
    installed in the same location on each node, or to be available via
@@ -4267,6 +4986,7 @@
 
 ("Parallel Computing","Base","addprocs_sge","addprocs_sge(n)
 
+
    Add processes via the Sun/Oracle Grid Engine batch queue, using
    \"qsub\".
 
@@ -4274,17 +4994,20 @@
 
 ("Parallel Computing","Base","nprocs","nprocs()
 
+
    Get the number of available processors.
 
 "),
 
 ("Parallel Computing","Base","myid","myid()
 
+
    Get the id of the current processor.
 
 "),
 
 ("Parallel Computing","Base","pmap","pmap(f, c)
+
 
    Transform collection \"c\" by applying \"f\" to each element in
    parallel. If \"nprocs() > 1\", the calling process will be
@@ -4293,7 +5016,9 @@
 
 "),
 
-("Parallel Computing","Base","remotecall","remotecall(id, func, args...)
+("Parallel Computing","Base","remotecall","remotecall(id, func,
+args...)
+
 
    Call a function asynchronously on the given arguments on the
    specified processor. Returns a \"RemoteRef\".
@@ -4302,6 +5027,7 @@
 
 ("Parallel Computing","Base","wait","wait(RemoteRef)
 
+
    Wait for a value to become available for the specified remote
    reference.
 
@@ -4309,23 +5035,29 @@
 
 ("Parallel Computing","Base","fetch","fetch(RemoteRef)
 
+
    Wait for and get the value of a remote reference.
 
 "),
 
-("Parallel Computing","Base","remotecall_wait","remotecall_wait(id, func, args...)
+("Parallel Computing","Base","remotecall_wait","remotecall_wait(id,
+func, args...)
+
 
    Perform \"wait(remotecall(...))\" in one message.
 
 "),
 
-("Parallel Computing","Base","remotecall_fetch","remotecall_fetch(id, func, args...)
+("Parallel Computing","Base","remotecall_fetch","remotecall_fetch(id,
+func, args...)
+
 
    Perform \"fetch(remotecall(...))\" in one message.
 
 "),
 
 ("Parallel Computing","Base","put","put(RemoteRef, value)
+
 
    Store a value to a remote reference. Implements \"shared queue of
    length 1\" semantics: if a value is already present, blocks until
@@ -4335,6 +5067,7 @@
 
 ("Parallel Computing","Base","take","take(RemoteRef)
 
+
    Fetch the value of a remote reference, removing it so that the
    reference is empty again.
 
@@ -4342,17 +5075,21 @@
 
 ("Parallel Computing","Base","RemoteRef","RemoteRef()
 
+
    Make an uninitialized remote reference on the local machine.
 
 "),
 
 ("Parallel Computing","Base","RemoteRef","RemoteRef(n)
 
+
    Make an uninitialized remote reference on processor \"n\".
 
 "),
 
-("Distributed Arrays","Base","DArray","DArray(init, dims[, procs, dist])
+("Distributed Arrays","Base","DArray","DArray(init, dims[, procs,
+dist])
+
 
    Construct a distributed array. \"init\" is a function that accepts
    a tuple of index ranges. This function should allocate a local
@@ -4371,12 +5108,14 @@
 
 ("Distributed Arrays","Base","dzeros","dzeros(dims, ...)
 
+
    Construct a distributed array of zeros. Trailing arguments are the
    same as those accepted by \"darray\".
 
 "),
 
 ("Distributed Arrays","Base","dones","dones(dims, ...)
+
 
    Construct a distributed array of ones. Trailing arguments are the
    same as those accepted by \"darray\".
@@ -4385,12 +5124,14 @@
 
 ("Distributed Arrays","Base","dfill","dfill(x, dims, ...)
 
+
    Construct a distributed array filled with value \"x\". Trailing
    arguments are the same as those accepted by \"darray\".
 
 "),
 
 ("Distributed Arrays","Base","drand","drand(dims, ...)
+
 
    Construct a distributed uniform random array. Trailing arguments
    are the same as those accepted by \"darray\".
@@ -4399,6 +5140,7 @@
 
 ("Distributed Arrays","Base","drandn","drandn(dims, ...)
 
+
    Construct a distributed normal random array. Trailing arguments are
    the same as those accepted by \"darray\".
 
@@ -4406,11 +5148,13 @@
 
 ("Distributed Arrays","Base","distribute","distribute(a)
 
+
    Convert a local array to distributed
 
 "),
 
 ("Distributed Arrays","Base","localize","localize(d)
+
 
    Get the local piece of a distributed array
 
@@ -4418,17 +5162,20 @@
 
 ("Distributed Arrays","Base","myindexes","myindexes(d)
 
+
    A tuple describing the indexes owned by the local processor
 
 "),
 
 ("Distributed Arrays","Base","procs","procs(d)
 
+
    Get the vector of processors storing pieces of \"d\"
 
 "),
 
 ("System","Base","run","run(command)
+
 
    Run a command object, constructed with backticks. Throws an error
    if anything goes wrong, including the process exiting with a non-
@@ -4438,6 +5185,7 @@
 
 ("System","Base","spawn","spawn(command)
 
+
    Run a command object asynchronously, returning the resulting
    \"Process\" object.
 
@@ -4445,12 +5193,14 @@
 
 ("System","Base","success","success(command)
 
+
    Run a command object, constructed with backticks, and tell whether
    it was successful (exited with a code of 0).
 
 "),
 
 ("System","Base","readsfrom","readsfrom(command)
+
 
    Starts running a command asynchronously, and returns a tuple
    (stream,process). The first value is a stream reading from the
@@ -4460,6 +5210,7 @@
 
 ("System","Base","writesto","writesto(command)
 
+
    Starts running a command asynchronously, and returns a tuple
    (stream,process). The first value is a stream writing to the
    process' standard input.
@@ -4467,6 +5218,7 @@
 "),
 
 ("System","Base","readandwrite","readandwrite(command)
+
 
    Starts running a command asynchronously, and returns a tuple
    (stdout,stdin,process) of the output stream and input stream of the
@@ -4476,6 +5228,7 @@
 
 ("System","Base",">",">()
 
+
    Redirect standard output of a process.
 
    **Example**: \"run(`ls` > \"out.log\")\"
@@ -4484,11 +5237,13 @@
 
 ("System","Base","<","<()
 
+
    Redirect standard input of a process.
 
 "),
 
 ("System","Base",">>",">>()
+
 
    Redirect standard output of a process, appending to the destination
    file.
@@ -4497,17 +5252,20 @@
 
 ("System","Base",".>",".>()
 
+
    Redirect the standard error stream of a process.
 
 "),
 
 ("System","Base","gethostname","gethostname() -> String
 
+
    Get the local machine's host name.
 
 "),
 
 ("System","Base","getipaddr","getipaddr() -> String
+
 
    Get the IP address of the local machine, as a string of the form
    \"x.x.x.x\".
@@ -4516,11 +5274,13 @@
 
 ("System","Base","pwd","pwd() -> String
 
+
    Get the current working directory.
 
 "),
 
 ("System","Base","cd","cd(dir::String)
+
 
    Set the current working directory. Returns the new current
    directory.
@@ -4529,12 +5289,14 @@
 
 ("System","Base","cd","cd(f[, \"dir\"])
 
+
    Temporarily changes the current working directory (HOME if not
    specified) and applies function f before returning.
 
 "),
 
 ("System","Base","mkdir","mkdir(path[, mode])
+
 
    Make a new directory with name \"path\" and permissions \"mode\".
    \"mode\" defaults to 0o777, modified by the current file creation
@@ -4544,6 +5306,7 @@
 
 ("System","Base","mkpath","mkpath(path[, mode])
 
+
    Create all directories in the given \"path\", with permissions
    \"mode\". \"mode\" defaults to 0o777, modified by the current file
    creation mask.
@@ -4552,17 +5315,20 @@
 
 ("System","Base","rmdir","rmdir(path)
 
+
    Remove the directory named \"path\".
 
 "),
 
 ("System","Base","getpid","getpid() -> Int32
 
+
    Get julia's process ID.
 
 "),
 
 ("System","Base","time","time([t::TmStruct])
+
 
    Get the system time in seconds since the epoch, with fairly high
    (typically, microsecond) resolution. When passed a \"TmStruct\",
@@ -4572,12 +5338,14 @@
 
 ("System","Base","time_ns","time_ns()
 
+
    Get the time in nanoseconds. The time corresponding to 0 is
    undefined, and wraps every 5.8 years.
 
 "),
 
 ("System","Base","strftime","strftime([format], time)
+
 
    Convert time, given as a number of seconds since the epoch or a
    \"TmStruct\", to a formatted string using the given format.
@@ -4586,6 +5354,7 @@
 "),
 
 ("System","Base","strptime","strptime([format], timestr)
+
 
    Parse a formatted time string into a \"TmStruct\" giving the
    seconds, minute, hour, date, etc. Supported formats are the same as
@@ -4600,6 +5369,7 @@
 
 ("System","Base","TmStruct","TmStruct([seconds])
 
+
    Convert a number of seconds since the epoch to broken-down format,
    with fields \"sec\", \"min\", \"hour\", \"mday\", \"month\",
    \"year\", \"wday\", \"yday\", and \"isdst\".
@@ -4608,6 +5378,7 @@
 
 ("System","Base","tic","tic()
 
+
    Set a timer to be read by the next call to \"toc()\" or \"toq()\".
    The macro call \"@time expr\" can also be used to time evaluation.
 
@@ -4615,11 +5386,13 @@
 
 ("System","Base","toc","toc()
 
+
    Print and return the time elapsed since the last \"tic()\".
 
 "),
 
 ("System","Base","toq","toq()
+
 
    Return, but do not print, the time elapsed since the last
    \"tic()\".
@@ -4628,6 +5401,7 @@
 
 ("System","Base","EnvHash","EnvHash() -> EnvHash
 
+
    A singleton of this type provides a hash table interface to
    environment variables.
 
@@ -4635,12 +5409,15 @@
 
 ("System","Base","ENV","ENV
 
+
    Reference to the singleton \"EnvHash\", providing a dictionary
    interface to system environment variables.
 
 "),
 
-("C Interface","Base","ccall","ccall((symbol, library) or fptr, RetType, (ArgType1, ...), ArgVar1, ...)
+("C Interface","Base","ccall","ccall((symbol, library) or fptr,
+RetType, (ArgType1, ...), ArgVar1, ...)
+
 
    Call function in C-exported shared library, specified by (function
    name, library) tuple (String or :Symbol). Alternatively, ccall may
@@ -4650,7 +5427,9 @@
 
 "),
 
-("C Interface","Base","cglobal","cglobal((symbol, library) or ptr[, Type=Void])
+("C Interface","Base","cglobal","cglobal((symbol, library) or ptr[,
+Type=Void])
+
 
    Obtain a pointer to a global variable in a C-exported shared
    library, specified exactly as in \"ccall\".  Returns a
@@ -4660,7 +5439,9 @@
 
 "),
 
-("C Interface","Base","cfunction","cfunction(fun::Function, RetType::Type, (ArgTypes...))
+("C Interface","Base","cfunction","cfunction(fun::Function,
+RetType::Type, (ArgTypes...))
+
 
    Generate C-callable function pointer from Julia function. Type
    annotation of the return value in the callback function is a must
@@ -4679,7 +5460,9 @@
 
 "),
 
-("C Interface","Base","dlopen","dlopen(libfile::String[, flags::Integer])
+("C Interface","Base","dlopen","dlopen(libfile::String[,
+flags::Integer])
+
 
    Load a shared library, returning an opaque handle.
 
@@ -4699,12 +5482,14 @@
 
 ("C Interface","Base","dlsym","dlsym(handle, sym)
 
+
    Look up a symbol from a shared library handle, return callable
    function pointer on success.
 
 "),
 
 ("C Interface","Base","dlsym_e","dlsym_e(handle, sym)
+
 
    Look up a symbol from a shared library handle, silently return NULL
    pointer on lookup failure.
@@ -4713,24 +5498,30 @@
 
 ("C Interface","Base","dlclose","dlclose(handle)
 
+
    Close shared library referenced by handle.
 
 "),
 
 ("C Interface","Base","c_free","c_free(addr::Ptr)
 
+
    Call free() from C standard library.
 
 "),
 
-("C Interface","Base","unsafe_load","unsafe_load(p::Ptr{T}, i::Integer)
+("C Interface","Base","unsafe_load","unsafe_load(p::Ptr{T},
+i::Integer)
+
 
    Dereference the pointer \"p[i]\" or \"*p\", returning a copy of
    type T.
 
 "),
 
-("C Interface","Base","unsafe_store!","unsafe_store!(p::Ptr{T}, x, i::Integer)
+("C Interface","Base","unsafe_store!","unsafe_store!(p::Ptr{T}, x,
+i::Integer)
+
 
    Assign to the pointer \"p[i] = x\" or \"*p = x\", making a copy of
    object x into the memory at p.
@@ -4738,6 +5529,7 @@
 "),
 
 ("C Interface","Base","pointer","pointer(a[, index])
+
 
    Get the native address of an array element. Be careful to ensure
    that a julia reference to \"a\" exists as long as this pointer will
@@ -4747,11 +5539,14 @@
 
 ("C Interface","Base","pointer","pointer(type, int)
 
+
    Convert an integer to a pointer of the specified element type.
 
 "),
 
-("C Interface","Base","pointer_to_array","pointer_to_array(p, dims[, own])
+("C Interface","Base","pointer_to_array","pointer_to_array(p, dims[,
+own])
+
 
    Wrap a native pointer as a Julia Array object. The pointer element
    type determines the array element type. \"own\" optionally
@@ -4763,11 +5558,13 @@
 
 ("Errors","Base","error","error(message::String)
 
+
    Raise an error with the given message
 
 "),
 
 ("Errors","Base","throw","throw(e)
+
 
    Throw an object as an exception
 
@@ -4775,17 +5572,20 @@
 
 ("Errors","Base","errno","errno()
 
+
    Get the value of the C library's \"errno\"
 
 "),
 
 ("Errors","Base","strerror","strerror(n)
 
+
    Convert a system call error code to a descriptive string
 
 "),
 
 ("Errors","Base","assert","assert(cond)
+
 
    Raise an error if \"cond\" is false. Also available as the macro
    \"@assert expr\".
@@ -4794,12 +5594,14 @@
 
 ("Tasks","Base","Task","Task(func)
 
+
    Create a \"Task\" (i.e. thread, or coroutine) to execute the given
    function. The task exits when this function returns.
 
 "),
 
 ("Tasks","Base","yieldto","yieldto(task, args...)
+
 
    Switch to the given task. The first time a task is switched to, the
    task's function is called with \"args\". On subsequent switches,
@@ -4809,11 +5611,13 @@
 
 ("Tasks","Base","current_task","current_task()
 
+
    Get the currently running Task.
 
 "),
 
 ("Tasks","Base","istaskdone","istaskdone(task)
+
 
    Tell whether a task has exited.
 
@@ -4821,11 +5625,13 @@
 
 ("Tasks","Base","consume","consume(task)
 
+
    Receive the next value passed to \"produce\" by the specified task.
 
 "),
 
 ("Tasks","Base","produce","produce(value)
+
 
    Send the given value to the last \"consume\" call, switching to the
    consumer task.
@@ -4834,6 +5640,7 @@
 
 ("Tasks","Base","yield","yield()
 
+
    For scheduled tasks, switch back to the scheduler to allow another
    scheduled task to run.
 
@@ -4841,19 +5648,24 @@
 
 ("Tasks","Base","task_local_storage","task_local_storage(symbol)
 
+
    Look up the value of a symbol in the current task's task-local
    storage.
 
 "),
 
-("Tasks","Base","task_local_storage","task_local_storage(symbol, value)
+("Tasks","Base","task_local_storage","task_local_storage(symbol,
+value)
+
 
    Assign a value to a symbol in the current task's task-local
    storage.
 
 "),
 
-("Base.Collections","Base.Collections","PriorityQueue{K,V}","PriorityQueue{K,V}([ord])
+("Base.Collections","Base.Collections","PriorityQueue{K,V}","Priority
+Queue{K,V}([ord])
+
 
    Construct a new PriorityQueue, with keys of type K and
    values/priorites of type V. If an order is not given, the priority
@@ -4863,6 +5675,7 @@
 
 ("Base.Collections","Base.Collections","enqueue!","enqueue!(pq, k, v)
 
+
    Insert the a key \"k\" into a priority queue \"pq\" with priority
    \"v\".
 
@@ -4870,11 +5683,13 @@
 
 ("Base.Collections","Base.Collections","dequeue!","dequeue!(pq)
 
+
    Remove and return the lowest priority key from a priority queue.
 
 "),
 
 ("Base.Collections","Base.Collections","heapify","heapify(v[, ord])
+
 
    Return a new vector in binary heap order, optionally using the
    given ordering.
@@ -4883,18 +5698,22 @@
 
 ("Base.Collections","Base.Collections","heapify!","heapify!(v[, ord])
 
+
    In-place heapify.
 
 "),
 
 ("Base.Collections","Base.Collections","isheap","isheap(v[, ord])
 
+
    Return true iff an array is heap-ordered according to the given
    order.
 
 "),
 
-("Base.Collections","Base.Collections","heappush!","heappush!(v[, ord])
+("Base.Collections","Base.Collections","heappush!","heappush!(v[,
+ord])
+
 
    Given a binary heap-ordered array, push a new element, preserving
    the heap property. For efficiency, this function does not check
@@ -4904,6 +5723,7 @@
 
 ("Base.Collections","Base.Collections","heappop!","heappop!(v[, ord])
 
+
    Given a binary heap-ordered array, remove and return the lowest
    ordered element. For efficiency, this function does not check that
    the array is indeed heap-ordered.
@@ -4912,6 +5732,7 @@
 
 ("Constants","Base","OS_NAME","OS_NAME
 
+
    A symbol representing the name of the operating system. Possible
    values are \":Linux\", \":Darwin\" (OS X), or \":Windows\".
 
@@ -4919,11 +5740,13 @@
 
 ("Constants","Base","ARGS","ARGS
 
+
    An array of the command line arguments passed to Julia, as strings.
 
 "),
 
 ("Constants","Base","C_NULL","C_NULL
+
 
    The C null pointer constant, sometimes used when calling external
    code.
@@ -4932,11 +5755,13 @@
 
 ("Constants","Base","CPU_CORES","CPU_CORES
 
+
    The number of CPU cores in the system.
 
 "),
 
 ("Constants","Base","WORD_SIZE","WORD_SIZE
+
 
    Standard word size on the current machine, in bits.
 
@@ -4944,11 +5769,13 @@
 
 ("Constants","Base","VERSION","VERSION
 
+
    An object describing which version of Julia is in use.
 
 "),
 
 ("Constants","Base","LOAD_PATH","LOAD_PATH
+
 
    An array of paths (as strings) where the \"require\" function looks
    for code.
@@ -4957,12 +5784,14 @@
 
 ("Filesystem","Base","isblockdev","isblockdev(path) -> Bool
 
+
    Returns \"true\" if \"path\" is a block device, \"false\"
    otherwise.
 
 "),
 
 ("Filesystem","Base","ischardev","ischardev(path) -> Bool
+
 
    Returns \"true\" if \"path\" is a character device, \"false\"
    otherwise.
@@ -4971,11 +5800,13 @@
 
 ("Filesystem","Base","isdir","isdir(path) -> Bool
 
+
    Returns \"true\" if \"path\" is a directory, \"false\" otherwise.
 
 "),
 
 ("Filesystem","Base","isexecutable","isexecutable(path) -> Bool
+
 
    Returns \"true\" if the current user has permission to execute
    \"path\", \"false\" otherwise.
@@ -4984,11 +5815,13 @@
 
 ("Filesystem","Base","isfifo","isfifo(path) -> Bool
 
+
    Returns \"true\" if \"path\" is a FIFO, \"false\" otherwise.
 
 "),
 
 ("Filesystem","Base","isfile","isfile(path) -> Bool
+
 
    Returns \"true\" if \"path\" is a regular file, \"false\"
    otherwise.
@@ -4997,12 +5830,14 @@
 
 ("Filesystem","Base","islink","islink(path) -> Bool
 
+
    Returns \"true\" if \"path\" is a symbolic link, \"false\"
    otherwise.
 
 "),
 
 ("Filesystem","Base","ispath","ispath(path) -> Bool
+
 
    Returns \"true\" if \"path\" is a valid filesystem path, \"false\"
    otherwise.
@@ -5011,12 +5846,14 @@
 
 ("Filesystem","Base","isreadable","isreadable(path) -> Bool
 
+
    Returns \"true\" if the current user has permission to read
    \"path\", \"false\" otherwise.
 
 "),
 
 ("Filesystem","Base","issetgid","issetgid(path) -> Bool
+
 
    Returns \"true\" if \"path\" has the setgid flag set, \"false\"
    otherwise.
@@ -5025,6 +5862,7 @@
 
 ("Filesystem","Base","issetuid","issetuid(path) -> Bool
 
+
    Returns \"true\" if \"path\" has the setuid flag set, \"false\"
    otherwise.
 
@@ -5032,11 +5870,13 @@
 
 ("Filesystem","Base","issocket","issocket(path) -> Bool
 
+
    Returns \"true\" if \"path\" is a socket, \"false\" otherwise.
 
 "),
 
 ("Filesystem","Base","issticky","issticky(path) -> Bool
+
 
    Returns \"true\" if \"path\" has the sticky bit set, \"false\"
    otherwise.
@@ -5045,6 +5885,7 @@
 
 ("Filesystem","Base","iswriteable","iswriteable(path) -> Bool
 
+
    Returns \"true\" if the current user has permission to write to
    \"path\", \"false\" otherwise.
 
@@ -5052,17 +5893,20 @@
 
 ("Filesystem","Base","dirname","dirname(path::String) -> String
 
+
    Get the directory part of a path.
 
 "),
 
 ("Filesystem","Base","basename","basename(path::String) -> String
 
+
    Get the file name part of a path.
 
 "),
 
 ("Filesystem","Base","isabspath","isabspath(path::String) -> Bool
+
 
    Determines whether a path is absolute (begins at the root
    directory).
@@ -5071,12 +5915,14 @@
 
 ("Filesystem","Base","joinpath","joinpath(parts...) -> String
 
+
    Join path components into a full path. If some argument is an
    absolute path, then prior components are dropped.
 
 "),
 
 ("Filesystem","Base","abspath","abspath(path::String) -> String
+
 
    Convert a path to an absolute path by adding the current directory
    if necessary.
@@ -5085,17 +5931,20 @@
 
 ("Filesystem","Base","tempname","tempname()
 
+
    Generate a unique temporary filename.
 
 "),
 
 ("Filesystem","Base","tempdir","tempdir()
 
+
    Obtain the path of a temporary directory.
 
 "),
 
 ("Filesystem","Base","mktemp","mktemp()
+
 
    Returns \"(path, io)\", where \"path\" is the path of a new
    temporary file and \"io\" is an open file object for this path.
@@ -5104,6 +5953,7 @@
 
 ("Filesystem","Base","mktempdir","mktempdir()
 
+
    Create a temporary directory and return its path.
 
 "),
@@ -5111,11 +5961,13 @@
 
 ("Linear Algebra","","*","*(A, B)
 
+
    Matrix multiplication
 
 "),
 
 ("Linear Algebra","","\\","\\(A, B)
+
 
    Matrix division using a polyalgorithm. For input matrices \"A\" and
    \"B\", the result \"X\" is such that \"A*X == B\" when \"A\" is
@@ -5133,11 +5985,13 @@
 
 ("Linear Algebra","","dot","dot(x, y)
 
+
    Compute the dot product
 
 "),
 
 ("Linear Algebra","","cross","cross(x, y)
+
 
    Compute the cross product of two 3-vectors
 
@@ -5145,17 +5999,20 @@
 
 ("Linear Algebra","","norm","norm(a)
 
+
    Compute the norm of a \"Vector\" or a \"Matrix\"
 
 "),
 
 ("Linear Algebra","","lu","lu(A) -> L, U, P
 
+
    Compute the LU factorization of \"A\", such that \"P*A = L*U\".
 
 "),
 
 ("Linear Algebra","","lufact","lufact(A) -> LU
+
 
    Compute the LU factorization of \"A\", returning an \"LU\" object
    for dense \"A\" or an \"UmfpackLU\" object for sparse \"A\". The
@@ -5173,6 +6030,7 @@
 
 ("Linear Algebra","","lufact!","lufact!(A) -> LU
 
+
    \"lufact!\" is the same as \"lufact\" but saves space by
    overwriting the input A, instead of creating a copy.  For sparse
    \"A\" the \"nzval\" field is not overwritten but the index fields,
@@ -5183,6 +6041,7 @@
 
 ("Linear Algebra","","chol","chol(A[, LU]) -> F
 
+
    Compute Cholesky factorization of a symmetric positive-definite
    matrix \"A\" and return the matrix \"F\". If \"LU\" is \"L\"
    (Lower), \"A = L*L'\". If \"LU\" is \"U\" (Upper), \"A = R'*R\".
@@ -5190,6 +6049,7 @@
 "),
 
 ("Linear Algebra","","cholfact","cholfact(A[, LU]) -> Cholesky
+
 
    Compute the Cholesky factorization of a dense symmetric positive-
    definite matrix \"A\" and return a \"Cholesky\" object. \"LU\" may
@@ -5203,6 +6063,7 @@
 "),
 
 ("Linear Algebra","","cholfact","cholfact(A[, ll]) -> CholmodFactor
+
 
    Compute the sparse Cholesky factorization of a sparse matrix \"A\".
    If \"A\" is Hermitian its Cholesky factor is determined.  If \"A\"
@@ -5221,12 +6082,15 @@
 
 ("Linear Algebra","","cholfact!","cholfact!(A[, LU]) -> Cholesky
 
+
    \"cholfact!\" is the same as \"cholfact\" but saves space by
    overwriting the input A, instead of creating a copy.
 
 "),
 
-("Linear Algebra","","cholpfact","cholpfact(A[, LU]) -> CholeskyPivoted
+("Linear Algebra","","cholpfact","cholpfact(A[, LU]) ->
+CholeskyPivoted
+
 
    Compute the pivoted Cholesky factorization of a symmetric positive
    semi-definite matrix \"A\" and return a \"CholeskyPivoted\" object.
@@ -5241,7 +6105,9 @@
 
 "),
 
-("Linear Algebra","","cholpfact!","cholpfact!(A[, LU]) -> CholeskyPivoted
+("Linear Algebra","","cholpfact!","cholpfact!(A[, LU]) ->
+CholeskyPivoted
+
 
    \"cholpfact!\" is the same as \"cholpfact\" but saves space by
    overwriting the input A, instead of creating a copy.
@@ -5250,12 +6116,14 @@
 
 ("Linear Algebra","","qr","qr(A[, thin]) -> Q, R
 
+
    Compute the QR factorization of \"A\" such that \"A = Q*R\". Also
    see \"qrfact\". The default is to compute a thin factorization.
 
 "),
 
 ("Linear Algebra","","qrfact","qrfact(A)
+
 
    Compute the QR factorization of \"A\" and return a \"QR\" object.
    The coomponents of the factorization \"F\" can be accessed as
@@ -5270,12 +6138,14 @@
 
 ("Linear Algebra","","qrfact!","qrfact!(A)
 
+
    \"qrfact!\" is the same as \"qrfact\" but saves space by
    overwriting the input A, instead of creating a copy.
 
 "),
 
 ("Linear Algebra","","qrp","qrp(A[, thin]) -> Q, R, P
+
 
    Compute the QR factorization of \"A\" with pivoting, such that
    \"A*P = Q*R\", Also see \"qrpfact\". The default is to compute a
@@ -5284,6 +6154,7 @@
 "),
 
 ("Linear Algebra","","qrpfact","qrpfact(A) -> QRPivoted
+
 
    Compute the QR factorization of \"A\" with pivoting and return a
    \"QRPivoted\" object. The components of the factorization \"F\" can
@@ -5301,12 +6172,14 @@
 
 ("Linear Algebra","","qrpfact!","qrpfact!(A) -> QRPivoted
 
+
    \"qrpfact!\" is the same as \"qrpfact\" but saves space by
    overwriting the input A, instead of creating a copy.
 
 "),
 
 ("Linear Algebra","","sqrtm","sqrtm(A)
+
 
    Compute the matrix square root of \"A\". If \"B = sqrtm(A)\", then
    \"B*B == A\" within roundoff error.
@@ -5315,11 +6188,13 @@
 
 ("Linear Algebra","","eig","eig(A) -> D, V
 
+
    Compute eigenvalues and eigenvectors of A
 
 "),
 
 ("Linear Algebra","","eigvals","eigvals(A)
+
 
    Returns the eigenvalues of \"A\".
 
@@ -5327,17 +6202,20 @@
 
 ("Linear Algebra","","eigmax","eigmax(A)
 
+
    Returns the largest eigenvalue of \"A\".
 
 "),
 
 ("Linear Algebra","","eigmin","eigmin(A)
 
+
    Returns the smallest eigenvalue of \"A\".
 
 "),
 
 ("Linear Algebra","","eigvecs","eigvecs(A[, eigvals])
+
 
    Returns the eigenvectors of \"A\".
 
@@ -5349,6 +6227,7 @@
 
 ("Linear Algebra","","eigfact","eigfact(A)
 
+
    Compute the eigenvalue decomposition of \"A\" and return an
    \"Eigen\" object. If \"F\" is the factorization object, the
    eigenvalues can be accessed with \"F[:values]\" and the
@@ -5359,12 +6238,14 @@
 
 ("Linear Algebra","","eigfact!","eigfact!(A)
 
+
    \"eigfact!\" is the same as \"eigfact\" but saves space by
    overwriting the input A, instead of creating a copy.
 
 "),
 
 ("Linear Algebra","","hessfact","hessfact(A)
+
 
    Compute the Hessenberg decomposition of \"A\" and return a
    \"Hessenberg\" object. If \"F\" is the factorization object, the
@@ -5377,12 +6258,14 @@
 
 ("Linear Algebra","","hessfact!","hessfact!(A)
 
+
    \"hessfact!\" is the same as \"hessfact\" but saves space by
    overwriting the input A, instead of creating a copy.
 
 "),
 
 ("Linear Algebra","","schurfact","schurfact(A) -> Schur
+
 
    Computes the Schur factorization of the matrix \"A\". The (quasi)
    triangular Schur factor can be obtained from the \"Schur\" object
@@ -5394,13 +6277,16 @@
 
 "),
 
-("Linear Algebra","","schur","schur(A) -> Schur[:T], Schur[:Z], Schur[:values]
+("Linear Algebra","","schur","schur(A) -> Schur[:T], Schur[:Z],
+Schur[:values]
+
 
    See schurfact
 
 "),
 
 ("Linear Algebra","","schurfact","schurfact(A, B) -> GeneralizedSchur
+
 
    Computes the Generalized Schur (or QZ) factorization of the
    matrices \"A\" and \"B\". The (quasi) triangular Schur factors can
@@ -5414,13 +6300,16 @@
 
 "),
 
-("Linear Algebra","","schur","schur(A, B) -> GeneralizedSchur[:S], GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
+("Linear Algebra","","schur","schur(A, B) -> GeneralizedSchur[:S],
+GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
+
 
    See schurfact
 
 "),
 
 ("Linear Algebra","","svdfact","svdfact(A[, thin]) -> SVD
+
 
    Compute the Singular Value Decomposition (SVD) of \"A\" and return
    an \"SVD\" object. \"U\", \"S\", \"V\" and \"Vt\" can be obtained
@@ -5434,6 +6323,7 @@
 
 ("Linear Algebra","","svdfact!","svdfact!(A[, thin]) -> SVD
 
+
    \"svdfact!\" is the same as \"svdfact\" but saves space by
    overwriting the input A, instead of creating a copy. If \"thin\" is
    \"true\", an economy mode decomposition is returned. The default is
@@ -5443,6 +6333,7 @@
 
 ("Linear Algebra","","svd","svd(A[, thin]) -> U, S, V
 
+
    Compute the SVD of A, returning \"U\", vector \"S\", and \"V\" such
    that \"A == U*diagm(S)*V'\". If \"thin\" is \"true\", an economy
    mode decomposition is returned.
@@ -5451,11 +6342,13 @@
 
 ("Linear Algebra","","svdvals","svdvals(A)
 
+
    Returns the singular values of \"A\".
 
 "),
 
 ("Linear Algebra","","svdvals!","svdvals!(A)
+
 
    Returns the singular values of \"A\", while saving space by
    overwriting the input.
@@ -5463,6 +6356,7 @@
 "),
 
 ("Linear Algebra","","svdfact","svdfact(A, B) -> GeneralizedSVD
+
 
    Compute the generalized SVD of \"A\" and \"B\", returning a
    \"GeneralizedSVD\" Factorization object, such that \"A =
@@ -5472,6 +6366,7 @@
 
 ("Linear Algebra","","svd","svd(A, B) -> U, V, Q, D1, D2, R0
 
+
    Compute the generalized SVD of \"A\" and \"B\", returning \"U\",
    \"V\", \"Q\", \"D1\", \"D2\", and \"R0\" such that \"A =
    U*D1*R0*Q'\" and \"B = V*D2*R0*Q'\".
@@ -5480,6 +6375,7 @@
 
 ("Linear Algebra","","svdvals","svdvals(A, B)
 
+
    Return only the singular values from the generalized singular value
    decomposition of \"A\" and \"B\".
 
@@ -5487,17 +6383,28 @@
 
 ("Linear Algebra","","triu","triu(M)
 
+
    Upper triangle of a matrix
 
 "),
 
 ("Linear Algebra","","tril","tril(M)
 
+
    Lower triangle of a matrix
 
 "),
 
+("Linear Algebra","","diagind","diagind(M[, k])
+
+
+   A \"Range\" giving the indices of the \"k\"-th diagonal of the
+   matrix \"M\".
+
+"),
+
 ("Linear Algebra","","diag","diag(M[, k])
+
 
    The \"k\"-th diagonal of a matrix, as a vector
 
@@ -5505,12 +6412,14 @@
 
 ("Linear Algebra","","diagm","diagm(v[, k])
 
+
    Construct a diagonal matrix and place \"v\" on the \"k\"-th
    diagonal
 
 "),
 
 ("Linear Algebra","","scale","scale(A, B)
+
 
    \"scale(A::Array, B::Number)\" scales all values in \"A\" with
    \"B\". Note: In cases where the array is big enough, *scale* can be
@@ -5528,11 +6437,13 @@
 
 ("Linear Algebra","","scale!","scale!(A, B)
 
+
    \"scale!(A,B)\" overwrites the input array with the scaled result.
 
 "),
 
 ("Linear Algebra","","Tridiagonal","Tridiagonal(dl, d, du)
+
 
    Construct a tridiagonal matrix from the lower diagonal, diagonal,
    and upper diagonal
@@ -5540,6 +6451,7 @@
 "),
 
 ("Linear Algebra","","Bidiagonal","Bidiagonal(dv, ev, isupper)
+
 
    Constructs an upper (isupper=true) or lower (isupper=false)
    bidiagonal matrix using the given diagonal (dv) and off-diagonal
@@ -5549,6 +6461,7 @@
 
 ("Linear Algebra","","Woodbury","Woodbury(A, U, C, V)
 
+
    Construct a matrix in a form suitable for applying the Woodbury
    matrix identity
 
@@ -5556,11 +6469,13 @@
 
 ("Linear Algebra","","rank","rank(M)
 
+
    Compute the rank of a matrix
 
 "),
 
 ("Linear Algebra","","norm","norm(A[, p])
+
 
    Compute the \"p\"-norm of a vector or a matrix. \"p\" is \"2\" by
    default, if not provided. If \"A\" is a vector, \"norm(A, p)\"
@@ -5573,11 +6488,13 @@
 
 ("Linear Algebra","","normfro","normfro(A)
 
+
    Compute the Frobenius norm of a matrix \"A\".
 
 "),
 
 ("Linear Algebra","","cond","cond(M[, p])
+
 
    Matrix condition number, computed using the p-norm. \"p\" is 2 by
    default, if not provided. Valid values for \"p\" are \"1\", \"2\",
@@ -5587,11 +6504,13 @@
 
 ("Linear Algebra","","trace","trace(M)
 
+
    Matrix trace
 
 "),
 
 ("Linear Algebra","","det","det(M)
+
 
    Matrix determinant
 
@@ -5599,11 +6518,13 @@
 
 ("Linear Algebra","","inv","inv(M)
 
+
    Matrix inverse
 
 "),
 
 ("Linear Algebra","","pinv","pinv(M)
+
 
    Moore-Penrose inverse
 
@@ -5611,11 +6532,13 @@
 
 ("Linear Algebra","","null","null(M)
 
+
    Basis for null space of M.
 
 "),
 
 ("Linear Algebra","","repmat","repmat(A, n, m)
+
 
    Construct a matrix by repeating the given matrix \"n\" times in
    dimension 1 and \"m\" times in dimension 2.
@@ -5624,11 +6547,13 @@
 
 ("Linear Algebra","","kron","kron(A, B)
 
+
    Kronecker tensor product of two vectors or two matrices.
 
 "),
 
 ("Linear Algebra","","linreg","linreg(x, y)
+
 
    Determine parameters \"[a, b]\" that minimize the squared error
    between \"y\" and \"a+b*x\".
@@ -5637,11 +6562,13 @@
 
 ("Linear Algebra","","linreg","linreg(x, y, w)
 
+
    Weighted least-squares linear regression.
 
 "),
 
 ("Linear Algebra","","expm","expm(A)
+
 
    Matrix exponential.
 
@@ -5649,11 +6576,13 @@
 
 ("Linear Algebra","","issym","issym(A)
 
+
    Test whether a matrix is symmetric.
 
 "),
 
 ("Linear Algebra","","isposdef","isposdef(A)
+
 
    Test whether a matrix is positive-definite.
 
@@ -5661,11 +6590,13 @@
 
 ("Linear Algebra","","istril","istril(A)
 
+
    Test whether a matrix is lower-triangular.
 
 "),
 
 ("Linear Algebra","","istriu","istriu(A)
+
 
    Test whether a matrix is upper-triangular.
 
@@ -5673,11 +6604,13 @@
 
 ("Linear Algebra","","ishermitian","ishermitian(A)
 
+
    Test whether a matrix is hermitian.
 
 "),
 
 ("Linear Algebra","","transpose","transpose(A)
+
 
    The transpose operator (.').
 
@@ -5685,11 +6618,14 @@
 
 ("Linear Algebra","","ctranspose","ctranspose(A)
 
+
    The conjugate transpose operator (').
 
 "),
 
-("Linear Algebra","","eigs","eigs(A; nev=6, which=\"LM\", tol=0.0, maxiter=1000, ritzvec=true)
+("Linear Algebra","","eigs","eigs(A; nev=6, which=\"LM\", tol=0.0,
+maxiter=1000, ritzvec=true)
+
 
    *eigs* computes the eigenvalues of A using Arnoldi factorization.
    The following keyword arguments are supported:
@@ -5700,7 +6636,9 @@
 
 "),
 
-("Linear Algebra","","svds","svds(A; nev=6, which=\"LA\", tol=0.0, maxiter=1000, ritzvec=true)
+("Linear Algebra","","svds","svds(A; nev=6, which=\"LA\", tol=0.0,
+maxiter=1000, ritzvec=true)
+
 
    *svds* computes the singular values of A using Arnoldi
    factorization. The following keyword arguments are supported:
@@ -5713,12 +6651,14 @@
 
 ("BLAS Functions","","copy!","copy!(n, X, incx, Y, incy)
 
+
    Copy \"n\" elements of array \"X\" with stride \"incx\" to array
    \"Y\" with stride \"incy\".  Returns \"Y\".
 
 "),
 
 ("BLAS Functions","","dot","dot(n, X, incx, Y, incy)
+
 
    Dot product of two vectors consisting of \"n\" elements of array
    \"X\" with stride \"incx\" and \"n\" elements of array \"Y\" with
@@ -5729,6 +6669,7 @@
 
 ("BLAS Functions","","nrm2","nrm2(n, X, incx)
 
+
    2-norm of a vector consisting of \"n\" elements of array \"X\" with
    stride \"incx\".
 
@@ -5736,11 +6677,13 @@
 
 ("BLAS Functions","","axpy!","axpy!(n, a, X, incx, Y, incy)
 
+
    Overwrite \"Y\" with \"a*X + Y\".  Returns \"Y\".
 
 "),
 
 ("BLAS Functions","","syrk!","syrk!(uplo, trans, alpha, A, beta, C)
+
 
    Rank-k update of the symmetric matrix \"C\" as \"alpha*A*A.' +
    beta*C\" or \"alpha*A.'*A + beta*C\" according to whether \"trans\"
@@ -5751,6 +6694,7 @@
 
 ("BLAS Functions","","syrk","syrk(uplo, trans, alpha, A)
 
+
    Returns either the upper triangle or the lower triangle, according
    to \"uplo\" ('U' or 'L'), of \"alpha*A*A.'\" or \"alpha*A.'*A\",
    according to \"trans\" ('N' or 'T').
@@ -5758,6 +6702,7 @@
 "),
 
 ("BLAS Functions","","herk!","herk!(uplo, trans, alpha, A, beta, C)
+
 
    Methods for complex arrays only.  Rank-k update of the Hermitian
    matrix \"C\" as \"alpha*A*A' + beta*C\" or \"alpha*A'*A + beta*C\"
@@ -5769,6 +6714,7 @@
 
 ("BLAS Functions","","herk","herk(uplo, trans, alpha, A)
 
+
    Methods for complex arrays only.  Returns either the upper triangle
    or the lower triangle, according to \"uplo\" ('U' or 'L'), of
    \"alpha*A*A'\" or \"alpha*A'*A\", according to \"trans\" ('N' or
@@ -5776,7 +6722,9 @@
 
 "),
 
-("BLAS Functions","","gbmv!","gbmv!(trans, m, kl, ku, alpha, A, x, beta, y)
+("BLAS Functions","","gbmv!","gbmv!(trans, m, kl, ku, alpha, A, x,
+beta, y)
+
 
    Update vector \"y\" as \"alpha*A*x + beta*y\" or \"alpha*A'*x +
    beta*y\" according to \"trans\" ('N' or 'T').  The matrix \"A\" is
@@ -5786,7 +6734,9 @@
 
 "),
 
-("BLAS Functions","","gbmv","gbmv(trans, m, kl, ku, alpha, A, x, beta, y)
+("BLAS Functions","","gbmv","gbmv(trans, m, kl, ku, alpha, A, x, beta,
+y)
+
 
    Returns \"alpha*A*x\" or \"alpha*A'*x\" according to \"trans\" ('N'
    or 'T'). The matrix \"A\" is a general band matrix of dimension
@@ -5796,6 +6746,7 @@
 "),
 
 ("BLAS Functions","","sbmv!","sbmv!(uplo, k, alpha, A, x, beta, y)
+
 
    Update vector \"y\" as \"alpha*A*x + beta*y\" where \"A\" is a a
    symmetric band matrix of order \"size(A,2)\" with \"k\" super-
@@ -5809,6 +6760,7 @@
 
 ("BLAS Functions","","sbmv","sbmv(uplo, k, alpha, A, x)
 
+
    Returns \"alpha*A*x\" where \"A\" is a symmetric band matrix of
    order \"size(A,2)\" with \"k\" super-diagonals stored in the
    argument \"A\".
@@ -5816,6 +6768,7 @@
 "),
 
 ("BLAS Functions","","gemm!","gemm!(tA, tB, alpha, A, B, beta, C)
+
 
    Update \"C\" as \"alpha*A*B + beta*C\" or the other three variants
    according to \"tA\" (transpose \"A\") and \"tB\".  Returns the
@@ -5825,12 +6778,14 @@
 
 ("BLAS Functions","","gemm","gemm(tA, tB, alpha, A, B)
 
+
    Returns \"alpha*A*B\" or the other three variants according to
    \"tA\" (transpose \"A\") and \"tB\".
 
 "),
 
 ("Punctuation","","punctuation","punctuation
+
 
    +-----------+---------------------------------------------------------------------------------------------+
    | symbol    | meaning                                                                                     |
@@ -5902,6 +6857,7 @@
 
 ("Base.Sort","Base.Sort","sort","sort(v[, alg[, ord]])
 
+
    Sort a vector in ascending order.  Specify \"alg\" to choose a
    particular sorting algorithm (\"Sort.InsertionSort\",
    \"Sort.QuickSort\", \"Sort.MergeSort\", or \"Sort.TimSort\"), and
@@ -5912,11 +6868,13 @@
 
 ("Base.Sort","Base.Sort","sort!","sort!(...)
 
+
    In-place sort.
 
 "),
 
 ("Base.Sort","Base.Sort","sortby","sortby(v, by[, alg])
+
 
    Sort a vector according to \"by(v)\".  Specify \"alg\" to choose a
    particular sorting algorithm (\"Sort.InsertionSort\",
@@ -5926,11 +6884,13 @@
 
 ("Base.Sort","Base.Sort","sortby!","sortby!(...)
 
+
    In-place \"sortby\".
 
 "),
 
 ("Base.Sort","Base.Sort","sortperm","sortperm(v[, alg[, ord]])
+
 
    Return a permutation vector, which when applied to the input vector
    \"v\" will sort it.  Specify \"alg\" to choose a particular sorting
@@ -5943,11 +6903,13 @@
 
 ("Base.Sort","Base.Sort","sort","sort(A, dim[, alg[, ord]])
 
+
    Sort a multidimensional array \"A\" along the given dimension.
 
 "),
 
 ("Base.Sort","Base.Sort","sortrows","sortrows(A[, alg[, ord]])
+
 
    Sort the rows of matrix \"A\" lexicographically.
 
@@ -5955,11 +6917,13 @@
 
 ("Base.Sort","Base.Sort","sortcols","sortcols(A[, alg[, ord]])
 
+
    Sort the columns of matrix \"A\" lexicographically.
 
 "),
 
 ("Base.Sort","Base.Sort","issorted","issorted(v[, ord])
+
 
    Test whether a vector is in ascending sorted order.  If specified,
    \"ord\" gives the ordering to test.
@@ -5968,6 +6932,7 @@
 
 ("Base.Sort","Base.Sort","searchsorted","searchsorted(a, x[, ord])
 
+
    Returns the range of indices of \"a\" equal to \"x\", assuming
    \"a\" is sorted according to ordering \"ord\" (default:
    \"Sort.Forward\").  Returns an empty range located at the insertion
@@ -5975,7 +6940,9 @@
 
 "),
 
-("Base.Sort","Base.Sort","searchsortedfirst","searchsortedfirst(a, x[, ord])
+("Base.Sort","Base.Sort","searchsortedfirst","searchsortedfirst(a, x[,
+ord])
+
 
    Returns the index of the first value of \"a\" equal to or
    succeeding \"x\", according to ordering \"ord\" (default:
@@ -5983,7 +6950,9 @@
 
 "),
 
-("Base.Sort","Base.Sort","searchsortedlast","searchsortedlast(a, x[, ord])
+("Base.Sort","Base.Sort","searchsortedlast","searchsortedlast(a, x[,
+ord])
+
 
    Returns the index of the last value of \"a\" preceding or equal to
    \"x\", according to ordering \"ord\" (default: \"Sort.Forward\").
@@ -5991,6 +6960,7 @@
 "),
 
 ("Base.Sort","Base.Sort","select","select(v, k[, ord])
+
 
    Find the element in position \"k\" in the sorted vector \"v\"
    without sorting, according to ordering \"ord\" (default:
@@ -6000,11 +6970,13 @@
 
 ("Base.Sort","Base.Sort","select!","select!(v, k[, ord])
 
+
    Version of \"select\" which permutes the input vector in place.
 
 "),
 
 ("Sparse Matrices","","sparse","sparse(I, J, V[, m, n, combine])
+
 
    Create a sparse matrix \"S\" of dimensions \"m x n\" such that
    \"S[I[k], J[k]] = V[k]\". The \"combine\" function is used to
@@ -6015,6 +6987,7 @@
 "),
 
 ("Sparse Matrices","","sparsevec","sparsevec(I, V[, m, combine])
+
 
    Create a sparse matrix \"S\" of size \"m x 1\" such that \"S[I[k]]
    = V[k]\". Duplicates are combined using the \"combine\" function,
@@ -6028,6 +7001,7 @@
 
 ("Sparse Matrices","","sparsevec","sparsevec(D::Dict[, m])
 
+
    Create a sparse matrix of size \"m x 1\" where the row values are
    keys from the dictionary, and the nonzero values are the values
    from the dictionary.
@@ -6036,17 +7010,20 @@
 
 ("Sparse Matrices","","issparse","issparse(S)
 
+
    Returns \"true\" if \"S\" is sparse, and \"false\" otherwise.
 
 "),
 
 ("Sparse Matrices","","sparse","sparse(A)
 
+
    Convert a dense matrix \"A\" into a sparse matrix.
 
 "),
 
 ("Sparse Matrices","","sparsevec","sparsevec(A)
+
 
    Convert a dense vector \"A\" into a sparse matrix of size \"m x
    1\". In julia, sparse vectors are really just sparse matrices with
@@ -6056,11 +7033,13 @@
 
 ("Sparse Matrices","","dense","dense(S)
 
+
    Convert a sparse matrix \"S\" into a dense matrix.
 
 "),
 
 ("Sparse Matrices","","full","full(S)
+
 
    Convert a sparse matrix \"S\" into a dense matrix.
 
@@ -6068,11 +7047,13 @@
 
 ("Sparse Matrices","","spzeros","spzeros(m, n)
 
+
    Create an empty sparse matrix of size \"m x n\".
 
 "),
 
 ("Sparse Matrices","","speye","speye(type, m[, n])
+
 
    Create a sparse identity matrix of specified type of size \"m x
    m\". In case \"n\" is supplied, create a sparse identity matrix of
@@ -6082,12 +7063,14 @@
 
 ("Sparse Matrices","","spones","spones(S)
 
+
    Create a sparse matrix with the same structure as that of \"S\",
    but with every nonzero element having the value \"1.0\".
 
 "),
 
 ("Sparse Matrices","","sprand","sprand(m, n, density[, rng])
+
 
    Create a random sparse matrix with the specified density. Nonzeros
    are sampled from the distribution specified by \"rng\". The uniform
@@ -6097,6 +7080,7 @@
 
 ("Sparse Matrices","","sprandn","sprandn(m, n, density)
 
+
    Create a random sparse matrix of specified density with nonzeros
    sampled from the normal distribution.
 
@@ -6104,11 +7088,13 @@
 
 ("Sparse Matrices","","sprandbool","sprandbool(m, n, density)
 
+
    Create a random sparse boolean matrix with the specified density.
 
 "),
 
 ("Base.Test","","@test ex","@test ex
+
 
    Test the expression *ex* and calls the current handler to handle
    the result.
@@ -6117,16 +7103,19 @@
 
 ("Base.Test","","@test_fails ex","@test_fails ex
 
+
    Test the expression *ex* and calls the current handler to handle
    the result in the following manner:
 
-   * If the test doesn't throw an error, the *Failure* case is called.
+   * If the test doesn't throw an error, the *Failure* case is
+     called.
 
    * If the test throws an error, the *Success* case is called.
 
 "),
 
 ("Base.Test","","@test_approx_eq a b","@test_approx_eq a b
+
 
    Test two floating point numbers *a* and *b* for equality taking in
    account small numerical errors.
@@ -6135,6 +7124,7 @@
 
 ("Base.Test","","@test_approx_eq_eps a b c","@test_approx_eq_eps a b c
 
+
    Test two floating point numbers *a* and *b* for equality taking in
    account a margin of tolerance given by *c*.
 
@@ -6142,11 +7132,13 @@
 
 ("Base.Test","Base.Test","registerhandler","registerhandler(handler)
 
+
    Change the handler function used globally to *handler*.
 
 "),
 
 ("Base.Test","Base.Test","withhandler","withhandler(f, handler)
+
 
    Run the function *f* using the *handler* as the handler.
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -183,11 +183,15 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Lower triangle of a matrix
 
-.. function:: diag(M, [k])
+.. function:: diagind(M[, k])
+
+   A ``Range`` giving the indices of the ``k``-th diagonal of the matrix ``M``.
+
+.. function:: diag(M[, k])
 
    The ``k``-th diagonal of a matrix, as a vector
 
-.. function:: diagm(v, [k])
+.. function:: diagm(v[, k])
 
    Construct a diagonal matrix and place ``v`` on the ``k``-th diagonal
 


### PR DESCRIPTION
Adds a method `diagind` that constructs a Range object giving the indices of the diagonal elements of a matrix. Also simplifies `diag` and `diagm`.

Addresses part of issue #3158 (see also discussion of #3152).
