### PR TITLE
Unicode identity matrix symbol

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -193,7 +193,7 @@ export
     γ, eulergamma,
     catalan,
     φ, golden,
-    I,
+    𝟙, I,
 
 # Operators
     !,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -149,7 +149,7 @@ export
     At_rdiv_Bt,
 
 # Constants
-    I
+    𝟙, I
 
 typealias BlasFloat Union(Float64,Float32,Complex128,Complex64)
 typealias BlasReal Union(Float64,Float32)

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -5,6 +5,7 @@ immutable UniformScaling{T<:Number} <: AbstractMatrix{T}
 end
 
 const I = UniformScaling(1)
+const 𝟙 = I
 
 getindex(J::UniformScaling, i::Integer,j::Integer) = ifelse(i==j,J.λ,zero(J.λ))
 


### PR DESCRIPTION
This adds a [double-struck 1](http://www.fileformat.info/info/unicode/char/1d7d9/index.htm) as an alternative to `I` for the constant representing the identity matrix. While this is obviously nice, and there are the precedents of `π`, `φ` etc., I can think of two possible reasons not to have it:
1. I may not be aware of a more appropriate Unicode symbol, this being the only suitable one I found browsing around
2. Github doesn't currently allow it in comments, which could in principle create minor hassles. At any rate, this is the reason why I didn't touch how UniformScaling matrices are shown.
