### PR TITLE
Move intfuncs up higher so we can get proper errors

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -81,6 +81,8 @@ include("env.jl")
 include("errno.jl")
 using .Errno
 include("path.jl")
+include("intfuncs.jl")
+
 
 # I/O
 include("task.jl")
@@ -103,7 +105,6 @@ importall .Printf
 include("file.jl")
 
 # core math functions
-include("intfuncs.jl")
 include("floatfuncs.jl")
 include("math.jl")
 importall .Math


### PR DESCRIPTION
Ever since the IO rework, I've been seeing `error: dec not defined` when running the build process on a machine without a proper TTY (e.g. output redirected to a file, run inside of Ubuntu's buildd servers, etc....)

This moves `intfuncs` higher up in the system image so we can get the definition of `dec` before the error occurs so we can see the error trying to be printed.
