### PR TITLE
fix sparse getindex regression

### DIFF
--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -289,6 +289,14 @@ for (aa116, ss116) in [(a116, s116), (ad116, sd116)]
     @test full(ss116[li,lj]) == aa116[li,lj]
 end
 
+let S = SparseMatrixCSC(3, 3, Uint8[1,1,1,1], Uint8[], Int64[])
+    S[1,1] = 1
+    S[5] = 2
+    S[end] = 3
+    @test S[end] == (S[1] + S[2,2])
+    @test 6 == sum(diag(S))
+end
+
 
 # setindex tests
 let a = spzeros(Int, 10, 10)


### PR DESCRIPTION
This PR aims to fix broken `getindex` for sparse matrices with index type other than `Int` and adds some related tests.
ref #7131, #7047
