### PR TITLE
Update to enable compilation with latest LLVM trunk.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -44,7 +44,6 @@
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/Target/TargetMachine.h"
-#include "llvm/ADT/OwningPtr.h"
 #else
 #include "llvm/Analysis/Verifier.h"
 #endif
@@ -120,7 +119,9 @@
 #include "llvm/MC/MCInstPrinter.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCContext.h"
+#ifndef LLVM35
 #include "llvm/ADT/OwningPtr.h"
+#endif
 #include "llvm/ADT/Triple.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/MemoryObject.h"
@@ -128,7 +129,9 @@
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/raw_ostream.h"
+#ifndef LLVM35
 #include "llvm/Support/system_error.h"
+#endif
 
 #if defined(_OS_WINDOWS_) && !defined(NOMINMAX)
 #define NOMINMAX
@@ -388,7 +391,11 @@ void jl_dump_objfile(char* fname, int jit_model)
 #if defined(_OS_WINDOWS_) && defined(USE_MCJIT)
     TheTriple.setObjectFormat(Triple::COFF);
 #endif
+#ifdef LLVM35
+    std::unique_ptr<TargetMachine>
+#else
     OwningPtr<TargetMachine>
+#endif
     TM(jl_TargetMachine->getTarget().createTargetMachine(
         TheTriple.getTriple(),
         jl_TargetMachine->getTargetCPU(),

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -107,7 +107,7 @@ void jl_dump_function_asm(void *Fptr, size_t Fsize,
     MCContext Ctx(MAI.get(), MRI.get(), MOFI.get(), &SrcMgr);
 #else
     MCContext Ctx(*MAI, *MRI, MOFI.get(), &SrcMgr);
-#endif    
+#endif
     MOFI->InitMCObjectFileInfo(TripleName, Reloc::Default, CodeModel::Default, Ctx);
 
     // Set up Subtarget and Disassembler

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -75,20 +75,34 @@ void jl_dump_function_asm(void *Fptr, size_t Fsize,
     const Target* TheTarget = TargetRegistry::lookupTarget(TripleName, err);
 
     // Set up required helpers and streamer 
+#ifdef LLVM35
+    std::unique_ptr<MCStreamer> Streamer;
+#else
     OwningPtr<MCStreamer> Streamer;
+#endif
     SourceMgr SrcMgr;
 
-#ifdef LLVM34
+#ifdef LLVM35
+    std::unique_ptr<MCAsmInfo> MAI(TheTarget->createMCAsmInfo(*TheTarget->createMCRegInfo(TripleName),TripleName));
+#elif defined(LLVM34)
     llvm::OwningPtr<MCAsmInfo> MAI(TheTarget->createMCAsmInfo(*TheTarget->createMCRegInfo(TripleName),TripleName));
 #else
     llvm::OwningPtr<MCAsmInfo> MAI(TheTarget->createMCAsmInfo(TripleName));
 #endif
     assert(MAI && "Unable to create target asm info!");
 
+#ifdef LLVM35
+    std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+#else
     llvm::OwningPtr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+#endif
     assert(MRI && "Unable to create target register info!");
 
+#ifdef LLVM35
+    std::unique_ptr<MCObjectFileInfo> MOFI(new MCObjectFileInfo());
+#else
     OwningPtr<MCObjectFileInfo> MOFI(new MCObjectFileInfo());
+#endif
 #ifdef LLVM34
     MCContext Ctx(MAI.get(), MRI.get(), MOFI.get(), &SrcMgr);
 #else
@@ -97,11 +111,13 @@ void jl_dump_function_asm(void *Fptr, size_t Fsize,
     MOFI->InitMCObjectFileInfo(TripleName, Reloc::Default, CodeModel::Default, Ctx);
 
     // Set up Subtarget and Disassembler
+#ifdef LLVM35
+    std::unique_ptr<MCSubtargetInfo>
+        STI(TheTarget->createMCSubtargetInfo(TripleName, MCPU, Features.getString()));
+    std::unique_ptr<const MCDisassembler> DisAsm(TheTarget->createMCDisassembler(*STI, Ctx));
+#else
     OwningPtr<MCSubtargetInfo>
         STI(TheTarget->createMCSubtargetInfo(TripleName, MCPU, Features.getString()));
-#ifdef LLVM35
-    OwningPtr<const MCDisassembler> DisAsm(TheTarget->createMCDisassembler(*STI, Ctx));
-#else
     OwningPtr<const MCDisassembler> DisAsm(TheTarget->createMCDisassembler(*STI));
 #endif
     if (!DisAsm) {
@@ -113,7 +129,11 @@ void jl_dump_function_asm(void *Fptr, size_t Fsize,
     bool ShowEncoding = false;
     bool ShowInst = false;
 
+#ifdef LLVM35
+    std::unique_ptr<MCInstrInfo> MCII(TheTarget->createMCInstrInfo());
+#else
     OwningPtr<MCInstrInfo> MCII(TheTarget->createMCInstrInfo());
+#endif
     MCInstPrinter* IP =
         TheTarget->createMCInstPrinter(OutputAsmVariant, *MAI, *MCII, *MRI, *STI);
     MCCodeEmitter *CE = 0;


### PR DESCRIPTION
LLVM trunk as replaced their homebrew `OwningPtr` with C++11's `std::unique_ptr`, and eliminated `llvm/Support/system_error.h`.  This PR updates the Julia sources to match.

As an alternative to minimize preprocessor lines, I considered creating a template typedef for `OwningPtr`.  But that seemed like it would be creating more obscure legacy code.
