### PR TITLE
workaround old version of /bin/date in msysgit

### DIFF
--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -39,11 +39,18 @@ branch=$(git branch | sed -n '/\* /s///p')
 build_number=$(git rev-list HEAD ^$last_tag | wc -l | sed -e 's/[^[:digit:]]//g')
 
 date_string=$git_time
-if [ "$(uname)" = "Darwin" ] || [ "$(uname)" = "FreeBSD" ]; then
+case $(uname) in
+  Darwin | FreeBSD)
     date_string="$(/bin/date -jr $git_time -u '+%Y-%m-%d %H:%M %Z')"
-else
+    ;;
+  MINGW*)
+    git_time=$(git log -1 --pretty=format:%ci)
+    date_string="$(/bin/date --date="$git_time" -u '+%Y-%m-%d %H:%M %Z')"
+    ;;
+  *)
     date_string="$(/bin/date --date="@$git_time" -u '+%Y-%m-%d %H:%M %Z')"
-fi
+    ;;
+esac
 if [ $(git describe --tags --exact-match 2> /dev/null) ]; then
     tagged_commit="true"
 else


### PR DESCRIPTION
I don't expect many people other than me to be trying to use msysgit as a build environment, but I found the version of `/bin/date` is pretty ancient there and running `version_git.sh` gives an error `invalid date `@1406586781'`.

Can someone test this on Mac, make sure using a switch case instead of an if statement doesn't break anything? Works okay on RHEL5, Ubuntu 14.04, Cygwin, MSYS2, and msysgit (wow I'm accumulating a crapton of different build environments).

I don't know the oldest version of git for which `--pretty=format:%ci` works, but that's pretty close to what we want here, so this could be cleaned up and unified across platforms instead of adding a special case for MSYS. `TODO` later?
