### PR TITLE
do not quote in writedlm when called from print.

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -302,22 +302,24 @@ readcsv(io; opts...)          = readdlm(io, ','; opts...)
 readcsv(io, T::Type; opts...) = readdlm(io, ',', T; opts...)
 
 # todo: keyword argument for # of digits to print
-writedlm_cell(io::IO, elt::FloatingPoint, dlm) = print_shortest(io, elt)
-function writedlm_cell{T}(io::IO, elt::String, dlm::T)
-    if !isempty(elt) && (('"' == elt[1]) || ('\n' in elt) || ((T <: Char) ? (dlm in elt) : contains(elt, dlm)))
+writedlm_cell(io::IO, elt::FloatingPoint, dlm, quotes) = print_shortest(io, elt)
+function writedlm_cell{T}(io::IO, elt::String, dlm::T, quotes::Bool)
+    if quotes && !isempty(elt) && (('"' in elt) || ('\n' in elt) || ((T <: Char) ? (dlm in elt) : contains(elt, dlm)))
         print(io, '"', replace(elt, r"\"", "\"\""), '"')
     else
         print(io, elt)
     end
 end
-writedlm_cell(io::IO, elt, dlm) = print(io, elt)
-function writedlm(io::IO, a::AbstractVecOrMat, dlm)
+writedlm_cell(io::IO, elt, dlm, quotes) = print(io, elt)
+function writedlm(io::IO, a::AbstractVecOrMat, dlm; opts...)
+    optsd = val_opts(opts)
+    quotes = get(optsd, :quotes, true)
     pb = PipeBuffer()
     nr = size(a,1)
     nc = size(a,2)
     for i = 1:nr
         for j = 1:nc
-            writedlm_cell(pb, a[i,j], dlm)
+            writedlm_cell(pb, a[i,j], dlm, quotes)
             j == nc ? write(pb,'\n') : print(pb,dlm)
         end
         (nb_available(pb) > (16*1024)) && write(io, takebuf_array(pb))
@@ -326,12 +328,12 @@ function writedlm(io::IO, a::AbstractVecOrMat, dlm)
     nothing
 end
 
-writedlm{T}(io::IO, a::AbstractArray{T,0}, dlm) = writedlm(io, reshape(a,1), dlm)
+writedlm{T}(io::IO, a::AbstractArray{T,0}, dlm; opts...) = writedlm(io, reshape(a,1), dlm; opts...)
 
-function writedlm(io::IO, a::AbstractArray, dlm)
+function writedlm(io::IO, a::AbstractArray, dlm; opts...)
     tail = size(a)[3:end]
     function print_slice(idxs...)
-        writedlm(io, sub(a, 1:size(a,1), 1:size(a,2), idxs...), dlm)
+        writedlm(io, sub(a, 1:size(a,1), 1:size(a,2), idxs...), dlm; opts...)
         if idxs != tail
             print("\n")
         end
@@ -339,13 +341,15 @@ function writedlm(io::IO, a::AbstractArray, dlm)
     cartesianmap(print_slice, tail)
 end
 
-function writedlm(io::IO, itr, dlm)
+function writedlm(io::IO, itr, dlm; opts...)
+    optsd = val_opts(opts)
+    quotes = get(optsd, :quotes, true)
     pb = PipeBuffer()
     for row in itr
         state = start(row)
         while !done(row, state)
             (x, state) = next(row, state)
-            writedlm_cell(pb, x, dlm)
+            writedlm_cell(pb, x, dlm, quotes)
             done(row, state) ? write(pb,'\n') : print(pb,dlm)
         end
         (nb_available(pb) > (16*1024)) && write(io, takebuf_array(pb))
@@ -354,14 +358,14 @@ function writedlm(io::IO, itr, dlm)
     nothing
 end
 
-function writedlm(fname::String, a, dlm)
+function writedlm(fname::String, a, dlm; opts...)
     open(fname, "w") do io
-        writedlm(io, a, dlm)
+        writedlm(io, a, dlm; opts...)
     end
 end
 
-writedlm(io, a) = writedlm(io, a, '\t')
-writecsv(io, a) = writedlm(io, a, ',')
+writedlm(io, a; opts...) = writedlm(io, a, '\t'; opts...)
+writecsv(io, a; opts...) = writedlm(io, a, ','; opts...)
 
 writemime(io::IO, ::MIME"text/csv", a::AbstractVecOrMat) = writedlm(io, a, ',')
 writemime(io::IO, ::MIME"text/tab-separated-values", a::AbstractVecOrMat) = writedlm(io, a, '\t')

--- a/base/show.jl
+++ b/base/show.jl
@@ -1009,7 +1009,7 @@ end
 
 show(io::IO, X::AbstractArray) = showarray(io, X, header=_limit_output, repr=!_limit_output)
 
-print(io::IO, X::AbstractArray) = writedlm(io, X)
+print(io::IO, X::AbstractArray) = writedlm(io, X; quotes=false)
 
 function with_output_limit(thk, lim=true)
     global _limit_output

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -72,6 +72,14 @@ let x = ["a" "b"; "d" ""], io = IOBuffer()
     @test readdlm(io) == x
 end
 
+let x = ["\"hello\"", "world\""], io = IOBuffer()
+    print(io, x)
+    @assert takebuf_string(io) == "\"hello\"\nworld\"\n"
+
+    writedlm(io, x)
+    @assert takebuf_string(io) == "\"\"\"hello\"\"\"\n\"world\"\"\"\n"
+end
+
 
 # source: http://www.i18nguy.com/unicode/unicode-example-utf8.zip
 let i18n_data = ["Origin (English)", "Name (English)", "Origin (Native)", "Name (Native)", 


### PR DESCRIPTION
fixes #6305

`writedlm` now takes an optional parameter `quotes` which is `true` by default, but set to `false` when called from `print`.
