### PR TITLE
Define integer indexing for Hermitian, Symmetric and Triangular, and symmetrize matrices when calling full

### DIFF
--- a/base/linalg/hermitian.jl
+++ b/base/linalg/hermitian.jl
@@ -16,8 +16,8 @@ function copy!(A::Hermitian, B::Hermitian)
     A
 end
 size(A::Hermitian, args...) = size(A.S, args...)
-print_matrix(io::IO, A::Hermitian, rows::Integer, cols::Integer) = print_matrix(io, full(A), rows, cols)
-full(A::Hermitian) = A.S
+getindex(A::Hermitian, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? getindex(A.S, i, j) : conj(getindex(A.S, j, i))
+full(A::Hermitian) = symmetrize_conj!(A.S, A.uplo)
 ishermitian(A::Hermitian) = true
 issym{T<:Real}(A::Hermitian{T}) = true
 issym{T<:Complex}(A::Hermitian{T}) = all(imag(A.S) .== 0)

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -16,8 +16,8 @@ function copy!(A::Symmetric, B::Symmetric)
     A
 end
 size(A::Symmetric, args...) = size(A.S, args...)
-print_matrix(io::IO, A::Symmetric, rows::Integer, cols::Integer) = print_matrix(io, full(A), rows, cols)
-full(A::Symmetric) = A.S
+getindex(A::Symmetric, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? getindex(A.S, i, j) : getindex(A.S, j, i)
+full(A::Symmetric) = symmetrize!(A.S, A.uplo)
 ishermitian{T<:Real}(A::Symmetric{T}) = true
 ishermitian{T<:Complex}(A::Symmetric{T}) = all(imag(A.S) .== 0)
 issym(A::Symmetric) = true

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -16,9 +16,9 @@ function Triangular(A::Matrix)
 end
 
 size(A::Triangular, args...) = size(A.UL, args...)
-full(A::Triangular) = (istril(A) ? tril : triu)(A.UL)
+full(A::Triangular) = (istril(A) ? tril! : triu!)(A.UL)
 
-print_matrix(io::IO, A::Triangular, rows::Integer, cols::Integer) = print_matrix(io, full(A), rows, cols)
+getindex{T}(A::Triangular{T}, i::Integer, j::Integer) = i == j ? A.UL[i,j] : ((A.uplo == 'U') == (i < j) ? getindex(A.UL, i, j) : zero(T))
 
 istril(A::Triangular) = A.uplo == 'L'
 istriu(A::Triangular) = A.uplo == 'U'


### PR DESCRIPTION
I think this makes printing of the matrices more efficient. The symmetrize functions should have been there already, so it was kind of a bug. The change ensures that you can cheat by defining a symmetric matrix from a non-symmetric and still get the right thing

```
julia> Symmetric(randn(5,5))
5x5 Symmetric{Float64}:
  0.296067  -0.334961    0.640948    0.479263   -0.492936 
 -0.334961  -1.99079     0.786062    0.509636    0.0130511
  0.640948   0.786062   -0.0259301   0.293401   -2.61745  
  0.479263   0.509636    0.293401   -0.0249051  -2.03061  
 -0.492936   0.0130511  -2.61745    -2.03061     0.91161  
```
