### PR TITLE
Add in `contrib/debug_bootstrap.gdb`

### DIFF
--- a/contrib/debug_bootstrap.gdb
+++ b/contrib/debug_bootstrap.gdb
@@ -1,0 +1,3 @@
+file ../usr/bin/julia-debug-basic
+r -bf sysimg.jl
+bt


### PR DESCRIPTION
This is a really simple `gdb` script to make it easier for others to report backtraces from bootstrap errors.  It goes hand-in-hand with the [debugging tips document](https://gist.github.com/staticfloat/6188418) I just wrote up.
