### PR TITLE
address readdlm default delimiter and boundserror. ref: #5391

### DIFF
--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -13,6 +13,11 @@ dlm_data = readdlm(joinpath("perf", "kernel", "imdb-1.tsv"), '\t')
 @test size(readcsv(IOBuffer("1,2,3,4\n1,2,3,"))) == (2,4)
 @test size(readcsv(IOBuffer("1,2,3,4\n1,2,3"))) == (2,4)
 
+@test size(readdlm(IOBuffer("1 2 3 4\n1 2 3"))) == (2,4)
+@test size(readdlm(IOBuffer("1\t2 3 4\n1 2 3"))) == (2,4)
+@test size(readdlm(IOBuffer("1\t 2 3 4\n1 2 3"))) == (2,5)
+@test size(readdlm(IOBuffer("1\t 2 3 4\n1 2 3\n"))) == (2,5)
+
 let x = [1,2,3], y = [4,5,6], io = IOBuffer()
     writedlm(io, zip(x,y), ",  ")
     seek(io, 0)


### PR DESCRIPTION
This addresses the following two issues in `readdlm`:
- default delimiters not being applied correctly when the data is ASCII
- BoundsError when there are empty columns

Test cases are also updated to capture this condition in future.
