### PR TITLE
Fixed table to render correctly in LaTeX/PDF

### DIFF
--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -590,6 +590,8 @@ matrix element has a probability ``d`` of being non-zero.
 Details can be found in the :ref:`stdlib-sparse` section of the standard library
 reference.
 
+.. tabularcolumns:: |l|l|L|
+
 +-----------------------+-------------------+----------------------------------------+
 | Sparse                | Dense             | Description                            |
 +-----------------------+-------------------+----------------------------------------+


### PR DESCRIPTION
Fix the table in arrays.rst under "Corresponding …" so that the table is rendered correctly in LaTeX, and thereby in PDF).
