### PR TITLE
RFC: generalised cat implementation

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -599,60 +599,47 @@ function vcat{T}(A::AbstractMatrix{T}...)
 end
 
 ## cat: general case
-
-function cat(catdim::Integer, X...)
+function cat(catdims, X...)
+    catdims = collect(catdims)
     nargs = length(X)
-    dimsX = map((a->isa(a,AbstractArray) ? size(a) : (1,)), X)
-    ndimsX = map((a->isa(a,AbstractArray) ? ndims(a) : 1), X)
-    d_max = maximum(ndimsX)
-
-    if catdim > d_max + 1
-        for i=1:nargs
-            if dimsX[1] != dimsX[i]
-                error("all inputs must have same dimensions when concatenating along a higher dimension");
-            end
-        end
-    elseif nargs >= 2
-        for d=1:d_max
-            if d == catdim; continue; end
-            len = d <= ndimsX[1] ? dimsX[1][d] : 1
-            for i = 2:nargs
-                if len != (d <= ndimsX[i] ? dimsX[i][d] : 1)
-                    error("mismatch in dimension ", d)
-                end
+    ndimsX = Int[isa(a,AbstractArray) ? ndims(a) : 0 for a in X]
+    ndimsC = max(maximum(ndimsX), maximum(catdims))
+    catsizes = zeros(Int,(nargs,length(catdims)))
+    dims2cat = zeros(Int,ndimsC)
+    for k = 1:length(catdims)
+        dims2cat[catdims[k]]=k
+    end
+    
+    typeC = isa(X[1],AbstractArray) ? eltype(X[1]) : typeof(X[1])
+    dimsC = Int[d <= ndimsX[1] ? size(X[1],d) : 1 for d=1:ndimsC]
+    for k = 1:length(catdims)
+        catsizes[1,k] = dimsC[catdims[k]]
+    end
+    for i = 2:nargs
+        typeC = promote_type(typeC, isa(X[i], AbstractArray) ? eltype(X[i]) : typeof(X[i]))
+        for d = 1:ndimsC
+            currentdim = (d <= ndimsX[i] ? size(X[i],d) : 1)
+            if dims2cat[d]==0
+                dimsC[d] == currentdim || error("mismatch in dimension ", d)
+            else
+                dimsC[d] += currentdim
+                catsizes[i,dims2cat[d]] = currentdim
             end
         end
     end
-
-    cat_ranges = [ catdim <= ndimsX[i] ? dimsX[i][catdim] : 1 for i=1:nargs ]
-
-    function compute_dims(d)
-        if d == catdim
-            if catdim <= d_max
-                return sum(cat_ranges)
-            else
-                return nargs
-            end
-        else
-            if d <= ndimsX[1]
-                return dimsX[1][d]
-            else
-                return 1
-            end
-        end
+    
+    C = similar(isa(X[1],AbstractArray) ? full(X[1]) : [X[1]], typeC, tuple(dimsC...))
+    if length(catdims)>1
+        fill!(C,0)
     end
-
-    ndimsC = max(catdim, d_max)
-    dimsC = ntuple(ndimsC, compute_dims)::(Int...)
-    typeC = promote_type(map(x->isa(x,AbstractArray) ? eltype(x) : typeof(x), X)...)
-    C = similar(isa(X[1],AbstractArray) ? full(X[1]) : [X[1]], typeC, dimsC)
-
-    range = 1
-    for k=1:nargs
-        nextrange = range+cat_ranges[k]
-        cat_one = [ i != catdim ? (1:dimsC[i]) : (range:nextrange-1) for i=1:ndimsC ]
-        C[cat_one...] = X[k]
-        range = nextrange
+    
+    offsets = zeros(Int,length(catdims))
+    for i=1:nargs
+        cat_one = [ dims2cat[d]==0 ? (1:dimsC[d]) : (offsets[dims2cat[d]]+(1:catsizes[i,dims2cat[d]])) for d=1:ndimsC]
+        C[cat_one...] = X[i]
+        for k = 1:length(catdims)
+            offsets[k] += catsizes[i,k]
+        end
     end
     return C
 end
@@ -660,65 +647,50 @@ end
 vcat(X...) = cat(1, X...)
 hcat(X...) = cat(2, X...)
 
-cat{T}(catdim::Integer, A::AbstractArray{T}...) = cat_t(catdim, T, A...)
+cat{T}(catdims, A::AbstractArray{T}...) = cat_t(catdims, T, A...)
 
-cat(catdim::Integer, A::AbstractArray...) =
-    cat_t(catdim, promote_eltype(A...), A...)
+cat(catdims, A::AbstractArray...) =
+    cat_t(catdims, promote_eltype(A...), A...)
 
-function cat_t(catdim::Integer, typeC, A::AbstractArray...)
-    # ndims of all input arrays should be in [d-1, d]
-
+function cat_t(catdims, typeC, A::AbstractArray...)
+    catdims = collect(catdims)
     nargs = length(A)
-    dimsA = map(size, A)
-    ndimsA = map(ndims, A)
-    d_max = maximum(ndimsA)
+    ndimsA = Int[ndims(a) for a in A]
+    ndimsC = max(maximum(ndimsA), maximum(catdims))
+    catsizes = zeros(Int,(nargs,length(catdims)))
+    dims2cat = zeros(Int,ndimsC)
+    for k = 1:length(catdims)
+        dims2cat[catdims[k]]=k
+    end
 
-    if catdim > d_max + 1
-        for i=1:nargs
-            if dimsA[1] != dimsA[i]
-                error("all inputs must have same dimensions when concatenating along a higher dimension");
-            end
-        end
-    elseif nargs >= 2
-        for d=1:d_max
-            if d == catdim; continue; end
-            len = d <= ndimsA[1] ? dimsA[1][d] : 1
-            for i = 2:nargs
-                if len != (d <= ndimsA[i] ? dimsA[i][d] : 1)
-                    error("mismatch in dimension ", d)
-                end
+    dimsC = Int[d <= ndimsA[1] ? size(A[1],d) : 1 for d=1:ndimsC]
+    for k = 1:length(catdims)
+        catsizes[1,k] = dimsC[catdims[k]]
+    end
+    for i = 2:nargs
+        for d = 1:ndimsC
+            currentdim = (d <= ndimsA[i] ? size(A[i],d) : 1)
+            if dims2cat[d]==0
+                dimsC[d] == currentdim || error("mismatch in dimension ", d)
+            else
+                dimsC[d] += currentdim
+                catsizes[i,dims2cat[d]] = currentdim
             end
         end
     end
 
-    cat_ranges = [ catdim <= ndimsA[i] ? dimsA[i][catdim] : 1 for i=1:nargs ]
-
-    function compute_dims(d)
-        if d == catdim
-            if catdim <= d_max
-                return sum(cat_ranges)
-            else
-                return nargs
-            end
-        else
-            if d <= ndimsA[1]
-                return dimsA[1][d]
-            else
-                return 1
-            end
-        end
+    C = similar(full(A[1]), typeC, tuple(dimsC...))
+    if length(catdims)>1
+        fill!(C,0)
     end
 
-    ndimsC = max(catdim, d_max)
-    dimsC = ntuple(ndimsC, compute_dims)::(Int...)
-    C = similar(full(A[1]), typeC, dimsC)
-
-    range = 1
-    for k=1:nargs
-        nextrange = range+cat_ranges[k]
-        cat_one = [ i != catdim ? (1:dimsC[i]) : (range:nextrange-1) for i=1:ndimsC ]
-        C[cat_one...] = A[k]
-        range = nextrange
+    offsets = zeros(Int,length(catdims))
+    for i=1:nargs
+        cat_one = [ dims2cat[d]==0 ? (1:dimsC[d]) : (offsets[dims2cat[d]]+(1:catsizes[i,dims2cat[d]])) for d=1:ndimsC]
+        C[cat_one...] = A[i]
+        for k = 1:length(catdims)
+            offsets[k] += catsizes[i,k]
+        end
     end
     return C
 end

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4172,9 +4172,9 @@ Indexing, Assignment, and Concatenation
 
    Broadcasts the ``X`` and ``inds`` arrays to a common size and stores the value from each position in ``X`` at the indices given by the same positions in ``inds``.
 
-.. function:: cat(dim, A...)
+.. function:: cat(dims, A...)
 
-   Concatenate the input arrays along the specified dimension
+   Concatenate the input arrays along the specified dimensions in the iterable ``dims``. For dimensions not in ``dims``, all input arrays should have the same size, which will also be the size of the output array along that dimension. For dimensions in ``dims``, the size of the output array is the sum of the sizes of the input arrays along that dimension. If ``dims`` is a single number, the different arrays are tightly stacked along that dimension. If ``dims`` is an iterable containing several dimensions, this allows to construct block diagonal matrices and their higher-dimensional analogues by simultaneously increasing several dimensions for every new input array and putting zero blocks elsewhere. For example, `cat([1,2], matrices...)` builds a block diagonal matrix, i.e. a block matrix with `matrices[1]`, `matrices[2]`, ... as diagonal blocks and matching zero blocks away from the diagonal.
 
 .. function:: vcat(A...)
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -72,6 +72,14 @@ tmp = zeros(Int,map(maximum,rng)...)
 tmp[rng...] = A[rng...]
 @test  tmp == cat(3,zeros(Int,2,3),[0 0 0; 0 47 52],zeros(Int,2,3),[0 0 0; 0 127 132])
 
+@test cat([1,2],1,2,3.,4.,5.) == diagm([1,2,3.,4.,5.])
+blk = [1 2;3 4]
+tmp = cat([1,3],blk,blk)
+@test tmp[1:2,1:2,1] == blk
+@test tmp[1:2,1:2,2] == zero(blk)
+@test tmp[3:4,1:2,1] == zero(blk)
+@test tmp[3:4,1:2,2] == blk
+
 x = rand(2,2)
 b = x[1,:]
 @test isequal(size(b), (1, 2))


### PR DESCRIPTION
This commit adds the generalised cat behaviour discussed in #7555 . It was suggested to call this function `dcat` with the d referring to the diagonal, since this method allows you to construct a block diagonal matrix. While I have followed this suggestion in the current commit, I am not sure whether I still agree with this choice. A block diagonal matrix is only the special case you get when 'catting' matrices and choosing `catdims=(1,2)`. For `catdims=d` an integer, it just does the same thing as the current `cat` for arbitrary multidimensional arrays and I believe this is the proper generalisation of that function for `catdims` equal to an arbitrary list of dimensions. So my suggestion would be to have this method as a replacement or additional method definition for `cat`. Comments are welcome. When everybody is happy, I will add test cases.
