### PR TITLE
more relaxed version parsing: don't require hyphen before prerelease

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -64,8 +64,8 @@ const VERSION_REGEX = r"^
     (\d+)                                   # major         (required)
     (?:\.(\d+))?                            # minor         (optional)
     (?:\.(\d+))?                            # patch         (optional)
-    (?:(-)|
-    (?:-((?:[0-9a-z-]+\.)*[0-9a-z-]+))?     # pre-release   (optional)
+    (?:(-)|                                 # pre-release   (optional)
+    ([a-z][0-9a-z-]*(?:\.[0-9a-z-]+)*|-(?:[0-9a-z-]+\.)*[0-9a-z-]+)?
     (?:(\+)|
     (?:\+((?:[0-9a-z-]+\.)*[0-9a-z-]+))?    # build         (optional)
     ))
@@ -86,6 +86,9 @@ function convert(::Type{VersionNumber}, v::String)
     major = int(major)
     minor = minor != nothing ? int(minor) : 0
     patch = patch != nothing ? int(patch) : 0
+    if prerl != nothing && !isempty(prerl) && prerl[1] == '-'
+        prerl = prerl[2:end] # strip leading '-'
+    end
     prerl = prerl != nothing ? split_idents(prerl) : minus == "-" ? ("",) : ()
     build = build != nothing ? split_idents(build) : plus  == "+" ? ("",) : ()
     VersionNumber(major, minor, patch, prerl, build)

--- a/test/version.jl
+++ b/test/version.jl
@@ -8,21 +8,21 @@
 @test v"3.2-1" == VersionNumber(3, 2, 0, (1,), ())
 @test v"4.3.2-1" == VersionNumber(4, 3, 2, (1,), ())
 
-@test v"1-a" == VersionNumber(1, 0, 0, ("a",), ())
-@test v"2.1-a" == VersionNumber(2, 1, 0, ("a",), ())
-@test v"3.2.1-a" == VersionNumber(3, 2, 1, ("a",), ())
+@test v"1-a" == VersionNumber(1, 0, 0, ("a",), ()) == v"1a"
+@test v"2.1-a" == VersionNumber(2, 1, 0, ("a",), ()) == v"2.1a"
+@test v"3.2.1-a" == VersionNumber(3, 2, 1, ("a",), ()) == v"3.2.1a"
 
-@test v"2-a1" == VersionNumber(2, 0, 0, ("a1",), ())
-@test v"3.2-a1" == VersionNumber(3, 2, 0, ("a1",), ())
-@test v"4.3.2-a1" == VersionNumber(4, 3, 2, ("a1",), ())
+@test v"2-a1" == VersionNumber(2, 0, 0, ("a1",), ()) == v"2a1"
+@test v"3.2-a1" == VersionNumber(3, 2, 0, ("a1",), ()) == v"3.2a1"
+@test v"4.3.2-a1" == VersionNumber(4, 3, 2, ("a1",), ()) == v"4.3.2a1"
 
 @test v"2-1a" == VersionNumber(2, 0, 0, ("1a",), ())
 @test v"3.2-1a" == VersionNumber(3, 2, 0, ("1a",), ())
 @test v"4.3.2-1a" == VersionNumber(4, 3, 2, ("1a",), ())
 
-@test v"2-a.1" == VersionNumber(2, 0, 0, ("a", 1), ())
-@test v"3.2-a.1" == VersionNumber(3, 2, 0, ("a", 1), ())
-@test v"4.3.2-a.1" == VersionNumber(4, 3, 2, ("a", 1), ())
+@test v"2-a.1" == VersionNumber(2, 0, 0, ("a", 1), ()) == v"2a.1"
+@test v"3.2-a.1" == VersionNumber(3, 2, 0, ("a", 1), ()) == v"3.2a.1"
+@test v"4.3.2-a.1" == VersionNumber(4, 3, 2, ("a", 1), ()) == v"4.3.2a.1"
 
 @test v"2-1.a" == VersionNumber(2, 0, 0, (1, "a"), ())
 @test v"3.2-1.a" == VersionNumber(3, 2, 0, (1, "a"), ())


### PR DESCRIPTION
This patch makes the hyphen before the prerelease number optional, as long as the prerelease number begins with a letter.  That allows e.g. `"1.2a1"` or `"1.1.3rc2"` to be parsed.  (I ran into the latter form recently with Matplotlib.)

cc: @StefanKarpinski 
