### PR TITLE
faster readcsv. fixes #3350

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -1212,6 +1212,11 @@ float64_isvalid(s::String, out::Array{Float64,1}) =
 float32_isvalid(s::String, out::Array{Float32,1}) =
     ccall(:jl_strtof, Int32, (Ptr{Uint8},Ptr{Float32}), s, out) == 0
 
+float64_isvalid(s::SubString, out::Array{Float64,1}) =
+    ccall(:jl_substrtod, Int32, (Ptr{Uint8},Int,Int,Ptr{Float64}), s.string, s.offset, s.endof, out) == 0
+float32_isvalid(s::SubString, out::Array{Float32,1}) =
+    ccall(:jl_substrtof, Int32, (Ptr{Uint8},Int,Int,Ptr{Float32}), s.string, s.offset, s.endof, out) == 0
+
 begin
     local tmp::Array{Float64,1} = Array(Float64,1)
     local tmpf::Array{Float32,1} = Array(Float32,1)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -600,6 +600,18 @@ DLLEXPORT void jl_print_int64(JL_STREAM *s, int64_t i)
     JL_PRINTF(s, "%lld", i);
 }
 
+DLLEXPORT int jl_substrtod(char *str, int offset, int len, double *out)
+{
+    char *p;
+    errno = 0;
+    char *bstr = str+offset;
+    *out = strtod(bstr, &p);
+    if((p == bstr) || (p != (bstr+len)) ||
+        (errno==ERANGE && (*out==0 || *out==HUGE_VAL || *out==-HUGE_VAL)))
+        return 1;
+    return 0;
+}
+
 DLLEXPORT int jl_strtod(char *str, double *out)
 {
     char *p;
@@ -613,6 +625,23 @@ DLLEXPORT int jl_strtod(char *str, double *out)
             return 1;
         p++;
     }
+    return 0;
+}
+
+DLLEXPORT int jl_substrtof(char *str, int offset, int len, float *out)
+{
+    char *p;
+    errno = 0;
+    char *bstr = str+offset;
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+    *out = (float)strtod(bstr, &p);
+#else
+    *out = strtof(bstr, &p);
+#endif
+
+    if((p == bstr) || (p != (bstr+len)) ||
+        (errno==ERANGE && (*out==0 || *out==HUGE_VALF || *out==-HUGE_VALF)))
+        return 1;
     return 0;
 }
 


### PR DESCRIPTION
Changes to `readdlm` for speed improvements. Instead of `readline` and `split` the new method instead slurps the whole file into memory, parses it linearly for delimiter offsets and uses `SubString` wherever possible.

With this patch:

```
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "help()" to list help topics
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.2.0-2039.r3771bf24.dirty
 _/ |\__'_|_|_|\__'_|  |  Commit 3771bf244d 2013-06-17 22:15:40*
|__/                   |  x86_64-apple-darwin12.4.0

julia> @time s = readcsv("vList.csv")
elapsed time: 16.183337526 seconds
1608716x9 Any Array:
   1.0  166.0  "Govindarajanagar  "  "RDU3444981"  "Mahesh B"                                            "Basavaraju"                 " ..."                     22.0   "M"
   2.0  166.0  "Govindarajanagar "    "RDU3524188"  "Kemparaju"                                           "Chikkanachari"              " ."                       34.0   "M"
```

Prior to this patch:

```
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "help()" to list help topics
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.2.0-2030.rbf13c7aa
 _/ |\__'_|_|_|\__'_|  |  Commit bf13c7aaf5 2013-06-16 04:52:40
|__/                   |  x86_64-apple-darwin12.4.0

julia> @time s = readcsv("vList.csv")
elapsed time: 151.918892449 seconds
1608716x9 Any Array:
   1.0  166.0  "Govindarajanagar  "  "RDU3444981"  "Mahesh B"                                            "Basavaraju"                 " ..."                     22.0   "M"
   2.0  166.0  "Govindarajanagar "    "RDU3524188"  "Kemparaju"                                           "Chikkanachari"              " ."                       34.0   "M"
```
