### PR TITLE
Ignore REQUIRE when giving suggestions of packages after using

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -222,6 +222,7 @@ function completions(string, pos)
             append!(suggestions, filter(readdir(Pkg.dir())) do pname
                 pname[1] != '.' &&
                 pname != "METADATA" &&
+                pname != "REQUIRE" &&
                 beginswith(pname, s)
             end)
         end


### PR DESCRIPTION
I like that the new REPL autocomplete after `using R\t`, but the REQUIRE file is not that useful.
