### PR TITLE
Windows: download busybox-win32 during make win-extras

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -51,3 +51,4 @@ External libraries, if used, include their own licenses:
 - [RMATH](http://www.r-project.org/Licenses/)
 - [SUITESPARSE](http://www.cise.ufl.edu/research/sparse/SuiteSparse/current/SuiteSparse/)
 - [ZLIB](http://zlib.net/zlib_license.html)
+- [BUSYBOX](https://github.com/rmyorston/busybox-w32/blob/master/LICENSE)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -26,7 +26,6 @@ Julia is licensed under the MIT License:
 
 External libraries, if used, include their own licenses:
 
-- [7-Zip](http://www.7-zip.org/license.txt)
 - [AMOS](http://www.netlib.org/slatec/guide)
 - [ARPACK](http://www.caam.rice.edu/software/ARPACK/RiceBSD.txt#LICENSE)
 - [ATLAS](http://math-atlas.sourceforge.net/faq.html#license)
@@ -37,7 +36,6 @@ External libraries, if used, include their own licenses:
 - [FADDEEVA](http://ab-initio.mit.edu/Faddeeva)
 - [FEMTOLISP](https://github.com/JeffBezanson/femtolisp)
 - [FFTW](http://fftw.org/doc/License-and-Copyright.html)
-- [GIT](http://git-scm.com/about/free-and-open-source)
 - [GMP](http://gmplib.org/manual/Copying.html#Copying)
 - [LAPACK](http://netlib.org/lapack/LICENSE.txt)
 - [LIBEXPAT](http://expat.cvs.sourceforge.net/viewvc/expat/expat/README)
@@ -51,4 +49,9 @@ External libraries, if used, include their own licenses:
 - [RMATH](http://www.r-project.org/Licenses/)
 - [SUITESPARSE](http://www.cise.ufl.edu/research/sparse/SuiteSparse/current/SuiteSparse/)
 - [ZLIB](http://zlib.net/zlib_license.html)
+
+Julia bundles the following as external executables on some platforms:
+
+- [7-Zip](http://www.7-zip.org/license.txt)
 - [BUSYBOX](https://github.com/rmyorston/busybox-w32/blob/master/LICENSE)
+- [GIT](http://git-scm.com/about/free-and-open-source)

--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,9 @@ ifeq ($(OS), WINNT)
 	[ ! -d dist-extras ] || ( cd dist-extras && \
 		cp 7z.exe 7z.dll libexpat-1.dll zlib1.dll $(bindir) && \
 	    mkdir $(DESTDIR)$(prefix)/Git && \
-	    7z x PortableGit.7z -o"$(DESTDIR)$(prefix)/Git" )
+	    7z x PortableGit.7z -o"$(DESTDIR)$(prefix)/Git" && \
+	    cp busybox.exe $(DESTDIR)$(prefix)/Git/bin/echo.exe && \
+	    cp busybox.exe $(DESTDIR)$(prefix)/Git/bin/printf.exe )
 	cd $(DESTDIR)$(bindir) && rm -f llvm* llc.exe lli.exe opt.exe LTO.dll bugpoint.exe macho-dump.exe
 	$(call spawn,./dist-extras/nsis/makensis.exe) -NOCD -DVersion=$(JULIA_VERSION) -DArch=$(ARCH) -DCommit=$(JULIA_COMMIT) ./contrib/windows/build-installer.nsi
 	./dist-extras/7z a -mx9 "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" julia-installer.exe
@@ -387,10 +389,12 @@ endif
 	cd dist-extras && \
 	$(JLDOWNLOAD) http://downloads.sourceforge.net/sevenzip/7z920_extra.7z && \
 	$(JLDOWNLOAD) https://unsis.googlecode.com/files/nsis-2.46.5-Unicode-setup.exe && \
+	$(JLDOWNLOAD) ftp://ftp.tigress.co.uk/public/gpl/6.0.0/busybox/busybox.exe && \
 	chmod a+x 7z.exe && \
 	chmod a+x 7z.dll && \
 	$(call spawn,./7z.exe) x -y -onsis nsis-2.46.5-Unicode-setup.exe && \
 	chmod a+x ./nsis/makensis.exe && \
+	chmod a+x busybox.exe && \
 	7z x -y mingw-libexpat.rpm -so > mingw-libexpat.cpio && \
 	7z e -y mingw-libexpat.cpio && \
 	7z x -y mingw-zlib.rpm -so > mingw-zlib.cpio && \


### PR DESCRIPTION
copy it to echo.exe and printf.exe during make dist
This allows test/spawn.jl to succeed on Windows, since echo and printf
are only included as shell scripts in msysgit (and an echo.bat in
contrib/windows), but libuv cannot spawn shell or bat scripts.

This is an alternative to #7349. Use of busybox can be either removed
or expanded upon in the future when msysgit is no longer bundled with
Windows Julia, for now this is just to make the spawn tests pass.

cc @vtjnash
https://github.com/rmyorston/busybox-w32 for more info on busybox-win32 -
it's unfortunately GPLv2, but so's msysgit so no big difference there.
