### PR TITLE
SharedArray - more exact array indexing definitions

### DIFF
--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -146,15 +146,18 @@ function deserialize{T,N}(s, t::Type{SharedArray{T,N}})
     sa
 end
 
-convert(::Type{Array}, sa::SharedArray) = sa.loc_shmarr
+convert(::Type{Array}, S::SharedArray) = S.loc_shmarr
 
-# avoiding ambiguity warnings
-getindex(sa::SharedArray, x::Real) = getindex(sa.loc_shmarr, x)
-getindex(sa::SharedArray, x::AbstractArray) = getindex(sa.loc_shmarr, x)
+# # pass through getindex and setindex! - they always work on the complete array unlike DArrays
+getindex(S::SharedArray) = getindex(S.loc_shmarr)
+getindex(S::SharedArray,I::AbstractArray) = getindex(S.loc_shmarr,I)
+getindex(S::SharedArray,I::Range1) = getindex(S.loc_shmarr,I)
+getindex(S::SharedArray,I::Real...) = getindex(S.loc_shmarr, I...)
 
-# pass through getindex and setindex! - they always work on the complete array unlike DArrays
-getindex(sa::SharedArray, args...) = getindex(sa.loc_shmarr, args...)
-setindex!(sa::SharedArray, args...) = (setindex!(sa.loc_shmarr, args...); sa)
+setindex!(S::SharedArray, x) = (setindex!(S.loc_shmarr, x); S)
+setindex!(S::SharedArray, x, I::Real...) = (setindex!(S.loc_shmarr, x, I...); S)
+setindex!(S::SharedArray, x, I::AbstractArray) = (setindex!(S.loc_shmarr, x, I); S)
+setindex!(S::SharedArray, x, I::Range1) = (setindex!(S.loc_shmarr, x, I); S)
 
 # convenience constructors
 function shmem_fill(v, dims; kwargs...) 

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -549,17 +549,16 @@ Shared Arrays use system shared memory to map the same array across many process
 
 The constructor for a shared array is of the form 
   ``SharedArray(T::Type, dims::NTuple; init=false, pids=workers())``
-which creates a shared array of type ``T``  and size ``dims`` across the processes
+which creates a shared array of a bitstype ``T``  and size ``dims`` across the processes
 specified by ``pids`` - all of which have to be on the same host. 
 
 If an ``init`` function of the type ``initfn(S::SharedArray)`` is specified, 
 it is called on all the participating workers. 
 
-Unlike distributed arrays, a shareds array is accessible only from those participating workers 
+Unlike distributed arrays, a shared array is accessible only from those participating workers 
 specified by the ``pids`` named argument (and the creating process too, if it is on the same host).
   
-Indexing into a shared array (both for setting as well as accessing values) is the same as 
-for a regular array.
+SharedArray indexing (assignment and accessing values) is just like a regular array.
 
 
     

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4521,7 +4521,7 @@ Shared Arrays (EXPERIMENTAL FEATURE)
 
 .. function:: SharedArray(T::Type, dims::NTuple; init=false, pids=workers())
 
-    Construct a SharedArray of type ``T``  and size ``dims`` across the processes
+    Construct a SharedArray of a bitstype ``T``  and size ``dims`` across the processes
     specified by ``pids`` - all of which have to be on the same host. 
 
     If an ``init`` function of the type ``initfn(S::SharedArray)`` is specified, 
@@ -4541,7 +4541,7 @@ Shared Arrays (EXPERIMENTAL FEATURE)
     across participating workers. Can be used as a simple work partitioning scheme.
     
 
-.. function:: procs(sa::SharedArray)
+.. function:: procs(S::SharedArray)
 
    Get the vector of processes that have mapped the shared array 
    


### PR DESCRIPTION
Changed the function prototypes for SharedArray setindex! and getindex to be more exact, in order to avoid ambiguity warnings in other packages.
