### PR TITLE
parse: refactor to make `greedy` and `raise` keyword arguments.

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -279,6 +279,9 @@ export ComplexPair
 @deprecate sortcols(v::AbstractMatrix,a::Algorithm,o::Ordering) sortcols(v,alg=a,order=o)
 @deprecate sortcols(v::AbstractMatrix,o::Ordering,a::Algorithm) sortcols(v,alg=a,order=o)
 
+@deprecate parse(str::String, pos::Int, greedy::Bool, raise::Bool) parse(str,pos,greedy=greedy,raise=raise)
+@deprecate parse(str::String, pos::Int, greedy::Bool) parse(str,pos,greedy=greedy)
+
 function amap(f::Function, A::AbstractArray, axis::Integer)
     depwarn("amap is deprecated, use mapslices(f, A, dims) instead", :amap)
     dimsA = size(A)

--- a/base/string.jl
+++ b/base/string.jl
@@ -1089,7 +1089,7 @@ function shell_parse(raw::String, interp::Bool)
                 error("space not allowed right after \$")
             end
             stpos = j
-            ex, j = parse(s,j,false)
+            ex, j = parse(s,j,greedy=false)
             last_parse = stpos:j
             update_arg(esc(ex)); i = j
         else
@@ -1191,16 +1191,16 @@ shell_escape(args::String...) = sprint(print_shell_escaped, args...)
 
 ## interface to parser ##
 
-function parse(str::String, pos::Int, greedy::Bool=true, err::Bool=true)
+function parse(str::String, pos::Int; greedy::Bool=true, raise::Bool=true)
     # returns (expr, end_pos). expr is () in case of parse error.
     ex, pos = ccall(:jl_parse_string, Any,
                     (Ptr{Uint8}, Int32, Int32),
                     str, pos-1, greedy ? 1:0)
-    if err && isa(ex,Expr) && is(ex.head,:error)
+    if raise && isa(ex,Expr) && is(ex.head,:error)
         throw(ParseError(ex.args[1]))
     end
     if ex == ()
-        if err
+        if raise
             throw(ParseError("end of input"))
         else
             ex = Expr(:error, "end of input")
@@ -1209,8 +1209,8 @@ function parse(str::String, pos::Int, greedy::Bool=true, err::Bool=true)
     ex, pos+1 # C is zero-based, Julia is 1-based
 end
 
-function parse(str::String)
-    ex, pos = parse(str, start(str))
+function parse(str::String; greedy::Bool=true, raise::Bool=true)
+    ex, pos = parse(str, start(str), greedy=greedy, raise=raise)
     done(str, pos) || error("syntax: extra token after end of expression")
     return ex
 end

--- a/base/string.jl
+++ b/base/string.jl
@@ -1209,8 +1209,8 @@ function parse(str::String, pos::Int; greedy::Bool=true, raise::Bool=true)
     ex, pos+1 # C is zero-based, Julia is 1-based
 end
 
-function parse(str::String; greedy::Bool=true, raise::Bool=true)
-    ex, pos = parse(str, start(str), greedy=greedy, raise=raise)
+function parse(str::String; raise::Bool=true)
+    ex, pos = parse(str, start(str), greedy=true, raise=raise)
     done(str, pos) || error("syntax: extra token after end of expression")
     return ex
 end

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -366,9 +366,9 @@ Syntax
 
    Generates a gensym symbol for a variable. For example, `@gensym x y` is transformed into `x = gensym("x"); y = gensym("y")`.
 
-.. function:: parse(str, [start, [greedy, [err]]])
+.. function:: parse(str, [start]; greedy=true, raise=false)
 
-   Parse the expression string and return an expression (which could later be passed to eval for execution). Start is the index of the first character to start parsing (default is 1). If greedy is true (default), parse will try to consume as much input as it can; otherwise, it will stop as soon as it has parsed a valid token. If err is true (default), parse errors will raise an error; otherwise, it will return the error as a normal expression.
+   Parse the expression string and return an expression (which could later be passed to eval for execution). Start is the index of the first character to start parsing (default is 1). If greedy is true (default), parse will try to consume as much input as it can; otherwise, it will stop as soon as it has parsed a valid token. If raise is true (default), parse errors will raise an error; otherwise, parse will return the error as an expression object.
 
 Iteration
 ---------


### PR DESCRIPTION
This makes the `parse` function more composable and self-documenting.
