### PR TITLE
RFC: Add `get!` for Dicts (addresses #1529)

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -529,6 +529,21 @@ function get!{K,V}(h::Dict{K,V}, key0, default)
     return v
 end
 
+function get!{K,V}(default::Function, h::Dict{K,V}, key0)
+    key = convert(K,key0)
+    if !isequal(key,key0)
+        error(key0, " is not a valid key for type ", K)
+    end
+
+    index = ht_keyindex2(h, key)
+
+    index > 0 && return h.vals[index]
+
+    v = convert(V,  default())
+    _setindex!(h, v, key, -index)
+    return v
+end
+
 function getindex{K,V}(h::Dict{K,V}, key)
     index = ht_keyindex(h, key)
     return (index<0) ? throw(KeyError(key)) : h.vals[index]::V

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -554,6 +554,11 @@ function get{K,V}(h::Dict{K,V}, key, deflt)
     return (index<0) ? deflt : h.vals[index]::V
 end
 
+function get{K,V}(deflt::Function, h::Dict{K,V}, key)
+    index = ht_keyindex(h, key)
+    return (index<0) ? deflt() : h.vals[index]::V
+end
+
 haskey(h::Dict, key) = (ht_keyindex(h, key) >= 0)
 in{T<:Dict}(key, v::KeyIterator{T}) = (ht_keyindex(v.dict, key) >= 0)
 
@@ -665,6 +670,9 @@ function getkey{K}(wkh::WeakKeyDict{K}, kk, deflt)
 end
 
 get{K}(wkh::WeakKeyDict{K}, key, def) = get(wkh.ht, key, def)
+get{K}(def::Function, wkh::WeakKeyDict{K}, key) = get(def, wkh.ht, key)
+get!{K}(wkh::WeakKeyDict{K}, key, def) = get!(wkh.ht, key, def)
+get!{K}(def::Function, wkh::WeakKeyDict{K}, key) = get!(def, wkh.ht, key)
 pop!{K}(wkh::WeakKeyDict{K}, key) = pop!(wkh.ht, key)
 pop!{K}(wkh::WeakKeyDict{K}, key, def) = pop!(wkh.ht, key, def)
 delete!{K}(wkh::WeakKeyDict{K}, key) = delete!(wkh.ht, key)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -727,6 +727,17 @@ Given a dictionary ``D``, the syntax ``D[x]`` returns the value of key ``x`` (if
 
    Return the value stored for the given key, or the given default value if no mapping for the key is present.
 
+.. function:: get(f::Function, collection, key)
+
+   Return the value stored for the given key, or if no mapping for the key is present, return ``f()``.  Use ``get!`` to also store the default value in the dictionary.
+
+   This is intended to be called using ``do`` block syntax::
+
+     get(dict, key) do
+         # default value calculated here
+	 time()
+     end
+
 .. function:: get!(collection, key, default)
 
    Return the value stored for the given key, or if no mapping for the key is present, store ``key => default``, and return ``default``.

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -727,6 +727,21 @@ Given a dictionary ``D``, the syntax ``D[x]`` returns the value of key ``x`` (if
 
    Return the value stored for the given key, or the given default value if no mapping for the key is present.
 
+.. function:: get!(collection, key, default)
+
+   Return the value stored for the given key, or if no mapping for the key is present, store ``key => default``, and return ``default``.
+
+.. function:: get!(f::Function, collection, key)
+
+   Return the value stored for the given key, or if no mapping for the key is present, store ``key => f()``, and return ``f()``.
+
+   This is intended to be called using ``do`` block syntax::
+
+     get!(dict, key) do
+         # default value calculated here
+	 time()
+     end
+
 .. function:: getkey(collection, key, default)
 
    Return the key matching argument ``key`` if one exists in ``collection``, otherwise return ``default``.

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -147,6 +147,16 @@ d4[1001] = randstring(3)
 @test !isequal({1 => 2}, {"dog" => "bone"})
 @test isequal(Dict{Int, Int}(), Dict{String, String}())
 
+# get! (get with default values assigned to the given location)
+
+let
+    d = {8=>19}
+    def = {}
+    @test get!(d, 8, 5) == 19
+    @test get!(d, 19, 2) == 2
+    @test d == {8=>19, 19=>2}
+end
+
 # issue #2540
 d = {x => 1
     for x in ['a', 'b', 'c']}

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -154,7 +154,10 @@ let
     def = {}
     @test get!(d, 8, 5) == 19
     @test get!(d, 19, 2) == 2
-    @test d == {8=>19, 19=>2}
+    @test get!(d, 42) do
+        int(e^2)
+    end == 7
+    @test d == {8=>19, 19=>2, 42=>7}
 end
 
 # issue #2540

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -150,14 +150,25 @@ d4[1001] = randstring(3)
 # get! (get with default values assigned to the given location)
 
 let
+    f(x) = x^2
     d = {8=>19}
     def = {}
     @test get!(d, 8, 5) == 19
     @test get!(d, 19, 2) == 2
-    @test get!(d, 42) do
-        int(e^2)
-    end == 7
-    @test d == {8=>19, 19=>2, 42=>7}
+
+    @test get!(d, 42) do  # d is updated with f(2)
+        f(2)
+    end == 4
+
+    @test get!(d, 42) do  # d is not updated
+        f(200)
+    end == 4
+
+    @test get(d, 13) do   # d is not updated
+        f(4)
+    end == 16
+
+    @test d == {8=>19, 19=>2, 42=>4}
 end
 
 # issue #2540


### PR DESCRIPTION
This PR refactors `setindex!(d::Dict, v, key)` into `setindex!` and `ht_keyindex2`, where `ht_keyindex2` returns either the current `index` of the key, or `-index` for the insertion location of a new key (after rehashing, etc).  

(Compare with `ht_keyindex`, which returns `-1` if the key is not in the hash table, and does not call `rehash`.)

This is used by `get!` to get the current or new location of a key.

The PR does not have any measurable impact on performance.

Related:
- #1529, #2108
- #1764. I feel that a function is preferable to a macro for most users and most uses.
- https://github.com/JuliaLang/DataStructures.jl/pull/3 
  - Provides a `DefaultDict` implementation based on the Python one.  
  - Evaluates `ht_keyindex` more than once --> kills performance.

CC: @toivoh, @StefanKarpinski 
