### PR TITLE
minor update of hypot to ensure consistency of output types

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -240,21 +240,6 @@ end
 
 log(b,x) = log(x)./log(b)
 
-hypot(x::Real, y::Real) = hypot(promote(x,y)...)
-function hypot{T<:Real}(x::T, y::T)
-    x = abs(x)
-    y = abs(y)
-    if x < y
-        x, y = y, x
-    end
-    if x == 0
-        r = y/one(x)
-    else
-        r = y/x
-    end
-    x * sqrt(one(r)+r*r)
-end
-
 # type specific math functions
 
 const libm = Base.libm_name
@@ -307,6 +292,21 @@ round(x::Float32) = ccall((:roundf, libm), Float32, (Float32,), x)
 
 floor(x::Float32) = ccall((:floorf, libm), Float32, (Float32,), x)
 @vectorize_1arg Real floor
+
+hypot(x::Real, y::Real) = hypot(promote(float(x), float(y))...)
+function hypot{T<:FloatingPoint}(x::T, y::T) 
+    x = abs(x)
+    y = abs(y)
+    if x < y
+        x, y = y, x
+    end
+    if x == 0
+        r = y/one(x)
+    else
+        r = y/x
+    end
+    x * sqrt(one(r)+r*r)
+end
 
 atan2(x::Real, y::Real) = atan2(promote(float(x),float(y))...)
 atan2{T<:FloatingPoint}(x::T, y::T) = Base.no_op_err("atan2", T)


### PR DESCRIPTION
hypot and atan2 are two important binary math functions. 

This patch serves two purposes:
- Originally, the hypot methods were separated in two places. Now I moved them together.
- To ensure that `hypot` and `atan2` have the same output type behavior. (e.g. Originally, `hypot` outputs `Float64` when inputs are `Int8`, while `atan2` outputs `Float32`. Now they do the same). This is a very minor thing, but I found it annoying when I am writing a generic numerical computation framework. 
