### PR TITLE
RFC: A faster string search algorithm, and an "index" function.

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -847,6 +847,23 @@ Strings
 
 .. function:: search(string, chars, [start])
 
+   Search for the first occurance of the given characters within the given string. The second argument may be a single character, a vector or a set of characters, a string, or a regular expression (though regular expressions are only allowed on contiguous strings, such as ASCII or UTF-8 strings). The third argument optionally specifies a starting index. The return value is a range of indexes where the matching sequence is found, such that ``s[search(s,x)] == x``. The return value is ``0:-1`` if there is no match.
+
+.. function:: rsearch(string, chars, [start])
+
+   Similar to ``search``, but returning the last occurance of the given characters within the given string, searching in reverse from ``start.''.
+
+.. function:: index(string, chars, [start])
+
+    Similar to ``search``, but return only the start index at which the characters were found, or 0 if they were not.
+
+.. function:: rindex(string, chars, [start])
+
+    Similar to ``rsearch``, but return only the start index at which the characters were found, or 0 if they were not.
+
+    Similar to ``search``, but return only the start index at which the
+    characters were found, or 0 if they were not.
+
    Search for the given characters within the given string. The second argument may be a single character, a vector or a set of characters, a string, or a regular expression (though regular expressions are only allowed on contiguous strings, such as ASCII or UTF-8 strings). The third argument optionally specifies a starting index. The return value is a range of indexes where the matching sequence is found, such that ``s[search(s,x)] == x``. The return value is ``0:-1`` if there is no match.
 
 .. function:: rsearch(string, chars, [start])

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -398,6 +398,7 @@ end
 for i = 1:endof(u8str)
     @test search(u8str, "", i) == i:i-1
 end
+@test search("", "") == 1:0
 
 # string rsearch with a zero-char string
 for i = 1:endof(astr)
@@ -406,6 +407,7 @@ end
 for i = 1:endof(u8str)
     @test rsearch(u8str, "", i) == i:i-1
 end
+@test rsearch("", "") == 1:0
 
 # string search with a zero-char regex
 for i = 1:endof(astr)


### PR DESCRIPTION
This is a faster string search function to address #3733. It should put julia on par with python, which is quite fast at this particular benchmark.

These versions do a byte-for-byte search, so I've left the original search functions in a as a more general-purpose fallback

I've also added a `index` function which works just like `search`, but returns just a start index rather than a Range object to avoid the overhead (it was about 30% slower otherwise).
