### PR TITLE
make byte order types IO wrappers

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -75,6 +75,16 @@ end
 show(io::IO, z::Complex) = complex_show(io, z, false)
 showcompact(io::IO, z::Complex) = complex_show(io, z, true)
 
+function read{T<:Real}(s::IO, ::Type{Complex{T}})
+    r = read(s,T)
+    i = read(s,T)
+    Complex{T}(r,i)
+end
+function write(s::IO, z::Complex)
+    write(s,real(z))
+    write(s,imag(z))
+end
+
 
 ## singleton type for imaginary unit constant ##
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -8,10 +8,10 @@
 
 abstract ByteOrderedIO <: IO
 
-type NetworkByteOrder{T<:IO} <: ByteOrderedIO
+immutable NetworkByteOrder{T<:IO} <: ByteOrderedIO
     io::T
 end
-type LittleByteOrder{T<:IO} <: ByteOrderedIO
+immutable LittleByteOrder{T<:IO} <: ByteOrderedIO
     io::T
 end
 
@@ -63,7 +63,10 @@ end
 
 write(s::IO, x::Integer) = write(HostByteOrder(s), x::Integer)
 
+write{I<:IO}(s::NetworkByteOrder{I}, x::Bool) = write(s.io,x)
+write{I<:IO}(s::LittleByteOrder{I}, x::Bool) = write(s.io,x)
 write(s::IO, x::Bool) = write(s, uint8(x))
+
 #write(s::IO, x::Float16) = write(s, reinterpret(Int16,x))
 write(s::IO, x::Float32) = write(s, reinterpret(Int32,x))
 write(s::IO, x::Float64) = write(s, reinterpret(Int64,x))
@@ -76,7 +79,8 @@ function write(s::IO, a::AbstractArray)
     nb
 end
 
-
+write{I<:IO}(s::NetworkByteOrder{I}, x::Char) = write(s.io,x)
+write{I<:IO}(s::LittleByteOrder{I}, x::Char) = write(s.io,x)
 function write(s::IO, c::Char)
     if c < 0x80
         write(s, uint8(c))
@@ -124,7 +128,10 @@ end
 
 read{T<:Integer}(s::IO, ::Type{T}) = read(HostByteOrder(s), T)
 
+read{I<:IO}(s::NetworkByteOrder{I}, ::Type{Bool}) = read(s.io,Bool)
+read{I<:IO}(s::LittleByteOrder{I}, ::Type{Bool}) = read(s.io,Bool)
 read(s::IO, ::Type{Bool})    = (read(s,Uint8)!=0)
+
 read(s::IO, ::Type{Float32}) = reinterpret(Float32,read(s,Int32))
 read(s::IO, ::Type{Float64}) = reinterpret(Float64,read(s,Int64))
 
@@ -143,7 +150,8 @@ function read{T}(s::IO, a::Array{T})
 end
 
 
-
+read{I<:IO}(s::NetworkByteOrder{I}, ::Type{Char}) = read(s.io,Char)
+read{I<:IO}(s::LittleByteOrder{I}, ::Type{Char}) = read(s.io,Char)
 function read(s::IO, ::Type{Char})
     ch = read(s, Uint8)
     if ch < 0x80

--- a/base/io.jl
+++ b/base/io.jl
@@ -6,26 +6,27 @@
 
 ## byte-order mark, ntoh & hton ##
 
-abstract ByteOrder
+abstract ByteOrderedIO <: IO
 
-type HostByteOrder <: ByteOrder 
+type NetworkByteOrder{T<:IO} <: ByteOrderedIO
+    io::T
 end
-
-type ReverseByteOrder <: ByteOrder 
+type LittleByteOrder{T<:IO} <: ByteOrderedIO
+    io::T
 end
 
 const ENDIAN_BOM = reinterpret(Uint32,uint8([1:4]))[1]
 
 if ENDIAN_BOM == 0x01020304
-    typealias NetworkByteOrder HostByteOrder 
-    typealias LittleByteOrder ReverseByteOrder 
+    typealias HostByteOrder NetworkByteOrder
+    typealias ReverseByteOrder LittleByteOrder
     ntoh(x) = identity(x)
     hton(x) = identity(x)
     ltoh(x) = bswap(x)
     htol(x) = bswap(x)
 elseif ENDIAN_BOM == 0x04030201
-    typealias NetworkByteOrder ReverseByteOrder
-    typealias LittleByteOrder HostByteOrder
+    typealias HostByteOrder LittleByteOrder
+    typealias ReverseByteOrder NetworkByteOrder
     ntoh(x) = bswap(x)
     hton(x) = bswap(x)
     ltoh(x) = identity(x)
@@ -41,44 +42,36 @@ write(s::IO, x::Uint8) = error(typeof(s)," does not support byte I/O")
 
 write(io::IO, x) = throw(MethodError(write, (io, x)))
 write(io::IO, xs...) = for x in xs write(io, x) end
+# needed to avoid ambiguous dispatch
+write{I<:IO}(s::NetworkByteOrder{I}, x::Uint8) = write(s.io,x)
+write{I<:IO}(s::LittleByteOrder{I}, x::Uint8) = write(s.io,x)
 
-function write(s::IO, x::Integer,::Type{NetworkByteOrder})
+function write{I<:IO}(s::NetworkByteOrder{I}, x::Integer)
     sz = sizeof(x)
     for n = sz:-1:1
-        write(s, uint8((x>>>((n-1)<<3))))
+        write(s.io, uint8(x >>> ((n-1)<<3) ))
     end
     sz
 end
-function write(s::IO, x::Integer,::Type{LittleByteOrder})
+function write{I<:IO}(s::LittleByteOrder{I}, x::Integer)
     sz = sizeof(x)
     for n = 1:sz
-        write(s, uint8((x>>>((n-1)<<3))))
+        write(s.io, uint8(x >>> ((n-1)<<3) ))
     end
     sz
 end
 
-write(s::IO, x::Bool) = write(s, uint8(x))
-#write{O<:ByteOrder}(s::IO, x::Float16, ::Type{O}) = write(s, reinterpret(Int16,x), O)
-write{O<:ByteOrder}(s::IO, x::Float32, ::Type{O}) = write(s, reinterpret(Int32,x), O)
-write{O<:ByteOrder}(s::IO, x::Float64, ::Type{O}) = write(s, reinterpret(Int64,x), O)
-function write{O<:ByteOrder}(s::IO, z::Complex, ::Type{O})
-    write(s,real(z),O)
-    write(s,imag(z),O)
-end
+write(s::IO, x::Integer) = write(HostByteOrder(s), x::Integer)
 
-write(s::IO, x::Number) = write(s, x, HostByteOrder)
+write(s::IO, x::Bool) = write(s, uint8(x))
+#write(s::IO, x::Float16) = write(s, reinterpret(Int16,x))
+write(s::IO, x::Float32) = write(s, reinterpret(Int32,x))
+write(s::IO, x::Float64) = write(s, reinterpret(Int64,x))
 
 function write(s::IO, a::AbstractArray)
     nb = 0
     for i = 1:length(a)
         nb += write(s, a[i])
-    end
-    nb
-end
-function write{O<:ByteOrder}(s::IO, a::AbstractArray, ::Type{O})
-    nb = 0
-    for i = 1:length(a)
-        nb += write(s, a[i],O)
     end
     nb
 end
@@ -110,33 +103,31 @@ end
 
 # all subtypes should implement this
 read(s::IO, x::Type{Uint8}) = error(typeof(s)," does not support byte I/O")
+# needed to avoid ambiguous dispatch
+read{I<:IO}(s::NetworkByteOrder{I}, ::Type{Uint8}) = read(s.io,Uint8)
+read{I<:IO}(s::LittleByteOrder{I}, ::Type{Uint8}) = read(s.io,Uint8)
 
-function read{T <: Integer}(s::IO, ::Type{T},::Type{LittleByteOrder})
-    x = zero(T)
-    for n = 1:sizeof(x)
-        x |= (convert(T,read(s,Uint8))<<((n-1)<<3))
-    end
-    return x
-end
-
-function read{T <: Integer}(s::IO, ::Type{T},::Type{NetworkByteOrder})
+function read{I<:IO,T<:Integer}(s::NetworkByteOrder{I}, ::Type{T})
     x = zero(T)
     for n = sizeof(x):-1:1
-        x |= (convert(T,read(s,Uint8))<<((n-1)<<3))
+        x |= (convert(T,read(s.io,Uint8))<<((n-1)<<3))
+    end
+    return x
+end
+function read{I<:IO,T<:Integer}(s::LittleByteOrder{I}, ::Type{T})
+    x = zero(T)
+    for n = 1:sizeof(x)
+        x |= (convert(T,read(s.io,Uint8))<<((n-1)<<3))
     end
     return x
 end
 
-read(s::IO, ::Type{Bool})    = (read(s,Uint8)!=0)
-read{O<:ByteOrder}(s::IO, ::Type{Float32}, ::Type{O}) = reinterpret(Float32,read(s,Int32,O))
-read{O<:ByteOrder}(s::IO, ::Type{Float64}, ::Type{O}) = reinterpret(Float64,read(s,Int64,O))
-function read{T<:Real,O<:ByteOrder}(s::IO, ::Type{Complex{T}}, ::Type{O})
-    r = read(s,T,O)
-    i = read(s,T,O)
-    Complex{T}(r,i)
-end
+read{T<:Integer}(s::IO, ::Type{T}) = read(HostByteOrder(s), T)
 
-read{N<:Number}(s::IO, ::Type{N}) = read(s,N,HostByteOrder)
+read(s::IO, ::Type{Bool})    = (read(s,Uint8)!=0)
+read(s::IO, ::Type{Float32}) = reinterpret(Float32,read(s,Int32))
+read(s::IO, ::Type{Float64}) = reinterpret(Float64,read(s,Int64))
+
 
 
 read{T}(s::IO, t::Type{T}, d1::Int, dims::Int...) =
@@ -147,19 +138,6 @@ read{T}(s::IO, ::Type{T}, dims::Dims) = read(s, Array(T, dims))
 function read{T}(s::IO, a::Array{T})
     for i = 1:length(a)
         a[i] = read(s, T)
-    end
-    return a
-end
-
-read{T,O<:ByteOrder}(s::IO, t::Type{T}, ::Type{O}, d1::Int, dims::Int...) =
-    read(s, t, O, tuple(d1,dims...))
-read{T,O<:ByteOrder}(s::IO, t::Type{T}, ::Type{O}, d1::Integer, dims::Integer...) =
-    read(s, t, O, map(int,tuple(d1,dims...)))
-read{T,O<:ByteOrder}(s::IO, ::Type{T}, ::Type{O}, dims::Dims) = read(s, Array(T, dims), O)
-
-function read{T,O<:ByteOrder}(s::IO, a::Array{T}, ::Type{O})
-    for i = 1:length(a)
-        a[i] = read(s, T, O)
     end
     return a
 end
@@ -547,6 +525,5 @@ end
 # BitArray I/O
 
 write(s::IO, B::BitArray) = write(s, B.chunks)
-write{O<:ByteOrder}(s::IO, B::BitArray, ::Type{O}) = write(s, B.chunks, O)
 read(s::IO, B::BitArray) = read(s, B.chunks)
-read{O<:ByteOrder}(s::IO, B::BitArray, ::Type{O}) = read(s, B.chunks, O)
+

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -4,7 +4,6 @@
 
 ("Getting Around","Base","exit","exit([code])
 
-
    Quit (or control-D at the prompt). The default exit code is zero,
    indicating that the processes completed successfully.
 
@@ -12,13 +11,11 @@
 
 ("Getting Around","Base","quit","quit()
 
-
    Calls \"exit(0)\".
 
 "),
 
 ("Getting Around","Base","atexit","atexit(f)
-
 
    Register a zero-argument function to be called at exit.
 
@@ -26,13 +23,11 @@
 
 ("Getting Around","Base","isinteractive","isinteractive()
 
-
    Determine whether Julia is running an interactive session.
 
 "),
 
 ("Getting Around","Base","whos","whos([Module,] [pattern::Regex])
-
 
    Print information about global variables in a module, optionally
    restricted to those matching \"pattern\".
@@ -40,7 +35,6 @@
 "),
 
 ("Getting Around","Base","edit","edit(file::String[, line])
-
 
    Edit a file optionally providing a line number to edit at. Returns
    to the julia prompt when you quit the editor. If the file name ends
@@ -50,7 +44,6 @@
 
 ("Getting Around","Base","edit","edit(function[, types])
 
-
    Edit the definition of a function, optionally specifying a tuple of
    types to indicate which method to edit. When the editor exits, the
    source file containing the definition is reloaded.
@@ -58,7 +51,6 @@
 "),
 
 ("Getting Around","Base","require","require(file::String...)
-
 
    Load source files once, in the context of the \"Main\" module, on
    every active node, searching the system-wide \"LOAD_PATH\" for
@@ -72,7 +64,6 @@
 
 ("Getting Around","Base","reload","reload(file::String)
 
-
    Like \"require\", except forces loading of files regardless of
    whether they have been loaded before. Typically used when
    interactively developing libraries.
@@ -80,7 +71,6 @@
 "),
 
 ("Getting Around","Base","include","include(path::String)
-
 
    Evaluate the contents of a source file in the current context.
    During including, a task-local include path is set to the directory
@@ -93,9 +83,7 @@
 
 "),
 
-("Getting
-Around","Base","include_string","include_string(code::String)
-
+("Getting Around","Base","include_string","include_string(code::String)
 
    Like \"include\", except reads code from the given string rather
    than from a file. Since there is no file path involved, no path
@@ -105,7 +93,6 @@ Around","Base","include_string","include_string(code::String)
 
 ("Getting Around","Base","evalfile","evalfile(path::String)
 
-
    Evaluate all expressions in the given file, and return the value of
    the last one. No other processing (path searching, fetching from
    node 1, etc.) is performed.
@@ -113,7 +100,6 @@ Around","Base","include_string","include_string(code::String)
 "),
 
 ("Getting Around","Base","usingmodule","usingmodule(name)
-
 
    Supports conditional inclusion of a package or module. Equivalent
    to \"using name\" in a file, except it can be inside an \"if\"
@@ -123,13 +109,11 @@ Around","Base","include_string","include_string(code::String)
 
 ("Getting Around","Base","help","help(name)
 
-
    Get help for a function. \"name\" can be an object or a string.
 
 "),
 
 ("Getting Around","Base","apropos","apropos(string)
-
 
    Search documentation for functions related to \"string\".
 
@@ -137,21 +121,17 @@ Around","Base","include_string","include_string(code::String)
 
 ("Getting Around","Base","which","which(f, args...)
 
-
    Show which method of \"f\" will be called for the given arguments.
 
 "),
 
 ("Getting Around","Base","methods","methods(f)
 
-
    Show all methods of \"f\" with their argument types.
 
 "),
 
-("Getting Around","Base","methodswith","methodswith(typ[,
-showparents])
-
+("Getting Around","Base","methodswith","methodswith(typ[, showparents])
 
    Show all methods with an argument of type \"typ\". If optional
    \"showparents\" is \"true\", also show arguments with a parent type
@@ -161,7 +141,6 @@ showparents])
 
 ("All Objects","Base","is","is(x, y)
 
-
    Determine whether \"x\" and \"y\" are identical, in the sense that
    no program could distinguish them.
 
@@ -169,13 +148,11 @@ showparents])
 
 ("All Objects","Base","isa","isa(x, type)
 
-
    Determine whether \"x\" is of the given type.
 
 "),
 
 ("All Objects","Base","isequal","isequal(x, y)
-
 
    True if and only if \"x\" and \"y\" have the same contents. Loosely
    speaking, this means \"x\" and \"y\" would look the same when
@@ -184,7 +161,6 @@ showparents])
 "),
 
 ("All Objects","Base","isless","isless(x, y)
-
 
    Test whether \"x\" is less than \"y\". Provides a total order
    consistent with \"isequal\". Values that are normally unordered,
@@ -196,20 +172,17 @@ showparents])
 
 ("All Objects","Base","typeof","typeof(x)
 
-
    Get the concrete type of \"x\".
 
 "),
 
 ("All Objects","Base","tuple","tuple(xs...)
 
-
    Construct a tuple of the given objects.
 
 "),
 
 ("All Objects","Base","ntuple","ntuple(n, f::Function)
-
 
    Create a tuple of length \"n\", computing each element as \"f(i)\",
    where \"i\" is the index of the element.
@@ -218,7 +191,6 @@ showparents])
 
 ("All Objects","Base","object_id","object_id(x)
 
-
    Get a unique integer id for \"x\". \"object_id(x)==object_id(y)\"
    if and only if \"is(x,y)\".
 
@@ -226,14 +198,12 @@ showparents])
 
 ("All Objects","Base","hash","hash(x)
 
-
    Compute an integer hash code such that \"isequal(x,y)\" implies
    \"hash(x)==hash(y)\".
 
 "),
 
 ("All Objects","Base","finalizer","finalizer(x, function)
-
 
    Register a function \"f(x)\" to be called when there are no
    program-accessible references to \"x\". The behavior of this
@@ -243,7 +213,6 @@ showparents])
 
 ("All Objects","Base","copy","copy(x)
 
-
    Create a shallow copy of \"x\": the outer structure is copied, but
    not all internal values. For example, copying an array produces a
    new array with identically-same elements as the original.
@@ -251,7 +220,6 @@ showparents])
 "),
 
 ("All Objects","Base","deepcopy","deepcopy(x)
-
 
    Create a deep copy of \"x\": everything is copied recursively,
    resulting in a fully independent object. For example, deep-copying
@@ -276,7 +244,6 @@ showparents])
 
 ("All Objects","Base","isdefined","isdefined(object, index | symbol)
 
-
    Tests whether an assignable location is defined. The arguments can
    be an array and index, a composite object and field name (as a
    symbol), or a module and a symbol.
@@ -285,13 +252,11 @@ showparents])
 
 ("All Objects","Base","convert","convert(type, x)
 
-
    Try to convert \"x\" to the given type.
 
 "),
 
 ("All Objects","Base","promote","promote(xs...)
-
 
    Convert all arguments to their common promotion type (if any), and
    return them all (as a tuple).
@@ -300,13 +265,11 @@ showparents])
 
 ("All Objects","Base","oftype","oftype(x, y)
 
-
    Convert \"y\" to the type of \"x\".
 
 "),
 
 ("All Objects","Base","identity","identity(x)
-
 
    The identity function. Returns its argument.
 
@@ -314,13 +277,11 @@ showparents])
 
 ("Types","Base","super","super(T::DataType)
 
-
    Return the supertype of DataType T
 
 "),
 
 ("Types","Base","subtype","subtype(type1, type2)
-
 
    True if and only if all values of \"type1\" are also of \"type2\".
    Can also be written using the \"<:\" infix operator as \"type1 <:
@@ -330,13 +291,11 @@ showparents])
 
 ("Types","Base","<:","<:(T1, T2)
 
-
    Subtype operator, equivalent to \"subtype(T1,T2)\".
 
 "),
 
 ("Types","Base","subtypes","subtypes(T::DataType)
-
 
    Return a list of immediate subtypes of DataType T.  Note that all
    currently loaded subtypes are included, including those not visible
@@ -346,7 +305,6 @@ showparents])
 
 ("Types","Base","subtypetree","subtypetree(T::DataType)
 
-
    Return a nested list of all subtypes of DataType T.  Note that all
    currently loaded subtypes are included, including those not visible
    in the current module.
@@ -355,20 +313,17 @@ showparents])
 
 ("Types","Base","typemin","typemin(type)
 
-
    The lowest value representable by the given (real) numeric type.
 
 "),
 
 ("Types","Base","typemax","typemax(type)
 
-
    The highest value representable by the given (real) numeric type.
 
 "),
 
 ("Types","Base","realmin","realmin(type)
-
 
    The smallest in absolute value non-subnormal value representable by
    the given floating-point type
@@ -377,14 +332,12 @@ showparents])
 
 ("Types","Base","realmax","realmax(type)
 
-
    The highest finite value representable by the given floating-point
    type
 
 "),
 
 ("Types","Base","maxintfloat","maxintfloat(type)
-
 
    The largest integer losslessly representable by the given floating-
    point type
@@ -393,14 +346,12 @@ showparents])
 
 ("Types","Base","sizeof","sizeof(type)
 
-
    Size, in bytes, of the canonical binary representation of the given
    type, if any.
 
 "),
 
 ("Types","Base","eps","eps([type])
-
 
    The distance between 1.0 and the next larger representable
    floating-point value of \"type\". The only types that are sensible
@@ -411,14 +362,12 @@ showparents])
 
 ("Types","Base","eps","eps(x)
 
-
    The distance between \"x\" and the next larger representable
    floating-point value of the same type as \"x\".
 
 "),
 
 ("Types","Base","promote_type","promote_type(type1, type2)
-
 
    Determine a type big enough to hold values of each argument type
    without loss, whenever possible. In some cases, where no type
@@ -431,7 +380,6 @@ showparents])
 
 ("Types","Base","promote_rule","promote_rule(type1, type2)
 
-
    Specifies what type should be used by \"promote\" when given values
    of types \"type1\" and \"type2\". This function should not be
    called directly, but should have definitions added to it for new
@@ -441,7 +389,6 @@ showparents])
 
 ("Types","Base","getfield","getfield(value, name::Symbol)
 
-
    Extract a named field from a value of composite type. The syntax
    \"a.b\" calls \"getfield(a, :b)\", and the syntax \"a.(b)\" calls
    \"getfield(a, b)\".
@@ -449,7 +396,6 @@ showparents])
 "),
 
 ("Types","Base","setfield","setfield(value, name::Symbol, x)
-
 
    Assign \"x\" to a named field in \"value\" of composite type. The
    syntax \"a.b = c\" calls \"setfield(a, :b, c)\", and the syntax
@@ -459,13 +405,11 @@ showparents])
 
 ("Types","Base","fieldoffsets","fieldoffsets(type)
 
-
    The offset of each field of \"type\" relative to data start.
 
 "),
 
 ("Types","Base","fieldtype","fieldtype(value, name::Symbol)
-
 
    Determine the declared type of a named field in a value of
    composite type.
@@ -474,14 +418,12 @@ showparents])
 
 ("Types","Base","isimmutable","isimmutable(v)
 
-
    True if value \"v\" is immutable.  See *Immutable Composite Types*
    for a discussion of immutability.
 
 "),
 
 ("Types","Base","isbits","isbits(T)
-
 
    True if \"T\" is a \"plain data\" type, meaning it is immutable and
    contains no references to other values. Typical examples are
@@ -492,7 +434,6 @@ showparents])
 
 ("Types","Base","isleaftype","isleaftype(T)
 
-
    Determine whether \"T\" is a concrete type that can have instances,
    meaning its only subtypes are itself and \"None\" (but \"T\" itself
    is not \"None\").
@@ -501,22 +442,18 @@ showparents])
 
 ("Types","Base","typejoin","typejoin(T, S)
 
-
    Compute a type that contains both \"T\" and \"S\".
 
 "),
 
 ("Types","Base","typeintersect","typeintersect(T, S)
 
-
    Compute a type that contains the intersection of \"T\" and \"S\".
    Usually this will be the smallest such type or one close to it.
 
 "),
 
-("Generic Functions","Base","method_exists","method_exists(f, tuple)
--> Bool
-
+("Generic Functions","Base","method_exists","method_exists(f, tuple) -> Bool
 
    Determine whether the given generic function has a method matching
    the given tuple of argument types.
@@ -527,14 +464,12 @@ showparents])
 
 ("Generic Functions","Base","applicable","applicable(f, args...)
 
-
    Determine whether the given generic function has a method
    applicable to the given arguments.
 
 "),
 
 ("Generic Functions","Base","invoke","invoke(f, (types...), args...)
-
 
    Invoke a method for the given generic function matching the
    specified types (as a tuple), on the specified arguments. The
@@ -548,7 +483,6 @@ showparents])
 
 ("Generic Functions","Base","|>","|>(x, f)
 
-
    Applies a function to the preceding argument which allows for easy
    function chaining.
 
@@ -558,13 +492,11 @@ showparents])
 
 ("Iteration","Base","start","start(iter) -> state
 
-
    Get initial iteration state for an iterable object
 
 "),
 
 ("Iteration","Base","done","done(iter, state) -> Bool
-
 
    Test whether we are done iterating
 
@@ -572,14 +504,12 @@ showparents])
 
 ("Iteration","Base","next","next(iter, state) -> item, state
 
-
    For a given iterable object and iteration state, return the current
    item and the next iteration state
 
 "),
 
 ("Iteration","Base","zip","zip(iters...)
-
 
    For a set of iterable objects, returns an iterable of tuples, where
    the \"i\"th tuple contains the \"i\"th component of each input
@@ -592,7 +522,6 @@ showparents])
 
 ("Iteration","Base","enumerate","enumerate(iter)
 
-
    Return an iterator that yields \"(i, x)\" where \"i\" is an index
    starting at 1, and \"x\" is the \"ith\" value from the given
    iterator.
@@ -601,21 +530,17 @@ showparents])
 
 ("General Collections","Base","isempty","isempty(collection) -> Bool
 
-
    Determine whether a collection is empty (has no elements).
 
 "),
 
-("General Collections","Base","empty!","empty!(collection) ->
-collection
-
+("General Collections","Base","empty!","empty!(collection) -> collection
 
    Remove all elements from a collection.
 
 "),
 
 ("General Collections","Base","length","length(collection) -> Integer
-
 
    For ordered, indexable collections, the maximum index \"i\" for
    which \"getindex(collection, i)\" is valid. For unordered
@@ -625,7 +550,6 @@ collection
 
 ("General Collections","Base","endof","endof(collection) -> Integer
 
-
    Returns the last index of the collection.
 
    **Example**: \"endof([1,2,4]) = 3\"
@@ -634,13 +558,11 @@ collection
 
 ("Iterable Collections","Base","contains","contains(itr, x) -> Bool
 
-
    Determine whether a collection contains the given value, \"x\".
 
 "),
 
 ("Iterable Collections","Base","findin","findin(a, b)
-
 
    Returns the indices of elements in collection \"a\" that appear in
    collection \"b\"
@@ -649,7 +571,6 @@ collection
 
 ("Iterable Collections","Base","unique","unique(itr)
 
-
    Returns an array containing only the unique elements of the
    iterable \"itr\", in the order that the first of each set of
    equivalent elements originally appears.
@@ -657,7 +578,6 @@ collection
 "),
 
 ("Iterable Collections","Base","reduce","reduce(op, v0, itr)
-
 
    Reduce the given collection with the given operator, i.e.
    accumulate \"v = op(v,elt)\" for each element, where \"v\" starts
@@ -670,13 +590,11 @@ collection
 
 ("Iterable Collections","Base","max","max(itr)
 
-
    Returns the largest element in a collection
 
 "),
 
 ("Iterable Collections","Base","min","min(itr)
-
 
    Returns the smallest element in a collection
 
@@ -684,13 +602,11 @@ collection
 
 ("Iterable Collections","Base","indmax","indmax(itr) -> Integer
 
-
    Returns the index of the maximum element in a collection
 
 "),
 
 ("Iterable Collections","Base","indmin","indmin(itr) -> Integer
-
 
    Returns the index of the minimum element in a collection
 
@@ -698,13 +614,11 @@ collection
 
 ("Iterable Collections","Base","findmax","findmax(itr) -> (x, index)
 
-
    Returns the maximum element and its index
 
 "),
 
 ("Iterable Collections","Base","findmin","findmin(itr) -> (x, index)
-
 
    Returns the minimum element and its index
 
@@ -712,13 +626,11 @@ collection
 
 ("Iterable Collections","Base","sum","sum(itr)
 
-
    Returns the sum of all elements in a collection
 
 "),
 
 ("Iterable Collections","Base","sum","sum(f, itr)
-
 
    Sum the results of calling function \"f\" on each element of
    \"itr\".
@@ -727,13 +639,11 @@ collection
 
 ("Iterable Collections","Base","prod","prod(itr)
 
-
    Returns the product of all elements of a collection
 
 "),
 
 ("Iterable Collections","Base","any","any(itr) -> Bool
-
 
    Test whether any elements of a boolean collection are true
 
@@ -741,13 +651,11 @@ collection
 
 ("Iterable Collections","Base","all","all(itr) -> Bool
 
-
    Test whether all elements of a boolean collection are true
 
 "),
 
 ("Iterable Collections","Base","count","count(p, itr) -> Integer
-
 
    Count the number of elements in \"itr\" for which predicate \"p\"
    is true.
@@ -756,7 +664,6 @@ collection
 
 ("Iterable Collections","Base","any","any(p, itr) -> Bool
 
-
    Determine whether any element of \"itr\" satisfies the given
    predicate.
 
@@ -764,14 +671,12 @@ collection
 
 ("Iterable Collections","Base","all","all(p, itr) -> Bool
 
-
    Determine whether all elements of \"itr\" satisfy the given
    predicate.
 
 "),
 
 ("Iterable Collections","Base","map","map(f, c) -> collection
-
 
    Transform collection \"c\" by applying \"f\" to each element.
 
@@ -781,13 +686,11 @@ collection
 
 ("Iterable Collections","Base","map!","map!(function, collection)
 
-
    In-place version of \"map()\".
 
 "),
 
 ("Iterable Collections","Base","mapreduce","mapreduce(f, op, itr)
-
 
    Applies function \"f\" to each element in \"itr\" and then reduces
    the result using the binary function \"op\".
@@ -798,13 +701,11 @@ collection
 
 ("Iterable Collections","Base","first","first(coll)
 
-
    Get the first element of an ordered collection.
 
 "),
 
 ("Iterable Collections","Base","last","last(coll)
-
 
    Get the last element of an ordered collection.
 
@@ -812,22 +713,18 @@ collection
 
 ("Iterable Collections","Base","step","step(r)
 
-
    Get the step size of a \"Range\" object.
 
 "),
 
 ("Iterable Collections","Base","collect","collect(collection)
 
-
    Return an array of all items in a collection. For associative
    collections, returns (key, value) tuples.
 
 "),
 
-("Indexable Collections","Base","getindex","getindex(collection,
-key...)
-
+("Indexable Collections","Base","getindex","getindex(collection, key...)
 
    Retrieve the value(s) stored at the given key or index within a
    collection. The syntax \"a[i,j,...]\" is converted by the compiler
@@ -835,9 +732,7 @@ key...)
 
 "),
 
-("Indexable Collections","Base","setindex!","setindex!(collection,
-value, key...)
-
+("Indexable Collections","Base","setindex!","setindex!(collection, value, key...)
 
    Store the given value at the given key or index within a
    collection. The syntax \"a[i,j,...] = x\" is converted by the
@@ -847,13 +742,11 @@ value, key...)
 
 ("Associative Collections","Base","Dict{K,V}","Dict{K,V}()
 
-
    Construct a hashtable with keys of type K and values of type V
 
 "),
 
 ("Associative Collections","Base","haskey","haskey(collection, key)
-
 
    Determine whether a collection has a mapping for a given key.
 
@@ -861,15 +754,12 @@ value, key...)
 
 ("Associative Collections","Base","get","get(collection, key, default)
 
-
    Return the value stored for the given key, or the given default
    value if no mapping for the key is present.
 
 "),
 
-("Associative Collections","Base","getkey","getkey(collection, key,
-default)
-
+("Associative Collections","Base","getkey","getkey(collection, key, default)
 
    Return the key matching argument \"key\" if one exists in
    \"collection\", otherwise return \"default\".
@@ -878,13 +768,11 @@ default)
 
 ("Associative Collections","Base","delete!","delete!(collection, key)
 
-
    Delete the mapping for the given key in a collection.
 
 "),
 
 ("Associative Collections","Base","keys","keys(collection)
-
 
    Return an iterator over all keys in a collection.
    \"collect(keys(d))\" returns an array of keys.
@@ -893,40 +781,31 @@ default)
 
 ("Associative Collections","Base","values","values(collection)
 
-
    Return an iterator over all values in a collection.
    \"collect(values(d))\" returns an array of values.
 
 "),
 
-("Associative Collections","Base","merge","merge(collection,
-others...)
-
+("Associative Collections","Base","merge","merge(collection, others...)
 
    Construct a merged collection from the given collections.
 
 "),
 
-("Associative Collections","Base","merge!","merge!(collection,
-others...)
-
+("Associative Collections","Base","merge!","merge!(collection, others...)
 
    Update collection with pairs from the other collections
 
 "),
 
-("Associative Collections","Base","filter","filter(function,
-collection)
-
+("Associative Collections","Base","filter","filter(function, collection)
 
    Return a copy of collection, removing (key, value) pairs for which
    function is false.
 
 "),
 
-("Associative Collections","Base","filter!","filter!(function,
-collection)
-
+("Associative Collections","Base","filter!","filter!(function, collection)
 
    Update collection, removing (key, value) pairs for which function
    is false.
@@ -935,14 +814,12 @@ collection)
 
 ("Associative Collections","Base","eltype","eltype(collection)
 
-
    Returns the type tuple of the (key,value) pairs contained in
    collection.
 
 "),
 
 ("Associative Collections","Base","sizehint","sizehint(s, n)
-
 
    Suggest that collection \"s\" reserve capacity for at least \"n\"
    elements. This can improve performance.
@@ -951,13 +828,11 @@ collection)
 
 ("Set-Like Collections","Base","add!","add!(collection, key)
 
-
    Add an element to a set-like collection.
 
 "),
 
 ("Set-Like Collections","Base","Set","Set(x...)
-
 
    Construct a \"Set\" with the given elements. Should be used instead
    of \"IntSet\" for sparse integer sets, or for sets of arbitrary
@@ -966,7 +841,6 @@ collection)
 "),
 
 ("Set-Like Collections","Base","IntSet","IntSet(i...)
-
 
    Construct a sorted set of the given integers. Implemented as a bit
    string, and therefore designed for dense integer sets. If the set
@@ -977,7 +851,6 @@ collection)
 
 ("Set-Like Collections","Base","union","union(s1, s2...)
 
-
    Construct the union of two or more sets. Maintains order with
    arrays.
 
@@ -985,13 +858,11 @@ collection)
 
 ("Set-Like Collections","Base","union!","union!(s, iterable)
 
-
    Union each element of \"iterable\" into set \"s\" in-place.
 
 "),
 
 ("Set-Like Collections","Base","intersect","intersect(s1, s2...)
-
 
    Construct the intersection of two or more sets. Maintains order and
    multiplicity of the first argument for arrays and ranges.
@@ -1000,7 +871,6 @@ collection)
 
 ("Set-Like Collections","Base","setdiff","setdiff(s1, s2)
 
-
    Construct the set of elements in \"s1\" but not \"s2\". Maintains
    order with arrays.
 
@@ -1008,13 +878,11 @@ collection)
 
 ("Set-Like Collections","Base","setdiff!","setdiff!(s, iterable)
 
-
    Remove each element of \"iterable\" from set \"s\" in-place.
 
 "),
 
 ("Set-Like Collections","Base","symdiff","symdiff(s1, s2...)
-
 
    Construct the symmetric difference of elements in the passed in
    sets or arrays. Maintains order with arrays.
@@ -1023,14 +891,12 @@ collection)
 
 ("Set-Like Collections","Base","symdiff!","symdiff!(s, n)
 
-
    IntSet s is destructively modified to toggle the inclusion of
    integer \"n\".
 
 "),
 
 ("Set-Like Collections","Base","symdiff!","symdiff!(s, itr)
-
 
    For each element in \"itr\", destructively toggle its inclusion in
    set \"s\".
@@ -1039,7 +905,6 @@ collection)
 
 ("Set-Like Collections","Base","symdiff!","symdiff!(s1, s2)
 
-
    Construct the symmetric difference of IntSets \"s1\" and \"s2\",
    storing the result in \"s1\".
 
@@ -1047,20 +912,17 @@ collection)
 
 ("Set-Like Collections","Base","complement","complement(s)
 
-
    Returns the set-complement of IntSet s.
 
 "),
 
 ("Set-Like Collections","Base","complement!","complement!(s)
 
-
    Mutates IntSet s into its set-complement.
 
 "),
 
 ("Set-Like Collections","Base","intersect!","intersect!(s1, s2)
-
 
    Intersects IntSets s1 and s2 and overwrites the set s1 with the
    result. If needed, s1 will be expanded to the size of s2.
@@ -1069,21 +931,17 @@ collection)
 
 ("Dequeues","Base","push!","push!(collection, item) -> collection
 
-
    Insert an item at the end of a collection.
 
 "),
 
 ("Dequeues","Base","pop!","pop!(collection) -> item
 
-
    Remove the last item in a collection and return it.
 
 "),
 
-("Dequeues","Base","unshift!","unshift!(collection, item) ->
-collection
-
+("Dequeues","Base","unshift!","unshift!(collection, item) -> collection
 
    Insert an item at the beginning of a collection.
 
@@ -1091,21 +949,17 @@ collection
 
 ("Dequeues","Base","shift!","shift!(collection) -> item
 
-
    Remove the first item in a collection.
 
 "),
 
 ("Dequeues","Base","insert!","insert!(collection, index, item)
 
-
    Insert an item at the given index.
 
 "),
 
-("Dequeues","Base","splice!","splice!(collection, index[,
-replacement]) -> item
-
+("Dequeues","Base","splice!","splice!(collection, index[, replacement]) -> item
 
    Remove the item at the given index, and return the removed item.
    Subsequent items are shifted down to fill the resulting gap. If
@@ -1114,9 +968,7 @@ replacement]) -> item
 
 "),
 
-("Dequeues","Base","splice!","splice!(collection, range[,
-replacement]) -> items
-
+("Dequeues","Base","splice!","splice!(collection, range[, replacement]) -> items
 
    Remove items in the specified index range, and return a collection
    containing the removed items. Subsequent items are shifted down to
@@ -1127,13 +979,11 @@ replacement]) -> items
 
 ("Dequeues","Base","resize!","resize!(collection, n) -> collection
 
-
    Resize collection to contain \"n\" elements.
 
 "),
 
 ("Dequeues","Base","append!","append!(collection, items) -> collection
-
 
    Add the elements of \"items\" to the end of a collection.
 
@@ -1141,13 +991,11 @@ replacement]) -> items
 
 ("Strings","Base","length","length(s)
 
-
    The number of characters in string \"s\".
 
 "),
 
 ("Strings","Base","*","*(s, t)
-
 
    Concatenate strings.
 
@@ -1157,7 +1005,6 @@ replacement]) -> items
 
 ("Strings","Base","^","^(s, n)
 
-
    Repeat string \"s\" \"n\" times.
 
    **Example**: \"\"Julia \"^3 == \"Julia Julia Julia \"\"
@@ -1166,20 +1013,17 @@ replacement]) -> items
 
 ("Strings","Base","string","string(xs...)
 
-
    Create a string from any values using the \"print\" function.
 
 "),
 
 ("Strings","Base","repr","repr(x)
 
-
    Create a string from any value using the \"show\" function.
 
 "),
 
 ("Strings","Base","bytestring","bytestring(::Ptr{Uint8})
-
 
    Create a string from the address of a C (0-terminated) string. A
    copy is made; the ptr can be safely freed.
@@ -1188,7 +1032,6 @@ replacement]) -> items
 
 ("Strings","Base","bytestring","bytestring(s)
 
-
    Convert a string to a contiguous byte array representation
    appropriate for passing it to C functions.
 
@@ -1196,13 +1039,11 @@ replacement]) -> items
 
 ("Strings","Base","ascii","ascii(::Array{Uint8, 1})
 
-
    Create an ASCII string from a byte array.
 
 "),
 
 ("Strings","Base","ascii","ascii(s)
-
 
    Convert a string to a contiguous ASCII string (all characters must
    be valid ASCII characters).
@@ -1211,13 +1052,11 @@ replacement]) -> items
 
 ("Strings","Base","utf8","utf8(::Array{Uint8, 1})
 
-
    Create a UTF-8 string from a byte array.
 
 "),
 
 ("Strings","Base","utf8","utf8(s)
-
 
    Convert a string to a contiguous UTF-8 string (all characters must
    be valid UTF-8 characters).
@@ -1226,14 +1065,12 @@ replacement]) -> items
 
 ("Strings","Base","is_valid_ascii","is_valid_ascii(s) -> Bool
 
-
    Returns true if the string or byte vector is valid ASCII, false
    otherwise.
 
 "),
 
 ("Strings","Base","is_valid_utf8","is_valid_utf8(s) -> Bool
-
 
    Returns true if the string or byte vector is valid UTF-8, false
    otherwise.
@@ -1242,14 +1079,12 @@ replacement]) -> items
 
 ("Strings","Base","is_valid_char","is_valid_char(c) -> Bool
 
-
    Returns true if the given char or integer is a valid Unicode code
    point.
 
 "),
 
 ("Strings","Base","ismatch","ismatch(r::Regex, s::String)
-
 
    Test whether a string contains a match of the given regular
    expression.
@@ -1258,7 +1093,6 @@ replacement]) -> items
 
 ("Strings","Base","lpad","lpad(string, n, p)
 
-
    Make a string at least \"n\" characters long by padding on the left
    with copies of \"p\".
 
@@ -1266,14 +1100,12 @@ replacement]) -> items
 
 ("Strings","Base","rpad","rpad(string, n, p)
 
-
    Make a string at least \"n\" characters long by padding on the
    right with copies of \"p\".
 
 "),
 
 ("Strings","Base","search","search(string, chars[, start])
-
 
    Search for the given characters within the given string. The second
    argument may be a single character, a vector or a set of
@@ -1288,7 +1120,6 @@ replacement]) -> items
 
 ("Strings","Base","replace","replace(string, pat, r[, n])
 
-
    Search for the given pattern \"pat\", and replace each occurance
    with \"r\". If \"n\" is provided, replace at most \"n\" occurances.
    As with search, the second argument may be a single character, a
@@ -1298,9 +1129,7 @@ replacement]) -> items
 
 "),
 
-("Strings","Base","split","split(string, [chars, [limit,]
-[include_empty]])
-
+("Strings","Base","split","split(string, [chars, [limit,] [include_empty]])
 
    Return an array of strings by splitting the given string on
    occurrences of the given character delimiters, which may be
@@ -1314,16 +1143,13 @@ replacement]) -> items
 
 "),
 
-("Strings","Base","rsplit","rsplit(string, [chars, [limit,]
-[include_empty]])
-
+("Strings","Base","rsplit","rsplit(string, [chars, [limit,] [include_empty]])
 
    Similar to \"split\", but starting from the end of the string.
 
 "),
 
 ("Strings","Base","strip","strip(string[, chars])
-
 
    Return \"string\" with any leading and trailing whitespace removed.
    If a string \"chars\" is provided, instead remove characters
@@ -1333,7 +1159,6 @@ replacement]) -> items
 
 ("Strings","Base","lstrip","lstrip(string[, chars])
 
-
    Return \"string\" with any leading whitespace removed. If a string
    \"chars\" is provided, instead remove characters contained in that
    string.
@@ -1341,7 +1166,6 @@ replacement]) -> items
 "),
 
 ("Strings","Base","rstrip","rstrip(string[, chars])
-
 
    Return \"string\" with any trailing whitespace removed. If a string
    \"chars\" is provided, instead remove characters contained in that
@@ -1351,13 +1175,11 @@ replacement]) -> items
 
 ("Strings","Base","beginswith","beginswith(string, prefix)
 
-
    Returns \"true\" if \"string\" starts with \"prefix\".
 
 "),
 
 ("Strings","Base","endswith","endswith(string, suffix)
-
 
    Returns \"true\" if \"string\" ends with \"suffix\".
 
@@ -1365,20 +1187,17 @@ replacement]) -> items
 
 ("Strings","Base","uppercase","uppercase(string)
 
-
    Returns \"string\" with all characters converted to uppercase.
 
 "),
 
 ("Strings","Base","lowercase","lowercase(string)
 
-
    Returns \"string\" with all characters converted to lowercase.
 
 "),
 
 ("Strings","Base","join","join(strings, delim)
-
 
    Join an array of strings into a single string, inserting the given
    delimiter between adjacent strings.
@@ -1387,13 +1206,11 @@ replacement]) -> items
 
 ("Strings","Base","chop","chop(string)
 
-
    Remove the last character from a string
 
 "),
 
 ("Strings","Base","chomp","chomp(string)
-
 
    Remove a trailing newline from a string
 
@@ -1401,13 +1218,11 @@ replacement]) -> items
 
 ("Strings","Base","ind2chr","ind2chr(string, i)
 
-
    Convert a byte index to a character index
 
 "),
 
 ("Strings","Base","chr2ind","chr2ind(string, i)
-
 
    Convert a character index to a byte index
 
@@ -1415,13 +1230,11 @@ replacement]) -> items
 
 ("Strings","Base","isvalid","isvalid(str, i)
 
-
    Tells whether index \"i\" is valid for the given string
 
 "),
 
 ("Strings","Base","nextind","nextind(str, i)
-
 
    Get the next valid string index after \"i\". Returns
    \"endof(str)+1\" at the end of the string.
@@ -1430,14 +1243,12 @@ replacement]) -> items
 
 ("Strings","Base","prevind","prevind(str, i)
 
-
    Get the previous valid string index before \"i\". Returns \"0\" at
    the beginning of the string.
 
 "),
 
 ("Strings","Base","thisind","thisind(str, i)
-
 
    Adjust \"i\" downwards until it reaches a valid index for the given
    string.
@@ -1446,7 +1257,6 @@ replacement]) -> items
 
 ("Strings","Base","randstring","randstring(len)
 
-
    Create a random ASCII string of length \"len\", consisting of
    upper- and lower-case letters and the digits 0-9
 
@@ -1454,13 +1264,11 @@ replacement]) -> items
 
 ("Strings","Base","charwidth","charwidth(c)
 
-
    Gives the number of columns needed to print a character.
 
 "),
 
 ("Strings","Base","strwidth","strwidth(s)
-
 
    Gives the number of columns needed to print a string.
 
@@ -1468,13 +1276,11 @@ replacement]) -> items
 
 ("Strings","Base","isalnum","isalnum(c::Char)
 
-
    Tests whether a character is alphanumeric.
 
 "),
 
 ("Strings","Base","isalpha","isalpha(c::Char)
-
 
    Tests whether a character is alphabetic.
 
@@ -1482,13 +1288,11 @@ replacement]) -> items
 
 ("Strings","Base","isascii","isascii(c::Char)
 
-
    Tests whether a character belongs to the ASCII character set.
 
 "),
 
 ("Strings","Base","isblank","isblank(c::Char)
-
 
    Tests whether a character is a tab or space.
 
@@ -1496,13 +1300,11 @@ replacement]) -> items
 
 ("Strings","Base","iscntrl","iscntrl(c::Char)
 
-
    Tests whether a character is a control character.
 
 "),
 
 ("Strings","Base","isdigit","isdigit(c::Char)
-
 
    Tests whether a character is a numeric digit (0-9).
 
@@ -1510,13 +1312,11 @@ replacement]) -> items
 
 ("Strings","Base","isgraph","isgraph(c::Char)
 
-
    Tests whether a character is printable, and not a space.
 
 "),
 
 ("Strings","Base","islower","islower(c::Char)
-
 
    Tests whether a character is a lowercase letter.
 
@@ -1524,13 +1324,11 @@ replacement]) -> items
 
 ("Strings","Base","isprint","isprint(c::Char)
 
-
    Tests whether a character is printable, including space.
 
 "),
 
 ("Strings","Base","ispunct","ispunct(c::Char)
-
 
    Tests whether a character is printable, and not a space or
    alphanumeric.
@@ -1539,13 +1337,11 @@ replacement]) -> items
 
 ("Strings","Base","isspace","isspace(c::Char)
 
-
    Tests whether a character is any whitespace character.
 
 "),
 
 ("Strings","Base","isupper","isupper(c::Char)
-
 
    Tests whether a character is an uppercase letter.
 
@@ -1553,13 +1349,11 @@ replacement]) -> items
 
 ("Strings","Base","isxdigit","isxdigit(c::Char)
 
-
    Tests whether a character is a valid hexadecimal digit.
 
 "),
 
 ("Strings","Base","symbol","symbol(str)
-
 
    Convert a string to a \"Symbol\".
 
@@ -1567,13 +1361,11 @@ replacement]) -> items
 
 ("I/O","Base","STDOUT","STDOUT
 
-
    Global variable referring to the standard out stream.
 
 "),
 
 ("I/O","Base","STDERR","STDERR
-
 
    Global variable referring to the standard error stream.
 
@@ -1581,22 +1373,18 @@ replacement]) -> items
 
 ("I/O","Base","STDIN","STDIN
 
-
    Global variable referring to the standard input stream.
 
 "),
 
 ("I/O","Base","OUTPUT_STREAM","OUTPUT_STREAM
 
-
    The default stream used for text output, e.g. in the \"print\" and
    \"show\" functions.
 
 "),
 
-("I/O","Base","open","open(file_name[, read, write, create, truncate,
-append]) -> IOStream
-
+("I/O","Base","open","open(file_name[, read, write, create, truncate, append]) -> IOStream
 
    Open a file in a mode specified by five boolean arguments. The
    default is to open files for reading only. Returns a stream for
@@ -1605,7 +1393,6 @@ append]) -> IOStream
 "),
 
 ("I/O","Base","open","open(file_name[, mode]) -> IOStream
-
 
    Alternate syntax for open, where a string-based mode specifier is
    used instead of the five booleans. The values of \"mode\"
@@ -1630,7 +1417,6 @@ append]) -> IOStream
 
 ("I/O","Base","open","open(f::function, args...)
 
-
    Apply the function \"f\" to the result of \"open(args...)\" and
    close the resulting file descriptor upon completion.
 
@@ -1640,14 +1426,12 @@ append]) -> IOStream
 
 ("I/O","Base","IOBuffer","IOBuffer([size]) -> IOBuffer
 
-
    Create an in-memory I/O stream, optionally specifying how much
    initial space is needed.
 
 "),
 
 ("I/O","Base","takebuf_array","takebuf_array(b::IOBuffer)
-
 
    Obtain the contents of an \"IOBuffer\" as an array, without
    copying.
@@ -1656,15 +1440,12 @@ append]) -> IOStream
 
 ("I/O","Base","takebuf_string","takebuf_string(b::IOBuffer)
 
-
    Obtain the contents of an \"IOBuffer\" as a string, without
    copying.
 
 "),
 
-("I/O","Base","fdio","fdio([name::String], fd::Integer[, own::Bool])
--> IOStream
-
+("I/O","Base","fdio","fdio([name::String], fd::Integer[, own::Bool]) -> IOStream
 
    Create an \"IOStream\" object from an integer file descriptor. If
    \"own\" is true, closing this object will close the underlying
@@ -1676,42 +1457,31 @@ append]) -> IOStream
 
 ("I/O","Base","flush","flush(stream)
 
-
    Commit all currently buffered writes to the given stream.
 
 "),
 
 ("I/O","Base","close","close(stream)
 
-
    Close an I/O stream. Performs a \"flush\" first.
 
 "),
 
-("I/O","Base","write","write(stream, x[, byteorder])
-
+("I/O","Base","write","write(stream, x)
 
    Write the canonical binary representation of a value to the given
-   stream. For numeric types, the optional argument specifies the byte
-   order or endianness: \"NetworkByteOrder\" for big-endian,
-   \"LittleByteOrder\" for little-endian, and \"HostByteOrder\" (the
-   default) for the type of the host.
+   stream.
 
 "),
 
-("I/O","Base","read","read(stream, type[, byteorder])
-
+("I/O","Base","read","read(stream, type)
 
    Read a value of the given type from a stream, in canonical binary
-   representation. For numeric types, the optional argument specifies
-   the byte order or endianness: \"NetworkByteOrder\" for big-endian,
-   \"LittleByteOrder\" for little-endian, and \"HostByteOrder\" (the
-   default) for the type of the host.
+   representation.
 
 "),
 
-("I/O","Base","read","read(stream, type[, byteorder], dims)
-
+("I/O","Base","read","read(stream, type, dims)
 
    Read a series of values of the given type from a stream, in
    canonical binary representation. \"dims\" is either a tuple or a
@@ -1722,13 +1492,11 @@ append]) -> IOStream
 
 ("I/O","Base","position","position(s)
 
-
    Get the current position of a stream.
 
 "),
 
 ("I/O","Base","seek","seek(s, pos)
-
 
    Seek a stream to the given position.
 
@@ -1736,13 +1504,11 @@ append]) -> IOStream
 
 ("I/O","Base","seekstart","seekstart(s)
 
-
    Seek a stream to its beginning.
 
 "),
 
 ("I/O","Base","seekend","seekend(s)
-
 
    Seek a stream to its end.
 
@@ -1750,13 +1516,11 @@ append]) -> IOStream
 
 ("I/O","Base","skip","skip(s, offset)
 
-
    Seek a stream relative to the current position.
 
 "),
 
 ("I/O","Base","eof","eof(stream)
-
 
    Tests whether an I/O stream is at end-of-file. If the stream is not
    yet exhausted, this function will block to wait for more data if
@@ -1767,14 +1531,12 @@ append]) -> IOStream
 
 ("I/O","Base","ntoh","ntoh(x)
 
-
    Converts the endianness of a value from Network byte order (big-
    endian) to that used by the Host.
 
 "),
 
 ("I/O","Base","hton","hton(x)
-
 
    Converts the endianness of a value from that used by the Host to
    Network byte order (big-endian).
@@ -1783,7 +1545,6 @@ append]) -> IOStream
 
 ("I/O","Base","ltoh","ltoh(x)
 
-
    Converts the endianness of a value from Little-endian to that used
    by the Host.
 
@@ -1791,14 +1552,12 @@ append]) -> IOStream
 
 ("I/O","Base","htol","htol(x)
 
-
    Converts the endianness of a value from that used by the Host to
    Little-endian.
 
 "),
 
 ("I/O","Base","serialize","serialize(stream, value)
-
 
    Write an arbitrary value to a stream in an opaque format, such that
    it can be read back by \"deserialize\". The read-back value will be
@@ -1811,13 +1570,11 @@ append]) -> IOStream
 
 ("I/O","Base","deserialize","deserialize(stream)
 
-
    Read a value written by \"serialize\".
 
 "),
 
 ("Network I/O","Base","connect","connect([host], port) -> TcpSocket
-
 
    Connect to the host \"host\" on port \"port\"
 
@@ -1825,13 +1582,11 @@ append]) -> IOStream
 
 ("Network I/O","Base","connect","connect(path) -> NamedPipe
 
-
    Connect to the Named Pipe/Domain Socket at \"path\"
 
 "),
 
 ("Network I/O","Base","listen","listen([addr], port) -> TcpServer
-
 
    Listen on port on the address specified by \"addr\". By default
    this listens on localhost only. To listen on all interfaces pass,
@@ -1841,20 +1596,17 @@ append]) -> IOStream
 
 ("Network I/O","Base","listen","listen(path) -> PipeServer
 
-
    Listens on/Creates a Named Pipe/Domain Socket
 
 "),
 
 ("Network I/O","Base","getaddrinfo","getaddrinfo(host)
 
-
    Gets the IP address of the \"host\" (may have to do a DNS lookup)
 
 "),
 
 ("Text I/O","Base","show","show(x)
-
 
    Write an informative text representation of a value to the current
    output stream. New types should overload \"show(io, x)\" where the
@@ -1864,7 +1616,6 @@ append]) -> IOStream
 
 ("Text I/O","Base","print","print(x)
 
-
    Write (to the default output stream) a canonical (un-decorated)
    text representation of a value if there is one, otherwise call
    \"show\".
@@ -1873,14 +1624,11 @@ append]) -> IOStream
 
 ("Text I/O","Base","println","println(x)
 
-
    Print (using \"print()\") \"x\" followed by a newline
 
 "),
 
-("Text I/O","Base","@printf","@printf([io::IOStream], \"%Fmt\",
-args...)
-
+("Text I/O","Base","@printf","@printf([io::IOStream], \"%Fmt\", args...)
 
    Print arg(s) using C \"printf()\" style format specification
    string. Optionally, an IOStream may be passed as the first argument
@@ -1890,20 +1638,17 @@ args...)
 
 ("Text I/O","Base","@sprintf","@sprintf(\"%Fmt\", args...)
 
-
    Return \"@printf\" formatted output as string.
 
 "),
 
 ("Text I/O","Base","showall","showall(x)
 
-
    Show x, printing all elements of arrays
 
 "),
 
 ("Text I/O","Base","dump","dump(x)
-
 
    Write a thorough text representation of a value to the current
    output stream.
@@ -1912,13 +1657,11 @@ args...)
 
 ("Text I/O","Base","readall","readall(stream)
 
-
    Read the entire contents of an I/O stream as a string.
 
 "),
 
 ("Text I/O","Base","readline","readline(stream)
-
 
    Read a single line of text, including a trailing newline character
    (if one is reached before the end of the input).
@@ -1927,13 +1670,11 @@ args...)
 
 ("Text I/O","Base","readuntil","readuntil(stream, delim)
 
-
    Read a string, up to and including the given delimiter byte.
 
 "),
 
 ("Text I/O","Base","readlines","readlines(stream)
-
 
    Read all lines as an array.
 
@@ -1941,14 +1682,11 @@ args...)
 
 ("Text I/O","Base","eachline","eachline(stream)
 
-
    Create an iterable object that will yield each line from a stream.
 
 "),
 
-("Text I/O","Base","readdlm","readdlm(source, delim::Char;
-has_header=false, use_mmap=false, ignore_invalid_chars=false)
-
+("Text I/O","Base","readdlm","readdlm(source, delim::Char; has_header=false, use_mmap=false, ignore_invalid_chars=false)
 
    Read a matrix from the source where each line gives one row, with
    elements separated by the given delimeter. The source can be a text
@@ -1973,9 +1711,7 @@ has_header=false, use_mmap=false, ignore_invalid_chars=false)
 
 "),
 
-("Text I/O","Base","readdlm","readdlm(source, delim::Char, T::Type;
-options...)
-
+("Text I/O","Base","readdlm","readdlm(source, delim::Char, T::Type; options...)
 
    Read a matrix from the source with a given element type. If \"T\"
    is a numeric type, the result is an array of that type, with any
@@ -1987,7 +1723,6 @@ options...)
 
 ("Text I/O","Base","writedlm","writedlm(filename, array, delim::Char)
 
-
    Write an array to a text file using the given delimeter (defaults
    to comma).
 
@@ -1995,21 +1730,17 @@ options...)
 
 ("Text I/O","Base","readcsv","readcsv(source, [T::Type]; options...)
 
-
    Equivalent to \"readdlm\" with \"delim\" set to comma.
 
 "),
 
 ("Text I/O","Base","writecsv","writecsv(filename, array)
 
-
    Equivalent to \"writedlm\" with \"delim\" set to comma.
 
 "),
 
-("Memory-mapped I/O","Base","mmap_array","mmap_array(type, dims,
-stream[, offset])
-
+("Memory-mapped I/O","Base","mmap_array","mmap_array(type, dims, stream[, offset])
 
    Create an \"Array\" whose values are linked to a file, using
    memory-mapping. This provides a convenient way of working with data
@@ -2032,9 +1763,7 @@ stream[, offset])
 
 "),
 
-("Memory-mapped I/O","Base","mmap_bitarray","mmap_bitarray([type],
-dims, stream[, offset])
-
+("Memory-mapped I/O","Base","mmap_bitarray","mmap_bitarray([type], dims, stream[, offset])
 
    Create a \"BitArray\" whose values are linked to a file, using
    memory-mapping; it has the same purpose, works in the same way, and
@@ -2051,7 +1780,6 @@ dims, stream[, offset])
 
 ("Memory-mapped I/O","Base","msync","msync(array)
 
-
    Forces synchronization between the in-memory version of a memory-
    mapped \"Array\" or \"BitArray\" and the on-disk version. You may
    not need to call this function, because synchronization is
@@ -2063,13 +1791,11 @@ dims, stream[, offset])
 
 ("Memory-mapped I/O","Base","mmap","mmap(len, prot, flags, fd, offset)
 
-
    Low-level interface to the mmap system call. See the man page.
 
 "),
 
 ("Memory-mapped I/O","Base","munmap","munmap(pointer, len)
-
 
    Low-level interface for unmapping memory (see the man page). With
    mmap_array you do not need to call this directly; the memory is
@@ -2079,13 +1805,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","-","-(x)
 
-
    Unary minus operator.
 
 "),
 
 ("Mathematical Functions","Base","+","+(x, y)
-
 
    Binary addition operator.
 
@@ -2093,13 +1817,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","-","-(x, y)
 
-
    Binary subtraction operator.
 
 "),
 
 ("Mathematical Functions","Base","*","*(x, y)
-
 
    Binary multiplication operator.
 
@@ -2107,13 +1829,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","/","/(x, y)
 
-
    Binary left-division operator.
 
 "),
 
 ("Mathematical Functions","Base","\\","\\(x, y)
-
 
    Binary right-division operator.
 
@@ -2121,13 +1841,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","^","^(x, y)
 
-
    Binary exponentiation operator.
 
 "),
 
 ("Mathematical Functions","Base",".+",".+(x, y)
-
 
    Element-wise binary addition operator.
 
@@ -2135,13 +1853,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base",".-",".-(x, y)
 
-
    Element-wise binary subtraction operator.
 
 "),
 
 ("Mathematical Functions","Base",".*",".*(x, y)
-
 
    Element-wise binary multiplication operator.
 
@@ -2149,13 +1865,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","./","./(x, y)
 
-
    Element-wise binary left division operator.
 
 "),
 
 ("Mathematical Functions","Base",".\\",".\\(x, y)
-
 
    Element-wise binary right division operator.
 
@@ -2163,13 +1877,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base",".^",".^(x, y)
 
-
    Element-wise binary exponentiation operator.
 
 "),
 
 ("Mathematical Functions","Base","div","div(a, b)
-
 
    Compute a/b, truncating to an integer
 
@@ -2177,13 +1889,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","fld","fld(a, b)
 
-
    Largest integer less than or equal to a/b
 
 "),
 
 ("Mathematical Functions","Base","mod","mod(x, m)
-
 
    Modulus after division, returning in the range [0,m)
 
@@ -2191,13 +1901,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","rem","rem(x, m)
 
-
    Remainder after division
 
 "),
 
 ("Mathematical Functions","Base","%","%(x, m)
-
 
    Remainder after division. The operator form of \"rem\".
 
@@ -2205,13 +1913,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","mod1","mod1(x, m)
 
-
    Modulus after division, returning in the range (0,m]
 
 "),
 
 ("Mathematical Functions","Base","//","//(num, den)
-
 
    Rational division
 
@@ -2219,13 +1925,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","num","num(x)
 
-
    Numerator of the rational representation of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","den","den(x)
-
 
    Denominator of the rational representation of \"x\"
 
@@ -2233,13 +1937,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","<<","<<(x, n)
 
-
    Left shift operator.
 
 "),
 
 ("Mathematical Functions","Base",">>",">>(x, n)
-
 
    Right shift operator.
 
@@ -2247,13 +1949,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base",">>>",">>>(x, n)
 
-
    Unsigned right shift operator.
 
 "),
 
 ("Mathematical Functions","Base",":",":(start[, step], stop)
-
 
    Range operator. \"a:b\" constructs a range from \"a\" to \"b\" with
    a step size of 1, and \"a:s:b\" is similar but uses a step size of
@@ -2264,13 +1964,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","colon","colon(start[, step], stop)
 
-
    Called by \":\" syntax for constructing ranges.
 
 "),
 
 ("Mathematical Functions","Base","==","==(x, y)
-
 
    Equality comparison operator.
 
@@ -2278,13 +1976,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","!=","!=(x, y)
 
-
    Not-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base","<","<(x, y)
-
 
    Less-than comparison operator.
 
@@ -2292,13 +1988,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","<=","<=(x, y)
 
-
    Less-than-or-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base",">",">(x, y)
-
 
    Greater-than comparison operator.
 
@@ -2306,13 +2000,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base",">=",">=(x, y)
 
-
    Greater-than-or-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base",".==",".==(x, y)
-
 
    Element-wise equality comparison operator.
 
@@ -2320,13 +2012,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base",".!=",".!=(x, y)
 
-
    Element-wise not-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base",".<",".<(x, y)
-
 
    Element-wise less-than comparison operator.
 
@@ -2334,13 +2024,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base",".<=",".<=(x, y)
 
-
    Element-wise less-than-or-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base",".>",".>(x, y)
-
 
    Element-wise greater-than comparison operator.
 
@@ -2348,13 +2036,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base",".>=",".>=(x, y)
 
-
    Element-wise greater-than-or-equals comparison operator.
 
 "),
 
 ("Mathematical Functions","Base","cmp","cmp(x, y)
-
 
    Return -1, 0, or 1 depending on whether \"x<y\", \"x==y\", or
    \"x>y\", respectively
@@ -2363,13 +2049,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","!","!(x)
 
-
    Boolean not
 
 "),
 
 ("Mathematical Functions","Base","~","~(x)
-
 
    Bitwise not
 
@@ -2377,13 +2061,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","&","&(x, y)
 
-
    Bitwise and
 
 "),
 
 ("Mathematical Functions","Base","|","|(x, y)
-
 
    Bitwise or
 
@@ -2391,14 +2073,11 @@ dims, stream[, offset])
 
 ("Mathematical Functions","Base","\$","\$(x, y)
 
-
    Bitwise exclusive or
 
 "),
 
-("Mathematical Functions","Base","isapprox","isapprox(x::Number,
-y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
-
+("Mathematical Functions","Base","isapprox","isapprox(x::Number, y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
    Inexact equality comparison - behaves slightly different depending
    on types of input args:
@@ -2421,13 +2100,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","sin","sin(x)
 
-
    Compute sine of \"x\", where \"x\" is in radians
 
 "),
 
 ("Mathematical Functions","Base","cos","cos(x)
-
 
    Compute cosine of \"x\", where \"x\" is in radians
 
@@ -2435,13 +2112,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","tan","tan(x)
 
-
    Compute tangent of \"x\", where \"x\" is in radians
 
 "),
 
 ("Mathematical Functions","Base","sind","sind(x)
-
 
    Compute sine of \"x\", where \"x\" is in degrees
 
@@ -2449,13 +2124,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","cosd","cosd(x)
 
-
    Compute cosine of \"x\", where \"x\" is in degrees
 
 "),
 
 ("Mathematical Functions","Base","tand","tand(x)
-
 
    Compute tangent of \"x\", where \"x\" is in degrees
 
@@ -2463,13 +2136,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","sinh","sinh(x)
 
-
    Compute hyperbolic sine of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","cosh","cosh(x)
-
 
    Compute hyperbolic cosine of \"x\"
 
@@ -2477,13 +2148,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","tanh","tanh(x)
 
-
    Compute hyperbolic tangent of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","asin","asin(x)
-
 
    Compute the inverse sine of \"x\", where the output is in radians
 
@@ -2491,13 +2160,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","acos","acos(x)
 
-
    Compute the inverse cosine of \"x\", where the output is in radians
 
 "),
 
 ("Mathematical Functions","Base","atan","atan(x)
-
 
    Compute the inverse tangent of \"x\", where the output is in
    radians
@@ -2506,7 +2173,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","atan2","atan2(y, x)
 
-
    Compute the inverse tangent of \"y/x\", using the signs of both
    \"x\" and \"y\" to determine the quadrant of the return value.
 
@@ -2514,20 +2180,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","asind","asind(x)
 
-
    Compute the inverse sine of \"x\", where the output is in degrees
 
 "),
 
 ("Mathematical Functions","Base","acosd","acosd(x)
 
-
    Compute the inverse cosine of \"x\", where the output is in degrees
 
 "),
 
 ("Mathematical Functions","Base","atand","atand(x)
-
 
    Compute the inverse tangent of \"x\", where the output is in
    degrees
@@ -2536,13 +2199,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","sec","sec(x)
 
-
    Compute the secant of \"x\", where \"x\" is in radians
 
 "),
 
 ("Mathematical Functions","Base","csc","csc(x)
-
 
    Compute the cosecant of \"x\", where \"x\" is in radians
 
@@ -2550,13 +2211,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","cot","cot(x)
 
-
    Compute the cotangent of \"x\", where \"x\" is in radians
 
 "),
 
 ("Mathematical Functions","Base","secd","secd(x)
-
 
    Compute the secant of \"x\", where \"x\" is in degrees
 
@@ -2564,13 +2223,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","cscd","cscd(x)
 
-
    Compute the cosecant of \"x\", where \"x\" is in degrees
 
 "),
 
 ("Mathematical Functions","Base","cotd","cotd(x)
-
 
    Compute the cotangent of \"x\", where \"x\" is in degrees
 
@@ -2578,13 +2235,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","asec","asec(x)
 
-
    Compute the inverse secant of \"x\", where the output is in radians
 
 "),
 
 ("Mathematical Functions","Base","acsc","acsc(x)
-
 
    Compute the inverse cosecant of \"x\", where the output is in
    radians
@@ -2593,7 +2248,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","acot","acot(x)
 
-
    Compute the inverse cotangent of \"x\", where the output is in
    radians
 
@@ -2601,13 +2255,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","asecd","asecd(x)
 
-
    Compute the inverse secant of \"x\", where the output is in degrees
 
 "),
 
 ("Mathematical Functions","Base","acscd","acscd(x)
-
 
    Compute the inverse cosecant of \"x\", where the output is in
    degrees
@@ -2616,7 +2268,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","acotd","acotd(x)
 
-
    Compute the inverse cotangent of \"x\", where the output is in
    degrees
 
@@ -2624,13 +2275,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","sech","sech(x)
 
-
    Compute the hyperbolic secant of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","csch","csch(x)
-
 
    Compute the hyperbolic cosecant of \"x\"
 
@@ -2638,13 +2287,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","coth","coth(x)
 
-
    Compute the hyperbolic cotangent of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","asinh","asinh(x)
-
 
    Compute the inverse hyperbolic sine of \"x\"
 
@@ -2652,13 +2299,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","acosh","acosh(x)
 
-
    Compute the inverse hyperbolic cosine of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","atanh","atanh(x)
-
 
    Compute the inverse hyperbolic cotangent of \"x\"
 
@@ -2666,13 +2311,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","asech","asech(x)
 
-
    Compute the inverse hyperbolic secant of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","acsch","acsch(x)
-
 
    Compute the inverse hyperbolic cosecant of \"x\"
 
@@ -2680,20 +2323,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","acoth","acoth(x)
 
-
    Compute the inverse hyperbolic cotangent of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","sinc","sinc(x)
 
-
    Compute \\sin(\\pi x) / (\\pi x) if x \\neq 0, and 1 if x = 0.
 
 "),
 
 ("Mathematical Functions","Base","cosc","cosc(x)
-
 
    Compute \\cos(\\pi x) / x - \\sin(\\pi x) / (\\pi x^2) if x \\neq
    0, and 0 if x = 0. This is the derivative of \"sinc(x)\".
@@ -2702,13 +2342,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","degrees2radians","degrees2radians(x)
 
-
    Convert \"x\" from degrees to radians
 
 "),
 
 ("Mathematical Functions","Base","radians2degrees","radians2degrees(x)
-
 
    Convert \"x\" from radians to degrees
 
@@ -2716,13 +2354,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","hypot","hypot(x, y)
 
-
    Compute the \\sqrt{x^2+y^2} without undue overflow or underflow
 
 "),
 
 ("Mathematical Functions","Base","log","log(x)
-
 
    Compute the natural logarithm of \"x\"
 
@@ -2730,13 +2366,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","log2","log2(x)
 
-
    Compute the natural logarithm of \"x\" to base 2
 
 "),
 
 ("Mathematical Functions","Base","log10","log10(x)
-
 
    Compute the natural logarithm of \"x\" to base 10
 
@@ -2744,13 +2378,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","log1p","log1p(x)
 
-
    Accurate natural logarithm of \"1+x\"
 
 "),
 
 ("Mathematical Functions","Base","frexp","frexp(val, exp)
-
 
    Return a number \"x\" such that it has a magnitude in the interval
    \"[1/2, 1)\" or 0, and val = x \\times 2^{exp}.
@@ -2759,13 +2391,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","exp","exp(x)
 
-
    Compute e^x
 
 "),
 
 ("Mathematical Functions","Base","exp2","exp2(x)
-
 
    Compute 2^x
 
@@ -2773,20 +2403,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","exp10","exp10(x)
 
-
    Compute 10^x
 
 "),
 
 ("Mathematical Functions","Base","ldexp","ldexp(x, n)
 
-
    Compute x \\times 2^n
 
 "),
 
 ("Mathematical Functions","Base","modf","modf(x)
-
 
    Return a tuple (fpart,ipart) of the fractional and integral parts
    of a number. Both parts have the same sign as the argument.
@@ -2795,20 +2422,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","expm1","expm1(x)
 
-
    Accurately compute e^x-1
 
 "),
 
 ("Mathematical Functions","Base","square","square(x)
 
-
    Compute x^2
 
 "),
 
 ("Mathematical Functions","Base","round","round(x[, digits[, base]])
-
 
    \"round(x)\" returns the nearest integral value of the same type as
    \"x\" to \"x\". \"round(x, digits)\" rounds to the specified number
@@ -2821,7 +2445,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","ceil","ceil(x[, digits[, base]])
 
-
    Returns the nearest integral value of the same type as \"x\" not
    less than \"x\". \"digits\" and \"base\" work as above.
 
@@ -2829,14 +2452,12 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","floor","floor(x[, digits[, base]])
 
-
    Returns the nearest integral value of the same type as \"x\" not
    greater than \"x\". \"digits\" and \"base\" work as above.
 
 "),
 
 ("Mathematical Functions","Base","trunc","trunc(x[, digits[, base]])
-
 
    Returns the nearest integral value of the same type as \"x\" not
    greater in magnitude than \"x\". \"digits\" and \"base\" work as
@@ -2846,13 +2467,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","iround","iround(x) -> Integer
 
-
    Returns the nearest integer to \"x\".
 
 "),
 
 ("Mathematical Functions","Base","iceil","iceil(x) -> Integer
-
 
    Returns the nearest integer not less than \"x\".
 
@@ -2860,20 +2479,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","ifloor","ifloor(x) -> Integer
 
-
    Returns the nearest integer not greater than \"x\".
 
 "),
 
 ("Mathematical Functions","Base","itrunc","itrunc(x) -> Integer
 
-
    Returns the nearest integer not greater in magnitude than \"x\".
 
 "),
 
 ("Mathematical Functions","Base","signif","signif(x, digits[, base])
-
 
    Rounds (in the sense of \"round\") \"x\" so that there are
    \"digits\" significant digits, under a base \"base\"
@@ -2884,20 +2500,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","min","min(x, y)
 
-
    Return the minimum of \"x\" and \"y\"
 
 "),
 
 ("Mathematical Functions","Base","max","max(x, y)
 
-
    Return the maximum of \"x\" and \"y\"
 
 "),
 
 ("Mathematical Functions","Base","clamp","clamp(x, lo, hi)
-
 
    Return x if \"lo <= x <= y\". If \"x < lo\", return \"lo\". If \"x
    > hi\", return \"hi\".
@@ -2906,13 +2519,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","abs","abs(x)
 
-
    Absolute value of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","abs2","abs2(x)
-
 
    Squared absolute value of \"x\"
 
@@ -2920,13 +2531,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","copysign","copysign(x, y)
 
-
    Return \"x\" such that it has the same sign as \"y\"
 
 "),
 
 ("Mathematical Functions","Base","sign","sign(x)
-
 
    Return \"+1\" if \"x\" is positive, \"0\" if \"x == 0\", and \"-1\"
    if \"x\" is negative.
@@ -2935,14 +2544,12 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","signbit","signbit(x)
 
-
    Returns \"1\" if the value of the sign of \"x\" is negative,
    otherwise \"0\".
 
 "),
 
 ("Mathematical Functions","Base","flipsign","flipsign(x, y)
-
 
    Return \"x\" with its sign flipped if \"y\" is negative. For
    example \"abs(x) = flipsign(x,x)\".
@@ -2951,13 +2558,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","sqrt","sqrt(x)
 
-
    Return \\sqrt{x}
 
 "),
 
 ("Mathematical Functions","Base","isqrt","isqrt(x)
-
 
    Integer square root.
 
@@ -2965,13 +2570,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","cbrt","cbrt(x)
 
-
    Return x^{1/3}
 
 "),
 
 ("Mathematical Functions","Base","erf","erf(x)
-
 
    Compute the error function of \"x\", defined by
    \\frac{2}{\\sqrt{\\pi}} \\int_0^x e^{-t^2} dt for arbitrary complex
@@ -2981,14 +2584,12 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","erfc","erfc(x)
 
-
    Compute the complementary error function of \"x\", defined by 1 -
    \\operatorname{erf}(x).
 
 "),
 
 ("Mathematical Functions","Base","erfcx","erfcx(x)
-
 
    Compute the scaled complementary error function of \"x\", defined
    by e^{x^2} \\operatorname{erfc}(x).  Note also that
@@ -2998,14 +2599,12 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","erfi","erfi(x)
 
-
    Compute the imaginary error function of \"x\", defined by -i
    \\operatorname{erf}(ix).
 
 "),
 
 ("Mathematical Functions","Base","dawson","dawson(x)
-
 
    Compute the Dawson function (scaled imaginary error function) of
    \"x\", defined by \\frac{\\sqrt{\\pi}}{2} e^{-x^2}
@@ -3015,14 +2614,12 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","erfinv","erfinv(x)
 
-
    Compute the inverse error function of a real \"x\", defined by
    \\operatorname{erf}(\\operatorname{erfinv}(x)) = x.
 
 "),
 
 ("Mathematical Functions","Base","erfcinv","erfcinv(x)
-
 
    Compute the inverse error complementary function of a real \"x\",
    defined by \\operatorname{erfc}(\\operatorname{erfcinv}(x)) = x.
@@ -3031,20 +2628,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","real","real(z)
 
-
    Return the real part of the complex number \"z\"
 
 "),
 
 ("Mathematical Functions","Base","imag","imag(z)
 
-
    Return the imaginary part of the complex number \"z\"
 
 "),
 
 ("Mathematical Functions","Base","reim","reim(z)
-
 
    Return both the real and imaginary parts of the complex number
    \"z\"
@@ -3053,20 +2647,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","conj","conj(z)
 
-
    Compute the complex conjugate of a complex number \"z\"
 
 "),
 
 ("Mathematical Functions","Base","angle","angle(z)
 
-
    Compute the phase angle of a complex number \"z\"
 
 "),
 
 ("Mathematical Functions","Base","cis","cis(z)
-
 
    Return \"cos(z) + i*sin(z)\" if z is real. Return \"(cos(real(z)) +
    i*sin(real(z)))/exp(imag(z))\" if \"z\" is complex
@@ -3075,13 +2666,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","binomial","binomial(n, k)
 
-
    Number of ways to choose \"k\" out of \"n\" items
 
 "),
 
 ("Mathematical Functions","Base","factorial","factorial(n)
-
 
    Factorial of n
 
@@ -3089,13 +2678,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","factorial","factorial(n, k)
 
-
    Compute \"factorial(n)/factorial(k)\"
 
 "),
 
 ("Mathematical Functions","Base","factor","factor(n)
-
 
    Compute the prime factorization of an integer \"n\". Returns a
    dictionary. The keys of the dictionary correspond to the factors,
@@ -3109,20 +2696,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","gcd","gcd(x, y)
 
-
    Greatest common divisor
 
 "),
 
 ("Mathematical Functions","Base","lcm","lcm(x, y)
 
-
    Least common multiple
 
 "),
 
 ("Mathematical Functions","Base","gcdx","gcdx(x, y)
-
 
    Greatest common divisor, also returning integer coefficients \"u\"
    and \"v\" that solve \"ux+vy == gcd(x,y)\"
@@ -3131,13 +2715,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","ispow2","ispow2(n)
 
-
    Test whether \"n\" is a power of two
 
 "),
 
 ("Mathematical Functions","Base","nextpow2","nextpow2(n)
-
 
    Next power of two not less than \"n\"
 
@@ -3145,13 +2727,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","prevpow2","prevpow2(n)
 
-
    Previous power of two not greater than \"n\"
 
 "),
 
 ("Mathematical Functions","Base","nextpow","nextpow(a, n)
-
 
    Next power of \"a\" not less than \"n\"
 
@@ -3159,13 +2739,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","prevpow","prevpow(a, n)
 
-
    Previous power of \"a\" not greater than \"n\"
 
 "),
 
 ("Mathematical Functions","Base","nextprod","nextprod([a, b, c], n)
-
 
    Next integer not less than \"n\" that can be written \"a^i1 * b^i2
    * c^i3\" for integers \"i1\", \"i2\", \"i3\".
@@ -3174,7 +2752,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","prevprod","prevprod([a, b, c], n)
 
-
    Previous integer not greater than \"n\" that can be written \"a^i1
    * b^i2 * c^i3\" for integers \"i1\", \"i2\", \"i3\".
 
@@ -3182,13 +2759,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","invmod","invmod(x, m)
 
-
    Inverse of \"x\", modulo \"m\"
 
 "),
 
 ("Mathematical Functions","Base","powermod","powermod(x, p, m)
-
 
    Compute \"mod(x^p, m)\"
 
@@ -3196,13 +2771,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","gamma","gamma(x)
 
-
    Compute the gamma function of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","lgamma","lgamma(x)
-
 
    Compute the logarithm of absolute value of \"gamma(x)\"
 
@@ -3210,13 +2783,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","lfact","lfact(x)
 
-
    Compute the logarithmic factorial of \"x\"
 
 "),
 
 ("Mathematical Functions","Base","digamma","digamma(x)
-
 
    Compute the digamma function of \"x\" (the logarithmic derivative
    of \"gamma(x)\")
@@ -3225,13 +2796,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","airy","airy(k, x)
 
-
    kth derivative of the Airy function \\operatorname{Ai}(x).
 
 "),
 
 ("Mathematical Functions","Base","airyai","airyai(x)
-
 
    Airy function \\operatorname{Ai}(x).
 
@@ -3239,13 +2808,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","airyprime","airyprime(x)
 
-
    Airy function derivative \\operatorname{Ai}'(x).
 
 "),
 
 ("Mathematical Functions","Base","airyaiprime","airyaiprime(x)
-
 
    Airy function derivative \\operatorname{Ai}'(x).
 
@@ -3253,13 +2820,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","airybi","airybi(x)
 
-
    Airy function \\operatorname{Bi}(x).
 
 "),
 
 ("Mathematical Functions","Base","airybiprime","airybiprime(x)
-
 
    Airy function derivative \\operatorname{Bi}'(x).
 
@@ -3267,13 +2832,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","besselj0","besselj0(x)
 
-
    Bessel function of the first kind of order 0, J_0(x).
 
 "),
 
 ("Mathematical Functions","Base","besselj1","besselj1(x)
-
 
    Bessel function of the first kind of order 1, J_1(x).
 
@@ -3281,13 +2844,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","besselj","besselj(nu, x)
 
-
    Bessel function of the first kind of order \"nu\", J_\\nu(x).
 
 "),
 
 ("Mathematical Functions","Base","bessely0","bessely0(x)
-
 
    Bessel function of the second kind of order 0, Y_0(x).
 
@@ -3295,13 +2856,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","bessely1","bessely1(x)
 
-
    Bessel function of the second kind of order 1, Y_1(x).
 
 "),
 
 ("Mathematical Functions","Base","bessely","bessely(nu, x)
-
 
    Bessel function of the second kind of order \"nu\", Y_\\nu(x).
 
@@ -3309,20 +2868,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","hankelh1","hankelh1(nu, x)
 
-
    Bessel function of the third kind of order \"nu\", H^{(1)}_\\nu(x).
 
 "),
 
 ("Mathematical Functions","Base","hankelh2","hankelh2(nu, x)
 
-
    Bessel function of the third kind of order \"nu\", H^{(2)}_\\nu(x).
 
 "),
 
 ("Mathematical Functions","Base","besseli","besseli(nu, x)
-
 
    Modified Bessel function of the first kind of order \"nu\",
    I_\\nu(x).
@@ -3331,14 +2887,12 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","besselk","besselk(nu, x)
 
-
    Modified Bessel function of the second kind of order \"nu\",
    K_\\nu(x).
 
 "),
 
 ("Mathematical Functions","Base","beta","beta(x, y)
-
 
    Euler integral of the first kind \\operatorname{B}(x,y) =
    \\Gamma(x)\\Gamma(y)/\\Gamma(x+y).
@@ -3347,14 +2901,12 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","lbeta","lbeta(x, y)
 
-
    Natural logarithm of the absolute value of the beta function
    \\log(|\\operatorname{B}(x,y)|).
 
 "),
 
 ("Mathematical Functions","Base","eta","eta(x)
-
 
    Dirichlet eta function \\eta(s) =
    \\sum^\\infty_{n=1}(-)^{n-1}/n^{s}.
@@ -3363,13 +2915,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","zeta","zeta(x)
 
-
    Riemann zeta function \\zeta(s).
 
 "),
 
 ("Mathematical Functions","Base","bitmix","bitmix(x, y)
-
 
    Hash two integers into a single integer. Useful for constructing
    hash functions.
@@ -3378,13 +2928,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Mathematical Functions","Base","ndigits","ndigits(n, b)
 
-
    Compute the number of digits in number \"n\" written in base \"b\".
 
 "),
 
 ("Data Formats","Base","bin","bin(n[, pad])
-
 
    Convert an integer to a binary string, optionally specifying a
    number of digits to pad to.
@@ -3393,14 +2941,12 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","hex","hex(n[, pad])
 
-
    Convert an integer to a hexadecimal string, optionally specifying a
    number of digits to pad to.
 
 "),
 
 ("Data Formats","Base","dec","dec(n[, pad])
-
 
    Convert an integer to a decimal string, optionally specifying a
    number of digits to pad to.
@@ -3409,14 +2955,12 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","oct","oct(n[, pad])
 
-
    Convert an integer to an octal string, optionally specifying a
    number of digits to pad to.
 
 "),
 
 ("Data Formats","Base","base","base(base, n[, pad])
-
 
    Convert an integer to a string in the given base, optionally
    specifying a number of digits to pad to. The base can be specified
@@ -3427,13 +2971,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","bits","bits(n)
 
-
    A string giving the literal bit representation of a number.
 
 "),
 
 ("Data Formats","Base","parseint","parseint([type], str[, base])
-
 
    Parse a string as an integer in the given base (default 10),
    yielding a number of the specified type (default \"Int\").
@@ -3442,7 +2984,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","parsefloat","parsefloat([type], str)
 
-
    Parse a string as a decimal floating point number, yielding a
    number of the specified type.
 
@@ -3450,13 +2991,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","bool","bool(x)
 
-
    Convert a number or numeric array to boolean
 
 "),
 
 ("Data Formats","Base","int","int(x)
-
 
    Convert a number or array to the default integer type on your
    platform. Alternatively, \"x\" can be a string, which is parsed as
@@ -3466,7 +3005,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","uint","uint(x)
 
-
    Convert a number or array to the default unsigned integer type on
    your platform. Alternatively, \"x\" can be a string, which is
    parsed as an unsigned integer.
@@ -3474,7 +3012,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 "),
 
 ("Data Formats","Base","integer","integer(x)
-
 
    Convert a number or array to integer type. If \"x\" is already of
    integer type it is unchanged, otherwise it converts it to the
@@ -3484,13 +3021,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","signed","signed(x)
 
-
    Convert a number to a signed integer
 
 "),
 
 ("Data Formats","Base","unsigned","unsigned(x)
-
 
    Convert a number to an unsigned integer
 
@@ -3498,13 +3033,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","int8","int8(x)
 
-
    Convert a number or array to \"Int8\" data type
 
 "),
 
 ("Data Formats","Base","int16","int16(x)
-
 
    Convert a number or array to \"Int16\" data type
 
@@ -3512,13 +3045,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","int32","int32(x)
 
-
    Convert a number or array to \"Int32\" data type
 
 "),
 
 ("Data Formats","Base","int64","int64(x)
-
 
    Convert a number or array to \"Int64\" data type
 
@@ -3526,13 +3057,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","int128","int128(x)
 
-
    Convert a number or array to \"Int128\" data type
 
 "),
 
 ("Data Formats","Base","uint8","uint8(x)
-
 
    Convert a number or array to \"Uint8\" data type
 
@@ -3540,13 +3069,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","uint16","uint16(x)
 
-
    Convert a number or array to \"Uint16\" data type
 
 "),
 
 ("Data Formats","Base","uint32","uint32(x)
-
 
    Convert a number or array to \"Uint32\" data type
 
@@ -3554,13 +3081,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","uint64","uint64(x)
 
-
    Convert a number or array to \"Uint64\" data type
 
 "),
 
 ("Data Formats","Base","uint128","uint128(x)
-
 
    Convert a number or array to \"Uint128\" data type
 
@@ -3568,20 +3093,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","float32","float32(x)
 
-
    Convert a number or array to \"Float32\" data type
 
 "),
 
 ("Data Formats","Base","float64","float64(x)
 
-
    Convert a number or array to \"Float64\" data type
 
 "),
 
 ("Data Formats","Base","float","float(x)
-
 
    Convert a number, array, or string to a \"FloatingPoint\" data
    type. For numeric data, the smallest suitable \"FloatingPoint\"
@@ -3590,7 +3112,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 "),
 
 ("Data Formats","Base","significand","significand(x)
-
 
    Extract the significand(s) (a.k.a. mantissa), in binary
    representation, of a floating-point number or array.
@@ -3602,13 +3123,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","exponent","exponent(x) -> Int
 
-
    Get the exponent of a normalized floating-point number.
 
 "),
 
 ("Data Formats","Base","isfloat64","isfloat64(x::Rational)
-
 
    Tests whether \"x\" or all its elements can be losslessly
    represented as a \"Float64\" data type
@@ -3617,13 +3136,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","complex64","complex64(r, i)
 
-
    Convert to \"r+i*im\" represented as a \"Complex64\" data type
 
 "),
 
 ("Data Formats","Base","complex128","complex128(r, i)
-
 
    Convert to \"r+i*im\" represented as a \"Complex128\" data type
 
@@ -3631,13 +3148,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","char","char(x)
 
-
    Convert a number or array to \"Char\" data type
 
 "),
 
 ("Data Formats","Base","complex","complex(r, i)
-
 
    Convert real numbers or arrays to complex
 
@@ -3645,13 +3160,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","bswap","bswap(n)
 
-
    Byte-swap an integer
 
 "),
 
 ("Data Formats","Base","num2hex","num2hex(f)
-
 
    Get a hexadecimal string of the binary representation of a floating
    point number
@@ -3660,7 +3173,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","hex2num","hex2num(str)
 
-
    Convert a hexadecimal string to the floating point number it
    represents
 
@@ -3668,15 +3180,12 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Data Formats","Base","hex2bytes","hex2bytes(s::ASCIIString)
 
-
    Convert an arbitrarily long hexadecimal string to its binary
    representation. Returns an Array{Uint8, 1}, i.e. an array of bytes.
 
 "),
 
-("Data Formats","Base","bytes2hex","bytes2hex(bin_arr::Array{Uint8,
-1})
-
+("Data Formats","Base","bytes2hex","bytes2hex(bin_arr::Array{Uint8, 1})
 
    Convert an array of bytes to its hexadecimal representation. All
    characters are in lower-case. Returns an ASCIIString.
@@ -3684,7 +3193,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 "),
 
 ("Numbers","Base","one","one(x)
-
 
    Get the multiplicative identity element for the type of x (x can
    also specify the type itself). For matrices, returns an identity
@@ -3694,7 +3202,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","zero","zero(x)
 
-
    Get the additive identity element for the type of x (x can also
    specify the type itself).
 
@@ -3702,13 +3209,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","pi","pi
 
-
    The constant pi
 
 "),
 
 ("Numbers","Base","im","im
-
 
    The imaginary unit
 
@@ -3716,13 +3221,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","e","e
 
-
    The constant e
 
 "),
 
 ("Numbers","Base","Inf","Inf
-
 
    Positive infinity of type Float64
 
@@ -3730,13 +3233,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","Inf32","Inf32
 
-
    Positive infinity of type Float32
 
 "),
 
 ("Numbers","Base","NaN","NaN
-
 
    A not-a-number value of type Float64
 
@@ -3744,13 +3245,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","NaN32","NaN32
 
-
    A not-a-number value of type Float32
 
 "),
 
 ("Numbers","Base","issubnormal","issubnormal(f) -> Bool
-
 
    Test whether a floating point number is subnormal
 
@@ -3758,13 +3257,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","isfinite","isfinite(f) -> Bool
 
-
    Test whether a number is finite
 
 "),
 
 ("Numbers","Base","isinf","isinf(f)
-
 
    Test whether a number is infinite
 
@@ -3772,13 +3269,11 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","isnan","isnan(f)
 
-
    Test whether a floating point number is not a number (NaN)
 
 "),
 
 ("Numbers","Base","inf","inf(f)
-
 
    Returns infinity in the same floating point type as \"f\" (or \"f\"
    can by the type itself)
@@ -3787,7 +3282,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","nan","nan(f)
 
-
    Returns NaN in the same floating point type as \"f\" (or \"f\" can
    by the type itself)
 
@@ -3795,20 +3289,17 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","nextfloat","nextfloat(f)
 
-
    Get the next floating point number in lexicographic order
 
 "),
 
 ("Numbers","Base","prevfloat","prevfloat(f) -> Float
 
-
    Get the previous floating point number in lexicographic order
 
 "),
 
 ("Numbers","Base","isinteger","isinteger(x)
-
 
    Test whether \"x\" or all its elements are numerically equal to
    some integer
@@ -3817,14 +3308,12 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","isreal","isreal(x)
 
-
    Test whether \"x\" or all its elements are numerically equal to
    some real number
 
 "),
 
 ("Numbers","Base","BigInt","BigInt(x)
-
 
    Create an arbitrary precision integer. \"x\" may be an \"Int\" (or
    anything that can be converted to an \"Int\") or a \"String\". The
@@ -3835,7 +3324,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","BigFloat","BigFloat(x)
 
-
    Create an arbitrary precision floating point number. \"x\" may be
    an \"Integer\", a \"Float64\", a \"String\" or a \"BigInt\". The
    usual mathematical operators are defined for this type, and results
@@ -3845,7 +3333,6 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","count_ones","count_ones(x::Integer) -> Integer
 
-
    Number of ones in the binary representation of \"x\".
 
    **Example**: \"count_ones(7) -> 3\"
@@ -3854,16 +3341,13 @@ y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
 
 ("Numbers","Base","count_zeros","count_zeros(x::Integer) -> Integer
 
-
    Number of zeros in the binary representation of \"x\".
 
    **Example**: \"count_zeros(int32(2 ^ 16 - 1)) -> 16\"
 
 "),
 
-("Numbers","Base","leading_zeros","leading_zeros(x::Integer) ->
-Integer
-
+("Numbers","Base","leading_zeros","leading_zeros(x::Integer) -> Integer
 
    Number of zeros leading the binary representation of \"x\".
 
@@ -3873,16 +3357,13 @@ Integer
 
 ("Numbers","Base","leading_ones","leading_ones(x::Integer) -> Integer
 
-
    Number of ones leading the binary representation of \"x\".
 
    **Example**: \"leading_ones(int32(2 ^ 32 - 2)) -> 31\"
 
 "),
 
-("Numbers","Base","trailing_zeros","trailing_zeros(x::Integer) ->
-Integer
-
+("Numbers","Base","trailing_zeros","trailing_zeros(x::Integer) -> Integer
 
    Number of zeros trailing the binary representation of \"x\".
 
@@ -3890,9 +3371,7 @@ Integer
 
 "),
 
-("Numbers","Base","trailing_ones","trailing_ones(x::Integer) ->
-Integer
-
+("Numbers","Base","trailing_ones","trailing_ones(x::Integer) -> Integer
 
    Number of ones trailing the binary representation of \"x\".
 
@@ -3902,7 +3381,6 @@ Integer
 
 ("Numbers","Base","isprime","isprime(x::Integer) -> Bool
 
-
    Returns \"true\" if \"x\" is prime, and \"false\" otherwise.
 
    **Example**: \"isprime(3) -> true\"
@@ -3911,13 +3389,11 @@ Integer
 
 ("Numbers","Base","primes","primes(n)
 
-
    Returns a collection of the prime numbers <= \"n\".
 
 "),
 
 ("Numbers","Base","isodd","isodd(x::Integer) -> Bool
-
 
    Returns \"true\" if \"x\" is odd (that is, not divisible by 2), and
    \"false\" otherwise.
@@ -3928,7 +3404,6 @@ Integer
 
 ("Numbers","Base","iseven","iseven(x::Integer) -> Bool
 
-
    Returns \"true\" is \"x\" is even (that is, divisible by 2), and
    \"false\" otherwise.
 
@@ -3937,7 +3412,6 @@ Integer
 "),
 
 ("Random Numbers","Base","srand","srand([rng], seed)
-
 
    Seed the RNG with a \"seed\", which may be an unsigned integer or a
    vector of unsigned integers. \"seed\" can even be a filename, in
@@ -3948,7 +3422,6 @@ Integer
 
 ("Random Numbers","Base","MersenneTwister","MersenneTwister([seed])
 
-
    Create a \"MersenneTwister\" RNG object. Different RNG objects can
    have their own seeds, which may be useful for generating different
    streams of random numbers.
@@ -3957,13 +3430,11 @@ Integer
 
 ("Random Numbers","Base","rand","rand()
 
-
    Generate a \"Float64\" random number uniformly in [0,1)
 
 "),
 
 ("Random Numbers","Base","rand!","rand!([rng], A)
-
 
    Populate the array A with random number generated from the
    specified RNG.
@@ -3971,7 +3442,6 @@ Integer
 "),
 
 ("Random Numbers","Base","rand","rand(rng::AbstractRNG[, dims...])
-
 
    Generate a random \"Float64\" number or array of the size specified
    by dims, using the specified RNG object. Currently,
@@ -3982,14 +3452,11 @@ Integer
 
 ("Random Numbers","Base","rand","rand(dims or [dims...])
 
-
    Generate a random \"Float64\" array of the size specified by dims
 
 "),
 
-("Random Numbers","Base","rand","rand(Int32|Uint32|Int64|Uint64|Int12
-8|Uint128[, dims...])
-
+("Random Numbers","Base","rand","rand(Int32|Uint32|Int64|Uint64|Int128|Uint128[, dims...])
 
    Generate a random integer of the given type. Optionally, generate
    an array of random integers of the given type by specifying dims.
@@ -3997,7 +3464,6 @@ Integer
 "),
 
 ("Random Numbers","Base","rand","rand(r[, dims...])
-
 
    Generate a random integer from the inclusive interval specified by
    \"Range1 r\" (for example, \"1:n\"). Optionally, generate a random
@@ -4007,7 +3473,6 @@ Integer
 
 ("Random Numbers","Base","randbool","randbool([dims...])
 
-
    Generate a random boolean value. Optionally, generate an array of
    random boolean values.
 
@@ -4015,14 +3480,12 @@ Integer
 
 ("Random Numbers","Base","randbool!","randbool!(A)
 
-
    Fill an array with random boolean values. A may be an \"Array\" or
    a \"BitArray\".
 
 "),
 
 ("Random Numbers","Base","randn","randn(dims or [dims...])
-
 
    Generate a normally-distributed random number with mean 0 and
    standard deviation 1. Optionally generate an array of normally-
@@ -4032,13 +3495,11 @@ Integer
 
 ("Arrays","Base","ndims","ndims(A) -> Integer
 
-
    Returns the number of dimensions of A
 
 "),
 
 ("Arrays","Base","size","size(A)
-
 
    Returns a tuple containing the dimensions of A
 
@@ -4046,20 +3507,17 @@ Integer
 
 ("Arrays","Base","eltype","eltype(A)
 
-
    Returns the type of the elements contained in A
 
 "),
 
 ("Arrays","Base","iseltype","iseltype(A, T)
 
-
    Tests whether A or its elements are of type T
 
 "),
 
 ("Arrays","Base","length","length(A) -> Integer
-
 
    Returns the number of elements in A (note that this differs from
    MATLAB where \"length(A)\" is the largest dimension of \"A\")
@@ -4068,20 +3526,17 @@ Integer
 
 ("Arrays","Base","nnz","nnz(A)
 
-
    Counts the number of nonzero values in array A (dense or sparse)
 
 "),
 
 ("Arrays","Base","conj!","conj!(A)
 
-
    Convert an array to its complex conjugate in-place
 
 "),
 
 ("Arrays","Base","stride","stride(A, k)
-
 
    Returns the distance in memory (in number of elements) between
    adjacent elements in dimension k
@@ -4090,13 +3545,11 @@ Integer
 
 ("Arrays","Base","strides","strides(A)
 
-
    Returns a tuple of the memory strides in each dimension
 
 "),
 
 ("Arrays","Base","ind2sub","ind2sub(dims, index) -> subscripts
-
 
    Returns a tuple of subscripts into an array with dimensions
    \"dims\", corresponding to the linear index \"index\"
@@ -4108,7 +3561,6 @@ Integer
 
 ("Arrays","Base","sub2ind","sub2ind(dims, i, j, k...) -> index
 
-
    The inverse of \"ind2sub\", returns the linear index corresponding
    to the provided subscripts
 
@@ -4116,14 +3568,12 @@ Integer
 
 ("Arrays","Base","Array","Array(type, dims)
 
-
    Construct an uninitialized dense array. \"dims\" may be a tuple or
    a series of integer arguments.
 
 "),
 
 ("Arrays","Base","getindex","getindex(type[, elements...])
-
 
    Construct a 1-d array of the specified type. This is usually called
    with the syntax \"Type[]\". Element values can be specified using
@@ -4133,7 +3583,6 @@ Integer
 
 ("Arrays","Base","cell","cell(dims)
 
-
    Construct an uninitialized cell array (heterogeneous array).
    \"dims\" can be either a tuple or a series of integer arguments.
 
@@ -4141,20 +3590,17 @@ Integer
 
 ("Arrays","Base","zeros","zeros(type, dims)
 
-
    Create an array of all zeros of specified type
 
 "),
 
 ("Arrays","Base","ones","ones(type, dims)
 
-
    Create an array of all ones of specified type
 
 "),
 
 ("Arrays","Base","infs","infs(type, dims)
-
 
    Create an array where every element is infinite and of the
    specified type
@@ -4163,13 +3609,11 @@ Integer
 
 ("Arrays","Base","nans","nans(type, dims)
 
-
    Create an array where every element is NaN of the specified type
 
 "),
 
 ("Arrays","Base","trues","trues(dims)
-
 
    Create a Bool array with all values set to true
 
@@ -4177,13 +3621,11 @@ Integer
 
 ("Arrays","Base","falses","falses(dims)
 
-
    Create a Bool array with all values set to false
 
 "),
 
 ("Arrays","Base","fill","fill(v, dims)
-
 
    Create an array filled with \"v\"
 
@@ -4191,13 +3633,11 @@ Integer
 
 ("Arrays","Base","fill!","fill!(A, x)
 
-
    Fill array \"A\" with value \"x\"
 
 "),
 
 ("Arrays","Base","reshape","reshape(A, dims)
-
 
    Create an array with the same data as the given array, but with
    different dimensions. An implementation for a particular type of
@@ -4206,7 +3646,6 @@ Integer
 "),
 
 ("Arrays","Base","similar","similar(array, element_type, dims)
-
 
    Create an uninitialized array of the same type as the given array,
    but with the specified element type and dimensions. The second and
@@ -4217,7 +3656,6 @@ Integer
 
 ("Arrays","Base","reinterpret","reinterpret(type, A)
 
-
    Construct an array with the same binary data as the given array,
    but with the specified element type
 
@@ -4225,20 +3663,17 @@ Integer
 
 ("Arrays","Base","eye","eye(n)
 
-
    n-by-n identity matrix
 
 "),
 
 ("Arrays","Base","eye","eye(m, n)
 
-
    m-by-n identity matrix
 
 "),
 
 ("Arrays","Base","linspace","linspace(start, stop, n)
-
 
    Construct a vector of \"n\" linearly-spaced elements from \"start\"
    to \"stop\".
@@ -4247,14 +3682,12 @@ Integer
 
 ("Arrays","Base","logspace","logspace(start, stop, n)
 
-
    Construct a vector of \"n\" logarithmically-spaced numbers from
    \"10^start\" to \"10^stop\".
 
 "),
 
 ("Arrays","Base","broadcast","broadcast(f, As...)
-
 
    Broadcasts the arrays \"As\" to a common size by expanding
    singleton dimensions, and returns an array of the results
@@ -4264,13 +3697,11 @@ Integer
 
 ("Arrays","Base","broadcast!","broadcast!(f, dest, As...)
 
-
    Like \"broadcast\", but store the result in the \"dest\" array.
 
 "),
 
 ("Arrays","Base","broadcast_function","broadcast_function(f)
-
 
    Returns a function \"broadcast_f\" such that
    \"broadcast_function(f)(As...) === broadcast(f, As...)\". Most
@@ -4280,13 +3711,11 @@ Integer
 
 ("Arrays","Base","broadcast!_function","broadcast!_function(f)
 
-
    Like \"broadcast_function\", but for \"broadcast!\".
 
 "),
 
 ("Arrays","Base","getindex","getindex(A, inds...)
-
 
    Returns a subset of array \"A\" as specified by \"inds\", where
    each \"ind\" may be an \"Int\", a \"Range\", or a \"Vector\".
@@ -4294,7 +3723,6 @@ Integer
 "),
 
 ("Arrays","Base","sub","sub(A, inds...)
-
 
    Returns a SubArray, which stores the input \"A\" and \"inds\"
    rather than computing the result immediately. Calling \"getindex\"
@@ -4304,7 +3732,6 @@ Integer
 
 ("Arrays","Base","slicedim","slicedim(A, d, i)
 
-
    Return all the data of \"A\" where the index for dimension \"d\"
    equals \"i\". Equivalent to \"A[:,:,...,i,:,:,...]\" where \"i\" is
    in position \"d\".
@@ -4313,7 +3740,6 @@ Integer
 
 ("Arrays","Base","setindex!","setindex!(A, X, inds...)
 
-
    Store values from array \"X\" within some subset of \"A\" as
    specified by \"inds\".
 
@@ -4321,16 +3747,13 @@ Integer
 
 ("Arrays","Base","broadcast_getindex","broadcast_getindex(A, inds...)
 
-
    Broadcasts the \"inds\" arrays to a common size like \"broadcast\",
    and returns an array of the results \"A[ks...]\", where \"ks\" goes
    over the positions in the broadcast.
 
 "),
 
-("Arrays","Base","broadcast_setindex!","broadcast_setindex!(A, X,
-inds...)
-
+("Arrays","Base","broadcast_setindex!","broadcast_setindex!(A, X, inds...)
 
    Broadcasts the \"X\" and \"inds\" arrays to a common size and
    stores the value from each position in \"X\" at the indices given
@@ -4340,13 +3763,11 @@ inds...)
 
 ("Arrays","Base","cat","cat(dim, A...)
 
-
    Concatenate the input arrays along the specified dimension
 
 "),
 
 ("Arrays","Base","vcat","vcat(A...)
-
 
    Concatenate along dimension 1
 
@@ -4354,13 +3775,11 @@ inds...)
 
 ("Arrays","Base","hcat","hcat(A...)
 
-
    Concatenate along dimension 2
 
 "),
 
 ("Arrays","Base","hvcat","hvcat(rows::(Int...), values...)
-
 
    Horizontal and vertical concatenation in one call. This function is
    called for block matrix syntax. The first argument specifies the
@@ -4371,13 +3790,11 @@ inds...)
 
 ("Arrays","Base","flipdim","flipdim(A, d)
 
-
    Reverse \"A\" in dimension \"d\".
 
 "),
 
 ("Arrays","Base","flipud","flipud(A)
-
 
    Equivalent to \"flipdim(A,1)\".
 
@@ -4385,13 +3802,11 @@ inds...)
 
 ("Arrays","Base","fliplr","fliplr(A)
 
-
    Equivalent to \"flipdim(A,2)\".
 
 "),
 
 ("Arrays","Base","circshift","circshift(A, shifts)
-
 
    Circularly shift the data in an array. The second argument is a
    vector giving the amount to shift in each dimension.
@@ -4400,13 +3815,11 @@ inds...)
 
 ("Arrays","Base","find","find(A)
 
-
    Return a vector of the linear indexes of the non-zeros in \"A\".
 
 "),
 
 ("Arrays","Base","find","find(f, A)
-
 
    Return a vector of the linear indexes of  \"A\" where \"f\" returns
    true.
@@ -4415,7 +3828,6 @@ inds...)
 
 ("Arrays","Base","findn","findn(A)
 
-
    Return a vector of indexes for each dimension giving the locations
    of the non-zeros in \"A\".
 
@@ -4423,13 +3835,11 @@ inds...)
 
 ("Arrays","Base","nonzeros","nonzeros(A)
 
-
    Return a vector of the non-zero values in array \"A\".
 
 "),
 
 ("Arrays","Base","findfirst","findfirst(A)
-
 
    Return the index of the first non-zero value in \"A\".
 
@@ -4437,13 +3847,11 @@ inds...)
 
 ("Arrays","Base","findfirst","findfirst(A, v)
 
-
    Return the index of the first element equal to \"v\" in \"A\".
 
 "),
 
 ("Arrays","Base","findfirst","findfirst(predicate, A)
-
 
    Return the index of the first element that satisfies the given
    predicate in \"A\".
@@ -4451,7 +3859,6 @@ inds...)
 "),
 
 ("Arrays","Base","permutedims","permutedims(A, perm)
-
 
    Permute the dimensions of array \"A\". \"perm\" is a vector
    specifying a permutation of length \"ndims(A)\". This is a
@@ -4462,7 +3869,6 @@ inds...)
 
 ("Arrays","Base","ipermutedims","ipermutedims(A, perm)
 
-
    Like \"permutedims()\", except the inverse of the given permutation
    is applied.
 
@@ -4470,13 +3876,11 @@ inds...)
 
 ("Arrays","Base","squeeze","squeeze(A, dims)
 
-
    Remove the dimensions specified by \"dims\" from array \"A\"
 
 "),
 
 ("Arrays","Base","vec","vec(Array) -> Vector
-
 
    Vectorize an array using column-major convention.
 
@@ -4484,20 +3888,17 @@ inds...)
 
 ("Arrays","Base","cumprod","cumprod(A[, dim])
 
-
    Cumulative product along a dimension.
 
 "),
 
 ("Arrays","Base","cumsum","cumsum(A[, dim])
 
-
    Cumulative sum along a dimension.
 
 "),
 
 ("Arrays","Base","cumsum_kbn","cumsum_kbn(A[, dim])
-
 
    Cumulative sum along a dimension, using the Kahan-Babuska-Neumaier
    compensated summation algorithm for additional accuracy.
@@ -4506,13 +3907,11 @@ inds...)
 
 ("Arrays","Base","cummin","cummin(A[, dim])
 
-
    Cumulative minimum along a dimension.
 
 "),
 
 ("Arrays","Base","cummax","cummax(A[, dim])
-
 
    Cumulative maximum along a dimension.
 
@@ -4520,13 +3919,11 @@ inds...)
 
 ("Arrays","Base","diff","diff(A[, dim])
 
-
    Finite difference operator of matrix or vector.
 
 "),
 
 ("Arrays","Base","rot180","rot180(A)
-
 
    Rotate matrix \"A\" 180 degrees.
 
@@ -4534,20 +3931,17 @@ inds...)
 
 ("Arrays","Base","rotl90","rotl90(A)
 
-
    Rotate matrix \"A\" left 90 degrees.
 
 "),
 
 ("Arrays","Base","rotr90","rotr90(A)
 
-
    Rotate matrix \"A\" right 90 degrees.
 
 "),
 
 ("Arrays","Base","reducedim","reducedim(f, A, dims, initial)
-
 
    Reduce 2-argument function \"f\" along dimensions of \"A\".
    \"dims\" is a vector specifying the dimensions to reduce, and
@@ -4556,7 +3950,6 @@ inds...)
 "),
 
 ("Arrays","Base","mapslices","mapslices(f, A, dims)
-
 
    Transform the given dimensions of array \"A\" using function \"f\".
    \"f\" is called on each slice of \"A\" of the form
@@ -4570,7 +3963,6 @@ inds...)
 
 ("Arrays","Base","sum_kbn","sum_kbn(A)
 
-
    Returns the sum of all array elements, using the Kahan-Babuska-
    Neumaier compensated summation algorithm for additional accuracy.
 
@@ -4578,13 +3970,11 @@ inds...)
 
 ("Combinatorics","Base","nthperm","nthperm(v, k)
 
-
    Compute the kth lexicographic permutation of a vector.
 
 "),
 
 ("Combinatorics","Base","nthperm!","nthperm!(v, k)
-
 
    In-place version of \"nthperm()\".
 
@@ -4592,13 +3982,11 @@ inds...)
 
 ("Combinatorics","Base","randperm","randperm(n)
 
-
    Construct a random permutation of the given length.
 
 "),
 
 ("Combinatorics","Base","invperm","invperm(v)
-
 
    Return the inverse permutation of v.
 
@@ -4606,13 +3994,11 @@ inds...)
 
 ("Combinatorics","Base","isperm","isperm(v) -> Bool
 
-
    Returns true if v is a valid permutation.
 
 "),
 
 ("Combinatorics","Base","permute!","permute!(v, p)
-
 
    Permute vector \"v\" in-place, according to permutation \"p\".  No
    checking is done to verify that \"p\" is a permutation.
@@ -4624,13 +4010,11 @@ inds...)
 
 ("Combinatorics","Base","ipermute!","ipermute!(v, p)
 
-
    Like permute!, but the inverse of the given permutation is applied.
 
 "),
 
 ("Combinatorics","Base","randcycle","randcycle(n)
-
 
    Construct a random cyclic permutation of the given length.
 
@@ -4638,13 +4022,11 @@ inds...)
 
 ("Combinatorics","Base","shuffle","shuffle(v)
 
-
    Randomly rearrange the elements of a vector.
 
 "),
 
 ("Combinatorics","Base","shuffle!","shuffle!(v)
-
 
    In-place version of \"shuffle()\".
 
@@ -4652,20 +4034,17 @@ inds...)
 
 ("Combinatorics","Base","reverse","reverse(v)
 
-
    Reverse vector \"v\".
 
 "),
 
 ("Combinatorics","Base","reverse!","reverse!(v) -> v
 
-
    In-place version of \"reverse()\".
 
 "),
 
 ("Combinatorics","Base","combinations","combinations(array, n)
-
 
    Generate all combinations of \"n\" elements from a given array.
    Because the number of combinations can be very large, this function
@@ -4675,7 +4054,6 @@ inds...)
 "),
 
 ("Combinatorics","Base","integer_partitions","integer_partitions(n, m)
-
 
    Generate all arrays of \"m\" integers that sum to \"n\". Because
    the number of partitions can be very large, this function runs
@@ -4687,7 +4065,6 @@ inds...)
 
 ("Combinatorics","Base","partitions","partitions(array)
 
-
    Generate all set partitions of the elements of an array,
    represented as arrays of arrays. Because the number of partitions
    can be very large, this function runs inside a Task to produce
@@ -4698,14 +4075,12 @@ inds...)
 
 ("Statistics","Base","mean","mean(v[, region])
 
-
    Compute the mean of whole array \"v\", or optionally along the
    dimensions in \"region\".
 
 "),
 
 ("Statistics","Base","std","std(v[, region])
-
 
    Compute the sample standard deviation of a vector or array``v``,
    optionally along dimensions in \"region\". The algorithm returns an
@@ -4718,14 +4093,12 @@ inds...)
 
 ("Statistics","Base","stdm","stdm(v, m)
 
-
    Compute the sample standard deviation of a vector \"v\" with known
    mean \"m\".
 
 "),
 
 ("Statistics","Base","var","var(v[, region])
-
 
    Compute the sample variance of a vector or array``v``, optionally
    along dimensions in \"region\". The algorithm will return an
@@ -4738,7 +4111,6 @@ inds...)
 
 ("Statistics","Base","varm","varm(v, m)
 
-
    Compute the sample variance of a vector \"v\" with known mean
    \"m\".
 
@@ -4746,13 +4118,11 @@ inds...)
 
 ("Statistics","Base","median","median(v)
 
-
    Compute the median of a vector \"v\".
 
 "),
 
 ("Statistics","Base","hist","hist(v[, n]) -> e, counts
-
 
    Compute the histogram of \"v\", optionally using approximately
    \"n\" bins. The return values are a range \"e\", which correspond
@@ -4763,7 +4133,6 @@ inds...)
 
 ("Statistics","Base","hist","hist(v, e) -> e, counts
 
-
    Compute the histogram of \"v\" using a vector/range \"e\" as the
    edges for the bins. The result will be a vector of length
    \"length(e) - 1\", with the \"i``th element being ``sum(e[i] .< v
@@ -4773,7 +4142,6 @@ inds...)
 
 ("Statistics","Base","histrange","histrange(v, n)
 
-
    Compute *nice* bin ranges for the edges of a histogram of \"v\",
    using approximately \"n\" bins. The resulting step sizes will be 1,
    2 or 5 multiplied by a power of 10.
@@ -4782,14 +4150,12 @@ inds...)
 
 ("Statistics","Base","midpoints","midpoints(e)
 
-
    Compute the midpoints of the bins with edges \"e\". The result is a
    vector/range of length \"length(e) - 1\".
 
 "),
 
 ("Statistics","Base","quantile","quantile(v, p)
-
 
    Compute the quantiles of a vector \"v\" at a specified set of
    probability values \"p\".
@@ -4798,14 +4164,12 @@ inds...)
 
 ("Statistics","Base","quantile","quantile(v)
 
-
    Compute the quantiles of a vector \"v\" at the probability values
    \"[.0, .2, .4, .6, .8, 1.0]\".
 
 "),
 
 ("Statistics","Base","cov","cov(v1[, v2])
-
 
    Compute the Pearson covariance between two vectors \"v1\" and
    \"v2\". If called with a single element \"v\", then computes
@@ -4815,7 +4179,6 @@ inds...)
 
 ("Statistics","Base","cor","cor(v1[, v2])
 
-
    Compute the Pearson correlation between two vectors \"v1\" and
    \"v2\". If called with a single element \"v\", then computes
    correlation of columns of \"v\".
@@ -4823,7 +4186,6 @@ inds...)
 "),
 
 ("Signal Processing","Base","fft","fft(A[, dims])
-
 
    Performs a multidimensional FFT of the array \"A\".  The optional
    \"dims\" argument specifies an iterable subset of dimensions (e.g.
@@ -4843,14 +4205,12 @@ inds...)
 
 ("Signal Processing","Base","fft!","fft!(A[, dims])
 
-
    Same as \"fft()\", but operates in-place on \"A\", which must be an
    array of complex floating-point numbers.
 
 "),
 
 ("Signal Processing","Base","ifft","ifft(A[, dims])
-
 
    Multidimensional inverse FFT.
 
@@ -4865,13 +4225,11 @@ inds...)
 
 ("Signal Processing","Base","ifft!","ifft!(A[, dims])
 
-
    Same as \"ifft()\", but operates in-place on \"A\".
 
 "),
 
 ("Signal Processing","Base","bfft","bfft(A[, dims])
-
 
    Similar to \"ifft()\", but computes an unnormalized inverse
    (backward) transform, which must be divided by the product of the
@@ -4884,14 +4242,11 @@ inds...)
 
 ("Signal Processing","Base","bfft!","bfft!(A[, dims])
 
-
    Same as \"bfft()\", but operates in-place on \"A\".
 
 "),
 
-("Signal Processing","Base","plan_fft","plan_fft(A[, dims[, flags[,
-timelimit]]])
-
+("Signal Processing","Base","plan_fft","plan_fft(A[, dims[, flags[, timelimit]]])
 
    Pre-plan an optimized FFT along given dimensions (\"dims\") of
    arrays matching the shape and type of \"A\".  (The first two
@@ -4916,50 +4271,39 @@ timelimit]]])
 
 "),
 
-("Signal Processing","Base","plan_ifft","plan_ifft(A[, dims[, flags[,
-timelimit]]])
-
+("Signal Processing","Base","plan_ifft","plan_ifft(A[, dims[, flags[, timelimit]]])
 
    Same as \"plan_fft()\", but produces a plan that performs inverse
    transforms \"ifft()\".
 
 "),
 
-("Signal Processing","Base","plan_bfft","plan_bfft(A[, dims[, flags[,
-timelimit]]])
-
+("Signal Processing","Base","plan_bfft","plan_bfft(A[, dims[, flags[, timelimit]]])
 
    Same as \"plan_fft()\", but produces a plan that performs an
    unnormalized backwards transform \"bfft()\".
 
 "),
 
-("Signal Processing","Base","plan_fft!","plan_fft!(A[, dims[, flags[,
-timelimit]]])
-
+("Signal Processing","Base","plan_fft!","plan_fft!(A[, dims[, flags[, timelimit]]])
 
    Same as \"plan_fft()\", but operates in-place on \"A\".
 
 "),
 
-("Signal Processing","Base","plan_ifft!","plan_ifft!(A[, dims[,
-flags[, timelimit]]])
-
+("Signal Processing","Base","plan_ifft!","plan_ifft!(A[, dims[, flags[, timelimit]]])
 
    Same as \"plan_ifft()\", but operates in-place on \"A\".
 
 "),
 
-("Signal Processing","Base","plan_bfft!","plan_bfft!(A[, dims[,
-flags[, timelimit]]])
-
+("Signal Processing","Base","plan_bfft!","plan_bfft!(A[, dims[, flags[, timelimit]]])
 
    Same as \"plan_bfft()\", but operates in-place on \"A\".
 
 "),
 
 ("Signal Processing","Base","rfft","rfft(A[, dims])
-
 
    Multidimensional FFT of a real array A, exploiting the fact that
    the transform has conjugate symmetry in order to save roughly half
@@ -4977,7 +4321,6 @@ flags[, timelimit]]])
 
 ("Signal Processing","Base","irfft","irfft(A, d[, dims])
 
-
    Inverse of \"rfft()\": for a complex array \"A\", gives the
    corresponding real array whose FFT yields \"A\" in the first half.
    As for \"rfft()\", \"dims\" is an optional subset of dimensions to
@@ -4993,7 +4336,6 @@ flags[, timelimit]]])
 
 ("Signal Processing","Base","brfft","brfft(A, d[, dims])
 
-
    Similar to \"irfft()\" but computes an unnormalized inverse
    transform (similar to \"bfft()\"), which must be divided by the
    product of the sizes of the transformed dimensions (of the real
@@ -5001,9 +4343,7 @@ flags[, timelimit]]])
 
 "),
 
-("Signal Processing","Base","plan_rfft","plan_rfft(A[, dims[, flags[,
-timelimit]]])
-
+("Signal Processing","Base","plan_rfft","plan_rfft(A[, dims[, flags[, timelimit]]])
 
    Pre-plan an optimized real-input FFT, similar to \"plan_fft()\"
    except for \"rfft()\" instead of \"fft()\".  The first two
@@ -5012,9 +4352,7 @@ timelimit]]])
 
 "),
 
-("Signal Processing","Base","plan_irfft","plan_irfft(A, d[, dims[,
-flags[, timelimit]]])
-
+("Signal Processing","Base","plan_irfft","plan_irfft(A, d[, dims[, flags[, timelimit]]])
 
    Pre-plan an optimized inverse real-input FFT, similar to
    \"plan_rfft()\" except for \"irfft()\" and \"brfft()\",
@@ -5024,7 +4362,6 @@ flags[, timelimit]]])
 "),
 
 ("Signal Processing","Base","dct","dct(A[, dims])
-
 
    Performs a multidimensional type-II discrete cosine transform (DCT)
    of the array \"A\", using the unitary normalization of the DCT. The
@@ -5038,14 +4375,12 @@ flags[, timelimit]]])
 
 ("Signal Processing","Base","dct!","dct!(A[, dims])
 
-
    Same as \"dct!()\", except that it operates in-place on \"A\",
    which must be an array of real or complex floating-point values.
 
 "),
 
 ("Signal Processing","Base","idct","idct(A[, dims])
-
 
    Computes the multidimensional inverse discrete cosine transform
    (DCT) of the array \"A\" (technically, a type-III DCT with the
@@ -5060,14 +4395,11 @@ flags[, timelimit]]])
 
 ("Signal Processing","Base","idct!","idct!(A[, dims])
 
-
    Same as \"idct!()\", but operates in-place on \"A\".
 
 "),
 
-("Signal Processing","Base","plan_dct","plan_dct(A[, dims[, flags[,
-timelimit]]])
-
+("Signal Processing","Base","plan_dct","plan_dct(A[, dims[, flags[, timelimit]]])
 
    Pre-plan an optimized discrete cosine transform (DCT), similar to
    \"plan_fft()\" except producing a function that computes \"dct()\".
@@ -5075,17 +4407,13 @@ timelimit]]])
 
 "),
 
-("Signal Processing","Base","plan_dct!","plan_dct!(A[, dims[, flags[,
-timelimit]]])
-
+("Signal Processing","Base","plan_dct!","plan_dct!(A[, dims[, flags[, timelimit]]])
 
    Same as \"plan_dct()\", but operates in-place on \"A\".
 
 "),
 
-("Signal Processing","Base","plan_idct","plan_idct(A[, dims[, flags[,
-timelimit]]])
-
+("Signal Processing","Base","plan_idct","plan_idct(A[, dims[, flags[, timelimit]]])
 
    Pre-plan an optimized inverse discrete cosine transform (DCT),
    similar to \"plan_fft()\" except producing a function that computes
@@ -5094,9 +4422,7 @@ timelimit]]])
 
 "),
 
-("Signal Processing","Base","plan_idct!","plan_idct!(A[, dims[,
-flags[, timelimit]]])
-
+("Signal Processing","Base","plan_idct!","plan_idct!(A[, dims[, flags[, timelimit]]])
 
    Same as \"plan_idct()\", but operates in-place on \"A\".
 
@@ -5104,13 +4430,11 @@ flags[, timelimit]]])
 
 ("Signal Processing","Base","fftshift","fftshift(x)
 
-
    Swap the first and second halves of each dimension of \"x\".
 
 "),
 
 ("Signal Processing","Base","fftshift","fftshift(x, dim)
-
 
    Swap the first and second halves of the given dimension of array
    \"x\".
@@ -5119,20 +4443,17 @@ flags[, timelimit]]])
 
 ("Signal Processing","Base","ifftshift","ifftshift(x[, dim])
 
-
    Undoes the effect of \"fftshift\".
 
 "),
 
 ("Signal Processing","Base","filt","filt(b, a, x)
 
-
    Apply filter described by vectors \"a\" and \"b\" to vector \"x\".
 
 "),
 
 ("Signal Processing","Base","deconv","deconv(b, a)
-
 
    Construct vector \"c\" such that \"b = conv(a,c) + r\". Equivalent
    to polynomial division.
@@ -5141,20 +4462,17 @@ flags[, timelimit]]])
 
 ("Signal Processing","Base","conv","conv(u, v)
 
-
    Convolution of two vectors. Uses FFT algorithm.
 
 "),
 
 ("Signal Processing","Base","xcorr","xcorr(u, v)
 
-
    Compute the cross-correlation of two vectors.
 
 "),
 
 ("Signal Processing","Base.FFTW","r2r","r2r(A, kind[, dims])
-
 
    Performs a multidimensional real-input/real-output (r2r) transform
    of type \"kind\" of the array \"A\", as defined in the FFTW manual.
@@ -5181,15 +4499,12 @@ flags[, timelimit]]])
 
 ("Signal Processing","Base.FFTW","r2r!","r2r!(A, kind[, dims])
 
-
    Same as \"r2r()\", but operates in-place on \"A\", which must be an
    array of real or complex floating-point numbers.
 
 "),
 
-("Signal Processing","Base.FFTW","plan_r2r","plan_r2r(A, kind[, dims[,
-flags[, timelimit]]])
-
+("Signal Processing","Base.FFTW","plan_r2r","plan_r2r(A, kind[, dims[, flags[, timelimit]]])
 
    Pre-plan an optimized r2r transform, similar to \"Base.plan_fft()\"
    except that the transforms (and the first three arguments)
@@ -5197,17 +4512,13 @@ flags[, timelimit]]])
 
 "),
 
-("Signal Processing","Base.FFTW","plan_r2r!","plan_r2r!(A, kind[,
-dims[, flags[, timelimit]]])
-
+("Signal Processing","Base.FFTW","plan_r2r!","plan_r2r!(A, kind[, dims[, flags[, timelimit]]])
 
    Similar to \"Base.plan_fft()\", but corresponds to \"r2r!()\".
 
 "),
 
-("Numerical Integration","Base","quadgk","quadgk(f, a, b, c...;
-reltol=sqrt(eps), abstol=0, maxevals=10^7, order=7)
-
+("Numerical Integration","Base","quadgk","quadgk(f, a, b, c...; reltol=sqrt(eps), abstol=0, maxevals=10^7, order=7)
 
    Numerically integrate the function \"f(x)\" from \"a\" to \"b\",
    and optionally over additional intervals \"b\" to \"c\" and so on.
@@ -5262,19 +4573,14 @@ reltol=sqrt(eps), abstol=0, maxevals=10^7, order=7)
 
 "),
 
-("Parallel Computing","Base","addprocs","addprocs(n) -> List of
-process identifiers
-
+("Parallel Computing","Base","addprocs","addprocs(n) -> List of process identifiers
 
    Add processes on the local machine. Can be used to take advantage
    of multiple cores.
 
 "),
 
-("Parallel Computing","Base","addprocs","addprocs({\"host1\",
-\"host2\", ...}; tunnel=false, dir=JULIA_HOME, sshflags::Cmd=``,
-cman::ClusterManager) -> List of process identifiers
-
+("Parallel Computing","Base","addprocs","addprocs({\"host1\", \"host2\", ...}; tunnel=false, dir=JULIA_HOME, sshflags::Cmd=``, cman::ClusterManager) -> List of process identifiers
 
    Add processes on remote machines via SSH or a custom cluster
    manager. Requires julia to be installed in the same location on
@@ -5301,9 +4607,7 @@ cman::ClusterManager) -> List of process identifiers
 
 "),
 
-("Parallel Computing","Base","addprocs_sge","addprocs_sge(n) -
-DEPRECATED from Base, use ClusterManagers.addprocs_sge(n)
-
+("Parallel Computing","Base","addprocs_sge","addprocs_sge(n) - DEPRECATED from Base, use ClusterManagers.addprocs_sge(n)
 
    Adds processes via the Sun/Oracle Grid Engine batch queue, using
    \"qsub\".
@@ -5312,13 +4616,11 @@ DEPRECATED from Base, use ClusterManagers.addprocs_sge(n)
 
 ("Parallel Computing","Base","nprocs","nprocs()
 
-
    Get the number of available processors.
 
 "),
 
 ("Parallel Computing","Base","nworkers","nworkers()
-
 
    Get the number of available worker processors. This is one less
    than nprocs(). Equal to nprocs() if nprocs() == 1.
@@ -5327,13 +4629,11 @@ DEPRECATED from Base, use ClusterManagers.addprocs_sge(n)
 
 ("Parallel Computing","Base","procs","procs()
 
-
    Returns a list of all process identifiers.
 
 "),
 
 ("Parallel Computing","Base","workers","workers()
-
 
    Returns a list of all worker process identifiers.
 
@@ -5341,20 +4641,17 @@ DEPRECATED from Base, use ClusterManagers.addprocs_sge(n)
 
 ("Parallel Computing","Base","rmprocs","rmprocs(pids...)
 
-
    Removes the specified workers.
 
 "),
 
 ("Parallel Computing","Base","myid","myid()
 
-
    Get the id of the current processor.
 
 "),
 
 ("Parallel Computing","Base","pmap","pmap(f, c)
-
 
    Transform collection \"c\" by applying \"f\" to each element in
    parallel. If \"nprocs() > 1\", the calling process will be
@@ -5363,9 +4660,7 @@ DEPRECATED from Base, use ClusterManagers.addprocs_sge(n)
 
 "),
 
-("Parallel Computing","Base","remotecall","remotecall(id, func,
-args...)
-
+("Parallel Computing","Base","remotecall","remotecall(id, func, args...)
 
    Call a function asynchronously on the given arguments on the
    specified processor. Returns a \"RemoteRef\".
@@ -5373,7 +4668,6 @@ args...)
 "),
 
 ("Parallel Computing","Base","wait","wait(x)
-
 
    Block the current task until some event occurs, depending on the
    type of the argument:
@@ -5383,8 +4677,7 @@ args...)
 
    * \"Condition\": Wait for \"notify\" on a condition.
 
-   * \"Process\": Wait for the process to exit, and get its exit
-     code.
+   * \"Process\": Wait for the process to exit, and get its exit code.
 
    * \"Task\": Wait for a \"Task\" to finish, returning its result
      value.
@@ -5393,29 +4686,23 @@ args...)
 
 ("Parallel Computing","Base","fetch","fetch(RemoteRef)
 
-
    Wait for and get the value of a remote reference.
 
 "),
 
-("Parallel Computing","Base","remotecall_wait","remotecall_wait(id,
-func, args...)
-
+("Parallel Computing","Base","remotecall_wait","remotecall_wait(id, func, args...)
 
    Perform \"wait(remotecall(...))\" in one message.
 
 "),
 
-("Parallel Computing","Base","remotecall_fetch","remotecall_fetch(id,
-func, args...)
-
+("Parallel Computing","Base","remotecall_fetch","remotecall_fetch(id, func, args...)
 
    Perform \"fetch(remotecall(...))\" in one message.
 
 "),
 
 ("Parallel Computing","Base","put","put(RemoteRef, value)
-
 
    Store a value to a remote reference. Implements \"shared queue of
    length 1\" semantics: if a value is already present, blocks until
@@ -5425,7 +4712,6 @@ func, args...)
 
 ("Parallel Computing","Base","take","take(RemoteRef)
 
-
    Fetch the value of a remote reference, removing it so that the
    reference is empty again.
 
@@ -5433,30 +4719,17 @@ func, args...)
 
 ("Parallel Computing","Base","RemoteRef","RemoteRef()
 
-
    Make an uninitialized remote reference on the local machine.
 
 "),
 
 ("Parallel Computing","Base","RemoteRef","RemoteRef(n)
 
-
    Make an uninitialized remote reference on processor \"n\".
 
 "),
 
-("Parallel Computing","Base","timedwait","timedwait(testcb::Function,
-secs::Float64; pollint::Float64=0.1)
-
-
-   Waits till \"testcb\" returns \"true\" or for \"secs`\" seconds,
-   whichever is earlier. \"testcb\" is polled every \"pollint\"
-   seconds.
-
-"),
-
 ("Parallel Computing","Base","@spawn","@spawn()
-
 
    Execute an expression on an automatically-chosen processor,
    returning a \"RemoteRef\" to the result.
@@ -5464,7 +4737,6 @@ secs::Float64; pollint::Float64=0.1)
 "),
 
 ("Parallel Computing","Base","@spawnat","@spawnat()
-
 
    Accepts two arguments, \"p\" and an expression, and runs the
    expression asynchronously on processor \"p\", returning a
@@ -5474,20 +4746,17 @@ secs::Float64; pollint::Float64=0.1)
 
 ("Parallel Computing","Base","@fetch","@fetch()
 
-
    Equivalent to \"fetch(@spawn expr)\".
 
 "),
 
 ("Parallel Computing","Base","@fetchfrom","@fetchfrom()
 
-
    Equivalent to \"fetch(@spawnat p expr)\".
 
 "),
 
 ("Parallel Computing","Base","@async","@async()
-
 
    Schedule an expression to run on the local machine, also adding it
    to the set of items that the nearest enclosing \"@sync\" waits for.
@@ -5496,15 +4765,12 @@ secs::Float64; pollint::Float64=0.1)
 
 ("Parallel Computing","Base","@sync","@sync()
 
-
    Wait until all dynamically-enclosed uses of \"@async\", \"@spawn\",
    and \"@spawnat\" complete.
 
 "),
 
-("Distributed Arrays","Base","DArray","DArray(init, dims[, procs,
-dist])
-
+("Distributed Arrays","Base","DArray","DArray(init, dims[, procs, dist])
 
    Construct a distributed array. \"init\" is a function that accepts
    a tuple of index ranges. This function should allocate a local
@@ -5523,14 +4789,12 @@ dist])
 
 ("Distributed Arrays","Base","dzeros","dzeros(dims, ...)
 
-
    Construct a distributed array of zeros. Trailing arguments are the
    same as those accepted by \"darray\".
 
 "),
 
 ("Distributed Arrays","Base","dones","dones(dims, ...)
-
 
    Construct a distributed array of ones. Trailing arguments are the
    same as those accepted by \"darray\".
@@ -5539,14 +4803,12 @@ dist])
 
 ("Distributed Arrays","Base","dfill","dfill(x, dims, ...)
 
-
    Construct a distributed array filled with value \"x\". Trailing
    arguments are the same as those accepted by \"darray\".
 
 "),
 
 ("Distributed Arrays","Base","drand","drand(dims, ...)
-
 
    Construct a distributed uniform random array. Trailing arguments
    are the same as those accepted by \"darray\".
@@ -5555,7 +4817,6 @@ dist])
 
 ("Distributed Arrays","Base","drandn","drandn(dims, ...)
 
-
    Construct a distributed normal random array. Trailing arguments are
    the same as those accepted by \"darray\".
 
@@ -5563,13 +4824,11 @@ dist])
 
 ("Distributed Arrays","Base","distribute","distribute(a)
 
-
    Convert a local array to distributed
 
 "),
 
 ("Distributed Arrays","Base","localize","localize(d)
-
 
    Get the local piece of a distributed array
 
@@ -5577,20 +4836,17 @@ dist])
 
 ("Distributed Arrays","Base","myindexes","myindexes(d)
 
-
    A tuple describing the indexes owned by the local processor
 
 "),
 
 ("Distributed Arrays","Base","procs","procs(d)
 
-
    Get the vector of processors storing pieces of \"d\"
 
 "),
 
 ("System","Base","run","run(command)
-
 
    Run a command object, constructed with backticks. Throws an error
    if anything goes wrong, including the process exiting with a non-
@@ -5600,14 +4856,12 @@ dist])
 
 ("System","Base","spawn","spawn(command)
 
-
    Run a command object asynchronously, returning the resulting
    \"Process\" object.
 
 "),
 
 ("System","Base","success","success(command)
-
 
    Run a command object, constructed with backticks, and tell whether
    it was successful (exited with a code of 0).
@@ -5616,21 +4870,17 @@ dist])
 
 ("System","Base","process_running","process_running(p::Process)
 
-
    Determine whether a process is currently running.
 
 "),
 
 ("System","Base","process_exited","process_exited(p::Process)
 
-
    Determine whether a process has exited.
 
 "),
 
-("System","Base","process_exit_status","process_exit_status(p::Proces
-s)
-
+("System","Base","process_exit_status","process_exit_status(p::Process)
 
    Get the exit status of an exited process. The result is undefined
    if the process is still running. Use \"wait(p)\" to wait for a
@@ -5640,14 +4890,12 @@ s)
 
 ("System","Base","kill","kill(p::Process, signum=SIGTERM)
 
-
    Send a signal to a process. The default is to terminate the
    process.
 
 "),
 
 ("System","Base","readsfrom","readsfrom(command)
-
 
    Starts running a command asynchronously, and returns a tuple
    (stream,process). The first value is a stream reading from the
@@ -5657,7 +4905,6 @@ s)
 
 ("System","Base","writesto","writesto(command)
 
-
    Starts running a command asynchronously, and returns a tuple
    (stream,process). The first value is a stream writing to the
    process' standard input.
@@ -5665,7 +4912,6 @@ s)
 "),
 
 ("System","Base","readandwrite","readandwrite(command)
-
 
    Starts running a command asynchronously, and returns a tuple
    (stdout,stdin,process) of the output stream and input stream of the
@@ -5675,14 +4921,12 @@ s)
 
 ("System","Base","ignorestatus","ignorestatus(command)
 
-
    Mark a command object so that running it will not throw an error if
    the result code is non-zero.
 
 "),
 
 ("System","Base","detach","detach(command)
-
 
    Mark a command object so that it will be run in a new process
    group, allowing it to outlive the julia process, and not have Ctl-C
@@ -5691,7 +4935,6 @@ s)
 "),
 
 ("System","Base","|>","|>
-
 
    Redirect standard input or output of a process.
 
@@ -5702,7 +4945,6 @@ s)
 
 ("System","Base",">>",">>
 
-
    Redirect standard output of a process, appending to the destination
    file.
 
@@ -5710,20 +4952,17 @@ s)
 
 ("System","Base",".>",".>
 
-
    Redirect the standard error stream of a process.
 
 "),
 
 ("System","Base","gethostname","gethostname() -> String
 
-
    Get the local machine's host name.
 
 "),
 
 ("System","Base","getipaddr","getipaddr() -> String
-
 
    Get the IP address of the local machine, as a string of the form
    \"x.x.x.x\".
@@ -5732,13 +4971,11 @@ s)
 
 ("System","Base","pwd","pwd() -> String
 
-
    Get the current working directory.
 
 "),
 
 ("System","Base","cd","cd(dir::String)
-
 
    Set the current working directory. Returns the new current
    directory.
@@ -5747,14 +4984,12 @@ s)
 
 ("System","Base","cd","cd(f[, dir])
 
-
    Temporarily changes the current working directory (HOME if not
    specified) and applies function f before returning.
 
 "),
 
 ("System","Base","mkdir","mkdir(path[, mode])
-
 
    Make a new directory with name \"path\" and permissions \"mode\".
    \"mode\" defaults to 0o777, modified by the current file creation
@@ -5764,7 +4999,6 @@ s)
 
 ("System","Base","mkpath","mkpath(path[, mode])
 
-
    Create all directories in the given \"path\", with permissions
    \"mode\". \"mode\" defaults to 0o777, modified by the current file
    creation mask.
@@ -5773,20 +5007,17 @@ s)
 
 ("System","Base","rmdir","rmdir(path)
 
-
    Remove the directory named \"path\".
 
 "),
 
 ("System","Base","getpid","getpid() -> Int32
 
-
    Get julia's process ID.
 
 "),
 
 ("System","Base","time","time([t::TmStruct])
-
 
    Get the system time in seconds since the epoch, with fairly high
    (typically, microsecond) resolution. When passed a \"TmStruct\",
@@ -5796,14 +5027,12 @@ s)
 
 ("System","Base","time_ns","time_ns()
 
-
    Get the time in nanoseconds. The time corresponding to 0 is
    undefined, and wraps every 5.8 years.
 
 "),
 
 ("System","Base","strftime","strftime([format], time)
-
 
    Convert time, given as a number of seconds since the epoch or a
    \"TmStruct\", to a formatted string using the given format.
@@ -5812,7 +5041,6 @@ s)
 "),
 
 ("System","Base","strptime","strptime([format], timestr)
-
 
    Parse a formatted time string into a \"TmStruct\" giving the
    seconds, minute, hour, date, etc. Supported formats are the same as
@@ -5827,7 +5055,6 @@ s)
 
 ("System","Base","TmStruct","TmStruct([seconds])
 
-
    Convert a number of seconds since the epoch to broken-down format,
    with fields \"sec\", \"min\", \"hour\", \"mday\", \"month\",
    \"year\", \"wday\", \"yday\", and \"isdst\".
@@ -5836,7 +5063,6 @@ s)
 
 ("System","Base","tic","tic()
 
-
    Set a timer to be read by the next call to \"toc()\" or \"toq()\".
    The macro call \"@time expr\" can also be used to time evaluation.
 
@@ -5844,13 +5070,11 @@ s)
 
 ("System","Base","toc","toc()
 
-
    Print and return the time elapsed since the last \"tic()\".
 
 "),
 
 ("System","Base","toq","toq()
-
 
    Return, but do not print, the time elapsed since the last
    \"tic()\".
@@ -5858,7 +5082,6 @@ s)
 "),
 
 ("System","Base","@time","@time()
-
 
    A macro to execute and expression, printing time it took to execute
    and the total number of bytes its execution caused to be allocated,
@@ -5868,7 +5091,6 @@ s)
 
 ("System","Base","@elapsed","@elapsed()
 
-
    A macro to evaluate an expression, discarding the resulting value,
    instead returning the number of seconds it took to execute as a
    floating-point number.
@@ -5876,7 +5098,6 @@ s)
 "),
 
 ("System","Base","@allocated","@allocated()
-
 
    A macro to evaluate an expression, discarding the resulting value,
    instead returning the total number of bytes allocated during
@@ -5886,7 +5107,6 @@ s)
 
 ("System","Base","EnvHash","EnvHash() -> EnvHash
 
-
    A singleton of this type provides a hash table interface to
    environment variables.
 
@@ -5894,15 +5114,12 @@ s)
 
 ("System","Base","ENV","ENV
 
-
    Reference to the singleton \"EnvHash\", providing a dictionary
    interface to system environment variables.
 
 "),
 
-("C Interface","Base","ccall","ccall((symbol, library) or fptr,
-RetType, (ArgType1, ...), ArgVar1, ...)
-
+("C Interface","Base","ccall","ccall((symbol, library) or fptr, RetType, (ArgType1, ...), ArgVar1, ...)
 
    Call function in C-exported shared library, specified by (function
    name, library) tuple (String or :Symbol). Alternatively, ccall may
@@ -5912,9 +5129,7 @@ RetType, (ArgType1, ...), ArgVar1, ...)
 
 "),
 
-("C Interface","Base","cglobal","cglobal((symbol, library) or ptr[,
-Type=Void])
-
+("C Interface","Base","cglobal","cglobal((symbol, library) or ptr[, Type=Void])
 
    Obtain a pointer to a global variable in a C-exported shared
    library, specified exactly as in \"ccall\".  Returns a
@@ -5924,9 +5139,7 @@ Type=Void])
 
 "),
 
-("C Interface","Base","cfunction","cfunction(fun::Function,
-RetType::Type, (ArgTypes...))
-
+("C Interface","Base","cfunction","cfunction(fun::Function, RetType::Type, (ArgTypes...))
 
    Generate C-callable function pointer from Julia function. Type
    annotation of the return value in the callback function is a must
@@ -5945,9 +5158,7 @@ RetType::Type, (ArgTypes...))
 
 "),
 
-("C Interface","Base","dlopen","dlopen(libfile::String[,
-flags::Integer])
-
+("C Interface","Base","dlopen","dlopen(libfile::String[, flags::Integer])
 
    Load a shared library, returning an opaque handle.
 
@@ -5967,14 +5178,12 @@ flags::Integer])
 
 ("C Interface","Base","dlsym","dlsym(handle, sym)
 
-
    Look up a symbol from a shared library handle, return callable
    function pointer on success.
 
 "),
 
 ("C Interface","Base","dlsym_e","dlsym_e(handle, sym)
-
 
    Look up a symbol from a shared library handle, silently return NULL
    pointer on lookup failure.
@@ -5983,30 +5192,24 @@ flags::Integer])
 
 ("C Interface","Base","dlclose","dlclose(handle)
 
-
    Close shared library referenced by handle.
 
 "),
 
 ("C Interface","Base","c_free","c_free(addr::Ptr)
 
-
    Call free() from C standard library.
 
 "),
 
-("C Interface","Base","unsafe_load","unsafe_load(p::Ptr{T},
-i::Integer)
-
+("C Interface","Base","unsafe_load","unsafe_load(p::Ptr{T}, i::Integer)
 
    Dereference the pointer \"p[i]\" or \"*p\", returning a copy of
    type T.
 
 "),
 
-("C Interface","Base","unsafe_store!","unsafe_store!(p::Ptr{T}, x,
-i::Integer)
-
+("C Interface","Base","unsafe_store!","unsafe_store!(p::Ptr{T}, x, i::Integer)
 
    Assign to the pointer \"p[i] = x\" or \"*p = x\", making a copy of
    object x into the memory at p.
@@ -6014,7 +5217,6 @@ i::Integer)
 "),
 
 ("C Interface","Base","pointer","pointer(a[, index])
-
 
    Get the native address of an array element. Be careful to ensure
    that a julia reference to \"a\" exists as long as this pointer will
@@ -6024,14 +5226,11 @@ i::Integer)
 
 ("C Interface","Base","pointer","pointer(type, int)
 
-
    Convert an integer to a pointer of the specified element type.
 
 "),
 
-("C Interface","Base","pointer_to_array","pointer_to_array(p, dims[,
-own])
-
+("C Interface","Base","pointer_to_array","pointer_to_array(p, dims[, own])
 
    Wrap a native pointer as a Julia Array object. The pointer element
    type determines the array element type. \"own\" optionally
@@ -6043,20 +5242,17 @@ own])
 
 ("Errors","Base","error","error(message::String)
 
-
    Raise an error with the given message
 
 "),
 
 ("Errors","Base","throw","throw(e)
 
-
    Throw an object as an exception
 
 "),
 
 ("Errors","Base","rethrow","rethrow([e])
-
 
    Throw an object without changing the current exception backtrace.
    The default argument is the current exception (if called within a
@@ -6066,13 +5262,11 @@ own])
 
 ("Errors","Base","backtrace","backtrace()
 
-
    Get a backtrace object for the current program point.
 
 "),
 
 ("Errors","Base","catch_backtrace","catch_backtrace()
-
 
    Get the backtrace of the current exception, for use within
    \"catch\" blocks.
@@ -6081,20 +5275,17 @@ own])
 
 ("Errors","Base","errno","errno()
 
-
    Get the value of the C library's \"errno\"
 
 "),
 
 ("Errors","Base","strerror","strerror(n)
 
-
    Convert a system call error code to a descriptive string
 
 "),
 
 ("Errors","Base","assert","assert(cond)
-
 
    Raise an error if \"cond\" is false. Also available as the macro
    \"@assert expr\".
@@ -6103,14 +5294,12 @@ own])
 
 ("Tasks","Base","Task","Task(func)
 
-
    Create a \"Task\" (i.e. thread, or coroutine) to execute the given
    function. The task exits when this function returns.
 
 "),
 
 ("Tasks","Base","yieldto","yieldto(task, args...)
-
 
    Switch to the given task. The first time a task is switched to, the
    task's function is called with \"args\". On subsequent switches,
@@ -6120,13 +5309,11 @@ own])
 
 ("Tasks","Base","current_task","current_task()
 
-
    Get the currently running Task.
 
 "),
 
 ("Tasks","Base","istaskdone","istaskdone(task)
-
 
    Tell whether a task has exited.
 
@@ -6134,13 +5321,11 @@ own])
 
 ("Tasks","Base","consume","consume(task)
 
-
    Receive the next value passed to \"produce\" by the specified task.
 
 "),
 
 ("Tasks","Base","produce","produce(value)
-
 
    Send the given value to the last \"consume\" call, switching to the
    consumer task.
@@ -6148,7 +5333,6 @@ own])
 "),
 
 ("Tasks","Base","yield","yield()
-
 
    For scheduled tasks, switch back to the scheduler to allow another
    scheduled task to run. A task that calls this function is still
@@ -6159,15 +5343,12 @@ own])
 
 ("Tasks","Base","task_local_storage","task_local_storage(symbol)
 
-
    Look up the value of a symbol in the current task's task-local
    storage.
 
 "),
 
-("Tasks","Base","task_local_storage","task_local_storage(symbol,
-value)
-
+("Tasks","Base","task_local_storage","task_local_storage(symbol, value)
 
    Assign a value to a symbol in the current task's task-local
    storage.
@@ -6175,7 +5356,6 @@ value)
 "),
 
 ("Tasks","Base","Condition","Condition()
-
 
    Create an edge-triggered event source that tasks can wait for.
    Tasks that call \"wait\" on a \"Condition\" are suspended and
@@ -6188,9 +5368,7 @@ value)
 
 "),
 
-("Tasks","Base","notify","notify(condition, val=nothing; all=true,
-error=false)
-
+("Tasks","Base","notify","notify(condition, val=nothing; all=true, error=false)
 
    Wake up tasks waiting for a condition, passing them \"val\". If
    \"all\" is true (the default), all waiting tasks are woken,
@@ -6201,7 +5379,6 @@ error=false)
 
 ("Tasks","Base","schedule","schedule(t::Task)
 
-
    Add a task to the scheduler's queue. This causes the task to run
    constantly when the system is otherwise idle, unless the task
    performs a blocking operation such as \"wait\".
@@ -6210,13 +5387,11 @@ error=false)
 
 ("Tasks","Base","@schedule","@schedule()
 
-
    Wrap an expression in a Task and add it to the scheduler's queue.
 
 "),
 
 ("Tasks","Base","@task","@task()
-
 
    Wrap an expression in a Task executing it, and return the Task.
    This only creates a task, and does not run it.
@@ -6225,28 +5400,23 @@ error=false)
 
 ("Tasks","Base","sleep","sleep(seconds)
 
-
    Block the current task for a specified number of seconds.
 
 "),
 
 ("Reflection","Base","module_name","module_name(m::Module) -> Symbol
 
-
    Get the name of a module as a symbol.
 
 "),
 
-("Reflection","Base","module_parent","module_parent(m::Module) ->
-Module
-
+("Reflection","Base","module_parent","module_parent(m::Module) -> Module
 
    Get a module's enclosing module. \"Main\" is its own parent.
 
 "),
 
 ("Reflection","Base","current_module","current_module() -> Module
-
 
    Get the *dynamically* current module, which is the module code is
    currently being read from. In general, this is not the same as the
@@ -6256,7 +5426,6 @@ Module
 
 ("Reflection","Base","fullname","fullname(m::Module)
 
-
    Get the fully-qualified name of a module as a tuple of symbols. For
    example, \"fullname(Base.Pkg)\" gives \"(:Base,:Pkg)\", and
    \"fullname(Main)\" gives \"()\".
@@ -6265,15 +5434,12 @@ Module
 
 ("Reflection","Base","names","names(x)
 
-
    Get an array of the names exported by a module, or the fields of a
    data type.
 
 "),
 
-("Reflection","Base","isconst","isconst([m::Module], s::Symbol) ->
-Bool
-
+("Reflection","Base","isconst","isconst([m::Module], s::Symbol) -> Bool
 
    Determine whether a global is declared \"const\" in a given module.
 
@@ -6281,22 +5447,17 @@ Bool
 
 ("Reflection","Base","isgeneric","isgeneric(f::Function) -> Bool
 
-
    Determine whether a function is generic.
 
 "),
 
-("Reflection","Base","function_name","function_name(f::Function) ->
-Symbol
-
+("Reflection","Base","function_name","function_name(f::Function) -> Symbol
 
    Get the name of a generic function as a symbol, or \":anonymous\".
 
 "),
 
-("Reflection","Base","function_module","function_module(f::Function,
-types) -> Module
-
+("Reflection","Base","function_module","function_module(f::Function, types) -> Module
 
    Determine the module containing a given definition of a generic
    function.
@@ -6305,7 +5466,6 @@ types) -> Module
 
 ("Reflection","Base","functionloc","functionloc(f::Function, types)
 
-
    Returns a tuple \"(filename,line)\" giving the location of a method
    definition.
 
@@ -6313,13 +5473,11 @@ types) -> Module
 
 ("Internals","Base","gc","gc()
 
-
    Perform garbage collection. This should not generally be used.
 
 "),
 
 ("Internals","Base","gc_disable","gc_disable()
-
 
    Disable garbage collection. This should be used only with extreme
    caution, as it can cause memory use to grow without bound.
@@ -6328,14 +5486,11 @@ types) -> Module
 
 ("Internals","Base","gc_enable","gc_enable()
 
-
    Re-enable garbage collection after calling \"gc_disable\".
 
 "),
 
-("Collections and Data Structures","Base.Collections","PriorityQueue{
-K,V}","PriorityQueue{K,V}([ord])
-
+("Base.Collections","Base.Collections","PriorityQueue{K,V}","PriorityQueue{K,V}([ord])
 
    Construct a new PriorityQueue, with keys of type K and
    values/priorites of type V. If an order is not given, the priority
@@ -6343,52 +5498,40 @@ K,V}","PriorityQueue{K,V}([ord])
 
 "),
 
-("Collections and Data
-Structures","Base.Collections","enqueue!","enqueue!(pq, k, v)
-
+("Base.Collections","Base.Collections","enqueue!","enqueue!(pq, k, v)
 
    Insert the a key \"k\" into a priority queue \"pq\" with priority
    \"v\".
 
 "),
 
-("Collections and Data
-Structures","Base.Collections","dequeue!","dequeue!(pq)
-
+("Base.Collections","Base.Collections","dequeue!","dequeue!(pq)
 
    Remove and return the lowest priority key from a priority queue.
 
 "),
 
-("Collections and Data
-Structures","Base.Collections","heapify","heapify(v[, ord])
-
+("Base.Collections","Base.Collections","heapify","heapify(v[, ord])
 
    Return a new vector in binary heap order, optionally using the
    given ordering.
 
 "),
 
-("Collections and Data
-Structures","Base.Collections","heapify!","heapify!(v[, ord])
-
+("Base.Collections","Base.Collections","heapify!","heapify!(v[, ord])
 
    In-place heapify.
 
 "),
 
-("Collections and Data
-Structures","Base.Collections","isheap","isheap(v[, ord])
-
+("Base.Collections","Base.Collections","isheap","isheap(v[, ord])
 
    Return true iff an array is heap-ordered according to the given
    order.
 
 "),
 
-("Collections and Data
-Structures","Base.Collections","heappush!","heappush!(v[, ord])
-
+("Base.Collections","Base.Collections","heappush!","heappush!(v[, ord])
 
    Given a binary heap-ordered array, push a new element, preserving
    the heap property. For efficiency, this function does not check
@@ -6396,9 +5539,7 @@ Structures","Base.Collections","heappush!","heappush!(v[, ord])
 
 "),
 
-("Collections and Data
-Structures","Base.Collections","heappop!","heappop!(v[, ord])
-
+("Base.Collections","Base.Collections","heappop!","heappop!(v[, ord])
 
    Given a binary heap-ordered array, remove and return the lowest
    ordered element. For efficiency, this function does not check that
@@ -6408,7 +5549,6 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Constants","Base","OS_NAME","OS_NAME
 
-
    A symbol representing the name of the operating system. Possible
    values are \":Linux\", \":Darwin\" (OS X), or \":Windows\".
 
@@ -6416,13 +5556,11 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Constants","Base","ARGS","ARGS
 
-
    An array of the command line arguments passed to Julia, as strings.
 
 "),
 
 ("Constants","Base","C_NULL","C_NULL
-
 
    The C null pointer constant, sometimes used when calling external
    code.
@@ -6431,13 +5569,11 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Constants","Base","CPU_CORES","CPU_CORES
 
-
    The number of CPU cores in the system.
 
 "),
 
 ("Constants","Base","WORD_SIZE","WORD_SIZE
-
 
    Standard word size on the current machine, in bits.
 
@@ -6445,13 +5581,11 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Constants","Base","VERSION","VERSION
 
-
    An object describing which version of Julia is in use.
 
 "),
 
 ("Constants","Base","LOAD_PATH","LOAD_PATH
-
 
    An array of paths (as strings) where the \"require\" function looks
    for code.
@@ -6460,14 +5594,12 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","isblockdev","isblockdev(path) -> Bool
 
-
    Returns \"true\" if \"path\" is a block device, \"false\"
    otherwise.
 
 "),
 
 ("Filesystem","Base","ischardev","ischardev(path) -> Bool
-
 
    Returns \"true\" if \"path\" is a character device, \"false\"
    otherwise.
@@ -6476,13 +5608,11 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","isdir","isdir(path) -> Bool
 
-
    Returns \"true\" if \"path\" is a directory, \"false\" otherwise.
 
 "),
 
 ("Filesystem","Base","isexecutable","isexecutable(path) -> Bool
-
 
    Returns \"true\" if the current user has permission to execute
    \"path\", \"false\" otherwise.
@@ -6491,13 +5621,11 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","isfifo","isfifo(path) -> Bool
 
-
    Returns \"true\" if \"path\" is a FIFO, \"false\" otherwise.
 
 "),
 
 ("Filesystem","Base","isfile","isfile(path) -> Bool
-
 
    Returns \"true\" if \"path\" is a regular file, \"false\"
    otherwise.
@@ -6506,14 +5634,12 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","islink","islink(path) -> Bool
 
-
    Returns \"true\" if \"path\" is a symbolic link, \"false\"
    otherwise.
 
 "),
 
 ("Filesystem","Base","ispath","ispath(path) -> Bool
-
 
    Returns \"true\" if \"path\" is a valid filesystem path, \"false\"
    otherwise.
@@ -6522,14 +5648,12 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","isreadable","isreadable(path) -> Bool
 
-
    Returns \"true\" if the current user has permission to read
    \"path\", \"false\" otherwise.
 
 "),
 
 ("Filesystem","Base","issetgid","issetgid(path) -> Bool
-
 
    Returns \"true\" if \"path\" has the setgid flag set, \"false\"
    otherwise.
@@ -6538,7 +5662,6 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","issetuid","issetuid(path) -> Bool
 
-
    Returns \"true\" if \"path\" has the setuid flag set, \"false\"
    otherwise.
 
@@ -6546,13 +5669,11 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","issocket","issocket(path) -> Bool
 
-
    Returns \"true\" if \"path\" is a socket, \"false\" otherwise.
 
 "),
 
 ("Filesystem","Base","issticky","issticky(path) -> Bool
-
 
    Returns \"true\" if \"path\" has the sticky bit set, \"false\"
    otherwise.
@@ -6561,7 +5682,6 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","iswriteable","iswriteable(path) -> Bool
 
-
    Returns \"true\" if the current user has permission to write to
    \"path\", \"false\" otherwise.
 
@@ -6569,20 +5689,17 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","dirname","dirname(path::String) -> String
 
-
    Get the directory part of a path.
 
 "),
 
 ("Filesystem","Base","basename","basename(path::String) -> String
 
-
    Get the file name part of a path.
 
 "),
 
 ("Filesystem","Base","isabspath","isabspath(path::String) -> Bool
-
 
    Determines whether a path is absolute (begins at the root
    directory).
@@ -6591,14 +5708,12 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","joinpath","joinpath(parts...) -> String
 
-
    Join path components into a full path. If some argument is an
    absolute path, then prior components are dropped.
 
 "),
 
 ("Filesystem","Base","abspath","abspath(path::String) -> String
-
 
    Convert a path to an absolute path by adding the current directory
    if necessary.
@@ -6607,20 +5722,17 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","tempname","tempname()
 
-
    Generate a unique temporary filename.
 
 "),
 
 ("Filesystem","Base","tempdir","tempdir()
 
-
    Obtain the path of a temporary directory.
 
 "),
 
 ("Filesystem","Base","mktemp","mktemp()
-
 
    Returns \"(path, io)\", where \"path\" is the path of a new
    temporary file and \"io\" is an open file object for this path.
@@ -6629,7 +5741,6 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Filesystem","Base","mktempdir","mktempdir()
 
-
    Create a temporary directory and return its path.
 
 "),
@@ -6637,13 +5748,11 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Linear Algebra","Base","*","*(A, B)
 
-
    Matrix multiplication
 
 "),
 
 ("Linear Algebra","Base","\\","\\(A, B)
-
 
    Matrix division using a polyalgorithm. For input matrices \"A\" and
    \"B\", the result \"X\" is such that \"A*X == B\" when \"A\" is
@@ -6661,13 +5770,11 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Linear Algebra","Base","dot","dot(x, y)
 
-
    Compute the dot product
 
 "),
 
 ("Linear Algebra","Base","cross","cross(x, y)
-
 
    Compute the cross product of two 3-vectors
 
@@ -6675,20 +5782,17 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Linear Algebra","Base","norm","norm(a)
 
-
    Compute the norm of a \"Vector\" or a \"Matrix\"
 
 "),
 
 ("Linear Algebra","Base","lu","lu(A) -> L, U, P
 
-
    Compute the LU factorization of \"A\", such that \"P*A = L*U\".
 
 "),
 
 ("Linear Algebra","Base","lufact","lufact(A) -> LU
-
 
    Compute the LU factorization of \"A\", returning an \"LU\" object
    for dense \"A\" or an \"UmfpackLU\" object for sparse \"A\". The
@@ -6706,7 +5810,6 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Linear Algebra","Base","lufact!","lufact!(A) -> LU
 
-
    \"lufact!\" is the same as \"lufact\" but saves space by
    overwriting the input A, instead of creating a copy.  For sparse
    \"A\" the \"nzval\" field is not overwritten but the index fields,
@@ -6717,7 +5820,6 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 ("Linear Algebra","Base","chol","chol(A[, LU]) -> F
 
-
    Compute Cholesky factorization of a symmetric positive-definite
    matrix \"A\" and return the matrix \"F\". If \"LU\" is \"L\"
    (Lower), \"A = L*L'\". If \"LU\" is \"U\" (Upper), \"A = R'*R\".
@@ -6725,7 +5827,6 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 "),
 
 ("Linear Algebra","Base","cholfact","cholfact(A[, LU]) -> Cholesky
-
 
    Compute the Cholesky factorization of a dense symmetric positive-
    definite matrix \"A\" and return a \"Cholesky\" object. \"LU\" may
@@ -6738,9 +5839,7 @@ Structures","Base.Collections","heappop!","heappop!(v[, ord])
 
 "),
 
-("Linear Algebra","Base","cholfact","cholfact(A[, ll]) ->
-CholmodFactor
-
+("Linear Algebra","Base","cholfact","cholfact(A[, ll]) -> CholmodFactor
 
    Compute the sparse Cholesky factorization of a sparse matrix \"A\".
    If \"A\" is Hermitian its Cholesky factor is determined.  If \"A\"
@@ -6759,15 +5858,12 @@ CholmodFactor
 
 ("Linear Algebra","Base","cholfact!","cholfact!(A[, LU]) -> Cholesky
 
-
    \"cholfact!\" is the same as \"cholfact\" but saves space by
    overwriting the input A, instead of creating a copy.
 
 "),
 
-("Linear Algebra","Base","cholpfact","cholpfact(A[, LU]) ->
-CholeskyPivoted
-
+("Linear Algebra","Base","cholpfact","cholpfact(A[, LU]) -> CholeskyPivoted
 
    Compute the pivoted Cholesky factorization of a symmetric positive
    semi-definite matrix \"A\" and return a \"CholeskyPivoted\" object.
@@ -6782,9 +5878,7 @@ CholeskyPivoted
 
 "),
 
-("Linear Algebra","Base","cholpfact!","cholpfact!(A[, LU]) ->
-CholeskyPivoted
-
+("Linear Algebra","Base","cholpfact!","cholpfact!(A[, LU]) -> CholeskyPivoted
 
    \"cholpfact!\" is the same as \"cholpfact\" but saves space by
    overwriting the input A, instead of creating a copy.
@@ -6793,14 +5887,12 @@ CholeskyPivoted
 
 ("Linear Algebra","Base","qr","qr(A[, thin]) -> Q, R
 
-
    Compute the QR factorization of \"A\" such that \"A = Q*R\". Also
    see \"qrfact\". The default is to compute a thin factorization.
 
 "),
 
 ("Linear Algebra","Base","qrfact","qrfact(A)
-
 
    Compute the QR factorization of \"A\" and return a \"QR\" object.
    The coomponents of the factorization \"F\" can be accessed as
@@ -6815,14 +5907,12 @@ CholeskyPivoted
 
 ("Linear Algebra","Base","qrfact!","qrfact!(A)
 
-
    \"qrfact!\" is the same as \"qrfact\" but saves space by
    overwriting the input A, instead of creating a copy.
 
 "),
 
 ("Linear Algebra","Base","qrp","qrp(A[, thin]) -> Q, R, P
-
 
    Compute the QR factorization of \"A\" with pivoting, such that
    \"A*P = Q*R\", Also see \"qrpfact\". The default is to compute a
@@ -6831,7 +5921,6 @@ CholeskyPivoted
 "),
 
 ("Linear Algebra","Base","qrpfact","qrpfact(A) -> QRPivoted
-
 
    Compute the QR factorization of \"A\" with pivoting and return a
    \"QRPivoted\" object. The components of the factorization \"F\" can
@@ -6849,14 +5938,12 @@ CholeskyPivoted
 
 ("Linear Algebra","Base","qrpfact!","qrpfact!(A) -> QRPivoted
 
-
    \"qrpfact!\" is the same as \"qrpfact\" but saves space by
    overwriting the input A, instead of creating a copy.
 
 "),
 
 ("Linear Algebra","Base","sqrtm","sqrtm(A)
-
 
    Compute the matrix square root of \"A\". If \"B = sqrtm(A)\", then
    \"B*B == A\" within roundoff error.
@@ -6865,13 +5952,11 @@ CholeskyPivoted
 
 ("Linear Algebra","Base","eig","eig(A) -> D, V
 
-
    Compute eigenvalues and eigenvectors of A
 
 "),
 
 ("Linear Algebra","Base","eig","eig(A, B) -> D, V
-
 
    Compute generalized eigenvalues and vectors of A and B
 
@@ -6879,13 +5964,11 @@ CholeskyPivoted
 
 ("Linear Algebra","Base","eigvals","eigvals(A)
 
-
    Returns the eigenvalues of \"A\".
 
 "),
 
 ("Linear Algebra","Base","eigmax","eigmax(A)
-
 
    Returns the largest eigenvalue of \"A\".
 
@@ -6893,13 +5976,11 @@ CholeskyPivoted
 
 ("Linear Algebra","Base","eigmin","eigmin(A)
 
-
    Returns the smallest eigenvalue of \"A\".
 
 "),
 
 ("Linear Algebra","Base","eigvecs","eigvecs(A[, eigvals])
-
 
    Returns the eigenvectors of \"A\".
 
@@ -6911,7 +5992,6 @@ CholeskyPivoted
 
 ("Linear Algebra","Base","eigfact","eigfact(A)
 
-
    Compute the eigenvalue decomposition of \"A\" and return an
    \"Eigen\" object. If \"F\" is the factorization object, the
    eigenvalues can be accessed with \"F[:values]\" and the
@@ -6922,7 +6002,6 @@ CholeskyPivoted
 
 ("Linear Algebra","Base","eigfact","eigfact(A, B)
 
-
    Compute the generalized eigenvalue decomposition of \"A\" and \"B\"
    and return an \"GeneralizedEigen\" object. If \"F\" is the
    factorization object, the eigenvalues can be accessed with
@@ -6932,14 +6011,12 @@ CholeskyPivoted
 
 ("Linear Algebra","Base","eigfact!","eigfact!(A[, B])
 
-
    \"eigfact!\" is the same as \"eigfact\" but saves space by
    overwriting the input A (and B), instead of creating a copy.
 
 "),
 
 ("Linear Algebra","Base","hessfact","hessfact(A)
-
 
    Compute the Hessenberg decomposition of \"A\" and return a
    \"Hessenberg\" object. If \"F\" is the factorization object, the
@@ -6952,14 +6029,12 @@ CholeskyPivoted
 
 ("Linear Algebra","Base","hessfact!","hessfact!(A)
 
-
    \"hessfact!\" is the same as \"hessfact\" but saves space by
    overwriting the input A, instead of creating a copy.
 
 "),
 
 ("Linear Algebra","Base","schurfact","schurfact(A) -> Schur
-
 
    Computes the Schur factorization of the matrix \"A\". The (quasi)
    triangular Schur factor can be obtained from the \"Schur\" object
@@ -6971,17 +6046,13 @@ CholeskyPivoted
 
 "),
 
-("Linear Algebra","Base","schur","schur(A) -> Schur[:T], Schur[:Z],
-Schur[:values]
-
+("Linear Algebra","Base","schur","schur(A) -> Schur[:T], Schur[:Z], Schur[:values]
 
    See schurfact
 
 "),
 
-("Linear Algebra","Base","schurfact","schurfact(A, B) ->
-GeneralizedSchur
-
+("Linear Algebra","Base","schurfact","schurfact(A, B) -> GeneralizedSchur
 
    Computes the Generalized Schur (or QZ) factorization of the
    matrices \"A\" and \"B\". The (quasi) triangular Schur factors can
@@ -6995,16 +6066,13 @@ GeneralizedSchur
 
 "),
 
-("Linear Algebra","Base","schur","schur(A, B) -> GeneralizedSchur[:S],
-GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
-
+("Linear Algebra","Base","schur","schur(A, B) -> GeneralizedSchur[:S], GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
    See schurfact
 
 "),
 
 ("Linear Algebra","Base","svdfact","svdfact(A[, thin]) -> SVD
-
 
    Compute the Singular Value Decomposition (SVD) of \"A\" and return
    an \"SVD\" object. \"U\", \"S\", \"V\" and \"Vt\" can be obtained
@@ -7018,7 +6086,6 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","svdfact!","svdfact!(A[, thin]) -> SVD
 
-
    \"svdfact!\" is the same as \"svdfact\" but saves space by
    overwriting the input A, instead of creating a copy. If \"thin\" is
    \"true\", an economy mode decomposition is returned. The default is
@@ -7028,7 +6095,6 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","svd","svd(A[, thin]) -> U, S, V
 
-
    Compute the SVD of A, returning \"U\", vector \"S\", and \"V\" such
    that \"A == U*diagm(S)*V'\". If \"thin\" is \"true\", an economy
    mode decomposition is returned.
@@ -7037,13 +6103,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","svdvals","svdvals(A)
 
-
    Returns the singular values of \"A\".
 
 "),
 
 ("Linear Algebra","Base","svdvals!","svdvals!(A)
-
 
    Returns the singular values of \"A\", while saving space by
    overwriting the input.
@@ -7051,7 +6115,6 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 "),
 
 ("Linear Algebra","Base","svdfact","svdfact(A, B) -> GeneralizedSVD
-
 
    Compute the generalized SVD of \"A\" and \"B\", returning a
    \"GeneralizedSVD\" Factorization object, such that \"A =
@@ -7061,7 +6124,6 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","svd","svd(A, B) -> U, V, Q, D1, D2, R0
 
-
    Compute the generalized SVD of \"A\" and \"B\", returning \"U\",
    \"V\", \"Q\", \"D1\", \"D2\", and \"R0\" such that \"A =
    U*D1*R0*Q'\" and \"B = V*D2*R0*Q'\".
@@ -7070,7 +6132,6 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","svdvals","svdvals(A, B)
 
-
    Return only the singular values from the generalized singular value
    decomposition of \"A\" and \"B\".
 
@@ -7078,20 +6139,17 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","triu","triu(M)
 
-
    Upper triangle of a matrix
 
 "),
 
 ("Linear Algebra","Base","tril","tril(M)
 
-
    Lower triangle of a matrix
 
 "),
 
 ("Linear Algebra","Base","diagind","diagind(M[, k])
-
 
    A \"Range\" giving the indices of the \"k\"-th diagonal of the
    matrix \"M\".
@@ -7100,13 +6158,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","diag","diag(M[, k])
 
-
    The \"k\"-th diagonal of a matrix, as a vector
 
 "),
 
 ("Linear Algebra","Base","diagm","diagm(v[, k])
-
 
    Construct a diagonal matrix and place \"v\" on the \"k\"-th
    diagonal
@@ -7114,7 +6170,6 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 "),
 
 ("Linear Algebra","Base","scale","scale(A, B)
-
 
    \"scale(A::Array, B::Number)\" scales all values in \"A\" with
    \"B\". Note: In cases where the array is big enough, \"scale\" can
@@ -7132,13 +6187,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","scale!","scale!(A, B)
 
-
    \"scale!(A,B)\" overwrites the input array with the scaled result.
 
 "),
 
 ("Linear Algebra","Base","Tridiagonal","Tridiagonal(dl, d, du)
-
 
    Construct a tridiagonal matrix from the lower diagonal, diagonal,
    and upper diagonal, respectively.  The result is of type
@@ -7148,7 +6201,6 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 "),
 
 ("Linear Algebra","Base","Bidiagonal","Bidiagonal(dv, ev, isupper)
-
 
    Constructs an upper (isupper=true) or lower (isupper=false)
    bidiagonal matrix using the given diagonal (dv) and off-diagonal
@@ -7160,7 +6212,6 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","SymTridiagonal","SymTridiagonal(d, du)
 
-
    Construct a real-symmetric tridiagonal matrix from the diagonal and
    upper diagonal, respectively. The result is of type
    \"SymTridiagonal\" and provides efficient specialized eigensolvers,
@@ -7170,7 +6221,6 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","Woodbury","Woodbury(A, U, C, V)
 
-
    Construct a matrix in a form suitable for applying the Woodbury
    matrix identity
 
@@ -7178,13 +6228,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","rank","rank(M)
 
-
    Compute the rank of a matrix
 
 "),
 
 ("Linear Algebra","Base","norm","norm(A[, p])
-
 
    Compute the \"p\"-norm of a vector or a matrix. \"p\" is \"2\" by
    default, if not provided. If \"A\" is a vector, \"norm(A, p)\"
@@ -7197,13 +6245,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","normfro","normfro(A)
 
-
    Compute the Frobenius norm of a matrix \"A\".
 
 "),
 
 ("Linear Algebra","Base","cond","cond(M[, p])
-
 
    Matrix condition number, computed using the p-norm. \"p\" is 2 by
    default, if not provided. Valid values for \"p\" are \"1\", \"2\",
@@ -7213,13 +6259,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","trace","trace(M)
 
-
    Matrix trace
 
 "),
 
 ("Linear Algebra","Base","det","det(M)
-
 
    Matrix determinant
 
@@ -7227,13 +6271,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","inv","inv(M)
 
-
    Matrix inverse
 
 "),
 
 ("Linear Algebra","Base","pinv","pinv(M)
-
 
    Moore-Penrose inverse
 
@@ -7241,13 +6283,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","null","null(M)
 
-
    Basis for null space of M.
 
 "),
 
 ("Linear Algebra","Base","repmat","repmat(A, n, m)
-
 
    Construct a matrix by repeating the given matrix \"n\" times in
    dimension 1 and \"m\" times in dimension 2.
@@ -7256,13 +6296,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","kron","kron(A, B)
 
-
    Kronecker tensor product of two vectors or two matrices.
 
 "),
 
 ("Linear Algebra","Base","linreg","linreg(x, y)
-
 
    Determine parameters \"[a, b]\" that minimize the squared error
    between \"y\" and \"a+b*x\".
@@ -7271,13 +6309,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","linreg","linreg(x, y, w)
 
-
    Weighted least-squares linear regression.
 
 "),
 
 ("Linear Algebra","Base","expm","expm(A)
-
 
    Matrix exponential.
 
@@ -7285,13 +6321,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","issym","issym(A)
 
-
    Test whether a matrix is symmetric.
 
 "),
 
 ("Linear Algebra","Base","isposdef","isposdef(A)
-
 
    Test whether a matrix is positive-definite.
 
@@ -7299,13 +6333,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","istril","istril(A)
 
-
    Test whether a matrix is lower-triangular.
 
 "),
 
 ("Linear Algebra","Base","istriu","istriu(A)
-
 
    Test whether a matrix is upper-triangular.
 
@@ -7313,13 +6345,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","ishermitian","ishermitian(A)
 
-
    Test whether a matrix is hermitian.
 
 "),
 
 ("Linear Algebra","Base","transpose","transpose(A)
-
 
    The transpose operator (\".'\").
 
@@ -7327,14 +6357,11 @@ GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
 
 ("Linear Algebra","Base","ctranspose","ctranspose(A)
 
-
    The conjugate transpose operator (\"'\").
 
 "),
 
-("Linear Algebra","Base","eigs","eigs(A; nev=6, which=\"LM\", tol=0.0,
-maxiter=1000, ritzvec=true)
-
+("Linear Algebra","Base","eigs","eigs(A; nev=6, which=\"LM\", tol=0.0, maxiter=1000, ritzvec=true)
 
    \"eigs\" computes the eigenvalues of A using Arnoldi factorization.
    The following keyword arguments are supported:
@@ -7352,9 +6379,7 @@ maxiter=1000, ritzvec=true)
 
 "),
 
-("Linear Algebra","Base","svds","svds(A; nev=6, which=\"LA\", tol=0.0,
-maxiter=1000, ritzvec=true)
-
+("Linear Algebra","Base","svds","svds(A; nev=6, which=\"LA\", tol=0.0, maxiter=1000, ritzvec=true)
 
    \"svds\" computes the singular values of A using Arnoldi
    factorization. The following keyword arguments are supported:
@@ -7373,7 +6398,6 @@ maxiter=1000, ritzvec=true)
 
 ("Linear Algebra","Base","peakflops","peakflops(n; parallel=false)
 
-
    \"peakflops\" computes the peak flop rate of the computer by using
    BLAS dgemm. By default, if no arguments are specified, it
    multiplies a matrix of size \"n x n\", where \"n = 2000\". If the
@@ -7391,14 +6415,12 @@ maxiter=1000, ritzvec=true)
 
 ("BLAS Functions","Base","copy!","copy!(n, X, incx, Y, incy)
 
-
    Copy \"n\" elements of array \"X\" with stride \"incx\" to array
    \"Y\" with stride \"incy\".  Returns \"Y\".
 
 "),
 
 ("BLAS Functions","Base","dot","dot(n, X, incx, Y, incy)
-
 
    Dot product of two vectors consisting of \"n\" elements of array
    \"X\" with stride \"incx\" and \"n\" elements of array \"Y\" with
@@ -7409,23 +6431,18 @@ maxiter=1000, ritzvec=true)
 
 ("BLAS Functions","Base.LinAlg.BLAS","nrm2","nrm2(n, X, incx)
 
-
    2-norm of a vector consisting of \"n\" elements of array \"X\" with
    stride \"incx\".
 
 "),
 
-("BLAS Functions","Base.LinAlg.BLAS","axpy!","axpy!(n, a, X, incx, Y,
-incy)
-
+("BLAS Functions","Base.LinAlg.BLAS","axpy!","axpy!(n, a, X, incx, Y, incy)
 
    Overwrite \"Y\" with \"a*X + Y\".  Returns \"Y\".
 
 "),
 
-("BLAS Functions","Base.LinAlg.BLAS","syrk!","syrk!(uplo, trans,
-alpha, A, beta, C)
-
+("BLAS Functions","Base.LinAlg.BLAS","syrk!","syrk!(uplo, trans, alpha, A, beta, C)
 
    Rank-k update of the symmetric matrix \"C\" as \"alpha*A*A.' +
    beta*C\" or \"alpha*A.'*A + beta*C\" according to whether \"trans\"
@@ -7434,9 +6451,7 @@ alpha, A, beta, C)
 
 "),
 
-("BLAS Functions","Base.LinAlg.BLAS","syrk","syrk(uplo, trans, alpha,
-A)
-
+("BLAS Functions","Base.LinAlg.BLAS","syrk","syrk(uplo, trans, alpha, A)
 
    Returns either the upper triangle or the lower triangle, according
    to \"uplo\" ('U' or 'L'), of \"alpha*A*A.'\" or \"alpha*A.'*A\",
@@ -7444,9 +6459,7 @@ A)
 
 "),
 
-("BLAS Functions","Base.LinAlg.BLAS","herk!","herk!(uplo, trans,
-alpha, A, beta, C)
-
+("BLAS Functions","Base.LinAlg.BLAS","herk!","herk!(uplo, trans, alpha, A, beta, C)
 
    Methods for complex arrays only.  Rank-k update of the Hermitian
    matrix \"C\" as \"alpha*A*A' + beta*C\" or \"alpha*A'*A + beta*C\"
@@ -7456,9 +6469,7 @@ alpha, A, beta, C)
 
 "),
 
-("BLAS Functions","Base.LinAlg.BLAS","herk","herk(uplo, trans, alpha,
-A)
-
+("BLAS Functions","Base.LinAlg.BLAS","herk","herk(uplo, trans, alpha, A)
 
    Methods for complex arrays only.  Returns either the upper triangle
    or the lower triangle, according to \"uplo\" ('U' or 'L'), of
@@ -7467,9 +6478,7 @@ A)
 
 "),
 
-("BLAS Functions","Base.LinAlg.BLAS","gbmv!","gbmv!(trans, m, kl, ku,
-alpha, A, x, beta, y)
-
+("BLAS Functions","Base.LinAlg.BLAS","gbmv!","gbmv!(trans, m, kl, ku, alpha, A, x, beta, y)
 
    Update vector \"y\" as \"alpha*A*x + beta*y\" or \"alpha*A'*x +
    beta*y\" according to \"trans\" ('N' or 'T').  The matrix \"A\" is
@@ -7479,9 +6488,7 @@ alpha, A, x, beta, y)
 
 "),
 
-("BLAS Functions","Base.LinAlg.BLAS","gbmv","gbmv(trans, m, kl, ku,
-alpha, A, x, beta, y)
-
+("BLAS Functions","Base.LinAlg.BLAS","gbmv","gbmv(trans, m, kl, ku, alpha, A, x, beta, y)
 
    Returns \"alpha*A*x\" or \"alpha*A'*x\" according to \"trans\" ('N'
    or 'T'). The matrix \"A\" is a general band matrix of dimension
@@ -7490,9 +6497,7 @@ alpha, A, x, beta, y)
 
 "),
 
-("BLAS Functions","Base.LinAlg.BLAS","sbmv!","sbmv!(uplo, k, alpha, A,
-x, beta, y)
-
+("BLAS Functions","Base.LinAlg.BLAS","sbmv!","sbmv!(uplo, k, alpha, A, x, beta, y)
 
    Update vector \"y\" as \"alpha*A*x + beta*y\" where \"A\" is a a
    symmetric band matrix of order \"size(A,2)\" with \"k\" super-
@@ -7504,9 +6509,7 @@ x, beta, y)
 
 "),
 
-("BLAS Functions","Base.LinAlg.BLAS","sbmv","sbmv(uplo, k, alpha, A,
-x)
-
+("BLAS Functions","Base.LinAlg.BLAS","sbmv","sbmv(uplo, k, alpha, A, x)
 
    Returns \"alpha*A*x\" where \"A\" is a symmetric band matrix of
    order \"size(A,2)\" with \"k\" super-diagonals stored in the
@@ -7514,9 +6517,7 @@ x)
 
 "),
 
-("BLAS Functions","Base.LinAlg.BLAS","gemm!","gemm!(tA, tB, alpha, A,
-B, beta, C)
-
+("BLAS Functions","Base.LinAlg.BLAS","gemm!","gemm!(tA, tB, alpha, A, B, beta, C)
 
    Update \"C\" as \"alpha*A*B + beta*C\" or the other three variants
    according to \"tA\" (transpose \"A\") and \"tB\".  Returns the
@@ -7526,22 +6527,18 @@ B, beta, C)
 
 ("BLAS Functions","Base.LinAlg.BLAS","gemm","gemm(tA, tB, alpha, A, B)
 
-
    Returns \"alpha*A*B\" or the other three variants according to
    \"tA\" (transpose \"A\") and \"tB\".
 
 "),
 
-("BLAS Functions","Base.LinAlg.BLAS","blas_set_num_threads","blas_set
-_num_threads(n)
-
+("BLAS Functions","Base.LinAlg.BLAS","blas_set_num_threads","blas_set_num_threads(n)
 
    Set the number of threads the BLAS library should use.
 
 "),
 
 ("Punctuation","","punctuation","punctuation
-
 
    +-----------+---------------------------------------------------------------------------------------------+
    | symbol    | meaning                                                                                     |
@@ -7611,126 +6608,112 @@ _num_threads(n)
 
 "),
 
-("Sorting and Related Functions","Base.Sort","sort!","sort!(v, [dim,]
-[alg=<algorithm>,] [by=<transform>,] [lt=<comparison>,] [rev=false])
+("Base.Sort","Base","sort","sort(v[, alg[, ord]])
 
-
-   Sort the vector \"v\" in place. \"QuickSort\" is used by default
-   for numeric arrays while \"MergeSort\" is used for other arrays.
-   You can specify an algorithm to use via the \"alg\" keyword (see
-   Sorting Algorithms for available algorithms). The \"by\" keyword
-   lets you provide a function that will be applied to each element
-   before comparison; the \"lt\" keyword allows providing a custom
-   \"less than\" function; use \"rev=true\" to reverse the sorting
-   order. These options are independent and can be used together in
-   all possible combinations: if both \"by\" and \"lt\" are specified,
-   the \"lt\" function is applied to the result of the \"by\"
-   function; \"rev=true\" reverses whatever ordering specified via the
-   \"by\" and \"lt\" keywords.
+   Sort a vector in ascending order.  Specify \"alg\" to choose a
+   particular sorting algorithm (\"Sort.InsertionSort\",
+   \"Sort.QuickSort\", \"Sort.MergeSort\", or \"Sort.TimSort\"), and
+   \"ord\" to sort with a custom ordering (e.g., \"Sort.Reverse\" or a
+   comparison function).
 
 "),
 
-("Sorting and Related Functions","Base.Sort","sort","sort(v,
-[alg=<algorithm>,] [by=<transform>,] [lt=<comparison>,] [rev=false])
+("Base.Sort","Base","sort!","sort!(...)
 
-
-   Variant of \"sort!\" that returns a sorted copy of \"v\" leaving
-   \"v\" itself unmodified.
+   In-place sort.
 
 "),
 
-("Sorting and Related Functions","Base.Sort","sort","sort(A, dim,
-[alg=<algorithm>,] [by=<transform>,] [lt=<comparison>,] [rev=false])
+("Base.Sort","Base","sortby","sortby(v, by[, alg])
 
+   Sort a vector according to \"by(v)\".  Specify \"alg\" to choose a
+   particular sorting algorithm (\"Sort.InsertionSort\",
+   \"Sort.QuickSort\", \"Sort.MergeSort\", or \"Sort.TimSort\").
+
+"),
+
+("Base.Sort","Base","sortby!","sortby!(...)
+
+   In-place \"sortby\".
+
+"),
+
+("Base.Sort","Base","sortperm","sortperm(v[, alg[, ord]])
+
+   Return a permutation vector, which when applied to the input vector
+   \"v\" will sort it.  Specify \"alg\" to choose a particular sorting
+   algorithm (\"Sort.InsertionSort\", \"Sort.QuickSort\",
+   \"Sort.MergeSort\", or \"Sort.TimSort\"), and \"ord\" to sort with
+   a custom ordering (e.g., \"Sort.Reverse\" or a comparison
+   function).
+
+"),
+
+("Base.Sort","Base","sort","sort(A, dim[, alg[, ord]])
 
    Sort a multidimensional array \"A\" along the given dimension.
 
 "),
 
-("Sorting and Related Functions","Base.Sort","sortperm","sortperm(v,
-[alg=<algorithm>,] [by=<transform>,] [lt=<comparison>,] [rev=false])
-
-
-   Return a permutation vector of indices of \"v\" that puts it in
-   sorted order. Specify \"alg\" to choose a particular sorting
-   algorithm (see Sorting Algorithms). \"MergeSort\" is used by
-   default, and since it is stable, the resulting permutation will be
-   the lexicographically first one that puts the input array into
-   sorted order – i.e. indices of equal elements appear in ascending
-   order. If you choose a non-stable sorting algorithm such as
-   \"QuickSort\", a different permutation that puts the array into
-   order may be returned. The order is specified using the same
-   keywords as \"sort!\".
-
-"),
-
-("Sorting and Related Functions","Base.Sort","sortrows","sortrows(A,
-[alg=<algorithm>,] [by=<transform>,] [lt=<comparison>,] [rev=false])
-
+("Base.Sort","Base","sortrows","sortrows(A[, alg[, ord]])
 
    Sort the rows of matrix \"A\" lexicographically.
 
 "),
 
-("Sorting and Related Functions","Base.Sort","sortcols","sortcols(A,
-[alg=<algorithm>,] [by=<transform>,] [lt=<comparison>,] [rev=false])
-
+("Base.Sort","Base","sortcols","sortcols(A[, alg[, ord]])
 
    Sort the columns of matrix \"A\" lexicographically.
 
 "),
 
-("Sorting and Related Functions","Base.Sort","issorted","issorted(v,
-[by=<transform>,] [lt=<comparison>,] [rev=false])
+("Base.Sort","Base","issorted","issorted(v[, ord])
 
-
-   Test whether a vector is in sorted order. The \"by\", \"lt\" and
-   \"rev\" keywords modify what order is considered to be sorted just
-   as they do for \"sort\".
+   Test whether a vector is in ascending sorted order.  If specified,
+   \"ord\" gives the ordering to test.
 
 "),
 
-("Sorting and Related
-Functions","Base.Sort","searchsorted","searchsorted(a, x,
-[by=<transform>,] [lt=<comparison>,] [rev=false])
+("Base.Sort","Base","searchsorted","searchsorted(a, x[, ord])
 
-
-   Returns the range of indices of \"a\" which compare as equal to
-   \"x\" according to the order specified by the \"by\", \"lt\" and
-   \"rev\" keywords, assuming that \"a\" is already sorted in that
-   order. Returns an empty range located at the insertion point if
-   \"a\" does not contain values equal to \"x\".
+   Returns the range of indices of \"a\" equal to \"x\", assuming
+   \"a\" is sorted according to ordering \"ord\" (default:
+   \"Sort.Forward\").  Returns an empty range located at the insertion
+   point if \"a\" does not contain \"x\".
 
 "),
 
-("Sorting and Related Functions","Base.Sort","select!","select!(v, k,
-[by=<transform>,] [lt=<comparison>,] [rev=false])
+("Base.Sort","Base","searchsortedfirst","searchsortedfirst(a, x[, ord])
 
-
-   Partially sort the vector \"v\" in place, according to the order
-   specified by \"by\", \"lt\" and \"rev\" so that the value at index
-   \"k\" (or range of adjacent values if \"k\" is a range) occurs at
-   the position where it would appear if the array were fully sorted.
-   If \"k\" is a single index, that values is returned; if \"k\" is a
-   range, an array of values at those indices is returned. Note that
-   \"select!\" does not fully sort the input array, but does leave the
-   returned elements where they would be if the array were fully
-   sorted.
+   Returns the index of the first value of \"a\" equal to or
+   succeeding \"x\", according to ordering \"ord\" (default:
+   \"Sort.Forward\").
 
 "),
 
-("Sorting and Related Functions","Base.Sort","select","select(v, k,
-[by=<transform>,] [lt=<comparison>,] [rev=false])
+("Base.Sort","Base","searchsortedlast","searchsortedlast(a, x[, ord])
 
+   Returns the index of the last value of \"a\" preceding or equal to
+   \"x\", according to ordering \"ord\" (default: \"Sort.Forward\").
 
-   Variant of \"select!\" which copies \"v\" before partially sorting
-   it, thereby returning the same thing as \"select!\" but leaving
-   \"v\" unmodified.
+"),
+
+("Base.Sort","Base","select","select(v, k[, ord])
+
+   Partially sort vector \"v\" according to ordering \"ord\", and
+   return the element at position \"k\".  \"k\" can also be a range,
+   in which case a vector of elements corresponding to the range
+   positions is returned.
+
+"),
+
+("Base.Sort","Base","select!","select!(v, k[, ord])
+
+   Version of \"select\" which permutes the input vector in place.
 
 "),
 
 ("Sparse Matrices","Base","sparse","sparse(I, J, V[, m, n, combine])
-
 
    Create a sparse matrix \"S\" of dimensions \"m x n\" such that
    \"S[I[k], J[k]] = V[k]\". The \"combine\" function is used to
@@ -7741,7 +6724,6 @@ Functions","Base.Sort","searchsorted","searchsorted(a, x,
 "),
 
 ("Sparse Matrices","Base","sparsevec","sparsevec(I, V[, m, combine])
-
 
    Create a sparse matrix \"S\" of size \"m x 1\" such that \"S[I[k]]
    = V[k]\". Duplicates are combined using the \"combine\" function,
@@ -7755,7 +6737,6 @@ Functions","Base.Sort","searchsorted","searchsorted(a, x,
 
 ("Sparse Matrices","Base","sparsevec","sparsevec(D::Dict[, m])
 
-
    Create a sparse matrix of size \"m x 1\" where the row values are
    keys from the dictionary, and the nonzero values are the values
    from the dictionary.
@@ -7764,20 +6745,17 @@ Functions","Base.Sort","searchsorted","searchsorted(a, x,
 
 ("Sparse Matrices","Base","issparse","issparse(S)
 
-
    Returns \"true\" if \"S\" is sparse, and \"false\" otherwise.
 
 "),
 
 ("Sparse Matrices","Base","sparse","sparse(A)
 
-
    Convert a dense matrix \"A\" into a sparse matrix.
 
 "),
 
 ("Sparse Matrices","Base","sparsevec","sparsevec(A)
-
 
    Convert a dense vector \"A\" into a sparse matrix of size \"m x
    1\". In julia, sparse vectors are really just sparse matrices with
@@ -7787,13 +6765,11 @@ Functions","Base.Sort","searchsorted","searchsorted(a, x,
 
 ("Sparse Matrices","Base","dense","dense(S)
 
-
    Convert a sparse matrix \"S\" into a dense matrix.
 
 "),
 
 ("Sparse Matrices","Base","full","full(S)
-
 
    Convert a sparse matrix \"S\" into a dense matrix.
 
@@ -7801,13 +6777,11 @@ Functions","Base.Sort","searchsorted","searchsorted(a, x,
 
 ("Sparse Matrices","Base","spzeros","spzeros(m, n)
 
-
    Create an empty sparse matrix of size \"m x n\".
 
 "),
 
 ("Sparse Matrices","Base","speye","speye(type, m[, n])
-
 
    Create a sparse identity matrix of specified type of size \"m x
    m\". In case \"n\" is supplied, create a sparse identity matrix of
@@ -7817,14 +6791,12 @@ Functions","Base.Sort","searchsorted","searchsorted(a, x,
 
 ("Sparse Matrices","Base","spones","spones(S)
 
-
    Create a sparse matrix with the same structure as that of \"S\",
    but with every nonzero element having the value \"1.0\".
 
 "),
 
 ("Sparse Matrices","Base","sprand","sprand(m, n, density[, rng])
-
 
    Create a random sparse matrix with the specified density. Nonzeros
    are sampled from the distribution specified by \"rng\". The uniform
@@ -7834,7 +6806,6 @@ Functions","Base.Sort","searchsorted","searchsorted(a, x,
 
 ("Sparse Matrices","Base","sprandn","sprandn(m, n, density)
 
-
    Create a random sparse matrix of specified density with nonzeros
    sampled from the normal distribution.
 
@@ -7842,30 +6813,25 @@ Functions","Base.Sort","searchsorted","searchsorted(a, x,
 
 ("Sparse Matrices","Base","sprandbool","sprandbool(m, n, density)
 
-
    Create a random sparse boolean matrix with the specified density.
 
 "),
 
 ("Sparse Matrices","Base","etree","etree(A[, post])
 
-
    Compute the elimination tree of a symmetric sparse matrix \"A\"
    from \"triu(A)\" and, optionally, its post-ordering permutation.
 
 "),
 
-("Unit and Functional Testing","Base.Test","@test","@test(ex)
-
+("Base.Test","Base.Test","@test","@test(ex)
 
    Test the expression \"ex\" and calls the current handler to handle
    the result.
 
 "),
 
-("Unit and Functional
-Testing","Base.Test","@test_throws","@test_throws(ex)
-
+("Base.Test","Base.Test","@test_throws","@test_throws(ex)
 
    Test the expression \"ex\" and calls the current handler to handle
    the result in the following manner:
@@ -7877,36 +6843,27 @@ Testing","Base.Test","@test_throws","@test_throws(ex)
 
 "),
 
-("Unit and Functional
-Testing","Base.Test","@test_approx_eq","@test_approx_eq(a, b)
-
+("Base.Test","Base.Test","@test_approx_eq","@test_approx_eq(a, b)
 
    Test two floating point numbers \"a\" and \"b\" for equality taking
    in account small numerical errors.
 
 "),
 
-("Unit and Functional
-Testing","Base.Test","@test_approx_eq_eps","@test_approx_eq_eps(a, b,
-tol)
-
+("Base.Test","Base.Test","@test_approx_eq_eps","@test_approx_eq_eps(a, b, tol)
 
    Test two floating point numbers \"a\" and \"b\" for equality taking
    in account a margin of tolerance given by \"tol\".
 
 "),
 
-("Unit and Functional
-Testing","Base.Test","registerhandler","registerhandler(handler)
-
+("Base.Test","Base.Test","registerhandler","registerhandler(handler)
 
    Change the handler function used globally to \"handler\".
 
 "),
 
-("Unit and Functional
-Testing","Base.Test","withhandler","withhandler(f, handler)
-
+("Base.Test","Base.Test","withhandler","withhandler(f, handler)
 
    Run the function \"f\" using the \"handler\" as the handler.
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -952,23 +952,15 @@ I/O
 
    Close an I/O stream. Performs a ``flush`` first.
 
-.. function:: write(stream, x[, byteorder])
+.. function:: write(stream, x)
 
-   Write the canonical binary representation of a value to the given
-   stream. For numeric types, the optional argument specifies the byte order
-   or endianness: ``NetworkByteOrder`` for big-endian, ``LittleByteOrder`` for
-   little-endian, and ``HostByteOrder`` (the default) for the type of the
-   host.
+   Write the canonical binary representation of a value to the given stream.
 
-.. function:: read(stream, type[, byteorder])
+.. function:: read(stream, type)
 
-   Read a value of the given type from a stream, in canonical binary
-   representation. For numeric types, the optional argument specifies the byte
-   order or endianness: ``NetworkByteOrder`` for big-endian,
-   ``LittleByteOrder`` for little-endian, and ``HostByteOrder`` (the default)
-   for the type of the host.
+   Read a value of the given type from a stream, in canonical binary representation.
 
-.. function:: read(stream, type[, byteorder], dims)
+.. function:: read(stream, type, dims)
 
    Read a series of values of the given type from a stream, in canonical binary representation. ``dims`` is either a tuple or a series of integer arguments specifying the size of ``Array`` to return.
 

--- a/test/iostring.jl
+++ b/test/iostring.jl
@@ -28,17 +28,19 @@ a = Array(Uint8, 2)
 @assert seek(io,0)
 @assert read(io,Int16,6) == Int16[1,2,3,4,5,6]
 @assert truncate(io,0)
-@assert write(io,int16(1),NetworkByteOrder) == 2
-@assert write(io,Int16[2,3,4,5,6],NetworkByteOrder) == 10
+@assert write(NetworkByteOrder(io),int16(1)) == 2
+@assert write(NetworkByteOrder(io),Int16[2,3,4,5,6]) == 10
 @assert seek(io,0)
-@assert read(io,Int16,NetworkByteOrder,5) == Int16[1,2,3,4,5]
-@assert read(io,Int16,NetworkByteOrder) == 6
+@assert read(NetworkByteOrder(io),Int16,5) == Int16[1,2,3,4,5]
+@assert read(NetworkByteOrder(io),Int16) == 6
 @assert truncate(io,0)
-@assert write(io,float64(1),NetworkByteOrder) == 8
-@assert write(io,Float64[2,3,4,5,6],NetworkByteOrder) == 40
+@assert write(NetworkByteOrder(io),float64(1)) == 8
+@assert write(NetworkByteOrder(io),Float64[2,3,4,5,6]) == 40
 @assert seek(io,0)
-@assert read(io,Float64,NetworkByteOrder,5) == Float64[1,2,3,4,5]
-@assert read(io,Float64,NetworkByteOrder) == float64(6)
+@assert read(NetworkByteOrder(io),Float64,5) == Float64[1,2,3,4,5]
+@assert read(NetworkByteOrder(io),Float64) == float64(6)
+@assert seek(io,0)
+@assert read(LittleByteOrder(io),Float64,6) == map(ntoh,Float64[1,2,3,4,5,6])
 @assert seek(io,2)
 @assert truncate(io, 10)
 @assert ioslength(io) == 10


### PR DESCRIPTION
Converts the ByteOrder types introduced in #3633 to IO wrappers.

Works quite well, requiring no changes for existing `read`/`write` methods. 

~~However, I seem to be getting some ambiguous dispatch errors that I can't seem to fix,~~
