### PR TITLE
readcsv fix col count when no newline. fixes #4890

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -187,7 +187,10 @@ function dlm_dims{T,D}(dbuff::T, eol::D, dlm::D)
     catch ex
         error("at row $nrows, column $col : $ex)")
     end
-    (col > 0) && (nrows += 1) 
+    if col > 0 
+        nrows += 1
+        ncols = max(ncols, col+1)
+    end
     ncols = max(ncols, col, 1)
     nrows = max(nrows, 1)
     return (nrows, ncols)

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -4,3 +4,11 @@ dlm_data = readdlm(joinpath("perf", "kernel", "imdb-1.tsv"), '\t')
 @test dlm_data[12345,2] == "Gladiator"
 @test dlm_data[31383,3] == 2005
 @test dlm_data[1,1] == "McClure, Marc (I)"
+
+@test size(readcsv(IOBuffer("1,2,3,4"))) == (1,4)
+@test size(readcsv(IOBuffer("1,2,3,"))) == (1,4)
+@test size(readcsv(IOBuffer("1,2,3,4\n"))) == (1,4)
+@test size(readcsv(IOBuffer("1,2,3,\n"))) == (1,4)
+@test size(readcsv(IOBuffer("1,2,3,4\n1,2,3,4"))) == (2,4)
+@test size(readcsv(IOBuffer("1,2,3,4\n1,2,3,"))) == (2,4)
+@test size(readcsv(IOBuffer("1,2,3,4\n1,2,3"))) == (2,4)


### PR DESCRIPTION
Increment column count for last row if there is no newline at end of file.
