### PR TITLE
Fixes for 32-bit in stat and stream

### DIFF
--- a/base/stat.jl
+++ b/base/stat.jl
@@ -6,9 +6,9 @@ immutable Stat
     uid     :: Uint
     gid     :: Uint
     rdev    :: Uint
-    size    :: Int
-    blksize :: Int
-    blocks  :: Int
+    size    :: Int64
+    blksize :: Int64
+    blocks  :: Int64
     mtime   :: Float64
     ctime   :: Float64
 end
@@ -21,9 +21,9 @@ Stat(buf::Union(Vector{Uint8},Ptr{Uint8})) = Stat(
     uint(ccall(:jl_stat_uid,     Uint32,  (Ptr{Uint8},), buf)),
     uint(ccall(:jl_stat_gid,     Uint32,  (Ptr{Uint8},), buf)),
     uint(ccall(:jl_stat_rdev,    Uint32,  (Ptr{Uint8},), buf)),
-     int(ccall(:jl_stat_size,    Coff_t,  (Ptr{Uint8},), buf)),
-     int(ccall(:jl_stat_blksize, Uint32,  (Ptr{Uint8},), buf)),
-     int(ccall(:jl_stat_blocks,  Uint32,  (Ptr{Uint8},), buf)),
+     int64(ccall(:jl_stat_size,    Uint64,  (Ptr{Uint8},), buf)),
+     int64(ccall(:jl_stat_blksize, Uint64,  (Ptr{Uint8},), buf)),
+     int64(ccall(:jl_stat_blocks,  Uint64,  (Ptr{Uint8},), buf)),
          ccall(:jl_stat_mtime,   Float64, (Ptr{Uint8},), buf),
          ccall(:jl_stat_ctime,   Float64, (Ptr{Uint8},), buf),
 )

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -303,10 +303,10 @@ _uv_hook_close(uv::AsyncWork) = (uv.handle = 0; nothing)
 _uv_hook_asynccb(async::AsyncWork, status::Int32) = async.cb(status)
 
 
-function start_timer(timer::TimeoutAsyncWork,timeout::Int64,repeat::Int64)
+function start_timer(timer::TimeoutAsyncWork,timeout::Real,repeat::Real)
     associate_julia_struct(timer.handle,timer)
     ccall(:uv_update_time,Void,(Ptr{Void},),eventloop())
-    ccall(:jl_timer_start,Int32,(Ptr{Void},Int64,Int64),timer.handle,timeout+1,repeat)
+    ccall(:jl_timer_start,Int32,(Ptr{Void},Int64,Int64),timer.handle,int64(round(timeout))+1,int64(round(repeat)))
 end
 
 function stop_timer(timer::TimeoutAsyncWork)
@@ -317,7 +317,7 @@ end
 function sleep(sec::Real)
     w = Condition()
     timer = TimeoutAsyncWork(status->notify(w, status))
-    start_timer(timer, int64(iround(sec*1000)), int64(0))
+    start_timer(timer, sec*1000, 0)
     local st
     try
         st = wait(w)

--- a/src/sys.c
+++ b/src/sys.c
@@ -164,17 +164,17 @@ DLLEXPORT unsigned int jl_stat_rdev(char *statbuf)
     return ((uv_stat_t*) statbuf)->st_rdev;
 }
 
-DLLEXPORT off_t jl_stat_size(char *statbuf)
+DLLEXPORT uint64_t jl_stat_size(char *statbuf)
 {
     return ((uv_stat_t*) statbuf)->st_size;
 }
 
-DLLEXPORT unsigned int jl_stat_blksize(char *statbuf)
+DLLEXPORT uint64_t jl_stat_blksize(char *statbuf)
 {
     return ((uv_stat_t*) statbuf)->st_blksize;
 }
 
-DLLEXPORT unsigned int jl_stat_blocks(char *statbuf)
+DLLEXPORT uint64_t jl_stat_blocks(char *statbuf)
 {
     return ((uv_stat_t*) statbuf)->st_blocks;
 }


### PR DESCRIPTION
These are pretty straightforward, I think, but I began this as a PR mostly hoping Travis would build 32-bit. Looks like that's not the case, unfortunately.

The most important part of this is the impact on `filesize()` for 32-bit builds. Since libuv returns a 64-bit value on all platforms, we might as well make use of it. Otherwise 32-bit Julia builds can be needlessly confused about the size of big files.
