### PR TITLE
RFC: Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+environment:
+#  USEMSVC: "1"
+  matrix:
+  - ARCH: "i686"
+  - ARCH: "x86_64"
+
+clone_depth: 50
+
+init:
+# Carriage returns are bad
+  - git config --global core.autocrlf input
+
+build_script:
+# temporarily disable backtrace test, failing right now for win64 on master
+  - sed -i 's/"backtrace",//' test/runtests.jl
+# Remove C:\MinGW\bin from the path, the version of MinGW installed on
+# AppVeyor is not compatible with the cross-compiled Julia Windows binaries
+  - set PATH=%PATH:C:\MinGW\bin;=%
+#  - '"%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64'
+# Since the AppVeyor VMs have Git installed, they have MSYS1
+  - sh --login /c/projects/julia/contrib/windows/msys_build.sh
+
+test_script:
+  - cd test && ..\usr\bin\julia runtests.jl all

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -176,5 +176,5 @@ else
   echo 'override STAGE1_DEPS += openlibm' >> Make.user
 fi
 
-make
+make -j2
 #make debug


### PR DESCRIPTION
Travis can't run on Windows yet, and the MinGW cross-compilers in the Ubuntu repository are a few versions old. [AppVeyor recently launched a beta for a Windows-based CI system](http://blog.appveyor.com/2014/02/19/appveyor-20-dedicated-build-vms-parallel-testing-nuget-deployment/) very similar in functionality to Travis. It's pretty straightforward to get Cygwin and the necessary MinGW compiler packages installed from the appveyor.yml file. MSYS2 could be tried here instead of Cygwin, I don't know whether there's a non-interactive version of the MSYS2 installer.

The difficult part is getting a Windows build of Julia to run in a reasonable amount of time. The script cygwin_build.sh downloads binaries for as many dependencies as I could find. A decent number have mingw64 rpm's available, but for the largest two (LLVM and OpenBlas) I had to dig around a little. Any volunteers want to try putting together a mingw64-llvm or mingw64-openblas (or suitesparse, arpack, etc) rpm, either in Fedora or the OpenSuse build service?

~~The initial time limit for free plans in AppVeyor is only 10 minutes per build, and it takes almost half that time just to install Cygwin and packages, and download dependency binaries. If you hit the time limit a few times it looks like they bump you up to 30 minutes.~~ [Here is the build result](https://ci-beta.appveyor.com/project/tkelman/julia/build/1.0.99) in the current state, some errors are happening related to version_git at the end, and `key not found: "HOMEDRIVE"` whatever that means. Any suggestions?

Edit: they increased the time limit to 30 minutes for everyone, I just happened to notice it immediately as they made that change.
