### PR TITLE
Added helpfull message for DomainError

### DIFF
--- a/base/repl.jl
+++ b/base/repl.jl
@@ -69,6 +69,23 @@ function showerror(io::IO, e::LoadError, bt)
     print(io, "\nat $(e.file):$(e.line)")
 end
 
+function showerror(io::IO, e::DomainError, bt)
+    try
+        print(io, "DomainError")
+        for b in bt
+            code = ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Int32), b, 0)
+            if length(code) == 3
+                if code[1] in (:log, :log2, :log10, :sqrt) # TODO add :besselj, :besseli, :bessely, :besselk
+                    print(io, "\n       ", code[1]," will only return complex result if called width a complex argument. Eg: ", code[1], "(complex(x))")
+                end
+                break
+            end
+        end
+    finally
+        show_backtrace(io, bt)
+    end
+end
+
 showerror(io::IO, e::SystemError) = print(io, "$(e.prefix): $(strerror(e.errnum))")
 showerror(io::IO, ::DivideError) = print(io, "integer division error")
 showerror(io::IO, ::StackOverflowError) = print(io, "stack overflow")

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -2341,19 +2341,19 @@ Mathematical Functions
 
 .. function:: log(x)
 
-   Compute the natural logarithm of ``x``
+   Compute the natural logarithm of ``x``. Throws ``DomainError`` for negative ``Real`` arguments. Use ``Complex`` negative arguments instead.
 
 .. function:: log2(x)
 
-   Compute the natural logarithm of ``x`` to base 2
+   Compute the natural logarithm of ``x`` to base 2. Throws ``DomainError`` for negative ``Real`` arguments.
 
 .. function:: log10(x)
 
-   Compute the natural logarithm of ``x`` to base 10
+   Compute the natural logarithm of ``x`` to base 10. Throws ``DomainError`` for negative ``Real`` arguments.
 
 .. function:: log1p(x)
 
-   Accurate natural logarithm of ``1+x``
+   Accurate natural logarithm of ``1+x``.  Throws ``DomainError`` for negative ``Real`` arguments.
 
 .. function:: frexp(val, exp)
 
@@ -2459,7 +2459,7 @@ Mathematical Functions
 
 .. function:: sqrt(x)
 
-   Return :math:`\sqrt{x}`
+   Return :math:`\sqrt{x}`. Throws ``DomainError`` for negative ``Real`` arguments. Use ``Complex`` negative arguments instead.
 
 .. function:: isqrt(x)
 


### PR DESCRIPTION
Some functions throw DomainError for Real arguments because of type
stability and that the correct answer is complex. This patch add a ugly
hack, inspecting the bactrace, to give newcommers a helpefull hint.

```
julia> sqrt(-1)
ERROR: DomainError
    sqrt will only return complex result if called width a complex argument. Eg: sqrt(complex(x))

julia> log(-1)
ERROR: DomainError
    log will only return complex result if called width a complex argument. Eg: log(complex(x))
```

See: https://github.com/JuliaLang/julia/issues/2144

I hate that this approach includes a list of functions (:log, :log2, :log10, :sqrt) that has to be updated and can not be extended by module writers, but from the discussion in #2144 it looks like something that might be accepted.
