### PR TITLE
RFC: Don't complain about redefining types when the type hasn't actually changed

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -133,7 +133,7 @@ int jl_equiv_type(jl_datatype_t *dta, jl_datatype_t *dtb) {
         return 0;
     if(dta->mutabl != dtb->mutabl) 
         return 0;
-    if(dta->super != dtb->super) 
+    if(!jl_egal((jl_value_t*)dta->super, (jl_value_t*)dtb->super))
         return 0;
     if(!jl_egal((jl_value_t*)dta->names, (jl_value_t*)dtb->names)) 
         return 0;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -125,6 +125,23 @@ static int bits_equal(void *a, void *b, int sz)
     }
 }
 
+int jl_equiv_type(jl_datatype_t *dta, jl_datatype_t *dtb) {
+    if(dta->name->name != dtb->name->name) 
+        return 0;
+    // if(!tuple_eq(dta->types, dtb->types)) return 0; // This isn't working as expected for some reason. dtb->types is often NULL
+    if(dta->abstract != dtb->abstract) 
+        return 0;
+    if(dta->mutabl != dtb->mutabl) 
+        return 0;
+    if(dta->super != dtb->super) 
+        return 0;
+    if(!jl_egal((jl_value_t*)dta->names, (jl_value_t*)dtb->names)) 
+        return 0;
+    if(!jl_egal((jl_value_t*)dta->parameters, (jl_value_t*)dtb->parameters)) 
+        return 0;
+    return 1;
+}
+
 int jl_egal(jl_value_t *a, jl_value_t *b)
 {
     if (a == b)
@@ -146,8 +163,7 @@ int jl_egal(jl_value_t *a, jl_value_t *b)
     if (dt == jl_datatype_type) {
         jl_datatype_t *dta = (jl_datatype_t*)a;
         jl_datatype_t *dtb = (jl_datatype_t*)b;
-        return dta->name == dtb->name &&
-            jl_egal((jl_value_t*)dta->parameters, (jl_value_t*)dtb->parameters);
+        return jl_equiv_type(dta, dtb);            
     }
     if (dt->mutabl) return 0;
     size_t sz = dt->size;

--- a/src/module.c
+++ b/src/module.c
@@ -349,13 +349,17 @@ DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var)
 
 DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
 {
+    int are_equal;
     if (b->constp && b->value != NULL) {
-        if (!jl_egal(rhs, b->value) &&
+        are_equal = jl_egal(rhs, b->value);
+        if (!are_equal &&
             (jl_typeof(rhs) != jl_typeof(b->value) ||
              jl_is_type(rhs) || jl_is_function(rhs) || jl_is_module(rhs))) {
             jl_errorf("invalid redefinition of constant %s", b->name->name);
         }
-        JL_PRINTF(JL_STDERR,"Warning: redefining constant %s\n",b->name->name);
+        if (!are_equal) {
+            JL_PRINTF(JL_STDERR,"Warning: redefining constant %s\n",b->name->name);
+        }
     }
     b->value = rhs;
 }


### PR DESCRIPTION
This PR is intended to make it easier to reload modules and re-execute scripts which define types. If the definition of a type hasn't changed in any way since the script was last evaluated (as determined by the new jl_equiv_type function), then the type declaration is safely reevaluated. Changing a type definition is still not allowed (I have a hacky way of accomplishing that in https://github.com/malmaud/Autoreload.jl, but I don't think it's appropriate for core Julia). 

This is a simple fix for a problem that has consistently annoyed interactive Julia users, who have been forced to take precautions such as defining types in a module instead of in the top level. Many users who come from a Matlab or IPython background are used to a workflow of constantly tweaking scripts in a single interactive session.

Additionally, this PR disables warnings when a constant is redefined to the same value it had previously. This prevents spurious warnings about redefining constants when reloading packages (e.g., reloading DataFrames causes dozens of unhelpful warnings about constant redefinitions).

It is not fully functional yet because for unclear reasons, the 'rhs' parameter in jl_checked_assignment (which contains the new type definition) often has NULL for its `types` and `super` fields, even when the data type does in fact have fields and a parent. Thus jl_equiv_type cannot reliably determine whether the new type definition has the same field types and the same parent as the old type definition. I was hoping someone else might have insight into that, but I'll keep looking into it. Otherwise, this patch seems to work smoothly.
