### PR TITLE
Fix apropos() output to include description

### DIFF
--- a/base/help.jl
+++ b/base/help.jl
@@ -144,22 +144,17 @@ apropos() = help()
 apropos(s::String) = apropos(STDOUT, s)
 function apropos(io::IO, txt::String)
     init_help()
-    n = 0
+    found = false
     r = Regex("\\Q$txt", Base.PCRE.CASELESS)
     for (func, entries) in FUNCTION_DICT
         if ismatch(r, func) || any(e->ismatch(r,e), entries)
+            found = true
             for desc in entries
-                nl = search(desc,'\n')
-                if nl != 0
-                    println(io, desc[1:(nl-1)])
-                else
-                    println(io, desc)
-                end
+                println(io, desc)
             end
-            n+=1
         end
     end
-    if n == 0
+    if !found
         println(io, "No help information found.")
     end
 end


### PR DESCRIPTION
This is a trivial patch to make `apropos()` output close to what a user would expect from such a function (i.e. a list of symbol/description pairs):

> sym1 - desc1
> sym2 - desc2
> ...

Since Julia documentation system is at early stages, there is no convention to write one-liner short descriptions throughout the codebase and therefore there isn't a simple way to mimic the Linux `apropos` tool behavior.

IMHO, it is better to have some description than not having at all, even if this is a provisional solution.
