### PR TITLE
Fix Regex to nothing matching in docs

### DIFF
--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -498,7 +498,7 @@ executed. Consider if the regular expression occurs in a loop::
 
     for line = lines
       m = match(r"^\s*(?:#|$)", line)
-      if m.match == nothing
+      if m == nothing
         # non-comment
       else
         # comment
@@ -514,7 +514,7 @@ this::
     re = Regex("^\\s*(?:#|\$)")
     for line = lines
       m = match(re, line)
-      if m.match == nothing
+      if m == nothing
         # non-comment
       else
         # comment


### PR DESCRIPTION
If a match does not succeed the result of `match(r"^\s*(?:#|$)", line)` is already `nothing` so we cannot access `m.match`.
