### PR TITLE
new readbytes and readbytes! functions

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1074,6 +1074,8 @@ export
     position,
     read,
     readall,
+    readbytes,
+    readbytes!,
     readchomp,
     readdir,
     readline,

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1006,6 +1006,10 @@ function create_worker(privhost, port, pubhost, stream, config)
                 if nread>0
                     try
                         line = readbytes(stream.buffer, nread)
+                        if length(line) < nread
+                            println(STDERR,"\tTruncated reply from worker $(wrker.id):\t",err)
+                            return false
+                        end
                         print("\tFrom worker $(wrker.id):\t",line)
                     catch err
                         println(STDERR,"\tError parsing reply from worker $(wrker.id):\t",err)

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -1667,6 +1667,26 @@
 
 "),
 
+("I/O","Base","readbytes!","readbytes!(stream, b::Vector{Uint8}, nb=length(b))
+
+   Read up to nb bytes from the stream into b, returning the
+   number of bytes read (increasing the size of b as needed).
+
+"),
+
+("I/O","Base","readbytes","readbytes(stream, nb=typemax(Int))
+
+   Read at most nb bytes from the stream, returning a
+   Vector{Uint8} of the bytes read.
+
+"),
+
+("Text I/O","Base","readall","readall(stream)
+
+   Read the entire contents of an I/O stream as a string.
+
+"),
+
 ("Text I/O","Base","readline","readline(stream)
 
    Read a single line of text, including a trailing newline character

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -970,6 +970,16 @@ I/O
 
    Read a series of values of the given type from a stream, in canonical binary representation. ``dims`` is either a tuple or a series of integer arguments specifying the size of ``Array`` to return.
 
+.. function:: readbytes!(stream, b::Vector{Uint8}, nb=length(b))
+
+   Read at most nb bytes from the stream into b, returning the
+   number of bytes read (increasing the size of b as needed).
+
+.. function:: readbytes(stream, nb=typemax(Int))
+
+   Read at most nb bytes from the stream, returning a
+   Vector{Uint8} of the bytes read.
+
 .. function:: position(s)
 
    Get the current position of a stream.


### PR DESCRIPTION
This pull request expands the functionality of the (internal) `readbytes` functions that we already had into two new (exported & documented) functions (inspired by the functionality in Python's [RawIOBase](http://docs.python.org/2/library/io.html#i-o-base-classes) class):

```
readbytes!(stream, buffer::Vector{Uint8}, nb=length(buffer))
readbytes(stream, nb=typemax(Int))
```

The `readbytes!` function reads up to `nb` bytes into `buffer` (growing it as needed), returning the number of bytes read.  The `readbytes` function reads up to `nb` bytes and returns a new Vector{Uint8} buffer containing the bytes read.

(Incidentally, we had two different implementations of `readall(s::IO)`, one replacing the other; I kept the one that uses `readbytes`.)

PS. I added this functionality to make it easier for PyCall to pass Julia `IO` objects as the corresponding types in Python.
