### PR TITLE
generate llvm global variables for most literal_pointer_val calls

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -715,7 +715,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         builder.CreateCall2(jlputs_func,
                             builder.CreateGEP(stringConst(msg.str()),
                                          ArrayRef<Value*>(zeros)),
-                            literal_pointer_val(JL_STDERR));
+                            literal_pointer_val(JL_STDERR,T_pint8));
     }
 
     // emit arguments

--- a/src/julia.h
+++ b/src/julia.h
@@ -873,6 +873,7 @@ void jl_init_serializer(void);
 
 DLLEXPORT void jl_save_system_image(char *fname);
 DLLEXPORT void jl_restore_system_image(char *fname);
+DLLEXPORT const char *jl_get_llvm_gv(jl_value_t *p);
 
 // front end interface
 DLLEXPORT jl_value_t *jl_parse_input_line(const char *str);

--- a/src/julia.h
+++ b/src/julia.h
@@ -249,10 +249,9 @@ typedef struct {
 } jl_weakref_t;
 
 typedef struct {
-    // not first-class
+    JL_DATA_TYPE
     jl_sym_t *name;
     jl_value_t *value;
-    jl_value_t *type;
     struct _jl_module_t *owner;  // for individual imported bindings
     unsigned constp:1;
     unsigned exportp:1;

--- a/test/file.jl
+++ b/test/file.jl
@@ -93,7 +93,6 @@ function test_monitor(slval)
     close(fm)
 end
 
-# Commented out the tests below due to issues 3015, 3016 and 3020 
 test_timeout(0.1)
 test_timeout(1)
 test_touch(0.1)


### PR DESCRIPTION
This takes care of generating llvm globals for all uses of literal_pointer_val (except a few that aren't very important, unless I missed some). we still need to tell dump.c about them before static compilation will work.
