### PR TITLE
isperm without determining the inverse permutation

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -125,9 +125,13 @@ function invperm(a::AbstractVector)
     return b
 end
 
-function isperm(a::AbstractVector)
-    b = _invperm(a)
-    return isempty(b) || b[1]!=0
+function isperm(A::AbstractVector)
+    n = length(A)
+    used = falses(n)
+    for a in A
+        (0 < a <= n) && (used[a] $= true) || return false
+    end
+    true
 end
 
 function permute!!(a, p::AbstractVector{Int})

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -102,27 +102,16 @@ function nthperm!(a::AbstractVector, k::Integer)
 end
 nthperm(a::AbstractVector, k::Integer) = nthperm!(copy(a),k)
 
-# invert a permutation
-function _invperm(a::AbstractVector)
+function invperm(a::AbstractVector)
     b = zero(a) # similar vector of zeros
     n = length(a)
     for i = 1:n
         j = a[i]
-        if !(1 <= j <= n) || b[j] != 0
-            b[1] = 0
-            break
-        end
+        ((1 <= j <= n) && b[j] == 0) ||
+            error("invperm: input is not a permutation")
         b[j] = i
     end
-    return b
-end
-
-function invperm(a::AbstractVector)
-    b = _invperm(a)
-    if !isempty(b) && b[1] == 0
-        error("invperm: input is not a permutation")
-    end
-    return b
+    b
 end
 
 function isperm(A::AbstractVector)

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -1,7 +1,11 @@
 @test factorial(7) == 5040
 @test factorial(7,3) == 7*6*5*4
 @test binomial(5,3) == 10
-@test isperm(shuffle([1:1000]))
+p = shuffle([1:1000])
+@test isperm(p)
+@test all(invperm(invperm(p)) .== p)
+push!(p, 1)
+@test !isperm(p)
 a = randcycle(10)
 @test ipermute!(permute!([1:10], a),a) == [1:10]
 @test collect(combinations("abc",2)) == ["ab","ac","bc"]


### PR DESCRIPTION
Stefan and I had written `isperm` by checking that the inverse permutation exists.  To do that we needed to extract the guts of `invperm` into `_invperm`.  Here I modify `isperm` to use a `BitVector` that records the values that have been seen while iterating over the elements of the argument.  On very large vectors it can be a bit faster than evaluating the inverse permutation, and it requires less storage.

The second commit folds the `_invperm` code back into `invperm` and adds some tests.
