### PR TITLE
poll_fd fix

### DIFF
--- a/base/poll.jl
+++ b/base/poll.jl
@@ -13,15 +13,9 @@ type FileMonitor
         this = new(handle,cb,false,Condition())
         associate_julia_struct(handle,this)
         finalizer(this,uvfinalize)
-        this        
+        this
     end
     FileMonitor(file) = FileMonitor(false,file)
-end
-
-function close(t::FileMonitor) 
-    if t.handle != C_NULL
-        ccall(:jl_close_uv,Void,(Ptr{Void},),t.handle)
-    end
 end
 
 immutable FileEvent
@@ -82,11 +76,11 @@ type PollingFileWatcher <: UVPollingWatcher
         associate_julia_struct(handle,this)
         finalizer(this,uvfinalize)
         this
-    end  
+    end
     PollingFileWatcher(file) =  PollingFileWatcher(false,file)
 end
 
-@unix_only typealias FDW_FD RawFD 
+@unix_only typealias FDW_FD RawFD
 @windows_only typealias FDW_FD WindowsRawSocket
 
 @unix_only _get_osfhandle(fd::RawFD) = fd
@@ -141,7 +135,7 @@ function fdw_wait_cb(fdw::FDWatcher, events::FDEvent, status)
     end
 end
 
-function _wait(fdw::FDWatcher,readable,writable)
+function wait(fdw::FDWatcher; readable=false,writable=false)
     if !readable && !writable
         error("must watch for at least one event")
     end
@@ -165,46 +159,27 @@ function _wait(fdw::FDWatcher,readable,writable)
     events
 end
 
-# On Unix we can only have one watcher per FD, so we need to keep an explicit 
-# list of them. On Windows, I think it is techincally possible to have more than one
-# watcher per FD, but in order to keep compatibility, we do the same on windows as we do
-# on unix
-
-let
-    global fdwatcher_init, wait
-    @unix_only begin
-        local fdwatcher_array
-        function fdwatcher_init()
-            fdwatcher_array = Array(FDWatcher,0)
+@unix_only begin
+    function wait(fd::RawFD; readable=false, writable=false)
+        fdw = FDWatcher(fd)
+        try
+            return wait(fdw,readable=readable,writable=writable)
+        finally
+            close(fdw)
         end
-
-        function wait(fd::RawFD; readable=false, writable=false)
-            old_length = length(fdwatcher_array)
-            if fd.fd+1 > old_length
-                resize!(fdwatcher_array,fd.fd+1)
-            end
-            if !isdefined(fdwatcher_array,fd.fd+1)
-                fdwatcher_array[fd.fd+1] = FDWatcher(fd)
-            end
-            _wait(fdwatcher_array[fd.fd+1],readable,writable)
-        end 
     end
-    @windows_only begin
-        local fdwatcher_array
-        function fdwatcher_init()
-            fdwatcher_array = Dict{WindowsRawSocket,FDWatcher}()
+end
+@windows_only begin
+    function wait(fd::RawFD; readable=false, writable=false)
+        wait(_get_osfhandle(fd); readable=readable, writable=writable)
+    end
+    function wait(socket::WindowsRawSocket; readable=false, writable=false)
+        fdw = FDWatcher(fd)
+        try
+            return wait(fdw,readable=readable,writable=writable)
+        finally
+            close(fdw)
         end
-
-        function wait(fd::RawFD; readable=false, writable=false)
-            wait(_get_osfhandle(fd); readable=readable, writable=writable)
-        end
-
-        function wait(socket::WindowsRawSocket; readable=false, writable=false)
-            if !haskey(fdwatcher_array,socket.handle)
-                fdwatcher_array[socket] = FDWatcher(socket)
-            end
-            _wait(fdwatcher_array[socket],readable,writable)
-        end 
     end
 end
 
@@ -232,8 +207,13 @@ function wait(m::FileMonitor)
     filename, events
 end
 
-
-close(t::UVPollingWatcher) = ccall(:jl_close_uv,Void,(Ptr{Void},),t.handle)
+function close(t::Union(FileMonitor,UVPollingWatcher))
+    if t.handle != C_NULL
+        ccall(:jl_close_uv,Void,(Ptr{Void},),t.handle)
+        disassociate_julia_struct(t)
+        t.handle = C_NULL
+    end
+end
 
 function start_watching(t::FDWatcher, events::FDEvent)
     associate_julia_struct(t.handle, t)
@@ -293,30 +273,19 @@ end
 
 _uv_hook_close(uv::FileMonitor) = (uv.handle = 0; nothing)
 _uv_hook_close(uv::UVPollingWatcher) = (uv.handle = 0; nothing)
-
 function poll_fd(s, seconds::Real; readable=false, writable=false)
-    wt = Condition()
-
-    @schedule (args = wait(s; readable=readable, writable=writable); notify(wt,(:poll,args)))
-    @schedule (sleep(seconds); notify(wt,(:timeout,fdtimeout())))
-
-    _, ret = wait(wt)
-
-    return ret
+   t1 = () -> wait(s; readable=readable, writable=writable)
+   t2 = () -> (sleep(seconds); fdtimeout())
+   wait(t2, t1)
 end
 
 function poll_file(s, interval_seconds::Real, seconds::Real)
-    wt = Condition()
     pfw = PollingFileWatcher(s)
-
-    @schedule (wait(pfw;interval=interval_seconds); notify(wt,(:poll)))
-    @schedule (sleep(seconds); notify(wt,(:timeout)))
-
-    result = wait(wt)
-    if result == :timeout
-        stop_watching(pfw)
-    end
-    result == :poll
+    t1 = () -> (wait(pfw;interval=interval_seconds); return :poll)
+    t2 = () -> (sleep(seconds); return :timeout)
+    result = wait(t2, t1)
+    result == :timeout && stop_watching(pfw)
+    return result == :poll
 end
 
 watch_file(s; poll=false) = watch_file(false, s, poll=poll)
@@ -325,7 +294,7 @@ function watch_file(cb, s; poll=false)
         pfw = PollingFileWatcher(cb,s)
         start_watching(pfw)
         return pfw
-    else 
+    else
         return FileMonitor(cb,s)
     end
 end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -268,7 +268,6 @@ function __init__()
     # Base library init
     reinit_stdio()
     Multimedia.reinit_displays() # since Multimedia.displays uses STDOUT as fallback
-    fdwatcher_init()
 end
 
 include("precompile.jl")

--- a/base/task.jl
+++ b/base/task.jl
@@ -67,7 +67,7 @@ function task_done_hook(t::Task)
     #isa(q,Condition) && notify(q, result, error=err)
     if isa(q,Task)
         nexttask = q
-        !istaskdone(nexttask) && nexttask.state = :runnable
+        !istaskdone(nexttask) && (nexttask.state = :runnable)
     elseif isa(q,Condition) && !isempty(q.waitq)
         notify(q, result, error=err)
     end

--- a/base/task.jl
+++ b/base/task.jl
@@ -266,13 +266,12 @@ function wait(cs...)
     ct.state = :waiting
 
     killq = Array(Any, 2*length(cs)); resize!(killq,0)
-    for c in cs
-        c = waitq(c, killq)::Condition
-        push!(c.waitq, ct)
-        push!(killq, c)
-    end
-
     try
+        for c in cs
+            c = waitq(c, killq)::Condition
+            push!(c.waitq, ct)
+            push!(killq, c)
+        end
         for c in cs
             hasresult, res = waitresult(c)
             hasresult && return res

--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -1,16 +1,13 @@
-@unix_only begin
-require("testdefs.jl")
-
 # This script does the following
 # Sets up n unix pipes
-# For the odd pipes, a byte is written to the write end at intervals specified in intvls 
+# For the odd pipes, a byte is written to the write end at intervals specified in intvls
 # Nothing is written into the even numbered pipes
 # Odd numbered pipes are tested for reads
 # Even numbered pipes are tested for timeouts
 # Writable ends are always tested for writability before a write
 
 n = 20
-intvls = [0.1, 0.1, 1.0, 2.0]  # NOTE: The first interval is just used to let the readers/writers sort of synchnronize.
+intvls = [2, .2, .1, .002]
 
 pipe_fds = cell(n)
 for i in 1:n
@@ -19,61 +16,69 @@ for i in 1:n
 end
 
 
-function pfd_tst_reads(idx)
-    for (i, intvl) in enumerate(intvls)
-        tic()
-        evt = poll_fd(RawFD(pipe_fds[idx][1]), intvl * 10.0; readable=true, writable=true)
-        t_elapsed = toq()
-        @test evt.readable && !(evt.writable) && !(evt.timedout)
-        
-        # ignore the first one, everyone is just getting setup and synchronized
-        if i > 1
-#            println("i ", i, ", Expected ", intvl, ", actual ", t_elapsed, ", diff ", t_elapsed - intvl)
-            # Assuming that a 200 millisecond buffer is good enough on a modern system
-            @test t_elapsed <= (intvl + 0.2)
-        end
-        
-        
-        dout = Array(Uint8, 1)
-        @test 1 == ccall(:read, Csize_t, (Cint, Ptr{Uint8},Csize_t), pipe_fds[idx][1], dout, 1)
-        @test dout[1] == int8('A')
-    end    
+function pfd_tst_reads(idx, intvl)
+    global ready += 1
+    wait(ready_c)
+    tic()
+    evt = poll_fd(RawFD(pipe_fds[idx][1]), intvl; readable=true, writable=true)
+    t_elapsed = toq()
+    @test !evt.timedout
+    @test evt.readable
+    @test !evt.writable
+
+    # println("Expected ", intvl, ", actual ", t_elapsed, ", diff ", t_elapsed - intvl)
+    # Assuming that a 2 second buffer is good enough on a modern system
+    @test t_elapsed <= (intvl + 1)
+
+    dout = Array(Uint8, 1)
+    @test 1 == ccall(:read, Csize_t, (Cint, Ptr{Uint8},Csize_t), pipe_fds[idx][1], dout, 1)
+    @test dout[1] == int8('A')
 end
 
 
-function pfd_tst_timeout(idx)
-    for intvl in intvls
-        tic()
-        evt = poll_fd(RawFD(pipe_fds[idx][1]), intvl; readable=true, writable=true)
-        @test !(evt.readable) && !(evt.writable) && evt.timedout
-        t_elapsed = toq()
-        
-        @test (intvl <= t_elapsed) && (t_elapsed <= (intvl + 0.2)) 
-    end
+function pfd_tst_timeout(idx, intvl)
+    global ready += 1
+    wait(ready_c)
+    tic()
+    evt = poll_fd(RawFD(pipe_fds[idx][1]), intvl; readable=true, writable=false)
+    @test evt.timedout
+    @test !evt.readable
+    @test !evt.writable
+    t_elapsed = toq()
+
+    @test (intvl <= t_elapsed) && (t_elapsed <= (intvl + 1))
 end
 
 
 # Odd numbers trigger reads, even numbers timeout
-@sync begin
-    for i in 1:n
-        if isodd(i)
-            @async pfd_tst_reads(i)
-        else
-            @async pfd_tst_timeout(i)
+for (i, intvl) in enumerate(intvls)
+    @sync begin
+        global ready = 0
+        global ready_c = Condition()
+        for i in 1:n
+            if isodd(i)
+                @async pfd_tst_reads(i, intvl)
+            else
+                @async pfd_tst_timeout(i, intvl)
+            end
         end
-    end
-    
-    for (i, intvl) in enumerate(intvls)
-        sleep(intvl)
+
+        while ready < n
+            sleep(0.1)
+        end
+        ready = 0
         # tickle only the odd ones, but test for writablity for everyone
         for idx in 1:n
-            evt = poll_fd(RawFD(pipe_fds[idx][2]), 0.0; readable=true, writable=true)
-            @test !(evt.readable) && evt.writable && !(evt.timedout)
-            
+            evt = poll_fd(RawFD(pipe_fds[idx][2]), 0.001; readable=true, writable=true)
+            @test !evt.timedout
+            @test !evt.readable
+            @test evt.writable
+
             if isodd(idx)
                 @test 1 == ccall(:write, Csize_t, (Cint, Ptr{Uint8},Csize_t), pipe_fds[idx][2], bytestring("A"), 1)
             end
-        end    
+        end
+        notify(ready_c, all=true)
     end
 end
 
@@ -81,7 +86,4 @@ end
 for i in 1:n
     ccall(:close, Cint, (Cint,), pipe_fds[i][1])
     ccall(:close, Cint, (Cint,), pipe_fds[i][2])
-end
-
-
 end

--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -69,7 +69,7 @@ for (i, intvl) in enumerate(intvls)
         ready = 0
         # tickle only the odd ones, but test for writablity for everyone
         for idx in 1:n
-            evt = poll_fd(RawFD(pipe_fds[idx][2]), 0.001; readable=true, writable=true)
+            evt = wait(RawFD(pipe_fds[idx][2]); readable=true, writable=true)
             @test !evt.timedout
             @test !evt.readable
             @test evt.writable

--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -1,51 +1,87 @@
 @unix_only begin
 require("testdefs.jl")
 
-pipe_fds = Array(Cint,2)
-@test 0 == ccall(:pipe, Cint, (Ptr{Cint},), pipe_fds)
+# This script does the following
+# Sets up n unix pipes
+# For the odd pipes, a byte is written to the write end at times defined in intvls 
+# Nothing is written into the even numbered pipes
+# Odd numbered pipes are tested for reads
+# Even numbered pipes are tested for timeouts
+# Writable ends are always tested for writability before a write
 
-function test_poll_fd(timeout_s)
-    rc = poll_fd(RawFD(pipe_fds[1]), timeout_s; readable=true)
-    produce(rc)
+n = 20
+intvls = [0.1, 0.1, 1.0, 2.0]  # NOTE: The first interval is just used to let the readers/writers sort of synchnronize.
+
+pipe_fds = cell(n)
+for i in 1:n
+    pipe_fds[i] = Array(Cint, 2)
+    @test 0 == ccall(:pipe, Cint, (Ptr{Cint},), pipe_fds[i])
 end
 
-function test_timeout_fd(tval)
-    tic()
-    t = Task(()->test_poll_fd(tval))
-    tr = consume(t)
-    t_elapsed = toq()
 
-    @test tr.timedout
-
-    @test tval <= t_elapsed
+function pfd_tst_reads(idx)
+    for (i, intvl) in enumerate(intvls)
+        tic()
+        evt = poll_fd(RawFD(pipe_fds[idx][1]), intvl * 10.0; readable=true, writable=true)
+        t_elapsed = toq()
+        @test isreadable(evt) && !iswritable(evt) && !(evt.timedout)
+        
+        # ignore the first one, everyone is just getting setup and synchronized
+        if i > 1
+#            println("i ", i, ", Expected ", intvl, ", actual ", t_elapsed, ", diff ", t_elapsed - intvl)
+            # Assuming that a 200 millisecond buffer is good enough on a modern system
+            @test t_elapsed <= (intvl + 0.2)
+        end
+        
+        
+        dout = Array(Uint8, 1)
+        @test 1 == ccall(:read, Csize_t, (Cint, Ptr{Uint8},Csize_t), pipe_fds[idx][1], dout, 1)
+        @test dout[1] == int8('A')
+    end    
 end
 
-function test_read(slval)
-    tval = slval * 1.1
-    tic()
-    t = Task(()->test_poll_fd(tval))
 
-    sleep(slval)
-    @test 1 == ccall(:write, Csize_t, (Cint, Ptr{Uint8},Csize_t), pipe_fds[2], bytestring("A"), 1)
-
-    tr = consume(t)
-    t_elapsed = toq()
-
-    @test isreadable(tr) || iswritable(tr)
-
-    dout = Array(Uint8, 1)
-    @test 1 == ccall(:read, Csize_t, (Cint, Ptr{Uint8},Csize_t), pipe_fds[1], dout, 1)
-    @test dout[1] == int8('A')
-
-    @test slval <= t_elapsed
+function pfd_tst_timeout(idx)
+    for intvl in intvls
+        tic()
+        evt = poll_fd(RawFD(pipe_fds[idx][1]), intvl; readable=true, writable=true)
+        @test !isreadable(evt) && !iswritable(evt) && evt.timedout
+        t_elapsed = toq()
+        
+        @test (intvl <= t_elapsed) && (t_elapsed <= (intvl + 0.2)) 
+    end
 end
 
-test_timeout_fd(.1)
-test_timeout_fd(1)
-test_read(.1)
-test_read(1)
 
-ccall(:close, Cint, (Cint,), pipe_fds[1])
-ccall(:close, Cint, (Cint,), pipe_fds[2])
+# Odd numbers trigger reads, even numbers timeout
+@sync begin
+    for i in 1:n
+        if isodd(i)
+            @async pfd_tst_reads(i)
+        else
+            @async pfd_tst_timeout(i)
+        end
+    end
+    
+    for (i, intvl) in enumerate(intvls)
+        sleep(intvl)
+        # tickle only the odd ones, but test for writablity for everyone
+        for idx in 1:n
+            evt = poll_fd(RawFD(pipe_fds[idx][2]), 0.0; readable=true, writable=true)
+            @test !isreadable(evt) && iswritable(evt) && !(evt.timedout)
+            
+            if isodd(idx)
+                @test 1 == ccall(:write, Csize_t, (Cint, Ptr{Uint8},Csize_t), pipe_fds[idx][2], bytestring("A"), 1)
+            end
+        end    
+    end
+end
+
+
+for i in 1:n
+    ccall(:close, Cint, (Cint,), pipe_fds[i][1])
+    ccall(:close, Cint, (Cint,), pipe_fds[i][2])
+end
+
 
 end


### PR DESCRIPTION
@JeffBezanson This implements julep #6563 in order to fix the issues with poll_fd (#4401)

julep #6563 is implemented by separating the steps involved with a call to `wait` into their component parts:

`waitq` --> prepares the wait call
`waitresult` --> extract a result from wait (if present)
~~`waitcleanup` --> cleanup after the wait call (remove from waitq)~~
`waitkill` --> ~~additional~~ cleanup (destructors) after the wait call

if these specialized methods don't exist, it simply falls back to calling `wait` in a Task (graceful degradation means a loss in performance, but not in functionality)

client code can plug into these methods, just like they currently can extend `wait`. for example, see `Timer`

also notable: `sleep(::Real)` is now an alias for `wait()`, since `wait(::Real)` was defined to mean `wait for timeout`
