### PR TITLE
Deprecate pointer(Type{T},x) and update a few uses in Base. Fixes #2911.

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -464,6 +464,9 @@ function tty_cols()
     tty_size()[2]
 end
 
+@deprecate pointer{T}(::Type{T}, x::Uint) convert(Ptr{T}, x)
+@deprecate pointer{T}(::Type{T}, x::Ptr) convert(Ptr{T}, x)
+
 # 0.3 discontinued functions
 
 scale!{T<:Base.LinAlg.BlasReal}(X::Array{T}, s::Complex) = error("scale!: Cannot scale a real array by a complex value in-place.  Use scale(X::Array{Real}, s::Complex) instead.")

--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -109,7 +109,7 @@ function mmap_array{T,N}(::Type{T}, dims::NTuple{N,Integer}, s::IO, offset::File
     else
         pmap, delta = mmap(len, prot, flags, fd(s), offset)
     end
-    A = pointer_to_array(pointer(T, uint(pmap)+delta), dims)
+    A = pointer_to_array(convert(Ptr{T}, uint(pmap)+delta), dims)
     finalizer(A,x->munmap(pmap,len+delta))
     return A
 end
@@ -149,7 +149,7 @@ function mmap_array{T,N}(::Type{T}, dims::NTuple{N,Integer}, s::IO, offset::File
     if viewhandle == C_NULL
         error("could not create mapping view: $(FormatMessage())")
     end
-    A = pointer_to_array(pointer(T, viewhandle+offset-offset_page), dims)
+    A = pointer_to_array(convert(Ptr{T}, viewhandle+offset-offset_page), dims)
     finalizer(A, x->munmap(viewhandle, mmaphandle))
     return A
 end

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -22,8 +22,6 @@ convert(::Type{Ptr{Int8}}, s::ByteString) = convert(Ptr{Int8}, s.data)
 convert{T}(::Type{Ptr{T}}, a::Array{T}) = ccall(:jl_array_ptr, Ptr{T}, (Any,), a)
 convert(::Type{Ptr{None}}, a::Array) = ccall(:jl_array_ptr, Ptr{None}, (Any,), a)
 
-pointer{T}(::Type{T}, x::Uint) = convert(Ptr{T}, x)
-pointer{T}(::Type{T}, x::Ptr) = convert(Ptr{T}, x)
 # note: these definitions don't mean any AbstractArray is convertible to
 # pointer. they just map the array element type to the pointer type for
 # convenience in cases that work.

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -479,7 +479,7 @@ function deserialize(s, ::Type{DataType})
     deserialize(s, t)
 end
 
-deserialize{T}(s, ::Type{Ptr{T}}) = pointer(T, 0)
+deserialize{T}(s, ::Type{Ptr{T}}) = convert(Ptr{T}, 0)
 
 function deserialize(s, ::Type{Task})
     t = Task(deserialize(s))


### PR DESCRIPTION
cc: @Keno, @JeffBezanson, @ViralBShah 
