### PR TITLE
workaround trouble from fix to #7845 with line endings

### DIFF
--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -232,10 +232,7 @@ end
 # so the rest of the terminal is 73 characters
 #########################################################################
 buf = IOBuffer(
-"""
-begin
-print("A very very very very very very very very very very very very ve")
-end""")
+"begin\nprint(\"A very very very very very very very very very very very very ve\")\nend")
 seek(buf,4)
 outbuf = IOBuffer()
 termbuf = Base.Terminals.TerminalBuffer(outbuf)


### PR DESCRIPTION
for any individuals who happen to check out test/lineedit.jl with a poorly
configured windows git, or make changes to the file in an antique editor

cc @Keno this should still capture the same test, if I revert the `base/LineEdit.jl` part of 75ec2a3994f9cbfe8c1a94d20c4e651d0cb41165 then it does fail as expected on Linux
