### PR TITLE
Restrict +,- and / to algebraic operations (for matrices). Use . versions for elementwise operations. Add UniformScaling matrix. Was:Don't let division with array default to elementwise division. 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -156,6 +156,10 @@ Library improvements
         the same length.  This generalizes and replaces `normfro` ([#6057]),
         and `norm` is now type-stable ([#6056]).
 
+      * + and - now only works when the sizes of the arrays are the same, i.e. the 
+        operations no longer do broadcasting. New `UniformScaling` type and identity
+        `I` constant (#5810).
+
     * Sparse linear algebra
 
       * Faster sparse `kron` ([#4958]).

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -326,11 +326,9 @@ imag{T<:Real}(x::AbstractArray{T}) = zero(x)
 *(A::Number, B::AbstractArray) = A .* B
 *(A::AbstractArray, B::Number) = A .* B
 
-/(A::Number, B::AbstractArray) = A ./ B
 /(A::AbstractArray, B::Number) = A ./ B
 
 \(A::Number, B::AbstractArray) = B ./ A
-\(A::AbstractArray, B::Number) = B ./ A
 
 ./(x::Number,y::AbstractArray )         = throw(MethodError(./, (x,y)))
 ./(x::AbstractArray, y::Number)         = throw(MethodError(./, (x,y)))
@@ -398,7 +396,7 @@ function circshift(a, shiftamts)
     for i=1:n
         s = size(a,i)
         d = i<=length(shiftamts) ? shiftamts[i] : 0
-        I[i] = d==0 ? (1:s) : mod([-d:s-1-d], s)+1
+        I[i] = d==0 ? (1:s) : mod([-d:s-1-d], s).+1
     end
     a[I...]::typeof(a)
 end
@@ -1183,10 +1181,6 @@ function mapslices(f::Function, A::AbstractArray, dims::AbstractVector)
     dimsA = [size(A)...]
     ndimsA = ndims(A)
     alldims = [1:ndimsA]
-
-    if dims == alldims
-        return f(A)
-    end
 
     otherdims = setdiff(alldims, dims)
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -782,7 +782,7 @@ for f in (:+, :-, :div, :mod, :&, :|, :$)
         end
     end
 end
-for f in (:+, :-, :.*, :./, :.%, :div, :mod, :rem, :&, :|, :$)
+for f in (:.+, :.-, :.*, :./, :.%, :div, :mod, :rem, :&, :|, :$)
     @eval begin
         function ($f){T}(A::Number, B::StridedArray{T})
             F = similar(B, promote_array_type(typeof(A),T))
@@ -802,7 +802,7 @@ for f in (:+, :-, :.*, :./, :.%, :div, :mod, :rem, :&, :|, :$)
 end
 
 # functions that should give an Int result for Bool arrays
-for f in (:+, :-)
+for f in (:.+, :.-)
     @eval begin
         function ($f)(A::Bool, B::StridedArray{Bool})
             F = Array(Int, size(B))
@@ -818,12 +818,16 @@ for f in (:+, :-)
             end
             return F
         end
+    end
+end
+for f in (:+, :-)
+    @eval begin
         function ($f)(A::StridedArray{Bool}, B::StridedArray{Bool})
             F = Array(Int, promote_shape(size(A), size(B)))
             for i=1:length(A)
                 @inbounds F[i] = ($f)(A[i], B[i])
             end
-            return F
+            return F        
         end
     end
 end

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -898,7 +898,7 @@ for f in (:+, :-)
         return r
     end
 end
-for f in (:+, :-),
+for f in (:.+, :.-),
     (arg1, arg2, T, fargs) in ((:(B::BitArray), :(x::Bool)    , Int                                   , :(b, x)),
                                (:(B::BitArray), :(x::Number)  , :(promote_array_type(typeof(x), Bool)), :(b, x)),
                                (:(x::Bool)    , :(B::BitArray), Int                                   , :(x, b)),

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -189,6 +189,16 @@ export PipeString
 @deprecate svdfact(A,thin)      svdfact(A,thin=thin)
 @deprecate svdfact!(A,thin)     svdfact(A,thin=thin)
 @deprecate svd(A,thin)          svd(A,thin=thin)
+@deprecate (+)(A::Array{Bool},x::Bool)      A .+ x
+@deprecate (+)(x::Bool,A::Array{Bool})      x .+ A 
+@deprecate (-)(A::Array{Bool},x::Bool)      A .- x
+@deprecate (-)(x::Bool,A::Array{Bool})      x .- A
+@deprecate (+)(A::Array,x::Number)          A .+ x
+@deprecate (+)(x::Number,A::Array)          x .+ A
+@deprecate (-)(A::Array,x::Number)          A .- x
+@deprecate (-)(x::Number,A::Array)          x .- A
+@deprecate (/)(x::Number,A::Array)          x ./ A
+@deprecate (\)(A::Array,x::Number)          A .\ x
 
 deprecated_ls() = run(`ls -l`)
 deprecated_ls(args::Cmd) = run(`ls -l $args`)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -51,6 +51,7 @@ export
     GeneralizedSVD,
     Hermitian,
     Hessenberg,
+    UniformScaling,
     InsertionSort,
     IntSet,
     IO,
@@ -189,6 +190,7 @@ export
     γ, eulergamma,
     catalan,
     φ, golden,
+    I,
 
 # Operators
     !,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -33,6 +33,7 @@ export
     Symmetric,
     Triangular,
     Diagonal,
+    UniformScaling,
 
 # Functions
     axpy!,
@@ -145,7 +146,10 @@ export
     At_mul_Bt,
     At_mul_Bt!,
     At_rdiv_B,
-    At_rdiv_Bt
+    At_rdiv_Bt,
+
+# Constants
+    I
 
 typealias BlasFloat Union(Float64,Float32,Complex128,Complex64)
 typealias BlasReal Union(Float64,Float32)
@@ -201,6 +205,7 @@ include("linalg/woodbury.jl")
 include("linalg/tridiag.jl")
 include("linalg/diagonal.jl")
 include("linalg/bidiag.jl")
+include("linalg/uniformscaling.jl")
 include("linalg/rectfullpacked.jl")
 include("linalg/givens.jl")
 include("linalg/special.jl")

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -248,7 +248,7 @@ Ac_ldiv_Bc{T<:BlasComplex}(A::LU{T}, B::StridedVecOrMat{T}) = @assertnonsingular
 
 /{T}(B::Matrix{T},A::LU{T}) = At_ldiv_Bt(A,B).'
 
-inv{T<:BlasFloat}(A::LU{T})=@assertnonsingular LAPACK.getri!(copy(A.factors), A.ipiv) A.info
+inv{T<:BlasFloat}(A::LU{T}) = @assertnonsingular LAPACK.getri!(copy(A.factors), A.ipiv) A.info
 
 cond{T<:BlasFloat}(A::LU{T}, p::Number) = inv(LAPACK.gecon!(p == 1 ? '1' : 'I', A.factors, norm(A[:L][A[:p],:]*A[:U], p)))
 cond(A::LU, p::Number) = norm(A[:L]*A[:U],p)*norm(inv(A),p)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -212,12 +212,14 @@ trace(x::Number) = x
 inv(a::AbstractVector) = error("argument must be a square matrix")
 inv{T}(A::AbstractMatrix{T}) = A_ldiv_B!(A,eye(T, chksquare(A)))
 
-function \{TA<:Number,TB<:Number}(A::AbstractMatrix{TA}, B::AbstractVecOrMat{TB})
+function \{TA,TB}(A::AbstractMatrix{TA}, B::AbstractVecOrMat{TB})
     TC = typeof(one(TA)/one(TB))
     A_ldiv_B!(convert(typeof(A).name.primary{TC}, A), TB == TC ? copy(B) : convert(typeof(B).name.primary{TC}, B))
 end
 \(a::AbstractVector, b::AbstractArray) = reshape(a, length(a), 1) \ b
 /(A::AbstractVecOrMat, B::AbstractVecOrMat) = (B' \ A')'
+# \(A::StridedMatrix,x::Number) = inv(A)*x Should be added at some point when the old elementwise version has been deprecated long enough
+# /(x::Number,A::StridedMatrix) = x*inv(A)
 
 cond(x::Number) = x == 0 ? Inf : 1.0
 cond(x::Number, p) = cond(x)

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -1,0 +1,74 @@
+import Base: +, -, *, /, copy, ctranspose, getindex, showarray, transpose
+import Base.LinAlg: SingularException
+immutable UniformScaling{T<:Number} <: AbstractMatrix{T}
+		λ::T
+end
+
+const I = UniformScaling(1)
+
+getindex(J::UniformScaling, i::Integer,j::Integer) = ifelse(i==j,J.λ,zero(J.λ))
+
+showarray(io::IO,J::UniformScaling;kw...) = print(io,"$(typeof(J))\n$(J.λ)*I")
+copy(J::UniformScaling) = UniformScaling(J.λ)
+
+transpose(J::UniformScaling) = J
+ctranspose(J::UniformScaling) = UniformScaling(conj(J.λ))
+
++(J1::UniformScaling,J2::UniformScaling)  = UniformScaling(J1.λ+J2.λ)
++{T}(B::BitArray{2},J::UniformScaling{T}) = bitunpack(B) + J
++(J::UniformScaling,B::BitArray{2}) 	  = J + bitunpack(B)
+function +{TA,TJ}(A::AbstractMatrix{TA},J::UniformScaling{TJ})
+    n = chksquare(A)
+    B = similar(A,promote_type(TA,TJ))
+    copy!(B,A)
+    @inbounds for i = 1:n
+        B[i,i] += J.λ
+    end
+    B
+end
++(J::UniformScaling,A::AbstractMatrix) = A + J
+
+-(J1::UniformScaling,J2::UniformScaling) = UniformScaling(J1.λ-J2.λ)
+-(B::BitArray{2},J::UniformScaling) 	 = bitunpack(B) - J
+-(J::UniformScaling,B::BitArray{2}) 	 = J - bitunpack(B)
+function -{TA,TJ<:Number}(A::AbstractMatrix{TA},J::UniformScaling{TJ})
+    n = chksquare(A)
+    B = similar(A,promote_type(TA,TJ))
+    copy!(B,A)
+    @inbounds for i = 1:n
+        B[i,i] -= J.λ
+    end
+    B
+end
+function -{TA,TJ<:Number}(J::UniformScaling{TJ},A::AbstractMatrix{TA})
+	n = chksquare(A)
+	B = -A
+	@inbounds for i = 1:n
+		B[i,i] += J.λ
+	end
+	B
+end
+
+*(J1::UniformScaling,J2::UniformScaling) = UniformScaling(J1.λ*J2.λ)
+*(B::BitArray{2},J::UniformScaling) = *(bitunpack(B),J::UniformScaling)
+*(J::UniformScaling,B::BitArray{2}) = *(J::UniformScaling,bitunpack(B))
+*(S::SparseMatrixCSC,J::UniformScaling) = J.λ == 1 ? S : J.λ*S
+*{Tv,Ti}(J::UniformScaling,S::SparseMatrixCSC{Tv,Ti}) = J.λ == 1 ? S : S*J.λ
+*(A::AbstractMatrix,J::UniformScaling) = J.λ == 1 ? A : J.λ*A
+*(J::UniformScaling,A::AbstractVecOrMat) = J.λ == 1 ? A : J.λ*A
+
+*(x::Number,J::UniformScaling) = UniformScaling(x*J.λ)
+*(J::UniformScaling,x::Number) = UniformScaling(J.λ*x)
+
+/(J1::UniformScaling,J2::UniformScaling) = J2.λ == 0 ? throw(SingularException(1)) : UniformScaling(J1.λ/J2.λ)
+/(J::UniformScaling,A::AbstractMatrix) = J.λ*inv(A)
+/(A::AbstractMatrix,J::UniformScaling) = J.λ == 0 ? throw(SingularException(1)) : A/J.λ
+
+/(J::UniformScaling,x::Number) = UniformScaling(J.λ/x)
+
+\(J1::UniformScaling,J2::UniformScaling) = J1.λ == 0 ? throw(SingularException(1)) : UniformScaling(J1.λ\J2.λ)
+\{T<:Number}(A::Union(Bidiagonal{T},Triangular{T}),J::UniformScaling) = inv(A)*J.λ
+\(J::UniformScaling,A::AbstractVecOrMat) = J.λ == 0 ? throw(SingularException(1)) : J.λ\A
+\(A::AbstractMatrix,J::UniformScaling) = inv(A)*J.λ
+
+\(x::Number,J::UniformScaling) = UniformScaling(x\J.λ)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1229,7 +1229,7 @@ function vcat(X::SparseMatrixCSC...)
             rX2 = X[i].colptr[c + 1] - 1
             rr2 = rr1 + (rX2 - rX1)
 
-            rowval[rr1 : rr2] = X[i].rowval[rX1 : rX2] + mX_sofar
+            rowval[rr1 : rr2] = X[i].rowval[rX1 : rX2] .+ mX_sofar
             nzval[rr1 : rr2] = X[i].nzval[rX1 : rX2]
             mX_sofar += mX[i]
             rr1 = rr2 + 1
@@ -1261,7 +1261,7 @@ function hcat(X::SparseMatrixCSC...)
     nnz_sofar = 0
     nX_sofar = 0
     for i = 1 : num
-        colptr[(1 : nX[i] + 1) + nX_sofar] = X[i].colptr + nnz_sofar
+        colptr[(1 : nX[i] + 1) + nX_sofar] = X[i].colptr .+ nnz_sofar
         rowval[(1 : nnzX[i]) + nnz_sofar] = X[i].rowval
         nzval[(1 : nnzX[i]) + nnz_sofar] = X[i].nzval
         nnz_sofar += nnzX[i]
@@ -1303,8 +1303,8 @@ function blkdiag(X::SparseMatrixCSC...)
     nX_sofar = 0
     mX_sofar = 0
     for i = 1 : num
-        colptr[(1 : nX[i] + 1) + nX_sofar] = X[i].colptr + nnz_sofar
-        rowval[(1 : nnzX[i]) + nnz_sofar] = X[i].rowval + mX_sofar
+        colptr[(1 : nX[i] + 1) + nX_sofar] = X[i].colptr .+ nnz_sofar
+        rowval[(1 : nnzX[i]) + nnz_sofar] = X[i].rowval .+ mX_sofar
         nzval[(1 : nnzX[i]) + nnz_sofar] = X[i].nzval
         nnz_sofar += nnzX[i]
         nX_sofar += nX[i]

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -274,15 +274,15 @@ function quantile!(v::AbstractVector, q::AbstractVector)
     lv = length(v)
     lq = length(q)
 
-    index = 1 + (lv-1)*q
+    index = 1 .+ (lv-1)*q
     lo = ifloor(index)
     hi = iceil(index)
     sort!(v)
     isnan(v[end]) && error("quantiles are undefined in presence of NaNs")
     i = find(index .> lo)
     r = float(v[lo])
-    h = (index-lo)[i]
-    r[i] = (1-h).*r[i] + h.*v[hi[i]]
+    h = (index.-lo)[i]
+    r[i] = (1.-h).*r[i] + h.*v[hi[i]]
     return r
 end
 quantile(v::AbstractVector, q::AbstractVector) = quantile!(copy(v),q)

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -286,7 +286,7 @@ operator should be used for elementwise operations.
 5.  Binary Boolean or bitwise — ``&``, ``|``, ``$``
 
 Some operators without dots operate elementwise anyway when one argument is a
-scalar. These operators are ``+``, ``-``, ``*``, ``/``, ``\``, and the bitwise
+scalar. These operators are ``*``, ``/``, ``\``, and the bitwise
 operators.
 
 Note that comparisons such as ``==`` operate on whole arrays, giving a single

--- a/doc/manual/linear-algebra.rst
+++ b/doc/manual/linear-algebra.rst
@@ -51,7 +51,8 @@ for them in LAPACK are available.
 +--------------------+-----------------------------------------------------------------------------------+
 | ``Diagonal``       | `Diagonal matrix <http://en.wikipedia.org/wiki/Diagonal_matrix>`_                 |
 +--------------------+-----------------------------------------------------------------------------------+
-
+| ``UniformScaling`` | `Uniform scaling operator <http://en.wikipedia.org/wiki/Uniform_scaling>`_        |
++--------------------+-----------------------------------------------------------------------------------+
 
 Elementary operations
 ---------------------
@@ -73,6 +74,8 @@ Elementary operations
 +--------------------+-------+-------+-------+-------+---------------------+
 | ``Diagonal``       |   X   |   X   |  XY   |   XY  | ``inv``, ``det``,   |
 |                    |       |       |       |       | ``logdet``, ``/``   |
++--------------------+-------+-------+-------+-------+---------------------+
+| ``UniformScaling`` |   X   |   X   |  XYZ  |  XYZ  | ``/``               |
 +--------------------+-------+-------+-------+-------+---------------------+
 
 Legend:
@@ -115,4 +118,8 @@ Legend:
 +---+-----------------------------------------------------------------------------------------------------------------------------------+------------------------+
 | D | An optimized method to find the characteristic vectors corresponding to the characteristic values ``x=[x1, x2,...]`` is available | ``eigvecs(M, x)``      |
 +---+-----------------------------------------------------------------------------------------------------------------------------------+------------------------+
+
+The uniform scaling operator
+--------------------------
+A ``UniformScaling`` operator represents a scalar times the identity operator, ``λ*I``. The identity operator ``I`` is defined as a constant and is an instance of ``UniformScaling``. The size of these operators are generic and match the other matrix in the binary operations ``+``,``-``,``*`` and ``\``. For ``A+I`` and ``A-I`` this means that ``A`` must be square. Multiplication with the identity operator ``I`` is a noop (except for checking that the scaling factor is one) and therefore almost without overhead. 
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -12,14 +12,14 @@ b = a+a
 @test length((1,)) == 1
 @test length((1,2)) == 2
 
-@test isequal(1+[1,2,3], [2,3,4])
-@test isequal([1,2,3]+1, [2,3,4])
-@test isequal(1-[1,2,3], [0,-1,-2])
-@test isequal([1,2,3]-1, [0,1,2])
+@test isequal(1.+[1,2,3], [2,3,4])
+@test isequal([1,2,3].+1, [2,3,4])
+@test isequal(1.-[1,2,3], [0,-1,-2])
+@test isequal([1,2,3].-1, [0,1,2])
 
 @test isequal(5*[1,2,3], [5,10,15])
 @test isequal([1,2,3]*5, [5,10,15])
-@test isequal(1/[1,2,5], [1.0,0.5,0.2])
+@test isequal(1./[1,2,5], [1.0,0.5,0.2])
 @test isequal([1,2,3]/5, [0.2,0.4,0.6])
 
 a = ones(2,2)
@@ -703,10 +703,9 @@ begin
     @test all(b.==6)
 
     # issue #5141
+    ## Update Removed the version that removes the dimensions when dims==1:ndims(A) 
     c1 = mapslices(x-> maximum(-x), a, [])
     @test c1 == -a
-    c2 = mapslices(x-> maximum(-x), a, [1,2])
-    @test c2 == maximum(-a)
     
     # other types than Number
     @test mapslices(prod,["1" "2"; "3" "4"],1) == ["13" "24"]
@@ -859,7 +858,7 @@ end
 @test isequal(flipdim([2,3,1], 2), [2,3,1])
 @test isequal(flipdim([2 3 1], 1), [2 3 1])
 @test isequal(flipdim([2 3 1], 2), [1 3 2])
-@test_throws flipdim([2,3,1] -1)
+@test_throws flipdim([2,3,1], -1)
 @test isequal(flipdim(1:10, 1), 10:-1:1)
 @test isequal(flipdim(1:10, 2), 1:10)
 @test_throws flipdim(1:10, -1)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -571,7 +571,7 @@ i2 = rand(1:10, n1, n2)
 
 # Matrix{Bool}/Matrix{Float64}
 b1 = randbool(n1, n2)
-f2 = 1.0 + rand(n1, n2)
+f2 = 1.0 .+ rand(n1, n2)
 @check_bit_operation (.*)(b1, f2) Matrix{Float64}
 @check_bit_operation (./)(b1, f2) Matrix{Float64}
 @check_bit_operation (.^)(b1, f2) Matrix{Float64}
@@ -590,23 +590,23 @@ cf1 = complex(f1)
 @check_bit_operation (&)(i1, b2)  Matrix{Int}
 @check_bit_operation (|)(i1, b2)  Matrix{Int}
 @check_bit_operation ($)(i1, b2)  Matrix{Int}
-@check_bit_operation (+)(i1, b2)  Matrix{Int}
-@check_bit_operation (-)(i1, b2)  Matrix{Int}
+@check_bit_operation (.+)(i1, b2)  Matrix{Int}
+@check_bit_operation (.-)(i1, b2)  Matrix{Int}
 @check_bit_operation (.*)(i1, b2) Matrix{Int}
 
 @check_bit_operation (&)(u1, b2)  Matrix{Uint8}
 @check_bit_operation (|)(u1, b2)  Matrix{Uint8}
 @check_bit_operation ($)(u1, b2)  Matrix{Uint8}
-@check_bit_operation (+)(u1, b2)  Matrix{Uint8}
-@check_bit_operation (-)(u1, b2)  Matrix{Uint8}
+@check_bit_operation (.+)(u1, b2)  Matrix{Uint8}
+@check_bit_operation (.-)(u1, b2)  Matrix{Uint8}
 @check_bit_operation (.*)(u1, b2) Matrix{Uint8}
 
 for (x1,t1) = {(f1, Float64),
                (ci1, Complex{Int}),
                (cu1, Complex{Uint8}),
                (cf1, Complex128)}
-    @check_bit_operation (+)(x1, b2)  Matrix{t1}
-    @check_bit_operation (-)(x1, b2)  Matrix{t1}
+    @check_bit_operation (.+)(x1, b2)  Matrix{t1}
+    @check_bit_operation (.-)(x1, b2)  Matrix{t1}
     @check_bit_operation (.*)(x1, b2) Matrix{t1}
 end
 
@@ -666,10 +666,10 @@ cf2 = complex(f2)
 @check_bit_operation (|)(b1, false)  BitMatrix
 @check_bit_operation ($)(b1, true)   BitMatrix
 @check_bit_operation ($)(b1, false)  BitMatrix
-@check_bit_operation (+)(b1, true)   Matrix{Int}
-@check_bit_operation (+)(b1, false)  Matrix{Int}
-@check_bit_operation (-)(b1, true)   Matrix{Int}
-@check_bit_operation (-)(b1, false)  Matrix{Int}
+@check_bit_operation (.+)(b1, true)   Matrix{Int}
+@check_bit_operation (.+)(b1, false)  Matrix{Int}
+@check_bit_operation (.-)(b1, true)   Matrix{Int}
+@check_bit_operation (.-)(b1, false)  Matrix{Int}
 @check_bit_operation (.*)(b1, true)  BitMatrix
 @check_bit_operation (.*)(b1, false) BitMatrix
 @check_bit_operation (./)(b1, true)  Matrix{Float32}
@@ -680,8 +680,8 @@ cf2 = complex(f2)
 @check_bit_operation (&)(b1, i2)  Matrix{Int}
 @check_bit_operation (|)(b1, i2)  Matrix{Int}
 @check_bit_operation ($)(b1, i2)  Matrix{Int}
-@check_bit_operation (+)(b1, i2)  Matrix{Int}
-@check_bit_operation (-)(b1, i2)  Matrix{Int}
+@check_bit_operation (.+)(b1, i2)  Matrix{Int}
+@check_bit_operation (.-)(b1, i2)  Matrix{Int}
 @check_bit_operation (.*)(b1, i2) Matrix{Int}
 @check_bit_operation (./)(b1, i2) Matrix{Float64}
 @check_bit_operation div(b1, i2)  Matrix{Int}
@@ -690,32 +690,32 @@ cf2 = complex(f2)
 @check_bit_operation (&)(b1, u2)  Matrix{Uint8}
 @check_bit_operation (|)(b1, u2)  Matrix{Uint8}
 @check_bit_operation ($)(b1, u2)  Matrix{Uint8}
-@check_bit_operation (+)(b1, u2)  Matrix{Uint8}
-@check_bit_operation (-)(b1, u2)  Matrix{Uint8}
+@check_bit_operation (.+)(b1, u2)  Matrix{Uint8}
+@check_bit_operation (.-)(b1, u2)  Matrix{Uint8}
 @check_bit_operation (.*)(b1, u2) Matrix{Uint8}
 @check_bit_operation (./)(b1, u2) Matrix{Float32}
 @check_bit_operation div(b1, u2)  Matrix{Uint8}
 @check_bit_operation mod(b1, u2)  Matrix{Uint8}
 
-@check_bit_operation (+)(b1, f2)  Matrix{Float64}
-@check_bit_operation (-)(b1, f2)  Matrix{Float64}
+@check_bit_operation (.+)(b1, f2)  Matrix{Float64}
+@check_bit_operation (.-)(b1, f2)  Matrix{Float64}
 @check_bit_operation (.*)(b1, f2) Matrix{Float64}
 @check_bit_operation (./)(b1, f2) Matrix{Float64}
 @check_bit_operation div(b1, f2)  Matrix{Float64}
 @check_bit_operation mod(b1, f2)  Matrix{Float64}
 
-@check_bit_operation (+)(b1, ci2)  Matrix{Complex{Int}}
-@check_bit_operation (-)(b1, ci2)  Matrix{Complex{Int}}
+@check_bit_operation (.+)(b1, ci2)  Matrix{Complex{Int}}
+@check_bit_operation (.-)(b1, ci2)  Matrix{Complex{Int}}
 @check_bit_operation (.*)(b1, ci2) Matrix{Complex{Int}}
 @check_bit_operation (./)(b1, ci2) Matrix{Complex128}
 
-@check_bit_operation (+)(b1, cu2)  Matrix{Complex{Uint8}}
-@check_bit_operation (-)(b1, cu2)  Matrix{Complex{Uint8}}
+@check_bit_operation (.+)(b1, cu2)  Matrix{Complex{Uint8}}
+@check_bit_operation (.-)(b1, cu2)  Matrix{Complex{Uint8}}
 @check_bit_operation (.*)(b1, cu2) Matrix{Complex{Uint8}}
 @check_bit_operation (./)(b1, cu2) Matrix{Complex64}
 
-@check_bit_operation (+)(b1, cf2)  Matrix{Complex128}
-@check_bit_operation (-)(b1, cf2)  Matrix{Complex128}
+@check_bit_operation (.+)(b1, cf2)  Matrix{Complex128}
+@check_bit_operation (.-)(b1, cf2)  Matrix{Complex128}
 @check_bit_operation (.*)(b1, cf2) Matrix{Complex128}
 @check_bit_operation (./)(b1, cf2) Matrix{Complex128}
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -62,13 +62,13 @@ for arr in (identity, as_sub)
     @test arr(bitpack([true false])) .^ arr([0, 3]) == [true true; true false]
 
     M = arr([11 12; 21 22])
-    @test broadcast_getindex(M, eye(Int, 2)+1,arr([1, 2])) == [21 11; 12 22]
-    @test_throws broadcast_getindex(M, eye(Int, 2)+1,arr([1, -1]))
-    @test_throws broadcast_getindex(M, eye(Int, 2)+1,arr([1, 2]), [2])
-    @test broadcast_getindex(M, eye(Int, 2)+1,arr([2, 1]), [1]) == [22 12; 11 21]
+    @test broadcast_getindex(M, eye(Int, 2).+1,arr([1, 2])) == [21 11; 12 22]
+    @test_throws broadcast_getindex(M, eye(Int, 2).+1,arr([1, -1]))
+    @test_throws broadcast_getindex(M, eye(Int, 2).+1,arr([1, 2]), [2])
+    @test broadcast_getindex(M, eye(Int, 2).+1,arr([2, 1]), [1]) == [22 12; 11 21]
 
     A = arr(zeros(2,2))
-    broadcast_setindex!(A, arr([21 11; 12 22]), eye(Int, 2)+1,arr([1, 2]))
+    broadcast_setindex!(A, arr([21 11; 12 22]), eye(Int, 2).+1,arr([1, 2]))
     @test A == M
     broadcast_setindex!(A, 5, [1,2], [2 2])
     @test A == [11 5; 21 5]

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -314,7 +314,7 @@ Bi = B+(2.5*im).*A[[2,1],[2,1]]
 @test Ac_mul_Bc(Ai, Bi) == [-28.25-66im 9.75-58im; -26-89im 21-73im]
 
 # 3x3
-A = [1 2 3; 4 5 6; 7 8 9]-5
+A = [1 2 3; 4 5 6; 7 8 9].-5
 B = [1 0 5; 6 -10 3; 2 -4 -1]
 @test A*B == [-26 38 -27; 1 -4 -6; 28 -46 15]
 @test Ac_mul_B(A, B) == [-6 2 -25; 3 -12 -18; 12 -26 -11]
@@ -328,15 +328,15 @@ Bi = B+(2.5*im).*A[[2,1,3],[2,3,1]]
 @test Ac_mul_Bc(Ai, Bi) == [1+2im 20.75+9im -44.75+42im; 19.5+17.5im -54-36.5im 51-14.5im; 13+7.5im 11.25+31.5im -43.25-14.5im]
 
 # Generic integer matrix multiplication
-A = [1 2 3; 4 5 6] - 3
+A = [1 2 3; 4 5 6] .- 3
 B = [2 -2; 3 -5; -4 7]
 @test A*B == [-7 9; -4 9]
 @test At_mul_Bt(A, B) == [-6 -11 15; -6 -13 18; -6 -15 21]
 A = ones(Int, 2, 100)
 B = ones(Int, 100, 3)
 @test A*B == [100 100 100; 100 100 100]
-A = rand(1:20, 5, 5) - 10
-B = rand(1:20, 5, 5) - 10
+A = rand(1:20, 5, 5) .- 10
+B = rand(1:20, 5, 5) .- 10
 @test At_mul_B(A, B) == A'*B
 @test A_mul_Bt(A, B) == A*B'
  
@@ -355,23 +355,23 @@ b = [1.2,-2.5]
 @test (Aref*b) == (Asub*b)
 @test At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
 @test A_mul_Bt(Asub, Asub) == A_mul_Bt(Aref, Aref)
-Ai = A + im
+Ai = A .+ im
 Aref = Ai[1:2:end,1:2:end]
 Asub = sub(Ai, 1:2:5, 1:2:4)
 @test Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
 @test A_mul_Bc(Asub, Asub) == A_mul_Bc(Aref, Aref)
 
 # syrk & herk
-A = reshape(1:1503, 501, 3)-750.0
+A = reshape(1:1503, 501, 3).-750.0
 res = float64([135228751 9979252 -115270247; 9979252 10481254 10983256; -115270247 10983256 137236759])
 @test At_mul_B(A, A) == res
 @test A_mul_Bt(A',A') == res
 cutoff = 501
-A = reshape(1:6*cutoff,2*cutoff,3)-(6*cutoff)/2
+A = reshape(1:6*cutoff,2*cutoff,3).-(6*cutoff)/2
 Asub = sub(A, 1:2:2*cutoff, 1:3)
 Aref = A[1:2:2*cutoff, 1:3]
 @test At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
-Ai = A - im
+Ai = A .- im
 Asub = sub(Ai, 1:2:2*cutoff, 1:3)
 Aref = Ai[1:2:2*cutoff, 1:3]
 @test Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)

--- a/test/linalg2.jl
+++ b/test/linalg2.jl
@@ -9,7 +9,7 @@ n = 5
 
 srand(123)
 
-d = 1 + rand(n)
+d = 1 .+ rand(n)
 dl = -rand(n-1)
 du = -rand(n-1)
 v = randn(n)
@@ -651,6 +651,47 @@ for elty in (Float32, Float64, BigFloat, Complex{Float32}, Complex{Float64}, Com
         end
     end
 end
+
+# Uniform scaling
+@test I[1,1] == 1 # getindex
+@test I[1,2] == 0 # getindex
+@test I === I' # transpose
+λ = complex(randn(),randn())
+J = UniformScaling(λ)
+@test J*eye(2) == conj(J'eye(2)) # ctranpose (and A(c)_mul_B)
+@test I + I === UniformScaling(2) # +
+B = randbool(2,2)
+@test B + I == B + eye(B)
+@test I + B == B + eye(B)
+A = randn(2,2)
+@test A + I == A + eye(A)
+@test I + A == A + eye(A)
+@test I - I === UniformScaling(0)
+@test B - I == B - eye(B)
+@test I - B == eye(B) - B
+@test A - I == A - eye(A)
+@test I - A == eye(A) - A
+@test I*J === UniformScaling(λ)
+@test B*J == B*λ
+@test J*B == B*λ
+S = sprandn(3,3,0.5)
+@test S*J == S*λ
+@test J*S == S*λ
+@test A*J == A*λ
+@test J*A == A*λ
+@test J*ones(3) == ones(3)*λ
+@test λ*J === UniformScaling(λ*J.λ)
+@test J*λ === UniformScaling(λ*J.λ)
+@test J/I === J
+@test I/A == inv(A)
+@test A/I == A
+@test I/λ === UniformScaling(1/λ)
+@test I\J === J
+T = Triangular(randn(3,3),:L)
+@test T\I == inv(T)
+@test I\A == A
+@test A\I == inv(A)
+@test λ\I === UniformScaling(1/λ)
 
 ## Issue related tests
 # issue 1447

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -35,7 +35,7 @@
 
 A = Complex128[exp(i*im) for i in 1:10^4]
 @test_approx_eq varm(A,0.) sum(map(abs2,A))/(length(A)-1)
-@test_approx_eq varm(A,mean(A)) var(A,1)
+@test_approx_eq varm(A,mean(A)) var(A)
 
 @test midpoints(1.0:1.0:10.0) == 1.5:1.0:9.5
 @test midpoints(1:10) == 1.5:9.5


### PR DESCRIPTION
Define Number rhs for Matrix lhs when dimensions match.

This is a followup on the discussion in JuliaLang/LinearAlgebra.jl#75.
