### PR TITLE
Changed the printing of MethodError

### DIFF
--- a/base/repl.jl
+++ b/base/repl.jl
@@ -99,13 +99,20 @@ showerror(io::IO, e::InterruptException) = print(io, "interrupt")
 
 function showerror(io::IO, e::MethodError)
     name = e.f.env.name
-    if is(e.f,convert) && length(e.args)==2
-        print(io, "no method $(name)(Type{$(e.args[1])},$(typeof(e.args[2])))")
-    elseif isa(e.f, DataType)
-        print(io, "no method $(e.f)$(typeof(e.args))")
+    if isa(e.f, DataType)
+        print(io, "no method $(e.f)(")
     else
-        print(io, "no method $(name)$(typeof(e.args))")
+        print(io, "no method $(name)(")
     end
+    for (i, arg) in enumerate(e.args)
+        if typeof(arg) == DataType
+            print(io, "Type{$(arg)}")
+        else
+            print(io, typeof(arg),)
+        end
+        i == length(e.args) || print(io,", ")
+    end
+    print(io, ")")
     if isdefined(Base,name)
         f = eval(Base,name)
         if f !== e.f && isgeneric(f) && applicable(f,e.args...)

--- a/base/repl.jl
+++ b/base/repl.jl
@@ -108,7 +108,7 @@ function showerror(io::IO, e::MethodError)
         if typeof(arg) == DataType
             print(io, "Type{$(arg)}")
         else
-            print(io, typeof(arg),)
+            print(io, typeof(arg))
         end
         i == length(e.args) || print(io,", ")
     end


### PR DESCRIPTION
MethodError printed "no method f(DataType)" for if it couldn't find a
method for the concrete datatype, eaven tough there were methods
available for other datatypes. This pathch changes the printing from
DataType to Type{MyType} instead.

fix #4825
