### PR TITLE
First draft of codespeedization of test/perf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ notifications:
         on_failure: always
     webhooks:
         urls:
-          - http://128.52.160.154/travis-hook
+          - http://julia.mit.edu:8000/travis-hook
           - http://criid.ee.washington.edu:8000/travis-hook
         on_failure: never
 before_install:

--- a/test/perf/Makefile
+++ b/test/perf/Makefile
@@ -1,18 +1,25 @@
 JULIAHOME = $(abspath ../..)
 include ../../Make.inc
 
-all: micro kernel cat shootout sort
+all: micro kernel cat shootout blas sort
 
-micro kernel cat sort:
+micro kernel cat shootout blas sort:
+	@$(MAKE) $(QUIET_MAKE) -C shootout
 	@$(call spawn,$(JULIA_EXECUTABLE)) $@/perf.jl | perl -nle '@_=split/,/; printf "%-18s %8.3f %8.3f %8.3f %8.3f\n", $$_[1], $$_[2], $$_[3], $$_[4], $$_[5]'
 
-shootout:
-	@$(MAKE) $(QUIET_MAKE) -C $@
-	@$(call spawn,$(JULIA_EXECUTABLE)) $@/perf.jl | perl -nle '@_=split/,/; printf "%-18s %8.3f %8.3f %8.3f %8.3f\n", $$_[1], $$_[2], $$_[3], $$_[4], $$_[5]'
+codespeed:
+	@$(MAKE) $(QUIET_MAKE) -C shootout
+	@$(call spawn,$(JULIA_EXECUTABLE)) micro/perf.jl codespeed
+	@$(call spawn,$(JULIA_EXECUTABLE)) kernel/perf.jl codespeed
+	@$(call spawn,$(JULIA_EXECUTABLE)) cat/perf.jl codespeed
+	@$(call spawn,$(JULIA_EXECUTABLE)) shootout/perf.jl codespeed
+	@$(call spawn,$(JULIA_EXECUTABLE)) blas/perf.jl codespeed
+	@$(call spawn,$(JULIA_EXECUTABLE)) sort/perf.jl codespeed
+
 
 clean:
 	rm -f *~
 	$(MAKE) -C micro $@
 	$(MAKE) -C shootout $@
 
-.PHONY: micro kernel cat shootout clean sort
+.PHONY: micro kernel cat shootout blas sort clean

--- a/test/perf/blas/level1.jl
+++ b/test/perf/blas/level1.jl
@@ -18,14 +18,14 @@ function axpytest(n, repeat)
 	y
 end
 
-@timeit dottest(2, 1_000_000) "dot_tiny"
-@timeit dottest(16, 1_000_000) "dot_small"
-@timeit dottest(64, 1_000_000) "dot_medium"
-@timeit dottest(256, 100_000) "dot_large"
-@timeit dottest(1024, 100_000) "dot_huge"
+@timeit dottest(2, 1_000_000) "dot_tiny" "Tiny dotproduct test"
+@timeit dottest(16, 1_000_000) "dot_small" "Small dotproduct test"
+@timeit dottest(64, 1_000_000) "dot_medium" "Medium dotproduct test"
+@timeit dottest(256, 100_000) "dot_large" "Large dotproduct test"
+@timeit dottest(1024, 100_000) "dot_huge" "Huge dotproduct test"
 
-@timeit axpytest(2, 1_000_000) "axpy_tiny"
-@timeit axpytest(16, 1_000_000) "axpy_small"
-@timeit axpytest(64, 1_000_000) "axpy_medium"
-@timeit axpytest(256, 100_000) "axpy_large"
-@timeit axpytest(1024, 100_000) "axpy_huge"
+@timeit axpytest(2, 1_000_000) "axpy_tiny" "Tiny BLAS axpy test"
+@timeit axpytest(16, 1_000_000) "axpy_small" "Small BLAS axpy test"
+@timeit axpytest(64, 1_000_000) "axpy_medium" "Medium BLAS axpy test"
+@timeit axpytest(256, 100_000) "axpy_large" "Large BLAS axpy test"
+@timeit axpytest(1024, 100_000) "axpy_huge" "Huge BLAS axpy test"

--- a/test/perf/blas/level2.jl
+++ b/test/perf/blas/level2.jl
@@ -10,8 +10,8 @@ function gemvtest(n, repeat)
 end
 
 
-@timeit gemvtest(2, 100_000) "gemv_tiny"
-@timeit gemvtest(16, 100_000) "gemv_small"
-@timeit gemvtest(64, 10_000) "gemv_medium"
-@timeit gemvtest(256, 1000) "gemv_large"
-@timeit gemvtest(1024, 100) "gemv_huge"
+@timeit gemvtest(2, 100_000) "gemv_tiny" "Tiny matrix-vector multiplication test"
+@timeit gemvtest(16, 100_000) "gemv_small" "Small matrix-vector multiplication test"
+@timeit gemvtest(64, 10_000) "gemv_medium" "Medium matrix-vector multiplication test"
+@timeit gemvtest(256, 1000) "gemv_large" "Large matrix-vector multiplication test"
+@timeit gemvtest(1024, 100) "gemv_huge" "Huge matrix-vector multiplication test"

--- a/test/perf/blas/level3.jl
+++ b/test/perf/blas/level3.jl
@@ -9,7 +9,7 @@ function matmultest(n, repeat)
 	b
 end
 
-@timeit matmultest(2, 1_000_000) "matmul_tiny"
-@timeit matmultest(16, 100_000) "matmul_small"
-@timeit matmultest(64, 10_000) "matmul_medium"
-@timeit matmultest(256, 100) "matmul_large"
+@timeit matmultest(2, 1_000_000) "matmul_tiny" "Tiny matrix-matrix multiplication test"
+@timeit matmultest(16, 100_000) "matmul_small" "Small matrix-matrix multiplication test"
+@timeit matmultest(64, 10_000) "matmul_medium" "Medium matrix-matrix multiplication test"
+@timeit matmultest(256, 100) "matmul_large" "Large matrix-matrix multiplication test"

--- a/test/perf/cat/perf.jl
+++ b/test/perf/cat/perf.jl
@@ -20,11 +20,11 @@ function cat2d_perf2(n, iter)
     end
 end
 
-@timeit cat2d_perf(5,20000) "small_hvcat"
-@timeit cat2d_perf2(5,20000) "small_hvcat_setind"
+@timeit cat2d_perf(5,20000) "small_hvcat" "Small horizontal/vertical matrix concatenaion"
+@timeit cat2d_perf2(5,20000) "small_hvcat_setind" "Small horizontal/vertical matrix concatenation using setindex"
 
-@timeit cat2d_perf(500,2) "large_hvcat"
-@timeit cat2d_perf2(500,2) "large_hvcat_setind"
+@timeit cat2d_perf(500,2) "large_hvcat" "Large horizontal/vertical matrix concatenation"
+@timeit cat2d_perf2(500,2) "large_hvcat_setind" "Large horizontal/vertical matrix concatenation using setindex"
 
 function hcat_perf(n, iter)
     a = rand(n,n)
@@ -46,11 +46,11 @@ function hcat_perf2(n, iter)
     end
 end
 
-@timeit hcat_perf(5,20000) "small_hcat"
-@timeit hcat_perf2(5,20000) "small_hcat_setind"
+@timeit hcat_perf(5,20000) "small_hcat" "Small horizontal matrix concatenation"
+@timeit hcat_perf2(5,20000) "small_hcat_setind" "Small horizontal matrix concatenation using setindex"
 
-@timeit hcat_perf(500,2) "large_hcat"
-@timeit hcat_perf2(500,2) "large_hcat_setind"
+@timeit hcat_perf(500,2) "large_hcat" "Large horizontal matrix concatenation"
+@timeit hcat_perf2(500,2) "large_hcat_setind" "Large horizontal matrix concatenation using setindex"
 
 function vcat_perf(n, iter)
     a = rand(n,n)
@@ -72,11 +72,11 @@ function vcat_perf2(n, iter)
     end
 end
 
-@timeit vcat_perf(5,20000) "small_vcat"
-@timeit vcat_perf2(5,20000) "small_vcat_setind"
+@timeit vcat_perf(5,20000) "small_vcat" "Small vertical matrix concatenaion"
+@timeit vcat_perf2(5,20000) "small_vcat_setind" "Small vertical matrix concatenation using setindex"
 
-@timeit vcat_perf(500,2) "large_vcat"
-@timeit vcat_perf2(500,2) "large_vcat_setind"
+@timeit vcat_perf(500,2) "large_vcat" "Large vertical matrix concatenaion"
+@timeit vcat_perf2(500,2) "large_vcat_setind" "Large vertical matrix concatenation using setindex"
 
 function catnd_perf(n, iter)
     a = rand(1,n,n,1)
@@ -98,8 +98,8 @@ function catnd_perf2(n, iter)
     end
 end
 
-@timeit catnd_perf(5,20000) "small_catnd"
-@timeit catnd_perf2(5,20000) "small_catnd_setind"
+@timeit catnd_perf(5,20000) "small_catnd" "Small N-dimensional matrix concatenation"
+@timeit catnd_perf2(5,20000) "small_catnd_setind" "Small N-dimensional matrix concatenation using setindex"
 
-@timeit catnd_perf(500,2) "large_catnd"
-@timeit catnd_perf2(500,2) "large_catnd_setind"
+@timeit catnd_perf(500,2) "large_catnd" "Large N-dimensional matrix concatenation"
+@timeit catnd_perf2(500,2) "large_catnd_setind" "Large N-dimensional matrix concatenation using setindex"

--- a/test/perf/kernel/perf.jl
+++ b/test/perf/kernel/perf.jl
@@ -10,58 +10,58 @@ function listn1n2(n1::Int,n2::Int)
     l1
 end
 
-@timeit listn1n2(1,10^6) "cons"
+@timeit listn1n2(1,10^6) "cons" "List concatenation"
 gc()
 
 # issue #1211
 include("ziggurat.jl")
 a = Array(Float64, 1000000)
-@timeit randn_zig!(a) "randn_zig"
+@timeit randn_zig!(a) "randn_zig" "Ziggurat gaussian number generator"
 
 # issue #950
 include("gk.jl")
-@timeit gk(350,[0.1]) "gk"
+@timeit gk(350,[0.1]) "gk" "Grigoriadis Khachiyan matrix games"
 
 # issue #942
 s = sparse(ones(280,280));
-@timeit s*s "sparsemul"
+@timeit s*s "sparsemul" "Sparse matrix multiplication"
 
 # issue #939
 y = [500000:-1:1];
-@timeit sortperm(y) "sortperm"
+@timeit sortperm(y) "sortperm" "Sorting of a worst-case vector"
 
 # issue #938
 x = 1:600000;
-@timeit sparse(x,x,x) "sparserang"
+@timeit sparse(x,x,x) "sparserange" "Construction of a sparse array from ranges"
 
 # issue #445
 include("stockcorr.jl")
-@timeit stockcorr() "stockcorr"
+@timeit stockcorr() "stockcorr" "Correlation analysis of random matrices"
 
 include("bench_eu.jl")
-@timeit bench_eu_vec(10000) "bench_eu_vec"
-@timeit bench_eu_devec(10000) "bench_eu_devec"
+@timeit bench_eu_vec(10000) "bench_eu_vec" "Vectorized Monte Carlo financial simulation"
+@timeit bench_eu_devec(10000) "bench_eu_devec" "Devectorized Monte Carlo financial simulation"
 
 # issue #1163
 include("actor_centrality.jl")
-@timeit1 actor_centrality() "actorgraph"
+@timeit1 actor_centrality() "actorgraph" "Centrality of actors in IMDB database"
 
 # issue #1168
 include("laplace.jl")
-@timeit1 laplace_vec() "laplace_vec"
-@timeit laplace_devec() "laplace_devec"
+@timeit1 laplace_vec() "laplace_vec" "Vectorized Laplacian"
+@timeit laplace_devec() "laplace_devec" "Devectorized Laplacian"
 
 # issue #1169
 include("go_benchmark.jl")
-@timeit1 benchmark(10) "go_benchmark"
+@timeit1 benchmark(10) "go_benchmark" "Simulation of random games of Go"
 
 # issue #3142
 include("simplex.jl")
-@timeit doTwoPassRatioTest() "simplex"
+@timeit doTwoPassRatioTest() "simplex" "Dual simplex algorithm for Linear Programming"
 
 # issue #3811
 include("raytracer.jl")
-@timeit Raytracer(5, 256, 4) "raytracer"
+@timeit Raytracer(5, 256, 4) "raytracer" "raytracer"
 
 function cmp_with_func(x::Vector, f::Function)
     count::Int = 0
@@ -74,7 +74,7 @@ function cmp_with_func(x::Vector, f::Function)
 end
 
 x = randn(200_000)
-@timeit (for n in 1:10; count = cmp_with_func(x, isless) end) "funarg"
+@timeit (for n in 1:10; count = cmp_with_func(x, isless) end) "funarg" "Function argument benchmark"
 
 
 function arith_vectorized(b,c,d)
@@ -86,7 +86,7 @@ b = randn(len)
 c = randn(len)
 d = randn(len)
 
-@timeit (for n in 1:10; a = arith_vectorized(b,c,d); end) "vectorize"
+@timeit (for n in 1:10; a = arith_vectorized(b,c,d); end) "vectorize" "Vectorized arithmetic"
 
 open("random.csv","w") do io
     writecsv(io, rand(100000,4))
@@ -99,7 +99,7 @@ function parsecsv()
     end
 end
 
-@timeit parsecsv() "splitline"
+@timeit parsecsv() "splitline" "CSV parsing"
 
 rm("random.csv")
 
@@ -194,4 +194,4 @@ _json_data = "{\"web-app\": {
     \"taglib-uri\": \"cofax.tld\",
     \"taglib-location\": \"/WEB-INF/tlds/cofax.tld\"}}}"
 
-@timeit (for n in 1:10; a = parse_json(_json_data); end) "json      "
+@timeit (for n in 1:10; a = parse_json(_json_data); end) "json" "JSON parsing"

--- a/test/perf/micro/perf.jl
+++ b/test/perf/micro/perf.jl
@@ -7,7 +7,7 @@ include("../perfutil.jl")
 fib(n) = n < 2 ? n : fib(n-1) + fib(n-2)
 
 @test fib(20) == 6765
-@timeit fib(20) "fib"
+@timeit fib(20) "fib" "Recursive fibonacci"
 
 ## parse integer ##
 
@@ -22,18 +22,18 @@ function parseintperf(t)
     return n
 end
 
-@timeit parseintperf(1000) "parse_int"
+@timeit parseintperf(1000) "parse_int" "Integer parsing"
 
 ## array constructors ##
 
 @test all(ones(200,200) .== 1)
-# @timeit ones(200,200) "ones"
+# @timeit ones(200,200) "ones" "description"
 
 ## matmul and transpose ##
 
 A = ones(200,200)
 @test all(A*A' .== 200)
-# @timeit A*A' "AtA"
+# @timeit A*A' "AtA" "description"
 
 ## mandelbrot set: complex arithmetic and comprehensions ##
 
@@ -51,7 +51,7 @@ end
 
 mandelperf() = [ mandel(complex(r,i)) for i=-1.:.1:1., r=-2.0:.1:0.5 ]
 @test sum(mandelperf()) == 14791
-@timeit mandelperf() "mandel"
+@timeit mandelperf() "mandel" "Calculation of mandelbrot set"
 
 ## numeric vector sort ##
 
@@ -77,7 +77,7 @@ function sortperf(n)
     qsort!(rand(n), 1, n)
 end
 @test issorted(sortperf(5000))
-@timeit sortperf(5000) "quicksort"
+@timeit sortperf(5000) "quicksort" "Sorting of random numbers using quicksort"
 
 ## slow pi series ##
 
@@ -93,7 +93,7 @@ function pisum()
 end
 
 @test abs(pisum()-1.644834071848065) < 1e-12
-@timeit pisum() "pi_sum"
+@timeit pisum() "pi_sum" "Summation of a power series"
 
 ## slow pi series, vectorized ##
 
@@ -130,11 +130,11 @@ end
 
 (s1, s2) = randmatstat(1000)
 @test 0.5 < s1 < 1.0 && 0.5 < s2 < 1.0
-@timeit randmatstat(1000) "rand_mat_stat"
+@timeit randmatstat(1000) "rand_mat_stat" "Statistics on a random matrix"
 
 ## largish random number gen & matmul ##
 
-@timeit rand(1000,1000)*rand(1000,1000) "rand_mat_mul"
+@timeit rand(1000,1000)*rand(1000,1000) "rand_mat_mul" "Multiplication of random matrices"
 
 ## printfd ##
 
@@ -148,5 +148,5 @@ end
     end
 
     printfd(1)
-    @timeit printfd(100000) "printfd"
+    @timeit printfd(100000) "printfd" "Printing to a file descriptor"
 end

--- a/test/perf/perfutil.jl
+++ b/test/perf/perfutil.jl
@@ -1,7 +1,81 @@
 const ntrials = 5
 print_output = isempty(ARGS)
+codespeed = length(ARGS) > 0 && ARGS[1] == "codespeed"
 
-macro timeit(ex,name)
+if codespeed
+    try
+        Pkg.init()
+        Pkg.add("JSON")
+        Pkg.add("Curl")
+    end
+    usingmodule("JSON")
+    usingmodule("Curl")
+
+    # Ensure that we've got the environment variables we want:
+    if !haskey(ENV, "JULIA_FLAVOR")
+        error( "You must provide the JULIA_FLAVOR environment variable identifying this julia build!" )
+    end
+
+    if !haskey(ENV, "JULIA_BRANCH")
+        error( "You must provide the JULIA_BRANCH environment variable identifying the branch this julia build grows on!" )
+    end
+
+    if !haskey(ENV, "JULIA_COMMIT_DATE")
+        error( "You must provide the JULIA_COMMIT_DATE environment variable in the form YYYY-MM-DD HH:MM:SS[TZ]" )
+    end
+
+    # Setup codespeed data dict for submissions to codespeed's JSON endpoint.  These parameters
+    # are constant across all benchmarks, so we'll just let them sit here for now
+    csdata = Dict()
+    #csdata["commitid"] = Base.BUILD_INFO.commit
+    csdata["commitid"] = Base.VERSION_COMMIT
+    csdata["project"] = "Julia"
+    #csdata["branch"] = Base.BUILD_INFO.branch
+    csdata["branch"] = ENV["JULIA_BRANCH"]
+    csdata["executable"] = ENV["JULIA_FLAVOR"]
+    csdata["environment"] = chomp(readall(`hostname`))
+    #csdata["result_date"] = join( split(Base.BUILD_INFO.date_string)[1:2], " " )    #Cut the timezone out
+    csdata["result_date"] = join( split(ENV["JULIA_COMMIT_DATE"])[1:2], " " )    #Cut the timezone out
+end
+
+# Takes in the raw array of values in vals, along with the benchmark name, description, unit and whether less is better
+function submit_to_codespeed(vals,name,desc,unit,test_group,lessisbetter=true)
+    # Points to the server 
+    codespeed_host = "128.52.160.154"
+
+    csdata["benchmark"] = name
+    csdata["description"] = desc
+    csdata["result_value"] = mean(vals)
+    csdata["std_dev"] = std(vals)
+    csdata["min"] = min(vals)
+    csdata["max"] = max(vals)
+    csdata["units"] = unit
+    csdata["units_title"] = test_group
+    csdata["lessisbetter"] = lessisbetter
+
+    println( "$name: $(mean(vals))" )
+    ret = Curl.post( "http://$codespeed_host/result/add/json/", {:json => to_json([csdata])} )
+    if( !ismatch(r".*202 ACCEPTED.*", ret.headers[1][1]) )
+        error("Error submitting $name, dumping headers and text: $(ret.headers[1])\n$(ret.text)\n\n")
+        return false
+    end
+    return true
+end
+
+macro output_timings(t,name,desc,group)
+    quote
+        # If we weren't given anything for the test group, infer off of file path!
+        test_group = length($group) == 0 ? split(Base.source_path(), "/")[end-1] : $group[1]
+        if codespeed
+            submit_to_codespeed( $t, $name, $desc, "seconds", test_group )
+        elseif print_output
+            @printf "julia,%s,%f,%f,%f,%f\n" $name min($t) max($t) mean($t) std($t)
+        end
+        gc()        
+    end
+end
+
+macro timeit(ex,name,desc,group...)
     quote
         t = zeros(ntrials)
         for i=0:ntrials
@@ -11,27 +85,21 @@ macro timeit(ex,name)
                 t[i] = e
             end
         end
-        if print_output
-            @printf "julia,%s,%f,%f,%f,%f\n" $name min(t) max(t) mean(t) std(t)
-        end
-        gc()
+        @output_timings t $name $desc $group
     end
 end
 
-macro timeit1(ex,name)
+macro timeit1(ex,name,desc,group...)
     quote
         t = 0.0
         for i=0:1
             t = 1000*(@elapsed $(esc(ex)))
         end
-        if print_output
-            @printf "julia,%s,%f,%f,%f,%f\n" $name t t t NaN
-        end
-        gc()
+        @output_timings [t] $name $desc $group
     end
 end
 
-macro timeit_init(ex,init,name)
+macro timeit_init(ex,init,name,desc,group...)
     quote
         t = zeros(ntrials)
         for i=0:ntrials
@@ -42,10 +110,7 @@ macro timeit_init(ex,init,name)
                 t[i] = e
             end
         end
-        if print_output
-            @printf "julia,%s,%f,%f,%f,%f\n" $name min(t) max(t) mean(t) std(t)
-        end
-        gc()
+        @output_timings t $name $desc $group
     end
 end
 

--- a/test/perf/shootout/perf.jl
+++ b/test/perf/shootout/perf.jl
@@ -1,10 +1,10 @@
 include("../perfutil.jl")
 
 include("binary_trees.jl")
-@timeit binary_trees(10) "binary_trees"
+@timeit binary_trees(10) "binary_trees" "Allocate and deallocate many many binary trees"
 
 include("fannkuch.jl")
-@timeit fannkuch(7) "fannkuch"
+@timeit fannkuch(7) "fannkuch" "Indexed-access to tiny integer-sequence"
 
 include("fasta.jl")
 n = 100
@@ -12,34 +12,34 @@ n = 100
     repeat_fasta(alu, 2n)
     random_fasta(iub[1], iub[2], 3n)
     random_fasta(homosapiens[1], homosapiens[2], 5n)
-end "fasta"
+end "fasta" "Generate and write random DNA sequences"
 
 include("k_nucleotide.jl")
-@timeit k_nucleotide("shootout/knucleotide-input.txt") "k_nucleotide"
+@timeit k_nucleotide("shootout/knucleotide-input.txt") "k_nucleotide" "Hashtable update and k-nucleotide strings"
 
 include("mandelbrot.jl")
-@timeit mandelbrot(200, "shootout/mandelbrot-output-julia.txt") "mandelbrot"
+@timeit mandelbrot(200, "shootout/mandelbrot-output-julia.txt") "mandelbrot" "Generate Mandelbrot set portable bitmap file"
 
 include("meteor_contest.jl")
-@timeit1 meteor_contest() "meteor_contest"
+@timeit1 meteor_contest() "meteor_contest" "Search for solutions to shape packing puzzle"
 
 include("nbody.jl")
 using NBody
-@timeit NBody.nbody() "nbody"
+@timeit NBody.nbody() "nbody" "Double-precision N-body simulation"
 
 include("nbody_vec.jl")
 using NBodyVec
-@timeit NBodyVec.nbody_vec() "nbody_vec"
+@timeit NBodyVec.nbody_vec() "nbody_vec" "A vectorized double-precision N-body simulation"
 
 include("pidigits.jl")
 @assert pidigits(1000) == 9216420198
-@timeit pidigits(1000) "pidigits"
+@timeit pidigits(1000) "pidigits" "Streaming arbitrary-precision arithmetic"
 
 include("regex_dna.jl")
-@timeit regex_dna("shootout/regexdna-input.txt") "regex_dna"
+@timeit regex_dna("shootout/regexdna-input.txt") "regex_dna" "Match DNA 8-mers and substitute nucleotides for IUB codes"
 
 include("revcomp.jl")
-@timeit revcomp("shootout/revcomp-input.txt") "revcomp"
+@timeit revcomp("shootout/revcomp-input.txt") "revcomp" "Read DNA sequences - write their reverse-complement"
 
 include("spectralnorm.jl")
-@timeit spectralnorm() "spectralnorm"
+@timeit spectralnorm() "spectralnorm" "Eigenvalue using the power method"

--- a/test/perf/sort/perf.jl
+++ b/test/perf/sort/perf.jl
@@ -7,63 +7,85 @@ sorts = [QuickSort, MergeSort, TimSort, InsertionSort]
 randstr_fn!(str_len::Int) = d -> (for i = 1:length(d); d[i] = randstring(str_len); end; d)
 randint_fn!(m::Int) = d -> rand!(1:m,d)
 
-for (T, typename, randfn!) in Any[(Int, string(Int), randint_fn!(10)), 
-                                  (Float64, string(Float64), rand!), 
-                                  (String, "String_05", randstr_fn!(5)),
-                                  (String, "String_10", randstr_fn!(10))]
-    for logsize = 6:2:18
-        size = 2^logsize
-        for s in sorts
-            if s == InsertionSort && logsize >=14; continue; end
-            data = Array(T, size)
-            gc()
+# If we're reporting to codespeed, only do a few tests.
+if codespeed
+    for (T, typename, randfn!) in Any[(Int, string(Int), randint_fn!(10)),
+                                    (String, "String_10", randstr_fn!(10))]
+        for size in [2^6,2^16]
+            for s in sorts
+                if s == InsertionSort && size != 2^6; continue; end
+                data = Array(T, size)
+                gc()
 
-            ## Random
-            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_random"
-            @timeit_init(sort!(data, alg=s), randfn!(data), name)
+                ## Random
+                name = "$(typename)_$(size)_$(string(s)[1:end-5])_random"
+                desc = "$(string(s)) run on $(size) $(typename) elements in random order"
+                @timeit_init(sort!(data, alg=s), randfn!(data), name, "")
 
-            ## Sorted
-            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_sorted"
-            @timeit(sort!(data, alg=s), name)
+                name = "$(typename)_$(size)_$(string(s)[1:end-5])_append"
+                desc = "$(string(s)) run on $(size) $(typename) elements pre-sorted 10 random elements appended"
+                @timeit_init(sort!(data, alg=s), begin data[end-9:end]=randfn!(Array(T,10)) end, name, "")
+            end
+        end
+    end
+else
+    for (T, typename, randfn!) in Any[(Int, string(Int), randint_fn!(10)), 
+                                    (Float64, string(Float64), rand!), 
+                                    (String, "String_05", randstr_fn!(5)),
+                                    (String, "String_10", randstr_fn!(10))]
+        for logsize = 6:2:18
+            size = 2^logsize
+            for s in sorts
+                if s == InsertionSort && logsize >=14; continue; end
+                data = Array(T, size)
+                gc()
 
-            ## Reverse sorted
-            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_reversed"
-            @timeit_init(sort!(data, alg=s), reverse!(data), name)
+                ## Random
+                name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_random"
+                @timeit_init(sort!(data, alg=s), randfn!(data), name, "")
 
-            ## Sorted with 3 exchanges
-            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_3exchanges"
-            @timeit_init(sort!(data, alg=s), 
-                         begin
-                             for i = 1:3
-                                 n1 = rand(1:size)
-                                 n2 = rand(1:size)
-                                 data[n1], data[n2] = data[n2], data[n1]
-                             end
-                         end, 
-                         name)
+                ## Sorted
+                name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_sorted"
+                @timeit(sort!(data, alg=s), name, "")
 
-            ## Sorted with 10 unsorted values appended
-            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_append"
-            @timeit_init(sort!(data, alg=s), begin data[end-9:end]=randfn!(Array(T,10)) end, name)
-            
-            ## Random data with 4 unique values
-            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_4unique"
-            @timeit_init(sort!(data4, alg=s), begin data4=data[rand(1:4,size)] end, name)
+                ## Reverse sorted
+                name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_reversed"
+                @timeit_init(sort!(data, alg=s), reverse!(data), name, "")
 
-            ## All values equal
-            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_allequal"
-            data1 = data[ones(Int, size)]
-            @timeit(sort!(data1, alg=s), name)
+                ## Sorted with 3 exchanges
+                name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_3exchanges"
+                @timeit_init(sort!(data, alg=s), 
+                             begin
+                                 for i = 1:3
+                                     n1 = rand(1:size)
+                                     n2 = rand(1:size)
+                                     data[n1], data[n2] = data[n2], data[n1]
+                                 end
+                             end, 
+                             name, "")
 
-            ## QuickSort median killer
-            if s == QuickSort && logsize > 16; continue; end  # too slow!
+                ## Sorted with 10 unsorted values appended
+                name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_append"
+                @timeit_init(sort!(data, alg=s), begin data[end-9:end]=randfn!(Array(T,10)) end, name, "")
+                
+                ## Random data with 4 unique values
+                name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_4unique"
+                @timeit_init(sort!(data4, alg=s), begin data4=data[rand(1:4,size)] end, name, "")
 
-            name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_qsortkiller"
-            data = data[1:size>>1]
-            data = sort!(data, alg=s)
-            data = vcat(reverse(data), data)
-            @timeit_init(sort!(qdata, alg=s), begin qdata=copy(data) end, name)
+                ## All values equal
+                name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_allequal"
+                data1 = data[ones(Int, size)]
+                @timeit(sort!(data1, alg=s), name, "")
+
+                ## QuickSort median killer
+                if s == QuickSort && logsize > 16; continue; end  # too slow!
+
+                name = "$(typename)_$(logsize)_$(string(s)[1:end-5])_qsortkiller"
+                data = data[1:size>>1]
+                data = sort!(data, alg=s)
+                data = vcat(reverse(data), data)
+                @timeit_init(sort!(qdata, alg=s), begin qdata=copy(data) end, name, "")
+            end
         end
     end
 end
-


### PR DESCRIPTION
# Summary:
- Change webhook notification URLs to julia.mit.edu (Linux) and criid.ee.washington.edu (OSX)
- Add `codespeed` target to test/perf/Makefile, which will run perfsuite and upload result to hardcoded codespeed installation location
  - Note that `make codespeed` will attempt to `Pkg.add()` the packages `JSON` and `Curl` if not already installed.
  - ~~Exclude `sort` subtests for now, see https://github.com/JuliaLang/julia/commit/453b4efc30bfdabf8a1db33a496ef5972afc9812~~
- Annotate all @time macro calls with an extra "Description" field, used to populate the codespeed database for the first time
  - ~~Again, exclude the `sort` tests for now, as this integration with codespeed will have to wait.  For now, empty descriptions~~
- Until extra build-time information is provided, expect environment variables such as JULIA_FLAVOR, JULIA_BRANCH, and JULIA_COMMIT_DATE on the command line when `make codespeed` is invoked.

This might be my biggest pull request yet, but I seem to have finally gotten things to the point where they're uploading to codespeed regularly.  I know it doesn't look like it due to the lack of history, but that's because I recently purged the memory of the codespeed installation.

Comments and critiques are welcome!  Once this gets merged, `master` will start to automagically get tracked; it fails right now due to the lack of the `codespeed` target in `test/perf/Makefile`.  I'm not sure if we ever want to backport this to `release-0.1`, perhaps this should be a 0.2+ thing.  :)
# Next on my TODO list:
- Build scaffolding around C code to create a "baseline" in codespeed to compare against
- Enjoy the pretty graphs, and make sure the build process is all toughened up (Only time will tell, now).
- Something I'm surely forgetting, but can't seem to put my finger on right now.....
