### PR TITLE
WIP: Test Harness & 32 Bit Issues

### DIFF
--- a/test/collections.jl
+++ b/test/collections.jl
@@ -66,9 +66,9 @@ let
     local bar
     bestkey(d, key) = key
     bestkey{K<:String,V}(d::Associative{K,V}, key) = string(key)
-    bar(x) = bestkey(x, :y)
-    @test bar([:x => [1,2,5]]) == :y
-    @test bar(["x" => [1,2,5]]) == "y"
+    foobar(x) = bestkey(x, :y)
+    @test foobar([:x => [1,2,5]]) == :y
+    @test foobar(["x" => [1,2,5]]) == "y"
 end
 
 # issue #1438

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,15 @@ ENV["OPENBLAS_NUM_THREADS"] = 1
 
 @everywhere include("testdefs.jl")
 
+
+#The parallel tests assume that they run from node 1
+run_threads = sum(tests .== "parallel") != 0
+tests = filter(x->(x!="parallel"), tests)
 reduce(propagate_errors, nothing, pmap(runtests, tests))
 
 @unix_only n > 1 && rmprocs(workers())
+if(run_threads)
+    runtests("parallel")
+end
+
 println("    \033[32;1mSUCCESS\033[0m")


### PR DESCRIPTION
After updating julia today I noticed that 'make testall' was failing on my machine. The first two commits solve relatively minor issues that were likely overlooked due to the number of cores and 32/64 bit types of builds that are being tested more often. The reason I currently have this left as a WIP commit is that I assume the third commit should not be merged as is as it adds a conditional check to the binary shift operator which should _not_ be needed.

I'm not quite too sure what the problem is with 128 bit shifts on my system, but it appears with both the included version of llvm and two recent (svn) images of llvm. Without the patch the behavior that makes some of the socket.jl tests fail is

```
julia> uint128(1) << 0
0x00000000000000010000000000000001
```

With the patch, the bitshift by zero does what is expected.

Currently with this patchset applied all tests run cleanly on my Slackware Linux 14.0 32 bit system.
