### PR TITLE
Add showcompact method for vectors of Number's

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -70,6 +70,17 @@ function show(io::IO, x::DataType)
     end
 end
 
+function showcompact{T<:Number}(io::IO, x::Vector{T})
+    if length(x) > 0
+        print(io, "[")
+        showcompact(io, x[1])
+        for j in 2:length(x)
+            print(io, ",")
+            showcompact(io, x[j])
+        end
+        print(io, "]")
+    end
+end
 showcompact(io::IO, x) = show(io, x)
 showcompact(x) = showcompact(STDOUT::IO, x)
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -71,15 +71,15 @@ function show(io::IO, x::DataType)
 end
 
 function showcompact{T<:Number}(io::IO, x::Vector{T})
+    print(io, "[")
     if length(x) > 0
-        print(io, "[")
         showcompact(io, x[1])
         for j in 2:length(x)
             print(io, ",")
             showcompact(io, x[j])
         end
-        print(io, "]")
     end
+    print(io, "]")
 end
 showcompact(io::IO, x) = show(io, x)
 showcompact(x) = showcompact(STDOUT::IO, x)
@@ -125,25 +125,25 @@ function show_delim_array(io::IO, itr, op, delim, cl, delim_one)
     newline = true
     first = true
     if !done(itr,state)
-	while true
+        while true
             if isa(itr,Array) && !isdefined(itr,state)
                 print(io, undef_ref_str)
                 state += 1
                 multiline = false
             else
-	        x, state = next(itr,state)
+                x, state = next(itr,state)
                 multiline = isa(x,AbstractArray) && ndims(x)>1 && length(x)>0
                 if newline
                     if multiline; println(io); end
                 end
-	        show(io, x)
+                show(io, x)
             end
-	    if done(itr,state)
+            if done(itr,state)
                 if delim_one && first
                     print(io, delim)
                 end
-		break
-	    end
+                break
+            end
             first = false
             print(io, delim)
             if multiline
@@ -151,7 +151,7 @@ function show_delim_array(io::IO, itr, op, delim, cl, delim_one)
             else
                 newline = true
             end
-	end
+        end
     end
     print(io, cl)
 end


### PR DESCRIPTION
Currently there is a peculiarity that `showcompact` applied to a floating point number produces a compact representation, similar to the representation the `print_matrix` method.  The `showcompact` method for a vector of numbers does switch to a horizontal orientation but uses the full precision.

This pull request adds a `showcompact` method for vectors of numbers to use showcompact on each number.  It doesn't use `tty_cols()` and hence could produce very long lines on long vectors.

``` jl
julia> r5 = rand(5)
5-element Array{Float64,1}:
 0.381319
 0.337257
 0.409786
 0.9746  
 0.679875

julia> showcompact(r5)
[0.381319,0.337257,0.409786,0.9746,0.679875]
```

I can understand if a more sophisticated version is desired but I do think that the current situation of writing full precision representations in `showcompact` should be changed.
