### PR TITLE
fix bounds checking of findnext

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1321,7 +1321,7 @@ end
 
 # returns the index of the next non-zero element, or 0 if all zeros
 function findnext(B::BitArray, start::Integer)
-    if start < 0
+    if start <= 0
         throw(BoundsError())
     elseif start > length(B)
         return 0
@@ -1349,7 +1349,7 @@ end
 
 # aux function: same as findnext(~B, start), but performed without temporaries
 function findnextnot(B::BitArray, start::Integer)
-    if start < 0
+    if start <= 0
         throw(BoundsError())
     elseif start > length(B)
         return 0


### PR DESCRIPTION
`findnext(randn(10) .< 0.0, 0)` causes segmentation fault bacause
the start index 0 is out of bounds.
