### PR TITLE
Create and use versioned package dir by default.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -288,6 +288,9 @@ Miscellaneous changes
   * `julia-release-*` executables renamed to `julia-*`,
     and `libjulia-release` renamed to `libjulia` ([#4177]).
 
+  * Packages will now be installed in `.julia/vX.Y`, where
+    X.Y is the current Julia version.
+
 Bugfixes and performance updates
 --------------------------------
 

--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -1,11 +1,33 @@
 module Cache
 
-using Base.Git, ..Types
+import Base.Git, ..Dir
+using ..Types
 
 path(pkg::String) = abspath(".cache", pkg)
 
+function mkcachedir()
+    cache = joinpath(realpath("."), ".cache")
+    if isdir(cache)
+        return
+    end
+
+    @windows_only mkdir(cache)
+    @unix_only begin
+        if Dir.isversioned(pwd())
+            rootcache = joinpath(realpath(".."), ".cache")
+            if !isdir(rootcache)
+                mkdir(rootcache)
+            end
+            run(`ln -s $rootcache $cache`)
+            return
+        end
+        mkdir(cache)
+    end
+end
+
+
 function prefetch{S<:String}(pkg::String, url::String, sha1s::Vector{S})
-    isdir(".cache") || mkdir(".cache")
+    isdir(".cache") || mkcachedir()
     cache = path(pkg)
     if !isdir(cache)
         info("Cloning cache of $pkg from $url")

--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -5,13 +5,16 @@ import ..Pkg: DEFAULT_META, META_BRANCH
 
 const DIR_NAME = ".julia"
 
+_pkgroot() = abspath(get(ENV,"JULIA_PKGDIR",joinpath(homedir(),DIR_NAME)))
+isversioned(p::String) = ((x,y) = (VERSION.major, VERSION.minor); basename(p) == "v$x.$y")
+
 function path()
-    b = abspath(get(ENV,"JULIA_PKGDIR",joinpath(homedir(),DIR_NAME)))
+    b = _pkgroot()
     x, y = VERSION.major, VERSION.minor
     d = joinpath(b,"v$x.$y")
-    isdir(d) && return d
-    d = joinpath(b,"v$x")
-    isdir(d) && return d
+    if isdir(d) || !isdir(b) || !isdir(joinpath(b, "METADATA"))
+        return d
+    end
     return b
 end
 path(pkg::String...) = normpath(path(),pkg...)


### PR DESCRIPTION
- Change pkgroot => _pkgroot, to discourage use outside of pkg/dir.jl
- Add versioned package dir information to NEWS.md

Except for the location of the `Git` module, this should be identical to the changes in v0.3 (except all in one commit). 

Tested with version 2, and it does indeed create and use a versioned package dir:

``` julia
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "help()" to list help topics
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.2.0+23 (2014-02-09 01:46 UTC)
 _/ |\__'_|_|_|\__'_|  |  kms/versioned_pkg_dir_julia0.2/647460a* (fork: 23 commits, 84 days)
|__/                   |  x86_64-linux-gnu

julia> Pkg.init()
INFO: Initializing package repository /home/kmsquire/.julia/v0.2
INFO: Cloning METADATA from git://github.com/JuliaLang/METADATA.jl

julia> Pkg.add("DataFrames")
INFO: Cloning cache of Blocks from git://github.com/tanmaykm/Blocks.jl.git
INFO: Cloning cache of DataArrays from git://github.com/JuliaStats/DataArrays.jl.git
INFO: Cloning cache of DataFrames from git://github.com/JuliaStats/DataFrames.jl.git
INFO: Cloning cache of GZip from git://github.com/kmsquire/GZip.jl.git
INFO: Cloning cache of SortingAlgorithms from git://github.com/JuliaLang/SortingAlgorithms.jl.git
INFO: Cloning cache of Stats from git://github.com/JuliaStats/Stats.jl.git
INFO: Cloning cache of StatsBase from git://github.com/JuliaStats/StatsBase.jl.git
INFO: Installing Blocks v0.0.1
INFO: Installing DataArrays v0.0.2
INFO: Installing DataFrames v0.4.2
INFO: Installing GZip v0.2.10
INFO: Installing SortingAlgorithms v0.0.1
INFO: Installing Stats v0.1.0
INFO: Installing StatsBase v0.2.10
INFO: REQUIRE updated.

julia> ;ls ~/.julia
v0.2

julia> ;ls ~/.julia/v0.2
Blocks  DataArrays  DataFrames  GZip  METADATA  REQUIRE  SortingAlgorithms  Stats  StatsBase
```

Note that we still could use migration functionality (#4876).

cc: @StefanKarpinski 
