### PR TITLE
Explicitly return nothing from runtests

### DIFF
--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -3,6 +3,7 @@ using Base.Test
 function runtests(name)
     println("     \033[1m*\033[0m \033[31m$(name)\033[0m")
     Core.include("$name.jl")
+    nothing
 end
 
 function propagate_errors(a,b)


### PR DESCRIPTION
runtests isn't expected to return anything meaningful, is it? I'm seeing the return type of the `numbers.jl` test causing a bizarre problem that I can't reproduce outside of AppVeyor. Compare [bad build](https://ci-beta.appveyor.com/project/tkelman/julia/build/1.0.204) to [better build - gets much further](https://ci-beta.appveyor.com/project/tkelman/julia/build/1.0.205). In the bad build, I had a few `println`s between the last few tests in `numbers.jl`, but none after the final test. In the good build, I only had a `println` on the last line. This oddly fixed an error

```
exception on 1: ERROR: type: subtype: expected Type{T<:Top}, got (ASCIIString,DataType)
while loading C:\projects\julia\test\runtests.jl, in expression starting on line 34
```
