### PR TITLE
Fix and test var type stability and edge cases for zero and one-element iterables

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -58,19 +58,21 @@ function var(iterable; corrected::Bool=true, mean=nothing)
             M = new_M
         end
         return S / (count - int(corrected))
-    else # mean provided
+    elseif isa(mean, Number) # mean provided
         # Cannot use a compensated version, e.g. the one from
         # "Updating Formulae and a Pairwise Algorithm for Computing Sample Variances."
         # by Chan, Golub, and LeVeque, Technical Report STAN-CS-79-773, 
         # Department of Computer Science, Stanford University,
         # because user can provide mean value that is different to mean(iterable)
-        sum2 = (value - mean)^2
+        sum2 = (value - mean::Number)^2
         while !done(iterable, state)
             value, state = next(iterable, state)
             count += 1
             sum2 += (value - mean)^2
         end
         return sum2 / (count - int(corrected))
+    else
+        error("invalid value of mean")
     end
 end
 
@@ -156,18 +158,18 @@ varm{T}(A::AbstractArray{T}, m::AbstractArray, region; corrected::Bool=true) =
     varm!(Array(momenttype(T), reduced_dims(size(A), region)), A, m; corrected=corrected)
 
 
-function var(A::AbstractArray; corrected::Bool=true, mean=nothing)
-    mean == 0 ? varzm(A; corrected=corrected) :
-    mean == nothing ? varm(A, Base.mean(A); corrected=corrected) :
-    isa(mean, Number) ? varm(A, mean; corrected=corrected) :
-    error("Invalid value of mean.")
+function var{T}(A::AbstractArray{T}; corrected::Bool=true, mean=nothing)
+    convert(momenttype(T), mean == 0 ? varzm(A; corrected=corrected) :
+                           mean == nothing ? varm(A, Base.mean(A); corrected=corrected) :
+                           isa(mean, Number) ? varm(A, mean::Number; corrected=corrected) :
+                           error("invalid value of mean"))::momenttype(T)
 end
 
 function var(A::AbstractArray, region; corrected::Bool=true, mean=nothing)
     mean == 0 ? varzm(A, region; corrected=corrected) :
     mean == nothing ? varm(A, Base.mean(A, region), region; corrected=corrected) :
-    isa(mean, AbstractArray) ? varm(A, mean, region; corrected=corrected) :
-    error("Invalid value of mean.")
+    isa(mean, AbstractArray) ? varm(A, mean::AbstractArray, region; corrected=corrected) :
+    error("invalid value of mean")
 end
 
 varm(iterable, m::Number; corrected::Bool=true) =

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -138,7 +138,7 @@ end
 function varm{T}(A::AbstractArray{T}, m::Number; corrected::Bool=true)
     n = length(A)
     n == 0 && return convert(momenttype(T), NaN)
-    n == 1 && return corrected ? convert(momenttype(T), NaN) : zero(momenttype(T))
+    n == 1 && return convert(momenttype(T), abs2(A[1] - m)/(1 - int(corrected)))
     return centralize_sumabs2(A, m, 1, n) / (n - int(corrected))
 end
 

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -60,17 +60,17 @@ end
 
 # edge case: one-element vector
 # iterable
-@test isnan(var((1,)))
+@test isnan(@inferred(var((1,))))
 @test var((1,); corrected=false) === 0.0
 @test var((1,); mean=2) === Inf
 @test var((1,); mean=2, corrected=false) === 1.0
 # reduction
-@test isnan(var([1]))
+@test isnan(@inferred(var([1])))
 @test var([1]; corrected=false) === 0.0
 @test var([1]; mean=2) === Inf
 @test var([1]; mean=2, corrected=false) === 1.0
 # reduction across dimensions
-@test_approx_eq var([1], 1) [NaN]
+@test_approx_eq @inferred(var([1], 1)) [NaN]
 @test_approx_eq var([1], 1; corrected=false) [0.0]
 @test_approx_eq var([1], 1; mean=[2]) [Inf]
 @test_approx_eq var([1], 1; mean=[2], corrected=false) [1.0]

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -41,10 +41,40 @@ end
 
 # test var & std
 
-@test var(Int[]) === NaN
-@test var(Int[]; corrected=false) === NaN
-@test var([1]) === NaN
+# edge case: empty vector
+# iterable; this has to throw for type stability
+@test_throws ErrorException var(())
+@test_throws ErrorException var((); corrected=false)
+@test_throws ErrorException var((); mean=2)
+@test_throws ErrorException var((); mean=2, corrected=false)
+# reduction
+@test isnan(var(Int[]))
+@test isnan(var(Int[]; corrected=false))
+@test isnan(var(Int[]; mean=2))
+@test isnan(var(Int[]; mean=2, corrected=false))
+# reduction across dimensions
+@test_approx_eq var(Int[], 1) [NaN]
+@test_approx_eq var(Int[], 1; corrected=false) [NaN]
+@test_approx_eq var(Int[], 1; mean=[2]) [NaN]
+@test_approx_eq var(Int[], 1; mean=[2], corrected=false) [NaN]
+
+# edge case: one-element vector
+# iterable
+@test isnan(var((1,)))
+@test var((1,); corrected=false) === 0.0
+@test var((1,); mean=2) === Inf
+@test var((1,); mean=2, corrected=false) === 1.0
+# reduction
+@test isnan(var([1]))
 @test var([1]; corrected=false) === 0.0
+@test var([1]; mean=2) === Inf
+@test var([1]; mean=2, corrected=false) === 1.0
+# reduction across dimensions
+@test_approx_eq var([1], 1) [NaN]
+@test_approx_eq var([1], 1; corrected=false) [0.0]
+@test_approx_eq var([1], 1; mean=[2]) [Inf]
+@test_approx_eq var([1], 1; mean=[2], corrected=false) [1.0]
+
 @test var(1:8) == 6.
 
 @test_approx_eq varm([1,2,3], 2) 1.


### PR DESCRIPTION
We should make sure that this is the behavior we want, but at least it's consistent.
