### PR TITLE
handle trailing whitespace in whitespace separated data

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -167,7 +167,7 @@ function dlm_offsets(sbuff::UTF8String, dlm, eol, begin_offsets::Array{Int,2}, e
         (val == eol) && (row += 1; col = 0)
         got_data = false
     end
-    if last_offset < slen
+    if (last_offset < slen) && (col < maxcol)
         col += 1
         begin_offsets[row,col] = last_offset+1
         end_offsets[row,col] = slen
@@ -196,7 +196,7 @@ function dlm_offsets(dbuff::Vector{Uint8}, dlm::Uint8, eol::Uint8, begin_offsets
         (val == eol) && (row += 1; col = 0)
         got_data = false
     end
-    if last_offset < slen
+    if (last_offset < slen) && (col < maxcol)
         col += 1
         begin_offsets[row,col] = last_offset+1
         end_offsets[row,col] = slen

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -29,6 +29,7 @@ result2 = reshape({1.0, 1.0, 2.0, 1.0, 3.0, "", 4.0, ""}, 2, 4)
 @test readdlm(IOBuffer(",,,1,,,,2,3,,,4,\n,,,1,,,1\n"), ',') == result1
 @test readdlm(IOBuffer("   1    2 3   4 \n   1   1\n")) == result2
 @test readdlm(IOBuffer("   1    2 3   4 \n   1   1\n"), ' ') == result1
+@test readdlm(IOBuffer("1 2\n3 4 \n")) == [[1.0, 3.0] [2.0, 4.0]]
 
 result1[1,4] = "भारत" 
 @test readdlm(IOBuffer(",,,भारत,,,,2,3,,,4,\n,,,1,,,1\n"), ',') == result1


### PR DESCRIPTION
Fixes the condition where additional white spaces in the last line of a whitespace delimited file threw errors. They will now be ignored.

```
julia> readdlm(IOBuffer("1 2 \n3 4 \n"))
2x2 Array{Float64,2}:
 1.0  2.0
 3.0  4.0

julia> readdlm(IOBuffer("1 2\n3 4 \n"))
2x2 Array{Float64,2}:
 1.0  2.0
 3.0  4.0
```
