### PR TITLE
Enable parsing (and ignoring) of Debian epoch in version string

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -61,6 +61,7 @@ convert(::Type{VersionNumber}, v::Tuple) = VersionNumber(v...)
 
 const VERSION_REGEX = r"^
     v?                                      # prefix        (optional)
+    (?:[0-9]+\:)?                           # epoch         (optional, skipped)
     (\d+)                                   # major         (required)
     (?:\.(\d+))?                            # minor         (optional)
     (?:\.(\d+))?                            # patch         (optional)


### PR DESCRIPTION
Allows parsing of strings like "5:9.16-0ubuntu0.14.04.1+fdkaac".  The epoch (5 here) is ignored.

See http://manpages.ubuntu.com/manpages/oneiric/man5/deb-version.5.html
