### PR TITLE
fix printing of :(ccall(:fun, ...))

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -421,6 +421,9 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
             show_unquoted(io, args[1], indent)
             show_enclosed_list(io, op, args[2:end], ",", cl, indent)
         end
+    elseif is(head, :ccall)
+        show_unquoted(io, :ccall, indent)
+        show_enclosed_list(io, '(', args, ",", ')', indent)
 
     # comparison (i.e. "x < y < z")
     elseif is(head, :comparison) && nargs >= 3 && (nargs&1==1)


### PR DESCRIPTION
A subtle bug in the new Expr printing code:

```
testcall = :(ccall(:getpid, Cint, ()))
eval(testcall) #ok
string(testcall) 
--> "Expr(ccall, :getpid, Cint, ())"
eval(parse(string(testcall)))
---> ERROR: ParseError("invalid \"ccall\" syntax")
```

Attached patch gives

```
string(testcall) 
--> "ccall(:getpid,Cint,())"
eval(parse(string(testcall))) # ok
```
