### PR TITLE
promotion: symmetrize promotion rules recursively with promote_type.

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -27,7 +27,6 @@ convert{T<:Real}(::Type{Complex{T}}, z::Complex) =
 convert{T<:Real}(::Type{T}, z::Complex) = (imag(z)==0 ? convert(T,real(z)) :
                                            throw(InexactError()))
 
-promote_rule{T<:Real}(::Type{Complex{T}}, ::Type{T}) = Complex{T}
 promote_rule{T<:Real,S<:Real}(::Type{Complex{T}}, ::Type{S}) =
     Complex{promote_type(T,S)}
 promote_rule{T<:Real,S<:Real}(::Type{Complex{T}}, ::Type{Complex{S}}) =

--- a/base/constants.jl
+++ b/base/constants.jl
@@ -4,19 +4,9 @@ immutable MathConst{sym} <: Real end
 
 show{sym}(io::IO, x::MathConst{sym}) = print(io, "$sym = $(string(float(x))[1:15])...")
 
-promote_rule{s,T<:Real}(::Type{MathConst{s}}, ::Type{T}) = Float64
-
-promote_rule{s}(::Type{MathConst{s}}, ::Type{Float64}) = Float64
 promote_rule{s}(::Type{MathConst{s}}, ::Type{Float32}) = Float32
-promote_rule{s}(::Type{MathConst{s}}, ::Type{BigInt}) = BigFloat
-promote_rule{s}(::Type{MathConst{s}}, ::Type{BigFloat}) = BigFloat
-promote_rule{s}(::Type{MathConst{s}}, ::Type{ImaginaryUnit}) = Complex{Float64}
-promote_rule{s}(::Type{ImaginaryUnit}, ::Type{MathConst{s}}) = Complex{Float64}
-
-promote_rule{s,T<:Integer}(::Type{MathConst{s}}, ::Type{Rational{T}}) =
-    promote_type(MathConst{s},T)
-promote_rule{s,T<:Real}(::Type{MathConst{s}}, ::Type{Complex{T}}) =
-    Complex{promote_type(MathConst{s},T)}
+promote_rule{s,t}(::Type{MathConst{s}}, ::Type{MathConst{t}}) = Float64
+promote_rule{s,T<:Number}(::Type{MathConst{s}}, ::Type{T}) = promote_type(Float64,T)
 
 convert(::Type{FloatingPoint}, x::MathConst) = float64(x)
 convert(::Type{Float16}, x::MathConst) = float16(float32(x))

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -112,7 +112,7 @@ promote_type{T,S}(::Type{T}, ::Type{S}) =
 
 promote_rule(T, S) = None
 
-promote_result(t,s,T,S) = typejoin(T,S)
+promote_result(t,s,T,S) = promote_type(T,S)
 # If no promote_rule is defined, both directions give None. In that
 # case use typejoin on the original types instead.
 promote_result{T,S}(::Type{T},::Type{S},::Type{None},::Type{None}) = typejoin(T, S)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -53,7 +53,6 @@ end
 convert(::Type{Rational}, x::Float64) = convert(Rational{Int64}, x)
 convert(::Type{Rational}, x::Float32) = convert(Rational{Int}, x)
 
-promote_rule{T<:Integer}(::Type{Rational{T}}, ::Type{T}) = Rational{T}
 promote_rule{T<:Integer,S<:Integer}(::Type{Rational{T}}, ::Type{S}) = Rational{promote_type(T,S)}
 promote_rule{T<:Integer,S<:Integer}(::Type{Rational{T}}, ::Type{Rational{S}}) = Rational{promote_type(T,S)}
 promote_rule{T<:Integer,S<:FloatingPoint}(::Type{Rational{T}}, ::Type{S}) = promote_type(T,S)

--- a/base/string.jl
+++ b/base/string.jl
@@ -814,13 +814,7 @@ end
 
 ## string promotion rules ##
 
-promote_rule(::Type{UTF8String} , ::Type{ASCIIString}) = UTF8String
-promote_rule(::Type{UTF8String} , ::Type{UTF16String}) = UTF8String
-promote_rule(::Type{ASCIIString}, ::Type{UTF16String}) = UTF8String
-promote_rule(::Type{UTF32String}, ::Type{UTF16String}) = UTF8String
-promote_rule(::Type{UTF8String} , ::Type{UTF32String}) = UTF8String
-promote_rule(::Type{ASCIIString}, ::Type{UTF32String}) = UTF8String
-promote_rule{T<:String}(::Type{RepString}, ::Type{T}) = RepString
+promote_rule{S<:String,T<:String}(::Type{S}, ::Type{T}) = UTF8String
 
 ## printing literal quoted string data ##
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1742,3 +1742,8 @@ for T = (Uint8,Int8,Uint16,Int16,Uint32,Int32,Uint64,Int64,Uint128,Int128)
         @test convert(T,n*(n^typemax(T))) == one(T)
     end
 end
+
+@test is(false*pi, 0.0)
+@test is(true*pi, float64(pi))
+@test is(pi*false, 0.0)
+@test is(pi*true, float64(pi))


### PR DESCRIPTION
If `promote_rule(T,S)` and `promote_rule(S,T)` disagree, call `promote_type` again on the results to get a single common answer. This can resolve cases where there is a conflict between two such rules, making the promotion system a bit more robust.
