### PR TITLE
Add the ability to install test dependencies and run tests to Pkg

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -2,7 +2,7 @@ module Pkg
 
 export Git, Dir, GitHub, Types, Reqs, Cache, Read, Query, Resolve, Write, Generate, Entry
 export dir, init, rm, add, available, installed, status, clone, checkout,
-       release, fix, update, resolve, register, tag, publish, generate
+       release, fix, update, resolve, register, tag, publish, generate, test
 
 const DEFAULT_META = "git://github.com/JuliaLang/METADATA.jl"
 const META_BRANCH = "metadata-v2"
@@ -61,6 +61,10 @@ build(pkgs::String...) = cd(Entry.build,[pkgs...])
 
 generate(pkg::String, license::String; force::Bool=false) =
 	cd(Generate.package,pkg,license,force=force)
+
+
+test() = cd(Entry.test)
+test(pkgs::String...) = cd(Entry.test,String[pkgs...])
 
 @deprecate release free
 @deprecate fixup build

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -698,6 +698,7 @@ function test(pkgs::Vector{String})
     for pkg in pkgs
         test!(pkg,errs,notests)
     end
+    resolve()
     if !isempty(errs) || !isempty(notests)
         messages = String[]
         isempty(errs) || push!(messages, "$(join(errs,", "," and ")) had test errors")

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -690,6 +690,7 @@ function test!(pkg::String, errs::Vector{String}, notests::Vector{String})
     else
         push!(notests,pkg)
     end
+    resolve()
 end
 
 function test(pkgs::Vector{String})
@@ -698,7 +699,6 @@ function test(pkgs::Vector{String})
     for pkg in pkgs
         test!(pkg,errs,notests)
     end
-    resolve()
     if !isempty(errs) || !isempty(notests)
         messages = String[]
         isempty(errs) || push!(messages, "$(join(errs,", "," and ")) had test errors")

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -667,7 +667,7 @@ end
 @unix_only const JULIA = joinpath(JULIA_HOME, "julia-readline")
 
 function test!(pkg::String, errs::Vector{String}, notests::Vector{String})
-    const tests_require = Reqs.parse("$pkg/REQUIRE",true)
+    const tests_require = Reqs.parse("$pkg/REQUIRE",test=true)
     if (!isempty(tests_require))
         info("Computing test dependencies for $pkg...")
         resolve(tests_require)

--- a/base/pkg/reqs.jl
+++ b/base/pkg/reqs.jl
@@ -79,7 +79,7 @@ function write(io::IO, reqs::Requires)
 end
 write(file::String, r::Union(Vector{Line},Requires)) = open(io->write(io,r), file, "w")
 
-function parse(lines::Vector{Line}, test::Bool=false)
+function parse(lines::Vector{Line}; test::Bool=false)
     reqs = Requires()
     for line in lines
         if isa(line,Requirement)
@@ -102,7 +102,7 @@ function parse(lines::Vector{Line}, test::Bool=false)
     end
     return reqs
 end
-parse(x, test::Bool=false) = parse(read(x),test)
+parse(x; test::Bool=false) = parse(read(x);test=test)
 
 # add & rm – edit the content a requires file
 

--- a/base/pkg/reqs.jl
+++ b/base/pkg/reqs.jl
@@ -13,19 +13,12 @@ immutable Requirement <: Line
     package::String
     versions::VersionSet
     system::Vector{String}
-    test::Bool
 
     function Requirement(content::String)
-        test = false
         fields = split(replace(content, r"#.*$", ""))
         system = String[]
         while !isempty(fields) && fields[1][1] == '@'
-            sys = shift!(fields)[2:end]
-            if sys=="test"
-                test = true
-            else
-                push!(system, sys)
-            end
+            push!(system,shift!(fields)[2:end])
         end
         isempty(fields) && error("invalid requires entry: $content")
         package = shift!(fields)
@@ -33,7 +26,7 @@ immutable Requirement <: Line
             error("invalid requires entry for $package: $content")
         versions = [ convert(VersionNumber, field) for field in fields ]
         issorted(versions) || error("invalid requires entry for $package: $content")
-        new(content, package, VersionSet(versions), system, test)
+        new(content, package, VersionSet(versions), system)
     end
     function Requirement(package::String, versions::VersionSet, system::Vector{String}=String[])
         content = ""
@@ -79,7 +72,7 @@ function write(io::IO, reqs::Requires)
 end
 write(file::String, r::Union(Vector{Line},Requires)) = open(io->write(io,r), file, "w")
 
-function parse(lines::Vector{Line}; test::Bool=false)
+function parse(lines::Vector{Line})
     reqs = Requires()
     for line in lines
         if isa(line,Requirement)
@@ -95,14 +88,13 @@ function parse(lines::Vector{Line}; test::Bool=false)
                 @linux_only   applies &= !("!linux"   in line.system)
                 applies || continue
             end
-            (test==line.test) || continue
             reqs[line.package] = haskey(reqs, line.package) ?
                 intersect(reqs[line.package], line.versions) : line.versions
         end
     end
     return reqs
 end
-parse(x; test::Bool=false) = parse(read(x);test=test)
+parse(x) = parse(read(x))
 
 # add & rm – edit the content a requires file
 

--- a/doc/stdlib/pkg.rst
+++ b/doc/stdlib/pkg.rst
@@ -131,3 +131,11 @@ to use them, you'll need to prefix each function call with an explicit ``Pkg.``,
 
    For each new package version tagged in ``METADATA`` not already published, make sure that the tagged package commits have been pushed to the repo at the registered URL for the package and if they all have, push ``METADATA``.
 
+.. function:: test()
+
+   Run the tests for all installed packages ensuring that each package's test dependencies are installed for the duration of the test. A package is tested by running its ``test/runtests.jl`` file and test dependencies are specified in ``test/REQUIRE``.
+
+.. function:: test(pkgs...)
+
+   Run the tests for each package in ``pkgs`` ensuring that each package's test dependencies are installed for the duration of the test. A package is tested by running its ``test/runtests.jl`` file and test dependencies are specified in ``test/REQUIRE``.
+

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -1,5 +1,3 @@
-using Base.Test
-
 function temp_pkg_dir(fn::Function)
   # Used in tests below to setup and teardown a sandboxed package directory
   const tmpdir = ENV["JULIA_PKGDIR"] = abspath(string("tmp.",randstring()))

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -17,17 +17,17 @@ end
 
 # Test adding a removing a package
 temp_pkg_dir() do
-	@test isempty(Pkg.installed())
-	Pkg.add("Example")
-	@test [keys(Pkg.installed())...] == ["Example"]
-	Pkg.rm("Example")
-	@test isempty(Pkg.installed())
+  @test isempty(Pkg.installed())
+  Pkg.add("Example")
+  @test [keys(Pkg.installed())...] == ["Example"]
+  Pkg.rm("Example")
+  @test isempty(Pkg.installed())
 end
 
 # testing a package with test dependencies causes them to be installed for the duration of the test
 temp_pkg_dir() do
-	Pkg.generate("PackageWithTestDependencies", "MIT")
-	@test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
+  Pkg.generate("PackageWithTestDependencies", "MIT")
+  @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
 
   isdir(Pkg.dir("PackageWithTestDependencies","test")) || mkdir(Pkg.dir("PackageWithTestDependencies","test"))
   open(Pkg.dir("PackageWithTestDependencies","test","REQUIRE"),"w") do f
@@ -49,13 +49,13 @@ end
 
 # testing a package with no runtests.jl errors
 temp_pkg_dir() do
-	Pkg.generate("PackageWithNoTests", "MIT")
+  Pkg.generate("PackageWithNoTests", "MIT")
 
   if isfile(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
     rm(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
   end
 
-	try
+  try
     Pkg.test("PackageWithNoTests")
   catch err
     @test err.msg == "PackageWithNoTests did not provide a test/runtests.jl file"
@@ -64,15 +64,15 @@ end
 
 # testing a package with failing tests errors
 temp_pkg_dir() do
-	Pkg.generate("PackageWithFailingTests", "MIT")
+  Pkg.generate("PackageWithFailingTests", "MIT")
 
   isdir(Pkg.dir("PackageWithFailingTests","test")) || mkdir(Pkg.dir("PackageWithFailingTests","test"))
   open(Pkg.dir("PackageWithFailingTests", "test", "runtests.jl"),"w") do f
     println(f,"using Base.Test")
     println(f,"@test false")
   end
- 
-	try
+
+  try
     Pkg.test("PackageWithFailingTests")
   catch err
     @test err.msg == "PackageWithFailingTests had test errors"

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -1,15 +1,71 @@
-ENV["JULIA_PKGDIR"] = string("tmp.",randstring())
-@test !isdir(Pkg.dir())
-try # ensure directory removal
-	Pkg.init()
-	@test isdir(Pkg.dir())
-	Pkg.resolve()
+function temp_pkg_dir(fn::Function)
+  # Used in tests below to setup and teardown a sandboxed package directory
+  const tmpdir = ENV["JULIA_PKGDIR"] = string("tmp.",randstring())
+  @test !isdir(Pkg.dir())
+  try
+    Pkg.init()
+    @test isdir(Pkg.dir())
+    Pkg.resolve()
 
+    fn()
+  finally
+    run(`rm -rf $tmpdir`)
+  end
+end
+
+# Test adding a removing a package
+temp_pkg_dir() do
 	@test isempty(Pkg.installed())
 	Pkg.add("Example")
 	@test [keys(Pkg.installed())...] == ["Example"]
 	Pkg.rm("Example")
 	@test isempty(Pkg.installed())
-finally
-	run(`rm -rf $(Pkg.dir())`)
 end
+
+# testing a package with @test dependencies causes them to be installed
+temp_pkg_dir() do
+	Pkg.generate("PackageWithTestDependencies", "MIT")
+	@test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
+	
+  open(Pkg.dir("PackageWithTestDependencies","REQUIRE"),"a") do f
+    println(f,"@test Example")
+  end
+  
+  open(Pkg.dir("PackageWithTestDependencies","run_tests.jl"),"w") do f
+    println(f,"")
+  end
+ 
+  Pkg.resolve() 
+  @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
+	
+  Pkg.test("PackageWithTestDependencies")
+  @test sort([keys(Pkg.installed())...]) == sort(["PackageWithTestDependencies", "Example"])
+end
+
+# testing a package with no run_test.jl errors
+temp_pkg_dir() do
+	Pkg.generate("PackageWithNoTests", "MIT")
+	
+	try
+    Pkg.test("PackageWithNoTests")
+  catch err
+    @test err.msg == "PackageWithNoTests did not provide a run_test.jl file"
+  end
+end
+
+# testing a package with failing tests errors
+temp_pkg_dir() do
+	Pkg.generate("PackageWithFailingTests", "MIT")
+	
+  open(Pkg.dir("PackageWithFailingTests","run_tests.jl"),"w") do f
+    println(f,"using Base.Test")
+    println(f,"@test false")
+  end
+ 
+	try
+    Pkg.test("PackageWithFailingTests")
+  catch err
+    @test err.msg == "PackageWithFailingTests had test errors"
+  end
+end
+

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -29,8 +29,8 @@ temp_pkg_dir() do
 	Pkg.generate("PackageWithTestDependencies", "MIT")
 	@test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
 
-  mkdir(Pkg.dir("PackageWithTestDependencies","test"))
-  open(Pkg.dir("PackageWithTestDependencies","test","REQUIRE"),"a") do f
+  isdir(Pkg.dir("PackageWithTestDependencies","test")) || mkdir(Pkg.dir("PackageWithTestDependencies","test"))
+  open(Pkg.dir("PackageWithTestDependencies","test","REQUIRE"),"w") do f
     println(f,"Example")
   end
 
@@ -47,9 +47,13 @@ temp_pkg_dir() do
   @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
 end
 
-# testing a package with no run_test.jl errors
+# testing a package with no runtests.jl errors
 temp_pkg_dir() do
 	Pkg.generate("PackageWithNoTests", "MIT")
+
+  if isfile(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
+    rm(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
+  end
 
 	try
     Pkg.test("PackageWithNoTests")
@@ -62,7 +66,7 @@ end
 temp_pkg_dir() do
 	Pkg.generate("PackageWithFailingTests", "MIT")
 
-  mkdir(Pkg.dir("PackageWithFailingTests","test"))
+  isdir(Pkg.dir("PackageWithFailingTests","test")) || mkdir(Pkg.dir("PackageWithFailingTests","test"))
   open(Pkg.dir("PackageWithFailingTests", "test", "runtests.jl"),"w") do f
     println(f,"using Base.Test")
     println(f,"@test false")


### PR DESCRIPTION
`Pkg.test("PackageName")` will install a package's test dependencies
(marked with `@test` in the REQUIRES file) then run its tests. If the
tests fail or there is no run_tests.jl provided then an error is raised.
