### PR TITLE
More instrumentation (memory allocation, also fixes #7259)

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1072,6 +1072,7 @@ export
     gc_disable,
     gc_enable,
     precompile,
+    clear_malloc_data,
 
 # misc
     atexit,

--- a/base/util.jl
+++ b/base/util.jl
@@ -12,6 +12,9 @@ gc_time_ns() = ccall(:jl_gc_total_hrtime, Uint64, ())
 # total number of bytes allocated so far
 gc_bytes() = ccall(:jl_gc_total_bytes, Int64, ())
 
+# reset the malloc log. Used to avoid counting memory allocated during compilation.
+clear_malloc_data() = ccall(:jl_clear_malloc_data, Void, ())
+
 function tic()
     t0 = time_ns()
     task_local_storage(:TIMERS, (t0, get(task_local_storage(), :TIMERS, ())))

--- a/src/gc.c
+++ b/src/gc.c
@@ -80,6 +80,7 @@ typedef struct _bigval_t {
 // GC knobs and self-measurement variables
 static size_t allocd_bytes = 0;
 static int64_t total_allocd_bytes = 0;
+static int64_t last_gc_total_bytes = 0;
 static size_t freed_bytes = 0;
 static uint64_t total_gc_time=0;
 #ifdef _P64
@@ -916,6 +917,15 @@ DLLEXPORT int jl_gc_is_enabled(void) { return is_gc_enabled; }
 
 DLLEXPORT int64_t jl_gc_total_bytes(void) { return total_allocd_bytes + allocd_bytes; }
 DLLEXPORT uint64_t jl_gc_total_hrtime(void) { return total_gc_time; }
+
+int64_t diff_gc_total_bytes(void)
+{
+    int64_t oldtb = last_gc_total_bytes;
+    int64_t newtb = jl_gc_total_bytes();
+    last_gc_total_bytes = newtb;
+    return newtb - oldtb;
+}
+void sync_gc_total_bytes(void) {last_gc_total_bytes = jl_gc_total_bytes();}
 
 void jl_gc_ephemeral_on(void)  { pools = &ephe_pools[0]; }
 void jl_gc_ephemeral_off(void) { pools = &norm_pools[0]; }

--- a/src/init.c
+++ b/src/init.c
@@ -67,6 +67,7 @@ extern BOOL (WINAPI *hSymRefreshModuleList)(HANDLE);
 char *julia_home = NULL;
 jl_compileropts_t jl_compileropts = { NULL, // build_path
                                       0,    // code_coverage
+				      0,    // malloc_log
                                       JL_COMPILEROPT_CHECK_BOUNDS_DEFAULT,
                                       0     // int32_literals
 };
@@ -378,6 +379,7 @@ static void jl_uv_exitcleanup_walk(uv_handle_t* handle, void *arg)
 }
 
 void jl_write_coverage_data(void);
+void jl_write_malloc_log(void);
 
 DLLEXPORT void uv_atexit_hook()
 {
@@ -386,6 +388,8 @@ DLLEXPORT void uv_atexit_hook()
 #endif
     if (jl_compileropts.code_coverage)
         jl_write_coverage_data();
+    if (jl_compileropts.malloc_log)
+        jl_write_malloc_log();
     if (jl_base_module) {
         jl_value_t *f = jl_get_global(jl_base_module, jl_symbol("_atexit"));
         if (f!=NULL && jl_is_function(f)) {

--- a/src/julia.h
+++ b/src/julia.h
@@ -1054,6 +1054,8 @@ DLLEXPORT void jl_gc_disable(void);
 DLLEXPORT int jl_gc_is_enabled(void);
 DLLEXPORT int64_t jl_gc_total_bytes(void);
 DLLEXPORT uint64_t jl_gc_total_hrtime(void);
+int64_t diff_gc_total_bytes(void);
+void sync_gc_total_bytes(void);
 void jl_gc_ephemeral_on(void);
 void jl_gc_ephemeral_off(void);
 DLLEXPORT void jl_gc_collect(void);
@@ -1072,6 +1074,8 @@ DLLEXPORT void *alloc_3w(void);
 DLLEXPORT void *alloc_4w(void);
 void *allocb(size_t sz);
 DLLEXPORT void *allocobj(size_t sz);
+
+DLLEXPORT void jl_clear_malloc_data(void);
 
 #else
 
@@ -1308,16 +1312,25 @@ DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v);
 void jl_print_gc_stats(JL_STREAM *s);
 #endif
 
+// debugging
+void show_execution_point(char *filename, int lno);
+
 // compiler options -----------------------------------------------------------
 
 typedef struct {
     char *build_path;
     int8_t code_coverage;
+    int8_t malloc_log;
     int8_t check_bounds;
     int int_literals;
 } jl_compileropts_t;
 
 extern DLLEXPORT jl_compileropts_t jl_compileropts;
+
+// Settings for code_coverage and mallog_log
+#define JL_LOG_NONE 0
+#define JL_LOG_USER 1
+#define JL_LOG_ALL  2
 
 #define JL_COMPILEROPT_CHECK_BOUNDS_DEFAULT 0
 #define JL_COMPILEROPT_CHECK_BOUNDS_ON 1

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -48,7 +48,8 @@ extern DLLEXPORT char *julia_home;
 char system_image[256] = JL_SYSTEM_IMAGE_PATH;
 
 static int lisp_prompt = 0;
-static int codecov=0;
+static int codecov  = JL_LOG_NONE;
+static int malloclog= JL_LOG_NONE;
 static char *program = NULL;
 char *image_file = NULL;
 
@@ -74,7 +75,10 @@ static const char *opts =
     " -F                       Load ~/.juliarc.jl, then handle remaining inputs\n"
     " --color={yes|no}         Enable or disable color text\n\n"
 
-    " --code-coverage          Count executions of source lines\n"
+    " --code-coverage={none|user|all}, --code-coverage\n"
+    "                          Count executions of source lines (omitting setting is equivalent to 'user')\n"
+    " --track-allocation={none|user|all}\n"
+    "                          Count bytes allocated by each source line\n"
     " --check-bounds={yes|no}  Emit bounds checks always or never (ignoring declarations)\n"
     " --int-literals={32|64}   Select integer literal size independent of platform\n";
 
@@ -88,7 +92,8 @@ void parse_opts(int *argcp, char ***argvp)
         { "lisp",          no_argument,       &lisp_prompt, 1 },
         { "help",          no_argument,       0, 'h' },
         { "sysimage",      required_argument, 0, 'J' },
-        { "code-coverage", no_argument,       &codecov, 1 },
+        { "code-coverage", optional_argument, 0, 'c' },
+        { "track-allocation",required_argument, 0, 'm' },
         { "check-bounds",  required_argument, 0, 300 },
         { "int-literals",  required_argument, 0, 301 },
         { 0, 0, 0, 0 }
@@ -122,6 +127,29 @@ void parse_opts(int *argcp, char ***argvp)
         case 'h':
             printf("%s%s", usage, opts);
             exit(0);
+	case 'c':
+	    if (optarg != NULL) {
+		if (!strcmp(optarg,"user"))
+		    codecov = JL_LOG_USER;
+		else if (!strcmp(optarg,"all"))
+		    codecov = JL_LOG_ALL;
+		else if (!strcmp(optarg,"none"))
+		    codecov = JL_LOG_NONE;
+	        break;
+	    }
+	    else
+		codecov = JL_LOG_USER;
+	    break;
+	case 'm':
+	    if (optarg != NULL) {
+		if (!strcmp(optarg,"user"))
+		    malloclog = JL_LOG_USER;
+		else if (!strcmp(optarg,"all"))
+		    malloclog = JL_LOG_ALL;
+		else if (!strcmp(optarg,"none"))
+		    malloclog = JL_LOG_NONE;
+	        break;
+	    }
         case 300:
             if (!strcmp(optarg,"yes"))
                 jl_compileropts.check_bounds = JL_COMPILEROPT_CHECK_BOUNDS_ON;
@@ -145,6 +173,7 @@ void parse_opts(int *argcp, char ***argvp)
         }
     }
     jl_compileropts.code_coverage = codecov;
+    jl_compileropts.malloc_log    = malloclog;
     if (!julia_home) {
         julia_home = getenv("JULIA_HOME");
         if (julia_home) {


### PR DESCRIPTION
This adds the ability to track the amount of memory allocated by each line of code. It mimics the `--code-coverage` functionality, writing a `filename.jl.mlc` (mlc = `malloc`, perhaps there's a better extension?) listing the number of bytes allocated by each line.

It's already quite useful, but not perfect, and I confess to not really understanding what's wrong. Here's a test script:

``` julia
function alloc1()
    s = 0
    for x = 1:3
        s += x
    end
    A = zeros(4000, 7000)
    s2 = sum(A)
    nothing
end

function alloc2()
    s = 0
    for x = 1:3
        s += x/2  # deliberately type-unstable
    end
    s
end

function runner()
    alloc1()
    alloc2()
end

runner()
println("Something")
println("Clearing allocation data to eliminate memory allocated during JITting")
clear_malloc_data()
runner()
```

which you use like this

```
julia --track-allocation=user logallocation.jl
```

Here's the resulting `.mlc` file: (EDIT: the off-by-one bug has been fixed)

```
       - function alloc1()
        0     s = 0
        0     for x = 1:3
        0         s += x
        -     end
        0     A = zeros(4000, 7000)
224000048     s2 = sum(A)
        0     nothing
        - end
        - 
        - function alloc2()
        0     s = 0
        0     for x = 1:3
       64         s += x/2  # deliberately type-unstable
        -     end
       32     s
        - end
        - 
        - function runner()
      192     alloc1()
        0     alloc2()
        - end
        - 
        - runner()
        - println("Something")
        - println("Clearing allocation data to eliminate memory allocated during JITting")
        - clear_malloc_data()
        - runner()
```

The core algorithm is to look for a change in `jl_gc_total_bytes` since the last line.

Observations:
- There seems to be an off-by-one bug even though I attempted to insert the memory-check instructions after each line had already been built.
- Anything run from the global scope (for example, a test script in a package's `tests/`) shows allocation on the first line of the function.
