### PR TITLE
RFC: add SubVector (fast 1d slices)

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -82,6 +82,7 @@ export
     SubDArray,
     SubOrDArray,
     SubString,
+    SubVector,
     SymTridiagonal,
     TcpSocket,
     TmStruct,

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -114,6 +114,19 @@ sA[2:5:end] = -1
 @test all(sA[2:5:end] .== -1)
 @test all(A[5:15:120] .== -1)
 
+# SubVector
+A = reshape(1:48, 8, 6)
+s = SubVector(A, 1:3:8, 2)
+@assert s[2] == A[4,2]
+@assert s == A[1:3:8, 2]
+s = SubVector(A, 2:3:8, 2)
+@assert s == A[2:3:8, 2]
+s = SubVector(A, 4, 3:6)
+@assert s == vec(A[4, 3:6])
+s[1] = 0
+@assert A[4,3] == 0
+ss = SubVector(s, 4:-2:2)
+@assert ss == [44,28]
 
 # get
 let


### PR DESCRIPTION
Here's a baby step towards making Arrays just pointers + size & stride information. With it I'm getting ~2x - 2.5x speedups over `mapslices` in a recent application that looks a lot like this:

```
    notd = setdiff([1:nd], d)
    indexes[d] = 1:size(A, d)
    for c in Counter(szA[notd])
        indexes[notd] = c
        s = SubVector(Aout, indexes...)
        filt!(b, a, s)
    end
```

`Counter` comes from `Grid.jl`.
