### PR TITLE
Fix 5896

### DIFF
--- a/base/repl.jl
+++ b/base/repl.jl
@@ -99,7 +99,7 @@ showerror(io::IO, e::KeyError) = (print(io, "key not found: "); show(io, e.key))
 showerror(io::IO, e::InterruptException) = print(io, "interrupt")
 
 function showerror(io::IO, e::MethodError)
-    name = e.f.env.name
+    name = isgeneric(e.f) ? e.f.env.name : :anonymous
     if isa(e.f, DataType)
         print(io, "no method $(e.f)(")
     else

--- a/base/util.jl
+++ b/base/util.jl
@@ -89,6 +89,9 @@ end
 # searching definitions
 
 function which(f::Callable, args...)
+    if !isgeneric(f)
+        throw(ErrorException("not a generic function, no methods available"))
+    end
     ms = methods(f, map(a->(isa(a,Type) ? Type{a} : typeof(a)), args))
     isempty(ms) && throw(MethodError(f, args))
     ms[1]


### PR DESCRIPTION
- `which()` is not valid for anonymous functions
- make `showerror(.., ::MethodError)` safer by checking for anonymous function.
  error message is not super helpful, but avoids the bizarre backtrace.
  `e.f.env == ()` for anonymous function, hence getfield error.

closes #5896
