### PR TITLE
RFC: added simple integration methods to base: trapz,simps

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -945,6 +945,8 @@ export
 
 #   numerical integration
     quadgk,
+    trapz,
+    simps,
 
 # iteration
     done,

--- a/base/integrate.jl
+++ b/base/integrate.jl
@@ -1,88 +1,98 @@
 module Integrate
+    # some simple integration routines, mostly for tabulated data
     export trapz, simps
-    # simple integration routines, mostly for tabulated vector data
-    # There are notable interface differences with quadgk()
-    #  * these do does not return an error term
-    #  * these only return scalar values
-    
-    # trapezoidal function integration, probably not the most accurate 
-    # method for functions, but this method is included to aid testing 
+
+    # trapezoidal function integration, probably not the most accurate
+    # method for functions, but this method is included to aid testing
     # and provide comparisons with the vector versions
+    #
+    # unlike quadgk(), this does not return an error term, which
+    # is designed to mirror the vector integrations methods
     function trapz(f::Function, a, b, n=1)
         h = (b-a) / n
-        r = f(a) + f(b)
+        r = (f(a) + f(b))/2.0
         for i in 1:n-1
-            r += 2*f(i*h + a)
+            r += f(i*h + a)
         end
-        r * h / 2
+        r * h
     end
 
-    # vector integration for uniform points (in x)
-    function trapz{T<:Number}(y::Vector{T}, dx=one(T))
-        r = zero(zero(T)*zero(T))
-        for i in 2:length(y)
-            r += y[i] + y[i-1]
-        end
-        r * dx /2.0
+    # integration for uniform points (in x)
+    function trapz{T <: Number}(y::Vector{T}, dx=one(T))
+        r = zero(zero(eltype(y)) * zero(dx))
+        r = (y[1] + y[end])/2
+        r += sum(y[2:end-1])
+        r * dx
     end
 
-    # vector integration for non-uniform points (in x)
-    function trapz{T<:Number}(y::Vector{T}, x::Vector{T})
+    # integration for non-uniform points (in x)
+    function trapz{T <: Number}(y::Vector{T}, x::Vector{T})
         n = length(y)
         if n != length(x)
-            error("Vectors must be of same length")
+            error("Input x,y must be of same length")
         end
-        r = zero(zero(T)*zero(T))
+        r = zero(zero(eltype(x))*zero(eltype(y)))
         for i in 2:n
             r += (x[i] - x[i-1]) * (y[i] + y[i-1])
         end
         r/2.0
     end
 
-    # some simpson rules for more simple integration
+    # simpson rules for more simple integration
     function simps(f::Function, a, b, n=2)
         h = (b-a) / n
-        r = f(a) + f(b)
-        for i in 2:2:n-1
-            r += 2*f(i*h + a)
-        end
+        r = zero(zero(a)*zero(f(a)))
         for i in 1:2:n
-            r += 4*f(i*h + a)
+            r += f(i*h + a)
         end
-        r * h / 3
+        r *= 2
+        for i in 2:2:n-1
+            r += f(i*h + a)
+        end
+        r *= 2
+        r += f(a) + f(b)
+        r * h / 3.0
     end
 
-    function simps{T<:Number}(y::Vector{T}, dx=one(T))
-        n = length(y) 
-        if iseven(n) 
+    function simps{T <: Number}(y::Vector{T}, dx=one(T))
+        n = length(y)
+        if iseven(n)
             error("Simpson rule requires ODD length input (EVEN number of intervals)")
         end
-        r = zero(zero(T)*zero(T))
-        for i in 3:2:n
-            r += (y[i-2] + 4*y[i-1] + y[i])
+        r = zero(zero(eltype(y))*zero(dx))
+        for i in 2:2:n-1
+            r += y[i]
+        end
+        r *= 2.0
+        for i in 3:2:n-2
+            r += y[i]
+        end
+        r *= 2.0
+        for i in (1,n)
+            r += y[i]
         end
         r * dx / 3.0
     end
 
-    function simps{T<:Number}(y::Vector{T}, x::Vector{T})
+    function simps{T <: Number}(y::Vector{T}, x::Vector{T})
         n = length(y)
         if n != length(x)
-            error("Vectors must be of same length")
+            error("Input x,y must be of same length")
         end
-        if iseven(n) 
+        if iseven(n)
             error("Simpson rule requires ODD length input (EVEN number of intervals)")
         end
 
-        # this is a quick generalization of the simpson's rule for 
+        # this is a quick generalization of the simpson's rule for
         # arbitrary separations in x
-        r = zero(zero(T)*zero(T))
+        r = zero(zero(eltype(y))*zero(eltype(x)))
         for i in 3:2:n
-            d1 = x[i-1] - x[i-2] 
-            d2 = x[i] - x[i-1] 
+            d1 = x[i-1] - x[i-2]
+            d2 = x[i] - x[i-1]
             h = x[i] - x[i-2]
-            r += h * ( 
-                    y[i-2] * (2 - d2 / d1) + 
-                    y[i-1] * h * h / (d1 * d2) + 
+            r += h * (
+                    y[i-2] * (2 - d2 / d1) +
+                    y[i-1] * h * h / (d1 * d2) +
                     y[i] * (2 - d1 / d2)
                 )
         end

--- a/base/integrate.jl
+++ b/base/integrate.jl
@@ -1,0 +1,92 @@
+module Integrate
+    export trapz, simps
+    # simple integration routines, mostly for tabulated vector data
+    # There are notable interface differences with quadgk()
+    #  * these do does not return an error term
+    #  * these only return scalar values
+    
+    # trapezoidal function integration, probably not the most accurate 
+    # method for functions, but this method is included to aid testing 
+    # and provide comparisons with the vector versions
+    function trapz(f::Function, a, b, n=1)
+        h = (b-a) / n
+        r = f(a) + f(b)
+        for i in 1:n-1
+            r += 2*f(i*h + a)
+        end
+        r * h / 2
+    end
+
+    # vector integration for uniform points (in x)
+    function trapz{T<:Number}(y::Vector{T}, dx=one(T))
+        r = zero(zero(T)*zero(T))
+        for i in 2:length(y)
+            r += y[i] + y[i-1]
+        end
+        r * dx /2.0
+    end
+
+    # vector integration for non-uniform points (in x)
+    function trapz{T<:Number}(y::Vector{T}, x::Vector{T})
+        n = length(y)
+        if n != length(x)
+            error("Vectors must be of same length")
+        end
+        r = zero(zero(T)*zero(T))
+        for i in 2:n
+            r += (x[i] - x[i-1]) * (y[i] + y[i-1])
+        end
+        r/2.0
+    end
+
+    # some simpson rules for more simple integration
+    function simps(f::Function, a, b, n=2)
+        h = (b-a) / n
+        r = f(a) + f(b)
+        for i in 2:2:n-1
+            r += 2*f(i*h + a)
+        end
+        for i in 1:2:n
+            r += 4*f(i*h + a)
+        end
+        r * h / 3
+    end
+
+    function simps{T<:Number}(y::Vector{T}, dx=one(T))
+        n = length(y) 
+        if iseven(n) 
+            error("Simpson rule requires ODD length input (EVEN number of intervals)")
+        end
+        r = zero(zero(T)*zero(T))
+        for i in 3:2:n
+            r += (y[i-2] + 4*y[i-1] + y[i])
+        end
+        r * dx / 3.0
+    end
+
+    function simps{T<:Number}(y::Vector{T}, x::Vector{T})
+        n = length(y)
+        if n != length(x)
+            error("Vectors must be of same length")
+        end
+        if iseven(n) 
+            error("Simpson rule requires ODD length input (EVEN number of intervals)")
+        end
+
+        # this is a quick generalization of the simpson's rule for 
+        # arbitrary separations in x
+        r = zero(zero(T)*zero(T))
+        for i in 3:2:n
+            d1 = x[i-1] - x[i-2] 
+            d2 = x[i] - x[i-1] 
+            h = x[i] - x[i-2]
+            r += h * ( 
+                    y[i-2] * (2 - d2 / d1) + 
+                    y[i-1] * h * h / (d1 * d2) + 
+                    y[i] * (2 - d1 / d2)
+                )
+        end
+        r / 6.0
+    end
+
+end

--- a/base/integrate.jl
+++ b/base/integrate.jl
@@ -1,32 +1,21 @@
 module Integrate
-    # some simple integration routines, mostly for tabulated data
+    # simple integration routines mostly for tabulated data
     export trapz, simps
 
-    # trapezoidal function integration, probably not the most accurate
-    # method for functions, but this method is included to aid testing
-    # and provide comparisons with the vector versions
-    #
-    # unlike quadgk(), this does not return an error term, which
-    # is designed to mirror the vector integrations methods
-    function trapz(f::Function, a, b, n=1)
-        h = (b-a) / n
-        r = (f(a) + f(b))/2.0
-        for i in 1:n-1
-            r += f(i*h + a)
-        end
-        r * h
+    function trapz(y)
+        trapz(y, one(eltype(y)))
     end
 
     # integration for uniform points (in x)
-    function trapz{T <: Number}(y::Vector{T}, dx=one(T))
+    function trapz(y, dx::Number)
         r = zero(zero(eltype(y)) * zero(dx))
-        r = (y[1] + y[end])/2
+        r += (y[1] + y[end])/2
         r += sum(y[2:end-1])
         r * dx
     end
 
     # integration for non-uniform points (in x)
-    function trapz{T <: Number}(y::Vector{T}, x::Vector{T})
+    function trapz(y,x)
         n = length(y)
         if n != length(x)
             error("Input x,y must be of same length")
@@ -38,23 +27,11 @@ module Integrate
         r/2.0
     end
 
-    # simpson rules for more simple integration
-    function simps(f::Function, a, b, n=2)
-        h = (b-a) / n
-        r = zero(zero(a)*zero(f(a)))
-        for i in 1:2:n
-            r += f(i*h + a)
-        end
-        r *= 2
-        for i in 2:2:n-1
-            r += f(i*h + a)
-        end
-        r *= 2
-        r += f(a) + f(b)
-        r * h / 3.0
+    function simps(y)
+        simps(y, one(eltype(y)))
     end
 
-    function simps{T <: Number}(y::Vector{T}, dx=one(T))
+    function simps(y, dx::Number)
         n = length(y)
         if iseven(n)
             error("Simpson rule requires ODD length input (EVEN number of intervals)")
@@ -74,7 +51,7 @@ module Integrate
         r * dx / 3.0
     end
 
-    function simps{T <: Number}(y::Vector{T}, x::Vector{T})
+    function simps(y,x)
         n = length(y)
         if n != length(x)
             error("Input x,y must be of same length")
@@ -85,7 +62,7 @@ module Integrate
 
         # this is a quick generalization of the simpson's rule for
         # arbitrary separations in x
-        r = zero(zero(eltype(y))*zero(eltype(x)))
+        r = zero(zero(eltype(x))*zero(eltype(y)))
         for i in 3:2:n
             d1 = x[i-1] - x[i-2]
             d2 = x[i] - x[i-1]

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -248,6 +248,8 @@ include("constants.jl")
 # Numerical integration
 include("quadgk.jl")
 importall .QuadGK
+include("integrate.jl")
+importall .Integrate
 
 # deprecated functions
 include("deprecated.jl")

--- a/test/math.jl
+++ b/test/math.jl
@@ -219,27 +219,18 @@ end
 @test_approx_eq quadgk(cos, 0,0.7,1, norm=abs)[1] sin(1)
 
 # simple integration: trapz, simps
-# first test functional accuracy
-@test_approx_eq trapz(x -> 3x, 0.5,1)  3/2*(1 - 0.5^2) 
-@test_approx_eq trapz(x -> x, 0,5,100) (5^2)/2
-@test_approx_eq simps(x -> 4.5x^2, 1, 2)  4.5/3*(2^3 - 1)
-@test_approx_eq_eps trapz(cos,BigFloat(0),BigFloat(1),100) sin(BigFloat(1)) 1e-5
-@test_approx_eq_eps simps(cos,BigFloat(0),BigFloat(1),100) sin(BigFloat(1)) 1e-10
+@test_approx_eq trapz([1:9])  (9^2 - 1)/2
+@test_approx_eq simps(4.5*[1:0.1:2].^2, 0.1)  4.5/3*(2^3 - 1)
 # now test consistency between methods
-function test_integrate(f::Function, a, b, n, fint::Function)
-    x = linspace(a,b,n+1)
+for (fint,a,b,n,f) in [ (trapz, 1,  2, 10, x->2x), 
+                        (simps, 1, 11, 20, x->3x^2) ] 
     dx = (b - a) / n
+    x = [a:dx:b]
     y = map(f,x)
-    res = fint(f,a,b,n)
-    # test scalar dx, y-vector version
-    @test_approx_eq res fint(y,dx)
-    # test x-,y- vector version
-    @test_approx_eq res fint(y,x)
+    @test_approx_eq fint(y,dx) fint(y,x)
 end
-test_integrate(x->x, 1,2,10, trapz)
-test_integrate(x->x^2, 1,2,10, simps)
 # test unequal spacings for vector input
-@test_approx_eq simps([3,192,243], [1,8,9]) (9^3 - 1)
+@test_approx_eq simps(3*[1,8,9].^2, [1,8,9]) (9^3 - 1)
 @test_approx_eq trapz([1,8,9], [1,8,9]) (9^2 - 1)/2
 
 # Ensure subnormal flags functions don't segfault


### PR DESCRIPTION
This adds trapezoidal and simpson integration methods to base,
mostly to address integration of tabulated (vector) input.
Versions that take function input are included for comparison.
Some tests are included for accuracy and consistency between
the methods.

The method names following simplification to match quadgk(), and 
also match the respective Numpy versions.
