### PR TITLE
RFC: Improve static load balancing in @parallel

### DIFF
--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -14,3 +14,14 @@ a = convert(Array, d)
 
 @test fetch(@spawnat id_me localpart(d)[1,1]) == d[1,1]
 @test fetch(@spawnat id_other localpart(d)[1,1]) == d[1,101]
+
+# Test @parallel load balancing - all processors should get either M or M+1
+# iterations out of the loop range for some M.
+if nprocs() < 4
+    addprocs(4 - nprocs())
+end
+workloads = hist(@parallel((a,b)->[a,b], for i=1:7; myid(); end), nprocs())[2]
+@test max(workloads) - min(workloads) <= 1
+
+# @parallel reduction should work even with very short ranges
+@test @parallel(+, for i=1:2; i; end) == 3


### PR DESCRIPTION
This patch ensures that static load balancing is as good as possible: each
worker process gets either M or M+1 elements of the input range.  Previously
the remainder of the work would all go to the last process, which increases
the wall time by up to a factor of two.

Also fix a bug in preduce() which could cause a bounds exception when the
length of the input range was smaller than the number of workers.  It's not
clear to me that this is actually a bug in the code, or a bug in the way that
bounds checking for ranges works.  In particular the following seem to be
inconsistent:

```
julia> (1:10)[11:10]
ERROR: BoundsError()
 in getindex at range.jl:111
```

vs

```
julia> ([1:10])[11:10]
0-element Int64 Array
```
