### PR TITLE
Update Mac juliarc.jl (fixes #6880)

### DIFF
--- a/contrib/mac/juliarc.jl
+++ b/contrib/mac/juliarc.jl
@@ -1,7 +1,7 @@
 # Set up environment for Julia OSX binary distribution
 let
     ROOT = abspath(JULIA_HOME,"..")
-    ENV["PATH"]="$JULIA_HOME:$(joinpath(ROOT, "libexec")):$(ENV["PATH"])"
+    ENV["PATH"]="$JULIA_HOME:$(joinpath(ROOT, "libexec", "git-core")):$(ENV["PATH"])"
     ENV["FONTCONFIG_PATH"] = joinpath(ROOT, "etc", "fonts")
     ENV["GIT_EXEC_PATH"] = joinpath(ROOT, "libexec", "git-core")
     ENV["GIT_TEMPLATE_DIR"] = joinpath(ROOT, "share", "git-core")


### PR DESCRIPTION
git (bundled in ROOT/libexec/git-core) isn't included on the PATH used by Julia. This causes issues on OSX when using the package manager because GIT_EXEC_PATH does point to the bundled git tools. By adding git-core explicitly, all issues are fixed. The bundled git is used throughout.

Reference: #6880
