### PR TITLE
Removed Base.randsym, which is undefined.

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -635,7 +635,6 @@ export
     qrp,
     qrpfact!,
     qrpfact,
-    randsym,
     rank,
     rref,
     scale!,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -95,7 +95,6 @@ export
     qrp,
     qrpfact!,
     qrpfact,
-    randsym,
     rank,
     rref,
     scale,


### PR DESCRIPTION
There is a symbol `randsym` exported from Base, but not defined. It appears in `names(Base)`. It also has the following tab completion behavior:

```
julia> Base.rands
Base.randsym     Base.randstring  
julia> Base.randsym
ERROR: randsym not defined
```

I couldn't find any trace of it in base, other than these two exports. I assume it was just removed/renamed at some point?
