### PR TITLE
RFC support for rand(Ranges) and rand(Ranges,dims)

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -110,6 +110,7 @@ rand(::Type{Float16}) = float16(rand())
 
 rand{T<:Real}(::Type{Complex{T}}) = complex(rand(T),rand(T))
 
+
 rand(r::MersenneTwister) = dsfmt_genrand_close_open(r.state)
 
 ## random integers
@@ -181,12 +182,18 @@ function rand(r::Range1{Int128})
     ulen = convert(Uint128, length(r))
     convert(Int128, first(r) + randu(ulen))
 end
+function rand{T<:Real}(r::Ranges{T})
+    ulen = convert(Uint64, length(r)) #length of Ranges is stored as Int, Uint64 is always enough
+    convert(T, first(r) + randu(ulen)*step(r))
+end
 
 
-# fallback for other integer types
+# fallback for other Real types
 rand{T<:Integer}(r::Range1{T}) = convert(T, rand(int(r)))
+rand{T<:Real}(r::Ranges{T}, dims::Dims) = rand!(r, Array(T, dims))
+rand{T<:Real}(r::Ranges{T}, dims::Int...) = rand(r, dims)
 
-function rand!{T<:Integer}(r::Range1{T}, A::Array{T})
+function rand!{T<:Real}(r::Ranges{T}, A::Array{T})
     for i=1:length(A) 
         A[i] = rand(r)
     end

--- a/test/random.jl
+++ b/test/random.jl
@@ -6,10 +6,15 @@
 @test minimum([rand(int32(1):int32(7^7)) for i = 1:100000]) > 0
 @test(typeof(rand(false:true)) == Bool)
 
-for T in (Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64, Int128, Uint128, Char, BigInt)
+for T in (Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64, Int128, Uint128, Char, BigInt,
+	Float16, Float32, Float64, Rational{Int})
     r = rand(convert(T, 97):convert(T, 122))
     @test typeof(r) == T
     @test 97 <= r <= 122
+    r = rand(convert(T, 97):convert(T,2):convert(T, 122),2)[1]
+    @test typeof(r) == T
+    @test 97 <= r <= 122
+    @test mod(r,2)==1
 end
 
 if sizeof(Int32) < sizeof(Int)


### PR DESCRIPTION
previously rand accepted only Range1{T<:Integer} 
closes #5041

allows things like

```
julia> rand(1:1//2:10,1,5)
1x5 Array{Rational{Int64},2}:
 19//2  19//2  2//1  8//1  17//2
julia> rand(1:7:100,1,5)
1x5 Array{Int64,2}:
 57  92  15  99  50
```

I left in most of the specific Range1{T<:Integer} code because I wasn't sure about performance.
