### PR TITLE
Fix some issues related to eigvals

### DIFF
--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -563,7 +563,7 @@ function eigvals!{T<:BlasComplex}(A::StridedMatrix{T}; permute::Bool=true, scale
     ishermitian(A) && return eigvals(Hermitian(A))
     return LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'N', 'N', A)[2]
 end
-eigvals{T}(A::AbstractMatrix{T}; kwargs...) = (S = promote_type(Float32,typeof(one(T)/norm(one(T)))); S != T ? eigvals!(convert(AbstractMatrix{S}, A); kwargs...) : eigvals!(copy(A); kwargs...))
+eigvals{T}(A::AbstractMatrix{T}, args...; kwargs...) = (S = promote_type(Float32,typeof(one(T)/norm(one(T)))); S != T ? eigvals!(convert(AbstractMatrix{S}, A), args...; kwargs...) : eigvals!(copy(A), args...; kwargs...))
 eigvals{T<:Number}(x::T; kwargs...) = (val = convert(promote_type(Float32,typeof(one(T)/norm(one(T)))),x); imag(val) == 0 ? [real(val)] : [val])
 
 #Computes maximum and minimum eigenvalue

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -37,16 +37,16 @@ ctranspose(A::Hermitian) = A
 factorize(A::HermOrSym) = bkfact(A.S, symbol(A.uplo), issym(A))
 \(A::HermOrSym, B::StridedVecOrMat) = \(bkfact(A.S, symbol(A.uplo), issym(A)), B)
 
-eigfact!{T<:BlasFloat}(A::HermOrSym{T}) = Eigen(LAPACK.syevr!('V', 'A', A.uplo, A.S, 0.0, 0.0, 0, 0, -1.0)...)
-eigfact!{T<:BlasFloat}(A::HermOrSym{T}, irange::UnitRange) = Eigen(LAPACK.syevr!('V', 'I', A.uplo, A.S, 0.0, 0.0, irange.start, irange.stop, -1.0)...)
-eigfact!{T<:BlasFloat}(A::HermOrSym{T}, vl::Real, vh::Real) = Eigen(LAPACK.syevr!('V', 'V', A.uplo, A.S, convert(T, vl), convert(T, vh), 0, 0, -1.0)...)
-eigvals!{T<:BlasFloat}(A::HermOrSym{T}) = LAPACK.syevr!('N', 'A', A.uplo, A.S, 0.0, 0.0, 0, 0, -1.0)[1]
-eigvals!{T<:BlasFloat}(A::HermOrSym{T}, irange::UnitRange) = LAPACK.syevr!('N', 'I', A.uplo, A.S, 0.0, 0.0, irange.start, irange.stop, -1.0)[1]
-eigvals!{T<:BlasFloat}(A::HermOrSym{T}, vl::Real, vh::Real) = LAPACK.syevr!('N', 'V', A.uplo, A.S, convert(T, vl), convert(T, vh), 0, 0, -1.0)[1]
-eigmax(A::HermOrSym) = eigvals(A, size(A, 1), size(A, 1))[1]
-eigmin(A::HermOrSym) = eigvals(A, 1, 1)[1]
+eigfact!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}})) = Eigen(LAPACK.syevr!('V', 'A', A.uplo, A.S, 0.0, 0.0, 0, 0, -1.0)...)
+eigfact!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}}), irange::UnitRange) = Eigen(LAPACK.syevr!('V', 'I', A.uplo, A.S, 0.0, 0.0, irange.start, irange.stop, -1.0)...)
+eigfact!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}}), vl::Real, vh::Real) = Eigen(LAPACK.syevr!('V', 'V', A.uplo, A.S, convert(T, vl), convert(T, vh), 0, 0, -1.0)...)
+eigvals!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}})) = LAPACK.syevr!('N', 'A', A.uplo, A.S, 0.0, 0.0, 0, 0, -1.0)[1]
+eigvals!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}}), irange::UnitRange) = LAPACK.syevr!('N', 'I', A.uplo, A.S, 0.0, 0.0, irange.start, irange.stop, -1.0)[1]
+eigvals!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}}), vl::Real, vh::Real) = LAPACK.syevr!('N', 'V', A.uplo, A.S, convert(T, vl), convert(T, vh), 0, 0, -1.0)[1]
+eigmax{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}})) = eigvals(A, size(A, 1), size(A, 1))[1]
+eigmin{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}})) = eigvals(A, 1, 1)[1]
 
-function eigfact!{T<:BlasReal}(A::Symmetric{T}, B::Symmetric{T})
+function eigfact!{T<:BlasReal}(A::HermOrSym{T}, B::HermOrSym{T})
     vals, vecs, _ = LAPACK.sygvd!(1, 'V', A.uplo, A.S, B.uplo == A.uplo ? B.S : B.S')
     GeneralizedEigen(vals, vecs)
 end
@@ -54,7 +54,7 @@ function eigfact!{T<:BlasComplex}(A::Hermitian{T}, B::Hermitian{T})
     vals, vecs, _ = LAPACK.sygvd!(1, 'V', A.uplo, A.S, B.uplo == A.uplo ? B.S : B.S')
     GeneralizedEigen(vals, vecs)
 end
-eigvals!{T<:BlasReal}(A::Symmetric{T}, B::Symmetric{T}) = LAPACK.sygvd!(1, 'N', A.uplo, A.S, B.uplo == A.uplo ? B.S : B.S')[1]
+eigvals!{T<:BlasReal}(A::HermOrSym{T}, B::HermOrSym{T}) = LAPACK.sygvd!(1, 'N', A.uplo, A.S, B.uplo == A.uplo ? B.S : B.S')[1]
 eigvals!{T<:BlasComplex}(A::Hermitian{T}, B::Hermitian{T}) = LAPACK.sygvd!(1, 'N', A.uplo, A.S, B.uplo == A.uplo ? B.S : B.S')[1]
 
 #Matrix-valued functions

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -10,9 +10,11 @@ immutable Hermitian{T} <: AbstractMatrix{T}
 end
 Hermitian(A::Matrix, uplo::Symbol=:U) = (chksquare(A);Hermitian(A, string(uplo)[1]))
 typealias HermOrSym{T} Union(Hermitian{T}, Symmetric{T})
+typealias RealHermSymComplexHerm{T<:Real} Union(Hermitian{T}, Symmetric{T}, Hermitian{Complex{T}})
 
 size(A::HermOrSym, args...) = size(A.S, args...)
-getindex(A::HermOrSym, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? getindex(A.S, i, j) : conj(getindex(A.S, j, i))
+getindex(A::Symmetric, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? getindex(A.S, i, j) : getindex(A.S, j, i)
+getindex(A::Hermitian, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? getindex(A.S, i, j) : conj(getindex(A.S, j, i))
 full(A::Symmetric) = copytri!(A.S, A.uplo)
 full(A::Hermitian) = copytri!(A.S, A.uplo, true)
 convert{T}(::Type{Symmetric{T}},A::Symmetric) = Symmetric(convert(Matrix{T},A.S), A.uplo)
@@ -37,14 +39,14 @@ ctranspose(A::Hermitian) = A
 factorize(A::HermOrSym) = bkfact(A.S, symbol(A.uplo), issym(A))
 \(A::HermOrSym, B::StridedVecOrMat) = \(bkfact(A.S, symbol(A.uplo), issym(A)), B)
 
-eigfact!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}})) = Eigen(LAPACK.syevr!('V', 'A', A.uplo, A.S, 0.0, 0.0, 0, 0, -1.0)...)
-eigfact!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}}), irange::UnitRange) = Eigen(LAPACK.syevr!('V', 'I', A.uplo, A.S, 0.0, 0.0, irange.start, irange.stop, -1.0)...)
-eigfact!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}}), vl::Real, vh::Real) = Eigen(LAPACK.syevr!('V', 'V', A.uplo, A.S, convert(T, vl), convert(T, vh), 0, 0, -1.0)...)
-eigvals!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}})) = LAPACK.syevr!('N', 'A', A.uplo, A.S, 0.0, 0.0, 0, 0, -1.0)[1]
-eigvals!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}}), irange::UnitRange) = LAPACK.syevr!('N', 'I', A.uplo, A.S, 0.0, 0.0, irange.start, irange.stop, -1.0)[1]
-eigvals!{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}}), vl::Real, vh::Real) = LAPACK.syevr!('N', 'V', A.uplo, A.S, convert(T, vl), convert(T, vh), 0, 0, -1.0)[1]
-eigmax{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}})) = eigvals(A, size(A, 1), size(A, 1))[1]
-eigmin{T<:BlasReal}(A::Union(HermOrSym{T}, Hermitian{Complex{T}})) = eigvals(A, 1, 1)[1]
+eigfact!{T<:BlasReal}(A::RealHermSymComplexHerm{T}) = Eigen(LAPACK.syevr!('V', 'A', A.uplo, A.S, 0.0, 0.0, 0, 0, -1.0)...)
+eigfact!{T<:BlasReal}(A::RealHermSymComplexHerm{T}, irange::UnitRange) = Eigen(LAPACK.syevr!('V', 'I', A.uplo, A.S, 0.0, 0.0, irange.start, irange.stop, -1.0)...)
+eigfact!{T<:BlasReal}(A::RealHermSymComplexHerm{T}, vl::Real, vh::Real) = Eigen(LAPACK.syevr!('V', 'V', A.uplo, A.S, convert(T, vl), convert(T, vh), 0, 0, -1.0)...)
+eigvals!{T<:BlasReal}(A::RealHermSymComplexHerm{T}) = LAPACK.syevr!('N', 'A', A.uplo, A.S, 0.0, 0.0, 0, 0, -1.0)[1]
+eigvals!{T<:BlasReal}(A::RealHermSymComplexHerm{T}, irange::UnitRange) = LAPACK.syevr!('N', 'I', A.uplo, A.S, 0.0, 0.0, irange.start, irange.stop, -1.0)[1]
+eigvals!{T<:BlasReal}(A::RealHermSymComplexHerm{T}, vl::Real, vh::Real) = LAPACK.syevr!('N', 'V', A.uplo, A.S, convert(T, vl), convert(T, vh), 0, 0, -1.0)[1]
+eigmax{T<:Real}(A::RealHermSymComplexHerm{T}) = eigvals(A, size(A, 1), size(A, 1))[1]
+eigmin{T<:Real}(A::RealHermSymComplexHerm{T}) = eigvals(A, 1, 1)[1]
 
 function eigfact!{T<:BlasReal}(A::HermOrSym{T}, B::HermOrSym{T})
     vals, vecs, _ = LAPACK.sygvd!(1, 'V', A.uplo, A.S, B.uplo == A.uplo ? B.S : B.S')
@@ -58,8 +60,8 @@ eigvals!{T<:BlasReal}(A::HermOrSym{T}, B::HermOrSym{T}) = LAPACK.sygvd!(1, 'N', 
 eigvals!{T<:BlasComplex}(A::Hermitian{T}, B::Hermitian{T}) = LAPACK.sygvd!(1, 'N', A.uplo, A.S, B.uplo == A.uplo ? B.S : B.S')[1]
 
 #Matrix-valued functions
-expm(A::HermOrSym) = (F = eigfact(A); F.vectors*Diagonal(exp(F.values))*F.vectors')
-function sqrtm(A::HermOrSym)
+expm{T<:Real}(A::RealHermSymComplexHerm{T}) = (F = eigfact(A); F.vectors*Diagonal(exp(F.values))*F.vectors')
+function sqrtm{T<:Real}(A::RealHermSymComplexHerm{T})
     F = eigfact(A)
     isposdef(F) && return F.vectors*Diagonal(sqrt(F.values))*F.vectors'
     return F.vectors*Diagonal(sqrt(complex(F.values)))*F.vectors'

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -134,6 +134,9 @@ debug && println("symmetric eigen-decomposition")
         @test_approx_eq v*Diagonal(d)*v' asym
         @test isequal(eigvals(asym[1]), eigvals(asym[1:1,1:1]))
         @test_approx_eq abs(eigfact(Hermitian(asym), 1:2)[:vectors]'v[:,1:2]) eye(eltya, 2)
+        @test_approx_eq abs(eigfact(Hermitian(asym), d[1]-10*eps(d[1]), d[2]+10*eps(d[2]))[:vectors]'v[:,1:2]) eye(eltya, 2)
+        @test_approx_eq eigvals(Hermitian(asym), 1:2) d[1:2]
+        @test_approx_eq eigvals(Hermitian(asym), d[1]-10*eps(d[1]), d[2]+10*eps(d[2])) d[1:2]
     end
 
 debug && println("non-symmetric eigen decomposition")


### PR DESCRIPTION
- Pass arguments to `eigvals` to `eigvals!`, so that `eigvals(A, irange)` and `eigvals(A, vl, vu)` work as described in the docs
- Restrict `eigfact!`/`eigvals!` to real symmetric/Hermitian or complex Hermitian matrices. Previously we allowed these methods to be called on complex symmetric matrices, which did not give correct results.
- Allow `eigfact!`/`eigvals!` for generalized eigenproblem of Hermitian real matrices.
- Add some additional tests.

I may be exposing my ignorance, but I'm confused about the current division between Symmetric and Hermitian. Are there situations where a symmetric complex matrix makes sense? If not, it seems like ideally we'd define Symmetric as `typealias Symmetric{T<:Real} Hermitian{T}`, although this would break the constructor.
