### PR TITLE
RFC: SparseVector Type

### DIFF
--- a/base/constants.jl
+++ b/base/constants.jl
@@ -68,7 +68,7 @@ const golden = φ
 for T in (MathConst, Rational, Integer, Number)
     ^(::MathConst{:e}, x::T) = exp(x)
 end
-for T in (Range, BitArray, SparseMatrixCSC, StridedArray, AbstractArray)
+for T in (Range, BitArray, SparseCSC, StridedArray, AbstractArray)
     .^(::MathConst{:e}, x::T) = exp(x)
 end
 ^(::MathConst{:e}, x::AbstractMatrix) = expm(x)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -407,8 +407,11 @@ eval(Sys, :(@deprecate shlib_list dllist))
 @deprecate degrees2radians deg2rad
 @deprecate radians2degrees rad2deg
 
-@deprecate spzeros(m::Integer) spzeros(m, m)
-@deprecate spzeros(Tv::Type, m::Integer) spzeros(Tv, m, m)
+# This syntax is being used for sparse vectors now.
+# It is probably inappropriate to reinstate deprecated methods with a different behavior.
+# Decision required...
+#@deprecate spzeros(m::Integer) spzeros(m, m)
+#@deprecate spzeros(Tv::Type, m::Integer) spzeros(Tv, m, m)
 
 @deprecate myindexes localindexes
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -85,6 +85,8 @@ export
     SharedMatrix,
     SharedVector,
     SparseMatrixCSC,
+    SparseVector,
+    SparseVecOrMat,
     StatStruct,
     StepRange,
     StridedArray,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -3,6 +3,8 @@ module LinAlg
 importall Base
 import Base: USE_BLAS64, size, copy, copy_transpose!, power_by_squaring, print_matrix
 
+using Base.SparseMatrix
+
 export 
 # Modules
     LAPACK,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -3,7 +3,7 @@ module LinAlg
 importall Base
 import Base: USE_BLAS64, size, copy, copy_transpose!, power_by_squaring, print_matrix
 
-using Base.SparseMatrix
+using Base.Sparse
 
 export 
 # Modules

--- a/base/linalg/cholmod.jl
+++ b/base/linalg/cholmod.jl
@@ -12,6 +12,7 @@ export                                  # types
  etree
 
 using Base.LinAlg.UMFPACK               # for decrement, increment, etc.
+using Base.SparseMatrix
  
 import Base: (*), convert, copy, ctranspose, eltype, findnz, getindex, hcat,
              isvalid, nfilled, show, size, sort!, transpose, vcat
@@ -1024,10 +1025,10 @@ full(A::CholmodSparse) = CholmodDense(A).mat
 full(A::CholmodDense) = A.mat
 function sparse(A::CholmodSparse)
     if bool(A.c.stype) return sparse!(copysym(A)) end
-    SparseMatrixCSC(A.c.m, A.c.n, increment(A.colptr0), increment(A.rowval0), copy(A.nzval))
+    SparseCSC((A.c.m, A.c.n), increment(A.colptr0), increment(A.rowval0), copy(A.nzval))
 end
 function sparse!(A::CholmodSparse)
-    SparseMatrixCSC(A.c.m, A.c.n, increment!(A.colptr0), increment!(A.rowval0), A.nzval)
+    SparseCSC((A.c.m, A.c.n), increment!(A.colptr0), increment!(A.rowval0), A.nzval)
 end    
 sparse(L::CholmodFactor) = sparse!(CholmodSparse(L))
 sparse(D::CholmodDense) = sparse!(CholmodSparse(D))

--- a/base/linalg/cholmod.jl
+++ b/base/linalg/cholmod.jl
@@ -12,7 +12,7 @@ export                                  # types
  etree
 
 using Base.LinAlg.UMFPACK               # for decrement, increment, etc.
-using Base.SparseMatrix
+using Base.Sparse
  
 import Base: (*), convert, copy, ctranspose, eltype, findnz, getindex, hcat,
              isvalid, nfilled, show, size, sort!, transpose, vcat

--- a/base/linalg/sparse.jl
+++ b/base/linalg/sparse.jl
@@ -191,7 +191,7 @@ function *{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti})
     # The Gustavson algorithm does not guarantee the product to have sorted row indices.
     Cunsorted = SparseCSC((mA, nB), colptrC, rowvalC, nzvalC)
     Ct = Cunsorted.'
-    Ctt = Base.SparseMatrix.transpose!(Ct, SparseCSC((mA, nB), colptrC, rowvalC, nzvalC))
+    Ctt = Base.Sparse.transpose!(Ct, SparseCSC((mA, nB), colptrC, rowvalC, nzvalC))
 end
 
 ## solvers

--- a/base/linalg/umfpack.jl
+++ b/base/linalg/umfpack.jl
@@ -10,7 +10,7 @@ import Base: (\), Ac_ldiv_B, At_ldiv_B, findnz, getindex, show, size
 
 import ..LinAlg: A_ldiv_B!, Ac_ldiv_B!, At_ldiv_B!, Factorization, det, lufact, lufact!
 
-using Base.SparseMatrix
+using Base.Sparse
 
 include("umfpack_h.jl")
 type MatrixIllConditionedException <: Exception

--- a/base/sparse.jl
+++ b/base/sparse.jl
@@ -1,6 +1,6 @@
 include("sparse/abstractsparse.jl")
 
-module SparseMatrix
+module Sparse
 
 importall Base
 import Base.NonTupleType, Base.float, Base.showarray, Base.dims2string
@@ -15,4 +15,4 @@ export SparseMatrixCSC, SparseCSC, SparseVector, SparseVecOrMat,
 include("sparse/sparsematrix.jl")
 include("sparse/csparse.jl")
 
-end # module SparseMatrix
+end # module Sparse

--- a/base/sparse.jl
+++ b/base/sparse.jl
@@ -3,14 +3,14 @@ include("sparse/abstractsparse.jl")
 module SparseMatrix
 
 importall Base
-import Base.NonTupleType, Base.float
+import Base.NonTupleType, Base.float, Base.showarray, Base.dims2string
 
-export SparseMatrixCSC, 
+export SparseMatrixCSC, SparseCSC, SparseVector, SparseVecOrMat,
        blkdiag, dense, diag, diagm, droptol!, dropzeros!, etree, full, 
        getindex, ishermitian, issparse, issym, istril, istriu, 
        setindex!, sparse, sparsevec, spdiagm, speye, spones, 
        sprand, sprandbool, sprandn, spzeros, symperm, trace, tril, tril!, 
-       triu, triu!
+       triu, triu!, writemime, summary, showarray
 
 include("sparse/sparsematrix.jl")
 include("sparse/csparse.jl")

--- a/base/sparse/abstractsparse.jl
+++ b/base/sparse/abstractsparse.jl
@@ -2,6 +2,7 @@ abstract AbstractSparseArray{Tv,Ti,N} <: AbstractArray{Tv,N}
 
 typealias AbstractSparseVector{Tv,Ti} AbstractSparseArray{Tv,Ti,1}
 typealias AbstractSparseMatrix{Tv,Ti} AbstractSparseArray{Tv,Ti,2}
+typealias AbstractSparseVecOrMat{Tv,Ti} Union(AbstractSparseVector{Tv,Ti}, AbstractSparseMatrix{Tv,Ti})
 
 issparse(A::AbstractArray) = false
 issparse(S::AbstractSparseArray) = true

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -213,7 +213,7 @@ include("client.jl")
 
 # sparse matrices and linear algebra
 include("sparse.jl")
-importall .SparseMatrix
+importall .Sparse
 include("linalg.jl")
 importall .LinAlg
 include("broadcast.jl")

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -187,7 +187,7 @@ mfe22 = eye(Float64, 2)
 @test nfilled(sparse([1,1],[1,2],[0.0,-0.0])) == 0
 
 # issue #5386
-K,J,V = findnz(SparseMatrixCSC(2,1,[1,3],[1,2],[1.0,0.0]))
+K,J,V = findnz(sparse([1,2],[1,1],[1.0,0.0],2,1))
 @test length(K) == length(J) == length(V) == 1
 
 # issue #5437

--- a/test/suitesparse.jl
+++ b/test/suitesparse.jl
@@ -155,6 +155,6 @@ pred = afiro'*sol
 @test norm(afiro * (y.mat - pred.mat)) < 1e-8
 
 # explicit zeros
-a = SparseMatrixCSC(2,2,[1,3,5],[1,2,1,2],[1.0,0.0,0.0,1.0]) 
+a = sparse([1,1,2,2],[1,2,1,2],[1.0,0.0,0.0,1.0],2,2) 
 @test_approx_eq lufact(a)\[2.0,3.0] [2.0,3.0]
 @test_approx_eq cholfact(a)\[2.0,3.0] [2.0,3.0]


### PR DESCRIPTION
This WIP PR adds a `SparseVector` type based on the existing `SparseMatrixCSC` type.
- Changes existing `SparseMatrixCSC{Tv,Ti}` to `SparseCSC{Tv,Ti,N}`
- exports `SparseMatrixCSC{Tv,Ti}` as `SparseCSC{Tv,Ti,2}`
- exports `SparseVector{Tv,Ti}` as `SparseCSC{Tv,Ti,1}`
- exports `SparseVecOrMat{Tv,Ti<:Integer}` as `Union(SparseMatrixCSC{Tv,Ti}, SparseVector{Tv,Ti})`

Also reinstated deprecated methods `spzeros(m::Integer)` and `spzeros(Tv::Type, m::Integer)` to create `SparseVector`s. It is probably inappropriate to reinstate them with a different behavior. Any other appropriate names?

Existing tests pass, but all operations on SparseVectors may not be implemented yet, and tests for vectors need to be added.
