### PR TITLE
faster SubString UTF8String (worrisome diff Linux v Win)

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -95,6 +95,8 @@ end
 
 isvalid(s::DirectIndexString, i::Integer) = (start(s) <= i <= endof(s))
 function isvalid(s::String, i::Integer)
+    i < 1 && return false
+    done(s,i) && return false
     try
         next(s,i)
         true

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1058,6 +1058,14 @@ let s="lorem ipsum",
     end
 end #let
 
+#for isvalid(SubString{UTF8String})
+let s = utf8("Σx + βz - 2")
+  for i in -1:length(s)+2
+      ss=SubString(s,1,i)
+      @test isvalid(ss,i)==isvalid(s,i)
+  end
+end
+
 ss=SubString("hello",1,5)
 @test_throws BoundsError ind2chr(ss, -1)
 @test_throws BoundsError chr2ind(ss, -1)


### PR DESCRIPTION
`isvalid(SubString{UTF8String}, i)` uses `next()` without `done()`.  For i>sizeof(String) performance is very slow compared to `isvalid(UTF8String,i)`.   

On linux, the difference is about 15x.  An example is below.

Worrisomely, the difference on Windows is far greater -- `isvalid(SubString{UTF8String}, i)`  -- _3000-4000x_ slower than `isvalid(UTF8String, i)`  for i>sizeof(String).

This change addresses the performance of `isvalid(SubString{UTF8String}, i)`, but I wonder if there might be a bigger problem with `try` clauses on Windows.

Linux example:

```
In [38]: s= "Σx +  βz - 2";

In [49]: ss= SubString(s,1,sizeof(s))
         sizeof(s), sizeof(ss), typeof(ss)
Out[49]: (13,13,SubString{UTF8String})

In [40]:
    ts = @elapsed isvalid(s, 1)
    ts = @elapsed isvalid(s, 1)
    ts = @elapsed isvalid(s, 1)
Out[40]: 1.132e-6

In [52]: @elapsed isvalid(ss, 1)
         @elapsed isvalid(ss, 1)
         tss = @elapsed isvalid(ss, 1)
Out[52]: 1.396e-6

In [53]: tss/ts
Out[53]: 1.2332155477031803

In [46]: @elapsed isvalid(s, 15)
         @elapsed isvalid(s, 15)
         ts = @elapsed isvalid(s, 15)
Out[46]: 1.086e-6

In [47]: @elapsed isvalid(ss, 15)
         @elapsed isvalid(ss, 15)
         tss = @elapsed isvalid(ss, 15)
Out[47]: 1.5733e-5

In [48]: tss/ts
Out[48]: 14.487108655616941
```
