### PR TITLE
Also serialize dt->instance. Fixes #5129

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -595,7 +595,7 @@ static size_t mark_sp = 0;
 
 static void push_root(jl_value_t *v, int d);
 
-#define gc_push_root(v,d) if (!gc_marked(v)) push_root((jl_value_t*)(v),d);
+#define gc_push_root(v,d) do {  assert(v != NULL); if (!gc_marked(v)) { push_root((jl_value_t*)(v),d); } } while (0)
 
 void jl_gc_setmark(jl_value_t *v)
 {

--- a/src/init.c
+++ b/src/init.c
@@ -154,6 +154,7 @@ void restore_signals()
 }
 void jl_throw_in_ctx(jl_value_t* excpt, CONTEXT *ctxThread, int bt)
 {
+    assert(excpt != NULL);
     bt_size = bt ? rec_backtrace_ctx(bt_data, MAX_BT_SIZE, ctxThread) : 0;
     jl_exception_in_transit = excpt;
 #if defined(_CPU_X86_64_)

--- a/src/task.c
+++ b/src/task.c
@@ -724,6 +724,7 @@ DLLEXPORT void gdbbacktrace()
 // yield to exception handler
 void NORETURN throw_internal(jl_value_t *e)
 {
+    assert(e != NULL);
     jl_exception_in_transit = e;
     if (jl_current_task->eh != NULL) {
         jl_longjmp(jl_current_task->eh->eh_ctx, 1);
@@ -751,6 +752,7 @@ void NORETURN throw_internal(jl_value_t *e)
 // record backtrace and raise an error
 DLLEXPORT void jl_throw(jl_value_t *e)
 {
+    assert(e != NULL);
     record_backtrace();
     throw_internal(e);
 }


### PR DESCRIPTION
dt->instance is one of the jl_value_t*'s that can occur purely in code
and not anywhere else in the AST. All other instances of where this
happends are captured by li->roots, since they need GC roots that way,
but this instance is rooted by the owning type.

@JeffBezanson @vtjnash 
