### PR TITLE
Export jl_uv_dlopen() and jl_lookup_soname()

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -58,7 +58,7 @@ extern "C" DLLEXPORT void jl_read_sonames(void)
     pclose(ldc);
 }
 
-extern "C" const char *jl_lookup_soname(char *pfx, size_t n)
+extern "C" DLLEXPORT const char *jl_lookup_soname(char *pfx, size_t n)
 {
     if (!got_sonames) {
         jl_read_sonames();

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -36,13 +36,9 @@ static char *extensions[] = { ".so", "" };
 
 extern char *julia_home;
 
-#if defined(__linux__)
-char *jl_lookup_soname(char *pfx, size_t n);
-#endif
-
 #define JL_RTLD(flags, FLAG) (flags & JL_RTLD_ ## FLAG ? RTLD_ ## FLAG : 0)
 
-static int jl_uv_dlopen(const char *filename, uv_lib_t *lib, unsigned flags)
+DLLEXPORT int jl_uv_dlopen(const char *filename, uv_lib_t *lib, unsigned flags)
 {
 #if defined(_OS_WINDOWS_)
     needsSymRefreshModuleList = 1;

--- a/src/julia.h
+++ b/src/julia.h
@@ -896,9 +896,14 @@ DLLEXPORT uv_lib_t *jl_load_dynamic_library(char *fname, unsigned flags);
 DLLEXPORT uv_lib_t *jl_load_dynamic_library_e(char *fname, unsigned flags);
 DLLEXPORT void *jl_dlsym_e(uv_lib_t *handle, char *symbol);
 DLLEXPORT void *jl_dlsym(uv_lib_t *handle, char *symbol);
+DLLEXPORT int jl_uv_dlopen(const char *filename, uv_lib_t *lib, unsigned flags);
 DLLEXPORT uv_lib_t *jl_wrap_raw_dl_handle(void *handle);
 char *jl_dlfind_win32(char *name);
 DLLEXPORT int add_library_mapping(char *lib, void *hnd);
+
+#if defined(__linux__)
+DLLEXPORT const char *jl_lookup_soname(char *pfx, size_t n);
+#endif
 
 // compiler
 void jl_compile(jl_function_t *f);


### PR DESCRIPTION
This so that we can define a function to find all possible libraries openable via dlopen(), rather than only finding the first openable one.

This is super great, because it addresses https://github.com/JuliaLang/BinDeps.jl/issues/86, allows for things like https://github.com/JuliaLang/Cairo.jl/pull/73, and in general should solve a lot of our BinDeps woes.  Mad props to @Keno for writing this up.
