### PR TITLE
small fix in parallel-computing.rst

### DIFF
--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -55,7 +55,7 @@ equal the number of CPU cores on the machine.
      0.60401   0.501111
      0.174572  0.157411
 
-    julia> s = @spawnat 2 1+fetch(r)
+    julia> s = @spawnat 2 1 .+ fetch(r)
     RemoteRef(2,1,7)
 
     julia> fetch(s)
@@ -98,14 +98,14 @@ a function, and picks where to do the operation for you::
     julia> r = @spawn rand(2,2)
     RemoteRef(1,1,0)
 
-    julia> s = @spawn 1+fetch(r)
+    julia> s = @spawn 1 .+ fetch(r)
     RemoteRef(1,1,1)
 
     julia> fetch(s)
     1.10824216411304866 1.13798233877923116
     1.12376292706355074 1.18750497916607167
 
-Note that we used ``1+fetch(r)`` instead of ``1+r``. This is because we
+Note that we used ``1 .+ fetch(r)`` instead of ``1 .+ r``. This is because we
 do not know where the code will run, so in general a ``fetch`` might be
 required to move ``r`` to the process doing the addition. In this
 case, ``@spawn`` is smart enough to perform the computation on the


### PR DESCRIPTION
minor edits in first example in parallel-computing.rst to switch from deprecated usage of '+' to '.+' for scalar-array addition.
