### PR TITLE
minor update of sum_seq

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1417,13 +1417,16 @@ prod(A::AbstractArray{Bool}) =
 function sum_seq{T}(a::AbstractArray{T}, ifirst::Int, ilast::Int)
 
     @inbounds if ifirst + 3 >= ilast  # a has at most four elements
-        s = zero(T)
-        i = ifirst
-        while i <= ilast
-            s += a[i]
-            i += 1
+        if ifirst > ilast
+            return zero(T)
+        else
+            i = ifirst
+            s = a[i]        
+            while i < ilast
+                s += a[i+=1]
+            end
+            return s
         end
-        return s
 
     else # a has more than four elements
 


### PR DESCRIPTION
When input array is not empty, zero(T) is not required to be defined.

This fixes the problem mentioned in https://groups.google.com/forum/#!topic/julia-users/5vNtBvRR9Vo.
