### PR TITLE
Fix #7387, operations between ranges and non-real numbers

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -458,7 +458,16 @@ convert{T}(::Type{FloatRange{T}}, r::OrdinalRange) =
 
 # +/- of ranges is defined in operators.jl (to be able to use @eval etc.)
 
-## non-linear operations on ranges ##
+## non-linear operations on ranges and fallbacks for non-real numbers ##
+
+.+(x::Number, r::Range) = [ x+y for y=r ]
+.+(r::Range, y::Number) = [ x+y for x=r ]
+
+.-(x::Number, r::Range) = [ x-y for y=r ]
+.-(r::Range, y::Number) = [ x-y for x=r ]
+
+.*(x::Number, r::Range) = [ x*y for y=r ]
+.*(r::Range, y::Number) = [ x*y for x=r ]
 
 ./(x::Number, r::Range) = [ x/y for y=r ]
 ./(r::Range, y::Number) = [ x/y for x=r ]

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -325,3 +325,11 @@ r = linrange(0.25,0.25,1)
 #issue #7484
 r7484 = 0.1:0.1:1
 @test [reverse(r7484)] == reverse([r7484])
+
+# issue #7387
+for r in (0:1, 0.0:1.0)
+    @test r+im == [r]+im
+    @test r-im == [r]-im
+    @test r*im == [r]*im
+    @test r/im == [r]/im
+end


### PR DESCRIPTION
This seems pretty trivial, but it occurs to me that it would be nice to have generic fallbacks for these functions for all AbstractArrays so that it's not necessary to reimplement them for user-defined types. In that case we would presumably want to use `similar` instead of comprehensions, but then there's the problem of getting the element type right, which is ultimately related to how we decide to handle #7258. So for now, I'm punting on that and just making the minimal change to fix this issue.
