### PR TITLE
Tweak base/version.jl printing a bit

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -319,7 +319,9 @@ end
 
 function versioninfo(io::IO=STDOUT, verbose::Bool=false)
     println(io,             "Julia Version $VERSION")
-    println(io,             commit_string)
+    if !isempty(BUILD_INFO.commit_short)
+      println(io,             "Commit $(BUILD_INFO.commit_short) ($(BUILD_INFO.date_string))")
+    end
     println(io,             "Platform Info:")
     println(io,             "  System: ", Sys.OS_NAME, " (", Sys.MACHINE, ")")
     println(io,             "  WORD_SIZE: ", Sys.WORD_SIZE)

--- a/base/version.jl
+++ b/base/version.jl
@@ -192,15 +192,15 @@ catch e
 end
 
 if BUILD_INFO.tagged_commit
-    global const commit_string = BUILD_INFO.TAGGED_RELEASE_BANNER
+    const commit_string = BUILD_INFO.TAGGED_RELEASE_BANNER
 elseif BUILD_INFO.commit == ""
-    global const commit_string = "Unknown commit"
+    const commit_string = ""
 else
     local days = int(floor((ccall(:clock_now, Float64, ()) - BUILD_INFO.fork_master_timestamp) / (60 * 60 * 24)))
     if BUILD_INFO.fork_master_distance == 0
-        global const commit_string = "Commit $(BUILD_INFO.commit_short) ($(days) days old master)"
+        const commit_string = "Commit $(BUILD_INFO.commit_short) ($(days) days old master)"
     else
-        global const commit_string = "$(BUILD_INFO.branch)/$(BUILD_INFO.commit_short) (fork: $(BUILD_INFO.fork_master_distance) commits, $(days) days)"
+        const commit_string = "$(BUILD_INFO.branch)/$(BUILD_INFO.commit_short) (fork: $(BUILD_INFO.fork_master_distance) commits, $(days) days)"
     end
 end
 commit_date = BUILD_INFO.date_string != "" ? " ($(BUILD_INFO.date_string))": ""


### PR DESCRIPTION
- I don't like printing "Unknown commit" when there's not `git` information, just print out what we know and leave it at that
- versioninfo() depended on the `commit_string` variable, but that gets changed when on a tagged release now.  I've changed it to just build its own output internally, when we have the information available.  One less weird global variable floating around!
