### PR TITLE
Show method table for foo( + tab at repl

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -67,6 +67,22 @@ function repl_hook(input::String)
                 macroexpand(Expr(:macrocall,symbol("@cmd"),input)))
 end
 
+function repl_methods(input::String)
+    tokens = split(input, ".")
+    fn = Main
+    for token in tokens
+        sym = symbol(token)
+        isdefined(fn, sym) || return
+        fn = fn.(sym)
+    end
+    isgeneric(fn) || return
+
+    buf = IOBuffer()
+    show_method_table(buf, methods(fn), -1, false)
+    println(buf)
+    takebuf_string(buf)
+end
+
 display_error(er) = display_error(er, {})
 function display_error(er, bt)
     with_output_color(:red, STDERR) do io

--- a/base/show.jl
+++ b/base/show.jl
@@ -416,11 +416,13 @@ function show(io::IO, m::Method)
     end
 end
 
-function show_method_table(io::IO, mt::MethodTable, max::Int=-1)
+function show_method_table(io::IO, mt::MethodTable, max::Int=-1, header=true)
     name = mt.name
     n = length(mt)
-    m = n==1 ? "method" : "methods"
-    print(io, "# $n $m for generic function \"$name\":")
+    if header
+        m = n==1 ? "method" : "methods"
+        print(io, "# $n $m for generic function \"$name\":")
+    end
     d = mt.defs
     n = rest = 0
     while !is(d,())

--- a/ui/repl-readline.c
+++ b/ui/repl-readline.c
@@ -244,7 +244,6 @@ static int space_callback(int count, int key)
     return 0;
 }
 
-#define MAX_METHODS 100
 int complete_method_table() {
     if (rl_point < 2 || rl_line_buffer[rl_point-1] != '(') return 0;
 
@@ -264,15 +263,20 @@ int complete_method_table() {
 
     if (!jl_is_byte_string(result)) return 0;
     char *completions = jl_string_data(result);
-    char *methods[MAX_METHODS+1];
 
+    int nallocmethods = 0;
+    size_t nchars = strlen(completions);
+    for (size_t i=0; i<nchars; i++) nallocmethods += completions[i] == '\n';
+
+    char **methods = malloc(sizeof(char *)*(nallocmethods+1));
     methods[0] = NULL;
     methods[1] = strtok_r(completions, "\n", &strtok_saveptr);
     if (methods[1] == NULL) return 0;
     int maxlen = strlen(methods[1]);
     int nmethods = 1;
+
     char *method;
-    while (nmethods < MAX_METHODS &&
+    while (nmethods < nallocmethods &&
            (method = strtok_r(NULL, "\n", &strtok_saveptr))) {
         int len = strlen(method);
         if (len > maxlen) maxlen = len;
@@ -281,6 +285,7 @@ int complete_method_table() {
     }
 
     rl_display_match_list(methods, nmethods, maxlen);
+    free(methods);
     rl_forced_update_display();
     return 1;
 }

--- a/ui/repl-readline.c
+++ b/ui/repl-readline.c
@@ -263,7 +263,7 @@ int complete_method_table() {
             tokenstart--;
         }
         tokenstart++;
-        // ! can't be the first character of a function, unless is not the only
+        // ! can't be the first character of a function, unless is's the only
         if (tokenstart != rl_point-2 && rl_line_buffer[tokenstart] == '!'){
             tokenstart ++;
         }

--- a/ui/repl-readline.c
+++ b/ui/repl-readline.c
@@ -631,10 +631,13 @@ static char **julia_completion(const char *text, int start, int end)
         // is a word break character, so to complete method tables we
         // extract the token preceding the (
         int tokenstart = end-2;
-        while (tokenstart>=0 && jl_word_char(rl_line_buffer[tokenstart])) {
+
+        while (tokenstart>=0 && (jl_word_char(rl_line_buffer[tokenstart]) ||
+                                 rl_line_buffer[tokenstart] == '!')) {
             tokenstart--;
         }
         tokenstart++;
+        tokenstart += rl_line_buffer[tokenstart] == '!';
 
         int tokenlen = end-tokenstart;
         char *token = malloc(tokenlen+1);

--- a/ui/repl-readline.c
+++ b/ui/repl-readline.c
@@ -250,12 +250,21 @@ int complete_method_table() {
     // extract the token preceding the (
     int tokenstart = rl_point-2;
 
-    while (tokenstart>=0 && (jl_word_char(rl_line_buffer[tokenstart]) ||
-           rl_line_buffer[tokenstart] == '!')) {
-        tokenstart--;
+    // check for special operators
+    if (strchr("\\><=|&+-*/%^~!", rl_line_buffer[tokenstart])){
+        while (tokenstart>0 && strchr("<>=!", rl_line_buffer[tokenstart-1])){
+            tokenstart--;
+        }
     }
-    tokenstart++;
-    tokenstart += rl_line_buffer[tokenstart] == '!';
+    else{
+        // check for functions that might contain ! but not start with !
+        while (tokenstart>=0 && (jl_word_char(rl_line_buffer[tokenstart]) ||
+              rl_line_buffer[tokenstart] == '!')) {
+            tokenstart--;
+        }
+        tokenstart++;
+        tokenstart += rl_line_buffer[tokenstart] == '!';
+    }
 
     jl_value_t* result = call_jl_function_with_string("repl_methods",
                                                       &rl_line_buffer[tokenstart],

--- a/ui/repl-readline.c
+++ b/ui/repl-readline.c
@@ -263,7 +263,7 @@ int complete_method_table() {
             tokenstart--;
         }
         tokenstart++;
-        // ! can't be the first character of a function, unless is's the only
+        // ! can't be the first character of a function, unless it's the only character
         if (tokenstart != rl_point-2 && rl_line_buffer[tokenstart] == '!'){
             tokenstart ++;
         }

--- a/ui/repl-readline.c
+++ b/ui/repl-readline.c
@@ -251,7 +251,7 @@ int complete_method_table() {
     int tokenstart = rl_point-2;
 
     // check for special operators
-    if (strchr("\\><=|&+-*/%^~!", rl_line_buffer[tokenstart])){
+    if (strchr("\\><=|&+-*/%^~", rl_line_buffer[tokenstart])){
         while (tokenstart>0 && strchr("<>=!", rl_line_buffer[tokenstart-1])){
             tokenstart--;
         }
@@ -263,7 +263,10 @@ int complete_method_table() {
             tokenstart--;
         }
         tokenstart++;
-        tokenstart += rl_line_buffer[tokenstart] == '!';
+        // ! can't be the first character of a function, unless is not the only
+        if (tokenstart != rl_point-2 && rl_line_buffer[tokenstart] == '!'){
+            tokenstart ++;
+        }
     }
 
     jl_value_t* result = call_jl_function_with_string("repl_methods",


### PR DESCRIPTION
``` julia
julia> print(\t
print(io::IO,b::BigFloat) at mpfr.jl:709                      print(io::IO,s::UTF8String) at utf8.jl:138
print(io::IOBuffer,s::SubString{T<:String}) at string.jl:617  print(io::IO,v::VersionNumber) at version.jl:42
print(io::IO,c::Char) at char.jl:56                           print(io::IO,X::AbstractArray{T,N}) at show.jl:895
print(io::IO,ip::IPv4) at socket.jl:30                        print(io::IO,x) at string.jl:3
print(io::IO,ip::IPv6) at socket.jl:85                        print(io::IO,x::Float16) at grisu.jl:119
print(io::IO,n::Unsigned) at show.jl:92                       print(io::IO,x::Float32) at grisu.jl:118
print(io::IO,s::ASCIIString) at ascii.jl:88                   print(io::IO,xs...) at string.jl:4
print(io::IO,s::RopeString) at string.jl:765                  print{mime}(io::IO,::MIME{mime}) at multimedia.jl:17
print(io::IO,s::String) at string.jl:66                       print(xs...) at string.jl:7
print(io::IO,s::Symbol) at show.jl:4
```

This supersedes #4357.
