### PR TITLE
Infer return type for permutedims

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -2009,7 +2009,8 @@ global permutedims
 function permutedims(B::Union(BitArray,StridedArray), perm)
     dimsB = size(B)
     ndimsB = length(dimsB)
-    dimsP = ntuple(ndimsB, i->dimsB[perm[i]])
+    ndimsB == length(perm) || error("permutedims: invalid dimensions")
+    dimsP = ntuple(ndimsB, i->dimsB[perm[i]])::typeof(dimsB)
     P = similar(B, dimsP)
     ranges = ntuple(ndimsB, i->(1:dimsP[i]))
     while length(stridenames) < ndimsB

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -213,6 +213,8 @@ const typeof_tfunc = function (t)
         else
             Type{typeof(t)}
         end
+    elseif isvarargtype(t)
+        Vararg{typeof_tfunc(t.parameters[1])}
     elseif isa(t,DataType)
         if isleaftype(t)
             Type{t}


### PR DESCRIPTION
This is the same kind of issue as #4387, but in this case we should be able to statically infer the return type of the array (at least as long as we don't care to make `permutedims([1, 2], [2, 1])` work, but this currently throws anyhow).

Unfortunately this revealed a bug in type inference, which statically infers `typeof(dimsB)` for BitArrays and SubArrays as of type

``` julia
(Type{TypeVar(:_,Vararg{Int})},)
```

which leads to the wrong `similar` method getting selected and inlined. I changed inference.jl to infer this as `(Vararg{Type{Int}},)` which works, but Vararg types give me the creeps and I'm not sure this is a complete solution.
