### PR TITLE
fix #7082, and workaround for windows "feature" #7174

### DIFF
--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -127,11 +127,10 @@ cmove_line_up(t::UnixTerminal, n) = (cmove_up(t, n); cmove_col(t, 0))
 cmove_line_down(t::UnixTerminal, n) = (cmove_down(t, n); cmove_col(t, 0))
 cmove_col(t::UnixTerminal, n) = write(t.out_stream, "$(CSI)$(n)G")
     
-@windows ? begin 
-    ispty(s::Base.AsyncStream) = bool(ccall(:jl_ispty, Cint, (Ptr{Void},), s))
-    ispty(s) = false
+@windows ? begin
+    import Base.ispty
     function raw!(t::TTYTerminal,raw::Bool)
-        if ispty(t.in_stream) || ispty(t.out_stream) || ispty(t.err_stream)
+        if ispty(t.in_stream)
             run(if raw
                     `stty raw -echo onlcr -ocrnl opost`
                 else

--- a/base/env.jl
+++ b/base/env.jl
@@ -32,7 +32,7 @@ _hasenv(s::String) = _hasenv(utf16(s))
 function _jl_win_getenv(s::UTF16String,len::Uint32)
     val=zeros(Uint16,len)
     ret=ccall(:GetEnvironmentVariableW,stdcall,Uint32,(Ptr{Uint16},Ptr{Uint16},Uint32),s,val,len)
-    if ret==0 || ret != len-1 || val[end] != 0
+    if len == 0 || ret != len-1 || val[end] != 0
         error(string("system error getenv: ", s, ' ', len, "-1 != ", ret, ": ", FormatMessage()))
     end
     val

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -967,10 +967,6 @@ DLLEXPORT int jl_ispty(uv_pipe_t *pipe)
  
 DLLEXPORT uv_handle_type jl_uv_handle_type(uv_handle_t *handle)
 {
-#ifdef _OS_WINDOWS_
-    if (jl_ispty((uv_pipe_t*)handle))
-        return UV_TTY;
-#endif
     return handle->type;
 }
 


### PR DESCRIPTION
@Keno can you test this? (it's configured on the julia windows test machine now) it still seemed to be blocking waiting for another character, so maybe the jl_ispty call was not the only call stopped by ReadFile? perhaps `stty` also?
