### PR TITLE
install utf8proc.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,9 @@ else
 endif
 	$(INSTALL_F) $(build_includedir)/uv* $(DESTDIR)$(includedir)/julia
 endif
+ifeq ($(USE_SYSTEM_UTF8PROC),0)
+	$(INSTALL_F) $(build_includedir)/utf8proc.h $(DESTDIR)$(includedir)/julia
+endif
 	$(INSTALL_F) src/julia.h src/options.h src/support/*.h $(DESTDIR)$(includedir)/julia
 	# Copy system image
 	$(INSTALL_F) $(build_private_libdir)/sys.ji $(DESTDIR)$(private_libdir)


### PR DESCRIPTION
This is needed by `src/flisp/julia_extensions.c`, and would be useful to have included in the binary installs.

We're currently building a static library of `libutf8proc.a`, but not installing it. That could be added as well, thoughts? The header's about 15 kb, the static library more like 550-650 kb.

(Similar story for openlibm, the static library and some of its headers are used by base Julia but not getting installed.)
