### PR TITLE
Add better error messages for dimension mismatches in promote_array

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -156,14 +156,14 @@ copy(x::Union(Symbol,Number,String,Function,Tuple,LambdaStaticData,
 
 function promote_shape(a::(Int,), b::(Int,))
     if a[1] != b[1]
-        error("dimensions must match")
+        throw(DimensionMismatch("Cannot promote dimensions $(a) to $(b)"))
     end
     return a
 end
 
 function promote_shape(a::(Int,Int), b::(Int,))
     if a[1] != b[1] || a[2] != 1
-        error("dimensions must match")
+        throw(DimensionMismatch("Cannot promote dimensions $(a) to $(b)"))
     end
     return a
 end
@@ -172,7 +172,7 @@ promote_shape(a::(Int,), b::(Int,Int)) = promote_shape(b, a)
 
 function promote_shape(a::(Int, Int), b::(Int, Int))
     if a[1] != b[1] || a[2] != b[2]
-        error("dimensions must match")
+        throw(DimensionMismatch("Cannot promote dimensions $(a) to $(b)"))
     end
     return a
 end
@@ -183,12 +183,12 @@ function promote_shape(a::Dims, b::Dims)
     end
     for i=1:length(b)
         if a[i] != b[i]
-            error("dimensions must match")
+            throw(DimensionMismatch("Cannot promote dimensions $(a) to $(b)"))
         end
     end
     for i=length(b)+1:length(a)
         if a[i] != 1
-            error("dimensions must match")
+            throw(DimensionMismatch("Cannot promote dimensions $(a) to $(b)"))
         end
     end
     return a


### PR DESCRIPTION
Before this change:

``` julia
julia> [1 2 3] + [1 2]
ERROR: dimensions must match

julia> 
```

After this change:

``` julia
julia> [1 2 3] + [1 2]
ERROR: DimensionMismatch("Cannot promote dimensions (1,3) to (1,2)")
 in promote_shape at operators.jl:175
 in + at array.jl:709

julia> [1 2 3] + [1 2; 2 3]
ERROR: DimensionMismatch("Cannot promote dimensions (1,3) to (2,2)")
 in promote_shape at operators.jl:175
 in + at array.jl:709

julia>
```
