### PR TITLE
limit xtra buffer allocation

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -32,6 +32,8 @@ typedef __uint128_t wideint_t;
 typedef uint64_t wideint_t;
 #endif
 
+size_t jl_arr_xtralloc_limit = 0;
+
 #define MAXINTVAL (((size_t)-1)>>1)
 
 static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
@@ -574,6 +576,18 @@ static void array_try_unshare(jl_array_t *a)
     }
 }
 
+size_t limit_overallocation(jl_array_t *a, size_t alen, size_t newlen, size_t inc)
+{
+    // Limit overallocation to jl_arr_xtralloc_limit
+    size_t es = a->elsize;
+    size_t xtra_elems_mem = (newlen - a->offset - alen - inc) * es;
+    if (xtra_elems_mem > jl_arr_xtralloc_limit) {
+        // prune down
+        return alen + inc + a->offset + (jl_arr_xtralloc_limit / es); 
+    }
+    return newlen;
+}
+
 void jl_array_grow_end(jl_array_t *a, size_t inc)
 {
     if (a->isshared && a->how!=3) jl_error("cannot resize array with shared data");
@@ -583,6 +597,8 @@ void jl_array_grow_end(jl_array_t *a, size_t inc)
         size_t newlen = a->maxsize==0 ? (inc<4?4:inc) : a->maxsize*2;
         while ((alen + inc) > newlen - a->offset)
             newlen *= 2;
+        
+        newlen = limit_overallocation(a, alen, newlen, inc);
         array_resize_buffer(a, newlen, alen, a->offset);
     }
 #ifdef STORE_ARRAY_LEN
@@ -641,6 +657,8 @@ void jl_array_grow_beg(jl_array_t *a, size_t inc)
             size_t newlen = a->maxsize==0 ? inc*2 : a->maxsize*2;
             while (alen+2*inc > newlen-a->offset)
                 newlen *= 2;
+            
+            newlen = limit_overallocation(a, alen, newlen, 2*inc);
             size_t center = (newlen - (alen + inc))/2;
             array_resize_buffer(a, newlen, alen, center+inc);
             char *newdata = (char*)a->data - (center+inc)*es;

--- a/src/init.c
+++ b/src/init.c
@@ -648,6 +648,7 @@ void julia_init(char *imageFile)
     jl_io_loop = uv_default_loop(); // this loop will internal events (spawning process etc.),
                                     // best to call this first, since it also initializes libuv
     jl_page_size = jl_getpagesize();
+    jl_arr_xtralloc_limit = uv_get_total_memory() / 100;  // Extra allocation limited to 1% of total RAM 
     jl_find_stack_bottom();
     jl_dl_handle = jl_load_dynamic_library(NULL, JL_RTLD_DEFAULT);
 #ifdef RTLD_DEFAULT

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -77,6 +77,8 @@ void jl_compute_field_offsets(jl_datatype_t *st);
 jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, size_t *dims,
                                              int isunboxed, int elsz);
 
+extern size_t jl_arr_xtralloc_limit;
+
 void jl_init_types(void);
 void jl_init_box_caches(void);
 DLLEXPORT void jl_init_frontend(void);


### PR DESCRIPTION
Limits any extra allocation to a maximum of 1% of system RAM. 
