### PR TITLE
Remove scale!{T<:BlasReal}(X::Array{T}, s::Complex)

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -408,3 +408,5 @@ function nnz(X)
     countnz(X)
 end
 export nnz
+
+scale!{T<:Base.LinAlg.BlasReal}(X::Array{T}, s::Complex) = error("scale!: Cannot scale a real array by a complex value in-place.  Use scale(X::Array{Real}, s::Complex) instead.")

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -1,7 +1,6 @@
 # Linear algebra functions for dense matrices in column major format
 
 scale!{T<:BlasFloat}(X::Array{T}, s::Number) = BLAS.scal!(length(X), convert(T,s), X, 1)
-scale!{T<:BlasReal}(X::Array{T}, s::Complex) = scale!(complex(X), s)
 scale!{T<:BlasComplex}(X::Array{T}, s::Real) = BLAS.scal!(length(X), oftype(real(zero(T)),s), X, 1)
 
 #Test whether a matrix is positive-definite

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -3,6 +3,14 @@
 scale(X::AbstractArray, s::Number) = scale!(copy(X), s)
 scale(s::Number, X::AbstractArray) = scale!(copy(X), s)
 
+function scale{R<:Real,S<:Complex}(X::AbstractArray{R}, s::S)
+    Y = Array(promote_type(R,S), size(X))
+    copy!(Y, X)
+    scale!(Y, s)
+end
+
+scale{R<:Real}(s::Complex, X::AbstractArray{R}) = scale(X, s)
+
 function scale!(X::AbstractArray, s::Number)
     for i in 1:length(X)
         @inbounds X[i] *= s

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -442,3 +442,13 @@ Ai = int(ceil(Ar*100))
 @test_approx_eq norm(Ai,Inf)   norm(full(Ai),Inf)
 @test_approx_eq normfro(Ai)    normfro(full(Ai))
 
+# scale real matrix by complex type
+@test_throws scale!([1.0], 2.0im)
+@test isequal(scale([1.0], 2.0im),             Complex{Float64}[2.0im])
+@test isequal(scale(Float32[1.0], 2.0f0im),    Complex{Float32}[2.0im])
+@test isequal(scale(Float32[1.0], 2.0im),      Complex{Float64}[2.0im])
+@test isequal(scale(Float64[1.0], 2.0f0im),    Complex{Float64}[2.0im])
+@test isequal(scale(Float32[1.0], big(2.0)im), Complex{BigFloat}[2.0im])
+@test isequal(scale(Float64[1.0], big(2.0)im), Complex{BigFloat}[2.0im])
+@test isequal(scale(BigFloat[1.0], 2.0im),     Complex{BigFloat}[2.0im])
+@test isequal(scale(BigFloat[1.0], 2.0f0im),   Complex{BigFloat}[2.0im])


### PR DESCRIPTION
- Reference: https://github.com/JuliaLang/julia/issues/1868#issuecomment-36004446

This is a minimal change to fix the issue referenced in the comment above. 

@jiahao, you seem to have written that code--was there something specific that you had in mind, or did other changes affect the functionality?

Cc: @andreasnoackjensen 
