### PR TITLE
bring back the more correct fieldtype now supporting integer indexing

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -383,6 +383,12 @@ end
 t_func[getfield] = (2, 2, getfield_tfunc)
 t_func[setfield!] = (3, 3, (o, f, v)->v)
 const fieldtype_tfunc = function (A, s, name)
+    if isType(s)
+        # fieldtype of a type only depends on its kind
+        # i.e. fieldtype(SomeDataType, :types) === (Any...,)
+        # rather than a specific type tuple
+        s = typeof(s.parameters[1])
+    end
     if !isa(s,DataType)
         return Type
     end
@@ -390,7 +396,7 @@ const fieldtype_tfunc = function (A, s, name)
     if is(t,None)
         return t
     end
-    Type{t}
+    Type{isleaftype(t) ? t : TypeVar(:_, t)}
 end
 t_func[fieldtype] = (2, 2, fieldtype_tfunc)
 t_func[Box] = (1, 1, (a,)->Box)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -550,7 +550,6 @@ JL_CALLABLE(jl_f_set_field)
 JL_CALLABLE(jl_f_field_type)
 {
     JL_NARGS(fieldtype, 2, 2);
-    JL_TYPECHK(fieldtype, symbol, args[1]);
     jl_value_t *v = args[0];
     jl_value_t *vt = (jl_value_t*)jl_typeof(v);
     if (vt == (jl_value_t*)jl_module_type)
@@ -558,8 +557,19 @@ JL_CALLABLE(jl_f_field_type)
     if (!jl_is_datatype(vt))
         jl_type_error("fieldtype", (jl_value_t*)jl_datatype_type, v);
     jl_datatype_t *st = (jl_datatype_t*)vt;
-    jl_sym_t *fld = (jl_sym_t*)args[1];
-    return jl_tupleref(st->types, jl_field_index(st, fld, 1));
+    int field_index;
+    if (jl_is_symbol(args[1])) {
+        field_index = jl_field_index(st, (jl_sym_t*)args[1], 1);
+    }
+    else if (jl_is_long(args[1])) {
+        field_index = jl_unbox_long(args[1]) - 1;
+        if (field_index < 0 || field_index >= jl_tuple_len(st->names))
+            jl_throw(jl_bounds_exception);
+    }
+    else {
+        jl_type_error("fieldtype", (jl_value_t*)jl_symbol_type, args[1]);
+    }
+    return jl_tupleref(st->types, field_index);
 }
 
 // conversion -----------------------------------------------------------------

--- a/test/core.jl
+++ b/test/core.jl
@@ -1787,7 +1787,6 @@ end
 const (¬) = !
 @test ¬false
 
-if false
 # issue #7652
 type A7652
     a :: Int
@@ -1797,7 +1796,14 @@ f7652() = issubtype(fieldtype(a7652, :a), Int)
 @test f7652() == issubtype(fieldtype(a7652, :a), Int) == true
 g7652() = fieldtype(A7652, :types)
 @test g7652() == fieldtype(A7652, :types) == Tuple
-end
+@test fieldtype(a7652, 1) == Int
+h7652() = a7652.(1) = 2
+h7652()
+@test a7652.a == 2
+i7652() = a7652.(1) = 3.0
+i7652()
+@test a7652.a == 3
+
 
 # issue #7679
 @test map(f->f(), { ()->i for i=1:3 }) == {1,2,3}


### PR DESCRIPTION
This should fix #7681. Inference was allowing fieldtype(_, ::Int) but the builtin function did not support this version. This patch (and the former one) may insert some new runtime calls but for now I don't see another simple way to preserve fieldtype semantics. No measurements were done but if this incurs a slowdown somewhere then the good way around would be to improve inference I guess.
It used to generate incorrect code quite easily :

```
type Foo; x :: Int; end
a = Foo(0)
f() = a.x = 1.0
f()
```

throws an error on master since it only converts 1.0 to Any.
