### PR TITLE
Infer element type for general multi-dimensional getindex

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -361,7 +361,7 @@ global getindex
 function getindex(A::Array, I::Union(Real,AbstractVector)...)
     checkbounds(A, I...)
     I = indices(I)
-    X = similar(A, index_shape(I...))
+    X = similar(A, eltype(A), index_shape(I...))
 
     if is(getindex_cache,nothing)
         getindex_cache = Dict()


### PR DESCRIPTION
For `getindex(A::Array, I::Union(Real,AbstractVector)...)` Julia can't infer the return type of `index_shape`, which means it can't infer whether this code will call `similar(a::AbstractArray{T,N},T)` or `similar{T}(a::AbstractArray{T,N},dims::(Int64...,))`, which means it can't infer the element type of the array that `getindex` returns, which is bad. This patch works around this by explicitly specifying the element type in the call to `similar`. It would be better if we could infer the dimensionality as well, but that seems harder.
