### PR TITLE
Changed Dict(ks,vs) to behave like Dict(zip(ks,vs))

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -291,7 +291,7 @@ type Dict{K,V} <: Associative{K,V}
     end
     function Dict(ks, vs)
         # TODO: eventually replace with a call to Dict(zip(ks,vs))
-        n = length(ks)
+        n = min(length(ks), length(vs))
         h = Dict{K,V}()
         for i=1:n
             h[ks[i]] = vs[i]


### PR DESCRIPTION
Currently the lenght of `ks` is used to deterimine the numer of elements in the dictionary. After this, the shortest of `ks` and `vs` is used.

An alternative might be to throw an error if they are not equal length, but I think the same behavior as `Dict(zip(ks,vs))`, is the most intuitive.
