### PR TITLE
RFC: Document and export alloc_request(), notify_filled().

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1010,6 +1010,7 @@ export
     parseip,
 
 # I/O and events
+    alloc_request,
     accept,
     close,
     connect,
@@ -1036,6 +1037,7 @@ export
     mmap_bitarray,
     msync,
     nb_available,
+    notify_filled,
     ntoh,
     open,
     PipeBuffer,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1142,6 +1142,17 @@ I/O
 
    Obtain the contents of an ``IOBuffer`` as a string, without copying.
 
+.. function:: alloc_request(b::IOBuffer, size)
+
+   Request a block of memory at the end of an ``IOBuffer``.
+   Allows external functions to write data directly to the buffer, and then call ``notify_filled()``.
+   Returns a tuple containing a pointer to the block and the actual size available.
+
+.. function:: notify_filled(b::IOBuffer, nbytes)
+
+   Notify an ``IOBuffer`` that it has been extended and filled with ``nbytes`` of data by an external function.  
+   Called after an ``alloc_reqest()``.
+
 .. function:: fdio([name::String, ]fd::Integer[, own::Bool]) -> IOStream
 
    Create an ``IOStream`` object from an integer file descriptor. If ``own`` is true, closing this object will close the underlying descriptor. By default, an ``IOStream`` is closed when it is garbage collected. ``name`` allows you to associate the descriptor with a named file.


### PR DESCRIPTION
These are currently used by libuv to get a pointer to a block of memory to fill, and then update the IOBuffer info.

Zlib.jl currently uses IOBuffers in a similar manner, but copies the data twice.  It would be nice if it could use this mechanism, and an exported interface is less likely to break/change than a non-exported one.

Also slightly updated the call signature of notify_filled() to be more friendly to external users, minimally affecting libuv use.
