### PR TITLE
RFC: Optional explicit return type for map and broadcast

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1306,7 +1306,7 @@ function map(f::Callable, As::AbstractArray...)
 end
 
 # Explicit control over return eltype
-function map(f::Callable, T::DataType, As::AbstractArray...)
+function map(f::Callable, T::Type, As::AbstractArray...)
     shape = mapreduce(size, promote_shape, As)
     prod(shape) == 0 && return similar(As[1], T, shape)
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1305,6 +1305,16 @@ function map(f::Callable, As::AbstractArray...)
     return map_to!(f, first, dest, As...)
 end
 
+# Explicit control over return eltype
+function map(f::Callable, T::DataType, As::AbstractArray...)
+    shape = mapreduce(size, promote_shape, As)
+    prod(shape) == 0 && return similar(As[1], T, shape)
+
+    first = f(map(a->a[1], As)...)
+    dest = similar(As[1], T, shape)
+    return map_to!(f, first, dest, As...)
+end
+
 # multi-item push!, unshift! (built on top of type-specific 1-item version)
 # (note: must not cause a dispatch loop when 1-item case is not defined)
 push!(A) = A

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -230,8 +230,11 @@ for (Bsig, Asig, gbf, gbb) in
     end  # let broadcast_cache
 end
 
+broadcast(f::Function, T::DataType, As...) =
+    broadcast!(f, Array(T, broadcast_shape(As...)), As...)
 
-broadcast(f::Function, As...) = broadcast!(f, Array(promote_eltype(As...), broadcast_shape(As...)), As...)
+broadcast(f::Function, As...) =
+    broadcast(f, promote_eltype(As...), As...)
 
 bitbroadcast(f::Function, As...) = broadcast!(f, BitArray(broadcast_shape(As...)), As...)
 

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -240,6 +240,7 @@ bitbroadcast(f::Function, As...) = broadcast!(f, BitArray(broadcast_shape(As...)
 
 broadcast!_function(f::Function) = (B, As...) -> broadcast!(f, B, As...)
 broadcast_function(f::Function) = (As...) -> broadcast(f, As...)
+broadcast_function(f::Function, T::DataType) = (As...) -> broadcast(f, T, As...)
 
 broadcast_getindex(src::AbstractArray, I::AbstractArray...) = broadcast_getindex!(Array(eltype(src), broadcast_shape(I...)), src, I...)
 @ngenerate N typeof(dest) function broadcast_getindex!(dest::AbstractArray, src::AbstractArray, I::NTuple{N, AbstractArray}...)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -230,7 +230,7 @@ for (Bsig, Asig, gbf, gbb) in
     end  # let broadcast_cache
 end
 
-broadcast(f::Function, T::DataType, As...) =
+broadcast(f::Function, T::Type, As...) =
     broadcast!(f, Array(T, broadcast_shape(As...)), As...)
 
 broadcast(f::Function, As...) =
@@ -240,7 +240,7 @@ bitbroadcast(f::Function, As...) = broadcast!(f, BitArray(broadcast_shape(As...)
 
 broadcast!_function(f::Function) = (B, As...) -> broadcast!(f, B, As...)
 broadcast_function(f::Function) = (As...) -> broadcast(f, As...)
-broadcast_function(f::Function, T::DataType) = (As...) -> broadcast(f, T, As...)
+broadcast_function(f::Function, T::Type) = (As...) -> broadcast(f, T, As...)
 
 broadcast_getindex(src::AbstractArray, I::AbstractArray...) = broadcast_getindex!(Array(eltype(src), broadcast_shape(I...)), src, I...)
 @ngenerate N typeof(dest) function broadcast_getindex!(dest::AbstractArray, src::AbstractArray, I::NTuple{N, AbstractArray}...)


### PR DESCRIPTION
``` julia
broadcast((x,y)->x+1.5y, (-5:5)', -5:5) => InexactError()
broadcast((x,y)->x+1.5y, Float64, (-5:5)', -5:5) => 11x11 Array{Float64,2}

map(join, ["z", "я"]) => ERROR: invalid ASCII sequence
map(join, UTF8String, ["z", "я"]) => UTF8String["z","я"]
```
