### PR TITLE
Revised csc_symperm

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -661,6 +661,7 @@ export
     sprandbool,
     sprandn,
     spzeros,
+    symperm,
 
 # bitarrays
     bitpack,

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -301,8 +301,8 @@ function *{T<:BlasFloat}(A::QRPackedQ{T}, B::StridedVecOrMat{T})
     end
     LAPACK.gemqrt!('L', 'N', A.vs, A.T, Bc)
 end
-Ac_mul_B{T<:BlasReal}(A::QRPackedQ{T}, B::StridedVecOrMat) = LAPACK.gemqrt!('L','T',A.vs,A.T,copy(B))
-Ac_mul_B{T<:BlasComplex}(A::QRPackedQ{T}, B::StridedVecOrMat) = LAPACK.gemqrt!('L','C',A.vs,A.T,copy(B))
+Ac_mul_B{T<:BlasReal}(A::QRPackedQ{T}, B::StridedVecOrMat{T}) = LAPACK.gemqrt!('L','T',A.vs,A.T,copy(B))
+Ac_mul_B{T<:BlasComplex}(A::QRPackedQ{T}, B::StridedVecOrMat{T}) = LAPACK.gemqrt!('L','C',A.vs,A.T,copy(B))
 *{T<:BlasFloat}(A::StridedVecOrMat{T}, B::QRPackedQ{T}) = LAPACK.gemqrt!('R', 'N', B.vs, B.T, copy(A))
 function A_mul_Bc{T<:BlasFloat}(A::StridedVecOrMat{T}, B::QRPackedQ{T})
     m = size(A, 1)
@@ -417,8 +417,8 @@ function *{T<:BlasFloat}(A::QRPivotedQ{T}, B::StridedVecOrMat{T})
     end
     LAPACK.ormqr!('L', 'N', A.hh, A.tau, Bc)
 end
-Ac_mul_B{T<:BlasReal}(A::QRPivotedQ{T}, B::StridedVecOrMat) = LAPACK.ormqr!('L','T',A.hh,A.tau,copy(B))
-Ac_mul_B{T<:BlasComplex}(A::QRPivotedQ{T}, B::StridedVecOrMat) = LAPACK.ormqr!('L','C',A.hh,A.tau,copy(B))
+Ac_mul_B{T<:BlasReal}(A::QRPivotedQ{T}, B::StridedVecOrMat{T}) = LAPACK.ormqr!('L','T',A.hh,A.tau,copy(B))
+Ac_mul_B{T<:BlasComplex}(A::QRPivotedQ{T}, B::StridedVecOrMat{T}) = LAPACK.ormqr!('L','C',A.hh,A.tau,copy(B))
 *(A::StridedVecOrMat, B::QRPivotedQ) = LAPACK.ormqr!('R', 'N', B.hh, B.tau, copy(A))
 function A_mul_Bc{T<:BlasFloat}(A::StridedVecOrMat{T}, B::QRPivotedQ{T})
     m = size(A, 1)

--- a/base/sparse.jl
+++ b/base/sparse.jl
@@ -9,7 +9,7 @@ export SparseMatrixCSC,
        dense, diag, diagm, droptol!, dropzeros!, etree, full, 
        getindex, ishermitian, issparse, issym, istril, istriu, 
        setindex!, sparse, sparsevec, spdiagm, speye, spones, 
-       sprand, sprandbool, sprandn, spzeros, trace, tril, tril!, 
+       sprand, sprandbool, sprandn, spzeros, symperm, trace, tril, tril!, 
        triu, triu!
 
 include("sparse/sparsematrix.jl")

--- a/base/sparse/csparse.jl
+++ b/base/sparse/csparse.jl
@@ -294,7 +294,7 @@ end
 
 # based on cs_symperm p. 21, "Direct Methods for Sparse Linear Systems"
 # form A[p,p] for a symmetric A stored in the upper triangle
-function csc_symperm{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, pinv::Vector{Ti})
+function symperm{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, pinv::Vector{Ti})
     m,n = size(A); Ap = A.colptr; Ai = A.rowval; Ax = A.nzval
     isperm(pinv) || error("perm must be a permutation")
     m == n == length(pinv) || error("Dimension mismatch")

--- a/doc/stdlib/sparse.rst
+++ b/doc/stdlib/sparse.rst
@@ -71,4 +71,8 @@ Sparse matrices support much of the same set of operations as dense matrices. Th
 
    Compute the elimination tree of a symmetric sparse matrix ``A`` from ``triu(A)`` and, optionally, its post-ordering permutation.
 
+.. function:: symperm(A, p)
+
+   Return the symmetric permutation of A, which is ``A[p,p]``.
+
 


### PR DESCRIPTION
A more careful reading of the `cs_symperm` function in CSparse was needed.
The CSparse function `cs_cumsum` has unexpected side-effects that need to
be emulated by copying the first `n` positions in the cumulative sum back to
the work vector `w`.  Also, the `w` vector must be initialized to zeros.

The `csc_symperm` function was hidden in the `Base.` namespace and it is doubtful
anyone else ever used it.
