### PR TITLE
Disable atsign-inbounds when running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ before_install:
 script:
     - make $BUILDOPTS prefix=/tmp/julia install
     - cd .. && mv julia julia2
-    - cd /tmp/julia/share/julia/test && /tmp/julia/bin/julia-debug runtests.jl all
+    - cd /tmp/julia/share/julia/test && /tmp/julia/bin/julia-debug --check-bounds=yes runtests.jl all
     - cd - && mv julia2 julia
     - echo "Ready for packaging..."

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1118,7 +1118,7 @@ function launch_local_workers(cman::LocalManager, np::Integer, config::Dict)
 
     # start the processes first...
     for i in 1:np
-        io, pobj = open(detach(`$(dir)/$(exename) --bind-to $(LPROC.bind_addr) $exeflags`), "r")
+        io, pobj = open(detach(`$(dir)/$(exename) $exeflags --bind-to $(LPROC.bind_addr)`), "r")
         io_objs[i] = io
         configs[i] = merge(config, {:process => pobj})
     end

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,7 @@ TESTS = all core keywordargs numbers strings unicode collections hashing	\
 default: all
 
 $(TESTS) ::
-	@$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) -f ./runtests.jl $@)
+	@$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes -f ./runtests.jl $@)
 
 perf:
 	@$(MAKE) -C perf all

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ end
 n = 1
 if net_on 
     n = min(8, CPU_CORES, length(tests))
-    n > 1  && addprocs(n)
+    n > 1  && addprocs(n; exeflags=`--check-bounds=yes`)
     blas_set_num_threads(1)
 else
     filter!(x -> !(x in net_required_for), tests)


### PR DESCRIPTION
Also propagate the `--check-bounds` option to workers
