### PR TITLE
Testing Woodbury with same random numbers on 32 and 64 bit system.

### DIFF
--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -387,13 +387,13 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
         d = rand(1:100, n)
         dl = -rand(0:10, n-1)
         du = -rand(0:10, n-1)
-        v = rand(1:100, n)
+        v = int(rand(int64(1:100), n))
         B = rand(1:100, n, 2)
 
-        # Woodbury
-        U = rand(1:100, n, 2)
-        V = rand(1:100, 2, n)
-        C = rand(1:100, 2, 2)
+        # Woodbury (use same integers on 32-bit and 64-bit systems)
+        U = int(rand(int64(1:100), n, 2))
+        V = int(rand(int64(1:100), 2, n))
+        C = int(rand(int64(1:100), 2, 2))
     else 
         d = convert(Vector{elty}, d)
         dl = convert(Vector{elty}, dl)


### PR DESCRIPTION
Fixes #5472. Likely the test criterion in this case is a bit too sharp, but that is unrelated to 32-bit or 64 questions.
