### PR TITLE
RFC: ifpkg macro

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1279,4 +1279,5 @@ export
     @sprintf,
     @deprecate,
     @boundscheck,
-    @inbounds
+    @inbounds,
+    @ifpkg

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -67,3 +67,15 @@ generate(pkg::String, license::String; force::Bool=false) =
 @deprecate fix pin
 
 end # module
+
+macro ifpkg(reqline, iftrue, iffalse...)
+	length(iffalse) <= 1 || error("ifpkg: wrong number of arguments")
+	isa(reqline, String) || error("ifpkg: reqline must be a string")
+	if Pkg.Dir.cd(Pkg.Entry.issatisfied, reqline)
+		iftrue
+	elseif !isempty(iffalse)
+		iffalse[1]
+	else
+		nothing
+	end
+end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -79,6 +79,14 @@ function installed(pkg::String)
     return nothing # registered but not installed
 end
 
+function issatisfied(reqline::String)
+    req = Reqs.Requirement(reqline)
+    Reqs.applies(req) || return true
+    req.package == "julia" && return VERSION in req.versions
+    Read.isinstalled(req.package) || return false
+    Read.installed_version(req.package) in req.versions
+end
+
 function status(io::IO)
     reqs = Reqs.parse("REQUIRE")
     instd = Read.installed()


### PR DESCRIPTION
We're getting to the point where package authors might want to execute different code depending on the version of another package or the version of Julia itself. This PR proposes an `@ifpkg` macro for doing so. `@ifpkg` accepts a requirement line of the same form as the REQUIRE file and determines whether that requirement is satisfied by an installed package. If it is satisfied, it substitutes its second argument. Otherwise it substitutes its third argument, or nothing if no third argument is specified.

Some examples of how this might be used:

``` julia
@ifpkg "julia 0.3-" eigvecs(A, ev) eigvecs(A, ev)[1]
@ifpkg "DataFrames 0.4" begin
    # DataFrames interface code goes here
end
```

There are two practical problems with the approach I'm using here. First, at least on my machine, `Pkg.installed()` is takes more than a second to execute. Since this macro calls the same Pkg functions, it takes just as long, which is not really acceptable for code that will be executed when loading packages. Second, I don't expect that this would work as implemented with Julia workers running on a different machine.

I am also unsure whether this macro is the right approach to this problem. It's arguable that ~~you could just use `@eval`~~ an eagerly-evaluted `@if` macro would be better:

``` julia
@if VERSION >= v"0.3-" eigvecs(A, ev) eigvecs(A, ev)[1]
@if isdir(Pkg.dir("DataFrames")) begin
    # DataFrames interface code goes here
end
```

although this gets messy if you want code to execute only if a package is registered in the user's METADATA checkout, it is installed, and it is newer than a certain version. But maybe the right approach is a new function and a more general macro.
