### PR TITLE
Deprecate cholpfact and qrpfact and introduce keyword arguments for pivoting. Make thin a keyword argument.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,6 +105,9 @@ Deprecated or removed
     argument specifying the floating point type to which they apply. The old
     behaviour and `[get/set/with]_bigfloat_rounding` functions are deprecated ([#5007])
 
+  * cholpfact and qrpfact are deprecated in favor of keyword arguments in 
+    cholfact and qrfact.
+
 [#4042]: https://github.com/JuliaLang/julia/issues/4042
 [#5164]: https://github.com/JuliaLang/julia/issues/5164
 [#5214]: https://github.com/JuliaLang/julia/issues/5214
@@ -135,6 +138,7 @@ Deprecated or removed
 [#5277]: https://github.com/JuliaLang/julia/issues/5277
 [#987]: https://github.com/JuliaLang/julia/issues/987
 [#2345]: https://github.com/JuliaLang/julia/issues/2345
+[#5330]: https://github.com/JuliaLang/julia/issues/5330
 
 Julia v0.2.0 Release Notes
 ==========================

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -168,6 +168,14 @@ export PipeString
 #   copy!(dest::AbstractArray, doffs::Integer, src::Integer)
 # in abstractarray.jl
 @deprecate copy!(dest::AbstractArray, src, doffs::Integer)  copy!(dest, doffs, src)
+@deprecate qrpfact!(A)         qrfact!(A, pivot=true)
+@deprecate qrpfact(A)          qrfact(A, pivot=true)
+@deprecate qrp(A, thin)        qr(A, thin=thin, pivot=true)
+@deprecate qrp(A)              qr(A, pivot=true)
+@deprecate cholpfact!(A)            cholfact!(A, :U, pivot=true)
+@deprecate cholpfact!(A,tol=tol)        cholfact!(A, :U, pivot=true, tol=tol)
+@deprecate cholpfact!(A,uplo,tol=tol)   cholfact!(A, uplo, pivot=true, tol=tol)
+@deprecate cholpfact(A)             cholfact(A, :U, pivot=true)
 
 deprecated_ls() = run(`ls -l`)
 deprecated_ls(args::Cmd) = run(`ls -l $args`)

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -111,6 +111,7 @@ export
     svdvals!,
     svdvals,
     symmetrize!,
+    symmetrize_conj!,
     trace,
     transpose,
     tril,

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -423,7 +423,7 @@ function factorize!{T}(A::Matrix{T})
         end
         return lufact!(A)
     end
-    return qrpfact!(A)
+    return qrfact!(A,pivot=true)
 end
 
 factorize(A::AbstractMatrix) = factorize!(copy(A))
@@ -443,7 +443,7 @@ function (\){T<:BlasFloat}(A::StridedMatrix{T}, B::StridedVecOrMat{T})
         istriu(A) && return \(Triangular(A, :U),B)
         return \(lufact(A),B)
     end
-    return qrpfact(A)\B
+    return qrfact(A,pivot=true)\B
 end
 
 ## Moore-Penrose inverse

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -1674,7 +1674,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
                   (Ptr{BlasChar}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt},
                    Ptr{BlasInt}, Ptr{$rtyp}, Ptr{$rtyp}, Ptr{BlasInt}),
                   &uplo, &n, A, &max(1,stride(A,2)), piv, rank, &tol, work, info)
-            @lapackerror
+            @assertargsok
             A, piv, rank[1], info[1] #Stored in PivotedCholesky
         end
     end

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -82,11 +82,9 @@ end
 
 size(A::Triangular, args...) = size(A.UL, args...)
 convert(::Type{Matrix}, A::Triangular) = full(A)
-full(A::Triangular) = A.UL
+full(A::Triangular) = A.uplo == 'U' ? triu!(A.UL) : tril!(A.UL)
 
-getindex{T}(A::Triangular{T}, i::Integer, j::Integer) = i == j ? A.UL[i,j] : ((A.uplo == 'U') == (i < j) ? getindex(A.UL, i, j) : zero(T))
-
-print_matrix(io::IO, A::Triangular, rows::Integer, cols::Integer) = print_matrix(io, full(A), rows, cols)
+getindex{T}(A::Triangular{T}, i::Integer, j::Integer) = i == j ? (A.unitdiag == 'U' ? one(T) : A.UL[i,j]) : ((A.uplo == 'U') == (i < j) ? getindex(A.UL, i, j) : zero(T))
 
 istril(A::Triangular) = A.uplo == 'L' || istriu(A.UL)
 istriu(A::Triangular) = A.uplo == 'U' || istril(A.UL)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -51,7 +51,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     @test_approx_eq l*l' apd
 
     # pivoted Choleksy decomposition
-    cpapd = cholpfact(apd)
+    cpapd = cholfact(apd, pivot=true)
     @test rank(cpapd) == n
     @test all(diff(diag(real(cpapd.UL))).<=0.) # diagonal should be non-increasing
     @test_approx_eq b apd * (cpapd\b)
@@ -88,16 +88,16 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     # QR decomposition
     qra   = qrfact(a)
     q,r   = qra[:Q], qra[:R]
-    @test_approx_eq q'*full(q, false) eye(elty, n)
-    @test_approx_eq q*full(q, false)' eye(elty, n)
+    @test_approx_eq q'*full(q, thin=false) eye(elty, n)
+    @test_approx_eq q*full(q, thin=false)' eye(elty, n)
     @test_approx_eq q*r a
     @test_approx_eq a*(qra\b) b
 
     # (Automatic) Fat pivoted QR decomposition
     qrpa  = factorize(a[1:5,:])
     q,r,p = qrpa[:Q], qrpa[:R], qrpa[:p]
-    @test_approx_eq q'*full(q, false) eye(elty, 5)
-    @test_approx_eq q*full(q, false)' eye(elty, 5)
+    @test_approx_eq q'*full(q, thin=false) eye(elty, 5)
+    @test_approx_eq q*full(q, thin=false)' eye(elty, 5)
     @test_approx_eq q*r a[1:5,p]
     @test_approx_eq q*r[:,invperm(p)] a[1:5,:]
     @test_approx_eq a[1:5,:]*(qrpa\b[1:5]) b[1:5]
@@ -105,8 +105,8 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     # (Automatic) Thin pivoted QR decomposition
     qrpa  = factorize(a[:,1:5])
     q,r,p = qrpa[:Q], qrpa[:R], qrpa[:p]
-    @test_approx_eq q'*full(q, false) eye(elty, n)
-    @test_approx_eq q*full(q, false)' eye(elty, n)
+    @test_approx_eq q'*full(q, thin=false) eye(elty, n)
+    @test_approx_eq q*full(q, thin=false)' eye(elty, n)
     @test_approx_eq q*r a[:,p]
     @test_approx_eq q*r[:,invperm(p)] a[:,1:5]
 
@@ -125,7 +125,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     @test_approx_eq asym[1:5,1:5]*f[:vectors] scale(a610'a610*f[:vectors], f[:values])
     @test_approx_eq f[:values] eigvals(asym[1:5,1:5], a610'a610)
     @test_approx_eq prod(f[:values]) prod(eigvals(asym[1:5,1:5]/(a610'a610)))
-
+ 
     # Non-symmetric generalized eigenproblem
     f = eigfact(a[1:5,1:5], a[6:10,6:10])
     @test_approx_eq a[1:5,1:5]*f[:vectors] scale(a[6:10,6:10]*f[:vectors], f[:values])
@@ -149,7 +149,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     # singular value decomposition
     usv = svdfact(a)                
     @test_approx_eq usv[:U]*scale(usv[:S],usv[:Vt]) a
-    
+  
     # Generalized svd
     gsvd = svdfact(a,a[1:5,:])
     @test_approx_eq gsvd[:U]*gsvd[:D1]*gsvd[:R]*gsvd[:Q]' a
@@ -163,7 +163,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
     
     x = tril(a)\b
     @test_approx_eq tril(a)*x b
-    
+   
     # Test null
     a15null = null(a[:,1:5]')
     @test rank([a[:,1:5] a15null]) == 10


### PR DESCRIPTION
I had to give up on rebasing #4621 and have tried to redo @jiahao's work here.
