### PR TITLE
fix clang on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: cpp
 os:
     - linux
-compiler: 
-    - clang
-    - gcc
+env:
+  matrix:
+    - USEGCC=1
+    - USECLANG=1
 notifications:
     email: false
     irc:


### PR DESCRIPTION
Ever since 670a6a14a0369e48ddaefbf759eba5a652a99453, picking up the settings of `CC` and `CXX` from environment variables no longer works. I think this is caused by always executing `CC += -m$(BINARY)`. So for the last month or so, Travis hasn't actually been building with clang at all.

An alternate thing we could do is change [these lines](https://github.com/JuliaLang/julia/blob/542b013eb6dd08480ee11da1db2449d13bfa39e2/Make.inc#L246-L247) to use `?=`, since there are other use cases where you might want to set `CC` and `CXX` via environment variables instead of through `Make.user`, and expect Julia to honor those settings. If you make this change, then you end up with `-m64` getting repeated 4 times in a bunch of places, since `Make.inc` gets included several times by different levels of recursive make. It's a little annoying, but probably harmless?
