### PR TITLE
Only use unpromoted arithmetic for types no larger than 32 bit on 32 bit systems. Use explicit integer sizes in random test to avoid errors on 32 bit systems.

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -9,6 +9,14 @@ import Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), ($),
              serialize, deserialize, bin, oct, dec, hex, isequal, invmod,
              prevpow2, nextpow2, ndigits0z, widen
 
+if Clong == Int32
+    typealias ClongMax Union(Int8, Int16, Int32)
+    typealias CulongMax Union(Uint8, Uint16, Uint32)
+else
+    typealias ClongMax Union(Int8, Int16, Int32, Int64)
+    typealias CulongMax Union(Uint8, Uint16, Uint32, Uint64)
+end
+
 type BigInt <: Integer
     alloc::Cint
     size::Cint
@@ -235,10 +243,10 @@ function +(x::BigInt, c::Culong)
     return z
 end
 +(c::Culong, x::BigInt) = x + c
-+(c::Unsigned, x::BigInt) = x + convert(Culong, c)
-+(x::BigInt, c::Unsigned) = x + convert(Culong, c)
-+(x::BigInt, c::Signed) = c < 0 ? -(x, convert(Culong, -c)) : x + convert(Culong, c)
-+(c::Signed, x::BigInt) = c < 0 ? -(x, convert(Culong, -c)) : x + convert(Culong, c)
++(c::CulongMax, x::BigInt) = x + convert(Culong, c)
++(x::BigInt, c::CulongMax) = x + convert(Culong, c)
++(x::BigInt, c::ClongMax) = c < 0 ? -(x, convert(Culong, -c)) : x + convert(Culong, c)
++(c::ClongMax, x::BigInt) = c < 0 ? -(x, convert(Culong, -c)) : x + convert(Culong, c)
 
 function -(x::BigInt, c::Culong)
     z = BigInt()
@@ -250,10 +258,10 @@ function -(c::Culong, x::BigInt)
     ccall((:__gmpz_ui_sub, :libgmp), Void, (Ptr{BigInt}, Culong, Ptr{BigInt}), &z, c, &x)
     return z
 end
--(x::BigInt, c::Unsigned) = -(x, convert(Culong, c))
--(c::Unsigned, x::BigInt) = -(convert(Culong, c), x)
--(x::BigInt, c::Signed) = c < 0 ? +(x, convert(Culong, -c)) : -(x, convert(Culong, c))
--(c::Signed, x::BigInt) = c < 0 ? -(x + convert(Culong, -c)) : -(convert(Culong, c), x)
+-(x::BigInt, c::CulongMax) = -(x, convert(Culong, c))
+-(c::CulongMax, x::BigInt) = -(convert(Culong, c), x)
+-(x::BigInt, c::ClongMax) = c < 0 ? +(x, convert(Culong, -c)) : -(x, convert(Culong, c))
+-(c::ClongMax, x::BigInt) = c < 0 ? -(x + convert(Culong, -c)) : -(convert(Culong, c), x)
 
 function *(x::BigInt, c::Culong)
     z = BigInt()
@@ -261,16 +269,16 @@ function *(x::BigInt, c::Culong)
     return z
 end
 *(c::Culong, x::BigInt) = x * c
-*(c::Unsigned, x::BigInt) = x * convert(Culong, c)
-*(x::BigInt, c::Unsigned) = x * convert(Culong, c)
+*(c::CulongMax, x::BigInt) = x * convert(Culong, c)
+*(x::BigInt, c::CulongMax) = x * convert(Culong, c)
 function *(x::BigInt, c::Clong)
     z = BigInt()
     ccall((:__gmpz_mul_si, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Clong), &z, &x, c)
     return z
 end
 *(c::Clong, x::BigInt) = x * c
-*(x::BigInt, c::Signed) = x * convert(Clong, c)
-*(c::Signed, x::BigInt) = x * convert(Clong, c)
+*(x::BigInt, c::ClongMax) = x * convert(Clong, c)
+*(c::ClongMax, x::BigInt) = x * convert(Clong, c)
 
 # unary ops
 for (fJ, fC) in ((:-, :neg), (:~, :com))

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -19,6 +19,8 @@ import
         serialize, deserialize, inf, nan, hash, cbrt, typemax, typemin,
         realmin, realmax, get_rounding, set_rounding, maxintfloat, widen
 
+import Base.GMP: ClongMax, CulongMax
+
 import Base.Math.lgamma_r
 
 const ROUNDING_MODE = [0]
@@ -140,8 +142,8 @@ function +(x::BigFloat, c::Culong)
     return z
 end
 +(c::Culong, x::BigFloat) = x + c
-+(c::Unsigned, x::BigFloat) = x + convert(Culong, c)
-+(x::BigFloat, c::Unsigned) = x + convert(Culong, c)
++(c::CulongMax, x::BigFloat) = x + convert(Culong, c)
++(x::BigFloat, c::CulongMax) = x + convert(Culong, c)
 
 # Signed addition
 function +(x::BigFloat, c::Clong)
@@ -150,8 +152,8 @@ function +(x::BigFloat, c::Clong)
     return z
 end
 +(c::Clong, x::BigFloat) = x + c
-+(x::BigFloat, c::Signed) = x + convert(Clong, c)
-+(c::Signed, x::BigFloat) = x + convert(Clong, c)
++(x::BigFloat, c::ClongMax) = x + convert(Clong, c)
++(c::ClongMax, x::BigFloat) = x + convert(Clong, c)
 
 # Float64 addition
 function +(x::BigFloat, c::Float64)
@@ -182,8 +184,8 @@ function -(c::Culong, x::BigFloat)
     ccall((:mpfr_ui_sub, :libmpfr), Int32, (Ptr{BigFloat}, Culong, Ptr{BigFloat}, Int32), &z, c, &x, ROUNDING_MODE[end])
     return z
 end
--(x::BigFloat, c::Unsigned) = -(x, convert(Culong, c))
--(c::Unsigned, x::BigFloat) = -(convert(Culong, c), x)
+-(x::BigFloat, c::CulongMax) = -(x, convert(Culong, c))
+-(c::CulongMax, x::BigFloat) = -(convert(Culong, c), x)
 
 # Signed subtraction
 function -(x::BigFloat, c::Clong)
@@ -196,8 +198,8 @@ function -(c::Clong, x::BigFloat)
     ccall((:mpfr_si_sub, :libmpfr), Int32, (Ptr{BigFloat}, Clong, Ptr{BigFloat}, Int32), &z, c, &x, ROUNDING_MODE[end])
     return z
 end
--(x::BigFloat, c::Signed) = -(x, convert(Clong, c))
--(c::Signed, x::BigFloat) = -(convert(Clong, c), x)
+-(x::BigFloat, c::ClongMax) = -(x, convert(Clong, c))
+-(c::ClongMax, x::BigFloat) = -(convert(Clong, c), x)
 
 # Float64 subtraction
 function -(x::BigFloat, c::Float64)
@@ -232,10 +234,8 @@ function *(x::BigFloat, c::Culong)
     return z
 end
 *(c::Culong, x::BigFloat) = x * c
-if Culong === Uint64
-    *(c::Uint32, x::BigFloat) = x * convert(Culong, c)
-    *(x::BigFloat, c::Uint32) = x * convert(Culong, c)
-end
+*(c::CulongMax, x::BigFloat) = x * convert(Culong, c)
+*(x::BigFloat, c::CulongMax) = x * convert(Culong, c)
 
 # Signed multiplication
 function *(x::BigFloat, c::Clong)
@@ -244,8 +244,8 @@ function *(x::BigFloat, c::Clong)
     return z
 end
 *(c::Clong, x::BigFloat) = x * c
-*(x::BigFloat, c::Union(Int8,Uint8,Int16,Uint16,Int32)) = x * convert(Clong, c)
-*(c::Union(Int8,Uint8,Int16,Uint16,Int32), x::BigFloat) = x * convert(Clong, c)
+*(x::BigFloat, c::ClongMax) = x * convert(Clong, c)
+*(c::ClongMax, x::BigFloat) = x * convert(Clong, c)
 
 # Float64 multiplication
 function *(x::BigFloat, c::Float64)
@@ -276,8 +276,8 @@ function /(c::Culong, x::BigFloat)
     ccall((:mpfr_ui_div, :libmpfr), Int32, (Ptr{BigFloat}, Culong, Ptr{BigFloat}, Int32), &z, c, &x, ROUNDING_MODE[end])
     return z
 end
-/(x::BigFloat, c::Unsigned) = /(x, convert(Culong, c))
-/(c::Unsigned, x::BigFloat) = /(convert(Culong, c), x)
+/(x::BigFloat, c::CulongMax) = /(x, convert(Culong, c))
+/(c::CulongMax, x::BigFloat) = /(convert(Culong, c), x)
 
 # Signed division
 function /(x::BigFloat, c::Clong)
@@ -290,8 +290,8 @@ function /(c::Clong, x::BigFloat)
     ccall((:mpfr_si_div, :libmpfr), Int32, (Ptr{BigFloat}, Clong, Ptr{BigFloat}, Int32), &z, c, &x, ROUNDING_MODE[end])
     return z
 end
-/(x::BigFloat, c::Signed) = /(x, convert(Clong, c))
-/(c::Signed, x::BigFloat) = /(convert(Clong, c), x)
+/(x::BigFloat, c::ClongMax) = /(x, convert(Clong, c))
+/(c::ClongMax, x::BigFloat) = /(convert(Clong, c), x)
 
 # Float64 division
 function /(x::BigFloat, c::Float64)
@@ -373,13 +373,13 @@ rad2deg(z::BigFloat) = 180/big(pi)*z
 deg2rad(z::BigFloat) = big(pi)/180*z
 
 
-function ^(x::BigFloat, y::Unsigned)
+function ^(x::BigFloat, y::CulongMax)
     z = BigFloat()
     ccall((:mpfr_pow_ui, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Culong, Int32), &z, &x, y, ROUNDING_MODE[end])
     return z
 end
 
-function ^(x::BigFloat, y::Signed)
+function ^(x::BigFloat, y::ClongMax)
     z = BigFloat()
     ccall((:mpfr_pow_si, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Clong, Int32), &z, &x, y, ROUNDING_MODE[end])
     return z
@@ -416,8 +416,9 @@ function ldexp(x::BigFloat, n::Culong)
     ccall((:mpfr_mul_2ui, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Culong, Int32), &z, &x, n, ROUNDING_MODE[end])
     return z
 end
-ldexp(x::BigFloat, n::Signed) = ldexp(x, convert(Clong, n))
-ldexp(x::BigFloat, n::Unsigned) = ldexp(x, convert(Culong, n))
+ldexp(x::BigFloat, n::ClongMax) = ldexp(x, convert(Clong, n))
+ldexp(x::BigFloat, n::CulongMax) = ldexp(x, convert(Culong, n))
+ldexp(x::BigFloat, n::Integer) = x*exp2(BigFloat(n))
 
 function besselj0(x::BigFloat)
     z = BigFloat()

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -26,22 +26,30 @@ y = BigFloat(12//1)
 x = BigFloat(12)
 y = BigFloat(30)
 @test x + y == BigFloat(42)
+@test x + typemax(Uint128) == x + BigInt(typemax(Uint128))
+@test x + typemax(Int128) == x + BigInt(typemax(Int128))
 
 # -
 x = BigFloat(12)
 y = BigFloat(-30)
 @test x - y == BigFloat(42)
+@test x - typemax(Uint128) == x - BigInt(typemax(Uint128))
+@test x - typemax(Int128) == x - BigInt(typemax(Int128))
 
 # *
 x = BigFloat(6)
 y = BigFloat(9)
 @test x * y != BigFloat(42)
 @test x * y == BigFloat(54)
+@test x * typemax(Uint128) == x * BigInt(typemax(Uint128))
+@test x * typemax(Int128) == x * BigInt(typemax(Int128))
 
 # /
 x = BigFloat(9)
 y = BigFloat(6)
 @test x / y == BigFloat(9/6)
+@test x / typemax(Uint128) == x / BigInt(typemax(Uint128))
+@test x / typemax(Int128) == x / BigInt(typemax(Int128))
 
 # iterated arithmetic
 a = BigFloat(12.25)

--- a/test/random.jl
+++ b/test/random.jl
@@ -45,10 +45,10 @@ end
 
 # Test ziggurat tables
 ziggurat_table_size = 256
-nmantissa           = 2^51 # one bit for the sign
+nmantissa           = int64(2)^51 # one bit for the sign
 ziggurat_nor_r      = BigFloat("3.65415288536100879635194725185604664812733315920964488827246397029393565706474")
 nor_section_area    = ziggurat_nor_r*exp(-ziggurat_nor_r^2/2) + erfc(ziggurat_nor_r/sqrt(BigFloat(2)))*sqrt(big(π)/2)
-emantissa           = 2^52
+emantissa           = int64(2)^52
 ziggurat_exp_r      = BigFloat("7.69711747013104971404462804811408952334296818528283253278834867283241051210533")
 exp_section_area    = (ziggurat_exp_r + 1)*exp(-ziggurat_exp_r)
 
@@ -72,7 +72,7 @@ function randmtzig_fill_ziggurat_tables() # Operates on the global arrays
     # defines this as
     # k_0 = 2^31 * r * f(r) / v, w_0 = 0.5^31 * v / f(r), f_0 = 1,
     # where v is the area of each strip of the ziggurat.
-    ki[1] = uint(itrunc(x1*fib[256]/nor_section_area*nmantissa))
+    ki[1] = uint64(itrunc(x1*fib[256]/nor_section_area*nmantissa))
     wib[1] = nor_section_area/fib[256]/nmantissa
     fib[1] = one(BigFloat)
 


### PR DESCRIPTION
This one should fix the test errors for random.jl on 32 bit machines. The changes are those suggested by @rickhg12hs in #6577.
