### PR TITLE
Change how StepRange gets its 'unit' in creating an empty range

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -30,9 +30,9 @@ immutable StepRange{T,S} <: OrdinalRange{T,S}
                 # start - step, which leads to a range that looks very large instead
                 # of empty.
                 if step > z
-                    last = start - one(step)
+                    last = start - one(stop-start)
                 else
-                    last = start + one(step)
+                    last = start + one(stop-start)
                 end
             else
                 diff = stop - start


### PR DESCRIPTION
Instead of relying on `one(step)` to create the empty range representation, get's the natural step of the StepRange through `stop - start`. The former behavior resulted in the following for date ranges:

``` julia
julia> dr = Date(2014,1,1):Year(1):Date(2013,12,31) # empty range with start > stop and positive step
2014-01-01:1 year:2013-01-01
```

cc: @JeffBezanson
This doesn't need to be 0.3, but I don't know that it hurts anything if we want to get it out of the way.
