### PR TITLE
match_all function to match all occurrences of a regex pattern in a string

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -761,6 +761,7 @@ export
     lpad,
     lstrip,
     match,
+    match_all,
     ismatch,
     nextind,
     prevind,

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -63,6 +63,18 @@ function info{T}(
     reinterpret(T,buf)[1]
 end
 
+function config{T}(what::Integer, ::Type{T})
+    buf = Array(Uint8, sizeof(T))
+    ret = ccall((:pcre_config, :libpcre), Int32,
+                (Int32, Ptr{Uint8}),
+                what, buf)
+
+    if ret != 0
+        error("config: error $n")
+    end
+    reinterpret(T,buf)[1]
+end
+
 function compile(pattern::String, options::Integer)
     errstr = Array(Ptr{Uint8},1)
     erroff = Array(Int32,1)


### PR DESCRIPTION
These commits add the ability to match all occurrences of a regex pattern in a given string. (Similar to the perl `/g` option or the ruby `scan`)

So, now one can search for all matches as follows.

```
julia> str = "The dark side of the moon"
"The dark side of the moon"

julia> match_all(r"(\w+)(\s*)", str)
6-element RegexMatch Array:
 RegexMatch("The ", 1="The", 2=" ")
 RegexMatch("dark ", 1="dark", 2=" ")
 ⋮
 RegexMatch("the ", 1="the", 2=" ")
 RegexMatch("moon", 1="moon", 2="")

```

```
#Test with Unicode

julia> s = "x \u2200 x \u2203 y"
"x ∀ x ∃ y"

julia> match_all(r".\s", s)
4-element RegexMatch Array:
 RegexMatch("x ")
 RegexMatch("∀ ")
 RegexMatch("x ")
 RegexMatch("∃ ")
```

```
#Test with empty strings matches

r = r"a?b?"
match_all(r, "asbds")

julia> match_all(r, "asbd")
5-element RegexMatch Array:
 RegexMatch("a")
 RegexMatch("")
 RegexMatch("b")
 RegexMatch("")
 RegexMatch("")
```

This is an initial pull request and there are still a couple of things pending -
1. Support for CRLF
2. Test code to be put in
