### PR TITLE
Cosmetic changes in Pkg files

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -293,7 +293,7 @@ function pull_request(dir::String, commit::String="", url::String="")
     info("Pushing changes as branch $branch")
     Git.run(`push -q $fork $commit:refs/heads/$branch`, dir=dir)
     pr_url = "$(response["html_url"])/compare/$branch"
-    @osx? run(`open $pr_url`) : info("To create a pull-request open:\n\n  $pr_url\n")
+    @osx? run(`open $pr_url`) : info("To create a pull-request, open:\n\n  $pr_url\n")
 end
 
 function submit(pkg::String, commit::String="")

--- a/base/pkg/github.jl
+++ b/base/pkg/github.jl
@@ -32,7 +32,7 @@ end
 
 function curl(url::String, opts::Cmd=``)
     success(`which curl`) || error("using the GitHub API requires having `curl` installed")
-    out, proc = readsfrom(`curl -i -s -S $opts $url`)
+    out, proc = open(`curl -i -s -S $opts $url`,"r")
     head = readline(out)
     status = int(split(head,r"\s+",3)[2])
     for line in eachline(out)


### PR DESCRIPTION
Add a comma for clarity in `Pkg.Entry.pull_request` and remove deprecated `readsfrom` in `Pkg.GitHub.curl`. Found these while mucking around in `Pkg` all morning.
