### PR TITLE
Db/jlsparse

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -625,6 +625,7 @@ export
 # sparse
     dense,
     full,
+    etree,
     issparse,
     sparse,
     sparsevec,

--- a/base/jlsparse.jl
+++ b/base/jlsparse.jl
@@ -1,0 +1,132 @@
+# These functions are based on C functions in the CSparse library by Tim Davis
+# CSparse can be downloaded from http://www.cise.ufl.edu/research/sparse/CSparse/CSparse.tar.gz
+# CSparse is Copyright (c) 2006-2007, Timothy A. Davis and released under
+# Lesser GNU Public License, version 2.1 or later.  A copy of the license can be
+# downloaded from http://www.gnu.org/licenses/lgpl-2.1.html
+
+# Because these functions are based on code covered by LGPL-2.1+ the same license
+# must apply to the code in this file which is
+# Copyright (c) 2013 Douglas M. Bates, Viral Shah and other contributors
+
+# Compute the elimination tree of A using triu(A) returning the parent vector.
+# A root node is indicated by 0. This tree may actually be a forest in that
+# there may be more than one root, indicating complete separability.
+# A trivial example is speye(n, n) in which every node is a root.
+function etree(A::SparseMatrixCSC, postorder::Bool)
+    m,n = size(A); Ap = A.colptr; Ai = A.rowval; T = eltype(Ai)
+    parent = zeros(T, n); ancestor = zeros(T, n)
+    for k in 1:n, p in Ap[k]:(Ap[k+1] - 1)
+        i = Ai[p]
+        while i != 0 && i < k
+            inext = ancestor[i] # inext = ancestor of i
+            ancestor[i] = k     # path compression
+            if (inext == 0) parent[i] = k end # no anc., parent is k
+            i = inext
+        end
+    end
+    if !postorder return parent end
+    head = zeros(T,n)                   # empty linked lists
+    next = zeros(T,n)
+    for j in n:-1:1                      # traverse in reverse order
+        if (parent[j] == 0) continue end # j is a root
+        next[j] = head[parent[j]]        # add j to list of its parent
+        head[parent[j]] = j
+    end
+    stack = T[]
+    sizehint(stack, n)
+    post = zeros(T,n)
+    k = 1
+    for j in 1:n
+        if (parent[j] != 0) continue end # skip j if it is not a root
+        push!(stack, j)                  # place j on the stack
+        while (length(stack) > 0)        # while (stack is not empty)
+            p = stack[end]               # p = top of stack
+            i = head[p]                  # i = youngest child of p
+            if (i == 0)
+                pop!(stack)
+                post[k] = p       # node p is the kth postordered node
+                k += 1
+            else
+            head[p] = next[i]           # remove i from children of p
+            push!(stack, i)
+            end
+        end
+    end
+    parent, post
+end
+
+etree(A::SparseMatrixCSC) = etree(A, false)
+
+# find nonzero pattern of Cholesky L(k,1:k-1) using etree and triu(A(:,k))
+# based on cs_ereach p. 43, "Direct Methods for Sparse Linear Systems"
+function ereach{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, k::Integer, parent::Vector{Ti})
+    m,n = size(A); Ap = A.colptr; Ai = A.rowval
+    s = Ti[]; sizehint(s, n)            # to be used as a stack
+    visited = falses(n)
+    visited[k] = true
+    for p in Ap[k]:(Ap[k+1] - 1)
+        i = Ai[p]                # A(i,k) is nonzero
+        if i > k continue end    # only use upper triangular part of A
+        while !visited[i]        # traverse up etree
+            push!(s,i)           # L(k,i) is nonzero
+            visited[i] = true
+            i = parent[i]
+        end
+    end
+    s
+end
+
+# based on cs_permute p. 21, "Direct Methods for Sparse Linear Systems"
+function csc_permute{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, pinv::Vector{Ti}, q::Vector{Ti})
+    m,n = size(A); Ap = A.colptr; Ai = A.rowval; Ax = A.nzval
+    if length(pinv) != m || length(q) !=  n 
+        error("Dimension mismatch, size(A) = $(size(A)), length(pinv) = $(length(pinv)) and length(q) = $(length(q))")
+    end
+    if !isperm(pinv) || !isperm(q) error("Both pinv and q must be permutations") end
+    C = copy(A); Cp = C.colptr; Ci = C.rowval; Cx = C.nzval
+    nz = zero(Ti)
+    for k in 1:n
+        Cp[k] = nz
+        j = q[k]
+        for t = Ap[j]:(Ap[j+1]-1)
+            Cx[nz] = Ax[t]
+            Ci[nz] = pinv[Ai[t]]
+            nz += one(Ti)
+        end
+    end
+    Cp[n + 1] = nz
+    (C.').'                    # double transpose to order the columns
+end
+
+# based on cs_symperm p. 21, "Direct Methods for Sparse Linear Systems"
+# form A[p,p] for a symmetric A stored in the upper triangle
+function csc_symperm{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, pinv::Vector{Ti})
+    m,n = size(A); Ap = A.colptr; Ai = A.rowval; Ax = A.nzval
+    if m != n || length(pinv) != m
+        error("A must be square, size(A) = $(size(A)), length(pinv) = $(length(pinv))")
+    end
+    if !isperm(pinv) error("Both pinv must be a permutation") end
+    C = copy(A); Cp = C.colptr; Ci = C.rowval; Cx = C.nzval
+    w = Array(Ti,n)
+    for j in 1:n                   # count entries in each column of C
+        j2 = pinv[j]
+        for p = Ap[j]:(Ap[j+1]-1)
+            i = Ai[p]
+            if i > j continue end
+            w[pinv[i]] += one(Ti)
+        end
+    end
+    Cp[:] = cumsum(vcat(one(Ti),w))
+    for j in 1:n                   # count entries in each column of C
+        j2 = pinv[j]
+        for p = Ap[j]:(Ap[j+1]-1)
+            i = Ai[p]
+            if i > j continue end
+            i2 = pinv[i]
+            q = w[max(i2,j2)]
+            Ci[q] = min(i2,j2)
+            Cx[q] = Ax[p]
+        end
+    end
+    (C.').'                    # double transpose to order the columns
+end

--- a/base/linalg/sparse.jl
+++ b/base/linalg/sparse.jl
@@ -327,113 +327,10 @@ function diff(a::SparseMatrixCSC, dim::Integer)
     end
 end
 
-## diag and related
-
-diag(A::SparseMatrixCSC) = [ A[i,i] for i=1:min(size(A)) ]
-
-function diagm{Tv,Ti}(v::SparseMatrixCSC{Tv,Ti})
-    if (size(v,1) != 1 && size(v,2) != 1)
-        error("Input should be nx1 or 1xn")
-    end
-
-    n = length(v)
-    numnz = nnz(v)
-    colptr = Array(Ti, n+1)
-    rowval = Array(Ti, numnz)
-    nzval = Array(Tv, numnz)
-
-    if size(v,1) == 1
-        copy!(colptr, 1, v.colptr, 1, n+1)
-        ptr = 1
-        for col = 1:n
-            if colptr[col] != colptr[col+1]
-                rowval[ptr] = col
-                nzval[ptr] = v.nzval[ptr]
-                ptr += 1
-            end
-        end
-    else
-        copy!(rowval, 1, v.rowval, 1, numnz)
-        copy!(nzval, 1, v.nzval, 1, numnz)
-        colptr[1] = 1
-        ptr = 1
-        col = 1
-        while col <= n && ptr <= numnz
-            while rowval[ptr] > col
-                colptr[col+1] = colptr[col]
-                col += 1
-            end
-            colptr[col+1] = colptr[col] + 1
-            ptr += 1
-            col += 1
-        end
-        if col <= n
-            colptr[(col+1):(n+1)] = colptr[col]
-        end
-    end
-
-    return SparseMatrixCSC{Tv,Ti}(n, n, colptr, rowval, nzval)
-end
-
-function spdiagm{T}(v::Union(AbstractVector{T},AbstractMatrix{T}))
-    if isa(v, AbstractMatrix)
-        if (size(v,1) != 1 && size(v,2) != 1)
-            error("Input should be nx1 or 1xn")
-        end
-    end
-
-    n = length(v)
-    numnz = nnz(v)
-    colptr = Array(Int, n+1)
-    rowval = Array(Int, numnz)
-    nzval = Array(T, numnz)
-
-    colptr[1] = 1
-
-    z = zero(T)
-
-    ptr = 1
-    for col=1:n
-        x = v[col]
-        if x != z
-            colptr[col+1] = colptr[col] + 1
-            rowval[ptr] = col
-            nzval[ptr] = x
-            ptr += 1
-        else
-            colptr[col+1] = colptr[col]
-        end
-    end
-
-    return SparseMatrixCSC(n, n, colptr, rowval, nzval)
-end
 
 ## norm and rank
 
 # TODO
-
-## trace
-
-function trace{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti})
-    t = zero(Tv)
-    for col=1:min(size(A))
-        first = A.colptr[col]
-        last = A.colptr[col+1]-1
-        while first <= last
-            mid = (first + last) >> 1
-            row = A.rowval[mid]
-            if row == col
-                t += A.nzval[mid]
-                break
-            elseif row > col
-                last = mid - 1
-            else
-                first = mid + 1
-            end
-        end
-    end
-    return t
-end
 
 # kron
 
@@ -493,49 +390,6 @@ end
 ## det, inv, cond
 
 # TODO
-
-## Structure query functions
-
-function issym(A::SparseMatrixCSC)
-    m, n = size(A)
-    if m != n; return false; end
-    return nnz(A - A.') == 0
-end
-
-function ishermitian(A::SparseMatrixCSC)
-    m, n = size(A)
-    if m != n; return false; end
-    return nnz(A - A') == 0
-end
-
-function istriu(A::SparseMatrixCSC)
-    for col = 1:min(A.n,A.m-1)
-        l1 = A.colptr[col+1]-1
-        for i = 0 : (l1 - A.colptr[col])
-            if A.rowval[l1-i] <= col
-                break
-            end
-            if A.nzval[l1-i] != 0
-                return false
-            end
-        end
-    end
-    return true
-end
-
-function istril(A::SparseMatrixCSC)
-    for col = 2:A.n
-        for i = A.colptr[col] : (A.colptr[col+1]-1)
-            if A.rowval[i] >= col
-                break
-            end
-            if A.nzval[i] != 0
-                return false
-            end
-        end
-    end
-    return true
-end
 
 ## scale methods
 

--- a/base/sparse.jl
+++ b/base/sparse.jl
@@ -267,7 +267,7 @@ function sparse_IJ_sorted!{Ti<:Integer}(I::AbstractVector{Ti}, J::AbstractVector
     return SparseMatrixCSC(m, n, colptr, I, V)
 end
 
-## sparse() can take its inputs in unsorted order
+## sparse() can take its inputs in unsorted order (the parent method is now in jlsparse.jl)
 
 sparse(I,J,v::Number) = sparse(I, J, fill(v,length(I)), int(max(I)), int(max(J)), +)
 
@@ -280,105 +280,6 @@ sparse(I,J,V::AbstractVector,m,n) = sparse(I, J, V, int(m), int(n), +)
 sparse(I,J,V::AbstractVector{Bool},m,n) = sparse(I, J, V, int(m), int(n), |)
 
 sparse(I,J,v::Number,m,n,combine::Function) = sparse(I, J, fill(v,length(I)), int(m), int(n), combine)
-
-# Based on Direct Methods for Sparse Linear Systems, T. A. Davis, SIAM, Philadelphia, Sept. 2006.
-# Section 2.4: Triplet form
-# http://www.cise.ufl.edu/research/sparse/CSparse/
-function sparse{Tv,Ti<:Integer}(I::AbstractVector{Ti}, J::AbstractVector{Ti}, 
-                                V::AbstractVector{Tv},
-                                nrow::Integer, ncol::Integer, combine::Function)
-
-    if length(I) == 0; return spzeros(eltype(V),nrow,ncol); end
-
-    # Work array
-    Wj = Array(Ti, max(nrow,ncol)+1)
-
-    # Allocate sparse matrix data structure
-    # Count entries in each row
-    nz = length(I)
-    Rnz = zeros(Ti, nrow+1)
-    Rnz[1] = 1
-    for k=1:nz
-        Rnz[I[k]+1] += 1
-    end
-    Rp = cumsum(Rnz)
-    Ri = Array(Ti, nz)
-    Rx = Array(Tv, nz)
-
-    # Construct row form
-    # place triplet (i,j,x) in column i of R
-    # Use work array for temporary row pointers
-    for i=1:nrow; Wj[i] = Rp[i]; end
-
-    for k=1:nz
-        ind = I[k]
-        p = Wj[ind]
-        Wj[ind] += 1
-        Rx[p] = V[k]
-        Ri[p] = J[k]
-    end
-
-    # Reset work array for use in counting duplicates
-    for j=1:ncol; Wj[j] = 0; end
-
-    # Sum up duplicates and squeeze
-    anz = 0
-    for i=1:nrow
-        p1 = Rp[i]
-        p2 = Rp[i+1] - 1
-        pdest = p1
-
-        for p = p1:p2
-            j = Ri[p]
-            pj = Wj[j]
-            if pj >= p1
-                Rx[pj] = combine (Rx[pj], Rx[p])
-            else
-                Wj[j] = pdest
-                if pdest != p
-                    Ri[pdest] = j
-                    Rx[pdest] = Rx[p]
-                end
-                pdest += 1
-            end
-        end
-
-        Rnz[i] = pdest - p1
-        anz += (pdest - p1)
-    end
-
-    # Transpose from row format to get the CSC format
-    RiT = Array(Ti, anz)
-    RxT = Array(Tv, anz)
-
-    # Reset work array to build the final colptr
-    Wj[1] = 1
-    for i=2:(ncol+1); Wj[i] = 0; end
-    for j = 1:nrow
-        p1 = Rp[j]
-        p2 = p1 + Rnz[j] - 1        
-        for p = p1:p2
-            Wj[Ri[p]+1] += 1
-        end
-    end
-    RpT = cumsum(Wj[1:(ncol+1)])
-
-    # Transpose 
-    for i=1:length(RpT); Wj[i] = RpT[i]; end
-    for j = 1:nrow
-        p1 = Rp[j]
-        p2 = p1 + Rnz[j] - 1
-        for p = p1:p2
-            ind = Ri[p]
-            q = Wj[ind]
-            Wj[ind] += 1
-            RiT[q] = j
-            RxT[q] = Rx[p]
-        end
-    end
-
-    return SparseMatrixCSC(nrow, ncol, RpT, RiT, RxT)
-end
 
 function find(S::SparseMatrixCSC)
     sz = size(S)
@@ -480,69 +381,6 @@ function one{T}(S::SparseMatrixCSC{T})
     m,n = size(S)
     if m != n; error("Multiplicative identity only defined for square matrices!"); end;
     speye(T, m)
-end
-
-## Transpose
-
-# Based on Direct Methods for Sparse Linear Systems, T. A. Davis, SIAM, Philadelphia, Sept. 2006.
-# Section 2.5: Transpose
-# http://www.cise.ufl.edu/research/sparse/CSparse/
-function transpose{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
-    (nT, mT) = size(S)
-    nnzS = nnz(S)
-    colptr_S = S.colptr
-    rowval_S = S.rowval
-    nzval_S = S.nzval
-
-    rowval_T = Array(Ti, nnzS)
-    nzval_T = Array(Tv, nnzS)
-
-    w = zeros(Ti, nT+1)
-    w[1] = 1
-    for i=1:nnzS
-        w[rowval_S[i]+1] += 1
-    end
-    colptr_T = cumsum(w)
-    w = copy(colptr_T)
-
-    for j = 1:mT, p = colptr_S[j]:(colptr_S[j+1]-1)
-        ind = rowval_S[p]
-        q = w[ind]
-        w[ind] += 1
-        rowval_T[q] = j
-        nzval_T[q] = nzval_S[p]
-    end
-
-    SparseMatrixCSC(mT, nT, colptr_T, rowval_T, nzval_T)
-end
-
-function ctranspose{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
-    (nT, mT) = size(S)
-    nnzS = nnz(S)
-    colptr_S = S.colptr
-    rowval_S = S.rowval
-    nzval_S = S.nzval
-
-    rowval_T = Array(Ti, nnzS)
-    nzval_T = Array(Tv, nnzS)
-
-    w = zeros(Ti, nT+1)
-    w[1] = 1
-    for i=1:nnzS
-        w[rowval_S[i]+1] += 1
-    end
-    colptr_T = cumsum(w)
-    w = copy(colptr_T)
-
-    for j = 1:mT, p = colptr_S[j]:(colptr_S[j+1]-1)
-        ind = rowval_S[p]
-        q = w[ind]
-        w[ind] += 1
-        rowval_T[q] = j
-        nzval_T[q] = conj(nzval_S[p])
-    end
-
-    SparseMatrixCSC(mT, nT, colptr_T, rowval_T, nzval_T)
 end
 
 ## Unary arithmetic and boolean operators
@@ -1410,6 +1248,82 @@ function hvcat(rows::(Int...), X::SparseMatrixCSC...)
     vcat(tmp_rows...)
 end
 
+## Structure query functions
+
+function issym(A::SparseMatrixCSC)
+    m, n = size(A)
+    if m != n; return false; end
+    return nnz(A - A.') == 0
+end
+
+function ishermitian(A::SparseMatrixCSC)
+    m, n = size(A)
+    if m != n; return false; end
+    return nnz(A - A') == 0
+end
+
+function istriu(A::SparseMatrixCSC)
+    for col = 1:min(A.n,A.m-1)
+        l1 = A.colptr[col+1]-1
+        for i = 0 : (l1 - A.colptr[col])
+            if A.rowval[l1-i] <= col
+                break
+            end
+            if A.nzval[l1-i] != 0
+                return false
+            end
+        end
+    end
+    return true
+end
+
+function istril(A::SparseMatrixCSC)
+    for col = 2:A.n
+        for i = A.colptr[col] : (A.colptr[col+1]-1)
+            if A.rowval[i] >= col
+                break
+            end
+            if A.nzval[i] != 0
+                return false
+            end
+        end
+    end
+    return true
+end
+
+function spdiagm{T}(v::Union(AbstractVector{T},AbstractMatrix{T}))
+    if isa(v, AbstractMatrix)
+        if (size(v,1) != 1 && size(v,2) != 1)
+            error("Input should be nx1 or 1xn")
+        end
+    end
+
+    n = length(v)
+    numnz = nnz(v)
+    colptr = Array(Int, n+1)
+    rowval = Array(Int, numnz)
+    nzval = Array(T, numnz)
+
+    colptr[1] = 1
+
+    z = zero(T)
+
+    ptr = 1
+    for col=1:n
+        x = v[col]
+        if x != z
+            colptr[col+1] = colptr[col] + 1
+            rowval[ptr] = col
+            nzval[ptr] = x
+            ptr += 1
+        else
+            colptr[col+1] = colptr[col]
+        end
+    end
+
+    return SparseMatrixCSC(n, n, colptr, rowval, nzval)
+end
+
 function mmread(filename::ASCIIString, infoonly::Bool)
 #      Reads the contents of the Matrix Market file 'filename'
 #      into a matrix, which will be either sparse or dense,
@@ -1463,36 +1377,86 @@ function expandptr{T<:Integer}(V::Vector{T})
     res
 end
 
-# Based on Direct Methods for Sparse Linear Systems, T. A. Davis, SIAM, Philadelphia, Sept. 2006.
-# Section 2.7: Removing entries from a matrix
-# http://www.cise.ufl.edu/research/sparse/CSparse/
-function fkeep!{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, f, other)
-    nzorig = nnz(A)
-    nz = 1
-    for j = 1:A.n
-        p = A.colptr[j]                 # record current position
-        A.colptr[j] = nz                # set new position
-        while p < A.colptr[j+1]
-            if f(A.rowval[p], j, A.nzval[p], other)
-                A.nzval[nz] = A.nzval[p]
-                A.rowval[nz] = A.rowval[p]
-                nz += 1
-            end
-            p += 1
+## diag and related using an iterator
+
+type cscdiagit{Tv,Ti}
+    A::SparseMatrixCSC{Tv,Ti}
+    n::Int
+end
+cscdiagit(A::SparseMatrixCSC) = cscdiagit(A,min(size(A)))
+
+length(d::cscdiagit) = d.n
+start(d::cscdiagit) = 1
+done(d::cscdiagit, j) = j > d.n
+function next{Tv,Ti}(d::cscdiagit{Tv,Ti}, j)
+    p = d.A.colptr; i = d.A.rowval;
+    first = p[j]
+    last = p[j+1]-1
+    while first <= last
+        mid = (first + last) >> 1
+        r = i[mid]
+        if r == j
+            return (d.A.nzval[mid], j+1)
+        elseif r > j
+            last = mid - 1
+        else
+            first = mid + 1
         end
     end
-    A.colptr[A.n + 1] = nz
-    nz -= 1
-    if nz < nzorig
-        resize!(A.nzval, nz)
-        resize!(A.rowval, nz)
-    end
-    A
+    zero(eltype(A)), j+1
 end
 
-droptol!(A::SparseMatrixCSC, tol) = fkeep!(A, (i,j,x,other)->abs(x)>other, tol)
-dropzeros!(A::SparseMatrixCSC) = fkeep!(A, (i,j,x,other)->x!=zero(Tv), None)
-triu!(A::SparseMatrixCSC) = fkeep!(A, (i,j,x,other)->(j>=i), None)
-triu(A::SparseMatrixCSC) = triu!(copy(A))
-tril!(A::SparseMatrixCSC) = fkeep!(A, (i,j,x,other)->(i>=j), None)
-tril(A::SparseMatrixCSC) = tril!(copy(A))
+function trace(A::SparseMatrixCSC)
+    s = zero(eltype(A))
+    for d in cscdiagit(A)
+        s += d
+    end
+    s
+end
+
+diag(A::SparseMatrixCSC) = [d for d in cscdiagit(A)]
+
+function diagm{Tv,Ti}(v::SparseMatrixCSC{Tv,Ti})
+    if (size(v,1) != 1 && size(v,2) != 1)
+        error("Input should be nx1 or 1xn")
+    end
+
+    n = length(v)
+    numnz = nnz(v)
+    colptr = Array(Ti, n+1)
+    rowval = Array(Ti, numnz)
+    nzval = Array(Tv, numnz)
+
+    if size(v,1) == 1
+        copy!(colptr, 1, v.colptr, 1, n+1)
+        ptr = 1
+        for col = 1:n
+            if colptr[col] != colptr[col+1]
+                rowval[ptr] = col
+                nzval[ptr] = v.nzval[ptr]
+                ptr += 1
+            end
+        end
+    else
+        copy!(rowval, 1, v.rowval, 1, numnz)
+        copy!(nzval, 1, v.nzval, 1, numnz)
+        colptr[1] = 1
+        ptr = 1
+        col = 1
+        while col <= n && ptr <= numnz
+            while rowval[ptr] > col
+                colptr[col+1] = colptr[col]
+                col += 1
+            end
+            colptr[col+1] = colptr[col] + 1
+            ptr += 1
+            col += 1
+        end
+        if col <= n
+            colptr[(col+1):(n+1)] = colptr[col]
+        end
+    end
+
+    return SparseMatrixCSC{Tv,Ti}(n, n, colptr, rowval, nzval)
+end
+

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -162,6 +162,7 @@ push!(I18n.CALLBACKS, Help.clear_cache)
 
 # sparse matrices and linear algebra
 include("sparse.jl")
+include("jlsparse.jl")
 include("linalg.jl")
 importall .LinAlg
 

--- a/doc/stdlib/sparse.rst
+++ b/doc/stdlib/sparse.rst
@@ -61,3 +61,8 @@ Sparse matrices support much of the same set of operations as dense matrices. Th
 
    Create a random sparse boolean matrix with the specified density.
 
+.. function:: etree(A[, post])
+
+   Compute the elimination tree of a symmetric sparse matrix ``A`` from ``triu(A)`` and, optionally, its post-ordering permutation.
+
+

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -75,3 +75,13 @@ end
 @test prod(se33)[1] == 0.0
 @test prod(se33, 1) == [0.0 0.0 0.0]
 @test prod(se33, 2) == [0.0 0.0 0.0]'
+
+# elimination tree
+## upper triangle of the pattern test matrix from Figure 4.2 of
+## "Direct Methods for Sparse Linear Systems" by Tim Davis, SIAM, 2006
+rowval = int32([1,2,2,3,4,5,1,4,6,1,7,2,5,8,6,9,3,4,6,8,10,3,5,7,8,10,11])
+colval = int32([1,2,3,3,4,5,6,6,6,7,7,8,8,8,9,9,10,10,10,10,10,11,11,11,11,11,11])
+A = sparse(rowval, colval, ones(length(rowval)))
+parent,post = Base.LinAlg.etree(A, true)
+@assert parent == int32([6,3,8,6,8,7,9,10,10,11,0])
+@assert post == int32([2,3,5,8,1,4,6,7,9,10,11])


### PR DESCRIPTION
Move functions that are based on code in the CSparse library of C functions to a separate file `base/linalg/jlsparse.jl`.  Also rearrange the functions in the `base/sparse.jl` and `base/linalg/sparse.jl` files to isolate those that are specific to linear algebra and those that deal more with structure.

This also adds an `etree` function similar to that in MATLAB.
