### PR TITLE
Simplify make_seed and undo 7b44eb now that register shifts are safe

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -83,11 +83,10 @@ function make_seed(n::Integer)
     seed = Uint32[]
     while true
         push!(seed, n & 0xffffffff)
-        n2 = n >> 32
-        if n2 == 0 || n2 == n
+        n >>= 32
+        if n == 0
             return seed
         end
-        n = n2
     end
 end
 


### PR DESCRIPTION
This needs to be tested more on 32-bit machines

As per discussion: https://github.com/JuliaLang/julia/commit/7b44ebe60f3e0a5e147f3124aa6ea813edadcfa0
