### PR TITLE
RFC: Fix for juliadoc package being out of scope.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,11 +12,15 @@
 # serve to show the default.
 
 import sys, os
-import juliadoc
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
+
+juliadoc_dir = '{0}/juliadoc/'.format(os.path.abspath('.'))
+sys.path.append(juliadoc_dir)
+
+import juliadoc
 
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
The change is needed in order to use `sphinx-build2` without make, see: https://github.com/JuliaLang/julia/pull/6087
