### PR TITLE
Make doctests pass

### DIFF
--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -373,9 +373,9 @@ the name of the function to vectorize. Here is a simple example:
 
     julia> methods(square)
     # 4 methods for generic function "square":
-    square{T<:Number}(::AbstractArray{T<:Number,1}) at operators.jl:356
-    square{T<:Number}(::AbstractArray{T<:Number,2}) at operators.jl:357
-    square{T<:Number}(::AbstractArray{T<:Number,N}) at operators.jl:359
+    square{T<:Number}(::AbstractArray{T<:Number,1}) at operators.jl:359
+    square{T<:Number}(::AbstractArray{T<:Number,2}) at operators.jl:360
+    square{T<:Number}(::AbstractArray{T<:Number,N}) at operators.jl:362
     square(x) at none:1
 
     julia> square([1 2 4; 5 6 7])

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -373,9 +373,9 @@ the name of the function to vectorize. Here is a simple example:
 
     julia> methods(square)
     # 4 methods for generic function "square":
-    square{T<:Number}(x::AbstractArray{T<:Number,1}) at operators.jl:248
-    square{T<:Number}(x::AbstractArray{T<:Number,2}) at operators.jl:249
-    square{T<:Number}(x::AbstractArray{T<:Number,N}) at operators.jl:251
+    square{T<:Number}(::AbstractArray{T<:Number,1}) at operators.jl:359
+    square{T<:Number}(::AbstractArray{T<:Number,2}) at operators.jl:360
+    square{T<:Number}(::AbstractArray{T<:Number,N}) at operators.jl:362
     square(x) at none:1
 
     julia> square([1 2 4; 5 6 7])
@@ -396,9 +396,9 @@ vector to the size of the matrix:
     julia> a = rand(2,1); A = rand(2,3);
 
     julia> repmat(a,1,3)+A
-    2x3 Float64 Array:
-     0.848333  1.66714  1.3262
-     1.26743   1.77988  1.13859
+    2x3 Array{Float64,2}:
+     1.20813  1.82068  1.25387
+     1.56851  1.86401  1.67846
 
 This is wasteful when dimensions get large, so Julia offers
 ``broadcast``, which expands singleton dimensions in
@@ -409,18 +409,18 @@ function elementwise:
 .. doctest::
 
     julia> broadcast(+, a, A)
-    2x3 Float64 Array:
-     0.848333  1.66714  1.3262
-     1.26743   1.77988  1.13859
+    2x3 Array{Float64,2}:
+     1.20813  1.82068  1.25387
+     1.56851  1.86401  1.67846
 
     julia> b = rand(1,2)
-    1x2 Float64 Array:
-     0.629799  0.754948
+    1x2 Array{Float64,2}:
+     0.867535  0.00457906
 
     julia> broadcast(+, a, b)
-    2x2 Float64 Array:
-     1.31849  1.44364
-     1.56107  1.68622
+    2x2 Array{Float64,2}:
+     1.71056  0.847604
+     1.73659  0.873631
 
 Elementwise operators such as ``.+`` and ``.*`` perform broadcasting if necessary. There is also a ``broadcast!`` function to specify an explicit destination, and ``broadcast_getindex`` and ``broadcast_setindex!`` that broadcast the indices before indexing.
 
@@ -488,38 +488,38 @@ stride parameters.
 .. doctest::
 
     julia> a = rand(10,10)
-    10x10 Float64 Array:
-     0.763921  0.884854   0.818783   0.519682   …  0.860332  0.882295   0.420202
-     0.190079  0.235315   0.0669517  0.020172      0.902405  0.0024219  0.24984
-     0.823817  0.0285394  0.390379   0.202234      0.516727  0.247442   0.308572
-     0.566851  0.622764   0.0683611  0.372167      0.280587  0.227102   0.145647
-     0.151173  0.179177   0.0510514  0.615746      0.322073  0.245435   0.976068
-     0.534307  0.493124   0.796481   0.0314695  …  0.843201  0.53461    0.910584
-     0.885078  0.891022   0.691548   0.547         0.727538  0.0218296  0.174351
-     0.123628  0.833214   0.0224507  0.806369      0.80163   0.457005   0.226993
-     0.362621  0.389317   0.702764   0.385856      0.155392  0.497805   0.430512
-     0.504046  0.532631   0.477461   0.225632      0.919701  0.0453513  0.505329
+    10x10 Array{Float64,2}:
+     0.561255   0.226678   0.203391  0.308912   …  0.750307  0.235023   0.217964
+     0.718915   0.537192   0.556946  0.996234      0.666232  0.509423   0.660788
+     0.493501   0.0565622  0.118392  0.493498      0.262048  0.940693   0.252965
+     0.0470779  0.736979   0.264822  0.228787      0.161441  0.897023   0.567641
+     0.343935   0.32327    0.795673  0.452242      0.468819  0.628507   0.511528
+     0.935597   0.991511   0.571297  0.74485    …  0.84589   0.178834   0.284413
+     0.160706   0.672252   0.133158  0.65554       0.371826  0.770628   0.0531208
+     0.306617   0.836126   0.301198  0.0224702     0.39344   0.0370205  0.536062
+     0.890947   0.168877   0.32002   0.486136      0.096078  0.172048   0.77672
+     0.507762   0.573567   0.220124  0.165816      0.211049  0.433277   0.539476
 
     julia> b = sub(a, 2:2:8,2:2:4)
-    4x2 SubArray of 10x10 Float64 Array:
-     0.235315  0.020172
-     0.622764  0.372167
-     0.493124  0.0314695
-     0.833214  0.806369
+    4x2 SubArray{Float64,2,Array{Float64,2},(StepRange{Int64,Int64},StepRange{Int64,Int64})}:
+     0.537192  0.996234
+     0.736979  0.228787
+     0.991511  0.74485
+     0.836126  0.0224702
 
     julia> (q,r) = qr(b);
 
     julia> q
-    4x2 Float64 Array:
-     -0.200268   0.331205
-     -0.530012   0.107555
-     -0.41968    0.720129
-     -0.709119  -0.600124
+    4x2 Array{Float64,2}:
+     -0.338809   0.78934
+     -0.464815  -0.230274
+     -0.625349   0.194538
+     -0.527347  -0.534856
 
     julia> r
-    2x2 Float64 Array:
-     -1.175  -0.786311
-      0.0    -0.414549
+    2x2 Array{Float64,2}:
+     -1.58553  -0.921517
+      0.0       0.866567
 
 Sparse Matrices
 ===============

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -373,9 +373,9 @@ the name of the function to vectorize. Here is a simple example:
 
     julia> methods(square)
     # 4 methods for generic function "square":
-    square{T<:Number}(::AbstractArray{T<:Number,1}) at operators.jl:359
-    square{T<:Number}(::AbstractArray{T<:Number,2}) at operators.jl:360
-    square{T<:Number}(::AbstractArray{T<:Number,N}) at operators.jl:362
+    square{T<:Number}(::AbstractArray{T<:Number,1}) at operators.jl:356
+    square{T<:Number}(::AbstractArray{T<:Number,2}) at operators.jl:357
+    square{T<:Number}(::AbstractArray{T<:Number,N}) at operators.jl:359
     square(x) at none:1
 
     julia> square([1 2 4; 5 6 7])

--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -51,7 +51,7 @@ numbers:
     -3 - 4im
 
     julia> (-1 + 2im)^2.5
-    2.729624464784009 - 6.9606644595719im
+    2.7296244647840084 - 6.960664459571898im
 
     julia> (-1 + 2im)^(1 + 1im)
     -0.27910381075826657 + 0.08708053414102428im
@@ -63,7 +63,7 @@ numbers:
     -63 - 60im
 
     julia> 3(2 - 5im)^-1.0
-    0.20689655172413793 + 0.5172413793103449im
+    0.20689655172413796 + 0.5172413793103449im
 
 The promotion mechanism ensures that combinations of operands of
 different types just work:
@@ -139,13 +139,13 @@ for complex numbers:
     1.272019649514069 + 0.7861513777574233im
 
     julia> cos(1 + 2im)
-    2.0327230070196656 - 3.0518977991517997im
+    2.0327230070196656 - 3.0518977991518im
 
     julia> exp(1 + 2im)
-    -1.1312043837568138 + 2.471726672004819im
+    -1.1312043837568135 + 2.4717266720048188im
 
     julia> sinh(1 + 2im)
-    -0.48905625904129374 + 1.4031192506220407im
+    -0.4890562590412937 + 1.4031192506220405im
 
 Note that mathematical functions typically return real values when applied
 to real numbers and complex values when applied to complex numbers.
@@ -156,9 +156,7 @@ versus ``-1 + 0im`` even though ``-1 == -1 + 0im``:
 
     julia> sqrt(-1)
     ERROR: DomainError
-    sqrt will only return a complex result if called with a complex argument.
-    try sqrt(complex(x))
-     in sqrt at math.jl:284
+     in sqrt at math.jl:131
 
     julia> sqrt(-1 + 0im)
     0.0 + 1.0im
@@ -189,11 +187,10 @@ and imaginary parts of a complex number as described in the
 .. doctest::
 
     julia> 1 + Inf*im
-    complex(1.0,Inf)
+    1.0 + Inf*im
 
     julia> 1 + NaN*im
-    complex(1.0,NaN)
-
+    1.0 + NaN*im
 
 .. _man-rational-numbers:
 
@@ -289,10 +286,10 @@ Constructing infinite rational values is acceptable:
 .. doctest::
 
     julia> 5//0
-    Inf
+    1//0
 
     julia> -3//0
-    -Inf
+    -1//0
 
     julia> typeof(ans)
     Rational{Int64} (constructor with 1 method)
@@ -303,8 +300,8 @@ Trying to construct a ``NaN`` rational value, however, is not:
 
     julia> 0//0
     ERROR: invalid rational: 0//0
-     in Rational at rational.jl:7
-     in // at rational.jl:17
+     in Rational at rational.jl:6
+     in // at rational.jl:15
 
 As usual, the promotion system makes interactions with other numeric
 types effortless:
@@ -318,19 +315,19 @@ types effortless:
     0.09999999999999998
 
     julia> 2//7 * (1 + 2im)
-    2//7 + 4//7im
+    2//7 + 4//7*im
 
     julia> 2//7 * (1.5 + 2im)
     0.42857142857142855 + 0.5714285714285714im
 
     julia> 3//2 / (1 + 2im)
-    3//10 - 3//5im
+    3//10 - 3//5*im
 
     julia> 1//2 + 2im
-    1//2 + 2//1im
+    1//2 + 2//1*im
 
     julia> 1 + 2//3im
-    1//1 - 2//3im
+    1//1 - 2//3*im
 
     julia> 0.5 == 1//2
     true

--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -156,6 +156,8 @@ versus ``-1 + 0im`` even though ``-1 == -1 + 0im``:
 
     julia> sqrt(-1)
     ERROR: DomainError
+    sqrt will only return a complex result if called with a complex argument.
+    try sqrt(complex(x))
      in sqrt at math.jl:131
 
     julia> sqrt(-1 + 0im)

--- a/doc/manual/constructors.rst
+++ b/doc/manual/constructors.rst
@@ -321,7 +321,7 @@ types of the arguments given to the constructor. Here are some examples:
     Point{Float64}(1.0,2.5)
 
     julia> Point(1,2.5)
-    ERROR: no method Point{T<:Real}(Int64, Float64)
+    ERROR: `Point{T<:Real}` has no method matching Point{T<:Real}(::Int64, ::Float64)
 
     ## explicit T ##
 
@@ -330,6 +330,7 @@ types of the arguments given to the constructor. Here are some examples:
 
     julia> Point{Int64}(1.0,2.5)
     ERROR: InexactError()
+     in Point at no file
 
     julia> Point{Float64}(1.0,2.5)
     Point{Float64}(1.0,2.5)
@@ -414,7 +415,7 @@ However, other similar calls still don't work:
 .. doctest::
 
     julia> Point(1.5,2)
-    ERROR: no method Point{T<:Real}(Float64, Int64)
+    ERROR: `Point{T<:Real}` has no method matching Point{T<:Real}(::Float64, ::Int64)
 
 For a much more general way of making all such calls work sensibly, see
 :ref:`man-conversion-and-promotion`. At the risk
@@ -534,7 +535,7 @@ whose real and imaginary parts are rationals:
 .. doctest::
 
     julia> (1 + 2im)//(1 - 2im)
-    -3//5 + 4//5im
+    -3//5 + 4//5*im
 
     julia> typeof(ans)
     Complex{Rational{Int64}} (constructor with 1 method)

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -337,12 +337,16 @@ except for the last entry in a conditional chain is an error:
 On the other hand, any type of expression can be used at the end of a conditional chain.  
 It will be evaluated and returned depending on the preceding conditionals:
 
+.. testsetup::
+
+    srand(123)
+
 .. doctest::
 
     julia> true && (x = rand(2,2))
     2x2 Array{Float64,2}:
-      0.104159  0.402732
-      0.377173  0.163156
+     0.768448  0.673959
+     0.940515  0.395453
 
     julia> false && (x = rand(2,2))
     false
@@ -580,9 +584,7 @@ negative real value:
 
     julia> sqrt(-1)
     ERROR: DomainError
-    sqrt will only return a complex result if called with a complex argument.
-    try sqrt(complex(x))
-     in sqrt at math.jl:284
+     in sqrt at math.jl:131
 
 You may define your own exceptions in the following way:
 
@@ -633,10 +635,10 @@ the way ``UndefVarError`` is written:
 
 .. doctest::
 
-    julia> type UndefVarError <: Exception
+    julia> type MyUndefVarError <: Exception
                var::Symbol
            end
-    julia> showerror(io::IO, e::UndefVarError) = print(io, e.var, " not defined")
+    julia> Base.showerror(io::IO, e::MyUndefVarError) = print(io, e.var, " not defined");
 
 Errors
 ~~~~~~
@@ -683,7 +685,7 @@ session:
     julia> verbose_fussy_sqrt(-1)
     before fussy_sqrt
     ERROR: negative x not allowed
-     in fussy_sqrt at none:1
+     in verbose_fussy_sqrt at none:3
 
 Warnings and informational messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -763,9 +765,6 @@ assumes ``x`` is a real number and returns its square root:
     
     julia> sqrt_second(-9)
     ERROR: DomainError
-    sqrt will only return a complex result if called with a complex argument.
-    try sqrt(complex(x))
-     in sqrt at math.jl:284
      in sqrt_second at none:7
 
 Note that the symbol following ``catch`` will always be interpreted as a
@@ -863,13 +862,12 @@ value it needs to produce:
              produce("stop")
            end;
 
-To consume values, first the producer is wrapped in a ``Task``, then
-``consume`` is called repeatedly on that object:
+To consume values, first the producer is wrapped in a ``Task``,
+then ``consume`` is called repeatedly on that object:
 
 .. doctest::
 
-    julia> p = Task(producer)
-    Task
+    julia> p = Task(producer);
 
     julia> consume(p)
     "start"

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -584,6 +584,8 @@ negative real value:
 
     julia> sqrt(-1)
     ERROR: DomainError
+    sqrt will only return a complex result if called with a complex argument.
+    try sqrt(complex(x))
      in sqrt at math.jl:131
 
 You may define your own exceptions in the following way:

--- a/doc/manual/conversion-and-promotion.rst
+++ b/doc/manual/conversion-and-promotion.rst
@@ -97,8 +97,8 @@ requested conversion:
 .. doctest::
 
     julia> convert(FloatingPoint, "foo")
-    ERROR: no method convert(Type{FloatingPoint}, ASCIIString)
-     in convert at base.jl:11
+    ERROR: `convert` has no method matching convert(::Type{FloatingPoint}, ::ASCIIString)
+     in convert at base.jl:13
 
 Some languages consider parsing strings as numbers or formatting
 numbers as strings to be conversions (many dynamic languages will even
@@ -132,7 +132,7 @@ to zero:
 
     julia> convert(Bool, 1im)
     ERROR: InexactError()
-     in convert at complex.jl:27
+     in convert at complex.jl:18
 
     julia> convert(Bool, 0im)
     false
@@ -239,7 +239,7 @@ promotion is to convert numeric arguments to a common type:
     (1.5 + 0.0im,0.0 + 1.0im)
 
     julia> promote(1 + 2im, 3//4)
-    (1//1 + 2//1im,3//4 + 0//1im)
+    (1//1 + 2//1*im,3//4 + 0//1*im)
 
 Floating-point values are promoted to the largest of the floating-point
 argument types. Integer values are promoted to the larger of either the

--- a/doc/manual/faq.rst
+++ b/doc/manual/faq.rst
@@ -458,7 +458,7 @@ the wrapper object.  For example:
     MyType{Float64} (constructor with 1 method)
 
     julia> typeof(t)
-    MyStillAmbiguousType (constructor with 1 method)
+    MyStillAmbiguousType (constructor with 2 methods)
 
 The type of field ``a`` can be readily determined from the type of
 ``m``, but not from the type of ``t``.  Indeed, in ``t`` it's possible
@@ -556,7 +556,7 @@ For example:
     julia> c = MySimpleContainer(1:3);
 
     julia> typeof(c)
-    MySimpleContainer{Range1{Int64}} (constructor with 1 method)
+    MySimpleContainer{UnitRange{Int64}} (constructor with 1 method)
 
     julia> c = MySimpleContainer([1:3]);
 

--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -610,7 +610,7 @@ However, type promotion between the primitive types above and
     -9223372036854775809
     
     julia> typeof(y)
-    BigInt (constructor with 7 methods)
+    BigInt (constructor with 10 methods)
 
 The default precision (in number of bits of the significand) and rounding
 mode of `BigFloat` operations can be changed, and all further calculations 

--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -235,7 +235,7 @@ Function          Tests if
     true
     
     julia> isequal(NaN,NaN32)
-    false
+    true
 
 ``isequal`` can also be used to distinguish signed zeros:
 

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -51,7 +51,7 @@ is an example of the short form used to quote an arithmetic expression:
 .. doctest::
 
     julia> ex = :(a+b*c+1)
-    :(+(a,*(b,c),1))
+    :(a + b * c + 1)
 
     julia> typeof(ex)
     Expr
@@ -64,10 +64,10 @@ is an example of the short form used to quote an arithmetic expression:
 
     julia> ex.args
     4-element Array{Any,1}:
-      :+       
-      :a       
-      :(*(b,c))
-     1         
+      :+
+      :a
+      :(b * c)
+     1
 
     julia> typeof(ex.args[1])
     Symbol
@@ -96,11 +96,11 @@ quoting form:
              y = 2
              x + y
            end
-    quote  # none, line 2:
-        x = 1 # line 3:
-        y = 2 # line 4:
-        +(x,y)
-    end
+    :(begin  # none, line 2:
+            x = 1 # line 3:
+            y = 2 # line 4:
+            x + y
+        end)
 
 Symbols
 ~~~~~~~
@@ -153,13 +153,13 @@ typing at the interactive prompt — using the ``eval`` function:
 .. doctest::
 
     julia> :(1 + 2)
-    :(+(1,2))
+    :(1 + 2)
 
     julia> eval(ans)
     3
 
     julia> ex = :(a + b)
-    :(+(a,b))
+    :(a + b)
 
     julia> eval(ex)
     ERROR: a not defined
@@ -200,7 +200,7 @@ dynamically generate arbitrary code which can then be run using
     julia> a = 1;
 
     julia> ex = Expr(:call, :+,a,:b)
-    :(+(1,b))
+    :(1 + b)
 
     julia> a = 0; b = 2;
 
@@ -235,7 +235,7 @@ clearly and concisely using interpolation:
     julia> a = 1;
 
     julia> ex = :($a + b)
-    :(+(1,b))
+    :(1 + b)
 
 This syntax is automatically rewritten to the form above where we
 explicitly called ``Expr``. The use of ``$`` for expression
@@ -341,8 +341,8 @@ This macro can be used like this:
     julia> @assert 1==1.0
 
     julia> @assert 1==0
-    ERROR: Assertion failed: 1 == 0
-     in error at error.jl:22
+    ERROR: assertion failed: 1 == 0
+     in error at error.jl:21
 
 In place of the written syntax, the macro call is expanded at parse time to
 its returned result. This is equivalent to writing::
@@ -387,14 +387,14 @@ function:
     :(if a == b
             nothing
         else
-            error("assertion failed: a == b")
+            Base.error("assertion failed: a == b")
         end)
 
     julia> macroexpand(:(@assert a==b "a should equal b!"))
     :(if a == b
             nothing
         else
-            error("assertion failed: a should equal b!")
+            Base.error("assertion failed: a should equal b!")
         end)
 
 There is yet another case that the actual ``@assert`` macro handles: what
@@ -409,7 +409,7 @@ Compare:
 .. doctest::
 
     julia> typeof(:("a should equal b"))
-    ASCIIString (constructor with 1 method)
+    ASCIIString (constructor with 2 methods)
 
     julia> typeof(:("a ($a) should equal b ($b)!"))
     Expr

--- a/doc/manual/methods.rst
+++ b/doc/manual/methods.rst
@@ -94,16 +94,16 @@ error:
 .. doctest::
 
     julia> f(2.0, 3)
-    ERROR: no method f(Float64, Int64)
+    ERROR: `f` has no method matching f(::Float64, ::Int64)
 
     julia> f(float32(2.0), 3.0)
-    ERROR: no method f(Float32, Float64)
+    ERROR: `f` has no method matching f(::Float32, ::Float64)
 
     julia> f(2.0, "3.0")
-    ERROR: no method f(Float64, ASCIIString)
+    ERROR: `f` has no method matching f(::Float64, ::ASCIIString)
 
     julia> f("2.0", "3.0")
-    ERROR: no method f(ASCIIString, ASCIIString)
+    ERROR: `f` has no method matching f(::ASCIIString, ::ASCIIString)
 
 As you can see, the arguments must be precisely of type ``Float64``.
 Other numeric types, such as integers or 32-bit floating-point values,
@@ -168,10 +168,10 @@ function ``f`` remains undefined, and applying it will still result in a
 .. doctest::
 
     julia> f("foo", 3)
-    ERROR: no method f(ASCIIString, Int64)
+    ERROR: `f` has no method matching f(::ASCIIString, ::Int64)
 
     julia> f()
-    ERROR: no method f()
+    ERROR: `f` has no method matching f()
 
 You can easily see which methods exist for a function by entering the
 function object itself in an interactive session:
@@ -221,99 +221,132 @@ Julia language. Core operations typically have dozens of methods:
 .. doctest::
 
     julia> methods(+)
-    # 92 methods for generic function "+":
-    +(x::Bool) at bool.jl:35
-    +(x::Bool,y::Bool) at bool.jl:38
-    +(x::Union(SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{Bool,N}),y::Union(SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{Bool,N})) at array.jl:992
-    +{S,T}(A::Union(SubArray{S,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{S,N}),B::Union(SubArray{T,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{T,N})) at array.jl:936
-    +{T<:Union(Int32,Int8,Int16)}(x::T<:Union(Int32,Int8,Int16),y::T<:Union(Int32,Int8,Int16)) at int.jl:16
-    +{T<:Union(Uint8,Uint32,Uint16)}(x::T<:Union(Uint8,Uint32,Uint16),y::T<:Union(Uint8,Uint32,Uint16)) at int.jl:20
-    +(x::Int64,y::Int64) at int.jl:41
-    +(x::Uint64,y::Uint64) at int.jl:42
-    +(x::Int128,y::Int128) at int.jl:43
-    +(x::Uint128,y::Uint128) at int.jl:44
-    +(a::Float16,b::Float16) at float.jl:129
-    +(x::Float32,y::Float32) at float.jl:131
-    +(x::Float64,y::Float64) at float.jl:132
-    +(z::Complex{T<:Real},w::Complex{T<:Real}) at complex.jl:133
-    +(x::Real,z::Complex{T<:Real}) at complex.jl:141
-    +(z::Complex{T<:Real},x::Real) at complex.jl:142
+    # 125 methods for generic function "+":
+    +(x::Bool) at bool.jl:36
+    +(x::Bool,y::Bool) at bool.jl:39
+    +(y::FloatingPoint,x::Bool) at bool.jl:49
+    +(A::BitArray{N},B::BitArray{N}) at bitarray.jl:848
+    +(A::Union(DenseArray{Bool,N},SubArray{Bool,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)}),B::Union(DenseArray{Bool,N},SubArray{Bool,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)})) at array.jl:797
+    +{S,T}(A::Union(SubArray{S,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)},DenseArray{S,N}),B::Union(SubArray{T,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)},DenseArray{T,N})) at array.jl:719
+    +{T<:Union(Int16,Int32,Int8)}(x::T<:Union(Int16,Int32,Int8),y::T<:Union(Int16,Int32,Int8)) at int.jl:16
+    +{T<:Union(Uint32,Uint16,Uint8)}(x::T<:Union(Uint32,Uint16,Uint8),y::T<:Union(Uint32,Uint16,Uint8)) at int.jl:20
+    +(x::Int64,y::Int64) at int.jl:33
+    +(x::Uint64,y::Uint64) at int.jl:34
+    +(x::Int128,y::Int128) at int.jl:35
+    +(x::Uint128,y::Uint128) at int.jl:36
+    +(x::Float32,y::Float32) at float.jl:119
+    +(x::Float64,y::Float64) at float.jl:120
+    +(z::Complex{T<:Real},w::Complex{T<:Real}) at complex.jl:110
+    +(x::Real,z::Complex{T<:Real}) at complex.jl:120
+    +(z::Complex{T<:Real},x::Real) at complex.jl:121
     +(x::Rational{T<:Integer},y::Rational{T<:Integer}) at rational.jl:113
-    +(x::Bool,y::Union(SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{Bool,N})) at array.jl:986
-    +(x::Union(SubArray{Bool,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{Bool,N}),y::Bool) at array.jl:989
-    +(x::Char,y::Char) at char.jl:25
-    +(x::Char,y::Integer) at char.jl:30
-    +(x::Integer,y::Char) at char.jl:31
-    +(x::BigInt,y::BigInt) at gmp.jl:160
-    +(a::BigInt,b::BigInt,c::BigInt) at gmp.jl:183
-    +(a::BigInt,b::BigInt,c::BigInt,d::BigInt) at gmp.jl:189
-    +(a::BigInt,b::BigInt,c::BigInt,d::BigInt,e::BigInt) at gmp.jl:196
-    +(x::BigInt,c::Uint64) at gmp.jl:208
-    +(c::Uint64,x::BigInt) at gmp.jl:212
-    +(c::Unsigned,x::BigInt) at gmp.jl:213
-    +(x::BigInt,c::Unsigned) at gmp.jl:214
-    +(x::BigInt,c::Signed) at gmp.jl:215
-    +(c::Signed,x::BigInt) at gmp.jl:216
-    +(x::BigFloat,c::Uint64) at mpfr.jl:141
-    +(c::Uint64,x::BigFloat) at mpfr.jl:145
-    +(c::Unsigned,x::BigFloat) at mpfr.jl:146
-    +(x::BigFloat,c::Unsigned) at mpfr.jl:147
-    +(x::BigFloat,c::Int64) at mpfr.jl:151
-    +(c::Int64,x::BigFloat) at mpfr.jl:155
-    +(x::BigFloat,c::Signed) at mpfr.jl:156
-    +(c::Signed,x::BigFloat) at mpfr.jl:157
-    +(x::BigFloat,c::Float64) at mpfr.jl:161
-    +(c::Float64,x::BigFloat) at mpfr.jl:165
-    +(c::Float32,x::BigFloat) at mpfr.jl:166
-    +(x::BigFloat,c::Float32) at mpfr.jl:167
-    +(x::BigFloat,c::BigInt) at mpfr.jl:171
-    +(c::BigInt,x::BigFloat) at mpfr.jl:175
-    +(x::BigFloat,y::BigFloat) at mpfr.jl:322
-    +(a::BigFloat,b::BigFloat,c::BigFloat) at mpfr.jl:333
-    +(a::BigFloat,b::BigFloat,c::BigFloat,d::BigFloat) at mpfr.jl:339
-    +(a::BigFloat,b::BigFloat,c::BigFloat,d::BigFloat,e::BigFloat) at mpfr.jl:346
-    +(x::MathConst{sym},y::MathConst{sym}) at constants.jl:28
-    +{T<:Number}(x::T<:Number,y::T<:Number) at promotion.jl:179
-    +(x::Number,y::Number) at promotion.jl:149
-    +(x::Real,r::Range{T<:Real}) at range.jl:285
-    +(x::Real,r::Range1{T<:Real}) at range.jl:286
-    +(r::Ranges{T},x::Real) at range.jl:287
-    +(r1::Ranges{T},r2::Ranges{T}) at range.jl:299
-    +() at operators.jl:50
-    +(x::Integer,y::Ptr{T}) at pointer.jl:61
-    +(x::Bool,B::BitArray{N}) at bitarray.jl:1226
-    +(x::Number) at operators.jl:56
-    +(x::Ptr{T},y::Integer) at pointer.jl:59
-    +(A::BitArray{N},B::BitArray{N}) at bitarray.jl:1215
-    +(B::BitArray{N},x::Bool) at bitarray.jl:1219
-    +(B::BitArray{N},x::Number) at bitarray.jl:1222
-    +(A::BitArray{N},B::AbstractArray{T,N}) at bitarray.jl:1467
-    +(A::SparseMatrixCSC{Tv,Ti<:Integer},B::Union(Number,Array{T,N})) at sparse/sparsematrix.jl:503
-    +(A::Union(Number,Array{T,N}),B::SparseMatrixCSC{Tv,Ti<:Integer}) at sparse/sparsematrix.jl:504
-    +(A::SymTridiagonal{T<:Union(Float32,Complex{Float32},Complex{Float64},Float64)},B::SymTridiagonal{T<:Union(Float32,Complex{Float32},Complex{Float64},Float64)}) at linalg/tridiag.jl:50
-    +(A::Tridiagonal{T},B::Tridiagonal{T}) at linalg/tridiag.jl:151
-    +(A::Tridiagonal{T},B::SymTridiagonal{T<:Union(Float32,Complex{Float32},Complex{Float64},Float64)}) at linalg/tridiag.jl:164
-    +(A::SymTridiagonal{T<:Union(Float32,Complex{Float32},Complex{Float64},Float64)},B::Tridiagonal{T}) at linalg/tridiag.jl:165
-    +(A::Bidiagonal{T},B::Bidiagonal{T}) at linalg/bidiag.jl:76
-    +(Da::Diagonal{T},Db::Diagonal{T}) at linalg/diagonal.jl:28
-    +{T<:Number}(x::AbstractArray{T<:Number,N}) at abstractarray.jl:325
-    +{T}(A::Number,B::Union(SubArray{T,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{T,N})) at array.jl:947
-    +{T}(A::Union(SubArray{T,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{T,N}),B::Number) at array.jl:954
-    +{S,T<:Real}(A::Union(SubArray{S,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{S,N}),B::Ranges{T<:Real}) at array.jl:962
-    +{S<:Real,T}(A::Ranges{S<:Real},B::Union(SubArray{T,N,A<:Array{T,N},I<:(Union(Range{Int64},Int64,Range1{Int64})...,)},Array{T,N})) at array.jl:971
-    +(x::Number,B::BitArray{N}) at bitarray.jl:1229
-    +(A::AbstractArray{T,N},B::BitArray{N}) at bitarray.jl:1468
-    +{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti},B::SparseMatrixCSC{Tv,Ti}) at sparse/sparsematrix.jl:409
-    +{TvA,TiA,TvB,TiB}(A::SparseMatrixCSC{TvA,TiA},B::SparseMatrixCSC{TvB,TiB}) at sparse/sparsematrix.jl:401
+    +(x::Char,y::Char) at char.jl:23
+    +(x::Char,y::Integer) at char.jl:26
+    +(x::Integer,y::Char) at char.jl:27
+    +(a::Float16,b::Float16) at float16.jl:132
+    +(x::BigInt,y::BigInt) at gmp.jl:194
+    +(a::BigInt,b::BigInt,c::BigInt) at gmp.jl:217
+    +(a::BigInt,b::BigInt,c::BigInt,d::BigInt) at gmp.jl:223
+    +(a::BigInt,b::BigInt,c::BigInt,d::BigInt,e::BigInt) at gmp.jl:230
+    +(x::BigInt,c::Uint64) at gmp.jl:242
+    +(c::Uint64,x::BigInt) at gmp.jl:246
+    +(c::Union(Uint32,Uint16,Uint8,Uint64),x::BigInt) at gmp.jl:247
+    +(x::BigInt,c::Union(Uint32,Uint16,Uint8,Uint64)) at gmp.jl:248
+    +(x::BigInt,c::Union(Int16,Int32,Int8,Int64)) at gmp.jl:249
+    +(c::Union(Int16,Int32,Int8,Int64),x::BigInt) at gmp.jl:250
+    +(x::BigFloat,c::Uint64) at mpfr.jl:147
+    +(c::Uint64,x::BigFloat) at mpfr.jl:151
+    +(c::Union(Uint32,Uint16,Uint8,Uint64),x::BigFloat) at mpfr.jl:152
+    +(x::BigFloat,c::Union(Uint32,Uint16,Uint8,Uint64)) at mpfr.jl:153
+    +(x::BigFloat,c::Int64) at mpfr.jl:157
+    +(c::Int64,x::BigFloat) at mpfr.jl:161
+    +(x::BigFloat,c::Union(Int16,Int32,Int8,Int64)) at mpfr.jl:162
+    +(c::Union(Int16,Int32,Int8,Int64),x::BigFloat) at mpfr.jl:163
+    +(x::BigFloat,c::Float64) at mpfr.jl:167
+    +(c::Float64,x::BigFloat) at mpfr.jl:171
+    +(c::Float32,x::BigFloat) at mpfr.jl:172
+    +(x::BigFloat,c::Float32) at mpfr.jl:173
+    +(x::BigFloat,c::BigInt) at mpfr.jl:177
+    +(c::BigInt,x::BigFloat) at mpfr.jl:181
+    +(x::BigFloat,y::BigFloat) at mpfr.jl:328
+    +(a::BigFloat,b::BigFloat,c::BigFloat) at mpfr.jl:339
+    +(a::BigFloat,b::BigFloat,c::BigFloat,d::BigFloat) at mpfr.jl:345
+    +(a::BigFloat,b::BigFloat,c::BigFloat,d::BigFloat,e::BigFloat) at mpfr.jl:352
+    +(x::MathConst{sym},y::MathConst{sym}) at constants.jl:23
+    +{T<:Number}(x::T<:Number,y::T<:Number) at promotion.jl:188
+    +{T<:FloatingPoint}(x::Bool,y::T<:FloatingPoint) at bool.jl:46
+    +(x::Number,y::Number) at promotion.jl:158
+    +(x::Integer,y::Ptr{T}) at pointer.jl:68
+    +(x::Bool,A::AbstractArray{Bool,N}) at array.jl:767
+    +(x::Number) at operators.jl:71
+    +(r1::OrdinalRange{T,S},r2::OrdinalRange{T,S}) at operators.jl:325
+    +{T<:FloatingPoint}(r1::FloatRange{T<:FloatingPoint},r2::FloatRange{T<:FloatingPoint}) at operators.jl:331
+    +(r1::FloatRange{T<:FloatingPoint},r2::FloatRange{T<:FloatingPoint}) at operators.jl:348
+    +(r1::FloatRange{T<:FloatingPoint},r2::OrdinalRange{T,S}) at operators.jl:349
+    +(r1::OrdinalRange{T,S},r2::FloatRange{T<:FloatingPoint}) at operators.jl:350
+    +(x::Ptr{T},y::Integer) at pointer.jl:66
+    +{S,T<:Real}(A::Union(SubArray{S,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)},DenseArray{S,N}),B::Range{T<:Real}) at array.jl:727
+    +{S<:Real,T}(A::Range{S<:Real},B::Union(SubArray{T,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)},DenseArray{T,N})) at array.jl:736
+    +(A::AbstractArray{Bool,N},x::Bool) at array.jl:766
+    +{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti},B::SparseMatrixCSC{Tv,Ti}) at sparse/sparsematrix.jl:530
+    +{TvA,TiA,TvB,TiB}(A::SparseMatrixCSC{TvA,TiA},B::SparseMatrixCSC{TvB,TiB}) at sparse/sparsematrix.jl:522
+    +(A::SparseMatrixCSC{Tv,Ti<:Integer},B::Array{T,N}) at sparse/sparsematrix.jl:621
+    +(A::Array{T,N},B::SparseMatrixCSC{Tv,Ti<:Integer}) at sparse/sparsematrix.jl:623
+    +(A::SymTridiagonal{T},B::SymTridiagonal{T}) at linalg/tridiag.jl:45
+    +(A::Tridiagonal{T},B::Tridiagonal{T}) at linalg/tridiag.jl:207
+    +(A::Tridiagonal{T},B::SymTridiagonal{T}) at linalg/special.jl:99
+    +(A::SymTridiagonal{T},B::Tridiagonal{T}) at linalg/special.jl:98
+    +{T,MT,uplo}(A::Triangular{T,MT,uplo,IsUnit},B::Triangular{T,MT,uplo,IsUnit}) at linalg/triangular.jl:10
+    +{T,MT,uplo1,uplo2}(A::Triangular{T,MT,uplo1,IsUnit},B::Triangular{T,MT,uplo2,IsUnit}) at linalg/triangular.jl:11
+    +(Da::Diagonal{T},Db::Diagonal{T}) at linalg/diagonal.jl:44
+    +(A::Bidiagonal{T},B::Bidiagonal{T}) at linalg/bidiag.jl:92
+    +{T}(B::BitArray{2},J::UniformScaling{T}) at linalg/uniformscaling.jl:26
+    +(A::Diagonal{T},B::Bidiagonal{T}) at linalg/special.jl:89
+    +(A::Bidiagonal{T},B::Diagonal{T}) at linalg/special.jl:90
+    +(A::Diagonal{T},B::Tridiagonal{T}) at linalg/special.jl:89
+    +(A::Tridiagonal{T},B::Diagonal{T}) at linalg/special.jl:90
+    +(A::Diagonal{T},B::Triangular{T,S<:AbstractArray{T,2},UpLo,IsUnit}) at linalg/special.jl:89
+    +(A::Triangular{T,S<:AbstractArray{T,2},UpLo,IsUnit},B::Diagonal{T}) at linalg/special.jl:90
+    +(A::Diagonal{T},B::Array{T,2}) at linalg/special.jl:89
+    +(A::Array{T,2},B::Diagonal{T}) at linalg/special.jl:90
+    +(A::Bidiagonal{T},B::Tridiagonal{T}) at linalg/special.jl:89
+    +(A::Tridiagonal{T},B::Bidiagonal{T}) at linalg/special.jl:90
+    +(A::Bidiagonal{T},B::Triangular{T,S<:AbstractArray{T,2},UpLo,IsUnit}) at linalg/special.jl:89
+    +(A::Triangular{T,S<:AbstractArray{T,2},UpLo,IsUnit},B::Bidiagonal{T}) at linalg/special.jl:90
+    +(A::Bidiagonal{T},B::Array{T,2}) at linalg/special.jl:89
+    +(A::Array{T,2},B::Bidiagonal{T}) at linalg/special.jl:90
+    +(A::Tridiagonal{T},B::Triangular{T,S<:AbstractArray{T,2},UpLo,IsUnit}) at linalg/special.jl:89
+    +(A::Triangular{T,S<:AbstractArray{T,2},UpLo,IsUnit},B::Tridiagonal{T}) at linalg/special.jl:90
+    +(A::Tridiagonal{T},B::Array{T,2}) at linalg/special.jl:89
+    +(A::Array{T,2},B::Tridiagonal{T}) at linalg/special.jl:90
+    +(A::Triangular{T,S<:AbstractArray{T,2},UpLo,IsUnit},B::Array{T,2}) at linalg/special.jl:89
+    +(A::Array{T,2},B::Triangular{T,S<:AbstractArray{T,2},UpLo,IsUnit}) at linalg/special.jl:90
+    +(A::SymTridiagonal{T},B::Triangular{T,S<:AbstractArray{T,2},UpLo,IsUnit}) at linalg/special.jl:98
+    +(A::Triangular{T,S<:AbstractArray{T,2},UpLo,IsUnit},B::SymTridiagonal{T}) at linalg/special.jl:99
+    +(A::SymTridiagonal{T},B::Array{T,2}) at linalg/special.jl:98
+    +(A::Array{T,2},B::SymTridiagonal{T}) at linalg/special.jl:99
+    +(A::Diagonal{T},B::SymTridiagonal{T}) at linalg/special.jl:107
+    +(A::SymTridiagonal{T},B::Diagonal{T}) at linalg/special.jl:108
+    +(A::Bidiagonal{T},B::SymTridiagonal{T}) at linalg/special.jl:107
+    +(A::SymTridiagonal{T},B::Bidiagonal{T}) at linalg/special.jl:108
+    +{T<:Number}(x::AbstractArray{T<:Number,N}) at abstractarray.jl:358
+    +(A::AbstractArray{T,N},x::Number) at array.jl:770
+    +(x::Number,A::AbstractArray{T,N}) at array.jl:771
+    +(J1::UniformScaling{T<:Number},J2::UniformScaling{T<:Number}) at linalg/uniformscaling.jl:25
+    +(J::UniformScaling{T<:Number},B::BitArray{2}) at linalg/uniformscaling.jl:27
+    +(J::UniformScaling{T<:Number},A::AbstractArray{T,2}) at linalg/uniformscaling.jl:28
+    +(J::UniformScaling{T<:Number},x::Number) at linalg/uniformscaling.jl:29
+    +(x::Number,J::UniformScaling{T<:Number}) at linalg/uniformscaling.jl:30
+    +{TA,TJ}(A::AbstractArray{TA,2},J::UniformScaling{TJ}) at linalg/uniformscaling.jl:33
     +{T}(a::HierarchicalValue{T},b::HierarchicalValue{T}) at pkg/resolve/versionweight.jl:19
     +(a::VWPreBuildItem,b::VWPreBuildItem) at pkg/resolve/versionweight.jl:82
     +(a::VWPreBuild,b::VWPreBuild) at pkg/resolve/versionweight.jl:120
     +(a::VersionWeight,b::VersionWeight) at pkg/resolve/versionweight.jl:164
     +(a::FieldValue,b::FieldValue) at pkg/resolve/fieldvalue.jl:41
-    +(a::Vec2,b::Vec2) at graphics.jl:62
-    +(bb1::BoundingBox,bb2::BoundingBox) at graphics.jl:128
-    +(a,b,c) at operators.jl:67
-    +(a,b,c,xs...) at operators.jl:68
+    +(a::Vec2,b::Vec2) at graphics.jl:60
+    +(bb1::BoundingBox,bb2::BoundingBox) at graphics.jl:123
+    +(a,b,c) at operators.jl:82
+    +(a,b,c,xs...) at operators.jl:83
 
 Multiple dispatch together with the flexible parametric type system give
 Julia its ability to abstractly express high-level algorithms decoupled
@@ -438,7 +471,7 @@ signature:
      4
 
     julia> myappend([1,2,3],2.5)
-    ERROR: no method myappend(Array{Int64,1}, Float64)
+    ERROR: `myappend` has no method matching myappend(::Array{Int64,1}, ::Float64)
 
     julia> myappend([1.0,2.0,3.0],4.0)
     4-element Array{Float64,1}:
@@ -448,7 +481,7 @@ signature:
      4.0
 
     julia> myappend([1.0,2.0,3.0],4)
-    ERROR: no method myappend(Array{Float64,1}, Int64)
+    ERROR: `myappend` has no method matching myappend(::Array{Float64,1}, ::Int64)
 
 As you can see, the type of the appended element must match the element
 type of the vector it is appended to, or a "no method" error is raised.

--- a/doc/manual/methods.rst
+++ b/doc/manual/methods.rst
@@ -216,9 +216,7 @@ pairs of arguments to which no other method definition applies.
 
 Although it seems a simple concept, multiple dispatch on the types of
 values is perhaps the single most powerful and central feature of the
-Julia language. Core operations typically have dozens of methods:
-
-.. doctest::
+Julia language. Core operations typically have dozens of methods::
 
     julia> methods(+)
     # 125 methods for generic function "+":

--- a/doc/manual/methods.rst
+++ b/doc/manual/methods.rst
@@ -226,8 +226,8 @@ Julia language. Core operations typically have dozens of methods:
     +(x::Bool,y::Bool) at bool.jl:39
     +(y::FloatingPoint,x::Bool) at bool.jl:49
     +(A::BitArray{N},B::BitArray{N}) at bitarray.jl:848
-    +(A::Union(DenseArray{Bool,N},SubArray{Bool,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)}),B::Union(DenseArray{Bool,N},SubArray{Bool,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)})) at array.jl:797
-    +{S,T}(A::Union(SubArray{S,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)},DenseArray{S,N}),B::Union(SubArray{T,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)},DenseArray{T,N})) at array.jl:719
+    +(A::Union(DenseArray{Bool,N},SubArray{Bool,N,A<:DenseArray{T,N},I<:(Union(Range{Int64},Int64)...,)}),B::Union(DenseArray{Bool,N},SubArray{Bool,N,A<:DenseArray{T,N},I<:(Union(Range{Int64},Int64)...,)})) at array.jl:797
+    +{S,T}(A::Union(SubArray{S,N,A<:DenseArray{T,N},I<:(Union(Range{Int64},Int64)...,)},DenseArray{S,N}),B::Union(SubArray{T,N,A<:DenseArray{T,N},I<:(Union(Range{Int64},Int64)...,)},DenseArray{T,N})) at array.jl:719
     +{T<:Union(Int16,Int32,Int8)}(x::T<:Union(Int16,Int32,Int8),y::T<:Union(Int16,Int32,Int8)) at int.jl:16
     +{T<:Union(Uint32,Uint16,Uint8)}(x::T<:Union(Uint32,Uint16,Uint8),y::T<:Union(Uint32,Uint16,Uint8)) at int.jl:20
     +(x::Int64,y::Int64) at int.jl:33
@@ -252,16 +252,16 @@ Julia language. Core operations typically have dozens of methods:
     +(c::Uint64,x::BigInt) at gmp.jl:246
     +(c::Union(Uint32,Uint16,Uint8,Uint64),x::BigInt) at gmp.jl:247
     +(x::BigInt,c::Union(Uint32,Uint16,Uint8,Uint64)) at gmp.jl:248
-    +(x::BigInt,c::Union(Int16,Int32,Int8,Int64)) at gmp.jl:249
-    +(c::Union(Int16,Int32,Int8,Int64),x::BigInt) at gmp.jl:250
+    +(x::BigInt,c::Union(Int64,Int16,Int32,Int8)) at gmp.jl:249
+    +(c::Union(Int64,Int16,Int32,Int8),x::BigInt) at gmp.jl:250
     +(x::BigFloat,c::Uint64) at mpfr.jl:147
     +(c::Uint64,x::BigFloat) at mpfr.jl:151
     +(c::Union(Uint32,Uint16,Uint8,Uint64),x::BigFloat) at mpfr.jl:152
     +(x::BigFloat,c::Union(Uint32,Uint16,Uint8,Uint64)) at mpfr.jl:153
     +(x::BigFloat,c::Int64) at mpfr.jl:157
     +(c::Int64,x::BigFloat) at mpfr.jl:161
-    +(x::BigFloat,c::Union(Int16,Int32,Int8,Int64)) at mpfr.jl:162
-    +(c::Union(Int16,Int32,Int8,Int64),x::BigFloat) at mpfr.jl:163
+    +(x::BigFloat,c::Union(Int64,Int16,Int32,Int8)) at mpfr.jl:162
+    +(c::Union(Int64,Int16,Int32,Int8),x::BigFloat) at mpfr.jl:163
     +(x::BigFloat,c::Float64) at mpfr.jl:167
     +(c::Float64,x::BigFloat) at mpfr.jl:171
     +(c::Float32,x::BigFloat) at mpfr.jl:172
@@ -285,8 +285,8 @@ Julia language. Core operations typically have dozens of methods:
     +(r1::FloatRange{T<:FloatingPoint},r2::OrdinalRange{T,S}) at operators.jl:349
     +(r1::OrdinalRange{T,S},r2::FloatRange{T<:FloatingPoint}) at operators.jl:350
     +(x::Ptr{T},y::Integer) at pointer.jl:66
-    +{S,T<:Real}(A::Union(SubArray{S,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)},DenseArray{S,N}),B::Range{T<:Real}) at array.jl:727
-    +{S<:Real,T}(A::Range{S<:Real},B::Union(SubArray{T,N,A<:DenseArray{T,N},I<:(Union(Int64,Range{Int64})...,)},DenseArray{T,N})) at array.jl:736
+    +{S,T<:Real}(A::Union(SubArray{S,N,A<:DenseArray{T,N},I<:(Union(Range{Int64},Int64)...,)},DenseArray{S,N}),B::Range{T<:Real}) at array.jl:727
+    +{S<:Real,T}(A::Range{S<:Real},B::Union(SubArray{T,N,A<:DenseArray{T,N},I<:(Union(Range{Int64},Int64)...,)},DenseArray{T,N})) at array.jl:736
     +(A::AbstractArray{Bool,N},x::Bool) at array.jl:766
     +{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti},B::SparseMatrixCSC{Tv,Ti}) at sparse/sparsematrix.jl:530
     +{TvA,TiA,TvB,TiB}(A::SparseMatrixCSC{TvA,TiA},B::SparseMatrixCSC{TvB,TiB}) at sparse/sparsematrix.jl:522

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -635,7 +635,7 @@ a string is invalid). Here's is a pair of somewhat contrived examples:
     "acd"
 
     julia> m.captures
-    3-element Array{Union(Nothing,SubString{UTF8String}),1}:
+    3-element Array{Union(SubString{UTF8String},Nothing),1}:
      "a"
      "c"
      "d"
@@ -656,7 +656,7 @@ a string is invalid). Here's is a pair of somewhat contrived examples:
     "ad"
 
     julia> m.captures
-    3-element Array{Union(Nothing,SubString{UTF8String}),1}:
+    3-element Array{Union(SubString{UTF8String},Nothing),1}:
      "a"
      nothing
      "d"

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -624,9 +624,7 @@ You can extract the following info from a ``RegexMatch`` object:
 For when a capture doesn't match, instead of a substring, ``m.captures``
 contains ``nothing`` in that position, and ``m.offsets`` has a zero
 offset (recall that indices in Julia are 1-based, so a zero offset into
-a string is invalid). Here's is a pair of somewhat contrived examples:
-
-.. doctest::
+a string is invalid). Here's is a pair of somewhat contrived examples::
 
     julia> m = match(r"(a|b)(c)?(d)", "acd")
     RegexMatch("acd", 1="a", 2="c", 3="d")
@@ -671,9 +669,7 @@ a string is invalid). Here's is a pair of somewhat contrived examples:
      2
 
 It is convenient to have captures returned as a tuple so that one can
-use tuple destructuring syntax to bind them to local variables:
-
-.. doctest::
+use tuple destructuring syntax to bind them to local variables::
 
     julia> first, second, third = m.captures; first
     "a"

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -227,11 +227,11 @@ a normal value:
 
     julia> str[end/3]
     ERROR: InexactError()
-     in getindex at string.jl:58
+     in getindex at string.jl:59
 
     julia> str[end/4]
     ERROR: InexactError()
-     in getindex at string.jl:58
+     in getindex at string.jl:59
 
 Using an index less than 1 or greater than ``end`` raises an error:
 
@@ -239,11 +239,9 @@ Using an index less than 1 or greater than ``end`` raises an error:
 
     julia> str[0]
     ERROR: BoundsError()
-     in getindex at ascii.jl:11
 
     julia> str[end+1]
     ERROR: BoundsError()
-     in getindex at ascii.jl:11
 
 You can also extract a substring using range indexing:
 
@@ -299,11 +297,13 @@ such an invalid byte index, an error is thrown:
 
     julia> s[2]
     ERROR: invalid UTF-8 character index
-     in getindex at utf8.jl:63
+     in next at ./utf8.jl:68
+     in getindex at string.jl:57
 
     julia> s[3]
     ERROR: invalid UTF-8 character index
-     in getindex at utf8.jl:63
+     in next at ./utf8.jl:68
+     in getindex at string.jl:57
 
     julia> s[4]
     ' '

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -553,9 +553,7 @@ Type Unions
 
 A type union is a special abstract type which includes as objects all
 instances of any of its argument types, constructed using the special
-``Union`` function:
-
-.. doctest::
+``Union`` function::
 
     julia> IntOrString = Union(Int,String)
     Union(String,Int64)
@@ -1166,9 +1164,7 @@ Only declared types (``DataType``) have unambiguous supertypes:
     Any
 
 If you apply ``super`` to other type objects (or non-type objects), a
-"no method" error is raised:
-
-.. doctest::
+"no method" error is raised::
 
     julia> super(Union(Float64,Int64))
     ERROR: `super` has no method matching super(::Type{Union(Float64,Int64)})

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -558,7 +558,7 @@ instances of any of its argument types, constructed using the special
 .. doctest::
 
     julia> IntOrString = Union(Int,String)
-    Union(Int64,String)
+    Union(String,Int64)
 
     julia> 1 :: IntOrString
     1
@@ -567,7 +567,7 @@ instances of any of its argument types, constructed using the special
     "Hello!"
 
     julia> 1.0 :: IntOrString
-    ERROR: type: typeassert: expected Union(Int64,String), got Float64
+    ERROR: type: typeassert: expected Union(String,Int64), got Float64
 
 The compilers for many languages have an internal union construct for
 reasoning about types; Julia simply exposes it to the programmer. The

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -366,13 +366,14 @@ However, the value for ``baz`` must be convertible to ``Int``:
 
     julia> Foo((), 23.5, 1)
     ERROR: InexactError()
+     in Foo at no file
 
 You may find a list of field names using the ``names`` function.
 
 .. doctest::
 
     julia> names(foo)
-    3-element Array{Any,1}:
+    3-element Array{Symbol,1}:
      :bar
      :baz
      :qux
@@ -566,7 +567,7 @@ instances of any of its argument types, constructed using the special
     "Hello!"
 
     julia> 1.0 :: IntOrString
-    ERROR: type: typeassert: expected Union(String,Int64), got Float64
+    ERROR: type: typeassert: expected Union(Int64,String), got Float64
 
 The compilers for many languages have an internal union construct for
 reasoning about types; Julia simply exposes it to the programmer. The
@@ -750,10 +751,10 @@ each field:
 .. doctest::
 
     julia> Point{Float64}(1.0)
-    ERROR: no method Point{Float64}(Float64)
+    ERROR: `Point{Float64}` has no method matching Point{Float64}(::Float64)
 
     julia> Point{Float64}(1.0,2.0,3.0)
-    ERROR: no method Point{Float64}(Float64, Float64, Float64)
+    ERROR: `Point{Float64}` has no method matching Point{Float64}(::Float64, ::Float64, ::Float64)
 
 Only one default constructor is generated for parametric types, since
 overriding it is not possible. This constructor accepts any arguments
@@ -786,7 +787,7 @@ isn't the case, the constructor will fail with a no method error:
 .. doctest::
 
     julia> Point(1,2.5)
-    ERROR: no method Point{T}(Int64, Float64)
+    ERROR: `Point{T}` has no method matching Point{T}(::Int64, ::Float64)
 
 Constructor methods to appropriately handle such mixed cases can be
 defined, but that will not be discussed until later on in
@@ -894,10 +895,10 @@ subtypes of ``Real``:
     Pointy{Real}
 
     julia> Pointy{String}
-    ERROR: type: Pointy: in T, expected Real, got Type{String}
+    ERROR: type: Pointy: in T, expected T<:Real, got Type{String}
 
     julia> Pointy{1}
-    ERROR: type: Pointy: in T, expected Real, got Int64
+    ERROR: type: Pointy: in T, expected T<:Real, got Int64
 
 Type parameters for parametric composite types can be restricted in the
 same manner::
@@ -1170,10 +1171,10 @@ If you apply ``super`` to other type objects (or non-type objects), a
 .. doctest::
 
     julia> super(Union(Float64,Int64))
-    ERROR: no method super(Type{Union(Float64,Int64)})
+    ERROR: `super` has no method matching super(::Type{Union(Float64,Int64)})
 
     julia> super(None)
-    ERROR: no method super(Type{None})
+    ERROR: `super` has no method matching super(::Type{None})
 
     julia> super((Float64,Int64))
-    ERROR: no method super(Type{(Float64,Int64)})
+    ERROR: `super` has no method matching super(::Type{(Float64,Int64)})

--- a/doc/manual/variables.rst
+++ b/doc/manual/variables.rst
@@ -88,6 +88,7 @@ Julia will even let you redefine built-in constants and functions if needed:
     10.0
     
     julia> sqrt = 4
+    Warning: imported binding for sqrt overwritten in module Main
     4
     
 However, this is obviously not recommended to avoid potential confusion.


### PR DESCRIPTION
Reflects lots of small changes in printouts and error messages, line numbers, etc.

Nontrivial changes:
- Bump JuliaDoc submodule
- The control flow documentation had to be reformatted slightly to make
  doctests pass.  The output of Task(...) now prints out a memory
  address which is clearly not reproducible, so the output is
  suppressed.
- Some roundoff printing issues in complex-and-rational-numbers?
- isequal(NaN,NaN32) == true
- ~~It also looks like sqrt(-1) no longer prints a helpful error message
  about trying sqrt(complex(-1))...?~~
- strings.rst, line 239: "ERROR: BoundsError() in getindex at
  ascii.jl:11" no longer prints out traceback??
- control-flow.rst, line 638: UndefVarError->MyUndefVarError to prevent
  overwriting Base UndefVarError

The output blocks containing Unions have been demoted to ordinary code blocks instead of doctests
<strike>WARNING: Because union types appear to be unsorted on output, sometimes
Union(a,b) is printed out as Union(b,a). This causes the doctests to
fail nondeterministically, e.g.

Failed example:
    super(Union(Float64,Int64))
Expected:
    ERROR: `super` has no method matching super(::Type{Union(Float64,Int64)})
Got:
    ERROR: `super` has no method matching super(::Type{Union(Int64,Float64)})~~
</strike>
