### PR TITLE
In latest llvm SVN, the "useCFI" arguement was removed from createAsmStreamer()

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -145,8 +145,8 @@ void jl_dump_function_asm(void* Fptr, size_t Fsize,
     Streamer.reset(TheTarget->createAsmStreamer(Ctx, stream, /*asmverbose*/true,
 #ifndef LLVM35
                                            /*useLoc*/ true,
-#endif
                                            /*useCFI*/ true,
+#endif
                                            /*useDwarfDirectory*/ true,
                                            IP, CE, MAB, ShowInst));
     Streamer->InitSections();


### PR DESCRIPTION
cc: @loladiro, @ihnorton 
