### PR TITLE
Get rid of the applicable call in rand(Range1)

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -139,13 +139,9 @@ for itype in (:Uint32, :Uint64, :Uint128, :Int32, :Int64, :Int128)
     end
 end
 
-# random integer from lo to hi inclusive
-function rand{T<:Integer}(r::Range1{T})
-    if !applicable(rand, T)
-        # Fallback for integer types where rand(T) is not defined.
-        return convert(T, rand(int(r)))
-    end
 
+# random integer from lo to hi inclusive
+function rand{T<:Union(Uint32,Uint64,Uint128,Int32,Int64,Int128)}(r::Range1{T})
     lo = r[1]
     hi = r[end]
     m = typemax(T)
@@ -172,6 +168,9 @@ function rand{T<:Integer}(r::Range1{T})
     end
     return convert(T, rem(s,d) + lo)
 end
+
+# fallback for other integer types
+rand{T<:Integer}(r::Range1{T}) = convert(T, rand(int(r)))
 
 function rand!{T<:Integer}(r::Range1{T}, A::Array{T})
     for i=1:length(A) 


### PR DESCRIPTION
Relying on multiple dispatch mechanism, we can get rid of the applicable call which is a performance killer for the function `rand`. 

This version is about 16x - 20x faster than the original one.

This is the first step to address https://github.com/JuliaLang/julia/issues/3751.
