### PR TITLE
Add new pointer_to_array method for generic Integers, e.g. Cint

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -31,6 +31,7 @@ pointer{T}(x::AbstractArray{T}, i::Int) = convert(Ptr{T},x) + (i-1)*sizeof(T)
 # unsafe pointer to array conversions
 pointer_to_array(p, dims::Dims) = pointer_to_array(p, dims, false)
 pointer_to_array(p, d::Int, own=false) = pointer_to_array(p, (d,), own)
+pointer_to_array(p, d::Integer, own=false) = pointer_to_array(p, (int(d),), own)
 function pointer_to_array{T,N}(p::Ptr{T}, dims::NTuple{N,Int}, own::Bool)
     ccall(:jl_ptr_to_array, Array{T,N}, (Any, Ptr{T}, Any, Int32),
           Array{T,N}, p, dims, own)


### PR DESCRIPTION
This came up while writing a callback for an external solver. The function I was trying to write for the callback looks something like.

``` julia
function eval_f(n::Cint, x_ptr::Ptr{Float64}, user_data::Ptr{Void})
  x = pointer_to_array(x_ptr, n)
  # ... calculate
  return(result)
end
```

However `pointer_to_array` can only handle arguments of type Int, which is problem on 64-bit Julia given that Cint is 32bit, and Int is 64 bit. This adds another method that automatically handles the conversion. I'm not sure what should be done with the Dims case, given that Dims is also defined by Int, not Integer.
