### PR TITLE
No more ImaginaryUnit: `const im = Complex(false,true)`.

### DIFF
--- a/base/bool.jl
+++ b/base/bool.jl
@@ -42,6 +42,12 @@ abs2(x::Bool) = x
 ^(x::Bool, y::Bool) = x|!y
 ^(x::Integer, y::Bool) = y ? x : one(x)
 
+function *{T<:Number}(x::Bool, y::T)
+    S = promote_type(Bool,T)
+    ifelse(x, convert(S,y), convert(S,0))
+end
+*(y::Number, x::Bool) = x * y
+
 div(x::Bool, y::Bool) = y ? x : throw(DivideError())
 fld(x::Bool, y::Bool) = div(x,y)
 rem(x::Bool, y::Bool) = y ? false : throw(DivideError())

--- a/base/bool.jl
+++ b/base/bool.jl
@@ -44,7 +44,9 @@ abs2(x::Bool) = x
 
 function *{T<:Number}(x::Bool, y::T)
     S = promote_type(Bool,T)
-    ifelse(x, convert(S,y), convert(S,0))
+    z = convert(S,0)
+    z = ifelse(signbit(y)==0, z, -z)
+    ifelse(x, convert(S,y), z)
 end
 *(y::Number, x::Bool) = x * y
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -59,7 +59,6 @@ isfinite(z::Complex) = isfinite(real(z)) && isfinite(imag(z))
 reim(z) = (real(z), imag(z))
 
 function complex_show(io::IO, z::Complex, compact::Bool)
-    z === im && return print(io, "im")
     r, i = reim(z)
     compact ? showcompact(io,r) : show(io,r)
     if signbit(i)==1 && !isnan(i)
@@ -74,6 +73,8 @@ function complex_show(io::IO, z::Complex, compact::Bool)
     end
     print(io, "im")
 end
+complex_show(io::IO, z::Complex{Bool}, compact::Bool) =
+    print(io, z == im ? "im" : "Complex($(z.re),$(z.im))")
 show(io::IO, z::Complex) = complex_show(io, z, false)
 showcompact(io::IO, z::Complex) = complex_show(io, z, true)
 
@@ -115,8 +116,8 @@ sign(z::Complex) = z/abs(z)
                                     real(z) * imag(w) + imag(z) * real(w))
 
 # adding or multiplying real & complex is common
-*(x::Bool, z::Complex) = ifelse(x,z,zero(z))
-*(z::Complex, x::Bool) = x * z
+*(x::Bool, z::Complex) = ifelse(x, z, zero(z))
+*(z::Complex, x::Bool) = ifelse(x, z, zero(z))
 *(x::Real, z::Complex) = complex(x * real(z), x * imag(z))
 *(z::Complex, x::Real) = complex(x * real(z), x * imag(z))
 +(x::Real, z::Complex) = complex(x + real(z), imag(z))

--- a/base/constants.jl
+++ b/base/constants.jl
@@ -18,9 +18,6 @@ for op in {:+, :-, :*, :/, :^}
     @eval $op(x::MathConst, y::MathConst) = $op(float64(x),float64(y))
 end
 
-*(x::MathConst, i::ImaginaryUnit) = float64(x)*i
-*(i::ImaginaryUnit, x::MathConst) = i*float64(x)
-
 macro math_const(sym, val, def)
     esym = esc(sym)
     qsym = esc(Expr(:quote, sym))

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -51,7 +51,6 @@ export
     GeneralizedSVD,
     Hermitian,
     Hessenberg,
-    ImaginaryUnit,
     InsertionSort,
     IntSet,
     IO,


### PR DESCRIPTION
This change requires giving multiplition by Bools special behavior. Approximately, `true * x = x` and `false * x = zero(x)`, but a bit complicated for the sake of promotion, the only non-trivial example of which is `Bool * MathConst`, which is promoted to Float64.

Idea originally due to @GunnarFarneback:
- https://groups.google.com/forum/#!topic/julia-dev/VkGrqnrAdaY
- https://github.com/JuliaLang/julia/issues/2980
- https://github.com/JuliaLang/julia/issues/3728

Compare against https://github.com/JuliaLang/julia/pull/5313.
