### PR TITLE
Allow setting USE_MKL and MKLLIB in Make.user

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -348,8 +348,14 @@ endif
 
 # MKL
 
-USE_MKL = 0
-MKLLIB = $$MKLROOT/lib/intel64
+ifeq ($(USE_MKL),)
+  USE_MKL = 0
+endif
+ifeq ($(USE_MKL), 1)
+ifeq ($(strip $(MKLLIB)),)
+  MKLLIB = $$MKLROOT/lib/intel64
+endif
+endif
 
 ifeq ($(USE_MKL), 1)
 USE_BLAS64 = 0


### PR DESCRIPTION
With this small change, one can set `USE_MKL` and `MKLLIB` in Make.user and Make.inc honors such settings if they are there.

If these variables are not set in Make.user, it falls back onto the default settings.
