### PR TITLE
RFC: Make MersenneTwister equivalent in 32- and 64-bit architectures

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -14,26 +14,13 @@ type MersenneTwister <: AbstractRNG
     state::DSFMT_state
     seed::Union(Uint32,Vector{Uint32})
 
-    function MersenneTwister()
-        seed = uint32(0)
-        state = DSFMT_state()
-        dsfmt_init_gen_rand(state, seed)
-        return new(state, seed)
-    end
-
-    function MersenneTwister(seed::Uint32)
-        state = DSFMT_state()
-        dsfmt_init_gen_rand(state, seed)
-        return new(state, seed)
-    end
-
     function MersenneTwister(seed::Vector{Uint32})
         state = DSFMT_state()
         dsfmt_init_by_array(state, seed)
         return new(state, seed)
     end
 
-    MersenneTwister(seed) = MersenneTwister(reinterpret(Uint32, [seed]))
+    MersenneTwister(seed=0) = MersenneTwister(make_seed(seed))
 end
 
 function srand(r::MersenneTwister, seed) 

--- a/test/random.jl
+++ b/test/random.jl
@@ -9,6 +9,12 @@
 @test length(randn(4, 5)) == 20
 @test length(randbool(4, 5)) == 20
 
+@test rand(MersenneTwister()) == 0.8236475079774124
+@test rand(MersenneTwister(0)) == 0.8236475079774124
+@test rand(MersenneTwister(42)) == 0.5331830160438613
+# Try a seed larger than 2^32
+@test rand(MersenneTwister(5294967296)) == 0.3498809918210497
+
 for T in (Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64, Int128, Uint128, Char, BigInt,
 	Float16, Float32, Float64, Rational{Int})
     r = rand(convert(T, 97):convert(T, 122))


### PR DESCRIPTION
As mentioned in issue #5999, reproduce the solution in 67f6fee for the MersenneTwister.

Note that users on 64-bit architectures will see their randomness change with no change in their seed after this commit.
