### PR TITLE
Concretely specify the type of dims in SubArray

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -5,7 +5,7 @@ typealias RangeIndex Union(Int, Range{Int}, Range1{Int})
 type SubArray{T,N,A<:AbstractArray,I<:(RangeIndex...,)} <: AbstractArray{T,N}
     parent::A
     indexes::I
-    dims::Dims
+    dims::NTuple{N,Int}
     strides::Array{Int,1}  # for accessing parent with linear indexes
     first_index::Int
 


### PR DESCRIPTION
This allows the type of `size(S::SubArray)` to be inferred.

Submitting as a PR because I can't test on current master, due to #5576 acting weirdly on my machine (and on Travis) compared to everyone else who tested this.
