### PR TITLE
Search $LDFLAGS for SuiteSparse before system libraries

### DIFF
--- a/contrib/filterDupLibs.sh
+++ b/contrib/filterDupLibs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+libnames=""
+libpaths=""
+
+# Loop over all command line arguments
+for i in "$@"; do
+    # Get basename of this argument, check if it is already in libnames
+    name=$(basename "$i")
+
+    if [[ -z $(echo $libnames | grep "$name") ]]; then
+        libnames+="$name " 
+        libpaths+="$i "
+    fi
+done
+
+echo $libpaths

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -10,7 +10,7 @@ default:
 	mkdir -p $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib
 	cd $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib && \
 	rm -f *.a && \
-	cp -f $(shell find $(shell eval $(JULIAHOME)/contrib/filterArgs.sh $(LDFLAGS)) /lib /usr/lib /usr/local/lib -name libamd.a -o -name libcolamd.a -o -name libcholmod.a -o -name libumfpack.a -o -name libspqr.a -o -name libsuitesparseconfig.a 2>/dev/null) . && \
+	cp -f $(shell eval $(JULIAHOME)/contrib/filterDupLibs.sh $(shell find $(shell eval $(JULIAHOME)/contrib/filterArgs.sh $(LDFLAGS)) /lib /usr/lib /usr/local/lib -name libamd.a -o -name libcolamd.a -o -name libcholmod.a -o -name libumfpack.a -o -name libspqr.a -o -name libsuitesparseconfig.a 2>/dev/null)) . && \
 	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
 	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
 	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -10,7 +10,7 @@ default:
 	mkdir -p $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib
 	cd $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib && \
 	rm -f *.a && \
-	cp -f $(shell find /lib /usr/lib /usr/local/lib $(shell eval $(JULIAHOME)/contrib/filterArgs.sh $(LDFLAGS)) -name libamd.a -o -name libcolamd.a -o -name libcholmod.a -o -name libumfpack.a -o -name libspqr.a -o -name libsuitesparseconfig.a 2>/dev/null) . && \
+	cp -f $(shell find $(shell eval $(JULIAHOME)/contrib/filterArgs.sh $(LDFLAGS)) /lib /usr/lib /usr/local/lib -name libamd.a -o -name libcolamd.a -o -name libcholmod.a -o -name libumfpack.a -o -name libspqr.a -o -name libsuitesparseconfig.a 2>/dev/null) . && \
 	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
 	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
 	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \


### PR DESCRIPTION
Additionally, filter out duplicate libraries found and only use the first ones found.  Useful on Homebrew when user has a generic suite-sparse installed (which relies on TBB) as well as the julia-specific suite-sparse installed.
