### PR TITLE
RFC: Added find_extrema, ind_extrema

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1153,8 +1153,29 @@ function findmin(a)
     return (m, mi)
 end
 
-indmax(a) = findmax(a)[2]
-indmin(a) = findmin(a)[2]
+function findminmax(a)
+    if isempty(a)
+        error("array must be non-empty")
+    end
+    vmin = vmax = a[1]
+    imin = imax = 1
+    for i = 2:length(a)
+        ai = a[i]
+        if ai < vmin || vmin!=vmin
+            vmin = ai
+            imin = i
+        end
+        if ai > vmax || vmax!=vmax
+            vmax = ai
+            imax = i
+        end
+    end
+    return ((vmin,imin), (vmax,imax))
+end
+
+argmax(a) = findmax(a)[2]
+argmin(a) = findmin(a)[2]
+argminmax(a) = (x = findminmax(a); (x[1][2], x[2][2]))
 
 # similar to Matlab's ismember
 # returns a vector containing the highest index in b for each value in a that is a member of b

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -159,3 +159,5 @@ scale!{T<:Base.LinAlg.BlasReal}(X::Array{T}, s::Complex) = error("scale!: Cannot
 
 @deprecate which(f::Callable, args...) @which f(args...)
 @deprecate rmdir rm
+@deprecate indmin argmin
+@deprecate indmax argmax

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -486,6 +486,9 @@ export
     zeta,
 
 # arrays
+    argmax,
+    argmin,
+    argminmax,
     bitbroadcast,
     broadcast!,
     broadcast!_function,
@@ -516,6 +519,7 @@ export
     findin,
     findmax,
     findmin,
+    findminmax,
     findn,
     findnext,
     findnz,
@@ -528,8 +532,6 @@ export
     hvcat,
     ind2sub,
     indexin,
-    indmax,
-    indmin,
     invperm,
     ipermute!,
     ipermutedims,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -661,31 +661,55 @@ Iterable Collections
     Compute both the minimum and maximum element in a single pass, and
     return them as a 2-tuple.
 
-.. function:: indmax(itr) -> Integer
+.. function:: argmax(itr) -> Integer
 
    Returns the index of the maximum element in a collection.
 
-.. function:: indmin(itr) -> Integer
+   See also: :func:`maximum`, :func:`findmax`
+
+.. function:: argmin(itr) -> Integer
 
    Returns the index of the minimum element in a collection.
+
+   See also: :func:`minimum`, :func:`findmin`
+
+.. function:: argminmax(itr) -> (Integer, Integer)
+
+   Returns the index of the minimum and maximum elements in a collection.
+
+   See also: :func:`minimum`, :func:`findmin`
 
 .. function:: findmax(itr) -> (x, index)
 
    Returns the maximum element and its index.
+
+   See also: :func:`maximum`, :func:`argmax`
 
 .. function:: findmax(A, dims) -> (maxval, index)
 
    For an array input, returns the value and index of the maximum over
    the given dimensions.
 
+   See also: :func:`maximum`, :func:`argmax`
+
 .. function:: findmin(itr) -> (x, index)
 
    Returns the minimum element and its index.
+
+   See also: :func:`minimum`, :func:`argmin`
 
 .. function:: findmin(A, dims) -> (minval, index)
 
    For an array input, returns the value and index of the minimum over
    the given dimensions.
+
+   See also: :func:`minimum`, :func:`argmin`
+
+.. function:: findminmax(itr) -> ((x, index),(y,index))
+
+   Returns the minimum and maximum elements and their indices.
+
+   See also: :func:`extrema`, :func:`argminmax`
 
 .. function:: maxabs(itr)
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -298,14 +298,18 @@ end
 @test isequal(a,findn(z))
 
 #argmin argmax
-@test indmax([10,12,9,11]) == 2
-@test indmin([10,12,9,11]) == 3
+@test argmax([10,12,9,11]) == 2
+@test argmin([10,12,9,11]) == 3
+@test argminmax([10,12,9,11]) == (3,2)
 @test findmin([NaN,3.2,1.8]) == (1.8,3)
 @test findmax([NaN,3.2,1.8]) == (3.2,2)
+@test findminmax([NaN,3.2,1.8]) == ((1.8,3),(3.2,2))
 @test findmin([NaN,3.2,1.8,NaN]) == (1.8,3)
 @test findmax([NaN,3.2,1.8,NaN]) == (3.2,2)
+@test findminmax([NaN,3.2,1.8,NaN]) == ((1.8,3),(3.2,2))
 @test findmin([3.2,1.8,NaN,2.0]) == (1.8,2)
 @test findmax([3.2,1.8,NaN,2.0]) == (3.2,1)
+@test findminmax([3.2,1.8,NaN,2.0]) == ((1.8,2),(3.2,1))
 
 ## permutedims ##
 

--- a/test/euler.jl
+++ b/test/euler.jl
@@ -233,7 +233,7 @@ function euler14(m)
             d -= 1
         end
     end
-    indmax(c)
+    argmax(c)
 end
 @test euler14(999999) == 837799
 

--- a/test/perf/perfcomp.jl
+++ b/test/perf/perfcomp.jl
@@ -32,8 +32,8 @@ function main()
     end
     println()
 
-    minname = names[indmin(change)]
-    maxname = names[indmax(change)]
+    minname = names[argmin(change)]
+    maxname = names[argmax(change)]
 
     minstd = baseline[minname][4]/baseline[minname][3]
     maxstd = baseline[maxname][4]/baseline[maxname][3]


### PR DESCRIPTION
Just adding parity:

`findmin/indmin <=> minimum`
`findmax/indmin <=> maximum`
`findextrema/indextrema <=> extrema`

~~It's named `find_extrema` because `findextrema` (and particularly `indextrema`) seemed less readable to me.~~ (Names no longer contain underscores.)

Just checking first if this is wanted.  If so, I'll add docs.  If not, please close.

**Edit: large bikeshedding spreadsheet [here](https://docs.google.com/spreadsheet/ccc?key=0AuYXP8SQ1FDndGxoNzlkYVA3MnhOYTg4TkNMZE52RWc&usp=sharing#gid=0)**
