### PR TITLE
Implement get() for SubArrays

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -645,28 +645,25 @@ setindex!{T<:Real}(A::Array, x, I::AbstractVector{Bool}, J::AbstractVector{T}) =
 
 # get (getindex with a default value)
 
-get(A::Array, i::Integer, default) = in_bounds(length(A), i) ? A[i] : default
-get(A::Array, I::(), default) = Array(typeof(default), 0)
-get(A::Array, I::Dims, default) = in_bounds(size(A), I...) ? A[I...] : default
+get(A::Array, i::Integer, default) = in_bounds(length(A), i) ? convert(typeof(default), A[i]) : default
+get(A::Array, I::Dims, default) = in_bounds(size(A), I...) ? convert(typeof(default), A[I...]) : default
 
-function get{T}(X::Array{T}, A::Array, I::Union(Ranges, Vector{Int}), default::T)
+function get!{T}(X::AbstractArray{T}, A::Array, I::Union(Ranges, Vector{Int}), default::T)
     ind = findin(I, 1:length(A))
     X[ind] = A[I[ind]]
     X[1:first(ind)-1] = default
     X[last(ind)+1:length(X)] = default
     X
 end
-get(A::Array, I::Ranges, default) = get(Array(typeof(default), length(I)), A, I, default)
+get(A::Array, I::Ranges, default) = get!(Array(typeof(default), length(I)), A, I, default)
 
-typealias RangeVecIntList Union((Union(Ranges, Vector{Int})...), Vector{Range1{Int}}, Vector{Range{Int}}, Vector{Vector{Int}})
-
-function get{T}(X::Array{T}, A::Array, I::RangeVecIntList, default::T)
+function get!{T}(X::AbstractArray{T}, A::Array, I::RangeVecIntList, default::T)
     fill!(X, default)
     dst, src = indcopy(size(A), I)
     X[dst...] = A[src...]
     X
 end
-get(A::Array, I::RangeVecIntList, default) = get(Array(typeof(default), map(length, I)...), A, I, default)
+get(A::Array, I::RangeVecIntList, default) = get!(Array(typeof(default), map(length, I)...), A, I, default)
 
 ## Dequeue functionality ##
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -219,6 +219,7 @@ export PipeString
 @deprecate msync(A::Array, flags::Int)    msync(A)
 @deprecate msync(A::BitArray, flags::Int) msync(A)
 @deprecate square(x::Number)          x*x
+@deprecate get(X::Array, A::Array, I, default) get!(X, A, I, default)
 
 deprecated_ls() = run(`ls -l`)
 deprecated_ls(args::Cmd) = run(`ls -l $args`)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -696,6 +696,7 @@ export
     endof,
     eltype,
     get,
+    get!,
     getindex,
     haskey,
     intersect,

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -161,6 +161,20 @@ let
     @test X == Xv
     X2 = get(A, Vector{Int}[[2:4], [9:-2:-13]], 0)
     @test X == X2
+    # subarrays
+    A = reshape(1:40, 5, 8)
+    sA = sub(A, 2:4, 3:8)
+    X = get(sA, (0:3, 1:7), NaN)
+    @test isequal(X, hcat(float(A[1:4, 3:8]),nans(4)))
+    x = get(sA, (0, -1), NaN32)
+    @test x == 1
+    x = get(sA, (-1, -1), NaN32)
+    @test isnan(x)
+    a = 1:5
+    sa = sub(a, 1:3)
+    @test get(sa, 4, NaN) == 4
+    @test isnan(get(sa, 0, NaN))
+    @test isequal(get(sa, 1:6, NaN), [[1:5], NaN])
 end
 
 ## arrays as dequeues


### PR DESCRIPTION
This implements `get()` for `SubArray`s, with the behavior that "missing" values are looked up in the parent:

```
julia> A = reshape(1:40, 5, 8)
5x8 Int64 Array:
 1   6  11  16  21  26  31  36
 2   7  12  17  22  27  32  37
 3   8  13  18  23  28  33  38
 4   9  14  19  24  29  34  39
 5  10  15  20  25  30  35  40

julia> sA = sub(A, 2:5, 3:7)
4x5 SubArray of 5x8 Int64 Array:
 12  17  22  27  32
 13  18  23  28  33
 14  19  24  29  34
 15  20  25  30  35

julia> get(sA, (2:4, -1:7), NaN)
3x9 Float64 Array:
 3.0   8.0  13.0  18.0  23.0  28.0  33.0  38.0  NaN
 4.0   9.0  14.0  19.0  24.0  29.0  34.0  39.0  NaN
 5.0  10.0  15.0  20.0  25.0  30.0  35.0  40.0  NaN
```

Main points to check:
- Renaming get->get! for the preallocated output, plus deprecation & exports change
- Should we disable linear-indexing for `get()` for arrays of dimension > 1? In the context of this behavior for `SubArray`s, there does not appear to be any reasonable interpretation for this operation.
