### PR TITLE
Make Cholesky factor always be Triangular. Fix odd transpose bug.

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -1,7 +1,7 @@
 module LinAlg
 
 importall Base
-import Base: USE_BLAS64, size, copy, copy_transpose!, power_by_squaring, print_matrix
+import Base: USE_BLAS64, size, copy, copy_transpose!, power_by_squaring, print_matrix, transpose!
 
 export 
 # Modules

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -52,8 +52,8 @@ size(C::Union(Cholesky, CholeskyPivoted)) = size(C.UL)
 size(C::Union(Cholesky, CholeskyPivoted), d::Integer) = size(C.UL,d)
 
 function getindex(C::Cholesky, d::Symbol)
-    d == :U && return triu!(symbol(C.uplo) == d ? C.UL : C.UL')
-    d == :L && return tril!(symbol(C.uplo) == d ? C.UL : C.UL')
+    d == :U && return Triangular(triu!(symbol(C.uplo) == d ? C.UL : C.UL'),:U)
+    d == :L && return Triangular(tril!(symbol(C.uplo) == d ? C.UL : C.UL'),:L)
     d == :UL && return Triangular(C.UL, symbol(C.uplo))
     throw(KeyError(d))
 end

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -95,8 +95,10 @@ getindex{T}(A::Triangular{T}, i::Integer, j::Integer) = i == j ? (A.unitdiag == 
 istril(A::Triangular) = A.uplo == 'L' || istriu(A.UL)
 istriu(A::Triangular) = A.uplo == 'U' || istril(A.UL)
 
-transpose(A::Triangular) = Triangular(copytri!(A.UL, A.uplo), A.uplo=='U'?'L':'U', A.unitdiag)
-ctranspose(A::Triangular) = Triangular(copytri!(A.UL, A.uplo, true), A.uplo=='U'?'L':'U', A.unitdiag)
+transpose(A::Triangular) = Triangular(transpose(A.UL), A.uplo=='U'?'L':'U', A.unitdiag)
+ctranspose(A::Triangular) = Triangular(ctranspose(A.UL), A.uplo=='U'?'L':'U', A.unitdiag)
+transpose!(A::Triangular) = Triangular(copytri!(A.UL, A.uplo), A.uplo=='U'?'L':'U', A.unitdiag)
+ctranspose!(A::Triangular) = Triangular(copytri!(A.UL, A.uplo, true), A.uplo=='U'?'L':'U', A.unitdiag)
 diag(A::Triangular) = diag(A.UL)
 big(A::Triangular) = Triangular(big(A.UL), A.uplo, A.unitdiag)
 


### PR DESCRIPTION
Extracting the factor of a `C::Cholesky` via `C[:U]`/`C[:L]` now returns a `Triangular` type (as `C[:UL]` already did).

I also made the `transpose(::Triangular)` to be copying: otherwise some very funny things happen:

```
julia> X = Triangular(randn(5,5),:U)
5x5 Triangular{Float64}:
 1.55896  -0.918047   2.31604   -1.39669   -0.333412  
 0.0      -0.458574  -0.297727   0.249335  -0.00512459
 0.0       0.0       -0.451148   0.687349   0.276854  
 0.0       0.0        0.0        0.369269   0.275956  
 0.0       0.0        0.0        0.0       -0.324809  

julia> X'*X
5x5 Array{Float64,2}:
 2.43036  0.0      0.0       0.0       0.0     
 0.0      0.21029  0.0       0.0       0.0     
 0.0      0.0      0.203535  0.0       0.0     
 0.0      0.0      0.0       0.136359  0.0     
 0.0      0.0      0.0       0.0       0.105501

julia> X
5x5 Triangular{Float64}:
 1.55896   0.0        0.0       0.0        0.0     
 0.0      -0.458574   0.0       0.0        0.0     
 0.0       0.0       -0.451148  0.0        0.0     
 0.0       0.0        0.0       0.369269   0.0     
 0.0       0.0        0.0       0.0       -0.324809
```

Existing behaviour is still available via the (unexported) `transpose!` method.

cc: @andreasnoackjensen
