### PR TITLE
Replace i1mach and d1mach calls

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -505,8 +505,6 @@ end
 gamma(z::Complex) = exp(lgamma(z))
 
 # Derivatives of the digamma function
-i1mach(i::Int) = ccall(("i1mach_", Math.openlibm_extras), Int32, (Ptr{Int32},), &i)
-d1mach(i::Int) = ccall(("d1mach_", Math.openlibm_extras), Float64, (Ptr{Int32},), &i)
 function psifn(x::Float64, n::Int, kode::Int, m::Int)
 # Translated from http://www.netlib.org/slatec/src/dpsifn.f
 # Note: Underflow handling at 380 in original is skipped
@@ -535,9 +533,9 @@ function psifn(x::Float64, n::Int, kode::Int, m::Int)
     if kode < 1 | kode > 2 error("kode must be one or two") end
     if m < 1 error("m must be larger than one") end
     mm = m
-    const nx = min(-i1mach(15),i1mach(16))
-    const r1m5 = d1mach(5)
-    const r1m4 = d1mach(4)*0.5
+    const nx = min(-exponent(realmin(Float64)) + 1, exponent(realmax(Float64)))
+    const r1m5 = log10(2)
+    const r1m4 = Base.eps(Float64) * 0.5
     const wdtol = max(r1m4, 0.5e-18)
 #-----------------------------------------------------------------------
 #     elim = approximate exponential over and underflow limit
@@ -570,7 +568,7 @@ function psifn(x::Float64, n::Int, kode::Int, m::Int)
 #-----------------------------------------------------------------------
 #     compute xmin and the number of terms of the series, fln+1
 #-----------------------------------------------------------------------
-    rln = r1m5*i1mach(14)
+    rln = r1m5 * (8 * sizeof(Float64) - 1 - int(log2(exponent(realmax(Float64)) + 1)))
     rln = min(rln, 18.06)
     fln = max(rln, 3.0) - 3.0
     yint = 3.50 + 0.40*fln


### PR DESCRIPTION
This pull request replaces the calls to `i1mach` and `d1mach` in the recently added polygamma code. I didn't see a cleaner way to replace the code to determine the number of digits in the significand of a Float64 value.
