### PR TITLE
Fix searchsorted for Ranges

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -175,7 +175,7 @@ function searchsorted(v::AbstractVector, x, lo::Int, hi::Int, o::Ordering)
     return lo+1:hi-1
 end
 
-function searchsortedlast{T<:Real}(a::Range{T}, x::Real, o::Ordering=Forward)
+function searchsortedlast{T<:Real}(a::Range{T}, x::Real, o::DirectOrdering)
     if step(a) == 0
         lt(o, x, first(a)) ? 0 : length(a)
     else
@@ -184,7 +184,7 @@ function searchsortedlast{T<:Real}(a::Range{T}, x::Real, o::Ordering=Forward)
     end
 end
 
-function searchsortedfirst{T<:Real}(a::Range{T}, x::Real, o::Ordering=Forward)
+function searchsortedfirst{T<:Real}(a::Range{T}, x::Real, o::DirectOrdering)
     if step(a) == 0
         lt(o, first(a), x) ? length(a)+1 : 1
     else
@@ -193,7 +193,7 @@ function searchsortedfirst{T<:Real}(a::Range{T}, x::Real, o::Ordering=Forward)
     end
 end
 
-function searchsortedlast{T<:Integer}(a::Range{T}, x::Real, o::Ordering=Forward)
+function searchsortedlast{T<:Integer}(a::Range{T}, x::Real, o::DirectOrdering)
     if step(a) == 0
         lt(o, x, first(a)) ? 0 : length(a)
     else
@@ -201,7 +201,7 @@ function searchsortedlast{T<:Integer}(a::Range{T}, x::Real, o::Ordering=Forward)
     end
 end
 
-function searchsortedfirst{T<:Integer}(a::Range{T}, x::Real, o::Ordering=Forward)
+function searchsortedfirst{T<:Integer}(a::Range{T}, x::Real, o::DirectOrdering)
     if step(a) == 0
         lt(o, first(a), x) ? length(a)+1 : 1
     else
@@ -209,8 +209,8 @@ function searchsortedfirst{T<:Integer}(a::Range{T}, x::Real, o::Ordering=Forward
     end
 end
 
-searchsorted{T<:Real}(a::Range{T}, x::Real; kws...) =
-    searchsortedfirst(a,x; kws...):searchsortedlast(a,x; kws...)
+searchsorted{T<:Real}(a::Range{T}, x::Real, o::DirectOrdering) =
+    searchsortedfirst(a,x,o):searchsortedlast(a,x,o)
 
 for s in {:searchsortedfirst, :searchsortedlast, :searchsorted}
     @eval begin

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -21,6 +21,9 @@ end
 @test searchsorted([1, 1, 2, 2, 3, 3], 4) == 7:6
 @test searchsorted([1.0, 1, 2, 2, 3, 3], 2.5) == 5:4
 
+@test searchsorted([1:10], 1, by=(x -> x >= 5)) == 1:4
+@test searchsorted([1:10], 10, by=(x -> x >= 5)) == 5:10
+
 for (rg,I) in {(49:57,47:59), (1:2:17,-1:19), (-3:0.5:2,-5:.5:4)}
     rg_r = reverse(rg)
     rgv, rgv_r = [rg], [rg_r]
@@ -43,6 +46,9 @@ for i = 1:100
     @test searchsorted(rg_r, prevfloat(rg_r[i]), rev=true) == i+1:i
     @test searchsorted(rg_r, nextfloat(rg_r[i]), rev=true) == i:i-1
 end
+
+@test searchsorted(1:10, 1, by=(x -> x >= 5)) == searchsorted([1:10], 1, by=(x -> x >= 5))
+@test searchsorted(1:10, 10, by=(x -> x >= 5)) == searchsorted([1:10], 10, by=(x -> x >= 5))
 
 a = rand(1:10000, 1000)
 


### PR DESCRIPTION
When a is a Range instead of a Vector, searchsorted(a, x, o::Ordering) is computed in constant time, instead of logarithmic time. However, this optimization only works when o is a DirectOrdering, and this restriction was not being enforced.
