### PR TITLE
RFC: MSVC continued

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -51,6 +51,7 @@ their own licenses:
 - [FFTW](http://fftw.org/doc/License-and-Copyright.html)
 - [GMP](http://gmplib.org/manual/Copying.html#Copying)
 - [MPFR](http://www.mpfr.org/mpfr-current/mpfr.html#Copying)
+- [MUSL](http://git.musl-libc.org/cgit/musl/tree/COPYRIGHT)
 - [OPENBLAS](https://raw.github.com/xianyi/OpenBLAS/master/LICENSE)
 - [LAPACK](http://netlib.org/lapack/LICENSE.txt)
 - [PCRE](http://www.pcre.org/licence.txt)

--- a/Make.inc
+++ b/Make.inc
@@ -634,7 +634,7 @@ JLDFLAGS += -Wl,--large-address-aware
 endif
 else
 OSLIBS += kernel32.lib ws2_32.lib psapi.lib advapi32.lib iphlpapi.lib shell32.lib winmm.lib
-JLDFLAGS =
+JLDFLAGS = -stack:8388608
 endif
 JCPPFLAGS += -D_WIN32_WINNT=0x0600
 UNTRUSTED_SYSTEM_LIBM = 1

--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,14 @@ $(build_private_libdir)/sys%ji: $(build_private_libdir)/sys%o
 .PRECIOUS: $(build_private_libdir)/sys%o
 
 $(build_private_libdir)/sys%$(SHLIB_EXT): $(build_private_libdir)/sys%o
+ifneq ($(USEMSVC), 1)
 	$(CXX) -shared -fPIC -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -o $@ $< \
 		$$([ $(OS) = Darwin ] && echo -Wl,-undefined,dynamic_lookup || echo -Wl,--unresolved-symbols,ignore-all ) \
 		$$([ $(OS) = WINNT ] && echo -ljulia -lssp)
 	$(DSYMUTIL) $@
+else
+	@true
+endif
 
 $(build_private_libdir)/sys0.o:
 	@$(QUIET_JULIA) cd base && \

--- a/base/math.jl
+++ b/base/math.jl
@@ -210,7 +210,7 @@ function frexp(x::Float64)
     k = int(xu >> 52) & 0x07ff
     if k == 0 # x is subnormal
         x == zero(x) && return x,0
-        x *= 0x1p54 # normalise significand
+        x *= 1.8014398509481984e16 # 0x1p54, normalise significand
         xu = reinterpret(Uint64,x)
         k = int(xu >> 52) & 0x07ff - 54
     elseif k == 0x07ff # NaN or Inf

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -49,10 +49,10 @@ function cos_kernel(x::DoubleFloat64)
 end
 
 function sin_kernel(x::DoubleFloat32)
-    S1 = -0x15555554cbac77.0p-55
-    S2 =  0x111110896efbb2.0p-59
-    S3 = -0x1a00f9e2cae774.0p-65
-    S4 =  0x16cd878c3b46a7.0p-71
+    S1 = -0.16666666641626524
+    S2 = 0.008333329385889463
+    S3 = -0.00019839334836096632
+    S4 = 2.718311493989822e-6
     
     z = x.hi*x.hi
     w = z*z
@@ -62,10 +62,10 @@ function sin_kernel(x::DoubleFloat32)
 end
 
 function cos_kernel(x::DoubleFloat32)
-    C0 = -0x1ffffffd0c5e81.0p-54
-    C1 =  0x155553e1053a42.0p-57
-    C2 = -0x16c087e80f1e27.0p-62
-    C3 =  0x199342e0ee5069.0p-68
+    C0 = -0.499999997251031
+    C1 = 0.04166662332373906
+    C2 = -0.001388676377460993
+    C3 = 2.439044879627741e-5
 
     z = x.hi*x.hi
     w = z*z

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -1,0 +1,191 @@
+#!/bin/sh
+# Script to compile Julia in MSYS assuming 7zip is installed and on the path,
+# or Cygwin assuming make, curl, and mingw64-$ARCH-gcc-g++ are installed
+
+# Run in top-level Julia directory
+cd `dirname "$0"`/../..
+# Stop on error
+set -e
+
+# If ARCH environment variable not set, choose based on uname -m
+if [ -z "$ARCH" ]; then
+  export ARCH=`uname -m`
+fi
+if [ $ARCH = x86_64 ]; then
+  bits=64
+  archsuffix=64
+else
+  bits=32
+  archsuffix=86
+fi
+echo "" > Make.user
+
+# Set XC_HOST if in Cygwin
+if [ -n "`uname | grep CYGWIN`" ]; then
+  if [ -z "$XC_HOST" ]; then
+    export XC_HOST="$ARCH-w64-mingw32"
+  fi
+  echo "override BUILD_MACHINE = $ARCH-pc-cygwin" >> Make.user
+  CROSS_COMPILE="$XC_HOST-"
+  # Set HOSTCC if we don't have Cygwin gcc installed
+  if [ -z "`which gcc 2>/dev/null`" ]; then
+    echo 'override HOSTCC = $(CROSS_COMPILE)gcc' >> Make.user
+  fi
+else
+  CROSS_COMPILE=""
+fi
+
+# Download most recent Julia binary for dependencies
+echo "" > get-deps.log
+if ! [ -e julia-installer.exe ]; then
+  f=julia-nightly-win$bits.exe
+  echo "Downloading $f"
+  curl -kLsSo $f http://status.julialang.org/download/win$bits
+  echo "Extracting $f"
+  7z x -y $f >> get-deps.log
+fi
+for i in bin/*.dll Git/bin/msys-1.0.dll Git/bin/msys-perl5_8.dll Git/bin/*.exe; do
+  if [ -z "$(file `which 7z` 2>/dev/null | grep shell)" ]; then
+    # Windows version of 7z.exe, use backslashes
+    7z e -y julia-installer.exe "\$_OUTDIR/$i" \
+      -ousr\\`dirname $i | sed -e 's|/julia||' -e 's|/|\\\\|g'` >> get-deps.log
+  else
+    # p7zip, use forward slashes
+    7z e -y julia-installer.exe "\$_OUTDIR/$i" \
+      -ousr/`dirname $i | sed -e 's|/julia||'` >> get-deps.log
+  fi
+done
+# Remove libjulia.dll if it was copied from downloaded binary
+rm -f usr/bin/libjulia.dll
+rm -f usr/bin/libjulia-debug.dll
+
+mingw=http://sourceforge.net/projects/mingw
+if [ -z "$USEMSVC" ]; then
+  if [ -z "`which ${CROSS_COMPILE}gcc 2>/dev/null`" ]; then
+    f=mingw-w$bits-bin-$ARCH-20140102.7z
+    if ! [ -e $f ]; then
+      echo "Downloading $f"
+      curl -kLOsS $mingw-w64-dgn/files/mingw-w64/$f
+    fi
+    echo "Extracting $f"
+    7z x -y $f >> get-deps.log
+    export PATH=$PATH:$PWD/mingw$bits/bin
+    # If there is a version of make.exe here, it is mingw32-make which won't work
+    rm -f mingw$bits/bin/make.exe
+  fi
+  export AR=${CROSS_COMPILE}ar
+
+  f=llvm-3.3-$ARCH-w64-mingw32-juliadeps.7z
+  # The MinGW binary version of LLVM doesn't include libgtest or libgtest_main
+  mkdir -p usr/lib
+  $AR cr usr/lib/libgtest.a
+  $AR cr usr/lib/libgtest_main.a
+else
+  echo "override USEMSVC = 1" >> Make.user
+  echo "override ARCH = $ARCH" >> Make.user
+  if [ $ARCH = x86_64 ]; then
+    echo "override MARCH = x86-64" >> Make.user
+  else
+    echo "override MARCH = $ARCH" >> Make.user
+  fi
+  echo "override XC_HOST = " >> Make.user
+  export CC="$PWD/deps/libuv/compile cl -nologo -MD -Z7"
+  export AR="$PWD/deps/libuv/ar-lib lib"
+  export LD="$PWD/linkld link"
+  echo "override CC = $CC" >> Make.user
+  echo 'override CXX = $(CC) -EHsc' >> Make.user
+  echo "override AR = $AR" >> Make.user
+  echo "override LD = $LD -DEBUG" >> Make.user
+
+  for i in share/julia/base/pcre_h.jl; do
+    7z e -y julia-installer.exe "\$_OUTDIR/$i" -obase >> get-deps.log
+  done
+
+  f=llvm-3.3-$ARCH-msvc12-juliadeps.7z
+fi
+
+if ! [ -e $f ]; then
+  echo "Downloading $f"
+  curl -kLOsS http://sourceforge.net/projects/juliadeps-win/files/$f
+fi
+echo "Extracting $f"
+7z x -y $f >> get-deps.log
+echo 'LLVM_CONFIG = $(JULIAHOME)/usr/bin/llvm-config' >> Make.user
+
+if [ -z "`which make 2>/dev/null`" ]; then
+  if [ -n "`uname | grep CYGWIN`" ]; then
+    echo "Install the Cygwin package for 'make' and try again."
+    exit 1
+  fi
+  f="/make/make-3.81-2/make-3.81-2-msys-1.0.11-bin.tar"
+  if ! [ -e `basename $f.lzma` ]; then
+    echo "Downloading `basename $f`"
+    curl -kLOsS $mingw/files/MSYS/Base$f.lzma
+  fi
+  7z x -y `basename $f.lzma` >> get-deps.log
+  tar -xf `basename $f`
+  # msysgit has an ancient version of touch that fails with `touch -c nonexistent`
+  cp usr/Git/bin/echo.exe bin/touch.exe
+  export PATH=$PWD/bin:$PATH
+fi
+
+f=mingw$bits-pcre-8.34-2.fc21.noarch
+if ! [ -e $f.rpm ]; then
+  echo "Downloading $f"
+  curl -kLOsS http://rpmfind.net/linux/fedora/linux/development/rawhide/x86_64/os/Packages/m/$f.rpm
+fi
+7z x -y $f.rpm >> get-deps.log
+7z x -y $f.cpio >> get-deps.log
+echo 'override PCRE_CONFIG = $(JULIAHOME)/usr/bin/pcre-config' >> Make.user
+# Move downloaded bin, lib, and include files into build tree
+mv usr/$ARCH-w64-mingw32/sys-root/mingw/bin/* usr/bin
+mv usr/$ARCH-w64-mingw32/sys-root/mingw/lib/*.dll.a usr/lib
+mv usr/$ARCH-w64-mingw32/sys-root/mingw/include/* usr/include
+# Modify prefix in pcre-config
+sed -i "s|prefix=/usr/$ARCH-w64-mingw32/sys-root/mingw|prefix=$PWD/usr|" usr/bin/pcre-config
+chmod +x usr/bin/*
+
+for lib in LLVM SUITESPARSE ARPACK BLAS LAPACK FFTW \
+    GMP MPFR PCRE LIBUNWIND RMATH OPENSPECFUN; do
+  echo "USE_SYSTEM_$lib = 1" >> Make.user
+done
+echo 'LIBBLAS = -L$(JULIAHOME)/usr/bin -lopenblas' >> Make.user
+echo 'LIBBLASNAME = libopenblas' >> Make.user
+echo 'override LIBLAPACK = $(LIBBLAS)' >> Make.user
+echo 'override LIBLAPACKNAME = $(LIBBLASNAME)' >> Make.user
+
+# Remaining dependencies:
+# openlibm since we need it as a static library to work properly
+# mojibake since its headers are not in the binary download
+echo 'override STAGE1_DEPS = uv' >> Make.user
+echo 'override STAGE2_DEPS = mojibake' >> Make.user
+echo 'override STAGE3_DEPS = ' >> Make.user
+make -C deps get-openlibm get-mojibake
+
+# Disable git and enable verbose make in AppVeyor
+if [ -n "$APPVEYOR" ]; then
+  echo 'override NO_GIT = 1' >> Make.user
+  echo 'VERBOSE = 1' >> Make.user
+fi
+
+if [ -n "$USEMSVC" ]; then
+  # Create a modified version of compile for wrapping link
+  sed -e 's/-link//' -e 's/cl/link/g' -e 's/ -Fe/ -OUT:/' \
+    -e 's|$dir/$lib|$dir/lib$lib|g' deps/libuv/compile > linkld
+  chmod +x linkld
+
+  # Openlibm doesn't build well with MSVC right now
+  echo 'USE_SYSTEM_OPENLIBM = 1' >> Make.user
+  # Since we don't have a static library for openlibm
+  echo 'override UNTRUSTED_SYSTEM_LIBM = 0' >> Make.user
+
+  # Compile libuv and mojibake without -TP first, then add -TP
+  make -C deps install-uv install-mojibake
+  cp usr/lib/uv.lib usr/lib/libuv.a
+  echo 'override CC += -TP' >> Make.user
+else
+  echo 'override STAGE1_DEPS += openlibm' >> Make.user
+fi
+
+make
+#make debug

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -517,6 +517,7 @@ install-llvm: $(LLVM_OBJ_TARGET)
 
 UV_SRC_TARGET = libuv/.libs/libuv.a
 UV_OBJ_TARGET = $(build_libdir)/libuv.a
+
 UV_CFLAGS = 
 ifeq ($(USEMSVC), 1)
 UV_CFLAGS += -DBUILDING_UV_SHARED
@@ -525,9 +526,14 @@ ifeq ($(USEICC), 1)
 UV_CFLAGS += -static-intel
 endif
 
-UV_OPTS += LDFLAGS="$(LDFLAGS) $(CLDFLAGS) -v"
+UV_MFLAGS += LDFLAGS="$(LDFLAGS) $(CLDFLAGS) -v"
 ifneq ($(UV_CFLAGS),)
-UV_OPTS += CFLAGS="$(UV_CFLAGS)"
+UV_MFLAGS += CFLAGS="$(UV_CFLAGS)"
+endif
+ifneq ($(USEMSVC), 1)
+UV_FLAGS = $(UV_MFLAGS)
+else
+UV_FLAGS = --disable-shared $(UV_MFLAGS)
 endif
 
 libuv/configure:
@@ -540,14 +546,14 @@ libuv/config.status: $(JULIAHOME)/.git/modules/deps/libuv/HEAD
 endif
 libuv/config.status: libuv/configure
 	cd libuv && \
-	./configure --with-pic $(CONFIGURE_COMMON) $(UV_OPTS)
+	./configure --with-pic $(CONFIGURE_COMMON) $(UV_FLAGS)
 	touch -c $@
 $(UV_SRC_TARGET): libuv/config.status
 	touch -c libuv/aclocal.m4
 	touch -c libuv/Makefile.in
 	touch -c libuv/configure
 	touch -c libuv/config.status
-	$(MAKE) -C libuv $(UV_OPTS)
+	$(MAKE) -C libuv $(UV_MFLAGS)
 	touch -c $@
 libuv/checked: $(UV_SRC_TARGET)
 ifeq ($(OS),$(BUILD_OS))

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1254,7 +1254,7 @@ ifeq (exists, $(shell [ -d $(JULIAHOME)/.git/modules/deps/libmojibake ] && echo 
 $(MOJIBAKE_SRC_TARGET): $(JULIAHOME)/.git/modules/deps/libmojibake/HEAD
 endif
 $(MOJIBAKE_SRC_TARGET): libmojibake/Makefile
-	$(MAKE) -C libmojibake cc="$(CC) -O2 -std=c99 $(fPIC)" AR="$(AR)" libmojibake.a
+	$(MAKE) -C libmojibake cc="$(CC) -O2 -std=c99 $(fPIC) -DMOJIBAKE_EXPORTS" AR="$(AR)" libmojibake.a
 	touch -c $@
 libmojibake/checked: $(MOJIBAKE_SRC_TARGET)
 ifeq ($(OS),$(BUILD_OS))

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ DEBUG_LIBS = $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp-debug.a $(WHOLE_AR
 RELEASE_LIBS = $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a $(COMMON_LIBS)
 
 OBJS = $(SRCS:%=%.o)
-DOBJS = $(SRCS:%=%.do)
+DOBJS = $(SRCS:%=%.dbg.obj)
 DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
 
@@ -50,14 +50,14 @@ HEADERS = julia.h julia_internal.h options.h $(wildcard support/*.h) $(LIBUV_INC
 
 %.o: %.c $(HEADERS)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(SHIPFLAGS) -DNDEBUG -c $< -o $@)
-%.do: %.c $(HEADERS)
+%.dbg.obj: %.c $(HEADERS)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 %.o: %.cpp $(HEADERS)
 	@$(call PRINT_CC, $(CXX) $(call exec,$(LLVM_CONFIG) --cxxflags) $(CPPFLAGS) $(CXXFLAGS) $(SHIPFLAGS) -c $< -o $@)
-%.do: %.cpp $(HEADERS)
+%.dbg.obj: %.cpp $(HEADERS)
 	@$(call PRINT_CC, $(CXX) $(call exec,$(LLVM_CONFIG) --cxxflags) $(CPPFLAGS) $(CXXFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 
-ast.o ast.do: julia_flisp.boot.inc flisp/*.h
+ast.o ast.dbg.obj: julia_flisp.boot.inc flisp/*.h
 
 julia_flisp.boot.inc: julia_flisp.boot flisp/libflisp.a
 	@$(call PRINT_FLISP, $(call spawn,./flisp/flisp) ./bin2hex.scm < $< > $@)
@@ -66,8 +66,8 @@ julia_flisp.boot: julia-parser.scm julia-syntax.scm \
 	match.scm utils.scm jlfrontend.scm mk_julia_flisp_boot.scm flisp/libflisp.a
 	@$(call PRINT_FLISP, $(call spawn,./flisp/flisp) ./mk_julia_flisp_boot.scm)
 
-codegen.o codegen.do: intrinsics.cpp debuginfo.cpp cgutils.cpp ccall.cpp disasm.cpp
-builtins.o builtins.do: table.c
+codegen.o codegen.dbg.obj: intrinsics.cpp debuginfo.cpp cgutils.cpp ccall.cpp disasm.cpp
+builtins.o builtins.dbg.obj: table.c
 
 support/libsupport.a: support/*.h support/*.c
 	$(MAKE) -C support
@@ -114,7 +114,7 @@ libjulia-release: $(build_shlibdir)/libjulia.$(SHLIB_EXT)
 clean:
 	-rm -f $(build_shlibdir)/libjulia*
 	-rm -f julia_flisp.boot julia_flisp.boot.inc
-	-rm -f *.do *.o *~ *# *.$(SHLIB_EXT) *.a
+	-rm -f *.dbg.obj *.o *~ *# *.$(SHLIB_EXT) *.a
 
 clean-flisp:
 	-$(MAKE) -C flisp clean

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -472,7 +472,7 @@ static jl_sym_t *mk_symbol(const char *str)
     sym = (jl_sym_t*)malloc(nb);
 #else
     if (sym_pool == NULL || pool_ptr+nb > sym_pool+SYM_POOL_SIZE) {
-        sym_pool = malloc(SYM_POOL_SIZE);
+        sym_pool = (char*)malloc(SYM_POOL_SIZE);
         pool_ptr = sym_pool;
     }
     sym = (jl_sym_t*)pool_ptr;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -654,7 +654,7 @@ DLLEXPORT int jl_substrtod(char *str, size_t offset, int len, double *out)
     int err = 0;
     if (!(*pend == '\0' || isspace((unsigned char)*pend) || *pend == ',')) {
         // confusing data outside substring. must copy.
-        char *newstr = malloc(len+1);
+        char *newstr = (char*)malloc(len+1);
         memcpy(newstr, bstr, len);
         newstr[len] = 0;
         bstr = newstr;
@@ -699,7 +699,7 @@ DLLEXPORT int jl_substrtof(char *str, int offset, int len, float *out)
     int err = 0;
     if (!(*pend == '\0' || isspace((unsigned char)*pend) || *pend == ',')) {
         // confusing data outside substring. must copy.
-        char *newstr = malloc(len+1);
+        char *newstr = (char*)malloc(len+1);
         memcpy(newstr, bstr, len);
         newstr[len] = 0;
         bstr = newstr;

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -651,7 +651,7 @@ static Value *emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     jl_value_t *rtt = rt;
 
     size_t nargt = jl_tuple_len(tt);
-    Value *argvals[nargt];
+    Value **argvals = (Value**) alloca(nargt*sizeof(Value*));
     std::vector<llvm::Type*> argtypes;
     /*
      * Semantics for arguments are as follows:

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -245,7 +245,7 @@ bool getObjUUID(llvm::object::MachOObjectFile *obj, uint8_t uuid[16])
 }
 #endif
 
-extern char *jl_sysimage_name;
+extern "C" char *jl_sysimage_name;
 
 bool jl_is_sysimg(const char *path)
 {

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -193,7 +193,13 @@ char *jl_dlfind_win32(char *f_name)
     if (jl_dlsym_e(jl_ntdll_handle, f_name))
         return "ntdll";
     if (jl_dlsym_e(jl_crtdll_handle, f_name))
+#if _MSC_VER == 1800
+        return "msvcr120";
+#elif defined(_MSC_VER)
+#error This version of MSVC has not been tested.
+#else
         return "msvcrt";
+#endif
     if (jl_dlsym(jl_winsock_handle, f_name))
         return "ws2_32";
     // additional common libraries (libc?) could be added here, but in general,

--- a/src/dump.c
+++ b/src/dump.c
@@ -926,7 +926,7 @@ static jl_value_t *jl_deserialize_value(ios_t *s)
         return v;
     }
     else if (vtag == (jl_value_t*)Singleton_tag) {
-        jl_value_t *v = allocobj(sizeof(void*));
+        jl_value_t *v = (jl_value_t*)allocobj(sizeof(void*));
         if (usetable)
             ptrhash_put(&backref_table, (void*)(ptrint_t)pos, v);
         return v;

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -22,7 +22,7 @@ LLT = $(LLTDIR)/libsupport.a $(LIBUV) $(LIBMOJIBAKE)
 
 FLAGS = -I$(LLTDIR) $(CFLAGS) $(HFILEDIRS:%=-I%) \
         -I$(LIBUV_INC) -I$(build_includedir) $(LIBDIRS:%=-L%) \
-        -DLIBRARY_EXPORTS
+        -DLIBRARY_EXPORTS -DMOJIBAKE_EXPORTS
 ifneq ($(USEMSVC), 1)
 FLAGS += -Wall -Wno-strict-aliasing -DUSE_COMPUTED_GOTO -fvisibility=hidden
 endif

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -16,7 +16,7 @@ SRCS += basename.c dirname.c
 endif
 
 OBJS = $(SRCS:%.c=%.o)
-DOBJS = $(SRCS:%.c=%.do)
+DOBJS = $(SRCS:%.c=%.dbg.obj)
 LLTDIR = ../support
 LLT = $(LLTDIR)/libsupport.a $(LIBUV) $(LIBMOJIBAKE)
 
@@ -24,7 +24,7 @@ FLAGS = -I$(LLTDIR) $(CFLAGS) $(HFILEDIRS:%=-I%) \
         -I$(LIBUV_INC) -I$(build_includedir) $(LIBDIRS:%=-L%) \
         -DLIBRARY_EXPORTS
 ifneq ($(USEMSVC), 1)
-FLAGS += -Wall -Wno-strict-aliasing -DUSE_COMPUTED_GOTO -fvisibility=hidden 
+FLAGS += -Wall -Wno-strict-aliasing -DUSE_COMPUTED_GOTO -fvisibility=hidden
 endif
 LIBFILES = $(LLT)
 LIBS = $(LIBFILES)
@@ -45,13 +45,13 @@ HEADERS = $(wildcard *.h) $(LIBUV_INC)/uv.h
 
 %.o: %.c $(HEADERS)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(SHIPFLAGS) -DNDEBUG -c $< -o $@)
-%.do: %.c $(HEADERS)
+%.dbg.obj: %.c $(HEADERS)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 
 flisp.o:   flisp.c cvalues.c types.c flisp.h print.c read.c equal.c
-flisp.do:  flisp.c cvalues.c types.c flisp.h print.c read.c equal.c
+flisp.dbg.obj:  flisp.c cvalues.c types.c flisp.h print.c read.c equal.c
 flmain.o:  flmain.c flisp.h
-flmain.do: flmain.c flisp.h
+flmain.dbg.obj: flmain.c flisp.h
 
 $(LLT): $(LLTDIR)/*.h $(LLTDIR)/*.c
 	cd $(LLTDIR) && $(MAKE)
@@ -71,8 +71,8 @@ else
 CCLD = $(LD)
 endif
 
-$(EXENAME)-debug: $(DOBJS) $(LIBFILES) $(LIBTARGET)-debug.a flmain.do
-	@$(call PRINT_LINK, $(CCLD) $(DEBUGFLAGS) $(DOBJS) flmain.do -o $(EXENAME)-debug $(LIBTARGET).a $(LIBS) $(OSLIBS))
+$(EXENAME)-debug: $(DOBJS) $(LIBFILES) $(LIBTARGET)-debug.a flmain.dbg.obj
+	@$(call PRINT_LINK, $(CCLD) $(DEBUGFLAGS) $(DOBJS) flmain.dbg.obj -o $(EXENAME)-debug $(LIBTARGET).a $(LIBS) $(OSLIBS))
 
 $(EXENAME): $(OBJS) $(LIBFILES) $(LIBTARGET).a flmain.o
 	@$(call PRINT_LINK, $(CCLD) $(SHIPFLAGS) $(OBJS) flmain.o -o $(EXENAME) $(LIBTARGET).a $(LIBS) $(OSLIBS))
@@ -84,7 +84,7 @@ endif
 
 clean:
 	rm -f *.o
-	rm -f *.do
+	rm -f *.dbg.obj
 	rm -f *.a
 	rm -f $(EXENAME)
 	rm -f $(EXENAME)-debug

--- a/src/gf.c
+++ b/src/gf.c
@@ -1512,7 +1512,7 @@ static void _compile_all(jl_module_t *m, htable_t *h)
 {
     size_t i;
     size_t sz = m->bindings.size;
-    void **table = malloc(sz * sizeof(void*));
+    void **table = (void**) malloc(sz * sizeof(void*));
     memcpy(table, m->bindings.table, sz*sizeof(void*));
     ptrhash_put(h, m, m);
     for(i=1; i < sz; i+=2) {

--- a/src/init.c
+++ b/src/init.c
@@ -741,7 +741,11 @@ void julia_init(char *imageFile)
 #ifdef _OS_WINDOWS_
     uv_dlopen("ntdll.dll", jl_ntdll_handle); // bypass julia's pathchecking for system dlls
     uv_dlopen("kernel32.dll", jl_kernel32_handle);
+#if _MSC_VER == 1800
+    uv_dlopen("msvcr120.dll", jl_crtdll_handle);
+#else
     uv_dlopen("msvcrt.dll", jl_crtdll_handle);
+#endif
     uv_dlopen("ws2_32.dll", jl_winsock_handle);
     _jl_exe_handle.handle = GetModuleHandleA(NULL);
     if (!DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -20,7 +20,7 @@ OBJS += _setjmp.win64.o _longjmp.win64.o
 endif
 endif
 
-DOBJS = $(OBJS:%.o=%.do)
+DOBJS = $(OBJS:%.o=%.dbg.obj)
 
 FLAGS = $(CFLAGS) $(HFILEDIRS:%=-I%) -I$(LIBUV_INC) -DLIBRARY_EXPORTS
 ifneq ($(USEMSVC), 1)
@@ -36,18 +36,18 @@ HEADERS = $(wildcard *.h) $(LIBUV_INC)/uv.h
 
 %.o: %.c $(HEADERS)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(SHIPFLAGS) -DNDEBUG -c $< -o $@)
-%.do: %.c $(HEADERS)
+%.dbg.obj: %.c $(HEADERS)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 ifneq ($(USEMSVC), 1)
 %.o: %.S
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(SHIPFLAGS) -c $< -o $@)
-%.do: %.S
+%.dbg.obj: %.S
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 else
 %.o: %.S
 	@$(call PRINT_CC, $(CPP) -P $(CPPFLAGS) $(SHIPFLAGS) $<)
 	@$(call PRINT_CC, $(AS) $(CPPFLAGS) $(SHIPFLAGS) -Fo$@ -c $*.i)
-%.do: %.S
+%.dbg.obj: %.S
 	@$(call PRINT_CC, $(CPP) -P $(CPPFLAGS) $(DEBUGFLAGS) $<)
 	@$(call PRINT_CC, $(AS) $(CPPFLAGS) $(DEBUGFLAGS) -Fo$@ -c $*.i)
 endif
@@ -65,7 +65,7 @@ libsupport-debug.a: $(DOBJS)
 
 clean:
 	rm -f *.o
-	rm -f *.do
+	rm -f *.dbg.obj
 	rm -f *.a
 	rm -f *~ *#
 	rm -f core*

--- a/src/support/_longjmp.win32.S
+++ b/src/support/_longjmp.win32.S
@@ -53,10 +53,13 @@
 
 #ifndef _MSC_VER
 .intel_syntax
-#else
-.model small,C
-#endif
 ENTRY(jl_longjmp)
+#else
+.586
+.model small,C
+.code
+jl_longjmp proc
+#endif
     mov    edx,DWORD PTR [esp+4]
     mov    eax,DWORD PTR [esp+8]
     mov    ebp,DWORD PTR [edx+0]
@@ -70,4 +73,7 @@ ENTRY(jl_longjmp)
     inc    eax
 a:  mov    DWORD PTR [esp],ecx
     ret
+#ifdef _MSC_VER
+jl_longjmp endp
+#endif
 END(jl_longjmp)

--- a/src/support/_longjmp.win64.S
+++ b/src/support/_longjmp.win64.S
@@ -2,8 +2,11 @@
 
 #ifndef _MSC_VER
 .intel_syntax noprefix
-#endif
 ENTRY(jl_longjmp)
+#else
+.code
+jl_longjmp proc
+#endif
     mov    rbx,QWORD PTR [rcx+8]
     mov    rsp,QWORD PTR [rcx+16]
     mov    rbp,QWORD PTR [rcx+24]
@@ -30,4 +33,7 @@ ENTRY(jl_longjmp)
     inc    eax
 a:  mov    QWORD PTR [rsp],r8
     ret
+#ifdef _MSC_VER
+jl_longjmp endp
+#endif
 END(jl_longjmp)

--- a/src/support/_setjmp.win32.S
+++ b/src/support/_setjmp.win32.S
@@ -53,10 +53,13 @@
 
 #ifndef _MSC_VER
 .intel_syntax
-#else
-.model small,C
-#endif
 ENTRY(jl_setjmp)
+#else
+.586
+.model small,C
+.code
+jl_setjmp proc
+#endif
     mov    eax,DWORD PTR [esp+4]
     mov    edx,DWORD PTR [esp+0]
     mov    DWORD PTR [eax+0],ebp  /* rta */
@@ -67,4 +70,7 @@ ENTRY(jl_setjmp)
     mov    DWORD PTR [eax+20],edx
     xor    eax,eax
     ret
+#ifdef _MSC_VER
+jl_setjmp endp
+#endif
 END(jl_setjmp)

--- a/src/support/_setjmp.win64.S
+++ b/src/support/_setjmp.win64.S
@@ -2,8 +2,11 @@
 
 #ifndef _MSC_VER
 .intel_syntax noprefix
-#endif
 ENTRY(jl_setjmp)
+#else
+.code
+jl_setjmp proc
+#endif
     mov    rdx,QWORD PTR [rsp]
     mov    QWORD PTR [rcx],0
     mov    QWORD PTR [rcx+8],rbx
@@ -29,4 +32,7 @@ ENTRY(jl_setjmp)
     movaps XMMWORD PTR [rcx+240],xmm15
     xor    rax,rax
     ret
+#ifdef _MSC_VER
+jl_setjmp endp
+#endif
 END(jl_setjmp)

--- a/src/support/timefuncs.c
+++ b/src/support/timefuncs.c
@@ -22,6 +22,10 @@
 
 #include "timefuncs.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(_OS_WINDOWS_)
 static double floattime(void)
 {
@@ -65,3 +69,7 @@ void sleep_ms(int ms)
     select(0, NULL, NULL, NULL, &timeout);
 #endif
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/support/timefuncs.h
+++ b/src/support/timefuncs.h
@@ -1,7 +1,15 @@
 #ifndef TIMEFUNCS_H
 #define TIMEFUNCS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DLLEXPORT double clock_now(void);
 void sleep_ms(int ms);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/sys.c
+++ b/src/sys.c
@@ -629,7 +629,7 @@ DLLEXPORT const char *jl_pathname_for_handle(uv_lib_t *uv_lib)
 #elif defined(_OS_WINDOWS_)
 
     wchar_t *pth16 = (wchar_t*)malloc(32768); // max long path length
-    DWORD n16 = GetModuleFileNameW(handle,pth16,32768);
+    DWORD n16 = GetModuleFileNameW((HMODULE)handle,pth16,32768);
     if (n16 <= 0) {
         free(pth16);
         return NULL;
@@ -669,7 +669,7 @@ static BOOL CALLBACK jl_EnumerateLoadedModulesProc64(
   _In_opt_  PVOID a
 )
 {
-    jl_array_grow_end(a, 1);
+    jl_array_grow_end((jl_array_t*)a, 1);
     //XXX: change to jl_arrayset if array storage allocation for Array{String,1} changes:
     jl_value_t *v = jl_cstr_to_string(ModuleName);
     jl_cellset(a, jl_array_dim0(a)-1, v);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -564,7 +564,7 @@ jl_value_t *jl_load(const char *fname)
         //This deliberatly uses ios, because stdio initialization has been moved to Julia
         jl_printf(JL_STDOUT, "%s\r\n", fname);
 #ifdef _OS_WINDOWS_        
-        uv_run(uv_default_loop(), 1);
+        uv_run(uv_default_loop(), (uv_run_mode)1);
 #endif
     }
     char *fpath = (char*)fname;

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,3 +1,5 @@
 /*.o
 /*.do
 /*.dSYM
+/*.obj
+/*.pdb

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -6,11 +6,18 @@ override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
 override CPPFLAGS += $(JCPPFLAGS)
 
+SRCS = repl
+ifeq ($(USEMSVC), 1)
+SRCS += getopt
+endif
+
 FLAGS = -I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(build_includedir)
 ifneq ($(USEMSVC), 1)
 FLAGS += -Wall -Wno-strict-aliasing -fno-omit-frame-pointer
 endif
 
+OBJS = $(SRCS:%=%.o)
+DOBJS = $(SRCS:%=%.do)
 DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
 ifeq ($(USE_LLVM_SHLIB),1)
@@ -64,9 +71,9 @@ else
 CXXLD = $(LD)
 endif
 
-$(build_bindir)/julia$(EXE): repl.o
+$(build_bindir)/julia$(EXE): $(OBJS)
 	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(LINK_FLAGS) $(SHIPFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -ljulia $(JLDFLAGS) $(CXXLDFLAGS))
-$(build_bindir)/julia-debug$(EXE): repl.do
+$(build_bindir)/julia-debug$(EXE): $(DOBJS)
 	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -ljulia-debug $(JLDFLAGS) $(CXXLDFLAGS))
 
 clean: | $(CLEAN_TARGETS)

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -17,7 +17,7 @@ FLAGS += -Wall -Wno-strict-aliasing -fno-omit-frame-pointer
 endif
 
 OBJS = $(SRCS:%=%.o)
-DOBJS = $(SRCS:%=%.do)
+DOBJS = $(SRCS:%=%.dbg.obj)
 DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
 ifeq ($(USE_LLVM_SHLIB),1)
@@ -42,7 +42,7 @@ release debug:
 
 %.o: %.c
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(SHIPFLAGS) -c $< -o $@)
-%.do: %.c
+%.dbg.obj: %.c
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 
 ifeq ($(OS),WINNT)
@@ -77,7 +77,7 @@ $(build_bindir)/julia-debug$(EXE): $(DOBJS)
 	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(LINK_FLAGS) $(DEBUGFLAGS) $^ -o $@ -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -ljulia-debug $(JLDFLAGS) $(CXXLDFLAGS))
 
 clean: | $(CLEAN_TARGETS)
-	rm -f *.o *.do
+	rm -f *.o *.dbg.obj
 	rm -f $(build_bindir)/julia*
 
 .PHONY: clean release debug julia-release julia-debug

--- a/ui/getopt.c
+++ b/ui/getopt.c
@@ -1,0 +1,147 @@
+/* This file is adapted from musl-libc
+----------------------------------------------------------------------
+Copyright © 2005-2014 Rich Felker, et al.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+----------------------------------------------------------------------
+*/
+
+#include <wchar.h>
+#include <string.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stddef.h>
+#include "getopt.h"
+
+char *optarg;
+int optind=1, opterr=1, optopt, __optpos, __optreset=0;
+
+#define optpos __optpos
+
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+  int i;
+  wchar_t c, d;
+  int k, l;
+  char *optchar;
+
+  if (!optind || __optreset) {
+    __optreset = 0;
+    __optpos = 0;
+    optind = 1;
+  }
+
+  if (optind >= argc || !argv[optind] || argv[optind][0] != '-' || !argv[optind][1])
+    return -1;
+  if (argv[optind][1] == '-' && !argv[optind][2])
+    return optind++, -1;
+
+  if (!optpos) optpos++;
+  if ((k = mbtowc(&c, argv[optind]+optpos, MB_LEN_MAX)) < 0) {
+    k = 1;
+    c = 0xfffd; /* replacement char */
+  }
+  optchar = argv[optind]+optpos;
+  optopt = c;
+  optpos += k;
+
+  if (!argv[optind][optpos]) {
+    optind++;
+    optpos = 0;
+  }
+
+  for (i=0; (l = mbtowc(&d, optstring+i, MB_LEN_MAX)) && d!=c; i+=l>0?l:1);
+
+  if (d != c) {
+    if (optstring[0] != ':' && opterr) {
+      fprintf(stderr, "%s: illegal option: %c\n", argv[0], optchar);
+    }
+    return '?';
+  }
+  if (optstring[i+1] == ':') {
+    if (optind >= argc) {
+      if (optstring[0] == ':') return ':';
+      if (opterr) {
+        fprintf(stderr, "%s: option requires an argument: %c\n", argv[0], optchar);
+      }
+      return '?';
+    }
+    if (optstring[i+2] == ':') optarg = 0;
+    if (optstring[i+2] != ':' || optpos) {
+      optarg = argv[optind++] + optpos;
+      optpos = 0;
+    }
+  }
+  return c;
+}
+
+static int __getopt_long(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx, int longonly)
+{
+  if (!optind || __optreset) {
+    __optreset = 0;
+    __optpos = 0;
+    optind = 1;
+  }
+  if (optind >= argc || !argv[optind] || argv[optind][0] != '-') return -1;
+  if ((longonly && argv[optind][1]) ||
+    (argv[optind][1] == '-' && argv[optind][2]))
+  {
+    int i;
+    for (i=0; longopts[i].name; i++) {
+      const char *name = longopts[i].name;
+      char *opt = argv[optind]+1;
+      if (*opt == '-') opt++;
+      for (; *name && *name == *opt; name++, opt++);
+      if (*name || (*opt && *opt != '=')) continue;
+      if (*opt == '=') {
+        if (!longopts[i].has_arg) continue;
+        optarg = opt+1;
+      } else {
+        if (longopts[i].has_arg == required_argument) {
+          if (!(optarg = argv[++optind]))
+            return ':';
+        } else optarg = NULL;
+      }
+      optind++;
+      if (idx) *idx = i;
+      if (longopts[i].flag) {
+        *longopts[i].flag = longopts[i].val;
+        return 0;
+      }
+      return longopts[i].val;
+    }
+    if (argv[optind][1] == '-') {
+      optind++;
+      return '?';
+    }
+  }
+  return getopt(argc, argv, optstring);
+}
+
+int getopt_long(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx)
+{
+  return __getopt_long(argc, argv, optstring, longopts, idx, 0);
+}
+
+int getopt_long_only(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx)
+{
+  return __getopt_long(argc, argv, optstring, longopts, idx, 1);
+}

--- a/ui/getopt.h
+++ b/ui/getopt.h
@@ -1,0 +1,56 @@
+/* This file is adapted from musl-libc
+----------------------------------------------------------------------
+Copyright © 2005-2014 Rich Felker, et al.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+----------------------------------------------------------------------
+*/
+
+#ifndef _GETOPT_H
+#define _GETOPT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int getopt(int, char * const [], const char *);
+extern char *optarg;
+extern int optind, opterr, optopt;
+
+struct option
+{
+  const char *name;
+  int has_arg;
+  int *flag;
+  int val;
+};
+
+int getopt_long(int, char *const *, const char *, const struct option *, int *);
+int getopt_long_only(int, char *const *, const char *, const struct option *, int *);
+
+#define no_argument        0
+#define required_argument  1
+#define optional_argument  2
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -13,15 +13,18 @@
 #include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#include <libgen.h>
-#endif
 #include <limits.h>
 #include <errno.h>
 #include <math.h>
-#include <getopt.h>
 #include <ctype.h>
+
+#ifndef _MSC_VER
+#include <unistd.h>
+#include <libgen.h>
+#include <getopt.h>
+#else
+#include "getopt.h"
+#endif
 
 #include "uv.h"
 #define WHOLE_ARCHIVE


### PR DESCRIPTION
Following up on #6230, #6349, and others. This gets past the stack overflow when compiling `inference.jl` into the system image, but craps out at `pcre.jl` because the preprocessed PCRE headers don't come out correctly from the MSVC preprocessor (it doesn't understand `-dM`). Putting this up so people can look at it, I'll keep thinking about workarounds for the preprocessor issues - can probably copy some of them straight out of the MinGW binaries.

How to run this, assuming you have Visual Studio 2013 (express should work) installed:
- start a command prompt, `cd "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC"`
- `vcvarsall x86_amd64`
- `cd` to your MSYS installation, whichever folder `sh.exe` is located in (either `bin` or `usr/bin` depending whether you're using MSYS1 or a recent MSYS2 - best to use msysgit here, otherwise you'll likely get an error message due to the MSYS version of `link.exe` showing up first in the path)
- `set MSYSTEM=MINGW32`
- `sh --login`
- `cd` to your Julia directory, checkout ~~this branch~~ latest master
- make sure msys can find 7z on the path
- `ARCH=x86_64 USEMSVC=1 contrib/windows/msys_build.sh`

This downloads the latest Windows nightly binary and uses as many dependencies from it as possible, and downloads an MSVC build of LLVM that I made in early April. I should update that with our latest patches, and build a 32-bit version with VS 2013 at some point.
