### PR TITLE
specialize length(SubString) for DirectIndexString

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -596,6 +596,8 @@ print(io::IOBuffer, s::SubString) = write(io, s)
 
 sizeof{T<:ByteString}(s::SubString{T}) = s.endof==0 ? 0 : next(s,s.endof)[2]-1
 
+length{T<:DirectIndexString}(s::SubString{T}) = endof(s)
+
 function next(s::SubString, i::Int)
     if i < 1 || i > s.endof
         error(BoundsError)

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -14,6 +14,8 @@ ________
 To use the default handler, the macro :func:`@test` can be used directly::
 
   # Julia code
+  julia> using Base.Test
+  
   julia> @test 1 == 1
 
   julia> @test 1 == 0

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -692,6 +692,26 @@ for i1 = 1:length(u8str2)
     end
 end
 
+str="tempus fugit"              #length(str)==12
+ss=SubString(str,1,length(str)) #match source string
+@test length(ss)==length(str)
+
+ss=SubString(str,1,0)    #empty SubString
+@test length(ss)==0
+
+ss=SubString(str,14,20)  #start indexed beyond source string length
+@test length(ss)==0
+
+ss=SubString(str,10,16)  #end indexed beyond source string length
+@test length(ss)==3
+
+str2=""
+ss=SubString(str2,1,4)  #empty source string
+@test length(ss)==0
+
+ss=SubString(str2,1,1)  #empty source string, identical start and end index
+@test length(ss)==0
+
 str = "aa\u2200\u2222bb"
 u = SubString(str, 3, 6)
 @test length(u)==2


### PR DESCRIPTION
passes 'make clean testall'

Double-checked code_typed( length,(SubString{ASCIIString},) ) to verify that this one actually affects execution :/

Current code_typed() output:

```
1-element Array{Any,1}:
 :($(Expr(:lambda, {:s}, {{:i,:n,:#s406,:#s404,:c,:#s403,:j,:#s405,:_var0,:_var1,:_var2,:_var3},{{:s,SubString{ASCIIString},0},{:i,Int64,2},{:n,Int64,2},{:#s406,(Char,Int64),18},{:#s404,(Char,Int64),18},{:c,Char,18},{:#s403,(Int64,Int64),18},{:j,Int64,18},{:#s405,Int64,2},{:_var0,Char,18},{:_var1,Int64,18},{:_var2,Int64,18},{:_var3,Int64,18}},{}}, :(begin  # string.jl, line 81:
        i = 1 # line 82:
        unless slt_int(top(getfield)(s::SubString{ASCIIString},:endof)::Int64,i::Int64)::Bool goto 0 # line 83:
        return 0
        0:  # line 85:
        n = 1 # line 86:
        unless true goto 2
        3:  # line 87:
        #s406 = next(s::SubString{ASCIIString},i::Int64)::(Char,Int64)
        #s405 = 1
        _var0 = tupleref(#s406::(Char,Int64),1)::Union(Int64,Char)
        _var1 = box(Int64,add_int(1,1))::Int64
        c = _var0::Char
        #s405 = _var1::Int64
        _var2 = tupleref(#s406::(Char,Int64),2)::Union(Int64,Char)
        _var3 = box(Int64,add_int(2,1))::Int64
        j = _var2::Int64
        #s405 = _var3::Int64 # line 88:
        unless slt_int(top(getfield)(s::SubString{ASCIIString},:endof)::Int64,j::Int64)::Bool goto 5 # line 89:
        return n::Int64
        5:  # line 91:
        n = box(Int64,add_int(n::Int64,1))::Int64 # line 92:
        i = j::Int64
        4: 
        unless false goto 3
        2: 
        1: 
        return
    end::Int64))))
```

Proposed code_typed() output:

```
1-element Array{Any,1}:
 :($(Expr(:lambda, {:s}, {{},{{:s,SubString{ASCIIString},0}},{}}, :(begin  # In[65], line 1:
        return top(getfield)(s::SubString{ASCIIString},:endof)::Int64
    end::Int64))))
```
