### PR TITLE
RFC: generalize writedlm to iterable arguments and arbitrary delimeters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,11 @@ Library improvements
 
   * Faster sparse `kron` ([#4958]).
 
+  * `writedlm` and `writecsv` now accept any iterable collection of
+    iterable rows, in addition to `AbstractArray` arguments, and the
+    ``writedlm`` delimiter can be any printable object (e.g. a
+    ``String``) instead of just a ``Char``.
+
 Deprecated or removed
 ---------------------
 

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -202,14 +202,14 @@ readcsv(io, T::Type; opts...) = readdlm(io, ',', T; opts...)
 # todo: keyword argument for # of digits to print
 writedlm_cell(io::IO, elt::FloatingPoint) = print_shortest(io, elt)
 writedlm_cell(io::IO, elt) = print(io, elt)
-function writedlm(io::IO, a::Union(AbstractMatrix,AbstractVector), dlm::Char)
+function writedlm(io::IO, a::Union(AbstractMatrix,AbstractVector), dlm)
     pb = PipeBuffer()
     nr = size(a,1)
     nc = size(a,2)
     for i = 1:nr
         for j = 1:nc
             writedlm_cell(pb, a[i,j])
-            write(pb, (j == nc) ? '\n' : dlm)
+            j == nc ? write(pb,'\n') : print(pb,dlm)
         end
         (nb_available(pb) > (16*1024)) && write(io, takebuf_array(pb))
     end
@@ -217,9 +217,9 @@ function writedlm(io::IO, a::Union(AbstractMatrix,AbstractVector), dlm::Char)
     nothing
 end
 
-writedlm{T}(io::IO, a::AbstractArray{T,0}, dlm::Char) = writedlm(io, reshape(a,1), dlm)
+writedlm{T}(io::IO, a::AbstractArray{T,0}, dlm) = writedlm(io, reshape(a,1), dlm)
 
-function writedlm(io::IO, a::AbstractArray, dlm::Char)
+function writedlm(io::IO, a::AbstractArray, dlm)
     tail = size(a)[3:end]
     function print_slice(idxs...)
         writedlm(io, sub(a, 1:size(a,1), 1:size(a,2), idxs...), dlm)
@@ -230,7 +230,22 @@ function writedlm(io::IO, a::AbstractArray, dlm::Char)
     cartesianmap(print_slice, tail)
 end
 
-function writedlm(fname::String, a, dlm::Char)
+function writedlm(io::IO, itr, dlm)
+    pb = PipeBuffer()
+    for row in itr
+        state = start(row)
+        while !done(row, state)
+            (x, state) = next(row, state)
+            writedlm_cell(pb, x)
+            done(row, state) ? write(pb,'\n') : print(pb,dlm)
+        end
+        (nb_available(pb) > (16*1024)) && write(io, takebuf_array(pb))
+    end
+    write(io, takebuf_array(pb))
+    nothing
+end
+
+function writedlm(fname::String, a, dlm)
     open(fname, "w") do io
         writedlm(io, a, dlm)
     end

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1630,15 +1630,19 @@ Text I/O
 
    Read a matrix from the source with a given element type. If ``T`` is a numeric type, the result is an array of that type, with any non-numeric elements as ``NaN`` for floating-point types, or zero. Other useful values of ``T`` include ``ASCIIString``, ``String``, and ``Any``.
 
-.. function:: writedlm(filename, array, delim::Char)
+.. function:: writedlm(f, A, delim='\t')
 
-   Write an array to a text file using the given delimeter (defaults to comma).
+   Write ``A`` (either an array type or an iterable collection of iterable rows) as text to ``f`` (either a filename string or an ``IO`` stream) using the given delimeter ``delim`` (which defaults to tab, but can be any printable Julia object, typically a ``Char`` or ``String``).
+
+   For example, two vectors ``x`` and ``y`` of the same length can
+   be written as two columns of tab-delimited text to ``f`` by
+   either ``writedlm(f, [x y])`` or by ``writedlm(f, zip(x, y))``.
 
 .. function:: readcsv(source, [T::Type]; options...)
 
    Equivalent to ``readdlm`` with ``delim`` set to comma.
 
-.. function:: writecsv(filename, array)
+.. function:: writecsv(filename, A)
 
    Equivalent to ``writedlm`` with ``delim`` set to comma.
 

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -12,3 +12,9 @@ dlm_data = readdlm(joinpath("perf", "kernel", "imdb-1.tsv"), '\t')
 @test size(readcsv(IOBuffer("1,2,3,4\n1,2,3,4"))) == (2,4)
 @test size(readcsv(IOBuffer("1,2,3,4\n1,2,3,"))) == (2,4)
 @test size(readcsv(IOBuffer("1,2,3,4\n1,2,3"))) == (2,4)
+
+let x = [1,2,3], y = [4,5,6], io = IOBuffer()
+    writedlm(io, zip(x,y), ",  ")
+    seek(io, 0)
+    @test readcsv(io) == [x y]
+end


### PR DESCRIPTION
This patch generalize the `writedlm(io, A, delim)` to accept arbitrary iterable collections (of iterable rows) for `A` and to accept arbitrary Julia objects for `delim` (which was previously restricted to `Char` for no discernable reason).  So, for example, you can now do:

```
julia> writedlm(STDOUT, combinations([1,2,3,4], 3), ", ")
1, 2, 3
1, 2, 4
1, 3, 4
2, 3, 4
```

The documentation is also updated (it was incomplete anyway), and a test case is added.
