### PR TITLE
Reduce memory footprint while reading an array from an asyncstream object

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -38,6 +38,8 @@ IOBuffer(readable::Bool,writable::Bool) = IOBuffer(Uint8[],readable,writable)
 IOBuffer() = IOBuffer(Uint8[], true, true)
 IOBuffer(maxsize::Int) = (x=IOBuffer(Array(Uint8,maxsize),true,true,maxsize); x.size=0; x)
 
+is_maxsize_unlimited(io::IOBuffer) = (io.maxsize == typemax(Int))
+
 read!(from::IOBuffer, a::Array) = read_sub(from, a, 1, length(a))
 
 function read_sub{T}(from::IOBuffer, a::Array{T}, offs, nel)
@@ -192,6 +194,11 @@ function takebuf_array(io::IOBuffer)
 end
 takebuf_string(io::IOBuffer) = bytestring(takebuf_array(io))
 
+function write(to::IOBuffer, from::IOBuffer) 
+    write(to, pointer(from.data,from.ptr), nb_available(from))
+    from.ptr += nb_available(from)
+end
+
 write(to::IOBuffer, p::Ptr, nb::Integer) = write(to, p, int(nb))
 function write(to::IOBuffer, p::Ptr, nb::Int)
     !to.writable && error("write failed")
@@ -255,3 +262,4 @@ function readuntil(io::IOBuffer, delim::Uint8)
     end
     read!(io, Array(Uint8, nb))
 end
+


### PR DESCRIPTION
Currently, deserializing a large array, say a couple of GB, results in the following:
1) The entire array is first recd into an IOBuffer associated with the socket, from where it is then copied onto the allocated array. 
2) The IOBuffer associated with the socket is never compressed, which means it continues to occupy as much memory as the largest array ever recd for the lifetime of the connection.

This PR  changes the above behavior to
1) Reads arrays from asyncstream objects directly into the array memory instead of via the sockets intermediate iobuffer.
2) Limits the length of data stored in the asyncstream's iobuffer. Pauses the libuv socket reads till user code actually starts requesting data from the asyncstream object. 

Without this patch

```
julia> remotecall_fetch(2, ()->ones(2^28));
julia> println(length(Base.PGRP.workers[2].socket.buffer.data))
2147511424
julia> println(length(Base.PGRP.workers[2].socket.buffer.data))
2147511424
```

With this patch

```
julia> remotecall_fetch(2, ()->ones(2^28));
julia> println(length(Base.PGRP.workers[2].socket.buffer.data))
131072
julia> println(length(Base.PGRP.workers[2].socket.buffer.data))
131072
```
