### PR TITLE
RFC: Moderately improved dict printing

### DIFF
--- a/test/collections.jl
+++ b/test/collections.jl
@@ -171,6 +171,39 @@ let f(x) = x^2,
     @test d == {8=>19, 19=>2, 42=>4}
 end
 
+# show
+for d in (["\n" => "\n", "1" => "\n", "\n" => "2"],
+          [string(i) => i for i = 1:30],
+          [reshape(1:i^2,i,i) => reshape(1:i^2,i,i) for i = 1:24],
+          [utf8(Char['α':'α'+i]) => utf8(Char['α':'α'+i]) for i = (1:10)*10])
+    for cols in (12, 40, 80), rows in (2, 10, 24)
+        # Ensure output is limited as requested
+        s = IOBuffer()
+        Base.showdict(s, d, true, rows, cols)
+        out = split(takebuf_string(s),'\n')
+        for line in out[2:end]
+            @test strwidth(line) <= cols
+        end
+        @test length(out) <= rows
+
+        for f in (keys, values)
+            s = IOBuffer()
+            Base.showkv(s, f(d), true, rows, cols)
+            out = split(takebuf_string(s),'\n')
+            for line in out[2:end]
+                @test strwidth(line) <= cols
+            end
+            @test length(out) <= rows
+        end
+    end
+    # Simply ensure these do not throw errors
+    Base.showdict(IOBuffer(), d, false)
+    @test !isempty(summary(d))
+    @test !isempty(summary(keys(d)))
+    @test !isempty(summary(values(d)))
+end
+
+
 # issue #2540
 d = {x => 1
     for x in ['a', 'b', 'c']}


### PR DESCRIPTION
This is a modest attempt at improving the situation for issue #1759.  I've added
slightly enhanced `summary`s with information about the number of k/v pairs for
Associative and Key/ValueIterator types.

I'm still slightly confused by all the different methods used for show, but
this PR keeps the old behavior (mostly) as `showcompact`. I then added new
functionality in `show` and `showlimited`, using newlines as delimiters between
key/value pairs.  When output is limited, values are truncated at newlines or
the TTY screen edge and a limited number of pairs are printed.

The key and value iterators no longer spit out entire dictionaries when shown.
They instead show a limited `{}` array of the keys and values.
