### PR TITLE
Removed comment in Arch section re Windows PATH

### DIFF
--- a/README.windows.md
+++ b/README.windows.md
@@ -139,8 +139,6 @@ First the required dependencies will be installed:
 
 The build and install process of Julia is the same as in steps 1-7 of Ubuntu.
 
-Finally, after completing the Julia cross-compilation by executing the 7 Julia build and installation steps described in the Ubuntu section and after moving the julia-* directory/zipfile to the target machine, add the `julia-*/lib` and `julia-*/lib/julia` directories to your Windows `PATH` environment variable.
-
 Important Build Errata
 ----------------------
 


### PR DESCRIPTION
I repeated the Arch cross-compilation steps to recheck everything, and noticed that the Windows PATH environment variable does not need to include the Julia lib directory (the Julia batch file executes without needing this additional step), so I removed my relevant comment.
