### PR TITLE
RFC: Enable LLVM support for Intel VTune Amplifier if platform supports it.

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -32,6 +32,9 @@ USE_SYSTEM_LIBUV=0
 USE_MKL = 0
 MKLLIB = $(MKLROOT)/lib/intel64
 
+# Set to 1 to enable profiling with Intel VTune Amplifier
+USE_INTEL_JITEVENTS = 0
+
 # we include twice to pickup user definitions better
 ifeq (exists, $(shell [ -e $(JULIAHOME)/Make.user ] && echo exists ))
 include $(JULIAHOME)/Make.user

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -211,11 +211,14 @@ else
 LLVM_FLAGS += --enable-optimized
 endif
 ifeq ($(OS), WINNT)
-LLVM_FLAGS += --with-extra-ld-options="-Wl,--stack,8388608" LDFLAGS="" --disable-shared --with-intel-jitevents
+LLVM_FLAGS += --with-extra-ld-options="-Wl,--stack,8388608" LDFLAGS="" --disable-shared
 LLVM_MFLAGS += CPPFLAGS="-D__USING_SJLJ_EXCEPTIONS__ -D__CRT__NO_INLINE"
 endif
-ifneq ($(and $(findstring Linux,$(OS)),$(findstring $(ARCH),"i386 i486 i686 x86_64")),)
+ifeq ($(USE_INTEL_JITEVENTS), 1)
 LLVM_FLAGS += --with-intel-jitevents
+ifeq ($(OS), WINNT)
+LLVM_FLAGS += --disable-threads
+endif
 else
 LLVM_FLAGS += --disable-threads
 endif

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -195,7 +195,7 @@ LLVM_COMPILER_RT_TAR=
 endif
 
 LLVM_TARGET_FLAGS= --enable-targets=host
-LLVM_FLAGS =  --disable-threads --disable-profiling --enable-shared --enable-static $(LLVM_TARGET_FLAGS) --disable-bindings --disable-docs
+LLVM_FLAGS = --disable-profiling --enable-shared --enable-static $(LLVM_TARGET_FLAGS) --disable-bindings --disable-docs
 LLVM_MFLAGS =
 ifeq ($(LLVM_ASSERTIONS), 1)
 LLVM_FLAGS += --enable-assertions 
@@ -211,8 +211,13 @@ else
 LLVM_FLAGS += --enable-optimized
 endif
 ifeq ($(OS), WINNT)
-LLVM_FLAGS += --with-extra-ld-options="-Wl,--stack,8388608" LDFLAGS="" --disable-shared
+LLVM_FLAGS += --with-extra-ld-options="-Wl,--stack,8388608" LDFLAGS="" --disable-shared --with-intel-jitevents
 LLVM_MFLAGS += CPPFLAGS="-D__USING_SJLJ_EXCEPTIONS__ -D__CRT__NO_INLINE"
+endif
+ifneq ($(and $(findstring Linux,$(OS)),$(findstring $(ARCH),"i386 i486 i686 x86_64")),)
+LLVM_FLAGS += --with-intel-jitevents
+else
+LLVM_FLAGS += --disable-threads
 endif
 
 ifeq ($(BUILD_LLDB),1)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3502,6 +3502,12 @@ extern "C" void jl_init_codegen(void)
 
     jl_jit_events = new JuliaJITEventListener();
     jl_ExecutionEngine->RegisterJITEventListener(jl_jit_events);
+#if LLVM_USE_INTEL_JITEVENTS
+    if( const char* jit_profiling = std::getenv("ENABLE_JITPROFILING") )
+        if( std::atoi(jit_profiling) )
+            jl_ExecutionEngine->RegisterJITEventListener(
+                JITEventListener::createIntelJITEventListener());
+#endif // LLVM_USE_INTEL_JITEVENTS
 
     BOX_F(int8,int32);  BOX_F(uint8,uint32);
     BOX_F(int16,int16); BOX_F(uint16,uint16);


### PR DESCRIPTION
The change to deps/Makefile causes LLVM to be compiled with --with-intel-jitevents for
- Windows
- Linux on x86

The change to src/codegen.cpp causes Julia to register a IntelJITEventListener
when the environment variable ENABLE_JITPROFILING is set.

Intel VTune Amplifier is not required to compile the code because the standard LLVM
distribution (3.3 or current pre-3.4 development version) already has the necessary code.
