### PR TITLE
Fix PriorityQueue(ks, vs) constructor

### DIFF
--- a/base/collections.jl
+++ b/base/collections.jl
@@ -129,7 +129,7 @@ type PriorityQueue{K,V} <: Associative{K,V}
         if length(ks) != length(vs)
             error("key and value arrays must have equal lengths")
         end
-        PriorityQueue{K,V}(zip(ks, vs))
+        PriorityQueue{K,V}(zip(ks, vs), o)
     end
 
     function PriorityQueue(itr, o::Ordering)

--- a/test/priorityqueue.jl
+++ b/test/priorityqueue.jl
@@ -21,6 +21,13 @@ pq = PriorityQueue(priorities)
 test_issorted!(pq, priorities)
 
 
+# building from two lists
+ks, vs = 1:n, rand(1:pmax, n)
+pq = PriorityQueue(ks, vs)
+priorities = Dict(ks, vs)
+test_issorted!(pq, priorities)
+
+
 # enqueing via enqueue!
 pq = PriorityQueue()
 for (k, v) in priorities


### PR DESCRIPTION
Right now, the constructor for building a PriorityQueue from a list of keys and a list of values is broken:

```
julia> pq = PriorityQueue(1:10, 1:10)
ERROR: no method PriorityQueue{Int64,Int64}(Zip2{UnitRange{Int64},UnitRange{Int64}})
 in PriorityQueue at collections.jl:132
 in PriorityQueue at collections.jl:159
```

This patch fixes it and adds a test.

By the way, there's a comment above this constructor that says "maybe deprecate." What's the reason? It seems useful.
