### PR TITLE
Make Libjulia compile on Windows with Intel Compiler

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ FLAGS = \
 	-Wall -Wno-strict-aliasing -fno-omit-frame-pointer \
 	-Iflisp -Isupport -fvisibility=hidden -fno-common \
 	-I$(call exec,$(LLVM_CONFIG) --includedir) \
-	-I$(LIBUV_INC) -I$(JULIAHOME)/usr/include
+	-I$(LIBUV_INC) -I$(JULIAHOME)/usr/include -DLIBRARY_EXPORTS
 
 LLVMLINK = $(call exec,$(LLVM_CONFIG) --libs)
 ifeq ($(USE_LLVM_SHLIB),1)

--- a/src/Makefile.debug
+++ b/src/Makefile.debug
@@ -8,7 +8,7 @@ FLAGS = \
     -Wall -Wno-strict-aliasing -fno-omit-frame-pointer \
 	-Iflisp -Isupport -fvisibility=hidden -fno-common \
 	-I$(call exec,$(LLVM_CONFIG) --includedir) \
-	-I$(EXTROOT)/include
+	-I$(EXTROOT)/include -DLIBRARY_EXPORTS
 
 OBJS = $(SRCS:%=%.o)
 DOBJS = $(SRCS:%=%.do)

--- a/src/array.c
+++ b/src/array.c
@@ -24,7 +24,7 @@ int jl_array_store_unboxed(jl_value_t *el_type)
 // at this size use malloc
 #define MALLOC_THRESH 1048576
 
-#ifdef _P64
+#if defined(_P64) && defined(UINT128MAX)
 typedef __uint128_t wideint_t;
 #else
 typedef uint64_t wideint_t;

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -747,7 +747,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     }
 
     // emit arguments
-    Value *argvals[(nargs-3)/2 + sret];
+    std::vector<Value *> argvals((nargs-3)/2 + sret);
     Value *result;
     if (sret) {
         assert(jl_is_structtype(rt));

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -747,7 +747,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     }
 
     // emit arguments
-    std::vector<Value *> argvals((nargs-3)/2 + sret);
+    Value **argvals = (Value**) alloca(((nargs-3)/2 + sret)*sizeof(Value*));
     Value *result;
     if (sret) {
         assert(jl_is_structtype(rt));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8,6 +8,7 @@
  * including <math.h> (or rather its content).
  */
 #if defined(_OS_WINDOWS_)
+#define NOMINMAX
 #include <malloc.h>
 #if defined(_COMPILER_INTEL_)
 #include <mathimf.h>
@@ -903,7 +904,7 @@ static Value *emit_lambda_closure(jl_value_t *expr, jl_codectx_t *ctx)
 
     int argStart = ctx->argDepth;
     size_t clen = jl_array_dim0(capt);
-    Value *captured[1+clen];
+    std::vector<Value *> captured(1+clen);
     captured[0] = ConstantInt::get(T_size, clen);
     for(i=0; i < clen; i++) {
         Value *val;
@@ -1691,7 +1692,7 @@ static Value *emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
     Value *result;
     if (f!=NULL && specialized && f->linfo!=NULL && f->linfo->cFunctionObject!=NULL) {
         // emit specialized call site
-        Value *argvals[nargs];
+        std::vector<Value *> argvals(nargs);
         Function *cf = (Function*)f->linfo->cFunctionObject;
         FunctionType *cft = cf->getFunctionType();
         for(size_t i=0; i < nargs; i++) {
@@ -2409,7 +2410,7 @@ static Function *gen_jlcall_wrapper(jl_lambda_info_t *lam, Function *f)
     builder.SetCurrentDebugLocation(noDbg);
 
     size_t nargs = jl_tuple_len(lam->specTypes);
-    Value *args[nargs];
+    std::vector<Value *> args(nargs);
     for(size_t i=0; i < nargs; i++) {
         Value *argPtr = builder.CreateGEP(argArray,
                                           ConstantInt::get(T_size, i));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -904,7 +904,7 @@ static Value *emit_lambda_closure(jl_value_t *expr, jl_codectx_t *ctx)
 
     int argStart = ctx->argDepth;
     size_t clen = jl_array_dim0(capt);
-    std::vector<Value *> captured(1+clen);
+    Value **captured = (Value**) alloca((1+clen)*sizeof(Value*));
     captured[0] = ConstantInt::get(T_size, clen);
     for(i=0; i < clen; i++) {
         Value *val;
@@ -1692,7 +1692,7 @@ static Value *emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
     Value *result;
     if (f!=NULL && specialized && f->linfo!=NULL && f->linfo->cFunctionObject!=NULL) {
         // emit specialized call site
-        std::vector<Value *> argvals(nargs);
+        Value **argvals = (Value**) alloca(nargs*sizeof(Value*));
         Function *cf = (Function*)f->linfo->cFunctionObject;
         FunctionType *cft = cf->getFunctionType();
         for(size_t i=0; i < nargs; i++) {
@@ -2410,7 +2410,7 @@ static Function *gen_jlcall_wrapper(jl_lambda_info_t *lam, Function *f)
     builder.SetCurrentDebugLocation(noDbg);
 
     size_t nargs = jl_tuple_len(lam->specTypes);
-    std::vector<Value *> args(nargs);
+    Value **args = (Value**) alloca(nargs*sizeof(Value*));
     for(size_t i=0; i < nargs; i++) {
         Value *argPtr = builder.CreateGEP(argArray,
                                           ConstantInt::get(T_size, i));

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -18,7 +18,7 @@ LLT = $(LLTDIR)/libsupport.a $(LIBUV)
 
 FLAGS = -Wall -Wno-strict-aliasing -I$(LLTDIR) $(CFLAGS) \
 	-DUSE_COMPUTED_GOTO $(HFILEDIRS:%=-I%) -I$(LIBUV_INC) $(LIBDIRS:%=-L%) \
-        -fvisibility=hidden
+        -fvisibility=hidden -DLIBRARY_EXPORTS
 LIBFILES = $(LLT)
 LIBS = $(LIBFILES)
 ifneq ($(OS),WINNT)

--- a/src/flisp/builtins.c
+++ b/src/flisp/builtins.c
@@ -308,19 +308,19 @@ static value_t fl_time_now(value_t *args, u_int32_t nargs)
 
 static value_t fl_path_cwd(value_t *args, uint32_t nargs)
 {
-    int err;
+    uv_err_t err;
     if (nargs > 1)
         argcount("path.cwd", nargs, 1);
     if (nargs == 0) {
         char buf[1024];
         err = uv_cwd(buf, sizeof(buf));
-        if (err != 0)
+        if (err.code != 0)
           lerrorf(IOError, "path.cwd: could not get cwd: %s", uv_strerror(err));
         return string_from_cstr(buf);
     }
     char *ptr = tostring(args[0], "path.cwd");
     err = uv_chdir(ptr);
-    if (err != 0)
+    if (err.code != 0)
         lerrorf(IOError, "path.cwd: could not cd to %s: %s", ptr, uv_strerror(err));
     return FL_T;
 }

--- a/src/flisp/builtins.c
+++ b/src/flisp/builtins.c
@@ -308,19 +308,19 @@ static value_t fl_time_now(value_t *args, u_int32_t nargs)
 
 static value_t fl_path_cwd(value_t *args, uint32_t nargs)
 {
-    uv_err_t err;
+    int err;
     if (nargs > 1)
         argcount("path.cwd", nargs, 1);
     if (nargs == 0) {
         char buf[1024];
         err = uv_cwd(buf, sizeof(buf));
-        if (err.code != 0)
+        if (err != 0)
           lerrorf(IOError, "path.cwd: could not get cwd: %s", uv_strerror(err));
         return string_from_cstr(buf);
     }
     char *ptr = tostring(args[0], "path.cwd");
     err = uv_chdir(ptr);
-    if (err.code != 0)
+    if (err != 0)
         lerrorf(IOError, "path.cwd: could not cd to %s: %s", ptr, uv_strerror(err));
     return FL_T;
 }

--- a/src/init.c
+++ b/src/init.c
@@ -52,7 +52,7 @@ void __cdecl fpreset (void);
 #include <windows.h>
 #include <dbghelp.h>
 extern int needsSymRefreshModuleList;
-extern WINBOOL WINAPI (*hSymRefreshModuleList)(HANDLE);
+extern BOOL (*hSymRefreshModuleList)(HANDLE);
 #endif
 #if defined(__linux__)
 //#define _GNU_SOURCE

--- a/src/init.c
+++ b/src/init.c
@@ -52,7 +52,7 @@ void __cdecl fpreset (void);
 #include <windows.h>
 #include <dbghelp.h>
 extern int needsSymRefreshModuleList;
-extern BOOL (*hSymRefreshModuleList)(HANDLE);
+extern BOOL (WINAPI *hSymRefreshModuleList)(HANDLE);
 #endif
 #if defined(__linux__)
 //#define _GNU_SOURCE

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -491,7 +491,7 @@ DLLEXPORT int jl_write_copy(uv_stream_t *stream, const char *str, size_t n, uv_w
     memcpy(data,str,n);
     uv_buf_t buf[]  = {{.base = data,.len=n}};
     uvw->data = NULL;
-    int err = uv_write(uvw,stream,buf,1,writecb);  
+    int err = uv_write(uvw,stream,buf,1,(uv_write_cb)writecb);  
     JL_SIGATOMIC_END();
     return err;
 }
@@ -532,7 +532,7 @@ DLLEXPORT int jl_write_no_copy(uv_stream_t *stream, char *data, size_t n, uv_wri
 {
     uv_buf_t buf[]  = {{.base = data,.len=n}};
     JL_SIGATOMIC_BEGIN();
-    int err = uv_write(uvw,stream,buf,1,writecb);
+    int err = uv_write(uvw,stream,buf,1,(uv_write_cb)writecb);
     uvw->data = NULL;
     JL_SIGATOMIC_END();
     return err;
@@ -645,7 +645,7 @@ DLLEXPORT void jl_exit(int exitcode)
 
 DLLEXPORT int jl_cwd(char *buffer, size_t size)
 {
-    return uv_cwd(buffer,size);
+    return uv_cwd(buffer,size).code;
 }
 
 DLLEXPORT int jl_getpid()
@@ -684,7 +684,7 @@ DLLEXPORT int jl_uv_sizeof_interface_address()
 
 DLLEXPORT int jl_uv_interface_addresses(uv_interface_address_t **ifAddrStruct,int *count)
 {
-    return uv_interface_addresses(ifAddrStruct,count);
+    return uv_interface_addresses(ifAddrStruct,count).code;
 }
 
 DLLEXPORT int jl_uv_interface_address_is_internal(uv_interface_address_t *addr)

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -645,7 +645,7 @@ DLLEXPORT void jl_exit(int exitcode)
 
 DLLEXPORT int jl_cwd(char *buffer, size_t size)
 {
-    return uv_cwd(buffer,size).code;
+    return uv_cwd(buffer,size);
 }
 
 DLLEXPORT int jl_getpid()
@@ -684,7 +684,7 @@ DLLEXPORT int jl_uv_sizeof_interface_address()
 
 DLLEXPORT int jl_uv_interface_addresses(uv_interface_address_t **ifAddrStruct,int *count)
 {
-    return uv_interface_addresses(ifAddrStruct,count).code;
+    return uv_interface_addresses(ifAddrStruct,count);
 }
 
 DLLEXPORT int jl_uv_interface_address_is_internal(uv_interface_address_t *addr)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -69,7 +69,7 @@ int jl_is_type(jl_value_t *v)
     return jl_is_nontuple_type(v);
 }
 
-static inline int is_unspec(jl_datatype_t *dt)
+STATIC_INLINE int is_unspec(jl_datatype_t *dt)
 {
     return (jl_datatype_t*)dt->name->primary == dt;
 }
@@ -280,7 +280,7 @@ typedef struct {
     jl_tuple_t *tvars;
 } cenv_t;
 
-static inline int is_bnd(jl_tvar_t *tv, cenv_t *env)
+STATIC_INLINE int is_bnd(jl_tvar_t *tv, cenv_t *env)
 {
     if (jl_is_typevar(env->tvars))
         return (jl_tvar_t*)env->tvars == tv;
@@ -291,7 +291,7 @@ static inline int is_bnd(jl_tvar_t *tv, cenv_t *env)
     return 0;
 }
 
-static inline int is_btv(jl_value_t *v)
+STATIC_INLINE int is_btv(jl_value_t *v)
 {
     return jl_is_typevar(v) && ((jl_tvar_t*)v)->bound;
 }

--- a/src/newobj_internal.h
+++ b/src/newobj_internal.h
@@ -1,14 +1,14 @@
 #ifndef NEWOBJ_INTERNAL_H
 #define NEWOBJ_INTERNAL_H
 
-static inline jl_value_t *newobj(jl_value_t *type, size_t nfields)
+STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
 {
     jl_value_t *jv = (jl_value_t*)allocobj((1+nfields) * sizeof(void*));
     jv->type = type;
     return jv;
 }
 
-static inline jl_value_t *newstruct(jl_datatype_t *type)
+STATIC_INLINE jl_value_t *newstruct(jl_datatype_t *type)
 {
     jl_value_t *jv = (jl_value_t*)allocobj(sizeof(void*) + type->size);
     jv->type = (jl_value_t*)type;

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -28,7 +28,7 @@ XOBJS = $(DOBJS)
 endif
 
 FLAGS = -Wall -Wno-strict-aliasing $(CFLAGS) $(HFILEDIRS:%=-I%) -I$(LIBUV_INC) \
-        -fvisibility=hidden
+        -fvisibility=hidden -DLIBRARY_EXPORTS
 
 DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -1,14 +1,14 @@
 #ifndef DTYPES_H
 #define DTYPES_H
 
+#include "platform.h"
+
 #if !defined(_OS_WINDOWS_)
 #include <inttypes.h>
 #endif
 #include <stddef.h>
 #include <stddef.h> // double include of stddef.h fixes #3421
 #include <stdint.h>
-
-#include "platform.h"
 
 #if defined(_OS_WINDOWS_)
 

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -55,10 +55,10 @@
 
 #ifdef _OS_WINDOWS_
 #define STDCALL __stdcall
-# ifdef IMPORT_EXPORTS
-#  define DLLEXPORT __declspec(dllimport)
-# else
+# ifdef LIBRARY_EXPORTS
 #  define DLLEXPORT __declspec(dllexport)
+# else
+#  define DLLEXPORT __declspec(dllimport)
 # endif
 #else
 #define STDCALL

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -1,14 +1,15 @@
 #ifndef DTYPES_H
 #define DTYPES_H
 
+#include <stddef.h>
+#include <stddef.h> // double include of stddef.h fixes #3421
+#include <stdint.h>
+
 #include "platform.h"
 
 #if !defined(_OS_WINDOWS_)
 #include <inttypes.h>
 #endif
-#include <stddef.h>
-#include <stddef.h> // double include of stddef.h fixes #3421
-#include <stdint.h>
 
 #if defined(_OS_WINDOWS_)
 

--- a/src/task.c
+++ b/src/task.c
@@ -530,7 +530,7 @@ static int frame_info_from_ip(const char **func_name, int *line_num, const char 
 
 #if defined(_OS_WINDOWS_)
 int needsSymRefreshModuleList;
-WINBOOL WINAPI (*hSymRefreshModuleList)(HANDLE);
+BOOL (*hSymRefreshModuleList)(HANDLE);
 DLLEXPORT size_t rec_backtrace(ptrint_t *data, size_t maxsize)
 {
     CONTEXT Context;

--- a/src/task.c
+++ b/src/task.c
@@ -530,7 +530,7 @@ static int frame_info_from_ip(const char **func_name, int *line_num, const char 
 
 #if defined(_OS_WINDOWS_)
 int needsSymRefreshModuleList;
-BOOL (*hSymRefreshModuleList)(HANDLE);
+BOOL (WINAPI *hSymRefreshModuleList)(HANDLE);
 DLLEXPORT size_t rec_backtrace(ptrint_t *data, size_t maxsize)
 {
     CONTEXT Context;


### PR DESCRIPTION
This is some work to make libjulia compile on windows with the intel compiler. There are already some make scripts (Windows.mk) in the julia source tree but it required some work to get it compile.

Some of the things are also a step forward to compile libjulia with MSVC.

Changes:
- __uint128_t is not defined in non-gcc environment
- There were some places where dynamically stack allocated C arrays were used (VLAs) (i.e. ccall.cpp:750). But these are not available in C++. I have changed these to use alloca.
- There was an issue with WINBOOL. I replaced it with BOOL, which should be defined for all windows compilers.
- The WINAPI macro has to be put into the brackets when declaring a function pointer.
- In dtypes.h  the header platform.h has to be included first as otherwise, the define _OS_WINDOWS_ is not available
- When including LLVM headers one has to define #define NOMINMAX as otherwise std::max is shadowed by a windows macro for max

It would be great if someone could review this and commit if it is fine.

There are still some issues left as my self-written program that uses libjulia crashes when trying to either build Base or use an exsisting sys.jl but I think this is the next step and want to first get this in.

One last comment on MSVC: With VS2010 there is an issue: It basically only allows C89. Solutions:
a) Forget about VS2010 and try VS2013 which should have basic C99 support
b) Put all declarations at the beginnings of each block (oh my god)
c) Compile with MSVC C++ compiler. This would mean that we have to introduce casts when assigning pointers of different type (i.e. jl_value_t\* x = (jl_value_t*) JL_NULL)
