### PR TITLE
Travis tests with release and nightly

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -121,9 +121,13 @@ function travis(pkg::String; force::Bool=false)
           - clang
         notifications:
           email: false
+        env:
+          matrix: 
+            - JULIAVERSION="juliareleases" 
+            - JULIAVERSION="julianightlies" 
         before_install:
           - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-          - sudo add-apt-repository ppa:staticfloat/julianightlies -y
+          - sudo add-apt-repository ppa:staticfloat/\${JULIAVERSION} -y
           - sudo apt-get update -qq -y
           - sudo apt-get install libpcre3-dev julia -y
         script:


### PR DESCRIPTION
This PR changes the generated travis configuration for new packages created via `Pkg.generate(...)` to run tests with both the nightly and release julia packages. The current configuration only runts tests with julia nightly on travis. 

Some packages might not want to support both, and they can remove the relevant line. But I think it will do us good for the package ecosystem to take reasonable efforts at supporting the last released julia version.

It this lands, I will submit PR's for as many of the existing packages as I can.
