### PR TITLE
hacks to make julia run on atom N270 architecture (32bit, running ubuntu 9.04)

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -148,7 +148,7 @@ JCFLAGS += '-DJL_SYSTEM_IMAGE_PATH="../$(JL_PRIVATE_LIBDIR)/sys.ji"'
 # OPENBLAS build options
 OPENBLAS_DYNAMIC_ARCH=0
 OPENBLAS_USE_THREAD=1
-OPENBLAS_TARGET_ARCH=
+OPENBLAS_TARGET_ARCH=NEHALEM
 
 # Use libraries available on the system instead of building them
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -528,7 +528,9 @@ install-double-conversion: $(BUILD)/lib/libgrisu.$(SHLIB_EXT)
 
 ## openlibm && openlibm-extras ##
 
-OPENLIBM_FLAGS = ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC)
+#OPENLIBM_FLAGS = ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC)
+
+OPENLIBM_FLAGS = ARCH="i686" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC)
 
 OPENLIBM_OBJ_TARGET = $(BUILD)/lib/libopenlibm.$(SHLIB_EXT)
 OPENLIBM_OBJ_SOURCE = openlibm/libopenlibm.$(SHLIB_EXT)
@@ -625,8 +627,12 @@ install-random: $(LIBRANDOM_OBJ_TARGET)
 RMATH_OBJ_TARGET = $(BUILD)/lib/libRmath.$(SHLIB_EXT)
 RMATH_OBJ_SOURCE = Rmath/src/libRmath.$(SHLIB_EXT)
 
+#RMATH_FLAGS += CC="$(CC)" USECLANG=$(USECLANG) USEGCC=$(USEGCC) \
+#			   OS="$(OS)" ARCH="$(ARCH)" \
+#			   USE_LIBRANDOM=1 LIBRANDOM_PATH="$(BUILD)/lib"
+
 RMATH_FLAGS += CC="$(CC)" USECLANG=$(USECLANG) USEGCC=$(USEGCC) \
-			   OS="$(OS)" ARCH="$(ARCH)" \
+			   OS="$(OS)" ARCH="i486" \
 			   USE_LIBRANDOM=1 LIBRANDOM_PATH="$(BUILD)/lib"
 
 Rmath/Make.inc:
@@ -688,6 +694,8 @@ ifneq ($(BUILD_OS),$(OS))
 OPENBLAS_BUILD_OPTS += OSNAME=$(OS) CROSS=1 HOSTCC=$(HOSTCC)
 endif
 ifeq ($(ARCH),i686)
+OPENBLAS_BUILD_OPTS += BINARY=32
+else ifeq ($(ARCH),i486)
 OPENBLAS_BUILD_OPTS += BINARY=32
 else ifeq ($(ARCH),x86_64)
 OPENBLAS_BUILD_OPTS += BINARY=64

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -138,6 +138,11 @@ typedef int64_t int_t;
 typedef uint32_t uint_t;
 typedef int32_t int_t;
 #endif
+
+#ifdef MY_HACK
+typedef __PTRDIFF_TYPE__ ptrdiff_t; 
+#endif
+
 typedef ptrdiff_t ptrint_t; // pointer-size int
 typedef size_t uptrint_t;
 typedef ptrdiff_t offset_t;

--- a/src/support/libsupport.h
+++ b/src/support/libsupport.h
@@ -1,6 +1,8 @@
 #ifndef LIBSUPPORT_H
 #define LIBSUPPORT_H
 
+#define MY_HACK
+
 #include "platform.h"
 
 #if defined(_CPU_X86_64_)

--- a/src/support/utf8.c
+++ b/src/support/utf8.c
@@ -20,6 +20,8 @@
 #include <wchar.h>
 #include <wctype.h>
 
+#define MY_HACK
+
 #include "dtypes.h"
 
 #ifdef _OS_WINDOWS_


### PR DESCRIPTION
With regard to Issue #3421 

Note this Pull Request is being sent for information purposes only. That is, so you can see what I needed to do to make julia install on atom N270 architecture (32bit, running ubuntu 9.04). It contains quick and dirty hacks, which should be made (much) better before being integrated into your code base (they will likely break things for other systems). I'm sending this so you know were the code breaks and how I fixed it---not because I think it is good enough to release.
