### PR TITLE
Added getindex(t::Associative, keys...)

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -144,6 +144,8 @@ function getindex(t::Associative, key)
     return v
 end
 
+getindex(t::Associative, keys...) = [getindex(t, key) for key in keys]
+
 push!(t::Associative, key, v) = setindex!(t, v, key)
 
 # hashing objects by identity


### PR DESCRIPTION
- convenience function for [getindex(d, key) for key in keys]

Since multidimensional dictionaries seem unlikely, this seems okay to me, but others may reasonably feel that the comprehension syntax is sufficient.

See https://groups.google.com/forum/#!topic/julia-users/5bi3jgJgF8g for the discussion that prompted this.

``` julia
julia> mydict = ["A"=>3, "B"=>5, "C"=>1]
["B"=>5,"C"=>1,"A"=>3]

julia> mydict[["B","C"]...]
2-element Array{Int64,1}:
 5
 1

julia> c = ["B","C"]; mydict[c...]
2-element Array{Int64,1}:
 5
 1
```
