### PR TITLE
Pkg.generate tweak

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -89,6 +89,7 @@ function init(pkg::String, url::String="")
     end
     isempty(url) && return
     info("Origin: $url")
+    Git.run(`remote add origin $url`,dir=pkg)
     Git.set_remote_url(url,dir=pkg)
 end
 


### PR DESCRIPTION
When generating new packages, run remote add before manually configuring the remote so that the fetch refs are set in the .config file. Fixes #5480.
