### PR TITLE
fix off-by-one in findn and findnz

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -298,7 +298,8 @@ function findn{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
         end
     end
 
-    if numnz != count-1
+    count -= 1
+    if numnz != count
         I = I[1:count]
         J = J[1:count]
     end
@@ -324,7 +325,8 @@ function findnz{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
         end
     end
 
-    if numnz != count-1
+    count -= 1
+    if numnz != count
         I = I[1:count]
         J = J[1:count]
         V = V[1:count]

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -182,3 +182,7 @@ mfe22 = eye(Float64, 2)
 
 # issue #5169
 @test nnz(sparse([1,1],[1,2],[0.0,-0.0])) == 0
+
+# issue #5386
+I,J,V = findnz(SparseMatrixCSC(2,1,[1,3],[1,2],[1.0,0.0]))
+@test length(I) == length(J) == length(V) == 1


### PR DESCRIPTION
`count` was equal to the number of nonzero elements plus one, so the output vectors had an extra element with junk.
