### PR TITLE
Fix logic error in process_exited(s::ProcessChain)

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -518,7 +518,7 @@ process_running(s::ProcessChain) = process_running(s.processes)
 
 process_exited(s::Process) = !process_running(s)
 process_exited(s::Vector{Process}) = all(process_exited,s)
-process_exited(s::ProcessChain) = process_running(s.processes)
+process_exited(s::ProcessChain) = !process_running(s.processes)
 
 process_signaled(s::Process) = (s.termsignal > 0)
 


### PR DESCRIPTION
It looks like `process_running(s::ProcessChain)` and `process_exited(s::ProcessChain)` were returning identical values previously.
