### PR TITLE
Add in PREFIX/etc/julia/juliarc.jl file for site-specific commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,13 @@ endif
 ifeq ($(OS), Darwin)
 	-./contrib/mac/fixup-libgfortran.sh $(PREFIX)/$(JL_PRIVATE_LIBDIR)
 endif
+	# Copy in juliarc.jl files per-platform for binary distributions as well
+ifeq ($(OS), Darwin)
+	-cat ./contrib/mac/juliarc.jl >> $(PREFIX)/etc/julia/juliarc.jl
+else ifeq ($(OS), WINNT)
+	-cat ./contrib/windows/juliarc.jl >> $(PREFIX)/etc/julia/juliarc.jl
+endif
+
 ifeq ($(OS), WINNT)
 	[ ! -d dist-extras ] || ( cd dist-extras && \
    		cp 7z.exe 7z.dll libexpat-1.dll zlib1.dll ../$(PREFIX)/bin && \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ VERSDIR = v`cut -d. -f1-2 < VERSION`
 all: default
 default: release
 
-DIRS = $(BUILD)/bin $(BUILD)/lib $(BUILD)/share/julia $(BUILD)/share/julia/man/man1
+DIRS = $(BUILD)/bin $(BUILD)/etc/julia $(BUILD)/lib $(BUILD)/share/julia $(BUILD)/share/julia/man/man1
 ifneq ($(JL_LIBDIR),bin)
 ifneq ($(JL_LIBDIR),lib)
 DIRS += $(BUILD)/$(JL_LIBDIR)
@@ -30,7 +30,7 @@ endif
 $(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
 $(foreach link,base test doc examples,$(eval $(call symlink_target,$(link),$(BUILD)/share/julia)))
 
-debug release: | $(DIRS) $(BUILD)/share/julia/base $(BUILD)/share/julia/test $(BUILD)/share/julia/doc $(BUILD)/share/julia/examples
+debug release: | $(DIRS) $(BUILD)/share/julia/base $(BUILD)/share/julia/test $(BUILD)/share/julia/doc $(BUILD)/share/julia/examples $(BUILD)/etc/julia/juliarc.jl
 	@$(MAKE) $(QUIET_MAKE) julia-$@
 	@export JL_PRIVATE_LIBDIR=$(JL_PRIVATE_LIBDIR) && \
 	$(MAKE) $(QUIET_MAKE) LD_LIBRARY_PATH=$(BUILD)/lib:$(LD_LIBRARY_PATH) JULIA_EXECUTABLE="$(JULIA_EXECUTABLE_$@)" $(BUILD)/$(JL_PRIVATE_LIBDIR)/sys.ji
@@ -59,6 +59,9 @@ $(BUILD)/share/julia/helpdb.jl: doc/helpdb.jl | $(BUILD)/share/julia
 
 $(BUILD)/share/man/man1/julia.1: doc/man/julia.1 | $(BUILD)/share/julia
 	@mkdir -p $(BUILD)/share/man/man1
+	@cp $< $@
+
+$(BUILD)/etc/julia/juliarc.jl: etc/juliarc.jl | $(BUILD)/etc/julia
 	@cp $< $@
 
 # use sys.ji if it exists, otherwise run two stages
@@ -156,7 +159,7 @@ PREFIX ?= julia-$(JULIA_COMMIT)
 install:
 	@$(MAKE) $(QUIET_MAKE) debug
 	@$(MAKE) $(QUIET_MAKE) release
-	@for subdir in "bin" "libexec" $(JL_LIBDIR) $(JL_PRIVATE_LIBDIR) "share/julia" "share/man/man1" "include/julia" "share/julia/site/"$(VERSDIR) ; do \
+	@for subdir in "bin" "libexec" $(JL_LIBDIR) $(JL_PRIVATE_LIBDIR) "share/julia" "share/man/man1" "include/julia" "share/julia/site/"$(VERSDIR) "etc/julia" ; do \
 		mkdir -p $(PREFIX)/$$subdir ; \
 	done
 	cp -a $(BUILD)/bin $(PREFIX)
@@ -187,6 +190,8 @@ ifeq ($(OS), WINNT)
 endif
 	# Copy in beautiful new man page!
 	cp $(BUILD)/share/man/man1/julia.1 $(PREFIX)/share/man/man1/
+	# Copy in etc/julia directory for things like juliarc.jl
+	cp -R $(BUILD)/etc/julia $(PREFIX)/etc/
 
 
 dist:

--- a/base/client.jl
+++ b/base/client.jl
@@ -248,7 +248,7 @@ function process_options(args::Array{Any,1})
             startup = false
         elseif args[i] == "-F"
             # load juliarc now before processing any more options
-            try_include(abspath(user_prefdir(),".juliarc.jl"))
+            load_juliarc()
             startup = false
         elseif beginswith(args[i], "--color")
             if args[i] == "--color"
@@ -317,6 +317,11 @@ function init_profiler()
     Profile.init(1_000_000, 0.001)
 end
 
+function load_juliarc()
+    try_include(abspath(JULIA_HOME,"..","etc","julia","juliarc.jl"))
+    try_include(abspath(user_prefdir(),".juliarc.jl"))
+end
+
 
 function _start()
     # set up standard streams
@@ -348,7 +353,7 @@ function _start()
         any(a->(a=="--worker"), ARGS) || init_head_sched()
         init_load_path()
         (quiet,repl,startup,color_set) = process_options(ARGS)
-        repl && startup && try_include(abspath(user_prefdir(),".juliarc.jl"))
+        repl && startup && load_juliarc()
 
         if repl
             if isa(STDIN,File)

--- a/contrib/mac/app/script
+++ b/contrib/mac/app/script
@@ -29,7 +29,7 @@ osascript 2>&1>/dev/null <<EOF
     if (ProcessList contains "Terminal") or ((count of every window) is less than 1) then
       tell application "System Events" to tell process "Terminal" to keystroke "n" using command down
     end if
-    do script ("exec bash -c \"PATH='${ROOT}/julia/bin:${PATH}' FONTCONFIG_PATH='${ROOT}/julia/etc/fonts' GIT_EXEC_PATH='${ROOT}/julia/libexec/git-core' GIT_TEMPLATE_DIR='${ROOT}/julia/share/git-core' TK_LIBRARY='/System/Library/Frameworks/Tk.framework/Versions/8.5/Resources/Scripts' exec '${ROOT}/julia/bin/julia'\"") in front window
+    do script ("exec '${ROOT}/julia/bin/julia'") in front window
   end tell
 EOF
 

--- a/contrib/mac/juliarc.jl
+++ b/contrib/mac/juliarc.jl
@@ -1,0 +1,9 @@
+# Set up environment for Julia OSX binary distribution
+let
+    ROOT = abspath(JULIA_HOME,"..")
+    ENV["PATH"]="$JULIA_HOME:$(ENV["PATH"])"
+    ENV["FONTCONFIG_PATH"] = joinpath(ROOT, "julia", "etc", "fonts")
+    ENV["GIT_EXEC_PATH"] = joinpath(ROOT, "julia", "libexec", "git-core")
+    ENV["GIT_TEMPLATE_DIR"] = joinpath(ROOT, "julia", "share", "git-core")
+    ENV["TK_LIBRARY"] = "/System/Library/Frameworks/Tk.framework/Versions/8.5/Resources/Scripts"
+end

--- a/etc/juliarc.jl
+++ b/etc/juliarc.jl
@@ -1,0 +1,3 @@
+# This file should contain site-specific commands to be executed on Julia startup
+# Users should store their own personal commands in user_prefdir(), in a file named .juliarc.jl
+


### PR DESCRIPTION
Lays the groundwork for addressing #4222 

This should replace the mess of environment variables being set in the OSX binary distribution so that we can simply invoke the executables directly and get the environment we need.  Additionally, this `juliarc.jl` file is included _before_ the user's personal `juliarc.jl` file so that if the user desires, they can override settings, etc...

@vtjnash @stevengj
