### PR TITLE
fix packages being uninstalled / reinstalled when running Pkg.test  with REQUIRES

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -667,15 +667,15 @@ function updatehook(pkgs::Vector)
 end
 
 function test!(pkg::String, errs::Vector{String}, notests::Vector{String}; coverage::Bool=false)
-    const reqs_path = abspath(pkg,"test","REQUIRE")
+    reqs_path = abspath(pkg,"test","REQUIRE")
     if isfile(reqs_path)
-        const tests_require = Reqs.parse(reqs_path)
+        tests_require = Reqs.parse(reqs_path)
         if (!isempty(tests_require))
             info("Computing test dependencies for $pkg...")
-            resolve(tests_require)
+            resolve(merge(Reqs.parse("REQUIRE"), tests_require))
         end
     end
-    const test_path = abspath(pkg,"test","runtests.jl")
+    test_path = abspath(pkg,"test","runtests.jl")
     if isfile(test_path)
         info("Testing $pkg")
         cd(dirname(test_path)) do


### PR DESCRIPTION
hopefully fixes https://github.com/JuliaLang/julia/issues/7967

Edit: This uninstalls test requirements after the tests are finished which is probably not the desired behavior.  What is the desired behavior exactly?  I'm assuming that we want to permanently install the test dependencies only when the tests run.  I'll modify the behavior tomorrow if this is the case.
