### PR TITLE
Fixes UVError bug in listen/accept

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -734,7 +734,7 @@ function accept(server::UVServer, client::AsyncStream)
             uv_error("accept:",_uv_lasterror()!=UV_EAGAIN)
         end
         err = wait(server.connectnotify)
-        if err.uv_code != -1
+        if err.uv_code == -1
             throw(UVError("accept",err))
         end
     end


### PR DESCRIPTION
Right now you get the following error on the first successful connection.

``` .sh
ERROR: accept: success (OK)
 in accept at stream.jl:738
```
