### PR TITLE
RFC: selection of shift-and-invert mode in eigs

### DIFF
--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -3,7 +3,7 @@ using .ARPACK
 ## eigs
 
 function eigs(A;nev::Integer=6, ncv::Integer=20, which::ASCIIString="LM",
-          tol=0.0, maxiter::Integer=1000, sigma=nothing, v0::Vector=zeros((0,)),
+          tol=0.0, maxiter::Integer=1000, sigma=(), v0::Vector=zeros((0,)),
           ritzvec::Bool=true, complexOP::Bool=false)
     n = chksquare(A)
     (n <= 6) && (nev = min(n-1, nev))
@@ -13,8 +13,6 @@ function eigs(A;nev::Integer=6, ncv::Integer=20, which::ASCIIString="LM",
     T     = eltype(A)
     cmplx = T<:Complex
     bmat  = "I"
-    const arpack_which_lm = "LM"   # always looking for largest EV
-    arpack_sigma = 0
     
     if !isempty(v0)
         length(v0)==n || throw(DimensionMismatch(""))
@@ -23,17 +21,19 @@ function eigs(A;nev::Integer=6, ncv::Integer=20, which::ASCIIString="LM",
         v0=zeros(T,(0,))
     end
 
-    if sigma == nothing && which == "LM"
+    if isempty(sigma)
         # normal iteration
         mode = 1
+        sigma = 0
         linop(x) = A * x
     else
-        if (sigma == nothing && which == "SM") || sigma == 0
-            # invert only
+        # always find ev closest in magnitude to sigma ...
+        which = "LM" 
+        if sigma == 0
+            # using invert only
             C = lufact(A)
         else
-            # shift and invert
-            arpack_sigma = sigma
+            # using shift and invert
             C = lufact(A - sigma*eye(A))
         end
         if cmplx
@@ -52,10 +52,10 @@ function eigs(A;nev::Integer=6, ncv::Integer=20, which::ASCIIString="LM",
         
     # Compute the Ritz values and Ritz vectors
     (resid, v, ldv, iparam, ipntr, workd, workl, lworkl, rwork, TOL) = 
-       ARPACK.aupd_wrapper(T, linop, n, sym, cmplx, bmat, nev, ncv, arpack_which_lm, tol, maxiter, mode, v0)
+       ARPACK.aupd_wrapper(T, linop, n, sym, cmplx, bmat, nev, ncv, which, tol, maxiter, mode, v0)
     
     # Postprocessing to get eigenvalues and eigenvectors
-    ARPACK.eupd_wrapper(T, n, sym, cmplx, bmat, nev, arpack_which_lm, ritzvec, TOL,
-        resid, ncv, v, ldv, arpack_sigma, iparam, ipntr, workd, workl, lworkl, rwork)
+    ARPACK.eupd_wrapper(T, n, sym, cmplx, bmat, nev, which, ritzvec, TOL,
+        resid, ncv, v, ldv, sigma, iparam, ipntr, workd, workl, lworkl, rwork)
 
 end

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -389,8 +389,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
     * ``ritzvec``: Returns the Ritz vectors ``v`` (eigenvectors) if ``true``
     * ``op_part``: which part of linear operator to use for real A (:real, :imag)
     * ``v0``: starting vector from which to start the Arnoldi iteration
-   ``eigs`` returns the ``nev`` requested eigenvalues in ``d``, the corresponding Ritz vectors ``v`` (only if ``ritzvec=true``), the number of converged eigenvalues ``nconv``, the number of iterations ``niter`` and the number of matrix vector multiplications ``nmult``, as well as the final residual vector ``resid``.
-    
+   ``eigs`` returns the ``nev`` requested eigenvalues in ``d``, the corresponding Ritz vectors ``v`` (only if ``ritzvec=true``), the number of converged eigenvalues ``nconv``, the number of iterations ``niter`` and the number of matrix vector multiplications ``nmult``, as well as the final residual vector ``resid``. If ``which="SM"`` inverse iteration is used to find the eigenvalues with smallest magnitude.    
 
 .. function:: svds(A; nev=6, which="LA", tol=0.0, maxiter=1000, ritzvec=true)
 

--- a/test/arpack.jl
+++ b/test/arpack.jl
@@ -1,4 +1,4 @@
-begin
+    begin
     local n,a,asym,d,v
     n = 10
     areal  = randn(n,n)
@@ -24,6 +24,11 @@ begin
 	(d,v) = eigs(apd, nev=3)
 	@test_approx_eq apd*v[:,3] d[3]*v[:,3]
 #        @test_approx_eq eigs(apd; nev=1, sigma=d[3])[1][1] d[3]
+
+    # test (shift-and-)invert mode
+    (d,v) = eigs(apd, nev=3, which="SM")
+    @test_approx_eq apd*v[:,3] d[3]*v[:,3]
+
     end
 end
 

--- a/test/arpack.jl
+++ b/test/arpack.jl
@@ -26,7 +26,7 @@
 #        @test_approx_eq eigs(apd; nev=1, sigma=d[3])[1][1] d[3]
 
     # test (shift-and-)invert mode
-    (d,v) = eigs(apd, nev=3, which="SM")
+    (d,v) = eigs(apd, nev=3, sigma=0)
     @test_approx_eq apd*v[:,3] d[3]*v[:,3]
 
     end


### PR DESCRIPTION
This changes the selection of shift-and-invert mode in eigs as discussed in JuliaLang/LinearAlgebra.jl#29:
- if `sigma==0` and `which="LM"` (default) the eigenvalues with largest magnitude are calculated
- if `sigma==0` and `which="SM"` inverse iteration is used to find eigenvalues with smallest magnitude
- if `sigma!=0` shift-and-invert is used to find eigenvalues closest to sigma

The docs are updated and I have added a test for the case with `which="SM"`.
(cc: @ViralBShah, @stevengj)
