### PR TITLE
Doc: Correct the function signature for parse and add an entry for the shorter signature

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -376,9 +376,13 @@ Syntax
 
    Generates a gensym symbol for a variable. For example, `@gensym x y` is transformed into `x = gensym("x"); y = gensym("y")`.
 
-.. function:: parse(str, [start]; greedy=true, raise=false)
+.. function:: parse(str, start; greedy=true, raise=true)
 
    Parse the expression string and return an expression (which could later be passed to eval for execution). Start is the index of the first character to start parsing (default is 1). If greedy is true (default), parse will try to consume as much input as it can; otherwise, it will stop as soon as it has parsed a valid token. If raise is true (default), parse errors will raise an error; otherwise, parse will return the error as an expression object.
+
+.. function:: parse(str; raise=true)
+
+   Parse the whole string greedily, returning a single expression.  An error is thrown if there are additional characters after the first expression.
 
 Iteration
 ---------


### PR DESCRIPTION
My take on the discussion on parse at https://groups.google.com/forum/#!topic/julia-dev/ulCca30P55g was to add a documentation entry specific to the shorter signature.  In doing so, I noticed that the documentation for the long form had an incorrect default.  This fixes both.
