### PR TITLE
Potential type instability for integer promotions?

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -367,6 +367,10 @@ end
 const WORD_SIZE = int(Int.size)*8
 
 ## integer promotions ##
+promote(x::SmallSigned) = (int(x),)
+promote(x::SmallUnsigned) = (uint(x),)
+promote_typeof(x::SmallSigned) = Int
+promote_typeof(x::SmallUnsigned) = Uint
 
 promote_rule(::Type{Int16},  ::Type{Int8} ) = Int
 promote_rule(::Type{Int32},  ::Type{Int8} ) = Int


### PR DESCRIPTION
In changing the documentation for #6254, I realized that even the more complicated description of integer promotion is incorrect because `promote(x) = (x,)`.  While I haven't experienced this myself in real code, I think the current behavior here is surprising, particularly when calling promote with a splatted variable-length iterable. This PR adds specialized methods for promote with one SmallSigned/SmallUnsigned argument so the behavior matches the documentation.

With this PR, `typeof(promote(uint8(3))) == (Uint,)`
