### PR TITLE
RFC: Bikeshed: rename subtype to issubtype

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -138,7 +138,7 @@ export
     setfield, yieldto, throw, tuple, tuplelen, tupleref, is, ===, isdefined,
     convert_default, convert_tuple, kwcall,
     # type reflection
-    subtype, typeassert, typeof, apply_type, isa,
+    issubtype, typeassert, typeof, apply_type, isa,
     # method reflection
     applicable, invoke, method_exists,
     # constants

--- a/base/darray.jl
+++ b/base/darray.jl
@@ -164,7 +164,7 @@ end
 function convert{S,T,N}(::Type{Array{S,N}}, s::SubDArray{T,N})
     I = s.indexes
     d = s.parent
-    if isa(I,(Range1{Int}...)) && subtype(S,T) && subtype(T,S)
+    if isa(I,(Range1{Int}...)) && issubtype(S,T) && issubtype(T,S)
         l = locate(d, map(first, I)...)
         if isequal(d.indexes[l...], I)
             # SubDArray corresponds to a chunk

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -118,6 +118,7 @@ export PipeString
 @deprecate eatwspace(io)  skipchars(io, isspace)
 @deprecate eatwspace_comment(io, cmt)  skipchars(io, isspace, linecomment=cmt)
 @deprecate open_any_tcp_port listenany
+@deprecate  subtype             issubtype
 
 deprecated_ls() = run(`ls -l`)
 deprecated_ls(args::Cmd) = run(`ls -l $args`)

--- a/base/int.jl
+++ b/base/int.jl
@@ -258,7 +258,7 @@ for to in _inttypes, from in _inttypes
         if to.size < from.size
             @eval convert(::Type{$to}, x::($from)) = box($to,trunc_int($to,unbox($from,x)))
         elseif from.size < to.size || from===Bool
-            if subtype(from, Signed)
+            if issubtype(from, Signed)
                 @eval convert(::Type{$to}, x::($from)) = box($to,sext_int($to,unbox($from,x)))
             else
                 @eval convert(::Type{$to}, x::($from)) = box($to,zext_int($to,unbox($from,x)))

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1,6 +1,6 @@
 ## types ##
 
-const (<:) = subtype
+const (<:) = issubtype
 
 super(T::DataType) = T.super
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -39,7 +39,7 @@ isbits(x) = isbits(typeof(x))
 isleaftype(t::ANY) = ccall(:jl_is_leaf_type, Int32, (Any,), t) != 0
 
 typeintersect(a::ANY,b::ANY) = ccall(:jl_type_intersection, Any, (Any,Any), a, b)
-typeseq(a::ANY,b::ANY) = subtype(a,b)&&subtype(b,a)
+typeseq(a::ANY,b::ANY) = issubtype(a,b) && issubtype(b,a)
 
 function fieldoffsets(x::DataType)
     offsets = Array(Int, length(x.names))

--- a/base/set.jl
+++ b/base/set.jl
@@ -44,8 +44,8 @@ function union(s::Set, sets::Set...)
     if U != Any
         for t in sets
             T = eltype(t)
-            U = subtype(T,U) ? U :
-                subtype(U,T) ? T : Any # TODO: tigher upper bound
+            U = issubtype(T,U) ? U :
+                issubtype(U,T) ? T : Any # TODO: tigher upper bound
         end
     end
     u = Set{U}()

--- a/contrib/julia.lang
+++ b/contrib/julia.lang
@@ -200,7 +200,7 @@
     <context id="builtin-function" style-ref="builtin-function">
       <keyword>is</keyword>
       <keyword>typeof</keyword>
-      <keyword>subtype</keyword>
+      <keyword>issubtype</keyword>
       <keyword>isa</keyword>
       <keyword>typeassert</keyword>
       <keyword>apply</keyword>

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -180,13 +180,13 @@ Types
 
    Return the supertype of DataType T
 
-.. function:: subtype(type1, type2)
+.. function:: issubtype(type1, type2)
 
    True if and only if all values of ``type1`` are also of ``type2``. Can also be written using the ``<:`` infix operator as ``type1 <: type2``.
 
 .. function:: <:(T1, T2)
 
-   Subtype operator, equivalent to ``subtype(T1,T2)``.
+   Subtype operator, equivalent to ``issubtype(T1,T2)``.
 
 .. function:: subtypes(T::DataType)
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1021,7 +1021,7 @@ void jl_init_primitives(void)
 {
     add_builtin_func("is", jl_f_is);
     add_builtin_func("typeof", jl_f_typeof);
-    add_builtin_func("subtype", jl_f_subtype);
+    add_builtin_func("issubtype", jl_f_subtype);
     add_builtin_func("isa", jl_f_isa);
     add_builtin_func("typeassert", jl_f_typeassert);
     add_builtin_func("apply", jl_f_apply);

--- a/test/core.jl
+++ b/test/core.jl
@@ -17,20 +17,20 @@
 @test !(Array{Int8,1} <: Array{Any,1})
 @test !(Array{Any,1} <: Array{Int8,1})
 @test Array{Int8,1} <: Array{Int8,1}
-@test !subtype(Type{None}, Type{Int32})
-@test !subtype(Vector{Float64},Vector{Union(Float64,Float32)})
+@test !issubtype(Type{None}, Type{Int32})
+@test !issubtype(Vector{Float64},Vector{Union(Float64,Float32)})
 @test is(None, typeintersect(Vector{Float64},Vector{Union(Float64,Float32)}))
 
 @test !isa(Array,Type{Any})
-@test subtype(Type{Complex},DataType)
+@test issubtype(Type{Complex},DataType)
 @test isa(Complex,Type{Complex})
-@test !subtype(Type{Ptr{None}},Type{Ptr})
-@test !subtype(Type{Rational{Int}}, Type{Rational})
+@test !issubtype(Type{Ptr{None}},Type{Ptr})
+@test !issubtype(Type{Rational{Int}}, Type{Rational})
 let T = TypeVar(:T,true)
     @test !is(None, typeintersect(Array{None},AbstractArray{T}))
     @test  is(None, typeintersect((Type{Ptr{Uint8}},Ptr{None}),
                                   (Type{Ptr{T}},Ptr{T})))
-    @test !subtype(Type{T},TypeVar)
+    @test !issubtype(Type{T},TypeVar)
 
     @test isequal(typeintersect((Range{Int},(Int,Int)),(AbstractArray{T},Dims)),
                   (Range{Int},(Int,Int)))
@@ -67,11 +67,11 @@ let N = TypeVar(:N,true)
 end
 @test is(None, typeintersect(Type{Any},Type{Complex}))
 @test is(None, typeintersect(Type{Any},Type{TypeVar(:T,Real)}))
-@test !subtype(Type{Array{Integer}},Type{AbstractArray{Integer}})
-@test !subtype(Type{Array{Integer}},Type{Array{TypeVar(:T,Integer)}})
+@test !issubtype(Type{Array{Integer}},Type{AbstractArray{Integer}})
+@test !issubtype(Type{Array{Integer}},Type{Array{TypeVar(:T,Integer)}})
 @test is(None, typeintersect(Type{Function},UnionType))
 @test is(Type{Int32}, typeintersect(Type{Int32},DataType))
-@test !subtype(Type,TypeVar)
+@test !issubtype(Type,TypeVar)
 @test !is(None, typeintersect(DataType, Type))
 @test !is(None, typeintersect(UnionType, Type))
 @test !is(None, typeintersect(DataType, Type{Int}))
@@ -80,22 +80,22 @@ end
 
 @test isa(Int,Type{TypeVar(:T,Number)})
 @test !isa(DataType,Type{TypeVar(:T,Number)})
-@test subtype(DataType,Type{TypeVar(:T,Type)})
+@test issubtype(DataType,Type{TypeVar(:T,Type)})
 
 @test isa((),Type{()})
-@test subtype((DataType,),Type{TypeVar(:T,Tuple)})
-@test !subtype((Int,),Type{TypeVar(:T,Tuple)})
+@test issubtype((DataType,),Type{TypeVar(:T,Tuple)})
+@test !issubtype((Int,),Type{TypeVar(:T,Tuple)})
 @test isa((Int,),Type{TypeVar(:T,Tuple)})
 
 @test !isa(Type{(Int,Int)},Tuple)
-@test subtype(Type{(Int,Int)},Tuple)
-@test subtype(Type{(Int,)}, (DataType,))
+@test issubtype(Type{(Int,Int)},Tuple)
+@test issubtype(Type{(Int,)}, (DataType,))
 
 # this is fancy: know that any type T<:Number must be either a DataType or a UnionType
-@test subtype(Type{TypeVar(:T,Number)},Union(DataType,UnionType))
-@test !subtype(Type{TypeVar(:T,Number)},DataType)
-@test subtype(Type{TypeVar(:T,Tuple)},Union(Tuple,UnionType))
-@test !subtype(Type{TypeVar(:T,Tuple)},Union(DataType,UnionType))
+@test issubtype(Type{TypeVar(:T,Number)},Union(DataType,UnionType))
+@test !issubtype(Type{TypeVar(:T,Number)},DataType)
+@test issubtype(Type{TypeVar(:T,Tuple)},Union(Tuple,UnionType))
+@test !issubtype(Type{TypeVar(:T,Tuple)},Union(DataType,UnionType))
 
 @test !is(None, typeintersect((DataType,DataType),Type{TypeVar(:T,(Number,Number))}))
 @test !is(None, typeintersect((DataType,UnionType),Type{(Number,None)}))
@@ -140,14 +140,14 @@ nttest1{n}(x::NTuple{n,Int}) = n
 abstract Sup_{A,B}
 abstract Qux_{T} <: Sup_{Qux_{Int},T}
 
-@test subtype(Qux_{Int}.super, Sup_)
+@test issubtype(Qux_{Int}.super, Sup_)
 @test is(Qux_{Int}, Qux_{Int}.super.parameters[1])
 @test is(Qux_{Int}.super.parameters[2], Int)
-@test subtype(Qux_{Char}.super, Sup_)
+@test issubtype(Qux_{Char}.super, Sup_)
 @test is(Qux_{Int}, Qux_{Char}.super.parameters[1])
 @test is(Qux_{Char}.super.parameters[2], Char)
 
-@test subtype(Qux_.super.parameters[1].super, Sup_)
+@test issubtype(Qux_.super.parameters[1].super, Sup_)
 @test is(Qux_{Int}, Qux_.super.parameters[1].super.parameters[1])
 @test is(Int, Qux_.super.parameters[1].super.parameters[2])
 


### PR DESCRIPTION
Not really necessary, but it does bring this in line with the `isa` boolean functions.

I didn't touch this in `/src` other than to rename the intrinsic.
