### PR TITLE
Add option to select the OpenSUSE Mirror and fix package versions in 'make win-extras'

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -80,6 +80,9 @@ else
 JULIA_COMMIT = $(JULIA_VERSION)
 endif
 
+# OpenSUSE mirror
+OPENSUSE_MIRROR = "http://download.opensuse.org/"
+
 # Directories where said libraries get installed to
 bindir = $(prefix)/bin
 libdir = $(prefix)/lib

--- a/Makefile
+++ b/Makefile
@@ -372,8 +372,8 @@ ifneq (,$(filter $(ARCH), i386 i486 i586 i686))
 	cd dist-extras && \
 	$(JLDOWNLOAD) http://downloads.sourceforge.net/sevenzip/7z920.exe && \
 	7z x -y 7z920.exe 7z.exe 7z.dll && \
-	$(JLDOWNLOAD) ${OPENSUSE_MIRROR}/repositories/windows:/mingw:/win32/openSUSE_13.1/noarch/mingw32-libexpat-2.0.1-8.1.noarch.rpm && \
-	mv mingw32-libexpat-*.rpm mingw-libexpat.rpm && \
+	$(JLDOWNLOAD) ${OPENSUSE_MIRROR}/repositories/windows:/mingw:/win32/openSUSE_13.1/noarch/mingw32-libexpat1-2.0.1-8.1.noarch.rpm && \
+	mv mingw32-libexpat1-*.rpm mingw-libexpat.rpm && \
 	$(JLDOWNLOAD) ${OPENSUSE_MIRROR}/repositories/windows:/mingw:/win32/openSUSE_13.1/noarch/mingw32-zlib-1.2.8-3.12.noarch.rpm && \
 	mv mingw32-zlib-*.rpm mingw-zlib.rpm
 else ifeq ($(ARCH),x86_64)
@@ -382,8 +382,8 @@ else ifeq ($(ARCH),x86_64)
 	7z x -y 7z920-x64.msi _7z.exe _7z.dll && \
 	mv _7z.dll 7z.dll && \
 	mv _7z.exe 7z.exe && \
-	$(JLDOWNLOAD) ${OPENSUSE_MIRROR}/repositories/windows:/mingw:/win64/openSUSE_13.1/noarch/mingw64-libexpat-2.0.1-7.1.noarch.rpm && \
-	mv mingw64-libexpat-*.rpm mingw-libexpat.rpm && \
+	$(JLDOWNLOAD) ${OPENSUSE_MIRROR}/repositories/windows:/mingw:/win64/openSUSE_13.1/noarch/mingw64-libexpat1-2.0.1-7.1.noarch.rpm && \
+	mv mingw64-libexpat1-*.rpm mingw-libexpat.rpm && \
 	$(JLDOWNLOAD) ${OPENSUSE_MIRROR}/repositories/windows:/mingw:/win64/openSUSE_13.1/noarch/mingw64-zlib-1.2.8-3.1.noarch.rpm && \
 	mv mingw64-zlib-*.rpm mingw-zlib.rpm
 else

--- a/Makefile
+++ b/Makefile
@@ -372,9 +372,9 @@ ifneq (,$(filter $(ARCH), i386 i486 i586 i686))
 	cd dist-extras && \
 	$(JLDOWNLOAD) http://downloads.sourceforge.net/sevenzip/7z920.exe && \
 	7z x -y 7z920.exe 7z.exe 7z.dll && \
-	$(JLDOWNLOAD) http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_13.1/noarch/mingw32-libexpat-2.0.1-7.7.noarch.rpm && \
+	$(JLDOWNLOAD) ${OPENSUSE_MIRROR}/repositories/windows:/mingw:/win32/openSUSE_13.1/noarch/mingw32-libexpat-2.0.1-8.1.noarch.rpm && \
 	mv mingw32-libexpat-*.rpm mingw-libexpat.rpm && \
-	$(JLDOWNLOAD) http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_13.1/noarch/mingw32-zlib-1.2.8-3.12.noarch.rpm && \
+	$(JLDOWNLOAD) ${OPENSUSE_MIRROR}/repositories/windows:/mingw:/win32/openSUSE_13.1/noarch/mingw32-zlib-1.2.8-3.12.noarch.rpm && \
 	mv mingw32-zlib-*.rpm mingw-zlib.rpm
 else ifeq ($(ARCH),x86_64)
 	cd dist-extras && \
@@ -382,9 +382,9 @@ else ifeq ($(ARCH),x86_64)
 	7z x -y 7z920-x64.msi _7z.exe _7z.dll && \
 	mv _7z.dll 7z.dll && \
 	mv _7z.exe 7z.exe && \
-	$(JLDOWNLOAD) http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_13.1/noarch/mingw64-libexpat-2.0.1-6.14.noarch.rpm && \
+	$(JLDOWNLOAD) ${OPENSUSE_MIRROR}/repositories/windows:/mingw:/win64/openSUSE_13.1/noarch/mingw64-libexpat-2.0.1-7.1.noarch.rpm && \
 	mv mingw64-libexpat-*.rpm mingw-libexpat.rpm && \
-	$(JLDOWNLOAD) http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_13.1/noarch/mingw64-zlib-1.2.8-3.1.noarch.rpm && \
+	$(JLDOWNLOAD) ${OPENSUSE_MIRROR}/repositories/windows:/mingw:/win64/openSUSE_13.1/noarch/mingw64-zlib-1.2.8-3.1.noarch.rpm && \
 	mv mingw64-zlib-*.rpm mingw-zlib.rpm
 else
 	$(error no win-extras target for ARCH=$(ARCH))


### PR DESCRIPTION
There are new versions of libexpat in opensuse mirrors. Also, it seems that mingw{32,64}-libexpat-\* is noew mingw{32,64}-libexpat1-*.

Additionally, I added an option to Make.inc (OPENSUSE_MIRROR) to make easier to select the desire openSUSE mirror until #7628 is fixed.
