### PR TITLE
literal type pointers

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -593,6 +593,7 @@ jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
         else
             tn = jl_new_typename((jl_sym_t*)name);
         t->name = tn;
+        t->llvm_val = julia_to_llvm(tn, t);
     }
 
     if (t->name->primary == NULL)
@@ -639,10 +640,11 @@ jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
 
 jl_uniontype_t *jl_new_uniontype(jl_tuple_t *types)
 {
-    jl_uniontype_t *t = (jl_uniontype_t*)newobj((jl_value_t*)jl_uniontype_type,1);
+    jl_uniontype_t *t = (jl_uniontype_t*)newobj((jl_value_t*)jl_uniontype_type,2);
     // don't make unions of 1 type; Union(T)==T
     assert(jl_tuple_len(types) != 1);
     t->types = types;
+    t->llvm_val = NULL;
     return t;
 }
 

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -270,7 +270,7 @@ static Value *julia_to_native(Type *ty, jl_value_t *jt, Value *jv,
         }
         *mightNeedTempSpace = true;
         Value *p = builder.CreateCall4(value_to_pointer_func,
-                                       literal_pointer_val(jl_tparam0(jt)), jv,
+                                       literal_type(jl_tparam0(jt)), jv,
                                        ConstantInt::get(T_int32, argn),
                                        ConstantInt::get(T_int32, (int)addressOf));
         return builder.CreateBitCast(p, ty);
@@ -729,7 +729,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                     sizeof(void*)+((jl_datatype_t*)rt)->size));
         //TODO: Fill type pointer fields with C_NULL's
         builder.CreateStore(
-                literal_pointer_val((jl_value_t*)rt),
+                literal_type(rt),
                 emit_nthptr_addr(result, (size_t)0));
         argvals[0] = builder.CreateBitCast(
                 emit_nthptr_addr(result, (size_t)1),
@@ -852,7 +852,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             builder.CreateCall(jlallocobj_func,
                                ConstantInt::get(T_size,
                                     sizeof(void*)+((jl_datatype_t*)rt)->size));
-        builder.CreateStore(literal_pointer_val((jl_value_t*)rt),
+        builder.CreateStore(literal_type(rt),
                             emit_nthptr_addr(strct, (size_t)0));
         builder.CreateStore(result,
                             builder.CreateBitCast(

--- a/src/dump.c
+++ b/src/dump.c
@@ -457,6 +457,7 @@ static jl_value_t *jl_deserialize_datatype(ios_t *s, int pos)
     dt->linfo = (jl_lambda_info_t*)jl_deserialize_value(s);
     dt->fptr = jl_deserialize_fptr(s);
     dt->struct_decl = NULL;
+    dt->llvm_val = julia_to_llvm(dt->name, dt);
     dt->instance = NULL;
     if (dt->name == jl_array_type->name || dt->name == jl_pointer_type->name ||
         dt->name == jl_type_type->name || dt->name == jl_vararg_type->name ||

--- a/src/gf.c
+++ b/src/gf.c
@@ -515,7 +515,7 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tuple_t *type,
                 jl_value_t *slottype = nth_slot_type(curr->sig, i);
                 if (slottype && curr->func!=method) {
                     if (jl_is_type_type(slottype) &&
-                        jl_type_intersection(slottype, decl_i) != jl_bottom_type) {
+                        jl_type_intersection(slottype, decl_i) != (jl_value_t*)jl_bottom_type) {
                         ok=0;
                         break;
                     }
@@ -719,7 +719,7 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tuple_t *type,
                 jl_value_t *slottype = nth_slot_type(curr->sig, i);
                 if (slottype && curr->func!=method) {
                     if (jl_is_type_type(slottype) &&
-                        jl_type_intersection(slottype, decl_i) != jl_bottom_type) {
+                        jl_type_intersection(slottype, decl_i) != (jl_value_t*)jl_bottom_type) {
                         ok=0;
                         break;
                     }

--- a/src/init.c
+++ b/src/init.c
@@ -644,9 +644,9 @@ void julia_init(char *imageFile)
     jl_gc_disable();
 #endif
     jl_init_frontend();
+    jl_init_codegen();
     jl_init_types();
     jl_init_tasks(jl_stack_lo, jl_stack_hi-jl_stack_lo);
-    jl_init_codegen();
     jl_an_empty_cell = (jl_value_t*)jl_alloc_cell_1d(0);
 
     jl_init_serializer();

--- a/src/julia.h
+++ b/src/julia.h
@@ -202,6 +202,7 @@ typedef struct {
 typedef struct {
     JL_DATA_TYPE
     jl_tuple_t *types;
+    void *llvm_val; //llvm::Value*
 } jl_uniontype_t;
 
 typedef struct {
@@ -229,6 +230,7 @@ typedef struct _jl_datatype_t {
     uint32_t alignment;  // strictest alignment over all fields
     uint32_t uid;
     void *struct_decl;  //llvm::Value*
+    void *llvm_val; //llvm::Value*
     jl_fielddesc_t fields[];
 } jl_datatype_t;
 
@@ -339,8 +341,8 @@ extern jl_datatype_t *jl_task_type;
 extern jl_datatype_t *jl_uniontype_type;
 extern jl_datatype_t *jl_datatype_type;
 
-extern jl_value_t *jl_bottom_type;
-extern jl_value_t *jl_top_type;
+extern jl_uniontype_t *jl_bottom_type;
+extern jl_uniontype_t *jl_top_type;
 extern jl_datatype_t *jl_lambda_info_type;
 extern DLLEXPORT jl_datatype_t *jl_module_type;
 extern jl_datatype_t *jl_vararg_type;
@@ -970,6 +972,9 @@ jl_function_t *jl_method_lookup_by_type(jl_methtable_t *mt, jl_tuple_t *types,
 jl_function_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t nargs, int cache);
 jl_value_t *jl_gf_invoke(jl_function_t *gf, jl_tuple_t *types,
                          jl_value_t **args, size_t nargs);
+
+void *julia_to_llvm(jl_typename_t *cname, void *addr);
+void *julia_global_to_llvm(const char *cname, void *addr);
 
 // AST access
 jl_array_t *jl_lam_args(jl_expr_t *l);

--- a/test/file.jl
+++ b/test/file.jl
@@ -93,7 +93,6 @@ function test_monitor(slval)
     close(fm)
 end
 
-# Commented out the tests below due to issues 3015, 3016 and 3020 
 test_timeout(0.1)
 test_timeout(1)
 test_touch(0.1)


### PR DESCRIPTION
This patch replaces literal_pointer_val( jl_type_t\* ) with something that is hopefully more friendly to static compilation.
