### PR TITLE
test/: avoid integer overflow on 32 bit systems

### DIFF
--- a/test/euler.jl
+++ b/test/euler.jl
@@ -67,7 +67,7 @@ end
 @test euler9(1000) == 31875000
 
 #10: 142913828922
-@test sum(primes(2000000)) == 142913828922
+@test sum(int64(primes(2000000))) == 142913828922
 
 #11: 70600674
 function euler11(grid,n)

--- a/test/mod2pi.jl
+++ b/test/mod2pi.jl
@@ -190,5 +190,5 @@ testModPi()
 @test_approx_eq mod2pi(int32(355))  3.1416227979431572
 @test_approx_eq mod2pi(355.0)       3.1416227979431572
 @test_approx_eq mod2pi(355.0f0)     3.1416228f0
-@test mod2pi(2^60) == mod2pi(2.0^60)
-@test_throws mod2pi(2^60-1)
+@test mod2pi(int64(2)^60) == mod2pi(2.0^60) 
+@test_throws mod2pi(int64(2)^60-1)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -102,4 +102,4 @@ r = (-4*int64(maxintfloat(is(Int,Int32) ? Float32 : Float64))):5
 @test_throws (0:2:10)[7:7]
 
 # avoiding intermediate overflow (#5065)
-@test length(1:4:typemax(Int64)) == 2305843009213693952
+@test length(1:4:typemax(Int)) == div(typemax(Int),4) + 1


### PR DESCRIPTION
After the fix of #5142 I am running the tests in 32 bit. These are
three smaller fixes to the tests for 32 bit systems fixing tests assuming 64bit ints.

```
while loading euler.jl, in expression starting on line 70
ERROR: test failed: :((sum(primes(2000000))==142913828922))

while loading ranges.jl, in expression starting on line 105
ERROR: test failed: :((length(1:4:typemax(Int64))==2305843009213693952))

while loading mod2pi.jl, in expression starting on line 193
ERROR: test failed: :((mod2pi(^(2,60))==mod2pi(^(2.0,60))))
```

One might argue that `length(1:4:typemax(Int64))` should actually throw an error as Range.len is of type Int32 there.
