### PR TITLE
Evaluate and print parts of comparisons in `@test`

### DIFF
--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -79,10 +79,10 @@ ________
 
 A handler is a function defined for three kinds of arguments: ``Success``, ``Failure``, ``Error``::
 
-  # The definition of the default handler
-  default_handler(r::Success) = nothing
-  default_handler(r::Failure) = error("test failed: $(r.expr)")
-  default_handler(r::Error)   = rethrow(r)
+  # An example definition of a test handler
+  test_handler(r::Success) = nothing
+  test_handler(r::Failure) = error("test failed: $(r.expr)")
+  test_handler(r::Error)   = rethrow(r)
 
 A different handler can be used for a block (with :func:`with_handler`)::
 
@@ -109,6 +109,8 @@ A different handler can be used for a block (with :func:`with_handler`)::
    in anonymous at no file:3
    in task_local_storage at task.jl:28
    in with_handler at test.jl:24
+
+The ``Success`` and ``Failure`` types include an additonal field, ``resultexpr``, which is a partially evaluated expression. For example, in a comparison it will contain an expression with the left and right sides evaluated.
 
 Macros
 ______

--- a/test/test.jl
+++ b/test/test.jl
@@ -40,6 +40,31 @@ Test.with_handler(test_handler) do
     @test errorflag
 end
 
+# Test evaluation of comparison tests
+i7586_1() = 1
+i7586_2() = 7
+i7586_3() = 9
+
+comparison_flags_s = [false,false,false]
+comparison_flags_f = [false,false,false]
+function test_handler2(r::Test.Success)
+    comparison_flags_s[1] = (r.resultexpr.args[1] == 1)
+    comparison_flags_s[2] = (r.resultexpr.args[3] == 7)
+    comparison_flags_s[3] = (r.resultexpr.args[5] == 9)
+end
+
+function test_handler2(r::Test.Failure)
+    comparison_flags_f[1] = (r.resultexpr.args[1] == 1)
+    comparison_flags_f[2] = (r.resultexpr.args[3] == 7)
+    comparison_flags_f[3] = (r.resultexpr.args[5] == 10)
+end
+
+Test.with_handler(test_handler2) do
+    @test i7586_1() <= i7586_2() <= i7586_3()
+    @test i7586_1() >= i7586_2() >= 10
+end
+@test all(comparison_flags_s)
+@test all(comparison_flags_f)
 
 # Test @test_throws
 domainerror_thrower() = throw(DomainError())


### PR DESCRIPTION
This builds off the PR by @iainNZ https://github.com/JuliaLang/julia/pull/6106.

I am trying to avoid evaluating the RHS and LHS twice as noticed by Jeff in #6106. I also think that this is slowing down the tests since we need to assign the results from the LHS and RHS to something.

This is how I am debugging: https://github.com/sjkelly/JuliaPlayground/blob/master/test/test_output.jl

**TODO:**
- [x] Support chained comparisons (5 <= 6 <= 7)
- [x] Update Documents
- [x] Add unit tests
