### PR TITLE
Make versioned .julia/v0.x dir by default.

### DIFF
--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -3,10 +3,35 @@ module Cache
 import ..Git
 using ..Types
 
-path(pkg::String) = abspath(".cache", pkg)
+import ..Dir: pkgroot, path
+
+function mkcachedir()
+    cache = realpath(abspath(".cache"))
+    if isdir(cache)
+        return
+    end
+
+    @windows_only mkdir(cache)
+    @unix_only begin
+        rootcache = realpath(joinpath(pkgroot(), ".cache"))
+        if rootcache == cache
+            mkdir(cache)
+        elseif isdir(rootcache)
+            try
+                ln(rootcache, cache)
+            catch
+                mkdir(cache)
+            end
+        else
+            mkdir(rootcache)
+            mkcachedir()
+        end
+    end
+end
+
 
 function prefetch{S<:String}(pkg::String, url::String, sha1s::Vector{S})
-    isdir(".cache") || mkdir(".cache")
+    isdir(".cache") || mkcachedir()
     cache = path(pkg)
     if !isdir(cache)
         info("Cloning cache of $pkg from $url")

--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -5,13 +5,15 @@ import ..Git
 
 const DIR_NAME = ".julia"
 
+pkgroot() = abspath(get(ENV,"JULIA_PKGDIR",joinpath(homedir(),DIR_NAME)))
+
 function path()
-    b = abspath(get(ENV,"JULIA_PKGDIR",joinpath(homedir(),DIR_NAME)))
+    b = pkgroot()
     x, y = VERSION.major, VERSION.minor
     d = joinpath(b,"v$x.$y")
-    isdir(d) && return d
-    d = joinpath(b,"v$x")
-    isdir(d) && return d
+    if isdir(d) || !isdir(b) || !isdir(joinpath(b, "METADATA"))
+        return d
+    end
     return b
 end
 path(pkg::String...) = normpath(path(),pkg...)


### PR DESCRIPTION
This addresses https://github.com/JuliaLang/METADATA.jl/issues/264.

Pkg already had the ability to deal with julia-versioned package directories (`.julia/v0.x`), but didn't create them by default.  This patch causes that to happen.  Currently existing `.julia` directories will continue to work.

The same fix was made in `base/pkg2`, so the upcoming Pkg update will have the same behavior.

Note that, unfortunately, git submodules don't work well with being moved, so for existing installations, the best solution is to blow away `.julia` and start afresh.  

cc: @StefanKarpinski
