### PR TITLE
Remove hard-coded Windows installation paths

### DIFF
--- a/contrib/windows/juliarc.jl
+++ b/contrib/windows/juliarc.jl
@@ -1,8 +1,5 @@
 let user_data_dir
-    ENV["PATH"] = JULIA_HOME*";"*joinpath(JULIA_HOME,"..","Git","bin")*";"*ENV["PATH"]*
-        ";C:\\Program Files\\Git\\bin;C:\\Program Files (x86)\\Git\\bin"*
-        ";C:\\MinGW\\bin;C:\\MinGW\\msys\\1.0\\bin"*
-        ";C:\\Python27;C:\\Python26;C:\\Python25"
+    ENV["PATH"] = JULIA_HOME*";"*joinpath(JULIA_HOME,"..","Git","bin")*";"*ENV["PATH"]
     haskey(ENV,"JULIA_EDITOR") || (ENV["JULIA_EDITOR"] = "start")
     user_data_dir = abspath(ENV["AppData"],"julia")
     isdir(user_data_dir) || mkdir(user_data_dir)


### PR DESCRIPTION
- For Git, shouldn't need to look in Program Files since Windows Julia bundles Git.
- MinGW is a build-time dependency, not a user dependency. These path additions were the only reason test/spawn.jl could ever execute successfully from a Windows command prompt (see for example https://github.com/JuliaLang/julia/issues/3548#issuecomment-36280804). This is a problem that can be addressed separately, and the solution should not rely on a hard-coded absolute path to MSYS1 (unless we start bundling our own MSYS in the Julia installer, in which case we'd use a relative path).
- Python should only be needed by packages, or at build time for LLVM. Wouldn't a better solution involve PYTHONPATH or PYTHONHOME, or manage this on a package level when Python is required?
