### PR TITLE
More Symbol Exports and C-API Example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,48 @@
+JULIAHOME = $(abspath ..)
+include $(JULIAHOME)/Make.inc
+
+override CFLAGS += $(JCFLAGS)
+override CXXFLAGS += $(JCXXFLAGS)
+
+FLAGS = -Wall -Wno-strict-aliasing -fno-omit-frame-pointer \
+	-I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(BUILD)/include $(CFLAGS) 
+
+DEBUGFLAGS += $(FLAGS)
+SHIPFLAGS += $(FLAGS)
+JLDFLAGS += $(LDFLAGS) $(NO_WHOLE_ARCHIVE) $(call exec,$(LLVM_CONFIG) --ldflags) $(OSLIBS) $(RPATH)
+
+ifeq ($(USE_SYSTEM_LIBM),0)
+ifneq ($(UNTRUSTED_SYSTEM_LIBM),0)
+ifeq ($(OS),WINNT)
+JLDFLAGS += $(WHOLE_ARCHIVE) $(BUILD)/lib/libopenlibm.a $(NO_WHOLE_ARCHIVE)
+else
+JLDFLAGS += $(WHOLE_ARCHIVE) $(BUILD)/$(JL_LIBDIR)/libopenlibm.a $(NO_WHOLE_ARCHIVE)
+endif
+endif
+endif
+
+embedding-release: embedding
+
+release debug:
+	$(MAKE) embedding-$@
+
+%.o: %.c
+	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(SHIPFLAGS) -c $< -o $@)
+%.do: %.c
+	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@)
+
+embedding: $(BUILD)/bin/embedding$(EXE)
+embedding-debug: $(BUILD)/bin/embedding-debug$(EXE)
+
+$(BUILD)/bin/embedding$(EXE): embedding.o
+	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(BUILD)/$(JL_PRIVATE_LIBDIR) -L$(BUILD)/$(JL_LIBDIR) -ljulia $(JLDFLAGS))
+$(BUILD)/bin/embedding-debug$(EXE): embedding.do
+	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(BUILD)/$(JL_PRIVATE_LIBDIR) -L$(BUILD)/$(JL_LIBDIR) -ljulia-debug $(JLDFLAGS))
+
+
+clean: | $(CLEAN_TARGETS)
+	rm -f *.o *.do
+	rm -f $(BUILD)/bin/embedding-debug $(BUILD)/bin/embedding
+
+.PHONY: clean release debug
+

--- a/examples/embedding.c
+++ b/examples/embedding.c
@@ -1,0 +1,100 @@
+#include <julia.h>
+#include <stdio.h>
+#include <math.h>
+
+double my_c_sqrt(double x)
+{
+    return sqrt(x);
+}
+
+int main()
+{
+    jl_init(NULL);
+
+    {
+      // Simple running Julia code
+
+      jl_eval_string("println(sqrt(2.0))");
+    }
+
+    {
+      // Accessing the return value
+
+      jl_value_t *ret = jl_eval_string("sqrt(2.0)");
+
+      if(jl_is_float64(ret))
+      {
+        double retDouble = jl_unbox_float64(ret);
+        printf("sqrt(2.0) in C: %e\n", retDouble);
+      }
+    }
+
+    {
+      // Same as above but with function handle (more flexible)
+
+      jl_function_t *func = jl_get_function(jl_base_module, "sqrt");
+      jl_value_t* argument = jl_box_float64(2.0);
+      jl_value_t* ret = jl_call1(func, argument);
+
+      if(jl_is_float64(ret))
+      {
+        double retDouble = jl_unbox_float64(ret);
+        printf("sqrt(2.0) in C: %e\n", retDouble);
+      }
+    }
+
+    {
+      // 1D arrays
+
+      jl_value_t* array_type = jl_apply_array_type( jl_float64_type, 1 );
+      jl_array_t* x          = jl_alloc_array_1d(array_type , 10);
+      JL_GC_PUSH1(&x);
+
+      double* xData = jl_array_data(x);
+
+      for(size_t i=0; i<jl_array_len(x); i++)
+        xData[i] = i;
+
+      jl_function_t *func  = jl_get_function(jl_base_module, "reverse!");
+      jl_call1(func, (jl_value_t*) x);
+
+      printf("x = [");
+      for(size_t i=0; i<jl_array_len(x); i++)
+        printf("%e ", xData[i]);
+      printf("]\n");
+
+      JL_GC_POP();
+    }
+
+    {
+      // define julia function and call it
+
+      jl_eval_string("my_func(x) = 2*x");
+
+      jl_function_t *func = jl_get_function(jl_current_module, "my_func");
+      jl_value_t* arg = jl_box_float64(5.0);
+      double ret = jl_unbox_float64(jl_call1(func, arg));
+
+      printf("my_func(5.0) = %f\n", ret);
+    }
+
+    {
+      // call c function 
+
+      jl_eval_string("println( ccall( :my_c_sqrt, Float64, (Float64,), 2.0 ) )");
+    }
+
+    {
+      // check for exceptions
+
+      jl_eval_string("this_function_does_not_exist()");
+
+      if (jl_exception_occurred())
+          printf("%s \n", jl_get_exception_str( jl_exception_occurred() ) );
+    }
+
+
+    return 0;
+}
+
+

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -129,6 +129,38 @@ DLLEXPORT const char *jl_bytestring_ptr(jl_value_t *s)
     return jl_string_data(s);
 }
 
+DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs)
+{
+    jl_value_t *v;
+    JL_TRY {
+        jl_value_t **argv;
+        JL_GC_PUSHARGS(argv, nargs+1);
+        argv[0] = (jl_value_t*) f;
+        for(int i=1; i<nargs+1; i++)
+            argv[i] = args[i-1];
+        v = jl_apply(f, args, nargs);
+        JL_GC_POP();
+    }
+    JL_CATCH {
+        v = NULL;
+    }
+    return v;
+}
+
+DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
+{
+    jl_value_t *v;
+    JL_TRY {
+        JL_GC_PUSH1(&f);
+        v = jl_apply(f, NULL, 0);
+        JL_GC_POP();
+    }
+    JL_CATCH {
+        v = NULL;
+    }
+    return v;
+}
+
 DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
 {
     jl_value_t *v;
@@ -150,6 +182,21 @@ DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b)
         JL_GC_PUSH3(&f,&a,&b);
         jl_value_t *args[2] = {a,b};
         v = jl_apply(f, args, 2);
+        JL_GC_POP();
+    }
+    JL_CATCH {
+        v = NULL;
+    }
+    return v;
+}
+
+DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a, jl_value_t *b, jl_value_t *c)
+{
+    jl_value_t *v;
+    JL_TRY {
+        JL_GC_PUSH4(&f,&a,&b,&c);
+        jl_value_t *args[3] = {a,b,c};
+        v = jl_apply(f, args, 3);
         JL_GC_POP();
     }
     JL_CATCH {

--- a/src/julia.h
+++ b/src/julia.h
@@ -366,7 +366,7 @@ extern jl_datatype_t *jl_function_type;
 extern jl_datatype_t *jl_abstractarray_type;
 extern jl_datatype_t *jl_storedarray_type;
 extern jl_datatype_t *jl_densearray_type;
-extern jl_datatype_t *jl_array_type;
+extern DLLEXPORT jl_datatype_t *jl_array_type;
 extern jl_typename_t *jl_array_typename;
 extern jl_datatype_t *jl_weakref_type;
 extern DLLEXPORT jl_datatype_t *jl_ascii_string_type;
@@ -390,18 +390,18 @@ extern jl_datatype_t *jl_box_type;
 extern jl_value_t *jl_box_any_type;
 extern jl_typename_t *jl_box_typename;
 
-extern jl_datatype_t *jl_bool_type;
-extern jl_datatype_t *jl_char_type;
-extern jl_datatype_t *jl_int8_type;
-extern jl_datatype_t *jl_uint8_type;
-extern jl_datatype_t *jl_int16_type;
-extern jl_datatype_t *jl_uint16_type;
-extern jl_datatype_t *jl_int32_type;
-extern jl_datatype_t *jl_uint32_type;
-extern jl_datatype_t *jl_int64_type;
-extern jl_datatype_t *jl_uint64_type;
-extern jl_datatype_t *jl_float32_type;
-extern jl_datatype_t *jl_float64_type;
+extern DLLEXPORT jl_datatype_t *jl_bool_type;
+extern DLLEXPORT jl_datatype_t *jl_char_type;
+extern DLLEXPORT jl_datatype_t *jl_int8_type;
+extern DLLEXPORT jl_datatype_t *jl_uint8_type;
+extern DLLEXPORT jl_datatype_t *jl_int16_type;
+extern DLLEXPORT jl_datatype_t *jl_uint16_type;
+extern DLLEXPORT jl_datatype_t *jl_int32_type;
+extern DLLEXPORT jl_datatype_t *jl_uint32_type;
+extern DLLEXPORT jl_datatype_t *jl_int64_type;
+extern DLLEXPORT jl_datatype_t *jl_uint64_type;
+extern DLLEXPORT jl_datatype_t *jl_float32_type;
+extern DLLEXPORT jl_datatype_t *jl_float64_type;
 extern jl_datatype_t *jl_floatingpoint_type;
 extern jl_datatype_t *jl_voidpointer_type;
 extern jl_datatype_t *jl_pointer_type;
@@ -684,7 +684,7 @@ int jl_args_morespecific(jl_value_t *a, jl_value_t *b);
 jl_typename_t *jl_new_typename(jl_sym_t *name);
 jl_tvar_t *jl_new_typevar(jl_sym_t *name,jl_value_t *lb,jl_value_t *ub);
 jl_typector_t *jl_new_type_ctor(jl_tuple_t *params, jl_value_t *body);
-jl_value_t *jl_apply_type(jl_value_t *tc, jl_tuple_t *params);
+DLLEXPORT jl_value_t *jl_apply_type(jl_value_t *tc, jl_tuple_t *params);
 jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n);
 jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n);
 jl_uniontype_t *jl_new_uniontype(jl_tuple_t *types);
@@ -710,12 +710,12 @@ DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t proc, jl_value_t *env,
                               jl_lambda_info_t *li);
 DLLEXPORT jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_tuple_t *sparams);
 DLLEXPORT jl_tuple_t *jl_tuple(size_t n, ...);
-jl_tuple_t *jl_tuple1(void *a);
-jl_tuple_t *jl_tuple2(void *a, void *b);
+DLLEXPORT jl_tuple_t *jl_tuple1(void *a);
+DLLEXPORT jl_tuple_t *jl_tuple2(void *a, void *b);
 DLLEXPORT jl_tuple_t *jl_alloc_tuple(size_t n);
 jl_tuple_t *jl_alloc_tuple_uninit(size_t n);
-jl_tuple_t *jl_tuple_append(jl_tuple_t *a, jl_tuple_t *b);
-jl_tuple_t *jl_tuple_fill(size_t n, jl_value_t *v);
+DLLEXPORT jl_tuple_t *jl_tuple_append(jl_tuple_t *a, jl_tuple_t *b);
+DLLEXPORT jl_tuple_t *jl_tuple_fill(size_t n, jl_value_t *v);
 DLLEXPORT jl_sym_t *jl_symbol(const char *str);
 DLLEXPORT jl_sym_t *jl_symbol_lookup(const char *str);
 DLLEXPORT jl_sym_t *jl_symbol_n(const char *str, int32_t len);
@@ -815,6 +815,10 @@ DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec);
 DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz);
 DLLEXPORT void *jl_value_ptr(jl_value_t *a);
 DLLEXPORT void jl_cell_1d_push(jl_array_t *a, jl_value_t *item);
+STATIC_INLINE jl_value_t *jl_apply_array_type(jl_datatype_t *type, size_t dim)
+{
+  return jl_apply_type((jl_value_t*)jl_array_type, jl_tuple2(type, jl_box_long(dim)));
+}
 
 // eq hash tables
 DLLEXPORT jl_array_t *jl_eqtable_put(jl_array_t *h, void *key, void *val);
@@ -876,17 +880,26 @@ DLLEXPORT struct tm* localtime_r(const time_t *t, struct tm *tm);
 // exceptions
 DLLEXPORT void NORETURN jl_error(const char *str);
 void NORETURN jl_errorf(const char *fmt, ...);
-void jl_too_few_args(const char *fname, int min);
-void jl_too_many_args(const char *fname, int max);
-void jl_type_error(const char *fname, jl_value_t *expected, jl_value_t *got);
+DLLEXPORT void jl_too_few_args(const char *fname, int min);
+DLLEXPORT void jl_too_many_args(const char *fname, int max);
+DLLEXPORT void jl_type_error(const char *fname, jl_value_t *expected, jl_value_t *got);
 DLLEXPORT void jl_type_error_rt(const char *fname, const char *context,
                       jl_value_t *ty, jl_value_t *got);
 jl_value_t *jl_no_method_error(jl_function_t *f, jl_value_t **args, size_t na);
 void jl_check_type_tuple(jl_tuple_t *t, jl_sym_t *name, const char *ctx);
+DLLEXPORT jl_value_t *jl_exception_occurred(void);
+DLLEXPORT void jl_exception_clear(void);
+STATIC_INLINE char* jl_get_exception_str(jl_value_t* exception)
+{
+    return jl_string_data( jl_fieldref( exception ,0 ) );
+}
+
 
 // initialization functions
+
 DLLEXPORT void julia_init(char *imageFile, int build_mode);
 DLLEXPORT int julia_trampoline(int argc, char *argv[], int (*pmain)(int ac,char *av[]), char* build_mode);
+DLLEXPORT void jl_init(char *julia_home_dir);
 void jl_init_types(void);
 void jl_init_box_caches(void);
 DLLEXPORT void jl_init_frontend(void);
@@ -911,6 +924,7 @@ jl_value_t *jl_parse_next(void);
 DLLEXPORT jl_value_t *jl_load_file_string(const char *text, char *filename);
 DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr);
 jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr);
+DLLEXPORT void *jl_eval_string(char *str);
 
 // some useful functions
 DLLEXPORT void jl_show(jl_value_t *stream, jl_value_t *v);
@@ -926,7 +940,7 @@ extern DLLEXPORT jl_module_t *jl_main_module;
 extern DLLEXPORT jl_module_t *jl_core_module;
 extern DLLEXPORT jl_module_t *jl_base_module;
 extern DLLEXPORT jl_module_t *jl_current_module;
-jl_module_t *jl_new_module(jl_sym_t *name);
+DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name);
 // get binding for reading
 DLLEXPORT jl_binding_t *jl_get_binding(jl_module_t *m, jl_sym_t *var);
 // get binding for assignment
@@ -941,12 +955,16 @@ DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val);
 DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val);
 DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs);
 DLLEXPORT void jl_declare_constant(jl_binding_t *b);
-void jl_module_using(jl_module_t *to, jl_module_t *from);
-void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
-void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
-void jl_module_importall(jl_module_t *to, jl_module_t *from);
+DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from);
+DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
+DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
+DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from);
 DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
 void jl_add_standard_imports(jl_module_t *m);
+STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
+{
+    return  (jl_function_t*) jl_get_global(m, jl_symbol(name));
+}
 
 // external libraries
 enum JL_RTLD_CONSTANT {
@@ -1044,6 +1062,12 @@ jl_value_t *jl_apply(jl_function_t *f, jl_value_t **args, uint32_t nargs)
 {
     return f->fptr((jl_value_t*)f, args, nargs);
 }
+
+DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs);
+DLLEXPORT jl_value_t *jl_call0(jl_function_t *f);
+DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a, jl_value_t *b, jl_value_t *c);
 
 #define JL_NARGS(fname, min, max)                               \
     if (nargs < min) jl_too_few_args(#fname, min);              \

--- a/src/julia.h
+++ b/src/julia.h
@@ -817,7 +817,11 @@ DLLEXPORT void *jl_value_ptr(jl_value_t *a);
 DLLEXPORT void jl_cell_1d_push(jl_array_t *a, jl_value_t *item);
 STATIC_INLINE jl_value_t *jl_apply_array_type(jl_datatype_t *type, size_t dim)
 {
-  return jl_apply_type((jl_value_t*)jl_array_type, jl_tuple2(type, jl_box_long(dim)));
+    jl_value_t *boxed_dim = jl_box_long(dim);
+    JL_GC_PUSH1(&boxed_dim);
+    jl_value_t *ret = jl_apply_type((jl_value_t*)jl_array_type, jl_tuple2(type, boxed_dim));
+    JL_GC_POP();
+    return ret;
 }
 
 // eq hash tables


### PR DESCRIPTION
This is work in progress:
- Export more symbols in julia.h
- Add a convenience inline function "jl_apply_array_type"
- Add an example how to use the C API (see #3111 and https://github.com/tknopp/julia/blob/docuCAPI/doc/manual/embedding.rst)

On linux, this requires #4955 to be merged.

I am pretty excited how easy the C API is to use. 
