### PR TITLE
RFC: add pointer(s::Union(ByteString,UTF16String,UTF32String))

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -26,7 +26,7 @@ pointer{T}(::Type{T}, x::Ptr) = convert(Ptr{T}, x)
 # pointer. they just map the array element type to the pointer type for
 # convenience in cases that work.
 pointer{T}(x::AbstractArray{T}) = convert(Ptr{T},x)
-pointer{T}(x::AbstractArray{T}, i::Int) = convert(Ptr{T},x) + (i-1)*sizeof(T)
+pointer{T}(x::AbstractArray{T}, i::Integer) = convert(Ptr{T},x)+(i-1)*sizeof(T)
 
 # unsafe pointer to array conversions
 pointer_to_array(p, dims::Dims) = pointer_to_array(p, dims, false)


### PR DESCRIPTION
This patch adds `pointer(s)` for `s::Union(ByteString,UTF16String,UTF32String)` and substrings thereof.  Not only is this more convenient than `convert(Ptr{Foo}, s)` (because `s` knows the correct pointer type), but it also works for arbitrary substrings (whereas `convert` throws an error if the substring is not at the end).

The patch also changes the `chars` field of `UTF32String` to `data` for consistency with our other string types; this makes it easier to write methods that work on `Union(ByteString,UTF16String,UTF32String)`.

Also, I changed the signature in `pointer{T}(x::AbstractArray{T}, i::Int)` to `pointer{T}(x::AbstractArray{T}, i::Integer)`, since I couldn't see any reason to restrict the index to `Int` here.
