### PR TITLE
add jl_is_nothing predicate

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -488,6 +488,7 @@ extern jl_sym_t *boundscheck_sym; extern jl_sym_t *copyast_sym;
 // basic predicates -----------------------------------------------------------
 
 #define jl_is_null(v)        (((jl_value_t*)(v)) == ((jl_value_t*)jl_null))
+#define jl_is_nothing(v)     (((jl_value_t*)(v)) == ((jl_value_t*)jl_nothing))
 #define jl_is_tuple(v)       jl_typeis(v,jl_tuple_type)
 #define jl_is_datatype(v)    jl_typeis(v,jl_datatype_type)
 #define jl_is_pointerfree(t) (((jl_datatype_t*)t)->pointerfree)


### PR DESCRIPTION
Julia C API is lacking in a predicate to check if a given value is
nothing or not. This commit includes the predicate in C macro.
