### PR TITLE
Deprecate all methods of bitmix, not just Uint

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -441,7 +441,10 @@ Set{T<:Number}(xs::T...) = Set{T}(xs)
 @deprecate infs(dims...)                 fill(Inf, dims)
 @deprecate infs{T}(x::AbstractArray{T})  fill(convert(T,Inf), size(x))
 
-@deprecate bitmix hash
+@deprecate bitmix(x, y::Uint)                 hash(x, y)
+@deprecate bitmix(x, y::Int)                  hash(x, uint(y))
+@deprecate bitmix(x, y::Union(Uint32, Int32)) convert(Uint32, hash(x, uint(y)))
+@deprecate bitmix(x, y::Union(Uint64, Int64)) convert(Uint64, hash(x, hash(y)))
 
 # 0.3 discontinued functions
 


### PR DESCRIPTION
In the spirit of making sure deprecated functions are deprecated for all methods, here's a few more deprecations for `bitmix`.

bitmix had previously been defined with methods for all of `Int32, Uint32, Int64, Uint64`, while hash only supports `Uint` in its second argument.  This adds the necessary deprecations for all those methods. Calling the non-machine-size method isn't optimal, but it returns the type that bitmix did.
