### PR TITLE
Windows: don't concatenate to etc/julia/juliarc.jl in make dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,8 +260,6 @@ endif
 	# If you want to make a distribution with a hardcoded path, you take care of installation
 ifeq ($(OS), Darwin)
 	-cat ./contrib/mac/juliarc.jl >> $(DESTDIR)$(prefix)/etc/julia/juliarc.jl
-else ifeq ($(OS), WINNT)
-	-cat ./contrib/windows/juliarc.jl >> $(DESTDIR)$(prefix)/etc/julia/juliarc.jl
 endif
 
 	# purge sys.{dll,so,dylib} as that file is not relocatable across processor architectures


### PR DESCRIPTION
This is already concatenated into as a prerequisite of `make release`,
and copied over by `make install` on line 235. There are 2 copies of
the `let user_data_dir` block in the distribution folder.

Unlike the Mac version which only goes into `make dist`, on Windows this
block goes into juliarc even for the not-yet-installed copy in `usr/etc/julia`.
