### PR TITLE
Change default qr subroutine to one that allows m<n. Update documentation for fat QR. Return permutation vector instead of matrix in pivoted QR.

### DIFF
--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -239,12 +239,12 @@ type QR{S<:BlasFloat} <: Factorization{S}
     vs::Matrix{S}                     # the elements on and above the diagonal contain the N-by-N upper triangular matrix R; the elements below the diagonal are the columns of V
     T::Matrix{S}                      # upper triangular factor of the block reflector.
 end
-QR{T<:BlasFloat}(A::StridedMatrix{T}) = QR(LAPACK.geqrt3!(A)...)
+QR{T<:BlasFloat}(A::StridedMatrix{T}, nb::Integer = min(minimum(size(A)), 36)) = QR(LAPACK.geqrt!(A, nb)...)
 
-qrfact!{T<:BlasFloat}(A::StridedMatrix{T}) = QR(A)
-qrfact!(A::StridedMatrix) = qrfact!(float(A))
-qrfact{T<:BlasFloat}(A::StridedMatrix{T}) = qrfact!(copy(A))
-qrfact(A::StridedMatrix) = qrfact!(float(A))
+qrfact!{T<:BlasFloat}(A::StridedMatrix{T}, args::Integer...) = QR(A, args...)
+qrfact!(A::StridedMatrix, args::Integer...) = qrfact!(float(A), args...)
+qrfact{T<:BlasFloat}(A::StridedMatrix{T}, args::Integer...) = qrfact!(copy(A), args...)
+qrfact(A::StridedMatrix, args::Integer...) = qrfact!(float(A), args...)
 qrfact(x::Integer) = qrfact(float(x))
 qrfact(x::Number) = QR(fill(one(x), 1, 1), fill(x, 1, 1))
 
@@ -262,7 +262,7 @@ function getindex(A::QR, d::Symbol)
     error("No such type field")
 end
 
-type QRPackedQ{S}  <: AbstractMatrix{S} 
+type QRPackedQ{S} <: AbstractMatrix{S} 
     vs::Matrix{S}                      
     T::Matrix{S}                       
 end
@@ -271,7 +271,7 @@ QRPackedQ(A::QR) = QRPackedQ(A.vs, A.T)
 size(A::QRPackedQ, args::Integer...) = size(A.vs, args...)
 
 function full{T<:BlasFloat}(A::QRPackedQ{T}, thin::Bool)
-    if thin return A * eye(T, size(A.T, 1)) end
+    if thin return A * eye(T, size(A.T, 2)) end
     return A * eye(T, size(A, 1))
 end
 full(A::QRPackedQ) = full(A, true)
@@ -323,7 +323,7 @@ qrpfact(A::StridedMatrix) = qrpfact!(float(A))
 
 function qrp(A::AbstractMatrix, thin::Bool)
     F = qrpfact(A)
-    return full(F[:Q], thin), F[:R], F[:P]
+    return full(F[:Q], thin), F[:R], F[:p]
 end
 qrp(A::AbstractMatrix) = qrp(A, false)
 

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -127,14 +127,15 @@ end
 # geqlf - unpivoted QL decomposition
 # geqrf - unpivoted QR decomposition
 # gegp3 - pivoted QR decomposition
+# geqrt - unpivoted QR by WY representation
 # geqrt3! - recursive algorithm producing compact WY representation of Q
 # gerqf - unpivoted RQ decomposition
 # getrf - LU decomposition
-for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
-    ((:dgebrd_,:dgelqf_,:dgeqlf_,:dgeqrf_,:dgeqp3_,:dgeqrt3_,:dgerqf_,:dgetrf_,:Float64,:Float64),
-     (:sgebrd_,:sgelqf_,:sgeqlf_,:sgeqrf_,:sgeqp3_,:sgeqrt3_,:sgerqf_,:sgetrf_,:Float32,:Float32),
-     (:zgebrd_,:zgelqf_,:zgeqlf_,:zgeqrf_,:zgeqp3_,:zgeqrt3_,:zgerqf_,:zgetrf_,:Complex128,:Float64),
-     (:cgebrd_,:cgelqf_,:cgeqlf_,:cgeqrf_,:cgeqp3_,:cgeqrt3_,:cgerqf_,:cgetrf_,:Complex64,:Float32))
+for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty) in
+    ((:dgebrd_,:dgelqf_,:dgeqlf_,:dgeqrf_,:dgeqp3_,:dgeqrt_,:dgeqrt3_,:dgerqf_,:dgetrf_,:Float64,:Float64),
+     (:sgebrd_,:sgelqf_,:sgeqlf_,:sgeqrf_,:sgeqp3_,:sgeqrt_,:sgeqrt3_,:sgerqf_,:sgetrf_,:Float32,:Float32),
+     (:zgebrd_,:zgelqf_,:zgeqlf_,:zgeqrf_,:zgeqp3_,:zgeqrt_,:zgeqrt3_,:zgerqf_,:zgetrf_,:Complex128,:Float64),
+     (:cgebrd_,:cgelqf_,:cgeqlf_,:cgeqrf_,:cgeqp3_,:cgeqrt_,:cgeqrt3_,:cgerqf_,:cgetrf_,:Complex64,:Float32))
     @eval begin
         # SUBROUTINE DGEBRD( M, N, A, LDA, D, E, TAUQ, TAUP, WORK, LWORK,
         #                    INFO )
@@ -264,6 +265,27 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt3, gerqf, getrf, elty, relty) in
                 end
             end
             A, tau, jpvt
+        end
+        function geqrt!(A::StridedMatrix{$elty}, nb::Integer)
+            chkstride1(A)
+            m, n = size(A)
+            minmn = min(m, n)
+            nb <= minmn || error("Block size too large")
+            lda = max(1, m)
+            T = Array($elty, nb, minmn)
+            work = Array($elty, nb*n)
+            if n > 0
+                info = Array(BlasInt, 1)
+                ccall(($(string(geqrt)), liblapack), Void, 
+                    (Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, 
+                     Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
+                     Ptr{BlasInt}),
+                     &m, &n, &nb, A, 
+                     &lda, T, &nb, work,
+                     info)
+                if info[1] < 0 throw(LAPACKException(info[1])) end
+            end
+            return A, T
         end
         function geqrt3!(A::StridedMatrix{$elty})
             chkstride1(A)
@@ -1391,20 +1413,23 @@ for (orglq, orgqr, ormlq, ormqr, gemqrt, elty) in
             chkstride1(T, C)
             m = size(C, 1)
             n = size(C, 2)
-            k = size(T, 1)
+            nb, k = size(T)
             if k == 0 return C end
             if side == 'L'
+                0 <= k <= m || error("Wrong value for k")
                 ldv = max(1, m)
                 wss = n*k
-                if m != size(V, 1) throw(DimensionMismatch("")) end
+                # if m != size(V, 1) throw(DimensionMismatch("")) end
             elseif side == 'R'
+                0 <= k <= n || error("Wrong value for k")
                 ldv = max(1, n)
                 wss = m*k
-                if n != size(V, 1) throw(DimensionMismatch("")) end
+                # if n != size(V, 1) throw(DimensionMismatch("")) end
             else
                 error("side must be either 'L' or 'R'")
             end
-            ldc = max(1, stride(C, 2))
+            1 <= nb <= k || error("Wrong value for nb")
+            ldc = max(1, m)
             work = Array($elty, wss)
             info = Array(BlasInt, 1)
             ccall(($(string(gemqrt)), liblapack), Void,
@@ -1413,8 +1438,8 @@ for (orglq, orgqr, ormlq, ormqr, gemqrt, elty) in
                  Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                  Ptr{$elty}, Ptr{BlasInt}),
                 &side, &trans, &m, &n,
-                &k, &k, V, &ldv,
-                T, &k, C, &ldc,
+                &k, &nb, V, &ldv,
+                T, &nb, C, &ldc,
                 work, info)
             if info[1] < 0 throw(LAPACKException(info[1])) end
             return C

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -81,19 +81,19 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
 .. function:: qr(A, [thin]) -> Q, R
 
-   Compute the QR factorization of ``A`` such that ``A = Q*R``. Also see ``qrfact``. The default is to compute a thin factorization.
+   Compute the QR factorization of ``A`` such that ``A = Q*R``. Also see ``qrfact``. The default is to compute a thin factorization. Note that `R` is not extended with zeros when the full `Q` is requested. 
 
 .. function:: qrfact(A)
 
-   Compute the QR factorization of ``A`` and return a ``QR`` object. The coomponents of the factorization ``F`` can be accessed as follows: the orthogonal matrix ``Q`` can be extracted with ``F[:Q]`` and the triangular matrix ``R`` with ``F[:R]``. The following functions are available for ``QR`` objects: ``size``, ``\``. When ``Q`` is extracted, the resulting type is the ``QRPackedQ`` object, and has the ``*`` operator overloaded to support efficient multiplication by ``Q`` and ``Q'``.
+   Compute the QR factorization of ``A`` and return a ``QR`` object. The components of the factorization ``F`` can be accessed as follows: the orthogonal matrix ``Q`` can be extracted with ``F[:Q]`` and the triangular matrix ``R`` with ``F[:R]``. The following functions are available for ``QR`` objects: ``size``, ``\``. When ``Q`` is extracted, the resulting type is the ``QRPackedQ`` object, and has the ``*`` operator overloaded to support efficient multiplication by ``Q`` and ``Q'``.
 
 .. function:: qrfact!(A)
 
    ``qrfact!`` is the same as :func:`qrfact`, but saves space by overwriting the input A, instead of creating a copy.
 
-.. function:: qrp(A, [thin]) -> Q, R, P
+.. function:: qrp(A, [thin]) -> Q, R, p
 
-   Compute the QR factorization of ``A`` with pivoting, such that ``A*P = Q*R``, Also see ``qrpfact``. The default is to compute a thin factorization.
+   Compute the QR factorization of ``A`` with pivoting, such that ``A[:,p] = Q*R``, Also see ``qrpfact``. The default is to compute a thin factorization.
 
 .. function:: qrpfact(A) -> QRPivoted
 


### PR DESCRIPTION
This should address the issues in JuliaLang/LinearAlgebra.jl#32, so now

```
julia> A=randn(2,4)
2x4 Array{Float64,2}:
 1.14841  0.148657   0.50509    0.870583
 0.5955   1.78331   -0.352758  -1.95542 

julia> qr(A)
(
2x2 Array{Float64,2}:
 -0.887745  -0.460335
 -0.460335   0.887745,

2x4 Array{Float64,2}:
 -1.29362  -0.952887  -0.286004   0.127291
  0.0       1.51469   -0.54567   -2.13667 )
```

@dmbates I browsed through the GLM code and couldn't find any call directly to `geqrt3` anymore. If I have missed it, this pull request might affect GLM because I have changed `qrfact` to call `geqrt`. They are very similar as `geqrt` is just a higher level interface to `geqrt3`.
