### PR TITLE
WIP: Enable LLVM loop vectorizer

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3092,11 +3092,12 @@ static void init_julia_llvm_env(Module *m)
     T_void = Type::getVoidTy(jl_LLVMContext);
 
     // add needed base definitions to our LLVM environment
-    StructType *valueSt = StructType::create(getGlobalContext(), "jl_value_t");
+    /*StructType *valueSt = StructType::create(getGlobalContext(), "jl_value_t");
     Type *valueStructElts[1] = { PointerType::getUnqual(valueSt) };
     ArrayRef<Type*> vselts(valueStructElts);
     valueSt->setBody(vselts);
-    jl_value_llvmt = valueSt;
+    jl_value_llvmt = valueSt;*/
+    jl_value_llvmt = PointerType::getUnqual(T_int8);
 
     jl_pvalue_llvmt = PointerType::get(jl_value_llvmt, 0);
     jl_ppvalue_llvmt = PointerType::get(jl_pvalue_llvmt, 0);
@@ -3380,6 +3381,7 @@ static void init_julia_llvm_env(Module *m)
     //FPM->add(createLoopDeletionPass());         // Delete dead loops
     FPM->add(createLoopUnrollPass());           // Unroll small loops
     //FPM->add(createLoopStrengthReducePass());   // (jwb added)
+    FPM->add(createLoopVectorizePass());          // Vectorize loops
     
     FPM->add(createInstructionCombiningPass()); // Clean up after the unroller
     FPM->add(createGVNPass());                  // Remove redundancies

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -65,6 +65,9 @@
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Config/llvm-config.h"
+#ifdef DEBUG
+#include "llvm/Support/CommandLine.h"
+#endif
 #include <setjmp.h>
 
 #include <string>
@@ -3394,7 +3397,9 @@ static void init_julia_llvm_env(Module *m)
 
 extern "C" void jl_init_codegen(void)
 {
-    
+#ifdef DEBUG
+    cl::ParseEnvironmentOptions("Julia", "JULIA_LLVM_ARGS");
+#endif
     InitializeNativeTarget();
     jl_Module = new Module("julia", jl_LLVMContext);
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -644,7 +644,7 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
     Value *typemin;
     switch (f) {
     HANDLE(neg_int,1) return builder.CreateSub(ConstantInt::get(t, 0), JL_INT(x));
-    HANDLE(add_int,2) return builder.CreateAdd(JL_INT(x), JL_INT(y));
+    HANDLE(add_int,2) return builder.CreateAdd(JL_INT(x), JL_INT(y), "", false, true);
     HANDLE(sub_int,2) return builder.CreateSub(JL_INT(x), JL_INT(y));
     HANDLE(mul_int,2) return builder.CreateMul(JL_INT(x), JL_INT(y));
     HANDLE(sdiv_int,2)


### PR DESCRIPTION
While there's been some discussion of adding SIMD types in #2299, I thought it might be fun to see how well the LLVM loop vectorizer can do with Julia code. This PR compiles (but doesn't compile sysimg.jl), runs, and vectorizes things ([sample](https://gist.github.com/simonster/6147815)), but there are two very big problems with it.

The first issue is that this PR turns all integer `add` operations into `add nsw` in order to get that proof of concept to work. Scalar evolution analysis requires that operations on the loop index produce undefined behavior on overflow, but to change this generally might be too unsafe for a high-level language. Since we should be able to guarantee that `next(::Range{Int})`/`next(::Range1{Int})` doesn't overflow, one option is to add `nsw` intrinsics and use those.

The second issue is that this PR turns `jl_value_t` into `int8*`. Not only does this seem very wrong, it also breaks building `sysimg.jl`, although Julia seems to run fine with a sysimg.jl built without this change. Unfortunately, I haven't been able to get the loop vectorizer to work with `jl_value_t` as a structure type. With this change, the IR going into the loop vectorization pass looks like [this](https://gist.github.com/simonster/6147959), whereas without it, the IR looks like [this](https://gist.github.com/simonster/6147965). Notice that, with `jl_value_t` as `i8*`, the bitcast is outside of the loop, whereas with `jl_value_t` as a structure type, it is inside the loop. This seems to bother the loop vectorizer, which tells me:

```
LV: Found a loop: if
LV: Found an induction variable.
LV: Found a runtime check ptr:  %7 = bitcast %jl_value_t* %6 to double*, !dbg !3370
LV: Found a runtime check ptr:  %7 = bitcast %jl_value_t* %6 to double*, !dbg !3370
LV: We need to compare 1 ptrs.
LV: We can perform a memory runtime check if needed.
LV: Found an unidentified write ptr:  %4 = load %jl_value_t** %3, align 8, !dbg !3369
LV: Adding Underlying value:  %4 = load %jl_value_t** %3, align 8, !dbg !3369
LV: Found an unidentified read ptr:  %4 = load %jl_value_t** %3, align 8, !dbg !3369
LV: Found a possible write-write reorder:  %4 = load %jl_value_t** %3, align 8, !dbg !3369
LV: Can't vectorize due to memory conflicts
LV: Not vectorizing.
```

If I move the bitcast out of the loop and compile the IR manually with `opt`, it seems to work, but I'm a little confused about what makes these cases different.
