### PR TITLE
Fixing redirected links in documentation from the output of `make linkcheck`

### DIFF
--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -529,7 +529,7 @@ For more details on how to pass callbacks to C libraries, see this
 C++
 ---
 
-Limited support for C++ is provided by the `Cpp <http://github.com/timholy/Cpp.jl>`_ 
+Limited support for C++ is provided by the `Cpp <https://github.com/timholy/Cpp.jl>`_ 
 and `Clang <https://github.com/ihnorton/Clang.jl>`_ packages.
 
 Handling Platform Variations

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -130,5 +130,5 @@ help new users get started with julia:
 - `Tutorial for Homer Reid's numerical analysis class <http://homerreid.dyndns.org/teaching/18.330/JuliaProgramming.shtml>`_
 - `An introductory presentation <https://github.com/ViralBShah/julia-presentations/raw/master/Fifth-Elephant-2013/Fifth-Elephant-2013.pdf>`_
 - `Videos from the Julia tutorial at MIT <http://julialang.org/blog/2013/03/julia-tutorial-MIT/>`_
-- `Forio Julia Tutorials <http://forio.com/julia/tutorials-list>`_
+- `Forio Julia Tutorials <http://forio.com/labs/julia-studio/tutorials>`_
 

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -128,7 +128,7 @@ help new users get started with julia:
 - `Julia and IJulia cheatsheet <http://math.mit.edu/%7Estevenj/Julia-cheatsheet.pdf>`_
 - `Learn Julia in a few minutes <http://learnxinyminutes.com/docs/julia/>`_
 - `Tutorial for Homer Reid's numerical analysis class <http://homerreid.dyndns.org/teaching/18.330/JuliaProgramming.shtml>`_
-- `An introductory presentation <https://github.com/ViralBShah/julia-presentations/raw/master/Fifth-Elephant-2013/Fifth-Elephant-2013.pdf>`_
+- `An introductory presentation <https://raw.githubusercontent.com/ViralBShah/julia-presentations/master/Fifth-Elephant-2013/Fifth-Elephant-2013.pdf>`_
 - `Videos from the Julia tutorial at MIT <http://julialang.org/blog/2013/03/julia-tutorial-MIT/>`_
 - `Forio Julia Tutorials <http://forio.com/labs/julia-studio/tutorials>`_
 

--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -555,7 +555,7 @@ Arbitrary Precision Arithmetic
 ------------------------------
 
 To allow computations with arbitrary-precision integers and floating point numbers, 
-Julia wraps the `GNU Multiple Precision Arithmetic Library (GMP) <http://gmplib.org>`_ and the `GNU MPFR Library <http://www.mpfr.org>`_, respectively. 
+Julia wraps the `GNU Multiple Precision Arithmetic Library (GMP) <https://gmplib.org>`_ and the `GNU MPFR Library <http://www.mpfr.org>`_, respectively. 
 The `BigInt` and `BigFloat` types are available in Julia for arbitrary precision 
 integer and floating point numbers respectively. 
 

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -97,7 +97,7 @@ One of Julia's goals is to provide an effective language for data analysis and s
 - Julia cannot assign to the results of function calls on the left-hand of an assignment operation: you cannot write ``diag(M) = ones(n)``.
 - Julia discourages populating the main namespace with functions. Most statistical functionality for Julia is found in `packages <http://docs.julialang.org/en/latest/packages/packagelist/>`_ like the DataFrames and Distributions packages:
 	- Distributions functions are found in the `Distributions package <https://github.com/JuliaStats/Distributions.jl>`_
-	- The `DataFrames package <https://github.com/HarlanH/DataFrames.jl>`_ provides data frames.
+	- The `DataFrames package <https://github.com/JuliaStats/DataFrames.jl>`_ provides data frames.
 	- Formulas for GLM's must be escaped: use ``:(y ~ x)`` instead of ``y ~ x``.
 - Julia provides tuples and real hash tables, but not R's lists. When returning multiple items, you should typically use a tuple: instead of ``list(a = 1, b = 2)``, use ``(1, 2)``.
 - Julia encourages all users to write their own types. Julia's types are much easier to use than S3 or S4 objects in R. Julia's multiple dispatch system means that ``table(x::TypeA)`` and ``table(x::TypeB)`` act like R's ``table.TypeA(x)`` and ``table.TypeB(x)``.

--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -298,7 +298,7 @@ Since packages are git repositories, before doing any package development you sh
 
 where ``FULL NAME`` is your actual full name (spaces are allowed between the double quotes) and ``EMAIL`` is your actual email address.
 Although it isn't necessary to use `GitHub <https://github.com/>`_ to create or publish Julia packages, most Julia packages as of writing this are hosted on GitHub and the package manager knows how to format origin URLs correctly and otherwise work with the service smoothly.
-We recommend that you create a `free account <https://github.com/signup/free>`_ on GitHub and then do::
+We recommend that you create a `free account <https://github.com/join>`_ on GitHub and then do::
 
     $ git config --global github.user "USERNAME"
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -7,7 +7,7 @@ Linear Algebra
 
 .. currentmodule:: Base
 
-Linear algebra functions in Julia are largely implemented by calling functions from `LAPACK <http://www.netlib.org/lapack/>`_.  Sparse factorizations call functions from `SuiteSparse < http://www.cise.ufl.edu/research/sparse/>` _.
+Linear algebra functions in Julia are largely implemented by calling functions from `LAPACK <http://www.netlib.org/lapack/>`_.  Sparse factorizations call functions from `SuiteSparse <http://www.cise.ufl.edu/research/sparse/>` _.
 
 .. function:: *(A, B)
    :noindex:

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -7,7 +7,7 @@ Linear Algebra
 
 .. currentmodule:: Base
 
-Linear algebra functions in Julia are largely implemented by calling functions from `LAPACK <http://www.netlib.org/lapack/>`_.  Sparse factorizations call functions from `SuiteSparse <http://www.suitesparse.com/>`_.
+Linear algebra functions in Julia are largely implemented by calling functions from `LAPACK <http://www.netlib.org/lapack/>`_.  Sparse factorizations call functions from `SuiteSparse < http://www.cise.ufl.edu/research/sparse/>` _.
 
 .. function:: *(A, B)
    :noindex:

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -7,7 +7,7 @@ Linear Algebra
 
 .. currentmodule:: Base
 
-Linear algebra functions in Julia are largely implemented by calling functions from `LAPACK <http://www.netlib.org/lapack/>`_.  Sparse factorizations call functions from `SuiteSparse <http://www.cise.ufl.edu/research/sparse/>` _.
+Linear algebra functions in Julia are largely implemented by calling functions from `LAPACK <http://www.netlib.org/lapack/>`_.  Sparse factorizations call functions from `SuiteSparse <http://www.cise.ufl.edu/research/sparse/>`_.
 
 .. function:: *(A, B)
    :noindex:

--- a/doc/stdlib/profile.rst
+++ b/doc/stdlib/profile.rst
@@ -32,7 +32,7 @@ this design has important strengths:
 
 - You do not have to make any modifications to your code to take
   timing measurements (in contrast to the alternative `instrumenting
-  profiler <https://github.com/timholy/Profile.jl>`_)
+  profiler <https://github.com/timholy/IProfile.jl>`_)
 - It can profile into Julia's core code and even (optionally) into C
   and Fortran libraries
 - By running "infrequently" there is very little performance overhead;


### PR DESCRIPTION
Fixed a series of links that are redirected in the documentation.

manual/calling-c-and-fortran-code.rst:532: http://github.com/timholy/Cpp.jl to https://github.com/timholy/Cpp.jl

manual/getting-started.rst:138: http://forio.com/julia/tutorials-list to http://forio.com/labs/julia-studio/tutorials/

manual/getting-started.rst:136: https://github.com/ViralBShah/julia-presentations/raw/master/Fifth-Elephant-2013/Fifth-Elephant-2013.pdf to https://raw.githubusercontent.com/ViralBShah/julia-
presentations/master/Fifth-Elephant-2013/Fifth-Elephant-2013.pdf

manual/integers-and-floating-point-numbers.rst:566: http://gmplib.org to https://gmplib.org/

manual/noteworthy-differences.rst:103: https://github.com/HarlanH/DataFrames.jl to https://github.com/JuliaStats/DataFrames.jl

manual/packages.rst:287: https://github.com/signup/free to https://github.com/join

stdlib/linalg.rst:10: http://www.suitesparse.com/ to http://www.cise.ufl.edu/research/sparse/

stdlib/profile.rst:33:  https://github.com/timholy/Profile.jl to https://github.com/timholy/IProfile.jl
