### PR TITLE
Sparse-Uint: bug fix & added performance tests

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -884,7 +884,7 @@ function getindex_general{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, J
     nnzS = 0
     pI = sortperm(I); I = I[pI]
     fI = find(I)
-    W = zeros(Int, nI + 1) # Keep row counts
+    W = zeros(Ti, nI + 1) # Keep row counts
     W[1] = 1               # For cumsum later
 
     # Form the structure of the result and compute space

--- a/test/perf/sparse/perf.jl
+++ b/test/perf/sparse/perf.jl
@@ -132,13 +132,11 @@ inds = [(intinds, "integers"), (logicalinds, "logical array"), (rangeinds, "a ra
 sizes = [(1, "small", "Small sparse matrix"), (2, "medium", "Medium sparse matrix")]
 
 # - matrix types
-mattyp = [(ts, "10 entries/column"), (us, "100 entries/column")]
-# change to following line, after regression is fixed: https://github.com/JuliaLang/julia/pull/7162#issuecomment-45400517
-#mattyp = [(ts, "10 entries/column"), (us, "100 entries/column"), (uus, "100 entries/column uint32")]
+mattyp = [(ts, "10 entries/column"), (us, "100 entries/column"), (uus, "100 entries/column uint32")]
 
 # - functions
 funs = [(integer_indexing, 1, "indexing"), (one_arg_indexing, 1, "1d indexing"),  
-        (row_indexing, 2, "indexing rows"), (col_indexing, 2, "indexing rows"), 
+        (row_indexing, 2, "indexing rows"), (col_indexing, 2, "indexing columns"), 
         (row_col_indexing, 3, "indexing rows & columns")]
 
 # performance tests:

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -289,13 +289,16 @@ for (aa116, ss116) in [(a116, s116), (ad116, sd116)]
     @test full(ss116[li,lj]) == aa116[li,lj]
 end
 
-let S = SparseMatrixCSC(3, 3, Uint8[1,1,1,1], Uint8[], Int64[])
-    S[1,1] = 1
-    S[5] = 2
-    S[end] = 3
-    @test S[end] == (S[1] + S[2,2])
-    @test 6 == sum(diag(S))
-end
+# workaround issue #7197: comment out let-block
+#let S = SparseMatrixCSC(3, 3, Uint8[1,1,1,1], Uint8[], Int64[])
+S1290 = SparseMatrixCSC(3, 3, Uint8[1,1,1,1], Uint8[], Int64[])
+    S1290[1,1] = 1
+    S1290[5] = 2
+    S1290[end] = 3
+    @test S1290[end] == (S1290[1] + S1290[2,2])
+    @test 6 == sum(diag(S1290))
+    @test (full(S1290)[[3,1],1])'' == full(S1290[[3,1],1])
+# end
 
 
 # setindex tests


### PR DESCRIPTION
This PR does:
- fix a bug in getindex_general.  Indexing with a disordered array lead to a no-methods error:
  `ERROR: no method SparseMatrixCSC{Tv,Ti<:Integer}(Int64, Int64, Array{Int64,1}, Array{Uint32,1}, Array{Float64,1})`  Test added.
- temprary fix for #7197 in `test/sparse.jl`
- added performance tests for Sparse-uint matrices
