### PR TITLE
pmap modified to work with any iterable

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -112,14 +112,21 @@ function map(f::Union(Function,DataType), iters...)
     result = {}
     len = length(iters)
     states = [start(iters[idx]) for idx in 1:len]
-
-    while all([!done(iters[idx],states[idx]) for idx in 1:len])
-        nxts = [next(iters[idx],states[idx]) for idx in 1:len]
-        map(idx->states[idx]=nxts[idx][2], 1:len)
-        nxtvals = [x[1] for x in nxts]
-        push!(result, f(nxtvals...))
+    nxtvals = cell(len)
+    cont = true
+    for idx in 1:len
+        done(iters[idx], states[idx]) && (cont = false; break)
     end
-    [result...]
+    while cont
+        for idx in 1:len
+            nxtvals[idx],states[idx] = next(iters[idx], states[idx])
+        end
+        push!(result, f(nxtvals...))
+        for idx in 1:len
+            done(iters[idx], states[idx]) && (cont = false; break)
+        end
+    end
+    result
 end
 
 function mapreduce(f::Callable, op::Function, itr)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -106,6 +106,22 @@ function reduce(op::Function, v0, itr)
     return v
 end
 
+##
+# generic map on any iterator
+function map(f::Union(Function,DataType), iters...)
+    result = {}
+    len = length(iters)
+    states = [start(iters[idx]) for idx in 1:len]
+
+    while all([!done(iters[idx],states[idx]) for idx in 1:len])
+        nxts = [next(iters[idx],states[idx]) for idx in 1:len]
+        map(idx->states[idx]=nxts[idx][2], 1:len)
+        nxtvals = [x[1] for x in nxts]
+        push!(result, f(nxtvals...))
+    end
+    [result...]
+end
+
 function mapreduce(f::Callable, op::Function, itr)
     s = start(itr)
     if done(itr, s)

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -743,7 +743,7 @@
 
 ("Iterable Collections","Base","map","map(f, c) -> collection
 
-   Transform collection \"c\" by applying \"f\" to each element.
+   Transform collection or iterator \"c\" by applying \"f\" to each element.
 
    **Example**: \"map((x) -> x * 2, [1, 2, 3]) = [2, 4, 6]\"
 
@@ -4948,10 +4948,10 @@
 
 ("Parallel Computing","Base","pmap","pmap(f, c)
 
-   Transform collection \"c\" by applying \"f\" to each element in
-   parallel. If \"nprocs() > 1\", the calling process will be
-   dedicated to assigning tasks. All other available processes will be
-   used as parallel workers.
+   Transform collection or iterator \"c\" by applying \"f\" to each 
+   element in parallel. If \"nprocs() > 1\", the calling process 
+   will be dedicated to assigning tasks. All other available 
+   processes will be used as parallel workers.
 
 "),
 

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -50,3 +50,32 @@ et=toq()
 @test (et >= 1.0) && (et <= 1.5)
 @test isready(rr1)
 @test !isready(rr3)
+
+
+# pmap tests
+# needs at least 4 processors (which are being created above for the @parallel tests)
+s = "a"*"bcdefghijklmnopqrstuvwxyz"^100;
+ups = "A"*"BCDEFGHIJKLMNOPQRSTUVWXYZ"^100;
+@test ups == bytestring(Uint8[uint8(c) for c in pmap(x->uppercase(x), s)])
+@test ups == bytestring(Uint8[uint8(c) for c in pmap(x->uppercase(char(x)), s.data)])
+
+# retry, on error exit
+res = pmap(x->(x=='a') ? error("test error. don't panic.") : uppercase(x), s; err_retry=true, err_stop=true);
+@test length(res) < length(ups)
+@test isa(res[1], Exception)
+
+# no retry, on error exit
+res = pmap(x->(x=='a') ? error("test error. don't panic.") : uppercase(x), s; err_retry=false, err_stop=true);
+@test length(res) < length(ups)
+@test isa(res[1], Exception)
+
+# retry, on error continue
+res = pmap(x->iseven(myid()) ? error("test error. don't panic.") : uppercase(x), s; err_retry=true, err_stop=false);
+@test length(res) == length(ups)
+@test ups == bytestring(Uint8[uint8(c) for c in res])
+
+# no retry, on error continue
+res = pmap(x->(x=='a') ? error("test error. don't panic.") : uppercase(x), s; err_retry=false, err_stop=false);
+@test length(res) == length(ups)
+@test isa(res[1], Exception)
+


### PR DESCRIPTION
The modified `pmap` can work with any iterable objects that do not have a known `length` (e.g. data getting read from streams).

Behaves slightly differently though when all elements in the source could not be tried because of any error. The current `pmap` returns a result array of size same as source. This new `pmap` would return a shorter result array of only valid results.

Also addresses a condition where `pmap` may not retry the last entry in the source fails.
