### PR TITLE
Fix mmap_bitarray; make it available in Windows

### DIFF
--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -124,36 +124,7 @@ function mmap_array{T,N,TInt<:Integer}(::Type{T}, dims::NTuple{N,TInt}, s::IO, o
     return A
 end
 
-# Mmapped-bitarray constructor
-function mmap_bitarray{N,TInt<:Integer}(dims::NTuple{N,TInt}, s::IOStream, offset::FileOffset)
-    prot, flags, iswrite = mmap_stream_settings(s)
-    if length(dims) == 0
-        dims = 0
-    end
-    n = prod(dims)
-    nc = num_bit_chunks(n)
-    if nc > typemax(Int)
-        error("File is too large to memory-map on this platform")
-    end
-    chunks = mmap_array(Uint64, (nc,), s, offset)
-    if iswrite
-        chunks[end] &= @_msk_end n
-    else
-        if chunks[end] != chunks[end] & @_msk_end n
-            error("The given file does not contain a valid BitArray of size ", join(dims, 'x'), " (open with r+ to override)")
-        end
-    end
-    B = BitArray{N}(ntuple(N,i->0)...)
-    B.chunks = chunks
-    B.len = n
-    if N != 1
-        B.dims = Int[i for i in dims]
-    end
-    finalizer(B, x->munmap(pointer(B.chunks), length(B.chunks)*sizeof(Uint64)))
-    return B
 end
-end
-
 
 ### Windows implementation ###
 @windows_only begin
@@ -200,4 +171,35 @@ function msync(p::Ptr, len::Integer)
     end
 end
 
+end
+
+# Mmapped-bitarray constructor
+function mmap_bitarray{N,TInt<:Integer}(dims::NTuple{N,TInt}, s::IOStream, offset::FileOffset)
+    iswrite = !isreadonly(s)
+    n = 1
+    for d in dims
+        if d < 0
+            error("invalid dimension size")
+        end
+        n *= d
+    end
+    nc = num_bit_chunks(n)
+    if nc > typemax(Int)
+        error("File is too large to memory-map on this platform")
+    end
+    chunks = mmap_array(Uint64, (nc,), s, offset)
+    if iswrite
+        chunks[end] &= @_msk_end n
+    else
+        if chunks[end] != chunks[end] & @_msk_end n
+            error("The given file does not contain a valid BitArray of size ", join(dims, 'x'), " (open with \"r+\" mode to override)")
+        end
+    end
+    B = BitArray{N}(ntuple(N,i->0)...)
+    B.chunks = chunks
+    B.len = n
+    if N != 1
+        B.dims = dims
+    end
+    return B
 end

--- a/test/file.jl
+++ b/test/file.jl
@@ -136,6 +136,31 @@ close(s)
 @test beginswith(str, "Hellx World")
 c=nothing; gc(); gc(); # cause munmap finalizer to run & free resources
 
+s = open(file, "w")
+write(s, [0xffffffffffffffff,
+          0xffffffffffffffff,
+          0xffffffffffffffff,
+          0x000000001fffffff])
+close(s)
+s = open(file, "r")
+@test isreadonly(s) == true
+b = mmap_bitarray((17,13), s)
+@test b == trues(17,13)
+@test_throws mmap_bitarray((7,3), s)
+close(s)
+s = open(file, "r+")
+b = mmap_bitarray((17,19), s)
+rand!(b)
+msync(b)
+b0 = copy(b)
+close(s)
+s = open(file, "r")
+@test isreadonly(s) == true
+b = mmap_bitarray((17,19), s)
+@test b == b0
+close(s)
+b=nothing; b0=nothing; gc(); gc(); # cause munmap finalizer to run & free resources
+
 #######################################################################
 # This section tests temporary file and directory creation.           #
 #######################################################################


### PR DESCRIPTION
This fixes `mmap_bitarray` breakage introduced in #4700. It also adds tests as required.

I noticed `mmap_bitarray` was wrapped in a Unix-only block, but since it's basically just a wrapper around `mmap_array` there's no reason the same code shouldn't work in Windows too. To this end, I just removed Unix-specific function calls, i.e. I changed the call to `mmap_stream_settings` with a simple `isreadonly`, and I removed the finalizer since the one from `mmap_array` should suffice. These changes however should be reviewed (@timholy) and tested on Windows (@vtjnash or @loladiro maybe?).
