### PR TITLE
.*, ./, and == for UniformScaling

### DIFF
--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -82,3 +82,10 @@ end
 \(A::AbstractMatrix, J::UniformScaling) = inv(A)*J.λ
 
 \(x::Number, J::UniformScaling) = UniformScaling(x\J.λ)
+
+.*(x::Number,J::UniformScaling) = UniformScaling(x*J.λ)
+.*(J::UniformScaling,x::Number) = UniformScaling(J.λ*x)
+
+./(J::UniformScaling,x::Number) = UniformScaling(J.λ/x)
+
+==(J1::UniformScaling,J2::UniformScaling) = (J1.λ == J2.λ)


### PR DESCRIPTION
Redo of #6192, which managed to break git, somehow. Adds .*, ./ between UniformScaling and Number, and == for UniformScaling. I see that on master, there are no longer imports for *,/ etc., so I left those off as well, but I can add those if it's an omission.

cc @andreasnoackjensen
