### PR TITLE
More useful error message when spawn fails

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -209,7 +209,7 @@ function _jl_spawn(cmd::Ptr{Uint8}, argv::Ptr{Ptr{Uint8}}, loop::Ptr{Void}, pp::
     if error != 0
         disassociate_julia_struct(proc)
         ccall(:jl_forceclose_uv,Void,(Ptr{Void},),proc)
-        throw(UVError("spawn",error))
+        throw(UVError("could not spawn "*string(pp.cmd), error))
     end
     associate_julia_struct(proc,pp)
     return proc


### PR DESCRIPTION
`"spawn: no such file or directory (ENOENT)"` is a common error that isn't so useful, especially if some or all of the backtrace gets truncated. Telling the user what the command was that failed should help, though it may get a little long in some cases.

x-ref example of this from julia-dev list: https://groups.google.com/forum/#!topic/julia-dev/SXX11w6I_D4
