### PR TITLE
Fixes 40 ms wait time on consecutive network calls - linux only

### DIFF
--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -885,6 +885,19 @@ DLLEXPORT int jl_connect_raw(uv_tcp_t *handle,struct sockaddr_storage *addr)
     return uv_tcp_connect(req,handle,(struct sockaddr*)addr,&jl_uv_connectcb);
 }
 
+#ifdef _OS_LINUX_
+DLLEXPORT int jl_tcp_quickack(uv_tcp_t *handle, int on)
+{
+    int fd = (handle)->io_watcher.fd;
+    if (fd != -1) {
+        if (setsockopt(fd, IPPROTO_TCP, TCP_QUICKACK, &on, sizeof(on))) {
+            return -1;
+        }
+    }
+  return 0;
+}
+#endif
+
 DLLEXPORT char *jl_ios_buf_base(ios_t *ios)
 {
     return ios->buf;


### PR DESCRIPTION
Fixes #45 and #6287, at least on my machine.

```
julia> tic();for i=1:1000;fetch(remotecall(2,+,1,1));end;toc()
elapsed time: 0.490795733 seconds
0.490795733
julia> tic();for i=1:1000;remotecall_fetch(2,+,1,1);end;toc()
elapsed time: 0.209214712 seconds
0.209214712
```

I had to disable both Nagle and set QUICKACK.

@carlobaldassi, could you check with this patch?
