### PR TITLE
ignore comments in readdlm. fixes #536

### DIFF
--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -2756,7 +2756,7 @@
 
 "),
 
-("Base","readdlm","readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap=true, ignore_invalid_chars=false, quotes=true)
+("Base","readdlm","readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap=true, ignore_invalid_chars=false, quotes=true, dims, comments=true, comment_char='#')
 
    Read a matrix from the source where each line (separated by
    \"eol\") gives one row, with elements separated by the given
@@ -2788,6 +2788,8 @@
    Specifying \"dims\" as a tuple of the expected rows and columns 
    (including header, if any) may speed up reading of large files.
 
+   If \"comments\" is \"true\", lines beginning with \"comment_char\" 
+   and text following \"comment_char\" in any line are ignored.
 "),
 
 ("Base","readdlm","readdlm(source, delim::Char, eol::Char; options...)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1812,7 +1812,7 @@ Text I/O
 
    Create an iterable object that will yield each line from a stream.
 
-.. function:: readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap=true, ignore_invalid_chars=false, quotes=true, dims)
+.. function:: readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap=true, ignore_invalid_chars=false, quotes=true, dims, comments=true, comment_char='#')
 
    Read a matrix from the source where each line (separated by ``eol``) gives one row, with elements separated by the given delimeter. The source can be a text file, stream or byte array. Memory mapped files can be used by passing the byte array representation of the mapped segment as source. 
 
@@ -1827,6 +1827,8 @@ Text I/O
    If ``quotes`` is ``true``, column enclosed within double-quote (``) characters are allowed to contain new lines and column delimiters. Double-quote characters within a quoted field must be escaped with another double-quote.
 
    Specifying ``dims`` as a tuple of the expected rows and columns (including header, if any) may speed up reading of large files.
+
+   If ``comments`` is ``true``, lines beginning with ``comment_char`` and text following ``comment_char`` in any line are ignored.
 
 .. function:: readdlm(source, delim::Char, eol::Char; options...)
 

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -94,6 +94,13 @@ let x = ["\"hello\"", "world\""], io = IOBuffer()
     @assert takebuf_string(io) == "\"\"\"hello\"\"\"\n\"world\"\"\"\n"
 end
 
+# test comments
+@test isequaldlm(readcsv(IOBuffer("#this is comment\n1,2,3\n#one more comment\n4,5,6")), [1. 2. 3.;4. 5. 6.], Float64)
+@test isequaldlm(readcsv(IOBuffer("#this is \n#comment\n1,2,3\n#one more \n#comment\n4,5,6")), [1. 2. 3.;4. 5. 6.], Float64)
+@test isequaldlm(readcsv(IOBuffer("1,2,#3\n4,5,6")), [1. 2. "";4. 5. 6.], Any)
+@test isequaldlm(readcsv(IOBuffer("1#,2,3\n4,5,6")), [1. "" "";4. 5. 6.], Any)
+@test isequaldlm(readcsv(IOBuffer("1,2,\"#3\"\n4,5,6")), [1. 2. "#3";4. 5. 6.], Any)
+@test isequaldlm(readcsv(IOBuffer("1,2,3\n #with leading whitespace\n4,5,6")), [1. 2. 3.;" " "" "";4. 5. 6.], Any)
 
 # source: http://www.i18nguy.com/unicode/unicode-example-utf8.zip
 let i18n_data = ["Origin (English)", "Name (English)", "Origin (Native)", "Name (Native)", 


### PR DESCRIPTION
This would enable `readdlm` to skip comments while parsing.
- Any line that begins with the comment char (`#` by default) would be treated as a comment.
- `#` at any other position in a line would skip the remaining of the line.
- `#` within a quoted column would have no effect.

New optional parameters to `readdlm`:
- `comment_char` : `#` by default.
- `comments` : whether to skip comments (`true` by default)
