### PR TITLE
UTF8proc: return correct category code for Cn code points

### DIFF
--- a/base/utf8proc.jl
+++ b/base/utf8proc.jl
@@ -107,14 +107,15 @@ function normalize_string(s::String, nf::Symbol)
                     throw(ArgumentError(":$nf is not one of :NFC, :NFD, :NFKC, :NFKD")))
 end
     
-# returns UTF8PROC_CATEGORY code in 0..30 giving Unicode category
+# returns UTF8PROC_CATEGORY code in 1:30 giving Unicode category
 function category_code(c)
-    # note: utf8proc returns 0, not UTF8PROC_CATEGORY_CN, for unassigned c
     c > 0x10FFFF && return 0x0000 # see utf8proc_get_property docs
     unsafe_load(ccall(:utf8proc_get_property, Ptr{Uint16}, (Int32,), c))
+    # note: utf8proc returns 0, not UTF8PROC_CATEGORY_CN, for unassigned c
+    c==0 ? UTF8PROC_CATEGORY_CN : c 
 end
 
-is_assigned_char(c) = category_code(c) != 0
+is_assigned_char(c) = category_code(c) != UTF8PROC_CATEGORY_CN
 
 # TODO: use UTF8PROC_CHARBOUND to extract graphemes from a string, e.g. to iterate over graphemes?
 


### PR DESCRIPTION
libutf8proc currently returns 0 (an invalid general category code) for
code points in UTF8PROC_CATEGORY_CN (Unassigned; reserved). This patch
intercepts a 0 return code and replaces it with UTF8PROC_CATEGORY_CN in
category_code().

Also changes is_assigned_char to use the intended Unicode general
category (Cn) instead of 0.

cc: @stevengj 
