### PR TITLE
Comprehension undefined

### DIFF
--- a/doc/manual/variables-and-scoping.rst
+++ b/doc/manual/variables-and-scoping.rst
@@ -291,7 +291,7 @@ loops with ``let`` blocks inside::
     end
     i  # here equal to 3
 
-However, comprehensions do not do this, and always freshly allocate their
+However, comprehensions (see p. ???) do not do this, and always freshly allocate their
 iteration variables::
 
     x = 0


### PR DESCRIPTION
On l. 294 of this file, 'comprehensions' are introduced for the first time in the Julia manual.  There needs to be some explanation or forward reference as to what they are.
