### PR TITLE
Adds DOI badge from Zenodo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 </div>
 
 [![Build Status](https://api.travis-ci.org/JuliaLang/julia.svg?branch=master)](https://travis-ci.org/JuliaLang/julia)
+[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.11242.png)](http://dx.doi.org/10.5281/zenodo.11242)
 
 <a name="The-Julia-Language"/>
 ## The Julia Language


### PR DESCRIPTION
Note that the DOI is for 0.3-rc3. I'm not sure how it's going to be
possible to tag an actual release that has the correct DOI reference in
the README of that release.
