### PR TITLE
better SEH handling

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -638,13 +638,20 @@ $(OPENLIBM_OBJ_SOURCE): openlibm/Makefile
 	$(MAKE) -C openlibm $(OPENLIBM_FLAGS) $(MAKE_COMMON)
 	touch -c $@
 $(OPENLIBM_OBJ_TARGET): $(OPENLIBM_OBJ_SOURCE)
+ifeq ($(OS),WINNT)
+	cp -a openlibm/libopenlibm.a $(build_libdir)/libopenlibm.a
+	cp $< $@
+else
 	$(MAKE) -C openlibm install $(OPENLIBM_FLAGS) $(MAKE_COMMON)
 	$(INSTALL_NAME_CMD)libopenlibm.dylib $@
 	touch -c $@
+endif
 
 clean-openlibm:
 	-$(MAKE) -C openlibm distclean $(OPENLIBM_FLAGS)
 	-rm $(OPENLIBM_OBJ_TARGET)
+	-rm $(build_libdir)/libopenlibm.a
+
 distclean-openlibm: clean-openlibm
 	-cd openlibm && git clean -fdx
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -501,6 +501,10 @@ static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, size_t nl,
             else if (head == enter_sym) {
                 jl_enter_handler(&__eh);
                 if (!jl_setjmp(__eh.eh_ctx,1)) {
+#ifdef _OS_WINDOWS_
+                    if (jl_exception_in_transit == jl_stackovf_exception)
+                        _resetstkoflw();
+#endif
                     return eval_body(stmts, locals, nl, i+1, toplevel);
                 }
                 else {


### PR DESCRIPTION
Trying to get the ball rolling on #5398

> we need to convert the upper case constants...

done

> Also, the handling of the in_ctx flag of _exception_handler should be slightly less of a special case, only affecting whether it creates a backtrace

included, but not sure if I correctly understood what you meant.

> Currently we call setjmp to avoid this return value. Instead use throw in context (& remove some code duplication)

iffy on this... I think it this should be !mingw? I'm not setup to build MSVC yet, if so.

@vtjnash
