### PR TITLE
avoid depending on the libpcre version

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -355,8 +355,6 @@ function _start()
     fdwatcher_reinit()
     # Initialize RNG
     Random.librandom_init()
-    # Ensure PCRE is compatible with the compiled reg-exes
-    PCRE.check_pcre()
     Sys.init()
     global const CPU_CORES = Sys.CPU_CORES
     if CPU_CORES > 8 && !("OPENBLAS_NUM_THREADS" in keys(ENV)) && !("OMP_NUM_THREADS" in keys(ENV))


### PR DESCRIPTION
This makes compiling pcre regex's lazier, so that they can don't depend upon the runtime version of libpcre. This would have helped with various issues such as #1221 and https://groups.google.com/d/msg/julia-users/HwXBv9v1mM4/o_W2NBXd1rQJ. It also makes #324 easy to implement.
