### PR TITLE
allocate a tighter temporary array in MergeSort

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -285,11 +285,13 @@ function sort!(v::AbstractVector, lo::Int, hi::Int, a::QuickSortAlg, o::Ordering
     return v
 end
 
-function sort!(v::AbstractVector, lo::Int, hi::Int, a::MergeSortAlg, o::Ordering, t=similar(v))
+function sort!(v::AbstractVector, lo::Int, hi::Int, a::MergeSortAlg, o::Ordering, t=similar(v,0))
     @inbounds if lo < hi
         hi-lo <= SMALL_THRESHOLD && return sort!(v, lo, hi, SMALL_ALGORITHM, o)
 
         m = (lo+hi)>>>1
+        isempty(t) && resize!(t, m-lo+1)
+
         sort!(v, lo,  m,  a, o, t)
         sort!(v, m+1, hi, a, o, t)
 

--- a/doc/stdlib/sort.rst
+++ b/doc/stdlib/sort.rst
@@ -216,7 +216,7 @@ appeared in the array to be sorted. ``QuickSort`` is the default
 algorithm for numeric values, including integers and floats.
 
 ``MergeSort`` is an O(n log n) stable sorting algorithm but is not
-in-place – it requires a temporary array of equal size to the
+in-place – it requires a temporary array of half the size of the
 input array – and is typically not quite as fast as ``QuickSort``.
 It is the default algorithm for non-numeric data.
 


### PR DESCRIPTION
This speeds things up a bit.
`sort!` has many methods, but only one is documented (namely the one with keywords). Should the other ones be renamed so they don't pollute `methods(sort!)`? On occasions, I find that `sort!(v, InsertionSort, Forward)` is faster for small arrays, maybe this method could be documented?
Could we replace all the `(lo+hi)>>>1` by `(lo+hi)÷2` ?
