### PR TITLE
Improved Pkg error messages

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -282,15 +282,14 @@ function resolve(
     have  :: Dict = Read.free(instd),
 )
     reqs = Query.requirements(reqs,fixed,avail)
-    deps = Query.dependencies(avail,fixed)
+    deps, conflicts = Query.dependencies(avail,fixed)
 
-    incompatible = {}
     for pkg in keys(reqs)
-        haskey(deps,pkg) || push!(incompatible,pkg)
+        if !haskey(deps,pkg)
+            error("$pkg's requirements can't be satisfied because of the following fixed packages: ",
+                   join(conflicts[pkg], ", ", " and "))
+        end
     end
-    isempty(incompatible) ||
-        error("The following packages are incompatible with fixed requirements: ",
-              join(incompatible, ", ", " and "))
 
     deps = Query.prune_dependencies(reqs,deps)
     want = Resolve.resolve(reqs,deps)

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -281,7 +281,7 @@ function resolve(
     fixed :: Dict = Read.fixed(avail,instd),
     have  :: Dict = Read.free(instd),
 )
-    reqs = Query.requirements(reqs,fixed)
+    reqs = Query.requirements(reqs,fixed,avail)
     deps = Query.dependencies(avail,fixed)
 
     incompatible = {}

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -291,6 +291,8 @@ function resolve(
         end
     end
 
+    Query.check_requirements(reqs,deps,fixed)
+
     deps = Query.prune_dependencies(reqs,deps)
     want = Resolve.resolve(reqs,deps)
 

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -3,8 +3,11 @@ module Query
 import ...Pkg
 using ..Types
 
-function requirements(reqs::Dict, fix::Dict)
+function requirements(reqs::Dict, fix::Dict, avail::Dict)
     for (p1,f1) in fix
+        for p2 in keys(f1.requires)
+            haskey(avail, p2) || haskey(fix, p2) || error("unknown package $p2 required by $p1")
+        end
         satisfies(p1, f1.version, reqs) ||
             warn("$p1 is fixed at $(f1.version) conflicting with top-level requirement: $(reqs[p1])")
         for (p2,f2) in fix

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -129,8 +129,8 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
         @assert !haskey(allowed, p)
         allowed[p] = (VersionNumber=>Bool)[]
         allowedp = allowed[p]
-        for (vn,_) in deps[p]
-            allowedp[vn] = in(vn, vs)
+        for vn in keys(deps[p])
+            allowedp[vn] = vn in vs
         end
         @assert !isempty(allowedp)
         @assert any(collect(values(allowedp)))
@@ -157,7 +157,7 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
 
         # Extract unique dependencies lists (aka classes), thereby
         # assigning an index to each class.
-        uniqdepssets = unique([a for (_,a) in fdepsp])
+        uniqdepssets = unique(values(fdepsp))
 
         # Store all dependencies seen so far for later use
         for a in uniqdepssets, r in a.requires
@@ -174,7 +174,7 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
         @assert !haskey(vmask, p)
         vmask[p] = (VersionNumber=>BitVector)[]
         vmaskp = vmask[p]
-        for (vn,_) in fdepsp
+        for vn in keys(fdepsp)
             vmaskp[vn] = falses(luds)
         end
         for (vn,a) in fdepsp
@@ -207,7 +207,7 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
     pruned_vers = (ByteString=>Vector{VersionNumber})[]
     eq_classes = (ByteString=>Dict{VersionNumber,Vector{VersionNumber}})[]
     for (p, vmaskp) in vmask
-        vmask0_uniq = unique([vm for (_,vm) in vmaskp])
+        vmask0_uniq = unique(values(vmaskp))
         nc = length(vmask0_uniq)
         classes = [ VersionNumber[] for c0 = 1:nc ]
         for (vn,vm) in vmaskp
@@ -245,7 +245,7 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
         haskey(eq_classes, p) && continue
         eq_classes[p] = (VersionNumber=>Vector{VersionNumber})[]
         eqclassp = eq_classes[p]
-        for (vn,_) in depsp
+        for vn in keys(depsp)
             eqclassp[vn] = [vn]
         end
     end
@@ -304,8 +304,8 @@ function dependencies_subset(deps::Dict{ByteString,Dict{VersionNumber,Available}
     allpkgs = pkgs
     while !isempty(staged)
         staged_next = Set{ByteString}()
-        for p in staged, (_,a) in deps[p], (rp,_) in a.requires
-            if !in(rp, allpkgs)
+        for p in staged, a in values(deps[p]), rp in keys(a.requires)
+            if !(rp in allpkgs)
                 push!(staged_next, rp)
             end
         end

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -15,7 +15,7 @@ function requirements(reqs::Dict, fix::Dict, avail::Dict)
                 warn("$p1 is fixed at $(f1.version) conflicting with requirement for $p2: $(f2.requires[p1])")
         end
     end
-    reqs = copy(reqs)
+    reqs = deepcopy(reqs)
     for (p1,f1) in fix
         merge_requires!(reqs, f1.requires)
     end

--- a/base/pkg/types.jl
+++ b/base/pkg/types.jl
@@ -3,7 +3,7 @@ module Types
 export VersionInterval, VersionSet, Requires, Available, Fixed,
        merge_requires!, satisfies, @recover
 
-import Base: show, isempty, in, intersect, isequal, hash
+import Base: show, isempty, in, intersect, isequal, hash, deepcopy_internal
 
 immutable VersionInterval
     lower::VersionNumber
@@ -47,6 +47,7 @@ function intersect(A::VersionSet, B::VersionSet)
 end
 isequal(A::VersionSet, B::VersionSet) = (A.intervals == B.intervals)
 hash(s::VersionSet) = hash(s.intervals)
+deepcopy_internal(vs::VersionSet, ::ObjectIdDict) = VersionSet(copy(vs.intervals))
 
 typealias Requires Dict{ByteString,VersionSet}
 

--- a/base/pkg/types.jl
+++ b/base/pkg/types.jl
@@ -40,6 +40,7 @@ isempty(s::VersionSet) = all(i->isempty(i), s.intervals)
 in(v::VersionNumber, s::VersionSet) = any(i->in(v,i), s.intervals)
 function intersect(A::VersionSet, B::VersionSet)
     ivals = vec([ intersect(a,b) for a in A.intervals, b in B.intervals ])
+    ivals = copy(ivals) # temporary bandaid for issue #4592
     filter!(i->!isempty(i), ivals)
     sort!(ivals, by=i->i.lower)
     VersionSet(ivals)


### PR DESCRIPTION
This mainly addresses #4049. It may also hotfix #4311.

The simplest and most common situations should be addressed here, in particular:
- misspelling a package name (e.g. DateTime instead of Datetime) results in an "unknown package" error
- when some required package can't be installed because its requirements are not satisfied by the fixed packages, this is explicitly stated, and the information about what fixed packages are to blame is also printed
- when some required package has no possible version as a consequence of fixed packages' requirements, this is detected and some useful information is printed

See also comments in commit messages.

More complex situations are still left out and could possibly be addressed in 0.2.x.

It's left as a PR mainly for code style review (@StefanKarpinski), but testing is also encouraged of course, especially by people with more complex `.julia` setups.
