### PR TITLE
add StructuredArray abstract type

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -91,6 +91,8 @@ export
     StridedMatrix,
     StridedVecOrMat,
     StridedVector,
+    StructuredArray,
+    StructuredMatrix,
     SubArray,
     SubDArray,
     SubOrDArray,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -9,6 +9,8 @@ export
     BLAS,
 
 # Types
+    StructuredArray,
+    StructuredMatrix,
     SymTridiagonal,
     Tridiagonal,
     Bidiagonal,
@@ -155,6 +157,10 @@ typealias BlasFloat Union(Float64,Float32,Complex128,Complex64)
 typealias BlasReal Union(Float64,Float32)
 typealias BlasComplex Union(Complex128,Complex64)
 typealias BlasChar Char
+
+abstract StructuredArray{T,N} <: AbstractArray{T,N}
+typealias StructuredMatrix{T} StructuredArray{T,2}
+
 
 if USE_BLAS64
     typealias BlasInt Int64

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -1,5 +1,5 @@
 # Bidiagonal matrices
-type Bidiagonal{T} <: AbstractMatrix{T}
+type Bidiagonal{T} <: StructuredMatrix{T}
     dv::AbstractVector{T} # diagonal
     ev::AbstractVector{T} # sub/super diagonal
     isupper::Bool # is upper bidiagonal (true) or lower (false)

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -1,6 +1,6 @@
 ## Diagonal matrices
 
-immutable Diagonal{T} <: AbstractMatrix{T}
+immutable Diagonal{T} <: StructuredMatrix{T}
     diag::Vector{T}
 end
 Diagonal(A::Matrix) = Diagonal(diag(A))

--- a/base/linalg/givens.jl
+++ b/base/linalg/givens.jl
@@ -1,4 +1,4 @@
-immutable Givens{T} <: AbstractMatrix{T}
+immutable Givens{T} <: StructuredMatrix{T}
     size::Int
     i1::Int
     i2::Int

--- a/base/linalg/rectfullpacked.jl
+++ b/base/linalg/rectfullpacked.jl
@@ -1,6 +1,6 @@
 # Rectangular Full Packed Matrices
 
-type SymmetricRFP{T<:BlasFloat} <: AbstractMatrix{T}
+type SymmetricRFP{T<:BlasFloat} <: StructuredMatrix{T}
     data::Vector{T}
     transr::Char
     uplo::Char
@@ -12,7 +12,7 @@ function Ac_mul_A_RFP{T<:BlasFloat}(A::Matrix{T})
     SymmetricRFP(C, 'N', 'U')
 end
 
-type TriangularRFP{T<:BlasFloat} <: AbstractMatrix{T}
+type TriangularRFP{T<:BlasFloat} <: StructuredMatrix{T}
     data::Vector{T}
     transr::Char
     uplo::Char

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -1,10 +1,10 @@
 #Symmetric and Hermitian matrices
-immutable Symmetric{T} <: AbstractMatrix{T}
+immutable Symmetric{T} <: StructuredMatrix{T}
     S::Matrix{T}
     uplo::Char
 end
 Symmetric(A::Matrix, uplo::Symbol=:U) = (chksquare(A);Symmetric(A, string(uplo)[1]))
-immutable Hermitian{T} <: AbstractMatrix{T}
+immutable Hermitian{T} <: StructuredMatrix{T}
     S::Matrix{T}
     uplo::Char
 end

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1,5 +1,5 @@
 ## Triangular
-immutable Triangular{T<:Number} <: AbstractMatrix{T}
+immutable Triangular{T<:Number} <: StructuredMatrix{T}
     UL::Matrix{T}
     uplo::Char
     unitdiag::Char

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -1,7 +1,7 @@
 #### Specialized matrix types ####
 
 ## Hermitian tridiagonal matrices
-immutable SymTridiagonal{T} <: AbstractMatrix{T}
+immutable SymTridiagonal{T} <: StructuredMatrix{T}
     dv::Vector{T}                        # diagonal
     ev::Vector{T}                        # subdiagonal
     function SymTridiagonal(dv::Vector{T}, ev::Vector{T})
@@ -140,7 +140,7 @@ function getindex{T}(A::SymTridiagonal{T}, i::Integer, j::Integer)
 end
 
 ## Tridiagonal matrices ##
-immutable Tridiagonal{T} <: AbstractMatrix{T}
+immutable Tridiagonal{T} <: StructuredMatrix{T}
     dl::Vector{T}    # sub-diagonal
     d::Vector{T}     # diagonal
     du::Vector{T}    # sup-diagonal


### PR DESCRIPTION
At the risk of spilling yet more bits over the type hiearchy (#6212, etc.), I would like to propose an abstract  `StructuredArray` type for "specially structured" arrays. The main purpose is to make it easier to reason about the type hierarchy, which is becoming difficult when dealing with ambiguous dispatch for all the `Ax_foo_Bx` methods.

```
julia> subtypes(StructuredArray)
10-element Array{Any,1}:
 Bidiagonal{T}                                                             
 Diagonal{T}                                                               
 Givens{T}                                                                 
 Hermitian{T}                                                              
 SymTridiagonal{T}                                                         
 SymmetricRFP{T<:Union(Complex{Float64},Float32,Complex{Float32},Float64)} 
 Symmetric{T}                                                              
 TriangularRFP{T<:Union(Complex{Float64},Float32,Complex{Float32},Float64)}
 Triangular{T<:Number}                                                     
 Tridiagonal{T}                                                            
```

The remaining subtypes of `AbstractArray` are:

```
julia> subtypes(AbstractArray)
10-element Array{Any,1}:
 AbstractSparseArray{Tv,Ti,N}                                          
 DArray{T,N,A}                                                         
 DenseArray{T,N}                                                       
 HessenbergQ{T}                                                        
 QRCompactWYQ{S}                                                       
 QRPackedQ{T}                                                          
 Range{T}                                                              
 StructuredArray{T,N}                                                  
 SubArray{T,N,A<:AbstractArray{T,N},I<:(Union(Range{Int64},Int64)...,)}
 Woodbury{T}                                                           
```

Of these, `HessenbergQ{T}`, `QRCompactWYQ{S}` and `QRPackedQ{T}` could also be moved, as they are also structured in some sense.
