### PR TITLE
Add Hash Function For Set

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -112,3 +112,5 @@ function filter!(f::Function, s::Set)
     return s
 end
 filter(f::Function, s::Set) = filter!(f, copy(s))
+
+hash(s::Set) = hash(sort(s.dict.keys[s.dict.slots .!= 0]))

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -346,6 +346,15 @@ for i in 1:length(origs)
     @test in(el, origs)
 end
 @test isempty(s)
+
+# hash
+s1 = Set{ASCIIString}("bar", "foo")
+s2 = Set{ASCIIString}("foo", "bar")
+s3 = Set{ASCIIString}("baz")
+@test hash(s1) == hash(s2)
+@test hash(s1) != hash(s3)
+
+
 # isequal
 @test  isequal(Set(), Set())
 @test !isequal(Set(), Set(1))


### PR DESCRIPTION
Set was missing a corresponding hash() function which previously resulted in incorrect behavior with respect to other containers like Dict. This commit adds a basic hash function to fix this.
