### PR TITLE
RFC: Interface definition and implementation macros

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1377,4 +1377,6 @@ export
     @inbounds,
     @simd,
     @label,
-    @goto
+    @goto,
+    @interface,
+    @implement

--- a/base/interface.jl
+++ b/base/interface.jl
@@ -1,0 +1,147 @@
+## interface definition and implementation ##
+
+macro interface(decl, body)
+    interface_body = Expr[]
+    if body.head != :block error("Invalid interface body") end
+    for expr in body.args
+        if typeof(expr) != Expr error("Unexpected non-expression $expr") end
+        if expr.head == :line
+            # Dict literal expressions don't like line annotations in the body
+            continue
+        end
+        if expr.head == :call
+            function_name = string(expr.args[1])
+            function_sig = Expr(:tuple, expr.args[2:end]...)
+            push!(interface_body, :(symbol($function_name) => $function_sig))
+            continue
+        end
+        error("Unexpected expression $expr")
+    end
+
+    interface_dict = Expr(:dict, interface_body...)
+    esc(Expr(:function, decl, Expr(:block, interface_dict)))
+end
+
+function used_typevars(vars, exprs)
+    base_var(expr::Symbol) = expr
+    function base_var(expr::Expr)
+        if expr.head != :<: error("Unexpected expr $expr ($(expr.head))") end
+        expr.args[1]
+    end
+
+    used = {[var, base_var(var), false] for var in vars}
+
+    function check_expr(expr::Symbol)
+        for ix = 1:length(used)
+            if used[ix][2] == expr
+                used[ix][3] = true
+                return
+            end
+        end
+    end
+    function check_expr(expr::Expr)
+        if expr.head != :curly error("Unexpected expr $expr") end
+        for var in expr.args
+            check_expr(var)
+        end
+    end
+
+    for expr in exprs
+        check_expr(expr)
+    end
+    result = Any[]
+    for p in used
+        if p[3] push!(result, p[1]) end
+    end
+    result
+end
+
+macro implement(decl, body)
+    if decl.head != :call error("Invalid declaration") end
+    if typeof(decl.args[1]) == Symbol
+        interface_name = decl.args[1]
+        interface_typevars = []
+    elseif decl.args[1].head == :curly
+        interface_name = decl.args[1].args[1]
+        interface_typevars = decl.args[1].args[2:end]
+    else
+        error("Invalid declaration")
+    end
+    interface_params = decl.args[2:end]
+    if length(interface_params) == 0 error("At least one parameter is needed") end
+    
+    interface = @eval $interface_name($interface_params...)
+    
+    implemented = Symbol[]
+    
+    if body.head != :block error("Invalid body") end
+    final_block = quote end
+    for expr in body.args
+        if typeof(expr) != Expr error("Unexpected non-expression $expr") end
+        if expr.head == :line
+            push!(final_block.args, expr)
+            continue
+        end
+        if expr.head == :(=)
+            final_expr = deepcopy(expr)
+            fn_decl = expr.args[1]
+            fn_body = expr.args[2]
+
+            if fn_decl.head != :call error("Invalid interface function declaration") end
+            fn_decl_name = fn_decl.args[1]
+            if typeof(fn_decl_name) != Symbol error("Invalid interface function declaration") end
+            if !haskey(interface, fn_decl_name) error("Interface has no function $fn_decl_name") end
+
+            interface_param_types = interface[fn_decl_name]
+            fn_decl_params = fn_decl.args[2:end]
+            if length(interface_param_types) != length(fn_decl_params) error("Mismatch between expected and actual parameter count") end
+
+            if length(interface_typevars) > 0
+                method_typevars = used_typevars(interface_typevars, interface_param_types)
+                if length(method_typevars) > 0
+                    final_expr.args[1].args[1] = Expr(:curly, fn_decl_name, method_typevars...)
+                end
+            end
+
+            for ix = 1:length(interface_param_types)
+                if typeof(fn_decl_params[ix]) != Symbol error("Interface function parameters must be unqualified") end
+                param_name = fn_decl_params[ix]
+                param_type = interface_param_types[ix]
+                final_expr.args[1].args[1+ix] = :($param_name :: $param_type)
+            end
+            push!(final_block.args, final_expr)
+            push!(implemented, fn_decl_name)
+            continue
+        end
+        error("Unexpected expression $expr")
+    end
+    if length(implemented) != length(interface)
+        missing = setdiff(keys(interface), implemented)
+        error("Missing interface functions $missing")
+    end
+    esc(final_block)
+end
+
+@interface mathy(A, B) begin
+    plus(A, B)
+    minus(A, B)
+end
+
+immutable MyInt
+    x::Int
+end
+
+@implement mathy(MyInt, MyInt) begin
+    plus(a, b) = MyInt(a.x + b.x)
+    minus(a, b) = MyInt(a.x - b.x)
+end
+
+@interface stack(A, B) begin
+    stack_push!(A, B)
+    stack_pop!(A)
+end
+
+@implement stack{T <: Integer}(Vector{T}, T) begin
+    stack_push!(vec, x) = push!(vec, x)
+    stack_pop!(vec) = pop!(vec)
+end

--- a/base/interface.jl
+++ b/base/interface.jl
@@ -121,27 +121,3 @@ macro implement(decl, body)
     end
     esc(final_block)
 end
-
-@interface mathy(A, B) begin
-    plus(A, B)
-    minus(A, B)
-end
-
-immutable MyInt
-    x::Int
-end
-
-@implement mathy(MyInt, MyInt) begin
-    plus(a, b) = MyInt(a.x + b.x)
-    minus(a, b) = MyInt(a.x - b.x)
-end
-
-@interface stack(A, B) begin
-    stack_push!(A, B)
-    stack_pop!(A)
-end
-
-@implement stack{T <: Integer}(Vector{T}, T) begin
-    stack_push!(vec, x) = push!(vec, x)
-    stack_pop!(vec) = pop!(vec)
-end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -268,6 +268,9 @@ include("graphics.jl")
 include("profile.jl")
 importall .Profile
 
+# interfaces
+include("interface.jl")
+
 function __init__()
     # Base library init
     reinit_stdio()


### PR DESCRIPTION
Example:

``` julia
@interface stack(Container, Data) begin
  push!(Container, Data)
  pop!(Container)
end

@implement stack{T}(Vector{T}, T) begin
  push!(vec, t) = Base.push!(vec, t)
  pop!(vec) = Base.pop!(vec)
end
```

This expands to:

``` julia
stack(Container, Data) = [
  :push! => (Container, Data),
  :pop! => (Container,)
]

push!{T}(vec::Vector{T}, t::T) = Base.push!(vec, t)
pop!{T}(vec::Vector{T}) = Base.pop!(vec)
```

Notable features:
- Interfaces and interface methods are normal functions, and can be exported, imported, passed around, inspected, etc.
- This does not introduce any new form of method overloading/resolution, it compiles down to normal Julian multiple dispatch.
- The methods are not owned by the interface, nor is the interface owned by any abstract type; it is a declaration that for any _list_ of types, they conform to the interface if a particular list of methods is defined on those types.
- Interface implementations can be type-parameterized, creating a family of interface implementations in the same way that a type-parameterized method definition creates a family of methods.  If a type parameter is unused by a particular method's type bindings, it will be stripped.

Notable warts:
- This inherits the same problems with scope that normal function overloading has; if the intended functions aren't imported, new ones will be silently created.
- Party A can declare an interface, and party B can be certain they've implemented it, but party A cannot define methods that require (in an enforced manner) parameter types to have an implementation defined for them.  This may be considered a wart or a feature depending on one's language philosophy; it prevents some potential bugs from being caught pseudo-statically, but allows methods to work on a wider variety of types (i.e. if they happen to have the methods defined outside of the interface mechanism).
