### PR TITLE
Added StackOverflow link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The main homepage for Julia can be found at [julialang.org](http://julialang.org
 This is the GitHub repository of Julia source code, including instructions for compiling and installing Julia, below.
 
 <a name="Resources"/>
+## Resources
 
 - **Homepage:** <http://julialang.org>
 - **Binaries:** <http://julialang.org/downloads/>
@@ -23,13 +24,22 @@ This is the GitHub repository of Julia source code, including instructions for c
 - **Source code:** <https://github.com/JuliaLang/julia>
 - **Git clone URL:** <git://github.com/JuliaLang/julia.git>
 - **Mailing lists:** <http://julialang.org/community/>
-- **Questions:** <https://stackoverflow.com/questions/tagged/julia-lang>
 - **IRC:** <http://webchat.freenode.net/?channels=julia>
 
 The mailing list for developer discussion is
 <http://groups.google.com/group/julia-dev/>. All are welcome, but the volume
 of messages is higher, and the discussions tend to be more esoteric. New
 developers may find the notes in [CONTRIBUTING](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md) helpful to start contributing to the Julia codebase.
+
+### External Resources
+<a name="External-Resources"/>
+
+- [**StackOverflow**](https://stackoverflow.com/questions/tagged/julia-lang)
+- [**Youtube**](https://www.youtube.com/channel/UC9IuUwwE2xdjQUT_LMLONoA)
+- [**Twitter**](https://twitter.com/JuliaLanguage)
+- [**Facebook Group**](https://www.facebook.com/juliaLanguageUserGroup)
+- [**Google+**](https://plus.google.com/communities/111295162646766639102)
+- [**Meetup**](http://julia.meetup.com/)
 
 <a name="Currently-Supported-Platforms"/>
 ## Currently Supported Platforms

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This is the GitHub repository of Julia source code, including instructions for c
 - **Source code:** <https://github.com/JuliaLang/julia>
 - **Git clone URL:** <git://github.com/JuliaLang/julia.git>
 - **Mailing lists:** <http://julialang.org/community/>
+- **Questions:** <https://stackoverflow.com/questions/tagged/julia-lang>
 - **IRC:** <http://webchat.freenode.net/?channels=julia>
 
 The mailing list for developer discussion is


### PR DESCRIPTION
I think StackOverflow is a very good platform, and helps expose Julia to a broader public, as well as helping new users. Putting a link here on the README should direct users to post more questions there.

Now, Julia is not very present at StackOverflow, and users might have the wrong impression that nobody uses the language or care about it. After all, the julia-users list is full of questions and nice answers.
