### PR TITLE
RFC: Mapslices for nonscalar arguments

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -634,6 +634,23 @@ begin
     @test c1 == -a
     c2 = mapslices(x-> maximum(-x), a, [1,2])
     @test c2 == maximum(-a)
+    
+        c = ones(2,3,4)
+    m1 = mapslices(x-> ones(2,3), c, [1,2])
+    m2 = mapslices(x-> ones(2,4), c, [1,3])
+    m3 = mapslices(x-> ones(3,4), c, [2,3])
+    @test size(m1) == size(m2) == size(m3) == size(c)
+    
+    n1 = mapslices(x-> ones(6), c, [1,2])
+    n2 = mapslices(x-> ones(6), c, [1,3])
+    n3 = mapslices(x-> ones(6), c, [2,3])
+    n1a = mapslices(x-> ones(1,6), c, [1,2])
+    n2a = mapslices(x-> ones(1,6), c, [1,3])
+    n3a = mapslices(x-> ones(1,6), c, [2,3])
+    @test size(n1a) == (1,6,4) && size(n2a) == (1,3,6)  && size(n3a) == (2,1,6)  
+    @test size(n1) == (6,1,4) && size(n2) == (6,3,1)  && size(n3) == (2,6,1)  
+   
+    
 end
 
 


### PR DESCRIPTION
Because of #5140 I took a detailed look at mapslices and how it arranges the results of `f(s)`, where `s` denotes the slices along dimensions `slicedims` of array `A`, into a new array `R = [f(s)]`.

I should just explain it here for anyone interested.
As stated in the documentation, the `f(s)` are concatenated along the sliced dimensions.
The new array inherits the number of dimensions of `A`, and the length of the dimensions not sliced over stays the same. The length of the `n` first dimensions in `slicedims` get modified to accomodate the `r`'s.
In fact, for the result `R` has the shape `sizeR` with

```
sizeR = size(A)
sizeR[slicedims] = [size(r), fill up with ones]
```

For example if `f` is scalar

```
julia> mapslices(sum, rand(4,5), [1]) 
1x5 Array{Float64,2}:
 1.80329  1.98077  2.89279  1.69202  2.69841
julia> mapslices(sum, rand(4,5), [2]) 
4x1 Array{Float64,2}:
 1.84754
 2.56395
 2.14556
 2.23409
```

and the following nonscalar `f` centers the columns versus the rows.

```
 A = mapslices(x-> x-mean(x), rand(4,5), [2]) 
4x5 Array{Float64,2}:
  0.230468     0.0108605  -0.141878  -0.219276    0.119825
 -0.106796    -0.318773   -0.147437   0.290916    0.28209 
  0.350075    -0.261308   -0.166023  -0.0719417   0.149197
 -0.00311726  -0.352739    0.374071   0.10547    -0.123686
julia> round(sum(A,2), 8)
4x1 Array{Float64,2}:
 -0.0
 -0.0
  0.0
  0.0
```

The implementation doesn't handle A which is 3-dimensional,
because in line https://github.com/JuliaLang/julia/blob/master/base/abstractarray.jl#L1628
the left and right side differ by dimensions of length 1

```
julia> A = mapslices(x-> x-mean(x), rand(4,3,2), [2,3]) 
ERROR: argument dimensions must match
 in setindex! at array.jl:606
 in mapslices at abstractarray.jl:1631
```

A possible fix is to assign elementwise if ndims(r) > 1.
