### PR TITLE
Performance: float(AbstractArray) and  complex(AbstractArray) 

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -315,8 +315,15 @@ end
 float{T<:FloatingPoint}(x::AbstractArray{T}) = x
 complex{T<:Complex}(x::AbstractArray{T}) = x
 
-float(A::AbstractArray)   = map_promote(x->convert(FloatingPoint,x), A)
-complex(A::AbstractArray) = map_promote(x->convert(Complex,x), A)
+function float(A::AbstractArray) 
+    cnv(x) = convert(FloatingPoint,x)
+    map_promote(cnv, A)
+end
+
+function complex(A::AbstractArray) 
+    cnv(x) = convert(Complex,x)
+    map_promote(cnv, A)
+end
 
 full(x::AbstractArray) = x
 


### PR DESCRIPTION
The test_profile() function used to demonstrate https://github.com/timholy/ProfileView.jl shows a performance hit from an anonymous function at abstractarray.jl line 319, which is complex(A::AbstractArray) .  map_promote() in that function contains an anonymous function that creates a performance hit.   Switching to a named function speeds test_profile() by about 3.3x on my 64-bit Linux system.  cc: @tholy

Profile View example with _current_ float(A::AbstractArray)  and complex(A::AbstractArray)  --  
http://nbviewer.ipython.org/gist/catawbasam/1fd6a82605a54b052425

Profile View example with _proposed_ float(A::AbstractArray)  and complex(A::AbstractArray)  --  
http://nbviewer.ipython.org/gist/catawbasam/e1768937952565213561
