### PR TITLE
in init_stdio, get FD out of the file object instead of hard-coding it

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -208,10 +208,10 @@ associate_julia_struct(handle::Ptr{Void},jlobj::ANY) =
 disassociate_julia_struct(handle::Ptr{Void}) = 
     ccall(:jl_uv_disassociate_julia_struct,Void,(Ptr{Void},),handle)
 
-function init_stdio(handle,fd)
+function init_stdio(handle)
     t = ccall(:jl_uv_handle_type,Int32,(Ptr{Void},),handle)
     if t == UV_FILE
-        return fdio(fd)
+        return fdio(ccall(:jl_uv_file_handle,Int32,(Ptr{Void},),handle))
     else
         if t == UV_TTY
             ret = TTY(handle)
@@ -236,9 +236,9 @@ function reinit_stdio()
     global uv_jl_writecb = cglobal(:jl_uv_writecb)
     global uv_jl_writecb_task = cglobal(:jl_uv_writecb_task)
     global uv_eventloop = ccall(:jl_global_event_loop, Ptr{Void}, ())
-    global STDIN = init_stdio(ccall(:jl_stdin_stream ,Ptr{Void},()),0)
-    global STDOUT = init_stdio(ccall(:jl_stdout_stream,Ptr{Void},()),1)
-    global STDERR = init_stdio(ccall(:jl_stderr_stream,Ptr{Void},()),2)
+    global STDIN = init_stdio(ccall(:jl_stdin_stream ,Ptr{Void},()))
+    global STDOUT = init_stdio(ccall(:jl_stdout_stream,Ptr{Void},()))
+    global STDERR = init_stdio(ccall(:jl_stderr_stream,Ptr{Void},()))
     reinit_displays() # since Multimedia.displays uses STDOUT as fallback
 end
 

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -815,6 +815,11 @@ DLLEXPORT uv_handle_type jl_uv_handle_type(uv_handle_t *handle)
     return handle->type;
 }
 
+DLLEXPORT uv_file jl_uv_file_handle(jl_uv_file_t *f)
+{
+    return f->file;
+}
+
 DLLEXPORT void jl_uv_req_set_data(uv_req_t *req, void *data)
 {
     req->data = data;


### PR DESCRIPTION
This eliminates some redundant mentions of the standard file numbers. This allows JL_STDOUT etc. to refer to other descriptors if necessary.
cc @loladiro 
