### PR TITLE
serialize/deserialize for Regex

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -241,3 +241,17 @@ filter(r::Regex, v)  = filter(x->ismatch(r,x), v)
 
 filter!(r::Regex, d::Dict) = filter!((k,v)->ismatch(r,k),d)
 filter(r::Regex,  d::Dict) = filter!(r,copy(d))
+
+
+# Don't serialize the pointers
+function serialize(s, r::Regex)
+    serialize_type(s, typeof(r))
+    serialize(s, r.pattern) 
+    serialize(s, r.options) 
+end
+
+function deserialize(s, t::Type{Regex})
+    pattern = deserialize(s)
+    options = deserialize(s)
+    Regex(pattern, options)        
+end


### PR DESCRIPTION
Currently Regex objects cannot be sent across processes. This PR fixes the same.
