### PR TITLE
added isopen(io) for IOStream, IOBuffer, and File

### DIFF
--- a/base/fs.jl
+++ b/base/fs.jl
@@ -35,7 +35,7 @@ export File,
        S_IRGRP, S_IWGRP, S_IXGRP, S_IRWXG,
        S_IROTH, S_IWOTH, S_IXOTH, S_IRWXO
 
-import Base: uvtype, uvhandle, eventloop, fd, position, stat, close, write, read, readall, 
+import Base: uvtype, uvhandle, eventloop, fd, position, stat, close, write, read, readall, isopen,
             _sizeof_uv_fs
 
 include("file_constants.jl")
@@ -54,6 +54,8 @@ type AsyncFile <: AbstractFile
     path::String
     open::Bool
 end
+
+isopen(f::Union(File,AsyncFile)) = f.open
 
 uvtype(::File) = Base.UV_RAW_FD
 uvhandle(file::File) = file.handle

--- a/base/io.jl
+++ b/base/io.jl
@@ -292,6 +292,7 @@ convert(T::Type{Ptr{Void}}, s::IOStream) = convert(T, s.ios)
 show(io::IO, s::IOStream) = print(io, "IOStream(", s.name, ")")
 fd(s::IOStream) = int(ccall(:jl_ios_fd, Clong, (Ptr{Void},), s.ios))
 close(s::IOStream) = ccall(:ios_close, Void, (Ptr{Void},), s.ios)
+isopen(s::IOStream) = bool(ccall(:ios_isopen, Cint, (Ptr{Void},), s.ios))
 flush(s::IOStream) = ccall(:ios_flush, Void, (Ptr{Void},), s.ios)
 isreadonly(s::IOStream) = bool(ccall(:ios_get_readonly, Cint, (Ptr{Void},), s.ios))
 

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -144,6 +144,7 @@ function close(io::IOBuffer)
     io.ptr = 1
     nothing
 end
+isopen(io::IOBuffer) = io.readable || io.writable || io.seekable || nb_available(io) > 0
 function bytestring(io::IOBuffer)
     if !io.readable error("bytestring read failed") end 
     if !io.seekable error("bytestring read failed") end 

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -605,6 +605,11 @@ void ios_close(ios_t *s)
     s->size = s->maxsize = s->bpos = 0;
 }
 
+int ios_isopen(ios_t *s)
+{
+	 return s->fd != -1;
+}
+
 static void _buf_init(ios_t *s, bufmode_t bm)
 {
     s->bm = bm;

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -72,6 +72,7 @@ DLLEXPORT int ios_trunc(ios_t *s, size_t size);
 DLLEXPORT int ios_eof(ios_t *s);
 DLLEXPORT int ios_flush(ios_t *s);
 DLLEXPORT void ios_close(ios_t *s);
+DLLEXPORT int ios_isopen(ios_t *s);
 DLLEXPORT char *ios_takebuf(ios_t *s, size_t *psize);  // release buffer to caller
 // set buffer space to use
 DLLEXPORT int ios_setbuf(ios_t *s, char *buf, size_t size, int own);


### PR DESCRIPTION
We already had `isopen` for some `AsyncStream` types.  Pretty trivial implementation.

This function is useful for passing IO objects to Python (since Python's `IOBase` [interface](http://docs.python.org/3/library/io.html#io.IOBase) includes an `isclosed` function).
