### PR TITLE
don't make a copy when hashing substrings

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -288,22 +288,6 @@ hash(a::AbstractArray{Bool}) = hash(bitpack(a))
 
 hash(x::ANY) = object_id(x)
 
-if WORD_SIZE == 64
-    hash(s::ByteString) =
-        ccall(:memhash, Uint64, (Ptr{Void}, Int), s.data, length(s.data))
-    hash(s::ByteString, seed::Union(Int,Uint)) =
-        ccall(:memhash_seed, Uint64, (Ptr{Void}, Int, Uint32),
-              s.data, length(s.data), uint32(seed))
-else
-    hash(s::ByteString) =
-        ccall(:memhash32, Uint32, (Ptr{Void}, Int), s.data, length(s.data))
-    hash(s::ByteString, seed::Union(Int,Uint)) =
-        ccall(:memhash32_seed, Uint32, (Ptr{Void}, Int, Uint32),
-              s.data, length(s.data), uint32(seed))
-end
-
-hash(s::String) = hash(bytestring(s))
-
 hash(x::Expr) = bitmix(hash(x.head),hash(x.args)+43)
 
 

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -30,6 +30,7 @@ for T=types, S=types, x=vals
 end
 
 @test hash(RopeString("1","2")) == hash("12")
+@test hash(SubString("--hello--",3,7)) == hash("hello")
 @test hash(:(X.x)) == hash(:(X.x))
 @test hash(:(X.x)) != hash(:(X.y))
 


### PR DESCRIPTION
As [discussed on the mailing list](https://groups.google.com/d/msg/julia-users/hxfR70Ro-lI/WucvdlXltK8J), one gets significant performance improvements by not making a copy when hashing a `SubString` of a `ByteString`.

No new method is required, just a slight generalization of the old `hash(::ByteString)`.
