### PR TITLE
Fix macro name for @sprintf errors

### DIFF
--- a/base/printf.jl
+++ b/base/printf.jl
@@ -751,21 +751,14 @@ is_str_expr(ex) =
     isa(ex,Expr) && (ex.head == :string || (ex.head == :macrocall && isa(ex.args[1],Symbol) &&
     endswith(string(ex.args[1]),"str")))
 
-function _printf(macroname, io, args)
-    if isempty(args) || !isa(args[1], String)
-        if !isempty(args) && is_str_expr(args[1])
-            error("$macroname: format must be a plain static string (no interpolation or prefix)")
-        else
-            error("$macroname: first or second argument must be a format string")
-        end
-    end
-    fmt = args[1]
+function _printf(macroname, io, fmt, args)
+    isa(fmt, String) || error("$macroname: format must be a plain static string (no interpolation or prefix)")
     sym_args, blk = gen(fmt)
-    if length(sym_args) != length(args)-1
+    if length(sym_args) != length(args)
         error("$macroname: wrong number of arguments")
     end
-    for i = length(args):-1:2
-        var = sym_args[i-1].args[1]
+    for i = length(args):-1:1
+        var = sym_args[i].args[1]
         unshift!(blk.args, :($var = $(esc(args[i]))))
     end
     unshift!(blk.args, :(out = $io))
@@ -775,15 +768,19 @@ end
 macro printf(args...)
     !isempty(args) || error("@printf: called with zero arguments")
     if isa(args[1], String) || is_str_expr(args[1])
-        _printf("@printf", :STDOUT, args)
+        _printf("@printf", :STDOUT, args[1], args[2:end])
     else
-        _printf("@printf", esc(args[1]), args[2:end])
+        (length(args) >= 2 && (isa(args[2], String) || is_str_expr(args[2]))) ||
+            error("@printf: first or second argument must be a format string")
+        _printf("@printf", esc(args[1]), args[2], args[3:end])
     end
 end
 
 macro sprintf(args...)
     !isempty(args) || error("@sprintf: called with zero arguments")
-    :(sprint(io->$(_printf("@sprintf", :io, args))))
+    isa(args[1], String) || is_str_expr(args[1]) || 
+        error("@sprintf: first argument must be a format string")
+    :(sprint(io->$(_printf("@sprintf", :io, args[1], args[2:end]))))
 end
 
 end # module


### PR DESCRIPTION
This is a bit pedantic, but before we'd get:

``` julia
julia> @sprintf "%d"
ERROR: @printf: wrong number of arguments
```
