### PR TITLE
Make sure SIGUSR1 is unblocked for profiler

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -352,6 +352,13 @@ DLLEXPORT int jl_profile_start_timer(void)
 {
     struct sigevent sigprof;
     struct sigaction sa;
+    sigset_t ss;
+
+    // Make sure SIGUSR1 is unblocked
+    sigemptyset(&ss);
+    sigaddset(&ss, SIGUSR1);
+    if (sigprocmask(SIG_UNBLOCK, &ss, NULL) == -1)
+        return -4;
 
     // Establish the signal handler
     memset(&sa, 0, sizeof(struct sigaction));


### PR DESCRIPTION
We cannot make any assumptions about the state of the signal mask.
Turns out that the USR1 signal can be blocked by parent processes and
then the profiler will not work right (gdm is an example).  Make sure
that if we are running the profiler that the USR1 signal is unblocked.
