### PR TITLE
RFC: add flush_cstdio function

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1029,6 +1029,7 @@ export
     fd,
     fdio,
     flush,
+    flush_cstdio,
     getaddrinfo,
     gethostname,
     getipaddr,

--- a/base/util.jl
+++ b/base/util.jl
@@ -1,3 +1,7 @@
+# flush C stdio output from external libraries:
+
+flush_cstdio() = ccall(:jl_flush_cstdio, Void, ())
+
 # timing
 
 # system date in seconds

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -1512,6 +1512,13 @@
 
 "),
 
+("I/O","Base","flush_cstdio","flush_cstdio()
+
+   Flushes the C stdout and stderr streams (which may have been
+   written to by external C code).
+
+"),
+
 ("I/O","Base","close","close(stream)
 
    Close an I/O stream. Performs a \"flush\" first.

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -983,6 +983,11 @@ I/O
 
    Commit all currently buffered writes to the given stream.
 
+.. function:: flush_cstdio()
+
+   Flushes the C ``stdout`` and ``stderr`` streams (which may have been
+   written to by external C code).
+
 .. function:: close(stream)
 
    Close an I/O stream. Performs a ``flush`` first.

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -648,6 +648,12 @@ DLLEXPORT int jl_strtof(char *str, float *out)
 
 // showing --------------------------------------------------------------------
 
+void jl_flush_cstdio()
+{
+    fflush(stdout);
+    fflush(stderr);
+}
+
 jl_value_t *jl_stdout_obj()
 {
     jl_value_t *stdout_obj = jl_get_global(jl_base_module, jl_symbol("STDOUT"));

--- a/src/julia.h
+++ b/src/julia.h
@@ -888,6 +888,7 @@ jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr);
 // some useful functions
 DLLEXPORT void jl_show(jl_value_t *stream, jl_value_t *v);
 void jl_show_tuple(jl_value_t *st, jl_tuple_t *t, char opn, char cls, int comma_one);
+DLLEXPORT void jl_flush_cstdio();
 DLLEXPORT jl_value_t *jl_stdout_obj();
 DLLEXPORT jl_value_t *jl_stderr_obj();
 DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b);


### PR DESCRIPTION
This adds `flush_cstdio()` function, which calls `fflush(stdout)` and `fflush(stderr)` in C.   This is needed in order to flush any output from external C code.

(For example, I need this in IJulia in order to make sure external `printf` output is captured after evaluating an input cell.)
