### PR TITLE
stop exporting Enumerate, Filter, Zip

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -43,11 +43,9 @@ export
     Dict,
     Dims,
     EachLine,
-    Enumerate,
     Factorization,
     FileMonitor,
     FileOffset,
-    Filter,
     FloatRange,
     Hermitian,
     UniformScaling,
@@ -111,7 +109,6 @@ export
     WeakRef,
     Woodbury,
     WString,
-    Zip,
 
 # Ccall types
     Cchar,
@@ -194,7 +191,7 @@ export
     ≠,
     !==,
     ≡,
-    ≢, 
+    ≢,
     $,
     %,
     &,
@@ -1208,7 +1205,7 @@ export
 # shared arrays
     sdata,
     indexpids,
-    
+
 # paths and file names
     abspath,
     basename,


### PR DESCRIPTION
Friends `Zip2` and `Rest` aren't exported now. And I think apart from clearing up the namespace, not exporting would be nice in terms of freedom to change implementations (of `enumerate`, etc.).
