### PR TITLE
Simple implementation of chmod(path, mode)

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1237,6 +1237,7 @@ export
 
 # filesystem operations
     cd,
+    chmod,
     cp,
     ctime,
     download,

--- a/base/file.jl
+++ b/base/file.jl
@@ -53,6 +53,7 @@ mkpath(path::String, mode::Signed) = error("mode must be an unsigned integer; tr
 
 function rm(path::String; recursive::Bool=false)
     if islink(path) || !isdir(path)
+        @windows_only if !iswritable(path); chmod(path, 0o777); end
         FS.unlink(path)
     else
         if recursive

--- a/base/fs.jl
+++ b/base/fs.jl
@@ -23,6 +23,7 @@ export File,
        rename,
        sendfile,
        symlink,
+       chmod,
        JL_O_WRONLY,
        JL_O_RDONLY,
        JL_O_RDWR,
@@ -161,6 +162,11 @@ end
 end
 @windowsxp_only symlink(p::String, np::String) = 
     error("WindowsXP does not support soft symlinks")
+
+function chmod(p::String, mode::Integer)
+    err = ccall(:jl_fs_chmod, Int32, (Ptr{Uint8}, Cint), p, mode)
+    uv_error("chmod",err)
+end
 
 function write(f::File, buf::Ptr{Uint8}, len::Integer, offset::Integer=-1)
     if !f.open

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -5279,6 +5279,11 @@ System
       This function raises an error under operating systems that do not support
       soft symbolic links, such as Windows XP.
 
+.. function:: chmod(path, mode)
+
+   Change the permissions mode of ``path`` to ``mode``. Only integer ``mode``s
+   (e.g. 0o777) are currently supported.
+
 .. function:: getpid() -> Int32
 
    Get julia's process ID.

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -442,6 +442,14 @@ DLLEXPORT int jl_fs_symlink(char *path, char *new_path, int flags)
     return ret;
 }
 
+DLLEXPORT int jl_fs_chmod(char *path, int mode)
+{
+    uv_fs_t req;
+    int ret = uv_fs_chmod(jl_io_loop, &req, path, mode, NULL);
+    uv_fs_req_cleanup(&req);
+    return ret;
+}
+
 DLLEXPORT int jl_fs_write(int handle, char *data, size_t len, size_t offset)
 {
     uv_fs_t req;

--- a/test/file.jl
+++ b/test/file.jl
@@ -28,10 +28,9 @@ end
 @test !islink(file)
 @test isreadable(file)
 @test iswritable(file)
-# Here's something else that might be UNIX-specific?
-run(`chmod -w $file`)
+chmod(file, filemode(file) & 0o7555)
 @test !iswritable(file)
-run(`chmod +w $file`)
+chmod(file, filemode(file) | 0o222)
 @test !isexecutable(file)
 @test filesize(file) == 0
 # On windows the filesize of a folder is the accumulation of all the contained


### PR DESCRIPTION
currently only integer modes, can do string modes like +x later
fixes #7574

Interestingly on Windows, it looks like libuv ignores everything you ask for except the `0o200` bit, and the returned `filemode()` ends up either `0o444` or `0o666`.
