### PR TITLE
Further changes to eigs

### DIFF
--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -2,19 +2,25 @@ using .ARPACK
 
 ## eigs
 
-function eigs{T<:BlasFloat}(A::AbstractMatrix{T};
-                            nev::Integer=6, ncv::Integer=20, which::ASCIIString="LM", 
-                            tol=0.0, maxiter::Integer=1000, sigma=0,v0::Vector{T}=Array(T,(0,)),
-                            ritzvec::Bool=true, complexOP::Bool=false)
+function eigs(A;nev::Integer=6, ncv::Integer=20, which::ASCIIString="LM",
+				tol=0.0, maxiter::Integer=1000, sigma=0,v0::Vector=zeros((0,)),
+				ritzvec::Bool=true, complexOP::Bool=false)
     (m, n) = size(A)
     if m != n; error("Input must be square"); end
-	if !isempty(v0) && length(v0)!=n; error("Starting vector must have length $n"); end
     if n <= 6 && nev > n-1; nev = n-1; end
     ncv = blas_int(min(max(2*nev+2, ncv), n))
     bmat   = "I"
     sym   = issym(A)
-    cmplx = iseltype(A,Complex)
+    T = eltype(A)
+    cmplx = T<:Complex
     bmat  = "I"
+	if !isempty(v0)
+		if length(v0)!=n; error("Starting vector must have length $n"); end
+		if eltype(v0)!=T; error("Starting vector must have eltype $T"); end
+	else
+		v0=zeros(T,(0,))
+	end
+
     if sigma == 0
         mode = 1
         linop(x) = A * x

--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -49,7 +49,8 @@ function aupd_wrapper(T, linop::Function, n::Integer,
                   iparam, ipntr, workd, workl, lworkl, info)
         end
         if info[1] == 3; warn("Try eigs/svds with a larger value for ncv."); end
-        if info[1] != 0; throw(ARPACKException(info[1])); end
+        if info[1] == 1; warn("Maximum number of iterations taken. Check nconv for number of converged eigenvalues."); end
+        if info[1] < 0; throw(ARPACKException(info[1])); end
         if (ido[1] != -1 && ido[1] != 1); break; end
         workd[ipntr[2]+zernm1] = linop(getindex(workd, ipntr[1]+zernm1))
     end
@@ -77,7 +78,7 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
               bmat, n, which, nev, tol, resid, ncv, v, ldv,
               iparam, ipntr, workd, workl, lworkl, rwork, info)
         if info[1] != 0; throw(ARPACKException(info[1])); end
-        return ritzvec ? (d[1:nev], v[1:n, 1:nev],iparam[3],iparam[9],resid) : (d[1:nev],iparam[3],iparam[9],resid)
+        return ritzvec ? (d[1:nev], v[1:n, 1:nev],iparam[5],iparam[3],iparam[9],resid) : (d[1:nev],iparam[5],iparam[3],iparam[9],resid)
 
     elseif sym
 
@@ -87,7 +88,7 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
               bmat, n, which, nev, tol, resid, ncv, v, ldv,
               iparam, ipntr, workd, workl, lworkl, info) 
         if info[1] != 0; throw(ARPACKException(info[1])); end
-        return ritzvec ? (d, v[1:n, 1:nev],iparam[3],iparam[9],resid) : (d,iparam[3],iparam[9],resid)
+        return ritzvec ? (d, v[1:n, 1:nev],iparam[5],iparam[3],iparam[9],resid) : (d,iparam[5],iparam[3],iparam[9],resid)
 
     else
 
@@ -113,7 +114,7 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
             j += 1
         end
         d = complex(dr[1:nev],di[1:nev])
-        return ritzvec ? (d, evec[1:n, 1:nev],iparam[3],iparam[9],resid) : (d,iparam[3],iparam[9],resid)
+        return ritzvec ? (d, evec[1:n, 1:nev],iparam[5],iparam[3],iparam[9],resid) : (d,iparam[5],iparam[3],iparam[9],resid)
     end
     
 end

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -378,7 +378,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    The conjugate transpose operator (``'``).
 
-.. function:: eigs(A; nev=6, which="LM", tol=0.0, maxiter=1000, sigma=0, ritzvec=true, op_part=:real,v0=zeros((0,))) -> (d,[v,]niter,nmult,resid)
+.. function:: eigs(A; nev=6, which="LM", tol=0.0, maxiter=1000, sigma=0, ritzvec=true, op_part=:real,v0=zeros((0,))) -> (d,[v,],nconv,niter,nmult,resid)
 
    ``eigs`` computes eigenvalues ``d`` of A using Arnoldi factorization. The following keyword arguments are supported:
     * ``nev``: Number of eigenvalues
@@ -389,7 +389,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
     * ``ritzvec``: Returns the Ritz vectors ``v`` (eigenvectors) if ``true``
     * ``op_part``: which part of linear operator to use for real A (:real, :imag)
     * ``v0``: starting vector from which to start the Arnoldi iteration
-   ``eigs`` returns the ``nev`` requested eigenvalues in ``d``, the corresponding Ritz vectors ``v`` (only if ``ritzvec=true``), the number of iterations ``niter`` and the number of matrix vector multiplications ``nmult``, as well as the final residual vector ``resid``.
+   ``eigs`` returns the ``nev`` requested eigenvalues in ``d``, the corresponding Ritz vectors ``v`` (only if ``ritzvec=true``), the number of converged eigenvalues ``nconv``, the number of iterations ``niter`` and the number of matrix vector multiplications ``nmult``, as well as the final residual vector ``resid``.
     
 
 .. function:: svds(A; nev=6, which="LA", tol=0.0, maxiter=1000, ritzvec=true)

--- a/test/arpack.jl
+++ b/test/arpack.jl
@@ -46,7 +46,7 @@ end
 Q=reshape(Q,(50,2,50))
 # Construct trace-preserving completely positive map from this
 Phi=CPM(Q)
-(d,v,numiter,numop,resid) = eigs(Phi,nev=1,which="LM")
+(d,v,nconv,numiter,numop,resid) = eigs(Phi,nev=1,which="LM")
 # Properties: largest eigenvalue should be 1, largest eigenvector, when reshaped as matrix
 # should be a Hermitian positive definite matrix (up to an arbitrary phase)
 
@@ -61,7 +61,7 @@ v=(v+v')/2
 Test.@test isposdef(v)
 
 # Repeat with starting vector
-(d2,v2,numiter2,numop2,resid2) = eigs(Phi,nev=1,which="LM",v0=reshape(v,(2500,)))
+(d2,v2,nconv2,numiter2,numop2,resid2) = eigs(Phi,nev=1,which="LM",v0=reshape(v,(2500,)))
 v2=reshape(v2,(50,50))
 v2=v2/trace(v2)
 Test.@test numiter2<numiter


### PR DESCRIPTION
Dear Julia developers,
I suggest some additional changes to eigs: feel free to decline my pull request.
(1) ARPACK info flag 1 now results in a warning (maximal number of
iterations taken) rather then throwing an error.
(2) Added the return value nconv, indicating the number of converged
eigenvalues, which is relevant when the maximal number of iterations
has been taken before all requested eigenvalues have converged (which
no longer leads to an error thanks to (1) ).
(3) Modified behavior of eigs such that any input type of matrix is
allowed, as long as the type of A overloads the methods size, issym,
eltype and can be multiplied with a vector of the same element type.
(4) Updated test file accordingly
