### PR TITLE
Remove deprecated add! in the stdlib overview doc

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -766,7 +766,7 @@ Partially implemented by: ``IntSet``, ``Set``, ``EnvHash``, ``Array``, ``BitArra
 Set-Like Collections
 --------------------
 
-,. function:: Set(x...)
+.. function:: Set(x...)
 
    Construct a ``Set`` with the given elements. Should be used instead of ``IntSet`` for sparse integer sets, or for sets of arbitrary objects.
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -766,11 +766,7 @@ Partially implemented by: ``IntSet``, ``Set``, ``EnvHash``, ``Array``, ``BitArra
 Set-Like Collections
 --------------------
 
-.. function:: add!(collection, key)
-
-   Add an element to a set-like collection.
-
-.. function:: Set(x...)
+,. function:: Set(x...)
 
    Construct a ``Set`` with the given elements. Should be used instead of ``IntSet`` for sparse integer sets, or for sets of arbitrary objects.
 


### PR DESCRIPTION
See with current master. push! works fine like with any other collection.

```
julia> a = Set()
Set{Any}()

julia> add!(a, 1)
WARNING: add!(s::Set,x) is deprecated, use push!(s,x) instead.
 in add! at deprecated.jl:19
Set{Any}(1)
```
