### PR TITLE
Patch pcre to pass all tests when compiled with GCC 4.9.

### DIFF
--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -22,6 +22,7 @@
 /openblas-*
 /patchelf-*
 /pcre-*
+!pcre-gcc49-compile.patch
 /root
 /SuiteSparse-*
 /zlib-*

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -482,6 +482,7 @@ pcre-$(PCRE_VER)/configure: pcre-$(PCRE_VER).tar.bz2
 	$(JLCHECKSUM) $<
 	$(TAR) jxf $<
 	touch -c $@
+	cd pcre-$(PCRE_VER) && patch -p1 < ../pcre-gcc49-compile.patch
 pcre-$(PCRE_VER)/config.status: pcre-$(PCRE_VER)/configure
 	cd pcre-$(PCRE_VER) && \
 	./configure $(CONFIGURE_COMMON) --enable-utf --enable-unicode-properties --enable-jit --includedir=$(build_includedir)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -478,11 +478,11 @@ PCRE_OBJ_TARGET = $(build_shlibdir)/libpcre.$(SHLIB_EXT)
 
 pcre-$(PCRE_VER).tar.bz2:
 	$(JLDOWNLOAD) $@ http://sourceforge.net/projects/pcre/files/pcre/$(PCRE_VER)/$@/download
-pcre-$(PCRE_VER)/configure: pcre-$(PCRE_VER).tar.bz2
+pcre-$(PCRE_VER)/configure: pcre-$(PCRE_VER).tar.bz2 pcre-gcc49-compile.patch
 	$(JLCHECKSUM) $<
 	$(TAR) jxf $<
-	touch -c $@
 	cd pcre-$(PCRE_VER) && patch -p1 < ../pcre-gcc49-compile.patch
+	touch -c $@
 pcre-$(PCRE_VER)/config.status: pcre-$(PCRE_VER)/configure
 	cd pcre-$(PCRE_VER) && \
 	./configure $(CONFIGURE_COMMON) --enable-utf --enable-unicode-properties --enable-jit --includedir=$(build_includedir)

--- a/deps/pcre-gcc49-compile.patch
+++ b/deps/pcre-gcc49-compile.patch
@@ -1,0 +1,43 @@
+diff -ur pcre-8.31.orig/pcre_compile.c pcre-8.31/pcre_compile.c
+--- pcre-8.31.orig/pcre_compile.c	2012-06-20 21:08:50.000000000 +0600
++++ pcre-8.31/pcre_compile.c	2014-07-03 17:18:04.314881746 +0600
+@@ -1292,11 +1292,15 @@
+ /* Read the minimum value and do a paranoid check: a negative value indicates
+ an integer overflow. */
+ 
+-while (IS_DIGIT(*p)) min = min * 10 + *p++ - CHAR_0;
+-if (min < 0 || min > 65535)
++while (IS_DIGIT(*p))
+   {
+-  *errorcodeptr = ERR5;
+-  return p;
++  min = min * 10 + (int)(*p++ - CHAR_0);
++  if (min > 65535)
++    {
++    *errorcodeptr = ERR5;
++    while (*p != CHAR_RIGHT_CURLY_BRACKET) p++;
++    return p;
++    }
+   }
+ 
+ /* Read the maximum value if there is one, and again do a paranoid on its size.
+@@ -1307,11 +1311,15 @@
+   if (*(++p) != CHAR_RIGHT_CURLY_BRACKET)
+     {
+     max = 0;
+-    while(IS_DIGIT(*p)) max = max * 10 + *p++ - CHAR_0;
+-    if (max < 0 || max > 65535)
++    while(IS_DIGIT(*p))
+       {
+-      *errorcodeptr = ERR5;
+-      return p;
++      max = max * 10 + (int)(*p++ - CHAR_0);
++      if (max > 65535)
++        {
++        *errorcodeptr = ERR5;
++        while (*p != CHAR_RIGHT_CURLY_BRACKET) p++;
++        return p;
++        }
+       }
+     if (max < min)
+       {


### PR DESCRIPTION
Pcre failed to pass one test when compiled with GCC 4.9.
Patch taken from Fedora, original url is
http://pkgs.fedoraproject.org/cgit/pcre.git/plain/pcre-8.35-Do-not-rely-on-wrapping-signed-integer-while-parsein.patch
Checked on Linux 64-bit with GCC 4.7, 4.8, 4.9, Clang 3.5 - all good.

Fixes https://github.com/JuliaLang/julia/issues/7458
