### PR TITLE
add norm=... keyword argument to quadgk

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4272,7 +4272,7 @@ Although several external packages are available for numeric integration
 and solution of ordinary differential equations, we also provide
 some built-in integration support in Julia.
 
-.. function:: quadgk(f, a,b,c...; reltol=sqrt(eps), abstol=0, maxevals=10^7, order=7)
+.. function:: quadgk(f, a,b,c...; reltol=sqrt(eps), abstol=0, maxevals=10^7, order=7, norm=norm)
 
    Numerically integrate the function ``f(x)`` from ``a`` to ``b``,
    and optionally over additional intervals ``b`` to ``c`` and so on.
@@ -4299,7 +4299,11 @@ some built-in integration support in Julia.
 
    The integrand ``f(x)`` can return any numeric scalar, vector, or matrix
    type, or in fact any type supporting ``+``, ``-``, multiplication
-   by real values, and a ``norm`` (i.e., any normed vector space).
+   by real values, and a ``norm`` (i.e., any normed vector space). 
+   Alternatively, a different norm can be specified by passing a `norm`-like
+   function as the `norm` keyword argument (which defaults to `norm` for
+   most types, except for matrices where the default is the L1 norm since
+   it is cheaper to compute).
 
    The algorithm is an adaptive Gauss-Kronrod integration technique:
    the integral in each interval is estimated using a Kronrod rule

--- a/test/math.jl
+++ b/test/math.jl
@@ -191,6 +191,7 @@ end
 @test_approx_eq quadgk(x -> exp(x), -Inf,0)[1] 1.0
 @test_approx_eq quadgk(x -> exp(-x^2), -Inf,Inf)[1] sqrt(pi)
 @test_approx_eq quadgk(x -> [exp(-x), exp(-2x)], 0, Inf)[1] [1,0.5]
+@test_approx_eq quadgk(cos, 0,0.7,1, norm=abs)[1] sin(1)
 
 # Ensure subnormal flags functions don't segfault
 @test any(ccall("jl_zero_subnormals", Uint8, (Uint8,), 1) .== [0x00 0x01])


### PR DESCRIPTION
As discussed in JuliaLang/ODE.jl#7, there is no reason not to let the user specify the desired error norm to use in the convergence criterion.   (e.g. there is potentially a big difference betwen converging in the L2 and Linf norms if you have a vector-valued integrand.)

cc: @tlycken 
