### PR TITLE
Fix Dereference after null check (coverty.com bug)

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -582,7 +582,7 @@ static jl_value_t *julia_type_of_without_metadata(Value *v, bool err=true)
 static jl_value_t *julia_type_of(Value *v)
 {
     MDNode *mdn;
-    if (dyn_cast<Instruction>(v) == NULL ||
+    if (dyn_cast_or_null<Instruction>(v) == NULL ||
         (mdn = ((Instruction*)v)->getMetadata("julia_type")) == NULL) {
         return julia_type_of_without_metadata(v, true);
     }


### PR DESCRIPTION
In at least two places in Julia, a pointer is checked for possible NULL value before it is passed to julia_type_of(). This indicates that the function should be able to handle NULL values.

According to the LLVM [docs](http://llvm.org/docs/ProgrammersManual.html#the-isa-cast-and-dyn-cast-templates), dyn_cast<> will dereference the pointer, and thus crash if the pointer is NULL. A few lines further down it mentions dyn_cast_or_null which will propagate a NULL value.
