### PR TITLE
More accurate linspace for types with greater precision than Float64

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -234,8 +234,9 @@ function linspace(start::Real, stop::Real, n::Integer)
         return a
     end
     n -= 1
+    S = promote_type(T, Float64)
     for i=0:n
-        a[i+1] = start*((n-i)/n) + stop*(i/n)
+        a[i+1] = start*(convert(S, (n-i))/n) + stop*(convert(S, i)/n)
     end
     a
 end


### PR DESCRIPTION
Before:

```
julia> linspace(BigFloat(0), BigFloat(1), 4)
4-element Array{BigFloat,1}:
 0e+00                                                      
 3.33333333333333314829616256247390992939472198486328125e-01
 6.6666666666666662965923251249478198587894439697265625e-01 
 1e+00
```

After:

```
julia> linspace(BigFloat(0), BigFloat(1), 4)
4-element Array{BigFloat,1}:
 0e+00                                                                               
 3.333333333333333333333333333333333333333333333333333333333333333333333333333348e-01
 6.666666666666666666666666666666666666666666666666666666666666666666666666666695e-01
 1e+00
```
