### PR TITLE
Improved error message for accessing local variables before they are assigned

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1805,9 +1805,7 @@ static Value *emit_checked_var(Value *bp, jl_sym_t *name, jl_codectx_t *ctx)
     BasicBlock *ifok = BasicBlock::Create(getGlobalContext(), "ok");
     builder.CreateCondBr(ok, ifok, err);
     builder.SetInsertPoint(err);
-    std::string msg;
-    msg += std::string(name->name);
-    msg += " not defined";
+    std::string msg = "local identifier \"" + std::string(name->name) + "\" referenced before assignment";
     just_emit_error(msg, ctx);
     builder.CreateBr(ifok);
     ctx->f->getBasicBlockList().push_back(ifok);


### PR DESCRIPTION
If someone tries to access a global variable (like a function object) in a function and later in the function assignes a value to an identifier with the same name, they might be confused when they get the error "variable not defined", when it was in fact defined twice. This commit changes the message to a more descriptive "local identifier "variable" referenced before assignment"

This is a response to #4834

I didn't quite understand setting where this error is raised, so I hope that someone will see if the same function is used for other purposes, where this change of wording might be misleading.
