### PR TITLE
RFC: Allow numbers to be broadcast

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -46,7 +46,7 @@ function broadcast_shape(As::AbstractArray...)
 end
 
 # Check that all arguments are broadcast compatible with shape
-function check_broadcast_shape(shape::Dims, As::AbstractArray...)
+function check_broadcast_shape(shape::Dims, As::Union(AbstractArray,Number)...)
     for A in As
         if ndims(A) > length(shape)
             error("cannot broadcast array to have fewer dimensions")
@@ -205,9 +205,9 @@ function gen_broadcast_function_tobitarray(genbody::Function, nd::Int, narrays::
 end
 
 for (Bsig, Asig, gbf, gbb) in
-    ((BitArray                          , Union(Array,BitArray)                   ,
+    ((BitArray                          , Union(Array,BitArray,Number)                   ,
       :gen_broadcast_function_tobitarray, :gen_broadcast_body_iter_tobitarray     ),
-     (Any                               , Union(Array,BitArray)                   ,
+     (Any                               , Union(Array,BitArray,Number)                   ,
       :gen_broadcast_function           , :gen_broadcast_body_iter                ),
      (BitArray                          , Any                                     ,
       :gen_broadcast_function_tobitarray, :gen_broadcast_body_cartesian_tobitarray),


### PR DESCRIPTION
## Update

This PR has been changed to just allowing numbers to be used in `broadcast!`.
## previous

This adds `@inplace!` macro for replacing broadcasting operators (`.+`) with calls to `broadcast!`, allowing for array reuse:

``` julia
julia> import Base.Broadcast.@inplace!

julia> x = ones(3,3)
3x3 Array{Float64,2}:
 1.0  1.0  1.0
 1.0  1.0  1.0
 1.0  1.0  1.0

julia> @inplace! x = x .+ x
3x3 Array{Float64,2}:
 2.0  2.0  2.0
 2.0  2.0  2.0
 2.0  2.0  2.0

julia> macroexpand(:(@inplace! a = b .+ c))
:(begin  # broadcast.jl, line 452:
        Base.Broadcast.broadcast!(+,a,b,c)
    end)
```

Two issues that would probably need to be addressed:

1) The parser doesn't allow _n_-ary `.+` and `.*` operations (unlike `+` and `*`), so

``` julia
julia> macroexpand(:(@inplace! a = b .+ c .+ d))
:(begin  # broadcast.jl, line 452:
        Base.Broadcast.broadcast!(+,a,b .+ c,d)
    end)
```

I could make the macro recursive, but I first thought I would find out if it would be worth considering a change to the parser?

2) ~~At the moment, numbers cannot be `broadcast`~~ I've made some changes to some of the broadcast methods to allow numbers to be broadcast:

``` julia
julia> import Base.Broadcast.@inplace!

julia> x = ones(3,3)
3x3 Array{Float64,2}:
 1.0  1.0  1.0
 1.0  1.0  1.0
 1.0  1.0  1.0

julia> @inplace! x .+= 1.0
3x3 Array{Float64,2}:
 2.0  2.0  2.0
 2.0  2.0  2.0
 2.0  2.0  2.0
```

I'm not sure if this will affect performance, so someone who understands all those things should probably check it out.
