### PR TITLE
RFC: allow specifying particular packages in Pkg.update

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -40,6 +40,8 @@ pin(pkg::String, ver::VersionNumber) = cd(Entry.pin,pkg,ver)
 
 update() = cd(Entry.update,META_BRANCH)
 update(pkg::String) = cd(Entry.update,META_BRANCH,pkg)
+update(pkgs::String...) = cd(Entry.update,META_BRANCH,collect(pkgs))
+update(pkgs::Vector) = cd(Entry.update,META_BRANCH,pkgs)
 resolve() = cd(Entry.resolve)
 
 register(pkg::String) = cd(Entry.register,pkg)

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -39,6 +39,7 @@ pin(pkg::String) = cd(Entry.pin,pkg)
 pin(pkg::String, ver::VersionNumber) = cd(Entry.pin,pkg,ver)
 
 update() = cd(Entry.update,META_BRANCH)
+update(pkg::String) = cd(Entry.update,META_BRANCH,pkg)
 resolve() = cd(Entry.resolve)
 
 register(pkg::String) = cd(Entry.register,pkg)

--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -116,7 +116,7 @@ requires_dict(pkg::String, avail::Dict=available(pkg)) =
 
 function installed(avail::Dict=available())
     pkgs = Dict{ByteString,(VersionNumber,Bool)}()
-    for pkg in readdir()
+    for pkg in keys(avail)
         isinstalled(pkg) || continue
         ap = get(avail,pkg,Dict{VersionNumber,Available}())
         pkgs[pkg] = (installed_version(pkg,ap),isfixed(pkg,ap))


### PR DESCRIPTION
This adds a single package form of `Pkg.update`, which can be invoked as:

```
julia> Pkg.update("FooBar")
```

to get new versions of FooBar _only_. You can also do `Pkg.update("METADATA")` to just update METADATA without upgrading packages. I am somewhat unclear on what's going on with all the cache prefetch stuff and this duplicates a lot of code. There's probably a better way to factor this, but it seems to work so I figured I'd open an RFC just to get discussion going if nothing else (there's been some mailing list threads lately about this functionality and it's something I frequently want myself).
