### PR TITLE
Tweaks to sum across dimensions

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -321,10 +321,10 @@ end
 sum_impl{T<:Integer}(f::Union(IdFun,AbsFun,Abs2Fun), a::AbstractArray{T}, ifirst::Int, ilast::Int) = 
     sum_seq(f, a, ifirst, ilast)
 
-function sum(f::Function, a::AbstractArray)
+function sum(f::Union(Function,Func{1}), a::AbstractArray)
     n = length(a)
     n == 0 && error("Argument is empty.")
-    n == 1 && return addzero(f(a[1]))
+    n == 1 && return addzero(evaluate(f, a[1]))
     sum_impl(f, a, 1, n)
 end
 

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -52,11 +52,6 @@ median{T}(v::AbstractArray{T}, region; checknan::Bool=true) =
 
 ## variances
 
-plusabs2(x, y) = x + abs2(y)
-eval(ngenerate(:N, :(typeof(R)), :(_sumabs2!{T,N}(R::AbstractArray, A::AbstractArray{T,N})), N->gen_reduction_body(N, plusabs2)))
-sumabs2!{R}(r::AbstractArray{R}, A::AbstractArray; init::Bool=true) = _sumabs2!(initarray!(r, zero(R), init), A)
-sumabs2{T}(A::AbstractArray{T}, region) = _sumabs2!(reduction_init(A, region, abs2(zero(T))+abs2(zero(T))), A)
-
 function varzm(v::AbstractArray; corrected::Bool=true)
     n = length(v)
     n == 0 && return NaN

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -8,6 +8,8 @@ safe_sum{T}(A::Array{T}, region) = safe_mapslices(sum, A, region)
 safe_prod{T}(A::Array{T}, region) = safe_mapslices(prod, A, region)
 safe_maximum{T}(A::Array{T}, region) = safe_mapslices(maximum, A, region)
 safe_minimum{T}(A::Array{T}, region) = safe_mapslices(minimum, A, region)
+safe_sumabs{T}(A::Array{T}, region) = safe_mapslices(sum, abs(A), region)
+safe_sumabs2{T}(A::Array{T}, region) = safe_mapslices(sum, abs2(A), region)
 
 Areduc = rand(3, 4, 5, 6)
 for region in {
@@ -19,11 +21,15 @@ for region in {
     @test_approx_eq prod!(r, Areduc) safe_prod(Areduc, region)
     @test_approx_eq maximum!(r, Areduc) safe_maximum(Areduc, region)
     @test_approx_eq minimum!(r, Areduc) safe_minimum(Areduc, region)
+    @test_approx_eq Base.sumabs!(r, Areduc) safe_sumabs(Areduc, region)
+    @test_approx_eq Base.sumabs2!(r, Areduc) safe_sumabs2(Areduc, region)
 
     @test_approx_eq sum(Areduc, region) safe_sum(Areduc, region)
     @test_approx_eq prod(Areduc, region) safe_prod(Areduc, region)
     @test_approx_eq maximum(Areduc, region) safe_maximum(Areduc, region)
     @test_approx_eq minimum(Areduc, region) safe_minimum(Areduc, region)
+    @test_approx_eq Base.sumabs(Areduc, region) safe_sumabs(Areduc, region)
+    @test_approx_eq Base.sumabs2(Areduc, region) safe_sumabs2(Areduc, region)
 end
 
 @test reducedim((a,b) -> a|b, [true false; false false], 1, false) == [true false]


### PR DESCRIPTION
- Implement `sum(fn, A, region)`
- Implement `Base.sumabs` across dimensions
- Use pairwise summation/BLAS for sums across first dimension
