### PR TITLE
sharedarray to use only workers on current host by default

### DIFF
--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -565,7 +565,7 @@ For other ``AbstractArray`` types, ``sdata`` just returns the object
 itself, so it's safe to use ``sdata`` on any Array-type object.
 
 The constructor for a shared array is of the form 
-  ``SharedArray(T::Type, dims::NTuple; pids=workers(), init=false)``
+  ``SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])``
 which creates a shared array of a bitstype ``T`` and size ``dims``
 across the processes specified by ``pids``.  Unlike distributed
 arrays, a shared array is accessible only from those participating

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4650,10 +4650,13 @@ Distributed Arrays
 Shared Arrays (Experimental, UNIX-only feature)
 -----------------------------------------------
 
-.. function:: SharedArray(T::Type, dims::NTuple; init=false, pids=workers())
+.. function:: SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
 
     Construct a SharedArray of a bitstype ``T``  and size ``dims`` across the processes
     specified by ``pids`` - all of which have to be on the same host. 
+    
+    If ``pids`` is left unspecified, the shared array will be mapped across all workers
+    on the current host.
 
     If an ``init`` function of the type ``initfn(S::SharedArray)`` is specified, 
     it is called on all the participating workers. 


### PR DESCRIPTION
If unspecified, the default behavior of the shared array constructor was to map the array across all workers. It has been changed to only use workers from the current host. This makes the sharedarray object more resilient to changes elsewhere, i.e. other parts of the program may start workers on other hosts, but the sharedarray parts of the code will continue to work.

This coupled with https://github.com/JuliaLang/julia/pull/5512 , i.e., `pmap` with a `pids` argument would allow folks to specify a `pids` keyword arg to pmap like `pids=procs(S)`, which would make the distributed code more resilient to changes in the number / distribution of workers.
