### PR TITLE
Further refactoring of reduce/mapreduce functions

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -30,13 +30,12 @@ isposdef(x::Number) = imag(x)==0 && real(x) > 0
 stride1(x::Array) = 1
 stride1(x::StridedVector) = stride(x, 1)::Int
 
-Base.sum_seq{T<:BlasFloat}(::Base.AbsFun, a::Union(Array{T},StridedVector{T}), ifirst::Int, ilast::Int) =
+import Base: mapreduce_seq_impl, AbsFun, Abs2Fun, AddFun
+
+mapreduce_seq_impl{T<:BlasFloat}(::AbsFun, ::AddFun, a::Union(Array{T},StridedVector{T}), ifirst::Int, ilast::Int) =
     BLAS.asum(ilast-ifirst+1, pointer(a, ifirst), stride1(a))
 
-# This appears to show a benefit from a larger block size
-Base.sum_pairwise_blocksize(::Base.Abs2Fun) = 4096
-
-function Base.sum_seq{T<:BlasFloat}(::Base.Abs2Fun, a::Union(Array{T},StridedVector{T}), ifirst::Int, ilast::Int)
+function mapreduce_seq_impl{T<:BlasFloat}(::Abs2Fun, ::AddFun, a::Union(Array{T},StridedVector{T}), ifirst::Int, ilast::Int)
     n = ilast-ifirst+1
     px = pointer(a, ifirst)
     incx = stride1(a)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -359,6 +359,45 @@ function extrema{T<:Real}(A::AbstractArray{T})
 end
 
 
+## all & any
+
+function all(itr)
+    for x in itr
+        if !x
+            return false
+        end
+    end
+    return true
+end
+
+function any(itr)
+    for x in itr
+        if x
+            return true
+        end
+    end
+    return false
+end
+
+function any(pred::Union(Function,Func{1}), itr)
+    for x in itr
+        if evaluate(pred, x)
+            return true
+        end
+    end
+    return false
+end
+
+function all(pred::Union(Function,Func{1}), itr)
+    for x in itr
+        if !evaluate(pred, x)
+            return false
+        end
+    end
+    return true
+end
+
+
 ## in & contains
 
 function in(x, itr)
@@ -421,42 +460,3 @@ function count(pred::Function, itr)
     end
     return n
 end
-
-## all & any
-
-function all(itr)
-    for x in itr
-        if !x
-            return false
-        end
-    end
-    return true
-end
-
-function any(itr)
-    for x in itr
-        if x
-            return true
-        end
-    end
-    return false
-end
-
-function any(pred::Union(Function,Func{1}), itr)
-    for x in itr
-        if pred(x)
-            return true
-        end
-    end
-    return false
-end
-
-function all(pred::Union(Function,Func{1}), itr)
-    for x in itr
-        if !pred(x)
-            return false
-        end
-    end
-    return true
-end
-

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -320,12 +320,12 @@ function extrema(itr)
     s = start(itr)
     done(itr, s) && error("argument is empty")
     (v, s) = next(itr, s)
-    vmin = v
-    vmax = v
     while v != v && !done(itr, s)
         (x, s) = next(itr, s)
         v = x
     end
+    vmin = v
+    vmax = v
     while !done(itr, s)
         (x, s) = next(itr, s)
         if x > vmax

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -322,45 +322,20 @@ function extrema(itr)
     (v, s) = next(itr, s)
     vmin = v
     vmax = v
+    while v != v && !done(itr, s)
+        (x, s) = next(itr, s)
+        v = x
+    end
     while !done(itr, s)
         (x, s) = next(itr, s)
-        if x == x
-            if x > vmax
-                vmax = x
-            elseif x < vmin
-                vmin = x
-            end
+        if x > vmax
+            vmax = x
+        elseif x < vmin
+            vmin = x
         end
     end
     return (vmin, vmax)
 end
-
-function extrema{T<:Real}(A::AbstractArray{T})
-    if isempty(A); error("argument must not be empty"); end
-    n = length(A)
-
-    # locate the first non NaN number
-    v = A[1]
-    i = 2
-    while v != v && i <= n
-        @inbounds v = A[i]
-        i += 1
-    end
-
-    vmin = v
-    vmax = v
-    while i <= n
-        @inbounds v = A[i]
-        if v > vmax
-            vmax = v
-        elseif v < vmin
-            vmin = v
-        end
-        i += 1
-    end
-    return (vmin, vmax)
-end
-
 
 ## all & any
 
@@ -455,11 +430,8 @@ end
 
 function count(pred::Union(Function,Func{1}), a::AbstractArray)
     n = 0
-    i = 0
-    len = length(a)
-    while i < len
-        @inbounds x = a[i+=1]
-        if evaluate(pred, x)
+    for i = 1:length(a)
+        @inbounds if evaluate(pred, a[i])
             n += 1
         end
     end

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -120,72 +120,20 @@ function mapreduce_pairwise_impl(f, op, A::AbstractArray, ifirst::Int, ilast::In
     end
 end
 
-mapreduce(f, op::Union(Function,Func{2}), itr) = mapfoldl(f, op, itr)
-mapreduce(f, op::Union(Function,Func{2}), v0, itr) = mapfoldl(f, op, v0, itr)
+mapreduce(f, op, itr) = mapfoldl(f, op, itr)
+mapreduce(f, op, v0, itr) = mapfoldl(f, op, v0, itr)
 
 # select different implementation depending on input arguments
-mapreduce_impl(f, op::Union(Function,Func{2}), A::AbstractArray) = mapreduce_seq_impl(f, op, A, 1, length(A))
+mapreduce_impl(f, op, A::AbstractArray) = mapreduce_seq_impl(f, op, A, 1, length(A))
 mapreduce_impl(f, op::AddFun, A::AbstractArray) = 
     mapreduce_pairwise_impl(f, op, A, 1, length(A), sum_pairwise_blocksize(f))
 
-function mapreduce(f, op::Union(Function,Func{2}), A::AbstractArray)
+function mapreduce(f, op, A::AbstractArray)
     n = length(A)
     n == 0 && error("Argument is empty.")
-    n == 1 && evaluate(f, A[1])
+    n == 1 && return evaluate(f, A[1])
     mapreduce_impl(f, op, A)
 end
-
-
-# function mapreduce(f::Callable, op::Callable, itr)
-#     s = start(itr)
-#     if done(itr, s)
-#         error("argument is empty")
-#     end
-#     (x, s) = next(itr, s)
-#     v = f(x)
-#     if done(itr, s)
-#         return v
-#     else # specialize for length > 1 to have a hopefully type-stable loop
-#         (x, s) = next(itr, s)
-#         result = op(v, f(x))
-#         while !done(itr, s)
-#             (x, s) = next(itr, s)
-#             result = op(result, f(x))
-#         end
-#         return result
-#     end
-# end
-
-function mapreduce(f::Callable, op::Callable, v0, itr)
-    v = v0
-    for x in itr
-        v = op(v,f(x))
-    end
-    return v
-end
-
-# # pairwise reduction, requires n > 1 (to allow type-stable loop)
-# function mr_pairwise(f::Callable, op::Callable, A::AbstractArray, i1,n)
-#     if n < 128
-#         @inbounds v = op(f(A[i1]), f(A[i1+1]))
-#         for i = i1+2:i1+n-1
-#             @inbounds v = op(v,f(A[i]))
-#         end
-#         return v
-#     else
-#         n2 = div(n,2)
-#         return op(mr_pairwise(f,op,A, i1,n2), mr_pairwise(f,op,A, i1+n2,n-n2))
-#     end
-# end
-# function mapreduce(f::Callable, op::Callable, A::AbstractArray)
-#     n = length(A)
-#     n == 0 ? error("argument is empty") : n == 1 ? f(A[1]) : mr_pairwise(f,op,A, 1,n)
-# end
-# function mapreduce(f::Callable, op::Callable, v0, A::AbstractArray)
-#     n = length(A)
-#     n == 0 ? v0 : n == 1 ? op(v0, f(A[1])) : op(v0, mr_pairwise(f,op,A, 1,n))
-# end
-
 
 reduce(op::Callable, v, itr) = foldl(op, v, itr)
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -169,7 +169,7 @@ end
 mapreduce(f, op, A::AbstractArray) = _mapreduce(f, op, A)
 mapreduce(f, op, a::Number) = evaluate(f, a)
 
-function mapreduce(f, op, A::AbstractArray)
+function mapreduce(f, op::Function, A::AbstractArray)
     is(op, +) ? _mapreduce(f, AddFun(), A) :
     is(op, *) ? _mapreduce(f, MulFun(), A) :
     is(op, &) ? _mapreduce(f, AndFun(), A) :

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -89,7 +89,7 @@ function mapfoldr_impl(f, op, v0, itr, i::Integer)
 end
 
 mapfoldr(f, op, v0, itr) = mapfoldr_impl(f, op, v0, itr, endof(itr))
-mapfoldr(f, op, itr) = (i = endof(itr); mapfoldr_impl(f, op, itr[i], itr, i-1))
+mapfoldr(f, op, itr) = (i = endof(itr); mapfoldr_impl(f, op, evaluate(f, itr[i]), itr, i-1))
 
 foldr(op, v0, itr) = mapfoldr(IdFun(), op, v0, itr)
 foldr(op, itr) = mapfoldr(IdFun(), op, itr)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -32,28 +32,28 @@ end
 @test sum(z) == sum(z,(1,2,3,4))[1] == 136
 
 # check variants of summation for type-stability and other issues (#6069)
-sum2(itr) = invoke(sum, (Any,), itr)
-plus(x,y) = x + y
-sum3(A) = reduce(plus, A)
-sum4(itr) = invoke(reduce, (Function, Any), plus, itr)
-sum5(A) = reduce(plus, 0, A)
-sum6(itr) = invoke(reduce, (Function, Int, Any), plus, 0, itr)
-sum7(A) = mapreduce(x->x, plus, A)
-sum8(itr) = invoke(mapreduce, (Function, Function, Any), x->x, plus, itr)
-sum9(A) = mapreduce(x->x, plus, 0, A)
-sum10(itr) = invoke(mapreduce, (Function, Function, Int, Any), x->x,plus,0,itr)
-for f in (sum2, sum5, sum6, sum9, sum10)
-    @test sum(z) == f(z)
-    @test sum(Int[]) == f(Int[]) == 0
-    @test sum(Int[7]) == f(Int[7]) == 7
-    @test typeof(f(Int8[])) == typeof(f(Int8[1])) == typeof(f(Int8[1 7]))
-end
-for f in (sum3, sum4, sum7, sum8)
-    @test sum(z) == f(z)
-    @test_throws ErrorException f(Int[])
-    @test sum(Int[7]) == f(Int[7]) == 7
-end
-@test typeof(sum(Int8[])) == typeof(sum(Int8[1])) == typeof(sum(Int8[1 7]))
+# sum2(itr) = invoke(sum, (Any,), itr)
+# plus(x,y) = x + y
+# sum3(A) = reduce(plus, A)
+# sum4(itr) = invoke(reduce, (Function, Any), plus, itr)
+# sum5(A) = reduce(plus, 0, A)
+# sum6(itr) = invoke(reduce, (Function, Int, Any), plus, 0, itr)
+# sum7(A) = mapreduce(x->x, plus, A)
+# sum8(itr) = invoke(mapreduce, (Function, Function, Any), x->x, plus, itr)
+# sum9(A) = mapreduce(x->x, plus, 0, A)
+# sum10(itr) = invoke(mapreduce, (Function, Function, Int, Any), x->x,plus,0,itr)
+# for f in (sum2, sum5, sum6, sum9, sum10)
+#     @test sum(z) == f(z)
+#     @test sum(Int[]) == f(Int[]) == 0
+#     @test sum(Int[7]) == f(Int[7]) == 7
+#     @test typeof(f(Int8[])) == typeof(f(Int8[1])) == typeof(f(Int8[1 7]))
+# end
+# for f in (sum3, sum4, sum7, sum8)
+#     @test sum(z) == f(z)
+#     @test_throws ErrorException f(Int[])
+#     @test sum(Int[7]) == f(Int[7]) == 7
+# end
+# @test typeof(sum(Int8[])) == typeof(sum(Int8[1])) == typeof(sum(Int8[1 7]))
 
 prod2(itr) = invoke(prod, (Any,), itr)
 @test prod(Int[]) == prod2(Int[]) == 1

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -1,18 +1,25 @@
 ## foldl & foldr
 
-# folds -- reduce.jl
-@test foldl(-,[1:5]) == -13
-@test foldl(-,10,[1:5]) == foldl(-,[10,1:5])
+# folds 
+@test foldl(-, 1:5) == -13
+@test foldl(-, 10, 1:5) == -5
 
-@test foldr(-,[1:5]) == 3
-@test foldr(-,10,[1:5]) == foldr(-,[1:5,10])
+@test Base.mapfoldl(abs2, -, 2:5) == -46
+@test Base.mapfoldl(abs2, -, 10, 2:5) == -44
 
-# reduce -- reduce.jl
+@test foldr(-, 1:5) == 3
+@test foldr(-, 10, 1:5) == -7
+
+@test Base.mapfoldr(abs2, -, 2:5) == -14
+@test Base.mapfoldr(abs2, -, 10, 2:5) == -4
+
+
+# reduce 
 @test reduce((x,y)->"($x+$y)", [9:11]) == "((9+10)+11)"
 @test reduce(max, [8 6 7 5 3 0 9]) == 9
 @test reduce(+, 1000, [1:5]) == (1000 + 1 + 2 + 3 + 4 + 5)
 
-# mapreduce -- reduce.jl
+# mapreduce 
 @test mapreduce(-, +, [-10 -9 -3]) == ((10 + 9) + 3)
 @test mapreduce((x)->x[1:3], (x,y)->"($x+$y)", ["abcd", "efgh", "01234"]) == "((abc+efg)+012)"
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -119,6 +119,10 @@ prod2(itr) = invoke(prod, (Any,), itr)
 @test isnan(minimum([NaN]))
 @test isequal(extrema([NaN]), (NaN, NaN))
 
+@test maximum([NaN, 2., 3.]) == 3.
+@test minimum([NaN, 2., 3.]) == 2.
+@test extrema([NaN, 2., 3.]) == (2., 3.)
+
 @test maximum([4., 3., NaN, 5., 2.]) == 5.
 @test minimum([4., 3., NaN, 5., 2.]) == 2.
 @test extrema([4., 3., NaN, 5., 2.]) == (2., 5.)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -166,6 +166,25 @@ prod2(itr) = invoke(prod, (Any,), itr)
 @test all(x->x>0, [4]) == true
 @test all(x->x>0, [-3, 4, 5]) == false
 
+# in
+
+@test in(1, Int[]) == false
+@test in(1, Int[1]) == true
+@test in(1, Int[2]) == false
+@test in(0, 1:3) == false
+@test in(1, 1:3) == true
+@test in(2, 1:3) == true
+
+# count & countnz
+
+@test count(x->x>0, Int[]) == 0
+@test count(x->x>0, -3:5) == 5
+
+@test countnz(Int[]) == 0
+@test countnz(Int[0]) == 0
+@test countnz(Int[1]) == 1
+@test countnz([1, 0, 2, 0, 3, 0, 4]) == 4
+
 
 ## cumsum, cummin, cummax
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -32,28 +32,28 @@ end
 @test sum(z) == sum(z,(1,2,3,4))[1] == 136
 
 # check variants of summation for type-stability and other issues (#6069)
-# sum2(itr) = invoke(sum, (Any,), itr)
-# plus(x,y) = x + y
-# sum3(A) = reduce(plus, A)
-# sum4(itr) = invoke(reduce, (Function, Any), plus, itr)
-# sum5(A) = reduce(plus, 0, A)
-# sum6(itr) = invoke(reduce, (Function, Int, Any), plus, 0, itr)
-# sum7(A) = mapreduce(x->x, plus, A)
-# sum8(itr) = invoke(mapreduce, (Function, Function, Any), x->x, plus, itr)
-# sum9(A) = mapreduce(x->x, plus, 0, A)
-# sum10(itr) = invoke(mapreduce, (Function, Function, Int, Any), x->x,plus,0,itr)
-# for f in (sum2, sum5, sum6, sum9, sum10)
-#     @test sum(z) == f(z)
-#     @test sum(Int[]) == f(Int[]) == 0
-#     @test sum(Int[7]) == f(Int[7]) == 7
-#     @test typeof(f(Int8[])) == typeof(f(Int8[1])) == typeof(f(Int8[1 7]))
-# end
-# for f in (sum3, sum4, sum7, sum8)
-#     @test sum(z) == f(z)
-#     @test_throws ErrorException f(Int[])
-#     @test sum(Int[7]) == f(Int[7]) == 7
-# end
-# @test typeof(sum(Int8[])) == typeof(sum(Int8[1])) == typeof(sum(Int8[1 7]))
+sum2(itr) = invoke(sum, (Any,), itr)
+plus(x,y) = x + y
+sum3(A) = reduce(plus, A)
+sum4(itr) = invoke(reduce, (Function, Any), plus, itr)
+sum5(A) = reduce(plus, 0, A)
+sum6(itr) = invoke(reduce, (Function, Int, Any), plus, 0, itr)
+sum7(A) = mapreduce(x->x, plus, A)
+sum8(itr) = invoke(mapreduce, (Function, Function, Any), x->x, plus, itr)
+sum9(A) = mapreduce(x->x, plus, 0, A)
+sum10(itr) = invoke(mapreduce, (Function, Function, Int, Any), x->x,plus,0,itr)
+for f in (sum2, sum5, sum6, sum9, sum10)
+    @test sum(z) == f(z)
+    @test sum(Int[]) == f(Int[]) == 0
+    @test sum(Int[7]) == f(Int[7]) == 7
+    @test typeof(f(Int8[])) == typeof(f(Int8[1])) == typeof(f(Int8[1 7]))
+end
+for f in (sum3, sum4, sum7, sum8)
+    @test sum(z) == f(z)
+    @test_throws ErrorException f(Int[])
+    @test sum(Int[7]) == f(Int[7]) == 7
+end
+@test typeof(sum(Int8[])) == typeof(sum(Int8[1])) == typeof(sum(Int8[1 7]))
 
 prod2(itr) = invoke(prod, (Any,), itr)
 @test prod(Int[]) == prod2(Int[]) == 1


### PR DESCRIPTION
Originally, reduce and mapreduce functions are not implemented in a coherent way. Similar algorithms are repeatedly implemented for different functions, resulting in inconsistent behaviors, subtle bugs, and higher maintenance cost. 

In this PR, we refactor the codebase for all these functions. The primary goal is to organize them into a coherent framework, without compromising flexibility and performance.

The core of this framework is the `mapreduce` function, defined as below:

``` julia
function _mapreduce{T}(f, op, A::AbstractArray{T})
    n = length(A)
    if n == 0
        return mr_empty(f, op, T)
    elseif n == 1
        return r_promote(op, evaluate(f, A[1]))
    elseif n < 16
        @inbounds fx1 = evaluate(f, A[1])
        @inbounds fx2 = evaluate(f, A[2])
        s = evaluate(op, fx1, fx2)
        i = 2
        while i < n
            @inbounds fx = evaluate(f, A[i+=1])
            s = evaluate(op, s, fx)
        end
        return s
    else
        return mapreduce_impl(f, op, A, 1, n)
    end
end

mapreduce(f, op, A::AbstractArray) = _mapreduce(f, op, A)
mapreduce(f, op, a::Number) = evaluate(f, a)

function mapreduce(f, op::Function, A::AbstractArray)
    is(op, +) ? _mapreduce(f, AddFun(), A) :
    is(op, *) ? _mapreduce(f, MulFun(), A) :
    is(op, &) ? _mapreduce(f, AndFun(), A) :
    is(op, |) ? _mapreduce(f, OrFun(), A) :
    _mapreduce(f, op, A)
end
```

The `mapreduce` function dispatches the actual operation depending on the length of the input array:
- `n = 0`: call `mr_empty` to handle empty array
- `n = 1`: call `r_promote` to promote the value, in order to attain type stability
- `2 <= n < 16`: use a simple loop to compute the result (since the array is small, it is not worth the efforts to call more sophisticated functions)
- `n >= 16`: call `mapreduce_impl` 

For different types of map-function `f` and reduce-operation `op`, one can specialize `mr_empty` to handle empty arrays differently (it raises an error by default), and specialize `mapreduce_impl` to implement faster or more accurate algorithms for certain operations.

For example, when `op` is of type `AddFun`, `mr_empty` returns zero whenever appropriate, and `mapreduce_impl` uses pairwise summation with four-way unrolling. In another example, when `op` is `AndFun` or `OrFun`, the `mapreduce_impl` uses an algorithm that may terminate earlier without scanning the whole array.

Other functions are merely one-liner that delegate to `mapreduce`:

``` julia
reduce(op, v0, itr) = mapreduce(IdFun(), op, v0, itr)
reduce(op, itr) = mapreduce(IdFun(), op, itr)
reduce(op, a::Number) = a

sum(f::Function, a) = mapreduce(f, AddFun(), a)
sum(a) = mapreduce(IdFun(), AddFun(), a)
sumabs(a) = mapreduce(AbsFun(), AddFun(), a)
sumabs2(a) = mapreduce(Abs2Fun(), AddFun(), a)

prod(f::Function, a) = mapreduce(f, MulFun(), a)
prod(a) = mapreduce(IdFun(), MulFun(), a)

# ......
```

In this way, consistent behavior is achieved. For example, the following statements actually invoke the same underlying algorithm:

``` julia
sum(x)
reduce(+, x)
reduce(AddFun(), x)
mapreduce(IdFun(), +, x)
...
```

With this refactoring, the source file `reduce.jl` is cut from _696_ lines to _444_ lines (a net loss of over _250_ lines).

The test script `test/reduce.jl` was also re-organized and expanded, which provides better coverage of these functions.

The refactoring pass all tests (including Steven's type stability tests).
