### PR TITLE
RFC: Immediately return true for equality checks if is(A,B)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1031,6 +1031,7 @@ end
 ## Reductions and scans ##
 
 function isequal(A::AbstractArray, B::AbstractArray)
+    if A === B return true end
     if size(A) != size(B)
         return false
     end
@@ -1054,6 +1055,7 @@ function lexcmp(A::AbstractArray, B::AbstractArray)
 end
 
 function (==)(A::AbstractArray, B::AbstractArray)
+    if A === B return true end
     if size(A) != size(B)
         return false
     end


### PR DESCRIPTION
Perhaps I'm missing something but why not immediately return true from these checks if the two objects are identical?  If this is valid there are likely other places this could happen too...but I thought I would first check.

Thanks,

Glen
