### PR TITLE
don't require subclasses of AbstractVector/Matrix to implement more than 1d/2d indexing

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -537,6 +537,37 @@ setindex!(t::AbstractArray, x, i::Real) =
     error("setindex! not defined for ",typeof(t))
 setindex!(t::AbstractArray, x) = throw(MethodError(setindex!, (t, x)))
 
+## Indexing: handle more indices than dimensions if "extra" indices are 1
+
+# Don't require vector/matrix subclasses to implement more than 1/2 indices,
+# respectively, by handling the extra dimensions in AbstractMatrix.
+
+function getindex(A::AbstractVector, i1,i2,i3...)
+    if i2*prod(i3) != 1
+        throw(BoundsError())
+    end
+    A[i1]
+end
+function getindex(A::AbstractMatrix, i1,i2,i3,i4...)
+    if i3*prod(i4) != 1
+        throw(BoundsError())
+    end
+    A[i1,i2]
+end
+
+function setindex!(A::AbstractVector, x, i1,i2,i3...)
+    if i2*prod(i3) != 1
+        throw(BoundsError())
+    end
+    A[i1] = x
+end
+function setindex!(A::AbstractMatrix, x, i1,i2,i3,i4...)
+    if i3*prod(i4) != 1
+        throw(BoundsError())
+    end
+    A[i1,i2] = x
+end
+
 ## Concatenation ##
 
 #TODO: ERROR CHECK


### PR DESCRIPTION
Currently, a subclass of `AbstractVector` has to implement `getindex` for arbitrarily many indices, or `repl_show` breaks as illustrated by the example below.  This is annoying and somewhat counter-intuitive.  The attached patch fixes this, so that multidimensional `getindex` and `setindex!` are provided automatically for `AbstractVector` and `AbstractMatrix`.  (Not sure if there is a good way to do this more generally.)

For example, before my patch is applied, the following code

```
type Foo{T} <: AbstractVector{T}
    v::Vector{T}
end
import Base: size, getindex
size(x::Foo) = size(x.v)
getindex(x::Foo, i::Integer) = x.v[i]
repl_show(Foo([1,2,3]))
```

leads to the surprising output

```
3-element Int64 Foo:
 #undef                                                                         
 #undef                                                                         
 #undef
```

due to several assumptions in `print_matrix` and subroutines thereof that vectors accept two-index arguments.
