### PR TITLE
Improve windows shell mode; fix edit() function for windows

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -60,7 +60,7 @@ function repl_cmd(cmd)
         end
         println(pwd())
     else
-        run(ignorestatus(@windows? cmd : (isa(STDIN, TTY) ? `$shell -i -c "($(shell_escape(cmd))) && true"` : `$shell -c "($(shell_escape(cmd))) && true"`)))
+        run(ignorestatus(@windows? `cmd /c $cmd` : (isa(STDIN, TTY) ? `$shell -i -c "($(shell_escape(cmd))) && true"` : `$shell -c "($(shell_escape(cmd))) && true"`)))
     end
     nothing
 end

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -23,7 +23,9 @@ function edit(file::String, line::Integer)
     if issrc
         file = find_source_file(file)
     end
-    if beginswith(edname, "emacs")
+    if OS_NAME == :Windows
+        spawn(`cmd /c $edname $file`)
+    elseif beginswith(edname, "emacs")
         spawn(`$edpath +$line $file`)
     elseif edname == "vim"
         run(`$edpath $file +$line`)
@@ -31,8 +33,6 @@ function edit(file::String, line::Integer)
         spawn(`$edpath $file -l $line`)
     elseif beginswith(edname, "subl")
         spawn(`$(shell_split(edpath)) $file:$line`)
-    elseif OS_NAME == :Windows && (edname == "start" || edname == "open")
-        spawn(`cmd /c start /b $file`)
     elseif OS_NAME == :Darwin && (edname == "start" || edname == "open")
         spawn(`open -t $file`)
     elseif edname == "kate"

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -32,7 +32,7 @@ function edit(file::String, line::Integer)
     elseif beginswith(edname, "subl")
         spawn(`$(shell_split(edpath)) $file:$line`)
     elseif OS_NAME == :Windows && (edname == "start" || edname == "open")
-        spawn(`start /b $file`)
+        spawn(`cmd /c start /b $file`)
     elseif OS_NAME == :Darwin && (edname == "start" || edname == "open")
         spawn(`open -t $file`)
     elseif edname == "kate"


### PR DESCRIPTION
Prepend 'cmd /c' to edit function `start` command to allow files to be opened properly on windows. Also prepend it to repl_cmd commands to better emulate shell mode for windows. Fixes #7107.
