### PR TITLE
align complex number printing (ref #29)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -718,7 +718,7 @@ function alignment(x::Real)
                    (length(m.captures[1]), length(m.captures[2]))
 end
 function alignment(x::Complex)
-    m = match(r"^(.*,)(.*)$", sprint(showcompact_lim, x))
+    m = match(r"^(.*[\+\-])(.*)$", sprint(showcompact_lim, x))
     m == nothing ? (length(sprint(showcompact_lim, x)), 0) :
                    (length(m.captures[1]), length(m.captures[2]))
 end


### PR DESCRIPTION
Aligning with the sign separating the real and im parts for now.

With this:

```
julia> rand(10)+im*rand(10)
10-element Array{Complex{Float64},1}:
 0.0274458+0.4798im  
  0.352604+0.640042im
   0.16287+0.725793im
  0.921465+0.842921im
  0.674144+0.904141im
  0.740832+0.760259im
  0.109258+0.196977im
   0.49121+0.488045im
  0.583651+0.775827im
  0.013235+0.399164im
```
