### PR TITLE
Fixed indenting in tm bundle

### DIFF
--- a/contrib/Julia.tmbundle/Preferences/Comments.tmPreferences
+++ b/contrib/Julia.tmbundle/Preferences/Comments.tmPreferences
@@ -9,9 +9,9 @@
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>
-		<string>^\s*((end|else|elsif)\b)</string>
+		<string>^\s*((end|else|elseif)\b)</string>
 		<key>increaseIndentPattern</key>
-		<string>^\s*(if|while|for|begin|function|macro|module|type|let)\b.*\s*$</string>
+		<string>^\s*(if|while|for|begin|function|macro|module|type|let|else|elseif)\b.*\s*$</string>
 		<key>shellVariables</key>
 		<array>
 			<dict>


### PR DESCRIPTION
else and elseif weren't opening a new indent block (at least in sublime 2)
