### PR TITLE
For @simd, clarify what user is asserting versus what is necessary to do any good.

### DIFF
--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -511,12 +511,17 @@ properties of the loop:
 -  Floating-point operations on reduction variables can be reordered,
    possibly causing different results than without ``@simd``.
 -  No iteration ever waits on another iteration to make forward progress.
+
+Using ``@simd`` merely gives the compiler license to vectorize. Whether 
+it actually does so depends on the compiler. To actually benefit from the 
+current implementation, your loop should have the following additional 
+properties:
+
 -  The loop must be an innermost loop.
 -  The loop body must be straight-line code. This is why ``@inbounds`` is currently needed for all array accesses.
 -  Accesses must have a stride pattern and cannot be "gathers" (random-index reads) or "scatters" (random-index writes).
 - The stride should be unit stride.
 - In some simple cases, for example with 2-3 arrays accessed in a loop, the LLVM auto-vectorization may kick in automatically, leading to no further speedup with ``@simd``. 
-- Using ``@simd`` merely gives the compiler license to vectorize. Whether it actually does so depends on the compiler. The current implementation will not vectorize if there are possible early exits from the loop, such as from array bounds checking. This limitation may be lifted in the future.
 
 Tools
 -----


### PR DESCRIPTION
This change delineates what a user is asserting by using `@simd` versus what has to be true for it to do any good.
