### PR TITLE
add MPFR cbrt and fallbacks for FloatingPoint, fix #4352

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -258,6 +258,13 @@ for f in (:cbrt, :sinh, :cosh, :tanh, :atan, :asinh, :exp, :erf, :erfc, :exp2, :
     end
 end
 
+# fallback definitions to prevent infinite loop from $f(x::Real) def above
+cbrt(x::FloatingPoint) = x^(1//3)
+exp2(x::FloatingPoint) = 2^x
+for f in (:sinh, :cosh, :tanh, :atan, :asinh, :exp, :erf, :erfc, :expm1)
+    @eval ($f)(x::FloatingPoint) = error("not implemented for ", typeof(x))
+end
+
 # TODO: GNU libc has exp10 as an extension; should openlibm?
 exp10(x::Float64) = 10.0^x
 exp10(x::Float32) = 10.0f0^x

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -19,7 +19,7 @@ import
         gamma, lgamma, digamma, erf, erfc, zeta, log1p, airyai, iceil, ifloor,
         itrunc, eps, signbit, sin, cos, tan, sec, csc, cot, acos, asin, atan,
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, atan2,
-        serialize, deserialize, inf, nan, hash
+        serialize, deserialize, inf, nan, hash, cbrt
 
 import Base.Math.lgamma_r
 
@@ -397,7 +397,7 @@ function ^(x::BigFloat, y::BigInt)
 end
 
 for f in (:exp, :exp2, :exp10, :expm1, :digamma, :erf, :erfc, :zeta,
-          :cosh,:sinh,:tanh,:sech,:csch,:coth,)
+          :cosh,:sinh,:tanh,:sech,:csch,:coth, :cbrt)
     @eval function $f(x::BigFloat)
         z = BigFloat()
         ccall(($(string(:mpfr_,f)), :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Int32), &z, &x, ROUNDING_MODE[end])


### PR DESCRIPTION
This fixes #4352 by adding `cbrt(x::BigFloat)`, and also provides fallback definitions for several `math.jl` functions that previously produced infinite recursions if a `FloatingPoint` type was encountered that did not have a specific implementation of the function.
