### PR TITLE
WIP: Add an optional coverage argument to Pkg.test

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -63,8 +63,8 @@ generate(pkg::String, license::String; force::Bool=false) =
 	cd(Generate.package,pkg,license,force=force)
 
 
-test() = cd(Entry.test)
-test(pkgs::String...) = cd(Entry.test,String[pkgs...])
+test(coverage=false) = cd(Entry.test,coverage)
+test(pkgs::Vector{String},coverage=false) = cd(Entry.test,pkgs)
 
 @deprecate release free
 @deprecate fixup build

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -666,7 +666,7 @@ function updatehook(pkgs::Vector)
     """)
 end
 
-function test!(pkg::String, errs::Vector{String}, notests::Vector{String})
+function test!(pkg::String, errs::Vector{String}, notests::Vector{String},coverage::Bool=false)
     const reqs_path = abspath(pkg,"test","REQUIRE")
     if isfile(reqs_path)
         const tests_require = Reqs.parse(reqs_path)
@@ -680,7 +680,7 @@ function test!(pkg::String, errs::Vector{String}, notests::Vector{String})
         info("Testing $pkg")
         cd(dirname(test_path)) do
             try
-                run(`$JULIA_HOME/julia $test_path`)
+                run(`$JULIA_HOME/julia $(coverage?"--code-coverage":"") $test_path`)
                 info("$pkg tests passed")
             catch err
                 warnbanner(err, label="[ ERROR: $pkg ]")
@@ -693,7 +693,7 @@ function test!(pkg::String, errs::Vector{String}, notests::Vector{String})
     resolve()
 end
 
-function test(pkgs::Vector{String})
+function test(pkgs::Vector{String},coverage::Bool=false)
     errs = String[]
     notests = String[]
     for pkg in pkgs
@@ -707,6 +707,6 @@ function test(pkgs::Vector{String})
     end
 end
 
-test() = test(sort!(String[keys(installed())...]))
+test(coverage::Bool=false) = test(sort!(String[keys(installed())...]),coverage)
 
 end # module


### PR DESCRIPTION
To address the issue raised in https://github.com/IainNZ/Coverage.jl/issues/9, whereby
`julia --code-coverage -e 'Pkg.test("MyPackage")'` 
doesn't work like you might think for a moment it does.
