### PR TITLE
Doc: Integer promotions to native word size

### DIFF
--- a/doc/manual/conversion-and-promotion.rst
+++ b/doc/manual/conversion-and-promotion.rst
@@ -241,9 +241,10 @@ promotion is to convert numeric arguments to a common type:
     julia> promote(1 + 2im, 3//4)
     (1//1 + 2//1im,3//4 + 0//1im)
 
-Integer values are promoted to the largest type of the integer values.
-Floating-point values are promoted to largest of the floating-point
-types. Mixtures of integers and floating-point values are promoted to a
+Floating-point values are promoted to the largest of the floating-point
+argument types. Integer values are promoted to the larger of either the
+native machine word size or the largest integer argument type.
+Mixtures of integers and floating-point values are promoted to a
 floating-point type big enough to hold all the values. Integers mixed
 with rationals are promoted to rationals. Rationals mixed with floats
 are promoted to floats. Complex values mixed with real values are


### PR DESCRIPTION
Make the text here a little more precise about using native machine sizes for integer promotions. Also swap the order with floating point so the easier case is described first.
