### PR TITLE
Support host count in machinefile

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -330,13 +330,11 @@ end
 function load_machine_file(path::String)
     machines = String[]
     for line in split(readall(path),'\n',false)
-        m = match(r"^([^\s*]+)\*(\d+)(.*)",line)
-        if m == nothing
-            push!(machines,line)
+        s = split(line,'*',false)
+        if length(s) > 1
+            append!(machines,fill(s[2],int(s[1])))
         else
-            (host, count, rest) = m.captures
-            count = (count != nothing) ? int(count) : 1
-            append!(machines,fill(string(host,rest),count))
+            push!(machines,line)
         end
     end
     return machines

--- a/base/client.jl
+++ b/base/client.jl
@@ -236,7 +236,7 @@ function process_options(args::Vector{UTF8String})
             addprocs(np)
         elseif args[i]=="--machinefile"
             i+=1
-            machines = split(readall(args[i]), '\n', false)
+            machines = load_machine_file(args[i])
             addprocs(machines)
         elseif args[i]=="-v" || args[i]=="--version"
             println("julia version ", VERSION)
@@ -325,6 +325,21 @@ function load_juliarc()
         try_include(abspath(JULIA_HOME,"..","etc","julia","juliarc.jl"))
     end
     try_include(abspath(homedir(),".juliarc.jl"))
+end
+
+function load_machine_file(path::String)
+    machines = String[]
+    for line in split(readall(path),'\n',false)
+        m = match(r"^([^\s*]+)\*(\d+)(.*)",line)
+        if m == nothing
+            push!(machines,line)
+        else
+            (host, count, rest) = m.captures
+            count = (count != nothing) ? int(count) : 1
+            append!(machines,fill(string(host,rest),count))
+        end
+    end
+    return machines
 end
 
 function early_init()

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -71,7 +71,7 @@ processes, while ``--machinefile file`` will launch a worker for each line in
 file ``file``. The machines defined in ``file`` must be accessible via a
 passwordless ``ssh`` login, with Julia installed at the same location as the
 current host. Each machine definition takes the form
-``[user@]host[:port][*count] [bind_addr]`` . ``user`` defaults to current user,
+``[count*][user@]host[:port] [bind_addr]`` . ``user`` defaults to current user,
 ``port`` to the standard ssh port. ``count`` is the number of workers to spawn
 on the node, and defaults to 1. Optionally, in case of multi-homed hosts,
 ``bind_addr`` may be used to explicitly specify an interface.

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -65,14 +65,15 @@ Or you could put that code into a script and run it::
     foo
     bar
 
-Julia can be started in parallel mode with either the ``-p`` or the 
-``--machinefile`` options. ``-p n`` will launch an additional ``n`` 
-worker processes, while ``--machinefile file`` will launch a worker 
-for each line in file ``file``. The machines defined in ``file`` must be 
-accessible via a passwordless ``ssh`` login, with Julia installed at the
-same location as the current host. Each machine definition takes the form 
-``[user@]host[:port] [bind_addr]`` . ``user`` defaults to current user, 
-``port`` to the standard ssh port. Optionally, in case of multi-homed hosts, 
+Julia can be started in parallel mode with either the ``-p`` or the
+``--machinefile`` options. ``-p n`` will launch an additional ``n`` worker
+processes, while ``--machinefile file`` will launch a worker for each line in
+file ``file``. The machines defined in ``file`` must be accessible via a
+passwordless ``ssh`` login, with Julia installed at the same location as the
+current host. Each machine definition takes the form
+``[user@]host[:port][*count] [bind_addr]`` . ``user`` defaults to current user,
+``port`` to the standard ssh port. ``count`` is the number of workers to spawn
+on the node, and defaults to 1. Optionally, in case of multi-homed hosts,
 ``bind_addr`` may be used to explicitly specify an interface.
     
     


### PR DESCRIPTION
This is the initial support for an improved machinefile, as described in #7589.
- Support the syntax `[user@]host[:port][*count] [bind_addr]` in the
  machinefile.
- Initial code just re-writes the list fed to addprocs() by repeating the host
  as specified, so there is no user-visible change.

Includes basic documentation.
