### PR TITLE
Necessary patches to get ATLAS building on OSX.

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -774,6 +774,11 @@ endif
 
 atlas/configure:
 	git clone git://github.com/vtjnash/atlas-3.10.0.git atlas
+	patch atlas/bin/atlas_install.c < atlas_install.c.patch
+	chmod +x atlas/configure
+	chmod +x atlas/CONFIG/src/ATLrun.sh
+	cp -f atlas_types.h atlas/include/
+
 ifeq "$(MAKECMDGOALS)" "compile-atlas"
 # only allow building atlas as the sole target (without -jN)
 # since it internally handles parallelism, for tuning timing accuracy

--- a/deps/atlas_install.c.patch
+++ b/deps/atlas_install.c.patch
@@ -1,0 +1,15 @@
+--- atlas_install.c	2013-07-22 22:34:11.000000000 -0700
++++ atlas_install.c.new	2013-07-22 22:34:02.000000000 -0700
+@@ -1144,10 +1144,12 @@
+    PrintStartStop(stdout, fpsum, 3, 1, 5, 1, 0, "FINAL STATIC LIBRARY UPDATE");
+    sprintf(ln2, "INSTALL_LOG/LIBUPDATE.LOG");
+    PrintBanner(ln2, 1, 5, 1, 1);
++#ifdef ATL_NCPU
+    sprintf(ln, "%s IBuildLibs IBuildPtlibs0 %s %s\n", fmake, redir, ln2);
+    fprintf(stdout, ln);
+    ATL_Cassert(system(ln)==0, "STATIC LIBRARY UPDATE", ln2);
+    PrintBanner(ln2, 0, 5, 1, 1);
++#endif
+    PrintStartStop(stdout, fpsum, 3, 0, 5, 1, 0, "FINAL STATIC LIBRARY UPDATE");
+ #ifdef ATL_DYLIBS
+    PrintStartStop(stdout, fpsum, 3, 1, 5, 2, 0,

--- a/deps/atlas_types.h
+++ b/deps/atlas_types.h
@@ -1,0 +1,20 @@
+// This file missing from <ATLAS_DIR>/include/
+
+#ifndef ATLAS_TYPE_H
+#define ATLAS_TYPE_H
+#define ATL_isize 4
+#define ATL_ssize 4
+#define ATL_dsize 8
+#define ATL_csize 8
+#define ATL_zsize 16
+#define ATL_iMulBySize(N_) ((((N_)) << 2))
+#define ATL_sMulBySize(N_) ((((N_)) << 2))
+#define ATL_dMulBySize(N_) ((((N_)) << 3))
+#define ATL_cMulBySize(N_) ((((N_)) << 3))
+#define ATL_zMulBySize(N_) ((((N_)) << 4))
+#define ATL_iDivBySize(N_) ((N_) >> 2)
+#define ATL_sDivBySize(N_) ((N_) >> 2)
+#define ATL_cDivBySize(N_) ((N_) >> 3)
+#define ATL_dDivBySize(N_) ((N_) >> 3)
+#define ATL_zDivBySize(N_) ((N_) >> 4)
+#endif


### PR DESCRIPTION
Compilation tested on OSX and Linux. Note that you need to `make -C deps compile-atlas` and also `make -C deps install-atlas`.

I pass all tests on OSX, but linux is throwing intermittent errors.  I have been testing with `USE_BLAS_64=0`, is that correct for ATLAS?  I can't seem to find much documentation about using ATLAS with Julia.
