### PR TITLE
Revamp Makefiles to better conform to common packaging guidelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
     - sudo apt-get update -qq -y
     - sudo apt-get install patchelf gfortran llvm-3.3-dev libsuitesparse-dev libncurses5-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libreadline-dev libdouble-conversion-dev libopenlibm-dev librmath-dev libmpfr-dev -y
 script:
-    - make $BUILDOPTS PREFIX=/tmp/julia install
+    - make $BUILDOPTS prefix=/tmp/julia install
     - cd .. && mv julia julia2
     - cd /tmp/julia/share/julia/test && /tmp/julia/bin/julia-debug-readline runtests.jl all
     - cd - && mv julia2 julia

--- a/DISTRIBUTING.md
+++ b/DISTRIBUTING.md
@@ -56,17 +56,17 @@ for Debian and Ubuntu-based systems. Although we have not yet experimented
 with it, [Alien](https://wiki.debian.org/Alien) could be used to
 generate Julia packages for various Linux distributions.
 
-By default, Julia loads `$PREFIX/etc/julia/juliarc.jl` as an
+By default, Julia loads `$prefix/etc/julia/juliarc.jl` as an
 installation-wide initialization file. This file can be used by
 distribution managers to provide paths to various binaries such as a
 bundled `git` executable (as we do on OS X), or to setup paths (as
-we do on Windows).  For Linux distribution packages, if `$PREFIX` is
+we do on Windows).  For Linux distribution packages, if `$prefix` is
 set to `/usr`, there is no `/usr/etc` to look into. This requires
 the path to Julia's private `etc` directory to be changed.  This can
-be done via the `SYSCONFDIR` make variable when building.  Simply
-pass `SYSCONFDIR=/etc` to `make` when building and Julia will first
+be done via the `sysconfdir` make variable when building.  Simply
+pass `sysconfdir=/etc` to `make` when building and Julia will first
 check `/etc/julia/juliarc.jl` before trying
-`$PREFIX/etc/julia/juliarc.jl`.
+`$prefix/etc/julia/juliarc.jl`.
 
 OS X
 ----

--- a/Make.inc
+++ b/Make.inc
@@ -477,10 +477,6 @@ ifeq ($(ARCH),i686)
 JLDFLAGS += -Wl,--large-address-aware
 endif
 UNTRUSTED_SYSTEM_LIBM = 1
-private_libdir = $(bindir)
-libdir = $(bindir)
-build_private_libdir = $(build_bindir)
-build_libdir = $(build_bindir)
 endif
 
 # Intel libraries

--- a/Make.inc
+++ b/Make.inc
@@ -64,8 +64,35 @@ else
 JULIA_COMMIT = $JULIA_VERSION
 endif
 
+# Directories where said libraries get installed to
+bindir = $(prefix)/bin
+libdir = $(prefix)/lib
+private_libdir = $(libdir)/julia
+libexecdir = $(prefix)/libexec
+datarootdir = $(prefix)/share
+includedir = $(prefix)/include
+sysconfdir = $(prefix)/etc
+
+# Directories where things get built into
+build_prefix = $(JULIAHOME)/usr
+build_bindir = $(build_prefix)/bin
+build_libdir = $(build_prefix)/lib
+build_private_libdir = $(build_prefix)/lib/julia
+build_libexecdir = $(build_prefix)/libexec
+build_datarootdir = $(build_prefix)/share
+build_includedir = $(build_prefix)/include
+build_sysconfdir = $(build_prefix)/etc
+
+# This used for debian packaging, to conform to library layout guidelines
+ifeq ($(MULTIARCH_INSTALL), 1)
+MULTIARCH = $(shell gcc -print-multiarch)
+private_libdir = $(libdir)/$(MULTIARCH)/julia
+libdir = $(libdir)/$(MULTIARCH)/
+endif
+
+
 # LLVM Options
-LLVMROOT = $(BUILD)
+LLVMROOT = $(build_prefix)
 LLVM_ASSERTIONS = 0
 LLVM_DEBUG = 0
 # set to 1 to get clang and compiler-rt
@@ -73,20 +100,6 @@ BUILD_LLVM_CLANG = 0
 # set to 1 to get lldb (often does not work, no chance with llvm3.2 and earlier)
 # see http://lldb.llvm.org/build.html for dependencies
 BUILD_LLDB = 0
-
-BUILD = $(JULIAHOME)/usr
-
-# Directories where said libraries get installed to
-LIBDIR = lib
-JL_LIBDIR = $(LIBDIR)
-JL_PRIVATE_LIBDIR = $(JL_LIBDIR)/julia
-
-# This used for debian packaging, to conform to library layout guidelines
-ifeq ($(MULTIARCH_INSTALL), 1)
-MULTIARCH = $(shell gcc -print-multiarch)
-JL_PRIVATE_LIBDIR = $(LIBDIR)/$(MULTIARCH)/julia
-JL_LIBDIR = $(LIBDIR)/$(MULTIARCH)/
-endif
 
 # Cross-compile
 #XC_HOST = i686-w64-mingw32
@@ -130,7 +143,7 @@ endif
 ifeq ($(OS), WINNT)
 fPIC =
 ifeq ($(BUILD_OS), WINNT)
-PATH := ${PATH}:${BUILD}/${JL_LIBDIR}:${BUILD}/${JL_PRIVATE_LIBDIR}:/c/Program Files/7-zip
+PATH := $(PATH):$(build_libdir):$(build_private_libdir):/c/Program Files/7-zip
 endif
 EXE = .exe
 else
@@ -220,8 +233,16 @@ AS := $(CROSS_COMPILE)as
 LD := $(CROSS_COMPILE)ld
 RANLIB := $(CROSS_COMPILE)ranlib
 
-# if not absolute, then relative to JULIA_HOME
-JCFLAGS += '-DJL_SYSTEM_IMAGE_PATH="../$(JL_PRIVATE_LIBDIR)/sys.ji"'
+
+# Calculate relative paths to libdir and private_libdir
+build_libdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(build_bindir) $(build_libdir))
+libdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(libdir))
+
+build_private_libdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(build_bindir) $(build_private_libdir))
+private_libdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(private_libdir))
+
+# if not absolute, then relative to the directory of the julia executable
+JCFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.ji\""
 
 ifeq (exists, $(shell [ -e $(JULIAHOME)/Make.user ] && echo exists ))
 include $(JULIAHOME)/Make.user
@@ -284,10 +305,10 @@ LIBUNWIND=-lunwind-generic -lunwind
 endif
 else
 ifeq ($(OS),Darwin)
-LIBUNWIND=$(BUILD)/$(JL_LIBDIR)/libosxunwind.a
+LIBUNWIND=$(build_libdir)/libosxunwind.a
 JCFLAGS+=-DLIBOSXUNWIND
 else
-LIBUNWIND=$(BUILD)/$(JL_LIBDIR)/libunwind-generic.a $(BUILD)/$(JL_LIBDIR)/libunwind.a
+LIBUNWIND=$(build_libdir)/libunwind-generic.a $(build_libdir)/libunwind.a
 endif
 endif
 endif
@@ -304,14 +325,14 @@ ifeq ($(USE_SYSTEM_READLINE), 1)
 READLINE = -lreadline
 else
 ifeq ($(OS),WINNT)
-READLINE = $(BUILD)/lib/libreadline.a
+READLINE = $(build_libdir)/libreadline.a
 else
-READLINE = $(BUILD)/$(JL_LIBDIR)/libreadline.a
+READLINE = $(build_libdir)/libreadline.a
 endif
 endif
 
 ifeq ($(OS),WINNT)
-READLINE += $(BUILD)/lib/libhistory.a
+READLINE += $(build_libdir)/libhistory.a
 else
 READLINE += -lncurses
 endif
@@ -319,7 +340,7 @@ endif
 ifeq ($(USE_SYSTEM_PCRE), 1)
 PCRE_CONFIG = pcre-config
 else
-PCRE_CONFIG = $(BUILD)/bin/pcre-config
+PCRE_CONFIG = $(build_bindir)/pcre-config
 endif
 
 # Use 64-bit libraries by default on 64-bit architectures
@@ -331,14 +352,14 @@ ifeq ($(USE_SYSTEM_BLAS), 1)
 ifeq ($(OS), Darwin)
 USE_BLAS64 = 0
 USE_SYSTEM_LAPACK = 0
-LIBBLAS = -L$(BUILD)/$(JL_LIBDIR) -lgfortblas
+LIBBLAS = -L$(build_libdir) -lgfortblas
 LIBBLASNAME = libgfortblas
 else
 LIBBLAS ?= -lblas
 LIBBLASNAME ?= libblas
 endif
 else
-LIBBLAS = -L$(BUILD)/$(JL_LIBDIR) -lopenblas
+LIBBLAS = -L$(build_libdir) -lopenblas
 LIBBLASNAME = libopenblas
 endif
 
@@ -352,7 +373,7 @@ ifeq ($(USE_SYSTEM_LAPACK), 1)
 LIBLAPACK = -llapack
 LIBLAPACKNAME = liblapack
 else
-LIBLAPACK = -L$(BUILD)/$(JL_LIBDIR) -llapack $(LIBBLAS)
+LIBLAPACK = -L$(build_libdir) -llapack $(LIBBLAS)
 LIBLAPACKNAME = liblapack
 endif
 endif
@@ -369,18 +390,14 @@ ifeq ($(USE_SYSTEM_LIBUV), 1)
   LIBUV = /usr/lib/libuv-julia.a
   LIBUV_INC = /usr/include
 else
-ifeq ($(OS),WINNT)
-  LIBUV = $(BUILD)/lib/libuv.a
-else
-  LIBUV = $(BUILD)/$(JL_LIBDIR)/libuv.a
-endif
+  LIBUV = $(build_libdir)/libuv.a
   LIBUV_INC = $(JULIAHOME)/deps/libuv/include
 endif
 
 ifeq ($(USE_SYSTEM_UTF8PROC), 1)
   LIBUTF8PROC = -lutf8proc
 else
-  LIBUTF8PROC = $(BUILD)/$(JL_LIBDIR)/libutf8proc.a
+  LIBUTF8PROC = $(build_libdir)/libutf8proc.a
 endif
 
 # OS specific stuff
@@ -402,10 +419,10 @@ ifeq ($(OS), WINNT)
   RPATH =
   RPATH_ORIGIN =
 else ifeq ($(OS), Darwin)
-  RPATH = -Wl,-rpath,'@executable_path/../$(JL_PRIVATE_LIBDIR)' -Wl,-rpath,'@executable_path/../$(JL_LIBDIR)'
+  RPATH = -Wl,-rpath,'@executable_path/$(build_private_libdir_rel)' -Wl,-rpath,'@executable_path/$(build_libdir_rel)'
   RPATH_ORIGIN =
 else
-  RPATH = -Wl,-rpath,'$$ORIGIN/../$(JL_PRIVATE_LIBDIR)' -Wl,-rpath,'$$ORIGIN/../$(JL_LIBDIR)' -Wl,-z,origin
+  RPATH = -Wl,-rpath,'$$ORIGIN/$(build_private_libdir_rel)' -Wl,-rpath,'$$ORIGIN/$(build_libdir_rel)' -Wl,-z,origin
   RPATH_ORIGIN = -Wl,-rpath,'$$ORIGIN' -Wl,-z,origin
 endif
 
@@ -443,7 +460,6 @@ endif
 ifeq ($(OS), Darwin)
 INSTALL_NAME_CMD = install_name_tool -id $(INSTALL_NAME_ID_DIR)
 INSTALL_NAME_CHANGE_CMD = install_name_tool -change
-RPATH = -Wl,-rpath,'@executable_path/../$(JL_LIBDIR)' -Wl,-rpath,'@executable_path/../$(JL_PRIVATE_LIBDIR)'
 SHLIB_EXT = dylib
 OSLIBS += -ldl -Wl,-w -framework CoreFoundation -framework CoreServices $(LIBUNWIND)
 WHOLE_ARCHIVE = -Xlinker -all_load
@@ -461,8 +477,10 @@ ifeq ($(ARCH),i686)
 JLDFLAGS += -Wl,--large-address-aware
 endif
 UNTRUSTED_SYSTEM_LIBM = 1
-JL_PRIVATE_LIBDIR = bin
-JL_LIBDIR = bin
+private_libdir = $(bindir)
+libdir = $(bindir)
+build_private_libdir = $(build_bindir)
+build_libdir = $(build_bindir)
 endif
 
 # Intel libraries
@@ -502,7 +520,7 @@ endif
 # or installed to usr/lib/libatlas from some another source (built as
 # a shared library, for your platform, single threaded)
 USE_ATLAS = 0
-ATLAS_LIBDIR = $(BUILD)/$(JL_LIBDIR)
+ATLAS_LIBDIR = $(build_libdir)
 #or ATLAS_LIBDIR = /path/to/system/atlas/lib
 
 ifeq ($(USE_ATLAS), 1)
@@ -563,8 +581,8 @@ exec = $(shell $(call spawn,$(1)))
 wine_pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(shell printf %s\n '$(2)' | xargs -d";" winepath -u | tr '\n' ' '))))
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(2)))))
 
-JULIA_EXECUTABLE_debug = $(BUILD)/bin/julia-debug-$(DEFAULT_REPL)$(EXE)
-JULIA_EXECUTABLE_release = $(BUILD)/bin/julia-$(DEFAULT_REPL)$(EXE)
+JULIA_EXECUTABLE_debug = $(build_bindir)/julia-debug-$(DEFAULT_REPL)$(EXE)
+JULIA_EXECUTABLE_release = $(build_bindir)/julia-$(DEFAULT_REPL)$(EXE)
 
 ifeq ($(OS), WINNT)
 JULIA_EXECUTABLE = $(JULIA_EXECUTABLE_release)

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,6 @@ ifeq ($(OS),WINNT)
 else
 	-cp -a $(build_libexecdir) $(DESTDIR)$(prefix)
 	cd $(DESTDIR)$(bindir) && ln -sf julia-$(DEFAULT_REPL) julia
-endif
 
 	for suffix in $(JL_LIBS) ; do \
 		$(INSTALL_M) $(build_libdir)/lib$${suffix}*.$(SHLIB_EXT)* $(DESTDIR)$(private_libdir) ; \
@@ -198,6 +197,8 @@ endif
 	for suffix in $(JL_PRIVATE_LIBS) ; do \
 		$(INSTALL_M) $(build_libdir)/lib$${suffix}*.$(SHLIB_EXT)* $(DESTDIR)$(private_libdir) ; \
 	done
+endif
+
 ifeq ($(USE_SYSTEM_LIBUV),0)
 ifeq ($(OS),WINNT)
 	$(INSTALL_M) $(build_libdir)/libuv.a $(DESTDIR)$(private_libdir)

--- a/Makefile
+++ b/Makefile
@@ -150,12 +150,12 @@ endif
 
 ifeq ($(OS),WINNT)
 define std_dll
-debug release: | $$(build_libdir)/lib$(1).dll
-$$(build_libdir)/lib$(1).dll: | $$(build_libdir)
+debug release: | $$(build_bindir)/lib$(1).dll
+$$(build_bindir)/lib$(1).dll: | $$(build_bindir)
 ifeq ($$(BUILD_OS),$$(OS))
-	cp $$(call pathsearch,lib$(1).dll,$$(PATH)) $$(build_libdir) ;
+	cp $$(call pathsearch,lib$(1).dll,$$(PATH)) $$(build_bindir) ;
 else
-	cp $$(call wine_pathsearch,lib$(1).dll,$$(STD_LIB_PATH)) $$(build_libdir) ;
+	cp $$(call wine_pathsearch,lib$(1).dll,$$(STD_LIB_PATH)) $$(build_bindir) ;
 endif
 JL_LIBS += $(1)
 endef

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,9 @@ else ifeq ($(OS), WINNT)
 	-cat ./contrib/windows/juliarc.jl >> $(DESTDIR)$(prefix)/etc/julia/juliarc.jl
 endif
 
+	# purge sys.{dll,so,dylib} as that file is not relocatable across processor architectures
+	-rm -f julia-$(JULIA_COMMIT)/$(private_libdir)/sys.$(SHLIB_EXT)
+
 ifeq ($(OS), WINNT)
 	[ ! -d dist-extras ] || ( cd dist-extras && \
 		cp 7z.exe 7z.dll libexpat-1.dll zlib1.dll ../$(bindir) && \

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ endif
 
 	# Overwrite JL_SYSTEM_IMAGE_PATH in julia binaries:
 	for julia in $(DESTDIR)$(bindir)/julia-* ; do \
-		$(build_bindir)/stringpatch $$(strings -t x - $$julia | grep "sys.ji$$" | awk '{print $$1;}' ) "$(private_libdir_rel)/sys.ji" $$julia; \
+		$(build_bindir)/stringpatch $$(strings -t x - $$julia | grep "sys.ji$$" | awk '{print $$1;}' ) "$(private_libdir_rel)/sys.ji" 256 $$julia; \
 	done
 
 	mkdir -p $(DESTDIR)$(sysconfdir)

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ endif
 
 debug release: | $(DIRS) $(build_datarootdir)/julia/base $(build_datarootdir)/julia/test $(build_datarootdir)/julia/doc $(build_datarootdir)/julia/examples $(build_sysconfdir)/julia/juliarc.jl
 	@$(MAKE) $(QUIET_MAKE) julia-$@
+# If we're on windows, we want all .dll's that are in /lib to be in /bin
+ifeq ($(OS),WINNT)
+	cp -a $(build_libdir)/*.$(SHLIB_EXT) $(build_bindir)/
+endif
 	@export private_libdir=$(private_libdir) && \
 	$(MAKE) $(QUIET_MAKE) LD_LIBRARY_PATH=$(build_libdir):$(LD_LIBRARY_PATH) JULIA_EXECUTABLE="$(JULIA_EXECUTABLE_$@)" $(build_private_libdir)/sys.$(SHLIB_EXT)
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ run-julia:
 run:
 	@$(call spawn,$(cmd))
 
-$(build_bindir)/stringpatch: $(build_bindir)
+$(build_bindir)/stringpatch: $(build_bindir) contrib/stringpatch.c
 	@$(call PRINT_CC, $(CC) -o $(build_bindir)/stringpatch contrib/stringpatch.c)
 
 

--- a/Makefile
+++ b/Makefile
@@ -307,10 +307,9 @@ clean: | $(CLEAN_TARGETS)
 	done
 	@rm -f julia
 	@rm -f *~ *# *.tar.gz
-	@rm -f $(build_bindir)/stringpatch
+	@rm -f $(build_bindir)/stringpatch source-dist.tmp source-dist.tmp1
 	@rm -fr $(build_private_libdir)
-	@rm -f source-dist.tmp source-dist.tmp1
-	# Temporarily add this line to the Makefile to remove extras
+# Temporarily add this line to the Makefile to remove extras
 	@rm -fr $(build_datarootdir)/julia/extras
 
 cleanall: clean

--- a/base/Makefile
+++ b/base/Makefile
@@ -14,12 +14,12 @@ errno_h.jl:
 	@$(call PRINT_PERL, echo '#include "errno.h"' | $(CPP) -dM - | perl -nle 'print "const $$1 = int32($$2)" if /^#define\s+(E\w+)\s+(\d+)\s*$$/' | sort > $@)
 
 fenv_constants.jl: ../src/fenv_constants.h
-	@$(PRINT_PERL) ${CPP} -P -DJULIA ../src/fenv_constants.h | tail -n 8 | perl -ple 's/\sFE_UN\w+/ 0x10/g; s/\sFE_O\w+/ 0x08/g; s/\sFE_DI\w+/ 0x04/g; s/\sFE_INV\w+/ 0x01/g; s/\sFE_TON\w+/ 0x00/g; s/\sFE_UP\w+/ 0x800/g; s/\sFE_DO\w+/ 0x400/g; s/\sFE_TOW\w+/ 0xc00/g' > $@
+	@$(PRINT_PERL) $(CPP) -P -DJULIA ../src/fenv_constants.h | tail -n 8 | perl -ple 's/\sFE_UN\w+/ 0x10/g; s/\sFE_O\w+/ 0x08/g; s/\sFE_DI\w+/ 0x04/g; s/\sFE_INV\w+/ 0x01/g; s/\sFE_TON\w+/ 0x00/g; s/\sFE_UP\w+/ 0x800/g; s/\sFE_DO\w+/ 0x400/g; s/\sFE_TOW\w+/ 0xc00/g' > $@
 
 file_constants.jl: ../src/file_constants.h
 	@$(call PRINT_PERL, $(CPP) -P -DJULIA ../src/file_constants.h | perl -nle 'print "$$1 0o$$2" if /^(\s*const\s+[A-z_]+\s+=)\s+(0[0-9]*)\s*$$/; print "$$1" if /^\s*(const\s+[A-z_]+\s+=\s+([1-9]|0x)[0-9A-z]*)\s*$$/' > $@)
 
-uv_constants.jl: ../src/uv_constants.h ../usr/include/uv-errno.h
+uv_constants.jl: ../src/uv_constants.h $(build_includedir)/uv-errno.h
 	@$(call PRINT_PERL, $(CPP) -P "-I$(LIBUV_INC)" -DJULIA ../src/uv_constants.h | tail -n 16 > $@)
 
 build_h.jl.phony:
@@ -42,6 +42,7 @@ endif
 	@echo "const SYSCONFDIR = \"$(SYSCONFDIR)\"" >> $@
 	@echo "const VERSION_STRING = \"$(JULIA_VERSION)\"" >> $@
 	@echo "const TAGGED_RELEASE_BANNER = \"$(TAGGED_RELEASE_BANNER)\"" >> $@
+	@echo "const SYSCONFDIR = \"$(sysconfdir)\"" >> $@
 
 	@# This to ensure that we always rebuild this file, but only when it is modified do we touch build_h.jl,
 	@# ensuring we rebuild the system image as infrequently as possible

--- a/base/Makefile
+++ b/base/Makefile
@@ -39,7 +39,6 @@ ifeq ($(USE_BLAS64), 1)
 else
 	@echo "const USE_BLAS64 = false" >> $@
 endif
-	@echo "const SYSCONFDIR = \"$(SYSCONFDIR)\"" >> $@
 	@echo "const VERSION_STRING = \"$(JULIA_VERSION)\"" >> $@
 	@echo "const TAGGED_RELEASE_BANNER = \"$(TAGGED_RELEASE_BANNER)\"" >> $@
 	@echo "const SYSCONFDIR = \"$(sysconfdir)\"" >> $@

--- a/base/client.jl
+++ b/base/client.jl
@@ -348,7 +348,7 @@ function init_profiler()
 end
 
 function load_juliarc()
-    # If the user built us with a specifi Base.SYSCONFDIR, check that location first for a juliarc.jl file
+    # If the user built us with a specific Base.SYSCONFDIR, check that location first for a juliarc.jl file
     #   If it is not found, then continue on to the relative path based on JULIA_HOME
     if !isempty(Base.SYSCONFDIR) && isfile(joinpath(Base.SYSCONFDIR,"julia","juliarc.jl"))
         include(abspath(Base.SYSCONFDIR,"julia","juliarc.jl"))

--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -20,8 +20,8 @@ dmg:
 	tar zxf ../../../julia-*.tar.gz
 	mv julia-* julia
 	-mkdir -p ./julia/libexec ./julia/share
-	-cp -a $(BUILD)/libexec/git* ./julia/libexec
-	-cp -a $(BUILD)/share/git* ./julia/share
+	-cp -a $(build_libexecdir)/git* ./julia/libexec
+	-cp -a $(build_datarootdir)/git* ./julia/share
 	rm -f julia/lib/*.{a,la}
 	-mkdir dmg
 	platypus -a Julia -p /bin/bash -V $(JULIA_VERSION) -R -u "The Julia Project" -i julia.icns -Q julia.icns -o "None" -I org.julialang -x -f julia script ./dmg/Julia-$(VERSION_SUFFIX).app

--- a/contrib/mac/fixup-libgfortran.sh
+++ b/contrib/mac/fixup-libgfortran.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # Run as: fixup-libgfortran.sh <$private_libdir>
-set +x
 
 if [[ -z "$1" ]]; then
     echo "Usage: $0 <private_libdir>"

--- a/contrib/relative_path.sh
+++ b/contrib/relative_path.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# both $1 and $2 are absolute paths beginning with /
+# returns relative path to $2/$target from $1/$source
+
+# Source copied from http://stackoverflow.com/a/12498485/230778
+
+source=$1
+target=$2
+
+if [[ ! "$source" == /* ]] || [[ ! "$target" == /* ]]; then
+    echo "ERROR: paths must be absolute paths, they must start with a forward slash!"
+    exit 1
+fi
+
+common_part=$source # for now
+result="" # for now
+
+while [[ "${target#$common_part}" == "${target}" ]]; do
+    # no match, means that candidate common part is not correct
+    # go up one level (reduce common part)
+    common_part="$(dirname $common_part)"
+    # and record that we went back, with correct / handling
+    if [[ -z $result ]]; then
+        result=".."
+    else
+        result="../$result"
+    fi
+done
+
+if [[ $common_part == "/" ]]; then
+    # special case for root (no common path)
+    result="$result/"
+fi
+
+# since we now have identified the common part,
+# compute the non-common part
+forward_part="${target#$common_part}"
+
+# and now stick all parts together
+if [[ -n $result ]] && [[ -n $forward_part ]]; then
+    result="$result$forward_part"
+elif [[ -n $forward_part ]]; then
+    # extra slash removal
+    result="${forward_part:1}"
+fi
+
+echo $result

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -11,27 +11,27 @@ ifeq ($(OS),Darwin)
 ifeq ($(USE_SYSTEM_BLAS),1)
 ifeq ($(USE_SYSTEM_LAPACK),0)
 
-$(BUILD)/lib/libgfortblas.dylib:
-	make -C ../deps/ $(BUILD)/lib/libgfortblas.dylib
+$(build_libdir)/libgfortblas.dylib:
+	make -C ../deps/ $(build_libdir)/libgfortblas.dylib
 
-default: $(BUILD)/lib/libgfortblas.dylib
+default: $(build_ibdir)/libgfortblas.dylib
 endif
 endif
 endif
 
 default:
-	mkdir -p $(BUILD)/$(JL_LIBDIR)
+	mkdir -p $(build_libdir)
 	mkdir -p $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib
 	cd $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib && \
-	rm -f $(BUILD)/$(JL_LIBDIR)/lib{amd,cholmod,colamd,spqr,umfpack}.$(SHLIB_EXT) && \
-	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libamd.a $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
-	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(SS_LIB)/libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) -L$(BUILD)/$(JL_LIBDIR) $(LDFLAGS) -lcolamd -lccolamd -lcamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(SS_LIB)/libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) -L$(BUILD)/$(JL_LIBDIR) $(LDFLAGS) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(SS_LIB)/libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT) -L$(BUILD)/$(JL_LIBDIR) $(LDFLAGS) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT)
+	rm -f $(build_libdir)/lib{amd,cholmod,colamd,spqr,umfpack}.$(SHLIB_EXT) && \
+	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libamd.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(build_libdir)/libamd.$(SHLIB_EXT) && \
+	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libcolamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(build_libdir)/libcolamd.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(SS_LIB)/libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libcholmod.$(SHLIB_EXT) -L$(build_libdir) $(LDFLAGS) -lcolamd -lccolamd -lcamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(build_libdir)/libcholmod.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(SS_LIB)/libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libumfpack.$(SHLIB_EXT) -L$(build_libdir) $(LDFLAGS) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(build_libdir)/libumfpack.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(SS_LIB)/libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libspqr.$(SHLIB_EXT) -L$(build_libdir) $(LDFLAGS) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(build_libdir)/libspqr.$(SHLIB_EXT)
 	

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -5,7 +5,7 @@ include $(JULIAHOME)/Make.inc
 
 all: default
 
-SS_LIB = $(shell dirname $(shell find $(shell eval $(JULIAHOME)/contrib/filterArgs.sh $(LDFLAGS)) /lib /usr/lib /usr/local/lib -name libsuitesparseconfig.a 2>/dev/null | head -n 1))
+SS_LIB = $(shell dirname $(shell find $(shell eval $(JULIAHOME)/contrib/filterArgs.sh $(LDFLAGS)) /lib /usr/lib /usr/local/lib -name libsuitesparseconfig.a 2>/dev/null | head -n 1) 2>/dev/null)
 
 ifeq ($(OS),Darwin)
 ifeq ($(USE_SYSTEM_BLAS),1)

--- a/contrib/stringpatch.c
+++ b/contrib/stringpatch.c
@@ -3,18 +3,24 @@
 #include <string.h>
 
 int main( int argc, char ** argv ) {
-	if( argc < 4 ) {
+	if( argc < 5 ) {
 		printf("Usage:\n");
-		printf("  %s <hex offset> <string to write> <file>\n", argv[0] );
+		printf("  %s <hex offset> <string to write> <maxlen> <file>\n", argv[0] );
 		return -1;
 	}
 
 	unsigned long offset = strtoul(argv[1], NULL, 16);
 	char * replacement = argv[2];
+	unsigned long maxlen = strtoul(argv[3], NULL, 10);
 
-	FILE * f = fopen( argv[3], "r+" );
+	FILE * f = fopen( argv[4], "r+" );
 	if( !f ) {
 		printf( "ERROR: Could not open %s for writing!\n", argv[3] );
+		return -1;
+	}
+
+	if( strlen(replacement) > maxlen ) {
+		printf( "ERROR: Replacement string length (%d) is greater than maxlen! (%d)\n", strlen(replacement), maxlen );
 		return -1;
 	}
 	

--- a/contrib/stringpatch.c
+++ b/contrib/stringpatch.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main( int argc, char ** argv ) {
+	if( argc < 4 ) {
+		printf("Usage:\n");
+		printf("  %s <hex offset> <string to write> <file>\n", argv[0] );
+		return -1;
+	}
+
+	unsigned long offset = strtoul(argv[1], NULL, 16);
+	char * replacement = argv[2];
+
+	FILE * f = fopen( argv[3], "r+" );
+	if( !f ) {
+		printf( "ERROR: Could not open %s for writing!\n", argv[3] );
+		return -1;
+	}
+	
+	fseek( f, offset, SEEK_SET );
+	fwrite( replacement, strlen(replacement)+1, 1, f );
+
+	fclose( f );
+	return 0;
+}

--- a/contrib/stringpatch.c
+++ b/contrib/stringpatch.c
@@ -20,7 +20,7 @@ int main( int argc, char ** argv ) {
 	}
 
 	if( strlen(replacement) > maxlen ) {
-		printf( "ERROR: Replacement string length (%d) is greater than maxlen! (%d)\n", strlen(replacement), maxlen );
+		printf( "ERROR: Replacement string length (%lu) is greater than maxlen! (%lu)\n", strlen(replacement), maxlen );
 		return -1;
 	}
 	

--- a/contrib/windows/prepare-julia-env.bat
+++ b/contrib/windows/prepare-julia-env.bat
@@ -13,5 +13,5 @@ for %%A in (%JULIA_EXE%) do set JULIA_HOME=%%~dp$PATH:A
 set JULIA=%JULIA_HOME%%JULIA_EXE%
 set PATH=%SYS_PATH%
 
-set JL_PRIVATE_LIBDIR=bin
+set private_libdir=bin
 if not exist "%JULIA_HOME%..\bin\sys.ji" (echo "Preparing Julia for first launch. This may take a while" && echo "You may see two git related errors. This is completely normal" && cd "%JULIA_HOME%..\share\julia\base" && "%JULIA%" -b sysimg.jl && popd && pushd "%cd%")

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -3,16 +3,18 @@ JULIAHOME = $(abspath ..)
 include $(JULIAHOME)/Make.inc
 include Versions.make
 
-CONFIGURE_COMMON = --prefix=$(abspath $(BUILD)) --build=$(BUILD_MACHINE)
+CONFIGURE_COMMON = --prefix=$(abspath $(build_prefix)) --build=$(BUILD_MACHINE) --libdir=$(abspath $(build_libdir))
 ifneq ($(XC_HOST),)
 CONFIGURE_COMMON += --host=$(XC_HOST)
 endif
 ifeq ($(OS),WINNT)
 CONFIGURE_COMMON += LDFLAGS=-Wl,--stack,8388608
-else ifneq ($(JL_LIBDIR),lib)
-CONFIGURE_COMMON += --libdir=$(abspath $(BUILD)/$(JL_LIBDIR))
 endif
 CONFIGURE_COMMON += F77="$(FC)" CC="$(CC)" CXX="$(CXX)"
+
+# If the top-level Makefile is called with environment variables,
+# they will override the values passed above to ./configure
+MAKE_COMMON = DESTDIR="" prefix=$(build_prefix) bindir=$(build_bindir) libdir=$(build_libdir) libexecdir=$(build_libexecdir) datarootdir=$(build_datarootdir) includedir=$(build_includedir) sysconfdir=$(build_sysconfdir)
 
 #autoconf configure-driven scripts: llvm readline pcre arpack fftw unwind gmp mpfr patchelf uv
 #custom Makefile rules: openlibm Rmath double-conversion random suitesparse-wrapper suitesparse lapack openblas utf8proc
@@ -45,7 +47,7 @@ endif
 ifeq ($(OS), Linux)
 ifneq ($(shell patchelf --version 2>/dev/null), patchelf 0.6)
 STAGE1_DEPS += patchelf
-PATCHELF=$(BUILD)/bin/patchelf
+PATCHELF=$(build_bindir)/patchelf
 else
 PATCHELF=patchelf
 endif
@@ -98,7 +100,7 @@ endif
 ifeq ($(USE_SYSTEM_MPFR), 0)
 STAGE2_DEPS += mpfr
 ifeq ($(USE_SYSTEM_GMP), 0)
-MPFR_OPTS = --with-gmp-include=$(abspath $(BUILD)/include) --with-gmp-lib=$(abspath $(BUILD)/$(JL_LIBDIR))
+MPFR_OPTS = --with-gmp-include=$(abspath $(build_includedir)) --with-gmp-lib=$(abspath $(build_libdir))
 endif
 endif
 ifeq ($(BUILD_OS),WINNT)
@@ -139,7 +141,7 @@ endif
 
 LIBS = $(STAGE1_DEPS) $(STAGE2_DEPS) $(STAGE3_DEPS)
 
-default: $(BUILD) install
+default: $(build_prefix) install
 get: $(addprefix get-, $(LIBS))
 configure: $(addprefix configure-, $(LIBS))
 compile: $(addprefix compile-, $(LIBS))
@@ -147,15 +149,16 @@ check: $(addprefix check-, $(LIBS))
 install: $(addprefix install-, $(LIBS))
 cleanall: $(addprefix clean-, $(LIBS))
 distclean: $(addprefix distclean-, $(LIBS))
-	rm -rf $(BUILD)
+	rm -rf $(build_prefix)
 getall: get-llvm get-readline get-uv get-pcre get-double-conversion get-openlibm get-openspecfun get-random get-openblas get-lapack get-fftw get-suitesparse get-arpack get-unwind get-osxunwind get-gmp get-mpfr get-zlib get-patchelf get-utf8proc
 
 ## PATHS ##
-DIRS = $(addprefix $(BUILD)/,lib include bin share etc)
+# sort is used to remove potential duplicates
+DIRS = $(sort $(build_bindir) $(build_libdir) $(build_includedir) $(build_sysconfdir) $(build_datarootdir))
 
 $(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
 
-$(BUILD): $(DIRS)
+$(build_prefix): $(DIRS)
 
 ## LLVM ##
 ifeq ($(BUILD_LLDB), 1)
@@ -178,7 +181,7 @@ endif
 
 LLVM_LIB_FILE = libLLVMJIT.a
 LLVM_OBJ_SOURCE = llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE)/$(LLVM_FLAVOR)/lib/$(LLVM_LIB_FILE)
-LLVM_OBJ_TARGET = $(BUILD)/lib/$(LLVM_LIB_FILE)
+LLVM_OBJ_TARGET = $(build_libdir)/$(LLVM_LIB_FILE)
 
 ifneq ($(LLVM_VER),svn)
 ifeq ($(LLVM_VER), 3.0)
@@ -370,13 +373,13 @@ llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE)/config.status: llvm-$(LLVM_VER)/configu
 	cd llvm-$(LLVM_VER) && \
 	mkdir -p build_$(LLVM_BUILDTYPE) && cd build_$(LLVM_BUILDTYPE) && \
 	export PATH=$(abspath llvm-$(LLVM_VER)/python2_path):$$PATH && \
-	../configure $(CONFIGURE_COMMON) $(LLVM_CC) $(LLVM_FLAGS)
+	../configure $(CONFIGURE_COMMON) $(LLVM_CC) $(LLVM_FLAGS) 
 	touch -c $@
 
 $(LLVM_OBJ_SOURCE): llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE)/config.status | $(llvm_python_workaround)
 	cd llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE) && \
 	export PATH=$(abspath llvm-$(LLVM_VER)/python2_path):$$PATH && \
-	$(MAKE) $(LLVM_MFLAGS)
+	$(MAKE) $(LLVM_MFLAGS) $(MAKE_COMMON)
 	touch -c $@
 
 llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE)/checked: $(LLVM_OBJ_SOURCE) | $(llvm_python_workaround)
@@ -388,13 +391,15 @@ endif
 	echo 1 > $@
 
 $(LLVM_OBJ_TARGET): $(LLVM_OBJ_SOURCE) | $(llvm_python_workaround)
+	# LLVM has weird install prefixes (see llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE)/Makefile.config for the full list)
+	# We map them here to the "normal" ones, which means just prefixing "PROJ_" to the variable name.
 	export PATH=$(abspath llvm-$(LLVM_VER)/python2_path):$$PATH && \
-	$(MAKE) -C llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE) install
+	$(MAKE) -C llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE) install $(MAKE_COMMON) PROJ_libdir=$(build_libdir) PROJ_bindir=$(build_bindir)
 	touch -c $@
 
 clean-llvm:
 	-$(MAKE) -C llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE) clean
-	-rm -f $(BUILD)/bin/llvm-config
+	-rm -f $(build_bindir)/llvm-config
 distclean-llvm:
 	-rm -rf llvm-$(LLVM_VER).tar.gz llvm-$(LLVM_VER).src.tar.gz clang-$(LLVM_VER).src.tar.gz clang-$(LLVM_VER).tar.gz libcxx-$(LLVM_VER).src.tar.gz compiler-rt-$(LLVM_VER).src.tar.gz llvm-$(LLVM_VER)
 
@@ -410,7 +415,7 @@ install-llvm: $(LLVM_OBJ_TARGET)
 
 
 ifeq ($(OS),WINNT)
-READLINE_OBJ_TARGET = $(BUILD)/lib/libreadline.a
+READLINE_OBJ_TARGET = $(build_libdir)/libreadline.a
 READLINE_OBJ_SOURCE = readline-$(READLINE_VER)/libreadline.a
 READLINE_URL = https://github.com/JuliaLang/readline/tarball/master
 READLINE_OPTS = --disable-shared --enable-static --with-curses
@@ -423,10 +428,10 @@ readline-$(READLINE_VER)/configure: readline-$(READLINE_VER).tar.gz
 	$(TAR) -C readline-$(READLINE_VER) --strip-components 1 -xf $<
 	touch -c $@
 $(READLINE_OBJ_TARGET): $(READLINE_OBJ_SOURCE) readline-$(READLINE_VER)/checked
-	$(MAKE) -C readline-$(READLINE_VER) $(READLINE_CFLAGS) install
+	$(MAKE) -C readline-$(READLINE_VER) $(READLINE_CFLAGS) install $(MAKE_COMMON)
 	touch -c $@
 else
-READLINE_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libreadline.$(SHLIB_EXT)
+READLINE_OBJ_TARGET = $(build_libdir)/libreadline.$(SHLIB_EXT)
 ifneq ($(OS),Darwin)
 READLINE_OBJ_SOURCE = readline-$(READLINE_VER)/shlib/libreadline.$(SHLIB_EXT).$(READLINE_VER)
 else
@@ -446,17 +451,17 @@ readline-$(READLINE_VER)/configure: readline-$(READLINE_VER).tar.gz
 	cd readline-$(READLINE_VER) && patch -p0 < ../readline62-004
 	touch -c $@
 $(READLINE_OBJ_TARGET): $(READLINE_OBJ_SOURCE) readline-$(READLINE_VER)/checked
-	$(MAKE) -C readline-$(READLINE_VER) install
+	$(MAKE) -C readline-$(READLINE_VER) install $(MAKE_COMMON)
 ifeq ($(OS),WINNT)
-	chmod +w $(BUILD)/lib/libreadline.* $(BUILD)/lib/libhistory.*
+	chmod +w $(build_libdir)/libreadline.* $(build_libdir)/libhistory.*
 else
-	chmod +w $(BUILD)/$(JL_LIBDIR)/libreadline.* $(BUILD)/$(JL_LIBDIR)/libhistory.*
+	chmod +w $(build_libdir)/libreadline.* $(build_libdir)/libhistory.*
 endif
 ifeq ($(OS), Darwin)
-	$(INSTALL_NAME_CMD)libreadline.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libreadline.$(SHLIB_EXT)
-	$(INSTALL_NAME_CMD)libhistory.dylib $(BUILD)/$(JL_LIBDIR)/libhistory.dylib
+	$(INSTALL_NAME_CMD)libreadline.$(SHLIB_EXT) $(build_libdir)/libreadline.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libhistory.dylib $(build_libdir)/libhistory.dylib
 else ifeq ($(OS), Linux)
-	for filename in $(BUILD)/$(JL_LIBDIR)/libhistory.so* $(BUILD)/$(JL_LIBDIR)/libreadline.so* ; do \
+	for filename in $(build_libdir)/libhistory.so* $(build_libdir)/libreadline.so* ; do \
 		$(PATCHELF) --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
@@ -493,11 +498,7 @@ install-readline: $(READLINE_OBJ_TARGET)
 ## LIBUV ##
 
 UV_SRC_TARGET = libuv/.libs/libuv.a
-ifeq ($(OS),WINNT)
-UV_OBJ_TARGET = $(BUILD)/lib/libuv.a
-else
-UV_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libuv.a
-endif
+UV_OBJ_TARGET = $(build_libdir)/libuv.a
 
 libuv/configure:
 	(cd .. && git submodule init && git submodule update)
@@ -524,12 +525,12 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 $(UV_OBJ_TARGET): $(UV_SRC_TARGET)
-	$(MAKE) -C libuv install
-	$(INSTALL_NAME_CMD)libuv.dylib $(BUILD)/$(JL_LIBDIR)/libuv.dylib
+	$(MAKE) -C libuv install $(MAKE_COMMON)
+	$(INSTALL_NAME_CMD)libuv.dylib $(build_libdir)/libuv.dylib
 
 clean-uv:
 	-$(MAKE) -C libuv clean
-	-rm -rf $(BUILD)/lib/libuv.a $(BUILD)/include/uv.h $(BUILD)/include/uv-private
+	-rm -rf $(build_libdir)/libuv.a $(build_includedir)/uv.h $(build_includedir)/uv-private
 distclean-uv: clean-uv
 	-$(MAKE) -C libuv distclean
 
@@ -543,7 +544,7 @@ install-uv: $(UV_OBJ_TARGET)
 ## PCRE ##
 
 PCRE_SRC_TARGET = pcre-$(PCRE_VER)/.libs/libpcre.$(SHLIB_EXT)
-PCRE_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libpcre.$(SHLIB_EXT)
+PCRE_OBJ_TARGET = $(build_libdir)/libpcre.$(SHLIB_EXT)
 
 pcre-$(PCRE_VER).tar.bz2:
 	$(JLDOWNLOAD) $@ http://sourceforge.net/projects/pcre/files/pcre/$(PCRE_VER)/$@/download
@@ -563,13 +564,13 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 $(PCRE_OBJ_TARGET): $(PCRE_SRC_TARGET) pcre-$(PCRE_VER)/checked
-	$(MAKE) -C pcre-$(PCRE_VER) $(LIBTOOL_CCLD) install
+	$(MAKE) -C pcre-$(PCRE_VER) $(LIBTOOL_CCLD) install $(MAKE_COMMON)
 	$(INSTALL_NAME_CMD)libpcre.dylib $@
 	touch -c $@
 
 clean-pcre:
 	-$(MAKE) -C pcre-$(PCRE_VER) clean
-	-rm -f $(BUILD)/$(JL_LIBDIR)/libpcre*
+	-rm -f $(build_libdir)/libpcre*
 distclean-pcre: clean-pcre
 	-rm -rf pcre-$(PCRE_VER).tar.bz2 pcre-$(PCRE_VER)
 
@@ -583,7 +584,7 @@ install-pcre: $(PCRE_OBJ_TARGET)
 ## Grisu floating-point printing library ##
 
 GRISU_OPTS = $(CXXFLAGS) -O3 -fvisibility=hidden $(fPIC)
-GRISU_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libgrisu.$(SHLIB_EXT)
+GRISU_OBJ_TARGET = $(build_libdir)/libgrisu.$(SHLIB_EXT)
 
 double-conversion-$(GRISU_VER).tar.gz:
 	$(JLDOWNLOAD) $@ http://double-conversion.googlecode.com/files/$@
@@ -623,14 +624,14 @@ get-double-conversion: double-conversion-$(GRISU_VER).tar.gz
 configure-double-conversion: get-double-conversion
 compile-double-conversion: double-conversion-$(GRISU_VER)/src/libgrisu.$(SHLIB_EXT)
 check-double-conversion: compile-double-conversion
-install-double-conversion: $(BUILD)/$(JL_LIBDIR)/libgrisu.$(SHLIB_EXT)
+install-double-conversion: $(build_libdir)/libgrisu.$(SHLIB_EXT)
 
 
 ## openlibm ##
 
 OPENLIBM_FLAGS = ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC)
 
-OPENLIBM_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libopenlibm.$(SHLIB_EXT)
+OPENLIBM_OBJ_TARGET = $(build_libdir)/libopenlibm.$(SHLIB_EXT)
 OPENLIBM_OBJ_SOURCE = openlibm/libopenlibm.$(SHLIB_EXT)
 
 openlibm/Makefile:
@@ -642,14 +643,10 @@ ifeq (exists, $(shell [ -d $(JULIAHOME)/.git/modules/deps/openlibm ] && echo exi
 $(OPENLIBM_OBJ_SOURCE): $(JULIAHOME)/.git/modules/deps/openlibm/HEAD
 endif
 $(OPENLIBM_OBJ_SOURCE): openlibm/Makefile
-	$(MAKE) -C openlibm $(OPENLIBM_FLAGS)
+	$(MAKE) -C openlibm $(OPENLIBM_FLAGS) $(MAKE_COMMON)
 	touch -c $@
-$(OPENLIBM_OBJ_TARGET): $(OPENLIBM_OBJ_SOURCE) | $(BUILD)/lib
-ifeq ($(OS),WINNT)
-	cp openlibm/libopenlibm.a $(BUILD)/lib/libopenlibm.a
-else
-	cp openlibm/libopenlibm.a $(BUILD)/$(JL_LIBDIR)/libopenlibm.a
-endif
+$(OPENLIBM_OBJ_TARGET): $(OPENLIBM_OBJ_SOURCE) | $(build_libdir)
+	cp openlibm/libopenlibm.a $(build_libdir)/libopenlibm.a
 	cp $< $@
 	$(INSTALL_NAME_CMD)libopenlibm.$(SHLIB_EXT) $@
 
@@ -669,7 +666,7 @@ install-openlibm: $(OPENLIBM_OBJ_TARGET)
 
 OPENSPECFUN_FLAGS = ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC) FFLAGS="$(JFFLAGS)" USE_OPENLIBM=1 OPENLIBM_HOME=$(JULIAHOME)/deps/openlibm
 
-OPENSPECFUN_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libopenspecfun.$(SHLIB_EXT)
+OPENSPECFUN_OBJ_TARGET = $(build_libdir)/libopenspecfun.$(SHLIB_EXT)
 OPENSPECFUN_OBJ_SOURCE = openspecfun/libopenspecfun.$(SHLIB_EXT)
 
 openspecfun/Makefile openspecfun/Makefile.extras:
@@ -681,14 +678,10 @@ ifeq (exists, $(shell [ -d $(JULIAHOME)/.git/modules/deps/openspecfun ] && echo 
 $(OPENSPECFUN_OBJ_SOURCE): $(JULIAHOME)/.git/modules/deps/openspecfun/HEAD
 endif
 $(OPENSPECFUN_OBJ_SOURCE): openspecfun/Makefile
-	$(MAKE) -C openspecfun $(OPENSPECFUN_FLAGS)
+	$(MAKE) -C openspecfun $(OPENSPECFUN_FLAGS) $(MAKE_COMMON)
 	touch -c $@
-$(OPENSPECFUN_OBJ_TARGET): $(OPENSPECFUN_OBJ_SOURCE) | $(BUILD)/lib
-ifeq ($(OS),WINNT)
-	cp openspecfun/libopenspecfun.a $(BUILD)/lib/libopenspecfun.a
-else
-	cp openspecfun/libopenspecfun.a $(BUILD)/$(JL_LIBDIR)/libopenspecfun.a
-endif
+$(OPENSPECFUN_OBJ_TARGET): $(OPENSPECFUN_OBJ_SOURCE) | $(build_libdir)
+	cp openspecfun/libopenspecfun.a $(build_libdir)/libopenspecfun.a
 	cp $< $@
 	$(INSTALL_NAME_CMD)libopenspecfun.$(SHLIB_EXT) $@
 
@@ -706,7 +699,7 @@ install-openspecfun: $(OPENSPECFUN_OBJ_TARGET)
 
 ## LIBRANDOM ##
 
-LIBRANDOM_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/librandom.$(SHLIB_EXT)
+LIBRANDOM_OBJ_TARGET = $(build_libdir)/librandom.$(SHLIB_EXT)
 LIBRANDOM_OBJ_SOURCE = random/librandom.$(SHLIB_EXT)
 
 LIBRANDOM_CFLAGS = $(CFLAGS) -O3 -finline-functions -fomit-frame-pointer -DNDEBUG -fno-strict-aliasing \
@@ -746,12 +739,12 @@ install-random: $(LIBRANDOM_OBJ_TARGET)
 
 ## Rmath ##
 
-RMATH_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libRmath-julia.$(SHLIB_EXT)
+RMATH_OBJ_TARGET = $(build_libdir)/libRmath-julia.$(SHLIB_EXT)
 RMATH_OBJ_SOURCE = Rmath/src/libRmath-julia.$(SHLIB_EXT)
 
 RMATH_FLAGS += CC="$(CC)" USECLANG=$(USECLANG) USEGCC=$(USEGCC) \
 			   OS="$(OS)" ARCH="$(ARCH)" \
-			   USE_LIBRANDOM=1 LIBRANDOM_PATH="$(BUILD)/$(JL_LIBDIR)"
+			   USE_LIBRANDOM=1 LIBRANDOM_PATH="$(build_libdir)"
 
 Rmath/Make.inc:
 	(cd .. && git submodule init && git submodule update)
@@ -762,9 +755,9 @@ ifeq (exists, $(shell [ -d $(JULIAHOME)/.git/modules/deps/Rmath ] && echo exists
 $(RMATH_OBJ_SOURCE): $(JULIAHOME)/.git/modules/deps/Rmath/HEAD
 endif
 $(RMATH_OBJ_SOURCE): Rmath/Make.inc $(LIBRANDOM_OBJ_TARGET)
-	$(MAKE) -C Rmath/src $(RMATH_FLAGS)
+	$(MAKE) -C Rmath/src $(RMATH_FLAGS) $(MAKE_COMMON)
 	touch -c $@
-$(RMATH_OBJ_TARGET): $(RMATH_OBJ_SOURCE) | $(BUILD)/lib
+$(RMATH_OBJ_TARGET): $(RMATH_OBJ_SOURCE) | $(build_libdir)
 	cp $< $@
 	$(INSTALL_NAME_CMD)libRmath-julia.$(SHLIB_EXT) $@
 
@@ -785,7 +778,7 @@ install-Rmath: $(RMATH_OBJ_TARGET)
 # LAPACK is built into OpenBLAS by default
 
 OPENBLAS_OBJ_SOURCE = openblas-$(OPENBLAS_VER)/libopenblas.$(SHLIB_EXT)
-OPENBLAS_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libopenblas.$(SHLIB_EXT)
+OPENBLAS_OBJ_TARGET = $(build_libdir)/libopenblas.$(SHLIB_EXT)
 
 OPENBLAS_BUILD_OPTS = CC="$(CC)" FC="$(FC)" RANLIB="$(RANLIB)" FFLAGS="$(FFLAGS) $(JFFLAGS)" TARGET=$(OPENBLAS_TARGET_ARCH)
 
@@ -871,12 +864,12 @@ endif
 $(OPENBLAS_OBJ_SOURCE): openblas-$(OPENBLAS_VER)/config.status
 	$(MAKE) -C openblas-$(OPENBLAS_VER) $(OPENBLAS_BUILD_OPTS) || (echo "*** Clean the OpenBLAS build with 'make -C deps clean-openblas'. Rebuild with 'make OPENBLAS_USE_THREAD=0 if OpenBLAS had trouble linking libpthread.so, and with 'make OPENBLAS_TARGET_ARCH=NEHALEM' if there were errors building SandyBridge support. Both these options can also be used simultaneously. ***" && false)
 	touch -c $@
-$(OPENBLAS_OBJ_TARGET): $(OPENBLAS_OBJ_SOURCE) | $(BUILD)/lib
-	cp -f openblas-$(OPENBLAS_VER)/libopenblas.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)
+$(OPENBLAS_OBJ_TARGET): $(OPENBLAS_OBJ_SOURCE) | $(build_libdir)
+	cp -f openblas-$(OPENBLAS_VER)/libopenblas.$(SHLIB_EXT) $(build_libdir)
 ifeq ($(OS), Linux)
-	ln -sf $(BUILD)/$(JL_LIBDIR)/libopenblas.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libopenblas.$(SHLIB_EXT).0
+	ln -sf $(build_libdir)/libopenblas.$(SHLIB_EXT) $(build_libdir)/libopenblas.$(SHLIB_EXT).0
 endif
-	$(INSTALL_NAME_CMD)libopenblas.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libopenblas.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libopenblas.$(SHLIB_EXT) $(build_libdir)/libopenblas.$(SHLIB_EXT)
 
 clean-openblas:
 	-$(MAKE) -C openblas-$(OPENBLAS_VER) clean
@@ -897,8 +890,8 @@ install-openblas: $(OPENBLAS_OBJ_TARGET)
 # configure script will search for the best match
 # (gcc 4.7, gcc, clang,ICC/microsoft/others)
 ATLAS_OBJ_SOURCE = atlas/build/lib/libsatlas.$(SHLIB_EXT)
-ATLAS_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libsatlas.$(SHLIB_EXT)
-ATLAS_FLAGS = --shared --prefix=$(BUILD) --cc=gcc -t 0 \
+ATLAS_OBJ_TARGET = $(build_libdir)/libsatlas.$(SHLIB_EXT)
+ATLAS_FLAGS = --shared --prefix=$(build_prefix) --cc=gcc -t 0 \
 	--with-netlib-lapack-tarfile=$(JULIAHOME)/deps/lapack-$(LAPACK_VER).tgz
 ifeq ($(OS), WINNT)
 ATLAS_FLAGS += -b 32 
@@ -966,7 +959,7 @@ endif
 libgfortblas.dylib: gfortblas.c gfortblas.alias
 	$(CC) -Wall -O3 $(CPPFLAGS) $(CFLAGS) $(fPIC) -shared $< -o $@ -pipe \
 				-Wl,-reexport_framework,vecLib -Wl,-alias_list,gfortblas.alias
-$(BUILD)/$(JL_LIBDIR)/libgfortblas.dylib: libgfortblas.dylib
+$(build_libdir)/libgfortblas.dylib: libgfortblas.dylib
 	cp -f $< $@
 	$(INSTALL_NAME_CMD)libgfortblas.dylib $@
 endif
@@ -974,7 +967,7 @@ endif
 ## LAPACK ##
 
 ifeq ($(USE_SYSTEM_LAPACK), 0)
-LAPACK_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/liblapack.$(SHLIB_EXT)
+LAPACK_OBJ_TARGET = $(build_libdir)/liblapack.$(SHLIB_EXT)
 LAPACK_OBJ_SOURCE = lapack-$(LAPACK_VER)/liblapack.$(SHLIB_EXT)
 else
 LAPACK_OBJ_TARGET =
@@ -983,7 +976,7 @@ endif
 
 LAPACK_MFLAGS = NOOPT="$(FFLAGS) $(JFFLAGS) $(GFORTBLAS_FFLAGS) -O0" OPTS="$(FFLAGS) $(JFFLAGS) $(GFORTBLAS_FFLAGS)" FORTRAN="$(FC)" LOADER="$(FC)"
 ifneq ($(OS),WINNT)
-LAPACK_MFLAGS += BLASLIB="-Wl,-rpath,'$(BUILD)/lib' $(LIBBLAS)"
+LAPACK_MFLAGS += BLASLIB="-Wl,-rpath,'$(build_libdir)' $(LIBBLAS)"
 endif
 
 lapack-$(LAPACK_VER).tgz:
@@ -995,7 +988,7 @@ lapack-$(LAPACK_VER)/Makefile: lapack-$(LAPACK_VER).tgz
 ifeq ($(USE_SYSTEM_BLAS), 0)
 lapack-$(LAPACK_VER)/liblapack.a: | $(OPENBLAS_OBJ_TARGET)
 else ifeq ($(OS),Darwin)
-lapack-$(LAPACK_VER)/liblapack.a: | $(BUILD)/$(JL_LIBDIR)/libgfortblas.dylib
+lapack-$(LAPACK_VER)/liblapack.a: | $(build_libdir)/libgfortblas.dylib
 endif
 lapack-$(LAPACK_VER)/liblapack.a: lapack-$(LAPACK_VER)/Makefile
 	cd lapack-$(LAPACK_VER) && \
@@ -1038,13 +1031,13 @@ ARPACK_OBJ_SOURCE = arpack-ng-$(ARPACK_VER)/.libs/libarpack-2.$(SHLIB_EXT)
 else
 ARPACK_OBJ_SOURCE = arpack-ng-$(ARPACK_VER)/.libs/libarpack.$(SHLIB_EXT)
 endif
-ARPACK_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libarpack.$(SHLIB_EXT)
+ARPACK_OBJ_TARGET = $(build_libdir)/libarpack.$(SHLIB_EXT)
 
 ARPACK_MFLAGS = F77="$(FC)" MPIF77="$(FC)"
 ARPACK_FFLAGS += $(FFLAGS) $(JFFLAGS)
 ARPACK_FLAGS = --with-blas="$(LIBBLAS)" --with-lapack="$(LIBLAPACK)" --disable-mpi --enable-shared FFLAGS="$(ARPACK_FFLAGS)"
 ifneq ($(OS),WINNT)
-ARPACK_FLAGS += LDFLAGS="-Wl,-rpath,'$(BUILD)/lib'"
+ARPACK_FLAGS += LDFLAGS="-Wl,-rpath,'$(build_libdir)'"
 endif
 
 arpack-ng-$(ARPACK_VER).tar.gz:
@@ -1077,15 +1070,15 @@ arpack-ng-$(ARPACK_VER)/checked: $(ARPACK_OBJ_SOURCE)
 	$(MAKE) check $(ARPACK_MFLAGS) && \
 	cd TESTS && $(call spawn,./dnsimp$(EXE))
 	echo 1 > $@
-$(ARPACK_OBJ_TARGET): $(ARPACK_OBJ_SOURCE) arpack-ng-$(ARPACK_VER)/checked | $(BUILD)/lib
+$(ARPACK_OBJ_TARGET): $(ARPACK_OBJ_SOURCE) arpack-ng-$(ARPACK_VER)/checked | $(build_libdir)
 	cd arpack-ng-$(ARPACK_VER) && \
-	$(MAKE) install $(ARPACK_MFLAGS)
+	$(MAKE) install $(ARPACK_MFLAGS) $(MAKE_COMMON)
 ifeq ($(OS), WINNT)
-	mv $(BUILD)/bin/libarpack-2.dll $@
+	mv $(build_bindir)/libarpack-2.dll $@
 endif
-	$(INSTALL_NAME_CMD)libarpack.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libarpack.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libarpack.$(SHLIB_EXT) $(build_libdir)/libarpack.$(SHLIB_EXT)
 ifeq ($(OS), Linux)
-	for filename in $(BUILD)/$(JL_LIBDIR)/libarpack.so* ; do \
+	for filename in $(build_libdir)/libarpack.so* ; do \
 		[ -L $$filename ] || $(PATCHELF) --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
@@ -1112,8 +1105,8 @@ else
 FFTW_SINGLE_SRC_TARGET = fftw-$(FFTW_VER)-single/.libs/libfftw3f.$(SHLIB_EXT)
 FFTW_DOUBLE_SRC_TARGET = fftw-$(FFTW_VER)-double/.libs/libfftw3.$(SHLIB_EXT)
 endif
-FFTW_SINGLE_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libfftw3f.$(SHLIB_EXT)
-FFTW_DOUBLE_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libfftw3.$(SHLIB_EXT)
+FFTW_SINGLE_OBJ_TARGET = $(build_libdir)/libfftw3f.$(SHLIB_EXT)
+FFTW_DOUBLE_OBJ_TARGET = $(build_libdir)/libfftw3.$(SHLIB_EXT)
 
 FFTW_CONFIG = --enable-shared --disable-fortran --disable-mpi --enable-fma --enable-threads
 ifneq ($(ARCH), ppc64)
@@ -1151,16 +1144,17 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 $(FFTW_SINGLE_OBJ_TARGET): $(FFTW_SINGLE_SRC_TARGET) fftw-$(FFTW_VER)-single/checked
-	$(MAKE) -C fftw-$(FFTW_VER)-single install
+	$(MAKE) -C fftw-$(FFTW_VER)-single install $(MAKE_COMMON)
 	touch -c $@
 ifeq ($(OS), Darwin)
-	$(INSTALL_NAME_CMD)libfftw3f.dylib $(BUILD)/$(JL_LIBDIR)/libfftw3f.dylib
-	$(INSTALL_NAME_CMD)libfftw3f_threads.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libfftw3f_threads.$(SHLIB_EXT)
-	$(INSTALL_NAME_CHANGE_CMD) $(BUILD)/$(JL_LIBDIR)/libfftw3f.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3f.dylib $(BUILD)/$(JL_LIBDIR)/libfftw3f_threads.dylib
+	$(INSTALL_NAME_CMD)libfftw3f.dylib $(build_libdir)/libfftw3f.dylib
+	$(INSTALL_NAME_CMD)libfftw3f_threads.$(SHLIB_EXT) $(build_libdir)/libfftw3f_threads.$(SHLIB_EXT)
+	$(INSTALL_NAME_CHANGE_CMD) $(build_libdir)/libfftw3f.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3f.dylib $(build_libdir)/libfftw3f_threads.dylib
 else ifeq ($(OS), WINNT)
-	mv -f $(BUILD)/$(JL_LIBDIR)/libfftw3f-3.dll $@
+	# note that on windows, we need to use $(build_bindir), not $(build_libdir)
+	mv -f $(build_bindir)/libfftw3f-3.dll $@
 else ifeq ($(OS), Linux)
-	for filename in $(BUILD)/$(JL_LIBDIR)/libfftw3f_threads.so* ; do \
+	for filename in $(build_libdir)/libfftw3f_threads.so* ; do \
 		[ -L $$filename ] || $(PATCHELF) --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
@@ -1189,15 +1183,16 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 $(FFTW_DOUBLE_OBJ_TARGET): $(FFTW_DOUBLE_SRC_TARGET) fftw-$(FFTW_VER)-double/checked
-	$(MAKE) -C fftw-$(FFTW_VER)-double install
+	$(MAKE) -C fftw-$(FFTW_VER)-double install $(MAKE_COMMON)
 ifeq ($(OS), Darwin)
-	$(INSTALL_NAME_CMD)libfftw3.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libfftw3.$(SHLIB_EXT)
-	$(INSTALL_NAME_CMD)libfftw3_threads.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libfftw3_threads.$(SHLIB_EXT)
-	$(INSTALL_NAME_CHANGE_CMD) $(BUILD)/$(JL_LIBDIR)/libfftw3.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3.dylib $(BUILD)/$(JL_LIBDIR)/libfftw3_threads.dylib
+	$(INSTALL_NAME_CMD)libfftw3.$(SHLIB_EXT) $(build_libdir)/libfftw3.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libfftw3_threads.$(SHLIB_EXT) $(build_libdir)/libfftw3_threads.$(SHLIB_EXT)
+	$(INSTALL_NAME_CHANGE_CMD) $(build_libdir)/libfftw3.3.dylib $(INSTALL_NAME_ID_DIR)libfftw3.dylib $(build_libdir)/libfftw3_threads.dylib
 else ifeq ($(OS), WINNT)
-	mv -f $(BUILD)/$(JL_LIBDIR)/libfftw3-3.dll $@
+	# note that on windows, we need to use $(build_bindir), not $(build_libdir)
+	mv -f $(build_bindir)/libfftw3-3.dll $@
 else ifeq ($(OS), Linux)
-	for filename in $(BUILD)/$(JL_LIBDIR)/libfftw3_threads.so* ; do \
+	for filename in $(build_libdir)/libfftw3_threads.so* ; do \
 		[ -L $$filename ] || $(PATCHELF) --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
@@ -1234,8 +1229,8 @@ install-fftw-double: $(FFTW_DOUBLE_OBJ_TARGET)
 ## UTF8PROC ##
 
 UTF8PROC_OBJ_SOURCE = utf8proc-v$(UTF8PROC_VER)/libutf8proc.a
-UTF8PROC_OBJ_LIB = $(BUILD)/$(JL_LIBDIR)/libutf8proc.a
-UTF8PROC_OBJ_HEADER = $(BUILD)/include/utf8proc.h
+UTF8PROC_OBJ_LIB = $(build_libdir)/libutf8proc.a
+UTF8PROC_OBJ_HEADER = $(build_includedir)/utf8proc.h
 UTF8PROC_OBJ_TARGET = $(UTF8PROC_OBJ_LIB) $(UTF8PROC_OBJ_HEADER)
 
 utf8proc-v$(UTF8PROC_VER).tar.gz:
@@ -1269,7 +1264,7 @@ install-utf8proc: $(UTF8PROC_OBJ_TARGET)
 ## SUITESPARSE ##
 
 SUITESPARSE_OBJ_SOURCE = SuiteSparse-$(SUITESPARSE_VER)/UMFPACK/Lib/libumfpack.a
-SUITESPARSE_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT)
+SUITESPARSE_OBJ_TARGET = $(build_libdir)/libspqr.$(SHLIB_EXT)
 
 ifeq ($(USE_BLAS64), 1)
 UMFPACK_CONFIG = -DLONGBLAS='long long' 
@@ -1283,10 +1278,10 @@ SUITE_SPARSE_LIB += -lrt
 endif
 endif
 ifneq ($(OS), WINNT)
-SUITE_SPARSE_LIB += -Wl,-rpath,'$(BUILD)/lib'
+SUITE_SPARSE_LIB += -Wl,-rpath,'$(build_libdir)'
 endif
 SUITESPARSE_MFLAGS = CC="$(CC)" CXX="$(CXX)" F77="$(FC)" AR="$(AR)" RANLIB="$(RANLIB)" BLAS="$(LIBBLAS)" LAPACK="$(LIBLAPACK)" \
-	  INSTALL_LIB="$(BUILD)/lib" INSTALL_INCLUDE="$(BUILD)/include" LIB="$(SUITE_SPARSE_LIB)" \
+	  INSTALL_LIB="$(build_libdir)" INSTALL_INCLUDE="$(build_includedir)" LIB="$(SUITE_SPARSE_LIB)" \
 	  UMFPACK_CONFIG="$(UMFPACK_CONFIG)" CHOLMOD_CONFIG="$(CHOLMOD_CONFIG)"
 
 SuiteSparse-$(SUITESPARSE_VER).tar.gz:
@@ -1318,20 +1313,20 @@ $(SUITESPARSE_OBJ_TARGET): $(SUITESPARSE_OBJ_SOURCE)
 	cd SuiteSparse-$(SUITESPARSE_VER)/lib && \
 	rm -f *.a && \
 	cp -f `find .. -name libamd.a -o -name libcolamd.a -o -name libcamd.a -o -name libccolamd.a -o -name libcholmod.a -o -name libumfpack.a -o -name libsuitesparseconfig.a -o -name libspqr.a 2>/dev/null` . && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libamd.$(SHLIB_EXT) && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libcolamd.$(SHLIB_EXT) && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libcamd.a $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libcamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libcamd.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libcamd.$(SHLIB_EXT) && \
-	$(CC) -shared $(WHOLE_ARCHIVE) libccolamd.a $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libccolamd.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libccolamd.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libccolamd.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) -L$(BUILD)/$(JL_LIBDIR) -lcolamd -lamd -lcamd -lccolamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libcholmod.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) -L$(BUILD)/$(JL_LIBDIR) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libumfpack.$(SHLIB_EXT) && \
-	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(BUILD)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT) -L$(BUILD)/$(JL_LIBDIR) -lcholmod -lcolamd -lamd $(LIBLAPACK) $(RPATH_ORIGIN) && \
-	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(BUILD)/$(JL_LIBDIR)/libspqr.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) libamd.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(build_libdir)/libamd.$(SHLIB_EXT) && \
+	$(CC) -shared $(WHOLE_ARCHIVE) libcolamd.a  $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libcolamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(build_libdir)/libcolamd.$(SHLIB_EXT) && \
+	$(CC) -shared $(WHOLE_ARCHIVE) libcamd.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libcamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libcamd.$(SHLIB_EXT) $(build_libdir)/libcamd.$(SHLIB_EXT) && \
+	$(CC) -shared $(WHOLE_ARCHIVE) libccolamd.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libccolamd.$(SHLIB_EXT) && \
+	$(INSTALL_NAME_CMD)libccolamd.$(SHLIB_EXT) $(build_libdir)/libccolamd.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libcholmod.a  $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libcholmod.$(SHLIB_EXT) -L$(build_libdir) -lcolamd -lamd -lcamd -lccolamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(build_libdir)/libcholmod.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libumfpack.a  $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libumfpack.$(SHLIB_EXT) -L$(build_libdir) -lcholmod -lcolamd -lamd $(LIBBLAS) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(build_libdir)/libumfpack.$(SHLIB_EXT) && \
+	$(CXX) -shared $(WHOLE_ARCHIVE) libsuitesparseconfig.a libspqr.a  $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libspqr.$(SHLIB_EXT) -L$(build_libdir) -lcholmod -lcolamd -lamd $(LIBLAPACK) $(RPATH_ORIGIN) && \
+	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(build_libdir)/libspqr.$(SHLIB_EXT)
 
 clean-suitesparse:
 	-$(MAKE) -C SuiteSparse-$(SUITESPARSE_VER) clean
@@ -1352,29 +1347,29 @@ SUITESPARSE_INC = -I /usr/include/suitesparse
 SUITESPARSE_LIB = -lumfpack -lcholmod -lamd -lcamd -lcolamd -lspqr
 else
 SUITESPARSE_INC = -I SuiteSparse-$(SUITESPARSE_VER)/CHOLMOD/Include -I SuiteSparse-$(SUITESPARSE_VER)/SuiteSparse_config -I SuiteSparse-$(SUITESPARSE_VER)/SPQR/Include
-SUITESPARSE_LIB = -L$(BUILD)/$(JL_LIBDIR) -lcholmod -lumfpack -lspqr $(RPATH_ORIGIN)
-$(BUILD)/$(JL_LIBDIR)/libsuitesparse_wrapper.$(SHLIB_EXT):  $(SUITESPARSE_OBJ_TARGET)
+SUITESPARSE_LIB = -L$(build_libdir) -lcholmod -lumfpack -lspqr $(RPATH_ORIGIN)
+$(build_libdir)/libsuitesparse_wrapper.$(SHLIB_EXT):  $(SUITESPARSE_OBJ_TARGET)
 endif
 
-$(BUILD)/$(JL_LIBDIR)/libsuitesparse_wrapper.$(SHLIB_EXT): SuiteSparse_wrapper.c
+$(build_libdir)/libsuitesparse_wrapper.$(SHLIB_EXT): SuiteSparse_wrapper.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -O2 -shared $(fPIC) $(SUITESPARSE_INC) $< -o $@ $(SUITESPARSE_LIB)
 	$(INSTALL_NAME_CMD)libsuitesparse_wrapper.$(SHLIB_EXT) $@
 	touch -c $@
 
 clean-suitesparse-wrapper:
-	-rm -f $(SUITESPARSE_OBJ_TARGET) $(BUILD)/$(JL_LIBDIR)/libsuitesparse_wrapper.$(SHLIB_EXT)
+	-rm -f $(SUITESPARSE_OBJ_TARGET) $(build_libdir)/libsuitesparse_wrapper.$(SHLIB_EXT)
 distclean-suitesparse-wrapper: clean-suitesparse-wrapper
 
 get-suitesparse-wrapper:
 configure-suitesparse-wrapper:
 compile-suitesparse-wrapper:
 check-suitesparse-wrapper:
-install-suitesparse-wrapper: $(BUILD)/$(JL_LIBDIR)/libsuitesparse_wrapper.$(SHLIB_EXT)
+install-suitesparse-wrapper: $(build_libdir)/libsuitesparse_wrapper.$(SHLIB_EXT)
 
 
 ## UNWIND ##
 
-LIBUNWIND_TARGET_OBJ = $(BUILD)/$(JL_LIBDIR)/libunwind.a
+LIBUNWIND_TARGET_OBJ = $(build_libdir)/libunwind.a
 LIBUNWIND_TARGET_SOURCE = libunwind-$(UNWIND_VER)/src/.libs/libunwind.a
 LIBUNWIND_CFLAGS = $(CFLAGS) -U_FORTIFY_SOURCE $(fPIC)
 
@@ -1397,10 +1392,10 @@ endif
 	echo 1 > $@
 #todo: libunwind tests known to fail
 $(LIBUNWIND_TARGET_OBJ): $(LIBUNWIND_TARGET_SOURCE)
-	$(MAKE) install -C libunwind-$(UNWIND_VER)
+	$(MAKE) install -C libunwind-$(UNWIND_VER) $(MAKE_COMMON)
 ifeq ($(ARCH), ppc64)
 	# workaround for configure script bug
-	mv $(BUILD)/lib64/libunwind*.a $(BUILD)/lib/
+	mv $(build_prefix)/lib64/libunwind*.a $(build_libdir)
 endif
 
 clean-unwind:
@@ -1419,7 +1414,7 @@ install-unwind: $(LIBUNWIND_TARGET_OBJ)
 
 OSXUNWIND_FLAGS = ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC) CFLAGS="-ggdb3 -O0" CXXFLAGS="-ggdb3 -O0" SFLAGS="-ggdb3" LDFLAGS="-Wl,-macosx_version_min,10.7"
 
-OSXUNWIND_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libosxunwind.$(SHLIB_EXT)
+OSXUNWIND_OBJ_TARGET = $(build_libdir)/libosxunwind.$(SHLIB_EXT)
 OSXUNWIND_OBJ_SOURCE = libosxunwind-$(OSXUNWIND_VER)/libosxunwind.$(SHLIB_EXT)
 
 libosxunwind-$(OSXUNWIND_VER).tar.gz: 
@@ -1432,10 +1427,10 @@ libosxunwind-$(OSXUNWIND_VER)/Makefile: libosxunwind-$(OSXUNWIND_VER).tar.gz
 $(OSXUNWIND_OBJ_SOURCE): libosxunwind-$(OSXUNWIND_VER)/Makefile
 	$(MAKE) -C libosxunwind-$(OSXUNWIND_VER) $(OSXUNWIND_FLAGS)
 	touch -c $@
-$(OSXUNWIND_OBJ_TARGET): $(OSXUNWIND_OBJ_SOURCE) | $(BUILD)/lib
-	cp libosxunwind-$(OSXUNWIND_VER)/libosxunwind.a $(BUILD)/lib/libosxunwind.a
+$(OSXUNWIND_OBJ_TARGET): $(OSXUNWIND_OBJ_SOURCE) | $(build_libdir)
+	cp libosxunwind-$(OSXUNWIND_VER)/libosxunwind.a $(build_libdir)/libosxunwind.a
 	cp $< $@
-	cp -R libosxunwind-$(OSXUNWIND_VER)/include/* $(BUILD)/include
+	cp -R libosxunwind-$(OSXUNWIND_VER)/include/* $(build_includedir)
 	$(INSTALL_NAME_CMD)libosxunwind.$(SHLIB_EXT) $@
 
 clean-osxunwind:
@@ -1452,7 +1447,7 @@ install-osxunwind: $(OSXUNWIND_OBJ_TARGET)
 ## GMP ##
 
 GMP_SRC_TARGET = gmp-$(GMP_VER)/.libs/libgmp.$(SHLIB_EXT)
-GMP_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libgmp.$(SHLIB_EXT)
+GMP_OBJ_TARGET = $(build_libdir)/libgmp.$(SHLIB_EXT)
 
 gmp-$(GMP_VER).tar.bz2:
 	$(JLDOWNLOAD) $@ ftp://ftp.gmplib.org/pub/gmp-$(GMP_VER)/$@
@@ -1471,11 +1466,7 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 $(GMP_OBJ_TARGET): $(GMP_SRC_TARGET) gmp-$(GMP_VER)/checked
-	$(MAKE) -C gmp-$(GMP_VER) $(LIBTOOL_CCLD) install
-ifeq ($(OS),WINNT)
-	mv -f $(BUILD)/lib/libgmp.lib $(BUILD)/$(JL_LIBDIR)/libgmp.lib
-	mv -f $(BUILD)/lib/libgmp.dll $@
-endif
+	$(MAKE) -C gmp-$(GMP_VER) $(LIBTOOL_CCLD) install $(MAKE_COMMON)
 	$(INSTALL_NAME_CMD)libgmp.dylib $@
 	touch -c $@
 
@@ -1498,9 +1489,9 @@ endif
 ## MPFR ##
 
 MPFR_SRC_TARGET = mpfr-$(MPFR_VER)/src/.libs/libmpfr.$(SHLIB_EXT)
-MPFR_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libmpfr.$(SHLIB_EXT)
+MPFR_OBJ_TARGET = $(build_libdir)/libmpfr.$(SHLIB_EXT)
 ifeq ($(OS),Darwin)
-MPFR_CHECK_MFLAGS = LDFLAGS="-Wl,-rpath,'$(BUILD)/$(JL_LIBDIR)'"
+MPFR_CHECK_MFLAGS = LDFLAGS="-Wl,-rpath,'$(build_libdir)'"
 endif
 
 mpfr-$(MPFR_VER).tar.bz2:
@@ -1520,7 +1511,7 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 $(MPFR_OBJ_TARGET): $(MPFR_SRC_TARGET) mpfr-$(MPFR_VER)/checked
-	$(MAKE) -C mpfr-$(MPFR_VER) $(LIBTOOL_CCLD) install
+	$(MAKE) -C mpfr-$(MPFR_VER) $(LIBTOOL_CCLD) install $(MAKE_COMMON)
 	$(INSTALL_NAME_CMD)libmpfr.dylib $@
 	touch -c $@
 
@@ -1543,7 +1534,7 @@ ZLIB_SRC_TARGET = zlib-$(ZLIB_VER)/zlib1.$(SHLIB_EXT)
 else
 ZLIB_SRC_TARGET = zlib-$(ZLIB_VER)/libz.$(SHLIB_EXT)
 endif
-ZLIB_OBJ_TARGET = $(BUILD)/$(JL_LIBDIR)/libz.$(SHLIB_EXT)
+ZLIB_OBJ_TARGET = $(build_libdir)/libz.$(SHLIB_EXT)
 ZLIB_CONFIGFLAGS = CFLAGS="-O3 $(CFLAGS) -D_FILE_OFFSET_BITS=64"
 ifneq ($(OS),$(BUILD_OS))
 ZLIB_CONFIGFLAGS += CHOST=$(XC_HOST)
@@ -1562,22 +1553,22 @@ ifeq ($(OS), WINNT)
 	cp win32/Makefile.gcc Makefile
 else
 	cd zlib-$(ZLIB_VER) && \
-	$(ZLIB_CONFIGFLAGS) ./configure --prefix=$(abspath $(BUILD)) #not an autoconf script
+	$(ZLIB_CONFIGFLAGS) ./configure --prefix=$(abspath $(build_prefix)) #not an autoconf script
 endif
 	echo 1 > $@
 $(ZLIB_SRC_TARGET): zlib-$(ZLIB_VER)/config.status
-	$(MAKE) -C zlib-$(ZLIB_VER) PREFIX=$(CROSS_COMPILE)
+	$(MAKE) -C zlib-$(ZLIB_VER)
 	touch -c $@
 zlib-$(ZLIB_VER)/checked: $(ZLIB_SRC_TARGET)
 ifneq ($(OS), WINNT)
-	$(MAKE) -C zlib-$(ZLIB_VER) check PREFIX=$(CROSS_COMPILE)
+	$(MAKE) -C zlib-$(ZLIB_VER) check prefix=$(CROSS_COMPILE)
 endif
 	echo 1 > $@
 $(ZLIB_OBJ_TARGET): $(ZLIB_SRC_TARGET) zlib-$(ZLIB_VER)/checked
 ifeq ($(OS), WINNT)
 	cp zlib-$(ZLIB_VER)/zlib1.dll $@
 else
-	$(MAKE) -C zlib-$(ZLIB_VER) install PREFIX=$(CROSS_COMPILE)
+	$(MAKE) -C zlib-$(ZLIB_VER) install prefix=$(CROSS_COMPILE) $(MAKE_COMMON)
 endif
 	$(INSTALL_NAME_CMD)libz.dylib $@
 	touch -c $@
@@ -1598,7 +1589,7 @@ install-zlib: $(ZLIB_OBJ_TARGET)
 ## patchelf ##
 
 PATCHELF_SOURCE = patchelf-$(PATCHELF_VER)/src/patchelf
-PATCHELF_TARGET = $(BUILD)/bin/patchelf
+PATCHELF_TARGET = $(build_bindir)/patchelf
 
 compile-patchelf: install-patchelf
 install-patchelf: $(PATCHELF_TARGET)
@@ -1622,7 +1613,7 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 $(PATCHELF_TARGET): $(PATCHELF_SOURCE) patchelf-$(PATCHELF_VER)/checked
-	$(MAKE) -C patchelf-$(PATCHELF_VER) install
+	$(MAKE) -C patchelf-$(PATCHELF_VER) install $(MAKE_COMMON)
 	touch -c $@
 
 clean-patchelf:
@@ -1640,7 +1631,7 @@ install-patchelf: $(PATCHELF_TARGET)
 ## Git
 
 GIT_SOURCE = git-$(GIT_VER)/src/git
-GIT_TARGET = $(BUILD)/git
+GIT_TARGET = $(build_prefix)/git
 
 git-$(GIT_VER).tar.gz:
 	$(JLDOWNLOAD) $@ http://git-core.googlecode.com/files/$@
@@ -1649,7 +1640,7 @@ git-$(GIT_VER)/configure: git-$(GIT_VER).tar.gz
 	touch -c $@
 git-$(GIT_VER)/config.status: git-$(GIT_VER)/configure
 	cd git-$(GIT_VER) && \
-	./configure $(CONFIGURE_COMMON) --bindir="$(BUILD)/libexec"
+	./configure $(CONFIGURE_COMMON) --bindir="$(build_libexecdir)"
 	touch -c $@
 $(GIT_SOURCE): git-$(GIT_VER)/config.status
 	$(MAKE) -C git-$(GIT_VER)
@@ -1657,7 +1648,7 @@ $(GIT_SOURCE): git-$(GIT_VER)/config.status
 git-$(GIT_VER)/checked: $(GIT_SOURCE)
 	echo 1 > $@
 $(GIT_TARGET): $(GIT_SOURCE) git-$(GIT_VER)/checked
-	$(MAKE) -C git-$(GIT_VER) install NO_INSTALL_HARDLINKS=1
+	$(MAKE) -C git-$(GIT_VER) install NO_INSTALL_HARDLINKS=1 $(MAKE_COMMON)
 	touch -c $@
 
 clean-git:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -155,7 +155,7 @@ linkcheck: juliadoc-pkg
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
 doctest: juliadoc-pkg
-	PATH=$(PATH):../usr/bin $(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
+	PATH=$(PATH):$(build_bindir) $(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,7 +5,7 @@ override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
 
 FLAGS = -Wall -Wno-strict-aliasing -fno-omit-frame-pointer \
-	-I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(BUILD)/include $(CFLAGS) 
+	-I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(build_includedir) $(CFLAGS) 
 
 DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
@@ -13,11 +13,7 @@ JLDFLAGS += $(LDFLAGS) $(NO_WHOLE_ARCHIVE) $(call exec,$(LLVM_CONFIG) --ldflags)
 
 ifeq ($(USE_SYSTEM_LIBM),0)
 ifneq ($(UNTRUSTED_SYSTEM_LIBM),0)
-ifeq ($(OS),WINNT)
-JLDFLAGS += $(WHOLE_ARCHIVE) $(BUILD)/lib/libopenlibm.a $(NO_WHOLE_ARCHIVE)
-else
-JLDFLAGS += $(WHOLE_ARCHIVE) $(BUILD)/$(JL_LIBDIR)/libopenlibm.a $(NO_WHOLE_ARCHIVE)
-endif
+JLDFLAGS += $(WHOLE_ARCHIVE) $(build_libdir)/libopenlibm.a $(NO_WHOLE_ARCHIVE)
 endif
 endif
 
@@ -31,18 +27,18 @@ release debug:
 %.do: %.c
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 
-embedding: $(BUILD)/bin/embedding$(EXE)
-embedding-debug: $(BUILD)/bin/embedding-debug$(EXE)
+embedding: $(build_bindir)/embedding$(EXE)
+embedding-debug: $(build_bindir)/embedding-debug$(EXE)
 
-$(BUILD)/bin/embedding$(EXE): embedding.o
-	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(BUILD)/$(JL_PRIVATE_LIBDIR) -L$(BUILD)/$(JL_LIBDIR) -ljulia $(JLDFLAGS))
-$(BUILD)/bin/embedding-debug$(EXE): embedding.do
-	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(BUILD)/$(JL_PRIVATE_LIBDIR) -L$(BUILD)/$(JL_LIBDIR) -ljulia-debug $(JLDFLAGS))
+$(build_bindir)/embedding$(EXE): embedding.o
+	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -ljulia $(JLDFLAGS))
+$(build_bindir)/embedding-debug$(EXE): embedding.do
+	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -ljulia-debug $(JLDFLAGS))
 
 
 clean: | $(CLEAN_TARGETS)
 	rm -f *.o *.do
-	rm -f $(BUILD)/bin/embedding-debug $(BUILD)/bin/embedding
+	rm -f $(build_bindir)/embedding-debug $(build_bindir)/embedding
 
 .PHONY: clean release debug
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,14 +14,14 @@ FLAGS = \
 	-Wall -Wno-strict-aliasing -fno-omit-frame-pointer \
 	-Iflisp -Isupport -fvisibility=hidden -fno-common \
 	-I$(call exec,$(LLVM_CONFIG) --includedir) \
-	-I$(LIBUV_INC) -I$(JULIAHOME)/usr/include -DLIBRARY_EXPORTS
+	-I$(LIBUV_INC) -I$(build_includedir) -DLIBRARY_EXPORTS
 
 LLVMLINK = $(call exec,$(LLVM_CONFIG) --libs) $(call exec,$(LLVM_CONFIG) --system-libs 2> /dev/null)
 ifeq ($(USE_LLVM_SHLIB),1)
 LLVMLINK = -lLLVM-$(LLVM_VER)
 endif
 
-LIBS = $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a -L$(BUILD)/lib $(LIBUV) $(LIBUTF8PROC) $(NO_WHOLE_ARCHIVE) $(call exec,$(LLVM_CONFIG) --ldflags) $(LLVMLINK) $(OSLIBS)
+LIBS = $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a -L$(build_libdir) $(LIBUV) $(LIBUTF8PROC) $(NO_WHOLE_ARCHIVE) $(call exec,$(LLVM_CONFIG) --ldflags) $(LLVMLINK) $(OSLIBS)
 
 ifneq ($(MAKECMDGOALS),debug)
 TARGET =
@@ -75,13 +75,13 @@ support/libsupport.a: support/*.h support/*.c
 flisp/libflisp.a: flisp/*.h flisp/*.c support/libsupport.a
 	$(MAKE) -C flisp
 
-$(BUILD)/$(JL_LIBDIR)/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a $(LIBUV)
+$(build_libdir)/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a $(LIBUV)
 	@$(call PRINT_LINK, $(CXX) $(DEBUGFLAGS) $(DOBJS) $(RPATH_ORIGIN) -shared -o $@ $(LDFLAGS) $(LIBS))
 	$(INSTALL_NAME_CMD)libjulia-debug.$(SHLIB_EXT) $@
 libjulia-debug.a: julia.expmap $(DOBJS) flisp/libflisp.a support/libsupport.a
 	rm -f $@
 	@$(call PRINT_LINK, ar -rcs $@ $(DOBJS))
-libjulia-debug: $(BUILD)/$(JL_LIBDIR)/libjulia-debug.$(SHLIB_EXT)
+libjulia-debug: $(build_libdir)/libjulia-debug.$(SHLIB_EXT)
 
 ifeq ($(SHLIB_EXT), so)
   SONAME = -Wl,-soname=libjulia.so
@@ -89,16 +89,16 @@ else
   SONAME =
 endif
 
-$(BUILD)/$(JL_LIBDIR)/libjulia.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a $(LIBUV)
+$(build_libdir)/libjulia.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a $(LIBUV)
 	@$(call PRINT_LINK, $(CXX) $(SHIPFLAGS) $(OBJS) $(RPATH_ORIGIN) -shared -o $@ $(LDFLAGS) $(LIBS) $(SONAME))
 	$(INSTALL_NAME_CMD)libjulia.$(SHLIB_EXT) $@
 libjulia.a: julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
 	rm -f $@
 	@$(call PRINT_LINK, ar -rcs $@ $(OBJS))
-libjulia-release: $(BUILD)/$(JL_LIBDIR)/libjulia.$(SHLIB_EXT)
+libjulia-release: $(build_libdir)/libjulia.$(SHLIB_EXT)
 
 clean:
-	-rm -f $(BUILD)/$(JL_LIBDIR)/libjulia*
+	-rm -f $(build_libdir)/libjulia*
 	-rm -f julia_flisp.boot julia_flisp.boot.inc
 	-rm -f *.do *.o *~ *# *.$(SHLIB_EXT) *.a h2j
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,7 +18,7 @@ perf:
 
 clean:
 	@$(MAKE) -C perf $@
-	-rm -f libccalltest.${SHLIB_EXT} ccalltest
+	-rm -f libccalltest.$(SHLIB_EXT) ccalltest
 
 .PHONY: $(TESTS) perf clean
 

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -5,7 +5,7 @@ override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
 
 FLAGS = -Wall -Wno-strict-aliasing -fno-omit-frame-pointer \
-	-I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(BUILD)/include
+	-I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(build_includedir)
 
 DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
@@ -13,11 +13,7 @@ JLDFLAGS += $(LDFLAGS) $(NO_WHOLE_ARCHIVE) $(call exec,$(LLVM_CONFIG) --ldflags)
 
 ifeq ($(USE_SYSTEM_LIBM),0)
 ifneq ($(UNTRUSTED_SYSTEM_LIBM),0)
-ifeq ($(OS),WINNT)
-JLDFLAGS += $(WHOLE_ARCHIVE) $(BUILD)/lib/libopenlibm.a $(NO_WHOLE_ARCHIVE)
-else
-JLDFLAGS += $(WHOLE_ARCHIVE) $(BUILD)/$(JL_LIBDIR)/libopenlibm.a $(NO_WHOLE_ARCHIVE)
-endif
+JLDFLAGS += $(WHOLE_ARCHIVE) $(build_libdir)/libopenlibm.a $(NO_WHOLE_ARCHIVE)
 endif
 endif
 
@@ -33,40 +29,40 @@ release debug:
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 
 ifeq ($(OS),WINNT)
-$(BUILD)/bin/julia.bat: ${JULIAHOME}/contrib/windows/*.bat
-	cp ${JULIAHOME}/contrib/windows/*.bat ${BUILD}/bin
-julia-release julia-debug: $(BUILD)/bin/julia.bat
+$(build_bindir)/julia.bat: $(JULIAHOME)/contrib/windows/*.bat
+	cp $(JULIAHOME)/contrib/windows/*.bat $(build_bindir)
+julia-release julia-debug: $(build_bindir)/julia.bat
 julia_res.o: $(JULIAHOME)/contrib/windows/julia.rc
-	JLVER=`cat ${JULIAHOME}/VERSION` && \
+	JLVER=`cat $(JULIAHOME)/VERSION` && \
 	JLVERi=`echo $$JLVER | perl -nle \
 		'/^(\d+)\.?(\d*)\.?(\d*)/ && \
 		print int $$1,",",int $$2,",0,",int $$3'` && \
 	$(CROSS_COMPILE)windres $< -O coff -o $@ -DJLVER=$$JLVERi -DJLVER_STR=\\\"$$JLVER\\\"
-$(BUILD)/bin/julia-readline$(EXE): julia_res.o
-$(BUILD)/bin/julia-debug-readline$(EXE): julia_res.o
-$(BUILD)/bin/julia-basic$(EXE): julia_res.o
-$(BUILD)/bin/julia-debug-basic$(EXE): julia_res.o
+$(build_bindir)/julia-readline$(EXE): julia_res.o
+$(build_bindir)/julia-debug-readline$(EXE): julia_res.o
+$(build_bindir)/julia-basic$(EXE): julia_res.o
+$(build_bindir)/julia-debug-basic$(EXE): julia_res.o
 JLDFLAGS += julia_res.o
 endif 
 
-julia-basic: $(BUILD)/bin/julia-basic$(EXE)
-julia-debug-basic: $(BUILD)/bin/julia-debug-basic$(EXE)
-julia-readline: $(BUILD)/bin/julia-readline$(EXE)
-julia-debug-readline: $(BUILD)/bin/julia-debug-readline$(EXE)
+julia-basic: $(build_bindir)/julia-basic$(EXE)
+julia-debug-basic: $(build_bindir)/julia-debug-basic$(EXE)
+julia-readline: $(build_bindir)/julia-readline$(EXE)
+julia-debug-readline: $(build_bindir)/julia-debug-readline$(EXE)
 
-$(BUILD)/bin/julia-basic$(EXE): repl.o repl-basic.o
-	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(BUILD)/$(JL_PRIVATE_LIBDIR) -L$(BUILD)/$(JL_LIBDIR) -ljulia $(JLDFLAGS))
-$(BUILD)/bin/julia-debug-basic$(EXE): repl.do repl-basic.do
-	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(BUILD)/$(JL_PRIVATE_LIBDIR) -L$(BUILD)/$(JL_LIBDIR) -ljulia-debug $(JLDFLAGS))
+$(build_bindir)/julia-basic$(EXE): repl.o repl-basic.o
+	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -ljulia $(JLDFLAGS))
+$(build_bindir)/julia-debug-basic$(EXE): repl.do repl-basic.do
+	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -ljulia-debug $(JLDFLAGS))
 
-$(BUILD)/bin/julia-readline$(EXE): repl.o repl-readline.o
-	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ $(READLINE) -L$(BUILD)/$(JL_PRIVATE_LIBDIR) -L$(BUILD)/$(JL_LIBDIR) -ljulia $(JLDFLAGS)) || (echo "*** Please ensure that the ncurses-devel package is installed on your OS, and try again. ***" && false)
-$(BUILD)/bin/julia-debug-readline$(EXE): repl.do repl-readline.do
-	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ $(READLINE) -L$(BUILD)/$(JL_PRIVATE_LIBDIR) -L$(BUILD)/$(JL_LIBDIR) -ljulia-debug $(JLDFLAGS))
+$(build_bindir)/julia-readline$(EXE): repl.o repl-readline.o
+	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ $(READLINE) -L$(build_private_libdir) -L$(build_libdir) -ljulia $(JLDFLAGS)) || (echo "*** Please ensure that the ncurses-devel package is installed on your OS, and try again. ***" && false)
+$(build_bindir)/julia-debug-readline$(EXE): repl.do repl-readline.do
+	@$(call PRINT_LINK, $(CXX) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ $(READLINE) -L$(build_private_libdir) -L$(build_libdir) -ljulia-debug $(JLDFLAGS))
 
 clean: | $(CLEAN_TARGETS)
 	rm -f *.o *.do
-	rm -f $(BUILD)/bin/julia-*-basic $(BUILD)/bin/julia-*-readline $(BUILD)/bin/julia
+	rm -f $(build_bindir)/julia-*-basic $(build_bindir)/julia-*-readline $(build_bindir)/julia
 
 .PHONY: clean release debug julia-release julia-debug
 

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -9,8 +9,10 @@
 #include "../src/julia.h"
 
 #ifndef JL_SYSTEM_IMAGE_PATH
-#define JL_SYSTEM_IMAGE_PATH ".." PATHSEPSTRING "lib" PATHSEPSTRING "julia" PATHSEPSTRING "sys.ji"
+#error "JL_SYSTEM_IMAGE_PATH not defined!"
 #endif
+
+char system_image[256] = JL_SYSTEM_IMAGE_PATH;
 
 static int lisp_prompt = 0;
 static int codecov=0;
@@ -58,7 +60,7 @@ void parse_opts(int *argcp, char ***argvp)
     int c;
     opterr = 0;
     int imagepathspecified=0;
-    image_file = JL_SYSTEM_IMAGE_PATH;
+    image_file = system_image;
     int skip = 0;
     int lastind = optind;
     while ((c = getopt_long(*argcp,*argvp,shortopts,longopts,0)) != -1) {
@@ -122,8 +124,8 @@ void parse_opts(int *argcp, char ***argvp)
             char path[512];
             if (!imagepathspecified) {
                 // build time path relative to JULIA_HOME
-                snprintf(path, sizeof(path), "%s%s",
-                         julia_home, PATHSEPSTRING JL_SYSTEM_IMAGE_PATH);
+                snprintf(path, sizeof(path), "%s%s%s",
+                         julia_home, PATHSEPSTRING, system_image);
                 image_file = strdup(path);
             }
             else if (jl_stat(image_file, (char*)&stbuf) != 0) {


### PR DESCRIPTION
This is a huge patchset, I know.  I've done as much testing as I can (OSX, Ubuntu, Fedora, Windows cross-compile) but I'd like to get some other people to test it if possible before merging.  The motivating factors for this are mostly to adhere to standard practice as much as possible, and to clean up the way installation directories are handled in general.  Comments are welcome, here is a summary of what these changes represent:
- Change/create Makefile variables to more standard names
  - `$(PREFIX)` -> `$(prefix)`, `$(PREFIX)/bin` -> `$(bindir)`, etc.
  - Also create new `$(build_prefix)` and `$(build_bindir)` makevars to abstract away "build time" tree layout from "install time" tree layout
  - Because we can now flexibly set the build layout, a fair amount of windows-specific checks and moves can be removed
    - we just set `$(build_libdir) = $(build_bindir)`, and this transparently makes its way through configure scripts and Makefiles
- Relocates binaries' RPATH entries on install
  - This is necessary when build-time tree layout != install-time tree layout
  - Better than changing build-time tree layout, as that requires a reconfiguration of all deps
  - Only done if the relative path from `julia` to `libjulia` changes between compilation and installation
- Adds tool to replace strings in binaries (`contrib/stringpatch.c`)
  - Used to overwrite `image_file` hardcoded in julia binary in `ui/repl.c` [here]().
  - Source modified to include ample extra space so if the new path is longer, we don't overwrite anything important
  - This modification is only done if the relative path from `julia` to `sys.ji` changes between compilation and installation
    - You can prevent this from happening if you know apriori what install-time tree layout you want, by setting `build_libdir` and friends at build time.
- Passes `make testall` in both the build directory (e.g. after a `make`) and in a foreign installed directory (e.g. after a `make install prefix=/usr/local libdir=/usr/local/lib64 DESTDIR=/tmp/jdst`) on OSX, Ubuntu and Windows cross-compile.
- Changes `$(libdir)` on windows to be equal to `$(bindir)` instead of equal to just `bin`.  This gets rid of some special-cases we've needed in the past.
