### PR TITLE
WIP: Add Vagrant configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@
 
 /usr
 /COMMIT
-/contrib/vagrant/.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 
 /usr
 /COMMIT
+/contrib/vagrant/.vagrant

--- a/Make.inc
+++ b/Make.inc
@@ -379,30 +379,37 @@ ifeq ($(BUILD_OS), WINNT)
 define mingw_to_dos
 $(subst /,\\,$(subst $(shell $(2) pwd),$(shell $(2) cmd //C cd),$(abspath $(1))))
 endef
+endif
+
 define symlink_target
 CLEAN_TARGETS += clean-$(2)/$(1)
 clean-$$(abspath $(2)/$(1)): 
+ifeq ($(BUILD_OS), WINNT)
 	@-cmd //C rmdir $$(call mingw_to_dos,$(2)/$(1),cd $(2) &&)
+else
+	@-rm $$(abspath $(2)/$(1))
+endif
 $$(subst $$(abspath $(JULIAHOME))/,,$$(abspath $(2)/$(1))): $$(abspath $(2)/$(1))
 $$(abspath $(2)/$(1)): | $$(abspath $(2))
-	@cmd //C mklink //J $$(call mingw_to_dos,$(2)/$(1),cd $(2) &&) $$(call mingw_to_dos,$(1),) 
+ifeq ($(BUILD_OS), WINNT)
+	@cmd //C mklink //J $$(call mingw_to_dos,$(2)/$(1),cd $(2) &&) $$(call mingw_to_dos,$(1),)
+else ifdef JULIA_VAGRANT_BUILD
+	@cp -R $$(abspath $(1)) $$@
+else
+	@ln -sf $$(abspath $(1)) $$@
+endif
 endef
+
+ifeq ($(BUILD_OS), WINNT)
 spawn = $(1)
 else
-define symlink_target
-CLEAN_TARGETS += clean-$(2)/$(1)
-clean-$$(abspath $(2)/$(1)): 
-	@-rm $$(abspath $(2)/$(1))
-$$(subst $$(abspath $(JULIAHOME))/,,$$(abspath $(2)/$(1))): $$(abspath $(2)/$(1))
-$$(abspath $(2)/$(1)): | $$(abspath $(2))
-	@ln -sf $$(abspath $(1)) $$@ 
-endef
-ifeq ($(OS),WINNT)
+ifeq ($(OS), WINNT)
 spawn = wine cmd /c "set PATH=$(WINE_PATH) && $$(exec winepath -w '$(1)')"
 else
 spawn = $(1)
 endif
 endif
+
 exec = $(shell $(call spawn,$(1)))
 
 wine_pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(shell printf %s\n '$(2)' | xargs -d";" winepath -u | tr '\n' ' '))))

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,9 @@ julia-debug julia-release:
 	@$(MAKE) $(QUIET_MAKE) -C base
 	@$(MAKE) $(QUIET_MAKE) -C ui $@
 ifneq ($(OS),WINNT)
+ifndef JULIA_VAGRANT_BUILD
 	@ln -sf $(BUILD)/bin/$@-$(DEFAULT_REPL) julia
+endif
 endif
 
 $(BUILD)/share/julia/helpdb.jl: doc/helpdb.jl | $(BUILD)/share/julia

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ You must use the `gmake` command on FreeBSD instead of `make`.
 
 In order to build Julia on Windows, see [README.windows](https://github.com/JuliaLang/julia/blob/master/README.windows.md).
 
+### Vagrant
+
+Julia can be developed in an isolated Vagrant environment. See [the Vagrant README](https://github.com/JuliaLang/julia/blob/master/contrib/vagrant/README.md) for details.
+
 <a name="Required-Build-Tools-External-Libraries"/>
 ## Required Build Tools and External Libraries
 

--- a/contrib/vagrant/.gitignore
+++ b/contrib/vagrant/.gitignore
@@ -1,0 +1,1 @@
+/.vagrant

--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -1,0 +1,43 @@
+## Developing Julia with Vagrant
+
+Vagrant is a system that creates lightweight, self-contained development
+environments as virtual machines. This directory contains a Vagrantfile which
+will provision a headless 64-bit Ubuntu 12.04 Precise Pangolin virtual machine
+on VirtualBox for building Julia.
+
+### Requirements
+
+To develop under Vagrant, you will first need to install [Oracle
+VirtualBox](https://www.virtualbox.org/wiki/Downloads) and
+[Vagrant](http://downloads.vagrantup.com/). Then, from a command line, enter
+the `contrib/vagrant` directory, and enter:
+
+```
+$ vagrant up
+```
+
+A virtual machine will be downloaded if needed, created, and provisioned with
+the dependencies to build Julia. By default, it exposes an SSH server to your
+local machine on port 2222. See the [Vagrant
+documentation](http://docs.vagrantup.com/v2/) for complete details on using
+Vagrant.
+
+### Building Julia
+
+Before attempting to build Julia from the Vagrant machine, you must ensure that
+submodules have been initialized and are up to date. On the host system, from
+the top level Julia repository directory, run:
+
+```
+$ git submodule init
+$ git submodule update
+```
+
+The Julia repository is exposed to the VM using a VirtualBox shared folder as
+`~/julia`. To speed up the build process and handle some limitations of
+VirtualBox shared folders, the contents of the julia-dependencies PPA are
+downloaded during provisioning. To take advantage of these dependencies, use
+the `jlmake` alias in place of `make`.
+
+When the build is complete, you can run
+`~/julia/usr/bin/julia-release-readline` to start Julia.

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -1,0 +1,58 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+rm /home/vagrant/postinstall.sh
+
+cat - > /home/vagrant/.bash_aliases <<"EOF"
+export JULIA_VAGRANT_BUILD=1
+BUILDOPTS="LLVM_CONFIG=llvm-config-3.2"
+for lib in LLVM ZLIB SUITESPARSE ARPACK BLAS FFTW LAPACK GMP MPFR PCRE LIBUNWIND READLINE GRISU OPENLIBM RMATH LIBUV; do
+    export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1"
+done
+
+alias jlmake="make $BUILDOPTS"
+EOF
+
+apt-get update -qq -y
+apt-get install python-software-properties -y
+add-apt-repository ppa:staticfloat/julia-deps -y
+apt-get update -qq -y
+apt-get install g++ git make patchelf gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libreadline-dev libdouble-conversion-dev libopenlibm-dev librmath-dev libuv-julia-dev libmpfr-dev -y
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "precise64"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "../..", "/home/vagrant/julia"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  config.vm.provision :shell, :inline => $script
+end


### PR DESCRIPTION
Provides a ready-to-go environment for working on Julia, with an eye towards Windows developers who would like to contribute to core, or to test on Linux. The Julia repository is shared between the host and guest, so editing files can be done in the host environment in your editor of choice.

It's a bit clunky--you have to run `git submodule init` and `git submodule update` from the host before our Make process gets to it or it messes up the submodule references; you also need to use the `make $BUILDOPTS` (aliased to `jlmake`) to ensure you get a fully USE_SYSTEM_\* build. At the very least, a full build in VirtualBox on Windows is impossible due to the `aux/` directory in the libunwind tarball.

Due to the limitations of VirtualBox shared folders, symlinks need to be replaced with either file copies or elided entirely.
