### PR TITLE
Update base.rst to fix Sphinx inline literal warning

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -5294,7 +5294,7 @@ System
 
 .. function:: chmod(path, mode)
 
-   Change the permissions mode of ``path`` to ``mode``. Only integer ``mode``s
+   Change the permissions mode of ``path`` to ``mode``. Only integer ``mode``\ s
    (e.g. 0o777) are currently supported.
 
 .. function:: getpid() -> Int32


### PR DESCRIPTION
Fix string literal warning and properly format output.

```
reading sources... [100%] stdlib/base                                           
/usr/local/src/julia/julia/doc/stdlib/base.rst:5297: WARNING: Inline literal start-string without end-string.
```
