### PR TITLE
Improve on functionality for matrices with zero dimensions

### DIFF
--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -206,9 +206,12 @@ for (fname, elty) in ((:dsyrk_,:Float64),
            if nn != n error("syrk!: dimension mismatch") end
            k  = size(A, trans == 'N' ? 2 : 1)
            ccall(($(string(fname)),libblas), Void,
-                 (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
-                  Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}),
-                 &uplo, &trans, &n, &k, &alpha, A, &stride(A,2), &beta, C, &stride(C,2))
+                 (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, 
+                  Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, 
+                  Ptr{$elty}, Ptr{BlasInt}),
+                 &uplo, &trans, &n, &k, 
+                 &alpha, A, &max(1,stride(A,2)), &beta, 
+                 C, &max(1,stride(C,2)))
            C
        end
    end
@@ -238,9 +241,12 @@ for (fname, elty) in ((:zherk_,:Complex128), (:cherk_,:Complex64))
            if nn != n error("syrk!: dimension mismatch") end
            k  = size(A, trans == 'N' ? 2 : 1)
            ccall(($(string(fname)),libblas), Void,
-                 (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
-                  Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}),
-                 &uplo, &trans, &n, &k, &alpha, A, &stride(A,2), &beta, C, &stride(C,2))
+                 (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, 
+                  Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, 
+                  Ptr{$elty}, Ptr{BlasInt}),
+                 &uplo, &trans, &n, &k, 
+                 &alpha, A, &max(1,stride(A,2)), &beta, 
+                 C, &max(1,stride(C,2)))
            C
        end
        function herk(uplo::BlasChar, trans::BlasChar, alpha::($elty), A::StridedVecOrMat{$elty})
@@ -269,8 +275,9 @@ for (fname, elty) in ((:dgbmv_,:Float64), (:sgbmv_,:Float32),
                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
                   Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                   Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}),
-                 &trans, &m, &size(A,2), &kl, &ku, &alpha, A, &stride(A,2),
-                 x, &stride(x,1), &beta, y, &stride(y,1))
+                 &trans, &m, &size(A,2), &kl, &ku, 
+                 &alpha, A, &max(1,stride(A,2)), x, &stride(x,1), 
+                 &beta, y, &stride(y,1))
            y
        end
        function gbmv(trans::BlasChar, m::Integer, kl::Integer, ku::Integer,
@@ -302,7 +309,7 @@ for (fname, elty) in ((:dsbmv_,:Float64), (:ssbmv_,:Float32),
            ccall(($(string(fname)),libblas), Void,
                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt},
                  Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}),
-                 &uplo, &size(A,2), &k, &alpha, A, &stride(A,2), x, &stride(x,1),
+                 &uplo, &size(A,2), &k, &alpha, A, &max(1,stride(A,2)), x, &stride(x,1),
                  &beta, y, &stride(y,1))
            y
        end
@@ -348,8 +355,8 @@ for (gemm, gemv, elty) in
                  (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
                   Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                   Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}),
-                 &transA, &transB, &m, &n, &k, &alpha, A, &stride(A,2),
-                 B, &stride(B,2), &beta, C, &stride(C,2))
+                 &transA, &transB, &m, &n, &k, &alpha, A, &max(1,stride(A,2)),
+                 B, &max(1,stride(B,2)), &beta, C, &max(1,stride(C,2)))
            C
        end
        function gemm(transA::BlasChar, transB::BlasChar,
@@ -379,7 +386,7 @@ for (gemm, gemv, elty) in
                   Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt},
                   Ptr{$elty}, Ptr{BlasInt},
                   Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}),
-                 &trans, &size(A,1), &size(A,2), &alpha, A, &stride(A,2),
+                 &trans, &size(A,1), &size(A,2), &alpha, A, &max(1,stride(A,2)),
                  X, &stride(X,1), &beta, Y, &stride(Y,1))
            Y
        end
@@ -418,8 +425,8 @@ for (mfname, vfname, elty) in ((:dsymm_,:dsymv_,:Float64),
            ccall(($(string(mfname)),libblas), Void,
                  (Ptr{Uint8}, Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty},
                   Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}),
-                 &side, &uplo, &m, &n, &alpha, A, &stride(A,2), B, &stride(B,2),
-                 &beta, C, &stride(C,2))
+                 &side, &uplo, &m, &n, &alpha, A, &max(1,stride(A,2)), B, &max(1,stride(B,2)),
+                 &beta, C, &max(1,stride(C,2)))
            C
        end
        function symm(side::BlasChar, uplo::BlasChar, alpha::($elty), A::StridedMatrix{$elty},
@@ -444,7 +451,7 @@ for (mfname, vfname, elty) in ((:dsymm_,:dsymv_,:Float64),
            ccall(($(string(vfname)),libblas), Void,
                  (Ptr{Uint8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt},
                  Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}),
-                 &uplo, &n, &alpha, A, &stride(A,2), x, &stride(x,1), &beta, y, &stride(y,1))
+                 &uplo, &n, &alpha, A, &max(1,stride(A,2)), x, &stride(x,1), &beta, y, &stride(y,1))
            y
        end
        function symv(uplo::BlasChar, alpha::($elty), A::StridedMatrix{$elty}, x::StridedVector{$elty})

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -38,6 +38,7 @@ isposdef(D::Diagonal) = all(D.diag .> 0)
 \(D::Diagonal, V::Vector) = V ./ D.diag
 function \(D::Diagonal, A::Matrix)
     m, n = size(A)
+    if m == 0 || n == 0 return A end
     if m != length(D.diag)
         error("argument dimensions do not match")
     end
@@ -52,6 +53,7 @@ function \(D::Diagonal, A::Matrix)
 end
 function /(A::Matrix, D::Diagonal)
     m, n = size(A)
+    if m == 0 || n == 0 return A end
     if n != length(D.diag)
         error("argument dimensions do not match")
     end

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -347,9 +347,11 @@ end
 
 # Julia implementation similarly to xgelsy
 function (\){T<:BlasFloat}(A::QRPivoted{T}, B::StridedMatrix{T}, rcond::Real)
-    ar = abs(A.hh[1])
     nr = min(size(A.hh))
-    if ar == 0 return zeros(T, length(A.tau), size(B, 2)), 0 end
+    nrhs = size(B, 2)
+    if nr == 0 return zeros(0, nrhs), 0 end
+    ar = abs(A.hh[1])
+    if ar == 0 return zeros(nr, nrhs), 0 end
     rnk = 1
     xmin = ones(T, nr)
     xmax = ones(T, nr)
@@ -365,7 +367,7 @@ function (\){T<:BlasFloat}(A::QRPivoted{T}, B::StridedMatrix{T}, rcond::Real)
         # if cond(r[1:rnk, 1:rnk])*rcond < 1 break end
     end
     C, tau = LAPACK.tzrzf!(A.hh[1:rnk,:])
-    X = [Triangular(C[1:rnk,1:rnk],:U)\(A[:Q]'B)[1:rnk,:]; zeros(T, size(A.hh, 2) - rnk, size(B, 2))]
+    X = [Triangular(C[1:rnk,1:rnk],:U)\(A[:Q]'B)[1:rnk,:]; zeros(T, size(A.hh, 2) - rnk, nrhs)]
     LAPACK.ormrz!('L', iseltype(B, Complex) ? 'C' : 'T', C, tau, X)
     return X[invperm(A[:p]),:], rnk
 end

--- a/base/linalg/hermitian.jl
+++ b/base/linalg/hermitian.jl
@@ -46,8 +46,9 @@ function expm(A::Hermitian)
     scale(F[:vectors], exp(F[:values])) * F[:vectors]'
 end
 
-function sqrtm(A::Hermitian, cond::Bool)
+function sqrtm(A::Hermitian, cond::Bool=false)
     F = eigfact(A)
+    if length(F[:values]) == 0 return A end
     vsqrt = sqrt(complex(F[:values]))
     if all(imag(vsqrt) .== 0)
         retmat = symmetrize!(scale(F[:vectors], real(vsqrt)) * F[:vectors]')

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -243,6 +243,7 @@ function syrk_wrapper{T<:BlasFloat}(tA, A::StridedMatrix{T})
         tAt = 'T'
     end
 
+    if mA == 0 || nA == 0; return zeros(T, mA, mA); end
     if mA == 2 && nA == 2; return matmul2x2(tA,tAt,A,A); end
     if mA == 3 && nA == 3; return matmul3x3(tA,tAt,A,A); end
 


### PR DESCRIPTION
Generally the argument for leading dimension of a matrix in BLAS and LAPACK calls must be at least one even though you are allowed to supply matrices with zero dimensions. Many of the wrappers could therefore make illegal calls. This pull request solves that problem. In addition the handling of zero dimension matrices is handled in some function before calling BLAS/LAPACK either for efficiency reasons or because the code would give wrong answers as for example `null` and `pinv`.
