### PR TITLE
[RFC] Faster Enumerate and Zip iterators + inlining issues

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -1,46 +1,83 @@
 # enumerate
 
-type Enumerate{I}
+immutable Enumerate{I}
     itr::I
 end
 enumerate(itr) = Enumerate(itr)
 
-length(e::Enumerate) = length(e.itr)
-start(e::Enumerate) = (1, start(e.itr))
-function next(e::Enumerate, state)
-    v, s = next(e.itr, state[2])
-    (state[1],v), (state[1]+1,s)
+immutable EnumerateState{S}
+    i::Int
+    s::S
 end
-done(e::Enumerate, state) = done(e.itr, state[2])
+
+length(e::Enumerate) = length(e.itr)
+start(e::Enumerate) = EnumerateState(1, start(e.itr))
+function next(e::Enumerate, state::EnumerateState)
+    v, s = next(e.itr, state.s)
+    (state.i,v), EnumerateState(state.i+1,s)
+end
+done(e::Enumerate, state::EnumerateState) = done(e.itr, state.s)
 
 # zip
 
-type Zip
-    itrs::Vector{Any}
-    vals::Vector{Any}  # temp storage for use by next()
-    Zip(itrs...) = new({itrs...}, Array(Any, length(itrs)))
+immutable Zip{N}
+    itrs::NTuple{N}
+    Zip(itrs...) = new(ntuple(i->itrs[i], length(itrs)))
 end
-zip(itrs...) = Zip(itrs...)
+zip(itrs...) = Zip{length(itrs)}(itrs...)
 
 length(z::Zip) = min(length, z.itrs)
-start(z::Zip) = { start(itr) for itr in z.itrs }
-function next(z::Zip, state)
-    for i = 1:length(z.itrs)
-        z.vals[i], state[i] = next(z.itrs[i], state[i])
-    end
-    tuple(z.vals...), state
+
+# This macro generates body functions like this:
+#
+#    (start(z.itrs[1]), start(z.itrs[2]), start(z.itrs[3]))
+#
+macro zip_start_ex(z,n)
+    aa = {Expr(:call, :(Base.start), Expr(:ref, :($(esc(z)).itrs), i)) for i=1:n}
+    Expr(:tuple, aa...)
 end
-function done(z::Zip, state)
-    if isempty(z.itrs)
-        return true
-    end
-    for i = 1:length(z.itrs)
-        if done(z.itrs[i], state[i])
-            return true
-        end
-    end
-    return false
+
+start(z::Zip{0}) = ()
+for i=1:10 @eval start(z::Zip{$i}) = @zip_start_ex(z, $i) end
+start{N}(z::Zip{N}) = (ntuple(i->start(z.itrs[i]), N))
+
+# This macro generates body functions like this:
+#
+#    v1,s1 = next(z.itrs[1], state[1])
+#    v2,s2 = next(z.itrs[2], state[2])
+#    v3,s3 = next(z.itrs[3], state[3])
+#    (v1,v2,v3,),(s1,s2,s3,)
+#
+macro zip_next_ex(z,state,n)
+    v = [gensym("v") for i=1:n]
+    s = [gensym("s") for i=1:n]
+    a = {Expr(:(=),
+           Expr(:tuple, v[i], s[i]),
+           Expr(:call, :(Base.next), Expr(:ref, :($(esc(z)).itrs), i), Expr(:ref, :($(esc(state))), i)))
+           for i = 1:n}
+    r = Expr(:tuple, Expr(:tuple, v...), Expr(:tuple, s...))
+    Expr(:block, a..., r)
 end
+
+next(z::Zip{0}, state::NTuple{0}) = ((), ())
+for i=1:10 @eval next(z::Zip{$i}, state::NTuple{$i}) = @zip_next_ex(z, state, $i) end
+function next{N}(z::Zip{N}, state::NTuple{N})
+    valstates = ntuple(i->next(z.itrs[i], state[i]), N)
+    ntuple(i->valstates[i][1], N), ntuple(i->valstates[i][2], N)
+end
+
+# This macro generates body functions like this:
+#
+#    done(z.itrs[1], state[1]) || done(z.itrs[2], state[2]) || done(z.itrs[3], state[3])
+#
+macro zip_done_ex(z,state,n)
+    a = {Expr(:call, :(Base.done), Expr(:ref, :($(esc(z)).itrs), i), Expr(:ref, :($(esc(state))), i)) for i = 1:n}
+    Expr(:||, a...)
+end
+
+done(z::Zip{0}, state::NTuple{0}) = true
+for i=1:10 @eval done(z::Zip{$i}, state::NTuple{$i}) = @zip_done_ex(z, state, $i) end
+done{N}(z::Zip{N}, state::NTuple{N}) = any(ntuple(i->done(z.itrs[i], state[i]),N))
 
 # filter
 


### PR DESCRIPTION
I tried to improve the performance of `Enumerate` and `Zip`. The gains are not huge, but see below.

For the case of `Enumerate`, it basically just amounts at changing the state variable from a `Tuple` to an immutable `EnumState`, with type parameters. I'm actually a little surprised that this makes any difference at all. However, the most surprising fact is what happens when I manually inline the `start`, `next` and `done` calls:

```
             Function   Elapsed Relative Replications
[1,]          "olden"   3.31237  276.495           10
[2,]    "oldeninline"   1.03624  86.4982           10
[3,]          "newen"   2.03722  170.053           10
[4,]    "neweninline" 0.0120131  1.00278           10
[5,]       "manualen" 0.0119799      1.0           10
```

As can be seen, inlining helps also in the case of the current version (`olden` vs `oldeninline`), but the performance improves dramatically when inlining the version of this pull request (`newen` vs `neweninline`) and get on par with manual enumeration (`manualen`). The code for the benchmark is [here](https://gist.github.com/carlobaldassi/5718864).

For the case of `Zip`, code changes are more substantial. Besides immutability, I tried to leverage dispatch as much as possible, in this case based on the size of the tuples used for states (custom states didn't provide any advantage here). I also used macros to avoid calls to anonymous functions: I hope I did them right (a review would be appreciated). Possibly, the increase in code complexity will be too much compared to the modest performance gains, which are less than 2x. Here are the benchmarks for zipping 2 or 3 iterables.

```
# PERF ZIP 2
#
              Function    Elapsed Relative Replications
[1,]          "oldzip"    2.58043  754.516          100
[2,]    "oldzipinline"    2.51329  734.884          100
[3,]          "newzip"    1.56089  456.404          100
[4,]    "newzipinline"   0.942679  275.638          100
[5,]       "manualzip" 0.00341999      1.0          100

# PERF ZIP 3
#
              Function    Elapsed Relative Replications
[1,]          "oldzip"    3.96949  870.477          100
[2,]    "oldzipinline"     3.5982  789.055          100
[3,]          "newzip"    2.21593  485.936          100
[4,]    "newzipinline"    1.52698  334.855          100
[5,]       "manualzip" 0.00456013      1.0          100
```

Again, inlining helps in all cases (much more in the `new` cases though), but manual zipping is unmatched by a very large margin, which is kind of disappointing. The code for these benchmarks is in the same gist linked above.
