### PR TITLE
Fix #6372

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -153,9 +153,11 @@ function clone(url::String, pkg::String)
         run(`rm -rf $pkg`)
         rethrow()
     end
-    isempty(Reqs.parse("$pkg/REQUIRE")) && return
     info("Computing changes...")
-    resolve()
+    if !edit(Reqs.add, pkg)
+        isempty(Reqs.parse("$pkg/REQUIRE")) && return
+        resolve()
+    end
 end
 
 function clone(url_or_pkg::String)


### PR DESCRIPTION
This adds the package to REQUIRE on `Pkg.clone()` if it exists in METADATA. This means that calling `Pkg.clone()` on a repo that's on an old tag will result in the package getting updated to the latest release, but that seemed preferable to making `Pkg.clone()` on a package that's on a tag result in a pinned package.
