### PR TITLE
Add `@showln`, to display expression values and also indicate position in code

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1305,6 +1305,7 @@ export
     @vectorize_1arg,
     @vectorize_2arg,
     @show,
+    @showln,
     @printf,
     @sprintf,
     @deprecate,

--- a/base/repl.jl
+++ b/base/repl.jl
@@ -182,3 +182,14 @@ function show_backtrace(io::IO, top_function::Symbol, t, set)
         show_trace_entry(io, lastname, lastfile, lastline, n)
     end
 end
+
+function show_backtrace1(bt)
+    for t in bt
+        lkup = ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Int32), t, 0)
+        if lkup != ()
+            fname, file, line = lkup
+            print("in ", fname, " at ", file, ", line ", line)
+            break
+        end
+    end
+end

--- a/base/show.jl
+++ b/base/show.jl
@@ -98,6 +98,10 @@ macro show(exs...)
     return blk
 end
 
+macro showln(exs...)
+    :(bt = backtrace(); @show $(esc(exs...)); print("  ("); show_backtrace1(bt); println(")"))
+end
+
 show(io::IO, tn::TypeName) = print(io, tn.name)
 show(io::IO, ::Nothing) = print(io, "nothing")
 show(io::IO, b::Bool) = print(io, b ? "true" : "false")


### PR DESCRIPTION
I've found this macro useful in my own work, particularly for tracking the value of a variable that changes during execution of a function.

```
function testme()
    x = 7
    @showln x
    x += 2
    @showln x
    x
end

julia> testme()
x => 7
  (in testme at /tmp/testme.jl, line 3)
x => 9
  (in testme at /tmp/testme.jl, line 5)
9
```

It would mean adding to exports, which means it needs to cross a "sufficiently useful" bar. I'm unsure myself, particularly since I'm hoping an integrated debugger will someday make this unnecessary. But I thought I'd share it and see what people think.
