### PR TITLE
`identity()` is now variadic.

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -111,7 +111,7 @@ gc_disable() = ccall(:jl_gc_disable, Void, ())
 
 bytestring(str::ByteString) = str
 
-identity(x) = x
+identity(x...) = x
 
 function append_any(xs...)
     # used by apply() and quote


### PR DESCRIPTION
In my (brief) tests, the variadic version doesn't incur a performance penalty in the single argument case. If it does in some cases I missed, I'll add it back.
