### PR TITLE
reverse range with select gives empty result. fixes #6534

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -82,8 +82,9 @@ function select!(v::AbstractVector, k::Int, lo::Int, hi::Int, o::Ordering)
 end
 
 function select!(v::AbstractVector, r::UnitRange, lo::Int, hi::Int, o::Ordering)
+    isempty(r) && (return v[r])
     a, b = first(r), last(r)
-    lo <= a <= b <= hi || error("select index $k is out of range $lo:$hi")
+    lo <= a <= b <= hi || error("selection $r is out of range $lo:$hi")
     @inbounds while true
         if lo == a && hi == b
             sort!(v, lo, hi, DEFAULT_UNSTABLE, o)


### PR DESCRIPTION
```
julia> a = [1:10];

julia> select(a, 1:3)
3-element Array{Int64,1}:
 1
 2
 3

julia> select(a, 3:1)
0-element Array{Int64,1}
```
