### PR TITLE
call bytestring on String arguments in ccalls that require Ptr{Uint8} conversion

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -12,10 +12,12 @@ const RTLD_NOLOAD    = 0x00000010
 const RTLD_DEEPBIND  = 0x00000020
 const RTLD_FIRST     = 0x00000040
 
-dlsym(hnd, s::Union(Symbol,String)) = ccall(:jl_dlsym, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
-dlsym_e(hnd, s::Union(Symbol,String)) = ccall(:jl_dlsym_e, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
-dlopen(s::String, flags::Integer) = ccall(:jl_load_dynamic_library, Ptr{Void}, (Ptr{Uint8},Uint32), s, flags)
-dlopen_e(s::String, flags::Integer) = ccall(:jl_load_dynamic_library_e, Ptr{Void}, (Ptr{Uint8},Uint32), s, flags)
+dlsym(hnd, s::Union(Symbol,ByteString)) = ccall(:jl_dlsym, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
+dlsym_e(hnd, s::Union(Symbol,ByteString)) = ccall(:jl_dlsym_e, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
+dlsym(hnd, s::String) = dlsym(hnd, bytestring(s))
+dlsym_e(hnd, s::String) = dlsym_e(hnd, bytestring(s))
+dlopen(s::String, flags::Integer) = ccall(:jl_load_dynamic_library, Ptr{Void}, (Ptr{Uint8},Uint32), bytestring(s), flags)
+dlopen_e(s::String, flags::Integer) = ccall(:jl_load_dynamic_library_e, Ptr{Void}, (Ptr{Uint8},Uint32), bytestring(s), flags)
 dlopen(s::String) = dlopen(s, RTLD_LAZY | RTLD_DEEPBIND)
 dlopen_e(s::String) = dlopen_e(s, RTLD_LAZY | RTLD_DEEPBIND)
 dlclose(p::Ptr) = if p!=C_NULL; ccall(:uv_dlclose,Void,(Ptr{Void},),p); end

--- a/base/client.jl
+++ b/base/client.jl
@@ -197,7 +197,7 @@ function parse_input_line(s::String)
     #     throw(ParseError("extra input after end of expression"))
     # end
     # expr
-    ccall(:jl_parse_input_line, Any, (Ptr{Uint8},), s)
+    ccall(:jl_parse_input_line, Any, (Ptr{Uint8},), bytestring(s))
 end
 
 function parse_input_line(io::IO)

--- a/base/file.jl
+++ b/base/file.jl
@@ -9,8 +9,8 @@ function pwd()
 end
 
 function cd(dir::String) 
-    @windows_only systemerror("chdir $dir", ccall(:_chdir,Int32,(Ptr{Uint8},),dir) == -1)
-    @unix_only systemerror("chdir $dir", ccall(:chdir,Int32,(Ptr{Uint8},),dir) == -1)
+    @windows_only systemerror("chdir $dir", ccall(:_chdir,Int32,(Ptr{Uint8},),bytestring(dir)) == -1)
+    @unix_only systemerror("chdir $dir", ccall(:chdir,Int32,(Ptr{Uint8},),bytestring(dir)) == -1)
 end
 cd() = cd(homedir())
 
@@ -100,7 +100,7 @@ end
 GetTempFileName(uunique::Uint32) = GetTempFileName(GetTempPath(), uunique)
 function GetTempFileName(temppath::String,uunique::Uint32)
     tname = Array(Uint8,261)
-    uunique = ccall(:GetTempFileNameA,stdcall,Uint32,(Ptr{Uint8},Ptr{Uint8},Uint32,Ptr{Uint8}),temppath,"julia",uunique,tname)
+    uunique = ccall(:GetTempFileNameA,stdcall,Uint32,(Ptr{Uint8},Ptr{Uint8},Uint32,Ptr{Uint8}),bytestring(temppath),"julia",uunique,tname)
     lentname = findfirst(tname,0)-1
     if uunique == 0 || lentname <= 0
         error("GetTempFileName failed")

--- a/base/fs.jl
+++ b/base/fs.jl
@@ -106,8 +106,8 @@ end
 
 # For move command
 function rename(src::String, dst::String)
-    err = ccall(:jl_fs_rename, Int32, (Ptr{Uint8}, Ptr{Uint8}), bytestring(src),
-                bytestring(dst))
+    err = ccall(:jl_fs_rename, Int32, (Ptr{Uint8}, Ptr{Uint8}),
+                bytestring(src), bytestring(dst))
 
     # on error, default to cp && rm
     if err < 0

--- a/base/io.jl
+++ b/base/io.jl
@@ -351,7 +351,7 @@ function open(fname::String, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::Bool)
     systemerror("opening file $fname",
                 ccall(:ios_file, Ptr{Void},
                       (Ptr{Uint8}, Ptr{Uint8}, Int32, Int32, Int32, Int32),
-                      s.ios, fname, rd, wr, cr, tr) == C_NULL)
+                      s.ios, bytestring(fname), rd, wr, cr, tr) == C_NULL)
     if ff
         systemerror("seeking to end of file $fname", ccall(:ios_seek_end, FileOffset, (Ptr{Void},), s.ios) != 0)
     end

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -34,22 +34,22 @@ type TmStruct
 end
 
 strftime(t) = strftime("%c", t)
-strftime(fmt::ByteString, t::Real) = strftime(fmt, TmStruct(t))
-function strftime(fmt::ByteString, tm::TmStruct)
+strftime(fmt::String, t::Real) = strftime(fmt, TmStruct(t))
+function strftime(fmt::String, tm::TmStruct)
     timestr = Array(Uint8, 128)
     n = ccall(:strftime, Int, (Ptr{Uint8}, Int, Ptr{Uint8}, Ptr{Void}),
-              timestr, length(timestr), fmt, &tm)
+              timestr, length(timestr), bytestring(fmt), &tm)
     if n == 0
         return ""
     end
     bytestring(convert(Ptr{Uint8},timestr))
 end
 
-strptime(timestr::ByteString) = strptime("%c", timestr)
-function strptime(fmt::ByteString, timestr::ByteString)
+strptime(timestr::String) = strptime("%c", timestr)
+function strptime(fmt::String, timestr::String)
     tm = TmStruct()
     r = ccall(:strptime, Ptr{Uint8}, (Ptr{Uint8}, Ptr{Uint8}, Ptr{Void}),
-              timestr, fmt, &tm)
+              bytestring(timestr), bytestring(fmt), &tm)
     # the following would tell mktime() that this is a local time, and that
     # it should try to guess the timezone. not sure if/how this should be
     # exposed in the API.

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -86,10 +86,11 @@ end
 
 # remote/parallel load
 
-include_string(txt::ByteString, fname::ByteString) =
-    ccall(:jl_load_file_string, Any, (Ptr{Uint8},Ptr{Uint8}), txt, fname)
+include_string(txt::String, fname::String) =
+    ccall(:jl_load_file_string, Any, (Ptr{Uint8},Ptr{Uint8}),
+          bytestring(txt), bytestring(fname))
 
-include_string(txt::ByteString) = include_string(txt, "string")
+include_string(txt::String) = include_string(txt, "string")
 
 function source_path(default::Union(String,Nothing)="")
     t = current_task()

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -64,7 +64,7 @@ end
 
 function BigFloat(x::String, base::Int)
     z = BigFloat()
-    err = ccall((:mpfr_set_str, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{Uint8}, Int32, Int32), &z, x, base, ROUNDING_MODE[end])
+    err = ccall((:mpfr_set_str, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{Uint8}, Int32, Int32), &z, bytestring(x), base, ROUNDING_MODE[end])
     if err != 0; error("incorrectly formatted number"); end
     return z
 end

--- a/base/path.jl
+++ b/base/path.jl
@@ -109,21 +109,23 @@ abspath(a::String, b::String...) = abspath(joinpath(a,b...))
 @windows_only function realpath(path::String)
     buflength = length(path)+1
     buf = zeros(Uint8,buflength)
+    bpath = bytestring(path)
     p = ccall((:GetFullPathNameA, "Kernel32"), stdcall, 
         Uint32, (Ptr{Uint8}, Uint32, Ptr{Uint8}, Ptr{Void}), 
-        path, buflength, buf, C_NULL)
+        bpath, buflength, buf, C_NULL)
     if p > buflength
         buf = zeros(Uint8,p)
         p = ccall((:GetFullPathNameA, "Kernel32"), stdcall, 
             Uint32, (Ptr{Uint8}, Uint32, Ptr{Uint8}, Ptr{Void}), 
-            path, p, buf, C_NULL)
+            bpath, p, buf, C_NULL)
     end
     systemerror(:realpath, p == 0)
     return bytestring(buf)[1:end-1]
 end
 
 @unix_only function realpath(path::String)
-    p = ccall(:realpath, Ptr{Uint8}, (Ptr{Uint8}, Ptr{Uint8}), path, C_NULL)
+    p = ccall(:realpath, Ptr{Uint8}, (Ptr{Uint8}, Ptr{Uint8}), 
+              bytestring(path), C_NULL)
     systemerror(:realpath, p == C_NULL)
     s = bytestring(p)
     c_free(p)

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -79,7 +79,7 @@ function compile(pattern::String, options::Integer)
     erroff = Array(Int32,1)
     re_ptr = ccall((:pcre_compile, :libpcre), Ptr{Void},
                     (Ptr{Uint8}, Int32, Ptr{Ptr{Uint8}}, Ptr{Int32}, Ptr{Uint8}),
-                    pattern, options, errstr, erroff, C_NULL)
+                    bytestring(pattern), options, errstr, erroff, C_NULL)
     if re_ptr == C_NULL
         error("$(bytestring(errstr[1]))",
               " at position $(erroff[1]+1)",

--- a/base/poll.jl
+++ b/base/poll.jl
@@ -5,7 +5,7 @@ type FileMonitor
     notify::Condition
     function FileMonitor(cb, file)
         handle = c_malloc(_sizeof_uv_fs_event)
-        err = ccall(:jl_fs_event_init,Int32, (Ptr{Void}, Ptr{Void}, Ptr{Uint8}, Int32), eventloop(),handle,file,0)
+        err = ccall(:jl_fs_event_init,Int32, (Ptr{Void}, Ptr{Void}, Ptr{Uint8}, Int32), eventloop(),handle,bytestring(file),0)
         if err < 0
             c_free(handle)
             throw(UVError("FileMonitor",err))
@@ -250,7 +250,7 @@ function start_watching(t::PollingFileWatcher, interval)
     associate_julia_struct(t.handle, t)
     uv_error("start_watching (File)",
              ccall(:jl_fs_poll_start, Int32, (Ptr{Void},Ptr{Uint8},Uint32),
-                   t.handle, t.file, iround(interval*1000)))
+                   t.handle, bytestring(t.file), iround(interval*1000)))
 end
 start_watching(f::Function, t::PollingFileWatcher, interval) = (t.cb = f;start_watching(t,interval))
 

--- a/base/string.jl
+++ b/base/string.jl
@@ -1200,7 +1200,7 @@ function parse(str::String, pos::Int; greedy::Bool=true, raise::Bool=true)
     # returns (expr, end_pos). expr is () in case of parse error.
     ex, pos = ccall(:jl_parse_string, Any,
                     (Ptr{Uint8}, Int32, Int32),
-                    str, pos-1, greedy ? 1:0)
+                    bytestring(str), pos-1, greedy ? 1:0)
     if raise && isa(ex,Expr) && is(ex.head,:error)
         throw(ParseError(ex.args[1]))
     end
@@ -1542,9 +1542,9 @@ string(x::Union(Int8,Int16,Int32,Int64,Int128)) = dec(x)
 ## string to float functions ##
 
 float64_isvalid(s::String, out::Array{Float64,1}) =
-    ccall(:jl_strtod, Int32, (Ptr{Uint8},Ptr{Float64}), s, out) == 0
+    ccall(:jl_strtod, Int32, (Ptr{Uint8},Ptr{Float64}), bytestring(s),out) == 0
 float32_isvalid(s::String, out::Array{Float32,1}) =
-    ccall(:jl_strtof, Int32, (Ptr{Uint8},Ptr{Float32}), s, out) == 0
+    ccall(:jl_strtof, Int32, (Ptr{Uint8},Ptr{Float32}), bytestring(s),out) == 0
 
 float64_isvalid(s::SubString, out::Array{Float64,1}) =
     ccall(:jl_substrtod, Int32, (Ptr{Uint8},Csize_t,Int,Ptr{Float64}), s.string, convert(Csize_t,s.offset), s.endof, out) == 0

--- a/base/util.jl
+++ b/base/util.jl
@@ -259,13 +259,13 @@ end
 end
 
 @windows_only begin
-    function clipboard(x::ByteString)
+    function clipboard(x::String)
         ccall((:OpenClipboard, "user32"), stdcall, Bool, (Ptr{Void},), C_NULL)
         ccall((:EmptyClipboard, "user32"), stdcall, Bool, ())
         p = ccall((:GlobalAlloc, "kernel32"), stdcall, Ptr{Void}, (Uint16,Int32), 2, length(x)+1)
         p = ccall((:GlobalLock, "kernel32"), stdcall, Ptr{Void}, (Ptr{Void},), p)
         # write data to locked, allocated space
-        ccall(:memcpy, Ptr{Void}, (Ptr{Void},Ptr{Uint8},Int32), p, x, length(x)+1)
+        ccall(:memcpy, Ptr{Void}, (Ptr{Void},Ptr{Uint8},Int32), p, bytestring(x), length(x)+1)
         ccall((:GlobalUnlock, "kernel32"), stdcall, Void, (Ptr{Void},), p)
         # set clipboard data type to 13 for Unicode text/string
         p = ccall((:SetClipboardData, "user32"), stdcall, Ptr{Void}, (Uint32, Ptr{Void}), 1, p)

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -850,7 +850,6 @@ bin_val = hex2bytes("07bf")
 
 # issue #4586
 @test rsplit(RevString("ailuj"),'l') == {"ju","ia"}
-@test_throws float64(RevString("64"))
 
 for T = (Uint8,Int8,Uint16,Int16,Uint32,Int32,Uint64,Int64,Uint128,Int128,BigInt),
     b = 2:62, _ = 1:10


### PR DESCRIPTION
The basic issue is that `String` arguments need to be passed through `bytestring` before being converted to `Ptr{Uint8}` by `ccall`.  This should have no overhead for the common cases since `bytestring(s::ByteString) = s` should be inlined.

Among other things, this fixes #5673, and subsumes #5675.
