### PR TITLE
Update ucfirst, lcfirst

### DIFF
--- a/base/ascii.jl
+++ b/base/ascii.jl
@@ -36,7 +36,7 @@ function string(c::ASCIIString...)
 end
 
 function ucfirst(s::ASCIIString)
-    if 'a' <= s[1] <= 'z'
+    if length(s) > 0 && 'a' <= s[1] <= 'z'
         t = ASCIIString(copy(s.data))
         t.data[1] -= 32
         return t
@@ -44,7 +44,7 @@ function ucfirst(s::ASCIIString)
     return s
 end
 function lcfirst(s::ASCIIString)
-    if 'A' <= s[1] <= 'Z'
+    if length(s) > 0 && 'A' <= s[1] <= 'Z'
         t = ASCIIString(copy(s.data))
         t.data[1] += 32
         return t

--- a/base/string.jl
+++ b/base/string.jl
@@ -779,8 +779,12 @@ lowercase(c::Char) = convert(Char, ccall(:towlower, Cwchar_t, (Cwchar_t,), c))
 uppercase(s::String) = map(uppercase, s)
 lowercase(s::String) = map(lowercase, s)
 
-ucfirst(s::String) = isupper(s[1]) ? s : string(uppercase(s[1]),s[nextind(s,1):end])
-lcfirst(s::String) = islower(s[1]) ? s : string(lowercase(s[1]),s[nextind(s,1):end])
+function ucfirst(s::String)
+    length(s) < 1 || isupper(s[1]) ? s : string(uppercase(s[1]),s[nextind(s,1):end])
+end
+function lcfirst(s::String)
+    length(s) < 1 || islower(s[1]) ? s : string(lowercase(s[1]),s[nextind(s,1):end])
+end
 
 ## string map, filter, has ##
 

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -130,8 +130,12 @@ function string(a::ByteString...)
     UTF8String(data)
 end
 
-ucfirst(s::UTF8String) = isupper(s[1]) ? s : string(uppercase(s[1]), s[2:end])
-lcfirst(s::UTF8String) = islower(s[1]) ? s : string(lowercase(s[1]), s[2:end])
+function ucfirst(s::UTF8String)
+    length(s) < 1 || isupper(s[1]) ? s : string(uppercase(s[1]), s[2:end])
+end
+function lcfirst(s::UTF8String)
+    length(s) < 1 || islower(s[1]) ? s : string(lowercase(s[1]), s[2:end])
+end
 
 function reverse(s::UTF8String)
     out = similar(s.data)

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -130,8 +130,8 @@ function string(a::ByteString...)
     UTF8String(data)
 end
 
-ucfirst(s::UTF8String) = string(uppercase(s[1]), s[2:end])
-lcfirst(s::UTF8String) = string(lowercase(s[1]), s[2:end])
+ucfirst(s::UTF8String) = isupper(s[1]) ? s : string(uppercase(s[1]), s[2:end])
+lcfirst(s::UTF8String) = islower(s[1]) ? s : string(lowercase(s[1]), s[2:end])
 
 function reverse(s::UTF8String)
     out = similar(s.data)


### PR DESCRIPTION
UTF8 commit: Can't imagine priors being skewed enough for this not to be an improvement.

Empty strings commit: Overhead of 0-3% seems worth it.
