### PR TITLE
Ensure existence of the target directory in repackage_system_suitesparse4.make

### DIFF
--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -12,6 +12,7 @@ ifeq ($(USE_SYSTEM_BLAS),1)
 ifeq ($(USE_SYSTEM_LAPACK),0)
 
 $(build_libdir)/libgfortblas.dylib:
+	mkdir -p $(build_libdir)
 	make -C ../deps/ $(build_libdir)/libgfortblas.dylib
 
 default: $(build_libdir)/libgfortblas.dylib


### PR DESCRIPTION
Fixes #6039
