### PR TITLE
Make version_git.sh work on older versions of git.

### DIFF
--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -34,9 +34,9 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 branch=$(git branch | sed -n '/\* /s///p')
 # Some versions of wc (eg on OS X) add extra whitespace to their output.
-# The tr(1) call stops this from breaking the generated Julia's indentation by
+# The sed(1) call stops this from breaking the generated Julia's indentation by
 # stripping all non-digits.
-build_number=$(git rev-list HEAD ^$last_tag | wc -l | tr -dc '[:digit:]')
+build_number=$(git rev-list HEAD ^$last_tag | wc -l | sed -e 's/[^[:digit:]]//g')
 
 date_string=$git_time
 if [ "$(uname)" = "Darwin" ] || [ "$(uname)" = "FreeBSD" ]; then
@@ -49,7 +49,7 @@ if [ $(git describe --tags --exact-match 2> /dev/null) ]; then
 else
     tagged_commit="false"
 fi
-fork_master_distance=$(git rev-list HEAD ^"$(echo $origin)master" | wc -l | tr -dc '[:digit:]')
+fork_master_distance=$(git rev-list HEAD ^"$(echo $origin)master" | wc -l | sed -e 's/[^[:digit:]]//g')
 fork_master_timestamp=$(git show -s $(git merge-base HEAD $(echo $origin)master) --format=format:"%ct")
 
 # Check for errrors and emit default value for missing numbers.

--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -33,7 +33,7 @@ if [ -n "$(git status --porcelain)" ]; then
     commit_short="$commit_short"*
 fi
 branch=$(git branch | sed -n '/\* /s///p')
-build_number=$(git rev-list --count HEAD ^$last_tag)
+build_number=$(git rev-list HEAD ^$last_tag | wc -l)
 
 date_string=$git_time
 if [ "$(uname)" = "Darwin" ] || [ "$(uname)" = "FreeBSD" ]; then
@@ -46,7 +46,7 @@ if [ $(git describe --tags --exact-match 2> /dev/null) ]; then
 else
     tagged_commit="false"
 fi
-fork_master_distance=$(git rev-list --count HEAD ^"$(echo $origin)master")
+fork_master_distance=$(git rev-list HEAD ^"$(echo $origin)master" | wc -l)
 fork_master_timestamp=$(git show -s $(git merge-base HEAD $(echo $origin)master) --format=format:"%ct")
 
 # Check for errrors and emit default value for missing numbers.

--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -33,7 +33,10 @@ if [ -n "$(git status --porcelain)" ]; then
     commit_short="$commit_short"*
 fi
 branch=$(git branch | sed -n '/\* /s///p')
-build_number=$(git rev-list HEAD ^$last_tag | wc -l)
+# Some versions of wc (eg on OS X) add extra whitespace to their output.
+# The tr(1) call stops this from breaking the generated Julia's indentation by
+# stripping all non-digits.
+build_number=$(git rev-list HEAD ^$last_tag | wc -l | tr -dc '[:digit:]')
 
 date_string=$git_time
 if [ "$(uname)" = "Darwin" ] || [ "$(uname)" = "FreeBSD" ]; then
@@ -46,7 +49,7 @@ if [ $(git describe --tags --exact-match 2> /dev/null) ]; then
 else
     tagged_commit="false"
 fi
-fork_master_distance=$(git rev-list HEAD ^"$(echo $origin)master" | wc -l)
+fork_master_distance=$(git rev-list HEAD ^"$(echo $origin)master" | wc -l | tr -dc '[:digit:]')
 fork_master_timestamp=$(git show -s $(git merge-base HEAD $(echo $origin)master) --format=format:"%ct")
 
 # Check for errrors and emit default value for missing numbers.


### PR DESCRIPTION
The --count option to git-rev-list was introduced in git version 1.7.6. When base/version_git.sh is run on versions of git without this option, a long help message is generated (cluttering up make output) and generating an incorrect base/version_git.jl.

This problem has previously arisen in #5587.
