### PR TITLE
Allow ccall of LLVM intrinsics

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -146,9 +146,9 @@ export
     # intrinsics module
     Intrinsics
     #ccall, cglobal, abs_float, add_float, add_int, and_int, ashr_int,
-    #box, bswap_int, checked_fptosi, checked_fptoui, checked_sadd,
+    #box, checked_fptosi, checked_fptoui, checked_sadd,
     #checked_smul, checked_ssub, checked_uadd, checked_umul, checked_usub,
-    #nan_dom_err, copysign_float, ctlz_int, ctpop_int, cttz_int,
+    #nan_dom_err, copysign_float, ctlz_int, cttz_int,
     #div_float, eq_float, eq_int, eqfsi64, eqfui64, flipsign_int,
     #fpext64, fpiseq, fpislt, fpsiround, fpuiround, fptosi, fptoui,
     #fptrunc32, le_float, lefsi64, lefui64, lesif64,

--- a/base/float.jl
+++ b/base/float.jl
@@ -243,7 +243,3 @@ end
 
 sizeof(::Type{Float32}) = 4
 sizeof(::Type{Float64}) = 8
-
-## byte order swaps for arbitrary-endianness serialization/deserialization ##
-bswap(x::Float32) = box(Float32,bswap_int(unbox(Float32,x)))
-bswap(x::Float64) = box(Float64,bswap_int(unbox(Float64,x)))

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -34,6 +34,10 @@ isfloat64(x::Number) = float64(x) == x
 isfloat64(::Float64) = true
 isfloat64(::Float32) = true
 
+## byte order swaps for arbitrary-endianness serialization/deserialization ##
+bswap(x::Float32) = reinterpret(Float32, bswap(reinterpret(Int32, x)))
+bswap(x::Float64) = reinterpret(Float64, bswap(reinterpret(Int64, x)))
+
 ## precision, as defined by the effective number of bits in the mantissa ##
 get_precision(::Float32) = 24
 get_precision(::Float64) = 53

--- a/base/int.jl
+++ b/base/int.jl
@@ -167,28 +167,6 @@ mod(x::Int64,  y::Int64)  = box(Int64,smod_int(unbox(Int64,x),unbox(Int64,y)))
 >>>(x::Uint64,  y::Int32) = box(Uint64,lshr_int(unbox(Uint64,x),unbox(Int32,y)))
 >>>(x::Uint128, y::Int32) = box(Uint128,lshr_int(unbox(Uint128,x),unbox(Int32,y)))
 
-bswap(x::Int8)    = x
-bswap(x::Uint8)   = x
-bswap(x::Int16)   = box(Int16,bswap_int(unbox(Int16,x)))
-bswap(x::Uint16)  = box(Uint16,bswap_int(unbox(Uint16,x)))
-bswap(x::Int32)   = box(Int32,bswap_int(unbox(Int32,x)))
-bswap(x::Uint32)  = box(Uint32,bswap_int(unbox(Uint32,x)))
-bswap(x::Int64)   = box(Int64,bswap_int(unbox(Int64,x)))
-bswap(x::Uint64)  = box(Uint64,bswap_int(unbox(Uint64,x)))
-bswap(x::Int128)  = box(Int128,bswap_int(unbox(Int128,x)))
-bswap(x::Uint128) = box(Uint128,bswap_int(unbox(Uint128,x)))
-
-count_ones(x::Int8)    = int(box(Int8,ctpop_int(unbox(Int8,x))))
-count_ones(x::Uint8)   = int(box(Uint8,ctpop_int(unbox(Uint8,x))))
-count_ones(x::Int16)   = int(box(Int16,ctpop_int(unbox(Int16,x))))
-count_ones(x::Uint16)  = int(box(Uint16,ctpop_int(unbox(Uint16,x))))
-count_ones(x::Int32)   = int(box(Int32,ctpop_int(unbox(Int32,x))))
-count_ones(x::Uint32)  = int(box(Uint32,ctpop_int(unbox(Uint32,x))))
-count_ones(x::Int64)   = int(box(Int64,ctpop_int(unbox(Int64,x))))
-count_ones(x::Uint64)  = int(box(Uint64,ctpop_int(unbox(Uint64,x))))
-count_ones(x::Int128)  = int(box(Int128,ctpop_int(unbox(Int128,x))))
-count_ones(x::Uint128) = int(box(Uint128,ctpop_int(unbox(Uint128,x))))
-
 leading_zeros(x::Int8)    = int(box(Int8,ctlz_int(unbox(Int8,x))))
 leading_zeros(x::Uint8)   = int(box(Uint8,ctlz_int(unbox(Uint8,x))))
 leading_zeros(x::Int16)   = int(box(Int16,ctlz_int(unbox(Int16,x))))

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -30,6 +30,28 @@ abs(x::Signed) = flipsign(x,x)
 
 ~(n::Integer) = -n-1
 
+bswap(x::Int8)    = x
+bswap(x::Uint8)   = x
+bswap(x::Int16)   = ccall("llvm.bswap.i16", Int16, (Int16,), x)
+bswap(x::Uint16)  = ccall("llvm.bswap.i16", Uint16, (Uint16,), x)
+bswap(x::Int32)   = ccall("llvm.bswap.i32", Int32, (Int32,), x)
+bswap(x::Uint32)  = ccall("llvm.bswap.i32", Uint32, (Uint32,), x)
+bswap(x::Int64)   = ccall("llvm.bswap.i64", Int64, (Int64,), x)
+bswap(x::Uint64)  = ccall("llvm.bswap.i64", Uint64, (Uint64,), x)
+bswap(x::Int128)  = ccall("llvm.bswap.i128", Int128, (Int128,), x)
+bswap(x::Uint128) = ccall("llvm.bswap.i128", Uint128, (Uint128,), x)
+
+count_ones(x::Int8)    = int(ccall("llvm.ctpop.i8", Int8, (Int8,), x))
+count_ones(x::Uint8)   = int(ccall("llvm.ctpop.i8", Uint8, (Uint8,), x))
+count_ones(x::Int16)   = int(ccall("llvm.ctpop.i16", Int16, (Int16,), x))
+count_ones(x::Uint16)  = int(ccall("llvm.ctpop.i16", Uint16, (Uint16,), x))
+count_ones(x::Int32)   = int(ccall("llvm.ctpop.i32", Int32, (Int32,), x))
+count_ones(x::Uint32)  = int(ccall("llvm.ctpop.i32", Uint32, (Uint32,), x))
+count_ones(x::Int64)   = int(ccall("llvm.ctpop.i64", Int64, (Int64,), x))
+count_ones(x::Uint64)  = int(ccall("llvm.ctpop.i64", Uint64, (Uint64,), x))
+count_ones(x::Int128)  = int(ccall("llvm.ctpop.i128", Int128, (Int128,), x))
+count_ones(x::Uint128) = int(ccall("llvm.ctpop.i128", Uint128, (Uint128,), x))
+
 ## number-theoretic functions ##
 
 function gcd{T<:Integer}(a::T, b::T)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -662,6 +662,17 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         Type *funcptype = PointerType::get(functype,0);
         llvmf = literal_pointer_val(fptr, funcptype);
     }
+    else if (!strncmp(f_name, "llvm.", 5)) {
+        llvmf = jl_Module->getOrInsertFunction(f_name, functype);
+        Function *llvmffunc = dyn_cast<Function>(llvmf);
+        if (llvmffunc == NULL || llvmffunc->getIntrinsicID() == 0) {
+            std::stringstream msg;
+            msg << "ccall: could not find intrinsic function ";
+            msg << f_name;
+            emit_error(msg.str(), ctx);
+            return literal_pointer_val(jl_nothing);
+        }
+    }
     else {
         void *symaddr;
         if (f_lib != NULL)

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -21,7 +21,7 @@ namespace JL_I {
         lesif64, leuif64,
         // bitwise operators
         and_int, or_int, xor_int, not_int, shl_int, lshr_int, ashr_int,
-        bswap_int, ctpop_int, ctlz_int, cttz_int,
+        ctlz_int, cttz_int,
         // conversion
         sext_int, zext_int, trunc_int,
         fptoui, fptosi, uitofp, sitofp,
@@ -922,16 +922,6 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
                          builder.CreateAShr(x, ConstantInt::get(x->getType(),
                                                                 x->getType()->getPrimitiveSizeInBits()-1)),
                          builder.CreateAShr(x, uint_cnvt(t,y)));
-    HANDLE(bswap_int,1)
-        x = JL_INT(x);
-        return builder.CreateCall(
-            Intrinsic::getDeclaration(jl_Module, Intrinsic::bswap,
-                                      ArrayRef<Type*>(x->getType())), x);
-    HANDLE(ctpop_int,1)
-        x = JL_INT(x);
-        return builder.CreateCall(
-            Intrinsic::getDeclaration(jl_Module, Intrinsic::ctpop,
-                                      ArrayRef<Type*>(x->getType())), x);
 #if !defined(LLVM_VERSION_MAJOR) || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 0)
     HANDLE(ctlz_int,1)
         x = JL_INT(x);
@@ -1096,8 +1086,8 @@ extern "C" void jl_init_intrinsic_functions(void)
     ADD_I(lesif64); ADD_I(leuif64);
     ADD_I(fpiseq); ADD_I(fpislt);
     ADD_I(and_int); ADD_I(or_int); ADD_I(xor_int); ADD_I(not_int);
-    ADD_I(shl_int); ADD_I(lshr_int); ADD_I(ashr_int); ADD_I(bswap_int);
-    ADD_I(ctpop_int); ADD_I(ctlz_int); ADD_I(cttz_int);
+    ADD_I(shl_int); ADD_I(lshr_int); ADD_I(ashr_int);
+    ADD_I(ctlz_int); ADD_I(cttz_int);
     ADD_I(sext_int); ADD_I(zext_int); ADD_I(trunc_int);
     ADD_I(fptoui); ADD_I(fptosi);
     ADD_I(fpsiround); ADD_I(fpuiround);

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1,3 +1,10 @@
 ccall_test_func(x) = ccall((:testUcharX, "./libccalltest"), Int32, (Uint8,), x)
 @assert ccall_test_func(3) == 1
 @assert ccall_test_func(259) == 1
+
+@assert ccall("llvm.sqrt.f64", Float64, (Float64,), 2) == sqrt(2)
+try
+	ccall("llvm.nonexistentintrinsic", Float64, (Float64,), 2)
+	error("ccall of non-existent intrinsic should throw")
+catch
+end


### PR DESCRIPTION
This simplifies things while adding flexibility, and as far as I can tell it generates exactly the same code. 

For the moment, I've only converted the `bswap_int` and `ctpop_int` intrinsics, but more could potentially be done with this:
- If we can drop support for LLVM <3.1, `ctlz_int` (`leading_zeros`) and `cttz_int` (`trailing_zeros`) can be converted from Julia intrinsics to ccalls to LLVM intrinsics
- If we can drop support for LLVM <3.2, `abs_float` can be converted from a Julia intrinsic to a ccall to `llvm.fabs`
- If we can drop support for LLVM <3.3, we can replace `floor`, `ceil`, and `trunc` calls to libm with `llvm.floor`, `llvm.ceil`, and `llvm.trunc`, which compile to a single instruction and are considerably faster
- `llvm.sqrt` compiles down to a single instruction, but the LLVM intrinsic has undefined behavior on negative values, so at the moment I think this would still need a Julia intrinsic to be inlineable. In a naïve benchmark it also doesn't seem any faster than calling into libm, although it might be faster in cases where the next operation is not a sqrt
- `llvm.powi` was discussed in #2741. It looks like LLVM just lowers this into a bunch of multiply instructions if the exponent is a constant. It doesn't sound like this will always give the same result as `pow`
- LLVM has intrinsics for several other mathematical functions, but AFAICT they just call libm and the only advantage is that constant expressions can be evaluated at compile time
- LLVM has intrinsics for `memcpy`/`memmove`/`memset`, but AFAICT they also just call the library functions unless they can be optimized out, and in the few cases where they're used I doubt they can be
