### PR TITLE
RFC: writesto(cmd) do io ... end

### DIFF
--- a/doc/manual/running-external-programs.rst
+++ b/doc/manual/running-external-programs.rst
@@ -47,6 +47,15 @@ can be used instead::
     julia> (chomp(a)) == "hello"
     true
 
+Conversely, if you want to write to the standard input of the external
+command, you can use a ``writesto`` method, for example::
+
+    julia> writesto(`less`, STDOUT) do io
+               for i = 1:1000
+                   println(io, i)
+               end
+           end
+
 .. _man-command-interpolation:
 
 Interpolation

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4953,9 +4953,17 @@ System
 
    Starts running a command asynchronously, and returns a tuple (stream,process). The first value is a stream reading from the process' standard output.
 
-.. function:: writesto(command)
+.. function:: writesto(command, stdout=DevNull)
 
-   Starts running a command asynchronously, and returns a tuple (stream,process). The first value is a stream writing to the process' standard input.
+   Starts running a command asynchronously (optionally writing to the given ``stdout`` stream), and returns a tuple ``(stream,process)``, where ``stream`` writing to the process' standard input.
+
+.. function:: writesto(f::Function, command, stdout=DevNull)
+
+   Given a function ``f(stream)`` that writes to a ``stream``, starts
+   running the command and uses ``f`` to write to the process' standard input,
+   then closes the stream and waits for the process to complete.  (The
+   optional ``stdout`` argument specifies the process' standard output.)
+   Returns the value returned by ``f``.
 
 .. function:: readandwrite(command)
 


### PR DESCRIPTION
There was a recent [thread on the mailing list](https://groups.google.com/forum/#!topic/julia-users/2SbdNdW_EEM) about how to use a pager like `less` in the REPL.    I was curious to see how we would page to `less` directly, and it took me a bit more digging than I would have liked.

This patch simplifies writing to a process by adding a new method to `writesto` that takes a function `f(io)`, much like `open` and friends, so that you can do e.g.

```
writesto(`less`, STDOUT) do io
      for i = 1:2000
          println(io, i)
      end
end
```

to page output through `less`.

(I thought about a different name, like `writeall`, but overloading `writesto` makes it easier to discover the alternative asynchronous form of `writesto`.

An alternative would be to overload `open` to either read or write from a command.  But in this case I would get rid of `writesto` and `readsfrom` entirely and replace them by `open(cmd, "w")` and `open(cmd, "r")`.
