### PR TITLE
RFC: Add julia ldlt factorization and solver for SymTridiagonal and julia lu factorization for Tridiagonal

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -620,6 +620,8 @@ export
     istril,
     istriu,
     kron,
+    ldltfact,
+    ldltfact!,
     linreg,
     logdet,
     lu,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -24,7 +24,7 @@ export
     Hessenberg,
     LU,
     LUTridiagonal,
-    LDLTTridiagonal,
+    LDLt,
     QR,
     QRPivoted,
     Schur,
@@ -78,8 +78,8 @@ export
     istril,
     istriu,
     kron,
-    ldltd!,
-    ldltd,
+    ldltfact!,
+    ldltfact,
     linreg,
     logdet,
     lu,
@@ -196,13 +196,14 @@ include("linalg/matmul.jl")
 include("linalg/lapack.jl")
 
 include("linalg/dense.jl")
+include("linalg/tridiag.jl")
 include("linalg/factorization.jl")
+include("linalg/lu.jl")
 
 include("linalg/bunchkaufman.jl")
 include("linalg/triangular.jl")
 include("linalg/symmetric.jl")
 include("linalg/woodbury.jl")
-include("linalg/tridiag.jl")
 include("linalg/diagonal.jl")
 include("linalg/bidiag.jl")
 include("linalg/uniformscaling.jl")
@@ -210,6 +211,7 @@ include("linalg/rectfullpacked.jl")
 include("linalg/givens.jl")
 include("linalg/special.jl")
 include("linalg/bitarray.jl")
+include("linalg/ldlt.jl")
 
 include("linalg/sparse.jl")
 include("linalg/umfpack.jl")

--- a/base/linalg/bunchkaufman.jl
+++ b/base/linalg/bunchkaufman.jl
@@ -22,6 +22,8 @@ bkfact{T<:BlasFloat}(A::StridedMatrix{T}, uplo::Symbol=:U, symmetric::Bool=issym
 bkfact{T}(A::StridedMatrix{T}, uplo::Symbol=:U, symmetric::Bool=issym(A)) = bkfact!(convert(Matrix{promote_type(Float32,typeof(sqrt(one(T))))},A),uplo,symmetric)
 
 convert{T}(::Type{BunchKaufman{T}},B::BunchKaufman) = BunchKaufman(convert(Matrix{T},B.LD),B.ipiv,B.uplo,B.symmetric)
+convert{T}(::Type{Factorization{T}}, B::BunchKaufman) = convert(BunchKaufman{T}, B)
+
 size(B::BunchKaufman) = size(B.LD)
 size(B::BunchKaufman,d::Integer) = size(B.LD,d)
 issym(B::BunchKaufman) = B.symmetric

--- a/base/linalg/cholmod.jl
+++ b/base/linalg/cholmod.jl
@@ -18,7 +18,7 @@ import Base: (*), convert, copy, ctranspose, eltype, findnz, getindex, hcat,
 
 import ..LinAlg: (\), A_mul_Bc, A_mul_Bt, Ac_ldiv_B, Ac_mul_B, At_ldiv_B, At_mul_B,
                  cholfact, cholfact!, copy, det, diag,
-                 full, logdet, norm, scale, scale!, solve, sparse
+                 full, logdet, norm, scale, scale!, sparse
 
 include("cholmod_h.jl")
 

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -1,11 +1,20 @@
 ## Diagonal matrices
 
-type Diagonal{T} <: AbstractMatrix{T}
+immutable Diagonal{T} <: AbstractMatrix{T}
     diag::Vector{T}
 end
 Diagonal(A::Matrix) = Diagonal(diag(A))
 
-convert{T<:Number,S<:Number}(::Type{Diagonal{T}}, A::Diagonal{S}) = T == S ? A : Diagonal(convert(Vector{T}, A.diag))
+convert{T}(::Type{Diagonal{T}}, D::Diagonal{T}) = D
+convert{T}(::Type{Diagonal{T}}, D::Diagonal) = Diagonal{T}(convert(Vector{T}, D.diag))
+convert{T}(::Type{AbstractMatrix{T}}, D::Diagonal) = convert(Diagonal{T}, D)
+
+function similar{T}(D::Diagonal, ::Type{T}, d::(Int,Int))
+    d[1] == d[2] || throw(ArgumentError("Diagonal matrix must be square"))
+    return Diagonal{T}(Array(T,d[1]))
+end
+
+copy!(D1::Diagonal, D2::Diagonal) = (copy!(D1.diag, D2.diag); D1)
 
 size(D::Diagonal) = (length(D.diag),length(D.diag))
 size(D::Diagonal,d::Integer) = d<1 ? error("dimension out of range") : (d<=2 ? length(D.diag) : 1)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -213,9 +213,9 @@ trace(x::Number) = x
 inv(a::AbstractVector) = error("argument must be a square matrix")
 inv{T}(A::AbstractMatrix{T}) = A_ldiv_B!(A,eye(T, chksquare(A)))
 
-function \{TA,TB}(A::AbstractMatrix{TA}, B::AbstractVecOrMat{TB})
+function \{TA,TB,N}(A::AbstractMatrix{TA}, B::AbstractArray{TB,N})
     TC = typeof(one(TA)/one(TB))
-    A_ldiv_B!(convert(typeof(A).name.primary{TC}, A), TB == TC ? copy(B) : convert(typeof(B).name.primary{TC}, B))
+    A_ldiv_B!(TA == TC ? copy(A) : convert(AbstractMatrix{TC}, A), TB == TC ? copy(B) : convert(AbstractArray{TC,N}, B))
 end
 \(a::AbstractVector, b::AbstractArray) = reshape(a, length(a), 1) \ b
 /(A::AbstractVecOrMat, B::AbstractVecOrMat) = (B' \ A')'

--- a/base/linalg/ldlt.jl
+++ b/base/linalg/ldlt.jl
@@ -1,0 +1,54 @@
+immutable LDLt{T,S<:AbstractMatrix{T}} <: Factorization{T}
+    data::S
+end
+
+size(S::LDLt) = size(S.data)
+size(S::LDLt, i::Integer) = size(S.data, i)
+
+convert{T,S}(::Type{LDLt{T,S}}, F::LDLt) = LDLt{T,S}(convert(S, F.data))
+convert{T,S,U}(::Type{LDLt{T}}, F::LDLt{S,U}) = convert(LDLt{T,U}, F)
+convert{T,S,U}(::Type{Factorization{T}}, F::LDLt{S,U}) = convert(LDLt{T,U}, F)
+
+# SymTridiagonal
+function ldltfact!{T<:Real}(S::SymTridiagonal{T})
+	n = size(S,1)
+	d = S.dv
+	e = S.ev
+	@inbounds for i = 1:n-1
+		e[i] /= d[i]
+		d[i+1] -= abs2(e[i])*d[i]
+		d[i+1] > 0 || throw(PosDefException(i+1))
+	end
+	return LDLt{T,SymTridiagonal{T}}(S)
+end
+function ldltfact{T}(M::SymTridiagonal{T})
+	S = typeof(one(T)/one(T))
+	return S == T ? ldltfact!(copy(M)) : ldltfact!(convert(SymTridiagonal{S}, M))
+end
+function A_ldiv_B!{T}(S::LDLt{T,SymTridiagonal{T}}, B::AbstractVecOrMat{T})
+	n, nrhs = size(B, 1), size(B, 2)
+	size(S,1) == n || throw(DimensionMismatch(""))
+	d = S.data.dv
+	l = S.data.ev
+	@inbounds begin
+		for i = 2:n
+			li1 = l[i-1]
+			for j = 1:nrhs
+				B[i,j] -= li1*B[i-1,j]
+			end
+		end
+		dn = d[n]
+		for j = 1:nrhs
+			B[n,j] /= dn
+		end
+		for i = n-1:-1:1
+			di = d[i]
+			li = l[i]
+			for j = 1:nrhs
+				B[i,j] /= di
+				B[i,j] -= li*B[i+1,j]
+			end
+		end
+	end
+	return B
+end

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -1,0 +1,313 @@
+####################
+# LU Factorization #
+####################
+immutable LU{T,S<:AbstractMatrix{T}} <: Factorization{T}
+    factors::S
+    ipiv::Vector{BlasInt}
+    info::BlasInt
+end
+
+# StridedMatrix
+function lufact!{T<:BlasFloat}(A::StridedMatrix{T}; pivot = true)
+    !pivot && return generic_lufact!(A, pivot=pivot)
+    lpt = LAPACK.getrf!(A)
+    return LU{T,typeof(A)}(lpt[1], lpt[2], lpt[3])
+end
+lufact!(A::StridedMatrix; pivot = true) = generic_lufact!(A, pivot=pivot)
+function generic_lufact!{T}(A::StridedMatrix{T}; pivot = true)
+    m, n = size(A)
+    minmn = min(m,n)
+    info = 0
+    ipiv = Array(BlasInt, minmn)
+    @inbounds begin
+        for k = 1:minmn
+            # find index max
+            kp = k
+            if pivot
+                amax = real(zero(T))
+                for i = k:m
+                    absi = abs(A[i,k])
+                    if absi > amax
+                        kp = i
+                        amax = absi
+                    end
+                end
+            end
+            ipiv[k] = kp
+            if A[kp,k] != 0
+                if k != kp
+                    # Interchange
+                    for i = 1:n
+                        tmp = A[k,i]
+                        A[k,i] = A[kp,i]
+                        A[kp,i] = tmp
+                    end
+                end
+                # Scale first column
+                Akkinv = inv(A[k,k])
+                for i = k+1:m
+                    A[i,k] *= Akkinv
+                end
+            elseif info == 0
+                info = k
+            end
+            # Update the rest
+            for j = k+1:n
+                for i = k+1:m
+                    A[i,j] -= A[i,k]*A[k,j]
+                end
+            end        
+        end
+    end
+    LU{T,typeof(A)}(A, ipiv, convert(BlasInt, info))
+end
+lufact{T<:BlasFloat}(A::AbstractMatrix{T}; pivot = true) = lufact!(copy(A), pivot=pivot)
+lufact{T}(A::AbstractMatrix{T}; pivot = true) = (S = typeof(one(T)/one(T)); S != T ? lufact!(convert(AbstractMatrix{S}, A), pivot=pivot) : lufact!(copy(A), pivot=pivot))
+lufact(x::Number) = LU(fill(x, 1, 1), BlasInt[1], x == 0 ? one(BlasInt) : zero(BlasInt))
+
+function lu(A::Union(Number, AbstractMatrix))
+    F = lufact(A)
+    F[:L], F[:U], F[:p]
+end
+
+function convert{T}(::Type{LU{T}}, F::LU)
+    M = convert(AbstractMatrix{T}, F.factors)
+    LU{T,typeof(M)}(M, F.ipiv, F.info)
+end    
+convert{T,S}(::Type{LU{T,S}}, F::LU) = LU{T,S}(convert(S, F.factors), F.ipiv, F.info)
+convert{T}(::Type{Factorization{T}}, F::LU) = convert(LU{T}, F)
+
+
+size(A::LU) = size(A.factors)
+size(A::LU,n) = size(A.factors,n)
+
+function ipiv2perm{T}(v::AbstractVector{T}, maxi::Integer)
+    p = T[1:maxi]
+    @inbounds for i in 1:length(v)
+        p[i], p[v[i]] = p[v[i]], p[i]
+    end
+    return p
+end
+
+function getindex{T,S<:StridedMatrix}(A::LU{T,S}, d::Symbol)
+    m, n = size(A)
+    d == :L && return tril(A.factors[1:m, 1:min(m,n)], -1) + eye(T, m, min(m,n))
+    d == :U && return triu(A.factors[1:min(m,n),1:n])
+    d == :p && return ipiv2perm(A.ipiv, m)
+    if d == :P
+        p = A[:p]
+        P = zeros(T, m, m)
+        for i in 1:m
+            P[i,p[i]] = one(T)
+        end
+        return P
+    end
+    throw(KeyError(d))
+end
+
+A_ldiv_B!{T<:BlasFloat, S<:StridedMatrix}(A::LU{T, S}, B::StridedVecOrMat{T}) = @assertnonsingular LAPACK.getrs!('N', A.factors, A.ipiv, B) A.info
+A_ldiv_B!{T,S<:StridedMatrix}(A::LU{T,S}, b::StridedVector) = A_ldiv_B!(Triangular(A.factors, :U, false), A_ldiv_B!(Triangular(A.factors, :L, true), b[ipiv2perm(A.ipiv, length(b))]))
+A_ldiv_B!{T,S<:StridedMatrix}(A::LU{T,S}, B::StridedMatrix) = A_ldiv_B!(Triangular(A.factors, :U, false), A_ldiv_B!(Triangular(A.factors, :L, true), B[ipiv2perm(A.ipiv, size(B, 1)),:]))
+At_ldiv_B{T<:BlasFloat,S<:StridedMatrix}(A::LU{T,S}, B::StridedVecOrMat{T}) = @assertnonsingular LAPACK.getrs!('T', A.factors, A.ipiv, copy(B)) A.info
+Ac_ldiv_B{T<:BlasComplex,S<:StridedMatrix}(A::LU{T,S}, B::StridedVecOrMat{T}) = @assertnonsingular LAPACK.getrs!('C', A.factors, A.ipiv, copy(B)) A.info
+At_ldiv_Bt{T<:BlasFloat,S<:StridedMatrix}(A::LU{T,S}, B::StridedVecOrMat{T}) = @assertnonsingular LAPACK.getrs!('T', A.factors, A.ipiv, transpose(B)) A.info
+Ac_ldiv_Bc{T<:BlasComplex,S<:StridedMatrix}(A::LU{T,S}, B::StridedVecOrMat{T}) = @assertnonsingular LAPACK.getrs!('C', A.factors, A.ipiv, ctranspose(B)) A.info
+
+function det{T,S}(A::LU{T,S})
+    n = chksquare(A)
+    A.info > 0 && return zero(typeof(A.factors[1]))
+    return prod(diag(A.factors)) * (bool(sum(A.ipiv .!= 1:n) % 2) ? -one(T) : one(T))
+end
+
+function logdet2{T<:Real,S}(A::LU{T,S})  # return log(abs(det)) and sign(det)
+    n = chksquare(A)
+    dg = diag(A.factors)
+    s = (bool(sum(A.ipiv .!= 1:n) % 2) ? -one(T) : one(T)) * prod(sign(dg))
+    sum(log(abs(dg))), s 
+end
+
+function logdet{T<:Real,S}(A::LU{T,S})
+    d,s = logdet2(A)
+    s>=0 || error("DomainError: determinant is negative")
+    d
+end
+
+function logdet{T<:Complex,S}(A::LU{T,S})
+    n = chksquare(A)
+    s = sum(log(diag(A.factors))) + (bool(sum(A.ipiv .!= 1:n) % 2) ? complex(0,pi) : 0) 
+    r, a = reim(s)
+    a = pi-mod(pi-a,2pi) #Take principal branch with argument (-pi,pi] 
+    complex(r,a)    
+end
+
+inv{T<:BlasFloat}(A::LU{T,StridedMatrix{T}}) = @assertnonsingular LAPACK.getri!(copy(A.factors), A.ipiv) A.info
+
+cond{T<:BlasFloat}(A::LU{T,StridedMatrix{T}}, p::Number) = inv(LAPACK.gecon!(p == 1 ? '1' : 'I', A.factors, norm(A[:L][A[:p],:]*A[:U], p)))
+cond(A::LU, p::Number) = norm(A[:L]*A[:U],p)*norm(inv(A),p)
+
+# Tridiagonal
+
+# See dgttrf.f
+function lufact!{T}(A::Tridiagonal{T}; pivot = true)
+    n = size(A, 1)
+    info = 0
+    ipiv = Array(BlasInt, n)
+    dl = A.dl
+    d = A.d
+    du = A.du
+    du2 = A.du2
+
+    @inbounds begin
+        for i = 1:n
+            ipiv[i] = i
+        end
+        for i = 1:n-2
+            # pivot or not?
+            if !pivot || abs(d[i]) >= abs(dl[i])
+                # No interchange
+                if d[i] != 0
+                    fact = dl[i]/d[i]
+                    dl[i] = fact
+                    d[i+1] -= fact*du[i]
+                    du2[i] = 0
+                end
+            else
+                # Interchange
+                fact = d[i]/dl[i]
+                d[i] = dl[i]
+                dl[i] = fact
+                tmp = du[i]
+                du[i] = d[i+1]
+                d[i+1] = tmp - fact*d[i+1]
+                du2[i] = du[i+1]
+                du[i+1] = -fact*du[i+1]
+                ipiv[i] = i+1
+            end
+        end
+        if n > 1
+            i = n-1
+            if !pivot || abs(d[i]) >= abs(dl[i])
+                if d[i] != 0
+                    fact = dl[i]/d[i]
+                    dl[i] = fact
+                    d[i+1] -= fact*du[i]
+                end
+            else
+                fact = d[i]/dl[i]
+                d[i] = dl[i]
+                dl[i] = fact
+                tmp = du[i]
+                du[i] = d[i+1]
+                d[i+1] = tmp - fact*d[i+1]
+                ipiv[i] = i+1
+            end
+        end
+        # check for a zero on the diagonal of U
+        for i = 1:n
+            if d[i] == 0
+                info = i
+                break
+            end
+        end
+    end
+    LU{T,Tridiagonal{T}}(A, ipiv, convert(BlasInt, info))
+end
+factorize(A::Tridiagonal) = lufact(A)
+
+# See dgtts2.f
+function A_ldiv_B!{T}(A::LU{T,Tridiagonal{T}}, B::AbstractVecOrMat)
+    n = size(A,1)
+    n == size(B,1) || throw(DimentionsMismatch(""))
+    nrhs = size(B,2)
+    dl = A.factors.dl
+    d = A.factors.d
+    du = A.factors.du
+    du2 = A.factors.du2
+    ipiv = A.ipiv
+    @inbounds begin
+        for j = 1:nrhs
+            for i = 1:n-1
+                ip = ipiv[i]
+                tmp = B[i+1-ip+i,j] - dl[i]*B[ip,j]
+                B[i,j] = B[ip,j]
+                B[i+1,j] = tmp
+            end
+            B[n,j] /= d[n]
+            if n > 1
+                B[n-1,j] = (B[n-1,j] - du[n-1]*B[n,j])/d[n-1]
+            end
+            for i = n-2:-1:1
+                B[i,j] = (B[i,j] - du[i]*B[i+1,j] - du2[i]*B[i+2,j])/d[i]
+            end
+        end
+    end
+    return B
+end
+
+function At_ldiv_B!{T}(A::LU{T,Tridiagonal{T}}, B::AbstractVecOrMat)
+    n = size(A,1)
+    n == size(B,1) || throw(DimentionsMismatch(""))
+    nrhs = size(B,2)
+    dl = A.factors.dl
+    d = A.factors.d
+    du = A.factors.du
+    du2 = A.factors.du2
+    ipiv = A.ipiv
+    @inbounds begin
+        for j = 1:nrhs
+            B[1,j] /= d[1]
+            if n > 1
+                B[2,j] = (B[2,j] - du[1]*B[1,j])/d[2]
+            end
+            for i = 3:n
+                B[i,j] = (B[i,j] - du[i-1]*B[i-1,j] - du2[i-2]*B[i-2,j])/d[i]
+            end
+            for i = n-1:-1:1
+                if ipiv[i] == i
+                    B[i,j] = B[i,j] - dl[i]*B[i+1,j]
+                else
+                    tmp = B[i+1,j]
+                    B[i+1,j] = B[i,j] - dl[i]*tmp
+                    B[i,j] = tmp
+                end
+            end
+        end
+    end
+    return B
+end
+
+# Ac_ldiv_B!{T<:Real}(A::LU{T,Tridiagonal{T}}, B::AbstractVecOrMat) = At_ldiv_B!(A,B)
+function Ac_ldiv_B!{T}(A::LU{T,Tridiagonal{T}}, B::AbstractVecOrMat)
+    n = size(A,1)
+    n == size(B,1) || throw(DimentionsMismatch(""))
+    nrhs = size(B,2)
+    dl = A.factors.dl
+    d = A.factors.d
+    du = A.factors.du
+    du2 = A.factors.du2
+    ipiv = A.ipiv
+    @inbounds begin
+        for j = 1:nrhs
+            B[1,j] /= conj(d[1])
+            if n > 1
+                B[2,j] = (B[2,j] - conj(du[1])*B[1,j])/conj(d[2])
+            end
+            for i = 3:n
+                B[i,j] = (B[i,j] - conj(du[i-1])*B[i-1,j] - conj(du2[i-2])*B[i-2,j])/conj(d[i])
+            end
+            for i = n-1:-1:1
+                if ipiv[i] == i
+                    B[i,j] = B[i,j] - conj(dl[i])*B[i+1,j]
+                else
+                    tmp = B[i+1,j]
+                    B[i+1,j] = B[i,j] - conj(dl[i])*tmp
+                    B[i,j] = tmp
+                end
+            end
+        end
+    end
+    return B
+end
+
+/(B::AbstractMatrix,A::LU) = At_ldiv_Bt(A,B).'
+

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -16,7 +16,9 @@ getindex(A::HermOrSym, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? ge
 full(A::Symmetric) = copytri!(A.S, A.uplo)
 full(A::Hermitian) = copytri!(A.S, A.uplo, true)
 convert{T}(::Type{Symmetric{T}},A::Symmetric) = Symmetric(convert(Matrix{T},A.S),A.uplo)
+convert{T}(::Type{AbstractMatrix{T}}, A::Symmetric) = convert(Symmetric{T}, A)
 convert{T}(::Type{Hermitian{T}},A::Hermitian) = Hermitian(convert(Matrix{T},A.S),A.uplo)
+convert{T}(::Type{AbstractMatrix{T}}, A::Hermitian) = convert(Hermitian{T}, A)
 copy(A::Symmetric) = Symmetric(copy(A.S),A.uplo)
 copy(A::Hermitian) = Hermitian(copy(A.S),A.uplo)
 ishermitian(A::Hermitian) = true
@@ -38,13 +40,13 @@ factorize(A::HermOrSym) = bkfact(A.S, symbol(A.uplo), issym(A))
 eigfact!{T<:BlasReal}(A::Symmetric{T}) = Eigen(LAPACK.syevr!('V', 'A', A.uplo, A.S, 0.0, 0.0, 0, 0, -1.0)...)
 eigfact!{T<:BlasComplex}(A::Hermitian{T}) = Eigen(LAPACK.syevr!('V', 'A', A.uplo, A.S, 0.0, 0.0, 0, 0, -1.0)...)
 eigfact{T<:BlasFloat}(A::HermOrSym{T}) = eigfact!(copy(A))
-eigfact{T}(A::HermOrSym{T}) = (S = promote_type(Float32,typeof(one(T)/norm(one(T)))); S != T ? eigfact!(convert(typeof(A).name.primary{S}, A)) : eigfact!(copy(A)))
+eigfact{T}(A::HermOrSym{T}) = (S = promote_type(Float32,typeof(one(T)/norm(one(T)))); S != T ? eigfact!(convert(AbstractMatrix{S}, A)) : eigfact!(copy(A)))
 eigvals!{T<:BlasReal}(A::Symmetric{T}, il::Int=1, ih::Int=size(A,1)) = LAPACK.syevr!('N', 'I', A.uplo, A.S, 0.0, 0.0, il, ih, -1.0)[1]
 eigvals!{T<:BlasReal}(A::Symmetric{T}, vl::Real, vh::Real) = LAPACK.syevr!('N', 'V', A.uplo, A.S, vl, vh, 0, 0, -1.0)[1]
 eigvals!{T<:BlasComplex}(A::Hermitian{T}, il::Int=1, ih::Int=size(A,1)) = LAPACK.syevr!('N', 'I', A.uplo, A.S, 0.0, 0.0, il, ih, -1.0)[1]
 eigvals!{T<:BlasComplex}(A::Hermitian{T}, vl::Real, vh::Real) = LAPACK.syevr!('N', 'V', A.uplo, A.S, vl, vh, 0, 0, -1.0)[1]
 eigvals{T<:BlasFloat}(A::HermOrSym{T},l::Real=1,h::Real=size(A,1)) = eigvals!(copy(A),l,h)
-eigvals{T}(A::HermOrSym{T},l::Real=1,h::Real=size(A,1)) = (S = promote_type(Float32,typeof(one(T)/norm(one(T)))); S != T ? eigvals!(convert(typeof(A).name.primary{S}, A, l, h)) : eigvals!(copy(A), l, h))
+eigvals{T}(A::HermOrSym{T},l::Real=1,h::Real=size(A,1)) = (S = promote_type(Float32,typeof(one(T)/norm(one(T)))); S != T ? eigvals!(convert(AbstractMatrix{S}, A, l, h)) : eigvals!(copy(A), l, h))
 eigmax(A::HermOrSym) = eigvals(A, size(A, 1), size(A, 1))[1]
 eigmin(A::HermOrSym) = eigvals(A, 1, 1)[1]
 

--- a/base/linalg/umfpack.jl
+++ b/base/linalg/umfpack.jl
@@ -8,7 +8,7 @@ export UmfpackLU,
 
 import Base: (\), Ac_ldiv_B, At_ldiv_B, findnz, getindex, show, size
 
-import ..LinAlg: A_ldiv_B!, Ac_ldiv_B!, At_ldiv_B!, Factorization, det, lufact, lufact!, solve
+import ..LinAlg: A_ldiv_B!, Ac_ldiv_B!, At_ldiv_B!, Factorization, det, lufact, lufact!
 
 include("umfpack_h.jl")
 type MatrixIllConditionedException <: Exception

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -162,7 +162,7 @@ function convert{Tv,Ti}(::Type{SparseMatrixCSC{Tv,Ti}}, M::Matrix)
                              convert(Vector{Tv},V), 
                              m, n)
 end
-
+convert{T}(::Type{AbstractMatrix{T}}, A::SparseMatrixCSC) = convert(SparseMatrixCSC{T}, A)
 convert(::Type{Matrix}, S::SparseMatrixCSC) = full(S)
 
 function full{Tv}(S::SparseMatrixCSC{Tv})

--- a/test/suitesparse.jl
+++ b/test/suitesparse.jl
@@ -149,7 +149,7 @@ afiro = CholmodSparse!(int32([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,
                         -1.0,2.279,1.4,-1.0,1.0,-1.0,1.0,1.0,1.0], 27, 51, 0)
 chmaf = cholfact(afiro)
 y = afiro'*ones(size(afiro,1))
-sol = Base.solve(chmaf, afiro*y) # least squares solution
+sol = chmaf\(afiro*y) # least squares solution
 @test isvalid(sol)
 pred = afiro'*sol
 @test norm(afiro * (y.mat - pred.mat)) < 1e-8


### PR DESCRIPTION
@alanedelman suggested Julia implementation for factorizations of `SymTridiagonal`s. I have followed LAPACK and used ldlt for `SymTridiagonal` because it doesn't require allocation. I also wrote a solver for the factorization and removed the calls to LAPACK.

For `Tridiagonal`, I translated the lu from LAPACK to Julia since I didn't dare to open a pull request with a version without pivoting. To do so, I have changed the `Tridiagonal` type to only have one extra vector allocation. This is required for the pivoting. This also caused some cleanup of the tridiagonal code. I have changed all `solve` methods to `A_ldiv_B` to be consistent with the rest of `Base`. If anyone uses the `Tridiagonal` code please have a look and test.

A style innovation that I would like some comments on is that I have parametrized lu and ldlt on matrix type. In consequence there is only one lu type definition because it works for ordinary matrices as well as tridiagonals. This change also makes it possible to use array views in factorizations. I would like to extend this innovation to the other special matrices such that e.g. `Triangular` can be any `AbstractMatrix`.

Finally, I Implement `convert(AbstractArray,x)` and `convert(Factorization,x)` methods as proposed by @JeffBezanson in #6078. I get the same type of warnings `could not show value of type Tuple`. @JeffBezanson can you figure out what is wrong?

cc: @jiahao 
