### PR TITLE
restore broadcasting array±scalar operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -216,9 +216,7 @@ Library improvements
         the same length.  This generalizes and replaces `normfro` ([#6057]),
         and `norm` is now type-stable ([#6056]).
 
-      * `+` and `-` now require the sizes of the arrays to be the
-        same: the operations no longer do broadcasting. New
-        `UniformScaling` matrix type and identity `I` constant (#5810).
+      * New `UniformScaling` matrix type and identity `I` constant (#5810).
 
       * None of the concrete matrix factorization types are exported from Base
         by default anymore.

--- a/base/array.jl
+++ b/base/array.jl
@@ -767,16 +767,15 @@ for f in (:.+, :.-, :.*, :./, :.\, :.%, :div, :mod, :rem, :&, :|, :$)
     end
 end
 
-# convenient and familiar aliases for broadcasting operations
-# of array ± scalar:
-(+)(A::StridedArray{Bool},x::Bool) = A .+ x
-(+)(x::Bool,A::StridedArray{Bool}) = x .+ A 
-(-)(A::StridedArray{Bool},x::Bool) = A .- x
-(-)(x::Bool,A::StridedArray{Bool}) = x .- A
-(+)(A::StridedArray,x::Number) = A .+ x
-(+)(x::Number,A::StridedArray) = x .+ A
-(-)(A::StridedArray,x::Number) = A .- x
-(-)(x::Number,A::StridedArray) = x .- A
+# familiar aliases for broadcasting operations of array ± scalar (#7226):
+(+)(A::AbstractArray{Bool},x::Bool) = A .+ x
+(+)(x::Bool,A::AbstractArray{Bool}) = x .+ A 
+(-)(A::AbstractArray{Bool},x::Bool) = A .- x
+(-)(x::Bool,A::AbstractArray{Bool}) = x .- A
+(+)(A::AbstractArray,x::Number) = A .+ x
+(+)(x::Number,A::AbstractArray) = x .+ A
+(-)(A::AbstractArray,x::Number) = A .- x
+(-)(x::Number,A::AbstractArray) = x .- A
 
 # functions that should give an Int result for Bool arrays
 for f in (:.+, :.-)

--- a/base/array.jl
+++ b/base/array.jl
@@ -767,6 +767,17 @@ for f in (:.+, :.-, :.*, :./, :.\, :.%, :div, :mod, :rem, :&, :|, :$)
     end
 end
 
+# convenient and familiar aliases for broadcasting operations
+# of array ± scalar:
+(+)(A::StridedArray{Bool},x::Bool) = A .+ x
+(+)(x::Bool,A::StridedArray{Bool}) = x .+ A 
+(-)(A::StridedArray{Bool},x::Bool) = A .- x
+(-)(x::Bool,A::StridedArray{Bool}) = x .- A
+(+)(A::StridedArray,x::Number) = A .+ x
+(+)(x::Number,A::StridedArray) = x .+ A
+(-)(A::StridedArray,x::Number) = A .- x
+(-)(x::Number,A::StridedArray) = x .- A
+
 # functions that should give an Int result for Bool arrays
 for f in (:.+, :.-)
     @eval begin

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -185,16 +185,7 @@ end
 @deprecate svdfact(A,thin)      svdfact(A,thin=thin)
 @deprecate svdfact!(A,thin)     svdfact(A,thin=thin)
 @deprecate svd(A,thin)          svd(A,thin=thin)
-# Note: These methods need a more helpfull error message than a `NoMethodError`,
-#       when the deprecation is removed
-@deprecate (+)(A::Array{Bool},x::Bool)      A .+ x
-@deprecate (+)(x::Bool,A::Array{Bool})      x .+ A 
-@deprecate (-)(A::Array{Bool},x::Bool)      A .- x
-@deprecate (-)(x::Bool,A::Array{Bool})      x .- A
-@deprecate (+)(A::Array,x::Number)          A .+ x
-@deprecate (+)(x::Number,A::Array)          x .+ A
-@deprecate (-)(A::Array,x::Number)          A .- x
-@deprecate (-)(x::Number,A::Array)          x .- A
+
 @deprecate (/)(x::Number,A::Array)          x ./ A
 @deprecate (\)(A::Array,x::Number)          A .\ x
 


### PR DESCRIPTION
As recently discussed in #5810, the deprecation of broadcasting `+` and `-` for arrays and scalars, while theoretically removing some ambiguity for the case of matrix+scalar (though it is not clear that this has ever been a problem in practice), seems to cause more annoyance than it is worth, and will be a continual headache for users migrating from NumPy, Matlab, etc.

This patch restores those functions.
