### PR TITLE
Preserve point position when indenting.

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -272,9 +272,7 @@ Do not move back beyond MIN."
     ;; Point is now at the beginning of indentation, restore it
     ;; to its original position (relative to indentation).
     (when (>= point-offset 0)
-      (move-to-column (+ (current-indentation) point-offset)))
-    (when (julia-at-keyword julia-block-end-keywords)
-      (forward-word 1))))
+      (move-to-column (+ (current-indentation) point-offset)))))
 
 (defalias 'julia-mode-prog-mode
   (if (fboundp 'prog-mode)

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -245,7 +245,7 @@ Do not move back beyond MIN."
 (defun julia-indent-line ()
   "Indent current line of julia code."
   (interactive)
-;  (save-excursion
+  (let* ((point-offset (- (current-column) (current-indentation))))
     (end-of-line)
     (indent-line-to
      (or (save-excursion (ignore-errors (julia-paren-indent)))
@@ -255,22 +255,26 @@ Do not move back beyond MIN."
                            (forward-to-indentation 0)
                            (julia-at-keyword julia-block-end-keywords))))
              (ignore-errors (+ (julia-last-open-block (point-min))
-                           (if endtok (- julia-basic-offset) 0)))))
-	 ;; previous line ends in =
-	 (save-excursion
-	   (if (and (not (equal (point-min) (line-beginning-position)))
-		    (progn
-		      (forward-line -1)
-		      (end-of-line) (backward-char 1)
-		      (equal (char-after (point)) ?=)))
-	       (+ julia-basic-offset (current-indentation))
-	     nil))
-	 ;; take same indentation as previous line
-	 (save-excursion (forward-line -1)
-			 (current-indentation))
+                               (if endtok (- julia-basic-offset) 0)))))
+         ;; previous line ends in =
+         (save-excursion
+           (if (and (not (equal (point-min) (line-beginning-position)))
+                    (progn
+                      (forward-line -1)
+                      (end-of-line) (backward-char 1)
+                      (equal (char-after (point)) ?=)))
+               (+ julia-basic-offset (current-indentation))
+             nil))
+         ;; take same indentation as previous line
+         (save-excursion (forward-line -1)
+                         (current-indentation))
          0))
+    ;; Point is now at the beginning of indentation, restore it
+    ;; to its original position (relative to indentation).
+    (when (>= point-offset 0)
+      (move-to-column (+ (current-indentation) point-offset)))
     (when (julia-at-keyword julia-block-end-keywords)
-      (forward-word 1)))
+      (forward-word 1))))
 
 (defalias 'julia-mode-prog-mode
   (if (fboundp 'prog-mode)


### PR DESCRIPTION
Fixes #7966.

The new logic is as follows:

If point is in the leading whitespace, jump to the first non-whitespace
character.

```
Before:
  |  foo
After <tab>:
    |foo
```

If point is on non-whitespace character, preserve its offset after
indentation.

```
Before:
  fo|o
After <tab>:
    fo|o
```

Finally, if point is on an end keyword (see `julia-block-end-keywords`),
then skip to the end. This allows repeated `<tab>` to navigate out of
blocks.

```
Before:
|        end
    end
<tab> once:
        end|
    end
<tab> again:
        end
    end|
```
