### PR TITLE
Clarify compiler depdencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ Julia can be developed in an isolated Vagrant environment. See [the Vagrant READ
 Building Julia requires that the following software be installed:
 
 - **[GNU make]**                — building dependencies.
-- **[gcc, g++][gcc]**           — compiling and linking C, C++
-- **[clang][clang]**            — clang is the default compiler on OS X (Need at least v3.1, Xcode 4.3.3 on OS X)
+- **[gcc, g++][gcc]** or **[clang][clang]** — compiling and linking C, C++ (if clang, need at least v3.1, Xcode 4.3.3 on OS X)
 - **[gfortran][gcc]**           — compiling and linking fortran libraries
 - **[git]**                     — version control and package management.
 - **[perl]**                    — preprocessing of header files of libraries.


### PR DESCRIPTION
This is really trivial, but, when I finally built julia on a non OS X machine, I was briefly confused about why you'd need both gcc and clang, until I looked at Make.inc and realized that you don't actually need both of them, even though they're both listed in the "Building Julia requires that the following software be installed" section.
