### PR TITLE
RFC: run pkg test on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
 script:
     - make $BUILDOPTS prefix=/tmp/julia install
     - cd .. && mv julia julia2
-    - cd /tmp/julia/share/julia/test && /tmp/julia/bin/julia-debug --check-bounds=yes runtests.jl all
+    - git config --global user.name "Travis CI"
+    - cd /tmp/julia/share/julia/test && /tmp/julia/bin/julia-debug --check-bounds=yes runtests.jl all && /tmp/julia/bin/julia-debug --check-bounds=yes runtests.jl pkg
     - cd - && mv julia2 julia
     - echo "Ready for packaging..."


### PR DESCRIPTION
This would catch at least some accidental breakage to pkg, such as #7493

This version slows Travis down a little more than it has to, since `test/pkg.jl` is executed separately from the rest of the tests which run in parallel. `runtests.jl` could instead be tweaked a little to include `pkg.jl` in its list under certain conditions, but cloning METADATA during the tests might not be acceptable for some distributions?
