### PR TITLE
RFC: @as macro for expression chaining.

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1156,7 +1156,7 @@ export
 # shared arrays
     sdata,
     indexpids,
-    
+
 # paths and file names
     abspath,
     basename,
@@ -1299,4 +1299,5 @@ export
     @sprintf,
     @deprecate,
     @boundscheck,
-    @inbounds
+    @inbounds,
+    @as

--- a/base/util.jl
+++ b/base/util.jl
@@ -531,6 +531,13 @@ macro as(name, bindings)
         exprs = asexpand(bindings)
     end
 
+    # expand function calls
+    for i in 1:length(exprs)
+        if isa(exprs[i],Symbol)
+            exprs[i] = Expr(:call,exprs[i],name)
+        end
+    end
+
     quote
         let $([Expr(:(=),name,expr) for expr in exprs]...)
             $name


### PR DESCRIPTION
This implements the `@as` macro, mostly as described in #5571.

I wasn't sure where to put the tests for this, I can add them if someone will let me know.

Some examples:

``` julia
@as x begin
    3
    x^2
    mod(x,4)
end
# => 1
```

``` julia
@as _ "julia\n" |> chomp(_) |> _ * reverse(_)
# => "juliaailuj"
```

One thing I have not done yet is @cdsousa's idea of automatically expanding `f` to `f(_)`; I can add it if we decide we want this.

This also might be pretty brittle, I doubt I've thought of all the edge cases. Would appreciate some tire kicking / feedback, I am still an egg when it comes to writing macros :)
