### PR TITLE
Make it safe to turn off/on profiling timer in code

### DIFF
--- a/base/profile.jl
+++ b/base/profile.jl
@@ -79,6 +79,8 @@ start_timer() = ccall(:profile_start_timer, Cint, ())
 
 stop_timer() = ccall(:profile_stop_timer, Void, ())
 
+is_running() = bool(ccall(:profile_is_running, Cint, ()))
+
 get_data_pointer() = convert(Ptr{Uint}, ccall(:profile_get_data, Ptr{Uint8}, ()))
 
 len_data() = convert(Int, ccall(:profile_len_data, Csize_t, ()))

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -264,6 +264,7 @@
     profile_clear_data;
     profile_start_timer;
     profile_stop_timer;
+    profile_is_running;
     jl_reshape_array;
     jl_restore_system_image;
     jl_run_event_loop;


### PR DESCRIPTION
Certain code (e.g., a `ccall` to `fork`) seems to cause trouble for the profiler. This allows one to turn off the profiling timer, e.g., 

```
    profiling = Profile.is_running()
    Profile.stop_timer()
    # code that shouldn't be profiled
    if profiling
        Profile.start_timer()
    end
```

@vtjnash, @loladiro.
