### PR TITLE
Fix inconsistency of lexcmp between scalars and single element arrays

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1037,10 +1037,8 @@ end
 function lexcmp(A::AbstractArray, B::AbstractArray)
     nA, nB = length(A), length(B)
     for i = 1:min(nA, nB)
-        a, b = A[i], B[i]
-        if !isequal(a, b)
-            return isless(a, b) ? -1 : +1
-        end
+        res = lexcmp(A[i], B[i])
+        res == 0 || return res
     end
     return cmp(nA, nB)
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -652,6 +652,17 @@ b = [3,1,2]
 a[b] = a
 @test a == [3,5,1]
 
+# lexicographic comparison
+@test lexcmp([1.0], [1]) == 0
+@test lexcmp([1], [1.0]) == 0
+@test lexcmp([1, 1], [1, 1]) == 0
+@test lexcmp([1, 1], [2, 1]) == -1
+@test lexcmp([2, 1], [1, 1]) == 1
+@test lexcmp([1, 1], [1, 2]) == -1
+@test lexcmp([1, 2], [1, 1]) == 1
+@test lexcmp([1], [1, 1]) == -1
+@test lexcmp([1, 1], [1]) == 1
+
 # sort on arrays
 begin
     local a = rand(3,3)


### PR DESCRIPTION
Before:

``` julia
julia> lexcmp([1.0], [1])
1

julia> lexcmp([1], [1.0])
1
```

After:

``` julia
julia> lexcmp([1.0], [1])
0

julia> lexcmp([1], [1.0])
0
```

I'm submitting this as a pull request because 1) I am not sure we want to call `lexcmp` on array elements, as opposed to `cmp`, and 2) at the root of this bug is:

``` julia
julia> isless(1.0, 1)
false

julia> isless(1, 1.0)
false

julia> isequal(1, 1.0)
false
```

which I'm not sure is intentional.
