### PR TITLE
@parallel and Darray use only workers. Minor cleanup of pmap.

### DIFF
--- a/base/darray.jl
+++ b/base/darray.jl
@@ -45,7 +45,7 @@ function DArray(init, dims, procs)
     end
     DArray(init, dims, procs, defaultdist(dims,procs))
 end
-DArray(init, dims) = DArray(init, dims, procs()[1:min(nprocs(),max(dims))])
+DArray(init, dims) = DArray(init, dims, workers()[1:min(nworkers(),max(dims))])
 
 size(d::DArray) = d.dims
 procs(d::DArray) = d.pmap


### PR DESCRIPTION
Closes #3654

pmap, @parallel and DArray (with default procs parameter) only use worker processes.

When when nprocs() > 1,  `pmap` was not using self. Now, it does not use id 1. 
