### PR TITLE
Query.Dependencies now returns a tuple Fix #4607

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -479,7 +479,7 @@ function check_metadata()
     avail = Read.available()
     instd = Read.installed(avail)
     fixed = Read.fixed(avail,instd,VERSION)
-    deps  = Query.dependencies(avail,fixed)
+    deps,conflict  = Query.dependencies(avail,fixed)
 
     problematic = Resolve.sanity_check(deps)
     if !isempty(problematic)


### PR DESCRIPTION
Fix `Pkg.Entry.check_metatdata` due to api changes in  https://github.com/JuliaLang/julia/commit/69f930e6c01d6ff049dd100cf12ca0ec7fd4aa41

This in turn is causing the METADATA.jl travis tests to fail. https://travis-ci.org/JuliaLang/METADATA.jl/builds/12866672
