### PR TITLE
RFC : Added interrupt_workers

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1105,6 +1105,7 @@ export
     addprocs,
     ClusterManager,
     fetch,
+    interrupt,
     isready,
     myid,
     nprocs,


### PR DESCRIPTION
Patch provides a means to support  Ctrl-C for both remote as well as local workers as outlined in https://github.com/JuliaLang/julia/issues/3805 

`Base.interrupt_workers()` must be called from the sigint handler as desired.

Interrupting workers has been implemented via callbacks to the ClusterManager. The system pid of the worker process is sent back as a response to the initial `:join_pgrp` message sent to the workers
