### PR TITLE
fix type stability in all norm variants

### DIFF
--- a/base/linalg/cholmod.jl
+++ b/base/linalg/cholmod.jl
@@ -782,7 +782,7 @@ for Ti in (:Int32,:Int64)
             ccall((@chm_nm "nnz" $Ti
                    ,:libcholmod), Int, (Ptr{c_CholmodSparse{Tv,$Ti}},Ptr{Uint8}),&A.c,cmn($Ti))
         end
-        function norm{Tv<:CHMVTypes}(A::CholmodSparse{Tv,$Ti},p::Number)
+        function norm{Tv<:CHMVTypes}(A::CholmodSparse{Tv,$Ti},p::Real)
             ccall((@chm_nm "norm_sparse" $Ti
                    , :libcholmod), Float64, 
                   (Ptr{c_CholmodSparse{Tv,$Ti}}, Cint, Ptr{Uint8}),

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -18,12 +18,8 @@ function norm{T<:BlasFloat, TI<:Integer}(x::StridedVector{T}, rx::Union(Range1{T
     BLAS.nrm2(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx))
 end
 
-function vecnorm{T<:BlasFloat}(x::Union(Array{T},StridedVector{T}), p::Real=2)
-    length(x) == 0 && return zero(T)
-    p == 1 && T <: Real && return BLAS.asum(x)
-    p == 2 && return BLAS.nrm2(x)
-    invoke(vecnorm, (Any, Real), x, p)
-end
+vecnorm1{T<:BlasReal}(x::Union(Array{T},StridedVector{T})) = BLAS.asum(x)
+vecnorm2{T<:BlasFloat}(x::Union(Array{T},StridedVector{T})) = BLAS.nrm2(x)
 
 function triu!{T}(M::Matrix{T}, k::Integer)
     m, n = size(M)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -145,36 +145,40 @@ norm(x::AbstractVector, p::Real=2) = vecnorm(x, p)
 
 function norm1{T}(A::AbstractMatrix{T})
     m,n = size(A)
-    nrm = zero(real(zero(T)))
+    Tnorm = typeof(float(real(zero(T))))
+    Tsum = promote_type(Float64,Tnorm)
+    nrm::Tsum = 0
     @inbounds begin
         for j = 1:n
-            nrmj = zero(real(zero(T)))
+            nrmj::Tsum = 0
             for i = 1:m
                 nrmj += abs(A[i,j])
             end
             nrm = max(nrm,nrmj)
         end
     end
-    return nrm
+    return convert(Tnorm, nrm)
 end
-function norm2(A::AbstractMatrix)
+function norm2{T}(A::AbstractMatrix{T})
     m,n = size(A)
-    if m == 0 || n == 0 return real(zero(eltype(A))) end
-    svdvals(A)[1]
+    Tnorm = typeof(float(real(zero(T))))
+    (m == 0 || n == 0) ? zero(Tnorm) : convert(Tnorm, svdvals(A)[1])
 end
 function normInf{T}(A::AbstractMatrix{T})
     m,n = size(A)
-    nrm = zero(real(zero(T)))
+    Tnorm = typeof(float(real(zero(T))))
+    Tsum = promote_type(Float64,Tnorm)
+    nrm::Tsum = 0
     @inbounds begin
         for i = 1:m
-            nrmi = zero(real(zero(T)))
+            nrmi::Tsum = 0
             for j = 1:n
                 nrmi += abs(A[i,j])
             end
             nrm = max(nrm,nrmi)
         end
     end
-    return nrm
+    return convert(Tnorm, nrm)
 end
 function norm{T}(A::AbstractMatrix{T}, p::Real=2)
     p == 2 && return norm2(A)
@@ -183,11 +187,8 @@ function norm{T}(A::AbstractMatrix{T}, p::Real=2)
     throw(ArgumentError("invalid p-norm p=$p. Valid: 1, 2, Inf"))
 end
 
-function norm(x::Number, p=2)
-    if p == 1 || p == Inf || p == -Inf return abs(x) end
-    p == 0 && return ifelse(x != 0, 1, 0)
-    float(abs(x))
-end
+norm(x::Number, p::Real=2) =
+    p == 0 ? convert(typeof(real(x)), ifelse(x != 0, 1, 0)) : abs(x)
 
 rank(A::AbstractMatrix, tol::Real) = sum(svdvals(A) .> tol)
 function rank(A::AbstractMatrix)


### PR DESCRIPTION
 Continuing where JuliaLang/LinearAlgebra.jl#91 and JuliaLang/julia#6057 left off, this makes all the `norm` functions type stable, both internally and externally.

Previously, similar to JuliaLang/LinearAlgebra.jl#91, `norm(x, p)` was not type stable, in the sense that the norm of an integer matrix or scalar would return different types for different `p`.  It was also not internally type stable, in that the reduction loop would change the type of the accumulator variable if `typeof(zero(T)) != typeof(zero(T)+zero(T))`, similar to JuliaLang/julia#6069.

Now, all matrix norms return a floating-point result, and accumulations are performed in at least double precision, similar to `vecnorm`.  `norm(x::Number, p)` returns a value with the same type as `real(x)` or `abs(x)`, since adding the floating-point conversion there would have complicated the code for no useful purpose.

I also made one or two other code cleanups.  The `p` parameter is consistently declared to be `Real`, and the dense vector norms override `vecnorm1` and `vecnorm2` rather than `vecnorm` to exploit dispatch.
