### PR TITLE
make character predicates (isspace etc) work for strings arguments too

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -348,9 +348,11 @@ for name = ("alnum", "alpha", "cntrl", "digit", "graph",
             "lower", "print", "punct", "space", "upper")
     f = symbol(string("is",name))
     @eval ($f)(c::Char) = bool(ccall($(string("isw",name)), Int32, (Cwchar_t,), c))
+    @eval $f(s::String) = all($f, s)
 end
 
 isblank(c::Char) = c==' ' || c=='\t'
+isblank(s::String) = all(isblank, s)
 
 ## generic string uses only endof and next ##
 
@@ -613,6 +615,7 @@ escape_nul(s::String, i::Int) =
     !done(s,i) && '0' <= next(s,i)[1] <= '7' ? "\\x00" : "\\0"
 
 isxdigit(c::Char) = '0'<=c<='9' || 'a'<=c<='f' || 'A'<=c<='F'
+isxdigit(s::String) = all(isxdigit, s)
 need_full_hex(s::String, i::Int) = !done(s,i) && isxdigit(next(s,i)[1])
 
 function print_escaped(io, s::String, esc::String)

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -1392,82 +1392,94 @@
 
 "),
 
-("Strings","Base","isalnum","isalnum(c::Char)
+("Strings","Base","isalnum","isalnum(c::Union(Char,String))
 
-   Tests whether a character is alphanumeric.
-
-"),
-
-("Strings","Base","isalpha","isalpha(c::Char)
-
-   Tests whether a character is alphabetic.
+   Tests whether a character is alphanumeric, or whether this
+   is true for all elements of a string.
 
 "),
 
-("Strings","Base","isascii","isascii(c::Char)
+("Strings","Base","isalpha","isalpha(c::Union(Char,String))
 
-   Tests whether a character belongs to the ASCII character set.
-
-"),
-
-("Strings","Base","isblank","isblank(c::Char)
-
-   Tests whether a character is a tab or space.
+   Tests whether a character is alphabetic, or whether this
+   is true for all elements of a string.
 
 "),
 
-("Strings","Base","iscntrl","iscntrl(c::Char)
+("Strings","Base","isascii","isascii(c::Union(Char,String))
 
-   Tests whether a character is a control character.
-
-"),
-
-("Strings","Base","isdigit","isdigit(c::Char)
-
-   Tests whether a character is a numeric digit (0-9).
+   Tests whether a character belongs to the ASCII character set, or whether this
+   is true for all elements of a string.
 
 "),
 
-("Strings","Base","isgraph","isgraph(c::Char)
+("Strings","Base","isblank","isblank(c::Union(Char,String))
 
-   Tests whether a character is printable, and not a space.
-
-"),
-
-("Strings","Base","islower","islower(c::Char)
-
-   Tests whether a character is a lowercase letter.
+   Tests whether a character is a tab or space, or whether this
+   is true for all elements of a string.
 
 "),
 
-("Strings","Base","isprint","isprint(c::Char)
+("Strings","Base","iscntrl","iscntrl(c::Union(Char,String))
 
-   Tests whether a character is printable, including space.
+   Tests whether a character is a control character, or whether this
+   is true for all elements of a string.
 
 "),
 
-("Strings","Base","ispunct","ispunct(c::Char)
+("Strings","Base","isdigit","isdigit(c::Union(Char,String))
+
+   Tests whether a character is a numeric digit (0-9), or whether this
+   is true for all elements of a string.
+
+"),
+
+("Strings","Base","isgraph","isgraph(c::Union(Char,String))
+
+   Tests whether a character is printable, and not a space, or whether this
+   is true for all elements of a string.
+
+"),
+
+("Strings","Base","islower","islower(c::Union(Char,String))
+
+   Tests whether a character is a lowercase letter, or whether this
+   is true for all elements of a string.
+
+"),
+
+("Strings","Base","isprint","isprint(c::Union(Char,String))
+
+   Tests whether a character is printable, including space, or whether this
+   is true for all elements of a string.
+
+"),
+
+("Strings","Base","ispunct","ispunct(c::Union(Char,String))
 
    Tests whether a character is printable, and not a space or
-   alphanumeric.
+   alphanumeric, or whether this is true for all elements of a string.
 
 "),
 
-("Strings","Base","isspace","isspace(c::Char)
+("Strings","Base","isspace","isspace(c::Union(Char,String))
 
-   Tests whether a character is any whitespace character.
-
-"),
-
-("Strings","Base","isupper","isupper(c::Char)
-
-   Tests whether a character is an uppercase letter.
+   Tests whether a character is any whitespace character, or whether this
+   is true for all elements of a string.
 
 "),
 
-("Strings","Base","isxdigit","isxdigit(c::Char)
+("Strings","Base","isupper","isupper(c::Union(Char,String))
 
-   Tests whether a character is a valid hexadecimal digit.
+   Tests whether a character is an uppercase letter, or whether this
+   is true for all elements of a string.
+
+"),
+
+("Strings","Base","isxdigit","isxdigit(c::Union(Char,String))
+
+   Tests whether a character is a valid hexadecimal digit, or whether this
+   is true for all elements of a string.
 
 "),
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -934,57 +934,70 @@ Strings
 
    Gives the number of columns needed to print a string.
 
-.. function:: isalnum(c::Char)
+.. function:: isalnum(c::Union(Char,String))
 
-   Tests whether a character is alphanumeric.
+   Tests whether a character is alphanumeric, or whether this
+   is true for all elements of a string.
 
-.. function:: isalpha(c::Char)
+.. function:: isalpha(c::Union(Char,String))
 
-   Tests whether a character is alphabetic.
+   Tests whether a character is alphabetic, or whether this
+   is true for all elements of a string.
 
-.. function:: isascii(c::Char)
+.. function:: isascii(c::Union(Char,String))
 
-   Tests whether a character belongs to the ASCII character set.
+   Tests whether a character belongs to the ASCII character set, or whether this
+   is true for all elements of a string.
 
-.. function:: isblank(c::Char)
+.. function:: isblank(c::Union(Char,String))
 
-   Tests whether a character is a tab or space.
+   Tests whether a character is a tab or space, or whether this
+   is true for all elements of a string.
 
-.. function:: iscntrl(c::Char)
+.. function:: iscntrl(c::Union(Char,String))
 
-   Tests whether a character is a control character.
+   Tests whether a character is a control character, or whether this
+   is true for all elements of a string.
 
-.. function:: isdigit(c::Char)
+.. function:: isdigit(c::Union(Char,String))
 
-   Tests whether a character is a numeric digit (0-9).
+   Tests whether a character is a numeric digit (0-9), or whether this
+   is true for all elements of a string.
 
-.. function:: isgraph(c::Char)
+.. function:: isgraph(c::Union(Char,String))
 
-   Tests whether a character is printable, and not a space.
+   Tests whether a character is printable, and not a space, or whether this
+   is true for all elements of a string.
 
-.. function:: islower(c::Char)
+.. function:: islower(c::Union(Char,String))
 
-   Tests whether a character is a lowercase letter.
+   Tests whether a character is a lowercase letter, or whether this
+   is true for all elements of a string.
 
-.. function:: isprint(c::Char)
+.. function:: isprint(c::Union(Char,String))
 
-   Tests whether a character is printable, including space.
+   Tests whether a character is printable, including space, or whether this
+   is true for all elements of a string.
 
-.. function:: ispunct(c::Char)
+.. function:: ispunct(c::Union(Char,String))
 
-   Tests whether a character is printable, and not a space or alphanumeric.
+   Tests whether a character is printable, and not a space or
+   alphanumeric, or whether this is true for all elements of a string.
 
-.. function:: isspace(c::Char)
+.. function:: isspace(c::Union(Char,String))
 
-   Tests whether a character is any whitespace character.
+   Tests whether a character is any whitespace character, or whether this
+   is true for all elements of a string.
 
-.. function:: isupper(c::Char)
+.. function:: isupper(c::Union(Char,String))
 
-   Tests whether a character is an uppercase letter.
+   Tests whether a character is an uppercase letter, or whether this
+   is true for all elements of a string.
 
-.. function:: isxdigit(c::Char)
+.. function:: isxdigit(c::Union(Char,String))
 
-   Tests whether a character is a valid hexadecimal digit.
+   Tests whether a character is a valid hexadecimal digit, or whether this
+   is true for all elements of a string.
 
 .. function:: symbol(str)
 


### PR DESCRIPTION
This adds the simple convenience that functions like `isspace` or `isalpha` can work for string arguments as well as for individual characters (returning `true` for a string if the predicate is true for all characters in the string).
