### PR TITLE
deleted control lines causing recompilation issue

### DIFF
--- a/contrib/relative_path.sh
+++ b/contrib/relative_path.sh
@@ -7,11 +7,6 @@
 source=$1
 target=$2
 
-if [[ ! "$source" == /* ]] || [[ ! "$target" == /* ]]; then
-    echo "ERROR: paths must be absolute paths, they must start with a forward slash!"
-    exit 1
-fi
-
 common_part=$source # for now
 result="" # for now
 


### PR DESCRIPTION
source and target folder can be i.e "julia-xxxxxx/bin" and it's not a problem for the makefile scenario. On the other hand keeping that check results in fail for OSX on recompilation.
