### PR TITLE
Add unique(AbstractArray, dim)

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -331,6 +331,32 @@ for i = tensors
     @test isequal(i,permutedims(ipermutedims(i,perm),perm))
 end
 
+## unique across dim ##
+
+# All rows and columns unique
+A = ones(10, 10)
+A[diagind(A)] = shuffle!([1:10])
+@test unique(A, 1) == A
+@test unique(A, 2) == A
+
+# 10 repeats of each row
+B = A[shuffle!(repmat(1:10, 10)), :]
+C = unique(B, 1)
+@test sortrows(C) == sortrows(A)
+@test unique(B, 2) == B
+@test unique(B.', 2).' == C
+
+# Along third dimension
+D = cat(3, B, B)
+@test unique(D, 1) == cat(3, C, C)
+@test unique(D, 3) == cat(3, B)
+
+# With hash collisions
+immutable HashCollision
+    x::Float64
+end
+Base.hash(::HashCollision) = uint(0)
+@test map(x->x.x, unique(map(HashCollision, B), 1)) == C
 
 ## reduce ##
 


### PR DESCRIPTION
Efficiently finds the unique columns, rows, etc. of an array. The algorithm first hashes along the specified dimension, then finds the unique hashes, and finally checks that the hashes don't collide. It is roughly O(n) in the number of elements in the array.

Compared with MATLAB's `unique(x, 'rows')`, which first sorts the rows, this approach gives much more consistent and almost always better performance. It is ~10% slower for MATLAB's best case (when values are random, and so sorting requires inspecting only a single column) and much faster for other cases (it is 25x faster than MATLAB for 500 repeats of the same 10 random rows with 5000 columns).

This is my first time using Cartesian. Without it, this code is presently about 10% faster for finding unique rows of a matrix, but the overhead is probably worth it for the generality.
