### PR TITLE
Option for recursive rmdir

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1228,6 +1228,7 @@ export
     isfifo,
     isfile,
     islink,
+    isfileorlink,
     ispath,
     isreadable,
     issetgid,

--- a/base/file.jl
+++ b/base/file.jl
@@ -53,9 +53,9 @@ mkpath(path::String, mode::Signed) = error("mode must be an unsigned integer; tr
 
 function rmdir(path::String, recursive::Bool=false)
     if recursive
-        dir_contents = map(p -> joinpath(path, p), readdir(path))
-        for f=dir_contents
-            isfile(f) && rm(f) || rmdir(f, true)
+        for p=readdir(path)
+            p = joinpath(path, p)
+            isfile(p) && rm(p) || rmdir(p, true)
         end
     end
     @unix_only ret = ccall(:rmdir, Int32, (Ptr{Uint8},), bytestring(path))

--- a/base/file.jl
+++ b/base/file.jl
@@ -55,7 +55,7 @@ function rmdir(path::String, recursive::Bool=false)
     if recursive
         for p=readdir(path)
             p = joinpath(path, p)
-            isfileorlink(p) ? rm(p) : rmdir(p, true)(p)
+            isfileorlink(p) ? rm(p) : rmdir(p, true)
         end
     end
     @unix_only ret = ccall(:rmdir, Int32, (Ptr{Uint8},), bytestring(path))

--- a/base/file.jl
+++ b/base/file.jl
@@ -55,7 +55,7 @@ function rmdir(path::String, recursive::Bool=false)
     if recursive
         for p=readdir(path)
             p = joinpath(path, p)
-            isfile(p) && rm(p) || rmdir(p, true)
+            isfileorlink(p) ? rm(p) : rmdir(p, true)(p)
         end
     end
     @unix_only ret = ccall(:rmdir, Int32, (Ptr{Uint8},), bytestring(path))

--- a/base/file.jl
+++ b/base/file.jl
@@ -51,7 +51,13 @@ end
 mkdir(path::String, mode::Signed) = error("mode must be an unsigned integer; try 0o$mode")
 mkpath(path::String, mode::Signed) = error("mode must be an unsigned integer; try 0o$mode")
 
-function rmdir(path::String)
+function rmdir(path::String, recursive::Bool=false)
+    if recursive
+        dir_contents = map(p -> joinpath(path, p), readdir(path))
+        for f=dir_contents
+            isfile(f) && rm(f) || rmdir(f, true)
+        end
+    end
     @unix_only ret = ccall(:rmdir, Int32, (Ptr{Uint8},), bytestring(path))
     @windows_only ret = ccall(:_rmdir, Int32, (Ptr{Uint8},), bytestring(path))
     systemerror(:rmdir, ret != 0)

--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -33,7 +33,7 @@ function prefetch{S<:String}(pkg::String, url::String, sha1s::Vector{S})
         info("Cloning cache of $pkg from $url")
         try Git.run(`clone -q --mirror $url $cache`)
         catch
-            run(`rm -rf $cache`)
+            rmdir(cache, true)
             rethrow()
         end
     end

--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -45,7 +45,7 @@ function init(meta::String=DEFAULT_META, branch::String=META_BRANCH)
             run(`touch REQUIRE`)
         end
     catch e
-        run(`rm -rf $dir`)
+        rmdir(dir, true)
         rethrow(e)
     end
 end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -150,7 +150,7 @@ function clone(url::String, pkg::String)
         Git.run(`clone -q $url $pkg`)
         Git.set_remote_url(url, dir=pkg)
     catch
-        run(`rm -rf $pkg`)
+        rmdir(pkg)
         rethrow()
     end
     isempty(Reqs.parse("$pkg/REQUIRE")) && return

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -150,7 +150,7 @@ function clone(url::String, pkg::String)
         Git.run(`clone -q $url $pkg`)
         Git.set_remote_url(url, dir=pkg)
     catch
-        rmdir(pkg)
+        rmdir(pkg, true)
         rethrow()
     end
     isempty(Reqs.parse("$pkg/REQUIRE")) && return

--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -76,7 +76,7 @@ function package(
             end
         end
     catch
-        isnew && run(`rm -rf $pkg`)
+        isnew && rmdir(pkg, true)
         rethrow()
     end
 end

--- a/base/pkg/write.jl
+++ b/base/pkg/write.jl
@@ -39,7 +39,7 @@ end
 
 function remove(pkg::String)
     isdir(".trash") || mkdir(".trash")
-     ispath(".trash/$pkg") && rmdir(".trash/$pkg", true)
+    ispath(".trash/$pkg") && rmdir(".trash/$pkg", true)
     run(`mv $pkg .trash/`)
 end
 

--- a/base/pkg/write.jl
+++ b/base/pkg/write.jl
@@ -39,7 +39,7 @@ end
 
 function remove(pkg::String)
     isdir(".trash") || mkdir(".trash")
-    ispath(".trash/$pkg") && run(`rm -rf .trash/$pkg`)
+     ispath(".trash/$pkg") && rmdir(".trash/$pkg", true)
     run(`mv $pkg .trash/`)
 end
 

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -74,8 +74,8 @@ issetuid(st::StatStruct) = (st.mode & 0o4000) > 0
 issetgid(st::StatStruct) = (st.mode & 0o2000) > 0
 issticky(st::StatStruct) = (st.mode & 0o1000) > 0
 
-  isreadable(st::StatStruct) = (st.mode & 0o444) > 0
-  iswritable(st::StatStruct) = (st.mode & 0o222) > 0
+isreadable(st::StatStruct) = (st.mode & 0o444) > 0
+iswritable(st::StatStruct) = (st.mode & 0o222) > 0
 isexecutable(st::StatStruct) = (st.mode & 0o111) > 0
 
 uperm(st::StatStruct) = uint8(st.mode >> 6) & 0x7
@@ -108,6 +108,8 @@ for f in {
 end
 
 islink(path...) = islink(lstat(path...))
+isfileorlink(path...) = isfileorlink(lstat(path...))
+
 
 # some convenience functions
 

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -58,14 +58,15 @@ lstat(path...) = lstat(joinpath(path...))
 
 # mode type predicates
 
-    ispath(st::StatStruct) = st.mode & 0xf000 != 0x0000
-    isfifo(st::StatStruct) = st.mode & 0xf000 == 0x1000
- ischardev(st::StatStruct) = st.mode & 0xf000 == 0x2000
-     isdir(st::StatStruct) = st.mode & 0xf000 == 0x4000
-isblockdev(st::StatStruct) = st.mode & 0xf000 == 0x6000
-    isfile(st::StatStruct) = st.mode & 0xf000 == 0x8000
-    islink(st::StatStruct) = st.mode & 0xf000 == 0xa000
-  issocket(st::StatStruct) = st.mode & 0xf000 == 0xc000
+      ispath(st::StatStruct) = st.mode & 0xf000 != 0x0000
+      isfifo(st::StatStruct) = st.mode & 0xf000 == 0x1000
+   ischardev(st::StatStruct) = st.mode & 0xf000 == 0x2000
+       isdir(st::StatStruct) = st.mode & 0xf000 == 0x4000
+  isblockdev(st::StatStruct) = st.mode & 0xf000 == 0x6000
+      isfile(st::StatStruct) = st.mode & 0xf000 == 0x8000
+      islink(st::StatStruct) = st.mode & 0xf000 == 0xa000
+    issocket(st::StatStruct) = st.mode & 0xf000 == 0xc000
+isfileorlink(st::StatStruct) = st.mode & 0xd000 == 0x8000
 
 # mode permission predicates
 
@@ -91,6 +92,7 @@ for f in {
     :isblockdev
     :isfile
     :islink
+    :isfileorlink
     :issocket
     :issetuid
     :issetgid

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -5067,9 +5067,9 @@ System
    Create all directories in the given ``path``, with permissions ``mode``.
    ``mode`` defaults to 0o777, modified by the current file creation mask.
 
-.. function:: rmdir(path)
+.. function:: rmdir(path, [recursive=false])
 
-   Remove the directory named ``path``.
+   Remove the directory named ``path``. To remove a non-empty directory you must pass recursive true.
 
 .. function:: getpid() -> Int32
 

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -33,6 +33,10 @@ Filesystem
 
    Returns ``true`` if ``path`` is a symbolic link, ``false`` otherwise.
 
+.. function:: isfileorlink(path) -> Bool
+
+   Returns ``true`` if ``path`` is a regular file or a symbolic link, ``false`` otherwise.
+
 .. function:: ispath(path) -> Bool
 
    Returns ``true`` if ``path`` is a valid filesystem path, ``false`` otherwise.

--- a/test/file.jl
+++ b/test/file.jl
@@ -11,9 +11,11 @@ close(open(file,"w")) # like touch, but lets the operating system update the tim
 @test isdir(dir)
 @test !isfile(dir)
 @test !islink(dir)
+@test !isfileorlink(dir)
 @test !isdir(file)
 @test isfile(file)
 @test !islink(file)
+@test isfileorlink(file)
 @test isreadable(file)
 @test iswritable(file)
 # Here's something else that might be UNIX-specific?
@@ -37,6 +39,7 @@ newfile = joinpath(dir, "bfile.txt")
 mv(file, newfile)
 @test !ispath(file)
 @test isfile(newfile)
+@test isfileorlink(newfile)
 file = newfile
 
 # Test renaming directories
@@ -56,6 +59,21 @@ b_stat = stat(b_tmpdir)
 @test Base.samefile(a_stat, b_stat)
 
 rmdir(b_tmpdir)
+
+# rmdir recursive TODO add links
+c_tmpdir = mktempdir()
+c_subdir = joinpath(c_tmpdir, "c_subdir")
+mkdir(c_subdir)
+c_file = joinpath(c_tmpdir, "cfile.txt")
+cp(newfile, c_file)
+
+@test isdir(c_subdir)
+@test isfile(c_file)
+@test_throws rmdir(c_tmpdir)
+
+rmdir(c_tmpdir, true)
+@test !isdir(c_tmpdir)
+
 
 #######################################################################
 # This section tests file watchers.                                   #

--- a/test/git.jl
+++ b/test/git.jl
@@ -30,4 +30,4 @@ try cd(dir) do
     end
     git_verify(states[1:3]...)
 
-end finally run(`rm -rf $dir`) end
+end finally rmdir(dir, true) end

--- a/test/gitutils.jl
+++ b/test/gitutils.jl
@@ -91,7 +91,7 @@ function git_setup(h::Dict, i::Dict, w::Dict, parents::String...)
     # clear the repo
     for line in eachline(`ls -A`)
         name = chomp(line)
-        name == ".git" || run(`rm -rf $name`)
+        name == ".git" || rmdir(name, true)
     end
 
     # create the head commit

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -9,7 +9,7 @@ function temp_pkg_dir(fn::Function)
 
     fn()
   finally
-    run(`rm -rf $tmpdir`)
+    rmdir(tmpdir, true)
   end
 end
 


### PR DESCRIPTION
At the moment to `rm -rf` you need to shell out, with this:

```
julia> mkpath("foo/bar/baz.jl")

julia> rmdir("foo")
ERROR: rmdir: Directory not empty
 in rmdir at file.jl:63
 in rmdir at file.jl:55

julia> rmdir("foo", true) # rm -rf
```

see also #7046.
