### PR TITLE
add `full` method for Cholesky

### DIFF
--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -48,6 +48,14 @@ convert{T}(::Type{Factorization{T}}, C::Cholesky) = convert(Cholesky{T}, C)
 convert{T}(::Type{CholeskyPivoted{T}},C::CholeskyPivoted) = CholeskyPivoted(convert(AbstractMatrix{T},C.UL),C.uplo,C.piv,C.rank,C.tol,C.info)
 convert{T}(::Type{Factorization{T}}, C::CholeskyPivoted) = convert(CholeskyPivoted{T}, C)
 
+function full{T<:BlasFloat}(C::Cholesky{T})
+    if C.uplo == 'U'
+        BLAS.trmm!('R', C.uplo, 'N', 'N', one(T), C.UL, tril!(C.UL'))
+    else
+        BLAS.trmm!('L', C.uplo, 'N', 'N', one(T), C.UL, triu!(C.UL'))
+    end
+end
+
 size(C::Union(Cholesky, CholeskyPivoted)) = size(C.UL)
 size(C::Union(Cholesky, CholeskyPivoted), d::Integer) = size(C.UL,d)
 

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -43,6 +43,10 @@ debug && println("(Automatic) upper Cholesky factor")
         for i=1:n, j=1:n
             @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
         end
+        E = abs(apd - full(capd))
+        for i=1:n, j=1:n
+            @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
+        end
 
         #Test error bound on linear solver: LAWNS 14, Theorem 2.1
         #This is a surprisingly loose bound...
@@ -56,7 +60,9 @@ debug && println("(Automatic) upper Cholesky factor")
         @test_approx_eq logdet(capd) log(det(capd)) # logdet is less likely to overflow
 
 debug && println("lower Cholesky factor")
-        l = cholfact(apd, :L)[:L]
+        lapd = cholfact(apd, :L)
+        @test_approx_eq full(lapd) apd
+        l = lapd[:L]
         @test_approx_eq l*l' apd
     end
 


### PR DESCRIPTION
Converts a `Cholesky` factorisation back to a full matrix, without allocating any unnecessary arrays.
