### PR TITLE
Complete multidimensional bounds checks for BitArrays and more

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -91,12 +91,12 @@ end
 
 checkbounds(A::AbstractArray, I) = checkbounds(length(A), I)
 
-function checkbounds(A::AbstractMatrix, I, J)
+function checkbounds(A::AbstractMatrix, I::Union(Real,AbstractArray), J::Union(Real,AbstractArray))
     checkbounds(size(A,1), I)
     checkbounds(size(A,2), J)
 end
 
-function checkbounds(A::AbstractArray, I, J)
+function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray), J::Union(Real,AbstractArray))
     checkbounds(size(A,1), I)
     sz = size(A,2)
     for i = 3:ndims(A)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -98,11 +98,7 @@ end
 
 function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray), J::Union(Real,AbstractArray))
     checkbounds(size(A,1), I)
-    sz = size(A,2)
-    for i = 3:ndims(A)
-        sz *= size(A, i) # TODO: sync. with decision on issue #1030
-    end
-    checkbounds(sz, J)
+    checkbounds(trailingsize(A,2), J)
 end
 
 function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray)...)
@@ -111,11 +107,7 @@ function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray)...)
         for dim = 1:(n-1)
             checkbounds(size(A,dim), I[dim])
         end
-        sz = size(A,n)
-        for i = n+1:ndims(A)
-            sz *= size(A,i)     # TODO: sync. with decision on issue #1030
-        end
-        checkbounds(sz, I[n])
+        checkbounds(trailingsize(A,n), I[n])
     end
 end
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1306,16 +1306,6 @@ function ind2sub!{T<:Integer}(sub::Array{T}, dims::Array{T}, ind::T)
     return
 end
 
-indices(I) = I
-indices(I::Int) = I
-indices(I::Real) = convert(Int, I)
-indices(I::AbstractArray{Bool,1}) = find(I)
-indices(I::(Any,))            = (indices(I[1]), )
-indices(I::(Any,Any,))        = (indices(I[1]), indices(I[2]))
-indices(I::(Any,Any,Any))     = (indices(I[1]), indices(I[2]), indices(I[3]))
-indices(I::(Any,Any,Any,Any)) = (indices(I[1]), indices(I[2]), indices(I[3]), indices(I[4]))
-indices(I::Tuple) = map(indices, I)
-
 # Generalized repmat
 function repeat{T}(A::Array{T};
                    inner::Array{Int} = ones(Int, ndims(A)),

--- a/base/array.jl
+++ b/base/array.jl
@@ -299,10 +299,10 @@ function getindex(A::Array, I::Range1{Int})
 end
 
 function getindex{T<:Real}(A::Array, I::AbstractVector{T})
-    return [ A[i] for i in indices(I) ]
+    return [ A[i] for i in to_index(I) ]
 end
 function getindex{T<:Real}(A::Ranges, I::AbstractVector{T})
-    return [ A[i] for i in indices(I) ]
+    return [ A[i] for i in to_index(I) ]
 end
 
 # 2d indexing
@@ -338,14 +338,14 @@ function getindex(A::Array, I::Range1{Int}, J::AbstractVector{Int})
     return X
 end
 
-getindex{T<:Real}(A::Array, I::AbstractVector{T}, j::Real) = [ A[i,j] for i=indices(I) ]
-getindex{T<:Real}(A::Array, I::Real, J::AbstractVector{T}) = [ A[i,j] for i=I,j=indices(J) ]
+getindex{T<:Real}(A::Array, I::AbstractVector{T}, j::Real) = [ A[i,j] for i=to_index(I) ]
+getindex{T<:Real}(A::Array, I::Real, J::AbstractVector{T}) = [ A[i,j] for i=I,j=to_index(J) ]
 
 # This next is a 2d specialization of the algorithm used for general
 # multidimensional indexing
 function getindex{T<:Real}(A::Array, I::AbstractVector{T}, J::AbstractVector{T})
     checkbounds(A, I, J)
-    I = indices(I); J = indices(J)
+    I = to_index(I); J = to_index(J)
     X = similar(A, index_shape(I, J))
     storeind = 1
     for j = J
@@ -362,7 +362,7 @@ let getindex_cache = nothing
 global getindex
 function getindex(A::Array, I::Union(Real,AbstractVector)...)
     checkbounds(A, I...)
-    I = indices(I)
+    I = to_index(I)
     X = similar(A, eltype(A), index_shape(I...))
 
     if is(getindex_cache,nothing)
@@ -566,7 +566,7 @@ let assign_cache = nothing, assign_scalar_cache = nothing
 global setindex!
 function setindex!(A::Array, x, I::Union(Real,AbstractArray)...)
     checkbounds(A, I...)
-    I = indices(I)
+    I = to_index(I)
     if !isa(x,AbstractArray)
         if is(assign_scalar_cache,nothing)
             assign_scalar_cache = Dict()

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -403,7 +403,7 @@ let getindex_cache = nothing
         X = BitArray(index_shape(I0, I...))
         nI = 1 + length(I)
 
-        I = map(x->(isa(x,Real) ? (to_index(x):to_index(x)) : indices(x)), I[1:nI-1])
+        I = map(x->(isa(x,Real) ? (to_index(x):to_index(x)) : to_index(x)), I[1:nI-1])
 
         f0 = first(I0)
         l0 = length(I0)
@@ -480,7 +480,7 @@ end
 let getindex_cache = nothing
     global getindex
     function getindex(B::BitArray, I::Union(Real,AbstractVector)...)
-        I = indices(I)
+        I = to_index(I)
         X = BitArray(index_shape(I...))
         Xc = X.chunks
 
@@ -677,7 +677,7 @@ end
 let setindex_cache = nothing
     global setindex!
     function setindex!(B::BitArray, X::AbstractArray, I::Union(Real,AbstractArray)...)
-        I = indices(I)
+        I = to_index(I)
         nel = 1
         for idx in I
             nel *= length(idx)
@@ -714,7 +714,7 @@ end
 let setindex_cache = nothing
     global setindex!
     function setindex!(B::BitArray, x, I::Union(Real,AbstractArray)...)
-        I = indices(I)
+        I = to_index(I)
         if is(setindex_cache,nothing)
             setindex_cache = Dict()
         end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -227,6 +227,12 @@ end
 to_index(i)       = i
 to_index(i::Real) = convert(Int, i)
 to_index(i::Int)  = i
+to_index(I::AbstractArray{Bool,1}) = find(I)
+to_index(I::(Any,))            = (to_index(I[1]), )
+to_index(I::(Any,Any,))        = (to_index(I[1]), to_index(I[2]))
+to_index(I::(Any,Any,Any))     = (to_index(I[1]), to_index(I[2]), to_index(I[3]))
+to_index(I::(Any,Any,Any,Any)) = (to_index(I[1]), to_index(I[2]), to_index(I[3]), to_index(I[4]))
+to_index(I::Tuple) = map(to_index, I)
 
 # vectorization
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -227,7 +227,13 @@ end
 to_index(i)       = i
 to_index(i::Real) = convert(Int, i)
 to_index(i::Int)  = i
+to_index(r::Range1{Int}) = r
+to_index{T}(r::Range1{T}) = to_index(first(r)):to_index(last(r))
 to_index(I::AbstractArray{Bool,1}) = find(I)
+to_index(i1, i2)         = to_index(i1), to_index(i2)
+to_index(i1, i2, i3)     = to_index(i1), to_index(i2), to_index(i3)
+to_index(i1, i2, i3, i4) = to_index(i1), to_index(i2), to_index(i3), to_index(i4)
+to_index(I...) = to_index(I)
 to_index(I::(Any,))            = (to_index(I[1]), )
 to_index(I::(Any,Any,))        = (to_index(I[1]), to_index(I[2]))
 to_index(I::(Any,Any,Any))     = (to_index(I[1]), to_index(I[2]), to_index(I[3]))


### PR DESCRIPTION
This completes bounds checks for multidimensional BitArrays, e.g. it is no longer valid to index a 2x4 BitArray `B` with `B[1,5]` or `B[3,1]`, which result in a `BoundsError`. Therefore, they now behave like Arrays, at least from what I can tell.
The cost in performance is at most 10% in my tests, i.e. the new code is within 1.1x of the old code (in most cases less, around 3%). However, I had to manually inline a bunch of stuff in certain cases to get there (the non-inlined versions were more like 3x to 4x slower then the old code in my tests) . I think some code ugliness is a fair price to pay to get both safety and decent performance in this case though.

In addition to this, there are a couple of other commits:
- I merged the internal `indices` function into the `to_index` function, since they seemed to be largely overlapping, and I added some more functionality; the name `to_index` may be slightly misleading though, but I think it's a minor problem.
- I restricted some signatures of the `checkbounds` function, otherwise some methods were never being called, and simplified some of the code.
