### PR TITLE
Improve printing of :for expressions

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -332,7 +332,13 @@ function show_block(io::IO, head, args::Vector, body, indent::Int)
     print(io, '\n', " "^indent)
 end
 show_block(io::IO,head,    block,i::Int) = show_block(io,head,{},   block,i)
-show_block(io::IO,head,arg,block,i::Int) = show_block(io,head,{arg},block,i)
+function show_block(io::IO, head, arg, block, i::Int)
+    if is_expr(arg, :block)
+        show_block(io, head, arg.args, block, i)
+    else
+        show_block(io, head, {arg}, block, i)
+    end
+end
 
 # show an indented list
 function show_list(io::IO, items, sep, indent::Int, prec::Int=0)


### PR DESCRIPTION
Motivated by the desire to move closer to being able to dump the results of `macroexpand` to a `.jl` file and get something parseable. Since the main definition of `show_block` calls `show_list`, I suspect this was the intended behavior.

``` julia
ex = quote
   for i = 1:5, j = 1:7
        x += i*j
   end
end
```

Before:

```
julia> ex
quote  # none, line 2:
    for begin 
            i = 1:5
            j = 1:7
        end # line 3:
        x += i * j
    end
end
```

After:

```
julia> ex
quote  # none, line 2:
    for i = 1:5, j = 1:7 # line 3:
        x += i * j
    end
end
```
