### PR TITLE
add missing count_ones for BigInt, export trailing_zeros and trailing_ones

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -5,7 +5,7 @@ export BigInt
 import Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), ($),
              binomial, cmp, convert, div, factorial, fld, gcd, gcdx, lcm, mod,
              ndigits, promote_rule, rem, show, isqrt, string, isprime, powermod,
-             widemul, sum
+             widemul, sum, trailing_zeros, trailing_ones, count_ones
 
 type BigInt <: Integer
     alloc::Cint
@@ -206,7 +206,9 @@ end
 >>(x::BigInt, c::Int32) = x >>> c
 
 trailing_zeros(x::BigInt) = int(ccall((:__gmpz_scan1, :libgmp), Culong, (Ptr{BigInt}, Culong), &x, 0))
- trailing_ones(x::BigInt) = int(ccall((:__gmpz_scan0, :libgmp), Culong, (Ptr{BigInt}, Culong), &x, 0))
+trailing_ones(x::BigInt) = int(ccall((:__gmpz_scan0, :libgmp), Culong, (Ptr{BigInt}, Culong), &x, 0))
+
+count_ones(x::BigInt) = int(ccall((:__gmpz_popcount, :libgmp), Culong, (Ptr{BigInt},), &x))
 
 function divrem(x::BigInt, y::BigInt)
     z1 = BigInt()

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -215,6 +215,10 @@ g = BigInt("-1")
 @test !isprime(BigInt(1))
 @test !isprime(BigInt(10000000020))
 
+@test trailing_ones(a) == 8
+@test trailing_zeros(b) == 2
+@test count_ones(a) == 14
+
 # Large Fibonacci to exercise BigInt
 # from Bill Hart, https://groups.google.com/group/julia-dev/browse_frm/thread/798e2d1322daf633
 function mul(a::Vector{BigInt}, b::Vector{BigInt})


### PR DESCRIPTION
I found these functions were missing/not exported. `leading_zeros` and `leading_ones` are also missing, but I don't see any built-in GMP function to compute them.
