### PR TITLE
clarify even more the evaluation scope of functions default values

### DIFF
--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -491,19 +491,21 @@ Evaluation Scope of Default Values
 
 Optional and keyword arguments differ slightly in how their default
 values are evaluated. When optional argument default expressions are
-evaluated, only *previous* arguments are in scope. For example, given
-this definition::
+evaluated, only *previous* arguments are in scope. In contrast, *all*
+the arguments are in scope when keyword arguments default expressions
+are evaluated. For example, given this definition::
 
     function f(x, a=b, b=1)
         ###
     end
 
-the ``b`` in ``a=b`` refers to the ``b`` in an outer scope, not the
+the ``b`` in ``a=b`` refers to a ``b`` in an outer scope, not the
 subsequent argument ``b``. However, if ``a`` and ``b`` were keyword
 arguments instead, then both would be created in the same scope and
-``a=b`` would result in an undefined variable error (since the
-default expressions are evaluated left-to-right, and ``b`` has not
-been assigned yet).
+the ``b`` in ``a=b`` would refer the the subsequent argument ``b``
+(shadowing any ``b`` in an outer scope), which would result in an
+undefined variable error (since the default expressions are evaluated
+left-to-right, and ``b`` has not been assigned yet).
 
 
 Block Syntax for Function Arguments


### PR DESCRIPTION
The previous formulation confused me on first read (the subtle difference was only stated through the example, and my naive conclusion was that keyword default expression can't access the outer scope).
