### PR TITLE
vec for sparse matrices & sparsevec from matrices

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -185,6 +185,17 @@ complex(A::SparseMatrixCSC, B::SparseMatrixCSC) = A + im*B
 
 # Construct a sparse vector
 
+function vec{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
+    colptr = Array(Ti,2)
+    rowval = similar(S.rowval)
+    lS = length(S)
+    sparse_compute_reshaped_colptr_and_rowval(colptr, rowval, lS, 1, S.colptr, S.rowval, S.m, S.n)
+    SparseMatrixCSC{Tv,Ti}(lS, 1, colptr, rowval, copy(S.nzval))
+end
+
+sparsevec(A::AbstractMatrix) = reshape(sparse(A), (length(A),1))
+sparsevec(S::SparseMatrixCSC) = vec(S)
+
 sparsevec{K<:Integer,V}(d::Dict{K,V}, len::Int) = sparsevec(collect(keys(d)), collect(values(d)), len)
 
 sparsevec{K<:Integer,V}(d::Dict{K,V}) = sparsevec(collect(keys(d)), collect(values(d)))

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -403,3 +403,15 @@ let S = spzeros(3, 3)
     @test size(reshape(S, 9, 1)) == (9,1)
 end
 
+let X = eye(5), M = rand(5,4), C = spzeros(3,3)
+    SX = sparse(X); SM = sparse(M)
+    VX = vec(X); VSX = vec(SX)
+    VM = vec(M); VSM1 = vec(SM); VSM2 = sparsevec(M)
+    VC = vec(C)
+    @test reshape(VX, (25,1)) == VSX
+    @test reshape(VM, (20,1)) == VSM1 == VSM2
+    @test size(VC) == (9,1)
+    @test nnz(VC) == 0
+    @test nnz(VSX) == 5
+end
+


### PR DESCRIPTION
This adds `vec` for sparse matrices that creates a sparse vector (essentially a `SparseMatrixCSC` of dimension (L,1) as is the current scheme).

Also adds `sparsevec` variations that take a matrix.

Ref: #6695
