### PR TITLE
Fixes #6307, src/support and src/flisp makefiles didn't apply JCPPFLAGS.

### DIFF
--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -3,6 +3,7 @@ include $(JULIAHOME)/Make.inc
 
 override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
+override CPPFLAGS += $(JCPPFLAGS)
 
 NAME = flisp
 EXENAME = $(NAME)

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -3,6 +3,7 @@ include $(JULIAHOME)/Make.inc
 
 override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
+override CPPFLAGS += $(JCPPFLAGS)
 
 OBJS = hashing.o timefuncs.o ptrhash.o operators.o \
 	utf8.o ios.o htable.o bitvector.o \


### PR DESCRIPTION
This fixes #6307 for me by adding `JCPPFLAGS` to CPPFLAGS in the `src/support` and `src/flisp` makefiles. The same pattern seems to be used in the `src` makefile as well.
