### PR TITLE
inline inexact method matches, repeated

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2298,7 +2298,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             end
         end
         free = effect_free(aei,sv,true)
-        if ((occ==0 && is(aeitype,None)) || islocal || (occ > 1 && !inline_worthy(aei, occ)) ||
+        if ((occ==0 && is(aeitype,None)) || islocal || (occ > 1 && !inline_worthy(aei, occ*2)) ||
                 (affect_free && !free) || (!affect_free && !effect_free(aei,sv,false)))
             if occ != 0 # islocal=true is implied by occ!=0
                 vnew = unique_name(enclosing_ast, ast)
@@ -2401,14 +2401,14 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
 end
 
 inline_worthy(body, cost::Real) = true
-function inline_worthy(body::Expr, cost::Real=1) # precondition: 0<cost
+function inline_worthy(body::Expr, cost::Real=1.0) # precondition: 0<cost
 #    if isa(body.args[1],QuoteNode) && (body.args[1]::QuoteNode).value === :inline
 #        shift!(body.args)
 #        return true
 #    end
-    symlim = int(5/cost)+1
+    symlim = 1+5/cost
     if length(body.args) < symlim
-        symlim *= 6
+        symlim *= 16
         if occurs_more(body, e->true, symlim) < symlim
             return true
         end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2401,12 +2401,12 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
 end
 
 inline_worthy(body, cost::Real) = true
-function inline_worthy(body::Expr, cost::Real=1) # 0 < occurrences <= 6
+function inline_worthy(body::Expr, cost::Real=1) # precondition: 0<cost
 #    if isa(body.args[1],QuoteNode) && (body.args[1]::QuoteNode).value === :inline
 #        shift!(body.args)
 #        return true
 #    end
-    symlim = iceil(6/cost)
+    symlim = int(5/cost)+1
     if length(body.args) < symlim
         symlim *= 6
         if occurs_more(body, e->true, symlim) < symlim

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1925,40 +1925,29 @@ function effect_free(e::ANY, sv, allow_volatile::Bool)
                                 return false
                             end
                         end
-                    end
-                else
-                    # arguments must also be effect_free
-                    for a in ea
-                        if !effect_free(a,sv,allow_volatile)
-                            return false
-                        end
+                        return true
                     end
                 end
-                return true
             end
         elseif e.head === :new
-            first = !allow_volatile
-            for a in ea
-                if first
-                    first = false
-                    typ = exprtype(a)
-                    if !isType(typ) || !isa((typ::Type).parameters[1],DataType) || ((typ::Type).parameters[1]::DataType).mutable
-                        return false
-                    end
-                end
-                if !effect_free(a,sv,allow_volatile)
+            if !allow_volatile
+                a = ea[1]
+                typ = exprtype(a)
+                if !isType(typ) || !isa((typ::Type).parameters[1],DataType) || ((typ::Type).parameters[1]::DataType).mutable
                     return false
                 end
             end
-            return true
         elseif e.head === :return
-            for a in ea
-                if !effect_free(a,sv,allow_volatile)
-                    return false
-                end
-            end
-            return true
+            # pass
+        else
+            return false
         end
+        for a in ea
+            if !effect_free(a,sv,allow_volatile)
+                return false
+            end
+        end
+        return true
     end
     return false
 end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2124,7 +2124,15 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
             argexprs = {argexprs[1:(na-1)]..., vararg}
             isva = true
         end
+    elseif na != length(argexprs)
+        # we have a method match only because an earlier
+        # inference step shortened our call args list, even
+        # though we have too many arguments to actually
+        # call this function
+        @assert isvarargtype(atypes[na])
+        return NF
     end
+
     @assert na == length(argexprs)
 
     if needcopy

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2304,7 +2304,7 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
                 vnew = unique_name(enclosing_ast, ast)
                 add_variable(enclosing_ast, vnew, aeitype, !islocal)
                 unshift!(stmts, Expr(:(=), vnew, aei))
-                argexprs[i] = argtype===Any ? vnew : SymbolNode(vnew,aeitype)
+                argexprs[i] = aeitype===Any ? vnew : SymbolNode(vnew,aeitype)
                 stmts_free &= free
             elseif !free && !isType(aeitype)
                 unshift!(stmts, aei)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1928,6 +1928,9 @@ function effect_free(e::ANY, sv, allow_volatile::Bool)
                         return true
                     end
                 end
+                # fall-through
+            else
+                return false
             end
         elseif e.head === :new
             if !allow_volatile
@@ -1937,8 +1940,9 @@ function effect_free(e::ANY, sv, allow_volatile::Bool)
                     return false
                 end
             end
+            # fall-through
         elseif e.head === :return
-            # pass
+            # fall-through
         else
             return false
         end
@@ -2252,11 +2256,11 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
                     end
                 end
             end
-            if isa(methitype,TypeVar) # eliminate ANY
+            if isa(methitype, TypeVar)
                 methitype = methitype.ub
             end
             if !(aeitype <: methitype)
-                #TODO: make Undef a faster special-case
+                #TODO: make Undef a faster special-case?
                 needtypeassert = true
                 aeitype = methitype
             end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2039,13 +2039,6 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     #     end
     # end
 
-    # Undef is a bad type
-    for ty in atypes
-        if Undef <: ty
-            return NF
-        end
-    end
-
     if !isa(linfo,LambdaStaticData) || meth[3].func.env !== ()
         return NF
     end
@@ -2170,7 +2163,10 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
     # when 1 method matches the inferred types, there is still a chance
     # of a no-method error at run time, unless the inferred types are a
     # subset of the method signature.
-    if !(atypes <: meth[1])
+    methargs = meth[1]
+    nm = length(methargs)
+    if !(atypes <: methargs)
+        incompletematch = true
         t = Expr(:call) # tuple(argexprs...)
         t.typ = Tuple
         argexprs2 = t.args
@@ -2181,20 +2177,14 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
         thrw.typ = None
         push!(stmts, thrw)
         push!(stmts, icall)
-        incompletematch = true
     else
         incompletematch = false
     end
-    methargs = meth[1]
-    nm = length(methargs)
 
     for i=na:-1:1 # stmts_free needs to be calculated in reverse-argument order
         a = args[i]
         aei = argexprs[i]
         aeitype = argtype = exprtype(aei)
-        if aeitype == ANY
-            aeitype = Any
-        end
         needtypeassert = false
         if incompletematch
             if isva
@@ -2222,6 +2212,9 @@ function inlineable(f, e::Expr, atypes, sv, enclosing_ast)
                         @assert i==nm
                     end
                 end
+            end
+            if isa(methitype,TypeVar) # eliminate ANY
+                methitype = methitype.ub
             end
             if !(aeitype <: methitype)
                 needtypeassert = true

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1188,7 +1188,9 @@ DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v)
         n += jl_static_show(out, ((jl_typector_t*)v)->body);
     }
     else if (jl_is_typevar(v)) {
-        n += JL_PRINTF(out, "%s", ((jl_tvar_t*)v)->name->name);
+        n += jl_static_show(out, ((jl_tvar_t*)v)->lb);
+        n += JL_PRINTF(out, "<:%s<:", ((jl_tvar_t*)v)->name->name);
+        n += jl_static_show(out, ((jl_tvar_t*)v)->ub);
     }
     else if (jl_is_module(v)) {
         jl_module_t *m = (jl_module_t*)v;


### PR DESCRIPTION
continuation of #6677. that one got closed because I was merging into the printf2 branch, and it merged into master

this inserts a MethodError based on the argument types of the only matching function, then inlines the function, or it's call site, for the exact method match
