### PR TITLE
Allow usage of specific immutable types as parameters

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -264,11 +264,15 @@ include("graphics.jl")
 include("profile.jl")
 importall .Profile
 
+const CUSTOM_PARAMETER_TYPES = Array(DataType, 0)
+
 function __init__()
     # Base library init
     reinit_stdio()
     Multimedia.reinit_displays() # since Multimedia.displays uses STDOUT as fallback
     fdwatcher_init()
+    push!(CUSTOM_PARAMETER_TYPES, Rational{Int})
+    ccall(:jl_register_custom_parameter_types, Void, (Any,), CUSTOM_PARAMETER_TYPES)
 end
 
 include("precompile.jl")


### PR DESCRIPTION
The proximal motivation behind this is to be able to support stuff like `sqrt(2Meter)`, where `Meter` is from SIUnits. This doesn't easily work now because SIUnits encodes the units as integer type parameters, and currently Rationals cannot be used as type parameters. One could do it now using a "cheat" like this:

```
immutable RationalP{Num,Denom}; end
```

and then using `RationalP{1,2}` as a parameter. However, I wondered if it would be better just to use plain Rationals.

Consequently, this implements a framework for "registering" specific types as being acceptable type parameters. I would be pretty surprised if there weren't some serious problems with this, but there's no better way to find out than by submitting it.
