### PR TITLE
added reflection method

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -222,6 +222,9 @@ code_warntype(f, t::(Type...)) = code_warntype(STDOUT, f, t)
 typesof(args...) = map(a->(isa(a,Type) ? Type{a} : typeof(a)), args)
 
 function gen_call_with_extracted_types(fcn, ex0)
+     if isa(ex0, Symbol)
+         return Expr(:call, fcn, Meta.quot(ex0))
+     end
     if isa(ex0, Expr) &&
         any(a->(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex0.args)
         # keyword args not used in dispatch, so just remove them
@@ -234,7 +237,7 @@ function gen_call_with_extracted_types(fcn, ex0)
                     Expr(:call, :typesof, map(esc, ex0.args[2:end])...))
     end
     ex = expand(ex0)
-    exret = Expr(:call, :error, "expression is not a function call")
+    exret = Expr(:call, :error, "expression is not a function call or symbol")
     if !isa(ex, Expr)
         # do nothing -> error
     elseif ex.head == :call

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -190,6 +190,8 @@ function which(f::ANY, t::(Type...))
     end
 end
 
+which(s::Symbol) = binding_module(current_module(), s)
+
 function functionloc(m::Method)
     lsd = m.func.code::LambdaStaticData
     ln = lsd.line
@@ -221,3 +223,13 @@ end
 
 type_alignment(x::DataType) = ccall(:jl_get_alignment,Csize_t,(Any,),x)
 field_offset(x::DataType,idx) = ccall(:jl_get_field_offset,Csize_t,(Any,Int32),x,idx)
+
+binding_module(var::Symbol) = binding_module(current_module(), var)
+function binding_module(m::Module, var::Symbol)
+    if isdefined(m, var) # this returns true for 'used' bindings
+        mod = ccall(:jl_get_module_of_binding, Any, (Any, Any), m, var)
+    else
+        error("Symbol $var is not bound in the module $m and not exported by any module 'used' within $m.")
+    end
+    mod
+end

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -106,10 +106,18 @@ Getting Around
    If ``types`` is an abstract type, then the method that would be called by ``invoke``
    is returned.
 
+.. function:: which(symbol)
+
+   Return the module in which the binding for the variable referenced
+   by ``symbol`` was created.
+
 .. function:: @which
 
-   Evaluates the arguments to the specified function call, and returns the ``Method`` object
-   for the method that would be called for those arguments.
+   Applied to a function call, it evaluates the arguments to the
+   specified function call, and returns the ``Method`` object for the
+   method that would be called for those arguments.  Applied to a
+   variable, it returns the module in which the variable was bound. It
+   calls out to the ``which`` function.
 
 .. function:: methods(f, [types])
 

--- a/src/module.c
+++ b/src/module.c
@@ -87,6 +87,15 @@ jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var)
     return *bp;
 }
 
+// return module of binding
+DLLEXPORT jl_module_t *jl_get_module_of_binding(jl_module_t *m, jl_sym_t *var)
+{
+    jl_binding_t *b = jl_get_binding(m, var);
+    if (b == NULL)
+        jl_errorf("Error: symbol :%s is not bound.", var->name);
+    return b->owner;
+}
+
 // get binding for adding a method
 // like jl_get_binding_wr, but uses existing imports instead of warning
 // and overwriting.


### PR DESCRIPTION
As far as I know, when using `using` it is not easy to find out which module a particular binding came from.  At least when the object the binding points to does not contain that data, like for instance a variable.

This adds a method and a macro to do that:

```
julia> Base.@binding_module sin
Base

julia> Base.@binding_module a
ERROR: Symbol a is not bound in the current module Main and not exported in any 'used' module.
 in error at error.jl:21
 in binding_module at reflection.jl:171

julia> a = 4
4

julia> Base.@binding_module a
Main

julia> Base.binding_module(:a)
Main
```

If this is of interest, someone should have a look at the c-code!  And I will add some test.  Should it be exported?  If so `function_module` should probably be exported too.
