### PR TITLE
WIP: Base.checked_{add,sub,mul} and overflow-safe parseint

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -573,3 +573,31 @@ else
 
     mod(x::Int128, y::Int128) = box(Int128,smod_int(unbox(Int128,x),unbox(Int128,y)))
 end
+
+## checked +, - and *
+
+for T in (Int8,Int16,Int32,Int64,Int128)
+    @eval begin
+        checked_add(x::$T, y::$T) = box($T,checked_sadd(unbox($T,x),unbox($T,y)))
+        checked_sub(x::$T, y::$T) = box($T,checked_ssub(unbox($T,x),unbox($T,y)))
+        checked_mul(x::$T, y::$T) = box($T,checked_smul(unbox($T,x),unbox($T,y)))
+    end
+end
+for T in (Uint8,Uint16,Uint32,Uint64,Uint128)
+    @eval begin
+        checked_add(x::$T, y::$T) = box($T,checked_uadd(unbox($T,x),unbox($T,y)))
+        checked_sub(x::$T, y::$T) = box($T,checked_usub(unbox($T,x),unbox($T,y)))
+        checked_mul(x::$T, y::$T) = box($T,checked_umul(unbox($T,x),unbox($T,y)))
+    end
+end
+
+# checked mul is broken for 8-bit types (LLVM bug?)
+
+for T in (Int8,Uint8)
+    @eval function checked_mul(x::$T, y::$T)
+        xy = x*y
+        xy8 = convert($T,xy)
+        xy == xy8 || throw(OverflowError())
+        return xy8
+    end
+end

--- a/base/string.jl
+++ b/base/string.jl
@@ -1437,9 +1437,9 @@ function parseint{T<:Integer}(::Type{T}, s::String, base::Integer)
     base = convert(T,base)
     n::T = 0
     while true
-        d = '0' <= c <= '9' ? c-'0' :
-            'A' <= c <= 'Z' ? c-'A'+10 :
-            'a' <= c <= 'z' ? c-'a'+10 : typemax(Int)
+        d::T = '0' <= c <= '9' ? c-'0' :
+               'A' <= c <= 'Z' ? c-'A'+10 :
+               'a' <= c <= 'z' ? c-'a'+10 : typemax(T)
         if d >= base
             isspace(c) || error("invalid digit $(repr(c)): $(repr(s))")
             while !done(s,i)
@@ -1447,14 +1447,12 @@ function parseint{T<:Integer}(::Type{T}, s::String, base::Integer)
                 isspace(c) || error("extra characters after whitespace: $(repr(s))")
             end
         else
-            # TODO: overflow detection?
-            n = n*base + d
+            (T <: Signed) && (d *= sgn)
+            n = checked_mul(n,base)
+            n = checked_add(n,d)
         end
         done(s,i) && break
         c, i = next(s,i)
-    end
-    if T <: Signed
-        n = flipsign(n,sgn)
     end
     return n
 end

--- a/base/string.jl
+++ b/base/string.jl
@@ -1418,35 +1418,21 @@ strip(s::String, chars::Chars) = lstrip(rstrip(s, chars), chars)
 ## string to integer functions ##
 
 function parseint{T<:Integer}(::Type{T}, s::String, base::Integer)
-    if !(2 <= base <= 36); error("invalid base: ",base); end
+    2 <= base <= 36 || error("invalid base: $base")
     i = start(s)
     while true
-        if done(s,i)
-            throw(ArgumentError(string(
-                "premature end of integer (in ", repr(s) ,")"
-            )))
-        end
-        c,i = next(s,i)
-        if !isspace(c)
-            break
-        end
+        done(s,i) && error("premature end of integer: $(repr(s))")
+        c, i = next(s,i)
+        isspace(c) || break
     end
     sgn = 1
     if T <: Signed && c == '-'
         sgn = -1
-        if done(s,i)
-            throw(ArgumentError(string(
-                "premature end of integer (in ", repr(s), ")"
-            )))
-        end
-        c,i = next(s,i)
+        done(s,i) && error("premature end of integer: $(repr(s))")
+        c, i = next(s,i)
     elseif c == '+'
-        if done(s,i)
-            throw(ArgumentError(string(
-                "premature end of integer (in ", repr(s), ")"
-            )))
-        end
-        c,i = next(s,i)
+        done(s,i) && error("premature end of integer: $(repr(s))")
+        c, i = next(s,i)
     end
     base = convert(T,base)
     n::T = 0
@@ -1455,27 +1441,17 @@ function parseint{T<:Integer}(::Type{T}, s::String, base::Integer)
             'A' <= c <= 'Z' ? c-'A'+10 :
             'a' <= c <= 'z' ? c-'a'+10 : typemax(Int)
         if d >= base
-            if !isspace(c)
-                throw(ArgumentError(string(
-                    repr(c)," is not a valid digit (in ", repr(s), ")"
-                )))
-            end
+            isspace(c) || error("invalid digit $(repr(c)): $(repr(s))")
             while !done(s,i)
-                c,i = next(s,i)
-                if !isspace(c)
-                    throw(ArgumentError(string(
-                        "extra characters after whitespace (in ", repr(s), ")"
-                    )))
-                end
+                c, i = next(s,i)
+                isspace(c) || error("extra characters after whitespace: $(repr(s))")
             end
         else
             # TODO: overflow detection?
             n = n*base + d
         end
-        if done(s,i)
-            break
-        end
-        c,i = next(s,i)
+        done(s,i) && break
+        c, i = next(s,i)
     end
     if T <: Signed
         n = flipsign(n,sgn)

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -218,6 +218,13 @@ parsehex(s) = parseint(s,16)
 @test_throws parseint("2x")
 @test_throws parseint("-")
 
+for T in (Int8,Uint8,Int16,Uint16,Int32,Uint32,Int64,Uint64,Int128,Uint128)
+    @test parseint(T,string(typemin(T))) == typemin(T)
+    @test parseint(T,string(typemax(T))) == typemax(T)
+    @test_throws parseint(T,string(big(typemin(T))-1))
+    @test_throws parseint(T,string(big(typemax(T))+1))
+end
+
 # string manipulation
 @test strip("\t  hi   \n") == "hi"
 

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -218,6 +218,15 @@ parsehex(s) = parseint(s,16)
 @test_throws parseint("2x")
 @test_throws parseint("-")
 
+@test parseint("1234") == 1234
+@test parseint("0x1234") == 0x1234
+@test parseint("0o1234") == 0o1234
+@test parseint("0b1011") == 0b1011
+@test parseint("-1234") == -1234
+@test parseint("-0x1234") == -int(0x1234)
+@test parseint("-0o1234") == -int(0o1234)
+@test parseint("-0b1011") == -int(0b1011)
+
 for T in (Int8,Uint8,Int16,Uint16,Int32,Uint32,Int64,Uint64,Int128,Uint128)
     @test parseint(T,string(typemin(T))) == typemin(T)
     @test parseint(T,string(typemax(T))) == typemax(T)


### PR DESCRIPTION
We've had the intrinsics for checked arithmetic for a rather long time, we just haven't used it anywhere. This defines checked `+`, `-` and `*` the same way that we define `+`, `-` and `*` and uses it in parseint to prevent overflow when attempting to parse a too-large value.

This is still a work-in-progress because it has some issues:
- [x] it doesn't work for `typemin(Int)`
- [x] it doesn't work for "small" integer types like `Int8` or `Uint8`
- [x] it needs tests
