### PR TITLE
Add support for @simd 

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1319,4 +1319,5 @@ export
     @sprintf,
     @deprecate,
     @boundscheck,
-    @inbounds
+    @inbounds,
+    @simd

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -1,0 +1,66 @@
+# Support for @simd for
+
+module SimdLoop
+
+export @simd
+
+# Error thrown from ill-formed uses of @simd
+type SimdError <: Exception
+    msg::ASCIIString
+end
+
+# Parse colon expression low:high, returning (low,high)
+function parse_range( x::Expr )
+    if x.head!=:(:)
+        throw( SimdError("range must use : syntax"))
+    elseif length(x.args)!=2
+        throw( SimdError("wrong number of args in range"));
+    else
+        (x.args[1],x.args[2])
+    end
+end
+
+# Parse iteration space expression
+#       symbol '=' range
+#       symbol 'in' range
+function parse_iteration_space( x::Expr )
+    if x.head!=:(=) && x.head!=:(in)
+        throw( SimdError("= or in expected"))
+    elseif length(x.args)!=2
+        throw( SimdError("simd syntax error"))
+    else
+        sym = (x.args[1])::Symbol
+        (low,high)=parse_range(x.args[2])
+        return (sym,low,high)
+    end
+end
+
+# Compile Expr x in context of @simd.
+function compile(x::Expr)
+    h = x.head
+    if h != :for
+        throw(SimdError("for loop expected"))
+    elseif length(x.args)!=2
+        throw(SimdError("1D for loop expected"))
+    else
+        (var,low,high) = parse_iteration_space(x.args[1])
+        tmp = gensym()
+        body = x.args[2]
+        loop = quote
+            local $tmp = $high+1
+            local $var = $low
+            while $var < $tmp
+                $body
+                $var = $var+1
+                $(Expr(:simdloop))  # Mark loop as SIMD loop
+            end
+        end
+        return loop
+    end
+end
+
+macro simd(forloop)
+    esc(compile(forloop))
+end
+
+end # simdloop

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -36,7 +36,7 @@ function compile(x)
         n = gensym() # Trip count
         s = gensym() # Step
         i = gensym() # Index variable
-        # LLVM vectorizer needs to compute a trip count, so make it obivious.
+        # LLVM vectorizer needs to compute a trip count, so make it obvious.
         quote
             local $r = $range
             local $n = length($r)

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -9,53 +9,47 @@ type SimdError <: Exception
     msg::ASCIIString
 end
 
-# Parse colon expression low:high, returning (low,high)
-function parse_range( x::Expr )
-    if x.head!=:(:)
-        throw( SimdError("range must use : syntax"))
-    elseif length(x.args)!=2
-        throw( SimdError("wrong number of args in range"));
-    else
-        (x.args[1],x.args[2])
-    end
-end
-
 # Parse iteration space expression
 #       symbol '=' range
 #       symbol 'in' range
-function parse_iteration_space( x::Expr )
-    if x.head!=:(=) && x.head!=:(in)
+function parse_iteration_space( x )
+    if !Meta.isexpr(x,[:(=),:in])
         throw( SimdError("= or in expected"))
     elseif length(x.args)!=2
-        throw( SimdError("simd syntax error"))
+        throw( SimdError("simd range syntax is wrong"))
+    elseif !isa(x.args[1],Symbol)
+        throw( SimdError("simd loop index must be a symbol"))
     else
-        sym = (x.args[1])::Symbol
-        (low,high)=parse_range(x.args[2])
-        return (sym,low,high)
+        x.args # symbol, range
     end
 end
 
 # Compile Expr x in context of @simd.
-function compile(x::Expr)
-    h = x.head
-    if h != :for
+function compile(x)
+    if !Meta.isexpr(x,:for)
         throw(SimdError("for loop expected"))
     elseif length(x.args)!=2
         throw(SimdError("1D for loop expected"))
     else
-        (var,low,high) = parse_iteration_space(x.args[1])
-        tmp = gensym()
-        body = x.args[2]
-        loop = quote
-            local $tmp = $high+1
-            local $var = $low
-            while $var < $tmp
-                $body
-                $var = $var+1
+        var,range = parse_iteration_space(x.args[1])
+        r = gensym() # Range
+        n = gensym() # Trip count
+        s = gensym() # Step
+        i = gensym() # Index variable
+        # LLVM vectorizer needs to compute a trip count, so make it obivious.
+        quote
+            local $r = $range
+            local $n = length($r)
+            local $s = step($r)
+            local $var = first($r)
+            local $i = zero($n)
+            while $i < $n
+                $(x.args[2])
+                $var += $s
+                $i += 1
                 $(Expr(:simdloop))  # Mark loop as SIMD loop
             end
         end
-        return loop
     end
 end
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -185,6 +185,10 @@ using .I18n
 using .Help
 push!(I18n.CALLBACKS, Help.clear_cache)
 
+# SIMD loops
+include("simdloop.jl")
+importall .SimdLoop
+
 # sparse matrices and linear algebra
 include("sparse.jl")
 importall .SparseMatrix

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -474,7 +474,7 @@ Here is an example with both forms of markup::
         s
     end
 
-The range for a ``@simd for`` loop must use the colon syntax, with two subexpresions.
+The range for a ``@simd for`` loop should be a one-dimensional range.
 A variable used for accumulating, such as ``s`` in the example, is called
 a *reduction variable*. By using``@simd``, you are asserting several
 properties of the loop:

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -459,6 +459,8 @@ properties.
    Be certain before doing this. If the subscripts are ever out of bounds,
    you may suffer crashes or silent corruption.
 -  Write ``@simd`` in front of ``for`` loops that are amenable to vectorization.
+   **This feature is experimental** and could change or disappear in future 
+   versions of Julia.  
 
 Here is an example with both forms of markup::
 

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -449,6 +449,47 @@ These are some minor points that might help in tight inner loops.
 -  Use ``div(x,y)`` for truncating division of integers instead of
    ``trunc(x/y)``, and ``fld(x,y)`` instead of ``floor(x/y)``.
 
+Performance Annotations
+-----------------------
+
+Sometimes you can enable better optimization by promising certain program
+properties.
+
+-  Use ``@inbounds`` to eliminate array bounds checking within expressions.
+   Be certain before doing this. If the subscripts are ever out of bounds,
+   you may suffer crashes or silent corruption.
+-  Write ``@simd`` in front of ``for`` loops that are amenable to vectorization.
+
+Here is an example with both forms of markup::
+
+    function tightloop( x, y, z )
+        s = zero(eltype(z))
+        n = min(length(x),length(y),length(z))
+        @simd for i in 1:n
+            @inbounds begin
+                z[i] = x[i]-y[i]
+                s += z[i]*z[i]
+            end
+        end
+        s
+    end
+
+The range for a ``@simd for`` loop must use the colon syntax, with two subexpresions.
+A variable used for accumulating, such as ``s`` in the example, is called
+a *reduction variable*. By using``@simd``, you are asserting several
+properties of the loop:
+
+-  It is safe to execute iterations in arbitrary or overlapping order,
+   with special consideration for reduction variables.
+-  Floating-point operations on reduction variables can be reordered,
+   possibly causing different results than without ``@simd``.
+-  No iteration ever waits on another iteration to make forward progress.
+
+Using ``@simd`` merely gives the compiler license to vectorize. Whether
+it actually does so depends on the compiler. The current implementation
+will not vectorize if there are possible early exits from the loop, such
+as from array bounds checking. This limitation may be lifted in the future.
+
 Tools
 -----
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ override CPPFLAGS += $(JCPPFLAGS)
 
 SRCS = \
 	jltypes gf ast builtins module codegen interpreter \
-	alloc dlload sys init task array dump toplevel jl_uv jlapi profile
+	alloc dlload sys init task array dump toplevel jl_uv jlapi profile llvm-simdloop
 
 FLAGS = \
 	-D_GNU_SOURCE \

--- a/src/Windows.mk
+++ b/src/Windows.mk
@@ -31,6 +31,7 @@ OBJECTS = \
 	toplevel.obj \
 	jl_uv.obj \
 	jlapi.obj \
+	llvm-simdloop.obj \
 	gc.obj
 
 LIBFLISP = flisp\libflisp.lib

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -87,6 +87,7 @@ jl_sym_t *compositetype_sym; jl_sym_t *type_goto_sym;
 jl_sym_t *global_sym; jl_sym_t *tuple_sym;
 jl_sym_t *dot_sym;    jl_sym_t *newvar_sym;
 jl_sym_t *boundscheck_sym; jl_sym_t *copyast_sym;
+jl_sym_t *simdloop_sym;
 
 typedef struct {
     int64_t a;

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -368,8 +368,7 @@ static Value *julia_to_native(Type *ty, jl_value_t *jt, Value *jv,
             return builder.CreateBitCast(emit_arrayptr(jv), ty);
         }
         if (aty == (jl_value_t*)jl_ascii_string_type || aty == (jl_value_t*)jl_utf8_string_type) {
-            // FIXME - is tbaa_arrayptr correct here?
-            return builder.CreateBitCast(emit_arrayptr(emit_nthptr(jv,1,tbaa_arrayptr)), ty);
+            return builder.CreateBitCast(emit_arrayptr(emit_nthptr(jv,1,tbaa_const)), ty);
         }
         if (jl_is_structtype(aty) && jl_is_leaf_type(aty) && !jl_is_array_type(aty)) {
             if (!addressOf) {

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -368,7 +368,8 @@ static Value *julia_to_native(Type *ty, jl_value_t *jt, Value *jv,
             return builder.CreateBitCast(emit_arrayptr(jv), ty);
         }
         if (aty == (jl_value_t*)jl_ascii_string_type || aty == (jl_value_t*)jl_utf8_string_type) {
-            return builder.CreateBitCast(emit_arrayptr(emit_nthptr(jv,1)), ty);
+            // FIXME - is tbaa_arrayptr correct here?
+            return builder.CreateBitCast(emit_arrayptr(emit_nthptr(jv,1,tbaa_arrayptr)), ty);
         }
         if (jl_is_structtype(aty) && jl_is_leaf_type(aty) && !jl_is_array_type(aty)) {
             if (!addressOf) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -664,6 +664,11 @@ static Value *mark_julia_type(Value *v, jl_value_t *jt)
     return v;
 }
 
+static Value *tbaa_decorate(MDNode* md, Instruction* load_or_store) {
+    load_or_store->setMetadata( llvm::LLVMContext::MD_tbaa, md );
+    return load_or_store;
+}
+
 // --- generating various error checks ---
 
 static jl_value_t *llvm_type_to_julia(Type *t, bool err=true);
@@ -733,7 +738,7 @@ static void raise_exception_unless(Value *cond, Value *exc, jl_codectx_t *ctx)
 static void raise_exception_unless(Value *cond, GlobalVariable *exc,
                                    jl_codectx_t *ctx)
 {
-    raise_exception_unless(cond, (Value*)builder.CreateLoad(exc, false), ctx);
+    raise_exception_unless(cond, (Value*)tbaa_decorate(tbaa_const,builder.CreateLoad(exc, false)), ctx);
 }
 
 static void raise_exception_if(Value *cond, Value *exc, jl_codectx_t *ctx)
@@ -839,11 +844,11 @@ static Value *emit_nthptr_addr(Value *v, Value *idx)
     return builder.CreateGEP(builder.CreateBitCast(v, jl_ppvalue_llvmt), idx);
 }
 
-static Value *emit_nthptr(Value *v, size_t n)
+static Value *emit_nthptr(Value *v, size_t n, MDNode *tbaa)
 {
     // p = (jl_value_t**)v; p[n]
     Value *vptr = emit_nthptr_addr(v, n);
-    return builder.CreateLoad(vptr, false);
+    return tbaa_decorate(tbaa,builder.CreateLoad(vptr, false));
 }
 
 static Value *emit_nthptr(Value *v, Value *idx)
@@ -865,7 +870,7 @@ static Value *typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
         data = builder.CreateBitCast(ptr, PointerType::get(elty, 0));
     else
         data = ptr;
-    Value *elt = builder.CreateLoad(builder.CreateGEP(data, idx_0based), false);
+    Value *elt = tbaa_decorate(tbaa_user, builder.CreateLoad(builder.CreateGEP(data, idx_0based), false));
     if (elty == jl_pvalue_llvmt) {
         null_pointer_check(elt, ctx);
     }
@@ -891,7 +896,7 @@ static Value *typed_store(Value *ptr, Value *idx_0based, Value *rhs,
         data = builder.CreateBitCast(ptr, PointerType::get(elty, 0));
     else
         data = ptr;
-    return builder.CreateStore(rhs, builder.CreateGEP(data, idx_0based));
+    return tbaa_decorate(tbaa_user, builder.CreateStore(rhs, builder.CreateGEP(data, idx_0based)));
 }
 
 // --- convert boolean value to julia ---
@@ -988,7 +993,7 @@ static Value *emit_tuplelen(Value *t,jl_value_t *jt)
         return builder.CreateLShr(builder.CreatePtrToInt(lenbits, T_int64),
                                   ConstantInt::get(T_int32, 52));
 #else
-        Value *lenbits = emit_nthptr(t, 1);
+        Value *lenbits = emit_nthptr(t, 1, tbaa_tuplelen);
         return builder.CreatePtrToInt(lenbits, T_size);
 #endif
     }
@@ -1120,20 +1125,20 @@ static Value *emit_tupleref(Value *tuple, Value *ival, jl_value_t *jt, jl_codect
                                                        Intrinsic::stacksave));
         builder.Insert(stacksave);
         Value *tempSpace = builder.CreateAlloca(at);
-        builder.CreateStore(tuple,tempSpace);
+        tbaa_decorate(tbaa_user, builder.CreateStore(tuple,tempSpace));
         Value *idxs[2];
         idxs[0] = ConstantInt::get(T_size,0);
         idxs[1] = builder.CreateSub(ival,ConstantInt::get(T_size,1));
         Value *v = builder.CreateGEP(tempSpace,ArrayRef<Value*>(&idxs[0],2));
         if (idx) {
-            v = mark_julia_type(builder.CreateLoad(v), jl_tupleref(jt,ci));
+            v = mark_julia_type(tbaa_decorate(tbaa_user, builder.CreateLoad(v)), jl_tupleref(jt,ci));
         }
         else {
             jl_add_linfo_root(ctx->linfo, jt);
             Value *lty = emit_tupleref(literal_pointer_val(jt), ival, jl_typeof(jt), ctx);
             size_t i, l = jl_tuple_len(jt);
             if (is_tupletype_homogeneous((jl_tuple_t*)jt) && jl_isbits(jl_t0(jt))) {
-                v = mark_julia_type(builder.CreateLoad(v), jl_t0(jt));
+                v = mark_julia_type(tbaa_decorate(tbaa_user, builder.CreateLoad(v)), jl_t0(jt));
             }
             else {
                 for (i = 0; i < l; i++) {
@@ -1147,7 +1152,7 @@ static Value *emit_tupleref(Value *tuple, Value *ival, jl_value_t *jt, jl_codect
                     Value *nb = ConstantExpr::getSizeOf(at->getElementType());
                     if (sizeof(size_t)==4)
                         nb = builder.CreateTrunc(nb, T_int32);
-                    v = allocate_box_dynamic(lty, nb, builder.CreateLoad(v));
+                    v = allocate_box_dynamic(lty, nb, tbaa_decorate(tbaa_user, builder.CreateLoad(v)));
                 }
             }
         }
@@ -1254,7 +1259,7 @@ static Value *emit_arraylen_prim(Value *t, jl_value_t *ty)
 {
 #ifdef STORE_ARRAY_LEN
     (void)ty;
-    Value *lenbits = emit_nthptr(t, 2);
+    Value *lenbits = emit_nthptr(t, 2, tbaa_arraylen);
     return builder.CreatePtrToInt(lenbits, T_size);
 #else
     jl_value_t *p1 = jl_tparam1(ty);
@@ -1280,20 +1285,20 @@ static Value *emit_arraylen(Value *t, jl_value_t *ex, jl_codectx_t *ctx)
 {
     jl_arrayvar_t *av = arrayvar_for(ex, ctx);
     if (av!=NULL)
-        return builder.CreateLoad(av->len);
+        return tbaa_decorate(tbaa_arraylen, builder.CreateLoad(av->len));
     return emit_arraylen_prim(t, expr_type(ex,ctx));
 }
 
 static Value *emit_arrayptr(Value *t)
 {
-    return emit_nthptr(t, 1);
+    return emit_nthptr(t, 1, tbaa_arrayptr);
 }
 
 static Value *emit_arrayptr(Value *t, jl_value_t *ex, jl_codectx_t *ctx)
 {
     jl_arrayvar_t *av = arrayvar_for(ex, ctx);
     if (av!=NULL)
-        return builder.CreateLoad(av->dataptr);
+        return tbaa_decorate(tbaa_arrayptr, builder.CreateLoad(av->dataptr));
     return emit_arrayptr(t);
 }
 
@@ -1301,18 +1306,18 @@ static Value *emit_arraysize(Value *t, jl_value_t *ex, int dim, jl_codectx_t *ct
 {
     jl_arrayvar_t *av = arrayvar_for(ex, ctx);
     if (av != NULL && dim <= (int)av->sizes.size())
-        return builder.CreateLoad(av->sizes[dim-1]);
+        return tbaa_decorate(tbaa_arraysize, builder.CreateLoad(av->sizes[dim-1]));
     return emit_arraysize(t, dim);
 }
 
 static void assign_arrayvar(jl_arrayvar_t &av, Value *ar)
 {
-    builder.CreateStore(builder.CreateBitCast(emit_arrayptr(ar),
-                                              av.dataptr->getType()->getContainedType(0)),
-                        av.dataptr);
-    builder.CreateStore(emit_arraylen_prim(ar, av.ty), av.len);
+    tbaa_decorate(tbaa_arrayptr,builder.CreateStore(builder.CreateBitCast(emit_arrayptr(ar),
+                                                    av.dataptr->getType()->getContainedType(0)),
+                                                    av.dataptr));
+    tbaa_decorate(tbaa_arraylen,builder.CreateStore(emit_arraylen_prim(ar, av.ty), av.len));
     for(size_t i=0; i < av.sizes.size(); i++)
-        builder.CreateStore(emit_arraysize(ar,i+1), av.sizes[i]);
+        tbaa_decorate(tbaa_user, builder.CreateStore(emit_arraysize(ar,i+1), av.sizes[i]));
 }
 
 static Value *data_pointer(Value *x)
@@ -1363,7 +1368,7 @@ static Value *emit_array_nd_index(Value *a, jl_value_t *ex, size_t nd, jl_value_
 
         ctx->f->getBasicBlockList().push_back(failBB);
         builder.SetInsertPoint(failBB);
-        builder.CreateCall2(prepare_call(jlthrow_line_func), builder.CreateLoad(prepare_global(jlboundserr_var)),
+        builder.CreateCall2(prepare_call(jlthrow_line_func), tbaa_decorate(tbaa_const,builder.CreateLoad(prepare_global(jlboundserr_var))),
                             ConstantInt::get(T_int32, ctx->lineno));
         builder.CreateUnreachable();
 
@@ -1585,7 +1590,7 @@ static void emit_cpointercheck(Value *x, const std::string &msg,
     emit_typecheck(t, (jl_value_t*)jl_datatype_type, msg, ctx);
 
     Value *istype =
-        builder.CreateICmpEQ(emit_nthptr(t, offsetof(jl_datatype_t,name)/sizeof(char*)),
+        builder.CreateICmpEQ(emit_nthptr(t, offsetof(jl_datatype_t,name)/sizeof(char*), tbaa_datatype),
                              literal_pointer_val((jl_value_t*)jl_pointer_type->name));
     BasicBlock *failBB = BasicBlock::Create(getGlobalContext(),"fail",ctx->f);
     BasicBlock *passBB = BasicBlock::Create(getGlobalContext(),"pass");

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -851,11 +851,11 @@ static Value *emit_nthptr(Value *v, size_t n, MDNode *tbaa)
     return tbaa_decorate(tbaa,builder.CreateLoad(vptr, false));
 }
 
-static Value *emit_nthptr(Value *v, Value *idx)
+static Value *emit_nthptr(Value *v, Value *idx, MDNode *tbaa)
 {
     // p = (jl_value_t**)v; p[n]
     Value *vptr = emit_nthptr_addr(v, idx);
-    return builder.CreateLoad(vptr, false);
+    return tbaa_decorate(tbaa,builder.CreateLoad(vptr, false));
 }
 
 static Value *typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
@@ -1232,7 +1232,7 @@ static Value *emit_arraysize(Value *t, Value *dim)
 #endif
     Value *dbits =
         emit_nthptr(t, builder.CreateAdd(dim,
-                                         ConstantInt::get(dim->getType(), o)));
+                                         ConstantInt::get(dim->getType(), o)), tbaa_arraysize);
     return builder.CreatePtrToInt(dbits, T_size);
 }
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1285,7 +1285,7 @@ static Value *emit_arraylen(Value *t, jl_value_t *ex, jl_codectx_t *ctx)
 {
     jl_arrayvar_t *av = arrayvar_for(ex, ctx);
     if (av!=NULL)
-        return tbaa_decorate(tbaa_arraylen, builder.CreateLoad(av->len));
+        return builder.CreateLoad(av->len);
     return emit_arraylen_prim(t, expr_type(ex,ctx));
 }
 
@@ -1298,7 +1298,7 @@ static Value *emit_arrayptr(Value *t, jl_value_t *ex, jl_codectx_t *ctx)
 {
     jl_arrayvar_t *av = arrayvar_for(ex, ctx);
     if (av!=NULL)
-        return tbaa_decorate(tbaa_arrayptr, builder.CreateLoad(av->dataptr));
+        return builder.CreateLoad(av->dataptr);
     return emit_arrayptr(t);
 }
 
@@ -1306,7 +1306,7 @@ static Value *emit_arraysize(Value *t, jl_value_t *ex, int dim, jl_codectx_t *ct
 {
     jl_arrayvar_t *av = arrayvar_for(ex, ctx);
     if (av != NULL && dim <= (int)av->sizes.size())
-        return tbaa_decorate(tbaa_arraysize, builder.CreateLoad(av->sizes[dim-1]));
+        return builder.CreateLoad(av->sizes[dim-1]);
     return emit_arraysize(t, dim);
 }
 
@@ -1315,9 +1315,9 @@ static void assign_arrayvar(jl_arrayvar_t &av, Value *ar)
     tbaa_decorate(tbaa_arrayptr,builder.CreateStore(builder.CreateBitCast(emit_arrayptr(ar),
                                                     av.dataptr->getType()->getContainedType(0)),
                                                     av.dataptr));
-    tbaa_decorate(tbaa_arraylen,builder.CreateStore(emit_arraylen_prim(ar, av.ty), av.len));
+    builder.CreateStore(emit_arraylen_prim(ar, av.ty), av.len);
     for(size_t i=0; i < av.sizes.size(); i++)
-        tbaa_decorate(tbaa_user, builder.CreateStore(emit_arraysize(ar,i+1), av.sizes[i]));
+        builder.CreateStore(emit_arraysize(ar,i+1), av.sizes[i]);
 }
 
 static Value *data_pointer(Value *x)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3718,9 +3718,9 @@ static void init_julia_llvm_env(Module *m)
     tbaa_arrayptr = tbaa_make_child("jtbaa_arrayptr",tbaa_array);
     tbaa_arraysize = tbaa_make_child("jtbaa_arraysize",tbaa_array);
     tbaa_arraylen = tbaa_make_child("jtbaa_arraylen",tbaa_array);
-    tbaa_tuplelen = tbaa_make_child("jtbaa_arraysize",tbaa_value);
+    tbaa_tuplelen = tbaa_make_child("jtbaa_tuplelen",tbaa_value);
     tbaa_func = tbaa_make_child("jtbaa_func",tbaa_value);
-    tbaa_datatype = tbaa_make_child("jtbaa_func",tbaa_value);
+    tbaa_datatype = tbaa_make_child("jtbaa_datatype",tbaa_value);
     tbaa_const = tbaa_make_child("jtbaa_const",tbaa_root,true);
 
     // every variable or function mapped in this function must be

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -198,7 +198,7 @@ static MDNode* tbaa_arraylen;               // The len in a jl_array_t
 static MDNode* tbaa_tuplelen;           // The len in a jl_tuple_t
 static MDNode* tbaa_func;           // A jl_function_t
 static MDNode* tbaa_datatype;       // A jl_datatype_t
-static MDNode* tbaa_const;          // Julia constant
+static MDNode* tbaa_const;          // Memory that is immutable by the time LLVM can see it
 
 namespace llvm {
     extern Pass *createLowerSimdLoopPass();

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -59,6 +59,7 @@
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/MDBuilder.h"
 #define LLVM33 1
 #else
 #include "llvm/DerivedTypes.h" 
@@ -94,6 +95,9 @@
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Config/llvm-config.h"
+#ifdef DEBUG
+#include "llvm/Support/CommandLine.h"
+#endif
 #include "llvm/Transforms/Utils/Cloning.h"
 #include <setjmp.h>
 
@@ -141,6 +145,7 @@ static RTDyldMemoryManager *jl_mcjmm;
 #else
 static Module *jl_Module;
 #endif
+static MDBuilder *mbuilder;
 static std::map<int, std::string> argNumberStrings;
 static FunctionPassManager *FPM;
 
@@ -182,6 +187,23 @@ static Type *T_pfloat32;
 static Type *T_float64;
 static Type *T_pfloat64;
 static Type *T_void;
+
+// type-based alias analysis nodes.  Indentation of comments indicates hierarchy.
+static MDNode* tbaa_user;           // User data
+static MDNode* tbaa_value;          // Julia value
+static MDNode* tbaa_array;              // Julia array
+static MDNode* tbaa_arrayptr;               // The pointer inside a jl_array_t
+static MDNode* tbaa_arraysize;              // A size in a jl_array_t
+static MDNode* tbaa_arraylen;               // The len in a jl_array_t
+static MDNode* tbaa_tuplelen;           // The len in a jl_tuple_t
+static MDNode* tbaa_func;           // A jl_function_t
+static MDNode* tbaa_datatype;       // A jl_datatype_t
+static MDNode* tbaa_const;          // Julia constant
+
+namespace llvm {
+    extern Pass *createLowerSimdLoopPass();
+    extern bool annotateSimdLoop( BasicBlock* latch );
+}
 
 // constants
 static Value *V_null;
@@ -1146,9 +1168,9 @@ static Value *emit_lambda_closure(jl_value_t *expr, jl_codectx_t *ctx)
         if (vari.closureidx != -1) {
             int idx = vari.closureidx;
 #ifdef OVERLAP_TUPLE_LEN
-            val = emit_nthptr((Value*)ctx->envArg, idx+1);
+            val = emit_nthptr((Value*)ctx->envArg, idx+1, tbaa_tuplelen);
 #else
-            val = emit_nthptr((Value*)ctx->envArg, idx+2);
+            val = emit_nthptr((Value*)ctx->envArg, idx+2, tbaa_tuplelen);
 #endif
         }
         else {
@@ -1517,7 +1539,7 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
     else if (f->fptr == &jl_f_apply && nargs==2 && ctx->vaStack &&
              symbol_eq(args[2], ctx->vaName)) {
         Value *theF = emit_expr(args[1],ctx);
-        Value *theFptr = builder.CreateBitCast(emit_nthptr(theF,1),jl_fptr_llvmt);
+        Value *theFptr = builder.CreateBitCast(emit_nthptr(theF,1, tbaa_func),jl_fptr_llvmt);
         Value *nva = emit_n_varargs(ctx);
 #ifdef _P64
         nva = builder.CreateTrunc(nva, T_int32);
@@ -1541,8 +1563,8 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                 idx = emit_bounds_check(idx, valen, ctx);
                 idx = builder.CreateAdd(idx, ConstantInt::get(T_size, ctx->nReqArgs));
                 JL_GC_POP();
-                return builder.
-                    CreateLoad(builder.CreateGEP(ctx->argArray,idx),false);
+                return tbaa_decorate(tbaa_user, builder.
+                    CreateLoad(builder.CreateGEP(ctx->argArray,idx),false));
             }
             Value *arg1 = emit_expr(args[1], ctx);
             if (jl_is_long(args[2])) {
@@ -1557,7 +1579,7 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                 }
                 if (idx==0 || (!isseqt && idx > tlen)) {
                     builder.CreateCall2(prepare_call(jlthrow_line_func),
-                                        builder.CreateLoad(prepare_global(jlboundserr_var)),
+                                        tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlboundserr_var))),
                                         ConstantInt::get(T_int32, ctx->lineno));
                     JL_GC_POP();
                     return V_null;
@@ -1839,11 +1861,11 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                     if (is_structtype_all_pointers(stt)) {
                         idx = emit_bounds_check(idx, ConstantInt::get(T_size, nfields), ctx);
                         Value *fld =
-                            builder.
+                            tbaa_decorate(tbaa_user, builder.
                             CreateLoad(builder.
                                        CreateGEP(builder.
                                                  CreateBitCast(strct, jl_ppvalue_llvmt),
-                                                 builder.CreateAdd(idx,ConstantInt::get(T_size,1))));
+                                                 builder.CreateAdd(idx,ConstantInt::get(T_size,1)))));
                         null_pointer_check(fld, ctx);
                         JL_GC_POP();
                         return fld;
@@ -2002,7 +2024,7 @@ static Value *emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx,
         }
         // extract pieces of the function object
         // TODO: try extractvalue instead
-        theFptr = builder.CreateBitCast(emit_nthptr(theFunc, 1), jl_fptr_llvmt);
+        theFptr = builder.CreateBitCast(emit_nthptr(theFunc, 1, tbaa_func), jl_fptr_llvmt);
         theF = theFunc;
     }
     else {
@@ -2111,9 +2133,9 @@ static Value *var_binding_pointer(jl_sym_t *s, jl_binding_t **pbnd,
         assert(((Value*)ctx->envArg)->getType() == jl_pvalue_llvmt);
         if (isBoxed(s, ctx)) {
 #ifdef OVERLAP_TUPLE_LEN
-            return emit_nthptr_addr(emit_nthptr((Value*)ctx->envArg, idx+1), 1);
+            return emit_nthptr_addr(emit_nthptr((Value*)ctx->envArg, idx+1, tbaa_tuplelen), 1);
 #else
-            return emit_nthptr_addr(emit_nthptr((Value*)ctx->envArg, idx+2), 1);
+            return emit_nthptr_addr(emit_nthptr((Value*)ctx->envArg, idx+2, tbaa_tuplelen), 1);
 #endif
         }
 #ifdef OVERLAP_TUPLE_LEN
@@ -2465,7 +2487,7 @@ static Value *emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed,
         Value *bp;
         if (iskw) {
             // fenv = theF->env
-            Value *fenv = emit_nthptr(theF, 2);
+            Value *fenv = emit_nthptr(theF, 2, tbaa_func);
             // bp = &((jl_methtable_t*)fenv)->kwsorter
             bp = emit_nthptr_addr(fenv, 7);
         }
@@ -2677,6 +2699,12 @@ static Value *emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed,
             }
         }
         return builder.CreateCall(prepare_call(jlcopyast_func), emit_expr(arg, ctx));
+    }
+    else if (head == simdloop_sym) {
+        if( !llvm::annotateSimdLoop(builder.GetInsertBlock()) )
+            JL_PRINTF(JL_STDERR,
+                      "Warning: could not attach metadata for @simd loop.\n");
+        return NULL;
     }
     else {
         if (!strcmp(head->name, "$"))
@@ -3304,7 +3332,7 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
 
     // fetch env out of function object if we need it
     if (hasCapt) {
-        ctx.envArg = emit_nthptr(fArg, 2);
+        ctx.envArg = emit_nthptr(fArg, 2, tbaa_func);
     }
 
     // step 8. set up GC frame
@@ -3603,6 +3631,13 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
 
 // --- initialization ---
 
+static MDNode* tbaa_make_child( const char* name, MDNode* parent, bool isConstant=false )
+{
+    MDNode* n = mbuilder->createTBAANode(name,parent,isConstant);
+    n->setValueName( ValueName::Create(name, name+strlen(name)));
+    return n;
+}
+
 static GlobalVariable *global_to_llvm(const std::string &cname, void *addr, Module *m)
 {
     GlobalVariable *gv =
@@ -3676,6 +3711,18 @@ extern "C" DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v)
 
 static void init_julia_llvm_env(Module *m)
 {
+    MDNode* tbaa_root = mbuilder->createTBAARoot("jtbaa");
+    tbaa_user = tbaa_make_child("jtbaa_user",tbaa_root);
+    tbaa_value = tbaa_make_child("jtbaa_value",tbaa_root);
+    tbaa_array = tbaa_make_child("jtbaa_array",tbaa_value);
+    tbaa_arrayptr = tbaa_make_child("jtbaa_arrayptr",tbaa_array);
+    tbaa_arraysize = tbaa_make_child("jtbaa_arraysize",tbaa_array);
+    tbaa_arraylen = tbaa_make_child("jtbaa_arraylen",tbaa_array);
+    tbaa_tuplelen = tbaa_make_child("jtbaa_arraysize",tbaa_value);
+    tbaa_func = tbaa_make_child("jtbaa_func",tbaa_value);
+    tbaa_datatype = tbaa_make_child("jtbaa_func",tbaa_value);
+    tbaa_const = tbaa_make_child("jtbaa_const",tbaa_root,true);
+
     // every variable or function mapped in this function must be
     // exported from libjulia, to support static compilation
     T_int1  = Type::getInt1Ty(getGlobalContext());
@@ -4039,6 +4086,10 @@ static void init_julia_llvm_env(Module *m)
 #endif
     FPM->add(jl_data_layout);
 
+#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 3
+    jl_TargetMachine->addAnalysisPasses(*FPM);
+#endif
+    FPM->add(createTypeBasedAliasAnalysisPass());
     // list of passes from vmkit
     FPM->add(createCFGSimplificationPass()); // Clean up disgusting code
     FPM->add(createPromoteMemoryToRegisterPass());// Kill useless allocas
@@ -4061,14 +4112,20 @@ static void init_julia_llvm_env(Module *m)
 
     FPM->add(createLoopIdiomPass()); //// ****
     FPM->add(createLoopRotatePass());           // Rotate loops.
+    // LoopRotate strips metadata from terminator, so run LowerSIMD afterwards
+    FPM->add(createLowerSimdLoopPass());        // Annotate loop marked with "simdloop" as LLVM parallel loop
     FPM->add(createLICMPass());                 // Hoist loop invariants
     FPM->add(createLoopUnswitchPass());         // Unswitch loops.
+    // Subsequent passes not stripping metadata from terminator
     FPM->add(createInstructionCombiningPass()); 
     FPM->add(createIndVarSimplifyPass());       // Canonicalize indvars
     //FPM->add(createLoopDeletionPass());         // Delete dead loops
     FPM->add(createLoopUnrollPass());           // Unroll small loops
     //FPM->add(createLoopStrengthReducePass());   // (jwb added)
     
+#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 3
+    FPM->add(createLoopVectorizePass());        // Vectorize loops
+#endif
     FPM->add(createInstructionCombiningPass()); // Clean up after the unroller
     FPM->add(createGVNPass());                  // Remove redundancies
     //FPM->add(createMemCpyOptPass());            // Remove memcpy / form memset  
@@ -4090,6 +4147,9 @@ static void init_julia_llvm_env(Module *m)
 
 extern "C" void jl_init_codegen(void)
 {
+#ifdef DEBUG
+    cl::ParseEnvironmentOptions("Julia", "JULIA_LLVM_ARGS");
+#endif
     imaging_mode = jl_compileropts.build_path != NULL;
 
     InitializeNativeTarget();
@@ -4174,6 +4234,7 @@ extern "C" void jl_init_codegen(void)
     jl_ExecutionEngine = eb.create(jl_TargetMachine);
 #endif // LLVM VERSION
     jl_ExecutionEngine->DisableLazyCompilation();
+    mbuilder = new MDBuilder(getGlobalContext());
 
     init_julia_llvm_env(m);
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -444,6 +444,9 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
     else if (ex->head == boundscheck_sym) {
         return (jl_value_t*)jl_nothing;
     }
+    else if (ex->head == simdloop_sym) {
+        return (jl_value_t*)jl_nothing;
+    }
     jl_errorf("unsupported or misplaced expression %s", ex->head->name);
     return (jl_value_t*)jl_nothing;
 }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3134,4 +3134,5 @@ void jl_init_types(void)
     boundscheck_sym = jl_symbol("boundscheck");
     newvar_sym = jl_symbol("newvar");
     copyast_sym = jl_symbol("copyast");
+    simdloop_sym = jl_symbol("simdloop");
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -427,6 +427,7 @@ extern jl_sym_t *abstracttype_sym; extern jl_sym_t *bitstype_sym;
 extern jl_sym_t *compositetype_sym; extern jl_sym_t *type_goto_sym;
 extern jl_sym_t *global_sym;  extern jl_sym_t *tuple_sym;
 extern jl_sym_t *boundscheck_sym; extern jl_sym_t *copyast_sym;
+extern jl_sym_t *simdloop_sym;
 
 
 // object accessors -----------------------------------------------------------

--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -1,0 +1,165 @@
+#define DEBUG_TYPE "lower_simd_loop"
+#undef DEBUG
+
+// This file defines two entry points:
+//     global function annotateSimdLoop: mark a loop as a SIMD loop.
+//     createLowerSimdLoopPass: construct LLVM for lowering a marked loop later.
+
+#include "llvm/Analysis/LoopPass.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/Support/Debug.h"
+#include <cstdio>
+
+namespace llvm {
+
+// simd loop
+static unsigned simd_loop_mdkind = 0;
+static MDNode* simd_loop_md = NULL;
+
+/// Mark loop as a SIMD loop.  Return false if loop cannot be marked.
+/// incr should be the basic block that increments the loop counter.
+bool annotateSimdLoop(BasicBlock* incr) {
+    DEBUG(dbgs() << "LSL: annotating simd_loop\n");
+    // Lazy initialization
+    if (!simd_loop_mdkind) {
+        simd_loop_mdkind = getGlobalContext().getMDKindID("simd_loop");
+        simd_loop_md = MDNode::get(getGlobalContext(), ArrayRef<Value*>());
+    }
+    // Ideally, the decoration would go on the block itself, but LLVM 3.3 does not
+    // support putting metadata on blocks.  So instead, put the decoration on the last
+    // Add instruction, which (somewhat riskily) is assumed to be the loop increment.
+    for (BasicBlock::reverse_iterator ri = incr->rbegin(); ri!=incr->rend(); ++ri) {
+        Instruction& i = *ri;
+        unsigned op = i.getOpcode();
+        if (op==Instruction::Add) {
+            if (i.getType()->isIntegerTy()) {
+                DEBUG(dbgs() << "LSL: setting simd_loop metadata\n");
+                i.setMetadata(simd_loop_mdkind, simd_loop_md);
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+    return false;
+}
+
+/// Pass that lowers a loop marked by annotateSimdLoop.
+/// This pass should run after reduction variables have been converted to phi nodes,
+/// otherwise floating-point reductions might not be recognized as such and
+/// prevent SIMDization.
+struct LowerSIMDLoop: public LoopPass {
+    static char ID;
+    LowerSIMDLoop() : LoopPass(ID) {}
+
+private:
+    /*override*/ bool runOnLoop(Loop *, LPPassManager &LPM);
+
+    /// Check if loop has "simd_loop" annotation.
+    /// If present, the annotation is an MDNode attached to an instruction in the loop's latch.
+    bool hasSIMDLoopMetadata( Loop *L) const;
+
+    /// If Phi is part of a reduction cycle of FAdd or FMul, mark the ops as permitting reassociation/commuting.
+    void enableUnsafeAlgebraIfReduction(PHINode* Phi, Loop* L) const;
+};
+
+bool LowerSIMDLoop::hasSIMDLoopMetadata(Loop *L) const {
+    // Note: If a loop has 0 or multiple latch blocks, it's probably not a simd_loop anyway.
+    if (BasicBlock* latch = L->getLoopLatch())
+        for (BasicBlock::iterator II = latch->begin(), EE = latch->end(); II!=EE; ++II)
+            if (II->getMetadata(simd_loop_mdkind))
+                return true;
+    return false;
+}
+
+void LowerSIMDLoop::enableUnsafeAlgebraIfReduction(PHINode* Phi, Loop* L) const {
+    typedef SmallVector<Instruction*, 8> chainVector;
+    chainVector chain;
+    Instruction *J;
+    unsigned opcode = 0;
+    for (Instruction *I = Phi; ; I=J) {
+        J = NULL;
+        // Find the user of instruction I that is within loop L.
+        for (Value::use_iterator UI = I->use_begin(), UE = I->use_end(); UI != UE; ++UI) {
+            Instruction *U = cast<Instruction>(*UI);
+            if (L->contains(U)) {
+                if (J) {
+                    DEBUG(dbgs() << "LSL: not a reduction var because op has two internal uses: " << *I << "\n");
+                    return;
+                }
+                J = U;
+            }
+        }
+        if (!J) {
+            DEBUG(dbgs() << "LSL: chain prematurely terminated at " << *I << "\n");
+            return;
+        }
+        if (J==Phi) {
+            // Found the entire chain.
+            break;
+        }
+        if (opcode) {
+            // Check that arithmetic op matches prior arithmetic ops in the chain.
+            if (J->getOpcode()!=opcode) {
+                DEBUG(dbgs() << "LSL: chain broke at " << *J << " because of wrong opcode\n");
+                return;
+            }
+        } else {
+            // First arithmetic op in the chain.
+            opcode = J->getOpcode();
+            if (opcode!=Instruction::FAdd && opcode!=Instruction::FMul) {
+                DEBUG(dbgs() << "LSL: first arithmetic op in chain is uninteresting" << *J << "\n");
+                return;
+            }
+        }
+        chain.push_back(J);
+    }
+    for (chainVector::const_iterator K=chain.begin(); K!=chain.end(); ++K) {
+        DEBUG(dbgs() << "LSL: marking " << **K << "\n");
+        (*K)->setHasUnsafeAlgebra(true);
+    }
+}
+
+bool LowerSIMDLoop::runOnLoop(Loop *L, LPPassManager &LPM) {
+    if (!simd_loop_mdkind)
+        return false;           // Fast rejection test.
+
+    if (!hasSIMDLoopMetadata(L))
+        return false;
+
+    DEBUG(dbgs() << "LSL: simd_loop found\n");
+    BasicBlock* latch = L->getLoopLatch();
+    MDNode* n = MDNode::get(getGlobalContext(), ArrayRef<Value*>());
+    latch->getTerminator()->setMetadata("llvm.loop.parallel", n);
+    MDNode* m = MDNode::get(getGlobalContext(), ArrayRef<Value*>(n));
+
+    // Mark memory references so that Loop::isAnnotatedParallel will return true for this loop.
+    for(Loop::block_iterator BBI = L->block_begin(), E=L->block_end(); BBI!=E; ++BBI)
+        for (BasicBlock::iterator I = (*BBI)->begin(), EE = (*BBI)->end(); I!=EE; ++I)
+            if (I->mayReadOrWriteMemory())
+                I->setMetadata("llvm.mem.parallel_loop_access", m);
+    assert(L->isAnnotatedParallel());
+
+    // Mark floating-point reductions as okay to reassociate/commute.
+    BasicBlock* Lh = L->getHeader();
+    DEBUG(dbgs() << "LSL: loop header: " << *Lh << "\n");
+    for (BasicBlock::iterator I = Lh->begin(), E = Lh->end(); I!=E; ++I)
+        if (PHINode *Phi = dyn_cast<PHINode>(I))
+            enableUnsafeAlgebraIfReduction(Phi,L);
+
+    return true;
+}
+
+char LowerSIMDLoop::ID = 0;
+
+static RegisterPass<LowerSIMDLoop> X("LowerSIMDLoop", "LowerSIMDLoop Pass",
+                                     false /* Only looks at CFG */,
+                                     false /* Analysis Pass */);
+
+Pass* createLowerSimdLoopPass() {
+    return new LowerSIMDLoop();
+}
+
+} // namespace llvm

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@ JULIAHOME = $(abspath ..)
 include ../Make.inc
 
 TESTS = all core keywordargs numbers strings unicode collections hashing	\
-	remote iobuffer arrayops linalg blas fft dsp sparse bitarray random	    \
+	remote iobuffer arrayops simdloop linalg blas fft dsp sparse bitarray random \
 	math functional bigint sorting statistics spawn parallel arpack file	\
 	git pkg resolve suitesparse complex version pollfd mpfr	broadcast       \
 	socket floatapprox priorityqueue readdlm regex float16 combinatorics    \

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 # linalg tests take the longest - start them off first
 testnames = [
     "linalg1", "linalg2", "core", "keywordargs", "numbers", "strings",
-    "collections", "hashing", "remote", "iobuffer", "arrayops",
+    "collections", "hashing", "remote", "iobuffer", "arrayops", "simdloop",
     "blas", "fft", "dsp", "sparse", "bitarray", "random", "math",
     "functional", "bigint", "sorting", "statistics", "spawn",
     "priorityqueue", "arpack", "file", "suitesparse", "version",

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -1,0 +1,44 @@
+function simd_loop_example_from_manual(x, y, z)
+    s = zero(eltype(z))
+    n = min(length(x),length(y),length(z))
+    @simd for i in 1:n
+        @inbounds begin
+            z[i] = x[i]-y[i]
+            s += z[i]*z[i]
+        end
+    end
+    s
+end
+
+function simd_loop_with_multiple_reductions(x, y, z)
+    # Use non-zero initial value to make sure reduction values include it.
+    (s,t) = (one(eltype(x)),one(eltype(y)))
+    @simd for i in 1:length(z)
+        @inbounds begin
+            s += x[i]
+            t += 2*y[i]
+            s += z[i]   # Two reductions go into s
+        end
+    end
+    (s,t)
+end
+
+for T in {Int32,Int64,Float32,Float64}
+   # Try various lengths to make sure "remainder loop" works
+   for n in {0,1,2,3,4,255,256,257}
+        # Dataset chosen so that results will be exact with only 24 bits of mantissa
+        a = convert(Array{T},[2*j+1 for j in 1:n])
+        b = convert(Array{T},[3*j+2 for j in 1:n])
+        c = convert(Array{T},[5*j+3 for j in 1:n])
+        s = simd_loop_example_from_manual(a,b,c)
+
+        @test a==[2*j+1 for j in 1:n]
+        @test b==[3*j+2 for j in 1:n]
+        @test c==[-j-1 for j in 1:n]
+        @test s==sum(c.*c)
+        (s,t) = simd_loop_with_multiple_reductions(a,b,c)
+        @test s==sum(a)+sum(c)+1
+        @test t==2*sum(b)+1
+    end
+end
+


### PR DESCRIPTION
This pull request enables the LLVM loop vectorizer.  ~~It's not quite ready for production.~~  I'd like feedback and help fixing some issues.  The overall design is explained in [this comment](https://github.com/JuliaLang/julia/issues/4786#issuecomment-31050948)  to issue #4786, except that it no longer relies on the "banana interface"mentioned in that comment.

Here is an example that it can vectorize when `a` is of type `Float32`, and `x` and `y` are of type `Array{Float32,1}`:

```
function saxpy( a, x, y )
    @simd for i=1:length(x)
        @inbounds y[i] = y[i]+a*x[i];
    end
end
```

I've seen the vectorized version run 3x faster than the unvectorized version when data fits in cache.  When AVX can be enabled, the results are likely even better. 

Programmers can put the `@simd` macro in front of one-dimensional `for` loops that have ranges of the form _m_:_n_ and the type of the loop index supports `<` and `+``.  The decoration is guaranteeing that the loop does _not_ rely on wrap-around behavior and the loop iterations are safe to execute in parallel, even if chunks are done in lockstep. 

The patch implements [type-based alias analysis](http://llvm.org/docs/LangRef.html#tbaa-metadata) , which may help LLVM optimize better in general, and is essential for vectorization.  The name "type-based alias analysis" is a bit of a misnomer, since it's really based on hierarchically partitioning memory.  I've implemented it for Julia assuming that type-punning is never done for parts of data structures that users cannot access directly, but that user data can be type-punned freely. 

~~Problems that I seek advice on:~~
- ~~The `@simd` macro is not found.    Currently I have to do the following within the REPL:~~

```
include("base/simdloop.jl")
using SimdLoop.@simd
```

~~I tried to copy the way`@printf` is defined/exported, but something is wrong with my patch.  What?~~
- LLVM 3.3 disallows attaching metadata to a block, so I've attached it to an instruction in the block.  It's kind of ad-hoc, but seems to work.  Is there a better way to do it?  
- An alternative to attaching metadata is to eliminate `src/llvm-simdloop.cpp` and instead rely on LLVM's auto-vectorization capability, which inserts memory dependence tests.  That indeed does work for the `saxpy` example above, i.e. it vectorizes _without_ the support `src/llvm-simdloop.cpp`. However, `@simd` would still be necessary to tranform the loop into a form such that LLVM can compute a trip count.
- An alternative to the trip-count issue is to eliminate `@simd` altogether and instead somehow ensure that _m_:_n_ is lowered to a form for which LLVM can compute a trip count.
- I'm a neophyte at writing macros,  `base/simdloop.jl` could use a review by an expert.

Apologies for the useless comment:

```
This file defines two entry points:
```

I just noticed it, but being late on a Friday, I'll fix it later.  It's supposed to say that one entry point is for marking simd loops and the other is for later lowering marked loops.

Thanks to @simonster for [his information](https://github.com/JuliaLang/julia/pull/3929)  on enabling the loop vectorizer.  It was a big help to get me going.
