### PR TITLE
stream.jl: provide flush() for all AsyncStream types (e.g. Pipes, TTYs, ...

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -240,7 +240,7 @@ function reinit_stdio()
     reinit_displays() # since Multimedia.displays uses STDOUT as fallback
 end
 
-flush(::Union(Pipe,TTY)) = nothing
+flush(::AsyncStream) = nothing
 
 function isopen(x)
     if !(x.status != StatusUninit && x.status != StatusInit)


### PR DESCRIPTION
...and TCP/UDP sockets)
