### PR TITLE
use winepath and spawn with stringreplace

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -742,22 +742,20 @@ else
 endif
 endef
 
-ifeq ($(BUILD_OS), WINNT)
+ifeq ($(BUILD_OS), WINNT) # MSYS
 spawn = $(1)
-else ifneq (,$(findstring CYGWIN,$(BUILD_OS)))
+cygpath_w = $(1)
+else ifneq (,$(findstring CYGWIN,$(BUILD_OS))) # Cygwin
 spawn = $(1)
-else
-ifeq ($(OS), WINNT)
-spawn = wine $(1)
-else
-spawn = $(1)
-endif
-endif
-
-ifneq (,$(findstring CYGWIN,$(BUILD_OS)))
 cygpath_w = `cygpath -w $(1)`
 else
+ifeq ($(OS), WINNT) # unix-to-Windows cross-compile
+spawn = wine $(1)
+cygpath_w = `winepath -w $(1)`
+else # not Windows
+spawn = $(1)
 cygpath_w = $(1)
+endif
 endif
 
 exec = $(shell $(call spawn,$(1)))

--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ endif
 
 	# Overwrite JL_SYSTEM_IMAGE_PATH in julia binaries:
 	for julia in $(DESTDIR)$(bindir)/julia* ; do \
-		$(build_bindir)/stringreplace $$(strings -t x - $$julia | grep "sys.ji$$" | awk '{print $$1;}' ) "$(private_libdir_rel)/sys.ji" 256 $(call cygpath_w,$$julia); \
+		$(call spawn,$(build_bindir)/stringreplace $$(strings -t x - $$julia | grep "sys.ji$$" | awk '{print $$1;}' ) "$(private_libdir_rel)/sys.ji" 256 $(call cygpath_w,$$julia)); \
 	done
 
 	mkdir -p $(DESTDIR)$(sysconfdir)


### PR DESCRIPTION
for cross compiling - wine apparently auto-mounts and translates /home,
but if you build julia somewhere else then mingw-compiled stringreplace
can't understand unix paths (same issue as on cygwin)
