### PR TITLE
Make median() always return a Float

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -462,7 +462,7 @@ function median!{T<:Real}(v::AbstractVector{T}; checknan::Bool=true)
     end
     n = length(v)
     if isodd(n)
-        return select!(v,div(n+1,2))
+        return float(select!(v,div(n+1,2)))
     else
         m = select!(v, div(n,2):div(n,2)+1)
         return (m[1] + m[2])/2

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -1,3 +1,7 @@
+@test median([1]) == 1.
+@test median([1,3]) == 2.
+@test median([1,3,2]) == 2.
+
 @test median([1.]) == 1.
 @test median([1.,3]) == 2.
 @test median([1.,3,2]) == 2.


### PR DESCRIPTION
This ensures type stability and is consistent with quantile().
Fixes #7331.
