### PR TITLE
Fix #7551

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -419,9 +419,13 @@ end
 function LineEdit.accept_result(s, p::LineEdit.HistoryPrompt{REPLHistoryProvider})
     parent = LineEdit.state(s, p).parent
     hist = p.hp
-    m = hist.mode_mapping[hist.modes[hist.cur_idx]]
-    LineEdit.replace_line(LineEdit.state(s, m), LineEdit.state(s, p).response_buffer)
-    LineEdit.transition(s, m)
+    if 1 <= hist.cur_idx <= length(hist.modes)
+        m = hist.mode_mapping[hist.modes[hist.cur_idx]]
+        LineEdit.replace_line(LineEdit.state(s, m), LineEdit.state(s, p).response_buffer)
+        LineEdit.transition(s, m)
+    else
+        LineEdit.transition(s, parent)
+    end
 end
 
 function history_prev(s::LineEdit.MIState, hist::REPLHistoryProvider,

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -161,6 +161,16 @@ begin
     LineEdit.accept_result(s, histp)
     @test LineEdit.mode(s) == shell_mode
     @test buffercontents(LineEdit.buffer(s)) == "ll"
+    
+    # Issue #7551
+    # Enter search mode and try accepting an empty result
+    REPL.history_reset_state(hp)
+    LineEdit.edit_clear(s)
+    cur_mode = LineEdit.mode(s)
+    LineEdit.enter_search(s, histp, true)
+    LineEdit.accept_result(s, histp)
+    @test LineEdit.mode(s) == cur_mode
+    @test buffercontents(LineEdit.buffer(s)) == ""
 end
 
 ccall(:jl_exit_on_sigint, Void, (Cint,), 1)


### PR DESCRIPTION
Simply drop out of search mode (back to the original mode) when accepting an empty search-string.
#7551
