### PR TITLE
jl_is_leaf_type static eval take 2

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -755,13 +755,11 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     if (fptr == &jl_is_leaf_type ||
         (f_lib==NULL && f_name && !strcmp(f_name, "jl_is_leaf_type"))) {
         jl_value_t *arg = args[4];
-        if (jl_is_expr(arg) || jl_is_symbol(arg)) {
-            jl_value_t* ty = expr_type(arg, ctx);
-            if (jl_is_type_type(ty) && !jl_is_typevar(jl_tparam0(ty))) {
-                int isleaf = jl_is_leaf_type(jl_tparam0(ty));
-                JL_GC_POP();
-                return ConstantInt::get(T_int32, isleaf);
-            }
+        jl_value_t* ty = expr_type(arg, ctx);
+        if (jl_is_type_type(ty) && !jl_is_typevar(jl_tparam0(ty))) {
+            int isleaf = jl_is_leaf_type(jl_tparam0(ty));
+            JL_GC_POP();
+            return ConstantInt::get(T_int32, isleaf);
         }
     }
 


### PR DESCRIPTION
Was being overly defensive. I forgot that the julia AST embed literal constants as values (which is quite pleasant IMO). The expr_type function seems solid enough to handle the things we throw at it. Should solves more instances of #7060 (still nothing on non concrete types though).
