### PR TITLE
Fix calling of makensis on win

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ ifeq ($(OS), WINNT)
 	    mkdir $(DESTDIR)$(prefix)/Git && \
 	    7z x PortableGit.7z -o"$(DESTDIR)$(prefix)/Git" )
 	cd $(DESTDIR)$(bindir) && rm -f llvm* llc.exe lli.exe opt.exe LTO.dll bugpoint.exe macho-dump.exe
-	$(call spawn,./dist-extras/nsis/makensis.exe) /NOCD /DVersion=$(JULIA_VERSION) /DArch=$(ARCH) /DCommit=$(JULIA_COMMIT) ./contrib/windows/build-installer.nsi
+	$(call spawn,./dist-extras/nsis/makensis.exe) -NOCD -DVersion=$(JULIA_VERSION) -DArch=$(ARCH) -DCommit=$(JULIA_COMMIT) ./contrib/windows/build-installer.nsi
 	./dist-extras/7z a -mx9 "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" julia-installer.exe
 	cat ./contrib/windows/7zS.sfx ./contrib/windows/7zSFX-config.txt "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" > "julia-${JULIA_VERSION}-${ARCH}.exe"
 	-rm -f julia-installer.exe


### PR DESCRIPTION
On a system that is set up based on [these instructions](https://github.com/JuliaLang/julia/blob/master/README.windows.md) with the msys2 environment, make dist throws an error because makensis.exe apparently needs arguments to be passed with a - instead of a / on Windows. This patch makes things work on my system.

I have NOT tested this on any other platform, so before this gets merged someone needs to test whether this then still works on the main platforms used for building the windows installer.
