### PR TITLE
Set cutoff threshold for functions that rely on BLAS Level 1 routines (Close #6951)

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -27,8 +27,11 @@ function norm{T<:BlasFloat, TI<:Integer}(x::StridedVector{T}, rx::Union(UnitRang
     BLAS.nrm2(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx))
 end
 
-vecnorm1{T<:BlasReal}(x::Union(Array{T},StridedVector{T})) = BLAS.asum(x)
-vecnorm2{T<:BlasFloat}(x::Union(Array{T},StridedVector{T})) = BLAS.nrm2(x)
+vecnorm1{T<:BlasReal}(x::Union(Array{T},StridedVector{T})) = 
+    length(x) > 16 ? BLAS.asum(x) : generic_vecnorm1(x)
+
+vecnorm2{T<:BlasFloat}(x::Union(Array{T},StridedVector{T})) = 
+    length(x) > 8 ? BLAS.nrm2(x) : generic_vecnorm2(x)
 
 function triu!{T}(M::Matrix{T}, k::Integer)
     m, n = size(M)

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -1,6 +1,15 @@
 # Linear algebra functions for dense matrices in column major format
 
-scale!{T<:BlasFloat}(X::Array{T}, s::Number) = BLAS.scal!(length(X), convert(T,s), X, 1)
+function scale!{T<:BlasFloat}(X::Array{T}, s::T)
+    if length(X) < 2048
+        generic_scale!(X, s)
+    else
+        BLAS.scal!(length(X), s, X, 1)
+    end
+    X
+end
+
+scale!{T<:BlasFloat}(X::Array{T}, s::Number) = scale!(X, convert(T, s))
 scale!{T<:BlasComplex}(X::Array{T}, s::Real) = BLAS.scal!(length(X), oftype(real(zero(T)),s), X, 1)
 
 #Test whether a matrix is positive-definite

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -53,7 +53,7 @@ diag(A::AbstractVector) = error("use diagm instead of diag to construct a diagon
 #diagm{T}(v::AbstractVecOrMat{T})
 
 # special cases of vecnorm; note that they don't need to handle isempty(x)
-function vecnormMinusInf(x)
+function generic_vecnormMinusInf(x)
     s = start(x)
     (v, s) = next(x, s)
     minabs = abs(v)
@@ -63,7 +63,8 @@ function vecnormMinusInf(x)
     end
     return float(minabs)
 end
-function vecnormInf(x)
+
+function generic_vecnormInf(x)
     s = start(x)
     (v, s) = next(x, s)
     maxabs = abs(v)
@@ -73,7 +74,8 @@ function vecnormInf(x)
     end
     return float(maxabs)
 end
-function vecnorm1(x)
+
+function generic_vecnorm1(x)
     s = start(x)
     (v, s) = next(x, s)
     av = float(abs(v))
@@ -85,7 +87,8 @@ function vecnorm1(x)
     end
     return convert(T, sum)
 end
-function vecnorm2(x)
+
+function generic_vecnorm2(x)
     maxabs = vecnormInf(x)
     maxabs == 0 && return maxabs
     s = start(x)
@@ -101,7 +104,8 @@ function vecnorm2(x)
     end
     return convert(T, maxabs * sqrt(sum))
 end
-function vecnormp(x, p)
+
+function generic_vecnormp(x, p)
     if p > 1 || p < 0 # need to rescale to avoid overflow/underflow
         maxabs = vecnormInf(x)
         maxabs == 0 && return maxabs
@@ -130,6 +134,13 @@ function vecnormp(x, p)
         return convert(T, sum^inv(pp))
     end
 end
+
+vecnormMinusInf(x) = generic_vecnormMinusInf(x)
+vecnormInf(x) = generic_vecnormInf(x)
+vecnorm1(x) = generic_vecnorm1(x)
+vecnorm2(x) = generic_vecnorm2(x)
+vecnormp(x, p) = generic_vecnormp(x, p)
+
 function vecnorm(itr, p::Real=2)
     isempty(itr) && return float(real(zero(eltype(itr))))
     p == 2 && return vecnorm2(itr)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -11,13 +11,14 @@ end
 
 scale{R<:Real}(s::Complex, X::AbstractArray{R}) = scale(X, s)
 
-function scale!(X::AbstractArray, s::Number)
-    for i in 1:length(X)
+function generic_scale!(X::AbstractArray, s::Number)
+    for i = 1:length(X)
         @inbounds X[i] *= s
     end
     X
 end
-scale!(s::Number, X::AbstractArray) = scale!(X, s)
+scale!(X::AbstractArray, s::Number) = generic_scale!(X, s)
+scale!(s::Number, X::AbstractArray) = generic_scale!(X, s)
 
 cross(a::AbstractVector, b::AbstractVector) = [a[2]*b[3]-a[3]*b[2], a[3]*b[1]-a[1]*b[3], a[1]*b[2]-a[2]*b[1]]
 


### PR DESCRIPTION
This patch adds a threshold for `scale!`, `vecnorm1`, and `vecnorm2`: they calls BLAS only when the array size is above a prefixed threshold.

This patch should fix ~~#6112~~ (#6951), and ensure that these functions perform reasonably well even for small arrays.
