### PR TITLE
Change promotion criterion in linalg functions from sqrt to norm

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -132,7 +132,11 @@ function norm{T}(A::AbstractMatrix{T}, p::Number=2)
     throw(ArgumentError("invalid p-norm p=$p. Valid: 1, 2, Inf"))
 end
 
-norm(x::Number, p=nothing) = abs(x)
+function norm(x::Number, p=2)
+    if p == 1 || p == Inf || p == -Inf return abs(x) end
+    p == 0 && return ifelse(x != 0, 1, 0)
+    float(abs(x))
+end
 
 normfro(A::AbstractMatrix) = norm(reshape(A, length(A)))
 normfro(x::Number) = abs(x)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -130,6 +130,7 @@ debug && println("symmetric eigen-decomposition")
         d,v   = eig(asym)
         @test_approx_eq asym*v[:,1] d[1]*v[:,1]
         @test_approx_eq v*scale(d,v') asym
+        @test isequal(eigvals(asym[1]), eigvals(asym[1:1,1:1]))
     end
 
 debug && println("non-symmetric eigen decomposition")
@@ -926,6 +927,7 @@ mmat = 100
 nmat = 80
 for elty in (Float16, Float32, Float64, BigFloat, Complex{Float16}, Complex{Float32}, Complex{Float64}, Complex{BigFloat}, Int32, Int64, BigInt)
     debug && println(elty)
+
     ## Vector
     x = ones(elty,10)
     xs = sub(x,1:2:10)
@@ -943,6 +945,13 @@ for elty in (Float16, Float32, Float64, BigFloat, Complex{Float16}, Complex{Floa
     @test_approx_eq norm(xs, 2) sqrt(5)
     @test_approx_eq norm(xs, 3) cbrt(5)
     @test_approx_eq norm(xs, Inf) 1
+
+    ## Number
+    norm(x[1:1]) === norm(x[1], -Inf)
+    norm(x[1:1]) === norm(x[1], 0)
+    norm(x[1:1]) === norm(x[1], 1)
+    norm(x[1:1]) === norm(x[1], 2)
+    norm(x[1:1]) === norm(x[1], Inf)
 
     for i = 1:10    
         x = elty <: Integer ? convert(Vector{elty}, rand(1:10, nnorm)) : 


### PR DESCRIPTION
When promoting the element types in e.g. `qrfact` and `eigfact` the closure should be with respect to normalisation not square root.
