### PR TITLE
printf tweaks, fixes, and BigFloat support

### DIFF
--- a/base/printf.jl
+++ b/base/printf.jl
@@ -531,11 +531,12 @@ macro handle_zero(ex)
     end
 end
 
-decode_oct(d::Real) = decode_oct(integer(d)) # TODO: real float decoding.
-decode_0ct(d::Real) = decode_0ct(integer(d)) # TODO: real float decoding.
-decode_dec(d::Real) = decode_dec(integer(d)) # TODO: real float decoding.
-decode_hex(d::Real) = decode_hex(integer(d)) # TODO: real float decoding.
-decode_HEX(d::Real) = decode_HEX(integer(d)) # TODO: real float decoding.
+# fallbacks for Real types without explicit decode_* implementation
+decode_oct(d::Real) = decode_oct(integer(d))
+decode_0ct(d::Real) = decode_0ct(integer(d))
+decode_dec(d::Real) = decode_dec(integer(d))
+decode_hex(d::Real) = decode_hex(integer(d))
+decode_HEX(d::Real) = decode_HEX(integer(d))
 
 handlenegative(d::Unsigned) = (false, d)
 function handlenegative(d::Integer)
@@ -661,6 +662,7 @@ function decode_dec(x::SmallFloatingPoint)
     end
     return NEG[1], POINT[1], LEN[1]
 end
+# TODO: implement decode_oct, decode_0ct, decode_hex, decode_HEX for SmallFloatingPoint
 
 ## fix decoding functions ##
 #
@@ -668,24 +670,31 @@ end
 # - if len less than point, trailing zeros implied
 #
 
-fix_dec(x::Integer, n::Int) = decode_dec(x)
+# fallback for Real types without explicit fix_dec implementation
 fix_dec(x::Real, n::Int) = fix_dec(float(x),n)
+
+fix_dec(x::Integer, n::Int) = decode_dec(x)
 
 function fix_dec(x::SmallFloatingPoint, n::Int)
     if n > BUFLEN-1; n = BUFLEN-1; end
     @grisu_ccall x Grisu.FIXED n
     if LEN[1] == 0
         DIGITS[1] = '0'
-        return (neg, int32(1), int32(1))
+        return (NEG[1], int32(1), int32(1))
     end
     return NEG[1], POINT[1], LEN[1]
 end
+
+# TODO: implement fix_dec for BigFloat
 
 ## ini decoding functions ##
 #
 # - returns (neg, point, len)
 # - implies len = n (requested digits)
 #
+
+# fallback for Real types without explicit fix_dec implementation
+ini_dec(x::Real, n::Int) = ini_dec(float(x),n)
 
 function ini_dec(d::Integer, n::Int)
     neg, x = handlenegative(d)
@@ -718,7 +727,6 @@ function ini_dec(d::Integer, n::Int)
     end
     return neg, pt, n
 end
-ini_dec(x::Real, n::Int) = ini_dec(float(x),n)
 
 function ini_dec(x::SmallFloatingPoint, n::Int)
     if x == 0.0
@@ -745,6 +753,8 @@ function ini_dec(x::BigInt, n::Int)
     end
     return (decode_dec(iround(x/big(10)^(d-n)))[1], d, n)
 end
+
+# TODO: implement ini_dec for BigFloat
 
 ### external printf interface ###
 

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -242,11 +242,11 @@ function gen_d(flags::ASCIIString, width::Int, precision::Int, c::Char)
     else
         fn = :decode_dec
     end
-    push!(blk.args, :((do_out, args) = $fn(out, $x, $flags, $width, $precision, $c)::(Bool,Tuple)))
+    push!(blk.args, :((do_out, args) = $fn(out, $x, $flags, $width, $precision, $c)))
     ifblk = Expr(:if, :do_out, Expr(:block))
     push!(blk.args, ifblk)
     blk = ifblk.args[2]
-    push!(blk.args, :((len, pt, neg) = args::(Int32,Int32,Bool)))
+    push!(blk.args, :((len, pt, neg) = args))
     # calculate padding
     width -= length(prefix)
     space_pad = width > max(1,precision) && '-' in flags ||
@@ -309,11 +309,11 @@ function gen_f(flags::ASCIIString, width::Int, precision::Int, c::Char)
     x, ex, blk = special_handler(flags,width)
     # interpret the number
     if precision < 0; precision = 6; end
-    push!(blk.args, :((do_out, args) = fix_dec(out, $x, $flags, $width, $precision, $c)::(Bool,Tuple)))
+    push!(blk.args, :((do_out, args) = fix_dec(out, $x, $flags, $width, $precision, $c)))
     ifblk = Expr(:if, :do_out, Expr(:block))
     push!(blk.args, ifblk)
     blk = ifblk.args[2]
-    push!(blk.args, :((len, pt, neg) = args::(Int32,Int32,Bool)))
+    push!(blk.args, :((len, pt, neg) = args))
     # calculate padding
     padding = nothing
     if precision > 0 || '#' in flags
@@ -373,11 +373,11 @@ function gen_e(flags::ASCIIString, width::Int, precision::Int, c::Char)
     # interpret the number
     if precision < 0; precision = 6; end
     ndigits = min(precision+1,BUFLEN-1)
-    push!(blk.args, :((do_out, args) = ini_dec(out,$x,$ndigits, $flags, $width, $precision, $c)::(Bool,Tuple)))
+    push!(blk.args, :((do_out, args) = ini_dec(out,$x,$ndigits, $flags, $width, $precision, $c)))
     ifblk = Expr(:if, :do_out, Expr(:block))
     push!(blk.args, ifblk)
     blk = ifblk.args[2]
-    push!(blk.args, :((len, pt, neg) = args::(Int32,Int32,Bool)))
+    push!(blk.args, :((len, pt, neg) = args))
     push!(blk.args, :(exp = pt-1))
     expmark = c=='E' ? "E" : "e"
     if precision==0 && '#' in flags

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -531,8 +531,13 @@ macro handle_zero(ex)
     end
 end
 
+decode_oct(d::Real) = decode_oct(integer(d)) # TODO: real float decoding.
+decode_0ct(d::Real) = decode_0ct(integer(d)) # TODO: real float decoding.
+decode_dec(d::Real) = decode_dec(integer(d)) # TODO: real float decoding.
+decode_hex(d::Real) = decode_hex(integer(d)) # TODO: real float decoding.
+decode_HEX(d::Real) = decode_HEX(integer(d)) # TODO: real float decoding.
+
 handlenegative(d::Unsigned) = (false, d)
-handlenegative(d::Real) = handlenegative(integer(d)) # TODO: real float decoding.
 function handlenegative(d::Integer)
     if d < 0
         return true, unsigned(oftype(d,-d))
@@ -541,7 +546,7 @@ function handlenegative(d::Integer)
     end
 end
 
-function decode_oct(d::Real)
+function decode_oct(d::Integer)
     neg, x = handlenegative(d)
     @handle_zero x
     pt = i = div((sizeof(x)<<3)-leading_zeros(x)+2,3)
@@ -553,7 +558,7 @@ function decode_oct(d::Real)
     return neg, int32(pt), int32(pt)
 end
 
-function decode_0ct(d::Real)
+function decode_0ct(d::Integer)
     neg, x = handlenegative(d)
     # doesn't need special handling for zero
     pt = i = div((sizeof(x)<<3)-leading_zeros(x)+5,3)
@@ -565,7 +570,7 @@ function decode_0ct(d::Real)
     return neg, int32(pt), int32(pt)
 end
 
-function decode_dec(d::Real)
+function decode_dec(d::Integer)
     neg, x = handlenegative(d)
     @handle_zero x
     pt = i = Base.ndigits0z(x)
@@ -577,7 +582,7 @@ function decode_dec(d::Real)
     return neg, int32(pt), int32(pt)
 end
 
-function decode_hex(d::Real, symbols::Array{Uint8,1})
+function decode_hex(d::Integer, symbols::Array{Uint8,1})
     neg, x = handlenegative(d)
     @handle_zero x
     pt = i = (sizeof(x)<<1)-(leading_zeros(x)>>2)
@@ -592,8 +597,8 @@ end
 const hex_symbols = "0123456789abcdef".data
 const HEX_symbols = "0123456789ABCDEF".data
 
-decode_hex(x::Real) = decode_hex(x,hex_symbols)
-decode_HEX(x::Real) = decode_hex(x,HEX_symbols)
+decode_hex(x::Integer) = decode_hex(x,hex_symbols)
+decode_HEX(x::Integer) = decode_hex(x,HEX_symbols)
 
 function decode(b::Int, x::BigInt)
     neg = x.size < 0
@@ -636,9 +641,8 @@ end
 #   *_0ct(x,n) => ensure that the first octal digits is zero
 #   *_HEX(x,n) => use uppercase digits for hexadecimal
 
-# - sets neg[1]
-# - sets point[1]
-# - implies len[1] = point[1]
+# - returns (neg, point, len)
+# - implies len = point
 #
 
 function decode_dec(x::SmallFloatingPoint)
@@ -660,9 +664,8 @@ end
 
 ## fix decoding functions ##
 #
-# - sets neg[1]
-# - sets point[1]
-# - sets len[1]; if less than point[1], trailing zeros implied
+# - returns (neg, point, len)
+# - if len less than point, trailing zeros implied
 #
 
 fix_dec(x::Integer, n::Int) = decode_dec(x)
@@ -680,9 +683,8 @@ end
 
 ## ini decoding functions ##
 #
-# - sets neg[1]
-# - sets point[1]
-# - implies len[1] = n (requested digits)
+# - returns (neg, point, len)
+# - implies len = n (requested digits)
 #
 
 function ini_dec(d::Integer, n::Int)

--- a/test/perf/micro/perf.jl
+++ b/test/perf/micro/perf.jl
@@ -138,10 +138,13 @@ end
 
 @unix_only begin
     function printfd(n)
-        open("/dev/null","w") do io
+        io = open("/dev/null","w")
+        try
             for i = 1:n
                 @printf(io,"%d %d\n",i,i+1)
             end
+        finally
+            close(io)
         end
     end
 


### PR DESCRIPTION
@StefanKarpinski 

with Keno's tuple work, we don't need to use global values for most of these return values. Although we still use the static buffer for DIGITS, the others can be returned on the stack without impacting performance.

And it's a net deletion of 1 LOC, uses 1 fewer macro, and (hopefully) will make adding BigFloat support more straightforward
