### PR TITLE
RFC: add evalpoly function, mirroring @evalpoly macro

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -287,7 +287,6 @@ export
     At_rdiv_Bt,
 
 # scalar math
-    @evalpoly,
     abs,
     abs2,
     acos,
@@ -349,6 +348,8 @@ export
     erfcx,
     erfi,
     erfinv,
+    evalpoly,
+    @evalpoly,
     exp,
     exp10,
     exp2,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1458,4 +1458,3 @@ Internals
    .. Docstring generated from Julia source
 
    Compile the given function ``f`` for the argument tuple (of types) ``args``\ , but do not execute it.
-

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1694,6 +1694,12 @@ Mathematical Functions
 
    Evaluate the polynomial :math:`\sum_k c[k] z^{k-1}` for the coefficients ``c[1]``\ , ``c[2]``\ , ...; that is, the coefficients are given in ascending order by power of ``z``\ .  This macro expands to efficient inline code that uses either Horner's method or, for complex ``z``\ , a more efficient Goertzel-like algorithm.
 
+.. function:: evalpoly(z, c)
+
+   .. Docstring generated from Julia source
+
+   Evaluate the polynomial c(z).
+
 Statistics
 ----------
 
@@ -2205,4 +2211,3 @@ some built-in integration support in Julia.
    These quadrature rules work best for smooth functions within each interval, so if your function has a known discontinuity or other singularity, it is best to subdivide your interval to put the singularity at an endpoint. For example, if ``f`` has a discontinuity at ``x=0.7`` and you want to integrate from 0 to 1, you should use ``quadgk(f, 0,0.7,1)`` to subdivide the interval at the point of discontinuity. The integrand is never evaluated exactly at the endpoints of the intervals, so it is possible to integrate functions that diverge at the endpoints as long as the singularity is integrable (for example, a ``log(x)`` or ``1/sqrt(x)`` singularity).
 
    For real-valued endpoints, the starting and/or ending points may be infinite. (A coordinate transformation is performed internally to map the infinite interval to a finite one.)
-

--- a/test/math.jl
+++ b/test/math.jl
@@ -662,6 +662,7 @@ end
 @test_approx_eq polygamma(3,5) polygamma(3,5.)
 
 @test @evalpoly(2,3,4,5,6) == 3+2*(4+2*(5+2*6)) == @evalpoly(2+0im,3,4,5,6)
+
 @test let evalcounts=0
           @evalpoly(begin
                         evalcounts += 1
@@ -673,6 +674,11 @@ a0 = 1
 a1 = 2
 c = 3
 @test @evalpoly(c, a0, a1) == 7
+
+@test evalpoly(2,[3,4,5,6]) == 3+2*(4+2*(5+2*6)) == evalpoly(2+0im,[3,4,5,6])
+@test evalpoly(2+1im,[3,4,5,6]) == @evalpoly(2+1im, 3,4,5,6)
+@test typeof(evalpoly([2],[3,4,5,6])) == Vector{Int}
+@test typeof(evalpoly([2+0im],[3,4,5,6])) == Vector{Complex{Int}}
 
 @test 1e-14 > err(eta(1+1e-9), 0.693147180719814213126976796937244130533478392539154928250926)
 @test 1e-14 > err(eta(1+5e-3), 0.693945708117842473436705502427198307157819636785324430166786)


### PR DESCRIPTION
As mentioned in #7146, since we have an `@evalpoly(z, c...)` it makes sense to also have a `evalpoly(z, c)`, analogous to Matlab's [polyval](http://www.mathworks.com/help/matlab/ref/polyval.html) but with the arguments in reverse order and the coefficients in ascending order by power of `z`.

We could alternatively mirror Matlab and store the coefficients in descending order, in which case we might as well swap the arguments and call it `polyval`.  However, this issue seems to have been discussed in vtjnash/Polynomial.jl#5, and the consensus seems to have been to reject Matlab's ordering, resulting in @Keno's [Polynomials.jl](https://github.com/Keno/Polynomials.jl) fork.
