### PR TITLE
Add macro definitions to ctags

### DIFF
--- a/contrib/ctags
+++ b/contrib/ctags
@@ -1,4 +1,4 @@
 --langdef=julia
 --langmap=julia:.jl
---regex-julia=/^[ \t]*function[ \t]+([^ \t({[]+).*$/\1/f,function/
+--regex-julia='/^[ \t]*(function|macro)[ \t]+([^ \t({[]+).*$/\2/f,function/'
 --regex-julia=/^[ \t]*(([^@#$ \t({[]+)|\(([^@#$ \t({[]+)\)|\((\$)\))[ \t]*(\{.*\})?[ \t]*\([^#]*\)[ \t]*=([^=].*$|$)/\2\3\4/f,function/


### PR DESCRIPTION
This adds macro definitions to the tags file that ctags creates when using these flags.  For example, when I run this on base/, I can now find the definitions for `@time`, `@printf`, etc.
