### PR TITLE
Improved error handling in base

### DIFF
--- a/base/fftw.jl
+++ b/base/fftw.jl
@@ -80,9 +80,7 @@ typealias fftwTypeSingle Union(Type{Float32},Type{Complex64})
 function export_wisdom(fname::String)
     f = ccall(:fopen, Ptr{Void}, (Ptr{Uint8},Ptr{Uint8}),
               bytestring(fname), bytestring("w"))
-    if f == C_NULL
-        error("could not open wisdom file $fname")
-    end
+    systemerror("could not open wisdom file $fname for writing", f == C_NULL)
     ccall((:fftw_export_wisdom_to_file,libfftw), Void, (Ptr{Void},), f)
     ccall(:fputs, Int32, (Ptr{Uint8},Ptr{Void}), bytestring(" "^256), f)
     ccall((:fftwf_export_wisdom_to_file,libfftwf), Void, (Ptr{Void},), f)
@@ -92,9 +90,7 @@ end
 function import_wisdom(fname::String)
     f = ccall(:fopen, Ptr{Void}, (Ptr{Uint8},Ptr{Uint8}),
               bytestring(fname), bytestring("r"))
-    if f == C_NULL
-        error("could not open wisdom file $fname")
-    end
+    systemerror("could not open wisdom file $fname for reading", f == C_NULL)
     if ccall((:fftw_import_wisdom_from_file,libfftw),Int32,(Ptr{Void},),f)==0||
        ccall((:fftwf_import_wisdom_from_file,libfftwf),Int32,(Ptr{Void},),f)==0
         error("failed to import wisdom from $fname")

--- a/base/file.jl
+++ b/base/file.jl
@@ -137,13 +137,10 @@ function readdir(path::String)
     # Allocate space for uv_fs_t struct
     uv_readdir_req = zeros(Uint8, ccall(:jl_sizeof_uv_fs_t, Int32, ()))
 
-    # defined in sys.c, to call uv_fs_readdir
+    # defined in sys.c, to call uv_fs_readdir, which sets errno on error.
     file_count = ccall(:jl_readdir, Int32, (Ptr{Uint8}, Ptr{Uint8}),
                        bytestring(path), uv_readdir_req)
-
-    if file_count < 0
-        error("unable to read directory $path")
-    end
+    systemerror("unable to read directory $path", file_count < 0)
 
     # The list of dir entries is returned as a contiguous sequence of null-terminated
     # strings, the first of which is pointed to by ptr in uv_readdir_req.

--- a/base/file.jl
+++ b/base/file.jl
@@ -71,6 +71,7 @@ function tempname()
     d = get(ENV, "TMPDIR", C_NULL) # tempnam ignores TMPDIR on darwin
     @unix_only p = ccall(:tempnam, Ptr{Uint8}, (Ptr{Uint8},Ptr{Uint8}), d, "julia")
     @windows_only p = ccall(:_tempnam, Ptr{Uint8}, (Ptr{Uint8},Ptr{Uint8}), d, "julia")
+    systemerror(:tempnam, p == C_NULL)
     s = bytestring(p)
     c_free(p)
     s

--- a/base/fs.jl
+++ b/base/fs.jl
@@ -232,8 +232,12 @@ const SEEK_SET = int32(0)
 const SEEK_CUR = int32(1)
 const SEEK_END = int32(2)
 
-position(f::File) = ccall(:jl_lseek, Coff_t,(Int32,Coff_t,Int32),f.handle,0,SEEK_CUR)
- 
+function position(f::File)
+    ret = ccall(:jl_lseek, Coff_t,(Int32,Coff_t,Int32),f.handle,0,SEEK_CUR)
+    systemerror("lseek", ret == -one(Coff_t))
+    ret
+end
+
 fd(f::File) = RawFD(f.handle)
 stat(f::File) = stat(fd(f))
 

--- a/base/fs.jl
+++ b/base/fs.jl
@@ -233,7 +233,7 @@ const SEEK_END = int32(2)
 
 function position(f::File)
     ret = ccall(:jl_lseek, Coff_t,(Int32,Coff_t,Int32),f.handle,0,SEEK_CUR)
-    systemerror("lseek", ret == -one(Coff_t))
+    systemerror("lseek", ret == -1)
     ret
 end
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -283,8 +283,9 @@ function truncate(s::IOStream, n::Integer)
 end
 
 function seek(s::IOStream, n::Integer)
-    ccall(:ios_seek, FileOffset, (Ptr{Void}, FileOffset), s.ios, n)==0 ||
-        error("seek failed")
+    ret = ccall(:ios_seek, FileOffset, (Ptr{Void}, FileOffset), s.ios, n)
+    systemerror("seek", ret == -1)
+    ret < -1 && error("seek failed")
     return s
 end
 
@@ -296,8 +297,9 @@ function seekend(s::IOStream)
 end
 
 function skip(s::IOStream, delta::Integer)
-    ccall(:ios_skip, FileOffset, (Ptr{Void}, FileOffset), s.ios, delta)==0 ||
-        error("skip failed")
+    ret = ccall(:ios_skip, FileOffset, (Ptr{Void}, FileOffset), s.ios, delta)
+    systemerror("skip", ret == -1)
+    ret < -1 && error("skip failed")
     return s
 end
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -268,7 +268,7 @@ close(s::IOStream) = ccall(:ios_close, Void, (Ptr{Void},), s.ios)
 isopen(s::IOStream) = bool(ccall(:ios_isopen, Cint, (Ptr{Void},), s.ios))
 function flush(s::IOStream)
     sigatomic_begin()
-    systemerror("flush", ccall(:ios_flush, Void, (Ptr{Void},), s.ios) != 0)
+    systemerror("flush", ccall(:ios_flush, Cint, (Ptr{Void},), s.ios) != 0)
     sigatomic_end()
     s
 end

--- a/base/io.jl
+++ b/base/io.jl
@@ -268,7 +268,7 @@ close(s::IOStream) = ccall(:ios_close, Void, (Ptr{Void},), s.ios)
 isopen(s::IOStream) = bool(ccall(:ios_isopen, Cint, (Ptr{Void},), s.ios))
 function flush(s::IOStream)
     sigatomic_begin()
-    ccall(:ios_flush, Void, (Ptr{Void},), s.ios)
+    systemerror("flush", ccall(:ios_flush, Void, (Ptr{Void},), s.ios) != 0)
     sigatomic_end()
     s
 end
@@ -303,7 +303,11 @@ function skip(s::IOStream, delta::Integer)
     return s
 end
 
-position(s::IOStream) = ccall(:ios_pos, FileOffset, (Ptr{Void},), s.ios)
+function position(s::IOStream)
+    pos = ccall(:ios_pos, FileOffset, (Ptr{Void},), s.ios)
+    systemerror("position", pos == -1)
+    return pos
+end
 
 eof(s::IOStream) = bool(ccall(:jl_ios_eof, Int32, (Ptr{Void},), s.ios))
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -278,8 +278,7 @@ modestr(s::IO) = modestr(isreadable(s), iswritable(s))
 modestr(r::Bool, w::Bool) = r ? (w ? "r+" : "r") : (w ? "w" : error("Neither readable nor writable"))
 
 function truncate(s::IOStream, n::Integer)
-    ccall(:ios_trunc, Int32, (Ptr{Void}, Uint), s.ios, n) == 0 ||
-        error("truncate failed")
+    systemerror("truncate", ccall(:ios_trunc, Int32, (Ptr{Void}, Uint), s.ios, n) != 0)
     return s
 end
 
@@ -292,8 +291,7 @@ end
 seekstart(s::IO) = seek(s,0)
 
 function seekend(s::IOStream)
-    ccall(:ios_seek_end, FileOffset, (Ptr{Void},), s.ios)==0 ||
-        error("seekend failed")
+    systemerror("seekend", ccall(:ios_seek_end, FileOffset, (Ptr{Void},), s.ios) != 0)
     return s
 end
 
@@ -317,18 +315,15 @@ end
 function CFILE(s::IO)
     @unix_only FILEp = ccall(:fdopen, Ptr{Void}, (Cint, Ptr{Uint8}), convert(Cint, fd(s)), modestr(s))
     @windows_only FILEp = ccall(:_fdopen, Ptr{Void}, (Cint, Ptr{Uint8}), convert(Cint, fd(s)), modestr(s))
-    if FILEp == 0
-        error("fdopen failed")
-    end
+    systemerror("fdopen", FILEp == C_NULL)
     seek(CFILE(FILEp), position(s))
 end
 
 convert(::Type{CFILE}, s::IO) = CFILE(s)
 
 function seek(h::CFILE, offset::Integer)
-    ccall(:fseek, Cint, (Ptr{Void}, Clong, Cint), 
-          h.ptr, convert(Clong, offset), int32(0)) == 0 ||
-          error("fseek failed")
+    systemerror("fseek", ccall(:fseek, Cint, (Ptr{Void}, Clong, Cint),
+                               h.ptr, convert(Clong, offset), int32(0)) != 0)
     h
 end
 
@@ -347,13 +342,12 @@ fdio(fd::Integer, own::Bool=false) = fdio(string("<fd ",fd,">"), fd, own)
 
 function open(fname::String, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::Bool)
     s = IOStream(string("<file ",fname,">"))
-    if ccall(:ios_file, Ptr{Void},
-             (Ptr{Uint8}, Ptr{Uint8}, Int32, Int32, Int32, Int32),
-             s.ios, fname, rd, wr, cr, tr) == C_NULL
-        error("could not open file ", fname)
-    end
-    if ff && ccall(:ios_seek_end, FileOffset, (Ptr{Void},), s.ios) != 0
-        error("error seeking to end of file ", fname)
+    systemerror("opening file $fname",
+                ccall(:ios_file, Ptr{Void},
+                      (Ptr{Uint8}, Ptr{Uint8}, Int32, Int32, Int32, Int32),
+                      s.ios, fname, rd, wr, cr, tr) == C_NULL)
+    if ff
+        systemerror("seeking to end of file $fname", ccall(:ios_seek_end, FileOffset, (Ptr{Void},), s.ios) != 0)
     end
     return s
 end

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -72,9 +72,7 @@ function gethostname()
     hn = Array(Uint8, 256)
     @unix_only err=ccall(:gethostname, Int32, (Ptr{Uint8}, Uint), hn, length(hn))
     @windows_only err=ccall(:gethostname, stdcall, Int32, (Ptr{Uint8}, Uint32), hn, length(hn))
-    if err != 0
-        error("gethostname")
-    end
+    systemerror("gethostname", err != 0)
     bytestring(convert(Ptr{Uint8},hn))
 end
 

--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -52,6 +52,7 @@ function mmap_grow(len::Integer, prot::Integer, flags::Integer, fd::Integer, off
         systemerror("pwrite", ccall(:jl_pwrite, Cssize_t, (Cint, Ptr{Void}, Uint, FileOffset), fd, int8([0]), 1, offset + len - 1) < 1)
     end
     cpos = ccall(:jl_lseek, FileOffset, (Cint, FileOffset, Cint), fd, cpos, SEEK_SET)
+    systemerror("lseek", cpos < 0)
     return mmap(len, prot, flags, fd, offset)
 end
 
@@ -77,6 +78,7 @@ function mmap_stream_settings(s::IO)
     const MAP_SHARED::Cint = 1
     const F_GETFL::Cint = 3
     mode = ccall(:fcntl,Cint,(Cint,Cint),fd(s),F_GETFL)
+    systemerror("fcntl F_GETFL", mode == -1)
     mode = mode & 3
     if mode == 0
         prot = PROT_READ

--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -29,9 +29,7 @@ function mmap(len::Integer, prot::Integer, flags::Integer, fd::Integer, offset::
     len_page::Int = (offset-offset_page) + len
     # Mmap the file
     p = ccall(:jl_mmap, Ptr{Void}, (Ptr{Void}, Csize_t, Cint, Cint, Cint, FileOffset), C_NULL, len_page, prot, flags, fd, offset_page)
-    if int(p) == -1
-        error("memory mapping failed: ", strerror())
-    end
+    systemerror("memory mapping failed", int(p) == -1)
     # Also return a pointer that compensates for any adjustment in the offset
     return p, int(offset-offset_page)
 end
@@ -47,38 +45,25 @@ function mmap_grow(len::Integer, prot::Integer, flags::Integer, fd::Integer, off
     const SEEK_END::Cint = 2
     # Save current file position so we can restore it later
     cpos = ccall(:jl_lseek, FileOffset, (Cint, FileOffset, Cint), fd, 0, SEEK_CUR)
-    if cpos < 0
-        error(strerror())
-    end
+    systemerror("lseek", cpos < 0)
     filelen = ccall(:jl_lseek, FileOffset, (Cint, FileOffset, Cint), fd, 0, SEEK_END)
-    if filelen < 0
-        error(strerror())
-    end
+    systemerror("lseek", filelen < 0)
     if (filelen < offset + len)
-        n = ccall(:jl_pwrite, Cssize_t, (Cint, Ptr{Void}, Uint, FileOffset), fd, int8([0]), 1, offset + len - 1)
-        if (n < 1)
-            error(strerror())
-        end
+        systemerror("pwrite", ccall(:jl_pwrite, Cssize_t, (Cint, Ptr{Void}, Uint, FileOffset), fd, int8([0]), 1, offset + len - 1) < 1)
     end
     cpos = ccall(:jl_lseek, FileOffset, (Cint, FileOffset, Cint), fd, cpos, SEEK_SET)
     return mmap(len, prot, flags, fd, offset)
 end
 
 function munmap(p::Ptr,len::Integer)
-    ret = ccall(:munmap,Cint,(Ptr{Void},Int),p,len)
-    if ret != 0
-        error(strerror())
-    end
+    systemerror("munmap", ccall(:munmap,Cint,(Ptr{Void},Int),p,len) != 0)
 end
 
 const MS_ASYNC = 1
 const MS_INVALIDATE = 2
 const MS_SYNC = 4
 function msync(p::Ptr, len::Integer, flags::Integer)
-    ret = ccall(:msync, Cint, (Ptr{Void}, Csize_t, Cint), p, len, flags)
-    if ret != 0
-        error(strerror())
-    end
+    systemerror("msync", ccall(:msync, Cint, (Ptr{Void}, Csize_t, Cint), p, len, flags) != 0)
 end
 msync(p::Ptr, len::Integer) = msync(p, len, MS_SYNC)
 

--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -217,7 +217,7 @@ value_t fl_ioseek(value_t *args, u_int32_t nargs)
     ios_t *s = toiostream(args[0], "io.seek");
     size_t pos = tosize(args[1], "io.seek");
     off_t res = ios_seek(s, (off_t)pos);
-    if (res == -1)
+    if (res < 0)
         return FL_F;
     return FL_T;
 }

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -405,7 +405,7 @@ off_t ios_seek(ios_t *s, off_t pos)
     s->_eof = 0;
     if (s->bm == bm_mem) {
         if ((size_t)pos > s->size)
-            return -1;
+            return -2;
         s->bpos = pos;
     }
     else {
@@ -446,7 +446,7 @@ off_t ios_skip(ios_t *s, off_t offs)
             }
             else if (s->bm == bm_mem) {
                 // TODO: maybe grow buffer
-                return -1;
+                return -2;
             }
         }
         else if (offs < 0) {
@@ -456,7 +456,7 @@ off_t ios_skip(ios_t *s, off_t offs)
                 return 0;
             }
             else if (s->bm == bm_mem) {
-                return -1;
+                return -2;
             }
         }
         ios_flush(s);

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -400,6 +400,9 @@ size_t ios_write(ios_t *s, const char *data, size_t n)
     return wrote;
 }
 
+// Returns 0 on success,
+//        -1 on error which set errno, and
+//        -2 on error which doesn't set errno.
 off_t ios_seek(ios_t *s, off_t pos)
 {
     s->_eof = 0;
@@ -436,6 +439,9 @@ off_t ios_seek_end(ios_t *s)
     return 0;
 }
 
+// Returns 0 on success,
+//        -1 on error which set errno, and
+//        -2 on error which doesn't set errno.
 off_t ios_skip(ios_t *s, off_t offs)
 {
     if (offs != 0) {


### PR DESCRIPTION
As a follow-up to #5193, I went ahead and checked the error-handling of most `ccall`s in `base/`. This pull-request does the following (I suggest to read the commits one-by-one instead of the full diff):
- a35ee0e replaces calls to `error` by calls to `systemerror` where these match perfectly.
- 4ff219f handles two cases where the `ccall`s might fail in two different ways, one with setting errno and the other without.
- b4e722d adds calls to `systemerror` where there weren't but I think there should be.
- 8af88ab fixes a bunch of minor errors and inconsistencies with error-handling in `fs.jl`.

I've been very cautious and `make testall` passes all tests, but please do review and comment.
