### PR TITLE
RFC : pfork - function executed in parallel use the fork() system call.

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1388,3 +1388,101 @@ function interrupt_waiting_task(t::Task, with_value)
         enq_work(t)
     end
 end
+
+function pfork(n::Integer, f::Function, args...)
+    if nprocs() > 1
+        error("pfork is incompatible with worker processes. Execute a `rmprocs(workers())` and try again.")
+    end
+    
+    pipes = cell(n)
+    cpids = cell(n)
+    responses=cell(n)
+    
+    for i in 1:n
+        pipe_fds = Array(Cint,2)
+        assert( 0 == ccall(:pipe, Cint, (Ptr{Cint},), pipe_fds))    
+        pipes[i] = pipe_fds
+
+        cpids[i] = ccall(:fork, Cint, ())
+        
+        if cpids[i] == 0
+            try
+                # child 
+                # close the read end in the child
+                ccall(:close, Cint, (Cint, ),  pipes[i][1])
+                
+                # seed the random number generator differently for each child...
+                srand([uint32(time()), uint32(i)])
+                
+                rv = apply(f, i, args...)
+                
+                iob=IOBuffer()
+                if rv == nothing
+                    serialize(iob, ())
+                else
+                    serialize(iob, rv)
+                end
+                
+                arr=takebuf_array(iob)
+                nb = length(arr)
+                nb_pending = nb
+                while nb_pending > 0
+                    #ssize_t write(int fd, const void *buf, size_t count);
+                    bw = ccall(:write, Csize_t, (Cint, Ptr{Uint8}, Csize_t), pipes[i][2], pointer(arr, (nb - nb_pending) + 1), nb_pending)
+                    if bw <= 0
+                        exit(1)
+                    end
+                    nb_pending -= bw
+                end
+                
+                #println("child process exiting")
+                ccall(:close, Cint, (Cint, ),  pipes[i][2])
+            catch e
+                println("forked child exiting with exception $e")
+            finally 
+                exit()
+            end
+        else
+            # close the write end in the parent
+            ccall(:close, Cint, (Cint, ),  pipes[i][2])
+        end
+    end
+
+    # Read all responses and wait for children to exit
+    @sync begin
+        for i in 1:n
+            #read all data in the pipe...
+            @async begin
+                buf = zeros(Uint8,65536)
+                iob = IOBuffer()
+                while true 
+                    br = ccall(:read, Csize_t, (Cint, Ptr{Uint8}, Csize_t), pipes[i][1], buf, 65536)
+                    if br > 0
+                        write(iob, buf[1:br])
+                    else
+                        break;
+                    end
+                end
+                
+                #close the write end
+                ccall(:close, Cint, (Cint, ),  pipes[i][1])
+                
+                retcode = Cint[0]
+                cpid_exited = ccall(:waitpid, Cint, (Cint, Ptr{Cint}, Cint), cpids[i], retcode, 0)
+                assert(cpid_exited == cpids[i])
+                #println("child process $(cpids[i]) exited")
+                
+                responses[i] = iob
+            end
+        end
+    end
+    
+    for i in 1:n
+        seekstart(responses[i])
+        responses[i] = deserialize(responses[i])
+    end
+    
+    responses
+end
+
+


### PR DESCRIPTION
This has been very much done in the lets-try-if-this-works mode.
- It uses the UNIX `fork()` system call to execute a function in parallel.
- `pfork(nforks::Integer, f::Function, args...)` forks `nforks` times and executes `f` in each child.
- The first parameter to `f` is the forked child index.
- `pfork` returns an array of size `nforks`, where the nth element is the value returned by the nth forked child.  

Overhead for forking, collecting empty responses and waiting for the exit of 8 children is around 130 milliseconds on my laptop.

```
julia> @time Base.pfork(8, x -> nothing) 
elapsed time: 0.130722159 seconds
8-element Any Array:
...
```

@parallel and pfork return similar elapsed times for the random tosses example in the manual when run for 10^10 iterations.
# Pros
- Passing huge amounts of data to the function in the child process is a non-issue since it is a fork.
- In the event the parent process has a shared memory segment, the children have full visibility into the same and
  can modify the segment in place. They don't have to bother with returning huge amounts of data either.
# Cons
- No fast implementation of fork() on Windows. So, this will likely be a UNIX only feature.
- Currently can only be executed when `nprocs() == 1`, i.e., this model is incompatible with the worker model.
- Unpredictable behavior if the function to be executed in the forked children calls `yield()` AND other I/O tasks are concurrently active. Can be used only where `f` is fully compute bound.

Is this useful and something that people would like to see in Base? 
Else I'll just add it to PTools.jl for now.
