### PR TITLE
Add Dict conversion method.

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -329,6 +329,7 @@ Dict(ks, vs) = Dict{Any,Any}(ks, vs)
 
 # conversion between Dict types
 convert{K,V}(::Type{Dict{K,V}},d::Dict) = Dict{K,V}(d)
+convert{K,V}(::Type{Dict{K,V}},d::Dict{K,V}) = d
 
 # syntax entry points
 Dict{K,V}(ks::(K...), vs::(V...)) = Dict{K  ,V  }(ks, vs)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -328,7 +328,7 @@ Dict{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V}) = Dict{K,V}(ks,vs)
 Dict(ks, vs) = Dict{Any,Any}(ks, vs)
 
 # conversion between Dict types
-convert{L,W,K,V}(::Type{Dict{L,W}},d::Dict{K,V}) = Dict{L,W}(d)
+convert{K,V}(::Type{Dict{K,V}},d::Dict) = Dict{K,V}(d)
 
 # syntax entry points
 Dict{K,V}(ks::(K...), vs::(V...)) = Dict{K  ,V  }(ks, vs)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -328,7 +328,18 @@ Dict{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V}) = Dict{K,V}(ks,vs)
 Dict(ks, vs) = Dict{Any,Any}(ks, vs)
 
 # conversion between Dict types
-convert{K,V}(::Type{Dict{K,V}},d::Dict) = Dict{K,V}(d)
+function convert{K,V}(::Type{Dict{K,V}},d::Dict)
+    h = Dict{K,V}()
+    for (k,v) in d
+        ck = convert(K,k)
+        if !haskey(h,ck)
+            h[ck] = convert(V,v)
+        else
+            error("key collision during dictionary conversion")
+        end
+    end
+    return h
+end
 convert{K,V}(::Type{Dict{K,V}},d::Dict{K,V}) = d
 
 # syntax entry points

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -327,6 +327,9 @@ Dict() = Dict{Any,Any}()
 Dict{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V}) = Dict{K,V}(ks,vs)
 Dict(ks, vs) = Dict{Any,Any}(ks, vs)
 
+# conversion between Dict types
+convert{L,W,K,V}(::Type{Dict{L,W}},d::Dict{K,V}) = Dict{L,W}(d)
+
 # syntax entry points
 Dict{K,V}(ks::(K...), vs::(V...)) = Dict{K  ,V  }(ks, vs)
 Dict{K  }(ks::(K...), vs::Tuple ) = Dict{K  ,Any}(ks, vs)


### PR DESCRIPTION
I was somewhat miffed to find the following:

```
julia> convert(Dict{String, String}, ["a" => "a"])
ERROR: no method convert(Type{Dict{String,String}}, Dict{ASCIIString,ASCIIString})
 in convert at base.jl:13
```

So I added this method to fix it. The type parameters are admittedly somewhat silly but it seems to work fine.
