### PR TITLE
RFC: Fix Windows symlink issues

### DIFF
--- a/base/fs.jl
+++ b/base/fs.jl
@@ -150,12 +150,15 @@ function sendfile(src::String, dst::String)
     end
 end
 
-@windows_only const UV_FS_SYMLINK_DIR = 0x0001
+@windows_only const UV_FS_SYMLINK_JUNCTION = 0x0002
 @non_windowsxp_only function symlink(p::String, np::String)
     flags = 0
-    @windows_only if isdir(p); flags |= UV_FS_SYMLINK_DIR; end
+    @windows_only if isdir(p); flags |= UV_FS_SYMLINK_JUNCTION; p = abspath(p); end
     err = ccall(:jl_fs_symlink, Int32, (Ptr{Uint8}, Ptr{Uint8}, Cint), 
                 bytestring(p), bytestring(np), flags)
+    @windows_only if err < 0
+        warn_once("Note: on Windows, creating file symlinks requires Administrator privileges.")
+    end
     uv_error("symlink",err)
 end
 @windowsxp_only symlink(p::String, np::String) = 

--- a/test/file.jl
+++ b/test/file.jl
@@ -5,7 +5,7 @@ dir = mktempdir()
 file = joinpath(dir, "afile.txt")
 close(open(file,"w")) # like touch, but lets the operating system update the timestamp for greater precision on some platforms (windows)
 
-@non_windowsxp_only begin
+@unix_only begin
     link = joinpath(dir, "afilelink.txt")
     symlink(file, link)
 end
@@ -36,17 +36,13 @@ run(`chmod +w $file`)
 @test filesize(file) == 0
 # On windows the filesize of a folder is the accumulation of all the contained
 # files and is thus zero in this case.
-@windows_only begin
-    @test filesize(dir) == 0
-end
-@unix_only begin
-    @test filesize(dir) > 0
-end
+@windows_only @test filesize(dir) == 0
+@unix_only @test filesize(dir) > 0
 @test int(time()) >= int(mtime(file)) >= int(mtime(dir)) >= 0 # 1 second accuracy should be sufficient
 
 # test links
+@unix_only @test islink(link) == true
 @non_windowsxp_only begin
-    @test islink(link) == true
     @test islink(dirlink) == true
     @test isdir(dirlink) == true
 end
@@ -280,10 +276,9 @@ close(f)
 ############
 # Clean up #
 ############
-@non_windowsxp_only begin
-    rm(link)
-    rm(dirlink)
-end
+@unix_only rm(link)
+@non_windowsxp_only rm(dirlink)
+
 rm(file)
 rmdir(subdir)
 rmdir(dir)


### PR DESCRIPTION
Since I provided the original PR, I thought I should try to provide the fix.  
- Provide a message on Windows if symlink creation fails, indicating
  that symlinks require admin priveleges
- Automatically attempts to create junction points whenever symlinking
  a directory

I don't have easy access to a Windows machine, so could someone with a Windows machine (@quinnj, @tkelman) please test?

This may not be the ideal fix, so feedback is welcome (and feel free to modify this repo directly, as I may not get to it quickly during the week).  

Cc: @StefanKarpinski 

Ref: #4396 
