### PR TITLE
Separate types for LU and LUTridiagonal.

### DIFF
--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -1489,7 +1489,7 @@ for (gtsv, gttrf, gttrs, elty) in
                    Ptr{BlasInt}, Ptr{BlasInt}),
                   &n, dl, d, du, du2, ipiv, info)
             @lapackerror
-            dl, d, du, du2, ipiv
+            dl, d, du, du2, ipiv, info[1]
         end
         #       SUBROUTINE DGTTRS( TRANS, N, NRHS, DL, D, DU, DU2, IPIV, B, LDB, INFO )
         #       .. Scalar Arguments ..


### PR DESCRIPTION
Also removes redundant `du2` vector from `Tridiagonal` type. This makes `LU` more consistent with other `Factorization` types.

cc: @andreasnoackjensen
