### PR TITLE
Fix pisum and mandelbrot microbenchmarks

### DIFF
--- a/test/perf/micro/perf.c
+++ b/test/perf/micro/perf.c
@@ -56,16 +56,15 @@ double *matmul_aat(int n, double *b) {
 }
 
 int mandel(double complex z) {
-    int n = 0;
+    int maxiter = 80;
     double complex c = z;
-    for (n=0; n<=79; ++n) {
+    for (int n=0; n<maxiter; ++n) {
         if (cabs(z) > 2.0) {
-            n -= 1;
-            break;
+            return n;
         }
         z = cpow(z,2)+c;
     }
-    return n+1;
+    return maxiter;
 }
 
 int mandelperf() {

--- a/test/perf/micro/perf.f90
+++ b/test/perf/micro/perf.f90
@@ -181,26 +181,27 @@ end function
 integer function mandel(z0) result(r)
 complex(dp), intent(in) :: z0
 complex(dp) :: c, z
-integer :: n
+integer :: n, maxiter
+maxiter = 80
 z = z0
 c = z0
-do n = 0, 78
+do n = 1, maxiter
     if (abs(z) > 2) then
-        r = n
+        r = n-1
         return
     end if
     z = z**2 + c
 end do
-r = 79
+r = maxiter
 end function
 
 integer function mandelperf() result(mandel_sum)
 real(dp) :: re, im
 mandel_sum = 0
-re = -2
-do while (re < 0.49_dp)
-    im = -1
-    do while (im < 0.99)
+re = -2._dp
+do while (re <= 0.5_dp)
+    im = -1._dp
+    do while (im <= 1._dp)
         mandel_sum = mandel_sum + mandel(cmplx(re, im, dp))
         im = im + 0.1_dp
     end do
@@ -241,9 +242,9 @@ end subroutine
 
 real(dp) function pisum() result(s)
 integer :: j, k
-do j = 1, 499
+do j = 1, 500
     s = 0
-    do k = 1, 9999
+    do k = 1, 10000
         s = s + 1._dp / k**2
     end do
 end do

--- a/test/perf/micro/perf.go
+++ b/test/perf/micro/perf.go
@@ -69,16 +69,15 @@ func randmatmul(n int) matrix.MatrixRO {
 // mandelbrot 
 
 func mandel(z complex128) int {
+	maxiter := 80
 	c := z
-	var n int
-	for n = 0; n < 79; n++ {
+	for n := 0; n < maxiter; n++ {
 		if cmplx.Abs(z) > 2 {
-			n -= 1
-			break
+			return n
 		}
 		z = z*z + c
 	}
-	return n + 1
+	return maxiter
 }
 
 func mandelperf() int {

--- a/test/perf/micro/perf.py
+++ b/test/perf/micro/perf.py
@@ -64,24 +64,24 @@ def randmatmul(n):
 ## mandelbrot ##
 
 def mandel(z):
+    maxiter = 80
     c = z
-    for n in range(0,79):
+    for n in range(maxiter):
         if abs(z) > 2:
-            n -= 1
-            break
+            return n
         z = z*z + c
-    return n + 1
+    return maxiter
 
 def mandelperf():
-    r1 = numpy.arange(-2.0, 0.5, 0.1)
-    r2 = numpy.arange(-1.0, 1.0, 0.1)
+    r1 = numpy.linspace(-2.0, 0.5, 26)
+    r2 = numpy.linspace(-1.0, 1.0, 21)
     return [mandel(complex(r, i)) for r in r1 for i in r2]
 
 def pisum():
     sum = 0.0
-    for j in range(1, 500):
+    for j in range(1, 501):
         sum = 0.0
-        for k in range(1, 10000):
+        for k in range(1, 10001):
             sum += 1.0/(k*k)
     return sum
 
@@ -118,7 +118,7 @@ if __name__=="__main__":
         if t < tmin: tmin = t
     print_perf ("parse_int", tmin)
 
-    assert sum(mandelperf()) == 14304
+    assert sum(mandelperf()) == 14791
     tmin = float('inf')
     for i in range(5):
         t = time.time()


### PR DESCRIPTION
Fixing number of iterations in pisum benchmark for Python and Fortran languages to match Julia version.
Fixing mandelbrot benchmark for Go, Python and Fortran languages.
Cleaning mandelbrot benchmark for C language.
