### PR TITLE
Update link to Arch Linux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ You can read about [getting started](http://julialang.org/manual/getting-started
 
 The following distributions include julia, but the versions may be out of date due to rapid development:
 
-* [Arch Linux package](https://aur.archlinux.org/packages.php?ID=56877)
+* [Arch Linux](https://www.archlinux.org/packages/community/i686/julia/)
 * [Debian GNU/Linux](http://packages.debian.org/sid/julia)
 * [Gentoo Linux](https://packages.gentoo.org/package/dev-lang/julia)
   * Git Package in the [Science overlay](https://wiki.gentoo.org/wiki/Project:Science/Overlay)


### PR DESCRIPTION
Binary package (both i686 and x86-64 version) has been added to Arch Linux community repo.

Also note, the lastest version could always be obtained through AUR as [julia-git](https://aur.archlinux.org/packages/julia-git/)
