### PR TITLE
fix #7188

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1344,6 +1344,7 @@ export
     @windowsxp_only,
     @non_windowsxp_only,
     @schedule,
+    @symbol_str,
     @sync,
     @async,
     @spawn,

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -6,6 +6,9 @@ symbol(s::UTF8String) = symbol(s.data)
 symbol(a::Array{Uint8,1}) =
     ccall(:jl_symbol_n, Any, (Ptr{Uint8}, Int32), a, length(a))::Symbol
 symbol(x::Char) = symbol(string(x))
+macro symbol_str(s)
+    QuoteNode(symbol(unescape_string(s)))
+end
 
 gensym() = ccall(:jl_gensym, Any, ())::Symbol
 

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -23,7 +23,6 @@ export
     GeneralizedSchur,
     Hessenberg,
     LU,
-    LUTridiagonal,
     LDLt,
     QR,
     QRPivoted,

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -5,7 +5,8 @@ module Meta
 
 export quot, 
        isexpr, 
-       show_sexpr
+       show_sexpr,
+       @symbol
 
 quot(ex) = Expr(:quote, ex)
 
@@ -42,6 +43,10 @@ function show_sexpr(io::IO, ex::Expr, indent::Int)
     if length(ex.args) == 0; print(io, ",)")
     else print(io, (ex.head === :block ? "\n"*" "^indent : ""), ')')
     end
+end
+
+macro symbol(s)
+    symbol(unescape_string(s))
 end
 
 end # module

--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -211,6 +211,31 @@ void fl_init_julia_extensions(void)
     assign_global_builtins(julia_flisp_func_info);
 }
 
+// returns true if a symbol could be quoted simply (e.g. :x),
+// rather than writing it as symbol("x")
+DLLEXPORT int jl_is_quotable_symbol(char *sym) {
+    size_t i = 0;
+    wchar_t c;
+
+    if (!strcmp(sym,"end")) return 0;
+
+    // Operator?
+    value_t fl_sym = symbol(sym);
+    value_t e = fl_applyn(1, symbol_value(symbol("operator?")), fl_sym);
+    if (e == FL_T) return 1;
+
+    // Identifier?
+    c = u8_nextchar(sym, &i);
+    if (c == 0) return 0;
+    if (!jl_id_start_char(c)) return 0;
+    c = u8_nextchar(sym, &i);
+    while (c != 0) {
+        if (!jl_id_char(c)) return 0;
+        c = u8_nextchar(sym, &i);
+    }
+    return 1;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This makes displaying and parsing of symbols more symmetric, as discussed in #7188. I'm not sure why this was a 0.3 issue, but here's code to make it work anyways.

I implemented symbol"" (`@symbol_str`), for normal usage (wrapped in a QuoteNode).

I also implemented a macro version `Meta.@symbol("")` for getting back a unadorned Symbol, so that even things like anonymous functions would be a bit more directly parseable:

``` julia
julia> macro test()
         quote
             function x() end
             function y() x() end
         end
       end

julia> @test
#124#y (generic function with 1 method)

julia> code_lowered(ans,())
1-element Array{Any,1}:
 :($(Expr(:lambda, {}, {{},{},{}}, :(begin  # none, line 6:
        return @symbol("#123#x")()
    end))))
```
