### PR TITLE
getindex(Cholesky{T},Symbol): Changed Char to Symbol in call to Triangular

### DIFF
--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -52,7 +52,7 @@ size(C::Union(Cholesky, CholeskyPivoted), d::Integer) = size(C.UL,d)
 function getindex(C::Cholesky, d::Symbol)
     d == :U && return triu!(symbol(C.uplo) == d ? C.UL : C.UL')
     d == :L && return tril!(symbol(C.uplo) == d ? C.UL : C.UL')
-    d == :UL && return Triangular(C.UL, C.uplo)
+    d == :UL && return Triangular(C.UL, symbol(C.uplo))
     throw(KeyError(d))
 end
 function getindex{T<:BlasFloat}(C::CholeskyPivoted{T}, d::Symbol)


### PR DESCRIPTION
The `getindex(Cholesky{T},Symbol)` method makes a call to `Triangular(Array{T,2},Char)`, which does not exist. I made the minimal change to make it run without errors.

**I don't understand what this function does; I just made a change that makes it run.** I'm happy to make a different change (or an issue) if this fix is wrong.

The current behavior:

``` julia
julia> m = [ 1 1; 1 0]
2x2 Array{Int64,2}:
 1  1
 1  0

julia> c = Cholesky(m,'U')
Cholesky{Int64} with factor:
2x2 Array{Int64,2}:
 1  1
 0  0

julia> c[:UL]
ERROR: no method Triangular{T<:Number}(Array{Int64,2}, Char)
 in getindex at linalg/factorization.jl:55
```

After this change (omitting identical setup of m & c):

``` .julia
julia> c[:UL]
2x2 Triangular{Int64}:
 1  1
 0  0
```
