### PR TITLE
fix #6364: float ranges honor length if specified

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -150,10 +150,10 @@ colon{T<:Real}(a::T, b::FloatingPoint, c::T) = colon(promote(a,b,c)...)
 colon{T<:FloatingPoint}(a::T, b::FloatingPoint, c::T) = colon(promote(a,b,c)...)
 colon{T<:FloatingPoint}(a::T, b::Real, c::T) = colon(promote(a,b,c)...)
 
-range(a::FloatingPoint, len::Integer) = colon(a, oftype(a,a+len-1))
-range(a::FloatingPoint, st::FloatingPoint, len::Integer) = colon(a, st, a+oftype(st,(len-1)*st))
-range(a::Real, st::FloatingPoint, len::Integer) = colon(a, st, a+oftype(st,(len-1)*st))
-range(a::FloatingPoint, st::Real, len::Integer) = colon(a, st, oftype(a,a+(len-1)*st))
+range(a::FloatingPoint, len::Integer) = FloatRange(a,one(a),len,one(a))
+range(a::FloatingPoint, st::FloatingPoint, len::Integer) = FloatRange(a,st,len,one(a))
+range(a::Real, st::FloatingPoint, len::Integer) = FloatRange(float(a), st, len, one(st))
+range(a::FloatingPoint, st::Real, len::Integer) = FloatRange(a, float(st), len, one(a))
 
 ## interface implementations
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -282,3 +282,6 @@ end
 @test length(typemax(Uint):uint(1):(typemax(Uint)-1)) == 0
 @test length(typemax(Uint):uint(2):(typemax(Uint)-1)) == 0
 @test length((typemin(Int)+3):5:(typemin(Int)+1)) == 0
+
+# issue #6364
+@test length((1:64)*(pi/5)) == 64


### PR DESCRIPTION
This is a minimal fix to #6364 (it makes `length((1:64)*(pi/5)) == 64`).  In particular, `range(a, st, len)` should produce a range with the given `len`.

The fix still isn't perfect, because if the length of the range is not exactly representable in the requested floating-point type, then it will be converted to a `FloatRange` with a rounded length.     Ideally, we should have a `FloatRange1` range type in which the length is an `Int` and there is no `divisor` field, in order to represent floating-point ranges with a specified length.   But I feel that adding yet another `Range` type should be a subsequent PR (and might wait for 0.4).

cc: @StefanKarpinski 
