### PR TITLE
RFC: WIP: start to remove pointer(::Array) & friends

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -98,7 +98,7 @@ function next(::EnvHash, i)
     if env == nothing
         error(BoundsError)
     end
-    env::ByteString
+    env = env::ByteString
     m = match(r"^(.*?)=(.*)$"s, env)
     if m == nothing
         error("malformed environment entry: $env")

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -14,21 +14,21 @@ convert{T}(::Type{Ptr{T}}, p::Ptr{T}) = p
 convert{T}(::Type{Ptr{T}}, p::Ptr) = box(Ptr{T}, unbox(Ptr,p))
 
 # object to pointer
-convert(::Type{Ptr{Uint8}}, x::Symbol) = ccall(:jl_symbol_name, Ptr{Uint8}, (Any,), x)
-convert(::Type{Ptr{Int8}}, x::Symbol) = ccall(:jl_symbol_name, Ptr{Int8}, (Any,), x)
-convert(::Type{Ptr{Uint8}}, s::ByteString) = convert(Ptr{Uint8}, s.data)
-convert(::Type{Ptr{Int8}}, s::ByteString) = convert(Ptr{Int8}, s.data)
+cconvert(::Type{Ptr{Uint8}}, x::Symbol) = ccall(:jl_symbol_name, Ptr{Uint8}, (Any,), x)
+cconvert(::Type{Ptr{Int8}}, x::Symbol) = ccall(:jl_symbol_name, Ptr{Int8}, (Any,), x)
+cconvert(::Type{Ptr{Uint8}}, s::ByteString) = cconvert(Ptr{Uint8}, s.data)
+cconvert(::Type{Ptr{Int8}}, s::ByteString) = cconvert(Ptr{Int8}, s.data)
 
-convert{T}(::Type{Ptr{T}}, a::Array{T}) = ccall(:jl_array_ptr, Ptr{T}, (Any,), a)
-convert(::Type{Ptr{None}}, a::Array) = ccall(:jl_array_ptr, Ptr{None}, (Any,), a)
+cconvert{T}(::Type{Ptr{T}}, a::Array{T}) = ccall(:jl_array_ptr, Ptr{T}, (Any,), a)
+cconvert(::Type{Ptr{None}}, a::Array) = ccall(:jl_array_ptr, Ptr{None}, (Any,), a)
 
 pointer{T}(::Type{T}, x::Uint) = convert(Ptr{T}, x)
 pointer{T}(::Type{T}, x::Ptr) = convert(Ptr{T}, x)
 # note: these definitions don't mean any AbstractArray is convertible to
 # pointer. they just map the array element type to the pointer type for
 # convenience in cases that work.
-pointer{T}(x::AbstractArray{T}) = convert(Ptr{T},x)
-pointer{T}(x::AbstractArray{T}, i::Integer) = convert(Ptr{T},x)+(i-1)*sizeof(T)
+pointer{T}(x::AbstractArray{T}) = cconvert(Ptr{T},x)
+pointer{T}(x::AbstractArray{T}, i::Integer) = cconvert(Ptr{T},x)+(i-1)*sizeof(T)
 
 # unsafe pointer to array conversions
 pointer_to_array(p, dims::Dims) = pointer_to_array(p, dims, false)

--- a/base/show.jl
+++ b/base/show.jl
@@ -2,7 +2,7 @@
 show(x) = show(STDOUT::IO, x)
 
 function print(io::IO, s::Symbol)
-    pname = convert(Ptr{Uint8}, s)
+    pname = cconvert(Ptr{Uint8}, s)
     write(io, pname, int(ccall(:strlen, Csize_t, (Ptr{Uint8},), pname)))
 end
 


### PR DESCRIPTION
I think the pointer and convert(::Ptr,Array) functions make it altogether too easy to make unmanaged pointers. Leading to unsafe situations such as the following:

``` julia
julia> type X
       x::Ptr{Void}
       end

julia> X([1,2,3])
X(Ptr{Void} @0x00007ffc644a6e40)
```

Furthermore, it encourages `ccall(:a, Ret, (Ptr{T},), pointer(T))`, which is identical to the call without the `pointer`, but is potentially missing a GC root.

However, attempting to remove the pointer function from base reveals a rather heavy dependence on this function. A few of the usages of the function in the blas libraries are there to compute an offset pointer. However, many or most of these usages seem largely unnecessary.
