### PR TITLE
Added sort performance tests

### DIFF
--- a/test/perf/Makefile
+++ b/test/perf/Makefile
@@ -1,10 +1,13 @@
 JULIAHOME = $(abspath ../..)
 include ../../Make.inc
 
-all: micro kernel cat shootout
+all: micro kernel cat shootout sort
 
-micro kernel cat shootout:
-	@$(MAKE) $(QUIET_MAKE) -C shootout
+micro kernel cat sort:
+	@$(call spawn,$(JULIA_EXECUTABLE)) $@/perf.jl | perl -nle '@_=split/,/; printf "%-18s %8.3f %8.3f %8.3f %8.3f\n", $$_[1], $$_[2], $$_[3], $$_[4], $$_[5]'
+
+shootout:
+	@$(MAKE) $(QUIET_MAKE) -C $@
 	@$(call spawn,$(JULIA_EXECUTABLE)) $@/perf.jl | perl -nle '@_=split/,/; printf "%-18s %8.3f %8.3f %8.3f %8.3f\n", $$_[1], $$_[2], $$_[3], $$_[4], $$_[5]'
 
 clean:
@@ -12,4 +15,4 @@ clean:
 	$(MAKE) -C micro $@
 	$(MAKE) -C shootout $@
 
-.PHONY: micro kernel cat shootout clean
+.PHONY: micro kernel cat shootout clean sort

--- a/test/perf/perfutil.jl
+++ b/test/perf/perfutil.jl
@@ -31,5 +31,24 @@ macro timeit1(ex,name)
     end
 end
 
+macro timeit_init(ex,init,name)
+    quote
+        t = zeros(ntrials)
+        for i=0:ntrials
+            $(esc(init))
+            e = 1000*(@elapsed $(esc(ex)))
+            if i > 0
+                # warm up on first iteration
+                t[i] = e
+            end
+        end
+        if print_output
+            @printf "julia,%s,%f,%f,%f,%f\n" $name min(t) max(t) mean(t) std(t)
+        end
+        gc()
+    end
+end
+
+
 # seed rng for more consistent timings
 srand(1776)

--- a/test/perf/sort/perf.jl
+++ b/test/perf/sort/perf.jl
@@ -1,0 +1,69 @@
+import Base.Sort: QuickSort, MergeSort, TimSort, InsertionSort
+
+include("../perfutil.jl")
+
+sorts = [QuickSort, MergeSort, TimSort, InsertionSort]
+
+randstr_fn!(str_len::Int) = d -> (for i = 1:length(d); d[i] = randstring(str_len); end; d)
+randint_fn!(m::Int) = d -> rand!(1:m,d)
+
+for (T, typename, randfn!) in Any[(Int, string(Int), randint_fn!(10)), 
+                                  (Float64, string(Float64), rand!), 
+                                  (String, "String_05", randstr_fn!(5)),
+                                  (String, "String_10", randstr_fn!(10))]
+    for logsize = 6:2:18
+        size = 2^logsize
+        for s in sorts
+            if s == InsertionSort && logsize >=14; continue; end
+            data = Array(T, size)
+            gc()
+
+            ## Random
+            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_random"
+            @timeit_init(sort!(data, alg=s), randfn!(data), name)
+
+            ## Sorted
+            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_sorted"
+            @timeit(sort!(data, alg=s), name)
+
+            ## Reverse sorted
+            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_reversed"
+            @timeit_init(sort!(data, alg=s), reverse!(data), name)
+
+            ## Sorted with 3 exchanges
+            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_3exchanges"
+            @timeit_init(sort!(data, alg=s), 
+                         begin
+                             for i = 1:3
+                                 n1 = rand(1:size)
+                                 n2 = rand(1:size)
+                                 data[n1], data[n2] = data[n2], data[n1]
+                             end
+                         end, 
+                         name)
+
+            ## Sorted with 10 unsorted values appended
+            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_append"
+            @timeit_init(sort!(data, alg=s), begin data[end-9:end]=randfn!(Array(T,10)) end, name)
+            
+            ## Random data with 4 unique values
+            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_4unique"
+            @timeit_init(sort!(data4, alg=s), begin data4=data[rand(1:4,size)] end, name)
+
+            ## All values equal
+            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_allequal"
+            data1 = data[ones(Int, size)]
+            @timeit(sort!(data1, alg=s), name)
+
+            ## QuickSort median killer
+            if s == QuickSort && logsize > 16; continue; end  # too slow!
+
+            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_qsortkiller"
+            data = data[1:size>>1]
+            data = sort!(data, alg=s)
+            data = vcat(reverse(data), data)
+            @timeit_init(sort!(qdata, alg=s), begin qdata=copy(data) end, name)
+        end
+    end
+end
+


### PR DESCRIPTION
Based on tests in https://github.com/kmsquire/SortPerf.jl, which are based on tests described in http://svn.python.org/projects/python/trunk/Objects/listsort.txt

Testing includes:
- all algorithms (QuickSort, MergeSort, InsertionSort, TimSort)
- range of sizes (2^6 -> 2^18)
- different datatypes (Int, Float, String)
- different data characteristics (random, sorted, reversed, 3 random exchanges, 10 random values appended, 4 unique values, all equal, quicksort median killer)

Also added a `timeit_init` macro, which allows some non-timed initialization to occur.
