### PR TITLE
Alternative fix for #3567

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -595,7 +595,7 @@ macro cmd(str)
     :(cmd_gen($(shell_parse(str)[1])))
 end
 
-wait(x::Process)      = if !process_exited(x); wait(x.exitnotify); end
+wait(x::Process)      = if !process_exited(x); stream_wait(x,x.exitnotify); end
 wait(x::ProcessChain) = for p in x.processes; wait(p); end
 
 show(io::IO, p::Process) = print(io, "Process(", p.cmd, ", ", process_status(p), ")")


### PR DESCRIPTION
As discussed in #5825, this puts handles that should be preserved into a global ObjectIdDict. The only slightly sketchy parts are the idle and async worker invocations which I'll have to think about (we don't have a good interface for them yet, really), but it's not as simple as just putting a wait() based interface on top, since people are using them for synchronization with threaded C libraries.

@JeffBezanson 
