### PR TITLE
remove unnecessary bytestring call for ccall string arguments

### DIFF
--- a/base/fftw.jl
+++ b/base/fftw.jl
@@ -71,18 +71,16 @@ typealias fftwTypeSingle Union(Type{Float32},Type{Complex64})
 # FFTW's api/import-wisdom-from-file.c file].
 
 function export_wisdom(fname::String)
-    f = ccall(:fopen, Ptr{Void}, (Ptr{Uint8},Ptr{Uint8}),
-              bytestring(fname), bytestring("w"))
+    f = ccall(:fopen, Ptr{Void}, (Ptr{Uint8},Ptr{Uint8}), fname, "w")
     systemerror("could not open wisdom file $fname for writing", f == C_NULL)
     ccall((:fftw_export_wisdom_to_file,libfftw), Void, (Ptr{Void},), f)
-    ccall(:fputs, Int32, (Ptr{Uint8},Ptr{Void}), bytestring(" "^256), f)
+    ccall(:fputs, Int32, (Ptr{Uint8},Ptr{Void}), " "^256, f)
     ccall((:fftwf_export_wisdom_to_file,libfftwf), Void, (Ptr{Void},), f)
     ccall(:fclose, Void, (Ptr{Void},), f)
 end
 
 function import_wisdom(fname::String)
-    f = ccall(:fopen, Ptr{Void}, (Ptr{Uint8},Ptr{Uint8}),
-              bytestring(fname), bytestring("r"))
+    f = ccall(:fopen, Ptr{Void}, (Ptr{Uint8},Ptr{Uint8}), fname, "r")
     systemerror("could not open wisdom file $fname for reading", f == C_NULL)
     if ccall((:fftw_import_wisdom_from_file,libfftw),Int32,(Ptr{Void},),f)==0||
        ccall((:fftwf_import_wisdom_from_file,libfftwf),Int32,(Ptr{Void},),f)==0

--- a/base/file.jl
+++ b/base/file.jl
@@ -8,7 +8,7 @@ function pwd()
 end
 
 function cd(dir::String) 
-    uv_error("chdir $dir", ccall(:uv_chdir, Cint, (Ptr{Uint8},), bytestring(dir)))
+    uv_error("chdir $dir", ccall(:uv_chdir, Cint, (Ptr{Uint8},), dir))
 end
 cd() = cd(homedir())
 
@@ -35,7 +35,7 @@ end
 cd(f::Function) = cd(f, homedir())
 
 function mkdir(path::String, mode::Unsigned=0o777)
-    @unix_only ret = ccall(:mkdir, Int32, (Ptr{Uint8},Uint32), bytestring(path), mode)
+    @unix_only ret = ccall(:mkdir, Int32, (Ptr{Uint8},Uint32), path, mode)
     @windows_only ret = ccall(:_wmkdir, Int32, (Ptr{Uint16},), utf16(path))
     systemerror(:mkdir, ret != 0)
 end
@@ -60,7 +60,7 @@ function rm(path::String; recursive::Bool=false)
                 rm(joinpath(path, p), recursive=true)
             end
         end
-        @unix_only ret = ccall(:rmdir, Int32, (Ptr{Uint8},), bytestring(path))
+        @unix_only ret = ccall(:rmdir, Int32, (Ptr{Uint8},), path)
         @windows_only ret = ccall(:_wrmdir, Int32, (Ptr{Uint16},), utf16(path))
         systemerror(:rmdir, ret != 0)
     end
@@ -151,7 +151,7 @@ function readdir(path::String)
 
     # defined in sys.c, to call uv_fs_readdir, which sets errno on error.
     file_count = ccall(:jl_readdir, Int32, (Ptr{Uint8}, Ptr{Uint8}),
-                       bytestring(path), uv_readdir_req)
+                        path, uv_readdir_req)
     systemerror("unable to read directory $path", file_count < 0)
 
     # The list of dir entries is returned as a contiguous sequence of null-terminated

--- a/base/fs.jl
+++ b/base/fs.jl
@@ -69,7 +69,7 @@ _uv_fs_result(req) = ccall(:jl_uv_fs_result,Int32,(Ptr{Void},),req)
 function open(f::File,flags::Integer,mode::Integer)
     req = c_malloc(_sizeof_uv_fs)
     ret = ccall(:uv_fs_open,Int32,(Ptr{Void},Ptr{Void},Ptr{Uint8},Int32,Int32,Ptr{Void}),
-                eventloop(),req,bytestring(f.path),flags,mode,C_NULL)
+                eventloop(), req, f.path, flags,mode, C_NULL)
     f.handle = _uv_fs_result(req)
     ccall(:uv_fs_req_cleanup,Void,(Ptr{Void},),req)
     c_free(req)
@@ -92,7 +92,7 @@ function close(f::File)
 end
 
 function unlink(p::String)
-    err = ccall(:jl_fs_unlink, Int32, (Ptr{Uint8},), bytestring(p))
+    err = ccall(:jl_fs_unlink, Int32, (Ptr{Uint8},), p)
     uv_error("unlink",err)
 end
 function unlink(f::File)
@@ -108,8 +108,7 @@ end
 
 # For move command
 function rename(src::String, dst::String)
-    err = ccall(:jl_fs_rename, Int32, (Ptr{Uint8}, Ptr{Uint8}), bytestring(src),
-                bytestring(dst))
+    err = ccall(:jl_fs_rename, Int32, (Ptr{Uint8}, Ptr{Uint8}), src, dst)
 
     # on error, default to cp && rm
     if err < 0
@@ -154,8 +153,7 @@ end
 @non_windowsxp_only function symlink(p::String, np::String)
     flags = 0
     @windows_only if isdir(p); flags |= UV_FS_SYMLINK_JUNCTION; p = abspath(p); end
-    err = ccall(:jl_fs_symlink, Int32, (Ptr{Uint8}, Ptr{Uint8}, Cint), 
-                bytestring(p), bytestring(np), flags)
+    err = ccall(:jl_fs_symlink, Int32, (Ptr{Uint8}, Ptr{Uint8}, Cint), p, np, flags)
     @windows_only if err < 0
         Base.warn_once("Note: on Windows, creating file symlinks requires Administrator privileges.")
     end

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -179,7 +179,7 @@ function versioninfo(io::IO=STDOUT, verbose::Bool=false)
     if verbose
         println(io,         "Environment:")
         for (k,v) in ENV
-            if !is(match(r"JULIA|PATH|FLAG|^TERM$|HOME",bytestring(k)), nothing)
+            if !is(match(r"JULIA|PATH|FLAG|^TERM$|HOME", bytestring(k)), nothing)
                 println(io, "  $(k) = $(v)")
             end
         end

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -33,10 +33,10 @@ show(io::IO, st::StatStruct) = print("StatStruct(mode=$(oct(st.mode,6)), size=$(
 # stat & lstat functions
 
 const stat_buf = Array(Uint8, ccall(:jl_sizeof_stat, Int32, ()))
-macro stat_call(sym,arg1type,arg)
+macro stat_call(sym, arg1type, arg)
     quote
         fill!(stat_buf,0)
-        r = ccall($(Expr(:quote,sym)), Int32, ($arg1type,Ptr{Uint8}), $(esc(arg)), stat_buf)
+        r = ccall($(Expr(:quote,sym)), Int32, ($arg1type, Ptr{Uint8}), $(esc(arg)), stat_buf)
         r==0 || r==UV_ENOENT || r==UV_ENOTDIR || throw(UVError("stat",r))
         st = StatStruct(stat_buf)
         if ispath(st) != (r==0)
@@ -48,10 +48,8 @@ end
 
 stat(fd::RawFD)     = @stat_call jl_fstat Int32 fd.fd
 stat(fd::Integer)   = @stat_call jl_fstat Int32 fd
-stat(path::ByteString)  = @stat_call jl_stat  Ptr{Uint8} path
-stat(path::String) = stat(bytestring(path))
-lstat(path::ByteString) = @stat_call jl_lstat Ptr{Uint8} path
-lstat(path::String) = lstat(bytestring(path))
+stat(path::String)  = @stat_call jl_stat  Ptr{Uint8} path
+lstat(path::String) = @stat_call jl_lstat Ptr{Uint8} path
 
 stat(path...) = stat(joinpath(path...))
 lstat(path...) = lstat(joinpath(path...))

--- a/base/utf8proc.jl
+++ b/base/utf8proc.jl
@@ -63,7 +63,7 @@ let
     function utf8proc_map(s::String, flags::Integer)
         result = ccall(:utf8proc_map, Cssize_t,
                        (Ptr{Uint8}, Cssize_t, Ptr{Ptr{Uint8}}, Cint),
-                       bytestring(s), 0, p, flags | UTF8PROC_NULLTERM)
+                       s, 0, p, flags | UTF8PROC_NULLTERM)
         result < 0 && error(bytestring(ccall(:utf8proc_errmsg, Ptr{Uint8},
                                              (Cssize_t,), result)))
         a = ccall(:jl_ptr_to_array_1d, Vector{Uint8}, 

--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -97,7 +97,7 @@ in
 
     function getenv(var::String)
       val = ccall( (:getenv, "libc"),
-                  Ptr{Uint8}, (Ptr{Uint8},), bytestring(var))
+                  Ptr{Uint8}, (Ptr{Uint8},), var)
       if val == C_NULL
         error("getenv: undefined variable: ", var)
       end


### PR DESCRIPTION
Due to https://github.com/JuliaLang/julia/pull/5677, `bytestring()` is now called for  for `String` type arguments in ccall.  This removes the remaining explicit bytestring calls in Base for consistency.
