### PR TITLE
moved repr from io.jl to string.jl

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -391,12 +391,6 @@ end
 
 sprint(f::Function, args...) = sprint(0, f, args...)
 
-function repr(x)
-    s = IOBuffer()
-    show(s, x)
-    takebuf_string(s)
-end
-
 write(x) = write(STDOUT::IO, x)
 
 function readuntil(s::IOStream, delim::Uint8)

--- a/base/string.jl
+++ b/base/string.jl
@@ -1378,3 +1378,9 @@ end
 
 bytes2hex(arr::Array{Uint8,1}) = join([hex(i, 2) for i in arr])
 
+function repr(x)
+    s = IOBuffer()
+    show(s, x)
+    takebuf_string(s)
+end
+


### PR DESCRIPTION
...as it is used in pcre.jl

Before:

```
julia> Regex(":)")
ERROR: repr not defined
 in compile at pcre.jl:85
 in Regex at regex.jl:18
 in Regex at regex.jl:34
```

After:

```
julia> Regex(":)")
ERROR: compile: unmatched parentheses at position 2 in ":)"
 in compile at pcre.jl:85
 in Regex at regex.jl:18
 in Regex at regex.jl:34
```
