### PR TITLE
Move git to libexec, remove all binaries other than `julia` from bin directory of install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ VERSDIR = v`cut -d. -f1-2 < VERSION`
 all: default
 default: release
 
-DIRS = $(BUILD)/bin $(BUILD)/etc/julia $(BUILD)/lib $(BUILD)/share/julia $(BUILD)/share/julia/man/man1
+DIRS = $(BUILD)/bin $(BUILD)/etc/julia $(BUILD)/lib $(BUILD)/libexec $(BUILD)/share/julia $(BUILD)/share/julia/man/man1
 ifneq ($(JL_LIBDIR),bin)
 ifneq ($(JL_LIBDIR),lib)
 DIRS += $(BUILD)/$(JL_LIBDIR)

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ install:
 		mkdir -p $(PREFIX)/$$subdir ; \
 	done
 	cp -a $(BUILD)/bin/julia* $(PREFIX)/bin/
+	cp -a $(BUILD)/libexec $(PREFIX)
 ifneq ($(OS),WINNT)
 	cd $(PREFIX)/bin && ln -sf julia-$(DEFAULT_REPL) julia
 endif

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ install:
 		mkdir -p $(PREFIX)/$$subdir ; \
 	done
 	cp -a $(BUILD)/bin/julia* $(PREFIX)/bin/
+	-cp -a $(BUILD)/bin/*.dll $(BUILD)/bin/*.bat $(PREFIX)/bin/
 	cp -a $(BUILD)/libexec $(PREFIX)
 ifneq ($(OS),WINNT)
 	cd $(PREFIX)/bin && ln -sf julia-$(DEFAULT_REPL) julia

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ install:
 	@for subdir in "bin" "libexec" $(JL_LIBDIR) $(JL_PRIVATE_LIBDIR) "share/julia" "share/man/man1" "include/julia" "share/julia/site/"$(VERSDIR) "etc/julia" ; do \
 		mkdir -p $(PREFIX)/$$subdir ; \
 	done
-	cp -a $(BUILD)/bin $(PREFIX)
+	cp -a $(BUILD)/bin/julia* $(PREFIX)/bin/
 ifneq ($(OS),WINNT)
 	cd $(PREFIX)/bin && ln -sf julia-$(DEFAULT_REPL) julia
 endif

--- a/contrib/mac/juliarc.jl
+++ b/contrib/mac/juliarc.jl
@@ -1,7 +1,7 @@
 # Set up environment for Julia OSX binary distribution
 let
     ROOT = abspath(JULIA_HOME,"..")
-    ENV["PATH"]="$JULIA_HOME:$(ENV["PATH"])"
+    ENV["PATH"]="$JULIA_HOME:$(joinpath(ROOT, "libexec")):$(ENV["PATH"])"
     ENV["FONTCONFIG_PATH"] = joinpath(ROOT, "etc", "fonts")
     ENV["GIT_EXEC_PATH"] = joinpath(ROOT, "libexec", "git-core")
     ENV["GIT_TEMPLATE_DIR"] = joinpath(ROOT, "share", "git-core")

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1535,7 +1535,7 @@ git-$(GIT_VER)/configure: git-$(GIT_VER).tar.gz
 	touch -c $@
 git-$(GIT_VER)/config.status: git-$(GIT_VER)/configure
 	cd git-$(GIT_VER) && \
-	./configure $(CONFIGURE_COMMON)
+	./configure $(CONFIGURE_COMMON) --bindir="$(BUILD)/libexec"
 	touch -c $@
 $(GIT_SOURCE): git-$(GIT_VER)/config.status
 	$(MAKE) -C git-$(GIT_VER)
@@ -1544,7 +1544,6 @@ git-$(GIT_VER)/checked: $(GIT_SOURCE)
 	echo 1 > $@
 $(GIT_TARGET): $(GIT_SOURCE) git-$(GIT_VER)/checked
 	$(MAKE) -C git-$(GIT_VER) install NO_INSTALL_HARDLINKS=1
-	mv $(BUILD)/bin/git* $(BUILD)/libexec/
 	touch -c $@
 
 clean-git:

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1544,6 +1544,7 @@ git-$(GIT_VER)/checked: $(GIT_SOURCE)
 	echo 1 > $@
 $(GIT_TARGET): $(GIT_SOURCE) git-$(GIT_VER)/checked
 	$(MAKE) -C git-$(GIT_VER) install NO_INSTALL_HARDLINKS=1
+	mv $(BUILD)/bin/git* $(BUILD)/libexec/
 	touch -c $@
 
 clean-git:


### PR DESCRIPTION
@vtjnash would this screw up anything on the Windows side of things? Specifically, I'm looking at [these lines](https://github.com/JuliaLang/julia/blob/d3a1856d1f87cce3869d15f354bd5c2c801ebbb9/Makefile#L229-233), it seems that perhaps we can even get rid of the removal of the `llvm` binaries, as they shouldn't ever get copied over now.  Without this change, the number of programs placed into `$(PREFIX)/bin` was truly amazing.  As seems to be a typical reaction when we fix bugs like this, "I'm amazed this ever worked at all".  ;)
