### PR TITLE
nthperm

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -102,6 +102,12 @@ function nthperm!(a::AbstractVector, k::Integer)
 end
 nthperm(a::AbstractVector, k::Integer) = nthperm!(copy(a),k)
 
+function nthperm{T<:Integer}(v::AbstractVector{T})
+#    @assert isperm(v)
+    n=length(v)
+    sum(map(i -> sum(v[i+1:end] .< v[i])factorial(n-i), 1:n-1)) + 1
+end
+
 function invperm(a::AbstractVector)
     b = zero(a) # similar vector of zeros
     n = length(a)

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -102,10 +102,10 @@ function nthperm!(a::AbstractVector, k::Integer)
 end
 nthperm(a::AbstractVector, k::Integer) = nthperm!(copy(a),k)
 
-function nthperm{T<:Integer}(v::AbstractVector{T})
-#    @assert isperm(v)
-    n=length(v)
-    sum(map(i -> sum(v[i+1:end] .< v[i])factorial(n-i), 1:n-1)) + 1
+function nthperm{T<:Integer}(p::AbstractVector{T})
+#    @assert isperm(p)
+    n=length(p)
+    sum(map(i -> sum(p[i+1:end] .< p[i])factorial(n-i), 1:n-1)) + 1
 end
 
 function invperm(a::AbstractVector)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3686,6 +3686,10 @@ Combinatorics
 
    Compute the kth lexicographic permutation of a vector.
 
+.. function:: nthperm(p)
+
+   Return the ``k`` that generated permutation ``p``.  Note that ``nthperm(nthperm([1:N], k)) == k``.
+
 .. function:: nthperm!(v, k)
 
    In-place version of :func:`nthperm`.


### PR DESCRIPTION
extended combinatorics to include k = nthperm(p) to be the inverse of p = nthperm([1::N], k).  Code corrected by Kevin Squire on julia-users. 
