### PR TITLE
Fix for LLVM trunk changes that broke enableUnsafeAlgebraIfReduction.

### DIFF
--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -82,8 +82,13 @@ void LowerSIMDLoop::enableUnsafeAlgebraIfReduction(PHINode* Phi, Loop* L) const 
     for (Instruction *I = Phi; ; I=J) {
         J = NULL;
         // Find the user of instruction I that is within loop L.
+#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 5
+        for (User *UI : I->users()) { /*}*/
+            Instruction *U = cast<Instruction>(UI);
+#else
         for (Value::use_iterator UI = I->use_begin(), UE = I->use_end(); UI != UE; ++UI) {
             Instruction *U = cast<Instruction>(*UI);
+#endif
             if (L->contains(U)) {
                 if (J) {
                     DEBUG(dbgs() << "LSL: not a reduction var because op has two internal uses: " << *I << "\n");


### PR DESCRIPTION
This is the fix for a [problem](https://github.com/JuliaLang/julia/pull/6928#issuecomment-44044227)  where Julia built with LLVM 3.5 does not vectorize `@simd` loops containing reductions.

This patch is "monkey see, monkey do" quality.  I don't understand why LLVM trunk broke the idiom that I was using in LLVM 3.3/3.4 to traverse uses of an LLVM instruction.  So I copied  the idiom that  LLVM trunk `LoopVectorizer` uses, which is different than the one that I originally copied from LLVM 3.3 `LoopVectorizer`.

The ```/_}_/''' is there to let text editors match the rest of the braces properly.
