### PR TITLE
Remove space from Windows install path

### DIFF
--- a/contrib/windows/build-installer.nsi
+++ b/contrib/windows/build-installer.nsi
@@ -12,7 +12,7 @@ RequestExecutionLevel user
 !define MUI_ICON "contrib\windows\julia.ico"
 
 # Variable definitions used in installer pages
-InstallDir "$LOCALAPPDATA\Julia ${Version}"
+InstallDir "$LOCALAPPDATA\Julia-${Version}"
 !define StartMenuFolder "Julia ${Version}" 
 
 # Page settings


### PR DESCRIPTION
Spaces in paths can cause problems with e.g. shelling out, so it'd be great if it wasn't the default.

c.f. one-more-minute/Jewel#5

Edit: I should have been clearer that the shelling out issue affects all Windows programs, so I'm talking about shelling out _to_ Julia, not from it.
