### PR TITLE
RFC: Promote result array in map

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1247,6 +1247,12 @@ function mapslices(f::Function, A::AbstractArray, dims::AbstractVector)
     return R
 end
 
+function promote_setindex!{T, S}(a::AbstractArray{T}, v::S, ids...)
+    Super = promote_type(T, S)
+    T == Super || (a = convert(AbstractArray{Super}, a))
+    a[ids...] = v
+    return a
+end
 
 ## 1 argument
 function map_to!(f::Callable, first, dest::AbstractArray, A::AbstractArray)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1258,7 +1258,7 @@ end
 function map_to!(f::Callable, first, dest::AbstractArray, A::AbstractArray)
     dest[1] = first
     for i=2:length(A)
-        dest[i] = f(A[i])
+        dest = promote_setindex!(dest, f(A[i]), i)
     end
     return dest
 end
@@ -1274,7 +1274,7 @@ end
 function map_to!(f::Callable, first, dest::AbstractArray, A::AbstractArray, B::AbstractArray)
     dest[1] = first
     for i=2:length(A)
-        dest[i] = f(A[i], B[i])
+        dest = promote_setindex!(dest, f(A[i], B[i]), i)
     end
     return dest
 end
@@ -1296,7 +1296,7 @@ function map_to!(f::Callable, first, dest::AbstractArray, As::AbstractArray...)
     ith = a->a[i]
     dest[1] = first
     for i=2:n
-        dest[i] = f(map(ith, As)...)
+        dest = promote_setindex!(dest, f(map(ith, As)...), i)
     end
     return dest
 end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1247,6 +1247,11 @@ function mapslices(f::Function, A::AbstractArray, dims::AbstractVector)
     return R
 end
 
+function promote_setindex!{T}(a::AbstractArray{T}, v::T, ids...)
+    a[ids...] = v
+    return a
+end
+
 function promote_setindex!{T, S}(a::AbstractArray{T}, v::S, ids...)
     Super = promote_type(T, S)
     T == Super || (a = convert(AbstractArray{Super}, a))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -144,10 +144,10 @@ eval(ngenerate(:N, nothing, :(setindex!{T}(s::SubArray{T,N}, v, ind::Integer)), 
     A
 end
 
-@ngenerate N typeof(dest) function copy!{T,N}(dest::AbstractArray{T,N}, src::AbstractArray{T,N})
+@ngenerate N typeof(dest) function copy!{S,T,N}(dest::AbstractArray{S,N}, src::AbstractArray{T,N})
     if @nall N d->(size(dest,d) == size(src,d))
         @nloops N i dest begin
-            @inbounds (@nref N dest i) = (@nref N src i)
+            @inbounds (isbits(T) || @ncall N isdefined src i) && ((@nref N dest i) = (@nref N src i))
         end
     else
         invoke(copy!, (typeof(dest), Any), dest, src)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -145,9 +145,10 @@ eval(ngenerate(:N, nothing, :(setindex!{T}(s::SubArray{T,N}, v, ind::Integer)), 
 end
 
 @ngenerate N typeof(dest) function copy!{S,T,N}(dest::AbstractArray{S,N}, src::AbstractArray{T,N})
+    defined = !isa(src, Array)
     if @nall N d->(size(dest,d) == size(src,d))
         @nloops N i dest begin
-            @inbounds (isbits(T) || @ncall N isdefined src i) && ((@nref N dest i) = (@nref N src i))
+            @inbounds (defined || @ncall N isdefined src i) && ((@nref N dest i) = (@nref N src i))
         end
     else
         invoke(copy!, (typeof(dest), Any), dest, src)


### PR DESCRIPTION
I've added promotion to `map` – if the next `f(x)` doesn't fit into the result array, the array type is promoted. This will fix things like `map(join, ["z", "я"])`. Equally, functions that can return `Int`s and `Float`s will promote to `Float` rather than trying to cast everything to `Int` (and producing `InexactError`s).

Performance in cases that already work should be largely unaffected; in almost all other cases, the promotion will only happen once. #210 still needs fixing for ideal performance, but at least this way `map` is functional in both senses.

(The worst case performance hit – for a small function over an `Int` array – is about 2x.)

In order to make this work I had to extend `copy!` to support undefined values, as well as making it more flexible so that it gets called instead of the generic `copy!(dest::AbstractArray, src)`.

By the way, why are there map definitions for 1, 2, and multiple args? Wouldn't the N arg version suffice?
