### PR TITLE
Change ’ into '

### DIFF
--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -43,7 +43,7 @@ The library, largely written in Julia itself, also integrates mature,
 best-of-breed C and Fortran libraries for linear algebra,
 random number generation, signal processing, and string processing.
 In addition, the Julia developer community is contributing a number of
-external packages through Julia’s built-in package manager at a rapid pace.
+external packages through Julia's built-in package manager at a rapid pace.
 Julia programs are organized around multiple dispatch;
 by defining functions and overloading them for different combinations
 of argument types, which can also be user-defined.


### PR DESCRIPTION
In my system (Ubuntu 12.04) "Julia’s" renders as "Juliaâs" using `nroff -man julia.1 | less`
