### PR TITLE
Sparse blkdiag

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -470,7 +470,6 @@ export
     zeta,
 
 # arrays
-    blkdiag,
     broadcast!,
     broadcast!_function,
     broadcast,
@@ -585,6 +584,7 @@ export
     bkfact!,
     bkfact,
     blas_set_num_threads,
+    blkdiag,
     chol,
     cholfact!,
     cholfact,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -470,6 +470,7 @@ export
     zeta,
 
 # arrays
+    blkdiag,
     broadcast!,
     broadcast!_function,
     broadcast,

--- a/base/sparse.jl
+++ b/base/sparse.jl
@@ -6,7 +6,7 @@ importall Base
 import Base.NonTupleType, Base.float
 
 export SparseMatrixCSC, 
-       dense, diag, diagm, droptol!, dropzeros!, etree, full, 
+       blkdiag, dense, diag, diagm, droptol!, dropzeros!, etree, full, 
        getindex, ishermitian, issparse, issym, istril, istriu, 
        setindex!, sparse, sparsevec, spdiagm, speye, spones, 
        sprand, sprandbool, sprandn, spzeros, symperm, trace, tril, tril!, 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3641,6 +3641,10 @@ Indexing, Assignment, and Concatenation
 
    If the first argument is a single integer ``n``, then all block rows are assumed to have ``n`` block columns.
 
+.. function:: blkdiag(A...)
+
+   Concatenate block-diagonally
+
 .. function:: flipdim(A, d)
 
    Reverse ``A`` in dimension ``d``.

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3641,10 +3641,6 @@ Indexing, Assignment, and Concatenation
 
    If the first argument is a single integer ``n``, then all block rows are assumed to have ``n`` block columns.
 
-.. function:: blkdiag(A...)
-
-   Concatenate block-diagonally
-
 .. function:: flipdim(A, d)
 
    Reverse ``A`` in dimension ``d``.

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -330,6 +330,10 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Kronecker tensor product of two vectors or two matrices.
 
+.. function:: blkdiag(A...)
+
+   Concatenate matrices block-diagonally. Currently only implemented for sparse matrices.
+
 .. function:: linreg(x, y)
 
    Determine parameters ``[a, b]`` that minimize the squared error between ``y`` and ``a+b*x``.

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -24,6 +24,9 @@ sz34 = spzeros(3, 4)
 se77 = speye(7)
 @test all([se44 sz42 sz41; sz34 se33] == se77)
 
+# check blkdiag concatenation
+@test all(blkdiag(se33, se33) == sparse([1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6], ones(6)))
+
 # check concatenation promotion
 sz41_f32 = spzeros(Float32, 4, 1)
 se33_i32 = speye(Int32, 3, 3)


### PR DESCRIPTION
I can't live without blkdiag on sparse matrices. This is almost identical to the hcat implementation, except for offsetting the row indices. There's probably a better way to share the common code? And I imagine this kind of thing should be tested, documented, etc.
