### PR TITLE
RFC: Allow Cygwin to MinGW cross compilation

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -106,6 +106,9 @@ BUILD_LLDB = 0
 #XC_HOST = i686-w64-mingw32
 #XC_HOST = x86_64-w64-mingw32
 
+# Figure out OS and architecture
+BUILD_OS := $(shell uname)
+
 ifeq ($(XC_HOST),)
 CROSS_COMPILE=
 HOSTCC = $(CC)
@@ -115,8 +118,13 @@ override OPENBLAS_DYNAMIC_ARCH = 1
 override CROSS_COMPILE=$(XC_HOST)-
 ifneq (,$(findstring mingw,$(XC_HOST)))
 override OS := WINNT
+ifneq (,$(findstring CYGWIN,$(BUILD_OS)))
+export STD_LIB_PATH := $(shell $(CROSS_COMPILE)gcc -print-search-dirs | grep programs | sed -e "s/^programs: =//" -e "s!/lib/!/bin/!g")
+export STD_LIB_PATH := $(STD_LIB_PATH):$(shell $(CROSS_COMPILE)gcc -print-search-dirs | grep libraries | sed -e "s/^libraries: =//" -e "s!/lib/!/bin/!g")
+else
 export STD_LIB_PATH := $(shell $(CROSS_COMPILE)gcc -print-search-dirs | grep programs | sed "s/^programs: =//" | xargs -d":" winepath -w | tr '\n' ';')
 export STD_LIB_PATH := $(STD_LIB_PATH);$(shell $(CROSS_COMPILE)gcc -print-search-dirs | grep libraries | sed "s/^libraries: =//" | xargs -d":" winepath -w | tr '\n' ';')
+endif
 else
 $(error "unknown XC_HOST variable set")
 endif
@@ -125,7 +133,6 @@ endif
 JLDOWNLOAD = $(JULIAHOME)/deps/jldownload
 
 # Figure out OS and architecture
-BUILD_OS := $(shell uname)
 OS := $(BUILD_OS)
 
 ifneq (,$(findstring MINGW,$(OS)))
@@ -367,7 +374,7 @@ LIBBLAS ?= -lblas
 LIBBLASNAME ?= libblas
 endif
 else
-LIBBLAS = -L$(build_libdir) -lopenblas
+LIBBLAS = -L$(build_shlibdir) -lopenblas
 LIBBLASNAME = libopenblas
 endif
 
@@ -381,7 +388,7 @@ ifeq ($(USE_SYSTEM_LAPACK), 1)
 LIBLAPACK = -llapack
 LIBLAPACKNAME = liblapack
 else
-LIBLAPACK = -L$(build_libdir) -llapack $(LIBBLAS)
+LIBLAPACK = -L$(build_shlibdir) -llapack $(LIBBLAS)
 LIBLAPACKNAME = liblapack
 endif
 endif
@@ -572,6 +579,8 @@ endef
 
 ifeq ($(BUILD_OS), WINNT)
 spawn = $(1)
+else ifneq (,$(findstring CYGWIN,$(BUILD_OS)))
+spawn = $(1)
 else
 ifeq ($(OS), WINNT)
 spawn = wine $(1)
@@ -580,9 +589,19 @@ spawn = $(1)
 endif
 endif
 
+ifneq (,$(findstring CYGWIN,$(BUILD_OS)))
+cygpath_w = `cygpath -w $(1)`
+else
+cygpath_w = $(1)
+endif
+
 exec = $(shell $(call spawn,$(1)))
 
+ifneq (,$(findstring CYGWIN,$(BUILD_OS)))
+wine_pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(2)))))
+else
 wine_pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(shell printf %s\n '$(2)' | xargs -d";" winepath -u | tr '\n' ' '))))
+endif
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(2)))))
 
 JULIA_EXECUTABLE_debug = $(build_bindir)/julia-debug-$(DEFAULT_REPL)$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
 $(build_private_libdir)/sys%ji: $(build_private_libdir)/sys%bc
 
 $(build_private_libdir)/sys%o: $(build_private_libdir)/sys%bc
-	$(call spawn,$(LLVM_LLC)) -filetype=obj -relocation-model=pic -mattr=-bmi2,-avx2 -o $@ $<
+	$(call spawn,$(LLVM_LLC)) -filetype=obj -relocation-model=pic -mattr=-bmi2,-avx2 -o $(call cygpath_w,$@) $(call cygpath_w,$<)
 
 .PRECIOUS: $(build_private_libdir)/sys%o
 
@@ -79,12 +79,12 @@ $(build_private_libdir)/sys%$(SHLIB_EXT): $(build_private_libdir)/sys%o
 
 $(build_private_libdir)/sys0.bc:
 	@$(QUIET_JULIA) cd base && \
-	$(call spawn,$(JULIA_EXECUTABLE)) --build $(build_private_libdir)/sys0 sysimg.jl
+	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys0) sysimg.jl
 
 $(build_private_libdir)/sys.bc: VERSION base/*.jl base/pkg/*.jl base/linalg/*.jl base/sparse/*.jl $(build_datarootdir)/julia/helpdb.jl $(build_datarootdir)/man/man1/julia.1 $(build_private_libdir)/sys0.$(SHLIB_EXT)
 	@$(QUIET_JULIA) cd base && \
-	$(call spawn,$(JULIA_EXECUTABLE)) --build $(build_private_libdir)/sys \
-		-J$(build_private_libdir)/$$([ -e $(build_private_libdir)/sys.ji ] && echo sys.ji || echo sys0.ji) -f sysimg.jl \
+	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys) \
+		-J$(call cygpath_w,$(build_private_libdir))/$$([ -e $(build_private_libdir)/sys.ji ] && echo sys.ji || echo sys0.ji) -f sysimg.jl \
 		|| (echo "*** This error is usually fixed by running 'make clean'. If the error persists, try 'make cleanall'. ***" && false)
 
 run-julia-debug run-julia-release: run-julia-%:


### PR DESCRIPTION
This isn't perfect, but it could be fewer manual steps and have better potential for automation on local Windows builds than the MSYS option (ref. discussion in JuliaLang/julia#5961). And this shouldn't break anything, though please correct me if I'm wrong.

With these changes, I can build Julia under 64-bit Cygwin, setting `XC_HOST = x86_64-w64-mingw32` in Make.user to use the MinGW cross-compilers. This way the compiled libraries and executables are native Windows, they do not require Cygwin or its runtime library to use. In fact the REPL doesn't start up correctly inside Cygwin's terminal at all, but neither does the MSYS-compiled version so that's not new.

Remaining issues: the unit tests start, but have an apparent failure in linalg2:

```
exception on 3: ERROR: test failed: norm((F[:vectors] * Diagonal(F[:values])) / F[:vectors] - A) > 0.01
 in error at error.jl:21
 in default_handler at test.jl:19
 in do_test at test.jl:39
while loading linalg2.jl, in expression starting on line 515
```

and the parallel tests hang completely. This may be indicative of a bigger problem, possibly in the threading model of the Cygwin-distributed MinGW compilers (as with the MSYS2 pacman-distributed versions, see JuliaLang/julia#5943)? I'm not sure which they use, but I'll look into it.
