### PR TITLE
Remove sort(...;order=...) deprecation.

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -89,8 +89,6 @@ ordtype(o::By,              vs::AbstractArray) = try typeof(o.by(vs[1])) catch A
 ordtype(o::Ordering,        vs::AbstractArray) = eltype(vs)
 
 function ord(lt::Function, by::Function, rev::Bool, order::Ordering=Forward)
-    order == Forward || order == Lexicographic ||
-        Base.warn_once("the `order` keyword is deprecated, use `lt`, `by` and `rev` instead")
     o = (lt===isless) & (by===identity) ? order  :
         (lt===isless) & (by!==identity) ? By(by) :
         (lt!==isless) & (by===identity) ? Lt(lt) :


### PR DESCRIPTION
- Per @StefanKarpinski, the `order` keyword was deprecated with the
  expectation that functions would be specialized soon.  As this does
  not seem to be the case, the keyword is still useful when
  performance is important.

Google groups ref: https://groups.google.com/d/topic/julia-users/rkLH2_QmBTU/discussion
