### PR TITLE
* Change test_throws to only check for a single exception type

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -40,12 +40,16 @@ function do_test(body,qex)
     end)
 end
 
-function do_test_throws(body,qex)
+function do_test_throws(body,qex,extype)
     handler()(try
         body()
         Failure(qex)
-    catch
-        Success(qex)
+    catch err
+        if isa(err,extype)
+            Success(qex)
+        else
+            rethrow()
+        end
     end)
 end
 
@@ -53,8 +57,8 @@ macro test(ex)
     :(do_test(()->($(esc(ex))),$(Expr(:quote,ex))))
 end
 
-macro test_throws(ex)
-    :(do_test_throws(()->($(esc(ex))),$(Expr(:quote,ex))))
+macro test_throws(ex,extype)
+    :(do_test_throws(()->($(esc(ex))),$(Expr(:quote,ex)),$(extype)))
 end
 macro test_fails(ex)
     Base.warn_once("@test_fails is deprecated, use @test_throws instead.")

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -97,7 +97,7 @@ sA = sub(A, 2, 1:5, :)
 @test parentindexes(sA) == (2:2, 1:5, 1:8)
 @test Base.parentdims(sA) == 1:3
 @test size(sA) == (1, 5, 8)
-@test_throws sA[2, 1:8]
+@test_throws sA[2, 1:8] BoundsError
 @test sA[1, 2, 1:8][:] == 5:15:120
 sA[2:5:end] = -1
 @test all(sA[2:5:end] .== -1)
@@ -150,23 +150,23 @@ a = [5:8]
 @test parent(a) == a
 @test parentindexes(a) == (1:4,)
 
-# 4335
-@test_throws slice(A, 1:2)
-@test_throws slice(A, 1:2, 3:4)
-@test_throws slice(A, 1:2, 3:4, 5:6, 7:8)
+# 4336
+@test_throws slice(A, 1:2) BoundsError
+@test_throws slice(A, 1:2, 3:4) BoundsError
+@test_throws slice(A, 1:2, 3:4, 5:6, 7:8) BoundsError
 
 # Out-of-bounds construction. See #4044
 A = rand(7,7)
 rng = 1:4
 sA = sub(A, 2, rng-1)
-@test_throws sA[1,1]
+@test_throws sA[1,1] BoundsError
 @test sA[1,2] == A[2,1]
 sA = sub(A, 2, rng)
 B = sub(sA, 1, rng-1)
 C = sub(B, 1, rng+1)
 @test C == sA
 sA = slice(A, 2, rng-1)
-@test_throws sA[1]
+@test_throws sA[1] BoundsError
 @test sA[2] == A[2,1]
 sA = slice(A, 2, rng)
 B = slice(sA, rng-1)
@@ -699,7 +699,7 @@ end
 @test isequal([1,2,3], [a for (a,b) in enumerate(2:4)])
 @test isequal([2,3,4], [b for (a,b) in enumerate(2:4)])
 
-@test_throws (10.^[-1])[1] == 0.1
+@test_throws (10.^[-1])[1] == 0.1 DomainError
 @test (10.^[-1.])[1] == 0.1
 
 # reverse
@@ -719,10 +719,10 @@ end
 @test isequal(flipdim([2,3,1], 2), [2,3,1])
 @test isequal(flipdim([2 3 1], 1), [2 3 1])
 @test isequal(flipdim([2 3 1], 2), [1 3 2])
-@test_throws flipdim([2,3,1] -1)
+@test_throws flipdim([2,3,1] -1) MethodError
 @test isequal(flipdim(1:10, 1), 10:-1:1)
 @test isequal(flipdim(1:10, 2), 1:10)
-@test_throws flipdim(1:10, -1)
+@test_throws flipdim(1:10, -1) ErrorException
 
 # issue 4228
 A = [[i i; i i] for i=1:2]
@@ -740,7 +740,7 @@ B = reshape(A, 4)
 @test push!(B,5) == [1,2,3,4,5]
 @test pop!(B) == 5
 C = reshape(B, 1, 4)
-@test_throws push!(C, 5)
+@test_throws push!(C, 5) MethodError
 
 A = [NaN]; B = [NaN]
 @test !(A==A)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -33,7 +33,7 @@ for arr in (identity, as_sub)
 
     A = arr(eye(2)); @test broadcast!(+, A, A, arr([1, 4])) == arr([2 1; 4 5])
     A = arr(eye(2)); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4; 1 5])
-    A = arr([1  0]); @test_throws broadcast!(+, A, A, arr([1, 4]))
+    A = arr([1  0]); @test_throws broadcast!(+, A, A, arr([1, 4])) ErrorException
     A = arr([1  0]); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4])
 
     @test arr([ 1    2])   .* arr([3,   4])   == [ 3 6; 4 8]

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -57,7 +57,7 @@ _d = {"a"=>0}
 let
     d = Dict{UTF8String, Vector{Int}}()
     d["a"] = [1, 2]
-    @test_throws d["b"] = 1
+    @test_throws d["b"] = 1 MethodError
     @test isa(repr(d), String)  # check that printable without error
 end
 
@@ -392,10 +392,10 @@ s = IntSet(0,1,10,20,200,300,1000,10000,10002)
 @test !in(0,s)
 @test !in(10002,s)
 @test in(10000,s)
-@test_throws first(IntSet())
-@test_throws last(IntSet())
+@test_throws first(IntSet()) ErrorException
+@test_throws last(IntSet()) ErrorException
 
 # Ranges
 
 @test isempty((1:4)[5:4])
-@test_throws (1:10)[8:-1:-2]
+@test_throws (1:10)[8:-1:-2] BoundsError

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -291,14 +291,14 @@
 #  tanh(-z) = -tanh(z)
 @test isequal(tanh(complex( 0.0, 0.0)),complex(0.0,0.0))
 @test isequal(tanh(complex( 0.0,-0.0)),complex(0.0,-0.0))
-@test_throws   tanh(complex( 0.0, Inf)) #complex(NaN,0.0)
-@test_throws   tanh(complex( 0.0,-Inf)) #complex(NaN,-0.0)
+@test_throws   tanh(complex( 0.0, Inf)) DomainError #complex(NaN,0.0)
+@test_throws   tanh(complex( 0.0,-Inf)) DomainError  #complex(NaN,-0.0)
 @test isequal(tanh(complex( 0.0, NaN)),complex(NaN,NaN))
 
 @test isequal(tanh(complex(-0.0, 0.0)),complex(-0.0,0.0))
 @test isequal(tanh(complex(-0.0,-0.0)),complex(-0.0,-0.0))
 
-@test_throws   tanh(complex( 5.0, Inf)) #complex(NaN,NaN)
+@test_throws   tanh(complex( 5.0, Inf)) DomainError #complex(NaN,NaN)
 @test isequal(tanh(complex( 5.0, NaN)),complex(NaN,NaN))
 
 @test isequal(tanh(complex( Inf, 0.0)),complex(1.0, 0.0))
@@ -340,7 +340,7 @@
 @test isequal(tan(complex(-5.0,-Inf)),complex(sin(2*5.0)*-0.0,-1.0))
 @test isequal(tan(complex(-5.0, NaN)),complex( NaN, NaN))
 
-@test_throws   tan(complex( Inf, 5.0)) #complex(NaN,NaN)
+@test_throws   tan(complex( Inf, 5.0)) DomainError #complex(NaN,NaN)
 @test isequal(tan(complex( Inf, Inf)),complex( 0.0, 1.0))
 @test isequal(tan(complex( Inf,-Inf)),complex (0.0,-1.0))
 @test isequal(tan(complex(-Inf, Inf)),complex(-0.0, 1.0))
@@ -596,5 +596,5 @@
 
 @test complex(1//2,1//3)^2 === complex(5//36, 1//3)
 @test complex(2,2)^2 === complex(0,8)
-@test_throws complex(2,2)^(-2)
+@test_throws complex(2,2)^(-2) DomainError
 @test complex(2.0,2.0)^(-2) === complex(0.0, -0.125)

--- a/test/core.jl
+++ b/test/core.jl
@@ -45,7 +45,7 @@ let T = TypeVar(:T,true)
                   (Number, Array{Number,1}))
     @test !is(None, typeintersect((Array{T}, Array{T}), (Array, Array{Any})))
     f47{T}(x::Vector{Vector{T}}) = 0
-    @test_throws f47(Array(Vector,0))
+    @test_throws f47(Array(Vector,0)) MethodError
     @test f47(Array(Vector{Int},0)) == 0
     @test typeintersect((T,T), (Union(Float64,Int64),Int64)) == (Int64,Int64)
     @test typeintersect((T,T), (Int64,Union(Float64,Int64))) == (Int64,Int64)
@@ -322,7 +322,7 @@ function let_undef()
         end
     end
 end
-@test_throws let_undef()
+@test_throws let_undef() ErrorException
 
 # const implies local in a local scope block
 function const_implies_local()
@@ -377,8 +377,8 @@ begin
     @test !isdefined(a, :foo)
     @test !isdefined(2, :a)
 
-    @test_throws isdefined(2)
-    @test_throws isdefined("a", 2)
+    @test_throws isdefined(2) TypeError
+    @test_throws isdefined("a", 2) TypeError
 end
 
 # dispatch
@@ -533,7 +533,7 @@ begin
     c = Vector[a]
 
     @test my_func(c,c)==0
-    @test_throws my_func(a,c)
+    @test_throws my_func(a,c) MethodError
 end
 
 begin
@@ -554,9 +554,9 @@ begin
 
     # issue #1202
     foor(x::UnionType) = 1
-    @test_throws foor(StridedArray)
+    @test_throws foor(StridedArray) MethodError
     @test foor(StridedArray.body) == 1
-    @test_throws foor(StridedArray)
+    @test_throws foor(StridedArray) MethodError
 end
 
 # issue #1153
@@ -664,9 +664,9 @@ function NewEntity{ T<:Component }(components::Type{T}...)
   map((c)->c(), components)
 end
 
-@test_throws NewEntity(Transform, Transform, Body, Body)
+@test_throws NewEntity(Transform, Transform, Body, Body) MethodError
 @test isa(NewEntity(Transform, Transform), (Transform, Transform))
-@test_throws NewEntity(Transform, Transform, Body, Body)
+@test_throws NewEntity(Transform, Transform, Body, Body) MethodError
 
 # issue #1826
 let
@@ -859,7 +859,7 @@ end
 
 # issue #3221
 let x = fill(nothing, 1)
-    @test_throws x[1] = 1
+    @test_throws x[1] = 1 MethodError
 end
 
 # issue #3220
@@ -997,10 +997,10 @@ end
 
 # make sure convert_default error isn't swallowed by typeof()
 convert_default_should_fail_here() = similar([1],typeof(zero(typeof(rand(2,2)))))
-@test_throws convert_default_should_fail_here()
+@test_throws convert_default_should_fail_here() MethodError
 
 # issue #4343
-@test_throws Array{Float64}{Int, 2}
+@test_throws Array{Float64}{Int, 2} ErrorException
 
 type Foo4376{T}
     x
@@ -1009,7 +1009,7 @@ type Foo4376{T}
 end
 
 @test isa(Foo4376{Float32}(Foo4376{Int}(2)), Foo4376{Float32})
-@test_throws Foo4376{Float32}(Foo4376{Float32}(2.0f0))
+@test_throws Foo4376{Float32}(Foo4376{Float32}(2.0f0)) MethodError
 
 type _0_test_ctor_syntax_
     _0_test_ctor_syntax_{T<:String}(files::Vector{T},step) = 0
@@ -1046,9 +1046,9 @@ end
 
 # issue #4526
 f4526(x) = isa(x.a, Nothing)
-@test_throws f4526(1)
-@test_throws f4526(im)
-@test_throws f4526(1+2im)
+@test_throws f4526(1) ErrorException
+@test_throws f4526(im) ErrorException
+@test_throws f4526(1+2im) ErrorException
 
 # issue #4528
 function f4528(A, B)
@@ -1057,7 +1057,7 @@ function f4528(A, B)
     end
 end
 @test f4528(false, int32(12)) === nothing
-@test_throws f4528(true, int32(12))
+@test_throws f4528(true, int32(12)) ErrorException
 
 # issue #4518
 f4518(x, y::Union(Int32,Int64)) = 0
@@ -1076,7 +1076,7 @@ end
 
 # issue #4645
 i4645(x) = (println(zz); zz = x; zz)
-@test_throws i4645(4)
+@test_throws i4645(4) ErrorException
 
 # issue #4505
 let
@@ -1092,7 +1092,7 @@ type Z4681
     Z4681() = new(C_NULL)
 end
 Base.convert(::Type{Ptr{Z4681}},b::Z4681) = b.x
-@test_throws ccall(:printf,Int,(Ptr{Uint8},Ptr{Z4681}),"",Z4681())
+@test_throws ccall(:printf,Int,(Ptr{Uint8},Ptr{Z4681}),"",Z4681()) TypeError
 
 # issue #4479
 f4479(::Real,c) = 1
@@ -1117,7 +1117,7 @@ type SIQ{A,B} <: Number
 end
 import Base: promote_rule
 promote_rule{T,T2,S,S2}(A::Type{SIQ{T,T2}},B::Type{SIQ{S,S2}}) = SIQ{promote_type(T,S)}
-@test_throws promote_type(SIQ{Int},SIQ{Float64})
+@test_throws promote_type(SIQ{Int},SIQ{Float64}) ErrorException
 
 # issue #4675
 f4675(x::StridedArray...) = 1

--- a/test/file.jl
+++ b/test/file.jl
@@ -146,7 +146,8 @@ s = open(file, "r")
 @test isreadonly(s) == true
 b = mmap_bitarray((17,13), s)
 @test b == trues(17,13)
-@test_throws mmap_bitarray((7,3), s)
+
+@test_throws mmap_bitarray((7,3), s) ErrorException
 close(s)
 s = open(file, "r+")
 b = mmap_bitarray((17,19), s)

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -2,7 +2,7 @@ ioslength(io::IOBuffer) = (io.seekable ? io.size : nb_available(io))
 
 let io = IOBuffer()
 @test eof(io)
-@test_throws read(io,Uint8)
+@test_throws read(io,Uint8) EOFError
 @test write(io,"abc") == 3
 @test ioslength(io) == 3
 @test position(io) == 3
@@ -29,14 +29,14 @@ seek(io, 2)
 truncate(io, 10)
 @test ioslength(io) == 10
 io.readable = false
-@test_throws read(io,Uint8[0])
+@test_throws read(io,Uint8[0]) ErrorException
 truncate(io, 0)
 @test write(io,"boston\ncambridge\n") > 0
 @test takebuf_string(io) == "boston\ncambridge\n"
 @test takebuf_string(io) == ""
 close(io)
-@test_throws write(io,Uint8[0])
-@test_throws seek(io,0)
+@test_throws write(io,Uint8[0]) ErrorException
+@test_throws seek(io,0) ErrorException
 @test eof(io)
 end
 
@@ -44,19 +44,19 @@ let io = IOBuffer("hamster\nguinea pig\nturtle")
 @test position(io) == 0
 @test readline(io) == "hamster\n"
 @test readall(io) == "guinea pig\nturtle"
-@test_throws read(io,Uint8)
+@test_throws read(io,Uint8) EOFError
 seek(io,0)
 @test read(io,Uint8) == 'h'
-@test_throws truncate(io,0)
-@test_throws write(io,uint8(0))
-@test_throws write(io,Uint8[0])
+@test_throws truncate(io,0) ErrorException
+@test_throws write(io,uint8(0)) ErrorException
+@test_throws write(io,Uint8[0]) ErrorException
 @test takebuf_string(io) == "hamster\nguinea pig\nturtle"
 @test takebuf_string(io) == "hamster\nguinea pig\nturtle" #should be unchanged
 close(io)
 end
 
 let io = PipeBuffer()
-@test_throws read(io,Uint8)
+@test_throws read(io,Uint8) EOFError
 @test write(io,"pancakes\nwaffles\nblueberries\n") > 0
 @test position(io) == 0
 @test readline(io) == "pancakes\n"
@@ -64,8 +64,8 @@ Base.compact(io)
 @test readline(io) == "waffles\n"
 @test write(io,"whipped cream\n") > 0
 @test readline(io) == "blueberries\n"
-@test_throws seek(io,0)
-@test_throws truncate(io,0)
+@test_throws seek(io,0) ErrorException
+@test_throws truncate(io,0) ErrorException
 @test readline(io) == "whipped cream\n"
 Base.compact(io)
 @test position(io) == 0

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -6,9 +6,9 @@ kwf1(ones; tens=0, hundreds=0) = ones + 10*tens + 100*hundreds
 @test kwf1(1, hundreds=2, tens=7) == 271
 @test kwf1(3, tens=7, hundreds=2) == 273
 
-@test_throws kwf1()        # no method, too few args
-@test_throws kwf1(1, z=0)  # unsupported keyword
-@test_throws kwf1(1, 2)    # no method, too many positional args
+@test_throws kwf1() MethodError           # no method, too few args
+@test_throws kwf1(1, z=0) ErrorException  # unsupported keyword
+@test_throws kwf1(1, 2) MethodError       # no method, too many positional args
 
 # keyword args plus varargs
 kwf2(x, rest...; y=1) = (x, y, rest)
@@ -16,14 +16,14 @@ kwf2(x, rest...; y=1) = (x, y, rest)
 @test isequal(kwf2(0,1,2), (0, 1, (1,2)))
 @test isequal(kwf2(0,1,2,y=88), (0, 88, (1,2)))
 @test isequal(kwf2(0,y=88,1,2), (0, 88, (1,2)))
-@test_throws kwf2(0, z=1)
-@test_throws kwf2(y=1)
+@test_throws kwf2(0, z=1) ErrorException
+@test_throws kwf2(y=1) MethodError
 
 # keyword arg with declared type
 kwf3(x; y::Float64 = 1.0) = x + y
 @test kwf3(2) == 3.0
 @test kwf3(2, y=3.0) == 5.0
-@test_throws kwf3(2, y=3)  # wrong type keyword
+@test_throws kwf3(2, y=3) TypeError  # wrong type keyword
 
 # function with only keyword args
 kwf4(;a=1,b=2) = (a,b)
@@ -46,8 +46,8 @@ opaf1(a,b=1,c=2,d=3) = (a,b,c,d)
 @test isequal(opaf1(0,2), (0,2,2,3))
 @test isequal(opaf1(0,2,4), (0,2,4,3))
 @test isequal(opaf1(0,2,4,6), (0,2,4,6))
-@test_throws opaf1()
-@test_throws opaf1(0,1,2,3,4)
+@test_throws opaf1() MethodError
+@test_throws opaf1(0,1,2,3,4) MethodError
 
 # optional positional plus varargs
 opaf2(a=1,rest...) = (a,rest)
@@ -60,7 +60,7 @@ opkwf1(a=0,b=1;k=2) = (a,b,k)
 @test isequal(opkwf1(), (0,1,2))
 @test isequal(opkwf1(10), (10,1,2))
 @test isequal(opkwf1(10,20), (10,20,2))
-@test_throws opkwf1(10,20,30)
+@test_throws opkwf1(10,20,30) MethodError
 @test isequal(opkwf1(10,20,k=8), (10,20,8))
 @test isequal(opkwf1(11;k=8),    (11, 1,8))
 @test isequal(opkwf1(k=8),       ( 0, 1,8))
@@ -76,7 +76,7 @@ let
     kwf5 = kwf_maker()
     @test kwf5() == 1
     @test kwf5(k=2) == 5
-    @test_throws kwf5(1)
+    @test_throws kwf5(1) MethodError
 end
 
 # with every feature!
@@ -92,7 +92,7 @@ extravagant_args(x,y=0,rest...;color="blue",kw...) =
 @test sin(1.0) == sin(1.0;{}...)
 
 # passing junk kw container
-@test_throws extravagant_args(1; {[]}...)
+@test_throws extravagant_args(1; {[]}...) BoundsError
 
 # keyword args with static parmeters
 kwf6{T}(x; k::T=1) = T
@@ -102,8 +102,8 @@ kwf6{T}(x; k::T=1) = T
 kwf7{T}(x::T; k::T=1) = T
 @test kwf7(2) === Int
 @test kwf7(1.5;k=2.5) === Float64
-@test_throws kwf7(1.5)
-@test_throws kwf7(1.5;k=2)
+@test_throws kwf7(1.5) MethodError
+@test_throws kwf7(1.5;k=2) TypeError
 
 # try to confuse it with quoted symbol
 kwf8{T}(x::MIME{:T};k::T=0) = 0
@@ -130,7 +130,7 @@ macro TEST4538_2()
 end
 @TEST4538_2
 @test test4538_2() == 1
-@test_throws test4538_2(2)
+@test_throws test4538_2(2) MethodError
 @test test4538_2(x=2) == 2
 
 f4538_3(;x=1) = x

--- a/test/math.jl
+++ b/test/math.jl
@@ -85,7 +85,7 @@ j43 = besselj(4,3.)
 
 @test_approx_eq j33 0.30906272225525164362
 @test_approx_eq j43 0.13203418392461221033
-@test_throws    besselj(0.1, -0.4)
+@test_throws    besselj(0.1, -0.4) DomainError
 @test_approx_eq besselj(0.1, complex(-0.4)) 0.820421842809028916 + 0.266571215948350899im
 @test_approx_eq besselj(3.2, 1.3+0.6im) 0.01135309305831220201 + 0.03927719044393515275im
 @test_approx_eq besselj(1, 3im) 3.953370217402609396im
@@ -95,7 +95,7 @@ true_k33 = 0.12217037575718356792
 @test_approx_eq besselk(3,3) true_k33
 @test_approx_eq besselk(-3,3) true_k33
 true_k3m3 = -0.1221703757571835679 - 3.0151549516807985776im
-@test_throws besselk(3,-3)
+@test_throws besselk(3,-3) DomainError
 @test_approx_eq besselk(3,complex(-3)) true_k3m3
 @test_approx_eq besselk(-3,complex(-3)) true_k3m3
 
@@ -104,7 +104,7 @@ y33 = bessely(3,3.)
 @test bessely(3,3) == y33
 @test_approx_eq bessely(-3,3) -y33
 @test_approx_eq y33 -0.53854161610503161800
-@test_throws bessely(3,-3)
+@test_throws bessely(3,-3) DomainError
 @test_approx_eq bessely(3,complex(-3)) 0.53854161610503161800 - 0.61812544451050328724im
 
 # beta, lbeta

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -144,9 +144,9 @@ y = BigFloat(1)
 
 # exponent
 x = BigFloat(0)
-@test_throws exponent(x)
+@test_throws exponent(x) DomainError
 x = BigFloat(Inf)
-@test_throws exponent(x)
+@test_throws exponent(x) DomainError
 x = BigFloat(15.674)
 @test exponent(x) == exponent(15.674)
 
@@ -160,7 +160,7 @@ prevfloat(y)
 @test x == y
 
 # sqrt DomainError
-@test_throws sqrt(BigFloat(-1))
+@test_throws sqrt(BigFloat(-1)) DomainError
 
 # precision
 old_precision = get_bigfloat_precision()
@@ -178,7 +178,7 @@ end
 @test precision(z) == 240
 x = BigFloat(12)
 @test precision(x) == old_precision
-@test_throws set_bigfloat_precision(1)
+@test_throws set_bigfloat_precision(1) DomainError
 
 # isinteger
 @test isinteger(BigFloat(12))
@@ -284,13 +284,13 @@ with_bigfloat_precision(53) do
 x = BigFloat(42)
     @test log(x) == log(42)
     @test isinf(log(BigFloat(0)))
-    @test_throws log(BigFloat(-1))
+    @test_throws log(BigFloat(-1)) DomainError
     @test log2(x) == log2(42)
     @test isinf(log2(BigFloat(0)))
-    @test_throws log2(BigFloat(-1))
+    @test_throws log2(BigFloat(-1)) DomainError
     @test log10(x) == log10(42)
     @test isinf(log10(BigFloat(0)))
-    @test_throws log10(BigFloat(-1))
+    @test_throws log10(BigFloat(-1)) DomainError
 end
 
 # exp / exp2 / exp10
@@ -304,11 +304,11 @@ end
 # convert to integer types
 x = BigFloat(12.1)
 y = BigFloat(42)
-@test_throws convert(Int32, x)
-@test_throws convert(Int64, x)
-@test_throws convert(BigInt, x)
-@test_throws convert(Uint32, x)
-@test_throws convert(Uint32, x)
+@test_throws convert(Int32, x) InexactError
+@test_throws convert(Int64, x) InexactError
+@test_throws convert(BigInt, x) InexactError
+@test_throws convert(Uint32, x) InexactError
+@test_throws convert(Uint32, x) InexactError
 @test convert(Int32, y) == 42
 @test convert(Int64, y) == 42
 @test convert(BigInt, y) == 42
@@ -347,8 +347,8 @@ with_bigfloat_precision(256) do
     @test factorial(x) == factorial(BigInt(42))
     x = BigFloat(10)
     @test factorial(x) == factorial(10)
-    @test_throws factorial(BigFloat(-1))
-    @test_throws factorial(BigFloat(331.3))
+    @test_throws factorial(BigFloat(-1)) DomainError
+    @test_throws factorial(BigFloat(331.3)) DomainError
 end
 
 # bessel functions
@@ -373,7 +373,7 @@ with_bigfloat_precision(53) do
     for f in (:acos,:asin,:acosh,:atanh),
         j in (-2, -1.5)
         @eval begin
-            @test_throws ($f)(BigFloat($j))
+            @test_throws ($f)(BigFloat($j)) DomainError
         end
     end
     for f in (:sin,:cos,:tan,:sec,:csc,:cot,:cosh,:sinh,:tanh,

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -39,7 +39,7 @@
 @test bool(-1.0) == true
 @test bool(Complex(0,0)) == false
 @test bool(Complex(1,0)) == true
-@test_throws bool(Complex(0,1)) == true
+@test_throws bool(Complex(0,1)) == true InexactError
 @test bool(0//1) == false
 @test bool(1//1) == true
 @test bool(1//2) == true
@@ -53,9 +53,9 @@
 @test min(1.0,1) == 1
 
 # lexing typemin(Int64)
-@test_throws parse("9223372036854775808")
-@test_throws parse("-(9223372036854775808)")
-@test_throws parse("-9223372036854775808^1")
+@test_throws parse("9223372036854775808") ParseError
+@test_throws parse("-(9223372036854775808)") ParseError
+@test_throws parse("-9223372036854775808^1") ParseError
 @test (-9223372036854775808)^1 == -9223372036854775808
 @test [1 -1 -9223372036854775808] == [1 -1 typemin(Int64)]
 
@@ -701,7 +701,7 @@ for a = -5:5, b = -5:5
     @test rationalize(a/b) == a//b
     @test a//b == a//b
     if b == 0
-        @test_throws integer(a//b) == integer(a/b)
+        @test_throws integer(a//b) == integer(a/b) DivideError
     else
         @test integer(a//b) == integer(a/b)
     end
@@ -792,8 +792,8 @@ for A = real_types, B = real_types
 end
 
 # comparison should fail on complex
-@test_throws complex(1,2) > 0
-@test_throws complex(1,2) > complex(0,0)
+@test_throws complex(1,2) > 0 MethodError
+@test_throws complex(1,2) > complex(0,0) MethodError
 
 # div, fld, rem, mod
 for yr = {
@@ -1131,21 +1131,21 @@ for x = 2^24-10:2^24+10
     @test iceil(y)      == i
 end
 
-@test_throws iround(Inf)
-@test_throws iround(NaN)
+@test_throws iround(Inf) InexactError
+@test_throws iround(NaN) InexactError
 @test iround(2.5) == 3
 @test iround(-1.9) == -2
-@test_throws iround(Int64, 9.223372036854776e18)
+@test_throws iround(Int64, 9.223372036854776e18) InexactError
 @test       iround(Int64, 9.223372036854775e18) == 9223372036854774784
-@test_throws iround(Int64, -9.223372036854778e18)
+@test_throws iround(Int64, -9.223372036854778e18) InexactError
 @test       iround(Int64, -9.223372036854776e18) == typemin(Int64)
-@test_throws iround(Uint64, 1.8446744073709552e19)
+@test_throws iround(Uint64, 1.8446744073709552e19) InexactError
 @test       iround(Uint64, 1.844674407370955e19) == 0xfffffffffffff800
-@test_throws iround(Int32, 2.1474836f9)
+@test_throws iround(Int32, 2.1474836f9) InexactError
 @test       iround(Int32, 2.1474835f9) == 2147483520
-@test_throws iround(Int32, -2.147484f9)
+@test_throws iround(Int32, -2.147484f9) InexactError
 @test       iround(Int32, -2.1474836f9) == typemin(Int32)
-@test_throws iround(Uint32, 4.2949673f9)
+@test_throws iround(Uint32, 4.2949673f9) InexactError
 @test       iround(Uint32, 4.294967f9) == 0xffffff00
 
 for n = 1:100
@@ -1166,7 +1166,7 @@ end
 
 @test iround(Uint, 0.5) == 1
 @test iround(Uint, prevfloat(0.5)) == 0
-@test_throws iround(Uint, -0.5)
+@test_throws iround(Uint, -0.5) InexactError
 @test iround(Uint, prevfloat(-0.5)) == 0
 
 @test iround(Int, 0.5f0) == 1
@@ -1176,7 +1176,7 @@ end
 
 @test iround(Uint, 0.5f0) == 1
 @test iround(Uint, prevfloat(0.5f0)) == 0
-@test_throws iround(Uint, -0.5f0)
+@test_throws iround(Uint, -0.5f0) InexactError
 @test iround(Uint, prevfloat(-0.5f0)) == 0
 
 # numbers that can't be rounded by trunc(x+0.5)

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -62,7 +62,7 @@ if haskey(ENV, "PTEST_FULL")
     println("START of parallel tests that print errors")
 
     # make sure exceptions propagate when waiting on Tasks
-    @test_throws (@sync (@async error("oops")))
+    @test_throws (@sync (@async error("oops"))) ErrorException
 
     # pmap tests
     # needs at least 4 processors (which are being created above for the @parallel tests)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -96,7 +96,7 @@ r = (-4*int64(maxintfloat(is(Int,Int32) ? Float32 : Float64))):5
 
 # indexing range with empty range (#4309)
 @test (3:6)[5:4] == 7:6
-@test_throws (3:6)[5:5]
-@test_throws (3:6)[5]
+@test_throws (3:6)[5:5] BoundsError
+@test_throws (3:6)[5] BoundsError
 @test (0:2:10)[7:6] == 12:2:10
-@test_throws (0:2:10)[7:7]
+@test_throws (0:2:10)[7:7] BoundsError

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -204,7 +204,7 @@ reqs_data = {
     {"A", v"1", v"2"},
     {"C", v"2"}
 }
-@test_throws resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data) ErrorException
 
 
 ## DEPENDENCY SCHEME 4: TWO PACKAGES, DAG, WITH TRIVIAL INCONSISTENCY
@@ -248,7 +248,7 @@ want = resolve_tst(deps_data, reqs_data)
 reqs_data = {
     {"A", v"2"}
 }
-@test_throws resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data) ErrorException
 
 
 ## DEPENDENCY SCHEME 6: TWO PACKAGES, CYCLIC, TOTALLY INCONSISTENT
@@ -266,13 +266,13 @@ deps_data = {
 reqs_data = {
     {"A"}
 }
-@test_throws resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data) ErrorException
 
 # require B (impossible)
 reqs_data = {
     {"B"}
 }
-@test_throws resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data) ErrorException
 
 
 ## DEPENDENCY SCHEME 7: THREE PACKAGES, CYCLIC, WITH INCONSISTENCY
@@ -306,7 +306,7 @@ want = resolve_tst(deps_data, reqs_data)
 reqs_data = {
     {"C", v"1", v"2"}
 }
-@test_throws resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data) ErrorException
 
 
 ## DEPENDENCY SCHEME 8: THREE PACKAGES, CYCLIC, TOTALLY INCONSISTENT
@@ -327,19 +327,19 @@ deps_data = {
 reqs_data = {
     {"A"}
 }
-@test_throws resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data) ErrorException
 
 # require B (impossible)
 reqs_data = {
     {"B"}
 }
-@test_throws resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data) ErrorException
 
 # require C (impossible)
 reqs_data = {
     {"C"}
 }
-@test_throws resolve_tst(deps_data, reqs_data)
+@test_throws resolve_tst(deps_data, reqs_data) ErrorException
 
 ## DEPENDENCY SCHEME 9: SIX PACKAGES, DAG
 deps_data = {

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -4,11 +4,11 @@
 @test ip"192.0xFFFF" == IPv4(192,0,255,255)
 @test ip"192.0xFFFFF" == IPv4(192,15,255,255)
 @test ip"192.0xFFFFFF" == IPv4(192,255,255,255)
-@test_throws Base.parseipv4("192.0xFFFFFFF")
+@test_throws Base.parseipv4("192.0xFFFFFFF") ErrorException
 @test ip"022.0.0.1" == IPv4(18,0,0,1)
 
-@test_throws Base.parseipv4("192.0xFFFFFFFFF")
-@test_throws Base.parseipv4("192.")
+@test_throws Base.parseipv4("192.0xFFFFFFFFF") ErrorException
+@test_throws Base.parseipv4("192.") ErrorException
 
 @test ip"::1" == IPv6(1)
 @test ip"2605:2700:0:3::4713:93e3" == IPv6(parseint(Uint128,"260527000000000300000000471393e3",16))
@@ -49,33 +49,20 @@ end
 wait(c)
 @test readall(connect("testsocket")) == "Hello World\n"
 
-try 
-    getaddrinfo(".invalid")
-catch e
-    @test typeof(e) == Base.UVError # E.g. not method error
-end
+@test_throws getaddrinfo(".invalid") Base.UVError
 
-try
-    # This should be an invalid port
-    connect("localhost",21452)
-    @test false
-catch e
-    @test typeof(e) == Base.UVError
-end
+# This should be an invalid port, e.g. nobody's listening
+@test_throws connect("localhost",21452) Base.UVError
 
 server = listen(2134)
-@async @test_throws accept(server);
+@async @test_throws accept(server) ErrorException;
 sleep(0.1)
 close(server)
 
 server = listen(2134)
 @async connect("localhost",2134)
 s1 = accept(server)
-@test_throws accept(server,s1)
+@test_throws accept(server,s1) ErrorException
 close(server)
 
-try 
-    connect(".invalid",80)
-catch e
-    @test typeof(e) == Base.UVError
-end
+@test_throws connect(".invalid",80) Base.UVError

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -38,7 +38,7 @@ begin
     kill(p)
 end
 
-@test_throws run(`foo`)
+@test_throws run(`foo`) Base.UVError
 
 if false
     prefixer(prefix, sleep) = `perl -nle '$|=1; print "'$prefix' ", $_; sleep '$sleep';'`

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -11,10 +11,10 @@
 @test median([1.,-1.,Inf,-Inf]) == 0.0
 @test isnan(median([-Inf,Inf]))
 
-@test_throws median([])
-@test_throws median([NaN])
-@test_throws median([0.0,NaN])
-@test_throws median([NaN,0.0])
+@test_throws median([]) ErrorException
+@test_throws median([NaN]) ErrorException
+@test_throws median([0.0,NaN]) ErrorException
+@test_throws median([NaN,0.0]) ErrorException
 
 @test mean([1,2,3]) == 2.
 @test mean([0 1 2; 4 5 6], 1) == [2. 3. 4.]

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -214,9 +214,9 @@ parsehex(s) = parseint(s,16)
 @test parseint(" 2") == 2
 @test parseint("+2\n") == 2
 @test parseint("-2") == -2
-@test_throws parseint("   2 \n 0")
-@test_throws parseint("2x")
-@test_throws parseint("-")
+@test_throws parseint("   2 \n 0") ArgumentError
+@test_throws parseint("2x") ArgumentError
+@test_throws parseint("-") ArgumentError
 
 # string manipulation
 @test strip("\t  hi   \n") == "hi"
@@ -771,10 +771,10 @@ bin_val = hex2bytes("07bf")
 @test "0123456789abcdefabcdef" == bytes2hex(hex2bytes("0123456789abcdefABCDEF"))
 
 # odd size
-@test_throws hex2bytes("0123456789abcdefABCDEF0")
+@test_throws hex2bytes("0123456789abcdefABCDEF0") ErrorException
 
 #non-hex characters
-@test_throws hex2bytes("0123456789abcdefABCDEFGH")
+@test_throws hex2bytes("0123456789abcdefABCDEFGH") ErrorException
 
 # sizeof
 @test sizeof("abc") == 3
@@ -832,4 +832,4 @@ bin_val = hex2bytes("07bf")
 
 # issue #4586
 @test rsplit(RevString("ailuj"),'l') == {"ju","ia"}
-@test_throws float64(RevString("64"))
+@test_throws float64(RevString("64")) MethodError


### PR DESCRIPTION
This way our tests don't mask other exceptions during the testing process.  Inspired by https://github.com/JuliaLang/julia/commit/bda1798a0587ad3b035d4534137d3ce9ed93e5e8
- Update everything in test/ to honor this change (Note, package authors wil still probably need to alter their own package tests)
- I even found a few tests that really wanted to be @test_throws tests but just didn't know it yet.
- Update a mistyped issue number

I'm ambivalent as to whether this makes it into 0.2; it seems more like a hygiene/test thing than anything critical.  The only reason I think it might be beneficial to have merged in sooner than later is for package authors using `@test_throws` in their own code.
