### PR TITLE
Add function to get libjulia path at runtime

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -209,6 +209,44 @@ char *jl_dlfind_win32(char *f_name)
 }
 #endif
 
+static char* libjulia_path = NULL;
+DLLEXPORT char *jl_get_libjulia_path()
+{
+    if(libjulia_path != NULL)
+    {
+        int max_path = 512;
+        libjulia_path = malloc(max_path);
+
+#ifdef _OS_WINDOWS_
+
+        HMODULE hm = NULL;
+
+        if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                (LPCSTR) &jl_get_libjulia_path,
+                &hm))
+        {
+            int ret = GetLastError();
+            fprintf(stderr, "GetModuleHandle returned %d\n", ret);
+        }
+        GetModuleFileNameA(hm, libjulia_path, max_path);
+#else
+        Dl_info dl_info;
+        dladdr((void *)jl_get_libjulia_path, &dl_info);
+        strncpy(libjulia_path, dl_info.dli_fname, max_path);
+#endif
+
+        // remove libjulia.so/dll/dylib from full path
+        char * pos = strrchr(libjulia_path, PATHSEP);
+        if (pos)
+        { // terminate string
+          pos[1] = '\0';
+        }
+      }
+
+    return libjulia_path;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -209,41 +209,36 @@ char *jl_dlfind_win32(char *f_name)
 }
 #endif
 
-static char* libjulia_path = NULL;
+static char *libjulia_path = NULL;
 DLLEXPORT char *jl_get_libjulia_path()
 {
-    if(libjulia_path != NULL)
-    {
+    if (libjulia_path != NULL) {
         int max_path = 512;
         libjulia_path = malloc(max_path);
 
 #ifdef _OS_WINDOWS_
-
         HMODULE hm = NULL;
 
         if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                (LPCSTR) &jl_get_libjulia_path,
-                &hm))
-        {
+                                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                                (LPCSTR) &jl_get_libjulia_path,
+                                &hm)) {
             int ret = GetLastError();
             fprintf(stderr, "GetModuleHandle returned %d\n", ret);
         }
         GetModuleFileNameA(hm, libjulia_path, max_path);
 #else
         Dl_info dl_info;
-        dladdr((void *)jl_get_libjulia_path, &dl_info);
+        dladdr((void*)jl_get_libjulia_path, &dl_info);
         strncpy(libjulia_path, dl_info.dli_fname, max_path);
 #endif
 
         // remove libjulia.so/dll/dylib from full path
-        char * pos = strrchr(libjulia_path, PATHSEP);
-        if (pos)
-        { // terminate string
-          pos[1] = '\0';
+        char *pos = strrchr(libjulia_path, PATHSEP);
+        if (pos) { // terminate string
+            pos[1] = '\0';
         }
-      }
-
+    }
     return libjulia_path;
 }
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -906,6 +906,7 @@ DLLEXPORT int jl_uv_dlopen(const char *filename, uv_lib_t *lib, unsigned flags);
 DLLEXPORT uv_lib_t *jl_wrap_raw_dl_handle(void *handle);
 char *jl_dlfind_win32(char *name);
 DLLEXPORT int add_library_mapping(char *lib, void *hnd);
+DLLEXPORT char *jl_get_libjulia_path();
 
 #if defined(__linux__) || defined(__FreeBSD__)
 DLLEXPORT const char *jl_lookup_soname(char *pfx, size_t n);


### PR DESCRIPTION
This adds a function "jl_get_libjulia_path" that gives the path of the libjulia library at runtime.

I would propose that this path should be the first location where the sys.ji (or sys.so in the future) is searched (in jl_init and repl.c). Once the static compilation branch is merged I can make a PR for changes in jl_init and repl.c

In this PR only the addition of the function is included.
