### PR TITLE
fix #7650 reshape of empty sparse matrices

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -60,7 +60,9 @@ function reinterpret{T,Tv,Ti}(::Type{T}, a::SparseMatrixCSC{Tv,Ti})
 end
 
 function sparse_compute_reshaped_colptr_and_rowval{Ti}(colptrS::Vector{Ti}, rowvalS::Vector{Ti}, mS::Int, nS::Int, colptrA::Vector{Ti}, rowvalA::Vector{Ti}, mA::Int, nA::Int)
-    ((length(colptrA) == (nA+1)) && (maximum(colptrA) <= (length(rowvalA)+1)) && (maximum(rowvalA) <= mA)) || throw(BoundsError())
+    lrowvalA = length(rowvalA)
+    maxrowvalA = (lrowvalA > 0) ? maximum(rowvalA) : zero(Ti)
+    ((length(colptrA) == (nA+1)) && (maximum(colptrA) <= (lrowvalA+1)) && (maxrowvalA <= mA)) || throw(BoundsError())
 
     colptrS[1] = 1
     colA = 1

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -398,3 +398,8 @@ end
 #Issue 7507
 @test (i7507=sparsevec(Dict{Int64, Float64}(), 10))==spzeros(10,1)
 
+#Issue 7650
+let S = spzeros(3, 3)
+    @test size(reshape(S, 9, 1)) == (9,1)
+end
+


### PR DESCRIPTION
Checking length of `rowval` before reducing for maximum.
