### PR TITLE
faster sprand, new randsubseq (fixes #6714 and #6708)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -175,6 +175,8 @@ Library improvements
 
       * `eigs(A, sigma)` now uses shift-and-invert for nonzero shifts `sigma` and inverse iteration for `which="SM"`. If `sigma==nothing` (the new default), computes ordinary (forward) iterations. ([#5776])
 
+      * `sprand` is faster, and whether any entry is nonzero is now determined independently with the specified probability ([#6726]).
+
     * Dense linear algebra for special matrix types
 
       * Interconversions between the special matrix types `Diagonal`, `Bidiagonal`,
@@ -252,6 +254,8 @@ Library improvements
 
   * Extended API for ``cov`` and ``cor``, which accept keyword arguments ``vardim``, 
     ``corrected``, and ``mean`` ([#6273])
+
+  * New functions `randsubseq` and `randsubseq!` to create a random subsequence of an array ([#6726])
 
 
 Deprecated or removed

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -545,6 +545,8 @@ export
     promote_shape,
     randcycle,
     randperm,
+    randsubseq!,
+    randsubseq,
     range,
     reducedim,
     repmat,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3814,6 +3814,19 @@ Indexing, Assignment, and Concatenation
 
    Throw an error if the specified indexes are not in bounds for the given array.
 
+.. function:: randsubseq(A, p) -> Vector
+   
+   Return a vector consisting of a random subsequence of the given array ``A``,
+   where each element of ``A`` is included (in order) with independent
+   probability ``p``.   (Complexity is linear in ``p*length(A)``, so this
+   function is efficient even if ``p`` is small and ``A`` is large.)
+
+.. function:: randsubseq!(S, A, p)
+
+   Like ``randsubseq``, but the results are stored in ``S`` (which is
+   resized as needed).
+   
+
 Array functions
 ~~~~~~~~~~~~~~~
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3819,7 +3819,8 @@ Indexing, Assignment, and Concatenation
    Return a vector consisting of a random subsequence of the given array ``A``,
    where each element of ``A`` is included (in order) with independent
    probability ``p``.   (Complexity is linear in ``p*length(A)``, so this
-   function is efficient even if ``p`` is small and ``A`` is large.)
+   function is efficient even if ``p`` is small and ``A`` is large.)  Technically,
+   this process is known as "Bernoulli sampling" of ``A``.
 
 .. function:: randsubseq!(S, A, p)
 

--- a/doc/stdlib/sparse.rst
+++ b/doc/stdlib/sparse.rst
@@ -55,17 +55,17 @@ Sparse matrices support much of the same set of operations as dense matrices. Th
 
    Construct a sparse diagonal matrix. ``B`` is a tuple of vectors containing the diagonals and ``d`` is a tuple containing the positions of the diagonals. In the case the input contains only one diagonaly, ``B`` can be a vector (instead of a tuple) and ``d`` can be the diagonal position (instead of a tuple), defaulting to 0 (diagonal). Optionally, ``m`` and ``n`` specify the size of the resulting sparse matrix.
 
-.. function:: sprand(m,n,density[,rng])
+.. function:: sprand(m,n,p[,rng])
 
-   Create a random sparse matrix with the specified density. Nonzeros are sampled from the distribution specified by ``rng``. The uniform distribution is used in case ``rng`` is not specified.
+   Create a random ``m`` by ``n`` sparse matrix, in which the probability of any element being nonzero is independently given by ``p`` (and hence the mean density of nonzeros is also exactly ``p``). Nonzero values are sampled from the distribution specified by ``rng``. The uniform distribution is used in case ``rng`` is not specified.
 
-.. function:: sprandn(m,n,density)
+.. function:: sprandn(m,n,p)
 
-   Create a random sparse matrix of specified density with nonzeros sampled from the normal distribution.
+   Create a random ``m`` by ``n`` sparse matrix with the specified (independent) probability ``p`` of any entry being nonzero, where nonzero values are sampled from the normal distribution.
 
-.. function:: sprandbool(m,n,density)
+.. function:: sprandbool(m,n,p)
 
-   Create a random sparse boolean matrix with the specified density.
+   Create a random ``m`` by ``n`` sparse boolean matrix with the specified (independent) probability ``p`` of any entry being ``true``.
 
 .. function:: etree(A[, post])
 


### PR DESCRIPTION
This patch implements a much faster (at least 5× on my laptop, but on an older machine I tried it was only 2×) `sprand` (fixing #6708), by filling in the matrix one (nonempty) column at a time.   It also changes the meaning of the specified `density` to something that is (I think) easier to explain: the probability of any element of the matrix being nonzero is (independently) given by `density`.

A subroutine used by both this `sprand` and the previous `sprand` is a function to compute a random subsequence of a given `AbstractArray` (e.g. `1:n`).  Since this is generally useful functionality, it seemed sensible to export it as functions `randsubseq(A, p)` and `randsubseq!(S, A, p)`.    What these functions do is to create a random (ordered) subsequence of `A` by selecting each element of `A` with independent probability `p`.     (This is different from the problem of finding a random subset of a fixed size.)

`randsubseq` is implemented using a new algorithm different from the previous one (which had the same mean (modulo the bug in #6714) but a more complicated, and I think less useful, distribution).  The new algorithm is somewhat faster, requires no temporary arrays, has Θ(`p * length(A)`) complexity, and avoids the statistical bug of #6714; it is inspired by an algorithm by Vitter for a related problem.

(As discussed in #6714, it might be nice to also have a `randsubseq(S, A)` that finds a random subsequence of fixed length `== length(S)`.  The algorithm in `StatsBase` for this problem is currently quite suboptimal according to my benchmarks as well as theoretically.  However, that may go into `StatsBase` rather than `Base` and in any case should be a separate PR.)

cc: @timholy, @StefanKarpinski, @lindahua 
