### PR TITLE
Fix inclusion order of deps/Versions.make

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 JULIAHOME = $(abspath ..)
-include $(JULIAHOME)/Make.inc
 include $(JULIAHOME)/deps/Versions.make
+include $(JULIAHOME)/Make.inc
 
 override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)


### PR DESCRIPTION
Include `deps/Versions.make` before `Make.inc`. This allows `Make.user` to
override versions of system dependencies without changing Versions.make.

Note: it looks like deps/Makefile does this correctly already.
