### PR TITLE
revert to multiplication for radian-degree conversion

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -41,13 +41,8 @@ cosc(x::Integer) = cosc(float(x))
 cosc{T<:Integer}(x::Complex{T}) = cosc(complex(float(real(x)),float(imag(x))))
 @vectorize_1arg Number cosc
 
-const pideg1 = 0.017453292501159012 # pi/180 truncated to 29 significant bits
-const pideg2 = 1.8784283451579438e-11 # pi/180 - pideg1
-const degpi1 = 57.29577946662903 # 180/pi to 29 significant bits
-const degpi2 = 4.645329255648566e-8 # 180/pi - degpi1
-
-radians2degrees(z::Real) = oftype(z, degpi1*z + degpi2*z)
-degrees2radians(z::Real) = oftype(z, pideg1*z + pideg2*z)
+radians2degrees(z::Real) = oftype(z, 57.29577951308232*z)
+degrees2radians(z::Real) = oftype(z, 0.017453292519943295*z)
 radians2degrees(z::Integer) = radians2degrees(float(z))
 degrees2radians(z::Integer) = degrees2radians(float(z))
 


### PR DESCRIPTION
I tried to be a bit too clever (or not clever enough) in 4a5161dc4788af70354f5f92257c5e39bdd5ef0a by splitting the multiplication when converting between radians and degrees: although this method is correct for 30 degrees, on average it actually gives worse rounding:

```
julia> X = rand(1000);

julia> sum(abs(Float64[degrees2radians(i) - float64((big(pi)/180)*i) for i = X]))
3.2187421402252864e-16

julia> sum(abs(Float64[(pi/180)*i - float64((big(pi)/180)*i) for i = X]))
1.6530017372257122e-16
```

This commit reverts to using ordinary multiplication (and so `sind(30) == 0.49999999999999994`).

It is possible to do multiplication by irrational numbers with correct rounding, based on splitting the floats into half-precision (see [Dekker (1971)](http://link.springer.com/article/10.1007%2FBF01397083) for details of half-precision methods), but these methods require more computations. For example:

``` julia
dpb = big(pi)/180
dp  = float64(dpb)
dph = signif(dp,26,2)
dpt = float64(dpb-dph)

# based on Veltkamp (1968), see Dekker (1971), p. 234
function degrees2radians(x)
    xh = signif(x,26,2)
    xt = x - xh
    z = x*dp
    z + ((((xh*dph - z) + xh*dpt) + xt*dph) + xt*dpt)
end
```

This approach could be used for any non-float-representable number, however it requires 11 floating point operations (plus a truncation), so is probably not worth it just to get the final digit correct.
