### PR TITLE
Fix search for bsdtar

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -234,9 +234,11 @@ LDFLAGS += -fsanitize=address
 endif
 
 TAR=`which gtar || which tar`
-TAR_TEST := $(shell $(TAR) --help 2>&1  | grep strip-components)
+TAR_TEST := $(shell $(TAR) --help 2>&1  | grep 'bsdtar\|strip-components')
 ifeq (,$(findstring components,$(TAR_TEST)))
+ifneq (bsdtar,$(findstring bsdtar,$(TAR_TEST)))
 $(error "please install either GNU tar or bsdtar")
+endif
 endif
 
 # ===========================================================================


### PR DESCRIPTION
Using `tar --help` on `bsdtar` doesn't show a `--strip-components` option like the GNU version (though it does show in the man page). Instead, explicitly check either for `strip-components` or `bsdtar`, which has supported strip-components for the same timeframe as GNU tar, with full support ~2006 for both.
