### PR TITLE
Rationalize return types of tridiag and Woodbury solve!()

### DIFF
--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -226,10 +226,13 @@ function solve!{T<:BlasFloat}(x::AbstractArray{T}, xrng::Ranges{Int}, M::Tridiag
         x[ix] = xlast
         ix -= xstride
     end
-    x
+    nothing
 end
 
-solve!(x::StridedVector, M::Tridiagonal, rhs::StridedVector) = solve!(x, 1:length(x), M, rhs, 1:length(rhs))
+function solve!(x::StridedVector, M::Tridiagonal, rhs::StridedVector)
+    solve!(x, 1:length(x), M, rhs, 1:length(rhs))
+    x
+end
 solve{TM<:BlasFloat,TB<:BlasFloat}(M::Tridiagonal{TM}, B::StridedVecOrMat{TB}) = solve!(zeros(typeof(one(TM)/one(TB)), size(B)), M, B)
 solve(M::Tridiagonal, B::StridedVecOrMat) = solve(float(M), float(B))
 function solve!(X::StridedMatrix, M::Tridiagonal, B::StridedMatrix)

--- a/base/linalg/woodbury.jl
+++ b/base/linalg/woodbury.jl
@@ -90,9 +90,13 @@ function solve!(x::AbstractArray, xrng::Ranges{Int}, W::Woodbury, rhs::AbstractA
         x[indx] = W.tmpN1[i] - W.tmpN2[i]
         indx += xinc
     end
+    nothing
 end
 
-solve!(x::AbstractVector, W::Woodbury, rhs::AbstractVector) = solve!(x, 1:length(x), W, rhs, 1:length(rhs))
+function solve!(x::AbstractVector, W::Woodbury, rhs::AbstractVector)
+    solve!(x, 1:length(x), W, rhs, 1:length(rhs))
+    x
+end
 solve(W::Woodbury, rhs::AbstractVector) = solve!(similar(rhs), W, rhs)
 solve(W::Woodbury, B::StridedMatrix)=solve!(similar(B), W, B)
 function solve!(X::StridedMatrix, W::Woodbury, B::StridedMatrix)


### PR DESCRIPTION
This is a very minor change in a non-exported interface. But given that I've been mostly out of the loop with regards to the big improvements in the linear algebra routines, I thought it would be best to ask first.

The Tridiagonal and Woodbury `solve!` routines have an interface like this:

```
solve!(output, outputrng::Ranges{Int}, matrix, rhs, rhsrng::Ranges{Int})
```

As a reminder, the intent is that the combination of `output` and `outputrng` can be used to choose an arbitrary 1-d subvector (a row or column of a matrix, for example), without the overhead of allocating an actual `SubArray`. This is important because tridiagonal routines are often used in situations in which `mapslices` would be the natural interface, but for which it is not yet sufficiently performant. (There's a second important difference: `solve!` can work in-place because it is non-aliasing for tridiagonal matrices, so even if `mapslices` were faster one might not want to use it.) Examples of such usage can be found in `Grid.jl`.

For the general case, this changes the return of `solve!` to be `nothing`, because if we think of this as effectively generating `output[outputrng]`, then it doesn't really make sense to return `output`. For the variant that omits the `Range` inputs (defaulting to the entire range), `output` gets returned.
