### PR TITLE
Check for definiteness in generalised eigensolvers. 

### DIFF
--- a/base/linalg/cholmod.jl
+++ b/base/linalg/cholmod.jl
@@ -18,7 +18,7 @@ import Base: (*), convert, copy, ctranspose, eltype, findnz, getindex, hcat,
 
 import ..LinAlg: (\), A_mul_Bc, A_mul_Bt, Ac_ldiv_B, Ac_mul_B, At_ldiv_B, At_mul_B,
                  cholfact, cholfact!, copy, det, diag,
-                 full, logdet, norm, scale, scale!, sparse
+                 full, isposdef!, logdet, norm, scale, scale!, sparse
 
 include("cholmod_h.jl")
 
@@ -1032,4 +1032,17 @@ end
 sparse(L::CholmodFactor) = sparse!(CholmodSparse(L))
 sparse(D::CholmodDense) = sparse!(CholmodSparse(D))
 sparse(T::CholmodTriplet) = sparse!(CholmodSparse(T))
+
+isposdef!{Tv<:CHMVTypes,Ti}(A::SparseMatrixCSC{Tv,Ti}) = ishermitian(A) && cholfact(A).c.minor == size(A,1)
+
 end #module
+
+# placing factorize here for now. Maybe add a new file
+function factorize(A::SparseMatrixCSC)
+    m, n = size(A)
+    if m == n
+        Ac = cholfact(A)
+        Ac.c.minor == m && ishermitian(A) && return Ac
+    end
+    return lufact(A)
+end

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -4,13 +4,11 @@ scale!{T<:BlasFloat}(X::Array{T}, s::Number) = BLAS.scal!(length(X), convert(T,s
 scale!{T<:BlasComplex}(X::Array{T}, s::Real) = BLAS.scal!(length(X), oftype(real(zero(T)),s), X, 1)
 
 #Test whether a matrix is positive-definite
-isposdef!{T<:BlasFloat}(A::Matrix{T}, UL::Char) = LAPACK.potrf!(UL, A)[2] == 0
-isposdef!(A::Matrix) = ishermitian(A) && isposdef!(A, 'U')
+isposdef!{T<:BlasFloat}(A::StridedMatrix{T}, UL::Symbol) = LAPACK.potrf!(string(UL)[1], A)[2] == 0
+isposdef!(A::StridedMatrix) = ishermitian(A) && isposdef!(A, :U)
 
-isposdef{T<:BlasFloat}(A::Matrix{T}, UL::Char) = isposdef!(copy(A), UL)
-isposdef{T<:BlasFloat}(A::Matrix{T}) = isposdef!(copy(A))
-isposdef{T<:Number}(A::Matrix{T}, UL::Char) = isposdef!(float64(A), UL)
-isposdef{T<:Number}(A::Matrix{T}) = isposdef!(float64(A))
+isposdef{T}(A::AbstractMatrix{T}, UL::Symbol) = (S = typeof(sqrt(one(T))); isposdef!(S == T ? copy(A) : convert(AbstractMatrix{S}, A), UL))
+isposdef{T}(A::AbstractMatrix{T}) = (S = typeof(sqrt(one(T))); isposdef!(S == T ? copy(A) : convert(AbstractMatrix{S}, A)))
 isposdef(x::Number) = imag(x)==0 && real(x) > 0
 
 function norm{T<:BlasFloat, TI<:Integer}(x::StridedVector{T}, rx::Union(UnitRange{TI},Range{TI}))

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -581,7 +581,7 @@ det(A::Eigen) = prod(A.values)
 
 # Generalized eigenproblem
 function eigfact!{T<:BlasReal}(A::StridedMatrix{T}, B::StridedMatrix{T})
-    issym(A) && issym(B) && return eigfact!(Symmetric(A), Symmetric(B))
+    issym(A) && isposdef(B) && return eigfact!(Symmetric(A), Symmetric(B))
     n = size(A, 1)
     alphar, alphai, beta, _, vr = LAPACK.ggev!('N', 'V', A, B)
     all(alphai .== 0) && return GeneralizedEigen(alphar ./ beta, vr)
@@ -602,19 +602,19 @@ function eigfact!{T<:BlasReal}(A::StridedMatrix{T}, B::StridedMatrix{T})
 end
 
 function eigfact!{T<:BlasComplex}(A::StridedMatrix{T}, B::StridedMatrix{T})
-    ishermitian(A) && ishermitian(B) && return eigfact!(Hermitian(A), Hermitian(B))
+    ishermitian(A) && isposdef(B) && return eigfact!(Hermitian(A), Hermitian(B))
     alpha, beta, _, vr = LAPACK.ggev!('N', 'V', A, B)
     return GeneralizedEigen(alpha./beta, vr)
 end
 eigfact{TA,TB}(A::AbstractMatrix{TA}, B::AbstractMatrix{TB}) = (S = promote_type(Float32,typeof(one(TA)/norm(one(TA))),TB); eigfact!(S != TA ? convert(AbstractMatrix{S},A) : copy(A), S != TB ? convert(AbstractMatrix{S},B) : copy(B)))
 
 function eigvals!{T<:BlasReal}(A::StridedMatrix{T}, B::StridedMatrix{T})
-    issym(A) && issym(B) && return eigvals!(Symmetric(A), Symmetric(B))
+    issym(A) && isposdef(B) && return eigvals!(Symmetric(A), Symmetric(B))
     alphar, alphai, beta, vl, vr = LAPACK.ggev!('N', 'N', A, B)
     (all(alphai .== 0) ? alphar : complex(alphar, alphai))./beta
 end
 function eigvals!{T<:BlasComplex}(A::StridedMatrix{T}, B::StridedMatrix{T})
-    ishermitian(A) && ishermitian(B) && return eigvals!(Hermitian(A), Hermitian(B))
+    ishermitian(A) && isposdef(B) && return eigvals!(Hermitian(A), Hermitian(B))
     alpha, beta, vl, vr = LAPACK.ggev!('N', 'N', A, B)
     alpha./beta
 end

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -2909,7 +2909,7 @@ for (syev, syevr, sygvd, elty) in
                 end
             end
             @assertargsok
-            @assertnonsingular
+            @assertposdef
             w, A, B
         end
     end
@@ -3058,7 +3058,7 @@ for (syev, syevr, sygvd, elty, relty) in
                 end
             end
             @assertargsok
-            @assertnonsingular
+            @assertposdef
             w, A, B
         end
     end

--- a/test/arpack.jl
+++ b/test/arpack.jl
@@ -2,12 +2,14 @@ begin
     srand(1234)
     local n,a,asym,b,bsym,d,v
     n = 10
-    areal  = randn(n,n)
-    breal  = randn(n,n)
-    acmplx = complex(randn(n,n), randn(n,n))
-    bcmplx = complex(randn(n,n), randn(n,n))
+    areal  = sprandn(n,n,0.4)
+    breal  = sprandn(n,n,0.4)
+    acmplx = complex(sprandn(n,n,0.4), sprandn(n,n,0.4))
+    bcmplx = complex(sprandn(n,n,0.4), sprandn(n,n,0.4))
 
-    for elty in (Float32, Float64, Complex64, Complex128)
+    testtol = 1e-6
+
+    for elty in (Float64, Complex128)
         if elty == Complex64 || elty == Complex128
             a = acmplx
             b = bcmplx
@@ -15,40 +17,42 @@ begin
             a = areal
             b = breal
         end
-        a     = convert(Matrix{elty}, a)
+        a     = convert(SparseMatrixCSC{elty}, a)
         asym  = a' + a                  # symmetric indefinite
         apd   = a'*a                    # symmetric positive-definite
 
-        b     = convert(Matrix{elty}, b)
+        b     = convert(SparseMatrixCSC{elty}, b)
         bsym  = b' + b
         bpd   = b'*b
 
-        if elty == Complex64 || elty == Float32
-            testtol = 1e-3
-        else
-            testtol = 1e-6
-        end
-
-	(d,v) = eigs(a, nev=3)
-	@test_approx_eq a*v[:,2] d[2]*v[:,2]
-	(d,v) = eigs(a, b, nev=3, tol=1e-8)
-	@test_approx_eq_eps a*v[:,2] d[2]*b*v[:,2] testtol
-
-	(d,v) = eigs(asym, nev=3)
-	@test_approx_eq asym*v[:,1] d[1]*v[:,1]
+    	(d,v) = eigs(a, nev=3)
+    	@test_approx_eq a*v[:,2] d[2]*v[:,2]
+        @test norm(v) > testtol # eigenvectors cannot be null vectors
+    	# (d,v) = eigs(a, b, nev=3, tol=1e-8) not handled yet
+    	# @test_approx_eq_eps a*v[:,2] d[2]*b*v[:,2] testtol
+        # @test norm(v) > testtol # eigenvectors cannot be null vectors
+    
+    	(d,v) = eigs(asym, nev=3)
+    	@test_approx_eq asym*v[:,1] d[1]*v[:,1]
         @test_approx_eq eigs(asym; nev=1, sigma=d[3])[1][1] d[3]
-
-	(d,v) = eigs(apd, nev=3)
-	@test_approx_eq apd*v[:,3] d[3]*v[:,3]
+        @test norm(v) > testtol # eigenvectors cannot be null vectors
+    
+    	(d,v) = eigs(apd, nev=3)
+    	@test_approx_eq apd*v[:,3] d[3]*v[:,3]
         @test_approx_eq eigs(apd; nev=1, sigma=d[3])[1][1] d[3]
-	(d,v) = eigs(apd, bpd, nev=3, tol=1e-8)
-	@test_approx_eq_eps apd*v[:,2] d[2]*bpd*v[:,2] testtol
-
+    	
+        (d,v) = eigs(apd, bpd, nev=3, tol=1e-8)
+    	@test_approx_eq_eps apd*v[:,2] d[2]*bpd*v[:,2] testtol
+        @test norm(v) > testtol # eigenvectors cannot be null vectors
+    
         # test (shift-and-)invert mode
         (d,v) = eigs(apd, nev=3, sigma=0)
         @test_approx_eq apd*v[:,3] d[3]*v[:,3]
+        @test norm(v) > testtol # eigenvectors cannot be null vectors
+        
         (d,v) = eigs(apd, bpd, nev=3, sigma=0, tol=1e-8)
         @test_approx_eq_eps apd*v[:,1] d[1]*bpd*v[:,1] testtol
+        @test norm(v) > testtol # eigenvectors cannot be null vectors
 
     end
 end


### PR DESCRIPTION
Use `I` and `UniformScaling` in eigs. Change default `nev` in `eigs` because different restrictions apply to symmetric and non-symmetric problems. Use `factorize` instead of `lufact` for inverse operations.

The way the generalised eigensolver in `eigs` is setup right now assumes that `B` is positive definite. According the ARPACK manual, it is possible to solve a general problem by some reorganisation of the problem, but for now I just return an error if `B` is not positive definite.

At some point, we should support the general problem, but the ARPACK is an extreme mental challenge to me, so I'll propose that the case with general `B` is not included in this pull request.

cc: @ViralBShah, @jiahao 
