### PR TITLE
Fix error message when stringpatch can't open file

### DIFF
--- a/contrib/stringpatch.c
+++ b/contrib/stringpatch.c
@@ -15,7 +15,7 @@ int main( int argc, char ** argv ) {
 
 	FILE * f = fopen( argv[4], "r+" );
 	if( !f ) {
-		printf( "ERROR: Could not open %s for writing!\n", argv[3] );
+		printf( "ERROR: Could not open %s for writing!\n", argv[4] );
 		return -1;
 	}
 


### PR DESCRIPTION
"Could not open 256 for writing!" was a confusing one.
