### PR TITLE
fix #3397 -- support for shell commands from readline-repl via ";" prefix

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -44,6 +44,29 @@ function repl_callback(ast::ANY, show_value)
     put(repl_channel, (ast, show_value))
 end
 
+function repl_cmd(cmd)
+    if isempty(cmd.exec)
+        error("no cmd to execute")
+    elseif cmd.exec[1] == "cd"
+        if length(cmd.exec) > 2
+            error("cd method only takes one argument")
+        elseif length(cmd.exec) == 2
+            cd(cmd.exec[2])
+        else
+            cd()
+        end
+        println(pwd())
+    else
+        run(cmd)
+    end
+    nothing
+end
+
+function repl_hook(input::String)
+    return Expr(:call, :(Base.repl_cmd),
+        macroexpand(Expr(:macrocall,symbol("@cmd"),input)))
+end
+
 display_error(er) = display_error(er, {})
 function display_error(er, bt)
     with_output_color(:red, STDERR) do io

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -217,6 +217,14 @@ export PipeString
 @deprecate openblas_set_num_threads      blas_set_num_threads
 @deprecate check_openblas                check_blas
 
+deprecated_ls() = run(`ls -l`)
+deprecated_ls(args::Cmd) = run(`ls -l $args`)
+deprecated_ls(args::String...) = run(`ls -l $args`)
+function ls(args...)
+    warn_once("ls() is deprecated, use readdir() instead. If you are at the repl prompt, consider `;ls`.")
+    deprecated_ls(args...)
+end
+
 # Redirection Operators
 @deprecate |(a::AbstractCmd,b::AbstractCmd) (a|>b)
 @deprecate >(a::Redirectable,b::AbstractCmd) (a|>b)

--- a/base/file.jl
+++ b/base/file.jl
@@ -65,11 +65,6 @@ end
 
 # The following use Unix command line facilites
 
-# list the contents of a directory
-ls() = run(`ls -l`)
-ls(args::Cmd) = run(`ls -l $args`)
-ls(args::String...) = run(`ls -l $args`)
-
 rm(path::String) = run(`rm $path`)
 cp(src::String, dst::String) = run(`cp $src $dst`)
 mv(src::String, dst::String) = run(`mv $src $dst`)


### PR DESCRIPTION
``` julia
julia> pwd()
"/Users/jameson/Documents/no-backup/julia"

julia> ?cd

julia> ?pwd
/Users/jameson

julia> ?ls -la
total 2688
drwxr-xr-x+ 119 jameson  staff     4046 Jun 20 12:30 .
drwxr-xr-x    5 root     admin      170 Jan  4 20:31 ..
-rw-------    1 jameson  staff        3 Aug 28  2011 .CFUserTextEncoding
-rw-r--r--@   1 jameson  staff    15364 May 26 02:00 .DS_Store

julia> ?cd C:\Users\jameson
ERROR: chdir C:\Users\jameson: No such file or directory
 in systemerror at error.jl:38
 in cd at file.jl:14

julia> ?echo a\
       b\
       c\
       d
a
 b
 c
 d

julia> ?ls $(Pkg.dir())
ArgParse          DataFrames        Gaston

julia> ?cd $(Pkg.dir("Winston"))

julia> ?pwd
/Users/jameson/.julia/Winston

julia> ?cd "/"
ERROR: chdir "/": No such file or directory
 in systemerror at error.jl:38
 in cd at file.jl:14

julia> ?cd /

julia> ?cd ~
ERROR: chdir ~: No such file or directory
 in systemerror at error.jl:38
 in cd at file.jl:14

julia> ?ls ~
ls: ~: No such file or directory
ERROR: failed process: Process(`ls ~`, ProcessExited(1)) [1]
 in error at error.jl:22
 in pipeline_error at process.jl:434
 in run at process.jl:418
```

This parses readline-repl lines starting with `?` as calls to the shell (actually, the run function). It detects calls to `cd` and instead calls `cd()`. Note that the implementation of `cd` means that it will behave slightly differently in the presence of $ interpolation.
