### PR TITLE
Added readdlm option to ignore empty columns.

### DIFF
--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -2536,24 +2536,33 @@
 
 "),
 
-("Text I/O","Base","readdlm","readdlm(source, delim::Char; has_header=false, use_mmap=false, ignore_invalid_chars=false)
+("Text I/O","Base","readdlm","readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap=false, ignore_invalid_chars=false)
 
-   Read a matrix from the source where each line gives one row, with
-   elements separated by the given delimeter. The source can be a text
-   file, stream or byte array. Memory mapped filed can be used by
-   passing the byte array representation of the mapped segment as
-   source.
+   Read a matrix from the source where each line (separated by \"eol\") 
+   gives one row, with elements separated by the given delimeter. The 
+   source can be a text file, stream or byte array. Memory mapped files 
+   can be used by passing the byte array representation of the mapped 
+   segment as source. 
 
-   If \"has_header\" is \"true\" the first row of data would be read
+   If \"T\" is a numeric type, the result is an array of that type, 
+   with any non-numeric elements as \"NaN\" for floating-point types, 
+   or zero. Other useful values of \"T\" include \"ASCIIString\", 
+   \"String\", and \"Any\".
+
+   If \"has_header\" is \"true\", the first row of data would be read
    as headers and the tuple \"(data_cells, header_cells)\" is returned
    instead of only \"data_cells\".
 
-   If \"use_mmap\" is \"true\" the file specified by \"source\" is
+   If \"use_mmap\" is \"true\", the file specified by \"source\" is
    memory mapped for potential speedups.
 
-   If \"ignore_invalid_chars\" is \"true\" bytes in \"source\" with
+   If \"ignore_invalid_chars\" is \"true\", bytes in \"source\" with
    invalid character encoding will be ignored. Otherwise an error is
    thrown indicating the offending character position.
+
+"),
+
+("Text I/O","Base","readdlm","readdlm(source, delim::Char, eol::Char; options...)
 
    If all data is numeric, the result will be a numeric array. If some
    elements cannot be parsed as numbers, a cell array of numbers and
@@ -2563,11 +2572,33 @@
 
 ("Text I/O","Base","readdlm","readdlm(source, delim::Char, T::Type; options...)
 
-   Read a matrix from the source with a given element type. If \"T\"
-   is a numeric type, the result is an array of that type, with any
-   non-numeric elements as \"NaN\" for floating-point types, or zero.
-   Other useful values of \"T\" include \"ASCIIString\", \"String\",
-   and \"Any\".
+   The end of line delimiter is taken as \"\\n\". 
+
+"),
+
+("Text I/O","Base","readdlm","readdlm(source, delim::Char; options...)
+
+   The end of line delimiter is taken as \"\\n\". If all data is 
+   numeric, the result will be a numeric array. If some elements 
+   cannot be parsed as numbers, a cell array of numbers and 
+   strings is returned.
+
+"),
+
+("Text I/O","Base","readdlm","readdlm(source, T::Type; options...)
+
+   The columns are assumed to be separated by one or more whitespaces. 
+   The end of line delimiter is taken as \"\\n\".
+
+"),
+
+("Text I/O","Base","readdlm","readdlm(source, options...)
+
+   The columns are assumed to be separated by one or more whitespaces. 
+   The end of line delimiter is taken as \"\\n\". If all data is 
+   numeric, the result will be a numeric array. If some elements 
+   cannot be parsed as numbers, a cell array of numbers and strings 
+   is returned.
 
 "),
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1664,22 +1664,37 @@ Text I/O
 
    Create an iterable object that will yield each line from a stream.
 
-.. function:: readdlm(source, delim::Char; has_header=false, use_mmap=false, ignore_invalid_chars=false)
+.. function:: readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap=false, ignore_invalid_chars=false)
 
-   Read a matrix from the source where each line gives one row, with elements separated by the given delimeter. The source can be a text file, stream or byte array. Memory mapped filed can be used by passing the byte array representation of the mapped segment as source. 
+   Read a matrix from the source where each line (separated by ``eol``) gives one row, with elements separated by the given delimeter. The source can be a text file, stream or byte array. Memory mapped files can be used by passing the byte array representation of the mapped segment as source. 
 
-   If ``has_header`` is ``true`` the first row of data would be read as headers and the tuple ``(data_cells, header_cells)`` is returned instead of only ``data_cells``.
+   If ``T`` is a numeric type, the result is an array of that type, with any non-numeric elements as ``NaN`` for floating-point types, or zero. Other useful values of ``T`` include ``ASCIIString``, ``String``, and ``Any``.
 
-   If ``use_mmap`` is ``true`` the file specified by ``source`` is memory mapped for potential speedups.
+   If ``has_header`` is ``true``, the first row of data would be read as headers and the tuple ``(data_cells, header_cells)`` is returned instead of only ``data_cells``.
 
-   If ``ignore_invalid_chars`` is ``true`` bytes in ``source`` with invalid character encoding will be ignored. Otherwise an error is thrown indicating the offending character position.
+   If ``use_mmap`` is ``true``, the file specified by ``source`` is memory mapped for potential speedups.
+
+   If ``ignore_invalid_chars`` is ``true``, bytes in ``source`` with invalid character encoding will be ignored. Otherwise an error is thrown indicating the offending character position.
+
+.. function:: readdlm(source, delim::Char, eol::Char; options...)
 
    If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a cell array of numbers and strings is returned.
-
-
+   
 .. function:: readdlm(source, delim::Char, T::Type; options...)
 
-   Read a matrix from the source with a given element type. If ``T`` is a numeric type, the result is an array of that type, with any non-numeric elements as ``NaN`` for floating-point types, or zero. Other useful values of ``T`` include ``ASCIIString``, ``String``, and ``Any``.
+   The end of line delimiter is taken as ``\n``.
+
+.. function:: readdlm(source, delim::Char; options...)
+
+   The end of line delimiter is taken as ``\n``. If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a cell array of numbers and strings is returned.
+
+.. function:: readdlm(source, T::Type; options...)
+
+   The columns are assumed to be separated by one or more whitespaces. The end of line delimiter is taken as ``\n``.
+
+.. function:: readdlm(source; options...)
+
+   The columns are assumed to be separated by one or more whitespaces. The end of line delimiter is taken as ``\n``. If all data is numeric, the result will be a numeric array. If some elements cannot be parsed as numbers, a cell array of numbers and strings is returned.
 
 .. function:: writedlm(f, A, delim='\t')
 

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -13,13 +13,98 @@ dlm_data = readdlm(joinpath("perf", "kernel", "imdb-1.tsv"), '\t')
 @test size(readcsv(IOBuffer("1,2,3,4\n1,2,3,"))) == (2,4)
 @test size(readcsv(IOBuffer("1,2,3,4\n1,2,3"))) == (2,4)
 
+@test size(readcsv(IOBuffer("1,2,3,4\r\n"))) == (1,4)
+@test size(readcsv(IOBuffer("1,2,3,4\r\n1,2,3\r\n"))) == (2,4)
+@test size(readcsv(IOBuffer("1,2,3,4\r\n1,2,3,4\r\n"))) == (2,4)
+
 @test size(readdlm(IOBuffer("1 2 3 4\n1 2 3"))) == (2,4)
 @test size(readdlm(IOBuffer("1\t2 3 4\n1 2 3"))) == (2,4)
-@test size(readdlm(IOBuffer("1\t 2 3 4\n1 2 3"))) == (2,5)
-@test size(readdlm(IOBuffer("1\t 2 3 4\n1 2 3\n"))) == (2,5)
+@test size(readdlm(IOBuffer("1\t 2 3 4\n1 2 3"))) == (2,4)
+@test size(readdlm(IOBuffer("1\t 2 3 4\n1 2 3\n"))) == (2,4)
+@test size(readdlm(IOBuffer("1,,2,3,4\n1,2,3\n"), ',')) == (2,5)
+
+result1 = reshape({"", "", "", "", "", "", 1.0, 1.0, "", "", "", "", "", 1.0, 2.0, "", 3.0, "", "", "", "", "", 4.0, "", "", ""}, 2, 13)
+result2 = reshape({1.0, 1.0, 2.0, 1.0, 3.0, "", 4.0, ""}, 2, 4)
+
+@test readdlm(IOBuffer(",,,1,,,,2,3,,,4,\n,,,1,,,1\n"), ',') == result1
+@test readdlm(IOBuffer("   1    2 3   4 \n   1   1\n")) == result2
+@test readdlm(IOBuffer("   1    2 3   4 \n   1   1\n"), ' ') == result1
+
+result1[1,4] = "भारत" 
+@test readdlm(IOBuffer(",,,भारत,,,,2,3,,,4,\n,,,1,,,1\n"), ',') == result1
+
+result1 = reshape({1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, ""}, 2, 4)
+@test readdlm(IOBuffer("1\t 2 3 4\n1 2 3")) == result1
+@test readdlm(IOBuffer("1\t 2 3 4\n1 2 3 ")) == result1
+@test readdlm(IOBuffer("1\t 2 3 4\n1 2 3\n")) == result1
+@test readdlm(IOBuffer("1,2,3,4\n1,2,3\n"), ',') == result1
+@test readdlm(IOBuffer("1,2,3,4\n1,2,3"), ',') == result1
+@test readdlm(IOBuffer("1,2,3,4\r\n1,2,3\r\n"), ',') == result1
 
 let x = [1,2,3], y = [4,5,6], io = IOBuffer()
     writedlm(io, zip(x,y), ",  ")
     seek(io, 0)
     @test readcsv(io) == [x y]
 end
+
+
+# source: http://www.i18nguy.com/unicode/unicode-example-utf8.zip
+i18n_data = ["Origin (English)", "Name (English)", "Origin (Native)", "Name (Native)", 
+"Australia", "Nicole Kidman", "Australia", "Nicole Kidman", 
+"Austria", "Johann Strauss", "Österreich", "Johann Strauß", 
+"Belgium (Flemish)", "Rene Magritte", "België", "René Magritte", 
+"Belgium (French)", "Rene Magritte", "Belgique", "René Magritte", 
+"Belgium (German)", "Rene Magritte", "Belgien", "René Magritte", 
+"Bhutan", "Gonpo Dorji", "འབྲུག་ཡུལ།", "མགོན་པོ་རྡོ་རྗེ།", 
+"Canada", "Celine Dion", "Canada", "Céline Dion", 
+"Canada - Nunavut (Inuktitut)", "Susan Aglukark", "ᓄᓇᕗᒻᒥᐅᑦ", "ᓱᓴᓐ ᐊᒡᓗᒃᑲᖅ", 
+"Democratic People's Rep. of Korea", "LEE Sol-Hee", "조선 민주주의 인민 공화국", "이설희", 
+"Denmark", "Soren Hauch-Fausboll", "Danmark", "Søren Hauch-Fausbøll", 
+"Denmark", "Soren Kierkegaard", "Danmark", "Søren Kierkegård", 
+"Egypt", "Abdel Halim Hafez", "ﻣﺼﺮ", "ﻋﺑﺪﺍﻠﺣﻟﻳﻢ ﺤﺎﻓﻅ", 
+"Egypt", "Om Kolthoum", "ﻣﺼﺮ", "ﺃﻡ ﻛﻟﺛﻭﻡ", 
+"Eritrea", "Berhane Zeray", "ብርሃነ ዘርኣይ", "ኤርትራ", 
+"Ethiopia", "Haile Gebreselassie", "ኃይሌ ገብረሥላሴ", "ኢትዮጵያ", 
+"France", "Gerard Depardieu", "France", "Gérard Depardieu", 
+"France", "Jean Reno", "France", "Jean Réno", 
+"France", "Camille Saint-Saens", "France", "Camille Saint-Saëns", 
+"France", "Mylene Demongeot", "France", "Mylène Demongeot", 
+"France", "Francois Truffaut", "France", "François Truffaut", 
+"France (Braille)", "Louis Braille", "⠋⠗⠁⠝⠉⠑", "⠇⠕⠥⠊⠎⠀<BR>⠃⠗⠁⠊⠇⠇⠑", 
+"Georgia", "Eduard Shevardnadze", "საქართველო", "ედუარდ შევარდნაძე", 
+"Germany", "Rudi Voeller", "Deutschland", "Rudi Völler", 
+"Germany", "Walter Schultheiss", "Deutschland", "Walter Schultheiß", 
+"Greece", "Giorgos Dalaras", "Ελλάς", "Γιώργος Νταλάρας", 
+"Iceland", "Bjork Gudmundsdottir", "Ísland", "Björk Guðmundsdóttir", 
+"India (Hindi)", "Madhuri Dixit", "भारत", "माधुरी दिछित", 
+"Ireland", "Sinead O'Connor", "Éire", "Sinéad O'Connor", 
+"Israel", "Yehoram Gaon", "ישראל", "יהורם גאון", 
+"Italy", "Fabrizio DeAndre", "Italia", "Fabrizio De André", 
+"Japan", "KUBOTA Toshinobu", "日本", "久保田    利伸", 
+"Japan", "HAYASHIBARA Megumi", "日本", "林原 めぐみ", 
+"Japan", "Mori Ogai", "日本", "森鷗外", 
+"Japan", "Tex Texin", "日本", "テクス テクサン", 
+"Norway", "Tor Age Bringsvaerd", "Noreg", "Tor Åge Bringsværd", 
+"Pakistan (Urdu)", "Nusrat Fatah Ali Khan", "پاکستان", "نصرت فتح علی خان", 
+"People's Rep. of China", "ZHANG Ziyi", "中国", "章子怡", 
+"People's Rep. of China", "WONG Faye", "中国", "王菲", 
+"Poland", "Lech Walesa", "Polska", "Lech Wałęsa", 
+"Puerto Rico", "Olga Tanon", "Puerto Rico", "Olga Tañón", 
+"Rep. of China", "Hsu Chi", "臺灣", "舒淇", 
+"Rep. of China", "Ang Lee", "臺灣", "李安", 
+"Rep. of Korea", "AHN Sung-Gi", "한민국", "안성기", 
+"Rep. of Korea", "SHIM Eun-Ha", "한민국", "심은하", 
+"Russia", "Mikhail Gorbachev", "Россия", "Михаил Горбачёв", 
+"Russia", "Boris Grebenshchikov", "Россия", "Борис Гребенщиков", 
+"Slovenia", "\"Frane \"\"Jezek\"\" Milcinski", "Slovenija", "Frane Milčinski - Ježek", 
+"Syracuse (Sicily)", "Archimedes", "Συρακούσα", "Ἀρχιμήδης", 
+"Thailand", "Thongchai McIntai", "ประเทศไทย", "ธงไชย แม็คอินไตย์", 
+"U.S.A.", "Brad Pitt", "U.S.A.", "Brad Pitt", 
+"Yugoslavia (Cyrillic)", "Djordje Balasevic", "Југославија", "Ђорђе Балашевић", 
+"Yugoslavia (Latin)", "Djordje Balasevic", "Jugoslavija", "Đorđe Balašević"]
+
+i18n_arr = transpose(reshape(i18n_data, 4, int(floor(length(i18n_data)/4))))
+i18n_buff = PipeBuffer()
+writedlm(i18n_buff, i18n_arr, ',')
+@test i18n_arr == readcsv(i18n_buff)
+


### PR DESCRIPTION
This adds a new option `ignore_empty_columns` for readdlm. Setting this to `true` results in adjoining column delimiters being squashed instead of resulting in a cell with empty string. This option can be used to read fixed width format data files.

e.g: with delimiter set to default (whitespace), and `ignore_empty_columns` set to false (default):

```
julia> iob = IOBuffer("  1  2  3  4\n 11 12 13 14");

julia> readdlm(iob)
2x9 Array{Any,2}:
 ""    " "   1.0    ""  2.0  ""  3.0  ""   4.0
 ""  11.0   12.0  13.0   ""  ""   ""  ""  14.0
```

With `ignore_empty_columns` set to true:

```
julia> iob = IOBuffer("  1  2  3  4\n 11 12 13 14");

julia> readdlm(iob; ignore_empty_columns=true)
2x4 Array{Float64,2}:
  1.0   2.0   3.0   4.0
 11.0  12.0  13.0  14.0
```

Also updated tests and docs for this option and added some new tests for `utf8` strings.
