### PR TITLE
changes to support Amazon EC2 instances via addprocs

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -907,18 +907,22 @@ function start_remote_workers(machines, cmds, tunnel=false)
         stream.line_buffered = true
         while true
             conninfo = readline(stream)
-            hostname, port = parse_connection_info(conninfo)
-            if hostname != ""
+            private_hostname, port = parse_connection_info(conninfo)
+            if private_hostname != ""
                 break
             end
         end
+        
+        s = split(machines[i],'@')
+        if length(s) > 1
+            user = s[1]
+            hostname = s[2]
+        else
+            user = ENV["USER"]
+            hostname = s[1]
+        end
+        
         if tunnel
-            s = split(machines[i],'@')
-            if length(s) > 1
-                user = s[1]
-            else
-                user = ENV["USER"]
-            end
             w[i] = Worker(hostname, port, user)
         else
             w[i] = Worker(hostname, port)
@@ -974,10 +978,11 @@ end
 # the tunnel is only used from the head (process 1); the nodes are assumed
 # to be mutually reachable without a tunnel, as is often the case in a cluster.
 function addprocs(machines::AbstractVector;
-                  tunnel=false, dir=JULIA_HOME, exename="./julia-release-basic")
+                  tunnel=false, dir=JULIA_HOME, exename="./julia-release-basic", sshoptions=[])
+    if isa(sshoptions, String) sshoptions = split(sshoptions) end
     add_workers(PGRP,
         start_remote_workers(machines,
-            map(m->detach(`ssh -n $m "bash -l -c \"cd $dir && $exename --worker\""`),
+            map(m->detach(`ssh -n $sshoptions $m "bash -l -c \"cd $dir && $exename --worker\""`),
                 machines),
             tunnel))
 end


### PR DESCRIPTION
In order to provide an ability for users to use `addprocs()` on EC2 instances from a local Julia console, the following changes have been done.
1. `addprocs()` enhanced to accept a keyword argument `sshoptions`. The requirement came up in supporting access to EC2 instances which would usually require the specification of a keyfile using `ssh`s `-i` option and also  `-o` options to disable the prompt for adding a new verified host.

For example, sshoptions may be specified by the user as `"-i /home/amitm/ec2instkey.pem -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"` 
1. `start_remote_workers()` changed to use the remote hostname from the machinename supplied. It currently uses the ip-address provided by the remote host as part of the initial handshake. This does not work for EC2 instances  since they are behind a firewall and NATed. The EC2 instance has a public ip-address(and hostname) different from the private ip-address actually bound to the NIC on the remote host. 

The function has been changed to use the hostname from the machinename supplied. 
