### PR TITLE
more inlining

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2238,7 +2238,7 @@ function inline_worthy(body::Expr)
 #        shift!(body.args)
 #        return true
 #    end
-    if length(body.args) < 11 && occurs_more(body, e->true, 50) < 50
+    if length(body.args) < 4 && occurs_more(body, e->true, 50) < 50
         return true
     end
     return false

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2378,7 +2378,7 @@ function inlining_pass(e::Expr, sv, ast)
         end
 
         for ninline = 1:100
-            atypes = tuple(map(exprtype, e.args[2:])...)
+            atypes = tuple(map(exprtype, e.args[2:end])...)
             if length(atypes) > MAX_TUPLETYPE_LEN
                 atypes = limit_tuple_type(atypes)
             end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1842,7 +1842,28 @@ function without_linenums(a::Array{Any,1})
     l
 end
 
-_pure_builtins = {getfield, tuple, tupleref, tuplelen, fieldtype, apply_type}
+_pure_builtins = {getfield, tuple, tupleref, tuplelen, fieldtype, apply_type,
+                  Intrinsics.checked_usub,Intrinsics.cglobal,Intrinsics.checked_fptosi,
+                  Intrinsics.lefsi64,Intrinsics.checked_umul,Intrinsics.fpext,Intrinsics.sext_int,
+                  Intrinsics.ltuif64,Intrinsics.sub_float,Intrinsics.checked_ssub,Intrinsics.sub_int,
+                  Intrinsics.abs_float,Intrinsics.ctpop_int,Intrinsics.div_float,Intrinsics.nan_dom_err,
+                  Intrinsics.mul_int,Intrinsics.fptosi,Intrinsics.uitofp,Intrinsics.neg_float,
+                  Intrinsics.eq_float,Intrinsics.ult_int,Intrinsics.srem_int,
+                  Intrinsics.ltsif64,Intrinsics.eq_int,Intrinsics.leuif64,
+                  Intrinsics.copysign_float,Intrinsics.fpislt,Intrinsics.add_float,Intrinsics.ltfui64,
+                  Intrinsics.fpsiround,Intrinsics.checked_uadd,Intrinsics.add_int,Intrinsics.fptoui,
+                  Intrinsics.slt_int,Intrinsics.urem_int,Intrinsics.select_value,Intrinsics.lt_float,
+                  Intrinsics.box,Intrinsics.sdiv_int,Intrinsics.flipsign_int,Intrinsics.or_int,
+                  Intrinsics.unbox,Intrinsics.ctlz_int,Intrinsics.checked_fptoui,
+                  Intrinsics.and_int,Intrinsics.le_float,Intrinsics.sle_int,Intrinsics.checked_smul,
+                  Intrinsics.ltfsi64,Intrinsics.bswap_int,Intrinsics.cttz_int,Intrinsics.lefui64,
+                  Intrinsics.sitofp,Intrinsics.checked_sadd,Intrinsics.udiv_int,Intrinsics.lshr_int,
+                  Intrinsics.trunc_int,Intrinsics.eqfsi64,Intrinsics.mul_float,Intrinsics.shl_int,
+                  Intrinsics.neg_int,Intrinsics.zext_int,Intrinsics.ule_int,Intrinsics.smod_int,
+                  Intrinsics.lesif64,Intrinsics.eqfui64,Intrinsics.ashr_int,Intrinsics.xor_int,
+                  Intrinsics.ne_int,Intrinsics.fpuiround,Intrinsics.fptrunc,Intrinsics.ne_float,
+                  Intrinsics.fpiseq,Intrinsics.not_int,Intrinsics.rem_float
+              } #all Intrinsic functions except pointerref,pointerset,ccall,jl_alloca,pointertoref
 
 # detect some important side-effect-free calls
 function effect_free(e::ANY, sv, any_expr::Bool)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1845,19 +1845,20 @@ end
 _pure_builtins = {getfield, tuple, tupleref, tuplelen, fieldtype, apply_type}
 
 # detect some important side-effect-free calls
-function effect_free(e::ANY, sv)
+function effect_free(e::ANY, sv, any_expr::Bool)
     if isa(e,Symbol) || isa(e,SymbolNode) || isa(e,Number) || isa(e,String) ||
         isa(e,TopNode) || isa(e,QuoteNode) || isa(e,Type)
         return true
     end
-    if isa(e,Expr)
+    if any_expr && isa(e,Expr)
+        e = e::Expr
         if e.head === :static_typeof
             return true
         end
         ea = e.args
         if e.head === :call || e.head === :call1
             for a in ea
-                if !effect_free(a,sv)
+                if !effect_free(a,sv,true)
                     return false
                 end
             end
@@ -1866,7 +1867,7 @@ function effect_free(e::ANY, sv)
             end
         elseif e.head === :new
             for a in ea
-                if !effect_free(a,sv)
+                if !effect_free(a,sv,true)
                     return false
                 end
             end
@@ -1900,7 +1901,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
         return (e.args[3],())
     end
     if isdefined(Main.Base,:isbits) && is(f,Main.Base.isbits) &&
-        length(atypes)==1 && isType(atypes[1]) && effect_free(argexprs[1],sv) &&
+        length(atypes)==1 && isType(atypes[1]) && effect_free(argexprs[1],sv,true) &&
         isleaftype(atypes[1].parameters[1])
         return (isbits(atypes[1].parameters[1]),())
     end
@@ -1919,7 +1920,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             end
         end
     end
-    if is(f,tuple) && isa(e.typ,Tuple) && all(isType,e.typ) && isleaftype(e.typ) && effect_free(e,sv)
+    if is(f,tuple) && isa(e.typ,Tuple) && all(isType,e.typ) && isleaftype(e.typ) && effect_free(e,sv,true)
         return (map(t->t.parameters[1], e.typ), ())
     end
     if isa(f,IntrinsicFunction)
@@ -2090,20 +2091,18 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             end
         end
 
+        # ok for argument to occur more than once if the actual argument
+        # is a symbol or constant
         occ = occurs_more(body, x->is(x,a), 1)
-        if occ != 1 || islocal
-            # ok for argument to occur more than once if the actual argument
-            # is a symbol or constant
-            if islocal || !effect_free(aei,sv) || (occ==0 && is(aeitype,None))
+        if islocal || !effect_free(aei,sv,false) || (occ==0 && is(aeitype,None))
+            if occ != 0
                 # introduce variable for this argument
-                if occ != 0
-                    vnew = unique_name(enclosing_ast, ast)
-                    add_variable(enclosing_ast, vnew, aeitype, !islocal)
-                    push!(stmts, Expr(:(=), vnew, aei))
-                    argexprs[i] = aeitype===Any ? vnew : SymbolNode(vnew,aeitype)
-                elseif !isType(aeitype) && !effect_free(aei,sv)
-                    push!(stmts, aei)
-                end
+                vnew = unique_name(enclosing_ast, ast)
+                add_variable(enclosing_ast, vnew, aeitype, !islocal)
+                push!(stmts, Expr(:(=), vnew, aei))
+                argexprs[i] = aeitype===Any ? vnew : SymbolNode(vnew,aeitype)
+            elseif !(isType(aeitype) || effect_free(aei,sv,true))
+                push!(stmts, aei)
             end
         end
     end
@@ -2345,7 +2344,7 @@ function inlining_pass(e::Expr, sv, ast)
                         newargs[i-2] = aarg.args[2:end]
                     elseif isa(aarg, Tuple)
                         newargs[i-2] = { QuoteNode(x) for x in aarg }
-                    elseif isa(t,Tuple) && !isvatuple(t) && effect_free(aarg,sv)
+                    elseif isa(t,Tuple) && !isvatuple(t) && effect_free(aarg,sv,true)
                         # apply(f,t::(x,y)) => f(t[1],t[2])
                         newargs[i-2] = { mk_tupleref(aarg,j) for j=1:length(t) }
                     else

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1842,28 +1842,23 @@ function without_linenums(a::Array{Any,1})
     l
 end
 
-_pure_builtins = {getfield, tuple, tupleref, tuplelen, fieldtype, apply_type,
-                  Intrinsics.checked_usub,Intrinsics.cglobal,Intrinsics.checked_fptosi,
-                  Intrinsics.lefsi64,Intrinsics.checked_umul,Intrinsics.fpext,Intrinsics.sext_int,
-                  Intrinsics.ltuif64,Intrinsics.sub_float,Intrinsics.checked_ssub,Intrinsics.sub_int,
-                  Intrinsics.abs_float,Intrinsics.ctpop_int,Intrinsics.div_float,Intrinsics.nan_dom_err,
-                  Intrinsics.mul_int,Intrinsics.fptosi,Intrinsics.uitofp,Intrinsics.neg_float,
-                  Intrinsics.eq_float,Intrinsics.ult_int,Intrinsics.srem_int,
-                  Intrinsics.ltsif64,Intrinsics.eq_int,Intrinsics.leuif64,
-                  Intrinsics.copysign_float,Intrinsics.fpislt,Intrinsics.add_float,Intrinsics.ltfui64,
-                  Intrinsics.fpsiround,Intrinsics.checked_uadd,Intrinsics.add_int,Intrinsics.fptoui,
-                  Intrinsics.slt_int,Intrinsics.urem_int,Intrinsics.select_value,Intrinsics.lt_float,
-                  Intrinsics.box,Intrinsics.sdiv_int,Intrinsics.flipsign_int,Intrinsics.or_int,
-                  Intrinsics.unbox,Intrinsics.ctlz_int,Intrinsics.checked_fptoui,
-                  Intrinsics.and_int,Intrinsics.le_float,Intrinsics.sle_int,Intrinsics.checked_smul,
-                  Intrinsics.ltfsi64,Intrinsics.bswap_int,Intrinsics.cttz_int,Intrinsics.lefui64,
-                  Intrinsics.sitofp,Intrinsics.checked_sadd,Intrinsics.udiv_int,Intrinsics.lshr_int,
-                  Intrinsics.trunc_int,Intrinsics.eqfsi64,Intrinsics.mul_float,Intrinsics.shl_int,
-                  Intrinsics.neg_int,Intrinsics.zext_int,Intrinsics.ule_int,Intrinsics.smod_int,
-                  Intrinsics.lesif64,Intrinsics.eqfui64,Intrinsics.ashr_int,Intrinsics.xor_int,
-                  Intrinsics.ne_int,Intrinsics.fpuiround,Intrinsics.fptrunc,Intrinsics.ne_float,
-                  Intrinsics.fpiseq,Intrinsics.not_int,Intrinsics.rem_float
-              } #all Intrinsic functions except pointerref,pointerset,ccall,jl_alloca,pointertoref
+const _pure_builtins = {getfield, tuple, tupleref, tuplelen, fieldtype, apply_type}
+
+function is_pure_builtin(f)
+    if contains_is(_pure_builtins, f)
+        return true
+    end
+    if isa(f,IntrinsicFunction)
+        if !(f === Intrinsics.pointerref ||
+             f === Intrinsics.pointerset ||
+             f === Intrinsics.ccall ||
+             f === Intrinsics.jl_alloca ||
+             f === Intrinsics.pointertoref)
+            return true
+        end
+    end
+    return false
+end
 
 # detect some important side-effect-free calls
 function effect_free(e::ANY, sv, any_expr::Bool)
@@ -1878,7 +1873,7 @@ function effect_free(e::ANY, sv, any_expr::Bool)
         end
         ea = e.args
         if e.head === :call || e.head === :call1
-            if is_known_call(e, _pure_builtins, sv)
+            if is_known_call_p(e, is_pure_builtin, sv)
                 if !any_expr && is_known_call(e, getfield, sv)
                     for a in ea
                         if isa(a,Symbol)
@@ -2509,12 +2504,12 @@ function is_known_call(e::Expr, func, sv)
     return !is(f,false) && is(_ieval(f), func)
 end
 
-function is_known_call(e::Expr, fs::Array, sv)
+function is_known_call_p(e::Expr, pred::Function, sv)
     if !(is(e.head,:call) || is(e.head,:call1))
         return false
     end
     f = isconstantfunc(e.args[1], sv)
-    return !is(f,false) && contains_is(fs, _ieval(f))
+    return !is(f,false) && pred(_ieval(f))
 end
 
 function is_var_assigned(ast, v)

--- a/base/poll.jl
+++ b/base/poll.jl
@@ -171,7 +171,7 @@ end
 # on unix
 
 let
-    global fdwatcher_init
+    global fdwatcher_reinit, wait
     @unix_only begin
         local fdwatcher_array
         function fdwatcher_init()

--- a/base/poll.jl
+++ b/base/poll.jl
@@ -171,7 +171,7 @@ end
 # on unix
 
 let
-    global fdwatcher_reinit, wait
+    global fdwatcher_init, wait
     @unix_only begin
         local fdwatcher_array
         function fdwatcher_init()


### PR DESCRIPTION
This pull requests adds inlining and improved call site type specialization. It separates function calls of type unions and provides support for multi-line inlining. (It also attempts to inline Union, but that part is causing the tests to fail)

While the standard inlining heuristic has not been updated, you can test the multiline inlining by forcing a function to be inlined by adding an `:inline` keyword:

``` julia
function abs(x) :inline
    if x > 0
        x
    else
        -x
    end
end
```
