### PR TITLE
Spurious check for step(r) == 0 in +in{T<:Integer}(x, r::Range{T})

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -524,4 +524,4 @@ function in(x, r::Range)
     n >= 1 && n <= length(r) && r[n] == x
 end
 
-in{T<:Integer}(x, r::Range{T}) = isinteger(x) && !isempty(r) && x>=minimum(r) && x<=maximum(r) && (step(r)==0 || mod(int(x)-first(r),step(r))==0)
+in{T<:Integer}(x, r::Range{T}) = isinteger(x) && !isempty(r) && x>=minimum(r) && x<=maximum(r) && (mod(int(x)-first(r),step(r))==0)


### PR DESCRIPTION
This removes a bit of possibly dangerous dead code. `step(r) != 0` is a constructor invariant for `<:Integer`-ranges and if that would not be the case, the test would return true even if 
`minimum(r)<x`.
