### PR TITLE
add BigInt prevpow2/nextpow2 (fix #4814)

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -6,7 +6,8 @@ import Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), ($),
              binomial, cmp, convert, div, divrem, factorial, fld, gcd, gcdx, lcm, mod,
              ndigits, promote_rule, rem, show, isqrt, string, isprime, powermod,
              widemul, sum, trailing_zeros, trailing_ones, count_ones, base, parseint,
-             serialize, deserialize, bin, oct, dec, hex, isequal, invmod
+             serialize, deserialize, bin, oct, dec, hex, isequal, invmod,
+             prevpow2, nextpow2
 
 type BigInt <: Integer
     alloc::Cint
@@ -413,5 +414,8 @@ widemul(x::BigInt, y::BigInt)   = x*y
 widemul(x::Int128, y::Uint128)  = BigInt(x)*BigInt(y)
 widemul(x::Uint128, y::Int128)  = BigInt(x)*BigInt(y)
 widemul{T<:Integer}(x::T, y::T) = BigInt(x)*BigInt(y)
+
+prevpow2(x::BigInt) = x < 0 ? -prevpow2(-x) : (x <= 2 ? x : one(BigInt) << (ndigits(x, 2)-1))
+nextpow2(x::BigInt) = x < 0 ? -nextpow2(-x) : (x <= 2 ? x : one(BigInt) << ndigits(x-1, 2))
 
 end # module

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1551,3 +1551,15 @@ end
 # negative power domain error
 @test_throws powermod(1,-2,1)
 @test_throws powermod(big(1),-2,1)
+
+# prevpow2/nextpow2:
+@test nextpow2(0) == prevpow2(0) == 0
+for i = -2:2
+    @test nextpow2(i) == prevpow2(i) == i
+end
+@test nextpow2(56789) == -nextpow2(-56789) == 65536
+@test prevpow2(56789) == -prevpow2(-56789) == 32768
+for i = -100:100
+    @test nextpow2(i) == nextpow2(big(i))
+    @test prevpow2(i) == prevpow2(big(i))
+end


### PR DESCRIPTION
Implemented in terms of `ndigits(2,x)`, which is documented to give the most-significant-bit in GMP.  Fixes #4814.

Also adds some test cases.  Note that I implemented the current semantics, but these may be altered by #4819.
