### PR TITLE
Fix #5937.

### DIFF
--- a/base/pkg/github.jl
+++ b/base/pkg/github.jl
@@ -31,7 +31,7 @@ function json()
 end
 
 function curl(url::String, opts::Cmd=``)
-    success(`which curl`) || error("using the GitHub API requires having `curl` installed")
+    success(`curl --version`) || error("using the GitHub API requires having `curl` installed")
     out, proc = readsfrom(`curl -i -s -S $opts $url`)
     head = readline(out)
     status = int(split(head,r"\s+",3)[2])


### PR DESCRIPTION
This removes the dependence on `which` and just requires `curl`.
