### PR TITLE
Autoload julia-mode.

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -222,6 +222,7 @@
     (when (julia-at-keyword julia-block-end-keywords)
       (forward-word 1)))
 
+;;;###autoload
 (defun julia-mode ()
   "Major mode for editing julia code"
   (interactive)


### PR DESCRIPTION
This is generally a good practice for Emacs libs - it means you don't have to load the entire file when starting Emacs.
