### PR TITLE
WIP: proposed design+implementation of serializing objects with cycles

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -10,6 +10,9 @@ type IOBuffer <: IO
     size::Int
     maxsize::Int # pre-allocated, fixed array size
     ptr::Int # read (and maybe write) pointer
+
+    serialization_table::ObjectIdDict
+
     IOBuffer(data::Vector{Uint8},readable::Bool,writable::Bool,seekable::Bool,append::Bool,maxsize::Int) = 
         new(data,readable,writable,seekable,append,length(data),maxsize,1)
 end
@@ -186,6 +189,7 @@ function takebuf_array(io::IOBuffer)
         io.ptr = 1
         io.size = 0
     end
+    isdefined(io,:serialization_table) && empty!(io.serialization_table)
     data
 end
 takebuf_string(io::IOBuffer) = bytestring(takebuf_array(io))

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -523,7 +523,7 @@ function serialize(s, rr::RemoteRef)
 end
 
 function deserialize(s, t::Type{RemoteRef})
-    rr = invoke(deserialize, (Any, DataType), s, t)
+    rr = invoke(deserialize, (Any, DataType, Any), s, t, -1)
     where = rr.where
     if where == myid()
         add_client(rr2id(rr), myid())

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -5,6 +5,7 @@ abstract LongSymbol
 abstract LongTuple
 abstract LongExpr
 abstract UndefRefTag
+abstract BackrefTag
 
 const ser_version = 1 # do not make changes without bumping the version #!
 const ser_tag = ObjectIdDict()
@@ -17,7 +18,7 @@ let i = 2
              Tuple, Array, Expr, LongSymbol, LongTuple, LongExpr,
              LineNumberNode, SymbolNode, LabelNode, GotoNode,
              QuoteNode, TopNode, TypeVar, Box, LambdaStaticData,
-             Module, UndefRefTag, Task, :reserved4,
+             Module, UndefRefTag, Task, BackrefTag,
              :reserved5, :reserved6, :reserved7, :reserved8,
              :reserved9, :reserved10, :reserved11, :reserved12,
              
@@ -53,6 +54,23 @@ function write_as_tag(s, x)
         write(s, uint8(0))
     end
     write(s, uint8(t))
+end
+
+# cycle handling
+serialize_cycle(io, x) = false
+
+function serialize_cycle(io::IOBuffer, x)
+    if !isdefined(io,:serialization_table)
+        io.serialization_table = ObjectIdDict()
+    end
+    offs = get(io.serialization_table, x, -1)
+    if offs != -1
+        writetag(io, BackrefTag)
+        write(io, int(offs))
+        return true
+    end
+    io.serialization_table[x] = position(io)
+    return false
 end
 
 serialize(s, x::Bool) = write_as_tag(s, x)
@@ -112,6 +130,7 @@ function serialize_array_data(s, a)
 end
 
 function serialize(s, a::Array)
+    serialize_cycle(s, a) && return
     writetag(s, Array)
     elty = eltype(a)
     serialize(s, elty)
@@ -130,6 +149,7 @@ function serialize(s, a::Array)
 end
 
 function serialize{T,N,A<:Array}(s, a::SubArray{T,N,A})
+    serialize_cycle(s, a) && return
     if !isbits(T) || stride(a,1)!=1
         return serialize(s, copy(a))
     end
@@ -140,6 +160,7 @@ function serialize{T,N,A<:Array}(s, a::SubArray{T,N,A})
 end
 
 function serialize(s, e::Expr)
+    serialize_cycle(s, e) && return
     l = length(e.args)
     if l <= 255
         writetag(s, Expr)
@@ -161,6 +182,7 @@ function serialize(s, m::Module)
 end
 
 function serialize(s, f::Function)
+    serialize_cycle(s, f) && return
     writetag(s, Function)
     name = false
     if isgeneric(f)
@@ -216,6 +238,7 @@ function lambda_number(l::LambdaStaticData)
 end
 
 function serialize(s, linfo::LambdaStaticData)
+    serialize_cycle(s, linfo) && return
     writetag(s, LambdaStaticData)
     serialize(s, lambda_number(linfo))
     serialize(s, uncompressed_ast(linfo))
@@ -235,6 +258,7 @@ function serialize(s, linfo::LambdaStaticData)
 end
 
 function serialize(s, t::Task)
+    serialize_cycle(s, t) && return
     if istaskstarted(t) && !t.done
         error("cannot serialize a running Task")
     end
@@ -284,10 +308,14 @@ function serialize(s, x)
         return write_as_tag(s, x)
     end
     t = typeof(x)
-    serialize_type(s, t)
     if length(t.names)==0 && t.size>0
+        serialize_type(s, t)
         write(s, x)
     else
+        if !isimmutable(x)
+            serialize_cycle(s, x) && return
+        end
+        serialize_type(s, t)
         serialize(s, length(t.names))
         for n in t.names
             if isdefined(x, n)
@@ -301,11 +329,32 @@ end
 
 ## deserializing values ##
 
+deserialization_table = nothing
+
 function deserialize(s)
-    handle_deserialize(s, int32(read(s, Uint8)))
+    global deserialization_table
+    top = false
+    if deserialization_table === nothing
+        deserialization_table = ObjectIdDict()
+        top = true
+    end
+
+    obj = handle_deserialize(s, int32(read(s, Uint8)))
+
+    if top
+        deserialization_table = nothing
+    end
+    obj
 end
 
+function deserialize_cycle(pos, x)
+    deserialization_table[pos] = x
+end
+
+deserialize(s, tag, pos) = deserialize(s, tag)
+
 function handle_deserialize(s, b)
+    last_obj_pos = position(s)-1
     if b == 0
         return deser_tag[int32(read(s, Uint8))]
     end
@@ -318,8 +367,11 @@ function handle_deserialize(s, b)
     elseif is(tag,LongTuple)
         len = read(s, Int32)
         return deserialize_tuple(s, len)
+    elseif is(tag,BackrefTag)
+        pos = read(s, Int)
+        return deserialization_table[pos]
     end
-    return deserialize(s, tag)
+    return deserialize(s, tag, last_obj_pos)
 end
 
 deserialize_tuple(s, len) = ntuple(len, i->deserialize(s))
@@ -386,7 +438,7 @@ function deserialize(s, ::Type{LambdaStaticData})
     end
 end
 
-function deserialize(s, ::Type{Array})
+function deserialize(s, ::Type{Array}, pos)
     elty = deserialize(s)
     dims = deserialize(s)::Dims
     if isbits(elty)
@@ -409,6 +461,7 @@ function deserialize(s, ::Type{Array})
         end
     end
     A = Array(elty, dims)
+    deserialize_cycle(pos, A)
     for i = 1:length(A)
         tag = int32(read(s, Uint8))
         if tag==0 || !is(deser_tag[tag], UndefRefTag)
@@ -474,7 +527,7 @@ function deserialize(s, ::Type{Task})
 end
 
 # default DataType deserializer
-function deserialize(s, t::DataType)
+function deserialize(s, t::DataType, pos)
     if length(t.names)==0 && t.size>0
         # bits type
         return read(s, t)
@@ -502,6 +555,7 @@ function deserialize(s, t::DataType)
         end
     else
         x = ccall(:jl_new_struct_uninit, Any, (Any,), t)
+        deserialize_cycle(pos, x)
         for n in t.names
             tag = int32(read(s, Uint8))
             if tag==0 || !is(deser_tag[tag], UndefRefTag)

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -333,11 +333,7 @@ deserialization_table = nothing
 
 function deserialize(s)
     global deserialization_table
-    top = false
-    if deserialization_table === nothing
-        deserialization_table = ObjectIdDict()
-        top = true
-    end
+    top = (deserialization_table === nothing)
 
     obj = handle_deserialize(s, int32(read(s, Uint8)))
 
@@ -348,10 +344,19 @@ function deserialize(s)
 end
 
 function deserialize_cycle(pos, x)
+    if pos < 0
+        return
+    end
+    global deserialization_table
+    if deserialization_table === nothing
+        deserialization_table = ObjectIdDict()
+    end
     deserialization_table[pos] = x
 end
 
-deserialize(s, tag, pos) = deserialize(s, tag)
+# deserialize_ is an internal function to dispatch on the tag
+# describing the serialized representation. the number of
+# representations is fixed, so deserialize_ does not get extended.
 
 function handle_deserialize(s, b)
     last_obj_pos = position(s)-1
@@ -371,15 +376,15 @@ function handle_deserialize(s, b)
         pos = read(s, Int)
         return deserialization_table[pos]
     end
-    return deserialize(s, tag, last_obj_pos)
+    return deserialize_(s, tag, last_obj_pos)
 end
 
 deserialize_tuple(s, len) = ntuple(len, i->deserialize(s))
 
-deserialize(s, ::Type{Symbol}) = symbol(read(s, Uint8, int32(read(s, Uint8))))
-deserialize(s, ::Type{LongSymbol}) = symbol(read(s, Uint8, read(s, Int32)))
+deserialize_(s, ::Type{Symbol}, p) = symbol(read(s, Uint8, int32(read(s, Uint8))))
+deserialize_(s, ::Type{LongSymbol}, p) = symbol(read(s, Uint8, read(s, Int32)))
 
-function deserialize(s, ::Type{Module})
+function deserialize_(s, ::Type{Module}, p)
     path = deserialize(s)
     m = Main
     for mname in path
@@ -390,7 +395,7 @@ end
 
 const known_lambda_data = Dict()
 
-function deserialize(s, ::Type{Function})
+function deserialize_(s, ::Type{Function}, p)
     b = read(s, Uint8)
     if b==0
         name = deserialize(s)::Symbol
@@ -415,7 +420,7 @@ function deserialize(s, ::Type{Function})
           C_NULL, env, linfo)::Function
 end
 
-function deserialize(s, ::Type{LambdaStaticData})
+function deserialize_(s, ::Type{LambdaStaticData}, p)
     lnumber = deserialize(s)
     ast = deserialize(s)
     roots = deserialize(s)
@@ -438,7 +443,7 @@ function deserialize(s, ::Type{LambdaStaticData})
     end
 end
 
-function deserialize(s, ::Type{Array}, pos)
+function deserialize_(s, ::Type{Array}, pos)
     elty = deserialize(s)
     dims = deserialize(s)::Dims
     if isbits(elty)
@@ -471,8 +476,8 @@ function deserialize(s, ::Type{Array}, pos)
     return A
 end
 
-deserialize(s, ::Type{Expr})     = deserialize_expr(s, int32(read(s, Uint8)))
-deserialize(s, ::Type{LongExpr}) = deserialize_expr(s, read(s, Int32))
+deserialize_(s, ::Type{Expr}, p)     = deserialize_expr(s, int32(read(s, Uint8)))
+deserialize_(s, ::Type{LongExpr}, p) = deserialize_expr(s, read(s, Int32))
 
 function deserialize_expr(s, len)
     hd = deserialize(s)::Symbol
@@ -483,7 +488,7 @@ function deserialize_expr(s, len)
     e
 end
 
-function deserialize(s, ::Type{TypeVar})
+function deserialize_(s, ::Type{TypeVar}, p)
     nf_expected = deserialize(s)
     name = deserialize(s)
     lb = deserialize(s)
@@ -491,13 +496,13 @@ function deserialize(s, ::Type{TypeVar})
     TypeVar(name, lb, ub)
 end
 
-function deserialize(s, ::Type{UnionType})
+function deserialize_(s, ::Type{UnionType}, p)
     nf_expected = deserialize(s)
     types = deserialize(s)
     Union(types...)
 end
 
-function deserialize(s, ::Type{DataType})
+function deserialize_(s, ::Type{DataType}, pos)
     form = read(s, Uint8)
     name = deserialize(s)::Symbol
     mod = deserialize(s)::Module
@@ -511,12 +516,15 @@ function deserialize(s, ::Type{DataType})
     if form == 0
         return t
     end
-    deserialize(s, t)
+    if applicable(deserialize, s, t)
+        return deserialize(s, t)
+    end
+    deserialize(s, t, pos)
 end
 
-deserialize{T}(s, ::Type{Ptr{T}}) = pointer(T, 0)
+deserialize_{T}(s, ::Type{Ptr{T}}, p) = pointer(T, 0)
 
-function deserialize(s, ::Type{Task})
+function deserialize_(s, ::Type{Task}, p)
     t = Task(deserialize(s))
     t.storage = deserialize(s)
     t.done = deserialize(s)
@@ -525,6 +533,9 @@ function deserialize(s, ::Type{Task})
     t.exception = deserialize(s)
     t
 end
+
+# all other formats are handled by the default DataType deserializer
+deserialize_(s, t::DataType, pos) = deserialize(s, t, pos)
 
 # default DataType deserializer
 function deserialize(s, t::DataType, pos)


### PR DESCRIPTION
this design is fully backwards-compatible with all uses and definitions of `serialize` and `deserialize`.

the methodology is as follows:
- serialize to an `IOBuffer`, and do a takebuf when a message is done
- objects that can participate in cycles insert
  
  ```
  serialize_cycle(io, OBJ) && return
  ```
  
  at the top of their `serialize` methods
- to support deserialization, implement `deserialize(io, ::Type{T}, pos)` and insert
  
  ```
  deserialize_cycle(pos, OBJ)
  ```
  
  as soon as the new object `OBJ` is allocated.

Part of the motivation for this design is that many types will never participate in cycles, and so as a user or extender of the serialization API it is possible to ignore the issue entirely,
