### PR TITLE
slight cleanup of Base.runtests()

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -353,6 +353,13 @@ function runtests(tests = ["all"], numcores = iceil(CPU_CORES/2))
     end
     ENV2 = copy(ENV)
     ENV2["JULIA_CPU_CORES"] = "$numcores"
-    run(setenv(`$JULIA_HOME/julia $(joinpath(JULIA_HOME,"..","share","julia",
-        "test","runtests.jl")) $tests`, ENV2))
+    try
+        run(setenv(`$(joinpath(JULIA_HOME, "julia")) $(joinpath(JULIA_HOME, "..",
+            "share", "julia", "test", "runtests.jl")) $tests`, ENV2))
+    catch
+        buf = PipeBuffer()
+        versioninfo(buf)
+        error("A test has failed. Please submit a bug report including error messages above\n" *
+            "and the output of versioninfo():\n$(readall(buf))")
+    end
 end

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -137,3 +137,19 @@ _________
 .. function:: with_handler(f, handler)
 
    Run the function ``f`` using the ``handler`` as the handler.
+
+
+Testing Base Julia
+==================
+
+Julia is under rapid development and has an extensive test suite to
+verify functionality across multiple platforms. If you build Julia
+from source, you can run this test suite with ``make test``. In a
+binary install, you can run the test suite using ``Base.runtests()``.
+
+.. currentmodule:: Base
+
+.. function:: runtests([tests=["all"] [, numcores=iceil(CPU_CORES/2) ]])
+
+   Run the Julia unit tests listed in ``tests``, which can be either a
+   string or an array of strings, using ``numcores`` processors.


### PR DESCRIPTION
following up on suggestions from #7846

use joinpath on the julia executable, wrap the process in a try catch
with a more specific error message than 'failed process'

I can also document this function (though it isn't exported) somewhere if anyone has a suggestion for which section to put it in.
