### PR TITLE
Don't declare Intrinsics.box as pure (fix #6566)

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1839,6 +1839,7 @@ function is_pure_builtin(f)
              f === Intrinsics.pointerset || # this one is never effect-free
              f === Intrinsics.ccall ||      # this one is never effect-free
              f === Intrinsics.jl_alloca ||  # this one is volatile, TODO: possibly also effect-free?
+             f === Intrinsics.box ||
              f === Intrinsics.pointertoref) # this one is volatile
             return true
         end


### PR DESCRIPTION
I don't really know what I'm doing here, but I was able to isolate the problem to `Intrinsics.box`.
