### PR TITLE
Fixed link to Homer Reid's numerical analysis class

### DIFF
--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -126,7 +126,7 @@ help new users get started with julia:
 
 - `Julia and IJulia cheatsheet <http://math.mit.edu/%7Estevenj/Julia-cheatsheet.pdf>`_
 - `Learn Julia in a few minutes <http://learnxinyminutes.com/docs/julia/>`_
-- `Tutorial for Homer Reid's numerical analysis class <http://homerreid.ath.cx/teaching/18.330/JuliaProgramming.shtml#SimplePrograms>`_
+- `Tutorial for Homer Reid's numerical analysis class <http://homerreid.dyndns.org/teaching/18.330/JuliaProgramming.shtml>`_
 - `An introductory presentation <https://github.com/ViralBShah/julia-presentations/raw/master/Fifth-Elephant-2013/Fifth-Elephant-2013.pdf>`_
 - `Videos from the Julia tutorial at MIT <http://julialang.org/blog/2013/03/julia-tutorial-MIT/>`_
 - `Forio Julia Tutorials <http://forio.com/julia/tutorials-list>`_


### PR DESCRIPTION
Now Homer Reid's page is in http://homerreid.dyndns.org, and so is the Julia tutorial, so the current link is broken. Changed the getting-started part of the manual to reflect this.
