### PR TITLE
Deprecate `@test_fails` in favor of `@test_throws`

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -1,7 +1,7 @@
 module Test
 
 export Result, Success, Failure, Error,
-       @test, @test_fails, @test_approx_eq, @test_approx_eq_eps,
+       @test, @test_fails, @test_throws, @test_approx_eq, @test_approx_eq_eps,
        registerhandler, withhandler
 
 abstract Result
@@ -39,7 +39,7 @@ function do_test(thk, qex)
     end)
 end
 
-function do_test_fails(thk, qex)
+function do_test_throws(thk, qex)
     handlers[end](try
         thk()
         Failure(qex)
@@ -63,8 +63,12 @@ macro test(ex)
     :(do_test(()->($(esc(ex))),$(Expr(:quote,ex))))
 end
 
+macro test_throws(ex)
+    :(do_test_throws(()->($(esc(ex))),$(Expr(:quote,ex))))
+end
 macro test_fails(ex)
-    :(do_test_fails(()->($(esc(ex))),$(Expr(:quote,ex))))
+    Base.warn_once("@test_fails is deprecated, use @test_throws instead.")
+    :(@test_throws $ex)
 end
 
 function test_approx_eq(va, vb, Eps, astr, bstr)

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -6399,7 +6399,7 @@
 
 "),
 
-("Base.Test","Base.Test","@test_fails","@test_fails(ex)
+("Base.Test","Base.Test","@test_throws","@test_throws(ex)
 
    Test the expression \"ex\" and calls the current handler to handle
    the result in the following manner:

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -33,19 +33,19 @@ As seen in the examples above, failures or errors will print the abstract
 syntax tree of the expression in question.
 
 Another macro is provided to check if the given expression throws an error,
-:func:`@test_fails`::
+:func:`@test_throws`::
 
-  julia> @test_fails error("An error")
+  julia> @test_throws error("An error")
 
-  julia> @test_fails 1 == 1
+  julia> @test_throws 1 == 1
   ERROR: test failed: :((1==1))
    in default_handler at test.jl:20
-   in do_test_fails at test.jl:46
+   in do_test_throws at test.jl:46
 
-  julia> @test_fails 1 != 1
+  julia> @test_throws 1 != 1
   ERROR: test failed: :((1!=1))
    in default_handler at test.jl:20
-   in do_test_fails at test.jl:46
+   in do_test_throws at test.jl:46
 
 As floating point comparisons can be imprecise, two additional macros exist taking in account small numerical errors::
 
@@ -122,7 +122,7 @@ ______
 
    Test the expression ``ex`` and calls the current handler to handle the result.
 
-.. function:: @test_fails(ex)
+.. function:: @test_throws(ex)
 
    Test the expression ``ex`` and calls the current handler to handle the result in the following manner:
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -94,7 +94,7 @@ ind = findin(a, b)
 A = reshape(1:120, 3, 5, 8)
 sA = sub(A, 2, 1:5, 1:8)
 @test size(sA) == (1, 5, 8)
-@test_fails sA[2, 1:8]
+@test_throws sA[2, 1:8]
 @test sA[1, 2, 1:8][:] == 5:15:120
 sA[2:5:end] = -1
 @test all(sA[2:5:end] .== -1)
@@ -232,7 +232,7 @@ for i = 1:3
 end
 
 #permutes correctly
-@test isequal(z,permutedims(y,(3,1,2))) 
+@test isequal(z,permutedims(y,(3,1,2)))
 
 # of a subarray
 a = rand(5,5)
@@ -471,5 +471,5 @@ end
 @test isequal([1,2,3], [a for (a,b) in enumerate(2:4)])
 @test isequal([2,3,4], [b for (a,b) in enumerate(2:4)])
 
-@test_fails (10.^[-1])[1] == 0.1
+@test_throws (10.^[-1])[1] == 0.1
 @test (10.^[-1.])[1] == 0.1

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -23,17 +23,17 @@ for arr in (identity, as_sub)
     @test broadcast(+, arr([1, 0]), arr([1, 4])) == [2, 4]
     @test broadcast(+) == 0
     @test broadcast(*) == 1
-    
+
     @test arr(eye(2)) .+ arr([1, 4]) == arr([2 1; 4 5])
     @test arr(eye(2)) .+ arr([1  4]) == arr([2 4; 1 5])
     @test arr([1  0]) .+ arr([1, 4]) == arr([2 1; 5 4])
     @test arr([1, 0]) .+ arr([1  4]) == arr([2 5; 1 4])
     @test arr([1, 0]) .+ arr([1, 4]) == arr([2, 4])
     @test arr([1]) .+ arr([]) == arr([])
-    
+
     A = arr(eye(2)); @test broadcast!(+, A, A, arr([1, 4])) == arr([2 1; 4 5])
     A = arr(eye(2)); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4; 1 5])
-    A = arr([1  0]); @test_fails broadcast!(+, A, A, arr([1, 4]))
+    A = arr([1  0]); @test_throws broadcast!(+, A, A, arr([1, 4]))
     A = arr([1  0]); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4])
 
     @test arr([ 1    2])   .* arr([3,   4])   == [ 3 6; 4 8]
@@ -41,12 +41,11 @@ for arr in (identity, as_sub)
     @test arr([1 2]) ./ arr([3, 4]) == [1/3 2/3; 1/4 2/4]
     @test arr([1 2]) .\ arr([3, 4]) == [3 1.5; 4 2]
     @test arr([3 4]) .^ arr([1, 2]) == [3 4; 9 16]
-    
+
     M = arr([11 12; 21 22])
     @test broadcast_getindex(M, eye(Int, 2)+1,arr([1, 2])) == [21 11; 12 22]
-    
+
     A = arr(zeros(2,2))
     broadcast_setindex!(A, arr([21 11; 12 22]), eye(Int, 2)+1,arr([1, 2]))
     @test A == M
 end
-

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -57,7 +57,7 @@ _d = {"a"=>0}
 let
     d = Dict{UTF8String, Vector{Int}}()
     d["a"] = [1, 2]
-    @test_fails d["b"] = 1
+    @test_throws d["b"] = 1
     @test isa(repr(d), String)  # check that printable without error
 end
 
@@ -310,7 +310,7 @@ for data_in in ((7,8,4,5),
         add!(s_new, el)
     end
     @test isequal(s, s_new)
-    
+
     t = tuple(s...)
     @test length(t) == length(s)
     for e in t
@@ -375,5 +375,5 @@ s = IntSet(0,1,10,20,200,300,1000,10000,10002)
 @test !contains(s,0)
 @test !contains(s,10002)
 @test contains(s,10000)
-@test_fails first(IntSet())
-@test_fails last(IntSet())
+@test_throws first(IntSet())
+@test_throws last(IntSet())

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,4 +1,4 @@
-# sqrt: 
+# sqrt:
 # tests special values from csqrt man page
 # as well as conj(sqrt(z)) = sqrt(conj(z))
 @test isequal(sqrt(complex( 0.0, 0.0)), complex( 0.0, 0.0))
@@ -35,7 +35,7 @@
 @test isequal(sqrt(complex( NaN, Inf)), complex( Inf, Inf))
 @test isequal(sqrt(complex( NaN,-Inf)), complex( Inf,-Inf))
 
-# log: 
+# log:
 #  log(conj(z)) = conj(log(z))
 
 @test isequal(log(complex( 0.0, 0.0)), complex(-Inf, 0.0))
@@ -291,14 +291,14 @@
 #  tanh(-z) = -tanh(z)
 @test isequal(tanh(complex( 0.0, 0.0)),complex(0.0,0.0))
 @test isequal(tanh(complex( 0.0,-0.0)),complex(0.0,-0.0))
-@test_fails   tanh(complex( 0.0, Inf)) #complex(NaN,0.0)
-@test_fails   tanh(complex( 0.0,-Inf)) #complex(NaN,-0.0)
+@test_throws   tanh(complex( 0.0, Inf)) #complex(NaN,0.0)
+@test_throws   tanh(complex( 0.0,-Inf)) #complex(NaN,-0.0)
 @test isequal(tanh(complex( 0.0, NaN)),complex(NaN,NaN))
 
 @test isequal(tanh(complex(-0.0, 0.0)),complex(-0.0,0.0))
 @test isequal(tanh(complex(-0.0,-0.0)),complex(-0.0,-0.0))
 
-@test_fails   tanh(complex( 5.0, Inf)) #complex(NaN,NaN)
+@test_throws   tanh(complex( 5.0, Inf)) #complex(NaN,NaN)
 @test isequal(tanh(complex( 5.0, NaN)),complex(NaN,NaN))
 
 @test isequal(tanh(complex( Inf, 0.0)),complex(1.0, 0.0))
@@ -340,7 +340,7 @@
 @test isequal(tan(complex(-5.0,-Inf)),complex(sin(2*5.0)*-0.0,-1.0))
 @test isequal(tan(complex(-5.0, NaN)),complex( NaN, NaN))
 
-@test_fails   tan(complex( Inf, 5.0)) #complex(NaN,NaN)
+@test_throws   tan(complex( Inf, 5.0)) #complex(NaN,NaN)
 @test isequal(tan(complex( Inf, Inf)),complex( 0.0, 1.0))
 @test isequal(tan(complex( Inf,-Inf)),complex (0.0,-1.0))
 @test isequal(tan(complex(-Inf, Inf)),complex(-0.0, 1.0))
@@ -596,5 +596,5 @@
 
 @test complex(1//2,1//3)^2 === complex(5//36, 1//3)
 @test complex(2,2)^2 === complex(0,8)
-@test_fails complex(2,2)^(-2)
+@test_throws complex(2,2)^(-2)
 @test complex(2.0,2.0)^(-2) === complex(0.0, -0.125)

--- a/test/core.jl
+++ b/test/core.jl
@@ -34,7 +34,7 @@ let T = TypeVar(:T,true)
 
     @test isequal(typeintersect((Range{Int},(Int,Int)),(AbstractArray{T},Dims)),
                   (Range{Int},(Int,Int)))
-    
+
     @test isequal(typeintersect((T, AbstractArray{T}),(Number, Array{Int,1})),
                   (Int, Array{Int,1}))
 
@@ -45,7 +45,7 @@ let T = TypeVar(:T,true)
                   (Number, Array{Number,1}))
     @test !is(None, typeintersect((Array{T}, Array{T}), (Array, Array{Any})))
     f47{T}(x::Vector{Vector{T}}) = 0
-    @test_fails f47(Array(Vector,0))
+    @test_throws f47(Array(Vector,0))
     @test f47(Array(Vector{Int},0)) == 0
 end
 let N = TypeVar(:N,true)
@@ -309,7 +309,7 @@ function let_undef()
         end
     end
 end
-@test_fails let_undef()
+@test_throws let_undef()
 
 # const implies local in a local scope block
 function const_implies_local()
@@ -356,16 +356,16 @@ begin
     a = Array(Float64,1)
     @test isdefined(a,1)
     @test isdefined(a)
-    @test_fails isdefined(a,2)
+    @test_throws isdefined(a,2)
 
     @test isdefined("a",:data)
     a = UndefField()
     @test !isdefined(a, :field)
-    @test_fails isdefined(a, :foo)
+    @test_throws isdefined(a, :foo)
 
-    @test_fails isdefined(2)
-    @test_fails isdefined(2, :a)
-    @test_fails isdefined("a", 2)
+    @test_throws isdefined(2)
+    @test_throws isdefined(2, :a)
+    @test_throws isdefined("a", 2)
 end
 
 # dispatch
@@ -520,7 +520,7 @@ begin
     c = Vector[a]
 
     @test my_func(c,c)==0
-    @test_fails my_func(a,c)
+    @test_throws my_func(a,c)
 end
 
 begin
@@ -541,9 +541,9 @@ begin
 
     # issue #1202
     foor(x::UnionType) = 1
-    @test_fails foor(StridedArray)
+    @test_throws foor(StridedArray)
     @test foor(StridedArray.body) == 1
-    @test_fails foor(StridedArray)
+    @test_throws foor(StridedArray)
 end
 
 # issue #1153
@@ -574,7 +574,7 @@ begin
     a2 = Any[101,102,103]
     p2 = pointer(a2)
     @test unsafe_load(p2) == 101
-    @test_fails unsafe_store!(p2, 909, 3)
+    @test_throws unsafe_store!(p2, 909, 3)
     @test a2 == [101,102,103]
 end
 
@@ -651,9 +651,9 @@ function NewEntity{ T<:Component }(components::Type{T}...)
   map((c)->c(), components)
 end
 
-@test_fails NewEntity(Transform, Transform, Body, Body)
+@test_throws NewEntity(Transform, Transform, Body, Body)
 @test isa(NewEntity(Transform, Transform), (Transform, Transform))
-@test_fails NewEntity(Transform, Transform, Body, Body)
+@test_throws NewEntity(Transform, Transform, Body, Body)
 
 # issue #1826
 let
@@ -843,7 +843,7 @@ end
 
 # issue #3221
 let x = fill(nothing, 1)
-    @test_fails x[1] = 1
+    @test_throws x[1] = 1
 end
 
 # issue #3220

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -27,6 +27,6 @@
 
 # filter -- array.jl
 @test isequal(filter(x->(x>1), [0 1 2 3 2 1 0]), [2, 3, 2])
-# TODO: @test_fails isequal(filter(x->x+1, [0 1 2 3 2 1 0]), [2, 3, 2])
+# TODO: @test_throws isequal(filter(x->x+1, [0 1 2 3 2 1 0]), [2, 3, 2])
 @test isequal(filter(x->(x>10), [0 1 2 3 2 1 0]), [])
 @test isequal(filter((ss)->length(ss)==3, ["abcd", "efg", "hij", "klmn", "opq"]), ["efg", "hij", "opq"])

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -6,9 +6,9 @@ kwf1(ones; tens=0, hundreds=0) = ones + 10*tens + 100*hundreds
 @test kwf1(1, hundreds=2, tens=7) == 271
 @test kwf1(3, tens=7, hundreds=2) == 273
 
-@test_fails kwf1()        # no method, too few args
-@test_fails kwf1(1, z=0)  # unsupported keyword
-@test_fails kwf1(1, 2)    # no method, too many positional args
+@test_throws kwf1()        # no method, too few args
+@test_throws kwf1(1, z=0)  # unsupported keyword
+@test_throws kwf1(1, 2)    # no method, too many positional args
 
 # keyword args plus varargs
 kwf2(x, rest...; y=1) = (x, y, rest)
@@ -16,14 +16,14 @@ kwf2(x, rest...; y=1) = (x, y, rest)
 @test isequal(kwf2(0,1,2), (0, 1, (1,2)))
 @test isequal(kwf2(0,1,2,y=88), (0, 88, (1,2)))
 @test isequal(kwf2(0,y=88,1,2), (0, 88, (1,2)))
-@test_fails kwf2(0, z=1)
-@test_fails kwf2(y=1)
+@test_throws kwf2(0, z=1)
+@test_throws kwf2(y=1)
 
 # keyword arg with declared type
 kwf3(x; y::Float64 = 1.0) = x + y
 @test kwf3(2) == 3.0
 @test kwf3(2, y=3.0) == 5.0
-@test_fails kwf3(2, y=3)  # wrong type keyword
+@test_throws kwf3(2, y=3)  # wrong type keyword
 
 # function with only keyword args
 kwf4(;a=1,b=2) = (a,b)
@@ -40,8 +40,8 @@ opaf1(a,b=1,c=2,d=3) = (a,b,c,d)
 @test isequal(opaf1(0,2), (0,2,2,3))
 @test isequal(opaf1(0,2,4), (0,2,4,3))
 @test isequal(opaf1(0,2,4,6), (0,2,4,6))
-@test_fails opaf1()
-@test_fails opaf1(0,1,2,3,4)
+@test_throws opaf1()
+@test_throws opaf1(0,1,2,3,4)
 
 # optional positional plus varargs
 opaf2(a=1,rest...) = (a,rest)
@@ -54,7 +54,7 @@ opkwf1(a=0,b=1;k=2) = (a,b,k)
 @test isequal(opkwf1(), (0,1,2))
 @test isequal(opkwf1(10), (10,1,2))
 @test isequal(opkwf1(10,20), (10,20,2))
-@test_fails opkwf1(10,20,30)
+@test_throws opkwf1(10,20,30)
 @test isequal(opkwf1(10,20,k=8), (10,20,8))
 @test isequal(opkwf1(11;k=8),    (11, 1,8))
 @test isequal(opkwf1(k=8),       ( 0, 1,8))
@@ -70,7 +70,7 @@ let
     kwf5 = kwf_maker()
     @test kwf5() == 1
     @test kwf5(k=2) == 5
-    @test_fails kwf5(1)
+    @test_throws kwf5(1)
 end
 
 # with every feature!
@@ -86,4 +86,4 @@ extravagant_args(x,y=0,rest...;color="blue",kw...) =
 @test sin(1.0) == sin(1.0;{}...)
 
 # passing junk kw container
-@test_fails extravagant_args(1; {[]}...)
+@test_throws extravagant_args(1; {[]}...)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -143,9 +143,9 @@ y = BigFloat(1)
 
 # exponent
 x = BigFloat(0)
-@test_fails exponent(x)
+@test_throws exponent(x)
 x = BigFloat(Inf)
-@test_fails exponent(x)
+@test_throws exponent(x)
 x = BigFloat(15.674)
 @test exponent(x) == exponent(15.674)
 
@@ -159,7 +159,7 @@ prevfloat(y)
 @test x == y
 
 # sqrt DomainError
-@test_fails sqrt(BigFloat(-1))
+@test_throws sqrt(BigFloat(-1))
 
 # precision
 old_precision = get_bigfloat_precision()
@@ -177,7 +177,7 @@ end
 @test get_precision(z) == 240
 x = BigFloat(12)
 @test get_precision(x) == old_precision
-@test_fails set_bigfloat_precision(1)
+@test_throws set_bigfloat_precision(1)
 
 # isinteger
 @test isinteger(BigFloat(12))
@@ -283,13 +283,13 @@ with_bigfloat_precision(53) do
 x = BigFloat(42)
     @test log(x) == log(42)
     @test isinf(log(BigFloat(0)))
-    @test_fails log(BigFloat(-1))
+    @test_throws log(BigFloat(-1))
     @test log2(x) == log2(42)
     @test isinf(log2(BigFloat(0)))
-    @test_fails log2(BigFloat(-1))
+    @test_throws log2(BigFloat(-1))
     @test log10(x) == log10(42)
     @test isinf(log10(BigFloat(0)))
-    @test_fails log10(BigFloat(-1))
+    @test_throws log10(BigFloat(-1))
 end
 
 # exp / exp2 / exp10
@@ -303,11 +303,11 @@ end
 # convert to integer types
 x = BigFloat(12.1)
 y = BigFloat(42)
-@test_fails convert(Int32, x)
-@test_fails convert(Int64, x)
-@test_fails convert(BigInt, x)
-@test_fails convert(Uint32, x)
-@test_fails convert(Uint32, x)
+@test_throws convert(Int32, x)
+@test_throws convert(Int64, x)
+@test_throws convert(BigInt, x)
+@test_throws convert(Uint32, x)
+@test_throws convert(Uint32, x)
 @test convert(Int32, y) == 42
 @test convert(Int64, y) == 42
 @test convert(BigInt, y) == 42
@@ -346,8 +346,8 @@ with_bigfloat_precision(256) do
     @test factorial(x) == factorial(BigInt(42))
     x = BigFloat(10)
     @test factorial(x) == factorial(10)
-    @test_fails factorial(BigFloat(-1))
-    @test_fails factorial(BigFloat(331.3))
+    @test_throws factorial(BigFloat(-1))
+    @test_throws factorial(BigFloat(331.3))
 end
 
 # bessel functions
@@ -372,7 +372,7 @@ with_bigfloat_precision(53) do
     for f in (:acos,:asin,:acosh,:atanh),
         j in (-2, -1.5)
         @eval begin
-            @test_fails ($f)(BigFloat($j))
+            @test_throws ($f)(BigFloat($j))
         end
     end
     for f in (:sin,:cos,:tan,:sec,:csc,:cot,:cosh,:sinh,:tanh,
@@ -733,4 +733,3 @@ tol = 1e-3
 @test_approx_eq_eps f+one(Rational{BigInt}) g tol
 
 # new tests
-

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -39,7 +39,7 @@
 @test bool(-1.0) == true
 @test bool(Complex(0,0)) == false
 @test bool(Complex(1,0)) == true
-@test_fails bool(Complex(0,1)) == true
+@test_throws bool(Complex(0,1)) == true
 @test bool(0//1) == false
 @test bool(1//1) == true
 @test bool(1//2) == true
@@ -53,9 +53,9 @@
 @test min(1.0,1) == 1
 
 # lexing typemin(Int64)
-@test_fails parse("9223372036854775808")
-@test_fails parse("-(9223372036854775808)")
-@test_fails parse("-9223372036854775808^1")
+@test_throws parse("9223372036854775808")
+@test_throws parse("-(9223372036854775808)")
+@test_throws parse("-9223372036854775808^1")
 @test (-9223372036854775808)^1 == -9223372036854775808
 @test [1 -1 -9223372036854775808] == [1 -1 typemin(Int64)]
 
@@ -691,7 +691,7 @@ for a = -5:5, b = -5:5
     @test rationalize(a/b) == a//b
     @test a//b == a//b
     if b == 0
-        @test_fails integer(a//b) == integer(a/b)
+        @test_throws integer(a//b) == integer(a/b)
     else
         @test integer(a//b) == integer(a/b)
     end
@@ -782,8 +782,8 @@ for A = real_types, B = real_types
 end
 
 # comparison should fail on complex
-@test_fails complex(1,2) > 0
-@test_fails complex(1,2) > complex(0,0)
+@test_throws complex(1,2) > 0
+@test_throws complex(1,2) > complex(0,0)
 
 # div, fld, rem, mod
 for yr = {
@@ -1114,21 +1114,21 @@ for x = 2^24-10:2^24+10
     @test iceil(y)      == i
 end
 
-@test_fails iround(Inf)
-@test_fails iround(NaN)
+@test_throws iround(Inf)
+@test_throws iround(NaN)
 @test iround(2.5) == 3
 @test iround(-1.9) == -2
-@test_fails iround(Int64, 9.223372036854776e18)
+@test_throws iround(Int64, 9.223372036854776e18)
 @test       iround(Int64, 9.223372036854775e18) == 9223372036854774784
-@test_fails iround(Int64, -9.223372036854778e18)
+@test_throws iround(Int64, -9.223372036854778e18)
 @test       iround(Int64, -9.223372036854776e18) == typemin(Int64)
-@test_fails iround(Uint64, 1.8446744073709552e19)
+@test_throws iround(Uint64, 1.8446744073709552e19)
 @test       iround(Uint64, 1.844674407370955e19) == 0xfffffffffffff800
-@test_fails iround(Int32, 2.1474836f9)
+@test_throws iround(Int32, 2.1474836f9)
 @test       iround(Int32, 2.1474835f9) == 2147483520
-@test_fails iround(Int32, -2.147484f9)
+@test_throws iround(Int32, -2.147484f9)
 @test       iround(Int32, -2.1474836f9) == typemin(Int32)
-@test_fails iround(Uint32, 4.2949673f9)
+@test_throws iround(Uint32, 4.2949673f9)
 @test       iround(Uint32, 4.294967f9) == 0xffffff00
 
 for n = 1:100
@@ -1149,7 +1149,7 @@ end
 
 @test iround(Uint, 0.5) == 1
 @test iround(Uint, prevfloat(0.5)) == 0
-@test_fails iround(Uint, -0.5)
+@test_throws iround(Uint, -0.5)
 @test iround(Uint, prevfloat(-0.5)) == 0
 
 @test iround(Int, 0.5f0) == 1
@@ -1159,7 +1159,7 @@ end
 
 @test iround(Uint, 0.5f0) == 1
 @test iround(Uint, prevfloat(0.5f0)) == 0
-@test_fails iround(Uint, -0.5f0)
+@test_throws iround(Uint, -0.5f0)
 @test iround(Uint, prevfloat(-0.5f0)) == 0
 
 # numbers that can't be rounded by trunc(x+0.5)
@@ -1273,7 +1273,7 @@ function approx_eq(a, b, tol)
     abs(a - b) < tol
 end
 approx_eq(a, b) = approx_eq(a, b, 1e-6)
-# rounding to digits relative to the decimal point 
+# rounding to digits relative to the decimal point
 @test approx_eq(round(pi,0), 3.)
 @test approx_eq(round(pi,1), 3.1)
 @test approx_eq(round(10*pi,-1), 30.)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -2,7 +2,7 @@ ENV["JULIA_PKGDIR"] = string("tmp.",randstring())
 @test !isdir(Pkg.dir())
 try # ensure directory removal
 
-@test_fails Pkg.cd_pkgdir()
+@test_throws Pkg.cd_pkgdir()
 Pkg.init()
 @test isdir(Pkg.dir())
 Pkg.resolve()

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -141,7 +141,7 @@ reqs_data = {
     {"A", 1, 2},
     {"C", 2}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 
 ## DEPENDENCY SCHEME 4: TWO PACKAGES, DAG, WITH TRIVIAL INCONSISTENCY
@@ -150,7 +150,7 @@ deps_data = {
     {"B", 1}
 }
 
-@test_fails sanity_tst(deps_data)
+@test_throws sanity_tst(deps_data)
 
 # require B (must not give errors)
 reqs_data = {
@@ -172,7 +172,7 @@ deps_data = {
     {"C", 2}
 }
 
-@test_fails sanity_tst(deps_data)
+@test_throws sanity_tst(deps_data)
 
 # require A, any version (must use the highest non-inconsistent)
 reqs_data = {
@@ -185,7 +185,7 @@ want = resolve_tst(deps_data, reqs_data)
 reqs_data = {
     {"A", 2}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 
 ## DEPENDENCY SCHEME 6: TWO PACKAGES, CYCLIC, TOTALLY INCONSISTENT
@@ -196,19 +196,19 @@ deps_data = {
     {"B", 2, "A", 2}
 }
 
-@test_fails sanity_tst(deps_data)
+@test_throws sanity_tst(deps_data)
 
 # require A (impossible)
 reqs_data = {
     {"A"}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 # require B (impossible)
 reqs_data = {
     {"B"}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 
 ## DEPENDENCY SCHEME 7: THREE PACKAGES, CYCLIC, WITH INCONSISTENCY
@@ -221,7 +221,7 @@ deps_data = {
     {"C", 2, "A", 2},
 }
 
-@test_fails sanity_tst(deps_data)
+@test_throws sanity_tst(deps_data)
 
 # require A
 reqs_data = {
@@ -241,7 +241,7 @@ want = resolve_tst(deps_data, reqs_data)
 reqs_data = {
     {"C", 1, 2}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 
 ## DEPENDENCY SCHEME 8: THREE PACKAGES, CYCLIC, TOTALLY INCONSISTENT
@@ -254,25 +254,25 @@ deps_data = {
     {"C", 2, "A", 1, 2},
 }
 
-@test_fails sanity_tst(deps_data)
+@test_throws sanity_tst(deps_data)
 
 # require A (impossible)
 reqs_data = {
     {"A"}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 # require B (impossible)
 reqs_data = {
     {"B"}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 # require C (impossible)
 reqs_data = {
     {"C"}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 ## DEPENDENCY SCHEME 9: SIX PACKAGES, DAG
 deps_data = {

--- a/test/resolve2.jl
+++ b/test/resolve2.jl
@@ -150,7 +150,7 @@ reqs_data = {
     {"A", 1, 2},
     {"C", 2}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 
 ## DEPENDENCY SCHEME 4: TWO PACKAGES, DAG, WITH TRIVIAL INCONSISTENCY
@@ -194,7 +194,7 @@ want = resolve_tst(deps_data, reqs_data)
 reqs_data = {
     {"A", 2}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 
 ## DEPENDENCY SCHEME 6: TWO PACKAGES, CYCLIC, TOTALLY INCONSISTENT
@@ -212,13 +212,13 @@ deps_data = {
 reqs_data = {
     {"A"}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 # require B (impossible)
 reqs_data = {
     {"B"}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 
 ## DEPENDENCY SCHEME 7: THREE PACKAGES, CYCLIC, WITH INCONSISTENCY
@@ -252,7 +252,7 @@ want = resolve_tst(deps_data, reqs_data)
 reqs_data = {
     {"C", 1, 2}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 
 ## DEPENDENCY SCHEME 8: THREE PACKAGES, CYCLIC, TOTALLY INCONSISTENT
@@ -273,19 +273,19 @@ deps_data = {
 reqs_data = {
     {"A"}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 # require B (impossible)
 reqs_data = {
     {"B"}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 # require C (impossible)
 reqs_data = {
     {"C"}
 }
-@test_fails resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data)
 
 ## DEPENDENCY SCHEME 9: SIX PACKAGES, DAG
 deps_data = {

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -3,8 +3,8 @@
 @test ip"192.0xFFFF" == IPv4(192,0,255,255)
 @test ip"022.0.0.1" == IPv4(18,0,0,1)
 
-@test_fails Base.parse_ipv4("192.0xFFFFFFFFF")
-@test_fails Base.parse_ipv4("192.")
+@test_throws Base.parse_ipv4("192.0xFFFFFFFFF")
+@test_throws Base.parse_ipv4("192.")
 
 @test ip"::1" == IPv6(1)
 @test ip"2605:2700:0:3::4713:93e3" == IPv6(parseint(Uint128,"260527000000000300000000471393e3",16))

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -35,7 +35,7 @@ a = Base.Condition()
 end
 kill(wait(a))
 
-@test_fails run(`foo`)
+@test_throws run(`foo`)
 
 if false
     prefixer(prefix, sleep) = `perl -nle '$|=1; print "'$prefix' ", $_; sleep '$sleep';'`
@@ -93,4 +93,3 @@ file = tempname()
 stdin, proc = writesto(`cat -` |> file)
 write(stdin, str)
 close(stdin)
-

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -11,10 +11,10 @@
 @test median([1.,-1.,Inf,-Inf]) == 0.0
 @test isnan(median([-Inf,Inf]))
 
-@test_fails median([])
-@test_fails median([NaN])
-@test_fails median([0.0,NaN])
-@test_fails median([NaN,0.0])
+@test_throws median([])
+@test_throws median([NaN])
+@test_throws median([0.0,NaN])
+@test_throws median([NaN,0.0])
 
 @test mean([1,2,3]) == 2.
 @test mean([0 1 2; 4 5 6], 1) == [2. 3. 4.]

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -214,9 +214,9 @@ parsehex(s) = parseint(s,16)
 @test parseint(" 2") == 2
 @test parseint("+2\n") == 2
 @test parseint("-2") == -2
-@test_fails parseint("   2 \n 0")
-@test_fails parseint("2x")
-@test_fails parseint("-")
+@test_throws parseint("   2 \n 0")
+@test_throws parseint("2x")
+@test_throws parseint("-")
 
 # string manipulation
 @test strip("\t  hi   \n") == "hi"
@@ -764,10 +764,10 @@ bin_val = hex2bytes("07bf")
 @test "0123456789abcdefabcdef" == bytes2hex(hex2bytes("0123456789abcdefABCDEF"))
 
 # odd size
-@test_fails hex2bytes("0123456789abcdefABCDEF0")
+@test_throws hex2bytes("0123456789abcdefABCDEF0")
 
 #non-hex characters
-@test_fails hex2bytes("0123456789abcdefABCDEFGH")
+@test_throws hex2bytes("0123456789abcdefABCDEFGH")
 
 # sizeof
 @test sizeof("abc") == 3


### PR DESCRIPTION
`@test_fails` seems poorly named, since test failure usually means "my test didn't pass," not "my test threw an error."

I'm not sure if this is the best way to handle macro deprecation; I'd be happy to do something else.
