### PR TITLE
readdlm variant to accept memory mapped byte arrays.

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -42,7 +42,10 @@ readdlm(input, dlm::Char, eol::Char) = readdlm_auto(input, dlm, Float64, eol, tr
 readdlm(input, dlm::Char, T::Type, eol::Char) = readdlm_auto(input, dlm, T, eol, false)
 
 readdlm_auto(input, dlm::Char, T::Type, eol::Char, auto::Bool=false) = readdlm_string(readall(input), dlm, T, eol, auto)
-readdlm_auto(input::Vector{Uint8}, dlm::Char, T::Type, eol::Char, auto::Bool=false) = readdlm_string(bytestring(input), dlm, T, eol, auto)
+function readdlm_auto(input::Vector{Uint8}, dlm::Char, T::Type, eol::Char, auto::Bool=false)
+    s = ccall(:jl_array_to_string, ByteString, (Array{Uint8,1},), input)
+    readdlm_string(s, dlm, T, eol, auto)
+end
 
 function readdlm_string(sbuff::String, dlm::Char, T::Type, eol::Char, auto::Bool=false)
     nrows,ncols = dlm_dims(sbuff, eol, dlm)

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -40,8 +40,11 @@ readdlm(input, dlm::Char) = readdlm(input, dlm, '\n')
 
 readdlm(input, dlm::Char, eol::Char) = readdlm_auto(input, dlm, Float64, eol, true)
 readdlm(input, dlm::Char, T::Type, eol::Char) = readdlm_auto(input, dlm, T, eol, false)
-function readdlm_auto(input, dlm::Char, T::Type, eol::Char, auto::Bool=false)
-    sbuff = readall(input)
+
+readdlm_auto(input, dlm::Char, T::Type, eol::Char, auto::Bool=false) = readdlm_string(readall(input), dlm, T, eol, auto)
+readdlm_auto(input::Vector{Uint8}, dlm::Char, T::Type, eol::Char, auto::Bool=false) = readdlm_string(bytestring(input), dlm, T, eol, auto)
+
+function readdlm_string(sbuff::String, dlm::Char, T::Type, eol::Char, auto::Bool=false)
     nrows,ncols = dlm_dims(sbuff, eol, dlm)
     offsets = zeros(Int, nrows, ncols)
     cells = Array(T, nrows, ncols)
@@ -55,7 +58,7 @@ function dlm_col_begin(ncols::Int, offsets::Array{Int,2}, row::Int, col::Int)
     pp_col = (1 == col) ? ncols : (col-1)
 
     ret = offsets[pp_row, pp_col]
-    (ret == 0) ? dlm_col_begin(csv, pp_row, pp_col) : (ret+2)
+    (ret == 0) ? dlm_col_begin(ncols, offsets, pp_row, pp_col) : (ret+2)
 end
 
 function dlm_fill{T}(cells::Array{T,2}, offsets::Array{Int,2}, sbuff::String, auto::Bool)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1006,19 +1006,19 @@ Text I/O
 
    Create an iterable object that will yield each line from a stream.
 
-.. function:: readdlm(filename, delim::Char)
+.. function:: readdlm(source, delim::Char)
 
-   Read a matrix from a text file where each line gives one row, with elements separated by the given delimeter. If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a cell array of numbers and strings is returned.
+   Read a matrix from the source where each line gives one row, with elements separated by the given delimeter. The source can be a text file, stream or byte array. Memory mapped filed can be used by passing the byte array representation of the mapped segment as source. If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a cell array of numbers and strings is returned.
 
-.. function:: readdlm(filename, delim::Char, T::Type)
+.. function:: readdlm(source, delim::Char, T::Type)
 
-   Read a matrix from a text file with a given element type. If ``T`` is a numeric type, the result is an array of that type, with any non-numeric elements as ``NaN`` for floating-point types, or zero. Other useful values of ``T`` include ``ASCIIString``, ``String``, and ``Any``.
+   Read a matrix from the source with a given element type. If ``T`` is a numeric type, the result is an array of that type, with any non-numeric elements as ``NaN`` for floating-point types, or zero. Other useful values of ``T`` include ``ASCIIString``, ``String``, and ``Any``.
 
 .. function:: writedlm(filename, array, delim::Char)
 
    Write an array to a text file using the given delimeter (defaults to comma).
 
-.. function:: readcsv(filename, [T::Type])
+.. function:: readcsv(source, [T::Type])
 
    Equivalent to ``readdlm`` with ``delim`` set to comma.
 


### PR DESCRIPTION
- `readdlm` variant to accept memory mapped byte arrays.
- updated docs for `readdlm`.
- fixed typo from the previous commit
