### PR TITLE
Added collect with eltype as argument

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -270,6 +270,22 @@ function collect{T}(itr::T)
     end
 end
 
+function collect{T}(element_type::Type, itr::T)
+    if method_exists(length,(T,))
+        i, a = 0, Array(element_type,length(itr))
+        for x in itr
+            a[i+=1] = x
+        end
+        return a
+    else
+        a = Array(element_type, 0)
+        for x in itr
+            push!(a,x)
+        end
+        return a
+    end
+end
+
 ## Indexing: getindex ##
 
 getindex(a::Array) = arrayref(a,1)

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -911,6 +911,13 @@
 
 "),
 
+("Iterable Collections","Base","collect","collect(element_type, collection)
+
+   Return an array of type \"Array{element_type,1}\" of all items in a
+   collection.
+
+"),
+
 ("Iterable Collections","Base","issubset","issubset(a, b)
 
    Determine whether every element of \"a\" is also in \"b\", using

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -8158,7 +8158,7 @@ popdisplay(d::Display)
    Compute the pivoted Cholesky factorization of a symmetric positive
    semi-definite matrix \"A\" and return a \"CholeskyPivoted\" object.
    \"LU\" may be 'L' for using the lower part or 'U' for the upper
-   part. The default is to use 'U'. The triangular factors containted
+   part. The default is to use 'U'. The triangular factors contained
    in the factorization \"F\" can be obtained with \"F[:L]\" and
    \"F[:U]\", whereas the permutation can be obtained with \"F[:P]\"
    or \"F[:p]\". The following functions are available for
@@ -8186,14 +8186,16 @@ popdisplay(d::Display)
 
 ("Linear Algebra","Base","qrfact","qrfact(A)
 
-   Compute the QR factorization of \"A\" and return a \"QR\" object.
-   The components of the factorization \"F\" can be accessed as
-   follows: the orthogonal matrix \"Q\" can be extracted with
-   \"F[:Q]\" and the triangular matrix \"R\" with \"F[:R]\". The
-   following functions are available for \"QR\" objects: \"size\",
-   \"\\\". When \"Q\" is extracted, the resulting type is the
-   \"QRPackedQ\" object, and has the \"*\" operator overloaded to
-   support efficient multiplication by \"Q\" and \"Q'\".
+   Computes the QR factorization of \"A\" and returns a \"QR\" type,
+   which is a \"Factorization\" \"F\" consisting of an orthogonal
+   matrix \"F[:Q]\" and a triangular matrix \"F[:R]\". The following
+   functions are available for \"QR\" objects: \"size\", \"\\\". The
+   orthogonal matrix \"Q=F[:Q]\" is a \"QRPackedQ\" type which has the
+   \"*\" operator overloaded to support efficient multiplication by
+   \"Q\" and \"Q'\". Multiplication with respect to either thin or
+   full \"Q\" is allowed, i.e. both \"F[:Q]*F[:R]\" and \"F[:Q]*A\"
+   are supported. A \"QRPackedQ\" matrix can be converted into a
+   regular matrix with \"full\".
 
 "),
 
@@ -8206,7 +8208,7 @@ popdisplay(d::Display)
 
 ("Linear Algebra","Base","qrp","qrp(A[, thin]) -> Q, R, p
 
-   Compute the QR factorization of \"A\" with pivoting, such that
+   Computes the QR factorization of \"A\" with pivoting, such that
    \"A[:,p] = Q*R\", Also see \"qrpfact\". The default is to compute a
    thin factorization.
 
@@ -8214,15 +8216,16 @@ popdisplay(d::Display)
 
 ("Linear Algebra","Base","qrpfact","qrpfact(A) -> QRPivoted
 
-   Compute the QR factorization of \"A\" with pivoting and return a
-   \"QRPivoted\" object. The components of the factorization \"F\" can
-   be accessed as follows: the orthogonal matrix \"Q\" can be
-   extracted with \"F[:Q]\", the triangular matrix \"R\" with
-   \"F[:R]\", and the permutation with \"F[:P]\" or \"F[:p]\". The
-   following functions are available for \"QRPivoted\" objects:
-   \"size\", \"\\\". When \"Q\" is extracted, the resulting type is
-   the \"QRPivotedQ\" object, and has the \"*\" operator overloaded to
-   support efficient multiplication by \"Q\" and \"Q'\". A
+   Computes the QR factorization of \"A\" with pivoting and returns a
+   \"QRPivoted\" object, which is a \"Factorization\" \"F\" consisting
+   of an orthogonal matrix \"F[:Q]\", a triangular matrix \"F[:R]\",
+   and a permutation \"F[:p]\" (or  its matrix representation
+   \"F[:P]\"). The following functions are available for \"QRPivoted\"
+   objects: \"size\", \"\\\". The orthogonal matrix \"Q=F[:Q]\" is a
+   \"QRPivotedQ\" type which has the \"*\" operator overloaded to
+   support efficient multiplication by \"Q\" and \"Q'\".
+   Multiplication with respect to either the thin or full \"Q\" is
+   allowed, i.e. both \"F[:Q]*F[:R]\" and \"F[:Q]*A\" are supperted. A
    \"QRPivotedQ\" matrix can be converted into a regular matrix with
    \"full\".
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -586,6 +586,10 @@ Iterable Collections
 
    Return an array of all items in a collection. For associative collections, returns (key, value) tuples.
 
+.. function:: collect(element_type, collection)
+
+   Return an array of type ``Array{element_type,1}`` of all items in a collection.
+
 .. function:: issubset(a, b)
 
    Determine whether every element of ``a`` is also in ``b``, using the


### PR DESCRIPTION
Currently collect(itr) does not allow the user to specify the type of
the elements of the returned array, but relies on the eltype() function.
This commit adds collect{T}(element_type::Type, itr::T), so that a user
can get a type specific array, without having to define eltype on the
iteration object.

Inspiration for this julia-users thred:
https://groups.google.com/forum/#!topic/julia-users/UbwDusuZa1o

I also added a commit with old helpdb.jl updates
