### PR TITLE
Fix a mistake in connect/listen error handling (due to change in UV API)

### DIFF
--- a/test/socket.jl
+++ b/test/socket.jl
@@ -55,6 +55,14 @@ catch e
     @test typeof(e) == Base.UVError # E.g. not method error
 end
 
+try
+    # This should be an invalid port
+    connect("localhost",21452)
+    @test false
+catch e
+    @test typeof(e) == Base.UVError
+end
+
 try 
     connect(".invalid",80)
 catch e


### PR DESCRIPTION
As a pull request because this exposes a problem during the tests. Not sure what the exact issue is, but wanted to make sure this doesn't get lost. 
