### PR TITLE
Doc: Add information on operator precedence

### DIFF
--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -293,6 +293,27 @@ expressions with side effects (such as printing) in chained comparisons.
 If side effects are required, the short-circuit ``&&`` operator should
 be used explicitly (see :ref:`man-short-circuit-evaluation`).
 
+Operator Precedence
+~~~~~~~~~~~~~~~~~~~
+
+Julia applies the following order of operations, from highest precedence 
+to lowest:
+
+================= =============================================================================================
+Category          Operators
+================= =============================================================================================
+Syntax            ``.`` followed by ``::``
+Exponentiation    ``^`` and its elementwise equivalent ``.^``
+Fractions         ``//`` and ``.//``
+Multiplication    ``* / % & \`` and  ``.* ./ .% .\``
+Bitshifts         ``<< >> >>>`` and ``.<< .>> .>>>``
+Addition          ``+ - | $`` and ``.+ .-``
+Syntax            ``: ..`` followed by ``|>``
+Comparisons       ``> < >= <= == === != !== <:`` and ``.> .< .>= .<= .== .!=``
+Control flow      ``&&`` followed by ``||`` followed by ``?``
+Assignments       ``= += -= *= /= //= \= ^= %= |= &= $= <<= >>= >>>=`` and ``.+= .-= .*= ./= .//= .\= .^= .%=``
+================= =============================================================================================
+
 .. _man-elementary-functions:
 
 Elementary Functions

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -52,6 +52,12 @@ differences that may trip up Julia users accustomed to MATLAB:
 -  If ``A`` and ``B`` are arrays, ``A == B`` doesn't return an array of
    booleans. Use ``A .== B`` instead. Likewise for the other boolean
    operators, ``<``, ``>``, ``!=``, etc.
+-  The operators ``&``, ``|``, and ``$`` perform the bitwise operations and,
+   or, and xor, respectively, and have precedence similar to Python's bitwise
+   operators (not like C). They can operate on scalars or elementwise
+   across arrays and can be used to combine logical arrays, but note the
+   difference in order of operations—parentheses may be required (e.g.,
+   to select elements of ``A`` equal to 1 or 2 use ``(A .== 1) | (A .== 2)``).
 -  The elements of a collection can be passed as arguments to a function
    using ``...``, as in ``xs=[1,2]; f(xs...)``.
 -  Julia's ``svd`` returns singular values as a vector instead of as a


### PR DESCRIPTION
Adds documentation to make #5187 less surprising.  I've added a table to the Mathematical Operations manual page, as well as a note for Matlab users like myself about the different precedence of `&` and `|`.
