### PR TITLE
Specialized solvers for Diagonal matrices

### DIFF
--- a/base/float16.jl
+++ b/base/float16.jl
@@ -103,7 +103,7 @@ end
 for op in (:+,:-,:*,:/,:\)
     @eval ($op)(a::Float16, b::Float16) = float16(($op)(float32(a), float32(b)))
 end
-for op in (:<,:isless)
+for op in (:<,:<=,:isless)
     @eval ($op)(a::Float16, b::Float16) = ($op)(float32(a), float32(b))
 end
 for func in (sin,cos,tan,asin,acos,atan,sinh,cosh,tanh,asinh,acosh,atanh,exp,log,exponent,sqrt)


### PR DESCRIPTION
This PR provides generic linear solvers, eigensystem solvers and singular value solvers for Diagonal matrices.

Where possible, the tests go beyond the standard `BlasFloat` numeric types to include `Float16`, `BigFloat` and their complex analogues.
