### PR TITLE
Add a specific error message for PCRE conflicts

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -371,6 +371,8 @@ function _start()
     fdwatcher_reinit()
     # Initialize RNG
     Random.librandom_init()
+    # Ensure PCRE is compatible with the compiled reg-exes
+    PCRE.check_pcre()
     # Check that BLAS is correctly built
     check_blas()
     LinAlg.init()

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -130,4 +130,14 @@ function exec(regex::Array{Uint8}, extra::Ptr{Void},
     cap ? ((n > -1 ? ovec[1:2(ncap+1)] : Array(Int32,0)), ncap) : n > -1
 end
 
+function check_pcre()
+    libver = bytestring(ccall((:pcre_version, :libpcre), Ptr{Uint8}, ()))
+    if VERSION != libver
+        println("ERROR: PCRE v\"$libver\" was loaded, but was compiled with v\"$VERSION\"")
+        println("Please ensure the libpcre that Julia's stdlib was compiled against is loaded.")
+        println("Quitting.")
+        quit()
+    end
+end
+
 end # module


### PR DESCRIPTION
When a different PCRE library is loaded than that which the stdlib was compiled against, the compiled regular expressions may fail. This compares the version strings of the compiled and loaded libpcre, and if different aborts (similarly to how Julia will abort with a BLAS linking error).

This is designed to give a more helpful error message when a different version of libpcre causes compiled regular expressions to fail.  Notably, the first regex that gets hit by this is the cause of issue https://github.com/JuliaLang/julia/issues/3838.

This exploits the fact that the constant Base.PCRE.VERSION is set and stored at compile-time, while a `ccall` Expr is not, but as a new Julia user I'm not entirely sure how stable that is.
