### PR TITLE
support multi-arg push! and unshift!

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1723,3 +1723,12 @@ function map(f::Callable, As::AbstractArray...)
     dest = similar(As[1], typeof(first), shape)
     return map_to!(f, first, dest, As...)
 end
+
+# multi-item push!, unshift! (built on top of type-specific 1-item version)
+# (note: must not cause a dispatch loop when 1-item case is not defined)
+push!(A) = A
+push!(A, a, b) = push!(push!(A, a), b)
+push!(A, a, b, c...) = push!(push!(A, a, b), c...)
+unshift!(A) = A
+unshift!(A, a, b) = unshift!(unshift!(A, b), a)
+unshift!(A, a, b, c...) = unshift!(unshift!(A, c...), a, b)

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -1154,9 +1154,9 @@
 
 "),
 
-("Dequeues","Base","push!","push!(collection, item) -> collection
+("Dequeues","Base","push!","push!(collection, items...) -> collection
 
-   Insert an item at the end of a collection.
+   Insert items at the end of a collection.
 
 "),
 
@@ -1166,9 +1166,9 @@
 
 "),
 
-("Dequeues","Base","unshift!","unshift!(collection, item) -> collection
+("Dequeues","Base","unshift!","unshift!(collection, items...) -> collection
 
-   Insert an item at the beginning of a collection.
+   Insert items at the beginning of a collection.
 
 "),
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -766,17 +766,17 @@ Partially implemented by: ``Array``.
 Dequeues
 --------
 
-.. function:: push!(collection, item) -> collection
+.. function:: push!(collection, items...) -> collection
 
-   Insert an item at the end of a collection.
+   Insert items at the end of a collection.
 
 .. function:: pop!(collection) -> item
 
    Remove the last item in a collection and return it.
 
-.. function:: unshift!(collection, item) -> collection
+.. function:: unshift!(collection, items...) -> collection
 
-   Insert an item at the beginning of a collection.
+   Insert items at the beginning of a collection.
 
 .. function:: shift!(collection) -> item
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -197,14 +197,19 @@ let
 end
 
 ## arrays as dequeues
-l = {1,2,3}
-push!(l,8)
+l = {1}
+push!(l,2,3,8)
 @test l[1]==1 && l[2]==2 && l[3]==3 && l[4]==8
 v = pop!(l)
 @test v == 8
 v = pop!(l)
 @test v == 3
 @test length(l)==2
+unshift!(l,4,7,5)
+@test l[1]==4 && l[2]==7 && l[3]==5 && l[4]==1 && l[5]==2
+v = shift!(l)
+@test v == 4
+@test length(l)==4
 
 # concatenation
 @test isequal([ones(2,2)  2*ones(2,1)], [1. 1 2; 1 1 2])


### PR DESCRIPTION
This patch extends `push!` and `unshift!` to accept multiple arguments: `push!(A, items...)` and `unshift!(A, items...)`, whenever the 1-item versions are defined.  For example:

```
julia> push!([1,2,3], 4,5)
5-element Array{Int64,1}:
 1
 2
 3
 4
 5

julia> unshift!([1,2,3], 4,5)
5-element Array{Int64,1}:
 4
 5
 1
 2
 3
```

Note that the ordering of the arguments is the same as their ordering in the resulting array (so the items are pushed from left to right, but unshifted from right to left).  This seems sensible to me (changing the ordering is a bit surprising), it mirrors `append!` and `prepend!`, and e.g. the Javascript push/unshift functions have the same semantics.

By default, these are implemented in terms of the 1-item versions.  Specific types could, of course, define specialized multi-argument versions, e.g. `push!(A::Array, items...)` could be defined to grow the array by several items at once and avoid overhead.  But this is an optimization that can be done later if it seems important.  The main thing is that this patch does not introduce any performance regressions, it just increases convenience.
