### PR TITLE
RFC: Compiling libjulia with MSVC compiler

### DIFF
--- a/Windows.inc
+++ b/Windows.inc
@@ -30,14 +30,20 @@ WINVER = 0x0600
 
 ###############################################################################
 
+!ifdef INTEL
 CC = icl /nologo /Qstd=c99
 LINK = xilink /nologo
 AR = xilib /nologo
+!else
+CC = cl /nologo /TP
+LINK = link /nologo
+AR = lib /nologo
+!endif
 
 ###############################################################################
 
 CFLAGS = /c /DCRTAPI1=_cdecl /DCRTAPI2=_cdecl /GS /D_WINNT /D_WIN32_WINNT=$(WINVER) /DNTDDI_VERSION=$(WINVER)0000 /DWINVER=$(WINVER) /DWIN32 /D_WIN32
-LFLAGS = /INCREMENTAL:NO
+LFLAGS = /INCREMENTAL:NO /NODEFAULTLIB:MSVCRT
 
 !if "$(CPU)" == "i386"
 CFLAGS = $(CFLAGS) /D_X86_=1

--- a/src/Windows.mk
+++ b/src/Windows.mk
@@ -38,11 +38,15 @@ LIBSUPPORT = support\libsupport.lib
 LIBUV = ..\deps\libuv\libuv.lib
 FLISP = flisp\flisp.exe
 
-INCLUDE = $(INCLUDE);$(MAKEDIR)\..\deps\libuv\include;$(MAKEDIR)\flisp;$(MAKEDIR)\support;C:\Program Files\LLVM\include;
-LIB = $(LIB);C:\Program Files\LLVM\lib;
+INCLUDE = $(INCLUDE);$(MAKEDIR)\..\deps\libuv\include;$(MAKEDIR)\flisp;$(MAKEDIR)\support;C:\Program Files\llvm\include
+!ifdef DEBUG
+LIB = $(LIB);C:\Program Files\llvm\lib\Debug
+!else
+LIB = $(LIB);C:\Program Files\llvm\lib\Release
+!endif
 
 CFLAGS = $(CFLAGS) -DCOPY_STACKS -D_CRT_SECURE_NO_WARNINGS
-CFLAGS = $(CFLAGS) -DJL_SYSTEM_IMAGE_PATH=\"../lib/julia/sys.ji\"
+CFLAGS = $(CFLAGS) -DJL_SYSTEM_IMAGE_PATH=\"../lib/julia/sys.ji\" -DLIBRARY_EXPORTS
 
 LIBWINDOWS = \
 	kernel32.lib \

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -472,7 +472,7 @@ jl_sym_t *jl_symbol_lookup(const char *str)
 
 DLLEXPORT jl_sym_t *jl_symbol_n(const char *str, int32_t len)
 {
-    char name[len+1];
+    char* name = (char*) alloca(len+1);
     memcpy(name, str, len);
     name[len] = '\0';
     return jl_symbol(name);
@@ -497,7 +497,7 @@ DLLEXPORT jl_sym_t *jl_gensym(void)
 DLLEXPORT jl_sym_t *jl_tagged_gensym(const char* str, int32_t len)
 {
     static char gs_name[14];
-    char name[sizeof(gs_name)+len+3];
+    char *name = (char*) alloca(sizeof(gs_name)+len+3);
     char *n;
     name[0] = '#'; name[1] = '#'; name[2+len] = '#';
     memcpy(name+2, str, len);
@@ -714,7 +714,7 @@ jl_value_t *jl_box##nb(jl_datatype_t *t, int##nb##_t x)         \
 {                                                               \
     assert(jl_is_bitstype(t));                                  \
     assert(jl_datatype_size(t) == sizeof(x));                   \
-    jl_value_t *v = alloc_##nw##w();                            \
+    jl_value_t *v = (jl_value_t*) alloc_##nw##w();              \
     v->type = (jl_value_t*)t;                                   \
     *(int##nb##_t*)jl_data_ptr(v) = x;                          \
     return v;                                                   \
@@ -748,13 +748,13 @@ UNBOX_FUNC(float32, float)
 UNBOX_FUNC(float64, double)
 UNBOX_FUNC(voidpointer, void*)
 
-#define BOX_FUNC(typ,c_type,pfx,nw)             \
-jl_value_t *pfx##_##typ(c_type x)               \
-{                                               \
-    jl_value_t *v = alloc_##nw##w();            \
-    v->type = (jl_value_t*)jl_##typ##_type;     \
-    *(c_type*)jl_data_ptr(v) = x;               \
-    return v;                                   \
+#define BOX_FUNC(typ,c_type,pfx,nw)               \
+jl_value_t *pfx##_##typ(c_type x)                 \
+{                                                 \
+    jl_value_t *v = (jl_value_t*) alloc_##nw##w();\
+    v->type = (jl_value_t*)jl_##typ##_type;       \
+    *(c_type*)jl_data_ptr(v) = x;                 \
+    return v;                                     \
 }
 BOX_FUNC(float32, float,  jl_box, 2)
 BOX_FUNC(voidpointer, void*,  jl_box, 2) //2 pointers == two words on all platforms
@@ -773,21 +773,21 @@ jl_value_t *jl_box_##typ(c_type x)                      \
     c_type idx = x+NBOX_C/2;                            \
     if ((u##c_type)idx < (u##c_type)NBOX_C)             \
         return boxed_##typ##_cache[idx];                \
-    jl_value_t *v = alloc_##nw##w();                    \
+    jl_value_t *v = (jl_value_t*) alloc_##nw##w();      \
     v->type = (jl_value_t*)jl_##typ##_type;             \
     *(c_type*)jl_data_ptr(v) = x;                       \
     return v;                                           \
 }
-#define UIBOX_FUNC(typ,c_type,nw)               \
-static jl_value_t *boxed_##typ##_cache[NBOX_C]; \
-jl_value_t *jl_box_##typ(c_type x)              \
-{                                               \
-    if (x < NBOX_C)                             \
-        return boxed_##typ##_cache[x];          \
-    jl_value_t *v = alloc_##nw##w();            \
-    v->type = (jl_value_t*)jl_##typ##_type;     \
-    *(c_type*)jl_data_ptr(v) = x;               \
-    return v;                                   \
+#define UIBOX_FUNC(typ,c_type,nw)                  \
+static jl_value_t *boxed_##typ##_cache[NBOX_C];    \
+jl_value_t *jl_box_##typ(c_type x)                 \
+{                                                  \
+    if (x < NBOX_C)                                \
+        return boxed_##typ##_cache[x];             \
+    jl_value_t *v = (jl_value_t*) alloc_##nw##w(); \
+    v->type = (jl_value_t*)jl_##typ##_type;        \
+    *(c_type*)jl_data_ptr(v) = x;                  \
+    return v;                                      \
 }
 SIBOX_FUNC(int16,  int16_t, 2)
 SIBOX_FUNC(int32,  int32_t, 2)

--- a/src/array.c
+++ b/src/array.c
@@ -73,7 +73,7 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
         size_t doffs = tsz;
         tsz += tot;
         tsz = (tsz+15)&-16; // align whole object 16
-        a = allocobj(tsz);
+        a = (jl_array_t*) allocobj(tsz);
         a->type = atype;
         a->how = 0;
         data = (char*)a + doffs;
@@ -83,7 +83,7 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
     }
     else {
         tsz = (tsz+15)&-16; // align whole object size 16
-        a = allocobj(tsz);
+        a = (jl_array_t*) allocobj(tsz);
         JL_GC_PUSH1(&a);
         a->type = atype;
         // temporarily initialize to make gc-safe
@@ -143,7 +143,7 @@ jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data, jl_tuple_t *di
     size_t ndims = jl_tuple_len(dims);
 
     int ndimwords = jl_array_ndimwords(ndims);
-    a = allocobj((sizeof(jl_array_t) + sizeof(void*) + ndimwords*sizeof(size_t) + 15)&-16);
+    a = (jl_array_t*) allocobj((sizeof(jl_array_t) + sizeof(void*) + ndimwords*sizeof(size_t) + 15)&-16);
     a->type = atype;
     a->ndims = ndims;
     a->offset = 0;
@@ -208,7 +208,7 @@ jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data, size_t nel,
     else
         elsz = sizeof(void*);
 
-    a = allocobj((sizeof(jl_array_t)+jl_array_ndimwords(1)*sizeof(size_t)+15)&-16);
+    a = (jl_array_t*) allocobj((sizeof(jl_array_t)+jl_array_ndimwords(1)*sizeof(size_t)+15)&-16);
     a->type = atype;
     a->data = data;
 #ifdef STORE_ARRAY_LEN
@@ -256,7 +256,7 @@ jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data, jl_tuple_t *dims,
         elsz = sizeof(void*);
 
     int ndimwords = jl_array_ndimwords(ndims);
-    a = allocobj((sizeof(jl_array_t) + ndimwords*sizeof(size_t)+15)&-16);
+    a = (jl_array_t*) allocobj((sizeof(jl_array_t) + ndimwords*sizeof(size_t)+15)&-16);
     a->type = atype;
     a->data = data;
 #ifdef STORE_ARRAY_LEN
@@ -292,7 +292,7 @@ jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data, jl_tuple_t *dims,
 jl_array_t *jl_new_array(jl_value_t *atype, jl_tuple_t *dims)
 {
     size_t ndims = jl_tuple_len(dims);
-    size_t *adims = alloca(ndims*sizeof(size_t));
+    size_t *adims = (size_t*) alloca(ndims*sizeof(size_t));
     size_t i;
     for(i=0; i < ndims; i++)
         adims[i] = jl_unbox_long(jl_tupleref(dims,i));
@@ -326,9 +326,9 @@ jl_array_t *jl_pchar_to_array(const char *str, size_t len)
 jl_value_t *jl_array_to_string(jl_array_t *a)
 {
     // TODO: check type of array?
-    jl_datatype_t* string_type = u8_isvalid(a->data, jl_array_len(a)) == 1 ? // ASCII
+    jl_datatype_t* string_type = u8_isvalid( (char*) a->data, jl_array_len(a)) == 1 ? // ASCII
         jl_ascii_string_type : jl_utf8_string_type;
-    jl_value_t *s = alloc_2w();
+    jl_value_t *s = (jl_value_t*) alloc_2w();
     s->type = (jl_value_t*)string_type;
     jl_set_nth_field(s, 0, (jl_value_t*)a);
     return s;
@@ -523,7 +523,7 @@ static void array_resize_buffer(jl_array_t *a, size_t newlen, size_t oldlen, siz
     char *newdata;
     if (a->how == 2) {
         // already malloc'd - use realloc
-        newdata = jl_gc_managed_realloc((char*)a->data - oldoffsnb, nbytes,
+        newdata = (char*) jl_gc_managed_realloc((char*)a->data - oldoffsnb, nbytes,
                                         oldnbytes+oldoffsnb, a->isaligned);
         if (offs != a->offset) {
             memmove(&newdata[offsnb], &newdata[oldoffsnb], oldnbytes);
@@ -531,13 +531,13 @@ static void array_resize_buffer(jl_array_t *a, size_t newlen, size_t oldlen, siz
     }
     else {
         if (nbytes >= MALLOC_THRESH) {
-            newdata = jl_gc_managed_malloc(nbytes);
+            newdata = (char*) jl_gc_managed_malloc(nbytes);
             jl_gc_track_malloced_array(a);
             a->how = 2;
             a->isaligned = 1;
         }
         else {
-            newdata = allocb(nbytes);
+            newdata = (char*) allocb(nbytes);
             a->how = 1;
         }
         memcpy(newdata + offsnb, (char*)a->data, oldnbytes);

--- a/src/ast.c
+++ b/src/ast.c
@@ -12,7 +12,7 @@
 #include "julia.h"
 #include "flisp.h"
 
-static char flisp_system_image[] = {
+static uint8_t flisp_system_image[] = {
 #include "julia_flisp.boot.inc"
 };
 
@@ -111,7 +111,7 @@ DLLEXPORT void jl_init_frontend(void)
     fl_init(2*512*1024);
     value_t img = cvalue(iostreamtype, sizeof(ios_t));
     ios_t *pi = value2c(ios_t*, img);
-    ios_static_buffer(pi, flisp_system_image, sizeof(flisp_system_image));
+    ios_static_buffer(pi, (char*) flisp_system_image, sizeof(flisp_system_image));
     
     if (fl_load_system_image(img)) {
         JL_PRINTF(JL_STDERR, "fatal error loading system image\n");
@@ -240,7 +240,7 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
         return (jl_value_t*)scmsym_to_julia(e);
     }
     if (fl_isstring(e)) {
-        return jl_pchar_to_string(cvalue_data(e), cvalue_len(e));
+        return jl_pchar_to_string( (char*) cvalue_data(e), cvalue_len(e));
     }
     if (e == FL_F) {
         return jl_false;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -254,6 +254,7 @@ JL_CALLABLE(jl_f_apply)
                             jl_tuple_len(args[1]));
         }
     }
+    jl_value_t **newargs;
     size_t n=0, i, j;
     for(i=1; i < nargs; i++) {
         if (jl_is_tuple(args[i])) {
@@ -275,7 +276,7 @@ JL_CALLABLE(jl_f_apply)
             goto fancy_apply;
         }
     }
-    jl_value_t **newargs = alloca(n * sizeof(jl_value_t*));
+    newargs = (jl_value_t**) alloca(n * sizeof(jl_value_t*));
     n = 0;
     for(i=1; i < nargs; i++) {
         if (jl_is_tuple(args[i])) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -233,7 +233,7 @@ static Type *julia_type_to_llvm(jl_value_t *jt)
                 return ret;
             }
             else {
-                Type *types[ntypes];
+                Type **types = (Type**) alloca(ntypes*sizeof(Type*));
                 size_t j = 0;
                 for (size_t i = 0; i < ntypes; ++i) {
                     Type *ty = julia_struct_to_llvm(jl_tupleref(jt,i));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,4 +1,5 @@
 #include "platform.h"
+#include "julia.h"
 
 /*
  * We include <mathimf.h> here, because somewhere below <math.h> is included also.
@@ -89,7 +90,6 @@ using namespace llvm;
 
 extern "C" {
 
-#include "julia.h"
 #include "builtin_proto.h"
 
 void *__stack_chk_guard = NULL;

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -80,7 +80,7 @@ static uv_lib_t *jl_load_dynamic_library_(char *modname, unsigned flags, int thr
     char *ext;
     char path[PATHBUF];
     int i;
-    uv_lib_t *handle=malloc(sizeof(uv_lib_t));
+    uv_lib_t *handle = (uv_lib_t*) malloc(sizeof(uv_lib_t));
     handle->errmsg=NULL;
 
     if (modname == NULL) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -1273,8 +1273,7 @@ void jl_init_serializer(void)
     assert(i <= Null_tag);
     VALUE_TAGS = (ptrint_t)ptrhash_get(&ser_tag, jl_null);
 
-    typedef jl_value_t* (*funcptr_t)(jl_value_t *, jl_value_t **, uint32_t);
-    funcptr_t fptrs[] = { 
+    jl_fptr_t fptrs[] = { 
                       jl_f_new_expr, jl_f_new_box,
                       jl_f_throw, jl_f_is, 
                       jl_f_no_function, jl_f_typeof, 

--- a/src/dump.c
+++ b/src/dump.c
@@ -132,7 +132,7 @@ static void jl_serialize_globalvals(ios_t *s)
     for(i=0; i < len; i+=2) {
         void *offs = p[i+1];
         if (offs != HT_NOTFOUND) {
-            int32_t gv = jl_get_llvm_gv(p[i]);
+            int32_t gv = jl_get_llvm_gv((jl_value_t*) p[i]);
             if (gv != 0) {
                 write_int32(s, (int)(intptr_t)offs);
                 write_int32(s, gv);
@@ -147,7 +147,7 @@ static void jl_deserialize_globalvals(ios_t *s)
     while (1) {
         intptr_t key = read_int32(s);
         if (key == 0) break;
-        jl_deserialize_gv(s, ptrhash_get(&backref_table, (void*)key));
+        jl_deserialize_gv(s, (jl_value_t*) ptrhash_get(&backref_table, (void*) key));
     }
 }
 
@@ -178,7 +178,7 @@ static void jl_deserialize_gv_syms(ios_t *s)
     }
 }
 
-struct {
+struct delayed_fptrs_t {
     jl_lambda_info_t *li;
     int32_t func;
     int32_t cfunc;
@@ -197,9 +197,12 @@ static void jl_delayed_fptrs(jl_lambda_info_t *li, int32_t func, int32_t cfunc)
                 delayed_fptrs_max = 2048;
             else
                 delayed_fptrs_max *= 2;
-            delayed_fptrs = realloc(delayed_fptrs, delayed_fptrs_max*sizeof(delayed_fptrs[0])); //assumes sizeof==alignof
+            delayed_fptrs = (struct delayed_fptrs_t*) realloc(delayed_fptrs, delayed_fptrs_max*sizeof(delayed_fptrs[0])); //assumes sizeof==alignof
         }
-        delayed_fptrs[delayed_fptrs_n++] = (typeof(delayed_fptrs[0])){.li=li, .func=func, .cfunc=cfunc};
+        delayed_fptrs[delayed_fptrs_n].li = li;
+        delayed_fptrs[delayed_fptrs_n].func = func;
+        delayed_fptrs[delayed_fptrs_n].cfunc = cfunc;
+        delayed_fptrs_n++;
     }
 }
 
@@ -216,11 +219,11 @@ static void jl_update_all_fptrs()
         jl_lambda_info_t *li = delayed_fptrs[i].li;
         int32_t func = delayed_fptrs[i].func-1;
         if (func >= 0) {
-            jl_fptr_to_llvm((jl_fptr_t)gvars[func], li, 0);
+            jl_fptr_to_llvm((void*)gvars[func], li, 0);
         }
         int32_t cfunc = delayed_fptrs[i].cfunc-1;
         if (cfunc >= 0) {
-            jl_fptr_to_llvm((jl_fptr_t)gvars[cfunc], li, 1);
+            jl_fptr_to_llvm((void*)gvars[cfunc], li, 1);
         }
     }
     delayed_fptrs_n = 0;
@@ -274,7 +277,7 @@ static void jl_serialize_datatype(ios_t *s, jl_datatype_t *dt)
     jl_serialize_value(s, dt->linfo);
     if (has_instance)
         jl_serialize_value(s, dt->instance);
-    jl_serialize_fptr(s, dt->fptr);
+    jl_serialize_fptr(s, (void*)dt->fptr);
 }
 
 static void jl_serialize_module(ios_t *s, jl_module_t *m)
@@ -424,7 +427,7 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
             jl_serialize_value(s, jl_box_long(jl_array_dim(ar,i)));
         if (!ar->ptrarray) {
             size_t tot = jl_array_len(ar) * ar->elsize;
-            ios_write(s, jl_array_data(ar), tot);
+            ios_write(s, (char*)jl_array_data(ar), tot);
         }
         else {
             for(i=0; i < jl_array_len(ar); i++) {
@@ -465,10 +468,10 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
         jl_serialize_value(s, (jl_value_t*)f->linfo);
         jl_serialize_value(s, f->env);
         if (f->linfo && f->linfo->ast && f->fptr != &jl_trampoline) {
-            jl_serialize_fptr(s, &jl_trampoline);
+            jl_serialize_fptr(s, (void*) &jl_trampoline);
         }
         else {
-            jl_serialize_fptr(s, f->fptr);
+            jl_serialize_fptr(s, (void*) f->fptr);
         }
     }
     else if (jl_is_lambda_info(v)) {
@@ -529,7 +532,7 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
 #endif
                 }
                 else {
-                    ios_write(s, data, jl_datatype_size(t));
+                    ios_write(s, (char*) data, jl_datatype_size(t));
                 }
             }
             else {
@@ -648,7 +651,7 @@ static jl_value_t *jl_deserialize_value_internal(ios_t *s)
         return NULL;
     if (tag == 0) {
         tag = read_uint8(s);
-        jl_value_t *v = ptrhash_get(&deser_tag, (void*)(ptrint_t)tag);
+        jl_value_t *v = (jl_value_t*) ptrhash_get(&deser_tag, (void*)(ptrint_t)tag);
         assert(v != HT_NOTFOUND);
         return v;
     }
@@ -692,7 +695,7 @@ static jl_value_t *jl_deserialize_value_internal(ios_t *s)
             len = read_uint8(s);
         else
             len = read_int32(s);
-        char *name = alloca(len+1);
+        char *name = (char*) alloca(len+1);
         ios_read(s, name, len);
         name[len] = '\0';
         jl_value_t *sym = (jl_value_t*)jl_symbol(name);
@@ -717,7 +720,7 @@ static jl_value_t *jl_deserialize_value_internal(ios_t *s)
             elsize = elsize&0x7fff;
         }
         jl_value_t *aty = jl_deserialize_value(s);
-        size_t *dims = alloca(ndims*sizeof(size_t));
+        size_t *dims = (size_t*) alloca(ndims*sizeof(size_t));
         for(i=0; i < ndims; i++)
             dims[i] = jl_unbox_long(jl_deserialize_value(s));
         jl_array_t *a = jl_new_array_for_deserialization((jl_value_t*)aty, ndims, dims, isunboxed, elsize);
@@ -725,7 +728,7 @@ static jl_value_t *jl_deserialize_value_internal(ios_t *s)
             ptrhash_put(&backref_table, (void*)(ptrint_t)pos, (jl_value_t*)a);
         if (!a->ptrarray) {
             size_t tot = jl_array_len(a) * a->elsize;
-            ios_read(s, jl_array_data(a), tot);
+            ios_read(s, (char*) jl_array_data(a), tot);
         }
         else {
             for(i=0; i < jl_array_len(a); i++) {
@@ -858,7 +861,7 @@ static jl_value_t *jl_deserialize_value_internal(ios_t *s)
         jl_value_t *v;
         if (nf == 0 && jl_datatype_size(dt)>0) {
             int nby = jl_datatype_size(dt);
-            char *data = alloca(nby);
+            char *data = (char*) alloca(nby);
             ios_read(s, data, nby);
             v = NULL;
             if (dt == jl_int32_type)
@@ -946,8 +949,8 @@ void jl_save_system_image(char *fname)
     jl_array_t *spec = mt->defs->func->linfo->specializations;
     if (spec != NULL && jl_array_len(spec) > 0 &&
         ((jl_lambda_info_t*)jl_cellref(spec,0))->inferred == 0) {
-        mt->cache = JL_NULL;
-        mt->cache_arg1 = JL_NULL;
+        mt->cache = (jl_methlist_t*) JL_NULL;
+        mt->cache_arg1 = (jl_array_t*) JL_NULL;
         mt->defs->func->linfo->tfunc = (jl_value_t*)jl_null;
         mt->defs->func->linfo->specializations = NULL;
     }
@@ -1000,7 +1003,7 @@ void jl_restore_system_image(char *fname, int build_mode)
     if (jl_is_debugbuild()) build_mode = 1;
 #endif
     if (!build_mode) {
-        char *fname_shlib = alloca(strlen(fname));
+        char *fname_shlib = (char*) alloca(strlen(fname));
         strcpy(fname_shlib, fname);
         char *fname_shlib_dot = strrchr(fname_shlib, '.');
         if (fname_shlib_dot != NULL) *fname_shlib_dot = 0;
@@ -1075,7 +1078,7 @@ jl_value_t *jl_ast_rettype(jl_lambda_info_t *li, jl_value_t *ast)
     ios_t src;
     jl_array_t *bytes = (jl_array_t*)ast;
     ios_mem(&src, 0);
-    ios_setbuf(&src, bytes->data, jl_array_len(bytes), 0);
+    ios_setbuf(&src, (char*) bytes->data, jl_array_len(bytes), 0);
     src.size = jl_array_len(bytes);
     int en = jl_gc_is_enabled();
     jl_gc_disable();
@@ -1123,7 +1126,7 @@ jl_value_t *jl_uncompress_ast(jl_lambda_info_t *li, jl_value_t *data)
     tree_literal_values = li->module->constant_table;
     ios_t src;
     ios_mem(&src, 0);
-    ios_setbuf(&src, bytes->data, jl_array_len(bytes), 0);
+    ios_setbuf(&src, (char*) bytes->data, jl_array_len(bytes), 0);
     src.size = jl_array_len(bytes);
     int en = jl_gc_is_enabled();
     jl_gc_disable();
@@ -1270,7 +1273,9 @@ void jl_init_serializer(void)
     assert(i <= Null_tag);
     VALUE_TAGS = (ptrint_t)ptrhash_get(&ser_tag, jl_null);
 
-    void *fptrs[] = { jl_f_new_expr, jl_f_new_box,
+    typedef jl_value_t* (*funcptr_t)(jl_value_t *, jl_value_t **, uint32_t);
+    funcptr_t fptrs[] = { 
+                      jl_f_new_expr, jl_f_new_box,
                       jl_f_throw, jl_f_is, 
                       jl_f_no_function, jl_f_typeof, 
                       jl_f_subtype, jl_f_isa, 
@@ -1293,8 +1298,8 @@ void jl_init_serializer(void)
                       NULL };
     i=2;
     while (fptrs[i-2] != NULL) {
-        ptrhash_put(&fptr_to_id, fptrs[i-2], (void*)i);
-        ptrhash_put(&id_to_fptr, (void*)i, fptrs[i-2]);
+        ptrhash_put(&fptr_to_id, (void*)fptrs[i-2], (void*)i);
+        ptrhash_put(&id_to_fptr, (void*)i, (void*)fptrs[i-2]);
         i += 1;
     }
 }

--- a/src/flisp/Windows.mk
+++ b/src/flisp/Windows.mk
@@ -35,7 +35,7 @@ LIBSUPPORT = $(MAKEDIR)\..\support\libsupport.lib
 
 INCLUDE = $(INCLUDE);$(MAKEDIR)\..\..\deps\libuv\include;$(MAKEDIR)\..\support
 
-CFLAGS = $(CFLAGS) /Qstd=c99 -D_CRT_SECURE_NO_WARNINGS -DIMPORT_EXPORT
+CFLAGS = $(CFLAGS) /Qstd=c99 -D_CRT_SECURE_NO_WARNINGS -DLIBRARY_EXPORTS
 LFLAGS = $(LFLAGS) kernel32.lib ws2_32.lib psapi.lib advapi32.lib iphlpapi.lib
 
 default: $(NAME).exe

--- a/src/flisp/basename.c
+++ b/src/flisp/basename.c
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <locale.h>
+#include <malloc.h>
 
 char *basename( char *path )
 {
@@ -52,7 +53,7 @@ char *basename( char *path )
          * in which to create a wide character reference copy of path
          */
 
-        wchar_t refcopy[1 + (len = mbstowcs( NULL, path, 0 ))];
+        wchar_t* refcopy = (wchar_t*) alloca((1 + (len = mbstowcs( NULL, path, 0 )))*sizeof(wchar_t));
 
         /* create the wide character reference copy of path,
          * and step over the drive designator, if present ...
@@ -134,7 +135,7 @@ char *basename( char *path )
                  * returning it in our own buffer.
                  */
 
-                retfail = realloc( retfail, len = 1 + wcstombs( NULL, L"/", 0 ));
+                retfail = (char*) realloc( retfail, len = 1 + wcstombs( NULL, L"/", 0 ));
                 wcstombs( path = retfail, L"/", len );
             }
 
@@ -158,7 +159,7 @@ char *basename( char *path )
      * after a previous call.
      */
 
-    retfail = realloc( retfail, len = 1 + wcstombs( NULL, L".", 0 ));
+    retfail = (char*) realloc( retfail, len = 1 + wcstombs( NULL, L".", 0 ));
     wcstombs( retfail, L".", len );
 
     /* restore the caller's locale, clean up, and return the result */

--- a/src/flisp/builtins.c
+++ b/src/flisp/builtins.c
@@ -131,7 +131,7 @@ static value_t fl_symbol(value_t *args, u_int32_t nargs)
     argcount("symbol", nargs, 1);
     if (!fl_isstring(args[0]))
         type_error("symbol", "string", args[0]);
-    return symbol(cvalue_data(args[0]));
+    return symbol((char*)cvalue_data(args[0]));
 }
 
 static value_t fl_keywordp(value_t *args, u_int32_t nargs)

--- a/src/flisp/cvalues.c
+++ b/src/flisp/cvalues.c
@@ -425,7 +425,7 @@ value_t cvalue_array(value_t *args, u_int32_t nargs)
     sz = elsize * cnt;
 
     value_t cv = cvalue(type, sz);
-    char *dest = cv_data((cvalue_t*)ptr(cv));
+    char *dest = (char*)cv_data((cvalue_t*)ptr(cv));
     FOR_ARGS(i,1,arg,args) {
         cvalue_init(type->eltype, arg, dest);
         dest += elsize;
@@ -502,7 +502,7 @@ void to_sized_ptr(value_t v, char *fname, char **pdata, size_t *psz)
             return;
         }
         else if (cv_isPOD(pcv)) {
-            *pdata = cv_data(pcv);
+            *pdata = (char*) cv_data(pcv);
             *psz = cv_len(pcv);
             return;
         }
@@ -666,7 +666,7 @@ static numerictype_t sym_to_numtype(value_t type)
         return T_FLOAT;
     else if (type == doublesym)
         return T_DOUBLE;
-    return N_NUMTYPES;
+    return (numerictype_t) N_NUMTYPES;
 }
 
 // (new type . args)
@@ -708,8 +708,8 @@ value_t cvalue_compare(value_t a, value_t b)
 {
     cvalue_t *ca = (cvalue_t*)ptr(a);
     cvalue_t *cb = (cvalue_t*)ptr(b);
-    char *adata = cv_data(ca);
-    char *bdata = cv_data(cb);
+    char *adata = (char*) cv_data(ca);
+    char *bdata = (char*) cv_data(cb);
     size_t asz = cv_len(ca);
     size_t bsz = cv_len(cb);
     size_t minsz = asz < bsz ? asz : bsz;
@@ -728,7 +728,7 @@ static void check_addr_args(char *fname, value_t arr, value_t ind,
 {
     size_t numel;
     cvalue_t *cv = (cvalue_t*)ptr(arr);
-    *data = cv_data(cv);
+    *data = (char*) cv_data(cv);
     numel = cv_len(cv)/(cv_class(cv)->elsz);
     *index = tosize(ind, fname);
     if (*index >= numel)
@@ -753,7 +753,7 @@ static value_t cvalue_array_aref(value_t *args)
             return fixnum(((int16_t*)data)[index]);
         return fixnum(((uint16_t*)data)[index]);
     }
-    char *dest = cptr(el);
+    char *dest = (char*) cptr(el);
     size_t sz = eltype->size;
     if (sz == 1)
         *dest = data[index];
@@ -783,7 +783,7 @@ value_t fl_builtin(value_t *args, u_int32_t nargs)
     argcount("builtin", nargs, 1);
     symbol_t *name = tosymbol(args[0], "builtin");
     cvalue_t *cv;
-    if (ismanaged(args[0]) || (cv=name->dlcache) == NULL) {
+    if (ismanaged(args[0]) || (cv=(cvalue_t*)name->dlcache) == NULL) {
         lerrorf(ArgError, "builtin: function %s not found", name->name);
     }
     return tagptr(cv, TAG_CVALUE);
@@ -795,7 +795,7 @@ value_t cbuiltin(char *name, builtin_t f)
     cv->type = builtintype;
     cv->data = &cv->_space[0];
     cv->len = sizeof(value_t);
-    *(void**)cv->data = f;
+    *(void**)cv->data = (void*) f;
 
     value_t sym = symbol(name);
     ((symbol_t*)ptr(sym))->dlcache = cv;
@@ -837,16 +837,21 @@ static builtinspec_t cvalues_builtin_info[] = {
 #define mk_primtype_(name,ctype) \
   name##type=get_type(name##sym);name##type->init = &cvalue_##ctype##_init
 
+struct prim_int16{ char a; int16_t i; };
+struct prim_int32{ char a; int32_t i; };
+struct prim_int64{ char a; int64_t i; };
+struct prim_ptr{ char a;  void   *i; };
+
 static void cvalues_init(void)
 {
     htable_new(&TypeTable, 256);
     htable_new(&reverse_dlsym_lookup_table, 256);
 
     // compute struct field alignment required for primitives
-    ALIGN2   = sizeof(struct { char a; int16_t i; }) - 2;
-    ALIGN4   = sizeof(struct { char a; int32_t i; }) - 4;
-    ALIGN8   = sizeof(struct { char a; int64_t i; }) - 8;
-    ALIGNPTR = sizeof(struct { char a; void   *i; }) - sizeof(void*);
+    ALIGN2   = sizeof(struct prim_int16) - 2;
+    ALIGN4   = sizeof(struct prim_int32) - 4;
+    ALIGN8   = sizeof(struct prim_int64) - 8;
+    ALIGNPTR = sizeof(struct prim_ptr) - sizeof(void*);
 
     builtintype = define_opaque_type(builtinsym, sizeof(builtin_t), NULL, NULL);
 
@@ -1418,7 +1423,7 @@ static value_t fl_ash(value_t *args, u_int32_t nargs)
             if (ta == T_UINT64)
                 return return_from_uint64((*(uint64_t*)aptr)<<n);
             else if (ta < T_FLOAT) {
-                int64_t i64 = conv_to_int64(aptr, ta);
+                int64_t i64 = conv_to_int64(aptr, (numerictype_t) ta);
                 return return_from_int64(i64<<n);
             }
         }

--- a/src/flisp/dirname.c
+++ b/src/flisp/dirname.c
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <locale.h>
+#include <malloc.h>
 
 char *dirname( char *path )
 {
@@ -52,7 +53,7 @@ char *dirname( char *path )
          * in which to create a wide character reference copy of path
          */
 
-        wchar_t refcopy[1 + (len = mbstowcs( NULL, path, 0 ))];
+        wchar_t* refcopy = (wchar_t*) alloca((1 + (len = mbstowcs( NULL, path, 0 )))*sizeof(wchar_t));
 
         /* create the wide character reference copy of path */
 
@@ -209,7 +210,7 @@ char *dirname( char *path )
                  */
 
                 *refname = L'\0';
-                retfail = realloc( retfail, len = 1 + wcstombs( NULL, refcopy, 0 ));
+                retfail = (char*) realloc( retfail, len = 1 + wcstombs( NULL, refcopy, 0 ));
                 wcstombs( path = retfail, refcopy, len );
             }
 
@@ -226,7 +227,7 @@ char *dirname( char *path )
      * in case the caller trashed it after a previous call.
      */
 
-    retfail = realloc( retfail, len = 1 + wcstombs( NULL, L".", 0 ));
+    retfail = (char*) realloc( retfail, len = 1 + wcstombs( NULL, L".", 0 ));
     wcstombs( retfail, L".", len );
 
     /* restore caller's locale, clean up, and return the default dirname */

--- a/src/flisp/equal.c
+++ b/src/flisp/equal.c
@@ -323,7 +323,7 @@ static uptrint_t bounded_hash(value_t a, int bound, int *oob)
     case TAG_CVALUE:
         cv = (cvalue_t*)ptr(a);
         data = cv_data(cv);
-        return memhash(data, cv_len(cv));
+        return memhash((char*) data, cv_len(cv));
 
     case TAG_VECTOR:
         if (bound <= 0) {

--- a/src/flisp/flisp.c
+++ b/src/flisp/flisp.c
@@ -46,6 +46,7 @@
 #include "platform.h"
 
 #if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+#include <malloc.h>
 char * basename(char *);
 char * dirname(char *);
 #else
@@ -274,7 +275,8 @@ static symbol_t *mk_symbol(char *str)
     else {
         sym->binding = UNBOUND;
     }
-    sym->type = sym->dlcache = NULL;
+    sym->type = NULL;
+    sym->dlcache = NULL;
     sym->hash = memhash32(str, len)^0xAAAAAAAA;
     strcpy(&sym->name[0], str);
     return sym;
@@ -653,7 +655,7 @@ void gc(int mustgrow)
 
     temp = tospace;
     tospace = fromspace;
-    fromspace = temp;
+    fromspace = (unsigned char*) temp;
 
     // if we're using > 80% of the space, resize tospace so we have
     // more space to fill next time. if we grew tospace last time,
@@ -669,7 +671,7 @@ void gc(int mustgrow)
         temp = LLT_REALLOC(tospace, heapsize*2);
         if (temp == NULL)
             fl_raise(memory_exception_value);
-        tospace = temp;
+        tospace = (unsigned char*) temp;
         if (grew) {
             heapsize*=2;
             temp = bitvector_resize(consflags, 0, heapsize/sizeof(cons_t), 1);
@@ -690,7 +692,7 @@ void gc(int mustgrow)
 static void grow_stack(void)
 {
     size_t newsz = N_STACK + (N_STACK>>1);
-    value_t *ns = realloc(Stack, newsz*sizeof(value_t));
+    value_t *ns = (value_t*) realloc(Stack, newsz*sizeof(value_t));
     if (ns == NULL)
         lerror(MemoryError, "stack overflow");
     Stack = ns;
@@ -950,9 +952,11 @@ static uint32_t process_keys(value_t kwtable,
                              uint32_t nreq, uint32_t nkw, uint32_t nopt,
                              uint32_t bp, uint32_t nargs, int va)
 {
+    uptrint_t n;
     uint32_t extr = nopt+nkw;
     uint32_t ntot = nreq+extr;
-    value_t args[extr], v;
+    value_t* args = (value_t*) alloca(extr*sizeof(value_t)); 
+    value_t v;
     uint32_t i, a = 0, nrestargs;
     value_t s1 = Stack[SP-1];
     value_t s2 = Stack[SP-2];
@@ -971,7 +975,7 @@ static uint32_t process_keys(value_t kwtable,
     }
     if (i >= nargs) goto no_kw;
     // now process keywords
-    uptrint_t n = vector_size(kwtable)/2;
+    n = vector_size(kwtable)/2;
     do {
         i++;
         if (i >= nargs)
@@ -1080,7 +1084,7 @@ static value_t apply_cl(uint32_t nargs)
  apply_cl_top:
     captured = 0;
     func = Stack[SP-nargs-1];
-    ip = cv_data((cvalue_t*)ptr(fn_bcode(func)));
+    ip = (uint8_t*) cv_data((cvalue_t*)ptr(fn_bcode(func)));
 #ifndef MEMDEBUG2
     assert(!ismanaged((uptrint_t)ip));
 #endif
@@ -2155,7 +2159,7 @@ static value_t fl_function(value_t *args, uint32_t nargs)
         type_error("function", "vector", args[1]);
     cvalue_t *arr = (cvalue_t*)ptr(args[0]);
     cv_pin(arr);
-    char *data = cv_data(arr);
+    char *data = (char*) cv_data(arr);
     int swap = 0;
     if ((uint8_t)data[4] >= N_OPCODES) {
         // read syntax, shifted 48 for compact text representation
@@ -2384,11 +2388,11 @@ static void lisp_init(size_t initial_heapsize)
 
     heapsize = initial_heapsize;
 
-    fromspace = LLT_ALLOC(heapsize);
+    fromspace = (unsigned char*) LLT_ALLOC(heapsize);
 #ifdef MEMDEBUG
     tospace   = NULL;
 #else
-    tospace   = LLT_ALLOC(heapsize);
+    tospace   = (unsigned char*) LLT_ALLOC(heapsize);
 #endif
     curheap = fromspace;
     lim = curheap+heapsize-sizeof(cons_t);
@@ -2396,7 +2400,7 @@ static void lisp_init(size_t initial_heapsize)
     htable_new(&printconses, 32);
     comparehash_init();
     N_STACK = 262144;
-    Stack = malloc(N_STACK*sizeof(value_t));
+    Stack = (value_t*) malloc(N_STACK*sizeof(value_t));
 
     FL_NIL = NIL = builtin(OP_THE_EMPTY_LIST);
     FL_T = builtin(OP_BOOL_CONST_T);

--- a/src/flisp/flmain.c
+++ b/src/flisp/flmain.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
 
     fname_buf[0] = '\0';
     value_t str = symbol_value(symbol("*install-dir*"));
-    char *exedir = (str == UNBOUND ? NULL : cvalue_data(str));
+    char *exedir = (char*) (str == UNBOUND ? NULL : cvalue_data(str));
     if (exedir != NULL) {
         strcat(fname_buf, exedir);
         strcat(fname_buf, PATHSEPSTRING);

--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -265,7 +265,7 @@ value_t fl_ioread(value_t *args, u_int32_t nargs)
     }
     value_t cv = cvalue(ft, n);
     char *data;
-    if (iscvalue(cv)) data = cv_data((cvalue_t*)ptr(cv));
+    if (iscvalue(cv)) data = (char*) cv_data((cvalue_t*)ptr(cv));
     else data = cp_data((cprim_t*)ptr(cv));
     size_t got = ios_read(value2c(ios_t*,args[0]), data, n);
     if (got < n)
@@ -329,7 +329,7 @@ value_t fl_ioreaduntil(value_t *args, u_int32_t nargs)
     argcount("io.readuntil", nargs, 2);
     value_t str = cvalue_string(80);
     cvalue_t *cv = (cvalue_t*)ptr(str);
-    char *data = cv_data(cv);
+    char *data = (char*) cv_data(cv);
     ios_t dest;
     ios_mem(&dest, 0);
     ios_setbuf(&dest, data, 80, 0);

--- a/src/flisp/print.c
+++ b/src/flisp/print.c
@@ -433,7 +433,7 @@ void fl_print_child(ios_t *f, value_t v)
                 if (print_circle_prefix(f, v)) break;
                 function_t *fn = (function_t*)ptr(v);
                 outs("#fn(", f);
-                char *data = cvalue_data(fn->bcode);
+                char *data = (char*) cvalue_data(fn->bcode);
                 size_t i, sz = cvalue_len(fn->bcode);
                 for(i=0; i < sz; i++) data[i] += 48;
                 fl_print_child(f, fn->bcode);
@@ -595,9 +595,9 @@ static void cvalue_printdata(ios_t *f, void *data, size_t len, value_t type,
         if (!DFINITE(d)) {
             char *rep;
             if (d != d)
-                rep = sign_bit(d) ? "-nan.0" : "+nan.0";
+                rep = (char*)(sign_bit(d) ? "-nan.0" : "+nan.0");
             else
-                rep = sign_bit(d) ? "-inf.0" : "+inf.0";
+                rep = (char*)(sign_bit(d) ? "-inf.0" : "+inf.0");
             if (type == floatsym && !print_princ && !weak)
                 HPOS+=ios_printf(f, "#%s(%s)", symbol_name(type), rep);
             else
@@ -651,9 +651,9 @@ static void cvalue_printdata(ios_t *f, void *data, size_t len, value_t type,
             if (init == 0) {
                 init = 1;
 #if defined(RTLD_SELF)
-                jl_static_print = dlsym(RTLD_SELF, "jl_static_show");
+                jl_static_print = (size_t (*)(ios_t *, void *)) dlsym(RTLD_SELF, "jl_static_show");
 #elif defined(RTLD_DEFAULT)
-                jl_static_print = dlsym(RTLD_DEFAULT, "jl_static_show");
+                jl_static_print = (size_t (*)(ios_t *, void *)) dlsym(RTLD_DEFAULT, "jl_static_show");
 #endif
                 jl_sym = symbol("julia_value");
             }
@@ -689,7 +689,7 @@ static void cvalue_printdata(ios_t *f, void *data, size_t len, value_t type,
             }
             if (eltype == bytesym) {
                 if (print_princ) {
-                    ios_write(f, data, len);
+                    ios_write(f, (char*) data, len);
                     /*
                     char *nl = memrchr(data, '\n', len);
                     if (nl)

--- a/src/flisp/read.c
+++ b/src/flisp/read.c
@@ -463,11 +463,11 @@ static value_t read_string(void)
     value_t s;
     u_int32_t wc=0;
 
-    buf = malloc(sz);
+    buf = (char*) malloc(sz);
     while (1) {
         if (i >= sz-4) {  // -4: leaves room for longest utf8 sequence
             sz *= 2;
-            temp = realloc(buf, sz);
+            temp = (char*) realloc(buf, sz);
             if (temp == NULL) {
                 free(buf);
                 lerror(ParseError, "read: out of memory reading string");

--- a/src/flisp/string.c
+++ b/src/flisp/string.c
@@ -45,7 +45,7 @@ value_t fl_string_count(value_t *args, u_int32_t nargs)
                 return fixnum(0);
         }
     }
-    char *str = cvalue_data(args[0]);
+    char *str = (char*) cvalue_data(args[0]);
     return size_wrap(u8_charnum(str+start, stop-start));
 }
 
@@ -78,7 +78,7 @@ value_t fl_string_reverse(value_t *args, u_int32_t nargs)
         type_error("string.reverse", "string", args[0]);
     size_t len = cv_len((cvalue_t*)ptr(args[0]));
     value_t ns = cvalue_string(len);
-    u8_reverse(cvalue_data(ns), cvalue_data(args[0]), len);
+    u8_reverse((char*)cvalue_data(ns), (char*)cvalue_data(args[0]), len);
     return ns;
 }
 
@@ -93,8 +93,8 @@ value_t fl_string_encode(value_t *args, u_int32_t nargs)
             uint32_t *ptr = (uint32_t*)cv_data(cv);
             size_t nbytes = u8_codingsize(ptr, nc);
             value_t str = cvalue_string(nbytes);
-            ptr = cv_data((cvalue_t*)ptr(args[0]));  // relocatable pointer
-            u8_toutf8(cvalue_data(str), nbytes, ptr, nc);
+            ptr = (uint32_t*) cv_data((cvalue_t*)ptr(args[0]));  // relocatable pointer
+            u8_toutf8((char*)cvalue_data(str), nbytes, ptr, nc);
             return str;
         }
     }
@@ -119,8 +119,8 @@ value_t fl_string_decode(value_t *args, u_int32_t nargs)
     size_t newsz = nc*sizeof(uint32_t);
     if (term) newsz += sizeof(uint32_t);
     value_t wcstr = cvalue(wcstringtype, newsz);
-    ptr = cv_data((cvalue_t*)ptr(args[0]));  // relocatable pointer
-    uint32_t *pwc = cvalue_data(wcstr);
+    ptr = (char*) cv_data((cvalue_t*)ptr(args[0]));  // relocatable pointer
+    uint32_t *pwc = (uint32_t*) cvalue_data(wcstr);
     u8_toucs(pwc, nc, ptr, nb);
     if (term) pwc[nc] = 0;
     return wcstr;
@@ -175,8 +175,8 @@ value_t fl_string_split(value_t *args, u_int32_t nargs)
         c = fl_cons(cvalue_string(ssz), FL_NIL);
 
         // we've done allocation; reload movable pointers
-        s = cv_data((cvalue_t*)ptr(args[0]));
-        delim = cv_data((cvalue_t*)ptr(args[1]));
+        s = (char*) cv_data((cvalue_t*)ptr(args[0]));
+        delim = (char*) cv_data((cvalue_t*)ptr(args[1]));
 
         if (ssz) memcpy(cv_data((cvalue_t*)ptr(car_(c))), &s[tokstart], ssz);
 
@@ -215,7 +215,7 @@ value_t fl_string_sub(value_t *args, u_int32_t nargs)
     if (i2 <= i1)
         return cvalue_string(0);
     value_t ns = cvalue_string(i2-i1);
-    s = cvalue_data(args[0]); // reload after alloc
+    s = (char*) cvalue_data(args[0]); // reload after alloc
     memcpy(cv_data((cvalue_t*)ptr(ns)), &s[i1], i2-i1);
     return ns;
 }
@@ -253,7 +253,7 @@ value_t fl_char_downcase(value_t *args, u_int32_t nargs)
 
 static value_t mem_find_byte(char *s, char c, size_t start, size_t len)
 {
-    char *p = memchr(s+start, c, len-start);
+    char *p = (char*) memchr(s+start, c, len-start);
     if (p == NULL)
         return FL_F;
     return size_wrap((size_t)(p - s));

--- a/src/flisp/types.c
+++ b/src/flisp/types.c
@@ -10,7 +10,7 @@ fltype_t *get_type(value_t t)
     }
     void **bp = equalhash_bp(&TypeTable, (void*)t);
     if (*bp != HT_NOTFOUND)
-        return *bp;
+        return (fltype_t*) *bp;
 
     int align, isarray=(iscons(t) && car_(t) == arraysym && iscons(cdr_(t)));
     size_t sz;
@@ -29,7 +29,7 @@ fltype_t *get_type(value_t t)
         ((symbol_t*)ptr(t))->type = ft;
     }
     else {
-        ft->numtype = N_NUMTYPES;
+        ft->numtype = (numerictype_t) N_NUMTYPES;
     }
     ft->size = sz;
     ft->vtable = NULL;
@@ -69,7 +69,7 @@ fltype_t *define_opaque_type(value_t sym, size_t sz, cvtable_t *vtab,
     fltype_t *ft = (fltype_t*)malloc(sizeof(fltype_t));
     ft->type = sym;
     ft->size = sz;
-    ft->numtype = N_NUMTYPES;
+    ft->numtype = (numerictype_t) N_NUMTYPES;
     ft->vtable = vtab;
     ft->artype = NULL;
     ft->eltype = NULL;

--- a/src/gc.c
+++ b/src/gc.c
@@ -313,7 +313,7 @@ static void run_finalizers(void)
         ff = (jl_value_t*)ptrhash_get(&finalizer_table, o);
         assert(ff != HT_NOTFOUND);
         ptrhash_remove(&finalizer_table, o);
-        run_finalizer(o, ff);
+        run_finalizer((jl_value_t*) o, ff);
     }
     JL_GC_POP();
 }
@@ -321,7 +321,7 @@ static void run_finalizers(void)
 void jl_gc_run_all_finalizers(void)
 {
     for(size_t i=0; i < finalizer_table.size; i+=2) {
-        jl_value_t *f = finalizer_table.table[i+1];
+        jl_value_t *f = (jl_value_t*) finalizer_table.table[i+1];
         if (f != HT_NOTFOUND && !jl_is_cpointer(f)) {
             schedule_finalization(finalizer_table.table[i]);
         }
@@ -402,7 +402,7 @@ void jl_gc_track_malloced_array(jl_array_t *a)
 {
     mallocarray_t *ma;
     if (mafreelist == NULL) {
-        ma = malloc(sizeof(mallocarray_t));
+        ma = (mallocarray_t*) malloc(sizeof(mallocarray_t));
     }
     else {
         ma = mafreelist;
@@ -462,7 +462,7 @@ static pool_t *pools = &norm_pools[0];
 
 static void add_page(pool_t *p)
 {
-    gcpage_t *pg = malloc_a16(sizeof(gcpage_t));
+    gcpage_t *pg = (gcpage_t*) malloc_a16(sizeof(gcpage_t));
     if (pg == NULL)
         jl_throw(jl_memory_exception);
     gcval_t *v = (gcval_t*)&pg->data[0];
@@ -867,9 +867,9 @@ static void gc_mark(void)
     // this must happen last.
     for(i=0; i < finalizer_table.size; i+=2) {
         if (finalizer_table.table[i+1] != HT_NOTFOUND) {
-            jl_value_t *v = finalizer_table.table[i];
+            jl_value_t *v = (jl_value_t*) finalizer_table.table[i];
             if (!gc_marked(v)) {
-                jl_value_t *fin = finalizer_table.table[i+1];
+                jl_value_t *fin = (jl_value_t*) finalizer_table.table[i+1];
                 if (gc_typeof(fin) == (jl_value_t*)jl_voidpointer_type) {
                     void *p = ((void**)fin)[1];
                     if (p)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1595,7 +1595,7 @@ static jl_value_t *lookup_type(jl_typename_t *tn, jl_value_t **key, size_t n)
         cl = jl_tuple_len(cache);
     }
     else {
-        data = jl_array_data(cache);
+        data = (jl_value_t**) jl_array_data(cache);
         cl = jl_array_len(cache);
     }
     for(size_t i=0; i < cl; i++) {
@@ -1770,6 +1770,11 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_value_t **env, size_t n,
                 cacheable = 0;
         }
 
+        jl_tuple_t *iparams_tuple;
+        jl_datatype_t *dt;
+        jl_datatype_t *ndt;
+        jl_tuple_t *ftypes;
+
         // if an identical instantiation is already in process somewhere
         // up the stack, return it. this computes a fixed point for
         // recursive types.
@@ -1803,15 +1808,14 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_value_t **env, size_t n,
         }
 
         // move array of instantiated parameters to heap; we need to keep it
-        jl_tuple_t *iparams_tuple = jl_alloc_tuple_uninit(ntp);
+        iparams_tuple = jl_alloc_tuple_uninit(ntp);
         for(i=0; i < ntp; i++)
             jl_tupleset(iparams_tuple, i, iparams[i]);
         *rt1 = (jl_value_t*)iparams_tuple;
 
-        jl_datatype_t *dt = (jl_datatype_t*)t;
+        dt = (jl_datatype_t*)t;
         // create and initialize new type
-        jl_datatype_t *ndt =
-            jl_new_uninitialized_datatype(jl_tuple_len(dt->names));
+        ndt = jl_new_uninitialized_datatype(jl_tuple_len(dt->names));
         *rt2 = (jl_value_t*)ndt;
         // associate these parameters with the new type on
         // the stack, in case one of its field types references it.
@@ -1837,7 +1841,7 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_value_t **env, size_t n,
         ndt->struct_decl = NULL;
         ndt->size = ndt->alignment = 0;
         ndt->super = (jl_datatype_t*)inst_type_w_((jl_value_t*)dt->super, env,n,stack, 1);
-        jl_tuple_t *ftypes = dt->types;
+        ftypes = dt->types;
         if (ftypes != NULL) {
             // recursively instantiate the types of the fields
             ndt->types = (jl_tuple_t*)inst_type_w_((jl_value_t*)ftypes, env, n, stack, 1);
@@ -1886,7 +1890,7 @@ void jl_reinstantiate_inner_types(jl_datatype_t *t)
     top.tt = (jl_datatype_t*)t;
     top.prev = NULL;
     size_t n = jl_tuple_len(t->parameters);
-    jl_value_t **env = alloca(n*2*sizeof(void*));
+    jl_value_t **env = (jl_value_t**) alloca(n*2*sizeof(void*));
     for(int i=0; i < n; i++) {
         env[i*2] = jl_tupleref(t->parameters,i);
         env[i*2+1] = env[i*2];
@@ -2311,7 +2315,7 @@ static jl_value_t *type_match_(jl_value_t *child, jl_value_t *parent,
         jl_tuple_t *t = ((jl_uniontype_t*)child)->types;
         if (morespecific) {
             cenv_t tenv;
-            tenv.data = alloca(MAX_CENV_SIZE*sizeof(void*));
+            tenv.data = (jl_value_t**) alloca(MAX_CENV_SIZE*sizeof(void*));
             for(i=0; i < jl_tuple_len(t); i++) {
                 int n = env->n;
                 tmp = type_match_(jl_tupleref(t,i), parent, env, 1, invariant);
@@ -2837,7 +2841,7 @@ void jl_init_types(void)
     jl_tupleset(jl_method_type->types, 3, jl_function_type);
     jl_tupleset(jl_lambda_info_type->types, 6, jl_function_type);
 
-    jl_bottom_func = jl_new_closure(jl_f_no_function, JL_NULL, NULL);
+    jl_bottom_func = jl_new_closure(jl_f_no_function, (jl_value_t*) JL_NULL, NULL);
 
     jl_intrinsic_type = jl_new_bitstype((jl_value_t*)jl_symbol("IntrinsicFunction"),
                                         jl_any_type, jl_null, 32);

--- a/src/julia.h
+++ b/src/julia.h
@@ -432,11 +432,10 @@ DLLEXPORT extern jl_value_t *jl_nothing;
 extern jl_function_t *jl_unprotect_stack_func;
 extern jl_function_t *jl_bottom_func;
 
-extern uv_lib_t *jl_dl_handle;
+DLLEXPORT extern uv_lib_t *jl_dl_handle;
 DLLEXPORT extern uv_lib_t *jl_RTLD_DEFAULT_handle;
 
 #if defined(_OS_WINDOWS_)
-DLLEXPORT extern uv_lib_t *jl_dl_handle;
 DLLEXPORT extern uv_lib_t *jl_exe_handle;
 extern uv_lib_t *jl_ntdll_handle;
 extern uv_lib_t *jl_kernel32_handle;
@@ -482,7 +481,7 @@ extern jl_sym_t *boundscheck_sym; extern jl_sym_t *copyast_sym;
 
 #ifdef JL_GC_MARKSWEEP
 void *allocb(size_t sz);
-void *allocobj(size_t sz);
+DLLEXPORT void *allocobj(size_t sz);
 #else
 #define allocb(nb)    malloc(nb)
 #define allocobj(nb)  malloc(nb)
@@ -728,7 +727,7 @@ jl_function_t *jl_new_generic_function(jl_sym_t *name);
 void jl_initialize_generic_function(jl_function_t *f, jl_sym_t *name);
 void jl_add_method(jl_function_t *gf, jl_tuple_t *types, jl_function_t *meth,
                    jl_tuple_t *tvars);
-jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_binding_t *bnd,
+DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_binding_t *bnd,
                           jl_tuple_t *argtypes, jl_function_t *f);
 DLLEXPORT jl_value_t *jl_box_bool(int8_t x);
 DLLEXPORT jl_value_t *jl_box_int8(int32_t x);
@@ -897,8 +896,8 @@ void jl_init_intrinsic_functions(void);
 void jl_init_tasks(void *stack, size_t ssize);
 void jl_init_serializer(void);
 
-void jl_save_system_image(char *fname);
-void jl_restore_system_image(char *fname, int build_mode);
+DLLEXPORT void jl_save_system_image(char *fname);
+DLLEXPORT void jl_restore_system_image(char *fname, int build_mode);
 void jl_dump_bitcode(char *fname);
 void jl_set_imaging_mode(int stat);
 int32_t jl_get_llvm_gv(jl_value_t *p);
@@ -967,7 +966,6 @@ DLLEXPORT uv_lib_t *jl_load_dynamic_library_e(char *fname, unsigned flags);
 DLLEXPORT void *jl_dlsym_e(uv_lib_t *handle, char *symbol);
 DLLEXPORT void *jl_dlsym(uv_lib_t *handle, char *symbol);
 DLLEXPORT uv_lib_t *jl_wrap_raw_dl_handle(void *handle);
-void *jl_dlsym_e(uv_lib_t *handle, char *symbol); //supress errors
 char *jl_dlfind_win32(char *name);
 DLLEXPORT int add_library_mapping(char *lib, void *hnd);
 
@@ -1102,7 +1100,7 @@ extern DLLEXPORT jl_gcframe_t *jl_pgcstack;
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 
 #define JL_GC_PUSHARGS(rts_var,n)                               \
-  rts_var = ((jl_value_t**)__builtin_alloca(((n)+2)*sizeof(jl_value_t*)))+2;    \
+  rts_var = ((jl_value_t**)alloca(((n)+2)*sizeof(jl_value_t*)))+2;    \
   ((void**)rts_var)[-2] = (void*)(((size_t)n)<<1);              \
   ((void**)rts_var)[-1] = jl_pgcstack;                          \
   jl_pgcstack = (jl_gcframe_t*)&(((void**)rts_var)[-2])
@@ -1135,9 +1133,9 @@ void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz, int isaligned);
 void jl_gc_free_array(jl_array_t *a);
 void jl_gc_track_malloced_array(jl_array_t *a);
 void jl_gc_run_all_finalizers(void);
-void *alloc_2w(void);
-void *alloc_3w(void);
-void *alloc_4w(void);
+DLLEXPORT void *alloc_2w(void);
+DLLEXPORT void *alloc_3w(void);
+DLLEXPORT void *alloc_4w(void);
 
 #else
 
@@ -1277,7 +1275,7 @@ DLLEXPORT JL_STREAM *jl_stdout_stream(void);
 DLLEXPORT JL_STREAM *jl_stdin_stream(void);
 DLLEXPORT JL_STREAM *jl_stderr_stream(void);
 
-extern char *julia_home;
+DLLEXPORT extern char *julia_home;
 
 STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
 {

--- a/src/support/Windows.mk
+++ b/src/support/Windows.mk
@@ -23,7 +23,6 @@ HEADERS = \
 OBJECTS = \
 	hashing.obj \
 	timefuncs.obj \
-	dblprint.obj \
 	ptrhash.obj \
 	operators.obj \
 	utf8.obj \
@@ -37,7 +36,7 @@ OBJECTS = \
 	wcwidth.obj
 
 INCLUDE = $(INCLUDE);$(MAKEDIR)\..\..\deps\libuv\include
-CFLAGS = $(CFLAGS) -D_CRT_SECURE_NO_WARNINGS
+CFLAGS = $(CFLAGS) -D_CRT_SECURE_NO_WARNINGS -DLIBRARY_EXPORTS
 
 default: lib$(NAME).lib
 
@@ -46,6 +45,6 @@ lib$(NAME).lib: $(OBJECTS)
 
 .c.obj:
 	$(CC) $(CFLAGS) $<
-
+	
 # vim: noexpandtab:ts=4:sw=4:
 

--- a/src/support/arraylist.c
+++ b/src/support/arraylist.c
@@ -35,7 +35,7 @@ static void al_grow(arraylist_t *a, size_t n)
 {
     if (a->len+n > a->max) {
         if (a->items == &a->_space[0]) {
-            void **p = LLT_ALLOC((a->len+n)*sizeof(void*));
+            void **p = (void**) LLT_ALLOC((a->len+n)*sizeof(void*));
             if (p == NULL) return;
             memcpy(p, a->items, a->len*sizeof(void*));
             a->items = p;
@@ -45,7 +45,7 @@ static void al_grow(arraylist_t *a, size_t n)
             size_t nm = a->max*2;
             if (nm == 0) nm = 1;
             while (a->len+n > nm) nm*=2;
-            void **p = LLT_REALLOC(a->items, nm*sizeof(void*));
+            void **p = (void**) LLT_REALLOC(a->items, nm*sizeof(void*));
             if (p == NULL) return;
             a->items = p;
             a->max = nm;

--- a/src/support/asprintf.c
+++ b/src/support/asprintf.c
@@ -26,6 +26,7 @@ extern int vsnprintf();
 #include <limits.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #ifndef VA_COPY
 # ifdef HAVE_VA_COPY
@@ -50,7 +51,7 @@ vasprintf(char **str, const char *fmt, va_list ap)
         size_t len;
 
         VA_COPY(ap2, ap);
-        if ((string = malloc(INIT_SZ)) == NULL)
+        if ((string = (char*) malloc(INIT_SZ)) == NULL)
                 goto fail;
 
         ret = vsnprintf(string, INIT_SZ, fmt, ap2);
@@ -60,7 +61,7 @@ vasprintf(char **str, const char *fmt, va_list ap)
                 goto fail;
         } else {        /* bigger than initial, realloc allowing for nul */
                 len = (size_t)ret + 1;
-                if ((newstr = realloc(string, len)) == NULL) {
+                if ((newstr = (char*) realloc(string, len)) == NULL) {
                         free(string);
                         goto fail;
                 } else {

--- a/src/support/bitvector.c
+++ b/src/support/bitvector.c
@@ -18,7 +18,7 @@ u_int32_t *bitvector_resize(u_int32_t *b, uint64_t oldsz, uint64_t newsz,
 {
     u_int32_t *p;
     size_t sz = ((newsz+31)>>5) * sizeof(uint32_t);
-    p = LLT_REALLOC(b, sz);
+    p = (u_int32_t*) LLT_REALLOC(b, sz);
     if (p == NULL) return NULL;
     if (initzero && newsz>oldsz) {
         size_t osz = ((oldsz+31)>>5) * sizeof(uint32_t);

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -165,12 +165,12 @@ static char *_buf_realloc(ios_t *s, size_t sz)
         // if we own the buffer we're free to resize it
         // always allocate 1 bigger in case user wants to add a NUL
         // terminator after taking over the buffer
-        temp = LLT_REALLOC(s->buf, sz+1);
+        temp = (char*) LLT_REALLOC(s->buf, sz+1);
         if (temp == NULL)
             return NULL;
     }
     else {
-        temp = LLT_ALLOC(sz+1);
+        temp = (char*) LLT_ALLOC(sz+1);
         if (temp == NULL)
             return NULL;
         s->ownbuf = 1;
@@ -633,7 +633,7 @@ char *ios_takebuf(ios_t *s, size_t *psize)
     ios_flush(s);
 
     if (s->buf == &s->local[0]) {
-        buf = LLT_ALLOC(s->size+1);
+        buf = (char*) LLT_ALLOC(s->size+1);
         if (buf == NULL)
             return NULL;
         if (s->size)
@@ -641,7 +641,7 @@ char *ios_takebuf(ios_t *s, size_t *psize)
     }
     else {
         if (s->buf == NULL)
-            buf = LLT_ALLOC(s->size+1);
+            buf = (char*) LLT_ALLOC(s->size+1);
         else
             buf = s->buf;
     }
@@ -800,11 +800,12 @@ static void _ios_init(ios_t *s)
 
 ios_t *ios_file(ios_t *s, char *fname, int rd, int wr, int create, int trunc)
 {
+    int flags;
     int fd;
     if (!(rd || wr))
         // must specify read and/or write
         goto open_file_err;
-    int flags = wr ? (rd ? O_RDWR : O_WRONLY) : O_RDONLY;
+    flags = wr ? (rd ? O_RDWR : O_WRONLY) : O_RDONLY;
     if (create) flags |= O_CREAT;
     if (trunc)  flags |= O_TRUNC;
 #if defined(_OS_WINDOWS_)
@@ -872,14 +873,14 @@ ios_t *ios_stderr = NULL;
 
 void ios_init_stdstreams(void)
 {
-    ios_stdin = malloc(sizeof(ios_t));
+    ios_stdin = (ios_t*) malloc(sizeof(ios_t));
     ios_fd(ios_stdin, STDIN_FILENO, 0, 0);
 
-    ios_stdout = malloc(sizeof(ios_t));
+    ios_stdout = (ios_t*) malloc(sizeof(ios_t));
     ios_fd(ios_stdout, STDOUT_FILENO, 0, 0);
     ios_stdout->bm = bm_line;
 
-    ios_stderr = malloc(sizeof(ios_t));
+    ios_stderr = (ios_t*) malloc(sizeof(ios_t));
     ios_fd(ios_stderr, STDERR_FILENO, 0, 0);
     ios_stderr->bm = bm_none;
 }

--- a/src/sys.c
+++ b/src/sys.c
@@ -42,6 +42,10 @@ char *dirname(char *);
 #include <xmmintrin.h>
 #endif
 
+#if defined _MSC_VER
+#include <io.h>
+#endif
+
 DLLEXPORT uint32_t jl_getutf8(ios_t *s)
 {
     uint32_t wc=0;
@@ -98,7 +102,7 @@ DLLEXPORT int jl_readdir(const char* path, uv_fs_t* readdir_req)
     return uv_fs_readdir(uv_default_loop(), readdir_req, path, 0 /*flags*/, NULL);
 }
 
-DLLEXPORT char* jl_uv_fs_t_ptr(uv_fs_t* req) {return req->ptr; }
+DLLEXPORT char* jl_uv_fs_t_ptr(uv_fs_t* req) {return (char*) req->ptr; }
 DLLEXPORT char* jl_uv_fs_t_ptr_offset(uv_fs_t* req, int offset) {return (char *)req->ptr + offset; }
 DLLEXPORT int jl_uv_fs_result(uv_fs_t *f) { return f->result; }
 
@@ -269,7 +273,7 @@ jl_value_t *jl_readuntil(ios_t *s, uint8_t delim)
         a = jl_alloc_array_1d(jl_array_uint8_type, 80);
         ios_t dest;
         ios_mem(&dest, 0);
-        ios_setbuf(&dest, a->data, 80, 0);
+        ios_setbuf(&dest, (char*) a->data, 80, 0);
         size_t n = ios_copyuntil(&dest, s, delim);
         if (dest.buf != a->data) {
             a = jl_takebuf_array(&dest);

--- a/src/table.c
+++ b/src/table.c
@@ -30,7 +30,7 @@ static void **jl_table_lookup_bp(jl_array_t **pa, void *key)
     size_t maxprobe = max_probe(sz);
     void **tab = (void**)a->data;
 
-    hv = keyhash(key);
+    hv = keyhash((jl_value_t*) key);
  retry_bp:
     iter = 0;
     index = h2index(hv,sz);
@@ -43,7 +43,7 @@ static void **jl_table_lookup_bp(jl_array_t **pa, void *key)
             return &tab[index+1];
         }
 
-        if (jl_egal(key, tab[index]))
+        if (jl_egal((jl_value_t*) key, (jl_value_t*) tab[index]))
             return &tab[index+1];
 
         index = (index+2) & (sz-1);
@@ -82,7 +82,7 @@ static void **jl_table_peek_bp(jl_array_t *a, void *key)
     size_t sz = hash_size(a);
     size_t maxprobe = max_probe(sz);
     void **tab = (void**)a->data;
-    uint_t hv = keyhash(key);
+    uint_t hv = keyhash((jl_value_t*) key);
     size_t index = h2index(hv, sz);
     sz *= 2;
     size_t orig = index;
@@ -91,7 +91,7 @@ static void **jl_table_peek_bp(jl_array_t *a, void *key)
     do {
         if (tab[index] == NULL)
             return NULL;
-        if (jl_egal(key, tab[index]))
+        if (jl_egal((jl_value_t*) key, (jl_value_t*) tab[index]))
             return &tab[index+1];
 
         index = (index+2) & (sz-1);
@@ -117,7 +117,7 @@ jl_value_t *jl_eqtable_get(jl_array_t *h, void *key, jl_value_t *deflt)
     void **bp = jl_table_peek_bp(h, key);
     if (bp == NULL || *bp == NULL)
         return deflt;
-    return *bp;
+    return (jl_value_t*) *bp;
 }
 
 DLLEXPORT
@@ -126,7 +126,7 @@ jl_value_t *jl_eqtable_pop(jl_array_t *h, void *key, jl_value_t *deflt)
     void **bp = jl_table_peek_bp(h, key);
     if (bp == NULL || *bp == NULL)
         return deflt;
-    jl_value_t *val = *bp;
+    jl_value_t *val = (jl_value_t*) *bp;
     *bp = NULL;
     return val;
 }

--- a/src/task.c
+++ b/src/task.c
@@ -159,12 +159,12 @@ static void save_stack(jl_task_t *t)
     size_t nb = (char*)t->stackbase - (char*)&_x;
     char *buf;
     if (t->stkbuf == NULL || t->bufsz < nb) {
-        buf = allocb(nb);
+        buf = (char*) allocb(nb);
         t->stkbuf = buf;
         t->bufsz = nb;
     }
     else {
-        buf = t->stkbuf;
+        buf = (char*) t->stkbuf;
     }
     t->ssize = nb;
     memcpy(buf, (char*)&_x, nb);
@@ -180,7 +180,7 @@ void __attribute__((noinline)) restore_stack(jl_task_t *t, jl_jmp_buf *where, ch
     if (!p) {
         p = _x;
         if ((char*)&_x > _x) {
-            p = alloca((char*)&_x - _x);
+            p = (char*) alloca((char*)&_x - _x);
     	}
         restore_stack(t, where, p);
     }
@@ -647,7 +647,7 @@ DLLEXPORT jl_value_t *jl_backtrace_from_here(void)
                                             jl_tuple2(jl_voidpointer_type,
                                                       jl_box_long(1)));
     jl_array_t *bt = jl_alloc_array_1d(array_ptr_void_type, MAX_BT_SIZE);
-    size_t n = rec_backtrace(jl_array_data(bt), MAX_BT_SIZE);
+    size_t n = rec_backtrace((ptrint_t*) jl_array_data(bt), MAX_BT_SIZE);
     if (n < MAX_BT_SIZE)
         jl_array_del_end(bt, MAX_BT_SIZE-n);
     return (jl_value_t*)bt;

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -17,7 +17,7 @@
 #include "julia.h"
 #include "builtin_proto.h"
 
-DLLEXPORT char *julia_home = NULL;
+char *julia_home = NULL;
 // current line number in a file
 int jl_lineno = 0;
 
@@ -164,7 +164,7 @@ int jl_eval_with_compiler_p(jl_expr_t *expr, int compileloops)
             }
         }
         size_t sz = (maxlabl+1+7)/8;
-        char *labls = alloca(sz); memset(labls,0,sz);
+        char *labls = (char*) alloca(sz); memset(labls,0,sz);
         for(i=0; i < jl_array_len(body); i++) {
             jl_value_t *stmt = jl_cellref(body,i);
             if (jl_is_labelnode(stmt)) {


### PR DESCRIPTION
This is the branch to make libjulia compilable with MSVC (fix #5347).

The current status is that everything compiles but linking libjulia.dll fails.
Since this touches lots of files it might make sense to get in the current status first and fix the linking issues in a further step. I fear a little that it will be hard to keep this up to date while master is changing.

So whats in here:
- Add missing type casts which are required to compile the source code with C++
- `sizeof` an anonymous struct seems to be not ok in C++
- Removed some DLLEXPORT from .c/.cpp files. I have not yet removed all but only those where the compiler complains.
- When using goto, the c++ clang compiler required that no variables are declared after the first goto.
- Replaced some VLAs by alloca.
- Clean up / keep up to date the Windows.mk makefiles. One can switch between Intel and MSVC compiler now.

Open issues:
- The question is how we want the names to be mangled in the final dll. To get C mangeling we would have to put extern "C" in all .c files.
- Not sure how to handle setjmp/longjmp on windows. They are available so is it worth to compile the assembler located in libsupport?
