### PR TITLE
Should reload accept module name without quotes?

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -50,6 +50,8 @@ function require(name::ByteString)
     nothing
 end
 
+reload(name) = reload(string(name))
+
 function reload(name::String)
     if myid() == 1
         @sync for p in filter(x -> x != 1, procs())


### PR DESCRIPTION
reload() requires a string to reload a module from the commandline. This pull request adds a method for convenience so that the tab completed module name can be used instead.

``` julia
julia> using Calculus
julia> reload(Calculus)
ERROR: no method reload(Module,)
```

the function might also be written as this if you want it to be more specific for my use case

``` julia
reload(module::Module) = reload(string(module))
```
