### PR TITLE
Added reference to Pkg.free in Pkg.checkout and Pkg.pin

### DIFF
--- a/doc/stdlib/pkg.rst
+++ b/doc/stdlib/pkg.rst
@@ -84,10 +84,12 @@ to use them, you'll need to prefix each function call with an explicit ``Pkg.``,
 
    Checkout the ``Pkg.dir(pkg)`` repo to the branch ``branch``.
    Defaults to checking out the "master" branch.
+   To go back to using the newest compatible released version, use ``Pkg.free(pkg)``
 
 .. function:: pin(pkg)
 
    Pin ``pkg`` at the current version.
+   To go back to using the newest compatible released version, use ``Pkg.free(pkg)``
 
 .. function:: pin(pkg, version)
 


### PR DESCRIPTION
When I say to someone that they must use `Pkg.checkout("JSON", "nd-array")` to test out a branch, it would be nice if the docs for `Pkg.checkout` told them how to get back to normal business after the branch gets merged. 
