### PR TITLE
RFC: Add methods to rand to support rand(rng, type)

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -97,12 +97,18 @@ rand(::Type{Float16}) = float16(rand())
 rand{T<:Real}(::Type{Complex{T}}) = complex(rand(T),rand(T))
 
 
-rand(r::MersenneTwister) = dsfmt_genrand_close_open(r.state)
+rand(rng::MersenneTwister) = dsfmt_genrand_close_open(rng.state)
+rand(rng::MersenneTwister, ::Type{Float64}) = rand(rng)
+rand(rng::MersenneTwister, ::Type{Float32}) = float32(rand(rng))
+rand(rng::MersenneTwister, ::Type{Float16}) = float16(rand(rng))
+rand{T<:Real}(rng::MersenneTwister, ::Type{Complex{T}}) = complex(rand(rng, T),rand(rng, T))
 
 ## random integers
 
 dsfmt_randui32() = dsfmt_gv_genrand_uint32()
 dsfmt_randui64() = uint64(dsfmt_randui32()) | (uint64(dsfmt_randui32())<<32)
+dsfmt_randui32(rng::MersenneTwister) = dsfmt_genrand_uint32(rng.state)
+dsfmt_randui64(rng::MersenneTwister) = uint64(dsfmt_randui32(rng)) | (uint64(dsfmt_randui32(rng))<<32)
 
 rand(::Type{Uint8})   = uint8(rand(Uint32))
 rand(::Type{Uint16})  = uint16(rand(Uint32))
@@ -115,6 +121,18 @@ rand(::Type{Int16})   = int16(rand(Uint16))
 rand(::Type{Int32})   = int32(rand(Uint32))
 rand(::Type{Int64})   = int64(rand(Uint64))
 rand(::Type{Int128})  = int128(rand(Uint128))
+
+rand(rng::AbstractRNG, ::Type{Uint8})   = uint8(rand(rng, Uint32))
+rand(rng::AbstractRNG, ::Type{Uint16})  = uint16(rand(rng, Uint32))
+rand(rng::MersenneTwister, ::Type{Uint32})  = dsfmt_randui32(rng)
+rand(rng::MersenneTwister, ::Type{Uint64})  = dsfmt_randui64(rng)
+rand(rng::AbstractRNG, ::Type{Uint128}) = uint128(rand(rng, Uint64))<<64 | rand(rng, Uint64)
+
+rand(rng::AbstractRNG, ::Type{Int8})    = int8(rand(rng, Uint8))
+rand(rng::AbstractRNG, ::Type{Int16})   = int16(rand(rng, Uint16))
+rand(rng::AbstractRNG, ::Type{Int32})   = int32(rand(rng, Uint32))
+rand(rng::AbstractRNG, ::Type{Int64})   = int64(rand(rng, Uint64))
+rand(rng::AbstractRNG, ::Type{Int128})  = int128(rand(rng, Uint128))
 
 # Arrays of random numbers
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3419,7 +3419,7 @@ Random number generation in Julia uses the `Mersenne Twister library <http://www
 
    Generate a random ``Float64`` array of the size specified by dims
 
-.. function:: rand(Int32|Uint32|Int64|Uint64|Int128|Uint128, [dims...])
+.. function:: rand([rng], Float16|Float32|Float64|Int32|Uint32|Int64|Uint64|Int128|Uint128|Complex{T}, [dims...])
 
    Generate a random integer of the given type. Optionally, generate an array of random integers of the given type by specifying dims.
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -6,6 +6,24 @@
 @test minimum([rand(int32(1):int32(7^7)) for i = 1:100000]) > 0
 @test(typeof(rand(false:true)) == Bool)
 
+# Test rand(::AbstractRNG, ::Type{...})
+@test rand(MersenneTwister(), Uint32) == 0x02631e40
+@test rand(MersenneTwister(42), Float16) == float16(0.5332)
+@test rand(MersenneTwister(42), Float32) == 0.53318304f0
+@test rand(MersenneTwister(42), Float64) == 0.5331830160438613
+@test rand(MersenneTwister(42), Uint8) == 0x73
+@test rand(MersenneTwister(42), Uint16) == 0x0e73
+@test rand(MersenneTwister(42), Uint32) == 0xea0b0e73
+@test rand(MersenneTwister(42), Uint64) == 0x0e0c7263ea0b0e73
+@test rand(MersenneTwister(42), Uint128) == 0x0e0c7263ea0b0e736c7aeb39fb64f900
+@test rand(MersenneTwister(42), Int8) == 115
+@test rand(MersenneTwister(42), Int16) == 3699
+@test rand(MersenneTwister(42), Int32) == -368374157
+@test rand(MersenneTwister(42), Int64) == 1012309789705440883
+@test rand(MersenneTwister(42), Int128) == 18673819614007004079327070939043395840
+@test rand(MersenneTwister(42), Complex{Int8}) == 115 + 99im
+@test rand(MersenneTwister(42), Complex{Int64}) == 1012309789705440883 + 7816818737518278912im
+
 @test length(randn(4, 5)) == 20
 @test length(randbool(4, 5)) == 20
 


### PR DESCRIPTION
rand(r::AbstractRNG, Int32|Uint32|Int64|Uint64|Int128|Uint128[, dims...])
