### PR TITLE
Adjust array/scalar promotion to handle rationals and complex numbers.

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -678,10 +678,9 @@ end
 ## Binary arithmetic operators ##
 
 promote_array_type{Scalar, Arry}(::Type{Scalar}, ::Type{Arry}) = promote_type(Scalar, Arry)
-promote_array_type{S<:Real, A<:Real}(::Type{S}, ::Type{A}) = A
-promote_array_type{S<:Complex, A<:Complex}(::Type{S}, ::Type{A}) = A
+promote_array_type{S<:Real, A<:FloatingPoint}(::Type{S}, ::Type{A}) = A
+promote_array_type{S<:Union(Complex, Real), AT<:FloatingPoint}(::Type{S}, ::Type{Complex{AT}}) = Complex{AT}
 promote_array_type{S<:Integer, A<:Integer}(::Type{S}, ::Type{A}) = A
-promote_array_type{S<:Real, A<:Integer}(::Type{S}, ::Type{A}) = promote_type(S, A)
 promote_array_type{S<:Integer}(::Type{S}, ::Type{Bool}) = S
 
 ./{T<:Integer}(x::Integer, y::StridedArray{T}) =


### PR DESCRIPTION
Even though I understand the reason, I am not a big fan of the fact that array and scalar promotion are different. However, given the difference, I still believe this is wrong

```
 julia> [1//1]/π
1-element Array{Rational{Int64},1}:
 78256779//245850922
```

and this must be violating the no array explosion policy

```
julia> [complex(1.0f0)]/1.0
1-element Array{Complex{Float64},1}:
 1.0+0.0im
```

This pull request gives

```
julia> [1//1]/π
1-element Array{Float64,1}:
 0.31831

julia> [complex(1.0f0)]/1.0
1-element Array{Complex{Float32},1}:
 1.0+0.0im
```

I might have overlooked a corner case or two, so please have a look.
