### PR TITLE
RFC : Load tests

### DIFF
--- a/test/load/ltests.jl
+++ b/test/load/ltests.jl
@@ -1,0 +1,114 @@
+
+addprocs(1)
+
+
+exp=5
+print("Testing repeated 10^$exp connect/disconnects....")
+
+(port, server) = open_any_tcp_port(8000)
+
+@spawnat(1, 
+    begin
+        while (true)
+            close(accept(server))
+        end
+    end
+    )
+
+@sync begin
+    @async begin 
+        for i in 1:10^exp
+            close(connect("localhost", port)); 
+#            println("finished $i")
+        end
+    end
+end
+
+close(server)
+println(" : OK")
+
+
+(port, server) = open_any_tcp_port(8000)
+
+exp=9
+size = 10^exp
+block = 10^(exp - 4)
+
+print("Testing open, send of 10^$exp bytes and closing. Other side should recv complete amount...")
+
+rr_rcd = RemoteRef()
+rr_sent = RemoteRef()
+
+@spawnat(1, 
+    begin
+        while (true)
+            s=accept(server)
+            bread = 0
+            while bread < size
+                data = read(s, Uint8, block)
+                @assert length(data) == block
+                bread += block
+            end
+#            println("process $(myid()) received $bread bytes")
+            close(s)
+            put(rr_rcd, true)
+        end
+    end)
+
+
+@spawnat(2, 
+    begin
+        s = connect("localhost", port)    
+        data = fill!(zeros(Uint8, block), int8(65))    
+        bwritten = 0
+        while bwritten < size
+            write(s, data)
+            bwritten += block
+        end
+        close(s)
+#        println("process $(myid()) sent $bwritten bytes")
+        put(rr_sent, true)
+    end)
+
+wait(rr_rcd)
+wait(rr_sent)
+
+close(server)
+
+println(": OK")
+    
+    
+require("sockxfer.jl")
+xfer_exp = 9
+print("Testing 10^$(xfer_exp) bytes of concurrent bidirectional transfers over a single socket connection...")
+
+
+(port, server) = open_any_tcp_port(8000)
+
+rr_server = RemoteRef()
+rr_client = RemoteRef()
+
+
+@spawnat(1, 
+    begin
+        while (true)
+            s=accept(server) 
+            @async begin xfer(s, xfer_exp); put(rr_server, true); take(rr_client); close(s); put(rr_server, true);   end 
+        end
+    end)
+
+
+
+@spawnat(workers()[1], begin s = connect("localhost", port); xfer(s, xfer_exp); put(rr_client, true); take(rr_server); close(s); put(rr_client, true);  end)
+
+take(rr_server)
+take(rr_client)
+
+close(server)
+
+println(" : OK")
+
+@unix_only include("memtest.jl")
+
+    
+    

--- a/test/load/memtest.jl
+++ b/test/load/memtest.jl
@@ -1,0 +1,92 @@
+
+#     
+# immutable RUsage
+#     ru_utime_sec::Clong         #  user CPU time used 
+#     ru_utime_usec::Clong        #  user CPU time used 
+#     ru_stime_sec::Clong         #  system CPU time used 
+#     ru_stime_usec::Clong        #  system CPU time used 
+#     ru_maxrss::Clong            #  maximum resident set size 
+#     ru_ixrss::Clong             #  integral shared memory size 
+#     ru_idrss::Clong             #  integral unshared data size 
+#     ru_isrss::Clong             #  integral unshared stack size 
+#     ru_minflt::Clong            #  page reclaims (soft page faults) 
+#     ru_majflt::Clong            #  page faults (hard page faults) 
+#     ru_nswap::Clong             #  swaps 
+#     ru_inblock::Clong           #  block input operations 
+#     ru_oublock::Clong           #  block output operations 
+#     ru_msgsnd::Clong            #  IPC messages sent 
+#     ru_msgrcv::Clong            #  IPC messages received 
+#     ru_nsignals::Clong          #  signals received 
+#     ru_nvcsw::Clong             #  voluntary context switches 
+#     ru_nivcsw::Clong            #  involuntary context switches 
+# end
+# 
+# RUSAGE_SELF::Cint is defined a 0 both on Mac and Linux....
+# 
+# ru1 = Array(RUsage, 1)
+# ru2 = Array(RUsage, 1)
+# 
+# diff = ru2[1].ru_maxrss - ru1[1].ru_maxrss
+# WARN = (diff > 1000) ? "WARNING" : ""
+# 
+# ccall(:getrusage, Cint, (Cint, Ptr{Void}), 0, ru1)
+# ccall(:getrusage, Cint, (Cint, Ptr{Void}), 0, ru2)
+
+function get_vmsize()
+    lines = split(open(readall, "/proc/self/status"), "\n")
+    vm_line = split(filter(x->beginswith(x, "VmSize"), lines)[1])
+    vmsize = int(vm_line[2])
+    
+    if uppercase(vm_line[3]) == "KB"
+        vmunits = 1
+    elseif uppercase(vm_line[3]) == "MB"
+        vmunits = 1000
+    else
+        error("Unknown unit $(vm_line[3])")
+    end
+    
+    vmsize * vmunits
+end
+
+function run_mtest(name, testf)
+    print ("Testing $name...")
+    for i in 1:2
+        print ("priming process...")
+        testf()             # priming
+    end
+    vm1 = get_vmsize()
+    println ("monitored run...")
+    testf()             # actual run        
+    vm2 = get_vmsize()
+
+    diff = vm2 - vm1
+    WARN = (diff > 1000) ? "<===================================== WARNING" : ""
+    println("Memory Test ($name) : VMSize difference : $diff KB $WARN")
+    
+end
+
+
+
+function mtest_create_strings()
+    for i in 1:10^8
+        string("$i")
+    end
+
+    gc()
+end
+
+
+
+run_mtest("create_strings", () -> mtest_create_strings())
+    
+    
+function mtest_remotecall_fetch()
+    for i in 1:10^5
+        remotecall_fetch(1, myid)
+    end
+    gc()
+end
+
+run_mtest("remotecall_fetch", () -> mtest_remotecall_fetch())
+
+    

--- a/test/load/sockxfer.jl
+++ b/test/load/sockxfer.jl
@@ -1,0 +1,34 @@
+
+
+
+function xfer(s, xfer_exp)
+    xfer_size = 10^xfer_exp
+    xfer_block = 10^(xfer_exp - 4)
+    
+    @sync begin
+        @async begin
+            # read in chunks of xfer_block
+            bread = 0
+            while bread < xfer_size
+                data = read(s, Uint8, xfer_block)
+                @assert length(data) == xfer_block
+                bread = bread + xfer_block
+            end
+            
+#            println("process $(myid()) received $bread bytes")
+            
+        end
+        
+        @async begin
+            # write in chunks of xfer_block
+            data = fill!(zeros(Uint8, xfer_block), int8(65))    
+            bwritten = 0
+            while bwritten < xfer_size
+                write(s, data)
+                bwritten = bwritten + xfer_block
+            end
+#            println("process $(myid()) sent $bwritten bytes")
+        end
+    end
+end
+


### PR DESCRIPTION
This patch is a starting point to add more load tests. 

Currently it has the following:
- 100000 socket connect/disconnects
- Sequential send of 1GB of data between two Julia processes
- Bidirectional send/recv of 1GB of data between two Julia processes

A couple of tests for memory leaks. Currently Linux only. 

Primes a test function, and gets the difference in vmsizes before and after a run. Prints a warning if the difference is more than 1000 KB

Let me know of any more tests we can add. And if Base if not a good place for these tests I'll move it into its own package. 
### TODO
- Add timing information 
- Print other system resource usage.

Any other ideas?  
