### PR TITLE
Support non-standard ssh port, doc updates, -p option change

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -234,7 +234,7 @@ function process_options(args::Array{Any,1})
             else
                 np = int(args[i])
             end
-            addprocs(np-1)
+            addprocs(np)
         elseif args[i]=="--machinefile"
             i+=1
             machines = split(readall(args[i]), '\n', false)

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -62,6 +62,14 @@ Or you could put that code into a script and run it::
     foo
     bar
 
+Julia can be started in parallel mode with either the ``-p`` or the 
+``--machinefile`` options. ``-p n`` will launch an additional ``n`` 
+worker processes, while ``--machinefile file`` will launch a worker 
+for each line in file ``file``. The machines defined in ``file`` must be 
+accessible via ``ssh`` and each machine definition takes the form 
+``[user@]host[:port]``
+    
+    
 If you have code that you want executed whenever julia is run, you can
 put it in ``~\.juliarc.jl``::
 

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -39,7 +39,7 @@ wait for a remote call to finish by calling ``wait`` on its remote
 reference, and you can obtain the full value of the result using
 ``fetch``.
 
-Let's try this out. Starting with ``julia -p n`` provides ``n``
+Let's try this out. Starting with ``julia -p n`` provides ``n`` worker
 processes on the local machine. Generally it makes sense for ``n`` to
 equal the number of CPU cores on the machine.
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4097,14 +4097,25 @@ some built-in integration support in Julia.
 Parallel Computing
 ------------------
 
-.. function:: addprocs(n) -> List of process identifiers
+.. function:: addprocs(n; cman::ClusterManager=LocalManager()) -> List of process identifiers
 
-   Add processes on the local machine. Can be used to take advantage of multiple cores.
+   ``addprocs(4)`` will add 4 processes on the local machine. This can be used to take 
+   advantage of multiple cores.
+   
+   Keyword argument ``cman`` can be used to provide a custom cluster manager to start workers. 
+   For example Beowulf clusters are  supported via a custom cluster manager implemented 
+   in  package ``ClusterManagers``.
+   
+   See the documentation for package ``ClusterManagers`` for more information on how to 
+   write a custom cluster manager.
 
-.. function:: addprocs({"host1","host2",...}; tunnel=false, dir=JULIA_HOME, sshflags::Cmd=``, cman::ClusterManager) -> List of process identifiers
+.. function:: addprocs(machines; tunnel=false, dir=JULIA_HOME, sshflags::Cmd=``) -> List of process identifiers
 
-   Add processes on remote machines via SSH or a custom cluster manager. 
+   Add processes on remote machines via SSH. 
    Requires julia to be installed in the same location on each node, or to be available via a shared file system.
+   
+   ``machines`` is a vector of host definitions of the form ``[user@]host[:port]``. A worker is started
+   for each such definition.
    
    Keyword arguments:
 
@@ -4114,13 +4125,6 @@ Parallel Computing
 
    ``sshflags`` : specifies additional ssh options, e.g. :literal:`sshflags=\`-i /home/foo/bar.pem\`` .
 
-   ``cman`` : Workers are started using the specified cluster manager. 
-
-   For example Beowulf clusters are  supported via a custom cluster manager implemented 
-   in  package ``ClusterManagers``.
-   
-   See the documentation for package ``ClusterManagers`` for more information on how to 
-   write a custom cluster manager.
    
 .. function:: nprocs()
 


### PR DESCRIPTION
This patch does the following:
- Supports machine definitions of the form `[user@]host[:port]`
- Changes behavior of `-p n` option from "total of n processes" to "additional n worker processes". This has been done to reflect the fact that `@parallel` and `pmap` both only use workers processes for computation when `nprocs() > 1`
- doc updates

closes #4298
