### PR TITLE
Eigs (arpack) starting vector and additional output

### DIFF
--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -4,10 +4,11 @@ using .ARPACK
 
 function eigs{T<:BlasFloat}(A::AbstractMatrix{T};
                             nev::Integer=6, ncv::Integer=20, which::ASCIIString="LM", 
-                            tol=0.0, maxiter::Integer=1000, sigma=0,
+                            tol=0.0, maxiter::Integer=1000, sigma=0,v0::Vector{T}=Array(T,(0,)),
                             ritzvec::Bool=true, complexOP::Bool=false)
     (m, n) = size(A)
     if m != n; error("Input must be square"); end
+	if !isempty(v0) && length(v0)!=n; error("Starting vector must have length $n"); end
     if n <= 6 && nev > n-1; nev = n-1; end
     ncv = blas_int(min(max(2*nev+2, ncv), n))
     bmat   = "I"
@@ -35,7 +36,7 @@ function eigs{T<:BlasFloat}(A::AbstractMatrix{T};
         
     # Compute the Ritz values and Ritz vectors
     (resid, v, ldv, iparam, ipntr, workd, workl, lworkl, rwork) = 
-       ARPACK.aupd_wrapper(T, linop, n, sym, cmplx, bmat, nev, ncv, which, tol, maxiter, mode)
+       ARPACK.aupd_wrapper(T, linop, n, sym, cmplx, bmat, nev, ncv, which, tol, maxiter, mode, v0)
     
     # Postprocessing to get eigenvalues and eigenvectors
     return ARPACK.eupd_wrapper(T, n, sym, cmplx, bmat, nev, which, ritzvec,

--- a/test/arpack.jl
+++ b/test/arpack.jl
@@ -53,16 +53,16 @@ Phi=CPM(Q)
 Test.@test_approx_eq d[1] 1. # largest eigenvalue should be 1.
 v=reshape(v,(50,50)) # reshape to matrix
 v=v/trace(v) # factor out arbitrary phase
-Test.@test_approx_eq normfro(imag(v)) 0. # it should be real
+Test.@test isapprox(normfro(imag(v)),0.) # it should be real
 v=real(v)
-#Test.@test_approx_eq normfro(v-v') 0. # it shoul be Hermitian
-# Comparison to 0. is way to strict for this to work!
+# Test.@test isapprox(normfro(v-v')/2,0.) # it should be Hermitian
+# Since this fails sometimes (numerical precision error),this test is commented out
 v=(v+v')/2
 Test.@test isposdef(v)
 
 # Repeat with starting vector
-(d2,v2,numiter,numop,resid) = eigs(Phi,nev=1,which="LM",v0=reshape(v,(2500,)))
-v2=reshape(v,(50,50))
-Test.@test numiter==1
+(d2,v2,numiter2,numop2,resid2) = eigs(Phi,nev=1,which="LM",v0=reshape(v,(2500,)))
+v2=reshape(v2,(50,50))
+v2=v2/trace(v2)
+Test.@test numiter2<numiter
 Test.@test_approx_eq v v2
-


### PR DESCRIPTION
I have added the functionality of specifying a starting vector for the eigs routine, which uses the Arnoldi solver in ARPACK. As mentioned in the ARPACK user's guide:
"The parameter info should be set to 0 on the initial call to dsaupd unless the user wants to supply the starting vector that initializes the IRLM. Normally, this default is a reasonable choice. However, if this eigenvalue calculation is one of a sequence of closely related problems then convergence may be accelerated if a suitable starting vector is specified. Typical choices in this situation might be to use the final value of the starting vector from the previous eigenvalue calculation (that vector will already be in the first column of V) or to construct a starting vector by taking a linear combination of the computed eigenvectors from the previously converged eigenvalue calculation. If the starting vector is to be supplied, then it should be placed in the array resid and info should be set to 1 on entry to dsaupd."

Eigs now also returns additional information regarding the convergence of the Arnoldi eigensolver. In particular, next to the Ritz vectors and eigenvalues, it returns the number of iterations, the number of matrix vector multiplications and the residual vector. 
