### PR TITLE
Enable |> to create a function when given of two.

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -157,6 +157,7 @@ copy(x::Union(Symbol,Number,String,Function,Tuple,LambdaStaticData,
 
 # function pipelining
 |>(x, f::Function) = f(x)
+|>(f::Function, g::Function) = (x...) -> g(f(x...))
 
 # array shape rules
 


### PR DESCRIPTION
That means, `f |> g` creates a function which, when applied, first
applies f to its arguments and then g to the result of f. This is very
useful to create functions for map/filter:

``` julia
map(sin, map(cos, map(sqrt, [1 2 3])))
```

or

``` julia
map((x)->sin(cos(sqrt(x))), [1 2 3])
```

become

``` julia
map(sqrt |> cos |> sin, [1 2 3])
```

which is much more readable imo.

And for a real-world use:

``` julia
map((fname)->float32(imread(fname)), image_filenames)
```

becomes

``` julia
map(imread |> float32, image_filenames)
```
