### PR TITLE
Fix Pkg.generate() with default `config`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_install:
     - sudo add-apt-repository ppa:staticfloat/julia-deps -y
     - sudo apt-get update -qq -y
     - sudo apt-get install patchelf gfortran llvm-3.3-dev libsuitesparse-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libdouble-conversion-dev libopenlibm-dev librmath-dev libmpfr-dev -y
+    - git config --global user.name "Travis Buildbot"
+    - git config --global user.email "travis@buildbot.example.org"
 script:
     - make $BUILDOPTS prefix=/tmp/julia install
     - cd .. && mv julia julia2

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -59,8 +59,8 @@ publish() = cd(Entry.publish,META_BRANCH)
 build() = cd(Entry.build)
 build(pkgs::String...) = cd(Entry.build,[pkgs...])
 
-generate(pkg::String, license::String; force::Bool=false, authors::Union(String,Array) = [], config::Dict={}) =
-	cd(Generate.package,pkg,license,force=force,authors=authors,config=config)
+generate(pkg::String, license::String; force::Bool=false) =
+	cd(Generate.package,pkg,license,force=force)
 
 
 test(;coverage::Bool=false) = cd(Entry.test; coverage=coverage)

--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -3,7 +3,7 @@ module Generate
 import ..Git, ..Read
 
 copyright_year() = readchomp(`date +%Y`)
-copyright_name(dir::String) = readchomp(Git.cmd(`config --get user.name`, dir=dir))
+copyright_name() = readchomp(`git config --global --get user.name`)
 github_user() = readchomp(ignorestatus(`git config --global --get github.user`))
 
 function git_contributors(dir::String, n::Int=typemax(Int))
@@ -47,7 +47,7 @@ function package(
 
         Git.transact(dir=pkg) do
             if isempty(authors)
-                authors = isnew ? copyright_name(pkg) : git_contributors(pkg,5)
+                authors = isnew ? copyright_name() : git_contributors(pkg,5)
             end
             Generate.license(pkg,license,years,authors,force=force)
             Generate.readme(pkg,user,force=force)

--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -31,20 +31,18 @@ function package(
     pkg::String,
     license::String;
     force::Bool = false,
-    authors::Union(String,Array) = "",
+    authors::String = "",
     years::Union(Int,String) = copyright_year(),
     user::String = github_user(),
-    config::Dict = {},
 )
     isnew = !ispath(pkg)
     try
         if isnew
             url = isempty(user) ? "" : "git://github.com/$user/$pkg.jl.git"
-            Generate.init(pkg,url,config=config)
+            Generate.init(pkg,url)
         else
             Git.dirty(dir=pkg) && error("$pkg is dirty – commit or stash your changes")
         end
-
         Git.transact(dir=pkg) do
             if isempty(authors)
                 authors = isnew ? copyright_name() : git_contributors(pkg,5)
@@ -83,14 +81,10 @@ function package(
     end
 end
 
-function init(pkg::String, url::String=""; config::Dict={})
+function init(pkg::String, url::String="")
     if !ispath(pkg)
         info("Initializing $pkg repo: $(abspath(pkg))")
         Git.run(`init -q $pkg`)
-
-        for (key,val) in config
-            Git.run(`config $key $val`, dir=pkg)
-        end
         Git.run(`commit -q --allow-empty -m "initial empty commit"`, dir=pkg)
     end
     isempty(url) && return

--- a/test/git.jl
+++ b/test/git.jl
@@ -8,8 +8,6 @@ mkdir(dir)
 try cd(dir) do
 
     run(`git init -q`)
-    run(`git config user.name "Julia Tester"`)
-    run(`git config user.email test@julialang.org`)
     run(`git commit -q --allow-empty -m "initial empty commit"`)
     git_verify(Dict(), Dict(), Dict())
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -24,7 +24,7 @@ end
 
 # testing a package with test dependencies causes them to be installed for the duration of the test
 temp_pkg_dir() do
-  Pkg.generate("PackageWithTestDependencies", "MIT", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
+  Pkg.generate("PackageWithTestDependencies", "MIT", authors="Julia Test", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
   @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
 
   isdir(Pkg.dir("PackageWithTestDependencies","test")) || mkdir(Pkg.dir("PackageWithTestDependencies","test"))
@@ -47,7 +47,7 @@ end
 
 # testing a package with no runtests.jl errors
 temp_pkg_dir() do
-  Pkg.generate("PackageWithNoTests", "MIT", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
+  Pkg.generate("PackageWithNoTests", "MIT", authors="Julia Test", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
 
   if isfile(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
     rm(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
@@ -62,7 +62,7 @@ end
 
 # testing a package with failing tests errors
 temp_pkg_dir() do
-  Pkg.generate("PackageWithFailingTests", "MIT", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
+  Pkg.generate("PackageWithFailingTests", "MIT", authors="Julia Test", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
 
   isdir(Pkg.dir("PackageWithFailingTests","test")) || mkdir(Pkg.dir("PackageWithFailingTests","test"))
   open(Pkg.dir("PackageWithFailingTests", "test", "runtests.jl"),"w") do f

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -24,7 +24,7 @@ end
 
 # testing a package with test dependencies causes them to be installed for the duration of the test
 temp_pkg_dir() do
-  Pkg.generate("PackageWithTestDependencies", "MIT", authors="Julia Test", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
+  Pkg.generate("PackageWithTestDependencies", "MIT")
   @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
 
   isdir(Pkg.dir("PackageWithTestDependencies","test")) || mkdir(Pkg.dir("PackageWithTestDependencies","test"))
@@ -47,7 +47,7 @@ end
 
 # testing a package with no runtests.jl errors
 temp_pkg_dir() do
-  Pkg.generate("PackageWithNoTests", "MIT", authors="Julia Test", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
+  Pkg.generate("PackageWithNoTests", "MIT")
 
   if isfile(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
     rm(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
@@ -62,7 +62,7 @@ end
 
 # testing a package with failing tests errors
 temp_pkg_dir() do
-  Pkg.generate("PackageWithFailingTests", "MIT", authors="Julia Test", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
+  Pkg.generate("PackageWithFailingTests", "MIT")
 
   isdir(Pkg.dir("PackageWithFailingTests","test")) || mkdir(Pkg.dir("PackageWithFailingTests","test"))
   open(Pkg.dir("PackageWithFailingTests", "test", "runtests.jl"),"w") do f

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -22,6 +22,12 @@ temp_pkg_dir() do
   @test isempty(Pkg.installed())
 end
 
+# test package generation with default args
+temp_pkg_dir() do
+  Pkg.generate("PackageWithNothing", "MIT")
+  @test [keys(Pkg.installed())...] == ["PackageWithNothing"]
+end
+
 # testing a package with test dependencies causes them to be installed for the duration of the test
 temp_pkg_dir() do
   Pkg.generate("PackageWithTestDependencies", "MIT")


### PR DESCRIPTION
Calling `Pkg.generate("Foo", "MIT")` on `master` currently fails with a non-obvious diagnostic due to `{}` not being convertible to `Dict`:

```
ERROR: `__generate#245__` has no method matching __generate#245__(::Bool, ::Array{None,1}, ::Array{Any,1}, ::ASCIIString, ::ASCIIString)
```
