### PR TITLE
Fix #7642.

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -467,22 +467,20 @@ function push!(a::Array{Any,1}, item::ANY)
 end
 
 function append!{T}(a::Array{T,1}, items::AbstractVector{T})
-    if is(T,None)
-        error(_grow_none_errmsg)
-    end
     n = length(items)
     ccall(:jl_array_grow_end, Void, (Any, Uint), a, n)
     copy!(a, length(a)-n+1, items, 1, n)
     return a
 end
 
-append!{T}(a::Array{T,1}, items::AbstractVector) = 
-    append!(a, convert(Array{T,1}, items))
-
-function prepend!{T}(a::Array{T,1}, items::AbstractVector{T})
+function append!{T}(a::Array{T,1}, items::AbstractVector)
     if is(T,None)
         error(_grow_none_errmsg)
     end
+    append!(a, convert(Array{T,1}, items))
+end
+
+function prepend!{T}(a::Array{T,1}, items::AbstractVector{T})
     n = length(items)
     ccall(:jl_array_grow_beg, Void, (Any, Uint), a, n)
     if a === items
@@ -493,8 +491,12 @@ function prepend!{T}(a::Array{T,1}, items::AbstractVector{T})
     return a
 end
 
-prepend!{T}(a::Array{T,1}, items::AbstractVector) = 
+function prepend!{T}(a::Array{T,1}, items::AbstractVector)
+    if is(T,None)
+        error(_grow_none_errmsg)
+    end
     prepend!(a, convert(Array{T,1}, items))
+end
 
 function resize!(a::Vector, nl::Integer)
     l = length(a)

--- a/base/array.jl
+++ b/base/array.jl
@@ -466,7 +466,7 @@ function push!(a::Array{Any,1}, item::ANY)
     return a
 end
 
-function append!{T}(a::Array{T,1}, items::AbstractVector)
+function append!{T}(a::Array{T,1}, items::AbstractVector{T})
     if is(T,None)
         error(_grow_none_errmsg)
     end
@@ -476,7 +476,10 @@ function append!{T}(a::Array{T,1}, items::AbstractVector)
     return a
 end
 
-function prepend!{T}(a::Array{T,1}, items::AbstractVector)
+append!{T}(a::Array{T,1}, items::AbstractVector) = 
+    append!(a, convert(Array{T,1}, items))
+
+function prepend!{T}(a::Array{T,1}, items::AbstractVector{T})
     if is(T,None)
         error(_grow_none_errmsg)
     end
@@ -489,6 +492,9 @@ function prepend!{T}(a::Array{T,1}, items::AbstractVector)
     end
     return a
 end
+
+prepend!{T}(a::Array{T,1}, items::AbstractVector) = 
+    prepend!(a, convert(Array{T,1}, items))
 
 function resize!(a::Vector, nl::Integer)
     l = length(a)
@@ -589,9 +595,7 @@ function deleteat!(a::Vector, inds)
     return a
 end
 
-const _default_splice = []
-
-function splice!(a::Vector, i::Integer, ins::AbstractArray=_default_splice)
+function splice!{T}(a::Array{T,1}, i::Integer, ins::AbstractVector{T}=T[])
     v = a[i]
     m = length(ins)
     if m == 0
@@ -607,7 +611,10 @@ function splice!(a::Vector, i::Integer, ins::AbstractArray=_default_splice)
     return v
 end
 
-function splice!{T<:Integer}(a::Vector, r::UnitRange{T}, ins::AbstractArray=_default_splice)
+splice!{T}(a::Array{T,1}, i::Integer, ins::AbstractVector) = 
+    splice!(a, i, convert(Array{T,1}, ins))
+
+function splice!{T,N<:Integer}(a::Array{T,1}, r::UnitRange{N}, ins::AbstractVector{T}=T[])
     v = a[r]
     m = length(ins)
     if m == 0
@@ -641,6 +648,9 @@ function splice!{T<:Integer}(a::Vector, r::UnitRange{T}, ins::AbstractArray=_def
     end
     return v
 end
+
+splice!{T,N<:Integer}(a::Array{T,1}, r::UnitRange{N}, ins::AbstractVector) = 
+    splice!(a, r, convert(Array{T,1}, ins))
 
 function empty!(a::Vector)
     ccall(:jl_array_del_end, Void, (Any, Uint), a, length(a))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -893,3 +893,30 @@ function i7197()
     ind2sub(size(S), 5)
 end
 @test i7197() == (2,2)
+
+# issue #7642
+A = [1,2,3]
+B = ["hey"]
+@test_throws MethodError append!(A,B)
+@test length(A) == 3
+
+@test_throws MethodError prepend!(A,B)
+@test length(A) == 3
+
+@test_throws MethodError splice!(A,1,B)
+@test length(A) == 3
+@test_throws MethodError splice!(A,2,B)
+@test length(A) == 3
+@test_throws MethodError splice!(A,3,B)
+@test length(A) == 3
+
+@test_throws MethodError splice!(A,1:3,B)
+@test length(A) == 3
+
+B = [1.0, 1.2, 1.5]
+@test_throws InexactError append!(A,B)
+@test length(A) == 3
+@test_throws InexactError prepend!(A,B)
+@test length(A) == 3
+@test_throws InexactError splice!(A,1:3,B)
+@test length(A) == 3


### PR DESCRIPTION
Explicitly call convert on append/prepend/splice items to match 1st array elements. This causes a MethodError to be thrown before any array growing/shrinking happens. Fixes #7642.

cc: @kmsquire, in particular I think the `splice!` changes should do the trick, but I'd appreciate a look over to make sure I didn't miss something.
