### PR TITLE
WIP: on-stack gc allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,20 +114,20 @@ $(build_private_libdir)/sys%ji: $(build_private_libdir)/sys%o
 .PRECIOUS: $(build_private_libdir)/sys%o
 
 $(build_private_libdir)/sys%$(SHLIB_EXT): $(build_private_libdir)/sys%o
-	$(CXX) -shared -fPIC -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -o $@ $< \
+	@$(call PRINT_LINK, $(CXX) -shared -fPIC -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -o $@ $< \
 		$$([ $(OS) = Darwin ] && echo -Wl,-undefined,dynamic_lookup || echo -Wl,--unresolved-symbols,ignore-all ) \
-		$$([ $(OS) = WINNT ] && echo -ljulia -lssp)
+		$$([ $(OS) = WINNT ] && echo -ljulia -lssp))
 	$(DSYMUTIL) $@
 
 $(build_private_libdir)/sys0.o:
-	@$(QUIET_JULIA) cd base && \
-	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys0) sysimg.jl
+	@$(call PRINT_JULIA, cd base && \
+	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys0) sysimg.jl)
 
 $(build_private_libdir)/sys.o: VERSION base/*.jl base/pkg/*.jl base/linalg/*.jl base/sparse/*.jl $(build_datarootdir)/julia/helpdb.jl $(build_datarootdir)/man/man1/julia.1 $(build_private_libdir)/sys0.$(SHLIB_EXT)
-	@$(QUIET_JULIA) cd base && \
+	@$(call PRINT_JULIA, cd base && \
 	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys) \
 		-J$(call cygpath_w,$(build_private_libdir))/$$([ -e $(build_private_libdir)/sys.ji ] && echo sys.ji || echo sys0.ji) -f sysimg.jl \
-		|| (echo "*** This error is usually fixed by running 'make clean'. If the error persists, try 'make cleanall'. ***" && false)
+		|| (echo "*** This error is usually fixed by running 'make clean'. If the error persists, try 'make cleanall'. ***" && false))
 
 run-julia-debug run-julia-release: run-julia-%:
 	$(MAKE) $(QUIET_MAKE) run-julia JULIA_EXECUTABLE="$(JULIA_EXECUTABLE_$*)"

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -120,7 +120,6 @@ void jl_enter_handler(jl_handler_t *eh)
 #ifdef JL_GC_MARKSWEEP
     eh->gcstack = jl_pgcstack;
 #endif
-    eh->alloca_stack = jl_alloca_stack;
     jl_current_task->eh = eh;
     // TODO: this should really go after setjmp(). see comment in
     // ctx_switch in task.c.

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -120,6 +120,7 @@ void jl_enter_handler(jl_handler_t *eh)
 #ifdef JL_GC_MARKSWEEP
     eh->gcstack = jl_pgcstack;
 #endif
+    eh->alloca_stack = jl_alloca_stack;
     jl_current_task->eh = eh;
     // TODO: this should really go after setjmp(). see comment in
     // ctx_switch in task.c.

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1131,6 +1131,9 @@ DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v)
     if (v == NULL) {
         n += JL_PRINTF(out, "#<null>");
     }
+    else if (0 < (intptr_t)v && (intptr_t)v < 4096) {
+        n += JL_PRINTF(out, "#<%d>", (int)(intptr_t)v);
+    }
     else if (jl_is_lambda_info(v)) {
         jl_lambda_info_t *li = (jl_lambda_info_t*)v;
         n += jl_static_show(out, (jl_value_t*)li->module);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -669,7 +669,7 @@ static Value *emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         Value *arg;
         bool needroot = false;
         if (t == jl_pvalue_llvmt || !jl_isbits(tti)) {
-            arg = emit_expr(argi, ctx, true);
+            arg = emit_expr(argi, ctx, true, true);
             if (t == jl_pvalue_llvmt && arg->getType() != jl_pvalue_llvmt) {
                 arg = boxed(arg, ctx);
                 needroot = true;
@@ -803,7 +803,7 @@ static Value *mark_or_box_ccall_result(Value *result, jl_value_t *rt_expr, jl_va
     if (!static_rt && rt != (jl_value_t*)jl_any_type) {
         // box if type was not statically known
         int nbits = try_to_determine_bitstype_nbits(rt_expr, ctx);
-        return allocate_box_dynamic(emit_expr(rt_expr, ctx),
+        return allocate_box_dynamic(emit_expr(rt_expr, ctx, true),
                                     ConstantInt::get(T_size, nbits/8),
                                     result);
     }
@@ -998,7 +998,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     if (fptr == (void *) &jl_array_ptr ||
         (f_lib==NULL && f_name && !strcmp(f_name,"jl_array_ptr"))) {
         assert(lrt->isPointerTy());
-        Value *ary = emit_expr(args[4], ctx);
+        Value *ary = emit_expr(args[4], ctx, /*escapes=*/true);
         JL_GC_POP();
         return mark_or_box_ccall_result(builder.CreateBitCast(emit_arrayptr(ary),lrt),
                                         args[2], rt, static_rt, ctx);
@@ -1012,7 +1012,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             addressOf = true;
             argi = jl_exprarg(argi,0);
         }
-        Value *ary = boxed(emit_expr(argi, ctx),ctx);
+        Value *ary = boxed(emit_expr(argi, ctx, true),ctx);
         JL_GC_POP();
         return mark_or_box_ccall_result(builder.CreateBitCast(emit_nthptr_addr(ary, addressOf?1:0), lrt),
                                         args[2], rt, static_rt, ctx);
@@ -1104,7 +1104,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         Value *arg;
         bool needroot = false;
         if (largty == jl_pvalue_llvmt || largty->isStructTy()) {
-            arg = emit_expr(argi, ctx, true);
+            arg = emit_expr(argi, ctx, true, true);
             if (largty == jl_pvalue_llvmt && arg->getType() != jl_pvalue_llvmt) {
                 arg = boxed(arg,ctx);
                 needroot = true;

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -669,7 +669,7 @@ static Value *emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         Value *arg;
         bool needroot = false;
         if (t == jl_pvalue_llvmt || !jl_isbits(tti)) {
-            arg = emit_expr(argi, ctx, true, true);
+            arg = emit_expr(argi, ctx, false, true);
             if (t == jl_pvalue_llvmt && arg->getType() != jl_pvalue_llvmt) {
                 arg = boxed(arg, ctx);
                 needroot = true;
@@ -998,7 +998,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     if (fptr == (void *) &jl_array_ptr ||
         (f_lib==NULL && f_name && !strcmp(f_name,"jl_array_ptr"))) {
         assert(lrt->isPointerTy());
-        Value *ary = emit_expr(args[4], ctx, /*escapes=*/true);
+        Value *ary = emit_expr(args[4], ctx, false);
         JL_GC_POP();
         return mark_or_box_ccall_result(builder.CreateBitCast(emit_arrayptr(ary),lrt),
                                         args[2], rt, static_rt, ctx);
@@ -1012,7 +1012,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             addressOf = true;
             argi = jl_exprarg(argi,0);
         }
-        Value *ary = boxed(emit_expr(argi, ctx, true),ctx);
+        Value *ary = boxed(emit_expr(argi, ctx, false),ctx);
         JL_GC_POP();
         return mark_or_box_ccall_result(builder.CreateBitCast(emit_nthptr_addr(ary, addressOf?1:0), lrt),
                                         args[2], rt, static_rt, ctx);
@@ -1104,7 +1104,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         Value *arg;
         bool needroot = false;
         if (largty == jl_pvalue_llvmt || largty->isStructTy()) {
-            arg = emit_expr(argi, ctx, true, true);
+            arg = emit_expr(argi, ctx, false, true);
             if (largty == jl_pvalue_llvmt && arg->getType() != jl_pvalue_llvmt) {
                 arg = boxed(arg,ctx);
                 needroot = true;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -617,12 +617,10 @@ static bool has_julia_type(Value *v)
 static jl_value_t *julia_type_of_without_metadata(Value *v, bool err=true)
 {
     Type *T = v->getType();
-    if (T != jl_pvalue_llvmt) {
-        if (dyn_cast<AllocaInst>(v) != NULL ||
-            dyn_cast<GetElementPtrInst>(v) != NULL) {
-                // an alloca always has llvm type pointer
-                return llvm_type_to_julia(T->getContainedType(0), err);
-        }
+    if (dyn_cast<AllocaInst>(v) != NULL ||
+        dyn_cast<GetElementPtrInst>(v) != NULL) {
+            // an alloca always has llvm type pointer
+            return llvm_type_to_julia(T->getContainedType(0), err);
     }
     return llvm_type_to_julia(T, err);
 }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1432,6 +1432,7 @@ static Value *init_bits_value(Value *newv, Value *jt, Type *t, Value *v)
 // allocate a box where the type might not be known at compile time
 static Value *allocate_box_dynamic(Value *jlty, Value *nb, Value *v)
 {
+    // TODO: allocate on the stack if !envescapes
     if (v->getType()->isPointerTy()) {
         v = builder.CreatePtrToInt(v, T_size);
     }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -617,10 +617,12 @@ static bool has_julia_type(Value *v)
 static jl_value_t *julia_type_of_without_metadata(Value *v, bool err=true)
 {
     Type *T = v->getType();
-    if (dyn_cast<AllocaInst>(v) != NULL ||
-        dyn_cast<GetElementPtrInst>(v) != NULL) {
-            // an alloca always has llvm type pointer
-            return llvm_type_to_julia(T->getContainedType(0), err);
+    if (T != jl_pvalue_llvmt) {
+        if (dyn_cast<AllocaInst>(v) != NULL ||
+            dyn_cast<GetElementPtrInst>(v) != NULL) {
+                // an alloca always has llvm type pointer
+                return llvm_type_to_julia(T->getContainedType(0), err);
+        }
     }
     return llvm_type_to_julia(T, err);
 }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -616,12 +616,15 @@ static bool has_julia_type(Value *v)
 
 static jl_value_t *julia_type_of_without_metadata(Value *v, bool err=true)
 {
-    if (dyn_cast<AllocaInst>(v) != NULL ||
-        dyn_cast<GetElementPtrInst>(v) != NULL) {
-        // an alloca always has llvm type pointer
-        return llvm_type_to_julia(v->getType()->getContainedType(0), err);
+    Type *T = v->getType();
+    if (T != jl_pvalue_llvmt) {
+        if (dyn_cast<AllocaInst>(v) != NULL ||
+            dyn_cast<GetElementPtrInst>(v) != NULL) {
+                // an alloca always has llvm type pointer
+                return llvm_type_to_julia(T->getContainedType(0), err);
+        }
     }
-    return llvm_type_to_julia(v->getType(), err);
+    return llvm_type_to_julia(T, err);
 }
 
 static jl_value_t *julia_type_of(Value *v)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1204,9 +1204,16 @@ static void simple_escape_analysis(jl_value_t *expr, bool varesc, bool envesc, j
                         varesc = true;
                         envesc = true;
                         i = 2;
-                    } else if (ff->fptr == jl_f_typeassert) {
-                        varesc = true;
-                        //envesc = envesc;
+                    }
+                    else if (ff->fptr == jl_f_typeassert) {
+                        simple_escape_analysis(jl_exprarg(e,1), true, envesc, ctx);
+                        simple_escape_analysis(jl_exprarg(e,2), true, false, ctx);
+                        return;
+                    }
+                    else if ( ff->fptr == jl_f_convert_default) {
+                        simple_escape_analysis(jl_exprarg(e,1), true, false, ctx);
+                        simple_escape_analysis(jl_exprarg(e,2), true, envesc, ctx);
+                        return;
                     }
                     else {
                         varesc = true;
@@ -1232,6 +1239,9 @@ static void simple_escape_analysis(jl_value_t *expr, bool varesc, bool envesc, j
             varesc = true;
             envesc = true;
             i = 1;
+        }
+        else if (e->head == amp_sym) {
+            i = 0;
         }
         else if (e->head == line_sym) {
             return;

--- a/src/gc.c
+++ b/src/gc.c
@@ -637,7 +637,7 @@ static size_t mark_stack_size = 0;
 static size_t mark_sp = 0;
 
 static struct {
-    jl_gcframe_t *s;
+    void* *s;
     ptrint_t offset;
 } *marked_stacks;
 static size_t marked_stacks_size = 0;
@@ -656,42 +656,18 @@ static void gc_unmark_stacks()
 {
     size_t i;
     for (i = 0; i < marked_stacks_sp; i++) {
-        jl_gcframe_t *s = marked_stacks[i].s;
+        void* *s = marked_stacks[i].s;
         ptrint_t offset = marked_stacks[i].offset;
         while (s != NULL) {
-            s = (jl_gcframe_t*)((char*)s + offset);
-            jl_value_t ***rts = (jl_value_t***)(((void**)s)+2);
-            size_t nr = s->nroots>>1;
-            if (s->nroots & 1) {
-                for(size_t i=0; i < nr; i++) {
-                    jl_value_t **ptr = (jl_value_t**)((char*)rts[i] + offset);
-                    if (*ptr != NULL && gc_marked(*ptr))
-                        gc_clrmark(*ptr);
-                }
-            }
-            else {
-                for(size_t i=0; i < nr; i++) {
-                    if (rts[i] != NULL && gc_marked(rts[i]))
-                        gc_clrmark(rts[i]);
-                }
-            }
-            s = s->prev;
+            s = (void**)((char*)s + offset);
+            gc_clrmark(s+1);
+            s = (void**)(*s);
         }
     }
 }
 
 static void gc_mark_stack(jl_gcframe_t *s, ptrint_t offset, int d)
 {
-    if (marked_stacks_sp >= marked_stacks_size) {
-        size_t newsz = marked_stacks_size>0 ? marked_stacks_size*2 : 8;
-        marked_stacks = (typeof(marked_stacks))realloc(marked_stacks,newsz*sizeof(*marked_stacks));
-        if (marked_stacks == NULL) exit(1);
-        marked_stacks_size = newsz;
-    }
-    marked_stacks[marked_stacks_sp].s = s;
-    marked_stacks[marked_stacks_sp].offset = offset;
-    marked_stacks_sp++;
-
     while (s != NULL) {
         s = (jl_gcframe_t*)((char*)s + offset);
         jl_value_t ***rts = (jl_value_t***)(((void**)s)+2);
@@ -751,17 +727,32 @@ static void gc_mark_task(jl_task_t *ta, int d)
     if (ta->stkbuf != NULL || ta == jl_current_task) {
         if (ta->stkbuf != NULL)
             gc_setmark_buf(ta->stkbuf);
+        if (marked_stacks_sp >= marked_stacks_size) {
+            size_t newsz = marked_stacks_size>0 ? marked_stacks_size*2 : 8;
+            marked_stacks = (typeof(marked_stacks))realloc(marked_stacks,newsz*sizeof(*marked_stacks));
+            if (marked_stacks == NULL) exit(1);
+            marked_stacks_size = newsz;
+        }
 #ifdef COPY_STACKS
         ptrint_t offset;
         if (ta == jl_current_task) {
             offset = 0;
+            marked_stacks[marked_stacks_sp].s = jl_alloca_stack;
+            marked_stacks[marked_stacks_sp].offset = offset;
+            marked_stacks_sp++;
             gc_mark_stack(jl_pgcstack, offset, d);
         }
         else {
             offset = (char *)ta->stkbuf - ((char *)ta->stackbase - ta->ssize);
+            marked_stacks[marked_stacks_sp].s = ta->alloca_stack;
+            marked_stacks[marked_stacks_sp].offset = offset;
+            marked_stacks_sp++;
             gc_mark_stack(ta->gcstack, offset, d);
         }
 #else
+        marked_stacks[marked_stacks_sp].s = ta->alloca_stack;
+        marked_stacks[marked_stacks_sp].offset = offset;
+        marked_stacks_sp++;
         gc_mark_stack(ta->gcstack, 0, d);
 #endif
     }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -456,7 +456,7 @@ static Value *generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx)
     }
 
     // dynamically-determined type; evaluate.
-    return allocate_box_dynamic(emit_expr(targ, ctx, true), ConstantInt::get(T_size,(nb+7)/8), vx);
+    return allocate_box_dynamic(emit_expr(targ, ctx, false), ConstantInt::get(T_size,(nb+7)/8), vx);
 }
 
 static Type *staticeval_bitstype(jl_value_t *targ, const char *fname, jl_codectx_t *ctx)
@@ -696,7 +696,7 @@ static Value *emit_runtime_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t
                                        FunctionType::get(jl_pvalue_llvmt, two_pvalue_llvmt, false));
     int ldepth = ctx->argDepth;
     Value *parg = emit_boxed_rooted(e, ctx);
-    Value *iarg = boxed(emit_expr(i, ctx, true), ctx);
+    Value *iarg = boxed(emit_expr(i, ctx, false), ctx);
     Value *ret = builder.CreateCall2(prepare_call(preffunc), parg, iarg);
     ctx->argDepth = ldepth;
     return ret;
@@ -752,7 +752,7 @@ static Value *emit_runtime_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *
     int ldepth = ctx->argDepth;
     Value *parg = emit_boxed_rooted(e, ctx);
     Value *iarg = emit_boxed_rooted(i, ctx);
-    Value *xarg = boxed(emit_expr(x, ctx, true), ctx);
+    Value *xarg = boxed(emit_expr(x, ctx, false), ctx);
     builder.CreateCall3(prepare_call(psetfunc), parg, xarg, iarg);
     ctx->argDepth = ldepth;
     return parg;
@@ -772,7 +772,7 @@ static Value *emit_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *i, jl_co
     jl_value_t *xty = expr_type(x, ctx);
     Value *val=NULL;
     if (!jl_subtype(xty, ety, 0)) {
-        val = emit_expr(x,ctx,true);
+        val = emit_expr(x,ctx,false);
         emit_typecheck(val, ety, "pointerset: type mismatch in assign", ctx);
     }
     if (expr_type(i, ctx) != (jl_value_t*)jl_long_type)

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -202,7 +202,7 @@ static Value *emit_unboxed(jl_value_t *e, jl_codectx_t *ctx)
 {
     Constant *c = julia_const_to_llvm(e);
     if (c) return mark_julia_type(c, jl_typeof(e));
-    return emit_expr(e, ctx, false);
+    return emit_expr(e, ctx, false, false);
 }
 
 static Type *jl_llvmtuple_eltype(Type *tuple, jl_value_t *jt, size_t i)
@@ -456,7 +456,7 @@ static Value *generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx)
     }
 
     // dynamically-determined type; evaluate.
-    return allocate_box_dynamic(emit_expr(targ, ctx), ConstantInt::get(T_size,(nb+7)/8), vx);
+    return allocate_box_dynamic(emit_expr(targ, ctx, true), ConstantInt::get(T_size,(nb+7)/8), vx);
 }
 
 static Type *staticeval_bitstype(jl_value_t *targ, const char *fname, jl_codectx_t *ctx)
@@ -696,7 +696,7 @@ static Value *emit_runtime_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t
                                        FunctionType::get(jl_pvalue_llvmt, two_pvalue_llvmt, false));
     int ldepth = ctx->argDepth;
     Value *parg = emit_boxed_rooted(e, ctx);
-    Value *iarg = boxed(emit_expr(i, ctx), ctx);
+    Value *iarg = boxed(emit_expr(i, ctx, true), ctx);
     Value *ret = builder.CreateCall2(prepare_call(preffunc), parg, iarg);
     ctx->argDepth = ldepth;
     return ret;
@@ -752,7 +752,7 @@ static Value *emit_runtime_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *
     int ldepth = ctx->argDepth;
     Value *parg = emit_boxed_rooted(e, ctx);
     Value *iarg = emit_boxed_rooted(i, ctx);
-    Value *xarg = boxed(emit_expr(x, ctx), ctx);
+    Value *xarg = boxed(emit_expr(x, ctx, true), ctx);
     builder.CreateCall3(prepare_call(psetfunc), parg, xarg, iarg);
     ctx->argDepth = ldepth;
     return parg;
@@ -772,7 +772,7 @@ static Value *emit_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *i, jl_co
     jl_value_t *xty = expr_type(x, ctx);
     Value *val=NULL;
     if (!jl_subtype(xty, ety, 0)) {
-        val = emit_expr(x,ctx);
+        val = emit_expr(x,ctx,true);
         emit_typecheck(val, ety, "pointerset: type mismatch in assign", ctx);
     }
     if (expr_type(i, ctx) != (jl_value_t*)jl_long_type)
@@ -786,7 +786,7 @@ static Value *emit_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *i, jl_co
             emit_error("pointerset: invalid pointer type", ctx);
             return NULL;
         }
-        if (val==NULL) val = emit_expr(x,ctx,true,true);
+        if (val==NULL) val = emit_expr(x,ctx,true,true,true);
         assert(val->getType() == jl_pvalue_llvmt); //Boxed
         assert(jl_is_datatype(ety));
         uint64_t size = ((jl_datatype_t*)ety)->size;
@@ -796,7 +796,7 @@ static Value *emit_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *i, jl_co
     else {
         if (val == NULL) {
             if (ety == (jl_value_t*)jl_any_type)
-                val = emit_expr(x,ctx);
+                val = emit_expr(x,ctx,true);
             else
                 val = emit_unboxed(x,ctx);
         }
@@ -866,7 +866,7 @@ static Value *emit_smod(Value *x, Value *den, jl_codectx_t *ctx)
     case intr: if (nargs!=n) jl_error(#intr": wrong number of arguments");
 
 static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
-                             jl_codectx_t *ctx)
+                             jl_codectx_t *ctx, bool escapes)
 {
     switch (f) {
     case ccall: return emit_ccall(args, nargs, ctx);
@@ -965,12 +965,12 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         int argStart = ctx->argDepth;
         Value *ifelse_result;
         if (llt1 == jl_pvalue_llvmt && llt2 == jl_pvalue_llvmt) {
-            Value *arg1 = emit_expr(args[3], ctx, false);
+            Value *arg1 = emit_expr(args[3], ctx, escapes, false);
             if (arg1->getType() == jl_pvalue_llvmt)
                 make_gcroot(arg1, ctx);
             ifelse_result = builder.CreateSelect(isfalse,
                                                  arg1,
-                                                 emit_expr(args[2], ctx, false));
+                                                 emit_expr(args[2], ctx, escapes, false));
         }
         else if (t1 == t2 && llt1 == llt2 && llt1 != jl_pvalue_llvmt) {
             ifelse_result = builder.CreateSelect(isfalse,
@@ -978,11 +978,11 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
                                                  auto_unbox(args[2], ctx));
         }
         else {
-            Value *arg1 = boxed(emit_expr(args[3],ctx,false), ctx, expr_type(args[3],ctx));
+            Value *arg1 = boxed(emit_expr(args[3],ctx,escapes,false), ctx, expr_type(args[3],ctx));
             make_gcroot(arg1, ctx);
             ifelse_result = builder.CreateSelect(isfalse,
                                                  arg1,
-                                                 boxed(emit_expr(args[2],ctx,false), ctx, expr_type(args[2],ctx)));
+                                                 boxed(emit_expr(args[2],ctx,escapes,false), ctx, expr_type(args[2],ctx)));
         }
         ctx->argDepth = argStart;
         return ifelse_result;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1027,7 +1027,6 @@ typedef struct _jl_gcframe_t {
 // x = f(); y = g(); foo(x, y); JL_GC_POP();
 
 extern DLLEXPORT jl_gcframe_t *jl_pgcstack;
-extern DLLEXPORT void** jl_alloca_stack;
 
 #define JL_GC_PUSH(...)                                                   \
   void *__gc_stkf[] = {(void*)((VA_NARG(__VA_ARGS__)<<1)|1), jl_pgcstack, \
@@ -1134,7 +1133,6 @@ typedef struct _jl_handler_t {
 #ifdef JL_GC_MARKSWEEP
     jl_gcframe_t *gcstack;
 #endif
-    void* *alloca_stack;
     struct _jl_handler_t *prev;
 } jl_handler_t;
 
@@ -1163,7 +1161,6 @@ typedef struct _jl_task_t {
     jl_handler_t *eh;
     // saved gc stack top for context switches
     jl_gcframe_t *gcstack;
-    void* *alloca_stack;
     // current module, or NULL if this task has not set one
     jl_module_t *current_module;
 } jl_task_t;
@@ -1186,7 +1183,6 @@ STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
 #ifdef JL_GC_MARKSWEEP
     jl_pgcstack = eh->gcstack;
 #endif
-    jl_alloca_stack = eh->alloca_stack;
     JL_SIGATOMIC_END();
 }
 

--- a/src/task.c
+++ b/src/task.c
@@ -153,6 +153,7 @@ jl_value_t *jl_exception_in_transit;
 #ifdef JL_GC_MARKSWEEP
 jl_gcframe_t *jl_pgcstack = NULL;
 #endif
+void* *jl_alloca_stack = NULL;
 
 static void start_task(jl_task_t *t);
 
@@ -246,6 +247,8 @@ static void ctx_switch(jl_task_t *t, jl_jmp_buf *where)
         jl_current_task->gcstack = jl_pgcstack;
         jl_pgcstack = t->gcstack;
 #endif
+        jl_current_task->alloca_stack = jl_alloca_stack;
+        jl_alloca_stack = t->alloca_stack;
 
         // restore task's current module, looking at parent tasks
         // if it hasn't set one.

--- a/src/task.c
+++ b/src/task.c
@@ -791,6 +791,7 @@ jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
 #ifdef JL_GC_MARKSWEEP
     t->gcstack = NULL;
 #endif
+    t->alloca_stack = NULL;
     t->stkbuf = NULL;
 
 #ifdef COPY_STACKS

--- a/src/task.c
+++ b/src/task.c
@@ -153,7 +153,6 @@ jl_value_t *jl_exception_in_transit;
 #ifdef JL_GC_MARKSWEEP
 jl_gcframe_t *jl_pgcstack = NULL;
 #endif
-void* *jl_alloca_stack = NULL;
 
 static void start_task(jl_task_t *t);
 
@@ -247,8 +246,6 @@ static void ctx_switch(jl_task_t *t, jl_jmp_buf *where)
         jl_current_task->gcstack = jl_pgcstack;
         jl_pgcstack = t->gcstack;
 #endif
-        jl_current_task->alloca_stack = jl_alloca_stack;
-        jl_alloca_stack = t->alloca_stack;
 
         // restore task's current module, looking at parent tasks
         // if it hasn't set one.
@@ -791,7 +788,6 @@ jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
 #ifdef JL_GC_MARKSWEEP
     t->gcstack = NULL;
 #endif
-    t->alloca_stack = NULL;
     t->stkbuf = NULL;
 
 #ifdef COPY_STACKS


### PR DESCRIPTION
This is an improvement to the GC by pre-computing the GC escape analysis and entirely avoiding malloc when it is detected that the value cannot leave the stack frame. In it's current form, this appears to have no impact on the perf tests (as expected), since it doesn't trace values across function calls. Through the addition of a gc-analysis pass to inference.jl, this can be easily improved however. Where this is most helpful is in allocating boxes for ccall for very cheap, allowing the elimination of the `&` special syntax without performance penalty:

Some initial function to be merged into base:

``` julia
julia> type Ref{T}
        x::T
       end

julia> Base.getindex(x::Ref) = x.x
getindex (generic function with 171 methods)

julia> Base.convert{T}(::Type{Ptr{T}}, b::Ref{T}) = ccall(:jl_value_ptr,Ptr{T},(Ptr{Ref},),&b)
convert (generic function with 452 methods)
```

And an example:

``` julia
julia> function call_fortran()
    x = Ref{Int}(0)
    ccall(:jl_, Void, (Ptr{Int}, Ptr{Int},), x, Ref{Int}(1))
    return x[]
end
call_fortran (generic function with 1 method)

julia> code_llvm(call_fortran,())

; Function Attrs: sspreq
define i64 @"julia_call_fortran;40340"() #2 {
top:
  %0 = alloca [5 x %jl_value_t*], align 8
  %.sub = getelementptr inbounds [5 x %jl_value_t*]* %0, i64 0, i64 0
  %1 = getelementptr [5 x %jl_value_t*]* %0, i64 0, i64 2, !dbg !1136
  store %jl_value_t* inttoptr (i64 6 to %jl_value_t*), %jl_value_t** %.sub, align 8
  %2 = load %jl_value_t*** @jl_pgcstack, align 8, !dbg !1136
  %3 = getelementptr [5 x %jl_value_t*]* %0, i64 0, i64 1, !dbg !1136
  %.c = bitcast %jl_value_t** %2 to %jl_value_t*, !dbg !1136
  store %jl_value_t* %.c, %jl_value_t** %3, align 8, !dbg !1136
  store %jl_value_t** %.sub, %jl_value_t*** @jl_pgcstack, align 8, !dbg !1136
  store %jl_value_t* null, %jl_value_t** %1, align 8, !dbg !1136
  %4 = getelementptr [5 x %jl_value_t*]* %0, i64 0, i64 3, !dbg !1136
  store %jl_value_t* null, %jl_value_t** %4, align 8, !dbg !1136
  %5 = load i8** @jl_alloca_stack, align 8, !dbg !1136
  %6 = getelementptr [5 x %jl_value_t*]* %0, i64 0, i64 4
  store %jl_value_t* null, %jl_value_t** %6, align 8
  %7 = alloca [3 x i8*], align 8, !dbg !1137
  %.sub1 = getelementptr inbounds [3 x i8*]* %7, i64 0, i64 0
  %8 = load i8** @jl_alloca_stack, align 8, !dbg !1137
  store i8* %8, i8** %.sub1, align 8, !dbg !1137
  %9 = bitcast [3 x i8*]* %7 to i8*, !dbg !1137
  store i8* %9, i8** @jl_alloca_stack, align 8, !dbg !1137
  %10 = getelementptr [3 x i8*]* %7, i64 0, i64 1, !dbg !1137
  %11 = bitcast i8** %10 to %jl_value_t*, !dbg !1137, !isAlloca !1139
  store i8* inttoptr (i64 140638926508672 to i8*), i8** %10, align 8, !dbg !1137
  store %jl_value_t* %11, %jl_value_t** %6, align 8, !dbg !1137
  %12 = getelementptr [3 x i8*]* %7, i64 0, i64 2, !dbg !1137
  %13 = load i64* inttoptr (i64 140638888978504 to i64*), align 8, !dbg !1137
  %.c2 = inttoptr i64 %13 to i8*, !dbg !1137
  store i8* %.c2, i8** %12, align 8, !dbg !1137, !tbaa %jtbaa_user
  store %jl_value_t* %11, %jl_value_t** %1, align 8, !dbg !1137
  %14 = alloca [3 x i8*], align 8, !dbg !1142
  %.sub3 = getelementptr inbounds [3 x i8*]* %14, i64 0, i64 0
  %15 = load i8** @jl_alloca_stack, align 8, !dbg !1142
  store i8* %15, i8** %.sub3, align 8, !dbg !1142
  %16 = bitcast [3 x i8*]* %14 to i8*, !dbg !1142
  store i8* %16, i8** @jl_alloca_stack, align 8, !dbg !1142
  %17 = getelementptr [3 x i8*]* %14, i64 0, i64 1, !dbg !1142
  %18 = bitcast i8** %17 to %jl_value_t*, !dbg !1142, !isAlloca !1139
  store i8* inttoptr (i64 140638926508672 to i8*), i8** %17, align 8, !dbg !1142
  store %jl_value_t* %18, %jl_value_t** %6, align 8, !dbg !1142
  %19 = getelementptr [3 x i8*]* %14, i64 0, i64 2, !dbg !1142
  %20 = load i64* inttoptr (i64 140638888978536 to i64*), align 8, !dbg !1142
  %.c4 = inttoptr i64 %20 to i8*, !dbg !1142
  store i8* %.c4, i8** %19, align 8, !dbg !1142, !tbaa %jtbaa_user
  store %jl_value_t* %18, %jl_value_t** %4, align 8, !dbg !1142
  %21 = bitcast i8** %12 to i64*, !dbg !1142
  %22 = bitcast i8** %19 to i64*, !dbg !1142
  call void inttoptr (i64 4318594960 to void (i64*, i64*)*)(i64* %21, i64* %22), !dbg !1142
  %23 = load i64* %21, align 8, !dbg !1143, !tbaa %jtbaa_user
  %24 = load %jl_value_t** %3, align 8, !dbg !1143
  %25 = getelementptr inbounds %jl_value_t* %24, i64 0, i32 0, !dbg !1143
  store %jl_value_t** %25, %jl_value_t*** @jl_pgcstack, align 8, !dbg !1143
  store i8* %5, i8** @jl_alloca_stack, align 8, !dbg !1143
  ret i64 %23, !dbg !1143
}
```

No `allocobj`!

TODO items:
- [x] remove the alloca stack frame when it isn't used
- [x] frob the stack less
- [x] future work: implement more complete gc analysis pass in julia (store info in Expr objects)
- [ ] correctly handle: `x = new(T, getfield(x,2), getfield(x,1))`
