### PR TITLE
Methods for QR-like factorizations with more arguments

### DIFF
--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -130,6 +130,12 @@ end
 # geqrt3! - recursive algorithm producing compact WY representation of Q
 # gerqf - unpivoted RQ decomposition
 # getrf - LU decomposition
+#
+# These mutating functions take as arguments all the values they
+# return, even if the value of the function does not depend on them
+# (e.g. the tau argument).  This is so that a factorization can be
+# updated in place.  The condensed mutating functions, usually a
+# function of A only, are defined after this block.
 for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
     ((:dgebrd_,:dgelqf_,:dgeqlf_,:dgeqrf_,:dgeqp3_,:dgeqrt3_,:dgerqf_,:dgetrf_,:Float64,:Float64),
      (:sgebrd_,:sgelqf_,:sgeqlf_,:sgeqrf_,:sgeqp3_,:sgeqrt3_,:sgerqf_,:sgetrf_,:Float32,:Float32),
@@ -143,6 +149,8 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
         # .. Array Arguments ..
         #  DOUBLE PRECISION   A( LDA, * ), D( * ), E( * ), TAUP( * ),
         #           TAUQ( * ), WORK( * )
+### Doesn't this function need to return taup and tauq?  You can't do
+### anything with the result otherwise
         function gebrd!(A::StridedMatrix{$elty})
             chkstride1(A)
             m, n  = size(A)
@@ -172,13 +180,13 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
         #       INTEGER            INFO, LDA, LWORK, M, N
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
-        function gelqf!(A::StridedMatrix{$elty})
+        function gelqf!(A::StridedMatrix{$elty}, tau::Vector{$elty})
             chkstride1(A)
             info  = Array(BlasInt, 1)
             m     = blas_int(size(A, 1))
             n     = blas_int(size(A, 2))
             lda   = blas_int(max(1,stride(A, 2)))
-            tau   = Array($elty, n)
+            if length(tau) != min(m,n) throw(DimensionMismatch("gelqf!")) end
             lwork = blas_int(-1)
             work  = Array($elty, (1,))
             for i in 1:2                # first call returns lwork as work[1]
@@ -199,13 +207,13 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
         #       INTEGER            INFO, LDA, LWORK, M, N
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
-        function geqlf!(A::StridedMatrix{$elty})
+        function geqlf!(A::StridedMatrix{$elty}, tau::Vector{$elty})
             chkstride1(A)
             info  = Array(BlasInt, 1)
             m     = blas_int(size(A, 1))
             n     = blas_int(size(A, 2))
             lda   = blas_int(max(1,stride(A, 2)))
-            tau   = Array($elty, n)
+            if length(tau) != min(m,n) throw(DimensionMismatch("geqlf!")) end
             lwork = blas_int(-1)
             work  = Array($elty, (1,))
             for i in 1:2                # first call returns lwork as work[1]
@@ -227,11 +235,10 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
         # *     .. Array Arguments ..
         #       INTEGER            JPVT( * )
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
-        function geqp3!(A::StridedMatrix{$elty})
+        function geqp3!(A::StridedMatrix{$elty}, jpvt::Vector{BlasInt}, tau::Vector{$elty})
             chkstride1(A)
             m, n  = size(A)
-            jpvt  = zeros(BlasInt, n)
-            tau   = Array($elty, min(m,n))
+            if length(tau) != min(m,n) || length(jpvt) != n throw(DimensionMismatch("geqp3!")) end
             lda   = max(1,stride(A,2))
             if lda == 0 return A, tau, jpvt end # Early exit
             work  = Array($elty, 1)
@@ -265,35 +272,32 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
             end
             A, tau, jpvt
         end
-        function geqrt3!(A::StridedMatrix{$elty})
-            chkstride1(A)
-            m, n = size(A)
-            if m < n throw(DimensionMismatch("Matrix cannot have less rows than columns")) end
-            lda = max(1, stride(A, 2))
-            T = Array($elty, n, n)
+        function geqrt3!(A::StridedMatrix{$elty}, T::Matrix{$elty})
+            chkstride1(A); chkstride1(T)
+            m, n = size(A); p, q = size(T)
+            if m < n throw(DimensionMismatch("geqrt3!: A cannot have fewer rows than columns")) end
+            if p < n || q < n throw(DimensionMismatch("geqrt3!")) end
             if n > 0
                 info = Array(BlasInt, 1)
                 ccall(($(string(geqrt3)), liblapack), Void, 
                     (Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                      Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
-                     &m, &n, A, &lda,
-                     T, &n, info)
+                     &m, &n, A, &max(1, stride(A, 2)),
+                     T, &max(1,stride(T,2)), info)
                 if info[1] < 0 throw(LAPACKException(info[1])) end
             end
             return A, T
         end
-        ## Several variants of geqrf! could be defined.
-        ## geqrfp! - positive elements on diagonal of R
-        ## geqrt!  - compact WY representation of Q (blocked algorithm)
+        ## geqrfp! - positive elements on diagonal of R - not defined yet
         # SUBROUTINE DGEQRF( M, N, A, LDA, TAU, WORK, LWORK, INFO )
         # *     .. Scalar Arguments ..
         #       INTEGER            INFO, LDA, LWORK, M, N
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
-        function geqrf!(A::StridedMatrix{$elty})
+        function geqrf!(A::StridedMatrix{$elty}, tau::Vector{$elty})
             chkstride1(A)
             m, n  = size(A)
-            tau   = Array($elty, n)
+            if length(tau) != min(m,n) throw(DimensionMismatch("geqrf!")) end
             work  = Array($elty, 1)
             lwork = blas_int(-1)
             info  = Array(BlasInt, 1)
@@ -315,11 +319,11 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
         #       INTEGER            INFO, LDA, LWORK, M, N
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
-        function gerqf!(A::StridedMatrix{$elty})
+        function gerqf!(A::StridedMatrix{$elty},tau::Vector{$elty})
             chkstride1(A)
             info  = Array(BlasInt, 1)
             m, n  = size(A)
-            tau   = Array($elty, n)
+            if length(tau) != min(m,n) throw(DimensionMismatch("gerqf!")) end
             lwork = blas_int(-1)
             work  = Array($elty, 1)
             for i in 1:2                # first call returns lwork as work[1]
@@ -355,6 +359,21 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
             A, ipiv, info[1]
         end
     end
+end
+
+gelqf!{T<:BlasFloat}(A::StridedMatrix{T}) = ((m,n)=size(A); gelqf!(A,Array(T,min(m,n))))
+geqlf!{T<:BlasFloat}(A::StridedMatrix{T}) = ((m,n)=size(A); geqlf!(A,Array(T,min(m,n))))
+geqrt3!{T<:BlasFloat}(A::StridedMatrix{T}) = (n=size(A,2); geqrt3!(A,Array(T,n,n)))
+geqrf!{T<:BlasFloat}(A::StridedMatrix{T}) = ((m,n)=size(A); geqrf!(A,Array(T,min(m,n))))
+gerqf!{T<:BlasFloat}(A::StridedMatrix{T}) = ((m,n)=size(A); gerqf!(A,Array(T,min(m,n))))
+
+function geqp3!{T<:BlasFloat}(A::StridedMatrix{T},jpvt::Vector{BlasInt})
+    m,n = size(A)
+    geqp3!(A,jpvt,Array(T,min(m,n)))
+end
+function geqp3!{T<:BlasFloat}(A::StridedMatrix{T})
+    m,n=size(A)
+    geqp3!(A,zeros(BlasInt,n),Array(T,min(m,n)))
 end
 
 ## Complete orthogonaliztion tools


### PR DESCRIPTION
Add methods for QR-like factorizations that take all the arguments that will be stored in a factorization.  With these a factorization can be updated in place.

These are now the most basic methods for the generic.  The methods that take only the matrix to be decomposed now call these after allocating vectors or matrices.

@andreasnoackjensen has suggested going further and storing the `work`, `iwork` etc. arrays in the factorization so that an update can be performed without any allocation of storage.
