### PR TITLE
Enable running java perf via Makefile Fix #6317

### DIFF
--- a/test/perf/micro/Makefile
+++ b/test/perf/micro/Makefile
@@ -103,6 +103,9 @@ benchmarks/stata.csv: perf.do
 benchmarks/lua.csv: perf.lua
 	for t in 1 2 3 4 5; do gsl-shell $<; done >$@
 
+benchmarks/java.csv: java/src/main/java/PerfBLAS.java
+	for t in 1 2 3 4 5; do cd java; mvn -q exec:java; done >$@
+
 BENCHMARKS = \
 	benchmarks/c.csv \
 	benchmarks/fortran.csv \
@@ -114,7 +117,8 @@ BENCHMARKS = \
 	benchmarks/r.csv \
 	benchmarks/lua.csv \
 	benchmarks/javascript.csv \
-	benchmarks/mathematica.csv
+	benchmarks/mathematica.csv \
+	benchmarks/java.csv
 
 benchmarks.csv: bin/collect.pl $(BENCHMARKS)
 	@$(call PRINT_PERL, $^ >$@)

--- a/test/perf/micro/bin/table.pl
+++ b/test/perf/micro/bin/table.pl
@@ -30,6 +30,7 @@ our $lua_ver = `gsl-shell -v 2>&1 | grep Shell | cut -f3 -d" " | cut -f1 -d,`;
 our $javascript_ver = `node -e "console.log(process.versions.v8)"`;
 our $mathematica_ver = `echo quit | math -version | head -n 1 | cut -f2 -d" "`;
 our $stata_ver = `stata -q -b version && grep version stata.log | cut -f2 -d" " && rm stata.log`;
+our $java_ver = `java -version 2>&1 |grep "version" | cut -f 3 -d " " | cut -c 2-9`;
 
 our %systems = (
   "fortran"    => ["Fortran"     , "GCC $fortran_ver" ],
@@ -43,6 +44,7 @@ our %systems = (
   "mathematica"=> ["Mathematica" , $mathematica_ver ],
   "lua"	       => ["LuaJIT"      , "gsl-shell $lua_ver" ],
   "stata"      => ["Stata"       , $stata_ver ],
+  "java"       => ["Java"        , $java_ver ],
 );
 
 our @systems = qw(fortran julia python r matlab octave mathematica javascript go lua);


### PR DESCRIPTION
Dependencies: 
1. Oracle Java 1.7
2. Maven (`brew install maven` on OSX)
3. Set JAVA_HOME (`export JAVA_HOME=`/usr/libexec/java_home`` on OSX)

I haven't enabled adding the results to the table yet. Is everyone happy for me to do so? On my laptop, the results are: 

```
                Java
                1.7.0_45
fib             0.44
parse_int       6.42
quicksort       2.12
mandel          0.31
pi_sum          1.02
rand_mat_stat   4.38
rand_mat_mul    2.45
```
