### PR TITLE
Remove trailing whitespace in .travis.yml from Pkg.generate()

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -135,9 +135,9 @@ function travis(pkg::String; force::Bool=false)
         notifications:
           email: false
         env:
-          matrix: 
-            - JULIAVERSION="juliareleases" 
-            - JULIAVERSION="julianightlies" 
+          matrix:
+            - JULIAVERSION="juliareleases"
+            - JULIAVERSION="julianightlies"
         before_install:
           - sudo add-apt-repository ppa:staticfloat/julia-deps -y
           - sudo add-apt-repository ppa:staticfloat/\${JULIAVERSION} -y


### PR DESCRIPTION
My git diff command highlights trailing whitespace in my diffs in strong RED. `Pkg.generate()` puts trailing whitespace in 3 lines in `.travis.yml`, and there is no reason to do that.
