### PR TITLE
simple code coverage tool

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -85,6 +85,7 @@
 
 #include <string>
 #include <sstream>
+#include <fstream>
 #include <map>
 #include <vector>
 #include <set>
@@ -273,12 +274,6 @@ struct jl_varinfo_t {
 };
 
 // --- helpers for reloading IR image
-extern "C"
-void jl_set_imaging_mode(int stat)
-{
-    imaging_mode = !!stat;
-}
-
 static void jl_gen_llvm_gv_array();
 
 extern "C"
@@ -3080,6 +3075,8 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
     ctx.f = f;
 
     // step 5. set up debug info context and create first basic block
+    bool do_coverage =
+        jl_compileropts.code_coverage && lam->module != jl_base_module && lam->module != jl_core_module;
     jl_value_t *stmt = jl_cellref(stmts,0);
     std::string filename = "no file";
     char *dbgFuncName = lam->name->name;
@@ -3124,6 +3121,7 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
         // special value: if function name is empty, disable debug info
         builder.SetCurrentDebugLocation(noDbg);
         debug_enabled = false;
+        do_coverage = false;
     }
     else {
         // TODO: Fix when moving to new LLVM version
@@ -3423,6 +3421,8 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
     }
 
     // step 15. compile body statements
+    if (do_coverage)
+        coverageVisitLine(filename, lno);
     bool prevlabel = false;
     for(i=0; i < stmtslen; i++) {
         jl_value_t *stmt = jl_cellref(stmts,i);
@@ -3430,12 +3430,16 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
             int lno = jl_linenode_line(stmt);
             if (debug_enabled)
                 builder.SetCurrentDebugLocation(DebugLoc::get(lno, 1, (MDNode*)SP, NULL));
+            if (do_coverage)
+                coverageVisitLine(filename, lno);
             ctx.lineno = lno;
         }
         else if (jl_is_expr(stmt) && ((jl_expr_t*)stmt)->head == line_sym) {
             int lno = jl_unbox_long(jl_exprarg(stmt, 0));
             if (debug_enabled)
                 builder.SetCurrentDebugLocation(DebugLoc::get(lno, 1, (MDNode*)SP, NULL));
+            if (do_coverage)
+                coverageVisitLine(filename, lno);
             ctx.lineno = lno;
         }
         if (jl_is_labelnode(stmt)) {
@@ -3985,6 +3989,8 @@ static void init_julia_llvm_env(Module *m)
 
 extern "C" void jl_init_codegen(void)
 {
+    imaging_mode = jl_compileropts.build_path != NULL;
+
     InitializeNativeTarget();
     InitializeNativeTargetAsmPrinter();
     InitializeNativeTargetAsmParser();

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3421,8 +3421,6 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
     }
 
     // step 15. compile body statements
-    if (do_coverage)
-        coverageVisitLine(filename, lno);
     bool prevlabel = false;
     for(i=0; i < stmtslen; i++) {
         jl_value_t *stmt = jl_cellref(stmts,i);

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -173,7 +173,7 @@ static void coverageVisitLine(std::string filename, int line)
     if (vec.size() <= (size_t)line)
         vec.resize(line+1, NULL);
     if (vec[line] == NULL)
-        vec[line] = new GlobalVariable(*jl_Module, T_int64, false, GlobalVariable::ExternalLinkage,
+        vec[line] = new GlobalVariable(*jl_Module, T_int64, false, GlobalVariable::InternalLinkage,
                                        ConstantInt::get(T_int64,0), "lcnt");
     GlobalVariable *v = vec[line];
     builder.CreateStore(builder.CreateAdd(builder.CreateLoad(v),

--- a/src/dump.c
+++ b/src/dump.c
@@ -989,7 +989,7 @@ extern void jl_get_system_hooks(void);
 extern void jl_get_uv_hooks(void);
 
 DLLEXPORT
-void jl_restore_system_image(char *fname, int build_mode)
+void jl_restore_system_image(char *fname)
 {
     ios_t f;
     char *fpath = fname;
@@ -997,6 +997,7 @@ void jl_restore_system_image(char *fname, int build_mode)
         JL_PRINTF(JL_STDERR, "System image file \"%s\" not found\n", fname);
         exit(1);
     }
+    int build_mode = (jl_compileropts.build_path != NULL);
 #ifdef _OS_WINDOWS_
     //XXX: the windows linker forces our system image to be
     //     linked against only one dll, I picked libjulia-release

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -44,7 +44,7 @@ DLLEXPORT void jl_init(char *julia_home_dir)
 {
     libsupport_init();
     char *image_file = jl_locate_sysimg(julia_home_dir, JL_SYSTEM_IMAGE_PATH);
-    julia_init(image_file, 0);
+    julia_init(image_file);
     jl_set_const(jl_core_module, jl_symbol("JULIA_HOME"),
                  jl_cstr_to_string(julia_home));
     jl_module_export(jl_core_module, jl_symbol("JULIA_HOME"));

--- a/src/julia.h
+++ b/src/julia.h
@@ -885,8 +885,8 @@ jl_value_t *jl_no_method_error(jl_function_t *f, jl_value_t **args, size_t na);
 void jl_check_type_tuple(jl_tuple_t *t, jl_sym_t *name, const char *ctx);
 
 // initialization functions
-DLLEXPORT void julia_init(char *imageFile, int build_mode);
-DLLEXPORT int julia_trampoline(int argc, char *argv[], int (*pmain)(int ac,char *av[]), char* build_mode);
+DLLEXPORT void julia_init(char *imageFile);
+DLLEXPORT int julia_trampoline(int argc, char *argv[], int (*pmain)(int ac,char *av[]));
 void jl_init_types(void);
 void jl_init_box_caches(void);
 DLLEXPORT void jl_init_frontend(void);
@@ -897,9 +897,8 @@ void jl_init_tasks(void *stack, size_t ssize);
 void jl_init_serializer(void);
 
 DLLEXPORT void jl_save_system_image(char *fname);
-DLLEXPORT void jl_restore_system_image(char *fname, int build_mode);
+DLLEXPORT void jl_restore_system_image(char *fname);
 void jl_dump_bitcode(char *fname);
-void jl_set_imaging_mode(int stat);
 int32_t jl_get_llvm_gv(jl_value_t *p);
 
 // front end interface
@@ -1267,9 +1266,9 @@ size_t rec_backtrace_ctx_dwarf(ptrint_t *data, size_t maxsize, bt_context_t ctx)
 
 
 //IO objects
-extern DLLEXPORT uv_stream_t *jl_uv_stdin; 
-extern DLLEXPORT uv_stream_t * jl_uv_stdout;
-extern DLLEXPORT uv_stream_t * jl_uv_stderr;
+extern DLLEXPORT uv_stream_t *jl_uv_stdin;
+extern DLLEXPORT uv_stream_t *jl_uv_stdout;
+extern DLLEXPORT uv_stream_t *jl_uv_stderr;
 
 DLLEXPORT JL_STREAM *jl_stdout_stream(void);
 DLLEXPORT JL_STREAM *jl_stdin_stream(void);
@@ -1333,6 +1332,15 @@ void jl_longjmp(jmp_buf _Buf,int _Value);
     else                                                        \
         for (i__ca=1, jl_eh_restore_state(&__eh); i__ca; i__ca=0)
 #endif
+
+// Compiler options
+
+typedef struct {
+    char *build_path;
+    int code_coverage;
+} jl_compileropts_t;
+
+extern DLLEXPORT jl_compileropts_t jl_compileropts;
 
 #ifdef __cplusplus
 }

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -17,7 +17,6 @@
 #include "julia.h"
 #include "builtin_proto.h"
 
-char *julia_home = NULL;
 // current line number in a file
 int jl_lineno = 0;
 

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -16,13 +16,13 @@ static int lisp_prompt = 0;
 static char *program = NULL;
 char *image_file = NULL;
 int tab_width = 2;
-char *build_mode = NULL;
 
 static const char *usage = "julia [options] [program] [args...]\n";
 static const char *opts =
     " -v --version             Display version information\n"
+    " -h --help                Print this message\n"
     " -q --quiet               Quiet startup without banner\n"
-    " -H --home <dir>          Load files relative to <dir>\n"
+    " -H --home <dir>          Set location of julia executable\n"
     " -T --tab <size>          Set REPL tab width to <size>\n\n"
 
     " -e --eval <expr>         Evaluate <expr>\n"
@@ -39,17 +39,19 @@ static const char *opts =
     " -F                       Load ~/.juliarc.jl, then handle remaining inputs\n"
     " --color=yes|no           Enable or disable color text\n\n"
 
-    " -h --help                Print this message\n";
+    " --code-coverage          Count executions of source lines\n";
 
-void parse_opts(int *argcp, char ***argvp) {
+void parse_opts(int *argcp, char ***argvp)
+{
     static char* shortopts = "+H:T:hJ:";
     static struct option longopts[] = {
-        { "home",        required_argument, 0, 'H' },
-        { "tab",         required_argument, 0, 'T' },
-        { "build",       required_argument, 0, 'b' },
-        { "lisp",        no_argument,       &lisp_prompt, 1 },
-        { "help",        no_argument,       0, 'h' },
-        { "sysimage",    required_argument, 0, 'J' },
+        { "home",          required_argument, 0, 'H' },
+        { "tab",           required_argument, 0, 'T' },
+        { "build",         required_argument, 0, 'b' },
+        { "lisp",          no_argument,       &lisp_prompt, 1 },
+        { "help",          no_argument,       0, 'h' },
+        { "sysimage",      required_argument, 0, 'J' },
+        { "code-coverage", no_argument,       &jl_compileropts.code_coverage, 1 },
         { 0, 0, 0, 0 }
     };
     int c;
@@ -74,7 +76,7 @@ void parse_opts(int *argcp, char ***argvp) {
             tab_width = atoi(optarg);
             break;
         case 'b':
-            build_mode = strdup(optarg);
+            jl_compileropts.build_path = strdup(optarg);
             if (!imagepathspecified)
                 image_file = NULL;
             break;
@@ -289,6 +291,6 @@ int main(int argc, char *argv[])
         jl_lisp_prompt();
         return 0;
     }
-    julia_init(lisp_prompt ? NULL : image_file, build_mode!=NULL);
-    return julia_trampoline(argc, argv, true_main, build_mode);
+    julia_init(lisp_prompt ? NULL : image_file);
+    return julia_trampoline(argc, argv, true_main);
 }


### PR DESCRIPTION
To use the tool, pass --code-coverage. On exit, for each source file foo.jl for which we have data, write foo.jl.cov next to the original file, with execution counts in front of each line, or "-" if no data.

Also start consolidating compiler options into a jl_compileropts struct. I think we will want to add many more options, and this will make it easier.
