### PR TITLE
Add fallback constructor for similar() on ranges 

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -164,6 +164,7 @@ linrange(a::Real, b::Real, len::Integer) =
 
 ## interface implementations
 
+similar(r::Range, T::Type, dims::(Integer...)) = Array(T, dims...)
 similar(r::Range, T::Type, dims::Dims) = Array(T, dims)
 
 size(r::Range) = (length(r),)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -344,3 +344,9 @@ for r in (0:1, 0.0:1.0)
     @test r*im == [r]*im
     @test r/im == [r]/im
 end
+
+# issue #7709
+@test length(map(identity, 0x01:0x05)) == 5
+@test length(map(identity, 0x0001:0x0005)) == 5
+@test length(map(identity, uint64(1):uint64(5))) == 5
+@test length(map(identity, uint128(1):uint128(5))) == 5


### PR DESCRIPTION
that takes a dims::(Integer...) argument. This allows similar to work on ranges where the return type on size() doesn't necessarily equal Dims::(Int...). Fixes #7709.
