### PR TITLE
Added sharedarray unlink tests. Minor cleanup in sharedarray.

### DIFF
--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -21,53 +21,65 @@ a = convert(Array, d)
 @test fetch(@spawnat id_other localpart(d)[1,1]) == d[1,101]
 
 
-if haskey(ENV, "TEST_SHARED_ARRAY")
-    @unix_only begin
-    # SharedArray tests
-    dims = (20,20,20)
-    d = Base.shmem_rand(1:100, dims)
-    a = convert(Array, d)
+@unix_only begin
 
-    partsums = Array(Int, length(procs(d)))
-    @sync begin
-        for (i, p) in enumerate(procs(d))
-            @async partsums[i] = remotecall_fetch(p, D->sum(D.loc_subarr_1d), d)
-        end
-    end
-    @test sum(a) == sum(partsums)
+dims = (20,20,20)
 
-    d = Base.shmem_rand(dims)
-    for p in procs(d)
-        idxes_in_p = remotecall_fetch(p, D -> parentindexes(D.loc_subarr_1d)[1], d)
-        idxf = first(idxes_in_p)
-        idxl = last(idxes_in_p)
-        d[idxf] = float64(idxf)
-        rv = remotecall_fetch(p, (D,idxf,idxl) -> begin assert(D[idxf] == float64(idxf)); D[idxl] = float64(idxl); D[idxl];  end, d,idxf,idxl)
-        @test d[idxl] == rv
-    end
+@linux_only begin
+    S = SharedArray(Int64, dims)
+    @test beginswith(S.segname, "/jl")
+    @test !ispath("/dev/shm" * S.segname)    
 
-    @test ones(10, 10, 10) == Base.shmem_fill(1.0, (10,10,10))
-    @test zeros(Int32, 10, 10, 10) == Base.shmem_fill(0, (10,10,10))
-
-    d = SharedArray(Int, dims; init = D->fill!(D.loc_subarr_1d, myid()))
-    for p in procs(d)
-        idxes_in_p = remotecall_fetch(p, D -> parentindexes(D.loc_subarr_1d)[1], d)
-        idxf = first(idxes_in_p)
-        idxl = last(idxes_in_p)
-        @test d[idxf] == p 
-        @test d[idxl] == p 
-    end
-
-    # SharedArray as an array
-    # Since the data in d will depend on the nprocs, just test that these operations work
-    a = d[1:5]
-    @test_throws d[-1:5]
-    a = d[1,1,1:3:end]
-    d[2:4] = 7
-    d[5,1:2:4,8] = 19
-
-    end # @unix_only(SharedArray tests)
+    S = SharedArray(Int64, dims; pids=[id_other])
+    @test beginswith(S.segname, "/jl")
+    @test !ispath("/dev/shm" * S.segname)    
 end
+
+# TODO : Need a similar test of shmem cleanup for OSX
+
+# SharedArray tests
+d = Base.shmem_rand(1:100, dims)
+a = convert(Array, d)
+
+partsums = Array(Int, length(procs(d)))
+@sync begin
+    for (i, p) in enumerate(procs(d))
+        @async partsums[i] = remotecall_fetch(p, D->sum(D.loc_subarr_1d), d)
+    end
+end
+@test sum(a) == sum(partsums)
+
+d = Base.shmem_rand(dims)
+for p in procs(d)
+    idxes_in_p = remotecall_fetch(p, D -> parentindexes(D.loc_subarr_1d)[1], d)
+    idxf = first(idxes_in_p)
+    idxl = last(idxes_in_p)
+    d[idxf] = float64(idxf)
+    rv = remotecall_fetch(p, (D,idxf,idxl) -> begin assert(D[idxf] == float64(idxf)); D[idxl] = float64(idxl); D[idxl];  end, d,idxf,idxl)
+    @test d[idxl] == rv
+end
+
+@test ones(10, 10, 10) == Base.shmem_fill(1.0, (10,10,10))
+@test zeros(Int32, 10, 10, 10) == Base.shmem_fill(0, (10,10,10))
+
+d = SharedArray(Int, dims; init = D->fill!(D.loc_subarr_1d, myid()))
+for p in procs(d)
+    idxes_in_p = remotecall_fetch(p, D -> parentindexes(D.loc_subarr_1d)[1], d)
+    idxf = first(idxes_in_p)
+    idxl = last(idxes_in_p)
+    @test d[idxf] == p 
+    @test d[idxl] == p 
+end
+
+# SharedArray as an array
+# Since the data in d will depend on the nprocs, just test that these operations work
+a = d[1:5]
+@test_throws d[-1:5]
+a = d[1,1,1:3:end]
+d[2:4] = 7
+d[5,1:2:4,8] = 19
+
+end # @unix_only(SharedArray tests)
 
 
 # Test @parallel load balancing - all processors should get either M or M+1


### PR DESCRIPTION
The SharedArray constructor is expected to unlink the shmem segment and also close the `fd` from `shm_open` immediately after the segment has been mapped on all participating processes. This ensures an automatic release of the segment when the last process has unmapped the same.

This PR adds a test on Linux that tests for the non-existence of the shmem segment under `/dev/shm` after the construction. There does not seem to be an equivalent test under OSX.
