### PR TITLE
io: always returning true is a lousy API design, return the IO arg.

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -271,23 +271,31 @@ isreadonly(s::IOStream) = bool(ccall(:ios_get_readonly, Cint, (Ptr{Void},), s.io
 iswritable(s::IOStream) = !isreadonly(s)
 isreadable(s::IOStream) = true
 
-truncate(s::IOStream, n::Integer) =
-    (ccall(:ios_trunc, Int32, (Ptr{Void}, Uint), s.ios, n)==0 ||
-     error("truncate failed"))
+function truncate(s::IOStream, n::Integer)
+    ccall(:ios_trunc, Int32, (Ptr{Void}, Uint), s.ios, n) == 0 ||
+        error("truncate failed")
+    return s
+end
 
-seek(s::IOStream, n::Integer) =
-    (ccall(:ios_seek, FileOffset, (Ptr{Void}, FileOffset), s.ios, n)==0 ||
-     error("seek failed"))
+function seek(s::IOStream, n::Integer)
+    ccall(:ios_seek, FileOffset, (Ptr{Void}, FileOffset), s.ios, n)==0 ||
+        error("seek failed")
+    return s
+end
 
-seekstart(s::IO) = seek(s, 0)
+seekstart(s::IO) = seek(s,0)
 
-seekend(s::IOStream) =
-    (ccall(:ios_seek_end, FileOffset, (Ptr{Void},), s.ios)==0 ||
-     error("seekend failed"))
+function seekend(s::IOStream)
+    ccall(:ios_seek_end, FileOffset, (Ptr{Void},), s.ios)==0 ||
+        error("seekend failed")
+    return s
+end
 
-skip(s::IOStream, delta::Integer) =
-    (ccall(:ios_skip, FileOffset, (Ptr{Void}, FileOffset), s.ios, delta)==0 ||
-     error("skip failed"))
+function skip(s::IOStream, delta::Integer)
+    ccall(:ios_skip, FileOffset, (Ptr{Void}, FileOffset), s.ios, delta)==0 ||
+        error("skip failed")
+    return s
+end
 
 position(s::IOStream) = ccall(:ios_pos, FileOffset, (Ptr{Void},), s.ios)
 
@@ -509,6 +517,7 @@ function skipchars(s::IOStream, pred; linecomment::Char=char(0xffffffff))
         end
         ch = peekchar(s); status = int(ch)
     end
+    return s
 end
 
 # BitArray I/O

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -89,17 +89,21 @@ iswritable(io::IOBuffer) = io.writable
 # This should maybe be sizeof() instead.
 #length(io::IOBuffer) = (io.seekable ? io.size : nb_available(io))
 nb_available(io::IOBuffer) = io.size - io.ptr + 1
-skip(io::IOBuffer, n::Integer) = (io.ptr = min(io.ptr + n, io.size+1))
+position(io::IOBuffer) = io.ptr-1
+
+function skip(io::IOBuffer, n::Integer)
+    io.ptr = min(io.ptr + n, io.size+1)
+    return io
+end
 function seek(io::IOBuffer, n::Integer)
     if !io.seekable error("seek failed") end
     io.ptr = min(n+1, io.size+1)
-    return true
+    return io
 end
 function seekend(io::IOBuffer)
     io.ptr = io.size+1
-    return true
+    return io
 end
-position(io::IOBuffer) = io.ptr-1
 function truncate(io::IOBuffer, n::Integer)
     if !io.writable error("truncate failed") end
     if !io.seekable error("truncate failed") end #because absolute offsets are meaningless
@@ -110,15 +114,16 @@ function truncate(io::IOBuffer, n::Integer)
     io.data[io.size+1:n] = 0
     io.size = n
     io.ptr = min(io.ptr, n+1)
-    return true
+    return io
 end
 function compact(io::IOBuffer)
     if !io.writable error("compact failed") end
     if io.seekable error("compact failed") end
-    ccall(:memmove, Ptr{Void}, (Ptr{Void},Ptr{Void},Uint), io.data, pointer(io.data,io.ptr), nb_available(io))
+    ccall(:memmove, Ptr{Void}, (Ptr{Void},Ptr{Void},Uint),
+          io.data, pointer(io.data,io.ptr), nb_available(io))
     io.size -= io.ptr - 1
     io.ptr = 1
-    return true
+    return io
 end
 function ensureroom(io::IOBuffer, nshort::Int)
     if !io.writable error("ensureroom failed") end

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -2,41 +2,41 @@ ioslength(io::IOBuffer) = (io.seekable ? io.size : nb_available(io))
 
 let io = IOBuffer()
 @test eof(io)
-@test try read(io,Uint8); false; catch e; isa(e,EOFError); end
+@test_throws read(io,Uint8)
 @test write(io,"abc") == 3
 @test ioslength(io) == 3
 @test position(io) == 3
 @test eof(io)
-@test seek(io, 0)
-@test read(io, Uint8) == 'a'
+seek(io, 0)
+@test read(io,Uint8) == 'a'
 a = Array(Uint8, 2)
 @test read(io, a) == a
 @test a == ['b','c']
 @test bytestring(io) == "abc"
-@test seek(io, 1)
-@test truncate(io, 2)
+seek(io, 1)
+truncate(io, 2)
 @test position(io) == 1
 @test !eof(io)
-@test seekend(io)
+seekend(io)
 @test position(io) == 2
-@test truncate(io, 0)
+truncate(io, 0)
 @test position(io) == 0
-@test truncate(io, 10)
+truncate(io, 10)
 @test position(io) == 0
 @test all(io.data .== 0)
 @test write(io,Int16[1,2,3,4,5,6]) == 12
-@test seek(io,2)
-@test truncate(io, 10)
+seek(io, 2)
+truncate(io, 10)
 @test ioslength(io) == 10
 io.readable = false
-@test try read(io,Uint8[0]); false; catch e; true; end
-@test truncate(io, 0)
+@test_throws read(io,Uint8[0])
+truncate(io, 0)
 @test write(io,"boston\ncambridge\n") > 0
 @test takebuf_string(io) == "boston\ncambridge\n"
 @test takebuf_string(io) == ""
 close(io)
-@test try write(io,Uint8[0]); false; catch e; true; end
-@test try seek(io,0); false; catch e; true; end
+@test_throws write(io,Uint8[0])
+@test_throws seek(io,0)
 @test eof(io)
 end
 
@@ -44,19 +44,19 @@ let io = IOBuffer("hamster\nguinea pig\nturtle")
 @test position(io) == 0
 @test readline(io) == "hamster\n"
 @test readall(io) == "guinea pig\nturtle"
-@test try read(io,Uint8); false; catch e; isa(e,EOFError); end
-@test seek(io,0)
+@test_throws read(io,Uint8)
+seek(io,0)
 @test read(io,Uint8) == 'h'
-@test try truncate(io,0); false; catch e; true; end
-@test try write(io,uint8(0)); false; catch e; true; end
-@test try write(io,Uint8[0]); false; catch e; true; end
+@test_throws truncate(io,0)
+@test_throws write(io,uint8(0))
+@test_throws write(io,Uint8[0])
 @test takebuf_string(io) == "hamster\nguinea pig\nturtle"
 @test takebuf_string(io) == "hamster\nguinea pig\nturtle" #should be unchanged
 close(io)
 end
 
 let io = PipeBuffer()
-@test try read(io,Uint8); false; catch e; isa(e,EOFError); end
+@test_throws read(io,Uint8)
 @test write(io,"pancakes\nwaffles\nblueberries\n") > 0
 @test position(io) == 0
 @test readline(io) == "pancakes\n"
@@ -64,8 +64,8 @@ Base.compact(io)
 @test readline(io) == "waffles\n"
 @test write(io,"whipped cream\n") > 0
 @test readline(io) == "blueberries\n"
-@test try seek(io,0); false; catch e; true; end
-@test try truncate(io,0); false; catch e; true; end
+@test_throws seek(io,0)
+@test_throws truncate(io,0)
 @test readline(io) == "whipped cream\n"
 Base.compact(io)
 @test position(io) == 0
@@ -81,7 +81,7 @@ io.maxsize = 75
 Base.ensureroom(io,100)
 @test ioslength(io) == 0
 @test length(io.data) == 75
-@test seekend(io)
+seekend(io)
 @test ioslength(io) == 0
 @test position(io) == 0
 write(io,zeros(Uint8,200))
@@ -116,7 +116,6 @@ skip(io,72)
 
 # issues 4021
 print(io, true)
-
 close(io)
 end
 


### PR DESCRIPTION
This changes imperative IO functions that don't return anything that
has meaning (e.g. always true) to return the IO object they were
called on instead, which allows chaining. Moreover, the API was
inconsitent before – the return type depended on the type of input.
