### PR TITLE
RFC: Implementation of deleteat! (Fixes #5118)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,9 @@ Library improvements
 
   * `modpi` function ([#4799]).
 
+  * New function `deleteat!` deletes a specified index or indices and
+    returns the updated collection
+
 Deprecated or removed
 ---------------------
 

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1049,12 +1049,7 @@ function insert!(B::BitVector, i::Integer, item)
     B[i] = item
 end
 
-function splice!(B::BitVector, i::Integer)
-    n = length(B)
-    if !(1 <= i <= n)
-        throw(BoundsError())
-    end
-    v = B[i]
+function _deleteat!(B::BitVector, i::Integer)
 
     k, j = get_chunks_id(i)
 
@@ -1085,6 +1080,17 @@ function splice!(B::BitVector, i::Integer)
 
     B.len -= 1
 
+    return B
+end
+
+function splice!(B::BitVector, i::Integer)
+    n = length(B)
+    if !(1 <= i <= n)
+        throw(BoundsError())
+    end
+
+    v = B[i]   # TODO: change to a copy if/when subscripting becomes an ArrayView
+    _deleteat!(B, i)
     return v
 end
 splice!(B::BitVector, i::Integer, ins::BitVector) = splice!(B, int(i):int(i), ins)
@@ -1103,8 +1109,11 @@ function splice!(B::BitVector, r::Range1{Int}, ins::BitVector = _default_bit_spl
         throw(BoundsError())
     end
     if (i_f > n)
-        return append!(B, ins)
+        append!(B, ins)
+        return BitVector(0)
     end
+
+    v = B[r]  # TODO: change to a copy if/when subscripting becomes an ArrayView
 
     Bc = B.chunks
 
@@ -1129,9 +1138,83 @@ function splice!(B::BitVector, r::Range1{Int}, ins::BitVector = _default_bit_spl
         Bc[end] &= @_msk_end new_l
     end
 
-    return B
+    return v
 end
 splice!(B::BitVector, r::Range1{Int}, ins::AbstractVector{Bool}) = splice!(B, r, bitpack(ins))
+
+function deleteat!(B::BitVector, i::Integer)
+    n = length(B)
+    if !(1 <= i <= n)
+        throw(BoundsError())
+    end
+
+    return _deleteat!(B, i)
+end
+
+function deleteat!(B::BitVector, r::Range1{Int})
+    n = length(B)
+    i_f = first(r)
+    i_l = last(r)
+    if !(1 <= i_f && i_l <= n)
+        throw(BoundsError())
+    end
+
+    Bc = B.chunks
+    new_l = length(B) - length(r)
+    delta_k = num_bit_chunks(new_l) - length(Bc)
+
+    copy_chunks(Bc, i_f, Bc, i_l+1, n-i_l)
+
+    if delta_k < 0
+        ccall(:jl_array_del_end, Void, (Any, Uint), Bc, -delta_k)
+    end
+
+    B.len = new_l
+
+    if new_l > 0
+        Bc[end] &= @_msk_end new_l
+    end
+
+    return B
+end
+
+function deleteat!(B::BitVector, inds)
+    n = new_l = length(B)
+    s = start(inds)
+    done(inds, s) && return B
+
+    Bc = B.chunks
+
+    (p, s) = next(inds, s)
+    q = p+1
+    new_l -= 1
+    while !done(inds, s)
+        (i,s) = next(inds, s)
+        if !(q <= i <= n)
+            i < q && error("indices must be unique and sorted")
+            throw(BoundsError())
+        end
+        new_l -= 1
+        if i > q
+            copy_chunks(Bc, p, Bc, q, i-q)
+            p += i-q
+        end
+        q = i+1
+    end
+
+    q <= n && copy_chunks(Bc, p, Bc, q, n-q+1)
+
+    delta_k = num_bit_chunks(new_l) - length(Bc)
+    delta_k < 0 && ccall(:jl_array_del_end, Void, (Any, Uint), Bc, -delta_k)
+
+    B.len = new_l
+
+    if new_l > 0
+        Bc[end] &= @_msk_end new_l
+    end
+
+    return B
+end
 
 function empty!(B::BitVector)
     ccall(:jl_array_del_end, Void, (Any, Uint), B.chunks, length(B.chunks))

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -693,6 +693,7 @@ export
     contains,
     count,
     delete!,
+    deleteat!,
     eltype,
     empty!,
     endof,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -827,6 +827,16 @@ Dequeues
 
    Insert an item at the given index.
 
+.. function:: deleteat!(collection, index)
+
+   Remove the item at the given index, and return the modified collection. Subsequent items
+   are shifted to fill the resulting gap.
+
+.. function:: deleteat!(collection, itr)
+
+   Remove the items at the indices given by `itr`, and return the modified collection. Subsequent 
+   items are shifted to fill the resulting gap.  `itr` must be sorted and unique.
+
 .. function:: splice!(collection, index, [replacement]) -> item
 
    Remove the item at the given index, and return the removed item. Subsequent items

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -713,6 +713,16 @@ for idx in {1, 2, 5, 9, 10, 1:0, 2:1, 1:1, 2:2, 1:2, 2:4, 9:8, 10:9, 9:9, 10:10,
     end
 end
 
+# deleteat!
+for idx in {1, 2, 5, 9, 10, 1:0, 2:1, 1:1, 2:2, 1:2, 2:4, 9:8, 10:9, 9:9, 10:10,
+            8:9, 9:10, 6:9, 7:10}
+    a = [1:10]; acopy = copy(a)
+    @test deleteat!(a, idx) == [acopy[1:(first(idx)-1)], acopy[(last(idx)+1):end]]
+end
+a = [1:10]
+@test deleteat!(a, [1,3,5,7:10...]) == [2,4,6]
+
+
 # comprehensions
 X = [ i+2j for i=1:5, j=1:5 ]
 @test X[2,3] == 8

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -190,8 +190,19 @@ b1 = randbool(v1)
 i1 = bitunpack(b1)
 for m = v1 : -1 : 1
     j = rand(1:m)
-    splice!(b1, j)
-    splice!(i1, j)
+    b = splice!(b1, j)
+    i = splice!(i1, j)
+    @test isequal(bitunpack(b1), i1)
+    @test b == i
+end
+@test length(b1) == 0
+
+b1 = randbool(v1)
+i1 = bitunpack(b1)
+for m = v1 : -1 : 1
+    j = rand(1:m)
+    deleteat!(b1, j)
+    deleteat!(i1, j)
     @test isequal(bitunpack(b1), i1)
 end
 @test length(b1) == 0
@@ -199,8 +210,17 @@ end
 b1 = randbool(v1)
 i1 = bitunpack(b1)
 for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
-    splice!(b1, j)
-    splice!(i1, j)
+    b = splice!(b1, j)
+    i = splice!(i1, j)
+    @test isequal(bitunpack(b1), i1)
+    @test b == i
+end
+
+b1 = randbool(v1)
+i1 = bitunpack(b1)
+for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
+    deleteat!(b1, j)
+    deleteat!(i1, j)
     @test isequal(bitunpack(b1), i1)
 end
 
@@ -210,8 +230,21 @@ for m1 = 1 : v1
     for m2 = m1 : v1
         b2 = copy(b1)
         i2 = copy(i1)
-        splice!(b2, m1:m2)
-        splice!(i2, m1:m2)
+        b = splice!(b2, m1:m2)
+        i = splice!(i2, m1:m2)
+        @test isequal(bitunpack(b2), i2)
+        @test b == i
+    end
+end
+
+b1 = randbool(v1)
+i1 = bitunpack(b1)
+for m1 = 1 : v1
+    for m2 = m1 : v1
+        b2 = copy(b1)
+        i2 = copy(i1)
+        deleteat!(b2, m1:m2)
+        deleteat!(i2, m1:m2)
         @test isequal(bitunpack(b2), i2)
     end
 end
@@ -225,10 +258,25 @@ for m1 = 1 : v1 + 1
             i2 = copy(i1)
             b3 = randbool(v2)
             i3 = bitunpack(b3)
-            splice!(b2, m1:m2, b3)
-            splice!(i2, m1:m2, i3)
+            b = splice!(b2, m1:m2, b3)
+            i = splice!(i2, m1:m2, i3)
             @test isequal(bitunpack(b2), i2)
+            @test b == i
         end
+    end
+end
+
+b1 = randbool(v1)
+i1 = bitunpack(b1)
+for m1 = 1 : v1 - 1
+    for m2 = m1 + 1 : v1
+        locs = randbool(m2-m1+1)
+        m = [m1:m2...][locs]
+        b2 = copy(b1)
+        i2 = copy(i1)
+        deleteat!(b2, m)
+        deleteat!(i2, m)
+        @test isequal(bitunpack(b2), i2)
     end
 end
 


### PR DESCRIPTION
As noted in #5118, `delindex!` was previously proposed but never implemented.  Here is an implementation ~~delindex!~~ `deleteat!` for 
- single indexes
- `Range1`
- general iterable of indices (must be sorted)

~~delindex!~~ `deleteat!` is more efficient than `splice!` when the items being removed from the collection are not needed and returning them is costly.

This PR also changes/fixes the return type of one of the `splice!` implementations for `BitArrays`, which was returning the modified array instead of the spliced-out region.  cc:@carlobaldassi

**Edit: changed name from `delindex!` to `deleteat!`.**
