### PR TITLE
change `whicht` to return rather than call `show`

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -94,8 +94,7 @@ function whicht(f, types)
         d = f.env.defs
         while !is(d,())
             if is(d.func.code, lsd)
-                display(d)
-                return
+                return d
             end
             d = d.next
         end


### PR DESCRIPTION
I would argue this is more useful. When run in the repl the returned value will be shown nicely, when run elsewhere the result can be used.
