### PR TITLE
Improve performance of A_ldiv_B! for QR factorizations. Fixes #7887.

### DIFF
--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -223,6 +223,9 @@ function getindex{T}(A::QRPivoted{T}, d::Symbol)
     end
     throw(KeyError(d))
 end
+# Type-stable interface to get Q
+getq(A::QRCompactWY) = QRCompactWYQ(A.factors,A.T)
+getq(A::QRPivoted) = QRPackedQ(A.factors,A.τ)
 
 immutable QRPackedQ{T} <: AbstractMatrix{T}
     factors::Matrix{T}
@@ -389,20 +392,24 @@ function A_ldiv_B!{T<:BlasFloat}(A::Union(QRCompactWY{T},QRPivoted{T}), B::Strid
     ar = abs(A.factors[1])
     if ar == 0 return zeros(nr, nrhs), 0 end
     rnk = 1
-    xmin = ones(T, nr)
-    xmax = ones(T, nr)
+    xmin = ones(T, 1)
+    xmax = ones(T, 1)
     tmin = tmax = ar
     while rnk < nr
-        tmin, smin, cmin = LAPACK.laic1!(2, sub(xmin, 1:rnk), tmin, sub(A.factors, 1:rnk, rnk + 1), A.factors[rnk + 1, rnk + 1])
-        tmax, smax, cmax = LAPACK.laic1!(1, sub(xmax, 1:rnk), tmax, sub(A.factors, 1:rnk, rnk + 1), A.factors[rnk + 1, rnk + 1])
+        tmin, smin, cmin = LAPACK.laic1!(2, xmin, tmin, sub(A.factors, 1:rnk, rnk + 1), A.factors[rnk + 1, rnk + 1])
+        tmax, smax, cmax = LAPACK.laic1!(1, xmax, tmax, sub(A.factors, 1:rnk, rnk + 1), A.factors[rnk + 1, rnk + 1])
         tmax*rcond > tmin && break
-        xmin[1:rnk + 1] = [smin*sub(xmin, 1:rnk), cmin]
-        xmax[1:rnk + 1] = [smax*sub(xmin, 1:rnk), cmax]
+        push!(xmin, cmin)
+        push!(xmax, cmax)
+        for i = 1:rnk
+            xmin[i] *= smin
+            xmax[i] = smax*xmin[i]
+        end
         rnk += 1
         # if cond(r[1:rnk, 1:rnk])*rcond < 1 break end
     end
     C, τ = LAPACK.tzrzf!(A.factors[1:rnk,:])
-    A_ldiv_B!(Triangular(C[1:rnk,1:rnk],:U),sub(Ac_mul_B!(A[:Q],sub(B, 1:mA, 1:nrhs)),1:rnk,1:nrhs))
+    A_ldiv_B!(Triangular(C[1:rnk,1:rnk],:U),sub(Ac_mul_B!(getq(A),sub(B, 1:mA, 1:nrhs)),1:rnk,1:nrhs))
     B[rnk+1:end,:] = zero(T)
     LAPACK.ormrz!('L', iseltype(B, Complex) ? 'C' : 'T', C, τ, sub(B,1:nA,1:nrhs))
     return isa(A,QRPivoted) ? B[invperm(A[:p]::Vector{BlasInt}),:] : B[1:nA,:], rnk


### PR DESCRIPTION
Don't merge before 0.4. See #7888.

To get really good performance we need faster array views.
