### PR TITLE
Use vecnorm in norm(Matrix) when first dimension has size one.

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -144,7 +144,7 @@ vecnorm(x::Number, p::Real=2) = p == 0 ? real(x==0 ? zero(x) : one(x)) : abs(x)
 norm(x::AbstractVector, p::Real=2) = vecnorm(x, p)
 
 function norm1{T}(A::AbstractMatrix{T})
-    m,n = size(A)
+    m, n = size(A)
     Tnorm = typeof(float(real(zero(T))))
     Tsum = promote_type(Float64,Tnorm)
     nrm::Tsum = 0
@@ -161,6 +161,7 @@ function norm1{T}(A::AbstractMatrix{T})
 end
 function norm2{T}(A::AbstractMatrix{T})
     m,n = size(A)
+    if m == 1 || n == 1 return vecnorm2(A) end
     Tnorm = typeof(float(real(zero(T))))
     (m == 0 || n == 0) ? zero(Tnorm) : convert(Tnorm, svdvals(A)[1])
 end


### PR DESCRIPTION
This one speeds up the norm calculations reported to be slow on the dev mailing list.

cc: @jiahao, @stevengj 
