### PR TITLE
Lock package directory when executing Pkg commands

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -2,7 +2,7 @@ module Pkg
 
 export Git, Dir, GitHub, Types, Reqs, Cache, Read, Query, Resolve, Write, Generate, Entry
 export dir, init, rm, add, available, installed, status, clone, checkout,
-       release, fix, update, resolve, register, tag, publish, generate
+       release, fix, update, resolve, register, tag, publish, generate, rmlock
 
 const DEFAULT_META = "git://github.com/JuliaLang/METADATA.jl"
 const META_BRANCH = "metadata-v2"
@@ -11,6 +11,8 @@ for file in split("git dir github types reqs cache read query resolve write gene
     include("pkg/$file.jl")
 end
 const cd = Dir.cd
+
+const rmlock = Dir.rmlock
 
 dir(path...) = Dir.path(path...)
 init(meta::String=DEFAULT_META, branch::String=META_BRANCH) = Dir.init(meta,branch)

--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -4,8 +4,35 @@ import ..Pkg: DEFAULT_META, META_BRANCH
 import ..Git
 
 const DIR_NAME = ".julia"
+const LOCK_NAME = "pkg.lck"
 
 pkgroot() = abspath(get(ENV,"JULIA_PKGDIR",joinpath(homedir(),DIR_NAME)))
+
+function transact(f::Function)
+    lockpath = joinpath(pkgroot(), LOCK_NAME)
+    if isfile(lockpath)
+        error("Could not lock package directory;
+        If you are sure another instance of Pkg is not
+        being used, run Pkg.rmlock()")
+    end
+    try
+        open(lockpath, "w") do fh
+            write(fh, "")
+        end
+        return f()
+    finally
+        if isfile(lockpath)
+            rm(lockpath)
+        end
+    end
+end
+
+function rmlock()
+    lockpath = joinpath(pkgroot(), LOCK_NAME)
+    if isfile(lockpath)
+        rm(lockpath)
+    end
+end
 
 function path()
     b = pkgroot()
@@ -24,7 +51,9 @@ function cd(f::Function, args...; kws...)
         !haskey(ENV,"JULIA_PKGDIR") ? init() :
             error("package directory $dir doesn't exist; run Pkg.init() to create it.")
     end
-    Base.cd(()->f(args...; kws...), dir)
+    transact() do
+        Base.cd(()->f(args...; kws...), dir)
+    end
 end
 
 function init(meta::String=DEFAULT_META, branch::String=META_BRANCH)
@@ -32,16 +61,20 @@ function init(meta::String=DEFAULT_META, branch::String=META_BRANCH)
     info("Initializing package repository $dir")
     if isdir(joinpath(dir,"METADATA"))
         info("Package directory $dir is already initialized.")
-        Git.set_remote_url(meta, dir=joinpath(dir,"METADATA"))
+        transact() do 
+            Git.set_remote_url(meta, dir=joinpath(dir,"METADATA"))
+        end
         return
     end
     try
         mkpath(dir)
-        Base.cd(dir) do
-            info("Cloning METADATA from $meta")
-            run(`git clone -q -b $branch $meta METADATA`)
-            Git.set_remote_url(meta, dir="METADATA")
-            run(`touch REQUIRE`)
+        transact() do
+            Base.cd(dir) do
+                info("Cloning METADATA from $meta")
+                run(`git clone -q -b $branch $meta METADATA`)
+                Git.set_remote_url(meta, dir="METADATA")
+                run(`touch REQUIRE`)
+            end
         end
     catch e
         run(`rm -rf $dir`)


### PR DESCRIPTION
Possible fix for https://github.com/JuliaLang/julia/issues/5622.  Write a simple lock file to the package directory when executing Pkg commands to prevent multiple instances of Pkg clobbering the same directory.
