### PR TITLE
Improvements of rand(Range1).

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -142,25 +142,36 @@ end
 
 # random integer from lo to hi inclusive
 function rand{T<:Integer}(r::Range1{T})
+    if !applicable(rand, T)
+        # Fallback for integer types where rand(T) is not defined.
+        return convert(T, rand(int(r)))
+    end
+
     lo = r[1]
     hi = r[end]
-
     m = typemax(T)
+
+    if hi - lo > m || hi - lo < 0
+        # Fallback for signed integer types when the length of the range
+        # is larger than typemax(T), e.g. rand(int32(-1):typemax(Int32)).
+        return convert(T, rand(unsigned(zero(T)):unsigned(hi - lo)) + lo)
+    end
+
     s = rand(T) & m
     if (hi-lo == m)
-        return s + lo
+        return convert(T, s + lo)
     end
     r = hi-lo+1
     if (r&(r-1))==0
         # power of 2 range
-        return s&(r-1) + lo
+        return convert(T, s&(r-1) + lo)
     end
     # note: m>=0 && r>=0
     lim = m - rem(rem(m,r)+1, r)
     while s > lim
         s = rand(T) & m
     end
-    return rem(s,r) + lo
+    return convert(T, rem(s,r) + lo)
 end
 
 function rand!{T<:Integer}(r::Range1{T}, A::Array{T})

--- a/test/random.jl
+++ b/test/random.jl
@@ -4,3 +4,16 @@
 @test -10 <= rand(-10:-5) <= -5
 @test -10 <= rand(-10:5) <= 5
 @test min([rand(int32(1):int32(7^7)) for i = 1:100000]) > 0
+@test(typeof(rand(false:true)) == Bool)
+
+for T in (Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64, Int128, Uint128, Char, BigInt)
+    r = rand(convert(T, 97):convert(T, 122))
+    @test typeof(r) == T
+    @test 97 <= r <= 122
+end
+
+if sizeof(Int32) < sizeof(Int)
+    r = rand(int32(-1):typemax(Int32))
+    @test typeof(r) == Int32
+    @test -1 <= r <= typemax(Int32)
+end


### PR DESCRIPTION
This pull request addresses the following shortcomings of the rand(Range1) function.

``` julia
julia> rand('a':'z')
ERROR: no method typemax(DataType,)
 in rand at random.jl:148

julia> typeof(rand(int32(1):int32(5)))
Int64

julia> rand(int32(-1):typemax(Int32))
[Hangs in infinite loop.]
```

Instead giving:

``` julia
julia> rand('a':'z')
'r'

julia> typeof(rand(int32(1):int32(5)))
Int32

julia> rand(int32(-1):typemax(Int32))
1410446553
```
