### PR TITLE
WIP: Add sendto() method to Base

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1025,6 +1025,7 @@ export
 
 # I/O and events
     accept,
+    bindudp,
     close,
     connect,
     countlines,
@@ -1069,6 +1070,7 @@ export
     readline,
     readlines,
     readuntil,
+    recv,
     redirect_stderr,
     redirect_stdin,
     redirect_stdout,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1075,6 +1075,7 @@ export
     seek,
     seekend,
     seekstart,
+    sendto,
     serialize,
     skip,
     skipchars,

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -335,6 +335,9 @@ accept(server::TcpServer) = accept(server, TcpSocket())
 accept(server::PipeServer) = accept(server, Pipe())
 
 ##
+sendto(data, host::IPv4, port::Uint16) =
+    ccall(:jl_send_to,Int32,(Ptr{Void},Ptr{Uint8},Uint32,Uint32, Uint16),
+    eventloop(),data,sizeof(data),hton(host.host),hton(port))
 
 bind(sock::TcpServer, addr::InetAddr) = bind(sock,addr.host,addr.port)
 bind(sock::TcpServer, host::IpAddr, port) = bind(sock, InetAddr(host,port))

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -2276,6 +2276,12 @@
 
 "),
 
+("Network I/O","Base","sendto","sendto(data, host::IPv4, port)
+
+   Send UDP packet containing data to the host port combination
+
+"),
+
 ("Network I/O","Base","nb_available","nb_available(stream)
 
    Returns the number of bytes available for reading before a read

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1476,6 +1476,10 @@ Network I/O
 
    Returns IPv6 object from ip address formatted as Integer  
 
+.. function:: sendto(data, host::IPv4, port)
+
+   Send UDP packet containing data to the host port combination
+
 .. function:: nb_available(stream)
 
    Returns the number of bytes available for reading before a read from this stream or buffer will block.

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -178,6 +178,12 @@ DLLEXPORT void jl_uv_connectcb(uv_connect_t *connect, int status)
     (void)ret;
 }
 
+DLLEXPORT void jl_uv_send_tocb(uv_udp_send_t *req, int status)
+{
+    uv_close((uv_handle_t*) req->handle, &jl_uv_closeHandle);
+    free(req);
+}
+
 DLLEXPORT void jl_uv_connectioncb(uv_stream_t *stream, int status)
 {
     JULIA_CB(connectioncb,stream->data,1,CB_INT32,status);
@@ -784,7 +790,7 @@ DLLEXPORT int jl_send_to(uv_loop_t *loop, char *value, uint32_t size, uint32_t h
     addr.sin_port = port;
 
     uv_buf_t buf[]  = {{.base = value,.len=size}};
-    return uv_udp_send(req, handle, buf, 1, addr, NULL);
+    return uv_udp_send(req, handle, buf, 1, addr, &jl_uv_send_tocb);
 }
 
 DLLEXPORT char *jl_ios_buf_base(ios_t *ios)

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -770,6 +770,23 @@ DLLEXPORT int jl_connect_raw(uv_tcp_t *handle,struct sockaddr_storage *addr)
     return -2; //error! Only IPv4 and IPv6 are implemented atm
 }
 
+DLLEXPORT int jl_send_to(uv_loop_t *loop, char *value, uint32_t size, uint32_t host, uint16_t port)
+{
+    uv_udp_t *handle = malloc(sizeof(uv_udp_t));
+    handle->data = 0;
+    uv_udp_init(loop, handle);
+    struct sockaddr_in addr;
+    uv_udp_send_t *req = malloc(sizeof(uv_udp_send_t));
+    req->data = 0;
+    memset(&addr, 0, sizeof(struct sockaddr_in));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = host;
+    addr.sin_port = port;
+
+    uv_buf_t buf[]  = {{.base = value,.len=size}};
+    return uv_udp_send(req, handle, buf, 1, addr, NULL);
+}
+
 DLLEXPORT char *jl_ios_buf_base(ios_t *ios)
 {
     return ios->buf;

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -83,6 +83,7 @@
     jl_forceclose_uv;
     jl_compile_hint;
     jl_compress_ast;
+    jl_send_to;
     jl_connect_raw;
     jl_continue_sym;
     jl_core_module;

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -257,6 +257,7 @@
     jl_backtrace_from_here;
     jl_lookup_code_address;
     jl_read_sonames;
+    jl_recv;
     rec_backtrace;
     profile_init;
     profile_get_data;
@@ -330,6 +331,7 @@
     jl_tcp_bind6;
     jl_tcp_init;
     jl_test;
+    jl_udp_bind;
     jl_poll_start;
     jl_fs_poll_start;
     jl_fs_event_init;

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -79,3 +79,12 @@ try
 catch e
     @test typeof(e) == Base.UVError
 end
+
+
+#UDP Test
+server = bindudp(parseip("127.0.0.1"), uint16(2134))
+sendto("Hello UDP world\n", parseip("127.0.0.1"), uint16(2134))
+(data, sname, sport) = recv(server)
+@test ASCIIString(data) == "Hello UDP world\n"
+@test sname == parseip("127.0.0.1")
+close(server)


### PR DESCRIPTION
This adds a hook into libuv's libuv_udp_send() method. Some future commits might add on some additional UDP support, but this is all the functionality I need for the moment. Any tests will need to come later when support is more complete (ie there is some receiving support), though some manual tests with an external UDP listener seem to indicate that this method works properly.
