### PR TITLE
Change default eigensolver for tridiagonal problems.

### DIFF
--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -1512,10 +1512,11 @@ for (stev, stebz, stegr, stein, elty) in
         #*  The spectrum may be computed either completely or partially by specifying
         #*  either an interval (VL,VU] or a range of indices IL:IU for the desired
         #*  eigenvalues.
-        function stegr!(jobz::BlasChar, range::BlasChar, dv::Vector{$elty}, ev::Vector{$elty}, vl::Real, vu::Real, il::Integer, iu::Integer, abstol::Real)
+        function stegr!(jobz::BlasChar, range::BlasChar, dv::Vector{$elty}, ev::Vector{$elty}, vl::Real, vu::Real, il::Integer, iu::Integer)
             n = length(dv)
             if length(ev) != (n-1) throw(DimensionMismatch("stebz!")) end
             eev = [ev, zero($elty)]
+            abstol = Array($elty, 1)
             m = Array(BlasInt, 1)
             w = Array($elty, n)
             ldz = jobz == 'N' ? 1 : n
@@ -1535,11 +1536,11 @@ for (stev, stebz, stegr, stein, elty) in
                     Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}),
                     &jobz, &range, &n, dv,
                     eev, &vl, &vu, &il,
-                    &iu, &abstol, m, w,
+                    &iu, abstol, m, w,
                     Z, &ldz, isuppz, work,
                     &lwork, iwork, &liwork, info)
                 if i == 1
-                    lwork = int(work[1])
+                    lwork = blas_int(work[1])
                     work = Array($elty, lwork)
                     liwork = iwork[1]
                     iwork = Array(BlasInt, liwork)
@@ -1598,8 +1599,7 @@ for (stev, stebz, stegr, stein, elty) in
         end
     end
 end
-stegr!(jobz::BlasChar, dv::Vector, ev::Vector) = stegr!(jobz, 'A', dv, ev, 0.0, 0.0, 0, 0, -1.0)
-stegr!(dv::Vector, ev::Vector) = stegr!('N', 'A', dv, ev, 0.0, 0.0, 0, 0, -1.0)
+stegr!(jobz::BlasChar, dv::Vector, ev::Vector) = stegr!(jobz, 'A', dv, ev, 0.0, 0.0, 0, 0)
         
 # Allow user to skip specification of iblock and isplit
 stein!(dv::Vector, ev::Vector, w_in::Vector)=stein!(dv, ev, w_in, zeros(BlasInt,0), zeros(BlasInt,0))

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -65,9 +65,9 @@ end
 
 #Wrap LAPACK DSTE{GR,BZ} to compute eigenvalues
 eig(m::SymTridiagonal) = LAPACK.stegr!('V', copy(m.dv), copy(m.ev))
-eigvals(m::SymTridiagonal, il::Int, iu::Int) = LAPACK.stebz!('I', 'E', 0.0, 0.0, il, iu, -1.0, copy(m.dv), copy(m.ev))[1]
-eigvals(m::SymTridiagonal, vl::Float64, vu::Float64) = LAPACK.stebz!('V', 'E', vl, vu, 0, 0, -1.0, copy(m.dv), copy(m.ev))[1]
-eigvals(m::SymTridiagonal) = LAPACK.stebz!('A', 'E', 0.0, 0.0, 0, 0, -1.0, copy(m.dv), copy(m.ev))[1]
+eigvals(m::SymTridiagonal, il::Int, iu::Int) = LAPACK.stegr!('N', 'I', copy(m.dv), copy(m.ev), 0.0, 0.0, il, iu)[1]
+eigvals{T<:BlasFloat}(m::SymTridiagonal, vl::T, vu::T) = LAPACK.stegr!('N', 'V', copy(m.dv), copy(m.ev), vl, vu, 0, 0)[1]
+eigvals(m::SymTridiagonal) = LAPACK.stev!('N', m.dv, m.ev)[1]
 
 #Computes largest and smallest eigenvalue
 eigmax(m::SymTridiagonal) = eigvals(m, size(m, 1), size(m, 1))[1]


### PR DESCRIPTION
As a consequence of JuliaLang/LinearAlgebra.jl#1511. Use stev! when all values are requested and stegr! when only some of the values are requested.
