### PR TITLE
Fix mmap_array with offset on Windows

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -813,6 +813,7 @@ DLLEXPORT int32_t jl_stat(const char *path, char *statbuf);
 DLLEXPORT void NORETURN jl_exit(int status);
 DLLEXPORT int jl_cpu_cores(void);
 DLLEXPORT long jl_getpagesize(void);
+DLLEXPORT long jl_getallocationgranularity(void);
 DLLEXPORT int jl_is_debugbuild(void);
 
 // environment entries

--- a/src/sys.c
+++ b/src/sys.c
@@ -525,6 +525,24 @@ long jl_getpagesize(void)
 }
 #endif
 
+#ifdef _OS_WINDOWS_
+static long cachedAllocationGranularity = 0;
+long jl_getallocationgranularity(void)
+{
+    if (!cachedAllocationGranularity) {
+        SYSTEM_INFO systemInfo;
+        GetSystemInfo (&systemInfo);
+        cachedAllocationGranularity = systemInfo.dwAllocationGranularity;
+    }
+    return cachedAllocationGranularity;
+}
+#else
+long jl_getallocationgranularity(void)
+{
+    return jl_getpagesize();
+}
+#endif
+
 DLLEXPORT long jl_SC_CLK_TCK(void)
 {
 #ifndef _OS_WINDOWS_

--- a/test/file.jl
+++ b/test/file.jl
@@ -213,8 +213,10 @@ A2 = mmap_array(Int, (m,n), s)
 seek(s, 0)
 A3 = mmap_array(Int, (m,n), s, convert(FileOffset,2*sizeof(Int)))
 @test A == A3
+A4 = mmap_array(Int, (m,150), s, convert(FileOffset,(2+150*m)*sizeof(Int)))
+@test A[:, 151:end] == A4
 close(s)
-A2=nothing; A3=nothing; gc(); gc(); # cause munmap finalizer to run & free resources
+A2=nothing; A3=nothing; A4=nothing; gc(); gc(); # cause munmap finalizer to run & free resources
 rm(fname)
 
 #######################################################################

--- a/test/file.jl
+++ b/test/file.jl
@@ -197,6 +197,26 @@ b = mmap_bitarray((17,19), s)
 close(s)
 b=nothing; b0=nothing; gc(); gc(); # cause munmap finalizer to run & free resources
 
+# mmap with an offset
+A = rand(1:20, 500, 300)
+fname = tempname()
+s = open(fname, "w+")
+write(s, size(A,1))
+write(s, size(A,2))
+write(s, A)
+close(s)
+s = open(fname)
+m = read(s, Int)
+n = read(s, Int)
+A2 = mmap_array(Int, (m,n), s)
+@test A == A2
+seek(s, 0)
+A3 = mmap_array(Int, (m,n), s, convert(FileOffset,2*sizeof(Int)))
+@test A == A3
+close(s)
+A2=nothing; A3=nothing; gc(); gc(); # cause munmap finalizer to run & free resources
+rm(fname)
+
 #######################################################################
 # This section tests temporary file and directory creation.           #
 #######################################################################


### PR DESCRIPTION
query allocation granularity (64k on Windows, larger than page size which is 4k),
ensure offset to MapViewOfFile is a multiple of the granularity

add a test for mmap_array with offset

fixes #7080 and #6203

some mmap issues remain with HDF5.jl, but there may be something else going on there
