### PR TITLE
delete / out of order dequeue on PriorityQueue

### DIFF
--- a/base/collections.jl
+++ b/base/collections.jl
@@ -271,6 +271,16 @@ function dequeue!(pq::PriorityQueue)
     x[1]
 end
 
+function dequeue!(pq::PriorityQueue, key)
+     !haskey(pq.index, key) && return
+     idx = delete!(pq.index, key)
+     splice!(pq.xs, idx)
+     for (k,v) in pq.index
+       (v >= idx) && (pq.index[k] = (v-1))
+     end
+     key
+end
+
 
 # Unordered iteration through key value pairs in a PriorityQueue
 start(pq::PriorityQueue) = start(pq.index)

--- a/base/collections.jl
+++ b/base/collections.jl
@@ -272,7 +272,7 @@ function dequeue!(pq::PriorityQueue)
 end
 
 function dequeue!(pq::PriorityQueue, key)
-     !haskey(pq.index, key) && return
+     !haskey(pq.index, key) && throw(KeyError(key))
      idx = delete!(pq.index, key)
      splice!(pq.xs, idx)
      for (k,v) in pq.index

--- a/test/priorityqueue.jl
+++ b/test/priorityqueue.jl
@@ -52,6 +52,13 @@ end
 
 test_issorted!(pq, priorities)
 
+# dequeuing
+pq = PriorityQueue(priorities)
+@test nothing == dequeue!(pq, 0)
+@test 10 == dequeue!(pq, 10)
+while !isempty(pq)
+    @test 10 != dequeue!(pq)
+end
 
 # low level heap operations
 xs = heapify!([v for v in values(priorities)])

--- a/test/priorityqueue.jl
+++ b/test/priorityqueue.jl
@@ -54,7 +54,12 @@ test_issorted!(pq, priorities)
 
 # dequeuing
 pq = PriorityQueue(priorities)
-@test nothing == dequeue!(pq, 0)
+try
+    dequeue!(pq, 0)
+    error("should have resulted in KeyError")
+catch ex
+    @test isa(ex, KeyError)
+end
 @test 10 == dequeue!(pq, 10)
 while !isempty(pq)
     @test 10 != dequeue!(pq)


### PR DESCRIPTION
A dequeue! variant that removes the specified key from the queue. 
Useful for just deleting an entry from the queue.
