### PR TITLE
Modified implementation of maximum & minimum with improved efficiency.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1606,7 +1606,7 @@ function prod{T}(A::AbstractArray{T})
 end
 
 function minimum{T<:Real}(A::AbstractArray{T})
-    if isempty(A); error("minimum: argument must not be empty"); end
+    if isempty(A); error("argument must not be empty"); end
     v = A[1]
     for i=2:length(A)
         @inbounds x = A[i]
@@ -1618,7 +1618,7 @@ function minimum{T<:Real}(A::AbstractArray{T})
 end
 
 function maximum{T<:Real}(A::AbstractArray{T})
-    if isempty(A); error("maximum: argument must not be empty"); end
+    if isempty(A); error("argument must not be empty"); end
     v = A[1]
     for i=2:length(A)
         @inbounds x = A[i]
@@ -1632,7 +1632,7 @@ end
 # specialized versions for floating-point, which deal with NaNs
 
 function minimum{T<:FloatingPoint}(A::AbstractArray{T})
-    if isempty(A); error("minimum: argument must not be empty"); end
+    if isempty(A); error("argument must not be empty"); end
     n = length(A)
 
     # locate the first non NaN number
@@ -1654,7 +1654,7 @@ function minimum{T<:FloatingPoint}(A::AbstractArray{T})
 end
 
 function maximum{T<:FloatingPoint}(A::AbstractArray{T})
-    if isempty(A); error("minimum: argument must not be empty"); end
+    if isempty(A); error("argument must not be empty"); end
     n = length(A)
 
     # locate the first non NaN number

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1606,11 +1606,11 @@ function prod{T}(A::AbstractArray{T})
 end
 
 function minimum{T<:Real}(A::AbstractArray{T})
-    if isempty(A); error("argument must not be empty"); end
+    if isempty(A); error("minimum: argument must not be empty"); end
     v = A[1]
     for i=2:length(A)
         @inbounds x = A[i]
-        if x < v || v!=v
+        if x < v
             v = x
         end
     end
@@ -1618,16 +1618,63 @@ function minimum{T<:Real}(A::AbstractArray{T})
 end
 
 function maximum{T<:Real}(A::AbstractArray{T})
-    if isempty(A); error("argument must not be empty"); end
+    if isempty(A); error("maximum: argument must not be empty"); end
     v = A[1]
     for i=2:length(A)
         @inbounds x = A[i]
-        if x > v || v!=v
+        if x > v
             v = x
         end
     end
     v
 end
+
+# specialized versions for floating-point, which deal with NaNs
+
+function minimum{T<:FloatingPoint}(A::AbstractArray{T})
+    if isempty(A); error("minimum: argument must not be empty"); end
+    n = length(A)
+
+    # locate the first non NaN number
+    v = A[1]
+    i = 2
+    while v != v && i <= n
+        @inbounds v = A[i]
+        i += 1
+    end
+
+    while i <= n
+        @inbounds x = A[i]
+        if x < v
+            v = x
+        end
+        i += 1
+    end
+    v
+end
+
+function maximum{T<:FloatingPoint}(A::AbstractArray{T})
+    if isempty(A); error("minimum: argument must not be empty"); end
+    n = length(A)
+
+    # locate the first non NaN number
+    v = A[1]
+    i = 2
+    while v != v && i <= n
+        @inbounds v = A[i]
+        i += 1
+    end
+
+    while i <= n
+        @inbounds x = A[i]
+        if x > v
+            v = x
+        end
+        i += 1
+    end
+    v
+end
+
 
 ## map over arrays ##
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -353,6 +353,13 @@ let es = sum_kbn(z), es2 = sum_kbn(z[1:10^5])
 end
 @test_approx_eq sum(sin(z)) sum(sin, z)
 
+@test maximum([4, 3, 5, 2]) == 5
+@test minimum([4, 3, 5, 2]) == 2
+@test isnan(maximum([NaN]))
+@test isnan(minimum([NaN]))
+@test maximum([4., 3., NaN, 5., 2.]) == 5.
+@test minimum([4., 3., NaN, 5., 2.]) == 2.
+
 @test any([true false; false false], 2) == [true false]'
 @test any([true false; false false], 1) == [true false]
 


### PR DESCRIPTION
With this modified implementation, we don't have to check `(v != v)` within inner loops. 

Rationales: 
1. NaN only exist for floating points -- so only have to deal with them in methods specialized to floating point. 
2. Once a non-NaN value is found, we can then follow the normal routine. Because `x > v` (or `x < v`) is never true when `x` is `NaN`, and therefore, `v` won't become `NaN` again.

Note: I also added several test cases to ensure the correctness.
