### PR TITLE
RFC: Fix for juliadoc module beeing out of scope.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,4 @@
 	url = git://github.com/JuliaLang/Rmath.git
 [submodule "doc/juliadoc"]
 	path = doc/juliadoc
-	url = git://github.com/JuliaLang/JuliaDoc.git
-
+	url = https://github.com/JuliaLang/JuliaDoc

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,11 +12,15 @@
 # serve to show the default.
 
 import sys, os
-import juliadoc
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
+
+docdir = '{0}/juliadoc/'.format(os.path.abspath('.'))
+sys.path.append(docdir)
+
+import juliadoc
 
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
The change is needed in order to use sphinx-build2:

``` bash
smaelvc@toybox ~/TEST/julia/doc (git)-[sphinx_fix] % sphinx-build2 -b gettext . _build/locale
Making output directory...
Running Sphinx v1.2.1

Exception occurred:
  File "conf.py", line 15, in <module>
    import juliadoc
ImportError: No module named juliadoc
The full traceback has been saved in /tmp/sphinx-err-qK4RSj.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
Either send bugs to the mailing list at <http://groups.google.com/group/sphinx-users/>,
or report them in the tracker at <http://bitbucket.org/birkenfeld/sphinx/issues/>. Thanks!
```

Full backtrace:

``` bash
ismaelvc@toybox ~/TEST/julia/doc (git)-[sphinx_fix] % cat /tmp/sphinx-err-qK4RSj.log
# Sphinx version: 1.2.1
# Python version: 2.7.6
# Docutils version: 0.11 release
# Jinja2 version: 2.7.2
# Loaded extensions:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/sphinx/cmdline.py", line 253, in main
    warningiserror, tags, verbosity, parallel)
  File "/usr/lib/python2.7/site-packages/sphinx/application.py", line 107, in __init__
    confoverrides or {}, self.tags)
  File "/usr/lib/python2.7/site-packages/sphinx/config.py", line 229, in __init__
    execfile_(filename, config)
  File "/usr/lib/python2.7/site-packages/sphinx/util/pycompat.py", line 100, in execfile_
    exec code in _globals
  File "conf.py", line 15, in <module>
    import juliadoc
ImportError: No module named juliadoc
```
