### PR TITLE
added map( <function>, <set> ) = <set>

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -116,3 +116,13 @@ filter(f::Function, s::Set) = filter!(f, copy(s))
 function map( f::Function, s::Set )
     Set( [ f(x) for x in s ] )
 end
+
+function map( f::Function, s::Set )
+    el = first( s )
+    t = typeof( f( el ) )
+    newset = Set{t}()
+    for x in s
+        push!( newset, f( x ) )
+    end
+    newset
+end

--- a/base/set.jl
+++ b/base/set.jl
@@ -112,3 +112,7 @@ function filter!(f::Function, s::Set)
     return s
 end
 filter(f::Function, s::Set) = filter!(f, copy(s))
+
+function map( f::Function, s::Set )
+    Set( [ f(x) for x in s ] )
+end

--- a/base/set.jl
+++ b/base/set.jl
@@ -114,10 +114,6 @@ end
 filter(f::Function, s::Set) = filter!(f, copy(s))
 
 function map( f::Function, s::Set )
-    Set( [ f(x) for x in s ] )
-end
-
-function map( f::Function, s::Set )
     el = first( s )
     t = typeof( f( el ) )
     newset = Set{t}()


### PR DESCRIPTION
Since functions aren't type I don't think there's any way to automatically update the type.

f: T1 -> T2
map( f, Set{T1} ) = Set{Any} (actual)
map( f, Set{T1} ) = Set{T2}   (desirable)
