### PR TITLE
use jl_isspace instead of isspace

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -609,7 +609,7 @@ DLLEXPORT int jl_substrtod(char *str, size_t offset, int len, double *out)
     char *bstr = str+offset;
     char *pend = bstr+len;
     int err = 0;
-    if (!(*pend == '\0' || isspace(*pend) || *pend == ',')) {
+    if (!(*pend == '\0' || jl_isspace(*pend) || *pend == ',')) {
         // confusing data outside substring. must copy.
         char *newstr = malloc(len+1);
         memcpy(newstr, bstr, len);
@@ -635,7 +635,7 @@ DLLEXPORT int jl_strtod(char *str, double *out)
         (errno==ERANGE && (*out==0 || *out==HUGE_VAL || *out==-HUGE_VAL)))
         return 1;
     while (*p != '\0') {
-        if (!isspace(*p))
+        if (!jl_isspace(*p))
             return 1;
         p++;
     }
@@ -654,7 +654,7 @@ DLLEXPORT int jl_substrtof(char *str, int offset, int len, float *out)
     char *bstr = str+offset;
     char *pend = bstr+len;
     int err = 0;
-    if (!(*pend == '\0' || isspace(*pend) || *pend == ',')) {
+    if (!(*pend == '\0' || jl_isspace(*pend) || *pend == ',')) {
         // confusing data outside substring. must copy.
         char *newstr = malloc(len+1);
         memcpy(newstr, bstr, len);
@@ -689,7 +689,7 @@ DLLEXPORT int jl_strtof(char *str, float *out)
         (errno==ERANGE && (*out==0 || *out==HUGE_VALF || *out==-HUGE_VALF)))
         return 1;
     while (*p != '\0') {
-        if (!isspace(*p))
+        if (!jl_isspace(*p))
             return 1;
         p++;
     }

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -17,9 +17,9 @@ extern "C" DLLEXPORT void jl_read_sonames(void)
         ssize_t n = getline(&line, &sz, ldc);
         if (n == -1)
             break;
-        if (n > 2 && isspace(line[0])) {
+        if (n > 2 && jl_isspace(line[0])) {
             int i=0;
-            while (isspace(line[++i])) ;
+            while (jl_isspace(line[++i])) ;
             char *name = &line[i];
             char *dot = strstr(name, ".so");
             i=0;
@@ -28,10 +28,10 @@ extern "C" DLLEXPORT void jl_read_sonames(void)
                 continue;
 
             // Detect if this entry is for the current architecture
-            while (!isspace(dot[++i])) ;
-            while (isspace(dot[++i])) ;
+            while (!jl_isspace(dot[++i])) ;
+            while (jl_isspace(dot[++i])) ;
             int j = i;
-            while (!isspace(dot[++j])) ;
+            while (!jl_isspace(dot[++j])) ;
             char *arch = strstr(dot+i,"x86-64");
             if (arch != NULL && arch < dot + j) {
 #ifdef _P32

--- a/src/flisp/read.c
+++ b/src/flisp/read.c
@@ -149,7 +149,7 @@ static char nextchar(void)
             } while ((char)ch != '\n');
             c = (char)ch;
         }
-    } while (c==' ' || isspace(c));
+    } while (c==' ' || jl_isspace(c));
     return c;
 }
 

--- a/src/support/int2str.c
+++ b/src/support/int2str.c
@@ -62,6 +62,12 @@ int str2int(char *str, size_t len, int64_t *res, uint32_t base)
 }
 */
 
+int jl_isspace(int c)
+{
+    return ((c == ' ')  || (c == '\t') || (c == '\n') ||
+            (c == '\v') || (c == '\f') || (c == '\r'));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/support/strtod.c
+++ b/src/support/strtod.c
@@ -133,7 +133,7 @@ double strtod_c(const char *nptr, char **endptr)
     p = nptr;
     
     /* parse leading spaces */
-    while (isspace(*p)) {
+    while (jl_isspace(*p)) {
         p++;
     }
     

--- a/src/support/utils.h
+++ b/src/support/utils.h
@@ -8,6 +8,7 @@ extern "C" {
 DLLEXPORT char *uint2str(char *dest, size_t len, uint64_t num, uint32_t base);
 int str2int(char *str, size_t len, int64_t *res, uint32_t base);
 int isdigit_base(char c, int base);
+int jl_isspace(int c);
 
 double conv_to_double(void *data, numerictype_t tag);
 int64_t conv_to_int64(void *data, numerictype_t tag);


### PR DESCRIPTION
due to Windows XP undefined behavior with unicode signed char values > 127

Fixes #7303, allowing Julia to run again on Windows XP (won't build on XP, but I tested a build from Win7 and it can be installed and run now), at the cost of duplicating some rather basic functionality. `isspace` may also be locale-dependent, which this should prevent from being a problem.

@vtjnash found the problem, hope I'm not stepping on his toes by proposing a fix.
