### PR TITLE
RFC: Allow tuples as type parameters.

### DIFF
--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -1,7 +1,7 @@
 .. _man-types:
 
 *********
- Types    
+ Types
 *********
 
 Type systems have traditionally fallen into two quite different camps:
@@ -61,7 +61,7 @@ Julia's type system that should be mentioned up front are:
 -  Only values, not variables, have types — variables are simply names
    bound to values.
 -  Both abstract and concrete types can be paramaterized by other types
-   and by certain other values (currently integers and symbols).
+   and by certain other values (currently integers, symbols, bools, and tuples thereof).
    Type parameters may be completely omitted when they
    do not need to be referenced or restricted.
 
@@ -1153,4 +1153,3 @@ If you apply ``super`` to other type objects (or non-type objects), a
 
     julia> super((Float64,Int64))
     ERROR: no method super(Type{(Float64,Int64)})
-

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1447,8 +1447,18 @@ int jl_types_equal_generic(jl_value_t *a, jl_value_t *b, int useenv)
 
 static int valid_type_param(jl_value_t *v)
 {
-    // TODO: maybe more things
-    return jl_is_type(v) || jl_is_long(v) || jl_is_symbol(v) || jl_is_typevar(v) || jl_is_bool(v);
+    if (jl_is_tuple(v)) {
+        size_t i;
+        size_t l = jl_tuple_len(v);
+        for(i=0; i < l; i++) {
+            if (!valid_type_param(jl_tupleref(v,i)))
+                return 0;
+        }
+        return 1;
+    } else {
+        // TODO: maybe more things
+        return jl_is_type(v) || jl_is_long(v) || jl_is_symbol(v) || jl_is_typevar(v) || jl_is_bool(v);
+    }
 }
 
 jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1181,6 +1181,7 @@ end
 f5150(T) = Array(Rational{T},1)
 @test typeof(f5150(Int)) === Array{Rational{Int},1}
 
+
 # issue #5165
 bitstype 64 T5165{S}
 make_t(x::Int64) = Base.box(T5165{Nothing}, Base.unbox(Int64, x))
@@ -1188,4 +1189,27 @@ xs5165 = T5165[make_t(1)]
 b5165 = IOBuffer()
 for x in xs5165
     println(b5165, x)   # segfaulted
+end
+
+# support tuples as type parameters
+
+type TupleParam{P}
+    x::Bool
+end
+
+function tupledispatch(a::TupleParam{(1,:a)})
+    a.x
+end
+
+let
+    # tuples can be used as type params
+    t1 = TupleParam{(1,:a)}(true)
+    t2 = TupleParam{(1,:b)}(true)
+
+    # tuple type params can't contain invalid type params
+    @test_throws t3 = TupleParam{(1,"nope")}(true)
+
+    # dispatch works properly
+    @test tupledispatch(t1) == true
+    @test_throws tupledispatch(t2)
 end


### PR DESCRIPTION
I decided to try and hack #5102 myself; this is what I came up with. Everything seems to work fine; all the tests pass and I added a quick one for this. I am not at all familiar with the internals so its entirely probable that I missed something, @JeffBezanson should certainly take a look. Also let me know if my style is out of line.

NB: since I made `valid_type_param` recursive, things like `(1,(2,3))` become valid type params. If we only want flat tuples I can change this.
