### PR TITLE
Fix/create getindex and == generic for (Sym)Tridiagonal in base/linalg/tridiag.jl, slight cleanup of Woodbury show

### DIFF
--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -150,7 +150,7 @@ det(A::SymTridiagonal) = det_usmani(A.ev, A.dv, A.ev)
 
 function getindex{T}(A::SymTridiagonal{T}, i::Integer, j::Integer)
     (1<=i<=size(A,2) && 1<=j<=size(A,2)) || throw(BoundsError())
-    i==j ? A.dv[i] : i==j+1 ? A.ev[i] : i+1==j ? A.ev[i] : zero(T)
+    i==j ? A.dv[i] : i==j+1 ? A.ev[j] : i+1==j ? A.ev[i] : zero(T)
 end
 
 ## Tridiagonal matrices ##
@@ -237,6 +237,12 @@ function diag{T}(M::Tridiagonal{T}, n::Integer=0)
         throw(BoundsError())
     end
 end
+
+function getindex{T}(A::Tridiagonal{T}, i::Integer, j::Integer)
+    (1<=i<=size(A,2) && 1<=j<=size(A,2)) || throw(BoundsError())
+    i==j ? A.d[i] : i==j+1 ? A.dl[j] : i+1==j ? A.du[i] : zero(T)
+end
+
 
 ###################
 # Generic methods #

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -250,7 +250,7 @@ end
 
 ==(A::Tridiagonal, B::Tridiagonal) = (A.dl==B.dl) && (A.d==B.d) && (A.du==B.du)
 ==(A::Tridiagonal, B::SymTridiagonal) = (A.dl==A.du==B.ev) && (A.d==B.dv)
-==(A::SymTridiagonal, B::SymTridiagonal) = B==A
+==(A::SymTridiagonal, B::Tridiagonal) = (B.dl==B.du==A.ev) && (B.d==A.dv)
 
 inv(A::Tridiagonal) = inv_usmani(A.dl, A.d, A.du)
 det(A::Tridiagonal) = det_usmani(A.dl, A.d, A.du)

--- a/base/linalg/woodbury.jl
+++ b/base/linalg/woodbury.jl
@@ -40,7 +40,7 @@ size(W::Woodbury) = size(W.A)
 
 function show(io::IO, W::Woodbury)
     println(io, summary(W), ":")
-    print(io, "A: ", W.A)
+    print(io, "A:\n", W.A)
     print(io, "\nU:\n")
     print_matrix(io, W.U)
     if isa(W.C, Matrix)


### PR DESCRIPTION
This fixes the fix to [Issue #5507](https://github.com/JuliaLang/julia/issues/5507), corrects the generic == for (Sym)Diagonals, and slightly improves the show method for Woodbury.
