### PR TITLE
Add OS-based dependency specification to Pkg

### DIFF
--- a/base/pkg/reqs.jl
+++ b/base/pkg/reqs.jl
@@ -37,11 +37,25 @@ end
 
 # general machinery for parsing REQUIRE files
 
+function parse_line(line::String)
+    if ismatch(r"^\s*(?:#|$)", line)
+        return Comment(line)
+    elseif beginswith(line, "@")
+        os,req = match(r"@(windows|osx|linux)\s*(.*)", line).captures
+        @windows ? (if (os == "windows") return Requirement(req) end) : nothing
+        @osx     ? (if (os == "osx")     return Requirement(req) end) : nothing
+        @linux   ? (if (os == "linux")   return Requirement(req) end) : nothing
+        return Comment(line)
+    else
+        return Requirement(line)
+    end
+end
+
 function read(readable::Union(IO,Base.AbstractCmd))
     lines = Line[]
     for line in eachline(readable)
         line = chomp(line)
-        push!(lines, ismatch(r"^\s*(?:#|$)", line) ? Comment(line) : Requirement(line))
+        push!(lines, parse_line(line))
     end
     return lines
 end


### PR DESCRIPTION
Here is a "simplest thing that might work" attempt to fix https://github.com/JuliaLang/julia/issues/4323

With this patch, OS-specific dependencies are specified in `requires` as:

```
@windows RPMmd
@linux APT
@osx Homebrew
```

Tested on linux and Windows with this [bogus METADATA](https://github.com/ihnorton/METADATA.jl/commit/af9698be18b5189decdf819ab9fbd1fec30eb1b4). Matched-platform requirement works; unmatched-platform requirement is ignored and doesn't seem to break anything.

cc: @StefanKarpinski
