### PR TITLE
Rename finfer, disassemble, and methods(function,types)

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -221,6 +221,7 @@ export PipeString
 @deprecate square(x::Number)          x*x
 @deprecate disassemble(f::Function,t::Tuple) asm_llvm(f,t)
 @deprecate disassemble(f::Function,t::Tuple,asm::Bool) (asm ? asm_native(f,t) : asm_llvm(f,t))
+@deprecate finfer                        ast_typed
 
 deprecated_ls() = run(`ls -l`)
 deprecated_ls(args::Cmd) = run(`ls -l $args`)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -219,6 +219,8 @@ export PipeString
 @deprecate msync(A::Array, flags::Int)    msync(A)
 @deprecate msync(A::BitArray, flags::Int) msync(A)
 @deprecate square(x::Number)          x*x
+@deprecate disassemble(f::Function,t::Tuple) asm_llvm(f,t)
+@deprecate disassemble(f::Function,t::Tuple,asm::Bool) (asm ? asm_native(f,t) : asm_llvm(f,t))
 
 deprecated_ls() = run(`ls -l`)
 deprecated_ls(args::Cmd) = run(`ls -l $args`)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -992,6 +992,7 @@ export
     asm_llvm,
     asm_native,
     ast_typed,
+    ast_lowered,
     isconst,
     isgeneric,
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -990,6 +990,8 @@ export
     whos,
     isinteractive,
     disassemble,
+    asm_llvm,
+    asm_native,
     finfer,
     isconst,
     isgeneric,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -991,7 +991,7 @@ export
     isinteractive,
     asm_llvm,
     asm_native,
-    finfer,
+    ast_typed,
     isconst,
     isgeneric,
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -989,7 +989,6 @@ export
     whicht,
     whos,
     isinteractive,
-    disassemble,
     asm_llvm,
     asm_native,
     finfer,

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2102,7 +2102,7 @@ function replace_tupleref(e::ANY, tupname, vals, sv, i0)
     end
 end
 
-function finfer(f::Callable, types)
+function ast_typed(f::Callable, types)
     x = methods(f,types)[1]
     (tree, ty) = typeinf(x[3], x[1], x[2])
     if !isa(tree,Expr)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -72,7 +72,7 @@ isgeneric(f::ANY) = (isa(f,Function)||isa(f,DataType)) && isa(f.env,MethodTable)
 
 function_name(f::Function) = isgeneric(f) ? f.env.name : (:anonymous)
 
-ast_lowered(f::Function,t::Tuple) = methods(f,t)
+ast_lowered(f::Function,t::Tuple) = methods(f,t)[1]
 methods(f::ANY,t::ANY) = _methods(f,t,-1)::Array{Any,1}
 _methods(f::ANY,t::ANY,lim) = ccall(:jl_matching_methods, Any, (Any,Any,Int32), f, t, lim)
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -88,6 +88,8 @@ methods(t::DataType) = (_methods(t,Tuple,0);  # force constructor creation
 uncompressed_ast(l::LambdaStaticData) =
     isa(l.ast,Expr) ? l.ast : ccall(:jl_uncompress_ast, Any, (Any,Any), l, l.ast)
 
+asm_llvm(f::Function, types::Tuple) = disassemble(f,types,false)
+asm_native(f::Function,types::Tuple) = disassemble(f,types,true)
 disassemble(f::Function, types::Tuple, asm::Bool = false) =
     print(ccall(:jl_dump_function, Any, (Any,Any,Bool), f, types, asm)::ByteString)
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -88,10 +88,10 @@ methods(t::DataType) = (_methods(t,Tuple,0);  # force constructor creation
 uncompressed_ast(l::LambdaStaticData) =
     isa(l.ast,Expr) ? l.ast : ccall(:jl_uncompress_ast, Any, (Any,Any), l, l.ast)
 
-asm_llvm(f::Function, types::Tuple) = disassemble(f,types,false)
-asm_native(f::Function,types::Tuple) = disassemble(f,types,true)
-disassemble(f::Function, types::Tuple, asm::Bool = false) =
-    print(ccall(:jl_dump_function, Any, (Any,Any,Bool), f, types, asm)::ByteString)
+asm_llvm(f::Function, types::Tuple) = 
+    print(ccall(:jl_dump_function, Any, (Any,Any,Bool), f, types, false)::ByteString)
+asm_native(f::Function,types::Tuple) = 
+    print(ccall(:jl_dump_function, Any, (Any,Any,Bool), f, types, true)::ByteString)
 
 function functionlocs(f::Function, types=(Any...))
     locs = Any[]

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -72,6 +72,7 @@ isgeneric(f::ANY) = (isa(f,Function)||isa(f,DataType)) && isa(f.env,MethodTable)
 
 function_name(f::Function) = isgeneric(f) ? f.env.name : (:anonymous)
 
+ast_lowered(f::Function,t::Tuple) = methods(f,t)
 methods(f::ANY,t::ANY) = _methods(f,t,-1)::Array{Any,1}
 _methods(f::ANY,t::ANY,lim) = ccall(:jl_matching_methods, Any, (Any,Any,Int32), f, t, lim)
 


### PR DESCRIPTION
Redo of #3724 using @StefanKarpinski 's names.
- finfer -> ast_typed
- methods(function, types) -> ast_lowered
- disassemble(function, types, true) -> asm_native
- disassemble(function, types, false) -> asm_llvm

`ast_lowered` is just an alias; the other three remove the method they're renaming.
