### PR TITLE
Fix #4228

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1013,7 +1013,7 @@ for (f, fp, op) = ((:cumsum, :cumsum_pairwise, :+),
         c = $(op===:+ ? (:(similar(v,typeof(+zero(eltype(v)))))) :
                         (:(similar(v))))
         if n == 0; return c; end
-        ($fp)(v, c, $(op==:+ ? :(zero(eltype(v))) : :(one(eltype(v)))), 1, n)
+        ($fp)(v, c, $(op==:+ ? :(zero(v[1])) : :(one(v[1]))), 1, n)
         return c
     end
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -699,3 +699,7 @@ end
 @test reverse!([1:10],6,10) == [1,2,3,4,5,10,9,8,7,6]
 
 
+# issue 4228
+A = [[i i; i i] for i=1:2]
+@test cumsum(A) == Any[[1 1; 1 1], [3 3; 3 3]]
+@test cumprod(A) == Any[[1 1; 1 1], [4 4; 4 4]]


### PR DESCRIPTION
Note that the function returns before this line if `v` is empty.
