### PR TITLE
Let big use convert for AbstractArrays instead of the vectorize macro

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -296,6 +296,10 @@ for (f,t) in ((:integer, Integer),
     end
 end
 
+big{T<:FloatingPoint,N}(x::AbstractArray{T,N}) = convert(AbstractArray{BigFloat,N}, x)
+big{T<:FloatingPoint,N}(x::AbstractArray{Complex{T},N}) = convert(AbstractArray{Complex{BigFloat},N}, x)
+big{T<:Integer,N}(x::AbstractArray{T,N}) = convert(AbstractArray{BigInt,N}, x)
+
 bool(x::AbstractArray{Bool}) = x
 bool(x::AbstractArray) = copy!(similar(x,Bool), x)
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -177,7 +177,6 @@ big(n::Integer) = convert(BigInt,n)
 big(x::FloatingPoint) = convert(BigFloat,x)
 big(q::Rational) = big(num(q))//big(den(q))
 big(z::Complex) = complex(big(real(z)),big(imag(z)))
-@vectorize_1arg Number big
 
 # more hashing definitions
 include("hashing2.jl")


### PR DESCRIPTION
The problem with the old behavior was that `big` on a `SymTridiagonal` densified the matrix.
