### PR TITLE
Hygiene: Remove randomness from loop in test/linalg.jl.

### DIFF
--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -20,10 +20,12 @@ areal = randn(n,n)/2
 aimg  = randn(n,n)/2
 breal = randn(n,2)/2
 bimg  = randn(n,2)/2
+bint = rand(1:5, n, 2)
+aint = rand(1:5, n, n)
 for eltya in (Float16, Float32, Float64, Complex32, Complex64, Complex128, BigFloat, Int)
+    a = eltya == Int ? aint : convert(Matrix{eltya}, eltya <: Complex ? complex(areal, aimg) : areal)
     for eltyb in (Float16, Float32, Float64, Complex32, Complex64, Complex128, Int)
-        a = eltya == Int ? rand(1:5, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(areal, aimg) : areal)
-        b = eltyb == Int ? rand(1:5, n, 2) : convert(Matrix{eltyb}, eltyb <: Complex ? complex(breal, bimg) : breal)
+        b = eltyb == Int ? bint : convert(Matrix{eltyb}, eltyb <: Complex ? complex(breal, bimg) : breal)
         asym = a'+a                  # symmetric indefinite
         apd  = a'*a                 # symmetric positive-definite
 


### PR DESCRIPTION
Before, a different integer matrix was generated for each type combination where eltya or eltyb was integer which makes reasoning and parallelization difficult (#5735).

This also helps a bit with fixing tests after JuliaLang/julia#5741.
