### PR TITLE
RFC: cleaner ^C handling in REPL

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -359,8 +359,12 @@ function _uv_hook_readcb(stream::AsyncStream, nread::Int, base::Ptr{Void}, len::
             ccall(:jl_forceclose_uv,Void,(Ptr{Void},),stream.handle)
             notify_error(stream.readnotify, UVError("readcb",nread))
         else
-            close(stream)
-            notify(stream.readnotify)
+            if isa(stream,TTY)
+                notify_error(stream.readnotify, EOFError())
+            else
+                close(stream)
+                notify(stream.readnotify)
+            end
         end
     else
         notify_filled(stream.buffer, nread, base, len)


### PR DESCRIPTION
this strips out a the error handling code from the repl, and moves it back into base. this greatly simplifies error handling, since we no longer have two sigint handlers. it also makes cleanup after ^C in the readline repl cleaner.

the biggest change here is that EOF is now a signal for a TTY, instead of a state. I think this better reflects the unique nature of a TTY, where an EOF condition is temporary (signaled by ^D), rather than permanent (signaled by the close of a pipe or socket).

this needs to be tested on windows.

inspired by wanting to fix #1306
