### PR TITLE
Remove `shuffle` from docs

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -2786,13 +2786,9 @@ Combinatorics
 
    Construct a random cyclic permutation of the given length.
 
-.. function:: shuffle(v)
-
-   Randomly rearrange the elements of a vector.
-
 .. function:: shuffle!(v)
 
-   In-place version of :func:`shuffle`.
+   Randomly rearrange the elements of a vector in-place
 
 .. function:: reverse(v)
 


### PR DESCRIPTION
`shuffle` appears to have been deprecated in favor of `shuffle!`, but hadn't been removed from docs
