### PR TITLE
Add missing -lgfortran flag to a openblas makefile

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -799,6 +799,7 @@ openblas-$(OPENBLAS_VER)/config.status: openblas-$(OPENBLAS_VER).tar.gz
 	mkdir -p openblas-$(OPENBLAS_VER) && \
 	$(TAR) -C openblas-$(OPENBLAS_VER) --strip-components 1 -xf $<
 	perl -i -ple 's/^\s*(EXTRALIB\s*\+=\s*-lSystemStubs)\s*$$/# $$1/g' openblas-$(OPENBLAS_VER)/Makefile.system
+	patch openblas-$(OPENBLAS_VER)/exports/Makefile < openblas-exports-makefile.patch
 	echo 1 > $@
 $(OPENBLAS_OBJ_SOURCE): openblas-$(OPENBLAS_VER)/config.status
 	$(MAKE) -C openblas-$(OPENBLAS_VER) $(OPENBLAS_BUILD_OPTS) || (echo "*** Clean the OpenBLAS build with 'make -C deps clean-openblas'. Rebuild with 'make OPENBLAS_USE_THREAD=0 if OpenBLAS had trouble linking libpthread.so, and with 'make OPENBLAS_TARGET_ARCH=NEHALEM' if there were errors building SandyBridge support. Both these options can also be used simultaneously. ***" && false)

--- a/deps/openblas-exports-makefile.patch
+++ b/deps/openblas-exports-makefile.patch
@@ -1,0 +1,11 @@
+--- Makefile.old Tue Jun 10 06:55:47 2014
++++ Makefile Fri Jun 13 13:11:28 2014
+@@ -85,7 +85,7 @@
+ 	$(RANLIB) ../$(LIBNAME)
+ 	$(CC) $(CFLAGS) $(LDFLAGS) libopenblas.def dllinit.$(SUFFIX) \
+ 	-shared -o ../$(LIBDLLNAME) -Wl,--out-implib,../$(LIBPREFIX).lib \
+-	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive $(FEXTRALIB)
++	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive $(FEXTRALIB) $(EXTRALIB)
+
+ libopenblas.def : gensymbol
+ 	perl ./gensymbol win2k    $(ARCH) dummy $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) > $(@F)


### PR DESCRIPTION
This allows openblas v0.2.9 to be compiled on Windows and fixes the problem I reported in #7240.
