### PR TITLE
RFC: RadixSort

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -82,6 +82,7 @@ export
     QR,
     QRPivoted,
     QuickSort,
+    RadixSort,
     Range,
     Range1,
     RangeIndex,

--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -3,9 +3,11 @@ module Order
 ## notions of element ordering ##
 
 export # not exported by Base
-    Ordering, Forward, By, Lt, Perm,
+    Ordering, Forward, 
+    By, Lt, Perm,
     ReverseOrdering, ForwardOrdering,
-    lt, ord
+    DirectOrdering,
+    lt, uint_mapping, ord, ordtype
     # Reverse, # TODO: clashes with Reverse iterator
 
 abstract Ordering
@@ -18,20 +20,18 @@ end
 ReverseOrdering(rev::ReverseOrdering) = rev.fwd
 ReverseOrdering{Fwd}(fwd::Fwd) = ReverseOrdering{Fwd}(fwd)
 
-immutable By <: Ordering
-    by::Function
-end
-immutable Lt <: Ordering
-    lt::Function
-end
+typealias DirectOrdering Union(ForwardOrdering,ReverseOrdering{ForwardOrdering})
 
 const Forward = ForwardOrdering()
 const Reverse = ReverseOrdering(Forward)
 
-lt(o::ForwardOrdering, a, b) = isless(a,b)
-lt(o::ReverseOrdering, a, b) = lt(o.fwd,b,a)
-lt(o::By,              a, b) = isless(o.by(a),o.by(b))
-lt(o::Lt,              a, b) = o.lt(a,b)
+immutable By <: Ordering
+    by::Function
+end
+
+immutable Lt <: Ordering
+    lt::Function
+end
 
 immutable Perm{O<:Ordering,V<:AbstractVector} <: Ordering
     order::O
@@ -39,8 +39,42 @@ immutable Perm{O<:Ordering,V<:AbstractVector} <: Ordering
 end
 Perm{O<:Ordering,V<:AbstractVector}(o::O,v::V) = Perm{O,V}(o,v)
 
+lt(o::ForwardOrdering, a, b) = isless(a,b)
+lt(o::ReverseOrdering, a, b) = lt(o.fwd,b,a)
+lt(o::By,              a, b) = isless(o.by(a),o.by(b))
+lt(o::Lt,              a, b) = o.lt(a,b)
 lt(p::Perm, a, b) = lt(p.order, p.data[a], p.data[b])
 
+# Map a bits-type to an unsigned int, maintaining sort order
+uint_mapping(::ForwardOrdering, x::Unsigned) = x
+uint_mapping(::ForwardOrdering, x::Int8)     = uint8  (x $ typemin(Int8))
+uint_mapping(::ForwardOrdering, x::Int16)    = uint16 (x $ typemin(Int16))
+uint_mapping(::ForwardOrdering, x::Int32)    = uint32 (x $ typemin(Int32))
+uint_mapping(::ForwardOrdering, x::Int64)    = uint64 (x $ typemin(Int64))
+uint_mapping(::ForwardOrdering, x::Int128)   = uint128(x $ typemin(Int128))
+uint_mapping(::ForwardOrdering, x::Float32)  = (y = reinterpret(Int32, x); uint32(y < 0 ? ~y : (y $ typemin(Int32))))
+uint_mapping(::ForwardOrdering, x::Float64)  = (y = reinterpret(Int64, x); uint64(y < 0 ? ~y : (y $ typemin(Int64))))
+
+uint_mapping{Fwd}(::ReverseOrdering{Fwd}, x) = ~uint_mapping(Fwd, x)
+#uint_mapping{T<:Real}(::ReverseOrdering{ForwardOrdering}, x::T) = ~uint_mapping(Forward, x)  ## Manually inlined
+uint_mapping(::ReverseOrdering{ForwardOrdering}, x::Unsigned) = ~x
+uint_mapping(::ReverseOrdering{ForwardOrdering}, x::Int8)     = ~uint8  (x $ typemin(Int8))
+uint_mapping(::ReverseOrdering{ForwardOrdering}, x::Int16)    = ~uint16 (x $ typemin(Int16))
+uint_mapping(::ReverseOrdering{ForwardOrdering}, x::Int32)    = ~uint32 (x $ typemin(Int32))
+uint_mapping(::ReverseOrdering{ForwardOrdering}, x::Int64)    = ~uint64 (x $ typemin(Int64))
+uint_mapping(::ReverseOrdering{ForwardOrdering}, x::Int128)   = ~uint128(x $ typemin(Int128))
+uint_mapping(::ReverseOrdering{ForwardOrdering}, x::Float32)  = (y = reinterpret(Int32, x); uint32(y < 0 ? y : ~(y $ typemin(Int32))))
+uint_mapping(::ReverseOrdering{ForwardOrdering}, x::Float64)  = (y = reinterpret(Int64, x); uint64(y < 0 ? y : ~(y $ typemin(Int64))))
+
+uint_mapping(o::By,   x)      = uint_mapping(Forward, o.by(x))
+uint_mapping(o::Perm, i::Int) = uint_mapping(o.order, o.data[i])
+
+ordtype   (o::ReverseOrdering, vs::AbstractArray) = ordtype(o.fwd, vs)
+ordtype   (o::Perm,            vs::AbstractArray) = ordtype(o.order, o.data)
+# TODO: here, we really want the return type of o.by, without calling it
+ordtype   (o::By,              vs::AbstractArray) = try typeof(o.by(vs[1])) catch Any end
+
+ordtype{T}(o::Ordering,        vs::AbstractArray{T}) = T
 
 function ord(lt::Function, by::Function, rev::Bool, order::Ordering=Forward)
     o = (lt===isless) & (by===identity) ? order  :

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -464,9 +464,7 @@ isnan(o::DirectOrdering, x::Floats) = (x!=x)
 isnan(o::Perm, i::Int) = isnan(o.order,o.data[i])
 
 uint_mapping{F<:Floats}(::Right, x::F) = uint_mapping(Forward, x)
-#uint_mapping{F<:Floats}(::Left,  x::F) = uint_mapping(Base.Ordering.Reverse, x)  ## Manually inlined
-uint_mapping(::Left, x::Float32) = (y = reinterpret(Int32, x); uint32(y < 0 ? y : ~(y $ typemin(Int32))))
-uint_mapping(::Left, x::Float64) = (y = reinterpret(Int64, x); uint64(y < 0 ? y : ~(y $ typemin(Int64))))
+uint_mapping{F<:Floats}(::Left , x::F) = uint_mapping(Forward, x)
 
 function nans2left!(v::AbstractVector, o::Ordering, lo::Int=1, hi::Int=length(v))
     hi < lo && return lo, hi


### PR DESCRIPTION
This probably belongs in a package with #3825, but I wanted to put it here to get some feedback, and to see if there's a reason for it in base. 

This is a fairly fast implementation of radix sort.  Many of the ideas were inspired by http://www.stereopsis.com/radix.html:
- histogramming all radixes in the same loop
- 11-bit radixes, rather than 8-bit, to reduce the number of passes through the data
- bit twiddling for signed integers and floating point numbers mapping them to unsigned integers, while maintaining sort order (see the `uint_mapping` function)

Additionally, one optimization occurs during the sort phase, where one extra comparison is done at the beginning of each outer loop see if any sorting is needed for the current radix; if none is needed, that iteration is skipped.  This is useful for sorting, e.g., 64-bit integers with small-ish positive values/ranges, as many of the radixes will be zero for all numbers involved.

After some work, the results is quite performant, with a few caveats/limitations.  Benefits include

1) it is especially fast at sorting smaller Int sizes (32-bit and smaller), often 2-4x faster than `QuickSort` (which is already a pretty fast implementation), and generally faster even for 64-bit numbers when the data is random
2) it is a stable sort
3) it's integrated with the current sorting framework, and can work with all standard `Orderings` except `Lt`.

Limitations:

1) it's limited to bits types: all sizes of `Int`, `Uint`, and `Float32/Float64`; no direct sorting of Strings
2) it will work with functions of non-bit types (eg., `sort!(a::Array{String}, by=length)` as long as the function produces a bits type; however the function call overhead is currently pretty high
3) in the same vein, it works with `sortperm`, with some overhead; this can still be faster than other algorithms for smaller data types
4) it has an up-front overhead which makes it slower than the other sorts for lists with less than ~2^13 (8192) values, give or take, depending on the machine.  Larger than that, it is generally faster than all other sorts (in Julia) for straight lists of Ints/Floats.  (**Edit: Actually, for 64-bit numbers, this depends on the range of values**)
5) For 128-bit numbers, it is quite slow (assuming the high order bits are not empty).  This is not surprising, since the run time is proportional to the size of the items being sorted, and 128-bit numbers are big (`O(kn)`, where k is the word size).
6) It uses O(N) memory (like `MergeSort`), which affects performance at some point depending on list and machine being used

You can see a comparison of all sorts in the [SortPerf.jl package](https://github.com/kmsquire/SortPerf.jl).  The README has a table with a summary suggesting when each algorithm should be used, and sortperf.pdf shows a comparison of all of the different sort algorithms run on various tests.  (Note that most of the tests were originally written to show off `TimSort`, and have some structure that other sorts (but not radix sort) can take advantage of.  `RadixSort` does come out on top sorting random lists, as well, as large lists with only a few unique values.)

Finally, I had to work around some type inference limitations for the `uint_mapping` function (look for "manually inlined" comments).  I'll file those issues separately.

Comments/suggestions on the implementation or what to do with it are welcome.

CC: @StefanKarpinski
