### PR TITLE
wait, fetch, and take from multiple RemoteRefs

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -635,8 +635,20 @@ function wait(rs::RemoteRef...)
     end
 end
 
+function fetch(rs::RemoteRef...)
+    vals = Any[]
+    sizehint(vals, length(rs))
+
+    for r in rs
+        push!(vals, fetch(r))
+    end
+
+    vals
+end
+
 fetch(r::RemoteRef) = sync_msg(:fetch, r)
-fetch(x::ANY) = x
+
+fetch(x::ANY...) = x
 
 # storing a value to a Ref
 put_ref(rid, v) = put(lookup_ref(rid), v)
@@ -673,6 +685,17 @@ function take(rr::RemoteRef)
     else
         remotecall_fetch(rr.where, take_ref, rid)
     end
+end
+
+function take(rs::RemoteRef...)
+    vals = Any[]
+    sizehint(vals, length(rs))
+
+    for r in rs
+        push!(vals, take(r))
+    end
+
+    vals
 end
 
 ## work queue ##

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -648,6 +648,7 @@ end
 
 fetch(r::RemoteRef) = sync_msg(:fetch, r)
 
+fetch(x::ANY) = x
 fetch(x::ANY...) = x
 
 # storing a value to a Ref

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -629,7 +629,12 @@ function sync_msg(verb::Symbol, r::RemoteRef)
     return is(verb,:fetch) ? v : r
 end
 
-wait(r::RemoteRef) = sync_msg(:wait, r)
+function wait(rs::RemoteRef...)
+    for r in rs
+        sync_msg(:wait, r)
+    end
+end
+
 fetch(r::RemoteRef) = sync_msg(:fetch, r)
 fetch(x::ANY) = x
 


### PR DESCRIPTION
I think it should be this easy to wait for multiple references.

Alternatives like creating a RemoteRef to wait for a collection of other references seem like overkill.
