### PR TITLE
REPL: Bind meta-backspace to delete previous word

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1019,6 +1019,9 @@ const default_keymap =
     # Backspace/^H
     '\b' => edit_backspace,
     127 => '\b',
+    # Meta Backspace
+    "\e\b" => edit_delete_prev_word,
+    "\e\x7f" => "\e\b",
     # ^D
     4 => quote
         if LineEdit.buffer(s).size > 0


### PR DESCRIPTION
Seems silly to PR such a small thing, but it took me far longer than it should have to figure out which key-codes were getting sent (and how to write them).

Enables option-backspace in iTerm on Macs (when option sends meta), should similarly work for alt-backspace on other systems.
