### PR TITLE
accelerate openblas startup for many-core machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ $(BUILD)/share/man/man1/julia.1: doc/man/julia.1 | $(BUILD)/share/julia
 
 $(BUILD)/etc/julia/juliarc.jl: etc/juliarc.jl | $(BUILD)/etc/julia
 	@cp $< $@
+ifeq ($(OS), WINNT)
+	@cat ./contrib/windows/juliarc.jl >> $(BUILD)/etc/julia/juliarc.jl
+$(BUILD)/etc/julia/juliarc.jl: contrib/windows/juliarc.jl
+endif
 
 # use sys.ji if it exists, otherwise run two stages
 $(BUILD)/$(JL_PRIVATE_LIBDIR)/sys%ji: $(BUILD)/$(JL_PRIVATE_LIBDIR)/sys%bc
@@ -232,8 +236,6 @@ endif
 	# If you want to make a distribution with a hardcoded path, you take care of installation
 ifeq ($(OS), Darwin)
 	-cat ./contrib/mac/juliarc.jl >> $(PREFIX)/etc/julia/juliarc.jl
-else ifeq ($(OS), WINNT)
-	-cat ./contrib/windows/juliarc.jl >> $(PREFIX)/etc/julia/juliarc.jl
 endif
 
 ifeq ($(OS), WINNT)

--- a/base/client.jl
+++ b/base/client.jl
@@ -373,23 +373,17 @@ function _start()
     Random.librandom_init()
     # Ensure PCRE is compatible with the compiled reg-exes
     PCRE.check_pcre()
+    Sys.init()
+    global const CPU_CORES = Sys.CPU_CORES
+    if CPU_CORES > 8 && !("OPENBLAS_NUM_THREADS" in keys(ENV)) && !("OMP_NUM_THREADS" in keys(ENV))
+        # Prevent openblas from stating to many threads, unless/until specifically requested
+        ENV["OPENBLAS_NUM_THREADS"] = 8
+    end
     # Check that BLAS is correctly built
     check_blas()
     LinAlg.init()
-    Sys.init()
     GMP.gmp_init()
-    global const CPU_CORES = Sys.CPU_CORES
     init_profiler()
-
-    @windows_only ENV["PATH"] = JULIA_HOME*";"*joinpath(JULIA_HOME,"..","Git","bin")*";"*ENV["PATH"]*
-        ";C:\\Program Files\\Git\\bin;C:\\Program Files (x86)\\Git\\bin"*
-        ";C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin"*
-        ";C:\\Python27;C:\\Python26;C:\\Python25"
-    @windows_only haskey(ENV,"JULIA_EDITOR") || (ENV["JULIA_EDITOR"] = "start")
-    @windows_only begin
-        user_data_dir = abspath(ENV["AppData"],"julia")
-        isdir(user_data_dir) || mkdir(user_data_dir)
-    end
 
     #atexit(()->flush(STDOUT))
     try

--- a/contrib/windows/juliarc.jl
+++ b/contrib/windows/juliarc.jl
@@ -1,0 +1,9 @@
+let user_data_dir
+    ENV["PATH"] = JULIA_HOME*";"*joinpath(JULIA_HOME,"..","Git","bin")*";"*ENV["PATH"]*
+        ";C:\\Program Files\\Git\\bin;C:\\Program Files (x86)\\Git\\bin"*
+        ";C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin"*
+        ";C:\\Python27;C:\\Python26;C:\\Python25"
+    haskey(ENV,"JULIA_EDITOR") || (ENV["JULIA_EDITOR"] = "start")
+    user_data_dir = abspath(ENV["AppData"],"julia")
+    isdir(user_data_dir) || mkdir(user_data_dir)
+end


### PR DESCRIPTION
Address #4993 and possibly #2852 and #3536
This only works against the static compile branch, because we need to run this code before the codegen loads openblas.
