### PR TITLE
Add IO->FILE* for interfacing with C functions

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -25,6 +25,7 @@ export
     BitMatrix,
     BitVector,
     BunchKaufman,
+    CFILE,
     Cholesky,
     CholeskyPivoted,
     Cmd,

--- a/test/file.jl
+++ b/test/file.jl
@@ -215,6 +215,23 @@ close(af)
 rm(afile)
 rm(bfile)
 
+###################
+# FILE* interface #
+###################
+
+f = open(file, "w")
+write(f, "Hello, world!")
+close(f)
+f = open(file, "r")
+FILEp = convert(CFILE, f)
+buf = Array(Uint8, 8)
+str = ccall(:fread, Csize_t, (Ptr{Void}, Csize_t, Csize_t, Ptr{Void}), buf, 1, 8, FILEp.ptr)
+@test bytestring(buf) == "Hello, w"
+@test position(FILEp) == 8
+seek(FILEp, 5)
+@test position(FILEp) == 5
+close(f)
+
 ############
 # Clean up #
 ############


### PR DESCRIPTION
In particular, I've found `fdopen` useful when interfacing with C libraries that do I/O. For example, suppose you need to parse the magic bytes of the file to check that it's of the type you expect (which you might do in Julia), then hand off I/O to a C function.

Rather than implementing this functionality multiple times in different packages, it seemed like it might be time to consider standardizing such functionality. Alternatively, we could have a `CIO.jl` package.

This has only been tested on Linux, although I tried to write it in a way that _should_ work on all platforms.

It might be prettiest to make `ccall` automatically convert an `IOStream` to a `FILE*`, if possible. However, there might be performance issues arising from the `fseek`, so it might be better not to make this _too_ easy.

Finally, the main reason this is a WIP: if the stream is opened in mode `"w"`, `fdopen` segfaults. HOWEVER, that seems to be because of this odd behavior:

```
julia> s = open("/tmp/test.dat", "w")
IOStream(<file /tmp/test.dat>)

julia> isreadable(s)
true
```

That seems like a bug to me. If you work around it with

```
julia> FILEp = fdopen(fd(s), "w")
Ptr{Void} @0x00000000048a3950
```

then there is no segfault.
