### PR TITLE
fix #6400

### DIFF
--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -72,6 +72,8 @@ static int _enonfatal(int err)
 }
 
 #define SLEEP_TIME 5//ms
+#define MAXSIZE ((1l << 31) - 1)   // OSX cannot handle blocks larger than this
+#define MIN(a,b) (((a)<(b))?(a):(b))
 
 // return error code, #bytes read in *nread
 // these wrappers retry operations until success or a fatal error
@@ -80,7 +82,7 @@ static int _os_read(long fd, void *buf, size_t n, size_t *nread)
     ssize_t r;
 
     while (1) {
-        r = read((int)fd, buf, n);
+        r = read((int)fd, buf, MIN(n, MAXSIZE));
         if (r > -1) {
             *nread = (size_t)r;
             return 0;
@@ -116,7 +118,7 @@ static int _os_write(long fd, const void *buf, size_t n, size_t *nwritten)
     ssize_t r;
 
     while (1) {
-        r = write((int)fd, buf, n);
+        r = write((int)fd, buf, MIN(n, MAXSIZE));
         if (r > -1) {
             *nwritten = (size_t)r;
             return 0;


### PR DESCRIPTION
Apparently OSX simply does not read / write blocks larger than 2^32-1. Strangely I could not find any references for this behavior. See https://gist.github.com/rened/10294680 for an analysis.

The fix is to only read / write MAXSIZE bytes in one go, the _os_read_all and _os_write_all function will iterate until everything got read / written.

All julia unit tests pass, and this checks the large size reads/writes:

``` jl
filename = "/tmp/bigfile"
for N = 30:34
    nbytes = 2^N
    println("N: $N, $nbytes bytes")
    data = Array(Uint8, nbytes)
    open(filename, "w") do s
        wrote = write(s, data)
        if wrote!=nbytes
            error("wrote only $wrote of $nbytes bytes")
        end
        println("  write worked!")
    end
    input = zero(data)
    open(filename, "r") do s
        read!(s, input)
        assert(input==data)
        println("  read worked!")
    end
end
```
