### PR TITLE
Add get_pcre_version() and check_pcre()

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -324,6 +324,8 @@ function _start()
     fdwatcher_reinit()
     # Initialize RNG
     Random.librandom_init()
+    # Check that pcre is the correct version
+    check_pcre()
     # Check that BLAS is correctly built
     check_blas()
     LinAlg.init()

--- a/base/util.jl
+++ b/base/util.jl
@@ -256,6 +256,22 @@ function check_blas()
     end
 end
 
+# Returns the PCRE version as a string, in an attempt to avoid using PCRE itself
+function get_pcre_version()
+    version_string = bytestring( ccall((:pcre_version, "libpcre"), Ptr{Uint8}, () ))
+    return version_string[1:search( version_string, " ")[1]-1]
+end
+
+function check_pcre()
+    required_version = "8.31"
+    linked_version = get_pcre_version()
+    # Check to see if it's a new enough pcre version, without actually using pcre
+    if float(linked_version) < float(required_version)
+        println("ERROR: The linked PCRE is too old!  PCRE $required_version or higher is required, currently linked against $linked_version")
+        quit()
+    end
+end
+
 # system information
 
 function versioninfo(io::IO=STDOUT, verbose::Bool=false)
@@ -288,6 +304,7 @@ function versioninfo(io::IO=STDOUT, verbose::Bool=false)
     println(io,             "  LAPACK: ",liblapack_name)
     println(io,             "  LIBM: ",libm_name)
     if verbose
+        println(io,         "  libpcre: libpcre (Version $(get_pcre_version()))")
         println(io,         "Environment:")
         for (k,v) in ENV
             if !is(match(r"JULIA|PATH|FLAG|^TERM$|HOME",k), nothing)


### PR DESCRIPTION
To ensure that the pcre version is what we want.

I'm not sure if 8.31 is the actual minimum version number we support, it's just what I had on my machine.
