### PR TITLE
Get rid of the old Set constructor.

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -3,9 +3,6 @@ type Set{T}
 
     Set() = new(Dict{T,Nothing}())
     Set(itr) = union!(new(Dict{T,Nothing}()), itr)
-
-    # for backwards compat
-    Set(xs::T...) = Set{T}(xs)
 end
 Set() = Set{Any}()
 Set(itr) = Set{eltype(itr)}(itr)


### PR DESCRIPTION
Can we just drop this? It's not actually backwards compatible and pretending it is just introduces subtle bugs when `xs` happens to be of length 1.
