### PR TITLE
Turn @inbounds into a no-op for debug builds

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -153,6 +153,9 @@ macro boundscheck(yesno,blk)
 end
 
 macro inbounds(blk)
+    if ccall(:jl_is_debugbuild, Any, ())::Bool
+        return :($(esc(blk)))
+    end
     :(@boundscheck false $(esc(blk)))
 end
 

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1180,7 +1180,7 @@ end
 # to be mutually reachable without a tunnel, as is often the case in a cluster.
 function addprocs_internal(np::Integer;
                   tunnel=false, dir=JULIA_HOME,
-                  exename=(ccall(:jl_is_debugbuild,Cint,())==0?"./julia-basic":"./julia-debug-basic"),
+                  exename=(ccall(:jl_is_debugbuild,Any,())::Bool?"./julia-basic":"./julia-debug-basic"),
                   sshflags::Cmd=``, cman=LocalManager(), exeflags=``)
                   
     config={:dir=>dir, :exename=>exename, :exeflags=>`$exeflags --worker`, :tunnel=>tunnel, :sshflags=>sshflags}

--- a/base/util.jl
+++ b/base/util.jl
@@ -355,7 +355,7 @@ function versioninfo(io::IO=STDOUT, verbose::Bool=false)
     if !isempty(GIT_VERSION_INFO.commit_short)
       println(io,             "Commit $(GIT_VERSION_INFO.commit_short) ($(GIT_VERSION_INFO.date_string))")
     end
-    if ccall(:jl_is_debugbuild, Bool, ())
+    if ccall(:jl_is_debugbuild, Any, ())::Bool
         println(io, "DEBUG build")
     end
     println(io,             "Platform Info:")

--- a/src/dump.c
+++ b/src/dump.c
@@ -1003,7 +1003,7 @@ void jl_restore_system_image(char *fname)
 #ifdef _OS_WINDOWS_
     //XXX: the windows linker forces our system image to be
     //     linked against only one dll, I picked libjulia-release
-    if (jl_is_debugbuild()) build_mode = 1;
+    if (jl_is_debugbuild() == jl_true) build_mode = 1;
 #endif
     if (!build_mode) {
         char *fname_shlib = (char*)alloca(strlen(fname));

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -234,11 +234,11 @@ DLLEXPORT void jl_sigatomic_end(void)
     JL_SIGATOMIC_END();
 }
 
-DLLEXPORT int jl_is_debugbuild(void) {
+DLLEXPORT jl_value_t *jl_is_debugbuild(void) {
 #ifdef DEBUG
-    return 1;
+    return jl_true;
 #else
-    return 0;
+    return jl_false;
 #endif
 }
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -808,7 +808,7 @@ DLLEXPORT int32_t jl_stat(const char *path, char *statbuf);
 DLLEXPORT void NORETURN jl_exit(int status);
 DLLEXPORT int jl_cpu_cores(void);
 DLLEXPORT long jl_getpagesize(void);
-DLLEXPORT int jl_is_debugbuild(void);
+DLLEXPORT jl_value_t* jl_is_debugbuild(void);
 
 // environment entries
 DLLEXPORT jl_value_t *jl_environ(int i);


### PR DESCRIPTION
There are a number of outstanding weird bugs at the moment (at least #5885, #5106, https://github.com/JuliaLang/Gtk.jl/issues/69, https://github.com/timholy/Images.jl/issues/35). In the hopes of reducing the number of times we need to don the rubber gloves, I decided to look into what would be required to conveniently disable `@inbounds`. This seems like a particularly simple solution.
