### PR TITLE
checked-ops-gate: re-enable 128-bit ops & tests less than 128 bits.

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -576,14 +576,14 @@ end
 
 ## checked +, - and *
 
-for T in (Int8,Int16,Int32,Int64)
+for T in (Int8,Int16,Int32,Int64)#,Int128)
     @eval begin
         checked_add(x::$T, y::$T) = box($T,checked_sadd(unbox($T,x),unbox($T,y)))
         checked_sub(x::$T, y::$T) = box($T,checked_ssub(unbox($T,x),unbox($T,y)))
         checked_mul(x::$T, y::$T) = box($T,checked_smul(unbox($T,x),unbox($T,y)))
     end
 end
-for T in (Uint8,Uint16,Uint32,Uint64)
+for T in (Uint8,Uint16,Uint32,Uint64)#,Uint128)
     @eval begin
         checked_add(x::$T, y::$T) = box($T,checked_uadd(unbox($T,x),unbox($T,y)))
         checked_sub(x::$T, y::$T) = box($T,checked_usub(unbox($T,x),unbox($T,y)))
@@ -601,3 +601,13 @@ for T in (Int8,Uint8)
         return xy8
     end
 end
+
+# checked ops are broken for 128-bit types (LLVM bug)
+
+checked_add(x::Int128, y::Int128) = x + y
+checked_sub(x::Int128, y::Int128) = x - y
+checked_mul(x::Int128, y::Int128) = x * y
+
+checked_add(x::Uint128, y::Uint128) = x + y
+checked_sub(x::Uint128, y::Uint128) = x - y
+checked_mul(x::Uint128, y::Uint128) = x * y

--- a/base/string.jl
+++ b/base/string.jl
@@ -1473,11 +1473,8 @@ function _parseint{T<:Integer}(::Type{T}, s::String, base::Int)
                'a' <= c <= 'z' ? c-'a'+10 : base
         d < base || error("invalid base-$base digit $(repr(c)) in $(repr(s))")
         (T <: Signed) && (d *= sgn)
-        # TODO: restore when checked_* work for Int128
-        #n = checked_mul(n,base)
-        n = n*base
-        #n = checked_add(n,d)
-        n = n+d
+        n = checked_mul(n,base)
+        n = checked_add(n,d)
         done(s,i) && return n
         c, i = next(s,i)
     end

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -227,12 +227,11 @@ parsehex(s) = parseint(s,16)
 @test parseint("-0o1234") == -int(0o1234)
 @test parseint("-0b1011") == -int(0b1011)
 
-for T in (Int8,Uint8,Int16,Uint16,Int32,Uint32,Int64,Uint64,Int128,Uint128)
+for T in (Int8,Uint8,Int16,Uint16,Int32,Uint32,Int64,Uint64)#,Int128,Uint128)
     @test parseint(T,string(typemin(T))) == typemin(T)
     @test parseint(T,string(typemax(T))) == typemax(T)
-    # TODO: restore when checked_* work for Int128
-    #@test_throws parseint(T,string(big(typemin(T))-1))
-    #@test_throws parseint(T,string(big(typemax(T))+1))
+    @test_throws parseint(T,string(big(typemin(T))-1))
+    @test_throws parseint(T,string(big(typemax(T))+1))
 end
 
 # string manipulation


### PR DESCRIPTION
I'm trying to fix the build stuff without entirely disabling the checked operations for smaller integer types.
