### PR TITLE
discontinue readavailable()

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -473,3 +473,12 @@ scale!{T<:Base.LinAlg.BlasReal}(X::Array{T}, s::Complex) = error("scale!: Cannot
 
 @deprecate which(f::Callable, args...) @which f(args...)
 @deprecate rmdir rm
+
+function readavailable(this::AsyncStream)
+    depwarn("readavailable() is discontinued. please choose from the alternative I/O functions, such as readall(), readbytes(), nb_available(), and !eof(), depending on your intended usage", :readavailable)
+    buf = this.buffer
+    @assert buf.seekable == false
+    wait_readnb(this,1)
+    takebuf_string(buf)
+end
+

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -391,10 +391,10 @@ function _uv_hook_readcb(stream::AsyncStream, nread::Int, base::Ptr{Void}, len::
         else
             if isa(stream,TTY)
                 stream.status = StatusEOF
+                notify(stream.closenotify)
             else
                 close(stream)
             end
-            notify(stream.readnotify)
         end
     else
         notify_filled(stream.buffer, nread, base, len)
@@ -696,13 +696,6 @@ end
 readline(this::AsyncStream) = readuntil(this, '\n')
 
 readline() = readline(STDIN)
-
-function readavailable(this::AsyncStream)
-    buf = this.buffer
-    @assert buf.seekable == false
-    wait_readnb(this,1)
-    takebuf_string(buf)
-end
 
 function readuntil(this::AsyncStream,c::Uint8)
     buf = this.buffer

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1727,10 +1727,6 @@ I/O
 
    Create a PipeBuffer to operate on a data vector, optionally specifying a size beyond which the underlying Array may not be grown.
 
-.. function:: readavailable(stream)
-
-   Read all available data on the stream, blocking the task only if no data is available. 
-
 .. function:: stat(file)
 
    Returns a structure whose fields contain information about the file. The fields of the structure are:

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -90,11 +90,10 @@ write(master,"1\nquit()\n")
 
 wait(p)
 
-output = readavailable(master)
-@test output == "julia> 1\r\nquit()\r\n1\r\n\r\njulia> "
-
-close(master)
 ccall(:close,Cint,(Cint,),fds)
+output = readall(master)
+@test output == "julia> 1\r\nquit()\r\n1\r\n\r\njulia> "
+close(master)
 
 end
 


### PR DESCRIPTION
This is really hard function to use correctly, since the only correct usage of this function is in a stream reader:

``` julia
buf = Uint8[]
while !eof(s)
  bytes = readavailable(s)
  append!(buf, s)
  if enough(buf)
     f(buf)
     empty!(buf)
  end
end
f(buf)
```

However, essentially all of the code I see posted to blogs and mailing lists to use this function are incorrectly defined, and subject to race conditions and the badly-defined behavior of this function (that and probably will stop working as soon as you try to bundle it into your application and output a decent amount of information, or forget that stdout is buffered, or run into a bit about latency)

I have seen users resort to it in the following situation, when users can't understand why `readall` hangs:

``` julia
(outRead, outWrite) = redirect_stdout()

print("Test")
print("ing")

close(outWrite)

data = readavailable(outRead)

close(outRead)
```

(copied from: http://thenewphalls.wordpress.com/2014/03/21/capturing-output-in-julia/)

however, the answer to their quandary is simple: `outWrite` is only one of the handles to the stdout. until you call `redirect_stdout` again, julia still has a second handle open (on fd 2) for use by `c` functions

related: https://github.com/JuliaLang/julia/issues/7022
