### PR TITLE
Fix parsing of error output from trrfs! call in \{::Triangular,...}

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -36,11 +36,12 @@ A_mul_Bc!{T<:BlasReal}(A::StridedMatrix{T}, B::Triangular{T}) = BLAS.trmm('R', B
 
 function \{T<:BlasFloat}(A::Triangular{T}, B::StridedVecOrMat{T})
     x = LAPACK.trtrs!(A.uplo, 'N', A.unitdiag, A.UL, copy(B))
-    for errors in LAPACK.trrfs!(A.uplo, 'N', A.unitdiag, A.UL, B, x)
-        all(isfinite(errors)) || all(errors.<one(T)/eps(T)) || warn("""Unreasonably large error in computed solution:
-forward error: $ferr
-backward error: $berr""")
-    end
+    errors=LAPACK.trrfs!(A.uplo, 'N', A.unitdiag, A.UL, B, x)
+    all(map(isfinite, [errors...])) || all([errors...] .< one(T)/eps(T)) || warn("""Unreasonably large error in computed solution:
+forward errors:
+$(errors[1])
+backward errors:
+$(errors[2])""")
     x
 end
 Ac_ldiv_B{T<:BlasReal}(A::Triangular{T}, B::StridedVecOrMat{T}) = LAPACK.trtrs!(A.uplo, 'T', A.unitdiag, A.UL, copy(B))


### PR DESCRIPTION
Makes printout of errors a little bit nicer.

Closes #6398
