### PR TITLE
close #52 (run doc example code as a test suite)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,7 +25,10 @@ import juliadoc
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.mathjax', 'juliadoc.julia', 'juliadoc.jlhelp']
+extensions = ['sphinx.ext.mathjax',
+              'juliadoc.julia',
+              'juliadoc.jldoctest',
+              'juliadoc.jlhelp']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -111,27 +111,31 @@ scalar.
 The following example computes a weighted average of the current element
 and its left and right neighbor along a 1-d grid. :
 
-.. doctest::
+.. testsetup:: *
+
+    srand(314)
+
+.. doctest:: array-rand
 
     julia> const x = rand(8)
-    8-element Float64 Array:
-     0.276455
-     0.614847
-     0.0601373
-     0.896024
-     0.646236
-     0.143959
-     0.0462343
-     0.730987
+    8-element Array{Float64,1}:
+     0.843025
+     0.869052
+     0.365105
+     0.699456
+     0.977653
+     0.994953
+     0.41084 
+     0.809411
 
     julia> [ 0.25*x[i-1] + 0.5*x[i] + 0.25*x[i+1] for i=2:length(x)-1 ]
-    6-element Float64 Array:
-     0.391572
-     0.407786
-     0.624605
-     0.583114
-     0.245097
-     0.241854
+    6-element Array{Float64,1}:
+     0.736559
+     0.57468
+     0.685417
+     0.912429
+     0.8446  
+     0.656511
 
 .. note:: In the above example, ``x`` is declared as constant because type
   inference in Julia does not work as well on non-constant global
@@ -150,7 +154,7 @@ array of type ``Any``:
 .. doctest::
 
     julia> { i/2 for i = 1:3 }
-    3-element Any Array:
+    3-element Array{Any,1}:
      0.5
      1.0
      1.5
@@ -188,16 +192,17 @@ Example:
 .. doctest::
 
     julia> x = reshape(1:16, 4, 4)
-    4x4 Int64 Array
-    1 5  9 13
-    2 6 10 14
-    3 7 11 15
-    4 8 12 16
+    4x4 Array{Int64,2}:
+     1  5   9  13
+     2  6  10  14
+     3  7  11  15
+     4  8  12  16
+
 
     julia> x[2:3, 2:end-1]
-    2x2 Int64 Array
-    6 10
-    7 11
+    2x2 Array{Int64,2}:
+     6  10
+     7  11
 
 Assignment
 ----------
@@ -230,16 +235,19 @@ Example:
 .. doctest::
 
     julia> x = reshape(1:9, 3, 3)
-    3x3 Int64 Array
-    1 4 7
-    2 5 8
-    3 6 9
+    3x3 Array{Int64,2}:
+     1  4  7
+     2  5  8
+     3  6  9
 
     julia> x[1:2, 2:3] = -1
-    3x3 Int64 Array
-    1 -1 -1
-    2 -1 -1
-    3  6  9
+    -1
+
+    julia> x
+    3x3 Array{Int64,2}:
+     1  -1  -1
+     2  -1  -1
+     3   6   9
 
 Concatenation
 -------------
@@ -321,9 +329,9 @@ the name of the function to vectorize. Here is a simple example:
 
     julia> methods(square)
     # 4 methods for generic function "square":
-    square{T<:Number}(x::AbstractArray{T<:Number,1}) at operators.jl:236
-    square{T<:Number}(x::AbstractArray{T<:Number,2}) at operators.jl:237
-    square{T<:Number}(x::AbstractArray{T<:Number,N}) at operators.jl:239
+    square{T<:Number}(x::AbstractArray{T<:Number,1}) at operators.jl:248
+    square{T<:Number}(x::AbstractArray{T<:Number,2}) at operators.jl:249
+    square{T<:Number}(x::AbstractArray{T<:Number,N}) at operators.jl:251
     square(x) at none:1
 
     julia> square([1 2 4; 5 6 7])
@@ -495,13 +503,15 @@ you can use the same names with an ``sp`` prefix:
 .. doctest::
 
     julia> spzeros(3,5)
-    3x5 sparse matrix with 0 nonzeros:
+    3x5 sparse matrix with 0 Float64 nonzeros:
+    <BLANKLINE>
 
     julia> speye(3,5)
-    3x5 sparse matrix with 3 nonzeros:
-        [1, 1]  =  1.0
-        [2, 2]  =  1.0
-        [3, 3]  =  1.0
+    3x5 sparse matrix with 3 Float64 nonzeros:
+            [1, 1]  =  1.0
+            [2, 2]  =  1.0
+            [3, 3]  =  1.0
+    <BLANKLINE>
 
 The ``sparse`` function is often a handy way to construct sparse
 matrices. It takes as its input a vector ``I`` of row indices, a
@@ -514,11 +524,12 @@ values. ``sparse(I,J,V)`` constructs a sparse matrix such that
     julia> I = [1, 4, 3, 5]; J = [4, 7, 18, 9]; V = [1, 2, -5, 3];
 
     julia> S = sparse(I,J,V)
-    5x18 sparse matrix with 4 nonzeros:
-         [1 ,  4]  =  1
-         [4 ,  7]  =  2
-         [5 ,  9]  =  3
-         [3 , 18]  =  -5
+    5x18 sparse matrix with 4 Int64 nonzeros:
+            [1 ,  4]  =  1
+            [4 ,  7]  =  2
+            [5 ,  9]  =  3
+            [3 , 18]  =  -5
+    <BLANKLINE>
 
 The inverse of the ``sparse`` function is ``findn``, which
 retrieves the inputs used to create the sparse matrix.
@@ -526,10 +537,10 @@ retrieves the inputs used to create the sparse matrix.
 .. doctest::
 
     julia> findn(S)
-    ([1, 4, 5, 3],[4, 7, 9, 18])
+    ([1,4,5,3],[4,7,9,18])
 
     julia> findnz(S)
-    ([1, 4, 5, 3],[4, 7, 9, 18],[1, 2, 3, -5])
+    ([1,4,5,3],[4,7,9,18],[1,2,3,-5])
 
 Another way to create sparse matrices is to convert a dense matrix
 into a sparse matrix using the ``sparse`` function:
@@ -537,12 +548,13 @@ into a sparse matrix using the ``sparse`` function:
 .. doctest::
 
     julia> sparse(eye(5))
-    5x5 sparse matrix with 5 nonzeros:
-        [1, 1]  =  1.0
-        [2, 2]  =  1.0
-        [3, 3]  =  1.0
-        [4, 4]  =  1.0
-        [5, 5]  =  1.0
+    5x5 sparse matrix with 5 Float64 nonzeros:
+            [1, 1]  =  1.0
+            [2, 2]  =  1.0
+            [3, 3]  =  1.0
+            [4, 4]  =  1.0
+            [5, 5]  =  1.0
+    <BLANKLINE>
 
 You can go in the other direction using the ``dense`` or the ``full``
 function. The ``issparse`` function can be used to query if a matrix

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -109,7 +109,9 @@ ranges ``rx``, ``ry``, etc. and each ``F(x,y,...)`` evaluation returns a
 scalar.
 
 The following example computes a weighted average of the current element
-and its left and right neighbor along a 1-d grid. ::
+and its left and right neighbor along a 1-d grid. :
+
+.. doctest::
 
     julia> const x = rand(8)
     8-element Float64 Array:
@@ -143,7 +145,9 @@ that the result is of type ``Float64`` by writing::
     Float64[ 0.25*x[i-1] + 0.5*x[i] + 0.25*x[i+1] for i=2:length(x)-1 ]
 
 Using curly brackets instead of square brackets is a shorthand notation for an
-array of type ``Any``::
+array of type ``Any``:
+
+.. doctest::
 
     julia> { i/2 for i = 1:3 }
     3-element Any Array:
@@ -179,7 +183,9 @@ Indexing syntax is equivalent to a call to ``getindex``::
 
     X = getindex(A, I_1, I_2, ..., I_n)
 
-Example::
+Example:
+
+.. doctest::
 
     julia> x = reshape(1:16, 4, 4)
     4x4 Int64 Array
@@ -219,7 +225,9 @@ Index assignment syntax is equivalent to a call to ``setindex!``::
 
       setindex!(A, X, I_1, I_2, ..., I_n)
 
-Example::
+Example:
+
+.. doctest::
 
     julia> x = reshape(1:9, 3, 3)
     3x3 Int64 Array
@@ -301,7 +309,9 @@ Furthermore, Julia provides the ``@vectorize_1arg`` and ``@vectorize_2arg``
 macros to automatically vectorize any function of one or two arguments
 respectively.  Each of these takes two arguments, namely the ``Type`` of
 argument (which is usually chosen to be to be the most general possible) and
-the name of the function to vectorize. Here is a simple example::
+the name of the function to vectorize. Here is a simple example:
+
+.. doctest::
 
     julia> square(x) = x^2
     square (generic function with 1 method)
@@ -327,7 +337,9 @@ Broadcasting
 It is sometimes useful to perform element-by-element binary operations
 on arrays of different sizes, such as adding a vector to each column
 of a matrix.  An inefficient way to do this would be to replicate the
-vector to the size of the matrix::
+vector to the size of the matrix:
+
+.. doctest::
 
     julia> a = rand(2,1); A = rand(2,3);
 
@@ -340,7 +352,9 @@ This is wasteful when dimensions get large, so Julia offers
 ``broadcast``, which expands singleton dimensions in
 array arguments to match the corresponding dimension in the other
 array without using extra memory, and applies the given
-function elementwise::
+function elementwise:
+
+.. doctest::
 
     julia> broadcast(+, a, A)
     2x3 Float64 Array:
@@ -478,7 +492,7 @@ equivalent to the ``zeros`` and ``eye`` functions that Julia provides
 for working with dense matrices. To produce sparse matrices instead,
 you can use the same names with an ``sp`` prefix:
 
-::
+.. doctest::
 
     julia> spzeros(3,5)
     3x5 sparse matrix with 0 nonzeros:
@@ -495,7 +509,7 @@ vector ``J`` of column indices, and a vector ``V`` of nonzero
 values. ``sparse(I,J,V)`` constructs a sparse matrix such that
 ``S[I[k], J[k]] = V[k]``.
 
-::
+.. doctest::
 
     julia> I = [1, 4, 3, 5]; J = [4, 7, 18, 9]; V = [1, 2, -5, 3];
 
@@ -509,7 +523,7 @@ values. ``sparse(I,J,V)`` constructs a sparse matrix such that
 The inverse of the ``sparse`` function is ``findn``, which
 retrieves the inputs used to create the sparse matrix.
 
-::
+.. doctest::
 
     julia> findn(S)
     ([1, 4, 5, 3],[4, 7, 9, 18])
@@ -520,7 +534,7 @@ retrieves the inputs used to create the sparse matrix.
 Another way to create sparse matrices is to convert a dense matrix
 into a sparse matrix using the ``sparse`` function:
 
-::
+.. doctest::
 
     julia> sparse(eye(5))
     5x5 sparse matrix with 5 nonzeros:
@@ -534,7 +548,7 @@ You can go in the other direction using the ``dense`` or the ``full``
 function. The ``issparse`` function can be used to query if a matrix
 is sparse.
 
-::
+.. doctest::
 
     julia> issparse(speye(5))
     true

--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -23,13 +23,17 @@ index variable name. Since Julia allows numeric literals to be
 :ref:`juxtaposed with identifiers as coefficients
 <man-numeric-literal-coefficients>`,
 this binding suffices to provide convenient syntax for complex numbers,
-similar to the traditional mathematical notation::
+similar to the traditional mathematical notation:
+
+.. doctest::
 
     julia> 1 + 2im
     1 + 2im
 
 You can perform all the standard arithmetic operations with complex
-numbers::
+numbers:
+
+.. doctest::
 
     julia> (1 + 2im)*(2 - 3im)
     8 + 1im
@@ -62,7 +66,9 @@ numbers::
     0.20689655172413793 + 0.5172413793103449im
 
 The promotion mechanism ensures that combinations of operands of
-different types just work::
+different types just work:
+
+.. doctest::
 
     julia> 2(1 - 1im)
     2 - 2im
@@ -94,7 +100,9 @@ different types just work::
 Note that ``3/4im == 3/(4*im) == -(3/4*im)``, since a literal
 coefficient binds more tightly than division.
 
-Standard functions to manipulate complex values are provided::
+Standard functions to manipulate complex values are provided:
+
+.. doctest::
 
     julia> real(1 + 2im)
     1
@@ -115,7 +123,9 @@ As is common, the absolute value of a complex number is its distance
 from zero. The ``abs2`` function gives the square of the absolute value,
 and is of particular use for complex numbers, where it avoids taking a
 square root. The full gamut of other :ref:`man-elementary-functions` is also
-defined for complex numbers::
+defined for complex numbers:
+
+.. doctest::
 
     julia> sqrt(im)
     0.7071067811865476 + 0.7071067811865475im
@@ -135,7 +145,9 @@ defined for complex numbers::
 Note that mathematical functions typically return real values when applied
 to real numbers and complex values when applied to complex numbers.
 For example, ``sqrt`` behaves differently when applied to ``-1``
-versus ``-1 + 0im`` even though ``-1 == -1 + 0im``::
+versus ``-1 + 0im`` even though ``-1 == -1 + 0im``:
+
+.. doctest::
 
     julia> sqrt(-1)
     ERROR: DomainError()
@@ -146,13 +158,17 @@ versus ``-1 + 0im`` even though ``-1 == -1 + 0im``::
 
 The :ref:`literal numeric coefficient notation <man-numeric-literal-coefficients>`
 does work when constructing complex number from variables. Instead, the
-multiplication must be explicitly written out::
+multiplication must be explicitly written out:
+
+.. doctest::
 
     julia> a = 1; b = 2; a + b*im
     1 + 2im
 
 Hoever, this is *not* recommended; Use the ``complex`` function instead to
-construct a complex value directly from its real and imaginary parts.::
+construct a complex value directly from its real and imaginary parts.:
+
+.. doctest::
 
     julia> complex(a,b)
     1 + 2im
@@ -161,7 +177,9 @@ This construction avoids the multiplication and addition operations.
 
 ``Inf`` and ``NaN`` propagate through complex numbers in the real
 and imaginary parts of a complex number as described in the 
-:ref:`man-special-floats` section::
+:ref:`man-special-floats` section:
+
+.. doctest::
 
     julia> 1 + Inf*im
     complex(1.0,Inf)
@@ -176,13 +194,17 @@ Rational Numbers
 ----------------
 
 Julia has a rational number type to represent exact ratios of integers.
-Rationals are constructed using the ``//`` operator::
+Rationals are constructed using the ``//`` operator:
+
+.. doctest::
 
     julia> 2//3
     2//3
 
 If the numerator and denominator of a rational have common factors, they
-are reduced to lowest terms such that the denominator is non-negative::
+are reduced to lowest terms such that the denominator is non-negative:
+
+.. doctest::
 
     julia> 6//9
     2//3
@@ -199,7 +221,9 @@ are reduced to lowest terms such that the denominator is non-negative::
 This normalized form for a ratio of integers is unique, so equality of
 rational values can be tested by checking for equality of the numerator
 and denominator. The standardized numerator and denominator of a
-rational value can be extracted using the ``num`` and ``den`` functions::
+rational value can be extracted using the ``num`` and ``den`` functions:
+
+.. doctest::
 
     julia> num(2//3)
     2
@@ -209,7 +233,9 @@ rational value can be extracted using the ``num`` and ``den`` functions::
 
 Direct comparison of the numerator and denominator is generally not
 necessary, since the standard arithmetic and comparison operations are
-defined for rational values::
+defined for rational values:
+
+.. doctest::
 
     julia> 2//3 == 6//9
     true
@@ -235,19 +261,25 @@ defined for rational values::
     julia> 6//5 / 10//7
     21//25
 
-Rationals can be easily converted to floating-point numbers::
+Rationals can be easily converted to floating-point numbers:
+
+.. doctest::
 
     julia> float(3//4)
     0.75
 
 Conversion from rational to floating-point respects the following
 identity for any integral values of ``a`` and ``b``, with the exception
-of the case ``a == 0`` and ``b == 0``::
+of the case ``a == 0`` and ``b == 0``:
+
+.. doctest::
 
     julia> isequal(float(a//b), a/b)
     true
 
-Constructing infinite rational values is acceptable::
+Constructing infinite rational values is acceptable:
+
+.. doctest::
 
     julia> 5//0
     Inf
@@ -258,13 +290,17 @@ Constructing infinite rational values is acceptable::
     julia> typeof(ans)
     Rational{Int64}
 
-Trying to construct a ``NaN`` rational value, however, is not::
+Trying to construct a ``NaN`` rational value, however, is not:
+
+.. doctest::
 
     julia> 0//0
     invalid rational: 0//0
 
 As usual, the promotion system makes interactions with other numeric
-types effortless::
+types effortless:
+
+.. doctest::
 
     julia> 3//5 + 1
     8//5

--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -127,7 +127,7 @@ defined for complex numbers:
 
 .. doctest::
 
-    julia> sqrt(im)
+    julia> sqrt(1im)
     0.7071067811865476 + 0.7071067811865475im
 
     julia> sqrt(1 + 2im)
@@ -150,8 +150,10 @@ versus ``-1 + 0im`` even though ``-1 == -1 + 0im``:
 .. doctest::
 
     julia> sqrt(-1)
-    ERROR: DomainError()
-     in sqrt at math.jl:111
+    ERROR: DomainError
+    sqrt will only return a complex result if called with a complex argument.
+    try sqrt(complex(x))
+     in sqrt at math.jl:284
 
     julia> sqrt(-1 + 0im)
     0.0 + 1.0im
@@ -288,14 +290,16 @@ Constructing infinite rational values is acceptable:
     -Inf
 
     julia> typeof(ans)
-    Rational{Int64}
+    Rational{Int64} (constructor with 1 method)
 
 Trying to construct a ``NaN`` rational value, however, is not:
 
 .. doctest::
 
     julia> 0//0
-    invalid rational: 0//0
+    ERROR: invalid rational: 0//0
+     in Rational at rational.jl:7
+     in // at rational.jl:17
 
 As usual, the promotion system makes interactions with other numeric
 types effortless:
@@ -306,7 +310,7 @@ types effortless:
     8//5
 
     julia> 3//5 - 0.5
-    0.1
+    0.09999999999999998
 
     julia> 2//7 * (1 + 2im)
     2//7 + 4//7im
@@ -321,7 +325,7 @@ types effortless:
     1//2 + 2//1im
 
     julia> 1 + 2//3im
-    1//1 + 2//3im
+    1//1 - 2//3im
 
     julia> 0.5 == 1//2
     true

--- a/doc/manual/constructors.rst
+++ b/doc/manual/constructors.rst
@@ -108,7 +108,9 @@ not greater than the second one. One could declare it like this::
     end
 
 Now ``OrderedPair`` objects can only be constructed such that
-``x <= y``::
+``x <= y``:
+
+.. doctest::
 
     julia> OrderedPair(1,2)
     OrderedPair(1,2)
@@ -249,7 +251,9 @@ be returned::
     julia> z = Incomplete();
 
 While you are allowed to create objects with uninitialized fields, any
-access to an uninitialized field is an immediate error::
+access to an uninitialized field is an immediate error:
+
+.. doctest::
 
     julia> z.xx
     access to undefined reference
@@ -370,7 +374,9 @@ This method uses the ``convert`` function to explicitly convert ``x`` to
 ``Float64`` and then delegates construction to the general constructor
 for the case where both arguments are ``Float64``. With this method
 definition what was previously a "no method" error now successfully
-creates a point of type ``Point{Float64}``::
+creates a point of type ``Point{Float64}``:
+
+.. doctest::
 
     julia> Point(1,2.5)
     Point(1.0,2.5)
@@ -378,7 +384,9 @@ creates a point of type ``Point{Float64}``::
     julia> typeof(ans)
     Point{Float64}
 
-However, other similar calls still don't work::
+However, other similar calls still don't work:
+
+.. doctest::
 
     julia> Point(1.5,2)
     no method Point(Float64,Int64)
@@ -394,7 +402,9 @@ the following outer method definition to make all calls to the general
 The ``promote`` function converts all its arguments to a common type
 — in this case ``Float64``. With this method definition, the ``Point``
 constructor promotes its arguments the same way that numeric operators
-like ``+`` do, and works for all kinds of real numbers::
+like ``+`` do, and works for all kinds of real numbers:
+
+.. doctest::
 
     julia> Point(1.5,2)
     Point(1.5,2.0)
@@ -492,7 +502,9 @@ number, we construct a new rational for the resulting ratio slightly
 differently; this behavior is actually identical to division of a
 rational with an integer. Finally, applying ``//`` to complex integral
 values creates an instance of ``Complex{Rational}`` — a complex number
-whose real and imaginary parts are rationals::
+whose real and imaginary parts are rationals:
+
+.. doctest::
 
     julia> (1 + 2im)//(1 - 2im)
     -3//5 + 4//5im

--- a/doc/manual/constructors.rst
+++ b/doc/manual/constructors.rst
@@ -98,7 +98,9 @@ constructor method, with two differences:
 
 For example, suppose one wants to declare a type that holds a pair of
 real numbers, subject to the constraint that the first number is
-not greater than the second one. One could declare it like this::
+not greater than the second one. One could declare it like this:
+
+.. testcode::
 
     type OrderedPair
       x::Real
@@ -116,7 +118,7 @@ Now ``OrderedPair`` objects can only be constructed such that
     OrderedPair(1,2)
 
     julia> OrderedPair(2,1)
-    out of order
+    ERROR: out of order
      in OrderedPair at none:5
 
 You can still reach in and directly change the field values to violate
@@ -216,7 +218,9 @@ fields uninitialized. The inner constructor method can then use the
 incomplete object, finishing its initialization before returning it.
 Here, for example, we take another crack at defining the
 ``SelfReferential`` type, with a zero-argument inner constructor
-returning instances having ``obj`` fields pointing to themselves::
+returning instances having ``obj`` fields pointing to themselves:
+
+.. testcode::
 
     type SelfReferential
       obj::SelfReferential
@@ -225,9 +229,11 @@ returning instances having ``obj`` fields pointing to themselves::
     end
 
 We can verify that this constructor works and constructs objects that
-are, in fact, self-referential::
+are, in fact, self-referential:
 
-    x = SelfReferential();
+.. doctest::
+
+    julia> x = SelfReferential();
 
     julia> is(x, x)
     true
@@ -240,13 +246,14 @@ are, in fact, self-referential::
 
 Although it is generally a good idea to return a fully initialized
 object from an inner constructor, incompletely initialized objects can
-be returned::
+be returned:
 
-    type Incomplete
-      xx
+.. doctest::
 
-      Incomplete() = new()
-    end
+    julia> type Incomplete
+             xx
+             Incomplete() = new()
+           end
 
     julia> z = Incomplete();
 
@@ -256,7 +263,7 @@ access to an uninitialized field is an immediate error:
 .. doctest::
 
     julia> z.xx
-    access to undefined reference
+    ERROR: access to undefined reference
 
 This prevents uninitialized fields from propagating throughout a program
 or forcing programmers to continually check for uninitialized fields,
@@ -284,37 +291,39 @@ Parametric types add a few wrinkles to the constructor story. Recall
 from :ref:`man-parametric-types` that, by default,
 instances of parametric composite types can be constructed either with
 explicitly given type parameters or with type parameters implied by the
-types of the arguments given to the constructor. Here are some examples::
+types of the arguments given to the constructor. Here are some examples:
 
-    type Point{T<:Real}
-      x::T
-      y::T
-    end
+.. doctest::
+
+    julia> type Point{T<:Real}
+             x::T
+             y::T
+           end
 
     ## implicit T ##
 
     julia> Point(1,2)
-    Point(1,2)
+    Point{Int64}(1,2)
 
     julia> Point(1.0,2.5)
-    Point(1.0,2.5)
+    Point{Float64}(1.0,2.5)
 
     julia> Point(1,2.5)
-    no method Point(Int64,Float64)
+    ERROR: no method Point{T<:Real}(Int64, Float64)
 
     ## explicit T ##
 
     julia> Point{Int64}(1,2)
-    Point(1,2)
+    Point{Int64}(1,2)
 
     julia> Point{Int64}(1.0,2.5)
-    no method Point(Float64,Float64)
+    ERROR: no method Point{Int64}(Float64, Float64)
 
     julia> Point{Float64}(1.0,2.5)
-    Point(1.0,2.5)
+    Point{Float64}(1.0,2.5)
 
     julia> Point{Float64}(1,2)
-    no method Point(Int64,Int64)
+    ERROR: no method Point{Float64}(Int64, Int64)
 
 As you can see, for constructor calls with explicit type parameters, the
 arguments must match that specific type: ``Point{Int64}(1,2)`` works,
@@ -366,9 +375,11 @@ method" errors.
 Suppose we wanted to make the constructor call ``Point(1,2.5)`` work by
 "promoting" the integer value ``1`` to the floating-point value ``1.0``.
 The simplest way to achieve this is to define the following additional
-outer constructor method::
+outer constructor method:
 
-    Point(x::Int64, y::Float64) = Point(convert(Float64,x),y)
+.. doctest::
+
+    julia> Point(x::Int64, y::Float64) = Point(convert(Float64,x),y);
 
 This method uses the ``convert`` function to explicitly convert ``x`` to
 ``Float64`` and then delegates construction to the general constructor
@@ -379,25 +390,27 @@ creates a point of type ``Point{Float64}``:
 .. doctest::
 
     julia> Point(1,2.5)
-    Point(1.0,2.5)
+    Point{Float64}(1.0,2.5)
 
     julia> typeof(ans)
-    Point{Float64}
+    Point{Float64} (constructor with 1 method)
 
 However, other similar calls still don't work:
 
 .. doctest::
 
     julia> Point(1.5,2)
-    no method Point(Float64,Int64)
+    ERROR: no method Point{T<:Real}(Float64, Int64)
 
 For a much more general way of making all such calls work sensibly, see
 :ref:`man-conversion-and-promotion`. At the risk
 of spoiling the suspense, we can reveal here that the all it takes is
 the following outer method definition to make all calls to the general
-``Point`` constructor work as one would expect::
+``Point`` constructor work as one would expect:
 
-    Point(x::Real, y::Real) = Point(promote(x,y)...)
+.. doctest::
+
+    julia> Point(x::Real, y::Real) = Point(promote(x,y)...);
 
 The ``promote`` function converts all its arguments to a common type
 — in this case ``Float64``. With this method definition, the ``Point``
@@ -407,13 +420,13 @@ like ``+`` do, and works for all kinds of real numbers:
 .. doctest::
 
     julia> Point(1.5,2)
-    Point(1.5,2.0)
+    Point{Float64}(1.5,2.0)
 
     julia> Point(1,1//2)
-    Point(1//1,1//2)
+    Point{Rational{Int64}}(1//1,1//2)
 
     julia> Point(1.0,1//2)
-    Point(1.0,0.5)
+    Point{Float64}(1.0,0.5)
 
 Thus, while the implicit type parameter constructors provided by default
 in Julia are fairly strict, it is possible to make them behave in a more
@@ -510,10 +523,10 @@ whose real and imaginary parts are rationals:
     -3//5 + 4//5im
 
     julia> typeof(ans)
-    ComplexPair{Rational{Int64}}
+    Complex{Rational{Int64}} (constructor with 1 method)
 
     julia> ans <: Complex{Rational}
-    true
+    false
 
 Thus, although the ``//`` operator usually returns an instance of
 ``Rational``, if either of its arguments are complex integers, it will

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -34,7 +34,9 @@ several subexpressions in order, returning the value of the last
 subexpression as its value. There are two Julia constructs that
 accomplish this: ``begin`` blocks and ``(;)`` chains. The value of both
 compound expression constructs is that of the last subexpression. Here's
-an example of a ``begin`` block::
+an example of a ``begin`` block:
+
+.. doctest::
 
     julia> z = begin
              x = 1
@@ -45,7 +47,9 @@ an example of a ``begin`` block::
 
 Since these are fairly small, simple expressions, they could easily be
 placed onto a single line, which is where the ``(;)`` chain syntax comes
-in handy::
+in handy:
+
+.. doctest::
 
     julia> z = (x = 1; y = 2; x + y)
     3
@@ -53,7 +57,9 @@ in handy::
 This syntax is particularly useful with the terse single-line function
 definition form introduced in :ref:`man-functions`. Although it
 is typical, there is no requirement that ``begin`` blocks be multiline
-or that ``(;)`` chains be single-line::
+or that ``(;)`` chains be single-line:
+
+.. doctest::
 
     julia> begin x = 1; y = 2; x + y end
     3
@@ -83,7 +89,9 @@ anatomy of the ``if``-``elseif``-``else`` conditional syntax::
 If the condition expression ``x < y`` is ``true``, then the corresponding block
 is evaluated; otherwise the condition expression ``x > y`` is evaluated, and if
 it is ``true``, the corresponding block is evaluated; if neither expression is
-true, the ``else`` block is evaluated. Here it is in action::
+true, the ``else`` block is evaluated. Here it is in action:
+
+.. doctest::
 
     julia> function test(x, y)
              if x < y
@@ -113,7 +121,9 @@ and no further condition expressions or blocks are evaluated.
 
 Unlike C, MATLAB, Perl, Python, and Ruby — but like Java, and a few
 other stricter, typed languages — it is an error if the value of a
-conditional expression is anything but ``true`` or ``false``::
+conditional expression is anything but ``true`` or ``false``:
+
+.. doctest::
 
     julia> if 1
              println("true")
@@ -140,7 +150,9 @@ The easiest way to understand this behavior is to see an example. In the
 previous example, the ``println`` call is shared by all three branches:
 the only real choice is which literal string to print. This could be
 written more concisely using the ternary operator. For the sake of
-clarity, let's try a two-way version first::
+clarity, let's try a two-way version first:
+
+.. doctest::
 
     julia> x = 1; y = 2;
 
@@ -156,7 +168,9 @@ If the expression ``x < y`` is true, the entire ternary operator
 expression evaluates to the string ``"less than"`` and otherwise it
 evaluates to the string ``"not less than"``. The original three-way
 example requires chaining multiple uses of the ternary operator
-together::
+together:
+
+.. doctest::
 
     julia> test(x, y) = println(x < y ? "x is less than y"    :
                                 x > y ? "x is greater than y" : "x is equal to y")
@@ -175,7 +189,9 @@ To facilitate chaining, the operator associates from right to left.
 
 It is significant that like ``if``-``elseif``-``else``, the expressions
 before and after the ``:`` are only evaluated if the condition
-expression evaluates to ``true`` or ``false``, respectively::
+expression evaluates to ``true`` or ``false``, respectively:
+
+.. doctest::
 
     julia> v(x) = (println(x); x)
     v (generic function with 1 method)
@@ -211,7 +227,9 @@ The reasoning is that ``a && b`` must be ``false`` if ``a`` is
 ``a || b`` must be true if ``a`` is ``true``, regardless of the value of
 ``b``. Both ``&&`` and ``||`` associate to the right, but ``&&`` has
 higher precedence than ``||`` does. It's easy to experiment with
-this behavior::
+this behavior:
+
+.. doctest::
 
     julia> t(x) = (println(x); true)
     t (generic function with 1 method)
@@ -261,7 +279,9 @@ precedence of various combinations of ``&&`` and ``||`` operators.
 Boolean operations *without* short-circuit evaluation can be done with the
 bitwise boolean operators introduced in :ref:`man-mathematical-operations`:
 ``&`` and ``|``. These are normal functions, which happen to support
-infix operator syntax, but always evaluate their arguments::
+infix operator syntax, but always evaluate their arguments:
+
+.. doctest::
 
     julia> f(1) & t(2)
     1
@@ -275,7 +295,9 @@ infix operator syntax, but always evaluate their arguments::
 
 Just like condition expressions used in ``if``, ``elseif`` or the
 ternary operator, the operands of ``&&`` or ``||`` must be boolean
-values (``true`` or ``false``). Using a non-boolean value is an error::
+values (``true`` or ``false``). Using a non-boolean value is an error:
+
+.. doctest::
 
     julia> 1 && 2
     type error: lambda: in if, expected Bool, got Int64
@@ -287,7 +309,9 @@ Repeated Evaluation: Loops
 
 There are two constructs for repeated evaluation of expressions: the
 ``while`` loop and the ``for`` loop. Here is an example of a ``while``
-loop::
+loop:
+
+.. doctest::
 
     julia> i = 1;
 
@@ -308,7 +332,9 @@ of the ``while`` loop. If the condition expression is ``false`` when the
 
 The ``for`` loop makes common repeated evaluation idioms easier to
 write. Since counting up and down like the above ``while`` loop does is
-so common, it can be expressed more concisely with a ``for`` loop::
+so common, it can be expressed more concisely with a ``for`` loop:
+
+.. doctest::
 
     julia> for i = 1:5
              println(i)
@@ -327,7 +353,9 @@ loop form is the scope during which the variable is visible. If the
 variable ``i`` has not been introduced in an other scope, in the ``for``
 loop form, it is visible only inside of the ``for`` loop, and not
 afterwards. You'll either need a new interactive session instance or a
-different variable name to test this::
+different variable name to test this:
+
+.. doctest::
 
     julia> for j = 1:5
              println(j)
@@ -347,7 +375,9 @@ explanation of variable scope and how it works in Julia.
 In general, the ``for`` loop construct can iterate over any container.
 In these cases, the alternative (but fully equivalent) keyword ``in`` is
 typically used instead of ``=``, since it makes the code read more
-clearly::
+clearly:
+
+.. doctest::
 
     julia> for i in [1,4,0]
              println(i)
@@ -369,7 +399,9 @@ later sections of the manual (see, e.g., :ref:`man-arrays`).
 It is sometimes convenient to terminate the repetition of a ``while``
 before the test condition is falsified or stop iterating in a ``for``
 loop before the end of the iterable object is reached. This can be
-accomplished with the ``break`` keyword::
+accomplished with the ``break`` keyword:
+
+.. doctest::
 
     julia> i = 1;
 
@@ -404,7 +436,9 @@ by using the ``break`` keyword.
 
 In other circumstances, it is handy to be able to stop an iteration and
 move on to the next one immediately. The ``continue`` keyword
-accomplishes this::
+accomplishes this:
+
+.. doctest::
 
     julia> for i = 1:10
              if i % 3 != 0
@@ -423,7 +457,9 @@ more code to be evaluated after the ``continue``, and often there are
 multiple points from which one calls ``continue``.
 
 Multiple nested ``for`` loops can be combined into a single outer loop,
-forming the cartesian product of its iterables::
+forming the cartesian product of its iterables:
+
+.. doctest::
 
     julia> for i = 1:2, j = 3:4
              println((i, j))
@@ -490,7 +526,9 @@ built-in ``Exception``\ s listed below all interrupt the normal flow of control.
 +------------------------+
 
 For example, the ``sqrt`` function throws a ``DomainError()`` if applied to a
-negative real value::
+negative real value:
+
+.. doctest::
 
     julia> sqrt(-1)
     ERROR: DomainError()
@@ -501,7 +539,9 @@ The ``throw`` function
 
 Exceptions can be created explicitly with ``throw``. For example, a function
 defined only for nonnegative numbers could be written to ``throw`` a ``DomainError``
-if the argument is negative. ::
+if the argument is negative. :
+
+.. doctest::
 
     julia> f(x) = x>=0 ? exp(-x) : throw(DomainError())
     f (generic function with 1 method)
@@ -514,7 +554,9 @@ if the argument is negative. ::
      in f at none:1
 
 Note that ``DomainError`` without parentheses is not an exception, but a type of
-exception. It needs to be called to obtain an ``Exception`` object ::
+exception. It needs to be called to obtain an ``Exception`` object :
+
+.. doctest::
 
     julia> typeof(DomainError()) <: Exception
     true
@@ -530,7 +572,9 @@ interrupts the normal flow of control.
 
 Suppose we want to stop execution immediately if the square root of a
 negative number is taken. To do this, we can define a fussy version of
-the ``sqrt`` function that raises an error if its argument is negative::
+the ``sqrt`` function that raises an error if its argument is negative:
+
+.. doctest::
 
     julia> fussy_sqrt(x) = x >= 0 ? sqrt(x) : error("negative x not allowed")
     fussy_sqrt (generic function with 1 method)
@@ -544,7 +588,9 @@ the ``sqrt`` function that raises an error if its argument is negative::
 If ``fussy_sqrt`` is called with a negative value from another function,
 instead of trying to continue execution of the calling function, it
 returns immediately, displaying the error message in the interactive
-session::
+session:
+
+.. doctest::
 
     julia> function verbose_fussy_sqrt(x)
              println("before fussy_sqrt")
@@ -568,7 +614,9 @@ Warnings and informational messages
 
 Julia also provides other functions that write messages to the standard error
 I/O, but do not throw any ``Exception``\ s and hence do not interrupt
-execution.::
+execution.:
+
+.. doctest::
 
     julia> info("Hi"); 1+1
     MESSAGE: Hi
@@ -588,7 +636,9 @@ The ``try/catch`` statement
 The ``try/catch`` statement allows for ``Exception``\ s to be tested for. For
 example, a customized square root function can be written to automatically
 call either the real or complex square root method on demand using
-``Exception``\ s ::
+``Exception``\ s :
+
+.. doctest::
 
     julia> f(x) = try
              sqrt(x)
@@ -610,7 +660,9 @@ slower than simply comparing and branching.
 ``try/catch`` statements also allow the ``Exception`` to be saved in a
 variable. In this contrived example, the following example calculates the
 square root of the second element of ``x`` if ``x`` is indexable, otherwise
-assumes ``x`` is a real number and returns its square root::
+assumes ``x`` is a real number and returns its square root:
+
+.. doctest::
 
     julia> sqrt_second(x) = try
              sqrt(x[2])
@@ -715,7 +767,9 @@ value it needs to produce::
     end
 
 To consume values, first the producer is wrapped in a ``Task``, then
-``consume`` is called repeatedly on that object::
+``consume`` is called repeatedly on that object:
+
+.. doctest::
 
     julia> p = Task(producer)
     Task
@@ -743,7 +797,9 @@ return multiple times. Between calls to ``produce``, the producer's
 execution is suspended and the consumer has control.
 
 A Task can be used as an iterable object in a ``for`` loop, in which
-case the loop variable takes on all the produced values::
+case the loop variable takes on all the produced values:
+
+.. doctest::
 
     julia> for x in Task(producer)
              println(x)

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -128,7 +128,7 @@ conditional expression is anything but ``true`` or ``false``:
     julia> if 1
              println("true")
            end
-    type error: lambda: in if, expected Bool, got Int64
+    ERROR: type: non-boolean (Int64) used in boolean context
 
 This error indicates that the conditional was of the wrong type:
 ``Int64`` rather than the required ``Bool``.
@@ -300,7 +300,7 @@ values (``true`` or ``false``). Using a non-boolean value is an error:
 .. doctest::
 
     julia> 1 && 2
-    type error: lambda: in if, expected Bool, got Int64
+    ERROR: type: non-boolean (Int64) used in boolean context
 
 .. _man-loops:
 
@@ -367,7 +367,7 @@ different variable name to test this:
     5
 
     julia> j
-    j not defined
+    ERROR: j not defined
 
 See :ref:`man-variables-and-scoping` for a detailed
 explanation of variable scope and how it works in Julia.
@@ -531,8 +531,10 @@ negative real value:
 .. doctest::
 
     julia> sqrt(-1)
-    ERROR: DomainError()
-     in sqrt at math.jl:117
+    ERROR: DomainError
+    sqrt will only return a complex result if called with a complex argument.
+    try sqrt(complex(x))
+     in sqrt at math.jl:284
 
 The ``throw`` function
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -550,7 +552,7 @@ if the argument is negative. :
     0.36787944117144233
     
     julia> f(-1)
-    ERROR: DomainError()
+    ERROR: DomainError
      in f at none:1
 
 Note that ``DomainError`` without parentheses is not an exception, but a type of
@@ -583,7 +585,8 @@ the ``sqrt`` function that raises an error if its argument is negative:
     1.4142135623730951
 
     julia> fussy_sqrt(-1)
-    negative x not allowed
+    ERROR: negative x not allowed
+     in fussy_sqrt at none:1
 
 If ``fussy_sqrt`` is called with a negative value from another function,
 instead of trying to continue execution of the calling function, it
@@ -607,7 +610,8 @@ session:
 
     julia> verbose_fussy_sqrt(-1)
     before fussy_sqrt
-    negative x not allowed
+    ERROR: negative x not allowed
+     in fussy_sqrt at none:1
 
 Warnings and informational messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -619,7 +623,7 @@ execution.:
 .. doctest::
 
     julia> info("Hi"); 1+1
-    MESSAGE: Hi
+    INFO: Hi
     2
     
     julia> warn("Hi"); 1+1
@@ -629,6 +633,7 @@ execution.:
     julia> error("Hi"); 1+1
     ERROR: Hi
      in error at error.jl:21
+
 
 The ``try/catch`` statement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -685,8 +690,10 @@ assumes ``x`` is a real number and returns its square root:
     3.0
     
     julia> sqrt_second(-9)
-    ERROR: DomainError()
-     in sqrt at math.jl:117
+    ERROR: DomainError
+    sqrt will only return a complex result if called with a complex argument.
+    try sqrt(complex(x))
+     in sqrt at math.jl:284
      in sqrt_second at none:7
 
 The power of the ``try/catch`` construct lies in the ability to unwind a deeply
@@ -756,15 +763,17 @@ they need to, passing values back and forth as necessary.
 
 Julia provides the functions ``produce`` and ``consume`` for solving
 this problem. A producer is a function that calls ``produce`` on each
-value it needs to produce::
+value it needs to produce:
 
-    function producer()
-      produce("start")
-      for n=1:4
-        produce(2n)
-      end
-      produce("stop")
-    end
+.. doctest::
+
+    julia> function producer()
+             produce("start")
+             for n=1:4
+               produce(2n)
+             end
+             produce("stop")
+           end;
 
 To consume values, first the producer is wrapped in a ``Task``, then
 ``consume`` is called repeatedly on that object:

--- a/doc/manual/conversion-and-promotion.rst
+++ b/doc/manual/conversion-and-promotion.rst
@@ -79,7 +79,7 @@ action:
     Int64
 
     julia> convert(Uint8, x)
-    12
+    0x0c
 
     julia> typeof(ans)
     Uint8
@@ -97,7 +97,8 @@ requested conversion:
 .. doctest::
 
     julia> convert(FloatingPoint, "foo")
-    no method convert(Type{FloatingPoint},ASCIIString)
+    ERROR: no method convert(Type{FloatingPoint}, ASCIIString)
+     in convert at base.jl:11
 
 Some languages consider parsing strings as numbers or formatting
 numbers as strings to be conversions (many dynamic languages will even
@@ -130,7 +131,8 @@ to zero:
     false
 
     julia> convert(Bool, 1im)
-    true
+    ERROR: InexactError()
+     in convert at complex.jl:27
 
     julia> convert(Bool, 0im)
     false
@@ -285,7 +287,7 @@ This allows calls like the following to work:
     -3//1
 
     julia> typeof(ans)
-    Rational{Int64}
+    Rational{Int64} (constructor with 1 method)
 
 For most user-defined types, it is better practice to require
 programmers to supply the expected types to constructor functions

--- a/doc/manual/conversion-and-promotion.rst
+++ b/doc/manual/conversion-and-promotion.rst
@@ -68,7 +68,9 @@ function. The ``convert`` function generally takes two arguments: the
 first is a type object while the second is a value to convert to that
 type; the returned value is the value converted to an instance of given
 type. The simplest way to understand this function is to see it in
-action::
+action:
+
+.. doctest::
 
     julia> x = 12
     12
@@ -90,7 +92,9 @@ action::
 
 Conversion isn't always possible, in which case a no method error is
 thrown indicating that ``convert`` doesn't know how to perform the
-requested conversion::
+requested conversion:
+
+.. doctest::
 
     julia> convert(FloatingPoint, "foo")
     no method convert(Type{FloatingPoint},ASCIIString)
@@ -115,7 +119,9 @@ type <man-singleton-types>`, ``Type{Bool}``, the only instance of
 which is ``Bool``. Thus, this method is only invoked when the first
 argument is the type value ``Bool``. When invoked, the method determines
 whether a numeric value is true or false as a boolean, by comparing it
-to zero::
+to zero:
+
+.. doctest::
 
     julia> convert(Bool, 1)
     true
@@ -211,7 +217,9 @@ Promotion to a common supertype is performed in Julia by the ``promote``
 function, which takes any number of arguments, and returns a tuple of
 the same number of values, converted to a common type, or throws an
 exception if promotion is not possible. The most common use case for
-promotion is to convert numeric arguments to a common type::
+promotion is to convert numeric arguments to a common type:
+
+.. doctest::
 
     julia> promote(1, 2.5)
     (1.0,2.5)
@@ -269,7 +277,9 @@ provides the following outer constructor method::
 
     Rational(n::Integer, d::Integer) = Rational(promote(n,d)...)
 
-This allows calls like the following to work::
+This allows calls like the following to work:
+
+.. doctest::
 
     julia> Rational(int8(15),int32(-5))
     -3//1
@@ -319,7 +329,9 @@ second function called ``promote_type``, which, given any number of type
 objects, returns the common type to which those values, as arguments to
 ``promote`` should be promoted. Thus, if one wants to know, in absence
 of actual values, what type a collection of values of certain types
-would promote to, one can use ``promote_type``::
+would promote to, one can use ``promote_type``:
+
+.. doctest::
 
     julia> promote_type(Int8, Uint16)
     Int64

--- a/doc/manual/faq.rst
+++ b/doc/manual/faq.rst
@@ -55,11 +55,13 @@ Type declarations and constructors
 
 How do "abstract" or ambiguous fields in types interact with the compiler?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Types can be declared without specifying the types of their fields::
+Types can be declared without specifying the types of their fields:
 
-    type MyAmbiguousType
-        a
-    end
+.. doctest::
+
+    julia> type MyAmbiguousType
+               a
+           end
 
 This allows ``a`` to be of any type. This can often be useful, but it
 does have a downside: for objects of type ``MyAmbiguousType``, the
@@ -77,10 +79,10 @@ be inferred about an object of type ``MyAmbiguousType``:
     MyAmbiguousType(17)
 
     julia> typeof(b)
-    MyAmbiguousType
+    MyAmbiguousType (constructor with 1 method)
 
     julia> typeof(c)
-    MyAmbiguousType
+    MyAmbiguousType (constructor with 1 method)
 
 ``b`` and ``c`` have the same type, yet their underlying
 representation of data in memory is very different. Even if you stored
@@ -93,18 +95,21 @@ performance.
 
 You can do better by declaring the type of ``a``. Here, we are focused
 on the case where ``a`` might be any one of several types, in which
-case the natural solution is to use parameters. For example::
+case the natural solution is to use parameters. For example:
 
-    type MyType{T<:FloatingPoint}
-        a::T
-    end
+.. doctest::
+
+    julia> type MyType{T<:FloatingPoint}
+             a::T
+           end
 
 This is a better choice than
-::
 
-    type MyStillAmbiguousType
-        a::FloatingPoint
-    end
+.. doctest::
+
+    julia> type MyStillAmbiguousType
+             a::FloatingPoint
+           end
 
 because the first version specifies the type of ``a`` from the type of
 the wrapper object.  For example:
@@ -118,10 +123,10 @@ the wrapper object.  For example:
     MyStillAmbiguousType(3.2)
 
     julia> typeof(m)
-    MyType{Float64}
+    MyType{Float64} (constructor with 1 method)
 
     julia> typeof(t)
-    MyStillAmbiguousType
+    MyStillAmbiguousType (constructor with 1 method)
 
 The type of field ``a`` can be readily determined from the type of
 ``m``, but not from the type of ``t``.  Indeed, in ``t`` it's possible
@@ -197,15 +202,17 @@ How should I declare "abstract container type" fields?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The same best practices that apply in the `previous section
-<#man-abstract-fields>`_ also work for container types::
+<#man-abstract-fields>`_ also work for container types:
 
-    type MySimpleContainer{A<:AbstractVector}
-        a::A
-    end
+.. doctest::
 
-    type MyAmbiguousContainer{T}
-        a::AbstractVector{T}
-    end
+    julia> type MySimpleContainer{A<:AbstractVector}
+             a::A
+           end
+
+    julia> type MyAmbiguousContainer{T}
+             a::AbstractVector{T}
+           end
 
 For example:
 
@@ -214,22 +221,22 @@ For example:
     julia> c = MySimpleContainer(1:3);
 
     julia> typeof(c)
-    MySimpleContainer{Range1{Int64}}
+    MySimpleContainer{Range1{Int64}} (constructor with 1 method)
 
     julia> c = MySimpleContainer([1:3]);
 
     julia> typeof(c)
-    MySimpleContainer{Array{Int64,1}}
+    MySimpleContainer{Array{Int64,1}} (constructor with 1 method)
 
     julia> b = MyAmbiguousContainer(1:3);
 
     julia> typeof(b)
-    MyAmbiguousContainer{Int64}
+    MyAmbiguousContainer{Int64} (constructor with 1 method)
 
     julia> b = MyAmbiguousContainer([1:3]);
 
     julia> typeof(b)
-    MyAmbiguousContainer{Int64}
+    MyAmbiguousContainer{Int64} (constructor with 1 method)
 
 For ``MySimpleContainer``, the object is fully-specified by its type
 and parameters, so the compiler can generate optimized functions. In

--- a/doc/manual/faq.rst
+++ b/doc/manual/faq.rst
@@ -66,7 +66,9 @@ does have a downside: for objects of type ``MyAmbiguousType``, the
 compiler will not be able to generate high-performance code.  The
 reason is that the compiler uses the types of objects, not their
 values, to determine how to build code. Unfortunately, very little can
-be inferred about an object of type ``MyAmbiguousType``::
+be inferred about an object of type ``MyAmbiguousType``:
+
+.. doctest::
 
     julia> b = MyAmbiguousType("Hello")
     MyAmbiguousType("Hello")
@@ -105,7 +107,9 @@ This is a better choice than
     end
 
 because the first version specifies the type of ``a`` from the type of
-the wrapper object.  For example::
+the wrapper object.  For example:
+
+.. doctest::
 
     julia> m = MyType(3.2)
     MyType{Float64}(3.2)
@@ -121,7 +125,9 @@ the wrapper object.  For example::
 
 The type of field ``a`` can be readily determined from the type of
 ``m``, but not from the type of ``t``.  Indeed, in ``t`` it's possible
-to change the type of field ``a``::
+to change the type of field ``a``:
+
+.. doctest::
 
     julia> typeof(t.a)
     Float64
@@ -133,7 +139,9 @@ to change the type of field ``a``::
     Float32
 
 In contrast, once ``m`` is constructed, the type of ``m.a`` cannot
-change::
+change:
+
+.. doctest::
 
     julia> m.a = 4.5f0
     4.5
@@ -148,7 +156,9 @@ not for objects like ``t``.
 
 Of course, all of this is true only if we construct ``m`` with a
 concrete type.  We can break this by explicitly constructing it with
-an abstract type::
+an abstract type:
+
+.. doctest::
 
     julia> m = MyType{FloatingPoint}(3.2)
     MyType{FloatingPoint}(3.2)
@@ -197,7 +207,9 @@ The same best practices that apply in the `previous section
         a::AbstractVector{T}
     end
 
-For example::
+For example:
+
+.. doctest::
 
     julia> c = MySimpleContainer(1:3);
 

--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -8,11 +8,18 @@ In Julia, a function is an object that maps a tuple of argument values
 to a return value. Julia functions are not pure mathematical functions,
 in the sense that functions can alter and be affected by the global
 state of the program. The basic syntax for defining functions in Julia
-is::
+is:
+
+.. testcode::
 
     function f(x,y)
       x + y
     end
+
+.. testoutput::
+    :hide:
+
+    f (generic function with 1 method)
 
 There is a second, more terse syntax for defining a function in Julia.
 The traditional function declaration syntax demonstrated above is
@@ -153,7 +160,7 @@ in fact the former is parsed to produce the function call internally.
 This also means that you can assign and pass around operators such as
 ``+`` and ``*`` just like you would with other function values:
 
-.. doctest::
+.. doctest:: f-plus
 
     julia> f = +;
 
@@ -200,7 +207,7 @@ without being given a name:
 .. doctest::
 
     julia> x -> x^2 + 2x - 1
-    #<function>
+    (anonymous function)
 
 This creates an unnamed function taking one argument *x* and returning the
 value of the polynomial *x*\ ^2 + 2\ *x* - 1 at that value. The primary
@@ -212,7 +219,7 @@ array containing the resulting values:
 .. doctest::
 
     julia> map(round, [1.2,3.5,1.7])
-    3-element Float64 Array:
+    3-element Array{Float64,1}:
      1.0
      4.0
      2.0
@@ -226,8 +233,8 @@ function object without needing a name:
 .. doctest::
 
     julia> map(x -> x^2 + 2x - 1, [1,3,-1])
-    3-element Int64 Array:
-     2
+    3-element Array{Int64,1}:
+      2
      14
      -2
 
@@ -245,11 +252,13 @@ In Julia, one returns a tuple of values to simulate returning multiple
 values. However, tuples can be created and destructured without needing
 parentheses, thereby providing an illusion that multiple values are
 being returned, rather than a single tuple value. For example, the
-following function returns a pair of values::
+following function returns a pair of values:
 
-    function foo(a,b)
-      a+b, a*b
-    end
+.. doctest::
+
+    julia> function foo(a,b)
+             a+b, a*b
+           end;
 
 If you call it in an interactive session without assigning the return
 value anywhere, you will see the tuple returned:
@@ -289,9 +298,12 @@ It is often convenient to be able to write functions taking an arbitrary
 number of arguments. Such functions are traditionally known as "varargs"
 functions, which is short for "variable number of arguments". You can
 define a varargs function by following the last argument with an
-ellipsis::
+ellipsis:
 
-    bar(a,b,x...) = (a,b,x)
+.. doctest::
+
+    julia> bar(a,b,x...) = (a,b,x)
+    bar (generic function with 1 method)
 
 The variables ``a`` and ``b`` are bound to the first two argument values
 as usual, and the variable ``x`` is bound to an iterable collection of
@@ -350,7 +362,7 @@ be a tuple:
 .. doctest::
 
     julia> x = [3,4]
-    2-element Int64 Array:
+    2-element Array{Int64,1}:
      3
      4
 
@@ -358,7 +370,7 @@ be a tuple:
     (1,2,(3,4))
 
     julia> x = [1,2,3,4]
-    4-element Int64 Array:
+    4-element Array{Int64,1}:
      1
      2
      3
@@ -373,7 +385,7 @@ function (although it often is)::
     baz(a,b) = a + b
 
     julia> args = [1,2]
-    2-element Int64 Array:
+    2-element Array{Int64,1}:
      1
      2
 
@@ -381,7 +393,7 @@ function (although it often is)::
     3
 
     julia> args = [1,2,3]
-    3-element Int64 Array:
+    3-element Array{Int64,1}:
      1
      2
      3

--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -27,13 +27,17 @@ function definitions are common in Julia. The short function syntax is
 accordingly quite idiomatic, considerably reducing both typing and
 visual noise.
 
-A function is called using the traditional parenthesis syntax::
+A function is called using the traditional parenthesis syntax:
+
+.. doctest::
 
     julia> f(2,3)
     5
 
 Without parentheses, the expression ``f`` refers to the function object,
-and can be passed around like any value::
+and can be passed around like any value:
+
+.. doctest::
 
     julia> g = f;
 
@@ -43,7 +47,9 @@ and can be passed around like any value::
 There are two other ways that functions can be applied: using special
 operator syntax for certain function names (see `Operators Are
 Functions <#operators-are-functions>`_ below), or with the ``apply``
-function::
+function:
+
+.. doctest::
 
     julia> apply(f,2,3)
     5
@@ -132,7 +138,9 @@ like ``&&`` and ``||``. These operators cannot be functions since
 :ref:`short-circuit evaluation <man-short-circuit-evaluation>` requires that
 their operands are not evaluated before evaluation of the operator.
 Accordingly, you can also apply them using parenthesized argument lists,
-just as you would any other function::
+just as you would any other function:
+
+.. doctest::
 
     julia> 1 + 2 + 3
     6
@@ -143,7 +151,9 @@ just as you would any other function::
 The infix form is exactly equivalent to the function application form —
 in fact the former is parsed to produce the function call internally.
 This also means that you can assign and pass around operators such as
-``+`` and ``*`` just like you would with other function values::
+``+`` and ``*`` just like you would with other function values:
+
+.. doctest::
 
     julia> f = +;
 
@@ -185,7 +195,9 @@ Functions in Julia are `first-class objects
 variables, called using the standard function call syntax from the
 variable they have been assigned to. They can be used as arguments, and
 they can be returned as values. They can also be created anonymously,
-without being given a name::
+without being given a name:
+
+.. doctest::
 
     julia> x -> x^2 + 2x - 1
     #<function>
@@ -195,7 +207,9 @@ value of the polynomial *x*\ ^2 + 2\ *x* - 1 at that value. The primary
 use for anonymous functions is passing them to functions which take
 other functions as arguments. A classic example is the ``map`` function,
 which applies a function to each value of an array and returns a new
-array containing the resulting values::
+array containing the resulting values:
+
+.. doctest::
 
     julia> map(round, [1.2,3.5,1.7])
     3-element Float64 Array:
@@ -207,7 +221,9 @@ This is fine if a named function effecting the transform one wants
 already exists to pass as the first argument to ``map``. Often, however,
 a ready-to-use, named function does not exist. In these situations, the
 anonymous function construct allows easy creation of a single-use
-function object without needing a name::
+function object without needing a name:
+
+.. doctest::
 
     julia> map(x -> x^2 + 2x - 1, [1,3,-1])
     3-element Int64 Array:
@@ -236,14 +252,18 @@ following function returns a pair of values::
     end
 
 If you call it in an interactive session without assigning the return
-value anywhere, you will see the tuple returned::
+value anywhere, you will see the tuple returned:
+
+.. doctest::
 
     julia> foo(2,3)
     (5,6)
 
 A typical usage of such a pair of return values, however, extracts each
 value into a variable. Julia supports simple tuple "destructuring" that
-facilitates this::
+facilitates this:
+
+.. doctest::
 
     julia> x, y = foo(2,3);
 
@@ -275,7 +295,9 @@ ellipsis::
 
 The variables ``a`` and ``b`` are bound to the first two argument values
 as usual, and the variable ``x`` is bound to an iterable collection of
-the zero or more values passed to ``bar`` after its first two arguments::
+the zero or more values passed to ``bar`` after its first two arguments:
+
+.. doctest::
 
     julia> bar(1,2)
     (1,2,())
@@ -294,7 +316,9 @@ passed to ``bar``.
 
 On the flip side, it is often handy to "splice" the values contained in
 an iterable collection into a function call as individual arguments. To
-do this, one also uses ``...`` but in the function call instead::
+do this, one also uses ``...`` but in the function call instead:
+
+.. doctest::
 
     julia> x = (3,4)
     (3,4)
@@ -304,7 +328,9 @@ do this, one also uses ``...`` but in the function call instead::
 
 In this case a tuple of values is spliced into a varargs call precisely
 where the variable number of arguments go. This need not be the case,
-however::
+however:
+
+.. doctest::
 
     julia> x = (2,3,4)
     (2,3,4)
@@ -319,7 +345,9 @@ however::
     (1,2,(3,4))
 
 Furthermore, the iterable object spliced into a function call need not
-be a tuple::
+be a tuple:
+
+.. doctest::
 
     julia> x = [3,4]
     2-element Int64 Array:
@@ -380,7 +408,9 @@ expressed concisely as::
 
 With this definition, the function can be called with either one or two
 arguments, and ``10`` is automatically passed when a second argument is not
-specified::
+specified:
+
+.. doctest::
 
     julia> parseint("12",10)
     12

--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -189,19 +189,18 @@ such as integers are given by the ``typemin`` and ``typemax`` functions:
     (-2147483648,2147483647)
 
     julia> for T = {Int8,Int16,Int32,Int64,Int128,Uint8,Uint16,Uint32,Uint64,Uint128}
-             println("$(lpad(T,6)): [$(typemin(T)),$(typemax(T))]")
+             println("$(lpad(T,7)): [$(typemin(T)),$(typemax(T))]")
            end
-
        Int8: [-128,127]
       Int16: [-32768,32767]
       Int32: [-2147483648,2147483647]
       Int64: [-9223372036854775808,9223372036854775807]
      Int128: [-170141183460469231731687303715884105728,170141183460469231731687303715884105727]
-      Uint8: [0x00,0xff]
-     Uint16: [0x0000,0xffff]
-     Uint32: [0x00000000,0xffffffff]
-     Uint64: [0x0000000000000000,0xffffffffffffffff]
-    Uint128: [0x00000000000000000000000000000000,0xffffffffffffffffffffffffffffffff]
+      Uint8: [0,255]
+     Uint16: [0,65535]
+     Uint32: [0,4294967295]
+     Uint64: [0,18446744073709551615]
+    Uint128: [0,340282366920938463463374607431768211455]
 
 The values returned by ``typemin`` and ``typemax`` are always of the
 given argument type. (The above expression uses several features we have
@@ -258,7 +257,7 @@ Literal floating-point numbers are represented in the standard formats:
     -1.23
 
     julia> 1e10
-    1e+10
+    1.0e10
 
     julia> 2.5e-4
     0.00025
@@ -402,7 +401,7 @@ types:
 .. doctest::
 
     julia> (typemin(Float16),typemax(Float16))
-    (Float16(0xfc00),Float16(0x7c00))
+    (-Inf16,Inf16)
 
     julia> (typemin(Float32),typemax(Float32))
     (-Inf32,Inf32)
@@ -425,13 +424,13 @@ and the next larger representable floating-point value:
 .. doctest::
 
     julia> eps(Float32)
-    1.192092896e-07
+    1.1920929f-7
 
     julia> eps(Float64)
-    2.22044604925031308e-16
+    2.220446049250313e-16
 
-    julia> eps() #Same as eps(Float64)
-    2.22044604925031308e-16
+    julia> eps() # same as eps(Float64)
+    2.220446049250313e-16
 
 These values are ``2.0^-23`` and ``2.0^-52`` as ``Float32`` and ``Float64``
 values, respectively. The ``eps`` function can also take a
@@ -444,13 +443,13 @@ than ``x``:
 .. doctest::
 
     julia> eps(1.0)
-    2.22044604925031308e-16
+    2.220446049250313e-16
 
     julia> eps(1000.)
-    1.13686837721616030e-13
+    1.1368683772161603e-13
 
     julia> eps(1e-27)
-    1.79366203433576585e-43
+    1.793662034335766e-43
 
     julia> eps(0.0)
     5.0e-324
@@ -596,7 +595,7 @@ However, type promotion between the primitive types above and
     -9223372036854775809
     
     julia> typeof(y)
-    BigInt
+    BigInt (constructor with 7 methods)
 
 The default precision (in number of bits of the significand) and rounding
 mode of `BigFloat` operations can be changed, and all further calculations 
@@ -617,10 +616,9 @@ will take these changes in account:
     julia> with_bigfloat_precision(40) do
            BigFloat(1) + BigFloat("0.1")
            end
-    1.0999999999985e+00 with 40 bits of precision
+    1.1000000000004e+00 with 40 bits of precision
 
 
-   
 .. _man-numeric-literal-coefficients:
 
 Numeric Literal Coefficients
@@ -675,10 +673,10 @@ imply multiplication:
 .. doctest::
 
     julia> (x-1)(x+1)
-    type error: apply: expected Function, got Int64
+    ERROR: type: apply: expected Function, got Int64
 
     julia> x(x+1)
-    type error: apply: expected Function, got Int64
+    ERROR: type: apply: expected Function, got Int64
 
 Both of these expressions are interpreted as function application: any
 expression that is not a numeric literal, when immediately followed by a
@@ -744,7 +742,5 @@ Examples:
     1
 
     julia> one(BigFloat)
-    1e+00
-    
-
+    1e+00 with 256 bits of precision
 

--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -69,7 +69,9 @@ naturally without explicit casting, thanks to a flexible, user-extensible
 Integers
 --------
 
-Literal integers are represented in the standard manner::
+Literal integers are represented in the standard manner:
+
+.. doctest::
 
     julia> 1
     1
@@ -125,7 +127,9 @@ regardless of the system type::
 
 Unsigned integers are input and output using the ``0x`` prefix and hexadecimal
 (base 16) digits ``0-9a-f`` (the capitalized digits ``A-F`` also work for input).
-The size of the unsigned value is determined by the number of hex digits used::
+The size of the unsigned value is determined by the number of hex digits used:
+
+.. doctest::
 
     julia> 0x1
     0x01
@@ -160,7 +164,9 @@ Recall that the variable ``ans`` is set to the value of the last expression
 evaluated in an interactive session. This does not occur when Julia code is
 run in other ways.
 
-Binary and octal literals are also supported::
+Binary and octal literals are also supported:
+
+.. doctest::
 
     julia> 0b10
     0x02
@@ -175,7 +181,9 @@ Binary and octal literals are also supported::
     Uint8
 
 The minimum and maximum representable values of primitive numeric types
-such as integers are given by the ``typemin`` and ``typemax`` functions::
+such as integers are given by the ``typemin`` and ``typemax`` functions:
+
+.. doctest::
 
     julia> (typemin(Int32), typemax(Int32))
     (-2147483648,2147483647)
@@ -207,7 +215,9 @@ Overflow behavior
 ~~~~~~~~~~~~~~~~~
 
 In Julia, exceeding the maximum representable value of a given type results in
-a wraparound behavior::
+a wraparound behavior:
+
+.. doctest::
 
     julia> x = typemax(Int64)
     9223372036854775807
@@ -228,7 +238,9 @@ in :ref:`man-arbitrary-precision-arithmetic` is recommended instead.
 Floating-Point Numbers
 ----------------------
 
-Literal floating-point numbers are represented in the standard formats::
+Literal floating-point numbers are represented in the standard formats:
+
+.. doctest::
 
     julia> 1.0
     1.0
@@ -252,7 +264,9 @@ Literal floating-point numbers are represented in the standard formats::
     0.00025
 
 The above results are all ``Float64`` values. Literal ``Float32`` values can
-be entered by writing an ``f`` in place of ``e``::
+be entered by writing an ``f`` in place of ``e``:
+
+.. doctest::
 
     julia> 0.5f0
     0.5f0
@@ -263,7 +277,9 @@ be entered by writing an ``f`` in place of ``e``::
     julia> 2.5f-4
     0.00025f0
 
-Values can be converted to ``Float32`` easily::
+Values can be converted to ``Float32`` easily:
+
+.. doctest::
 
     julia> float32(-1.5)
     -1.5f0
@@ -271,7 +287,9 @@ Values can be converted to ``Float32`` easily::
     julia> typeof(ans)
     Float32
 
-Hexadecimal floating-point literals are also valid, but only as ``Float64`` values::
+Hexadecimal floating-point literals are also valid, but only as ``Float64`` values:
+
+.. doctest::
 
     julia> 0x1p0
     1.0
@@ -286,7 +304,9 @@ Hexadecimal floating-point literals are also valid, but only as ``Float64`` valu
     Float64
 
 Half-precision floating-point numbers are also supported (``Float16``), but
-only as a storage format. In calculations they'll be converted to ``Float32``::
+only as a storage format. In calculations they'll be converted to ``Float32``:
+
+.. doctest::
 
     julia> sizeof(float16(4.))
     2
@@ -301,7 +321,9 @@ Floating-point zero
 Floating-point numbers have `two zeros
 <http://en.wikipedia.org/wiki/Signed_zero>`_, positive zero and negative zero.
 They are equal to each other but have different binary representations, as can
-be seen using the ``bits`` function: ::
+be seen using the ``bits`` function: :
+
+.. doctest::
 
     julia> 0.0 == -0.0
     true
@@ -334,7 +356,9 @@ For further discussion of how these non-finite floating-point values are
 ordered with respect to each other and other floats, see
 :ref:`man-numeric-comparisons`. By the
 `IEEE 754 standard <http://en.wikipedia.org/wiki/IEEE_754-2008>`_, these
-floating-point values are the results of certain arithmetic operations::
+floating-point values are the results of certain arithmetic operations:
+
+.. doctest::
 
     julia> 1/Inf
     0.0
@@ -373,7 +397,9 @@ floating-point values are the results of certain arithmetic operations::
     NaN
 
 The ``typemin`` and ``typemax`` functions also apply to floating-point
-types::
+types:
+
+.. doctest::
 
     julia> (typemin(Float16),typemax(Float16))
     (Float16(0xfc00),Float16(0x7c00))
@@ -394,7 +420,9 @@ adjacent representable floating-point numbers, which is often known as
 `machine epsilon <http://en.wikipedia.org/wiki/Machine_epsilon>`_.
 
 Julia provides the ``eps`` function, which gives the distance between ``1.0``
-and the next larger representable floating-point value::
+and the next larger representable floating-point value:
+
+.. doctest::
 
     julia> eps(Float32)
     1.192092896e-07
@@ -411,7 +439,9 @@ floating-point value as an argument, and gives the absolute difference
 between that value and the next representable floating point value. That
 is, ``eps(x)`` yields a value of the same type as ``x`` such that
 ``x + eps(x)`` is the next representable floating-point value larger
-than ``x``::
+than ``x``:
+
+.. doctest::
 
     julia> eps(1.0)
     2.22044604925031308e-16
@@ -434,7 +464,9 @@ from zero. By definition, ``eps(1.0)`` is the same as ``eps(Float64)`` since
 
 Julia also provides the ``nextfloat`` and ``prevfloat`` functions which return
 the next largest or smallest representable floating-point number to the
-argument respectively: ::
+argument respectively: :
+
+.. doctest::
 
     julia> x = 1.25f0
     1.25f0
@@ -524,7 +556,9 @@ integer and floating point numbers respectively.
 
 Constructors exist to create these types from primitive numerical types, or from ``String``. 
 Once created, they participate in arithmetic with all other numeric types thanks to Julia's 
-:ref:`type promotion and conversion mechanism <man-conversion-and-promotion>`. ::
+:ref:`type promotion and conversion mechanism <man-conversion-and-promotion>`. :
+
+.. doctest::
 
     julia> BigInt(typemax(Int64)) + 1
     9223372036854775808
@@ -542,7 +576,9 @@ Once created, they participate in arithmetic with all other numeric types thanks
     815915283247897734345611269596115894272000000000
 
 However, type promotion between the primitive types above and
-`BigInt`/`BigFloat` is not automatic and must be explicitly stated. ::
+`BigInt`/`BigFloat` is not automatic and must be explicitly stated. :
+
+.. doctest::
 
     julia> x = typemin(Int64)
     -9223372036854775808
@@ -564,7 +600,9 @@ However, type promotion between the primitive types above and
 
 The default precision (in number of bits of the significand) and rounding
 mode of `BigFloat` operations can be changed, and all further calculations 
-will take these changes in account::
+will take these changes in account:
+
+.. doctest::
 
     julia> with_bigfloat_rounding(RoundUp) do
            BigFloat(1) + BigFloat("0.1")
@@ -590,7 +628,9 @@ Numeric Literal Coefficients
 
 To make common numeric formulas and expressions clearer, Julia allows
 variables to be immediately preceded by a numeric literal, implying
-multiplication. This makes writing polynomial expressions much cleaner::
+multiplication. This makes writing polynomial expressions much cleaner:
+
+.. doctest::
 
     julia> x = 3
     3
@@ -601,7 +641,9 @@ multiplication. This makes writing polynomial expressions much cleaner::
     julia> 1.5x^2 - .5x + 1
     13.0
 
-It also makes writing exponential functions more elegant::
+It also makes writing exponential functions more elegant:
+
+.. doctest::
 
     julia> 2^2x
     64
@@ -611,20 +653,26 @@ operators such as negation. So ``2^3x`` is parsed as ``2^(3x)``, and
 ``2x^3`` is parsed as ``2*(x^3)``.
 
 Numeric literals also work as coefficients to parenthesized
-expressions::
+expressions:
+
+.. doctest::
 
     julia> 2(x-1)^2 - 3(x-1) + 1
     3
 
 Additionally, parenthesized expressions can be used as coefficients to
-variables, implying multiplication of the expression by the variable::
+variables, implying multiplication of the expression by the variable:
+
+.. doctest::
 
     julia> (x-1)x
     6
 
 Neither juxtaposition of two parenthesized expressions, nor placing a
 variable before a parenthesized expression, however, can be used to
-imply multiplication::
+imply multiplication:
+
+.. doctest::
 
     julia> (x-1)(x+1)
     type error: apply: expected Function, got Int64
@@ -682,7 +730,9 @@ Function     Description
 These functions are useful in :ref:`man-numeric-comparisons` to avoid overhead
 from unnecessary :ref:`type conversion <man-conversion-and-promotion>`.
 
-Examples::
+Examples:
+
+.. doctest::
 
     julia> zero(Float32)
     0.0f0

--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -42,7 +42,9 @@ Julia's promotion system makes arithmetic operations on mixtures of argument
 types "just work" naturally and automatically. See :ref:`man-conversion-and-promotion`
 for details of the promotion system.
 
-Here are some simple examples using arithmetic operators::
+Here are some simple examples using arithmetic operators:
+
+.. doctest::
 
     julia> 1 + 2 + 3
     6
@@ -75,7 +77,9 @@ Expression   Name
 ``x << y``   logical/arithmetic shift left
 ===========  =========================================================================
 
-Here are some examples with bitwise operators::
+Here are some examples with bitwise operators:
+
+.. doctest::
 
     julia> ~123
     -124
@@ -137,7 +141,9 @@ Operator Name
 ``>=``   greater than or equal to
 ======== ========================
 
-Here are some simple examples::
+Here are some simple examples:
+
+.. doctest::
 
     julia> 1 == 1
     true
@@ -183,7 +189,9 @@ standard <http://en.wikipedia.org/wiki/IEEE_754-2008>`_:
 -  ``NaN`` is not equal to, not less than, and not greater than anything,
    including itself.
 
-The last point is potentially surprising and thus worth noting::
+The last point is potentially surprising and thus worth noting:
+
+.. doctest::
 
     julia> NaN == NaN
     false
@@ -197,7 +205,9 @@ The last point is potentially surprising and thus worth noting::
     julia> NaN > NaN
     false
 
-and can cause especial headaches with :ref:`Arrays <man-arrays>`::
+and can cause especial headaches with :ref:`Arrays <man-arrays>`:
+
+.. doctest::
 
     julia> [1 NaN] == [1 NaN]
     false
@@ -214,7 +224,9 @@ Function          Tests if
 ``isnan(x)``      ``x`` is not a number
 ================= ==================================
 
-``isequal`` considers ``NaN``\ s equal to each other::
+``isequal`` considers ``NaN``\ s equal to each other:
+
+.. doctest::
 
     julia> isequal(NaN,NaN)
     true
@@ -225,7 +237,9 @@ Function          Tests if
     julia> isequal(NaN,NaN32)
     false
 
-``isequal`` can also be used to distinguish signed zeros::
+``isequal`` can also be used to distinguish signed zeros:
+
+.. doctest::
 
     julia> -0.0 == 0.0
     true
@@ -242,7 +256,9 @@ Chaining comparisons
 
 Unlike most languages, with the `notable exception of
 Python <http://en.wikipedia.org/wiki/Python_syntax_and_semantics#Comparison_operators>`_,
-comparisons can be arbitrarily chained::
+comparisons can be arbitrarily chained:
+
+.. doctest::
 
     julia> 1 < 2 <= 2 < 3 == 3 > 2 >= 1 == 1 < 3 != 5
     true

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -47,7 +47,9 @@ strings) that makes it easy to create expression objects without
 explicitly constructing ``Expr`` objects. There are two forms: a short
 form for inline expressions using ``:`` followed by a single expression,
 and a long form for blocks of code, enclosed in ``quote ... end``. Here
-is an example of the short form used to quote an arithmetic expression::
+is an example of the short form used to quote an arithmetic expression:
+
+.. doctest::
 
     julia> ex = :(a+b*c+1)
     +(a,*(b,c),1)
@@ -86,7 +88,9 @@ constructed by Julia code can easily have arbitrary run-time values
 without literal forms as args. In this specific example, ``+`` and ``a``
 are symbols, ``*(b,c)`` is a subexpression, and ``1`` is a literal
 64-bit signed integer. Here's an example of the longer expression
-quoting form::
+quoting form:
+
+.. doctest::
 
     julia> quote
          x = 1
@@ -104,7 +108,9 @@ Symbols
 ~~~~~~~
 
 When the argument to ``:`` is just a symbol, a ``Symbol`` object results
-instead of an ``Expr``::
+instead of an ``Expr``:
+
+.. doctest::
 
     julia> :foo
     foo
@@ -118,7 +124,9 @@ the value bound to that symbol in the appropriate :ref:`scope
 <man-variables-and-scoping>`.
 
 Sometimes extra parentheses around the argument to ``:`` are needed to avoid
-ambiguity in parsing.::
+ambiguity in parsing.:
+
+.. doctest::
 
     julia> :(:)
     :(:)
@@ -127,7 +135,9 @@ ambiguity in parsing.::
     :(::)
 
 ``Symbol``\ s can also be created using the ``symbol`` function, which takes
-a character or string as its argument::
+a character or string as its argument:
+
+.. doctest::
 
     julia> symbol('\'')
     :'
@@ -140,7 +150,9 @@ a character or string as its argument::
 
 Given an expression object, one can cause Julia to evaluate (execute) it
 at the *top level* scope — i.e. in effect like loading from a file or
-typing at the interactive prompt — using the ``eval`` function::
+typing at the interactive prompt — using the ``eval`` function:
+
+.. doctest::
 
     julia> :(1 + 2)
     +(1,2)
@@ -161,7 +173,9 @@ typing at the interactive prompt — using the ``eval`` function::
 
 Expressions passed to ``eval`` are not limited to returning values
 — they can also have side-effects that alter the state of the top-level
-evaluation environment::
+evaluation environment:
+
+.. doctest::
 
     julia> ex = :(x = 1)
     x = 1
@@ -181,7 +195,9 @@ assigned to the top-level variable ``x``.
 Since expressions are just ``Expr`` objects which can be constructed
 programmatically and then evaluated, one can, from within Julia code,
 dynamically generate arbitrary code which can then be run using
-``eval``. Here is a simple example::
+``eval``. Here is a simple example:
+
+.. doctest::
 
     julia> a = 1;
 
@@ -214,7 +230,9 @@ tedious and ugly. Since the Julia parser is already excellent at
 producing expression objects, Julia allows "splicing" or interpolation
 of expression objects, prefixed with ``$``, into quoted expressions,
 written using normal syntax. The above example can be written more
-clearly and concisely using interpolation::
+clearly and concisely using interpolation:
+
+.. doctest::
 
     julia> a = 1;
     1
@@ -272,7 +290,9 @@ expression argument given to ``@eval`` can be a block::
     end
 
 Interpolating into an unquoted expression is not supported and will
-cause a compile-time error::
+cause a compile-time error:
+
+.. doctest::
 
     julia> $a + b
     unsupported or misplaced expression $
@@ -317,7 +337,9 @@ macro (see
         :($ex ? nothing : error("Assertion failed: ", $(string(ex))))
     end
 
-This macro can be used like this::
+This macro can be used like this:
+
+.. doctest::
 
     julia> @assert 1==1.0
 

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -52,21 +52,21 @@ is an example of the short form used to quote an arithmetic expression:
 .. doctest::
 
     julia> ex = :(a+b*c+1)
-    +(a,*(b,c),1)
+    :(+(a,*(b,c),1))
 
     julia> typeof(ex)
     Expr
 
     julia> ex.head
-    call
+    :call
 
     julia> typeof(ans)
     Symbol
 
     julia> ex.args
-    4-element Any Array:
-      +        
-      a        
+    4-element Array{Any,1}:
+      :+       
+      :a       
       :(*(b,c))
      1         
 
@@ -93,15 +93,14 @@ quoting form:
 .. doctest::
 
     julia> quote
-         x = 1
-         y = 2
-         x + y
-       end
-
-    begin
-      x = 1
-      y = 2
-      +(x,y)
+             x = 1
+             y = 2
+             x + y
+           end
+    quote  # none, line 2:
+        x = 1 # line 3:
+        y = 2 # line 4:
+        +(x,y)
     end
 
 Symbols
@@ -113,7 +112,7 @@ instead of an ``Expr``:
 .. doctest::
 
     julia> :foo
-    foo
+    :foo
 
     julia> typeof(ans)
     Symbol
@@ -155,16 +154,16 @@ typing at the interactive prompt — using the ``eval`` function:
 .. doctest::
 
     julia> :(1 + 2)
-    +(1,2)
+    :(+(1,2))
 
     julia> eval(ans)
     3
 
     julia> ex = :(a + b)
-    +(a,b)
+    :(+(a,b))
 
     julia> eval(ex)
-    a not defined
+    ERROR: a not defined
 
     julia> a = 1; b = 2;
 
@@ -178,10 +177,10 @@ evaluation environment:
 .. doctest::
 
     julia> ex = :(x = 1)
-    x = 1
+    :(x = 1)
 
     julia> x
-    x not defined
+    ERROR: x not defined
 
     julia> eval(ex)
     1
@@ -235,7 +234,6 @@ clearly and concisely using interpolation:
 .. doctest::
 
     julia> a = 1;
-    1
 
     julia> ex = :($a + b)
     :(+(1,b))
@@ -295,7 +293,7 @@ cause a compile-time error:
 .. doctest::
 
     julia> $a + b
-    unsupported or misplaced expression $
+    ERROR: unsupported or misplaced expression $
 
 .. _man-macros:
 
@@ -344,7 +342,8 @@ This macro can be used like this:
     julia> @assert 1==1.0
 
     julia> @assert 1==0
-    Assertion failed: 1==0
+    ERROR: assertion failed: :((1==0))
+     in error at error.jl:21
 
 Macro calls are expanded so that the above calls are precisely
 equivalent to writing::

--- a/doc/manual/methods.rst
+++ b/doc/manual/methods.rst
@@ -74,9 +74,11 @@ type and count.
 
 When defining a function, one can optionally constrain the types of
 parameters it is applicable to, using the ``::`` type-assertion
-operator, introduced in the section on :ref:`man-composite-types`::
+operator, introduced in the section on :ref:`man-composite-types`:
 
-    f(x::Float64, y::Float64) = 2x + y
+.. doctest::
+
+    julia> f(x::Float64, y::Float64) = 2x + y;
 
 This function definition applies only to calls where ``x`` and ``y`` are
 both values of type ``Float64``:
@@ -92,16 +94,16 @@ error:
 .. doctest::
 
     julia> f(2.0, 3)
-    no method f(Float64,Int64)
+    ERROR: no method f(Float64, Int64)
 
     julia> f(float32(2.0), 3.0)
-    no method f(Float32,Float64)
+    ERROR: no method f(Float32, Float64)
 
     julia> f(2.0, "3.0")
-    no method f(Float64,ASCIIString)
+    ERROR: no method f(Float64, ASCIIString)
 
     julia> f("2.0", "3.0")
-    no method f(ASCIIString,ASCIIString)
+    ERROR: no method f(ASCIIString, ASCIIString)
 
 As you can see, the arguments must be precisely of type ``Float64``.
 Other numeric types, such as integers or 32-bit floating-point values,
@@ -110,9 +112,11 @@ strings parsed as numbers. Because ``Float64`` is a concrete type and
 concrete types cannot be subclassed in Julia, such a definition can only
 be applied to arguments that are exactly of type ``Float64``. It may
 often be useful, however, to write more general methods where the
-declared parameter types are abstract::
+declared parameter types are abstract:
 
-    f(x::Number, y::Number) = 2x - y
+.. doctest::
+
+    julia> f(x::Number, y::Number) = 2x - y;
 
     julia> f(2.0, 3)
     1.0
@@ -164,10 +168,10 @@ function ``f`` remains undefined, and applying it will still result in a
 .. doctest::
 
     julia> f("foo", 3)
-    no method f(ASCIIString,Int64)
+    ERROR: no method f(ASCIIString, Int64)
 
     julia> f()
-    no method f()
+    ERROR: no method f()
 
 You can easily see which methods exist for a function by entering the
 function object itself in an interactive session:
@@ -175,9 +179,7 @@ function object itself in an interactive session:
 .. doctest::
 
     julia> f
-    Methods for generic function f
-    f(Float64,Float64)
-    f(Number,Number)
+    f (generic function with 2 methods)
 
 This output tells us that ``f`` is a function object with two methods:
 one taking two ``Float64`` arguments and one taking arguments of type
@@ -190,7 +192,7 @@ can define a catch-all method for ``f`` like so:
 
 .. doctest::
 
-    julia> f(x,y) = println("Whoa there, Nelly.")
+    julia> f(x,y) = println("Whoa there, Nelly.");
 
     julia> f("foo", 1)
     Whoa there, Nelly.
@@ -207,11 +209,12 @@ Julia language. Core operations typically have dozens of methods:
 
     julia> methods(+)
     # 92 methods for generic function "+":
+    +(x::Bool) at bool.jl:35
     +(x::Bool,y::Bool) at bool.jl:38
-    +(x::Union(Array{Bool,N},SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range1{Int64},Int64,Range{Int64})...,)}),y::Union(Array{Bool,N},SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range1{Int64},Int64,Range{Int64})...,)})) at array.jl:982
-    +{S,T}(A::Union(Array{S,N},SubArray{S,N,A<:Array{T,N},I<:(Union(Range1{Int64},Int64,Range{Int64})...,)}),B::Union(Array{T,N},SubArray{T,N,A<:Array{T,N},I<:(Union(Range1{Int64},Int64,Range{Int64})...,)})) at array.jl:926
-    +{T<:Union(Int16,Int8,Int32)}(x::T<:Union(Int16,Int8,Int32),y::T<:Union(Int16,Int8,Int32)) at int.jl:16
-    +{T<:Union(Uint16,Uint8,Uint32)}(x::T<:Union(Uint16,Uint8,Uint32),y::T<:Union(Uint16,Uint8,Uint32)) at int.jl:20
+    +(x::Union(SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{Bool,N}),y::Union(SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{Bool,N})) at array.jl:992
+    +{S,T}(A::Union(SubArray{S,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{S,N}),B::Union(SubArray{T,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{T,N})) at array.jl:936
+    +{T<:Union(Int32,Int8,Int16)}(x::T<:Union(Int32,Int8,Int16),y::T<:Union(Int32,Int8,Int16)) at int.jl:16
+    +{T<:Union(Uint8,Uint32,Uint16)}(x::T<:Union(Uint8,Uint32,Uint16),y::T<:Union(Uint8,Uint32,Uint16)) at int.jl:20
     +(x::Int64,y::Int64) at int.jl:41
     +(x::Uint64,y::Uint64) at int.jl:42
     +(x::Int128,y::Int128) at int.jl:43
@@ -219,22 +222,25 @@ Julia language. Core operations typically have dozens of methods:
     +(a::Float16,b::Float16) at float.jl:129
     +(x::Float32,y::Float32) at float.jl:131
     +(x::Float64,y::Float64) at float.jl:132
-    +(z::Complex{T<:Real},w::Complex{T<:Real}) at complex.jl:132
-    +(x::Real,z::Complex{T<:Real}) at complex.jl:140
-    +(z::Complex{T<:Real},x::Real) at complex.jl:141
+    +(z::Complex{T<:Real},w::Complex{T<:Real}) at complex.jl:133
+    +(x::Real,z::Complex{T<:Real}) at complex.jl:141
+    +(z::Complex{T<:Real},x::Real) at complex.jl:142
     +(x::Rational{T<:Integer},y::Rational{T<:Integer}) at rational.jl:113
-    +(x::Bool,y::Union(Array{Bool,N},SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range1{Int64},Int64,Range{Int64})...,)})) at array.jl:976
-    +(x::Union(Array{Bool,N},SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range1{Int64},Int64,Range{Int64})...,)}),y::Bool) at array.jl:979
+    +(x::Bool,y::Union(SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{Bool,N})) at array.jl:986
+    +(x::Union(SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{Bool,N}),y::Bool) at array.jl:989
     +(x::Char,y::Char) at char.jl:25
     +(x::Char,y::Integer) at char.jl:30
     +(x::Integer,y::Char) at char.jl:31
-    +(x::BigInt,y::BigInt) at gmp.jl:159
-    +(x::BigInt,c::Uint64) at gmp.jl:195
-    +(c::Uint64,x::BigInt) at gmp.jl:199
-    +(c::Unsigned,x::BigInt) at gmp.jl:200
-    +(x::BigInt,c::Unsigned) at gmp.jl:201
-    +(x::BigInt,c::Signed) at gmp.jl:202
-    +(c::Signed,x::BigInt) at gmp.jl:203
+    +(x::BigInt,y::BigInt) at gmp.jl:160
+    +(a::BigInt,b::BigInt,c::BigInt) at gmp.jl:183
+    +(a::BigInt,b::BigInt,c::BigInt,d::BigInt) at gmp.jl:189
+    +(a::BigInt,b::BigInt,c::BigInt,d::BigInt,e::BigInt) at gmp.jl:196
+    +(x::BigInt,c::Uint64) at gmp.jl:208
+    +(c::Uint64,x::BigInt) at gmp.jl:212
+    +(c::Unsigned,x::BigInt) at gmp.jl:213
+    +(x::BigInt,c::Unsigned) at gmp.jl:214
+    +(x::BigInt,c::Signed) at gmp.jl:215
+    +(c::Signed,x::BigInt) at gmp.jl:216
     +(x::BigFloat,c::Uint64) at mpfr.jl:141
     +(c::Uint64,x::BigFloat) at mpfr.jl:145
     +(c::Unsigned,x::BigFloat) at mpfr.jl:146
@@ -250,48 +256,42 @@ Julia language. Core operations typically have dozens of methods:
     +(x::BigFloat,c::BigInt) at mpfr.jl:171
     +(c::BigInt,x::BigFloat) at mpfr.jl:175
     +(x::BigFloat,y::BigFloat) at mpfr.jl:322
-    +(x::MathConst{sym},y::MathConst{sym}) at constants.jl:28
-    +{T<:Number}(x::T<:Number,y::T<:Number) at promotion.jl:178
-    +(x::Number,y::Number) at promotion.jl:148
-    +(x::Real,r::Range{T<:Real}) at range.jl:282
-    +(x::Real,r::Range1{T<:Real}) at range.jl:283
-    +(r::Ranges{T},x::Real) at range.jl:284
-    +(r1::Ranges{T},r2::Ranges{T}) at range.jl:296
-    +(x::Bool) at bool.jl:35
-    +() at operators.jl:50
-    +(x::Number) at operators.jl:56
-    +(a::BigInt,b::BigInt,c::BigInt) at gmp.jl:170
     +(a::BigFloat,b::BigFloat,c::BigFloat) at mpfr.jl:333
-    +(a,b,c) at operators.jl:67
-    +(a::BigInt,b::BigInt,c::BigInt,d::BigInt) at gmp.jl:176
-    +(a::BigInt,b::BigInt,c::BigInt,d::BigInt,e::BigInt) at gmp.jl:183
     +(a::BigFloat,b::BigFloat,c::BigFloat,d::BigFloat) at mpfr.jl:339
     +(a::BigFloat,b::BigFloat,c::BigFloat,d::BigFloat,e::BigFloat) at mpfr.jl:346
-    +(a,b,c,xs...) at operators.jl:68
-    +(x::Ptr{T},y::Integer) at pointer.jl:59
+    +(x::MathConst{sym},y::MathConst{sym}) at constants.jl:28
+    +{T<:Number}(x::T<:Number,y::T<:Number) at promotion.jl:179
+    +(x::Number,y::Number) at promotion.jl:149
+    +(x::Real,r::Range{T<:Real}) at range.jl:285
+    +(x::Real,r::Range1{T<:Real}) at range.jl:286
+    +(r::Ranges{T},x::Real) at range.jl:287
+    +(r1::Ranges{T},r2::Ranges{T}) at range.jl:299
+    +() at operators.jl:50
     +(x::Integer,y::Ptr{T}) at pointer.jl:61
-    +{T<:Number}(x::AbstractArray{T<:Number,N}) at abstractarray.jl:334
-    +{T}(A::Number,B::Union(Array{T,N},SubArray{T,N,A<:Array{T,N},I<:(Union(Range1{Int64},Int64,Range{Int64})...,)})) at array.jl:937
-    +{T}(A::Union(Array{T,N},SubArray{T,N,A<:Array{T,N},I<:(Union(Range1{Int64},Int64,Range{Int64})...,)}),B::Number) at array.jl:944
-    +{S,T<:Real}(A::Union(Array{S,N},SubArray{S,N,A<:Array{T,N},I<:(Union(Range1{Int64},Int64,Range{Int64})...,)}),B::Ranges{T<:Real}) at array.jl:952
-    +{S<:Real,T}(A::Ranges{S<:Real},B::Union(Array{T,N},SubArray{T,N,A<:Array{T,N},I<:(Union(Range1{Int64},Int64,Range{Int64})...,)})) at array.jl:961
-    +(A::BitArray{N},B::BitArray{N}) at bitarray.jl:1143
-    +(B::BitArray{N},x::Bool) at bitarray.jl:1147
-    +(B::BitArray{N},x::Number) at bitarray.jl:1150
-    +(x::Bool,B::BitArray{N}) at bitarray.jl:1154
-    +(x::Number,B::BitArray{N}) at bitarray.jl:1157
-    +(A::BitArray{N},B::AbstractArray{T,N}) at bitarray.jl:1395
-    +(A::AbstractArray{T,N},B::BitArray{N}) at bitarray.jl:1396
-    +{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti},B::SparseMatrixCSC{Tv,Ti}) at sparse/sparsematrix.jl:409
-    +{TvA,TiA,TvB,TiB}(A::SparseMatrixCSC{TvA,TiA},B::SparseMatrixCSC{TvB,TiB}) at sparse/sparsematrix.jl:401
-    +(A::SparseMatrixCSC{Tv,Ti<:Integer},B::Union(Array{T,N},Number)) at sparse/sparsematrix.jl:503
-    +(A::Union(Array{T,N},Number),B::SparseMatrixCSC{Tv,Ti<:Integer}) at sparse/sparsematrix.jl:504
-    +(A::SymTridiagonal{T<:Union(Complex{Float64},Float32,Float64,Complex{Float32})},B::SymTridiagonal{T<:Union(Complex{Float64},Float32,Float64,Complex{Float32})}) at linalg/tridiag.jl:50
+    +(x::Bool,B::BitArray{N}) at bitarray.jl:1226
+    +(x::Number) at operators.jl:56
+    +(x::Ptr{T},y::Integer) at pointer.jl:59
+    +(A::BitArray{N},B::BitArray{N}) at bitarray.jl:1215
+    +(B::BitArray{N},x::Bool) at bitarray.jl:1219
+    +(B::BitArray{N},x::Number) at bitarray.jl:1222
+    +(A::BitArray{N},B::AbstractArray{T,N}) at bitarray.jl:1467
+    +(A::SparseMatrixCSC{Tv,Ti<:Integer},B::Union(Number,Array{T,N})) at sparse/sparsematrix.jl:503
+    +(A::Union(Number,Array{T,N}),B::SparseMatrixCSC{Tv,Ti<:Integer}) at sparse/sparsematrix.jl:504
+    +(A::SymTridiagonal{T<:Union(Float32,Complex{Float32},Complex{Float64},Float64)},B::SymTridiagonal{T<:Union(Float32,Complex{Float32},Complex{Float64},Float64)}) at linalg/tridiag.jl:50
     +(A::Tridiagonal{T},B::Tridiagonal{T}) at linalg/tridiag.jl:151
-    +(A::Tridiagonal{T},B::SymTridiagonal{T<:Union(Complex{Float64},Float32,Float64,Complex{Float32})}) at linalg/tridiag.jl:164
-    +(A::SymTridiagonal{T<:Union(Complex{Float64},Float32,Float64,Complex{Float32})},B::Tridiagonal{T}) at linalg/tridiag.jl:165
+    +(A::Tridiagonal{T},B::SymTridiagonal{T<:Union(Float32,Complex{Float32},Complex{Float64},Float64)}) at linalg/tridiag.jl:164
+    +(A::SymTridiagonal{T<:Union(Float32,Complex{Float32},Complex{Float64},Float64)},B::Tridiagonal{T}) at linalg/tridiag.jl:165
     +(A::Bidiagonal{T},B::Bidiagonal{T}) at linalg/bidiag.jl:76
     +(Da::Diagonal{T},Db::Diagonal{T}) at linalg/diagonal.jl:28
+    +{T<:Number}(x::AbstractArray{T<:Number,N}) at abstractarray.jl:325
+    +{T}(A::Number,B::Union(SubArray{T,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{T,N})) at array.jl:947
+    +{T}(A::Union(SubArray{T,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{T,N}),B::Number) at array.jl:954
+    +{S,T<:Real}(A::Union(SubArray{S,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{S,N}),B::Ranges{T<:Real}) at array.jl:962
+    +{S<:Real,T}(A::Ranges{S<:Real},B::Union(SubArray{T,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{T,N})) at array.jl:971
+    +(x::Number,B::BitArray{N}) at bitarray.jl:1229
+    +(A::AbstractArray{T,N},B::BitArray{N}) at bitarray.jl:1468
+    +{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti},B::SparseMatrixCSC{Tv,Ti}) at sparse/sparsematrix.jl:409
+    +{TvA,TiA,TvB,TiB}(A::SparseMatrixCSC{TvA,TiA},B::SparseMatrixCSC{TvB,TiB}) at sparse/sparsematrix.jl:401
     +{T}(a::HierarchicalValue{T},b::HierarchicalValue{T}) at pkg/resolve/versionweight.jl:19
     +(a::VWPreBuildItem,b::VWPreBuildItem) at pkg/resolve/versionweight.jl:82
     +(a::VWPreBuild,b::VWPreBuild) at pkg/resolve/versionweight.jl:120
@@ -299,6 +299,8 @@ Julia language. Core operations typically have dozens of methods:
     +(a::FieldValue,b::FieldValue) at pkg/resolve/fieldvalue.jl:41
     +(a::Vec2,b::Vec2) at graphics.jl:62
     +(bb1::BoundingBox,bb2::BoundingBox) at graphics.jl:128
+    +(a,b,c) at operators.jl:67
+    +(a,b,c,xs...) at operators.jl:68
 
 Multiple dispatch together with the flexible parametric type system give
 Julia its ability to abstractly express high-level algorithms decoupled
@@ -314,11 +316,16 @@ arguments:
 
 .. doctest::
 
-    julia> g(x::Float64, y) = 2x + y
+    julia> g(x::Float64, y) = 2x + y;
 
-    julia> g(x, y::Float64) = x + 2y
-    Warning: New definition g(Any,Float64) is ambiguous with g(Float64,Any).
-             To fix, define g(Float64,Float64) before the new definition.
+    julia> g(x, y::Float64) = x + 2y;
+    Warning: New definition 
+        g(Any,Float64) at none:1
+    is ambiguous with: 
+        g(Float64,Any) at none:1.
+    To fix, define 
+        g(Float64,Float64)
+    before the new definition.
 
     julia> g(2.0, 3)
     7.0
@@ -338,11 +345,11 @@ the intersection case:
 
 .. doctest::
 
-    julia> g(x::Float64, y::Float64) = 2x + 2y
+    julia> g(x::Float64, y::Float64) = 2x + 2y;
 
-    julia> g(x::Float64, y) = 2x + y
+    julia> g(x::Float64, y) = 2x + y;
 
-    julia> g(x, y::Float64) = x + 2y
+    julia> g(x, y::Float64) = x + 2y;
 
     julia> g(2.0, 3)
     7.0
@@ -363,10 +370,13 @@ Parametric Methods
 ------------------
 
 Method definitions can optionally have type parameters immediately after
-the method name and before the parameter tuple::
+the method name and before the parameter tuple:
 
-    same_type{T}(x::T, y::T) = true
-    same_type(x,y) = false
+.. doctest::
+
+    julia> same_type{T}(x::T, y::T) = true;
+
+    julia> same_type(x,y) = false;
 
 The first method applies whenever both arguments are of the same
 concrete type, regardless of what type that is, while the second method
@@ -405,22 +415,27 @@ signature:
 .. doctest::
 
     julia> myappend{T}(v::Vector{T}, x::T) = [v..., x]
+    myappend (generic function with 1 method)
 
     julia> myappend([1,2,3],4)
-    4-element Int64 Array:
-    1
-    2
-    3
-    4
+    4-element Array{Int64,1}:
+     1
+     2
+     3
+     4
 
     julia> myappend([1,2,3],2.5)
-    no method myappend(Array{Int64,1},Float64)
+    ERROR: no method myappend(Array{Int64,1}, Float64)
 
     julia> myappend([1.0,2.0,3.0],4.0)
-    [1.0,2.0,3.0,4.0]
+    4-element Array{Float64,1}:
+     1.0
+     2.0
+     3.0
+     4.0
 
     julia> myappend([1.0,2.0,3.0],4)
-    no method myappend(Array{Float64,1},Int64)
+    ERROR: no method myappend(Array{Float64,1}, Int64)
 
 As you can see, the type of the appended element must match the element
 type of the vector it is appended to, or a "no method" error is raised.
@@ -430,6 +445,7 @@ return value:
 .. doctest::
 
     julia> mytypeof{T}(x::T) = T
+    mytypeof (generic function with 1 method)
 
     julia> mytypeof(1)
     Int64
@@ -466,7 +482,7 @@ The ``same_type_numeric`` function behaves much like the ``same_type``
 function defined above, but is only defined for pairs of numbers.
 
 Note on Optional and keyword Arguments
-------------------------------------
+--------------------------------------
 
 As mentioned briefly in :ref:`man-functions`, optional arguments are
 implemented as syntax for multiple method definitions. For example,

--- a/doc/manual/methods.rst
+++ b/doc/manual/methods.rst
@@ -79,13 +79,17 @@ operator, introduced in the section on :ref:`man-composite-types`::
     f(x::Float64, y::Float64) = 2x + y
 
 This function definition applies only to calls where ``x`` and ``y`` are
-both values of type ``Float64``::
+both values of type ``Float64``:
+
+.. doctest::
 
     julia> f(2.0, 3.0)
     7.0
 
 Applying it to any other types of arguments will result in a "no method"
-error::
+error:
+
+.. doctest::
 
     julia> f(2.0, 3)
     no method f(Float64,Int64)
@@ -130,7 +134,9 @@ the behavior for ``f`` over all pairs of instances of the abstract type
 ``Number`` — but with a different behavior specific to pairs of
 ``Float64`` values. If one of the arguments is a 64-bit float but the
 other one is not, then the ``f(Float64,Float64)`` method cannot be
-called and the more general ``f(Number,Number)`` method must be used::
+called and the more general ``f(Number,Number)`` method must be used:
+
+.. doctest::
 
     julia> f(2.0, 3.0)
     7.0
@@ -153,7 +159,9 @@ from magic. [Clarke61]_
 
 For non-numeric values, and for fewer or more than two arguments, the
 function ``f`` remains undefined, and applying it will still result in a
-"no method" error::
+"no method" error:
+
+.. doctest::
 
     julia> f("foo", 3)
     no method f(ASCIIString,Int64)
@@ -162,7 +170,9 @@ function ``f`` remains undefined, and applying it will still result in a
     no method f()
 
 You can easily see which methods exist for a function by entering the
-function object itself in an interactive session::
+function object itself in an interactive session:
+
+.. doctest::
 
     julia> f
     Methods for generic function f
@@ -176,7 +186,9 @@ one taking two ``Float64`` arguments and one taking arguments of type
 In the absence of a type declaration with ``::``, the type of a method
 parameter is ``Any`` by default, meaning that it is unconstrained since
 all values in Julia are instances of the abstract type ``Any``. Thus, we
-can define a catch-all method for ``f`` like so::
+can define a catch-all method for ``f`` like so:
+
+.. doctest::
 
     julia> f(x,y) = println("Whoa there, Nelly.")
 
@@ -189,7 +201,9 @@ pairs of arguments to which no other method definition applies.
 
 Although it seems a simple concept, multiple dispatch on the types of
 values is perhaps the single most powerful and central feature of the
-Julia language. Core operations typically have dozens of methods::
+Julia language. Core operations typically have dozens of methods:
+
+.. doctest::
 
     julia> methods(+)
     # 92 methods for generic function "+":
@@ -296,7 +310,9 @@ Method Ambiguities
 
 It is possible to define a set of function methods such that there is no
 unique most specific method applicable to some combinations of
-arguments::
+arguments:
+
+.. doctest::
 
     julia> g(x::Float64, y) = 2x + y
 
@@ -318,7 +334,9 @@ Here the call ``g(2.0, 3.0)`` could be handled by either the
 more specific than the other. In such cases, Julia warns you about this
 ambiguity, but allows you to proceed, arbitrarily picking a method. You
 should avoid method ambiguities by specifying an appropriate method for
-the intersection case::
+the intersection case:
+
+.. doctest::
 
     julia> g(x::Float64, y::Float64) = 2x + 2y
 
@@ -354,7 +372,9 @@ The first method applies whenever both arguments are of the same
 concrete type, regardless of what type that is, while the second method
 acts as a catch-all, covering all other cases. Thus, overall, this
 defines a boolean function that checks whether its two arguments are of
-the same type::
+the same type:
+
+.. doctest::
 
     julia> same_type(1, 2)
     true
@@ -380,7 +400,9 @@ to being used as the types of parameters: they can be used anywhere a
 value would be in the signature of the function or body of the function.
 Here's an example where the method type parameter ``T`` is used as the
 type parameter to the parametric type ``Vector{T}`` in the method
-signature::
+signature:
+
+.. doctest::
 
     julia> myappend{T}(v::Vector{T}, x::T) = [v..., x]
 
@@ -403,7 +425,9 @@ signature::
 As you can see, the type of the appended element must match the element
 type of the vector it is appended to, or a "no method" error is raised.
 In the following example, the method type parameter ``T`` is used as the
-return value::
+return value:
+
+.. doctest::
 
     julia> mytypeof{T}(x::T) = T
 

--- a/doc/manual/networking-and-streams.rst
+++ b/doc/manual/networking-and-streams.rst
@@ -28,7 +28,7 @@ Note that I pressed enter again so that Julia would read the newline. Now, as yo
 data to be read as the second argument. For example, to read a simply byte array, we could do::
 
     julia> x = zeros(Uint8,4)
-    4-element Uint8 Array:
+    4-element Array{Uint8,1}:
      0x00
      0x00
      0x00
@@ -36,7 +36,7 @@ data to be read as the second argument. For example, to read a simply byte array
 
     julia> read(STDIN,x)
     abcd 
-    4-element Uint8 Array:
+    4-element Array{Uint8,1}:
      0x61
      0x62
      0x63
@@ -47,7 +47,7 @@ above as::
     
     julia> readbytes(STDIN,4)
     abcd 
-    4-element Uint8 Array:
+    4-element Array{Uint8,1}:
      0x61
      0x62
      0x63

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -223,20 +223,24 @@ a normal value:
     ' '
 
     julia> str[end/3]
-    'o'
+    ERROR: InexactError()
+     in getindex at string.jl:58
 
     julia> str[end/4]
-    'l'
+    ERROR: InexactError()
+     in getindex at string.jl:58
 
 Using an index less than 1 or greater than ``end`` raises an error:
 
 .. doctest::
 
     julia> str[0]
-    BoundsError()
+    ERROR: BoundsError()
+     in getindex at ascii.jl:11
 
     julia> str[end+1]
-    BoundsError()
+    ERROR: BoundsError()
+     in getindex at ascii.jl:11
 
 You can also extract a substring using range indexing:
 
@@ -291,10 +295,12 @@ such an invalid byte index, an error is thrown:
     '∀'
 
     julia> s[2]
-    invalid UTF-8 character index
+    ERROR: invalid UTF-8 character index
+     in getindex at utf8.jl:63
 
     julia> s[3]
-    invalid UTF-8 character index
+    ERROR: invalid UTF-8 character index
+     in getindex at utf8.jl:63
 
     julia> s[4]
     ' '
@@ -321,11 +327,11 @@ inefficient and verbose way to iterate through the characters of ``s``:
              end
            end
     ∀
-
+    <BLANKLINE>
     x
-
+    <BLANKLINE>
     ∃
-
+    <BLANKLINE>
     y
 
 The blank lines actually have spaces on them. Fortunately, the above
@@ -339,11 +345,11 @@ exception handling required:
              println(c)
            end
     ∀
-
+    <BLANKLINE>
     x
-
+    <BLANKLINE>
     ∃
-
+    <BLANKLINE>
     y
 
 UTF-8 is not the only encoding that Julia supports, and adding support
@@ -401,13 +407,13 @@ sessions:
 .. doctest::
 
     julia> v = [1,2,3]
-    3-element Int64 Array:
+    3-element Array{Int64,1}:
      1
      2
      3
 
     julia> "v: $v"
-    "v: [1, 2, 3]"
+    "v: 1\n2\n3\n"
 
 The ``string`` function is the identity for ``String`` and ``Char``
 values, so these are interpolated into strings as themselves, unquoted
@@ -536,7 +542,7 @@ any options turned on just uses ``r"..."``:
     r"^\s*(?:#|$)"
 
     julia> typeof(ans)
-    Regex
+    Regex (constructor with 3 methods)
 
 To check if a regex matches a string, use the ``ismatch`` function:
 
@@ -606,7 +612,7 @@ a string is invalid). Here's is a pair of somewhat contrived examples:
     "acd"
 
     julia> m.captures
-    3-element Union(UTF8String,ASCIIString,Nothing) Array:
+    3-element Array{Union(Nothing,SubString{UTF8String}),1}:
      "a"
      "c"
      "d"
@@ -615,7 +621,7 @@ a string is invalid). Here's is a pair of somewhat contrived examples:
     1
 
     julia> m.offsets
-    3-element Int64 Array:
+    3-element Array{Int64,1}:
      1
      2
      3
@@ -627,7 +633,7 @@ a string is invalid). Here's is a pair of somewhat contrived examples:
     "ad"
 
     julia> m.captures
-    3-element Union(UTF8String,ASCIIString,Nothing) Array:
+    3-element Array{Union(Nothing,SubString{UTF8String}),1}:
      "a"
      nothing
      "d"
@@ -636,7 +642,7 @@ a string is invalid). Here's is a pair of somewhat contrived examples:
     1
 
     julia> m.offsets
-    3-element Int64 Array:
+    3-element Array{Int64,1}:
      1
      0
      2
@@ -720,7 +726,15 @@ three:
 .. doctest::
 
     julia> b"DATA\xff\u2200"
-    [68,65,84,65,255,226,136,128]
+    8-element Array{Uint8,1}:
+     0x44
+     0x41
+     0x54
+     0x41
+     0xff
+     0xe2
+     0x88
+     0x80
 
 The ASCII string "DATA" corresponds to the bytes 68, 65, 84, 65.
 ``\xff`` produces the single byte 255. The Unicode escape ``\u2200`` is
@@ -732,7 +746,7 @@ error:
 .. doctest::
 
     julia> "DATA\xff\u2200"
-    syntax error: invalid UTF-8 sequence
+    ERROR: syntax: invalid UTF-8 sequence
 
 Also observe the significant distinction between ``\xff`` and ``\uff``:
 the former escape sequence encodes the *byte 255*, whereas the latter
@@ -742,11 +756,11 @@ bytes in UTF-8:
 .. doctest::
 
     julia> b"\xff"
-    1-element Uint8 Array:
+    1-element Array{Uint8,1}:
      0xff
 
     julia> b"\uff"
-    2-element Uint8 Array:
+    2-element Array{Uint8,1}:
      0xc3
      0xbf
 

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -65,7 +65,9 @@ A ``Char`` value represents a single character: it is just a 32-bit
 integer with a special literal representation and appropriate arithmetic
 behaviors, whose numeric value is interpreted as a `Unicode code
 point <http://en.wikipedia.org/wiki/Code_point>`_. Here is how ``Char``
-values are input and shown::
+values are input and shown:
+
+.. doctest::
 
     julia> 'x'
     'x'
@@ -74,7 +76,9 @@ values are input and shown::
     Char
 
 You can convert a ``Char`` to its integer value, i.e. code point,
-easily::
+easily:
+
+.. doctest::
 
     julia> int('x')
     120
@@ -83,7 +87,9 @@ easily::
     Int64
 
 On 32-bit architectures, ``typeof(ans)`` will be ``Int32``. You can
-convert an integer value back to a ``Char`` just as easily::
+convert an integer value back to a ``Char`` just as easily:
+
+.. doctest::
 
     julia> char(120)
     'x'
@@ -91,7 +97,9 @@ convert an integer value back to a ``Char`` just as easily::
 Not all integer values are valid Unicode code points, but for
 performance, the ``char`` conversion does not check that every character
 value is valid. If you want to check that each converted value is a
-valid code point, use the ``is_valid_char`` function::
+valid code point, use the ``is_valid_char`` function:
+
+.. doctest::
 
     julia> char(0x110000)
     '\U110000'
@@ -107,7 +115,9 @@ be valid Unicode characters.
 
 You can input any Unicode character in single quotes using ``\u``
 followed by up to four hexadecimal digits or ``\U`` followed by up to
-eight hexadecimal digits (the longest valid value only requires six)::
+eight hexadecimal digits (the longest valid value only requires six):
+
+.. doctest::
 
     julia> '\u0'
     '\0'
@@ -126,7 +136,9 @@ characters can be printed as-is and which must be output using the
 generic, escaped ``\u`` or ``\U`` input forms. In addition to these
 Unicode escape forms, all of `C's traditional escaped input
 forms <http://en.wikipedia.org/wiki/C_syntax#Backslash_escapes>`_ can
-also be used::
+also be used:
+
+.. doctest::
 
     julia> int('\0')
     0
@@ -150,7 +162,9 @@ also be used::
     255
 
 You can do comparisons and a limited amount of arithmetic with
-``Char`` values::
+``Char`` values:
+
+.. doctest::
 
     julia> 'A' < 'a'
     true
@@ -170,12 +184,16 @@ You can do comparisons and a limited amount of arithmetic with
 String Basics
 -------------
 
-Here a variable is initialized with a simple string literal::
+Here a variable is initialized with a simple string literal:
+
+.. doctest::
 
     julia> str = "Hello, world.\n"
     "Hello, world.\n"
 
-If you want to extract a character from a string, you index into it::
+If you want to extract a character from a string, you index into it:
+
+.. doctest::
 
     julia> str[1]
     'H'
@@ -194,7 +212,9 @@ a length of ``n``.
 In any indexing expression, the keyword ``end`` can be used as a
 shorthand for the last index (computed by ``endof(str)``).
 You can perform arithmetic and other operations with ``end``, just like
-a normal value::
+a normal value:
+
+.. doctest::
 
     julia> str[end-1]
     '.'
@@ -208,7 +228,9 @@ a normal value::
     julia> str[end/4]
     'l'
 
-Using an index less than 1 or greater than ``end`` raises an error::
+Using an index less than 1 or greater than ``end`` raises an error:
+
+.. doctest::
 
     julia> str[0]
     BoundsError()
@@ -216,12 +238,16 @@ Using an index less than 1 or greater than ``end`` raises an error::
     julia> str[end+1]
     BoundsError()
 
-You can also extract a substring using range indexing::
+You can also extract a substring using range indexing:
+
+.. doctest::
 
     julia> str[4:9]
     "lo, wo"
 
-Note the distinction between ``str[k]`` and ``str[k:k]``::
+Note the distinction between ``str[k]`` and ``str[k:k]``:
+
+.. doctest::
 
     julia> str[6]
     ','
@@ -240,7 +266,9 @@ Julia fully supports Unicode characters and strings. As `discussed
 above <#characters>`_, in character literals, Unicode code points can be
 represented using Unicode ``\u`` and ``\U`` escape sequences, as well as
 all the standard C escape sequences. These can likewise be used to write
-string literals::
+string literals:
+
+.. doctest::
 
     julia> s = "\u2200 x \u2203 y"
     "∀ x ∃ y"
@@ -255,7 +283,9 @@ encoded as they are in ASCII, using a single byte, while code points
 0x80 and above are encoded using multiple bytes — up to four per
 character. This means that not every byte index into a UTF-8 string is
 necessarily a valid index for a character. If you index into a string at
-such an invalid byte index, an error is thrown::
+such an invalid byte index, an error is thrown:
+
+.. doctest::
 
     julia> s[1]
     '∀'
@@ -279,7 +309,9 @@ into ``s``, the sequence of characters returned, when errors aren't
 thrown, is the sequence of characters comprising the string ``s``.
 Thus, we do have the identity that ``length(s) <= endof(s)`` since each
 character in a string must have its own index. The following is an
-inefficient and verbose way to iterate through the characters of ``s``::
+inefficient and verbose way to iterate through the characters of ``s``:
+
+.. doctest::
 
     julia> for i = 1:endof(s)
              try
@@ -299,7 +331,9 @@ inefficient and verbose way to iterate through the characters of ``s``::
 The blank lines actually have spaces on them. Fortunately, the above
 awkward idiom is unnecessary for iterating through the characters in a
 string, since you can just use the string as an iterable object, no
-exception handling required::
+exception handling required:
+
+.. doctest::
 
     julia> for c in s
              println(c)
@@ -324,7 +358,9 @@ which goes into some greater detail.
 Interpolation
 -------------
 
-One of the most common and useful string operations is concatenation::
+One of the most common and useful string operations is concatenation:
+
+.. doctest::
 
     julia> greet = "Hello"
     "Hello"
@@ -337,7 +373,9 @@ One of the most common and useful string operations is concatenation::
 
 Constructing strings like this can become a bit cumbersome, however. To
 reduce the need for these verbose calls to ``string``, Julia allows
-interpolation into string literals using ``$``, as in Perl::
+interpolation into string literals using ``$``, as in Perl:
+
+.. doctest::
 
     julia> "$greet, $whom.\n"
     "Hello, world.\n"
@@ -348,7 +386,9 @@ into a concatenation of string literals with variables.
 
 The shortest complete expression after the ``$`` is taken as the
 expression whose value is to be interpolated into the string. Thus, you
-can interpolate any expression into a string using parentheses::
+can interpolate any expression into a string using parentheses:
+
+.. doctest::
 
     julia> "1 + 2 = $(1 + 2)"
     "1 + 2 = 3"
@@ -356,7 +396,9 @@ can interpolate any expression into a string using parentheses::
 Both concatenation and string interpolation call the generic ``string``
 function to convert objects into ``String`` form. Most non-``String``
 objects are converted to strings as they are shown in interactive
-sessions::
+sessions:
+
+.. doctest::
 
     julia> v = [1,2,3]
     3-element Int64 Array:
@@ -369,7 +411,9 @@ sessions::
 
 The ``string`` function is the identity for ``String`` and ``Char``
 values, so these are interpolated into strings as themselves, unquoted
-and unescaped::
+and unescaped:
+
+.. doctest::
 
     julia> c = 'x'
     'x'
@@ -378,7 +422,9 @@ and unescaped::
     "hi, x"
 
 To include a literal ``$`` in a string literal, escape it with a
-backslash::
+backslash:
+
+.. doctest::
 
     julia> print("I have \$100 in my account.\n")
     I have $100 in my account.
@@ -387,7 +433,9 @@ Common Operations
 -----------------
 
 You can lexicographically compare strings using the standard comparison
-operators::
+operators:
+
+.. doctest::
 
     julia> "abracadabra" < "xylophone"
     true
@@ -402,7 +450,9 @@ operators::
     true
 
 You can search for the index of a particular character using the
-``search`` function::
+``search`` function:
+
+.. doctest::
 
     julia> search("xylophone", 'x')
     1
@@ -414,7 +464,9 @@ You can search for the index of a particular character using the
     0
 
 You can start the search for a character at a given offset by providing
-a third argument::
+a third argument:
+
+.. doctest::
 
     julia> search("xylophone", 'o')
     4
@@ -425,7 +477,9 @@ a third argument::
     julia> search("xylophone", 'o', 8)
     0
 
-Another handy string function is ``repeat``::
+Another handy string function is ``repeat``:
+
+.. doctest::
 
     julia> repeat(".:Z:.", 10)
     ".:Z:..:Z:..:Z:..:Z:..:Z:..:Z:..:Z:..:Z:..:Z:..:Z:."
@@ -474,7 +528,9 @@ which are parsed into a state machine that can be used to efficiently
 search for patterns in strings. In Julia, regular expressions are input
 using non-standard string literals prefixed with various identifiers
 beginning with ``r``. The most basic regular expression literal without
-any options turned on just uses ``r"..."``::
+any options turned on just uses ``r"..."``:
+
+.. doctest::
 
     julia> r"^\s*(?:#|$)"
     r"^\s*(?:#|$)"
@@ -482,7 +538,9 @@ any options turned on just uses ``r"..."``::
     julia> typeof(ans)
     Regex
 
-To check if a regex matches a string, use the ``ismatch`` function::
+To check if a regex matches a string, use the ``ismatch`` function:
+
+.. doctest::
 
     julia> ismatch(r"^\s*(?:#|$)", "not a comment")
     false
@@ -494,7 +552,9 @@ As one can see here, ``ismatch`` simply returns true or false,
 indicating whether the given regex matches the string or not. Commonly,
 however, one wants to know not just whether a string matched, but also
 *how* it matched. To capture this information about a match, use the
-``match`` function instead::
+``match`` function instead:
+
+.. doctest::
 
     julia> match(r"^\s*(?:#|$)", "not a comment")
 
@@ -518,7 +578,9 @@ If a regular expression does match, the value returned by ``match`` is a
 including the substring that the pattern matches and any captured
 substrings, if there are any. This example only captures the portion of
 the substring that matches, but perhaps we want to capture any non-blank
-text after the comment character. We could do the following::
+text after the comment character. We could do the following:
+
+.. doctest::
 
     julia> m = match(r"^\s*(?:#\s*(.*?)\s*$|$)", "# a comment ")
     RegexMatch("# a comment ", 1="a comment")
@@ -533,7 +595,9 @@ You can extract the following info from a ``RegexMatch`` object:
 For when a capture doesn't match, instead of a substring, ``m.captures``
 contains ``nothing`` in that position, and ``m.offsets`` has a zero
 offset (recall that indices in Julia are 1-based, so a zero offset into
-a string is invalid). Here's is a pair of somewhat contrived examples::
+a string is invalid). Here's is a pair of somewhat contrived examples:
+
+.. doctest::
 
     julia> m = match(r"(a|b)(c)?(d)", "acd")
     RegexMatch("acd", 1="a", 2="c", 3="d")
@@ -578,7 +642,9 @@ a string is invalid). Here's is a pair of somewhat contrived examples::
      2
 
 It is convenient to have captures returned as a tuple so that one can
-use tuple destructuring syntax to bind them to local variables::
+use tuple destructuring syntax to bind them to local variables:
+
+.. doctest::
 
     julia> first, second, third = m.captures; first
     "a"
@@ -617,7 +683,9 @@ manpage <http://perldoc.perl.org/perlre.html#Modifiers>`_::
         treated as a metacharacter introducing a comment, just as in
         ordinary code.
 
-For example, the following regex has all three flags turned on::
+For example, the following regex has all three flags turned on:
+
+.. doctest::
 
     julia> r"a+.*b+.*?d$"ism
     r"a+.*b+.*?d$"ims
@@ -647,7 +715,9 @@ and octal escapes less than 0x80 (128) are covered by both of the first
 two rules, but here these rules agree. Together, these rules allow one
 to easily use ASCII characters, arbitrary byte values, and UTF-8
 sequences to produce arrays of bytes. Here is an example using all
-three::
+three:
+
+.. doctest::
 
     julia> b"DATA\xff\u2200"
     [68,65,84,65,255,226,136,128]
@@ -657,7 +727,9 @@ The ASCII string "DATA" corresponds to the bytes 68, 65, 84, 65.
 encoded in UTF-8 as the three bytes 226, 136, 128. Note that the
 resulting byte array does not correspond to a valid UTF-8 string — if
 you try to use this as a regular string literal, you will get a syntax
-error::
+error:
+
+.. doctest::
 
     julia> "DATA\xff\u2200"
     syntax error: invalid UTF-8 sequence
@@ -665,7 +737,9 @@ error::
 Also observe the significant distinction between ``\xff`` and ``\uff``:
 the former escape sequence encodes the *byte 255*, whereas the latter
 escape sequence represents the *code point 255*, which is encoded as two
-bytes in UTF-8::
+bytes in UTF-8:
+
+.. doctest::
 
     julia> b"\xff"
     1-element Uint8 Array:

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -91,7 +91,9 @@ implementation — recall that all concrete types are final, so no
 implementation is a subtype of any other. When the type is abstract, it
 suffices for the value to be implemented by a concrete type that is a
 subtype of the abstract type. If the type assertion is not true, an
-exception is thrown, otherwise, the left-hand value is returned::
+exception is thrown, otherwise, the left-hand value is returned:
+
+.. doctest::
 
     julia> (1+2)::FloatingPoint
     ERROR: type: typeassert: expected FloatingPoint, got Int64
@@ -105,7 +107,9 @@ When attached to a variable, the ``::`` operator means something a bit
 different: it declares the variable to always have the specified type,
 like a type declaration in a statically-typed language such as C. Every
 value assigned to the variable will be converted to the declared type
-using the ``convert`` function::
+using the ``convert`` function:
+
+.. doctest::
 
     julia> function foo()
              x::Int8 = 1000
@@ -208,7 +212,9 @@ The ``<:`` operator in general means "is a subtype of", and, used in
 declarations like this, declares the right-hand type to be an immediate
 supertype of the newly declared type. It can also be used in expressions
 as a subtype operator which returns ``true`` when its left operand is a
-subtype of its right operand::
+subtype of its right operand:
+
+.. doctest::
 
     julia> Integer <: Number
     true
@@ -323,7 +329,9 @@ Fields with no type annotation default to ``Any``, and can accordingly
 hold any type of value.
 
 New objects of composite type ``Foo`` are created by applying the
-``Foo`` type object like a function to values for its fields::
+``Foo`` type object like a function to values for its fields:
+
+.. doctest::
 
     julia> foo = Foo("Hello, world.", 23, 1.5)
     Foo("Hello, world.",23,1.5)
@@ -335,13 +343,17 @@ Since the ``bar`` field is unconstrained in type, any value will do; the
 value for ``baz`` must be an ``Int`` and ``qux`` must be a ``Float64``.
 The signature of the default constructor is taken directly from the
 field type declarations ``(Any,Int,Float64)``, so arguments must match
-this implied type signature::
+this implied type signature:
+
+.. doctest::
 
     julia> Foo((), 23.5, 1)
     no method Foo((),Float64,Int64)
 
 You can access the field values of a composite object using the
-traditional ``foo.bar`` notation::
+traditional ``foo.bar`` notation:
+
+.. doctest::
 
     julia> foo.bar
     "Hello, world."
@@ -352,7 +364,9 @@ traditional ``foo.bar`` notation::
     julia> foo.qux
     1.5
 
-You can also change the values as one would expect::
+You can also change the values as one would expect:
+
+.. doctest::
 
     julia> foo.qux = 2
     2.0
@@ -430,7 +444,9 @@ are actually all closely related. They share the same key properties:
 
 Because of these shared properties, these types are internally
 represented as instances of the same concept, ``DataType``, which
-is the type of any of these types::
+is the type of any of these types:
+
+.. doctest::
 
     julia> typeof(Real)
     DataType
@@ -453,12 +469,16 @@ Tuple Types
 Tuples are an abstraction of the arguments of a function — without the
 function itself. The salient aspects of a function's arguments are their
 order and their types. The type of a tuple of values is the tuple of
-types of values::
+types of values:
+
+.. doctest::
 
     julia> typeof((1,"foo",2.5))
     (Int64,ASCIIString,Float64)
 
-Accordingly, a tuple of types can be used anywhere a type is expected::
+Accordingly, a tuple of types can be used anywhere a type is expected:
+
+.. doctest::
 
     julia> (1,"foo",2.5) :: (Int64,String,Any)
     (1,"foo",2.5)
@@ -467,12 +487,16 @@ Accordingly, a tuple of types can be used anywhere a type is expected::
     ERROR: type: typeassert: expected (Int64,String,Float32), got (Int64,ASCIIString,Float64)
 
 If one of the components of the tuple is not a type, however, you will
-get an error::
+get an error:
+
+.. doctest::
 
     julia> (1,"foo",2.5) :: (Int64,String,3)
     ERROR: type: typeassert: expected Type{T<:Top}, got (DataType,DataType,Int64)
 
-Note that the empty tuple ``()`` is its own type::
+Note that the empty tuple ``()`` is its own type:
+
+.. doctest::
 
     julia> typeof(())
     ()
@@ -480,7 +504,9 @@ Note that the empty tuple ``()`` is its own type::
 Tuple types are *covariant* in their constituent types, which means
 that one tuple type is a subtype of another if elements of the first
 are subtypes of the corresponding elements of the second. For
-example::
+example:
+
+.. doctest::
 
     julia> (Int,String) <: (Real,Any)
     true
@@ -499,7 +525,9 @@ Type Unions
 
 A type union is a special abstract type which includes as objects all
 instances of any of its argument types, constructed using the special
-``Union`` function::
+``Union`` function:
+
+.. doctest::
 
     julia> IntOrString = Union(Int,String)
     Union(Int,String)
@@ -515,7 +543,9 @@ instances of any of its argument types, constructed using the special
 
 The compilers for many languages have an internal union construct for
 reasoning about types; Julia simply exposes it to the programmer. The
-union of no types is the "bottom" type, ``None``::
+union of no types is the "bottom" type, ``None``:
+
+.. doctest::
 
     julia> Union()
     None
@@ -576,7 +606,9 @@ type). ``Point{Float64}`` is a concrete type equivalent to the type
 defined by replacing ``T`` in the definition of ``Point`` with
 ``Float64``. Thus, this single declaration actually declares an
 unlimited number of types: ``Point{Float64}``, ``Point{String}``,
-``Point{Int64}``, etc. Each of these is now a usable concrete type::
+``Point{Int64}``, etc. Each of these is now a usable concrete type:
+
+.. doctest::
 
     julia> Point{Float64}
     Point{Float64}
@@ -587,7 +619,9 @@ unlimited number of types: ``Point{Float64}``, ``Point{String}``,
 The type ``Point{Float64}`` is a point whose coordinates are 64-bit
 floating-point values, while the type ``Point{String}`` is a "point"
 whose "coordinates" are string objects (see :ref:`man-strings`).
-However, ``Point`` itself is also a valid type object::
+However, ``Point`` itself is also a valid type object:
+
+.. doctest::
 
     julia> Point
     Point{T}
@@ -595,7 +629,9 @@ However, ``Point`` itself is also a valid type object::
 Here the ``T`` is the dummy type symbol used in the original declaration
 of ``Point``. What does ``Point`` by itself mean? It is an abstract type
 that contains all the specific instances ``Point{Float64}``,
-``Point{String}``, etc.::
+``Point{String}``, etc.:
+
+.. doctest::
 
     julia> Point{Float64} <: Point
     true
@@ -603,7 +639,9 @@ that contains all the specific instances ``Point{Float64}``,
     julia> Point{String} <: Point
     true
 
-Other types, of course, are not subtypes of it::
+Other types, of course, are not subtypes of it:
+
+.. doctest::
 
     julia> Float64 <: Point
     false
@@ -612,7 +650,9 @@ Other types, of course, are not subtypes of it::
     false
 
 Concrete ``Point`` types with different values of ``T`` are never
-subtypes of each other::
+subtypes of each other:
+
+.. doctest::
 
     julia> Point{Float64} <: Point{Int64}
     false
@@ -659,7 +699,9 @@ object constructor.
 
 Since the type ``Point{Float64}`` is a concrete type equivalent to
 ``Point`` declared with ``Float64`` in place of ``T``, it can be applied
-as a constructor accordingly::
+as a constructor accordingly:
+
+.. doctest::
 
     julia> Point{Float64}(1.0,2.0)
     Point(1.0,2.0)
@@ -668,7 +710,9 @@ as a constructor accordingly::
     Point{Float64}
 
 For the default constructor, exactly one argument must be supplied for
-each field::
+each field:
+
+.. doctest::
 
     julia> Point{Float64}(1.0)
     no method Point(Float64,)
@@ -684,7 +728,9 @@ In many cases, it is redundant to provide the type of ``Point`` object
 one wants to construct, since the types of arguments to the constructor
 call already implicitly provide type information. For that reason, you
 can also apply ``Point`` itself as a constructor, provided that the
-implied value of the parameter type ``T`` is unambiguous::
+implied value of the parameter type ``T`` is unambiguous:
+
+.. doctest::
 
     julia> Point(1.0,2.0)
     Point(1.0,2.0)
@@ -700,7 +746,9 @@ implied value of the parameter type ``T`` is unambiguous::
 
 In the case of ``Point``, the type of ``T`` is unambiguously implied if
 and only if the two arguments to ``Point`` have the same type. When this
-isn't the case, the constructor will fail with a no method error::
+isn't the case, the constructor will fail with a no method error:
+
+.. doctest::
 
     julia> Point(1,2.5)
     no method Point(Int64,Float64)
@@ -719,7 +767,9 @@ types, in much the same way::
 
 With this declaration, ``Pointy{T}`` is a distinct abstract type for
 each type or integer value of ``T``. As with parametric composite types,
-each such instance is a subtype of ``Pointy``::
+each such instance is a subtype of ``Pointy``:
+
+.. doctest::
 
     julia> Pointy{Int64} <: Pointy
     true
@@ -728,7 +778,9 @@ each such instance is a subtype of ``Pointy``::
     true
 
 Parametric abstract types are invariant, much as parametric composite
-types are::
+types are:
+
+.. doctest::
 
     julia> Pointy{Float64} <: Pointy{Real}
     false
@@ -748,7 +800,9 @@ follows::
     end
 
 Given such a declaration, for each choice of ``T``, we have ``Point{T}``
-as a subtype of ``Pointy{T}``::
+as a subtype of ``Pointy{T}``:
+
+.. doctest::
 
     julia> Point{Float64} <: Pointy{Float64}
     true
@@ -759,7 +813,9 @@ as a subtype of ``Pointy{T}``::
     julia> Point{String} <: Pointy{String}
     true
 
-This relationship is also invariant::
+This relationship is also invariant:
+
+.. doctest::
 
     julia> Point{Float64} <: Pointy{Real}
     false
@@ -788,7 +844,9 @@ constrain the range of ``T`` like so::
 
 With such a declaration, it is acceptable to use any type that is a
 subtype of ``Real`` in place of ``T``, but not types that are not
-subtypes of ``Real``::
+subtypes of ``Real``:
+
+.. doctest::
 
     julia> Pointy{Float64}
     Pointy{Float64}
@@ -834,7 +892,9 @@ There is a special kind of abstract parametric type that must be
 mentioned here: singleton types. For each type, ``T``, the "singleton
 type" ``Type{T}`` is an abstract type whose only instance is the object
 ``T``. Since the definition is a little difficult to parse, let's look
-at some examples::
+at some examples:
+
+.. doctest::
 
     julia> isa(Float64, Type{Float64})
     true
@@ -851,7 +911,9 @@ at some examples::
 In other words, ``isa(A,Type{B})`` is true if and only if ``A`` and
 ``B`` are the same object and that object is a type. Without the
 parameter, ``Type`` is simply an abstract type which has all type
-objects as its instances, including, of course, singleton types::
+objects as its instances, including, of course, singleton types:
+
+.. doctest::
 
     julia> isa(Type{Float64},Type)
     true
@@ -862,7 +924,9 @@ objects as its instances, including, of course, singleton types::
     julia> isa(Real,Type)
     true
 
-Any object that is not a type is not an instance of ``Type``::
+Any object that is not a type is not an instance of ``Type``:
+
+.. doctest::
 
     julia> isa(1,Type)
     false
@@ -905,7 +969,9 @@ essentially defining an entire family of types with identical structure,
 differentiated only by their type parameter. Thus, ``Ptr{Float64}`` and
 ``Ptr{Int64}`` are distinct types, even though they have identical
 representations. And of course, all specific pointer types are subtype
-of the umbrella ``Ptr`` type::
+of the umbrella ``Ptr`` type:
+
+.. doctest::
 
     julia> Ptr{Float64} <: Ptr
     true
@@ -945,7 +1011,9 @@ names for cases where some of the parameter choices are fixed.
 Julia's arrays have type ``Array{T,N}`` where ``T`` is the element type
 and ``N`` is the number of array dimensions. For convenience, writing
 ``Array{Float64}`` allows one to specify the element type without
-specifying the dimension::
+specifying the dimension:
+
+.. doctest::
 
     julia> Array{Float64,1} <: Array{Float64} <: Array
     true
@@ -977,7 +1045,9 @@ operator, which indicates whether its left hand operand is a subtype of
 its right hand operand.
 
 The ``isa`` function tests if an object is of a given type and returns
-true or false::
+true or false:
+
+.. doctest::
 
     julia> isa(1,Int)
     true
@@ -987,7 +1057,9 @@ true or false::
 
 The ``typeof`` function, already used throughout the manual in examples,
 returns the type of its argument. Since, as noted above, types are
-objects, they also have types, and we can ask what their types are::
+objects, they also have types, and we can ask what their types are:
+
+.. doctest::
 
     julia> typeof(Rational)
     DataType
@@ -1000,7 +1072,9 @@ objects, they also have types, and we can ask what their types are::
 
 What if we repeat the process? What is the type of a type of a type?
 As it happens, types are all composite values and thus all have a type of
-``DataType``::
+``DataType``:
+
+.. doctest::
 
     julia> typeof(DataType)
     DataType
@@ -1012,7 +1086,9 @@ The reader may note that ``DataType`` shares with the empty tuple
 (see `above <#tuple-types>`_), the distinction of being its own type
 (i.e. a fixed point of the ``typeof`` function). This leaves any number
 of tuple types recursively built with ``()`` and ``DataType`` as
-their only atomic values, which are their own type::
+their only atomic values, which are their own type:
+
+.. doctest::
 
     julia> typeof(())
     ()
@@ -1033,7 +1109,9 @@ All fixed points of the ``typeof`` function are like this.
 
 Another operation that applies to some types is ``super``, which
 reveals a type's supertype.
-Only declared types (``DataType``) have unambiguous supertypes::
+Only declared types (``DataType``) have unambiguous supertypes:
+
+.. doctest::
 
     julia> super(Float64)
     FloatingPoint
@@ -1048,7 +1126,9 @@ Only declared types (``DataType``) have unambiguous supertypes::
     Any
 
 If you apply ``super`` to other type objects (or non-type objects), a
-"no method" error is raised::
+"no method" error is raised:
+
+.. doctest::
 
     julia> super(Union(Float64,Int64))
     no method super(UnionType,)

--- a/doc/manual/variables-and-scoping.rst
+++ b/doc/manual/variables-and-scoping.rst
@@ -149,7 +149,7 @@ global scope. This is especially evident in the case of assignments:
     julia> for i = 1:1; y = 10; end
 
     julia> y
-    y not defined
+    ERROR: y not defined
 
     julia> y = 0
     0
@@ -231,7 +231,7 @@ block without creating any new bindings:
              end
              x
            end
-    syntax error: local x declared twice
+    ERROR: syntax: local "x" declared twice
 
     julia> begin
              local x = 1

--- a/doc/manual/variables-and-scoping.rst
+++ b/doc/manual/variables-and-scoping.rst
@@ -142,7 +142,9 @@ declarations is necessary, and definitions can be ordered arbitrarily.
 At the interactive prompt, variable scope works the same way as anywhere
 else. The prompt behaves as if there is scope block wrapped around
 everything you type, except that this scope block is identified with the
-global scope. This is especially evident in the case of assignments::
+global scope. This is especially evident in the case of assignments:
+
+.. doctest::
 
     julia> for i = 1:1; y = 10; end
 
@@ -218,7 +220,9 @@ behave identically. We can use ``let`` to create a new binding for
 
 Since the ``begin`` construct does not introduce a new scope, it can be
 useful to use a zero-argument ``let`` to just introduce a new scope
-block without creating any new bindings::
+block without creating any new bindings:
+
+.. doctest::
 
     julia> begin
              local x = 1

--- a/doc/manual/variables.rst
+++ b/doc/manual/variables.rst
@@ -50,7 +50,9 @@ Unicode names (in UTF-8 encoding) are allowed:
 
     \end{CJK*}
 
-Julia will even let you redefine built-in constants and functions if needed::
+Julia will even let you redefine built-in constants and functions if needed:
+
+.. doctest::
 
     julia> pi
     π = 3.1415926535897...
@@ -79,7 +81,9 @@ contexts operators can be used just like variables; for example ``(+)`` refers
 to the addition function, and ``(+) = f`` will reassign it.
 
 The only explicitly disallowed names for variables are the names of built-in
-statements::
+statements:
+
+.. doctest::
 
     julia> else = false
     ERROR: syntax: unexpected else

--- a/doc/manual/variables.rst
+++ b/doc/manual/variables.rst
@@ -86,10 +86,10 @@ statements:
 .. doctest::
 
     julia> else = false
-    ERROR: syntax: unexpected else
+    ERROR: syntax: unexpected "else"
     
     julia> try = "No"
-    ERROR: syntax: unexpected =
+    ERROR: syntax: unexpected "="
 
 
 Stylistic Conventions


### PR DESCRIPTION
I've modified [sphinx's doc testing extension](http://sphinx-doc.org/ext/doctest.html) to work with julia.

```
$ cat doc/manual/complex-and-rational-numbers.rst
...

.. doctest::

    julia> 1 + 2//3im
    1//1 + 2//3im

...
$ make -C doc doctest
...
**********************************************************************
File "manual/complex-and-rational-numbers.rst", line 326, in default
Failed example:
    1 + 2//3im
Expected:
    1//1 + 2//3im
Got:
    1//1 - 2//3im
**********************************************************************
...
```

Output is also saved to `_build/doctest/output.txt`.

Almost all the errors found so far are trivial formatting or wording changes, but here are (all?) the less trivial ones:
- https://github.com/JuliaLang/julia/commit/b995da566412b3a8f56fce282f4324e42c425577#diff-13afb6acee031f3512ddc8e67a82d94eL515
- https://github.com/JuliaLang/julia/commit/b995da566412b3a8f56fce282f4324e42c425577#diff-7e34a64cb7b5cc70c65971108b1e4969L323
- https://github.com/JuliaLang/julia/commit/b995da566412b3a8f56fce282f4324e42c425577#diff-13afb6acee031f3512ddc8e67a82d94eL515
- https://github.com/JuliaLang/julia/commit/b995da566412b3a8f56fce282f4324e42c425577#diff-076252d2677e65b4c3032a7c77e2c0eeL225
