### PR TITLE
RFC: Shared-memory parallel computing

### DIFF
--- a/base/SharedArrays.jl
+++ b/base/SharedArrays.jl
@@ -1,0 +1,196 @@
+module SharedArrays
+
+import Base: eltype, mmap_array, myindexes, ndims, serialize, size
+
+export AbstractSharedArray, SharedArray, cutdim, cutdim!, myarray, nchunks, nrefs, pcall, pcall_bw, proc, sharedsync
+
+abstract AbstractSharedArray{T,N} <: AbstractArray{T,N}
+
+# A SharedArray should live only on process id 1, everyone else
+# sees a SSharedArray
+# SSharedArray = Serializable shared array
+
+type SSharedArray{T,N} <: AbstractSharedArray{T,N}
+    dims::NTuple{N,Int}
+    refs::Array{RemoteRef,1}
+    cutdim::Int
+end
+
+type SharedArray{T,N} <: AbstractSharedArray{T,N}
+    data::Array{T,N}   # the array on process id 1
+    sarray::SSharedArray{T,N}
+end
+
+function SharedArray{T}(::Type{T}, dims::Dims, procs = 1:nprocs(); filename::ASCIIString = joinpath(ramdisk(), string("julia", randstring(10))), offset::Integer = 0, mode::ASCIIString = "", cutdim::Integer = defaultcutdim(dims, length(procs)))
+    exists = isfile(filename)
+    if mode == ""
+        mode = exists ? "r" : "w+"
+    end
+    s = open(filename, mode)
+    data = mmap_array(T, dims, s, offset)
+    rd = mode == "r" || mode == "r+" || mode == "w+"
+    wr = mode == "w" || mode == "r+" || mode == "w+"
+    refs = Array(RemoteRef, 0)
+    n = prod(dims)
+    for p in procs
+        if p != 1
+            push!(refs, remotecall_wait(p, mmap_array, T, dims, filename, rd, wr, offset))
+        end
+    end
+    if !exists
+        unlink(filename)  # so the file gets cleaned up automatically
+    end
+    S = SharedArray{T,length(dims)}(data, SSharedArray{T,length(dims)}(dims, refs, int(cutdim)))
+end
+
+function sharedsync(procs = 1:nprocs())
+    n = length(setdiff(procs, 1))
+    SharedArray(Bool, (n,), procs)
+end
+
+serialize(io, S::SharedArray) = serialize(io, S.sarray)
+
+
+eltype{T}(S::AbstractSharedArray{T}) = T
+ndims{T,N}(S::AbstractSharedArray{T,N}) = N
+size(S::SharedArray) = size(S.data)
+size(S::SharedArray, i::Integer) = size(S.data, i)
+size(S::SSharedArray) = S.dims
+
+nchunks(S::SharedArray) = nchunks(S.sarray)
+nchunks(S::SSharedArray) = S.cutdim == 0 ? 1 : length(S.refs)+1
+
+nrefs(S::SharedArray) = length(S.sarray.refs)
+
+proc(S::SharedArray, ind::Integer) = S.sarray.refs[ind].where
+
+cutdim(S::SharedArray) = cutdim(S.sarray)
+cutdim(S::SSharedArray) = S.cutdim
+cutdim!(S::SharedArray, dim::Integer) = S.sarray.cutdim = dim
+
+myindex(S::SharedArray) = 0
+
+function myindex(S::SSharedArray)
+    id = myid()
+    if id == 1
+        return 0  # generally this shouldn't occur, since myindex(SharedArray) should cover this
+    end
+    for i = 1:length(S.refs)
+        if id == S.refs[i].where
+            return i
+        end
+    end
+    -1
+end
+
+myarray(S::SharedArray) = S.data
+
+function myarray{T,N}(S::SSharedArray{T,N})
+    ind = myindex(S)
+    if ind == 0
+        return S.data
+    elseif ind > 0
+        return fetch(S.refs[ind])::Array{T,N}
+    end
+    error("No local version of SharedArray")
+end
+
+function myindexes(S::SharedArray)
+    cutdim = S.sarray.cutdim
+    if cutdim == 0
+        return ntuple(ndims(S), i->1:size(S, i))
+    end
+    n = size(S, cutdim)
+    k = nchunks(S)
+    ntuple(ndims(S), i->(i == cutdim) ? (1:iround(n/k)) : (1:size(S, i)) )
+end
+
+function myindexes(S::SSharedArray)
+    ind = myindex(S)
+    if ind < 0
+        return ntuple(ndims(S), i->1:0)
+    end
+    if S.cutdim == 0
+        return ntuple(ndims(S), i->1:S.dims[i])
+    end
+    n = S.dims[S.cutdim]
+    k = nchunks(S)
+    ntuple(ndims(S), i->(i == S.cutdim) ? (iround(ind*n/k)+1:iround((ind+1)*n/k)) : (1:S.dims[i]) )
+end
+
+function pcall(f::Function, args...)
+    for i = 1:length(args)
+        if isa(args[i], SharedArray)
+            return pcall_arg(f, i, args...)
+        end
+    end
+    f(args...), Array(RemoteRef, 0)
+end
+
+function pcall_arg(f::Function, index::Integer, args...)
+    S = args[index]
+    r = Array(RemoteRef, nrefs(S))
+    for i = 1:nrefs(S)
+        r[i] = remotecall(proc(S, i), f, args...)
+    end
+    ret = f(args...)
+    for i = 1:nrefs(S)
+        wait(r[i])
+    end
+    ret, r
+end
+
+# A busy-wait version of pcall
+# done should be created with sharedsync
+function pcall_bw(f::Function, done::SharedArray, args...)
+    n = nrefs(done)
+    fill!(done, false)
+    r = Array(RemoteRef, n)
+    for i = 1:n
+        r[i] = remotecall(proc(done, i), pcall_bw, f, done, args...)
+    end
+    ret = f(args...)
+    while !all(done) end
+    ret, r
+end
+
+function pcall_bw(f::Function, done::SSharedArray, args...)
+    ret = f(args...)
+    bw = myarray(done)
+    bw[myindex(done)] = true
+    ret
+end
+
+getindex(S::SharedArray, ind::Real) = getindex(S.data, ind)
+getindex(S::SharedArray, I::AbstractArray) = getindex(S.data, I)
+setindex!(S::SharedArray, val, ind::Real) = setindex!(S.data, val, ind)
+getindex(S::SharedArray, ind...) = getindex(S.data, ind...)
+setindex!(S::SharedArray, val, ind...) = setindex!(S.data, val, ind...)
+
+# Allow myarray and myindexes to work on arbitrary AbstractArrays,
+# so that algorithms may work for either SharedArrays or other array types
+myarray(A::AbstractArray) = A
+myindexes(A::AbstractArray) = ntuple(ndims(A), i->1:size(A,i))
+
+# Utilities
+function mmap_array(T, dims, filename::String, rd::Bool, wr::Bool, offset)
+    s = open(filename, rd, wr, false, false, false)
+    mmap_array(T, dims, s, offset)
+end
+
+@linux_only ramdisk() = "/dev/shm"
+@unix_only unlink(filename) = ccall(:unlink, Cint, (Ptr{Uint8},), filename)
+
+function defaultcutdim(dims, n)
+    d = length(dims)
+    while d > 0 && n <= dims[d]
+        d -= 1
+    end
+    if d == 0
+        d = indmax(dims)
+    end
+    d
+end
+
+
+end  # module

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -153,6 +153,7 @@ include("combinatorics.jl")
 # distributed arrays and memory-mapped arrays
 include("darray.jl")
 include("mmap.jl")
+include("sharedarrays.jl")
 
 # utilities - version, timing, help, edit, metaprogramming
 include("sysinfo.jl")

--- a/test/sharedarrays.jl
+++ b/test/sharedarrays.jl
@@ -2,7 +2,7 @@ if nprocs() < 4
     addprocs(4-nprocs())
 end
 
-@everywhere using SharedArrays
+@everywhere using Base.SharedArrays
 
 @everywhere function fillme!(A::AbstractArray)
     B = myarray(A)

--- a/test/sharedarrays.jl
+++ b/test/sharedarrays.jl
@@ -1,0 +1,40 @@
+if nprocs() < 4
+    addprocs(4-nprocs())
+end
+
+@everywhere using SharedArrays
+
+@everywhere function fillme!(A::AbstractArray)
+    B = myarray(A)
+    ind = myindexes(A)
+    B[ind...] = myid()
+    A
+end
+
+S = SharedArray(Int, (5, 8))
+
+# Create the result we expect to get
+n = size(S,2)
+target = zeros(Int, size(S,1), n)
+k = nchunks(S)
+for i = 0:k-1
+    ind = iround(i*n/k)+1:iround((i+1)*n/k)
+    target[:,ind] = i+1
+end
+
+ret, rr = pcall(fillme!, S)
+@assert ret == target
+@assert S == target
+fill!(S, 14)  # so we can check that the next runs properly
+bw = sharedsync()
+ret, rr = pcall_bw(fillme!, bw, S)
+@assert ret == target
+@assert S == target
+
+@time pcall(fillme!, S)
+@time pcall_bw(fillme!, bw, S)
+
+# Test that nothing breaks when the number of array elements is smaller
+# than the number of processes
+S = SharedArray(Float64, (2,))
+pcall(fillme!, S)


### PR DESCRIPTION
This is 0.3 material or beyond.

A recent mailing-list [discussion](https://groups.google.com/d/msg/julia-dev/vYtrPgjQl8o/WsQlJ-XUlyYJ), and particularly a comment by Jason Riedy, pointed out a potential strategy for shared-memory parallelism that circumvents some of the problems with other strategies. I've fleshed that basic idea out here, hopefully in a way that provides a fairly nice Julian interface.

This is an RFC for several important reasons: at the moment it's Linux-only, there are API issues to consider, I haven't integrated it into the build process of Julia (it's easier to test and tweak this way, if someone else wants to do so), there are no docs, etc.

Noteworthy features:
- This presents both a natural "array" interface and something suitable for parallelism, which I find to be the most attractive thing about this implementation. The main trick here is subverting the serializer so that we can have the full array version available in process id 1 without a big transport hit (the other processes just see the remote-ref version).
- Compared to PTools' `pfork`, this has a more modest overhead. On my machine `pfork` has approximately 500ms minimum latency even for a trivial computation. Here, the `pcall` form is limited by the event queue, and on my machine seems to have a minimum latency of about 40ms. The busy-wait version `pcall_bw` gets that down to less than 1ms per process.
- It uses shared memory but cleans up after itself nicely, so is a little like Amit's shared memory/server tasks without the risk of leaving resources dangling.

In my view the main API issue to consider is how to handle the return value(s). As an example of the conceptual challenge, many Julia functions have a return like `fill!()`, where the filled array is returned---this is nice because then you can chain together function calls very naturally. However, serializing that output will result in a huge performance hit. So the convention here is to return two things: the full output of the function call on process id 1 (which requires no serialization), and the output of each other process as an array of remote references. In cases where the output is already being stored in a pre-allocated `SharedArray`, none of these outputs matter anyway, because such results are immediately available in the array that exists in process id 1.

CC @amitmurthy.
