### PR TITLE
RFC: Added select!(v, r::Range1)

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -18,7 +18,7 @@ function median!{T<:Real}(v::AbstractVector{T}; checknan::Bool=true)
     isempty(v) && error("median of an empty array is undefined")
     checknan && any(isnan,v) && error("median of an array with NaNs is undefined")
     n = length(v)
-    isodd(n) ? select!(v,div(n+1,2)) : (select!(v,div(n,2))+select!(v,div(n,2)+1))/2
+    isodd(n) ? select!(v,div(n+1,2)) : (mm = select!(v, div(n,2):div(n,2)+1); (mm[1]+mm[2])/2)
 end
 median{T<:Real}(v::AbstractArray{T}; checknan::Bool=true) = median!(copy(vec(v)), checknan=checknan)
 

--- a/doc/stdlib/sort.rst
+++ b/doc/stdlib/sort.rst
@@ -174,9 +174,10 @@ Sorting-related Functions
 
 .. function:: select(v, k[, ord])
 
-   Find the element in position ``k`` in the sorted vector ``v``
-   without sorting, according to ordering ``ord`` (default:
-   ``Sort.Forward``).
+   Partially sort vector ``v`` according to ordering ``ord``, and return 
+   the element at position ``k``.  ``k`` can also be a range, in which 
+   case a vector of elements corresponding to the range positions is 
+   returned.
 
 .. function:: select!(v, k[, ord])
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -5,6 +5,7 @@
 @test issorted([1,2,3])
 @test reverse([2,3,1]) == [1,3,2]
 @test select([3,6,30,1,9],3) == 6
+@test select([3,6,30,1,9],3:4) == [6,9]
 @test sum(randperm(6)) == 21
 @test nthperm([0,1,2],3) == [1,0,2]
 


### PR DESCRIPTION
This is in response to 6f23b428d7.

Seems to work:

``` julia
julia> for i = 1:10000
          lim=10000; a = rand(lim); b = copy(a); i1 = rand(1:lim-1); i2 = rand(i1:lim)
          sort!(b)
          @assert select!(a, i1:i2) == b[i1:i2]
       end

julia>
```

Also improves `median` calculation time slightly.

Before:

``` julia
julia> x = randn(10000);

julia> sum([@elapsed median(x) for i in 1:1000])
1.0680626930000012

julia> sum([@elapsed median!(x) for i in 1:1000])
0.6929740309999998
```

After:

``` julia
julia> sum([@elapsed median(x) for i in 1:1000])
0.9136840810000004

julia> sum([@elapsed median!(x) for i in 1:1000])
0.6345926139999998
```
