### PR TITLE
Fix spelling in base/sysimg.jl: 'sprcific' -> 'specific'

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -58,7 +58,7 @@ include("iterator.jl")
 import Core.Undef  # used internally by compiler
 include("inference.jl")
 
-# For OS sprcific stuff in I/O
+# For OS specific stuff in I/O
 include("osutils.jl")
 
 const DL_LOAD_PATH = ByteString[]


### PR DESCRIPTION
I fixed a misspelled word in a comment. 
