### PR TITLE
WIP: Use single call to dsfmt_gv_genrand_uint32() for small ranges

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -161,16 +161,35 @@ immutable RandIntGen{T<:Integer, U<:Unsigned}
     u::U   # maximum multiple of k within the domain of U
 
     RandIntGen(a::T, k::U) = new(a, k, div(typemax(U),k)*k)
+    RandIntGen(a::Uint64, k::Uint64) = new(a, k, div((k >> 32 != 0)*0xFFFFFFFF00000000 + 0x00000000FFFFFFFF, k)*k)
+    RandIntGen(a::Int64, k::Int64) = new(a, k, div((k >> 32 != 0)*0xFFFFFFFF00000000 + 0x00000000FFFFFFFF, k)*k)
+
 end
 
 RandIntGen{T<:Unsigned}(r::Range1{T}) = RandIntGen{T,T}(first(r), convert(T, length(r)))
-
 # specialized versions
 for (T, U) in [(Uint8, Uint32), (Uint16, Uint32), (Int8, Uint32), (Int16, Uint32), 
                (Int32, Uint32), (Int64, Uint64), (Int128, Uint128), 
                (Bool, Uint32), (Char, Uint32)]
 
     @eval RandIntGen(r::Range1{$T}) = RandIntGen{$T, $U}(first(r), convert($U, length(r)))
+end
+
+
+function rand{T<:Integer}(g::RandIntGen{T,Uint64})
+    local x::Uint64
+    if g.k >> 32 == 0
+        x = convert(Uint64,rand(Uint32))
+        while x >= g.u
+            x = convert(Uint64,rand(Uint32))
+        end
+    else
+        x = rand(Uint64)
+        while x >= g.u
+            x = rand(Uint64)
+        end
+    end
+    return convert(T, g.a + rem(x, g.k))
 end
 
 function rand{T<:Integer,U<:Unsigned}(g::RandIntGen{T,U})

--- a/base/random.jl
+++ b/base/random.jl
@@ -161,6 +161,7 @@ immutable RandIntGen{T<:Integer, U<:Unsigned}
     u::U   # maximum multiple of k within the domain of U
 
     RandIntGen(a::T, k::U) = new(a, k, div(typemax(U),k)*k)
+
     RandIntGen(a::Uint64, k::Uint64) = new(a, k, div((k >> 32 != 0)*0xFFFFFFFF00000000 + 0x00000000FFFFFFFF, k)*k)
     RandIntGen(a::Int64, k::Uint64) = new(a, k, div((k >> 32 != 0)*0xFFFFFFFF00000000 + 0x00000000FFFFFFFF, k)*k)
 
@@ -175,7 +176,8 @@ for (T, U) in [(Uint8, Uint32), (Uint16, Uint32), (Int8, Uint32), (Int16, Uint32
     @eval RandIntGen(r::Range1{$T}) = RandIntGen{$T, $U}(first(r), convert($U, length(r)))
 end
 
-
+# this function uses 32 bit entropy for small ranges of length <= typemax(Uint32)
+# the constructor of RandIntGen is responsible for providing the right value of k
 function rand{T<:Union(Uint64, Int64)}(g::RandIntGen{T,Uint64})
     local x::Uint64
     if g.k >> 32 == 0

--- a/base/random.jl
+++ b/base/random.jl
@@ -162,7 +162,7 @@ immutable RandIntGen{T<:Integer, U<:Unsigned}
 
     RandIntGen(a::T, k::U) = new(a, k, div(typemax(U),k)*k)
     RandIntGen(a::Uint64, k::Uint64) = new(a, k, div((k >> 32 != 0)*0xFFFFFFFF00000000 + 0x00000000FFFFFFFF, k)*k)
-    RandIntGen(a::Int64, k::Int64) = new(a, k, div((k >> 32 != 0)*0xFFFFFFFF00000000 + 0x00000000FFFFFFFF, k)*k)
+    RandIntGen(a::Int64, k::Uint64) = new(a, k, div((k >> 32 != 0)*0xFFFFFFFF00000000 + 0x00000000FFFFFFFF, k)*k)
 
 end
 

--- a/base/random.jl
+++ b/base/random.jl
@@ -176,12 +176,12 @@ for (T, U) in [(Uint8, Uint32), (Uint16, Uint32), (Int8, Uint32), (Int16, Uint32
 end
 
 
-function rand{T<:Integer}(g::RandIntGen{T,Uint64})
+function rand{T<:Union(Uint64, Int64)}(g::RandIntGen{T,Uint64})
     local x::Uint64
     if g.k >> 32 == 0
-        x = convert(Uint64,rand(Uint32))
+        x = rand(Uint32)
         while x >= g.u
-            x = convert(Uint64,rand(Uint32))
+            x = rand(Uint32)
         end
     else
         x = rand(Uint64)

--- a/base/random.jl
+++ b/base/random.jl
@@ -162,8 +162,8 @@ immutable RandIntGen{T<:Integer, U<:Unsigned}
 
     RandIntGen(a::T, k::U) = new(a, k, div(typemax(U),k)*k)
 
-    RandIntGen(a::Uint64, k::Uint64) = new(a, k, div((k >> 32 != 0)*0xFFFFFFFF00000000 + 0x00000000FFFFFFFF, k)*k)
-    RandIntGen(a::Int64, k::Uint64) = new(a, k, div((k >> 32 != 0)*0xFFFFFFFF00000000 + 0x00000000FFFFFFFF, k)*k)
+    RandIntGen(a::Uint64, k::Uint64) = new(a::T, k::U, div((k >> 32 != 0)*0xFFFFFFFF00000000 + 0x00000000FFFFFFFF, k)*k)
+    RandIntGen(a::Int64, k::Uint64) = new(a::T, k::U, div((k >> 32 != 0)*0xFFFFFFFF00000000 + 0x00000000FFFFFFFF, k)*k)
 
 end
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -383,7 +383,7 @@ C = randn(2,2)
 
 for elty in (Float32, Float64, Complex64, Complex128, Int)
     if elty == Int
-        srand(61516384)
+        srand(61516300)
         d = rand(1:100, n)
         dl = -rand(0:10, n-1)
         du = -rand(0:10, n-1)

--- a/test/random.jl
+++ b/test/random.jl
@@ -21,6 +21,9 @@ if sizeof(Int32) < sizeof(Int)
     r = rand(int32(-1):typemax(Int32))
     @test typeof(r) == Int32
     @test -1 <= r <= typemax(Int32)
+    @test all([div(typemax(Uint64),k)*k == Base.Random.RandIntGen(uint64(1:k)).u for k in 13 .+ int64(2).^(32:62)])
+    @test all([div(typemax(Uint64),k)*k == Base.Random.RandIntGen(int64(1:k)).u for k in 13 .+ int64(2).^(32:61)])
+
 end
 
 #same random numbers on for small ranges on all systems
@@ -36,7 +39,5 @@ r = uint64(rand(uint32(97:122)))
 srand(seed)
 @test r == rand(uint64(97:122))
 
-@test all([div(typemax(Uint32),k)*k == Base.Random.RandIntGen(uint64(1:k)).u for k in 13 .+ int64(2).^(1:31)])
-@test all([div(typemax(Uint64),k)*k == Base.Random.RandIntGen(uint64(1:k)).u for k in 13 .+ int64(2).^(32:62)])
-@test all([div(typemax(Uint32),k)*k == Base.Random.RandIntGen(int64(1:k)).u for k in 13 .+ int64(2).^(1:31)])
-@test all([div(typemax(Uint64),k)*k == Base.Random.RandIntGen(int64(1:k)).u for k in 13 .+ int64(2).^(32:61)])
+@test all([div(typemax(Uint32),k)*k == Base.Random.RandIntGen(uint64(1:k)).u for k in 13 .+ int64(2).^(1:30)])
+@test all([div(typemax(Uint32),k)*k == Base.Random.RandIntGen(int64(1:k)).u for k in 13 .+ int64(2).^(1:30)])

--- a/test/random.jl
+++ b/test/random.jl
@@ -23,9 +23,20 @@ if sizeof(Int32) < sizeof(Int)
     @test -1 <= r <= typemax(Int32)
 end
 
+#same random numbers on for small ranges on all systems
+
 seed = rand(Uint) #leave state nondeterministic as above
 srand(seed)
 r = int64(rand(int32(97:122)))
 srand(seed)
 @test r == rand(int64(97:122))
 
+srand(seed)
+r = uint64(rand(uint32(97:122)))
+srand(seed)
+@test r == rand(uint64(97:122))
+
+@test all([div(typemax(Uint32),k)*k == Base.Random.RandIntGen(uint64(1:k)).u for k in 13 .+ int64(2).^(1:31)])
+@test all([div(typemax(Uint64),k)*k == Base.Random.RandIntGen(uint64(1:k)).u for k in 13 .+ int64(2).^(32:62)])
+@test all([div(typemax(Uint32),k)*k == Base.Random.RandIntGen(int64(1:k)).u for k in 13 .+ int64(2).^(1:31)])
+@test all([div(typemax(Uint64),k)*k == Base.Random.RandIntGen(int64(1:k)).u for k in 13 .+ int64(2).^(32:61)])

--- a/test/random.jl
+++ b/test/random.jl
@@ -22,3 +22,10 @@ if sizeof(Int32) < sizeof(Int)
     @test typeof(r) == Int32
     @test -1 <= r <= typemax(Int32)
 end
+
+seed = rand(Uint) #leave state nondeterministic as above
+srand(seed)
+r = int64(rand(int32(97:122)))
+srand(seed)
+@test r == rand(int64(97:122))
+


### PR DESCRIPTION
This is just an idea regarding JuliaLang/julia#5549, ~~this way one looses the type stability in RandIntGen~~, but gains faster number generation, when length(r) <= typemax(Uint32)  and only one call to dsfmt_gv_genrand_uint32 to obtain entropy is needed.
