### PR TITLE
RFC: Fix in methods `reinterpret` and `reshape` for sparse matrices.

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -102,7 +102,7 @@ function reinterpret{T,Tv,Ti,N}(::Type{T}, a::SparseMatrixCSC{Tv,Ti}, dims::NTup
     mA,nA = size(a)
     numnz = nnz(a)
     colptr = Array(Ti, nS+1)
-    rowval = copy(a.rowval)
+    rowval = similar(a.rowval)
     nzval = reinterpret(T, a.nzval)
 
     sparse_compute_reshaped_colptr_and_rowval(colptr, rowval, mS, nS, a.colptr, a.rowval, mA, nA)
@@ -118,7 +118,7 @@ function reshape{Tv,Ti}(a::SparseMatrixCSC{Tv,Ti}, dims::NTuple{2,Int})
     mA,nA = size(a)
     numnz = nnz(a)
     colptr = Array(Ti, nS+1)
-    rowval = copy(a.rowval)
+    rowval = similar(a.rowval)
     nzval = a.nzval
 
     sparse_compute_reshaped_colptr_and_rowval(colptr, rowval, mS, nS, a.colptr, a.rowval, mA, nA)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -119,7 +119,7 @@ function reshape{Tv,Ti}(a::SparseMatrixCSC{Tv,Ti}, dims::NTuple{2,Int})
     numnz = nnz(a)
     colptr = Array(Ti, nS+1)
     rowval = similar(a.rowval)
-    nzval = a.nzval
+    nzval = copy(a.nzval)
 
     sparse_compute_reshaped_colptr_and_rowval(colptr, rowval, mS, nS, a.colptr, a.rowval, mA, nA)
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -102,7 +102,7 @@ function reinterpret{T,Tv,Ti,N}(::Type{T}, a::SparseMatrixCSC{Tv,Ti}, dims::NTup
     mA,nA = size(a)
     numnz = nnz(a)
     colptr = Array(Ti, nS+1)
-    rowval = a.rowval
+    rowval = copy(a.rowval)
     nzval = reinterpret(T, a.nzval)
 
     sparse_compute_reshaped_colptr_and_rowval(colptr, rowval, mS, nS, a.colptr, a.rowval, mA, nA)
@@ -118,7 +118,7 @@ function reshape{Tv,Ti}(a::SparseMatrixCSC{Tv,Ti}, dims::NTuple{2,Int})
     mA,nA = size(a)
     numnz = nnz(a)
     colptr = Array(Ti, nS+1)
-    rowval = a.rowval
+    rowval = copy(a.rowval)
     nzval = a.nzval
 
     sparse_compute_reshaped_colptr_and_rowval(colptr, rowval, mS, nS, a.colptr, a.rowval, mA, nA)

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -415,3 +415,12 @@ let X = eye(5), M = rand(5,4), C = spzeros(3,3)
     @test nnz(VSX) == 5
 end
 
+#Issue 7677
+let A = sprand(5,5,0.5,(n)->rand(Float64,n)), ACPY = A
+    B = reshape(A,25,1)
+    @test A == ACPY
+    C = reinterpret(Int64, A, (25, 1))
+    @test A == ACPY
+    D = reinterpret(Int64, B)
+    @test C == D
+end

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -416,7 +416,7 @@ let X = eye(5), M = rand(5,4), C = spzeros(3,3)
 end
 
 #Issue 7677
-let A = sprand(5,5,0.5,(n)->rand(Float64,n)), ACPY = A
+let A = sprand(5,5,0.5,(n)->rand(Float64,n)), ACPY = copy(A)
     B = reshape(A,25,1)
     @test A == ACPY
     C = reinterpret(Int64, A, (25, 1))


### PR DESCRIPTION
Calling these methods on sparse matrices would result in corruption of the original matrix, due to sharing of the `rowval` field between the original and reinterpreted/reshaped matrix.  This is now prevented by having the field copied.
