### PR TITLE
Install sigint handler for program mode too

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -279,6 +279,7 @@ function process_options(args::Vector{UTF8String})
             repl = false
             # remove julia's arguments
             splice!(ARGS, 1:length(ARGS), args[i+1:end])
+            ccall(:jl_exit_on_sigint, Void, (Cint,), 1)
             include(args[i])
             break
         else
@@ -382,7 +383,6 @@ function _start()
                 quit()
             end
             quiet || REPL.banner(term,term)
-            ccall(:jl_install_sigint_handler, Void, ())
             local repl
             if term.term_type == "dumb"
                 repl = REPL.BasicREPL(term)

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -969,8 +969,6 @@ function start_worker(out::IO)
     #close(STDIN)
 
     disable_threaded_libs()
-
-    ccall(:jl_install_sigint_handler, Void, ())
     disable_nagle(sock)
 
     try

--- a/src/init.c
+++ b/src/init.c
@@ -72,6 +72,7 @@ jl_compileropts_t jl_compileropts = { NULL, // build_path
 };
 
 int jl_boot_file_loaded = 0;
+int exit_on_sigint = 0;
 
 char *jl_stack_lo;
 char *jl_stack_hi;
@@ -191,6 +192,7 @@ DLLEXPORT void gdblookup(ptrint_t ip);
 
 static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guarantee __stdcall
 {
+    if (exit_on_sigint) jl_exit(0);
     int sig;
     //windows signals use different numbers from unix
     switch(wsig) {
@@ -339,6 +341,7 @@ void restore_signals(void)
 
 void sigint_handler(int sig, siginfo_t *info, void *context)
 {
+    if (exit_on_sigint) jl_exit(0);
     if (jl_defer_signal) {
         jl_signal_pending = sig;
     }
@@ -836,6 +839,8 @@ void julia_init(char *imageFile)
 
     if (imageFile)
         jl_init_restored_modules();
+
+    jl_install_sigint_handler();
 }
 
 DLLEXPORT void jl_install_sigint_handler()
@@ -983,6 +988,8 @@ DLLEXPORT void jl_get_system_hooks(void)
     jl_loaderror_type = (jl_datatype_t*)basemod("LoadError");
     jl_weakref_type = (jl_datatype_t*)basemod("WeakRef");
 }
+
+DLLEXPORT void jl_exit_on_sigint(int on) {exit_on_sigint = on;}
 
 #ifdef __cplusplus
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -1091,6 +1091,8 @@ DLLEXPORT extern volatile sig_atomic_t jl_defer_signal;
     } while(0)
 
 DLLEXPORT void restore_signals(void);
+DLLEXPORT void jl_install_sigint_handler();
+
 
 // tasks and exceptions -------------------------------------------------------
 

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -267,7 +267,7 @@ int true_main(int argc, char *argv[])
             jl_arrayset(args, s, i);
         }
     }
-    
+
     // run program if specified, otherwise enter REPL
     if (program) {
         int ret = exec_program();


### PR DESCRIPTION
In a non-REPL case, the program currently terminates upon a Ctrl-C without calling the `atexit` functions.

This patch:
- installs the sigint handler for both the REPL and Program modes
- In program mode, the master process exits after calling the `atexit` functions.
