### PR TITLE
Added ::IO type specifier on writemime methods in repl.jl

### DIFF
--- a/base/repl.jl
+++ b/base/repl.jl
@@ -1,7 +1,7 @@
 # fallback text/plain representation of any type:
 writemime(io, ::MIME"text/plain", x) = showlimited(io, x)
 
-function writemime(io, ::MIME"text/plain", f::Function)
+function writemime(io::IO, ::MIME"text/plain", f::Function)
     if isgeneric(f)
         n = length(f.env)
         m = n==1 ? "method" : "methods"
@@ -11,7 +11,7 @@ function writemime(io, ::MIME"text/plain", f::Function)
     end
 end
 
-function writemime(io, ::MIME"text/plain", v::AbstractVector)
+function writemime(io::IO, ::MIME"text/plain", v::AbstractVector)
     if isa(v, Ranges)
         show(io, v)
     else
@@ -23,7 +23,7 @@ function writemime(io, ::MIME"text/plain", v::AbstractVector)
     end
 end
 
-function writemime(io, ::MIME"text/plain", v::DataType)
+function writemime(io::IO, ::MIME"text/plain", v::DataType)
     show(io, v)
     methods(v) # force constructor creation
     if isgeneric(v)


### PR DESCRIPTION
I noticed that the `writemime` methods in repl.jl apparently doesn't use the correct interface, because it does not specify that `io` must be of type `IO`

``` julia
# Changed
function writemime(io, ::MIME"text/plain", f::Function)
# To
function writemime(io::IO, ::MIME"text/plain", f::Function)
```
