### PR TITLE
Enable AVX for  Intel 4th-Generation Core processor ("Haswell") .

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -363,9 +363,10 @@ ifeq ($(BUILD_LLDB), 1)
 		git fetch))
 	cd llvm-$(LLVM_VER)/tools/lldb && git checkout origin/release_32
 endif
+ifeq ($(LLVM_VER),3.3)
+	patch -p0 < llvm-3.3.patch
 ifeq ($(OS),WINNT)
 ifeq ($(ARCH),x86_64)
-ifeq ($(LLVM_VER),3.3)
 	patch -p0 < win64-int128.llvm-3.3.patch
 endif
 endif

--- a/deps/llvm-3.3.patch
+++ b/deps/llvm-3.3.patch
@@ -1,0 +1,180 @@
+diff -u -r -N llvm-3.3.src/lib/Support/Host.cpp llvm-3.3/lib/Support/Host.cpp
+--- llvm-3.3.src/lib/Support/Host.cpp	2013-05-04 02:36:23.000000000 -0500
++++ llvm-3.3/lib/Support/Host.cpp	2014-06-05 15:08:41.975312974 -0500
+@@ -52,8 +52,54 @@
+ 
+ /// GetX86CpuIDAndInfo - Execute the specified cpuid and return the 4 values in the
+ /// specified arguments.  If we can't run cpuid on the host, return true.
+-static bool GetX86CpuIDAndInfo(unsigned value, unsigned *rEAX,
+-                            unsigned *rEBX, unsigned *rECX, unsigned *rEDX) {
++static bool GetX86CpuIDAndInfo(unsigned value, unsigned *rEAX, unsigned *rEBX,
++                               unsigned *rECX, unsigned *rEDX) {
++#if defined(__GNUC__) || defined(__clang__)
++  #if defined(__x86_64__) || defined(_M_AMD64) || defined (_M_X64)
++    // gcc doesn't know cpuid would clobber ebx/rbx. Preseve it manually.
++    asm ("movq\t%%rbx, %%rsi\n\t"
++         "cpuid\n\t"
++         "xchgq\t%%rbx, %%rsi\n\t"
++         : "=a" (*rEAX),
++           "=S" (*rEBX),
++           "=c" (*rECX),
++           "=d" (*rEDX)
++         :  "a" (value));
++    return false;
++  #elif defined(i386) || defined(__i386__) || defined(__x86__) || defined(_M_IX86)
++    asm ("movl\t%%ebx, %%esi\n\t"
++         "cpuid\n\t"
++         "xchgl\t%%ebx, %%esi\n\t"
++         : "=a" (*rEAX),
++           "=S" (*rEBX),
++           "=c" (*rECX),
++           "=d" (*rEDX)
++         :  "a" (value));
++    return false;
++// pedantic #else returns to appease -Wunreachable-code (so we don't generate
++// postprocessed code that looks like "return true; return false;")
++  #else
++    return true;
++  #endif
++#elif defined(_MSC_VER)
++  // The MSVC intrinsic is portable across x86 and x64.
++  int registers[4];
++  __cpuid(registers, value);
++  *rEAX = registers[0];
++  *rEBX = registers[1];
++  *rECX = registers[2];
++  *rEDX = registers[3];
++  return false;
++#else
++  return true;
++#endif
++}
++
++/// GetX86CpuIDAndInfoEx - Execute the specified cpuid with subleaf and return the
++/// 4 values in the specified arguments.  If we can't run cpuid on the host,
++/// return true.
++bool GetX86CpuIDAndInfoEx(unsigned value, unsigned subleaf, unsigned *rEAX,
++                          unsigned *rEBX, unsigned *rECX, unsigned *rEDX) {
+ #if defined(__x86_64__) || defined(_M_AMD64) || defined (_M_X64)
+   #if defined(__GNUC__)
+     // gcc doesn't know cpuid would clobber ebx/rbx. Preseve it manually.
+@@ -64,16 +110,22 @@
+            "=S" (*rEBX),
+            "=c" (*rECX),
+            "=d" (*rEDX)
+-         :  "a" (value));
++         :  "a" (value),
++            "c" (subleaf));
+     return false;
+   #elif defined(_MSC_VER)
+-    int registers[4];
+-    __cpuid(registers, value);
+-    *rEAX = registers[0];
+-    *rEBX = registers[1];
+-    *rECX = registers[2];
+-    *rEDX = registers[3];
+-    return false;
++    // __cpuidex was added in MSVC++ 9.0 SP1
++    #if (_MSC_VER > 1500) || (_MSC_VER == 1500 && _MSC_FULL_VER >= 150030729)
++      int registers[4];
++      __cpuidex(registers, value, subleaf);
++      *rEAX = registers[0];
++      *rEBX = registers[1];
++      *rECX = registers[2];
++      *rEDX = registers[3];
++      return false;
++    #else
++      return true;
++    #endif
+   #else
+     return true;
+   #endif
+@@ -86,11 +138,13 @@
+            "=S" (*rEBX),
+            "=c" (*rECX),
+            "=d" (*rEDX)
+-         :  "a" (value));
++         :  "a" (value),
++            "c" (subleaf));
+     return false;
+   #elif defined(_MSC_VER)
+     __asm {
+       mov   eax,value
++      mov   ecx,subleaf
+       cpuid
+       mov   esi,rEAX
+       mov   dword ptr [esi],eax
+@@ -102,8 +156,6 @@
+       mov   dword ptr [esi],edx
+     }
+     return false;
+-// pedantic #else returns to appease -Wunreachable-code (so we don't generate
+-// postprocessed code that looks like "return true; return false;")
+   #else
+     return true;
+   #endif
+@@ -148,21 +200,27 @@
+   unsigned Model  = 0;
+   DetectX86FamilyModel(EAX, Family, Model);
+ 
++  union {
++    unsigned u[3];
++    char     c[12];
++  } text;
++
++  GetX86CpuIDAndInfo(0, &EAX, text.u+0, text.u+2, text.u+1);
++
++  unsigned MaxLeaf = EAX;
+   bool HasSSE3 = (ECX & 0x1);
++  bool HasSSE41 = (ECX & 0x80000);
+   // If CPUID indicates support for XSAVE, XRESTORE and AVX, and XGETBV 
+   // indicates that the AVX registers will be saved and restored on context
+   // switch, then we have full AVX support.
+   const unsigned AVXBits = (1 << 27) | (1 << 28);
+   bool HasAVX = ((ECX & AVXBits) == AVXBits) && OSHasAVXSupport();
++  bool HasAVX2 = HasAVX && MaxLeaf >= 0x7 &&
++                 !GetX86CpuIDAndInfoEx(0x7, 0x0, &EAX, &EBX, &ECX, &EDX) &&
++                 (EBX & 0x20);
+   GetX86CpuIDAndInfo(0x80000001, &EAX, &EBX, &ECX, &EDX);
+   bool Em64T = (EDX >> 29) & 0x1;
+ 
+-  union {
+-    unsigned u[3];
+-    char     c[12];
+-  } text;
+-
+-  GetX86CpuIDAndInfo(0, &EAX, text.u+0, text.u+2, text.u+1);
+   if (memcmp(text.c, "GenuineIntel", 12) == 0) {
+     switch (Family) {
+     case 3:
+@@ -244,7 +302,8 @@
+                // 17h. All processors are manufactured using the 45 nm process.
+                //
+                // 45nm: Penryn , Wolfdale, Yorkfield (XE)
+-        return "penryn";
++        // Not all Penryn processors support SSE 4.1 (such as the Pentium brand)
++        return HasSSE41 ? "penryn" : "core2";
+ 
+       case 26: // Intel Core i7 processor and Intel Xeon processor. All
+                // processors are manufactured using the 45 nm process.
+@@ -269,10 +328,20 @@
+ 
+       // Ivy Bridge:
+       case 58:
++      case 62: // Ivy Bridge EP
+         // Not all Ivy Bridge processors support AVX (such as the Pentium
+         // versions instead of the i7 versions).
+         return HasAVX ? "core-avx-i" : "corei7";
+ 
++      // Haswell:
++      case 60:
++      case 63:
++      case 69:
++      case 70:
++        // Not all Haswell processors support AVX too (such as the Pentium
++        // versions instead of the i7 versions).
++        return HasAVX2 ? "core-avx2" : "corei7";
++
+       case 28: // Most 45 nm Intel Atom processors
+       case 38: // 45 nm Atom Lincroft
+       case 39: // 32 nm Atom Medfield


### PR DESCRIPTION
This patch enables AVX on "Haswell" processors.  Previously, Julia was treating such shiny new processors as 2004 vintage processors, notably foregoing AVX.  The patch also fixes a problem for some low-end "Penryn" processors  that lack SSE 4.1.  The patch is large, but is all copied line-by-line from LLVM 3.4, so I don't expect any problems. 

The root problem was that the CPU identification logic in LLVM 3.3 did not know about the Haswell model numbers, and so was treating such machines as generic 64-bit x86.

An alternative that I considered was to add only the new switch cases and have them return `"core-avx-i"` instead of `"core-avx2"`  But it felt safer to just copy existing code from LLVM 3.4.  Currently, Julia turns off AVX2 support explicitly if not using MCJIT, because of a known bug, so the patch effectively does not enable AVX2.

This PR fixes the LLVM 3.3 problem mentioned in  #7097, but not the LLVM trunk problem.
