### PR TITLE
RFC: Make )x call methods(x) at repl

### DIFF
--- a/base/help.jl
+++ b/base/help.jl
@@ -1,6 +1,6 @@
 module Help
 
-export help, apropos, @help
+export help, apropos, @help, @methods
 
 CATEGORY_LIST = nothing
 CATEGORY_DICT = nothing
@@ -223,6 +223,14 @@ macro help(ex)
     elseif ex.head == :macrocall && length(ex.args) == 1
         # e.g., "julia> @help @printf"
         return Expr(:call, :help, string(ex.args[1]))
+    else
+        return Expr(:macrocall, symbol("@which"), esc(ex))
+    end
+end
+
+macro methods(ex)
+    if !isa(ex, Expr) || isname(ex)
+        return Expr(:call, :methods, esc(ex))
     else
         return Expr(:macrocall, symbol("@which"), esc(ex))
     end

--- a/ui/repl-readline.c
+++ b/ui/repl-readline.c
@@ -188,9 +188,10 @@ static jl_value_t* repl_parse_input_line(char *buf) {
         JL_GC_POP();
         return result;
     }
-    else if (buf[0] == '?') {
+    else if (buf[0] == '?' || buf[0] == ')') {
         char *tmpbuf;
-        asprintf(&tmpbuf, "@Base.help %s", buf+1);
+        asprintf(&tmpbuf, buf[0] == '?' ? "@Base.help %s" :
+                                          "@Base.methods %s", buf+1);
         jl_value_t *v = jl_parse_input_line(tmpbuf);
         free(tmpbuf);
         return v;


### PR DESCRIPTION
I find myself typing `methods` a lot after #4344, but I see the argument for the new behavior, especially in non-command-line environments. This PR makes `)` a shortcut for `methods` in the REPL, just as `?` is a shortcut for `help`.

I have no particular affinity for `)`. I chose it because it should always be invalid at the start of a block of code and it bears some relationship to a function call.

Over the long term we will want to make sure that all forms of all methods in Base are documented and improve the help mechanism so that packages can tie into it (e.g. as in #1619), at which point this shortcut shouldn't really be necessary. But since this is just repl syntax it shouldn't break anything if we deprecate/remove it at a later date.
