### PR TITLE
remove explicit paths, and gnutar assumption

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -222,6 +222,8 @@ JCFLAGS += -fsanitize=address -mllvm -asan-stack=0
 LDFLAGS += -fsanitize=address
 endif
 
+TAR=`which gtar || which tar`
+
 # ===========================================================================
 
 BUILD_MACHINE := $(shell $(HOSTCC) -dumpmachine)

--- a/Make.inc
+++ b/Make.inc
@@ -223,6 +223,10 @@ LDFLAGS += -fsanitize=address
 endif
 
 TAR=`which gtar || which tar`
+TAR_TEST := $(shell $(TAR) --help 2>&1  | grep strip-components)
+ifeq (,$(findstring components,$(TAR_TEST)))
+$(error "please install either GNU tar or bsdtar")
+endif
 
 # ===========================================================================
 

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ ifeq ($(OS), WINNT)
 	./dist-extras/7z a -mx9 "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" julia-installer.exe
 	cat ./dist-extras/7zS.sfx ./contrib/windows/7zSFX-config.txt "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" > "Julia Installer ${VERSDIR}-${ARCH}.exe"
 else
-	tar zcvf julia-$(JULIA_COMMIT)-$(OS)-$(ARCH).tar.gz julia-$(JULIA_COMMIT)
+	$(TAR) zcvf julia-$(JULIA_COMMIT)-$(OS)-$(ARCH).tar.gz julia-$(JULIA_COMMIT)
 endif
 	rm -fr julia-$(JULIA_COMMIT)
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -3,12 +3,6 @@ JULIAHOME = $(abspath ..)
 include $(JULIAHOME)/Make.inc
 include Versions.make
 
-ifeq ($(OS), OpenBSD)
-TAR=`which gtar`
-else
-TAR=`which tar`
-endif
-
 CONFIGURE_COMMON = --prefix=$(abspath $(BUILD)) --build=$(BUILD_MACHINE)
 ifneq ($(XC_HOST),)
 CONFIGURE_COMMON += --host=$(XC_HOST)
@@ -449,7 +443,7 @@ readline-$(READLINE_VER).tar.gz:
 	$(JLDOWNLOAD) $@ http://ftp.gnu.org/gnu/readline/$@
 	touch -c $@
 readline-$(READLINE_VER)/configure: readline-$(READLINE_VER).tar.gz
-	tar zxf $<
+	$(TAR) zxf $<
 	cd readline-$(READLINE_VER) && patch -p0 < ../readline62-001
 	cd readline-$(READLINE_VER) && patch -p0 < ../readline62-002
 	cd readline-$(READLINE_VER) && patch -p0 < ../readline62-003
@@ -558,7 +552,7 @@ PCRE_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libpcre.$(SHLIB_EXT)
 pcre-$(PCRE_VER).tar.bz2:
 	$(JLDOWNLOAD) $@ http://sourceforge.net/projects/pcre/files/pcre/$(PCRE_VER)/$@/download
 pcre-$(PCRE_VER)/configure: pcre-$(PCRE_VER).tar.bz2
-	tar jxf $<
+	$(TAR) jxf $<
 	touch -c $@
 pcre-$(PCRE_VER)/config.status: pcre-$(PCRE_VER)/configure
 	cd pcre-$(PCRE_VER) && \
@@ -1001,7 +995,7 @@ endif
 lapack-$(LAPACK_VER).tgz:
 	$(JLDOWNLOAD) $@ http://www.netlib.org/lapack/$@
 lapack-$(LAPACK_VER)/Makefile: lapack-$(LAPACK_VER).tgz
-	tar zxf $<
+	$(TAR) zxf $<
 	cd lapack-$(LAPACK_VER)/SRC && patch < ../../dlasd4-lapack-3.4.2.patch && patch < ../../slasd4-lapack-3.4.2.patch
 	touch -c $@
 ifeq ($(USE_SYSTEM_BLAS), 0)
@@ -1063,7 +1057,7 @@ arpack-ng-$(ARPACK_VER).tar.gz:
 	$(JLDOWNLOAD) $@ http://forge.scilab.org/index.php/p/arpack-ng/downloads/get/arpack-ng-$(ARPACK_VER).tar.gz
 	touch -c $@
 arpack-ng-$(ARPACK_VER)/configure: arpack-ng-$(ARPACK_VER).tar.gz
-	tar zxf $< 
+	$(TAR) zxf $< 
 	touch -c $@
 
 ifeq ($(USE_ATLAS), 1)
@@ -1393,7 +1387,7 @@ LIBUNWIND_CFLAGS = $(CFLAGS) -U_FORTIFY_SOURCE $(fPIC)
 libunwind-$(UNWIND_VER).tar.gz:
 	$(JLDOWNLOAD) $@ http://download.savannah.gnu.org/releases/libunwind/$@ 
 libunwind-$(UNWIND_VER)/configure: libunwind-$(UNWIND_VER).tar.gz
-	tar xfz $<
+	$(TAR) xfz $<
 	touch -c $@
 libunwind-$(UNWIND_VER)/config.status: libunwind-$(UNWIND_VER)/configure
 	cd libunwind-$(UNWIND_VER) && \
@@ -1438,7 +1432,7 @@ libosxunwind-$(OSXUNWIND_VER).tar.gz:
 	$(JLDOWNLOAD) $@ https://github.com/JuliaLang/libosxunwind/archive/v$(OSXUNWIND_VER).tar.gz
 
 libosxunwind-$(OSXUNWIND_VER)/Makefile: libosxunwind-$(OSXUNWIND_VER).tar.gz
-	tar xfz $<
+	$(TAR) xfz $<
 	touch -c $@
 
 $(OSXUNWIND_OBJ_SOURCE): libosxunwind-$(OSXUNWIND_VER)/Makefile
@@ -1469,7 +1463,7 @@ GMP_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libgmp.$(SHLIB_EXT)
 gmp-$(GMP_VER).tar.bz2:
 	$(JLDOWNLOAD) $@ ftp://ftp.gmplib.org/pub/gmp-$(GMP_VER)/$@
 gmp-$(GMP_VER)/configure: gmp-$(GMP_VER).tar.bz2
-	tar jxf $<
+	$(TAR) jxf $<
 	touch -c $@
 gmp-$(GMP_VER)/config.status: gmp-$(GMP_VER)/configure
 	cd gmp-$(GMP_VER) && \
@@ -1518,7 +1512,7 @@ endif
 mpfr-$(MPFR_VER).tar.bz2:
 	$(JLDOWNLOAD) $@ http://www.mpfr.org/mpfr-current/$@
 mpfr-$(MPFR_VER)/configure: mpfr-$(MPFR_VER).tar.bz2
-	tar jxf $<
+	$(TAR) jxf $<
 	touch -c $@
 mpfr-$(MPFR_VER)/config.status: mpfr-$(MPFR_VER)/configure $(MPFR_DEPS)
 	cd mpfr-$(MPFR_VER) && \
@@ -1566,7 +1560,7 @@ endif
 zlib-$(ZLIB_VER).tar.gz:
 	$(JLDOWNLOAD) $@ http://zlib.net/$@
 zlib-$(ZLIB_VER)/configure: zlib-$(ZLIB_VER).tar.gz
-	tar zxf $<
+	$(TAR) zxf $<
 	touch -c $@
 zlib-$(ZLIB_VER)/config.status: zlib-$(ZLIB_VER)/configure
 ifeq ($(OS), WINNT)
@@ -1618,7 +1612,7 @@ install-patchelf: $(PATCHELF_TARGET)
 patchelf-$(PATCHELF_VER).tar.bz2:
 	$(JLDOWNLOAD) $@ http://hydra.nixos.org/build/1524660/download/2/$@
 patchelf-$(PATCHELF_VER)/configure: patchelf-$(PATCHELF_VER).tar.bz2
-	tar jxf $<
+	$(TAR) jxf $<
 	touch -c $@
 patchelf-$(PATCHELF_VER)/config.status: patchelf-$(PATCHELF_VER)/configure
 	cd patchelf-$(PATCHELF_VER) && \
@@ -1657,7 +1651,7 @@ GIT_TARGET = $(BUILD)/git
 git-$(GIT_VER).tar.gz:
 	$(JLDOWNLOAD) $@ http://git-core.googlecode.com/files/$@
 git-$(GIT_VER)/configure: git-$(GIT_VER).tar.gz
-	tar zxf $<
+	$(TAR) zxf $<
 	touch -c $@
 git-$(GIT_VER)/config.status: git-$(GIT_VER)/configure
 	cd git-$(GIT_VER) && \

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -3,6 +3,12 @@ JULIAHOME = $(abspath ..)
 include $(JULIAHOME)/Make.inc
 include Versions.make
 
+ifeq ($(OS), OpenBSD)
+TAR=`which gtar`
+else
+TAR=`which tar`
+endif
+
 CONFIGURE_COMMON = --prefix=$(abspath $(BUILD)) --build=$(BUILD_MACHINE)
 ifneq ($(XC_HOST),)
 CONFIGURE_COMMON += --host=$(XC_HOST)
@@ -298,7 +304,7 @@ endif
 llvm-$(LLVM_VER)/configure: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR)
 ifneq ($(LLVM_VER),svn)
 	mkdir -p llvm-$(LLVM_VER) && \
-	tar -C llvm-$(LLVM_VER) --strip-components 1 -xf $(LLVM_TAR)
+	$(TAR) -C llvm-$(LLVM_VER) --strip-components 1 -xf $(LLVM_TAR)
 else
 	([ ! -d llvm-$(LLVM_VER) ] && \
 		git clone http://llvm.org/git/llvm.git llvm-$(LLVM_VER) ) || \
@@ -312,7 +318,7 @@ endif
 ifneq ($(LLVM_VER),svn)
 ifneq ($(LLVM_CLANG_TAR),)
 	mkdir -p llvm-$(LLVM_VER)/tools/clang && \
-	tar -C llvm-$(LLVM_VER)/tools/clang --strip-components 1 -xf $(LLVM_CLANG_TAR)
+	$(TAR) -C llvm-$(LLVM_VER)/tools/clang --strip-components 1 -xf $(LLVM_CLANG_TAR)
 endif
 else
 ifneq ($(BUILD_LLVM_CLANG),)
@@ -325,11 +331,11 @@ endif
 ifneq ($(LLVM_VER),svn)
 ifneq ($(LLVM_COMPILER_RT_TAR),)
 	mkdir -p llvm-$(LLVM_VER)/projects/compiler-rt && \
-	tar -C llvm-$(LLVM_VER)/projects/compiler-rt --strip-components 1 -xf $(LLVM_COMPILER_RT_TAR)
+	$(TAR) -C llvm-$(LLVM_VER)/projects/compiler-rt --strip-components 1 -xf $(LLVM_COMPILER_RT_TAR)
 endif
 ifneq ($(LLVM_LIBCXX_TAR),)
 	mkdir -p llvm-$(LLVM_VER)/projects/libcxx && \
-	tar -C llvm-$(LLVM_VER)/projects/libcxx --strip-components 1 -xf $(LLVM_LIBCXX_TAR)
+	$(TAR) -C llvm-$(LLVM_VER)/projects/libcxx --strip-components 1 -xf $(LLVM_LIBCXX_TAR)
 endif
 else
 ifneq ($(BUILD_LLVM_CLANG),)
@@ -420,7 +426,7 @@ readline-$(READLINE_VER).tar.gz:
 	touch -c $@
 readline-$(READLINE_VER)/configure: readline-$(READLINE_VER).tar.gz
 	mkdir readline-$(READLINE_VER)
-	tar -C readline-$(READLINE_VER) --strip-components 1 -xf $<
+	$(TAR) -C readline-$(READLINE_VER) --strip-components 1 -xf $<
 	touch -c $@
 $(READLINE_OBJ_TARGET): $(READLINE_OBJ_SOURCE) readline-$(READLINE_VER)/checked
 	$(MAKE) -C readline-$(READLINE_VER) $(READLINE_CFLAGS) install
@@ -594,7 +600,7 @@ double-conversion-$(GRISU_VER).tar.gz:
 	touch -c $@
 double-conversion-$(GRISU_VER)/Makefile: double-conversion-$(GRISU_VER).tar.gz
 	mkdir -p double-conversion-$(GRISU_VER) && \
-	tar -C double-conversion-$(GRISU_VER) --strip-components 1 -xf double-conversion-$(GRISU_VER).tar.gz
+	$(TAR) -C double-conversion-$(GRISU_VER) --strip-components 1 -xf double-conversion-$(GRISU_VER).tar.gz
 	touch -c $@
 
 ifeq ($(USE_SYSTEM_GRISU), 0)
@@ -726,7 +732,7 @@ random/dsfmt-$(DSFMT_VER).tar.gz:
 random/dsfmt-$(DSFMT_VER)/config.status: random/dsfmt-$(DSFMT_VER).tar.gz
 	cd random && \
 	mkdir -p dsfmt-$(DSFMT_VER) && \
-	tar -C dsfmt-$(DSFMT_VER) --strip-components 1 -xf dsfmt-$(DSFMT_VER).tar.gz && \
+	$(TAR) -C dsfmt-$(DSFMT_VER) --strip-components 1 -xf dsfmt-$(DSFMT_VER).tar.gz && \
 	cd dsfmt-$(DSFMT_VER) && patch < ../dSFMT.h.patch && patch < ../dSFMT.c.patch
 	echo 1 > $@
 $(LIBRANDOM_OBJ_SOURCE): random/jl_random.c random/randmtzig.c random/dsfmt-$(DSFMT_VER)/config.status
@@ -842,6 +848,8 @@ else ifeq ($(ARCH),i686)
 OPENBLAS_BUILD_OPTS += BINARY=32
 else ifeq ($(ARCH),x86_64)
 OPENBLAS_BUILD_OPTS += BINARY=64
+else ifeq ($(ARCH),amd64)
+OPENBLAS_BUILD_OPTS += BINARY=64
 else
 $(error "unknown arch for openblas cross-compile")
 endif
@@ -862,7 +870,7 @@ openblas-$(OPENBLAS_VER).tar.gz:
 	$(JLDOWNLOAD) $@ https://github.com/xianyi/OpenBLAS/tarball/$(OPENBLAS_VER) 
 openblas-$(OPENBLAS_VER)/config.status: openblas-$(OPENBLAS_VER).tar.gz
 	mkdir -p openblas-$(OPENBLAS_VER) && \
-	tar -C openblas-$(OPENBLAS_VER) --strip-components 1 -xf $<
+	$(TAR) -C openblas-$(OPENBLAS_VER) --strip-components 1 -xf $<
 	perl -i -ple 's/^\s*(EXTRALIB\s*\+=\s*-lSystemStubs)\s*$$/# $$1/g' $@.system
 ifeq  ($(OPENBLAS_VER),v0.2.8)
 	cd openblas-$(OPENBLAS_VER)/lapack-netlib/SRC && \
@@ -1135,7 +1143,7 @@ fftw-$(FFTW_VER).tar.gz:
 
 fftw-$(FFTW_VER)-single/configure: fftw-$(FFTW_VER).tar.gz
 	mkdir -p fftw-$(FFTW_VER)-single && \
-	tar -C fftw-$(FFTW_VER)-single --strip-components 1 -xf $<
+	$(TAR) -C fftw-$(FFTW_VER)-single --strip-components 1 -xf $<
 ifeq ($(OS),WINNT)
 	patch fftw-$(FFTW_VER)-single/configure < fftw-config-nopthreads.patch
 	patch fftw-$(FFTW_VER)-single/kernel/ifftw.h < ifftw.h.patch
@@ -1172,7 +1180,7 @@ endif
 
 fftw-$(FFTW_VER)-double/configure: fftw-$(FFTW_VER).tar.gz
 	mkdir -p fftw-$(FFTW_VER)-double && \
-	tar -C fftw-$(FFTW_VER)-double --strip-components 1 -xf $<
+	$(TAR) -C fftw-$(FFTW_VER)-double --strip-components 1 -xf $<
 ifeq ($(OS),WINNT)
 	patch fftw-$(FFTW_VER)-double/configure < fftw-config-nopthreads.patch
 	patch fftw-$(FFTW_VER)-double/kernel/ifftw.h < ifftw.h.patch
@@ -1246,7 +1254,7 @@ utf8proc-v$(UTF8PROC_VER).tar.gz:
 	$(JLDOWNLOAD) $@ http://www.public-software-group.org/pub/projects/utf8proc/v$(UTF8PROC_VER)/$@
 
 utf8proc-v$(UTF8PROC_VER)/Makefile: utf8proc-v$(UTF8PROC_VER).tar.gz
-	tar -xzf $<
+	$(TAR) -xzf $<
 	patch $@ < utf8proc_Makefile.patch
 	touch -c $@
 
@@ -1297,7 +1305,7 @@ SuiteSparse-$(SUITESPARSE_VER).tar.gz:
 	$(JLDOWNLOAD) $@ http://www.cise.ufl.edu/research/sparse/SuiteSparse/$@ 
 SuiteSparse-$(SUITESPARSE_VER)/Makefile: SuiteSparse-$(SUITESPARSE_VER).tar.gz
 	mkdir -p SuiteSparse-$(SUITESPARSE_VER)
-	tar -C SuiteSparse-$(SUITESPARSE_VER) --strip-components 1 -zxf $<
+	$(TAR) -C SuiteSparse-$(SUITESPARSE_VER) --strip-components 1 -zxf $<
 	touch -c $@
 
 ifeq ($(USE_ATLAS), 1)

--- a/deps/jldownload
+++ b/deps/jldownload
@@ -5,9 +5,9 @@
 
 MIRROR_HOST=http://d304tytmzqn1fl.cloudfront.net
 
-WGET=/usr/bin/wget
-CURL=/usr/bin/curl
-FETCH=/usr/bin/fetch
+WGET=$(which wget)
+CURL=$(which curl)
+FETCH=$(which fetch)
 
 TIMEOUT=15 # seconds
 WGET_OPTS="--no-check-certificate --tries=1 --timeout=$TIMEOUT"


### PR DESCRIPTION
This diff brings julia closer to building on OpenBSD which does not have gnutar installed by default. 

wget and friends are all in (usually) /usr/local/bin - so we ask the system where it has them. They could also be replaced with ftp(1) which supports http
