### PR TITLE
Fix make distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ cleanall: clean
 
 distclean: cleanall
 	@$(MAKE) -C deps distclean
-	@$(MAKE) -C doc distclean
+	@$(MAKE) -C doc cleanall
 	rm -fr usr
 
 .PHONY: default debug release julia-debug julia-release \


### PR DESCRIPTION
There is no `distclean` target defined in `doc/Makefile`, so this previously failed with an error.
