### PR TITLE
BitArray broadcasting

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -916,11 +916,6 @@ for f in (:+, :-),
     end
 end
 
-function (./)(A::BitArray, B::BitArray)
-    shp = promote_shape(size(A),size(B))
-    reshape([ A[i] ./ B[i] for i=1:length(A) ], shp)
-end
-
 for f in (:/, :\)
     @eval begin
         ($f)(A::BitArray, B::BitArray) = ($f)(bitunpack(A), bitunpack(B))

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -6,8 +6,6 @@ macro _div64(l) :($(esc(l)) >>> 6) end
 macro _mod64(l) :($(esc(l)) & 63) end
 macro _msk_end(l) :(@_mskr @_mod64 $(esc(l))) end
 num_bit_chunks(n::Int) = @_div64 (n+63)
-const bitcache_chunks = 64 # this can be changed
-const bitcache_size = 64 * bitcache_chunks # do not change this
 
 ## BitArray
 
@@ -1023,22 +1021,6 @@ for f in (:&, :|, :$)
     end
 end
 
-function (.^)(A::BitArray, B::BitArray)
-    F = BitArray(promote_shape(size(A),size(B))...)
-    Fc = F.chunks
-    Ac = A.chunks
-    Bc = B.chunks
-    if !isempty(Ac) && !isempty(Bc)
-        for i = 1:length(Fc) - 1
-            Fc[i] = Ac[i] | ~Bc[i]
-        end
-        msk = @_msk_end length(F)
-        Fc[end] = msk & (Ac[end] | ~Bc[end])
-    end
-    return F
-end
-(.^)(A::Array{Bool}, B::BitArray) = (.^)(bitpack(A), B)
-(.^)(B::BitArray, A::Array{Bool}) = (.^)(B, bitpack(A))
 function (.^)(B::BitArray, x::Bool)
     x ? copy(B) : trues(size(B))
 end
@@ -1070,12 +1052,12 @@ function (.^){T<:Number}(B::BitArray, x::T)
         zerr = nothing
         uerr = nothing
         try
-            z = false .^ x
+            z = false^x
         catch err
             zerr = err
         end
         try
-            u = true .^ x
+            u = true^x
         catch err
             uerr = err
         end
@@ -1104,52 +1086,6 @@ function (.^){T<:Number}(B::BitArray, x::T)
         end
         return F
     end
-end
-
-function dumpbitcache(Bc::Vector{Uint64}, bind::Int, C::Vector{Bool})
-    ind = 1
-    nc = min(bitcache_chunks, length(Bc)-bind+1)
-    for i = 1:nc
-        u = uint64(1)
-        c = uint64(0)
-        for j = 1:64
-            if C[ind]
-                c |= u
-            end
-            ind += 1
-            u <<= 1
-        end
-        Bc[bind] = c
-        bind += 1
-    end
-end
-
-function bitcache_pow{T}(A::BitArray, B::Array{T}, l::Int, ind::Int, C::Vector{Bool})
-    left = l - ind + 1
-    for j = 1:min(bitcache_size, left)
-        C[j] = bool(A[ind] .^ B[ind])
-        ind += 1
-    end
-    C[left+1:bitcache_size] = false
-    return ind
-end
-function (.^){T<:Integer}(A::BitArray, B::Array{T})
-    F = BitArray(promote_shape(size(A),size(B)))
-    Fc = F.chunks
-    l = length(F)
-    if l == 0
-        return F
-    end
-    C = Array(Bool, bitcache_size)
-    ind = 1
-    cind = 1
-    nFc = num_bit_chunks(l)
-    for i = 1:div(l + bitcache_size - 1, bitcache_size)
-        ind = bitcache_pow(A, B, l, ind, C)
-        dumpbitcache(Fc, cind, C)
-        cind += bitcache_chunks
-    end
-    return F
 end
 
 (.*)(A::BitArray, B::BitArray) = A & B

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1083,9 +1083,6 @@ function (.^){T<:Number}(B::BitArray, x::T)
     end
 end
 
-(.*)(A::BitArray, B::BitArray) = A & B
-(.*)(A::Array{Bool}, B::BitArray) = A & B
-(.*)(B::BitArray, A::Array{Bool}) = A & B
 (.*)(x::Bool, B::BitArray) = x & B
 (.*)(B::BitArray, x::Bool) = B & x
 (.*)(x::Number, B::BitArray) = x .* bitunpack(B)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -145,10 +145,20 @@ end
 
 ## elementwise operators ##
 
-.+(As::AbstractArray...) = broadcast(+, As...)
 .*(As::AbstractArray...) = broadcast(*, As...)
-.-(A::AbstractArray, B::AbstractArray) = broadcast(-, A, B)
 .%(A::AbstractArray, B::AbstractArray) = broadcast(%, A, B)
+
+eltype_plus(As::AbstractArray...) = promote_eltype(As...)
+eltype_plus(As::AbstractArray{Bool}...) = typeof(true+true)
+
+.+(As::AbstractArray...) = broadcast!(+, Array(eltype_plus(As...), broadcast_shape(As...)), As...)
+
+type_minus(T, S) = promote_type(T, S)
+type_minus(::Type{Bool}, ::Type{Bool}) = typeof(true-true)
+
+function .-(A::AbstractArray, B::AbstractArray)
+    broadcast!(-, Array(type_minus(eltype(A), eltype(B)), broadcast_shape(A,B)), A, B)
+end
 
 type_div(T,S) = promote_type(T,S)
 type_div{T<:Integer,S<:Integer}(::Type{T},::Type{S}) = typeof(one(T)/one(S))

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -74,7 +74,7 @@ function gen_broadcast_body(nd::Int, narrays::Int, f::Function)
     end
 end
 
-function broadcast!_function(nd::Int, narrays::Int, f::Function)
+function gen_broadcast_function(nd::Int, narrays::Int, f::Function)
     As = [symbol("A_"*string(i)) for i = 1:narrays]
     body = gen_broadcast_body(nd, narrays, f)
     @eval begin
@@ -92,8 +92,8 @@ function broadcast!(f::Function, B, As...)
     nd = ndims(B)
     narrays = length(As)
     key = (f, nd, narrays)
-    if !haskey(broadcast_cache,key)
-        func = broadcast!_function(nd, narrays, f)
+    if !haskey(broadcast_cache, key)
+        func = gen_broadcast_function(nd, narrays, f)
         broadcast_cache[key] = func
     else
         func = broadcast_cache[key]

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -381,4 +381,16 @@ function (.^){T<:Integer}(A::BitArray, B::Array{T})
     return F
 end
 
+for (sigA, sigB) in ((BitArray, BitArray),
+                     (AbstractArray{Bool}, BitArray),
+                     (BitArray, AbstractArray{Bool}))
+    @eval function (.*)(A::$sigA, B::$sigB)
+        try
+            return bitpack(A) & bitpack(B)
+        catch
+            return bitbroadcast(&, A, B)
+        end
+    end
+end
+
 end # module

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -5,7 +5,7 @@ import Base.promote_eltype
 import Base.num_bit_chunks, Base.@_msk_end, Base.getindex_unchecked
 import Base.(.+), Base.(.-), Base.(.*), Base.(./), Base.(.\)
 import Base.(.==), Base.(.<), Base.(.!=), Base.(.<=)
-export broadcast, broadcast!, broadcast_function, broadcast!_function
+export broadcast, broadcast!, broadcast_function, broadcast!_function, bitbroadcast
 export broadcast_getindex, broadcast_setindex!
 
 ## Broadcasting utilities ##

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -107,6 +107,11 @@ function power_by_squaring(x, p::Integer)
     end
     return y
 end
+power_by_squaring(x::Bool, p::Unsigned) = ((p==0) | x)
+function power_by_squaring(x::Bool, p::Integer)
+    p < 0 && throw(DomainError())
+    return (p==0) | x
+end
 
 ^{T<:Integer}(x::T, p::T) = power_by_squaring(x,p)
 ^(x::Number, p::Integer)  = power_by_squaring(x,p)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -7,6 +7,7 @@ end
 
 unsafe_getindex(v::Real, ind::Integer) = v
 unsafe_getindex(v::Ranges, ind::Integer) = first(v) + (ind-1)*step(v)
+unsafe_getindex(v::BitArray, ind::Integer) = Base.getindex_unchecked(v.chunks, ind)
 unsafe_getindex(v::AbstractArray, ind::Integer) = v[ind]
 
 # Version that uses cartesian indexing for src

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -224,7 +224,6 @@ end
 end
 
 # general version with Real (or logical) indexing which dispatches on the appropriate method
-# TODO: fix return type
 
 @ngenerate N Bool function getindex(B::BitArray, I::NTuple{N,Real}...)
     @nexprs N d->(J_d = to_index(I_d))

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3589,6 +3589,10 @@ All mathematical operations and functions are supported for arrays
    ``f`` unless it is also listed in the ``As``, as in ``broadcast!(f, A, A, B)`` to perform
    ``A[:] = broadcast(f, A, B)``.
 
+.. function:: bitbroadcast(f, As...)
+
+   Like ``broadcast``, but allocates a ``BitArray`` to store the result, rather then an ``Array``.
+
 .. function:: broadcast_function(f)
 
    Returns a function ``broadcast_f`` such that ``broadcast_function(f)(As...) === broadcast(f, As...)``. Most useful in the form ``const broadcast_f = broadcast_function(f)``.

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -57,6 +57,7 @@ for arr in (identity, as_sub)
     @test arr([1 2]) ./ arr([3, 4]) == [1/3 2/3; 1/4 2/4]
     @test arr([1 2]) .\ arr([3, 4]) == [3 1.5; 4 2]
     @test arr([3 4]) .^ arr([1, 2]) == [3 4; 9 16]
+    @test arr(bitpack([true false])) .* arr(bitpack([true, true])) == [true false; true false]
     @test arr(bitpack([true false])) .^ arr(bitpack([false, true])) == [true true; true false]
     @test arr(bitpack([true false])) .^ arr([0, 3]) == [true true; true false]
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -57,6 +57,8 @@ for arr in (identity, as_sub)
     @test arr([1 2]) ./ arr([3, 4]) == [1/3 2/3; 1/4 2/4]
     @test arr([1 2]) .\ arr([3, 4]) == [3 1.5; 4 2]
     @test arr([3 4]) .^ arr([1, 2]) == [3 4; 9 16]
+    @test arr(bitpack([true false])) .^ arr(bitpack([false, true])) == [true true; true false]
+    @test arr(bitpack([true false])) .^ arr([0, 3]) == [true true; true false]
 
     M = arr([11 12; 21 22])
     @test broadcast_getindex(M, eye(Int, 2)+1,arr([1, 2])) == [21 11; 12 22]


### PR DESCRIPTION
This fixes #5877 and touches related issues, in that it makes element-wise comparisons (`.==`, `.<`, etc.) broadcasting, and also completes broadcasting behaviour for all element-wise operations which involve BitArrays (`.*`, `./`, etc.), unless I missed something.

Besides that, there is some minor stuff in here, the most relevant being that it fixes `.+` and `.-` for Bools, which now return `Array{Int}`. There's also a specialization for `Bool^Int`.

This is a pull request even though to me it's ready for merging, mainly to highlight some issues I found. Here's a list of reasons why I didn't merge it directly:
1. Since broadcast is @toivoh's (and others) creature, review is in order
2. The code adds a specialization for `broadcast!(f::Function, B::BitArray, ...)`, but adds another function `bitbroadcast`, which is not exported: should it be exported?
3. Performance is good, unless broadcasting is actually needed (i.e. `broadcast_shape` yields something different from `promote_shape`) _and_ BitArrays are involved in the argument list.
   
   3a. In the case `promote_shape` succeeds, I added fallbacks which make things efficient. One possibly questionable issue is my use of `try` blocks for that purpose.
   
   3b. In case it fails, and BitArrays are involved (e.g. `trues(5) .+ falses(1,5)`), cartesian iteration kills performance, to the point that it is much faster to invoke `bitunpack` on the arguments first; however, that may clearly become very memory-expensive. I haven't been able to overcome this issue yet, so advice would be welcome on this. (One might imagine unpacking below a certain size, but that is not a very satisfactory solution.)

Example of timings for the last issue: here's a specialized version which doesn't truly broadcast:

```
julia> n1=110; n2=323; n3=681; a = randbool(n1,n2,n3); b = randbool(n1,n2,n3);

julia> @time a .* b; # not really broadcasting
elapsed time: 0.004324182 seconds (3024816 bytes allocated)
```

And here's one where it does:

```
julia> n1=110; n2=323; n3=681; a = randbool(n1,1,n3); b = randbool(1,n2,1);

julia> @time a .* b; # broadcasting
elapsed time: 1.087884438 seconds (3029848 bytes allocated)

julia> @time bitunpack(a) .* bitunpack(b); # broadcasting
elapsed time: 0.124664672 seconds (24273712 bytes allocated)
```

Similar timings are obtained for comparison operations like `.==`.

Part of the problem is that `@inbounds` is ineffective for BitArrays, but I don't think it's only that (even if it would be nice to have some way of making it work, cc @JeffBezanson ). Probably, with a sufficient effort, one could come up with some (contrived) way out from this by avoiding multidimensional indexing for BitArrays, but even in that case it is hard to think of a solution for general AbstractArrays (e.g. comparing a `BitArray` with an `Array`).
