### PR TITLE
Fix mandelbrot microbenchmark in C, Fortran and Go

### DIFF
--- a/test/perf/micro/perf.c
+++ b/test/perf/micro/perf.c
@@ -62,16 +62,16 @@ int mandel(double complex z) {
         if (cabs(z) > 2.0) {
             return n;
         }
-        z = cpow(z,2)+c;
+        z = z*z+c;
     }
     return maxiter;
 }
 
 int mandelperf() {
     int mandel_sum = 0;
-    for (double re=-2.0; re<=0.5; re+=0.1) {
-        for (double im=-1.0; im<=1.0; im+=0.1) {
-            int m = mandel(re+im*I);
+    for (int re=-20; re<=5; re+=1) {
+        for (int im=-10; im<=10; im+=1) {
+            int m = mandel(re/10.0+I*im/10.0);
             mandel_sum += m;
         }
     }
@@ -286,7 +286,7 @@ int main() {
         t = clock_now()-t;
         if (t < tmin) tmin = t;
     }
-    assert(mandel_sum == 14719);
+    assert(mandel_sum == 14791);
     print_perf("mandel", tmin);
 
     // sort

--- a/test/perf/micro/perf.f90
+++ b/test/perf/micro/perf.f90
@@ -196,16 +196,16 @@ r = maxiter
 end function
 
 integer function mandelperf() result(mandel_sum)
-real(dp) :: re, im
+integer :: re, im
 mandel_sum = 0
-re = -2._dp
-do while (re <= 0.5_dp)
-    im = -1._dp
-    do while (im <= 1._dp)
-        mandel_sum = mandel_sum + mandel(cmplx(re, im, dp))
-        im = im + 0.1_dp
+re = -20
+do while (re <= 5)
+    im = -10
+    do while (im <= 10)
+        mandel_sum = mandel_sum + mandel(cmplx(re/10._dp, im/10._dp, dp))
+        im = im + 1
     end do
-    re = re + 0.1_dp
+    re = re + 1
 end do
 end function
 
@@ -346,9 +346,7 @@ do i = 1, 5
     call cpu_time(t2)
     if (t2-t1 < tmin) tmin = t2-t1
 end do
-! This number is processor dependent, as it can differ a bit depending on the
-! floating point rounding errors:
-!call assert(f == 14307)
+call assert(f == 14791)
 print "('fortran,mandel,',f0.6)", tmin*1000._dp / NRUNS
 
 tmin = 1e9_dp

--- a/test/perf/micro/perf.go
+++ b/test/perf/micro/perf.go
@@ -82,9 +82,9 @@ func mandel(z complex128) int {
 
 func mandelperf() int {
 	mandel_sum := 0
-	for re := -2.0; re <= 0.5; re += 0.1 {
-		for im := -1.0; im <= 1.0; im += 0.1 {
-			m := mandel(complex(re, im))
+	for re := -20; re <= 5; re += 1 {
+		for im := -10; im <= 10; im += 1 {
+			m := mandel(complex(float64(re)/10, float64(im)/10))
 			mandel_sum += m
 		}
 	}
@@ -145,8 +145,7 @@ func main() {
 	}
 	print_perf("parse_int", tmin)
 
-	// fmt.Println(mandelperf())
-	// FIXME: assert(mandelperf() == 14791)
+	assert(mandelperf() == 14791)
 	tmin = float64(math.MaxFloat64)
 	for i := 0; i < 5; i++ {
 		t := time.Now()


### PR DESCRIPTION
Now they produce correct value consistent with Julia version. Discrepancy have existed due to error accumulation in floating-point loops and inaccuracy in cpow function (for C).
