### PR TITLE
readdlm has_header is now header, skipstart added

### DIFF
--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -2864,7 +2864,7 @@
 
 "),
 
-("Base","readdlm","readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap, ignore_invalid_chars=false, quotes=true, dims, comments=true, comment_char='#')
+("Base","readdlm","readdlm(source, delim::Char, T::Type, eol::Char; header=false, skipstart=0, use_mmap, ignore_invalid_chars=false, quotes=true, dims, comments=true, comment_char='#')
 
    Read a matrix from the source where each line (separated by
    \"eol\") gives one row, with elements separated by the given
@@ -2877,9 +2877,12 @@
    or zero. Other useful values of \"T\" include \"ASCIIString\",
    \"String\", and \"Any\".
 
-   If \"has_header\" is \"true\", the first row of data would be read
-   as headers and the tuple \"(data_cells, header_cells)\" is returned
+   If \"header\" is \"true\", the first row of data will be read
+   as header and the tuple \"(data_cells, header_cells)\" is returned
    instead of only \"data_cells\".
+
+   Specifying \"skipstart\" will ignore the corresponding number
+   of initial lines from the input.
 
    If \"use_mmap\" is \"true\", the file specified by \"source\" is
    memory mapped for potential speedups. Default is \"true\" except on

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1899,13 +1899,15 @@ Text I/O
 
    Create an iterable object that will yield each line from a stream.
 
-.. function:: readdlm(source, delim::Char, T::Type, eol::Char; has_header=false, use_mmap, ignore_invalid_chars=false, quotes=true, dims, comments=true, comment_char='#')
+.. function:: readdlm(source, delim::Char, T::Type, eol::Char; header=false, skipstart=0, use_mmap, ignore_invalid_chars=false, quotes=true, dims, comments=true, comment_char='#')
 
    Read a matrix from the source where each line (separated by ``eol``) gives one row, with elements separated by the given delimeter. The source can be a text file, stream or byte array. Memory mapped files can be used by passing the byte array representation of the mapped segment as source. 
 
    If ``T`` is a numeric type, the result is an array of that type, with any non-numeric elements as ``NaN`` for floating-point types, or zero. Other useful values of ``T`` include ``ASCIIString``, ``String``, and ``Any``.
 
-   If ``has_header`` is ``true``, the first row of data would be read as headers and the tuple ``(data_cells, header_cells)`` is returned instead of only ``data_cells``.
+   If ``header`` is ``true``, the first row of data will be read as header and the tuple ``(data_cells, header_cells)`` is returned instead of only ``data_cells``.
+
+   Specifying ``skipstart`` will ignore the corresponding number of initial lines from the input.
 
    If ``use_mmap`` is ``true``, the file specified by ``source`` is memory mapped for potential speedups. Default is ``true`` except on Windows. On Windows, you may want to specify ``true`` if the file is large, and is only read once and not written to.
 


### PR DESCRIPTION
fixes #6869
- `header` takes a boolean value and behaves like `has_header` or DataFrames `header` option.
- `skipstart` takes a positive integer value and behaves like DataFrames `skipstart` option.
