### PR TITLE
Use similar instead of Array in array.jl

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -760,7 +760,7 @@ promote_array_type{S<:Integer}(::Type{S}, ::Type{Bool}) = S
 for f in (:+, :-, :div, :mod, :&, :|, :$)
     @eval begin
         function ($f){S,T}(A::StridedArray{S}, B::StridedArray{T})
-            F = Array(promote_type(S,T), promote_shape(size(A),size(B)))
+            F = similar(A, promote_type(S,T), promote_shape(size(A),size(B)))
             for i=1:length(A)
                 @inbounds F[i] = ($f)(A[i], B[i])
             end
@@ -768,7 +768,7 @@ for f in (:+, :-, :div, :mod, :&, :|, :$)
         end
         # interaction with Ranges
         function ($f){S,T<:Real}(A::StridedArray{S}, B::Ranges{T})
-            F = Array(promote_type(S,T), promote_shape(size(A),size(B)))
+            F = similar(A, promote_type(S,T), promote_shape(size(A),size(B)))
             i = 1
             for b in B
                 @inbounds F[i] = ($f)(A[i], b)
@@ -777,7 +777,7 @@ for f in (:+, :-, :div, :mod, :&, :|, :$)
             return F
         end
         function ($f){S<:Real,T}(A::Ranges{S}, B::StridedArray{T})
-            F = Array(promote_type(S,T), promote_shape(size(A),size(B)))
+            F = similar(B, promote_type(S,T), promote_shape(size(A),size(B)))
             i = 1
             for a in A
                 @inbounds F[i] = ($f)(a, B[i])
@@ -810,14 +810,14 @@ end
 for f in (:.+, :.-)
     @eval begin
         function ($f)(A::Bool, B::StridedArray{Bool})
-            F = Array(Int, size(B))
+            F = similar(B, Int, size(B))
             for i=1:length(B)
                 @inbounds F[i] = ($f)(A, B[i])
             end
             return F
         end
         function ($f)(A::StridedArray{Bool}, B::Bool)
-            F = Array(Int, size(A))
+            F = similar(A, Int, size(A))
             for i=1:length(A)
                 @inbounds F[i] = ($f)(A[i], B)
             end
@@ -828,7 +828,7 @@ end
 for f in (:+, :-)
     @eval begin
         function ($f)(A::StridedArray{Bool}, B::StridedArray{Bool})
-            F = Array(Int, promote_shape(size(A), size(B)))
+            F = similar(A, Int, promote_shape(size(A), size(B)))
             for i=1:length(A)
                 @inbounds F[i] = ($f)(A[i], B[i])
             end
@@ -1089,14 +1089,14 @@ function find(testf::Function, A::StridedArray)
             push!(tmpI, i)
         end
     end
-    I = Array(Int, length(tmpI))
+    I = similar(A, Int, length(tmpI))
     copy!(I, tmpI)
     I
 end
 
 function find(A::StridedArray)
     nnzA = countnz(A)
-    I = Array(Int, nnzA)
+    I = similar(A, Int, nnzA)
     count = 1
     for i=1:length(A)
         if A[i] != 0
@@ -1114,8 +1114,8 @@ findn(A::AbstractVector) = find(A)
 
 function findn(A::StridedMatrix)
     nnzA = countnz(A)
-    I = Array(Int, nnzA)
-    J = Array(Int, nnzA)
+    I = similar(A, Int, nnzA)
+    J = similar(A, Int, nnzA)
     count = 1
     for j=1:size(A,2), i=1:size(A,1)
         if A[i,j] != 0
@@ -1149,7 +1149,7 @@ end
 
 function nonzeros{T}(A::StridedArray{T})
     nnzA = countnz(A)
-    V = Array(T, nnzA)
+    V = similar(A, T, nnzA)
     count = 1
     if nnzA > 0
         for i=1:length(A)


### PR DESCRIPTION
Following up on #6167. There are some functions in `array.jl` that need this change as well.
