### PR TITLE
change package name regex in `Pkg.clone`

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -166,7 +166,7 @@ function clone(url_or_pkg::String)
         # TODO: Cache.prefetch(pkg,url)
     else
         url = url_or_pkg
-        m = match(r"/(\w+?)(?:\.jl)?(?:\.git)?$", url)
+        m = match(r"(\w+?)(?:\.jl)?(?:\.git)?$", url)
         m != nothing || error("can't determine package name from URL: $url")
         pkg = m.captures[1]
     end


### PR DESCRIPTION
Yesterday @tkelman was having problems running a `Pkg.clone` on a windows box ([here](https://github.com/JuliaLang/JSON.jl/pull/54)). I started poking at it and found this:

``` julia
julia> pwd()
"C:\\foo\\Bar.jl"

julia> Pkg.clone(pwd())
Error: can't determine package name from URL: C:\foo\Bar.jl
...
```

Looking at the regex changed here, it looks like there's a rather arbitrary "/" thrown in which prevents it from almost ever working on windows... After removal (and a little testing here: http://regex101.com/), as far as I can tell, old paths / urls still work and new ones without "/" do too.
