### PR TITLE
Fix qr multiplication

### DIFF
--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -1417,14 +1417,16 @@ for (orglq, orgqr, ormlq, ormqr, gemqrt, elty) in
             if k == 0 return C end
             if side == 'L'
                 0 <= k <= m || error("Wrong value for k")
-                ldv = max(1, m)
+                m == size(V,1) || throw(DimensionMismatch(""))
+                ldv = stride(V,2)
+                ldv >= max(1, m) || throw(DimensionMismatch("Q and C don't fit"))
                 wss = n*k
-                # if m != size(V, 1) throw(DimensionMismatch("")) end
             elseif side == 'R'
                 0 <= k <= n || error("Wrong value for k")
-                ldv = max(1, n)
+                n == size(V,1) || throw(DimensionMismatch(""))
+                ldv = stride(V,2)
+                ldv >= max(1, n) || throw(DimensionMismatch("Stride error"))
                 wss = m*k
-                # if n != size(V, 1) throw(DimensionMismatch("")) end
             else
                 error("side must be either 'L' or 'R'")
             end

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -85,7 +85,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
 .. function:: qrfact(A)
 
-   Compute the QR factorization of ``A`` and return a ``QR`` object. The components of the factorization ``F`` can be accessed as follows: the orthogonal matrix ``Q`` can be extracted with ``F[:Q]`` and the triangular matrix ``R`` with ``F[:R]``. The following functions are available for ``QR`` objects: ``size``, ``\``. When ``Q`` is extracted, the resulting type is the ``QRPackedQ`` object, and has the ``*`` operator overloaded to support efficient multiplication by ``Q`` and ``Q'``.
+   Compute the QR factorization of ``A`` and return a ``QR`` object. The components of the factorization ``F`` can be accessed as follows: the orthogonal matrix ``Q`` can be extracted with ``F[:Q]`` and the triangular matrix ``R`` with ``F[:R]``. The following functions are available for ``QR`` objects: ``size``, ``\``. When ``Q`` is extracted, the resulting type is the ``QRPackedQ`` object, and has the ``*`` operator overloaded to support efficient multiplication by ``Q`` and ``Q'``. It is automatically assessed whether multiplicationen is with respect to the thin or full ``Q``, i.e. both ``F[:Q]*F[:R]`` and ``F[:Q]*A`` is supperted. A ``QRPackedQ`` matrix can be converted into a regular matrix with ``full``.
 
 .. function:: qrfact!(A)
 
@@ -97,7 +97,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
 .. function:: qrpfact(A) -> QRPivoted
 
-   Compute the QR factorization of ``A`` with pivoting and return a ``QRPivoted`` object. The components of the factorization ``F`` can be accessed as follows: the orthogonal matrix ``Q`` can be extracted with ``F[:Q]``, the triangular matrix ``R`` with ``F[:R]``, and the permutation with ``F[:P]`` or ``F[:p]``. The following functions are available for ``QRPivoted`` objects: ``size``, ``\``. When ``Q`` is extracted, the resulting type is the ``QRPivotedQ`` object, and has the ``*`` operator overloaded to support efficient multiplication by ``Q`` and ``Q'``. A ``QRPivotedQ`` matrix can be converted into a regular matrix with ``full``.
+   Compute the QR factorization of ``A`` with pivoting and return a ``QRPivoted`` object. The components of the factorization ``F`` can be accessed as follows: the orthogonal matrix ``Q`` can be extracted with ``F[:Q]``, the triangular matrix ``R`` with ``F[:R]``, and the permutation with ``F[:P]`` or ``F[:p]``. The following functions are available for ``QRPivoted`` objects: ``size``, ``\``. When ``Q`` is extracted, the resulting type is the ``QRPivotedQ`` object, and has the ``*`` operator overloaded to support efficient multiplication by ``Q`` and ``Q'``. It is automatically assessed whether multiplicationen is with respect to the thin or full ``Q``, i.e. both ``F[:Q]*F[:R]`` and ``F[:Q]*A`` is supperted. A ``QRPivotedQ`` matrix can be converted into a regular matrix with ``full``.
 
 .. function:: qrpfact!(A) -> QRPivoted
 


### PR DESCRIPTION
This should fix JuliaLang/LinearAlgebra.jl#34. Check dimensions when multiplying with `Q`. Multiplication is now always with respect to the full `Q` to avoid confusion. This means that you cannot `qrfact(A)[:Q]*qrfact(A)[:R]`. The full `Q` is now used for printing.
