### PR TITLE
SIGINT on Ctrl-C in REPL if under ptrace

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1157,6 +1157,9 @@ const default_keymap =
     "\ed" => edit_delete_next_word,
     # ^C
     "^C" => s->begin
+        try # raise the debugger if present
+            ccall(:jl_raise_debugger, Int, ())
+        end
         move_input_end(s)
         refresh_line(s)
         print(terminal(s), "^C\n\n")

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -118,8 +118,9 @@ size_t rec_backtrace_ctx_dwarf(ptrint_t *data, size_t maxsize, bt_context_t ctx)
 #endif
 
 #ifndef _OS_WINDOWS_
-DLLEXPORT void jl_dump_linedebug_info();
+DLLEXPORT void jl_dump_linedebug_info(void);
 DLLEXPORT void jl_restore_linedebug_info(uv_lib_t* handle);
+DLLEXPORT void jl_raise_debugger(void);
 #endif
 
 #ifdef __cplusplus

--- a/src/sys.c
+++ b/src/sys.c
@@ -11,6 +11,7 @@
 #ifndef _OS_WINDOWS_
 #include <sys/sysctl.h>
 #include <sys/wait.h>
+#include <sys/ptrace.h>
 #include <unistd.h>
 #include <sys/mman.h>
 #include <dlfcn.h>
@@ -22,6 +23,7 @@
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #include <mach-o/nlist.h>
+#include <sys/types.h> // for jl_raise_debugger
 #endif
 
 #ifdef _OS_LINUX_
@@ -655,6 +657,45 @@ DLLEXPORT int jl_dllist(jl_array_t *list)
     return EnumerateLoadedModules64(GetCurrentProcess(), jl_EnumerateLoadedModulesProc64, list);
 }
 #endif
+
+DLLEXPORT void jl_raise_debugger(void)
+{
+    size_t debugger = 0;
+#if defined(__APPLE__) && defined(DEBUG)
+    // Code derived from:
+    // https://developer.apple.com/library/mac/samplecode/sc2195/Listings/PublicUtility_CADebugger_cpp.html
+    int                 junk;
+    int                 mib[4];
+    struct kinfo_proc   info;
+    size_t              size;
+
+    info.kp_proc.p_flag = 0;
+
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC;
+    mib[2] = KERN_PROC_PID;
+    mib[3] = getpid();
+
+    size = sizeof(info);
+    junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
+    assert(junk == 0);
+
+    debugger = ( (info.kp_proc.p_flag & P_TRACED) != 0 ) ? 1 : 0;
+    // end of derivative code
+#elif defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
+    debugger = ( ptrace(PTRACE_TRACEME, 0, 0, 0) < 0 ) ? 1 : 0;
+#elif defined(_OS_WINDOWS_)
+    debugger = (IsDebuggerPresent() == 1) ? 1 : 0;
+#endif // #ifdef __APPLE__
+
+    if (debugger == 1) {
+#ifdef _OS_WINDOWS_
+        DebugBreak();
+#else
+        raise(SIGINT);
+#endif // _OS_WINDOWS_
+    }
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This can just as well live in my .juliarc, but I figured I would see if anyone else is interested. This raises `SIGINT` upon `Ctrl-C` in the REPL if Julia is running under ptrace, which is nice for setting breaks in the debugger (^Z works, but it is annoying because it takes 3 or 4 continues to resume due to threads).
