### PR TITLE
RFC: add a warning against having multiple copies of a shared library loaded

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -14,8 +14,16 @@ const RTLD_FIRST     = 0x00000040
 
 dlsym(hnd, s::Union(Symbol,String)) = ccall(:jl_dlsym, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
 dlsym_e(hnd, s::Union(Symbol,String)) = ccall(:jl_dlsym_e, Ptr{Void}, (Ptr{Void}, Ptr{Uint8}), hnd, s)
-dlopen(s::String, flags::Integer) = ccall(:jl_load_dynamic_library, Ptr{Void}, (Ptr{Uint8},Uint32), s, flags)
-dlopen_e(s::String, flags::Integer) = ccall(:jl_load_dynamic_library_e, Ptr{Void}, (Ptr{Uint8},Uint32), s, flags)
+function dlopen(s::String, flags::Integer)
+    lib = ccall(:jl_load_dynamic_library, Ptr{Void}, (Ptr{Uint8},Uint32), s, flags)
+    Sys.check_dllist()
+    lib
+end
+function dlopen_e(s::String, flags::Integer)
+    lib = ccall(:jl_load_dynamic_library_e, Ptr{Void}, (Ptr{Uint8},Uint32), s, flags)
+    Sys.check_dllist()
+    lib
+end
 dlopen(s::String) = dlopen(s, RTLD_LAZY | RTLD_DEEPBIND)
 dlopen_e(s::String) = dlopen_e(s, RTLD_LAZY | RTLD_DEEPBIND)
 dlclose(p::Ptr) = if p!=C_NULL; ccall(:uv_dlclose,Void,(Ptr{Void},),p); end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -222,8 +222,11 @@ include("client.jl")
 include("printf.jl")
 importall .Printf
 
-# misc useful functions & macros
+# misc useful functions & macros and system information
 include("util.jl")
+include("sysinfo.jl")
+import .Sys.CPU_CORES
+
 
 # sparse matrices and linear algebra
 include("sparse.jl")
@@ -242,10 +245,6 @@ include("statistics.jl")
 include("fftw.jl")
 include("dsp.jl")
 importall .DSP
-
-# system information
-include("sysinfo.jl")
-import .Sys.CPU_CORES
 
 # mathematical constants
 include("constants.jl")


### PR DESCRIPTION
this is the first part in a series of improvements I would like to make to improve dealing with binary dependency (and inspired by JuliaCon!)

this might be useful because it is undefined which library C may use to lookup various functions. this can be problematic if there is global state in the shared library which is expected to be common across calls to the library from various dependencies

this behavior should probably also be part of `get_library` in `ccall.cpp` to be truly useful

the main open question is whether this should only warn about explicitly loaded dependencies, or all (as it does now, and is, I think, preferable)
