### PR TITLE
RFC: More detailed messages for basic test macro

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -65,8 +65,8 @@ macro test(ex)
             $lhssym = nothing
             $rhssym = nothing
             try
-                $lhssym = $(ex.args[1])
-                $rhssym = $(ex.args[3])
+                $lhssym = $(esc(ex.args[1]))
+                $rhssym = $(esc(ex.args[3]))
             end
             do_test( ()->($(esc(ex))), $(Expr(:quote,ex)), $lhssym, $rhssym )
         end

--- a/base/test.jl
+++ b/base/test.jl
@@ -11,6 +11,7 @@ type Failure <: Result
     lhs
     rhs
 end
+Failure(expr) = Failure(expr, nothing, nothing)
 type Error <: Result
     expr
     err

--- a/base/test.jl
+++ b/base/test.jl
@@ -8,6 +8,8 @@ type Success <: Result
 end
 type Failure <: Result
     expr
+    lhs
+    rhs
 end
 type Error <: Result
     expr
@@ -16,7 +18,12 @@ type Error <: Result
 end
 
 default_handler(r::Success) = nothing
-default_handler(r::Failure) = error("test failed: $(r.expr)")
+function default_handler(r::Failure)
+    if r.lhs != nothing && r.rhs != nothing
+        error("test failed: $(r.expr) [$(r.lhs) $(r.expr.args[2]) $(r.rhs)]")
+    end
+    error("test failed: $(r.expr)")
+end
 default_handler(r::Error)   = rethrow(r)
 
 handler() = get(task_local_storage(), :TEST_HANDLER, default_handler)
@@ -32,9 +39,9 @@ function showerror(io::IO, r::Error, bt)
     showerror(io, r.err, r.backtrace)
 end
 
-function do_test(body,qex)
+function do_test(body,qex,lhs=nothing,rhs=nothing)
     handler()(try
-        body() ? Success(qex) : Failure(qex)
+        body() ? Success(qex) : Failure(qex,lhs,rhs)
     catch err
         Error(qex,err,catch_backtrace())
     end)
@@ -50,7 +57,21 @@ function do_test_throws(body,qex)
 end
 
 macro test(ex)
-    :(do_test(()->($(esc(ex))),$(Expr(:quote,ex))))
+    if ex.head == :comparison && length(ex.args) == 3
+        lhssym = gensym()
+        rhssym = gensym()
+        quote
+            $lhssym = nothing
+            $rhssym = nothing
+            try
+                $lhssym = $(ex.args[1])
+                $rhssym = $(ex.args[3])
+            end
+            do_test( ()->($(esc(ex))), $(Expr(:quote,ex)), $lhssym, $rhssym )
+        end
+    else
+        :(do_test(()->($(esc(ex))),$(Expr(:quote,ex))))
+    end
 end
 
 macro test_throws(ex)

--- a/base/test.jl
+++ b/base/test.jl
@@ -58,7 +58,7 @@ function do_test_throws(body,qex)
 end
 
 macro test(ex)
-    if ex.head == :comparison && length(ex.args) == 3
+    if typeof(ex) == Expr && ex.head == :comparison && length(ex.args) == 3
         lhssym = gensym()
         rhssym = gensym()
         quote


### PR DESCRIPTION
(improved/fixed version of https://github.com/JuliaLang/julia/pull/6094)

Perhaps we shouldn't be working on Base.Test and should really just have the @assert macro (to which this functionality could be added) and rely on packages for fancier testing. Having said that, given the fairly widespread usage of @test in both base Julia and many packages, I thought this might at least make things a little nicer for those of us using it.

I think the :comparison case, the simple function call, and the negation of a function call are the most common use cases I've seen. If this is a desirable patch in general, would love to hear of other useful cases that could be added.

Note that if the test fails because an error is thrown then this will not report on any part of the test that was capable of being evaluated - not that I think it really should try.

``` julia
mystery1() = 1
mystery5() = 5
@test mystery5() <= mystery1()
ERROR: test failed: mystery5() <= mystery1() [5 <= 1]
```
