### PR TITLE
Add getindex method for Bidiagonal matrix type.

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -21,6 +21,11 @@ end
 
 Bidiagonal(A::AbstractMatrix, isupper::Bool)=Bidiagonal(diag(A), diag(A, isupper?1:-1), isupper)
 
+function getindex{T}(A::Bidiagonal{T}, i::Integer, j::Integer)
+    (1<=i<=size(A,2) && 1<=j<=size(A,2)) || throw(BoundsError())
+    i == j ? A.dv[i] : (A.isupper && (i == j-1)) || (!A.isupper && (i == j+1)) ? A.ev[min(i,j)] : zero(T)
+end
+
 #Converting from Bidiagonal to dense Matrix
 full{T}(M::Bidiagonal{T}) = convert(Matrix{T}, M)
 convert{T}(::Type{Matrix{T}}, A::Bidiagonal{T})=diagm(A.dv) + diagm(A.ev, A.isupper?1:-1)


### PR DESCRIPTION
A Bidiagonal matrix is now printed correctly in an interactive session.

Before:
julia> B = Bidiagonal([1,2,3,4],[1,2,3],true)
4x4 Bidiagonal{Int64}:
# undef #undef #undef #undef
# undef #undef #undef #undef
# undef #undef #undef #undef
# undef #undef #undef #undef

After:
julia> B = Bidiagonal([1,2,3,4],[1,2,3],true)
4x4 Bidiagonal{Int64}:
1  1  0  0
0  2  2  0
0  0  3  3
0  0  0  4

julia> B = Bidiagonal([1,2,3,4],[1,2,3],false)
4x4 Bidiagonal{Int64}:
1  0  0  0
1  2  0  0
0  2  3  0
0  0  3  4
