### PR TITLE
new MathConst type: make π, e, and γ instances.

### DIFF
--- a/base/constants.jl
+++ b/base/constants.jl
@@ -2,6 +2,7 @@
 
 immutable MathConst{sym} <: Real end
 
+big(x::MathConst) = convert(BigFloat,x)
 show{sym}(io::IO, ::MathConst{sym}) = print(io, sym)
 
 promote_rule{s}(::Type{MathConst{s}}, ::Type) = Float64
@@ -46,8 +47,9 @@ macro math_const(sym, val, def)
         $bigconvert
         Base.convert(::Type{Float64}, ::MathConst{$qsym}) = $val
         Base.convert(::Type{Float32}, ::MathConst{$qsym}) = $(float32(val))
-        @assert float64($esym) == float64(convert(BigFloat,$esym))
-        @assert float32($esym) == float32(convert(BigFloat,$esym))
+        @assert isa(big($esym), BigFloat)
+        @assert float64($esym) == float64(big($esym))
+        @assert float32($esym) == float32(big($esym))
     end
 end
 
@@ -56,7 +58,10 @@ end
 @math_const π 3.14159265358979323846 pi
 @math_const e 2.71828182845904523536 exp(big(1))
 @math_const γ 0.57721566490153286061 euler
+@math_const G 0.91596559417721901505 catalan
 
 # aliases
 const pi = π
+const eu = e
 const eulergamma = γ
+const catalan = G

--- a/base/constants.jl
+++ b/base/constants.jl
@@ -59,9 +59,11 @@ end
 @math_const e 2.71828182845904523536 exp(big(1))
 @math_const γ 0.57721566490153286061 euler
 @math_const G 0.91596559417721901505 catalan
+@math_const φ 1.61803398874989484820 (1+sqrt(big(5)))/2
 
 # aliases
 const pi = π
 const eu = e
 const eulergamma = γ
 const catalan = G
+const golden = φ

--- a/base/constants.jl
+++ b/base/constants.jl
@@ -1,0 +1,62 @@
+## general machinery for mathematical constants
+
+immutable MathConst{sym} <: Real end
+
+show{sym}(io::IO, ::MathConst{sym}) = print(io, sym)
+
+promote_rule{s}(::Type{MathConst{s}}, ::Type) = Float64
+promote_rule{s}(::Type{MathConst{s}}, ::Type{Float32}) = Float32
+promote_rule{s}(::Type{MathConst{s}}, ::Type{BigInt}) = BigFloat
+promote_rule{s}(::Type{MathConst{s}}, ::Type{BigFloat}) = BigFloat
+promote_rule{s}(::Type{MathConst{s}}, ::Type{ImaginaryUnit}) = Complex{Float64}
+promote_rule{s}(::Type{ImaginaryUnit}, ::Type{MathConst{s}}) = Complex{Float64}
+promote_rule{s,T<:Real}(::Type{MathConst{s}}, ::Type{Complex{T}}) =
+    Complex{promote_type(MathConst{s},T)}
+
+convert(::Type{FloatingPoint}, x::MathConst) = float64(x)
+convert{T<:Real}(::Type{Complex{T}}, x::MathConst) = convert(Complex{T}, float64(x))
+convert{T<:Integer}(::Type{Rational{T}}, x::MathConst) = convert(Rational{T}, float64(x))
+
+-(x::MathConst) = -float64(x)
++(x::MathConst, y::MathConst) = float64(x) + float64(y)
+-(x::MathConst, y::MathConst) = float64(x) - float64(y)
+*(x::MathConst, y::MathConst) = float64(x) * float64(y)
+/(x::MathConst, y::MathConst) = float64(x) / float64(y)
+^(x::MathConst, y::MathConst) = float64(x) ^ float64(y)
+
+*(x::MathConst, i::ImaginaryUnit) = float64(x)*i
+*(i::ImaginaryUnit, x::MathConst) = i*float64(x)
+
+## specific mathematical constants
+
+const π = MathConst{:π}()
+const e = MathConst{:e}()
+const γ = MathConst{:γ}()
+
+for (sym, name) in ((:π, :pi), (:γ, :euler))
+    qsym = Expr(:quote, sym)
+    @eval begin
+        function convert(::Type{BigFloat}, ::MathConst{$qsym})
+            c = BigFloat()
+            ccall(($(string("mpfr_const_", name)), :libmpfr),
+                  Cint, (Ptr{BigFloat}, Int32),
+                  &c, MPFR.ROUNDING_MODE[end])
+            return c
+        end
+    end
+end
+
+convert(::Type{BigFloat}, ::MathConst{:e}) = exp(big(1))
+
+for sym in (:π, :e, :γ)
+    x = eval(sym)
+    qsym = Expr(:quote, sym)
+    @eval begin
+        convert(::Type{Float64}, ::MathConst{$qsym}) = $(float64(convert(BigFloat,x)))
+        convert(::Type{Float32}, ::MathConst{$qsym}) = $(float32(convert(BigFloat,x)))
+    end
+end
+
+# aliases
+const pi = π
+const eulergamma = γ

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -54,6 +54,7 @@ export
     ImaginaryUnit,
     IntSet,
     LocalProcess,
+    MathConst,
     Matrix,
     ObjectIdDict,
     PollingFileWatcher,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -273,6 +273,7 @@ export
     atan2,
     atand,
     atanh,
+    big,
     bitmix,
     bool,
     binomial,

--- a/base/float.jl
+++ b/base/float.jl
@@ -259,14 +259,6 @@ end
 sizeof(::Type{Float32}) = 4
 sizeof(::Type{Float64}) = 8
 
-## mathematical constants ##
-
-const e  = 2.71828182845904523536
-const pi = 3.14159265358979323846
-const π = pi
-const euler_mascheroni = 0.57721566490153286061
-const γ = euler_mascheroni
-
 ## byte order swaps for arbitrary-endianness serialization/deserialization ##
 bswap(x::Float32) = box(Float32,bswap_int(unbox(Float32,x)))
 bswap(x::Float64) = box(Float64,bswap_int(unbox(Float64,x)))

--- a/base/math.jl
+++ b/base/math.jl
@@ -15,58 +15,13 @@ export sin, cos, tan, sinh, cosh, tanh, asin, acos, atan,
        besselj0, besselj1, besselj, bessely0, bessely1, bessely,
        hankelh1, hankelh2, besseli, besselk, besselh,
        beta, lbeta, eta, zeta, polygamma, invdigamma, digamma, trigamma,
-       erfinv, erfcinv,
-       MathConst, e, π, γ, pi, euler_mascheroni
+       erfinv, erfcinv
 
 import Base: log, exp, sin, cos, tan, sinh, cosh, tanh, asin,
              acos, atan, asinh, acosh, atanh, sqrt, log2, log10,
              max, min, ceil, floor, trunc, round, ^, exp2, exp10
 
 import Core.Intrinsics.nan_dom_err
-
-## mathematical constants ##
-
-import Base: show, promote_rule, convert
-
-immutable MathConst{sym} <: Real end
-
-show{sym}(io::IO, ::MathConst{sym}) = print(io, sym)
-
-const e = MathConst{:e}()
-const π = MathConst{:π}()
-const γ = MathConst{:γ}()
-
-const pi = π
-const euler_mascheroni = γ
-
-promote_rule{s}(::Type{MathConst{s}}, ::Type) = Float64
-promote_rule{s}(::Type{MathConst{s}}, ::Type{Float32}) = Float32
-promote_rule{s}(::Type{MathConst{s}}, ::Type{ImaginaryUnit}) = Complex{Float64}
-promote_rule{s}(::Type{ImaginaryUnit}, ::Type{MathConst{s}}) = Complex{Float64}
-promote_rule{s,T<:Real}(::Type{MathConst{s}}, ::Type{Complex{T}}) =
-    Complex{promote_type(MathConst{s},T)}
-
-convert(::Type{Float64}, ::MathConst{:e}) = 2.71828182845904523536
-convert(::Type{Float64}, ::MathConst{:π}) = 3.14159265358979323846
-convert(::Type{Float64}, ::MathConst{:γ}) = 0.57721566490153286061
-
-convert(::Type{Float32}, ::MathConst{:e}) = 2.7182817f0
-convert(::Type{Float32}, ::MathConst{:π}) = 3.1415927f0
-convert(::Type{Float32}, ::MathConst{:γ}) = 0.5772157f0
-
-convert(::Type{FloatingPoint}, x::MathConst) = float64(x)
-convert{T<:Real}(::Type{Complex{T}}, x::MathConst) = convert(Complex{T}, float64(x))
-convert{T<:Integer}(::Type{Rational{T}}, x::MathConst) = convert(Rational{T}, float64(x))
-
--(x::MathConst) = -float64(x)
-+(x::MathConst, y::MathConst) = float64(x) + float64(y)
--(x::MathConst, y::MathConst) = float64(x) - float64(y)
-*(x::MathConst, y::MathConst) = float64(x) * float64(y)
-/(x::MathConst, y::MathConst) = float64(x) / float64(y)
-^(x::MathConst, y::MathConst) = float64(x) ^ float64(y)
-
-*(x::MathConst, i::ImaginaryUnit) = float64(x)*i
-*(i::ImaginaryUnit, x::MathConst) = i*float64(x)
 
 # non-type specific math functions
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -15,14 +15,50 @@ export sin, cos, tan, sinh, cosh, tanh, asin, acos, atan,
        besselj0, besselj1, besselj, bessely0, bessely1, bessely,
        hankelh1, hankelh2, besseli, besselk, besselh,
        beta, lbeta, eta, zeta, polygamma, invdigamma, digamma, trigamma,
-       erfinv, erfcinv
+       erfinv, erfcinv,
+       MathConst, e, π, γ, pi, euler_mascheroni
 
-import Base.log, Base.exp, Base.sin, Base.cos, Base.tan, Base.sinh, Base.cosh,
-       Base.tanh, Base.asin, Base.acos, Base.atan, Base.asinh, Base.acosh,
-       Base.atanh, Base.sqrt, Base.log2, Base.log10, Base.max, Base.min,
-       Base.ceil, Base.floor, Base.trunc, Base.round, Base.^, Base.exp2, Base.exp10
+import Base: log, exp, sin, cos, tan, sinh, cosh, tanh, asin,
+             acos, atan, asinh, acosh, atanh, sqrt, log2, log10,
+             max, min, ceil, floor, trunc, round, ^, exp2, exp10
 
 import Core.Intrinsics.nan_dom_err
+
+## mathematical constants ##
+
+import Base: show, promote_rule, convert
+
+immutable MathConst{sym} <: Real end
+
+show{sym}(io::IO, ::MathConst{sym}) = print(io, sym)
+
+const e = MathConst{:e}()
+const π = MathConst{:π}()
+const γ = MathConst{:γ}()
+
+const pi = π
+const euler_mascheroni = γ
+
+promote_rule{sym}(::Type{MathConst{sym}}, ::Type) = Float64
+promote_rule{sym}(::Type{MathConst{sym}}, ::Type{Float32})  = Float32
+
+convert(::Type{Float64}, ::MathConst{:e}) = 2.71828182845904523536
+convert(::Type{Float64}, ::MathConst{:π}) = 3.14159265358979323846
+convert(::Type{Float64}, ::MathConst{:γ}) = 0.57721566490153286061
+
+convert(::Type{Float32}, ::MathConst{:e}) = 2.7182817f0
+convert(::Type{Float32}, ::MathConst{:π}) = 3.1415927f0
+convert(::Type{Float32}, ::MathConst{:γ}) = 0.5772157f0
+
+convert(::Type{FloatingPoint}, x::MathConst) = float64(x)
+convert{T<:Integer}(::Type{Rational{T}}, x::MathConst) = convert(Rational{T}, float64(x))
+
+-(x::MathConst) = -float64(x)
++(x::MathConst, y::MathConst) = float64(x) + float64(y)
+-(x::MathConst, y::MathConst) = float64(x) - float64(y)
+*(x::MathConst, y::MathConst) = float64(x) * float64(y)
+/(x::MathConst, y::MathConst) = float64(x) / float64(y)
+^(x::MathConst, y::MathConst) = float64(x) ^ float64(y)
 
 # non-type specific math functions
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -39,8 +39,12 @@ const γ = MathConst{:γ}()
 const pi = π
 const euler_mascheroni = γ
 
-promote_rule{sym}(::Type{MathConst{sym}}, ::Type) = Float64
-promote_rule{sym}(::Type{MathConst{sym}}, ::Type{Float32})  = Float32
+promote_rule{s}(::Type{MathConst{s}}, ::Type) = Float64
+promote_rule{s}(::Type{MathConst{s}}, ::Type{Float32}) = Float32
+promote_rule{s}(::Type{MathConst{s}}, ::Type{ImaginaryUnit}) = Complex{Float64}
+promote_rule{s}(::Type{ImaginaryUnit}, ::Type{MathConst{s}}) = Complex{Float64}
+promote_rule{s,T<:Real}(::Type{MathConst{s}}, ::Type{Complex{T}}) =
+    Complex{promote_type(MathConst{s},T)}
 
 convert(::Type{Float64}, ::MathConst{:e}) = 2.71828182845904523536
 convert(::Type{Float64}, ::MathConst{:π}) = 3.14159265358979323846
@@ -51,6 +55,7 @@ convert(::Type{Float32}, ::MathConst{:π}) = 3.1415927f0
 convert(::Type{Float32}, ::MathConst{:γ}) = 0.5772157f0
 
 convert(::Type{FloatingPoint}, x::MathConst) = float64(x)
+convert{T<:Real}(::Type{Complex{T}}, x::MathConst) = convert(Complex{T}, float64(x))
 convert{T<:Integer}(::Type{Rational{T}}, x::MathConst) = convert(Rational{T}, float64(x))
 
 -(x::MathConst) = -float64(x)
@@ -59,6 +64,9 @@ convert{T<:Integer}(::Type{Rational{T}}, x::MathConst) = convert(Rational{T}, fl
 *(x::MathConst, y::MathConst) = float64(x) * float64(y)
 /(x::MathConst, y::MathConst) = float64(x) / float64(y)
 ^(x::MathConst, y::MathConst) = float64(x) ^ float64(y)
+
+*(x::MathConst, i::ImaginaryUnit) = float64(x)*i
+*(i::ImaginaryUnit, x::MathConst) = i*float64(x)
 
 # non-type specific math functions
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -1,12 +1,7 @@
 module MPFR
 
 export
-    # Types
     BigFloat,
-    # Functions
-    bigfloat_pi,
-    bigfloat_eulergamma,
-    bigfloat_catalan,
     get_bigfloat_precision,
     set_bigfloat_precision,
     with_bigfloat_precision,
@@ -22,7 +17,6 @@ import
         prevfloat, promote_rule, rem, round, show, showcompact, sum, sqrt,
         string, trunc, get_precision, exp10, expm1, gamma, lgamma, digamma,
         erf, erfc, zeta, log1p, airyai, iceil, ifloor, itrunc, eps, signbit,
-    # import trigonometric functions
         sin, cos, tan, sec, csc, cot, acos, asin, atan, cosh, sinh, tanh,
         sech, csch, coth, acosh, asinh, atanh, atan2
 
@@ -564,23 +558,6 @@ function atan2(y::BigFloat, x::BigFloat)
     ccall((:mpfr_atan2, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Ptr{BigFloat}, Int32), &z, &y, &x, ROUNDING_MODE[end])
     return z
 end
-
-# Mathematical constants:
-for (c, cmpfr) in ((:pi, :pi), (:eulergamma, :euler), (:catalan, :catalan))
-    @eval function $(symbol(string("bigfloat_", c)))()
-        c = BigFloat()
-        ccall(($(string("mpfr_const_", cmpfr)), :libmpfr), 
-              Cint, (Ptr{BigFloat}, Int32),
-              &c, ROUNDING_MODE[end])
-        return c
-    end
-end
-
-promote_rule{sym}(::Type{MathConst{sym}}, ::Type{BigFloat}) = BigFloat
-promote_rule{sym}(::Type{MathConst{sym}}, ::Type{BigInt})   = BigFloat
-
-convert(::Type{BigFloat}, ::MathConst{:γ}) = bigfloat_eulergamma()
-convert(::Type{BigFloat}, ::MathConst{:π}) = bigfloat_pi()
 
 # Utility functions
 ==(x::BigFloat, y::BigFloat) = ccall((:mpfr_equal_p, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}), &x, &y) != 0

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -566,7 +566,7 @@ function atan2(y::BigFloat, x::BigFloat)
 end
 
 # Mathematical constants:
-for (c, cmpfr) in ((:pi,:pi), (:eulergamma, :euler), (:catalan, :catalan))
+for (c, cmpfr) in ((:pi, :pi), (:eulergamma, :euler), (:catalan, :catalan))
     @eval function $(symbol(string("bigfloat_", c)))()
         c = BigFloat()
         ccall(($(string("mpfr_const_", cmpfr)), :libmpfr), 
@@ -575,6 +575,12 @@ for (c, cmpfr) in ((:pi,:pi), (:eulergamma, :euler), (:catalan, :catalan))
         return c
     end
 end
+
+promote_rule{sym}(::Type{MathConst{sym}}, ::Type{BigFloat}) = BigFloat
+promote_rule{sym}(::Type{MathConst{sym}}, ::Type{BigInt})   = BigFloat
+
+convert(::Type{BigFloat}, ::MathConst{:γ}) = bigfloat_eulergamma()
+convert(::Type{BigFloat}, ::MathConst{:π}) = bigfloat_pi()
 
 # Utility functions
 ==(x::BigFloat, y::BigFloat) = ccall((:mpfr_equal_p, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}), &x, &y) != 0

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -185,7 +185,6 @@ big(z::Complex) = complex(big(real(z)),big(imag(z)))
 
 # mathematical constants
 include("constants.jl")
-big(x::MathConst) = convert(BigFloat,x)
 
 # Numerical integration
 include("quadgk.jl")

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -179,6 +179,12 @@ importall .GMP
 include("mpfr.jl")
 importall .MPFR
 
+big(n::Integer) = convert(BigInt,n)
+big(x::MathConst) = convert(BigFloat,x)
+big(x::FloatingPoint) = convert(BigFloat,x)
+big(q::Rational) = big(num(q))//big(den(q))
+big(z::Complex) = complex(big(real(z)),big(imag(z)))
+
 # Numerical integration
 include("quadgk.jl")
 importall .QuadGK

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -178,12 +178,14 @@ include("gmp.jl")
 importall .GMP
 include("mpfr.jl")
 importall .MPFR
-
 big(n::Integer) = convert(BigInt,n)
-big(x::MathConst) = convert(BigFloat,x)
 big(x::FloatingPoint) = convert(BigFloat,x)
 big(q::Rational) = big(num(q))//big(den(q))
 big(z::Complex) = complex(big(real(z)),big(imag(z)))
+
+# mathematical constants
+include("constants.jl")
+big(x::MathConst) = convert(BigFloat,x)
 
 # Numerical integration
 include("quadgk.jl")

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -225,7 +225,7 @@ end
 @test repr(-Inf) == "-Inf"
 @test repr(NaN) == "NaN"
 @test repr(-NaN) == "NaN"
-@test repr(pi) == "3.141592653589793"
+@test repr(float64(pi)) == "3.141592653589793"
 
 @test repr(1.0f0) == "1.0f0"
 @test repr(-1.0f0) == "-1.0f0"


### PR DESCRIPTION
Related to https://github.com/JuliaLang/julia/issues/3294.
