### PR TITLE
Cleanup `make dist`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ include $(JULIAHOME)/Make.inc
 # so that prefix/share/julia/VERSDIR can be overwritten without touching
 # third-party code).
 VERSDIR = v`cut -d. -f1-2 < VERSION`
-INSTALL_F = install -pm644
-INSTALL_M = install -pm755
+INSTALL_F = contrib/install.sh 644
+INSTALL_M = contrib/install.sh 755
 
 #file name of make dist result
 ifeq ($(JULIA_DIST_TARNAME),)
@@ -247,15 +247,6 @@ endif
 	done
 endif
 
-ifeq ($(USE_SYSTEM_LIBUV),0)
-ifeq ($(OS),WINNT)
-	$(INSTALL_M) $(build_libdir)/libuv.a $(DESTDIR)$(private_libdir)
-	$(INSTALL_F) $(build_includedir)/tree.h $(DESTDIR)$(includedir)/julia
-else
-	$(INSTALL_M) $(build_libdir)/libuv.a $(DESTDIR)$(private_libdir)
-endif
-	$(INSTALL_F) $(build_includedir)/uv* $(DESTDIR)$(includedir)/julia
-endif
 	$(INSTALL_F) src/julia.h src/options.h src/support/*.h $(DESTDIR)$(includedir)/julia
 	# Copy system image
 	$(INSTALL_F) $(build_private_libdir)/sys.ji $(DESTDIR)$(private_libdir)

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Usage: very similar to `install`
+#   install.sh 755 src1 src2 ... dest
+
+PERMS=$1
+shift
+
+ARGS=""
+while [ $# -gt 1 ]; do
+    ARGS="$ARGS $1"
+    shift
+done
+DEST=$1
+
+for SRC in $ARGS; do
+    # Copy file, then take output of the form 'src' -> 'dest' and get only 'dest'
+    DESTFILE=$(cp -va $SRC $DEST | sed -e $'s/ -> /\\\n/g' | tail -n 1)
+
+    # If there are surrounding quotes, remove them.  We do this simply by knowing that the destination is always an absolute path
+    if [ "$(echo $DESTFILE | head -c1)" != "/" ]; then
+        DESTFILE=$(echo $DESTFILE | awk '{print substr($0, 2, length-2)}')
+    fi
+
+    # Do the chmod dance, and ignore errors on platforms that don't like setting permissions of symlinks
+    chmod $PERMS $DESTFILE 2>/dev/null
+done


### PR DESCRIPTION
- No longer install anything related to libuv with `make dist`
- Use custom `install` imposter; copy symlinks correctly to drastically reduce `make dist` size.

Tested on OSX and Linux (Ubuntu)
