### PR TITLE
RFC: add Histogram types

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -865,7 +865,9 @@ export
 # statistics
     cor,
     cov,
+    Histogram,
     hist,
+    BivariateHistogram,
     hist2d,
     histrange,
     mean!,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -867,8 +867,6 @@ export
     cov,
     Histogram,
     hist,
-    BivariateHistogram,
-    hist2d,
     histrange,
     mean!,
     mean,

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -723,13 +723,13 @@ B = cat(3, 1, 2, 3)
 begin
     local a,h,i
     a = rand(5,5)
-    h = mapslices(v -> hist(v,0:0.1:1)[2], a, 1)
-    H = mapslices(v -> hist(v,0:0.1:1)[2], a, 2)
+    h = mapslices(v -> hist(v,0:0.1:1), a, 1)
+    H = mapslices(v -> hist(v,0:0.1:1), a, 2)
     s = mapslices(sort, a, [1])
     S = mapslices(sort, a, [2])
     for i = 1:5
-        @test h[:,i] == hist(a[:,i],0:0.1:1)[2]
-        @test vec(H[i,:]) == hist(vec(a[i,:]),0:0.1:1)[2]
+        @test h[i] == hist(a[:,i],0:0.1:1)
+        @test H[i] == hist(vec(a[i,:]),0:0.1:1)
         @test s[:,i] == sort(a[:,i])
         @test vec(S[i,:]) == sort(vec(a[i,:]))
     end

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -131,7 +131,7 @@ end # @unix_only(SharedArray tests)
 if nprocs() < 4
     remotecall_fetch(1, () -> addprocs(4 - nprocs()))
 end
-workloads = hist(@parallel((a,b)->[a,b], for i=1:7; myid(); end), nprocs())[2]
+workloads = hist(@parallel((a,b)->[a,b], for i=1:7; myid(); end), nprocs()).weights
 @test maximum(workloads) - minimum(workloads) <= 1
 
 # @parallel reduction should work even with very short ranges

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -192,15 +192,17 @@ end
 
 # test hist
 
-@test sum(hist([1,2,3])[2]) == 3
-@test hist([])[2] == []
-@test hist([1])[2] == [1]
-@test hist([1,2,3],[0,2,4]) == ([0,2,4],[2,1])
-@test hist([1,2,3],0:2:4) == (0:2:4,[2,1])
-@test all(hist([1:100]/100,0.0:0.01:1.0)[2] .==1)
-@test hist([1,1,1,1,1])[2][1] == 5
-@test sum(hist2d(rand(100, 2))[3]) == 100
-@test hist([1 2 3 4;1 2 3 4]) == (0.0:2.0:4.0, [2 2 0 0; 0 0 2 2])
+@test sum(hist([1,2,3]).weights) == 3
+@test hist([]).weights == []
+@test hist([1]).weights == [1]
+@test hist([1,2,3],[0,2,4]) == Histogram([0,2,4],[2,1])
+@test hist([1,2,3],[0,2,4]) != Histogram([0,2,4],[1,1])
+@test hist([1,2,3],0:2:4) == Histogram(0:2:4,[2,1])
+@test all(hist([1:100]/100,0.0:0.01:1.0).weights .==1)
+@test hist([1,1,1,1,1]).weights[1] == 5
+@test sum(hist2d(rand(100, 2)).weights) == 100
+r = 0.0:2.0:4.0
+@test hist([1 2 3 4;1 2 3 4],r) == [Histogram(r,[2,0]),Histogram(r,[2,0]),Histogram(r,[0,2]),Histogram(r,[0,2])]
 
 @test midpoints(1.0:1.0:10.0) == 1.5:1.0:9.5
 @test midpoints(1:10) == 1.5:9.5

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -200,9 +200,9 @@ end
 @test hist([1,2,3],0:2:4) == Histogram(0:2:4,[2,1])
 @test all(hist([1:100]/100,0.0:0.01:1.0).weights .==1)
 @test hist([1,1,1,1,1]).weights[1] == 5
-@test sum(hist2d(rand(100, 2)).weights) == 100
-r = 0.0:2.0:4.0
-@test hist([1 2 3 4;1 2 3 4],r) == [Histogram(r,[2,0]),Histogram(r,[2,0]),Histogram(r,[0,2]),Histogram(r,[0,2])]
+@test sum(hist((rand(100),rand(100))).weights) == 100
+#r = 0.0:2.0:4.0
+#@test hist([1 2 3 4;1 2 3 4],r) == [Histogram(r,[2,0]),Histogram(r,[2,0]),Histogram(r,[0,2]),Histogram(r,[0,2])]
 
 @test midpoints(1.0:1.0:10.0) == 1.5:1.0:9.5
 @test midpoints(1:10) == 1.5:9.5

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -191,7 +191,6 @@ end
 
 
 # test hist
-
 @test sum(hist([1,2,3]).weights) == 3
 @test hist([]).weights == []
 @test hist([1]).weights == [1]
@@ -201,6 +200,11 @@ end
 @test all(hist([1:100]/100,0.0:0.01:1.0).weights .==1)
 @test hist([1,1,1,1,1]).weights[1] == 5
 @test sum(hist((rand(100),rand(100))).weights) == 100
+@test hist(1:100,5;interval=:right).weights == [20,20,20,20,20]
+@test hist(1:100,5;interval=:left).weights == [19,20,20,20,20,1]
+@test hist(0:99,5;interval=:right).weights == [1,20,20,20,20,19]
+@test hist(0:99,5;interval=:left).weights == [20,20,20,20,20]
+
 #r = 0.0:2.0:4.0
 #@test hist([1 2 3 4;1 2 3 4],r) == [Histogram(r,[2,0]),Histogram(r,[2,0]),Histogram(r,[0,2]),Histogram(r,[0,2])]
 


### PR DESCRIPTION
This adds explicit types for histograms. The main advantage is that we can define methods that operate on histograms, notably `plot`. This approach closely mirrors existing functionality, but there are some alternatives that may be worth thinking about:
- Use `hist` to create both 1d and 2d versions: this could be done using tuples (similar to the `kde` function in [KernelDensity.jl](https://github.com/JuliaStats/KernelDensity.jl)).
- Create a general type for an N-dimensional histogram. For example

```
immutable Histogram{N,E,T}
   edges::NTuple{N,E}
   weights::Array{T,N}
end
```
- Methods for combining multiple histograms (for example, with distributed arrays): we could overload `+` for this?
- Move all this out of Base into [StatsBase.jl](https://github.com/JuliaStats/StatsBase.jl) (see JuliaStats/StatsBase.jl#49)
