### PR TITLE
Add rand! method for AbstractRNG and AbstractArray types

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -130,6 +130,14 @@ function rand!{T}(A::Array{T})
     end
     A
 end
+
+function rand!(r::AbstractRNG, A::AbstractArray)
+    for i=1:length(A)
+        @inbounds A[i] = rand(r)
+    end
+    A
+end
+
 rand(T::Type, dims::Dims) = rand!(Array(T, dims))
 rand{T<:Number}(::Type{T}) = error("no random number generator for type $T; try a more specific type")
 rand{T<:Number}(::Type{T}, dims::Int...) = rand(T, dims)

--- a/test/random.jl
+++ b/test/random.jl
@@ -19,6 +19,13 @@ srand(0); rand(); x = rand(384);
 # Try a seed larger than 2^32
 @test rand(MersenneTwister(5294967296)) == 0.3498809918210497
 
+# Test array filling, Issue #7643
+@test rand(MersenneTwister(0), 1) == [0.8236475079774124]
+A = zeros(2, 2)
+rand!(MersenneTwister(0), A)
+@test A == [0.8236475079774124  0.16456579813368521;
+            0.9103565379264364  0.17732884646626457]
+
 # randn
 @test randn(MersenneTwister(42)) == -0.5560268761463861
 A = zeros(2, 2)


### PR DESCRIPTION
Several functions invoke

```
rand!(r::AbstractRNG, A::AbstractArray)
```

causing an error, since that method doesn't exist (issue #7643).
This commit provides the missing method and closes #7643.
