### PR TITLE
init.c tweak

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -123,6 +123,7 @@ void fpe_handler(int arg)
 }
 #endif
 
+#ifndef _OS_WINDOWS_
 static int is_addr_on_stack(void *addr)
 {
 #ifdef COPY_STACKS
@@ -133,6 +134,7 @@ static int is_addr_on_stack(void *addr)
             (char*)addr < (char*)jl_current_task->stack+jl_current_task->ssize);
 #endif
 }
+#endif
 
 #if defined(__linux__) || defined(__FreeBSD__)
 extern int in_jl_;


### PR DESCRIPTION
The windows build has gotten so tidy lately; this suppresses and unused method warning on windows. First time editing julia source! (hopefully this doesn't break everything....)
