### PR TITLE
32-bit test failure in core, box: argument is of incorrect size

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -1121,9 +1121,9 @@ f4518(x::ASCIIString, y::Union(Int32,Int64)) = 1
 @test f4518("",1) == 1
 
 # issue #4581
-bitstype 64 Date4581{T}
+bitstype WORD_SIZE Date4581{T}
 let
-    x = Intrinsics.box(Date4581{Int}, Intrinsics.unbox(Int64,int64(1234)))
+    x = Intrinsics.box(Date4581{Int}, Intrinsics.unbox(Int,int(1234)))
     xs = Date4581[x]
     ys = copy(xs)
     @test ys !== xs
@@ -1132,7 +1132,7 @@ end
 
 # issue #6591
 function f6591(d)
-    Intrinsics.box(Int64, d)
+    Intrinsics.box(Int, d)
     (f->f(d))(identity)
 end
 let d = Intrinsics.box(Date4581{Int}, 1)


### PR DESCRIPTION
On 32 bit Windows since 07780c24f48172b088fd6, running `test/core.jl` gives `ERROR: box: argument is of incorrect size` at line 1138. Oddly in the REPL, running these lines gives `ERROR: type: apply: expected Function, got IntrinsicFunction` instead.

I don't entirely get what `Intrinsics.box` does, so this could easily be breaking the intent of these tests for issues #4581 and #6591, not sure. Any better fixes for this problem?

Don't have a 32 bit Linux machine to test on, but I suspect this may be causing similar issues there?
