### PR TITLE
Update openlibm to master and install it properly

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -637,10 +637,10 @@ endif
 $(OPENLIBM_OBJ_SOURCE): openlibm/Makefile
 	$(MAKE) -C openlibm $(OPENLIBM_FLAGS) $(MAKE_COMMON)
 	touch -c $@
-$(OPENLIBM_OBJ_TARGET): $(OPENLIBM_OBJ_SOURCE) | $(build_shlibdir)
-	cp openlibm/libopenlibm.a $(build_libdir)/libopenlibm.a
-	cp $< $@
-	$(INSTALL_NAME_CMD)libopenlibm.$(SHLIB_EXT) $@
+$(OPENLIBM_OBJ_TARGET): $(OPENLIBM_OBJ_SOURCE)
+	$(MAKE) -C openlibm install $(MAKE_COMMON)
+	$(INSTALL_NAME_CMD)libopenlibm.dylib $@
+	touch -c $@
 
 clean-openlibm:
 	-$(MAKE) -C openlibm distclean $(OPENLIBM_FLAGS)


### PR DESCRIPTION
This is more standard and it's required for a future
fix making openspecfun no longer include headers from the
openlibm source directory.

Cf. https://github.com/JuliaLang/openlibm/issues/41

I'm not sure the Makefile code is completely correct, but in my tests it works.
