### PR TITLE
root module on allocation

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1393,6 +1393,10 @@ JL_CALLABLE(jl_apply_generic)
       otherwise instantiate the generic method and use it
     */
     jl_function_t *mfunc = jl_method_table_assoc_exact(mt, args, nargs);
+    // if running inference overwrites this particular method, it becomes
+    // unreachable from the method table, thus :
+    JL_GC_PUSH1(&mfunc);
+
     if (mfunc != jl_bottom_func) {
         if (mfunc->linfo != NULL && 
             (mfunc->linfo->inInference || mfunc->linfo->inCompile)) {
@@ -1418,11 +1422,13 @@ JL_CALLABLE(jl_apply_generic)
             show_call(F, args, nargs);
         }
 #endif
+        JL_GC_POP();
         return jl_no_method_error((jl_function_t*)F, args, nargs);
     }
     assert(!mfunc->linfo || !mfunc->linfo->inInference);
-
-    return jl_apply(mfunc, args, nargs);
+    jl_value_t* res = jl_apply(mfunc, args, nargs);
+    JL_GC_POP();
+    return res;
 }
 
 // invoke()

--- a/src/module.c
+++ b/src/module.c
@@ -17,6 +17,7 @@ jl_module_t *jl_current_module=NULL;
 jl_module_t *jl_new_module(jl_sym_t *name)
 {
     jl_module_t *m = (jl_module_t*)allocobj(sizeof(jl_module_t));
+    JL_GC_PUSH1(&m);
     m->type = (jl_value_t*)jl_module_type;
     assert(jl_is_symbol(name));
     m->name = name;
@@ -29,6 +30,7 @@ jl_module_t *jl_new_module(jl_sym_t *name)
     // export own name, so "using Foo" makes "Foo" itself visible
     jl_set_const(m, name, (jl_value_t*)m);
     jl_module_export(m, name);
+    JL_GC_POP();
     return m;
 }
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -51,13 +51,13 @@ jl_module_t *jl_new_main_module(void)
 
     jl_main_module = jl_new_module(jl_symbol("Main"));
     jl_main_module->parent = jl_main_module;
+    jl_current_module = jl_main_module;
+
     jl_core_module->parent = jl_main_module;
     jl_set_const(jl_main_module, jl_symbol("Core"),
                  (jl_value_t*)jl_core_module);
     jl_set_global(jl_core_module, jl_symbol("Main"),
                   (jl_value_t*)jl_main_module);
-
-    jl_current_module = jl_main_module;
     jl_current_task->current_module = jl_main_module;
 
     return old_main;


### PR DESCRIPTION
While allocating a module, set_const and module_export can allocate memory so the module must be rooted.
This could be the cause of #6637 but I'm not sure.
I don't think anybody actually ever hit the second one since it is very rare but well...
