### PR TITLE
Rename make variable LIBS

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -67,7 +67,7 @@ endif
 # disable automatic Makefile rules
 .SUFFIXES:
 
-# find out if git repository is availible
+# find out if git repository is available
 ifeq ($(shell [ -e $(JULIAHOME)/.git ] && echo true || echo "Warning: git information unavailable; versioning information limited" >&2), true)
 NO_GIT = 0
 else

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1088,7 +1088,7 @@ ARPACK_MFLAGS = F77="$(FC)" MPIF77="$(FC)"
 ARPACK_FFLAGS += $(FFLAGS) $(JFFLAGS)
 ARPACK_FLAGS = --with-blas="$(LIBBLAS)" --with-lapack="$(LIBLAPACK)" --disable-mpi --enable-shared FFLAGS="$(ARPACK_FFLAGS)"
 ifneq ($(OS),WINNT)
-ARPACK_FLAGS += LDFLAGS="-Wl,-rpath,'$(build_libdir)'"
+ARPACK_FLAGS += LDFLAGS="$(LDFLAGS) -Wl,-rpath,'$(build_libdir)'"
 endif
 
 # ARPACK-NG upstream keeps changing their download filenames

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -527,7 +527,7 @@ ifeq ($(USEICC), 1)
 UV_CFLAGS += -static-intel
 endif
 
-UV_OPTS += LDFLAGS="$(CLDFLAGS) -v"
+UV_OPTS += LDFLAGS="$(LDFLAGS) $(CLDFLAGS) -v"
 ifneq ($(UV_CFLAGS),)
 UV_OPTS += CFLAGS="$(UV_CFLAGS)"
 endif

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1481,7 +1481,7 @@ install-unwind: $(LIBUNWIND_TARGET_OBJ)
 
 ## OS X Unwind ##
 
-OSXUNWIND_FLAGS = ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC) CFLAGS="-ggdb3 -O0" CXXFLAGS="-ggdb3 -O0" SFLAGS="-ggdb3" LDFLAGS="-Wl,-macosx_version_min,10.7"
+OSXUNWIND_FLAGS = ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC) CFLAGS="-ggdb3 -O0" CXXFLAGS="$(CXXFLAGS) -ggdb3 -O0" SFLAGS="-ggdb3" LDFLAGS="-Wl,-macosx_version_min,10.7"
 
 OSXUNWIND_OBJ_TARGET = $(build_shlibdir)/libosxunwind.$(SHLIB_EXT)
 OSXUNWIND_OBJ_SOURCE = libosxunwind-$(OSXUNWIND_VER)/libosxunwind.$(SHLIB_EXT)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -133,16 +133,16 @@ endif
 
 ## Common build target prefixes
 
-LIBS = $(STAGE1_DEPS) $(STAGE2_DEPS) $(STAGE3_DEPS)
+DEP_LIBS = $(STAGE1_DEPS) $(STAGE2_DEPS) $(STAGE3_DEPS)
 
 default: $(build_prefix) install
-get: $(addprefix get-, $(LIBS))
-configure: $(addprefix configure-, $(LIBS))
-compile: $(addprefix compile-, $(LIBS))
-check: $(addprefix check-, $(LIBS))
-install: $(addprefix install-, $(LIBS))
-cleanall: $(addprefix clean-, $(LIBS))
-distcleanall: $(addprefix distclean-, $(LIBS))
+get: $(addprefix get-, $(DEP_LIBS))
+configure: $(addprefix configure-, $(DEP_LIBS))
+compile: $(addprefix compile-, $(DEP_LIBS))
+check: $(addprefix check-, $(DEP_LIBS))
+install: $(addprefix install-, $(DEP_LIBS))
+cleanall: $(addprefix clean-, $(DEP_LIBS))
+distcleanall: $(addprefix distclean-, $(DEP_LIBS))
 	rm -rf $(build_prefix)
 getall: get-llvm get-uv get-pcre get-double-conversion get-openlibm get-openspecfun get-dsfmt get-Rmath get-openblas get-lapack get-fftw get-suitesparse get-arpack get-unwind get-osxunwind get-gmp get-mpfr get-zlib get-patchelf get-mojibake
 


### PR DESCRIPTION
If the initial environment happens to contain a variable LIBS, then make will export its variable LIBS, overriding the environment (see e.g. https://www.gnu.org/software/make/manual/html_node/Variables_002fRecursion.html). This will break libuv/configure, since Julia's LIBS variable is not what autoconf expects in $LIBS. libuv/configure will then try to execute e.g. "cc -c conftest.c libuv", which is obviously wrong.

Renaming LIBS to DEPS_LIBS solves the issue.
