### PR TITLE
Added Dict constructor from tuple array

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -303,6 +303,8 @@ Dict{K,V}(ks::(K...), vs::(V...)) = Dict{K  ,V  }(ks, vs)
 Dict{K  }(ks::(K...), vs::Tuple ) = Dict{K  ,Any}(ks, vs)
 Dict{V  }(ks::Tuple , vs::(V...)) = Dict{Any,V  }(ks, vs)
 
+Dict{K,V}(kv::Array{(K,V)}) = Dict{K,V}(zip(kv...)...)
+
 similar{K,V}(d::Dict{K,V}) = (K=>V)[]
 
 function serialize(s, t::Dict)


### PR DESCRIPTION
Right now, we can get an array of tuples from a Dictionary via `collect`, but there's no constructor from such an array.  This pull request remedies that.

``` julia
julia> a = [("A",1),("B",2),("C",4)]
3-element Array{(ASCIIString,Int64),1}:
 ("A",1)
 ("B",2)
 ("C",4)

julia> Dict(a)
["B"=>2,"C"=>4,"A"=>1]

julia> typeof(ans)
Dict{ASCIIString,Int64} (constructor with 2 methods)
```
