### PR TITLE
Use shared utf8proc library when USE_SYSTEM_UTF8PROC=1

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -354,7 +354,7 @@ endif
 endif
 
 ifeq ($(USE_SYSTEM_UTF8PROC), 1)
-  LIBUTF8PROC = /usr/lib/libutf8proc.a
+  LIBUTF8PROC = -lutf8proc
 else
   LIBUTF8PROC = $(BUILD)/$(JL_LIBDIR)/libutf8proc.a
 endif


### PR DESCRIPTION
Distribution policies strongly discourage statically linking to libraries in packages [1]  since security fixes and other bug fixes are not likely to be applied on time (and they would require a rebuild of the package anyway). People passing `USE_SYSTEM_UTF8PROC=1` are likely to prefer dynamic linking too, since I don't think many distributions provide static versions of utf8proc.

This patch seems to work but honestly it's worth checking a little more. :-)

1: https://fedoraproject.org/wiki/Packaging:Guidelines#Packaging_Static_Libraries_2
