### PR TITLE
Fix #3567

### DIFF
--- a/base/poll.jl
+++ b/base/poll.jl
@@ -291,8 +291,8 @@ function _uv_hook_fspollcb(t::PollingFileWatcher,status::Int32,prev::Ptr,cur::Pt
     end
 end
 
-_uv_hook_close(uv::FileMonitor) = (uv.handle = 0; nothing)
-_uv_hook_close(uv::UVPollingWatcher) = (uv.handle = 0; nothing)
+_uv_hook_close(uv::FileMonitor) = (c_free(uv.handle); uv.handle = 0; nothing)
+_uv_hook_close(uv::UVPollingWatcher) = (c_free(uv.handle); uv.handle = 0; nothing)
 
 function poll_fd(s, seconds::Real; readable=false, writable=false)
     wt = Condition()

--- a/base/process.jl
+++ b/base/process.jl
@@ -221,6 +221,7 @@ function _uv_hook_return_spawn(proc::Process, exit_status::Int32, termsignal::In
 end
 
 function _uv_hook_close(proc::Process)
+    c_free(proc.handle)
     proc.handle = 0
     if isa(proc.closecb, Function) proc.closecb(proc) end
     notify(proc.closenotify)

--- a/src/gc.c
+++ b/src/gc.c
@@ -782,6 +782,13 @@ double clock_now(void);
 static void gc_mark_uv_handle(uv_handle_t *handle, void *arg)
 {
     if (handle->data) {
+        if (handle->type == UV_TTY || handle->type == UV_TCP || handle->type == UV_UDP || handle->type == UV_NAMED_PIPE)
+        {
+            char preserve = *(((char*)handle)-1);
+            if (preserve == 0)
+                return;
+            assert(preserve == 1);
+        }
         gc_push_root((jl_value_t*)(handle->data), 0);
     }
 }

--- a/src/init.c
+++ b/src/init.c
@@ -467,7 +467,7 @@ extern jl_jmp_buf * volatile jl_jmp_target;
 
 void *init_stdio_handle(uv_file fd,int readable)
 {
-    void *handle;
+    uint8_t *handle;
     uv_handle_type type = uv_guess_handle(fd);
     jl_uv_file_t *file;
 #ifndef _OS_WINDOWS_    
@@ -480,7 +480,9 @@ void *init_stdio_handle(uv_file fd,int readable)
     //printf("%d: %d -- %d\n", fd, type, 0);
     switch(type) {
         case UV_TTY:
-            handle = malloc(sizeof(uv_tty_t));
+            handle = malloc(sizeof(uv_tty_t)+1);
+            *handle = 0;
+            handle = handle+1;
             if (uv_tty_init(jl_io_loop,(uv_tty_t*)handle,fd,readable)) {
                 jl_errorf("Error initializing stdio in uv_tty_init (%d, %d)\n", fd, type);
                 abort();
@@ -494,10 +496,12 @@ void *init_stdio_handle(uv_file fd,int readable)
             file->type = UV_FILE;
             file->file = fd;
             file->data = 0;
-            handle = file;
+            handle = (uint8_t*)file;
             break;
         case UV_NAMED_PIPE:
-            handle = malloc(sizeof(uv_pipe_t));
+            handle = malloc(sizeof(uv_pipe_t)+1);
+            *handle = 0;
+            handle = handle+1;
             if (uv_pipe_init(jl_io_loop, (uv_pipe_t*)handle, (readable?UV_PIPE_READABLE:UV_PIPE_WRITABLE))) {
                 jl_errorf("Error initializing stdio in uv_pipe_init (%d, %d)\n", fd, type);
                 abort();
@@ -509,7 +513,9 @@ void *init_stdio_handle(uv_file fd,int readable)
             ((uv_pipe_t*)handle)->data=0;
             break;
         case UV_TCP:
-            handle = malloc(sizeof(uv_tcp_t));
+            handle = malloc(sizeof(uv_tcp_t)+1);
+            *handle = 0;
+            handle = handle+1;
             if (uv_tcp_init(jl_io_loop, (uv_tcp_t*)handle)) {
                 jl_errorf("Error initializing stdio in uv_tcp_init (%d, %d)\n", fd, type);
                 abort();

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -148,8 +148,9 @@ DLLEXPORT void jl_uv_closeHandle(uv_handle_t* handle)
 {
     if (handle->data) {
         JULIA_CB(close,handle->data,0); (void)ret;
+    } else {
+        free(handle);
     }
-    free(handle);
 }
 
 DLLEXPORT void jl_uv_shutdownCallback(uv_shutdown_t* req, int status)


### PR DESCRIPTION
We malloc an extra byte at the beginning of the uv objects that have buffers (and thus might get a callback that the buffer was filled even when not blocked on a read). It might be worth putting it at the end instead, but that's kind painful too, since they are all of different length.

This was surprisingly painful to fix. 
