### PR TITLE
SIGINFO

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -140,6 +140,10 @@ static int is_addr_on_stack(void *addr)
 #endif
 }
 
+#ifndef SIGINFO
+#define SIGINFO SIGUSR1
+#endif
+
 void sigdie_handler(int sig, siginfo_t *info, void *context) {
     if (sig != SIGINFO) {
         sigset_t sset;

--- a/src/init.c
+++ b/src/init.c
@@ -64,10 +64,14 @@ extern BOOL (WINAPI *hSymRefreshModuleList)(HANDLE);
 #include <sched.h>   // for setting CPU affinity
 #endif
 
+DLLEXPORT void jlbacktrace();
+DLLEXPORT void gdbbacktrace();
+DLLEXPORT void gdblookup(ptrint_t ip);
+
 char *julia_home = NULL;
 jl_compileropts_t jl_compileropts = { NULL, // build_path
                                       0,    // code_coverage
-				      0,    // malloc_log
+                                      0,    // malloc_log
                                       JL_COMPILEROPT_CHECK_BOUNDS_DEFAULT,
                                       0     // int32_literals
 };
@@ -135,29 +139,44 @@ static int is_addr_on_stack(void *addr)
             (char*)addr < (char*)jl_current_task->stack+jl_current_task->ssize);
 #endif
 }
+
+void sigdie_handler(int sig, siginfo_t *info, void *context) {
+    if (sig != SIGINFO) {
+        sigset_t sset;
+        uv_tty_reset_mode();
+        sigfillset(&sset);
+        sigprocmask(SIG_UNBLOCK, &sset, NULL);
+        signal(sig, SIG_DFL);
+    }
+    ios_printf(ios_stderr,"\nsignal (%d): %s\n", sig, strsignal(sig));
+#ifdef __APPLE__
+    gdbbacktrace();
+#else
+    bt_size = rec_backtrace_ctx(bt_data, MAX_BT_SIZE, (ucontext_t*)context);
+    jlbacktrace();
+#endif
+    if (sig != SIGSEGV &&
+        sig != SIGBUS &&
+        sig != SIGILL &&
+        sig != SIGINFO) {
+        raise(sig);
+    }
+}
 #endif
 
 #if defined(__linux__) || defined(__FreeBSD__)
 extern int in_jl_;
 void segv_handler(int sig, siginfo_t *info, void *context)
 {
-    sigset_t sset;
-
-    if (in_jl_ || is_addr_on_stack(info->si_addr)) {
+    if (sig == SIGSEGV && (in_jl_ || is_addr_on_stack(info->si_addr))) {
+        sigset_t sset;
         sigemptyset(&sset);
         sigaddset(&sset, SIGSEGV);
         sigprocmask(SIG_UNBLOCK, &sset, NULL);
         jl_throw(jl_stackovf_exception);
     }
     else {
-        uv_tty_reset_mode();
-        sigfillset(&sset);
-        sigprocmask(SIG_UNBLOCK, &sset, NULL);
-        signal(sig, SIG_DFL);
-        if (sig != SIGSEGV &&
-            sig != SIGBUS &&
-            sig != SIGILL)
-            raise(sig);
+        sigdie_handler(sig, info, context);
     }
 }
 #endif
@@ -190,8 +209,6 @@ void jl_throw_in_ctx(jl_value_t *excpt, CONTEXT *ctxThread, int bt)
 }
 
 volatile HANDLE hMainThread = NULL;
-DLLEXPORT void jlbacktrace();
-DLLEXPORT void gdblookup(ptrint_t ip);
 
 static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guarantee __stdcall
 {
@@ -251,7 +268,7 @@ static LONG WINAPI _exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo,
                 jl_throw_in_ctx(jl_stackovf_exception, ExceptionInfo->ContextRecord,0);
                 return EXCEPTION_CONTINUE_EXECUTION;
         }
-        ios_puts("Please submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.\nException: ", ios_stderr);
+        ios_puts("\nPlease submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.\nException: ", ios_stderr);
         switch (ExceptionInfo->ExceptionRecord->ExceptionCode) {
             case EXCEPTION_ACCESS_VIOLATION:
                 ios_puts("EXCEPTION_ACCESS_VIOLATION", ios_stderr); break;
@@ -656,6 +673,11 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
         return KERN_SUCCESS;
     }
     else {
+        ret = thread_get_state(thread,x86_THREAD_STATE64,(thread_state_t)&state,&count);
+        HANDLE_MACH_ERROR("thread_get_state(3)",ret);
+        ios_printf(ios_stderr,"\nsignal (%d): %s\n", SIGSEGV, strsignal(SIGSEGV));
+        bt_size = rec_backtrace_ctx(bt_data, MAX_BT_SIZE, (unw_context_t*)&state);
+        jlbacktrace();
         return KERN_INVALID_ARGUMENT;
     }
 }
@@ -847,13 +869,46 @@ void julia_init(char *imageFile)
     struct sigaction act;
     memset(&act, 0, sizeof(struct sigaction));
     sigemptyset(&act.sa_mask);
-    act.sa_sigaction = segv_handler;
+    act.sa_sigaction = sigdie_handler;
     act.sa_flags = SA_ONSTACK | SA_SIGINFO;
     if (sigaction(SIGSEGV, &act, NULL) < 0) {
         JL_PRINTF(JL_STDERR, "sigaction: %s\n", strerror(errno));
         jl_exit(1);
     }
 #endif // defined(_OS_DARWIN_)
+    struct sigaction act_die;
+    memset(&act_die, 0, sizeof(struct sigaction));
+    sigemptyset(&act_die.sa_mask);
+    act_die.sa_sigaction = sigdie_handler;
+    act_die.sa_flags = SA_SIGINFO;
+    if (sigaction(SIGINFO, &act_die, NULL) < 0) {
+        JL_PRINTF(JL_STDERR, "sigaction: %s\n", strerror(errno));
+        jl_exit(1);
+    }
+    if (sigaction(SIGBUS, &act_die, NULL) < 0) {
+        JL_PRINTF(JL_STDERR, "sigaction: %s\n", strerror(errno));
+        jl_exit(1);
+    }
+    if (sigaction(SIGILL, &act_die, NULL) < 0) {
+        JL_PRINTF(JL_STDERR, "sigaction: %s\n", strerror(errno));
+        jl_exit(1);
+    }
+    if (sigaction(SIGTERM, &act_die, NULL) < 0) {
+        JL_PRINTF(JL_STDERR, "sigaction: %s\n", strerror(errno));
+        jl_exit(1);
+    }
+    if (sigaction(SIGABRT, &act_die, NULL) < 0) {
+        JL_PRINTF(JL_STDERR, "sigaction: %s\n", strerror(errno));
+        jl_exit(1);
+    }
+    if (sigaction(SIGQUIT, &act_die, NULL) < 0) {
+        JL_PRINTF(JL_STDERR, "sigaction: %s\n", strerror(errno));
+        jl_exit(1);
+    }
+    if (sigaction(SIGSYS, &act_die, NULL) < 0) {
+        JL_PRINTF(JL_STDERR, "sigaction: %s\n", strerror(errno));
+        jl_exit(1);
+    }
 #else // defined(_OS_WINDOWS_)
     if (signal(SIGFPE, (void (__cdecl *)(int))fpe_handler) == SIG_ERR) {
         JL_PRINTF(JL_STDERR, "Couldn't set SIGFPE\n");
@@ -919,11 +974,11 @@ DLLEXPORT int julia_trampoline(int argc, char **argv, int (*pmain)(int ac,char *
                 free(build_o);
             }
             else {
-                ios_printf(ios_stderr,"FATAL: failed to create string for .o build path");
+                ios_printf(ios_stderr,"\nFATAL: failed to create string for .o build path\n");
             }
         }
         else {
-            ios_printf(ios_stderr,"FATAL: failed to create string for .ji build path");
+            ios_printf(ios_stderr,"\nFATAL: failed to create string for .ji build path\n");
         }
     }
     p[sizeof(__stack_chk_guard)-1] = a;

--- a/src/profile.c
+++ b/src/profile.c
@@ -16,6 +16,9 @@ static volatile int running = 0;
 /////////////////////////////////////////
 // Timers to take samples at intervals //
 /////////////////////////////////////////
+DLLEXPORT void jl_profile_stop_timer(void);
+DLLEXPORT int jl_profile_start_timer(void);
+
 #if defined(_WIN32)
 //
 // Windows
@@ -263,8 +266,8 @@ DLLEXPORT int jl_profile_start_timer(void)
         profile_started = 1;
     }
 
-    timerprof.tv_sec = 0;
-    timerprof.tv_nsec = nsecprof;
+    timerprof.tv_sec = nsecprof/1000000;
+    timerprof.tv_nsec = nsecprof%1000000;
 
     running = 1;
     ret = clock_alarm(clk, TIME_RELATIVE, timerprof, profile_port);
@@ -286,38 +289,58 @@ DLLEXPORT void jl_profile_stop_timer(void)
 struct itimerval timerprof;
 
 // The handler function, called whenever the profiling timer elapses
-static void profile_bt(int dummy)
+static void profile_bt(int sig)
 {
-    // Get backtrace data
-    bt_size_cur += rec_backtrace((ptrint_t*)bt_data_prof+bt_size_cur, bt_size_max-bt_size_cur-1);
-    // Mark the end of this block with 0
-    bt_data_prof[bt_size_cur] = 0;
-    bt_size_cur++;
-    // Re-arm the  timer
     if (running && bt_size_cur < bt_size_max) {
-        timerprof.it_value.tv_usec = nsecprof/1000;
-        setitimer(ITIMER_REAL, &timerprof, 0);
-        signal(SIGALRM, profile_bt);
+        // Get backtrace data
+        bt_size_cur += rec_backtrace((ptrint_t*)bt_data_prof+bt_size_cur, bt_size_max-bt_size_cur-1);
+        // Mark the end of this block with 0
+        bt_data_prof[bt_size_cur] = 0;
+        bt_size_cur++;
+    }
+    if (bt_size_cur >= bt_size_max) {
+        // Buffer full: Delete the  timer
+        jl_profile_stop_timer();
     }
 }
 
 DLLEXPORT int jl_profile_start_timer(void)
 {
-    timerprof.it_interval.tv_sec = 0;
-    timerprof.it_interval.tv_usec = 0;
-    timerprof.it_value.tv_sec = 0;
-    timerprof.it_value.tv_usec = nsecprof/1000;
-    if (setitimer(ITIMER_REAL, &timerprof, 0) == -1)
+    struct sigevent sigprof;
+    struct sigaction sa;
+    sigset_t ss;
+
+    // Make sure SIGPROF is unblocked
+    sigemptyset(&ss);
+    sigaddset(&ss, SIGPROF);
+    if (sigprocmask(SIG_UNBLOCK, &ss, NULL) == -1)
+        return -4;
+
+    // Establish the signal handler
+    memset(&sa, 0, sizeof(struct sigaction));
+    sa.sa_handler = profile_bt;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGPROF, &sa, NULL) == -1)
+        return -1;
+
+    timerprof.it_interval.tv_sec = nsecprof/1000000;
+    timerprof.it_interval.tv_usec = (nsecprof/1000)%1000;
+    timerprof.it_value.tv_sec = nsecprof/1000000;
+    timerprof.it_value.tv_usec = (nsecprof/1000)%1000;
+    if (setitimer(ITIMER_PROF, &timerprof, 0) == -1)
         return -3;
 
     running = 1;
-    signal(SIGALRM, profile_bt);
 
     return 0;
 }
 
 DLLEXPORT void jl_profile_stop_timer(void)
 {
+    if (running) {
+        memset(&timerprof, 0, sizeof(timerprof));
+        setitimer(ITIMER_PROF, &timerprof, 0);
+    }
     running = 0;
 }
 #else
@@ -334,17 +357,16 @@ static struct itimerspec itsprof;
 // The handler function, called whenever the profiling timer elapses
 static void profile_bt(int signal, siginfo_t *si, void *uc)
 {
-    if (si->si_value.sival_ptr == &timerprof && bt_size_cur < bt_size_max) {
+    if (running && si->si_value.sival_ptr == &timerprof && bt_size_cur < bt_size_max) {
         // Get backtrace data
         bt_size_cur += rec_backtrace((ptrint_t*)bt_data_prof+bt_size_cur, bt_size_max-bt_size_cur-1);
         // Mark the end of this block with 0
         bt_data_prof[bt_size_cur] = 0;
         bt_size_cur++;
-        // Re-arm the  timer
-        if (bt_size_cur < bt_size_max) {
-            itsprof.it_value.tv_nsec = nsecprof;
-            timer_settime(timerprof, 0, &itsprof, NULL);
-        }
+    }
+    if (bt_size_cur >= bt_size_max) {
+        // Buffer full: Delete the  timer
+        jl_profile_stop_timer();
     }
 }
 
@@ -354,9 +376,9 @@ DLLEXPORT int jl_profile_start_timer(void)
     struct sigaction sa;
     sigset_t ss;
 
-    // Make sure SIGUSR1 is unblocked
+    // Make sure SIGUSR2 is unblocked
     sigemptyset(&ss);
-    sigaddset(&ss, SIGUSR1);
+    sigaddset(&ss, SIGUSR2);
     if (sigprocmask(SIG_UNBLOCK, &ss, NULL) == -1)
         return -4;
 
@@ -365,22 +387,22 @@ DLLEXPORT int jl_profile_start_timer(void)
     sa.sa_flags = SA_SIGINFO;
     sa.sa_sigaction = profile_bt;
     sigemptyset(&sa.sa_mask);
-    if (sigaction(SIGUSR1, &sa, NULL) == -1)
+    if (sigaction(SIGUSR2, &sa, NULL) == -1)
         return -1;
 
     // Establish the signal event
     memset(&sigprof, 0, sizeof(struct sigevent));
     sigprof.sigev_notify = SIGEV_SIGNAL;
-    sigprof.sigev_signo = SIGUSR1;
+    sigprof.sigev_signo = SIGUSR2;
     sigprof.sigev_value.sival_ptr = &timerprof;
-    if (timer_create(CLOCK_REALTIME, &sigprof, &timerprof) == -1)
+    if (timer_create(CLOCK_PROCESS_CPUTIME_ID, &sigprof, &timerprof) == -1)
         return -2;
 
     // Start the timer
-    itsprof.it_value.tv_sec = 0;
-    itsprof.it_interval.tv_sec = 0;       // make it fire once
-    itsprof.it_interval.tv_nsec = 0;
-    itsprof.it_value.tv_nsec = nsecprof;
+    itsprof.it_interval.tv_sec = nsecprof/1000000;
+    itsprof.it_interval.tv_nsec = nsecprof%1000000;
+    itsprof.it_value.tv_sec = nsecprof/1000000;
+    itsprof.it_value.tv_nsec = nsecprof%1000000;
     if (timer_settime(timerprof, 0, &itsprof, NULL) == -1)
         return -3;
 

--- a/src/task.c
+++ b/src/task.c
@@ -685,10 +685,9 @@ DLLEXPORT void gdblookup(ptrint_t ip)
     const char *func_name;
     int line_num;
     const char *file_name;
-#ifdef _OS_WINDOWS_
     int fromC = frame_info_from_ip(&func_name, &line_num, &file_name, ip, 0);
-#else
-    frame_info_from_ip(&func_name, &line_num, &file_name, ip, 0);
+#ifndef _OS_WINDOWS_
+    (void)fromC; // fromC not used on unix
 #endif
     if (func_name != NULL) {
         ios_printf(ios_stderr, "%s at %s:%d\n", func_name, file_name, line_num);


### PR DESCRIPTION
I realize it is late in the process to propose a large patch like this, so I wanted to make sure you were OK with this new behavior (of printing failure backtraces before crashing) before I merged it. This essentially replicates what we have been doing on Windows all along, but for Unix.

this is intended to help with debugging #7640

It also adds a bonus feature of printing a current stack trace if the process receives SIGINFO / SIGUSR1 (the changes in profile were mostly driven by wanting to free SIGUSR1 for this purpose, and just reviewing the rest of the code for potential problems / excess syscalls):

```
shell> kill -SIGUSR1 $(getpid())

signal (10): User defined signal 1
??? at ???:1913539451
??? at ???:1929952982
??? at ???:1913539760
??? at ???:1910527513
uv__epoll_wait at /home/jameson/julia/deps/libuv/src/unix/linux-syscalls.c:316
uv__update_time at /home/jameson/julia/deps/libuv/src/unix/internal.h:299
uv_run at /home/jameson/julia/deps/libuv/src/unix/core.c:295
process_events at ./stream.jl:536
wait at ./task.jl:268
wait at ./task.jl:189
??? at ???:1918977437
stream_wait at ./stream.jl:263
wait at ./process.jl:619
success at process.jl:492
??? at ???:1890324771
??? at ???:1918977611
repl_cmd at ./client.jl:63
??? at ???:1885079356
??? at ???:1918977437
??? at ???:1919258476
??? at ???:1919253409
??? at ???:1919319008
??? at ???:1918997612
eval_user_input at REPL.jl:54
??? at ???:1890308503
??? at ???:1918977611
anonymous at task.jl:96
??? at ???:1919285091
??? at ???:1919280343
??? at ???:4199469
??? at ???:1909679981
??? at ???:4199525

julia> 
```

@JeffBezanson @timholy @Keno 
