### PR TITLE
WIP: fixing eigs

### DIFF
--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -5,8 +5,8 @@ using .ARPACK
 eigs(A; args...) = eigs(A, I; args...)
 
 function eigs(A, B;
-              nev::Integer=6, ncv::Integer=max(20,2*nev+1), which::ASCIIString="LM",
-              tol=0.0, maxiter::Integer=1000, sigma=nothing, v0::Vector=zeros((0,)),
+              nev::Integer=6, ncv::Integer=max(20,2*nev+1), which=:LM,
+              tol=0.0, maxiter::Integer=300, sigma=nothing, v0::Vector=zeros(eltype(A),(0,)),
               ritzvec::Bool=true)
 
     n = chksquare(A)
@@ -30,13 +30,46 @@ function eigs(A, B;
     isgeneral && !isposdef(B) && throw(PosDefException(0))
     bmat = isgeneral ? "G" : "I"
     isshift = sigma !== nothing
-    sigma = isshift ? sigma : zero(T)
+    
+    if isa(which,String)
+        warn("Use symbols instead of strings for specifying which eigenvalues to compute")
+        which=symbol(which)
+    end
+    which == :LM || which == :SM || which == :LR || which == :SR || which == :LI || which == :SI || which == :BE || error("invalid value for which")
+    which != :BE || sym || error("which = :BE only possible for real symmetric problem")
+    isshift && which == :SM && warn("use of :SM in shift-and-invert mode is not recommended, use :LM to find eigenvalues closest to sigma")
+
+    if which==:SM && !isshift # transform into shift-and-invert method with sigma = 0
+        isshift=true
+        sigma=zero(T)
+        which=:LM
+    end
+    
+    if sigma != nothing && !iscmplx && isa(sigma,Complex)
+        error("complex shifts for real problems are not yet supported")
+    end
+    sigma = isshift ? convert(T,sigma) : zero(T)
 
     if !isempty(v0)
         length(v0)==n || throw(DimensionMismatch(""))
         eltype(v0)==T || error("Starting vector must have eltype $T")
-    else
-        v0=zeros(T,(0,))
+    end
+    
+    whichstr = "LM"
+    if which == :BE
+        whichstr = "BE"
+    end
+    if which == :LR
+        whichstr = (!sym ? "LR" : "LA")
+    end
+    if which == :SR
+        whichstr = (!sym ? "SR" : "SA")
+    end
+    if which == :LI
+        whichstr = (!sym ? "LI" : error("largest imaginary is meaningless for symmetric eigenvalue problems"))
+    end
+    if which == :SI
+        whichstr = (!sym ? "SI" : error("smallest imaginary is meaningless for symmetric eigenvalue problems"))
     end
 
     # Refer to ex-*.doc files in ARPACK/DOCUMENTS for calling sequence
@@ -48,32 +81,28 @@ function eigs(A, B;
             solveSI(x) = x
         else                #    Shift-invert mode
             mode       = 3
-            solveSI(x) = factorize(sigma==0 ? A : A - UniformScaling(sigma)) \ x
+            F = factorize(sigma==zero(T) ? A : A - UniformScaling(sigma))
+            solveSI(x) = F \ x
         end
     else                    # Generalized eigen problem
         matvecB(x) = B * x
         if !isshift         #    Regular inverse mode
             mode       = 2
-            solveSI(x) = factorize(B) \ x
+            F = factorize(B)
+            solveSI(x) = F \ x
         else                #    Shift-invert mode
             mode       = 3
-            solveSI(x) = factorize(sigma==0 ? A : A-sigma*B) \ x
+            F = factorize(sigma==zero(T) ? A : A-sigma*B)
+            solveSI(x) = F \ x
         end
     end
 
     # Compute the Ritz values and Ritz vectors
     (resid, v, ldv, iparam, ipntr, workd, workl, lworkl, rwork, TOL) = 
-       ARPACK.aupd_wrapper(T, matvecA, matvecB, solveSI, n, sym, iscmplx, bmat, nev, ncv, which, tol, maxiter, mode, v0)
+       ARPACK.aupd_wrapper(T, matvecA, matvecB, solveSI, n, sym, iscmplx, bmat, nev, ncv, whichstr, tol, maxiter, mode, v0)
     
     # Postprocessing to get eigenvalues and eigenvectors
-    if ritzvec
-        (eval, evec, nconv, niter, nmult, resid) =
-             ARPACK.eupd_wrapper(T, n, sym, iscmplx, bmat, nev, which, ritzvec, TOL,
+    return ARPACK.eupd_wrapper(T, n, sym, iscmplx, bmat, nev, whichstr, ritzvec, TOL,
                                  resid, ncv, v, ldv, sigma, iparam, ipntr, workd, workl, lworkl, rwork)
-    else
-        (eval, nconv, niter, nmult, resid) =
-             ARPACK.eupd_wrapper(T, n, sym, iscmplx, bmat, nev, which, ritzvec, TOL,
-                                 resid, ncv, v, ldv, sigma, iparam, ipntr, workd, workl, lworkl, rwork)
-    end
 
 end

--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -47,58 +47,54 @@ function aupd_wrapper(T, matvecA::Function, matvecB::Function, solveSI::Function
             naupd(ido, bmat, n, which, nev, TOL, resid, ncv, v, n,
                   iparam, ipntr, workd, workl, lworkl, info)
         end
-
-        # Check for warnings and errors
-        # Refer to ex-*.doc files in ARPACK/DOCUMENTS for calling sequence
-        if info[1] == 3; warn("try eigs/svds with a larger value for ncv"); end
-        if info[1] == 1; warn("maximum number of iterations reached; check nconv for number of converged eigenvalues"); end
-        if info[1] < 0; throw(ARPACKException(info[1])); end
-
+        
         load_idx = ipntr[1]+zernm1
         store_idx = ipntr[2]+zernm1
         x = workd[load_idx]
-        if ido[1] == -1
-            if mode == 1
+        if mode == 1  # corresponds to dsdrv1, dndrv1 or zndrv1
+            if ido[1] == 1
                 workd[store_idx] = matvecA(x)
-            elseif mode == 2
-                if sym
-                    temp = matvecA(x)
-                    workd[load_idx] = temp    # overwrite as per Remark 5 in dsaupd.f
-                    workd[store_idx] = solveSI(temp)
-                else
-                    workd[store_idx] = solveSI(matvecA(x))
-                end
-            elseif mode == 3
-                if bmat == "I"
-                    workd[store_idx] = solveSI(x)
-                elseif bmat == "G"
-                    workd[store_idx] = solveSI(matvecB(x))
-                end
+            elseif ido[1] == 99
+                break
+            else
+                error("Internal ARPACK error")
             end
-        elseif ido[1] == 1
-            if mode == 1
-                workd[store_idx] = matvecA(x)
-            elseif mode == 2
-                if sym
-                    temp = matvecA(x)
-                    workd[load_idx] = temp
-                    workd[store_idx] = solveSI(temp)
-                else
-                    workd[store_idx] = solveSI(matvecA(x))
-                end
-            elseif mode == 3
-                if bmat == "I"
-                    workd[store_idx] = solveSI(x)
-                else
-                    workd[store_idx] = solveSI(workd[ipntr[3]+zernm1])
-                end
+        elseif mode == 3 && bmat == "I" # corresponds to dsdrv2, dndrv2 or zndrv2
+            if ido[1] == -1 || ido[1] == 1
+                workd[store_idx] = solveSI(x)
+            elseif ido[1] == 99
+                break
+            else
+                error("Internal ARPACK error")
             end
-        elseif ido[1] == 2
-            workd[store_idx] = matvecB(x)
-        elseif ido[1] == 99
-            break
+        elseif mode == 2 # corresponds to dsdrv3, dndrv3 or zndrv3
+            if ido[1] == -1 || ido[1] == 1
+                tmp = matvecA(x)
+                if sym
+                    workd[load_idx] = tmp    # overwrite as per Remark 5 in dsaupd.f
+                end
+                workd[store_idx] = solveSI(tmp)
+            elseif ido[1] == 2
+                workd[store_idx] = matvecB(x)
+            elseif ido[1] == 99
+                break
+            else
+                error("Internal ARPACK error")
+            end
+        elseif mode == 3 && bmat == "G" # corresponds to dsdrv4, dndrv4 or zndrv4
+            if ido[1] == -1
+                workd[store_idx] = solveSI(matvecB(x))
+            elseif  ido[1] == 1
+                workd[store_idx] = solveSI(workd[ipntr[3]+zernm1])
+            elseif ido[1] == 2
+                workd[store_idx] = matvecB(x)
+            elseif ido[1] == 99
+                break
+            else
+                error("Internal ARPACK error")
+            end
         else
-            error("Internal ARPACK error")
+            error("ARPACK mode not yet supported")
         end
     end
     
@@ -114,26 +110,43 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
     select = Array(BlasInt, ncv)
     info   = zeros(BlasInt, 1)
     
+    dmap = x->abs(x)
+    if iparam[7] == 3 # shift-and-invert
+        dmap = x->abs(1./(x-sigma))
+    elseif which == "LR" || which == "LA" || which == "BE"
+        dmap = x->real(x)
+    elseif which == "SR" || which == "SA"
+        dmap = x->-real(x)
+    elseif which == "LI"
+        dmap = x->imag(x)
+    elseif which == "SI"
+        dmap = x->-imag(x)
+    end
+    
     if cmplx
 
         d = Array(T, nev+1)
-        sigma = ones(T, 1)*sigma
+        sigmar = ones(T, 1)*sigma
         workev = Array(T, 2ncv)
-        neupd(ritzvec, howmny, select, d, v, ldv, sigma, workev,
+        neupd(ritzvec, howmny, select, d, v, ldv, sigmar, workev,
               bmat, n, which, nev, TOL, resid, ncv, v, ldv,
               iparam, ipntr, workd, workl, lworkl, rwork, info)
         if info[1] != 0; throw(ARPACKException(info[1])); end
-        return ritzvec ? (d[1:nev], v[1:n, 1:nev],iparam[5],iparam[3],iparam[9],resid) : (d[1:nev],iparam[5],iparam[3],iparam[9],resid)
+        
+        p = sortperm(dmap(d[1:nev]), rev=true)
+        return ritzvec ? (d[p], v[1:n, p],iparam[5],iparam[3],iparam[9],resid) : (d[p],iparam[5],iparam[3],iparam[9],resid)
 
     elseif sym
 
         d = Array(T, nev)
-        sigma = ones(T, 1)*sigma
-        seupd(ritzvec, howmny, select, d, v, ldv, sigma,
+        sigmar = ones(T, 1)*sigma
+        seupd(ritzvec, howmny, select, d, v, ldv, sigmar,
               bmat, n, which, nev, TOL, resid, ncv, v, ldv,
               iparam, ipntr, workd, workl, lworkl, info) 
         if info[1] != 0; throw(ARPACKException(info[1])); end
-        return ritzvec ? (d, v[1:n, 1:nev],iparam[5],iparam[3],iparam[9],resid) : (d,iparam[5],iparam[3],iparam[9],resid)
+            
+        p = sortperm(dmap(d), rev=true)
+        return ritzvec ? (d[p], v[1:n, p],iparam[5],iparam[3],iparam[9],resid) : (d,iparam[5],iparam[3],iparam[9],resid)
 
     else
 
@@ -147,19 +160,33 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
               iparam, ipntr, workd, workl, lworkl, info)
         if info[1] != 0; throw(ARPACKException(info[1])); end
         evec = complex(zeros(T, n, nev+1), zeros(T, n, nev+1))
+        
         j = 1
-        while j <= nev
-            if di[j] == 0
-                evec[:,j] = v[:,j]
+        indfake = 0
+        while j <= nev+1
+            if abs(complex(dr[j],di[j])) < sqrt(eps(T))*sqrt(nextfloat(zero(T))) # is this a good criterion for really small?
+                indfake = j
             else
-                evec[:,j]   = v[:,j] + im*v[:,j+1]
-                evec[:,j+1] = v[:,j] - im*v[:,j+1]
-                j += 1
+                if di[j] == 0
+                    evec[:,j] = v[:,j]
+                else
+                    evec[:,j]   = v[:,j] + im*v[:,j+1]
+                    evec[:,j+1] = v[:,j] - im*v[:,j+1]
+                    j += 1
+                end
             end
             j += 1
         end
-        d = complex(dr[1:nev],di[1:nev])
-        return ritzvec ? (d, evec[1:n, 1:nev],iparam[5],iparam[3],iparam[9],resid) : (d,iparam[5],iparam[3],iparam[9],resid)
+        d = complex(dr,di)
+        p = sortperm(dmap(d), rev=true)
+        
+        if indfake == 0
+            p = p[1:nev]
+        else
+            p = setdiff(p, indfake)
+        end
+        
+        return ritzvec ? (d[p], evec[1:n, p],iparam[5],iparam[3],iparam[9],resid) : (d[p],iparam[5],iparam[3],iparam[9],resid)
     end
     
 end

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -513,19 +513,17 @@ Linear algebra functions in Julia are largely implemented by calling functions f
       ========= ======================================================================================================================
       ``which`` type of eigenvalues
       --------- ----------------------------------------------------------------------------------------------------------------------
-      ``"LM"``  eigenvalues of largest magnitude
-      ``"SM"``  eigenvalues of smallest magnitude
-      ``"LA"``  largest algebraic eigenvalues (real symmetric ``A`` only)
-      ``"SA"``  smallest algebraic eigenvalues (real symmetric ``A`` only)
-      ``"BE"``  compute half of the eigenvalues from each end of the spectrum, biased in favor of the high end. (symmetric ``A`` only)
-      ``"LR"``  eigenvalues of largest real part (nonsymmetric ``A`` only)
-      ``"SR"``  eigenvalues of smallest real part (nonsymmetric ``A`` only)
-      ``"LI"``  eigenvalues of largest imaginary part (nonsymmetric ``A`` only)
-      ``"SI"``  eigenvalues of smallest imaginary part (nonsymmetric ``A`` only)
+      ``:LM``  eigenvalues of largest magnitude (default)
+      ``:SM``  eigenvalues of smallest magnitude
+      ``:LR``  eigenvalues of largest real part
+      ``:SR``  eigenvalues of smallest real part
+      ``:LI``  eigenvalues of largest imaginary part (nonsymmetric or complex ``A`` only)
+      ``:SI``  eigenvalues of smallest imaginary part (nonsymmetric or complex ``A`` only)
+      ``:BE``  compute half of the eigenvalues from each end of the spectrum, biased in favor of the high end. (real symmetric ``A`` only)
       ========= ======================================================================================================================
 
     * ``tol``: tolerance (:math:`tol \le 0.0` defaults to ``DLAMCH('EPS')``)
-    * ``maxiter``: Maximum number of iterations
+    * ``maxiter``: Maximum number of iterations (default = 300)
     * ``sigma``: Specifies the level shift used in inverse iteration. If ``nothing`` (default), defaults to ordinary (forward) iterations. Otherwise, find eigenvalues close to ``sigma`` using shift and invert iterations.
     * ``ritzvec``: Returns the Ritz vectors ``v`` (eigenvectors) if ``true``
     * ``v0``: starting vector from which to start the iterations

--- a/test/arpack.jl
+++ b/test/arpack.jl
@@ -28,8 +28,8 @@ begin
     	(d,v) = eigs(a, nev=3)
     	@test_approx_eq a*v[:,2] d[2]*v[:,2]
         @test norm(v) > testtol # eigenvectors cannot be null vectors
-    	# (d,v) = eigs(a, b, nev=3, tol=1e-8) not handled yet
-    	# @test_approx_eq_eps a*v[:,2] d[2]*b*v[:,2] testtol
+        # (d,v) = eigs(a, b, nev=3, tol=1e-8) # not handled yet
+        # @test_approx_eq_eps a*v[:,2] d[2]*b*v[:,2] testtol
         # @test norm(v) > testtol # eigenvectors cannot be null vectors
     
     	(d,v) = eigs(asym, nev=3)
@@ -57,6 +57,23 @@ begin
     end
 end
 
+# Problematic example from #6965
+A6965 = [
+         1.0   1.0   1.0   1.0   1.0   1.0   1.0  1.0
+        -1.0   2.0   0.0   0.0   0.0   0.0   0.0  1.0
+        -1.0   0.0   3.0   0.0   0.0   0.0   0.0  1.0
+        -1.0   0.0   0.0   4.0   0.0   0.0   0.0  1.0
+        -1.0   0.0   0.0   0.0   5.0   0.0   0.0  1.0
+        -1.0   0.0   0.0   0.0   0.0   6.0   0.0  1.0
+        -1.0   0.0   0.0   0.0   0.0   0.0   7.0  1.0
+        -1.0  -1.0  -1.0  -1.0  -1.0  -1.0  -1.0  8.0
+       ];
+       
+d, = eigs(A6965,which=:SM,nev=2,ncv=4,tol=eps())
+@test_approx_eq d[1] 2.5346936860350002
+@test_approx_eq real(d[2]) 2.6159972444834976
+@test_approx_eq abs(imag(d[2])) 1.2917858749046127
+
 # Example from Quantum Information Theory
 import Base: size, issym, ishermitian
 
@@ -82,7 +99,7 @@ end
 Q=reshape(Q,(50,2,50))
 # Construct trace-preserving completely positive map from this
 Phi=CPM(Q)
-(d,v,nconv,numiter,numop,resid) = eigs(Phi,nev=1,which="LM")
+(d,v,nconv,numiter,numop,resid) = eigs(Phi,nev=1,which=:LM)
 # Properties: largest eigenvalue should be 1, largest eigenvector, when reshaped as matrix
 # should be a Hermitian positive definite matrix (up to an arbitrary phase)
 
@@ -97,7 +114,7 @@ v=(v+v')/2
 @test isposdef(v)
 
 # Repeat with starting vector
-(d2,v2,nconv2,numiter2,numop2,resid2) = eigs(Phi,nev=1,which="LM",v0=reshape(v,(2500,)))
+(d2,v2,nconv2,numiter2,numop2,resid2) = eigs(Phi,nev=1,which=:LM,v0=reshape(v,(2500,)))
 v2=reshape(v2,(50,50))
 v2/=trace(v2)
 @test numiter2<numiter


### PR DESCRIPTION
First part of fixes for solving the issue reported in JuliaLang/LinearAlgebra.jl#115:
- default value of `maxiter` reduced (1000 was a lot)
- change `which` specification to use symbols rather than strings, e.g. `:LM` etc
- input preprocessing to transform `which=:SM` into a shift-and-invert method with `sigma=0`.

Remains to be done:
- fix output postprocessing in `eupd_wrapper` to select correct eigenvalues and eigenvectors.

I am to tired to finish this now, will try to do so tomorrow.
