### PR TITLE
hash for IntSet

### DIFF
--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -181,6 +181,18 @@ function hash(s::Set, h::Uint)
     return h
 end
 
+function hash(s::IntSet, h::Uint)
+    h += uint(0x88989f1fc7dea67d)
+    h += hash(s.fill1s)
+    filln = s.fill1s ? uint32(-1) : uint32(0)
+    for x in s.bits
+        if x != filln
+            h = hash(x, h)
+        end
+    end
+    return h
+end
+
 # hashing ranges by component at worst leads to collisions for very similar ranges
 function hash(r::Range, h::Uint)
     h += uint(0x80707b6821b70087)

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -469,6 +469,11 @@ s = IntSet(0,1,10,20,200,300,1000,10000,10002)
 @test in(10000,s)
 @test_throws ErrorException first(IntSet())
 @test_throws ErrorException last(IntSet())
+t = copy(s)
+sizehint(t, 20000) #check that hash does not depend on size of internal Array{Uint32, 1}
+@test hash(s) == hash(t)
+@test hash(complement(s)) == hash(complement(t))
+
 
 # Ranges
 


### PR DESCRIPTION
There was no implementation of `hash(s::IntSet, h::Uint)` for `IntSet`s, and the fallback is `hash(x::ANY, h::Uint)` ([here](https://github.com/JuliaLang/julia/blob/1c5a76d494601464ed7dc6bc393d6848e1954c36/base/hashing.jl#L8)), so `isequal(a::IntSet, b::IntSet)` did not imply `hash(a)==hash(b)` per the [manual](http://docs.julialang.org/en/latest/stdlib/base/?highlight=hash#Base.isequal).

This pull request implements `hash(s::IntSet, h::Uint)`. 
