### PR TITLE
Skip PCRE tests on Windows

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -471,7 +471,9 @@ $(PCRE_SRC_TARGET): pcre-$(PCRE_VER)/config.status
 	touch -c $@
 pcre-$(PCRE_VER)/checked: $(PCRE_SRC_TARGET)
 ifeq ($(OS),$(BUILD_OS))
+ifneq ($(OS),WINNT)
 	$(MAKE) -C pcre-$(PCRE_VER) check -j1
+endif
 endif
 	echo 1 > $@
 $(PCRE_OBJ_TARGET): $(PCRE_SRC_TARGET) pcre-$(PCRE_VER)/checked


### PR DESCRIPTION
These constantly fail for silly reasons like line endings or
not having the French locale installed.

May as well just save a manual step and needing to refer people
to an easily-missed item in README.windows.md.

ref #6641 #5247 #6295
