### PR TITLE
Provide a build option USE_LLVM_SHLIB to help #2494

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -32,9 +32,13 @@ USE_SYSTEM_LIBUV=0
 USE_MKL = 0
 MKLLIB = $(MKLROOT)/lib/intel64
 
+# Link to the LLVM shared library
+USE_LLVM_SHLIB = 0
+
 # Set to 1 to enable profiling with Intel VTune Amplifier
 USE_INTEL_JITEVENTS = 0
 
+# libc++ is standard on OS X 10.9, but not for earlier releases
 USE_LIBCPP = 0
 
 # we include twice to pickup user definitions better

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,6 @@
 JULIAHOME = $(abspath ..)
 include $(JULIAHOME)/Make.inc
+include $(JULIAHOME)/deps/Versions.make
 
 override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
@@ -15,7 +16,12 @@ FLAGS = \
 	-I$(call exec,$(LLVM_CONFIG) --includedir) \
 	-I$(LIBUV_INC) -I$(JULIAHOME)/usr/include
 
-LIBS = $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a -L$(BUILD)/lib $(LIBUV) $(NO_WHOLE_ARCHIVE) $(call exec,$(LLVM_CONFIG) --libs) $(call exec,$(LLVM_CONFIG) --ldflags) $(OSLIBS)
+LLVMLINK = $(call exec,$(LLVM_CONFIG) --libs)
+ifeq ($(USE_LLVM_SHLIB),1)
+LLVMLINK = -lLLVM-$(LLVM_VER)
+endif
+
+LIBS = $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a -L$(BUILD)/lib $(LIBUV) $(NO_WHOLE_ARCHIVE) $(call exec,$(LLVM_CONFIG) --ldflags) $(LLVMLINK) $(OSLIBS)
 
 ifneq ($(MAKECMDGOALS),debug)
 TARGET =


### PR DESCRIPTION
This makes it possible to link LLVM as a shared library. If this ever becomes the default, the install targets will need to be updated to also distribute `libLLVM-3.x.{dylib,so,dll}`.
