### PR TITLE
Integrate gsl-shell/luajit into microbenchmarks

### DIFF
--- a/test/perf/micro/Makefile
+++ b/test/perf/micro/Makefile
@@ -19,10 +19,8 @@ endif
 FFLAGS=-fexternal-blas
 ifeq ($(findstring gfortran, $(FC)), gfortran)
 ifeq ($(USE_BLAS64), 1)
-echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-echo WARNING: gfortran cannot multiply matrices using 64-bit external BLAS.
-echo          External BLAS usage is turned OFF.
-echo !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#gfortran cannot multiply matrices using 64-bit external BLAS.
+#External BLAS usage is turned OFF.
 FFLAGS=
 endif
 FFLAGS+= -static-libgfortran
@@ -97,6 +95,9 @@ benchmarks/javascript.csv: perf.js
 benchmarks/mathematica.csv: perf.nb
 	for t in 1 2 3 4 5; do $(MATHEMATICABIN) -noprompt -run "<<$<; Exit[]"; done >$@
 
+benchmarks/lua.csv: perf.lua
+	for t in 1 2 3 4 5; do gsl-shell $<; done >$@
+
 BENCHMARKS = \
 	benchmarks/c.csv \
 	benchmarks/fortran.csv \
@@ -106,6 +107,7 @@ BENCHMARKS = \
 	benchmarks/matlab.csv \
 	benchmarks/octave.csv \
 	benchmarks/r.csv \
+	benchmarks/lua.csv \
 	benchmarks/javascript.csv \
 	benchmarks/mathematica.csv
 

--- a/test/perf/micro/bin/table.pl
+++ b/test/perf/micro/bin/table.pl
@@ -19,13 +19,14 @@ our @benchmarks = qw(
   rand_mat_mul
 );
 
-our $julia_ver = `julia -e 'print(Base.BUILD_INFO.version_string)'`;
+our $julia_ver = `julia -v | cut -f3 -d" "`;
 our $fortran_ver = `gfortran-4.8 -v 2>&1 | grep "gcc version" | cut -f3 -d" "`;
 our $python_ver = `python -V 2>&1 | cut -f2 -d" "`;
 our $matlab_ver = `matlab -nodisplay -nojvm -nosplash -r "version -release, quit" | tail -n 3 | head -n 1`;
 our $R_ver = `R --version | grep "R version" | cut -f3 -d" "`;
 our $octave_ver = `octave -v | grep version | cut -f4 -d" "`;
 our $go_ver = `go version | cut -f3 -d" "`;
+our $lua_ver = `gsl-shell -v 2>&1 | grep Shell | cut -f3 -d" " | cut -f1 -d,`;
 our $javascript_ver = `node -e "console.log(process.versions.v8)"`;
 our $mathematica_ver = `echo quit | math -version | head -n 1 | cut -f2 -d" "`;
 
@@ -39,9 +40,10 @@ our %systems = (
   "javascript" => ["JavaScript", "V8 $javascript_ver"],
   "go"         => ["Go"          , $go_ver ],
   "mathematica"=> ["Mathematica" , $mathematica_ver ],
+  "lua"	       => ["Lua" , "gsl-shell $lua_ver"],
 );
 
-our @systems = qw(fortran julia python r matlab octave mathematica javascript go);
+our @systems = qw(fortran julia python r matlab octave mathematica javascript go lua);
 
 print qq[<table class="benchmarks">\n];
 print qq[<colgroup>\n];

--- a/test/perf/micro/perf.lua
+++ b/test/perf/micro/perf.lua
@@ -41,7 +41,7 @@ local function timeit(f, name)
         local tx = elapsed(f)
         t = t and min(t, tx) or tx
     end
-    print(format("gsl_shell,%s,%g", name, t))
+    print(format("lua,%s,%g", name, t))
 end
 
 local function fib(n)


### PR DESCRIPTION
Integrate gsl-shell/luajit into microbenchmarks
- Also update command to get Julia version info.
- Renames label for gsl-shell/lua tests from gsl_shell to lua.
- Remove non-working external BLAS usage warning.

Closes #1662.
