### PR TITLE
Remove trailing whitespace in generated test/runtests.jl

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -118,7 +118,7 @@ function tests(pkg::String; force::Bool=false)
     genfile(pkg,"test/runtests.jl",force) do io
         print(io, """
         using $pkg
-        using Base.Test  
+        using Base.Test
 
         # write your own tests here
         @test 1 == 1


### PR DESCRIPTION
Just a minor cleanup.
