### PR TITLE
Added eltype(itr::EachLine)

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -226,6 +226,11 @@ function done(itr::EachLine, nada)
     true
 end
 next(itr::EachLine, nada) = (readline(itr.stream), nothing)
+eltype(itr::EachLine) = String
+
+function readlines(s)
+    collect(eachline(s))
+end
 
 function readlines(s, fx::Function...)
     a = {}


### PR DESCRIPTION
The type returned from `readlines` is `Array{Any,1}`, and the `EachLine` iterator does not specify an element type. This PR attempts to fix those two issues.

There is still an issue with the way list comprehensions are used in `collect` that makes the inferred type from `readlines` [wider than necessary](https://gist.github.com/ivarne/b447e8fccc4b9f9cf47d) (`Union(Array{String,1},Array{Union(UTF8String,ASCIIString),N})`).

Not sure if that is an issue that should be reported elsewhere.
