### PR TITLE
Slight improvement of the ARP entries and some re-factoring of the Installer

### DIFF
--- a/contrib/windows/build-installer.nsi
+++ b/contrib/windows/build-installer.nsi
@@ -37,22 +37,34 @@ Function createDesktopLink
     ${EndIf}
 FunctionEnd
 
-# Registry related
 # Adds the entries that create the icon in the uninstall section of the control panel.
 Function addUninstallRegEntriesHKCU
-    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayName" "$(^Name)"
-    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayIcon" "$\"$INSTDIR\${EXE_FILE}$\""
-    WriteRegStr HKCU "${REG_UNINSTALL}" "Publisher" "${DOMAIN}"
-    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayVersion" "${Version}"
-    WriteRegDWord HKCU "${REG_UNINSTALL}" "EstimatedSize" 383590 ;KB
-    WriteRegStr HKCU "${REG_UNINSTALL}" "HelpLink" "${WEBSITE_LINK}"
-    WriteRegStr HKCU "${REG_UNINSTALL}" "URLInfoAbout" "${WEBSITE_LINK}"
-    WriteRegStr HKCU "${REG_UNINSTALL}" "InstallLocation" "$\"$INSTDIR$\""
-    WriteRegStr HKCU "${REG_UNINSTALL}" "InstallSource" "$\"$EXEDIR$\""
-    WriteRegDWord HKCU "${REG_UNINSTALL}" "NoModify" 1
-    WriteRegDWord HKCU "${REG_UNINSTALL}" "NoRepair" 1
-    WriteRegStr HKCU "${REG_UNINSTALL}" "UninstallString" "$\"$INSTDIR\${UNINSTALLER_NAME}$\""
-    WriteRegStr HKCU "${REG_UNINSTALL}" "Comments" "Uninstalls $(^Name)"
+    WriteRegStr HKCU "${REG_UNINSTALL}" \
+                "DisplayName" "$(^Name)"
+    WriteRegStr HKCU "${REG_UNINSTALL}" \
+                "DisplayIcon" "$\"$INSTDIR\${EXE_FILE}$\""
+    WriteRegStr HKCU "${REG_UNINSTALL}" \
+                "Publisher" "${DOMAIN}"
+    WriteRegStr HKCU "${REG_UNINSTALL}" \
+                "DisplayVersion" "${Version}"
+    WriteRegDWord HKCU "${REG_UNINSTALL}" \
+                  "EstimatedSize" 383590 ;KB
+    WriteRegStr HKCU "${REG_UNINSTALL}" \
+                "HelpLink" "${WEBSITE_LINK}"
+    WriteRegStr HKCU "${REG_UNINSTALL}" \
+                "URLInfoAbout" "${WEBSITE_LINK}"
+    WriteRegStr HKCU "${REG_UNINSTALL}" \
+                "InstallLocation" "$\"$INSTDIR$\""
+    WriteRegStr HKCU "${REG_UNINSTALL}" \
+                "InstallSource" "$\"$EXEDIR$\""
+    WriteRegDWord HKCU "${REG_UNINSTALL}" \
+                  "NoModify" 1
+    WriteRegDWord HKCU "${REG_UNINSTALL}" \
+                  "NoRepair" 1
+    WriteRegStr HKCU "${REG_UNINSTALL}" \
+                "UninstallString" "$\"$INSTDIR\${UNINSTALLER_NAME}$\""
+    WriteRegStr HKCU "${REG_UNINSTALL}" \
+                "Comments" "Uninstalls $(^Name)"
 FunctionEnd
 
 # Adds ARP related entries to HKLM
@@ -99,7 +111,8 @@ InstallDir "$LOCALAPPDATA\Julia-${Version}"
 
 !insertmacro MUI_LANGUAGE "English"
 
-Section "Dummy Section" SecDummy
+# Main section
+Section "MainSection" SEC01
     SetOutPath $INSTDIR
     File /a /r "julia-${Commit}\*"
     WriteUninstaller "$INSTDIR\${UNINSTALLER_NAME}"
@@ -110,9 +123,9 @@ Section "Dummy Section" SecDummy
     
     # Add uninstall icon in the control panel
     Call addUninstallRegEntriesHKCU
-    
 SectionEnd
 
+# Uninstall section
 Section "uninstall"
     Delete "$INSTDIR\${UNINSTALLER_NAME}"
     Delete "$DESKTOP\Julia.lnk"

--- a/contrib/windows/build-installer.nsi
+++ b/contrib/windows/build-installer.nsi
@@ -11,22 +11,65 @@ ShowInstDetails show
 RequestExecutionLevel user
 BrandingText "Julia ${Version}"
 
+# Add/Remove Programs entry
+!define ARP "Software\Microsoft\Windows\CurrentVersion\Uninstall\Julia ${Version}"
+!define REG_UNINSTALL "${ARP}"
+!define EXE_FILE "bin\julia.exe"
+!define DOMAIN "julialang.org"
+!define WEBSITE_LINK "http://${DOMAIN}"
+!define UNINSTALLER_NAME "Uninstall.exe"
+
 # User interface changes
 var Checkbox
 
 # Add the desktop checkbox to the final page.
 Function desktopCheckbox
-  ${NSD_CreateCheckbox} 120u 130u 100% 10u "Create &desktop shortcut"
-  Pop $Checkbox
-  SetCtlColors $Checkbox "" "ffffff"
+    ${NSD_CreateCheckbox} 120u 130u 100% 10u "Create &desktop shortcut"
+    Pop $Checkbox
+    SetCtlColors $Checkbox "" "ffffff"
 FunctionEnd
 
 # Create the desktop link only, if the desktop checkbox is active.
 Function createDesktopLink
-  ${NSD_GetState} $Checkbox $0
-  ${If} $0 <> 0
-    CreateShortCut "$DESKTOP\Julia.lnk" "$INSTDIR\bin\julia.exe"
-  ${EndIf}
+    ${NSD_GetState} $Checkbox $0
+    ${If} $0 <> 0
+        CreateShortCut "$DESKTOP\Julia.lnk" "$INSTDIR\${EXE_FILE}"
+    ${EndIf}
+FunctionEnd
+
+# Registry related
+# Adds the entries that create the icon in the uninstall section of the control panel.
+Function addUninstallRegEntriesHKCU
+    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayName" "$(^Name)"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayIcon" "$\"$INSTDIR\${EXE_FILE}$\""
+    WriteRegStr HKCU "${REG_UNINSTALL}" "Publisher" "${DOMAIN}"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "DisplayVersion" "${Version}"
+    WriteRegDWord HKCU "${REG_UNINSTALL}" "EstimatedSize" 383590 ;KB
+    WriteRegStr HKCU "${REG_UNINSTALL}" "HelpLink" "${WEBSITE_LINK}"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "URLInfoAbout" "${WEBSITE_LINK}"
+    WriteRegStr HKCU "${REG_UNINSTALL}" "InstallLocation" "$\"$INSTDIR$\""
+    WriteRegStr HKCU "${REG_UNINSTALL}" "InstallSource" "$\"$EXEDIR$\""
+    WriteRegDWord HKCU "${REG_UNINSTALL}" "NoModify" 1
+    WriteRegDWord HKCU "${REG_UNINSTALL}" "NoRepair" 1
+    WriteRegStr HKCU "${REG_UNINSTALL}" "UninstallString" "$\"$INSTDIR\${UNINSTALLER_NAME}$\""
+    WriteRegStr HKCU "${REG_UNINSTALL}" "Comments" "Uninstalls $(^Name)"
+FunctionEnd
+
+# Adds ARP related entries to HKLM
+Function addArpHKCU
+    WriteRegStr HKCU "${ARP}" \
+                 "DisplayName" "Julia Language ${Version}"
+    WriteRegStr HKCU "${ARP}" \
+                 "Publisher" "The Julia Project"
+    WriteRegStr HKCU "${ARP}" \
+                 "DisplayIcon" "$INSTDIR\${EXE_FILE}"
+    WriteRegStr HKCU "${ARP}" \
+                 "UninstallString" "$\"$INSTDIR\${UNINSTALLER_NAME}$\""
+    WriteRegStr HKCU "${ARP}" \
+                 "QuietUninstallString" "$\"$INSTDIR\${UNINSTALLER_NAME}$\" /S"
+    WriteRegDWORD HKCU "${ARP}" "EstimatedSize" "300"
+    WriteRegDWORD HKCU "${ARP}" "NoModify" "1"
+    WriteRegDWORD HKCU "${ARP}" "NoRepair" "1"
 FunctionEnd
 
 # Icon settings
@@ -34,7 +77,7 @@ FunctionEnd
 
 # Variable definitions used in installer pages
 InstallDir "$LOCALAPPDATA\Julia-${Version}"
-!define StartMenuFolder "Julia ${Version}" 
+!define StartMenuFolder "Julia ${Version}"
 
 # Page settings
 # Note that we repurpose the checkboxes on the FinishPage
@@ -48,45 +91,32 @@ InstallDir "$LOCALAPPDATA\Julia-${Version}"
 !define MUI_FINISHPAGE_RUN_FUNCTION ShowInstallFolder
 
 # Pages to show
-
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
-
 !define MUI_PAGE_CUSTOMFUNCTION_SHOW desktopCheckbox
 !define MUI_PAGE_CUSTOMFUNCTION_LEAVE createDesktopLink
 !insertmacro MUI_PAGE_FINISH
 
 !insertmacro MUI_LANGUAGE "English"
 
-# Add/Remove Programs entry
-!define ARP "Software\Microsoft\Windows\CurrentVersion\Uninstall\Julia ${Version}"
-
 Section "Dummy Section" SecDummy
     SetOutPath $INSTDIR
     File /a /r "julia-${Commit}\*"
-    WriteUninstaller "$INSTDIR\Uninstall.exe"
-    CreateShortcut "$INSTDIR\julia.lnk" "$INSTDIR\bin\julia.exe"
+    WriteUninstaller "$INSTDIR\${UNINSTALLER_NAME}"
+    CreateShortcut "$INSTDIR\julia.lnk" "$INSTDIR\${EXE_FILE}"
 
     # ARP entries
-    WriteRegStr HKLM "${ARP}" \
-                 "DisplayName" "Julia Language ${Version}"
-    WriteRegStr HKLM "${ARP}" \
-                 "Publisher" "The Julia Project"
-    WriteRegStr HKLM "${ARP}" \
-                 "DisplayIcon" "$INSTDIR\bin\julia.exe"
-    WriteRegStr HKLM "${ARP}" \
-                 "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
-    WriteRegStr HKLM "${ARP}" \
-                 "QuietUninstallString" "$\"$INSTDIR\uninstall.exe$\" /S"
-    WriteRegDWORD HKLM "${ARP}" "EstimatedSize" "300"
-    WriteRegDWORD HKLM "${ARP}" "NoModify" "1"
-    WriteRegDWORD HKLM "${ARP}" "NoRepair" "1"
+    Call addArpHKCU
+    
+    # Add uninstall icon in the control panel
+    Call addUninstallRegEntriesHKCU
+    
 SectionEnd
- 
+
 Section "uninstall"
-    Delete "$INSTDIR/uninstall.exe"
+    Delete "$INSTDIR\${UNINSTALLER_NAME}"
     Delete "$DESKTOP\Julia.lnk"
-    DeleteRegKey HKLM "${ARP}"
+    DeleteRegKey HKCU "${ARP}"
     RMDir /r "$SMPROGRAMS\${StartMenuFolder}"
     RMDir /r "$INSTDIR/"
 SectionEnd
@@ -94,13 +124,11 @@ SectionEnd
 # Helper function to create Start Menu folder and shortcuts
 Function AddToStartMenu
     CreateDirectory "$SMPROGRAMS\${StartMenuFolder}"
-    CreateShortcut "$SMPROGRAMS\${StartMenuFolder}\julia.lnk" "$INSTDIR\julia.lnk" "" "" "" "" "" "The Julia Language"
-    CreateShortcut "$SMPROGRAMS\${StartMenuFolder}\Uninstall.lnk" "$instdir\Uninstall.exe"
-FunctionEnd 
+    CreateShortcut "$SMPROGRAMS\${StartMenuFolder}\julia.lnk" "$INSTDIR\julia.lnk" "" "" "" "" "" "$(^Name)"
+    CreateShortcut "$SMPROGRAMS\${StartMenuFolder}\Uninstall.lnk" "$instdir\${UNINSTALLER_NAME}"
+FunctionEnd
 
 # Opens the installation folder
 Function ShowInstallFolder
     ExecShell "open" $INSTDIR
 FunctionEnd
-
-

--- a/contrib/windows/build-installer.nsi
+++ b/contrib/windows/build-installer.nsi
@@ -69,19 +69,19 @@ FunctionEnd
 
 # Adds ARP related entries to HKLM
 Function addArpHKCU
-    WriteRegStr HKCU "${ARP}" \
+    WriteRegStr HKLM "${ARP}" \
                  "DisplayName" "Julia Language ${Version}"
-    WriteRegStr HKCU "${ARP}" \
+    WriteRegStr HKLM "${ARP}" \
                  "Publisher" "The Julia Project"
-    WriteRegStr HKCU "${ARP}" \
+    WriteRegStr HKLM "${ARP}" \
                  "DisplayIcon" "$INSTDIR\${EXE_FILE}"
-    WriteRegStr HKCU "${ARP}" \
+    WriteRegStr HKLM "${ARP}" \
                  "UninstallString" "$\"$INSTDIR\${UNINSTALLER_NAME}$\""
-    WriteRegStr HKCU "${ARP}" \
+    WriteRegStr HKLM "${ARP}" \
                  "QuietUninstallString" "$\"$INSTDIR\${UNINSTALLER_NAME}$\" /S"
-    WriteRegDWORD HKCU "${ARP}" "EstimatedSize" "300"
-    WriteRegDWORD HKCU "${ARP}" "NoModify" "1"
-    WriteRegDWORD HKCU "${ARP}" "NoRepair" "1"
+    WriteRegDWORD HKLM "${ARP}" "EstimatedSize" "300"
+    WriteRegDWORD HKLM "${ARP}" "NoModify" "1"
+    WriteRegDWORD HKLM "${ARP}" "NoRepair" "1"
 FunctionEnd
 
 # Icon settings

--- a/contrib/windows/build-installer.nsi
+++ b/contrib/windows/build-installer.nsi
@@ -38,7 +38,7 @@ Function createDesktopLink
 FunctionEnd
 
 # Adds the entries that create the icon in the uninstall section of the control panel.
-Function addUninstallRegEntriesHKCU
+Function addArpHKCU
     WriteRegStr HKCU "${REG_UNINSTALL}" \
                 "DisplayName" "$(^Name)"
     WriteRegStr HKCU "${REG_UNINSTALL}" \
@@ -63,25 +63,10 @@ Function addUninstallRegEntriesHKCU
                   "NoRepair" 1
     WriteRegStr HKCU "${REG_UNINSTALL}" \
                 "UninstallString" "$\"$INSTDIR\${UNINSTALLER_NAME}$\""
-    WriteRegStr HKCU "${REG_UNINSTALL}" \
-                "Comments" "Uninstalls $(^Name)"
-FunctionEnd
-
-# Adds ARP related entries to HKLM
-Function addArpHKCU
-    WriteRegStr HKLM "${ARP}" \
-                 "DisplayName" "Julia Language ${Version}"
-    WriteRegStr HKLM "${ARP}" \
-                 "Publisher" "The Julia Project"
-    WriteRegStr HKLM "${ARP}" \
-                 "DisplayIcon" "$INSTDIR\${EXE_FILE}"
-    WriteRegStr HKLM "${ARP}" \
-                 "UninstallString" "$\"$INSTDIR\${UNINSTALLER_NAME}$\""
     WriteRegStr HKLM "${ARP}" \
                  "QuietUninstallString" "$\"$INSTDIR\${UNINSTALLER_NAME}$\" /S"
-    WriteRegDWORD HKLM "${ARP}" "EstimatedSize" "300"
-    WriteRegDWORD HKLM "${ARP}" "NoModify" "1"
-    WriteRegDWORD HKLM "${ARP}" "NoRepair" "1"
+    WriteRegStr HKCU "${REG_UNINSTALL}" \
+                "Comments" "Uninstalls $(^Name)"
 FunctionEnd
 
 # Icon settings
@@ -120,9 +105,6 @@ Section "MainSection" SEC01
 
     # ARP entries
     Call addArpHKCU
-    
-    # Add uninstall icon in the control panel
-    Call addUninstallRegEntriesHKCU
 SectionEnd
 
 # Uninstall section


### PR DESCRIPTION
Hello,

I just have re-factored the ARP related entries so that it looks "nice" in the "Uninstall or change a program" section of the control panel:
![arp_entries](https://cloud.githubusercontent.com/assets/442931/3434031/965feb3a-0085-11e4-8106-5623d70a9385.png)
Furthermore I have moved the ARP entries from HKLM to HKCU. After all the installer is running with user execution level ("RequestExecutionLevel user"), so I would suggest not to use HKLM  registry keys.
