### PR TITLE
use LIBUV_INC so that USE_SYSTEM_LIBUV works

### DIFF
--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -35,7 +35,7 @@ SHIPFLAGS += $(FLAGS)
 
 default: release
 
-HEADERS = $(wildcard *.h) $(JULIAHOME)/deps/libuv/include/uv.h
+HEADERS = $(wildcard *.h) $(LIBUV_INC)/uv.h
 
 %.o: %.c $(HEADERS)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(SHIPFLAGS) -DNDEBUG -c $< -o $@)


### PR DESCRIPTION
`LIBUV_INC` gets set here https://github.com/JuliaLang/julia/blob/master/Make.inc#L404-L410

When `USE_SYSTEM_LIBUV` is not 1, we have `LIBUV_INC = $(JULIAHOME)/deps/libuv/include` so these are equivalent. But when it is 1, `$(JULIAHOME)/deps/libuv` may not exist at all and if the paths need manual modification, it's much nicer to `override LIBUV_INC` in Make.user than `override HEADERS`.
