### PR TITLE
Fix error when filename is null

### DIFF
--- a/base/poll.jl
+++ b/base/poll.jl
@@ -267,7 +267,7 @@ function stop_watching(t::PollingFileWatcher)
 end
 
 function _uv_hook_fseventscb(t::FileMonitor,filename::Ptr,events::Int32,status::Int32)
-    fname = bytestring(convert(Ptr{Uint8},filename))
+    fname = filename == C_NULL ? "" : bytestring(convert(Ptr{Uint8},filename))
     fe = FileEvent(events)
     if isa(t.cb,Function)
         t.cb(fname, fe, status)


### PR DESCRIPTION
Seen occasionally on Windows when running test/file.jl

This has been reported before [here](https://github.com/JuliaLang/julia/issues/5305#issuecomment-33313637), and in older versions of this function anything involving the filename had been commented out for this same reason of it occasionally being null. I don't fully understand where this is coming from, so apologies if this change is detrimental in any way.
