### PR TITLE
RFC: basic floating point exception functionality

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -14,7 +14,7 @@ errno_h.jl:
 	@$(call PRINT_PERL, echo '#include "errno.h"' | $(CPP) -dM - | perl -nle 'print "const $$1 = int32($$2)" if /^#define\s+(E\w+)\s+(\d+)\s*$$/' | sort > $@)
 
 fenv_constants.jl: ../src/fenv_constants.h
-	@$(PRINT_PERL) $(CPP) -P -DJULIA ../src/fenv_constants.h | tail -n 9 | perl -ple 's/\sFE_UN\w+/ 0x10/g; s/\sFE_O\w+/ 0x08/g; s/\sFE_DI\w+/ 0x04/g; s/\sFE_INV\w+/ 0x01/g; s/\sFE_TON\w+/ 0x00/g; s/\sFE_UP\w+/ 0x800/g; s/\sFE_DO\w+/ 0x400/g; s/\sFE_TOW\w+/ 0xc00/g' > $@
+	@$(PRINT_PERL) $(CPP) -P -DJULIA ../src/fenv_constants.h | tail -n 9 | perl -ple 's/\sFE_INE\w+/ 0x20/g; s/\sFE_UN\w+/ 0x10/g; s/\sFE_O\w+/ 0x08/g; s/\sFE_DI\w+/ 0x04/g; s/\sFE_INV\w+/ 0x01/g; s/\sFE_TON\w+/ 0x00/g; s/\sFE_UP\w+/ 0x800/g; s/\sFE_DO\w+/ 0x400/g; s/\sFE_TOW\w+/ 0xc00/g' > $@
 
 file_constants.jl: ../src/file_constants.h
 	@$(call PRINT_PERL, $(CPP) -P -DJULIA ../src/file_constants.h | perl -nle 'print "$$1 0o$$2" if /^(\s*const\s+[A-z_]+\s+=)\s+(0[0-9]*)\s*$$/; print "$$1" if /^\s*(const\s+[A-z_]+\s+=\s+([1-9]|0x)[0-9A-z]*)\s*$$/' > $@)

--- a/base/Makefile
+++ b/base/Makefile
@@ -14,7 +14,7 @@ errno_h.jl:
 	@$(call PRINT_PERL, echo '#include "errno.h"' | $(CPP) -dM - | perl -nle 'print "const $$1 = int32($$2)" if /^#define\s+(E\w+)\s+(\d+)\s*$$/' | sort > $@)
 
 fenv_constants.jl: ../src/fenv_constants.h
-	@$(PRINT_PERL) $(CPP) -P -DJULIA ../src/fenv_constants.h | tail -n 8 | perl -ple 's/\sFE_UN\w+/ 0x10/g; s/\sFE_O\w+/ 0x08/g; s/\sFE_DI\w+/ 0x04/g; s/\sFE_INV\w+/ 0x01/g; s/\sFE_TON\w+/ 0x00/g; s/\sFE_UP\w+/ 0x800/g; s/\sFE_DO\w+/ 0x400/g; s/\sFE_TOW\w+/ 0xc00/g' > $@
+	@$(PRINT_PERL) $(CPP) -P -DJULIA ../src/fenv_constants.h | tail -n 9 | perl -ple 's/\sFE_UN\w+/ 0x10/g; s/\sFE_O\w+/ 0x08/g; s/\sFE_DI\w+/ 0x04/g; s/\sFE_INV\w+/ 0x01/g; s/\sFE_TON\w+/ 0x00/g; s/\sFE_UP\w+/ 0x800/g; s/\sFE_DO\w+/ 0x400/g; s/\sFE_TOW\w+/ 0xc00/g' > $@
 
 file_constants.jl: ../src/file_constants.h
 	@$(call PRINT_PERL, $(CPP) -P -DJULIA ../src/file_constants.h | perl -nle 'print "$$1 0o$$2" if /^(\s*const\s+[A-z_]+\s+=)\s+(0[0-9]*)\s*$$/; print "$$1" if /^\s*(const\s+[A-z_]+\s+=\s+([1-9]|0x)[0-9A-z]*)\s*$$/' > $@)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -18,8 +18,8 @@ import
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, atan2,
         serialize, deserialize, inf, nan, hash, cbrt, typemax, typemin,
         realmin, realmax, get_rounding, set_rounding, maxintfloat, 
-        clear_floatexcept, is_floatexcept, FEUnderflow, FEOverflow, FEDivByZero,
-        FEInexact, FENaN, FERange
+        clear_floatexcept, is_floatexcept, raise_floatexcept,
+        FEUnderflow, FEOverflow, FEDivByZero, FEInexact, FENaN, FERange
 
 import Base.Math.lgamma_r
 
@@ -623,7 +623,7 @@ for (eJ,eC) in ((:FEUnderflow,:underflow),(:FEOverflow,:overflow),(:FEDivByZero,
     @eval begin
         is_floatexcept(::Type{BigFloat},::Type{$eJ}) = ccall(($(string(:mpfr_,eC,:_p)), :libmpfr),Cint,()) != zero(Cint)
         clear_floatexcept(::Type{BigFloat},::Type{$eJ}) = ccall(($(string(:mpfr_clear_,eC)), :libmpfr),None,())
-        #raise_floatexcept(::Type{BigFloat},::Type{$eJ}) = ccall(($(string(:mpfr_set_,eC)), :libmpfr),None,())
+        raise_floatexcept(::Type{BigFloat},::Type{$eJ}) = ccall(($(string(:mpfr_set_,eC)), :libmpfr),None,())
     end
 end
 clear_floatexcept(::Type{BigFloat}) = ccall((:mpfr_clear_flags, :libmpfr),None,())

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -59,4 +59,69 @@ function with_rounding{T}(f::Function, ::Type{T}, rounding::RoundingMode)
     end
 end
 
+
+## floating point exceptions ##
+import Base: show, in, convert
+
+export FloatExceptions, FEInexact, FEUnderflow, FEOverflow, FEDivByZero, FEInvalid, FloatExceptionSet, 
+FEAll, clear_floatexcept, get_floatexcept, is_floatexcept
+
+
+abstract FloatExceptions
+
+immutable FEInexact <: FloatExceptions end
+immutable FEUnderflow <: FloatExceptions end
+immutable FEOverflow <: FloatExceptions end
+immutable FEDivByZero <: FloatExceptions end
+immutable FEInvalid <: FloatExceptions end
+
+
+# IEEE 754 requires the ability to check/set/clear multiple exceptions
+immutable FloatExceptionSet
+    flags::Cint
+    FloatExceptionSet(e::Integer) = new(convert(Cint,e))
+end    
+
+convert(::Type{FloatExceptionSet},::Type{FEInexact}) = FloatExceptionSet(JL_FE_INEXACT)
+convert(::Type{FloatExceptionSet},::Type{FEUnderflow}) = FloatExceptionSet(JL_FE_UNDERFLOW)
+convert(::Type{FloatExceptionSet},::Type{FEOverflow}) = FloatExceptionSet(JL_FE_OVERFLOW)
+convert(::Type{FloatExceptionSet},::Type{FEDivByZero}) = FloatExceptionSet(JL_FE_DIVBYZERO)
+convert(::Type{FloatExceptionSet},::Type{FEInvalid}) = FloatExceptionSet(JL_FE_INVALID)
+
+const FEAll = FloatExceptionSet(JL_FE_INEXACT | JL_FE_UNDERFLOW | JL_FE_OVERFLOW | JL_FE_DIVBYZERO | JL_FE_INVALID)
+
+in(fs1::FloatExceptionSet,fs2::FloatExceptionSet) = fs1.flags & fs2.flags != zero(Cint)
+in{E<:FloatExceptions}(::Type{E},fs::FloatExceptionSet) = in(convert(FloatExceptionSet,E), fs)
+
+show(io::IO,fe::FloatExceptionSet) = showcompact(io, filter(x->in(x,fe),subtypes(FloatExceptions)))
+
+
+
+# IEEE754 2008 5.7.4 requires the following functions:
+# lowerFlags, raiseFlags, testFlags, testSavedFlags (handled by "in"), restoreFlags, saveAllFlags
+
+# lowerFlags
+function clear_floatexcept(f::FloatExceptionSet) 
+    if ccall(:feclearexcept, Cint, (Cint,), f.flags) != zero(Cint)
+        error("Could not clear floating point exception flag")
+    end
+end
+clear_floatexcept{E<:FloatExceptions}(::Type{E}) = clear_floatexcept(convert(FloatExceptionSet,E))
+clear_floatexcept() = clear_floatexcept(FEAll)
+
+function get_floatexcept(f::FloatExceptionSet)
+    FloatExceptionSet(ccall(:fetestexcept, Cint, (Cint,), f.flags))
+end
+# saveAllFlags
+get_floatexcept() = get_floatexcept(FEAll)
+
+# testFlags 
+is_floatexcept(f::FloatExceptionSet) = in(f,get_floatexcept(f))
+is_floatexcept{E<:FloatExceptions}(::Type{E}) = is_floatexcept(convert(FloatExceptionSet,E))
+is_floatexcept() = is_floatexcept(FEAll)
+
+# TODO: raiseFlags, restoreFlags
+
+
+
 end #module

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -65,7 +65,7 @@ end
 import Base: show, in, convert
 
 export FloatExceptions, FEInexact, FEUnderflow, FEOverflow, FEDivByZero, FEInvalid, 
-FENaN, FERange, FloatExceptionSet, FEAll, clear_floatexcept, get_floatexcept, is_floatexcept
+FENaN, FERange, FloatExceptionSet, FEAll, clear_floatexcept, get_floatexcept, is_floatexcept, raise_floatexcept
 
 
 abstract FloatExceptions
@@ -108,7 +108,7 @@ show(io::IO,fe::FloatExceptionSet) = showcompact(io, filter(x->in(x,fe),[IEEEExc
 # lowerFlags
 function clear_floatexcept{T<:IEEEFloat}(::Type{T},f::FloatExceptionSet) 
     if ccall(:feclearexcept, Cint, (Cint,), f.flags) != zero(Cint)
-        error("Could not clear floating point exception flag")
+        error("Could not clear floating point exception flags")
     end
 end
 clear_floatexcept{E<:FloatExceptions,T<:IEEEFloat}(::Type{T},::Type{E}) = clear_floatexcept(T,convert(FloatExceptionSet,E))
@@ -125,7 +125,15 @@ is_floatexcept{T<:IEEEFloat}(::Type{T},f::FloatExceptionSet) = in(f,get_floatexc
 is_floatexcept{E<:FloatExceptions,T<:IEEEFloat}(::Type{T},::Type{E}) = is_floatexcept(T,convert(FloatExceptionSet,E))
 is_floatexcept{T<:IEEEFloat}(::Type{T}) = is_floatexcept(T,FEAll)
 
-# TODO: raiseFlags, restoreFlags
+# raiseFlags
+function raise_floatexcept{T<:IEEEFloat}(::Type{T},f::FloatExceptionSet)
+    if ccall(:feraiseexcept, Cint, (Cint,), f.flags) != zero(Cint)
+        error("Could not raise floating point exception flags")
+    end
+end
+raise_floatexcept{E<:FloatExceptions,T<:IEEEFloat}(::Type{T},::Type{E}) = raise_floatexcept(T,convert(FloatExceptionSet,E))
+
+# TODO: restoreFlags
 
 
 

--- a/src/sys.c
+++ b/src/sys.c
@@ -24,6 +24,7 @@ char *dirname(char *);
 #include <libgen.h>
 #endif
 #include <fcntl.h>
+#include <fenv.h>
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
@@ -532,6 +533,10 @@ DLLEXPORT long jl_SC_CLK_TCK(void)
     return 0;
 #endif
 }
+
+// --- fenv ---
+DLLEXPORT int jl_sizeof_fenv_t (void) { return sizeof(fenv_t); }
+DLLEXPORT int jl_sizeof_fexcept_t (void) { return sizeof(fexcept_t); }
 
 // Dynamic Library interrogation
 

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -91,18 +91,32 @@ end
 
 ## Floating point exceptions
 using Base.Rounding
-clear_floatexcept()
-x = 1e-200 * 1e-200
-@test is_floatexcept(FEUnderflow)
+for T = [Float32,Float64,BigFloat]
+    clear_floatexcept(T)
+    x = realmin(T)
+    @test !is_floatexcept(T,FEUnderflow)
+    if T != BigFloat
+        y = x/2
+        @test !is_floatexcept(T,FEUnderflow) # exact should not raise underflow
+    end
+    y = x/3
+    @test is_floatexcept(T,FEUnderflow)
 
-clear_floatexcept()
-x = 1e200*1e200
-@test is_floatexcept(FEOverflow)
+    clear_floatexcept(T)
+    x = realmax(T)
+    @test !is_floatexcept(T,FEOverflow)
+    y = x*2
+    @test is_floatexcept(T,FEOverflow)
 
-clear_floatexcept()
-x = 1.0/0.0
-@test is_floatexcept(FEDivByZero)
+    clear_floatexcept(T)
+    @test !is_floatexcept(T,FEDivByZero)
+    y = one(T)/zero(T)
+    @test is_floatexcept(T,FEDivByZero)
 
-clear_floatexcept()
-x = Inf-Inf
-@test is_floatexcept(FEInvalid)
+    except = T == BigFloat ? FENaN : FEInvalid
+    clear_floatexcept(T)
+    x = inf(T)
+    @test !is_floatexcept(T,except)    
+    y = x-x
+    @test is_floatexcept(T,except)
+end

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -87,3 +87,22 @@ with_rounding(Float32,RoundDown) do
     @test a32 - b32 === -c32
     @test b32 - a32 === c32
 end
+
+
+## Floating point exceptions
+using Base.Rounding
+clear_floatexcept()
+x = 1e-200 * 1e-200
+@test is_floatexcept(FEUnderflow)
+
+clear_floatexcept()
+x = 1e200*1e200
+@test is_floatexcept(FEOverflow)
+
+clear_floatexcept()
+x = 1.0/0.0
+@test is_floatexcept(FEDivByZero)
+
+clear_floatexcept()
+x = Inf-Inf
+@test is_floatexcept(FEInvalid)

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -123,4 +123,11 @@ for T = [Float32,Float64,BigFloat]
     clear_floatexcept(T)
     raise_floatexcept(T,FEUnderflow)
     @test is_floatexcept(T,FEUnderflow)
+    if T != BigFloat
+        a = save_floatexcept(T,FEUnderflow)
+        clear_floatexcept(T)
+        @test !is_floatexcept(T,FEUnderflow)
+        restore_floatexcept(T,a,FEUnderflow)
+        @test is_floatexcept(T,FEUnderflow)
+    end
 end

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -119,4 +119,8 @@ for T = [Float32,Float64,BigFloat]
     @test !is_floatexcept(T,except)    
     y = x-x
     @test is_floatexcept(T,except)
+
+    clear_floatexcept(T)
+    raise_floatexcept(T,FEUnderflow)
+    @test is_floatexcept(T,FEUnderflow)
 end


### PR DESCRIPTION
This adds basic functionality for checking and clearing floating point exception flags (#2976). Usage is currently:

```
using Base.Rounding
get_floatexcept(Float64)
is_floatexcept(Float64,FEUnderflow)
```

Still to do:
- [ ] Settle on a consistent interface
- [x] Incorporate `BigFloat` flags: I've now added these, but the [exceptions don't exactly match the IEEE ones](http://www.mpfr.org/mpfr-3.1.2/mpfr.html#Exceptions)
- [x] A way to store and restore flags
- [ ] At the moment, almost every operation seems to flag `FEInexact` (input, printing, etc.), even for exact numbers (e.g. `x=1.0`): I'm not sure what the correct behaviour is here.

cc: @andrioni 
