### PR TITLE
Create 7z'ed win bin distribution for use by chocolatey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,9 +278,7 @@ ifeq ($(OS), WINNT)
 	$(call spawn,./dist-extras/nsis/makensis.exe) -NOCD -DVersion=$(JULIA_VERSION) -DArch=$(ARCH) -DCommit=$(JULIA_COMMIT) ./contrib/windows/build-installer.nsi
 	./dist-extras/7z a -mx9 "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" julia-installer.exe
 	cat ./contrib/windows/7zS.sfx ./contrib/windows/7zSFX-config.txt "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" > "julia-${JULIA_VERSION}-${ARCH}.exe"
-	touch ./julia-$(JULIA_COMMIT)/bin/7z.exe.ignore
-	./dist-extras/7z a -mx9 julia-chocolatey-$(JULIA_COMMIT)-$(ARCH).7z ./julia-$(JULIA_COMMIT)/*
-	rm -f ./julia-$(JULIA_COMMIT)/bin/7z.exe.ignore
+	./dist-extras/7z a -mx9 julia-$(JULIA_VERSION)-$(JULIA_COMMIT)-$(ARCH).7z ./julia-$(JULIA_COMMIT)/*
 	-rm -f julia-installer.exe
 else
 	$(TAR) zcvf julia-$(JULIA_COMMIT)-$(OS)-$(ARCH).tar.gz julia-$(JULIA_COMMIT)

--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,9 @@ ifeq ($(OS), WINNT)
 	$(call spawn,./dist-extras/nsis/makensis.exe) -NOCD -DVersion=$(JULIA_VERSION) -DArch=$(ARCH) -DCommit=$(JULIA_COMMIT) ./contrib/windows/build-installer.nsi
 	./dist-extras/7z a -mx9 "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" julia-installer.exe
 	cat ./contrib/windows/7zS.sfx ./contrib/windows/7zSFX-config.txt "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" > "julia-${JULIA_VERSION}-${ARCH}.exe"
+	touch ./julia-$(JULIA_COMMIT)/bin/7z.exe.ignore
+	./dist-extras/7z a -mx9 julia-chocolatey-$(JULIA_COMMIT)-$(ARCH).7z ./julia-$(JULIA_COMMIT)/*
+	rm -f ./julia-$(JULIA_COMMIT)/bin/7z.exe.ignore
 	-rm -f julia-installer.exe
 else
 	$(TAR) zcvf julia-$(JULIA_COMMIT)-$(OS)-$(ARCH).tar.gz julia-$(JULIA_COMMIT)


### PR DESCRIPTION
See also #7386.

Ideally this PR would be merged soonish, and then the nightly build script be updated so that one 7z for x86 and one for x64 created by this code gets uploaded to amazon with each nightly build.

Things would be easiest if the nightly build script loaded all of these files into `http://s3.amazonaws.com/julianightlies/bin/winnt/chocolatey/`, i.e. if there weren't separate sub dirs for platform or julia version.

Having this in place now, before the chocolatey stuff is done, would allows us to work on the chocolatey package for real, i.e. with the necessary 7z files in place to be downloaded by chocolatey.
