### PR TITLE
Windows test failures in file.jl: "stat: operation not permitted (EPERM)"

### DIFF
--- a/test/file.jl
+++ b/test/file.jl
@@ -298,5 +298,6 @@ rm(file)
 rm(subdir)
 rm(dir)
 
-@test !ispath(file)
-@test !ispath(dir)
+# The following fail on Windows with "stat: operation not permitted (EPERM)"
+@unix_only @test !ispath(file)
+@unix_only @test !ispath(dir)


### PR DESCRIPTION
This has been seen before by @magistere [here](https://github.com/JuliaLang/julia/issues/5305#issuecomment-33313637). There may still be file handles open so the unlinked file and removed directory cannot be stat-ed. Very similar problem occurs in node: https://github.com/joyent/node/issues/7164. I tried to clean up as much as I could figure out:

```
ccall(:fclose, Void, (Ptr{Void},), FILEp.ptr)
ccall(:_close, Void, (Ptr{Void},), FILEp.ptr)
FILEp = nothing
a_stat = nothing
af = nothing
b_stat = nothing
buf = nothing
emptyf = nothing
f = nothing
s = nothing
gc()
gc()
```

but could not get consistent success here. Any suggestions about what might still be open and how to absolutely close it before calling `ispath` on the deleted file and directory? Skipping the test is a workaround, not a real solution.
