### PR TITLE
WIP: Add ability to build a custom libcxx

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -698,8 +698,13 @@ endif
 # Custom libcxx
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
 LDFLAGS += -L$(build_libdir) -lc++abi
-CXXLDFLAGS += -L$(build_libdir) -lc++abi -stdlib=libc++
+CXXLDFLAGS += -L$(build_libdir) -lc++abi -stdlib=libc++ -lc++
 CPPFLAGS += -I$(build_includedir)/c++/v1
+ifeq ($(USEICC),1)
+CXXFLAGS += -cxxlib-nostd -static-intel
+CLDFLAGS += -static-intel
+LDFLAGS += -cxxlib-nostd -static-intel
+endif
 endif
 
 # Make tricks

--- a/Make.inc
+++ b/Make.inc
@@ -291,6 +291,12 @@ DEBUGFLAGS = -O0 -ggdb3 -DJL_DEBUG_BUILD -fstack-protector-all
 SHIPFLAGS = -O3 -g -falign-functions
 endif
 
+ifneq ($(USEICC),1)
+JCFLAGS += -m$(BINARY)
+JCXXFLAGS += -m$(BINARY)
+JFFLAGS += -m$(BINARY)
+endif
+
 ifeq ($(LLVM_VER),svn)
 JCXXFLAGS += -std=c++11
 endif
@@ -431,9 +437,6 @@ BINARY=64
 else
 $(error "unknown word-size for arch: $(ARCH)")
 endif
-CC += -m$(BINARY)
-CXX += -m$(BINARY)
-FC += -m$(BINARY)
 
 ifeq ($(USEGCC),1)
 ifneq ($(ARCH), ppc64)
@@ -690,6 +693,13 @@ LIBBLAS = -L$(ATLAS_LIBDIR) -lsatlas
 LIBLAPACK = $(LIBBLAS)
 LIBBLASNAME = libsatlas
 LIBLAPACKNAME = $(LIBBLASNAME)
+endif
+
+# Custom libcxx
+ifeq ($(BUILD_CUSTOM_LIBCXX),1)
+LDFLAGS += -L$(build_libdir) -lc++abi
+CXXLDFLAGS += -L$(build_libdir) -lc++abi -stdlib=libc++
+CPPFLAGS += -I$(build_includedir)/c++/v1
 endif
 
 # Make tricks

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -352,10 +352,13 @@ libcxx-build/lib/libc++.so: install-libcxxabi
 $(build_libdir)/libc++.so: libcxx-build/lib/libc++.so
 	cd libcxx-build && $(MAKE) install
 install-libcxx: $(build_libdir)/libc++.so
+get-libcxx: llvm-$(LLVM_VER)/projects/libcxx
+get-libcxxabi: llvm-$(LLVM_VER)/projects/libcxxabi
 endif
 
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
-	LIBCXX_DEPENDENCY = install-libcxx
+LIBCXX_DEPENDENCY = install-libcxx
+LIBCXX_GET_DEPENDENCY = get-libcxx get-libcxxabi
 endif
 
 llvm-$(LLVM_VER)/configure: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) $(LIBCXX_DEPENDENCY)
@@ -474,7 +477,11 @@ clean-llvm:
 distclean-llvm:
 	-rm -rf llvm-$(LLVM_VER).tar.gz llvm-$(LLVM_VER).src.tar.gz clang-$(LLVM_VER).src.tar.gz clang-$(LLVM_VER).tar.gz libcxx-$(LLVM_VER).src.tar.gz compiler-rt-$(LLVM_VER).src.tar.gz llvm-$(LLVM_VER)
 
+ifneq ($(LLVM_VER),svn)
 get-llvm: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR)
+else
+get-llvm: llvm-$(LLVM_VER)/configure $(LIBCXX_GET_DEPENDENCY)
+endif
 configure-llvm: llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE)/config.status
 compile-llvm: $(LLVM_OBJ_SOURCE)
 check-llvm: llvm-$(LLVM_VER)/build_$(LLVM_BUILDTYPE)/checked

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -402,6 +402,10 @@ ifneq ($(LLVM_CLANG_TAR),)
 	mkdir -p llvm-$(LLVM_VER)/tools/clang && \
 	$(TAR) -C llvm-$(LLVM_VER)/tools/clang --strip-components 1 -xf $(LLVM_CLANG_TAR)
 endif
+ifneq ($(LLVM_COMPILER_RT_TAR),)
+	mkdir -p llvm-$(LLVM_VER)/projects/compiler-rt && \
+	$(TAR) -C llvm-$(LLVM_VER)/projects/compiler-rt --strip-components 1 -xf $(LLVM_COMPILER_RT_TAR)
+endif
 else
 ifeq ($(BUILD_LLVM_CLANG),1)
 	([ ! -d llvm-$(LLVM_VER)/tools/clang ] && \

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -328,6 +328,12 @@ else
 endif
 
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
+
+LIBCXX_OPTIONS = OPTIONS="-I../../libcxx/include $(CXXFLAGS) $(LDFLAGS)" CC="$(CC) $(CFLAGS)" CXX="$(CXX)"
+ifeq ($(USEICC),1)
+LIBCXX_OPTIONS += EXTRA_LIBS="-Bstatic -lirc"
+endif
+
 llvm-$(LLVM_VER)/projects/libcxx: $(LLVM_LIBCXX_TAR)
 	([ ! -d llvm-$(LLVM_VER)/projects/libcxx ] && \
 	git clone $(LLVM_GIT_URL_LIBCXX) llvm-$(LLVM_VER)/projects/libcxx  ) || \
@@ -345,7 +351,7 @@ libcxx-build/Makefile: llvm-$(LLVM_VER)/projects/libcxx | llvm-$(LLVM_VER)/proje
 		cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_LIBCXXABI_INCLUDE_PATHS="../llvm-$(LLVM_VER)/projects/libcxxabi/include" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(build_prefix) ../llvm-$(LLVM_VER)/projects/libcxx -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)"  -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir) -Bstatic -lirc -Bdynamic" -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
 llvm-$(LLVM_VER)/projects/libcxxabi/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi | llvm-$(LLVM_VER)/projects/libcxx
 	cd llvm-$(LLVM_VER)/projects/libcxxabi/lib && \
-	OPTIONS="-I../../libcxx/include $(CXXFLAGS) $(LDFLAGS)" CC="$(CC) -static-intel" EXTRA_LIBS="-Bstatic -lirc" CXX="$(CXX)" ./buildit
+	$(LIBCXX_OPTIONS) ./buildit
 $(build_libdir)/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi/libc++abi.so.1.0
 	cp llvm-$(LLVM_VER)/projects/libcxxabi/lib/libc++abi.so.1.0 $(build_libdir)
 	ln -s $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++abi.so
@@ -365,7 +371,7 @@ LIBCXX_DEPENDENCY = $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++.so.1
 LIBCXX_GET_DEPENDENCY = get-libcxx get-libcxxabi
 endif
 
-llvm-$(LLVM_VER)/configure: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) $(LIBCXX_DEPENDENCY)
+llvm-$(LLVM_VER)/configure: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) | $(LIBCXX_DEPENDENCY)
 ifneq ($(LLVM_CLANG_TAR),)
 	$(JLCHECKSUM) $(LLVM_CLANG_TAR)
 endif
@@ -497,12 +503,18 @@ install-llvm: $(LLVM_OBJ_TARGET)
 
 UV_SRC_TARGET = libuv/.libs/libuv.a
 UV_OBJ_TARGET = $(build_libdir)/libuv.a
-ifneq ($(USEMSVC), 1)
-UV_OPTS =
-else
-UV_OPTS = CFLAGS=-DBUILDING_UV_SHARED
+UV_CFLAGS = 
+ifeq ($(USEMSVC), 1)
+UV_CFLAGS += -DBUILDING_UV_SHARED
 endif
-UV_OPTS += LDFLAGS="$(CLDFLAGS) -v" CFLAGS="-static-intel"
+ifeq ($(USEICC), 1)
+UV_CFLAGS += -static-intel
+endif
+
+UV_OPTS += LDFLAGS="$(CLDFLAGS) -v"
+ifneq ($(UV_CFLAGS),)
+UV_OPTS += CFLAGS="$(UV_CFLAGS)"
+endif
 
 libuv/configure:
 	(cd .. && git submodule init && git submodule update)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -284,6 +284,9 @@ LLVM_MFLAGS += $(LLVM_CC)
 
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
 LLVM_LDFLAGS += -Wl,-R$(build_libdir)
+ifeq ($(USEICC),1)
+LLVM_LDFLAGS += -no_cpprt -lc++ -lc++abi
+endif
 endif
 
 LLVM_FLAGS += CPPFLAGS="$(CPPFLAGS) $(LLVM_CPPFLAGS)" LDFLAGS="$(LLVM_LDFLAGS)"
@@ -339,25 +342,25 @@ libcxx-build:
 	mkdir -p libcxx-build
 libcxx-build/Makefile: llvm-$(LLVM_VER)/projects/libcxx llvm-$(LLVM_VER)/projects/libcxxabi libcxx-build
 	cd libcxx-build && \
-		cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_LIBCXXABI_INCLUDE_PATHS="../llvm-$(LLVM_VER)/projects/libcxxabi/include" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(build_prefix) ../llvm-$(LLVM_VER)/projects/libcxx -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)"  -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir)"
-$(build_libdir)/libc++abi.so: llvm-$(LLVM_VER)/projects/libcxxabi
+		cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_LIBCXXABI_INCLUDE_PATHS="../llvm-$(LLVM_VER)/projects/libcxxabi/include" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(build_prefix) ../llvm-$(LLVM_VER)/projects/libcxx -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)"  -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir) -Bstatic -lirc -Bdynamic" -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
+$(build_libdir)/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi
 	cd llvm-$(LLVM_VER)/projects/libcxxabi/lib && \
-	OPTIONS=-I../../libcxx/include ./buildit
+	OPTIONS="-I../../libcxx/include $(CXXFLAGS) $(LDFLAGS)" CC="$(CC) -static-intel" EXTRA_LIBS="-Bstatic -lirc" CXX=$(CXX) ./buildit
 	cp llvm-$(LLVM_VER)/projects/libcxxabi/lib/libc++abi.so.1.0 $(build_libdir)
 	ln -s $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++abi.so
 	ln -s $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++abi.so.1
 install-libcxxabi: $(build_libdir)/libc++abi.so
-libcxx-build/lib/libc++.so: install-libcxxabi
+libcxx-build/lib/libc++.so.1.0: $(build_libdir)/libc++abi.so libcxx-build/Makefile
 	cd libcxx-build && $(MAKE)
-$(build_libdir)/libc++.so: libcxx-build/lib/libc++.so
+$(build_libdir)/libc++.so.1.0: libcxx-build/lib/libc++.so.1.0
 	cd libcxx-build && $(MAKE) install
-install-libcxx: $(build_libdir)/libc++.so
+install-libcxx: $(build_libdir)/libc++.so.1.0
 get-libcxx: llvm-$(LLVM_VER)/projects/libcxx
 get-libcxxabi: llvm-$(LLVM_VER)/projects/libcxxabi
 endif
 
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
-LIBCXX_DEPENDENCY = install-libcxx
+LIBCXX_DEPENDENCY = $(build_libdir)/libc++abi.so 
 LIBCXX_GET_DEPENDENCY = get-libcxx get-libcxxabi
 endif
 
@@ -498,6 +501,7 @@ UV_OPTS =
 else
 UV_OPTS = CFLAGS=-DBUILDING_UV_SHARED
 endif
+UV_OPTS += LDFLAGS="$(CLDFLAGS) -v" CFLAGS="-static-intel"
 
 libuv/configure:
 	(cd .. && git submodule init && git submodule update)
@@ -516,7 +520,7 @@ $(UV_SRC_TARGET): libuv/config.status
 	touch -c libuv/Makefile.in
 	touch -c libuv/configure
 	touch -c libuv/config.status
-	$(MAKE) -C libuv
+	$(MAKE) -C libuv $(UV_OPTS)
 	touch -c $@
 libuv/checked: $(UV_SRC_TARGET)
 ifeq ($(OS),$(BUILD_OS))
@@ -589,7 +593,7 @@ install-pcre: $(PCRE_OBJ_TARGET)
 GRISU_OPTS = $(CXXFLAGS) -O3 -fvisibility=hidden $(fPIC)
 GRISU_OBJ_TARGET = $(build_shlibdir)/libgrisu.$(SHLIB_EXT)
 
-double-conversion-$(GRISU_VER).tar.gz:
+double-conversion-$(GRISU_VER).tar.gz: $(LIBCXX_DEPENDENCY)
 	$(JLDOWNLOAD) $@ http://double-conversion.googlecode.com/files/$@
 	touch -c $@
 double-conversion-$(GRISU_VER)/Makefile: double-conversion-$(GRISU_VER).tar.gz

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -345,7 +345,7 @@ libcxx-build/Makefile: llvm-$(LLVM_VER)/projects/libcxx | llvm-$(LLVM_VER)/proje
 		cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_LIBCXXABI_INCLUDE_PATHS="../llvm-$(LLVM_VER)/projects/libcxxabi/include" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(build_prefix) ../llvm-$(LLVM_VER)/projects/libcxx -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)"  -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir) -Bstatic -lirc -Bdynamic" -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
 llvm-$(LLVM_VER)/projects/libcxxabi/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi
 	cd llvm-$(LLVM_VER)/projects/libcxxabi/lib && \
-	OPTIONS="-I../../libcxx/include $(CXXFLAGS) $(LDFLAGS)" CC="$(CC) -static-intel" EXTRA_LIBS="-Bstatic -lirc" CXX=$(CXX) ./buildit
+	OPTIONS="-I../../libcxx/include $(CXXFLAGS) $(LDFLAGS)" CC="$(CC) -static-intel" EXTRA_LIBS="-Bstatic -lirc" CXX="$(CXX)" ./buildit
 $(build_libdir)/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi/libc++abi.so.1.0
 	cp llvm-$(LLVM_VER)/projects/libcxxabi/lib/libc++abi.so.1.0 $(build_libdir)
 	ln -s $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++abi.so

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -340,17 +340,18 @@ llvm-$(LLVM_VER)/projects/libcxxabi: $(LLVM_LIBCXXABI_TAR)
 	git pull --ff-only)
 libcxx-build:
 	mkdir -p libcxx-build
-libcxx-build/Makefile: llvm-$(LLVM_VER)/projects/libcxx llvm-$(LLVM_VER)/projects/libcxxabi libcxx-build
+libcxx-build/Makefile: llvm-$(LLVM_VER)/projects/libcxx | llvm-$(LLVM_VER)/projects/libcxxabi libcxx-build
 	cd libcxx-build && \
 		cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_LIBCXXABI_INCLUDE_PATHS="../llvm-$(LLVM_VER)/projects/libcxxabi/include" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(build_prefix) ../llvm-$(LLVM_VER)/projects/libcxx -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)"  -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir) -Bstatic -lirc -Bdynamic" -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
-$(build_libdir)/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi
+llvm-$(LLVM_VER)/projects/libcxxabi/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi
 	cd llvm-$(LLVM_VER)/projects/libcxxabi/lib && \
 	OPTIONS="-I../../libcxx/include $(CXXFLAGS) $(LDFLAGS)" CC="$(CC) -static-intel" EXTRA_LIBS="-Bstatic -lirc" CXX=$(CXX) ./buildit
+$(build_libdir)/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi/libc++abi.so.1.0
 	cp llvm-$(LLVM_VER)/projects/libcxxabi/lib/libc++abi.so.1.0 $(build_libdir)
 	ln -s $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++abi.so
 	ln -s $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++abi.so.1
 install-libcxxabi: $(build_libdir)/libc++abi.so
-libcxx-build/lib/libc++.so.1.0: $(build_libdir)/libc++abi.so libcxx-build/Makefile
+libcxx-build/lib/libc++.so.1.0: | $(build_libdir)/libc++abi.so.1.0 libcxx-build/Makefile
 	cd libcxx-build && $(MAKE)
 $(build_libdir)/libc++.so.1.0: libcxx-build/lib/libc++.so.1.0
 	cd libcxx-build && $(MAKE) install
@@ -360,7 +361,7 @@ get-libcxxabi: llvm-$(LLVM_VER)/projects/libcxxabi
 endif
 
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
-LIBCXX_DEPENDENCY = $(build_libdir)/libc++abi.so 
+LIBCXX_DEPENDENCY = $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++.so.1.0
 LIBCXX_GET_DEPENDENCY = get-libcxx get-libcxxabi
 endif
 
@@ -593,7 +594,7 @@ install-pcre: $(PCRE_OBJ_TARGET)
 GRISU_OPTS = $(CXXFLAGS) -O3 -fvisibility=hidden $(fPIC)
 GRISU_OBJ_TARGET = $(build_shlibdir)/libgrisu.$(SHLIB_EXT)
 
-double-conversion-$(GRISU_VER).tar.gz: $(LIBCXX_DEPENDENCY)
+double-conversion-$(GRISU_VER).tar.gz: 
 	$(JLDOWNLOAD) $@ http://double-conversion.googlecode.com/files/$@
 	touch -c $@
 double-conversion-$(GRISU_VER)/Makefile: double-conversion-$(GRISU_VER).tar.gz
@@ -603,7 +604,7 @@ double-conversion-$(GRISU_VER)/Makefile: double-conversion-$(GRISU_VER).tar.gz
 	touch -c $@
 
 ifeq ($(USE_SYSTEM_GRISU), 0)
-$(GRISU_OBJ_TARGET): double-conversion-$(GRISU_VER)/Makefile
+$(GRISU_OBJ_TARGET): double-conversion-$(GRISU_VER)/Makefile $(LIBCXX_DEPENDENCY)
 	cd double-conversion-$(GRISU_VER) && \
 	$(CXX) -c $(GRISU_OPTS) -o src/bignum.o -Isrc src/bignum.cc && \
 	$(CXX) -c $(GRISU_OPTS) -o src/bignum-dtoa.o -Isrc src/bignum-dtoa.cc && \

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -160,6 +160,8 @@ LLVM_GIT_URL_LLVM ?= $(LLVM_GIT_URL_BASE)/llvm.git
 LLVM_GIT_URL_CLANG ?= $(LLVM_GIT_URL_BASE)/clang.git
 LLVM_GIT_URL_COMPILER_RT ?= $(LLVM_GIT_URL_BASE)/compiler-rt.git
 LLVM_GIT_URL_LLDB ?= $(LLVM_GIT_URL_BASE)/lldb.git
+LLVM_GIT_URL_LIBCXX ?= $(LLVM_GIT_URL_BASE)/libcxx.git
+LLVM_GIT_URL_LIBCXXABI ?= $(LLVM_GIT_URL_BASE)/libcxxabi.git
 
 ifeq ($(BUILD_LLDB), 1)
 BUILD_LLVM_CLANG = 1
@@ -197,11 +199,9 @@ LLVM_COMPILER_RT_TAR=
 else ifeq ($(LLVM_VER), 3.3)
 LLVM_CLANG_TAR=cfe-$(LLVM_VER).src.tar.gz
 LLVM_COMPILER_RT_TAR=compiler-rt-$(LLVM_VER).src.tar.gz
-LLVM_LIBCXX_TAR=libcxx-$(LLVM_VER).src.tar.gz
 else
 LLVM_CLANG_TAR=clang-$(LLVM_VER).src.tar.gz
 LLVM_COMPILER_RT_TAR=compiler-rt-$(LLVM_VER).src.tar.gz
-LLVM_LIBCXX_TAR=libcxx-$(LLVM_VER).src.tar.gz
 endif
 else
 LLVM_CLANG_TAR=
@@ -210,7 +210,15 @@ LLVM_LIBCXX_TAR=
 endif
 endif
 
-LLVM_CXXFLAGS =
+ifeq ($(BUILD_CUSTOM_LIBCXX),1)
+ifneq ($(LLVM_VER),svn)
+LLVM_LIBCXX_TAR=libcxx-$(LLVM_VER).src.tar.gz
+endif
+endif
+
+LLVM_CXXFLAGS = $(CXXFLAGS)
+LLVM_CPPFLAGS =
+LLVM_LDFLAGS = $(LDFLAGS)
 LLVM_TARGET_FLAGS= --enable-targets=host
 LLVM_FLAGS += --disable-profiling --enable-shared --enable-static $(LLVM_TARGET_FLAGS) --disable-bindings --disable-docs
 LLVM_MFLAGS =
@@ -232,7 +240,7 @@ LLVM_FLAGS += --enable-libcpp
 endif
 ifeq ($(OS), WINNT)
 LLVM_FLAGS += --with-extra-ld-options="-Wl,--stack,8388608" LDFLAGS="" --disable-shared
-LLVM_MFLAGS += CPPFLAGS="-D__USING_SJLJ_EXCEPTIONS__ -D__CRT__NO_INLINE"
+LLVM_CPPFLAGS += -D__USING_SJLJ_EXCEPTIONS__ -D__CRT__NO_INLINE
 endif
 ifeq ($(USE_INTEL_JITEVENTS), 1)
 LLVM_FLAGS += --with-intel-jitevents
@@ -260,7 +268,8 @@ endif
 
 
 ifeq ($(LLVM_SANITIZE),1)
-LLVM_CC = CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
+LLVM_CC = CFLAGS="-fsanitize=address"
+LLVM_LDFLAGS += -fsanitize=address
 LLVM_CXXFLAGS += -fsanitize=address
 LLVM_MFLAGS += TOOL_NO_EXPORTS= HAVE_LINK_VERSION_SCRIPT=0
 else
@@ -272,6 +281,13 @@ LLVM_FLAGS += CXXFLAGS="$(LLVM_CXXFLAGS)"
 LLVM_MFLAGS += CXXFLAGS="$(LLVM_CXXFLAGS)"
 endif
 LLVM_MFLAGS += $(LLVM_CC)
+
+ifeq ($(BUILD_CUSTOM_LIBCXX),1)
+LLVM_LDFLAGS += -Wl,-R$(build_libdir)
+endif
+
+LLVM_FLAGS += CPPFLAGS="$(CPPFLAGS) $(LLVM_CPPFLAGS)" LDFLAGS="$(LLVM_LDFLAGS)"
+LLVM_MFLAGS += CPPFLAGS="$(CPPFLAGS) $(LLVM_CPPFLAGS)" LDFLAGS="$(LLVM_LDFLAGS)"
 
 ifneq ($(LLVM_CLANG_TAR),)
 $(LLVM_CLANG_TAR):
@@ -308,14 +324,47 @@ else
   LLVM_FLAGS += --with-python="$(shell ./find_python_for_llvm)"
 endif
 
-llvm-$(LLVM_VER)/configure: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR)
+ifeq ($(BUILD_CUSTOM_LIBCXX),1)
+llvm-$(LLVM_VER)/projects/libcxx: $(LLVM_LIBCXX_TAR)
+	([ ! -d llvm-$(LLVM_VER)/projects/libcxx ] && \
+	git clone $(LLVM_GIT_URL_LIBCXX) llvm-$(LLVM_VER)/projects/libcxx  ) || \
+	(cd llvm-$(LLVM_VER)/projects/libcxx  && \
+	git pull --ff-only)
+llvm-$(LLVM_VER)/projects/libcxxabi: $(LLVM_LIBCXXABI_TAR)
+	([ ! -d llvm-$(LLVM_VER)/projects/libcxxabi ] && \
+	git clone $(LLVM_GIT_URL_LIBCXXABI) llvm-$(LLVM_VER)/projects/libcxxabi  ) || \
+	(cd llvm-$(LLVM_VER)/projects/libcxxabi  && \
+	git pull --ff-only)
+libcxx-build:
+	mkdir -p libcxx-build
+libcxx-build/Makefile: llvm-$(LLVM_VER)/projects/libcxx llvm-$(LLVM_VER)/projects/libcxxabi libcxx-build
+	cd libcxx-build && \
+		cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_LIBCXXABI_INCLUDE_PATHS="../llvm-$(LLVM_VER)/projects/libcxxabi/include" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(build_prefix) ../llvm-$(LLVM_VER)/projects/libcxx -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)"  -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir)"
+$(build_libdir)/libc++abi.so: llvm-$(LLVM_VER)/projects/libcxxabi
+	cd llvm-$(LLVM_VER)/projects/libcxxabi/lib && \
+	OPTIONS=-I../../libcxx/include ./buildit
+	cp llvm-$(LLVM_VER)/projects/libcxxabi/lib/libc++abi.so.1.0 $(build_libdir)
+	ln -s $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++abi.so
+	ln -s $(build_libdir)/libc++abi.so.1.0 $(build_libdir)/libc++abi.so.1
+install-libcxxabi: $(build_libdir)/libc++abi.so
+libcxx-build/lib/libc++.so: install-libcxxabi
+	cd libcxx-build && $(MAKE)
+$(build_libdir)/libc++.so: libcxx-build/lib/libc++.so
+	cd libcxx-build && $(MAKE) install
+install-libcxx: $(build_libdir)/libc++.so
+endif
+
+ifeq ($(BUILD_CUSTOM_LIBCXX),1)
+	LIBCXX_DEPENDENCY = install-libcxx
+endif
+
+llvm-$(LLVM_VER)/configure: $(LLVM_TAR) $(LLVM_CLANG_TAR) $(LLVM_COMPILER_RT_TAR) $(LLVM_LIBCXX_TAR) $(LIBCXX_DEPENDENCY)
 ifneq ($(LLVM_CLANG_TAR),)
 	$(JLCHECKSUM) $(LLVM_CLANG_TAR)
 endif
 ifneq ($(LLVM_COMPILER_RT_TAR),)
 	$(JLCHECKSUM) $(LLVM_COMPILER_RT_TAR)
 endif
-
 ifneq ($(LLVM_LIBCXX_TAR),)
 	$(JLCHECKSUM) $(LLVM_LIBCXX_TAR)
 endif
@@ -345,19 +394,10 @@ ifeq ($(BUILD_LLVM_CLANG),1)
 	([ ! -d llvm-$(LLVM_VER)/tools/clang ] && \
 		git clone $(LLVM_GIT_URL_CLANG) llvm-$(LLVM_VER)/tools/clang  ) || \
 		(cd llvm-$(LLVM_VER)/tools/clang  && \
-		git pull --ff-only)	
+		git pull --ff-only)
 endif
 endif
-ifneq ($(LLVM_VER),svn)
-ifneq ($(LLVM_COMPILER_RT_TAR),)
-	mkdir -p llvm-$(LLVM_VER)/projects/compiler-rt && \
-	$(TAR) -C llvm-$(LLVM_VER)/projects/compiler-rt --strip-components 1 -xf $(LLVM_COMPILER_RT_TAR)
-endif
-ifneq ($(LLVM_LIBCXX_TAR),)
-	mkdir -p llvm-$(LLVM_VER)/projects/libcxx && \
-	$(TAR) -C llvm-$(LLVM_VER)/projects/libcxx --strip-components 1 -xf $(LLVM_LIBCXX_TAR)
-endif
-else
+ifeq ($(LLVM_VER),svn)
 ifeq ($(BUILD_LLVM_CLANG),1)
 	([ ! -d llvm-$(LLVM_VER)/tools/clang ] && \
 		git clone $(LLVM_GIT_URL_CLANG) llvm-$(LLVM_VER)/tools/clang  ) || \

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -343,7 +343,7 @@ libcxx-build:
 libcxx-build/Makefile: llvm-$(LLVM_VER)/projects/libcxx | llvm-$(LLVM_VER)/projects/libcxxabi libcxx-build
 	cd libcxx-build && \
 		cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_LIBCXXABI_INCLUDE_PATHS="../llvm-$(LLVM_VER)/projects/libcxxabi/include" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(build_prefix) ../llvm-$(LLVM_VER)/projects/libcxx -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_COMPILER="$(CXX)"  -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir) -Bstatic -lirc -Bdynamic" -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
-llvm-$(LLVM_VER)/projects/libcxxabi/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi
+llvm-$(LLVM_VER)/projects/libcxxabi/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi | llvm-$(LLVM_VER)/projects/libcxx
 	cd llvm-$(LLVM_VER)/projects/libcxxabi/lib && \
 	OPTIONS="-I../../libcxx/include $(CXXFLAGS) $(LDFLAGS)" CC="$(CC) -static-intel" EXTRA_LIBS="-Bstatic -lirc" CXX="$(CXX)" ./buildit
 $(build_libdir)/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi/libc++abi.so.1.0

--- a/src/Makefile
+++ b/src/Makefile
@@ -88,7 +88,7 @@ CXXLD = $(LD) -dll -export:jl_setjmp -export:jl_longjmp
 endif
 
 $(build_shlibdir)/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp-debug.a support/libsupport-debug.a $(LIBUV)
-	@$(call PRINT_LINK, $(CXXLD) $(DEBUGFLAGS) $(DOBJS) $(RPATH_ORIGIN) -o $@ $(LDFLAGS) $(DEBUG_LIBS))
+	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(DEBUGFLAGS) $(DOBJS) $(RPATH_ORIGIN) -o $@ $(LDFLAGS) $(DEBUG_LIBS))
 	$(INSTALL_NAME_CMD)libjulia-debug.$(SHLIB_EXT) $@
 	$(DSYMUTIL) $@
 libjulia-debug.a: julia.expmap $(DOBJS) flisp/libflisp-debug.a support/libsupport-debug.a
@@ -103,7 +103,7 @@ else
 endif
 
 $(build_shlibdir)/libjulia.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a $(LIBUV)
-	@$(call PRINT_LINK, $(CXXLD) $(SHIPFLAGS) $(OBJS) $(RPATH_ORIGIN) -o $@ $(LDFLAGS) $(RELEASE_LIBS) $(SONAME))
+	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(SHIPFLAGS) $(OBJS) $(RPATH_ORIGIN) -o $@ $(LDFLAGS) $(RELEASE_LIBS) $(SONAME)) $(CXXLDFLAGS)
 	$(INSTALL_NAME_CMD)libjulia.$(SHLIB_EXT) $@
 	$(DSYMUTIL) $@
 libjulia.a: julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -80,7 +80,7 @@ endif
 endif
 
 $(EXENAME): $(OBJS) $(LIBFILES) $(LIBTARGET).a flmain.o
-	@$(call PRINT_LINK, $(CCLD) $(SHIPFLAGS) $(OBJS) flmain.o $(LDFLAGS) -o $(EXENAME) $(LIBTARGET).a $(LIBS) $(OSLIBS))
+	@$(call PRINT_LINK, $(CCLD) $(SHIPFLAGS) $(OBJS) flmain.o -o $(EXENAME) $(LIBTARGET).a $(LIBS) $(OSLIBS))
 ifneq ($(USEMSVC), 1)
 	$(call spawn,./$(EXENAME)) unittest.lsp
 endif

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -65,9 +65,9 @@ CXXLD = $(LD)
 endif
 
 $(build_bindir)/julia$(EXE): repl.o
-	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -ljulia $(JLDFLAGS))
+	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -ljulia $(JLDFLAGS) $(CXXLDFLAGS))
 $(build_bindir)/julia-debug$(EXE): repl.do
-	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -ljulia-debug $(JLDFLAGS))
+	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -ljulia-debug $(JLDFLAGS) $(CXXLDFLAGS))
 
 clean: | $(CLEAN_TARGETS)
 	rm -f *.o *.do

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -65,9 +65,9 @@ CXXLD = $(LD)
 endif
 
 $(build_bindir)/julia$(EXE): repl.o
-	@$(call PRINT_LINK, $(CXXLD) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -ljulia $(JLDFLAGS))
+	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -ljulia $(JLDFLAGS))
 $(build_bindir)/julia-debug$(EXE): repl.do
-	@$(call PRINT_LINK, $(CXXLD) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -ljulia-debug $(JLDFLAGS))
+	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -ljulia-debug $(JLDFLAGS))
 
 clean: | $(CLEAN_TARGETS)
 	rm -f *.o *.do


### PR DESCRIPTION
This is useful when compiling on a system with an outdated std c++ library,
but you need to build llvm, or when wanting to build julia with msan.

On hold until after 0.3
