### PR TITLE
more efficient setindex for sparsematrix

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -591,8 +591,8 @@ for (op, restype) in ( (:+, Nothing), (:-, Nothing), (:.*, Nothing),
                 colptrS[col+1] = ptrS
             end
 
-            splice!(rowvalS, colptrS[end]:length(rowvalS))
-            splice!(nzvalS, colptrS[end]:length(nzvalS))
+            deleteat!(rowvalS, colptrS[end]:length(rowvalS))
+            deleteat!(nzvalS, colptrS[end]:length(nzvalS))
             return SparseMatrixCSC(m, n, colptrS, rowvalS, nzvalS)
         end
 
@@ -1053,8 +1053,8 @@ function setindex!{T,Ti}(A::SparseMatrixCSC{T,Ti}, v, i0::Integer, i1::Integer)
             end
         end
         if loc != -1
-            splice!(A.rowval, loc)
-            splice!(A.nzval, loc)
+            deleteat!(A.rowval, loc)
+            deleteat!(A.nzval, loc)
             for j = (i1+1):(A.n+1)
                 A.colptr[j] = A.colptr[j] - 1
             end
@@ -1242,8 +1242,8 @@ function spset!{Tv,Ti<:Integer}(A::SparseMatrixCSC{Tv}, x::Tv, I::AbstractVector
 
     if nadd > 0
         colptrA[n+1] = rowidx
-        splice!(rowvalA, rowidx:nnzA)
-        splice!(nzvalA, rowidx:nnzA)
+        deleteat!(rowvalA, rowidx:nnzA)
+        deleteat!(nzvalA, rowidx:nnzA)
         
         A.colptr = colptrA
         A.rowval = rowvalA
@@ -1299,8 +1299,8 @@ function spdelete!{Tv,Ti<:Integer}(A::SparseMatrixCSC{Tv}, I::AbstractVector{Ti}
 
     if ndel > 0
         colptrA[n+1] = rowidx
-        splice!(rowvalA, rowidx:nnzA)
-        splice!(nzvalA, rowidx:nnzA)
+        deleteat!(rowvalA, rowidx:nnzA)
+        deleteat!(nzvalA, rowidx:nnzA)
         
         A.colptr = colptrA
         A.rowval = rowvalA
@@ -1427,8 +1427,8 @@ function setindex!{Tv,Ti,T<:Integer}(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixC
         colB += 1
     end
 
-    splice!(rowvalS, colptrS[end]:length(rowvalS))
-    splice!(nzvalS, colptrS[end]:length(nzvalS))
+    deleteat!(rowvalS, colptrS[end]:length(rowvalS))
+    deleteat!(nzvalS, colptrS[end]:length(nzvalS))
 
     A.colptr = colptrS
     A.rowval = rowvalS

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -240,17 +240,52 @@ for op in (:sin, :cos, :tan, :iceil, :ifloor, :ceil, :floor, :abs, :abs2)
 end
 
 # setindex tests
-a = spzeros(Int, 10, 10)
-@test nfilled(a) == 0
-a[1,:] = 1
-@test nfilled(a) == 10
-@test a[1,:] == sparse(ones(Int,1,10))
-a[:,2] = 2
-@test nfilled(a) == 19
-@test a[:,2] == 2*sparse(ones(Int,10,1))
+let a = spzeros(Int, 10, 10)
+    @test countnz(a) == 0
+    a[1,:] = 1
+    @test countnz(a) == 10
+    @test a[1,:] == sparse(ones(Int,1,10))
+    a[:,2] = 2
+    @test countnz(a) == 19
+    @test a[:,2] == 2*sparse(ones(Int,10,1))
 
-a[1,:] = 1:10
-@test a[1,:] == sparse([1:10]')
-a[:,2] = 1:10
-@test a[:,2] == sparse([1:10])
+    a[1,:] = 1:10
+    @test a[1,:] == sparse([1:10]')
+    a[:,2] = 1:10
+    @test a[:,2] == sparse([1:10])
+end
+
+let A = spzeros(Int, 10, 20)
+    A[1:5,1:10] = 10
+    A[1:5,1:10] = 10
+    @test countnz(A) == 50
+    @test A[1:5,1:10] == 10 * ones(Int, 5, 10)
+    A[6:10,11:20] = 0
+    @test countnz(A) == 50
+    A[6:10,11:20] = 20
+    @test countnz(A) == 100
+    @test A[6:10,11:20] == 20 * ones(Int, 5, 10)
+    A[4:8,8:16] = 15
+    @test countnz(A) == 121
+    @test A[4:8,8:16] == 15 * ones(Int, 5, 9)
+end
+
+let ASZ = 1000, TSZ = 800 
+    A = sprand(ASZ, 2*ASZ, 0.0001)
+    B = copy(A)
+    nA = countnz(A)
+    x = A[1:TSZ, 1:(2*TSZ)]
+    nx = countnz(x)
+    A[1:TSZ, 1:(2*TSZ)] = 0
+    nB = countnz(A)
+    @test nB == (nA - nx)
+    A[1:TSZ, 1:(2*TSZ)] = x
+    @test countnz(A) == nA
+    @test A == B
+    A[1:TSZ, 1:(2*TSZ)] = 10
+    @test countnz(A) == nB + 2*TSZ*TSZ
+    A[1:TSZ, 1:(2*TSZ)] = x
+    @test countnz(A) == nA
+    @test A == B
+end
 


### PR DESCRIPTION
This implements `setindex!(A::SparseMatrixCSC, x::Number, I, J)` to be more efficient.

Before:

```
julia> A = sprand(10000, 10000, 0.0001);

julia> @time A[1:8000, 1:8000] = 10;    # set some new indices
elapsed time: 62.222216641 seconds (13574393504 bytes allocated)

julia> @time A[1:8000, 1:8000] = 11;    # change existing values
elapsed time: 67.845266004 seconds (16635419192 bytes allocated)

julia> @time A[1:8000, 1:8000] = 0;     # zero existing values
elapsed time: 5.030329475 seconds (2560507944 bytes allocated)

julia> @time A[1:8000, 1:8000] = 0;     # zero already zero'd values
elapsed time: 0.709701096 seconds (512507944 bytes allocated)

julia> @time A[1:8000, 1:8000] = 10;    # set all new indices
elapsed time: 52.267994938 seconds (13038875192 bytes allocated)
```

With this patch:

```
julia> A = sprand(10000, 10000, 0.0001);

julia> @time A[1:8000, 1:8000] = 10;    # set some new indices
elapsed time: 1.84697863 seconds (1030174960 bytes allocated)

julia> @time A[1:8000, 1:8000] = 11;    # change existing values
elapsed time: 0.792033539 seconds (96 bytes allocated)

julia> @time A[1:8000, 1:8000] = 0;     # zero existing values
elapsed time: 5.615637808 seconds (2048139680 bytes allocated)

julia> @time A[1:8000, 1:8000] = 0;     # zero already zero'd values
elapsed time: 0.000156263 seconds (96 bytes allocated)

julia> @time A[1:8000, 1:8000] = 10;    # set all new indices
elapsed time: 1.726549776 seconds (1024139680 bytes allocated)
```
