### PR TITLE
Improve result type of broadcasting ./ and .\, add broadcasting .^

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -880,11 +880,6 @@ promote_array_type{S<:Integer}(::Type{S}, ::Type{Bool}) = S
 
 # ^ is difficult, since negative exponents give a different type
 
-.^(x::StridedArray, y::StridedArray) =
-    reshape([ x[i] ^ y[i] for i=1:length(x) ], promote_shape(size(x),size(y)))
-.^{T<:Integer}(x::StridedArray{Bool}, y::StridedArray{T}) =
-    reshape([ bool(x[i] ^ y[i]) for i=1:length(x) ], promote_shape(size(x),size(y)))
-
 .^(x::Number, y::StridedArray) =
     reshape([ x    ^ y[i] for i=1:length(y) ], size(y))
 .^(x::Bool  , y::StridedArray) =

--- a/base/array.jl
+++ b/base/array.jl
@@ -864,19 +864,11 @@ promote_array_type{S<:Integer, A<:Integer}(::Type{S}, ::Type{A}) = A
 promote_array_type{S<:Real, A<:Integer}(::Type{S}, ::Type{A}) = promote_type(S, A)
 promote_array_type{S<:Integer}(::Type{S}, ::Type{Bool}) = S
 
-./{T<:Integer,S<:Integer}(x::StridedArray{T}, y::StridedArray{S}) =
-    reshape([ x[i] ./ y[i] for i=1:length(x) ], promote_shape(size(x),size(y)))
 ./{T<:Integer}(x::Integer, y::StridedArray{T}) =
     reshape([ x    ./ y[i] for i=1:length(y) ], size(y))
 ./{T<:Integer}(x::StridedArray{T}, y::Integer) =
     reshape([ x[i] ./ y    for i=1:length(x) ], size(x))
 
-./{T<:Integer,S<:Integer}(x::StridedArray{Complex{T}}, y::StridedArray{S}) =
-    reshape([ x[i] ./ y[i] for i=1:length(x) ], promote_shape(size(x),size(y)))
-./{T<:Integer,S<:Integer}(x::StridedArray{T}, y::StridedArray{Complex{S}}) =
-    reshape([ x[i] ./ y[i] for i=1:length(x) ], promote_shape(size(x),size(y)))
-./{T<:Integer,S<:Integer}(x::StridedArray{Complex{T}}, y::StridedArray{Complex{S}}) =
-    reshape([ x[i] ./ y[i] for i=1:length(x) ], promote_shape(size(x),size(y)))
 ./{T<:Integer}(x::Integer, y::StridedArray{Complex{T}}) =
     reshape([ x    ./ y[i] for i=1:length(y) ], size(y))
 ./{T<:Integer}(x::StridedArray{Complex{T}}, y::Integer) =

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -218,10 +218,6 @@ end
 
 ## actual functions for broadcast and broadcast! ##
 
-for (fname, op) in {(:.+, +), (:.-, -), (:.*, *), (:./, /), (:.\, \)}
-    eval(code_broadcast(fname, quot(op)))
-end
-
 broadcastfuns = (Function=>Function)[]
 function broadcast_function(op::Function)
     (haskey(broadcastfuns, op) ? broadcastfuns[op] :
@@ -240,6 +236,21 @@ end
 function broadcast!(op::Function, dest::StridedArray, As::StridedArray...)
     broadcast!_function(op)(dest, As...)
 end
+
+
+## elementwise operators ##
+
+const broadcast_add = broadcast_function(+)
+const broadcast_sub = broadcast_function(-)
+const broadcast_mul = broadcast_function(*)
+const broadcast_div = broadcast_function(/)
+const broadcast_rdiv = broadcast_function(\)
+
+.+(As::StridedArray...) = broadcast_add(As...)
+.*(As::StridedArray...) = broadcast_mul(As...)
+.-(A::StridedArray, B::StridedArray) = broadcast_sub(A, B)
+./(A::StridedArray, B::StridedArray) = broadcast_div(A, B)
+.\(A::StridedArray, B::StridedArray) = broadcast_rdiv(A, B)
 
 
 end # module

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -249,14 +249,26 @@ end
 const broadcast_add = broadcast_function(+)
 const broadcast_sub = broadcast_function(-)
 const broadcast_mul = broadcast_function(*)
-const broadcast_div = broadcast_function(/)
-const broadcast_rdiv = broadcast_function(\)
+const broadcast_div_T  = broadcast_T_function(/)
+const broadcast_rdiv_T = broadcast_T_function(\)
 
 .+(As::StridedArray...) = broadcast_add(As...)
 .*(As::StridedArray...) = broadcast_mul(As...)
 .-(A::StridedArray, B::StridedArray) = broadcast_sub(A, B)
-./(A::StridedArray, B::StridedArray) = broadcast_div(A, B)
-.\(A::StridedArray, B::StridedArray) = broadcast_rdiv(A, B)
+
+type_div(T,S) = promote_type(T,S)
+type_div{T<:Integer,S<:Integer}(::Type{T},::Type{S}) = Float64
+type_div{T,S}(::Type{Complex{T}},::Type{Complex{S}})  = Complex{type_div(T,S)}
+type_div{T,S}(::Type{Complex{T}},::Type{S})           = Complex{type_div(T,S)}
+type_div{T,S}(::Type{T},::Type{Complex{S}})           = Complex{type_div(T,S)}
+
+function ./(A::StridedArray, B::StridedArray) 
+    broadcast_div_T(type_div(eltype(A), eltype(B)), A, B)
+end
+
+function .\(A::StridedArray, B::StridedArray) 
+    broadcast_rdiv_T(type_div(eltype(B), eltype(A)), A, B)
+end
 
 
 end # module

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -251,6 +251,7 @@ const broadcast_sub = broadcast_function(-)
 const broadcast_mul = broadcast_function(*)
 const broadcast_div_T  = broadcast_T_function(/)
 const broadcast_rdiv_T = broadcast_T_function(\)
+const broadcast_pow_T  = broadcast_T_function(^)
 
 .+(As::StridedArray...) = broadcast_add(As...)
 .*(As::StridedArray...) = broadcast_mul(As...)
@@ -268,6 +269,14 @@ end
 
 function .\(A::StridedArray, B::StridedArray) 
     broadcast_rdiv_T(type_div(eltype(B), eltype(A)), A, B)
+end
+
+type_pow(T,S) = promote_type(T,S)
+type_pow{S<:Integer}(::Type{Bool},::Type{S}) = Bool
+type_pow{S}(T,::Type{Rational{S}}) = type_pow(T, type_div(S, S))
+
+function .^(A::StridedArray, B::StridedArray) 
+    broadcast_pow_T(type_pow(eltype(A), eltype(B)), A, B)
 end
 
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -38,6 +38,8 @@ for arr in (identity, as_sub)
 
     @test arr([ 1    2])   .* arr([3,   4])   == [ 3 6; 4 8]
     @test arr([24.0 12.0]) ./ arr([2.0, 3.0]) == [12 6; 8 4]
+    @test arr([1 2]) ./ arr([3, 4]) == [1/3 2/3; 1/4 2/4]
+    @test arr([1 2]) .\ arr([3, 4]) == [3 1.5; 4 2]
     
     M = arr([11 12; 21 22])
     @test broadcast_getindex(M, eye(Int, 2)+1,arr([1, 2])) == [21 11; 12 22]

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -40,6 +40,7 @@ for arr in (identity, as_sub)
     @test arr([24.0 12.0]) ./ arr([2.0, 3.0]) == [12 6; 8 4]
     @test arr([1 2]) ./ arr([3, 4]) == [1/3 2/3; 1/4 2/4]
     @test arr([1 2]) .\ arr([3, 4]) == [3 1.5; 4 2]
+    @test arr([3 4]) .^ arr([1, 2]) == [3 4; 9 16]
     
     M = arr([11 12; 21 22])
     @test broadcast_getindex(M, eye(Int, 2)+1,arr([1, 2])) == [21 11; 12 22]


### PR DESCRIPTION
This patch makes `./`, `.\`, and `.^` be broadcasting for all `StridedArray` arguments, and produces more or less the same result types as the previous unbroadcasted versions. I added a case for `.^` where the exponent is rational.

Does it seem reasonable to compute the result type as at the bottom of `broadcast.jl`?
