### PR TITLE
Don't export symbols from Core that shouldn't be called directly

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -1,6 +1,8 @@
 # important core definitions
 
-using Core.Intrinsics
+using Core: Intrinsics, arraylen, arrayref, arrayset, arraysize,
+            tuplelen, tupleref, convert_default, convert_tuple, kwcall,
+            typeassert, apply_type
 
 import Core.Array  # to add methods
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -135,11 +135,12 @@ export
     Expr, GotoNode, LabelNode, LineNumberNode, QuoteNode, SymbolNode, TopNode,
     GetfieldNode, NewvarNode,
     # object model functions
-    apply, arraylen, arrayref, arrayset, arraysize, fieldtype, getfield,
-    setfield!, yieldto, throw, tuple, tuplelen, tupleref, is, ===, isdefined,
-    convert_default, convert_tuple, kwcall,
+    apply, fieldtype, getfield, setfield!, yieldto, throw, tuple, is, ===, isdefined,
+    # arraylen, arrayref, arrayset, arraysize, tuplelen, tupleref, convert_default,
+    # convert_tuple, kwcall,
     # type reflection
-    issubtype, typeassert, typeof, apply_type, isa,
+    issubtype, typeof, isa,
+    # typeassert, apply_type,
     # method reflection
     applicable, invoke, method_exists,
     # constants


### PR DESCRIPTION
Core's exports are in the namespace of every module, so it doesn't make much sense to me to export these functions, all of which are undocumented and some of which will make Julia segfault if called with the wrong method signature.
