### PR TITLE
Interrupt signal crashes Julia in emacs

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -167,16 +167,22 @@ function run_frontend(repl::BasicREPL, repl_channel::RemoteRef, response_channel
         write(repl.terminal, "julia> ")
         line = ""
         ast = nothing
-        while true
-            line *= readline(repl.terminal)
-            ast = Base.parse_input_line(line)
-            (isa(ast,Expr) && ast.head == :incomplete) || break
-        end
-        if !isempty(line)
-            put!(repl_channel, (ast, 1))
-            val, bt = take!(response_channel)
-            if !ends_with_semicolon(line)
-                print_response(d, val, bt, true, false)
+        try
+            while true
+                line *= readline(repl.terminal)
+                ast = Base.parse_input_line(line)
+                (isa(ast,Expr) && ast.head == :incomplete) || break
+            end
+            if !isempty(line)
+                put!(repl_channel, (ast, 1))
+                val, bt = take!(response_channel)
+                if !ends_with_semicolon(line)
+                    print_response(d, val, bt, true, false)
+                end
+            end
+        catch e
+            if ! isa(e, InterruptException)
+                throw(e)
             end
         end
         write(repl.terminal, '\n')


### PR DESCRIPTION
In emacs (both ESS REPL and eshell), sending an interrupt signal ("C-c C-c" and "C-c", respectively) causes Julia to crash

In eshell:
1. lauch Julia
2. Press control-c

```
$ julia 
[logo]
julia> 8
8

julia> ERROR: interrupt
 in stream_wait at stream.jl:252
 in wait_readbyte at stream.jl:298
 in readuntil at stream.jl:670
 in readuntil at io.jl:148
 in readuntil at Terminals.jl:160
 in run_frontend at REPL.jl:169
 in run_repl at REPL.jl:151
```
