### PR TITLE
Fix FDWatcher on Windows

### DIFF
--- a/base/poll.jl
+++ b/base/poll.jl
@@ -62,6 +62,7 @@ end
 
 @unix_only _get_osfhandle(fd::RawFD) = fd
 @windows_only _get_osfhandle(fd::RawFD) = WindowsRawSocket(ccall(:_get_osfhandle,Ptr{Void},(Cint,),fd.fd))
+@windows_only _get_osfhandle(fd::WindowsRawSocket) = fd
 
 type FDWatcher <: UVPollingWatcher
     handle::Ptr{Void}
@@ -172,10 +173,10 @@ let
         end
 
         function wait(socket::WindowsRawSocket; readable=false, writable=false)
-            if !has(fdwatcher_array,socket.handle)
-                fdwatcher_array[fd.handle] = FDWatcher(socket)
+            if !haskey(fdwatcher_array,socket.handle)
+                fdwatcher_array[socket] = FDWatcher(socket)
             end
-            _wait(fdwatcher_array[fd.handle],readable,writable)
+            _wait(fdwatcher_array[socket],readable,writable)
         end 
     end
 end


### PR DESCRIPTION
With this and https://github.com/JuliaLang/ZMQ.jl/pull/28 I am able to use IJulia on Windows with the latest binary d32bc80 on the download page (thank you, Jameson!), after removing sys.ji and regenerating.

![image](https://f.cloud.github.com/assets/327706/1144838/4b004878-1dd3-11e3-883b-0c1e471ac412.png)

Manual steps:
- install anaconda
- compiled ZMQ lib using mingw64; copied libzmq.dll to julia/bin
- RPMmd.update(); RPMmd.install("nettle")
- start "ipython qtconsole --profile julia" from _inside_ of Julia because of https://github.com/JuliaLang/julia/pull/4252

@loladiro @vtjnash @stevengj
