### PR TITLE
WIP: initial stab at an abstract graphics/GUI interface

### DIFF
--- a/base/GUI.jl
+++ b/base/GUI.jl
@@ -1,0 +1,94 @@
+module GUI
+
+using Trees
+
+import Trees: destroy!
+
+export # types
+    AbstractButton,
+    AbstractCanvas,
+    AbstractCanvas3D,
+    AbstractFrame,
+    AbstractWidget,
+    AbstractWindow,
+    # functions
+    button,
+    draw,
+    frame,
+    resize,
+    height,
+    width,
+    window
+
+abstract GraphicsObject
+
+typealias GraphicsHandle{T<:GraphicsObject} AryNode{T}  # I _love_ that this is possible!
+
+graphicsobject(p::GraphicsHandle, obj::GraphicsObject) = AryNode(p, obj)
+
+type GraphicsRoot <: GraphicsObject; end
+
+const graphicsroot = AryNode{GraphicsRoot}()
+
+destroy!() = destroy!(graphicsroot)
+
+function draw(obj::GraphicsHandle)
+    for c in obj.children
+        draw(c)
+    end
+    draw(get(obj))
+end
+
+draw(n::Nothing) = nothing
+
+function resize(obj::GraphicsHandle)
+    for c in obj.children
+        resize(c)
+    end
+    resize(get(obj))
+end
+
+resize(n::Nothing) = nothing
+
+width(obj::GraphicsHandle) = width(get(obj))
+height(obj::GraphicsHandle) = height(get(obj))
+
+abstract AbstractWindow <: GraphicsObject
+abstract AbstractFrame <: GraphicsObject
+abstract AbstractCanvas <: GraphicsObject
+abstract AbstractCanvas3D <: GraphicsObject
+abstract AbstractWidget <: GraphicsObject
+abstract AbstractButton <: GraphicsObject
+
+# This is predicated on a constructor Window() in a specific graphics toolkit wrapper
+# Will this mod trick work??
+window(title::String, w::Integer, h::Integer; mod::Module = current_module()) = AryNode(graphicsroot, mod.Window(title, int(w), int(h)))
+
+function frame{T<:Union(AbstractWindow,AbstractFrame)}(win::AryNode{T}; col::Integer = 1, row::Integer = 1, justify = "nsew", color = (0.85,0.85,0.85), mod::Module = current_module())
+    f = AryNode(win, mod.Frame(color))
+    mod.grid(f, col, row, justify)
+    f
+end
+
+function button{F<:AbstractFrame}(f::AryNode{F}, msg::String, callback::Function; col::Integer = 1, row::Integer = 1, justify = "nsew", mod::Module = current_module())
+    b = AryNode(f, mod.Button(msg, callback))
+    mod.grid(f, col, row, justify)
+    b
+end
+
+type MouseHandler
+    button1press
+    button1release
+    button2press
+    button2release
+    button3press
+    button3release
+    motion
+    button1motion
+
+    MouseHandler() = new(default_mouse_cb, default_mouse_cb, default_mouse_cb,
+                         default_mouse_cb, default_mouse_cb, default_mouse_cb,
+                         default_mouse_cb, default_mouse_cb)
+end
+
+end

--- a/base/trees.jl
+++ b/base/trees.jl
@@ -1,0 +1,125 @@
+module Trees
+
+import Base: eltype, get, show
+
+export # types
+    AbstractNode,
+    AryNode,
+    # functions
+    ancestor,
+    children,
+    destroy!,
+    isleaf,
+    isroot,
+    parent,
+    root
+
+abstract AbstractNode
+
+# An AryNode will always have parent and children defined; data might not be. Use get() to access data.
+type AryNode{T} <: AbstractNode
+    parent
+    children::Set
+    data::T
+
+    function AryNode{T}(p, data::T)  # if we declare p::AryNode, it seems to assume AryNode{T}
+        if !isa(p, AryNode)
+            error("Invalid parent of type ", typeof(p))
+        end
+        s = new(p, Set(), data)
+        add!(p.children, s)
+        s
+    end
+    function AryNode(p::AryNode)
+        if !isa(p, AryNode)
+            error("Invalid parent of type ", typeof(p))
+        end
+        s = new(p, Set())
+        add!(p.children, s)
+        s
+    end
+    # For the root node
+    function AryNode()
+        s = new()
+        s.parent = s
+        s.children = Set()
+        s
+    end
+end
+AryNode{T}(p::AryNode, data::T) = AryNode{T}(p, data)
+AryNode{T}(::Type{T}) = AryNode{T}()
+AryNode() = AryNode{Nothing}()
+
+parent(node::AbstractNode) = node.parent
+
+children(node::AryNode) = node.children
+
+get(node::AryNode) = isdefined(node, :data) ? node.data : nothing
+
+isroot(node::AbstractNode) = parent(node) == node
+
+isleaf(node::AbstractNode) = isempty(children(node))
+
+root(node::AryNode) = isroot(node) ? node : root(parent(node))
+
+ancestor{T}(node::AryNode, ::Type{T}) = isa(get(node), T) || isroot(node) ? node : ancestor(parent(node), T)
+
+function destroy!(node::AryNode)
+    for c in node.children
+        destroy!(c)
+    end
+    if !isroot(node)
+        delete!(node.parent.children, node)
+    end
+    node.parent = node  # detach from the tree
+    # Also call any data-specific cleanup
+    if isdefined(node, :data)
+        node.data = destroy!(node.data)
+    end
+end
+
+destroy!(x) = x
+
+# eltype(node::AryNode) = typeof(get(node))
+eltype{T}(node::AryNode{T}) = T
+
+function show(io::IO, node::AryNode)
+    println(io, eltype(node), " node:")
+    print(io, "  parent: ")
+    if isroot(node)
+        println(io, "<self>")
+    elseif isroot(node.parent)
+        println(io, "root node")
+    else
+        println(io, eltype(node.parent), " node")
+    end
+    print(io, "  children: ", childrenstring(node.children))
+    data = get(node)
+    if data != nothing
+        print(io, "\n  data: ", data)
+    end
+end
+
+function childrenstring(s::Set)
+    nmax = 3
+    if isempty(s)
+        return "<none>"
+    end
+    buf = IOBuffer()
+    i = 1
+    state = start(s)
+    while !done(s, state) && i <= nmax
+        item, state = next(s, state)
+        if i > 1
+            print(buf, ", ")
+        end
+        print(buf, eltype(item))
+        i += 1
+    end
+    if !done(s, state)
+        print(buf, ", ...")
+    end
+    takebuf_string(buf)
+end
+
+end

--- a/test/trees.jl
+++ b/test/trees.jl
@@ -1,0 +1,16 @@
+root = Trees.AryNode()
+@test Trees.isroot(root)
+@test eltype(root) == Nothing
+c1 = Trees.AryNode(root, 7.3)
+@test c1.parent == root
+@test contains(root.children, c1)
+c2 = Trees.AryNode(root, "cat")
+c3 = Trees.AryNode(root, 4//3)
+c4 = Trees.AryNode(root, [1 2;3 4])
+c21 = Trees.AryNode(c2, -3)
+@test contains(root.children, c2)
+@test !contains(root.children, c21)
+@test Trees.destroy!(c2) == "cat"
+@test Trees.isroot(c2)
+@test Trees.isroot(c21)
+@test !contains(root.children, c2)


### PR DESCRIPTION
Here's a beginning at a generic specification of a window-management/GUI interface. It is toolkit-agnostic (and consequently can't do very much), but it already attempts to provide some facilities that we currently lack. I'm posting it at this early phase because there's enough in place to be able to ask whether this is moving in the right direction, and it's a lot of work to go much further than this.

Most importantly, this organizes graphics objects into a tree, making it possible to query the list of windows, delete objects, etc. For example, currently we have no way (that I know of) of closing all opened windows in a session, short of quitting the session; this will fix that, among other things. In theory you should be able to use multiple toolkits simultaneously (e.g., Tk and Gtk) and everything will work automagically (whether that's wise is another matter...).

For Tk, something like this pull request this will allow us to resolve a currently-messy issue: the split between `TkWidget` and `Tk_Widget` etc (the various container types). We have two ways of creating windows, one of which can store elementary parent/child relationships and the other which cannot. Moreover, even if you create objects with the `Tk_Widget` type, traversing towards the root returns a `TkWidget`, which means that you've lost the type information (including information about the children in container-objects). Consequently, if you go up a level, you can't go back down again. Fixing such issues should, among other things, make it much easier to address https://github.com/JuliaLang/Tk.jl/issues/53.

I've gone to some effort to insulate the "toolkit implementer" from the details of tree traversal (and particularly, from having to maintain the organization of the tree). The basic design principle is that `GraphicsHandle`s are to be returned by all operations that create graphics objects, and these handles are simply nodes in a tree. However, they are _typed_ nodes, and consequently when used as arguments they will dispatch to the right functions.

None of this is "wired in" yet; you have to `include()`/`using` (which facilitates testing at this early stage). Here's a demo session:

```
julia> include("trees.jl")

julia> include("GUI.jl")

julia> include("/tmp/guitest.jl")

julia> using GUI, GUItest

julia> win = window("test window", 400, 200)
Window node:
  parent: root node
  children: <none>
  data: Window("test window",400,200)

julia> b = button(win, "Done", x->x)  # deliberate mistake, we want buttons in frames
ERROR: no method button(AryNode{Window},ASCIIString,Function)

julia> f = frame(win)
Placing at position 1, 1
Frame node:
  parent: Window node
  children: <none>
  data: Frame(RGB(0.85,0.85,0.85))

julia> b = button(f, "Done", x->x)
Placing at position 1, 1
Button node:
  parent: Frame node
  children: <none>
  data: Button("Done",# function)

julia> win
Window node:
  parent: root node
  children: Frame
  data: Window("test window",400,200)

julia> f
Frame node:
  parent: Window node
  children: Button
  data: Frame(RGB(0.85,0.85,0.85))

```

And here was my `guitest.jl`, which is basically what the "toolkit implementer" needs to write:

```
module GUItest

using Trees
using GUI
using Color

export # types
    Button,
    Frame,
    Window,
    # functions
    grid

type Window <: AbstractWindow
    title::String
    w::Int
    h::Int
end

width(win::Window) = win.w
height(win::Window) = win.h

type Frame <: AbstractFrame
    color::ColorValue
end
Frame(rgb::(Real,Real,Real)) = Frame(RGB(rgb[1],rgb[2],rgb[3]))

type Button <: AbstractButton
    msg::String
    callback::Function
end

grid(obj, col, row, justify) = println("Placing at position ", col, ", ", row)

end
```

You can see the generic wrapper releases the implementer from having to worry about any of the tree-hierarchy details.
