### PR TITLE
Update base.rst to match currently available `quantile` methods

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3840,12 +3840,12 @@ Statistics
    Compute the quantiles of a vector ``v`` at a specified set of probability values ``p``.
    Note: Julia does not ignore ``NaN`` values in the computation.
 
-.. function:: quantile(v)
+.. function:: quantile(v, p)
 
-   Compute the quantiles of a vector ``v`` at the probability values ``[.0, .2, .4, .6, .8, 1.0]``.
+   Compute the quantile of a vector ``v`` at the probability ``p``.
    Note: Julia does not ignore ``NaN`` values in the computation.
 
-.. function:: quantile!(v, [p])
+.. function:: quantile!(v, p)
 
    Like ``quantile``, but overwrites the input vector.
 


### PR DESCRIPTION
This edits help(quantile) and help(quantile!) to match up with methods(quantile) and methods(quantile!)

Current methods(quantile) output:

``` jl
julia> methods(quantile)
#2 methods for generic function "quantile":
quantile(v::AbstractArray{T,1},q::AbstractArray{T,1}) at statistics.jl:288
quantile(v::AbstractArray{T,1},q::Number) at statistics.jl:289

julia> methods(quantile!)
#1 method for generic function "quantile!":
quantile!(v::AbstractArray{T,1},q::AbstractArray{T,1}) at statistics.jl:268
```

Github's online editing interface seems to be super-slow for editing when the file is as big as base.rst. =/
