### PR TITLE
RFC: add jl_get_cpu_name function to libjulia

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -6,6 +6,7 @@ export  CPU_CORES,
         ARCH,
         MACHINE,
         cpu_info,
+        cpu_name,
         cpu_summary,
         uptime,
         loadavg,
@@ -121,6 +122,8 @@ function cpu_info()
     ccall(:uv_free_cpu_info, Void, (Ptr{UV_cpu_info_t}, Int32), UVcpus[1], count[1])
     cpus
 end
+
+const cpu_name = ccall(:jl_get_cpu_name, ByteString, ())
 
 function uptime()
     uptime_ = Array(Float64,1)

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -30,6 +30,7 @@ function init_sysinfo()
         ccall(:jl_cpu_cores, Int32, ())
     )
     global const SC_CLK_TCK = ccall(:jl_SC_CLK_TCK, Clong, ())
+    global const cpu_name = ccall(:jl_get_cpu_name, ByteString, ())
 end
 
 type UV_cpu_info_t
@@ -122,8 +123,6 @@ function cpu_info()
     ccall(:uv_free_cpu_info, Void, (Ptr{UV_cpu_info_t}, Int32), UVcpus[1], count[1])
     cpus
 end
-
-const cpu_name = ccall(:jl_get_cpu_name, ByteString, ())
 
 function uptime()
     uptime_ = Array(Float64,1)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -500,6 +500,10 @@ static Type *NoopType;
 extern "C" {
     const char *jl_cpu_string = MSTR(JULIA_TARGET_ARCH);
     int globalUnique = 0;
+    DLLEXPORT const char *jl_get_cpu_name(void)
+    {
+        return llvm::sys::getHostCPUName().data();
+    }
 }
 
 #include "cgutils.cpp"

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -500,10 +500,13 @@ static Type *NoopType;
 extern "C" {
     const char *jl_cpu_string = MSTR(JULIA_TARGET_ARCH);
     int globalUnique = 0;
-    DLLEXPORT const char *jl_get_cpu_name(void)
-    {
-        return llvm::sys::getHostCPUName().data();
-    }
+}
+
+extern "C" DLLEXPORT
+jl_value_t *jl_get_cpu_name(void)
+{
+    StringRef HostCPUName = llvm::sys::getHostCPUName();
+    return jl_pchar_to_string(HostCPUName.data(), HostCPUName.size());
 }
 
 #include "cgutils.cpp"


### PR DESCRIPTION
thin ccall'able wrapper around llvm::sys::getHostCPUName

As @stevengj suggested here https://groups.google.com/forum/#!topic/julia-dev/EYXr9KkMWgI, this was rather trivial. I'm open to renaming or moving this anywhere more appropriate. Can also add the result of this into Julia's `Sys` module if people would like that.
