### PR TITLE
specialize length(sub{utf8})

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -603,7 +603,13 @@ sizeof{T<:ByteString}(s::SubString{T}) = s.endof==0 ? 0 : next(s,s.endof)[2]-1
 # default implementation will work but it's slow
 # can this be delegated efficiently somehow?
 # that may require additional string interfaces
+
 length{T<:DirectIndexString}(s::SubString{T}) = endof(s)
+
+function length(s::SubString{UTF8String}) 
+    ssget=s.string[1+s.offset:s.offset+s.endof]
+    return  int(ccall(:u8_strlen, Csize_t, (Ptr{Uint8},), ssget.data))
+end
 
 function next(s::SubString, i::Int)
     if i < 1 || i > s.endof

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1063,3 +1063,11 @@ ss=SubString("hello",1,5)
 @test_throws BoundsError chr2ind(ss, -1)
 @test_throws BoundsError chr2ind(ss, 10)
 @test_throws BoundsError ind2chr(ss, 10)
+
+
+# length(SubString{UTF8String}) performance specialization
+s="|f(x)-f(y)| < ε"
+@test length(SubString(s,1,0))==length(s[1:0])
+@test length(SubString(s,4,4))==length(s[4:4])
+@test length(SubString(s,1,7))==length(s[1:7])
+@test length(SubString(s,3,11))==length(s[3:11])


### PR DESCRIPTION
length(SubString{UTF8String}) is currently running 5-10x slower than length(UTF8String).  This patch specializes length(SubString{UTF8String}) to provide roughly 5x speed increase.
