### PR TITLE
Added error message if a task without any consumers tries producing

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -94,6 +94,7 @@ function produce(v)
     #empty = isempty(q.waitq)
     ct = current_task()
     q = ct.consumers
+    q == nothing && error("Cannot produce without consumers")
     if isa(q,Condition)
         t = shift!(q.waitq)
         empty = isempty(q.waitq)


### PR DESCRIPTION
Before, `produce(1)` from e.g. the REPL would throw a non-informative `ERROR: type Nothing is immutable`
