### PR TITLE
Trailing newlines in prompt corrupt the history file

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -320,7 +320,7 @@ function add_history(hist::REPLHistoryProvider, s)
     entry = """
     # mode: $mode
     # time: $(strftime("%F %T %Z", time()))
-    $(replace(str, r"^"ms, "\t"))
+    $('\t')$(replace(str, '\n', "\n\t"))
     """
     # TODO: write-lock history file
     seekend(hist.history_file)


### PR DESCRIPTION
Previously:

```
$ julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "help()" to list help topics
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.3.0-prerelease+3536 (2014-06-07 11:52 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 51dbcce* (0 days old master)
|__/                   |  x86_64-apple-darwin13.1.0

julia> 1 # with a trailing newline in the prompt text

1

julia> quit()

$ julia -q
ERROR: Invalid history format. If you have a ~/.julia_history file left over from an older version of Julia, try renaming or deleting it.
```

.julia_history stores the prompt text with leading tab indentation, and the
REPL expects all prompt lines to start with a `\t`. Previously, these tabs were
inserted when writing to the history file by substituting line starts (`r"^"ms`)
with a tab character. However, final newlines are not considered line starts,
so they were entered into the history file without the tab, which corrupts the
file.

This fixes that, by prefixing the prompt with a `\t` and then replacing all
newlines with `\n\t`.
