### PR TITLE
Fix goto/label in macros invoked from another module.

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3262,9 +3262,10 @@ So far only the second case can actually occur.
 	   ((escape) (cadr e))
 	   ((using import importall export) (map unescape e))
 	   ((macrocall)
+        (if (or (eq? (cadr e) '@label) (eq? (cadr e) '@goto)) e
 	    `(macrocall ,.(map (lambda (x)
 				 (resolve-expansion-vars- x env m inarg))
-			       (cdr e))))
+			       (cdr e)))))
 	   ((symboliclabel) e)
 	   ((symbolicgoto) e)
 	   ((type)

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -87,4 +87,16 @@ end
 
 @test goto_test7(false) == nothing
 
+module GotoMacroTest
+    macro goto_test8_macro()
+        quote
+            function $(esc(:goto_test8))()
+                @label a
+                @goto a
+            end
+        end
+    end
+end
+
+GotoMacroTest.@goto_test8_macro
 


### PR DESCRIPTION
This sort of thing previously incorrectly threw an error

``` julia
module A
    macro some_macro()
        quote
            function $(esc(:foo))
                @label a
                @goto a
            end
        end
    end
end

A.@some_macro
```

It would try to rewrite `@label a` with `@label A.a`, this commit adds an special case to avoid that.
