### PR TITLE
improve ability to use require from sysimg.jl

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -315,9 +315,9 @@ const roottask = current_task()
 is_interactive = false
 isinteractive() = (is_interactive::Bool)
 
+const LOAD_PATH = ByteString[]
 function init_load_path()
     vers = "v$(VERSION.major).$(VERSION.minor)"
-    global const LOAD_PATH = ByteString[]
     if haskey(ENV,"JULIA_LOAD_PATH")
         prepend!(LOAD_PATH, split(ENV["JULIA_LOAD_PATH"], @windows? ';' : ':'))    
     end

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -175,7 +175,7 @@ type LocalProcess
     id::Int
 end
 
-const LPROC = LocalProcess(0)
+const LPROC = LocalProcess(1)
 
 const map_pid_wrkr = Dict{Int, Union(Worker, LocalProcess)}()
 const map_sock_wrkr = ObjectIdDict()


### PR DESCRIPTION
these changes allow `require` to work while (after) building the sysimg

@JeffBezanson any concerns with this before merging?
