### PR TITLE
Pkg2: new VersionInterval rules, version filtering, new resolve objective function 

### DIFF
--- a/base/pkg2.jl
+++ b/base/pkg2.jl
@@ -100,9 +100,9 @@ resolve(
             error("$pkg has no version compatible with fixed requirements")
     end
 
-    deps, eq_classes = Query.prune_dependencies(reqs,deps)
+    deps = Query.prune_dependencies(reqs,deps)
 
-    want = Resolve.resolve(reqs,deps,eq_classes)
+    want = Resolve.resolve(reqs,deps)
 
     # compare what is installed with what should be
     install, update, remove = Query.diff(have, want)

--- a/base/pkg2.jl
+++ b/base/pkg2.jl
@@ -100,7 +100,9 @@ resolve(
             error("$pkg has no version compatible with fixed requirements")
     end
 
-    want = Resolve.resolve(reqs,deps)
+    deps, eq_classes = Query.prune_dependencies(reqs,deps)
+
+    want = Resolve.resolve(reqs,deps,eq_classes)
 
     # compare what is installed with what should be
     install, update, remove = Query.diff(have, want)

--- a/base/pkg2/query.jl
+++ b/base/pkg2/query.jl
@@ -287,14 +287,14 @@ end
 function filter_prereleases(deps::Dict{ByteString,Dict{VersionNumber,Available}},
                             fixed::Dict{ByteString,VersionNumber} = (ByteString=>VersionNumber)[])
 
-    eqfixed = [ p=>VersionNumber(vn.major, vn.minor, vn.patch) for (p,vn) in fixed ]
+    eqfixed = [ p=>normal(vn) for (p,vn) in fixed ]
 
     filtered_deps = (ByteString=>Dict{VersionNumber,Available})[]
     for (p, depsp) in deps
         filtered_deps[p] = (VersionNumber=>Available)[]
         vmap = (VersionNumber=>Vector{VersionNumber})[]
         for vn in keys(depsp)
-            eqvn = VersionNumber(vn.major, vn.minor, vn.patch)
+            eqvn = normal(vn)
             haskey(vmap, eqvn) || (vmap[eqvn] = VersionNumber[])
             push!(vmap[eqvn], vn)
         end
@@ -302,7 +302,7 @@ function filter_prereleases(deps::Dict{ByteString,Dict{VersionNumber,Available}}
             sort!(vmap[eqvn])
         end
         for (vn, a) in depsp
-            eqvn = VersionNumber(vn.major, vn.minor, vn.patch)
+            eqvn = normal(vn)
             if haskey(fixed, p) && eqvn == eqfixed[p]
                 vn != fixed[p] && continue
                 filtered_deps[p][vn] = a

--- a/base/pkg2/query.jl
+++ b/base/pkg2/query.jl
@@ -290,4 +290,27 @@ function dependencies_subset(deps::Dict{ByteString,Dict{VersionNumber,Available}
     return sub_deps
 end
 
+function filter_prereleases(deps::Dict{ByteString,Dict{VersionNumber,Available}})
+
+    filtered_deps = (ByteString=>Dict{VersionNumber,Available})[]
+    for (p, depsp) in deps
+        filtered_deps[p] = (VersionNumber=>Available)[]
+        vmap = (VersionNumber=>Vector{VersionNumber})[]
+        for vn in keys(depsp)
+            eqvn = VersionNumber(vn.major, vn.minor, vn.patch)
+            haskey(vmap, eqvn) || (vmap[eqvn] = VersionNumber[])
+            push!(vmap[eqvn], vn)
+        end
+        for eqvn in keys(vmap)
+            sort!(vmap[eqvn])
+        end
+        for (vn, a) in depsp
+            eqvn = VersionNumber(vn.major, vn.minor, vn.patch)
+            vn != vmap[eqvn][end] && continue
+            filtered_deps[p][vn] = a
+        end
+    end
+    return filtered_deps
+end
+
 end # module

--- a/base/pkg2/query.jl
+++ b/base/pkg2/query.jl
@@ -319,9 +319,9 @@ function prune_dependencies(reqs::Requires, deps::Dict{ByteString,Dict{VersionNu
                             fixed::Dict{ByteString,VersionNumber} = (ByteString=>VersionNumber)[])
     deps = dependencies_subset(deps, Set{ByteString}(keys(reqs)...))
     deps = filter_prereleases(deps, fixed)
-    deps, eq_classes = prune_versions(reqs, deps)
+    deps, _ = prune_versions(reqs, deps)
 
-    return deps, eq_classes
+    return deps
 end
 
 

--- a/base/pkg2/resolve.jl
+++ b/base/pkg2/resolve.jl
@@ -1,5 +1,6 @@
 module Resolve
 
+include("resolve/versionweight.jl")
 include("resolve/interface.jl")
 include("resolve/maxsum.jl")
 
@@ -8,11 +9,10 @@ using ..Types, ..Query, .PkgToMaxSumInterface, .MaxSum
 export resolve, sanity_check
 
 # Use the max-sum algorithm to resolve packages dependencies
-function resolve(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber,Available}},
-                 eq_classes::Dict{ByteString,Dict{VersionNumber,Vector{VersionNumber}}})
+function resolve(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber,Available}})
 
     # init structures
-    interface = Interface(reqs, deps, eq_classes)
+    interface = Interface(reqs, deps)
 
     graph = Graph(interface)
     msgs = Messages(interface, graph)
@@ -84,9 +84,9 @@ function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}})
         nvn = VersionNumber(vn.major, vn.minor, vn.patch+1)
         sub_reqs = (ByteString=>VersionSet)[p=>VersionSet([vn, nvn])]
         fixed = (ByteString=>VersionNumber)[p=>vn]
-        sub_deps, sub_eq_classes = Query.prune_dependencies(sub_reqs, deps, fixed)
+        sub_deps = Query.prune_dependencies(sub_reqs, deps, fixed)
 
-        interface = Interface(sub_reqs, sub_deps, sub_eq_classes)
+        interface = Interface(sub_reqs, sub_deps)
 
         graph = Graph(interface)
         msgs = Messages(interface, graph)

--- a/base/pkg2/resolve/fieldvalue.jl
+++ b/base/pkg2/resolve/fieldvalue.jl
@@ -1,5 +1,7 @@
 module FieldValues
 
+using ...VersionWeights
+
 export FieldValue, Field, validmax, secondmax
 
 # FieldValue is a numeric type which helps dealing with
@@ -18,23 +20,23 @@ export FieldValue, Field, validmax, secondmax
 #
 immutable FieldValue
     l0::Int
-    l1::Int
-    l2::Int
+    l1::VersionWeight
+    l2::VersionWeight
     l3::Int
     l4::Int128
 end
-FieldValue(l0::Int,l1::Int,l2::Int,l3::Int) = FieldValue(l0, l1, l2, l3, int128(0))
-FieldValue(l0::Int,l1::Int,l2::Int) = FieldValue(l0, l1, l2, 0)
-FieldValue(l0::Int,l1::Int) = FieldValue(l0, l1, 0)
-FieldValue(l0::Int) = FieldValue(l0, 0)
+FieldValue(l0::Int,l1::VersionWeight,l2::VersionWeight,l3::Int) = FieldValue(l0, l1, l2, l3, int128(0))
+FieldValue(l0::Int,l1::VersionWeight,l2::VersionWeight) = FieldValue(l0, l1, l2, 0)
+FieldValue(l0::Int,l1::VersionWeight) = FieldValue(l0, l1, VersionWeight(0))
+FieldValue(l0::Int) = FieldValue(l0, VersionWeight(0))
 FieldValue() = FieldValue(0)
 
 typealias Field Vector{FieldValue}
 
 Base.zero(::Type{FieldValue}) = FieldValue()
 
-Base.typemin(::Type{FieldValue}) = (x=typemin(Int); FieldValue(x,x,x,x,typemin(Int128)))
-Base.typemax(::Type{FieldValue}) = (x=typemax(Int); FieldValue(x,x,x,x,typemax(Int128)))
+Base.typemin(::Type{FieldValue}) = (x=typemin(Int); y=typemin(VersionWeight); FieldValue(x,y,y,x,typemin(Int128)))
+Base.typemax(::Type{FieldValue}) = (x=typemax(Int); y=typemax(VersionWeight); FieldValue(x,y,y,x,typemax(Int128)))
 
 Base.(:-)(a::FieldValue, b::FieldValue) = FieldValue(a.l0-b.l0, a.l1-b.l1, a.l2-b.l2, a.l3-b.l3, a.l4-b.l4)
 Base.(:+)(a::FieldValue, b::FieldValue) = FieldValue(a.l0+b.l0, a.l1+b.l1, a.l2+b.l2, a.l3+b.l3, a.l4+b.l4)

--- a/base/pkg2/resolve/interface.jl
+++ b/base/pkg2/resolve/interface.jl
@@ -47,12 +47,10 @@ type Interface
     # equivalence classes: after version pruning, for each package and each
     #                      version keeps a vector with all versions in the
     #                      equivalence class
-    eq_classes_map::Dict{ByteString,Dict{VersionNumber,Vector{VersionNumber}}}
+    eq_classes::Dict{ByteString,Dict{VersionNumber,Vector{VersionNumber}}}
 
-    function Interface(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber,Available}})
-
-        # reduce deps by version pruning
-        deps, eq_classes_map = Query.prune_versions(reqs, deps)
+    function Interface(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber,Available}},
+                       eq_classes::Dict{ByteString,Dict{VersionNumber,Vector{VersionNumber}}})
 
         # generate pkgs
         pkgs = sort!(ByteString[Set{ByteString}(keys(deps)...)...])
@@ -103,8 +101,8 @@ type Interface
         vweight = [ Array(Int, spp[p0]) for p0 = 1:np ]
         for p0 = 1:np
             p = pkgs[p0]
-            @assert haskey(eq_classes_map, p)
-            eqclass0 = eq_classes_map[p]
+            @assert haskey(eq_classes, p)
+            eqclass0 = eq_classes[p]
             allv = vcat([cl for (_,cl) in eqclass0]...)
             vweight0 = vweight[p0]
             pvers0 = pvers[p0]
@@ -115,7 +113,7 @@ type Interface
             vweight0[spp[p0]] = length(allv)
         end
 
-        return new(reqs, deps, pkgs, np, spp, pdict, pvers, vdict, vweight, eq_classes_map)
+        return new(reqs, deps, pkgs, np, spp, pdict, pvers, vdict, vweight, eq_classes)
     end
 end
 

--- a/base/pkg2/resolve/maxsum.jl
+++ b/base/pkg2/resolve/maxsum.jl
@@ -2,7 +2,7 @@ module MaxSum
 
 include("fieldvalue.jl")
 
-using .FieldValues, ..PkgToMaxSumInterface
+using .FieldValues, ..VersionWeights, ..PkgToMaxSumInterface
 
 export UnsatError, Graph, Messages, maxsum
 
@@ -191,7 +191,7 @@ type Messages
 
         # external fields: there are 2 terms, a noise to break potential symmetries
         #                  and one to favor newest versions over older, and no-version over all
-        fld = [ [ FieldValue(0,0,vweight[p0][v0],0,noise(p0,v0)) for v0 = 1:spp[p0] ] for p0 = 1:np]
+        fld = [ [ FieldValue(0,VersionWeight(0),vweight[p0][v0],0,noise(p0,v0)) for v0 = 1:spp[p0] ] for p0 = 1:np]
 
         # enforce requirements
         for (rp, rvs) in reqs
@@ -290,7 +290,7 @@ function update(p0::Int, graph::Graph, msgs::Messages)
         if dir1 == -1
             # p0 depends on p1
             for v0 = 1:spp0-1
-                cavmsg[v0] += FieldValue(0,0,0,v0)
+                cavmsg[v0] += FieldValue(0,VersionWeight(0),VersionWeight(0),v0)
             end
         end
 
@@ -314,7 +314,7 @@ function update(p0::Int, graph::Graph, msgs::Messages)
             end
             if dir1 == 1 && v1 != spp1
                 # p1 depends on p0
-                newmsg[v1] += FieldValue(0,0,0,v1)
+                newmsg[v1] += FieldValue(0,VersionWeight(0),VersionWeight(0),v1)
             end
             m = max(m, newmsg[v1])
         end

--- a/base/pkg2/resolve/versionweight.jl
+++ b/base/pkg2/resolve/versionweight.jl
@@ -1,0 +1,43 @@
+module VersionWeights
+
+export VersionWeight
+
+# The numeric type used to determine how the different
+# versions of a package should be weighed
+immutable VersionWeight
+    major::Int
+    minor::Int
+    patch::Int
+    uninstall::Int
+end
+VersionWeight(major::Int,minor::Int,patch::Int) = VersionWeight(major, minor, patch, 0)
+VersionWeight(major::Int,minor::Int) = VersionWeight(major, minor, 0)
+VersionWeight(major::Int) = VersionWeight(major, 0)
+VersionWeight() = VersionWeight(0)
+
+VersionWeight(vn::VersionNumber, uninstall=false) = VersionWeight(vn.major, vn.minor, vn.patch, int(uninstall))
+
+Base.zero(::Type{VersionWeight}) = VersionWeight()
+
+Base.typemin(::Type{VersionWeight}) = (x=typemin(Int); VersionWeight(x,x,x,x))
+Base.typemax(::Type{VersionWeight}) = (x=typemax(Int); VersionWeight(x,x,x,x))
+
+Base.(:-)(a::VersionWeight, b::VersionWeight) = VersionWeight(a.major-b.major, a.minor-b.minor, a.patch-b.patch, a.uninstall-b.uninstall)
+Base.(:+)(a::VersionWeight, b::VersionWeight) = VersionWeight(a.major+b.major, a.minor+b.minor, a.patch+b.patch, a.uninstall+b.uninstall)
+
+Base.(:-)(a::VersionWeight) = VersionWeight(-a.major, -a.minor, -a.patch, -a.uninstall)
+
+function Base.isless(a::VersionWeight, b::VersionWeight)
+    a.major < b.major && return true
+    a.major > b.major && return false
+    a.minor < b.minor && return true
+    a.minor > b.minor && return false
+    a.patch < b.patch && return true
+    a.patch > b.patch && return true
+    a.uninstall < b.uninstall && return true
+    return false
+end
+
+Base.abs(a::VersionWeight) = VersionWeight(abs(a.major), abs(a.minor), abs(a.patch), abs(a.uninstall))
+
+end

--- a/base/pkg2/types.jl
+++ b/base/pkg2/types.jl
@@ -1,18 +1,27 @@
 module Types
 
 export VersionInterval, VersionSet, Requires, Available, Fixed,
-       merge_requires!, satisfies, @recover
+       merge_requires!, satisfies, normal, @recover
+
+normal(v::VersionNumber) = VersionNumber(v.major, v.minor, v.patch)
 
 immutable VersionInterval
     lower::VersionNumber
     upper::VersionNumber
+    VersionInterval(lower::VersionNumber, upper::VersionNumber) = new(normal(lower), normal(upper))
 end
 VersionInterval(lower::VersionNumber) = VersionInterval(lower,typemax(VersionNumber))
 VersionInterval() = VersionInterval(typemin(VersionNumber))
 
-Base.show(io::IO, i::VersionInterval) = print(io, "[$(i.lower),$(i.upper))")
+function Base.show(io::IO, i::VersionInterval)
+    if i.upper == normal(typemax(VersionNumber))
+        print(io, "[$(i.lower),$(typemax(VersionNumber)))")
+    else
+        print(io, "[$(i.lower),$(i.upper))")
+    end
+end
 Base.isempty(i::VersionInterval) = i.upper <= i.lower
-Base.contains(i::VersionInterval, v::VersionNumber) = i.lower <= v < i.upper
+Base.contains(i::VersionInterval, v::VersionNumber) = i.lower <= normal(v) < i.upper
 Base.intersect(a::VersionInterval, b::VersionInterval) = VersionInterval(max(a.lower,b.lower), min(a.upper,b.upper))
 Base.isequal(a::VersionInterval, b::VersionInterval) = (a.lower == b.lower) & (a.upper == b.upper)
 

--- a/test/resolve2.jl
+++ b/test/resolve2.jl
@@ -52,8 +52,8 @@ function resolve_tst(deps_data, reqs_data)
     #println()
     #println("deps=$deps")
     #println("reqs=$reqs")
-    deps, eq_classes = Query.prune_dependencies(reqs, deps)
-    want = resolve(reqs, deps, eq_classes)
+    deps = Query.prune_dependencies(reqs, deps)
+    want = resolve(reqs, deps)
 end
 
 ## DEPENDENCY SCHEME 1: TWO PACKAGES, DAG

--- a/test/resolve2.jl
+++ b/test/resolve2.jl
@@ -1,4 +1,5 @@
 using Base.Pkg2.Types
+using Base.Pkg2.Query
 using Base.Pkg2.Resolve
 
 function deps_from_data(deps_data)
@@ -51,7 +52,8 @@ function resolve_tst(deps_data, reqs_data)
     #println()
     #println("deps=$deps")
     #println("reqs=$reqs")
-    want = resolve(reqs, deps)
+    deps, eq_classes = Query.prune_dependencies(reqs, deps)
+    want = resolve(reqs, deps, eq_classes)
 end
 
 ## DEPENDENCY SCHEME 1: TWO PACKAGES, DAG


### PR DESCRIPTION
@StefanKarpinski

As discussed, here is a revised version of Pkg2 resolve whose objective function is not affected by version pruning, which can therefore be moved upstream.

In order for this change to make sense, as suggested by Stefan, I also changed VersionInterval to only use and consider the "normal" part of the version, disregarding the prerelease and build fields. Therefore, a require line such as `julia 0.1- 0.2-` can now be written as `julia 0.1 0.2`.

As for require line parsing, it issues warnings for all non-normal versions except those in the form `x.y.z-`.

There is also a prefiltering step, such that versions of a package are first grouped according to their normal version number, and then only the highest value is kept. Examples of combinations and the resulting version:

```
1.2-pre, 1.2-pre2, 1.2  --> 1.2
1.2-pre, 1.2-pre2 --> 1.2pre
1.2-pre, 1.2, 1.2+build1 --> 1.2+build1
```

However, the sanity check routine is still checking all of them (in case they don't belong to the same equivalence class).

Some additional details are provided in the commit messages.

In my tests everything works fine, and the new weight function has a surprisingly little impact on performance. Users should not notice any difference at the moment, but probably advertising the change in the parsing rules would be a good idea.
