### PR TITLE
RFC: Macro for delegating methods to the fields of a composite type

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -995,6 +995,7 @@ export
     peakflops,
     tty_cols,
     tty_rows,
+    @delegate,
 
 # I/O and events
     accept,

--- a/base/util.jl
+++ b/base/util.jl
@@ -405,3 +405,19 @@ function methodswith(io::IO, t::Type, showparents::Bool)
         end
     end
 end
+
+macro delegate(source, targets)
+    typename = esc(source.args[1])
+    fieldname = esc(Expr(:quote, source.args[2].args[1]))
+    funcnames = targets.args
+    n = length(funcnames)
+    fdefs = Array(Any, n)
+    for i in 1:n
+        funcname = esc(funcnames[i])
+        fdefs[i] = quote
+                     ($funcname)(a::($typename), args...) =
+                       ($funcname)(a.($fieldname), args...)
+                   end
+    end
+    return Expr(:block, fdefs...)
+end


### PR DESCRIPTION
As discussed long ago on the mailing list (https://groups.google.com/d/msg/julia-dev/MV7lYRgAcB0/s6_RMeHLpEYJ), I've created a simple `@delegate` macro that allows one to delegate methods to the fields of a composite types. An example is shown below in which a new container type can delegate methods like `size` and `length` to an array contained inside of it:

```
type MyContainer
    elems::Array
end

importall Base

@delegate MyContainer.elems [size, length]

x = MyContainer([1, 2, 3, 4])

size(x)
length(x)
```

Right now, this only supports functions for which the first argument is the field which delegated methods need. Before we merge this, I think we'll want to find a clean generalization.
