### PR TITLE
Add awk one-liner to check helpdb.jl build

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -164,4 +164,5 @@ doctest: juliadoc-pkg
 
 helpdb.jl: stdlib/*.rst juliadoc-pkg
 	$(SPHINXBUILD) -b jlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/jlhelp
+	@awk 'BEGIN{n=0} {if(/^$$/) {n++} else {n=0}} (n>1){print "**********************************************************************\nERROR: Your sphinx-build created a helpdb.jl with extraneous newlines.\nInspect $(BUILDDIR)/jlhelp/jlhelp.jl for your current build.\n helpdb.jl NOT updated\n**********************************************************************"; exit(255)}' $(BUILDDIR)/jlhelp/jlhelp.jl
 	mv $(BUILDDIR)/jlhelp/jlhelp.jl helpdb.jl


### PR DESCRIPTION
`make -C doc helpdb.jl` now runs a short awk script that counts the
number of consecutive empty lines in helpdb.jl. If two or more
consecutive empty lines are detected, the awk script throws an error and
prevents `make` from overwriting the current helpdb.jl.

The purpose of this PR is to avoid accidentally check in builds of helpdb.jl with extraneous newlines which occur with certain versions of Sphinx.
