### PR TITLE
Added an offset to search(io::IOBuffer, delim, offset), so that

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -236,9 +236,10 @@ end
 readbytes(io::IOBuffer) = read(io, Array(Uint8, nb_available(io)))
 readbytes(io::IOBuffer, nb) = read(io, Array(Uint8, min(nb, nb_available(io))))
 
-function search(buf::IOBuffer, delim)
-    p = pointer(buf.data, buf.ptr)
-    q = ccall(:memchr,Ptr{Uint8},(Ptr{Uint8},Int32,Csize_t),p,delim,nb_available(buf))
+function search(buf::IOBuffer, delim, offset=0)
+    offset = min(offset, nb_available(buf))
+    p = pointer(buf.data, buf.ptr+offset)
+    q = ccall(:memchr,Ptr{Uint8},(Ptr{Uint8},Int32,Csize_t),p,delim,nb_available(buf)-offset)
     nb = (q == C_NULL ? 0 : q-p+1)
 end
 function readuntil(io::IOBuffer, delim::Uint8)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -264,7 +264,9 @@ function wait_connected(x)
 end
 
 function wait_readbyte(x::AsyncStream, c::Uint8)
-    while isopen(x) && search(x.buffer,c) <= 0
+    nb = 0
+    while isopen(x) && search(x.buffer,c,nb) <= 0
+        nb = nb_available(x.buffer)
         start_reading(x)
         wait(x.readnotify)
     end


### PR DESCRIPTION
the search can pick up after the buffer is filled further.

One use case was changed to use this.  Other uses exist outside of Base.
