### PR TITLE
fixed her2k tests in test/linalg.jl

### DIFF
--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -516,8 +516,8 @@ for elty in (Complex64, Complex128)
     V = convert(Array{elty, 2}, V)
     @test_approx_eq tril(LinAlg.BLAS.her2k('L','N',U,V)) tril(U*V' + V*U')
     @test_approx_eq triu(LinAlg.BLAS.her2k('U','N',U,V)) triu(U*V' + V*U')
-    @test_approx_eq tril(LinAlg.BLAS.her2k('L','T',U,V)) tril(U'*V + V'*U)
-    @test_approx_eq triu(LinAlg.BLAS.her2k('U','T',U,V)) triu(U'*V + V'*U)        
+    @test_approx_eq tril(LinAlg.BLAS.her2k('L','C',U,V)) tril(U'*V + V'*U)
+    @test_approx_eq triu(LinAlg.BLAS.her2k('U','C',U,V)) triu(U'*V + V'*U)        
 end
 
 # LAPACK tests


### PR DESCRIPTION
The Trans parameter is supposed to be 'N' or 'C', and not 'N' or 'T'. The tast didn't fail using OpenBLAS, however.
