### PR TITLE
WIP: implement #= ... =# multiline comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,8 @@ New language features
     the module is first loaded, and on process startup if a pre-compiled
     version of the module is present ([#1268]).
 
+  * Multiline comments: `#= .... =#` ([#69], [#6128]).
+
 Library improvements
 --------------------
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -355,10 +355,29 @@
        (eq? (car t) 'macrocall)
        (memq (cadr t) '(@int128_str @uint128_str @bigint_str))))
 
+; skip to end of comment, starting at #:  either #...<eol> or #= .... =#.
+(define (skip-comment port)
+  (define (skip-multiline-comment port)
+    (let ((c (read-char port)))
+      (if (eof-object? c) 
+          (error "non-terminated multiline comment #= ... =#")
+          (begin (if (eqv? c #\=)
+                     (let ((c (peek-char port)))
+                       (if (eqv? c #\#)
+                           (read-char port)
+                           (skip-multiline-comment port)))
+                     (skip-multiline-comment port))))))
+
+  (read-char port) ; read # that was already peeked
+  (if (eqv? (peek-char port) #\=)
+      (begin (read-char port) ; read initial =
+             (skip-multiline-comment port))
+      (skip-to-eol port)))
+
 (define (skip-ws-and-comments port)
   (skip-ws port #t)
   (if (eqv? (peek-char port) #\#)
-      (begin (skip-to-eol port)
+      (begin (skip-comment port)
 	     (skip-ws-and-comments port)))
   #t)
 
@@ -371,7 +390,7 @@
 
 	  ((char-numeric? c)    (read-number port #f #f))
 
-	  ((eqv? c #\#)         (skip-to-eol port) (next-token port s))
+	  ((eqv? c #\#)         (skip-comment port) (next-token port s))
 
 	  ; . is difficult to handle; it could start a number or operator
 	  ((and (eqv? c #\.)


### PR DESCRIPTION
This fixes #69, implementing `#= ... =#` multiline comments.

~~(Several people had suggested `#= ... =#` instead, but `#{ ... }#` has the advantage of exploiting automatic editor brace matching out of the box.   Pascal forever!)~~ Changed to `#= .. =#` to make accidental multiline comments less likely (see below).

It doesn't interact nicely with the REPL yet, because the REPL doesn't realize that `#{ ...` means that it should wait for more input.  @loladiro, where is the end-of-input heuristic implemented in the REPL?

I haven't documented it yet, for the simple reason that comment syntax is not currently documented anywhere(!) in the Julia manual as far as I can tell, and I couldn't figure out what section it should go into.
