### PR TITLE
Extend pipelining to all Callables

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -170,7 +170,7 @@ copy(x::Union(Symbol,Number,String,Function,Tuple,LambdaStaticData,
               TopNode,QuoteNode,DataType,UnionType)) = x
 
 # function pipelining
-|>(x, f::Function) = f(x)
+|>(x, f::Callable) = f(x)
 
 # array shape rules
 


### PR DESCRIPTION
This would allow such things as:

```
"FredBarneyWilmaBetty" |> IOBuffer
```
