### PR TITLE
Update Mac juliarc.jl (fixes #6880)

### DIFF
--- a/contrib/mac/juliarc.jl
+++ b/contrib/mac/juliarc.jl
@@ -3,7 +3,5 @@ let
     ROOT = abspath(JULIA_HOME,"..")
     ENV["PATH"]="$JULIA_HOME:$(joinpath(ROOT, "libexec")):$(ENV["PATH"])"
     ENV["FONTCONFIG_PATH"] = joinpath(ROOT, "etc", "fonts")
-    ENV["GIT_EXEC_PATH"] = joinpath(ROOT, "libexec", "git-core")
-    ENV["GIT_TEMPLATE_DIR"] = joinpath(ROOT, "share", "git-core")
     ENV["TK_LIBRARY"] = "/System/Library/Frameworks/Tk.framework/Versions/8.5/Resources/Scripts"
 end


### PR DESCRIPTION
Even though 0.3 uses the system git, the GIT_EXEC_PATH is still set to the old targets within the Julia distribution. If system git and the bundled components don't match in some way, index packing fails (e.g., when pulling Pkg METADATA). Removing the settings fixes the bug.
