### PR TITLE
`in` on an empty range should be false, not an error

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -553,4 +553,4 @@ function in(x, r::Range)
     n >= 1 && n <= length(r) && r[n] == x
 end
 
-in{T<:Integer}(x, r::Range{T}) = isinteger(x) && x>=minimum(r) && x<=maximum(r) && (step(r)==0 || mod(int(x)-first(r),step(r))==0)
+in{T<:Integer}(x, r::Range{T}) = isinteger(x) && !isempty(r) && x>=minimum(r) && x<=maximum(r) && (step(r)==0 || mod(int(x)-first(r),step(r))==0)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -94,6 +94,9 @@ r = (-4*int64(maxintfloat(is(Int,Int32) ? Float32 : Float64))):5
 @test (3 in r)
 @test (3.0 in r)
 
+@test !(1 in 1:0)
+@test !(1.0 in 1.0:0.0)
+
 # indexing range with empty range (#4309)
 @test (3:6)[5:4] == 7:6
 @test_throws (3:6)[5:5]


### PR DESCRIPTION
Previously:

```
julia> 1 in 1:0
ERROR: range must be non-empty
 in minimum at range.jl:201
 in in at range.jl:556
```

All other collections (including float ranges) simply return false on an empty collection.  This (very very simple) PR fixes this and adds a few basic test cases in `test/ranges.jl`.
