### PR TITLE
RFC: rm warning about type parameters shadowing identifiers

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -844,10 +844,6 @@ JL_CALLABLE(jl_f_typevar)
         JL_NARGS(typevar, 1, 1);
     }
     JL_TYPECHK(typevar, symbol, args[0]);
-    if (jl_boundp(jl_current_module, (jl_sym_t*)args[0]) &&
-        jl_is_type(jl_get_global(jl_current_module, (jl_sym_t*)args[0]))) {
-        jl_printf(JL_STDERR, "Warning: type parameter name %s shadows an identifier.\n", ((jl_sym_t*)args[0])->name);
-    }
     jl_value_t *lb = (jl_value_t*)jl_bottom_type;
     jl_value_t *ub = (jl_value_t*)jl_any_type;
     int b = 0;


### PR DESCRIPTION
As discussed in JuliaLang/IJulia.jl#37, this warning is analogous to giving a warning for defining `function f(x)` when there's a global called `x` (similar to gcc's `-Wshadow` option).  It doesn't make sense to have this warning (at least, not by default) for type parameters and not for other formal parameters.
