### PR TITLE
Restrict zero and one to Number types. Default to floating points.

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -42,6 +42,11 @@ reinterpret{T<:Real}(::Type{T}, x::Real) = box(T,x)
 
 map(f::Callable, x::Number) = f(x)
 
+zero(x::Number) = oftype(x,0.0)
+zero{T<:Number}(::Type{T}) = oftype(T,0.0)
+one(x::Number)  = oftype(x,1.0)
+one{T<:Number}(::Type{T}) = oftype(T,1.0)
+
 const _numeric_conversion_func_names =
     (:int,:integer,:signed,:int8,:int16,:int32,:int64,:int128,
      :uint,:unsigned,:uint8,:uint16,:uint32,:uint64,:uint128,

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -143,9 +143,6 @@ At_ldiv_Bt(a,b) = transpose(a)\transpose(b)
 oftype{T}(::Type{T},c) = convert(T,c)
 oftype{T}(x::T,c) = convert(T,c)
 
-zero(x) = oftype(x,0)
-one(x)  = oftype(x,1)
-
 widen{T<:Number}(x::T) = convert(widen(T), x)
 
 sizeof(T::Type) = error(string("size of type ",T," unknown"))

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -61,3 +61,8 @@ eltype{T}(::Ptr{T}) = T
 +(x::Ptr, y::Integer) = oftype(x, uint(uint(x) + y))
 -(x::Ptr, y::Integer) = oftype(x, uint(uint(x) - y))
 +(x::Integer, y::Ptr) = y + x
+
+zero{T}(::Type{Ptr{T}}) = convert(Ptr{T}, 0)
+zero{T}(x::Ptr{T}) = convert(Ptr{T}, 0)
+one{T}(::Type{Ptr{T}}) = convert(Ptr{T}, 1)
+one{T}(x::Ptr{T}) = convert(Ptr{T}, 1)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -105,6 +105,11 @@ typemax{T<:Integer}(::Type{Rational{T}}) = one(T)//zero(T)
 
 isinteger(x::Rational) = x.den == 1
 
+zero{T}(::Type{Rational{T}}) = zero(T)//one(T)
+zero{T}(q::Rational{T}) = zero(T)//one(T)
+one{T}(::Type{Rational{T}}) = one(T)//one(T)
+one{T}(q::Rational{T}) = one(T)//one(T)
+
 hash(x::Rational) = bitmix(hash(x.num), ~hash(x.den))
 
 -(x::Rational) = (-x.num) // x.den

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1575,7 +1575,7 @@ approx_eq(a, b) = approx_eq(a, b, 1e-6)
 for T in [Int,BigInt], n = [1:1000,1000000]
     n = convert(T,n)
     f = factor(n)
-    @test n == prod([p^k for (p,k)=f])
+    @test n == prod(T[p^k for (p,k)=f])
     prime = n!=1 && length(f)==1 && get(f,n,0)==1
     @test isprime(n) == prime
 

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -209,8 +209,8 @@ for i=1:2, a={[1 2 3], [1 2 3]', speye(3)}
 end
 
 # test for "access to undefined error" types that initially allocate elements as #undef
-@test all(sparse(1:2, 1:2, Any[1,2])^2 == sparse(1:2, 1:2, [1,4]))
-sd1 = diff(sparse([1,1,1], [1,2,3], Any[1,2,3]), 1)
+@test all(sparse(1:2, 1:2, Number[1,2])^2 == sparse(1:2, 1:2, [1,4]))
+sd1 = diff(sparse([1,1,1], [1,2,3], Number[1,2,3]), 1)
 
 # issue #6036
 P = spzeros(Float64, 3, 3)


### PR DESCRIPTION
There is some room for choosing the return type of e.g. `zero(Real)` and right now the default is `Int`. By using floating points instead the `InexactError` in #4796 could have been avoided. This pr also restricts `zero` and `one` such that `zero/one(Any)` is no longer defined. It is possible that this change will break some code with type inference problems, but maybe that is a good.
