### PR TITLE
add an internal function to replace Main, use it in sysimg.jl

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -112,7 +112,6 @@
 #     runnable::Bool
 # end
 
-import Main
 import Core.Intrinsics.ccall
 
 export

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -1,3 +1,6 @@
+import Core.Intrinsics.ccall
+ccall(:jl_new_main_module, Any, ())
+
 baremodule Base
 
 eval(x) = Core.eval(Base,x)
@@ -246,5 +249,8 @@ begin
 end
 
 end # baremodule Base
+
+using Base
+importall Base.Operators
 
 Base.isfile("userimg.jl") && Base.include("userimg.jl")

--- a/src/dump.c
+++ b/src/dump.c
@@ -1022,6 +1022,7 @@ void jl_restore_system_image(char *fname)
     jl_array_type->env = jl_deserialize_value(&f);
     
     jl_main_module = (jl_module_t*)jl_deserialize_value(&f);
+    jl_internal_main_module = jl_main_module;
     jl_core_module = (jl_module_t*)jl_get_global(jl_main_module,
                                                  jl_symbol("Core"));
     jl_base_module = (jl_module_t*)jl_get_global(jl_main_module,

--- a/src/gc.c
+++ b/src/gc.c
@@ -813,6 +813,7 @@ static void gc_mark(void)
 
     // modules
     gc_push_root(jl_main_module, 0);
+    gc_push_root(jl_internal_main_module, 0);
     gc_push_root(jl_current_module, 0);
     if (jl_old_base_module) gc_push_root(jl_old_base_module, 0);
 

--- a/src/init.c
+++ b/src/init.c
@@ -690,14 +690,13 @@ void julia_init(char *imageFile)
     jl_init_serializer();
 
     if (!imageFile) {
-        jl_main_module = jl_new_module(jl_symbol("Main"));
-        jl_main_module->parent = jl_main_module;
         jl_core_module = jl_new_module(jl_symbol("Core"));
-        jl_core_module->parent = jl_main_module;
-        jl_set_const(jl_main_module, jl_symbol("Core"),
-                     (jl_value_t*)jl_core_module);
-        jl_module_using(jl_main_module, jl_core_module);
+        jl_new_main_module();
+        jl_internal_main_module = jl_main_module;
+
         jl_current_module = jl_core_module;
+        jl_root_task->current_module = jl_current_module;
+
         jl_init_intrinsic_functions();
         jl_init_primitives();
         jl_load("boot.jl");

--- a/src/julia.h
+++ b/src/julia.h
@@ -766,6 +766,7 @@ DLLEXPORT jl_value_t *jl_apply_array_type(jl_datatype_t *type, size_t dim);
 
 // modules and global variables
 extern DLLEXPORT jl_module_t *jl_main_module;
+extern DLLEXPORT jl_module_t *jl_internal_main_module;
 extern DLLEXPORT jl_module_t *jl_core_module;
 extern DLLEXPORT jl_module_t *jl_base_module;
 extern DLLEXPORT jl_module_t *jl_current_module;
@@ -789,6 +790,7 @@ DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
 DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
 DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from);
 DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
+DLLEXPORT jl_module_t *jl_new_main_module(void);
 void jl_add_standard_imports(jl_module_t *m);
 STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
 {


### PR DESCRIPTION
make the Core.Main binding non-constant, so uses of "Main" in general refer to the _current_ Main. Doing "import Main" will give you a constant reference to the Main at that time.

fixes #5802

related to #1195
