### PR TITLE
Faster linear indexing for SubArrays, dims 1-5

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -203,10 +203,53 @@ getindex(s::SubArray, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real
 getindex(s::SubArray, i::Integer) = s[ind2sub(size(s), i)...]
 
 function getindex{T}(s::SubArray{T,2}, ind::Integer)
-    ld = size(s,1)
-    i = rem(ind-1,ld)+1
-    j = div(ind-1,ld)+1
-    s.parent[s.first_index + (i-1)*s.strides[1] + (j-1)*s.strides[2]]
+    strd2 = size(s,1)
+    ind -= 1
+    i2 = div(ind,strd2)
+    i1 = ind-i2*strd2
+    s.parent[s.first_index + i1*s.strides[1] + i2*s.strides[2]]
+end
+
+function getindex{T}(s::SubArray{T,3}, ind::Integer)
+    strd2 = size(s,1)
+    strd3 = strd2*size(s,2)
+    ind -= 1
+    i3 = div(ind,strd3)
+    ind -= i3*strd3
+    i2 = div(ind,strd2)
+    i1 = ind-i2*strd2
+    s.parent[s.first_index + i1*s.strides[1] + i2*s.strides[2] + i3*s.strides[3]]
+end
+
+function getindex{T}(s::SubArray{T,4}, ind::Integer)
+    strd2 = size(s,1)
+    strd3 = strd2*size(s,2)
+    strd4 = strd3*size(s,3)
+    ind -= 1
+    i4 = div(ind,strd4)
+    ind -= i4*strd4
+    i3 = div(ind,strd3)
+    ind -= i3*strd3
+    i2 = div(ind,strd2)
+    i1 = ind-i2*strd2
+    s.parent[s.first_index + i1*s.strides[1] + i2*s.strides[2] + i3*s.strides[3] + i4*s.strides[4]]
+end
+
+function getindex{T}(s::SubArray{T,5}, ind::Integer)
+    strd2 = size(s,1)
+    strd3 = strd2*size(s,2)
+    strd4 = strd3*size(s,3)
+    strd5 = strd4*size(s,4)
+    ind -= 1
+    i5 = div(ind,strd5)
+    ind -= i5*strd5
+    i4 = div(ind,strd4)
+    ind -= i4*strd4
+    i3 = div(ind,strd3)
+    ind -= i3*strd3
+    i2 = div(ind,strd2)
+    i1 = ind-i2*strd2
+    s.parent[s.first_index + i1*s.strides[1] + i2*s.strides[2] + i3*s.strides[3] + i4*s.strides[4] + i5*s.strides[5]]
 end
 
 function getindex(s::SubArray, is::Integer...)
@@ -317,11 +360,57 @@ end
 setindex!(s::SubArray, v, i::Integer) = setindex!(s, v, ind2sub(size(s), i)...)
 
 function setindex!{T}(s::SubArray{T,2}, v, ind::Integer)
-    ld = size(s,1)
-    i = rem(ind-1,ld)+1
-    j = div(ind-1,ld)+1
-    s.parent[s.first_index + (i-1)*s.strides[1] + (j-1)*s.strides[2]] = v
-    return s
+    strd2 = size(s,1)
+    ind -= 1
+    i2 = div(ind,strd2)
+    i1 = ind-i2*strd2
+    s.parent[s.first_index + i1*s.strides[1] + i2*s.strides[2]] = v
+    s
+end
+
+function setindex!{T}(s::SubArray{T,3}, v, ind::Integer)
+    strd2 = size(s,1)
+    strd3 = strd2*size(s,2)
+    ind -= 1
+    i3 = div(ind,strd3)
+    ind -= i3*strd3
+    i2 = div(ind,strd2)
+    i1 = ind-i2*strd2
+    s.parent[s.first_index + i1*s.strides[1] + i2*s.strides[2] + i3*s.strides[3]] = v
+    s
+end
+
+function setindex!{T}(s::SubArray{T,4}, v, ind::Integer)
+    strd2 = size(s,1)
+    strd3 = strd2*size(s,2)
+    strd4 = strd3*size(s,3)
+    ind -= 1
+    i4 = div(ind,strd4)
+    ind -= i4*strd4
+    i3 = div(ind,strd3)
+    ind -= i3*strd3
+    i2 = div(ind,strd2)
+    i1 = ind-i2*strd2
+    s.parent[s.first_index + i1*s.strides[1] + i2*s.strides[2] + i3*s.strides[3] + i4*s.strides[4]] = v
+    s
+end
+
+function setindex!{T}(s::SubArray{T,5}, v, ind::Integer)
+    strd2 = size(s,1)
+    strd3 = strd2*size(s,2)
+    strd4 = strd3*size(s,3)
+    strd5 = strd4*size(s,4)
+    ind -= 1
+    i5 = div(ind,strd5)
+    ind -= i5*strd5
+    i4 = div(ind,strd4)
+    ind -= i4*strd4
+    i3 = div(ind,strd3)
+    ind -= i3*strd3
+    i2 = div(ind,strd2)
+    i1 = ind-i2*strd2
+    s.parent[s.first_index + i1*s.strides[1] + i2*s.strides[2] + i3*s.strides[3] + i4*s.strides[4] + i5*s.strides[5]] = v
+    s
 end
 
 function setindex!(s::SubArray, v, is::Integer...)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -203,7 +203,7 @@ getindex(s::SubArray, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real
 getindex(s::SubArray, i::Integer) = s[ind2sub(size(s), i)...]
 
 function getindex{T}(s::SubArray{T,2}, ind::Integer)
-    strd2 = size(s,1)
+    @inbounds strd2 = s.dims[1]
     ind -= 1
     i2 = div(ind,strd2)
     i1 = ind-i2*strd2
@@ -211,8 +211,8 @@ function getindex{T}(s::SubArray{T,2}, ind::Integer)
 end
 
 function getindex{T}(s::SubArray{T,3}, ind::Integer)
-    strd2 = size(s,1)
-    strd3 = strd2*size(s,2)
+    @inbounds strd2 = s.dims[1]
+    @inbounds strd3 = strd2*s.dims[2]
     ind -= 1
     i3 = div(ind,strd3)
     ind -= i3*strd3
@@ -222,9 +222,9 @@ function getindex{T}(s::SubArray{T,3}, ind::Integer)
 end
 
 function getindex{T}(s::SubArray{T,4}, ind::Integer)
-    strd2 = size(s,1)
-    strd3 = strd2*size(s,2)
-    strd4 = strd3*size(s,3)
+    @inbounds strd2 = s.dims[1]
+    @inbounds strd3 = strd2*s.dims[2]
+    @inbounds strd4 = strd3*s.dims[3]
     ind -= 1
     i4 = div(ind,strd4)
     ind -= i4*strd4
@@ -236,10 +236,10 @@ function getindex{T}(s::SubArray{T,4}, ind::Integer)
 end
 
 function getindex{T}(s::SubArray{T,5}, ind::Integer)
-    strd2 = size(s,1)
-    strd3 = strd2*size(s,2)
-    strd4 = strd3*size(s,3)
-    strd5 = strd4*size(s,4)
+    @inbounds strd2 = s.dims[1]
+    @inbounds strd3 = strd2*s.dims[2]
+    @inbounds strd4 = strd3*s.dims[3]
+    @inbounds strd5 = strd4*s.dims[4]
     ind -= 1
     i5 = div(ind,strd5)
     ind -= i5*strd5
@@ -360,7 +360,7 @@ end
 setindex!(s::SubArray, v, i::Integer) = setindex!(s, v, ind2sub(size(s), i)...)
 
 function setindex!{T}(s::SubArray{T,2}, v, ind::Integer)
-    strd2 = size(s,1)
+    @inbounds strd2 = s.dims[1]
     ind -= 1
     i2 = div(ind,strd2)
     i1 = ind-i2*strd2
@@ -369,8 +369,8 @@ function setindex!{T}(s::SubArray{T,2}, v, ind::Integer)
 end
 
 function setindex!{T}(s::SubArray{T,3}, v, ind::Integer)
-    strd2 = size(s,1)
-    strd3 = strd2*size(s,2)
+    @inbounds strd2 = s.dims[1]
+    @inbounds strd3 = strd2*s.dims[2]
     ind -= 1
     i3 = div(ind,strd3)
     ind -= i3*strd3
@@ -381,9 +381,9 @@ function setindex!{T}(s::SubArray{T,3}, v, ind::Integer)
 end
 
 function setindex!{T}(s::SubArray{T,4}, v, ind::Integer)
-    strd2 = size(s,1)
-    strd3 = strd2*size(s,2)
-    strd4 = strd3*size(s,3)
+    @inbounds strd2 = s.dims[1]
+    @inbounds strd3 = strd2*s.dims[2]
+    @inbounds strd4 = strd3*s.dims[3]
     ind -= 1
     i4 = div(ind,strd4)
     ind -= i4*strd4
@@ -396,10 +396,10 @@ function setindex!{T}(s::SubArray{T,4}, v, ind::Integer)
 end
 
 function setindex!{T}(s::SubArray{T,5}, v, ind::Integer)
-    strd2 = size(s,1)
-    strd3 = strd2*size(s,2)
-    strd4 = strd3*size(s,3)
-    strd5 = strd4*size(s,4)
+    @inbounds strd2 = s.dims[1]
+    @inbounds strd3 = strd2*s.dims[2]
+    @inbounds strd4 = strd3*s.dims[3]
+    @inbounds strd5 = strd4*s.dims[4]
     ind -= 1
     i5 = div(ind,strd5)
     ind -= i5*strd5


### PR DESCRIPTION
Since many of the algorithms in base working on `AbstractArray`s use linear indexing, it seemed reasonable to write hand-tuned linear-indexing for the most commonly-used dimensions. This is still much slower than cartesian indexing, but a big improvement over what we have now. In 5 dimensions the improvement is something like 40-fold, as shown below.

Test script:

```
function linearfill!(A::AbstractArray)
    for i = 1:length(A)
        A[i] = i
    end
    A
end

A2 = zeros(1000,1000)
B2 = sub(A2, :, :)
linearfill!(A2)
print("Array 2d: ")
@time linearfill!(A2)
Ac = copy(A2)
linearfill!(B2)
print("SubArray 2d: ")
@time linearfill!(B2)
@assert A2 == Ac

...
```

and so forth up through 5 dimensions (always with `10^6` total elements).

Before this patch:

```
julia> include("/tmp/test_linear.jl")
Array 2d: elapsed time: 0.001823028 seconds (48 bytes allocated)
SubArray 2d: elapsed time: 0.025735556 seconds (64 bytes allocated)
Array 3d: elapsed time: 0.001867426 seconds (48 bytes allocated)
SubArray 3d: elapsed time: 0.372512698 seconds (103983712 bytes allocated)
Array 4d: elapsed time: 0.002026042 seconds (48 bytes allocated)
SubArray 4d: elapsed time: 2.425155532 seconds (521105744 bytes allocated)
Array 5d: elapsed time: 0.001645669 seconds (48 bytes allocated)
SubArray 5d: elapsed time: 3.028932076 seconds (662305792 bytes allocated)
```

In 5d, it's approximately 2000-fold slower to use a `SubArray`.

With this patch:

```
julia> include("/tmp/test_linear.jl")
Array 2d: elapsed time: 0.00195559 seconds (6896 bytes allocated)
SubArray 2d: elapsed time: 0.027324321 seconds (64 bytes allocated)
Array 3d: elapsed time: 0.001553236 seconds (48 bytes allocated)
SubArray 3d: elapsed time: 0.047140215 seconds (64 bytes allocated)
Array 4d: elapsed time: 0.001706639 seconds (48 bytes allocated)
SubArray 4d: elapsed time: 0.064958196 seconds (64 bytes allocated)
Array 5d: elapsed time: 0.001624899 seconds (48 bytes allocated)
SubArray 5d: elapsed time: 0.086291385 seconds (112 bytes allocated)
```

Now in 5d it's a mere 50-fold slower to use a `SubArray`. The main remaining issue is that `div` is approximately ten-fold more expensive than `*` and `/`.
