### PR TITLE
Remove warnings from Intel VTune Amplifier about signal stack being too small

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -510,6 +510,11 @@ JCPPFLAGS += -D_WIN32_WINNT=0x0600
 UNTRUSTED_SYSTEM_LIBM = 1
 endif
 
+# Intel VTune Amplifier
+ifeq ($(USE_INTEL_JITEVENTS), 1)
+JCPPFLAGS += -DJL_USE_INTEL_JITEVENTS
+endif
+
 # Intel libraries
 
 ifeq ($(USE_INTEL_LIBM), 1)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4296,12 +4296,11 @@ extern "C" void jl_init_codegen(void)
 
     jl_jit_events = new JuliaJITEventListener();
     jl_ExecutionEngine->RegisterJITEventListener(jl_jit_events);
-#if LLVM_USE_INTEL_JITEVENTS
-    if (const char* jit_profiling = std::getenv("ENABLE_JITPROFILING"))
-        if (std::atoi(jit_profiling))
-            jl_ExecutionEngine->RegisterJITEventListener(
-                JITEventListener::createIntelJITEventListener());
-#endif // LLVM_USE_INTEL_JITEVENTS
+#ifdef JL_USE_INTEL_JITEVENTS
+    if (jl_using_intel_jitevents) 
+        jl_ExecutionEngine->RegisterJITEventListener(
+            JITEventListener::createIntelJITEventListener());
+#endif // JL_USE_INTEL_JITEVENTS
 
     BOX_F(int8,int32);  BOX_F(uint8,uint32);
     BOX_F(int16,int16); BOX_F(uint16,uint16);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -76,7 +76,9 @@ void jl_initialize_generic_function(jl_function_t *f, jl_sym_t *name);
 void jl_compute_field_offsets(jl_datatype_t *st);
 jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, size_t *dims,
                                              int isunboxed, int elsz);
-
+#ifdef JL_USE_INTEL_JITEVENTS 
+extern char jl_using_intel_jitevents;
+#endif
 extern size_t jl_arr_xtralloc_limit;
 
 void jl_init_types(void);


### PR DESCRIPTION
Intel VTune Amplifier XE 2013 requires a 64K signal stack on Linux.  (See page 16 [here](https://software.intel.com/sites/default/files/article/251102/release-notes-amplifier-xe-linux-update4.pdf) for details).  This pull request provides this size stack if all three of the following conditions are true:
- Julia is running on Linux.
- Julia was configured with `USE_INTEL_JITEVENTS`.
- Julia is running under Intel VTune Amplifier.
  Otherwise, the signal stack size is the same.  If Julia is not configured with `USE_INTEL_JITEVENTS`, no overhead (in space or time) is incurred. 
