### PR TITLE
Fix readlines return type

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -231,7 +231,7 @@ function done(itr::EachLine, nada)
     true
 end
 next(itr::EachLine, nada) = (readline(itr.stream), nothing)
-eltype(itr::EachLine) = ByteString
+eltype(itr::EachLine) = String
 
 readlines(s=STDIN) = collect(eachline(s))
 


### PR DESCRIPTION
This small fix ensures that `readlines` returns an array of type `Array{String}` as expected, instead of an array of type `Array{ByteString}`.
