### PR TITLE
Repair floating point ranges with start==stop.

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -46,7 +46,7 @@ function colon{T<:Real}(start::T, step::T, stop::T)
         nf = (stop-start)/step + 1
         if T <: FloatingPoint
             n = round(nf)
-            if abs(n-nf) < eps(n)*3
+            if n > 1 && abs(n-nf) < eps(n)*3
                 # adjust step to try to hit stop exactly
                 step = (stop-start)/(n-1)
                 len = itrunc(n)


### PR DESCRIPTION
As noted in https://groups.google.com/forum/#!topic/julia-users/xd2OI3J6ilM

```
julia> 1:1.0:1
ERROR: Range: step cannot be NaN
 in Range at range.jl:13
```

This fixes it.
