### PR TITLE
RFC: automated BLAS nthreads tuning

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -583,6 +583,7 @@ export
 # linear algebra
     bkfact!,
     bkfact,
+    blas_restore_num_threads,
     blas_set_num_threads,
     blkdiag,
     chol,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -187,6 +187,8 @@ end
 include("linalg/exceptions.jl")
 include("linalg/generic.jl")
 
+include("linalg/blas_tune.jl")
+
 include("linalg/blas.jl")
 include("linalg/matmul.jl")
 include("linalg/lapack.jl")

--- a/base/linalg/blas_tune.jl
+++ b/base/linalg/blas_tune.jl
@@ -1,0 +1,9 @@
+function blas_nthreads(coefs, p...)
+    np = coefs[1]
+    for i = 1:length(p)
+        np += coefs[i+1]*log(p[i])
+    end
+    min(CPU_CORES, max(1, iround(np)))
+end
+geevx!_nthreads(p) = blas_nthreads([0.999847584209725,0.0], p...)
+gemm!_nthreads(p) = blas_nthreads([2.666666666666666,0.41321635739041884,0.0,0.0854930394600868], p...)

--- a/base/util.jl
+++ b/base/util.jl
@@ -308,6 +308,8 @@ function blas_set_num_threads(n::Integer)
     return nothing
 end
 
+blas_restore_num_threads() = nprocs() == 1 ? blas_set_num_threads(CPU_CORES) : 1
+
 function check_blas()
     blas = blas_vendor()
     if blas == :openblas

--- a/etc/blas_calibrate.jl
+++ b/etc/blas_calibrate.jl
@@ -1,0 +1,164 @@
+using Iterators, HDF5, JLD, NLopt
+
+const LAPACK = Base.LinAlg.LAPACK
+const BLAS = Base.LinAlg.BLAS
+
+# T[n, i1, i2, ...] is the execution time of an algorithm
+# with nthreads[n] threads and parameter setting p1[i1], p2[i2], etc.
+
+function perf_run(func::Function, nthreads, P::Tuple, constructor::Function)
+    l = map(length, P)
+    T = Array(Float64, length(nthreads), l...)
+    t = zeros(3)
+    pindex = map(x->1:length(x), P)
+    for i in product(pindex...)
+        cp = [P[j][i[j]] for j = 1:length(P)]
+        args = constructor(cp...)
+        argscopy = ntuple(length(args), i->copy(args[i]))
+        func(argscopy...)  # run once to force a compile
+        gc()
+        gc_disable()
+        try
+            for n = 1:length(nthreads)
+                blas_set_num_threads(nthreads[n])
+                for iter = 1:length(t)
+                    for k = 1:length(args); copy!(argscopy[k], args[k]); end
+                    t[iter] = @elapsed func(argscopy...)
+                    if t[iter] < 1e-3
+                        nrep = min(10, iceil(1e-3/t[iter]))
+                        for r = 2:nrep
+                            for k = 1:length(args); copy!(argscopy[k], args[k]); end
+                            t[iter] += @elapsed func(argscopy...)
+                        end
+                        t[iter] = t[iter]/nrep
+                    end
+                end
+                T[n,i...] = median(t)
+            end
+        finally
+            gc_enable()
+        end
+    end
+    T
+end
+
+function perf_measure1(f::Function, fid, name, nprocs, P, constructor::Function)
+    println("Measuring ", name)
+    g_create(fid, name) do g
+        write(g, "nprocs", nprocs)
+        write(g, "P", P)
+        T = perf_run(f, nprocs, P, constructor)
+        write(g, "T", T)
+    end
+end
+
+function perf_measure()
+    len = int(2.^([2:20]/2))
+    nprocs = 1:4
+    jldopen("blas_calibrate.jld", "w") do fid
+        perf_measure1(A->LAPACK.geevx!('B','N','N','N',A), fid, "geevx!", nprocs, (len,), n->(rand(n,n),))
+        perf_measure1((C,A,B)->BLAS.gemm!('N','N',1.0,A,B,0.0,C), fid, "gemm!", nprocs, (len,len,len), (m,k,n)->(Array(Float64,m,n),rand(m,k),rand(k,n)))
+    end
+    nothing
+end
+
+### Write the tuning file
+# Optimize a model
+#     nthreads = c0 + c1*log(p1) + c2*log(p2) + ...
+# to yield the best overall performance, and then
+# record the paramaters as a callable function to
+# base/linalg/blas_tune.jl
+function tune()
+    open(joinpath(JULIA_HOME, "../../base/linalg/blas_tune.jl"),"w") do fileout
+        write(fileout, """
+function blas_nthreads(coefs, p...)
+    np = coefs[1]
+    for i = 1:length(p)
+        np += coefs[i+1]*log(p[i])
+    end
+    min(CPU_CORES, max(1, iround(np)))
+end
+""")
+        jldopen("blas_calibrate.jld") do filein
+            tune1(fileout, filein, "geevx!")
+            tune1(fileout, filein, "gemm!")
+        end
+    end
+    nothing
+end
+
+function tune1(fileout, filein, name)
+    println("Optimizing ", name)
+    g = filein[name]
+    try
+        T = read(g, "T")
+        np = read(g, "nprocs")
+        P = read(g, "P")
+        minf, minx, ret = perf_optimize1(T, np, P)
+        if ret == :FTOL_REACHED || ret == :XTOL_REACHED
+            write(fileout, """
+$(name)_nthreads(p) = blas_nthreads([""")
+            for i = 1:length(minx)
+                print(fileout, minx[i])
+                if i < length(minx)
+                    write(fileout, ',')
+                end
+            end
+            write(fileout, """], p...)
+""")
+        else
+            error("Failed to converge")
+        end
+    finally
+        close(g)
+    end
+end
+
+function perf_optimize1(T, nprocs, P)
+    Tnorm = T ./ minimum(T, 1)
+    nd = length(P)+1
+    opt = Opt(:GN_DIRECT_L, nd)
+    mnp = maximum(nprocs)
+    bounds = vcat(float(mnp),Float64[mnp/log(maximum(p)) for p in P])
+    lower_bounds!(opt, -bounds)
+    upper_bounds!(opt, bounds)
+    min_objective!(opt, (x,g)->perf_objective(x, Tnorm, nprocs, P))
+    xtol_abs!(opt, bounds/100)
+    ftol_rel!(opt, 1e-5)
+    stopval!(opt, 0)
+    minf, minx, ret = optimize(opt, 2*bounds.*(rand(nd)-0.5))
+end
+
+function perf_objective(x::Vector, Tnorm, nprocs, P)
+    if length(x) != length(P)+1
+        error("x has $(length(x)) parameters, but given the parameter list it should be $(length(P)+1)")
+    end
+    logP = {reshape(log(P[d]), ntuple(d, i->i==d?length(P[d]):1)) for d = 1:length(P)}
+    np = x[1]
+    for i = 1:length(x)-1
+        np = np .+ x[i+1]*logP[i]
+    end
+    # since np won't be inferrable, call a separate function
+    # but bias parameters to zero if they don't matter
+    val = perf_val(np, Tnorm, nprocs) + 0.001*(abs(x[1]-1) + sum(abs(x[2:end])))
+    return val
+end
+
+function perf_val(np, Tnorm, nprocs)
+    # Find the nearest entry in nprocs for each entry of np
+    dist = zeros(length(nprocs))
+    Tindex = similar(np, Int)
+    for i = 1:length(np)
+        thisnp = np[i]
+        for j = 1:length(dist)
+            dist[j] = abs(nprocs[j]-thisnp)
+        end
+        Tindex[i] = indmin(dist)
+    end
+    # Look up the execution time
+    val = zero(eltype(Tnorm))
+    for i = 1:div(length(Tnorm), size(Tnorm,1))
+        val += Tnorm[Tindex[i],i]
+    end
+    val - length(np) + 1
+end


### PR DESCRIPTION
Lately there has been a certain amount of distress about how OpenBLAS uses threads. This PR is an attempt to do two things: (1) give Julia a mechanism to set its own policies, and (2) help OpenBLAS developers collect the performance data they need to make things better. CC @xianyi, @wernsaar.

The way this works is the following:
- Measure the performance of a function for different settings of `blas_set_num_threads` and different problem sizes. For an eigenvalue problem, there's just 1 parameter, `n`, as in the `nxn` matrix. For matrix multiply, there are 3 parameters, `m`, `k`, and `n` (for `mxk` times `kxn`).
- Store the performance data to disk, since it can take a while to acquire and is interesting in its own right
- Analyze the performance data, in particular with respect to a model

```
nthreads = c0 + c1*log(p1) + c2*log(p2) + ...
```

and optimizing the parameters to give the best overall performance, as defined by the average (over all problem sizes) of the ratio `time_for_chosen_number_of_threads/time_for_best_choice_of_threads`. In other words, a `2x2x2` task that takes `1e-5` seconds will contribute to the objective function just as much as a `512x1024x512` task that takes much longer.
- Enshrine the model parameters in the file `base/linalg/blas_tune.jl`, which provides a function to calculate the number of threads for each problem analyzed.

This PR enables just two functions, used by `eigfact!` and matrix multiplication. Perhaps we'd want to expand this to more functions. To add a new function, you have to:
1. Set up the test to [run](https://github.com/JuliaLang/julia/blob/teh/blastune/etc/blas_calibrate.jl#L59-L60) and be [analyzed](https://github.com/JuliaLang/julia/blob/teh/blastune/etc/blas_calibrate.jl#L83-L84)
2. To exploit the results, add calls to the auto-generated `nthreads` function inside the [relevant LAPACK function](https://github.com/JuliaLang/julia/blob/teh/blastune/base/linalg/blas.jl#L521-L532) (that `ccall` was already there, of course, and was not changed).

To run the performance testing on your own machine, navigate to the `etc` directory and do this:

```
include("blas_calibrate.jl")
perf_measure()
tune()
```

The timing results are stored in a JLD/HDF5 file. If you're mostly interested in the raw results, here's an example: 

```
using HDF5, JLD, Winston
T, sz = jldopen("blas_calibrate.jld") do fid
                g = fid["gemm!"]
                T = read(g, "T")
                sz = read(g, "P")
                close(g)
                T, sz
              end
rng(sz) = (log2(sz[1]), log2(sz[end]))
r = slice(T, 1, :,19,:)./slice(T,4,:,19,:)
p = imagesc(rng(sz[1]), rng(sz[3]), log10(r), (-1,1))
# Work around a bug in Winston: flip the y axis labels
yr = getattr(p, "yrange")
setattr(p, "yrange", (yr[2],yr[1])); display(p)
xlabel("log2(m)")
ylabel("log2(n)")
title("log10(T_{1thread}/T_{4threads})")
```

This has some significant limitations. Most notably, `blas_set_num_threads` does not control the actual number of threads used; instead, it seems to set an upper limit on the number of threads, but OpenBLAS might use fewer. That means we're not really taking advantage of the full range of possibilities---if OpenBLAS sometimes uses fewer threads than it should be, we can't measure that.

This fact helps explain some features of the performance data, which may be of interest to the OpenBLAS folks. For example, consider matrix multiplication:
![image](https://f.cloud.github.com/assets/1525481/2298427/fde9ec02-a0bc-11e3-932b-45df24a5f5a1.png)
Here, `x` and `y` axes are the size of `m` and `n`, and `k=1024`. You can see that the ratio is 1 when `m` and `n` are small, suggesting that OpenBLAS chooses to use 1 thread. But note two oddities:
- Just above the cutoff, it's obvious that using 4 threads is the better solution. Presumably OpenBLAS could do even better for such problems by using more threads. (The large value of `k` presumably accounts for the desirability of using multiple threads here.)
- Curiously, the performance advantage of threads tails off for larger `m` and `n` (see the upper right quadrant). This makes no sense to me (I thought each CPU had its own L1 cache).

Also on my machine, it's always best to use just 1 thread for `eigfact!`. This is consistent with some user reports, and seems to suggest a problem with `geevx!`.

Some things that could be done:
- If the OpenBLAS developers want to exploit this, consider adding an option to turn off all choices about the number of threads to use, and just let Julia set this number. That would give you the most useful performance data. It's also possible that the model-fit I've done here might be fairly flexible and robust mechanism for choosing the proper number of threads for different problem sizes internally within OpenBLAS.
- On the Julia side, we could run these tests on more functions
- Someone probably needs to think about how to handle and store tuning data for multiple architectures.
