### PR TITLE
Disable fill_array calls in DSFMT to fix 6573

### DIFF
--- a/base/librandom.jl
+++ b/base/librandom.jl
@@ -5,12 +5,7 @@ export DSFMT_state, dsfmt_get_min_array_size, dsfmt_get_idstring,
        dsfmt_init_by_array, dsfmt_gv_init_by_array,
        dsfmt_genrand_close1_open2, dsfmt_gv_genrand_close1_open2,
        dsfmt_genrand_close_open, dsfmt_gv_genrand_close_open, 
-       dsfmt_genrand_open_close, dsfmt_gv_genrand_open_close, 
-       dsfmt_genrand_open_open, dsfmt_gv_genrand_open_open, 
-       dsfmt_fill_array_close1_open2!, dsfmt_gv_fill_array_close1_open2!,
        dsfmt_fill_array_close_open!, dsfmt_gv_fill_array_close_open!, 
-       dsfmt_fill_array_open_close!, dsfmt_gv_fill_array_open_close!, 
-       dsfmt_fill_array_open_open!, dsfmt_gv_fill_array_open_open!, 
        dsfmt_genrand_uint32, dsfmt_gv_genrand_uint32, 
        randmtzig_randn, randmtzig_exprnd,
        win32_SystemFunction036!
@@ -74,6 +69,19 @@ end
 
 function dsfmt_gv_genrand_close_open()
     ccall((:dsfmt_gv_genrand_close_open, :librandom),
+    Float64,
+    ())
+end
+
+function dsfmt_genrand_close1_open2(s::DSFMT_state)
+    ccall((:dsfmt_genrand_close1_open2, :librandom),
+    Float64,
+    (Ptr{Void},),
+    s.val)
+end
+
+function dsfmt_gv_genrand_close1_open2()
+    ccall((:dsfmt_gv_genrand_close1_open2, :librandom),
     Float64,
     ())
 end

--- a/base/random.jl
+++ b/base/random.jl
@@ -117,14 +117,16 @@ rand(::Type{Int128})  = int128(rand(Uint128))
 
 # Arrays of random numbers
 
-rand!(A::Array{Float64}) = dsfmt_gv_fill_array_close_open!(A)
+## Disable fill_array routines to address #6573
+#rand!(A::Array{Float64}) = dsfmt_gv_fill_array_close_open!(A)
 rand(::Type{Float64}, dims::Dims) = rand!(Array(Float64, dims))
 rand(::Type{Float64}, dims::Int...) = rand(Float64, dims)
 
 rand(dims::Dims) = rand(Float64, dims)
 rand(dims::Int...) = rand(Float64, dims)
 
-rand!(r::MersenneTwister, A::Array{Float64}) = dsfmt_fill_array_close_open!(r.state, A)
+## Disable fill_array routines to address #6573
+#rand!(r::MersenneTwister, A::Array{Float64}) = dsfmt_fill_array_close_open!(r.state, A)
 rand(r::AbstractRNG, dims::Dims) = rand!(r, Array(Float64, dims))
 rand(r::AbstractRNG, dims::Int...) = rand(r, dims)
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -635,7 +635,7 @@ dsfmt-$(DSFMT_VER)/config.status: dsfmt-$(DSFMT_VER).tar.gz
 	$(TAR) -C dsfmt-$(DSFMT_VER) --strip-components 1 -xf dsfmt-$(DSFMT_VER).tar.gz && \
 	cd dsfmt-$(DSFMT_VER) && patch < ../dSFMT.h.patch && patch < ../dSFMT.c.patch
 	echo 1 > $@
-$(LIBRANDOM_OBJ_SOURCE): dsfmt-$(DSFMT_VER)/config.status dsfmt-$(DSFMT_VER)/dSFMT.c 
+$(LIBRANDOM_OBJ_SOURCE): dsfmt-$(DSFMT_VER)/config.status
 	$(CC) $(CPPFLAGS) $(LIBRANDOM_CFLAGS) $(LDFLAGS) dsfmt-$(DSFMT_VER)/dSFMT.c -o librandom.$(SHLIB_EXT) && \
 	$(INSTALL_NAME_CMD)librandom.$(SHLIB_EXT) librandom.$(SHLIB_EXT)
 $(LIBRANDOM_OBJ_TARGET): $(LIBRANDOM_OBJ_SOURCE)

--- a/test/random.jl
+++ b/test/random.jl
@@ -1,3 +1,7 @@
+# Issue #6573
+srand(0); rand(); x = rand(384);
+@test find(x .== rand()) == []
+
 @test rand() != rand()
 @test 0.0 <= rand() < 1.0
 @test rand(Uint32) >= 0


### PR DESCRIPTION
For #6573 I looked through the code but it appears that we are calling the `fill_array` routines correctly. For now, to fix this issue, I am disabling the `fill_array` routines, so that we only call `dsfmt_gv_genrand_close_open` for all random number generation.
