### PR TITLE
Use NTFS junctions to share/julia/base etc instead of Cygwin symlinks

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -706,6 +706,8 @@ $$(subst $$(abspath $(JULIAHOME))/,,$$(abspath $(2)/$(1))): $$(abspath $(2)/$(1)
 $$(abspath $(2)/$(1)): | $$(abspath $(2))
 ifeq ($(BUILD_OS), WINNT)
 	@cmd //C mklink //J $$(call mingw_to_dos,$(2)/$(1),cd $(2) &&) $$(call mingw_to_dos,$(1),)
+else ifneq (,$(findstring CYGWIN,$(BUILD_OS)))
+	@cmd /C mklink /J $$(call cygpath_w,$(2)/$(1)) $$(call cygpath_w,$(1))
 else ifdef JULIA_VAGRANT_BUILD
 	@cp -R $$(abspath $(1)) $$@
 else


### PR DESCRIPTION
I would've committed this straight to master if @StefanKarpinski hadn't just reverted a feature addition.

This switches from using Cygwin symlinks, which only Cygwin applications can read, to NTFS junctions (as we're using in the MSYS build) for `share/julia/base`, `share/julia/doc`, and `share/julia/examples`, and `share/julia/test`. This allows the from-source Julia build in a Cygwin-to-MinGW cross-compile to reference files with the same paths relative to `JULIA_HOME` as a binary install.
