### PR TITLE
Follow up to #7760

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -352,7 +352,7 @@ function intersect{T1<:Integer, T2<:Integer}(r::StepRange{T1}, s::UnitRange{T2})
     end
 end
 
-function intersect{T1<:Integer, T2<:Integer}(r::StepRange{T1}, s::StepRange{T2})
+function intersect(r::StepRange, s::StepRange)
     if length(r) == 0 || length(s) == 0
         return range(first(r), step(r), 0)
     elseif step(s) < 0


### PR DESCRIPTION
Remove type constraints from intersect(::StepRange,::StepRange). This allows date ranges, for example, to utilize the implementation because Period types implement `mod()`, `gcdx()`, and `lcm()`.
