### PR TITLE
conditional testing of SharedArray

### DIFF
--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -58,7 +58,11 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=workers())
         end
         
         # All good, immediately unlink the segment.
-        remotecall(shmmem_create_pid, () -> begin shm_unlink(shm_seg_name); nothing end)  
+        if onlocalhost
+            shm_unlink(shm_seg_name)
+        else
+            remotecall(shmmem_create_pid, () -> begin shm_unlink(shm_seg_name); nothing end)  
+        end
         shm_seg_name = "" 
         
         sa = SharedArray{T,N}(dims, pids, refs)

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -21,45 +21,46 @@ a = convert(Array, d)
 @test fetch(@spawnat id_other localpart(d)[1,1]) == d[1,101]
 
 
-@unix_only begin
-# SharedArray tests
-dims = (20,20,20)
-d = Base.shmem_rand(1:100, dims)
-a = convert(Array, d)
+if haskey(ENV, "TEST_SHARED_ARRAY")
+    @unix_only begin
+    # SharedArray tests
+    dims = (20,20,20)
+    d = Base.shmem_rand(1:100, dims)
+    a = convert(Array, d)
 
-partsums = Array(Int, length(procs(d)))
-@sync begin
-    for (i, p) in enumerate(procs(d))
-        @async partsums[i] = remotecall_fetch(p, D->sum(D.loc_subarr_1d), d)
+    partsums = Array(Int, length(procs(d)))
+    @sync begin
+        for (i, p) in enumerate(procs(d))
+            @async partsums[i] = remotecall_fetch(p, D->sum(D.loc_subarr_1d), d)
+        end
     end
+    @test sum(a) == sum(partsums)
+
+    d = Base.shmem_rand(dims)
+    for p in procs(d)
+        idxes_in_p = remotecall_fetch(p, D -> parentindexes(D.loc_subarr_1d)[1], d)
+        idxf = first(idxes_in_p)
+        idxl = last(idxes_in_p)
+        d[idxf] = float64(idxf)
+        rv = remotecall_fetch(p, (D,idxf,idxl) -> begin assert(D[idxf] == float64(idxf)); D[idxl] = float64(idxl); D[idxl];  end, d,idxf,idxl)
+        @test d[idxl] == rv
+    end
+
+    @test ones(10, 10, 10) == Base.shmem_fill(1.0, (10,10,10))
+    @test zeros(Int32, 10, 10, 10) == Base.shmem_fill(0, (10,10,10))
+
+    d = SharedArray(Int, dims; init = D->fill!(D.loc_subarr_1d, myid()))
+    for p in procs(d)
+        idxes_in_p = remotecall_fetch(p, D -> parentindexes(D.loc_subarr_1d)[1], d)
+        idxf = first(idxes_in_p)
+        idxl = last(idxes_in_p)
+        @test d[idxf] == p 
+        @test d[idxl] == p 
+    end
+
+
+    end # @unix_only(SharedArray tests)
 end
-@test sum(a) == sum(partsums)
-
-d = Base.shmem_rand(dims)
-for p in procs(d)
-    idxes_in_p = remotecall_fetch(p, D -> parentindexes(D.loc_subarr_1d)[1], d)
-    idxf = first(idxes_in_p)
-    idxl = last(idxes_in_p)
-    d[idxf] = float64(idxf)
-    rv = remotecall_fetch(p, (D,idxf,idxl) -> begin assert(D[idxf] == float64(idxf)); D[idxl] = float64(idxl); D[idxl];  end, d,idxf,idxl)
-    @test d[idxl] == rv
-end
-
-@test ones(10, 10, 10) == Base.shmem_fill(1.0, (10,10,10))
-@test zeros(Int32, 10, 10, 10) == Base.shmem_fill(0, (10,10,10))
-
-d = SharedArray(Int, dims; init = D->fill!(D.loc_subarr_1d, myid()))
-for p in procs(d)
-    idxes_in_p = remotecall_fetch(p, D -> parentindexes(D.loc_subarr_1d)[1], d)
-    idxf = first(idxes_in_p)
-    idxl = last(idxes_in_p)
-    @test d[idxf] == p 
-    @test d[idxl] == p 
-end
-
-
-end # @unix_only(SharedArray tests)
-
 
 
 # Test @parallel load balancing - all processors should get either M or M+1


### PR DESCRIPTION
In certain cases, the shared memory segments created were not being unlinked cleanly. I have made the sharedarray test conditional for now.

On linux, you can manually do a `rm /dev/shm/jl*` . On OSX you will need a reboot. Sorry about this, calling shm_unlink from a remotecall seems to be ineffective. I have disabled the tests till it is fixed.   
