### PR TITLE
Adds \backpprime and \backppprime to tab-completion

### DIFF
--- a/base/latex_symbols.jl
+++ b/base/latex_symbols.jl
@@ -50,6 +50,8 @@ const latex_symbols = [
     "\\pprime" => "″",
     "\\ppprime" => "‴",
     "\\pppprime" => "⁗",
+    "\\backpprime" => "‶",
+    "\\backppprime" => "‷",
 
     # Superscripts
     "\\^0" => "⁰",


### PR DESCRIPTION
This PR extends #7961 by adding the _non-standard_ LaTeX-like commands for reversed double and triple primes respectively.
