### PR TITLE
mapreduce and reduce for AbstractArrays with an initial value do not do pairwise via recursion

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -157,10 +157,6 @@ function mapreduce(f::Callable, op::Function, A::AbstractArray)
     n = length(A)
     n == 0 ? op() : mr_pairwise(f,op,A, 1,n)
 end
-function mapreduce(f::Callable, op::Function, v0, A::AbstractArray)
-    n = length(A)
-    n == 0 ? v0 : op(v0, mr_pairwise(f,op,A, 1,n))
-end
 
 function r_pairwise(op::Function, A::AbstractArray, i1,n)
     if n < 128
@@ -177,10 +173,6 @@ end
 function reduce(op::Function, A::AbstractArray)
     n = length(A)
     n == 0 ? op() : r_pairwise(op,A, 1,n)
-end
-function reduce(op::Function, v0, A::AbstractArray)
-    n = length(A)
-    n == 0 ? v0 : op(v0, r_pairwise(op,A, 1,n))
 end
 
 function any(itr)

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -26,10 +26,22 @@ end
 @test reduce((x,y)->"($x+$y)", [9:11]) == "((9+10)+11)"
 @test reduce(max, [8 6 7 5 3 0 9]) == 9
 @test reduce(+, 1000, [1:5]) == (1000 + 1 + 2 + 3 + 4 + 5)
+rv = reduce( (x,y) -> x * string(y), "0", [1,2,3,4,5])
+@test length(rv) == 6
+@test searchindex(rv, "0") == 1
+@test searchindex(rv, "1") > 1
+@test searchindex(rv, "3") > 1
+@test searchindex(rv, "5") > 1
 
 # mapreduce -- reduce.jl
 @test mapreduce(-, +, [-10 -9 -3]) == ((10 + 9) + 3)
 @test mapreduce((x)->x[1:3], (x,y)->"($x+$y)", ["abcd", "efgh", "01234"]) == "((abc+efg)+012)"
+rv = mapreduce((x)->string(x), (x,y)-> x * y, "0", [1,2,3,4,5])
+@test length(rv) == 6
+@test searchindex(rv, "0") == 1
+@test searchindex(rv, "1") > 1
+@test searchindex(rv, "3") > 1
+@test searchindex(rv, "5") > 1
 
 # filter -- array.jl
 @test isequal(filter(x->(x>1), [0 1 2 3 2 1 0]), [2, 3, 2])


### PR DESCRIPTION
Removed pairwise code called for AbstractArray mapreduce / reduce, with an initial value, as per discussion in #4777
Regular reduce/mapreduce gets called in these cases.
Added tests.

Closes #4777 
