### PR TITLE
Unexport bind/TcpSocket

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -101,7 +101,6 @@ export
     SVD,
     Symmetric,
     SymTridiagonal,
-    TcpSocket,
     Timer,
     TimSort,
     TmStruct,
@@ -1020,7 +1019,6 @@ export
 
 # I/O and events
     accept,
-    bind,
     close,
     connect,
     countlines,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1382,15 +1382,6 @@ Network I/O
    Accepts a connection on the given server and returns a connection to the client. An uninitialized client 
    stream may be provided, in which case it will be used instead of creating a new stream.
 
-.. function:: bind(server[,addr...])
-
-   Binds a server to the given address (which may be any of the arguments accepted by listen).
-   Note that you must still call listen to be able to accept connections on this server.
-
-.. function:: listen(sever) -> PipeServer
-
-   Starts listening on a server that has been previously bound to an address by ``bind``.
-
 .. function:: open_any_tcp_port(hint) -> (Uint16,TcpServer)
 
    Create a TcpServer on any port, using hint as a starting point. Returns a tuple of the actual port that the server

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -37,20 +37,6 @@ end
 wait(c)
 @test readall(connect(2134)) == "Hello World\n"
 
-c = Base.Condition()
-@async begin
-	server = Base.TcpServer()
-	bind(server,IPv4(0),2135)
-	listen(server)
-	Base.notify(c)
-	sock = accept(server)
-	write(sock,"Hello World\n")
-	close(server)
-	close(sock)
-end
-wait(c)
-@test readall(connect(2135)) == "Hello World\n"
-
 isfile("testsocket") && Base.FS.unlink("testsocket")
 @async begin
 	s = listen("testsocket")


### PR DESCRIPTION
This unexports bind and TcpServer. I discussed this with @JeffBezanson and we came to the conclusion that we don't really see a use case for this. If we want to support a bind/connect workflow that is best done with an option to the connect method than forcing everybody in the common case to use bind.

One problem this brings up is that you can't declare a member of your your type to be a TcpSocket anymore, but we feel that you shouldn't rely on the fact that you get a `TcpSocket` anyway in light of the fact that this will definitely change as part of #3887, as well as if you change the transport by, say, introducing a TLS layer.

Anyway, if you have any strong opinions to the contrary, do bring them up. Otherwise I will merge this in a couple of days. 
