### PR TITLE
remove undefs from readdlm result. fixes #6247

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -98,7 +98,8 @@ function dlm_fill{T}(cells::Array{T,2}, offarr::Vector{Vector{Int}}, sbuff::Stri
     const tmp64 = Array(Float64,1)
 
     idx = 1
-    lastrow = lastcol = 1
+    lastrow = 1
+    lastcol = 0
     offidx = 1
     offsets = offarr[1]
     fail = false
@@ -144,15 +145,20 @@ function dlm_fill{T}(cells::Array{T,2}, offarr::Vector{Vector{Int}}, sbuff::Stri
         lastcol = col
     end
 
-    if lastcol < maxcol
-        for cidx in (lastcol+1):maxcol
-            if (T <: String) || (T == Any)
-                cells[lastrow,cidx] = SubString(sbuff, 1, 0)
-            elseif ((T <: Number) || (T <: Char)) && auto
-                return dlm_fill(Array(Any,maxrow,maxcol), offarr, sbuff, false, row_offset, eol)
-            else
-                error("missing value at row $lastrow column $cidx")
+    if (lastcol < maxcol) || (lastrow < maxrow)
+        while lastrow <= maxrow
+            (lastcol == maxcol) && (lastcol = 0; lastrow += 1)
+            for cidx in (lastcol+1):maxcol
+                if (T <: String) || (T == Any)
+                    cells[lastrow,cidx] = SubString(sbuff, 1, 0)
+                elseif ((T <: Number) || (T <: Char)) && auto
+                    return dlm_fill(Array(Any,maxrow,maxcol), offarr, sbuff, false, row_offset, eol)
+                else
+                    error("missing value at row $lastrow column $cidx")
+                end
             end
+            lastcol = maxcol
+            (lastrow == maxrow) && break;
         end
     end
     cells

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -52,6 +52,8 @@ let result1 = reshape({"abc", "hello", "def,ghi", " \"quote\" ", "new\nline", "w
     @test isequal(readdlm(IOBuffer("abc,\"def,ghi\",\"new\nline\"\n\"hello\",\" \"\"quote\"\" \",world"), ',', quotes=false), result2)
 end
 
+@test isequal(readcsv(IOBuffer("\n1,2,3\n4,5,6\n\n\n")), reshape({"",1.0,4.0,"","","",2.0,5.0,"","","",3.0,6.0,"",""}, 5, 3))
+
 let x = [1,2,3], y = [4,5,6], io = IOBuffer()
     writedlm(io, zip(x,y), ",  ")
     seek(io, 0)


### PR DESCRIPTION
They will be returned as empty strings.
Also added tests to capture this.
