### PR TITLE
Add in a short delay when opening the terminal on OSX

### DIFF
--- a/contrib/mac/app/script
+++ b/contrib/mac/app/script
@@ -29,6 +29,7 @@ osascript 2>&1>/dev/null <<EOF
     if (ProcessList contains "Terminal") or ((count of every window) is less than 1) then
       tell application "System Events" to tell process "Terminal" to keystroke "n" using command down
     end if
+    delay .5
     do script ("exec bash -c \"PATH='${ROOT}/julia/bin:${PATH}' FONTCONFIG_PATH='${ROOT}/julia/etc/fonts' GIT_EXEC_PATH='${ROOT}/julia/libexec/git-core' GIT_TEMPLATE_DIR='${ROOT}/julia/share/git-core' TK_LIBRARY='/System/Library/Frameworks/Tk.framework/Versions/8.5/Resources/Scripts' exec '${ROOT}/julia/bin/julia'\"") in front window
   end tell
 EOF


### PR DESCRIPTION
Allows for users with `~/.bash_profile` setups that open tmux, screen etc.. by default to launch the Julia app properly.

See https://github.com/JuliaLang/julia/pull/3547 for discussion. A better implementation would be a command to Terminal.app to not start a shell that reads these customized scripts, however a search for such a command has been unsuccessful.
