### PR TITLE
Add a reexported keyword for use with using, import, and importall

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -86,6 +86,7 @@ jl_sym_t *compositetype_sym; jl_sym_t *type_goto_sym;
 jl_sym_t *global_sym; jl_sym_t *tuple_sym;
 jl_sym_t *dot_sym;    jl_sym_t *newvar_sym;
 jl_sym_t *boundscheck_sym; jl_sym_t *copyast_sym;
+jl_sym_t *reexported_sym;
 
 typedef struct {
     int64_t a;

--- a/src/init.c
+++ b/src/init.c
@@ -696,7 +696,7 @@ void julia_init(char *imageFile)
         jl_core_module->parent = jl_main_module;
         jl_set_const(jl_main_module, jl_symbol("Core"),
                      (jl_value_t*)jl_core_module);
-        jl_module_using(jl_main_module, jl_core_module);
+        jl_module_using(jl_main_module, jl_core_module, 0);
         jl_current_module = jl_core_module;
         jl_init_intrinsic_functions();
         jl_init_primitives();
@@ -743,7 +743,7 @@ void julia_init(char *imageFile)
         jl_add_standard_imports(jl_main_module);
     }
     // eval() uses Main by default, so Main.eval === Core.eval
-    jl_module_import(jl_main_module, jl_core_module, jl_symbol("eval"));
+    jl_module_import(jl_main_module, jl_core_module, jl_symbol("eval"), 0);
     jl_current_module = jl_main_module;
 
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2935,4 +2935,5 @@ void jl_init_types(void)
     boundscheck_sym = jl_symbol("boundscheck");
     newvar_sym = jl_symbol("newvar");
     copyast_sym = jl_symbol("copyast");
+    reexported_sym = jl_symbol("reexported");
 }

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1216,6 +1216,9 @@
 	(take-token s)
 	(loop (cons (symbol (string.sub (string nxt) 1))
 		    path)))
+       ((eq? nxt 'reexported)
+    (take-token s)
+    `(,word (reexported ,@(reverse path))))
        (else
 	(error (string "invalid \"" word "\" statement")))))))
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -425,6 +425,7 @@ extern jl_sym_t *abstracttype_sym; extern jl_sym_t *bitstype_sym;
 extern jl_sym_t *compositetype_sym; extern jl_sym_t *type_goto_sym;
 extern jl_sym_t *global_sym;  extern jl_sym_t *tuple_sym;
 extern jl_sym_t *boundscheck_sym; extern jl_sym_t *copyast_sym;
+extern jl_sym_t *reexported_sym;
 
 
 // object accessors -----------------------------------------------------------
@@ -783,10 +784,10 @@ DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val);
 DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val);
 DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs);
 DLLEXPORT void jl_declare_constant(jl_binding_t *b);
-DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from);
-DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
-DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
-DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from);
+DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from, int reexported);
+DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s, int reexported);
+DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s, int reexported);
+DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from, int reexported);
 DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
 void jl_add_standard_imports(jl_module_t *m);
 STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,7 @@ TESTS = all core keywordargs numbers strings unicode collections hashing	\
 	math functional bigint sorting statistics spawn parallel arpack file	\
 	git pkg resolve suitesparse complex version pollfd mpfr	broadcast       \
 	socket floatapprox priorityqueue readdlm regex float16 combinatorics    \
-	sysinfo rounding ranges mod2pi euler show
+	sysinfo rounding ranges mod2pi euler show reexported
 
 default: all
 

--- a/test/reexported.jl
+++ b/test/reexported.jl
@@ -1,0 +1,43 @@
+module testmod
+    exported = true
+    private = true
+    export exported
+end
+
+module usingmod
+    using testmod reexported, Base.Test
+    @test exported == true
+    @test !isdefined(:private)
+end
+
+module usingtestmod
+    using usingmod, Base.Test
+    @test exported == true
+    @test !isdefined(:private)
+end
+
+module importmod
+    import testmod.private reexported
+    using Base.Test
+    @test !isdefined(:exported)
+    @test private == true
+end
+
+module importtestmod
+    using importmod, Base.Test
+    @test !isdefined(:exported)
+    @test private == true
+end
+
+module importallmod
+    importall testmod reexported
+    using Base.Test
+    @test exported == true
+    @test !isdefined(:private)
+end
+
+module importalltestmod
+    using importallmod, Base.Test
+    @test exported == true
+    @test !isdefined(:private)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ testnames = [
     "priorityqueue", "arpack", "file", "suitesparse", "version",
     "resolve", "pollfd", "mpfr", "broadcast", "complex", "socket",
     "floatapprox", "readdlm", "regex", "float16", "combinatorics",
-    "sysinfo", "rounding", "ranges", "mod2pi", "euler", "show"
+    "sysinfo", "rounding", "ranges", "mod2pi", "euler", "show", "reexported"
 ]
 @unix_only push!(testnames, "unicode")
 


### PR DESCRIPTION
This is an alternative to #5608 that is similar to @vtjnash's proposal from #1986, although I didn't implement the `as` part of that proposal. Syntax is:

``` julia
using MyModule reexported, ...
import MyModule.fn reexported, ...
importall MyModule reexported, ...
```

I chose this approach over the others mentioned in #1986 because it wasn't clear to me what should happen if you try to `reexport MyModule` or `exportall MyModule` without first having called `importall MyModule` or `using MyModule`. It also avoids an additional reserved keyword since it is only applicable after `using`, `import`, or `importall`. I am not convinced it is a better option than #5608 (it's not any easier to use and it's a lot more code), but hopefully one of these can make it into Base.
