### PR TITLE
Require that slice dimensions match array dimensions.  Fixes #4336.

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -89,6 +89,9 @@ function slice{T,N}(A::AbstractArray{T,N}, i::NTuple{N,RangeIndex})
     SubArray{T,n,typeof(A),typeof(i)}(A, i)
 end
 
+# Throw error on slice dimension mismatch
+slice{T,N,M}(A::AbstractArray{T,N}, i::NTuple{M,RangeIndex}) = throw(BoundsError())
+
 slice(A::AbstractArray, i::RangeIndex...) = slice(A, i)
 
 function slice(A::SubArray, i::RangeIndex...)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -148,6 +148,11 @@ a = [5:8]
 @test parent(a) == a
 @test parentindexes(a) == (1:4,)
 
+# 4335
+@test_throws slice(A, 1:2)
+@test_throws slice(A, 1:2, 3:4)
+@test_throws slice(A, 1:2, 3:4, 5:6, 7:8)
+
 # Out-of-bounds construction. See #4044
 A = rand(7,7)
 rng = 1:4


### PR DESCRIPTION
Note that this does not allow trailing dimensions of 1.  Should we?
