### PR TITLE
Clean up .travis.yml for release-0.1 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - BUILDOPTS="LLVM_CONFIG=llvm-config-3.2 USE_QUIET=0"; for lib in LLVM ZLIB SUITESPARSE ARPACK BLAS FFTW LAPACK LIGHTTPD GMP PCRE LIBUNWIND READLINE GLPK; do export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1"; done
     - sudo apt-get update -qq -y
     - sudo apt-get install zlib1g-dev
-    - sudo add-apt-repository ppa:staticfloat/julia-deps -y
+    - sudo add-apt-repository ppa:staticfloat/julia-0.1-deps -y
     - sudo apt-get update -qq -y
     - sudo apt-get install gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev libarpack2-dev libfftw3-dev libpcre3-dev lighttpd libgmp-dev libunwind7-dev libreadline-dev -y
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,3 @@ script:
     - make $BUILDOPTS PREFIX=/tmp/julia install
     - cd .. && mv julia julia2
     - cd /tmp/julia/share/julia/test && /tmp/julia/bin/julia runtests.jl all
-    - cd - && mv julia2 julia
-    - echo "Ready for packaging..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - sudo apt-get install zlib1g-dev
     - sudo add-apt-repository ppa:staticfloat/julia-0.1-deps -y
     - sudo apt-get update -qq -y
-    - sudo apt-get install gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev libarpack2-dev libfftw3-dev libpcre3-dev lighttpd libgmp-dev libunwind7-dev libreadline-dev -y
+    - sudo apt-get install gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev libarpack2-dev libfftw3-dev libpcre3-dev libgmp-dev libunwind7-dev libreadline-dev -y
 script:
     - make $BUILDOPTS PREFIX=/tmp/julia install
     - cd .. && mv julia julia2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
 notifications:
     email: false
 before_install:
-    - BUILDOPTS="LLVM_CONFIG=llvm-config-3.2 USE_QUIET=0"; for lib in LLVM ZLIB SUITESPARSE ARPACK BLAS FFTW LAPACK LIGHTTPD GMP PCRE LIBUNWIND READLINE GLPK; do export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1"; done
+    - BUILDOPTS="LLVM_CONFIG=llvm-config-3.2 USE_QUIET=0 USE_LIB64=0"; for lib in LLVM ZLIB SUITESPARSE ARPACK BLAS FFTW LAPACK LIGHTTPD GMP PCRE LIBUNWIND READLINE GLPK; do export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1"; done
     - sudo apt-get update -qq -y
     - sudo apt-get install zlib1g-dev
     - sudo add-apt-repository ppa:staticfloat/julia-0.1-deps -y


### PR DESCRIPTION
This enables Travis builds on release-0.1 again.

We seem to have some kind of problem with libfftw, but I'm not sure what it is.
