### PR TITLE
RFC: Make pasting into the REPL much simpler

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -603,33 +603,8 @@ function setup_interface(d::REPLDisplay, req, rep; extra_repl_keymap = Dict{Any,
                 indent = Base.indentation(input)[1]
                 input = Base.unindent(lstrip(input), indent)
             end
-            buf = copy(LineEdit.buffer(s))
-            edit_insert(buf,input)
-            string = takebuf_string(buf)
-            pos = 0
-            sz = length(string.data)
-            while pos <= sz
-                oldpos = pos
-                ast, pos = Base.parse(string, pos, raise=false)
-                # Get the line and strip leading and trailing whitespace
-                line = strip(bytestring(string.data[max(oldpos, 1):min(pos-1, sz)]))
-                isempty(line) && continue
-                LineEdit.replace_line(s, line)
-                LineEdit.refresh_line(s)
-                (pos > sz && last(string) != '\n') && break
-                if !isa(ast, Expr) || (ast.head != :continue && ast.head != :incomplete)
-                    LineEdit.commit_line(s)
-                    # This is slightly ugly but ok for now
-                    terminal = LineEdit.terminal(s)
-                    stop_reading(terminal)
-                    raw!(terminal, false) && disable_bracketed_paste(terminal)
-                    LineEdit.mode(s).on_done(s, LineEdit.buffer(s), true)
-                    raw!(terminal, true) && enable_bracketed_paste(terminal)
-                    start_reading(terminal)
-                else
-                    break
-                end
-            end
+            edit_insert(LineEdit.buffer(s),input)
+            LineEdit.refresh_line(s)
         end,
     }
 


### PR DESCRIPTION
Previously, the REPL would try to determine if you had pasted a complete expression, and, if that expression was followed by a newline, it would evaluate it.  If there were multiple expressions, it would evaluate each one by one. However, this often fails for me when pasting incomplete snippets that I intend to edit in the command line, and since we have such good multi-line editing support I don't even think it's necessary.

This patch simply removes those smarts.  All pasted text is entered into the buffer verbatim (except for an unindentation pass if the cursor is at the beginning of the buffer). The pasted text is not sent for evaluation, even if followed by trailing newlines.  Additionally, this fixes #6664 as the cursor ends up at the end of the pasted snippet.

This may be controversial, but I think this dramatically reduces the number of surprises when pasting text.  The case that bit me again today was simply pasting two floating point numbers: I just wanted to divide one by the other, but mistakenly pasted the denominator first.  So I then copied the numerator, went back to the beginning of the line, and hit paste, intending to type `/` and then evaluate it.  But it ended up getting evaluated immediately and throwing a syntax error.  I could probably make it smarter for this case, too, but… what is the gain here?  Simply so pasted text gets evaluated immediately if it is a complete syntax?  I'm not sure that's worth it.
