### PR TITLE
Convert key to Dict key type before hashing

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -456,6 +456,12 @@ end
 
 # get the index where a key is stored, or -1 if not present
 function ht_keyindex{K,V}(h::Dict{K,V}, key)
+    try
+        key = convert(K, key)
+    catch
+        return -1
+    end
+
     sz = length(h.keys)
     iter = 0
     maxprobe = max(16, sz>>6)


### PR DESCRIPTION
After fc05d74d0bd2117c8691e68e751ee9b212a5d3a2:

``` julia
julia> a = Dict{Int16, Any}()
Dict{Int16,Any}()

julia> a[1] = 1
1

julia> a[1]
ERROR: key not found: 1
 in getindex at dict.jl:486
```

This is because `setindex!()` calls `convert()` on the key but `getindex()` does not. This PR calls `convert()` in `ht_keyindex()`, which fixes this. I wrapped this in `try`/`catch` so that `get()`/`getkey()` won't throw when `convert(::KeyType, ::DictKeyType)` fails or doesn't exist.
