### PR TITLE
Make customizing the REPL easier

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -27,7 +27,7 @@ type Mode <: TextInterface
 end
 
 type Prompt <: TextInterface
-    prompt::ASCIIString
+    prompt
     first_prompt
     # A string or function to be printed before the prompt. May not change the length of the prompt.
     # This may be used for changing the color, issuing other terminal escape codes, etc.

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1,8 +1,8 @@
 module LineEdit
 
-using Base.Terminals
+using ..Terminals
 
-import Base.Terminals: raw!, width, height, cmove, getX,
+import ..Terminals: raw!, width, height, cmove, getX,
                        getY, clear_line, beep
 
 import Base: ensureroom, peek, show
@@ -27,12 +27,15 @@ type Mode <: TextInterface
 end
 
 type Prompt <: TextInterface
-    prompt
+    prompt::ASCIIString
     first_prompt
-    prompt_color::ASCIIString
+    # A string or function to be printed before the prompt. May not change the length of the prompt.
+    # This may be used for changing the color, issuing other terminal escape codes, etc.
+    prompt_prefix
+    # Same as prefix except after the prompt
+    prompt_suffix
     keymap_func
     keymap_func_data
-    input_color
     complete
     on_enter
     on_done
@@ -602,10 +605,12 @@ default_enter_cb(_) = true
 
 write_prompt(terminal, s::PromptState) = write_prompt(terminal, s, s.p.prompt)
 function write_prompt(terminal, s::PromptState, prompt)
-    write(terminal, s.p.prompt_color)
+    prefix = isa(s.p.prompt_prefix,Function) ? s.p.prompt_prefix() : s.p.prompt_prefix
+    suffix = isa(s.p.prompt_suffix,Function) ? s.p.prompt_suffix() : s.p.prompt_suffix
+    write(terminal, prefix)
     write(terminal, prompt)
     write(terminal, Base.text_colors[:normal])
-    write(terminal, s.p.input_color)
+    write(terminal, suffix)
 end
 write_prompt(terminal, s::ASCIIString) = write(terminal, s)
 
@@ -1269,17 +1274,17 @@ const default_keymap_func = @LineEdit.keymap [LineEdit.default_keymap, LineEdit.
 
 function Prompt(prompt;
     first_prompt = prompt,
-    prompt_color = "",
+    prompt_prefix = "",
+    prompt_suffix = "",
     keymap_func = default_keymap_func,
     keymap_func_data = nothing,
-    input_color = "",
     complete = EmptyCompletionProvider(),
     on_enter = default_enter_cb,
     on_done = ()->nothing,
     hist = EmptyHistoryProvider())
 
-    Prompt(prompt, first_prompt, prompt_color, keymap_func, keymap_func_data,
-           input_color, complete, on_enter, on_done, hist)
+    Prompt(prompt, first_prompt, prompt_prefix, prompt_suffix, keymap_func, keymap_func_data,
+        complete, on_enter, on_done, hist)
 end
 
 run_interface(::Prompt) = nothing

--- a/base/client.jl
+++ b/base/client.jl
@@ -354,6 +354,7 @@ function _start()
         (quiet,repl,startup,color_set,no_history_file) = process_options(copy(ARGS))
 
         local term
+        global active_repl
         if repl
             if !isa(STDIN,TTY)
                 global is_interactive |= !isa(STDIN,Union(File,IOStream))
@@ -362,6 +363,15 @@ function _start()
                 term = Terminals.TTYTerminal(get(ENV,"TERM",@windows? "" : "dumb"),STDIN,STDOUT,STDERR)
                 global is_interactive = true
                 color_set || (global have_color = Terminals.hascolor(term))
+            end
+
+            quiet || REPL.banner(term,term)
+            local repl
+            if term.term_type == "dumb"
+                active_repl = REPL.BasicREPL(term)
+            else
+                active_repl = REPL.LineEditREPL(term)
+                active_repl.no_history_file = no_history_file
             end
         end
 
@@ -384,15 +394,7 @@ function _start()
                 end
                 quit()
             end
-            quiet || REPL.banner(term,term)
-            local repl
-            if term.term_type == "dumb"
-                repl = REPL.BasicREPL(term)
-            else
-                repl = REPL.LineEditREPL(term)
-                repl.no_history_file = no_history_file
-            end
-            REPL.run_repl(repl)
+            REPL.run_repl(active_repl)
         end
     catch err
         display_error(err,catch_backtrace())

--- a/base/client.jl
+++ b/base/client.jl
@@ -363,15 +363,14 @@ function _start()
                 term = Terminals.TTYTerminal(get(ENV,"TERM",@windows? "" : "dumb"),STDIN,STDOUT,STDERR)
                 global is_interactive = true
                 color_set || (global have_color = Terminals.hascolor(term))
-            end
+                if term.term_type == "dumb"
+                    active_repl = REPL.BasicREPL(term)
+                else
+                    active_repl = REPL.LineEditREPL(term)
+                    active_repl.no_history_file = no_history_file
+                end
 
-            quiet || REPL.banner(term,term)
-            local repl
-            if term.term_type == "dumb"
-                active_repl = REPL.BasicREPL(term)
-            else
-                active_repl = REPL.LineEditREPL(term)
-                active_repl.no_history_file = no_history_file
+                quiet || REPL.banner(term,term)
             end
         end
 


### PR DESCRIPTION
This is all the stuff I needed to customize the REPL in the way I want (mostly to hack in iTerm2 specific stuff), but I figure other people might have different needs, so if you have a specific customization need that this doesn't cover let me know. 

Basically what this does is expose a handle to the main REPL started by the standard library (`Base.active_repl`), as well as adding the interface as a field so you can customize it either later, or replace it entirely in your .juliarc.jl, so for example you could do (in your `.juliarc.jl`):

```
Base.active_repl.interface = Base.REPL.setup_interface(Base.active_repl;extra_repl_keymap = {...})
```

to add custom keyboard commands. 

cc @mbauman
