### PR TITLE
Make .* and ./ work between StridedArray arguments

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -903,7 +903,7 @@ promote_array_type{S<:Integer}(::Type{S}, ::Type{Bool}) = S
 .^(x::StridedArray{Bool}, y::Integer) =
     reshape([ bool(x[i] ^ y) for i=1:length(x) ], size(x))
 
-for f in (:+, :-, :.*, :./, :div, :mod, :&, :|, :$)
+for f in (:+, :-, :div, :mod, :&, :|, :$)
     @eval begin
         function ($f){S,T}(A::StridedArray{S}, B::StridedArray{T})
             F = Array(promote_type(S,T), promote_shape(size(A),size(B)))
@@ -912,6 +912,10 @@ for f in (:+, :-, :.*, :./, :div, :mod, :&, :|, :$)
             end
             return F
         end
+    end
+end
+for f in (:+, :-, :.*, :./, :div, :mod, :&, :|, :$)
+    @eval begin
         function ($f){T}(A::Number, B::StridedArray{T})
             F = similar(B, promote_array_type(typeof(A),T))
             for i=1:length(B)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1,7 +1,7 @@
 module Broadcast
 
 using ..Meta.quot
-import Base.(.+), Base.(.-), Base.(.*), Base.(./) 
+import Base.(.+), Base.(.-), Base.(.*), Base.(./), Base.(.\)
 export broadcast, broadcast!, broadcast_function, broadcast!_function
 export broadcast_getindex, broadcast_setindex!
 
@@ -218,7 +218,7 @@ end
 
 ## actual functions for broadcast and broadcast! ##
 
-for (fname, op) in {(:.+, +), (:.-, -), (:.*, *), (:./, /)}
+for (fname, op) in {(:.+, +), (:.-, -), (:.*, *), (:./, /), (:.\, \)}
     eval(code_broadcast(fname, quot(op)))
 end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -35,6 +35,9 @@ for arr in (identity, as_sub)
     A = arr(eye(2)); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4; 1 5])
     A = arr([1  0]); @test_fails broadcast!(+, A, A, arr([1, 4]))
     A = arr([1  0]); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4])
+
+    @test arr([ 1    2])   .* arr([3,   4])   == [ 3 6; 4 8]
+    @test arr([24.0 12.0]) ./ arr([2.0, 3.0]) == [12 6; 8 4]
     
     M = arr([11 12; 21 22])
     @test broadcast_getindex(M, eye(Int, 2)+1,arr([1, 2])) == [21 11; 12 22]
@@ -43,3 +46,4 @@ for arr in (identity, as_sub)
     broadcast_setindex!(A, arr([21 11; 12 22]), eye(Int, 2)+1,arr([1, 2]))
     @test A == M
 end
+


### PR DESCRIPTION
Removes previous methods for 

```
.*(::StridedArray, ::StridedArray)
./(::StridedArray, ::StridedArray)
```

to allow these cases to use the newly introduced broadcasting operations. Also adds broadcasting support for `.\`.
