### PR TITLE
Incomplete fix/workaround for broadcast static type inference (#4673)

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -191,7 +191,7 @@ function code_broadcasts(name::String, op)
         end
 
         function $fname(As::StridedArray...)
-            $fname_T(promote_type([eltype(A) for A in As]...), As...)
+            $fname_T(Base.promote_eltype(As...), As...)
         end
 
         function $fname{T}(As::StridedArray{T}...)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -8,13 +8,24 @@ export broadcast_getindex, broadcast_setindex!
 
 ## Broadcasting utilities ##
 
+droparg1(a, args...) = args
+
+longer_tuple(x::(), retx::Tuple, y::(), rety::Tuple) = retx
+longer_tuple(x::(), retx::Tuple, y::Tuple, rety::Tuple) = rety
+longer_tuple(x::Tuple, retx::Tuple, y::(), rety::Tuple) = retx
+longer_tuple(x::Tuple, retx::Tuple, y::Tuple, rety::Tuple) =
+    longer_tuple(droparg1(x...), retx, droparg1(y...), rety)
+longer_tuple(x::Tuple, y::Tuple) = longer_tuple(x, x, y, y)
+
+longer_size(x::AbstractArray) = size(x)
+longer_size(x::AbstractArray, y::AbstractArray...) =
+    longer_tuple(size(x), longer_size(y...))
+
 # Calculate the broadcast shape of the arguments, or error if incompatible
 broadcast_shape() = ()
 function broadcast_shape(As::AbstractArray...)
-    nd = ndims(As[1])
-    for i = 2:length(As)
-        nd = max(nd, ndims(As[i]))
-    end
+    sz = longer_size(As...)
+    nd = length(sz)
     bshape = ones(Int, nd)
     for A in As
         for d = 1:ndims(A)
@@ -28,7 +39,7 @@ function broadcast_shape(As::AbstractArray...)
             end
         end
     end
-    return tuple(bshape...)
+    return tuple(bshape...)::typeof(sz)
 end
 
 # Check that all arguments are broadcast compatible with shape


### PR DESCRIPTION
~~This changes the order of broadcast function definitions to work around #4675.~~ (No longer necessary since bfe8986c6a1c090d08d637460840abcf5c13f300). It also attempts to fix static type inference for the dimensionality of the returned array to fix #4673, although this only works for cases of sufficiently low dimensionality (`code_typed(.*, (Matrix{Float64}, Array{Float64, 8}))` works, but `code_typed(.*, (Matrix{Float64}, Array{Float64, 9}))` does not; `code_typed(.*, (Matrix{Float64}, Matrix{Float64}, Matrix{Float64}))` works but `code_typed(.*, (Matrix{Float64}, Matrix{Float64}, Array{Float64, 3}))` does not).

I'm not fully satisfied with this, but I'm putting it out there in case someone has an idea of how to make it more satisfactory.
