### PR TITLE
Improve manual page and add julia-{basic,readline}

### DIFF
--- a/doc/man/julia-basic.1
+++ b/doc/man/julia-basic.1
@@ -1,0 +1,1 @@
+.so man1/julia.1

--- a/doc/man/julia-readline.1
+++ b/doc/man/julia-readline.1
@@ -1,0 +1,1 @@
+.so man1/julia.1

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -1,38 +1,37 @@
-./" To get a preview of the man page as it will actually be displayed, run
-./"
-./" > nroff -man julia.1 | less
-./"
-./" at the terminal.
-./"
-./" Suggestions and improvements very much appreciated!
-./" Nothing is too large or too small.
-./" This man page was largely taken from pre-existing sources of documentation.
-./" This is documented by comments in the man page's source.
-./"
-./" # TODOs:
-./" 1. Simple, hopefully portable way to get the man page on everyone's manpath.
-./"    (The whole point was to be able to simply `man julia`!)
-./" 2. Put options in alphabetical order instead of the order from julia --help?
-./"
-./" Possible sections to add to man page:
-./" - licensing
-./" - internet resources and/or documentation
-./" - environment
-./" - files
-./" - see also
-./" - diagnostics
-./" - notes
+.\" To get a preview of the man page as it will actually be displayed, run
+.\"
+.\" > nroff -man julia.1 | less
+.\"
+.\" at the terminal.
+.\"
+.\" Suggestions and improvements very much appreciated!
+.\" Nothing is too large or too small.
+.\" This man page was largely taken from pre-existing sources of documentation.
+.\" This is documented by comments in the man page's source.
+.\"
+.\" # TODOs:
+.\" 1. Simple, hopefully portable way to get the man page on everyone's manpath.
+.\"    (The whole point was to be able to simply `man julia`!)
+.\" 2. Put options in alphabetical order instead of the order from julia --help?
+.\"
+.\" Possible sections to add to man page:
+.\" - licensing
+.\" - internet resources and/or documentation
+.\" - environment
+.\" - see also
+.\" - diagnostics
+.\" - notes
 
-.TH JULIA 1 2013-06-11 Julia "Julia Programmers' Reference Guide"
+.TH JULIA 1 2013-12-10 Julia "Julia Programmers' Reference Guide"
 
-./" from the front page of http://julialang.org/
+.\" from the front page of http://julialang.org/
 .SH NAME
-julia - high-level, high-performance dynamic programming language for technical computing
+julia, julia-basic, julia-readline - high-level, high-performance dynamic programming language for technical computing
 
 .SH SYNOPSIS
 julia [option] [program] [args..]
 
-./" Taken almost verbatim from the front page of http://julialang.org/
+.\" Taken almost verbatim from the front page of http://julialang.org/
 .SH DESCRIPTION
 Julia is a high-level, high-performance dynamic programming language
 for technical computing, with syntax that is familiar to users
@@ -51,8 +50,19 @@ For a more in-depth discussion of the rationale and advantages of Julia
 over other systems, please see the online manual:
 http://docs.julialang.org/en/latest/manual/
 
+\fBjulia\fP is an alias for \fBjulia-readline\fP.
 
-./" This section was taken nearly verbatim from the output of `julia --help`
+\fBjulia-readline\fP launches an interactive Julia session with Readline
+capabilities.
+
+\fBjulia-basic\fP launches an interactive Julia session without
+Readline capabilities.
+
+If a Julia source file is given as \fIprogram\fP (possibly with arguments in
+\fIargs\fP) then, instead of launching an interactive session, Julia executes
+the program and exits.
+
+.\" This section was taken nearly verbatim from the output of `julia --help`
 .SH "COMMAND-LINE OPTIONS"
 .TP 25
 -v --version
@@ -118,6 +128,17 @@ Load ~/.juliarc.jl, then handle remaining inputs
 -h --help
 Print a help message displaying command-line arguments
 
+
+.SH FILES
+.I ~/.juliarc.jl
+.RS
+Per user startup file.
+.RE
+
+.I /etc/julia/juliarc.jl
+.RS
+System-wide startup file.
+.RE
 
 .SH BUGS
 Please report any bugs using the GitHub issue tracker:


### PR DESCRIPTION
This is yet another patch that distributions could stop carrying
if this was merged.

I'm not sure in what cases julia-debug is installed, but it could
make sense to provide another man page too, or at least a redirection.
