### PR TITLE
[RFC] Export valid llvm module with code_llvm

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3690,7 +3690,6 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
 static MDNode* tbaa_make_child( const char* name, MDNode* parent, bool isConstant=false )
 {
     MDNode* n = mbuilder->createTBAANode(name,parent,isConstant);
-    n->setValueName( ValueName::Create(name, name+strlen(name)));
     return n;
 }
 


### PR DESCRIPTION
Hi,

when looking into possible optimizations for the LLVM-IR generated by Julia, it is generally useful to 
have code_llvm emit LLVM-IR that is loadable into LLVM's opt tool. The following two patches tweak the
LLVM-IR dumping to make this possible.

This is more a RFC than a finished pull request. The current code has only be tested with LLVM_VER=svn. If this functionality is desired, the changes still need to be tested with older versions of LLVM.
