### PR TITLE
WIP: Add methods: optional RNG argument to rand([rng], Array{...}) and r...

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -121,13 +121,14 @@ rand(::Type{Int128})  = int128(rand(Uint128))
 rand!(A::Array{Float64}) = dsfmt_gv_fill_array_close_open!(A)
 rand(::Type{Float64}, dims::Dims) = rand!(Array(Float64, dims))
 rand(::Type{Float64}, dims::Int...) = rand(Float64, dims)
+rand!(rng::MersenneTwister, A::Array{Float64}) = dsfmt_fill_array_close_open!(rng.state, A)
+rand(rng::AbstractRNG, ::Type{Float64}, dims::Dims) = rand!(rng, Array(Float64, dims))
+rand(rng::AbstractRNG, ::Type{Float64}, dims::Int...) = rand(rng, Float64, dims)
 
 rand(dims::Dims) = rand(Float64, dims)
 rand(dims::Int...) = rand(Float64, dims)
-
-rand!(r::MersenneTwister, A::Array{Float64}) = dsfmt_fill_array_close_open!(r.state, A)
-rand(r::AbstractRNG, dims::Dims) = rand!(r, Array(Float64, dims))
-rand(r::AbstractRNG, dims::Int...) = rand(r, dims)
+rand(rng::AbstractRNG, dims::Dims) = rand(rng, Float64, dims)
+rand(rng::AbstractRNG, dims::Int...) = rand(rng, Float64, dims)
 
 function rand!{T}(A::Array{T})
     for i=1:length(A)
@@ -138,6 +139,16 @@ end
 rand(T::Type, dims::Dims) = rand!(Array(T, dims))
 rand{T<:Number}(::Type{T}) = error("no random number generator for type $T; try a more specific type")
 rand{T<:Number}(::Type{T}, dims::Int...) = rand(T, dims)
+
+function rand!{T}(rng::AbstractRNG, A::Array{T})
+    for i=1:length(A)
+        A[i] = rand(rng, T)
+    end
+    A
+end
+rand(rng::AbstractRNG, T::Type, dims::Dims) = rand!(rng, Array(T, dims))
+rand{T<:Number}(rng::AbstractRNG, ::Type{T}) = error("no random number generator for type $T; try a more specific type")
+rand{T<:Number}(rng::AbstractRNG, ::Type{T}, dims::Int...) = rand(rng, T, dims)
 
 # Generate random integer within a range
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3411,11 +3411,11 @@ Random number generation in Julia uses the `Mersenne Twister library <http://www
 
    Populate the array A with random number generated from the specified RNG.
 
-.. function:: rand(rng::AbstractRNG, [dims...])
+.. function:: rand([rng], [dims...])
 
    Generate a random ``Float64`` number or array of the size specified by dims, using the specified RNG object. Currently, ``MersenneTwister`` is the only available Random Number Generator (RNG), which may be seeded using srand.
 
-.. function:: rand(dims or [dims...])
+.. function:: rand([rng], dims or [dims...])
 
    Generate a random ``Float64`` array of the size specified by dims
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -15,6 +15,15 @@
 # Try a seed larger than 2^32
 @test rand(MersenneTwister(5294967296)) == 0.3498809918210497
 
+z = zeros(1)
+rand!(MersenneTwister(42), z)
+@test z[1] == 0.5331830160438613
+@test rand(MersenneTwister(42), Float64, (1, 1))[1] == 0.5331830160438613
+@test rand(MersenneTwister(42), Float64, 1, 1)[1] == 0.5331830160438613
+@test rand(MersenneTwister(42), (1, 1))[1] == 0.5331830160438613
+@test rand(MersenneTwister(42), 1, 1)[1] == 0.5331830160438613
+@testfails rand(MersenneTwister(42), Uint64)
+
 for T in (Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64, Int128, Uint128, Char, BigInt,
 	Float16, Float32, Float64, Rational{Int})
     r = rand(convert(T, 97):convert(T, 122))


### PR DESCRIPTION
...and!([rng], Array{...}) that create arrays

For some reason, dsfmt_fill_array with state is not deterministic in my tests right now?
