### PR TITLE
Change lu to return permutation vector instead of permutation matrix.

### DIFF
--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -142,7 +142,7 @@ lufact(x::Number) = LU(fill(x, 1, 1), [1], x == 0 ? 1 : 0)
 
 function lu(A::Union(Number, AbstractMatrix))
     F = lufact(A)
-    return (F[:L], F[:U], F[:P])
+    return (F[:L], F[:U], F[:p])
 end
 
 size(A::LU) = size(A.factors)

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -43,9 +43,9 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    ``factorize!`` is the same as :func:`factorize`, but saves space by overwriting the input A, instead of creating a copy.
 
-.. function:: lu(A) -> L, U, P
+.. function:: lu(A) -> L, U, p
 
-   Compute the LU factorization of ``A``, such that ``P*A = L*U``.
+   Compute the LU factorization of ``A``, such that ``A[p,:] = L*U``.
 
 .. function:: lufact(A) -> LU
 


### PR DESCRIPTION
The permutation matrix can be expensive to construct. This is also in line with svd returning the singular values in a vector. Finally, this change makes lu work for sparse matrices.
