### PR TITLE
Add @reexport macro

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1296,4 +1296,5 @@ export
     @sprintf,
     @deprecate,
     @boundscheck,
-    @inbounds
+    @inbounds,
+    @reexport


### PR DESCRIPTION
This would fix #1986. Syntax is:

``` julia
@reexport using MyModule1, MyModule2
```

Unlike my macro in #1986, this handles relative imports. It's a little awkward, since the macro expands into `using` and `eval` statements, but I couldn't find another way to do it. We might still want a new language keyword instead, but I figured I'd submit this as a PR and see what people think.
