### PR TITLE
Fixed description of ``NULL`` in the comparison to R

### DIFF
--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -175,5 +175,5 @@ One of Julia's goals is to provide an effective language for data analysis and s
 - ``colMeans()`` and ``rowMeans()``, ``size(m, 1)`` and ``size(m, 2)``
 - In R, performance requires vectorization. In Julia, almost the opposite is true: the best performing code is often achieved by using devectorized loops.
 - Unlike R, there is no delayed evaluation in Julia. For most users, this means that there are very few unquoted expressions or column names.
-- Julia does not ``NULL`` type.
+- Julia does not support the ``NULL`` type.
 - There is no equivalent of R's ``assign`` or ``get`` in Julia.


### PR DESCRIPTION
Someone accidentally forgot a couple of words here when describing the lack of NULL support. This one line fix puts the words back in.
