### PR TITLE
Add warning for missing module in myid() == 1

### DIFF
--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -330,6 +330,9 @@ function deserialize(s, ::Type{Module})
     path = deserialize(s)
     m = Main
     for mname in path
+        if !isdefined(m,mname)
+            warn("Module $mname not defined on process $(myid())")  # an error seemingly fails
+        end
         m = eval(m,mname)::Module
     end
     m


### PR DESCRIPTION
Here's a (probably lame) attempt to fix a problem that comes up when the main and worker processes have different code. Let's say we set the file `Private.jl` to the following contents:

```
module Private

type MyType
    a::Int
end

end

m = Private.MyType(7)
```

and

```
module Shared

myfunction(x) = x.a+1

end
```

Then trying to send an object of type `MyType` from process 1 to 2, when 2 doesn't know about module `Private`, leads to a very helpful error message:

```
julia> include("Private.jl")
MyType(7)

julia> wpid = addprocs(1)[1]
2

julia> require("Shared.jl")

julia> remotecall_fetch(wpid, Shared.myfunction, m)
fatal error on 2: ERROR: Private not defined
 in deserialize at serialize.jl:333
 in handle_deserialize at serialize.jl:321
 in deserialize at serialize.jl:449
 in handle_deserialize at serialize.jl:321
 in deserialize at serialize.jl:304
 in anonymous at serialize.jl:324
 in ntuple at tuple.jl:30
 in deserialize_tuple at serialize.jl:324
 in handle_deserialize at serialize.jl:316
 in anonymous at task.jl:820
Worker 2 terminated.
ERROR: ProcessExitedException()
 in remotecall_fetch at multi.jl:673
 in remotecall_fetch at multi.jl:678
```

However, the converse is harder to interpret:

```
julia> wpid = addprocs(1)[1]
2

julia> r = remotecall_wait(wpid, Core.include, "Private.jl")
RemoteRef(2,1,6)

julia> fetch(r)
Worker 2 terminated.
ERROR: ProcessExitedException()
 in remotecall_fetch at multi.jl:673
 in fetch at multi.jl:728
```

With this change, it prints a warning like this:

```
julia> fetch(r)
WARNING: Module Private not defined on process 1
Worker 2 terminated.
ERROR: ProcessExitedException()
 in remotecall_fetch at multi.jl:673
 in fetch at multi.jl:728
```

but I was not able to figure out how to get the more-natural `error` to produce useful behavior.
