### PR TITLE
simplify Main.Base initialization and fix #7245 in the process

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -106,8 +106,7 @@ importall .FS
 include("process.jl")
 include("multimedia.jl")
 importall .Multimedia
-# TODO: should put this in _init, but need to handle its boolean argument correctly
-ccall(:jl_get_uv_hooks, Void, (Cint,), 0)
+ccall(:jl_get_uv_hooks, Void, ()) # TODO: should put this in _init
 include("grisu.jl")
 import .Grisu.print_shortest
 include("file.jl")

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -234,6 +234,8 @@ extern char *jl_sysimage_name;
 
 bool jl_is_sysimg(const char *path)
 {
+    if (!jl_sysimage_name)
+        return 0;
     const char *filename = strrchr(path,'/');
     if (filename == NULL)
         filename = path;
@@ -256,7 +258,7 @@ void jl_getDylibFunctionInfo(const char **name, int *line, const char **filename
     if (fbase != 0) {
 #else
     Dl_info dlinfo;
-    if (dladdr((void*)pointer, &dlinfo) != 0) {
+    if ((dladdr((void*)pointer, &dlinfo) != 0) && dlinfo.dli_fname) {
         if (skipC && !jl_is_sysimg(dlinfo.dli_fname))
             return;
         uint64_t fbase = (uint64_t)dlinfo.dli_fbase;

--- a/src/dump.c
+++ b/src/dump.c
@@ -1023,7 +1023,7 @@ extern jl_function_t *jl_typeinf_func;
 extern int jl_boot_file_loaded;
 extern void jl_get_builtin_hooks(void);
 extern void jl_get_system_hooks(void);
-extern void jl_get_uv_hooks(int);
+extern void jl_get_uv_hooks();
 
 DLLEXPORT
 void jl_restore_system_image(char *fname)
@@ -1086,7 +1086,7 @@ void jl_restore_system_image(char *fname)
 
     jl_get_builtin_hooks();
     jl_get_system_hooks();
-    jl_get_uv_hooks(1);
+    jl_get_uv_hooks();
     jl_boot_file_loaded = 1;
     jl_typeinf_func = (jl_function_t*)jl_get_global(jl_base_module,
                                                     jl_symbol("typeinf_ext"));


### PR DESCRIPTION
@JeffBezanson please confirm that this won't cause performance regressions. I think it should be fine, since I didn't reset the typeinf function pointer.

I am moved the reinitialization of many global constants much earlier in the build process, so that the first and second build are more similar. This change will hopefully allow simpler usage of these types while building the system image (since there shouldn't be old instances and type pointers hanging around as much to confuse things).
