### PR TITLE
readcsv can read true and false strings as Bool.

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -319,6 +319,7 @@ function dlm_fill(T::DataType, offarr::Vector{Vector{Int}}, dims::NTuple{2,Integ
 end
 
 
+colval{T<:Bool, S<:String}(sval::S, cells::Array{T,2}, row::Int, col::Int, tmp64::Array{Float64,1}) = ((sval=="true") && (cells[row,col]=true; return false); (sval=="false") && (cells[row,col]=false; return false); true)
 colval{T<:Number, S<:String}(sval::S, cells::Array{T,2}, row::Int, col::Int, tmp64::Array{Float64,1}) = (float64_isvalid(sval, tmp64) ? ((cells[row,col] = tmp64[1]); false) : true)
 colval{T<:String, S<:String}(sval::S, cells::Array{T,2}, row::Int, col::Int, tmp64::Array{Float64,1}) = ((cells[row,col] = sval); false)
 colval{S<:String}(sval::S, cells::Array{Any,2}, row::Int, col::Int, tmp64::Array{Float64,1}) = ((cells[row,col] = float64_isvalid(sval, tmp64) ? tmp64[1] : sval); false)

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -68,6 +68,12 @@ end
 
 @test isequaldlm(readcsv(IOBuffer("\n1,2,3\n4,5,6\n\n\n")), reshape({"",1.0,4.0,"","","",2.0,5.0,"","","",3.0,6.0,"",""}, 5, 3), Any)
 
+let x = randbool(5, 10), io = IOBuffer()
+    writedlm(io, x)
+    seek(io, 0)
+    @test readdlm(io, Bool) == x
+end
+
 let x = [1,2,3], y = [4,5,6], io = IOBuffer()
     writedlm(io, zip(x,y), ",  ")
     seek(io, 0)


### PR DESCRIPTION
fixes #7463

```
julia> x = randbool(3, 5)
3x5 BitArray{2}:
 true   true  false  false  false
 true   true   true   true   true
 true  false   true   true  false

julia> writedlm("/tmp/bools.txt", x)

julia> readdlm("/tmp/bools.txt", Bool)
3x5 Array{Bool,2}:
 true   true  false  false  false
 true   true   true   true   true
 true  false   true   true  false
```

Comparing speeds of some different ways of reading bools:

```
julia> x = randbool(100, 100);

julia> writedlm("/tmp/bools.txt", x);

julia> writedlm("/tmp/ints.txt", int(x));

julia> @time convert(Array{Bool}, readdlm("/tmp/ints.txt", Int));
elapsed time: 0.004178626 seconds (1126928 bytes allocated)

julia> @time map(parse, readdlm("/tmp/bools.txt"));
elapsed time: 0.169436071 seconds (4093824 bytes allocated)

julia> @time readdlm("/tmp/bools.txt", Bool);
elapsed time: 0.00311209 seconds (1051616 bytes allocated)
```
