### PR TITLE
Fix #6347: Make movement by word jump to word-boundaries

### DIFF
--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -101,6 +101,17 @@ seekend(buf)
 buf = IOBuffer("4 +aaa+ x")
 seek(buf,8)
 @test LineEdit.edit_delete_prev_word(buf)
-@test position(buf) == 2
-@test buf.size == 3
-@test bytestring(buf.data[1:buf.size]) == "4 x"
+@test position(buf) == 3
+@test buf.size == 4
+@test bytestring(buf.data[1:buf.size]) == "4 +x"
+
+buf = IOBuffer("x = func(arg1,arg2 , arg3)")
+seekend(buf)
+LineEdit.char_move_word_left(buf)
+@test position(buf) == 21
+@test LineEdit.edit_delete_prev_word(buf)
+@test bytestring(buf.data[1:buf.size]) == "x = func(arg1,arg3)"
+@test LineEdit.edit_delete_prev_word(buf)
+@test bytestring(buf.data[1:buf.size]) == "x = func(arg3)"
+@test LineEdit.edit_delete_prev_word(buf)
+@test bytestring(buf.data[1:buf.size]) == "x = arg3)"


### PR DESCRIPTION
This restores all movement- and deletion-by-word to jump to word boundaries instead of whitespace, as noted in #6347 and https://github.com/JuliaLang/julia/commit/e27771df954f44551eba06fdc7d1a9f6e4f12ab8#commitcomment-5847965.  I've preserved the delete-to-whitespace behavior in `^w` as `edit_werase`.

I've also changed the `char_move_right/_left` methods to return the character they step over. This ended up simplifying some of the more complicated by-word logic.

I initially used the old non-word-char list from e27771df954f44551eba06fdc7d1a9f6e4f12ab8, ~~but I think `isspace(c) || ispunct(c)` will be more consistent for unicode users.~~
