### PR TITLE
multi.jl: worker finalization, remove :cmd, flush worker() info

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -238,7 +238,7 @@ function reinit_stdio()
     reinit_displays() # since Multimedia.displays uses STDOUT as fallback
 end
 
-flush(::TTY) = nothing
+flush(::Union(Pipe,TTY)) = nothing
 
 function isopen(x)
     if !(x.status != StatusUninit && x.status != StatusInit)


### PR DESCRIPTION
Flushing here rids us of problems caused by buffering (recent STDOUT IOStream changes?). Additionally, we don't need :cmd anymore with the latest ClusterManagers.jl, and finalization lets us properly clean up after firing up a PBS/Torque or SGE instance (remove temporary working files, processes).
