### PR TITLE
fix searchsorted for sorted segments of arrays

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -159,10 +159,10 @@ end
 # returns the range of indices of v equal to x
 # if v does not contain x, returns a 0-length range
 # indicating the insertion point of x
-function searchsorted(v::AbstractVector, x, lo::Int, hi::Int, o::Ordering)
-    1 <= lo <= hi <= length(v) || throw(BoundsError())
-    lo = lo-1
-    hi = hi+1
+function searchsorted(v::AbstractVector, x, ilo::Int, ihi::Int, o::Ordering)
+    1 <= ilo <= ihi <= length(v) || throw(BoundsError())
+    lo = ilo-1
+    hi = ihi+1
     @inbounds while lo < hi-1
         m = (lo+hi)>>>1
         if lt(o, v[m], x)
@@ -170,8 +170,8 @@ function searchsorted(v::AbstractVector, x, lo::Int, hi::Int, o::Ordering)
         elseif lt(o, x, v[m])
             hi = m
         else
-            a = searchsortedfirst(v, x, max(lo,1), m, o)
-            b = searchsortedlast(v, x, m, min(hi,length(v)), o)
+            a = searchsortedfirst(v, x, max(lo,ilo), m, o)
+            b = searchsortedlast(v, x, m, min(hi,ihi), o)
             return a:b
         end
     end

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -23,6 +23,8 @@ end
 
 @test searchsorted([1:10], 1, by=(x -> x >= 5)) == 1:4
 @test searchsorted([1:10], 10, by=(x -> x >= 5)) == 5:10
+@test searchsorted([1:5, 1:5, 1:5], 1, 6, 10, Base.Order.Forward) == 6:6
+@test searchsorted(ones(15), 1, 6, 10, Base.Order.Forward) == 6:10
 
 for (rg,I) in {(49:57,47:59), (1:2:17,-1:19), (-3:0.5:2,-5:.5:4)}
     rg_r = reverse(rg)


### PR DESCRIPTION
This fixes `searchsorted` to work properly on sorted segments of overall unsorted arrays.

Without this patch:

```
julia> searchsorted(ones(15), 1, 6, 10, Base.Order.Forward)
5:11

julia> searchsorted([1:5, 1:5, 1:5], 1, 6, 10, Base.Order.Forward)
5:6
```

With this patch:

```
julia> searchsorted(ones(15), 1, 6, 10, Base.Order.Forward)
6:10

julia> searchsorted([1:5, 1:5, 1:5], 1, 6, 10, Base.Order.Forward)
6:6
```
