### PR TITLE
marked shared array in doc as unix-only

### DIFF
--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -543,8 +543,8 @@ is ``DArray``\ -specific, but we list it here for completeness::
 
 
     
-Shared Arrays (EXPERIMENTAL FEATURE)
-------------------------------------
+Shared Arrays (Experimental, UNIX-only feature)
+-----------------------------------------------
 
 Shared Arrays use system shared memory to map the same array across
 many processes.  While there are some similarities to a ``DArray``,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4614,8 +4614,8 @@ Distributed Arrays
    Get the vector of processors storing pieces of ``d``
 
    
-Shared Arrays (EXPERIMENTAL FEATURE)
-------------------------------------
+Shared Arrays (Experimental, UNIX-only feature)
+-----------------------------------------------
 
 .. function:: SharedArray(T::Type, dims::NTuple; init=false, pids=workers())
 


### PR DESCRIPTION
To avoid situations like this - https://groups.google.com/d/msg/julia-users/XWgRwheyuLw/3BVqDWrQtXMJ 
