### PR TITLE
Allow bootstrap with no external IP address

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -546,7 +546,7 @@ function getipaddr()
         end
     end
     ccall(:uv_free_interface_addresses,Void,(Ptr{Uint8},Int32),addr,count)
-    error("no active external interfaces")
+    return ip"127.0.0.1"
 end
 
 ##


### PR DESCRIPTION
62d0b3d4 introduced a dependency on the availability of an external IP address, via getaddrinfo()
this breaks building when only a loopback address is available, such as on a VM or subway.

This PR fixes the following error during bootstrap, which I saw on the way home this evening and on a VirtualBox-hosted instance over the weekend (but was red-herringed by a Wine error at the time):

```
multi.jl
ERROR: ErrorException("no active external interfaces")
while loading multi.jl, in expression starting on line 188
while loading /cmn/jldev/base/sysimg.jl, in expression starting on line 138
```

cc: @loladiro @amitmurthy
