### PR TITLE
Add optional overwrite flag to download

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -315,8 +315,11 @@ end
 ## file downloading ##
 
 downloadcmd = nothing
-@unix_only function download(url::String, filename::String)
+@unix_only function download(url::String, filename::String, overwrite::Bool=true)
     global downloadcmd
+    if !overwrite && isfile(filename)
+        return filename
+    end
     if downloadcmd === nothing
         for checkcmd in (:curl, :wget, :fetch)
             if success(`which $checkcmd` |> DevNull)
@@ -337,7 +340,10 @@ downloadcmd = nothing
     filename
 end
 
-@windows_only function download(url::String, filename::String)
+@windows_only function download(url::String, filename::String, overwrite::Bool=true)
+    if !overwrite && isfile(filename)
+        return filename
+    end
     res = ccall((:URLDownloadToFileW,:urlmon),stdcall,Cuint,
                 (Ptr{Void},Ptr{Uint16},Ptr{Uint16},Cint,Ptr{Void}),0,utf16(url),utf16(filename),0,0)
     if res != 0

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -315,7 +315,7 @@ end
 ## file downloading ##
 
 downloadcmd = nothing
-@unix_only function download(url::String, filename::String, overwrite::Bool=true)
+@unix_only function download(url::String, filename::String; overwrite::Bool=true)
     global downloadcmd
     if !overwrite && isfile(filename)
         return filename
@@ -340,7 +340,7 @@ downloadcmd = nothing
     filename
 end
 
-@windows_only function download(url::String, filename::String, overwrite::Bool=true)
+@windows_only function download(url::String, filename::String; overwrite::Bool=true)
     if !overwrite && isfile(filename)
         return filename
     end

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1933,9 +1933,10 @@ I/O
 
    Copy a file from `src` to `dest`.
 
-.. function:: download(url,[localfile])
+.. function:: download(url,[localfile]; overwrite=false)
 
    Download a file from the given url, optionally renaming it to the given local file name.
+   If the flag ``overwrite=false``  and `localfile` exists the file will not be downloaded.
    Note that this function relies on the availability of external tools such as ``curl``, 
    ``wget`` or ``fetch`` to download the file and is provided for convenience. For production
    use or situations in which more options are need, please use a package that provides the

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1933,7 +1933,7 @@ I/O
 
    Copy a file from `src` to `dest`.
 
-.. function:: download(url,[localfile]; overwrite=false)
+.. function:: download(url,[localfile]; overwrite=true)
 
    Download a file from the given url, optionally renaming it to the given local file name.
    If the flag ``overwrite=false``  and `localfile` exists the file will not be downloaded.


### PR DESCRIPTION
If `overwrite=false` and file exists we skip the download, see #8147.
