### PR TITLE
Add missing tree.h on windows and use STATIC_EXPORT in bit vector (see #4937)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ endif
 ifeq ($(USE_SYSTEM_LIBUV),0)
 ifeq ($(OS),WINNT)
 	cp -a $(BUILD)/lib/libuv.a $(PREFIX)/$(JL_PRIVATE_LIBDIR)
+	cp -a $(BUILD)/include/tree.h $(PREFIX)/include/julia
 else
 	cp -a $(BUILD)/$(JL_LIBDIR)/libuv.a $(PREFIX)/$(JL_PRIVATE_LIBDIR)
 endif

--- a/src/support/bitvector.h
+++ b/src/support/bitvector.h
@@ -9,7 +9,7 @@
 #ifdef __INTEL_COMPILER
 #define count_bits(b) _popcnt32(b)
 #else
-static inline u_int32_t count_bits(u_int32_t b)
+STATIC_INLINE u_int32_t count_bits(u_int32_t b)
 {
     b = b - ((b>>1)&0x55555555);
     b = ((b>>2)&0x33333333) + (b&0x33333333);


### PR DESCRIPTION
Both changes are required for making julia.h usable under MSVC.
This basically fixes #4937.

Will copying tree.h into the installation include dir automatically put the file into the windows installer?
