### PR TITLE
Use BLAS for pairwise sumabs2 when possible

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -52,6 +52,15 @@ median{T}(v::AbstractArray{T}, region; checknan::Bool=true) =
 
 ## variances
 
+function varzm_pairwise{T<:Base.LinAlg.BlasFloat}(A::StridedArray{T}, i1::Int, n::Int)
+    if n <= 2048
+        BLAS.dot(n, pointer(A, i1), stride(A, 1), pointer(A, i1), stride(A, 1))
+    else
+        n2 = div(n,2)
+        varzm_pairwise(A, i1, n2) + varzm_pairwise(A, i1+n2, n-n2)
+    end
+end
+
 function varzm_pairwise(A::AbstractArray, i1::Int, n::Int)
     if n < 256
         @inbounds s = abs2(A[i1])

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -52,16 +52,16 @@ median{T}(v::AbstractArray{T}, region; checknan::Bool=true) =
 
 ## variances
 
-function varzm_pairwise{T<:Base.LinAlg.BlasFloat}(A::StridedArray{T}, i1::Int, n::Int)
+function sumabs2_pairwise{T<:Base.LinAlg.BlasFloat}(A::StridedArray{T}, i1::Int, n::Int)
     if n <= 2048
         BLAS.dot(n, pointer(A, i1), stride(A, 1), pointer(A, i1), stride(A, 1))
     else
         n2 = div(n,2)
-        varzm_pairwise(A, i1, n2) + varzm_pairwise(A, i1+n2, n-n2)
+        sumabs2_pairwise(A, i1, n2) + sumabs2_pairwise(A, i1+n2, n-n2)
     end
 end
 
-function varzm_pairwise(A::AbstractArray, i1::Int, n::Int)
+function sumabs2_pairwise(A::AbstractArray, i1::Int, n::Int)
     if n < 256
         @inbounds s = abs2(A[i1])
         for i=i1+1:i1+n-1
@@ -70,24 +70,11 @@ function varzm_pairwise(A::AbstractArray, i1::Int, n::Int)
         return s
     else
         n2 = div(n,2)
-        return varzm_pairwise(A, i1, n2) + varzm_pairwise(A, i1+n2, n-n2)
+        return sumabs2_pairwise(A, i1, n2) + sumabs2_pairwise(A, i1+n2, n-n2)
     end
 end
 
-function varm_pairwise(A::AbstractArray, m::Number, i1::Int, n::Int) # see sum_pairwise
-    if n < 256
-        @inbounds s = abs2(A[i1] - m)
-        for i = i1+1:i1+n-1
-            @inbounds s += abs2(A[i] - m)
-        end
-        return s
-    else
-        n2 = div(n,2)
-        return varm_pairwise(A, m, i1, n2) + varm_pairwise(A, m, i1+n2, n-n2)
-    end
-end
-
-sumabs2(v::AbstractArray) = varzm_pairwise(v, 1, length(v))
+sumabs2(v::AbstractArray) = sumabs2_pairwise(v, 1, length(v))
 
 plusabs2(x, y) = x + abs2(y)
 eval(ngenerate(:N, :(typeof(R)), :(_sumabs2!{T,N}(R::AbstractArray, A::AbstractArray{T,N})), N->gen_reduction_body(N, plusabs2)))
@@ -103,6 +90,19 @@ end
 function varzm(v::AbstractArray, region; corrected::Bool=true)
     cn = regionsize(v, region) - int(corrected)
     sumabs2(v, region) / cn    
+end
+
+function varm_pairwise(A::AbstractArray, m::Number, i1::Int, n::Int) # see sum_pairwise
+    if n < 256
+        @inbounds s = abs2(A[i1] - m)
+        for i = i1+1:i1+n-1
+            @inbounds s += abs2(A[i] - m)
+        end
+        return s
+    else
+        n2 = div(n,2)
+        return varm_pairwise(A, m, i1, n2) + varm_pairwise(A, m, i1+n2, n-n2)
+    end
 end
 
 function varm(v::AbstractArray, m::Number; corrected::Bool=true)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -179,8 +179,7 @@ big(z::Complex) = complex(big(real(z)),big(imag(z)))
 # more hashing definitions
 include("hashing2.jl")
 
-# random number generation and statistics
-include("statistics.jl")
+# random number generation
 include("librandom.jl")
 include("random.jl")
 importall .Random
@@ -226,6 +225,9 @@ const ⋅ = dot
 const × = cross
 include("broadcast.jl")
 importall .Broadcast
+
+# statistics
+include("statistics.jl")
 
 # signal processing
 include("fftw.jl")


### PR DESCRIPTION
Here's a comparison of the performance and error (for Normal(0, 1) input compared to `sum_kbn(abs2(x))`) for the current algorithm, plain `BLAS.dot`, and this pairwise algorithm on my Sandy Bridge system:

![comparison](https://cloud.githubusercontent.com/assets/470884/3084974/c4e1f3dc-e504-11e3-8367-5adbc489617f.png)

I'm not sure whether a pairwise algorithm is truly necessary for most applications of this method, but this PR appears to greatly reduce the performance cost while still providing greater accuracy. cc @lindahua 
