### PR TITLE
Adds an expm1 function for complex values. 

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -20,7 +20,8 @@ export sin, cos, tan, sinh, cosh, tanh, asin, acos, atan,
 
 import Base: log, exp, sin, cos, tan, sinh, cosh, tanh, asin,
              acos, atan, asinh, acosh, atanh, sqrt, log2, log10,
-             max, min, minmax, ceil, floor, trunc, round, ^, exp2, exp10
+             max, min, minmax, ceil, floor, trunc, round, ^, exp2,
+             exp10, expm1
 
 import Core.Intrinsics: nan_dom_err, sqrt_llvm, box, unbox, powi_llvm
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -103,6 +103,41 @@
 @test isequal(exp(complex( NaN, 5.0)), complex( NaN, NaN))
 @test isequal(exp(complex( NaN, NaN)), complex( NaN, NaN))
 
+# expm1:
+#  expm1(conj(z)) = conj(expm1(z))
+
+@test isequal(expm1(complex( 0.0, 0.0)), complex(0.0, 0.0))
+@test isequal(expm1(complex( 0.0,-0.0)), complex(0.0,-0.0))
+@test isequal(expm1(complex( 0.0, Inf)), complex(NaN, NaN))
+@test isequal(expm1(complex( 0.0,-Inf)), complex(NaN, NaN))
+@test isequal(expm1(complex( 0.0, NaN)), complex(NaN, NaN))
+
+@test isequal(expm1(complex(-0.0, 0.0)), complex(-0.0, 0.0))
+@test isequal(expm1(complex(-0.0,-0.0)), complex(-0.0,-0.0))
+
+@test isequal(expm1(complex( 5.0, Inf)), complex(NaN, NaN))
+
+@test isequal(expm1(complex( Inf, 0.0)), complex(Inf, 0.0))
+@test isequal(expm1(complex( Inf,-0.0)), complex(Inf,-0.0))
+@test isequal(expm1(complex( Inf, 5.0)), complex(cos(5.0)*Inf,sin(5.0)* Inf))
+@test isequal(expm1(complex( Inf,-5.0)), complex(cos(5.0)*Inf,sin(5.0)*-Inf))
+@test isequal(expm1(complex( Inf, NaN)), complex(-Inf, NaN))
+@test isequal(expm1(complex( Inf, Inf)), complex(-Inf, NaN))
+@test isequal(expm1(complex( Inf,-Inf)), complex(-Inf, NaN))
+
+@test isequal(expm1(complex(-Inf, 0.0)), complex(-1.0, 0.0))
+@test isequal(expm1(complex(-Inf,-0.0)), complex(-1.0,-0.0))
+@test isequal(expm1(complex(-Inf, 5.0)), complex(-1.0,sin(5.0)* 0.0))
+@test isequal(expm1(complex(-Inf,-5.0)), complex(-1.0,sin(5.0)*-0.0))
+@test isequal(expm1(complex(-Inf, Inf)), complex(-1.0, 0.0))
+@test isequal(expm1(complex(-Inf,-Inf)), complex(-1.0,-0.0))
+@test isequal(expm1(complex(-Inf, NaN)), complex(-1.0, 0.0))
+
+@test isequal(expm1(complex( NaN, 0.0)), complex( NaN, 0.0))
+@test isequal(expm1(complex( NaN,-0.0)), complex( NaN,-0.0))
+@test isequal(expm1(complex( NaN, 5.0)), complex( NaN, NaN))
+@test isequal(expm1(complex( NaN, NaN)), complex( NaN, NaN))
+
 # ^ (cpow)
 #  equivalent to exp(y*log(x))
 #    except for 0^0?

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -138,6 +138,20 @@
 @test isequal(expm1(complex( NaN, 5.0)), complex( NaN, NaN))
 @test isequal(expm1(complex( NaN, NaN)), complex( NaN, NaN))
 
+@test isequal(expm1(complex( 1e-20, 0.0)), complex(expm1( 1e-20), 0.0))
+@test isequal(expm1(complex(-1e-20, 0.0)), complex(expm1(-1e-20), 0.0))
+
+@test_approx_eq expm1(complex( 1e-20, 1e-10)) complex( 5e-21, 1e-10)
+@test_approx_eq expm1(complex( 1e-20,-1e-10)) complex( 5e-21,-1e-10)
+@test_approx_eq expm1(complex(-1e-20, 1e-10)) complex(-1.5e-20, 1e-10)
+@test_approx_eq expm1(complex(-1e-20,-1e-10)) complex(-1.5e-20,-1e-10)
+
+@test_approx_eq expm1(complex( 10.0, 10.0)) exp(complex( 10.0, 10.0))-1
+@test_approx_eq expm1(complex( 10.0,-10.0)) exp(complex( 10.0,-10.0))-1
+@test_approx_eq expm1(complex(-10.0, 10.0)) exp(complex(-10.0, 10.0))-1
+@test_approx_eq expm1(complex(-10.0,-10.0)) exp(complex(-10.0,-10.0))-1
+
+
 # ^ (cpow)
 #  equivalent to exp(y*log(x))
 #    except for 0^0?


### PR DESCRIPTION
Partially addresses #3141. It uses the property that

```
cos(x) - 1 = -2*sin(x/2)^2
```

There is some cancellation error when `real(z)` ~ `imag(z)^2/2` for small `z`, but otherwise is fairly stable.

I also removed some unnecessary branching conditions from the complex `exp`.
