### PR TITLE
Restore old Associative show method as print

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -16,19 +16,23 @@ function summary(t::Associative)
     string(typeof(t), " with ", n, (n==1 ? " entry" : " entries"))
 end
 
-function showcompact{K,V}(io::IO, t::Associative{K,V})
-    print(io, summary(t))
-    if !isempty(t)
-        print(io, ": ")
-        delims = (K == V == Any) ? ('{', '}') : ('[', ']')
+function print{K,V}(io::IO, t::Associative{K,V})
+    if isempty(t)
+        print(io, typeof(t),"()")
+    else
+        if K === Any && V === Any
+            delims = ['{','}']
+        else
+            delims = ['[',']']
+        end
         print(io, delims[1])
         first = true
         for (k, v) in t
             first || print(io, ',')
             first = false
-            showcompact(io, k)
+            print(io, k)
             print(io, "=>")
-            showcompact(io, v)
+            print(io, v)
         end
         print(io, delims[2])
     end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -16,7 +16,7 @@ function summary(t::Associative)
     string(typeof(t), " with ", n, (n==1 ? " entry" : " entries"))
 end
 
-function print{K,V}(io::IO, t::Associative{K,V})
+function show{K,V}(io::IO, t::Associative{K,V})
     if isempty(t)
         print(io, typeof(t),"()")
     else
@@ -30,9 +30,9 @@ function print{K,V}(io::IO, t::Associative{K,V})
         for (k, v) in t
             first || print(io, ',')
             first = false
-            print(io, k)
+            show(io, k)
             print(io, "=>")
-            print(io, v)
+            show(io, v)
         end
         print(io, delims[2])
     end
@@ -61,13 +61,14 @@ function _truncate_at_width_or_chars(str, width, chars="", truncmark="…")
     end
 end
 
-function showdict{K,V}(io::IO, t::Associative{K,V}, limit_output::Bool = false,
+showdict(t::Associative; kw...) = showdict(STDOUT, t; kw...)
+function showdict{K,V}(io::IO, t::Associative{K,V}; limit::Bool = false,
                        rows = tty_rows()-3, cols = tty_cols())
     print(io, summary(t))
     isempty(t) && return
     print(io, ":")
 
-    if limit_output
+    if limit
         rows < 2   && (print(io, " …"); return)
         cols < 12  && (cols = 12) # Minimum widths of 2 for key, 4 for value
         cols -= 6 # Subtract the widths of prefix "  " separator " => "
@@ -85,9 +86,9 @@ function showdict{K,V}(io::IO, t::Associative{K,V}, limit_output::Bool = false,
 
     for (i, (k, v)) in enumerate(t)
         print(io, "\n  ")
-        limit_output && i > rows && (print(io, rpad("⋮", keylen), " => ⋮"); break)
+        limit && i > rows && (print(io, rpad("⋮", keylen), " => ⋮"); break)
 
-        if limit_output
+        if limit
             key = rpad(_truncate_at_width_or_chars(ks[i], keylen, "\r\n"), keylen)
         else
             key = sprint(show, k)
@@ -96,15 +97,12 @@ function showdict{K,V}(io::IO, t::Associative{K,V}, limit_output::Bool = false,
         print(io, " => ")
 
         val = sprint(show, v)
-        if limit_output
+        if limit
             val = _truncate_at_width_or_chars(val, cols - keylen, "\r\n")
         end
         print(io, val)
     end
 end
-
-show{K,V}(io::IO, t::Associative{K,V}) = showdict(io, t, false)
-showlimited{K,V}(io::IO, t::Associative{K,V}) = showdict(io, t, true)
 
 immutable KeyIterator{T<:Associative}
     dict::T
@@ -116,15 +114,15 @@ end
 summary{T<:Union(KeyIterator,ValueIterator)}(iter::T) =
     string(T.name, " for a ", summary(iter.dict))
 
-show(io::IO, iter::Union(KeyIterator,ValueIterator)) = showkv(io, iter, false)
-showlimited(io::IO, iter::Union(KeyIterator,ValueIterator)) = showkv(io, iter, true)
+show(io::IO, iter::Union(KeyIterator,ValueIterator)) = show(io, collect(iter))
 
-function showkv{T<:Union(KeyIterator,ValueIterator)}(io::IO, iter::T, limit_output::Bool = false,
+showkv(iter::Union(KeyIterator,ValueIterator); kw...) = showkv(STDOUT, iter; kw...)
+function showkv{T<:Union(KeyIterator,ValueIterator)}(io::IO, iter::T; limit::Bool = false,
                                                      rows = tty_rows()-3, cols = tty_cols())
     print(io, summary(iter))
     isempty(iter) && return
     print(io, ". ", T<:KeyIterator ? "Keys" : "Values", ":")
-    if limit_output
+    if limit
         rows < 2 && (print(io, " …"); return)
         cols < 4 && (cols = 4)
         cols -= 2 # For prefix "  "
@@ -133,10 +131,10 @@ function showkv{T<:Union(KeyIterator,ValueIterator)}(io::IO, iter::T, limit_outp
 
     for (i, v) in enumerate(iter)
         print(io, "\n  ")
-        limit_output && i >= rows && (print(io, "⋮"); break)
+        limit && i >= rows && (print(io, "⋮"); break)
 
         str = sprint(show, v)
-        limit_output && (str = _truncate_at_width_or_chars(str, cols, "\r\n"))
+        limit && (str = _truncate_at_width_or_chars(str, cols, "\r\n"))
         print(io, str)
     end
 end

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -36,6 +36,12 @@ function writemime(io::IO, ::MIME"text/plain", v::DataType)
     end
 end
 
+writemime(io::IO, ::MIME"text/plain", t::Associative) = 
+    showdict(io, t, limit=true)
+writemime(io::IO, ::MIME"text/plain", t::Union(KeyIterator,ValueIterator)) = 
+    showkv(io, t, limit=true)
+
+
 # showing exception objects as descriptive error messages
 
 showerror(io::IO, e) = show(io, e)

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -179,7 +179,7 @@ for d in (["\n" => "\n", "1" => "\n", "\n" => "2"],
     for cols in (12, 40, 80), rows in (2, 10, 24)
         # Ensure output is limited as requested
         s = IOBuffer()
-        Base.showdict(s, d, true, rows, cols)
+        Base.showdict(s, d, limit=true, rows=rows, cols=cols)
         out = split(takebuf_string(s),'\n')
         for line in out[2:end]
             @test strwidth(line) <= cols
@@ -188,7 +188,7 @@ for d in (["\n" => "\n", "1" => "\n", "\n" => "2"],
 
         for f in (keys, values)
             s = IOBuffer()
-            Base.showkv(s, f(d), true, rows, cols)
+            Base.showkv(s, f(d), limit=true, rows=rows, cols=cols)
             out = split(takebuf_string(s),'\n')
             for line in out[2:end]
                 @test strwidth(line) <= cols
@@ -197,7 +197,7 @@ for d in (["\n" => "\n", "1" => "\n", "\n" => "2"],
         end
     end
     # Simply ensure these do not throw errors
-    Base.showdict(IOBuffer(), d, false)
+    Base.showdict(IOBuffer(), d, limit=false)
     @test !isempty(summary(d))
     @test !isempty(summary(keys(d)))
     @test !isempty(summary(values(d)))


### PR DESCRIPTION
This should fix #7142 and JuliaLang/JSON.jl#72.  The previous Associative show method is now the print method.
