### PR TITLE
Add double, triple and quadruple primes to tab-completion

### DIFF
--- a/base/latex_symbols.jl
+++ b/base/latex_symbols.jl
@@ -47,6 +47,9 @@ const latex_symbols = [
     "\\cbrt" => "\u221B",
     "\\female" => "♀",
     "\\mars" => "♂",
+    "\\pprime" => "″",
+    "\\ppprime" => "‴",
+    "\\pppprime" => "⁗",
 
     # Superscripts
     "\\^0" => "⁰",

--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -117,8 +117,8 @@ DLLEXPORT int jl_id_char(uint32_t wc)
         cat == UTF8PROC_CATEGORY_ND || cat == UTF8PROC_CATEGORY_PC ||
         cat == UTF8PROC_CATEGORY_SK || cat == UTF8PROC_CATEGORY_ME ||
         cat == UTF8PROC_CATEGORY_NO ||
-        // primes
-        (wc >= 0x2032 && wc <= 0x2034) ||
+        // primes (single, double, triple, their reverses, and quadruple)
+        (wc >= 0x2032 && wc <= 0x2037) || (wc == 0x2057) ||
         // Other_ID_Continue
         wc == 0x0387 || wc == 0x19da || (wc >= 0x1369 && wc <= 0x1371))
         return 1;


### PR DESCRIPTION
moar Unicode goodness - in the reference w3c symbol mapping file, the multiple prime symbols are mapped to `''`, `'''` etc. and not their corresponding Unicode characters and therefore have to be special-cased.

Also add reversed single, double, triple primes as well as quadruple prime to allowable jl_id_char's

cc: @JeffBezanson 
