### PR TITLE
Extend LOAD_PATH via environment variable

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -315,9 +315,7 @@ function init_load_path()
     vers = "v$(VERSION.major).$(VERSION.minor)"
     global const LOAD_PATH = ByteString[]
     if haskey(ENV,"JULIA_LOAD_PATH")
-        @unix_only sep = ":"
-        @windows_only sep = ";"
-        prepend!(LOAD_PATH, split(ENV["JULIA_LOAD_PATH"], sep))
+        prepend!(LOAD_PATH, split(ENV["JULIA_LOAD_PATH"], @windows? ';' : ':'))    
     end
     push!(LOAD_PATH,abspath(JULIA_HOME,"..","local","share","julia","site",vers))
     push!(LOAD_PATH,abspath(JULIA_HOME,"..","share","julia","site",vers))

--- a/base/client.jl
+++ b/base/client.jl
@@ -314,13 +314,10 @@ isinteractive() = (is_interactive::Bool)
 function init_load_path()
     vers = "v$(VERSION.major).$(VERSION.minor)"
     global const LOAD_PATH = ByteString[]
-    julia_load_path = get(ENV, "JULIA_LOAD_PATH", "")
-    if !isempty(julia_load_path)
+    if haskey(ENV,"JULIA_LOAD_PATH")
         @unix_only sep = ":"
         @windows_only sep = ";"
-        for s in split(julia_load_path,sep)
-            push!(LOAD_PATH, s)
-        end
+        prepend!(LOAD_PATH, split(ENV["JULIA_LOAD_PATH"], sep))
     end
     push!(LOAD_PATH,abspath(JULIA_HOME,"..","local","share","julia","site",vers))
     push!(LOAD_PATH,abspath(JULIA_HOME,"..","share","julia","site",vers))

--- a/base/client.jl
+++ b/base/client.jl
@@ -313,10 +313,7 @@ isinteractive() = (is_interactive::Bool)
 
 function init_load_path()
     vers = "v$(VERSION.major).$(VERSION.minor)"
-    global const LOAD_PATH = ByteString[
-        abspath(JULIA_HOME,"..","local","share","julia","site",vers),
-        abspath(JULIA_HOME,"..","share","julia","site",vers)
-    ]
+    global const LOAD_PATH = ByteString[]
     julia_load_path = get(ENV, "JULIA_LOAD_PATH", "")
     if !isempty(julia_load_path)
         @unix_only sep = ":"
@@ -325,6 +322,8 @@ function init_load_path()
             push!(LOAD_PATH, s)
         end
     end
+    push!(LOAD_PATH,abspath(JULIA_HOME,"..","local","share","julia","site",vers))
+    push!(LOAD_PATH,abspath(JULIA_HOME,"..","share","julia","site",vers))
 end
 
 function init_sched()

--- a/base/client.jl
+++ b/base/client.jl
@@ -317,6 +317,14 @@ function init_load_path()
         abspath(JULIA_HOME,"..","local","share","julia","site",vers),
         abspath(JULIA_HOME,"..","share","julia","site",vers)
     ]
+    julia_load_path = get(ENV, "JULIA_LOAD_PATH", "")
+    if !isempty(julia_load_path)
+        @unix_only sep = ":"
+        @windows_only sep = ";"
+        for s in split(julia_load_path,sep)
+            push!(LOAD_PATH, s)
+        end
+    end
 end
 
 function init_sched()

--- a/doc/manual/modules.rst
+++ b/doc/manual/modules.rst
@@ -63,6 +63,18 @@ Method definitions are a bit special: they do not search modules named in
 elsewhere. For example, in ``MyModule`` above we wanted to add a method
 to the standard ``show`` function, so we had to write ``import Base.show``.
 
+Module paths
+------------
+
+The Julia variable LOAD_PATH contains the directories Julia searches for 
+modules. It can be extended using the ``push!`` method::
+
+    push!(LOAD_PATH, "/Path/To/My/Module/")
+
+Putting this statement to the ``~\.juliarc.jl`` file will extend LOAD_PATH 
+on every Julia startup. Alternatively, the Julia module load path can be
+extended by defining the environoment variable JULIA_LOAD_PATH and putting
+directories to it.
 
 Modules and files
 -----------------


### PR DESCRIPTION
This adds the possibility to extend LOAD_PATH using an environment variable. I know that this can also be done by using the .juliarc.jl but there are situations where setting an environment variable is easier.

I am not totally sure if I got the path separator right, or if there is already a definition for this.
