### PR TITLE
patches to cartesian.jl

### DIFF
--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -97,7 +97,7 @@ generate1(itersym::Symbol, prototype, bodyfunc, N::Int, varname, T) =
 generate1{K}(itersyms::NTuple{K,Symbol}, prototype, bodyfunc, itervals::NTuple{K,Int}) =
      Expr(:function, spliceint!(sreplace!(copy(prototype), itersyms, itervals)), bodyfunc(itervals))
 
-function ngenerate(itersym::Symbol, returntypeexpr, prototype, bodyfunc, dims, makecached::Bool = true)
+function ngenerate(itersym::Symbol, returntypeexpr, prototype, bodyfunc, dims=1:CARTESIAN_DIMS, makecached::Bool = true)
     varname, T = get_splatinfo(prototype, itersym)
     # Generate versions for specific dimensions
     fdim = [generate1(itersym, prototype, bodyfunc, N, varname, T) for N in dims]


### PR DESCRIPTION
As discussed with @timholy in the Cartesian package, this patch allows the cartesian macros to work with an arbitrary number of parameters `N1`, `N2`, ... which is useful for writing more complicated functions for multidimensional arrays, e.g. a a mutating binary operation such as tensor contraction (see TensorOperations.jl ) requires three multidimensional arrays (two inputs, one output) with different `N1`, `N2` and `N3`. 
