### PR TITLE
Faster bytestring for SubString{ByteString} and splitsub to split into substrings

### DIFF
--- a/base/help.jl
+++ b/base/help.jl
@@ -15,7 +15,7 @@ function clear_cache()
 end
 
 function decor_help_desc(func::String, mfunc::String, desc::String)
-    sd = split(desc, '\n')
+    sd = convert(Array{ByteString,1}, split(desc, '\n'))
     for i = 1:length(sd)
         if beginswith(sd[i], func)
             sd[i] = mfunc * sd[i][length(func)+1:end]

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -1494,7 +1494,7 @@
 
 ("Strings","Base","split","split(string, [chars, [limit,] [include_empty]])
 
-   Return an array of strings by splitting the given string on
+   Return an array of substrings by splitting the given string on
    occurrences of the given character delimiters, which may be
    specified in any of the formats allowed by \"search\"'s second
    argument (i.e. a single character, collection of characters,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1011,7 +1011,7 @@ Strings
 
 .. function:: split(string, [chars, [limit,] [include_empty]])
 
-   Return an array of strings by splitting the given string on occurrences of the given character delimiters, which may be specified in any of the formats allowed by ``search``'s second argument (i.e. a single character, collection of characters, string, or regular expression). If ``chars`` is omitted, it defaults to the set of all space characters, and ``include_empty`` is taken to be false. The last two arguments are also optional: they are are a maximum size for the result and a flag determining whether empty fields should be included in the result.
+   Return an array of substrings by splitting the given string on occurrences of the given character delimiters, which may be specified in any of the formats allowed by ``search``'s second argument (i.e. a single character, collection of characters, string, or regular expression). If ``chars`` is omitted, it defaults to the set of all space characters, and ``include_empty`` is taken to be false. The last two arguments are also optional: they are are a maximum size for the result and a flag determining whether empty fields should be included in the result.
 
 .. function:: rsplit(string, [chars, [limit,] [include_empty]])
 


### PR DESCRIPTION
This PR adds:
- a specialized faster `bytestring` method for substrings
- splitsub & rsplitsub methods that return substrings instead of strings

This can probably address #3667 and #1250. 
Code duplication could have been avoided by calling `splitsub` from `split` and converting the result into strings, but that would be less optimal.

Below are some time comparisons for these changes.

Time comparisons for `bytestring` (source below):

```
# with specialized bytestring for SubStrings:
elapsed time: 2.591398653 seconds (880001560 bytes allocated)
# without
elapsed time: 8.966283881 seconds (2640001560 bytes allocated)
```

Time comparisons for `splitsub` (source below):

```
splitsub:
elapsed time: 2.363995988 seconds (588436464 bytes allocated)
split:
elapsed time: 4.266700792 seconds (1068436464 bytes allocated)
```

A `splitsub` + `convert` results in:

```
elapsed time: 5.18554128 seconds (1468438024 bytes allocated)
```

Source for `bytestring` time comparison:

```
const nstr = 10^7
const lstr = 6

function makestr()
    iob = IOBuffer()
    for idx in 1:nstr
        write(iob, randstring(lstr))
        write(iob, ' ')
    end
    takebuf_string(iob)
end

function timeconvert()
    s = makestr()
    substrs = matchall(r"[^\s]+", s)
    gc()
    @time convert(Array{ASCIIString, 1}, substrs)
end

timeconvert()
```

Source for `splitsub` time comparison:

```
const nstr = 10^7
const lstr = 6

function makestr()
    iob = IOBuffer()
    for idx in 1:nstr
        write(iob, randstring(lstr))
        write(iob, ' ')
    end
    takebuf_string(iob)
end

function fss(str::String)
    gc()
    @time astr = splitsub(str)
end

function fs(str::String)
    gc()
    @time split(str)
end

function f()
    str = makestr()
    println("splitsub:")
    fss(str)
    println("split:")
    fs(str)
end

f()
```
