### PR TITLE
Make the REPL re-entrant and easier to debug

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -788,11 +788,11 @@ function keymap_unify(keymaps)
     return ret
 end
 
-macro keymap(func, keymaps)
+macro keymap(keymaps)
     dict = keymap_unify(keymap_prepare(keymaps))
     body = keymap_gen_body(dict, dict)
     esc(quote
-        function $(func)(s, data)
+        (s, data) -> begin
             $body
             return :ok
         end
@@ -978,8 +978,7 @@ function setup_search_keymap(hp)
         "\e[F"    => s->(accept_result(s, p); move_input_end(s)),
         "*"       => :(LineEdit.edit_insert(data.query_buffer, c1); LineEdit.update_display_buffer(s, data))
     }
-    @eval @LineEdit.keymap keymap_func $([pkeymap, escape_defaults])
-    p.keymap_func = keymap_func
+    p.keymap_func = @eval @LineEdit.keymap $([pkeymap, escape_defaults])
     keymap = {
         "^R"    => s->(enter_search(s, p, true)),
         "^S"    => s->(enter_search(s, p, false)),
@@ -1212,7 +1211,7 @@ function reset_state(s::MIState)
     end
 end
 
-@LineEdit.keymap default_keymap_func [LineEdit.default_keymap, LineEdit.escape_defaults]
+const default_keymap_func = @LineEdit.keymap [LineEdit.default_keymap, LineEdit.escape_defaults]
 
 function Prompt(prompt;
     first_prompt = prompt,

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -5,7 +5,7 @@ using Base.Terminals
 import Base.Terminals: raw!, width, height, cmove, getX,
                        getY, clear_line, beep
 
-import Base: ensureroom, peek
+import Base: ensureroom, peek, show
 
 abstract TextInterface
 
@@ -38,6 +38,8 @@ type Prompt <: TextInterface
     on_done
     hist
 end
+
+show(io::IO, x::Prompt) = show(io, string("Prompt(\"", x.prompt, "\",...)"))
 
 immutable InputAreaState
     num_rows::Int64

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -598,9 +598,8 @@ function setup_interface(d::REPLDisplay, req, rep; extra_repl_keymap = Dict{Any,
 
     a = Dict{Any,Any}[hkeymap, repl_keymap, LineEdit.history_keymap(hp), LineEdit.default_keymap, LineEdit.escape_defaults]
     prepend!(a, extra_repl_keymap)
-    @eval @LineEdit.keymap repl_keymap_func $(a)
 
-    main_prompt.keymap_func = repl_keymap_func
+    main_prompt.keymap_func = @eval @LineEdit.keymap $(a)
 
     const mode_keymap = {
         '\b' => function (s)
@@ -625,9 +624,7 @@ function setup_interface(d::REPLDisplay, req, rep; extra_repl_keymap = Dict{Any,
 
     b = Dict{Any,Any}[hkeymap, mode_keymap, LineEdit.history_keymap(hp), LineEdit.default_keymap, LineEdit.escape_defaults]
 
-    @eval @LineEdit.keymap mode_keymap_func $(b)
-
-    shell_mode.keymap_func = help_mode.keymap_func = mode_keymap_func
+    shell_mode.keymap_func = help_mode.keymap_func = @eval @LineEdit.keymap $(b)
 
     ModalInterface([main_prompt, shell_mode, help_mode,hkp])
 end

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -99,8 +99,8 @@ function display_error(io::IO, er, bt)
     end
 end
 
-immutable REPLDisplay <: Display
-    repl::AbstractREPL
+immutable REPLDisplay{R<:AbstractREPL} <: Display
+    repl::R
 end
 function display(d::REPLDisplay, ::MIME"text/plain", x)
     io = outstream(d.repl)
@@ -437,7 +437,7 @@ function respond(f, d, main, req, rep)
     end
 end
 
-function reset(d::REPLDisplay)
+function reset(d::REPLDisplay{LineEditREPL})
     raw!(d.repl.t, false)
     print(Base.text_colors[:normal])
 end
@@ -670,9 +670,8 @@ answer_color(r::LineEditREPL) = r.answer_color
 answer_color(r::StreamREPL) = r.answer_color
 answer_color(::BasicREPL) = Base.text_colors[:white]
 
-print_response(d::REPLDisplay, r::StreamREPL,args...) = print_response(d, r.stream,r, args...)
-print_response(d::REPLDisplay, r::LineEditREPL,args...) = print_response(d, r.t, r, args...)
-print_response(d::REPLDisplay, args...) = print_response(d, d.repl, args...)
+print_response(d::REPLDisplay{StreamREPL}, args...)   = print_response(d, d.repl.stream, d.repl, args...)
+print_response(d::REPLDisplay{LineEditREPL}, args...) = print_response(d, d.repl.t, d.repl, args...)
 
 function run_repl(stream::AsyncStream)
     repl =

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -20,7 +20,7 @@ const bar_keymap = {
     'b' => :( global b_bar; b_bar += 1)
 }
 
-@eval @LineEdit.keymap test1_func $foo_keymap
+test1_func = @eval @LineEdit.keymap $foo_keymap
 
 function run_test(f,buf)
     global a_foo, a_bar, b_bar
@@ -33,13 +33,13 @@ end
 run_test(test1_func,IOBuffer("aa"))
 @test a_foo == 2
 
-@eval @LineEdit.keymap test2_func $([foo2_keymap, foo_keymap])
+test2_func = @eval @LineEdit.keymap $([foo2_keymap, foo_keymap])
 
 run_test(test2_func,IOBuffer("aaabb"))
 @test a_foo == 3
 @test b_foo == 2
 
-@eval @LineEdit.keymap test3_func $([bar_keymap, foo_keymap])
+test3_func = @eval @LineEdit.keymap $([bar_keymap, foo_keymap])
 
 run_test(test3_func,IOBuffer("aab"))
 @test a_bar == 2


### PR DESCRIPTION
The two patches here simplify working with the REPL itself.  The first allows for printing of REPL objects in the REPL.  The second makes it re-entrant.

Previously, the keymap functions were assigned a name with the eval macro (that is - in global scope). This changes the keymap macro to instead return an anonymous function so that additional instances of the REPL don't clobber the previous keymap functions.

So, you can now start a second REPL inside the first.  I've found this particularly useful for testing keybindings, but I could see it being useful in other cases, too.

`Base.REPL.run_repl(Base.REPL.LineEditREPL(Base.Terminals.TTYTerminal(get(ENV,"TERM",""),STDIN,STDOUT,STDERR)))`

cc: @nolta @loladiro
