### PR TITLE
Tweaks to StepRange: Take 2

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -508,8 +508,7 @@ reverse(r::FloatRange)   = FloatRange(last(r), -r.step, r.len, r.divisor)
 ## sorting ##
 
 issorted(r::UnitRange) = true
-issorted(r::Range) = step(r) >= 0
-issorted{T,S}(r::StepRange{T,S}) = step(r) >= zero(S)
+issorted(r::Range) = step(r) >= zero(step(r))
 
 sort(r::UnitRange) = r
 sort!(r::UnitRange) = r
@@ -552,12 +551,7 @@ function map(f::Callable, r::Range)
 end
 
 function in(x, r::Range)
-    n = step(r) == 0 ? 1 : iround((x-first(r))/step(r))+1
-    n >= 1 && n <= length(r) && r[n] == x
-end
-
-function in{T,S}(x, r::StepRange{T,S})
-    n = step(r) == zero(S) ? 1 : iround((x-first(r))/step(r))+1
+    n = step(r) == zero(step(r)) ? 1 : iround((x-first(r))/step(r))+1
     n >= 1 && n <= length(r) && r[n] == x
 end
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -44,7 +44,7 @@ immutable StepRange{T,S} <: OrdinalRange{T,S}
                         remain = oftype(T, unsigned(diff) % step)
                     end
                 else
-                    remain = diff % step
+                    remain = steprem(start,stop,step)
                 end
                 last = stop - remain
             end
@@ -53,6 +53,8 @@ immutable StepRange{T,S} <: OrdinalRange{T,S}
         new(start, step, last)
     end
 end
+
+steprem(start,stop,step) = (stop-start) % step
 
 StepRange{T,S}(start::T, step::S, stop::T) = StepRange{T,S}(start, step, stop)
 
@@ -507,14 +509,15 @@ reverse(r::FloatRange)   = FloatRange(last(r), -r.step, r.len, r.divisor)
 
 issorted(r::UnitRange) = true
 issorted(r::Range) = step(r) >= 0
+issorted{T,S}(r::StepRange{T,S}) = step(r) >= zero(S)
 
 sort(r::UnitRange) = r
 sort!(r::UnitRange) = r
 
-sort{T<:Real}(r::Range{T}) = issorted(r) ? r : reverse(r)
+sort(r::Range) = issorted(r) ? r : reverse(r)
 
 sortperm(r::UnitRange) = 1:length(r)
-sortperm{T<:Real}(r::Range{T}) = issorted(r) ? (1:1:length(r)) : (length(r):-1:1)
+sortperm(r::Range) = issorted(r) ? (1:1:length(r)) : (length(r):-1:1)
 
 function sum{T<:Real}(r::Range{T})
     l = length(r)
@@ -550,6 +553,11 @@ end
 
 function in(x, r::Range)
     n = step(r) == 0 ? 1 : iround((x-first(r))/step(r))+1
+    n >= 1 && n <= length(r) && r[n] == x
+end
+
+function in{T,S}(x, r::StepRange{T,S})
+    n = step(r) == zero(S) ? 1 : iround((x-first(r))/step(r))+1
     n >= 1 && n <= length(r) && r[n] == x
 end
 


### PR DESCRIPTION
The `issorted` and `in` changes are pretty straightforward, using the step for comparison. `sort` and `sortperm` remove the `T<:Real` restriction to apply to `StepRange` as well. All `test/ranges.jl` tests still pass with these changes, though I can add some more and try to break things if needed.

The introduction of `steprem` is annoying, but surprisingly minimal to allow full support for different step types than the difference between start and stop. The reasoning is that most Ordinal types shouldn't have to worry because the fallback to `(stop-start) % step` should work, but it allows for overloading (similar to how I'm overloading `length`). 

Fixes #6638

cc: @JeffBezanson 

Support methods I'm using to get range functionality for dates: https://github.com/karbarcca/Dates.jl/blob/master/src/ranges.jl
Relevant tests the date ranges are passing with these changes: https://github.com/karbarcca/Dates.jl/blob/master/test/test_ranges.jl
