### PR TITLE
Add Pkg.whorequires to list packages depending on a particular package

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -66,7 +66,7 @@ generate(pkg::String, license::String; force::Bool=false, authors::Union(String,
 test(;coverage::Bool=false) = cd(Entry.test; coverage=coverage)
 test(pkgs::String...; coverage::Bool=false) = cd(Entry.test,String[pkgs...]; coverage=coverage)
 
-whorequires(packagename::String) = Reqs.whorequires(packagename)
+dependents(packagename::String) = Reqs.dependents(packagename)
 
 @deprecate release free
 @deprecate fixup build

--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -66,6 +66,8 @@ generate(pkg::String, license::String; force::Bool=false, authors::Union(String,
 test(;coverage::Bool=false) = cd(Entry.test; coverage=coverage)
 test(pkgs::String...; coverage::Bool=false) = cd(Entry.test,String[pkgs...]; coverage=coverage)
 
+whorequires(packagename::String) = Reqs.whorequires(packagename)
+
 @deprecate release free
 @deprecate fixup build
 @deprecate fix pin

--- a/base/pkg/reqs.jl
+++ b/base/pkg/reqs.jl
@@ -96,18 +96,18 @@ function parse(lines::Vector{Line})
 end
 parse(x) = parse(read(x))
 
-function whorequires(packagename::String)
-    pkgrequires = String[]
+function dependents(packagename::String)
+    pkgs = String[]
     for pkg in Pkg.available()
         for r in read(Pkg.dir(pkg, "REQUIRE"))
             isa(r, Requirement) || continue
             if r.package == packagename
-                push!(pkgrequires, pkg)
+                push!(pkgs, pkg)
                 break
             end
         end
     end
-    pkgrequires
+    pkgs
 end
 
 # add & rm – edit the content a requires file

--- a/base/pkg/reqs.jl
+++ b/base/pkg/reqs.jl
@@ -98,12 +98,10 @@ parse(x) = parse(read(x))
 
 function dependents(packagename::String)
     pkgs = String[]
-    for pkg in Pkg.available()
-        for r in read(Pkg.dir(pkg, "REQUIRE"))
-            isa(r, Requirement) || continue
-            if r.package == packagename
+    cd(Pkg.dir()) do
+        for (pkg,latest) in Pkg.Read.latest()
+            if haskey(latest.requires, packagename)
                 push!(pkgs, pkg)
-                break
             end
         end
     end

--- a/base/pkg/reqs.jl
+++ b/base/pkg/reqs.jl
@@ -96,6 +96,20 @@ function parse(lines::Vector{Line})
 end
 parse(x) = parse(read(x))
 
+function whorequires(packagename::String)
+    pkgrequires = String[]
+    for pkg in Pkg.available()
+        for r in read(Pkg.dir(pkg, "REQUIRE"))
+            isa(r, Requirement) || continue
+            if r.package == packagename
+                push!(pkgrequires, pkg)
+                break
+            end
+        end
+    end
+    pkgrequires
+end
+
 # add & rm – edit the content a requires file
 
 function add(lines::Vector{Line}, pkg::String, versions::VersionSet=VersionSet())


### PR DESCRIPTION
Do not merge until the 0.4 window opens.

Demo:

```
julia> Pkg.whorequires("Color")
8-element Array{String,1}:
 "Cairo"      
 "Compose"    
 "Gadfly"     
 "Images"     
 "ImageView"  
 "ProfileView"
 "PyPlot"     
 "Winston"    
```

Now I know which packages should be tested if I'm contemplating a breaking change to Color.

CC @StefanKarpinski.
