### PR TITLE
RFC: kw arg printer

### DIFF
--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -35,7 +35,7 @@ Base.show_method_candidates(buf, Base.MethodError(method_c1,(1, 1, 1)))
 test_have_color(buf, "", "")
 
 method_c2(x::Int32, args...) = true
-method_c2(x::Int32, y::Float64 ,args...) = true
+method_c2(x::Int32, y::Float64, args...) = true
 method_c2(x::Int32, y::Float64) = true
 method_c2{T<:Real}(x::T, y::T, z::T) = true
 
@@ -296,7 +296,6 @@ let err_str,
     err_str = @except_stackframe FunctionLike()() ErrorException
     @test err_str == " in (::FunctionLike)() at $sn:$(method_defs_lineno + 7)"
 end
-
 
 # Issue #13032
 withenv("JULIA_EDITOR" => nothing, "VISUAL" => nothing, "EDITOR" => nothing) do

--- a/test/show.jl
+++ b/test/show.jl
@@ -315,9 +315,22 @@ end
 #test methodshow.jl functions
 @test Base.inbase(Base)
 @test Base.inbase(LinAlg)
+@test !Base.inbase(Core)
 
-@test contains(sprint(io -> writemime(io,"text/plain",methods(Base.inbase))),"inbase(m::Module)")
-@test contains(sprint(io -> writemime(io,"text/html",methods(Base.inbase))),"inbase(m::<b>Module</b>)")
+let repr = sprint(io -> writemime(io,"text/plain", methods(Base.inbase)))
+    @test contains(repr, "inbase(m::Module)")
+end
+let repr = sprint(io -> writemime(io,"text/html", methods(Base.inbase)))
+    @test contains(repr, "inbase(m::<b>Module</b>)")
+end
+
+f5971(x, y...; z=1, w...) = nothing
+let repr = sprint(io -> writemime(io,"text/plain", methods(f5971)))
+    @test contains(repr, "f5971(x, y...; z)")
+end
+let repr = sprint(io -> writemime(io,"text/html", methods(f5971)))
+    @test contains(repr, "f5971(x, y...; <i>z</i>)")
+end
 
 if isempty(Base.GIT_VERSION_INFO.commit)
     @test contains(Base.url(methods(eigs).defs),"https://github.com/JuliaLang/julia/tree/v$VERSION/base/linalg/arnoldi.jl#L")


### PR DESCRIPTION
fix #4469, fix #2758, reopen #5230

This extract keyword argument information from the method cache. It would ideally be fixed later to use less auto-detection in a later cleanup effort, for better precision (to handle `...` vargs), but this could be helpful anyways in the short term. (theres a few other small fixes in here that I noticed while working on this).
