### PR TITLE
Small adjustments to apprend!/preprend!

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -668,7 +668,7 @@ function push!(a::Array{Any,1}, item::ANY)
     return a
 end
 
-function append!{T}(a::Array{T,1}, items::Vector)
+function append!{T}(a::Array{T,1}, items::AbstractVector)
     if is(T,None)
         error(_grow_none_errmsg)
     end
@@ -679,7 +679,7 @@ function append!{T}(a::Array{T,1}, items::Vector)
     return a
 end
 
-function prepend!{T}(a::Array{T,1}, items::Array{T,1})
+function prepend!{T}(a::Array{T,1}, items::AbstractVector)
     if is(T,None)
         error(_grow_none_errmsg)
     end

--- a/base/array.jl
+++ b/base/array.jl
@@ -673,6 +673,7 @@ function append!{T}(a::Array{T,1}, items::Vector)
         error(_grow_none_errmsg)
     end
     n = length(items)
+    a === items && (items = copy(items))
     ccall(:jl_array_grow_end, Void, (Any, Uint), a, n)
     a[end-n+1:end] = items
     return a
@@ -683,6 +684,7 @@ function prepend!{T}(a::Array{T,1}, items::Array{T,1})
         error(_grow_none_errmsg)
     end
     n = length(items)
+    a === items && (items = copy(items))
     ccall(:jl_array_grow_beg, Void, (Any, Uint), a, n)
     a[1:n] = items
     return a


### PR DESCRIPTION
A couple of trivial commits:
- Fix the case in which one tries to append/prepend a Vector to itself, by making a copy before growing. It could probably be handled more efficiently, but at least this avoids the error.
- Relax the type signature and allow a generic AbstractVector to be appended/preprended; I don't see anything against this, but I'm not sure of why it was restricted originally; in any case, the two functions has a different signature for the second argument, which seems wrong.
