### PR TITLE
Fix type-stability issue in example life_rule.

### DIFF
--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -533,9 +533,7 @@ is ``DArray``\ -specific, but we list it here for completeness::
                 nc = +(old[i-1,j-1], old[i-1,j], old[i-1,j+1],
                        old[i  ,j-1],             old[i  ,j+1],
                        old[i+1,j-1], old[i+1,j], old[i+1,j+1])
-                new[i-1,j-1] = (nc == 3 ? 1 :
-                                nc == 2 ? old[i,j] :
-                                0)
+                new[i-1,j-1] = (nc == 3 || nc == 2 && old[i,j])
             end
         end
         new


### PR DESCRIPTION
I was using the life example from the documentation for a benchmark and discovered that method table lookup was being flogged hard, because of ?: operations that mix  Bool and Int.   This PR fixes the issue, knocking off about 25% of the execution time.
