### PR TITLE
Reference extrema from documentation of minmax

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -2770,6 +2770,7 @@ Mathematical Functions
 .. function:: minmax(x, y)
 
    Return ``(min(x,y), max(x,y))``.
+   See also: ``extrema(x)`` that returns ``(minimum(x), maximum(x))`` 
 
 .. function:: clamp(x, lo, hi)
 


### PR DESCRIPTION
I have forgotten a few times what the `extrema` function is called, and end up looking at the documentation for `minmax`. This adds the helpful hint that I would have appreciated.
