### PR TITLE
accurate sind, cosd functions

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -41,13 +41,19 @@ cosc(x::Integer) = cosc(float(x))
 cosc{T<:Integer}(x::Complex{T}) = cosc(complex(float(real(x)),float(imag(x))))
 @vectorize_1arg Number cosc
 
-radians2degrees(z::Real) = oftype(z, (180/pi) * z)
-degrees2radians(z::Real) = oftype(z, (pi/180) * z)
-radians2degrees(z::Integer) = oftype(float(z), (180/pi) * z)
-degrees2radians(z::Integer) = oftype(float(z), (pi/180) * z)
+const pideg1 = 0.017453292501159012 # pi/180 truncated to 29 significant bits
+const pideg2 = 1.8784283451579438e-11 # pi/180 - pideg1
+const degpi1 = 57.29577946662903 # 180/pi to 29 significant bits
+const degpi2 = 4.645329255648566e-8 # 180/pi - degpi2
+
+radians2degrees(z::Real) = oftype(z, degpi1*z + degpi2*z)
+degrees2radians(z::Real) = oftype(z, pideg1*z + pideg2*z)
+radians2degrees(z::Integer) = radians2degrees(float(z))
+degrees2radians(z::Integer) = degrees2radians(float(z))
 
 for (finv, f) in ((:sec, :cos), (:csc, :sin), (:cot, :tan),
-                  (:sech, :cosh), (:csch, :sinh), (:coth, :tanh))
+                  (:sech, :cosh), (:csch, :sinh), (:coth, :tanh),
+                  (:secd, :cosd), (:cscd, :sind), (:cotd, :tand))
     @eval begin
         ($finv)(z) = 1 ./ (($f)(z))
     end
@@ -60,8 +66,68 @@ for (fa, fainv) in ((:asec, :acos), (:acsc, :asin), (:acot, :atan),
     end
 end
 
-for (fd, f) in ((:sind, :sin), (:cosd, :cos), (:tand, :tan),
-                (:secd, :sec), (:cscd, :csc), (:cotd, :cot))
+function sind(x::Real)
+    if isinf(x)
+        return throw(DomainError())
+    elseif isnan(x)
+        return nan(x)
+    end
+
+    rx = rem(x,360.0)
+    arx = abs(rx)
+
+    if arx == 0.0
+        # return -0.0 iff x == -0.0
+        return x == 0.0 ? x : arx
+    elseif arx < 45.0
+        return sin(degrees2radians(rx))
+    elseif arx <= 135.0
+        arx = 90.0 - arx
+        return copysign(cos(degrees2radians(arx)),rx)
+    elseif arx < 225.0
+        rx = copysign(180.0,rx) - rx
+        return sin(degrees2radians(rx))
+    elseif arx <= 315.0
+        arx = 270.0 - arx
+        return -copysign(cos(degrees2radians(arx)),rx)
+    else
+        rx = rx - copysign(360.0,rx)
+        return sin(degrees2radians(rx))
+    end
+end
+
+function cosd(x::Real)
+    if isinf(x)
+        return throw(DomainError())
+    elseif isnan(x)
+        return nan(x)
+    end
+
+    rx = abs(rem(x,360.0))
+
+    if rx <= 45.0
+        return cos(degrees2radians(rx))
+    elseif rx < 135.0
+        rx = 90.0 - rx
+        return sin(degrees2radians(rx))
+    elseif rx <= 225.0
+        rx = 180.0 - rx
+        return -cos(degrees2radians(rx))
+    elseif rx < 315.0
+        rx = rx - 270.0
+        return sin(degrees2radians(rx))
+    else
+        rx = 360.0 - rx
+        return cos(degrees2radians(rx))
+    end
+end
+
+tand(x::Real) = sind(x) / cosd(x)
+
+
+
+
+for (fd, f) in ((:sind, :sin), (:cosd, :cos), (:tand, :tan))
     @eval begin
         ($fd)(z) = ($f)(degrees2radians(z))
     end

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -10,15 +10,16 @@ export
     with_bigfloat_rounding
 
 import
-    Base: (*), +, -, /, <, <=, ==, >, >=, ^, besselj, besselj0, besselj1,
-        bessely, bessely0, bessely1, ceil, cmp, convert, copysign, exp, exp2,
-        exponent, factorial, floor, hypot, isinteger, iround, isfinite,
-        isinf, isnan, ldexp, log, log2, log10, max, min, mod, modf, nextfloat,
-        prevfloat, promote_rule, rem, round, show, showcompact, sum, sqrt,
-        string, trunc, get_precision, exp10, expm1, gamma, lgamma, digamma,
-        erf, erfc, zeta, log1p, airyai, iceil, ifloor, itrunc, eps, signbit,
-        sin, cos, tan, sec, csc, cot, acos, asin, atan, cosh, sinh, tanh,
-        sech, csch, coth, acosh, asinh, atanh, atan2, serialize, deserialize
+    Base: (*), +, -, /, <, <=, ==, >, >=, ^, besselj, besselj0, besselj1, bessely,
+        bessely0, bessely1, ceil, cmp, convert, copysign, degrees2radians,
+        exp, exp2, exponent, factorial, floor, hypot, isinteger, iround,
+        isfinite, isinf, isnan, ldexp, log, log2, log10, max, min, mod, modf,
+        nextfloat, prevfloat, promote_rule, radians2degrees, rem, round, show,
+        showcompact, sum, sqrt, string, trunc, get_precision, exp10, expm1,
+        gamma, lgamma, digamma, erf, erfc, zeta, log1p, airyai, iceil, ifloor,
+        itrunc, eps, signbit, sin, cos, tan, sec, csc, cot, acos, asin, atan,
+        cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, atan2,
+        serialize, deserialize
 
 const ROUNDING_MODE = [0]
 const DEFAULT_PRECISION = [256]
@@ -377,6 +378,10 @@ function sqrt(x::BigFloat)
 end
 
 sqrt(x::BigInt) = sqrt(BigFloat(x))
+
+radians2degrees(z::BigFloat) = 180/big(pi)*z
+degrees2radians(z::BigFloat) = big(pi)/180*z
+
 
 function ^(x::BigFloat, y::Unsigned)
     z = BigFloat()

--- a/test/math.jl
+++ b/test/math.jl
@@ -4,6 +4,12 @@
 @test significand(12.8) == 1.6
 @test exponent(12.8) == 3
 
+# degree-based trig functions
+for x = -400:40:400
+    @test_approx_eq_eps sind(x) sin(pi/180*x) eps(pi/180*x)
+    @test_approx_eq_eps cosd(x) cos(pi/180*x) eps(pi/180*x)
+end
+
 # error functions
 @test_approx_eq erf(1) 0.84270079294971486934
 @test_approx_eq erfc(1) 0.15729920705028513066


### PR DESCRIPTION
This improves the accuracy of `sind` and `cosd` for `Real` types by using range reduction and splitting the multiplication by `pi/180` into two terms. As a result, we now have `sind(30) == 0.5` and `sind(180) == 0.0`.
- For `BigFloat`s, only range reduction is used, so `sind(big(30))` is still (slightly) off. I don't know enough about MPFR, but it might be possible to use the split multiplication approach here as well.
- `tand(x)` is defined as `sind(x)/cosd(x)`: this gives the correct result for `tand(45)`, and rounds correctly for `tand(60)`. It also means that `tand(90) == Inf` and `tand(270) == -Inf`: I'm not sure what the correct answer is here, but these happen to be what matlab returns. It also means that `tand(180) = -0.0`, which is less important, but again, may not be "correct".
- Unfortunately, the same trick doesn't work as well for inverse functions, so we still get `asind(0.5) == 30.000000000000004`.
- The same tricks could also be used to improve `sinc`, via a `sinpi` function: however as the issue here is really only integer values, we could also just define it to be:

``` julia
sinc(x::Number) = x==0 ? one(x)  : (isinteger(x) ? zero(x) : (pix=pi*x; oftype(x,sin(pix)/pix)))
```
