### PR TITLE
RFC: Show  build status for packages which have travis integration

### DIFF
--- a/doc/packages/packagelist.rst
+++ b/doc/packages/packagelist.rst
@@ -14,9 +14,11 @@ _______________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Generate simple plots as ASCII art in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-07-26) 
 
-  Generate simple plots as ASCII art in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -44,9 +46,11 @@ _____________________________________________
      :alt: Amit Murthy
      :target: https://github.com/amitmurthy
 
+  Julia interface to AWS 
+
   Current Version: ``0.0.0``  (updated: 2013-07-09) 
 
-  Julia interface to AWS 
+  Master build status: No Travis-CI build
 
   Maintainer: `Amit Murthy <https://github.com/amitmurthy>`_
 
@@ -84,9 +88,11 @@ _______________________________________________________
      :alt: dlfivefifty
      :target: https://github.com/dlfivefifty
 
+  Julia IFun Implementation 
+
   Current Version: ``0.0.0``  (updated: 2013-07-15) 
 
-  Julia IFun Implementation 
+  Master build status: No Travis-CI build
 
   Maintainer: `dlfivefifty <https://github.com/dlfivefifty>`_
 
@@ -120,9 +126,14 @@ __________________________________________________________
      :alt: Carlo Baldassi
      :target: https://github.com/carlobaldassi
 
+  Package for parsing command-line arguments to Julia programs. 
+
   Current Version: ``0.2.4``  (updated: 2013-06-18) 
 
-  Package for parsing command-line arguments to Julia programs. 
+  Master build status: |ArgParse_build|
+
+  .. |ArgParse_build| image:: https://api.travis-ci.org/carlobaldassi/ArgParse.jl.png
+     :align: bottom
 
   Maintainer: `Carlo Baldassi <https://github.com/carlobaldassi>`_
 
@@ -164,9 +175,11 @@ _________________________________________________
      :alt: gusl
      :target: https://github.com/gusl
 
+   
+
   Current Version: ``0.0.0``  (updated: 2013-04-11) 
 
-   
+  Master build status: No Travis-CI build
 
   Maintainer: `gusl <https://github.com/gusl>`_
 
@@ -194,9 +207,11 @@ _____________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  A package for benchmarking code and packages 
+
   Current Version: ``0.0.1``  (updated: 2013-06-23) 
 
-  A package for benchmarking code and packages 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -237,9 +252,11 @@ ___________________________________________________
      :alt: Keno Fischer
      :target: https://github.com/loladiro
 
+  Tool for building binary dependencies for Julia modules 
+
   Current Version: ``0.2.2``  (updated: 2013-07-31) 
 
-  Tool for building binary dependencies for Julia modules 
+  Master build status: No Travis-CI build
 
   Maintainer: `Keno Fischer <https://github.com/loladiro>`_
 
@@ -298,9 +315,11 @@ _________________________________________________
      :alt: Diego Javier Zea
      :target: https://github.com/diegozea
 
+  Julia's package for working on Bioinformatics with DNA, RNA and Protein Sequences 
+
   Current Version: ``0.2.1``  (updated: 2013-05-25) 
 
-  Julia's package for working on Bioinformatics with DNA, RNA and Protein Sequences 
+  Master build status: No Travis-CI build
 
   Maintainer: `Diego Javier Zea <https://github.com/diegozea>`_
 
@@ -324,6 +343,40 @@ _________________________________________________
 
 ----
 
+`Blocks <https://github.com/tanmaykm/Blocks.jl>`_
+_________________________________________________
+
+  .. image:: https://secure.gravatar.com/avatar/eea0b193dae8ac47946202ee404a6d7a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+     :height: 80px
+     :width: 80px
+     :align: right
+     :alt: Tanmay Mohapatra
+     :target: https://github.com/tanmaykm
+
+  A framework to represent chunks of entities and parallel methods on them. 
+
+  Current Version: ``0.0.0``  (updated: 2013-08-02) 
+
+  Master build status: No Travis-CI build
+
+  Maintainer: `Tanmay Mohapatra <https://github.com/tanmaykm>`_
+
+  Dependencies::
+
+      DataFrames     Any Version
+      HDFS           Any Version
+      julia          [v"0.2.0-"]
+
+  Contributors:
+
+    .. image:: https://secure.gravatar.com/avatar/eea0b193dae8ac47946202ee404a6d7a?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png
+        :height: 40px
+        :width: 40px
+        :alt: Tanmay Mohapatra
+        :target: https://github.com/tanmaykm
+
+----
+
 `BloomFilters <https://github.com/johnmyleswhite/BloomFilters.jl>`_
 ___________________________________________________________________
 
@@ -334,9 +387,11 @@ ___________________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Bloom filters in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-02-03) 
 
-  Bloom filters in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -364,9 +419,11 @@ __________________________________________
      :alt: Fazlul Shahriar
      :target: https://github.com/fhs
 
+  32-bit cyclic redundancy check (CRC-32) checksum implementation for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-07-21) 
 
-  32-bit cyclic redundancy check (CRC-32) checksum implementation for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Fazlul Shahriar <https://github.com/fhs>`_
 
@@ -394,9 +451,11 @@ ________________________________________________
      :alt: The Julia Language
      :target: https://github.com/JuliaLang
 
+  Bindings to the Cairo graphics library. 
+
   Current Version: ``0.2.5``  (updated: 2013-08-01) 
 
-  Bindings to the Cairo graphics library. 
+  Master build status: No Travis-CI build
 
   Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
 
@@ -498,9 +557,14 @@ ___________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Calculus functions in Julia 
+
   Current Version: ``0.1.1``  (updated: 2013-04-27) 
 
-  Calculus functions in Julia 
+  Master build status: |Calculus_build|
+
+  .. |Calculus_build| image:: https://api.travis-ci.org/johnmyleswhite/Calculus.jl.png
+     :align: bottom
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -552,9 +616,11 @@ __________________________________________________
      :alt: Mike Nolta
      :target: https://github.com/nolta
 
+  Calendar time package for Julia 
+
   Current Version: ``0.3.3``  (updated: 2013-07-15) 
 
-  Calendar time package for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Mike Nolta <https://github.com/nolta>`_
 
@@ -595,9 +661,11 @@ ______________________________________________________
      :alt: Tim Holy
      :target: https://github.com/timholy
 
+  Fast multidimensional iteration 
+
   Current Version: ``0.0.0``  (updated: 2013-05-28) 
 
-  Fast multidimensional iteration 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tim Holy <https://github.com/timholy>`_
 
@@ -625,9 +693,11 @@ ___________________________________________________
      :alt: Alessandro Andrioni
      :target: https://github.com/andrioni
 
+  Catalan: a combinatorics library for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-05-07) 
 
-  Catalan: a combinatorics library for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Alessandro Andrioni <https://github.com/andrioni>`_
 
@@ -667,9 +737,14 @@ _________________________________________________________________
      :alt: Tanmay Mohapatra
      :target: https://github.com/tanmaykm
 
+  Few utility types over Julia Vector type 
+
   Current Version: ``0.0.0``  (updated: 2013-05-25) 
 
-  Few utility types over Julia Vector type 
+  Master build status: |ChainedVectors_build|
+
+  .. |ChainedVectors_build| image:: https://api.travis-ci.org/tanmaykm/ChainedVectors.jl.png
+     :align: bottom
 
   Maintainer: `Tanmay Mohapatra <https://github.com/tanmaykm>`_
 
@@ -697,9 +772,11 @@ ___________________________________________________________________
      :alt: Theodore Papamarkou
      :target: https://github.com/scidom
 
+  Simulation, Bayesian inference and Bayesian model selection for chemical kinetics in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-07-07) 
 
-  Simulation, Bayesian inference and Bayesian model selection for chemical kinetics in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Theodore Papamarkou <https://github.com/scidom>`_
 
@@ -729,9 +806,11 @@ _______________________________________________
      :alt: Isaiah
      :target: https://github.com/ihnorton
 
+  Julia interface to libclang and C wrapper generator 
+
   Current Version: ``0.0.0``  (updated: 2013-06-09) 
 
-  Julia interface to libclang and C wrapper generator 
+  Master build status: No Travis-CI build
 
   Maintainer: `Isaiah <https://github.com/ihnorton>`_
 
@@ -790,9 +869,11 @@ _________________________________________
      :alt: Miles Lubin
      :target: https://github.com/mlubin
 
+  Interface to the Coin-OR Linear Programming solver (CLP) 
+
   Current Version: ``0.0.3``  (updated: 2013-06-24) 
 
-  Interface to the Coin-OR Linear Programming solver (CLP) 
+  Master build status: No Travis-CI build
 
   Maintainer: `Miles Lubin <https://github.com/mlubin>`_
 
@@ -828,9 +909,11 @@ ___________________________________________________________________
      :alt: Lance Hepler
      :target: https://github.com/nlhepler
 
+   
+
   Current Version: ``0.0.0``  (updated: 2013-07-10) 
 
-   
+  Master build status: No Travis-CI build
 
   Maintainer: `Lance Hepler <https://github.com/nlhepler>`_
 
@@ -864,9 +947,11 @@ _______________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Basic functions for clustering data: k-means, dp-means, etc. 
+
   Current Version: ``0.2.1``  (updated: 2013-06-21) 
 
-  Basic functions for clustering data: k-means, dp-means, etc. 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -915,9 +1000,11 @@ ________________________________________________
      :alt: Daniel Jones
      :target: https://github.com/dcjones
 
+  Common data encoding algorithms 
+
   Current Version: ``0.0.0``  (updated: 2013-06-23) 
 
-  Common data encoding algorithms 
+  Master build status: No Travis-CI build
 
   Maintainer: `Daniel Jones <https://github.com/dcjones>`_
 
@@ -951,9 +1038,11 @@ _______________________________________________
      :alt: Miles Lubin
      :target: https://github.com/mlubin
 
+  Interface to the Coin-OR CBC solver for mixed-integer programming 
+
   Current Version: ``0.0.2``  (updated: 2013-05-21) 
 
-  Interface to the Coin-OR CBC solver for mixed-integer programming 
+  Master build status: No Travis-CI build
 
   Maintainer: `Miles Lubin <https://github.com/mlubin>`_
 
@@ -989,9 +1078,11 @@ ________________________________________________
      :alt: The Julia Language
      :target: https://github.com/JuliaLang
 
+  Basic color manipulation utilities. 
+
   Current Version: ``0.2.4``  (updated: 2013-07-27) 
 
-  Basic color manipulation utilities. 
+  Master build status: No Travis-CI build
 
   Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
 
@@ -1049,9 +1140,11 @@ __________________________________________________
      :alt: Daniel Jones
      :target: https://github.com/dcjones
 
+  Declarative vector graphics 
+
   Current Version: ``0.1.6``  (updated: 2013-07-17) 
 
-  Declarative vector graphics 
+  Master build status: No Travis-CI build
 
   Maintainer: `Daniel Jones <https://github.com/dcjones>`_
 
@@ -1135,9 +1228,11 @@ _______________________________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Types and functions for working with continued fractions in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-02-07) 
 
-  Types and functions for working with continued fractions in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -1165,9 +1260,11 @@ __________________________________________
      :alt: Tim Holy
      :target: https://github.com/timholy
 
+  Utilities for calling C++ from Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-03-15) 
 
-  Utilities for calling C++ from Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tim Holy <https://github.com/timholy>`_
 
@@ -1195,9 +1292,11 @@ _____________________________________________________
      :alt: Steven G. Johnson
      :target: https://github.com/stevengj
 
+  One- and multi-dimensional adaptive integration routines for the Julia language 
+
   Current Version: ``1.0.0``  (updated: 2013-07-15) 
 
-  One- and multi-dimensional adaptive integration routines for the Julia language 
+  Master build status: No Travis-CI build
 
   Maintainer: `Steven G. Johnson <https://github.com/stevengj>`_
 
@@ -1220,9 +1319,11 @@ __________________________________________
      :alt: Forio Online Simulations
      :target: https://github.com/forio
 
+  a Julia HTTP curl library 
+
   Current Version: ``0.0.1``  (updated: 2013-05-29) 
 
-  a Julia HTTP curl library 
+  Master build status: No Travis-CI build
 
   Maintainer: `Forio Online Simulations <https://github.com/forio>`_
 
@@ -1256,9 +1357,11 @@ _______________________________________________
      :alt: Isaiah
      :target: https://github.com/ihnorton
 
+  DICOM for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-03-01) 
 
-  DICOM for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Isaiah <https://github.com/ihnorton>`_
 
@@ -1316,9 +1419,11 @@ _______________________________________________
      :alt: Keno Fischer
      :target: https://github.com/loladiro
 
+  Julia Package for parsing the DWARF file format 
+
   Current Version: ``0.0.0``  (updated: 2013-06-17) 
 
-  Julia Package for parsing the DWARF file format 
+  Master build status: No Travis-CI build
 
   Maintainer: `Keno Fischer <https://github.com/loladiro>`_
 
@@ -1348,9 +1453,14 @@ ___________________________________________________________
      :alt: Julia Statistics
      :target: https://github.com/JuliaStats
 
+  library for working with tabular data in Julia 
+
   Current Version: ``0.3.8``  (updated: 2013-07-26) 
 
-  library for working with tabular data in Julia 
+  Master build status: |DataFrames_build|
+
+  .. |DataFrames_build| image:: https://api.travis-ci.org/JuliaStats/DataFrames.jl.png
+     :align: bottom
 
   Maintainer: `Julia Statistics <https://github.com/JuliaStats>`_
 
@@ -1548,9 +1658,14 @@ _________________________________________________________________
      :alt: Dahua Lin
      :target: https://github.com/lindahua
 
+  Julia implementation of Data structures 
+
   Current Version: ``0.2.4``  (updated: 2013-07-27) 
 
-  Julia implementation of Data structures 
+  Master build status: |DataStructures_build|
+
+  .. |DataStructures_build| image:: https://api.travis-ci.org/lindahua/DataStructures.jl.png
+     :align: bottom
 
   Maintainer: `Dahua Lin <https://github.com/lindahua>`_
 
@@ -1584,9 +1699,11 @@ ______________________________________________________
      :alt: Jacob Quinn
      :target: https://github.com/karbarcca
 
+  A Date and DateTime implementation for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-07-27) 
 
-  A Date and DateTime implementation for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Jacob Quinn <https://github.com/karbarcca>`_
 
@@ -1620,9 +1737,11 @@ _____________________________________________
      :alt: toivoh
      :target: https://github.com/toivoh
 
+  Prototype interactive debugger for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-07-20) 
 
-  Prototype interactive debugger for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `toivoh <https://github.com/toivoh>`_
 
@@ -1668,9 +1787,11 @@ _______________________________________________________________
      :alt: Ben Sadeghi
      :target: https://github.com/bensadeghi
 
+  Decision Tree Classifier in Julia 
+
   Current Version: ``0.1.0``  (updated: 2013-06-11) 
 
-  Decision Tree Classifier in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Ben Sadeghi <https://github.com/bensadeghi>`_
 
@@ -1698,9 +1819,11 @@ ___________________________________________________________
      :alt: Dahua Lin
      :target: https://github.com/lindahua
 
+  A Julia framework for delayed expression evaluation 
+
   Current Version: ``0.2.1``  (updated: 2013-04-15) 
 
-  A Julia framework for delayed expression evaluation 
+  Master build status: No Travis-CI build
 
   Maintainer: `Dahua Lin <https://github.com/lindahua>`_
 
@@ -1728,9 +1851,11 @@ _______________________________________________________
      :alt: Jonathan Chang
      :target: https://github.com/slycoder
 
+  Utility functions for manipulating Dicts in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-05-14) 
 
-  Utility functions for manipulating Dicts in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Jonathan Chang <https://github.com/slycoder>`_
 
@@ -1758,9 +1883,11 @@ __________________________________________________________
      :alt: David de Laat
      :target: https://github.com/daviddelaat
 
+  KeysView and ValuesView types for dynamic low-overhead views into the entries of dictionaries 
+
   Current Version: ``0.0.0``  (updated: 2013-02-23) 
 
-  KeysView and ValuesView types for dynamic low-overhead views into the entries of dictionaries 
+  Master build status: No Travis-CI build
 
   Maintainer: `David de Laat <https://github.com/daviddelaat>`_
 
@@ -1788,9 +1915,11 @@ ________________________________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Methods for dimensionality reduction: PCA, ICA, NMF 
+
   Current Version: ``0.0.0``  (updated: 2013-01-17) 
 
-  Methods for dimensionality reduction: PCA, ICA, NMF 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -1818,9 +1947,11 @@ _______________________________________________________________
      :alt: Lei WANG
      :target: https://github.com/wlbksy
 
+  Discrete factor and its operations in Probabilistic Graphical Models 
+
   Current Version: ``0.0.0``  (updated: 2013-06-06) 
 
-  Discrete factor and its operations in Probabilistic Graphical Models 
+  Master build status: No Travis-CI build
 
   Maintainer: `Lei WANG <https://github.com/wlbksy>`_
 
@@ -1848,9 +1979,11 @@ _____________________________________________________
      :alt: Dahua Lin
      :target: https://github.com/lindahua
 
+  Julia module for Distance evaluation 
+
   Current Version: ``0.2.1``  (updated: 2013-04-15) 
 
-  Julia module for Distance evaluation 
+  Master build status: No Travis-CI build
 
   Maintainer: `Dahua Lin <https://github.com/lindahua>`_
 
@@ -1879,9 +2012,14 @@ _________________________________________________________________
      :alt: Julia Statistics
      :target: https://github.com/JuliaStats
 
+  A Julia package for probability distributions and associated functions. 
+
   Current Version: ``0.2.3``  (updated: 2013-07-29) 
 
-  A Julia package for probability distributions and associated functions. 
+  Master build status: |Distributions_build|
+
+  .. |Distributions_build| image:: https://api.travis-ci.org/JuliaStats/Distributions.jl.png
+     :align: bottom
 
   Maintainer: `Julia Statistics <https://github.com/JuliaStats>`_
 
@@ -1982,9 +2120,11 @@ _________________________________________________________
      :alt: Theodore Papamarkou
      :target: https://github.com/scidom
 
+  Julia package for representing dual numbers and for performing dual algebra 
+
   Current Version: ``0.0.0``  (updated: 2013-04-21) 
 
-  Julia package for representing dual numbers and for performing dual algebra 
+  Master build status: No Travis-CI build
 
   Maintainer: `Theodore Papamarkou <https://github.com/scidom>`_
 
@@ -2012,9 +2152,11 @@ ___________________________________________
      :alt: Keno Fischer
      :target: https://github.com/loladiro
 
+  Julia Package for working with ELF files 
+
   Current Version: ``0.0.0``  (updated: 2013-05-28) 
 
-  Julia Package for working with ELF files 
+  Master build status: No Travis-CI build
 
   Maintainer: `Keno Fischer <https://github.com/loladiro>`_
 
@@ -2043,9 +2185,11 @@ __________________________________________________
      :alt: Mike Nolta
      :target: https://github.com/nolta
 
+  Elliptic integral and Jacobi elliptic special functions 
+
   Current Version: ``0.0.0``  (updated: 2013-03-13) 
 
-  Elliptic integral and Jacobi elliptic special functions 
+  Master build status: No Travis-CI build
 
   Maintainer: `Mike Nolta <https://github.com/nolta>`_
 
@@ -2073,9 +2217,14 @@ ____________________________________________________
      :alt: The Julia Language
      :target: https://github.com/JuliaLang
 
+  Example Julia package repo. 
+
   Current Version: ``0.0.0``  (updated: 2012-11-22) 
 
-  Example Julia package repo. 
+  Master build status: |Example_build|
+
+  .. |Example_build| image:: https://api.travis-ci.org/JuliaLang/Example.jl.png
+     :align: bottom
 
   Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
 
@@ -2133,9 +2282,11 @@ _____________________________________________________________________
      :alt: Zach Allaun
      :target: https://github.com/zachallaun
 
+  Utilities for working with the Julia `Expr` type 
+
   Current Version: ``0.0.0``  (updated: 2013-04-30) 
 
-  Utilities for working with the Julia `Expr` type 
+  Master build status: No Travis-CI build
 
   Maintainer: `Zach Allaun <https://github.com/zachallaun>`_
 
@@ -2163,9 +2314,11 @@ ______________________________________________
      :alt: Mike Nolta
      :target: https://github.com/nolta
 
+  FITS file package for Julia 
+
   Current Version: ``0.0.0``  (updated: 2012-12-09) 
 
-  FITS file package for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Mike Nolta <https://github.com/nolta>`_
 
@@ -2193,9 +2346,11 @@ _________________________________________________________
      :alt: Zach Allaun
      :target: https://github.com/zachallaun
 
+  Midje-like testing for Julia 
+
   Current Version: ``0.1.0``  (updated: 2013-07-02) 
 
-  Midje-like testing for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Zach Allaun <https://github.com/zachallaun>`_
 
@@ -2229,9 +2384,14 @@ ________________________________________________________
      :alt: Carlo Baldassi
      :target: https://github.com/carlobaldassi
 
+  Utilities to read/write FASTA format files in Julia 
+
   Current Version: ``0.1.1``  (updated: 2013-06-28) 
 
-  Utilities to read/write FASTA format files in Julia 
+  Master build status: |FastaIO_build|
+
+  .. |FastaIO_build| image:: https://api.travis-ci.org/carlobaldassi/FastaIO.jl.png
+     :align: bottom
 
   Maintainer: `Carlo Baldassi <https://github.com/carlobaldassi>`_
 
@@ -2260,9 +2420,14 @@ ____________________________________________________________
      :alt: Carlo Baldassi
      :target: https://github.com/carlobaldassi
 
+  [DEPRECATED PACKAGE. USE FastaIO INSTEAD] 
+
   Current Version: ``0.2.1``  (updated: 2013-05-22) 
 
-  [DEPRECATED PACKAGE. USE FastaIO INSTEAD] 
+  Master build status: |FastaRead_build|
+
+  .. |FastaRead_build| image:: https://api.travis-ci.org/carlobaldassi/FastaRead.jl.png
+     :align: bottom
 
   Maintainer: `Carlo Baldassi <https://github.com/carlobaldassi>`_
 
@@ -2297,9 +2462,11 @@ ___________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  File::Find implementation in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-01-19) 
 
-  File::Find implementation in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -2327,9 +2494,11 @@ ________________________________________________________________________________
      :alt: Zach Allaun
      :target: https://github.com/zachallaun
 
+  Functional and and persistent data structures for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-05-16) 
 
-  Functional and and persistent data structures for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Zach Allaun <https://github.com/zachallaun>`_
 
@@ -2369,9 +2538,11 @@ _____________________________________________________________________
      :alt: Zach Allaun
      :target: https://github.com/zachallaun
 
+  Functional Julia – based on fogus/lemonad 
+
   Current Version: ``0.0.0``  (updated: 2013-04-30) 
 
-  Functional Julia – based on fogus/lemonad 
+  Master build status: No Travis-CI build
 
   Maintainer: `Zach Allaun <https://github.com/zachallaun>`_
 
@@ -2399,9 +2570,11 @@ __________________________________________________
      :alt: Andrey Kolev
      :target: https://github.com/AndreyKolev
 
+  Julia GARCH package 
+
   Current Version: ``0.0.0``  (updated: 2013-07-29) 
 
-  Julia GARCH package 
+  Master build status: No Travis-CI build
 
   Maintainer: `Andrey Kolev <https://github.com/AndreyKolev>`_
 
@@ -2423,9 +2596,11 @@ _____________________________________________
      :alt: Jay Weisskopf
      :target: https://github.com/jayschwa
 
+  GLFW bindings for Julia. GLFW is a multi-platform library for opening a window, creating an OpenGL context, and managing input. 
+
   Current Version: ``0.0.0``  (updated: 2013-04-02) 
 
-  GLFW bindings for Julia. GLFW is a multi-platform library for opening a window, creating an OpenGL context, and managing input. 
+  Master build status: No Travis-CI build
 
   Maintainer: `Jay Weisskopf <https://github.com/jayschwa>`_
 
@@ -2455,9 +2630,11 @@ _____________________________________________
      :alt: Julia Statistics
      :target: https://github.com/JuliaStats
 
+  Generalized linear models in Julia 
+
   Current Version: ``0.2.0``  (updated: 2013-07-30) 
 
-  Generalized linear models in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Julia Statistics <https://github.com/JuliaStats>`_
 
@@ -2506,9 +2683,14 @@ __________________________________________________
      :alt: Carlo Baldassi
      :target: https://github.com/carlobaldassi
 
+  GLPK wrapper module for Julia 
+
   Current Version: ``0.2.4``  (updated: 2013-06-18) 
 
-  GLPK wrapper module for Julia 
+  Master build status: |GLPK_build|
+
+  .. |GLPK_build| image:: https://api.travis-ci.org/carlobaldassi/GLPK.jl.png
+     :align: bottom
 
   Maintainer: `Carlo Baldassi <https://github.com/carlobaldassi>`_
 
@@ -2543,9 +2725,11 @@ ________________________________________________________________________________
      :alt: Carlo Baldassi
      :target: https://github.com/carlobaldassi
 
+  Interface between the GLPK.jl wrapper and MathProgBase.jl 
+
   Current Version: ``0.0.0``  (updated: 2013-06-07) 
 
-  Interface between the GLPK.jl wrapper and MathProgBase.jl 
+  Master build status: No Travis-CI build
 
   Maintainer: `Carlo Baldassi <https://github.com/carlobaldassi>`_
 
@@ -2575,9 +2759,11 @@ ______________________________________________
      :alt: Robert J. Ennis
      :target: https://github.com/rennis250
 
+  Julia interface to GLUT 
+
   Current Version: ``0.0.0``  (updated: 2013-01-18) 
 
-  Julia interface to GLUT 
+  Master build status: No Travis-CI build
 
   Maintainer: `Robert J. Ennis <https://github.com/rennis250>`_
 
@@ -2606,9 +2792,14 @@ _________________________________________
      :alt: Jiahao Chen
      :target: https://github.com/jiahao
 
+  Julia interface to the GNU Scientific Library (GSL) 
+
   Current Version: ``0.0.0``  (updated: 2013-04-04) 
 
-  Julia interface to the GNU Scientific Library (GSL) 
+  Master build status: |GSL_build|
+
+  .. |GSL_build| image:: https://api.travis-ci.org/jiahao/GSL.jl.png
+     :align: bottom
 
   Maintainer: `Jiahao Chen <https://github.com/jiahao>`_
 
@@ -2642,9 +2833,11 @@ _____________________________________________
      :alt: Kevin Squire
      :target: https://github.com/kmsquire
 
+  A Julia interface for gzip functions in zlib 
+
   Current Version: ``0.2.4``  (updated: 2013-06-25) 
 
-  A Julia interface for gzip functions in zlib 
+  Master build status: No Travis-CI build
 
   Maintainer: `Kevin Squire <https://github.com/kmsquire>`_
 
@@ -2680,9 +2873,11 @@ ________________________________________________
      :alt: Daniel Jones
      :target: https://github.com/dcjones
 
+  Crafty statistical graphics for Julia. 
+
   Current Version: ``0.1.7``  (updated: 2013-07-09) 
 
-  Crafty statistical graphics for Julia. 
+  Master build status: No Travis-CI build
 
   Maintainer: `Daniel Jones <https://github.com/dcjones>`_
 
@@ -2773,9 +2968,11 @@ _____________________________________________
      :alt: mbaz
      :target: https://github.com/mbaz
 
+  A julia front-end for gnuplot. 
+
   Current Version: ``0.0.0``  (updated: 2013-05-05) 
 
-  A julia front-end for gnuplot. 
+  Master build status: No Travis-CI build
 
   Maintainer: `mbaz <https://github.com/mbaz>`_
 
@@ -2815,9 +3012,11 @@ _____________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  A Julia package to estimate the geographic location of IP addresses 
+
   Current Version: ``0.0.0``  (updated: 2013-06-24) 
 
-  A Julia package to estimate the geographic location of IP addresses 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -2845,9 +3044,11 @@ _____________________________________________________________
      :alt: Theodore Papamarkou
      :target: https://github.com/scidom
 
+  Geometric MCMC algorithms and zero-variance (ZV) Monte Carlo Bayesian routines 
+
   Current Version: ``0.0.0``  (updated: 2013-04-12) 
 
-  Geometric MCMC algorithms and zero-variance (ZV) Monte Carlo Bayesian routines 
+  Master build status: No Travis-CI build
 
   Maintainer: `Theodore Papamarkou <https://github.com/scidom>`_
 
@@ -2875,9 +3076,11 @@ ______________________________________________
      :alt: Robert J. Ennis
      :target: https://github.com/rennis250
 
+  Minimal implementation of Jasper's Julia FFI 
+
   Current Version: ``0.0.0``  (updated: 2013-01-15) 
 
-  Minimal implementation of Jasper's Julia FFI 
+  Master build status: No Travis-CI build
 
   Maintainer: `Robert J. Ennis <https://github.com/rennis250>`_
 
@@ -2911,9 +3114,14 @@ _________________________________________________
      :alt: Keno Fischer
      :target: https://github.com/loladiro
 
+  Transport Level Security for Julia Streams provided by GnuTLS 
+
   Current Version: ``0.0.0``  (updated: 2013-07-26) 
 
-  Transport Level Security for Julia Streams provided by GnuTLS 
+  Master build status: |GnuTLS_build|
+
+  .. |GnuTLS_build| image:: https://api.travis-ci.org/loladiro/GnuTLS.jl.png
+     :align: bottom
 
   Maintainer: `Keno Fischer <https://github.com/loladiro>`_
 
@@ -2942,9 +3150,11 @@ _____________________________________________________________
      :alt: john verzani
      :target: https://github.com/jverzani
 
+  Julia interface to Google Chart Tools 
+
   Current Version: ``0.0.0``  (updated: 2013-05-14) 
 
-  Julia interface to Google Chart Tools 
+  Master build status: No Travis-CI build
 
   Maintainer: `john verzani <https://github.com/jverzani>`_
 
@@ -2975,9 +3185,14 @@ __________________________________________________
      :alt: The Julia Language
      :target: https://github.com/JuliaLang
 
+  Working with graphs in Julia 
+
   Current Version: ``0.2.3``  (updated: 2013-06-20) 
 
-  Working with graphs in Julia 
+  Master build status: |Graphs_build|
+
+  .. |Graphs_build| image:: https://api.travis-ci.org/JuliaLang/Graphs.jl.png
+     :align: bottom
 
   Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
 
@@ -3066,9 +3281,11 @@ ____________________________________________
      :alt: Tim Holy
      :target: https://github.com/timholy
 
+  Interpolation and related operations on grids 
+
   Current Version: ``0.2.3``  (updated: 2013-08-01) 
 
-  Interpolation and related operations on grids 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tim Holy <https://github.com/timholy>`_
 
@@ -3102,9 +3319,11 @@ __________________________________________
      :alt: Jameson Nash
      :target: https://github.com/vtjnash
 
+  Julia interface to Gtk windowing toolkit. 
+
   Current Version: ``0.2.0``  (updated: 2013-07-24) 
 
-  Julia interface to Gtk windowing toolkit. 
+  Master build status: No Travis-CI build
 
   Maintainer: `Jameson Nash <https://github.com/vtjnash>`_
 
@@ -3133,9 +3352,11 @@ _________________________________________________
      :alt: Dahua Lin
      :target: https://github.com/lindahua
 
+  Julia Port of Gurobi Optimizer 
+
   Current Version: ``0.0.0``  (updated: 2013-06-13) 
 
-  Julia Port of Gurobi Optimizer 
+  Master build status: No Travis-CI build
 
   Maintainer: `Dahua Lin <https://github.com/lindahua>`_
 
@@ -3176,9 +3397,11 @@ ____________________________________________
      :alt: Tim Holy
      :target: https://github.com/timholy
 
+  HDF5 interface for the Julia language 
+
   Current Version: ``0.2.5``  (updated: 2013-07-27) 
 
-  HDF5 interface for the Julia language 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tim Holy <https://github.com/timholy>`_
 
@@ -3224,9 +3447,11 @@ _____________________________________________
      :alt: Tanmay Mohapatra
      :target: https://github.com/tanmaykm
 
+  HDFS interface for Julia as a wrapper over Hadoop HDFS library. 
+
   Current Version: ``0.0.0``  (updated: 2013-07-24) 
 
-  HDFS interface for Julia as a wrapper over Hadoop HDFS library. 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tanmay Mohapatra <https://github.com/tanmaykm>`_
 
@@ -3256,9 +3481,11 @@ _________________________________________
      :alt: Dirk Gadsden
      :target: https://github.com/dirk
 
+  HTTP library (server, client, parser) for the Julia language 
+
   Current Version: ``0.0.2``  (updated: 2013-03-06) 
 
-  HTTP library (server, client, parser) for the Julia language 
+  Master build status: No Travis-CI build
 
   Maintainer: `Dirk Gadsden <https://github.com/dirk>`_
 
@@ -3286,9 +3513,11 @@ ___________________________________________________________
      :alt: Amit Murthy
      :target: https://github.com/amitmurthy
 
+   
+
   Current Version: ``0.0.0``  (updated: 2013-07-06) 
 
-   
+  Master build status: No Travis-CI build
 
   Maintainer: `Amit Murthy <https://github.com/amitmurthy>`_
 
@@ -3317,9 +3546,11 @@ _____________________________________________________
      :alt: Steven G. Johnson
      :target: https://github.com/stevengj
 
+  Fast Walsh-Hadamard transforms for the Julia language 
+
   Current Version: ``0.0.0``  (updated: 2013-02-13) 
 
-  Fast Walsh-Hadamard transforms for the Julia language 
+  Master build status: No Travis-CI build
 
   Maintainer: `Steven G. Johnson <https://github.com/stevengj>`_
 
@@ -3341,9 +3572,11 @@ ___________________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Hopfield networks in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-07-28) 
 
-  Hopfield networks in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -3371,9 +3604,11 @@ _____________________________________________________________
      :alt: Hacker School
      :target: https://github.com/hackerschool
 
+   
+
   Current Version: ``0.0.1``  (updated: 2013-07-18) 
 
-   
+  Master build status: No Travis-CI build
 
   Maintainer: `Hacker School <https://github.com/hackerschool>`_
 
@@ -3419,9 +3654,11 @@ _____________________________________________________________
      :alt: Hacker School
      :target: https://github.com/hackerschool
 
+   
+
   Current Version: ``0.0.2``  (updated: 2013-07-26) 
 
-   
+  Master build status: No Travis-CI build
 
   Maintainer: `Hacker School <https://github.com/hackerschool>`_
 
@@ -3479,9 +3716,11 @@ _____________________________________________________________
      :alt: Hacker School
      :target: https://github.com/hackerschool
 
+   
+
   Current Version: ``0.0.1``  (updated: 2013-07-18) 
 
-   
+  Master build status: No Travis-CI build
 
   Maintainer: `Hacker School <https://github.com/hackerschool>`_
 
@@ -3540,9 +3779,11 @@ ____________________________________________________________________
      :alt: Simon Kornblith
      :target: https://github.com/simonster
 
+  T-tests, Wilcoxon rank sum (Mann-Whitney U), signed rank, and circular statistics in Julia 
+
   Current Version: ``0.2.0``  (updated: 2013-04-16) 
 
-  T-tests, Wilcoxon rank sum (Mann-Whitney U), signed rank, and circular statistics in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Simon Kornblith <https://github.com/simonster>`_
 
@@ -3572,9 +3813,11 @@ ________________________________________
      :alt: Mike Nolta
      :target: https://github.com/nolta
 
+  Julia wrapper for the International Components for Unicode (ICU) library 
+
   Current Version: ``0.0.0``  (updated: 2013-07-03) 
 
-  Julia wrapper for the International Components for Unicode (ICU) library 
+  Master build status: No Travis-CI build
 
   Maintainer: `Mike Nolta <https://github.com/nolta>`_
 
@@ -3620,9 +3863,11 @@ ______________________________________________________
      :alt: Tim Holy
      :target: https://github.com/timholy
 
+  Interactive display of images and movies 
+
   Current Version: ``0.0.2``  (updated: 2013-07-25) 
 
-  Interactive display of images and movies 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tim Holy <https://github.com/timholy>`_
 
@@ -3659,9 +3904,11 @@ ________________________________________________
      :alt: Tim Holy
      :target: https://github.com/timholy
 
+  An image library for Julia 
+
   Current Version: ``0.2.7``  (updated: 2013-07-19) 
 
-  An image library for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tim Holy <https://github.com/timholy>`_
 
@@ -3708,9 +3955,14 @@ ____________________________________________________________________
      :alt: Tracy Wadleigh
      :target: https://github.com/twadleigh
 
+  Statically-sized immutable vectors and matrices. 
+
   Current Version: ``0.0.0``  (updated: 2013-04-09) 
 
-  Statically-sized immutable vectors and matrices. 
+  Master build status: |ImmutableArrays_build|
+
+  .. |ImmutableArrays_build| image:: https://api.travis-ci.org/twadleigh/ImmutableArrays.jl.png
+     :align: bottom
 
   Maintainer: `Tracy Wadleigh <https://github.com/twadleigh>`_
 
@@ -3756,9 +4008,11 @@ ____________________________________________________
      :alt: The Julia Language
      :target: https://github.com/JuliaLang
 
+  Reading and writing Windows-style INI files (writing not yet implemented). 
+
   Current Version: ``0.2.1``  (updated: 2013-06-29) 
 
-  Reading and writing Windows-style INI files (writing not yet implemented). 
+  Master build status: No Travis-CI build
 
   Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
 
@@ -3810,9 +4064,11 @@ ________________________________________________________
      :alt: The Julia Language
      :target: https://github.com/JuliaLang
 
+  Common functional iterator patterns. 
+
   Current Version: ``0.1.1``  (updated: 2013-06-29) 
 
-  Common functional iterator patterns. 
+  Master build status: No Travis-CI build
 
   Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
 
@@ -3858,9 +4114,14 @@ ________________________________________
      :alt: Avik Sengupta
      :target: https://github.com/aviks
 
+  A Julia package for quantitative finance 
+
   Current Version: ``0.0.0``  (updated: 2013-01-03) 
 
-  A Julia package for quantitative finance 
+  Master build status: |Ito_build|
+
+  .. |Ito_build| image:: https://api.travis-ci.org/aviks/Ito.jl.png
+     :align: bottom
 
   Maintainer: `Avik Sengupta <https://github.com/aviks>`_
 
@@ -3897,9 +4158,11 @@ ______________________________________________
      :alt: The Julia Language
      :target: https://github.com/JuliaLang
 
+  JSON parsing and printing 
+
   Current Version: ``0.1.1``  (updated: 2013-07-12) 
 
-  JSON parsing and printing 
+  Master build status: No Travis-CI build
 
   Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
 
@@ -3987,9 +4250,14 @@ ___________________________________________
      :alt: Iain Dunning
      :target: https://github.com/IainNZ
 
+  Modelling language for Linear, Integer, and Quadratic Programming 
+
   Current Version: ``0.0.0``  (updated: 2013-07-20) 
 
-  Modelling language for Linear, Integer, and Quadratic Programming 
+  Master build status: |JuMP_build|
+
+  .. |JuMP_build| image:: https://api.travis-ci.org/IainNZ/JuMP.jl.png
+     :align: bottom
 
   Maintainer: `Iain Dunning <https://github.com/IainNZ>`_
 
@@ -4026,9 +4294,14 @@ _______________________________________________________
      :alt: Tanmay Mohapatra
      :target: https://github.com/tanmaykm
 
+  Judy Array for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-05-26) 
 
-  Judy Array for Julia 
+  Master build status: |JudyDicts_build|
+
+  .. |JudyDicts_build| image:: https://api.travis-ci.org/tanmaykm/JudyDicts.jl.png
+     :align: bottom
 
   Maintainer: `Tanmay Mohapatra <https://github.com/tanmaykm>`_
 
@@ -4056,9 +4329,11 @@ ____________________________________________________________
      :alt: Jameson Nash
      :target: https://github.com/vtjnash
 
+   
+
   Current Version: ``0.0.0``  (updated: 2013-04-08) 
 
-   
+  Master build status: No Travis-CI build
 
   Maintainer: `Jameson Nash <https://github.com/vtjnash>`_
 
@@ -4087,9 +4362,11 @@ ___________________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  KL-divergence estimation in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-01-17) 
 
-  KL-divergence estimation in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -4117,9 +4394,11 @@ __________________________________________________
      :alt: Simon Kornblith
      :target: https://github.com/simonster
 
+  LIBSVM bindings for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-04-15) 
 
-  LIBSVM bindings for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Simon Kornblith <https://github.com/simonster>`_
 
@@ -4147,9 +4426,11 @@ _____________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  A package for working with human languages 
+
   Current Version: ``0.0.1``  (updated: 2013-05-24) 
 
-  A package for working with human languages 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -4177,9 +4458,11 @@ ______________________________________________________________
      :alt: Daniel Jones
      :target: https://github.com/dcjones
 
+  Lazy sequences. 
+
   Current Version: ``0.1.0``  (updated: 2013-06-20) 
 
-  Lazy sequences. 
+  Master build status: No Travis-CI build
 
   Maintainer: `Daniel Jones <https://github.com/dcjones>`_
 
@@ -4207,9 +4490,11 @@ _____________________________________________________
      :alt: Amit Murthy
      :target: https://github.com/amitmurthy
 
+  Thin Julia wrapper of libCURL 
+
   Current Version: ``0.0.0``  (updated: 2013-07-06) 
 
-  Thin Julia wrapper of libCURL 
+  Master build status: No Travis-CI build
 
   Maintainer: `Amit Murthy <https://github.com/amitmurthy>`_
 
@@ -4237,9 +4522,11 @@ _______________________________________________________
      :alt: Amit Murthy
      :target: https://github.com/amitmurthy
 
+  Julia interface to libexpat 
+
   Current Version: ``0.0.0``  (updated: 2013-07-05) 
 
-  Julia interface to libexpat 
+  Master build status: No Travis-CI build
 
   Maintainer: `Amit Murthy <https://github.com/amitmurthy>`_
 
@@ -4273,9 +4560,11 @@ ________________________________________________________________
      :alt: Carlo Baldassi
      :target: https://github.com/carlobaldassi
 
+  [DEPRECATED PACKAGE - SUPERSEDED BY MathProgBase] 
+
   Current Version: ``0.2.1``  (updated: 2013-05-23) 
 
-  [DEPRECATED PACKAGE - SUPERSEDED BY MathProgBase] 
+  Master build status: No Travis-CI build
 
   Maintainer: `Carlo Baldassi <https://github.com/carlobaldassi>`_
 
@@ -4304,9 +4593,11 @@ ___________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Loss functions 
+
   Current Version: ``0.0.0``  (updated: 2012-12-23) 
 
-  Loss functions 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -4334,9 +4625,11 @@ ____________________________________________
      :alt: Simon Kornblith
      :target: https://github.com/simonster
 
+  Julia module for reading MATLAB files 
+
   Current Version: ``0.2.1``  (updated: 2013-06-29) 
 
-  Julia module for reading MATLAB files 
+  Master build status: No Travis-CI build
 
   Maintainer: `Simon Kornblith <https://github.com/simonster>`_
 
@@ -4384,9 +4677,11 @@ _________________________________________________
      :alt: Dahua Lin
      :target: https://github.com/lindahua
 
+  Calling MATLAB in Julia through MATLAB Engine 
+
   Current Version: ``0.0.0``  (updated: 2013-05-10) 
 
-  Calling MATLAB in Julia through MATLAB Engine 
+  Master build status: No Travis-CI build
 
   Maintainer: `Dahua Lin <https://github.com/lindahua>`_
 
@@ -4420,9 +4715,11 @@ ___________________________________________
      :alt: Chris DuBois
      :target: https://github.com/doobwa
 
+  MCMC tools for Julia 
+
   Current Version: ``0.0.0``  (updated: 2012-11-23) 
 
-  MCMC tools for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Chris DuBois <https://github.com/doobwa>`_
 
@@ -4462,9 +4759,11 @@ _____________________________________________
      :alt: Steven G. Johnson
      :target: https://github.com/stevengj
 
+  fast modified discrete cosine transform (MDCT and IMDCT) for the Julia language 
+
   Current Version: ``0.0.0``  (updated: 2013-04-05) 
 
-  fast modified discrete cosine transform (MDCT and IMDCT) for the Julia language 
+  Master build status: No Travis-CI build
 
   Maintainer: `Steven G. Johnson <https://github.com/stevengj>`_
 
@@ -4486,9 +4785,11 @@ _________________________________________________
      :alt: Dahua Lin
      :target: https://github.com/lindahua
 
+  A set of functions to support the development of machine learning algorithms 
+
   Current Version: ``0.2.3``  (updated: 2013-07-20) 
 
-  A set of functions to support the development of machine learning algorithms 
+  Master build status: No Travis-CI build
 
   Maintainer: `Dahua Lin <https://github.com/lindahua>`_
 
@@ -4516,9 +4817,11 @@ _____________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Tools for working with the MNIST data set 
+
   Current Version: ``0.0.0``  (updated: 2013-04-12) 
 
-  Tools for working with the MNIST data set 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -4546,9 +4849,11 @@ _______________________________________________________________________
      :alt: milktrader
      :target: https://github.com/milktrader
 
+  Technical analysis of financial time series in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-03-02) 
 
-  Technical analysis of financial time series in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `milktrader <https://github.com/milktrader>`_
 
@@ -4581,9 +4886,11 @@ ___________________________________________________________
      :alt: Miles Lubin
      :target: https://github.com/mlubin
 
+  Provides standard interface to linear/mixed-integer/++ optimization solvers, including linprog and mixintprog functions. 
+
   Current Version: ``0.0.0``  (updated: 2013-06-24) 
 
-  Provides standard interface to linear/mixed-integer/++ optimization solvers, including linprog and mixintprog functions. 
+  Master build status: No Travis-CI build
 
   Maintainer: `Miles Lubin <https://github.com/mlubin>`_
 
@@ -4623,9 +4930,11 @@ _____________________________________________________
      :alt: Hacker School
      :target: https://github.com/hackerschool
 
+   
+
   Current Version: ``0.0.1``  (updated: 2013-07-18) 
 
-   
+  Master build status: No Travis-CI build
 
   Maintainer: `Hacker School <https://github.com/hackerschool>`_
 
@@ -4677,9 +4986,11 @@ ____________________________________________________
      :alt: Simon Kornblith
      :target: https://github.com/simonster
 
+  @memoize macro for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-06-13) 
 
-  @memoize macro for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Simon Kornblith <https://github.com/simonster>`_
 
@@ -4707,9 +5018,11 @@ __________________________________________________
      :alt: Tracy Wadleigh
      :target: https://github.com/twadleigh
 
+  Generation and manipulation of triangular meshes. 
+
   Current Version: ``0.0.0``  (updated: 2013-03-03) 
 
-  Generation and manipulation of triangular meshes. 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tracy Wadleigh <https://github.com/twadleigh>`_
 
@@ -4743,9 +5056,11 @@ ______________________________________________
      :alt: Douglas Bates
      :target: https://github.com/dmbates
 
+  Julia interface to Metis graph partitioning 
+
   Current Version: ``0.0.0``  (updated: 2013-04-30) 
 
-  Julia interface to Metis graph partitioning 
+  Master build status: No Travis-CI build
 
   Maintainer: `Douglas Bates <https://github.com/dmbates>`_
 
@@ -4774,9 +5089,11 @@ __________________________________________________________
      :alt: Douglas Bates
      :target: https://github.com/dmbates
 
+  A Julia package for fitting (statistical) mixed-effects models 
+
   Current Version: ``0.0.0``  (updated: 2013-06-19) 
 
-  A Julia package for fitting (statistical) mixed-effects models 
+  Master build status: No Travis-CI build
 
   Maintainer: `Douglas Bates <https://github.com/dmbates>`_
 
@@ -4806,9 +5123,11 @@ _______________________________________________________________
      :alt: Dahua Lin
      :target: https://github.com/lindahua
 
+  A Julia package for probabilistic mixture models 
+
   Current Version: ``0.1.1``  (updated: 2013-07-23) 
 
-  A Julia package for probabilistic mixture models 
+  Master build status: No Travis-CI build
 
   Maintainer: `Dahua Lin <https://github.com/lindahua>`_
 
@@ -4839,9 +5158,11 @@ ____________________________________________
      :alt: Patrick O'Leary
      :target: https://github.com/pao
 
+  Monadic expressions and sequences for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-03-05) 
 
-  Monadic expressions and sequences for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Patrick O'Leary <https://github.com/pao>`_
 
@@ -4871,9 +5192,11 @@ ____________________________________________
      :alt: Brian Smith
      :target: https://github.com/Lytol
 
+  Mongo bindings for the Julia programming language 
+
   Current Version: ``0.0.0``  (updated: 2013-03-14) 
 
-  Mongo bindings for the Julia programming language 
+  Master build status: No Travis-CI build
 
   Maintainer: `Brian Smith <https://github.com/Lytol>`_
 
@@ -4901,9 +5224,11 @@ __________________________________________________
      :alt: Avik Sengupta
      :target: https://github.com/aviks
 
+  Mongrel2 handlers in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-01-26) 
 
-  Mongrel2 handlers in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Avik Sengupta <https://github.com/aviks>`_
 
@@ -4944,9 +5269,11 @@ _____________________________________________________
      :alt: Hacker School
      :target: https://github.com/hackerschool
 
+  Sinatra-like micro framework for web programming in Julia 
+
   Current Version: ``0.0.1``  (updated: 2013-07-18) 
 
-  Sinatra-like micro framework for web programming in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Hacker School <https://github.com/hackerschool>`_
 
@@ -5016,9 +5343,11 @@ _____________________________________________________
      :alt: john verzani
      :target: https://github.com/jverzani
 
+  Port of mustache.js to julia 
+
   Current Version: ``0.0.0``  (updated: 2013-07-09) 
 
-  Port of mustache.js to julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `john verzani <https://github.com/jverzani>`_
 
@@ -5070,9 +5399,11 @@ ___________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Null hypothesis significance tests 
+
   Current Version: ``0.0.1``  (updated: 2013-05-28) 
 
-  Null hypothesis significance tests 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -5101,9 +5432,11 @@ ________________________________________________
      :alt: Simon Kornblith
      :target: https://github.com/simonster
 
+  Julia module for reading NIfTI MRI files 
+
   Current Version: ``0.0.0``  (updated: 2013-05-12) 
 
-  Julia module for reading NIfTI MRI files 
+  Master build status: No Travis-CI build
 
   Maintainer: `Simon Kornblith <https://github.com/simonster>`_
 
@@ -5132,9 +5465,11 @@ _______________________________________________
      :alt: Steven G. Johnson
      :target: https://github.com/stevengj
 
+  Package to call the NLopt nonlinear-optimization library from the Julia language 
+
   Current Version: ``0.0.0``  (updated: 2013-03-28) 
 
-  Package to call the NLopt nonlinear-optimization library from the Julia language 
+  Master build status: No Travis-CI build
 
   Maintainer: `Steven G. Johnson <https://github.com/stevengj>`_
 
@@ -5156,9 +5491,11 @@ ______________________________________
      :alt: Fazlul Shahriar
      :target: https://github.com/fhs
 
+  A Julia package that provides support for reading and writing Numpy .npy and .npz files 
+
   Current Version: ``0.0.0``  (updated: 2013-07-24) 
 
-  A Julia package that provides support for reading and writing Numpy .npy and .npz files 
+  Master build status: No Travis-CI build
 
   Maintainer: `Fazlul Shahriar <https://github.com/fhs>`_
 
@@ -5186,9 +5523,11 @@ ______________________________________________
      :alt: Harlan Harris
      :target: https://github.com/HarlanH
 
+  Julia named index and named vector types 
+
   Current Version: ``0.0.0``  (updated: 2012-11-17) 
 
-  Julia named index and named vector types 
+  Master build status: No Travis-CI build
 
   Maintainer: `Harlan Harris <https://github.com/HarlanH>`_
 
@@ -5216,9 +5555,11 @@ ________________________________________________
      :alt: meggart
      :target: https://github.com/meggart
 
+  NetCDF support for the julia programming language 
+
   Current Version: ``0.0.0``  (updated: 2013-05-07) 
 
-  NetCDF support for the julia programming language 
+  Master build status: No Travis-CI build
 
   Maintainer: `meggart <https://github.com/meggart>`_
 
@@ -5246,9 +5587,14 @@ _______________________________________________________________________
      :alt: Dahua Lin
      :target: https://github.com/lindahua
 
+  Julia extensions to provide high performance computational support 
+
   Current Version: ``0.2.12``  (updated: 2013-07-29) 
 
-  Julia extensions to provide high performance computational support 
+  Master build status: |NumericExtensions_build|
+
+  .. |NumericExtensions_build| image:: https://api.travis-ci.org/lindahua/NumericExtensions.jl.png
+     :align: bottom
 
   Maintainer: `Dahua Lin <https://github.com/lindahua>`_
 
@@ -5288,9 +5634,11 @@ ______________________________________________
      :alt: Jacob Quinn
      :target: https://github.com/karbarcca
 
+  A low-level ODBC interface for the Julia programming language 
+
   Current Version: ``0.2.0``  (updated: 2013-07-26) 
 
-  A low-level ODBC interface for the Julia programming language 
+  Master build status: No Travis-CI build
 
   Maintainer: `Jacob Quinn <https://github.com/karbarcca>`_
 
@@ -5332,9 +5680,11 @@ __________________________________________
      :alt: Jameson Nash
      :target: https://github.com/vtjnash
 
+  Assorted basic Ordinary Differential Equation solvers 
+
   Current Version: ``0.0.0``  (updated: 2013-03-01) 
 
-  Assorted basic Ordinary Differential Equation solvers 
+  Master build status: No Travis-CI build
 
   Maintainer: `Jameson Nash <https://github.com/vtjnash>`_
 
@@ -5362,9 +5712,11 @@ __________________________________________________
      :alt: Robert J. Ennis
      :target: https://github.com/rennis250
 
+  Julia interface to OpenGL 
+
   Current Version: ``0.0.0``  (updated: 2013-01-18) 
 
-  Julia interface to OpenGL 
+  Master build status: No Travis-CI build
 
   Maintainer: `Robert J. Ennis <https://github.com/rennis250>`_
 
@@ -5392,9 +5744,11 @@ _______________________________________________
      :alt: Dirk Gadsden
      :target: https://github.com/dirk
 
+  WIP OpenSSL bindings for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-03-06) 
 
-  WIP OpenSSL bindings for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Dirk Gadsden <https://github.com/dirk>`_
 
@@ -5422,9 +5776,14 @@ _____________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Optimization functions for Julia 
+
   Current Version: ``0.1.6``  (updated: 2013-07-15) 
 
-  Optimization functions for Julia 
+  Master build status: |Optim_build|
+
+  .. |Optim_build| image:: https://api.travis-ci.org/johnmyleswhite/Optim.jl.png
+     :align: bottom
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -5487,9 +5846,11 @@ ____________________________________________________
      :alt: The Julia Language
      :target: https://github.com/JuliaLang
 
+  A framework for providing optional arguments to functions. 
+
   Current Version: ``0.2.1``  (updated: 2013-06-06) 
 
-  A framework for providing optional arguments to functions. 
+  Master build status: No Travis-CI build
 
   Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
 
@@ -5541,9 +5902,11 @@ ____________________________________________
      :alt: Simon Kornblith
      :target: https://github.com/simonster
 
+  Julia module for reading Plexon PLX files 
+
   Current Version: ``0.0.0``  (updated: 2013-04-02) 
 
-  Julia module for reading Plexon PLX files 
+  Master build status: No Travis-CI build
 
   Maintainer: `Simon Kornblith <https://github.com/simonster>`_
 
@@ -5571,9 +5934,11 @@ ___________________________________________________
      :alt: Amit Murthy
      :target: https://github.com/amitmurthy
 
-  Current Version: ``0.0.0``  (updated: 2013-07-05) 
-
   Collection of utilities for parallel processing in Julia  
+
+  Current Version: ``0.0.0``  (updated: 2013-07-11) 
+
+  Master build status: No Travis-CI build
 
   Maintainer: `Amit Murthy <https://github.com/amitmurthy>`_
 
@@ -5607,9 +5972,11 @@ _________________________________________________________________
      :alt: toivoh
      :target: https://github.com/toivoh
 
+  Method dispatch based on pattern matching for Julia 
+
   Current Version: ``0.0.1``  (updated: 2013-05-01) 
 
-  Method dispatch based on pattern matching for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `toivoh <https://github.com/toivoh>`_
 
@@ -5643,9 +6010,11 @@ _______________________________________________________________
      :alt: Ben J. Ward
      :target: https://github.com/Ward9250
 
+  The Julia package for analysis of evolution and phylogeny 
+
   Current Version: ``0.0.0``  (updated: 2013-06-29) 
 
-  The Julia package for analysis of evolution and phylogeny 
+  Master build status: No Travis-CI build
 
   Maintainer: `Ben J. Ward <https://github.com/Ward9250>`_
 
@@ -5673,9 +6042,11 @@ ________________________________________________________
      :alt: Jameson Nash
      :target: https://github.com/vtjnash
 
+  Polynomial manipulations 
+
   Current Version: ``0.0.0``  (updated: 2013-03-01) 
 
-  Polynomial manipulations 
+  Master build status: No Travis-CI build
 
   Maintainer: `Jameson Nash <https://github.com/vtjnash>`_
 
@@ -5703,9 +6074,11 @@ __________________________________________________
      :alt: Tim Holy
      :target: https://github.com/timholy
 
+  Profilers for Julia 
+
   Current Version: ``0.2.3``  (updated: 2013-07-26) 
 
-  Profilers for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tim Holy <https://github.com/timholy>`_
 
@@ -5763,9 +6136,11 @@ __________________________________________________________
      :alt: Tim Holy
      :target: https://github.com/timholy
 
+  Visualization of Julia profiling data 
+
   Current Version: ``0.0.0``  (updated: 2013-08-01) 
 
-  Visualization of Julia profiling data 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tim Holy <https://github.com/timholy>`_
 
@@ -5797,9 +6172,11 @@ ______________________________________________________________
      :alt: Tim Holy
      :target: https://github.com/timholy
 
+  Progress meter for long-running computations 
+
   Current Version: ``0.0.0``  (updated: 2013-06-07) 
 
-  Progress meter for long-running computations 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tim Holy <https://github.com/timholy>`_
 
@@ -5833,9 +6210,11 @@ _________________________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  ProjectTemplate for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-01-19) 
 
-  ProjectTemplate for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -5864,9 +6243,11 @@ _________________________________________________
      :alt: Steven G. Johnson
      :target: https://github.com/stevengj
 
+  Package to call Python functions from the Julia language 
+
   Current Version: ``0.0.0``  (updated: 2013-07-18) 
 
-  Package to call Python functions from the Julia language 
+  Master build status: No Travis-CI build
 
   Maintainer: `Steven G. Johnson <https://github.com/stevengj>`_
 
@@ -5918,9 +6299,11 @@ _________________________________________________
      :alt: Junfeng Li
      :target: https://github.com/autozimu
 
+  Graphics solution for Julia based on pyplot 
+
   Current Version: ``0.0.0``  (updated: 2013-06-19) 
 
-  Graphics solution for Julia based on pyplot 
+  Master build status: No Travis-CI build
 
   Maintainer: `Junfeng Li <https://github.com/autozimu>`_
 
@@ -5956,9 +6339,11 @@ _________________________________________________
      :alt: john verzani
      :target: https://github.com/jverzani
 
+  julia interface for accessing Qt via PyCall and PySide 
+
   Current Version: ``0.0.0``  (updated: 2013-07-18) 
 
-  julia interface for accessing Qt via PyCall and PySide 
+  Master build status: No Travis-CI build
 
   Maintainer: `john verzani <https://github.com/jverzani>`_
 
@@ -5989,9 +6374,11 @@ ___________________________________________________
      :alt: milktrader
      :target: https://github.com/milktrader
 
+  Julia api to Quandl open source financial, economic and social datasets 
+
   Current Version: ``0.0.1``  (updated: 2013-04-09) 
 
-  Julia api to Quandl open source financial, economic and social datasets 
+  Master build status: No Travis-CI build
 
   Maintainer: `milktrader <https://github.com/milktrader>`_
 
@@ -6020,9 +6407,11 @@ ____________________________________________________
      :alt: Patrick O'Leary
      :target: https://github.com/pao
 
+  QuickCheck specification-based testing for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-02-22) 
 
-  QuickCheck specification-based testing for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Patrick O'Leary <https://github.com/pao>`_
 
@@ -6052,9 +6441,11 @@ _____________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Julia package for loading many of the data sets available in R 
+
   Current Version: ``0.0.1``  (updated: 2013-06-23) 
 
-  Julia package for loading many of the data sets available in R 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -6095,9 +6486,11 @@ _____________________________________________
      :alt: Keno Fischer
      :target: https://github.com/loladiro
 
+  Pure-julia REPL implementation 
+
   Current Version: ``0.0.0``  (updated: 2013-06-17) 
 
-  Pure-julia REPL implementation 
+  Master build status: No Travis-CI build
 
   Maintainer: `Keno Fischer <https://github.com/loladiro>`_
 
@@ -6132,9 +6525,11 @@ _____________________________________________________________
      :alt: Andreas Noack Jensen
      :target: https://github.com/andreasnoackjensen
 
+  Code for testing of Julia's random numbers 
+
   Current Version: ``0.0.0``  (updated: 2013-02-25) 
 
-  Code for testing of Julia's random numbers 
+  Master build status: No Travis-CI build
 
   Maintainer: `Andreas Noack Jensen <https://github.com/andreasnoackjensen>`_
 
@@ -6168,9 +6563,11 @@ ______________________________________________
      :alt: Jameson Nash
      :target: https://github.com/vtjnash
 
+  RPM-md processing library 
+
   Current Version: ``0.0.3``  (updated: 2013-07-07) 
 
-  RPM-md processing library 
+  Master build status: No Travis-CI build
 
   Maintainer: `Jameson Nash <https://github.com/vtjnash>`_
 
@@ -6208,9 +6605,11 @@ _______________________________________________________________
      :alt: Jiahao Chen
      :target: https://github.com/jiahao
 
+  Random matrices package for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-03-28) 
 
-  Random matrices package for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Jiahao Chen <https://github.com/jiahao>`_
 
@@ -6247,9 +6646,11 @@ _________________________________________________
      :alt: Sam Chill
      :target: https://github.com/SamChill
 
+   
+
   Current Version: ``0.0.0``  (updated: 2013-07-18) 
 
-   
+  Master build status: No Travis-CI build
 
   Maintainer: `Sam Chill <https://github.com/SamChill>`_
 
@@ -6277,9 +6678,11 @@ _____________________________________________________
      :alt: Keno Fischer
      :target: https://github.com/loladiro
 
+  Julia readline-like library 
+
   Current Version: ``0.0.0``  (updated: 2013-06-17) 
 
-  Julia readline-like library 
+  Master build status: No Travis-CI build
 
   Maintainer: `Keno Fischer <https://github.com/loladiro>`_
 
@@ -6308,9 +6711,11 @@ _________________________________________________________
      :alt: Dahua Lin
      :target: https://github.com/lindahua
 
+  Algorithms for regression analysis (e.g. linear regression and logistic regression) 
+
   Current Version: ``0.0.0``  (updated: 2013-07-06) 
 
-  Algorithms for regression analysis (e.g. linear regression and logistic regression) 
+  Master build status: No Travis-CI build
 
   Maintainer: `Dahua Lin <https://github.com/lindahua>`_
 
@@ -6340,9 +6745,11 @@ _______________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Tools for resampling data in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-01-19) 
 
-  Tools for resampling data in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -6370,9 +6777,11 @@ ___________________________________________
      :alt: Laurent Gautier
      :target: https://github.com/lgautier
 
+  Julia-to-R interface 
+
   Current Version: ``0.0.0``  (updated: 2013-02-05) 
 
-  Julia-to-R interface 
+  Master build status: No Travis-CI build
 
   Maintainer: `Laurent Gautier <https://github.com/lgautier>`_
 
@@ -6406,9 +6815,11 @@ ______________________________________________
      :alt: Douglas Bates
      :target: https://github.com/dmbates
 
+  Archive of functions that emulate R's d-p-q-r functions for probability distributions 
+
   Current Version: ``0.0.0``  (updated: 2013-03-04) 
 
-  Archive of functions that emulate R's d-p-q-r functions for probability distributions 
+  Master build status: No Travis-CI build
 
   Maintainer: `Douglas Bates <https://github.com/dmbates>`_
 
@@ -6436,9 +6847,11 @@ ___________________________________________________________
      :alt: Xiao He
      :target: https://github.com/mrxiaohe
 
+  A collection of robust statistical tests 
+
   Current Version: ``0.0.0``  (updated: 2013-06-30) 
 
-  A collection of robust statistical tests 
+  Master build status: No Travis-CI build
 
   Maintainer: `Xiao He <https://github.com/mrxiaohe>`_
 
@@ -6471,9 +6884,11 @@ _____________________________________________
      :alt: John Travers
      :target: https://github.com/jtravs
 
+  Root finding functions for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-04-11) 
 
-  Root finding functions for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Travers <https://github.com/jtravs>`_
 
@@ -6501,9 +6916,11 @@ ___________________________________________
      :alt: M. Schauer
      :target: https://github.com/mschauer
 
+  Simulation and inference for Ito processes and diffusions. 
+
   Current Version: ``0.1.0``  (updated: 2013-06-21) 
 
-  Simulation and inference for Ito processes and diffusions. 
+  Master build status: No Travis-CI build
 
   Maintainer: `M. Schauer <https://github.com/mschauer>`_
 
@@ -6532,9 +6949,11 @@ ____________________________________________
      :alt: Robert J. Ennis
      :target: https://github.com/rennis250
 
+  Julia interface to SDL 
+
   Current Version: ``0.0.0``  (updated: 2013-01-18) 
 
-  Julia interface to SDL 
+  Master build status: No Travis-CI build
 
   Maintainer: `Robert J. Ennis <https://github.com/rennis250>`_
 
@@ -6563,9 +6982,11 @@ __________________________________________________
      :alt: Jacob Quinn
      :target: https://github.com/karbarcca
 
+  A Julia interface to the Sqlite library and support for operations on DataFrames 
+
   Current Version: ``0.1.0``  (updated: 2013-06-20) 
 
-  A Julia interface to the Sqlite library and support for operations on DataFrames 
+  Master build status: No Travis-CI build
 
   Maintainer: `Jacob Quinn <https://github.com/karbarcca>`_
 
@@ -6600,9 +7021,11 @@ _________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  SVM's for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-04-14) 
 
-  SVM's for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -6630,9 +7053,11 @@ ________________________________________________________________________________
      :alt: David de Laat
      :target: https://github.com/daviddelaat
 
+  Interface to semidefinite programming libraries. 
+
   Current Version: ``0.0.0``  (updated: 2013-03-08) 
 
-  Interface to semidefinite programming libraries. 
+  Master build status: No Travis-CI build
 
   Maintainer: `David de Laat <https://github.com/daviddelaat>`_
 
@@ -6660,9 +7085,11 @@ _______________________________________________________
      :alt: Ben Lauwens
      :target: https://github.com/BenLauwens
 
+  Process oriented simulation library written in Julia 
+
   Current Version: ``0.1.2``  (updated: 2013-05-03) 
 
-  Process oriented simulation library written in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Ben Lauwens <https://github.com/BenLauwens>`_
 
@@ -6690,9 +7117,11 @@ ____________________________________________________________
      :alt: fredo-dedup
      :target: https://github.com/fredo-dedup
 
+  basic mcmc sampler implemented in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-07-01) 
 
-  basic mcmc sampler implemented in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `fredo-dedup <https://github.com/fredo-dedup>`_
 
@@ -6720,9 +7149,11 @@ ___________________________________________
      :alt: Tom Short
      :target: https://github.com/tshort
 
+  Experiments with non-causal, equation-based modeling in Julia 
+
   Current Version: ``0.0.0``  (updated: 2012-11-23) 
 
-  Experiments with non-causal, equation-based modeling in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tom Short <https://github.com/tshort>`_
 
@@ -6750,9 +7181,11 @@ ___________________________________________________
      :alt: Amit Murthy
      :target: https://github.com/amitmurthy
 
+  Julia wrapper for libsodium 
+
   Current Version: ``0.0.0``  (updated: 2013-04-24) 
 
-  Julia wrapper for libsodium 
+  Master build status: No Travis-CI build
 
   Maintainer: `Amit Murthy <https://github.com/amitmurthy>`_
 
@@ -6780,9 +7213,11 @@ _________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  The Soundex algorithm in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-07-08) 
 
-  The Soundex algorithm in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -6810,9 +7245,14 @@ _________________________________________________
      :alt: Julia Statistics
      :target: https://github.com/JuliaStats
 
+  Basic statistics for Julia 
+
   Current Version: ``0.2.6``  (updated: 2013-07-22) 
 
-  Basic statistics for Julia 
+  Master build status: |Stats_build|
+
+  .. |Stats_build| image:: https://api.travis-ci.org/JuliaStats/Stats.jl.png
+     :align: bottom
 
   Maintainer: `Julia Statistics <https://github.com/JuliaStats>`_
 
@@ -6870,9 +7310,11 @@ ______________________________________________
      :alt: Patrick O'Leary
      :target: https://github.com/pao
 
+  Swiss Army Knife for encoding and decoding binary streams 
+
   Current Version: ``0.0.0``  (updated: 2013-05-23) 
 
-  Swiss Army Knife for encoding and decoding binary streams 
+  Master build status: No Travis-CI build
 
   Maintainer: `Patrick O'Leary <https://github.com/pao>`_
 
@@ -6926,9 +7368,11 @@ ___________________________________________________
      :alt: Tom Short
      :target: https://github.com/tshort
 
+  Julia interface to Sundials, including a nonlinear solver (KINSOL), ODE's (CVODE), and DAE's (IDA). 
+
   Current Version: ``0.0.0``  (updated: 2013-05-07) 
 
-  Julia interface to Sundials, including a nonlinear solver (KINSOL), ODE's (CVODE), and DAE's (IDA). 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tom Short <https://github.com/tshort>`_
 
@@ -6950,9 +7394,11 @@ _______________________________________________
      :alt: john verzani
      :target: https://github.com/jverzani
 
+  Start of Julia interface to SymPy via PyCall 
+
   Current Version: ``0.2.0``  (updated: 2013-07-22) 
 
-  Start of Julia interface to SymPy via PyCall 
+  Master build status: No Travis-CI build
 
   Maintainer: `john verzani <https://github.com/jverzani>`_
 
@@ -6994,9 +7440,11 @@ _________________________________________
      :alt: pygy
      :target: https://github.com/pygy
 
+  A TOML parser for Julia. 
+
   Current Version: ``0.0.0``  (updated: 2013-03-06) 
 
-  A TOML parser for Julia. 
+  Master build status: No Travis-CI build
 
   Maintainer: `pygy <https://github.com/pygy>`_
 
@@ -7025,9 +7473,11 @@ _______________________________________________________
      :alt: Keno Fischer
      :target: https://github.com/loladiro
 
+  Terminal Interfaces for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-06-17) 
 
-  Terminal Interfaces for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Keno Fischer <https://github.com/loladiro>`_
 
@@ -7055,9 +7505,11 @@ ___________________________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  Julia package for text analysis 
+
   Current Version: ``0.0.1``  (updated: 2013-05-24) 
 
-  Julia package for text analysis 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -7087,9 +7539,14 @@ __________________________________________________________
      :alt: Carlo Baldassi
      :target: https://github.com/carlobaldassi
 
+  Package for wrapping text into paragraphs. 
+
   Current Version: ``0.1.1``  (updated: 2013-06-28) 
 
-  Package for wrapping text into paragraphs. 
+  Master build status: |TextWrap_build|
+
+  .. |TextWrap_build| image:: https://api.travis-ci.org/carlobaldassi/TextWrap.jl.png
+     :align: bottom
 
   Maintainer: `Carlo Baldassi <https://github.com/carlobaldassi>`_
 
@@ -7123,9 +7580,11 @@ ___________________________________________________________
      :alt: milktrader
      :target: https://github.com/milktrader
 
+  Modeling time series in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-06-14) 
 
-  Modeling time series in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `milktrader <https://github.com/milktrader>`_
 
@@ -7164,9 +7623,11 @@ ___________________________________________________________
      :alt: milktrader
      :target: https://github.com/milktrader
 
+  Time series toolkit for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-04-10) 
 
-  Time series toolkit for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `milktrader <https://github.com/milktrader>`_
 
@@ -7204,9 +7665,11 @@ __________________________________________
      :alt: The Julia Language
      :target: https://github.com/JuliaLang
 
+  Julia interface to Tk windowing toolkit. 
+
   Current Version: ``0.2.4``  (updated: 2013-08-01) 
 
-  Julia interface to Tk windowing toolkit. 
+  Master build status: No Travis-CI build
 
   Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
 
@@ -7301,9 +7764,11 @@ ___________________________________________________________
      :alt: Jonathan Chang
      :target: https://github.com/slycoder
 
+  TopicModels for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-03-17) 
 
-  TopicModels for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Jonathan Chang <https://github.com/slycoder>`_
 
@@ -7331,9 +7796,11 @@ _________________________________________________________________________
      :alt: milktrader
      :target: https://github.com/milktrader
 
+  Downloading financial time series data and providing financial asset types in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-03-01) 
 
-  Downloading financial time series data and providing financial asset types in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `milktrader <https://github.com/milktrader>`_
 
@@ -7366,9 +7833,11 @@ ______________________________________________
      :alt: The Julia Language
      :target: https://github.com/JuliaLang
 
+  Implementation of the trie data structure. 
+
   Current Version: ``0.0.0``  (updated: 2012-11-13) 
 
-  Implementation of the trie data structure. 
+  Master build status: No Travis-CI build
 
   Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
 
@@ -7396,9 +7865,14 @@ _______________________________________________________
      :alt: Keno Fischer
      :target: https://github.com/loladiro
 
+  Pure julia URI parser 
+
   Current Version: ``0.0.0``  (updated: 2013-07-12) 
 
-  Pure julia URI parser 
+  Master build status: |URIParser_build|
+
+  .. |URIParser_build| image:: https://api.travis-ci.org/loladiro/URIParser.jl.png
+     :align: bottom
 
   Maintainer: `Keno Fischer <https://github.com/loladiro>`_
 
@@ -7432,9 +7906,11 @@ ___________________________________________________________
      :alt: Keno Fischer
      :target: https://github.com/loladiro
 
+  RFC6570 URI templates for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-07-15) 
 
-  RFC6570 URI templates for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Keno Fischer <https://github.com/loladiro>`_
 
@@ -7462,9 +7938,14 @@ _____________________________________________________
      :alt: Tanmay Mohapatra
      :target: https://github.com/tanmaykm
 
+  Parse URL strings into components and re-create the URL string back from components. 
+
   Current Version: ``0.0.0``  (updated: 2013-06-24) 
 
-  Parse URL strings into components and re-create the URL string back from components. 
+  Master build status: |URLParse_build|
+
+  .. |URLParse_build| image:: https://api.travis-ci.org/tanmaykm/URLParse.jl.png
+     :align: bottom
 
   Maintainer: `Tanmay Mohapatra <https://github.com/tanmaykm>`_
 
@@ -7492,9 +7973,11 @@ ____________________________________________
      :alt: Mike Nolta
      :target: https://github.com/nolta
 
+  UTF16 string type for Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-01-14) 
 
-  UTF16 string type for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Mike Nolta <https://github.com/nolta>`_
 
@@ -7528,9 +8011,11 @@ ______________________________________________
      :alt: Tim Holy
      :target: https://github.com/timholy
 
+  Infrastructure for handling physical units for the Julia programming language 
+
   Current Version: ``0.2.0``  (updated: 2013-07-29) 
 
-  Infrastructure for handling physical units for the Julia programming language 
+  Master build status: No Travis-CI build
 
   Maintainer: `Tim Holy <https://github.com/timholy>`_
 
@@ -7558,9 +8043,11 @@ _________________________________________________________________
      :alt: Zach Allaun
      :target: https://github.com/zachallaun
 
+  Function dispatch on values 
+
   Current Version: ``0.0.0``  (updated: 2013-04-30) 
 
-  Function dispatch on values 
+  Master build status: No Travis-CI build
 
   Maintainer: `Zach Allaun <https://github.com/zachallaun>`_
 
@@ -7588,9 +8075,11 @@ ______________________________________________
      :alt: Daniel Casimiro
      :target: https://github.com/dancasimiro
 
+  Julia package for working with WAV files 
+
   Current Version: ``0.1.0``  (updated: 2013-01-16) 
 
-  Julia package for working with WAV files 
+  Master build status: No Travis-CI build
 
   Maintainer: `Daniel Casimiro <https://github.com/dancasimiro>`_
 
@@ -7619,9 +8108,11 @@ _____________________________________________________________
      :alt: Hacker School
      :target: https://github.com/hackerschool
 
+   
+
   Current Version: ``0.0.1``  (updated: 2013-07-18) 
 
-   
+  Master build status: No Travis-CI build
 
   Maintainer: `Hacker School <https://github.com/hackerschool>`_
 
@@ -7673,9 +8164,11 @@ ________________________________________________
      :alt: Mike Nolta
      :target: https://github.com/nolta
 
+  2D plotting for Julia 
+
   Current Version: ``0.3.0``  (updated: 2013-07-15) 
 
-  2D plotting for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Mike Nolta <https://github.com/nolta>`_
 
@@ -7767,9 +8260,11 @@ ____________________________________________
      :alt: Daniel Jones
      :target: https://github.com/dcjones
 
+  parse yer yamls 
+
   Current Version: ``0.1.3``  (updated: 2013-07-22) 
 
-  parse yer yamls 
+  Master build status: No Travis-CI build
 
   Maintainer: `Daniel Jones <https://github.com/dcjones>`_
 
@@ -7800,9 +8295,11 @@ ____________________________________________
      :alt: The Julia Language
      :target: https://github.com/JuliaLang
 
+  Julia interface to ZMQ 
+
   Current Version: ``0.0.0``  (updated: 2013-04-13) 
 
-  Julia interface to ZMQ 
+  Master build status: No Travis-CI build
 
   Maintainer: `The Julia Language <https://github.com/JuliaLang>`_
 
@@ -7860,9 +8357,11 @@ ______________________________________________
      :alt: Fazlul Shahriar
      :target: https://github.com/fhs
 
+  Read/Write ZIP file archives in Julia 
+
   Current Version: ``0.1.0``  (updated: 2013-07-24) 
 
-  Read/Write ZIP file archives in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Fazlul Shahriar <https://github.com/fhs>`_
 
@@ -7891,9 +8390,11 @@ ____________________________________________
      :alt: Daniel Jones
      :target: https://github.com/dcjones
 
+  zlib bindings for Julia 
+
   Current Version: ``0.1.1``  (updated: 2013-07-22) 
 
-  zlib bindings for Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `Daniel Jones <https://github.com/dcjones>`_
 
@@ -7933,9 +8434,11 @@ _________________________________________________
      :alt: John Myles White
      :target: https://github.com/johnmyleswhite
 
+  The k-nearest neighbors algorithm in Julia 
+
   Current Version: ``0.0.0``  (updated: 2013-04-12) 
 
-  The k-nearest neighbors algorithm in Julia 
+  Master build status: No Travis-CI build
 
   Maintainer: `John Myles White <https://github.com/johnmyleswhite>`_
 
@@ -7953,5 +8456,5 @@ _________________________________________________
 
 ----
 
-.. footer: 200 packages, generated 2 Aug 2013 12:08:40 GMT+05:30 
+.. footer: 201 packages, generated 2 Aug 2013 21:49:37 GMT+05:30 
 


### PR DESCRIPTION
This PR displays the current build status for packages that have continuous integration running on Travis. 

While this is a minority of packages currently, it will hopefully cause some social pressure on packages to add tests and to run them automatically. 

See screenshot below on how it looks for packages with and without travis integration. 

![screen shot 2013-08-02 at 22 10 21](https://f.cloud.github.com/assets/378918/902972/334559c8-fba3-11e2-913c-f3a9b84d7656.png)
