### PR TITLE
Fix #7420

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -270,7 +270,7 @@ end
 
 function getindex(r::FloatRange, s::OrdinalRange)
     0 < last(s) <= length(r) || throw(BoundsError())
-    FloatRange(r[first(s)],step(r)*step(s),length(s),r.divisor)
+    FloatRange(r[first(s)], r.step*step(s),length(s),r.divisor)
 end
 
 function show(io::IO, r::Range)


### PR DESCRIPTION
When indexing a FloatRange with a OrdinalRange, you have to be careful to use the actual r.step, instead of step(r) = r.step/r.divisor.
