### PR TITLE
Fix show(::Expr) precedence of function calls

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -476,10 +476,16 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
                 show_enclosed_list(io, op, func_args, ",", cl, indent)
             end
 
-        # normal function (i.e. "f(x,y)")
+        # normal function (i.e. "f(x,y)" or "A[x,y]")
         else
             op, cl = expr_calls[head]
-            show_unquoted(io, func, indent)
+            if isa(func, Symbol) || (isa(func, Expr) && func.head == :.)
+                show_unquoted(io, func, indent)
+            else
+                print(io, '(')
+                show_unquoted(io, func, indent)
+                print(io, ')')
+            end
             show_enclosed_list(io, op, func_args, ",", cl, indent)
         end
     elseif is(head, :ccall)

--- a/test/show.jl
+++ b/test/show.jl
@@ -165,3 +165,9 @@ end"""
 @test sprint(show, symbol("foo \"bar")) == "symbol(\"foo \\\"bar\")"
 @test sprint(show, :+) == ":+"
 @test sprint(show, symbol("end")) == "symbol(\"end\")"
+
+# Function and array reference precedence
+@test_repr "([2] + 3)[1]"
+@test_repr "foo.bar[1]"
+@test_repr "foo.bar()"
+@test_repr "(foo + bar)()"


### PR DESCRIPTION
The shown expressions of complicated function calls and array references such as `([2] + 3)[1]` were previously shown simply as `[2] + 3[1]`. This fixes that.
