### PR TITLE
run `;cmd` through a shell

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -57,14 +57,15 @@ function repl_cmd(cmd)
         end
         println(pwd())
     else
-        run(cmd)
+        shell = get(ENV,"SHELL","/bin/sh")
+        run(detach(`$shell -i -c "$(shell_escape(cmd))"`))
     end
     nothing
 end
 
 function repl_hook(input::String)
-    return Expr(:call, :(Base.repl_cmd),
-                macroexpand(Expr(:macrocall,symbol("@cmd"),input)))
+    Expr(:call, :(Base.repl_cmd),
+         macroexpand(Expr(:macrocall,symbol("@cmd"),input)))
 end
 
 function repl_methods(input::String)

--- a/base/client.jl
+++ b/base/client.jl
@@ -52,13 +52,14 @@ function repl_cmd(cmd)
         if length(cmd.exec) > 2
             error("cd method only takes one argument")
         elseif length(cmd.exec) == 2
-            cd(readchomp(`$shell -c "echo $(shell_escape(cmd.exec[2]))"`))
+            dir = cmd.exec[2]
+            cd(@windows? dir : readchomp(`$shell -c "echo $(shell_escape(dir))"`))
         else
             cd()
         end
         println(pwd())
     else
-        run(detach(`$shell -i -c "$(shell_escape(cmd))"`))
+        run(@windows? cmd : detach(`$shell -i -c "$(shell_escape(cmd))"`))
     end
     nothing
 end

--- a/base/client.jl
+++ b/base/client.jl
@@ -45,19 +45,19 @@ function repl_callback(ast::ANY, show_value)
 end
 
 function repl_cmd(cmd)
+    shell = get(ENV,"SHELL","/bin/sh")
     if isempty(cmd.exec)
         error("no cmd to execute")
     elseif cmd.exec[1] == "cd"
         if length(cmd.exec) > 2
             error("cd method only takes one argument")
         elseif length(cmd.exec) == 2
-            cd(cmd.exec[2])
+            cd(readchomp(`$shell -c "echo $(shell_escape(cmd.exec[2]))"`))
         else
             cd()
         end
         println(pwd())
     else
-        shell = get(ENV,"SHELL","/bin/sh")
         run(detach(`$shell -i -c "$(shell_escape(cmd))"`))
     end
     nothing


### PR DESCRIPTION
I like this behavior a _lot_ better – it behaves like your shell, which is really much nicer. If people like this, I think we should do it. There is a remaining issue with it, however, which is that there's no way to use shell variables.
