### PR TITLE
[RFC] Should insert!() return the same as push!()?

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -758,6 +758,7 @@ function insert!{T}(a::Array{T,1}, i::Integer, item)
         end
     end
     a[i] = item
+    return a
 end
 
 const _default_splice = []


### PR DESCRIPTION
I was a little surprised to find that insert!() returns the element being inserted, whereas push!() returns the new state of the array.  I've modified the former to act as the latter, and as the documentation doesn't seem to speak to this, does this seem reasonable to all of you?  I'm mostly just interested in consistency.
