### PR TITLE
RFC: Track and make use of consecutive keystrokes in the REPL

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -552,11 +552,13 @@ end
 function edit_kill_line(s::MIState)
     buf = buffer(s)
     pos = position(buf)
-    s.kill_buffer = readline(buf)
-    if length(s.kill_buffer) > 1 && s.kill_buffer[end] == '\n'
-        s.kill_buffer = s.kill_buffer[1:end-1]
+    killbuf = readline(buf)
+    if length(killbuf) > 1 && killbuf[end] == '\n'
+        killbuf = killbuf[1:end-1]
         char_move_left(buf)
     end
+    s.kill_buffer = s.key_repeats > 0 ? s.kill_buffer * killbuf : killbuf
+
     splice_buffer!(buf, pos:position(buf)-1)
     refresh_line(s)
 end

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1106,27 +1106,24 @@ on_enter(s::PromptState) = s.p.on_enter(s)
 
 move_input_start(s) = (seek(buffer(s), 0))
 move_input_end(s) = (seekend(buffer(s)))
-function move_line_start(s)
+function move_line_start(s::MIState)
     buf = buffer(s)
     curpos = position(buf)
     curpos == 0 && return
-    if buf.data[curpos] == '\n'
+    if s.key_repeats > 0
         move_input_start(s)
     else
         seek(buf, rsearch(buf.data, '\n', curpos-1))
     end
 end
-function move_line_end(s)
+function move_line_end(s::MIState)
     buf = buffer(s)
-    curpos = position(buf)
     eof(buf) && return
-    c = read(buf, Char)
-    if c == '\n'
+    if s.key_repeats > 0
         move_input_end(s)
         return
     end
-    seek(buf, curpos)
-    pos = search(buffer(s).data, '\n', curpos+1)
+    pos = search(buffer(s).data, '\n', position(buf)+1)
     if pos == 0
         move_input_end(s)
         return

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1113,7 +1113,7 @@ function move_line_start(s::MIState)
     if s.key_repeats > 0
         move_input_start(s)
     else
-        seek(buf, rsearch(buf.data, '\n', curpos-1))
+        seek(buf, rsearch(buf.data, '\n', curpos))
     end
 end
 function move_line_end(s::MIState)

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -220,14 +220,13 @@ type LineEditREPL <: AbstractREPL
     in_shell::Bool
     in_help::Bool
     envcolors::Bool
-    consecutive_returns::Int
     waserror::Bool
     specialdisplay
     interface
     backendref::REPLBackendRef
     LineEditREPL(t,prompt_color,input_color,answer_color,shell_color,help_color,no_history_file,in_shell,in_help,envcolors) =
         new(t,prompt_color,input_color,answer_color,shell_color,help_color,no_history_file,in_shell,
-            in_help,envcolors,0,false,nothing)
+            in_help,envcolors,false,nothing)
 end
 outstream(r::LineEditREPL) = r.t
 specialdisplay(r::LineEditREPL) = r.specialdisplay
@@ -492,15 +491,9 @@ LineEdit.reset_state(hist::REPLHistoryProvider) = history_reset_state(hist)
 
 const julia_green = "\033[1m\033[32m"
 
-function return_callback(repl, s)
-    if position(s.input_buffer) != 0 && eof(s.input_buffer) &&
-        (seek(s.input_buffer, position(s.input_buffer)-1); read(s.input_buffer, Uint8) == '\n')
-        repl.consecutive_returns += 1
-    else
-        repl.consecutive_returns = 0
-    end
-    ast = parse_input_line(bytestring(s.input_buffer))
-    if repl.consecutive_returns > 1 || !isa(ast, Expr) || (ast.head != :continue && ast.head != :incomplete)
+function return_callback(s)
+    ast = parse_input_line(bytestring(LineEdit.buffer(s)))
+    if  !isa(ast, Expr) || (ast.head != :continue && ast.head != :incomplete)
         return true
     else
         return false
@@ -589,7 +582,7 @@ function setup_interface(repl::LineEditREPL; extra_repl_keymap = Dict{Any,Any}[]
         prompt_suffix = repl.envcolors ? Base.input_color() : repl.input_color,
         keymap_func_data = repl,
         complete = replc,
-        on_enter = s->return_callback(repl, s))
+        on_enter = return_callback)
 
     julia_prompt.on_done = respond(Base.parse_input_line, repl, julia_prompt)
 

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -161,3 +161,45 @@ let buf = IOBuffer()
     LineEdit.edit_transpose(buf)
     @test bytestring(buf.data[1:buf.size]) == "βγαδε"
 end
+
+let
+    term = Base.Terminals.FakeTerminal(IOBuffer(), IOBuffer(), IOBuffer())
+    s = LineEdit.init_state(term, Base.REPL.ModalInterface([Base.REPL.Prompt("test> ")]))
+    buf = LineEdit.buffer(s)
+
+    LineEdit.edit_insert(s,"first line\nsecond line\nthird line")
+    @test bytestring(buf.data[1:buf.size]) == "first line\nsecond line\nthird line"
+
+    ## edit_move_line_start/end ##
+    seek(buf, 0)
+    LineEdit.move_line_end(s)
+    @test position(buf) == sizeof("first line")
+    LineEdit.move_line_end(s) # Only move to input end on repeated keypresses
+    @test position(buf) == sizeof("first line")
+    s.key_repeats = 1 # Manually flag a repeated keypress
+    LineEdit.move_line_end(s)
+    s.key_repeats = 0
+    @test eof(buf)
+
+    seekend(buf)
+    LineEdit.move_line_start(s)
+    @test position(buf) == sizeof("first line\nsecond line\n")
+    LineEdit.move_line_start(s)
+    @test position(buf) == sizeof("first line\nsecond line\n")
+    s.key_repeats = 1 # Manually flag a repeated keypress
+    LineEdit.move_line_start(s)
+    s.key_repeats = 0
+    @test position(buf) == 0
+
+    ## edit_kill_line, edit_yank ##
+    seek(buf, 0)
+    LineEdit.edit_kill_line(s)
+    s.key_repeats = 1 # Manually flag a repeated keypress
+    LineEdit.edit_kill_line(s)
+    s.key_repeats = 0
+    @test bytestring(buf.data[1:buf.size]) == "second line\nthird line"
+    LineEdit.move_line_end(s)
+    LineEdit.edit_move_right(s)
+    LineEdit.edit_yank(s)
+    @test bytestring(buf.data[1:buf.size]) == "second line\nfirst line\nthird line"
+end


### PR DESCRIPTION
This PR enables the tracking of repeated consecutive keystrokes, and uses it in four places:
1. This supersedes the REPL's own counting of consecutive returns to abort an incomplete AST entry within its on_enter done-check with a more general implementation.  The on_enter functionality is very minutely different -- instead of checking for three consecutive newlines, this checks for three consecutive keystrokes that call the return callback (so, e.g., alternating between `^J` and return won't trigger this).  But for nearly all use-cases this behaves the same.
2. When the same keystroke is used to repeatedly call edit_kill (^K), the killed text is appended to the buffer instead of replacing it.
3. For tab completions, instead of the current complete-or-show-possible-completions behavior, this now requires a second consecutive tab press to show the possible completions. This behaves a little bit more like most shells, and prevents excessive printing of options in most cases.  I had thought that this would be necessary to incrementally complete the latex symbol names, but it turns out that it doesn't really require counting consecutive tabs and is orthogonal to this change, so I have split it out and will submit it separately.
4. In move_line_start/end (^A/^E), jump to the start/end of input upon a repeated keystroke instead of detecting that the cursor is already at the beginning or end of a line. This way the behavior changes based purely upon the input instead of relying on where the cursor happens to be.

Overall, this simplifies some logic (in 1 & 4) while allowing for more complex behaviors.

cc: @loladiro
