### PR TITLE
Fix allocated macro, correct bytes measurements in time and timed macros

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -40,7 +40,7 @@ macro time(ex)
         local val = $(esc(ex))
         local t1 = time_ns()
         local b1 = gc_bytes()
-        println("elapsed time: ", (t1-t0)/1e9, " seconds (", b1-b0, " bytes allocated)")
+        println("elapsed time: ", (t1-t0)/1e9, " seconds (", b1-b0-3*16, " bytes allocated)")
         val
     end
 end
@@ -57,16 +57,14 @@ end
 # measure bytes allocated without any contamination from compilation
 macro allocated(ex)
     quote
-        let
-            local f
-            function f()
-                b0 = gc_bytes()
-                $(esc(ex))
-                b1 = gc_bytes()
-                b1-b0
-            end
-            f()
+        local f
+        function f()
+            b0 = gc_bytes()
+            $(esc(ex))
+            b1 = gc_bytes()
+            b1-b0
         end
+        f()
     end
 end
 
@@ -78,7 +76,7 @@ macro timed(ex)
         local val = $(esc(ex))
         local t1 = time_ns()
         local b1 = gc_bytes()
-        val, (t1-t0)/1e9, b1-b0
+        val, (t1-t0)/1e9, b1-b0-3*16
     end
 end
 


### PR DESCRIPTION
Before:

``` julia
@allocated true
# ERROR: cannot assign variables in other modules
# in #54#f at util.jl:63
@time true  # elapsed time: 1.882e-6 seconds (6888 bytes allocated)
@time true  # elapsed time: 8.94e-7 seconds (48 bytes allocated)
@time true  # still 48, due to the 3 16-byte allocations via time_ns and gc_bytes
```

I'm not sure I'm honoring the description of `@allocated` ("measure bytes allocated without any contamination from compilation"), but I don't remember it doing anything different before.
