### PR TITLE
Refactoring sum functions

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -22,7 +22,7 @@ isposdef(x::Number) = imag(x)==0 && real(x) > 0
 
 
 Base.sumabs{T<:BlasFloat}(x::Union(Array{T},StridedVector{T})) = 
-    (n = length(x); n > 32 ? BLAS.asum(x) : Base.sum_impl(Base.AbsFun(), x, 1, n))
+    length(x) > 32 ? BLAS.asum(x) : Base._sumabs(x)
 
 stride1(x::Array) = 1
 stride1(x::StridedVector) = stride(x, 1)::Int
@@ -34,7 +34,7 @@ function Base.sumabs2{T<:BlasFloat}(x::Union(Array{T},StridedVector{T}))
         incx = stride1(x)
         return BLAS.dot(n, px, incx, px, incx)
     else
-        return Base.sum_impl(Base.Abs2Fun(), x, 1, n)
+        return Base._sumabs2(x)
     end
 end
 
@@ -45,7 +45,7 @@ end
 
 vecnorm1{T<:BlasReal}(x::Union(Array{T},StridedVector{T})) = 
     length(x) > 16 ? BLAS.asum(x) : generic_vecnorm1(x)
-    
+
 vecnorm2{T<:BlasFloat}(x::Union(Array{T},StridedVector{T})) = 
     length(x) > 8 ? BLAS.nrm2(x) : generic_vecnorm2(x)
 

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -20,6 +20,24 @@ isposdef{T}(A::AbstractMatrix{T}, UL::Symbol) = (S = typeof(sqrt(one(T))); ispos
 isposdef{T}(A::AbstractMatrix{T}) = (S = typeof(sqrt(one(T))); isposdef!(S == T ? copy(A) : convert(AbstractMatrix{S}, A)))
 isposdef(x::Number) = imag(x)==0 && real(x) > 0
 
+
+Base.sumabs{T<:BlasFloat}(x::Union(Array{T},StridedVector{T})) = 
+    (n = length(x); n > 32 ? BLAS.asum(x) : Base.sum_impl(Base.AbsFun(), x, 1, n))
+
+stride1(x::Array) = 1
+stride1(x::StridedVector) = stride(x, 1)::Int
+
+function Base.sumabs2{T<:BlasFloat}(x::Union(Array{T},StridedVector{T}))
+    n = length(x)
+    if n > 128
+        px = pointer(x)
+        incx = stride1(x)
+        return BLAS.dot(n, px, incx, px, incx)
+    else
+        return Base.sum_impl(Base.Abs2Fun(), x, 1, n)
+    end
+end
+
 function norm{T<:BlasFloat, TI<:Integer}(x::StridedVector{T}, rx::Union(UnitRange{TI},Range{TI}))
     (minimum(rx) < 1 || maximum(rx) > length(x)) && throw(BoundsError())
     BLAS.nrm2(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx))
@@ -27,7 +45,7 @@ end
 
 vecnorm1{T<:BlasReal}(x::Union(Array{T},StridedVector{T})) = 
     length(x) > 16 ? BLAS.asum(x) : generic_vecnorm1(x)
-
+    
 vecnorm2{T<:BlasFloat}(x::Union(Array{T},StridedVector{T})) = 
     length(x) > 8 ? BLAS.nrm2(x) : generic_vecnorm2(x)
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -237,7 +237,7 @@ function sum(itr)
     _sum(IdFun(), itr, s)
 end
 
-function sum(f::Function, itr)
+function sum(f::Union(Function,Func{1}), itr)
     s = start(itr)
     done(itr, s) && error("Argument is empty.")
     _sum(f, itr, s)
@@ -245,6 +245,9 @@ end
 
 sum(x::Number) = x
 sum(A::AbstractArray{Bool}) = countnz(A)
+
+sumabs(itr) = sum(AbsFun(), itr)
+sumabs2(itr) = sum(Abs2Fun(), itr)
 
 # Note: sum_seq uses four accumulators, so each accumulator gets at most 256 numbers
 const PAIRWISE_SUM_BLOCKSIZE = 1024

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -339,19 +339,21 @@ function sum(f::Function, a::AbstractArray)
     sum_impl(f, a, 1, n)
 end
 
-function sumabs{T}(a::AbstractArray{T})
+function _sumabs{T}(a::AbstractArray{T})
     n = length(a)
-    n == 0 && return sumzero(abs(zero(T)))
+    n == 0 && return addzero(abs(zero(T)))
     n == 1 && return addzero(abs(a[1]))
     sum_impl(AbsFun(), a, 1, n)
 end
+sumabs(a::AbstractArray) = _sumabs(a)
 
-function sumabs2{T}(a::AbstractArray{T})
+function _sumabs2{T}(a::AbstractArray{T})
     n = length(a)
-    n == 0 && return sumzero(abs2(zero(T)))
+    n == 0 && return addzero(abs2(zero(T)))
     n == 1 && return addzero(abs2(a[1]))
     sum_impl(Abs2Fun(), a, 1, n)
 end
+sumabs2(a::AbstractArray) = _sumabs2(a)
 
 # Kahan (compensated) summation: O(1) error growth, at the expense
 # of a considerable increase in computational expense.

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -8,16 +8,25 @@
 
 abstract Func{N}
 
+type IdFun <: Func{1} end
+type AbsFun <: Func{1} end
+type Abs2Fun <: Func{1} end
+
 type AddFun <: Func{2} end
 type MulFun <: Func{2} end
 type AndFun <: Func{2} end
 type OrFun <: Func{2} end
 
+evaluate(::IdFun, x) = x
+evaluate(::AbsFun, x) = abs(x)
+evaluate(::Abs2Fun, x) = abs2(x)
+evaluate(f::Callable, x) = f(x)
+
 evaluate(::AddFun, x, y) = x + y
 evaluate(::MulFun, x, y) = x * y
 evaluate(::AndFun, x, y) = x & y
 evaluate(::OrFun, x, y) = x | y
-evaluate(f::Callable, x, y) = f(x,y)
+evaluate(f::Callable, x, y) = f(x, y)
 
 ###### Generic reduction functions ######
 
@@ -191,7 +200,7 @@ sumtype{T}(::Type{T}) = typeof(zero(T) + zero(T))
 sumzero{T}(::Type{T}) = zero(T) + zero(T)
 addzero(x) = x + zero(x) 
 
-typealias SumResultNumber Union(Int,Int64,Int128,Float32,Float64,Complex64,Complex128)
+typealias SumResultNumber Union(Uint,Uint64,Uint128,Int,Int64,Int128,Float32,Float64,Complex64,Complex128)
 
 sumtype{T<:SumResultNumber}(::Type{T}) = T
 sumzero{T<:SumResultNumber}(::Type{T}) = zero(T)
@@ -202,6 +211,20 @@ addzero(a::AbstractArray) = a
 
 # general sum over iterables
 
+function _sum(f, itr, s)  # deal with non-empty cases
+    # pre-condition: s = start(itr) && !done(itr, s)
+    (v, s) = next(itr, s)
+    done(itr, s) && return addzero(evaluate(f, v)) # adding zero for type stability
+    # specialize for length > 1 to have type-stable loop
+    (x, s) = next(itr, s)
+    result = evaluate(f, v) + evaluate(f, x)
+    while !done(itr, s)
+        (x, s) = next(itr, s)
+        result += evaluate(f, x)
+    end
+    return result    
+end 
+
 function sum(itr)
     s = start(itr)
     if done(itr, s)
@@ -211,16 +234,13 @@ function sum(itr)
             throw(ArgumentError("sum(itr) is undefined for empty collections; instead, do isempty(itr) ? z : sum(itr), where z is the correct type of zero for your sum"))
         end
     end
-    (v, s) = next(itr, s)
-    done(itr, s) && return addzero(v) # adding zero for type stability
-    # specialize for length > 1 to have type-stable loop
-    (x, s) = next(itr, s)
-    result = v + x
-    while !done(itr, s)
-        (x, s) = next(itr, s)
-        result += x
-    end
-    return result
+    _sum(IdFun(), itr, s)
+end
+
+function sum(f::Function, itr)
+    s = start(itr)
+    done(itr, s) && error("Argument is empty.")
+    _sum(f, itr, s)
 end
 
 sum(x::Number) = x
@@ -231,14 +251,14 @@ const PAIRWISE_SUM_BLOCKSIZE = 1024
 
 # a fast implementation of sum in sequential order (from left to right).
 # to allow type-stable loops, requires length > 1
-function sum_seq{T}(a::AbstractArray{T}, ifirst::Int, ilast::Int)
+function sum_seq(f, a::AbstractArray, ifirst::Int, ilast::Int)
     
     @inbounds if ifirst + 6 >= ilast  # length(a) < 8
         i = ifirst
-        s = a[i] + a[i+1]
+        s = evaluate(f, a[i]) + evaluate(f, a[i+1])
         i = i+1
         while i < ilast
-            s += a[i+=1]
+            s += evaluate(f, a[i+=1])
         end
         return s
 
@@ -249,23 +269,23 @@ function sum_seq{T}(a::AbstractArray{T}, ifirst::Int, ilast::Int)
         # into four-way accumulation. Benchmark shows
         # that this results in about 2x speed-up.                
 
-        s1 = a[ifirst] + a[ifirst + 4]
-        s2 = a[ifirst + 1] + a[ifirst + 5]
-        s3 = a[ifirst + 2] + a[ifirst + 6]
-        s4 = a[ifirst + 3] + a[ifirst + 7]
+        s1 = evaluate(f, a[ifirst]) + evaluate(f, a[ifirst + 4])
+        s2 = evaluate(f, a[ifirst + 1]) + evaluate(f, a[ifirst + 5])
+        s3 = evaluate(f, a[ifirst + 2]) + evaluate(f, a[ifirst + 6])
+        s4 = evaluate(f, a[ifirst + 3]) + evaluate(f, a[ifirst + 7])
 
         i = ifirst + 8
         il = ilast - 3
         while i <= il
-            s1 += a[i]
-            s2 += a[i+1]
-            s3 += a[i+2]
-            s4 += a[i+3]
+            s1 += evaluate(f, a[i])
+            s2 += evaluate(f, a[i+1])
+            s3 += evaluate(f, a[i+2])
+            s4 += evaluate(f, a[i+3])
             i += 4
         end
 
         while i <= ilast
-            s1 += a[i]
+            s1 += evaluate(f, a[i])
             i += 1
         end
 
@@ -285,29 +305,50 @@ end
 #        Manfred Tasche and Hansmartin Zeuner, Handbook of
 #        Analytic-Computational Methods in Applied Mathematics (2000).
 #
-function sum_pairwise(a::AbstractArray, ifirst::Int, ilast::Int)
+function sum_pairwise(f, a::AbstractArray, ifirst::Int, ilast::Int)
     # bsiz: maximum block size
 
     if ifirst + PAIRWISE_SUM_BLOCKSIZE >= ilast
-        sum_seq(a, ifirst, ilast)
+        sum_seq(f, a, ifirst, ilast)
     else
         imid = (ifirst + ilast) >>> 1
-        sum_pairwise(a, ifirst, imid) + sum_pairwise(a, imid+1, ilast)
+        sum_pairwise(f, a, ifirst, imid) + sum_pairwise(f, a, imid+1, ilast)
     end
 end
 
 # sum_impl requires length(a) > 1 
 #
-sum_impl{T<:Integer}(a::AbstractArray{T}, ifirst::Int, ilast::Int) = sum_seq(a, ifirst, ilast)
-sum_impl(a::AbstractArray, ifirst::Int, ilast::Int) = sum_pairwise(a, ifirst, ilast)
+sum_impl(f, a::AbstractArray, ifirst::Int, ilast::Int) = sum_pairwise(f, a, ifirst, ilast)
+sum_impl{T<:Integer}(f::Union(IdFun,AbsFun,Abs2Fun), a::AbstractArray{T}, ifirst::Int, ilast::Int) = 
+    sum_seq(f, a, ifirst, ilast)
 
 function sum{T}(a::AbstractArray{T})
     n = length(a)
     n == 0 && return sumzero(T)
     n == 1 && return addzero(a[1])
-    sum_impl(a, 1, length(a))
+    sum_impl(IdFun(), a, 1, n)
 end
 
+function sum(f::Function, a::AbstractArray)
+    n = length(a)
+    n == 0 && error("Argument is empty.")
+    n == 1 && return addzero(f(a[1]))
+    sum_impl(f, a, 1, n)
+end
+
+function sumabs{T}(a::AbstractArray{T})
+    n = length(a)
+    n == 0 && return sumzero(abs(zero(T)))
+    n == 1 && return addzero(abs(a[1]))
+    sum_impl(AbsFun(), a, 1, n)
+end
+
+function sumabs2{T}(a::AbstractArray{T})
+    n = length(a)
+    n == 0 && return sumzero(abs2(zero(T)))
+    n == 1 && return addzero(abs2(a[1]))
+    sum_impl(Abs2Fun(), a, 1, n)
+end
 
 # Kahan (compensated) summation: O(1) error growth, at the expense
 # of a considerable increase in computational expense.
@@ -328,7 +369,6 @@ function sum_kbn{T<:FloatingPoint}(A::AbstractArray{T})
         end
         s = t
     end
-
     s + c
 end
 
@@ -579,7 +619,6 @@ end
 
 maximum(f::Function, itr) = mapreduce(f, scalarmax, itr)
 minimum(f::Function, itr) = mapreduce(f, scalarmin, itr)
-sum(f::Function, itr)     = mapreduce(f, +        , itr)
 prod(f::Function, itr)    = mapreduce(f, *        , itr)
 
 function any(pred::Function, itr)

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -52,30 +52,6 @@ median{T}(v::AbstractArray{T}, region; checknan::Bool=true) =
 
 ## variances
 
-function sumabs2_pairwise{T<:Base.LinAlg.BlasFloat}(A::StridedArray{T}, i1::Int, n::Int)
-    if n <= 2048
-        BLAS.dot(n, pointer(A, i1), stride(A, 1), pointer(A, i1), stride(A, 1))
-    else
-        n2 = div(n,2)
-        sumabs2_pairwise(A, i1, n2) + sumabs2_pairwise(A, i1+n2, n-n2)
-    end
-end
-
-function sumabs2_pairwise(A::AbstractArray, i1::Int, n::Int)
-    if n < 256
-        @inbounds s = abs2(A[i1])
-        for i=i1+1:i1+n-1
-            @inbounds s += abs2(A[i])
-        end
-        return s
-    else
-        n2 = div(n,2)
-        return sumabs2_pairwise(A, i1, n2) + sumabs2_pairwise(A, i1+n2, n-n2)
-    end
-end
-
-sumabs2(v::AbstractArray) = sumabs2_pairwise(v, 1, length(v))
-
 plusabs2(x, y) = x + abs2(y)
 eval(ngenerate(:N, :(typeof(R)), :(_sumabs2!{T,N}(R::AbstractArray, A::AbstractArray{T,N})), N->gen_reduction_body(N, plusabs2)))
 sumabs2!{R}(r::AbstractArray{R}, A::AbstractArray; init::Bool=true) = _sumabs2!(initarray!(r, zero(R), init), A)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -419,7 +419,23 @@ let es = sum_kbn(z), es2 = sum_kbn(z[1:10^5])
     @test (es - cs[end]) < es * 1e-13
     @test (es2 - cs[10^5]) < es2 * 1e-13
 end
-@test_approx_eq sum(sin(z)) sum(sin, z)
+
+@test_throws ErrorException sum(sin, Int[])
+@test Base.sumabs(Float64[]) === 0.0
+@test Base.sumabs2(Float64[]) === 0.0
+
+@test sum(sin, [1]) == sin(1)
+@test Base.sumabs([int8(-2)]) === 2
+@test Base.sumabs2([int8(-2)]) === 4
+
+x = -2:3
+@test sum(sin, x) == sum(sin(x))
+@test Base.sumabs(x) === 9
+@test Base.sumabs2(x) === 19
+
+@test_approx_eq sum(sin, z) sum(sin(z))
+@test_approx_eq Base.sumabs(z) sum(abs(z))
+@test_approx_eq Base.sumabs2(z) sum(abs2(z))
 
 @test maximum([4, 3, 5, 2]) == 5
 @test minimum([4, 3, 5, 2]) == 2
@@ -440,6 +456,7 @@ end
 
 @test all([true true; false true], 2) == [true false]'
 @test all([true false; false true], 1) == [false false]
+
 
 ## large matrices transpose ##
 


### PR DESCRIPTION
- All sum functions, including `sum(x)`, `sum(f, x)`, `sumabs(x)`, and `sumabs2(x)` now use the same core implementation, namely `sum_seq` and `sum_pairwise`. Everything else is just light-weight wrappers.
- I did some simple benchmarks myself, which shows that this implementation will not compromise runtime efficiency.
- `sumabs` will be used to implement `vecnorm1`, and `sumabs2` will be useful for implementing `var`.
