### PR TITLE
Emacs highlighting fixes

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -106,6 +106,11 @@
      "baremodule" "importall" "immutable")
    'symbols))
 
+(defconst julia-builtin-regex
+  (regexp-opt
+   '("error" "throw")
+   'symbols))
+
 (defconst julia-font-lock-keywords
   (list
    '("\\<\\(\\|Uint\\(8\\|16\\|32\\|64\\|128\\)\\|Int\\(8\\|16\\|32\\|64\\|128\\)\\|BigInt\\|Integer\\|BigFloat\\|FloatingPoint\\|Float16\\|Float32\\|Float64\\|Complex128\\|Complex64\\|ComplexPair\\|Bool\\|Char\\|DataType\\|Number\\|Real\\|Int\\|Uint\\|Array\\|DArray\\|AbstractArray\\|AbstractVector\\|AbstractMatrix\\|AbstractSparseMatrix\\|SubArray\\|StridedArray\\|StridedVector\\|StridedMatrix\\|VecOrMat\\|StridedVecOrMat\\|DenseArray\\|Range\\|OrdinalRange\\|StepRange\\|UnitRange\\|FloatRange\\|SparseMatrixCSC\\|Tuple\\|NTuple\\|Symbol\\|Function\\|Vector\\|Matrix\\|Union\\|Type\\|Any\\|Complex\\|None\\|String\\|Ptr\\|Void\\|Exception\\|Task\\|Signed\\|Unsigned\\|Associative\\|Dict\\|IO\\|IOStream\\|Rational\\|Regex\\|RegexMatch\\|Set\\|IntSet\\|ASCIIString\\|UTF8String\\|ByteString\\|Expr\\|WeakRef\\|Nothing\\|ObjectIdDict\\|SubString\\)\\>" .
@@ -125,6 +130,7 @@
     (list julia-type-annotation-regex 1 'font-lock-type-face)
     (list julia-type-parameter-regex 1 'font-lock-type-face)
     (list julia-subtype-regex 1 'font-lock-type-face)
+    (list julia-builtin-regex 1 'font-lock-builtin-face)
 ))
 
 (defconst julia-block-start-keywords

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -83,13 +83,16 @@
   (rx symbol-start "function" (1+ space) (group (1+ (or word ?_ ?!)))))
 
 (defconst julia-type-regex
-  (rx symbol-start "type" (1+ space) (group (1+ (or word ?_)))))
+  (rx symbol-start (or "function" "type" "abstract") (1+ space) (group (1+ (or word ?_)))))
 
 (defconst julia-type-annotation-regex
   (rx "::" (group (1+ (or word ?_)))))
 
+(defconst julia-type-parameter-regex
+  (rx symbol-start (1+ (or word ?_)) "{" (group (1+ (or word ?_))) "}"))
+
 (defconst julia-subtype-regex
-  (rx "<:" (1+ space) (group (1+ (or word ?_)))))
+  (rx "<:" (1+ space) (group (1+ (or word ?_))) (0+ space) (or "\n" "{" "end")))
 
 (defconst julia-macro-regex
   "@\\w+")
@@ -119,6 +122,7 @@
     (list julia-function-regex 1 'font-lock-function-name-face)
     (list julia-type-regex 1 'font-lock-type-face)
     (list julia-type-annotation-regex 1 'font-lock-type-face)
+    (list julia-type-parameter-regex 1 'font-lock-type-face)
     (list julia-subtype-regex 1 'font-lock-type-face)
 ))
 

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -80,7 +80,12 @@
 ].* \\(in\\)\\(\\s-\\|$\\)+")
 
 (defconst julia-function-regex
-  (rx symbol-start "function" (1+ space) (group (1+ (or word ?_ ?!)))))
+  (rx symbol-start "function"
+      (1+ space)
+      ;; Don't highlight module names in function declarations:
+      (* (seq (1+ (or word ?_)) "."))
+      ;; The function name itself
+      (group (1+ (or word ?_ ?!)))))
 
 (defconst julia-type-regex
   (rx symbol-start (or "immutable" "type" "abstract") (1+ space) (group (1+ (or word ?_)))))

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -83,7 +83,7 @@
   (rx symbol-start "function" (1+ space) (group (1+ (or word ?_ ?!)))))
 
 (defconst julia-type-regex
-  (rx symbol-start (or "function" "type" "abstract") (1+ space) (group (1+ (or word ?_)))))
+  (rx symbol-start (or "immutable" "type" "abstract") (1+ space) (group (1+ (or word ?_)))))
 
 (defconst julia-type-annotation-regex
   (rx "::" (group (1+ (or word ?_)))))

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -114,7 +114,8 @@
     (cons julia-macro-regex 'font-lock-keyword-face)
     (cons
      (regexp-opt
-      '("true" "false" "C_NULL" "Inf" "NaN" "Inf32" "NaN32" "nothing"))
+      '("true" "false" "C_NULL" "Inf" "NaN" "Inf32" "NaN32" "nothing")
+      'symbols)
      'font-lock-constant-face)
     (list julia-unquote-regex 2 'font-lock-constant-face)
     (list julia-char-regex 2 'font-lock-string-face)

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -94,7 +94,8 @@
      "try" "catch" "return" "local" "abstract" "function" "macro" "ccall"
      "finally" "typealias" "break" "continue" "type" "global"
      "module" "using" "import" "export" "const" "let" "bitstype" "do"
-     "baremodule" "importall" "immutable")))
+     "baremodule" "importall" "immutable")
+   'symbols))
 
 (defconst julia-font-lock-keywords
   (list

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -93,7 +93,7 @@
    '("if" "else" "elseif" "while" "for" "begin" "end" "quote"
      "try" "catch" "return" "local" "abstract" "function" "macro" "ccall"
      "finally" "typealias" "break" "continue" "type" "global"
-     "module" "using" "import" "export" "const" "let" "bitstype" "do"
+     "module" "using" "import" "export" "const" "let" "bitstype" "do" "in"
      "baremodule" "importall" "immutable")
    'symbols))
 

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -85,6 +85,9 @@
 (defconst julia-type-regex
   (rx symbol-start "type" (1+ space) (group (1+ (or word ?_)))))
 
+(defconst julia-type-annotation-regex
+  (rx "::" (group (1+ (or word ?_)))))
+
 (defconst julia-macro-regex
   "@\\w+")
 
@@ -112,6 +115,7 @@
     (list julia-forloop-in-regex 1 'font-lock-keyword-face)
     (list julia-function-regex 1 'font-lock-function-name-face)
     (list julia-type-regex 1 'font-lock-type-face)
+    (list julia-type-annotation-regex 1 'font-lock-type-face)
 ))
 
 (defconst julia-block-start-keywords

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -88,6 +88,9 @@
 (defconst julia-type-annotation-regex
   (rx "::" (group (1+ (or word ?_)))))
 
+(defconst julia-subtype-regex
+  (rx "<:" (1+ space) (group (1+ (or word ?_)))))
+
 (defconst julia-macro-regex
   "@\\w+")
 
@@ -116,6 +119,7 @@
     (list julia-function-regex 1 'font-lock-function-name-face)
     (list julia-type-regex 1 'font-lock-type-face)
     (list julia-type-annotation-regex 1 'font-lock-type-face)
+    (list julia-subtype-regex 1 'font-lock-type-face)
 ))
 
 (defconst julia-block-start-keywords


### PR DESCRIPTION
Some further fixes to Emacs syntax highlighting, see the individual commit message for the gory details.
