### PR TITLE
Add sinpi and cospi to vectorized functions

### DIFF
--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -336,7 +336,7 @@ elementwise::
     airy airyai airyaiprime airybi airybiprime airyprime
     acos acosh asin asinh atan atan2 atanh
     acsc acsch asec asech acot acoth
-    cos  cosh  sin  sinh  tan  tanh  sinc  cosc
+    cos  cospi cosh  sin  sinpi sinh  tan  tanh  sinc  cosc
     csc  csch  sec  sech  cot  coth
     acosd asind atand asecd acscd acotd
     cosd  sind  tand  secd  cscd  cotd


### PR DESCRIPTION
sinpi and cospi were missing from the list of built-in vectorized functions. I have added them next to sin and cos respectively in the doc.
