### PR TITLE
multi: do not assume a bash login shell, use sh by default

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -961,7 +961,7 @@ function ssh_tunnel(user, host, port, sshflags)
 end
 
 #function worker_ssh_cmd(host, key)
-#    `ssh -i $key -n $host "bash -l -c \"cd $JULIA_HOME && ./julia-release-basic --worker\""`
+#    `ssh -i $key -n $host "sh -l -c \"cd $JULIA_HOME && ./julia-release-basic --worker\""`
 #end
 
 # start and connect to processes via SSH.
@@ -972,7 +972,7 @@ function addprocs(machines::AbstractVector;
                   tunnel=false, dir=JULIA_HOME, exename="./julia-release-basic", sshflags::Cmd=``)
     add_workers(PGRP,
         start_remote_workers(machines,
-            map(m->detach(`ssh -n $sshflags $m "bash -l -c \"cd $dir && $exename --worker\""`),
+            map(m->detach(`ssh -n $sshflags $m "sh -l -c \"cd $dir && $exename --worker\""`),
                 machines),
             tunnel, sshflags))
 end


### PR DESCRIPTION
I have users with strange bash/dash/csh/zsh setups that spew all sorts of fun wonkiness when worker shells are started in bash. I propose defaulting to sh, which bypasses bash-specific behavior (and occasional strangeness) and results in a more streamlined experience for my users.
