### PR TITLE
Simplify implementation of centralize_sumabs2

### DIFF
--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -41,6 +41,10 @@ end
 
 # test var & std
 
+@test var(Int[]) === NaN
+@test var(Int[]; corrected=false) === NaN
+@test var([1]) === NaN
+@test var([1]; corrected=false) === 0.0
 @test var(1:8) == 6.
 
 @test_approx_eq varm([1,2,3], 2) 1.


### PR DESCRIPTION
This is not only a bit shorter but also a bit faster, likely due to the partially unrolled summation.

Also fix a bounds violation when computing the variance of a vector with a single element. (The caller did not actually ensure `length >= 2`.)

cc @lindahua
