### PR TITLE
Tweak description of assignment scoping

### DIFF
--- a/doc/manual/variables-and-scoping.rst
+++ b/doc/manual/variables-and-scoping.rst
@@ -43,7 +43,7 @@ current scope are as follows:
 -  A function's arguments are introduced as new local variables into the
    function's body scope.
 -  An assignment ``x = y`` introduces a new local variable ``x`` only if
-   ``x`` is neither declared global nor explicitly introduced as local
+   ``x`` is neither declared global nor introduced as local
    by any enclosing scope before *or after* the current line of code.
 
 In the following example, there is only one ``x`` assigned both inside


### PR DESCRIPTION
A local variable can be introduced into an enclosing scope without the `local` keyword. The use of the term "explicit" here makes one think of the `local` keyword.
