### PR TITLE
Travis SVG badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </a>
 </div>
 
-[![Build Status](https://api.travis-ci.org/JuliaLang/julia.png?branch=master)](https://travis-ci.org/JuliaLang/julia)
+[![Build Status](https://api.travis-ci.org/JuliaLang/julia.svg?branch=master)](https://travis-ci.org/JuliaLang/julia)
 
 <a name="The-Julia-Language"/>
 ## The Julia Language

--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -110,7 +110,7 @@ function readme(pkg::String, user::String=""; force::Bool=false)
         println(io, "# $pkg")
         isempty(user) && return
         url = "https://travis-ci.org/$user/$pkg.jl"
-        println(io, "\n[![Build Status]($url.png)]($url)")
+        println(io, "\n[![Build Status]($url.svg)]($url)")
     end
 end
 


### PR DESCRIPTION
Travis now supports SVG badges. Use them in READMEs generated with Pkg.generate and in Julia's README

http://blog.travis-ci.com/2014-03-20-build-status-badges-support-svg/
