### PR TITLE
Document the option for find to accept a function.

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -2359,6 +2359,10 @@ Indexing, Assignment, and Concatenation
 
    Return a vector of the linear indexes of the non-zeros in ``A``.
 
+.. function:: find(f,A)
+
+   Return a vector of the linear indexes of  ``A`` where ``f`` returns true.
+
 .. function:: findn(A)
 
    Return a vector of indexes for each dimension giving the locations of the non-zeros in ``A``.


### PR DESCRIPTION
I couldn't figure out how to do something like `numpy.where`, @johnmyleswhite pointed out that find can do this, and I noticed this fact wasn't documented, so I documented it.
