### PR TITLE
Enable reporting to status.julialang.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ notifications:
         on_failure: always
     webhooks:
         urls:
+          - http://status.julialang.org/put/travis
           - http://criid.ee.washington.edu:8000/travis-hook
           - http://julia.mit.edu:8000/travis-hook
-        on_failure: never
 before_install:
     - BUILDOPTS="LLVM_CONFIG=llvm-config-3.3 VERBOSE=1 USE_BLAS64=0"; for lib in LLVM ZLIB SUITESPARSE ARPACK BLAS FFTW LAPACK GMP MPFR PCRE LIBUNWIND READLINE GRISU OPENLIBM RMATH; do export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1"; done
     - sudo apt-get update -qq -y

--- a/test/perf/Makefile
+++ b/test/perf/Makefile
@@ -20,6 +20,7 @@ codespeed:
 #	@$(call spawn,$(JULIA_EXECUTABLE)) blas/perf.jl codespeed
 #	@$(call spawn,$(JULIA_EXECUTABLE)) lapack/perf.jl codespeed
 #	@$(call spawn,$(JULIA_EXECUTABLE)) sort/perf.jl codespeed
+	@$(call spawn,$(JULIA_EXECUTABLE)) report.jl
 
 
 clean:

--- a/test/perf/report.jl
+++ b/test/perf/report.jl
@@ -1,0 +1,7 @@
+using HTTPClient.HTTPC
+
+env_name = chomp(readall(`hostname`))
+commit = Base.BUILD_INFO.commit
+flavor = ENV["JULIA_FLAVOR"]
+json = "{\"env\": \"$env_name\", \"blas\":\"$flavor\", \"commit\":\"$commit\"}"
+post("http://status.julialang.org/put/codespeed", json )


### PR DESCRIPTION
This will cause travis to automatically report to status.julialang.org (still a WIP, but getting real data on there instead of fake data is a step in the right direction!)
