### PR TITLE
Allow Julia to compile with current (pre-3.5) LLVM trunk 

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -60,7 +60,9 @@
 #include "llvm/Intrinsics.h"
 #include "llvm/Attributes.h"
 #endif
-#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 2 
+#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 5 
+#include "llvm/IR/DIBuilder.h"
+#elif defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 2 
 #include "llvm/DebugInfo.h"
 #include "llvm/DIBuilder.h"
 #ifndef LLVM33


### PR DESCRIPTION
This patch adjusts for some changes that LLVM introduced after LLVM 3.4.  The patch is _not_ claimed to make Julia fully functional with the current LLVM trunk.  It's just enough to enable Julia to compile with the current LLVM trunk, so that LLVM 3.5 issues can be explored, and reported back to the LLVM community if appropriate.

I don't understand why the include of `llvm/DebugInfo.h` seems to be no longer necessary.   In its place, the LLVM trunk has (using Julia paths):

```
deps/llvm-3.5/include/llvm/DebugInfo/DIContext.h  
deps/llvm-3.5/include/llvm/DebugInfo/DWARFFormValue.h
```
