### PR TITLE
Implement corner cases for partitions

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -443,7 +443,7 @@ length(p::SetPartitions) = nsetpartitions(length(p.s))
 partitions(s::AbstractVector) = SetPartitions(s)
 
 start(p::SetPartitions) = (n = length(p.s); (zeros(Int32, n), ones(Int32, n-1), n, 1))
-done(p::SetPartitions, s) = !isempty(s) && s[1][1] > 0
+done(p::SetPartitions, s) = s[1][1] > 0
 next(p::SetPartitions, s) = nextsetpartition(p.s, s...)
 
 function nextsetpartition(s::AbstractVector, a, b, n, m)

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -565,7 +565,7 @@ function nfixedsetpartitions(n::Int,m::Int)
 end
 
 
-# For a list of integers i1, i2, i3, find the smallest 
+# For a list of integers i1, i2, i3, find the smallest
 #     i1^n1 * i2^n2 * i3^n3 >= x
 # for integer n1, n2, n3
 function nextprod(a::Vector{Int}, x)
@@ -579,7 +579,7 @@ function nextprod(a::Vector{Int}, x)
     p::widen(Int) = mx[1]             # initial value of product in this case
     best = p
     icarry = 1
-    
+
     while v[end] < mx[end]
         if p >= x
             best = p < best ? p : best  # keep the best found yet
@@ -621,7 +621,7 @@ function prevprod(a::Vector{Int}, x)
     p::widen(Int) = first
     best = p
     icarry = 1
-    
+
     while v[end] < mx[end]
         while p <= x
             best = p > best ? p : best

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -15,8 +15,12 @@ a = randcycle(10)
 @test collect(filter(x->(iseven(x[1])),combinations([1,2,3],2))) == {[2,3]}
 @test collect(partitions(4)) ==  {[4], [3,1], [2,2], [2,1,1], [1,1,1,1]}
 @test collect(partitions(8,3)) == {[6,1,1], [5,2,1], [4,3,1], [4,2,2], [3,3,2]}
+@test collect(partitions(8, 1)) == {[8]}
+@test collect(partitions(8, 9)) == {}
 @test collect(partitions([1,2,3])) == {{[1,2,3]}, {[1,2],[3]}, {[1,3],[2]}, {[1],[2,3]}, {[1],[2],[3]}}
 @test collect(partitions([1,2,3,4],3)) == {{[1,2],[3],[4]}, {[1,3],[2],[4]}, {[1],[2,3],[4]}, {[1,4],[2],[3]}, {[1],[2,4],[3]},{[1],[2],[3,4]}}
+@test collect(partitions([1,2,3,4],1)) == {{[1, 2, 3, 4]}}
+@test collect(partitions([1,2,3,4],5)) == {}
 
 @test length(collect(partitions(30))) == length(partitions(30))
 @test length(collect(partitions(90,4))) == length(partitions(90,4))

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -32,7 +32,7 @@ end
 #Issue 6154
 @test binomial(int32(34), int32(15)) == binomial(BigInt(34), BigInt(15)) == 1855967520
 @test binomial(int64(67), int64(29)) == binomial(BigInt(67), BigInt(29)) == 7886597962249166160
-@test binomial(int128(131), int128(62)) == binomial(BigInt(131), BigInt(62)) == 157311720980559117816198361912717812000 
+@test binomial(int128(131), int128(62)) == binomial(BigInt(131), BigInt(62)) == 157311720980559117816198361912717812000
 
 # issue #6579
 @test factorial(0) == 1


### PR DESCRIPTION
This PR implements `partitions(n, m)` for the case where `n = 1`  and the case where `m > n`, as well as the analogous situation for `partitions(v::AbstractVector, m)`.

New behavior:

```
julia> collect(partitions(5, 1))
1-element Array{Any,1}:
 [5]

julia> collect(partitions(5, 10))
0-element Array{Any,1}

julia> collect(partitions([1,2], 1))
1-element Array{Any,1}:
 [[1,2]]

julia> collect(partitions([1,2], 3))
0-element Array{Any,1}
```
