### PR TITLE
WIP: Boundschecks for searchsorted & remove step(r::Range)==0 tests

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -125,6 +125,7 @@ select(v::AbstractVector, k::Union(Int,OrdinalRange); kws...) = select!(copy(v),
 # index of the first value of vector a that is greater than or equal to x;
 # returns length(v)+1 if x is greater than all values in v.
 function searchsortedfirst(v::AbstractVector, x, lo::Int, hi::Int, o::Ordering)
+    1 <= lo <= hi <= length(v) || throw(BoundsError())
     lo = lo-1
     hi = hi+1
     @inbounds while lo < hi-1
@@ -141,6 +142,7 @@ end
 # index of the last value of vector a that is less than or equal to x;
 # returns 0 if x is less than all values of v.
 function searchsortedlast(v::AbstractVector, x, lo::Int, hi::Int, o::Ordering)
+    1 <= lo <= hi <= length(v) || throw(BoundsError())
     lo = lo-1
     hi = hi+1
     @inbounds while lo < hi-1
@@ -158,6 +160,7 @@ end
 # if v does not contain x, returns a 0-length range
 # indicating the insertion point of x
 function searchsorted(v::AbstractVector, x, lo::Int, hi::Int, o::Ordering)
+    1 <= lo <= hi <= length(v) || throw(BoundsError())
     lo = lo-1
     hi = hi+1
     @inbounds while lo < hi-1
@@ -176,37 +179,21 @@ function searchsorted(v::AbstractVector, x, lo::Int, hi::Int, o::Ordering)
 end
 
 function searchsortedlast{T<:Real}(a::Range{T}, x::Real, o::DirectOrdering)
-    if step(a) == 0
-        lt(o, x, first(a)) ? 0 : length(a)
-    else
-        n = max(min(iround((x-first(a))/step(a))+1,length(a)),1)
-        lt(o, x, a[n]) ? n-1 : n
-    end
+    n = max(min(iround((x-first(a))/step(a))+1,length(a)),1)
+    lt(o, x, a[n]) ? n-1 : n
 end
 
 function searchsortedfirst{T<:Real}(a::Range{T}, x::Real, o::DirectOrdering)
-    if step(a) == 0
-        lt(o, first(a), x) ? length(a)+1 : 1
-    else
-        n = max(min(iround((x-first(a))/step(a))+1,length(a)),1)
-        lt(o, a[n] ,x) ? n+1 : n
-    end
+    n = max(min(iround((x-first(a))/step(a))+1,length(a)),1)
+    lt(o, a[n] ,x) ? n+1 : n
 end
 
 function searchsortedlast{T<:Integer}(a::Range{T}, x::Real, o::DirectOrdering)
-    if step(a) == 0
-        lt(o, x, first(a)) ? 0 : length(a)
-    else
-        max(min(fld(ifloor(x)-first(a),step(a))+1,length(a)),0)
-    end
+    max(min(fld(ifloor(x)-first(a),step(a))+1,length(a)),0)
 end
 
 function searchsortedfirst{T<:Integer}(a::Range{T}, x::Real, o::DirectOrdering)
-    if step(a) == 0
-        lt(o, first(a), x) ? length(a)+1 : 1
-    else
-        max(min(-fld(ifloor(-x)+first(a),step(a))+1,length(a)+1),1)
-    end
+    max(min(-fld(ifloor(-x)+first(a),step(a))+1,length(a)+1),1)
 end
 
 searchsorted{T<:Real}(a::Range{T}, x::Real, o::DirectOrdering) =

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -50,6 +50,10 @@ end
 @test searchsorted(1:10, 1, by=(x -> x >= 5)) == searchsorted([1:10], 1, by=(x -> x >= 5))
 @test searchsorted(1:10, 10, by=(x -> x >= 5)) == searchsorted([1:10], 10, by=(x -> x >= 5))
 
+@test_throws BoundsError searchsortedfirst(1:10, 5,  0, 7, Base.Order.Forward)
+@test_throws BoundsError searchsortedfirst(1:10, 5,  1, 11, Base.Order.Forward)
+@test_throws BoundsError searchsortedfirst(1:10, 5,  5, 1, Base.Order.Forward)
+
 a = rand(1:10000, 1000)
 
 for alg in [InsertionSort, MergeSort]


### PR DESCRIPTION
1) Checks bounds on the more low-level `searchsorted*` methods.  At the moment
an error like this is possible:

```
julia> searchsortedfirst([1:10], 5,  -10, 7, Base.Order.Forward)
zsh: segmentation fault (core dumped)
```

I corrected this by adding a bounds check.  The alternative would be to rename the low-level `searchsorted*` to, say, `_searchsorted*` and not export them. (my understanding is that no exported methods in Base should seg-fault unless they are labeled `unsafe_`)

_TODO_: The same goes for the low-level `select!` and `sort!` methods, which also do not check bounds.  But some of them are recursive and a bounds check is only necessary on the first execution.  Maybe renaming would be better?   @StefanKarpinski, I think you updated sort.jl most recently, maybe you can comment.  Let me know what would be the preferred solution and I can update this PR.

Here an example of a `sort!` bug:

```
julia> a = rand(2)
2-element Array{Float64,1}:
 0.0272557
 0.200126 

julia> sort!(a, 1, 15, Base.Sort.QuickSort, Base.Order.Forward)
2-element Array{Float64,1}:
 9.88131e-324
 9.88131e-324
```

2) Removes the `step(r)==0` tests as ranges cannot have 0 steps (I think)
