### PR TITLE
accept more Integer types for dims::Int... arguments

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -39,7 +39,7 @@ end
 
 strides(a::AbstractArray) = ntuple(ndims(a), i->stride(a,i))::Dims
 
-function isassigned(a::AbstractArray, i::Int...)
+function isassigned(a::AbstractArray, i::Integer...)
     # TODO
     try
         a[i...]
@@ -97,7 +97,7 @@ end
 
 ## Bounds-checking without errors ##
 in_bounds(l::Int, i::Integer) = 1 <= i <= l
-function in_bounds(sz::Dims, I::Int...)
+function in_bounds(sz::Dims, I::Integer...)
     n = length(I)
     for dim = 1:(n-1)
         1 <= I[dim] <= sz[dim] || return false
@@ -115,8 +115,8 @@ end
 similar{T}(a::AbstractArray{T})               = similar(a, T, size(a))
 similar   (a::AbstractArray, T)               = similar(a, T, size(a))
 similar{T}(a::AbstractArray{T}, dims::Dims)   = similar(a, T, dims)
-similar{T}(a::AbstractArray{T}, dims::Int...) = similar(a, T, dims)
-similar   (a::AbstractArray, T, dims::Int...) = similar(a, T, dims)
+similar{T}(a::AbstractArray{T}, dims::Integer...) = similar(a, T, convert(Dims, dims))
+similar   (a::AbstractArray, T, dims::Integer...) = similar(a, T, convert(Dims, dims))
 
 function reshape(a::AbstractArray, dims::Dims)
     if prod(dims) != length(a)
@@ -124,7 +124,7 @@ function reshape(a::AbstractArray, dims::Dims)
     end
     copy!(similar(a, dims), a)
 end
-reshape(a::AbstractArray, dims::Int...) = reshape(a, dims)
+reshape(a::AbstractArray, dims::Integer...) = reshape(a, convert(Dims, dims))
 
 vec(a::AbstractArray) = reshape(a,length(a))
 vec(a::AbstractVector) = a
@@ -644,7 +644,7 @@ function cat(catdim::Integer, X...)
     end
 
     ndimsC = max(catdim, d_max)
-    dimsC = ntuple(ndimsC, compute_dims)::(Int...)
+    dimsC = ntuple(ndimsC, compute_dims)::Dims
     typeC = promote_type(map(x->isa(x,AbstractArray) ? eltype(x) : typeof(x), X)...)
     C = similar(isa(X[1],AbstractArray) ? full(X[1]) : [X[1]], typeC, dimsC)
 
@@ -711,7 +711,7 @@ function cat_t(catdim::Integer, typeC, A::AbstractArray...)
     end
 
     ndimsC = max(catdim, d_max)
-    dimsC = ntuple(ndimsC, compute_dims)::(Int...)
+    dimsC = ntuple(ndimsC, compute_dims)::Dims
     C = similar(full(A[1]), typeC, dimsC)
 
     range = 1
@@ -739,7 +739,7 @@ function hvcat(nbc::Integer, as...)
     hvcat(ntuple(nbr, i->nbc), as...)
 end
 
-function hvcat{T}(rows::(Int...), as::AbstractMatrix{T}...)
+function hvcat{T}(rows::Dims, as::AbstractMatrix{T}...)
     nbr = length(rows)  # number of block rows
 
     nc = 0
@@ -782,9 +782,9 @@ function hvcat{T}(rows::(Int...), as::AbstractMatrix{T}...)
     out
 end
 
-hvcat(rows::(Int...)) = []
+hvcat(rows::Dims) = []
 
-function hvcat{T<:Number}(rows::(Int...), xs::T...)
+function hvcat{T<:Number}(rows::Dims, xs::T...)
     nr = length(rows)
     nc = rows[1]
 
@@ -817,7 +817,7 @@ function hvcat_fill(a, xs)
     a
 end
 
-function hvcat(rows::(Int...), xs::Number...)
+function hvcat(rows::Dims, xs::Number...)
     nr = length(rows)
     nc = rows[1]
     #error check
@@ -949,7 +949,7 @@ end
 ## Other array functions ##
 
 # fallback definition of hvcat in terms of hcat and vcat
-function hvcat(rows::(Int...), as...)
+function hvcat(rows::Dims, as...)
     nbr = length(rows)  # number of block rows
     rs = cell(nbr)
     a = 1
@@ -1131,7 +1131,7 @@ end
 ## iteration utilities ##
 
 # slow, but useful
-function cartesianmap(body, t::(Int...), it...)
+function cartesianmap(body, t::Dims, it...)
     idx = length(t)-length(it)
     if idx == 1
         for i = 1:t[1]

--- a/base/array.jl
+++ b/base/array.jl
@@ -27,6 +27,7 @@ strides{T}(a::Array{T,2}) = (1, size(a,1))
 strides{T}(a::Array{T,3}) = (1, size(a,1), size(a,1)*size(a,2))
 
 isassigned(a::Array, i::Int...) = isdefined(a, i...)
+isassigned(a::Array, i::Integer...) = isassigned(a, convert(Dims, i)...)
 
 ## copy ##
 
@@ -162,7 +163,7 @@ fill(v, dims::Dims)       = fill!(Array(typeof(v), dims), v)
 fill(v, dims::Integer...) = fill!(Array(typeof(v), dims...), v)
 
 cell(dims::Integer...)   = Array(Any, dims...)
-cell(dims::(Integer...)) = Array(Any, convert((Int...), dims))
+cell(dims::(Integer...)) = Array(Any, convert(Dims, dims))
 
 for (fname, felt) in ((:zeros,:zero), (:ones,:one))
     @eval begin

--- a/base/base.jl
+++ b/base/base.jl
@@ -21,6 +21,7 @@ tupletail(x::Tuple) = argtail(x...)
 convert(T::(Any, Any...), x::(Any, Any...)) =
     tuple(convert(T[1],x[1]), convert(tupletail(T), tupletail(x))...)
 
+convert{T}(::Type{(T...)}, x::(T...)) = x
 convert{T}(::Type{(T...)}, x::Tuple) = cnvt_all(T, x...)
 cnvt_all(T) = ()
 cnvt_all(T, x, rest...) = tuple(convert(T,x), cnvt_all(T, rest...)...)

--- a/base/darray.jl
+++ b/base/darray.jl
@@ -141,8 +141,8 @@ function localindexes(d::DArray)
 end
 
 # find which piece holds index (I...)
-function locate(d::DArray, I::Int...)
-    ntuple(ndims(d), i->searchsortedlast(d.cuts[i], I[i]))
+function locate(d::DArray, I::Integer...)
+    ntuple(ndims(d), i->searchsortedlast(d.cuts[i], int(I[i])))
 end
 
 chunk{T,N,A}(d::DArray{T,N,A}, i...) = fetch(d.chunks[i...])::A
@@ -150,15 +150,15 @@ chunk{T,N,A}(d::DArray{T,N,A}, i...) = fetch(d.chunks[i...])::A
 ## convenience constructors ##
 
 dzeros(args...) = DArray(I->zeros(map(length,I)), args...)
-dzeros(d::Int...) = dzeros(d)
+dzeros(d::Integer...) = dzeros(convert(Dims, d))
 dones(args...) = DArray(I->ones(map(length,I)), args...)
-dones(d::Int...) = dones(d)
+dones(d::Integer...) = dones(convert(Dims, d))
 dfill(v, args...) = DArray(I->fill(v, map(length,I)), args...)
-dfill(v, d::Int...) = dfill(v, d)
+dfill(v, d::Integer...) = dfill(v, convert(Dims, d))
 drand(args...)  = DArray(I->rand(map(length,I)), args...)
-drand(d::Int...) = drand(d)
+drand(d::Integer...) = drand(convert(Dims, d))
 drandn(args...) = DArray(I->randn(map(length,I)), args...)
-drandn(d::Int...) = drandn(d)
+drandn(d::Integer...) = drandn(convert(Dims, d))
 
 ## conversions ##
 
@@ -231,10 +231,10 @@ function getindex(r::RemoteRef, args...)
     end
 end
 
-getindex(d::DArray, i::Int) = getindex_tuple(d, ind2sub(size(d), i))
-getindex(d::DArray, i::Int...) = getindex_tuple(d, i)
+getindex(d::DArray, i::Integer) = getindex_tuple(d, ind2sub(size(d), int(i)))
+getindex(d::DArray, i::Integer...) = getindex_tuple(d, convert(Dims, i))
 
-function getindex_tuple{T}(d::DArray{T}, I::(Int...))
+function getindex_tuple{T}(d::DArray{T}, I::Dims)
     chidx = locate(d, I...)
     chunk = d.chunks[chidx...]
     idxs = d.indexes[chidx...]

--- a/base/io.jl
+++ b/base/io.jl
@@ -115,10 +115,8 @@ read(s::IO, ::Type{Float16}) = box(Float16,unbox(Int16,read(s,Int16)))
 read(s::IO, ::Type{Float32}) = box(Float32,unbox(Int32,read(s,Int32)))
 read(s::IO, ::Type{Float64}) = box(Float64,unbox(Int64,read(s,Int64)))
 
-read{T}(s::IO, t::Type{T}, d1::Int, dims::Int...) =
-    read(s, t, tuple(d1,dims...))
 read{T}(s::IO, t::Type{T}, d1::Integer, dims::Integer...) =
-    read(s, t, map(int,tuple(d1,dims...)))
+    read(s, t, tuple(int(d1), convert(Dims, dims)...))
 
 read{T}(s::IO, ::Type{T}, dims::Dims) = read!(s, Array(T, dims))
 

--- a/base/random.jl
+++ b/base/random.jl
@@ -116,13 +116,12 @@ rand(::Type{Int128})  = int128(rand(Uint128))
 # Arrays of random numbers
 
 rand(::Type{Float64}, dims::Dims) = rand!(Array(Float64, dims))
-rand(::Type{Float64}, dims::Int...) = rand(Float64, dims)
 
 rand(dims::Dims) = rand(Float64, dims)
-rand(dims::Int...) = rand(Float64, dims)
+rand(dims::Integer...) = rand(Float64, convert(Dims, dims))
 
 rand(r::AbstractRNG, dims::Dims) = rand!(r, Array(Float64, dims))
-rand(r::AbstractRNG, dims::Int...) = rand(r, dims)
+rand(r::AbstractRNG, dims::Integer...) = rand(r, dims)
 
 function rand!{T}(A::Array{T})
     for i=1:length(A)
@@ -140,8 +139,7 @@ end
 
 rand(T::Type, dims::Dims) = rand!(Array(T, dims))
 rand{T<:Number}(::Type{T}) = error("no random number generator for type $T; try a more specific type")
-rand{T<:Number}(::Type{T}, dims::Int...) = rand(T, dims)
-
+rand{T<:Number}(::Type{T}, dims::Integer...) = rand(T, convert(Dims, dims))
 
 ## Generate random integer within a range
 
@@ -234,7 +232,7 @@ function rand!{T}(r::Range{T}, A::AbstractArray)
 end
 
 rand{T}(r::Range{T}, dims::Dims) = rand!(r, Array(T, dims))
-rand(r::Range, dims::Int...) = rand(r, dims)
+rand(r::Range, dims::Integer...) = rand(r, convert(Dims, dims))
 
 
 ## random Bools
@@ -242,7 +240,7 @@ rand(r::Range, dims::Int...) = rand(r, dims)
 rand!(B::BitArray) = Base.bitarray_rand_fill!(B)
 
 randbool(dims::Dims) = rand!(BitArray(dims))
-randbool(dims::Int...) = rand!(BitArray(dims))
+randbool(dims::Integer...) = rand!(BitArray(convert(Dims, dims)))
 
 randbool() = ((dsfmt_randui32() & 1) == 1)
 randbool!(B::BitArray) = rand!(B)
@@ -257,7 +255,7 @@ randn(rng::MersenneTwister) = randmtzig_randn(rng.state)
 randn!(A::Array{Float64}) = (for i = 1:length(A);A[i] = randmtzig_randn();end;A)
 randn!(rng::MersenneTwister, A::Array{Float64}) = (for i = 1:length(A);A[i] = randmtzig_randn(rng.state);end;A)
 randn(dims::Dims) = randn!(Array(Float64, dims))
-randn(dims::Int...) = randn!(Array(Float64, dims...))
+randn(dims::Integer...) = randn!(Array(Float64, convert(Dims, dims)))
 
 ## random UUID generation
 

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -106,7 +106,8 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
     S
 end
 
-SharedArray(T, I::Int...; kwargs...) = SharedArray(T, I; kwargs...)
+SharedArray(T, I::Integer...; kwargs...) = SharedArray(T, convert(Dims, I);
+                                                       kwargs...)
 
 typealias SharedVector{T} SharedArray{T,1}
 typealias SharedMatrix{T} SharedArray{T,2}
@@ -243,7 +244,8 @@ end
 function shmem_fill(v, dims; kwargs...)
     SharedArray(typeof(v), dims; init = S->fill!(S.loc_subarr_1d, v), kwargs...)
 end
-shmem_fill(v, I::Int...; kwargs...) = shmem_fill(v, I; kwargs...)
+shmem_fill(v, I::Integer...; kwargs...) = shmem_fill(v, convert(Dims, I);
+                                                     kwargs...)
 
 # rand variant with range
 function shmem_rand(TR::Union(DataType, UnitRange), dims; kwargs...)
@@ -253,16 +255,16 @@ function shmem_rand(TR::Union(DataType, UnitRange), dims; kwargs...)
         SharedArray(TR, dims; init = S -> map!((x)->rand(TR), S.loc_subarr_1d), kwargs...)
     end
 end
-shmem_rand(TR::Union(DataType, UnitRange), i::Int; kwargs...) = shmem_rand(TR, (i,); kwargs...)
-shmem_rand(TR::Union(DataType, UnitRange), I::Int...; kwargs...) = shmem_rand(TR, I; kwargs...)
+shmem_rand(TR::Union(DataType, UnitRange), i::Integer; kwargs...) = shmem_rand(TR, (int(i),); kwargs...)
+shmem_rand(TR::Union(DataType, UnitRange), I::Integer...; kwargs...) = shmem_rand(TR, convert(Dims, I); kwargs...)
 
 shmem_rand(dims; kwargs...) = shmem_rand(Float64, dims; kwargs...)
-shmem_rand(I::Int...; kwargs...) = shmem_rand(I; kwargs...)
+shmem_rand(I::Integer...; kwargs...) = shmem_rand(convert(Dims, I); kwargs...)
 
 function shmem_randn(dims; kwargs...)
     SharedArray(Float64, dims; init = S-> map!((x)->randn(), S.loc_subarr_1d), kwargs...)
 end
-shmem_randn(I::Int...; kwargs...) = shmem_randn(I; kwargs...)
+shmem_randn(I::Integer...; kwargs...) = shmem_randn(convert(Dims, I); kwargs...)
 
 similar(S::SharedArray, T, dims::Dims) = SharedArray(T, dims; pids=procs(S))
 similar(S::SharedArray, T) = similar(S, T, size(S))

--- a/test/random.jl
+++ b/test/random.jl
@@ -160,3 +160,6 @@ a = uuid4()
 @test_throws ArgumentError UUID("550e8400e29b-41d4-a716-446655440000")
 @test_throws ArgumentError UUID("550e8400e29b-41d4-a716-44665544000098")
 @test_throws ArgumentError UUID("z50e8400-e29b-41d4-a716-446655440000")
+
+# #7956
+@test size(rand(int32(3), int8(4))) == (3,4)


### PR DESCRIPTION
[As discussed on the mailing list](https://groups.google.com/d/msg/julia-users/HvbCM0J-CjM/Rut_Syhlc8kJ), there's no real reason that functions like `rand(dims::Int...)` can't accept other `Integer` types.  This patch genericizes a number of functions in `Base` that took `Int...` arguments to accept `Integer...`.

There shouldn't be a performance penalty, since I made sure `convert(Dims, dims::Dims)` returns `dims` by adding a new diagonal tuple method to `convert`.

Functions accepting an explicit `(Int...)` (`== Dims`) tuple still require `Int`; it was too much of a pain to change these, and they are generally lower-level functions than the varargs functions.
