### PR TITLE
Export Reverse in Base.Order

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -3,12 +3,11 @@ module Order
 ## notions of element ordering ##
 
 export # not exported by Base
-    Ordering, Forward, Lexicographic,
+    Ordering, Forward, Reverse, Lexicographic,
     By, Lt, Perm,
     ReverseOrdering, ForwardOrdering, LexicographicOrdering,
     DirectOrdering,
     lt, uint_mapping, ord, ordtype
-    # Reverse, # TODO: clashes with Reverse iterator
 
 abstract Ordering
 


### PR DESCRIPTION
In the past, Base.Order did not export Reverse since it clashed with the Reverse iterator. However, Reverse iterator has since been removed (see https://github.com/JuliaLang/julia/issues/4590), so there is no longer any conflict.
