### PR TITLE
RFC : Alternative implementation of timedwait

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1112,6 +1112,7 @@ export
     take,
     wait,
     ClusterManager,
+    timedwait,
 
 # distributed arrays
     distribute,
@@ -1262,5 +1263,4 @@ export
     @sprintf,
     @deprecate,
     @boundscheck,
-    @inbounds,
-    @timedwait
+    @inbounds

--- a/base/util.jl
+++ b/base/util.jl
@@ -333,35 +333,3 @@ usingmodule(names::Symbol...) = eval(current_module(), Expr(:toplevel, Expr(:usi
 usingmodule(names::String) = usingmodule([symbol(name) for name in split(names,".")]...)
 
 
-macro timedwait(ex, wait_secs, poll_interval)
-    quote
-        start = time()
-        done = RemoteRef()
-        function timercb(aw, status)
-            try
-                if $(esc(ex))
-                    put(done, :ok)
-                elseif (time() - start) > $(wait_secs)
-                    put(done, :timed_out)
-                elseif status != 0
-                    put(done, :error)
-                end
-            catch e
-                put(done, :error)
-                stop_timer(aw)
-            end
-        end
-
-        if !$(esc(ex))
-            t = TimeoutAsyncWork(timercb)
-            start_timer(t, $(poll_interval), $(poll_interval))
-            ret = fetch(done)
-            stop_timer(t)
-        else
-            ret = :ok
-        end
-        ret
-    end
-end
-
-

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3162,6 +3162,11 @@ Parallel Computing
 
    Make an uninitialized remote reference on processor ``n``.
 
+.. function:: timedwait(testcb::Function, secs::Float64; pollint::Float64=0.1)
+
+   Waits till ``testcb`` returns ``true`` or for ``secs``` seconds, whichever is earlier.
+   ``testcb`` is polled every ``pollint`` seconds.
+   
 .. function:: @spawn
 
    Execute an expression on an automatically-chosen processor, returning a

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -30,3 +30,23 @@ workloads = hist(@parallel((a,b)->[a,b], for i=1:7; myid(); end), nprocs())[2]
 
 # @parallel reduction should work even with very short ranges
 @test @parallel(+, for i=1:2; i; end) == 3
+
+# Testing timedwait on multiple RemoteRefs
+rr1 = RemoteRef()
+rr2 = RemoteRef()
+rr3 = RemoteRef()
+
+@async begin sleep(0.5); put(rr1, :ok) end
+@async begin sleep(1.0); put(rr2, :ok) end
+@async begin sleep(2.0); put(rr3, :ok) end
+
+tic()
+timedwait(1.0) do
+    all(map(isready, [rr1, rr2, rr3]))
+end
+et=toq()
+
+# assuming that 0.5 seconds is a good enough buffer on a typical modern CPU
+@test (et >= 1.0) && (et <= 1.5)
+@test isready(rr1)
+@test !isready(rr3)


### PR DESCRIPTION
This is an alternative to @timedwait as implemented https://github.com/JuliaLang/julia/pull/3764 

Differences: 
- `timedwait` is a function
- polling interval is a kw arg with default of 0.1 seconds
- code moved to `multi.jl` from `util.jl`

Return values are still symbols instead of integer values. Symbols are self explanatory and do not need to be exported. 

Do let  me know if this is preferred over the macro implementation. Wanted this issue closed before I document and use the same elsewhere.
