### PR TITLE
allow readbytes() on Cmd type

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -389,6 +389,16 @@ function readandwrite(cmds::AbstractCmd)
     return (out, in, processes)
 end
 
+readbytes(cmd::AbstractCmd) = readbytes(cmd, DevNull)
+function readbytes(cmd::AbstractCmd,stdin::AsyncStream)
+    (out,pc) = readsfrom(cmd, stdin)
+    if !success(pc)
+        pipeline_error(pc)
+    end
+    wait_close(out)
+    return takebuf_array(out.buffer)
+end
+
 readall(cmd::AbstractCmd) = readall(cmd, DevNull)
 function readall(cmd::AbstractCmd,stdin::AsyncStream)
     (out,pc) = readsfrom(cmd, stdin)


### PR DESCRIPTION
This allows bytes to be read from a command's stdout.

Before this, I had to pipe output though something like `od` and process the text into an array, or redirect to a file.

readall() will fail (it might not if you have a few bytes):

```
julia> readall(`dd if=/dev/urandom bs=10 count=1`)
1+0 records in
1+0 records out
10 bytes transferred in 0.000039 secs (257319 bytes/sec)
"�ا�绖Error showing value of type UTF8String:
ERROR: invalid UTF-8 character index
 in getindex at utf8.jl:63
 in print_escaped at string.jl:622
 in print_quoted at string.jl:639
 in writemime at repl.jl:2
 in display at multimedia.jl:109
 in display at multimedia.jl:111
 in display at multimedia.jl:143
```

Now:

```
julia> readbytes(`dd if=/dev/urandom bs=10 count=1`)
1+0 records in
1+0 records out
10 bytes transferred in 0.000031 secs (322639 bytes/sec)
10-element Array{Uint8,1}:
 0x04
 0xee
 0xcc
 0x14
 0x04
 0x2b
 0x75
 0xd9
 0xe2
 0x24
```
