### PR TITLE
Fix #7426, StepRange iteration bug

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -166,7 +166,7 @@ similar(r::Range, T::Type, dims::Dims) = Array(T, dims)
 size(r::Range) = (length(r),)
 
 isempty(r::StepRange) =
-    (r.start != r.stop) && ((r.step > zero(r.step)) != (r.stop > r.start))
+    (r.start != r.stop) & ((r.step > zero(r.step)) != (r.stop > r.start))
 isempty(r::UnitRange) = r.start > r.stop
 isempty(r::FloatRange) = length(r)==0
 
@@ -224,7 +224,8 @@ done(r::FloatRange, i) = (length(r) <= i)
 # lifted domain (e.g. Int8+Int8 => Int); use that for iterating.
 start(r::StepRange) = convert(typeof(r.start+r.step), r.start)
 next{T}(r::StepRange{T}, i) = (oftype(T,i), i+r.step)
-done{T,S}(r::StepRange{T,S}, i) = (i!=r.stop) & ((r.step>zero(S))==(i>r.stop))
+done{T,S}(r::StepRange{T,S}, i) = isempty(r) | (i < min(r.start, r.stop)) | (i > max(r.start, r.stop))
+done{T,S}(r::StepRange{T,S}, i::Integer) = isempty(r) | (i == r.stop+r.step)
 
 start(r::UnitRange) = oftype(r.start+1, r.start)
 next{T}(r::UnitRange{T}, i) = (oftype(T,i), i+1)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -319,3 +319,5 @@ r = linrange(0.25,0.25,1)
 @test length(r) == 1
 @test_throws Exception linrange(0.25,0.5,1)
 
+# issue #7426
+@test [typemax(Int):1:typemax(Int)] == [typemax(Int)]


### PR DESCRIPTION
The integer-only definition parallels what we have for StepRanges and seems to work quite well for all cases but `typemin(Int):1<<n:typemax(Int)`. As a benchmark, I used:

``` julia
function f(a)
    z = 0
    for x in a
        z += x
    end
    z
end
@time f(0:5:10000000000)
@time f(0:5:10000000000)
```

On my system, the method in this PR is 1.6x faster than the existing method and also fixes #7426.

As far as `typemin(Int):1<<n:typemax(Int)`, this might be a little better than before, since `[typemin(Int):1<<n:typemax(Int)]` returns uninitialized memory instead of segfaulting, but we should probably throw an error for this case in the constructor.

I'm less sure what should be done with non-integer types, which in theory StepRange supports. The definition I've added here can handle both wrapping and the possibility that iteration might not actually hit `r.stop+r.step`, (which the integer-only definition cannot). However, it could be expensive for arbitrary types if the `isempty`, `min`, and `max` operations can't be hoisted outside of the loop. The integer-only definition is not especially necessary, but it is slightly faster (1.5x instead of 1.6x).
