### PR TITLE
Make prompts and i-searches the same word length

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -885,7 +885,7 @@ function refresh_multi_line(termbuf::TerminalBuffer, s::SearchState)
     write(buf, readall(s.response_buffer))
     buf.ptr = offset + ptr - 1
     s.response_buffer.ptr = ptr
-    s.ias = refresh_multi_line(termbuf, s.terminal, buf, s.ias, s.backward ? "(reverse-i-search)`" : "(i-search)`")
+    s.ias = refresh_multi_line(termbuf, s.terminal, buf, s.ias, s.backward ? "(reverse-i-search)`" : "(forward-i-search)`")
 end
 
 function refresh_multi_line(s::Union(SearchState,PromptState))

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -530,7 +530,7 @@ function setup_interface(d::REPLDisplay, req, rep; extra_repl_keymap = Dict{Any,
     main_prompt.on_done = respond(Base.parse_input_line, d, main_prompt, req, rep)
 
     # Setup help mode
-    help_mode = Prompt("help> ",
+    help_mode = Prompt(" help> ",
         prompt_color = repl.help_color,
         input_color = repl.input_color,
         keymap_func_data = repl,


### PR DESCRIPTION
This is a purely cosmetic change that I've been using for the past few weeks to make the REPL prompt start location stable.  I've been surprised how much more 'grounded' the REPL feels, and it helps reduce flickering when changing modes with text on the line (e.g., from help and back).

I did it predominantly for the search modes: `(reverse-i-search)` and `(i-search)` are substantially different lengths and so when switching search directions (which I do more often since ^N and ^P were bound), the entire line shifts position by quite a bit.  I found it disorienting.  Fortunately, `reverse` and `forward` both have seven characters.  This very minimal patch renames i-search to forward-i-search.

But I think I like the even simpler change for help more: `"help> "` becomes `" help> "` to keep the prompt start at the same location as shell and julia.

(This is so minor, it's probably not worth the noise.  But since I've liked it enough to keep the patch floating on top of master every time I update, I figured I'd submit it.)
