### PR TITLE
WIP: Mapping over [] returns []. Fixes #6719

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1261,7 +1261,7 @@ function map_to!(f::Callable, first, dest::AbstractArray, A::AbstractArray)
 end
 
 function map(f::Callable, A::AbstractArray)
-    if isempty(A); return {}; end
+    if isempty(A); return []; end
     first = f(A[1])
     dest = similar(A, typeof(first))
     return map_to!(f, first, dest, A)

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -13,6 +13,10 @@ let io=IOBuffer(3)
     @test takebuf_string(io)=="12"
 end
 
+# map over [] should return []
+# issue #6719
+@test isequal(typeof(map(x -> x, [])), Array{None,1})
+
 # maps of tuples (formerly in test/core.jl) -- tuple.jl
 @test map((x,y)->x+y,(1,2,3),(4,5,6)) == (5,7,9)
 @test map((x,y)->x+y,


### PR DESCRIPTION
This PR resolves #6719 as suggested by Jeff Bezanzon. Have a look there
for a description of the problem.

I am a bit troubled that i'm essentially able to return anything I want here.
Ie in scala, the map function on a list looks like this: `map[B](f: (A) ⇒ B): List[B]`.
Without this sort of constraint i could reasonably
- return {}, as before
- return the input A if isempty(A)
- return []

It would be ideal if I knew the return type of f, then that could be the return type
of map. Without this, I don't see clear semantics for the map function across 
all of it's methods. What about mapping over an empty range? This currently 
returns {}, should that also be changed to []? What about all the iterables? 

This is my first pull request, sorry for all the questions :)
