### PR TITLE
add realmin realmax for BigFloat

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -19,7 +19,8 @@ import
         gamma, lgamma, digamma, erf, erfc, zeta, log1p, airyai, iceil, ifloor,
         itrunc, eps, signbit, sin, cos, tan, sec, csc, cot, acos, asin, atan,
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, atan2,
-        serialize, deserialize, inf, nan, hash, cbrt, typemax, typemin
+        serialize, deserialize, inf, nan, hash, cbrt, typemax, typemin,
+        realmin, realmax
 
 import Base.Math.lgamma_r
 
@@ -686,6 +687,9 @@ function prevfloat(x::BigFloat)
 end
 
 eps(::Type{BigFloat}) = nextfloat(BigFloat(1)) - BigFloat(1)
+
+realmin(::Type{BigFloat}) = nextfloat(zero(BigFloat))
+realmax(::Type{BigFloat}) = prevfloat(inf(BigFloat))
 
 function with_bigfloat_precision(f::Function, precision::Integer)
     old_precision = get_bigfloat_precision()

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -341,6 +341,14 @@ end
 x = eps(BigFloat)
 @test BigFloat(1) + x == BigFloat(1) + prevfloat(x)
 
+# realmin/realmax
+x = realmin(BigFloat)
+@test x > 0 
+@test prevfloat(x) == 0
+x = realmax(BigFloat)
+@test !isinf(x)
+@test isinf(nextfloat(x))
+
 # factorial
 with_bigfloat_precision(256) do
     x = BigFloat(42)


### PR DESCRIPTION
This adds `realmin` and `realmax` methods for `BigFloat`.

See discussion [here](https://github.com/JuliaStats/Distributions.jl/pull/148#issuecomment-24661366)
