### PR TITLE
add efficient mean and median for ranges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@ Library improvements
     intend to use the default `Forward` order, or
     `pq = PriorityQueue(KeyType, ValueType, OrderType)` otherwise ([#8011]).
 
+  * Efficient `mean` and `median` for ranges ([#8089]).
+
 Julia v0.3.0 Release Notes
 ==========================
 
@@ -948,3 +950,4 @@ Too numerous to mention.
 [#7917]: https://github.com/JuliaLang/julia/issues/7917
 [#7992]: https://github.com/JuliaLang/julia/issues/7992
 [#8011]: https://github.com/JuliaLang/julia/issues/8011
+[#8089]: https://github.com/JuliaLang/julia/issues/8089

--- a/base/range.jl
+++ b/base/range.jl
@@ -553,22 +553,12 @@ function sum{T<:Real}(r::Range{T})
                                      : (step(r) * l) * ((l-1)>>1))
 end
 
-
 function mean{T<:Real}(r::Range{T})
     isempty(r) && error("mean of an empty range is undefined")
     (first(r) + last(r)) / 2
 end
 
-function median{T<:Real}(r::Range{T})
-    isempty(r) && error("median of an empty range is undefined")
-    n = length(r)
-    if iseven(n)
-        mid = n >> 1
-        return (r[mid] + r[mid+1]) / 2
-    else # odd
-        return float(r[(n+1)>>1])
-    end
-end
+median{T<:Real}(r::Range{T}) = mean(r)
 
 function map!(f::Callable, dest, r::Range)
     i = 1

--- a/base/range.jl
+++ b/base/range.jl
@@ -553,6 +553,23 @@ function sum{T<:Real}(r::Range{T})
                                      : (step(r) * l) * ((l-1)>>1))
 end
 
+
+function mean{T<:Real}(r::Range{T})
+    isempty(r) && error("mean of an empty range is undefined")
+    (first(r) + last(r)) / 2
+end
+
+function median{T<:Real}(r::Range{T})
+    isempty(r) && error("median of an empty range is undefined")
+    n = length(r)
+    if iseven(n)
+        mid = n >> 1
+        return (r[mid] + r[mid+1]) / 2
+    else # odd
+        return float(r[(n+1)>>1])
+    end
+end
+
 function map!(f::Callable, dest, r::Range)
     i = 1
     for ri in r dest[i] = f(ri); i+=1; end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -350,3 +350,11 @@ end
 @test length(map(identity, 0x0001:0x0005)) == 5
 @test length(map(identity, uint64(1):uint64(5))) == 5
 @test length(map(identity, uint128(1):uint128(5))) == 5
+
+# mean/median
+for f in (mean, median)
+    for n = 2:5
+        @test f(2:n) == f([2:n])
+        @test_approx_eq f(2:0.1:n) f([2:0.1:n])
+    end
+end


### PR DESCRIPTION
These are useful (see e.g. shashi/Interact.jl#9) and there is no reason for them not to be fast.  I actually didn't realize that they were missing.
