### PR TITLE
add workspace() function that replaces Main

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,7 +66,7 @@ REPL improvements
   * Tab-substitution of LaTeX math symbols (e.g. `\alpha` by `α`) ([#6911]).
     This also works in IJulia and in Emacs ([#6920]).
 
-  * `clear` function for obtaining a fresh workspace ([#1195]).
+  * `workspace()` function for obtaining a fresh workspace ([#1195]).
 
 Library improvements
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,8 @@ REPL improvements
   * Tab-substitution of LaTeX math symbols (e.g. `\alpha` by `α`) ([#6911]).
     This also works in IJulia and in Emacs ([#6920]).
 
+  * `clear` function for obtaining a fresh workspace ([#1195]).
+
 Library improvements
 --------------------
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1059,7 +1059,7 @@ export
     versioninfo,
     which,
     whos,
-    clear,
+    workspace,
 
 # loading source files
     evalfile,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1059,6 +1059,7 @@ export
     versioninfo,
     which,
     whos,
+    clear,
 
 # loading source files
     evalfile,

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -331,7 +331,7 @@ function download(url::String)
     download(url, filename)
 end
 
-function clear()
+function workspace()
     last = Core.Main
     b = last.Base
     ccall(:jl_new_main_module, Any, ())

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -330,3 +330,16 @@ function download(url::String)
     filename = tempname()
     download(url, filename)
 end
+
+function clear()
+    last = Core.Main
+    b = last.Base
+    ccall(:jl_new_main_module, Any, ())
+    m = Core.Main
+    ccall(:jl_add_standard_imports, Void, (Any,), m)
+    eval(m,
+         Expr(:toplevel,
+              :(const Base = $(Expr(:quote, b))),
+              :(const LastMain = $(Expr(:quote, last)))))
+    m
+end

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -341,5 +341,5 @@ function clear()
          Expr(:toplevel,
               :(const Base = $(Expr(:quote, b))),
               :(const LastMain = $(Expr(:quote, last)))))
-    m
+    nothing
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -3,8 +3,26 @@ module_name(m::Module) = ccall(:jl_module_name, Any, (Any,), m)::Symbol
 module_parent(m::Module) = ccall(:jl_module_parent, Any, (Any,), m)::Module
 current_module() = ccall(:jl_get_current_module, Any, ())::Module
 
-fullname(m::Module) = m===Main ? () : tuple(fullname(module_parent(m))...,
-                                            module_name(m))
+function fullname(m::Module)
+    if m === Main
+        ()
+    elseif module_parent(m) === m
+        # not Main, but is its own parent, means a prior Main module
+        n = ()
+        this = Main
+        while this !== m
+            if isdefined(this, :LastMain)
+                n = tuple(n..., :LastMain)
+                this = this.LastMain
+            else
+                error("no reference to module ", module_name(m))
+            end
+        end
+        return n
+    else
+        tuple(fullname(module_parent(m))..., module_name(m))
+    end
+end
 
 names(m::Module, all::Bool, imported::Bool) = ccall(:jl_module_names, Array{Symbol,1}, (Any,Int32,Int32), m, all, imported)
 names(m::Module, all::Bool) = names(m, all, false)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -128,7 +128,7 @@ Getting Around
    Print information about the version of Julia in use. If the ``verbose`` argument
    is true, detailed system information is shown as well.
 
-.. function:: clear()
+.. function:: workspace()
 
    Replace the top-level module (``Main``) with a new one, providing a clean workspace.
    The previous ``Main`` module is made available as ``LastMain``. A previously-loaded

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -128,6 +128,14 @@ Getting Around
    Print information about the version of Julia in use. If the ``verbose`` argument
    is true, detailed system information is shown as well.
 
+.. function:: clear()
+
+   Replace the top-level module (``Main``) with a new one, providing a clean workspace.
+   The previous ``Main`` module is made available as ``LastMain``. A previously-loaded
+   package can be accessed using a statement such as ``using LastMain.Package``.
+
+   This function should only be used interactively.
+
 All Objects
 -----------
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -808,7 +808,7 @@ DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s)
 DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from);
 DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
 DLLEXPORT jl_module_t *jl_new_main_module(void);
-void jl_add_standard_imports(jl_module_t *m);
+DLLEXPORT void jl_add_standard_imports(jl_module_t *m);
 STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
 {
     return  (jl_function_t*) jl_get_global(m, jl_symbol(name));


### PR DESCRIPTION
I believe the delay imposed by restarting julia and loading packages is causing a significant amount of pain and productivity loss. This feature should help.

Example session:

```
julia> using Winston    # takes a while

julia> plot(rand(8))    # plots

julia> clear()

julia> whos()
Base                          Module
Core                          Module
LastMain                      Module
Main                          Module
ans                           Nothing

julia> using LastMain.Winston    # takes no time

julia> plot(rand(8))  # plots

julia> Winston
LastMain.Winston
```

Note there is a hack to use `LastMain...LastMain.X` as the full name of old modules. The full implications of this are not yet clear, but this should be ok for interactive use. Note also that this approach keeps everything around and doesn't free any memory, but that should be ok until you run out :)
