### PR TITLE
Vagrant: update Vagrantfile, fix make testall

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -5,7 +5,7 @@ MKLLIB = $(MKLROOT)/lib/intel64
 
 # we include twice to pickup user definitions better
 ifeq (exists, $(shell [ -e $(JULIAHOME)/Make.user ] && echo exists ))
-include $(JULIAHOME)/Make.user 
+include $(JULIAHOME)/Make.user
 endif
 
 # disable automatic Makefile rules
@@ -79,7 +79,7 @@ override BUILD_OS := WINNT
 endif
 
 ifeq ($(OS), WINNT)
-fPIC = 
+fPIC =
 ifeq ($(BUILD_OS), WINNT)
 PATH := ${PATH}:${BUILD}/lib:${BUILD}/lib/julia:/c/Program Files/7-zip
 endif
@@ -227,7 +227,7 @@ LLVM_CONFIG=$(LLVMROOT)/bin/llvm-config
 endif
 
 ifeq ($(USE_SYSTEM_READLINE), 1)
-READLINE = -lreadline 
+READLINE = -lreadline
 else
 READLINE = $(BUILD)/lib/libreadline.a
 endif
@@ -305,8 +305,8 @@ ifeq ($(OS), Darwin)
   INSTALL_NAME_CHANGE_CMD = install_name_tool -change
 else
   INSTALL_NAME_ID_DIR =
-  INSTALL_NAME_CMD = true -ignore 
-  INSTALL_NAME_CHANGE_CMD = true -ignore 
+  INSTALL_NAME_CMD = true -ignore
+  INSTALL_NAME_CHANGE_CMD = true -ignore
 endif
 
 # shared library runtime paths
@@ -431,7 +431,7 @@ endif
 
 define dir_target
 $$(subst $$(abspath $(JULIAHOME))/,,$$(abspath $(1))): $$(abspath $(1))
-$$(abspath $(1)): 
+$$(abspath $(1)):
 	@mkdir -p $$@
 endef
 
@@ -443,7 +443,7 @@ endif
 
 define symlink_target
 CLEAN_TARGETS += clean-$(2)/$(1)
-clean-$$(abspath $(2)/$(1)): 
+clean-$$(abspath $(2)/$(1)):
 ifeq ($(BUILD_OS), WINNT)
 	@-cmd //C rmdir $$(call mingw_to_dos,$(2)/$(1),cd $(2) &&)
 else
@@ -479,6 +479,8 @@ JULIA_EXECUTABLE_debug = $(BUILD)/bin/julia-debug-$(DEFAULT_REPL)$(EXE)
 JULIA_EXECUTABLE_release = $(BUILD)/bin/julia-$(DEFAULT_REPL)$(EXE)
 
 ifeq ($(OS), WINNT)
+JULIA_EXECUTABLE = $(JULIA_EXECUTABLE_release)
+else ifdef JULIA_VAGRANT_BUILD
 JULIA_EXECUTABLE = $(JULIA_EXECUTABLE_release)
 else
 JULIA_EXECUTABLE = $(JULIAHOME)/julia

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -6,8 +6,8 @@ rm /home/vagrant/postinstall.sh
 
 cat - > /home/vagrant/.bash_aliases <<"EOF"
 export JULIA_VAGRANT_BUILD=1
-BUILDOPTS="LLVM_CONFIG=llvm-config-3.2"
-for lib in LLVM ZLIB SUITESPARSE ARPACK BLAS FFTW LAPACK GMP MPFR PCRE LIBUNWIND READLINE GRISU OPENLIBM RMATH LIBUV; do
+BUILDOPTS="LLVM_CONFIG=llvm-config-3.3 USE_BLAS64=0"
+for lib in LLVM ZLIB SUITESPARSE ARPACK BLAS FFTW LAPACK GMP MPFR PCRE LIBUNWIND READLINE GRISU OPENLIBM RMATH; do
     export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1"
 done
 
@@ -18,7 +18,7 @@ apt-get update -qq -y
 apt-get install python-software-properties -y
 add-apt-repository ppa:staticfloat/julia-deps -y
 apt-get update -qq -y
-apt-get install g++ git make patchelf gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libreadline-dev libdouble-conversion-dev libopenlibm-dev librmath-dev libuv-julia-dev libmpfr-dev -y
+apt-get install g++ git make patchelf gfortran llvm-3.3 libsuitesparse-dev libncurses5-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libreadline-dev libdouble-conversion-dev libopenlibm-dev librmath-dev libuv-julia-dev libmpfr-dev -y
 SCRIPT
 
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
Compile libuv from source and use LLVM 3.3. Also, point the testall target at the executable in usr/bin instead of the symlink, which won't exist in the Vagrant build.

Running this through a pull request due to the Make.inc change.

I think I was supposed to have this fixed a couple of weeks ago, so getting it taken care of finally.
