### PR TITLE
WIP: Efficient eigenvalue/vector and singular value/vector computations for special LAPACK matrices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,13 @@ Library improvements
 
   * `.juliarc.jl` is now loaded for both script and REPL execution ([#5076]).
 
+  * More routines for specialized matrix types
+    - `Triangular`
+      - generic linear solver `\`, `inv` ([#5255])
+      - generic eigensystems solver `eigvals`, `eigvecs`, `eigfact` ([#5255])
+      - generic `transpose`, `ctranspose`, `istril`, `istriu` ([#5255])
+      - LAPACK wrapper for condition number estimate `cond` ([#5255])
+
 Deprecated or removed
 ---------------------
 
@@ -78,7 +85,7 @@ Deprecated or removed
 [#4670]: https://github.com/JuliaLang/julia/issues/4670
 [#5007]: https://github.com/JuliaLang/julia/issues/5007
 [#5076]: https://github.com/JuliaLang/julia/issues/5076
-
+[#5255]: https://github.com/JuliaLang/julia/issues/5255
 
 Julia v0.2.0 Release Notes
 ==========================

--- a/base/array.jl
+++ b/base/array.jl
@@ -193,17 +193,16 @@ end
 fill(v, dims::Dims)       = fill!(Array(typeof(v), dims), v)
 fill(v, dims::Integer...) = fill!(Array(typeof(v), dims...), v)
 
-zeros{T}(::Type{T}, dims...) = fill!(Array(T, dims...), zero(T))
-zeros(dims...)               = fill!(Array(Float64, dims...), 0.0)
-
-ones{T}(::Type{T}, dims...) = fill!(Array(T, dims...), one(T))
-ones(dims...)               = fill!(Array(Float64, dims...), 1.0)
-
-infs{T}(::Type{T}, dims...) = fill!(Array(T, dims...), inf(T))
-infs(dims...)               = fill!(Array(Float64, dims...), Inf)
-
-nans{T}(::Type{T}, dims...) = fill!(Array(T, dims...), nan(T))
-nans(dims...)               = fill!(Array(Float64, dims...), NaN)
+for (fname, felt) in ((:zeros,:zero),
+                      (:ones,:one),
+                      (:infs,:inf), 
+                      (:nans,:nan))
+    @eval begin
+        ($fname){T}(::Type{T}, dims...) = fill!(Array(T, dims...), ($felt)(T))
+        ($fname)(dims...)               = fill!(Array(Float64, dims...), ($felt)(Float64))
+        ($fname){T}(x::AbstractMatrix{T}) = ($fname)(T, size(x, 1), size(x, 2))
+    end
+end
 
 function eye(T::Type, m::Integer, n::Integer)
     a = zeros(T,m,n)
@@ -219,7 +218,7 @@ eye{T}(x::AbstractMatrix{T}) = eye(T, size(x, 1), size(x, 2))
 
 function one{T}(x::AbstractMatrix{T})
     m,n = size(x)
-    if m != n; error("multiplicative identity defined only for square matrices"); end;
+    m==n || throw(DimensionMismatch("multiplicative identity defined only for square matrices"))
     eye(T, m)
 end
 

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -473,7 +473,7 @@ function cond(A::StridedMatrix, p::Real=2)
     if p == 2
         v = svdvals(A)
         maxv = maximum(v)
-        return maxv == 0.0 ? Inf : maxv / minimum(v)
+        return maxv == 0.0 ? inf(typeof(real(A[1,1]))) : maxv / minimum(v)
     elseif p == 1 || p == Inf
         chksquare(A)
         return cond(lufact(A), p)

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -215,7 +215,7 @@ Ac_ldiv_Bc{T<:BlasComplex}(A::LU{T}, B::StridedVecOrMat{T}) = @assertnonsingular
 
 inv(A::LU)=@assertnonsingular LAPACK.getri!(copy(A.factors), A.ipiv) A.info
 
-cond(A::LU, p) = 1.0/LinAlg.LAPACK.gecon!(p == 1 ? '1' : 'I', A.factors, norm(A[:L][A[:p],:]*A[:U], p))
+cond(A::LU, p) = inv(LAPACK.gecon!(p == 1 ? '1' : 'I', A.factors, norm(A[:L][A[:p],:]*A[:U], p)))
 
 ## QR decomposition without column pivots. By the faster geqrt3
 type QR{S<:BlasFloat} <: Factorization{S}

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -110,5 +110,6 @@ function inv(A::Triangular)
 end
 
 #Generic eigensystems
+eigvals(A::Triangular) = diag(A.UL)
 det(A::Triangular) = prod(eigvals(A))
 

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -42,6 +42,17 @@ A_rdiv_Bc{T<:BlasComplex}(A::StridedVecOrMat{T}, B::Triangular{T}) = BLAS.trsm!(
 
 inv{T<:BlasFloat}(A::Triangular{T}) = LAPACK.trtri!(A.uplo, A.unitdiag, copy(A.UL))
 
+function cond{T<:BlasFloat}(A::Triangular{T}, p::Real=2)
+	chksquare(A)
+	if p==1
+		inv(LAPACK.trcon!('O', A.uplo, A.unitdiag, A.UL))
+	elseif p==Inf
+		inv(LAPACK.trcon!('I', A.uplo, A.unitdiag, A.UL))
+	else #use fallback
+		return cond(full(A), p)
+	end
+end
+
 ####################
 # Generic routines #
 ####################

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -15,13 +15,9 @@ function Triangular(A::Matrix)
     throw(ArgumentError("matrix is not triangular"))
 end
 
-size(A::Triangular, args...) = size(A.UL, args...)
-full(A::Triangular) = (istril(A) ? tril! : triu!)(A.UL)
-
-getindex{T}(A::Triangular{T}, i::Integer, j::Integer) = i == j ? A.UL[i,j] : ((A.uplo == 'U') == (i < j) ? getindex(A.UL, i, j) : zero(T))
-
-istril(A::Triangular) = A.uplo == 'L'
-istriu(A::Triangular) = A.uplo == 'U'
+######################
+# BlasFloat routines #
+######################
 
 # Vector multiplication
 *{T<:BlasFloat}(A::Triangular{T}, b::Vector{T}) = BLAS.trmv(A.uplo, 'N', A.unitdiag, A.UL, b)
@@ -44,7 +40,64 @@ Ac_ldiv_B{T<:BlasComplex}(A::Triangular{T}, B::StridedVecOrMat{T}) = LAPACK.trtr
 A_rdiv_Bc{T<:BlasReal}(A::StridedVecOrMat{T}, B::Triangular{T}) = BLAS.trsm!('R', B.uplo, 'T', B.unitdiag, one(T), B.UL, copy(A))
 A_rdiv_Bc{T<:BlasComplex}(A::StridedVecOrMat{T}, B::Triangular{T}) = BLAS.trsm!('R', B.uplo, 'C', B.unitdiag, one(T), B.UL, copy(A))
 
-det(A::Triangular) = prod(diag(A.UL))
-
 inv{T<:BlasFloat}(A::Triangular{T}) = LAPACK.trtri!(A.uplo, A.unitdiag, copy(A.UL))
-inv(A::Triangular) = inv(Triangular(float(A.UL), A.uplo, A.unitdiag))
+
+####################
+# Generic routines #
+####################
+
+full(A::Triangular) = (istril(A) ? tril! : triu!)(A.UL)
+getindex{T}(A::Triangular{T}, i::Integer, j::Integer) = i == j ? A.UL[i,j] : ((A.uplo == 'U') == (i < j) ? getindex(A.UL, i, j) : zero(T))
+
+istril(A::Triangular) = A.uplo == 'L' || istriu(A.UL)
+istriu(A::Triangular) = A.uplo == 'U' || istril(A.UL)
+
+size(A::Triangular, args...) = size(A.UL, args...)
+
+transpose(A::Triangular) = Triangular(A.UL, A.uplo=='U':'L':'U', A.unitdiag)
+ctranspose(A::Triangular) = conj(transpose(A))
+
+#Generic solver using naive substitution
+function naivesub!(A::Triangular, b::AbstractVector, x::AbstractVector=b)
+    N = size(A, 2)
+    N==length(b)==length(x) || throw(DimensionMismatch(""))
+
+	if A.uplo == 'L' #do forward substitution
+	    for j = 1:N
+	    	x[j] = b[j]
+	        for k = 1:j-1
+	        	x[j] -= A[j,k] * x[k]
+	        end
+	        if A.unitdiag=='N'
+	        	x[j]/= A[j,j]==0 ? throw(SingularException(j)) : A[j,j]
+	        end
+	    end
+    elseif A.uplo == 'U' #do backward substitution
+	    for j = N:-1:1
+	        x[j] = b[j]
+	        for k = j+1:1:N
+	            x[j] -= A[j,k] * x[k]
+	        end
+	        if A.unitdiag=='N'
+	        	x[j]/= A[j,j]==0 ? throw(SingularException(j)) : A[j,j]
+	        end
+	    end
+	else
+		throw(ArgumentError("Unknown uplo=$(A.uplo)"))
+	end
+    x
+end
+\{T<:Number}(A::Triangular{T}, b::AbstractVector{T}) = naivesub!(A, b, similar(b))
+\{T<:Number}(A::Triangular{T}, B::AbstractMatrix{T}) = hcat([naivesub!(A, B[:,i], similar(B[:,i])) for i=1:size(B,2)]...)
+
+function inv(A::Triangular)
+	B = eye(eltype(A), size(A, 1))
+	for i=1:size(B,2)
+		naivesub!(A, B[:,i])
+	end
+	B
+end
+
+#Generic eigensystems
+det(A::Triangular) = prod(eigvals(A))
+

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -82,12 +82,12 @@ end
 ####################
 
 size(A::Triangular, args...) = size(A.UL, args...)
+convert(::Type{Matrix}, A::Triangular) = full(A)
+full(A::Triangular) = A.UL
+
+getindex{T}(A::Triangular{T}, i::Integer, j::Integer) = i == j ? A.UL[i,j] : ((A.uplo == 'U') == (i < j) ? getindex(A.UL, i, j) : zero(T))
 
 print_matrix(io::IO, A::Triangular, rows::Integer, cols::Integer) = print_matrix(io, full(A), rows, cols)
-
-convert(::Type{Matrix}, A::Triangular) = full(A)
-full(A::Triangular) = (istril(A) ? tril! : triu!)(A.UL)
-getindex{T}(A::Triangular{T}, i::Integer, j::Integer) = i == j ? A.UL[i,j] : ((A.uplo == 'U') == (i < j) ? getindex(A.UL, i, j) : zero(T))
 
 istril(A::Triangular) = A.uplo == 'L' || istriu(A.UL)
 istriu(A::Triangular) = A.uplo == 'U' || istril(A.UL)

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -96,6 +96,14 @@ transpose(A::Triangular) = Triangular(A.UL, A.uplo=='U':'L':'U', A.unitdiag)
 ctranspose(A::Triangular) = conj(transpose(A))
 diag(A::Triangular) = diag(A.UL)
 
+#Generic multiplication
+for func in (:*, :Ac_mul_B, :A_mul_Bc, :Ac_ldiv_B, :/, :A_rdiv_Bc)
+    @eval begin
+        ($func){T}(A::Triangular{T}, B::AbstractVector{T}) = ($func)(full(A), B)
+        #($func){T}(A::AbstractArray{T}, B::Triangular{T}) = ($func)(full(A), B)
+    end
+end
+
 #Generic solver using naive substitution
 function naivesub!(A::Triangular, b::AbstractVector, x::AbstractVector=b)
     N = size(A, 2)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -206,6 +206,12 @@ for elty in (Float32, Float64, Complex64, Complex128)
         tx = TM \ b
         @test_approx_eq_eps norm(TM*tx-b) 0 solve_error
         @test_approx_eq_eps norm(x-tx) 0 solve_error
+        #Eigensystems
+        vals, vecs = eig(TM)
+        for i=1:n
+            @test_approx_eq  M*vecs[:,i] vals[i]*vecs[:,i]
+            @test_approx_eq TM*vecs[:,i] vals[i]*vecs[:,i]
+        end
         #Condition number
         for p in [1.0, Inf]
             @test_approx_eq_eps cond(TM, p) cond(M, p) (cond(TM,p)+cond(M,p))*fudgefactor

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -601,7 +601,29 @@ function test_approx_eq_vecs(a, b)
     end
 end
 
-#LAPACK tests for symmetric tridiagonal matrices
+##############################
+# Tests for special matrices #
+##############################
+
+#Triangular matrices
+n=5
+for elty in (Float32, Float64)
+  AUfull = convert(Matrix{elty}, sum([diagm(randn(n-i), i) for i=0:n-1]))
+  for Afull in {AUfull, AUfull'} #Test upper and lower triangular
+    A = Triangular(Afull)
+    #Test eigenvalues/vectors against dense routines
+    d1, d2 = eigvals(A), eigvals(Afull)
+    v1, v2 = eigvecs(A), eigvecs(Afull)
+    @test_approx_eq d1 d2
+    test_approx_eq_vecs(v1, v2)
+    #Test spectral decomposition
+    #XXX This is not the correct error bound
+    @test_approx_eq_eps 0 norm(v1 * diagm(d1) * inv(v1) - Afull) sqrt(eps(elty))
+    @test_approx_eq_eps 0 norm(v2 * diagm(d2) * inv(v2) - Afull) sqrt(eps(elty))
+  end
+end
+
+#SymTridiagonal (symmetric tridiagonal) matrices
 n=5
 Ainit = randn(n)
 Binit = randn(n-1)
@@ -630,7 +652,7 @@ for elty in (Float32, Float64)
 end
 
 
-#Test bidiagonal matrices and their SVDs
+#Bidiagonal matrices
 dv = randn(n)
 ev = randn(n-1)
 for elty in (Float32, Float64, Complex64, Complex128)
@@ -653,24 +675,22 @@ for elty in (Float32, Float64, Complex64, Complex128)
         @test ctranspose(ctranspose(T)) == T
 
         if (elty <: Real)
-            #XXX If I run either of these tests separately, by themselves, things are OK.
-            # Enabling BOTH tests results in segfault.
-            # Where is the memory corruption???
-
-            @test_approx_eq svdvals(full(T)) svdvals(T)
-            u1, d1, v1 = svd(full(T))
+            Tfull = full(T)
+            #Test singular values/vectors
+            @test_approx_eq svdvals(Tfull) svdvals(T)
+            u1, d1, v1 = svd(Tfull)
             u2, d2, v2 = svd(T)
             @test_approx_eq d1 d2
             test_approx_eq_vecs(u1, u2) 
             test_approx_eq_vecs(v1, v2) 
      
             #Test eigenvalues/vectors
-            d1, v1 = eig(full(T))
+            d1, v1 = eig(Tfull)
             d2, v2 = eigvals(T), eigvecs(T)
             @test_approx_eq d1 d2
             test_approx_eq_vecs(v1, v2) 
-            @test_approx_eq_eps 0 norm(v1 * diagm(d1) * inv(v1) - full(T)) 1e-14
-            @test_approx_eq_eps 0 norm(v2 * diagm(d2) * inv(v2) - full(T)) 1e-14
+            @test_approx_eq_eps 0 norm(v1 * diagm(d1) * inv(v1) - Tfull) eps(elty)*n*(n+1)
+            @test_approx_eq_eps 0 norm(v2 * diagm(d2) * inv(v2) - Tfull) eps(elty)*n*(n+1)
         end
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -661,8 +661,16 @@ for elty in (Float32, Float64, Complex64, Complex128)
             u1, d1, v1 = svd(full(T))
             u2, d2, v2 = svd(T)
             @test_approx_eq d1 d2
-            test_approx_eq_vecs(u1, u2)
-            test_approx_eq_vecs(v1, v2)
+            test_approx_eq_vecs(u1, u2) 
+            test_approx_eq_vecs(v1, v2) 
+     
+            #Test eigenvalues/vectors
+            d1, v1 = eig(full(T))
+            d2, v2 = eigvals(T), eigvecs(T)
+            @test_approx_eq d1 d2
+            test_approx_eq_vecs(v1, v2) 
+            @test_approx_eq_eps 0 norm(v1 * diagm(d1) * inv(v1) - full(T)) 1e-14
+            @test_approx_eq_eps 0 norm(v2 * diagm(d2) * inv(v2) - full(T)) 1e-14
         end
     end
 end


### PR DESCRIPTION
Provides new LAPACK wrappers where necessary to provide specialized eigenvalue/vector and singular value/vector routines for `Triangular`, `Tridiagonal`, `SymTridiagonal`, `Bidiagonal` and `Diagonal` matrices.

Related issue: JuliaLang/LinearAlgebra.jl#17
- `Triangular` (provided by JuliaLang/julia#5255)
- `Tridiagonal`
- [ ] `eigvals`
- [ ] `eigvecs`
- [ ] `svdvals`
- [ ] `svdvecs`
- `SymTridiagonal`
- [ ] `eigvals`
- [ ] `eigvecs`
- [ ] `svdvals`
- [ ] `svdvecs`
- `Bidiagonal`
- [ ] `eigvals`
- [ ] `eigvecs`
- [ ] `svdvals`
- [ ] `svdvecs`
- `Diagonal`
- [ ] `eigvals`
- [ ] `eigvecs`
- [ ] `svdvals`
- [ ] `svdvecs`
