### PR TITLE
WIP: implementation of fixed-size arrays

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -13,6 +13,7 @@ export
     LAPACK,
 
 # Types
+    AbstractFixedArray,
     AbstractMatrix,
     AbstractSparseArray,
     AbstractSparseMatrix,
@@ -48,6 +49,8 @@ export
     FileMonitor,
     FileOffset,
     Filter,
+    FixedArrayI,
+    FixedArrayM,
     FloatRange,
     Hermitian,
     UniformScaling,

--- a/base/fixedarrays.jl
+++ b/base/fixedarrays.jl
@@ -1,0 +1,105 @@
+module FixedArrays
+
+export AbstractFixedArray, FixedArrayI, FixedArrayM
+
+using Base.Cartesian
+import Base: (*), (==), A_mul_B!, eltype, getindex, length, ndims, size
+
+## Types
+
+abstract AbstractFixedArray{T,N,SZ} <: DenseArray{T,N}
+
+immutable FixedArrayI{T,N,SZ,L} <: AbstractFixedArray{T,N,SZ}
+    data::NTuple{L,T}
+end
+
+immutable FixedArrayM{T,N,SZ} <: AbstractFixedArray{T,N,SZ}
+    data::Array{T,N}
+end
+
+## Constructors
+# Note these can't be type-stable, since the size of A is unknown to the type system
+
+function FixedArrayI(A::AbstractArray)
+    L = length(A)
+    FixedArrayI{eltype(A), ndims(A), size(A), L}(ntuple(L, i->A[i]))
+end
+
+toarray(A) = convert(Array, A)
+toarray(A::Array) = copy(A)
+
+FixedArrayM(A::AbstractArray) = FixedArrayM{eltype(A), ndims(A), size(A)}(toarray(A))
+
+
+## Utility functions
+eltype{T,N,SZ}(A::AbstractFixedArray{T,N,SZ}) = T
+length{T,N,SZ}(A::AbstractFixedArray{T,N,SZ}) = prod(SZ)
+ ndims{T,N,SZ}(A::AbstractFixedArray{T,N,SZ}) = N
+  size{T,N,SZ}(A::AbstractFixedArray{T,N,SZ}) = SZ
+  size{T,N,SZ}(A::AbstractFixedArray{T,N,SZ}, d::Integer) = SZ[d]
+
+getindex(A::AbstractFixedArray, i::Real) = A.data[i]
+@nsplat N getindex(A::FixedArrayM, I::NTuple{N,Real}...) = getindex(A.data, I...)
+
+getindex{T,SZ}(A::FixedArrayI{T,2,SZ}, i::Real, j::Real) = A.data[i+(j-1)*SZ[1]]
+
+## Comparisons
+
+for (TA, TB) in ((AbstractArray,AbstractFixedArray), (AbstractArray,AbstractFixedArray))
+    if TA == AbstractArray && TB == AbstractArray
+        continue
+    end
+    @eval begin
+        function (==)(A::$TA, B::$TB)
+            size(A) == size(B) || return false
+            for i = 1:length(B)
+                if A[i] != B[i]
+                    return false
+                end
+            end
+            true
+        end
+    end
+end
+
+## Linear algebra
+
+for N=1:4, K=1:4, M=1:4
+    L = M*N
+    @eval begin
+        function (*){TA,TB}(A::FixedArrayI{TA,2,($M,$K)}, B::FixedArrayI{TB,2,($K,$N)})
+            TP = typeof(one(TA)*one(TB) + one(TA)*one(TB))
+            @nexprs $K d2->(@nexprs $M d1->A_d1_d2 = A.data[(d2-1)*$M+d1])
+            @nexprs $N d2->(@nexprs $K d1->B_d1_d2 = B.data[(d2-1)*$K+d1])
+            @nexprs $N n->(@nexprs $M m->begin
+                tmp = zero(TP)
+                @nexprs $K k->(tmp += A_m_k * B_k_n)
+                dest_{m+(n-1)*$K} = tmp
+            end)
+            FixedArrayI{TP,2,($M,$N),$L}(@ntuple $L d->dest_d)
+        end
+    end
+end
+
+function (*){TA,TB,M,K,N}(A::FixedArrayM{TA,2,(M,K)}, B::FixedArrayM{TB,2,(K,N)})
+    TP = typeof(one(TA)*one(TB) + one(TA)*one(TB))
+    A_mul_B!(FixedArrayM{TP,2,(M,N)}(Array(TP, M, N)), A, B)
+end
+
+for N=1:4, K=1:4, M=1:4
+    @eval begin
+        function A_mul_B!{TC,TA,TB}(out::FixedArrayM{TC,2,($M,$N)}, A::AbstractFixedArray{TA,2,($M,$K)}, B::AbstractFixedArray{TB,2,($K,$N)})
+            TP = typeof(one(TA)*one(TB) + one(TA)*one(TB))
+            @nexprs $K d2->(@nexprs $M d1->@inbounds A_d1_d2 = A.data[(d2-1)*$M+d1])
+            @nexprs $N d2->(@nexprs $K d1->@inbounds B_d1_d2 = B.data[(d2-1)*$K+d1])
+            @nexprs $N n->(@nexprs $M m->begin
+                tmp = zero(TP)
+                @nexprs $K k->(tmp += A_m_k * B_k_n)
+                @inbounds out.data[m,n] = tmp
+            end)
+            out
+        end
+    end
+end
+
+end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -235,6 +235,10 @@ const × = cross
 include("broadcast.jl")
 importall .Broadcast
 
+# fixed arrays
+include("fixedarrays.jl")
+using .FixedArrays
+
 # statistics
 include("statistics.jl")
 

--- a/test/fixedarrays.jl
+++ b/test/fixedarrays.jl
@@ -1,0 +1,15 @@
+using Base.Test
+
+let
+    A = rand(2,2)
+    B = rand(2,3)
+    C = A*B
+    for Constr in (FixedArrayI, FixedArrayM)
+        AI = Constr(A)
+        BI = Constr(B)
+        CI = AI*BI
+        @test_approx_eq CI C
+        CI = Constr(C)
+        @test CI == C
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,8 @@
 testnames = [
     "linalg", "core", "keywordargs", "numbers", "strings",
     "collections", "hashing", "remote", "iobuffer", "arrayops", "reduce", "reducedim",
-    "simdloop", "blas", "fft", "dsp", "sparse", "bitarray", "random", "math",
+    "simdloop", "blas", "fft", "dsp", "sparse", "bitarray", "fixedarrays",
+    "random", "math",
     "functional", "bigint", "sorting", "statistics", "spawn",
     "backtrace", "priorityqueue", "arpack", "file", "suitesparse", "version",
     "resolve", "pollfd", "mpfr", "broadcast", "complex", "socket",


### PR DESCRIPTION
This implements fixed-size arrays (whose size is part of the type parameters).  Compared to the proof-of-concept in #5857, it solves the constructor problems. There was some debate in #5857 (and echoed [on julia-dev](https://groups.google.com/d/msg/julia-dev/vFRa0B2IiAk/RAwmBU7MiccJ)) about whether mutable or immutable would be more desirable, so for fun this implements both.

Ultimately, the multiplication routine will be a nice application of staged functions. As it is, this defines 128 new methods for `*`.

This has uncovered some type-inference problems, to be filed in other issues. Given that I'd expect such problems to destroy performance, it's shockingly good. (Of the fixed-size tests, only the last line below does not suffer from type-stability problems. Hence, it is more illustrative of what one might ultimately hope for.)

Timing info:

``` julia
f(n::Integer, A, B) = (C = A*B; for i = 1:n; C = A*B; end)
g(n::Integer, A, B) = (C = A*B; for i = 1:n; A_mul_B!(C,A,B); end)
A = rand(2,2)
B = rand(2,3)
AfI = FixedArrayI(A)
BfI = FixedArrayI(B)
AfM = FixedArrayM(A)
BfM = FixedArrayM(B)
# hide warmup
julia> @time f(10^6, A, B)
elapsed time: 0.505924798 seconds (128000224 bytes allocated, 18.89% gc time)

julia> @time f(10^6, AfI, BfI)
elapsed time: 1.244501688 seconds (504000600 bytes allocated, 28.19% gc time)

julia> @time f(10^6, AfM, BfM)
elapsed time: 0.632096601 seconds (144000240 bytes allocated, 14.57% gc time)

julia> @time g(10^6, A, B)
elapsed time: 0.349824437 seconds (224 bytes allocated)

julia> @time g(10^6, AfM, BfM)
elapsed time: 0.056289786 seconds (240 bytes allocated)
```
