### PR TITLE
Add performance tests for @simd.

### DIFF
--- a/test/perf/Makefile
+++ b/test/perf/Makefile
@@ -1,9 +1,9 @@
 JULIAHOME = $(abspath ../..)
 include ../../Make.inc
 
-all: micro kernel cat shootout blas lapack sort spell sparse
+all: micro kernel cat shootout blas lapack simd sort spell sparse
 
-micro kernel cat shootout blas lapack sort spell sparse:
+micro kernel cat shootout blas lapack simd sort spell sparse:
 	@$(MAKE) $(QUIET_MAKE) -C shootout
 ifneq ($(OS),WINNT)
 	@$(call spawn,$(JULIA_EXECUTABLE)) $@/perf.jl | perl -nle '@_=split/,/; printf "%-18s %8.3f %8.3f %8.3f %8.3f\n", $$_[1], $$_[2], $$_[3], $$_[4], $$_[5]'
@@ -19,6 +19,7 @@ codespeed:
 #	@$(call spawn,$(JULIA_EXECUTABLE)) cat/perf.jl codespeed
 #	@$(call spawn,$(JULIA_EXECUTABLE)) blas/perf.jl codespeed
 #	@$(call spawn,$(JULIA_EXECUTABLE)) lapack/perf.jl codespeed
+#	@$(call spawn,$(JULIA_EXECUTABLE)) simd/perf.jl codespeed
 #	@$(call spawn,$(JULIA_EXECUTABLE)) sort/perf.jl codespeed
 	@$(call spawn,$(JULIA_EXECUTABLE)) spell/perf.jl codespeed
 	@$(call spawn,$(JULIA_EXECUTABLE)) sparse/perf.jl codespeed
@@ -30,4 +31,4 @@ clean:
 	$(MAKE) -C micro $@
 	$(MAKE) -C shootout $@
 
-.PHONY: micro kernel cat shootout blas lapack sort spell sparse clean
+.PHONY: micro kernel cat shootout blas lapack simd sort spell sparse clean

--- a/test/perf/simd/axpy.jl
+++ b/test/perf/simd/axpy.jl
@@ -1,0 +1,24 @@
+# Compute y += a*x using @simd for vectors x and y
+function simd_axpy( a, x, y )
+    # LLVM's auto-vectorizer typically vectorizes this loop even without @simd 
+    @simd for i=1:length(x)
+        @inbounds y[i] += a*x[i]
+    end
+end
+
+# Run axpy(a,x,y) m times
+function flog_axpy( m, a, x, y )
+    for j=1:m
+        simd_axpy(a,x,y)
+    end
+end
+
+# Run axpy for Float32 and Float64
+for t in [Float32,Float64]
+    n = 1000
+    x = rand(t,n)
+    y = rand(t,n)
+    a = convert(t,0.5)
+    bits = 8*sizeof(t)
+    @timeit(flog_axpy(100,a,x,y), "simd_axpy_$bits", "SIMD BLAS axpy for type $t", "SIMD")
+end

--- a/test/perf/simd/inner.jl
+++ b/test/perf/simd/inner.jl
@@ -1,0 +1,25 @@
+# Inner produce of x and y
+function inner( x, y )
+    s = zero(eltype(x))
+    @simd for i=1:length(x)
+        @inbounds s += x[i]*y[i]
+    end
+    s
+end
+
+function flog_inner( m, x, y )
+    s = zero(eltype(x))
+    for j=1:m
+        s += inner(x,y)
+    end
+    s
+end
+
+for t in [Float32,Float64]
+    n = 1000
+    x = rand(t,n)
+    y = rand(t,n)
+    bits = 8*sizeof(t)
+    @timeit(flog_inner(100,x,y), "inner_$bits", "SIMD inner product for type $t", "SIMD")
+end
+

--- a/test/perf/simd/perf.jl
+++ b/test/perf/simd/perf.jl
@@ -1,0 +1,6 @@
+include("../perfutil.jl")
+
+include("axpy.jl")
+include("sum_reduce.jl")
+include("inner.jl")
+include("seismic_fdtd.jl")

--- a/test/perf/simd/seismic_fdtd.jl
+++ b/test/perf/simd/seismic_fdtd.jl
@@ -1,0 +1,49 @@
+# Finite-difference time-domain seismic simulation in 2D using a staggered grid.
+# The intent is to test performance of @simd on the inner loop of a 2D loop nest.
+# 
+# If @simd ever supports forward-lexical dependences, then the kernels in updateV
+# and updateU can be merged.
+
+# Update velocity component fields Vx and Vy
+function updateV( irange, jrange, U, Vx, Vy, A )
+    for j in jrange
+        @simd for i in irange
+            @inbounds begin
+                Vx[i,j] += (A[i,j+1]+A[i,j])*(U[i,j+1]-U[i,j])  
+                Vy[i,j] += (A[i+1,j]+A[i,j])*(U[i+1,j]-U[i,j])
+            end
+        end
+    end
+end
+
+# Update pressure field U
+function updateU( irange, jrange, U, Vx, Vy, B )
+    for j in jrange
+        @simd for i in irange
+            @inbounds begin
+                U [i,j] += B[i,j]*((Vx[i,j]-Vx[i,j-1]) + (Vy[i,j]-Vy[i-1,j]))
+            end
+        end
+    end
+end
+
+# Alternate updates for given number of steps
+function flog_fdtd( steps, U, Vx, Vy, A, B ) 
+    m,n = size(U)
+    for k=1:steps
+         updateV(2:m-1,2:n-1,U,Vx,Vy,A) 
+         updateU(2:m-1,2:n-1,U,Vx,Vy,B) 
+    end
+end
+
+for t in [Float32,Float64]
+    m = 200
+    n = 200
+    A = fill(convert(t,0.2),m,n)
+    B = fill(convert(t,0.25),m,n)
+    U = rand(t,m,n) .- convert(t,.5)
+    Vx = zeros(t,m,n)
+    Vy = zeros(t,m,n)
+    bits = 8*sizeof(t)
+    @timeit(flog_fdtd(10,U,Vx,Vy,A,B),"seismic_fdtd_$bits","2D finite-difference seismic simulation for $t", "SIMD")
+end

--- a/test/perf/simd/sum_reduce.jl
+++ b/test/perf/simd/sum_reduce.jl
@@ -1,0 +1,24 @@
+function sum_reduce(x, istart, iend)
+    s = zero(eltype(x))
+    @simd for i = istart:iend
+        @inbounds s += x[i]
+    end
+    s
+end
+
+function flog_sum_reduce( m, x )
+    s = zero(eltype(x))
+    for j=1:m
+        # Try different starting and ending indices.
+        sum_reduce(x,j,length(x)-(j-1))
+    end
+    s    
+end
+
+for t in [Float32,Float64]
+    n = 1000
+    x = rand(t,n)
+    bits = 8*sizeof(t)
+    @timeit(flog_sum_reduce(100,x), "sum_reduction_$bits", "SIMD sum reduction over array of type $t", "SIMD")
+end
+


### PR DESCRIPTION
This PR adds performance tests for `@simd`.   There are 4 tests, which are run for `Float32` and `Float64`.  I suspect that LLVM is not vectorizing all the `Float64` cases, but that gives us something to shoot for.

This is the first time that I've contributed tests, so any style pointers appreciated.
