### PR TITLE
task iter does not consume in done call. fixes #6447

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -162,12 +162,13 @@ function consume(P::Task, values...)
     schedule_and_wait(P)
 end
 
-start(t::Task) = nothing
-function done(t::Task, val)
+start(t::Task) = (istaskstarted(t) || (t.result = consume(t)); return nothing)
+done(t::Task, val) = istaskdone(t)
+function next(t::Task, val) 
+    result = t.result
     t.result = consume(t)
-    istaskdone(t)
+    (result, nothing)
 end
-next(t::Task, val) = (t.result, nothing)
 
 
 ## condition variables


### PR DESCRIPTION
This changes the iterator for `Task` to consume only in `start` and `next` calls.
The `istaskstarted` check in `start` is to allow it to be called multiple times from `isempty`.
