### PR TITLE
correct rl_startup_hook type while USE_SYSTEM_READLINE=1

### DIFF
--- a/ui/repl-readline.c
+++ b/ui/repl-readline.c
@@ -835,7 +835,7 @@ void jl_init_repl(int history)
     rl_instream = fopen("/dev/null","r");
     prompt_length = 7;  // == strlen("julia> ")
     init_history();
-    rl_startup_hook = (Function*)init_rl;
+    rl_startup_hook = (rl_hook_func_t*)init_rl;
 }
 
 static char *prompt_string=NULL;


### PR DESCRIPTION
I set `USE_SYSTEM_READLINE=1` in my Make.user, and then Julia fails to build:

```
    PERL base/build_h.jl.phony
    CC ui/repl-readline.o
repl-readline.c:838:24: error: use of undeclared identifier 'Function'
    rl_startup_hook = (Function*)init_rl;
                       ^
repl-readline.c:838:33: error: expected expression
    rl_startup_hook = (Function*)init_rl;
                                ^
2 errors generated.
make[2]: *** [repl-readline.o] Error 1
make[1]: *** [julia-release] Error 2
make: *** [release] Error 2
```

I found there's no `Function` typedef in the system provided libreadline headers, so I changed it to `rl_hook_func_t`.
