### PR TITLE
Bring fieldtype typefunc closer to the fieldtype builtin. Helps #7652

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -383,6 +383,12 @@ end
 t_func[getfield] = (2, 2, getfield_tfunc)
 t_func[setfield!] = (3, 3, (o, f, v)->v)
 const fieldtype_tfunc = function (A, s, name)
+    if isType(s)
+        # fieldtype of a type only depends on its kind
+        # i.e. fieldtype(SomeDataType, :types) === (Any...,)
+        # rather than a specific type tuple
+        s = typeof(s.parameters[1])
+    end
     if !isa(s,DataType)
         return Type
     end
@@ -390,7 +396,7 @@ const fieldtype_tfunc = function (A, s, name)
     if is(t,None)
         return t
     end
-    Type{t}
+    Type{isleaftype(t) ? t : TypeVar(:_, t)}
 end
 t_func[fieldtype] = (2, 2, fieldtype_tfunc)
 t_func[Box] = (1, 1, (a,)->Box)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1786,3 +1786,13 @@ end
 # addition of ¬ (\neg) parsing
 const (¬) = !
 @test ¬false
+
+# issue #7652
+type A7652
+    a :: Int
+end
+a7652 = A7652(0)
+f7652() = issubtype(fieldtype(a7652, :a), Int)
+@test f7652() == issubtype(fieldtype(a7652, :a), Int) == true
+g7652() = fieldtype(A7652, :types)
+@test g7652() == fieldtype(A7652, :types) == Tuple


### PR DESCRIPTION
This fixes at least the reported problem and another one where the additional getfield inference smartness could create discrepancies between inferred and untyped code.
It is not a complete solution since we could infer more precise types for fields that are abstract, but I see that the same kind of simplification is done at some other places (typeof, ...) so it should be ok.
