### PR TITLE
Allow to customize file name of make dist result.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ VERSDIR = v`cut -d. -f1-2 < VERSION`
 INSTALL_F = install -pm644
 INSTALL_M = install -pm755
 
+#file name of make dist result
+ifeq ($(JULIA_DIST_TARNAME),)
+	JULIA_DIST_TARNAME = julia-$(JULIA_COMMIT)-$(OS)-$(ARCH)
+endif
+
 all: default
 default: release
 
@@ -281,7 +286,7 @@ ifeq ($(OS), WINNT)
 	cat ./contrib/windows/7zS.sfx ./contrib/windows/7zSFX-config.txt "julia-install-$(JULIA_COMMIT)-$(ARCH).7z" > "julia-${JULIA_VERSION}-${ARCH}.exe"
 	-rm -f julia-installer.exe
 else
-	$(TAR) zcvf julia-$(JULIA_COMMIT)-$(OS)-$(ARCH).tar.gz julia-$(JULIA_COMMIT)
+	$(TAR) zcvf $(JULIA_DIST_TARNAME).tar.gz julia-$(JULIA_COMMIT)
 endif
 	rm -fr $(prefix)
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/7407
Now it is possible to setup own file name mask in Make.user, for example 
`JULIA_DIST_TARNAME =  julia-$(shell date +'%Y%m%d')-$(JULIA_COMMIT)-$(OS)-$(ARCH)`

This is useful on consequent builds, you can add build date to archive name to be able to sort files.
