### PR TITLE
Improve the fasta.jl benchmark 

### DIFF
--- a/test/perf/shootout/fasta.jl
+++ b/test/perf/shootout/fasta.jl
@@ -1,7 +1,6 @@
-
 const line_width = 60
 
-const alu = string( 
+const alu = string(
    "GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGG",
    "GAGGCCGAGGCGGGCGGATCACCTGAGGTCAGGAGTTCGAGA",
    "CCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACTAAAAAT",
@@ -10,74 +9,56 @@ const alu = string(
    "AGGCGGAGGTTGCAGTGAGCCGAGATCGCGCCACTGCACTCC",
    "AGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAA")
 
-const iub =
-    (b"acgtBDHKMNRSVWY", 
-     [0.27, 0.12, 0.12, 0.27, 0.02,
-      0.02, 0.02, 0.02, 0.02, 0.02,
-      0.02, 0.02, 0.02, 0.02, 0.02])
+const iub1 = b"acgtBDHKMNRSVWY"
+const iub2 = [0.27, 0.12, 0.12, 0.27, 0.02,0.02, 0.02, 0.02, 0.02, 0.02,0.02, 0.02, 0.02, 0.02, 0.02]
 
-const homosapiens =
-    (b"acgt",
-     [0.3029549426680, 0.1979883004921,
-      0.1975473066391, 0.3015094502008])
+const homosapiens1 = b"acgt"
+const homosapiens2 = [0.3029549426680, 0.1979883004921,0.1975473066391, 0.3015094502008]
 
+const IM  = 139968.0
+const IA  =   3877.0
+const IC  =  29573.0
 
-
-const IM  = 139968
-const IA  =   3877
-const IC  =  29573
-const IMf = float64(IM)
-rng_state = 42
-
-function gen_random(max::Float64)
-    global rng_state = (rng_state * IA + IC) % IM
-    max * float(rng_state) / IMf
+function gen_random()
+    global rng_state::Float64 = ((rng_state::Float64 * IA + IC) % IM) / IM
 end
-
-
 function repeat_fasta(src, n)
     k = length(src)
-    s = string(src, src, src[1:n % k])
-
-#    for j = 0:div(n, line_width) - 1
-#        i = j * line_width % k
-#        println(s[i + 1:i + line_width])
-#    end
-
-#    if n % line_width > 0
-#        println(s[end - (n % line_width) + 1:])
-#    end
+    @inbounds s = string(src, src, src[1:n % k])
+    return s
 end
-
-
 function choose_char(cs)
     k = length(cs)
-    r = gen_random(1.0)
-
-    if r < cs[1]; return 1; end
-
-    a::Uint = 1
-    b::Uint = k
-
+    r = gen_random()
+    @inbounds begin
+    r < cs[1] && return 1
+    a = 1
+    b = k
     while b > a + 1
-        c = div(a + b, 2)
+        c = fld(a + b, 2)
         if r < cs[c]; b = c; else a = c; end
     end
-
+    end
     b
 end
-
-
 function random_fasta(symb, pr, n)
     cs = cumsum(pr)
     line = Array(Uint8, line_width)
     k = n
+    @inbounds begin
     while k > 0
         m = min(k, line_width)
         for i = 1:m
             line[i] = symb[choose_char(cs)]
         end
-#        write(line[1:m]); println()
         k -= line_width
     end
+    end
+end
+
+rng_state = 42.0
+function fasta(n=25000000)
+  repeat_fasta(alu, 2n)
+  random_fasta(iub1, iub2, 3n)
+  random_fasta(homosapiens1, homosapiens2, 5n)
 end

--- a/test/perf/shootout/perf.jl
+++ b/test/perf/shootout/perf.jl
@@ -7,12 +7,7 @@ include("fannkuch.jl")
 @timeit fannkuch(7) "fannkuch" "Indexed-access to tiny integer-sequence"
 
 include("fasta.jl")
-n = 100
-@timeit begin
-    repeat_fasta(alu, 2n)
-    random_fasta(iub[1], iub[2], 3n)
-    random_fasta(homosapiens[1], homosapiens[2], 5n)
-end "fasta" "Generate and write random DNA sequences"
+@timeit fasta(100) "fasta" "Generate and write random DNA sequences"
 
 include("k_nucleotide.jl")
 @timeit k_nucleotide("shootout/knucleotide-input.txt") "k_nucleotide" "Hashtable update and k-nucleotide strings"


### PR DESCRIPTION
The old code ran the full suite in 117s, the new one runs in 7s, which is 1.4x C. See here for full benchmarks: http://benchmarksgame.alioth.debian.org/u32/benchmark.php?test=fasta&lang=all&id=1&data=u32
