### PR TITLE
Fix #4412

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -377,7 +377,7 @@ function setindex!(s::SubArray, v, I::Union(Real,AbstractArray)...)
     setindex!(s.parent, v, newindexes...)
 end
 
-stride(s::SubArray, i::Integer) = s.strides[i]
+stride(s::SubArray, i::Integer) = i <= length(s.strides) ? s.strides[i] : s.strides[end]*s.dims[end]
 
 convert{T}(::Type{Ptr{T}}, x::SubArray{T}) =
     pointer(x.parent) + (x.first_index-1)*sizeof(T)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -103,6 +103,8 @@ sA[2:5:end] = -1
 @test all(sA[2:5:end] .== -1)
 @test all(A[5:15:120] .== -1)
 @test strides(sA) == (1,3,15)
+@test stride(sA,3) == 15
+@test stride(sA,4) == 120
 sA = sub(A, 1:3, 1:5, 5)
 @test Base.parentdims(sA) == 1:2
 sA[1:3,1:5] = -2


### PR DESCRIPTION
Makes `SubArray` `stride()` work like `Array`'s.
