### PR TITLE
Incremental completion of latex symbols

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -170,7 +170,7 @@ function completions(string, pos)
     end
 
     slashpos = rsearch(string, '\\', pos)
-    if 0 <= rsearch(string, whitespace_chars, pos) < slashpos
+    if rsearch(string, whitespace_chars, pos) < slashpos
         # latex symbol substitution
         s = string[slashpos:pos]
         latex = get(latex_symbols, s, "")

--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -140,8 +140,9 @@ end
 
 include("latex_symbols.jl")
 
-const non_identifier_chars = [" \t\n\"\\'`\$><=:;|&{}()[],+-*/?%^~"...]
-const non_filename_chars = [" \t\n\"\\'`@\$><=;|&{("...]
+const non_identifier_chars = [" \t\n\r\"\\'`\$><=:;|&{}()[],+-*/?%^~"...]
+const non_filename_chars = [" \t\n\r\"\\'`@\$><=;|&{("...]
+const whitespace_chars = [" \t\n\r"...]
 
 # Aux function to detect whether we're right after a
 # using or import keyword
@@ -169,10 +170,17 @@ function completions(string, pos)
     end
 
     slashpos = rsearch(string, '\\', pos)
-    if slashpos > 0
-        latex = get(latex_symbols, string[slashpos:pos], "")
-        if !isempty(latex)
+    if 0 <= rsearch(string, whitespace_chars, pos) < slashpos
+        # latex symbol substitution
+        s = string[slashpos:pos]
+        latex = get(latex_symbols, s, "")
+        if !isempty(latex) # complete an exact match
             return [latex], slashpos:pos, true
+        else
+            # return possible matches; these cannot be mixed with regular
+            # Julian completions as only latex symbols contain the leading \
+            latex_names = filter(k -> beginswith(k, s), keys(latex_symbols))
+            return sort!(collect(latex_names)), slashpos:pos, true
         end
     end
 


### PR DESCRIPTION
If there is no whitespace between the nearest `\` and the cursor, try to complete a latex symbol or its name _instead_ of a Julian name.  This allows for interactive discovery of latex names, but whitespace is required for completion of a Julia name after a right-divide. Note that if these completions were instead _appended_ to the Julia options, they have to display without the leading `\`. I found that to be confusing when mixed in with the Julian names.

If the word matches a latex name exactly, it replaces it with the symbol. Otherwise, it attempts to complete the latex names. While there are some names that are prefixes to other names, I don't find this to be too jarring. It does effectively "shadow" the longer names, making them harder to discover.

cc: @stevengj
