### PR TITLE
Fix Permutation's `next` function to work with Filter

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -236,6 +236,7 @@ function next(p::Permutations, s)
         # special case to generate 1 result for len==0
         return (p.a,[1])
     end
+    s = copy(s)
     perm = p.a[s]
     k = length(s)-1
     while k > 0 && s[k] > s[k+1];  k -= 1;  end

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -6,6 +6,8 @@ a = randcycle(10)
 @test ipermute!(permute!([1:10], a),a) == [1:10]
 @test collect(combinations("abc",2)) == ["ab","ac","bc"]
 @test collect(permutations("abc")) == ["abc","acb","bac","bca","cab","cba"]
+@test collect(filter(x->(iseven(x[1])),permutations([1,2,3]))) == {[2,1,3],[2,3,1]}
+@test collect(filter(x->(iseven(x[3])),permutations([1,2,3]))) == {[1,3,2],[3,1,2]}
 @test collect(partitions(4)) ==  {[4], [3,1], [2,2], [2,1,1], [1,1,1,1]}
 @test collect(partitions(8,3)) == {[6,1,1], [5,2,1], [4,3,1], [4,2,2], [3,3,2]}
 @test collect(partitions([1,2,3])) == {{[1,2,3]}, {[1,2],[3]}, {[1,3],[2]}, {[1],[2,3]}, {[1],[2],[3]}}


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/issues/4381

Filter does not work properly with Permutation because the `next` function modifies its arguments.
Adding a call to `copy` fixes this by not modifying the second argument.
