### PR TITLE
Fix isdeprecated() call in doc/DocCheck.jl

### DIFF
--- a/doc/DocCheck.jl
+++ b/doc/DocCheck.jl
@@ -101,7 +101,7 @@ function _undocumented_rst()
                s = symbol(line) # for submodules: string(:Sort) == "Base.Sort"
                if !isdefined(s) continue end
                if haskey(FUNCTION_DICT, line) || haskey(MODULE_DICT, line) || haskey(CATEGORY_DICT, string(s))
-                  m = getkey(MODULE_DICT, line, "")
+                  m = eval(symbol(getkey(MODULE_DICT, line, "Base")))
                   isdeprecated(m,s) && continue
                   havecount+=1; total+=1; continue
                end


### PR DESCRIPTION
Error is

``` julia
julia> DocCheck.undocumented_rst()
Loading help data...
ERROR: no method isdeprecated(ASCIIString,Symbol)
 in _undocumented_rst at /home/kmsquire/Source/julia/doc/DocCheck.jl:107
 in undocumented_rst at /home/kmsquire/Source/julia/doc/DocCheck.jl:138
```

I'm not quite sure how this worked before, but either the first parameter needs to be a Module, or needs to be removed.  This pull request jumps through hoops to make it a module. Let me know if there's a better way to do this.
