### PR TITLE
some indexing tweaks

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -289,8 +289,8 @@ getindex(A::Array, i0::Real, i1::Real, i2::Real, i3::Real,  i4::Real) =
 getindex(A::Array, i0::Real, i1::Real, i2::Real, i3::Real,  i4::Real, i5::Real) =
     arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3),to_index(i4),to_index(i5))
 
-getindex(A::Array, i0::Real, i1::Real, i2::Real, i3::Real,  i4::Real, i5::Real, I::Int...) =
-    arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3),to_index(i4),to_index(i5),I...)
+getindex(A::Array, i0::Real, i1::Real, i2::Real, i3::Real,  i4::Real, i5::Real, I::Real...) =
+    arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3),to_index(i4),to_index(i5),to_index(I)...)
 
 # Fast copy using copy! for Range1
 function getindex(A::Array, I::Range1{Int})
@@ -350,8 +350,8 @@ setindex!{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real) =
     arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4))
 setindex!{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real) =
     arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4), to_index(i5))
-setindex!{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real, I::Int...) =
-    arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4), to_index(i5), I...)
+setindex!{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real, I::Real...) =
+    arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4), to_index(i5), to_index(I)...)
 
 function setindex!{T<:Real}(A::Array, x, I::AbstractVector{T})
     for i in I

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -278,7 +278,7 @@ function setindex_shape_check{T}(X::AbstractArray{T,2}, i, j)
 end
 
 # convert to integer index
-to_index(i)       = i
+to_index(i)       = error("invalid index: $i")
 to_index(i::Real) = convert(Int, i)
 to_index(i::Int)  = i
 to_index(r::Range1{Int}) = r

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -214,8 +214,8 @@ getindex(s::SubArray, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real) =
     getindex(s, to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4))
 getindex(s::SubArray, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real) =
     getindex(s, to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4), to_index(i5))
-getindex(s::SubArray, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real, is::Int...) =
-    getindex(s, to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4), to_index(i5), is...)
+getindex(s::SubArray, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real, is::Real...) =
+    getindex(s, to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4), to_index(i5), to_index(is)...)
 
 getindex(s::SubArray, i::Integer) = s[ind2sub(size(s), i)...]
 


### PR DESCRIPTION
Two independent commits in this PR:
1. fix #6017 by disallowing generic `to_index`, i.e. leaving only `Real` and `AbstractArray{Real}` as valid types. Alternative fixes (e.g. restricting `getindex` signatures) didn't turn out to be practical, and to me the restriction on indexing in general seems reasonable, and won't hopefully break anything: in Base it is always used like that (at times implicitly, as in the case exposed by #6017), and the function is not exported. Of all packages installed on my system, only ArrayViews uses it, and only once without explicitly restricting to `Real` (it's defined on `Ranges`), so I guess this should be safe (cc @lindahua). Also, if more exotic needs emerge, it's easy to add specialized `to_index` versions.
2. extend the signature of purely-scalar Array and SubArray indexing in high dimensions, which previously was allowing Reals for dimensions up to 6, and only Ints afterwards. This seems weird to me, but maybe there's something I'm not aware of (cc @JeffBezanson). BTW it's the same in ArrayViews (cc @lindahua).
