### PR TITLE
Removed argument --bind-to and check for empty bind_addr

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -192,7 +192,7 @@ function try_include(f::String)
 end
 
 function process_options(args::Array{Any,1})
-    global ARGS, bind_addr
+    global ARGS
     quiet = false
     repl = true
     startup = true
@@ -204,9 +204,6 @@ function process_options(args::Array{Any,1})
         elseif args[i]=="--worker"
             start_worker()
             # doesn't return
-        elseif args[i]=="--bind-to"
-            i += 1
-            bind_addr = args[i]
         elseif args[i]=="-e" || args[i]=="--eval"
             repl = false
             i+=1

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -877,11 +877,12 @@ end
 # argument is descriptor to write listening port # to.
 start_worker() = start_worker(STDOUT)
 function start_worker(out::IO)
+    global bind_addr
     default_port = uint16(9009)
     (actual_port,sock) = open_any_tcp_port(accept_handler,default_port) 
     write(out, "julia_worker:")  # print header
     write(out, "$(dec(actual_port))#") # print port
-    write(out, bind_addr)      #TODO: print hostname
+    write(out, bind_addr == "" ? "127.0.0.1" : bind_addr)      #TODO: print hostname
     write(out, '\n')
     # close STDIN; workers will not use it
     #close(STDIN)
@@ -1044,7 +1045,7 @@ function launch_procs(n::Integer, config::Dict)
         sshflags = config[:sshflags]
         lcmd(idx) =  `ssh -n $sshflags $(cman.machines[idx]) "sh -l -c \"cd $dir && $exename $exeflags\""`
     else
-        lcmd(idx) =  `$(dir)/$(exename) --bind-to $bind_addr $exeflags`
+        lcmd(idx) =  `$(dir)/$(exename) $exeflags`
     end
     
     for i in 1:n


### PR DESCRIPTION
Workaround for issue https://github.com/JuliaLang/julia/issues/3747

I have also removed the command line argument bind-to, since it was not really being used. 

The global `bind_addr` has been retained and is set by `getipaddr()`, though even that is not really being used.
