### PR TITLE
Replace b = a*a with A_mul_B(b, a, a) in BLAS level3 perf test.

### DIFF
--- a/test/perf/blas/level3.jl
+++ b/test/perf/blas/level3.jl
@@ -4,7 +4,7 @@ function matmultest(n, repeat)
 	a = rand(n,n)
 	b = similar(a)
 	for ct=1:repeat
-		b = a * a
+		A_mul_B(b, a, a)
 	end
 	b
 end


### PR DESCRIPTION
As discussed on julia-dev, the prior version is largely a GC test, since it
allocates memory for the result on each iteration. This version more directly
tests the BLAS library.
