### PR TITLE
duplicate gemm function in document

### DIFF
--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -637,9 +637,9 @@ Usually a function has 4 methods defined, one each for ``Float64``,
    Returns ``alpha*A*B`` or the other three variants
    according to ``tA`` (transpose ``A``) and ``tB``.
 
-.. function:: gemm(tA, tB, alpha, A, B)
+.. function:: gemm(tA, tB, A, B)
 
-   Returns ``alpha*A*B`` or the other three variants
+   Returns ``A*B`` or the other three variants
    according to ``tA`` (transpose ``A``) and ``tB``.
 
 .. function:: gemv!(tA, alpha, A, x, beta, y)
@@ -653,7 +653,7 @@ Usually a function has 4 methods defined, one each for ``Float64``,
    Returns ``alpha*A*x`` or ``alpha*A'x`` according to ``tA``
    (transpose ``A``).
 
-.. function:: gemv(tA, alpha, A, x)
+.. function:: gemv(tA, A, x)
 
    Returns ``A*x`` or ``A'x`` according to ``tA`` (transpose ``A``).
 


### PR DESCRIPTION
duplicate `gemm` function, and I think in BLAS document under linalg

```
gemv(tA, alpha, A, x)

    Returns A*x or A'x according to tA (transpose A).
```

should not have argument alpha....

I think this function may be

```
gemv(tA,A,x) 
```

perhaps I am missing something?
