### PR TITLE
Add in removal of trailing / character to fix mkpath error in recursion

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -48,6 +48,9 @@ function mkdir(path::String, mode::Unsigned=0o777)
 end
 
 function mkpath(path::String, mode::Unsigned=0o777)
+    if path[end] == pathsep()[1]
+        path = path[1:prevind(path,end)]
+    end
     dir = dirname(path)
     (path == dir || isdir(path)) && return
     mkpath(dir, mode)


### PR DESCRIPTION
Without this, a `mkpath("/tmp/a/b/c/")` throws an error, but successfully completes the requested filesystem operation.

This is because `dirname("/tmp/a/b/c/") == "/tmp/a/b/c"`, which is consistent with python (so `dirname()` shouldn't change, I don't think) but does cause problems for this recursive algorithm.

I'm submitting a PR because I don't know if this is the best way to deal with the problem.
