### PR TITLE
RFC: change mimewritable to take instance rather than type

### DIFF
--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -34,12 +34,12 @@ end
 # For any type T one can define writemime(io, ::MIME"type", x::T) = ...
 # in order to provide a way to export T as a given mime type.
 
-mimewritable{mime}(::MIME{mime}, T::Type) =
-  method_exists(writemime, (IO, MIME{mime}, T))
+mimewritable{mime}(::MIME{mime}, x) =
+  method_exists(writemime, (IO, MIME{mime}, typeof(x)))
 
 # it is convenient to accept strings instead of ::MIME
 writemime(io, m::String, x) = writemime(io, MIME(m), x)
-mimewritable(m::String, T::Type) = mimewritable(MIME(m), T)
+mimewritable(m::String, x) = mimewritable(MIME(m), x)
 
 ###########################################################################
 # MIME types are assumed to be binary data except for a set of types known

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1679,12 +1679,12 @@ Julia environments (such as the IPython-based IJulia notebook).
    dispatch mechanisms in determining how to display objects of any
    given type.
 
-.. function:: mimewritable(mime, T::Type)
+.. function:: mimewritable(mime, x)
 
-   Returns a boolean value indicating whether or not objects of type
-   ``T`` can be written as the given ``mime`` type.  (By default, this
+   Returns a boolean value indicating whether or not the object ``x``
+   can be written as the given ``mime`` type.  (By default, this
    is determined automatically by the existence of the corresponding
-   ``writemime`` function.)
+   ``writemime`` function for ``typeof(x)``.)
 
 .. function:: reprmime(mime, x)
 


### PR DESCRIPTION
This patch changes the `mimewritable` function to be called as `mimewritable(mime, x)` rather than `mimewritable(mime, typeof(x))`, i.e. to accept an instance rather than a type.  This makes it much more flexible, because not all instances of a given type may be writable to the same MIME types.

The necessity for this patch arose in stevengj/PyCall.jl#43, because not all `PyObject` instances will implement the [IPython display API](http://nbviewer.ipython.org/url/github.com/ipython/ipython/raw/master/examples/notebooks/Custom%20Display%20Logic.ipynb), and even those that do will sometimes support different MIME types depending on the instance (e.g. for `IPython.display.Image` instances it depends on the image source).

This breaks backwards compatibility.  However, as far as I can tell, the only package currently using `mimewritable` is IJulia, and I've [patched IJulia](https://github.com/JuliaLang/IJulia.jl/commit/2c9b31731a44e08d4a9d67c8506a8cc7a147491e) to work with both versions of the API.
