### PR TITLE
Manually symlink libopenblas.so to libopenblas.so.0 in usr/lib/

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -734,6 +734,9 @@ $(OPENBLAS_OBJ_SOURCE): openblas-$(OPENBLAS_VER)/config.status
 	touch -c $@
 $(OPENBLAS_OBJ_TARGET): $(OPENBLAS_OBJ_SOURCE) | $(BUILD)/lib
 	cp -f openblas-$(OPENBLAS_VER)/libopenblas.$(SHLIB_EXT) $(BUILD)/lib
+ifeq ($(OS), Linux)
+	ln -sf $(BUILD)/lib/libopenblas.$(SHLIB_EXT) $(BUILD)/lib/libopenblas.$(SHLIB_EXT).0
+endif
 	$(INSTALL_NAME_CMD)libopenblas.$(SHLIB_EXT) $(BUILD)/lib/libopenblas.$(SHLIB_EXT)
 
 clean-openblas:


### PR DESCRIPTION
Fixes #3586.  Thanks to @vtjnash for helping out, and I request comments before I merge.
