### PR TITLE
Speed up coda generated @simd

### DIFF
--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -42,3 +42,28 @@ for T in {Int32,Int64,Float32,Float64}
     end
 end
 
+# Test that scope rules match regular for
+let j=4
+    # Use existing local variable.
+    @simd for j=1:0 end
+    @test j==4
+    @simd for j=1:3 end
+    @test j==3
+
+    # Use global variable
+    global simd_glob = 4
+    @simd for simd_glob=1:0 end
+    @test simd_glob==4
+    @simd for simd_glob=1:3 end
+    @test simd_glob==3
+
+    # Index that is local to loop
+    @simd for simd_loop_local=1:0 end
+    simd_loop_local_present = true
+    try 
+        simd_loop_local += 1
+    catch
+        simd_loop_local_present = false
+    end
+    @test !simd_loop_local_present
+end


### PR DESCRIPTION
Summary: The new support for `@simd` introduced a heavyweight coda for mimicking `for` scope rules.  The coda can hurt performance significantly.  The patch is a hack that speeds it up significantly, though it would be good to fix the problem more properly.  The patch also includes unit tests for the scope rule subtleties.  Perhaps someone more expert in Julia internals can point out a better fix.

The `@simd` in the original pull request #5355 inadvertently did not respect the scope rules of `for` and related behavior for zero-trip loops.  What was actually committed fixed the scope oversight (thanks!), though not for the zero-trip case.  Alas, the fix was expensive, for one of my examples it almost halves `@simd` performance compared to auto-vectorization introduced by #5355.  It's the sort of thing that gives a bad reputation to dynamic languages. :frowning: 

Instead of inspecting whether the index variable is defined or not, the hack uses a one-trip loop in the coda to induce whatever effect a `for` loop has scope-wise.  As circuitous as this is, it seems to be significantly faster then the previous approach, though it still hurts performance noticeably.

Ideally, there ought to be a way to identify at compilation time whether there loop index is local to the for loop or not.. 
