### PR TITLE
readdlm: handle white space after last column properly

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -115,7 +115,8 @@ function dlm_fill{T}(cells::Array{T,2}, offarr::Vector{Vector{Int}}, sbuff::Stri
         (row < 1) && continue
         (row > maxrow) && break
 
-        if (row > lastrow) && (lastcol < maxcol)
+        while lastrow < row
+            (lastcol == maxcol) && (lastcol = 0; lastrow += 1)
             for cidx in (lastcol+1):maxcol
                 if (T <: String) || (T == Any)
                     cells[lastrow,cidx] = SubString(sbuff, 1, 0)
@@ -125,6 +126,8 @@ function dlm_fill{T}(cells::Array{T,2}, offarr::Vector{Vector{Int}}, sbuff::Stri
                     error("missing value at row $lastrow column $cidx")
                 end
             end
+            lastcol = maxcol
+        (lastrow == row) && break
         end
 
         endpos = prevind(sbuff, nextind(sbuff,endpos))
@@ -158,7 +161,7 @@ function dlm_fill{T}(cells::Array{T,2}, offarr::Vector{Vector{Int}}, sbuff::Stri
                 end
             end
             lastcol = maxcol
-            (lastrow == maxrow) && break;
+            (lastrow == maxrow) && break
         end
     end
     cells
@@ -234,17 +237,15 @@ function dlm_dims{T,D}(dbuff::T, eol::D, dlm::D, qchar::D, ign_adj_dlm::Bool, al
                         expct_col = true
                         col += 1
                         offidx = store_column(offsets, nrows+1, col, false, col_start_idx, idx-2, offidx)
-                        col_start_idx = idx
-                    else
-                        col_start_idx = idx
                     end
+                    col_start_idx = idx
                 elseif is_eol
                     nrows += 1
                     if expct_col 
                         col += 1
                         offidx = store_column(offsets, nrows, col, false, col_start_idx, idx-2, offidx)
-                        col_start_idx = idx
                     end
+                    col_start_idx = idx
                     ncols = max(ncols, col)
                     col = 0
                     expct_col = false

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -52,6 +52,12 @@ let result1 = reshape({"abc", "hello", "def,ghi", " \"quote\" ", "new\nline", "w
     @test isequal(readdlm(IOBuffer("abc,\"def,ghi\",\"new\nline\"\n\"hello\",\" \"\"quote\"\" \",world"), ',', quotes=false), result2)
 end
 
+let result1 = reshape({"t", "c", "", "c"}, 2, 2),
+    result2 = reshape({"t", "\"c", "t", "c"}, 2, 2)
+    @test isequal(readdlm(IOBuffer("t  \n\"c\" c")), result1)
+    @test isequal(readdlm(IOBuffer("t t \n\"\"\"c\" c")), result2)
+end
+
 @test isequal(readcsv(IOBuffer("\n1,2,3\n4,5,6\n\n\n")), reshape({"",1.0,4.0,"","","",2.0,5.0,"","","",3.0,6.0,"",""}, 5, 3))
 
 let x = [1,2,3], y = [4,5,6], io = IOBuffer()


### PR DESCRIPTION
ref: discussion in #5856
Also fix undef columns for empty lines within rows.

Now:

```
julia> readdlm(IOBuffer("\"test1\" \"test2\" \n\"cuac1\" \"cuac2\""))
2x2 Array{Any,2}:
 "test1"  "test2"
 "cuac1"  "cuac2"

julia> readdlm(IOBuffer(" \n\n\n"), ' ')
3x2 Array{Any,2}:
 ""  ""
 ""  ""
 ""  ""
```
