### PR TITLE
make it explicit that hex, binary and octal literals are all Uints

### DIFF
--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -165,8 +165,14 @@ Binary and octal literals are also supported::
     julia> 0b10
     0x02
 
+    julia> typeof(ans)
+    Uint8
+
     julia> 0o10
     0x08
+
+    julia> typeof(ans)
+    Uint8
 
 The minimum and maximum representable values of primitive numeric types
 such as integers are given by the ``typemin`` and ``typemax`` functions::


### PR DESCRIPTION
For novices, it might be easy to miss that 0x1, 0o1 and 0b1 are all represented internally as the same type (Uint8), therefore the output of such values is always formatted as a hexadecimal number.
This change makes that more explicit.
