### PR TITLE
changes chooseproc behavior so that we start from master+1 pid

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1248,7 +1248,7 @@ end
 
 ## higher-level functions: spawn, pmap, pfor, etc. ##
 
-let nextidx = 1
+let nextidx = 0
     global chooseproc
     function chooseproc(thunk::Function)
         p = -1


### PR DESCRIPTION
right now with addprocs(>3) we start allocating work to process
pid 3 before wrapping around.  This change just starts allocating work
to process 2 (worker 1) which should be more intuitive. See #8105.
