### PR TITLE
PriorityQueue: use O(logN) algorithm for dequeue!(pq, key)

### DIFF
--- a/base/collections.jl
+++ b/base/collections.jl
@@ -254,6 +254,7 @@ function setindex!{K,V}(pq::PriorityQueue{K, V}, value, key)
     else
         enqueue!(pq, key, value)
     end
+    value
 end
 
 

--- a/base/collections.jl
+++ b/base/collections.jl
@@ -179,7 +179,7 @@ PriorityQueue{K,V}(a::AbstractArray{(K,V)}, o::Ordering=Forward) = PriorityQueue
 length(pq::PriorityQueue) = length(pq.xs)
 isempty(pq::PriorityQueue) = isempty(pq.xs)
 haskey(pq::PriorityQueue, key) = haskey(pq.index, key)
-peek(pq::PriorityQueue) = pq.xs[1]
+peek(pq::PriorityQueue) = (kv = pq.xs[1]; (kv.a, kv.b))
 
 
 function percolate_down!(pq::PriorityQueue, i::Integer)

--- a/base/collections.jl
+++ b/base/collections.jl
@@ -1,10 +1,11 @@
 
 module Collections
 
-import Base: setindex!, done, get, haskey, isempty, length, next, getindex, start
+import Base: setindex!, done, get, hash, haskey, isempty, length, next, getindex, start
 import ..Order: Forward, Ordering, lt
 
 export
+    Pair,
     PriorityQueue,
     dequeue!,
     enqueue!,
@@ -106,37 +107,48 @@ end
 # PriorityQueue
 # -------------
 
+immutable Pair{A,B}
+    a::A
+    b::B
+end
+
+function hash(p::Pair, h::Uint)
+    h = hash(p.a, h)
+    hash(p.b, h)
+end
+hash(p::Pair) = hash(p, zero(Uint))
+
 # A PriorityQueue that acts like a Dict, mapping values to their priorities,
 # with the addition of a dequeue! function to remove the lowest priority
 # element.
-type PriorityQueue{K,V} <: Associative{K,V}
+type PriorityQueue{K,V,O<:Ordering} <: Associative{K,V}
     # Binary heap of (element, priority) pairs.
-    xs::Array{(K, V), 1}
-    o::Ordering
+    xs::Array{Pair{K,V}, 1}
+    o::O
 
     # Map elements to their index in xs
     index::Dict{K, Int}
 
-    function PriorityQueue(o::Ordering)
-        new(Array((K, V), 0), o, Dict{K, Int}())
+    function PriorityQueue(o::O)
+        new(Array(Pair{K,V}, 0), o, Dict{K, Int}())
     end
 
-    PriorityQueue() = PriorityQueue{K,V}(Forward)
+    PriorityQueue() = PriorityQueue{K,V,O}(Forward)
 
     function PriorityQueue(ks::AbstractArray{K}, vs::AbstractArray{V},
-                           o::Ordering)
+                           o::O)
         # TODO: maybe deprecate
         if length(ks) != length(vs)
             error("key and value arrays must have equal lengths")
         end
-        PriorityQueue{K,V}(zip(ks, vs), o)
+        PriorityQueue{K,V,O}(zip(ks, vs), o)
     end
 
-    function PriorityQueue(itr, o::Ordering)
-        xs = Array((K, V), length(itr))
+    function PriorityQueue(itr, o::O)
+        xs = Array(Pair{K,V}, length(itr))
         index = Dict{K, Int}()
         for (i, (k, v)) in enumerate(itr)
-            xs[i] = (k, v)
+            xs[i] = Pair{K,V}(k, v)
             if haskey(index, k)
                 error("PriorityQueue keys must be unique")
             end
@@ -153,15 +165,16 @@ type PriorityQueue{K,V} <: Associative{K,V}
     end
 end
 
-PriorityQueue(o::Ordering=Forward) = PriorityQueue{Any,Any}(o)
+PriorityQueue(o::Ordering=Forward) = PriorityQueue{Any,Any,typeof(o)}(o)
+PriorityQueue{K,V}(::Type{K}, ::Type{V}, o::Ordering=Forward) = PriorityQueue{K,V,typeof(o)}(o)
 
 # TODO: maybe deprecate
 PriorityQueue{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V},
-                   o::Ordering=Forward) = PriorityQueue{K,V}(ks, vs, o)
+                   o::Ordering=Forward) = PriorityQueue{K,V,typeof(o)}(ks, vs, o)
 
-PriorityQueue{K,V}(kvs::Associative{K,V}, o::Ordering=Forward) = PriorityQueue{K,V}(kvs, o)
+PriorityQueue{K,V}(kvs::Associative{K,V}, o::Ordering=Forward) = PriorityQueue{K,V,typeof(o)}(kvs, o)
 
-PriorityQueue{K,V}(a::AbstractArray{(K,V)}, o::Ordering=Forward) = PriorityQueue{K,V}(a, o)
+PriorityQueue{K,V}(a::AbstractArray{(K,V)}, o::Ordering=Forward) = PriorityQueue{K,V,typeof(o)}(a, o)
 
 length(pq::PriorityQueue) = length(pq.xs)
 isempty(pq::PriorityQueue) = isempty(pq.xs)
@@ -173,16 +186,16 @@ function percolate_down!(pq::PriorityQueue, i::Integer)
     x = pq.xs[i]
     @inbounds while (l = heapleft(i)) <= length(pq)
         r = heapright(i)
-        j = r > length(pq) || lt(pq.o, pq.xs[l][2], pq.xs[r][2]) ? l : r
-        if lt(pq.o, pq.xs[j][2], x[2])
-            pq.index[pq.xs[j][1]] = i
+        j = r > length(pq) || lt(pq.o, pq.xs[l].b, pq.xs[r].b) ? l : r
+        if lt(pq.o, pq.xs[j].b, x.b)
+            pq.index[pq.xs[j].a] = i
             pq.xs[i] = pq.xs[j]
             i = j
         else
             break
         end
     end
-    pq.index[x[1]] = i
+    pq.index[x.a] = i
     pq.xs[i] = x
 end
 
@@ -191,27 +204,39 @@ function percolate_up!(pq::PriorityQueue, i::Integer)
     x = pq.xs[i]
     @inbounds while i > 1
         j = heapparent(i)
-        if lt(pq.o, x[2], pq.xs[j][2])
-            pq.index[pq.xs[j][1]] = i
+        if lt(pq.o, x.b, pq.xs[j].b)
+            pq.index[pq.xs[j].a] = i
             pq.xs[i] = pq.xs[j]
             i = j
         else
             break
         end
     end
-    pq.index[x[1]] = i
+    pq.index[x.a] = i
     pq.xs[i] = x
 end
 
+# Equivalent to percolate_up! with an element having lower priority than any other
+function force_up!(pq::PriorityQueue, i::Integer)
+    x = pq.xs[i]
+    @inbounds while i > 1
+        j = heapparent(i)
+        pq.index[pq.xs[j].a] = i
+        pq.xs[i] = pq.xs[j]
+        i = j
+    end
+    pq.index[x.a] = i
+    pq.xs[i] = x
+end
 
 function getindex{K,V}(pq::PriorityQueue{K,V}, key)
-    pq.xs[pq.index[key]][2]
+    pq.xs[pq.index[key]].b
 end
 
 
 function get{K,V}(pq::PriorityQueue{K,V}, key, deflt)
     i = get(pq.index, key, 0)
-    i == 0 ? deflt : pq.xs[i][2]
+    i == 0 ? deflt : pq.xs[i].b
 end
 
 
@@ -219,8 +244,8 @@ end
 function setindex!{K,V}(pq::PriorityQueue{K, V}, value, key)
     if haskey(pq, key)
         i = pq.index[key]
-        _, oldvalue = pq.xs[i]
-        pq.xs[i] = (key, value)
+        oldvalue = pq.xs[i].b
+        pq.xs[i] = Pair{K,V}(key, value)
         if lt(pq.o, oldvalue, value)
             percolate_down!(pq, i)
         else
@@ -237,7 +262,7 @@ function enqueue!{K,V}(pq::PriorityQueue{K,V}, key, value)
         error("PriorityQueue keys must be unique")
     end
 
-    push!(pq.xs, (key, value))
+    push!(pq.xs, Pair{K,V}(key, value))
     pq.index[key] = length(pq)
     percolate_up!(pq, length(pq))
     pq
@@ -249,19 +274,17 @@ function dequeue!(pq::PriorityQueue)
     y = pop!(pq.xs)
     if !isempty(pq)
         pq.xs[1] = y
-        pq.index[pq.xs[1][1]] = 1
+        pq.index[y.a] = 1
         percolate_down!(pq, 1)
     end
-    delete!(pq.index, x[1])
-    x[1]
+    delete!(pq.index, x.a)
+    x.a
 end
 
 function dequeue!(pq::PriorityQueue, key)
-    idx = pop!(pq.index, key)  # throws key error if missing
-    deleteat!(pq.xs, idx)
-    for (k,v) in pq.index
-        (v >= idx) && (pq.index[k] = (v-1))
-    end
+    idx = pq.index[key]
+    force_up!(pq, idx)
+    dequeue!(pq)
     key
 end
 
@@ -273,7 +296,7 @@ done(pq::PriorityQueue, i) = done(pq.index, i)
 
 function next(pq::PriorityQueue, i)
     (k, idx), i = next(pq.index, i)
-    return ((k, pq.xs[idx][2]), i)
+    return ((k, pq.xs[idx].b), i)
 end
 
 

--- a/test/priorityqueue.jl
+++ b/test/priorityqueue.jl
@@ -12,14 +12,26 @@ function test_issorted!(pq::PriorityQueue, priorities)
     end
 end
 
+function test_isrequested!(pq::PriorityQueue, keys)
+    i = 0
+    while !isempty(pq)
+        krqst =  keys[i+=1]
+        krcvd = dequeue!(pq, krqst)
+        @test krcvd == krqst
+    end
+end
+
 pmax = 1000
 n = 10000
-priorities = Dict(1:n, rand(1:pmax, n))
+r = rand(1:pmax, n)
+priorities = Dict(1:n, r)
 
 # building from a dict
 pq = PriorityQueue(priorities)
 test_issorted!(pq, priorities)
 
+pq = PriorityQueue(priorities)
+test_isrequested!(pq, 1:n)
 
 # building from two lists
 ks, vs = 1:n, rand(1:pmax, n)


### PR DESCRIPTION
This PR should speed up some of my own work by a factor of 10^4 or so. The main highlight is switching from an `O(N)` algorithm to one that's `O(logN)` in `dequeue!(pq, key)`. That change should not be controversial.

However, I made a couple of other changes that might merit some discussion:
- The old version contained a field `o::Ordering`, but `Ordering` is an abstract type. Consequently calls that involved `lt` had to use generic fallback paths, and allocated lots of memory. I added the specific ordering type to the parameters. However, **this is breaking** since anyone who formerly wrote `pq = PriorityQueue{K,V}()` will have to change it. Because it's quite irritating to have to write `pq = PriorityQueue{K,V,typeof(Base.Order.Forward)}()`, I added the following constructor variant: `pq = PriorityQueue(K,V)`. I am a little worried this might cause trouble in ways I'm not thinking of. The performance enhancement from this change is not as huge at the change in the `dequeue(pq, key)` algorithm (as you'll see below), but it's still a factor of 2 or so and it affects basically all operations with PriorityQueues. So to me it seems worth it.
- Because tuples still aren't fully optimized, I switched to using an immutable `Pair` for storing the key, value pairs.

Here are some benchmark results using a version identical to what I checked in here, but outside of `Base` so that it allows direct comparison in the same session:

``` julia
import Base.Collections
import Collections2

function rundequeue1(pq::Collections.PriorityQueue)
    i = 0
    while !isempty(pq)
        Collections.dequeue!(pq)
    end
end
function rundequeue1(pq::Collections2.PriorityQueue)
    i = 0
    while !isempty(pq)
        Collections2.dequeue!(pq)
    end
end

function rundequeue(pq::Collections.PriorityQueue, indexes)
    for i in indexes
#         i == Collections.dequeue!(pq, i) || error("whoops")
        Collections.dequeue!(pq, i)
    end
end
function rundequeue(pq::Collections2.PriorityQueue, indexes)
    for i in indexes
#         i == Collections2.dequeue!(pq, i) || error("whoops")
        Collections2.dequeue!(pq, i)
    end
end

n = 10
r = rand(n)
p = sortperm(r)
pq = Collections.PriorityQueue(1:n, r)
# rundequeue1(pq, p)
rundequeue1(pq)
pq = Collections2.PriorityQueue(1:n, r)
# rundequeue1(pq, p)
rundequeue1(pq)
pq = Collections.PriorityQueue(1:n, r)
rundequeue(pq, 1:n)
pq = Collections2.PriorityQueue(1:n, r)
rundequeue(pq, 1:n)
pq = Collections2.PriorityQueue(1:n, r)
@time rundequeue1(pq)  # run @time once so we get good allocation stats

n = 10^4
r = rand(n)
pq = Collections.PriorityQueue(1:n, r)
gc()
@time rundequeue1(pq)
pq = Collections2.PriorityQueue(1:n, r)
gc()
@time rundequeue1(pq)
pq = Collections.PriorityQueue(1:n, r)
gc()
@time rundequeue(pq,1:n)
pq = Collections2.PriorityQueue(1:n, r)
gc()
@time rundequeue(pq,1:n)

n = 10
# ks = [(i, i) for i = 1:n]
ks = Collections2.Pair{Int,Int}[Collections2.Pair(i,i) for i = 1:n]
r = rand(n)
sks = ks[sortperm(r)]
pq = Collections.PriorityQueue(ks, r)
rundequeue1(pq)
pq = Collections2.PriorityQueue(ks, r)
rundequeue1(pq)
pq = Collections.PriorityQueue(ks, r)
rundequeue(pq, ks)
pq = Collections2.PriorityQueue(ks, r)
rundequeue(pq, ks)

n = 10^4
# ks = (Int,Int)[(i, i) for i = 1:n]
ks = Collections2.Pair{Int,Int}[Collections2.Pair(i,i) for i = 1:n]
r = rand(n)
pq = Collections.PriorityQueue(ks, r)
gc()
@time rundequeue1(pq)
pq = Collections2.PriorityQueue(ks, r)
gc()
@time rundequeue1(pq)
pq = Collections.PriorityQueue(ks, r)
gc()
@time rundequeue(pq, ks)
pq = Collections2.PriorityQueue(ks, r)
gc()
@time rundequeue(pq, ks)
```

Results:

```
elapsed time: 0.000714793 seconds (13848 bytes allocated)  # @time warmup
elapsed time: 0.02635067 seconds (9735568 bytes allocated)   # old dequeue(pq), Int keys
elapsed time: 0.008842291 seconds (80 bytes allocated)           # new dequeue(pq), Intkeys
elapsed time: 2.598704021 seconds (104 bytes allocated)      # old dequeue(pq, key), Int keys
elapsed time: 0.017406964 seconds (104 bytes allocated)      # new dequeue(pq, key), Int keys
# Rest are with Pair{Int,Int} keys
elapsed time: 0.030444504 seconds (10851880 bytes allocated)
elapsed time: 0.01073713 seconds (80 bytes allocated)
elapsed time: 2.920255148 seconds (80 bytes allocated)
elapsed time: 0.017320849 seconds (80 bytes allocated)
```

Since my own problems are more likely to be in the `10^6-10^7` range, the actual expected benefits are of course much larger.
