### PR TITLE
Use memmove instead of memcpy in copy! Fixes #3937

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -31,7 +31,7 @@ isassigned(a::Array, i::Int...) = isdefined(a, i...)
 ## copy ##
 
 function unsafe_copy!{T}(dest::Ptr{T}, src::Ptr{T}, N)
-    ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, Uint),
+    ccall(:memmove, Ptr{Void}, (Ptr{Void}, Ptr{Void}, Uint),
           dest, src, N*sizeof(T))
     return dest
 end


### PR DESCRIPTION
People seemed on board in #3937

I got burned by this the other day with code that worked on OSX but broke in subtle ways on Linux because it was shifting values in an array using `copy!`.
