### PR TITLE
Patch ARPACK for fortran calling convention to be consistent with MKL.

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -31,7 +31,6 @@ USE_SYSTEM_RMATH=0
 USE_SYSTEM_LIBUV=0
 
 USE_MKL = 0
-MKLLIB = $(MKLROOT)/lib/intel64
 
 # Link to the LLVM shared library
 USE_LLVM_SHLIB = 0
@@ -202,6 +201,7 @@ endif
 endif
 
 JFFLAGS = -O2 $(fPIC)
+JF2CFLAGS = -ff2c -fno-second-underscore
 CPP = $(CC) -E
 AR := $(CROSS_COMPILE)ar
 AS := $(CROSS_COMPILE)as
@@ -445,6 +445,9 @@ endif
 ifeq ($(USE_MKL), 1)
 ifeq ($(USE_BLAS64), 1)
 export MKL_INTERFACE_LAYER := ILP64
+MKLLIB = $(MKLROOT)/lib/intel64
+else
+MKLLIB = $(MKLROOT)/lib/ia32
 endif
 USE_SYSTEM_BLAS=1
 USE_SYSTEM_LAPACK=1

--- a/base/util.jl
+++ b/base/util.jl
@@ -307,7 +307,8 @@ function blas_set_num_threads(n::Integer)
 end
 
 function check_blas()
-    if blas_vendor() == :openblas
+    blas = blas_vendor()
+    if blas == :openblas
         openblas_config = openblas_get_config()
         openblas64 = ismatch(r".*USE64BITINT.*", openblas_config)
         if Base.USE_BLAS64 != openblas64
@@ -322,6 +323,10 @@ function check_blas()
             end
             println("Quitting.")
             quit()
+        end
+    elseif blas == :mkl
+        if Base.USE_BLAS64
+            ENV["MKL_INTERFACE_LAYER"] = "ILP64"
         end
     end
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -663,7 +663,7 @@ install-openlibm: $(OPENLIBM_OBJ_TARGET)
 
 ## openspecfun ##
 
-OPENSPECFUN_FLAGS = ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC) USE_OPENLIBM=1 OPENLIBM_HOME=$(JULIAHOME)/deps/openlibm
+OPENSPECFUN_FLAGS = ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC) FFLAGS="$(JFFLAGS)" USE_OPENLIBM=1 OPENLIBM_HOME=$(JULIAHOME)/deps/openlibm
 
 OPENSPECFUN_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libopenspecfun.$(SHLIB_EXT)
 OPENSPECFUN_OBJ_SOURCE = openspecfun/libopenspecfun.$(SHLIB_EXT)
@@ -1035,7 +1035,7 @@ endif
 ARPACK_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libarpack.$(SHLIB_EXT)
 
 ARPACK_MFLAGS = F77="$(FC)" MPIF77="$(FC)"
-ARPACK_OPTS = $(FFLAGS) $(JFFLAGS)
+ARPACK_FFLAGS += $(FFLAGS) $(JFFLAGS)
 ARPACK_FLAGS = --with-blas="$(LIBBLAS)" --with-lapack="$(LIBLAPACK)" --disable-mpi --enable-shared FFLAGS="$(ARPACK_FFLAGS)"
 ifneq ($(OS),WINNT)
 ARPACK_FLAGS += LDFLAGS="-Wl,-rpath,'$(BUILD)/lib'"


### PR DESCRIPTION
This patch was obtained from macports: http://trac.macports.org/ticket/35508

This also sets the environment variable for the ILP64 MKL upon startup, if `USE_BLAS64=1`

See JuliaLang/julia#3928 JuliaLang/LinearAlgebra.jl#53 
