### PR TITLE
Add julia lu factorization. Fix some promotion for linear systems and fix bidiagonal and triangular solvers for multiple right hand side.

### DIFF
--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -5,6 +5,8 @@ type Diagonal{T} <: AbstractMatrix{T}
 end
 Diagonal(A::Matrix) = Diagonal(diag(A))
 
+convert{T<:Number,S<:Number}(::Type{Diagonal{T}}, A::Diagonal{S}) = T == S ? A : Diagonal(convert(Vector{T}, A.diag))
+
 size(D::Diagonal) = (length(D.diag),length(D.diag))
 size(D::Diagonal,d::Integer) = d<1 ? error("dimension out of range") : (d<=2 ? length(D.diag) : 1)
 

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1,5 +1,5 @@
 ## Triangular
-type Triangular{T<:Number} <: AbstractMatrix{T}
+immutable Triangular{T<:Number} <: AbstractMatrix{T}
     UL::Matrix{T}
     uplo::Char
     unitdiag::Char
@@ -89,8 +89,8 @@ getindex{T}(A::Triangular{T}, i::Integer, j::Integer) = i == j ? (A.unitdiag == 
 istril(A::Triangular) = A.uplo == 'L' || istriu(A.UL)
 istriu(A::Triangular) = A.uplo == 'U' || istril(A.UL)
 
-transpose(A::Triangular) = Triangular(A.UL, A.uplo=='U':'L':'U', A.unitdiag)
-ctranspose(A::Triangular) = conj(transpose(A))
+transpose(A::Triangular) = Triangular(symmetrize!(A.UL, A.uplo), A.uplo=='U'?'L':'U', A.unitdiag)
+ctranspose(A::Triangular) = Triangular(symmetrize_conj!(A.UL, A.uplo), A.uplo=='U'?'L':'U', A.unitdiag)
 diag(A::Triangular) = diag(A.UL)
 big(A::Triangular) = Triangular(big(A.UL), A.uplo, A.unitdiag)
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -150,6 +150,17 @@ function convert{Tv,Ti,TvS,TiS}(::Type{SparseMatrixCSC{Tv,Ti}}, S::SparseMatrixC
     end
 end
 
+function convert{Tv,TvS,TiS}(::Type{SparseMatrixCSC{Tv}}, S::SparseMatrixCSC{TvS,TiS})
+    if Tv == TvS
+        return S
+    else
+        return SparseMatrixCSC(S.m, S.n,
+                               S.colptr,
+                               S.rowval,
+                               convert(Vector{Tv},S.nzval))
+    end
+end
+
 function convert{Tv,Ti}(::Type{SparseMatrixCSC{Tv,Ti}}, M::Matrix)
     m, n = size(M)
     (I, J, V) = findnz(M)

--- a/base/test.jl
+++ b/base/test.jl
@@ -73,7 +73,7 @@ function test_approx_eq(va, vb, Eps, astr, bstr)
 end
 
 test_approx_eq(va, vb, astr, bstr) =
-    test_approx_eq(va, vb, 10^4*length(va)*eps(float(max(maximum(abs(va)), maximum(abs(vb))))), astr, bstr)
+    test_approx_eq(va, vb, 10^4*length(va)*max(eps(float(maximum(abs(va)))), eps(float(maximum(abs(vb))))), astr, bstr)
 
 macro test_approx_eq_eps(a, b, c)
     :(test_approx_eq($(esc(a)), $(esc(b)), $(esc(c)), $(string(a)), $(string(b))))

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -288,8 +288,8 @@ end
 b2 = randbool(n1, n1)
 
 @check_bit_operation (*) Matrix{Int} (b1, b2)
-@check_bit_operation (/) Matrix{Float64} (b1, b1)
-@check_bit_operation (\) Matrix{Float64} (b1, b1)
+@check_bit_operation (/) Matrix{Float32} (b1, b1)
+@check_bit_operation (\) Matrix{Float32} (b1, b1)
 
 b0 = falses(0)
 @check_bit_operation (&) BitVector (b0, b0)


### PR DESCRIPTION
I have added a julia implementation of the LU decomposition and adjusted the higher level functions to call that when `eltype` is not `BlasType`. The decomposition is stored in the same type as the LAPACK version. I don't think pivoting is so important when `eltype` is not `BlasType` since the result should be exact for rational matrices and for `Matrix{BigFloat}` you can always adjust the precision. If necessary, pivoting can be added later.

The promotion fixes should also fix JuliaLang/LinearAlgebra.jl#56

This is progress towards fixing JuliaLang/LinearAlgebra.jl#11 

I have changed the tests to use multiple right hand side to catch the error in the `Bidiagonal`/`Triangular` solvers.
