### PR TITLE
only use 'catalan' for Catalan's constant, not 'G'

### DIFF
--- a/base/constants.jl
+++ b/base/constants.jl
@@ -57,14 +57,13 @@ big(x::MathConst) = convert(BigFloat,x)
 @math_const π 3.14159265358979323846 pi
 @math_const e 2.71828182845904523536 exp(big(1))
 @math_const γ 0.57721566490153286061 euler
-@math_const G 0.91596559417721901505 catalan
+@math_const catalan 0.91596559417721901505 catalan
 @math_const φ 1.61803398874989484820 (1+sqrt(big(5)))/2
 
 # aliases
 const pi = π
 const eu = e
 const eulergamma = γ
-const catalan = G
 const golden = φ
 
 # special behaviors

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -190,7 +190,7 @@ export
     π, pi,
     e, eu,
     γ, eulergamma,
-    G, catalan,
+    catalan,
     φ, golden,
 
 # Operators


### PR DESCRIPTION
This constant is way too rarely used (in comparison with `e`) to give it a single-letter name `G` in the global namespace.

Not only is `G` used for other [common constants](http://en.wikipedia.org/wiki/Gravitational_constant), but people don't even agree on `G` for Catalan's constant.  MathWorld uses `K`, Wikipedia uses `G`, and Mathematica uses `C`.  (Maple uses `Catalan`.)
