### PR TITLE
RFC: Split delete!(h::Dict,key) into pop!(), delete!() (#3405)

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1619,7 +1619,7 @@ function union(vs...)
         for v_elem in v
             if !contains(seen, v_elem)
                 push!(ret, v_elem)
-                add!(seen, v_elem)
+                push!(seen, v_elem)
             end
         end
     end
@@ -1634,7 +1634,7 @@ function setdiff(a, b)
     for a_elem in a
         if !contains(seen, a_elem) && !contains(bset, a_elem)
             push!(ret, a_elem)
-            add!(seen, a_elem)
+            push!(seen, a_elem)
         end
     end
     ret

--- a/base/collections.jl
+++ b/base/collections.jl
@@ -254,13 +254,12 @@ function dequeue!(pq::PriorityQueue)
 end
 
 function dequeue!(pq::PriorityQueue, key)
-     !haskey(pq.index, key) && throw(KeyError(key))
-     idx = delete!(pq.index, key)
-     splice!(pq.xs, idx)
-     for (k,v) in pq.index
-       (v >= idx) && (pq.index[k] = (v-1))
-     end
-     key
+    idx = pop!(pq.index, key)  # throws key error if missing
+    splice!(pq.xs, idx)
+    for (k,v) in pq.index
+        (v >= idx) && (pq.index[k] = (v-1))
+    end
+    key
 end
 
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -33,7 +33,8 @@ end
 @deprecate  insert          insert!
 @deprecate  del             delete!
 @deprecate  del_all         empty!
-@deprecate  add             add!
+@deprecate  add             push!
+@deprecate  add!            push!
 @deprecate  add_each        add_each!
 @deprecate  del_each        del_each!
 @deprecate  toggle          symdiff!
@@ -234,6 +235,16 @@ end
 function start_timer(timer::TimeoutAsyncWork, timeout::Int, repeat::Int)
     warn_once("start_timer now expects arguments in units of seconds. you may need to update your code")
     invoke(start_timer, (TimeoutAsyncWork,Real,Real), timer, timeout, repeat)
+end
+
+# delete!(Dict, key, ...)
+@deprecate  delete!(d::Dict, key, default)  pop!(d, key, default)
+
+# Duplicates function in dict.jl, but adds warning
+function delete!(t::ObjectIdDict, key::ANY)
+    warn_once("delete!(h::ObjectIdDict,key) now returns the modified dictionary.\nUse pop!(h::ObjectIdDict,key) to retrieve the value instead.")
+    ccall(:jl_eqtable_pop, Any, (Any, Any), t.ht, key)
+    t
 end
 
 # redirection operators

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -33,8 +33,6 @@ end
 @deprecate  insert          insert!
 @deprecate  del             delete!
 @deprecate  del_all         empty!
-@deprecate  add             push!
-@deprecate  add!            push!
 @deprecate  add_each        add_each!
 @deprecate  del_each        del_each!
 @deprecate  toggle          symdiff!
@@ -224,6 +222,9 @@ export PipeString
 @deprecate finfer                     code_typed
 @deprecate disassemble(f::Function,t::Tuple)           code_llvm(f,t)
 @deprecate disassemble(f::Function,t::Tuple,asm::Bool) (asm ? code_native(f,t) : code_llvm(f,t))
+@deprecate  add(s::Set, x)                  push!
+@deprecate  add!(s::Set, x)                 push!
+@deprecate  delete!(d::Dict, key, default)  pop!(d, key, default)
 
 deprecated_ls() = run(`ls -l`)
 deprecated_ls(args::Cmd) = run(`ls -l $args`)
@@ -235,16 +236,6 @@ end
 function start_timer(timer::TimeoutAsyncWork, timeout::Int, repeat::Int)
     warn_once("start_timer now expects arguments in units of seconds. you may need to update your code")
     invoke(start_timer, (TimeoutAsyncWork,Real,Real), timer, timeout, repeat)
-end
-
-# delete!(Dict, key, ...)
-@deprecate  delete!(d::Dict, key, default)  pop!(d, key, default)
-
-# Duplicates function in dict.jl, but adds warning
-function delete!(t::ObjectIdDict, key::ANY)
-    warn_once("delete!(h::ObjectIdDict,key) now returns the modified dictionary.\nUse pop!(h::ObjectIdDict,key) to retrieve the value instead.")
-    ccall(:jl_eqtable_pop, Any, (Any, Any), t.ht, key)
-    t
 end
 
 # redirection operators

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -222,8 +222,8 @@ export PipeString
 @deprecate finfer                     code_typed
 @deprecate disassemble(f::Function,t::Tuple)           code_llvm(f,t)
 @deprecate disassemble(f::Function,t::Tuple,asm::Bool) (asm ? code_native(f,t) : code_llvm(f,t))
-@deprecate  add(s::Set, x)                  push!
-@deprecate  add!(s::Set, x)                 push!
+@deprecate  add(s::Set, x)                  push!(s,x)
+@deprecate  add!(s::Set, x)                 push!(s,x)
 @deprecate  delete!(d::Dict, key, default)  pop!(d, key, default)
 
 deprecated_ls() = run(`ls -l`)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -159,7 +159,6 @@ function pop!(t::ObjectIdDict, key::ANY)
 end
 
 function delete!(t::ObjectIdDict, key::ANY)
-    #warn_once("delete!(h::ObjectIdDict,key) now returns the modified dictionary.\nUse pop!(h::ObjectIdDict,key) to retrieve the value instead.")
     ccall(:jl_eqtable_pop, Any, (Any, Any), t.ht, key)
     t
 end
@@ -541,7 +540,6 @@ function _delete!(h::Dict, index)
 end
 
 function delete!(h::Dict, key)
-    warn_once("delete!(h::Dict,key) now returns the modified dictionary.\nUse pop!(h::Dict,key) to retrieve the value instead.")
     index = ht_keyindex(h, key)
     if index > 0; _delete!(h, index); end
     h

--- a/base/env.jl
+++ b/base/env.jl
@@ -73,9 +73,16 @@ const ENV = EnvHash()
 getindex(::EnvHash, k::String) = @accessEnv k throw(KeyError(k))
 get(::EnvHash, k::String, def) = @accessEnv k (return def)
 contains(::KeyIterator{EnvHash}, k::String) = _hasenv(k)
-delete!(::EnvHash, k::String) = (v = ENV[k]; _unsetenv(k); v)
+pop!(::EnvHash, k::String) = (v = ENV[k]; _unsetenv(k); v)
+pop!(::EnvHash, k::String, def) = haskey(ENV,k) ? pop!(ENV,k) : def
+function delete!(::EnvHash, k::String)
+    warn_once("delete!(h::EnvHash,key) now returns the modified environment.\nUse pop!(h::EnvHash,key) to retrieve the value instead.\n")
+    _unsetenv(k)
+    ENV
+end
 delete!(::EnvHash, k::String, def) = haskey(ENV,k) ? delete!(ENV,k) : def
 setindex!(::EnvHash, v, k::String) = _setenv(k,string(v))
+push!(::EnvHash, k::String, v) = setindex!(ENV, v, k)
 
 @unix_only begin
 start(::EnvHash) = 0

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -680,7 +680,6 @@ export
     unshift!,
 
 # collections
-    add!,
     all,
     any,
     collect,
@@ -709,6 +708,8 @@ export
     mapreduce,
     merge!,
     merge,
+    #pop!,
+    #push!,
     reduce,
     setdiff!,
     setdiff,

--- a/base/git.jl
+++ b/base/git.jl
@@ -166,7 +166,7 @@ function config_sections(cfg::Dict)
     sections = Set{ByteString}()
     for (key,_) in cfg
         m = match(r"^(.+)\.", key)
-        if m != nothing add!(sections,m.captures[1]) end
+        if m != nothing; push!(sections,m.captures[1]); end
     end
     sections
 end
@@ -181,7 +181,7 @@ function merge_configs(Bc::Dict, Lc::Dict, Rc::Dict)
     for section in Bs - Ls & Rs
         filter!((k,v)->!beginswith(k,"$section."),Lc)
         filter!((k,v)->!beginswith(k,"$section."),Rc)
-        add!(deleted, section)
+        push!(deleted, section)
     end
     # merge the remaining config key-value pairs
     cfg = Dict()

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1133,7 +1133,7 @@ function typeinf(linfo::LambdaStaticData,atypes::Tuple,sparams::Tuple, def, cop)
     recpts = IntSet()  # statements that depend recursively on our value
     W = IntSet()
     # initial set of pc
-    add!(W,1)
+    push!(W,1)
     # initial types
     s[1] = ObjectIdDict()
     for v in vars
@@ -1191,7 +1191,7 @@ function typeinf(linfo::LambdaStaticData,atypes::Tuple,sparams::Tuple, def, cop)
         pc = first(W)
         while true
             #print(pc,": ",s[pc],"\n")
-            delete!(W, pc, 0)
+            delete!(W, pc)
             if is(handler_at[pc],())
                 handler_at[pc] = cur_hand
             else
@@ -1204,7 +1204,7 @@ function typeinf(linfo::LambdaStaticData,atypes::Tuple,sparams::Tuple, def, cop)
                 if !(isa(frame.prev,CallStack) && frame.prev.cycleid == frame.cycleid)
                     toprec = true
                 end
-                add!(recpts, pc)
+                push!(recpts, pc)
                 #if dbg
                 #    show(pc); print(" recurred\n")
                 #end
@@ -1214,7 +1214,7 @@ function typeinf(linfo::LambdaStaticData,atypes::Tuple,sparams::Tuple, def, cop)
                 # propagate type info to exception handler
                 l = cur_hand[1]::Int
                 if stchanged(changes, s[l], vars)
-                    add!(W, l)
+                    push!(W, l)
                     s[l] = stupdate(s[l], changes, vars)
                 end
             end
@@ -1234,7 +1234,7 @@ function typeinf(linfo::LambdaStaticData,atypes::Tuple,sparams::Tuple, def, cop)
                         # general case
                         handler_at[l] = cur_hand
                         if stchanged(changes, s[l], vars)
-                            add!(W, l)
+                            push!(W, l)
                             s[l] = stupdate(s[l], changes, vars)
                         end
                     end
@@ -1257,7 +1257,7 @@ function typeinf(linfo::LambdaStaticData,atypes::Tuple,sparams::Tuple, def, cop)
                         if ot === NF || !typeseq(vt,ot)
                             # l+1 is the statement after the label, where the
                             # static_typeof occurs.
-                            add!(W, l+1)
+                            push!(W, l+1)
                             s[l+1][var] = vt
                         end
                     end
@@ -1269,7 +1269,7 @@ function typeinf(linfo::LambdaStaticData,atypes::Tuple,sparams::Tuple, def, cop)
                         if !(isa(frame.prev,CallStack) && frame.prev.cycleid == frame.cycleid)
                             toprec = true
                         end
-                        add!(recpts, pc)
+                        push!(recpts, pc)
                         #if dbg
                         #    show(pc); print(" recurred\n")
                         #end
@@ -1290,7 +1290,7 @@ function typeinf(linfo::LambdaStaticData,atypes::Tuple,sparams::Tuple, def, cop)
                             #    show(r)
                             #    print("\n")
                             #end
-                            add!(W,r)
+                            push!(W,r)
                         end
                     end
                 elseif is(hd,:enter)
@@ -2030,7 +2030,7 @@ function find_sa_vars(ast)
     for vi in ast.args[2][2]
         if (vi[3]&1)!=0
             # remove captured vars
-            delete!(av, vi[1], nothing)
+            delete!(av, vi[1])
         end
     end
     av

--- a/base/intset.jl
+++ b/base/intset.jl
@@ -76,19 +76,7 @@ end
 pop!(s::IntSet) = pop!(s, last(s))
 
 function delete!(s::IntSet, n::Integer)
-    if n >= s.limit
-        if s.fill1s
-            lim = int(n + div(n,2))
-            sizehint(s, lim)
-        else
-            return s
-        end
-    end
-    mask = uint32(1)<<(n&31)
-    idx = n>>5 + 1
-    b = s.bits[idx]
-    if (b&mask)==0; return s; end
-    s.bits[idx] = b&~mask
+    pop!(s, n, n)
     return s
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -112,7 +112,7 @@ function reload_path(path)
     end
     package_list[path] = time()
     tls = task_local_storage()
-    prev = delete!(tls, :SOURCE_PATH, nothing)
+    prev = pop!(tls, :SOURCE_PATH, nothing)
     try
         eval(Main, :(Base.include_from_node1($path)))
     catch e

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -253,7 +253,7 @@ function rmprocs(args...; waitfor = 0.0)
     
     for i in [args...]
         if haskey(map_pid_wrkr, i)
-            add!(rmprocset, i)
+            push!(rmprocset, i)
             remote_do(i, exit)
         end
     end
@@ -324,7 +324,7 @@ function deregister_worker(pg, pid)
             w.manage(w.id, w.config, :deregister)
         end
     end
-    add!(map_del_wrkr, pid)
+    push!(map_del_wrkr, pid)
 
     # delete this worker from our RemoteRef client sets
     ids = {}
@@ -344,7 +344,7 @@ function deregister_worker(pg, pid)
     # throw exception to tasks waiting for this pid
     for (id,rv) in tonotify
         notify_error(rv.full, ProcessExitedException())
-        delete!(pg.refs, id, nothing)
+        delete!(pg.refs, id)
     end
 end
 

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -315,9 +315,9 @@ end
 deregister_worker(pid) = deregister_worker(PGRP, pid)
 function deregister_worker(pg, pid)
     pg.workers = filter(x -> !(x.id == pid), pg.workers)
-    w = delete!(map_pid_wrkr, pid, nothing)
+    w = pop!(map_pid_wrkr, pid, nothing)
     if isa(w, Worker) 
-        delete!(map_sock_wrkr, w.socket) 
+        pop!(map_sock_wrkr, w.socket) 
         
         # Notify the cluster manager of this workers death
         if myid() == 1
@@ -420,7 +420,7 @@ function lookup_ref(pg, id)
         # first we've heard of this ref
         rv = RemoteValue()
         pg.refs[id] = rv
-        add!(rv.clientset, id[1])
+        push!(rv.clientset, id[1])
     end
     rv
 end
@@ -478,7 +478,7 @@ end
 
 function add_client(id, client)
     rv = lookup_ref(id)
-    add!(rv.clientset, client)
+    push!(rv.clientset, client)
     nothing
 end
 
@@ -575,7 +575,7 @@ end
 function schedule_call(rid, thunk)
     rv = RemoteValue()
     (PGRP::ProcessGroup).refs[rid] = rv
-    add!(rv.clientset, rid[1])
+    push!(rv.clientset, rid[1])
     enq_work(@task(run_work_thunk(rv,thunk)))
     rv
 end

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -293,7 +293,7 @@ function gather_repository_data(julia_version::VersionNumber=VERSION)
         p = d[2].package
         if haskey(fixed, p)
             if !contains(d[2], Version(p, fixed[p]))
-                add!(unsatisfiable, d[1])
+                push!(unsatisfiable, d[1])
             end
             false # drop
         else
@@ -304,7 +304,7 @@ function gather_repository_data(julia_version::VersionNumber=VERSION)
         !contains(unsatisfiable, v)
     end
     pkgs = Set{String}()
-    for v in vers add!(pkgs, v.package) end
+    for v in vers; push!(pkgs, v.package); end
     filter!(deps) do d
         contains(pkgs, d[1].package) && !contains(unsatisfiable, d[1])
     end
@@ -313,7 +313,7 @@ function gather_repository_data(julia_version::VersionNumber=VERSION)
         filter!(deps) do d
             p = d[2].package
             if !contains(pkgs, p)
-                add!(unsatisfiable, d[1])
+                push!(unsatisfiable, d[1])
                 false # drop
             else
                 true # keep
@@ -326,7 +326,7 @@ function gather_repository_data(julia_version::VersionNumber=VERSION)
             !contains(unsatisfiable, v)
         end
         empty!(pkgs)
-        for v in vers add!(pkgs, v.package) end
+        for v in vers; push!(pkgs, v.package); end
         filter!(deps) do d
             contains(pkgs, d[1].package) && !contains(unsatisfiable, d[1])
         end

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -60,7 +60,7 @@ end
 
 function ReqsStruct(reqs::Vector{VersionSet}, vers::Vector{Version}, deps::Vector{(Version,VersionSet)})
     pkgs = Set{String}()
-    for v in vers add!(pkgs, v.package) end
+    for v in vers; push!(pkgs, v.package); end
 
     for r in reqs
         if !contains(pkgs, r.package)
@@ -1224,7 +1224,7 @@ function substructs(reqsstruct0::ReqsStruct, pkgstruct0::PkgStruct, pdeps::Vecto
             for w in pdeps[p0], vs in w
                 p1 = pdict[vs.package]
                 if !contains(pset, p1)
-                    add!(staged_next, p1)
+                    push!(staged_next, p1)
                 end
             end
         end

--- a/base/pkg2/query.jl
+++ b/base/pkg2/query.jl
@@ -16,7 +16,7 @@ function requirements(reqs::Dict, fix::Dict)
         merge_requires!(reqs, f1.requires)
     end
     for (p,f) in fix
-        delete!(reqs, p, nothing)
+        delete!(reqs, p)
     end
     reqs
 end
@@ -24,10 +24,10 @@ end
 function dependencies(avail::Dict, fix::Dict)
     avail = deepcopy(avail)
     for (fp,fx) in fix
-        delete!(avail, fp, nothing)
+        delete!(avail, fp)
         for (ap,av) in avail, (v,a) in copy(av)
             if satisfies(fp, fx.version, a.requires)
-                delete!(a.requires, fp, nothing)
+                delete!(a.requires, fp)
             else
                 delete!(av, v)
             end
@@ -125,7 +125,7 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
 
         # Store all dependencies seen so far for later use
         for a in uniqdepssets, r in a.requires
-            add!(alldeps, r)
+            push!(alldeps, r)
         end
 
         # If the package has just one version, it's uninteresting
@@ -270,7 +270,7 @@ function dependencies_subset(deps::Dict{ByteString,Dict{VersionNumber,Available}
         staged_next = Set{ByteString}()
         for p in staged, (_,a) in deps[p], (rp,_) in a.requires
             if !contains(allpkgs, rp)
-                add!(staged_next, rp)
+                push!(staged_next, rp)
             end
         end
         allpkgs = union(allpkgs, staged_next)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -49,12 +49,12 @@ end
 
 # subtypes
 function _subtypes(m::Module, x::DataType, sts=Set(), visited=Set())
-    add!(visited, m)
+    push!(visited, m)
     for s in names(m,true)
         if isdefined(m,s)
             t = eval(m,s)
             if isa(t, DataType) && super(t).name == x.name
-                add!(sts, t)
+                push!(sts, t)
             elseif isa(t, Module) && !contains(visited, t)
                 _subtypes(t, x, sts, visited)
             end

--- a/base/set.jl
+++ b/base/set.jl
@@ -62,7 +62,8 @@ function intersect(s::Set, sets::Set...)
     for x in s
         for t in sets
             if !contains(t,x)
-                delete!(i,x)  # no error thrown on missing value
+                delete!(i,x)
+                break
             end
         end
     end
@@ -72,7 +73,7 @@ end
 function setdiff(a::Set, b::Set)
     d = copy(a)
     for x in b
-        delete!(d, x)  # no error thrown on missing value
+        delete!(d, x)
     end
     d
 end

--- a/base/set.jl
+++ b/base/set.jl
@@ -16,12 +16,13 @@ eltype{T}(s::Set{T}) = T
 
 contains(s::Set, x) = haskey(s.dict, x)
 
-add!(s::Set, x) = (s.dict[x] = nothing; s)
-delete!(s::Set, x) = (delete!(s.dict, x); x)
-delete!(s::Set, x, deflt) = delete!(s.dict, x, deflt)
+push!(s::Set, x) = (s.dict[x] = nothing; s)
+pop!(s::Set, x) = (pop!(s.dict, x); x)
+pop!(s::Set, x, deflt) = pop!(s.dict, x, deflt) == deflt ? deflt : x
+delete!(s::Set, x) = (delete!(s.dict, x); s)
 
-union!(s::Set, xs) = (for x=xs; add!(s,x); end; s)
-setdiff!(s::Set, xs) = (for x=xs; delete!(s,x,nothing); end; s)
+union!(s::Set, xs) = (for x=xs; push!(s,x); end; s)
+setdiff!(s::Set, xs) = (for x=xs; delete!(s,x); end; s)
 
 similar{T}(s::Set{T}) = Set{T}()
 copy(s::Set) = union!(similar(s), s)
@@ -60,8 +61,8 @@ function intersect(s::Set, sets::Set...)
     i = copy(s)
     for x in s
         for t in sets
-            if !contains(t,x) & contains(i,x)
-                delete!(i,x)
+            if !contains(t,x)
+                delete!(i,x)  # no error thrown on missing value
             end
         end
     end
@@ -71,9 +72,7 @@ end
 function setdiff(a::Set, b::Set)
     d = copy(a)
     for x in b
-        if contains(d, x)
-            delete!(d, x)
-        end
+        delete!(d, x)  # no error thrown on missing value
     end
     d
 end
@@ -96,7 +95,7 @@ function unique(C)
     seen = Set{eltype(C)}()
     for x in C
         if !contains(seen, x)
-            add!(seen, x)
+            push!(seen, x)
             push!(out, x)
         end
     end

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -367,7 +367,7 @@ end
 callback_dict = ObjectIdDict()
 
 function _uv_hook_getaddrinfo(cb::Function, addrinfo::Ptr{Void}, status::Int32)
-    delete!(callback_dict,cb)
+    pop!(callback_dict,cb) # using pop forces an error if cb not in callback_dict
     if status != 0 || addrinfo == C_NULL
         cb(UVError("getaddrinfo callback",status))
         return

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -552,11 +552,11 @@ As with arrays, ``Dicts`` may be created with comprehensions. For example,
 
 .. function:: delete!(collection, key)
 
-   Delete the mapping for the given key in a collection.
+   Delete the mapping for the given key in a collection, and return the colection.
 
 .. function:: pop!(collection, key[, default])
 
-   Delete and return the mapping for ``key`` if it exists in ``collection``, otherwise return ``default``.
+   Delete and return the mapping for ``key`` if it exists in ``collection``, otherwise return ``default``, or throw an error if default is not specified.
 
 .. function:: keys(collection)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -554,6 +554,10 @@ As with arrays, ``Dicts`` may be created with comprehensions. For example,
 
    Delete the mapping for the given key in a collection.
 
+.. function:: pop!(collection, key[, default])
+
+   Delete and return the mapping for ``key`` if it exists in ``collection``, otherwise return ``default``.
+
 .. function:: keys(collection)
 
    Return an iterator over all keys in a collection. ``collect(keys(d))`` returns an array of keys.

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -107,6 +107,7 @@
     jl_eqtable_get;
     jl_eqtable_next;
     jl_eqtable_put;
+    jl_eqtable_pop;
     jl_errno;
     jl_errorexception_type;
     jl_exception_in_transit;

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -103,7 +103,6 @@
     jl_enq_send_req;
     jl_enter_handler;
     jl_environ;
-    jl_eqtable_del;
     jl_eqtable_get;
     jl_eqtable_next;
     jl_eqtable_put;

--- a/src/table.c
+++ b/src/table.c
@@ -121,7 +121,7 @@ jl_value_t *jl_eqtable_get(jl_array_t *h, void *key, jl_value_t *deflt)
 }
 
 DLLEXPORT
-jl_value_t *jl_eqtable_del(jl_array_t *h, void *key, jl_value_t *deflt)
+jl_value_t *jl_eqtable_pop(jl_array_t *h, void *key, jl_value_t *deflt)
 {
     void **bp = jl_table_peek_bp(h, key);
     if (bp == NULL || *bp == NULL)

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -87,7 +87,7 @@ begin
     for id in seq
         if id > 0
             x = xs[id]
-            add!(s, x)
+            push!(s, x)
             @test contains(s, x)                 # check that x can be found
         else
             delete!(s, xs[-id])
@@ -183,7 +183,7 @@ d = (String => String)[ a => "foo" for a in ["a","b","c"]]
 s = Set()
 @test isempty(s)
 for i in 1:1000
-    add!(s, i)
+    push!(s, i)
     @test (length(s) == i)
 end
 
@@ -216,10 +216,16 @@ data_out = collect(s)
 # no duplicates
 s = Set(1,2,3)
 @test length(s) == 3
-add!(s,2)
+push!(s,2)
 @test length(s) == 3
 delete!(s,2)
 @test length(s) == 2
+push!(s,2)
+@test length(s) == 3
+pop!(s,2)
+@test length(s) == 2
+pop!(s)
+@test length(s) == 1
 
 # union
 s = union(Set(1,2), Set(3,4))
@@ -295,8 +301,8 @@ data_in = (1,2,9,8,4)
 s = Set(data_in...)
 c = copy(s)
 @test isequal(s,c)
-add!(s,100)
-add!(c,200)
+push!(s,100)
+push!(c,200)
 @test !contains(c, 100)
 @test !contains(s, 200)
 
@@ -307,7 +313,7 @@ for data_in in ((7,8,4,5),
 
     s_new = Set()
     for el in s
-        add!(s_new, el)
+        push!(s_new, el)
     end
     @test isequal(s, s_new)
 

--- a/test/gitutils.jl
+++ b/test/gitutils.jl
@@ -34,7 +34,7 @@ function verify_tree(d::Dict, tree::String)
         else
             error("verify_tree: don't know what to do with $name => $data")
         end
-        add!(seen, name)
+        push!(seen, name)
     end
     # check that nothing was missing from tree
     for (name, data) in d

--- a/test/perf/kernel/actor_centrality.jl
+++ b/test/perf/kernel/actor_centrality.jl
@@ -25,7 +25,7 @@ function centrality_mean(G::Graph, start_node)
             if !haskey(dists, n)
                 dists[n] = cdist
                 for neigh in n.n
-                    add!(nnext, neigh)
+                    push!(nnext, neigh)
                 end
             end
         end
@@ -44,9 +44,9 @@ function read_graph()
             k = split(strip(readline(io)), "\t")
             actor, movie = k[1], join(k[2:3], "_")
             ac, mn = get(G, actor), get(G, movie)
-            add!(actors, actor)
-            add!(ac.n, mn)
-            add!(mn.n, ac)
+            push!(actors, actor)
+            push!(ac.n, mn)
+            push!(mn.n, ac)
         end
     end
     G, sort!([ a for a in actors])

--- a/test/perf/kernel/json.jl
+++ b/test/perf/kernel/json.jl
@@ -36,7 +36,7 @@ function parse_json(strng::String)
         if next_char != ']'
             while true
                 val = parse_value()
-                add!(object, val)
+                push!(object, val)
                 if next_char() == ']'
                     break
                 end


### PR DESCRIPTION
As discussed in #3405, here are some exploratory changes to split `delete!(h::Dict, key)` into two functions.
- `pop!(h::Dict, key)` returns the value removed from `h`, or throws an error if the key missing
- `pop!(h::Dict, key, default)` returns the value removed from `h`, or `default` if the key is missing
- `delete!(h::Dict, key)` discards the value and returns the modified dictionary; no error thrown on missing value.

Also implemented for `Set()`, `IntSet()`.  ~~Haven't touched `ObjectIdDict` or `WeakKeyDict`.~~

**Edit:** Added info about errors, default value on `pop!()`
**Edit:** Also updated `ObjectIdDict`, `WeakKeyDict`
