### PR TITLE
Tilde expansion in REPL shell completion

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -108,6 +108,9 @@ function complete_keyword(s::ByteString)
 end
 
 function complete_path(path::AbstractString, pos)
+    if ismatch(r"^~(?:/|$)", path)
+        path = homedir() * path[2:end]
+    end
     dir, prefix = splitdir(path)
     local files
     try
@@ -354,7 +357,7 @@ function shell_completions(string, pos)
     isempty(args.args[end].args) && return UTF8String[], 0:-1, false
     arg = args.args[end].args[end]
     if all(map(s -> isa(s, AbstractString), args.args[end].args))
-        # Treat this as a path (perhaps give a list of comands in the future as well?)
+        # Treat this as a path (perhaps give a list of commands in the future as well?)
         return complete_path(join(args.args[end].args), pos)
     elseif isexpr(arg, :escape) && (isexpr(arg.args[1], :incomplete) || isexpr(arg.args[1], :error))
         r = first(last_parse):prevind(last_parse, last(last_parse))


### PR DESCRIPTION
Search relative to `homedir()` if path begins with `~`.
