### PR TITLE
change l -> ℓ for integer local variables, for legibility

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -114,7 +114,7 @@ function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray)...)
 end
 
 ## Bounds-checking without errors ##
-in_bounds(l::Int, i::Integer) = 1 <= i <= l
+in_bounds(ℓ::Int, i::Integer) = 1 <= i <= ℓ
 function in_bounds(sz::Dims, I::Int...)
     n = length(I)
     for dim = 1:(n-1)
@@ -1128,9 +1128,9 @@ ind2sub(dims::(Integer,Integer,Integer), ind::Int) =
 
 function ind2sub{T<:Integer}(dims::(Integer,Integer...), ind::AbstractVector{T})
     n = length(dims)
-    l = length(ind)
-    t = ntuple(n, x->Array(Int, l))
-    for i = 1:l
+    ℓ = length(ind)
+    t = ntuple(n, x->Array(Int, ℓ))
+    for i = 1:ℓ
         s = ind2sub(dims, ind[i])
         for j = 1:n
             t[j][i] = s[j]

--- a/base/array.jl
+++ b/base/array.jl
@@ -518,14 +518,14 @@ function prepend!{T}(a::Array{T,1}, items::AbstractVector)
 end
 
 function resize!(a::Vector, nl::Integer)
-    l = length(a)
-    if nl > l
-        ccall(:jl_array_grow_end, Void, (Any, Uint), a, nl-l)
+    ℓ = length(a)
+    if nl > ℓ
+        ccall(:jl_array_grow_end, Void, (Any, Uint), a, nl-ℓ)
     else
         if nl < 0
             throw(BoundsError())
         end
-        ccall(:jl_array_del_end, Void, (Any, Uint), a, l-nl)
+        ccall(:jl_array_del_end, Void, (Any, Uint), a, ℓ-nl)
     end
     return a
 end
@@ -588,8 +588,8 @@ end
 function deleteat!{T<:Integer}(a::Vector, r::Range1{T})
     n = length(a)
     f = first(r)
-    l = last(r)
-    if !(1 <= f && l <= n)
+    ℓ = last(r)
+    if !(1 <= f && ℓ <= n)
         throw(BoundsError())
     end
     return _deleteat!(a, f, length(r))
@@ -649,22 +649,22 @@ function splice!{T<:Integer}(a::Vector, r::Range1{T}, ins::AbstractArray=_defaul
 
     n = length(a)
     f = first(r)
-    l = last(r)
+    ℓ = last(r)
     d = length(r)
 
     if m < d
         delta = d - m
-        if f-1 < n-l
+        if f-1 < n-ℓ
             _deleteat_beg!(a, f, delta)
         else
-            _deleteat_end!(a, l-delta+1, delta)
+            _deleteat_end!(a, ℓ-delta+1, delta)
         end
     elseif m > d
         delta = m - d
-        if f-1 < n-l
+        if f-1 < n-ℓ
             _growat_beg!(a, f, delta)
         else
-            _growat_end!(a, l+1, delta)
+            _growat_end!(a, ℓ+1, delta)
         end
     end
 
@@ -861,19 +861,19 @@ function slicedim(A::Array, d::Integer, i::Integer)
     B = similar(A, d_out)
     index_offset = 1 + (i-1)*M
 
-    l = 1
+    ℓ = 1
 
     if M==1
         for j=0:stride:(N-stride)
-            B[l] = A[j + index_offset]
-            l += 1
+            B[ℓ] = A[j + index_offset]
+            ℓ += 1
         end
     else
         for j=0:stride:(N-stride)
             offs = j + index_offset
             for k=0:(M-1)
-                B[l] = A[offs + k]
-                l += 1
+                B[ℓ] = A[offs + k]
+                ℓ += 1
             end
         end
     end
@@ -1172,9 +1172,9 @@ end
 function findin(a, b::Range1)
     ind = Array(Int, 0)
     f = first(b)
-    l = last(b)
+    ℓ = last(b)
     for i = 1:length(a)
-        if f <= a[i] <= l
+        if f <= a[i] <= ℓ
             push!(ind, i)
         end
     end

--- a/base/ascii.jl
+++ b/base/ascii.jl
@@ -97,20 +97,20 @@ convert(::Type{ASCIIString}, s::ASCIIString) = s
 convert(::Type{ASCIIString}, s::UTF8String) = ascii(s.data)
 convert(::Type{ASCIIString}, a::Array{Uint8,1}) = is_valid_ascii(a) ? ASCIIString(a) : error("invalid ASCII sequence")
 function convert(::Type{ASCIIString}, a::Array{Uint8,1}, invalids_as::ASCIIString)
-    l = length(a)
+    ℓ = length(a)
     idx = 1
     iscopy = false
-    while idx <= l
+    while idx <= ℓ
         (a[idx] < 0x80) && (idx +=1; continue)
         !iscopy && (a = copy(a); iscopy = true)
         endn = idx
-        while endn <= l
+        while endn <= ℓ
             (a[endn] < 0x80) && break
             endn += 1
         end
         (endn > idx) && (endn -= 1)
         splice!(a, idx:endn, invalids_as.data)
-        l = length(a)
+        ℓ = length(a)
     end
     convert(ASCIIString, a)
 end

--- a/base/base.jl
+++ b/base/base.jl
@@ -118,19 +118,19 @@ function append_any(xs...)
     # must be a separate function from append(), since apply() needs this
     # exact function.
     out = Array(Any, 4)
-    l = 4
+    ℓ = 4
     i = 1
     for x in xs
         for y in x
-            if i > l
+            if i > ℓ
                 ccall(:jl_array_grow_end, Void, (Any, Uint), out, 16)
-                l += 16
+                ℓ += 16
             end
             arrayset(out, y, i)
             i += 1
         end
     end
-    ccall(:jl_array_del_end, Void, (Any, Uint), out, l-i+1)
+    ccall(:jl_array_del_end, Void, (Any, Uint), out, ℓ-i+1)
     out
 end
 

--- a/base/c.jl
+++ b/base/c.jl
@@ -77,11 +77,11 @@ reenable_sigint(f::Function) = try sigatomic_end(); f(); finally sigatomic_begin
 function find_library{T<:ByteString, S<:ByteString}(libnames::Array{T,1}, extrapaths::Array{S,1}=ASCIIString[])
     for lib in libnames
         for path in extrapaths
-            l = joinpath(path, lib)
-            p = dlopen_e(l, RTLD_LAZY)
+            ℓ = joinpath(path, lib)
+            p = dlopen_e(ℓ, RTLD_LAZY)
             if p != C_NULL
                 dlclose(p)
-                return l
+                return ℓ
             end
         end
         p = dlopen_e(lib, RTLD_LAZY)

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -249,9 +249,9 @@ function next(p::Permutations, s)
     if k == 0
         s[1] = length(s)+1   # done
     else
-        l = length(s)
-        while s[k] >= s[l];  l -= 1;  end
-        s[k],s[l] = s[l],s[k]
+        ℓ = length(s)
+        while s[k] >= s[ℓ];  ℓ -= 1;  end
+        s[k],s[ℓ] = s[ℓ],s[k]
         reverse!(s,k+1)
     end
     (perm,s)

--- a/base/darray.jl
+++ b/base/darray.jl
@@ -180,10 +180,10 @@ function convert{S,T,N}(::Type{Array{S,N}}, s::SubDArray{T,N})
     I = s.indexes
     d = s.parent
     if isa(I,(Range1{Int}...)) && S<:T && T<:S
-        l = locate(d, map(first, I)...)
-        if isequal(d.indexes[l...], I)
+        ℓ = locate(d, map(first, I)...)
+        if isequal(d.indexes[ℓ...], I)
             # SubDArray corresponds to a chunk
-            return chunk(d, l...)
+            return chunk(d, ℓ...)
         end
     end
     a = Array(S, size(s))

--- a/base/io.jl
+++ b/base/io.jl
@@ -228,11 +228,11 @@ next(itr::EachLine, nada) = (readline(itr.stream), nothing)
 
 function readlines(s, fx::Function...)
     a = {}
-    for l in eachline(s)
+    for ℓ in eachline(s)
         for f in fx
-          l = f(l)
+          ℓ = f(ℓ)
         end
-        push!(a, l)
+        push!(a, ℓ)
     end
     return a
 end
@@ -496,31 +496,31 @@ end
 
 # based on code by Glen Hertz
 function readuntil(s::IO, t::String)
-    l = length(t)
-    if l == 0
+    ℓ = length(t)
+    if ℓ == 0
         return ""
     end
-    if l > 40
+    if ℓ > 40
         warn("readuntil(IO,String) will perform poorly with a long string")
     end
     out = IOBuffer()
-    m = Array(Char, l)  # last part of stream to match
+    m = Array(Char, ℓ)  # last part of stream to match
     t = collect(t)
     i = 0
     while !eof(s)
         i += 1
         c = read(s, Char)
         write(out, c)
-        if i <= l
+        if i <= ℓ
             m[i] = c
         else
             # shift to last part of s
-            for j = 2:l
+            for j = 2:ℓ
                 m[j-1] = m[j]
             end
-            m[l] = c
+            m[ℓ] = c
         end
-        if i >= l && m == t
+        if i >= ℓ && m == t
             break
         end
     end

--- a/base/linalg/bitarray.jl
+++ b/base/linalg/bitarray.jl
@@ -208,10 +208,10 @@ function findmin(a::BitArray)
         ti += k
         k==64 || return (false, ti)
     end
-    l = (Base.@_mod64 (length(a)-1)) + 1
-    msk = Base.@_mskr l
+    ℓ = (Base.@_mod64 (length(a)-1)) + 1
+    msk = Base.@_mskr ℓ
     @inbounds k = trailing_ones(ac[end] & msk)
     ti += k
-    k==l || return (false, ri)
+    k==ℓ || return (false, ri)
     return m, mi
 end

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -107,10 +107,10 @@ end
 function kron{T,S}(a::Matrix{T}, b::Matrix{S})
     R = Array(promote_type(T,S), size(a,1)*size(b,1), size(a,2)*size(b,2))
     m = 1
-    for j = 1:size(a,2), l = 1:size(b,2), i = 1:size(a,1)
+    for j = 1:size(a,2), ℓ = 1:size(b,2), i = 1:size(a,1)
         aij = a[i,j]
         for k = 1:size(b,1)
-            R[m] = aij*b[k,l]
+            R[m] = aij*b[k,ℓ]
             m += 1
         end
     end
@@ -157,8 +157,8 @@ function rref{T}(A::Matrix{T})
             for k = 1:nr
                 if k != i
                     d = U[k,j]
-                    for l = j:nc
-                        U[k,l] -= d*U[i,l]
+                    for ℓ = j:nc
+                        U[k,ℓ] -= d*U[i,ℓ]
                     end
                 end
             end

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -454,7 +454,7 @@ for (tzrzf, ormrz, elty) in
         function ormrz!(side::BlasChar, trans::BlasChar, A::StridedMatrix{$elty}, tau::StridedVector{$elty}, C::StridedMatrix{$elty})
             m, n = size(C)
             k = length(tau)
-            l = size(A, 2) - size(A, 1)
+            ℓ = size(A, 2) - size(A, 1)
             lda = max(1, stride(A,2))
             ldc = max(1, stride(C,2))
             work = Array($elty, 1)
@@ -467,7 +467,7 @@ for (tzrzf, ormrz, elty) in
                      Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
                      Ptr{BlasInt}, Ptr{BlasInt}),
                     &side, &trans, &m, &n, 
-                    &k, &l, A, &lda, 
+                    &k, &ℓ, A, &lda, 
                     tau, C, &ldc, work, 
                     &lwork, info)
                 if i == 1
@@ -1112,7 +1112,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
             if size(B, 2) != n; throw(DimensionMismatch("")); end
             p = size(B, 1)
             k = Array(BlasInt, 1)
-            l = Array(BlasInt, 1)
+            ℓ = Array(BlasInt, 1)
             lda = max(1,stride(A, 2))
             ldb = max(1,stride(B, 2))
             alpha = Array($relty, n)
@@ -1137,7 +1137,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
                     Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                     Ptr{$elty}, Ptr{$relty}, Ptr{BlasInt}, Ptr{BlasInt}),
                     &jobu, &jobv, &jobq, &m, 
-                    &n, &p, k, l, 
+                    &n, &p, k, ℓ, 
                     A, &lda, B, &ldb, 
                     alpha, beta, U, &ldu, 
                     V, &ldv, Q, &ldq, 
@@ -1151,19 +1151,19 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
                     Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
                     Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}),
                     &jobu, &jobv, &jobq, &m, 
-                    &n, &p, k, l, 
+                    &n, &p, k, ℓ, 
                     A, &lda, B, &ldb, 
                     alpha, beta, U, &ldu, 
                     V, &ldv, Q, &ldq, 
                     work, iwork, info)
             end
             @lapackerror
-            if m - k[1] - l[1] >= 0
-                R = triu(A[1:k[1] + l[1],n - k[1] - l[1] + 1:n])
+            if m - k[1] - ℓ[1] >= 0
+                R = triu(A[1:k[1] + ℓ[1],n - k[1] - ℓ[1] + 1:n])
             else
-                R = triu([A[1:m, n - k[1] - l[1] + 1:n]; B[m - k[1] + 1:l[1], n - k[1] - l[1] + 1:n]])
+                R = triu([A[1:m, n - k[1] - ℓ[1] + 1:n]; B[m - k[1] + 1:ℓ[1], n - k[1] - ℓ[1] + 1:n]])
             end
-            U, V, Q, alpha, beta, k[1], l[1], R
+            U, V, Q, alpha, beta, k[1], ℓ[1], R
         end
     end
 end

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -43,8 +43,8 @@ eigvals!{T<:BlasReal}(A::Symmetric{T}, il::Int=1, ih::Int=size(A,1)) = LAPACK.sy
 eigvals!{T<:BlasReal}(A::Symmetric{T}, vl::Real, vh::Real) = LAPACK.syevr!('N', 'V', A.uplo, A.S, vl, vh, 0, 0, -1.0)[1]
 eigvals!{T<:BlasComplex}(A::Hermitian{T}, il::Int=1, ih::Int=size(A,1)) = LAPACK.syevr!('N', 'I', A.uplo, A.S, 0.0, 0.0, il, ih, -1.0)[1]
 eigvals!{T<:BlasComplex}(A::Hermitian{T}, vl::Real, vh::Real) = LAPACK.syevr!('N', 'V', A.uplo, A.S, vl, vh, 0, 0, -1.0)[1]
-eigvals{T<:BlasFloat}(A::HermOrSym{T},l::Real=1,h::Real=size(A,1)) = eigvals!(copy(A),l,h)
-eigvals{T}(A::HermOrSym{T},l::Real=1,h::Real=size(A,1)) = (S = promote_type(Float32,typeof(sqrt(one(T)))); S != T ? eigvals!(convert(typeof(A).name.primary{S}, A, l, h)) : eigvals!(copy(A), l, h))
+eigvals{T<:BlasFloat}(A::HermOrSym{T},ℓ::Real=1,h::Real=size(A,1)) = eigvals!(copy(A),ℓ,h)
+eigvals{T}(A::HermOrSym{T},ℓ::Real=1,h::Real=size(A,1)) = (S = promote_type(Float32,typeof(sqrt(one(T)))); S != T ? eigvals!(convert(typeof(A).name.primary{S}, A, ℓ, h)) : eigvals!(copy(A), ℓ, h))
 eigmax(A::HermOrSym) = eigvals(A, size(A, 1), size(A, 1))[1]
 eigmin(A::HermOrSym) = eigvals(A, 1, 1)[1]
 

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1118,7 +1118,7 @@ function launch_ssh_workers(cman::SSHManager, np::Integer, config::Dict)
         sshflags = config[:sshflags]
         cman.machines[i] = machine_def[1]
         
-        io, pobj = readsfrom(detach(`ssh -n $sshflags $(machine_def[1]) "sh -l -c \"cd $dir && $exename $exeflags\""`))
+        io, pobj = readsfrom(detach(`ssh -n $sshflags $(machine_def[1]) "sh -ℓ -c \"cd $dir && $exename $exeflags\""`))
         io_objs[i] = io
         configs[i] = merge(config, {:machine => cman.machines[i]})
     end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -161,9 +161,9 @@ end
     stride = 1
     index = I_0
     @nexprs N d->begin
-        l = size(B,d)
-        stride *= l
-        1 <= I_{d-1} <= l || throw(BoundsError())
+        ℓ = size(B,d)
+        stride *= ℓ
+        1 <= I_{d-1} <= ℓ || throw(BoundsError())
         index += (I_d - 1) * stride
     end
     return B[index]
@@ -246,9 +246,9 @@ end
     stride = 1
     index = I_0
     @nexprs N d->begin
-        l = size(B,d)
-        stride *= l
-        1 <= I_{d-1} <= l || throw(BoundsError())
+        ℓ = size(B,d)
+        stride *= ℓ
+        1 <= I_{d-1} <= ℓ || throw(BoundsError())
         index += (I_d - 1) * stride
     end
     B[index] = x
@@ -364,9 +364,9 @@ end
     stride = 1
     index = I_0
     @nexprs N d->begin
-        l = size(B,d)
-        stride *= l
-        1 <= I_{d-1} <= l || return false
+        ℓ = size(B,d)
+        stride *= ℓ
+        1 <= I_{d-1} <= ℓ || return false
         index += (I_d - 1) * stride
     end
     return isassigned(B, index)

--- a/base/quadgk.jl
+++ b/base/quadgk.jl
@@ -297,9 +297,9 @@ function kronrod{T<:FloatingPoint}(::Type{T}, n::Integer)
     for m = 0:n-2
         u = zero(T)
         for k = div(m+1,2):-1:0
-            l = m - k + 1
+            ℓ = m - k + 1
             k1 = k + n + 2
-            u += b[k1]*s[k+1] - b[l]*s[k+2]
+            u += b[k1]*s[k+1] - b[ℓ]*s[k+2]
             s[k+2] = u
         end
         s,t = t,s
@@ -310,10 +310,10 @@ function kronrod{T<:FloatingPoint}(::Type{T}, n::Integer)
     for m = n-1:2n-3
         u = zero(T)
         for k = m+1-n:div(m-1,2)
-            l = m - k + 1
-            j = n - l
+            ℓ = m - k + 1
+            j = n - ℓ
             k1 = k + n + 2
-            u -= b[k1]*s[j+2] - b[l]*s[j+3]
+            u -= b[k1]*s[j+2] - b[ℓ]*s[j+3]
             s[j+2] = u
         end
         k = div(m+1,2)

--- a/base/range.jl
+++ b/base/range.jl
@@ -405,10 +405,10 @@ sortperm(r::Range1) = 1:length(r)
 sortperm{T<:Real}(r::Range{T}) = issorted(r) ? (1:1:length(r)) : (length(r):-1:1)
 
 function sum{T<:Real}(r::Ranges{T})
-    l = length(r)
-    # note that a little care is required to avoid overflow in l*(l-1)/2
-    return l * first(r) + (iseven(l) ? (step(r) * (l-1)) * (l>>1)
-                                     : (step(r) * l) * ((l-1)>>1))
+    ℓ = length(r)
+    # note that a little care is required to avoid overflow in ℓ*(ℓ-1)/2
+    return ℓ * first(r) + (iseven(ℓ) ? (step(r) * (ℓ-1)) * (ℓ>>1)
+                                     : (step(r) * ℓ) * ((ℓ-1)>>1))
 end
 
 function map!(f::Callable, dest, r::Ranges)

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -120,12 +120,12 @@ convert{T}(::Type{SharedArray{T}}, A::Array) = (S = SharedArray(T, size(A)); cop
 convert{TS,TA,N}(::Type{SharedArray{TS,N}}, A::Array{TA,N}) = (S = SharedArray(TS, size(A)); copy!(S, A))
 
 function range_1dim(S::SharedArray, n) 
-    l = length(S)
+    ℓ = length(S)
     nw = length(S.pids)
-    partlen = div(l, nw)
+    partlen = div(ℓ, nw)
 
     if n == nw
-        return (((n-1) * partlen) + 1):l
+        return (((n-1) * partlen) + 1):ℓ
     else
         return (((n-1) * partlen) + 1):(n*partlen) 
     end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -350,10 +350,10 @@ function sprand(m::Integer, n::Integer, density::FloatingPoint, rng::Function, v
     #        otherwise, we'll randomly generate the indices to skip
     K = (density > 0.5) ? N*(1-density) : N*density
     # Use Newton's method to invert the birthday problem
-    l = log(1.0-1.0/N)
+    ℓ = log(1.0-1.0/N)
     k = K
-    k = k + ((1-K/N)*exp(-k*l) - 1)/l
-    k = k + ((1-K/N)*exp(-k*l) - 1)/l # for K<N/2, 2 iterations suffice
+    k = k + ((1-K/N)*exp(-k*ℓ) - 1)/ℓ
+    k = k + ((1-K/N)*exp(-k*ℓ) - 1)/ℓ # for K<N/2, 2 iterations suffice
     ik = int(k)
     ind = sort(rand(1:N, ik))
     uind = Array(Int, 0)   # unique indices

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -65,11 +65,11 @@ varm(v::Ranges, m::Number) = var(v)
 ## variance
 function var(v::Ranges)
     s = step(v)
-    l = length(v)
-    if l == 0 || l == 1
+    ℓ = length(v)
+    if ℓ == 0 || ℓ == 1
         return NaN
     end
-    return abs2(s) * (l + 1) * l / 12
+    return abs2(s) * (ℓ + 1) * ℓ / 12
 end
 var(v::AbstractArray) = varm(v, mean(v))
 function var(v::AbstractArray, region)

--- a/base/string.jl
+++ b/base/string.jl
@@ -147,12 +147,12 @@ function ind2chr(s::String, i::Integer)
     j = 1
     k = start(s)
     while true
-        c, l = next(s,k)
+        c, ℓ = next(s,k)
         if i <= k
             return j
         end
         j += 1
-        k = l
+        k = ℓ
     end
 end
 
@@ -163,12 +163,12 @@ function chr2ind(s::String, i::Integer)
     j = 1
     k = start(s)
     while true
-        c, l = next(s,k)
+        c, ℓ = next(s,k)
         if i == j
             return k
         end
         j += 1
-        k = l
+        k = ℓ
     end
 end
 
@@ -335,12 +335,12 @@ function _rsearchindex(s, t, i)
     end
     t = RevString(t)
     rs = RevString(s)
-    l = endof(s)
+    ℓ = endof(s)
     t1, j2 = next(t,start(t))
     while true
         i = rsearch(s,t1,i)
         if i == 0 return 0 end
-        c, ii = next(rs,l-i+1)
+        c, ii = next(rs,ℓ-i+1)
         j = j2; k = ii
         matched = true
         while !done(t,j)
@@ -356,9 +356,9 @@ function _rsearchindex(s, t, i)
             end
         end
         if matched
-            return nextind(s,l-k+1)
+            return nextind(s,ℓ-k+1)
         end
-        i = l-ii+1
+        i = ℓ-ii+1
     end
 end
 
@@ -1234,24 +1234,24 @@ end
 function lpad(s::String, n::Integer, p::String=" ")
     m = n - strwidth(s)
     if m <= 0; return s; end
-    l = strwidth(p)
-    if l==1
+    ℓ = strwidth(p)
+    if ℓ==1
         return bytestring(p^m * s)
     end
-    q = div(m,l)
-    r = m - q*l
+    q = div(m,ℓ)
+    r = m - q*ℓ
     bytestring(p^q*p[1:chr2ind(p,r)]*s)
 end
 
 function rpad(s::String, n::Integer, p::String=" ")
     m = n - strwidth(s)
     if m <= 0; return s; end
-    l = strwidth(p)
-    if l==1
+    ℓ = strwidth(p)
+    if ℓ==1
         return bytestring(s * p^m)
     end
-    q = div(m,l)
-    r = m - q*l
+    q = div(m,ℓ)
+    r = m - q*ℓ
     bytestring(s*p^q*p[1:chr2ind(p,r)])
 end
 

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -199,10 +199,10 @@ getindex{T}(s::SubArray{T,2}, i::Integer, j::Integer) =
     s.parent[s.first_index + (i-1)*s.strides[1] + (j-1)*s.strides[2]]
 getindex{T}(s::SubArray{T,3}, i::Integer, j::Integer, k::Integer) =
     s.parent[s.first_index + (i-1)*s.strides[1] + (j-1)*s.strides[2] + (k-1)*s.strides[3]]
-getindex{T}(s::SubArray{T,4}, i::Integer, j::Integer, k::Integer, l::Integer) =
-    s.parent[s.first_index + (i-1)*s.strides[1] + (j-1)*s.strides[2] + (k-1)*s.strides[3] + (l-1)*s.strides[4]]
-getindex{T}(s::SubArray{T,5}, i::Integer, j::Integer, k::Integer, l::Integer, m::Integer) =
-    s.parent[s.first_index + (i-1)*s.strides[1] + (j-1)*s.strides[2] + (k-1)*s.strides[3] + (l-1)*s.strides[4] + (m-1)*s.strides[5]]
+getindex{T}(s::SubArray{T,4}, i::Integer, j::Integer, k::Integer, ℓ::Integer) =
+    s.parent[s.first_index + (i-1)*s.strides[1] + (j-1)*s.strides[2] + (k-1)*s.strides[3] + (ℓ-1)*s.strides[4]]
+getindex{T}(s::SubArray{T,5}, i::Integer, j::Integer, k::Integer, ℓ::Integer, m::Integer) =
+    s.parent[s.first_index + (i-1)*s.strides[1] + (j-1)*s.strides[2] + (k-1)*s.strides[3] + (ℓ-1)*s.strides[4] + (m-1)*s.strides[5]]
 
 getindex(s::SubArray, i::Real) = getindex(s, to_index(i))
 getindex(s::SubArray, i0::Real, i1::Real) =
@@ -369,11 +369,11 @@ setindex!{T}(s::SubArray{T,2}, v, i::Integer, j::Integer) =
 setindex!{T}(s::SubArray{T,3}, v, i::Integer, j::Integer, k::Integer) =
     setindex!(s.parent, v, s.first_index +(i-1)*s.strides[1]+(j-1)*s.strides[2]+(k-1)*s.strides[3])
 
-setindex!{T}(s::SubArray{T,4}, v, i::Integer, j::Integer, k::Integer, l::Integer) =
-    setindex!(s.parent, v, s.first_index +(i-1)*s.strides[1]+(j-1)*s.strides[2]+(k-1)*s.strides[3]+(l-1)*s.strides[4])
+setindex!{T}(s::SubArray{T,4}, v, i::Integer, j::Integer, k::Integer, ℓ::Integer) =
+    setindex!(s.parent, v, s.first_index +(i-1)*s.strides[1]+(j-1)*s.strides[2]+(k-1)*s.strides[3]+(ℓ-1)*s.strides[4])
 
-setindex!{T}(s::SubArray{T,5}, v, i::Integer, j::Integer, k::Integer, l::Integer, m::Integer) =
-    setindex!(s.parent, v, s.first_index +(i-1)*s.strides[1]+(j-1)*s.strides[2]+(k-1)*s.strides[3]+(l-1)*s.strides[4]+(m-1)*s.strides[5])
+setindex!{T}(s::SubArray{T,5}, v, i::Integer, j::Integer, k::Integer, ℓ::Integer, m::Integer) =
+    setindex!(s.parent, v, s.first_index +(i-1)*s.strides[1]+(j-1)*s.strides[2]+(k-1)*s.strides[3]+(ℓ-1)*s.strides[4]+(m-1)*s.strides[5])
 
 setindex!{T}(s::SubArray{T,1}, v, I::Range1{Int}) =
     setindex!(s.parent, v, (s.first_index+(first(I)-1)*s.strides[1]):s.strides[1]:(s.first_index+(last(I)-1)*s.strides[1]))

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -160,23 +160,23 @@ convert(::Type{UTF8String}, s::UTF8String) = s
 convert(::Type{UTF8String}, s::ASCIIString) = UTF8String(s.data)
 convert(::Type{UTF8String}, a::Array{Uint8,1}) = is_valid_utf8(a) ? UTF8String(a) : error("invalid UTF-8 sequence")
 function convert(::Type{UTF8String}, a::Array{Uint8,1}, invalids_as::String)
-    l = length(a)
+    ℓ = length(a)
     idx = 1
     iscopy = false
-    while idx <= l
+    while idx <= ℓ
         if is_utf8_start(a[idx])
             nextidx = idx+1+utf8_trailing[a[idx]+1]
-            (nextidx <= (l+1)) && (idx = nextidx; continue)
+            (nextidx <= (ℓ+1)) && (idx = nextidx; continue)
         end
         !iscopy && (a = copy(a); iscopy = true)
         endn = idx
-        while endn <= l
+        while endn <= ℓ
             is_utf8_start(a[endn]) && break
             endn += 1
         end
         (endn > idx) && (endn -= 1)
         splice!(a, idx:endn, invalids_as.data)
-        l = length(a)
+        ℓ = length(a)
     end
     UTF8String(a)
 end


### PR DESCRIPTION
As @StefanKarpinski remarked in commit d15ce97f9fa026ca1c97299dce829d48869c8838, the use of `l` as a variable is often a bit unfortunate from a legibility standpoint, since it is easily confused with `1`.  This patch changes most such usages in the Julia source code for integer local variables to `ℓ` instead (LaTeX [\ell](http://www.fileformat.info/info/unicode/char/2113/index.htm)).  cc: @jiahao 
