### PR TITLE
added rsplit. fix rsearch for case when both string and pattern are empty

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -764,6 +764,7 @@ export
     rstrip,
     search,
     split,
+    rsplit,
     string,
     strip,
     strwidth,

--- a/base/string.jl
+++ b/base/string.jl
@@ -261,7 +261,7 @@ function _rsearch(s, t, i)
 end
 rsearch(s::Union(Array{Uint8,1},Array{Int8,1}),t::Union(Array{Uint8,1},Array{Int8,1}),i) = _rsearch(s,t,i)
 rsearch(s::String, t::String, i::Integer) = _rsearch(s,t,i)
-rsearch(s::String, t::String) = rsearch(s,t,endof(s))
+rsearch(s::String, t::String) = (isempty(s) && isempty(t)) ? (1:0) : rsearch(s,t,endof(s))
 
 contains(::String, ::String) = error("use search() to look for substrings")
 
@@ -1027,6 +1027,32 @@ split(s::String, spl)             = split(s, spl, 0, true)
 # a bit oddball, but standard behavior in Perl, Ruby & Python:
 const _default_delims = [' ','\t','\n','\v','\f','\r']
 split(str::String) = split(str, _default_delims, 0, false)
+
+function rsplit(str::String, splitter, limit::Integer, keep_empty::Bool)
+    strs = String[]
+    i = start(str)
+    n = endof(str)
+    r = rsearch(str,splitter)
+    j = first(r)-1
+    k = last(r)
+    while((0 <= j < n) && (length(strs) != limit-1))
+        if(i <= k)
+            (keep_empty || (k < n)) && unshift!(strs, str[k+1:n])
+            n = j
+        end
+        (k <= j) && (j = prevind(str,j))
+        r = rsearch(str,splitter,j)
+        j = first(r)-1
+        k = last(r)
+    end
+    (keep_empty || (n > 0)) && unshift!(strs, str[1:n])
+    return strs
+end
+rsplit(s::String, spl, n::Integer) = rsplit(s, spl, n, true)
+rsplit(s::String, spl, keep::Bool) = rsplit(s, spl, 0, keep)
+rsplit(s::String, spl)             = rsplit(s, spl, 0, true)
+#rsplit(str::String) = rsplit(str, _default_delims, 0, false)
+
 
 function replace(str::ByteString, pattern, repl::Function, limit::Integer)
     n = 1

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -1069,6 +1069,12 @@
 
 "),
 
+("Strings","Base","rsplit","rsplit(string, [chars, [limit,] [include_empty]])
+
+   Similar to \"split\", but starting from the end of the string.
+
+"),
+
 ("Strings","Base","strip","strip(string[, chars])
 
    Return \"string\" with any leading and trailing whitespace removed.

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -707,6 +707,10 @@ Strings
 
    Return an array of strings by splitting the given string on occurrences of the given character delimiters, which may be specified in any of the formats allowed by ``search``'s second argument (i.e. a single character, collection of characters, string, or regular expression). If ``chars`` is omitted, it defaults to the set of all space characters, and ``include_empty`` is taken to be false. The last two arguments are also optional: they are are a maximum size for the result and a flag determining whether empty fields should be included in the result.
 
+.. function:: rsplit(string, [chars, [limit,] [include_empty]])
+
+   Similar to ``split``, but starting from the end of the string.
+
 .. function:: strip(string, [chars])
 
    Return ``string`` with any leading and trailing whitespace removed. If a string ``chars`` is provided, instead remove characters contained in that string.

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -482,6 +482,26 @@ end
 @test isequal(split("a b c"), ["a","b","c"])
 @test isequal(split("a  b \t c\n"), ["a","b","c"])
 
+@test isequal(rsplit("foo,bar,baz", 'x'), ["foo,bar,baz"])
+@test isequal(rsplit("foo,bar,baz", ','), ["foo","bar","baz"])
+@test isequal(rsplit("foo,bar,baz", ","), ["foo","bar","baz"])
+@test isequal(rsplit("foo,bar,baz", ',', 0), ["foo","bar","baz"])
+@test isequal(rsplit("foo,bar,baz", ',', 1), ["foo,bar,baz"])
+@test isequal(rsplit("foo,bar,baz", ',', 2), ["foo,bar","baz"])
+@test isequal(rsplit("foo,bar,baz", ',', 3), ["foo","bar","baz"])
+@test isequal(rsplit("foo,bar", "o,b"), ["fo","ar"])
+
+@test isequal(rsplit("", ','), [""])
+@test isequal(rsplit(",", ','), ["",""])
+@test isequal(rsplit(",,", ','), ["","",""])
+@test isequal(rsplit(",,", ',', 2), [",",""])
+@test isequal(rsplit("", ',', false), [])
+@test isequal(rsplit(",", ',', false), [])
+@test isequal(rsplit(",,", ',', false), [])
+
+#@test isequal(rsplit("a b c"), ["a","b","c"])
+#@test isequal(rsplit("a  b \t c\n"), ["a","b","c"])
+
 let str = "a.:.ba..:..cba.:.:.dcba.:."
 @test isequal(split(str, ".:."), ["a","ba.",".cba",":.dcba",""])
 @test isequal(split(str, ".:.", false), ["a","ba.",".cba",":.dcba"])
@@ -490,9 +510,19 @@ let str = "a.:.ba..:..cba.:.:.dcba.:."
 @test isequal(split(str, r"\.(:\.)+", false), ["a","ba.",".cba","dcba"])
 @test isequal(split(str, r"\.+:\.+"), ["a","ba","cba",":.dcba",""])
 @test isequal(split(str, r"\.+:\.+", false), ["a","ba","cba",":.dcba"])
+
+@test isequal(rsplit(str, ".:."), ["a","ba.",".cba.:","dcba",""])
+@test isequal(rsplit(str, ".:.", false), ["a","ba.",".cba.:","dcba"])
+@test isequal(rsplit(str, ".:.", 2), ["a.:.ba..:..cba.:.:.dcba", ""])
+@test isequal(rsplit(str, ".:.", 3), ["a.:.ba..:..cba.:", "dcba", ""])
+@test isequal(rsplit(str, ".:.", 4), ["a.:.ba.", ".cba.:", "dcba", ""])
+@test isequal(rsplit(str, ".:.", 5), ["a", "ba.", ".cba.:", "dcba", ""])
+@test isequal(rsplit(str, ".:.", 6), ["a", "ba.", ".cba.:", "dcba", ""])
 end
 
 # zero-width splits
+@test isequal(rsplit("", ""), [""])
+
 @test isequal(split("", ""), [""])
 @test isequal(split("", r""), [""])
 @test isequal(split("abc", ""), ["a","b","c"])


### PR DESCRIPTION
`rsplit` behaves like `split` but in the reverse direction:

```
julia> rsplit("foo,bar,baz", ',', 2)
2-element String Array:
 "foo,bar"
 "baz"    

julia> split("foo,bar,baz", ',', 2)
2-element String Array:
 "foo"    
 "bar,baz"
```

before `rsearch` fix:

```
julia> search("", "")
1:0

julia> rsearch("", "")
ERROR: BoundsError()
 in _rsearch at string.jl:224
 in rsearch at string.jl:264
```

after `rsearch` fix:

```
julia> rsearch("", "")
1:0
```
