### PR TITLE
Code coverage kwarg for Pkg.test

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -63,8 +63,8 @@ generate(pkg::String, license::String; force::Bool=false) =
 	cd(Generate.package,pkg,license,force=force)
 
 
-test() = cd(Entry.test)
-test(pkgs::String...) = cd(Entry.test,String[pkgs...])
+test(;coverage::Bool=false) = cd(Entry.test; coverage=coverage)
+test(pkgs::String...; coverage::Bool=false) = cd(Entry.test,String[pkgs...]; coverage=coverage)
 
 @deprecate release free
 @deprecate fixup build

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -666,7 +666,7 @@ function updatehook(pkgs::Vector)
     """)
 end
 
-function test!(pkg::String, errs::Vector{String}, notests::Vector{String})
+function test!(pkg::String, errs::Vector{String}, notests::Vector{String}; coverage::Bool=false)
     const reqs_path = abspath(pkg,"test","REQUIRE")
     if isfile(reqs_path)
         const tests_require = Reqs.parse(reqs_path)
@@ -680,7 +680,12 @@ function test!(pkg::String, errs::Vector{String}, notests::Vector{String})
         info("Testing $pkg")
         cd(dirname(test_path)) do
             try
-                run(`$JULIA_HOME/julia $test_path`)
+                if coverage
+                    cmd = `$JULIA_HOME/julia --code-coverage $test_path`
+                else
+                    cmd = `$JULIA_HOME/julia $test_path`
+                end
+                run(cmd)
                 info("$pkg tests passed")
             catch err
                 warnbanner(err, label="[ ERROR: $pkg ]")
@@ -693,11 +698,11 @@ function test!(pkg::String, errs::Vector{String}, notests::Vector{String})
     resolve()
 end
 
-function test(pkgs::Vector{String})
+function test(pkgs::Vector{String}; coverage::Bool=false)
     errs = String[]
     notests = String[]
     for pkg in pkgs
-        test!(pkg,errs,notests)
+        test!(pkg,errs,notests; coverage=coverage)
     end
     if !isempty(errs) || !isempty(notests)
         messages = String[]
@@ -707,6 +712,6 @@ function test(pkgs::Vector{String})
     end
 end
 
-test() = test(sort!(String[keys(installed())...]))
+test(;coverage::Bool=false) = test(sort!(String[keys(installed())...]); coverage=coverage)
 
 end # module


### PR DESCRIPTION
This PR effectively replaces #7393 - it does the same thing, but with keyword arguments instead of optional positional arguments.

Ping @IainNZ, @StefanKarpinski

If this can be merged before v0.3 is tagged, it will probably simplify travis scripts for many packages quite a lot, since the API for package testing stabilizes. Currently, a lot of packages have somewhat hackish bash scripting that test for `JULIAVERSION = "julianightlies"` or `JULIAVERSION = "juliareleases"` to determine if `julia -e 'Pkg.test(...)'` or `julia [--code-coverage] test/runtest.jl` should be called. I think this change has merits even if the coverage tools in themselves are somewhat unreliable at the moment.
