### PR TITLE
error.jl: add application-oriented assertion facility

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -37,13 +37,136 @@ strerror(e::Integer) = bytestring(ccall(:strerror, Ptr{Uint8}, (Int32,), e))
 strerror() = strerror(errno())
 systemerror(p, b::Bool) = b ? throw(SystemError(string(p))) : nothing
 
-## assertion functions and macros ##
+## assertion functions and macros that raise an error on assertion violations ##
 
 assert(x) = assert(x,'?')
 assert(x,labl) = x ? nothing : error("assertion failed: ", labl)
 macro assert(ex)
     :($(esc(ex)) ? nothing : error("assertion failed: ", $(string(ex))))
 end
+
+## application-oriented assertion macro that need not raise an error ##
+
+module Assertions # PRELIMINARY VERSION by pkoppstein@gmail.com 2013-06-15
+
+# This version is PRELIMINARY, primarily because the file and line number
+# of the assertion are not printed when an assertion violation is detected.
+
+# Usage:
+#     @ASSERT <condition>
+# or  @ASSERT <condition>, <expr> ....
+# or  @ASSERT (<condition>, <expr> ....)  # a space is required after "@ASSERT"
+#
+# If assertion checking is on, then an attempt to evaluate the tuple
+# (<condition>, <expr> ....) will always be made.
+#
+# For an assertion to be considered valid:
+# <condition> should evaluate to a boolean value;
+# <expr>      should be an expression that does not raise an exception.
+# 
+# The @ASSERT macro has been written with the goal of ensuring that:
+# (a) invalid assertions will NEVER raise a run-time error;
+# (b) if @ASSERT returns a value, that value with be nothing.
+#
+# Examples:
+# julia> x=1; y=2
+# julia> @ASSERT x == 1
+# julia> @ASSERT (x == y, "x=$x", "y=$y")
+# Assertion failed: :((x==y)) where ("x=1","y=2")
+
+# Examples showing that invalid assertions do not raise an error, even
+# if Assertions.state.error is true:
+# julia> Assertions.error(true)
+# julia> @ASSERT 1
+# MESSAGE: INVALID ASSERTION: 1
+# julia> @ASSERT 1 == 1, error("farewell") 
+# MESSAGE: INVALID ASSERTION: :(1 == 1,error("farewell"))
+
+# By default:
+# - assertion checking is on
+# - assertion violations do NOT raise an error
+# - assertion violation messages are sent to OUTPUT_STREAM
+#
+# To turn assertion-checking off:            Assertions.on(false)
+# To raise an error on assertion violations: Assertions.error(true)
+# To direct assertions to STDERR:            Assertions.io(STDERR)
+
+type State
+  on::Bool
+  io::IO
+  error::Bool
+end
+
+state = State(true, OUTPUT_STREAM, false)  # the default values
+
+function on(b::Bool) 
+  state.on = b
+end
+
+function io(v::IO)
+  state.io = v
+end
+
+function error(v::Bool)
+  state.error = v
+end
+
+# possibly print a message, and possibly raise an error
+function message(msg)
+  if state.error
+    if state.io != STDERR 
+       println(state.io, "Assertion failed: ", msg)
+    end
+    error("Assertion failed: ", msg) 
+  else
+    println(state.io, "Assertion failed: ", msg)
+  end
+end
+
+# helper method
+function check(values, exp, show)
+  if typeof(values[1]) == Bool
+    if !values[1] ; message( "$exp where $show" ) ; end
+  else
+     message( "invalid assertion: $exp where $show" )
+  end
+end
+
+end # Assertions
+
+# NOTE: The @ASSERT macro is deliberately defined outside the Assertions module.
+macro ASSERT(ex)
+  if Assertions.state.on
+    if typeof(ex) == Expr && ex.head == :tuple && length( ex.args ) > 0
+      :(begin
+          local values, exp, show
+          try
+            values = $(esc(ex) )
+            exp = $(string(ex.args[1]))
+            show = string( values[2:end] )
+          catch
+            info("INVALID ASSERTION: " *  $(string(ex)))
+            values=(true,)
+          end
+          Assertions.check(values, exp, show)
+        end
+       )
+    else 
+      :(begin
+          local value
+          try
+            value = $(esc(ex))
+          catch
+            info("INVALID ASSERTION: " * $(string(ex)))
+            value = true
+          end
+          value ? nothing : (Assertions.message( $(string(ex)) ))
+        end
+       )
+    end
+  end
+end # @ASSERT
+
 
 ## printing with color ##
 


### PR DESCRIPTION
This modification to error.jl adds a module named Assertions and a top-level macro which can be called in essentially one of two ways:

<pre><code>
 @ASSERT &lt;condition&gt;
 @ASSERT (&lt;condition&gt;, &lt;expr&gt; ....)
</code></pre>


Please see the "Design FAQ" at http://docs.oracle.com/javase/7/docs/technotes/guides/language/assert.html 
for the general rationale for having this kind of application-oriented assertion facility as part of the core language. (Two relevant paragraphs are appended below at (*).)  

There are as best I can tell two other reasons:
1. the facility should print the file and line number of an assertion violation;
2. the ability to turn assertion checking off when invoking julia. 

The key features of this application-oriented assertion facility are:
1. it is very simple to use;
2. there is virtually no overhead if assertion-checking is turned off;
3. assertion violations do not raise a run-tim error condition unless a flag specifies otherwise;
4. errors in assertion specifications should not raise run-time errors;
5. if @ASSERT returns a value, it is nothing.

Further details are in error.jl; these should ultimately be migrated to Julia documentation.

PLEASE NOTE THAT THERE ARE STILL SOME BOOTSTRAPPING ISSUES TO BE RESOLVED.

The additional code can be exercised by moving it to a separate file.

(*)
Excerpts from http://docs.oracle.com/javase/7/docs/technotes/guides/language/assert.html 

> Why provide an assertion facility, given that one can program assertions atop the Java programming language with no special support?
> Although ad hoc implementations are possible, they are of necessity either ugly (requiring an if statement for each assertion) or inefficient (evaluating the condition even if assertions are disabled). Further, each ad hoc implementation has its own means of enabling and disabling assertions, which lessens the utility of these implementations, especially for debugging in the field. As a result of these shortcomings, assertions have never become a part of the culture among engineers using the Java programming language. Adding assertion support to the platform stands a good chance of rectifying this situation.
> 
> Why does this facility justify a language change, as opposed to a library solution?
> We recognize that a language change is a serious effort, not to be undertaken lightly. The library approach was considered. It was, however, deemed essential that the runtime cost of assertions be negligible if they are disabled. In order to achieve this with a library, the programmer is forced to hard-code each assertion as an if statement. Many programmers would not do this. Either they would omit the if statement and performance would suffer, or they would ignore the facility entirely. Note also that assertions were contained in James Gosling's original specification for the Java programming language. Assertions were removed from the Oak specification because time constraints prevented a satisfactory design and implementation.
