### PR TITLE
RFC: Restored old, 30x faster version of digamma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.o
 *.dylib
 *.dSYM
+.Rhistory

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@
 *.o
 *.dylib
 *.dSYM
-.Rhistory

--- a/test/math.jl
+++ b/test/math.jl
@@ -124,6 +124,19 @@ y33 = bessely(3,3.)
 
 # digamma
 for elty in (Float32, Float64)
+
+    @test_approx_eq digamma(convert(elty, 9)) convert(elty, 2.140641477955609996536345)
+    @test_approx_eq digamma(convert(elty, 2.5)) convert(elty, 0.7031566406452431872257)
+    @test_approx_eq digamma(convert(elty, 0.1)) convert(elty, -10.42375494041107679516822)
+    @test_approx_eq digamma(convert(elty, 7e-4)) convert(elty, -1429.147493371120205005198)
+    @test_approx_eq digamma(convert(elty, 7e-5)) convert(elty, -14286.29138623969227538398)
+    @test_approx_eq digamma(convert(elty, 7e-6)) convert(elty, -142857.7200612932791081972)
+    @test_approx_eq digamma(convert(elty, 2e-6)) convert(elty, -500000.5772123750382073831)
+    @test_approx_eq digamma(convert(elty, 1e-6)) convert(elty, -1000000.577214019968668068)
+    @test_approx_eq digamma(convert(elty, 7e-7)) convert(elty, -1428572.005785942019703646)
+    @test_approx_eq digamma(convert(elty, -0.5)) convert(elty, .03648997397857652055902367)
+    @test_approx_eq digamma(convert(elty, -1.1)) convert(elty,  10.15416395914385769902271)
+
     @test_approx_eq digamma(convert(elty, 0.1)) convert(elty, -10.42375494041108)
     @test_approx_eq digamma(convert(elty, 1/2)) convert(elty, -γ - log(4))
     @test_approx_eq digamma(convert(elty, 1)) convert(elty, -γ)


### PR DESCRIPTION
Commit b19013db795af2d578090fd5c2c3462e43f5c422, "Add Julia translation of psifn from SLATEC with interfaces di-, tri- … " added a flexible polygamma function, but converting digamma into a thin wrapper around polygamma makes it 30-100x slower on my laptop.  This patch keeps the polygamma function, but keeps the old digamma implementation for that important special case.

I also added a few additional tests from Tom Minka's Lighspeed toolbox (http://research.microsoft.com/en-us/um/people/minka/software/lightspeed/)
