### PR TITLE
Add new sparse matmul performance tracking test

### DIFF
--- a/test/perf/kernel/perf.jl
+++ b/test/perf/kernel/perf.jl
@@ -25,6 +25,8 @@ include("gk.jl")
 # issue #942
 s = sparse(ones(280,280));
 @timeit s*s "sparsemul" "Sparse matrix - sparse matrix multiplication"
+s2 = sparse(rand(1:2000,10^5), kron([1:10^4],ones(Int,10)), ones(Int,10^5), 2000, 10^4);
+@timeit s2*s2' "sparsemul2" "Sparse matrix - matrix multiplication with fill-in"
 
 # issue #938
 x = 1:600000;


### PR DESCRIPTION
Existing test for sparse matrix-matrix multiplication ("sparse" matrix of all ones) is not very representative.

Test matrix is thanks to Michael Schnall-Levin here https://groups.google.com/forum/#!topic/julia-users/TVbVXtbNzgk

Does anything else need to be added, or would this automatically start showing up on speed.julialang.org if it gets merged?
