### PR TITLE
RFC: Prettyprint for Expr nodes :comprehension, :export, :import, :module :' and :.'

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -545,12 +545,15 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
     elseif is(head, :&) && length(args) == 1
         print(io, '&')
         show_unquoted(io, args[1])
-    elseif is(head, symbol('\'')) && length(args) == 1
-        show_unquoted(io, args[1])
-        print(io, "'")
-    elseif is(head, symbol(".'")) && length(args) == 1
-        show_unquoted(io, args[1])
-        print(io, ".'")
+    elseif head in (symbol('\''), :(.')) && length(args) == 1
+        if isa(args[1], Expr) && !is(args[1].head, :(.))
+            print(io, "(")
+            show_unquoted(io, args[1], indent+indent_width)
+            print(io, ")")
+        else
+            show_unquoted(io, args[1], indent+indent_width)
+        end
+        print(io, "$head")
     elseif is(head, :comprehension) && length(args) >= 2
         print(io, "[")
         show_unquoted(io, args[1], indent+indent_width)

--- a/base/show.jl
+++ b/base/show.jl
@@ -265,7 +265,7 @@ const expr_infix_wide = Set([:(=), :(+=), :(-=), :(*=), :(/=), :(\=), :(&=),
 const expr_infix = Set([:(:), :(<:), :(->), :(=>), symbol("::")])
 const expr_calls  = [:call =>('(',')'), :ref =>('[',']'), :curly =>('{','}')]
 const expr_parens = [:tuple=>('(',')'), :vcat=>('[',']'), :cell1d=>('{','}'),
-                     :hcat =>('[',']'), :row =>('[',']')]
+                     :hcat =>('[',']'), :row =>('[',']'), :dict  =>('[',']')]
 
 ## AST decoding helpers ##
 
@@ -389,7 +389,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         end
 
     # list (i.e. "(1,2,3)" or "[1,2,3]")
-    elseif haskey(expr_parens, head)               # :tuple/:vcat/:cell1d
+    elseif haskey(expr_parens, head)               # :tuple/:vcat/:cell1d/:hcat/:row/:dict
         op, cl = expr_parens[head]
         if head === :vcat && !isempty(args) && is_expr(args[1], :row)
             sep = ";"
@@ -554,7 +554,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
             show_unquoted(io, args[1], indent+indent_width)
         end
         print(io, "$head")
-    elseif is(head, :comprehension) && length(args) >= 2
+    elseif head in (:comprehension, :dict_comprehension) && length(args) >= 2
         print(io, "[")
         show_unquoted(io, args[1], indent+indent_width)
         print(io, " for ")
@@ -563,9 +563,20 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
     elseif is(head, :typed_comprehension) && length(args) >= 3
         print(io, args[1])
         show_unquoted(io, Expr(:comprehension, args[2:end]...), indent+indent_width)
+    elseif is(head, :typed_dict_comprehension) && length(args) >= 3
+        print(io, "($(args[1]))")
+        show_unquoted(io, Expr(:dict_comprehension, args[2:end]...), indent+indent_width)
+    elseif is(head, :typed_dict) && length(args) >= 1
+        if args[1] == Expr(:(=>), TopNode(:Any), TopNode(:Any))
+            show_enclosed_list(io, "{", args[2:end], ",", "}", indent)
+        else
+            print(io, "($(args[1]))")
+            show_enclosed_list(io, "[", args[2:end], ",", "]", indent)
+        end
     elseif is(head, :module) && length(args) == 3
         show_block(io, args[1] ? "module $(args[2])" : "baremodule $(args[2])", args[3], indent)
         print(io, "end")
+
     # print anything else as "Expr(head, args...)"
     else
         print(io, "\$(Expr(")

--- a/base/show.jl
+++ b/base/show.jl
@@ -488,7 +488,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         print(io, "...")
 
     elseif (nargs == 1 && head in (:return, :abstract, :const)) ||
-                          head in (:local,  :global)
+                          head in (:local,  :global, :export, :import)
         print(io, head, ' ')
         show_list(io, args, ", ", indent)
     elseif is(head, :macrocall) && nargs >= 1
@@ -545,7 +545,24 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
     elseif is(head, :&) && length(args) == 1
         print(io, '&')
         show_unquoted(io, args[1])
-
+    elseif is(head, symbol('\'')) && length(args) == 1
+        show_unquoted(io, args[1])
+        print(io, "'")
+    elseif is(head, symbol(".'")) && length(args) == 1
+        show_unquoted(io, args[1])
+        print(io, ".'")
+    elseif is(head, :comprehension) && length(args) >= 2
+        print(io, "[")
+        show_unquoted(io, args[1], indent+indent_width)
+        print(io, " for ")
+        show_list(io, args[2:end], ", ", indent)
+        print(io, "]")
+    elseif is(head, :typed_comprehension) && length(args) >= 3
+        print(io, args[1])
+        show_unquoted(io, Expr(:comprehension, args[2:end]...), indent+indent_width)
+    elseif is(head, :module) && length(args) == 3
+        show_block(io, args[1] ? "module $(args[2])" : "baremodule $(args[2])", args[3], indent)
+        print(io, "end")
     # print anything else as "Expr(head, args...)"
     else
         print(io, "\$(Expr(")


### PR DESCRIPTION
Noticed that prettyprinting does not work for some Expr nodes. I've implemented support for them and thought others might want them too. Don't know if there is a reason for these to not exists.

I've added support for
- List comprehensions, typed and untyped.
- `export` and `import`
- `module` and `baremodule` (don't know if this is correct, but I'm guessing that `args[1]` of a module node represents `baremodule` or `module`)
- The transpose operator `'` and `.'`, are there more postfix operators like theses that should be handled together like what has been done with unary and binary operators?
