### PR TITLE
[release-0.2] Fix readline 6.3 compilation problems

### DIFF
--- a/ui/repl-readline.c
+++ b/ui/repl-readline.c
@@ -831,7 +831,7 @@ void jl_init_repl(int history)
     rl_instream = fopen("/dev/null","r");
     prompt_length = 7;  // == strlen("julia> ")
     init_history();
-    rl_startup_hook = (Function*)init_rl;
+    rl_startup_hook = (rl_hook_func_t*)init_rl;
 }
 
 static char *prompt_string=NULL;


### PR DESCRIPTION
Readline 6.3 has removed the `Function *` types, causing compilation to fail when the user has readline 6.3 installed on their system and uses `USE_SYSTEM_READLINE=1`.  This patch also works with readline 6.2, so we retain compatibility with the readline that Julia downloads and installs.
