### PR TITLE
Somewhat corrected handling of () and {} in type syntax highlighting in textmate bundle

### DIFF
--- a/contrib/Julia.tmbundle/Syntaxes/Julia.tmLanguage
+++ b/contrib/Julia.tmbundle/Syntaxes/Julia.tmLanguage
@@ -529,7 +529,7 @@
 					<key>comments</key>
 					<string>Matches a typed variable, such as 'id::String'</string>
 					<key>match</key>
-					<string>([a-zA-Z0-9_]+)(::[a-zA-Z0-9_{}]+)</string>
+					<string>([a-zA-Z0-9_]+)(::([a-zA-Z0-9_]+|\(.*\))(\{.*\})?)</string>
 					<key>name</key>
 					<string>other.typed-variable.julia</string>
 				</dict>


### PR DESCRIPTION
Before, expressions like x::Array{(Int, Int), 2} or x::(Int, Int) were not being parsed correctly by the textmate grammar. 
