### PR TITLE
Add Pkg2.installed(pkg) method

### DIFF
--- a/base/pkg2.jl
+++ b/base/pkg2.jl
@@ -43,6 +43,8 @@ function installed()
     return pkgs
 end
 
+installed(pkg) = get(installed(),pkg,nothing)
+
 status(io::IO=STDOUT) = Dir.cd() do
     reqs = Reqs.parse("REQUIRE")
     instd = Read.installed()


### PR DESCRIPTION
As a follow-up to #4022, add this convenience method to test if a particular package is installed.

@StefanKarpinski 
