### PR TITLE
RFC: use pairwise summation for sum, cumsum, and cumprod

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -315,6 +315,7 @@ let es = sum_kbn(z), es2 = sum_kbn(z[1:10^5])
     @test (es - cs[end]) < es * 1e-13
     @test (es2 - cs[10^5]) < es2 * 1e-13
 end
+@test sum(sin(z)) == sum(sin, z)
 
 ## large matrices transpose ##
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -308,6 +308,14 @@ v[2,2,1,1] = 40.0
 
 @test isequal(v,sum(z,(3,4)))
 
+z = rand(10^6)
+let es = sum_kbn(z), es2 = sum_kbn(z[1:10^5])
+    @test (es - sum(z)) < es * 1e-13
+    cs = cumsum(z)
+    @test (es - cs[end]) < es * 1e-13
+    @test (es2 - cs[10^5]) < es2 * 1e-13
+end
+
 ## large matrices transpose ##
 
 for i = 1 : 3

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -32,6 +32,10 @@
 @test all(hist([1:100]/100,0.0:0.01:1.0)[2] .==1)
 @test hist([1,1,1,1,1])[2][1] == 5
 
+A = Complex128[exp(i*im) for i in 1:10^4]
+@test_approx_eq varm(A,0.) sum(map(abs2,A))/(length(A)-1)
+@test_approx_eq varm(A,mean(A)) var(A,1)
+
 @test midpoints(1.0:1.0:10.0) == 1.5:1.0:9.5
 @test midpoints(1:10) == 1.5:9.5
 @test midpoints(Float64[1.0:1.0:10.0]) == Float64[1.5:1.0:9.5]


### PR DESCRIPTION
This patch modifies the `sum` and `cumsum` functions (and `cumprod`) to use [pairwise summation](http://en.wikipedia.org/wiki/Pairwise_summation) for summing `AbstractArray`s, in order to achieve much better accuracy at a negligible computational cost.

Pairwise summation recursively divides the array in half, sums the halves recursively, and then adds the two sums.  As long as the base case is large enough (here, n=128 seemed to suffice), the overhead of the recursion is negligible compared to naive summation (a simple loop).  The advantage of this algorithm is that it achieves O(sqrt(log n)) mean error growth, versus O(sqrt(n)) for naive summation, which is almost indistinguishable from the O(1) error growth of Kahan compensated summation. 

For example:

```
A = rand(10^8)
es = sum_kbn(A)
(oldsum(A) - es)/es, (newsum(A) - es)/es
```

where `oldsum` and `newsum` are the old and new implementations, respectively, gives `(-1.2233732622777777e-13,0.0)` on my machine in a typical run: the old `sum` loses three significant digits, whereas the new `sum` loses none.  On the other hand, their execution time is nearly identical:

```
@time oldsum(A);
@time newsum(A);
```

gives

```
elapsed time: 0.116988841 seconds (105816 bytes allocated)
elapsed time: 0.110502884 seconds (64 bytes allocated)
```

(The difference is within the noise.)

@JeffBezanson and @StefanKarpinski, I think I mentioned this possibility to you at Berkeley.
