### PR TITLE
export Core.JULIA_IMAGE_FILE

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -69,6 +69,7 @@ DLLEXPORT void gdbbacktrace();
 DLLEXPORT void gdblookup(ptrint_t ip);
 
 char *julia_home = NULL;
+char *julia_image_file = NULL;
 jl_compileropts_t jl_compileropts = { NULL, // build_path
                                       0,    // code_coverage
                                       0,    // malloc_log
@@ -772,6 +773,8 @@ void julia_init(char *imageFile)
     jl_init_serializer();
 
     if (!imageFile) {
+        julia_image_file = NULL;
+
         jl_core_module = jl_new_module(jl_symbol("Core"));
         jl_new_main_module();
         jl_internal_main_module = jl_main_module;
@@ -793,6 +796,8 @@ void julia_init(char *imageFile)
     }
 
     if (imageFile) {
+        julia_image_file = strdup(imageFile);
+
         JL_TRY {
             jl_restore_system_image(imageFile);
         }
@@ -802,6 +807,9 @@ void julia_init(char *imageFile)
             JL_PRINTF(JL_STDERR, "\n");
             jl_exit(1);
         }
+        jl_set_const(jl_core_module, jl_symbol("JULIA_IMAGE_FILE"),
+                     jl_cstr_to_string(julia_image_file));
+        jl_module_export(jl_core_module, jl_symbol("JULIA_IMAGE_FILE"));
     }
 
     // set module field of primitive types

--- a/src/julia.h
+++ b/src/julia.h
@@ -866,6 +866,7 @@ DLLEXPORT void jl_init(char *julia_home_dir);
 DLLEXPORT void jl_init_with_image(char *julia_home_dir, char *image_relative_path);
 DLLEXPORT int jl_is_initialized(void);
 DLLEXPORT extern char *julia_home;
+DLLEXPORT extern char *julia_image_file;
 
 DLLEXPORT void jl_save_system_image(char *fname);
 DLLEXPORT void jl_restore_system_image(char *fname);


### PR DESCRIPTION
As discussed with @JeffBezanson and @jakebolewski, this adds `Core.JULIA_IMAGE_FILE` so that you have access in Julia to the image filename.

e.g. this is useful in pyjulia, or any other program that wants to use the `jl_init_with_image`, so that it can get the image-file path from Julia.
