### PR TITLE
added type assert to toq

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -25,7 +25,7 @@ function toq()
     if is(timers,())
         error("toc() without tic()")
     end
-    t0 = timers[1]
+    t0 = timers[1]::Uint64
     task_local_storage(:TIMERS, timers[2])
     (t1-t0)/1e9
 end


### PR DESCRIPTION
Previously, according to `code_typed(toq,())`, `toq` and `toc` type-inferred to a return type of `Any`.
They really always return a `Float64`. Adding this type-assert makes the inferred return type `Float64`.
