### PR TITLE
Command line argument support for package args and env vars

### DIFF
--- a/ui/repl.c
+++ b/ui/repl.c
@@ -33,6 +33,11 @@ static const char *opts =
     " -f --no-startup          Don't load ~/.juliarc.jl\n"
     " -F                       Load ~/.juliarc.jl, then handle remaining inputs\n\n"
 
+    " --package-<pkgname> var val\n"
+    "                          set package configuration parameter\n"
+    " --package pkgname        loads package pkgname\n"
+    " --env var val            set environment variable\n\n"
+    
     " -h --help                Print this message\n";
 
 void parse_opts(int *argcp, char ***argvp) {


### PR DESCRIPTION
This PR supports the following additional command line arguments:
- `--package-<pkgname> var val` which allows for package specific command line arguments. Currently stored as `<pkgname>.var` fields in a global dict - PACKAGE_ARGS (to be exported)
- `--package pkgname` loads said package after all other common line arguments have been processed
- `env var val` adds said `var` into ENV

The requirement for the above came about by a need to bundle server type components as packages and have an ability to easily configure and start them up on remote machines using ssh commands. Since a  `<package>.jl` file is run on package loading, the behavior of the said code can be controlled by package specific arguments.

If this PR is acceptable,  I will also do the following
1. Send package specific args and env variables to all workers. 
2. Add another option `--detach` which will result in the REPL not being launched and the julia process will run as long as any tasks are scheduled either due to package loading at startup or due to a `-e` option. Again useful in launching servers directly from packages without having a startup script or a lengthy `-e`  option via ssh commands. Functionally similar to the --worker flag, except that it does not start listening on a random port but runs till any scheduled tasks complete

Will need help/suggestions in implementing a `--detach` option.
