### PR TITLE
Removed D3 from LICENCE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -29,7 +29,6 @@ External libraries, if used, include their own licenses:
 - [AMOS](http://www.netlib.org/slatec/guide)
 - [ARPACK](http://www.caam.rice.edu/software/ARPACK/RiceBSD.txt#LICENSE)
 - [ATLAS](http://math-atlas.sourceforge.net/faq.html#license)
-- [D3](https://github.com/mbostock/d3/raw/master/LICENSE)
 - [DOUBLE-CONVERSION](https://code.google.com/p/double-conversion/)
 - [DSFMT](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/LICENSE.txt)
 - [OPENLIBM](https://github.com/JuliaLang/openlibm/blob/master/LICENSE.md)


### PR DESCRIPTION
I can't find any traces of D3 in the repository or downloaded dependencies.
