### PR TITLE
parse ¬ (\neg) as a prefix operator

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -45,7 +45,7 @@
 	    (eval `(define ,(symbol (string "is-" name "?")) (Set ,name))))
 	  prec-names)
 
-(define unary-ops '(+ - ! ~ |<:| |>:| √ ∛ ∜))
+(define unary-ops '(+ - ! ¬ ~ |<:| |>:| √ ∛ ∜))
 
 ; operators that are both unary and binary
 (define unary-and-binary-ops '(+ - $ & ~))
@@ -63,7 +63,7 @@
 (define ctrans-op (string->symbol "'"))
 (define vararg-op (string->symbol "..."))
 
-(define operators (list* '~ '! '-> '√ '∛ '∜ ctrans-op trans-op vararg-op
+(define operators (list* '~ '! '¬ '-> '√ '∛ '∜ ctrans-op trans-op vararg-op
 			 (delete-duplicates
 			  (apply append (map eval prec-names)))))
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1782,3 +1782,7 @@ let
     end
     @test v == {(1,1), (1,2)}
 end
+
+# addition of ¬ (\neg) parsing
+const (¬) = !
+@test ¬false


### PR DESCRIPTION
As [discussed on julia-users](https://groups.google.com/d/msg/julia-users/oqdUhGFXVbw/3KgWmpfWY6oJ), this patch parses `¬` as a prefix operator like `!`, although it doesn't define it by default (since `!` is already perfectly good).

The main arguments for this, in my mind, are:
- There is nothing sensible to do with ¬ except to parse it as a prefix operator.
- We already parse the other logic symbols (e.g. `∧`) as operators, so we might as well complete the set.

@jverzani also has a use-case in SymPy.
