### PR TITLE
Restricts worker terminated message to error conditions. rmprocs() waits...

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -231,17 +231,33 @@ function workers()
     end
 end
 
-function rmprocs(args...)
+rmprocset = Set()
+function rmprocs(args...; waitfor = 0.0)
     # Only pid 1 can add and remove processes
     if myid() != 1
         error("only process 1 can add and remove processes")
     end
     
+    global rmprocset
+    empty!(rmprocset)
+    
     for i in [args...]
         if haskey(map_pid_wrkr, i)
+            add!(rmprocset, i)
             remote_do(i, exit)
         end
     end
+    
+    start = time()
+    while (time() - start) < waitfor 
+        if length(rmprocset) == 0
+            break;
+        else
+            sleep(0.1)
+        end
+    end
+    
+    ((waitfor > 0) && (length(rmprocset) > 0)) ? :timed_out : :ok
 end
 
 
@@ -850,19 +866,24 @@ function create_message_handler_loop(sock::AsyncStream) #returns immediately
                 exit(1)
             end
             
-            if isa(e,EOFError)
-                deregister_worker(iderr)
-                
-                if (myid() == 1) println("Worker $iderr terminated.") end
-                
-                #TODO : Notify all RemoteRefs linked to this Worker who just died....
-                # How?
-                
-                return nothing
-            else
-                # TODO : Treat any exception as death of node / major screw-up and cleanup?
-                rethrow(e)
+            # Will treat any exception as death of node and cleanup
+            # since currently we do not have a mechanism for workers to reconnect
+            # to each other on unhandled errors
+            deregister_worker(iderr)
+            
+            if isopen(sock) close(sock) end
+            
+            if (myid() == 1) 
+                global rmprocset
+                if contains(rmprocset, iderr)
+                    delete!(rmprocset, iderr)
+                else
+                    println("Worker $iderr terminated.") 
+                    rethrow(e)
+                end
             end
+
+            return nothing
         end
     end)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,5 +19,5 @@ blas_set_num_threads(1)
 
 reduce(propagate_errors, nothing, pmap(runtests, tests))
 
-@unix_only n > 1 && rmprocs(workers())
+@unix_only n > 1 && rmprocs(workers(), waitfor=5.0)
 println("    \033[32;1mSUCCESS\033[0m")


### PR DESCRIPTION
... for workers to exit.

Addresses issues raised in https://github.com/JuliaLang/julia/commit/68256c137ed0ebd52892a1b1e162d45576b45149#commitcomment-3665073

rmprocs also has an optional timeout parameter.

Also treating all exceptions the same in the socket event loop for the worker connection.
