### PR TITLE
isvalid() chr2ind() ind2chr() for SubString of DirectIndexString

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -599,6 +599,10 @@ print(io::IOBuffer, s::SubString) = write(io, s)
 
 sizeof{T<:ByteString}(s::SubString{T}) = s.endof==0 ? 0 : next(s,s.endof)[2]-1
 
+# TODO: length(s::SubString) = ??
+# default implementation will work but it's slow
+# can this be delegated efficiently somehow?
+# that may require additional string interfaces
 length{T<:DirectIndexString}(s::SubString{T}) = endof(s)
 
 function next(s::SubString, i::Int)
@@ -617,10 +621,11 @@ function getindex(s::SubString, i::Int)
 end
 
 endof(s::SubString) = s.endof
-# TODO: length(s::SubString) = ??
-# default implementation will work but it's slow
-# can this be delegated efficiently somehow?
-# that may require additional string interfaces
+
+isvalid{T<:DirectIndexString}(s::SubString{T}, i::Integer) = (start(s) <= i <= endof(s))
+
+ind2chr{T<:DirectIndexString}(s::SubString{T}, i::Integer) = begin checkbounds(s,i); i end
+chr2ind{T<:DirectIndexString}(s::SubString{T}, i::Integer) = begin checkbounds(s,i); i end
 
 nextind(s::SubString, i::Integer) = nextind(s.string, i+s.offset)-s.offset
 prevind(s::SubString, i::Integer) = prevind(s.string, i+s.offset)-s.offset

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1030,3 +1030,36 @@ end
 @test checkbounds("hello", 2)
 @test checkbounds("hello", 1:5)
 @test checkbounds("hello", [1:5])
+
+
+# isvalid(), chr2ind() and ind2chr() for SubString{DirectIndexString}
+let s="lorem ipsum",
+    sdict=[SubString(s,1,11)=>s, 
+        SubString(s,1,6)=>"lorem ",
+        SubString(s,1,0)=>"", 
+        SubString(s,2,4)=>"ore", 
+        SubString(s,2,16)=>"orem ipsum", 
+        SubString(s,12,14)=>""
+    ]
+    for (ss,s) in sdict
+        for i in -1:12
+            @test isvalid(ss,i)==isvalid(s,i)
+        end
+    end
+    for (ss,s) in sdict
+        for i in 1:length(ss)
+            @test ind2chr(ss,i)==ind2chr(s,i)
+        end
+    end
+    for (ss,s) in sdict
+        for i in 1:length(ss)
+            @test chr2ind(ss,i)==chr2ind(s,i)
+        end
+    end
+end #let
+
+ss=SubString("hello",1,5)
+@test_throws BoundsError ind2chr(ss, -1)
+@test_throws BoundsError chr2ind(ss, -1)
+@test_throws BoundsError chr2ind(ss, 10)
+@test_throws BoundsError ind2chr(ss, 10)


### PR DESCRIPTION
On a microbenchmark these sped up isvalid(SubString{DirectIndexString},i) by about 40%
and produced a 4-5x speed improvement in chr2ind(SubString{DirectIndexString},i)
and ind2chr(SubString{DirectIndexString},i)

Benchmark details + code_typed() comparisons are available at: http://nbviewer.ipython.org/gist/catawbasam/99043bb74519378428fd
