### PR TITLE
Fix cache dir creation to allow relative paths for JULIA_PKGDIR

### DIFF
--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -1,9 +1,7 @@
 module Cache
 
-import ..Git
+import ..Git, ..Dir
 using ..Types
-
-import ..Dir: pkgroot
 
 path(pkg::String) = abspath(".cache", pkg)
 
@@ -15,13 +13,15 @@ function mkcachedir()
 
     @windows_only mkdir(cache)
     @unix_only begin
-        rootcache = joinpath(realpath(pkgroot()), ".cache")
-        if !isdir(rootcache)
-            mkdir(rootcache)
-        end
-        if rootcache != cache
+        if Dir.isversioned(pwd())
+            rootcache = joinpath(realpath(".."), ".cache")
+            if !isdir(rootcache)
+                mkdir(rootcache)
+            end
             run(`ln -s $rootcache $cache`)
+            return
         end
+        mkdir(cache)
     end
 end
 

--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -5,11 +5,11 @@ import ..Git
 
 const DIR_NAME = ".julia"
 
-pkgroot() = abspath(get(ENV,"JULIA_PKGDIR",joinpath(homedir(),DIR_NAME)))
+_pkgroot() = abspath(get(ENV,"JULIA_PKGDIR",joinpath(homedir(),DIR_NAME)))
 isversioned(p::String) = ((x,y) = (VERSION.major, VERSION.minor); basename(p) == "v$x.$y")
 
 function path()
-    b = pkgroot()
+    b = _pkgroot()
     x, y = VERSION.major, VERSION.minor
     d = joinpath(b,"v$x.$y")
     if isdir(d) || !isdir(b) || !isdir(joinpath(b, "METADATA"))

--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -6,6 +6,7 @@ import ..Git
 const DIR_NAME = ".julia"
 
 pkgroot() = abspath(get(ENV,"JULIA_PKGDIR",joinpath(homedir(),DIR_NAME)))
+isversioned(p::String) = ((x,y) = (VERSION.major, VERSION.minor); basename(p) == "v$x.$y")
 
 function path()
     b = pkgroot()

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -1,4 +1,4 @@
-ENV["JULIA_PKGDIR"] = abspath(string("tmp.",randstring()))
+ENV["JULIA_PKGDIR"] = string("tmp.",randstring())
 @test !isdir(Pkg.dir())
 try # ensure directory removal
 	Pkg.init()


### PR DESCRIPTION
- Change cachedir creation to (re)allow relative paths for JULIA_PKGDIR
- Change pkgroot => _pkgroot, to discourage use outside of pkg/dir.jl

CC: @StefanKarpinski 
