### PR TITLE
Doc: repr uses showall, not show

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -927,7 +927,7 @@ Strings
 
 .. function:: repr(x)
 
-   Create a string from any value using the ``show`` function.
+   Create a string from any value using the ``showall`` function.
 
 .. function:: bytestring(::Ptr{Uint8})
 


### PR DESCRIPTION
string.jl:1654

```
function repr(x)
    s = IOBuffer()
    showall(s, x)
    takebuf_string(s)
end
```
