### PR TITLE
sorting API refactor using keywords

### DIFF
--- a/base/darray.jl
+++ b/base/darray.jl
@@ -60,7 +60,7 @@ function defaultdist(dims, procs)
     dims = [dims...]
     chunks = ones(Int, length(dims))
     np = length(procs)
-    f = sort!(collect(keys(factor(np))), Sort.Reverse)
+    f = sort!(collect(keys(factor(np))), order=Sort.Reverse)
     k = 1
     while np > 1
         # repeatedly allocate largest factor to largest dim

--- a/base/darray.jl
+++ b/base/darray.jl
@@ -60,7 +60,7 @@ function defaultdist(dims, procs)
     dims = [dims...]
     chunks = ones(Int, length(dims))
     np = length(procs)
-    f = sort!(collect(keys(factor(np))), order=Sort.Reverse)
+    f = sort!(collect(keys(factor(np))), rev=true)
     k = 1
     while np > 1
         # repeatedly allocate largest factor to largest dim

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -252,7 +252,73 @@ export assign
 typealias ComplexPair Complex
 export ComplexPair
 
-## along an axis
+# superseded sorting API
+
+@deprecate select(v::AbstractVector,k::Union(Int,Range1),o::Ordering) select(v,k,order=o)
+@deprecate select(v::AbstractVector,k::Union(Int,Range1),f::Function) select(v,k,lt=f)
+@deprecate select(f::Function,v::AbstractVector,k::Union(Int,Range1)) select(v,k,lt=f)
+
+# @deprecate select!(v::AbstractVector,k::Union(Int,Range1),o::Ordering) select!(v,k,order=o)
+@deprecate select!(v::AbstractVector,k::Union(Int,Range1),f::Function) select!(v,k,lt=f)
+@deprecate select!(f::Function,v::AbstractVector,k::k::Union(Int,Range1)) select!(v,k,lt=f)
+
+@deprecate sort(v::AbstractVector,o::Ordering) sort(v,order=o)
+@deprecate sort(v::AbstractVector,a::Algorithm) sort(v,alg=a)
+@deprecate sort(v::AbstractVector,a::Algorithm,o::Ordering) sort(v,alg=a,order=o)
+@deprecate sort(v::AbstractVector,o::Ordering,a::Algorithm) sort(v,alg=a,order=o)
+@deprecate sort(v::AbstractVector,f::Function) sort(v,lt=f)
+@deprecate sort(v::AbstractVector,a::Algorithm,f::Function) sort(v,alg=a,lt=f)
+@deprecate sort(v::AbstractVector,f::Function,a::Algorithm) sort(v,alg=a,lt=f)
+@deprecate sort(f::Function,v::AbstractVector,a::Algorithm) sort(v,alg=a,lt=f)
+
+@deprecate sort!(v::AbstractVector,o::Ordering) sort!(v,order=o)
+@deprecate sort!(v::AbstractVector,a::Algorithm) sort!(v,alg=a)
+# @deprecate sort!(v::AbstractVector,a::Algorithm,o::Ordering) sort!(v,alg=a,order=o)
+@deprecate sort!(v::AbstractVector,o::Ordering,a::Algorithm) sort!(v,alg=a,order=o)
+@deprecate sort!(v::AbstractVector,f::Function) sort!(v,lt=f)
+@deprecate sort!(v::AbstractVector,a::Algorithm,f::Function) sort!(v,alg=a,lt=f)
+@deprecate sort!(v::AbstractVector,f::Function,a::Algorithm) sort!(v,alg=a,lt=f)
+@deprecate sort!(f::Function,v::AbstractVector,a::Algorithm) sort!(v,alg=a,lt=f)
+
+@deprecate sortperm(v::AbstractVector,o::Ordering) sortperm(v,order=o)
+@deprecate sortperm(v::AbstractVector,a::Algorithm) sortperm(v,alg=a)
+@deprecate sortperm(v::AbstractVector,a::Algorithm,o::Ordering) sortperm(v,alg=a,order=o)
+@deprecate sortperm(v::AbstractVector,o::Ordering,a::Algorithm) sortperm(v,alg=a,order=o)
+@deprecate sortperm(v::AbstractVector,f::Function) sortperm(v,lt=f)
+@deprecate sortperm(v::AbstractVector,a::Algorithm,f::Function) sortperm(v,alg=a,lt=f)
+@deprecate sortperm(v::AbstractVector,f::Function,a::Algorithm) sortperm(v,alg=a,lt=f)
+@deprecate sortperm(f::Function,v::AbstractVector,a::Algorithm) sortperm(v,alg=a,lt=f)
+
+@deprecate sort(v::AbstractVector,d::Integer,o::Ordering) sort(v,d,order=o)
+@deprecate sort(v::AbstractVector,d::Integer,a::Algorithm) sort(v,d,alg=a)
+@deprecate sort(v::AbstractVector,d::Integer,a::Algorithm,o::Ordering) sort(v,d,alg=a,order=o)
+@deprecate sort(v::AbstractVector,d::Integer,o::Ordering,a::Algorithm) sort(v,d,alg=a,order=o)
+
+@deprecate sort!(v::AbstractVector,d::Integer,o::Ordering) sort!(v,d,order=o)
+@deprecate sort!(v::AbstractVector,d::Integer,a::Algorithm) sort!(v,d,alg=a)
+@deprecate sort!(v::AbstractVector,d::Integer,a::Algorithm,o::Ordering) sort!(v,d,alg=a,order=o)
+@deprecate sort!(v::AbstractVector,d::Integer,o::Ordering,a::Algorithm) sort!(v,d,alg=a,order=o)
+
+@deprecate sortby(v::AbstractVector,f::Function) sort(v,by=f)
+@deprecate sortby(v::AbstractVector,a::Algorithm,f::Function) sort(v,alg=a,by=f)
+@deprecate sortby(v::AbstractVector,f::Function,a::Algorithm) sort(v,alg=a,by=f)
+@deprecate sortby(f::Function,v::AbstractVector,a::Algorithm) sort(v,alg=a,by=f)
+
+@deprecate sortby!(v::AbstractVector,f::Function) sortby!(v,by=f)
+@deprecate sortby!(v::AbstractVector,a::Algorithm,f::Function) sort!(v,alg=a,by=f)
+@deprecate sortby!(v::AbstractVector,f::Function,a::Algorithm) sort!(v,alg=a,by=f)
+@deprecate sortby!(f::Function,v::AbstractVector,a::Algorithm) sort!(v,alg=a,by=f)
+
+@deprecate sortrows(v::AbstractMatrix,o::Ordering) sortrows(v,order=o)
+@deprecate sortrows(v::AbstractMatrix,a::Algorithm) sortrows(v,alg=a)
+@deprecate sortrows(v::AbstractMatrix,a::Algorithm,o::Ordering) sortrows(v,alg=a,order=o)
+@deprecate sortrows(v::AbstractMatrix,o::Ordering,a::Algorithm) sortrows(v,alg=a,order=o)
+
+@deprecate sortcols(v::AbstractMatrix,o::Ordering) sortcols(v,order=o)
+@deprecate sortcols(v::AbstractMatrix,a::Algorithm) sortcols(v,alg=a)
+@deprecate sortcols(v::AbstractMatrix,a::Algorithm,o::Ordering) sortcols(v,alg=a,order=o)
+@deprecate sortcols(v::AbstractMatrix,o::Ordering,a::Algorithm) sortcols(v,alg=a,order=o)
+
 function amap(f::Function, A::AbstractArray, axis::Integer)
     warn_once("amap is deprecated, use mapslices(f, A, dims) instead")
     dimsA = size(A)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -547,8 +547,6 @@ export
     slicedim,
     sort,
     sort!,
-    sortby,
-    sortby!,
     sortperm,
     sortrows,
     sortcols,

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -911,7 +911,7 @@ function decimate(n::Int, graph::Graph, msgs::Messages)
     #println("DECIMATING $n NODES")
     fld = msgs.fld
     decimated = msgs.decimated
-    fldorder = sortperm(fld, order=Sort.By(secondmax))
+    fldorder = sortperm(fld, by=secondmax)
     for p0 in fldorder
         if decimated[p0]
             continue
@@ -1300,7 +1300,7 @@ function sanity_check(vers::Vector{Version}, deps::Vector{(Version,VersionSet)})
         p0, v0 = vdict[v]
         return -pndeps[p0][v0]
     end
-    svers = sortby(vers, vrank)
+    svers = sort(vers, by=vrank)
 
     nv = length(svers)
 
@@ -1373,7 +1373,7 @@ function sanity_check(vers::Vector{Version}, deps::Vector{(Version,VersionSet)})
             end
             i += 1
         end
-        sortby!(insane, x->x[1])
+        sort!(insane, by=x->x[1])
         throw(MetadataError(insane))
     end
 

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -911,7 +911,7 @@ function decimate(n::Int, graph::Graph, msgs::Messages)
     #println("DECIMATING $n NODES")
     fld = msgs.fld
     decimated = msgs.decimated
-    fldorder = sortperm(fld, Sort.By(secondmax))
+    fldorder = sortperm(fld, order=Sort.By(secondmax))
     for p0 in fldorder
         if decimated[p0]
             continue

--- a/base/pkg2/resolve.jl
+++ b/base/pkg2/resolve.jl
@@ -60,7 +60,7 @@ function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}})
     for (p,d) in deps, (vn,_) in d
         push!(vers, (p,vn))
     end
-    sortby!(vers, pvn->(-ndeps[pvn[1]][pvn[2]]))
+    sort!(vers, by=pvn->(-ndeps[pvn[1]][pvn[2]]))
 
     nv = length(vers)
 

--- a/base/pkg2/resolve/maxsum.jl
+++ b/base/pkg2/resolve/maxsum.jl
@@ -399,7 +399,7 @@ function decimate(n::Int, graph::Graph, msgs::Messages)
     #println("DECIMATING $n NODES")
     fld = msgs.fld
     decimated = msgs.decimated
-    fldorder = sortperm(fld, Sort.By(secondmax))
+    fldorder = sortperm(fld, order=Sort.By(secondmax))
     for p0 in fldorder
         if decimated[p0]
             continue

--- a/base/pkg2/resolve/maxsum.jl
+++ b/base/pkg2/resolve/maxsum.jl
@@ -399,7 +399,7 @@ function decimate(n::Int, graph::Graph, msgs::Messages)
     #println("DECIMATING $n NODES")
     fld = msgs.fld
     decimated = msgs.decimated
-    fldorder = sortperm(fld, order=Sort.By(secondmax))
+    fldorder = sortperm(fld, by=secondmax)
     for p0 in fldorder
         if decimated[p0]
             continue

--- a/base/pkg2/types.jl
+++ b/base/pkg2/types.jl
@@ -39,7 +39,7 @@ Base.contains(s::VersionSet, v::VersionNumber) = any(i->contains(i,v), s.interva
 function Base.intersect(A::VersionSet, B::VersionSet)
     ivals = vec([ intersect(a,b) for a in A.intervals, b in B.intervals ])
     filter!(i->!isempty(i), ivals)
-    sortby!(ivals, i->i.lower)
+    sort!(ivals, by=i->i.lower)
     VersionSet(ivals)
 end
 Base.isequal(A::VersionSet, B::VersionSet) = (A.intervals == B.intervals)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -62,7 +62,7 @@ function _subtypes(m::Module, x::DataType, sts=Set(), visited=Set())
     end
     sts
 end
-subtypes(m::Module, x::DataType) = sortby(string, collect(_subtypes(m, x)))
+subtypes(m::Module, x::DataType) = sort(collect(_subtypes(m, x)), by=string)
 subtypes(x::DataType) = subtypes(Main, x)
 
 subtypetree(x::DataType, level=-1) = (level == 0 ? (x, {}) : (x, {subtypetree(y, level-1) for y in subtypes(x)}))

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -417,7 +417,7 @@ lt{T<:Floats}(::Right, x::T, y::T) = slt_int(unbox(T,x),unbox(T,y))
 isnan(o::Direct, x::Floats) = (x!=x)
 isnan{O<:Direct}(o::Perm{O}, i::Int) = isnan(O(),o.data[i])
 
-function nans2left!(v::AbstractVector, lo::Int, hi::Int, o::Ordering)
+function nans2left!(v::AbstractVector, o::Ordering, lo::Int=1, hi::Int=length(v))
     hi < lo && return lo, hi
     i = lo
     while (i < hi) & isnan(o, v[i])
@@ -438,7 +438,7 @@ function nans2left!(v::AbstractVector, lo::Int, hi::Int, o::Ordering)
     end
     return i, hi
 end
-function nans2right!(v::AbstractVector, lo::Int, hi::Int, o::Ordering)
+function nans2right!(v::AbstractVector, o::Ordering, lo::Int=1, hi::Int=length(v))
     hi < lo && return lo, hi
     i = hi
     while (i > lo) & isnan(o, v[i])
@@ -459,8 +459,6 @@ function nans2right!(v::AbstractVector, lo::Int, hi::Int, o::Ordering)
     end
     return lo, i
 end
-nans2left!(v::AbstractVector, o::Ordering) = nans2left!(v, 1, length(v), o)
-nans2right!(v::AbstractVector, o::Ordering) = nans2right!(v, 1, length(v), o)
 
 nans2end!(v::AbstractVector, o::ForwardOrdering) = nans2right!(v, o)
 nans2end!(v::AbstractVector, o::ReverseOrdering) = nans2left!(v, o)
@@ -487,6 +485,7 @@ function fpsort!(v::AbstractVector, a::Algorithm, o::Ordering)
     sort!(v, i,  hi, a, right(o))
     return v
 end
+
 sort!{T<:Floats}(v::AbstractVector{T}, a::Algorithm, o::Direct) = fpsort!(v, a, o)
 sort!{O<:Direct,T<:Floats}(v::Vector{Int}, a::Algorithm, o::Perm{O,Vector{T}}) = fpsort!(v, a, o)
 

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -372,6 +372,25 @@ for (sb,s) in {(:sortby!, :sort!), (:sortby, :sort), (:sortpermby, :sortperm)}
     end
 end
 
+## sorting multi-dimensional arrays ##
+
+sort(A::AbstractArray, dim::Integer; alg::Algorithm=defalg(A), order::Ordering=Forward) =
+    mapslices(a->sort(a, alg=alg, order=order), A, [dim])
+
+function sortrows(A::AbstractMatrix; alg::Algorithm=defalg(A), order::Ordering=Forward)
+    c = 1:size(A,2)
+    rows = [ sub(A,i,c) for i=1:size(A,1) ]
+    p = sortperm(rows, alg=alg, order=order)
+    A[p,:]
+end
+
+function sortcols(A::AbstractMatrix; alg::Algorithm=defalg(A), order::Ordering=Forward)
+    r = 1:size(A,1)
+    cols = [ sub(A,r,i) for i=1:size(A,2) ]
+    p = sortperm(cols, alg=alg, order=order)
+    A[:,p]
+end
+
 ## fast clever sorting for floats ##
 
 module Float
@@ -472,24 +491,5 @@ sort!{T<:Floats}(v::AbstractVector{T}, a::Algorithm, o::Direct) = fpsort!(v, a, 
 sort!{O<:Direct,T<:Floats}(v::Vector{Int}, a::Algorithm, o::Perm{O,Vector{T}}) = fpsort!(v, a, o)
 
 end # module Sort.Float
-
-## sorting multi-dimensional arrays ##
-
-sort(A::AbstractArray, dim::Integer; alg::Algorithm=defalg(A), order::Ordering=Forward) =
-    mapslices(a->sort(a, alg=alg, order=order), A, [dim])
-
-function sortrows(A::AbstractMatrix; alg::Algorithm=defalg(A), order::Ordering=Forward)
-    c = 1:size(A,2)
-    rows = [ sub(A,i,c) for i=1:size(A,1) ]
-    p = sortperm(rows, alg=alg, order=order)
-    A[p,:]
-end
-
-function sortcols(A::AbstractMatrix; alg::Algorithm=defalg(A), order::Ordering=Forward)
-    r = 1:size(A,1)
-    cols = [ sub(A,r,i) for i=1:size(A,2) ]
-    p = sortperm(cols, alg=alg, order=order)
-    A[:,p]
-end
 
 end # module Sort

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -7,17 +7,20 @@ import
     Base.sortperm
 
 export # also exported by Base
+    # order-only:
     issorted,
-    sort,
-    sort!,
-    sortperm,
-    sortrows,
-    sortcols,
     select,
     select!,
     searchsorted,
     searchsortedfirst,
     searchsortedlast,
+    # order & algorithm:
+    sort,
+    sort!,
+    sortperm,
+    sortrows,
+    sortcols,
+    # algorithms:
     InsertionSort,
     QuickSort,
     MergeSort,
@@ -32,11 +35,6 @@ export # not exported by Base
     DEFAULT_STABLE,
     SMALL_ALGORITHM,
     SMALL_THRESHOLD
-
-# not exported
-    # selectby
-    # selectby!
-    # sortpermby
 
 ## notions of element ordering ##
 
@@ -142,12 +140,12 @@ function select!(v::AbstractVector, r::Range1, lo::Int, hi::Int, o::Ordering)
     end
 end
 
-select!(v::AbstractVector, k, o::Ordering) = select!(v,k,1,length(v),o)
-select!(v::AbstractVector, k;
+select!(v::AbstractVector, k::Union(Int,Range1), o::Ordering) = select!(v,k,1,length(v),o)
+select!(v::AbstractVector, k::Union(Int,Range1);
     lt::Function=isless, by::Function=identity, order::Ordering=Forward, rev::Bool=false) =
     select!(v, k, ord(lt,by,order,rev))
 
-select(v::AbstractVector, k; kws...) = select!(copy(v), k; kws...)
+select(v::AbstractVector, k::Union(Int,Range1); kws...) = select!(copy(v), k; kws...)
 
 # reference on sorted binary search:
 #   http://www.tbray.org/ongoing/When/200x/2003/03/22/Binary

--- a/examples/bubblesort.jl
+++ b/examples/bubblesort.jl
@@ -1,8 +1,9 @@
 importall Base
 
-type BubbleSort <: Sort.Algorithm end
+type BubbleSortAlg <: Sort.Algorithm end
+const BubbleSort = BubbleSortAlg()
 
-function sort!(v::AbstractVector, lo::Int, hi::Int, ::BubbleSort, o::Sort.Ordering)
+function sort!(v::AbstractVector, lo::Int, hi::Int, ::BubbleSortAlg, o::Sort.Ordering)
     while true
         clean = true
         for i = lo:hi-1

--- a/examples/bubblesort.jl
+++ b/examples/bubblesort.jl
@@ -1,9 +1,7 @@
-importall Base
-
-type BubbleSortAlg <: Sort.Algorithm end
+immutable BubbleSortAlg <: Sort.Algorithm end
 const BubbleSort = BubbleSortAlg()
 
-function sort!(v::AbstractVector, lo::Int, hi::Int, ::BubbleSortAlg, o::Sort.Ordering)
+function Base.sort!(v::AbstractVector, lo::Int, hi::Int, ::BubbleSortAlg, o::Sort.Ordering)
     while true
         clean = true
         for i = lo:hi-1

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -430,11 +430,11 @@ begin
     @test isless(asc[:,1],asc[:,2])
     @test isless(asc[:,2],asc[:,3])
 
-    asr = sortrows(a, Sort.Reverse)
+    asr = sortrows(a, order=Sort.Reverse)
     @test isless(asr[2,:],asr[1,:])
     @test isless(asr[3,:],asr[2,:])
 
-    asc = sortcols(a, Sort.Reverse)
+    asc = sortcols(a, order=Sort.Reverse)
     @test isless(asc[:,2],asc[:,1])
     @test isless(asc[:,3],asc[:,2])
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -430,11 +430,11 @@ begin
     @test isless(asc[:,1],asc[:,2])
     @test isless(asc[:,2],asc[:,3])
 
-    asr = sortrows(a, order=Sort.Reverse)
+    asr = sortrows(a, rev=true)
     @test isless(asr[2,:],asr[1,:])
     @test isless(asr[3,:],asr[2,:])
 
-    asc = sortcols(a, order=Sort.Reverse)
+    asc = sortcols(a, rev=true)
     @test isless(asc[:,2],asc[:,1])
     @test isless(asc[:,3],asc[:,2])
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -1,5 +1,5 @@
 @test sort([2,3,1]) == [1,2,3]
-@test sort([2,3,1],Sort.Reverse) == [3,2,1]
+@test sort([2,3,1], order=Sort.Reverse) == [3,2,1]
 @test sortperm([2,3,1]) == [3,1,2]
 @test !issorted([2,3,1])
 @test issorted([1,2,3])
@@ -30,30 +30,30 @@ rg_r = 57:-1:49; rgv_r = [rg_r]
 for i = 47:59
     @test searchsortedfirst(rg, i) == searchsortedfirst(rgv, i)
     @test searchsortedlast(rg, i) == searchsortedlast(rgv, i)
-    @test searchsortedfirst(rg_r, i, Sort.Reverse) ==
-          searchsortedfirst(rgv_r, i, Sort.Reverse)
-    @test searchsortedlast(rg_r, i, Sort.Reverse) ==
-          searchsortedlast(rgv_r, i, Sort.Reverse)
+    @test searchsortedfirst(rg_r, i, order=Sort.Reverse) ==
+          searchsortedfirst(rgv_r, i, order=Sort.Reverse)
+    @test searchsortedlast(rg_r, i, order=Sort.Reverse) ==
+          searchsortedlast(rgv_r, i, order=Sort.Reverse)
 end
 rg = 1:2:17; rgv = [rg]
 rg_r = 17:-2:1; rgv_r = [rg_r]
 for i = -1:19
     @test searchsortedfirst(rg, i) == searchsortedfirst(rgv, i)
     @test searchsortedlast(rg, i) == searchsortedlast(rgv, i)
-    @test searchsortedfirst(rg_r, i, Sort.Reverse) ==
-          searchsortedfirst(rgv_r, i, Sort.Reverse)
-    @test searchsortedlast(rg_r, i, Sort.Reverse) ==
-          searchsortedlast(rgv_r, i, Sort.Reverse)
+    @test searchsortedfirst(rg_r, i, order=Sort.Reverse) ==
+          searchsortedfirst(rgv_r, i, order=Sort.Reverse)
+    @test searchsortedlast(rg_r, i, order=Sort.Reverse) ==
+          searchsortedlast(rgv_r, i, order=Sort.Reverse)
 end
 rg = -3:0.5:2; rgv = [rg]
 rg_r = 2:-0.5:-3; rgv_r = [rg_r]
 for i = -5:.5:4
     @test searchsortedfirst(rg, i) == searchsortedfirst(rgv, i)
     @test searchsortedlast(rg, i) == searchsortedlast(rgv, i)
-    @test searchsortedfirst(rg_r, i, Sort.Reverse) ==
-          searchsortedfirst(rgv_r, i, Sort.Reverse)
-    @test searchsortedlast(rg_r, i, Sort.Reverse) ==
-          searchsortedlast(rgv_r, i, Sort.Reverse)
+    @test searchsortedfirst(rg_r, i, order=Sort.Reverse) ==
+          searchsortedfirst(rgv_r, i, order=Sort.Reverse)
+    @test searchsortedlast(rg_r, i, order=Sort.Reverse) ==
+          searchsortedlast(rgv_r, i, order=Sort.Reverse)
 end
 
 rg = 3+0*(1:5); rgv = [rg]
@@ -61,56 +61,56 @@ rg_r = rg; rgv_r = [rg_r]
 for i = 2:4
     @test searchsortedfirst(rg, i) == searchsortedfirst(rgv, i)
     @test searchsortedlast(rg, i) == searchsortedlast(rgv, i)
-    @test searchsortedfirst(rg_r, i, Sort.Reverse) ==
-          searchsortedfirst(rgv_r, i, Sort.Reverse)
-    @test searchsortedlast(rg_r, i, Sort.Reverse) ==
-          searchsortedlast(rgv_r, i, Sort.Reverse)
+    @test searchsortedfirst(rg_r, i, order=Sort.Reverse) ==
+          searchsortedfirst(rgv_r, i, order=Sort.Reverse)
+    @test searchsortedlast(rg_r, i, order=Sort.Reverse) ==
+          searchsortedlast(rgv_r, i, order=Sort.Reverse)
 end
 
 rg = 0.0:0.01:1.0
 for i = 2:101
-    @test searchsortedfirst(rg,rg[i]) == i
-    @test searchsortedfirst(rg,prevfloat(rg[i])) == i
-    @test searchsortedfirst(rg,nextfloat(rg[i])) == i+1
+    @test searchsortedfirst(rg, rg[i]) == i
+    @test searchsortedfirst(rg, prevfloat(rg[i])) == i
+    @test searchsortedfirst(rg, nextfloat(rg[i])) == i+1
 
-    @test searchsortedlast(rg,rg[i]) == i
-    @test searchsortedlast(rg,prevfloat(rg[i])) == i-1
-    @test searchsortedlast(rg,nextfloat(rg[i])) == i
+    @test searchsortedlast(rg, rg[i]) == i
+    @test searchsortedlast(rg, prevfloat(rg[i])) == i-1
+    @test searchsortedlast(rg, nextfloat(rg[i])) == i
 end
 
 rg_r = reverse(rg)
 for i = 1:100
-    @test searchsortedfirst(rg_r,rg_r[i],Sort.Reverse) == i
-    @test searchsortedfirst(rg_r,prevfloat(rg_r[i]),Sort.Reverse) == i+1
-    @test searchsortedfirst(rg_r,nextfloat(rg_r[i]),Sort.Reverse) == i
+    @test searchsortedfirst(rg_r, rg_r[i], order=Sort.Reverse) == i
+    @test searchsortedfirst(rg_r, prevfloat(rg_r[i]), order=Sort.Reverse) == i+1
+    @test searchsortedfirst(rg_r, nextfloat(rg_r[i]), order=Sort.Reverse) == i
 
-    @test searchsortedlast(rg_r,rg_r[i],Sort.Reverse) == i
-    @test searchsortedlast(rg_r,prevfloat(rg_r[i]),Sort.Reverse) == i
-    @test searchsortedlast(rg_r,nextfloat(rg_r[i]),Sort.Reverse) == i-1
+    @test searchsortedlast(rg_r, rg_r[i], order=Sort.Reverse) == i
+    @test searchsortedlast(rg_r, prevfloat(rg_r[i]), order=Sort.Reverse) == i
+    @test searchsortedlast(rg_r, nextfloat(rg_r[i]), order=Sort.Reverse) == i-1
 end
 
 a = rand(1:10000, 1000)
 
 for alg in [InsertionSort, MergeSort, TimSort]
-    b = sort(a, alg)
+    b = sort(a, alg=alg)
     @test issorted(b)
-    ix = sortperm(a, alg)
+    ix = sortperm(a, alg=alg)
     b = a[ix]
     @test issorted(b)
     @test a[ix] == b
 
-    b = sort(a, alg, Sort.Reverse)
-    @test issorted(b, Sort.Reverse)
-    ix = sortperm(a, alg, Sort.Reverse)
+    b = sort(a, alg=alg, order=Sort.Reverse)
+    @test issorted(b, order=Sort.Reverse)
+    ix = sortperm(a, alg=alg, order=Sort.Reverse)
     b = a[ix]
-    @test issorted(b, Sort.Reverse)
+    @test issorted(b, order=Sort.Reverse)
     @test a[ix] == b
 
-    b = sortby(a, alg, x -> -10x)
-    @test issorted(b, Sort.By(x -> -10x))
-    ix = sortperm(a, alg, Sort.By(x -> -10x))
+    b = sortby(a, x->1/x, alg=alg)
+    @test issorted(b, order=Sort.By(x->1/x))
+    ix = sortperm(a, alg=alg, order=Sort.By(x->1/x))
     b = a[ix]
-    @test issorted(b, Sort.By(x -> -10x))
+    @test issorted(b, order=Sort.By(x->1/x))
     @test a[ix] == b
 
     c = copy(a)
@@ -120,26 +120,26 @@ for alg in [InsertionSort, MergeSort, TimSort]
     ipermute!(c, ix)
     @test c == a
 
-    c = sort(a, alg) do x,y
+    c = sort(a, alg=alg) do x,y
         x > y
     end
     @test b == c
 
-    c = sortby(a, alg) do x
+    c = sortby(a, alg=alg) do x
         -10x
     end
     @test b == c
 end
 
-b = sort(a, QuickSort)
+b = sort(a, alg=QuickSort)
 @test issorted(b)
-b = sort(a, QuickSort, Sort.Reverse)
-@test issorted(b, Sort.Reverse)
-b = sortby(a, QuickSort, x -> -10x)
-@test issorted(b, Sort.By(x -> -10x))
+b = sort(a, alg=QuickSort, order=Sort.Reverse)
+@test issorted(b, order=Sort.Reverse)
+b = sortby(a, x->1/x, alg=QuickSort)
+@test issorted(b, order=Sort.By(x->1/x))
 
-@test select([3,6,30,1,9], 2, Sort.Reverse) == 9
-@test select([3,6,30,1,9], 2, Sort.By(x -> -x)) == 9
+@test select([3,6,30,1,9], 2, order=Sort.Reverse) == 9
+@test select([3,6,30,1,9], 2, order=Sort.By(x->1/x)) == 9
 
 ## more advanced sorting tests ##
 
@@ -161,12 +161,12 @@ for n in [0:10, 100, 1000]
 
     for ord in [Sort.Forward, Sort.Reverse]
         # insersion sort as a reference
-        pi = sortperm(v,InsertionSort,ord)
+        pi = sortperm(v, alg=InsertionSort, order=ord)
         @test isperm(pi)
         s = v[pi]
-        @test issorted(s, ord)
+        @test issorted(s, order=ord)
         @test hist(s,r) == h
-        @test all([ issorted(pi[s.==i]) for i in r ])
+        @test all(issorted,[pi[s.==i] for i in r])
         si = copy(v)
         permute!(si, pi)
         @test si == s
@@ -174,7 +174,7 @@ for n in [0:10, 100, 1000]
         @test si == v
 
         # mergesort
-        pm = sortperm(v,MergeSort,ord)
+        pm = sortperm(v, alg=MergeSort, order=ord)
         @test pi == pm
         sm = copy(v)
         permute!(sm, pm)
@@ -183,7 +183,7 @@ for n in [0:10, 100, 1000]
         @test sm == v
 
         # timsort
-        pt = sortperm(v,TimSort,ord)
+        pt = sortperm(v, alg=TimSort, order=ord)
         @test pi == pt
         st = copy(v)
         permute!(st, pt)
@@ -192,7 +192,7 @@ for n in [0:10, 100, 1000]
         @test st == v
 
         # quicksort (unstable)
-        pq = sortperm(v,QuickSort,ord)
+        pq = sortperm(v, alg=QuickSort, order=ord)
         @test isperm(pi)
         @test v[pq] == s
         sq = copy(v)
@@ -207,12 +207,12 @@ for n in [0:10, 100, 1000]
     for ord in [Sort.Forward, Sort.Reverse],
         alg in [InsertionSort, QuickSort, MergeSort, TimSort]
         # test float sorting with NaNs
-        s = sort(v,alg,ord)
-        @test issorted(s, ord)
+        s = sort(v, alg=alg, order=ord)
+        @test issorted(s, order=ord)
         @test reinterpret(Uint64,v[isnan(v)]) == reinterpret(Uint64,s[isnan(s)])
 
         # test float permutation with NaNs
-        p = sortperm(v,alg,ord)
+        p = sortperm(v, alg=alg, order=ord)
         @test isperm(p)
         vp = v[p]
         @test isequal(s,vp)

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -106,11 +106,11 @@ for alg in [InsertionSort, MergeSort, TimSort]
     @test issorted(b, order=Sort.Reverse)
     @test a[ix] == b
 
-    b = sortby(a, x->1/x, alg=alg)
-    @test issorted(b, order=Sort.By(x->1/x))
-    ix = sortperm(a, alg=alg, order=Sort.By(x->1/x))
+    b = sort(a, alg=alg, by=x->1/x)
+    @test issorted(b, by=x->1/x)
+    ix = sortperm(a, alg=alg, by=x->1/x)
     b = a[ix]
-    @test issorted(b, order=Sort.By(x->1/x))
+    @test issorted(b, by=x->1/x)
     @test a[ix] == b
 
     c = copy(a)
@@ -120,14 +120,10 @@ for alg in [InsertionSort, MergeSort, TimSort]
     ipermute!(c, ix)
     @test c == a
 
-    c = sort(a, alg=alg) do x,y
-        x > y
-    end
+    c = sort(a, alg=alg, lt=(>))
     @test b == c
 
-    c = sortby(a, alg=alg) do x
-        -10x
-    end
+    c = sort(a, alg=alg, by=x->1/x)
     @test b == c
 end
 
@@ -135,11 +131,11 @@ b = sort(a, alg=QuickSort)
 @test issorted(b)
 b = sort(a, alg=QuickSort, order=Sort.Reverse)
 @test issorted(b, order=Sort.Reverse)
-b = sortby(a, x->1/x, alg=QuickSort)
-@test issorted(b, order=Sort.By(x->1/x))
+b = sort(a, alg=QuickSort, by=x->1/x)
+@test issorted(b, by=x->1/x)
 
 @test select([3,6,30,1,9], 2, order=Sort.Reverse) == 9
-@test select([3,6,30,1,9], 2, order=Sort.By(x->1/x)) == 9
+@test select([3,6,30,1,9], 2, by=x->1/x) == 9
 
 ## more advanced sorting tests ##
 
@@ -215,7 +211,7 @@ for n in [0:10, 100, 1000]
         p = sortperm(v, alg=alg, order=ord)
         @test isperm(p)
         vp = v[p]
-        @test isequal(s,vp)
-        @test reinterpret(Uint64,s) == reinterpret(Uint64,vp)
+        @test isequal(vp,s)
+        @test reinterpret(Uint64,vp) == reinterpret(Uint64,s)
     end
 end

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -1,5 +1,5 @@
 @test sort([2,3,1]) == [1,2,3]
-@test sort([2,3,1], order=Sort.Reverse) == [3,2,1]
+@test sort([2,3,1], rev=true) == [3,2,1]
 @test sortperm([2,3,1]) == [3,1,2]
 @test !issorted([2,3,1])
 @test issorted([1,2,3])
@@ -30,30 +30,30 @@ rg_r = 57:-1:49; rgv_r = [rg_r]
 for i = 47:59
     @test searchsortedfirst(rg, i) == searchsortedfirst(rgv, i)
     @test searchsortedlast(rg, i) == searchsortedlast(rgv, i)
-    @test searchsortedfirst(rg_r, i, order=Sort.Reverse) ==
-          searchsortedfirst(rgv_r, i, order=Sort.Reverse)
-    @test searchsortedlast(rg_r, i, order=Sort.Reverse) ==
-          searchsortedlast(rgv_r, i, order=Sort.Reverse)
+    @test searchsortedfirst(rg_r, i, rev=true) ==
+          searchsortedfirst(rgv_r, i, rev=true)
+    @test searchsortedlast(rg_r, i, rev=true) ==
+          searchsortedlast(rgv_r, i, rev=true)
 end
 rg = 1:2:17; rgv = [rg]
 rg_r = 17:-2:1; rgv_r = [rg_r]
 for i = -1:19
     @test searchsortedfirst(rg, i) == searchsortedfirst(rgv, i)
     @test searchsortedlast(rg, i) == searchsortedlast(rgv, i)
-    @test searchsortedfirst(rg_r, i, order=Sort.Reverse) ==
-          searchsortedfirst(rgv_r, i, order=Sort.Reverse)
-    @test searchsortedlast(rg_r, i, order=Sort.Reverse) ==
-          searchsortedlast(rgv_r, i, order=Sort.Reverse)
+    @test searchsortedfirst(rg_r, i, rev=true) ==
+          searchsortedfirst(rgv_r, i, rev=true)
+    @test searchsortedlast(rg_r, i, rev=true) ==
+          searchsortedlast(rgv_r, i, rev=true)
 end
 rg = -3:0.5:2; rgv = [rg]
 rg_r = 2:-0.5:-3; rgv_r = [rg_r]
 for i = -5:.5:4
     @test searchsortedfirst(rg, i) == searchsortedfirst(rgv, i)
     @test searchsortedlast(rg, i) == searchsortedlast(rgv, i)
-    @test searchsortedfirst(rg_r, i, order=Sort.Reverse) ==
-          searchsortedfirst(rgv_r, i, order=Sort.Reverse)
-    @test searchsortedlast(rg_r, i, order=Sort.Reverse) ==
-          searchsortedlast(rgv_r, i, order=Sort.Reverse)
+    @test searchsortedfirst(rg_r, i, rev=true) ==
+          searchsortedfirst(rgv_r, i, rev=true)
+    @test searchsortedlast(rg_r, i, rev=true) ==
+          searchsortedlast(rgv_r, i, rev=true)
 end
 
 rg = 3+0*(1:5); rgv = [rg]
@@ -61,10 +61,10 @@ rg_r = rg; rgv_r = [rg_r]
 for i = 2:4
     @test searchsortedfirst(rg, i) == searchsortedfirst(rgv, i)
     @test searchsortedlast(rg, i) == searchsortedlast(rgv, i)
-    @test searchsortedfirst(rg_r, i, order=Sort.Reverse) ==
-          searchsortedfirst(rgv_r, i, order=Sort.Reverse)
-    @test searchsortedlast(rg_r, i, order=Sort.Reverse) ==
-          searchsortedlast(rgv_r, i, order=Sort.Reverse)
+    @test searchsortedfirst(rg_r, i, rev=true) ==
+          searchsortedfirst(rgv_r, i, rev=true)
+    @test searchsortedlast(rg_r, i, rev=true) ==
+          searchsortedlast(rgv_r, i, rev=true)
 end
 
 rg = 0.0:0.01:1.0
@@ -80,13 +80,13 @@ end
 
 rg_r = reverse(rg)
 for i = 1:100
-    @test searchsortedfirst(rg_r, rg_r[i], order=Sort.Reverse) == i
-    @test searchsortedfirst(rg_r, prevfloat(rg_r[i]), order=Sort.Reverse) == i+1
-    @test searchsortedfirst(rg_r, nextfloat(rg_r[i]), order=Sort.Reverse) == i
+    @test searchsortedfirst(rg_r, rg_r[i], rev=true) == i
+    @test searchsortedfirst(rg_r, prevfloat(rg_r[i]), rev=true) == i+1
+    @test searchsortedfirst(rg_r, nextfloat(rg_r[i]), rev=true) == i
 
-    @test searchsortedlast(rg_r, rg_r[i], order=Sort.Reverse) == i
-    @test searchsortedlast(rg_r, prevfloat(rg_r[i]), order=Sort.Reverse) == i
-    @test searchsortedlast(rg_r, nextfloat(rg_r[i]), order=Sort.Reverse) == i-1
+    @test searchsortedlast(rg_r, rg_r[i], rev=true) == i
+    @test searchsortedlast(rg_r, prevfloat(rg_r[i]), rev=true) == i
+    @test searchsortedlast(rg_r, nextfloat(rg_r[i]), rev=true) == i-1
 end
 
 a = rand(1:10000, 1000)
@@ -99,11 +99,11 @@ for alg in [InsertionSort, MergeSort, TimSort]
     @test issorted(b)
     @test a[ix] == b
 
-    b = sort(a, alg=alg, order=Sort.Reverse)
-    @test issorted(b, order=Sort.Reverse)
-    ix = sortperm(a, alg=alg, order=Sort.Reverse)
+    b = sort(a, alg=alg, rev=true)
+    @test issorted(b, rev=true)
+    ix = sortperm(a, alg=alg, rev=true)
     b = a[ix]
-    @test issorted(b, order=Sort.Reverse)
+    @test issorted(b, rev=true)
     @test a[ix] == b
 
     b = sort(a, alg=alg, by=x->1/x)
@@ -129,12 +129,12 @@ end
 
 b = sort(a, alg=QuickSort)
 @test issorted(b)
-b = sort(a, alg=QuickSort, order=Sort.Reverse)
-@test issorted(b, order=Sort.Reverse)
+b = sort(a, alg=QuickSort, rev=true)
+@test issorted(b, rev=true)
 b = sort(a, alg=QuickSort, by=x->1/x)
 @test issorted(b, by=x->1/x)
 
-@test select([3,6,30,1,9], 2, order=Sort.Reverse) == 9
+@test select([3,6,30,1,9], 2, rev=true) == 9
 @test select([3,6,30,1,9], 2, by=x->1/x) == 9
 
 ## more advanced sorting tests ##


### PR DESCRIPTION
Quoting the main commit:

> The idea here is that the ordering and algorithm for sorting are two orthogonal parameters that have sensible defaults: neither, both or either can be independently specified. The resulting API is slightly more verbose but also somewhat more self-documenting.
> 
> Another sign that this might be on the right track is that this change reduces the LOC of base/sort.jl by 41 lines and reduces the method count of sort, for example, from 12 to 6.

Still needs deprecation methods before merging, but I thought I'd put it out there for feedback.

Note: I really wish that the `lt` and `by` ordering variations could be cleanly specified this way too – that would really cut the API down to a nice lean size without sacrificing any functionality. But I can't figure out a good way to do it.
