### PR TITLE
Define functions for ImaginaryUnit

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -607,3 +607,10 @@ function atanh{T<:FloatingPoint}(z::Complex{T})
     complex(ξ, η)
 end
 atanh(z::Complex) = atanh(float(z))
+
+for f in (:sqrt, :exp, :log, :sin, :cos, :tan, :asin, :acos, :atan,
+          :sinh, :cosh, :tanh, :asinh, :acosh, :atanh)
+    @eval begin
+        ($f)(x::ImaginaryUnit) = ($f)(convert(Complex, x))
+    end
+end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -598,3 +598,4 @@
 @test complex(2,2)^2 === complex(0,8)
 @test_throws complex(2,2)^(-2)
 @test complex(2.0,2.0)^(-2) === complex(0.0, -0.125)
+@test sin(im) == sin(1im)


### PR DESCRIPTION
Now many common functions are not defined for imaginary unit `im` that has separate type (not Complex).

```
julia> sin(im)
ERROR: no method sin(ImaginaryUnit,)

julia> sqrt(im)
ERROR: no method sqrt(ImaginaryUnit,)
```

This pull request defines missing methods with `ImaginaryUnit` argument.
