### PR TITLE
Make splice!(::BitVector, ::Integer, ::BitVector) return a Bool

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -732,12 +732,10 @@ function splice!(B::BitVector, i::Integer)
     _deleteat!(B, i)
     return v
 end
-splice!(B::BitVector, i::Integer, ins::BitVector) = splice!(B, int(i):int(i), ins)
-splice!(B::BitVector, i::Integer, ins::AbstractVector{Bool}) = splice!(B, i, bitpack(ins))
 
 const _default_bit_splice = BitVector(0)
 
-function splice!(B::BitVector, r::UnitRange{Int}, ins::BitVector = _default_bit_splice)
+function splice!(B::BitVector, r::Union(UnitRange{Int}, Integer), ins::BitVector = _default_bit_splice)
     n = length(B)
     i_f = first(r)
     i_l = last(r)
@@ -775,7 +773,7 @@ function splice!(B::BitVector, r::UnitRange{Int}, ins::BitVector = _default_bit_
 
     return v
 end
-splice!(B::BitVector, r::UnitRange{Int}, ins::AbstractVector{Bool}) = splice!(B, r, bitpack(ins))
+splice!(B::BitVector, r::Union(UnitRange{Int}, Integer), ins::AbstractVector{Bool}) = splice!(B, r, bitpack(ins))
 
 function empty!(B::BitVector)
     ccall(:jl_array_del_end, Void, (Any, Uint), B.chunks, length(B.chunks))

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -482,6 +482,21 @@ end
 
 b1 = randbool(v1)
 i1 = bitunpack(b1)
+for m1 = 1 : v1
+    for v2 = [0, 1, 63, 64, 65, 127, 128, 129, 191, 192, 193, rand(1:v1)]
+        b2 = copy(b1)
+        i2 = copy(i1)
+        b3 = randbool(v2)
+        i3 = bitunpack(b3)
+        b = splice!(b2, m1, b3)
+        i = splice!(i2, m1, i3)
+        @test isequal(bitunpack(b2), i2)
+        @test b == i
+    end
+end
+
+b1 = randbool(v1)
+i1 = bitunpack(b1)
 for m1 = 1 : v1 - 1
     for m2 = m1 + 1 : v1
         locs = randbool(m2-m1+1)


### PR DESCRIPTION
Previously this returned a one-element BitArray, which was inconsistent with `splice!(::Vector{Bool}, ::Integer, ::Vector{Bool})`
