### PR TITLE
missing : for codeblock

### DIFF
--- a/doc/manual/running-external-programs.rst
+++ b/doc/manual/running-external-programs.rst
@@ -48,7 +48,7 @@ can be used instead::
     true
 
 More generally, you can use ``open`` to read from or write to an external
-command.  For example:
+command.  For example::
 
     julia> open(`less`, "w", STDOUT) do io
                for i = 1:1000


### PR DESCRIPTION
One code example is showing up as a block quote due to a missing ':'
