### PR TITLE
Missing 'fully implemented' spec for Iterable

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -885,6 +885,8 @@ Iterable Collections
    For associative collections, the function is passed two arguments (key and value).
 
 
+Fully implemented by... partly implemented by...
+
 Indexable Collections
 ---------------------
 


### PR DESCRIPTION
The section on Iterable Collections is missing a specification of which types fully and partly implement them.  For example, maximum is implemented for IntSet but not maxabs.  I don't know how to fix this because I don't know what is implemented and what is not.  Perhaps this is a moving target?
