### PR TITLE
readdlm improvements

### DIFF
--- a/base/ascii.jl
+++ b/base/ascii.jl
@@ -81,4 +81,22 @@ ascii(x) = convert(ASCIIString, x)
 convert(::Type{ASCIIString}, s::ASCIIString) = s
 convert(::Type{ASCIIString}, s::UTF8String) = ascii(s.data)
 convert(::Type{ASCIIString}, a::Array{Uint8,1}) = is_valid_ascii(a) ? ASCIIString(a) : error("invalid ASCII sequence")
+function convert(::Type{ASCIIString}, a::Array{Uint8,1}, invalids_as::ASCIIString)
+    l = length(a)
+    idx = 1
+    iscopy = false
+    while idx <= l
+        (a[idx] < 0x80) && (idx +=1; continue)
+        !iscopy && (a = copy(a); iscopy = true)
+        endn = idx
+        while endn <= l
+            (a[endn] < 0x80) && break
+            endn += 1
+        end
+        (endn > idx) && (endn -= 1)
+        splice!(a, idx:endn, invalids_as.data)
+        l = length(a)
+    end
+    convert(ASCIIString, a)
+end
 convert(::Type{ASCIIString}, s::String) = ascii(bytestring(s))

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -1537,18 +1537,34 @@
 
 "),
 
-("Text I/O","Base","readdlm","readdlm(filename, delim::Char)
+("Text I/O","Base","readdlm","readdlm(source, delim::Char; has_header=false, use_mmap=true, ignore_invalid_chars=false)
 
-   Read a matrix from a text file where each line gives one row, with
-   elements separated by the given delimeter. If all data is numeric,
-   the result will be a numeric array. If some elements cannot be
-   parsed as numbers, a cell array of numbers and strings is returned.
+   Read a matrix from the source where each line gives one row, with 
+   elements separated by the given delimeter. The source can be a 
+   text file, stream or byte array. Memory mapped filed can be used 
+   by passing the byte array representation of the mapped segment as 
+   source. 
+
+   If \"has_header\" is \"true\" the first row of data would be read 
+   as headers and the tuple \"(data_cells, header_cells)\" is 
+   returned instead of only \"data_cells\".
+
+   If \"use_mmap\" is \"true\" the file specified by \"source\" is 
+   memory mapped for potential speedups.
+
+   If \"ignore_invalid_chars\" is \"true\" bytes in \"source\" with 
+   invalid character encoding will be ignored. Otherwise an error is 
+   thrown indicating the offending character position.
+
+   If all data is numeric, \"data_cells\" will be a numeric array. If 
+   some elements cannot be parsed as numbers, a cell array of numbers 
+   and strings is returned for \"data_cells\".
 
 "),
 
-("Text I/O","Base","readdlm","readdlm(filename, delim::Char, T::Type)
+("Text I/O","Base","readdlm","readdlm(source, delim::Char, T::Type; options...)
 
-   Read a matrix from a text file with a given element type. If \"T\"
+   Read a matrix from the source with a given element type. If \"T\"
    is a numeric type, the result is an array of that type, with any
    non-numeric elements as \"NaN\" for floating-point types, or zero.
    Other useful values of \"T\" include \"ASCIIString\", \"String\",
@@ -1563,7 +1579,7 @@
 
 "),
 
-("Text I/O","Base","readcsv","readcsv(filename[, T::Type])
+("Text I/O","Base","readcsv","readcsv(filename[, T::Type]; options...)
 
    Equivalent to \"readdlm\" with \"delim\" set to comma.
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1006,11 +1006,20 @@ Text I/O
 
    Create an iterable object that will yield each line from a stream.
 
-.. function:: readdlm(source, delim::Char)
+.. function:: readdlm(source, delim::Char; has_header=false, use_mmap=true, ignore_invalid_chars=false)
 
-   Read a matrix from the source where each line gives one row, with elements separated by the given delimeter. The source can be a text file, stream or byte array. Memory mapped filed can be used by passing the byte array representation of the mapped segment as source. If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a cell array of numbers and strings is returned.
+   Read a matrix from the source where each line gives one row, with elements separated by the given delimeter. The source can be a text file, stream or byte array. Memory mapped filed can be used by passing the byte array representation of the mapped segment as source. 
 
-.. function:: readdlm(source, delim::Char, T::Type)
+   If ``has_header`` is ``true`` the first row of data would be read as headers and the tuple ``(data_cells, header_cells)`` is returned instead of only ``data_cells``.
+
+   If ``use_mmap`` is ``true`` the file specified by ``source`` is memory mapped for potential speedups.
+
+   If ``ignore_invalid_chars`` is ``true`` bytes in ``source`` with invalid character encoding will be ignored. Otherwise an error is thrown indicating the offending character position.
+
+   If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a cell array of numbers and strings is returned.
+
+
+.. function:: readdlm(source, delim::Char, T::Type; options...)
 
    Read a matrix from the source with a given element type. If ``T`` is a numeric type, the result is an array of that type, with any non-numeric elements as ``NaN`` for floating-point types, or zero. Other useful values of ``T`` include ``ASCIIString``, ``String``, and ``Any``.
 
@@ -1018,7 +1027,7 @@ Text I/O
 
    Write an array to a text file using the given delimeter (defaults to comma).
 
-.. function:: readcsv(source, [T::Type])
+.. function:: readcsv(source, [T::Type]; options...)
 
    Equivalent to ``readdlm`` with ``delim`` set to comma.
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ TESTS = all core keywordargs numbers strings unicode collections hashing	\
 	remote iostring arrayops linalg blas fft dsp sparse bitarray		\
 	random math functional bigint sorting statistics spawn parallel		\
 	arpack file git pkg pkg2 resolve suitesparse complex version		\
-	pollfd mpfr broadcast socket floatapprox priorityqueue
+	pollfd mpfr broadcast socket floatapprox priorityqueue readdlm
 
 $(TESTS) ::
 	$(QUIET_JULIA) $(call spawn,$(JULIA_EXECUTABLE)) ./runtests.jl $@

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -1,0 +1,10 @@
+dlm_data = try
+        readdlm(joinpath(JULIA_HOME, split("../../test/perf2/imdb-1.tsv", '/')...), '\t')
+    catch
+        readdlm(joinpath(JULIA_HOME, split("../../julia/share/julia/test/perf2/imdb-1.tsv", '/')...), '\t')
+    end
+
+@test size(dlm_data) == (31383,3)
+@test dlm_data[12345,2] == "Gladiator"
+@test dlm_data[31383,3] == 2005
+@test dlm_data[1,1] == "McClure, Marc (I)"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ testnames = ["core", "keywordargs", "numbers", "strings", "unicode",
              "statistics", "spawn", "parallel", "priorityqueue",
              "arpack", "file", "perf", "suitesparse", "version",
              "resolve", "pollfd", "mpfr", "broadcast", "complex",
-             "socket", "floatapprox"]
+             "socket", "floatapprox", "readdlm"]
 
 tests = ARGS==["all"] ? testnames : ARGS
 n = min(8, CPU_CORES, length(tests))


### PR DESCRIPTION
Used `mmap` to read files.

`readdlm` and `readcsv` now take optional named arguments to:
- not use `mmap`
- read header (and return a tuple: `(data, hdr)`)
- ignore invalid characters

In the process, introduced `convert` variants for creating `ASCIIString` and `UTF8String` from byte arrays while replacing invalid character sequences with a new (potentially empty) sequence.
