### PR TITLE
WIP: Fix #6275

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -243,6 +243,10 @@ JCPPFLAGS += -D_LARGEFILE_SOURCE -D_DARWIN_USE_64_BIT_INODE=1
 endif
 endif
 
+ifeq ($(LLVM_VER),svn)
+JCXXFLAGS += -std=c++11
+endif
+
 JFFLAGS = -O2 $(fPIC)
 JF2CFLAGS = -ff2c -fno-second-underscore
 ifneq ($(USEMSVC),1)

--- a/Make.inc
+++ b/Make.inc
@@ -504,7 +504,7 @@ endif
 ifeq ($(OS), WINNT)
 ifneq ($(USEMSVC), 1)
 OSLIBS += -Wl,--export-all-symbols -Wl,--version-script=$(JULIAHOME)/src/julia.expmap \
-	$(NO_WHOLE_ARCHIVE) -lpsapi -lkernel32 -lws2_32 -liphlpapi -lwinmm -ldbghelp -lssp
+	$(NO_WHOLE_ARCHIVE) -lz -lpsapi -lkernel32 -lws2_32 -liphlpapi -lwinmm -ldbghelp -lssp
 JLDFLAGS = -Wl,--stack,8388608
 ifeq ($(ARCH),i686)
 JLDFLAGS += -Wl,--large-address-aware

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ $(build_private_libdir)/sys%$(SHLIB_EXT): $(build_private_libdir)/sys%o
 	$(CXX) -shared -fPIC -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -o $@ $< \
 		$$([ $(OS) = Darwin ] && echo -Wl,-undefined,dynamic_lookup || echo -Wl,--unresolved-symbols,ignore-all ) \
 		$$([ $(OS) = WINNT ] && echo -ljulia -lssp)
+ifeq ($(OS), Darwin)
+	dsymutil $@
+endif
 
 $(build_private_libdir)/sys0.o:
 	@$(QUIET_JULIA) cd base && \

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -42,7 +42,7 @@ function firstcaller(bt::Array{Ptr{None},1}, funcsym::Symbol)
     # Identify the calling line
     i = 1
     while i <= length(bt)
-        lkup = ccall(:jl_lookup_code_address, Any, (Ptr{Void},), bt[i])
+        lkup = ccall(:jl_lookup_code_address, Any, (Ptr{Void},Cint), bt[i], true)
         i += 1
         if lkup === ()
             continue

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -90,7 +90,7 @@ len_data() = convert(Int, ccall(:jl_profile_len_data, Csize_t, ()))
 maxlen_data() = convert(Int, ccall(:jl_profile_maxlen_data, Csize_t, ()))
 
 function lookup(ip::Uint)
-    info = ccall(:jl_lookup_code_address, Any, (Ptr{Void},), ip)
+    info = ccall(:jl_lookup_code_address, Any, (Ptr{Void},Cint), ip, false)
     if length(info) == 4
         return LineInfo(string(info[1]), string(info[2]), int(info[3]), info[4])
     else

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -78,7 +78,7 @@ end
 function showerror(io::IO, e::DomainError, bt)
     print(io, "DomainError")
     for b in bt
-        code = ccall(:jl_lookup_code_address, Any, (Ptr{Void},), b)
+        code = ccall(:jl_lookup_code_address, Any, (Ptr{Void},Cint), b, true)
         if length(code) == 4
             if code[1] in (:log, :log2, :log10, :sqrt) # TODO add :besselj, :besseli, :bessely, :besselk
                 print(io, "\n", code[1],
@@ -159,7 +159,7 @@ function show_backtrace(io::IO, top_function::Symbol, t, set)
     local fname, file, line
     count = 0
     for i = 1:length(t)
-        lkup = ccall(:jl_lookup_code_address, Any, (Ptr{Void},), t[i])
+        lkup = ccall(:jl_lookup_code_address, Any, (Ptr{Void},Cint), t[i], true)
         if lkup === ()
             continue
         end

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -36,6 +36,9 @@
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/Analysis/Passes.h"
 #include "llvm/Bitcode/ReaderWriter.h"
+#ifdef _OS_DARWIN_
+#include "llvm/Object/MachO.h"
+#endif
 #if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 5
 #define LLVM35 1
 #include "llvm/IR/Verifier.h"
@@ -47,6 +50,7 @@
 #else
 #include "llvm/Analysis/Verifier.h"
 #endif
+#include "llvm/DebugInfo/DIContext.h"
 #if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 4
 #define LLVM34 1
 #define USE_MCJIT 1
@@ -54,7 +58,6 @@
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
 #include "llvm/ExecutionEngine/ObjectImage.h"
 #include "llvm/ADT/DenseMapInfo.h"
-#include "llvm/DebugInfo/DIContext.h"
 #include "llvm/Object/ObjectFile.h"
 #endif
 #if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 3
@@ -3250,11 +3253,14 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
     else {
         m = shadow_module;
     }
-    funcName << ";" << globalUnique++;
+#ifndef LLVM35
+    funcName << ";";
+#endif
 #else
     m = jl_Module;
-    funcName << globalUnique++;
+    funcName << ";";
 #endif
+    funcName << globalUnique++;
 
     if (specsig) {
         std::vector<Type*> fsig(0);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3795,7 +3795,11 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
 static MDNode* tbaa_make_child( const char* name, MDNode* parent, bool isConstant=false )
 {
     MDNode* n = mbuilder->createTBAANode(name,parent,isConstant);
+#ifdef LLVM35
+    n->setValueName( ValueName::Create(name));
+#else
     n->setValueName( ValueName::Create(name, name+strlen(name)));
+#endif
     return n;
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,10 +1,3 @@
-#include "platform.h"
-#if defined(_OS_WINDOWS_)
-#define NOMINMAX
-#endif
-#include "julia.h"
-#include "julia_internal.h"
-
 /*
  * We include <mathimf.h> here, because somewhere below <math.h> is included also.
  * As a result, Intel C++ Composer generates an error. To prevent this error, we
@@ -107,6 +100,38 @@
 #include "llvm/Support/CommandLine.h"
 #endif
 #include "llvm/Transforms/Utils/Cloning.h"
+ // For disasm
+#include "llvm/Support/MachO.h"
+#include "llvm/MC/MCDisassembler.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/MCObjectFileInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/ADT/OwningPtr.h"
+#include "llvm/ADT/Triple.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/MemoryObject.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetRegistry.h"
+#include "llvm/Support/Host.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/system_error.h"
+
+#include "platform.h"
+#if defined(_OS_WINDOWS_)
+#define NOMINMAX
+#endif
+
+#include "julia.h"
+#include "julia_internal.h"
+
 #include <setjmp.h>
 
 #include <string>

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -298,11 +298,13 @@ void jl_getDylibFunctionInfo(const char **name, int *line, const char **filename
 #ifdef LLVM35
             ErrorOr<llvm::object::ObjectFile*> errorobj = llvm::object::ObjectFile::createObjectFile(
 #else
-            lvm::object::ObjectFile *errorobj = llvm::object::ObjectFile::createObjectFile(
+            llvm::object::ObjectFile *errorobj = llvm::object::ObjectFile::createObjectFile(
 #endif
                 MemoryBuffer::getMemBuffer(
-                StringRef((const char *)dlinfo.dli_fbase, (size_t)(((uint64_t)-1)-(uint64_t)dlinfo.dli_fbase)),"",false),
-                false, sys::fs::file_magic::unknown
+                StringRef((const char *)dlinfo.dli_fbase, (size_t)(((uint64_t)-1)-(uint64_t)dlinfo.dli_fbase)),"",false)
+#ifdef LLVM35
+                ,false, sys::fs::file_magic::unknown
+#endif
             );
 #endif
 #ifdef LLVM35

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -312,7 +312,7 @@ void jl_getDylibFunctionInfo(const char **name, int *line, const char **filename
 #endif
 #else
 #ifndef _OS_WINDOWS_
-            char *fname = dlinfo.dli_fname
+            const char *fname = dlinfo.dli_fname;
 #else
             IMAGEHLP_MODULE64 ModuleInfo;
             ModuleInfo.SizeOfStruct = sizeof(IMAGEHLP_MODULE64);

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -147,8 +147,9 @@ const char *jl_demangle(const char *name) {
     if (*name == '\0') goto done;
     while ((*end++ != ';') && (*end != '\0'));
     if (*name == '\0') goto done;
-    ret = (char*)malloc(end-start-1);
+    ret = (char*)malloc(end-start);
     memcpy(ret,start,end-start-1);
+    ret[end-start-1] = '\0';
     return ret;
     done:
         return strdup(name);
@@ -188,7 +189,7 @@ void lookup_pointer(DIContext *context, const char **name, int *line, const char
     #include <mach-o/dyld.h>
 #endif
 #ifndef _OS_WINDOWS_
-#include <dlfnc.h>
+#include <dlfcn.h>
 #endif
 typedef struct {
     llvm::object::ObjectFile *obj;

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -19,6 +19,7 @@ struct FuncInfo{
 struct ObjectInfo {
     object::ObjectFile* object;
     object::SymbolRef symref;
+    size_t size;
 };
 #endif
 
@@ -108,9 +109,8 @@ public:
         for (const object::SymbolRef &sym_iter : obj.symbols()) {
             sym_iter.getType(SymbolType);
             if (SymbolType != object::SymbolRef::ST_Function) continue;
-            
             sym_iter.getAddress(Addr);
-            ObjectInfo tmp = {obj.getObjectFile(), sym_iter};
+            ObjectInfo tmp = {obj.getObjectFile(), sym_iter, obj.getData().size()};
             objectmap[Addr] = tmp;
         }
         #else

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -17,28 +17,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/MC/MCDisassembler.h"
-#include "llvm/MC/MCInst.h"
-#include "llvm/MC/MCStreamer.h"
-#include "llvm/MC/MCSubtargetInfo.h"
-#include "llvm/MC/MCObjectFileInfo.h"
-#include "llvm/MC/MCRegisterInfo.h"
-#include "llvm/MC/MCAsmInfo.h"
-#include "llvm/MC/MCAsmBackend.h"
-#include "llvm/MC/MCCodeEmitter.h"
-#include "llvm/MC/MCInstPrinter.h"
-#include "llvm/MC/MCInstrInfo.h"
-#include "llvm/MC/MCContext.h"
-#include "llvm/ADT/OwningPtr.h"
-#include "llvm/ADT/Triple.h"
-#include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/MemoryObject.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/TargetRegistry.h"
-#include "llvm/Support/Host.h"
-#include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/system_error.h"
-
 #include <string>
 #include <iostream>
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -105,6 +105,7 @@ extern int globalUnique;
 extern void jl_cpuid(int32_t CPUInfo[4], int32_t InfoType);
 extern const char *jl_cpu_string;
 uv_lib_t *jl_sysimg_handle = NULL;
+char *jl_sysimage_name = NULL;
 
 static void jl_load_sysimg_so(char *fname)
 {
@@ -136,6 +137,7 @@ static void jl_load_sysimg_so(char *fname)
             jl_error("System image has unknown target cpu architecture.\n"
                      "Please delete or regenerate sys.{so,dll,dylib}.");
         }
+        jl_sysimage_name = strdup(fname);
     }
     else {
         sysimg_gvars = 0;
@@ -1104,10 +1106,6 @@ void jl_restore_system_image(char *fname)
     jl_get_binding_wr(jl_core_module, jl_symbol("JULIA_HOME"))->value =
         jl_cstr_to_string(julia_home);
     jl_update_all_fptrs();
-#ifndef _OS_WINDOWS_
-    // restore the line information for Julia backtraces
-    if (jl_sysimg_handle != NULL) jl_restore_linedebug_info(jl_sysimg_handle);
-#endif
 }
 
 void jl_init_restored_modules()

--- a/src/init.c
+++ b/src/init.c
@@ -909,9 +909,6 @@ DLLEXPORT int julia_trampoline(int argc, char **argv, int (*pmain)(int ac,char *
             free(build_ji);
             char *build_o;
             if (asprintf(&build_o, "%s.o",build_path) > 0) {
-#ifndef _OS_WINDOWS_
-                jl_dump_linedebug_info();
-#endif
                 jl_dump_objfile(build_o,0);
                 free(build_o);
             }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -122,8 +122,6 @@ size_t rec_backtrace_ctx_dwarf(ptrint_t *data, size_t maxsize, bt_context_t ctx)
 #endif
 
 #ifndef _OS_WINDOWS_
-DLLEXPORT void jl_dump_linedebug_info(void);
-DLLEXPORT void jl_restore_linedebug_info(uv_lib_t* handle);
 DLLEXPORT void jl_raise_debugger(void);
 #endif
 

--- a/src/task.c
+++ b/src/task.c
@@ -685,7 +685,7 @@ DLLEXPORT void gdblookup(ptrint_t ip)
     const char *func_name;
     int line_num;
     const char *file_name;
-    int fromC = frame_info_from_ip(&func_name, &line_num, &file_name, ip, false);
+    int fromC = frame_info_from_ip(&func_name, &line_num, &file_name, ip, 0);
     if (func_name != NULL) {
         ios_printf(ios_stderr, "%s at %s:%d\n", func_name, file_name, line_num);
 #ifdef _OS_WINDOWS_

--- a/src/task.c
+++ b/src/task.c
@@ -456,14 +456,14 @@ static void init_task(jl_task_t *t)
 ptrint_t bt_data[MAX_BT_SIZE+1];
 size_t bt_size = 0;
 
-void jl_getFunctionInfo(const char **name, int *line, const char **filename, size_t pointer);
+void jl_getFunctionInfo(const char **name, int *line, const char **filename, size_t pointer, int skipC);
 
 static const char* name_unknown = "???";
-static int frame_info_from_ip(const char **func_name, int *line_num, const char **file_name, size_t ip)
+static int frame_info_from_ip(const char **func_name, int *line_num, const char **file_name, size_t ip, int skipC)
 {
     int fromC = 0;
 
-    jl_getFunctionInfo(func_name, line_num, file_name, ip);
+    jl_getFunctionInfo(func_name, line_num, file_name, ip, skipC);
     if (*func_name == NULL) {
         fromC = 1;
 #if defined(_OS_WINDOWS_)
@@ -512,24 +512,9 @@ static int frame_info_from_ip(const char **func_name, int *line_num, const char 
             jl_in_stackwalk = 0;
         }
 #else
-        Dl_info dlinfo;
-        if (dladdr((void*)ip, &dlinfo) != 0) {
-            *file_name = (dlinfo.dli_fname != NULL) ? dlinfo.dli_fname : name_unknown;
-            if (dlinfo.dli_sname != NULL) {
-                *func_name = dlinfo.dli_sname;
-                // line number in C looks tricky. addr2line and libbfd seem promising. For now, punt and just return address offset.
-                *line_num = ip-(size_t)dlinfo.dli_saddr;
-            }
-            else {
-                *func_name = name_unknown;
-                *line_num = 0;
-            }
-        }
-        else {
-            *func_name = name_unknown;
-            *file_name = name_unknown;
-            *line_num = ip;
-        }
+        *func_name = name_unknown;
+        *file_name = name_unknown;
+        *line_num = ip;
 #endif
     }
     return fromC;
@@ -660,12 +645,12 @@ DLLEXPORT jl_value_t *jl_backtrace_from_here(void)
     return (jl_value_t*)bt;
 }
 
-DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip)
+DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
 {
     const char *func_name;
     int line_num;
     const char *file_name;
-    int fromC = frame_info_from_ip(&func_name, &line_num, &file_name, (size_t)ip);
+    int fromC = frame_info_from_ip(&func_name, &line_num, &file_name, (size_t)ip, skipC);
     if (func_name != NULL) {
         jl_value_t *r = (jl_value_t*)jl_alloc_tuple(4);
         JL_GC_PUSH1(&r);
@@ -700,12 +685,9 @@ DLLEXPORT void gdblookup(ptrint_t ip)
     const char *func_name;
     int line_num;
     const char *file_name;
-    int fromC = frame_info_from_ip(&func_name, &line_num, &file_name, ip);
+    int fromC = frame_info_from_ip(&func_name, &line_num, &file_name, ip, false);
     if (func_name != NULL) {
-        if (fromC)
-            ios_printf(ios_stderr, "%s at %s: offset %x\n", func_name, file_name, line_num);
-        else
-            ios_printf(ios_stderr, "%s at %s:%d\n", func_name, file_name, line_num);
+        ios_printf(ios_stderr, "%s at %s:%d\n", func_name, file_name, line_num);
 #ifdef _OS_WINDOWS_
         if (fromC && func_name != name_unknown) free((void*)func_name);
         if (fromC && file_name != name_unknown) free((void*)file_name);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -16,6 +16,7 @@
 #endif
 #include "julia.h"
 #include "julia_internal.h"
+#include "uv.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -548,7 +549,10 @@ jl_value_t *jl_load(const char *fname)
 {
     if (jl_current_module == jl_base_module) {
         //This deliberatly uses ios, because stdio initialization has been moved to Julia
-        jl_printf(JL_STDOUT, "%s\n", fname);
+        jl_printf(JL_STDOUT, "%s\r\n", fname);
+#ifdef _OS_WINDOWS_        
+        uv_run(uv_default_loop(), 1);
+#endif
     }
     char *fpath = (char*)fname;
     uv_stat_t stbuf;


### PR DESCRIPTION
The approach is as follows. On MCJIT with LLVM trunk we get proper line numbers.
On 3.3 we get proper line numbers on Linux (and probably Windows), but on Mac,
you have to use a patched version of LLVM. If you don't use the patched version
of LLVM you'll still get the function names but no line numbers.

This is almost done, just need to add the LLVM patch for 3.3 and test on various platforms. 
