### PR TITLE
Key and value iterators show their contents on the REPL

### DIFF
--- a/base/repl.jl
+++ b/base/repl.jl
@@ -33,6 +33,11 @@ function writemime(io::IO, ::MIME"text/plain", v::DataType)
     end
 end
 
+function writemime{K, V}(io::IO, ::MIME"text/plain", iter::Union(KeyIterator{Dict{K, V}}, ValueIterator{Dict{K, V}}))
+    print(io, "Iterator for ")
+    writemime(io, MIME("text/plain"), collect(iter))
+end
+
 # showing exception objects as descriptive error messages
 
 showerror(io::IO, e) = show(io, e)


### PR DESCRIPTION
@simonster suggested this idea. Since showing a key iterator on the REPL is currently dumping the whole dictionary using the most generic `show` routine, it seems we might as well show just the dictionary keys. A frequent complaint about Python 3 is that its inconvenient to inspect dictionaries on the REPL since you constantly forced to collect the key iterators, so why not avoid that. 
