### PR TITLE
Set DataLayout in codegen

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3334,7 +3334,9 @@ static void init_julia_llvm_env(Module *m)
 
     // set up optimization passes
     FPM = new FunctionPassManager(jl_Module);
-#ifndef LLVM32
+#ifdef LLVM32
+    FPM->add(new DataLayout(*jl_ExecutionEngine->getDataLayout()));
+#else 
     FPM->add(new TargetData(*jl_ExecutionEngine->getTargetData()));
 #endif
     // list of passes from vmkit


### PR DESCRIPTION
DataLayout is apparently the replacement for TargetData in LLVM 3.2+. Without it, LLVM apparently doesn't optimize `memset`s into stores, but it looks like there are a lot of other optimization passes that make use of this information as well.
