### PR TITLE
Remove .git directory/repository of juliadoc in make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,9 @@ endif
 	$(INSTALL_M) $(build_private_libdir)/sys.$(SHLIB_EXT) $(DESTDIR)$(private_libdir)
 	# Copy in all .jl sources as well
 	cp -R -L $(build_datarootdir)/julia $(DESTDIR)$(datarootdir)/
+	# Remove git repository of juliadoc
+	rm -r $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.git
+	rm $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.gitignore
 	# Copy in beautiful new man page!
 	$(INSTALL_F) $(build_datarootdir)/man/man1/julia.1 $(DESTDIR)$(datarootdir)/man/man1/
 


### PR DESCRIPTION
.git directories and .gitignore files are development releated and are not meant to be shipped in a release installation.
