### PR TITLE
Faster set

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -5,13 +5,13 @@ type Set{T}
     count::Int
 
     function Set()
-	n = 16
-	new(zeros(Uint8,n), Array(T,n), 0, 0)
+        n = 16
+        new(zeros(Uint8,n), Array(T,n), 0, 0)
     end
     function Set(itr)
         //todo:  n should be _tablesz(length(itr)) if itr has a length function
-	n = 16
-	union!(new(zeros(Uint8,n), Array(T,n), 0, 0), itr)
+        n = 16
+        union!(new(zeros(Uint8,n), Array(T,n), 0, 0), itr)
     end
 end
 Set() = Set{Any}()
@@ -36,16 +36,16 @@ function push!{T}(s::Set{T}, x)
     if index > 0
         s.keys[index] = key
     else
-    	s.slots[-index] = 0x1
-    	s.keys[-index] = key
-    	s.count += 1
+        s.slots[-index] = 0x1
+        s.keys[-index] = key
+        s.count += 1
 
-    	sz = length(s.keys)
-    	# Rehash now if necessary
-    	if s.ndel >= ((3*sz)>>2) || s.count*3 > sz*2
+        sz = length(s.keys)
+        # Rehash now if necessary
+        if s.ndel >= ((3*sz)>>2) || s.count*3 > sz*2
            # > 3/4 deleted or > 2/3 full
            srehash(s, s.count > 64000 ? s.count*2 : s.count*4)
-    	end
+        end
     end
     s
 end

--- a/base/set.jl
+++ b/base/set.jl
@@ -9,7 +9,7 @@ type Set{T}
         new(zeros(Uint8,n), Array(T,n), 0, 0)
     end
     function Set(itr)
-        //todo:  n should be _tablesz(length(itr)) if itr has a length function
+        #todo:  n should be _tablesz(length(itr)) if itr has a length function
         n = 16
         union!(new(zeros(Uint8,n), Array(T,n), 0, 0), itr)
     end

--- a/base/set.jl
+++ b/base/set.jl
@@ -62,9 +62,10 @@ function pop!(s::Set, x, deflt)
         _delete!(s, index)
         return x
     else 
-       return deflt
+        return deflt
     end
 end
+
 function delete!(s::Set, x) 
     index = sht_keyindex(s, x)
     if index > 0; _delete!(s, index); end
@@ -106,10 +107,10 @@ next(s::Set, i) = (s.keys[i], skip_deleted(s,i+1))
 
 # TODO: Throw error on empty
 function pop!(s::Set)
-   index = skip_deleted(s,1)
-   val = s.keys[index]
-   _delete!(s, index)
-   val
+    index = skip_deleted(s,1)
+    val = s.keys[index]
+    _delete!(s, index)
+    val
 end
 
 join_eltype() = None


### PR DESCRIPTION
This extracts the useful parts out of Dict and injects them into Set.  This appears to speed things and save some memory(about 10% in the code that I have tried).  I'm not sure if that speedup is worth the extra complexity.
I prefixed the method names copied from dict with an 's' (I possibly shouldn't have, and just let the dispatcher handle things.)
