### PR TITLE
WIP: use mutating matrix multiplication in eigs

### DIFF
--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -73,7 +73,11 @@ function eigs(A, B;
     end
 
     # Refer to ex-*.doc files in ARPACK/DOCUMENTS for calling sequence
-    matvecA(x) = A * x
+    if method_exists(Base.A_mul_B!,(Vector{T},typeof(A),Vector{T}))
+        matvecA(y,x) = A_mul_B!(y,A,x)
+    else
+        matvecA(y,x) = copy!(y,A*x)
+    end
     if !isgeneral           # Standard problem
         matvecB(x) = x
         if !isshift         #    Regular mode

--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -34,7 +34,7 @@ function aupd_wrapper(T, matvecA::Function, matvecB::Function, solveSI::Function
     iparam[3] = blas_int(maxiter) # maxiter
     iparam[7] = blas_int(mode)    # mode
 
-    zernm1 = 0:(n-1)
+#    zernm1 = 0:(n-1)
 
     while true
         if cmplx
@@ -48,12 +48,13 @@ function aupd_wrapper(T, matvecA::Function, matvecB::Function, solveSI::Function
                   iparam, ipntr, workd, workl, lworkl, info)
         end
         
-        load_idx = ipntr[1]+zernm1
-        store_idx = ipntr[2]+zernm1
-        x = workd[load_idx]
+        # load_idx = ipntr[1]+zernm1
+        # store_idx = ipntr[2]+zernm1
+        x = pointer_to_array(pointer(workd,ipntr[1]),n)
+        y = pointer_to_array(pointer(workd,ipntr[2]),n)
         if mode == 1  # corresponds to dsdrv1, dndrv1 or zndrv1
             if ido[1] == 1
-                workd[store_idx] = matvecA(x)
+                matvecA(y,x)
             elseif ido[1] == 99
                 break
             else


### PR DESCRIPTION
Currently, the arpack wrapper of eigs allocates way too much memory. Firstly, no mutating methods are used, so every matrix multiplication creates (allocates) a new output, which is then copied to the position requested by Arpack. Secondly, for every new matrix multiplication, a new inputvector `x=workd[load_idx]` is created (allocated). So that is two vector allocations per matrix multiplication, both of which could be avoided. The second one will automatically go away when indexing creates a view. The first one requires to switch to mutating methods whenever possible (e.g. whenever defined for the type of A).

This is a work in progress, since so far only the standard mode is covered (i.e. no shift-invert, no generalised eigenvalue problems, so this will fail the tests). Also, I currently use `pointer` and `pointer_to_array` to create a view, but a simple `slice` would probably have been ok.
