### PR TITLE
Consistently use quotes in parsing errors

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -59,12 +59,12 @@ void jl_errorf(const char *fmt, ...)
 void jl_too_few_args(const char *fname, int min)
 {
     // TODO: ArgumentError
-    jl_errorf("%s: too few arguments (expected %d)", fname, min);
+    jl_errorf("\"%s\": too few arguments (expected %d)", fname, min);
 }
 
 void jl_too_many_args(const char *fname, int max)
 {
-    jl_errorf("%s: too many arguments (expected %d)", fname, max);
+    jl_errorf("\"%s\": too many arguments (expected %d)", fname, max);
 }
 
 void jl_type_error_rt(const char *fname, const char *context,
@@ -312,7 +312,7 @@ JL_CALLABLE(jl_f_kwcall)
         jl_error("function does not accept keyword arguments");
     jl_function_t *sorter = ((jl_methtable_t*)f->env)->kwsorter;
     if (sorter == NULL) {
-        jl_errorf("function %s does not accept keyword arguments",
+        jl_errorf("function \"%s\" does not accept keyword arguments",
                   jl_gf_name(f)->name);
     }
 
@@ -470,7 +470,7 @@ JL_CALLABLE(jl_f_set_field)
         jl_type_error("setfield", (jl_value_t*)jl_datatype_type, v);
     jl_datatype_t *st = (jl_datatype_t*)vt;
     if (!st->mutabl)
-        jl_errorf("type %s is immutable", st->name->name->name);
+        jl_errorf("type \"%s\" is immutable", st->name->name->name);
     jl_sym_t *fld = (jl_sym_t*)args[1];
     size_t i = jl_field_index(st, fld, 1);
     jl_value_t *ft = jl_tupleref(st->types,i);
@@ -677,7 +677,7 @@ void jl_show(jl_value_t *stream, jl_value_t *v)
             jl_show_gf = (jl_function_t*)jl_get_global(jl_base_module, jl_symbol("show"));
         }
         if (jl_show_gf==NULL || stream==NULL) {
-            JL_PRINTF(JL_STDERR, " could not show value of type %s",
+            JL_PRINTF(JL_STDERR, " could not show value of type \"%s\"",
                       jl_is_tuple(v) ? "Tuple" : 
                       ((jl_datatype_t*)jl_typeof(v))->name->name->name);
             return;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -248,7 +248,7 @@ static Function *to_function(jl_lambda_info_t *li, bool cstyle)
             builder.SetCurrentDebugLocation(olddl);
         }
         JL_SIGATOMIC_END();
-        jl_rethrow_with_add("error compiling %s", li->name->name);
+        jl_rethrow_with_add("error compiling \"%s\"", li->name->name);
     }
     assert(f != NULL);
     nested_compile = last_n_c;
@@ -328,16 +328,16 @@ void *jl_function_ptr(jl_function_t *f, jl_value_t *rt, jl_value_t *argt)
                 jl_lambda_info_t *li = ff->linfo;
                 jl_value_t *astrt = jl_ast_rettype(li, li->ast);
                 if (!jl_types_equal((jl_value_t*)li->specTypes, argt)) {
-                    jl_errorf("cfunction: type signature of %s does not match",
+                    jl_errorf("cfunction: type signature of \"%s\" does not match",
                               li->name->name);
                 }
                 if (!jl_types_equal(astrt, rt) &&
                     !(astrt==(jl_value_t*)jl_nothing->type && rt==(jl_value_t*)jl_bottom_type)) {
                     if (astrt == (jl_value_t*)jl_bottom_type) {
-                        jl_errorf("cfunction: %s does not return", li->name->name);
+                        jl_errorf("cfunction: \"%s\" does not return", li->name->name);
                     }
                     else {
-                        jl_errorf("cfunction: return type of %s does not match",
+                        jl_errorf("cfunction: return type of \"%s\" does not match",
                                   li->name->name);
                     }
                 }
@@ -1806,8 +1806,9 @@ static Value *emit_checked_var(Value *bp, jl_sym_t *name, jl_codectx_t *ctx)
     builder.CreateCondBr(ok, ifok, err);
     builder.SetInsertPoint(err);
     std::string msg;
+    msg += "\"";
     msg += std::string(name->name);
-    msg += " not defined";
+    msg += "\" not defined";
     just_emit_error(msg, ctx);
     builder.CreateBr(ifok);
     ctx->f->getBasicBlockList().push_back(ifok);
@@ -2303,7 +2304,7 @@ static Value *emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed,
     }
     else {
         if (!strcmp(head->name, "$"))
-            jl_error("syntax: prefix $ in non-quoted expression");
+            jl_error("syntax: prefix \"$\" in non-quoted expression");
         if (jl_is_toplevel_only_expr(expr) &&
             ctx->linfo->name == anonymous_sym && ctx->vars.empty() &&
             ctx->linfo->module == jl_current_module) {
@@ -2323,7 +2324,7 @@ static Value *emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed,
                 jl_errorf("macro definition not allowed inside a local scope");
             }
             else {
-                jl_errorf("unsupported or misplaced expression %s in function %s",
+                jl_errorf("unsupported or misplaced expression \"%s\" in function \"%s\"",
                           head->name, ctx->linfo->name->name);
             }
         }

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -95,7 +95,7 @@ void jl_dump_function_asm(void* Fptr, size_t Fsize,
 
     OwningPtr<const MCDisassembler> DisAsm(TheTarget->createMCDisassembler(*STI));
     if (!DisAsm) {
-        JL_PRINTF(JL_STDERR, "error: no disassembler for target", TripleName.c_str(), "\n");
+        JL_PRINTF(JL_STDERR, "error: no disassembler for target \"", TripleName.c_str(), "\"\n");
         return;
     }
  

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -88,7 +88,7 @@ static uv_lib_t *jl_load_dynamic_library_(char *modname, unsigned flags, int thr
         if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                                 (LPCSTR)(&jl_load_dynamic_library),
                                 &handle->handle))
-            jl_errorf("could not load base module", modname);
+            jl_errorf("could not load base module \"", modname, "\"");
 #else
         handle->handle = dlopen(NULL,RTLD_NOW);
 #endif
@@ -142,7 +142,7 @@ static uv_lib_t *jl_load_dynamic_library_(char *modname, unsigned flags, int thr
 
     if (throw_err) {
         //JL_PRINTF(JL_STDERR, "could not load module %s (%d): %s\n", modname, error, uv_dlerror(handle));
-        jl_errorf("could not load module %s: %s", modname, uv_dlerror(handle));
+        jl_errorf("could not load module \"%s\": %s", modname, uv_dlerror(handle));
     }
     uv_dlclose(handle);
     free(handle);
@@ -174,7 +174,7 @@ DLLEXPORT void *jl_dlsym(uv_lib_t *handle, char *symbol)
     void *ptr;
     int  error = uv_dlsym(handle, symbol, &ptr);
     if (error != 0) {
-        jl_printf(JL_STDERR, "symbol could not be found %s (%d): %s\n", symbol, error, uv_dlerror(handle));
+        jl_printf(JL_STDERR, "symbol could not be found \"%s\" (%d): %s\n", symbol, error, uv_dlerror(handle));
     }
     return ptr;
 }

--- a/src/gf.c
+++ b/src/gf.c
@@ -389,7 +389,7 @@ void jl_type_infer(jl_lambda_info_t *li, jl_tuple_t *argtypes,
         fargs[2] = (jl_value_t*)jl_null;
         fargs[3] = (jl_value_t*)def;
 #ifdef TRACE_INFERENCE
-        JL_PRINTF(JL_STDERR,"inference on %s", li->name->name);
+        JL_PRINTF(JL_STDERR,"inference on \"%s\"", li->name->name);
         jl_static_show(JL_STDERR, (jl_value_t*)argtypes);
         JL_PRINTF(JL_STDERR, "\n");
 #endif
@@ -1081,11 +1081,11 @@ jl_methlist_t *jl_method_list_insert(jl_methlist_t **pml, jl_tuple_t *type,
                 jl_module_t *newmod = method->linfo->module;
                 jl_value_t *errstream = jl_stderr_obj();
                 JL_STREAM *s = JL_STDERR;
-                JL_PRINTF(s, "Warning: Method definition %s", method->linfo->name->name);
+                JL_PRINTF(s, "Warning: Method definition \"%s\"", method->linfo->name->name);
                 jl_show(errstream, (jl_value_t*)type);
-                JL_PRINTF(s, " in module %s", l->func->linfo->module->name->name);
+                JL_PRINTF(s, " in module \"%s\"", l->func->linfo->module->name->name);
                 print_func_loc(s, l->func->linfo);
-                JL_PRINTF(s, " overwritten in module %s", newmod->name->name);
+                JL_PRINTF(s, " overwritten in module \"%s\"", newmod->name->name);
                 print_func_loc(s, method->linfo);
                 JL_PRINTF(s, ".\n");
             }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -63,7 +63,7 @@ jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e)
 {
     jl_value_t *v = jl_get_global(m, e);
     if (v == NULL)
-        jl_errorf("%s not defined", e->name);
+        jl_errorf("\"%s\" not defined", e->name);
     return v;
 }
 
@@ -87,7 +87,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
             v = jl_get_global(jl_current_module, (jl_sym_t*)e);
         }
         if (v == NULL) {
-            jl_errorf("%s not defined", ((jl_sym_t*)e)->name);
+            jl_errorf("\"%s\" not defined", ((jl_sym_t*)e)->name);
         }
         return v;
     }
@@ -101,7 +101,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
         jl_sym_t *s = (jl_sym_t*)jl_fieldref(e,0);
         jl_value_t *v = jl_get_global(jl_base_relative_to(jl_current_module),s);
         if (v == NULL)
-            jl_errorf("%s not defined", s->name);
+            jl_errorf("\"%s\" not defined", s->name);
         return v;
     }
     if (!jl_is_expr(e)) {
@@ -297,10 +297,10 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
         para = eval(args[1], locals, nl);
         vnb  = eval(args[2], locals, nl);
         if (!jl_is_long(vnb))
-            jl_errorf("invalid declaration of bits type %s", ((jl_sym_t*)name)->name);
+            jl_errorf("invalid declaration of bits type \"%s\"", ((jl_sym_t*)name)->name);
         int32_t nb = jl_unbox_long(vnb);
         if (nb < 1 || nb>=(1<<23) || (nb&7) != 0)
-            jl_errorf("invalid number of bits in type %s",
+            jl_errorf("invalid number of bits in type \"%s\"",
                       ((jl_sym_t*)name)->name);
         jl_datatype_t *dt =
             jl_new_bitstype(name, jl_any_type, (jl_tuple_t*)para, nb);
@@ -364,13 +364,13 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
     }
     else if (ex->head == error_sym || ex->head == jl_continue_sym) {
         if (jl_is_byte_string(args[0]))
-            jl_errorf("syntax: %s", jl_string_data(args[0]));
+            jl_errorf("syntax: \"%s\"", jl_string_data(args[0]));
         jl_throw(args[0]);
     }
     else if (ex->head == boundscheck_sym) {
         return (jl_value_t*)jl_nothing;
     }
-    jl_errorf("unsupported or misplaced expression %s", ex->head->name);
+    jl_errorf("unsupported or misplaced expression \"%s\"", ex->head->name);
     return (jl_value_t*)jl_nothing;
 }
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1490,7 +1490,7 @@ jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n)
     }
     size_t ntp = jl_tuple_len(tp);
     if (n > ntp)
-        jl_errorf("too many parameters for type %s", tname);
+        jl_errorf("too many parameters for type \"%s\"", tname);
     jl_value_t **env;
     JL_GC_PUSHARGS(env, 2*ntp);
     memset(env, 0, 2 * ntp * sizeof(jl_value_t*));
@@ -1524,7 +1524,7 @@ jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n)
         ne++;
     }
     if (ne < n)
-        jl_errorf("too many parameters for type %s", tname);
+        jl_errorf("too many parameters for type \"%s\"", tname);
     if (jl_is_typector(tc)) tc = (jl_value_t*)((jl_typector_t*)tc)->body;
     jl_value_t *result = jl_instantiate_type_with((jl_value_t*)tc, env, ne);
     JL_GC_POP();

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -137,7 +137,7 @@
 
 (define (read-operator port c)
   (if (and (eqv? c #\*) (eqv? (peek-char port) #\*))
-      (error "use ^ instead of **"))
+      (error "use \"^\" instead of \"**\""))
   (if (or (eof-object? (peek-char port)) (not (opchar? (peek-char port))))
       (symbol (string c)) ; 1-char operator
       (let loop ((str (string c))
@@ -203,16 +203,16 @@
 	  (begin (read-char port)
 		 (if (dot-opchar? (peek-char port))
 		     (io.ungetc port #\.)
-		     (error (string "invalid numeric constant "
-				    (get-output-string str) #\.))))))
+		     (error (string "invalid numeric constant \""
+				    (get-output-string str) #\. "\""))))))
     (define (read-digs lz)
       (let ((D (accum-digits (peek-char port) pred port lz)))
 	(let ((d  (car D))
 	      (ok (cdr D)))
 	  (if (not ok)
 	      (begin (display d str)
-		     (error (string "invalid numeric constant "
-				    (get-output-string str)))))
+		     (error (string "invalid numeric constant \""
+				    (get-output-string str) "\""))))
 	  (and (not (equal? d ""))
 	       (not (eof-object? d))
 	       (display d str)
@@ -261,8 +261,8 @@
 	  (if (and (or (eq? pred char-bin?) (eq? pred char-oct?))
 		   (not (eof-object? c))
 		   (char-numeric? c))
-	      (error (string "invalid numeric constant "
-			     (get-output-string str) c)))))
+	      (error (string "invalid numeric constant \""
+			     (get-output-string str) c "\"")))))
     (let* ((s (get-output-string str))
 	   (r (cond ((eq? pred char-hex?) 16)
 		    ((eq? pred char-oct?) 8)
@@ -282,9 +282,9 @@
 		((eq? pred char-bin?) (fix-uint-neg neg (sized-uint-literal n s 1)))
                 (is-float32-literal   (float n))
 		(else (if (and (integer? n) (> n 9223372036854775807))
-			  (error (string "invalid numeric constant " s))
+			  (error (string "invalid numeric constant \"" s "\""))
 			  n)))
-	  (error (string "invalid numeric constant " s))))))
+	  (error (string "invalid numeric constant \"" s "\""))))))
 
 (define (fix-uint-neg neg n)
   (if neg `(call - ,n) n))
@@ -333,7 +333,7 @@
 			((opchar? nextc)
 			 (let ((op (read-operator port c)))
 			   (if (and (eq? op '..) (opchar? (peek-char port)))
-			       (error (string "invalid operator " op (peek-char port))))
+			       (error (string "invalid operator \"" op (peek-char port) "\"")))
 			   op))
 			(else '|.|)))))
 
@@ -341,7 +341,7 @@
 
 	  ((identifier-char? c) (accum-julia-symbol c port))
 
-	  (else (error (string "invalid character " (read-char port)))))))
+	  (else (error (string "invalid character \"" (read-char port) "\""))))))
 
 ; --- parser ---
 
@@ -415,7 +415,7 @@
 	   (begin (take-token s)
 		  (let ((then (without-range-colon (parse-eq* s))))
 		    (if (not (eq? (take-token s) ':))
-			(error "colon expected in ? expression")
+			(error "colon expected in \"?\" expression")
 			(list 'if ex then (parse-cond s))))))
 	  #;((string? ex)
 	   (let loop ((args (list ex)))
@@ -454,7 +454,7 @@
 ; ow, my eyes!!
 (define (parse-Nary s down ops head closers allow-empty)
   (if (invalid-initial-token? (require-token s))
-      (error (string "unexpected " (peek-token s))))
+      (error (string "unexpected \"" (peek-token s) "\"")))
   (if (memv (require-token s) closers)
       (list head)  ; empty block
       (let loop ((ex
@@ -526,13 +526,13 @@
 			(cond ((closing-token? (peek-token s))
 			       ':)  ; missing last argument
 			      ((newline? (peek-token s))
-			       (error "line break in : expression"))
+			       (error "line break in \":\" expression"))
 			      (else
 			       (parse-expr s)))))
 		   (if (and (not (ts:space? s))
 			    (or (eq? argument '<) (eq? argument '>)))
-		       (error (string ': argument " found instead of "
-				      argument ':)))
+		       (error (string : "\":" argument "\" found instead of \""
+				      argument ":\"")))
 		   (if first?
 		       (loop (list t ex argument) #f)
 		       (loop (append ex (list argument)) #t)))))
@@ -662,7 +662,7 @@
 		(not (ts:space? s)))
 	   (begin
 	     #;(if (and (number? ex) (= ex 0))
-		 (error "juxtaposition with literal 0"))
+		 (error "juxtaposition with literal \"0\""))
 	     `(call * ,ex ,(parse-unary s))))
 	  (else ex))))
 
@@ -683,8 +683,8 @@
 		   (if (memq (peek-token s) '(^ .^))
 		       ;; -2^x parsed as (- (^ 2 x))
 		       (begin (if (= num -9223372036854775808)
-				  (error (string "invalid numeric constant "
-						 (- num))))
+				  (error (string "invalid numeric constant \""
+						 (- num) "\"")))
 			      (ts:put-back! s (maybe-negate op num))
 			      (list 'call op (parse-factor s)))
 		       num))
@@ -839,13 +839,13 @@
   (let ((t (peek-token s)))
     (cond ((eq? t 'end) (take-token s))
 	  ((eof-object? t)
-	   (error (string "incomplete: " word " at "
+	   (error (string "incomplete: \"" word "\" at "
 			  current-filename ":" expect-end-current-line
 			  " requires end")))
 	  (else
-	   (error (string word " at "
+	   (error (string "\"" word "\" at "
 			  current-filename ":" expect-end-current-line
-			  " expected end, got " t))))))
+			  " expected \"end\", got \"" t "\""))))))
 
 (define (parse-subtype-spec s)
   (subtype-syntax (parse-ineq s)))
@@ -894,14 +894,14 @@
 	       (block ,(line-number-node s)
 		      ,(parse-resword s 'if))))
 	 ((else)    (list 'if test then (parse-resword s 'begin)))
-	 (else      (error (string "unexpected " nxt))))))
+	 (else      (error (string "unexpected \"" nxt "\""))))))
     ((let)
      (let ((binds (if (memv (peek-token s) '(#\newline #\;))
 		      '()
 		      (parse-comma-separated-assignments s))))
        (if (not (or (eof-object? (peek-token s))
 		    (memv (peek-token s) '(#\newline #\; end))))
-	   (error "let variables should end in ; or newline"))
+	   (error "let variables should end in \";\" or newline"))
        (let ((ex (parse-block s)))
 	 (expect-end s)
 	 `(let ,ex ,@binds))))
@@ -922,11 +922,11 @@
 			   ;; in "function (x)" the (x) is a tuple
 			   `(tuple ,sig)
 			   ;; function foo  =>  syntax error
-			   (error (string "expected ( in " word " definition")))
+			   (error (string "expected \"(\" in \"" word "\" definition")))
 		       (if (not (and (pair? sig)
 				     (or (eq? (car sig) 'call)
 					 (eq? (car sig) 'tuple))))
-			   (error (string "expected ( in " word " definition"))
+			   (error (string "expected \"(\" in \"" word "\" definition"))
 			   sig)))
 	    (loc   (begin (skip-ws-and-comments (ts:port s))
 			  (line-number-filename-node s)))
@@ -999,7 +999,7 @@
 		   catchb
 		   catchv
 		   fb)))
-	  (else    (error (string "unexpected " nxt)))))))
+	  (else    (error (string "unexpected \"" nxt "\"")))))))
     ((return)          (let ((t (peek-token s)))
 			 (if (or (eqv? t #\newline) (closing-token? t))
 			     (list 'return '(null))
@@ -1011,7 +1011,7 @@
 		     (or (eq? (car assgn) '=)
 			 (eq? (car assgn) 'global)
 			 (eq? (car assgn) 'local))))
-	   (error "expected assignment after const")
+	   (error "expected assignment after \"const\"")
 	   `(const ,assgn))))
     ((module baremodule)
      (let* ((name (parse-atom s))
@@ -1032,7 +1032,7 @@
      (let ((es (map macrocall-to-atsym
 		    (parse-comma-separated s parse-atom))))
        (if (not (every symbol? es))
-	   (error "invalid export statement"))
+	   (error "invalid \"export\" statement"))
        `(export ,@es)))
     ((import using importall)
      (let ((imports (parse-imports s word)))
@@ -1041,7 +1041,7 @@
 	   (cons 'toplevel imports))))
     ((ccall)
      (if (not (eqv? (peek-token s) #\())
-	 (error "invalid ccall syntax")
+	 (error "invalid \"ccall\" syntax")
 	 (begin
 	   (take-token s)
 	   (let ((al (parse-arglist s #\))))
@@ -1051,7 +1051,7 @@
 		 `(ccall ,(car al) ,@(cddr al) (,(cadr al)))
 		 `(ccall ,.al))))))
     ((do)
-     (error "invalid do syntax"))
+     (error "invalid \"do\" syntax"))
     (else (error "unhandled reserved word"))))))
 
 (define (parse-do s)
@@ -1111,7 +1111,7 @@
 (define (parse-import s word)
   (let loop ((path (parse-import-dots s)))
     (if (not (symbol? (car path)))
-	(error (string "invalid " word " statement: expected identifier")))
+	(error (string "invalid \"" word "\" statement: expected identifier")))
     (let ((nxt (peek-token s)))
       (cond
        ((eq? nxt '|.|)
@@ -1125,7 +1125,7 @@
 	(loop (cons (symbol (string.sub (string nxt) 1))
 		    path)))
        (else
-	(error (string "invalid " word " statement")))))))
+	(error (string "invalid \"" word "\" statement")))))))
 
 ; parse comma-separated assignments, like "i=1:n,j=1:m,..."
 (define (parse-comma-separated s what)
@@ -1213,7 +1213,7 @@
 		      #;((eqv? c #\newline)
 		       (error "unexpected line break in argument list"))
 		      ((memv c '(#\] #\}))
-		       (error (string "unexpected " c " in argument list")))
+		       (error (string "unexpected \"" c "\" in argument list")))
 		      (else
 		       (error (string "missing comma or " closer
 				      " in argument list"))))))))))
@@ -1237,7 +1237,7 @@
 	    ((#\;)
 	     (error "unexpected semicolon in array expression"))
 	    ((#\] #\})
-	     (error (string "unexpected " t)))
+	     (error (string "unexpected \"" t "\"")))
 	    (else
 	     (error "missing separator in array expression")))))))
 
@@ -1286,7 +1286,7 @@
 	    ((#\,)
 	     (error "unexpected comma in matrix expression"))
 	    ((#\] #\})
-	     (error (string "unexpected " t)))
+	     (error (string "unexpected \"" t "\"")))
 	    ((for)
 	     (if (and (not semicolon)
 		      (length= outer 1)
@@ -1352,13 +1352,13 @@
       #;((#\newline)
       (error "unexpected line break in tuple"))
       ((#\] #\})
-       (error (string "unexpected " (peek-token s) " in tuple")))
+       (error (string "unexpected \"" (peek-token s) "\" in tuple")))
       (else
        (error "missing separator in tuple")))))
 
 (define (not-eof-2 c)
   (if (eof-object? c)
-      (error "incomplete: invalid ` syntax")
+      (error "incomplete: invalid \"`\" syntax")
       c))
 
 (define (parse-backquote s)
@@ -1407,7 +1407,7 @@
                     (take-token s)
                     ex)
                    (else (error "invalid interpolation syntax")))))
-          (else (error (string "invalid interpolation syntax: " c))))))
+          (else (error (string "invalid interpolation syntax: \"" c "\""))))))
 
 (define (tostr custom io)
   (if custom
@@ -1482,7 +1482,7 @@
   (let ((ex (parse-atom- s)))
     (if (or (memq ex syntactic-operators)
 	    (eq? ex '....))
-	(error (string "invalid identifier name " ex)))
+	(error (string "invalid identifier name \"" ex "\"")))
     ex))
 
 (define (parse-atom- s)
@@ -1527,7 +1527,7 @@
 	       (list 'quote (parse-atom- s))))
 
 	  ;; misplaced =
-	  ((eq? t '=) (error "unexpected ="))
+	  ((eq? t '=) (error "unexpected \"=\""))
 
 	  ;; identifier
 	  ((symbol? t) (take-token s))
@@ -1545,7 +1545,7 @@
 	     ;; allow (=) etc.
 	     (let ((tok (take-token s)))
 	       (if (not (eqv? (require-token s) #\) ))
-		   (error (string "invalid identifier name " tok))
+		   (error (string "invalid identifier name \"" tok "\""))
 		   (take-token s))
 	       tok))
 	    (else
@@ -1581,7 +1581,7 @@
 		     #;((eqv? t #\newline)
 		        (error "unexpected line break in tuple"))
 		     ((memv t '(#\] #\}))
-		      (error (string "unexpected " t " in tuple")))
+		      (error (string "unexpected \"" t "\" in tuple")))
 		     (else
 		      (error "missing separator in tuple")))))))))
 
@@ -1660,7 +1660,7 @@
 	   (take-token s)
 	   (parse-backquote s))
 
-	  (else (error (string "invalid syntax: " (take-token s)))))))
+	  (else (error (string "invalid syntax: \"" (take-token s) "\""))))))
 
 (define (valid-modref? e)
   (and (length= e 3) (eq? (car e) '|.|) (pair? (caddr e))
@@ -1672,7 +1672,7 @@
   (cond ((symbol? e)  (symbol (string #\@ e)))
 	((valid-modref? e)  `(|.| ,(cadr e)
 			      (quote ,(macroify-name (cadr (caddr e))))))
-	(else (error (string "invalid macro use @" e)))))
+	(else (error (string "invalid macro use \"@" e "\"" )))))
 
 ; --- main entry point ---
 

--- a/src/module.c
+++ b/src/module.c
@@ -70,7 +70,7 @@ jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var)
         else if ((*bp)->owner != m) {
             // TODO: change this to an error soon
             jl_printf(JL_STDERR,
-                       "Warning: imported binding for %s overwritten in module %s\n", var->name, m->name->name);
+                       "Warning: imported binding for \"%s\" overwritten in module \"%s\"\n", var->name, m->name->name);
         }
         else {
             return *bp;
@@ -95,9 +95,9 @@ jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *var)
         if (b->owner != m && b->owner != NULL) {
             jl_binding_t *b2 = jl_get_binding(b->owner, var);
             if (b2 == NULL)
-                jl_errorf("invalid method definition: imported function %s.%s does not exist", b->owner->name->name, var->name);
+                jl_errorf("invalid method definition: imported function \"%s.%s\" does not exist", b->owner->name->name, var->name);
             if (!b->imported)
-                jl_errorf("error in method definition: function %s.%s must be explicitly imported to be extended", b->owner->name->name, var->name);
+                jl_errorf("error in method definition: function \"%s.%s\" must be explicitly imported to be extended", b->owner->name->name, var->name);
             return b2;
         }
         b->owner = m;
@@ -174,7 +174,7 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
     jl_binding_t *b = jl_get_binding(from, s);
     if (b == NULL) {
         jl_printf(JL_STDERR,
-                  "Warning: could not import %s.%s into %s\n",
+                  "Warning: could not import \"%s.%s\" into \"%s\"\n",
                   from->name->name, s->name, to->name->name);
     }
     else {
@@ -197,7 +197,7 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
                     return;
                 }
                 jl_printf(JL_STDERR,
-                          "Warning: ignoring conflicting import of %s.%s into %s\n",
+                          "Warning: ignoring conflicting import of \"%s.%s\" into \"%s\"\n",
                           from->name->name, s->name, to->name->name);
             }
             else if (bto->constp || bto->value) {
@@ -208,7 +208,7 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
                     return;
                 }
                 jl_printf(JL_STDERR,
-                          "Warning: import of %s.%s into %s conflicts with an existing identifier; ignored.\n",
+                          "Warning: import of \"%s.%s\" into \"%s\" conflicts with an existing identifier; ignored.\n",
                           from->name->name, s->name, to->name->name);
             }
             else {
@@ -271,7 +271,7 @@ void jl_module_using(jl_module_t *to, jl_module_t *from)
                     var != to->name &&
                     !eq_bindings(jl_get_binding(to,var), b)) {
                     jl_printf(JL_STDERR,
-                              "Warning: using %s.%s in module %s conflicts with an existing identifier.\n",
+                              "Warning: using \"%s.%s\" in module \"%s\" conflicts with an existing identifier.\n",
                               from->name->name, var->name, to->name->name);
                 }
             }
@@ -351,9 +351,9 @@ void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
         if (!jl_egal(rhs, b->value) &&
             (jl_typeof(rhs) != jl_typeof(b->value) ||
              jl_is_type(rhs) || jl_is_function(rhs) || jl_is_module(rhs))) {
-            jl_errorf("invalid redefinition of constant %s", b->name->name);
+            jl_errorf("invalid redefinition of constant \"%s\"", b->name->name);
         }
-        JL_PRINTF(JL_STDERR,"Warning: redefining constant %s\n",b->name->name);
+        JL_PRINTF(JL_STDERR,"Warning: redefining constant \"%s\"\n",b->name->name);
     }
     b->value = rhs;
 }
@@ -361,7 +361,7 @@ void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
 void jl_declare_constant(jl_binding_t *b)
 {
     if (b->value != NULL && !b->constp) {
-        jl_errorf("cannot declare %s constant; it already has a value",
+        jl_errorf("cannot declare \"%s\" constant; it already has a value",
                   b->name->name);
     }
     b->constp = 1;

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -48,7 +48,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
     jl_binding_t *b = jl_get_binding_wr(parent_module, name);
     jl_declare_constant(b);
     if (b->value != NULL) {
-        JL_PRINTF(JL_STDERR, "Warning: replacing module %s\n", name->name);
+        JL_PRINTF(JL_STDERR, "Warning: replacing module \"%s\"\n", name->name);
     }
     jl_module_t *newm = jl_new_module(name);
     newm->parent = parent_module;
@@ -233,7 +233,7 @@ static jl_module_t *eval_import_path_(jl_array_t *args, int retrying)
             if (mb->owner == m || mb->imported) {
                 m = (jl_module_t*)mb->value;
                 if (m == NULL || !jl_is_module(m))
-                    jl_errorf("invalid module path (%s does not name a module)", var->name);
+                    jl_errorf("invalid module path (\"%s\" does not name a module)", var->name);
                 break;
             }
         }
@@ -255,7 +255,7 @@ static jl_module_t *eval_import_path_(jl_array_t *args, int retrying)
             return NULL;
         }
         else {
-            jl_errorf("in module path: %s not defined", var->name);
+            jl_errorf("in module path: \"%s\" not defined", var->name);
         }
     }
 
@@ -312,7 +312,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast)
         assert(jl_is_symbol(name));
         m = (jl_module_t*)jl_eval_global_var(m, name);
         if (!jl_is_module(m))
-	    jl_errorf("invalid %s statement: name exists but does not refer to a module", ex->head->name);
+	    jl_errorf("invalid \"%s\" statement: name exists but does not refer to a module", ex->head->name);
         jl_module_importall(jl_current_module, m);
         return jl_nothing;
     }
@@ -443,7 +443,7 @@ jl_value_t *jl_parse_eval_all(char *fname)
                 break;
             if (jl_is_expr(form)) {
                 if (((jl_expr_t*)form)->head == jl_continue_sym) {
-                    jl_errorf("syntax: %s", jl_string_data(jl_exprarg(form,0)));
+                    jl_errorf("syntax: \"%s\"", jl_string_data(jl_exprarg(form,0)));
                 }
                 if (((jl_expr_t*)form)->head == error_sym) {
                     jl_interpret_toplevel_expr(form);
@@ -477,10 +477,10 @@ jl_value_t *jl_load(const char *fname)
     char *fpath = (char*)fname;
     uv_stat_t stbuf;
     if (jl_stat(fpath, (char*)&stbuf) != 0 || (stbuf.st_mode & S_IFMT) != S_IFREG) {
-        jl_errorf("could not open file %s", fpath);
+        jl_errorf("could not open file \"%s\"", fpath);
     }
     if (jl_start_parsing_file(fpath) != 0) {
-        jl_errorf("could not open file %s", fpath);
+        jl_errorf("could not open file \"%s\"", fpath);
     }
     jl_value_t *result = jl_parse_eval_all(fpath);
     if (fpath != fname) free(fpath);
@@ -516,7 +516,7 @@ void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super)
         !jl_is_abstracttype(super) ||
         jl_subtype(super,(jl_value_t*)jl_vararg_type,0) ||
         jl_subtype(super,(jl_value_t*)jl_type_type,0)) {
-        jl_errorf("invalid subtyping in definition of %s",tt->name->name->name);
+        jl_errorf("invalid subtyping in definition of \"%s\"",tt->name->name->name);
     }
     tt->super = (jl_datatype_t*)super;
     if (jl_tuple_len(tt->parameters) > 0) {
@@ -560,7 +560,7 @@ jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_binding_t *bnd,
     if (bnd) {
         //jl_declare_constant(bnd);
         if (bnd->value != NULL && !bnd->constp) {
-            jl_errorf("cannot define function %s; it already has a value",
+            jl_errorf("cannot define function \"%s\"; it already has a value",
                       bnd->name->name);
         }
         bnd->constp = 1;
@@ -590,7 +590,7 @@ jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_binding_t *bnd,
         jl_value_t *elt = jl_tupleref(argtypes,i);
         if (!jl_is_type(elt) && !jl_is_typevar(elt)) {
             jl_lambda_info_t *li = f->linfo;
-            jl_errorf("invalid type for argument %s in method definition for %s at %s:%d",
+            jl_errorf("invalid type for argument \"%s\" in method definition for \"%s\" at %s:%d",
                       jl_is_expr(li->ast) ?
                       ((jl_sym_t*)jl_arrayref(jl_lam_args((jl_expr_t*)li->ast),i))->name :
                       "?",
@@ -604,7 +604,7 @@ jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_binding_t *bnd,
         if (!jl_is_typevar(tv))
             jl_type_error_rt(name->name, "method definition", (jl_value_t*)jl_tvar_type, tv);
         if (!ishidden && !type_contains((jl_value_t*)argtypes, tv)) {
-            JL_PRINTF(JL_STDERR, "Warning: static parameter %s does not occur in signature for %s",
+            JL_PRINTF(JL_STDERR, "Warning: static parameter \"%s\" does not occur in signature for \"%s\"",
                       ((jl_tvar_t*)tv)->name->name, name->name);
             print_func_loc(JL_STDERR, f->linfo);
             JL_PRINTF(JL_STDERR, ".\nThe method will not be callable.\n");


### PR DESCRIPTION
Use quotes around identifier and operators, as well as around
parsed expressions to make understanding messages easier.

This is a change I felt the need for after getting a message like

> ERROR: unrecognized named argument types

which is much clearer as

> ERROR: unrecognized named argument "types"

This can be even more useful when a weird user-typed expression that could not be parsed is printed.

I've reused the convention to use double quotes, which I found in one string. Another string used single quotes around `:`. If you prefer single quotes in some cases, and double quotes in other, I can adapt the commit. But I find such a convention very hard to respect in a large code base, let alone package authors.

I'm not familial at all with Scheme, so I hope I've not broken anything. Most cases are simple, but you should probably have a look at the lines I changed that contain `#\.` and `':` (i.e. line 206 and line 534).
