### PR TITLE
RFC: Implement test for gc-managed allocation

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1004,6 +1004,7 @@ export
     gc,
     gc_disable,
     gc_enable,
+    gc_bytes,
 
 # misc
     exit,

--- a/base/util.jl
+++ b/base/util.jl
@@ -6,6 +6,9 @@ time() = ccall(:clock_now, Float64, ())
 # high-resolution relative time, in nanoseconds
 time_ns() = ccall(:jl_hrtime, Uint64, ())
 
+# total number of bytes allocated so far
+gc_bytes() = ccall(:jl_gc_total_bytes, Csize_t, ())
+
 function tic()
     t0 = time_ns()
     task_local_storage(:TIMERS, (t0, get(task_local_storage(), :TIMERS, ())))
@@ -33,9 +36,11 @@ end
 macro time(ex)
     quote
         local t0 = time_ns()
+        local b0 = gc_bytes()
         local val = $(esc(ex))
         local t1 = time_ns()
-        println("elapsed time: ", (t1-t0)/1e9, " seconds")
+        local b1 = gc_bytes()
+        println("elapsed time: ", (t1-t0)/1e9, " seconds (", int(b1-b0), " allocated bytes)")
         val
     end
 end

--- a/src/gc.c
+++ b/src/gc.c
@@ -74,6 +74,7 @@ typedef struct _bigval_t {
 
 // GC knobs and self-measurement variables
 static size_t allocd_bytes = 0;
+static size_t total_allocd_bytes = 0;
 static size_t freed_bytes = 0;
 #define default_collect_interval (3200*1024*sizeof(void*))
 static size_t collect_interval = default_collect_interval;
@@ -837,6 +838,8 @@ DLLEXPORT void jl_gc_enable(void)    { is_gc_enabled = 1; }
 DLLEXPORT void jl_gc_disable(void)   { is_gc_enabled = 0; }
 DLLEXPORT int jl_gc_is_enabled(void) { return is_gc_enabled; }
 
+DLLEXPORT size_t jl_gc_total_bytes(void) { return total_allocd_bytes + allocd_bytes; }
+
 void jl_gc_ephemeral_on(void)  { pools = &ephe_pools[0]; }
 void jl_gc_ephemeral_off(void) { pools = &norm_pools[0]; }
 
@@ -861,6 +864,7 @@ static void print_obj_profile(void)
 void jl_gc_collect(void)
 {
     size_t actual_allocd = allocd_bytes;
+    total_allocd_bytes += allocd_bytes;
     allocd_bytes = 0;
     if (is_gc_enabled) {
         JL_SIGATOMIC_BEGIN();

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -138,6 +138,7 @@
     jl_gc_disable;
     jl_gc_enable;
     jl_gc_is_enabled;
+    jl_gc_total_bytes;
     jl_gc_lookfor;
     jl_gc_new_weakref;
     jl_gc_counted_malloc;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1089,6 +1089,7 @@ void jl_gc_setmark(jl_value_t *v);
 DLLEXPORT void jl_gc_enable(void);
 DLLEXPORT void jl_gc_disable(void);
 DLLEXPORT int jl_gc_is_enabled(void);
+DLLEXPORT size_t jl_gc_total_bytes(void);
 void jl_gc_ephemeral_on(void);
 void jl_gc_ephemeral_off(void);
 DLLEXPORT void jl_gc_collect(void);


### PR DESCRIPTION
In optimizing code, usually one of the most important steps is to stamp out any unnecessary garbage-collection. One can test for this with the profiler, but a more direct approach seems desirable.

Demonstration:

```
julia> x = randn(3,5,8);

julia> size(x)
(3,5,8)

julia> size(x,2)
5

julia> @gcallocated sz = size(x,2)
false

julia> @gcallocated sz = size(x)
true
```

In the source, I'm not certain I got every place where this is relevant, but I hope I did.
