### PR TITLE
inline inexact method matches

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2005,13 +2005,6 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     #     end
     # end
 
-    # Undef is a bad type
-    for ty in atypes
-        if Undef <: ty
-            return NF
-        end
-    end
-
     if !isa(linfo,LambdaStaticData) || meth[3].func.env !== ()
         return NF
     end
@@ -2136,7 +2129,10 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     # when 1 method matches the inferred types, there is still a chance
     # of a no-method error at run time, unless the inferred types are a
     # subset of the method signature.
-    if !(atypes <: meth[1])
+    methargs = meth[1]
+    nm = length(methargs)
+    if !(atypes <: methargs)
+        incompletematch = true
         t = Expr(:call) # tuple(argexprs...)
         t.typ = Tuple
         argexprs2 = t.args
@@ -2147,20 +2143,14 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
         thrw.typ = None
         push!(stmts, thrw)
         push!(stmts, icall)
-        incompletematch = true
     else
         incompletematch = false
     end
-    methargs = meth[1]
-    nm = length(methargs)
 
     for i=na:-1:1 # stmts_free needs to be calculated in reverse-argument order
         a = args[i]
         aei = argexprs[i]
         aeitype = argtype = exprtype(aei)
-        if aeitype == ANY
-            aeitype = Any
-        end
         needtypeassert = false
         if incompletematch
             if isva
@@ -2188,6 +2178,9 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
                         @assert i==nm
                     end
                 end
+            end
+            if isa(methitype,TypeVar) # eliminate ANY
+                methitype = methitype.ub
             end
             if !(aeitype <: methitype)
                 needtypeassert = true

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1824,7 +1824,7 @@ function without_linenums(a::Array{Any,1})
     l
 end
 
-const _pure_builtins = {tuple, tupleref, tuplelen, fieldtype, apply_type, is, isa, typeof} # known affect-free calls (also effect-free)
+const _pure_builtins = {tuple, tupleref, tuplelen, fieldtype, apply_type, is, isa, typeof, typeassert} # known affect-free calls (also effect-free)
 const _pure_builtins_volatile = {getfield, arrayref} # known effect-free calls (might not be affect-free)
 
 function is_pure_builtin(f)
@@ -2005,12 +2005,13 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     #     end
     # end
 
-    # when 1 method matches the inferred types, there is still a chance
-    # of a no-method error at run time, unless the inferred types are a
-    # subset of the method signature.
-    if !(atypes <: meth[1])
-        return NF
+    # Undef is a bad type
+    for ty in atypes
+        if Undef <: ty
+            return NF
+        end
     end
+
     if !isa(linfo,LambdaStaticData) || meth[3].func.env !== ()
         return NF
     end
@@ -2059,6 +2060,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     args = f_argnames(ast)
     na = length(args)
 
+    isva = false
     if na>0 && is_rest_arg(ast.args[1][na])
         vaname = args[na]
         len_argexprs = length(argexprs)
@@ -2093,6 +2095,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             # construct tuple-forming expression for argument tail
             vararg = mk_tuplecall(argexprs[na:end])
             argexprs = {argexprs[1:(na-1)]..., vararg}
+            isva = true
         end
     end
     @assert na == length(argexprs)
@@ -2129,10 +2132,47 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     # see if each argument occurs only once in the body expression
     stmts = {}
     stmts_free = true # true = all entries of stmts are effect_free
-    for i=length(args):-1:1 # stmts_free needs to be calculated in reverse-argument order
+
+    methargs = meth[1]
+    nm = length(methargs)
+    for i=na:-1:1 # stmts_free needs to be calculated in reverse-argument order
         a = args[i]
         aei = argexprs[i]
-        aeitype = exprtype(aei)
+        aeitype = argtype = typeintersect(exprtype(aei),Any)  # remove Undef
+        if aeitype == ANY
+            aeitype = Any
+        end
+        if isva
+            if nm == 0
+                methitype = ()
+            elseif i > nm
+                methitype = methargs[end]
+                if isvarargtype(methitype)
+                    methitype = (methitype,)
+                else
+                    methitype = ()
+                end
+            else
+                methitype = tuple(methargs[i:end]...)
+            end
+            isva = false
+        else
+            if i < nm
+                methitype = methargs[i]
+            else
+                methitype = methargs[end]
+                if isvarargtype(methitype)
+                    methitype = (methitype::Vararg).parameters[1]
+                else
+                    @assert i==nm
+                end
+            end
+        end
+        needtypeassert = false
+        if !(aeitype <: methitype)
+            needtypeassert = true
+            aeitype = methitype
+        end
 
         islocal = false # if the argument name is also used as a local variable,
                         # we need to keep it as a variable name
@@ -2151,7 +2191,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
         # ok for argument to occur more than once if the actual argument
         # is a symbol or constant, or is not affected by previous statements
         # that will exist after the inlining pass finishes
-        affect_free = stmts_free && !islocal # false = previous statements might affect the result of evaluating argument
+        affect_free = stmts_free && !islocal && !needtypeassert # false = previous statements might affect the result of evaluating argument
         occ = 0
         for j = length(body.args):-1:1
             b = body.args[j]
@@ -2167,14 +2207,21 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             end
         end
         free = effect_free(aei,sv,true)
-        if ((occ==0 && is(aeitype,None)) || islocal || (occ > 1 && !inline_worthy(aei, occ)) ||
+        if ((occ==0 && is(aeitype,None)) || islocal || needtypeassert || (occ > 1 && !inline_worthy(aei, occ)) ||
                 (affect_free && !free) || (!affect_free && !effect_free(aei,sv,false)))
-            if occ != 0 # islocal=true is implied
+            if occ != 0 || needtypeassert # islocal=true is implied
                 # introduce variable for this argument
                 vnew = unique_name(enclosing_ast, ast)
                 add_variable(enclosing_ast, vnew, aeitype, !islocal)
-                unshift!(stmts, Expr(:(=), vnew, aei))
                 argexprs[i] = aeitype===Any ? vnew : SymbolNode(vnew,aeitype)
+                if needtypeassert
+                    vnew2 = unique_name(enclosing_ast, ast)
+                    add_variable(enclosing_ast, vnew2, argtype, true)
+                    push!(stmts, Expr(:(=), vnew, Expr(:call, TopNode(:typeassert), vnew2, aeitype)))
+                else
+                    vnew2 = vnew
+                end
+                unshift!(stmts, Expr(:(=), vnew2, aei))
                 stmts_free &= free
             elseif !free && !isType(aeitype)
                 unshift!(stmts, aei)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1857,6 +1857,9 @@ function effect_free(e::ANY, sv, allow_volatile::Bool)
         isa(e,TopNode) || isa(e,QuoteNode) || isa(e,Type) || isa(e,Tuple)
         return true
     end
+    if isconstantfunc(e, sv) !== false
+        return true
+    end
     if isa(e,Expr)
         e = e::Expr
         if e.head === :static_typeof
@@ -1865,27 +1868,31 @@ function effect_free(e::ANY, sv, allow_volatile::Bool)
         ea = e.args
         if e.head === :call || e.head === :call1
             if is_known_call_p(e, is_pure_builtin, sv)
-                if !allow_volatile && is_known_call_p(e, (f)->contains_is(_pure_builtins_volatile, f), sv)
-                    # arguments must be immutable to ensure e is affect_free
-                    first = true
-                    for a in ea
-                        if first # first "arg" is the function name
-                            first = false
-                            continue
-                        end
-                        if isa(a,Symbol)
-                            return false
-                        end
-                        if isa(a,SymbolNode)
-                            typ = (a::SymbolNode).typ
-                            if !isa(typ,Tuple)
-                                if !isa(typ,DataType) || typ.mutable
-                                    return false
+                if !allow_volatile
+                    if is_known_call(e, arrayref, sv)
+                        return false
+                    elseif is_known_call(e, getfield, sv)
+                        # arguments must be immutable to ensure e is affect_free
+                        first = true
+                        for a in ea
+                            if first # first "arg" is the function name
+                                first = false
+                                continue
+                            end
+                            if isa(a,Symbol)
+                                return false
+                            end
+                            if isa(a,SymbolNode)
+                                typ = (a::SymbolNode).typ
+                                if !isa(typ,Tuple)
+                                    if !isa(typ,DataType) || typ.mutable
+                                        return false
+                                    end
                                 end
                             end
-                        end
-                        if !effect_free(a,sv,allow_volatile)
-                            return false
+                            if !effect_free(a,sv,allow_volatile)
+                                return false
+                            end
                         end
                     end
                 else
@@ -1898,7 +1905,7 @@ function effect_free(e::ANY, sv, allow_volatile::Bool)
                 end
                 return true
             end
-        elseif e.head == :new
+        elseif e.head === :new
             first = !allow_volatile
             for a in ea
                 if first
@@ -1913,7 +1920,7 @@ function effect_free(e::ANY, sv, allow_volatile::Bool)
                 end
             end
             return true
-        elseif e.head == :return
+        elseif e.head === :return
             for a in ea
                 if !effect_free(a,sv,allow_volatile)
                     return false
@@ -2052,6 +2059,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
 
     body = Expr(:block)
     body.args = without_linenums(ast.args[3].args)::Array{Any,1}
+    need_mod_annotate = true
     cost = 1.0
     if incompletematch
         cost *= 4
@@ -2060,7 +2068,31 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
         cost /= 4
     end
     if !inline_worthy(body, cost)
-        return NF
+        if incompletematch
+            # inline a typeassert-based call-site, rather than a
+            # full generic lookup, using the inliner to handle
+            # all the fiddly details
+            numarg = length(argexprs)
+            newnames = unique_names(ast,numarg)
+            sp = ()
+            spvals = {}
+            meth = (methargs, sp)
+            locals = {}
+            newcall = Expr(:call, e.args[1])
+            newcall.typ = ty
+            for i = 1:numarg
+                name = newnames[i]
+                argtype = exprtype(argexprs[i])
+                argtype = typeintersect(argtype,Any)  # remove Undef
+                push!(locals, {name,argtype,0})
+                push!(newcall.args, argtype===Any ? name : SymbolNode(name, argtype))
+            end
+            body.args = {Expr(:return, newcall)}
+            ast = Expr(:lambda, newnames, {{}, locals, {}}, body)
+            need_mod_annotate = false
+        else
+            return NF
+        end
     end
 
     spnames = { sp[i].name for i=1:2:length(sp) }
@@ -2139,14 +2171,16 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     end
 
     # annotate variables in the body expression with their module
-    mfrom = linfo.module; mto = (inference_stack::CallStack).mod
-    try
-        body = resolve_globals(body, enc_locllist, enclosing_ast.args[1], mfrom, mto, args, spnames)
-    catch ex
-        if isa(ex,GetfieldNode)
-            return NF
+    if need_mod_annotate
+        mfrom = linfo.module; mto = (inference_stack::CallStack).mod
+        try
+            body = resolve_globals(body, enc_locllist, enclosing_ast.args[1], mfrom, mto, args, spnames)
+        catch ex
+            if isa(ex,GetfieldNode)
+                return NF
+            end
+            rethrow(ex)
         end
-        rethrow(ex)
     end
 
     # see if each argument occurs only once in the body expression
@@ -2162,7 +2196,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
         argexprs2 = t.args
         icall = LabelNode(label_counter(body.args)+1)
         partmatch = Expr(:gotoifnot, false, icall.label)
-        thrw = Expr(:call, :throw, Expr(:call, :MethodError, f, t))
+        thrw = Expr(:call, :throw, Expr(:call, Main.Base.MethodError, f, t))
         thrw.typ = None
     end
 
@@ -2281,7 +2315,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             end
         end
         if incompletematch
-            unshift!(argexprs2, a)
+            unshift!(argexprs2, (argtype===Any ? a : SymbolNode(a,argtype)))
         end
     end
     if incompletematch && partmatch.args[1] != false
@@ -2416,19 +2450,9 @@ function inlining_pass(e::Expr, sv, ast)
         return (e,())
     end
     arg1 = eargs[1]
-    # don't inline first (global) arguments of ccall, as this needs to be evaluated
-    # by the interpreter and inlining might put in something it can't handle,
-    # like another ccall (or try to move the variables out into the function)
-    if is_known_call(e, Core.Intrinsics.ccall, sv)
-        i0 = 5
-        isccall = true
-    else
-        i0 = 1
-        isccall = false
-    end
     stmts = {}
     if e.head === :body
-        i = i0
+        i = 1
         while i <= length(eargs)
             ei = eargs[i]
             if isa(ei,Expr)
@@ -2445,6 +2469,16 @@ function inlining_pass(e::Expr, sv, ast)
             i += 1
         end
     else
+        # don't inline first (global) arguments of ccall, as this needs to be evaluated
+        # by the interpreter and inlining might put in something it can't handle,
+        # like another ccall (or try to move the variables out into the function)
+        if is_known_call(e, Core.Intrinsics.ccall, sv)
+            i0 = 5
+            isccall = true
+        else
+            i0 = 1
+            isccall = false
+        end
         has_stmts = false # needed to preserve order-of-execution
         for i=length(eargs):-1:i0
             ei = eargs[i]
@@ -2485,94 +2519,94 @@ function inlining_pass(e::Expr, sv, ast)
                 end
             end
         end
-    end
-    if isccall
-        le = length(eargs)
-        for i=5:2:le
-            if i<le && (isa(eargs[i],Symbol) || isa(eargs[i],SymbolNode))
-                eargs[i+1] = 0
+        if isccall
+            le = length(eargs)
+            for i=5:2:le
+                if i<le && (isa(eargs[i],Symbol) || isa(eargs[i],SymbolNode))
+                    eargs[i+1] = 0
+                end
             end
         end
-    end
-    if is(e.head,:call1)
-        e.head = :call
-        ET = exprtype(arg1)
-        if isType(ET)
-            f = ET.parameters[1]
-        else
-            f = _ieval(arg1)
-        end
+        if is(e.head,:call1)
+            e.head = :call
+            ET = exprtype(arg1)
+            if isType(ET)
+                f = ET.parameters[1]
+            else
+                f = _ieval(arg1)
+            end
 
-        if is(f, ^) || is(f, .^)
-            if length(e.args) == 3 && isa(e.args[3],Union(Int32,Int64))
-                a1 = e.args[2]
-                if isa(a1,basenumtype) || ((isa(a1,Symbol) || isa(a1,SymbolNode)) &&
-                                           exprtype(a1) <: basenumtype)
-                    if e.args[3]==2
-                        e.args = {TopNode(:*), a1, a1}
-                        f = *
-                    elseif e.args[3]==3
-                        e.args = {TopNode(:*), a1, a1, a1}
-                        f = *
+            if is(f, ^) || is(f, .^)
+                if length(e.args) == 3 && isa(e.args[3],Union(Int32,Int64))
+                    a1 = e.args[2]
+                    if isa(a1,basenumtype) || ((isa(a1,Symbol) || isa(a1,SymbolNode)) &&
+                                               exprtype(a1) <: basenumtype)
+                        if e.args[3]==2
+                            e.args = {TopNode(:*), a1, a1}
+                            f = *
+                        elseif e.args[3]==3
+                            e.args = {TopNode(:*), a1, a1, a1}
+                            f = *
+                        end
                     end
                 end
             end
-        end
 
-        for ninline = 1:100
-            atypes = tuple(map(exprtype, e.args[2:end])...)
-            if length(atypes) > MAX_TUPLETYPE_LEN
-                atypes = limit_tuple_type(atypes)
-            end
-            res = inlineable(f, e, atypes, sv, ast)
-            if isa(res,Tuple)
-                if isa(res[2],Array)
-                    append!(stmts,res[2])
+            for ninline = 1:100
+                atypes = tuple(map(exprtype, e.args[2:end])...)
+                if length(atypes) > MAX_TUPLETYPE_LEN
+                    atypes = limit_tuple_type(atypes)
                 end
-                res = res[1]
-            end
-
-            if !is(res,NF)
-                # iteratively inline apply(f, tuple(...), tuple(...), ...) in order
-                # to simplify long vararg lists as in multi-arg +
-                if isa(res,Expr) && is_known_call(res, apply, sv)
-                    e = res::Expr
-                    f = apply
-                else
-                    return (res,stmts)
+                res = inlineable(f, e, atypes, sv, ast)
+                if isa(res,Tuple)
+                    if isa(res[2],Array)
+                        append!(stmts,res[2])
+                    end
+                    res = res[1]
                 end
-            end
 
-            if is(f,apply)
-                na = length(e.args)
-                newargs = cell(na-2)
-                for i = 3:na
-                    aarg = e.args[i]
-                    t = to_tuple_of_Types(exprtype(aarg))
-                    if isa(aarg,Expr) && is_known_call(aarg, tuple, sv)
-                        # apply(f,tuple(x,y,...)) => f(x,y,...)
-                        newargs[i-2] = aarg.args[2:end]
-                    elseif isa(aarg, Tuple)
-                        newargs[i-2] = { QuoteNode(x) for x in aarg }
-                    elseif isa(t,Tuple) && !isvatuple(t) && effect_free(aarg,sv,true)
-                        # apply(f,t::(x,y)) => f(t[1],t[2])
-                        newargs[i-2] = { mk_tupleref(aarg,j,t[j]) for j=1:length(t) }
+                if !is(res,NF)
+                    # iteratively inline apply(f, tuple(...), tuple(...), ...) in order
+                    # to simplify long vararg lists as in multi-arg +
+                    if isa(res,Expr) && is_known_call(res, apply, sv)
+                        e = res::Expr
+                        f = apply
                     else
-                        # not all args expandable
+                        return (res,stmts)
+                    end
+                end
+
+                if is(f,apply)
+                    na = length(e.args)
+                    newargs = cell(na-2)
+                    for i = 3:na
+                        aarg = e.args[i]
+                        t = to_tuple_of_Types(exprtype(aarg))
+                        if isa(aarg,Expr) && is_known_call(aarg, tuple, sv)
+                            # apply(f,tuple(x,y,...)) => f(x,y,...)
+                            newargs[i-2] = aarg.args[2:end]
+                        elseif isa(aarg, Tuple)
+                            newargs[i-2] = { QuoteNode(x) for x in aarg }
+                        elseif isa(t,Tuple) && !isvatuple(t) && effect_free(aarg,sv,true)
+                            # apply(f,t::(x,y)) => f(t[1],t[2])
+                            newargs[i-2] = { mk_tupleref(aarg,j,t[j]) for j=1:length(t) }
+                        else
+                            # not all args expandable
+                            return (e,stmts)
+                        end
+                    end
+                    e.args = [{e.args[2]}, newargs...]
+
+                    # now try to inline the simplified call
+
+                    f = isconstantfunc(e.args[1], sv)
+                    if f===false
                         return (e,stmts)
                     end
-                end
-                e.args = [{e.args[2]}, newargs...]
-
-                # now try to inline the simplified call
-
-                f = isconstantfunc(e.args[1], sv)
-                if f===false
+                    f = _ieval(f)
+                else
                     return (e,stmts)
                 end
-                f = _ieval(f)
-            else
-                return (e,stmts)
             end
         end
     end
@@ -2591,32 +2625,39 @@ const some_names = {:_var0, :_var1, :_var2, :_var3, :_var4, :_var5, :_var6,
                     :_var7, :_var8, :_var9, :_var10, :_var11, :_var12,
                     :_var13, :_var14, :_var15, :_var16, :_var17, :_var18,
                     :_var19, :_var20, :_var21, :_var22, :_var23, :_var24}
-
+function contains_is1(vinflist::Array{Any,1}, x::Symbol)
+    for y in vinflist
+        if is(y[1],x)
+            return true
+        end
+    end
+    return false
+end
 function unique_name(ast)
-    locllist = ast.args[2][1]::Array{Any,1}
+    locllist = ast.args[2][2]::Array{Any,1}
     for g in some_names
-        if !contains_is(locllist, g)
+        if !contains_is1(locllist, g)
             return g
         end
     end
     g = gensym()
-    while contains_is(locllist, g)
+    while contains_is1(locllist, g)
         g = gensym()
     end
     g
 end
 function unique_name(ast1, ast2)
-    locllist1 = ast1.args[2][1]::Array{Any,1}
-    locllist2 = ast2.args[2][1]::Array{Any,1}
+    locllist1 = ast1.args[2][2]::Array{Any,1}
+    locllist2 = ast2.args[2][2]::Array{Any,1}
     for g in some_names
-        if !contains_is(locllist1, g) &&
-           !contains_is(locllist2, g)
+        if !contains_is1(locllist1, g) &&
+           !contains_is1(locllist2, g)
             return g
         end
     end
     g = gensym()
-    while contains_is(locllist1, g) |
-          contains_is(locllist2, g)
+    while contains_is1(locllist1, g) |
+          contains_is1(locllist2, g)
         g = gensym()
     end
     g
@@ -2624,9 +2665,9 @@ end
 
 function unique_names(ast, n)
     ns = {}
-    locllist = ast.args[2][1]::Array{Any,1}
+    locllist = ast.args[2][2]::Array{Any,1}
     for g in some_names
-        if !contains_is(locllist, g)
+        if !contains_is1(locllist, g)
             push!(ns, g)
             if length(ns)==n
                 return ns
@@ -2635,7 +2676,7 @@ function unique_names(ast, n)
     end
     while length(ns)<n
         g = gensym()
-        while contains_is(locllist, g) || contains_is(ns, g)
+        while contains_is1(locllist, g) || contains_is(ns, g)
             g = gensym()
         end
         push!(ns, g)
@@ -2691,12 +2732,29 @@ function remove_redundant_temp_vars(ast, sa)
                 # this transformation is not valid for vars used before def.
                 # we need to preserve the point of assignment to know where to
                 # throw errors (issue #4645).
-                delete_var!(ast, v)
-                sym_replace(ast.args[3], {v}, {}, {init}, {})
+
+                if (isa(init,SymbolNode) ? (init.typ<:local_typeof(v, varinfo)) : true)
+                    # the transformation is not ideal if the assignment
+                    # is present for the auto-unbox functionality
+                    # (from inlining improved type inference information)
+                    # and this transformation would worsen the type information
+                    # everywhere later in the function
+
+                    delete_var!(ast, v)
+                    sym_replace(ast.args[3], {v}, {}, {init}, {})
+                end
             end
         end
     end
     ast
+end
+function local_typeof(v, varinfo)
+    for (v2, typ, info) in varinfo
+        if v === v2
+            return typ
+        end
+    end
+    @assert false "v not in varinfo"
 end
 
 occurs_undef(var, expr) =

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2090,7 +2090,15 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             argexprs = {argexprs[1:(na-1)]..., vararg}
             isva = true
         end
+    elseif na != length(argexprs)
+        # we have a method match only because an earlier
+        # inference step shortened our call args list, even
+        # though we have too many arguments to actually
+        # call this function
+        @assert isvarargtype(atypes[na])
+        return NF
     end
+
     @assert na == length(argexprs)
 
     if needcopy

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1894,40 +1894,29 @@ function effect_free(e::ANY, sv, allow_volatile::Bool)
                                 return false
                             end
                         end
-                    end
-                else
-                    # arguments must also be effect_free
-                    for a in ea
-                        if !effect_free(a,sv,allow_volatile)
-                            return false
-                        end
+                        return true
                     end
                 end
-                return true
             end
         elseif e.head === :new
-            first = !allow_volatile
-            for a in ea
-                if first
-                    first = false
-                    typ = exprtype(a)
-                    if !isType(typ) || !isa((typ::Type).parameters[1],DataType) || ((typ::Type).parameters[1]::DataType).mutable
-                        return false
-                    end
-                end
-                if !effect_free(a,sv,allow_volatile)
+            if !allow_volatile
+                a = ea[1]
+                typ = exprtype(a)
+                if !isType(typ) || !isa((typ::Type).parameters[1],DataType) || ((typ::Type).parameters[1]::DataType).mutable
                     return false
                 end
             end
-            return true
         elseif e.head === :return
-            for a in ea
-                if !effect_free(a,sv,allow_volatile)
-                    return false
-                end
-            end
-            return true
+            # pass
+        else
+            return false
         end
+        for a in ea
+            if !effect_free(a,sv,allow_volatile)
+                return false
+            end
+        end
+        return true
     end
     return false
 end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2267,7 +2267,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             end
         end
         free = effect_free(aei,sv,true)
-        if ((occ==0 && is(aeitype,None)) || islocal || (occ > 1 && !inline_worthy(aei, occ)) ||
+        if ((occ==0 && is(aeitype,None)) || islocal || (occ > 1 && !inline_worthy(aei, occ*2)) ||
                 (affect_free && !free) || (!affect_free && !effect_free(aei,sv,false)))
             if occ != 0 # islocal=true is implied by occ!=0
                 vnew = unique_name(enclosing_ast, ast)
@@ -2370,14 +2370,14 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
 end
 
 inline_worthy(body, cost::Real) = true
-function inline_worthy(body::Expr, cost::Real=1) # precondition: 0<cost
+function inline_worthy(body::Expr, cost::Real=1.0) # precondition: 0<cost
 #    if isa(body.args[1],QuoteNode) && (body.args[1]::QuoteNode).value === :inline
 #        shift!(body.args)
 #        return true
 #    end
-    symlim = int(5/cost)+1
+    symlim = 1+5/cost
     if length(body.args) < symlim
-        symlim *= 6
+        symlim *= 16
         if occurs_more(body, e->true, symlim) < symlim
             return true
         end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2023,7 +2023,16 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             spvals[i] = QuoteNode(spvals[i])
         end
     end
-    (ast, ty) = typeinf(linfo, meth[1], meth[2], linfo)
+
+    methargs = meth[1]::Tuple
+    nm = length(methargs)
+    if !(atypes <: methargs)
+        incompletematch = true
+    else
+        incompletematch = false
+    end
+
+    (ast, ty) = typeinf(linfo, methargs, meth[2]::Tuple, linfo)
     if is(ast,())
         return NF
     end
@@ -2043,7 +2052,14 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
 
     body = Expr(:block)
     body.args = without_linenums(ast.args[3].args)::Array{Any,1}
-    if !inline_worthy(body)
+    cost = 1.0
+    if incompletematch
+        cost *= 4
+    end
+    if is(f, next) || is(f, done)
+        cost /= 4
+    end
+    if !inline_worthy(body, cost)
         return NF
     end
 
@@ -2140,10 +2156,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     # when 1 method matches the inferred types, there is still a chance
     # of a no-method error at run time, unless the inferred types are a
     # subset of the method signature.
-    methargs = meth[1]
-    nm = length(methargs)
-    if !(atypes <: methargs)
-        incompletematch = true
+    if incompletematch
         t = Expr(:call) # tuple(args...)
         t.typ = Tuple
         argexprs2 = t.args
@@ -2151,8 +2164,6 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
         partmatch = Expr(:gotoifnot, false, icall.label)
         thrw = Expr(:call, :throw, Expr(:call, :MethodError, f, t))
         thrw.typ = None
-    else
-        incompletematch = false
     end
 
     for i=na:-1:1 # stmts_free needs to be calculated in reverse-argument order
@@ -2214,7 +2225,6 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
         # ok for argument to occur more than once if the actual argument
         # is a symbol or constant, or is not affected by previous statements
         # that will exist after the inlining pass finishes
-        affect_free = stmts_free && !islocal && !needtypeassert # false = previous statements might affect the result of evaluating argument
         if needtypeassert
             vnew1 = unique_name(enclosing_ast, ast)
             add_variable(enclosing_ast, vnew1, aeitype, !islocal)
@@ -2227,6 +2237,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             args[i] = a = vnew2
             islocal = false
             aeitype = argtype
+            affect_free = stmts_free
             occ = 3
             # it's really late in codegen, so we expand the typeassert manually: cond = !isa(vnew2, methitype) | cond
             cond = Expr(:call, Intrinsics.isa, v2, methitype)
@@ -2239,6 +2250,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             cond.typ = Bool
             partmatch.args[1] = cond
         else
+            affect_free = stmts_free && !islocal # false = previous statements might affect the result of evaluating argument
             occ = 0
             for j = length(body.args):-1:1
                 b = body.args[j]
@@ -2257,11 +2269,11 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
         free = effect_free(aei,sv,true)
         if ((occ==0 && is(aeitype,None)) || islocal || (occ > 1 && !inline_worthy(aei, occ)) ||
                 (affect_free && !free) || (!affect_free && !effect_free(aei,sv,false)))
-            if (occ != 0) # islocal=true is implied by occ!=0
+            if occ != 0 # islocal=true is implied by occ!=0
                 vnew = unique_name(enclosing_ast, ast)
                 add_variable(enclosing_ast, vnew, aeitype, !islocal)
                 unshift!(stmts, Expr(:(=), vnew, aei))
-                argexprs[i] = (argtype===Any ? vnew : SymbolNode(vnew,aeitype))
+                argexprs[i] = argtype===Any ? vnew : SymbolNode(vnew,aeitype)
                 stmts_free &= free
             elseif !free && !isType(aeitype)
                 unshift!(stmts, aei)
@@ -2357,13 +2369,13 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     return (expr, stmts)
 end
 
-inline_worthy(body, occurences::Int) = true
-function inline_worthy(body::Expr, occurences::Int=1) # 0 < occurrences <= 6
+inline_worthy(body, cost::Real) = true
+function inline_worthy(body::Expr, cost::Real=1) # 0 < occurrences <= 6
 #    if isa(body.args[1],QuoteNode) && (body.args[1]::QuoteNode).value === :inline
 #        shift!(body.args)
 #        return true
 #    end
-    symlim = div(6,occurences)
+    symlim = iceil(6/cost)
     if length(body.args) < symlim
         symlim *= 6
         if occurs_more(body, e->true, symlim) < symlim

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2370,12 +2370,12 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
 end
 
 inline_worthy(body, cost::Real) = true
-function inline_worthy(body::Expr, cost::Real=1) # 0 < occurrences <= 6
+function inline_worthy(body::Expr, cost::Real=1) # precondition: 0<cost
 #    if isa(body.args[1],QuoteNode) && (body.args[1]::QuoteNode).value === :inline
 #        shift!(body.args)
 #        return true
 #    end
-    symlim = iceil(6/cost)
+    symlim = int(5/cost)+1
     if length(body.args) < symlim
         symlim *= 6
         if occurs_more(body, e->true, symlim) < symlim

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1129,6 +1129,9 @@ function tmerge(typea::ANY, typeb::ANY)
     if typeb <: typea
         return typea
     end
+    if typea <: Tuple && typeb <: Tuple
+        return Tuple
+    end
     u = Union(typea, typeb)
     if length(u.types) > MAX_TYPEUNION_LEN || type_too_complex(u, 0)
         # don't let type unions get too big

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2273,7 +2273,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
                 vnew = unique_name(enclosing_ast, ast)
                 add_variable(enclosing_ast, vnew, aeitype, !islocal)
                 unshift!(stmts, Expr(:(=), vnew, aei))
-                argexprs[i] = argtype===Any ? vnew : SymbolNode(vnew,aeitype)
+                argexprs[i] = aeitype===Any ? vnew : SymbolNode(vnew,aeitype)
                 stmts_free &= free
             elseif !free && !isType(aeitype)
                 unshift!(stmts, aei)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2133,45 +2133,66 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     stmts = {}
     stmts_free = true # true = all entries of stmts are effect_free
 
+    # when 1 method matches the inferred types, there is still a chance
+    # of a no-method error at run time, unless the inferred types are a
+    # subset of the method signature.
+    if !(atypes <: meth[1])
+        t = Expr(:call) # tuple(argexprs...)
+        t.typ = Tuple
+        argexprs2 = t.args
+        icall = genlabel(sv)
+        partmatch = Expr(:gotoifnot, false, icall.label)
+        push!(stmts, partmatch)
+        thrw = Expr(:call, :throw, Expr(:call, :MethodError, f, t))
+        thrw.typ = None
+        push!(stmts, thrw)
+        push!(stmts, icall)
+        incompletematch = true
+    else
+        incompletematch = false
+    end
     methargs = meth[1]
     nm = length(methargs)
+
     for i=na:-1:1 # stmts_free needs to be calculated in reverse-argument order
         a = args[i]
         aei = argexprs[i]
-        aeitype = argtype = typeintersect(exprtype(aei),Any)  # remove Undef
+        aeitype = argtype = exprtype(aei)
         if aeitype == ANY
             aeitype = Any
         end
-        if isva
-            if nm == 0
-                methitype = ()
-            elseif i > nm
-                methitype = methargs[end]
-                if isvarargtype(methitype)
-                    methitype = (methitype,)
-                else
-                    methitype = ()
-                end
-            else
-                methitype = tuple(methargs[i:end]...)
-            end
-            isva = false
-        else
-            if i < nm
-                methitype = methargs[i]
-            else
-                methitype = methargs[end]
-                if isvarargtype(methitype)
-                    methitype = (methitype::Vararg).parameters[1]
-                else
-                    @assert i==nm
-                end
-            end
-        end
         needtypeassert = false
-        if !(aeitype <: methitype)
-            needtypeassert = true
-            aeitype = methitype
+        if incompletematch
+            if isva
+                if nm == 0
+                    methitype = ()
+                elseif i > nm
+                    methitype = methargs[end]
+                    if isvarargtype(methitype)
+                        methitype = (methitype,)
+                    else
+                        methitype = ()
+                    end
+                else
+                    methitype = tuple(methargs[i:end]...)
+                end
+                isva = false
+            else
+                if i < nm
+                    methitype = methargs[i]
+                else
+                    methitype = methargs[end]
+                    if isvarargtype(methitype)
+                        methitype = (methitype::Vararg).parameters[1]
+                    else
+                        @assert i==nm
+                    end
+                end
+            end
+            if !(aeitype <: methitype)
+                needtypeassert = true
+                aeitype = methitype
+            end
         end
 
         islocal = false # if the argument name is also used as a local variable,
@@ -2206,10 +2227,11 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
                 break
             end
         end
+
         free = effect_free(aei,sv,true)
         if ((occ==0 && is(aeitype,None)) || islocal || needtypeassert || (occ > 1 && !inline_worthy(aei, occ)) ||
                 (affect_free && !free) || (!affect_free && !effect_free(aei,sv,false)))
-            if occ != 0 || needtypeassert # islocal=true is implied
+            if occ != 0 || needtypeassert || (incompletematch && !free) # islocal=true is implied by occ!=0
                 # introduce variable for this argument
                 vnew = unique_name(enclosing_ast, ast)
                 add_variable(enclosing_ast, vnew, aeitype, !islocal)
@@ -2217,7 +2239,19 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
                 if needtypeassert
                     vnew2 = unique_name(enclosing_ast, ast)
                     add_variable(enclosing_ast, vnew2, argtype, true)
-                    push!(stmts, Expr(:(=), vnew, Expr(:call, TopNode(:typeassert), vnew2, aeitype)))
+                    vnew2expr = (argtype===Any ? vnew2 : SymbolNode(vnew2,argtype))
+                    push!(stmts, Expr(:(=), vnew, vnew2expr))
+                    unshift!(argexprs2, vnew2expr)
+                    # it's really late in codegen, so we expand the typeassert manually: cond = !isa(vnew2, methitype) | cond
+                    cond = Expr(:call, TopNode(:isa), vnew2expr, methitype)
+                    cond.typ = Bool
+                    cond = Expr(:call, TopNode(:not_int), cond)
+                    cond.typ = Bool
+                    cond = Expr(:call, TopNode(:or_int), cond, partmatch.args[1])
+                    cond.typ = Bool
+                    cond = Expr(:call, TopNode(:box), Bool, cond)
+                    cond.typ = Bool
+                    partmatch.args[1] = cond
                 else
                     vnew2 = vnew
                 end
@@ -2228,6 +2262,12 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
                 stmts_free = false
             end
         end
+        if !needtypeassert && incompletematch
+            unshift!(argexprs2, argexprs[i])
+        end
+    end
+    if incompletematch
+        unshift!(argexprs2, TopNode(:tuple))
     end
 
     # ok, substitute argument expressions for argument names in the body

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2133,16 +2133,13 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     nm = length(methargs)
     if !(atypes <: methargs)
         incompletematch = true
-        t = Expr(:call) # tuple(argexprs...)
+        t = Expr(:call) # tuple(args...)
         t.typ = Tuple
         argexprs2 = t.args
-        icall = genlabel(sv)
+        icall = LabelNode(label_counter(body.args)+1)
         partmatch = Expr(:gotoifnot, false, icall.label)
-        push!(stmts, partmatch)
         thrw = Expr(:call, :throw, Expr(:call, :MethodError, f, t))
         thrw.typ = None
-        push!(stmts, thrw)
-        push!(stmts, icall)
     else
         incompletematch = false
     end
@@ -2183,6 +2180,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
                 methitype = methitype.ub
             end
             if !(aeitype <: methitype)
+                #TODO: make Undef a faster special-case
                 needtypeassert = true
                 aeitype = methitype
             end
@@ -2206,61 +2204,68 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
         # is a symbol or constant, or is not affected by previous statements
         # that will exist after the inlining pass finishes
         affect_free = stmts_free && !islocal && !needtypeassert # false = previous statements might affect the result of evaluating argument
-        occ = 0
-        for j = length(body.args):-1:1
-            b = body.args[j]
-            if occ < 1
-                occ += occurs_more(b, x->is(x,a), 5)
-            end
-            if occ > 0 && affect_free && !effect_free(b, sv, true) #TODO: we could short-circuit this test better by memoizing effect_free(b) in the for loop over i
-                affect_free = false
-            end
-            if occ > 5
-                occ = 6
-                break
+        if needtypeassert
+            vnew1 = unique_name(enclosing_ast, ast)
+            add_variable(enclosing_ast, vnew1, aeitype, !islocal)
+            v1 = (aeitype===Any ? vnew1 : SymbolNode(vnew1,aeitype))
+            push!(spnames, a)
+            push!(spvals, v1)
+            vnew2 = unique_name(enclosing_ast, ast)
+            v2 = (argtype===Any ? vnew2 : SymbolNode(vnew2,argtype))
+            unshift!(body.args, Expr(:(=), a, v2))
+            args[i] = a = vnew2
+            islocal = false
+            aeitype = argtype
+            occ = 3
+            # it's really late in codegen, so we expand the typeassert manually: cond = !isa(vnew2, methitype) | cond
+            cond = Expr(:call, Intrinsics.isa, v2, methitype)
+            cond.typ = Bool
+            cond = Expr(:call, Intrinsics.not_int, cond)
+            cond.typ = Bool
+            cond = Expr(:call, Intrinsics.or_int, cond, partmatch.args[1])
+            cond.typ = Bool
+            cond = Expr(:call, Intrinsics.box, Bool, cond)
+            cond.typ = Bool
+            partmatch.args[1] = cond
+        else
+            occ = 0
+            for j = length(body.args):-1:1
+                b = body.args[j]
+                if occ < 1
+                    occ += occurs_more(b, x->is(x,a), 5)
+                end
+                if occ > 0 && affect_free && !effect_free(b, sv, true) #TODO: we could short-circuit this test better by memoizing effect_free(b) in the for loop over i
+                    affect_free = false
+                end
+                if occ > 5
+                    occ = 6
+                    break
+                end
             end
         end
-
         free = effect_free(aei,sv,true)
-        if ((occ==0 && is(aeitype,None)) || islocal || needtypeassert || (occ > 1 && !inline_worthy(aei, occ)) ||
+        if ((occ==0 && is(aeitype,None)) || islocal || (occ > 1 && !inline_worthy(aei, occ)) ||
                 (affect_free && !free) || (!affect_free && !effect_free(aei,sv,false)))
-            if occ != 0 || needtypeassert || (incompletematch && !free) # islocal=true is implied by occ!=0
-                # introduce variable for this argument
+            if (occ != 0) # islocal=true is implied by occ!=0
                 vnew = unique_name(enclosing_ast, ast)
                 add_variable(enclosing_ast, vnew, aeitype, !islocal)
-                argexprs[i] = aeitype===Any ? vnew : SymbolNode(vnew,aeitype)
-                if needtypeassert
-                    vnew2 = unique_name(enclosing_ast, ast)
-                    add_variable(enclosing_ast, vnew2, argtype, true)
-                    vnew2expr = (argtype===Any ? vnew2 : SymbolNode(vnew2,argtype))
-                    push!(stmts, Expr(:(=), vnew, vnew2expr))
-                    unshift!(argexprs2, vnew2expr)
-                    # it's really late in codegen, so we expand the typeassert manually: cond = !isa(vnew2, methitype) | cond
-                    cond = Expr(:call, TopNode(:isa), vnew2expr, methitype)
-                    cond.typ = Bool
-                    cond = Expr(:call, TopNode(:not_int), cond)
-                    cond.typ = Bool
-                    cond = Expr(:call, TopNode(:or_int), cond, partmatch.args[1])
-                    cond.typ = Bool
-                    cond = Expr(:call, TopNode(:box), Bool, cond)
-                    cond.typ = Bool
-                    partmatch.args[1] = cond
-                else
-                    vnew2 = vnew
-                end
-                unshift!(stmts, Expr(:(=), vnew2, aei))
+                unshift!(stmts, Expr(:(=), vnew, aei))
+                argexprs[i] = (argtype===Any ? vnew : SymbolNode(vnew,aeitype))
                 stmts_free &= free
             elseif !free && !isType(aeitype)
                 unshift!(stmts, aei)
                 stmts_free = false
             end
         end
-        if !needtypeassert && incompletematch
-            unshift!(argexprs2, argexprs[i])
+        if incompletematch
+            unshift!(argexprs2, a)
         end
     end
-    if incompletematch
-        unshift!(argexprs2, TopNode(:tuple))
+    if incompletematch && partmatch.args[1] != false
+        unshift!(body.args, icall)
+        unshift!(body.args, thrw)
+        unshift!(body.args, partmatch)
+        unshift!(argexprs2, top_tuple)
     end
 
     # ok, substitute argument expressions for argument names in the body
@@ -2663,10 +2668,10 @@ function remove_redundant_temp_vars(ast, sa)
                 # this transformation is not valid for vars used before def.
                 # we need to preserve the point of assignment to know where to
                 # throw errors (issue #4645).
-            delete_var!(ast, v)
-            sym_replace(ast.args[3], {v}, {}, {init}, {})
+                delete_var!(ast, v)
+                sym_replace(ast.args[3], {v}, {}, {init}, {})
+            end
         end
-    end
     end
     ast
 end

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -531,11 +531,12 @@ macro handle_zero(ex)
     end
 end
 
-decode_oct(d::Real) = decode_oct(integer(d)) # TODO: real float decoding.
-decode_0ct(d::Real) = decode_0ct(integer(d)) # TODO: real float decoding.
-decode_dec(d::Real) = decode_dec(integer(d)) # TODO: real float decoding.
-decode_hex(d::Real) = decode_hex(integer(d)) # TODO: real float decoding.
-decode_HEX(d::Real) = decode_HEX(integer(d)) # TODO: real float decoding.
+# fallbacks for Real types without explicit decode_* implementation
+decode_oct(d::Real) = decode_oct(integer(d))
+decode_0ct(d::Real) = decode_0ct(integer(d))
+decode_dec(d::Real) = decode_dec(integer(d))
+decode_hex(d::Real) = decode_hex(integer(d))
+decode_HEX(d::Real) = decode_HEX(integer(d))
 
 handlenegative(d::Unsigned) = (false, d)
 function handlenegative(d::Integer)
@@ -661,6 +662,7 @@ function decode_dec(x::SmallFloatingPoint)
     end
     return NEG[1], POINT[1], LEN[1]
 end
+# TODO: implement decode_oct, decode_0ct, decode_hex, decode_HEX for SmallFloatingPoint
 
 ## fix decoding functions ##
 #
@@ -668,24 +670,31 @@ end
 # - if len less than point, trailing zeros implied
 #
 
-fix_dec(x::Integer, n::Int) = decode_dec(x)
+# fallback for Real types without explicit fix_dec implementation
 fix_dec(x::Real, n::Int) = fix_dec(float(x),n)
+
+fix_dec(x::Integer, n::Int) = decode_dec(x)
 
 function fix_dec(x::SmallFloatingPoint, n::Int)
     if n > BUFLEN-1; n = BUFLEN-1; end
     @grisu_ccall x Grisu.FIXED n
     if LEN[1] == 0
         DIGITS[1] = '0'
-        return (neg, int32(1), int32(1))
+        return (NEG[1], int32(1), int32(1))
     end
     return NEG[1], POINT[1], LEN[1]
 end
+
+# TODO: implement fix_dec for BigFloat
 
 ## ini decoding functions ##
 #
 # - returns (neg, point, len)
 # - implies len = n (requested digits)
 #
+
+# fallback for Real types without explicit fix_dec implementation
+ini_dec(x::Real, n::Int) = ini_dec(float(x),n)
 
 function ini_dec(d::Integer, n::Int)
     neg, x = handlenegative(d)
@@ -718,7 +727,6 @@ function ini_dec(d::Integer, n::Int)
     end
     return neg, pt, n
 end
-ini_dec(x::Real, n::Int) = ini_dec(float(x),n)
 
 function ini_dec(x::SmallFloatingPoint, n::Int)
     if x == 0.0
@@ -745,6 +753,8 @@ function ini_dec(x::BigInt, n::Int)
     end
     return (decode_dec(iround(x/big(10)^(d-n)))[1], d, n)
 end
+
+# TODO: implement ini_dec for BigFloat
 
 ### external printf interface ###
 

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -242,11 +242,11 @@ function gen_d(flags::ASCIIString, width::Int, precision::Int, c::Char)
     else
         fn = :decode_dec
     end
-    push!(blk.args, :((do_out, args) = $fn(out, $x, $flags, $width, $precision, $c)::(Bool,Tuple)))
+    push!(blk.args, :((do_out, args) = $fn(out, $x, $flags, $width, $precision, $c)))
     ifblk = Expr(:if, :do_out, Expr(:block))
     push!(blk.args, ifblk)
     blk = ifblk.args[2]
-    push!(blk.args, :((len, pt, neg) = args::(Int32,Int32,Bool)))
+    push!(blk.args, :((len, pt, neg) = args))
     # calculate padding
     width -= length(prefix)
     space_pad = width > max(1,precision) && '-' in flags ||
@@ -309,11 +309,11 @@ function gen_f(flags::ASCIIString, width::Int, precision::Int, c::Char)
     x, ex, blk = special_handler(flags,width)
     # interpret the number
     if precision < 0; precision = 6; end
-    push!(blk.args, :((do_out, args) = fix_dec(out, $x, $flags, $width, $precision, $c)::(Bool,Tuple)))
+    push!(blk.args, :((do_out, args) = fix_dec(out, $x, $flags, $width, $precision, $c)))
     ifblk = Expr(:if, :do_out, Expr(:block))
     push!(blk.args, ifblk)
     blk = ifblk.args[2]
-    push!(blk.args, :((len, pt, neg) = args::(Int32,Int32,Bool)))
+    push!(blk.args, :((len, pt, neg) = args))
     # calculate padding
     padding = nothing
     if precision > 0 || '#' in flags
@@ -373,11 +373,11 @@ function gen_e(flags::ASCIIString, width::Int, precision::Int, c::Char)
     # interpret the number
     if precision < 0; precision = 6; end
     ndigits = min(precision+1,BUFLEN-1)
-    push!(blk.args, :((do_out, args) = ini_dec(out,$x,$ndigits, $flags, $width, $precision, $c)::(Bool,Tuple)))
+    push!(blk.args, :((do_out, args) = ini_dec(out,$x,$ndigits, $flags, $width, $precision, $c)))
     ifblk = Expr(:if, :do_out, Expr(:block))
     push!(blk.args, ifblk)
     blk = ifblk.args[2]
-    push!(blk.args, :((len, pt, neg) = args::(Int32,Int32,Bool)))
+    push!(blk.args, :((len, pt, neg) = args))
     push!(blk.args, :(exp = pt-1))
     expmark = c=='E' ? "E" : "e"
     if precision==0 && '#' in flags

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -531,8 +531,13 @@ macro handle_zero(ex)
     end
 end
 
+decode_oct(d::Real) = decode_oct(integer(d)) # TODO: real float decoding.
+decode_0ct(d::Real) = decode_0ct(integer(d)) # TODO: real float decoding.
+decode_dec(d::Real) = decode_dec(integer(d)) # TODO: real float decoding.
+decode_hex(d::Real) = decode_hex(integer(d)) # TODO: real float decoding.
+decode_HEX(d::Real) = decode_HEX(integer(d)) # TODO: real float decoding.
+
 handlenegative(d::Unsigned) = (false, d)
-handlenegative(d::Real) = handlenegative(integer(d)) # TODO: real float decoding.
 function handlenegative(d::Integer)
     if d < 0
         return true, unsigned(oftype(d,-d))
@@ -541,7 +546,7 @@ function handlenegative(d::Integer)
     end
 end
 
-function decode_oct(d::Real)
+function decode_oct(d::Integer)
     neg, x = handlenegative(d)
     @handle_zero x
     pt = i = div((sizeof(x)<<3)-leading_zeros(x)+2,3)
@@ -553,7 +558,7 @@ function decode_oct(d::Real)
     return neg, int32(pt), int32(pt)
 end
 
-function decode_0ct(d::Real)
+function decode_0ct(d::Integer)
     neg, x = handlenegative(d)
     # doesn't need special handling for zero
     pt = i = div((sizeof(x)<<3)-leading_zeros(x)+5,3)
@@ -565,7 +570,7 @@ function decode_0ct(d::Real)
     return neg, int32(pt), int32(pt)
 end
 
-function decode_dec(d::Real)
+function decode_dec(d::Integer)
     neg, x = handlenegative(d)
     @handle_zero x
     pt = i = Base.ndigits0z(x)
@@ -577,7 +582,7 @@ function decode_dec(d::Real)
     return neg, int32(pt), int32(pt)
 end
 
-function decode_hex(d::Real, symbols::Array{Uint8,1})
+function decode_hex(d::Integer, symbols::Array{Uint8,1})
     neg, x = handlenegative(d)
     @handle_zero x
     pt = i = (sizeof(x)<<1)-(leading_zeros(x)>>2)
@@ -592,8 +597,8 @@ end
 const hex_symbols = "0123456789abcdef".data
 const HEX_symbols = "0123456789ABCDEF".data
 
-decode_hex(x::Real) = decode_hex(x,hex_symbols)
-decode_HEX(x::Real) = decode_hex(x,HEX_symbols)
+decode_hex(x::Integer) = decode_hex(x,hex_symbols)
+decode_HEX(x::Integer) = decode_hex(x,HEX_symbols)
 
 function decode(b::Int, x::BigInt)
     neg = x.size < 0
@@ -636,9 +641,8 @@ end
 #   *_0ct(x,n) => ensure that the first octal digits is zero
 #   *_HEX(x,n) => use uppercase digits for hexadecimal
 
-# - sets neg[1]
-# - sets point[1]
-# - implies len[1] = point[1]
+# - returns (neg, point, len)
+# - implies len = point
 #
 
 function decode_dec(x::SmallFloatingPoint)
@@ -660,9 +664,8 @@ end
 
 ## fix decoding functions ##
 #
-# - sets neg[1]
-# - sets point[1]
-# - sets len[1]; if less than point[1], trailing zeros implied
+# - returns (neg, point, len)
+# - if len less than point, trailing zeros implied
 #
 
 fix_dec(x::Integer, n::Int) = decode_dec(x)
@@ -680,9 +683,8 @@ end
 
 ## ini decoding functions ##
 #
-# - sets neg[1]
-# - sets point[1]
-# - implies len[1] = n (requested digits)
+# - returns (neg, point, len)
+# - implies len = n (requested digits)
 #
 
 function ini_dec(d::Integer, n::Int)

--- a/test/perf/micro/perf.jl
+++ b/test/perf/micro/perf.jl
@@ -138,13 +138,10 @@ end
 
 @unix_only begin
     function printfd(n)
-        io = open("/dev/null","w")
-        try
+        open("/dev/null","w") do io
             for i = 1:n
                 @printf(io,"%d %d\n",i,i+1)
             end
-        finally
-            close(io)
         end
     end
 

--- a/test/perf/micro/perf.jl
+++ b/test/perf/micro/perf.jl
@@ -138,10 +138,13 @@ end
 
 @unix_only begin
     function printfd(n)
-        open("/dev/null","w") do io
+        io = open("/dev/null","w")
+        try
             for i = 1:n
                 @printf(io,"%d %d\n",i,i+1)
             end
+        finally
+            close(io)
         end
     end
 


### PR DESCRIPTION
@JeffBezanson Do you know where this going wrong? `if !(aeitype <: methitype)` appears to be failing, even though I haven't removed the precondition test of `if !(atypes <: meth[1])`

inspired by https://github.com/JuliaLang/julia/commit/024bbce1a6aa4b0ed68f01fa152c008c8f84d10a#commitcomment-6137158

Is the following behavior correct? I think it must be true, but is also causing type-inference issues with this patch on the indicated line

```
julia> methods(convert,(Type{(Char,Char)},(Char,Char)))
1-element Array{Any,1}:
 convert(T::(Any,Any...),x::(Any,Any...)) at base.jl:21

julia> methods(convert,((Char,Char),(Char,Char)))
1-element Array{Any,1}:
 convert(T::(Any,Any...),x::(Any,Any...)) at base.jl:21
```
