### PR TITLE
Make == compare Dict values using == instead of isequal

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -119,6 +119,19 @@ function isequal(l::Associative, r::Associative)
     true
 end
 
+function ==(l::Associative, r::Associative)
+    if isa(l,ObjectIdDict) != isa(r,ObjectIdDict)
+        return false
+    end
+    if length(l) != length(r) return false end
+    for (key, value) in l
+        if value != get(r, key, _MISSING)
+            return false
+        end
+    end
+    true
+end
+
 # some support functions
 
 _tablesz(x::Integer) = x < 16 ? 16 : one(x)<<((sizeof(x)<<3)-leading_zeros(x-1))


### PR DESCRIPTION
After fc05d74d0bd2117c8691e68e751ee9b212a5d3a2:

``` julia
julia> 1 == 1.0
true
julia> {"a"=>1} == {"a"=>1.0}
false
```

See also #4150. This fix is a little weird because of the asymmetry between keys and values (`==` implies that keys are `isequal` and values are `==`), but the current behavior is also a little weird.
