### PR TITLE
Added methods to make MethodTable iterable

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -96,6 +96,11 @@ function length(mt::MethodTable)
     n
 end
 
+start(mt::MethodTable) = mt.defs
+next(mt::MethodTable, m::Method) = (m,m.next)
+done(mt::MethodTable, m::Method) = false
+done(mt::MethodTable, i::()) = true
+
 uncompressed_ast(l::LambdaStaticData) =
     isa(l.ast,Expr) ? l.ast : ccall(:jl_uncompress_ast, Any, (Any,Any), l, l.ast)
 


### PR DESCRIPTION
It would be easier to work with `MethodTable`s if you could write a for loop over them. This adds the 4 needed API functions to make that work.

For example, you can now:

```
for m in (+).env
    println(m)
end
```
