### PR TITLE
README: Remove old terminal binding instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,16 +304,6 @@ The following distributions include julia, but the versions may be out of date d
 <a name="Editor-Terminal-Setup"/>
 ## Editor and Terminal Setup
 
-Currently, Julia editing mode support is available for Emacs, Vim, Textmate, Sublime Text, Notepad++, and Kate, in `contrib/`
+Currently, Julia editing mode support is available for Emacs, Vim, Textmate, Sublime Text, Notepad++, and Kate, in `contrib/`.
 
-Adjusting your terminal bindings is optional; everything will work fine without these key bindings.
-For the best interactive session experience, however, make sure that your terminal emulator (`Terminal`, `iTerm`, `xterm`, etc.) sends the `^H` sequence for `Backspace` (delete key) and that the `Shift-Enter` key combination sends a `\n` newline character to distinguish it from just pressing `Enter`, which sends a `\r` carriage return character.
-These bindings allow custom readline handlers to trap and correctly deal with these key sequences; other programs will continue to behave normally with these bindings.
-The first binding makes backspacing through text at the prompt behave more intuitively.
-The second binding allows `Shift-Enter` to insert a newline without evaluating the current expression, even when the current expression is complete.
-(Pressing an unmodified `Enter` inserts a newline if the current expression is incomplete, evaluates the expression if it is complete, or shows an error if the syntax is irrecoverably invalid.)
-
-On Linux systems, the `Shift-Enter` binding can be set by placing the following line in the file `.xmodmaprc` in your home directory:
-
-    keysym Return = Return Linefeed
-
+In the terminal, Julia makes great use of both control-key and meta-key bindings. To make the meta-key bindings more accessible, many terminal emulator programs (e.g., `Terminal`, `iTerm`, `xterm`, etc) allow you to use the alt or option key as meta.  See the section in the manual on [interacting with Julia](http://docs.julialang.org/en/latest/manual/interacting-with-julia/) for more details.


### PR DESCRIPTION
There were previously two terminal binding tips: Bind backspace to `^H` and shift-enter to `\n` instead of `\r`.

For backspace, the new REPL also binds ASCII 127 to backspace. If there are terminals sending different keycodes than either 127 or `^H` (which is equivalent to `\b`) then they are either configured totally wrong or we should attempt to bind those keycodes, too.

For return, there is now no difference between `\r` and `\n`, so there is no point in directing people to make that change.  Line feeds are entered with meta-enter.

Instead, add a tip about the meta-key and point to the interacting with Julia manual section.
