### PR TITLE
Support OrdinalRange in select for Vectors.

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -428,6 +428,8 @@ minimum{T<:Real}(A::AbstractArray{T}) = minimum_rgn(A, 1, length(A))
 
 ## extrema
 
+extrema(r::Range) = (minimum(r), maximum(r))
+
 function extrema(itr)
     s = start(itr)
     if done(itr, s)

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -81,9 +81,9 @@ function select!(v::AbstractVector, k::Int, lo::Int, hi::Int, o::Ordering)
     return v[lo]
 end
 
-function select!(v::AbstractVector, r::UnitRange, lo::Int, hi::Int, o::Ordering)
+function select!(v::AbstractVector, r::OrdinalRange, lo::Int, hi::Int, o::Ordering)
     isempty(r) && (return v[r])
-    a, b = first(r), last(r)
+    a, b = extrema(r)
     lo <= a <= b <= hi || error("selection $r is out of range $lo:$hi")
     @inbounds while true
         if lo == a && hi == b
@@ -112,12 +112,12 @@ function select!(v::AbstractVector, r::UnitRange, lo::Int, hi::Int, o::Ordering)
     end
 end
 
-select!(v::AbstractVector, k::Union(Int,UnitRange), o::Ordering) = select!(v,k,1,length(v),o)
-select!(v::AbstractVector, k::Union(Int,UnitRange);
+select!(v::AbstractVector, k::Union(Int,OrdinalRange), o::Ordering) = select!(v,k,1,length(v),o)
+select!(v::AbstractVector, k::Union(Int,OrdinalRange);
     lt::Function=isless, by::Function=identity, rev::Bool=false, order::Ordering=Forward) =
     select!(v, k, ord(lt,by,rev,order))
 
-select(v::AbstractVector, k::Union(Int,UnitRange); kws...) = select!(copy(v), k; kws...)
+select(v::AbstractVector, k::Union(Int,OrdinalRange); kws...) = select!(copy(v), k; kws...)
 
 # reference on sorted binary search:
 #   http://www.tbray.org/ongoing/When/200x/2003/03/22/Binary

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -6,6 +6,12 @@
 @test reverse([2,3,1]) == [1,3,2]
 @test select([3,6,30,1,9],3) == 6
 @test select([3,6,30,1,9],3:4) == [6,9]
+let a=[1:10]
+    for r in {2:4, 1:2, 10:10, 4:2, 2:1, 4:-1:2, 2:-1:1, 10:-1:10, 4:1:3, 1:2:8, 10:-3:1}
+        @test select(a, r) == [r]
+        @test select(a, r, rev=true) == (11 .- [r])
+    end
+end
 @test sum(randperm(6)) == 21
 @test nthperm([0,1,2],3) == [1,0,2]
 


### PR DESCRIPTION
ref #6538, #6534

```
julia> a=[1:10];

julia> select(a,1:2:8)
4-element Array{Int64,1}:
 1
 3
 5
 7

julia> select(a, 2:-1:1)
2-element Array{Int64,1}:
 2
 1
```
