### PR TITLE
Label QRCompactWY.T as Triangular

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -196,11 +196,11 @@ include("linalg/lapack.jl")
 
 include("linalg/dense.jl")
 include("linalg/tridiag.jl")
+include("linalg/triangular.jl")
 include("linalg/factorization.jl")
 include("linalg/lu.jl")
 
 include("linalg/bunchkaufman.jl")
-include("linalg/triangular.jl")
 include("linalg/symmetric.jl")
 include("linalg/woodbury.jl")
 include("linalg/diagonal.jl")

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -226,7 +226,7 @@ immutable QRPackedQ{T} <: AbstractMatrix{T}
 end
 immutable QRCompactWYQ{S} <: AbstractMatrix{S} 
     factors::Matrix{S}
-    T::Matrix{S}
+    T::Triangular{S}
 end
 
 convert{T}(::Type{QRPackedQ{T}}, Q::QRPackedQ) = QRPackedQ(convert(AbstractMatrix{T}, Q.factors), convert(Vector{T}, Q.τ))

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -141,8 +141,9 @@ end
 # Note. For QRCompactWY factorization without pivoting, the WY representation based method introduced in LAPACK 3.4
 immutable QRCompactWY{S} <: Factorization{S}
     factors::Matrix{S}
-    T::Matrix{S}
+    T::Triangular{S}
 end
+QRCompactWY{S}(factors::Matrix{S}, T::Matrix{S})=QRCompactWY{S}(factors, Triangular(T, :U))
 
 immutable QRPivoted{T} <: Factorization{T}
     factors::Matrix{T}

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -243,7 +243,7 @@ full{T}(A::Union(QRPackedQ{T},QRCompactWYQ{T}); thin::Bool=true) = A_mul_B!(A, t
 
 ## Multiplication by Q
 ### QB
-A_mul_B!{T<:BlasFloat}(A::QRCompactWYQ{T}, B::StridedVecOrMat{T}) = LAPACK.gemqrt!('L','N',A.factors,A.T,B)
+A_mul_B!{T<:BlasFloat}(A::QRCompactWYQ{T}, B::StridedVecOrMat{T}) = LAPACK.gemqrt!('L','N',A.factors,A.T.data,B)
 A_mul_B!{T<:BlasFloat}(A::QRPackedQ{T}, B::StridedVecOrMat{T}) = LAPACK.ormqr!('L','N',A.factors,A.τ,B)
 function A_mul_B!{T}(A::QRPackedQ{T}, B::AbstractVecOrMat{T})
     mA, nA = size(A.factors)
@@ -280,8 +280,8 @@ function *{TA,TB}(A::Union(QRPackedQ{TA},QRCompactWYQ{TA}), B::StridedMatrix{TB}
     A_mul_B!(Anew,Bnew)
 end
 ### QcB
-Ac_mul_B!{T<:BlasReal}(A::QRCompactWYQ{T}, B::StridedVecOrMat{T}) = LAPACK.gemqrt!('L','T',A.factors,A.T,B)
-Ac_mul_B!{T<:BlasComplex}(A::QRCompactWYQ{T}, B::StridedVecOrMat{T}) = LAPACK.gemqrt!('L','C',A.factors,A.T,B)
+Ac_mul_B!{T<:BlasReal}(A::QRCompactWYQ{T}, B::StridedVecOrMat{T}) = LAPACK.gemqrt!('L','T',A.factors,A.T.data,B)
+Ac_mul_B!{T<:BlasComplex}(A::QRCompactWYQ{T}, B::StridedVecOrMat{T}) = LAPACK.gemqrt!('L','C',A.factors,A.T.data,B)
 Ac_mul_B!{T<:BlasReal}(A::QRPackedQ{T}, B::StridedVecOrMat{T}) = LAPACK.ormqr!('L','T',A.factors,A.τ,B)
 Ac_mul_B!{T<:BlasComplex}(A::QRPackedQ{T}, B::StridedVecOrMat{T}) = LAPACK.ormqr!('L','C',A.factors,A.τ,B)
 function Ac_mul_B!{T}(A::QRPackedQ{T}, B::AbstractVecOrMat{T})
@@ -311,7 +311,7 @@ function Ac_mul_B{TQ<:Number,TB<:Number,N}(Q::Union(QRPackedQ{TQ},QRCompactWYQ{T
     Ac_mul_B!(convert(AbstractMatrix{TQB}, Q), TB == TQB ? copy(B) : convert(AbstractArray{TQB,N}, B))
 end
 ### AQ
-A_mul_B!{T<:BlasFloat}(A::StridedVecOrMat{T}, B::QRCompactWYQ{T}) = LAPACK.gemqrt!('R','N', B.factors, B.T, A)
+A_mul_B!{T<:BlasFloat}(A::StridedVecOrMat{T}, B::QRCompactWYQ{T}) = LAPACK.gemqrt!('R','N', B.factors, B.T.data, A)
 A_mul_B!(A::StridedVecOrMat, B::QRPackedQ) = LAPACK.ormqr!('R', 'N', B.factors, B.τ, A)
 function A_mul_B!{T}(A::StridedMatrix{T},Q::QRPackedQ{T})
     mQ, nQ = size(Q.factors)
@@ -340,8 +340,8 @@ function *{TA,TQ,N}(A::StridedArray{TA,N}, Q::Union(QRPackedQ{TQ},QRCompactWYQ{T
     A_mul_B!(TA==TAQ ? copy(A) : convert(AbstractArray{TAQ,N}, A), convert(AbstractMatrix{TAQ}, Q))
 end
 ### AQc
-A_mul_Bc!{T<:BlasReal}(A::StridedVecOrMat{T}, B::QRCompactWYQ{T}) = LAPACK.gemqrt!('R','T',B.factors,B.T,A)
-A_mul_Bc!{T<:BlasComplex}(A::StridedVecOrMat{T}, B::QRCompactWYQ{T}) = LAPACK.gemqrt!('R','C',B.factors,B.T,A)
+A_mul_Bc!{T<:BlasReal}(A::StridedVecOrMat{T}, B::QRCompactWYQ{T}) = LAPACK.gemqrt!('R','T',B.factors,B.T.data,A)
+A_mul_Bc!{T<:BlasComplex}(A::StridedVecOrMat{T}, B::QRCompactWYQ{T}) = LAPACK.gemqrt!('R','C',B.factors,B.T.data,A)
 A_mul_Bc!{T<:BlasReal}(A::StridedVecOrMat{T}, B::QRPackedQ{T}) = LAPACK.ormqr!('R','T',B.factors,B.τ,A)
 A_mul_Bc!{T<:BlasComplex}(A::StridedVecOrMat{T}, B::QRPackedQ{T}) = LAPACK.ormqr!('R','C',B.factors,B.τ,A)
 function A_mul_Bc!{T}(A::AbstractMatrix{T},Q::QRPackedQ{T})

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -225,8 +225,8 @@ immutable QRPackedQ{T} <: AbstractMatrix{T}
     τ::Vector{T}
 end
 immutable QRCompactWYQ{S} <: AbstractMatrix{S} 
-    factors::Matrix{S}                      
-    T::Matrix{S}                       
+    factors::Matrix{S}
+    T::Matrix{S}
 end
 
 convert{T}(::Type{QRPackedQ{T}}, Q::QRPackedQ) = QRPackedQ(convert(AbstractMatrix{T}, Q.factors), convert(Vector{T}, Q.τ))
@@ -366,9 +366,14 @@ function A_mul_Bc!{T}(A::AbstractMatrix{T},Q::QRPackedQ{T})
     end
     A
 end
-function A_mul_Bc{TA,TB,N}(A::AbstractArray{TA,N}, B::Union(QRCompactWYQ{TB},QRPackedQ{TB}))
+A_mul_Bc(A::Triangular, B::Union(QRCompactWYQ,QRPackedQ)) = A_mul_Bc(full(A), B)
+function A_mul_Bc{TA,TB}(A::AbstractArray{TA}, B::Union(QRCompactWYQ{TB},QRPackedQ{TB}))
     TAB = promote_type(TA,TB)
-    A_mul_Bc!(size(A,2)==size(B.factors,1) ? (TA == TAB ? copy(A) : convert(AbstractMatrix{TAB}, A)) : (size(A,2)==size(B.factors,2) ? [A zeros(TAB, size(A, 1), size(B.factors, 1) - size(B.factors, 2))] : throw(DimensionMismatch(""))),convert(AbstractMatrix{TAB}, B))
+    A_mul_Bc!(size(A,2)==size(B.factors,1) ? (TA == TAB ? copy(A) : convert(AbstractMatrix{TAB}, A)) :
+              size(A,2)==size(B.factors,2) ? [A zeros(TAB, size(A, 1), size(B.factors, 1) - size(B.factors, 2))] :
+              throw(DimensionMismatch("")),
+
+              convert(AbstractMatrix{TAB}, B))
 end
 
 # Julia implementation similarly to xgelsy

--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -111,3 +111,7 @@ for op in (:+, :-)
     end
 end
 
+A_mul_Bc!(A::Triangular, B::QRCompactWYQ) = A_mul_Bc!(full!(A),B)
+A_mul_Bc!(A::Triangular, B::QRPackedQ) = A_mul_Bc!(full!(A),B)
+A_mul_Bc(A::Triangular, B::Union(QRCompactWYQ,QRPackedQ)) = A_mul_Bc(full(A), B)
+

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -175,13 +175,10 @@ A_mul_B!{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::Triangular{T,S,UpLo
 A_mul_B!(A::Tridiagonal, B::Triangular) = A*full!(B)
 A_mul_B!(C::AbstractVecOrMat, A::Triangular, B::AbstractVecOrMat) = A_mul_B!(A, copy!(C, B))
 
-A_mul_Bc!(A::Triangular, B::QRCompactWYQ) = A_mul_Bc!(full!(A),B)
-A_mul_Bc!(A::Triangular, B::QRPackedQ) = A_mul_Bc!(full!(A),B)
 A_mul_Bc!(C::AbstractVecOrMat, A::Triangular, B::AbstractVecOrMat) = A_mul_Bc!(A, copy!(C, B))
 
 #Generic multiplication
 *(A::Tridiagonal, B::Triangular) = A_mul_B!(full(A), B)
-A_mul_Bc(A::Triangular, B::Union(QRCompactWYQ,QRPackedQ)) = A_mul_Bc(full(A), B)
 for func in (:*, :Ac_mul_B, :A_mul_Bc, :/, :A_rdiv_Bc)
     @eval begin
         ($func){TA,TB,SA<:AbstractMatrix,SB<:AbstractMatrix,UpLoA,UpLoB,IsUnitA,IsUnitB}(A::Triangular{TA,SA,UpLoA,IsUnitA}, B::Triangular{TB,SB,UpLoB,IsUnitB}) = ($func)(A, full(B))

--- a/test/linalg2.jl
+++ b/test/linalg2.jl
@@ -510,4 +510,10 @@ let
     @test S*T == [z z; 0 0]
 end
 
+#Issue 7304
+let
+    A=[-√.5 -√.5; -√.5 √.5]
+    Q=full(qrfact(A)[:Q])
+    @test vecnorm(A-Q) < eps()
+end
 


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#122

This PR currently does fix the original issue, but in order to do so, I had to reorder the way things are loaded in `LinAlg` so that `Triangular` in `triangular.jl` was defined before `QRCompactWY` in `factorization.jl`. This now throws the ambiguity warning:

``` julia
linalg.jl
Warning: New definition 
    A_mul_Bc could not show value of type Tuple at linalg/factorization.jl:370
is ambiguous with: 
    A_mul_Bc could not show value of type Tuple at linalg/triangular.jl:185.
To fix, define 
    A_mul_Bc could not show value of type Tuple
before the new definition.
```

when building Julia.

Would appreciate any help to resolve the warning.
