### PR TITLE
fix ? help for qualified names (e.g. Foo.bar)

### DIFF
--- a/base/help.jl
+++ b/base/help.jl
@@ -212,8 +212,13 @@ function help(x)
     end
 end
 
+# check whether an expression is a qualified name, e.g. Base.FFTW.FORWARD
+isname(n::Symbol) = true
+isname(ex::Expr) = ((ex.head == :. && isname(ex.args[1]) && isname(ex.args[2]))
+                    || (ex.head == :quote && isname(ex.args[1])))
+
 macro help(ex)
-    if !isa(ex, Expr)
+    if !isa(ex, Expr) || isname(ex)
         return Expr(:call, :help, esc(ex))
     elseif ex.head == :macrocall && length(ex.args) == 1
         # e.g., "julia> @help @printf"


### PR DESCRIPTION
This change fixes the `?` help (`Base.@help`) in the REPL (and IJulia) to work for qualified names, e.g `?Base.print` will now call `help(Base.print)` as you might expect.

cc: @loladiro
