### PR TITLE
Allow for setting of an initial git config when creating pkg repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
 script:
     - make $BUILDOPTS prefix=/tmp/julia install
     - cd .. && mv julia julia2
-    - git config --global user.name "Travis CI"
     - cd /tmp/julia/share/julia/test && /tmp/julia/bin/julia-debug --check-bounds=yes runtests.jl all && /tmp/julia/bin/julia-debug --check-bounds=yes runtests.jl pkg
     - cd - && mv julia2 julia
     - echo "Ready for packaging..."

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -59,8 +59,8 @@ publish() = cd(Entry.publish,META_BRANCH)
 build() = cd(Entry.build)
 build(pkgs::String...) = cd(Entry.build,[pkgs...])
 
-generate(pkg::String, license::String; force::Bool=false) =
-	cd(Generate.package,pkg,license,force=force)
+generate(pkg::String, license::String; force::Bool=false, authors::Union(String,Array) = [], config::Dict={}) =
+	cd(Generate.package,pkg,license,force=force,authors=authors,config=config)
 
 
 test() = cd(Entry.test)

--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -34,15 +34,17 @@ function package(
     authors::String = "",
     years::Union(Int,String) = copyright_year(),
     user::String = github_user(),
+    config::Dict = {},
 )
     isnew = !ispath(pkg)
     try
         if isnew
             url = isempty(user) ? "" : "git://github.com/$user/$pkg.jl.git"
-            Generate.init(pkg,url)
+            Generate.init(pkg,url,config=config)
         else
             Git.dirty(dir=pkg) && error("$pkg is dirty – commit or stash your changes")
         end
+
         Git.transact(dir=pkg) do
             if isempty(authors)
                 authors = isnew ? copyright_name() : git_contributors(pkg,5)
@@ -81,10 +83,14 @@ function package(
     end
 end
 
-function init(pkg::String, url::String="")
+function init(pkg::String, url::String=""; config::Dict={})
     if !ispath(pkg)
         info("Initializing $pkg repo: $(abspath(pkg))")
         Git.run(`init -q $pkg`)
+
+        for (key,val) in config
+            Git.run(`config $key $val`, dir=pkg)
+        end
         Git.run(`commit -q --allow-empty -m "initial empty commit"`, dir=pkg)
     end
     isempty(url) && return

--- a/test/git.jl
+++ b/test/git.jl
@@ -8,6 +8,8 @@ mkdir(dir)
 try cd(dir) do
 
     run(`git init -q`)
+    run(`git config user.name "Julia Tester"`)
+    run(`git config user.email test@julialang.org`)
     run(`git commit -q --allow-empty -m "initial empty commit"`)
     git_verify(Dict(), Dict(), Dict())
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -24,7 +24,7 @@ end
 
 # testing a package with test dependencies causes them to be installed for the duration of the test
 temp_pkg_dir() do
-  Pkg.generate("PackageWithTestDependencies", "MIT")
+  Pkg.generate("PackageWithTestDependencies", "MIT", authors="Julia Test", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
   @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
 
   isdir(Pkg.dir("PackageWithTestDependencies","test")) || mkdir(Pkg.dir("PackageWithTestDependencies","test"))
@@ -47,7 +47,7 @@ end
 
 # testing a package with no runtests.jl errors
 temp_pkg_dir() do
-  Pkg.generate("PackageWithNoTests", "MIT")
+  Pkg.generate("PackageWithNoTests", "MIT", authors="Julia Test", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
 
   if isfile(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
     rm(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
@@ -62,7 +62,7 @@ end
 
 # testing a package with failing tests errors
 temp_pkg_dir() do
-  Pkg.generate("PackageWithFailingTests", "MIT")
+  Pkg.generate("PackageWithFailingTests", "MIT", authors="Julia Test", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
 
   isdir(Pkg.dir("PackageWithFailingTests","test")) || mkdir(Pkg.dir("PackageWithFailingTests","test"))
   open(Pkg.dir("PackageWithFailingTests", "test", "runtests.jl"),"w") do f


### PR DESCRIPTION
Makes `test/pkg.jl` work even when there is no `~/.gitconfig` and the username can't be guessed off of `/etc/passwd` comments.

ref #7789
