### PR TITLE
Return NaN for median of vectors containing NaN. Closes #6486

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -31,7 +31,11 @@ mean{T}(v::AbstractArray{T}, region) =
 
 function median!{T<:Real}(v::AbstractVector{T}; checknan::Bool=true)
     isempty(v) && error("median of an empty array is undefined")
-    checknan && any(isnan,v) && error("median of an array with NaNs is undefined")
+    if checknan
+        for x in v
+            isnan(x) && return x
+        end
+    end
     n = length(v)
     if isodd(n)
         return select!(v,div(n+1,2))

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -16,10 +16,10 @@
 
 
 @test_throws ErrorException median([])
-@test_throws ErrorException median([NaN])
-@test_throws ErrorException median([0.0,NaN])
-@test_throws ErrorException median([NaN,0.0])
-@test_throws ErrorException median([NaN 0.0; 1.2 4.5], 2)
+@test isnan(median([NaN]))
+@test isnan(median([0.0,NaN]))
+@test isnan(median([NaN,0.0]))
+@test isequal(median([NaN 0.0; 1.2 4.5], 2), reshape([NaN; 2.85], 2, 1))
 
 @test mean([1,2,3]) == 2.
 @test mean([0 1 2; 4 5 6], 1) == [2.  3.  4.]


### PR DESCRIPTION
This seemed to be the consensus, so I'll merge tomorrow unless there is a complaint.
