### PR TITLE
Generate .o file directly rather than going through LLC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,7 @@ $(build_sysconfdir)/julia/juliarc.jl: contrib/windows/juliarc.jl
 endif
 
 # use sys.ji if it exists, otherwise run two stages
-$(build_private_libdir)/sys%ji: $(build_private_libdir)/sys%bc
-
-$(build_private_libdir)/sys%o: $(build_private_libdir)/sys%bc
-	$(call spawn,$(LLVM_LLC)) -filetype=obj -relocation-model=pic -mattr=-bmi2,-avx2 -o $@ $<
+$(build_private_libdir)/sys%ji: $(build_private_libdir)/sys%o
 
 .PRECIOUS: $(build_private_libdir)/sys%o
 
@@ -77,11 +74,11 @@ $(build_private_libdir)/sys%$(SHLIB_EXT): $(build_private_libdir)/sys%o
 		$$([ $(OS) = Darwin ] && echo -Wl,-undefined,dynamic_lookup || echo -Wl,--unresolved-symbols,ignore-all ) \
 		$$([ $(OS) = WINNT ] && echo -ljulia -lssp)
 
-$(build_private_libdir)/sys0.bc:
+$(build_private_libdir)/sys0.o:
 	@$(QUIET_JULIA) cd base && \
 	$(call spawn,$(JULIA_EXECUTABLE)) --build $(build_private_libdir)/sys0 sysimg.jl
 
-$(build_private_libdir)/sys.bc: VERSION base/*.jl base/pkg/*.jl base/linalg/*.jl base/sparse/*.jl $(build_datarootdir)/julia/helpdb.jl $(build_datarootdir)/man/man1/julia.1 $(build_private_libdir)/sys0.$(SHLIB_EXT)
+$(build_private_libdir)/sys.o: VERSION base/*.jl base/pkg/*.jl base/linalg/*.jl base/sparse/*.jl $(build_datarootdir)/julia/helpdb.jl $(build_datarootdir)/man/man1/julia.1 $(build_private_libdir)/sys0.$(SHLIB_EXT)
 	@$(QUIET_JULIA) cd base && \
 	$(call spawn,$(JULIA_EXECUTABLE)) --build $(build_private_libdir)/sys \
 		-J$(build_private_libdir)/$$([ -e $(build_private_libdir)/sys.ji ] && echo sys.ji || echo sys0.ji) -f sysimg.jl \

--- a/src/init.c
+++ b/src/init.c
@@ -867,10 +867,10 @@ DLLEXPORT int julia_trampoline(int argc, char **argv, int (*pmain)(int ac,char *
         if (asprintf(&build_ji, "%s.ji",build_path) > 0) {
             jl_save_system_image(build_ji);
             free(build_ji);
-            char *build_bc;
-            if (asprintf(&build_bc, "%s.bc",build_path) > 0) {
-                jl_dump_bitcode(build_bc);
-                free(build_bc);
+            char *build_o;
+            if (asprintf(&build_o, "%s.o",build_path) > 0) {
+                jl_dump_objfile(build_o);
+                free(build_o);
             }
             else {
                 ios_printf(ios_stderr,"FATAL: failed to create string for .bc build path");

--- a/src/init.c
+++ b/src/init.c
@@ -869,11 +869,18 @@ DLLEXPORT int julia_trampoline(int argc, char **argv, int (*pmain)(int ac,char *
             free(build_ji);
             char *build_o;
             if (asprintf(&build_o, "%s.o",build_path) > 0) {
-                jl_dump_objfile(build_o);
+                jl_dump_objfile(build_o,0);
                 free(build_o);
+                char *build_jlo;
+                if (asprintf(&build_jlo, "%s.jlo",build_path) > 0) {
+                    jl_dump_objfile(build_jlo,1);
+                    free(build_jlo);
+                } else {
+                    ios_printf(ios_stderr,"FATAL: failed to create string for .jlo build path");
+                }
             }
             else {
-                ios_printf(ios_stderr,"FATAL: failed to create string for .bc build path");
+                ios_printf(ios_stderr,"FATAL: failed to create string for .o build path");
             }
         }
         else {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -87,6 +87,7 @@ void jl_init_tasks(void *stack, size_t ssize);
 void jl_init_serializer(void);
 
 void jl_dump_bitcode(char *fname);
+void jl_dump_objfile(char *fname);
 int32_t jl_get_llvm_gv(jl_value_t *p);
 
 #ifdef _OS_LINUX_

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -87,7 +87,7 @@ void jl_init_tasks(void *stack, size_t ssize);
 void jl_init_serializer(void);
 
 void jl_dump_bitcode(char *fname);
-void jl_dump_objfile(char *fname);
+void jl_dump_objfile(char *fname, int jit_model);
 int32_t jl_get_llvm_gv(jl_value_t *p);
 
 #ifdef _OS_LINUX_
@@ -98,6 +98,8 @@ jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_tuple_t *sp);
 
 void jl_generate_fptr(jl_function_t *f);
 void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig);
+
+int jl_load_sysimg_o(char *fname);
 
 // backtraces
 #ifdef _OS_WINDOWS_


### PR DESCRIPTION
This is the first part of #5459. This patch removes the dependency on llc. There the remaining question of what to do for the linker. On Linux/OS X we can probably just call out to the system linker (can we reasonably expect a linker to be present during install on those system?), which on windows definitely won't be possible, since that would require either MCJIT or Visual Studio. The other two options are shipping lld or switching to MCJIT and use MCJIT RuntimeDyld to load the raw object file into memory. That last solution isn't great, because we'll have to write the object file with the large code model, but it's probably the best we can do without a system linker. 
