### PR TITLE
`@inbounds`: evaluate to the value of the given expression.

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -132,8 +132,9 @@ end
 macro boundscheck(yesno,blk)
     quote
         $(Expr(:boundscheck,yesno))
-        $(esc(blk))
+        local val = $(esc(blk))
         $(Expr(:boundscheck,:pop))
+        val
     end
 end
 


### PR DESCRIPTION
@JeffBezanson, is this ok, or does it potentially sabotage the performance gains? I found that there were a fair number of situations where I wanted to wrap an expression in `@inbounds` but also use its value.
