### PR TITLE
Add Profile.callers to determine main callers of a particular function

### DIFF
--- a/base/profile.jl
+++ b/base/profile.jl
@@ -66,6 +66,23 @@ function getdict(data::Vector{Uint})
     Dict(uip, [lookup(ip) for ip in uip])
 end
 
+function callers(funcname::ByteString, bt::Vector{Uint}, lidict; filename = nothing, linerange = nothing)
+    if filename == nothing && linerange == nothing
+        return callersf(li -> li.func == funcname, bt, lidict)
+    end
+    filename == nothing && error("If supplying linerange, you must also supply the filename")
+    if linerange == nothing
+        return callersf(li -> li.func == funcname && li.file == filename, bt, lidict)
+    else
+        return callersf(li -> li.func == funcname && li.file == filename && in(li.line, linerange), bt, lidict)
+    end
+end
+
+callers(funcname::ByteString; kwargs...) = callers(funcname, retrieve()...; kwargs...)
+callers(func::Function, bt::Vector{Uint}, lidict; kwargs...) = callers(string(func), bt, lidict; kwargs...)
+callers(func::Function; kwargs...) = callers(string(func), retrieve()...; kwargs...)
+
+
 ####
 #### Internal interface
 ####
@@ -372,6 +389,30 @@ function tree{T<:Unsigned}(io::IO, data::Vector{T}, lidict::Dict, C::Bool, combi
     len = Int[length(x) for x in bt]
     keep = len .> 0
     tree(io, bt[keep], counts[keep], lidict, level, combine, cols)
+end
+
+function callersf(matchfunc::Function, bt::Vector{Uint}, lidict)
+    counts = Dict{LineInfo, Int}()
+    lastmatched = false
+    for id in bt
+        if id == 0
+            lastmatched = false
+            continue
+        end
+        li = lidict[id]
+        if lastmatched
+            if haskey(counts, li)
+                counts[li] += 1
+            else
+                counts[li] = 1
+            end
+        end
+        lastmatched = matchfunc(li)
+    end
+    k = collect(keys(counts))
+    v = collect(values(counts))
+    p = sortperm(v, rev=true)
+    [(v[i], k[i]) for i in p]
 end
 
 # Utilities

--- a/doc/stdlib/profile.rst
+++ b/doc/stdlib/profile.rst
@@ -355,3 +355,14 @@ Function reference
    values that store the file name, function name, and line
    number. This function allows you to save profiling results for
    future analysis.
+
+.. function::callers(funcname, [data, lidict], [filename=<filename>], [linerange=<start:stop>]) -> Vector{(count, linfo)}
+
+   Given a previous profiling run, determine who called a particular
+   function. Supplying the filename (and optionally, range of line
+   numbers over which the function is defined) allows you to
+   disambiguate an overloaded method. The returned value is a vector
+   containing a count of the number of calls and line information
+   about the caller.  One can optionally supply backtrace data
+   obtained from ``retrieve``; otherwise, the current internal profile
+   buffer is used.


### PR DESCRIPTION
EDIT: name changed to "callers"

This is somewhat like the Profiling analog of `@which`. It's quite useful in aggregating results from a complex sequence of runs.

Demo: in `Gadfly/test`,

```
julia> @profile include("test.jl")

julia> Profile.whocalled("cyclezip")
3-element Array{(Any,Any),1}:
 (392,LineInfo("circle","/home/tim/.julia/v0.3/Compose/src/form.jl",139,false))
 (214,LineInfo("text","/home/tim/.julia/v0.3/Compose/src/form.jl",249,false))  
 (3,LineInfo("rectangle","/home/tim/.julia/v0.3/Compose/src/form.jl",93,false))
```
