### PR TITLE
fixed typo in queens example

### DIFF
--- a/examples/queens.jl
+++ b/examples/queens.jl
@@ -1,4 +1,4 @@
-addqueen(queens::Array{Vector{Int}}, queen::Vector{Int}) = push(copy(queens), queen)
+addqueen(queens::Array{Vector{Int}}, queen::Vector{Int}) = push!(copy(queens), queen)
 
 hitsany(queen::Vector{Int}, queens::Array{Vector{Int}}) = any(map((x) -> hits(queen, x), queens))
 hits(a::Array{Int}, b::Array{Int}) = any(a .== b) || abs(a-b)[1] == abs(a-b)[2]


### PR DESCRIPTION
This example didn't run because there is no `push`, so I'm assuming it should be `push!` now?

Did `push` get deprecated and removed somewhere along the way?
