### PR TITLE
start worker by --machinefile option from the same path as the current h...

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -237,7 +237,8 @@ function process_options(args::Vector{UTF8String})
         elseif args[i]=="--machinefile"
             i+=1
             machines = split(readall(args[i]), '\n', false)
-            addprocs(machines)
+            exename=(ccall(:jl_is_debugbuild,Cint,())==0?"./julia":"./julia-debug")
+            addprocs(machines; dir=pwd(), exename=joinpath(JULIA_HOME, exename))
         elseif args[i]=="-v" || args[i]=="--version"
             println("julia version ", VERSION)
             exit(0)


### PR DESCRIPTION
Before this patch, `--machinefile` option starts workers at `JULIA_HOME` instead of the same path as the current (master) host.
Document says (and I want) that the slave workers start from the same path as where the master runs.
