### PR TITLE
make function printing more demo-friendly

### DIFF
--- a/base/repl.jl
+++ b/base/repl.jl
@@ -1,11 +1,13 @@
 # fallback text/plain representation of any type:
 writemime(io, ::MIME"text/plain", x) = showlimited(io, x)
 
-function writemime(io, ::MIME"text/plain", v::Function)
-    if isgeneric(v)
-        show_method_table(io, methods(v), 5)
+function writemime(io, ::MIME"text/plain", f::Function)
+    if isgeneric(f)
+        n = length(f.env)
+        m = n==1 ? "method" : "methods"
+        print(io, "$(f.env.name) (generic function with $n $m)")
     else
-        show(io, v)
+        show(io, f)
     end
 end
 
@@ -23,14 +25,11 @@ end
 
 function writemime(io, ::MIME"text/plain", v::DataType)
     show(io, v)
-    methods(v)  # force constructor creation
+    methods(v) # force constructor creation
     if isgeneric(v)
-        if v === v.name.primary
-            name = string(v.name.name)
-        else
-            name = repr(v)
-        end
-        print(io, "  (use methods($name) to see constructors)")
+        n = length(v.env)
+        m = n==1 ? "method" : "methods"
+        print(io, " (constructor with $n $m)")
     end
 end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -39,12 +39,12 @@ function show(io::IO, f::Function)
     elseif isdefined(f, :env) && isa(f.env,Symbol)
         print(io, f.env)
     else
-        print(io, "# function")
+        print(io, "(anonymous function)")
     end
 end
 
 function show(io::IO, x::IntrinsicFunction)
-    print(io, "# intrinsic function ", box(Int32,unbox(IntrinsicFunction,x)))
+    print(io, "(intrinsic function #", box(Int32,unbox(IntrinsicFunction,x)), ")")
 end
 
 function show(io::IO, x::UnionType)
@@ -418,7 +418,9 @@ end
 
 function show_method_table(io::IO, mt::MethodTable, max::Int=-1)
     name = mt.name
-    print(io, "# methods for generic function ", name)
+    n = length(mt)
+    m = n==1 ? "method" : "methods"
+    print(io, "# $n $m for generic function \"$name\":")
     d = mt.defs
     n = rest = 0
     while !is(d,())


### PR DESCRIPTION
I found that even printing a handful of methods when showing a generic function was very disruptive while presenting using IJulia, so this pull request changes generic functions to just print a single-line summary. It also makes printing anonymous functions and intrinsics match in style. The new style can be seen in [this IJulia notebook](http://nbviewer.ipython.org/b8fe9dbb36c1427b9f22).
