### PR TITLE
RFC: make running the test suite slightly easier

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -346,3 +346,7 @@ function workspace()
     empty!(package_locks)
     nothing
 end
+
+function runtests()
+    run(`$JULIA_HOME/julia $(joinpath(JULIA_HOME,"..","share","julia","test","runtests.jl"))`)
+end

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -348,6 +348,9 @@ function workspace()
 end
 
 function runtests(tests = ["all"], numcores = iceil(CPU_CORES/2))
+    if isa(tests,String)
+        tests = split(tests)
+    end
     ENV2 = copy(ENV)
     ENV2["JULIA_CPU_CORES"] = "$numcores"
     run(setenv(`$JULIA_HOME/julia $(joinpath(JULIA_HOME,"..","share","julia",

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -347,6 +347,9 @@ function workspace()
     nothing
 end
 
-function runtests()
-    run(`$JULIA_HOME/julia $(joinpath(JULIA_HOME,"..","share","julia","test","runtests.jl"))`)
+function runtests(tests = ["all"], numcores = iceil(CPU_CORES/2))
+    ENV2 = copy(ENV)
+    ENV2["JULIA_CPU_CORES"] = "$numcores"
+    run(setenv(`$JULIA_HOME/julia $(joinpath(JULIA_HOME,"..","share","julia",
+        "test","runtests.jl")) $tests`, ENV2))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,6 @@ cd(dirname(@__FILE__)) do
     n = 1
     if net_on 
         n = min(8, CPU_CORES, length(tests))
-        isempty(ARGS) && (n = min(n, iceil(CPU_CORES/2)))
         n > 1 && addprocs(n; exeflags=`--check-bounds=yes`)
         blas_set_num_threads(1)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ testnames = [
 # parallel tests depend on other workers - do them last
 push!(testnames, "parallel")
 
-tests = ARGS==["all"] ? testnames : ARGS
+tests = (ARGS==["all"] || isempty(ARGS)) ? testnames : ARGS
 
 if "linalg" in tests
     # specifically selected case
@@ -32,18 +32,21 @@ catch
     net_on = false
 end
 
-n = 1
-if net_on 
-    n = min(8, CPU_CORES, length(tests))
-    n > 1  && addprocs(n; exeflags=`--check-bounds=yes`)
-    blas_set_num_threads(1)
-else
-    filter!(x -> !(x in net_required_for), tests)
+cd(dirname(@__FILE__)) do
+    n = 1
+    if net_on 
+        n = min(8, CPU_CORES, length(tests))
+        isempty(ARGS) && (n = min(n, iceil(CPU_CORES/2)))
+        n > 1 && addprocs(n; exeflags=`--check-bounds=yes`)
+        blas_set_num_threads(1)
+    else
+        filter!(x -> !(x in net_required_for), tests)
+    end
+
+    @everywhere include("testdefs.jl")
+
+    reduce(propagate_errors, nothing, pmap(runtests, tests; err_retry=false, err_stop=true))
+
+    @unix_only n > 1 && rmprocs(workers(), waitfor=5.0)
+    println("    \033[32;1mSUCCESS\033[0m")
 end
-
-@everywhere include("testdefs.jl")
-
-reduce(propagate_errors, nothing, pmap(runtests, tests; err_retry=false, err_stop=true))
-
-@unix_only n > 1 && rmprocs(workers(), waitfor=5.0)
-println("    \033[32;1mSUCCESS\033[0m")


### PR DESCRIPTION
- default to running all tests if no command-line arguments provided
- cd to the test directory, then back when finished
- use at most half of the cpu cores when no command-line arguments given

This is a "lite" version of #7748. Now there will be several relatively simple ways to run the test suite, which I think we should encourage users to do via a note on the download page.
- From command line `julia /path/to/share/julia/test/runtests.jl`
- From inside Julia `include(joinpath(JULIA_HOME,"../share/julia/test/runtests.jl"))`
- From inside Julia `Pkg.test(joinpath(JULIA_HOME,"../share/julia"))` - a pun since base Julia isn't really a package, but slightly shorter

I went for half the cores on the users' machine (rounded up) for the case when `isempty(ARGS)` rather than all minus one ([as suggested by Jeff](https://github.com/JuliaLang/julia/pull/7748#issuecomment-50300630)) since lots of machines have hyperthreading enabled these days. That tends to lead to oversubscription (and in the case of my laptop overheating), half the reported number of logical cores is probably closer to the actual number of physical cores than all minus 1.

~~Returning to the starting directory could be done more robustly, with something like a try-finally or a do-block of some kind, I'm open to suggestions for improving it.~~
