### PR TITLE
Avoid out of bounds access in arpack neupd_wrapper

### DIFF
--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -125,7 +125,7 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
     
     if cmplx
 
-        d = Array(T, nev+1)
+        d = zeros(T, nev+1)
         sigmar = ones(T, 1)*sigma
         workev = Array(T, 2ncv)
         neupd(ritzvec, howmny, select, d, v, ldv, sigmar, workev,
@@ -138,7 +138,7 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
 
     elseif sym
 
-        d = Array(T, nev)
+        d = zeros(T, nev)
         sigmar = ones(T, 1)*sigma
         seupd(ritzvec, howmny, select, d, v, ldv, sigmar,
               bmat, n, which, nev, TOL, resid, ncv, v, ldv,
@@ -150,8 +150,8 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
 
     else
 
-        dr     = Array(T, nev+1)
-        di     = Array(T, nev+1)
+        dr     = zeros(T, nev+1)
+        di     = zeros(T, nev+1)
         sigmar = ones(T, 1)*real(sigma)
         sigmai = ones(T, 1)*imag(sigma)
         workev = Array(T, 3*ncv)
@@ -174,6 +174,8 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
                     evec[:,j]   = v[:,j] + im*v[:,j+1]
                     evec[:,j+1] = v[:,j] - im*v[:,j+1]
                     j += 1
+                else
+                    error("Complex eigenvalues must occur in conjugate pairs")
                 end
             end
             j += 1

--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -165,7 +165,7 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
         
         j = 1
         while j <= nev
-            if di[j] == zero(T)
+            if di[j] == 0
                 evec[:,j] = v[:,j]
             else # For complex conjugate pairs
                 evec[:,j]   = v[:,j] + im*v[:,j+1]
@@ -174,8 +174,8 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
             end
             j += 1
         end
-        if j == nev+1 && di[j] !== NaN
-            if di[j] == zero(T)
+        if j == nev+1 && !isnan(di[j])
+            if di[j] == 0
                 evec[:,j] = v[:,j]
                 j += 1
             else

--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -164,12 +164,13 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
         j = 1
         indfake = 0
         while j <= nev+1
-            if abs(complex(dr[j],di[j])) < sqrt(eps(T))*sqrt(nextfloat(zero(T))) # is this a good criterion for really small?
+            # Perhaps there is a better criterion for really small?
+            if abs(complex(dr[j],di[j])) < sqrt(eps(T))*sqrt(nextfloat(zero(T)))
                 indfake = j
             else
                 if di[j] == 0
                     evec[:,j] = v[:,j]
-                else
+                elseif j < nev+1 # For complex conjugate pairs
                     evec[:,j]   = v[:,j] + im*v[:,j+1]
                     evec[:,j+1] = v[:,j] - im*v[:,j+1]
                     j += 1


### PR DESCRIPTION
Trying to avoid out of bounds access in eupd wrapper in JuliaLang/LinearAlgebra.jl#132 

This should really not be happening, since these eigenvalues are in complex conjugate pairs and occur together.

Cc: @jutho
