### PR TITLE
Fix `using X` when X.jl is in working directory

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -13,6 +13,7 @@ function find_in_path(name::String)
         base = name[1:end-3]
     else
         name = string(base,".jl")
+        isfile(name) && return abspath(name)
     end
     for prefix in [Pkg.dir(), LOAD_PATH]
         path = joinpath(prefix, name)


### PR DESCRIPTION
I think this is a bug, since the commit message for 6afe305e245cdd685fea6e0263a94156a2c15368 doesn't indicate that this was supposed to change.

This is probably also necessary to fix `require("X")` in the same situation.
