### PR TITLE
REPL: Moving left and right was skipping newlines

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -316,7 +316,7 @@ function edit_move_left(buf::IOBuffer)
         #move to the next base UTF8 character to the left
         while true
             c = char_move_left(buf)
-            if charwidth(c) != 0 || position(buf) == 0
+            if charwidth(c) != 0 || c == '\n' || position(buf) == 0
                 break
             end
         end
@@ -374,7 +374,7 @@ function edit_move_right(buf::IOBuffer)
             pos = position(buf)
             nextc = read(buf,Char)
             seek(buf,pos)
-            (charwidth(nextc) != 0) && break
+            (charwidth(nextc) != 0 || nextc == '\n') && break
         end
         return true
     end

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -45,6 +45,27 @@ run_test(test3_func,IOBuffer("aab"))
 @test a_bar == 2
 @test b_bar == 1
 
+## edit_move{left,right} ##
+buf = IOBuffer("a\na\na\n")
+seek(buf, 0)
+for i = 1:6
+    LineEdit.edit_move_right(buf)
+    @test position(buf) == i
+end
+@test eof(buf)
+for i = 5:0
+    LineEdit.edit_move_left(buf)
+    @test position(buf) == i
+end
+
+# skip unicode combining characters
+buf = IOBuffer("ŷ")
+seek(buf, 0)
+LineEdit.edit_move_right(buf)
+@test eof(buf)
+LineEdit.edit_move_left(buf)
+@test position(buf) == 0
+
 ## edit_move_{up,down} ##
 
 buf = IOBuffer("type X\n    a::Int\nend")


### PR DESCRIPTION
Issue #7210 fixed movement across combining characters, such that moving left
and right by one character would skip all zero-width characters, but this also
inadvertently includes newlines. This made it impossible to navigate to the end
of a line that ended with a newline with the left and right arrows alone. And movement across multiple newlines would skip across them all at once.

This fixes that and adds simple regression tests.

cc: @Keno
