### PR TITLE
fix #6540: utf16(s) for binary data, etc.

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -775,6 +775,7 @@ export
     is_valid_ascii,
     is_valid_char,
     is_valid_utf8,
+    is_valid_utf16,
     isalnum,
     isalpha,
     isascii,

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -33,7 +33,7 @@ IOBuffer(data::Vector{Uint8},readable::Bool,writable::Bool,maxsize::Int) =
         IOBuffer(data,readable,writable,true,false,maxsize)
 IOBuffer(data::Vector{Uint8},readable::Bool,writable::Bool) = IOBuffer(data,readable,writable,typemax(Int))
 IOBuffer(data::Vector{Uint8}) = IOBuffer(data, true, false)
-IOBuffer(str::String) = IOBuffer(str.data, true, false)
+IOBuffer(str::ByteString) = IOBuffer(str.data, true, false)
 IOBuffer(readable::Bool,writable::Bool) = IOBuffer(Uint8[],readable,writable)
 IOBuffer() = IOBuffer(Uint8[], true, true)
 IOBuffer(maxsize::Int) = (x=IOBuffer(Array(Uint8,maxsize),true,true,maxsize); x.size=0; x)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1300,6 +1300,14 @@ Strings
 
    General unescaping of traditional C and Unicode escape sequences. Reverse of :func:`escape_string`. See also :func:`print_unescaped`.
 
+.. function:: utf16(s)
+
+   Create a UTF-16 string from a byte array, array of ``Uint16``, or
+   any other string type.  (Data must be valid UTF-16.)
+
+.. function:: is_valid_utf16(s)
+
+   Returns true if the string or ``Uint16`` array is valid UTF-16.
 
 I/O
 ---

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1303,7 +1303,9 @@ Strings
 .. function:: utf16(s)
 
    Create a UTF-16 string from a byte array, array of ``Uint16``, or
-   any other string type.  (Data must be valid UTF-16.)
+   any other string type.  (Data must be valid UTF-16.  Conversions of
+   byte arrays check for a byte-order marker in the first two bytes,
+   and do not include it in the resulting string.)
 
 .. function:: is_valid_utf16(s)
 

--- a/test/unicode.jl
+++ b/test/unicode.jl
@@ -54,4 +54,5 @@ else
 	@test length(u16) == 4
 	@test utf8(u16) == u8
 	@test collect(u8) == collect(u16)
+        @test u16 == utf16(u16.data) == utf16(reinterpret(Uint8, u16.data))
 end


### PR DESCRIPTION
This patch adds `utf16(s)` for binary data, an `is_valid_utf16(s)` function analogous to `is_valid_utf8`, and restricts `IOBuffer(s::String)` to `ByteString`s as discussed in #6540.
