### PR TITLE
RFC: factorize() and \

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -115,6 +115,7 @@ export
     SVD,
     GeneralizedSVD,
     Hermitian,
+    Symmetric,
     Triangular,
     Diagonal,
     InsertionSort,
@@ -566,6 +567,8 @@ export
     checkbounds,
 
 # linear algebra
+    bkfact,
+    bkfact!,
     chol,
     cholfact,
     cholfact!,
@@ -591,6 +594,8 @@ export
     expm,
     sqrtm,
     eye,
+    factorize,
+    factorize!,
     hessfact,
     hessfact!,
     ishermitian,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -26,10 +26,13 @@ export
     Schur,
     SVD,
     Hermitian,
+    Symmetric,
     Triangular,
     Diagonal,
 
 # Functions
+    bkfact,
+    bkfact!,
     check_openblas,
     chol,
     cholfact,
@@ -57,6 +60,8 @@ export
     expm,
     sqrtm,
     eye,
+    factorize,
+    factorize!,
     gradient,
     hessfact,
     hessfact!,
@@ -158,6 +163,7 @@ include("linalg/factorization.jl")
 include("linalg/bunchkaufman.jl")
 include("linalg/triangular.jl")
 include("linalg/hermitian.jl")
+include("linalg/symmetric.jl")
 include("linalg/woodbury.jl")
 include("linalg/tridiag.jl")
 include("linalg/bidiag.jl")

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -54,9 +54,9 @@ promote_rule{T,S}(::Type{Tridiagonal{T}}, ::Type{Bidiagonal{S}})=Tridiagonal{pro
 
 function show(io::IO, M::Bidiagonal)
     println(io, summary(M), ":")
-    print(io, "diag: ")
+    print(io, " diag:")
     print_matrix(io, (M.dv)')
-    print(io, M.isupper?"\n sup: ":"\n sub: ")
+    print(io, M.isupper?"\nsuper:":"\n  sub:")
     print_matrix(io, (M.ev)')
 end
 
@@ -112,7 +112,7 @@ end
 # solver uses tridiagonal gtsv! 
 function \{T<:BlasFloat}(M::Bidiagonal{T}, rhs::StridedVecOrMat{T})
     if stride(rhs, 1) == 1
-        z = zeros(size(M)[1])
+        z = zeros(size(M, 1) - 1)
         if M.isupper
             return LAPACK.gtsv!(z, copy(M.dv), copy(M.ev), copy(rhs))
         else

--- a/base/linalg/bunchkaufman.jl
+++ b/base/linalg/bunchkaufman.jl
@@ -6,21 +6,50 @@ type BunchKaufman{T<:BlasFloat} <: Factorization{T}
     LD::Matrix{T}
     ipiv::Vector{BlasInt}
     uplo::Char
-    function BunchKaufman(A::Matrix{T}, uplo::Char)
-        LD, ipiv = LAPACK.sytrf!(uplo , copy(A))
-        new(LD, ipiv, uplo)
-    end
+    symmetric::Bool
 end
-BunchKaufman{T<:BlasFloat}(A::StridedMatrix{T}, uplo::Char) = BunchKaufman{T}(A, uplo)
-BunchKaufman{T<:Real}(A::StridedMatrix{T}, uplo::Char) = BunchKaufman(float64(A), uplo)
-BunchKaufman{T<:Number}(A::StridedMatrix{T}) = BunchKaufman(A, 'U')
+function bkfact!{T<:BlasReal}(A::StridedMatrix{T}, uplo::Symbol)
+    LD, ipiv = LAPACK.sytrf!(string(uplo)[1] , A)
+    BunchKaufman(LD, ipiv, string(uplo)[1], true)
+end
+function bkfact!{T<:BlasReal}(A::StridedMatrix{T}, uplo::Symbol, symmetric::Bool)
+	if symmetric return bkfact!(A, uplo) end
+	error("The Bunch-Kaufman decomposition is only valid for symmetric matrices")
+end
+function bkfact!{T<:BlasComplex}(A::StridedMatrix{T}, uplo::Symbol, symmetric::Bool)
+    if symmetric
+    	LD, ipiv = LAPACK.sytrf!(string(uplo)[1] , A)
+    else
+    	LD, ipiv = LAPACK.hetrf!(string(uplo)[1] , A)
+    end
+    BunchKaufman(LD, ipiv, string(uplo)[1], symmetric)
+end
+bkfact!{T<:BlasComplex}(A::StridedMatrix{T}, uplo::Symbol) = bkfact!(A, uplo, issym(A))
+bkfact!(A::StridedMatrix, args...) = bkfact!(float(A), args...)
+bkfact!{T<:BlasFloat}(A::StridedMatrix{T}) = bkfact!(A, :U)
+bkfact{T<:BlasFloat}(A::StridedMatrix{T}, args...) = bkfact!(copy(A), args...)
+bkfact(A::StridedMatrix, args...) = bkfact!(float(A), args...)
 
 size(B::BunchKaufman) = size(B.LD)
 size(B::BunchKaufman,d::Integer) = size(B.LD,d)
+issym(B::BunchKaufman) = B.symmetric
+ishermitian(B::BunchKaufman) = !B.symmetric
 
-function inv(B::BunchKaufman)
+function inv{T<:BlasReal}(B::BunchKaufman{T})
     symmetrize_conj!(LAPACK.sytri!(B.uplo, copy(B.LD), B.ipiv), B.uplo)
 end
+function inv{T<:BlasComplex}(B::BunchKaufman{T})
+	if issym(B)
+    	symmetrize!(LAPACK.sytri!(B.uplo, copy(B.LD), B.ipiv), B.uplo)
+    else
+    	symmetrize_conj!(LAPACK.hetri!(B.uplo, copy(B.LD), B.ipiv), B.uplo)
+	end
+end
 
-\{T<:BlasFloat}(B::BunchKaufman{T}, R::StridedVecOrMat{T}) =
-    LAPACK.sytrs!(B.uplo, B.LD, B.ipiv, copy(R))
+\{T<:BlasReal}(B::BunchKaufman{T}, R::StridedVecOrMat{T}) = LAPACK.sytrs!(B.uplo, B.LD, B.ipiv, copy(R))
+function \{T<:BlasComplex}(B::BunchKaufman{T}, R::StridedVecOrMat{T})
+	if issym(B)
+    	return LAPACK.sytrs!(B.uplo, B.LD, B.ipiv, copy(R))
+    end
+    return LAPACK.hetrs!(B.uplo, B.LD, B.ipiv, copy(R))
+end

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -346,13 +346,13 @@ expm{T<:Union(Float32,Float64,Complex64,Complex128)}(A::StridedMatrix{T}) = expm
 expm{T<:Integer}(A::StridedMatrix{T}) = expm!(float(A))
 expm(x::Number) = exp(x)
 
-function sqrtm(A::StridedMatrix, cond::Bool)
+function sqrtm{T<:Real}(A::StridedMatrix{T}, cond::Bool)
     m, n = size(A)
     if m != n error("DimentionMismatch") end
-    if ishermitian(A) 
-        return sqrtm(Hermitian(A), cond)
+    if issym(A) 
+        return sqrtm(Symmetric(A), cond)
     else
-        SchurF = schurfact!(iseltype(A,Complex) ? copy(A) : complex(A))
+        SchurF = schurfact!(complex(A))
         R = zeros(eltype(SchurF[:T]), n, n)
         for j = 1:n
             R[j,j] = sqrt(SchurF[:T][j,j])
@@ -375,6 +375,35 @@ function sqrtm(A::StridedMatrix, cond::Bool)
         return (all(imag(retmat) .== 0) ? real(retmat) : retmat)
     end
 end
+function sqrtm{T<:Complex}(A::StridedMatrix{T}, cond::Bool)
+    m, n = size(A)
+    if m != n error("DimentionMismatch") end
+    if ishermitian(A) 
+        return sqrtm(Hermitian(A), cond)
+    else
+        SchurF = schurfact(A)
+        R = zeros(eltype(SchurF[:T]), n, n)
+        for j = 1:n
+            R[j,j] = sqrt(SchurF[:T][j,j])
+            for i = j - 1:-1:1
+                r = SchurF[:T][i,j]
+                for k = i + 1:j - 1
+                    r -= R[i,k]*R[k,j]
+                end
+                if r != 0
+                    R[i,j] = r / (R[i,i] + R[j,j])
+                end
+            end
+        end
+    end
+    retmat = SchurF[:vectors]*R*SchurF[:vectors]'
+    if cond
+        alpha = norm(R)^2/norm(SchurF[:T])
+        return retmat, alpha
+    else
+        return retmat
+    end
+end
 
 sqrtm{T<:Integer}(A::StridedMatrix{T}, cond::Bool) = sqrtm(float(A), cond)
 sqrtm{T<:Integer}(A::StridedMatrix{Complex{T}}, cond::Bool) = sqrtm(complex128(A), cond)
@@ -383,35 +412,92 @@ sqrtm(a::Number) = (b = sqrt(complex(a)); imag(b) == 0 ? real(b) : b)
 sqrtm(a::Complex) = sqrt(a)
 
 function det(A::Matrix)
-    m, n = size(A)
-    if m != n; throw(DimensionMismatch("det only defined for square matrices")); end
     if istriu(A) | istril(A); return det(Triangular(A, :U, false)); end
     return det(lufact(A))
 end
 det(x::Number) = x
 
-logdet(A::Matrix) = logdet(cholfact(A))
+logdet(A::Matrix) = logdet(lufact(A))
 
-function inv{T<:BlasFloat}(A::AbstractMatrix{T})
-    if istriu(A) return inv(Triangular(A, :U)) end
-    if istril(A) return inv(Triangular(A, :L)) end
-    if ishermitian(A) return inv(Hermitian(A)) end
+function inv(A::AbstractMatrix)
+    if istriu(A) | istril(A); return inv(Triangular(A, :U, false)); end
     return inv(lufact(A))
 end
-inv(A::AbstractMatrix) = inv(float(A))
 
-function (\){T<:BlasFloat}(A::StridedMatrix{T}, B::StridedVecOrMat{T})
-    if size(A, 1) == size(A, 2) # Square
-        if istriu(A) return Triangular(A, :U)\B end
-        if istril(A) return Triangular(A, :L)\B end
-        if ishermitian(A) return Hermitian(A)\B end
-        ans, _, _, info = LAPACK.gesv!(copy(A), copy(B))
-        if info > 0; throw(SingularException(info)); end
-        return ans
-    else
-        LAPACK.gelsy!(copy(A), copy(B))[1]
+function factorize!{T}(A::Matrix{T})
+    m, n = size(A)
+    if m == n
+        if m == 1 return A[1] end
+        utri    = true
+        utri1   = true
+        herm    = T <: Complex
+        sym     = true
+        for j = 1:n-1, i = j+1:m
+            if utri1
+                if A[i,j] != 0
+                    utri1 = i == j + 1
+                    utri = false
+                end
+            end
+            if sym
+                sym &= A[i,j] == A[j,i]
+            end
+            if (T <: Complex) & herm
+                herm &= A[i,j] == conj(A[j,i])
+            end
+            if !(utri1|herm|sym) break end
+        end
+        ltri = true
+        ltri1 = true
+        for j = 3:n, i = 1:j-2
+            ltri1 &= A[i,j] == 0
+            if !ltri1 break end
+        end
+        if ltri1
+            for i = 1:n-1
+                if A[i,i+1] != 0
+                    ltri &= false
+                    break
+                end
+            end
+            if ltri
+                if utri
+                    return Diagonal(A)
+                end
+                if utri1
+                    return lufact!(Bidiagonal(diag(A), diag(A, -1), false))
+                end
+                return Triangular(A, :L)
+            end
+            if utri
+                return lufact!(Bidiagonal(diag(A), diag(A, 1), true))
+            end
+            if utri1
+                if (herm & (T <: Complex)) | sym
+                    return ldltd!(SymTridiagonal(diag(A), diag(A, -1)))
+                end
+                return lufact!(Tridiagonal(diag(A, -1), diag(A), diag(A, 1)))
+            end
+        end
+        if utri
+            return Triangular(A, :U)
+        end
+        if herm
+            C, info = LAPACK.potrf!('U', copy(A))
+            if info == 0 return Cholesky(C, 'U') end
+            return factorize!(Hermitian(A))
+        end
+        if sym
+            C, info = LAPACK.potrf!('U', copy(A))
+            if info == 0 return Cholesky(C, 'U') end
+            return factorize!(Symmetric(A))
+        end
+        return lufact!(A)
     end
+    return qrpfact!(A)
 end
+
+factorize(A::AbstractMatrix) = factorize!(copy(A))
 
 (\){T1<:BlasFloat, T2<:BlasFloat}(A::StridedMatrix{T1}, B::StridedVecOrMat{T2}) =
     (\)(convert(Array{promote_type(T1,T2)},A), convert(Array{promote_type(T1,T2)},B))
@@ -420,6 +506,18 @@ end
 (\){T1<:Real, T2<:Real}(A::StridedMatrix{T1}, B::StridedVecOrMat{T2}) = (\)(float64(A), float64(B))
 (\){T1<:Number, T2<:Number}(A::StridedMatrix{T1}, B::StridedVecOrMat{T2}) = (\)(complex128(A), complex128(B))
 (\)(a::Vector, B::StridedVecOrMat) = (\)(reshape(a, length(a), 1), B)
+function (\){T<:BlasFloat}(A::StridedMatrix{T}, B::StridedVecOrMat{T})
+    m, n = size(A)
+    if m == n
+        if istril(A)
+            if istriu(A) return \(Diagonal(A),B) end
+            return \(Triangular(A, :L),B) 
+        end
+        if istriu(A) return \(Triangular(A, :U),B) end
+        return \(lufact(A),B)
+    end
+    return qrpfact(A)\B
+end
 
 ## Moore-Penrose inverse
 function pinv{T<:BlasFloat}(A::StridedMatrix{T})

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -3,6 +3,7 @@
 type Diagonal{T} <: AbstractMatrix{T}
     diag::Vector{T}
 end
+Diagonal(A::Matrix) = Diagonal(diag(A))
 
 size(D::Diagonal) = (length(D.diag),length(D.diag))
 size(D::Diagonal,d::Integer) = d<1 ? error("dimension out of range") : (d<=2 ? length(D.diag) : 1)

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -60,7 +60,7 @@ for (gbtrf, gbtrs, elty) in
             n    = size(AB,2)
             if m != n || m != size(B,1) throw(DimensionMismatch("gbtrs!")) end
             ccall(($(string(gbtrs)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
                    Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},   Ptr{BlasInt},
                    Ptr{BlasInt}),
                   &trans, &n, &kl, &ku, &size(B,2), AB, &stride(AB,2), ipiv,
@@ -93,7 +93,7 @@ for (gebal, gebak, elty, relty) in
             ilo     = Array(BlasInt, 1)
             scale   = Array($relty, n)
             ccall(($(string(gebal)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                    Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$relty}, Ptr{BlasInt}),
                   &job, &n, A, &stride(A,2), ilo, ihi, scale, info)
             if info[1] != 0 throw(LAPACKException(info[1])) end
@@ -112,7 +112,7 @@ for (gebal, gebak, elty, relty) in
             chksquare(V)
             info    = Array(BlasInt, 1)
             ccall(($(string(gebak)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
                    Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                   &job, &side, &size(V,1), &ilo, &ihi, scale, &n, V, &stride(V,2), info)
             if info[1] != 0 throw(LAPACKException(info[1])) end
@@ -231,7 +231,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
             chkstride1(A)
             m, n  = size(A)
             jpvt  = zeros(BlasInt, n)
-            tau   = Array($elty, n)
+            tau   = Array($elty, min(m,n))
             work  = Array($elty, 1)
             lwork = blas_int(-1)
             info  = Array(BlasInt, 1)
@@ -262,6 +262,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
         function geqrt3!(A::StridedMatrix{$elty})
             chkstride1(A)
             m, n = size(A)
+            if m < n throw(DimensionMismatch("Matrix cannot have less rows than columns")) end
             lda = max(1, stride(A, 2))
             T = Array($elty, n, n)
             info = Array(BlasInt, 1)
@@ -348,6 +349,82 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
     end
 end
 
+## Complete orthogonaliztion tools
+for (tzrzf, ormrz, elty) in 
+    ((:dtzrzf_,:dormrz_,:Float64),
+     (:stzrzf_,:sormrz_,:Float32),
+     (:ztzrzf_,:zunmrz_,:Complex128),
+     (:ctzrzf_,:cunmrz_,:Complex64))
+    @eval begin
+ #      *       SUBROUTINE ZTZRZF( M, N, A, LDA, TAU, WORK, LWORK, INFO )
+ #   22 * 
+ #   23 *       .. Scalar Arguments ..
+ #   24 *       INTEGER            INFO, LDA, LWORK, M, N
+ #   25 *       ..
+ #   26 *       .. Array Arguments ..
+ #   27 *       COMPLEX*16         A( LDA, * ), TAU( * ), WORK( * )
+        function tzrzf!(A::StridedMatrix{$elty})
+            m, n = size(A)
+            if n < m throw(DimensionMismatch("Matrix cannot have fewer columns than rows")) end
+            lda = max(1, m)
+            tau = Array($elty, m)
+            work = Array($elty, 1)
+            lwork = -1
+            info = Array(BlasInt, 1)
+            for i = 1:2
+                ccall(($(string(tzrzf)), liblapack), Void,
+                    (Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                     Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+                    &m, &n, A, &lda, 
+                    tau, work, &lwork, info)
+                if i == 1
+                    lwork = blas_int(real(work[1]))
+                    work = Array($elty, lwork)
+                end
+            end
+            if info[1] != 0 throw(LAPACKException(info[1])) end
+            return A, tau
+        end
+   # 21 *       SUBROUTINE ZUNMRZ( SIDE, TRANS, M, N, K, L, A, LDA, TAU, C, LDC,
+   # 22 *                          WORK, LWORK, INFO )
+   # 23 * 
+   # 24 *       .. Scalar Arguments ..
+   # 25 *       CHARACTER          SIDE, TRANS
+   # 26 *       INTEGER            INFO, K, L, LDA, LDC, LWORK, M, N
+   # 27 *       ..
+   # 28 *       .. Array Arguments ..
+   # 29 *       COMPLEX*16         A( LDA, * ), C( LDC, * ), TAU( * ), WORK( * )
+        function ormrz!(side::BlasChar, trans::BlasChar, A::StridedMatrix{$elty}, tau::StridedVector{$elty}, C::StridedMatrix{$elty})
+            m, n = size(C)
+            k = length(tau)
+            l = size(A, 2) - size(A, 1)
+            lda = max(1, k)
+            ldc = max(1, m)
+            work = Array($elty, 1)
+            lwork = -1
+            info = Array(BlasInt, 1)
+            for i = 1:2
+                ccall(($(string(ormrz)), liblapack), Void,
+                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt},
+                     Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                     Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
+                     Ptr{BlasInt}, Ptr{BlasInt}),
+                    &side, &trans, &m, &n, 
+                    &k, &l, A, &lda, 
+                    tau, C, &ldc, work, 
+                    &lwork, info)
+                if i == 1
+                    lwork = blas_int(real(work[1]))
+                    work = Array($elty, lwork)
+                end
+            end
+            if info[1] != 0 throw(LAPACKException(info[1])) end
+            return C
+        end
+    end
+end
+
+
 ## (GE) general matrices, solvers with factorization, solver and inverse
 for (gels, gesv, getrs, getri, elty) in
     ((:dgels_,:dgesv_,:dgetrs_,:dgetri_,:Float64),
@@ -369,7 +446,7 @@ for (gels, gesv, getrs, getri, elty) in
             lwork = blas_int(-1)
             for i in 1:2
                 ccall(($(string(gels)),liblapack), Void,
-                      (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
+                      (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
                        Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                        Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                       &(btrn?'T':'N'), &m, &n, &size(B,2), A, &stride(A,2),
@@ -420,7 +497,7 @@ for (gels, gesv, getrs, getri, elty) in
             nrhs    = size(B, 2)
             info    = Array(BlasInt, 1)
             ccall(($(string(getrs)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                    Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                   &trans, &n, &size(B,2), A, &stride(A,2), ipiv, B, &stride(B,2), info)
             if info[1] != 0 throw(LAPACKException(info[1])) end
@@ -720,7 +797,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
             for i = 1:2
                 if cmplx
                     ccall(($(string(geev)),liblapack), Void,
-                          (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty},
+                          (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty},
                            Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, 
                            Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                            Ptr{$relty}, Ptr{BlasInt}),
@@ -728,7 +805,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
                           work, &lwork, rwork, info)
                 else
                     ccall(($(string(geev)),liblapack), Void,
-                          (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty},
+                          (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty},
                            Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{$elty},
                            Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
                            Ptr{BlasInt}, Ptr{BlasInt}),
@@ -782,7 +859,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
             for i = 1:2
                 if cmplx
                     ccall(($(string(gesdd)),liblapack), Void,
-                          (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
+                          (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
                            Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt},
                            Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                            Ptr{$relty}, Ptr{BlasInt}, Ptr{BlasInt}),
@@ -790,7 +867,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
                           work, &lwork, rwork, iwork, info)
                 else
                     ccall(($(string(gesdd)),liblapack), Void,
-                          (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
+                          (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
                            Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt},
                            Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                            Ptr{BlasInt}, Ptr{BlasInt}),
@@ -832,7 +909,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
             for i in 1:2
                 if cmplx
                     ccall(($(string(gesvd)),liblapack), Void,
-                          (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt},
+                          (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt},
                            Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty},
                            Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
                            Ptr{BlasInt}, Ptr{$relty}, Ptr{BlasInt}),
@@ -840,7 +917,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
                           work, &lwork, rwork, info)
                 else
                     ccall(($(string(gesvd)),liblapack), Void,
-                          (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt},
+                          (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt},
                            Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty},
                            Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
                            Ptr{BlasInt}, Ptr{BlasInt}),
@@ -893,7 +970,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
             info = Array(BlasInt, 1)
             if cmplx
                 ccall(($(string(ggsvd)),liblapack), Void,
-                    (Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt},
+                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt},
                     Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
                     Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                     Ptr{$relty}, Ptr{$relty}, Ptr{$elty}, Ptr{BlasInt},
@@ -907,7 +984,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
                     work, rwork, iwork, info)
             else
                 ccall(($(string(ggsvd)),liblapack), Void,
-                    (Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt},
+                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt},
                     Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
                     Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                     Ptr{$relty}, Ptr{$relty}, Ptr{$elty}, Ptr{BlasInt},
@@ -936,12 +1013,6 @@ for (ggev, elty) in
     @eval begin
     #       SUBROUTINE DGGEV( JOBVL, JOBVR, N, A, LDA, B, LDB, ALPHAR, ALPHAI,
 #      $                  BETA, VL, LDVL, VR, LDVR, WORK, LWORK, INFO )
-# *
-# *  -- LAPACK driver routine (version 3.2) --
-# *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
-# *  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
-# *     November 2006
-# *
 # *     .. Scalar Arguments ..
 #       CHARACTER          JOBVL, JOBVR
 #       INTEGER            INFO, LDA, LDB, LDVL, LDVR, LWORK, N
@@ -995,12 +1066,6 @@ for (ggev, elty, relty) in
     @eval begin
       # SUBROUTINE ZGGEV( JOBVL, JOBVR, N, A, LDA, B, LDB, ALPHA, BETA,
      # $                  VL, LDVL, VR, LDVR, WORK, LWORK, RWORK, INFO )
-# *
-# *  -- LAPACK driver routine (version 3.2) --
-# *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
-# *  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
-# *     November 2006
-# *
 # *     .. Scalar Arguments ..
       # CHARACTER          JOBVL, JOBVR
       # INTEGER            INFO, LDA, LDB, LDVL, LDVR, LWORK, N
@@ -1049,6 +1114,67 @@ for (ggev, elty, relty) in
         end
     end
 end
+# One step incremental condition estimation of max/min singular values
+for (laic1, elty) in
+    ((:dlaic1_,:Float64),
+     (:slaic1_,:Float32))
+    @eval begin
+   # 21 *       SUBROUTINE DLAIC1( JOB, J, X, SEST, W, GAMMA, SESTPR, S, C )
+   # 22 * 
+   # 23 *       .. Scalar Arguments ..
+   # 24 *       INTEGER            J, JOB
+   # 25 *       DOUBLE PRECISION   C, GAMMA, S, SEST, SESTPR
+   # 26 *       ..
+   # 27 *       .. Array Arguments ..
+   # 28 *       DOUBLE PRECISION   W( J ), X( J )
+        function laic1!(job::Integer, x::StridedVector{$elty}, sest::$elty, w::StridedVector{$elty}, gamma::$elty)
+            j = length(x)
+            if j != length(w) error(DimensionMismatch("Vectors must have same length")) end
+            sestpr = Array($elty, 1)
+            s = Array($elty, 1)
+            c = Array($elty, 1)
+            ccall(($(string(laic1)), liblapack), Void,
+                (Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty},
+                 Ptr{$elty}, Ptr{$elty}, Ptr{$elty}, Ptr{$elty},
+                 Ptr{$elty}),
+                &job, &j, x, &sest, 
+                w, &gamma, sestpr, s, 
+                c)
+            return sestpr[1], s[1], c[1]
+        end
+    end
+end
+for (laic1, elty, relty) in
+    ((:zlaic1_,:Complex128,:Float64),
+     (:claic1_,:Complex64,:Float32))
+    @eval begin
+   # 21 *       SUBROUTINE ZLAIC1( JOB, J, X, SEST, W, GAMMA, SESTPR, S, C )
+   # 22 * 
+   # 23 *       .. Scalar Arguments ..
+   # 24 *       INTEGER            J, JOB
+   # 25 *       DOUBLE PRECISION   SEST, SESTPR
+   # 26 *       COMPLEX*16         C, GAMMA, S
+   # 27 *       ..
+   # 28 *       .. Array Arguments ..
+   # 29 *       COMPLEX*16         W( J ), X( J )
+        function laic1!(job::Integer, x::StridedVector{$elty}, sest::$relty, w::StridedVector{$elty}, gamma::$elty)
+            j = length(x)
+            if j != length(w) error(DimensionMismatch("Vectors must have same length")) end
+            sestpr = Array($relty, 1)
+            s = Array($elty, 1)
+            c = Array($elty, 1)
+            ccall(($(string(laic1)), liblapack), Void,
+                (Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$relty},
+                 Ptr{$elty}, Ptr{$elty}, Ptr{$relty}, Ptr{$elty},
+                 Ptr{$elty}),
+                &job, &j, x, &sest, 
+                w, &gamma, sestpr, s, 
+                c)
+            return sestpr[1], s[1], c[1]
+        end
+    end
+end
+
 
 # (GT) General tridiagonal, decomposition, solver and direct solver
 for (gtsv, gttrf, gttrs, elty) in
@@ -1115,7 +1241,7 @@ for (gtsv, gttrf, gttrs, elty) in
             if n != size(B,1) throw(DimensionMismatch("gttrs!")) end
             info = Array(BlasInt, 1)
             ccall(($(string(gttrs)),liblapack), Void,
-                   (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt},
+                   (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt},
                     Ptr{$elty}, Ptr{$elty}, Ptr{$elty}, Ptr{$elty},
                     Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                    &trans, &n, &size(B,2), dl, d, du, du2, ipiv, B, &stride(B,2), info)
@@ -1162,7 +1288,8 @@ for (orglq, orgqr, ormlq, ormqr, gemqrt, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orgqr!(A::StridedMatrix{$elty}, tau::Vector{$elty})
             chkstride1(A)
-            m, n = size(A)
+            m = size(A, 1)
+            n = min(m, size(A, 2))
             k = length(tau)
             if k > n throw(DimensionMismatch("invalid number of reflectors")) end
             work  = Array($elty, 1)
@@ -1181,7 +1308,7 @@ for (orglq, orgqr, ormlq, ormqr, gemqrt, elty) in
                     work = Array($elty, lwork)
                 end
             end
-            A
+            A[:,1:n]
         end
         #      SUBROUTINE DORMLQ( SIDE, TRANS, M, N, K, A, LDA, TAU, C, LDC,
         #                         WORK, LWORK, INFO )
@@ -1200,7 +1327,7 @@ for (orglq, orgqr, ormlq, ormqr, gemqrt, elty) in
             info  = Array(BlasInt, 1)
             for i in 1:2
                 ccall(($(string(ormlq)),liblapack), Void,
-                      (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
+                      (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
                        Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt},
                        Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                       &side, &trans, &m, &n, &k, A, &stride(A,2), tau,
@@ -1235,7 +1362,7 @@ for (orglq, orgqr, ormlq, ormqr, gemqrt, elty) in
             info  = Array(BlasInt, 1)
             for i in 1:2
                 ccall(($(string(ormqr)),liblapack), Void,
-                      (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, 
+                      (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, 
                        Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, 
                        Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, 
                        Ptr{BlasInt}),
@@ -1271,7 +1398,7 @@ for (orglq, orgqr, ormlq, ormqr, gemqrt, elty) in
             work = Array($elty, wss)
             info = Array(BlasInt, 1)
             ccall(($(string(gemqrt)), liblapack), Void,
-                (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt},
+                (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt},
                  Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                  Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                  Ptr{$elty}, Ptr{BlasInt}),
@@ -1308,7 +1435,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
             if size(B,1) != n throw(DimensionMismatch("posv!")) end
             info    = Array(BlasInt, 1)
             ccall(($(string(posv)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                    Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                   &uplo, &n, &size(B,2), A, &stride(A,2), B, &stride(B,2), info)
             if info[1] < 0 throw(LAPACKException(info[1])) end
@@ -1327,7 +1454,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
             chksquare(A)
             info = Array(BlasInt, 1)
             ccall(($(string(potrf)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                   &uplo, &size(A,1), A, &stride(A,2), info)
             if info[1] < 0 throw(LAPACKException(info[1])) end
             A, info[1]
@@ -1344,7 +1471,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
             chkstride1(A)
             info = Array(BlasInt, 1)
             ccall(($(string(potri)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                   &uplo, &size(A,1), A, &stride(A,2), info)
             if info[1] < 0 throw(LAPACKException(info[1])) end
             A, info[1]
@@ -1362,7 +1489,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
             if size(B,1) != n throw(DimensionMismatch("left and right hand sides do not fit")) end
             info = Array(BlasInt, 1)
             ccall(($(string(potrs)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                    Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                   &uplo, &n, &size(B,2), A, &stride(A,2), B, &stride(B,2), info)
             if info[1] != 0 throw(LAPACKException(info[1])) end
@@ -1385,7 +1512,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
             work = Array($rtyp, 2n)
             info = Array(BlasInt, 1)
             ccall(($(string(pstrf)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
                    Ptr{BlasInt}, Ptr{$rtyp}, Ptr{$rtyp}, Ptr{BlasInt}),
                   &uplo, &n, A, &stride(A,2), piv, rank, &tol, work, info)
             if info[1] < 0 throw(LAPACKException(info[1])) end
@@ -1477,7 +1604,7 @@ for (pttrs, elty, relty) in
             if length(E) != (n-1) || size(B,1) != n throw(DimensionMismatch("pttrs!")) end
             info = Array(BlasInt, 1)
             ccall(($(string(pttrs)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$relty}, Ptr{$elty},
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$relty}, Ptr{$elty},
                    Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                   &uplo, &n, &size(B,2), D, E, B, &stride(B,2), info)
             if info[1] != 0 throw(LAPACKException(info[1])) end
@@ -1506,7 +1633,7 @@ for (trtri, trtrs, elty) in
             lda     = stride(A, 2)
             info    = Array(BlasInt, 1)
             ccall(($(string(trtri)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                    Ptr{BlasInt}),
                   &uplo, &diag, &n, A, &lda, info)
             if info[1] < 0 throw(LAPACKException(info[1])) end
@@ -1526,7 +1653,7 @@ for (trtri, trtrs, elty) in
             if size(B,1) != n throw(DimensionMismatch("trtrs!")) end
             info    = Array(BlasInt, 1)
             ccall(($(string(trtrs)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt},
                    Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                   &uplo, &trans, &diag, &n, &size(B,2), A, &stride(A,2),
                   B, &stride(B,2), info)
@@ -1553,7 +1680,7 @@ for (stev, stebz, stegr, stein, elty) in
             work = Array($elty, max(1, 2n-2))
             info = Array(BlasInt, 1)
             ccall(($(string(stev)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{$elty},
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{$elty},
                    Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}),
                   &job, &n, dv, ev, Zmat, &n, work, info)
             if info[1] != 0 throw(LAPACKException(info[1])) end
@@ -1576,7 +1703,7 @@ for (stev, stebz, stegr, stein, elty) in
             iwork = Array(BlasInt,3*n)
             info = Array(BlasInt, 1)
             ccall(($(string(stebz)),liblapack), Void,
-                (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty},
+                (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty},
                 Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
                 Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
                 Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
@@ -1614,7 +1741,7 @@ for (stev, stebz, stegr, stein, elty) in
             info = Array(BlasInt, 1)
             for i = 1:2
                 ccall(($(string(stegr)), liblapack), Void, 
-                    (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty},
+                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty},
                     Ptr{$elty}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt},
                     Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
                     Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
@@ -1691,13 +1818,11 @@ stein!(dv::Vector, ev::Vector, w_in::Vector)=stein!(dv, ev, w_in, zeros(BlasInt,
 # Allow user to specify just one eigenvector to get in stein!
 stein!(dv::Vector, ev::Vector, eval::Real)=stein!(dv, ev, [eval], zeros(BlasInt,0), zeros(BlasInt,0))
 
-## (SY) symmetric matrices - eigendecomposition, Bunch-Kaufman decomposition,
+## (SY) symmetric real matrices - Bunch-Kaufman decomposition,
 ## solvers (direct and factored) and inverse.
-for (syconv, syev, sysv, sytrf, sytri, sytrs, elty, relty) in
-    ((:dsyconv_,:dsyev_,:dsysv_,:dsytrf_,:dsytri_,:dsytrs_,:Float64, :Float64),
-     (:ssyconv_,:ssyev_,:ssysv_,:ssytrf_,:ssytri_,:ssytrs_,:Float32, :Float32),
-     (:zheconv_,:zheev_,:zhesv_,:zhetrf_,:zhetri_,:zhetrs_,:Complex128, :Float64),
-     (:checonv_,:cheev_,:chesv_,:chetrf_,:chetri_,:chetrs_,:Complex64, :Float32))
+for (syconv, sysv, sytrf, sytri, sytrs, elty) in
+    ((:dsyconv_,:dsysv_,:dsytrf_,:dsytri_,:dsytrs_,:Float64),
+     (:ssyconv_,:ssysv_,:ssytrf_,:ssytri_,:ssytrs_,:Float32))
     @eval begin
         #       SUBROUTINE DSYCONV( UPLO, WAY, N, A, LDA, IPIV, WORK, INFO )
         # *     .. Scalar Arguments ..
@@ -1713,49 +1838,11 @@ for (syconv, syev, sysv, sytrf, sytri, sytrs, elty, relty) in
             work  = Array($elty, n)
             info  = Array(BlasInt, 1)
             ccall(($(string(syconv)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                    Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}),
                   &uplo, &'C', &n, A, &stride(A,2), ipiv, work, info)
             if info[1] != 0 throw(LAPACKException(info[1])) end
             A, work
-        end
-        #       SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
-        # *     .. Scalar Arguments ..
-        #       CHARACTER          JOBZ, UPLO
-        #       INTEGER            INFO, LDA, LWORK, N
-        # *     .. Array Arguments ..
-        #       DOUBLE PRECISION   A( LDA, * ), W( * ), WORK( * )
-        function syev!(jobz::BlasChar, uplo::BlasChar, A::StridedMatrix{$elty})
-            chkstride1(A)
-            chksquare(A)
-            cmplx = iseltype(A,Complex)
-            n     = size(A, 1)
-            W     = Array($relty, n)
-            work  = Array($elty, 1)
-            lwork = blas_int(-1)
-            if cmplx
-                rwork = Array($relty, max(1, 3n-2))
-            end
-            info  = Array(BlasInt, 1)
-            for i in 1:2
-                if cmplx
-                    ccall(($(string(syev)),liblapack), Void,
-                          (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
-                          Ptr{$relty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$relty}, Ptr{BlasInt}),
-                          &jobz, &uplo, &n, A, &stride(A,2), W, work, &lwork, rwork, info)
-                else
-                    ccall(($(string(syev)),liblapack), Void,
-                          (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
-                          Ptr{$relty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
-                          &jobz, &uplo, &n, A, &stride(A,2), W, work, &lwork, info)
-                end
-                if info[1] != 0 throw(LAPACKException(info[1])) end
-                if lwork < 0
-                    lwork = blas_int(real(work[1]))
-                    work = Array($elty, lwork)
-                end
-            end
-            jobz == 'V' ? (W, A) : W
         end
         #       SUBROUTINE DSYSV( UPLO, N, NRHS, A, LDA, IPIV, B, LDB, WORK,
         #                         LWORK, INFO )
@@ -1776,7 +1863,7 @@ for (syconv, syev, sysv, sytrf, sytri, sytrs, elty, relty) in
             info  = Array(BlasInt, 1)
             for i in 1:2
                 ccall(($(string(sysv)),liblapack), Void,
-                      (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
+                      (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
                        Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                       &uplo, &n, &size(B,2), A, &stride(A,2), ipiv, B, &stride(B,2),
                       work, &lwork, info)
@@ -1805,7 +1892,7 @@ for (syconv, syev, sysv, sytrf, sytri, sytrs, elty, relty) in
             info  = Array(BlasInt, 1)
             for i in 1:2
                 ccall(($(string(sytrf)),liblapack), Void,
-                      (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                      (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                        Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                       &uplo, &n, A, &stride(A,2), ipiv, work, &lwork, info)
                 if info[1] < 0 throw(LAPACKException(info[1])) end
@@ -1833,7 +1920,7 @@ for (syconv, syev, sysv, sytrf, sytri, sytrs, elty, relty) in
 #             info  = Array(BlasInt, 1)
 #             for i in 1:2
 #                 ccall(($(string(sytri)),liblapack), Void,
-#                       (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+#                       (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
 #                        Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
 #                       &uplo, &n, A, &stride(A,2), ipiv, work, &lwork, info)
 #                 if info[1] != 0 throw(LAPACKException(info[1])) end
@@ -1858,7 +1945,7 @@ for (syconv, syev, sysv, sytrf, sytri, sytrs, elty, relty) in
             work  = Array($elty, n)
             info  = Array(BlasInt, 1)
             ccall(($(string(sytri)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                    Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}),
                   &uplo, &n, A, &stride(A,2), ipiv, work, info)
             if info[1] != 0 throw(LAPACKException(info[1])) end
@@ -1880,7 +1967,7 @@ for (syconv, syev, sysv, sytrf, sytri, sytrs, elty, relty) in
             if n != size(B,1) throw(DimensionMismatch("sytrs!")) end
             info  = Array(BlasInt, 1)
             ccall(($(string(sytrs)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                    Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                   &uplo, &n, &size(B,2), A, &stride(A,2), ipiv, B, &stride(B,2), info)
             if info[1] != 0 throw(LAPACKException(info[1])) end
@@ -1888,18 +1975,401 @@ for (syconv, syev, sysv, sytrf, sytri, sytrs, elty, relty) in
         end
     end
 end
-for (sygvd, elty) in
-    ((:dsygvd_,:Float64),
-     (:ssygvd_,:Float32))
+## (SY) hermitian matrices - eigendecomposition, Bunch-Kaufman decomposition,
+## solvers (direct and factored) and inverse.
+for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
+    ((:zsyconv_,:zhesv_,:zhetrf_,:zhetri_,:zhetrs_,:Complex128, :Float64),
+     (:csyconv_,:chesv_,:chetrf_,:chetri_,:chetrs_,:Complex64, :Float32))
     @eval begin
+   #   SUBROUTINE ZSYCONV( UPLO, WAY, N, A, LDA, IPIV, WORK, INFO )
+   # 22 * 
+   # 23 *       .. Scalar Arguments ..
+   # 24 *       CHARACTER          UPLO, WAY
+   # 25 *       INTEGER            INFO, LDA, N
+   # 26 *       ..
+   # 27 *       .. Array Arguments ..
+   # 28 *       INTEGER            IPIV( * )
+   # 29 *       COMPLEX*16         A( LDA, * ), WORK( * )
+        function syconv!(uplo::BlasChar, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
+            chkstride1(A)
+            chksquare(A)
+            n     = size(A,1)
+            work  = Array($elty, n)
+            info  = Array(BlasInt, 1)
+            ccall(($(string(syconv)),liblapack), Void,
+                  (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                   Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}),
+                  &uplo, &'C', &n, A, &stride(A,2), ipiv, work, info)
+            if info[1] != 0 throw(LAPACKException(info[1])) end
+            A, work
+        end
+#       SUBROUTINE ZHESV( UPLO, N, NRHS, A, LDA, IPIV, B, LDB, WORK,
+# *     .. Scalar Arguments ..
+#       CHARACTER          UPLO
+#       INTEGER            INFO, LDA, LDB, LWORK, N, NRHS
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            IPIV( * )
+#       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
+        function hesv!(uplo::BlasChar, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
+            chkstride1(A,B)
+            chksquare(A)
+            n     = size(A,1)
+            if n != size(B,1) throw(DimensionMismatch("sysv!")) end
+            ipiv  = Array(BlasInt, n)
+            work  = Array($elty, 1)
+            lwork = blas_int(-1)
+            info  = Array(BlasInt, 1)
+            for i in 1:2
+                ccall(($(string(hesv)),liblapack), Void,
+                      (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
+                       Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+                      &uplo, &n, &size(B,2), A, &stride(A,2), ipiv, B, &stride(B,2),
+                      work, &lwork, info)
+                if info[1] < 0 throw(LAPACKException(info[1])) end
+                if lwork < 0
+                    lwork = blas_int(real(work[1]))
+                    work = Array($elty, lwork)
+                end
+            end
+            B, A, ipiv, info[1]
+        end
+#       SUBROUTINE ZHETRF( UPLO, N, A, LDA, IPIV, WORK, LWORK, INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          UPLO
+#       INTEGER            INFO, LDA, LWORK, N
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            IPIV( * )
+#       COMPLEX*16         A( LDA, * ), WORK( * )
+        function hetrf!(uplo::BlasChar, A::StridedMatrix{$elty})
+            chkstride1(A)
+            chksquare(A)
+            n     = size(A,1)
+            ipiv  = Array(BlasInt, n)
+            work  = Array($elty, 1)
+            lwork = blas_int(-1)
+            info  = Array(BlasInt, 1)
+            for i in 1:2
+                ccall(($(string(hetrf)),liblapack), Void,
+                      (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                       Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+                      &uplo, &n, A, &stride(A,2), ipiv, work, &lwork, info)
+                if info[1] < 0 throw(LAPACKException(info[1])) end
+                if info[1] > 0 throw(SingularException(info[1])) end
+                if lwork < 0
+                    lwork = blas_int(real(work[1]))
+                    work = Array($elty, lwork)
+                end
+            end
+            A, ipiv, info
+        end
+#       SUBROUTINE ZHETRI2( UPLO, N, A, LDA, IPIV, WORK, LWORK, INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          UPLO
+#       INTEGER            INFO, LDA, LWORK, N
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            IPIV( * )
+#       COMPLEX*16         A( LDA, * ), WORK( * )
+#         function hetri!(uplo::BlasChar, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
+#             chkstride1(A)
+#             chksquare(A)
+#             n     = size(A,1)
+#             work  = Array($elty, 1)
+#             lwork = blas_int(-1)
+#             info  = Array(BlasInt, 1)
+#             for i in 1:2
+#                 ccall(($(string(hetri)),liblapack), Void,
+#                       (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+#                        Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+#                       &uplo, &n, A, &stride(A,2), ipiv, work, &lwork, info)
+#                 if info[1] != 0 throw(LAPACKException(info[1])) end
+#                 if lwork < 0
+#                     lwork = blas_int(real(work[1]))
+#                     work = Array($elty, lwork)
+#                 end
+#             end
+#             A
+#         end
+#       SUBROUTINE ZHETRI( UPLO, N, A, LDA, IPIV, WORK, INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          UPLO
+#       INTEGER            INFO, LDA, N
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            IPIV( * )
+#       COMPLEX*16         A( LDA, * ), WORK( * )
+        function hetri!(uplo::BlasChar, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
+            chkstride1(A)
+            chksquare(A)
+            n     = size(A,1)
+            work  = Array($elty, n)
+            info  = Array(BlasInt, 1)
+            ccall(($(string(hetri)),liblapack), Void,
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                   Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}),
+                  &uplo, &n, A, &stride(A,2), ipiv, work, info)
+            if info[1] != 0 throw(LAPACKException(info[1])) end
+            A
+        end
+#       SUBROUTINE ZHETRS( UPLO, N, NRHS, A, LDA, IPIV, B, LDB, INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          UPLO
+#       INTEGER            INFO, LDA, LDB, N, NRHS
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            IPIV( * )
+#       COMPLEX*16         A( LDA, * ), B( LDB, * )
+        function hetrs!(uplo::BlasChar, A::StridedMatrix{$elty},
+                       ipiv::Vector{BlasInt}, B::StridedVecOrMat{$elty})
+            chkstride1(A,B)
+            chksquare(A)
+            n     = size(A,1)
+            if n != size(B,1) throw(DimensionMismatch("hetrs!")) end
+            info  = Array(BlasInt, 1)
+            ccall(($(string(hetrs)),liblapack), Void,
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                   Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+                  &uplo, &n, &size(B,2), A, &stride(A,2), ipiv, B, &stride(B,2), info)
+            if info[1] != 0 throw(LAPACKException(info[1])) end
+            B
+        end
+    end
+end
+for (sysv, sytrf, sytri, sytrs, elty, relty) in
+    ((:zsysv_,:zsytrf_,:zsytri_,:zsytrs_,:Complex128, :Float64),
+     (:csysv_,:csytrf_,:csytri_,:csytrs_,:Complex64, :Float32))
+    @eval begin
+#       SUBROUTINE ZSYSV( UPLO, N, NRHS, A, LDA, IPIV, B, LDB, WORK,
+#      $                  LWORK, INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          UPLO
+#       INTEGER            INFO, LDA, LDB, LWORK, N, NRHS
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            IPIV( * )
+#       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
+        function sysv!(uplo::BlasChar, A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty})
+            chkstride1(A,B)
+            chksquare(A)
+            n     = size(A,1)
+            if n != size(B,1) throw(DimensionMismatch("sysv!")) end
+            ipiv  = Array(BlasInt, n)
+            work  = Array($elty, 1)
+            lwork = blas_int(-1)
+            info  = Array(BlasInt, 1)
+            for i in 1:2
+                ccall(($(string(sysv)),liblapack), Void,
+                      (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
+                       Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+                      &uplo, &n, &size(B,2), A, &stride(A,2), ipiv, B, &stride(B,2),
+                      work, &lwork, info)
+                if info[1] < 0 throw(LAPACKException(info[1])) end
+                if lwork < 0
+                    lwork = blas_int(real(work[1]))
+                    work = Array($elty, lwork)
+                end
+            end
+            B, A, ipiv, info[1]
+        end
+#       SUBROUTINE ZSYTRF( UPLO, N, A, LDA, IPIV, WORK, LWORK, INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          UPLO
+#       INTEGER            INFO, LDA, LWORK, N
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            IPIV( * )
+#       COMPLEX*16         A( LDA, * ), WORK( * )
+        function sytrf!(uplo::BlasChar, A::StridedMatrix{$elty})
+            chkstride1(A)
+            chksquare(A)
+            n     = size(A,1)
+            ipiv  = Array(BlasInt, n)
+            work  = Array($elty, 1)
+            lwork = blas_int(-1)
+            info  = Array(BlasInt, 1)
+            for i in 1:2
+                ccall(($(string(sytrf)),liblapack), Void,
+                      (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                       Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+                      &uplo, &n, A, &stride(A,2), ipiv, work, &lwork, info)
+                if info[1] < 0 throw(LAPACKException(info[1])) end
+                if info[1] > 0 throw(SingularException(info[1])) end
+                if lwork < 0
+                    lwork = blas_int(real(work[1]))
+                    work = Array($elty, lwork)
+                end
+            end
+            A, ipiv, info
+        end
+#       SUBROUTINE ZSYTRI2( UPLO, N, A, LDA, IPIV, WORK, LWORK, INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          UPLO
+#       INTEGER            INFO, LDA, LWORK, N
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            IPIV( * )
+#       COMPLEX*16         A( LDA, * ), WORK( * )
+#         function sytri!(uplo::BlasChar, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
+#             chkstride1(A)
+#             chksquare(A)
+#             n     = size(A,1)
+#             work  = Array($elty, 1)
+#             lwork = blas_int(-1)
+#             info  = Array(BlasInt, 1)
+#             for i in 1:2
+#                 ccall(($(string(sytri)),liblapack), Void,
+#                       (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+#                        Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+#                       &uplo, &n, A, &stride(A,2), ipiv, work, &lwork, info)
+#                 if info[1] != 0 throw(LAPACKException(info[1])) end
+#                 if lwork < 0
+#                     lwork = blas_int(real(work[1]))
+#                     work = Array($elty, lwork)
+#                 end
+#             end
+#             A
+#         end
+#       SUBROUTINE ZSYTRI( UPLO, N, A, LDA, IPIV, WORK, INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          UPLO
+#       INTEGER            INFO, LDA, N
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            IPIV( * )
+#       COMPLEX*16         A( LDA, * ), WORK( * )
+        function sytri!(uplo::BlasChar, A::StridedMatrix{$elty}, ipiv::Vector{BlasInt})
+            chkstride1(A)
+            chksquare(A)
+            n     = size(A,1)
+            work  = Array($elty, n)
+            info  = Array(BlasInt, 1)
+            ccall(($(string(sytri)),liblapack), Void,
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                   Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}),
+                  &uplo, &n, A, &stride(A,2), ipiv, work, info)
+            if info[1] != 0 throw(LAPACKException(info[1])) end
+            A
+        end
+#       SUBROUTINE ZSYTRS( UPLO, N, NRHS, A, LDA, IPIV, B, LDB, INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          UPLO
+#       INTEGER            INFO, LDA, LDB, N, NRHS
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            IPIV( * )
+#       COMPLEX*16         A( LDA, * ), B( LDB, * )
+        function sytrs!(uplo::BlasChar, A::StridedMatrix{$elty},
+                       ipiv::Vector{BlasInt}, B::StridedVecOrMat{$elty})
+            chkstride1(A,B)
+            chksquare(A)
+            n     = size(A,1)
+            if n != size(B,1) throw(DimensionMismatch("sytrs!")) end
+            info  = Array(BlasInt, 1)
+            ccall(($(string(sytrs)),liblapack), Void,
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                   Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+                  &uplo, &n, &size(B,2), A, &stride(A,2), ipiv, B, &stride(B,2), info)
+            if info[1] != 0 throw(LAPACKException(info[1])) end
+            B
+        end
+    end
+end
+
+# Symmetric (real) eigensolvers
+for (syev, syevr, sygvd, elty) in
+    ((:dsyev_,:dsyevr_,:dsygvd_,:Float64),
+     (:ssyev_,:ssyevr_,:ssygvd_,:Float32))
+    @eval begin
+        #       SUBROUTINE DSYEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, INFO )
+        # *     .. Scalar Arguments ..
+        #       CHARACTER          JOBZ, UPLO
+        #       INTEGER            INFO, LDA, LWORK, N
+        # *     .. Array Arguments ..
+        #       DOUBLE PRECISION   A( LDA, * ), W( * ), WORK( * )
+        function syev!(jobz::BlasChar, uplo::BlasChar, A::StridedMatrix{$elty})
+            chkstride1(A)
+            chksquare(A)
+            n     = size(A, 1)
+            W     = Array($elty, n)
+            work  = Array($elty, 1)
+            lwork = blas_int(-1)
+            info  = Array(BlasInt, 1)
+            for i in 1:2
+                ccall(($(string(syev)),liblapack), Void,
+                      (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                      Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
+                      &jobz, &uplo, &n, A, &stride(A,2), W, work, &lwork, info)
+                if info[1] != 0 throw(LAPACKException(info[1])) end
+                if lwork < 0
+                    lwork = blas_int(real(work[1]))
+                    work = Array($elty, lwork)
+                end
+            end
+            jobz == 'V' ? (W, A) : W
+        end
+        #       SUBROUTINE DSYEVR( JOBZ, RANGE, UPLO, N, A, LDA, VL, VU, IL, IU,
+        #      $                   ABSTOL, M, W, Z, LDZ, ISUPPZ, WORK, LWORK,
+        #      $                   IWORK, LIWORK, INFO )
+        # *     .. Scalar Arguments ..
+        #       CHARACTER          JOBZ, RANGE, UPLO
+        #       INTEGER            IL, INFO, IU, LDA, LDZ, LIWORK, LWORK, M, N
+        #       DOUBLE PRECISION   ABSTOL, VL, VU
+        # *     ..
+        # *     .. Array Arguments ..
+        #       INTEGER            ISUPPZ( * ), IWORK( * )
+        #       DOUBLE PRECISION   A( LDA, * ), W( * ), WORK( * ), Z( LDZ, * )    
+        function syevr!(jobz::BlasChar, range::BlasChar, uplo::BlasChar, A::StridedMatrix{$elty}, vl::FloatingPoint, vu::FloatingPoint, il::Integer, iu::Integer, abstol::FloatingPoint)
+            chkstride1(A)
+            chksquare(A)                   
+            n = size(A, 2)
+            lda = max(1,stride(A,2))
+            m = Array(BlasInt, 1)
+            w = Array($elty, n)
+            if jobz == 'N'
+                ldz = 1
+                Z = Array($elty, ldz, 0)
+            elseif jobz == 'V'
+                ldz = n
+                Z = Array($elty, ldz, n)
+            else
+                error("jobz must be 'N' of 'V'")
+            end
+            isuppz = Array(BlasInt, 2*n)
+            work  = Array($elty, 1)
+            lwork = blas_int(-1)
+            iwork = Array(BlasInt, 1)
+            liwork = blas_int(-1)
+            info  = Array(BlasInt, 1)
+            for i in 1:2
+                ccall(($(string(syevr)),liblapack), Void,
+                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, 
+                        Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, 
+                        Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                        Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
+                        Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
+                        Ptr{BlasInt}),
+                    &jobz, &range, &uplo, &n, 
+                    A, &lda, &vl, &vu, 
+                    &il, &iu, &abstol, m,
+                    w, Z, &ldz, isuppz,
+                    work, &lwork, iwork, &liwork, 
+                    info)
+                if info[1] != 0 throw(LAPACKException(info[1])) end
+                if lwork < 0
+                    lwork = blas_int(real(work[1]))
+                    work = Array($elty, lwork)
+                    liwork = iwork[1]
+                    iwork = Array(BlasInt, liwork)
+                end
+            end
+            return w[1:m[1]], Z[:,1:(jobz == 'V' ? m[1] : 0)]
+        end    
+        syevr!(jobz::BlasChar, A::StridedMatrix{$elty}) = syevr!(jobz, 'A', 'U', A, 0.0, 0.0, 0, 0, -1.0)   
+        # Generalized eigenproblem
 #           SUBROUTINE DSYGVD( ITYPE, JOBZ, UPLO, N, A, LDA, B, LDB, W, WORK,
 #      $                   LWORK, IWORK, LIWORK, INFO )
-# *
-# *  -- LAPACK driver routine (version 3.3.1) --
-# *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
-# *  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
-# *  -- April 2011                                                      --
-# *
 # *     .. Scalar Arguments ..
 #       CHARACTER          JOBZ, UPLO
 #       INTEGER            INFO, ITYPE, LDA, LDB, LIWORK, LWORK, N
@@ -1910,8 +2380,8 @@ for (sygvd, elty) in
         function sygvd!(itype::Integer, jobz::BlasChar, uplo::BlasChar, A::StridedMatrix{$elty}, B::StridedMatrix{$elty})
             chkstride1(A,B)
             n = size(A, 1)
-            if size(A, 2) != n | size(B, 1) != size(B, 2) throw(DimensionMismatch("matrices must be square")) end
-            if size(B, 1) != n throw(DimensionMismatch("matrices must have same size")) end
+            if size(A, 2) != n | size(B, 1) != size(B, 2) throw(DimensionMismatch("Matrices must be square")) end
+            if size(B, 1) != n throw(DimensionMismatch("Matrices must have same size")) end
             lda = max(1, n)
             ldb = max(1, n)
             w = Array($elty, n)
@@ -1943,10 +2413,105 @@ for (sygvd, elty) in
         end
     end
 end
-for (sygvd, elty, relty) in 
-    ((:zhegvd_,:Complex128,:Float64),
-     (:chegvd_,:Complex64,:Float32))
+# Hermitian eigensolvers
+for (syev, syevr, sygvd, elty, relty) in 
+    ((:zheev_,:zheevr_,:zhegvd_,:Complex128,:Float64),
+     (:cheev_,:cheevr_,:chegvd_,:Complex64,:Float32))
     @eval begin
+# SUBROUTINE ZHEEV( JOBZ, UPLO, N, A, LDA, W, WORK, LWORK, RWORK, INFO )        
+# *     .. Scalar Arguments ..
+#       CHARACTER          JOBZ, UPLO
+#       INTEGER            INFO, LDA, LWORK, N
+# *     ..
+# *     .. Array Arguments ..
+#       DOUBLE PRECISION   RWORK( * ), W( * )
+#       COMPLEX*16         A( LDA, * ), WORK( * )
+        function syev!(jobz::BlasChar, uplo::BlasChar, A::StridedMatrix{$elty})
+            chkstride1(A)
+            chksquare(A)
+            n     = size(A, 1)
+            W     = Array($relty, n)
+            work  = Array($elty, 1)
+            lwork = blas_int(-1)
+            rwork = Array($relty, max(1, 3n-2))
+            info  = Array(BlasInt, 1)
+            for i in 1:2
+                ccall(($(string(syev)),liblapack), Void,
+                      (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                      Ptr{$relty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$relty}, Ptr{BlasInt}),
+                      &jobz, &uplo, &n, A, &stride(A,2), W, work, &lwork, rwork, info)
+                if info[1] != 0 throw(LAPACKException(info[1])) end
+                if lwork < 0
+                    lwork = blas_int(real(work[1]))
+                    work = Array($elty, lwork)
+                end
+            end
+            jobz == 'V' ? (W, A) : W
+        end
+#       SUBROUTINE ZHEEVR( JOBZ, RANGE, UPLO, N, A, LDA, VL, VU, IL, IU,
+#      $                   ABSTOL, M, W, Z, LDZ, ISUPPZ, WORK, LWORK,
+#      $                   RWORK, LRWORK, IWORK, LIWORK, INFO )
+# *     .. Scalar Arguments ..
+#       CHARACTER          JOBZ, RANGE, UPLO
+#       INTEGER            IL, INFO, IU, LDA, LDZ, LIWORK, LRWORK, LWORK,
+#      $                   M, N
+#       DOUBLE PRECISION   ABSTOL, VL, VU
+# *     ..
+# *     .. Array Arguments ..
+#       INTEGER            ISUPPZ( * ), IWORK( * )
+#       DOUBLE PRECISION   RWORK( * ), W( * )
+#       COMPLEX*16         A( LDA, * ), WORK( * ), Z( LDZ, * ) 
+        function syevr!(jobz::BlasChar, range::BlasChar, uplo::BlasChar, A::StridedMatrix{$elty}, vl::FloatingPoint, vu::FloatingPoint, il::Integer, iu::Integer, abstol::FloatingPoint)
+            chkstride1(A)
+            chksquare(A)
+            n = size(A, 2)
+            lda = max(1,stride(A,2))
+            m = Array(BlasInt, 1)
+            w = Array($relty, n)
+            if jobz == 'N'
+                ldz = 1
+                Z = Array($elty, ldz, 0)
+            elseif jobz == 'V'
+                ldz = n
+                Z = Array($elty, ldz, n)
+            else
+                error("jobz must be 'N' of 'V'")
+            end
+            isuppz = Array(BlasInt, 2*n)
+            work  = Array($elty, 1)
+            lwork = blas_int(-1)
+            rwork = Array($relty, 1)
+            lrwork = blas_int(-1)
+            iwork = Array(BlasInt, 1)
+            liwork = blas_int(-1)
+            info  = Array(BlasInt, 1)
+            for i in 1:2
+                ccall(($(string(syevr)),liblapack), Void,
+                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, 
+                        Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, 
+                        Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
+                        Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
+                        Ptr{$elty}, Ptr{BlasInt}, Ptr{$relty}, Ptr{BlasInt},
+                        Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}),
+                    &jobz, &range, &uplo, &n, 
+                    A, &lda, &vl, &vu, 
+                    &il, &iu, &abstol, m,
+                    w, Z, &ldz, isuppz,
+                    work, &lwork, rwork, &lrwork,
+                    iwork, &liwork, info)
+                if info[1] != 0 throw(LAPACKException(info[1])) end
+                if lwork < 0
+                    lwork = blas_int(real(work[1]))
+                    work = Array($elty, lwork)
+                    lrwork = blas_int(rwork[1])
+                    rwork = Array($relty, lrwork)
+                    liwork = iwork[1]
+                    iwork = Array(BlasInt, liwork)
+                end
+            end
+            return w[1:m[1]], Z[:,1:(jobz == 'V' ? m[1] : 0)]
+        end
+        syevr!(jobz::BlasChar, A::StridedMatrix{$elty}) = syevr!(jobz, 'A', 'U', A, 0.0, 0.0, 0, 0, -1.0)
 #       SUBROUTINE ZHEGVD( ITYPE, JOBZ, UPLO, N, A, LDA, B, LDB, W, WORK,
 #      $                   LWORK, RWORK, LRWORK, IWORK, LIWORK, INFO )
 # *
@@ -1966,8 +2531,8 @@ for (sygvd, elty, relty) in
         function sygvd!(itype::Integer, jobz::BlasChar, uplo::BlasChar, A::StridedMatrix{$elty}, B::StridedMatrix{$elty})
             chkstride1(A,B)
             n = size(A, 1)
-            if size(A, 2) != n | size(B, 1) != size(B, 2) throw(DimensionMismatch("matrices must be square")) end
-            if size(B, 1) != n throw(DimensionMismatch("matrices must have same size")) end
+            if size(A, 2) != n | size(B, 1) != size(B, 2) throw(DimensionMismatch("Matrices must be square")) end
+            if size(B, 1) != n throw(DimensionMismatch("Matrices must have same size")) end
             lda = max(1, n)
             ldb = max(1, n)
             w = Array($relty, n)
@@ -2087,7 +2652,7 @@ for (bdsdc, elty) in
             q = Array($elty, ldq)
             iq= Array(BlasInt, ldiq)
             work =Array($elty, lwork)
-            iwork=Array(BlasInt, 7n)
+            iwork=Array(BlasInt, 8n)
             info =Array(BlasInt, 1)
             ccall(($(string(bdsdc)),liblapack), Void,
            (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty},
@@ -2108,143 +2673,6 @@ for (bdsdc, elty) in
         end
     end
 end
-
-
-
-# New symmetric eigen solver
-for (syevr, elty) in
-    ((:dsyevr_,:Float64),
-     (:ssyevr_,:Float32))
-    @eval begin
-        function syevr!(jobz::BlasChar, range::BlasChar, uplo::BlasChar, A::StridedMatrix{$elty}, vl::FloatingPoint, vu::FloatingPoint, il::Integer, iu::Integer, abstol::FloatingPoint)
-        #       SUBROUTINE DSYEVR( JOBZ, RANGE, UPLO, N, A, LDA, VL, VU, IL, IU,
-        #      $                   ABSTOL, M, W, Z, LDZ, ISUPPZ, WORK, LWORK,
-        #      $                   IWORK, LIWORK, INFO )
-        # *     .. Scalar Arguments ..
-        #       CHARACTER          JOBZ, RANGE, UPLO
-        #       INTEGER            IL, INFO, IU, LDA, LDZ, LIWORK, LWORK, M, N
-        #       DOUBLE PRECISION   ABSTOL, VL, VU
-        # *     ..
-        # *     .. Array Arguments ..
-        #       INTEGER            ISUPPZ( * ), IWORK( * )
-        #       DOUBLE PRECISION   A( LDA, * ), W( * ), WORK( * ), Z( LDZ, * )    
-            chkstride1(A)
-            chksquare(A)                   
-            n = size(A, 2)
-            lda = max(1,stride(A,2))
-            m = Array(BlasInt, 1)
-            w = Array($elty, n)
-            if jobz == 'N'
-                ldz = 1
-                Z = Array($elty, ldz, 0)
-            elseif jobz == 'V'
-                ldz = n
-                Z = Array($elty, ldz, n)
-            else
-                error("jobz must be 'N' of 'V'")
-            end
-            isuppz = Array(BlasInt, 2*n)
-            work  = Array($elty, 1)
-            lwork = blas_int(-1)
-            iwork = Array(BlasInt, 1)
-            liwork = blas_int(-1)
-            info  = Array(BlasInt, 1)
-            for i in 1:2
-                ccall(($(string(syevr)),liblapack), Void,
-                    (Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, 
-                        Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, 
-                        Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
-                        Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
-                        Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
-                        Ptr{BlasInt}),
-                    &jobz, &range, &uplo, &n, 
-                    A, &lda, &vl, &vu, 
-                    &il, &iu, &abstol, m,
-                    w, Z, &ldz, isuppz,
-                    work, &lwork, iwork, &liwork, 
-                    info)
-                if info[1] != 0 throw(LAPACKException(info[1])) end
-                if lwork < 0
-                    lwork = blas_int(real(work[1]))
-                    work = Array($elty, lwork)
-                    liwork = iwork[1]
-                    iwork = Array(BlasInt, liwork)
-                end
-            end
-            return w[1:m[1]], Z[:,1:(jobz == 'V' ? m[1] : 0)]
-        end
-    end
-end
-for (syevr, elty, relty) in
-    ((:zheevr_,:Complex128,:Float64),
-     (:cheevr_,:Complex64,:Float32))
-    @eval begin
-        function syevr!(jobz::BlasChar, range::BlasChar, uplo::BlasChar, A::StridedMatrix{$elty}, vl::FloatingPoint, vu::FloatingPoint, il::Integer, iu::Integer, abstol::FloatingPoint)
-#       SUBROUTINE ZHEEVR( JOBZ, RANGE, UPLO, N, A, LDA, VL, VU, IL, IU,
-#      $                   ABSTOL, M, W, Z, LDZ, ISUPPZ, WORK, LWORK,
-#      $                   RWORK, LRWORK, IWORK, LIWORK, INFO )
-# *     .. Scalar Arguments ..
-#       CHARACTER          JOBZ, RANGE, UPLO
-#       INTEGER            IL, INFO, IU, LDA, LDZ, LIWORK, LRWORK, LWORK,
-#      $                   M, N
-#       DOUBLE PRECISION   ABSTOL, VL, VU
-# *     ..
-# *     .. Array Arguments ..
-#       INTEGER            ISUPPZ( * ), IWORK( * )
-#       DOUBLE PRECISION   RWORK( * ), W( * )
-#       COMPLEX*16         A( LDA, * ), WORK( * ), Z( LDZ, * ) 
-            chkstride1(A)
-            chksquare(A)
-            n = size(A, 2)
-            lda = max(1,stride(A,2))
-            m = Array(BlasInt, 1)
-            w = Array($relty, n)
-            if jobz == 'N'
-                ldz = 1
-                Z = Array($elty, ldz, 0)
-            elseif jobz == 'V'
-                ldz = n
-                Z = Array($elty, ldz, n)
-            else
-                error("jobz must be 'N' of 'V'")
-            end
-            isuppz = Array(BlasInt, 2*n)
-            work  = Array($elty, 1)
-            lwork = blas_int(-1)
-            rwork = Array($relty, 1)
-            lrwork = blas_int(-1)
-            iwork = Array(BlasInt, 1)
-            liwork = blas_int(-1)
-            info  = Array(BlasInt, 1)
-            for i in 1:2
-                ccall(($(string(syevr)),liblapack), Void,
-                    (Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, 
-                        Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, 
-                        Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
-                        Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
-                        Ptr{$elty}, Ptr{BlasInt}, Ptr{$relty}, Ptr{BlasInt},
-                        Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}),
-                    &jobz, &range, &uplo, &n, 
-                    A, &lda, &vl, &vu, 
-                    &il, &iu, &abstol, m,
-                    w, Z, &ldz, isuppz,
-                    work, &lwork, rwork, &lrwork,
-                    iwork, &liwork, info)
-                if info[1] != 0 throw(LAPACKException(info[1])) end
-                if lwork < 0
-                    lwork = blas_int(real(work[1]))
-                    work = Array($elty, lwork)
-                    lrwork = blas_int(rwork[1])
-                    rwork = Array($relty, lrwork)
-                    liwork = iwork[1]
-                    iwork = Array(BlasInt, liwork)
-                end
-            end
-            return w[1:m[1]], Z[:,1:(jobz == 'V' ? m[1] : 0)]
-        end
-    end
-end
-syevr!(jobz::Char, A::StridedMatrix) = syevr!(jobz, 'A', 'U', A, 0.0, 0.0, 0, 0, -1.0)
 
 # Estimate condition number
 for (gecon, elty) in
@@ -2270,7 +2698,7 @@ for (gecon, elty) in
             iwork = Array(BlasInt, n)
             info = Array(BlasInt, 1)
             ccall(($(string(gecon)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, 
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, 
                    Ptr{$elty}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt},
                    Ptr{BlasInt}),
                   &normtype, &n, A, &lda, &anorm, rcond, work, iwork,
@@ -2304,7 +2732,7 @@ for (gecon, elty, relty) in
             rwork = Array($relty, 2n)
             info = Array(BlasInt, 1)
             ccall(($(string(gecon)),liblapack), Void,
-                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, 
+                  (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, 
                    Ptr{$relty}, Ptr{$relty}, Ptr{$elty}, Ptr{$relty},
                    Ptr{BlasInt}),
                   &normtype, &n, A, &lda, &anorm, rcond, work, rwork,
@@ -2420,7 +2848,7 @@ for (gees, gges, elty) in
             info = Array(BlasInt, 1)
             for i = 1:2
                 ccall(($(string(gees)),liblapack), Void,
-                    (Ptr{Uint8}, Ptr{Uint8}, Ptr{Void}, Ptr{BlasInt},
+                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{Void}, Ptr{BlasInt},
                         Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
                         Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
                         Ptr{BlasInt}, Ptr{Void}, Ptr{BlasInt}),
@@ -2467,7 +2895,7 @@ for (gees, gges, elty) in
             info = Array(BlasInt, 1)
             for i = 1:2
                 ccall(($(string(gges)), liblapack), Void,
-                    (Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{Void},
+                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{Void},
                         Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
                         Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty},
                         Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
@@ -2516,7 +2944,7 @@ for (gees, gges, elty, relty) in
             info = Array(BlasInt, 1)
             for i = 1:2
                 ccall(($(string(gees)),liblapack), Void,
-                    (Ptr{Uint8}, Ptr{Uint8}, Ptr{Void}, Ptr{BlasInt},
+                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{Void}, Ptr{BlasInt},
                         Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
                         Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, 
                         Ptr{$relty}, Ptr{Void}, Ptr{BlasInt}),
@@ -2560,7 +2988,7 @@ for (gees, gges, elty, relty) in
             info = Array(BlasInt, 1)
             for i = 1:2
                 ccall(($(string(gges)), liblapack), Void,
-                    (Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{Void},
+                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{Void},
                         Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
                         Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty},
                         Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
@@ -2602,7 +3030,7 @@ for (fn, elty, relty) in ((:dsfrk_, :Float64, :Float64),
             end
             lda = max(1, stride(A, 2))
             ccall(($(string(fn)), liblapack), Void,
-                (Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt},
+                (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt},
                  Ptr{BlasInt}, Ptr{$relty}, Ptr{$elty}, Ptr{BlasInt},
                  Ptr{$relty}, Ptr{$elty}),
                 &transr, &uplo, &trans, &n,
@@ -2623,7 +3051,7 @@ for (fn, elty) in ((:dpftrf_, :Float64),
             n = int(div(sqrt(8length(A)), 2))
             info = Array(BlasInt, 1)
             ccall(($(string(fn)), liblapack), Void,
-                (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty},
+                (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty},
                  Ptr{BlasInt}),
                 &transr, &uplo, &n, A,
                 info)
@@ -2643,7 +3071,7 @@ for (fn, elty) in ((:dpftri_, :Float64),
             n = int(div(sqrt(8length(A)), 2))
             info = Array(BlasInt, 1)
             ccall(($(string(fn)), liblapack), Void,
-                (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty},
+                (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty},
                  Ptr{BlasInt}),
                 &transr, &uplo, &n, A, 
                 info)
@@ -2667,7 +3095,7 @@ for (fn, elty) in ((:dpftrs_, :Float64),
             ldb = max(1, stride(B, 2))
             info = Array(BlasInt, 1)
             ccall(($(string(fn)), liblapack), Void,
-                (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt},
+                (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt},
                  Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                 &transr, &uplo, &n, &nhrs,
                 A, B, &ldb, info)
@@ -2689,8 +3117,8 @@ for (fn, elty) in ((:dtfsm_, :Float64),
             if int(div(sqrt(8length(A)), 2)) != m throw(DimensionMismatch("")) end
             ldb = max(1, stride(B, 2))
             ccall(($(string(fn)), liblapack), Void,
-                (Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8},
-                 Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
+                (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar},
+                 Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
                  Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}),
                 &transr, &side, &uplo, &trans,
                 &diag, &m, &n, &alpha,
@@ -2710,7 +3138,7 @@ for (fn, elty) in ((:dtftri_, :Float64),
             n = int(div(sqrt(8length(A)), 2))
             info = Array(BlasInt, 1)
             ccall(($(string(fn)), liblapack), Void,
-                (Ptr{Uint8}, Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, 
+                (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, 
                  Ptr{$elty}, Ptr{BlasInt}),
                 &transr, &uplo, &diag, &n, 
                 A, info)
@@ -2731,7 +3159,7 @@ for (fn, elty) in ((:dtfttr_, :Float64),
             info = Array(BlasInt, 1)
             A = Array($elty, n, n)
             ccall(($(string(fn)), liblapack), Void,
-                (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty},
+                (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty},
                  Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                 &transr, &uplo, &n, Arf,
                 A, &n, info)
@@ -2754,7 +3182,7 @@ for (fn, elty) in ((:dtrttf_, :Float64),
             info = Array(BlasInt, 1)
             Arf = Array($elty, div(n*(n+1), 2))
             ccall(($(string(fn)), liblapack), Void,
-                (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty},
+                (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty},
                  Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}),
                 &transr, &uplo, &n, A,
                 &lda, Arf, info)

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -1,0 +1,64 @@
+# Symmetric matrices
+
+type Symmetric{T<:Number} <: AbstractMatrix{T}
+    S::Matrix{T}
+    uplo::Char
+end
+function Symmetric{T<:Number}(S::Matrix{T}, uplo::Symbol)
+    if size(S, 1) != size(S, 2) throw(DimensionMismatch("Matrix must be square")); end
+    return Symmetric(S, string(uplo)[1])
+end
+Symmetric(A::StridedMatrix) = Symmetric(A, :U)
+
+copy(A::Symmetric) = Symmetric(copy(A.S), A.uplo)
+size(A::Symmetric, args...) = size(A.S, args...)
+print_matrix(io::IO, A::Symmetric) = print_matrix(io, full(A))
+full(A::Symmetric) = A.S
+ishermitian{T<:Real}(A::Symmetric) = true
+ishermitian{T<:Complex}(A::Symmetric) = all(imag(A.S) .== 0)
+issym(A::Symmetric) = true
+transpose(A::Symmetric) = A
+
+*(A::Symmetric, B::Symmetric) = *(full(A), full(B))
+*(A::Symmetric, B::StridedMatrix) = *(full(A), B)
+*(A::StridedMatrix, B::Symmetric) = *(A, full(B))
+
+factorize!{T<:Real}(A::Symmetric{T}) = bkfact!(A.S, symbol(A.uplo))
+factorize!{T<:Complex}(A::Symmetric{T}) = bkfact!(A.S, symbol(A.uplo), true)
+\(A::Symmetric, B::StridedVecOrMat) = \(bkfact(A.S, symbol(A.uplo), true), B)
+
+eigfact!{T<:BlasReal}(A::Symmetric{T}) = Eigen(LAPACK.syevr!('V', 'A', A.uplo, A.S, 0.0, 0.0, 0, 0, -1.0)...)
+eigfact(A::Symmetric) = eigfact!(copy(A))
+eigvals{T<:BlasReal}(A::Symmetric{T}, il::Int, ih::Int) = LAPACK.syevr!('N', 'I', A.uplo, copy(A.S), 0.0, 0.0, il, ih, -1.0)[1]
+eigvals{T<:BlasReal}(A::Symmetric{T}, vl::Real, vh::Real) = LAPACK.syevr!('N', 'V', A.uplo, copy(A.S), vl, vh, 0, 0, -1.0)[1]
+eigvals(A::Symmetric) = eigvals(A, 1, size(A, 1))
+eigmax(A::Symmetric) = eigvals(A, size(A, 1), size(A, 1))[1]
+eigmin(A::Symmetric) = eigvals(A, 1, 1)[1]
+
+function eigfact!{T<:BlasReal}(A::Symmetric{T}, B::Symmetric{T})
+    vals, vecs, _ = LAPACK.sygvd!(1, 'V', A.uplo, A.S, B.uplo == A.uplo ? B.S : B.S')
+    return GeneralizedEigen(vals, vecs)
+end
+eigfact(A::Symmetric, B::Symmetric) = eigfact!(copy(A), copy(B))
+eigvals!{T<:BlasReal}(A::Symmetric{T}, B::Symmetric{T}) = LAPACK.sygvd!(1, 'N', A.uplo, A.S, B.uplo == A.uplo ? B.S : B.S')[1]
+
+function expm{T<:Real}(A::Symmetric{T})
+    F = eigfact(A)
+    scale(F[:vectors], exp(F[:values])) * F[:vectors]'
+end
+
+function sqrtm{T<:Real}(A::Symmetric{T}, cond::Bool)
+    F = eigfact(A)
+    vsqrt = sqrt(complex(F[:values]))
+    if all(imag(vsqrt) .== 0)
+        retmat = symmetrize!(scale(F[:vectors], real(vsqrt)) * F[:vectors]')
+    else
+        zc = complex(F[:vectors])
+        retmat = symmetrize!(scale(zc, vsqrt) * zc')
+    end
+    if cond
+        return retmat, norm(vsqrt, Inf)^2/norm(F[:values], Inf)
+    else
+        return retmat
+    end
+end


### PR DESCRIPTION
A new general matrix factorization method. Some changes to the treatment of symmetric and hermitian matrices and some bug fixes. And some tests.

This is a follow up on the discussion in JuliaLang/LinearAlgebra.jl#16. The main new thing is `factorize` which tries to guess a good factorization depending on the structure of matrix. For example

``` julia
julia> A=randn(5,5);

julia> typeof(factorize(A))
LU{Float64}

julia> typeof(factorize(A + A'))
BunchKaufman{Float64}

julia> typeof(factorize(A'A))
Cholesky{Float64}

julia> typeof(factorize(A[:,1:2]))
QRPivoted{Float64}
```

For complex indifinite matrices it is necessary to distinguish between symmetric and hermitian matrices (the Bunch-Kaufman case) and therefore I have added a `Symmetric` type which also works for real matrices. Hence `Hermitian` is now a complex matrix only type. I have also added the `bkfact` method for constructing the Bunch-Kaufman decoposition directly.

To handle least squares, I had to reimplement the functionality of `xgelsy` in Julia because I wanted to be able to solve rank deficient problems. You can now reuse a QR based "predicter":

``` julia
julia> mX = randn(10,2)*randn(2,3);y1 = randn(10);y2 = randn(10);

julia> xf = factorize(mX);

julia> xf\y1
3-element Float64 Array:
 -0.18619   
  0.811663  
  0.00219657

julia> xf\y2
3-element Float64 Array:
  0.0448524
 -0.197673 
  0.0139636
```

I got some random failures in the tests but I couldn't get them if I ran the tests with `include` from a Julia session.
