### PR TITLE
fetching 0.3 sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ All systems are supported with both x86/64 (64-bit) and x86 (32-bit) architectur
 
 First, acquire the source code by cloning the git repository:
 
-    git clone git://github.com/JuliaLang/julia.git
+    git clone -b release-0.3 git://github.com/JuliaLang/julia.git
 
 (If you are behind a firewall, you may need to use the `https` protocol instead of the `git` protocol:
 


### PR DESCRIPTION
Slight modification to the readme.md file in the release-0.3 branch.
This is the readme of the 0.3 version, hence we should clone the release-0.3 branch if we want to build from source.
