### PR TITLE
RFC: Enable github two-factor authentication; fixes #5252

### DIFF
--- a/base/pkg/github.jl
+++ b/base/pkg/github.jl
@@ -36,9 +36,14 @@ function curl(url::String, opts::Cmd=``)
     out, proc = open(`curl -i -s -S $opts $url`,"r")
     head = readline(out)
     status = int(split(head,r"\s+";limit=3)[2])
+    header = (String=>String)[]
     for line in eachline(out)
-        ismatch(r"^\s*$",line) || continue
-        wait(proc); return status, readall(out)
+        if !ismatch(r"^\s*$",line)
+            (k,v) = split(line, r":\s*", 2)
+            header[k] = v
+            continue
+        end
+        wait(proc); return status, header, readall(out)
     end
     error("strangely formatted HTTP response")
 end
@@ -55,20 +60,30 @@ end
 function token(user::String=user())
     tokfile = Dir.path(".github","token")
     isfile(tokfile) && return strip(readchomp(tokfile))
-    status, content = curl("https://api.github.com/authorizations",AUTH_DATA,`-u $user`)
+    status, header, content = curl("https://api.github.com/authorizations",AUTH_DATA,`-u $user`)
+
+    # Check for two-factor authentication
+    if status == 401 && get(header, "X-GitHub-OTP", "") |> x->beginswith(x, "required") && isinteractive()
+        info("Two-factor authentication in use.  Enter auth code.  (You may have to re-enter your password.)")
+        print(STDERR, "Authentication code: ")
+        code = readline(STDIN) |> chomp
+        status, header, content = curl("https://api.github.com/authorizations",AUTH_DATA,`-H "X-GitHub-OTP: $code" -u $user`)
+    end
+
     if status == 422
         error_code = json().parse(content)["errors"][1]["code"]
         if error_code == "already_exists"
-            info("Retrieving existing GitHub token (you may have to enter you password again)")
-            status,content = curl("https://api.github.com/authorizations",`-u $user`)
+            info("Retrieving existing GitHub token. (You may have to re-enter your password.)")
+            status, header, content = curl("https://api.github.com/authorizations",`-u $user`)
             (status >= 400) && error("$status: $(json().parse(content)["message"])")
             for entry in json().parse(content)
                 if entry["note"] == AUTH_NOTE
                     tok = entry["token"]
+                    break
                 end
             end
         else
-            error("GitHub returned validation error (422): $error_code")
+            error("GitHub returned validation error (422): $error_code: $(json().parse(content)["message"])")
         end
     else
         (status != 401 && status != 403) || error("$status: $(json().parse(content)["message"])")
@@ -81,7 +96,7 @@ end
 
 function req(resource::String, data, opts::Cmd=``)
     url = "https://api.github.com/$resource"
-    status, content = curl(url,data,`-u $(token()):x-oauth-basic $opts`)
+    status, header, content = curl(url,data,`-u $(token()):x-oauth-basic $opts`)
     response = json().parse(content)
     status, response
 end


### PR DESCRIPTION
I was getting annoyed at having to disable two-factor authentication to run `Pkg.publish()`.  Here's an attempt at fixing that.

``` julia
julia> Pkg.publish()
INFO: Validating METADATA
INFO: No new package versions to publish
INFO: Submitting METADATA changes
INFO: Forking JuliaLang/METADATA.jl to kmsquire
Enter host password for user 'kmsquire':
INFO: Two-factor authentication in use.  Enter auth code.  (You may need to re-enter your password.)
Authentication code: 420442
Enter host password for user 'kmsquire':

INFO: Pushing changes as branch pull-request/5068ad74
INFO: To create a pull-request open:

  https://github.com/kmsquire/METADATA.jl/compare/pull-request/5068ad74
```

Remaining issues:
1. Because there are two calls to curl, we have to enter our password twice. (minor)
~~2. For the second password prompt, enter has to be pressed twice(!) (major)~~
3. Adding more than one auth token does not seem to be possible.  For an existing token and a new machine, I get:

``` julia
    ERROR: 422: Validation Failed -- https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
       resource:   OauthAccess
       field:      description
       error code: already_exists
```

~~Regarding 2, which is the main annoyance, I'm stumped.  I'm guessing some interaction between the repl and the spawned process is not letting curl see one of the return characters.  Or maybe running the same process twice is causing issues.~~

**Edit:** I just had to reauthenticate, and found that on latest master, this is no longer a problem (or at least it worked this time without having to press enter twice.

Since authenticating twice seems like a minor price to pay for having two-factor auth enabled, I think this can be merged (although I would appreciate someone else testing).

Cc: @StefanKarpinski, @aviks 
