### PR TITLE
Added eltype for tuples when members all have the same type

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -20,6 +20,10 @@ indexed_next(t::Tuple, i::Int, state) = (t[i], i+1)
 indexed_next(a::Array, i::Int, state) = (a[i], i+1)
 indexed_next(I, i, state) = done(I,state) ? throw(BoundsError()) : next(I, state)
 
+# eltype
+
+eltype{T}(x::(T...)) = T
+
 ## mapping ##
 
 ntuple(n::Integer, f::Function) = ntuple(f, n) # TODO: deprecate this?


### PR DESCRIPTION
Right now, calling eltype on a tuple always returns `Any`.  This patch allows `eltype` to be more specific if all of the tuple members have the same type:

``` julia
julia> eltype(("A","B","C"))
ASCIIString (constructor with 1 method)

julia> eltype((1,2,3))
Int64

julia> eltype((1,2,'c'))
Any
```
