### PR TITLE
Ensuring at least 8 workers when parallel tests are run

### DIFF
--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -1,3 +1,7 @@
+# NOTE: worker processes cannot add more workers, only the client process can. 
+# Make sure to update runtests.jl with the mnimum number of 
+# workers required whenever the requirement here changes.
+
 if nprocs() < 2
     addprocs(1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,12 @@ testnames = ["core", "keywordargs", "numbers", "strings", "unicode",
              "socket", "floatapprox", "readdlm", "regex"]
 
 tests = ARGS==["all"] ? testnames : ARGS
+
 n = min(8, CPU_CORES, length(tests))
+
+# if parallel tests are being run, make sure we have at least 4 workers - refer parallel.jl
+contains(tests, "parallel") && (n = max(n, 4))
+
 @unix_only n > 1 && addprocs(n)
 
 blas_set_num_threads(1)


### PR DESCRIPTION
Made the changes in `runtests.jl` rather than `parallel.jl` since `parallel.jl` can be run independently during development and the `addprocs` is valid during a independent run.

Closes #3590
