### PR TITLE
Define isless for Method

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -1,5 +1,8 @@
 # Method and method-table pretty-printing
 
+# Allow sorting by function name
+isless(a::Method,b::Method) = isless(a.func.code.name,b.func.code.name)
+
 function argtype_decl(n, t) # -> (argname, argtype)
     if isa(n,Expr)
         n = n.args[1]  # handle n::T in arg list


### PR DESCRIPTION
This allows the user to sort the output of `methodswith` (for example) to make the result easier to scan through. It simply punts to isless on the function names.

It's very trivial, but it scratches an itch.
