### PR TITLE
fix gcd & lcm sign and optimize gcdx and invmod

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -313,6 +313,9 @@ powermod(x::BigInt, p::Integer, m::BigInt) = powermod(x, BigInt(p), m)
 powermod(x::BigInt, p::Integer, m::Integer) = powermod(x, BigInt(p), BigInt(m))
 
 function gcdx(a::BigInt, b::BigInt)
+    if b == 0 # shortcut this to ensure consistent results with gcdx(a,b)
+        return a < 0 ? (-a,-one(BigInt),zero(BigInt)) : (a,one(BigInt),zero(BigInt))
+    end
     g = BigInt()
     s = BigInt()
     t = BigInt()

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -6,7 +6,7 @@ import Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), ($),
              binomial, cmp, convert, div, divrem, factorial, fld, gcd, gcdx, lcm, mod,
              ndigits, promote_rule, rem, show, isqrt, string, isprime, powermod,
              widemul, sum, trailing_zeros, trailing_ones, count_ones, base, parseint,
-             serialize, deserialize, bin, oct, dec, hex, isequal
+             serialize, deserialize, bin, oct, dec, hex, isequal, invmod
 
 type BigInt <: Integer
     alloc::Cint
@@ -152,7 +152,7 @@ deserialize(s, ::Type{BigInt}) = parseint(BigInt, deserialize(s), 62)
 # Binary ops
 for (fJ, fC) in ((:+, :add), (:-,:sub), (:*, :mul),
                  (:fld, :fdiv_q), (:div, :tdiv_q), (:mod, :fdiv_r), (:rem, :tdiv_r),
-                 (:gcd, :gcd), (:lcm, :lcm),
+                 (:gcd, :gcd), (:lcm, :lcm), (:invmod, :invert),
                  (:&, :and), (:|, :ior), (:$, :xor))
     @eval begin
         function ($fJ)(x::BigInt, y::BigInt)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -40,7 +40,9 @@ function gcd{T<:Integer}(a::T, b::T)
     end
     abs(a)
 end
-lcm{T<:Integer}(a::T, b::T) = abs(a * div(b, gcd(b,a)))
+
+# explicit a==0 test is to handle case of lcm(0,0) correctly
+lcm{T<:Integer}(a::T, b::T) = a == 0 ? a : abs(a * div(b, gcd(b,a)))
 
 gcd(a::Integer) = a
 lcm(a::Integer) = a

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -33,16 +33,14 @@ abs(x::Signed) = flipsign(x,x)
 ## number-theoretic functions ##
 
 function gcd{T<:Integer}(a::T, b::T)
-    neg = a < 0
     while b != 0
         t = b
         b = rem(a, b)
         a = t
     end
-    g = abs(a)
-    neg ? -g : g
+    abs(a)
 end
-lcm{T<:Integer}(a::T, b::T) = a * div(b, gcd(b,a))
+lcm{T<:Integer}(a::T, b::T) = abs(a * div(b, gcd(b,a)))
 
 gcd(a::Integer) = a
 lcm(a::Integer) = a
@@ -61,15 +59,14 @@ function gcdx{T<:Integer}(a::T, b::T)
         s0, s1 = s1, s0 - q*s1
         t0, t1 = t1, t0 - q*t1
     end
-    (a, s0, t0)
+    a < 0 ? (-a, -s0, -t0) : (a, s0, t0)
 end
 gcdx(a::Integer, b::Integer) = gcdx(promote(a,b)...)
 
 # multiplicative inverse of n mod m, error if none
 function invmod(n, m)
     g, x, y = gcdx(n, m)
-    g == 1 ? (x < 0 ? m + x : x) : 
-    g == -1 ? (x > 0 ? abs(m) - x : -x) : error("no inverse exists")
+    g == 1 ? (x < 0 ? abs(m) + x : x) : error("no inverse exists")
 end
 
 # ^ for any x supporting *

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -52,21 +52,24 @@ gcd(a::Integer, b::Integer...) = gcd(a, gcd(b...))
 lcm(a::Integer, b::Integer...) = lcm(a, lcm(b...))
 
 # return (gcd(a,b),x,y) such that ax+by == gcd(a,b)
-function gcdx(a, b)
-    if b == 0
-        (a, 1, 0)
-    else
-        m = rem(a, b)
-        k = div((a-m), b)
-        (g, x, y) = gcdx(b, m)
-        (g, y, x-k*y)
+function gcdx{T<:Integer}(a::T, b::T)
+    s0, s1 = one(T), zero(T)
+    t0, t1 = s1, s0
+    while b != 0
+        q = div(a, b)
+        a, b = b, rem(a, b)
+        s0, s1 = s1, s0 - q*s1
+        t0, t1 = t1, t0 - q*t1
     end
+    (a, s0, t0)
 end
+gcdx(a::Integer, b::Integer) = gcdx(promote(a,b)...)
 
-# multiplicative inverse of x mod m, error if none
+# multiplicative inverse of n mod m, error if none
 function invmod(n, m)
     g, x, y = gcdx(n, m)
-    g != 1 ? error("no inverse exists") : (x < 0 ? m + x : x)
+    g == 1 ? (x < 0 ? m + x : x) : 
+    g == -1 ? (x > 0 ? abs(m) - x : -x) : error("no inverse exists")
 end
 
 # ^ for any x supporting *

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -6,7 +6,7 @@ immutable Rational{T<:Integer} <: Real
         if num == 0 && den == 0
             error("invalid rational: 0//0")
         end
-        g = gcd(den, num)
+        g = den < 0 ? -gcd(den,num) : gcd(den, num)
         new(div(num, g), div(den, g))
     end
 end

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -3885,13 +3885,13 @@ popdisplay(d::Display)
 
 ("Mathematical Functions","Base","gcd","gcd(x, y)
 
-   Greatest common (positive) divisor
+   Greatest common (positive) divisor (or zero if x and y are both zero).
 
 "),
 
 ("Mathematical Functions","Base","lcm","lcm(x, y)
 
-   Least common (positive) multiple
+   Least common (non-negative) multiple.
 
 "),
 

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -3885,19 +3885,19 @@ popdisplay(d::Display)
 
 ("Mathematical Functions","Base","gcd","gcd(x, y)
 
-   Greatest common divisor
+   Greatest common (positive) divisor
 
 "),
 
 ("Mathematical Functions","Base","lcm","lcm(x, y)
 
-   Least common multiple
+   Least common (positive) multiple
 
 "),
 
 ("Mathematical Functions","Base","gcdx","gcdx(x, y)
 
-   Greatest common divisor, also returning integer coefficients \"u\"
+   Greatest common (positive) divisor, also returning integer coefficients \"u\"
    and \"v\" that solve \"ux+vy == gcd(x,y)\"
 
 "),

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -2632,11 +2632,11 @@ Mathematical Functions
 
 .. function:: gcd(x,y)
 
-   Greatest common (positive) divisor.
+   Greatest common (positive) divisor (or zero if x and y are both zero).
 
 .. function:: lcm(x,y)
 
-   Least common (positive) multiple.
+   Least common (non-negative) multiple.
 
 .. function:: gcdx(x,y)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -2632,15 +2632,15 @@ Mathematical Functions
 
 .. function:: gcd(x,y)
 
-   Greatest common divisor
+   Greatest common (positive) divisor.
 
 .. function:: lcm(x,y)
 
-   Least common multiple
+   Least common (positive) multiple.
 
 .. function:: gcdx(x,y)
 
-   Greatest common divisor, also returning integer coefficients ``u`` and ``v`` that solve ``ux+vy == gcd(x,y)``
+   Greatest common (positive) divisor, also returning integer coefficients ``u`` and ``v`` that solve ``ux+vy == gcd(x,y)``
 
 .. function:: ispow2(n)
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1511,3 +1511,16 @@ end
 # overflow in rational comparison
 @test 3//2 < typemax(Int)
 @test 3//2 <= typemax(Int)
+
+# check gcd and related functions against GMP
+for i = -20:20, j = -20:20
+    local d = gcd(i,j)
+    @test d >= 0
+    @test lcm(i,j) >= 0
+    local ib = big(i)
+    local jb = big(j)
+    @test d == gcd(ib,jb)
+    @test lcm(i,j) == lcm(ib,jb)
+    @test gcdx(i,j) == gcdx(ib,jb)
+    @test d != 1 || invmod(i,j) == invmod(ib,jb)
+end


### PR DESCRIPTION
The attached patch fixes several bugs (including #4810):
- gcd, lcm, and gcdx, returned inconsistent signs between BigInt and other integer types.  Now they always return a positive gcd and lcm.
- invmod was broken for negative arguments, since it was incorrectly interpreting a gcd of `-1` as meaning that the inverse did not exist.
- `Rational` construction was broken for BigInt because of the gcd sign inconsistency.
- `gcdx` was not type-stable (it promoted a result to `Int` in one case).

I also rewrote `gcdx` non-recursively to make it about 20x faster on my machine, and use the GMP `invmod` function directly for `BigInt`.
