### PR TITLE
RFC: Use real terminal size for show (fix #7295 and #4513)

### DIFF
--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -106,20 +106,6 @@ type TerminalBuffer <: UnixTerminal
     out_stream::Base.IO
 end
 
-type FakeTerminal <: UnixTerminal
-    in_stream::Base.IO
-    out_stream::Base.IO
-    err_stream::Base.IO
-    hascolor::Bool
-    raw::Bool
-    FakeTerminal(stdin,stdout,stderr,hascolor=true) =
-        new(stdin,stdout,stderr,hascolor,false)
-end
-
-hascolor(t::FakeTerminal) = t.hascolor
-raw!(t::FakeTerminal, raw::Bool) = t.raw = raw
-size(t::FakeTerminal) = (24, 80)
-
 type TTYTerminal <: UnixTerminal
     term_type::ASCIIString
     in_stream::Base.TTY

--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -33,11 +33,6 @@ import Base:
     write,
     writemime
 
-immutable Size
-    width
-    height
-end
-
 ## TextTerminal ##
 
 abstract TextTerminal <: Base.IO
@@ -87,8 +82,8 @@ function writepos(t::TextTerminal, x, y, args...)
     cmove(t, x, y)
     write(t, args...)
 end
-width(t::TextTerminal) = size(t).width
-height(t::TextTerminal) = size(t).height
+width(t::TextTerminal) = size(t)[2]
+height(t::TextTerminal) = size(t)[1]
 
 # For terminals with buffers
 flush(t::TextTerminal) = nothing
@@ -117,14 +112,13 @@ type FakeTerminal <: UnixTerminal
     err_stream::Base.IO
     hascolor::Bool
     raw::Bool
-    size::Size
     FakeTerminal(stdin,stdout,stderr,hascolor=true) =
-        new(stdin,stdout,stderr,hascolor,false,Size(80,80))
+        new(stdin,stdout,stderr,hascolor,false)
 end
 
 hascolor(t::FakeTerminal) = t.hascolor
 raw!(t::FakeTerminal, raw::Bool) = t.raw = raw
-size(t::FakeTerminal) = t.size
+size(t::FakeTerminal) = (24, 80)
 
 type TTYTerminal <: UnixTerminal
     term_type::ASCIIString
@@ -170,15 +164,16 @@ disable_bracketed_paste(t::UnixTerminal) = write(t.out_stream, "$(CSI)?2004l")
 end_keypad_transmit_mode(t::UnixTerminal) = # tput rmkx
     write(t.out_stream, "$(CSI)?1l\x1b>")
 
-function size(t::TTYTerminal)
-    s = zeros(Int32, 2)
-    Base.uv_error("size (TTY)", ccall((@windows ? :jl_tty_get_winsize : :uv_tty_get_winsize),
-                                      Int32, (Ptr{Void}, Ptr{Int32}, Ptr{Int32}),
-                                      t.out_stream.handle, pointer(s,1), pointer(s,2)) != 0)
-    w,h = s[1],s[2]
-    w > 0 || (w = 80)
-    h > 0 || (h = 24)
-    Size(w,h)
+let s = zeros(Int32, 2)
+    function Base.size(t::TTYTerminal)
+        Base.uv_error("size (TTY)", ccall((@windows ? :jl_tty_get_winsize : :uv_tty_get_winsize),
+                                          Int32, (Ptr{Void}, Ptr{Int32}, Ptr{Int32}),
+                                          t.out_stream.handle, pointer(s,1), pointer(s,2)) != 0)
+        w,h = s[1],s[2]
+        w > 0 || (w = 80)
+        h > 0 || (h = 24)
+        (int(h),int(w))
+    end
 end
 
 clear(t::UnixTerminal) = write(t.out_stream, "\x1b[H\x1b[2J")

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -455,6 +455,15 @@ Set{T<:Number}(xs::T...) = Set{T}(xs)
 @deprecate readsfrom(cmd, args...)      open(cmd, "r", args...)
 @deprecate writesto(cmd, args...)      open(cmd, "w", args...)
 
+function tty_rows()
+    depwarn("tty_rows() is deprecated, use tty_size() instead", :tty_rows)
+    tty_size()[1]
+end
+function tty_cols()
+    depwarn("tty_cols() is deprecated, use tty_size() instead", :tty_cols)
+    tty_size()[2]
+end
+
 # 0.3 discontinued functions
 
 scale!{T<:Base.LinAlg.BlasReal}(X::Array{T}, s::Complex) = error("scale!: Cannot scale a real array by a complex value in-place.  Use scale(X::Array{Real}, s::Complex) instead.")

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -63,7 +63,8 @@ end
 
 showdict(t::Associative; kw...) = showdict(STDOUT, t; kw...)
 function showdict{K,V}(io::IO, t::Associative{K,V}; limit::Bool = false,
-                       rows = tty_rows()-3, cols = tty_cols())
+                       sz=(s = tty_size(); (s[1]-3, s[2])))
+    rows, cols = sz
     print(io, summary(t))
     isempty(t) && return
     print(io, ":")
@@ -118,7 +119,8 @@ show(io::IO, iter::Union(KeyIterator,ValueIterator)) = show(io, collect(iter))
 
 showkv(iter::Union(KeyIterator,ValueIterator); kw...) = showkv(STDOUT, iter; kw...)
 function showkv{T<:Union(KeyIterator,ValueIterator)}(io::IO, iter::T; limit::Bool = false,
-                                                     rows = tty_rows()-3, cols = tty_cols())
+                                                     sz=(s = tty_size(); (s[1]-3, s[2])))
+    rows, cols = sz
     print(io, summary(iter))
     isempty(iter) && return
     print(io, ". ", T<:KeyIterator ? "Keys" : "Values", ":")

--- a/base/env.jl
+++ b/base/env.jl
@@ -184,5 +184,15 @@ end
 
 ## misc environment-related functionality ##
 
-tty_cols() = parseint(Int32, get(ENV,"COLUMNS","80"), 10)
-tty_rows() = parseint(Int32, get(ENV,"LINES","25"), 10)
+function tty_size()
+    if isdefined(Base, :active_repl)
+        os = REPL.outstream(Base.active_repl)
+        if isa(os, Terminals.TTYTerminal)
+            try
+                sz = size(os)
+                return (sz.height, sz.width)
+            end
+        end
+    end
+    return (25, 80)
+end

--- a/base/env.jl
+++ b/base/env.jl
@@ -189,10 +189,9 @@ function tty_size()
         os = REPL.outstream(Base.active_repl)
         if isa(os, Terminals.TTYTerminal)
             try
-                sz = size(os)
-                return (sz.height, sz.width)
+                return size(os)
             end
         end
     end
-    return (25, 80)
+    return (24, 80)
 end

--- a/base/env.jl
+++ b/base/env.jl
@@ -188,9 +188,7 @@ function tty_size()
     if isdefined(Base, :active_repl)
         os = REPL.outstream(Base.active_repl)
         if isa(os, Terminals.TTYTerminal)
-            try
-                return size(os)
-            end
+            return size(os)
         end
     end
     return (24, 80)

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -497,7 +497,7 @@ end
 full(A::HessenbergQ) = LAPACK.orghr!(1, size(A.factors, 1), copy(A.factors), A.τ)
 
 # Also printing of QRQs
-print_matrix(io::IO, A::Union(QRPackedQ,QRCompactWYQ,HessenbergQ), rows::Integer, cols::Integer, punct...) = print_matrix(io, full(A), rows, cols, punct...)
+print_matrix(io::IO, A::Union(QRPackedQ,QRCompactWYQ,HessenbergQ), sz::(Integer, Integer), punct...) = print_matrix(io, full(A), sz, punct...)
 
 
 #######################

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -596,11 +596,12 @@ function check_metadata()
 end
 
 function warnbanner(msg...; label="[ WARNING ]", prefix="")
-    warn(prefix="", Base.cpad(label,Base.tty_cols(),"="))
+    cols = Base.tty_size()[2]
+    warn(prefix="", Base.cpad(label,cols,"="))
     println(STDERR)
     warn(prefix=prefix, msg...)
     println(STDERR)
-    warn(prefix="", "="^Base.tty_cols())
+    warn(prefix="", "="^cols)
 end
 
 function build!(pkgs::Vector, errs::Dict, seen::Set=Set())

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -34,7 +34,7 @@ __init__() = init(1_000_000, 0.001)
 
 clear() = ccall(:jl_profile_clear_data, Void, ())
 
-function print{T<:Unsigned}(io::IO, data::Vector{T} = fetch(), lidict::Dict = getdict(data); format = :tree, C = false, combine = true, cols = Base.tty_cols())
+function print{T<:Unsigned}(io::IO, data::Vector{T} = fetch(), lidict::Dict = getdict(data); format = :tree, C = false, combine = true, cols = Base.tty_size()[2])
     if format == :tree
         tree(io, data, lidict, C, combine, cols)
     elseif format == :flat

--- a/base/show.jl
+++ b/base/show.jl
@@ -827,8 +827,7 @@ function print_matrix_vdots(io::IO,
 end
 
 function print_matrix(io::IO, X::AbstractVecOrMat,
-                      rows::Integer = tty_rows()-4,
-                      cols::Integer = tty_cols(),
+                      sz::(Integer, Integer) = (s = tty_size(); (s[1]-4, s[2])),
                       pre::String = " ",
                       sep::String = "  ",
                       post::String = "",
@@ -836,6 +835,7 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
                       vdots::String = "\u22ee",
                       ddots::String = "  \u22f1  ",
                       hmod::Integer = 5, vmod::Integer = 5)
+    rows, cols = sz
     cols -= length(pre) + length(post)
     presp = repeat(" ", length(pre))
     postsp = ""
@@ -1001,7 +1001,8 @@ end
 showarray(X::AbstractArray; kw...) = showarray(STDOUT, X; kw...)
 function showarray(io::IO, X::AbstractArray;
                    header::Bool=true, limit::Bool=_limit_output,
-                   rows = tty_rows()-4, cols = tty_cols(), repr=false)
+                   sz = (s = tty_size(); (s[1]-4, s[2])), repr=false)
+    rows, cols = sz
     header && print(io, summary(X))
     if !isempty(X)
         header && println(io, ":")
@@ -1024,10 +1025,10 @@ function showarray(io::IO, X::AbstractArray;
         else
             punct = (" ", "  ", "")
             if ndims(X)<=2
-                print_matrix(io, X, rows, cols, punct...)
+                print_matrix(io, X, sz, punct...)
             else
                 show_nd(io, X, limit,
-                        (io,slice)->print_matrix(io,slice,rows,cols,punct...),
+                        (io,slice)->print_matrix(io,slice,sz,punct...),
                         !repr)
             end
         end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -20,7 +20,7 @@ countnz(S::SparseMatrixCSC) = countnz(S.nzval)
 
 function Base.showarray(io::IO, S::SparseMatrixCSC;
                         header::Bool=true, limit::Bool=Base._limit_output,
-                        rows = Base.tty_rows(), repr=false)
+                        rows = Base.tty_size()[1], repr=false)
     # TODO: repr?
 
     if header

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -179,7 +179,7 @@ for d in (["\n" => "\n", "1" => "\n", "\n" => "2"],
     for cols in (12, 40, 80), rows in (2, 10, 24)
         # Ensure output is limited as requested
         s = IOBuffer()
-        Base.showdict(s, d, limit=true, rows=rows, cols=cols)
+        Base.showdict(s, d, limit=true, sz=(rows, cols))
         out = split(takebuf_string(s),'\n')
         for line in out[2:end]
             @test strwidth(line) <= cols
@@ -188,7 +188,7 @@ for d in (["\n" => "\n", "1" => "\n", "\n" => "2"],
 
         for f in (keys, values)
             s = IOBuffer()
-            Base.showkv(s, f(d), limit=true, rows=rows, cols=cols)
+            Base.showkv(s, f(d), limit=true, sz=(rows, cols))
             out = split(takebuf_string(s),'\n')
             for line in out[2:end]
                 @test strwidth(line) <= cols

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -17,7 +17,21 @@ Base.link_pipe(stdin_read,true,stdin_write,true)
 Base.link_pipe(stdout_read,true,stdout_write,true)
 Base.link_pipe(stderr_read,true,stderr_write,true)
 
-repl = Base.REPL.LineEditREPL(Base.Terminals.FakeTerminal(stdin_read, stdout_write, stderr_write))
+type FakeTerminal <: Base.Terminals.UnixTerminal
+    in_stream::Base.IO
+    out_stream::Base.IO
+    err_stream::Base.IO
+    hascolor::Bool
+    raw::Bool
+    FakeTerminal(stdin,stdout,stderr,hascolor=true) =
+        new(stdin,stdout,stderr,hascolor,false)
+end
+
+Base.Terminals.hascolor(t::FakeTerminal) = t.hascolor
+Base.Terminals.raw!(t::FakeTerminal, raw::Bool) = t.raw = raw
+Base.Terminals.size(t::FakeTerminal) = (24, 80)
+
+repl = Base.REPL.LineEditREPL(FakeTerminal(stdin_read, stdout_write, stderr_write))
 # In the future if we want we can add a test that the right object
 # gets displayed by intercepting the display
 repl.specialdisplay = Base.REPL.REPLDisplay(repl)


### PR DESCRIPTION
Replaces `tty_rows()`/`tty_cols()` with `tty_size()`, which (through Terminals) calls `uv_tty_get_winsize()` to get the terminal size.

The reason for the change is that `uv_tty_get_winsize()` gives both the rows and columns, so if we wanted to keep `tty_rows()`/`tty_cols()`, we'd have to call `uv_tty_get_winsize()` once for each, even though they are nearly always used together. AFAIK none of the methods whose signatures I've changed were ever exported, but this could still break some packages.

I am assuming that calling `uv_tty_get_winsize()` is not expensive enough that it's worth registering a SIGWINCH handler and only updating the numbers on window resize, as readline used to do. My Linux system can do >10^6 calls to `tty_size()` per second, which seems plenty fast to me. Given how cheap the call is, it may not even be worth replacing `tty_rows()`/`tty_cols()`. Of course other platforms may be different.
