### PR TITLE
added readline() = readline(STDIN)

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -606,6 +606,8 @@ function readline(this::AsyncStream)
     readline(buf)
 end
 
+readline() = readline(STDIN)
+
 function readavailable(this::AsyncStream)
     buf = this.buffer
     @assert buf.seekable == false


### PR DESCRIPTION
It's annoying that `readline()` is not defined, when `readline(STDIN)` is a reasonable default/meaning for that.
