### PR TITLE
Do not include JIT.h header file on MCJIT builds.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -23,7 +23,6 @@
 #define __STDC_CONSTANT_MACROS
 #endif
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
-#include "llvm/ExecutionEngine/JIT.h"
 #include "llvm/ExecutionEngine/JITEventListener.h"
 #include "llvm/ExecutionEngine/JITMemoryManager.h"
 #include "llvm/PassManager.h"
@@ -56,6 +55,8 @@
 #include "llvm/ExecutionEngine/ObjectImage.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/Object/ObjectFile.h"
+#else
+#include "llvm/ExecutionEngine/JIT.h"
 #endif
 #if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 3
 #include "llvm/IR/DerivedTypes.h"


### PR DESCRIPTION
Minor cleanup. It works just fine even without this PR.
