### PR TITLE
Added reference to ``put`` in parallel-computing.rst

### DIFF
--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -37,7 +37,7 @@ return immediately; the process that made the call proceeds to its
 next operation while the remote call happens somewhere else. You can
 wait for a remote call to finish by calling ``wait`` on its remote
 reference, and you can obtain the full value of the result using
-``fetch``.
+``fetch``. You can store a value to a remote reference using ``put``.
 
 Let's try this out. Starting with ``julia -p n`` provides ``n`` worker
 processes on the local machine. Generally it makes sense for ``n`` to


### PR DESCRIPTION
Previously there was no mention on how to load a value into a remote reference.
