### PR TITLE
Native implementation of mv & cp commands in repl

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1188,6 +1188,7 @@ export
     pwd,
     rm,
     rmdir,
+    samefile,
     stat,
     tempdir,
     tempname,

--- a/base/file.jl
+++ b/base/file.jl
@@ -62,8 +62,8 @@ end
 # The following use Unix command line facilites
 
 rm(path::String) = FS.unlink(path)
-cp(src::String, dst::String) = run(`cp $src $dst`)
-mv(src::String, dst::String) = run(`mv $src $dst`)
+cp(src::String, dst::String) = FS.sendfile(src, dst)
+mv(src::String, dst::String) = FS.rename(src, dst)
 touch(path::String) = run(`touch $path`)
 
 # Obtain a temporary filename.

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -403,6 +403,24 @@ DLLEXPORT int jl_fs_unlink(char *path)
     return ret;
 }
 
+DLLEXPORT int jl_fs_rename(char *src_path, char *dst_path)
+{
+    uv_fs_t req;
+    int ret = uv_fs_rename(jl_io_loop, &req, src_path, dst_path, NULL);
+    uv_fs_req_cleanup(&req);
+    return ret;
+}
+
+DLLEXPORT int jl_fs_sendfile(int src_fd, int dst_fd,
+                             int64_t in_offset, size_t len)
+{
+    uv_fs_t req;
+    int ret = uv_fs_sendfile(jl_io_loop, &req, dst_fd, src_fd,
+                             in_offset, len, NULL);
+    uv_fs_req_cleanup(&req);
+    return ret;
+}
+
 DLLEXPORT int jl_fs_write(int handle, char *buf, size_t len, size_t offset)
 {
     uv_fs_t req;

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -333,6 +333,8 @@
     jl_fs_poll_start;
     jl_fs_event_init;
     jl_fs_unlink;
+    jl_fs_rename;
+    jl_fs_sendfile;
     jl_fs_write;
     jl_fs_write_byte;
     jl_fs_read;

--- a/test/file.jl
+++ b/test/file.jl
@@ -184,6 +184,24 @@ emptyf = open(emptyfile)
 close(emptyf)
 rm(emptyfile)
 
+# Test copy file
+afile = joinpath(dir, "a.txt")
+touch(afile)
+af = open(afile, "r+")
+write(af, "This is indeed a test")
+
+bfile = joinpath(dir, "b.txt")
+cp(afile, bfile)
+
+a_stat = stat(afile)
+b_stat = stat(bfile)
+@test a_stat.mode == b_stat.mode
+@test a_stat.size == b_stat.size
+
+close(af)
+rm(afile)
+rm(bfile)
+
 ############
 # Clean up #
 ############

--- a/test/file.jl
+++ b/test/file.jl
@@ -39,6 +39,24 @@ mv(file, newfile)
 @test isfile(newfile) == true
 file = newfile
 
+# Test renaming directories
+a_tmpdir = mktempdir()
+b_tmpdir = joinpath(dir, "b_tmpdir")
+
+# grab a_tmpdir's file info before renaming
+a_stat = stat(a_tmpdir)
+
+# rename, then make sure b_tmpdir does exist and a_tmpdir doesn't
+mv(a_tmpdir, b_tmpdir)
+@test isdir(b_tmpdir) == true
+@test isdir(a_tmpdir) == false
+
+# get b_tmpdir's file info and compare with a_tmpdir
+b_stat = stat(b_tmpdir)
+@test Base.samefile(a_stat, b_stat) == true
+
+rmdir(b_tmpdir)
+
 #######################################################################
 # This section tests file watchers.                                   #
 #######################################################################

--- a/test/file.jl
+++ b/test/file.jl
@@ -53,7 +53,7 @@ mv(a_tmpdir, b_tmpdir)
 
 # get b_tmpdir's file info and compare with a_tmpdir
 b_stat = stat(b_tmpdir)
-@test Base.samefile(a_stat, b_stat) == true
+@test samefile(a_stat, b_stat) == true
 
 rmdir(b_tmpdir)
 


### PR DESCRIPTION
Instead of calling an underlying shell, the mv and cp commands now use
jl_fs_rename and jl_fs_sendfile respectively (wrappers for libuv).  In
the event that the rename call fails on error, mv command still uses
native implementation by defaulting to cp (sendfile) and rm (unlink).

This fix also includes a new unit test for the copy function.  It copies
contents of one file to another and checks that both files are
equivalent.

Fixes issue #4157
