### PR TITLE
Allow `test_throws` to take an user-defined exception type

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -72,7 +72,7 @@ macro test_throws(args...)
         ex = args[2]
         extype = args[1]
     end
-    :(do_test_throws(()->($(esc(ex))),$(Expr(:quote,ex)),backtrace(),$(extype)))
+    :(do_test_throws(()->($(esc(ex))),$(Expr(:quote,ex)),backtrace(),$(esc(extype))))
 end
 
 macro test_fails(ex)


### PR DESCRIPTION
``` julia
module L

type Error <: Exception
    msg::String
end
error(s::String) = throw(Error(s))

end

module T
import Base.Test: @test_throws
import L

@test_throws L.Error L.error("error!")

end
```

returns

```
ERROR: L not defined
 in include at boot.jl:244
 in include_from_node1 at loading.jl:128
while loading ~/julia/t.jl, in expression starting on line 14
```
