### PR TITLE
Bring back the nice LineEditREPL on Windows

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -351,7 +351,7 @@ function _start()
                 global is_interactive = !isa(STDIN,Union(File,IOStream))
                 color_set || (global have_color = false)
             else
-                term = Terminals.TTYTerminal(get(ENV,"TERM","dumb"),STDIN,STDOUT,STDERR)
+                term = Terminals.TTYTerminal(get(ENV,"TERM",@windows? "" : "dumb"),STDIN,STDOUT,STDERR)
                 global is_interactive = true
                 color_set || (global have_color = Terminals.hascolor(term))
             end


### PR DESCRIPTION
Windows doesn't have the TERM env var set outside of MSYS/Cygwin, so c8ae026c557 caused Windows Julia to default to the BasicREPL.

The LineEditREPL still has line duplication bugs on Windows (https://github.com/JuliaLang/julia/issues/6488), but overall it's a nicer experience than the BasicREPL.

This may un-fix https://github.com/JuliaLang/julia/issues/6428 on Windows, but I suspect Windows users are more frequently running Julia from cmd or by double-clicking than inside Emacs.
