### PR TITLE
specialize promote_shape for (Int, Int) and (Int, Int)

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -148,6 +148,13 @@ end
 
 promote_shape(a::(Int,), b::(Int,Int)) = promote_shape(b, a)
 
+function promote_shape(a::(Int, Int), b::(Int, Int))
+    if a[1] != b[1] || a[2] != b[2]
+        error("argument dimensions must match")
+    end
+    return a
+end
+
 function promote_shape(a::Dims, b::Dims)
     if length(a) < length(b)
         return promote_shape(b, a)


### PR DESCRIPTION
Originally, there are specialized versions for 
- (Int,) and (Int,)
- (Int, Int) and (Int,)
- (Int,) and (Int, Int)

I add (Int, Int) and (Int, Int) here, which is of very common use and worth specializing.
