### PR TITLE
RFC: Interface Prototype

### DIFF
--- a/base/interfaces.jl
+++ b/base/interfaces.jl
@@ -1,0 +1,126 @@
+
+type Interfaces
+    functions::Dict{Symbol,Vector{DataType}}
+    signatures::Dict{(Symbol,DataType),Any}
+
+    Interfaces() = new(Dict{Symbol,Vector{DataType}}(), Dict{(Symbol,DataType),Any}())
+end
+
+_interfaces = Interfaces()
+ 
+function add_interface(d::DataType, f::Symbol, signature=nothing)
+ 
+    if haskey(_interfaces.functions, f)
+       push!(_interfaces.functions[f], d) 
+    else
+       _interfaces.functions[f] = DataType[d]
+    end
+
+    if signature == nothing # now the signature will not be checked anymore
+        _interfaces.signatures[(f,d)] = nothing
+    else
+        if haskey(_interfaces.signatures, (f,d))
+            if _interfaces.signatures[(f,d)] != nothing
+                push!(_interfaces.signatures[(f,d)], signature)
+            end
+        else
+           _interfaces.signatures[(f,d)] = [signature]
+        end
+    end
+    nothing
+end
+ 
+function verify_interface(d::DataType)
+    for (f,itypes) in _interfaces.functions
+    
+        isInInterfaceTable = false
+ 
+        for it in itypes
+            if d <: it
+            
+                isInMethodTable = false
+            
+                if !isdefined(f)
+                    error("Interface not implemented! $d has to implement ", string(f), " in order to be subtype of $it !")
+                end
+                mt = methods(eval(Main,f))
+            
+                if _interfaces.signatures[(f,it)] == nothing
+                    for m in mt
+                        if d <: m.sig[1]
+                            isInMethodTable = true
+                        end
+                    end
+                    if !isInMethodTable
+                        error("Interface not implemented! $d has to implement ", string(f), " in order to be subtype of $it !")
+                    end                    
+                else 
+                    for ex in _interfaces.signatures[(f,it)]
+                        isInMethodTable = false
+                        typeargs = eval(Main,ex)
+                        for m in mt
+                            if length(m.sig) == length(typeargs)
+                                same_signature = true
+                                if !( d <: m.sig[1] )
+                                    same_signature = false
+                                end
+                                for i=2:length(m.sig)
+                                    if !( typeargs[i] <: m.sig[i] )
+                                        same_signature = false
+                                    end
+                                end
+                                if same_signature
+                                    isInMethodTable = true
+                                end
+                            end
+                        end
+                        if !isInMethodTable
+                            error("Interface not implemented! $d has to implement ", string(f), " in order to be subtype of $it !")
+                        end                        
+                    end
+                end
+            end
+        end
+    end    
+    
+    return true
+end
+
+function isinterface(f::Symbol, args)
+    if !haskey(_interfaces.functions,f) || length(args) == 0
+        return (false,Nothing)
+    end
+
+    itypes = _interfaces.functions[f]
+    d = typeof(args[1])
+    for it in itypes
+        if d <: eval(Main,it)
+            if _interfaces.signatures[(f,it)] == nothing
+                return (true,it)                  
+            else 
+                for ex in _interfaces.signatures[(f,it)]
+                    isInMethodTable = false
+                    typeargs = eval(Main,ex)
+                        
+                    if length(args) == length(typeargs)
+                        same_signature = true
+                        if !( d <: typeof(args[1]))
+                            same_signature = false
+                        end
+                        for i=2:length(args)
+                            if !( typeargs[i] <: typeof(args[i]) )
+                                same_signature = false
+                            end
+                        end
+                        if same_signature
+                           return (true,it)
+                        end                        
+                    end
+                end
+            end
+        end
+    end    
+ 
+    return (false,Nothing)
+end
+

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -103,6 +103,12 @@ showerror(io::IO, e::InterruptException) = print(io, "interrupt")
 
 function showerror(io::IO, e::MethodError)
     name = isgeneric(e.f) ? e.f.env.name : :anonymous
+    iface, parent = isinterface(symbol(name), e.args)
+    if iface
+        d = typeof(e.args[1])
+        println(io, "Type $(d) has to implement $(name) to be a subtype of $(parent)!")
+    end
+
     if isa(e.f, DataType)
         print(io, "no method $(e.f)(")
     else

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -197,6 +197,7 @@ importall .DataFmt
 include("deepcopy.jl")
 include("util.jl")
 include("interactiveutil.jl")
+include("interfaces.jl")
 include("replutil.jl")
 include("test.jl")
 include("meta.jl")


### PR DESCRIPTION
This is prototype for the interface system outlined in #6975. The most important missing thing is the parse support that would need help from someone with experience in hacking the parser.

This PR adds three functions:
- `add_interface`: Adds an interface to the interface table (this is what should be called from the parser)
- `verify_interface`: Checks whether a type fulfills all interfaces
- `isinterface`: Returns if a function belongs to an interface (this is an internal function used by `showerror`)

Further, the PR modifies `showerror` to check if a function is an interface and then displays the error message.

The interface implementation can be used in two different ways. Either one implements the interface and the calls `verify_interface` to directly validate that the interface is fulfilled. Or one skips the last step and still gets a nice error message.

In action:

```
julia> abstract A
julia> type B <: A end
julia> Base.add_interface(A,:length)
julia> length(B())
ERROR: Type B has to implement length to be a subtype of A!
no method length(B)
```
