### PR TITLE
fix eps

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -287,7 +287,7 @@ prevfloat(x::FloatingPoint) = nextfloat(x,-1)
     realmin() = realmin(Float64)
     realmax() = realmax(Float64)
 
-    eps(x::FloatingPoint) = isfinite(x) ? abs(x)-prevfloat(abs(x)) : nan(x)
+    eps(x::FloatingPoint) = isfinite(x) ? abs(x) >= realmin(x) ? ldexp(eps(typeof(x)),exponent(x)) : nextfloat(zero(x)) : nan(x)
     eps(::Type{Float16}) = $(box(Float16,unbox(Uint16,0x1400)))
     eps(::Type{Float32}) = $(box(Float32,unbox(Uint32,0x34000000)))
     eps(::Type{Float64}) = $(box(Float64,unbox(Uint64,0x3cb0000000000000)))

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -340,6 +340,7 @@ end
 # eps
 x = eps(BigFloat)
 @test BigFloat(1) + x == BigFloat(1) + prevfloat(x)
+@test eps(BigFloat) == eps(BigFloat(1))
 
 # realmin/realmax
 x = realmin(BigFloat)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1093,7 +1093,22 @@ end
 @test mod(int64(2),typemax(Int64)) == 2
 
 # things related to floating-point epsilon
+@test eps() == eps(Float64)
+@test eps(Float64) == eps(1.0)
+@test eps(Float64) == eps(1.5)
+@test eps(Float32) == eps(1f0)
 @test eps(float(0)) == 5e-324
+@test eps(-float(0)) == 5e-324
+@test eps(nextfloat(float(0))) == 5e-324
+@test eps(-nextfloat(float(0))) == 5e-324
+@test eps(realmin()) == 5e-324
+@test eps(-realmin()) == 5e-324
+@test eps(realmax()) ==  2.0^(1023-52)
+@test eps(-realmax()) ==  2.0^(1023-52)
+@test isnan(eps(NaN))
+@test isnan(eps(Inf))
+@test isnan(eps(-Inf))
+
 @test .1+.1+.1 != .3
 # TODO: uncomment when isapprox() becomes part of base.
 # @test isapprox(.1+.1+.1, .3)


### PR DESCRIPTION
This fixes a problem from the changed definition of `eps` in commit a4f9c269873f3f027f4ace92bce99b81a5bf977f so that `eps() = eps(1.0)`, with correct behaviour for `realmin()` and `realmax()`.

Note that due to lack of subnormals, `BigFloat` behaviour is a bit strange, so that `eps(zero(BigFloat)) == realmin(BigFloat)`, and `eps(realmin(BigFloat)) == zero(BigFloat)`, but I don't know what else would be best here.

UPDATE: it may be possible to make this more efficient with some bit-twiddling, but I'll leave that to someone else.
