### PR TITLE
More Cartesian housekeeping, plus implementation of copy!

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -109,7 +109,7 @@ broadcast!_function(f::Function) = (B, As...) -> broadcast!(f, B, As...)
 broadcast_function(f::Function) = (As...) -> broadcast(f, As...)
 
 broadcast_getindex(src::AbstractArray, I::AbstractArray...) = broadcast_getindex!(Array(eltype(src), broadcast_shape(I...)), src, I...)
-@ngenerate N function broadcast_getindex!(dest::AbstractArray, src::AbstractArray, I::NTuple{N, AbstractArray}...)
+@ngenerate N typeof(dest) function broadcast_getindex!(dest::AbstractArray, src::AbstractArray, I::NTuple{N, AbstractArray}...)
     check_broadcast_shape(size(dest), I...)  # unnecessary if this function is never called directly
     checkbounds(src, I...)
     @nloops N i dest d->(@nexprs N k->(j_d_k = size(I_k, d) == 1 ? 1 : i_d)) begin
@@ -119,7 +119,7 @@ broadcast_getindex(src::AbstractArray, I::AbstractArray...) = broadcast_getindex
     dest
 end
 
-@ngenerate N function broadcast_setindex!(A::AbstractArray, x, I::NTuple{N, AbstractArray}...)
+@ngenerate N typeof(A) function broadcast_setindex!(A::AbstractArray, x, I::NTuple{N, AbstractArray}...)
     checkbounds(A, I...)
     shape = broadcast_shape(I...)
     @nextract N shape d->(length(shape) < d ? 1 : shape[d])

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -2,7 +2,7 @@ module Cartesian
 
 export @ngenerate, @nsplat, @nloops, @nref, @ncall, @nexprs, @nextract, @nall, @ntuple, ngenerate
 
-const CARTESIAN_DIMS = 2   # FIXME: increase after testing is complete
+const CARTESIAN_DIMS = 4
 
 ### @ngenerate, for auto-generation of separate versions of functions for different dimensionalities
 # Examples (deliberately trivial):

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -274,13 +274,15 @@ function _nref(N::Int, A::Symbol, ex)
 end
 
 # Generate f(arg1, arg2, ...)
-macro ncall(N, f, sym)
-    _ncall(N, f, sym)
+macro ncall(N, f, sym...)
+    _ncall(N, f, sym...)
 end
 
-function _ncall(N::Int, f, ex)
+function _ncall(N::Int, f, args...)
+    pre = args[1:end-1]
+    ex = args[end]
     vars = [ inlineanonymous(ex,i) for i = 1:N ]
-    Expr(:escape, Expr(:call, f, vars...))
+    Expr(:escape, Expr(:call, f, pre..., vars...))
 end
 
 # Generate N expressions

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -138,6 +138,16 @@ eval(ngenerate(:N, nothing, :(setindex!{T}(s::SubArray{T,N}, v, ind::Integer)), 
     A
 end
 
+@ngenerate N typeof(dest) function copy!{T,N}(dest::AbstractArray{T,N}, src::AbstractArray{T,N})
+    if @nall N d->(size(dest,d) == size(src,d))
+        @nloops N i dest begin
+            @inbounds (@nref N dest i) = (@nref N src i)
+        end
+    else
+        invoke(copy!, (typeof(dest), Any), dest, src)
+    end
+    dest
+end
 
 ### from bitarray.jl
 

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -5,7 +5,7 @@ typealias RangeIndex Union(Int, Range{Int}, Range1{Int})
 type SubArray{T,N,A<:AbstractArray,I<:(RangeIndex...,)} <: AbstractArray{T,N}
     parent::A
     indexes::I
-    dims::Dims
+    dims::NTuple{N,Int}
     strides::Array{Int,1}  # for accessing parent with linear indexes
     first_index::Int
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -50,12 +50,10 @@ a = reshape(b, (2, 2, 2, 2, 2))
 
 sz = (5,8,7)
 A = reshape(1:prod(sz),sz...)
-tmp = A[2:6]
-@test tmp == [2:6]
+@test A[2:6] == [2:6]
 tmp = A[1:3,2,2:4]
 @test tmp == cat(3,46:48,86:88,126:128)
-tmp = A[:,7:-3:1,5]
-@test tmp == [191 176 161; 192 177 162; 193 178 163; 194 179 164; 195 180 165]
+@test A[:,7:-3:1,5] == [191 176 161; 192 177 162; 193 178 163; 194 179 164; 195 180 165]
 tmp = A[:,3:9]
 @test tmp == reshape(11:45,5,7)
 rng = (2,2:3,2:2:5)
@@ -89,6 +87,9 @@ a = [3, 5, -7, 6]
 b = [4, 6, 2, -7, 1]
 ind = findin(a, b)
 @test ind == [3,4]
+
+rt = Base.return_types(setindex!, (Array{Int32, 3}, Uint8, Vector{Int}, Float64, Range1{Int}))
+@test length(rt) == 1 && rt[1] == Array{Int32, 3}
 
 # sub
 A = reshape(1:120, 3, 5, 8)
@@ -771,6 +772,8 @@ fill!(S, 2)
 S = sub(A, 1:2, 3)
 fill!(S, 3)
 @test A == [1 1 3; 2 2 3; 1 1 1]
+rt = Base.return_types(fill!, (Array{Int32, 3}, Uint8))
+@test length(rt) == 1 && rt[1] == Array{Int32, 3}
 
 # splice!
 for idx in {1, 2, 5, 9, 10, 1:0, 2:1, 1:1, 2:2, 1:2, 2:4, 9:8, 10:9, 9:9, 10:10,
@@ -861,4 +864,17 @@ A = [NaN]; B = [NaN]
 # complete testsuite for reducedim
 
 include("reducedim.jl")
-
+# Inferred types
+Nmax = Base.Cartesian.CARTESIAN_DIMS+1 # TODO: go up to CARTESIAN_DIMS+2 (currently this exposes problems)
+for N = 1:Nmax
+    #indexing with (Range1, Range1, Range1)
+    args = ntuple(N, d->Range1{Int})
+    @test Base.return_types(getindex, tuple(Array{Float32, N}, args...)) == {Array{Float32, N}}
+    @test Base.return_types(getindex, tuple(BitArray{N}, args...)) == {BitArray{N}}
+    @test Base.return_types(setindex!, tuple(Array{Float32, N}, Array{Int, 1}, args...)) == {Array{Float32, N}}
+    # Indexing with (Range1, Range1, Float64)
+    args = ntuple(N, d->d<N ? Range1{Int} : Float64)
+    N > 1 && @test Base.return_types(getindex, tuple(Array{Float32, N}, args...)) == {Array{Float32, N-1}}
+    N > 1 && @test Base.return_types(getindex, tuple(BitArray{N}, args...)) == {BitArray{N-1}}
+    N > 1 && @test Base.return_types(setindex!, tuple(Array{Float32, N}, Array{Int, 1}, args...)) == {Array{Float32, N}}
+end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -865,7 +865,7 @@ A = [NaN]; B = [NaN]
 
 include("reducedim.jl")
 # Inferred types
-Nmax = Base.Cartesian.CARTESIAN_DIMS+1 # TODO: go up to CARTESIAN_DIMS+2 (currently this exposes problems)
+Nmax = 3 # TODO: go up to CARTESIAN_DIMS+2 (currently this exposes problems)
 for N = 1:Nmax
     #indexing with (Range1, Range1, Range1)
     args = ntuple(N, d->Range1{Int})

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -22,7 +22,7 @@ for arr in (identity, as_sub)
     @test broadcast(+, arr([1, 0]), arr([1  4])) == [2 5; 1 4]
     @test broadcast(+, arr([1, 0]), arr([1, 4])) == [2, 4]
 
-    @test arr(eye(2)) .+ arr([1, 4]) == arr([2 1; 4 5])
+    @test @inferred(arr(eye(2)) .+ arr([1, 4])) == arr([2 1; 4 5])
     @test arr(eye(2)) .+ arr([1  4]) == arr([2 4; 1 5])
     @test arr([1  0]) .+ arr([1, 4]) == arr([2 1; 5 4])
     @test arr([1, 0]) .+ arr([1  4]) == arr([2 5; 1 4])
@@ -58,3 +58,11 @@ for arr in (identity, as_sub)
     @test A == diagm(10:12)
     @test_throws broadcast_setindex!(A, 7, [1,-1], [1 2])
 end
+
+@test @inferred([0,1.2].+reshape([0,-2],1,1,2)) == reshape([0 -2; 1.2 -0.8],2,1,2)
+rt = Base.return_types(.+, (Array{Float64, 3}, Array{Int, 1}))
+@test length(rt) == 1 && rt[1] == Array{Float64, 3}
+rt = Base.return_types(broadcast, (Function, Array{Float64, 3}, Array{Int, 1}))
+@test length(rt) == 1 && rt[1] == Array{Float64, 3}
+rt = Base.return_types(broadcast!, (Function, Array{Float64, 3}, Array{Float64, 3}, Array{Int, 1}))
+@test length(rt) == 1 && rt[1] == Array{Float64, 3}

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -25,3 +25,7 @@ R = reducedim((a,b) -> a+b, [1 2; 3 4], 2, 0.0)
 @test eltype(R) == Float64
 @test_approx_eq R [3,7]
 @test reducedim((a,b) -> a+b, [1 2; 3 4], 1, 0) == [4 6]
+
+# inferred return types
+rt = Base.return_types(reducedim, (Function, Array{Float64, 3}, Int, Float64))
+@test length(rt) == 1 && rt[1] == Array{Float64, 3}


### PR DESCRIPTION
- Cleans up `@ngenerate` to add return-type annotation
- Adds `@nsplat` to generate specialized versions of functions that avoid splatting
- Adds quite a few new tests of type inference
- Implements cartesian `copy!` for faster performance on SubArrays

The addition of `@nsplat` is not strictly necessary; I could ditch that and write them out by hand, if desired. The main motivation for adding it was to automatically synchronize the use of splatting with changes in CARTESIAN_DIMS.

Performance gain on `copy!` is the usual:
Master:

```
julia> A = rand(1000,1000,50);

julia> B = zeros(1000,1000,50);

julia> S = sub(B, :, :, :);

julia> @time copy!(S, A);
elapsed time: 2.144633973 seconds (48 bytes allocated)
```

This branch:

```
julia> @time copy!(S, A);
elapsed time: 0.399700238 seconds (48 bytes allocated)
```

CC @carlobaldassi.
