### PR TITLE
RFC: add ``locateat``, which is similar to Matlab's ``ismember``

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1371,6 +1371,13 @@ end
 indmax(a) = findmax(a)[2]
 indmin(a) = findmin(a)[2]
 
+# similar to Matlab's ismember
+# returns a vector containing the highest index in b for each value in a that is a member of b
+function indexin{T}(a::AbstractArray{T}, b::AbstractArray{T})
+    bdict = Dict(b, 1:length(b))
+    [get(bdict, i, 0) for i in a]
+end
+
 # findin (the index of intersection)
 function findin(a, b::Range1)
     ind = Array(Int, 0)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -491,6 +491,7 @@ export
     hcat,
     hvcat,
     ind2sub,
+    indexin,
     indmax,
     indmin,
     invperm,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -304,6 +304,12 @@ Iterable Collections
 .. function:: contains(itr, x) -> Bool
 
    Determine whether a collection contains the given value, ``x``.
+   
+.. function:: indexin(a, b)
+
+   Returns a vector containing the highest index in ``b``
+   for each value in ``a`` that is a member of ``b`` .
+   The output vector contains 0 wherever ``a`` is not a member of ``b``.
 
 .. function:: findin(a, b)
 


### PR DESCRIPTION
Add a function `locateat{T}(a::AbstractArray{T}, b::AbstractArray{T})` , which is similar to Matlab's `ismember`.

It returns a vector containing the highest index in `b` for each value in `a` that is a member of `b` .
The output vector contains 0 wherever `a` is not a member of `b`.

```
julia> locateat([2 3 4],[2 9 6 4])
3-element Int32 Array:
 1
 0
 4

julia> locateat(["a";"b"],["a" "b";"c" "d"])
2-element Int32 Array:
 1
 3
```
