### PR TITLE
Let floatx and complexx use convert. Fix similar for sparse matrices.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -283,13 +283,14 @@ end
 bool(x::AbstractArray{Bool}) = x
 bool(x::AbstractArray) = copy!(similar(x,Bool), x)
 
-for (f,t) in ((:float16,    Float16),
+convert{T,S,N}(::Type{AbstractArray{T}}, A::Array{S,N}) = convert(Array{T,N}, A)
+convert{T,S,N}(::Type{AbstractArray{T,N}}, A::Array{S,N}) = convert(Array{T,N}, A)
+for (f,T) in ((:float16,    Float16),
               (:float32,    Float32),
               (:float64,    Float64),
               (:complex64,  Complex64),
               (:complex128, Complex128))
-    @eval ($f)(x::AbstractArray{$t}) = x
-    @eval ($f)(x::AbstractArray) = copy!(similar(x,$t), x)
+    @eval ($f)(x::AbstractArray) = convert(AbstractArray{$T}, x)
 end
 
 float{T<:FloatingPoint}(x::AbstractArray{T}) = x

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -324,6 +324,7 @@ function convert{T,N}(::Type{BitArray{N}}, A::AbstractArray{T,N})
 end
 
 convert{N}(::Type{BitArray{N}}, B::BitArray{N}) = B
+convert{T,N}(::Type{AbstractArray{T,N}}, B::BitArray{N}) = convert(Array{Bool,N}, B)
 
 reinterpret{N}(::Type{Bool}, B::BitArray, dims::NTuple{N,Int}) = reinterpret(B, dims)
 reinterpret{N}(B::BitArray, dims::NTuple{N,Int}) = reshape(B, dims)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -127,28 +127,10 @@ end
 copy(S::SparseMatrixCSC) =
     SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), copy(S.nzval))
 
-similar(S::SparseMatrixCSC, Tv::NonTupleType) =
-    SparseMatrixCSC(S.m, S.n, similar(S.colptr), similar(S.rowval), Array(Tv, length(S.rowval)))
-
+similar(S::SparseMatrixCSC, Tv::NonTupleType=eltype(S))   = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), Array(Tv, length(S.nzval)))
+similar{Tv,Ti,TvNew}(S::SparseMatrixCSC{Tv,Ti}, ::Type{TvNew}, ::Type{Ti}) = similar(S, TvNew)
+similar{Tv,Ti,TvNew,TiNew}(S::SparseMatrixCSC{Tv,Ti}, ::Type{TvNew}, ::Type{TiNew}) = SparseMatrixCSC(S.m, S.n, convert(Array{TiNew},S.colptr), convert(Array{TiNew}, S.rowval), Array(TvNew, length(S.nzval)))
 similar(S::SparseMatrixCSC, Tv::Type, d::(Integer,Integer)) = spzeros(Tv, d[1], d[2])
-
-function similar(A::SparseMatrixCSC, Tv::Type, Ti::Type)
-    colptrA = A.colptr; rowvalA = A.rowval; nzvalA = A.nzval
-
-    colptr = Array(Ti, length(colptrA))
-    rowval = Array(Ti, length(rowvalA))
-    nzval  = Array(Tv, length(nzvalA))
-
-    for i=1:length(colptr)
-        colptr[i] = colptrA[i]
-    end
-
-    for i=1:length(rowval)
-        rowval[i] = rowvalA[i]
-    end
-
-    SparseMatrixCSC(S.m, S.n, similar(S.colptr), similar(S.rowval), Array(Tv, length(S.rowval)))
-end
 
 function convert{Tv,Ti,TvS,TiS}(::Type{SparseMatrixCSC{Tv,Ti}}, S::SparseMatrixCSC{TvS,TiS})
     if Tv == TvS && Ti == TiS


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#90, but unsure if `convert(typeof(x).name.primary{$T}, x)` is the right approach for `float32(AbstractArray)` etc. It feels like a hack.
