### PR TITLE
add general copysign method

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -21,6 +21,7 @@ signbit(x::Real) = int(x < 0)
 sign(x::Real) = x < 0 ? oftype(x,-1) : x > 0 ? one(x) : x
 abs(x::Real) = x < 0 ? -x : x
 abs2(x::Real) = x*x
+copysign(x::Real, y::Real) = y >= 0 ? abs(x) : -abs(x)
 
 conj(x::Real) = x
 transpose(x::Number) = x


### PR DESCRIPTION
I noticed that 

```
int(BigInt(3) // BigInt(5))
```

doesn't work due to there being no `copysign` method for `BigInt`. 

I didn't really see a reason not to implement this for general `Real` arguments; I hope that's ok.
