### PR TITLE
Allow numbers to be `broadcast!`.

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -20,13 +20,13 @@ longer_tuple(x::Tuple, retx::Tuple, y::Tuple, rety::Tuple) =
     longer_tuple(droparg1(x...), retx, droparg1(y...), rety)
 longer_tuple(x::Tuple, y::Tuple) = longer_tuple(x, x, y, y)
 
-longer_size(x::AbstractArray) = size(x)
-longer_size(x::AbstractArray, y::AbstractArray...) =
+longer_size(x::Union(AbstractArray,Number)) = size(x)
+longer_size(x::Union(AbstractArray,Number), y::Union(AbstractArray,Number)...) =
     longer_tuple(size(x), longer_size(y...))
 
 # Calculate the broadcast shape of the arguments, or error if incompatible
 broadcast_shape() = ()
-function broadcast_shape(As::AbstractArray...)
+function broadcast_shape(As::Union(AbstractArray,Number)...)
     sz = longer_size(As...)
     nd = length(sz)
     bshape = ones(Int, nd)
@@ -46,7 +46,7 @@ function broadcast_shape(As::AbstractArray...)
 end
 
 # Check that all arguments are broadcast compatible with shape
-function check_broadcast_shape(shape::Dims, As::AbstractArray...)
+function check_broadcast_shape(shape::Dims, As::Union(AbstractArray,Number)...)
     for A in As
         if ndims(A) > length(shape)
             error("cannot broadcast array to have fewer dimensions")
@@ -205,9 +205,9 @@ function gen_broadcast_function_tobitarray(genbody::Function, nd::Int, narrays::
 end
 
 for (Bsig, Asig, gbf, gbb) in
-    ((BitArray                          , Union(Array,BitArray)                   ,
+    ((BitArray                          , Union(Array,BitArray,Number)                   ,
       :gen_broadcast_function_tobitarray, :gen_broadcast_body_iter_tobitarray     ),
-     (Any                               , Union(Array,BitArray)                   ,
+     (Any                               , Union(Array,BitArray,Number)                   ,
       :gen_broadcast_function           , :gen_broadcast_body_iter                ),
      (BitArray                          , Any                                     ,
       :gen_broadcast_function_tobitarray, :gen_broadcast_body_cartesian_tobitarray),

--- a/base/number.jl
+++ b/base/number.jl
@@ -13,7 +13,8 @@ length(x::Number) = 1
 endof(x::Number) = 1
 getindex(x::Number) = x
 getindex(x::Number, i::Integer) = i == 1 ? x : throw(BoundsError())
-getindex(x::Number, i::Real) = getindex(x, to_index(i))
+getindex(x::Number, I::Integer...) = all([i == 1 for i in I]) ? x : throw(BoundsError())
+getindex(x::Number, I::Real...) = getindex(x, to_index(i)...)
 first(x::Number) = x
 last(x::Number) = x
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -39,6 +39,7 @@ for arr in (identity, as_sub)
     @test broadcast(+, arr([1  0]), arr([1, 4])) == [2 1; 5 4]
     @test broadcast(+, arr([1, 0]), arr([1  4])) == [2 5; 1 4]
     @test broadcast(+, arr([1, 0]), arr([1, 4])) == [2, 4]
+    @test broadcast(+, arr([1, 0]), 2) == [3, 2]
 
     @test @inferred(arr(eye(2)) .+ arr([1, 4])) == arr([2 1; 4 5])
     @test arr(eye(2)) .+ arr([1  4]) == arr([2 4; 1 5])
@@ -51,6 +52,7 @@ for arr in (identity, as_sub)
     A = arr(eye(2)); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4; 1 5])
     A = arr([1  0]); @test_throws ErrorException broadcast!(+, A, A, arr([1, 4]))
     A = arr([1  0]); @test broadcast!(+, A, A, arr([1  4])) == arr([2 4])
+    A = arr([1  0]); @test broadcast!(+, A, A, 2) == arr([3 2])
 
     @test arr([ 1    2])   .* arr([3,   4])   == [ 3 6; 4 8]
     @test arr([24.0 12.0]) ./ arr([2.0, 3.0]) == [12 6; 8 4]


### PR DESCRIPTION
(from #6839) This PR is to allow numbers to be used in the `broadcast!` function. This would be very useful for my [InplaceOps.jl](https://github.com/simonbyrne/InplaceOps.jl) package.
