### PR TITLE
Do not set HOME in julia .bat script

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -191,6 +191,8 @@ function try_include(f::String)
     end
 end
 
+user_home() = ENV[@windows?"USERPROFILE":"HOME"]
+
 function process_options(args::Array{Any,1})
     global ARGS, bind_addr
     quiet = false
@@ -248,7 +250,7 @@ function process_options(args::Array{Any,1})
             startup = false
         elseif args[i] == "-F"
             # load juliarc now before processing any more options
-            try_include(abspath(ENV["HOME"],".juliarc.jl"))
+            try_include(abspath(user_home(),".juliarc.jl"))
             startup = false
         elseif beginswith(args[i], "--color")
             if args[i] == "--color"
@@ -337,9 +339,6 @@ function _start()
         if !isdir(user_data_dir)
             mkdir(user_data_dir)
         end
-        if !haskey(ENV,"HOME")
-            ENV["HOME"] = user_data_dir
-        end
     end
 
     #atexit(()->flush(STDOUT))
@@ -348,7 +347,7 @@ function _start()
         any(a->(a=="--worker"), ARGS) || init_head_sched()
         init_load_path()
         (quiet,repl,startup,color_set) = process_options(ARGS)
-        repl && startup && try_include(abspath(ENV["HOME"],".juliarc.jl"))
+        repl && startup && try_include(abspath(user_home(),".juliarc.jl"))
 
         if repl
             if isa(STDIN,File)

--- a/base/file.jl
+++ b/base/file.jl
@@ -13,7 +13,7 @@ function cd(dir::String)
     @windows_only systemerror("chdir $dir", ccall(:_chdir,Int32,(Ptr{Uint8},),dir) == -1)
     @unix_only systemerror("chdir $dir", ccall(:chdir,Int32,(Ptr{Uint8},),dir) == -1)
 end
-cd() = cd(ENV["HOME"])
+cd() = cd(user_home())
 
 # do stuff in a directory, then return to current directory
 
@@ -39,7 +39,7 @@ end
     end
 end
 
-cd(f::Function) = cd(f, ENV["HOME"])
+cd(f::Function) = cd(f, user_home())
 
 function mkdir(path::String, mode::Unsigned=0o777)
     @unix_only ret = ccall(:mkdir, Int32, (Ptr{Uint8},Uint32), bytestring(path), mode)

--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -8,7 +8,8 @@ const DEFAULT_META = "git://github.com/JuliaLang/METADATA.jl"
 @windows_only const DIR_NAME = "packages"
 
 function path()
-    b = abspath(get(ENV,"JULIA_PKGDIR",joinpath(ENV["HOME"],DIR_NAME)))
+    b = abspath(get(ENV,"JULIA_PKGDIR",
+        joinpath((@windows?abspath(ENV["AppData"],"julia"):ENV["HOME"]),DIR_NAME)))
     x, y = VERSION.major, VERSION.minor
     d = joinpath(b,"v$x.$y")
     isdir(d) && return d

--- a/contrib/windows/prepare-julia-env.bat
+++ b/contrib/windows/prepare-julia-env.bat
@@ -12,7 +12,6 @@ set JULIA_EXE=julia-readline.exe
 for %%A in (%JULIA_EXE%) do set JULIA_HOME=%%~dp$PATH:A
 set JULIA=%JULIA_HOME%%JULIA_EXE%
 set PATH=%JULIA_HOME%;%JULIA_HOME%..\lib\julia;%JULIA_HOME%..\lib;.;%SYS_PATH%;%~dp0\Git\bin;C:\MinGW\msys\1.0\bin;C:\MinGW\bin;C:\Program Files\Git\bin;C:\Program Files (x86)\Git\bin;C:\Python27;C:\Python26;C:\Python25
-set HOME=%APPDATA%\julia
 set JL_PRIVATE_LIBDIR=lib\julia
 set JULIA_EDITOR=start
 


### PR DESCRIPTION
@vtjnash Are you ok with this? I noticed this while trying to get IJulia to run which uses HOME to locate some of its config files. The original reason we had this was because git needed, but we do that via `setenv` no anyway, so I don't see a reason to keep it. Thoughts?

The only thing that this would imply is that we'd have to tell users to use `Git.git(`config user.name`)` etc. instead of running git directly. 
