### PR TITLE
Some error message cleanup to fix segfault when transposing sparse vector with illegal values.

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -121,7 +121,7 @@ function reinterpret{T,S,N}(::Type{T}, a::Array{S}, dims::NTuple{N,Int})
     end
     nel = div(length(a)*sizeof(S),sizeof(T))
     if prod(dims) != nel
-        error("new dimensions $(dims) must be consistent with array size $(nel)")
+        throw(DimensionMismatch("new dimensions $(dims) must be consistent with array size $(nel)"))
     end
     ccall(:jl_reshape_array, Array{T,N}, (Any, Any, Any), Array{T,N}, a, dims)
 end
@@ -129,7 +129,7 @@ reinterpret(t::Type,x) = reinterpret(t,[x])[1]
 
 function reshape{T,N}(a::Array{T}, dims::NTuple{N,Int})
     if prod(dims) != length(a)
-        error("new dimensions $(dims) must be consistent with array size $(length(a))")
+        throw(DimensionMismatch("new dimensions $(dims) must be consistent with array size $(length(a))"))
     end
     ccall(:jl_reshape_array, Array{T,N}, (Any, Any, Any), Array{T,N}, a, dims)
 end
@@ -598,12 +598,12 @@ function setindex!(A::Array, x, I::Union(Real,AbstractArray)...)
             nel *= length(idx)
         end
         if length(X) != nel
-            error("argument dimensions must match")
+            throw(DimensionMismatch(""))
         end
         if ndims(X) > 1
             for i = 1:length(I)
                 if size(X,i) != length(I[i])
-                    error("argument dimensions must match")
+                    throw(DimensionMismatch(""))
                 end
             end
         end
@@ -996,7 +996,7 @@ end
 ## promotion to complex ##
 
 function complex{S<:Real,T<:Real}(A::Array{S}, B::Array{T})
-    if size(A) != size(B); error("argument dimensions must match"); end
+    if size(A) != size(B); throw(DimensionMismatch("")); end
     F = similar(A, typeof(complex(zero(S),zero(T))))
     for i=1:length(A)
         @inbounds F[i] = complex(A[i], B[i])

--- a/base/base.jl
+++ b/base/base.jl
@@ -70,6 +70,10 @@ end
 
 type EOFError <: Exception end
 
+type DimensionMismatch <: Exception
+    name::ASCIIString
+end
+
 type WeakRef
     value
     WeakRef() = WeakRef(nothing)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -138,6 +138,7 @@ export
 
 # Exceptions
     ArgumentError,
+    DimensionMismatch,
     EOFError,
     ErrorException,
     KeyError,

--- a/base/linalg/exceptions.jl
+++ b/base/linalg/exceptions.jl
@@ -2,8 +2,7 @@ export LAPACKException,
        ARPACKException,
        SingularException,
        PosDefException,
-       RankDeficientException,
-       DimensionMismatch
+       RankDeficientException
 
 type LAPACKException <: Exception
     info::BlasInt
@@ -23,8 +22,4 @@ end
 
 type RankDeficientException <: Exception
     info::BlasInt
-end
-
-type DimensionMismatch <: Exception
-    name::ASCIIString
 end

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -176,3 +176,6 @@ P,post = Base.LinAlg.etree(A, true)
 sfe22 = speye(Float64, 2)
 mfe22 = eye(Float64, 2)
 @test reinterpret(Int64, sfe22) == reinterpret(Int64, mfe22)
+
+# Issue 5190
+@test_throws sparsevec([3,5,7],[0.1,0.0,3.2],4)


### PR DESCRIPTION
This should fix #5190.

I have moved `DimensionMismatch` from the linear algebra specific exceptions to the definitions of exceptions in `base.jl`. This was necessary for using the exception in `sparsematrix.jl`. For consistency I also changed the error messages in `array.jl` to use the exception.
