### PR TITLE
fix #7203 and #7218

### DIFF
--- a/test/strings.jl
+++ b/test/strings.jl
@@ -811,18 +811,18 @@ s = "   p"
       \t""" == ""
 @test """
       foo
-      \tbar""" == "foo\n\tbar"
+      \tbar""" == "foo$(nl)\tbar"
 @test """
       foo
       \tbar
-      """ == "foo\n\tbar\n"
+      """ == "foo$(nl)\tbar$(nl)"
 @test """
       foo
-      bar\t""" == "foo\nbar\t"
+      bar\t""" == "foo$(nl)bar\t"
 @test """
       foo
       \tbar
-       """ == "foo\n       bar\n"
+       """ == "foo$(nl)       bar$(nl)"
 
 # bytes2hex and hex2bytes
 hex_str = "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"


### PR DESCRIPTION
for Windows users who have git configured with \r\n line endings,
or modify the source in an editor that always uses \r\n
