### PR TITLE
Use PIC relocation on FreeBSD (fixes #6568)

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -354,7 +354,7 @@ void jl_dump_objfile(char* fname, int jit_model)
         jl_TargetMachine->getTargetCPU(),
         jl_TargetMachine->getTargetFeatureString(),
         jl_TargetMachine->Options,
-#ifdef _OS_LINUX_
+#if defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
         Reloc::PIC_,
 #else
         jit_model ? Reloc::PIC_ : Reloc::Default,

--- a/src/support/platform.h
+++ b/src/support/platform.h
@@ -58,7 +58,7 @@
 *******************************************************************************/
 
 #if defined(__FreeBSD__)
-#define _OS_FREEBSD__
+#define _OS_FREEBSD_
 #elif defined(__linux__)
 #define _OS_LINUX_
 #elif defined(_WIN32) || defined(_WIN64)


### PR DESCRIPTION
Fixes #6568

Also fixes a typo in platform.h (double underscore in `_OS_FREEBSD__`). As far as I can grep that symbol does not yet appear anywhere else in the repository.
