### PR TITLE
RFC: make isempty(itr) work for general iterables

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -1,3 +1,5 @@
+isempty(itr) = done(itr, start(itr))
+
 # enumerate
 
 immutable Enumerate{I}


### PR DESCRIPTION
As mentioned in #5797, it would be nice if `isempty(itr)` worked for general iterable collections.   The patch to implement this is trivial, and I don't see a downside to this.
