### PR TITLE
Added checkbox for creation of the desktop shortcut and branding text

### DIFF
--- a/contrib/windows/build-installer.nsi
+++ b/contrib/windows/build-installer.nsi
@@ -1,4 +1,6 @@
-!include "MUI.nsh"
+!include "MUI2.nsh"
+!include "nsDialogs.nsh"
+!include "winmessages.nsh"
 
 Name "The Julia Language"
 OutFile "julia-installer.exe"
@@ -7,6 +9,25 @@ CRCCheck on
 SetDataBlockOptimize on
 ShowInstDetails show
 RequestExecutionLevel user
+BrandingText "Julia ${Version}"
+
+# User interface changes
+var Checkbox
+
+# Add the desktop checkbox to the final page.
+Function desktopCheckbox
+  ${NSD_CreateCheckbox} 120u 130u 100% 10u "Create &desktop shortcut"
+  Pop $Checkbox
+  SetCtlColors $Checkbox "" "ffffff"
+FunctionEnd
+
+# Create the desktop link only, if the desktop checkbox is active.
+Function createDesktopLink
+  ${NSD_GetState} $Checkbox $0
+  ${If} $0 <> 0
+    CreateShortCut "$DESKTOP\Julia.lnk" "$INSTDIR\bin\julia.exe"
+  ${EndIf}
+FunctionEnd
 
 # Icon settings
 !define MUI_ICON "contrib\windows\julia.ico"
@@ -30,6 +51,9 @@ InstallDir "$LOCALAPPDATA\Julia-${Version}"
 
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
+
+!define MUI_PAGE_CUSTOMFUNCTION_SHOW desktopCheckbox
+!define MUI_PAGE_CUSTOMFUNCTION_LEAVE createDesktopLink
 !insertmacro MUI_PAGE_FINISH
 
 !insertmacro MUI_LANGUAGE "English"
@@ -43,6 +67,7 @@ SectionEnd
  
 Section "uninstall"
     Delete "$INSTDIR/uninstall.exe"
+    Delete "$DESKTOP\Julia.lnk"
     RMDir /r "$SMPROGRAMS\${StartMenuFolder}"
     RMDir /r "$INSTDIR/"
 SectionEnd
@@ -53,6 +78,8 @@ Function AddToStartMenu
     CreateShortcut "$SMPROGRAMS\${StartMenuFolder}\julia.lnk" "$INSTDIR\julia.lnk" "" "" "" "" "" "The Julia Language"
     CreateShortcut "$SMPROGRAMS\${StartMenuFolder}\Uninstall.lnk" "$instdir\Uninstall.exe"
 FunctionEnd 
+
+# Opens the installation folder
 Function ShowInstallFolder
     ExecShell "open" $INSTDIR
 FunctionEnd


### PR DESCRIPTION
Hello, 

I have added to the Julia installer a checkbox for the creation of the desktop shortcut and added the branding text too. In the processes I had to change the includes. Now Ithe script is including MUI2.nsh instead of MUI.nsh.

The following screenshots show the changes:

![image](https://cloud.githubusercontent.com/assets/442931/3387628/058aed0c-fc80-11e3-8b44-1272a5357d6f.png)

![image](https://cloud.githubusercontent.com/assets/442931/3387654/3504e718-fc80-11e3-9e5e-71dd7382a2e3.png)

Please let me know, if the changes are OK.

I can continue to contribute to this installer, so also new suggestions would be appreciated.

Regards,

Gil
