### PR TITLE
More descriptive error for environment variable not found

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -72,7 +72,7 @@ const ENV = EnvHash()
 
 similar(::EnvHash) = Dict{ByteString,ByteString}()
 
-getindex(::EnvHash, k::String) = @accessEnv k throw(KeyError(k))
+getindex(::EnvHash, k::String) = @accessEnv k error("environment variable not found: $k")
 get(::EnvHash, k::String, def) = @accessEnv k (return def)
 in(k::String, ::KeyIterator{EnvHash}) = _hasenv(k)
 pop!(::EnvHash, k::String) = (v = ENV[k]; _unsetenv(k); v)


### PR DESCRIPTION
When `ERROR: key not found: "foo"` happens deep in some internal function, it's not always obvious that it's referring to an environment variable. Bikeshedding on the error message welcome (or if this needs to be done differently), but I think this is a special enough case that it should get a specific message.
