### PR TITLE
Restore method listing for foo(\t at REPL

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -166,15 +166,15 @@ end
 
 function completeLine(c::REPLCompletionProvider,s)
     partial = bytestring(s.input_buffer.data[1:position(s.input_buffer)])
-    ret, range = completions(partial,endof(partial))
-    return (ret,partial[range])
+    ret, range, should_complete = completions(partial,endof(partial))
+    return (ret, partial[range], should_complete)
 end
 
 function completeLine(c::ShellCompletionProvider,s)
     # First parse everything up to the current position
     partial = bytestring(s.input_buffer.data[1:position(s.input_buffer)])
-    ret, range = shell_completions(partial,endof(partial))
-    return (ret, partial[range])
+    ret, range, should_complete = shell_completions(partial,endof(partial))
+    return (ret, partial[range], should_complete)
 end
 
 type REPLHistoryProvider <: HistoryProvider

--- a/base/client.jl
+++ b/base/client.jl
@@ -70,22 +70,6 @@ function repl_hook(input::String)
          macroexpand(Expr(:macrocall,symbol("@cmd"),input)))
 end
 
-function repl_methods(input::String)
-    tokens = split(input, ".")
-    fn = Main
-    for token in tokens
-        sym = symbol(token)
-        isdefined(fn, sym) || return
-        fn = fn.(sym)
-    end
-    isgeneric(fn) || return
-
-    buf = IOBuffer()
-    show_method_table(buf, methods(fn), -1, false)
-    println(buf)
-    takebuf_string(buf)
-end
-
 display_error(er) = display_error(er, {})
 function display_error(er, bt)
     with_output_color(:red, STDERR) do io


### PR DESCRIPTION
This is somewhat intrusive, since we don't actually want to complete `foo(\t`, only show a list of completions. I'm not entirely sure this is the right approach, since users of REPLCompletions other than the REPL might want to do something special with the methods list, as IJulia does. I also fixed an extra newline at the end of the completion list if `length(completions) % num_cols == 0`.
