### PR TITLE
writedlm for arrays of dimension 3 or greater

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -504,7 +504,7 @@ function writedlm(io::IO, a::AbstractArray, dlm; opts...)
     function print_slice(idxs...)
         writedlm(io, sub(a, 1:size(a,1), 1:size(a,2), idxs...), dlm; opts...)
         if idxs != tail
-            print("\n")
+            print(io, "\n")
         end
     end
     cartesianmap(print_slice, tail)


### PR DESCRIPTION
writedlm outputs the newline between slices of an array of dimension 3 or more to the output stream (instead of stdout)
