### PR TITLE
Improve printing of try block expressions

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -478,10 +478,13 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         show_block(io, "if",   args[1], args[2], indent)
         show_block(io, "else", args[3], indent)
         print(io, "end")
-    elseif is(head, :try) && nargs == 3
+    elseif is(head, :try) && 3 <= nargs <= 4
         show_block(io, "try", args[1], indent)
-        if !(is(args[2], false) && is_expr(args[3], :block, 0))
-            show_block(io, "catch", args[2], args[3], indent)
+        if is_expr(args[3], :block)
+            show_block(io, "catch", is(args[2], false) ? [] : args[2], args[3], indent)
+        end
+        if nargs >= 4 && is_expr(args[4], :block)
+            show_block(io, "finally", [], args[4], indent)
         end
         print(io, "end")
     elseif is(head, :let) && nargs >= 1


### PR DESCRIPTION
Previously, try blocks didn't quite show their catch statements correctly, and they completely failed to display nicely when a finally block was included:

```
julia> :(try; do_try() catch end)
:(try  # line 1:
        do_try()
    end)

julia> :(try; do_try() catch do_catch() end)
:(try  # line 1:
        do_try()
    catch false
        do_catch()
    end)

julia> :(try; do_try() finally do_final() end)
:($(Expr(:try, :(begin  # line 1:
        do_try()
    end), false, false, :(begin  # line 1:
        do_final()
    end))))
```

With this patch, they display correctly and look much more like the written syntax:

```
julia> :(try; do_try() catch end)
:(try  # line 1:
        do_try()
    catch
    end)

julia> :(try; do_try() catch do_catch() end)
:(try  # line 1:
        do_try()
    catch
        do_catch()
    end)

julia> :(try; do_try() finally do_final() end)
:(try  # line 1:
        do_try()
    finally  # line 1:
        do_final()
    end)
```
