### PR TITLE
Use julia parser in completion - take 2

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -153,6 +153,21 @@ function parse_input_line(io::IO)
     end
 end
 
+# detect the reason which caused an :incomplete expression
+# from the error message
+# NOTE: the error messages are defined in src/julia-parser.scm
+incomplete_tag(ex) = :none
+function incomplete_tag(ex::Expr)
+    Meta.isexpr(ex, :incomplete) || return :none
+    msg = ex.args[1]
+    contains(msg, "string") && return :string
+    contains(msg, "comment") && return :comment
+    contains(msg, "requires end") && return :block
+    contains(msg, "\"`\"") && return :cmd
+    contains(msg, "character") && return :char
+    return :other
+end
+
 # try to include() a file, ignoring if not found
 try_include(path::String) = isfile(path) && include(path)
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -360,7 +360,7 @@
   (define (skip-multiline-comment port count)
     (let ((c (read-char port)))
       (if (eof-object? c) 
-          (error "incomplete: unterminated multi-line comment #= ... =#")
+          (error "incomplete: unterminated multi-line comment #= ... =#") ; NOTE: changing this may affect code in base/client.jl
           (begin (if (eqv? c #\=)
                      (let ((c (peek-char port)))
                        (if (eqv? c #\#)
@@ -440,7 +440,7 @@
 (define (require-token s)
   (let ((t (or (ts:pbtok s) (ts:last-tok s) (next-token (ts:port s) s))))
     (if (eof-object? t)
-	(error "incomplete: premature end of input")
+	(error "incomplete: premature end of input") ; NOTE: changing this may affect code in base/client.jl
 	(if (newline? t)
 	    (begin (take-token s)
 		   (require-token s))
@@ -950,7 +950,7 @@
   (let ((t (peek-token s)))
     (cond ((eq? t 'end) (take-token s))
 	  ((eof-object? t)
-	   (error (string "incomplete: \"" word "\" at "
+	   (error (string "incomplete: \"" word "\" at " ; NOTE: changing this may affect code in base/client.jl
 			  current-filename ":" expect-end-current-line
 			  " requires end")))
 	  (else
@@ -1483,7 +1483,7 @@
 
 (define (not-eof-2 c)
   (if (eof-object? c)
-      (error "incomplete: invalid \"`\" syntax")
+      (error "incomplete: invalid \"`\" syntax") ; NOTE: changing this may affect code in base/client.jl
       c))
 
 (define (parse-backquote s)
@@ -1505,7 +1505,7 @@
 
 (define (not-eof-3 c)
   (if (eof-object? c)
-      (error "incomplete: invalid string syntax")
+      (error "incomplete: invalid string syntax") ; NOTE: changing this may affect code in base/client.jl
       c))
 
 (define (take-char p)
@@ -1592,7 +1592,7 @@
 
 (define (not-eof-1 c)
   (if (eof-object? c)
-      (error "incomplete: invalid character literal")
+      (error "incomplete: invalid character literal") ; NOTE: changing this may affect code in base/client.jl
       c))
 
 (define (unescape-string s)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1412,6 +1412,21 @@ let
           ex == Expr(:error, "invalid assignment location \"#<julia_value>\"")
 end
 
+# make sure that incomplete tags are detected correctly
+# (i.e. error messages in src/julia-parser.scm must be matched correctly
+# by the code in base/client.jl)
+for (str, tag) in ["" => :none, "\"" => :string, "#=" => :comment, "'" => :char,
+                   "`" => :cmd, "begin;" => :block, "quote;" => :block,
+                   "let;" => :block, "for i=1;" => :block, "function f();" => :block,
+                   "f() do x;" => :block, "module X;" => :block, "type X;" => :block,
+                   "immutable X;" => :block, "(" => :other, "[" => :other,
+                   "{" => :other, "begin" => :other, "quote" => :other,
+                   "let" => :other, "for" => :other, "function" => :other,
+                   "f() do" => :other, "module" => :other, "type" => :other,
+                   "immutable" => :other]
+    @test Base.incomplete_tag(parse(str, raise=false)) == tag
+end
+
 # issue #6031
 macro m6031(x); x; end
 @test @m6031([2,4,6])[3] == 6

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -14,7 +14,7 @@ test_scomplete(s) = shell_completions(s,endof(s))
 s = ""
 c,r = test_complete(s)
 @test in("CompletionFoo",c)
-@test r == 0:-1
+@test isempty(r)
 @test s[r] == ""
 
 s = "Comp"


### PR DESCRIPTION
Alternative version to #6344. This one does not touch the parser or any of the code in src/, and is generally much cleaner. The weak spot is of course that it determines the reason for incompleteness from the error message, but I think that's acceptable for the time being, considering that 1) it's not everyday that error messages are changed 2) the advantages for the parser are a much cleaner and robust code 3) any alternative AFAICT requires changes to the parser which range from "superficial but dissatisfying" to "deep but substantial (i.e. long-term)". So I think it's worth it for now.
Opinions?
