### PR TITLE
Default .travis.yml changes

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -143,6 +143,7 @@ function travis(pkg::String; force::Bool=false)
           - sudo add-apt-repository ppa:staticfloat/\${JULIAVERSION} -y
           - sudo apt-get update -qq -y
           - sudo apt-get install libpcre3-dev julia -y
+          - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
         script:
           - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("$pkg")'
         """)


### PR DESCRIPTION
Change default .travis.yml file to prevent Travis from doing a shallow clone for new packages. Fixes #5222.

cc: @Simonster, @staticfloat
