### PR TITLE
Add frexp to BigFloats, closes #7467

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -18,7 +18,7 @@ import
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, atan2,
         serialize, deserialize, inf, nan, cbrt, typemax, typemin,
         realmin, realmax, get_rounding, set_rounding, maxintfloat, widen,
-        significand
+        significand, frexp
 
 import Base.GMP: ClongMax, CulongMax
 
@@ -660,6 +660,13 @@ function exponent(x::BigFloat)
     end
     # The '- 1' is to make it work as Base.exponent
     return ccall((:mpfr_get_exp, :libmpfr), Clong, (Ptr{BigFloat},), &x) - 1
+end
+
+function frexp(x::BigFloat)
+    z = BigFloat()
+    c = Clong[0]
+    ccall((:mpfr_frexp, :libmpfr), Int32, (Ptr{Clong}, Ptr{BigFloat}, Ptr{BigFloat}, Cint), c, &z, &x, ROUNDING_MODE[end])
+    return (z, c[1])
 end
 
 function significand(x::BigFloat)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -158,6 +158,12 @@ x = BigFloat(Inf)
 x = BigFloat(15.674)
 @test exponent(x) == exponent(15.674)
 
+# frexp
+for i in [big(0.2), big(1.2), big(1220.0), big(23414.123)]
+    mantissa, ex = frexp(i)
+    @test i == mantissa * 2. ^ ex
+end
+
 # significand
 for i in [big(0.2), big(1.2), big(1220.0), big(23414.123)]
     @test i == significand(i) * 2. ^ exponent(i)


### PR DESCRIPTION
cc: @quinnj

I've decided to keep `significand(::BigFloat)` as is to use less memory (BigFloat isn't very temporary variable-friendly), but it basically is `significand(x::BigFloat) = frexp(x)[1] * 2`
