### PR TITLE
Adds explicit Rational{BigInt} convert method

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -124,7 +124,13 @@ promote_rule{T<:Real}(::Type{BigFloat}, ::Type{T}) = BigFloat
 promote_rule{T<:FloatingPoint}(::Type{BigInt},::Type{T}) = BigFloat
 promote_rule{T<:FloatingPoint}(::Type{BigFloat},::Type{T}) = BigFloat
 
-rationalize(x::BigFloat; tol::Real=eps(x)) = rationalize(BigInt, x, tol=tol)
+function convert(::Type{Rational{BigInt}}, x::FloatingPoint)
+    if isnan(x); return zero(BigInt)//zero(BigInt); end
+    if isinf(x); return copysign(one(BigInt),x)//zero(BigInt); end
+    if x == 0;   return zero(BigInt) // one(BigInt); end
+    s = max(precision(x) - exponent(x), 0)
+    BigInt(ldexp(x,s)) // (BigInt(1) << s)
+end
 
 # serialization
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -56,7 +56,7 @@ end
 
 function convert{T<:Integer}(::Type{Rational{T}}, x::FloatingPoint)
     r = rationalize(T, x, tol=0)
-    x === convert(typeof(x), r) || throw(InexactError())
+    x == convert(typeof(x), r) || throw(InexactError())
     r
 end
 convert(::Type{Rational}, x::Float64) = convert(Rational{Int64}, x)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1468,6 +1468,22 @@ approx_eq(a, b) = approx_eq(a, b, 1e-6)
 # issue 3412
 @test convert(Rational{Int32},0.5) === int32(1)//int32(2)
 
+# issue 6712
+@test convert(Rational{BigInt},float64(pi)) == float64(pi)
+@test convert(Rational{BigInt},big(pi)) == big(pi)
+
+@test convert(Rational,0.0) == 0
+@test convert(Rational,-0.0) == 0
+@test convert(Rational,zero(BigFloat)) == 0
+@test convert(Rational,-zero(BigFloat)) == 0
+@test convert(Rational{BigInt},0.0) == 0
+@test convert(Rational{BigInt},-0.0) == 0
+@test convert(Rational{BigInt},zero(BigFloat)) == 0
+@test convert(Rational{BigInt},-zero(BigFloat)) == 0
+@test convert(Rational{BigInt},5e-324) == 5e-324
+@test convert(Rational{BigInt},realmin(Float64)) == realmin(Float64)
+@test convert(Rational{BigInt},realmax(Float64)) == realmax(Float64)
+
 @test isa(convert(Float64, big(1)//2), Float64)
 
 # primes


### PR DESCRIPTION
Indirectly addresses ~~#6712~~ #7501.

I also added some more tests, and changed a `===` to a `==`, which was causing problems with signed zeros and `BigFloat`s.
