### PR TITLE
Update Travis CI build to try building docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,5 @@ script:
     - cp /tmp/julia/lib/julia/sys.ji local.ji && /tmp/julia/bin/julia-debug -J local.ji -e 'true' && rm local.ji
     - cd /tmp/julia/share/julia/test && /tmp/julia/bin/julia-debug --check-bounds=yes runtests.jl all && /tmp/julia/bin/julia-debug --check-bounds=yes runtests.jl pkg
     - cd - && mv julia2 julia
+    - cd julia && make -C doc html SPHINXOPTS="-n -v -v" && make -C doc latexpdf SPHINXOPTS="-n -v -v"
     - echo "Ready for packaging..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
         sudo apt-get install zlib1g-dev;
         sudo add-apt-repository ppa:staticfloat/julia-deps -y;
         sudo apt-get update -qq -y;
-        sudo apt-get install patchelf gfortran llvm-3.3-dev libsuitesparse-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libopenlibm-dev librmath-dev libmpfr-dev -y;
+        sudo apt-get install patchelf gfortran llvm-3.3-dev libsuitesparse-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libopenlibm-dev librmath-dev libmpfr-dev texlive-latex-base -y;
       elif [ `uname` = "Darwin" ]; then
         brew tap staticfloat/julia;
         brew rm --force $(brew deps --HEAD julia);


### PR DESCRIPTION
This PR adds automatic doctest builds to Travis. By including the doctests as part of the Travis test suite, the hope is to prevent the documentation examples from becoming so far out of sync with reality as to require serious manual updating, as in #7693.

This is the brute force solution to #7691.

Four documentation tests are included here:
- HTML documentation build test
- PDF documentation build test (which can catch some embedded HTMLisms)
- Doctest build test (runs example blocks and compares them with the embedded output)
- Link test (checks that links are still current)
