### PR TITLE
Only set LIBLAPACK if not provided by the ENV

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -397,8 +397,8 @@ LIBLAPACK = $(LIBBLAS)
 LIBLAPACKNAME = $(LIBBLASNAME)
 else
 ifeq ($(USE_SYSTEM_LAPACK), 1)
-LIBLAPACK = -llapack
-LIBLAPACKNAME = liblapack
+LIBLAPACK ?= -llapack
+LIBLAPACKNAME ?= liblapack
 else
 LIBLAPACK = -L$(build_shlibdir) -llapack $(LIBBLAS)
 LIBLAPACKNAME = liblapack


### PR DESCRIPTION
liblapack ist not always called liblapack in the system but different implementations have different names. Only set them to the default if the names were not declared yet (i.e. do the same as we do already with LIBBLASNAME).
