### PR TITLE
readdlm quoted column support

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -66,23 +66,21 @@ end
 
 function readdlm_string(sbuff::String, dlm::Char, T::Type, eol::Char, auto::Bool, optsd::Dict)
     ign_empty = (dlm == invalid_dlm)
+    quotes = get(optsd, :quotes, true)
 
-    nrows,ncols = try
-            dlm_dims(sbuff, eol, dlm, ign_empty)
+    nrows,ncols,offsets = try
+            dlm_dims(sbuff, eol, dlm, '"', ign_empty, quotes)
         catch ex
             !get(optsd, :ignore_invalid_chars, false) && throw(ex)
             sbuff = ascii_if_possible(convert(typeof(sbuff), sbuff.data, ""))
-            dlm_dims(sbuff, eol, dlm, ign_empty)
+            dlm_dims(sbuff, eol, dlm, '"', ign_empty, quotes)
         end
-    begin_offsets = zeros(Int, nrows, ncols)
-    end_offsets = zeros(Int, nrows, ncols)
     has_header = get(optsd, :has_header, false)
     cells = Array(T, has_header ? nrows-1 : nrows, ncols)
-    dlm_offsets(sbuff, dlm, eol, begin_offsets, end_offsets, ign_empty)
-    has_header ? (dlm_fill(cells, begin_offsets, end_offsets, sbuff, auto, 1, dlm, eol, ign_empty), dlm_fill(Array(String, 1, ncols), begin_offsets, end_offsets, sbuff, auto, 0, dlm, eol, ign_empty)) : dlm_fill(cells, begin_offsets, end_offsets, sbuff, auto, 0, dlm, eol, ign_empty)
+    has_header ? (dlm_fill(cells, offsets, sbuff, auto, 1, eol), dlm_fill(Array(String, 1, ncols), offsets, sbuff, auto, 0, eol)) : dlm_fill(cells, offsets, sbuff, auto, 0, eol)
 end
 
-const valid_opts = [:has_header, :ignore_invalid_chars, :use_mmap]
+const valid_opts = [:has_header, :ignore_invalid_chars, :use_mmap, :quotes]
 function val_opts(opts)
     d = Dict{Symbol,Bool}()
     for opt in opts
@@ -93,154 +91,225 @@ function val_opts(opts)
     d
 end
 
-function dlm_fill{T}(cells::Array{T,2}, begin_offsets::Array{Int,2}, end_offsets::Array{Int,2}, sbuff::String, auto::Bool, row_offset::Int, dlm::Char, eol::Char, ign_adj_dlm::Bool)
+function dlm_fill{T}(cells::Array{T,2}, offarr::Vector{Vector{Int}}, sbuff::String, auto::Bool, row_offset::Int, eol::Char)
     maxrow,maxcol = size(cells)
-    tmp64 = Array(Float64,1)
+    const tmp64 = Array(Float64,1)
 
-    for row in (1+row_offset):(maxrow+row_offset)
-        cell_row = row-row_offset
-        for col in 1:maxcol
-            start_pos = begin_offsets[row,col] 
-            end_pos = end_offsets[row,col]
+    idx = 1
+    lastrow = lastcol = 1
+    offidx = 1
+    offsets = offarr[1]
+    fail = false
+    
+    while idx <= length(offsets)
+        row = offsets[idx] - row_offset
+        col = offsets[idx+1]
+        quoted = bool(offsets[idx+2])
+        startpos = offsets[idx+3]
+        endpos = offsets[idx+4]
+        ((idx += 5) > 5000) && (offidx < length(offarr)) && (idx = 1; offsets = offarr[offidx += 1])
 
-            if start_pos > 0 && end_pos > 0
-                end_idx = prevind(sbuff, nextind(sbuff,end_pos))
-                (end_idx > 0) && ('\n' == eol) && ('\r' == sbuff[end_idx]) && (end_idx = prevind(sbuff, end_idx))
-                if ign_adj_dlm
-                    is_default_dlm = (dlm == invalid_dlm)
-                    while start_pos <= end_idx
-                        val = sbuff[start_pos] 
-                        (is_default_dlm ? !in(val, _default_delims) : (val != dlm)) && break
-                        start_pos = nextind(sbuff, start_pos)
-                    end
-                end
-                sval = SubString(sbuff, start_pos, end_idx)
-            else
-                sval = SubString(sbuff, 1, 0)
-            end
-            
-            if T <: Char
-                (length(sval) != 1) && error("file entry \"$(sval)\" is not a Char")
-                cells[cell_row,col] = next(sval,1)[1]
-            elseif T <: Number
-                if float64_isvalid(sval, tmp64)
-                    cells[cell_row,col] = tmp64[1]
-                elseif auto
-                    return dlm_fill(Array(Any,maxrow,maxcol), begin_offsets, end_offsets, sbuff, false, row_offset, dlm, eol, ign_adj_dlm)
+        (row < 1) && continue
+        (row > maxrow) && break
+
+        if (row > lastrow) && (lastcol < maxcol)
+            for cidx in (lastcol+1):maxcol
+                if (T <: String) || (T == Any)
+                    cells[lastrow,cidx] = SubString(sbuff, 1, 0)
+                elseif ((T <: Number) || (T <: Char)) && auto
+                    return dlm_fill(Array(Any,maxrow,maxcol), offarr, sbuff, false, row_offset, eol)
                 else
-                    cells[cell_row,col] = NaN
+                    error("missing value at row $lastrow column $cidx")
                 end
-            elseif T <: String
-                cells[cell_row,col] = sval
-            elseif T == Any
-                cells[cell_row,col] = float64_isvalid(sval, tmp64) ? tmp64[1] : sval
+            end
+        end
+
+        endpos = prevind(sbuff, nextind(sbuff,endpos))
+        (endpos > 0) && ('\n' == eol) && ('\r' == sbuff[endpos]) && (endpos = prevind(sbuff, endpos))
+        if quoted 
+            sval = SubString(sbuff, startpos+1, endpos-1)
+            fail = ('"' in sval) ? _colval(replace(sval, r"\"\"", "\""), cells, row, col, tmp64) : _colval(sval, cells, row, col, tmp64)
+        else
+            sval = SubString(sbuff, startpos, endpos)
+            fail = _colval(sval, cells, row, col, tmp64)
+        end
+
+        if fail
+            ((T <: Number) && auto) ? (return dlm_fill(Array(Any,maxrow,maxcol), offarr, sbuff, false, row_offset, eol)) : error("file entry \"$(sval)\" cannot be converted to $T")
+        end
+
+        lastrow = row
+        lastcol = col
+    end
+
+    if lastcol < maxcol
+        for cidx in (lastcol+1):maxcol
+            if (T <: String) || (T == Any)
+                cells[lastrow,cidx] = SubString(sbuff, 1, 0)
+            elseif ((T <: Number) || (T <: Char)) && auto
+                return dlm_fill(Array(Any,maxrow,maxcol), offarr, sbuff, false, row_offset, eol)
             else
-                error("file entry \"$(sval)\" cannot be converted to $T")
+                error("missing value at row $lastrow column $cidx")
             end
         end
     end
     cells
 end
 
+_colval{T<:Number, S<:String}(sval::S, cells::Array{T,2}, row::Int, col::Int, tmp64::Array{Float64,1}) = (float64_isvalid(sval, tmp64) ? ((cells[row,col] = tmp64[1]); false) : true)
+_colval{T<:String, S<:String}(sval::S, cells::Array{T,2}, row::Int, col::Int, tmp64::Array{Float64,1}) = ((cells[row,col] = sval); false)
+_colval{S<:String}(sval::S, cells::Array{Any,2}, row::Int, col::Int, tmp64::Array{Float64,1}) = ((cells[row,col] = float64_isvalid(sval, tmp64) ? tmp64[1] : sval); false)
+_colval{T<:Char, S<:String}(sval::S, cells::Array{T,2}, row::Int, col::Int, tmp64::Array{Float64,1}) = ((length(sval) == 1) ? ((cells[row,col] = next(sval,1)[1]); false) : true)
+_colval{S<:String}(sval::S, cells::Array, row::Int, col::Int, tmp64::Array{Float64,1}) = true
 
-function dlm_offsets(sbuff::UTF8String, dlm, eol, begin_offsets::Array{Int,2}, end_offsets::Array{Int,2}, ign_adj_dlm::Bool)
-    isascii(dlm) && isascii(eol) && (return dlm_offsets(sbuff.data, uint8(dlm), uint8(eol), begin_offsets, end_offsets, ign_adj_dlm))
-
-    col = 0
-    row = 1
-    maxrow,maxcol = size(begin_offsets)
-    idx = 1
-    is_default_dlm = (dlm == invalid_dlm)
-    got_data = false
-    last_offset = 0
-    slen = length(sbuff.data)
-    while idx <= slen
-        val,idx = next(sbuff, idx)
-        (val != eol) && (is_default_dlm ? !in(val, _default_delims) : (val != dlm)) && (got_data = true) && continue
-        if got_data || !ign_adj_dlm
-            col += 1
-            end_offsets[row,col] = idx-2
-            begin_offsets[row,col] = last_offset+1
-        end
-        last_offset = idx
-        (row >= maxrow) && (col == maxcol) && break
-        (val == eol) && (row += 1; col = 0)
-        got_data = false
+function store_column(oarr::Vector{Vector{Int}}, row::Int, col::Int, quoted::Bool, startpos::Int, endpos::Int, offidx::Int)
+    offsets = oarr[end]
+    if length(offsets) < offidx
+        offsets = Array(Int, 5000)
+        push!(oarr, offsets)
+        offidx = 1
     end
-    if (last_offset < slen) && (col < maxcol)
-        col += 1
-        begin_offsets[row,col] = last_offset+1
-        end_offsets[row,col] = slen
-    end
+    offsets[offidx] = row
+    offsets[offidx+1] = col
+    offsets[offidx+2] = int(quoted)
+    offsets[offidx+3] = startpos
+    offsets[offidx+4] = endpos
+    offidx + 5
 end
 
-dlm_offsets(sbuff::ASCIIString, dlmc, eolc, begin_offsets::Array{Int,2}, end_offsets::Array{Int,2}, ign_adj_dlm::Bool) = dlm_offsets(sbuff.data, uint8(dlmc), uint8(eolc), begin_offsets, end_offsets, ign_adj_dlm)
-function dlm_offsets(dbuff::Vector{Uint8}, dlm::Uint8, eol::Uint8, begin_offsets::Array{Int,2}, end_offsets::Array{Int,2}, ign_adj_dlm::Bool)
-    col = 0
-    row = 1
-    is_default_dlm = (dlm == uint8(invalid_dlm))
-    maxrow,maxcol = size(begin_offsets)
-    got_data = false
-    last_offset = 0
-    slen = length(dbuff)
-    for idx in 1:slen
-        val = dbuff[idx]
-        (val != eol) && (is_default_dlm ? !in(val, _default_delims) : (val != dlm)) && (got_data = true) && continue
-        if got_data || !ign_adj_dlm
-            col += 1
-            end_offsets[row,col] = idx-1
-            begin_offsets[row,col] = last_offset+1
-        end
-        last_offset = idx
-        (row >= maxrow) && (col == maxcol) && break
-        (val == eol) && (row += 1; col = 0)
-        got_data = false
-    end
-    if (last_offset < slen) && (col < maxcol)
-        col += 1
-        begin_offsets[row,col] = last_offset+1
-        end_offsets[row,col] = slen
-    end
-end
-
-dlm_dims(s::ASCIIString, eol::Char, dlm::Char, ign_adj_dlm::Bool) = dlm_dims(s.data, uint8(eol), uint8(dlm), ign_adj_dlm)
-function dlm_dims{T,D}(dbuff::T, eol::D, dlm::D, ign_adj_dlm::Bool)
-    isa(dbuff, UTF8String) && isascii(eol) && isascii(dlm) && (return dlm_dims(dbuff.data, uint8(eol), uint8(dlm), ign_adj_dlm))
+dlm_dims(s::ASCIIString, eol::Char, dlm::Char, qchar::Char, ign_adj_dlm::Bool, allow_quote::Bool) = dlm_dims(s.data, uint8(eol), uint8(dlm), uint8(qchar), ign_adj_dlm, allow_quote)
+function dlm_dims{T,D}(dbuff::T, eol::D, dlm::D, qchar::D, ign_adj_dlm::Bool, allow_quote::Bool)
+    qascii = !allow_quote || (D <: Uint8) || isascii(qchar)
+    (T <: UTF8String) && isascii(eol) && isascii(dlm) && qascii && (return dlm_dims(dbuff.data, uint8(eol), uint8(dlm), uint8(qchar), ign_adj_dlm, allow_quote))
     ncols = nrows = col = 0
     is_default_dlm = (dlm == convert(D, invalid_dlm))
+    error_str = ""
+    state = 0   # 0: begin field, 1: quoted field, 2: unquoted field, 3: second quote (could either be end of field or escape character)
+    is_eol = is_dlm = is_quote = expct_col = false
+    idx = 1
+    offsets = Array(Array{Int,1}, 1)
+    offsets[1] = Array(Int, 5000)
+    offidx = 1
     try
-        got_data = false
-        for val in dbuff
-            (val != eol) && (is_default_dlm ? !in(val, _default_delims) : (val != dlm)) && (got_data = true) && continue
-            (got_data || !ign_adj_dlm) && (col += 1)
-            (val == eol) && (nrows += 1; ncols = max(ncols, col); col = 0)
-            got_data = false
+        slen = sizeof(dbuff)
+        col_start_idx = 1
+        while idx <= slen
+            val,idx = next(dbuff, idx)
+            is_eol = (val == eol)
+            is_dlm = is_eol ? false : is_default_dlm ? in(val, _default_delims) : (val == dlm)
+            is_quote = (val == qchar)
+
+            if 2 == state   # unquoted field
+                if is_dlm
+                    state = 0
+                    col += 1
+                    offidx = store_column(offsets, nrows+1, col, false, col_start_idx, idx-2, offidx)
+                    col_start_idx = idx
+                    !ign_adj_dlm && (expct_col = true)
+                elseif is_eol
+                    nrows += 1
+                    col += 1
+                    offidx = store_column(offsets, nrows, col, false, col_start_idx, idx-2, offidx)
+                    col_start_idx = idx
+                    ncols = max(ncols, col)
+                    col = 0
+                    state = 0
+                end
+            elseif 1 == state   # quoted field
+                is_quote && (state = 3)
+            elseif 0 == state   # begin field
+                if is_quote
+                    state = allow_quote ? 1 : 2
+                    expct_col = false
+                elseif is_dlm
+                    if !ign_adj_dlm 
+                        expct_col = true
+                        col += 1
+                        offidx = store_column(offsets, nrows+1, col, false, col_start_idx, idx-2, offidx)
+                        col_start_idx = idx
+                    else
+                        col_start_idx = idx
+                    end
+                elseif is_eol
+                    nrows += 1
+                    if expct_col 
+                        col += 1
+                        offidx = store_column(offsets, nrows, col, false, col_start_idx, idx-2, offidx)
+                        col_start_idx = idx
+                    end
+                    ncols = max(ncols, col)
+                    col = 0
+                    expct_col = false
+                else
+                    state = 2
+                    expct_col = false
+                end
+            elseif 3 == state   # second quote
+                if is_quote
+                    state = 1
+                elseif is_dlm
+                    state = 0
+                    col += 1
+                    offidx = store_column(offsets, nrows+1, col, true, col_start_idx, idx-2, offidx)
+                    col_start_idx = idx
+                    !ign_adj_dlm && (expct_col = true)
+                elseif is_eol
+                    nrows += 1
+                    col += 1
+                    offidx = store_column(offsets, nrows, col, true, col_start_idx, idx-2, offidx)
+                    col_start_idx = idx
+                    ncols = max(ncols, col)
+                    col = 0
+                    state = 0
+                else
+                    error_str = "unexpected character '$(char(val))' after quoted field at row $(nrows+1) column $(col+1)"
+                    break
+                end
+            end
+        end
+
+        if isempty(error_str)
+            if 1 == state       # quoted field
+                error_str = "truncated column at row $(nrows+1) column $(col+1)"
+            elseif (2 == state) || (3 == state) || ((0 == state) && is_dlm)   # unquoted field, second quote, or begin field with last character as delimiter
+                col += 1
+                nrows += 1
+                offidx = store_column(offsets, nrows, col, (3 == state), col_start_idx, idx-1, offidx)
+                ncols = max(ncols, col)
+            end
         end
     catch ex
-        error("at row $nrows, column $col : $ex)")
+        error("at row $(nrows+1), column $col : $ex)")
     end
-    if col > 0 
-        nrows += 1
-        ncols = max(ncols, col+1)
-    end
-    ncols = max(ncols, col, 1)
+    !isempty(error_str) && error(error_str)
+    
+    ncols = max(ncols, 1)
     nrows = max(nrows, 1)
-    return (nrows, ncols)
+    trimsz = (offidx-1)%5000
+    (trimsz > 0) && resize!(offsets[end], trimsz)
+    return (nrows, ncols, offsets)
 end
 
 readcsv(io; opts...)          = readdlm(io, ','; opts...)
 readcsv(io, T::Type; opts...) = readdlm(io, ',', T; opts...)
 
 # todo: keyword argument for # of digits to print
-writedlm_cell(io::IO, elt::FloatingPoint) = print_shortest(io, elt)
-writedlm_cell(io::IO, elt) = print(io, elt)
+writedlm_cell(io::IO, elt::FloatingPoint, dlm) = print_shortest(io, elt)
+function writedlm_cell{T}(io::IO, elt::String, dlm::T)
+    if ('"' == elt[1]) || ('\n' in elt) || ((T <: Char) ? (dlm in elt) : contains(elt, dlm))
+        print(io, '"', replace(elt, r"\"", "\"\""), '"')
+    else
+        print(io, elt)
+    end
+end
+writedlm_cell(io::IO, elt, dlm) = print(io, elt)
 function writedlm(io::IO, a::AbstractVecOrMat, dlm)
     pb = PipeBuffer()
     nr = size(a,1)
     nc = size(a,2)
     for i = 1:nr
         for j = 1:nc
-            writedlm_cell(pb, a[i,j])
+            writedlm_cell(pb, a[i,j], dlm)
             j == nc ? write(pb,'\n') : print(pb,dlm)
         end
         (nb_available(pb) > (16*1024)) && write(io, takebuf_array(pb))
@@ -268,7 +337,7 @@ function writedlm(io::IO, itr, dlm)
         state = start(row)
         while !done(row, state)
             (x, state) = next(row, state)
-            writedlm_cell(pb, x)
+            writedlm_cell(pb, x, dlm)
             done(row, state) ? write(pb,'\n') : print(pb,dlm)
         end
         (nb_available(pb) > (16*1024)) && write(io, takebuf_array(pb))

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -2622,7 +2622,7 @@
 
 "),
 
-("Text I/O","Base","readdlm","readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap=false, ignore_invalid_chars=false)
+("Text I/O","Base","readdlm","readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap=true, ignore_invalid_chars=false, quotes=true)
 
    Read a matrix from the source where each line (separated by
    \"eol\") gives one row, with elements separated by the given
@@ -2645,6 +2645,11 @@
    If \"ignore_invalid_chars\" is \"true\", bytes in \"source\" with
    invalid character encoding will be ignored. Otherwise an error is
    thrown indicating the offending character position.
+
+   If \"quotes\" is \"true\", column enclosed within double-quote (\") 
+   characters are allowed to contain new lines and column delimiters. 
+   Double-quote characters within a quoted field must be escaped with 
+   another double-quote.
 
 "),
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1745,7 +1745,7 @@ Text I/O
 
    Create an iterable object that will yield each line from a stream.
 
-.. function:: readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap=false, ignore_invalid_chars=false)
+.. function:: readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap=true, ignore_invalid_chars=false, quotes=true)
 
    Read a matrix from the source where each line (separated by ``eol``) gives one row, with elements separated by the given delimeter. The source can be a text file, stream or byte array. Memory mapped files can be used by passing the byte array representation of the mapped segment as source. 
 
@@ -1756,6 +1756,8 @@ Text I/O
    If ``use_mmap`` is ``true``, the file specified by ``source`` is memory mapped for potential speedups.
 
    If ``ignore_invalid_chars`` is ``true``, bytes in ``source`` with invalid character encoding will be ignored. Otherwise an error is thrown indicating the offending character position.
+
+   If ``quotes`` is ``true``, column enclosed within double-quote (``) characters are allowed to contain new lines and column delimiters. Double-quote characters within a quoted field must be escaped with another double-quote.
 
 .. function:: readdlm(source, delim::Char, eol::Char; options...)
 

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -1,9 +1,9 @@
-dlm_data = readdlm(joinpath("perf", "kernel", "imdb-1.tsv"), '\t')
-
-@test size(dlm_data) == (31383,3)
-@test dlm_data[12345,2] == "Gladiator"
-@test dlm_data[31383,3] == 2005
-@test dlm_data[1,1] == "McClure, Marc (I)"
+let dlm_data = readdlm(joinpath("perf", "kernel", "imdb-1.tsv"), '\t')
+    @test size(dlm_data) == (31383,3)
+    @test dlm_data[12345,2] == "Gladiator"
+    @test dlm_data[31383,3] == 2005
+    @test dlm_data[1,1] == "McClure, Marc (I)"
+end
 
 @test size(readcsv(IOBuffer("1,2,3,4"))) == (1,4)
 @test size(readcsv(IOBuffer("1,2,3,"))) == (1,4)
@@ -23,24 +23,34 @@ dlm_data = readdlm(joinpath("perf", "kernel", "imdb-1.tsv"), '\t')
 @test size(readdlm(IOBuffer("1\t 2 3 4\n1 2 3\n"))) == (2,4)
 @test size(readdlm(IOBuffer("1,,2,3,4\n1,2,3\n"), ',')) == (2,5)
 
-result1 = reshape({"", "", "", "", "", "", 1.0, 1.0, "", "", "", "", "", 1.0, 2.0, "", 3.0, "", "", "", "", "", 4.0, "", "", ""}, 2, 13)
-result2 = reshape({1.0, 1.0, 2.0, 1.0, 3.0, "", 4.0, ""}, 2, 4)
+let result1 = reshape({"", "", "", "", "", "", 1.0, 1.0, "", "", "", "", "", 1.0, 2.0, "", 3.0, "", "", "", "", "", 4.0, "", "", ""}, 2, 13),
+    result2 = reshape({1.0, 1.0, 2.0, 1.0, 3.0, "", 4.0, ""}, 2, 4)
 
-@test readdlm(IOBuffer(",,,1,,,,2,3,,,4,\n,,,1,,,1\n"), ',') == result1
-@test readdlm(IOBuffer("   1    2 3   4 \n   1   1\n")) == result2
-@test readdlm(IOBuffer("   1    2 3   4 \n   1   1\n"), ' ') == result1
-@test readdlm(IOBuffer("1 2\n3 4 \n")) == [[1.0, 3.0] [2.0, 4.0]]
+    @test isequal(readdlm(IOBuffer(",,,1,,,,2,3,,,4,\n,,,1,,,1\n"), ','), result1)
+    @test isequal(readdlm(IOBuffer("   1    2 3   4 \n   1   1\n")), result2)
+    @test isequal(readdlm(IOBuffer("   1    2 3   4 \n   1   1\n"), ' '), result1)
+    @test isequal(readdlm(IOBuffer("1 2\n3 4 \n")), [[1.0, 3.0] [2.0, 4.0]])
+end
 
-result1[1,4] = "भारत" 
-@test readdlm(IOBuffer(",,,भारत,,,,2,3,,,4,\n,,,1,,,1\n"), ',') == result1
+let result1 = reshape({"", "", "", "", "", "", "भारत", 1.0, "", "", "", "", "", 1.0, 2.0, "", 3.0, "", "", "", "", "", 4.0, "", "", ""}, 2, 13)
+    @test isequal(readdlm(IOBuffer(",,,भारत,,,,2,3,,,4,\n,,,1,,,1\n"), ',') , result1)
+end
 
-result1 = reshape({1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, ""}, 2, 4)
-@test readdlm(IOBuffer("1\t 2 3 4\n1 2 3")) == result1
-@test readdlm(IOBuffer("1\t 2 3 4\n1 2 3 ")) == result1
-@test readdlm(IOBuffer("1\t 2 3 4\n1 2 3\n")) == result1
-@test readdlm(IOBuffer("1,2,3,4\n1,2,3\n"), ',') == result1
-@test readdlm(IOBuffer("1,2,3,4\n1,2,3"), ',') == result1
-@test readdlm(IOBuffer("1,2,3,4\r\n1,2,3\r\n"), ',') == result1
+let result1 = reshape({1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, ""}, 2, 4)
+    @test isequal(readdlm(IOBuffer("1\t 2 3 4\n1 2 3")), result1)
+    @test isequal(readdlm(IOBuffer("1\t 2 3 4\n1 2 3 ")), result1)
+    @test isequal(readdlm(IOBuffer("1\t 2 3 4\n1 2 3\n")), result1)
+    @test isequal(readdlm(IOBuffer("1,2,3,4\n1,2,3\n"), ','), result1)
+    @test isequal(readdlm(IOBuffer("1,2,3,4\n1,2,3"), ','), result1)
+    @test isequal(readdlm(IOBuffer("1,2,3,4\r\n1,2,3\r\n"), ','), result1)
+end
+
+let result1 = reshape({"abc", "hello", "def,ghi", " \"quote\" ", "new\nline", "world"}, 2, 3),
+    result2 = reshape({"abc", "line\"", "\"hello\"", "\"def", "", "\" \"\"quote\"\" \"", "ghi\"", "", "world", "\"new", "", ""}, 3, 4)
+
+    @test isequal(readdlm(IOBuffer("abc,\"def,ghi\",\"new\nline\"\n\"hello\",\" \"\"quote\"\" \",world"), ','), result1)
+    @test isequal(readdlm(IOBuffer("abc,\"def,ghi\",\"new\nline\"\n\"hello\",\" \"\"quote\"\" \",world"), ',', quotes=false), result2)
+end
 
 let x = [1,2,3], y = [4,5,6], io = IOBuffer()
     writedlm(io, zip(x,y), ",  ")
@@ -48,64 +58,70 @@ let x = [1,2,3], y = [4,5,6], io = IOBuffer()
     @test readcsv(io) == [x y]
 end
 
+let x = ["abc", "def\"ghi", "jk\nl"], y = [1, ",", "\"quoted\""], io = IOBuffer()
+    writedlm(io, zip(x,y), ',')
+    seek(io, 0)
+    @test readcsv(io) == [x y]
+end
+
 
 # source: http://www.i18nguy.com/unicode/unicode-example-utf8.zip
-i18n_data = ["Origin (English)", "Name (English)", "Origin (Native)", "Name (Native)", 
-"Australia", "Nicole Kidman", "Australia", "Nicole Kidman", 
-"Austria", "Johann Strauss", "Österreich", "Johann Strauß", 
-"Belgium (Flemish)", "Rene Magritte", "België", "René Magritte", 
-"Belgium (French)", "Rene Magritte", "Belgique", "René Magritte", 
-"Belgium (German)", "Rene Magritte", "Belgien", "René Magritte", 
-"Bhutan", "Gonpo Dorji", "འབྲུག་ཡུལ།", "མགོན་པོ་རྡོ་རྗེ།", 
-"Canada", "Celine Dion", "Canada", "Céline Dion", 
-"Canada - Nunavut (Inuktitut)", "Susan Aglukark", "ᓄᓇᕗᒻᒥᐅᑦ", "ᓱᓴᓐ ᐊᒡᓗᒃᑲᖅ", 
-"Democratic People's Rep. of Korea", "LEE Sol-Hee", "조선 민주주의 인민 공화국", "이설희", 
-"Denmark", "Soren Hauch-Fausboll", "Danmark", "Søren Hauch-Fausbøll", 
-"Denmark", "Soren Kierkegaard", "Danmark", "Søren Kierkegård", 
-"Egypt", "Abdel Halim Hafez", "ﻣﺼﺮ", "ﻋﺑﺪﺍﻠﺣﻟﻳﻢ ﺤﺎﻓﻅ", 
-"Egypt", "Om Kolthoum", "ﻣﺼﺮ", "ﺃﻡ ﻛﻟﺛﻭﻡ", 
-"Eritrea", "Berhane Zeray", "ብርሃነ ዘርኣይ", "ኤርትራ", 
-"Ethiopia", "Haile Gebreselassie", "ኃይሌ ገብረሥላሴ", "ኢትዮጵያ", 
-"France", "Gerard Depardieu", "France", "Gérard Depardieu", 
-"France", "Jean Reno", "France", "Jean Réno", 
-"France", "Camille Saint-Saens", "France", "Camille Saint-Saëns", 
-"France", "Mylene Demongeot", "France", "Mylène Demongeot", 
-"France", "Francois Truffaut", "France", "François Truffaut", 
-"France (Braille)", "Louis Braille", "⠋⠗⠁⠝⠉⠑", "⠇⠕⠥⠊⠎⠀<BR>⠃⠗⠁⠊⠇⠇⠑", 
-"Georgia", "Eduard Shevardnadze", "საქართველო", "ედუარდ შევარდნაძე", 
-"Germany", "Rudi Voeller", "Deutschland", "Rudi Völler", 
-"Germany", "Walter Schultheiss", "Deutschland", "Walter Schultheiß", 
-"Greece", "Giorgos Dalaras", "Ελλάς", "Γιώργος Νταλάρας", 
-"Iceland", "Bjork Gudmundsdottir", "Ísland", "Björk Guðmundsdóttir", 
-"India (Hindi)", "Madhuri Dixit", "भारत", "माधुरी दिछित", 
-"Ireland", "Sinead O'Connor", "Éire", "Sinéad O'Connor", 
-"Israel", "Yehoram Gaon", "ישראל", "יהורם גאון", 
-"Italy", "Fabrizio DeAndre", "Italia", "Fabrizio De André", 
-"Japan", "KUBOTA Toshinobu", "日本", "久保田    利伸", 
-"Japan", "HAYASHIBARA Megumi", "日本", "林原 めぐみ", 
-"Japan", "Mori Ogai", "日本", "森鷗外", 
-"Japan", "Tex Texin", "日本", "テクス テクサン", 
-"Norway", "Tor Age Bringsvaerd", "Noreg", "Tor Åge Bringsværd", 
-"Pakistan (Urdu)", "Nusrat Fatah Ali Khan", "پاکستان", "نصرت فتح علی خان", 
-"People's Rep. of China", "ZHANG Ziyi", "中国", "章子怡", 
-"People's Rep. of China", "WONG Faye", "中国", "王菲", 
-"Poland", "Lech Walesa", "Polska", "Lech Wałęsa", 
-"Puerto Rico", "Olga Tanon", "Puerto Rico", "Olga Tañón", 
-"Rep. of China", "Hsu Chi", "臺灣", "舒淇", 
-"Rep. of China", "Ang Lee", "臺灣", "李安", 
-"Rep. of Korea", "AHN Sung-Gi", "한민국", "안성기", 
-"Rep. of Korea", "SHIM Eun-Ha", "한민국", "심은하", 
-"Russia", "Mikhail Gorbachev", "Россия", "Михаил Горбачёв", 
-"Russia", "Boris Grebenshchikov", "Россия", "Борис Гребенщиков", 
-"Slovenia", "\"Frane \"\"Jezek\"\" Milcinski", "Slovenija", "Frane Milčinski - Ježek", 
-"Syracuse (Sicily)", "Archimedes", "Συρακούσα", "Ἀρχιμήδης", 
-"Thailand", "Thongchai McIntai", "ประเทศไทย", "ธงไชย แม็คอินไตย์", 
-"U.S.A.", "Brad Pitt", "U.S.A.", "Brad Pitt", 
-"Yugoslavia (Cyrillic)", "Djordje Balasevic", "Југославија", "Ђорђе Балашевић", 
-"Yugoslavia (Latin)", "Djordje Balasevic", "Jugoslavija", "Đorđe Balašević"]
+let i18n_data = ["Origin (English)", "Name (English)", "Origin (Native)", "Name (Native)", 
+        "Australia", "Nicole Kidman", "Australia", "Nicole Kidman", 
+        "Austria", "Johann Strauss", "Österreich", "Johann Strauß", 
+        "Belgium (Flemish)", "Rene Magritte", "België", "René Magritte", 
+        "Belgium (French)", "Rene Magritte", "Belgique", "René Magritte", 
+        "Belgium (German)", "Rene Magritte", "Belgien", "René Magritte", 
+        "Bhutan", "Gonpo Dorji", "འབྲུག་ཡུལ།", "མགོན་པོ་རྡོ་རྗེ།", 
+        "Canada", "Celine Dion", "Canada", "Céline Dion", 
+        "Canada - Nunavut (Inuktitut)", "Susan Aglukark", "ᓄᓇᕗᒻᒥᐅᑦ", "ᓱᓴᓐ ᐊᒡᓗᒃᑲᖅ", 
+        "Democratic People's Rep. of Korea", "LEE Sol-Hee", "조선 민주주의 인민 공화국", "이설희", 
+        "Denmark", "Soren Hauch-Fausboll", "Danmark", "Søren Hauch-Fausbøll", 
+        "Denmark", "Soren Kierkegaard", "Danmark", "Søren Kierkegård", 
+        "Egypt", "Abdel Halim Hafez", "ﻣﺼﺮ", "ﻋﺑﺪﺍﻠﺣﻟﻳﻢ ﺤﺎﻓﻅ", 
+        "Egypt", "Om Kolthoum", "ﻣﺼﺮ", "ﺃﻡ ﻛﻟﺛﻭﻡ", 
+        "Eritrea", "Berhane Zeray", "ብርሃነ ዘርኣይ", "ኤርትራ", 
+        "Ethiopia", "Haile Gebreselassie", "ኃይሌ ገብረሥላሴ", "ኢትዮጵያ", 
+        "France", "Gerard Depardieu", "France", "Gérard Depardieu", 
+        "France", "Jean Reno", "France", "Jean Réno", 
+        "France", "Camille Saint-Saens", "France", "Camille Saint-Saëns", 
+        "France", "Mylene Demongeot", "France", "Mylène Demongeot", 
+        "France", "Francois Truffaut", "France", "François Truffaut", 
+        "France (Braille)", "Louis Braille", "⠋⠗⠁⠝⠉⠑", "⠇⠕⠥⠊⠎⠀<BR>⠃⠗⠁⠊⠇⠇⠑", 
+        "Georgia", "Eduard Shevardnadze", "საქართველო", "ედუარდ შევარდნაძე", 
+        "Germany", "Rudi Voeller", "Deutschland", "Rudi Völler", 
+        "Germany", "Walter Schultheiss", "Deutschland", "Walter Schultheiß", 
+        "Greece", "Giorgos Dalaras", "Ελλάς", "Γιώργος Νταλάρας", 
+        "Iceland", "Bjork Gudmundsdottir", "Ísland", "Björk Guðmundsdóttir", 
+        "India (Hindi)", "Madhuri Dixit", "भारत", "माधुरी दिछित", 
+        "Ireland", "Sinead O'Connor", "Éire", "Sinéad O'Connor", 
+        "Israel", "Yehoram Gaon", "ישראל", "יהורם גאון", 
+        "Italy", "Fabrizio DeAndre", "Italia", "Fabrizio De André", 
+        "Japan", "KUBOTA Toshinobu", "日本", "久保田    利伸", 
+        "Japan", "HAYASHIBARA Megumi", "日本", "林原 めぐみ", 
+        "Japan", "Mori Ogai", "日本", "森鷗外", 
+        "Japan", "Tex Texin", "日本", "テクス テクサン", 
+        "Norway", "Tor Age Bringsvaerd", "Noreg", "Tor Åge Bringsværd", 
+        "Pakistan (Urdu)", "Nusrat Fatah Ali Khan", "پاکستان", "نصرت فتح علی خان", 
+        "People's Rep. of China", "ZHANG Ziyi", "中国", "章子怡", 
+        "People's Rep. of China", "WONG Faye", "中国", "王菲", 
+        "Poland", "Lech Walesa", "Polska", "Lech Wałęsa", 
+        "Puerto Rico", "Olga Tanon", "Puerto Rico", "Olga Tañón", 
+        "Rep. of China", "Hsu Chi", "臺灣", "舒淇", 
+        "Rep. of China", "Ang Lee", "臺灣", "李安", 
+        "Rep. of Korea", "AHN Sung-Gi", "한민국", "안성기", 
+        "Rep. of Korea", "SHIM Eun-Ha", "한민국", "심은하", 
+        "Russia", "Mikhail Gorbachev", "Россия", "Михаил Горбачёв", 
+        "Russia", "Boris Grebenshchikov", "Россия", "Борис Гребенщиков", 
+        "Slovenia", "\"Frane \"\"Jezek\"\" Milcinski", "Slovenija", "Frane Milčinski - Ježek", 
+        "Syracuse (Sicily)", "Archimedes", "Συρακούσα", "Ἀρχιμήδης", 
+        "Thailand", "Thongchai McIntai", "ประเทศไทย", "ธงไชย แม็คอินไตย์", 
+        "U.S.A.", "Brad Pitt", "U.S.A.", "Brad Pitt", 
+        "Yugoslavia (Cyrillic)", "Djordje Balasevic", "Југославија", "Ђорђе Балашевић", 
+        "Yugoslavia (Latin)", "Djordje Balasevic", "Jugoslavija", "Đorđe Balašević"]
 
-i18n_arr = transpose(reshape(i18n_data, 4, int(floor(length(i18n_data)/4))))
-i18n_buff = PipeBuffer()
-writedlm(i18n_buff, i18n_arr, ',')
-@test i18n_arr == readcsv(i18n_buff)
-
+    i18n_arr = transpose(reshape(i18n_data, 4, int(floor(length(i18n_data)/4))))
+    i18n_buff = PipeBuffer()
+    writedlm(i18n_buff, i18n_arr, ',')
+    @test i18n_arr == readcsv(i18n_buff)
+end


### PR DESCRIPTION
This adds ability to read quoted columns to `readdlm` and `readcsv`.

```
julia> csv = readcsv(IOBuffer("first field,\"second \"\"quoted\"\" field\",\"\"\"begin with quote\"\nfirst field,\"this comma, is escaped\",\"new\nline\""))
2x3 Array{Any,2}:
 "first field"  "second \"quoted\" field"  "\"begin with quote"
 "first field"  "this comma, is escaped"   "new\nline"         
```

Columns containing new lines, column delimiters, or beginning with a double-quote are automatically quoted by `writedlm`.

```
julia> iob = IOBuffer(); writecsv(iob, csv); takebuf_string(iob)
"first field,second \"quoted\" field,\"\"\"begin with quote\"\nfirst field,\"this comma, is escaped\",\"new\nline\"\n"
```

A new keyword argument `quotes` allows this to be switched on or off (on by default).

(Ref: #5838. Should fix: #5375)
