### PR TITLE
Fix #7196, #5476

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -173,10 +173,10 @@ function clone(url_or_pkg::String)
     clone(url,pkg)
 end
 
-function _checkout(pkg::String, what::String, merge::Bool=false, pull::Bool=false)
+function _checkout(pkg::String, what::String, merge::Bool=false, pull::Bool=false, branch::Bool=false)
     Git.transact(dir=pkg) do
         Git.dirty(dir=pkg) && error("$pkg is dirty, bailing")
-        Git.run(`checkout -q -t $what`, dir=pkg)
+        branch ? Git.run(`checkout -q -B $what -t origin/$what`, dir=pkg) : Git.run(`checkout -q $what`, dir=pkg)
         merge && Git.run(`merge -q --ff-only $what`, dir=pkg)
         if pull
             info("Pulling $pkg latest $what...")
@@ -189,7 +189,7 @@ end
 function checkout(pkg::String, branch::String, merge::Bool, pull::Bool)
     ispath(pkg,".git") || error("$pkg is not a git repo")
     info("Checking out $pkg $branch...")
-    _checkout(pkg,branch,merge,pull)
+    _checkout(pkg,branch,merge,pull,true)
 end
 
 function free(pkg::String)


### PR DESCRIPTION
Fix for current `Pkg.checkout` issues.  This PR assumes that the desired upstream repo is named "origin", which seems to be what `Pkg.add` assumes.  

It might be safer to use `refs/remotes/origin`, in which case `Pkg.add` should also be updated.

cc: @StefanKarpinski @quinnj 
