### PR TITLE
Document that map can operate on multiple collections.

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -618,11 +618,14 @@ Iterable Collections
 
    **Example**: ``all((i) -> i>i, [4,5,6]) = true``
 
-.. function:: map(f, c) -> collection
+.. function:: map(f, c...) -> collection
 
    Transform collection ``c`` by applying ``f`` to each element.
+   For multiple collection arguments, apply ``f`` elementwise.
 
-   **Example**: ``map((x) -> x * 2, [1, 2, 3]) = [2, 4, 6]``
+   **Examples**:
+     * ``map((x) -> x * 2, [1, 2, 3]) = [2, 4, 6]``
+     * ``map((x,y) -> x + y, [1, 2, 3], [10, 20, 30]) = [11, 22, 33]``
 
 .. function:: map!(function, collection)
 


### PR DESCRIPTION
Twice I'd had other users ask me if there is any way to apply `map` elementwise to multiple collections.   It's apparently been implemented that way, but not documented yet.  This pull request documents it.
