### PR TITLE
Add libllvm_version to base_h.jl, include in versioninfo() output

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -1,4 +1,5 @@
 JULIAHOME = ..
+include ../deps/Versions.make
 include ../Make.inc
 
 PCRE_CONST = 0x[0-9a-fA-F]+|[-+]?\s*[0-9]+
@@ -51,6 +52,7 @@ else
 endif
 	@echo "const libfftw_name = \"$(LIBFFTWNAME)\"" >> $@
 	@echo "const libfftwf_name = \"$(LIBFFTWFNAME)\"" >> $@
+	@echo "const libllvm_version = \"$(LLVM_VER)\"" >> $@
 	@echo "const VERSION_STRING = \"$(JULIA_VERSION)\"" >> $@
 	@echo "const TAGGED_RELEASE_BANNER = \"$(TAGGED_RELEASE_BANNER)\"" >> $@
 	@echo "const SYSCONFDIR = \"$(sysconfdir)\"" >> $@

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -176,6 +176,7 @@ function versioninfo(io::IO=STDOUT, verbose::Bool=false)
     end
     println(io,             "  LAPACK: ",liblapack_name)
     println(io,             "  LIBM: ",libm_name)
+    println(io,             "  LLVM: libLLVM-",libllvm_version)
     if verbose
         println(io,         "Environment:")
         for (k,v) in ENV


### PR DESCRIPTION
This is pretty useful now that we have users trying out not only llvm 3.4 but 3.5 as well.
