### PR TITLE
Use deleteat! instead of splice! in linalg/sparse

### DIFF
--- a/base/linalg/sparse.jl
+++ b/base/linalg/sparse.jl
@@ -167,8 +167,8 @@ function *{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti})
         colptrC[nB+1] = ip
     end
 
-    splice!(rowvalC, colptrC[end]:length(rowvalC))
-    splice!(nzvalC, colptrC[end]:length(nzvalC))
+    deleteat!(rowvalC, colptrC[end]:length(rowvalC))
+    deleteat!(nzvalC, colptrC[end]:length(nzvalC))
 
     # The Gustavson algorithm does not guarantee the product to have sorted row indices.
     Cunsorted = SparseMatrixCSC(mA, nB, colptrC, rowvalC, nzvalC)
@@ -359,8 +359,8 @@ function sparse_diff1{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
         end
         colptr[col+1] = numnz+1
     end
-    splice!(rowval, numnz+1:length(rowval))
-    splice!(nzval, numnz+1:length(nzval))
+    deleteat!(rowval, numnz+1:length(rowval))
+    deleteat!(nzval, numnz+1:length(nzval))
     return SparseMatrixCSC{Tv,Ti}(m-1, n, colptr, rowval, nzval)
 end
 
@@ -449,8 +449,8 @@ function sparse_diff2{Tv,Ti}(a::SparseMatrixCSC{Tv,Ti})
 
         colptr[col+1] = ptrS
     end
-    splice!(rowval, ptrS:length(rowval))
-    splice!(nzval, ptrS:length(nzval))
+    deleteat!(rowval, ptrS:length(rowval))
+    deleteat!(nzval, ptrS:length(nzval))
     return SparseMatrixCSC{Tv,Ti}(m, n-1, colptr, rowval, nzval)
 end
 

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -195,3 +195,8 @@ I,J,V = findnz(SparseMatrixCSC(2,1,[1,3],[1,2],[1.0,0.0]))
 
 # issue 5824
 @test sprand(4,5,0.5).^0 == sparse(ones(4,5))
+
+# test for "access to undefined error" types that initially allocate elements as #undef
+@test all(sparse(1:2, 1:2, Any[1,2])^2 == sparse(1:2, 1:2, [1,4]))
+sd1 = diff(sparse([1,1,1], [1,2,3], Any[1,2,3]), 1)
+


### PR DESCRIPTION
If the array type of a sparse matrix is such that elements are initially allocated as #undef, then splice! will fail to remove the extra elements since it returns the values, giving error: access to undefined reference.

Adding test first to show failure case in Travis, then will commit fix.
