### PR TITLE
Use double-double precision for sinpi/cospi

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1,8 +1,8 @@
-immutable Double64
+immutable DoubleFloat64
     hi::Float64
     lo::Float64
 end
-immutable Double32
+immutable DoubleFloat32
     hi::Float64
 end
 
@@ -17,7 +17,7 @@ end
 ## software is freely granted, provided that this notice
 ## is preserved.
 
-function sin_kernel(x::Double64)
+function sin_kernel(x::DoubleFloat64)
     S1 = -1.66666666666666324348e-01
     S2 =  8.33333333332248946124e-03
     S3 = -1.98412698298579493134e-04
@@ -32,7 +32,7 @@ function sin_kernel(x::Double64)
     x.hi-((z*(0.5*x.lo-v*r)-x.lo)-v*S1)
 end
 
-function cos_kernel(x::Double64)
+function cos_kernel(x::DoubleFloat64)
     C1 =  4.16666666666666019037e-02
     C2 = -1.38888888888741095749e-03
     C3 =  2.48015872894767294178e-05
@@ -48,7 +48,7 @@ function cos_kernel(x::Double64)
     w + (((1.0-w)-hz) + (z*r-x.hi*x.lo))
 end
 
-function sin_kernel(x::Double32)
+function sin_kernel(x::DoubleFloat32)
     S1 = -0x15555554cbac77.0p-55
     S2 =  0x111110896efbb2.0p-59
     S3 = -0x1a00f9e2cae774.0p-65
@@ -61,7 +61,7 @@ function sin_kernel(x::Double32)
     float32((x.hi + s*(S1+z*S2)) + s*w*r)
 end
 
-function cos_kernel(x::Double32)
+function cos_kernel(x::DoubleFloat32)
     C0 = -0x1ffffffd0c5e81.0p-54
     C1 =  0x155553e1053a42.0p-57
     C2 = -0x16c087e80f1e27.0p-62
@@ -90,9 +90,9 @@ function mulpi_ext(x::Float64)
     y_hi = m*x
     y_lo = x_hi * m_lo + (x_lo* m_hi + ((x_hi*m_hi-y_hi) + x_lo*m_lo))
 
-    Double64(y_hi,y_lo)
+    DoubleFloat64(y_hi,y_lo)
 end
-mulpi_ext(x::Float32) = Double32(pi*float64(x))
+mulpi_ext(x::Float32) = DoubleFloat32(pi*float64(x))
 mulpi_ext(x::Rational) = mulpi_ext(float(x))
 mulpi_ext(x::Real) = pi*x # Fallback
 
@@ -227,9 +227,9 @@ function deg2rad_ext(x::Float64)
     y_hi = m*x
     y_lo = x_hi * m_lo + (x_lo* m_hi + ((x_hi*m_hi-y_hi) + x_lo*m_lo))
 
-    Double64(y_hi,y_lo)
+    DoubleFloat64(y_hi,y_lo)
 end
-deg2rad_ext(x::Float32) = Double32(deg2rad(float64(x)))
+deg2rad_ext(x::Float32) = DoubleFloat32(deg2rad(float64(x)))
 deg2rad_ext(x::Real) = deg2rad(x) # Fallback
 
 function sind(x::Real)

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -8,7 +8,7 @@ end
 
 # kernel_* functions are only valid for |x| < pi/4 = 0.7854
 # translated from openlibm code: k_sin.c, k_cos.c, k_sinf.c, k_cosf.c
-# which are made available under following licence:
+# which are made available under the following licence:
 
 ## Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
 ##
@@ -93,6 +93,7 @@ function mulpi_ext(x::Float64)
     Double64(y_hi,y_lo)
 end
 mulpi_ext(x::Float32) = Double32(pi*float64(x))
+mulpi_ext(x::Rational) = mulpi_ext(float(x))
 mulpi_ext(x::Real) = pi*x # Fallback
 
 function sinpi(x::Real)
@@ -102,18 +103,18 @@ function sinpi(x::Real)
         return nan(x)
     end
 
-    rx = copysign(float(rem(x,2)),x)
+    rx = copysign(rem(x,2),x)
     arx = abs(rx)
 
     if rx == zero(rx)
-        return rx 
+        return copysign(float(zero(rx)),x)
     elseif arx < oftype(rx,0.25)
         return sin_kernel(mulpi_ext(rx))
     elseif arx <= oftype(rx,0.75)
         y = mulpi_ext(oftype(rx,0.5) - arx)
         return copysign(cos_kernel(y),rx)
     elseif arx == one(x)
-        return copysign(zero(rx),rx)
+        return copysign(float(zero(rx)),rx)
     elseif arx < oftype(rx,1.25)
         y = mulpi_ext((one(rx) - arx)*sign(rx))
         return sin_kernel(y)
@@ -152,9 +153,8 @@ function cospi(x::Real)
     end
 end
 
-
-sinpi(x::Integer) = zero(x)
-cospi(x::Integer) = isodd(x) ? -one(x) : one(x)
+sinpi(x::Integer) = x >= 0 ? zero(float(x)) : -zero(float(x))
+cospi(x::Integer) = isodd(x) ? -one(float(x)) : one(float(x))
 
 function sinpi(z::Complex)
     zr, zi = reim(z)

--- a/test/math.jl
+++ b/test/math.jl
@@ -5,25 +5,52 @@
 @test exponent(12.8) == 3
 
 # degree-based trig functions
-for T = (Float32,Float64)
+for T = (Float32,Float64,Rational{Int})
+    fT = typeof(float(one(T)))
     for x = -400:40:400
-        @test_approx_eq_eps sind(convert(T,x))::T convert(T,sin(pi/180*x)) eps(deg2rad(convert(T,x)))
-        @test_approx_eq_eps cosd(convert(T,x))::T convert(T,cos(pi/180*x)) eps(deg2rad(convert(T,x)))
+        @test_approx_eq_eps sind(convert(T,x))::fT convert(fT,sin(pi/180*x)) eps(deg2rad(convert(fT,x)))
+        @test_approx_eq_eps cosd(convert(T,x))::fT convert(fT,cos(pi/180*x)) eps(deg2rad(convert(fT,x)))
     end
-    for x = 0.0:180:720
-        @test sind(convert(T,x)) === zero(T)
-        @test sind(-convert(T,x)) === -zero(T)
-    end
+    
+    @test sind(convert(T,0.0))::fT === zero(fT)
+    @test sind(convert(T,180.0))::fT === zero(fT)
+    @test sind(convert(T,360.0))::fT === zero(fT)
+    T != Rational{Int} && @test sind(convert(T,-0.0))::fT === -zero(fT)
+    @test sind(convert(T,-180.0))::fT === -zero(fT)
+    @test sind(convert(T,-360.0))::fT === -zero(fT)
+
+    @test cosd(convert(T,90))::fT === zero(fT)
+    @test cosd(convert(T,270))::fT === zero(fT)
+    @test cosd(convert(T,-90))::fT === zero(fT)
+    @test cosd(convert(T,-270))::fT === zero(fT)
+
 
     for x = -3:0.3:3
-        @test_approx_eq_eps sinpi(convert(T,x))::T convert(T,sin(pi*x)) eps(pi*convert(T,x))
-        @test_approx_eq_eps cospi(convert(T,x))::T convert(T,cos(pi*x)) eps(pi*convert(T,x))
+        @test_approx_eq_eps sinpi(convert(T,x))::fT convert(fT,sin(pi*x)) eps(pi*convert(fT,x))
+        @test_approx_eq_eps cospi(convert(T,x))::fT convert(fT,cos(pi*x)) eps(pi*convert(fT,x))
     end
-    for x = 0.0:1.0:4.0
-        @test sinpi(convert(T,x)) === zero(T)
-        @test sinpi(-convert(T,x)) === -zero(T)
-    end
+
+    @test sinpi(convert(T,0.0))::fT === zero(fT)
+    @test sinpi(convert(T,1.0))::fT === zero(fT)
+    @test sinpi(convert(T,2.0))::fT === zero(fT)
+    T != Rational{Int} && @test sinpi(convert(T,-0.0))::fT === -zero(fT)
+    @test sinpi(convert(T,-1.0))::fT === -zero(fT)
+    @test sinpi(convert(T,-2.0))::fT === -zero(fT)
+
+    @test cospi(convert(T,0.5))::fT === zero(fT)
+    @test cospi(convert(T,1.5))::fT === zero(fT)
+    @test cospi(convert(T,-0.5))::fT === zero(fT)
+    @test cospi(convert(T,-1.5))::fT === zero(fT)
+
+    # check exact values
+    @test sind(convert(T,30)) == 0.5
+    @test cosd(convert(T,60)) == 0.5
+    @test sind(convert(T,150)) == 0.5
+    @test sinpi(one(T)/convert(T,6)) == 0.5
+    T != Float32 && @test cospi(one(T)/convert(T,3)) == 0.5
+    T == Rational{Int} && @test sinpi(5//6) == 0.5
 end
+
 
 # check type stability
 for T = (Float32,Float64,BigFloat)


### PR DESCRIPTION
This does the multiplication by pi in `sinpi`/`cospi` using double-double arithmetic. It improves the accuracy, with a maximum error of ~0.8 ulps (from ~1.8 ulps previously). So now we have nice things like `sinpi(1/6) == 0.5`. 

Possible downsides:
- It is slightly slower (around 2-3% from what I can tell).
- It requires openlibm (I don't think the kernel functions are usually exported in other libms). However the functions themselves aren't very complicated (e.g. [sin](https://github.com/JuliaLang/openlibm/blob/master/src/k_sin.c)) so we could easily implement them in native julia.

If we're happy with this, I can do the same for `sind`/`cosd` as well.
