### PR TITLE
Add '-t' option to git checkout

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -176,7 +176,7 @@ end
 function _checkout(pkg::String, what::String, merge::Bool=false, pull::Bool=false)
     Git.transact(dir=pkg) do
         Git.dirty(dir=pkg) && error("$pkg is dirty, bailing")
-        Git.run(`checkout -q $what`, dir=pkg)
+        Git.run(`checkout -q -t $what`, dir=pkg)
         merge && Git.run(`merge -q --ff-only $what`, dir=pkg)
         if pull
             info("Pulling $pkg latest $what...")


### PR DESCRIPTION
Use '-t' option in git checkout to set upstream tracking on branches. Fixes #5476.

cc: @staticfloat, @StefanKarpinski

I think this is what was discussed in the referenced issue, but let me know if there's anything else we need to check/do here.
