### PR TITLE
WIP: use shared symlink pkg cache on Windows newer than XP

### DIFF
--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -11,8 +11,8 @@ function mkcachedir()
         return
     end
 
-    @windows_only mkdir(cache)
-    @unix_only begin
+    @windowsxp_only mkdir(cache)
+    @non_windowsxp_only begin
         if Dir.isversioned(pwd())
             rootcache = joinpath(realpath(".."), ".cache")
             if !isdir(rootcache)


### PR DESCRIPTION
This is following up on something @kmsquire asked me to do in #7274, now that symlinks sort of work on Windows newer than XP. Symlinks to files require admin rights in Vista/7/8, so for symlink to a directory we went with NTFS junctions instead.

Putting this up for review first, I'd like to do a bit more testing and verify that there are no bad interactions with #7055 for NTFS junctions. Also see #4396 for earlier discussion.
