### PR TITLE
Fix typo in symdiff(IntSet, IntSet). Closes #5618

### DIFF
--- a/base/intset.jl
+++ b/base/intset.jl
@@ -88,7 +88,7 @@ function setdiff!(s::IntSet, ns)
 end
 
 setdiff(a::IntSet, b::IntSet) = setdiff!(copy(a),b)
-symdiff(a::IntSet, b::IntSet) =
+symdiff(s1::IntSet, s2::IntSet) =
     (s1.limit >= s2.limit ? symdiff!(copy(s1), s2) : symdiff!(copy(s2), s1))
 
 function empty!(s::IntSet)

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -274,6 +274,9 @@ end
 @test setdiff(IntSet(1, 2, 3, 4), IntSet(2, 4, 5, 6)) == IntSet(1, 3)
 @test setdiff(Set(1, 2, 3, 4), Set(2, 4, 5, 6)) == Set(1, 3)
 
+@test symdiff(IntSet(1, 2, 3, 4), IntSet(2, 4, 5, 6)) == IntSet(1, 3, 5, 6)
+@test symdiff(Set(1, 2, 3, 4), Set(2, 4, 5, 6)) == Set(1, 3, 5, 6)
+
 s1 = Set(1, 2, 3, 4)
 setdiff!(s1, Set(2, 4, 5, 6))
 


### PR DESCRIPTION
Also adds test for symdiff over Sets and IntSets.
