### PR TITLE
Added in(x::String, y::String) = contains(y, x)

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -234,6 +234,8 @@ function in(x, itr)
     return false
 end
 
+in(x::String, y::String) = contains(y, x)
+
 function contains(itr, x)
     warn_once("contains(collection, item) is deprecated, use in(item, collection) instead")
     in(x, itr)


### PR DESCRIPTION
I'm not optimistic that this will fly, but I figured I would try. ;-)

If this patch isn't acceptable, we need 

``` julia
in(::String, ::String) = error("Use contains(x,y) for string containment")
```

since 

``` julia
julia> "not" in "knot"
false
```

says that "not" is not in "knot", which is clearly misleading. :-)

Other than this, to quote Stefan, I'm unreasonably happy about the infix version of "in". ;-)
