### PR TITLE
binomial no longer uses Float64 internally.

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -37,15 +37,17 @@ function binomial{T<:Integer}(n::T, k::T)
     if k > (n>>1)
         k = (n - k)
     end
-    x = nn = n - k + 1.0
-    nn += 1.0
-    rr = 2.0
+    x::T = nn = n - k + 1
+    nn += 1
+    rr = 2
     while rr <= k
-        x *= nn/rr
+        xt = div(widemul(x, nn), rr)
+        x = xt
+        x == xt || throw(OverflowError())
         rr += 1
         nn += 1
     end
-    sgn*iround(T,x)
+    convert(T, copysign(x, sgn))
 end
 
 ## other ordering related functions ##

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -28,3 +28,9 @@ for n = 0:7, k = 1:factorial(n)
     @test isperm(p)
     @test nthperm(p) == k
 end
+
+#Issue 6154
+@test binomial(int32(34), int32(15)) == binomial(BigInt(34), BigInt(15)) == 1855967520
+@test binomial(int64(67), int64(29)) == binomial(BigInt(67), BigInt(29)) == 7886597962249166160
+@test binomial(int128(131), int128(62)) == binomial(BigInt(131), BigInt(62)) == 157311720980559117816198361912717812000 
+


### PR DESCRIPTION
Replaces the old accumulation step, using `x=*(nn::Float64, rr::Float64)`,
with `x::T=div(widemul(x,nn), rr)` as suggested by @JeffBezanson.

Previously, `binomial(54,23)` computed the wrong answer. The new thresholds are:

| type | arguments | failure mode |
| --- | --- | --- |
| `Int32` | (34,16) | integer overflow (throws `OverflowError()`) |
| `Int64` | (67,29) | integer overflow (throws `OverflowError()`) |
| `Int128` | (131,63) | integer overflow (throws `OverflowError()`) |

Fix #6154.
