### PR TITLE
Filtering (filt) across columns of arrays and method signature tweaks

### DIFF
--- a/base/dsp.jl
+++ b/base/dsp.jl
@@ -14,18 +14,14 @@ export FFTW, filt, filt!, deconv, conv, conv2, xcorr, fftshift, ifftshift,
 _zerosi(b,a,T) = zeros(promote_type(eltype(b), eltype(a), T), max(length(a), length(b))-1)
 
 function filt{T,S}(b::Union(AbstractVector, Number), a::Union(AbstractVector, Number),
-                   x::AbstractArray{T}; si::AbstractArray{S}=_zerosi(b,a,T))
+                   x::AbstractArray{T}, si::AbstractArray{S}=_zerosi(b,a,T))
     filt!(Array(promote_type(eltype(b), eltype(a), T, S), size(x)), b, a, x, si)
 end
 
 # in-place filtering: returns results in the out argument, which may shadow x
 # (and does so by default)
-function filt!{T}(b::Union(AbstractVector, Number), a::Union(AbstractVector, Number), x::AbstractArray{T};
-                  si::AbstractArray=_zerosi(b,a,T), out::AbstractArray=x)
-    filt!(out, b, a, x, si)
-end
-function filt!{S,N}(out::AbstractArray, b::Union(AbstractVector, Number), a::Union(AbstractVector, Number),
-                    x::AbstractArray, si::AbstractArray{S,N})
+function filt!{T,S,N}(out::AbstractArray, b::Union(AbstractVector, Number), a::Union(AbstractVector, Number),
+                      x::AbstractArray{T}, si::AbstractArray{S,N}=_zerosi(b,a,T))
     isempty(b) && error("b must be non-empty")
     isempty(a) && error("a must be non-empty")
     a[1] == 0  && error("a[1] must be nonzero")

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4664,15 +4664,15 @@ calling functions from `FFTW <http://www.fftw.org>`_.
 
    Undoes the effect of ``fftshift``.
 
-.. function:: filt(b, a, x; si=zeros(max(length(a),length(b))-1))
+.. function:: filt(b, a, x, [si])
 
    Apply filter described by vectors ``a`` and ``b`` to vector ``x``, with an
-   optional initial filter state keyword argument ``si`` (defaults to zeros).
+   optional initial filter state vector ``si`` (defaults to zeros).
 
-.. function:: filt!(b, a, x; si=zeros(max(length(a),length(b))-1), out=x)
+.. function:: filt!(out, b, a, x, [si])
 
-   Same as :func:`filt`, but stores the result in the ``out`` keyword argument,
-   which may alias the input ``x`` to modify it in-place (it does so by default).
+   Same as :func:`filt` but writes the result into the ``out`` argument,
+   which may alias the input ``x`` to modify it in-place.
 
 .. function:: deconv(b,a)
 

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -6,6 +6,14 @@ x = [1., 1., 0., 1., 1., 0., 0., 0.]
 # With ranges
 @test filt(b, 1., 1.0:10.0) == [1., 4., 10., 20., 30., 40., 50., 60., 70., 80.]
 @test filt(1.:4., 1., 1.0:10.0) == [1., 4., 10., 20., 30., 40., 50., 60., 70., 80.]
+# Across an array is the same as channel-by-channel
+@test filt(b, 1., [x 1.0:8.0]) == [filt(b, 1., x) filt(b, 1., 1.0:8.0)]
+@test filt(b, [1., -0.5], [x 1.0:8.0]) == [filt(b, [1., -0.5], x) filt(b, [1., -0.5], 1.0:8.0)]
+si = zeros(3)
+@test filt(b, 1., [x 1.0:8.0], si=si) == [filt(b, 1., x, si=si) filt(b, 1., 1.0:8.0, si=si)]
+@test si == zeros(3) # Will likely fail if/when arrayviews are implemented
+si = [zeros(3) ones(3)]
+@test filt(b, 1., [x 1.0:8.0], si=si) == [filt(b, 1., x, si=zeros(3)) filt(b, 1., 1.0:8.0, si=ones(3))]
 # With initial conditions: a lowpass 5-pole butterworth filter with W_n = 0.25,
 # and a stable initial filter condition matched to the initial value
 b = [0.003279216306360201,0.016396081531801006,0.03279216306360201,0.03279216306360201,0.016396081531801006,0.003279216306360201]

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -10,16 +10,16 @@ x = [1., 1., 0., 1., 1., 0., 0., 0.]
 @test filt(b, 1., [x 1.0:8.0]) == [filt(b, 1., x) filt(b, 1., 1.0:8.0)]
 @test filt(b, [1., -0.5], [x 1.0:8.0]) == [filt(b, [1., -0.5], x) filt(b, [1., -0.5], 1.0:8.0)]
 si = zeros(3)
-@test filt(b, 1., [x 1.0:8.0], si=si) == [filt(b, 1., x, si=si) filt(b, 1., 1.0:8.0, si=si)]
+@test filt(b, 1., [x 1.0:8.0], si) == [filt(b, 1., x, si) filt(b, 1., 1.0:8.0, si)]
 @test si == zeros(3) # Will likely fail if/when arrayviews are implemented
 si = [zeros(3) ones(3)]
-@test filt(b, 1., [x 1.0:8.0], si=si) == [filt(b, 1., x, si=zeros(3)) filt(b, 1., 1.0:8.0, si=ones(3))]
+@test filt(b, 1., [x 1.0:8.0], si) == [filt(b, 1., x, zeros(3)) filt(b, 1., 1.0:8.0, ones(3))]
 # With initial conditions: a lowpass 5-pole butterworth filter with W_n = 0.25,
 # and a stable initial filter condition matched to the initial value
 b = [0.003279216306360201,0.016396081531801006,0.03279216306360201,0.03279216306360201,0.016396081531801006,0.003279216306360201]
 a = [1.0,-2.4744161749781606,2.8110063119115782,-1.703772240915465,0.5444326948885326,-0.07231566910295834]
-init = [0.9967207836936347,-1.4940914728163142,1.2841226760316475,-0.4524417279474106,0.07559488540931815]
-@test_approx_eq filt(b, a, ones(10), si=init) ones(10) # Shouldn't affect DC offset
+si = [0.9967207836936347,-1.4940914728163142,1.2841226760316475,-0.4524417279474106,0.07559488540931815]
+@test_approx_eq filt(b, a, ones(10), si) ones(10) # Shouldn't affect DC offset
 
 # Convolution
 a = [1., 2., 1., 2.]


### PR DESCRIPTION
Here are yet two more patches for `filt` and `filt!` following #7513.
#### 1. Enable filtering (filt) across columns of arrays.

When passed a multidimensional array, simply iterate over its columns, independently filtering each one.  The starting filter state may be given as a vector (in which case it is common across all columns) or an array with the same number of columns as the input.  This is a pretty common feature and is very handy.

cf. https://github.com/JuliaDSP/DSP.jl/pull/58#issuecomment-48619941
#### 2. Relax filt signatures to allow heterogeneous types

Previously, `filt[!]` methods were only defined for arguments of all the same type `T<:Number`. This relaxes that restriction, allowing one to, for example, filter an array of Float32s by Float64 coefficients. Instead of defining many type parameters (`T<:Number, S<:Number, R<:…`), filt now simply trusts that the eltype of the arrays have methods for basic arithmetic. By default, the output of filt will be determined by `promote_type` of all arguments.

I needed this second change to simplify filtering of arrays of Float32s. It should generally be more forgiving.

cc: @simonster, @timholy, @codles
