### PR TITLE
Use system provided libblas/libopenblas on Linux x64

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -219,7 +219,7 @@ endif
 
 # Use 64-bit libraries by default on 64-bit architectures
 ifeq ($(ARCH), x86_64)
-USE_BLAS64 = 1
+USE_BLAS64 ?= 1
 endif
 
 ifeq ($(USE_SYSTEM_BLAS), 1)

--- a/Make.inc
+++ b/Make.inc
@@ -241,8 +241,9 @@ endif
 # decide whether use system libopenblas on linux
 ifeq ($(USE_SYSTEM_OPENBLAS), 1)
 ifeq ($(OS), Linux)
-LIBOPENBLAS_PATH ?= /usr/lib/openblas-base
+ifneq (, $(LIBOPENBLAS_PATH))
 LDFLAGS += -Wl,-rpath $(LIBOPENBLAS_PATH)
+endif
 LIBBLAS = -lopenblas
 LIBBLASNAME = libopenblas
 USE_SYSTEM_BLAS = 1

--- a/Make.inc
+++ b/Make.inc
@@ -143,6 +143,7 @@ USE_SYSTEM_PCRE=0
 USE_SYSTEM_LIBM=0
 USE_SYSTEM_OPENLIBM=0
 USE_SYSTEM_BLAS=0
+USE_SYSTEM_OPENBLAS=0
 USE_SYSTEM_LAPACK=0
 USE_SYSTEM_FFTW=0
 USE_SYSTEM_GMP=0
@@ -235,6 +236,17 @@ endif
 else
 LIBBLAS = -L$(BUILD)/lib -lopenblas
 LIBBLASNAME = libopenblas
+endif
+
+# decide whether use system libopenblas on linux
+ifeq ($(USE_SYSTEM_OPENBLAS), 1)
+ifeq ($(OS), Linux)
+LIBBLAS_PATH ?= /usr/lib/openblas-base
+LDFLAGS += -Wl,-rpath $(LIBBLAS_PATH)
+LIBBLAS = -lopenblas
+LIBBLASNAME = libopenblas
+USE_SYSTEM_BLAS = 1
+endif
 endif
 
 # OpenBLAS builds LAPACK as part of its build.

--- a/Make.inc
+++ b/Make.inc
@@ -143,7 +143,6 @@ USE_SYSTEM_PCRE=0
 USE_SYSTEM_LIBM=0
 USE_SYSTEM_OPENLIBM=0
 USE_SYSTEM_BLAS=0
-USE_SYSTEM_OPENBLAS=0
 USE_SYSTEM_LAPACK=0
 USE_SYSTEM_FFTW=0
 USE_SYSTEM_GMP=0
@@ -230,24 +229,12 @@ USE_SYSTEM_LAPACK = 0
 LIBBLAS = -L$(BUILD)/lib -lgfortblas
 LIBBLASNAME = libgfortblas
 else
-LIBBLAS = -lblas
-LIBBLASNAME = libblas
+LIBBLAS ?= -lblas
+LIBBLASNAME ?= libblas
 endif
 else
 LIBBLAS = -L$(BUILD)/lib -lopenblas
 LIBBLASNAME = libopenblas
-endif
-
-# decide whether use system libopenblas on linux
-ifeq ($(USE_SYSTEM_OPENBLAS), 1)
-ifeq ($(OS), Linux)
-ifneq (, $(LIBOPENBLAS_PATH))
-LDFLAGS += -Wl,-rpath $(LIBOPENBLAS_PATH)
-endif
-LIBBLAS = -lopenblas
-LIBBLASNAME = libopenblas
-USE_SYSTEM_BLAS = 1
-endif
 endif
 
 # OpenBLAS builds LAPACK as part of its build.

--- a/Make.inc
+++ b/Make.inc
@@ -241,8 +241,8 @@ endif
 # decide whether use system libopenblas on linux
 ifeq ($(USE_SYSTEM_OPENBLAS), 1)
 ifeq ($(OS), Linux)
-LIBBLAS_PATH ?= /usr/lib/openblas-base
-LDFLAGS += -Wl,-rpath $(LIBBLAS_PATH)
+LIBOPENBLAS_PATH ?= /usr/lib/openblas-base
+LDFLAGS += -Wl,-rpath $(LIBOPENBLAS_PATH)
 LIBBLAS = -lopenblas
 LIBBLASNAME = libopenblas
 USE_SYSTEM_BLAS = 1

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Julia does not install anything outside the directory it was cloned into. Julia 
 
 GCC version 4.6 or later is recommended to build Julia.
 
-If the build fails trying to compile OpenBLAS, set one of the following build options in `Make.user` and build again. Use `OPENBLAS_TARGET_ARCH=BARCELONA` on AMD CPUs, and `OPENBLAS_TARGET_ARCH=NEHALEM` on Intel CPUs. If you want to use the system provided `libblas`, set `USE_SYSTEM_BLAS=1` in `Make.user`. If you want to use the system provided `libopenblas`(instead of `libblas`), set `LIBBLAS=-lopenblas` and `LIBBLASNAME=libopenblas` in `Make.user`i beside `USE_SYSTEM_BLAS=1`. Note that on some Linux distributions(e.g. Debian) `libblas.so` is a soft link to `libopenblas.so` by default if both of them were installed.
+If the build fails trying to compile OpenBLAS, set one of the following build options in `Make.user` and build again. Use `OPENBLAS_TARGET_ARCH=BARCELONA` on AMD CPUs, and `OPENBLAS_TARGET_ARCH=NEHALEM` on Intel CPUs. If you want to use the system provided `libblas`, set `USE_SYSTEM_BLAS=1` in `Make.user`. If you want to use the system provided `libopenblas`(instead of `libblas`), set `LIBBLAS=-lopenblas` and `LIBBLASNAME=libopenblas` in `Make.user` beside `USE_SYSTEM_BLAS=1`. Note that on some Linux distributions(e.g. Debian) `libblas.so` is a soft link to `libopenblas.so` by default if both of them were installed.
 
 On some Linux distributions you may need to change how the readline library is linked. If you get a build error involving readline, set `USE_SYSTEM_READLINE=1` in `Make.user`.
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,15 @@ Julia does not install anything outside the directory it was cloned into. Julia 
 
 GCC version 4.6 or later is recommended to build Julia.
 
-If the build fails trying to compile OpenBLAS, set one of the following build options in `Make.user` and build again. Use `OPENBLAS_TARGET_ARCH=BARCELONA` on AMD CPUs, and `OPENBLAS_TARGET_ARCH=NEHALEM` on Intel CPUs.
+If the build fails trying to compile OpenBLAS, set one of the following build options in `Make.user` and build again. Use `OPENBLAS_TARGET_ARCH=BARCELONA` on AMD CPUs, and `OPENBLAS_TARGET_ARCH=NEHALEM` on Intel CPUs. If you want to use the system provided `libblas`, set `USE_SYSTEM_BLAS=1` in `Make.user`. If you want to use the system provided `libopenblas`(instead of `libblas`), set `LIBBLAS=-lopenblas` and `LIBBLASNAME=libopenblas` in `Make.user`i beside `USE_SYSTEM_BLAS=1`. Note that on some Linux distributions(e.g. Debian) `libblas.so` is a soft link to `libopenblas.so` by default if both of them were installed.
 
 On some Linux distributions you may need to change how the readline library is linked. If you get a build error involving readline, set `USE_SYSTEM_READLINE=1` in `Make.user`.
 
 On Ubuntu or Debian systems, if you get any errors related to `ncurses`, you need to `apt-get install libncurses5-dev`.
 
 On CentOS 5 systems, the default compiler (gcc 4.1) is too old to build Julia.
+
+You can set `USE_SYSTEM_XXX=1` and `LDFLAGS=-Wl,-rpath /path/to/dir/contains/libXXX.so` in `Make.user` to use an external `XXX` shared library which is not in the system library search path. Instead of setting `LDFLAGS`, putting the library directory into the environment variable `LD_LIBRARY_PATH` (at both compiling time and runtime) also works.
 
 ### OS X
 

--- a/base/util.jl
+++ b/base/util.jl
@@ -262,9 +262,9 @@ function versioninfo(io::IO=STDOUT, verbose::Bool=false)
         println(io          )
         println(io,         Sys.cpu_info())
     end
-    if Base.libblas_name == "libopenblas"
+    if Base.libblas_name == "libopenblas" || blas_vendor() == :openblas
         openblas_config = openblas_get_config()
-        println(io,         "  BLAS: ",libblas_name, " (", openblas_config, ")")
+        println(io,         "  BLAS: libopenblas (", openblas_config, ")")
     else
         println(io,         "  BLAS: ",libblas_name)
     end


### PR DESCRIPTION
Hi there, the reasons for mading these minor changes are:
- To use system provided libblas/libopenblas on  Linux x64:
  Julia use 64-bit blas libraries by default on 64-bit architectures, but unfortunately the system provided blas libraries on Linux x64 is configured without `USE64BITINT`, so it'd better to give a chance to set `USE_BLAS64=0` in `Make.usr`.
- To use system provided libopenblas certainly on Linux:
  I installed both `libblas-dev` and `libopenblas-dev` on my Linux box(Debian x64), and the shared object files `/usr/lib/libblas.so*` are finally linked to libopenblas' shared objects(by the packages alternatives mechanism). So when I set `USE_SYSTEM_BLAS=1`, Julia use the system provided libopenblas, this is OK except that the function `versioninfo` says it's using libblas(but libopenblas actually).
  And, yesterday I updated the alternative of libblas.so from `/usr/lib/openblas-base/libopenblas.so` to `/usr/lib/libblas/libblas.so` for some purposes regardless of Julia. After doing this, Julia can not use the system provided libopenblas by setting `USE_SYSTEM_BLAS=1` , so I add a var `USE_SYSTEM_OPENBLAS` to make Julia using the system provided libopenblas in this scenario.

Now, Julia can be built successfully on Linux x64 using the system provide libopenblas certainly by putting these lines in `Make.usr`:

```
#USE_SYSTEM_BLAS=1
USE_SYSTEM_OPENBLAS=1
#OPENBLAS_PATH=/usr/lib/openblas-base # this is set by default
USE_BLAS64=0
```

And, the function `versioninfo` can tell the `BLAS` is `libopenblas (NO_LAPACK NO_LAPACKE DYNAMIC_ARCH NO_AFFINITY)` but not `libblas` now.
