### PR TITLE
Fixes mmap error when reading 0-byte files, issue #6321

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -40,7 +40,7 @@ readdlm(input, dlm::Char, T::Type, eol::Char; opts...) = readdlm_auto(input, dlm
 
 function readdlm_auto(input, dlm::Char, T::Type, eol::Char, auto::Bool; opts...)
     optsd = val_opts(opts)
-    isa(input, String) && (fsz = filesize(input); input = get(optsd, :use_mmap, true) && fsz < typemax(Int) ? as_mmap(input,fsz) : readall(input))
+    isa(input, String) && (fsz = filesize(input); input = get(optsd, :use_mmap, true) && (fsz > 0) && fsz < typemax(Int) ? as_mmap(input,fsz) : readall(input))
     sinp = isa(input, Vector{Uint8}) ? ccall(:jl_array_to_string, ByteString, (Array{Uint8,1},), input) :
            isa(input, IO) ? readall(input) :
            input


### PR DESCRIPTION
Fixed by calling the mmap version only if file size > 0
