### PR TITLE
RFC: Official deprecation policy

### DIFF
--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -532,3 +532,19 @@ various releases of Julia. Examples of runtime checks::
     VERSION >= v"0.2.1" #get at least version 0.2.1
 
 See the section on :ref:`version number literals <man-version-number-literals>` for a more complete description.
+
+
+Deprecating Packages
+--------------------
+
+Some packages may eventually become unnecessary, be absorbed by other packages, or a simply not maintained.
+Removing a package from METADATA suddenly may cause issues for users who have the package installed either
+directly or as a dependency of another package. The following is the correct procedure for removing a package
+from METADATA:
+
+1. Tag a new release with an Julia version upper-bound equal to the current Julia release/pre-release ??? version. 
+   For example, if the package currently requires at least Julia 0.2 and the current release is Julia 0.4,
+   the version dependency should be listed as ``julia 0.2 0.4``.
+2. When a new stable version of Julia is released, all packages with a maximum version restriction that is 
+   one/two ??? minor releases behind will be removed from METADATA. For example, the package we just described
+   would be removed from METADATA when Julia 0.5/0.6 is released.


### PR DESCRIPTION
Inspired by discussion [here](https://github.com/JuliaLang/METADATA.jl/issues/347) and elsewhere. First stab at writing said policy.

I think this "policy" is simple and unlikely to cause issues, and will provide a stable mechanism to trim dead packages from METADATA over time. If packages are truly abandoned (i.e. the maintainer isn't willing/able to do this themselves) we can always tag a new release ourselves (and file an issue with the maintainer so they will be aware of the issue). 

The main thing that needs to be clarified are when exactly things get done. The options are
- `release/one` Tag max version as current Julia minor release, remove packages when next minor release comes out (aggressive) (e.g. tag v0.2 as max, remove when v0.3 released)
- `release/two` Tag max version as current Julia minor release, remove packages when next-next minor release comes out (less agressive, my favourite) (e.g. tag v0.2 as max, remove when v0.4 released)
- `unstable/one` Tag max version as current Julia minor unstable release, remove packages when next minor release comes out (less aggressive) (e.g. tag v0.3 as max, remove when v0.4 released)
- `unstable/two` Tag max version as current Julia minor unstable release, remove packages when next-next minor release comes out (slow) (e.g. tag v0.3 as max, remove when v0.5 released) 

I think `release/two` is best because if it really is deprecated then presumably no one is using it right now, so no need for it to work on the unstable version - tagging max version as release won't cause any grief. Anyone still using it when two more versions come around shouldn't be surprised when a package is removed.

There is a question of whether things ever need to actually be removed from METADATA - if the max version is set, you can't add it anyway, so its effectively dead. I'm in favor of removing them to avoid ambiguity to the passing observer but up for discussion.
