### PR TITLE
Reshape can accept : to signal an implicit dimension

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -175,6 +175,7 @@ function reshape(A::AbstractArray, dims::(Union(Int,  Colon)...))
     reshape(A, new_dims...)
 end
 
+reshape(a::AbstractArray, dims::Int...) = reshape(a, dims)
 reshape(a::AbstractArray, dims::Union(Int, Colon)...) = reshape(a, dims)
 
 vec(a::AbstractArray) = reshape(a,length(a))

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -149,7 +149,33 @@ function reshape(a::AbstractArray, dims::Dims)
     end
     copy!(similar(a, dims), a)
 end
-reshape(a::AbstractArray, dims::Int...) = reshape(a, dims)
+
+function reshape(A::AbstractArray, dims::(Union(Int,  Colon)...))
+    new_dims = Array(Int, length(dims))
+    dim_product = 1.
+    missing_dim_idx = -1
+    colon = Colon()
+    for i = 1:length(dims)
+        if dims[i] != colon
+            new_dims[i] = dims[i]
+            dim_product *= dims[i]
+        else
+            if missing_dim_idx == -1
+                missing_dim_idx = i
+            else
+                error("reshape: only one implicit dimension allowed")
+            end
+        end
+    end
+    missing_dim_value, remainder = divrem(length(A), dim_product)
+    if remainder != 0
+        error("reshape: invalid dimensions")
+    end
+    new_dims[missing_dim_idx] = missing_dim_value
+    reshape(A, new_dims...)
+end
+
+reshape(a::AbstractArray, dims::Union(Int, Colon)...) = reshape(a, dims)
 
 vec(a::AbstractArray) = reshape(a,length(a))
 vec(a::AbstractVector) = a


### PR DESCRIPTION
If one dimension passed to reshape is a :, it is replaced with the value which is implicitly defined by the other dimensions to make the reshape valid (or throws an error if there is no such value).

Example:

``` julia
julia> x=rand(10)
```

All of these are equivalent:

``` julia
julia> reshape(x, 5, :)
julia> reshape(x, , 2)
julia> reshape(x, 5, 2)
```

Throws an error:

``` julia
julia> reshape(x, 3, :)
```

Closes #4250
