### PR TITLE
Stop never-ending string on github

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -121,7 +121,7 @@
       nil
     (if (and (equal (char-after (point)) ?#)
 	     (evenp (julia-strcount
-		     (buffer-substring p0 (point)) ?\")))
+		     (buffer-substring p0 (point)) ?\"))) ;" ;<-- Makes it display nicely on github
 	t
       (if (= (point) p0)
 	  nil


### PR DESCRIPTION
On github all `"` in elisp starts a string even if it is started with `?\`. This change adds a `"` in a comment to prevent the syntax highlighting on github to read the rest of the document as a string. The change only affects how the file is displayed on github. I understand if you do not want to introduce a comment purely for this reason.
