### PR TITLE
add generic fallback for Blas.LinAlg.axpy!

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -35,6 +35,7 @@ export
     Diagonal,
 
 # Functions
+    axpy!,
     bkfact,
     bkfact!,
     check_blas,

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -37,7 +37,7 @@ export
 
 const libblas = Base.libblas_name
 
-import ..LinAlg: BlasFloat, BlasChar, BlasInt, blas_int, DimensionMismatch, chksquare
+import ..LinAlg: BlasFloat, BlasChar, BlasInt, blas_int, DimensionMismatch, chksquare, axpy!
 
 # Level 1
 ## copy
@@ -163,12 +163,12 @@ for (fname, elty) in ((:daxpy_,:Float64),
         end
     end
 end
-function axpy!{T,Ta<:Number}(alpha::Ta, x::Array{T}, y::Array{T})
+function axpy!{T<:BlasFloat,Ta<:Number}(alpha::Ta, x::Array{T}, y::Array{T})
     length(x)==length(y) || throw(DimensionMismatch(""))
     axpy!(length(x), convert(T,alpha), x, 1, y, 1)
 end
 
-function axpy!{T,Ta<:Number,Ti<:Integer}(alpha::Ta, x::Array{T}, rx::Union(Range1{Ti},Range{Ti}),
+function axpy!{T<:BlasFloat,Ta<:Number,Ti<:Integer}(alpha::Ta, x::Array{T}, rx::Union(Range1{Ti},Range{Ti}),
                                          y::Array{T}, ry::Union(Range1{Ti},Range{Ti}))
 
     length(rx)==length(ry) || throw(DimensionMismatch(""))
@@ -177,6 +177,7 @@ function axpy!{T,Ta<:Number,Ti<:Integer}(alpha::Ta, x::Array{T}, rx::Union(Range
         throw(BoundsError())
     end
     axpy!(length(rx), convert(T, alpha), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
+    y
 end
 
 ## iamax

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -203,3 +203,24 @@ function peakflops(n::Integer=2000; parallel::Bool=false)
     parallel ? sum(pmap(peakflops, [ n for i in 1:nworkers()])) : (2*n^3/t)
 end
 
+# BLAS-like in-place y=alpha*x+y function (see also the version in blas.jl
+#                                          for BlasFloat Arrays)
+function axpy!(alpha, x::AbstractArray, y::AbstractArray)
+    n = length(x)
+    n==length(y) || throw(DimensionMismatch(""))
+    for i = 1:n
+        @inbounds y[i] += alpha * x[i]
+    end
+    y
+end
+function axpy!{Ti<:Integer,Tj<:Integer}(alpha, x::AbstractArray, rx::AbstractArray{Ti}, y::AbstractArray, ry::AbstractArray{Tj})
+    length(x)==length(y) || throw(DimensionMismatch(""))
+    if minimum(rx) < 1 || maximum(rx) > length(x) || minimum(ry) < 1 || maximum(ry) > length(y) || length(rx) != length(ry)
+        throw(BoundsError())
+    end
+    for i = 1:length(rx)
+        @inbounds y[ry[i]] += alpha * x[rx[i]]
+    end
+    y
+end
+


### PR DESCRIPTION
In cases where one wants to use `axpy!` to reduce memory allocation (see e.g. Julialang/IterativeSolvers.jl#16), it is annoying that it is only defined for `Array`s of `BlasFloat` types.   This patch provides a fallback for arbitrary array-like and range-like types.

Also, I noticed that `axpy!(alpha, x, y)` for BLAS types returned `y`, but `axpy!(alpha, x, rx, y, ry)` returned a pointer to data in `y`.  The latter exposure of the internal implementation seems undesirable and not very useful, so I modified it to return `y`.
