### PR TITLE
correct handling of integer values for sinpi, as per IEEE-754 2008

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -49,19 +49,16 @@ function sinpi(x::Real)
         return nan(x)
     end
 
-    rx = float(rem(x,2))
+    rx = copysign(float(rem(x,2)),x)
     arx = abs(rx)
 
-    if arx == 0.0
-        # return -0.0 iff x == -0.0
-        return x == 0.0 ? x : arx
-    elseif arx < 0.25
+    if arx < 0.25
         return sin(pi*rx)
     elseif arx <= 0.75
         arx = 0.5 - arx
         return copysign(cos(pi*arx),rx)
     elseif arx < 1.25
-        rx = copysign(1.0,rx) - rx
+        rx = (1.0-arx)*copysign(1.0,rx)
         return sin(pi*rx)
     elseif arx <= 1.75
         arx = 1.5 - arx

--- a/base/math.jl
+++ b/base/math.jl
@@ -52,19 +52,19 @@ function sinpi(x::Real)
     rx = copysign(float(rem(x,2)),x)
     arx = abs(rx)
 
-    if arx < 0.25
+    if arx < oftype(rx,0.25)
         return sin(pi*rx)
-    elseif arx <= 0.75
-        arx = 0.5 - arx
+    elseif arx <= oftype(rx,0.75)
+        arx = oftype(rx,0.5) - arx
         return copysign(cos(pi*arx),rx)
-    elseif arx < 1.25
-        rx = (1.0-arx)*copysign(1.0,rx)
+    elseif arx < oftype(rx,1.25)
+        rx = (one(rx) - arx)*sign(rx)
         return sin(pi*rx)
-    elseif arx <= 1.75
-        arx = 1.5 - arx
+    elseif arx <= oftype(rx,1.75)
+        arx = oftype(rx,1.5) - arx
         return -copysign(cos(pi*arx),rx)
     else
-        rx = rx - copysign(2.0,rx)
+        rx = rx - copysign(oftype(rx,2.0),rx)
         return sin(pi*rx)
     end
 end
@@ -78,19 +78,19 @@ function cospi(x::Real)
 
     rx = abs(float(rem(x,2)))
 
-    if rx <= 0.25
+    if rx <= oftype(rx,0.25)
         return cos(pi*rx)
-    elseif rx < 0.75
-        rx = 0.5 - rx
+    elseif rx < oftype(rx,0.75)
+        rx = oftype(rx,0.5) - rx
         return sin(pi*rx)
-    elseif rx <= 1.25
-        rx = 1.0 - rx
+    elseif rx <= oftype(rx,1.25)
+        rx = one(rx) - rx
         return -cos(pi*rx)
-    elseif rx < 1.75
-        rx = rx - 1.5
+    elseif rx < oftype(rx,1.75)
+        rx = rx - oftype(rx,1.5)
         return sin(pi*rx)
     else
-        rx = 2.0 - rx
+        rx = oftype(rx,2.0) - rx
         return cos(pi*rx)
     end
 end
@@ -169,25 +169,22 @@ function sind(x::Real)
         return nan(x)
     end
 
-    rx = rem(x,360.0)
+    rx = copysign(float(rem(x,360)),x)
     arx = abs(rx)
 
-    if arx == 0.0
-        # return -0.0 iff x == -0.0
-        return x == 0.0 ? 0.0 : arx
-    elseif arx < 45.0
+    if arx < oftype(rx,45.0)
         return sin(deg2rad(rx))
-    elseif arx <= 135.0
-        arx = 90.0 - arx
+    elseif arx <= oftype(rx,135.0)
+        arx = oftype(rx,90.0) - arx
         return copysign(cos(deg2rad(arx)),rx)
-    elseif arx < 225.0
-        rx = copysign(180.0,rx) - rx
+    elseif arx < oftype(rx,225.0)
+        rx = (oftype(rx,180.0) - arx)*sign(rx)
         return sin(deg2rad(rx))
     elseif arx <= 315.0
-        arx = 270.0 - arx
+        arx = oftype(rx,270.0) - arx
         return -copysign(cos(deg2rad(arx)),rx)
     else
-        rx = rx - copysign(360.0,rx)
+        rx = rx - copysign(oftype(rx,360.0),rx)
         return sin(deg2rad(rx))
     end
 end
@@ -200,21 +197,21 @@ function cosd(x::Real)
         return nan(x)
     end
 
-    rx = abs(rem(x,360.0))
+    rx = abs(float(rem(x,360)))
 
-    if rx <= 45.0
+    if rx <= oftype(rx,45.0)
         return cos(deg2rad(rx))
-    elseif rx < 135.0
-        rx = 90.0 - rx
+    elseif rx < oftype(rx,135.0)
+        rx = oftype(rx,90.0) - rx
         return sin(deg2rad(rx))
-    elseif rx <= 225.0
-        rx = 180.0 - rx
+    elseif rx <= oftype(rx,225.0)
+        rx = oftype(rx,180.0) - rx
         return -cos(deg2rad(rx))
-    elseif rx < 315.0
-        rx = rx - 270.0
+    elseif rx < oftype(rx,315.0)
+        rx = rx - oftype(rx,270.0)
         return sin(deg2rad(rx))
     else
-        rx = 360.0 - rx
+        rx = oftype(rx,360.0) - rx
         return cos(deg2rad(rx))
     end
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -5,22 +5,24 @@
 @test exponent(12.8) == 3
 
 # degree-based trig functions
-for x = -400:40:400
-    @test_approx_eq_eps sind(x) sin(pi/180*x) eps(pi/180*x)
-    @test_approx_eq_eps cosd(x) cos(pi/180*x) eps(pi/180*x)
-end
-for x = 0.0:180:720
-    @test sind(x) === 0.0
-    @test sind(-x) === -0.0
-end
+for T = (Float32,Float64)
+    for x = -400:40:400
+        @test_approx_eq_eps sind(convert(T,x))::T convert(T,sin(pi/180*x)) eps(deg2rad(convert(T,x)))
+        @test_approx_eq_eps cosd(convert(T,x))::T convert(T,cos(pi/180*x)) eps(deg2rad(convert(T,x)))
+    end
+    for x = 0.0:180:720
+        @test sind(convert(T,x)) === zero(T)
+        @test sind(-convert(T,x)) === -zero(T)
+    end
 
-for x = -3:0.3:3
-    @test_approx_eq_eps sinpi(x) sin(pi*x) eps(pi*x)
-    @test_approx_eq_eps cospi(x) cos(pi*x) eps(pi*x)
-end
-for x = 0.0:1.0:4.0
-    @test sinpi(x) === 0.0
-    @test sinpi(-x) === -0.0
+    for x = -3:0.3:3
+        @test_approx_eq_eps sinpi(convert(T,x))::T convert(T,sin(pi*x)) eps(pi*convert(T,x))
+        @test_approx_eq_eps cospi(convert(T,x))::T convert(T,cos(pi*x)) eps(pi*convert(T,x))
+    end
+    for x = 0.0:1.0:4.0
+        @test sinpi(convert(T,x)) === zero(T)
+        @test sinpi(-convert(T,x)) === -zero(T)
+    end
 end
 
 # check type stability

--- a/test/math.jl
+++ b/test/math.jl
@@ -9,11 +9,21 @@ for x = -400:40:400
     @test_approx_eq_eps sind(x) sin(pi/180*x) eps(pi/180*x)
     @test_approx_eq_eps cosd(x) cos(pi/180*x) eps(pi/180*x)
 end
+for x = 0.0:180:720
+    @test sind(x) === 0.0
+    @test sind(-x) === -0.0
+end
 
 for x = -3:0.3:3
     @test_approx_eq_eps sinpi(x) sin(pi*x) eps(pi*x)
     @test_approx_eq_eps cospi(x) cos(pi*x) eps(pi*x)
 end
+for x = 0.0:1.0:4.0
+    @test sinpi(x) === 0.0
+    @test sinpi(-x) === -0.0
+end
+
+
 
 
 # error functions

--- a/test/math.jl
+++ b/test/math.jl
@@ -23,7 +23,12 @@ for x = 0.0:1.0:4.0
     @test sinpi(-x) === -0.0
 end
 
-
+# check type stability
+for T = (Float32,Float64,BigFloat)
+    for f = (sind,cosd,sinpi,cospi)
+        @test Base.return_types(f,(T,)) == [T]
+    end
+end
 
 
 # error functions


### PR DESCRIPTION
According to the [IEEE 754](http://ieeexplore.ieee.org/xpl/articleDetails.jsp?arnumber=4610935) standard, `sinpi(x) = -0.0` for negative-integer `x`, so that `sinpi(-x) == -sinpi(x)`.
