### PR TITLE
add more isreadable/iswriteable/isreadonly functions

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -34,6 +34,8 @@ else
     error("seriously? what is this machine?")
 end
 
+isreadonly(s) = isreadable(s) && !iswriteable(s)
+
 ## binary I/O ##
 
 # all subtypes should implement this
@@ -294,6 +296,8 @@ fd(s::IOStream) = int(ccall(:jl_ios_fd, Clong, (Ptr{Void},), s.ios))
 close(s::IOStream) = ccall(:ios_close, Void, (Ptr{Void},), s.ios)
 flush(s::IOStream) = ccall(:ios_flush, Void, (Ptr{Void},), s.ios)
 isreadonly(s::IOStream) = bool(ccall(:ios_get_readonly, Cint, (Ptr{Void},), s.ios))
+iswriteable(s::IOStream) = !isreadonly(s)
+isreadable(s::IOStream) = true
 
 truncate(s::IOStream, n::Integer) =
     (ccall(:ios_trunc, Int32, (Ptr{Void}, Uint), s.ios, n)==0 ||

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -73,6 +73,9 @@ end
 
 read{T}(from::IOBuffer, ::Type{Ptr{T}}) = convert(Ptr{T}, read(from, Uint))
 
+isreadable(io::IOBuffer) = io.readable
+iswriteable(io::IOBuffer) = io.writable
+
 # TODO: IOBuffer is not iterable, so doesn't really have a length.
 # This should maybe be sizeof() instead.
 #length(io::IOBuffer) = (io.seekable ? io.size : nb_available(io))

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -177,6 +177,13 @@ function TTY(fd::RawFD; readable::Bool = false)
     ret
 end
 
+# note that uv_is_readable/writeable work for any subtype of
+# uv_stream_t, including uv_tty_t and uv_pipe_t
+isreadable(io::Union(NamedPipe,PipeServer,TTY)) =
+    bool(ccall(:uv_is_readable, Cint, (Ptr{Void},), io.handle))
+iswriteable(io::Union(NamedPipe,PipeServer,TTY)) =
+    bool(ccall(:uv_is_writable, Cint, (Ptr{Void},), io.handle))
+
 show(io::IO,stream::TTY) = print(io,"TTY(",uv_status_string(stream),", ",
     nb_available(stream.buffer)," bytes waiting)")
 


### PR DESCRIPTION
We already export these functions, this just adds definitions for more stream types.

(It would be nice to add them for `File` objects too, but that seems like it requires one to modify libuv to add a new function that calls `fcntl(fd,  F_GETFL)` or the Windows equivalent thereof.)
