### PR TITLE
[RFC] Ask user to run testsuite (closes #7745)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,10 @@ $(build_datarootdir)/man/man1/julia.1: doc/man/julia.1 | $(build_datarootdir)/ju
 	@mkdir -p $(build_datarootdir)/man/man1
 	@cp $< $@
 
-$(build_sysconfdir)/julia/juliarc.jl: etc/juliarc.jl | $(build_sysconfdir)/julia
+$(build_sysconfdir)/julia/juliarc.jl: etc/juliarc.jl contrib/testbanner.jl | $(build_sysconfdir)/julia
 	@cp $< $@
+	# Copy in testing banner julia snippet to juliarc.jl
+	-cat ./contrib/testbanner.jl >> $(build_sysconfdir)/julia/juliarc.jl
 ifeq ($(OS), WINNT)
 	@cat ./contrib/windows/juliarc.jl >> $(build_sysconfdir)/julia/juliarc.jl
 $(build_sysconfdir)/julia/juliarc.jl: contrib/windows/juliarc.jl

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -346,3 +346,35 @@ function workspace()
     empty!(package_locks)
     nothing
 end
+
+function runtests(test_names...)
+    if length(test_names) == 0
+        test_names = ["all"]
+    else
+        test_names = [z for z in test_names]
+    end
+    ARGS = test_names
+    cd(joinpath(JULIA_HOME,"../share/julia/test/")) do
+        include("runtests.jl")
+    end
+
+    # Once we've run this for this version, silence it from happening again
+    if test_names == ["all"]
+        silence_test_banner()
+    end
+end
+
+function get_firstboot_version()
+    firstboot = joinpath(Pkg.Dir._pkgroot(),".firstboot")
+
+    try
+        return convert(VersionNumber,readchomp(open(firstboot)))
+    end
+    return nothing
+end
+
+function silence_test_banner()
+    firstboot = joinpath(Pkg.Dir._pkgroot(),".firstboot")
+    write(open(firstboot, "w"), string(Base.VERSION))
+    return
+end

--- a/contrib/testbanner.jl
+++ b/contrib/testbanner.jl
@@ -1,0 +1,11 @@
+# Check for existence of version file telling us the last version we tested
+if isinteractive()
+    vers = Base.get_firstboot_version()
+    if vers == nothing || vers < Base.VERSION
+        print("It looks like this version of Julia is new on this machine. ")
+        print("Please run the testsuite to ensure proper setup by typing ")
+        print_with_color(:red, "Base.runtests() ")
+        print("at the repl, or silence this message for this version of julia by typing ")
+        print_with_color(:red, "Base.silence_test_banner()\n")
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ testnames = [
 # parallel tests depend on other workers - do them last
 push!(testnames, "parallel")
 
-tests = ARGS==["all"] ? testnames : ARGS
+tests = (ARGS == ["all"] || isempty(ARGS)) ? testnames : ARGS
 
 if "linalg" in tests
     # specifically selected case


### PR DESCRIPTION
- Change `runtests.jl` so that when run without arguments, it assumes `"all"` was passed.
- Add functions to `interactiveutil.jl` that allow for getting and setting of a version string in `~/.julia/.firstboot` that notifies julia as to whether or not the current gitsha has been tested against the test suite
- Add a snippet into `etc/julia/juliarc.jl` to check for that file and determine whether it should nag the user.

So this approach may be a _little_ overkill, but I thought it was nice to think through a way that we can have "first-time setup" logic embedded into Julia.  If this isn't the way we want to do it, then we should probably find another way to do it, but this way seemed easiest.  The reason I squirrel the data away into `~/.julia` is because `Pkg.Dir._pkgroot()` is the only directory I know of that I will almost always have write access to.

If we want, we can make a `Base.silence_test_banner(forever=true)` that just writes out `1000.0.0` to `~/.julia/.firstboot`, and then it would never bother the user again.
