### PR TITLE
Another attempt at fixing #4697

### DIFF
--- a/base/help.jl
+++ b/base/help.jl
@@ -120,6 +120,8 @@ function print_help_entries(entries)
     end
 end
 
+func_expr_from_symbols(s::Vector{Symbol}) = length(s) == 1 ? s[1] : Expr(:., func_expr_from_symbols(s[1:end-1]), Expr(:quote, s[end]))
+
 help_for(s::String) = help_for(s, 0)
 function help_for(fname::String, obj)
     init_help()
@@ -127,17 +129,26 @@ function help_for(fname::String, obj)
     if haskey(FUNCTION_DICT, fname)
         print_help_entries(FUNCTION_DICT[fname])
         found = true
-    else
-        if haskey(MODULE_DICT, fname)
-            allmods = MODULE_DICT[fname]
-            alldesc = {}
-            for mod in allmods
-                mfname = isempty(mod) ? fname : mod * "." * fname
+    elseif haskey(MODULE_DICT, fname)
+        allmods = MODULE_DICT[fname]
+        alldesc = {}
+        for mod in allmods
+            mfname = isempty(mod) ? fname : mod * "." * fname
+            if isgeneric(obj)
+                mf = eval(func_expr_from_symbols(map(symbol, split(mfname, "."))))
+                if mf === obj
+                    append!(alldesc, FUNCTION_DICT[mfname])
+                    found = true
+                end
+            else
                 append!(alldesc, FUNCTION_DICT[mfname])
+                found = true
             end
-            print_help_entries(alldesc)
-            found = true
         end
+        found && print_help_entries(alldesc)
+    elseif haskey(FUNCTION_DICT, "Base." * fname)
+        print_help_entries(FUNCTION_DICT["Base." * fname])
+        found = true
     end
     if !found
         if isa(obj, DataType)


### PR DESCRIPTION
Maybe 0.2.x material.

This should not suffer from the drawback pointed out by Jeff in #4699.

After this change:
- `help(f)` filters function definitions if `f` is a `Function`, so e.g. `help(Pkg.init)` only shows the help for the right function, not also `Profile.init` (but if a function is extended by another module and it's the same generic function it is shown too)
- A fallback is added such that `"Base."` is prepended as default; e.g. calling `help("Pkg.init")` now works (previously only `"Base.Pkg.init"` or `"init"` were recognized)

The filtering is done by getting a function object from a string via `eval`, and comparing the result with the given function object; it's a little bit ugly but I hope that's fine.
