### PR TITLE
Fix: #6279

### DIFF
--- a/base/.gitignore
+++ b/base/.gitignore
@@ -5,4 +5,5 @@
 /file_constants.jl
 /uv_constants.jl
 /version_git.jl
+/version_git.jl.phony
 /userimg.jl


### PR DESCRIPTION
Added `/version_git.jl.phony` to `base/.gitignore` so that the mark for dirty build becomes correct.
Thanks to @johngrogan
