### PR TITLE
Don't copy in convert(AbstractArray) when element type is the same

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -299,7 +299,8 @@ end
 bool(x::AbstractArray{Bool}) = x
 bool(x::AbstractArray) = copy!(similar(x,Bool), x)
 
-convert{T,S,N}(::Type{AbstractArray{T,N}}, A::Array{S,N}) = convert(Array{T,N}, A)
+convert{T,N}(::Type{AbstractArray{T,N}}, A::AbstractArray{T,N}) = A
+convert{T,S,N}(::Type{AbstractArray{T,N}}, A::AbstractArray{S,N}) = copy!(similar(A,T), A)
 
 for (f,T) in ((:float16,    Float16),
               (:float32,    Float32),

--- a/base/array.jl
+++ b/base/array.jl
@@ -208,8 +208,6 @@ convert{T,n}(::Type{Array{T,n}}, x::Array{T,n}) = x
 convert{T,n,S}(::Type{Array{T}}, x::Array{S,n}) = convert(Array{T,n}, x)
 convert{T,n,S}(::Type{Array{T,n}}, x::Array{S,n}) = copy!(similar(x,T), x)
 
-convert{T,S,N}(::Type{AbstractArray{T,N}}, B::StridedArray{S,N}) = copy!(similar(B,T), B)
-
 function collect(T::Type, itr)
     if applicable(length, itr)
         # when length() isn't defined this branch might pollute the


### PR DESCRIPTION
...and make it work for all `AbstractArray`s.
