### PR TITLE
Add fieldoffsets(DataType)

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -946,6 +946,7 @@ export
 # types
     convert,
     isleaftype,
+    fieldoffsets,
     oftype,
     promote,
     promote_rule,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -41,6 +41,12 @@ isleaftype(t::ANY) = ccall(:jl_is_leaf_type, Int32, (Any,), t) != 0
 typeintersect(a::ANY,b::ANY) = ccall(:jl_type_intersection, Any, (Any,Any), a, b)
 typeseq(a::ANY,b::ANY) = subtype(a,b)&&subtype(b,a)
 
+function fieldoffsets(x::DataType)
+    offsets = Array(Int, length(x.names))
+    ccall(:jl_field_offsets, Void, (Any, Ptr{Int}), x, offsets)
+    offsets
+end
+
 # subtypes
 function _subtypes(m::Module, x::DataType, sts=Set(), visited=Set())
     add!(visited, m)

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -364,6 +364,12 @@
 
 "),
 
+("Types","Base","fieldoffsets","fieldoffsets(type)
+
+   The offset of each field of \"type\" relative to data start.
+
+"),
+
 ("Types","Base","fieldtype","fieldtype(value, name::Symbol)
 
    Determine the declared type of a named field in a value of

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -205,6 +205,10 @@ Types
    The syntax ``a.b = c`` calls ``setfield(a, :b, c)``, and the syntax ``a.(b) = c``
    calls ``setfield(a, b, c)``.
 
+.. function:: fieldoffsets(type)
+
+   The offset of each field of ``type`` relative to data start.
+
 .. function:: fieldtype(value, name::Symbol)
 
    Determine the declared type of a named field in a value of composite type.

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -130,6 +130,7 @@
     jl_fd_isset;
     jl_fd_set;
     jl_fd_zero;
+    jl_field_offsets;
     jl_free2;
     jl_fstat;
     jl_gc_add_finalizer;

--- a/src/sys.c
+++ b/src/sys.c
@@ -477,6 +477,14 @@ DLLEXPORT jl_value_t *jl_is_char_signed()
     return ((char)255) < 0 ? jl_true : jl_false;
 }
 
+DLLEXPORT void jl_field_offsets(jl_datatype_t *dt, ssize_t *offsets)
+{
+    size_t i;
+    for(i=0; i < jl_tuple_len(dt->names); i++) {
+        offsets[i] = jl_field_offset(dt, i);
+    }
+}
+
 // -- misc sysconf info --
 
 #ifdef _OS_WINDOWS_


### PR DESCRIPTION
In order to efficiently map immutables to compound types in HDF5, it would be useful to know the layout of immutables in memory, but as far as I can tell, this isn't readily available to Julia. This PR adds a `fieldoffsets` function that returns the array of field offsets.
