### PR TITLE
Help people get started with Julia on Google Compute Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,24 @@ If the `gcc44` and `gfortran44` packages are installed, you can specify their us
 
 Otherwise, install or contact your systems administrator to install a more recent version of `gcc`.
 
+#### Google Compute Engine
+
+Google Compute Engine is evolving rapidly, as is Julia.  This section is current as of March 2014 and assumes working knowledge of Google Cloud Services.
+
+These instructions currently cover only the Debian image currently available on Google Compute Engine.  There are only two things you need to do:
+
+1. Do `apt-get install` for the following packages on your build instance:
+
+* bzip2
+* gcc
+* gfortran
+* g++
+* make
+* m4
+* ncurses-dev
+
+2. As of Julia pre-0.3, you will need to edit `deps/Versions.make` to select `OPENBLAS_VER = v0.2.9.rc2` to build on Google's Sandybridge cores. (Alternatively, you could fall back to the Nehelem architecture via a `make` option, but that would entail performance penalties.)
+
 #### Linux Build Troubleshooting
 
  Problem              | Possible Solution

--- a/README.md
+++ b/README.md
@@ -122,17 +122,14 @@ Google Compute Engine is evolving rapidly, as is Julia.  This section is current
 
 These instructions currently cover only the Debian image currently available on Google Compute Engine.  There are only two things you need to do:
 
-1. Do `apt-get install` for the following packages on your build instance:
-
-* bzip2
-* gcc
-* gfortran
-* g++
-* make
-* m4
-* ncurses-dev
+1. Install packages required to build on your instance:
+  ```
+  apt-get install bzip2 gcc gfortran git g++ make m4 ncurses-dev
+  ```
 
 2. As of Julia pre-0.3, you will need to edit `deps/Versions.make` to select `OPENBLAS_VER = v0.2.9.rc2` to build on Google's Sandybridge cores. (Alternatively, you could fall back to the Nehelem architecture via a `make` option, but that would entail performance penalties.)
+
+Now you should be able to build using the generic Linux instructions above. These instructions were tested on a `g1-small` instance on 2014-03-28.
 
 #### Linux Build Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ These notes apply to the Debian 7 image currently available on Google Compute En
   apt-get install bzip2 gcc gfortran git g++ make m4 ncurses-dev
   ```
 
-2. Edit `deps/Versions.make` in the julia source tree to select `OPENBLAS_VER = v0.2.9.rc2`. This picks up changes to support Google's Sandybridge cores. (Alternatively, you could fall back to the Nehelem architecture via a `make` option, but that would entail performance penalties.)
+2. Edit `deps/Versions.make` in the julia source tree to select `OPENBLAS_VER = v0.2.9.rc2`. This picks up changes to support the Sandybridge cores used by Google Compute Engine. (Alternatively, you could fall back to the Nehelem architecture via a `make` option, but that would entail performance penalties.)
 
 Now you should be able to build using the generic Linux instructions. These instructions were tested on a `g1-small` instance on 2014-03-28. Other resources include [information on Google Compute Engine](https://cloud.google.com/products/compute-engine/) and a series of [tutorials by Julia Ferraioli](http://www.blog.juliaferraioli.com/2013/12/julia-on-google-compute-engine.html).
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ These notes apply to the Debian 7 image currently available on Google Compute En
   apt-get install bzip2 gcc gfortran git g++ make m4 ncurses-dev
   ```
 
-2. Edit `deps/Versions.make` in the julia source tree to select `OPENBLAS_VER = v0.2.9.rc2`. This picks up changes to support the Sandybridge cores used by Google Compute Engine. (Alternatively, you could fall back to the Nehelem architecture via a `make` option, but that would entail performance penalties.)
+2. Now clone `JuliaLang:master` and edit `deps/Versions.make` to select `OPENBLAS_VER = v0.2.9.rc2`. This picks up changes to support the Sandybridge cores used by Google Compute Engine. (Alternatively, you could fall back to the Nehelem architecture via a `make` option, but that would entail performance penalties.)
 
 Now you should be able to build using the generic Linux instructions. These instructions were tested on a `g1-small` instance on 2014-03-28. Other resources include [information on Google Compute Engine](https://cloud.google.com/products/compute-engine/) and a series of [tutorials by Julia Ferraioli](http://www.blog.juliaferraioli.com/2013/12/julia-on-google-compute-engine.html).
 

--- a/README.md
+++ b/README.md
@@ -120,16 +120,16 @@ Otherwise, install or contact your systems administrator to install a more recen
 
 Google Compute Engine is evolving rapidly, as is Julia.  This section is current as of March 2014 and assumes working knowledge of Google Cloud Services.
 
-These instructions currently cover only the Debian image currently available on Google Compute Engine.  There are only two things you need to do:
+These notes apply to the Debian 7 image currently available on Google Compute Engine and Julia pre-0.3.  There are only two things you need to do:
 
 1. Install packages required to build on your instance:
   ```
   apt-get install bzip2 gcc gfortran git g++ make m4 ncurses-dev
   ```
 
-2. As of Julia pre-0.3, you will need to edit `deps/Versions.make` to select `OPENBLAS_VER = v0.2.9.rc2` to build on Google's Sandybridge cores. (Alternatively, you could fall back to the Nehelem architecture via a `make` option, but that would entail performance penalties.)
+2. Edit `deps/Versions.make` in the julia source tree to select `OPENBLAS_VER = v0.2.9.rc2`. This picks up changes to support Google's Sandybridge cores. (Alternatively, you could fall back to the Nehelem architecture via a `make` option, but that would entail performance penalties.)
 
-Now you should be able to build using the generic Linux instructions above. These instructions were tested on a `g1-small` instance on 2014-03-28.
+Now you should be able to build using the generic Linux instructions. These instructions were tested on a `g1-small` instance on 2014-03-28. Other resources include [information on Google Compute Engine](https://cloud.google.com/products/compute-engine/) and a series of [tutorials by Julia Ferraioli](http://www.blog.juliaferraioli.com/2013/12/julia-on-google-compute-engine.html).
 
 #### Linux Build Troubleshooting
 


### PR DESCRIPTION
Why? Because it's hip to be embarrassingly parallel, and Google offers lots of cores for cheap to us poor, misguided saps who traded our university accounts for salaries.

What this is: a stop-gap until Julia HEAD builds cleanly on a stock GCE image.

What this is not: a tutorial on GCE.
