### PR TITLE
Enable tab completion of macros in the REPL

### DIFF
--- a/ui/repl-readline.c
+++ b/ui/repl-readline.c
@@ -742,7 +742,7 @@ static void init_rl(void)
         // make sure keywords are in symbol table
         (void)jl_symbol(lang_keywords[i]);
     }
-    rl_completer_word_break_characters = " \t\n\"\\'`@$><=;|&{}()[],+-*/?%^~!:";
+    rl_completer_word_break_characters = " \t\n\"\\'`$><=;|&{}()[],+-*/?%^~!:";
     Keymap keymaps[] = {emacs_standard_keymap, vi_insertion_keymap};
     int i;
     for (i = 0; i < sizeof(keymaps)/sizeof(keymaps[0]); i++) {


### PR DESCRIPTION
This is a very minor (one-character) modification.  It simply considers '@' a word character for tab-completion purposes.  
