### PR TITLE
Pkg2: reinstate prerelease/build versions

### DIFF
--- a/base/pkg2/reqs.jl
+++ b/base/pkg2/reqs.jl
@@ -16,19 +16,9 @@ immutable Requirement <: Line
     function Requirement(content::String)
         fields = split(replace(content, r"#.*$", ""))
         package = shift!(fields)
-        versions = VersionNumber[]
-        for field in fields
-            m = match(Base.VERSION_REGEX, field)
-            m == nothing && error("invalid requires entry field for $package: $field")
-            major, minor, patch, minus, prerl, plus, build = m.captures
-            major = int(major)
-            minor = minor != nothing ? int(minor) : 0
-            patch = patch != nothing ? int(patch) : 0
-            v = VersionNumber(major, minor, patch)
-            (prerl != nothing || build != nothing || plus == "+") &&
-                warn("in requires entry for $package: field $field will be treated as $v")
-            push!(versions, v)
-        end
+        all(field->ismatch(Base.VERSION_REGEX, field), fields) ||
+            error("invalid requires entry for $package: $fields")
+        versions = [ convert(VersionNumber, field) for field in fields ]
         issorted(versions) || error("invalid requires entry for $package: $versions")
         new(content, package, VersionSet(versions))
     end

--- a/base/pkg2/resolve/fieldvalue.jl
+++ b/base/pkg2/resolve/fieldvalue.jl
@@ -27,8 +27,8 @@ immutable FieldValue
 end
 FieldValue(l0::Int,l1::VersionWeight,l2::VersionWeight,l3::Int) = FieldValue(l0, l1, l2, l3, int128(0))
 FieldValue(l0::Int,l1::VersionWeight,l2::VersionWeight) = FieldValue(l0, l1, l2, 0)
-FieldValue(l0::Int,l1::VersionWeight) = FieldValue(l0, l1, VersionWeight(0))
-FieldValue(l0::Int) = FieldValue(l0, VersionWeight(0))
+FieldValue(l0::Int,l1::VersionWeight) = FieldValue(l0, l1, zero(VersionWeight))
+FieldValue(l0::Int) = FieldValue(l0, zero(VersionWeight))
 FieldValue() = FieldValue(0)
 
 typealias Field Vector{FieldValue}
@@ -44,15 +44,20 @@ Base.(:+)(a::FieldValue, b::FieldValue) = FieldValue(a.l0+b.l0, a.l1+b.l1, a.l2+
 function Base.isless(a::FieldValue, b::FieldValue)
     a.l0 < b.l0 && return true
     a.l0 > b.l0 && return false
-    a.l1 < b.l1 && return true
-    a.l1 > b.l1 && return false
-    a.l2 < b.l2 && return true
-    a.l2 > b.l2 && return false
+    c = cmp(a.l1, b.l1)
+    c < 0 && return true
+    c > 0 && return false
+    c = cmp(a.l2, b.l2)
+    c < 0 && return true
+    c > 0 && return false
     a.l3 < b.l3 && return true
     a.l3 > b.l3 && return false
     a.l4 < b.l4 && return true
     return false
 end
+
+Base.isequal(a::FieldValue, b::FieldValue) =
+    a.l0 == b.l0 && a.l1 == b.l1 && a.l2 == b.l2 && a.l3 == b.l3 && a.l4 == b.l4
 
 Base.abs(a::FieldValue) = FieldValue(abs(a.l0), abs(a.l1), abs(a.l2), abs(a.l3), abs(a.l4))
 Base.abs(f::Field) = FieldValue[abs(a) for a in f]

--- a/base/pkg2/resolve/maxsum.jl
+++ b/base/pkg2/resolve/maxsum.jl
@@ -191,7 +191,7 @@ type Messages
 
         # external fields: there are 2 terms, a noise to break potential symmetries
         #                  and one to favor newest versions over older, and no-version over all
-        fld = [ [ FieldValue(0,VersionWeight(0),vweight[p0][v0],0,noise(p0,v0)) for v0 = 1:spp[p0] ] for p0 = 1:np]
+        fld = [ [ FieldValue(0,zero(VersionWeight),vweight[p0][v0],0,noise(p0,v0)) for v0 = 1:spp[p0] ] for p0 = 1:np]
 
         # enforce requirements
         for (rp, rvs) in reqs

--- a/base/pkg2/resolve/versionweight.jl
+++ b/base/pkg2/resolve/versionweight.jl
@@ -2,42 +2,200 @@ module VersionWeights
 
 export VersionWeight
 
+immutable HierarchicalValue{T}
+    v::Vector{T}
+    rest::T
+end
+
+HierarchicalValue{T}(v::Vector{T}, rest::T = zero(T)) = HierarchicalValue{T}(v, rest)
+HierarchicalValue(T::Type) = HierarchicalValue(T[])
+
+Base.zero{T}(::Type{HierarchicalValue{T}}) = HierarchicalValue(T)
+
+Base.typemin{T}(::Type{HierarchicalValue{T}}) = HierarchicalValue(T[], typemin(T))
+Base.typemax{T}(::Type{HierarchicalValue{T}}) = HierarchicalValue(T[], typemax(T))
+
+for (bf,f) in ((:(:-), :-), (:(:+),:+))
+    @eval function Base.($bf){T}(a::HierarchicalValue{T}, b::HierarchicalValue{T})
+        av = a.v
+        bv = b.v
+        la = length(a.v)
+        lb = length(b.v)
+        l0 = min(la, lb)
+        l1 = max(la, lb)
+        ld = la - lb
+        rv = Array(T, l1)
+        rf = ($f)(a.rest, b.rest)
+        @inbounds for i = 1:l0
+            rv[i] = ($f)(av[i], bv[i])
+        end
+        @inbounds for i = l0+1:l0+ld
+            rv[i] = ($f)(av[i], b.rest)
+        end
+        @inbounds for i = l0+1:l0-ld
+            rv[i] = ($f)(a.rest, bv[i])
+        end
+        return HierarchicalValue(rv, rf)
+    end
+end
+
+Base.(:-){T}(a::HierarchicalValue{T}) = HierarchicalValue(-a.v, -a.rest)
+
+function Base.cmp{T}(a::HierarchicalValue{T}, b::HierarchicalValue{T})
+    av = a.v
+    bv = b.v
+    la = length(a.v)
+    lb = length(b.v)
+    l0 = min(la, lb)
+    l1 = max(la, lb)
+    ld = la - lb
+    rv = Array(T, l1)
+    @inbounds for i = 1:l0
+        c = cmp(av[i], bv[i]); c != 0 && return c
+    end
+    @inbounds for i = l0+1:l0+ld
+        c = cmp(av[i], b.rest); c != 0 && return c
+    end
+    @inbounds for i = l0+1:l0-ld
+        c = cmp(a.rest, bv[i]); c != 0 && return c
+    end
+    return cmp(a.rest, b.rest)
+end
+Base.isless{T}(a::HierarchicalValue{T}, b::HierarchicalValue{T}) = (cmp(a, b) == -1)
+Base.isequal{T}(a::HierarchicalValue{T}, b::HierarchicalValue{T}) = (a.v == b.v) && (a.rest == b.rest)
+
+Base.abs{T}(a::HierarchicalValue{T}) = HierarchicalValue(T[abs(x) for x in a.v], abs(a.rest))
+
+bpencode(ident::ASCIIString) =
+    Int[c == '-' ? 1 :
+        ('0' <= c <= '9') ? (c - '0' + 2) :
+        ('A' <= c <= 'Z') ? (c - 'A' + 12) :
+        # 'a' <= c <= 'z'
+        (c - 'a' + 38) for c in ident]
+
+immutable VWPreBuildItem
+    nonempty::Int
+    s::HierarchicalValue{Int}
+    i::Int
+end
+VWPreBuildItem() = VWPreBuildItem(0, HierarchicalValue(Int), 0)
+VWPreBuildItem(i::Int) = VWPreBuildItem(1, HierarchicalValue(Int), i)
+VWPreBuildItem(s::ASCIIString) = VWPreBuildItem(1, HierarchicalValue(bpencode(s)), 0)
+
+Base.zero(::Type{VWPreBuildItem}) = VWPreBuildItem()
+
+Base.typemin(::Type{VWPreBuildItem}) = (x=typemin(Int); VWPreBuildItem(x, HierarchicalValue(Int[], x), x))
+Base.typemax(::Type{VWPreBuildItem}) = (x=typemax(Int); VWPreBuildItem(x, HierarchicalValue(Int[], x), x))
+
+Base.(:-)(a::VWPreBuildItem, b::VWPreBuildItem) = VWPreBuildItem(a.nonempty-b.nonempty, a.s-b.s, a.i-b.i)
+Base.(:+)(a::VWPreBuildItem, b::VWPreBuildItem) = VWPreBuildItem(a.nonempty+b.nonempty, a.s+b.s, a.i+b.i)
+
+Base.(:-)(a::VWPreBuildItem) = VWPreBuildItem(-a.nonempty, -a.s, -a.i)
+
+function Base.cmp(a::VWPreBuildItem, b::VWPreBuildItem)
+    c = cmp(a.nonempty, b.nonempty); c != 0 && return c
+    c = cmp(a.s, b.s); c != 0 && return c
+    return cmp(a.i, b.i)
+end
+Base.isless(a::VWPreBuildItem, b::VWPreBuildItem) = (cmp(a,b) == -1)
+Base.isequal(a::VWPreBuildItem, b::VWPreBuildItem) = (cmp(a,b) == 0)
+
+Base.abs(a::VWPreBuildItem) = VWPreBuildItem(abs(a.nonempty), abs(a.s), abs(a.i))
+
+immutable VWPreBuild
+    nonempty::Int
+    w::HierarchicalValue{VWPreBuildItem}
+end
+
+function VWPreBuild(ispre::Bool, desc::(Union(Int,ASCIIString)...))
+    isempty(desc) && return VWPreBuild(0, HierarchicalValue(VWPreBuildItem))
+    desc == ("",) && return VWPreBuild(ispre ? -1 : 1, HierarchicalValue(VWPreBuildItem[]))
+    nonempty = ispre ? -1 : 0
+    w = Array(VWPreBuildItem, length(desc))
+    i = 1
+    @inbounds for item in desc
+        w[i] = VWPreBuildItem(item)
+        i += 1
+    end
+    return VWPreBuild(nonempty, HierarchicalValue(w))
+end
+VWPreBuild() = VWPreBuild(0, HierarchicalValue(VWPreBuildItem))
+
+Base.zero(::Type{VWPreBuild}) = VWPreBuild()
+
+Base.typemin(::Type{VWPreBuild}) = VWPreBuild(typemin(Int), typemin(HierarchicalValue{VWPreBuildItem}))
+Base.typemax(::Type{VWPreBuild}) = VWPreBuild(typemax(Int), typemax(HierarchicalValue{VWPreBuildItem}))
+
+Base.(:-)(a::VWPreBuild, b::VWPreBuild) = VWPreBuild(a.nonempty-b.nonempty, a.w-b.w)
+Base.(:+)(a::VWPreBuild, b::VWPreBuild) = VWPreBuild(a.nonempty+b.nonempty, a.w+b.w)
+
+Base.(:-)(a::VWPreBuild) = VWPreBuild(-a.nonempty, -a.w)
+
+function Base.cmp(a::VWPreBuild, b::VWPreBuild)
+    c = cmp(a.nonempty, b.nonempty); c != 0 && return c
+    return cmp(a.w, b.w)
+end
+Base.isless(a::VWPreBuild, b::VWPreBuild) = (cmp(a,b) == -1)
+Base.isequal(a::VWPreBuild, b::VWPreBuild) = (cmp(a,b) == 0)
+
+Base.abs(a::VWPreBuild) = VWPreBuild(abs(a.nonempty), abs(a.w))
+
 # The numeric type used to determine how the different
 # versions of a package should be weighed
 immutable VersionWeight
     major::Int
     minor::Int
     patch::Int
+    prerelease::VWPreBuild
+    build::VWPreBuild
     uninstall::Int
 end
-VersionWeight(major::Int,minor::Int,patch::Int) = VersionWeight(major, minor, patch, 0)
+VersionWeight(major::Int,minor::Int,patch::Int,prerelease::VWPreBuild,build::VWPreBuild) = VersionWeight(major, minor, patch, prerelease, build, 0)
+VersionWeight(major::Int,minor::Int,patch::Int,prerelease::VWPreBuild) = VersionWeight(major, minor, patch, prerelease, zero(VWPreBuild))
+VersionWeight(major::Int,minor::Int,patch::Int) = VersionWeight(major, minor, patch, zero(VWPreBuild))
 VersionWeight(major::Int,minor::Int) = VersionWeight(major, minor, 0)
 VersionWeight(major::Int) = VersionWeight(major, 0)
 VersionWeight() = VersionWeight(0)
 
-VersionWeight(vn::VersionNumber, uninstall=false) = VersionWeight(vn.major, vn.minor, vn.patch, int(uninstall))
+VersionWeight(vn::VersionNumber, uninstall=false) =
+    VersionWeight(vn.major, vn.minor, vn.patch,
+                  VWPreBuild(true, vn.prerelease), VWPreBuild(false, vn.build),
+                  int(uninstall))
 
 Base.zero(::Type{VersionWeight}) = VersionWeight()
 
-Base.typemin(::Type{VersionWeight}) = (x=typemin(Int); VersionWeight(x,x,x,x))
-Base.typemax(::Type{VersionWeight}) = (x=typemax(Int); VersionWeight(x,x,x,x))
+Base.typemin(::Type{VersionWeight}) = (x=typemin(Int); y=typemin(VWPreBuild); VersionWeight(x,x,x,y,y,x))
+Base.typemax(::Type{VersionWeight}) = (x=typemax(Int); y=typemax(VWPreBuild); VersionWeight(x,x,x,y,y,x))
 
-Base.(:-)(a::VersionWeight, b::VersionWeight) = VersionWeight(a.major-b.major, a.minor-b.minor, a.patch-b.patch, a.uninstall-b.uninstall)
-Base.(:+)(a::VersionWeight, b::VersionWeight) = VersionWeight(a.major+b.major, a.minor+b.minor, a.patch+b.patch, a.uninstall+b.uninstall)
+Base.(:-)(a::VersionWeight, b::VersionWeight) =
+    VersionWeight(a.major-b.major, a.minor-b.minor, a.patch-b.patch,
+                  a.prerelease-b.prerelease, a.build-b.build,
+                  a.uninstall-b.uninstall)
 
-Base.(:-)(a::VersionWeight) = VersionWeight(-a.major, -a.minor, -a.patch, -a.uninstall)
+Base.(:+)(a::VersionWeight, b::VersionWeight) =
+    VersionWeight(a.major+b.major, a.minor+b.minor, a.patch+b.patch,
+                  a.prerelease+b.prerelease, a.build+b.build,
+                  a.uninstall+b.uninstall)
 
-function Base.isless(a::VersionWeight, b::VersionWeight)
-    a.major < b.major && return true
-    a.major > b.major && return false
-    a.minor < b.minor && return true
-    a.minor > b.minor && return false
-    a.patch < b.patch && return true
-    a.patch > b.patch && return false
-    a.uninstall < b.uninstall && return true
-    return false
+Base.(:-)(a::VersionWeight) =
+    VersionWeight(-a.major, -a.minor, -a.patch,
+                  -a.prerelease, -a.build,
+                  -a.uninstall)
+
+function Base.cmp(a::VersionWeight, b::VersionWeight)
+    c = cmp(a.major, b.major); c != 0 && return c
+    c = cmp(a.minor, b.minor); c != 0 && return c
+    c = cmp(a.patch, b.patch); c != 0 && return c
+    c = cmp(a.prerelease, b.prerelease); c != 0 && return c
+    c = cmp(a.build, b.build); c != 0 && return c
+    return cmp(a.uninstall, b.uninstall)
 end
+Base.isless(a::VersionWeight, b::VersionWeight) = (cmp(a, b) == -1)
+Base.isequal(a::VersionWeight, b::VersionWeight) = (cmp(a, b) == 0)
 
-Base.abs(a::VersionWeight) = VersionWeight(abs(a.major), abs(a.minor), abs(a.patch), abs(a.uninstall))
+Base.abs(a::VersionWeight) =
+    VersionWeight(abs(a.major), abs(a.minor), abs(a.patch),
+                  abs(a.prerelease), abs(a.build),
+                  abs(a.uninstall))
 
 end

--- a/base/pkg2/types.jl
+++ b/base/pkg2/types.jl
@@ -1,27 +1,18 @@
 module Types
 
 export VersionInterval, VersionSet, Requires, Available, Fixed,
-       merge_requires!, satisfies, normal, @recover
-
-normal(v::VersionNumber) = VersionNumber(v.major, v.minor, v.patch)
+       merge_requires!, satisfies, @recover
 
 immutable VersionInterval
     lower::VersionNumber
     upper::VersionNumber
-    VersionInterval(lower::VersionNumber, upper::VersionNumber) = new(normal(lower), normal(upper))
 end
 VersionInterval(lower::VersionNumber) = VersionInterval(lower,typemax(VersionNumber))
 VersionInterval() = VersionInterval(typemin(VersionNumber))
 
-function Base.show(io::IO, i::VersionInterval)
-    if i.upper == normal(typemax(VersionNumber))
-        print(io, "[$(i.lower),$(typemax(VersionNumber)))")
-    else
-        print(io, "[$(i.lower),$(i.upper))")
-    end
-end
+Base.show(io::IO, i::VersionInterval) = print(io, "[$(i.lower),$(i.upper))")
 Base.isempty(i::VersionInterval) = i.upper <= i.lower
-Base.contains(i::VersionInterval, v::VersionNumber) = i.lower <= normal(v) < i.upper
+Base.contains(i::VersionInterval, v::VersionNumber) = i.lower <= v < i.upper
 Base.intersect(a::VersionInterval, b::VersionInterval) = VersionInterval(max(a.lower,b.lower), min(a.upper,b.upper))
 Base.isequal(a::VersionInterval, b::VersionInterval) = (a.lower == b.lower) & (a.upper == b.upper)
 

--- a/test/resolve2.jl
+++ b/test/resolve2.jl
@@ -1,22 +1,74 @@
 using Base.Pkg2.Types
 using Base.Pkg2.Query
 using Base.Pkg2.Resolve
+using Base.Pkg2.Resolve.VersionWeights
+
+# Check that VersionWeight keeps the same ordering as VersionNumber
+
+vlst = [
+    v"0.0.0",
+    v"0.0.1",
+    v"0.1.0",
+    v"0.1.1",
+    v"1.0.0",
+    v"1.0.1",
+    v"1.1.0",
+    v"1.1.1",
+    v"1.0.0-pre",
+    v"1.0.0-pre1",
+    v"1.0.1-pre",
+    v"1.0.0-0.pre.2",
+    v"1.0.0-0.pre.3",
+    v"1.0.0-0.pre1.tst",
+    v"1.0.0-pre.1+0.1",
+    v"1.0.0-pre.1+0.1plus",
+    v"1.0.0-pre.1-+0.1plus",
+    v"1.0.0-pre.1-+0.1Plus",
+    v"1.0.0-pre.1-+0.1pLUs",
+    v"1.0.0-pre.1-+0.1pluS",
+    v"1.0.0+0.1plus",
+    v"1.0.0+0.1plus-",
+    v"1.0.0+-",
+    v"1.0.0-",
+    v"1.0.0+",
+    v"1.0.0--",
+    v"1.0.0---",
+    v"1.0.0--+-",
+    v"1.0.0+--",
+    v"1.0.0+-.-",
+    v"1.0.0+0.-",
+    v"1.0.0+-.0",
+    v"1.0.0-a+--",
+    v"1.0.0-a+-.-",
+    v"1.0.0-a+0.-",
+    v"1.0.0-a+-.0"
+    ]
+
+for v1 in vlst, v2 in vlst
+    vw1 = VersionWeight(v1)
+    vw2 = VersionWeight(v2)
+    clt = v1 < v2
+    @test clt == (vw1 < vw2)
+    ceq = v1 == v2
+    @test ceq == (vw1 == vw2)
+end
+
+# auxiliary functions
 
 function deps_from_data(deps_data)
     deps = Dict{ByteString,Dict{VersionNumber,Available}}()
     for d in deps_data
-        p = d[1]; vnn = d[2]; r = d[3:end]
+        p = d[1]; vn = d[2]; r = d[3:end]
         if !haskey(deps, p)
             deps[p] = (VersionNumber=>Available)[]
         end
-        vn = VersionNumber(vnn)
         if !haskey(deps[p], vn)
             deps[p][vn] = Available("$(p)_$(vn)_sha1", (ByteString=>VersionSet)[])
         end
         isempty(r) && continue
         rp = r[1]
         if length(r) > 1
-            rvs = VersionSet([VersionNumber(w) for w=r[2:end]])
+            rvs = VersionSet(VersionNumber[r[2:end]...])
         else
             rvs = VersionSet()
         end
@@ -27,8 +79,8 @@ end
 function reqs_from_data(reqs_data)
     reqs = (ByteString=>VersionSet)[]
     for r in reqs_data
-        p = r[1]; vns = r[2:end]
-        reqs[p] = VersionSet([VersionNumber(vn) for vn in vns])
+        p = r[1]
+        reqs[p] = VersionSet(VersionNumber[r[2:end]...])
     end
     reqs
 end
@@ -58,10 +110,10 @@ end
 
 ## DEPENDENCY SCHEME 1: TWO PACKAGES, DAG
 deps_data = {
-    {"A", 1, "B", 1},
-    {"A", 2, "B", 2},
-    {"B", 1, },
-    {"B", 2, }
+    {"A", v"1", "B", v"1"},
+    {"A", v"2", "B", v"2"},
+    {"B", v"1"},
+    {"B", v"2"}
 }
 
 @test sanity_tst(deps_data)
@@ -72,22 +124,22 @@ reqs_data = {
 }
 
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["B"=>VersionNumber(2)]
+@test want == ["B"=>v"2"]
 
 # require just A: must bring in B
 reqs_data = {
     {"A"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(2), "B"=>VersionNumber(2)]
+@test want == ["A"=>v"2", "B"=>v"2"]
 
 
 ## DEPENDENCY SCHEME 2: TWO PACKAGES, CYCLIC
 deps_data = {
-    {"A", 1, "B", 2},
-    {"A", 2, "B", 1},
-    {"B", 1, "A", 2},
-    {"B", 2, "A", 1}
+    {"A", v"1", "B", v"2"},
+    {"A", v"2", "B", v"1"},
+    {"B", v"1", "A", v"2"},
+    {"B", v"2", "A", v"1"}
 }
 
 @test sanity_tst(deps_data)
@@ -97,31 +149,31 @@ reqs_data = {
     {"A"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(2), "B"=>VersionNumber(2)]
+@test want == ["A"=>v"2", "B"=>v"2"]
 
 # require just B, force lower version
 reqs_data = {
-    {"B", 1, 2}
+    {"B", v"1", v"2"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(2), "B"=>VersionNumber(1)]
+@test want == ["A"=>v"2", "B"=>v"1"]
 
 # require just A, force lower version
 reqs_data = {
-    {"A", 1, 2}
+    {"A", v"1", v"2"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(1), "B"=>VersionNumber(2)]
+@test want == ["A"=>v"1", "B"=>v"2"]
 
 
 ## DEPENDENCY SCHEME 3: THREE PACKAGES, CYCLIC, TWO MUTUALLY EXCLUSIVE SOLUTIONS
 deps_data = {
-    {"A", 1, "B", 2},
-    {"A", 2, "B", 1, 2},
-    {"B", 1, "C", 2},
-    {"B", 2, "C", 1, 2},
-    {"C", 1, "A", 1, 2},
-    {"C", 2, "A", 2}
+    {"A", v"1", "B", v"2"},
+    {"A", v"2", "B", v"1", v"2"},
+    {"B", v"1", "C", v"2"},
+    {"B", v"2", "C", v"1", v"2"},
+    {"C", v"1", "A", v"1", v"2"},
+    {"C", v"2", "A", v"2"}
 }
 
 @test sanity_tst(deps_data)
@@ -131,84 +183,84 @@ reqs_data = {
     {"A"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(2), "B"=>VersionNumber(1), "C"=>VersionNumber(2)]
+@test want == ["A"=>v"2", "B"=>v"1", "C"=>v"2"]
 
 # require just B (must choose solution which has the highest version for B)
 reqs_data = {
     {"B"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(1), "B"=>VersionNumber(2), "C"=>VersionNumber(1)]
+@test want == ["A"=>v"1", "B"=>v"2", "C"=>v"1"]
 
 # require just A, force lower version
 reqs_data = {
-    {"A", 1, 2}
+    {"A", v"1", v"2"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(1), "B"=>VersionNumber(2), "C"=>VersionNumber(1)]
+@test want == ["A"=>v"1", "B"=>v"2", "C"=>v"1"]
 
 # require A and C, incompatible versions
 reqs_data = {
-    {"A", 1, 2},
-    {"C", 2}
+    {"A", v"1", v"2"},
+    {"C", v"2"}
 }
 @test_throws resolve_tst(deps_data, reqs_data)
 
 
 ## DEPENDENCY SCHEME 4: TWO PACKAGES, DAG, WITH TRIVIAL INCONSISTENCY
 deps_data = {
-    {"A", 1, "B", 2},
-    {"B", 1}
+    {"A", v"1", "B", v"2"},
+    {"B", v"1"}
 }
 
-@test sanity_tst(deps_data, {("A", VersionNumber(1))})
+@test sanity_tst(deps_data, {("A", v"1")})
 
 # require B (must not give errors)
 reqs_data = {
     {"B"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["B"=>VersionNumber(1)]
+@test want == ["B"=>v"1"]
 
 
 ## DEPENDENCY SCHEME 5: THREE PACKAGES, DAG, WITH IMPLICIT INCONSISTENCY
 deps_data = {
-    {"A", 1, "B", 2},
-    {"A", 1, "C", 2},
-    {"A", 2, "B", 1, 2},
-    {"A", 2, "C", 1, 2},
-    {"B", 1, "C", 2},
-    {"B", 2, "C", 2},
-    {"C", 1},
-    {"C", 2}
+    {"A", v"1", "B", v"2"},
+    {"A", v"1", "C", v"2"},
+    {"A", v"2", "B", v"1", v"2"},
+    {"A", v"2", "C", v"1", v"2"},
+    {"B", v"1", "C", v"2"},
+    {"B", v"2", "C", v"2"},
+    {"C", v"1"},
+    {"C", v"2"}
 }
 
-@test sanity_tst(deps_data, {("A", VersionNumber(2))})
+@test sanity_tst(deps_data, {("A", v"2")})
 
 # require A, any version (must use the highest non-inconsistent)
 reqs_data = {
     {"A"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(1), "B"=>VersionNumber(2), "C"=>VersionNumber(2)]
+@test want == ["A"=>v"1", "B"=>v"2", "C"=>v"2"]
 
 # require A, force highest version (impossible)
 reqs_data = {
-    {"A", 2}
+    {"A", v"2"}
 }
 @test_throws resolve_tst(deps_data, reqs_data)
 
 
 ## DEPENDENCY SCHEME 6: TWO PACKAGES, CYCLIC, TOTALLY INCONSISTENT
 deps_data = {
-    {"A", 1, "B", 2},
-    {"A", 2, "B", 1, 2},
-    {"B", 1, "A", 1, 2},
-    {"B", 2, "A", 2}
+    {"A", v"1", "B", v"2"},
+    {"A", v"2", "B", v"1", v"2"},
+    {"B", v"1", "A", v"1", v"2"},
+    {"B", v"2", "A", v"2"}
 }
 
-@test sanity_tst(deps_data, {("A", VersionNumber(1)), ("A", VersionNumber(2)),
-                             ("B", VersionNumber(1)), ("B", VersionNumber(2))})
+@test sanity_tst(deps_data, {("A", v"1"), ("A", v"2"),
+                             ("B", v"1"), ("B", v"2")})
 
 # require A (impossible)
 reqs_data = {
@@ -225,51 +277,51 @@ reqs_data = {
 
 ## DEPENDENCY SCHEME 7: THREE PACKAGES, CYCLIC, WITH INCONSISTENCY
 deps_data = {
-    {"A", 1, "B", 1, 2},
-    {"A", 2, "B", 2},
-    {"B", 1, "C", 1, 2},
-    {"B", 2, "C", 2},
-    {"C", 1, "A", 2},
-    {"C", 2, "A", 2},
+    {"A", v"1", "B", v"1", v"2"},
+    {"A", v"2", "B", v"2"},
+    {"B", v"1", "C", v"1", v"2"},
+    {"B", v"2", "C", v"2"},
+    {"C", v"1", "A", v"2"},
+    {"C", v"2", "A", v"2"},
 }
 
-@test sanity_tst(deps_data, {("A", VersionNumber(1)), ("B", VersionNumber(1)),
-                             ("C", VersionNumber(1))})
+@test sanity_tst(deps_data, {("A", v"1"), ("B", v"1"),
+                             ("C", v"1")})
 
 # require A
 reqs_data = {
     {"A"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(2), "B"=>VersionNumber(2), "C"=>VersionNumber(2)]
+@test want == ["A"=>v"2", "B"=>v"2", "C"=>v"2"]
 
 # require C
 reqs_data = {
     {"C"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(2), "B"=>VersionNumber(2), "C"=>VersionNumber(2)]
+@test want == ["A"=>v"2", "B"=>v"2", "C"=>v"2"]
 
 # require C, lowest version (impossible)
 reqs_data = {
-    {"C", 1, 2}
+    {"C", v"1", v"2"}
 }
 @test_throws resolve_tst(deps_data, reqs_data)
 
 
 ## DEPENDENCY SCHEME 8: THREE PACKAGES, CYCLIC, TOTALLY INCONSISTENT
 deps_data = {
-    {"A", 1, "B", 1, 2},
-    {"A", 2, "B", 2},
-    {"B", 1, "C", 1, 2},
-    {"B", 2, "C", 2},
-    {"C", 1, "A", 2},
-    {"C", 2, "A", 1, 2},
+    {"A", v"1", "B", v"1", v"2"},
+    {"A", v"2", "B", v"2"},
+    {"B", v"1", "C", v"1", v"2"},
+    {"B", v"2", "C", v"2"},
+    {"C", v"1", "A", v"2"},
+    {"C", v"2", "A", v"1", v"2"},
 }
 
-@test sanity_tst(deps_data, {("A", VersionNumber(1)), ("A", VersionNumber(2)),
-                             ("B", VersionNumber(1)), ("B", VersionNumber(2)),
-                             ("C", VersionNumber(1)), ("C", VersionNumber(2))})
+@test sanity_tst(deps_data, {("A", v"1"), ("A", v"2"),
+                             ("B", v"1"), ("B", v"2"),
+                             ("C", v"1"), ("C", v"2")})
 
 # require A (impossible)
 reqs_data = {
@@ -291,20 +343,20 @@ reqs_data = {
 
 ## DEPENDENCY SCHEME 9: SIX PACKAGES, DAG
 deps_data = {
-    {"A", 1},
-    {"A", 2},
-    {"A", 3},
-    {"B", 1, "A", 1, 2},
-    {"B", 2, "A"},
-    {"C", 1, "A", 2, 3},
-    {"C", 2, "A", 2},
-    {"D", 1, "B", 1},
-    {"D", 2, "B", 2},
-    {"E", 1, "D"},
-    {"F", 1, "A", 1, 3},
-    {"F", 1, "E"},
-    {"F", 2, "C", 2},
-    {"F", 2, "E"},
+    {"A", v"1"},
+    {"A", v"2"},
+    {"A", v"3"},
+    {"B", v"1", "A", v"1", v"2"},
+    {"B", v"2", "A"},
+    {"C", v"1", "A", v"2", v"3"},
+    {"C", v"2", "A", v"2"},
+    {"D", v"1", "B", v"1"},
+    {"D", v"2", "B", v"2"},
+    {"E", v"1", "D"},
+    {"F", v"1", "A", v"1", v"3"},
+    {"F", v"1", "E"},
+    {"F", v"2", "C", v"2"},
+    {"F", v"2", "E"},
 }
 
 @test sanity_tst(deps_data)
@@ -314,40 +366,114 @@ reqs_data = {
     {"F"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(3), "B"=>VersionNumber(2), "C"=>VersionNumber(2),
-               "D"=>VersionNumber(2), "E"=>VersionNumber(1), "F"=>VersionNumber(2)]
+@test want == ["A"=>v"3", "B"=>v"2", "C"=>v"2",
+               "D"=>v"2", "E"=>v"1", "F"=>v"2"]
 
 # require just F, lower version
 reqs_data = {
-    {"F", 1, 2}
+    {"F", v"1", v"2"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(2), "B"=>VersionNumber(2), "D"=>VersionNumber(2),
-               "E"=>VersionNumber(1), "F"=>VersionNumber(1)]
+@test want == ["A"=>v"2", "B"=>v"2", "D"=>v"2",
+               "E"=>v"1", "F"=>v"1"]
 
 # require F and B; force lower B version -> must bring down F, A, and D versions too
 reqs_data = {
     {"F"},
-    {"B", 1, 2}
+    {"B", v"1", v"2"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(1), "B"=>VersionNumber(1), "D"=>VersionNumber(1),
-               "E"=>VersionNumber(1), "F"=>VersionNumber(1)]
+@test want == ["A"=>v"1", "B"=>v"1", "D"=>v"1",
+               "E"=>v"1", "F"=>v"1"]
 
 # require F and D; force lower D version -> must not bring down F version
 reqs_data = {
     {"F"},
-    {"D", 1, 2}
+    {"D", v"1", v"2"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(3), "B"=>VersionNumber(2), "C"=>VersionNumber(2),
-               "D"=>VersionNumber(1), "E"=>VersionNumber(1), "F"=>VersionNumber(2)]
+@test want == ["A"=>v"3", "B"=>v"2", "C"=>v"2",
+               "D"=>v"1", "E"=>v"1", "F"=>v"2"]
 
 # require F and C; force lower C version -> must bring down F and A versions
 reqs_data = {
     {"F"},
-    {"C", 1, 2}
+    {"C", v"1", v"2"}
 }
 want = resolve_tst(deps_data, reqs_data)
-@test want == ["A"=>VersionNumber(2), "B"=>VersionNumber(2), "C"=>VersionNumber(1),
-               "D"=>VersionNumber(2), "E"=>VersionNumber(1), "F"=>VersionNumber(1)]
+@test want == ["A"=>v"2", "B"=>v"2", "C"=>v"1",
+               "D"=>v"2", "E"=>v"1", "F"=>v"1"]
+
+## DEPENDENCY SCHEME 10: SIX PACKAGES, DAG, WITH PRERELEASE/BUILD VERSIONS
+deps_data = {
+    {"A", v"1"},
+    {"A", v"2-rc.1"},
+    {"A", v"2-rc.1+bld"},
+    {"A", v"2"},
+    {"A", v"2.1.0"},
+    {"B", v"1", "A", v"1", v"2-"},
+    {"B", v"1.0.1-beta", "A", v"2-rc"},
+    {"B", v"1.0.1", "A"},
+    {"C", v"1", "A", v"2-", v"2.1"},
+    {"C", v"1+BLD", "A", v"2-rc.1", v"2.1"},
+    {"C", v"2", "A", v"2-rc.1"},
+    {"D", v"1", "B", v"1"},
+    {"D", v"2", "B", v"1.0.1-"},
+    {"E", v"1-plztst", "D"},
+    {"E", v"1", "D"},
+    {"F", v"1.1", "A", v"1", v"2.1"},
+    {"F", v"1.1", "E", v"1"},
+    {"F", v"2-rc.1", "A", v"2-", v"2.1"},
+    {"F", v"2-rc.1", "C", v"1"},
+    {"F", v"2-rc.1", "E"},
+    {"F", v"2-rc.2", "A", v"2-", v"2.1"},
+    {"F", v"2-rc.2", "C", v"2"},
+    {"F", v"2-rc.2", "E"},
+    {"F", v"2", "C", v"2"},
+    {"F", v"2", "E"},
+}
+
+@test sanity_tst(deps_data)
+
+# require just F
+reqs_data = {
+    {"F"}
+}
+want = resolve_tst(deps_data, reqs_data)
+@test want == ["A"=>v"2.1", "B"=>v"1.0.1", "C"=>v"2",
+               "D"=>v"2", "E"=>v"1", "F"=>v"2"]
+
+# require just F, lower version
+reqs_data = {
+    {"F", v"1", v"2-"}
+}
+want = resolve_tst(deps_data, reqs_data)
+@test want == ["A"=>v"2", "B"=>v"1.0.1", "D"=>v"2",
+               "E"=>v"1", "F"=>v"1.1"]
+
+# require F and B; force lower B version -> must bring down F, A, and D versions too
+reqs_data = {
+    {"F"},
+    {"B", v"1", v"1.0.1-"}
+}
+want = resolve_tst(deps_data, reqs_data)
+@test want == ["A"=>v"1", "B"=>v"1", "D"=>v"1",
+               "E"=>v"1", "F"=>v"1.1"]
+
+# require F and D; force lower D version -> must not bring down F version
+reqs_data = {
+    {"F"},
+    {"D", v"1", v"2"}
+}
+want = resolve_tst(deps_data, reqs_data)
+@test want == ["A"=>v"2.1", "B"=>v"1.0.1", "C"=>v"2",
+               "D"=>v"1", "E"=>v"1", "F"=>v"2"]
+
+# require F and C; force lower C version -> must bring down F and A versions
+reqs_data = {
+    {"F"},
+    {"C", v"1", v"2"}
+}
+want = resolve_tst(deps_data, reqs_data)
+@test want == ["A"=>v"2", "B"=>v"1.0.1", "C"=>v"1+BLD",
+               "D"=>v"2", "E"=>v"1", "F"=>v"2-rc.1"]


### PR DESCRIPTION
@StefanKarpinski
I managed to convert VersionNumbers to weights in a general way (i.e. including prerelease/build fields). The implementation is quite complicated and at times rather arbitrary, but it's hidden away from the main API, and it works fine (and I think fulfills our purposes). Performance hit seems negligible for reasonable use cases (surprisingly).
This means that requirement files will again deal with prereleases/build versions just like they do in Pkg1, and therefore that a requirement such as `julia 0.1- 0.2-` is again meaningful. See commit messages and new tests in `test/resolve2` for more details (or just ask).
