### PR TITLE
Avoid 32-bit possible integer overflow in test.jl.

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -73,7 +73,7 @@ function test_approx_eq(va, vb, Eps, astr, bstr)
 end
 
 test_approx_eq(va, vb, astr, bstr) =
-    test_approx_eq(va, vb, 10^4*length(va)*max(eps(float(maximum(abs(va)))), eps(float(maximum(abs(vb))))), astr, bstr)
+    test_approx_eq(va, vb, 1E4*length(va)*max(eps(float(maximum(abs(va)))), eps(float(maximum(abs(vb))))), astr, bstr)
 
 macro test_approx_eq_eps(a, b, c)
     :(test_approx_eq($(esc(a)), $(esc(b)), $(esc(c)), $(string(a)), $(string(b))))


### PR DESCRIPTION
fixes JuliaDSP/DSP.jl/issues/18 
unfortunately does not fix #5472
