### PR TITLE
Show time spent during garbage collection in @time macro (implement #7119)

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -45,11 +45,13 @@ macro time(ex)
         local t1 = time_ns()
         local b1 = gc_bytes()
         local tgc1 = gc_time_ns()
-        if tgc1 == tgc0
-            println("elapsed time: ", (t1-t0)/1e9, " seconds (", b1-b0, " bytes allocated)")
+        if tgc1 > tgc0
+            @printf("elapsed time: %s seconds (%d bytes allocated, %.2f%% gc)\n",
+                    (t1-t0)/1e9, b1-b0, 100*(tgc1-tgc0)/(t1-t0))
         else
-            println("elapsed time: ", (t1-t0)/1e9, " seconds (", (tgc1-tgc0)/(t1-t0), "% garbage collection, ", b1-b0, " bytes allocated)")
-        end
+            @printf("elapsed time: %s seconds (%d bytes allocated)\n",
+                    (t1-t0)/1e9, b1-b0)
+        end        
         val
     end
 end

--- a/base/util.jl
+++ b/base/util.jl
@@ -38,15 +38,15 @@ end
 # print elapsed time, return expression value
 macro time(ex)
     quote
-        local tgc0 = gc_time_ns()
         local b0 = gc_bytes()
         local t0 = time_ns()
+        local tgc0 = gc_time_ns()
         local val = $(esc(ex))
+        local tgc1 = gc_time_ns()
         local t1 = time_ns()
         local b1 = gc_bytes()
-        local tgc1 = gc_time_ns()
         if tgc1 > tgc0
-            @printf("elapsed time: %s seconds (%d bytes allocated, %.2f%% gc)\n",
+            @printf("elapsed time: %s seconds (%d bytes allocated, %.2f%% gc time)\n",
                     (t1-t0)/1e9, b1-b0, 100*(tgc1-tgc0)/(t1-t0))
         else
             @printf("elapsed time: %s seconds (%d bytes allocated)\n",

--- a/src/julia.h
+++ b/src/julia.h
@@ -1036,6 +1036,7 @@ DLLEXPORT void jl_gc_enable(void);
 DLLEXPORT void jl_gc_disable(void);
 DLLEXPORT int jl_gc_is_enabled(void);
 DLLEXPORT int64_t jl_gc_total_bytes(void);
+DLLEXPORT uint64_t jl_gc_total_hrtime(void);
 void jl_gc_ephemeral_on(void);
 void jl_gc_ephemeral_off(void);
 DLLEXPORT void jl_gc_collect(void);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -127,6 +127,10 @@ DLLEXPORT void jl_restore_linedebug_info(uv_lib_t* handle);
 DLLEXPORT void jl_raise_debugger(void);
 #endif
 
+// timers
+// Returns time in nanosec
+DLLEXPORT uint64_t jl_hrtime(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Implement #7119.

During testing I get `0%` most of the time. Maybe the gc fraction should only be shown when the gc is actually run? @StefanKarpinski

My fun test is `@time gc()`
