### PR TITLE
RFC: Add in special case handler for bootstrap errors

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -627,6 +627,9 @@ static void NORETURN throw_internal(jl_value_t *e)
     else {
         if (jl_current_task == jl_root_task) {
             JL_PRINTF(JL_STDERR, "fatal: error thrown and no exception handler available.\n");
+            // Special case on ErrorException, as that's what's thrown by jl_errorf() on bootstrap errors
+            if( jl_typeof(e) == (jl_value_t*)jl_errorexception_type )
+                JL_PRINTF(JL_STDERR, "%s\n", jl_string_data(jl_fieldref(e,0)));
             exit(1);
         }
         jl_task_t *cont = jl_current_task->on_exit;


### PR DESCRIPTION
This patch adds in some really rudimentary exception printing when something comes up during bootstrap.  This should make the `fatal: error thrown and no exception handler available` errors a little less cryptic, as the actual problem is always hidden by Julia freaking out that we haven't given her an error handler yet.

@JeffBezanson, this is my first time mucking around with all these strange `jl_*` types; anything I majorly screwed up?
