### PR TITLE
Use INFINITY and NAN instead of strtod

### DIFF
--- a/src/support/bitvector.c
+++ b/src/support/bitvector.c
@@ -13,6 +13,10 @@
 #include <malloc.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 u_int32_t *bitvector_resize(u_int32_t *b, uint64_t oldsz, uint64_t newsz,
                             int initzero)
 {
@@ -190,3 +194,7 @@ u_int32_t bitvector_any1(u_int32_t *b, u_int64_t offs, u_int64_t nbits)
     }
     return 0;
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/support/bitvector.h
+++ b/src/support/bitvector.h
@@ -1,6 +1,10 @@
 #ifndef BITVECTOR_H
 #define BITVECTOR_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DLLEXPORT u_int32_t *bitvector_new(u_int64_t n, int initzero);
 DLLEXPORT
 u_int32_t *bitvector_resize(u_int32_t *b, uint64_t oldsz, uint64_t newsz,
@@ -15,5 +19,9 @@ DLLEXPORT
 u_int64_t bitvector_count(u_int32_t *b, u_int64_t offs, u_int64_t nbits);
 DLLEXPORT
 u_int32_t bitvector_any1(u_int32_t *b, u_int64_t offs, u_int64_t nbits);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/support/libsupportinit.c
+++ b/src/support/libsupportinit.c
@@ -1,4 +1,5 @@
 #include <locale.h>
+#include <math.h>
 #include "libsupport.h"
 
 #ifdef __cplusplus
@@ -21,10 +22,10 @@ void libsupport_init(void)
 
         ios_init_stdstreams();
 
-        D_PNAN = strtod("+NaN",NULL);
-        D_NNAN = -strtod("+NaN",NULL);
-        D_PINF = strtod("+Inf",NULL);
-        D_NINF = strtod("-Inf",NULL);
+        D_PNAN = +NAN;
+        D_NNAN = -NAN;
+        D_PINF = +INFINITY;
+        D_NINF = -INFINITY;
         isInitialized=1;
     }
 }


### PR DESCRIPTION
This fixes an error `syntax: overflow in numeric constant "0"` in MSVC builds (thanks @vtjnash for figuring this out). `strtod` is not C99 compliant in any currently-released version of Visual Studio, [though it will apparently be fixed for the next release](https://connect.microsoft.com/VisualStudio/feedback/details/794104/strtod-does-not-implement-the-c99-c-11-standard). The `INFINITY` and `NAN` identifiers were added to `math.h` only in VS 2013. Could  maybe fall back to `openlibm.h` instead? Ref. #6230 and #6349.

Also adds `extern "C"` on bitvector - there will be several more of these, for ccall-only functions that weren't needed to link libjulia or the REPL exe.
