### PR TITLE
Compute sum of squared residuals faster in gels!

### DIFF
--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -516,7 +516,14 @@ for (gels, gesv, getrs, getri, elty) in
             end
             k   = min(m, n)
             F   = m < n ? tril(A[1:k, 1:k]) : triu(A[1:k, 1:k])
-            F, isa(B, Vector) ? B[1:k] : B[1:k,:], [sum(B[(k+1):size(B,1), i].^2) for i=1:size(B,2)]
+            ssr = [begin
+                x = zero($elty)
+                for j=k+1:size(B,1)
+                    x += abs2(B[j, i])
+                end
+                x
+            end for i=1:size(B,2)]
+            F, isa(B, Vector) ? B[1:k] : B[1:k,:], ssr
         end
         # SUBROUTINE DGESV( N, NRHS, A, LDA, IPIV, B, LDB, INFO )
         # *     .. Scalar Arguments ..


### PR DESCRIPTION
This was taking a substantial portion of the function runtime. Before:

``` julia
julia> srand(1776); @time Base.LinAlg.LAPACK.gels!('N', rand(1000, 100), rand(1000, 100000));
elapsed time: 3.392343747 seconds (2374561640 bytes allocated)
```

After:

``` julia
julia> srand(1776); @time Base.LinAlg.LAPACK.gels!('N', rand(1000, 100), rand(1000, 100000));
elapsed time: 2.074082745 seconds (910542724 bytes allocated)
```

The other work `gels!` performs on the outputs takes something like 10% of the function runtime in this test case, which is acceptable, although I was a little surprised the wrapper does anything more than just call the LAPACK function.
