### PR TITLE
correct unparsing of Unicode binary operator expressions

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -893,6 +893,11 @@ DLLEXPORT int jl_is_operator(char *sym) {
              == FL_T;
 }
 
+DLLEXPORT int jl_operator_precedence(char *sym) {
+     return numval(fl_applyn(1, symbol_value(symbol("operator-precedence")),
+                             symbol(sym)));
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -45,6 +45,17 @@
 	    (eval `(define ,(symbol (string "is-" name "?")) (Set ,name))))
 	  prec-names)
 
+;; hash table of binary operators -> precedence
+(define prec-table (let ((t (table)))
+                     (define (pushprec L prec)
+                       (if (not (null? L))
+                           (begin
+                             (for-each (lambda (x) (put! t x prec)) (car L))
+                             (pushprec (cdr L) (+ prec 1)))))
+                     (pushprec (map eval prec-names) 1)
+                     t))
+(define (operator-precedence op) (get prec-table op 0))
+
 (define unary-ops '(+ - ! ¬ ~ |<:| |>:| √ ∛ ∜))
 
 ; operators that are both unary and binary

--- a/src/julia.h
+++ b/src/julia.h
@@ -951,6 +951,7 @@ DLLEXPORT jl_value_t *jl_compress_ast(jl_lambda_info_t *li, jl_value_t *ast);
 DLLEXPORT jl_value_t *jl_uncompress_ast(jl_lambda_info_t *li, jl_value_t *data);
 
 DLLEXPORT int jl_is_operator(char *sym);
+DLLEXPORT int jl_operator_precedence(char *sym);
 
 STATIC_INLINE int jl_vinfo_capt(jl_array_t *vi)
 {

--- a/test/show.jl
+++ b/test/show.jl
@@ -157,3 +157,7 @@ end"""
 @test_repr "foo.bar[1]"
 @test_repr "foo.bar()"
 @test_repr "(foo + bar)()"
+
+# unicode operator printing
+@test sprint(show, :(1 ⊕ (2 ⊗ 3))) == ":(1 ⊕ 2 ⊗ 3)"
+@test sprint(show, :((1 ⊕ 2) ⊗ 3)) == ":((1 ⊕ 2) ⊗ 3)"


### PR DESCRIPTION
This now gets operator precedences directly from `julia-parser.scm` rather than repeating them in `show.jl`.

Previously, `:(1 ⊕ 2 ⊗ 3)` would be shown as `":(⊕(1,⊗(2,3)))"` whereas now it is shown in infix form.
