### PR TITLE
Allow triple quoted strings as format strings for `[@]printf`

### DIFF
--- a/base/printf.jl
+++ b/base/printf.jl
@@ -758,12 +758,28 @@ end
 
 _is_str_expr(ex) =
     isa(ex,Expr) && ex.head==:macrocall && isa(ex.args[1],Symbol) &&
-    (ex.args[1] == :str || endswith(string(ex.args[1]),"_str"))
+    (ex.args[1] == :str || endswith(string(ex.args[1]),"str"))
+
+#TODO: remove when triple quotes parses to a string and not a @mstr macrocall
+# and the following line fails with an exception
+:("""hi""").head
+function _convert_mstr_macro(ex)
+    !isa(ex, Expr) && return ex
+    if ex.head == :macrocall &&
+            ex.args[1] == symbol("@mstr") &&
+            length(ex.args) == 2 &&
+            isa(ex.args[2], String)
+        return ex.args[2]
+    end
+    ex
+end
 
 macro printf(args...)
     if length(args) == 0
         error("@printf: called with zero arguments")
     end
+    #TODO: remove when @mstr macrocall gets removed
+    args = map(_convert_mstr_macro, args)
     if !isa(args[1],String) && !(length(args) > 1 && isa(args[2],String))
         if _is_str_expr(args[1]) || length(args) > 1 && _is_str_expr(args[2])
            error("format must be a plain static string (no interpolation or prefix)")


### PR DESCRIPTION
This is a temporary hack for #2682, but the proper fix would be to fix the parser to not emit macroall to the AST for triple quoted strings.

This commit also includes a ugly hack that will error when it is time to remove this fast fix.

``` julia
:("""hi""").head
```

See: https://groups.google.com/forum/#!topic/julia-users/U1shoGwnCCQ
