### PR TITLE
Add makevar SYSCONFDIR, closes #4560

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,8 +190,13 @@ ifeq ($(OS), WINNT)
 endif
 	# Copy in beautiful new man page!
 	cp $(BUILD)/share/man/man1/julia.1 $(PREFIX)/share/man/man1/
-	# Copy in etc/julia directory for things like juliarc.jl
+	# Copy etc/julia directory to SYSCONFIGDIR if it is set, otherwise to just $(PREFIX)/etc/
+ifneq ($(SYSCONFDIR),)
+	mkdir -p $(SYSCONFDIR)
+	cp -R $(BUILD)/etc/julia $(SYSCONFDIR)/
+else
 	cp -R $(BUILD)/etc/julia $(PREFIX)/etc/
+endif
 
 
 dist:
@@ -211,6 +216,8 @@ ifeq ($(OS), Darwin)
 	-./contrib/mac/fixup-libgfortran.sh $(PREFIX)/$(JL_PRIVATE_LIBDIR)
 endif
 	# Copy in juliarc.jl files per-platform for binary distributions as well
+	# Note that we don't install to SYSCONFDIR: we always install to PREFIX/etc.
+	# If you want to make a distribution with a hardcoded path, you take care of installation
 ifeq ($(OS), Darwin)
 	-cat ./contrib/mac/juliarc.jl >> $(PREFIX)/etc/julia/juliarc.jl
 else ifeq ($(OS), WINNT)

--- a/base/Makefile
+++ b/base/Makefile
@@ -59,6 +59,7 @@ ifeq ($(USE_BLAS64), 1)
 else
 	@echo "const USE_BLAS64 = false" >> $@
 endif
+	@echo "const SYSCONFDIR = \"$(SYSCONFDIR)\"" >> $@
 
 	@echo "immutable BuildInfo" >> $@
 	@echo "    version_string::ASCIIString" >> $@

--- a/base/client.jl
+++ b/base/client.jl
@@ -346,7 +346,13 @@ function init_profiler()
 end
 
 function load_juliarc()
-    try_include(abspath(JULIA_HOME,"..","etc","julia","juliarc.jl"))
+    # If the user built us with a specifi Base.SYSCONFDIR, check that location first for a juliarc.jl file
+    #   If it is not found, then continue on to the relative path based on JULIA_HOME
+    if !isempty(Base.SYSCONFDIR) && isfile(joinpath(Base.SYSCONFDIR,"julia","juliarc.jl"))
+        include(abspath(Base.SYSCONFDIR,"julia","juliarc.jl"))
+    else
+        try_include(abspath(JULIA_HOME,"..","etc","julia","juliarc.jl"))
+    end
     try_include(abspath(user_prefdir(),".juliarc.jl"))
 end
 


### PR DESCRIPTION
Alright, I've taken a look at this, and I think the best thing to do is the following:
- By default, `make install` tries to put files into `JULIA_HOME/etc/julia/`, and julia only looks for an installation-wide `juliarc.jl` in that folder.  (This is ignoring user-wide `~/.juliarc.jl` files)
- If the user specifies `SYSCONFDIR=blahblahblah`, then `make install` respects that, and updates `build_h.jl` accordingly so that Julia knows where to look at runtime.  To be explicit, `SYSCONFDIR` should equal something like `/etc`, and julia will look in `$SYSCONFDIR/julia/juliarc.jl`, for example.  If nothing is found there, we fallback to the relative path and try that `JULIA_HOME/../etc/julia/juliarc.jl`

@Narrat please review this and see if it solves your problem satisfactorily.  Ideally, package maintainers would simply need to include `SYSCONFDIR=/etc` in their make incantation to get `/etc/julia/juliarc.jl` into the paths that are searched for a startup file.
