### PR TITLE
Use nnz to implement sum over bool arrays

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1431,7 +1431,7 @@ prod{T}(A::AbstractArray{T}, region) = reducedim(*,A,region,one(T))
 all(A::AbstractArray{Bool}, region) = reducedim(&,A,region,true)
 any(A::AbstractArray{Bool}, region) = reducedim(|,A,region,false)
 sum(A::AbstractArray{Bool}, region) = reducedim(+,A,region,0,similar(A,Int,reduced_dims(A,region)))
-sum(A::AbstractArray{Bool}) = sum(A, [1:ndims(A)])[1]
+sum(A::AbstractArray{Bool}) = nnz(A)
 prod(A::AbstractArray{Bool}) =
     error("use all() instead of prod() for boolean arrays")
 prod(A::AbstractArray{Bool}, region) =


### PR DESCRIPTION
This minor change results in about 1.5x - 2x speedup and smaller memory footprint.
