### PR TITLE
RFC: proposed new array assignment shape matching rule

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -433,7 +433,7 @@ end
 
 function setindex!{T}(A::Array{T}, X::Array{T}, I::Range1{Int})
     if length(X) != length(I)
-        error("tried to assign $(length(X)) elements to $(length(I)) destinations");
+        throw_setindex_mismatch(X, (I,))
     end
     copy!(A, first(I), X, 1, length(I))
     return A
@@ -441,7 +441,7 @@ end
 
 function setindex!{T<:Real}(A::Array, X::AbstractArray, I::AbstractVector{T})
     if length(X) != length(I)
-        error("tried to assign $(length(X)) elements to $(length(I)) destinations");
+        throw_setindex_mismatch(X, (I,))
     end
     count = 1
     if is(X,A)
@@ -465,7 +465,7 @@ function setindex!{T<:Real}(A::Array, x, i::Real, J::AbstractVector{T})
     else
         X = x
         if length(X) != length(J)
-            error("tried to assign $(length(X)) elements to $(length(J)) destinations");
+            throw_setindex_mismatch(X, (i,J))
         end
         count = 1
         for j in J
@@ -489,7 +489,7 @@ function setindex!{T<:Real}(A::Array, x, I::AbstractVector{T}, j::Real)
     else
         X = x
         if length(X) != length(I)
-            error("tried to assign $(length(X)) elements to $(length(I)) destinations");
+            throw_setindex_mismatch(X, (I,j))
         end
         count = 1
         for i in I
@@ -504,7 +504,7 @@ function setindex!{T}(A::Array{T}, X::Array{T}, I::Range1{Int}, j::Real)
     j = to_index(j)
     checkbounds(A, I, j)
     if length(X) != length(I)
-        error("tried to assign $(length(X)) elements to $(length(I)) destinations");
+        throw_setindex_mismatch(X, (I,j))
     end
     unsafe_copy!(A, first(I) + (j-1)*size(A,1), X, 1, length(I))
     return A
@@ -512,11 +512,7 @@ end
 
 function setindex!{T}(A::Array{T}, X::Array{T}, I::Range1{Int}, J::Range1{Int})
     checkbounds(A, I, J)
-    nel = length(I)*length(J)
-    if length(X) != nel ||
-        (ndims(X) > 1 && (size(X,1)!=length(I) || size(X,2)!=length(J)))
-        error("tried to assign $(size(X,1)) x $(size(X,2)) Array to $(length(I)) x $(length(J)) destination");
-    end
+    setindex_shape_check(X, I, J)
     if length(I) == size(A,1)
         unsafe_copy!(A, first(I) + (first(J)-1)*size(A,1), X, 1, size(A,1)*length(J))
     else
@@ -531,11 +527,7 @@ end
 
 function setindex!{T}(A::Array{T}, X::Array{T}, I::Range1{Int}, J::AbstractVector{Int})
     checkbounds(A, I, J)
-    nel = length(I)*length(J)
-    if length(X) != nel ||
-        (ndims(X) > 1 && (size(X,1)!=length(I) || size(X,2)!=length(J)))
-        error("tried to assign $(size(X)) Array to ($(length(I)),$(length(J))) destination");
-    end
+    setindex_shape_check(X, I, J)
     refoffset = 1
     for j = J
         unsafe_copy!(A, first(I) + (j-1)*size(A,1), X, refoffset, length(I))
@@ -556,11 +548,7 @@ function setindex!{T<:Real}(A::Array, x, I::AbstractVector{T}, J::AbstractVector
         end
     else
         X = x
-        nel = length(I)*length(J)
-        if length(X) != nel ||
-            (ndims(X) > 1 && (size(X,1)!=length(I) || size(X,2)!=length(J)))
-            error("tried to assign $(size(X,1)) x $(size(X,2)) Array to $(length(I)) x $(length(J)) destination");
-        end
+        setindex_shape_check(X, I, J)
         count = 1
         for j in J
             offset = (j-1)*m

--- a/base/array.jl
+++ b/base/array.jl
@@ -593,20 +593,7 @@ function setindex!(A::Array, x, I::Union(Real,AbstractArray)...)
             assign_cache = Dict()
         end
         X = x
-        nel = 1
-        for idx in I
-            nel *= length(idx)
-        end
-        if length(X) != nel
-            throw(DimensionMismatch(""))
-        end
-        if ndims(X) > 1
-            for i = 1:length(I)
-                if size(X,i) != length(I[i])
-                    throw(DimensionMismatch(""))
-                end
-            end
-        end
+        setindex_shape_check(X, I...)
         gen_array_index_map(assign_cache, storeind -> quote
                               A[$storeind] = X[refind]
                               refind += 1

--- a/base/client.jl
+++ b/base/client.jl
@@ -142,6 +142,8 @@ function repl_callback(ast::ANY, show_value)
     put(repl_channel, (ast, show_value))
 end
 
+_eval_done = Condition()
+
 function run_repl()
     global const repl_channel = RemoteRef()
 
@@ -155,7 +157,7 @@ function run_repl()
             read(STDIN, buf)
             ccall(:jl_read_buffer,Void,(Ptr{Void},Cssize_t),buf,1)
             if _repl_enough_stdin
-                yield()
+                wait(_eval_done)
             end
         end
         put(repl_channel,(nothing,-1))
@@ -175,6 +177,7 @@ function run_repl()
             break
         end
         eval_user_input(ast, show_value!=0)
+        notify(_eval_done)
     end
 
     if have_color

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -211,55 +211,36 @@ index_shape(i, I...) = tuple(length(i), index_shape(I...)...)
 # those are the permutations that preserve the order of the non-singleton
 # dimensions.
 function setindex_shape_check(X::AbstractArray, I...)
-    li = length(I)
-    ii = 1
-    nel = 1
-    xi = 1
-    ndx = ndims(X)
-    match = true
-    while ii < li
-        lii = length(I[ii])::Int
-        ii += 1
-        if lii != 1
-            nel *= lii
-            local lxi
-            while true
-                lxi = size(X,xi)
-                xi += 1
-                if lxi != 1 || xi > ndx
-                    break
-                end
+    li = ndims(X)
+    lj = length(I)
+    i = j = 1
+    while true
+        ii = size(X,i)
+        jj = length(I[j])::Int
+        if i == li || j == lj
+            while i < li
+                i += 1
+                ii *= size(X,i)
             end
-            if xi > ndx
-                trailing = lii
-                while ii <= li
-                    lii = length(I[ii])::Int
-                    trailing *= lii
-                    ii += 1
-                end
-                # X's last dimension can match all the trailing indexes
-                if lxi == trailing && match
-                    return
-                else
-                    throw(DimensionMismatch(""))
-                end
-            else
-                if lxi != lii
-                    match = false
-                end
+            while j < lj
+                j += 1
+                jj *= length(I[j])::Int
             end
+            if ii != jj
+                throw(DimensionMismatch(""))
+            end
+            return
         end
-    end
-
-    # last index can match X's trailing dimensions
-    lii = length(I[ii])::Int
-    nel *= lii
-    if lii != trailingsize(X,xi)
-        match = false
-    end
-
-    if !(match && length(X)==nel)
-        throw(DimensionMismatch(""))
+        if ii == jj
+            i += 1
+            j += 1
+        elseif ii == 1
+            i += 1
+        elseif jj == 1
+            j += 1
+        else
+            throw(DimensionMismatch(""))
+        end
     end
 end
 

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -419,7 +419,7 @@ static native_sym_arg_t interpret_symbol_arg(jl_value_t *arg, jl_codectx_t *ctx,
                                "cglobal: first argument not a pointer or valid constant expression",
                                ctx);
         }
-        jl_ptr = emit_unbox(T_size, arg1, ptr_ty);
+        jl_ptr = emit_unbox(T_size, arg1, (jl_value_t*)jl_voidpointer_type);
     }
 
     void *fptr=NULL;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1229,8 +1229,7 @@ static Value *boxed(Value *v,  jl_codectx_t *ctx, jl_value_t *jt)
         Value *tpl = builder.CreateCall(jl_alloc_tuple_func,ConstantInt::get(T_size,n));
         int last_depth = ctx->argDepth;
         make_gcroot(tpl,ctx);
-        for (size_t i = 0; i < n; ++i)
-        {
+        for (size_t i = 0; i < n; ++i) {
             jl_value_t *jti = jl_tupleref(jt,i);
             Value *vi = emit_tupleref(v,ConstantInt::get(T_size,i+1),jt,ctx);
             emit_tupleset(tpl,ConstantInt::get(T_size,i+1),boxed(vi,ctx,jti),jt,ctx);


### PR DESCRIPTION
would fix #4048, #4383

This rule ignores singleton dimensions, and allows the last dimension of one side to match all trailing dimensions of the other.

The logic to implement this is pretty complicated, and I hope some code simplifications can be found. Indexing-related code always makes my brain freeze.

Right now, we don't even have a consistent rule. For example the left-hand side `A[1, 1:n]` permits different right-hand sides than `A[1:1, 1:n]`. And 1-d right-hand sides are special-cased, but the general version is to allow the last dimension of the RHS to match trailing indexes.

A rule like this is safe regardless of how we decide to change the number of dimensions returned by `getindex`.

EDIT: Follow-on work still needed to use this rule everywhere. Tests also needed.
