### PR TITLE
Change nowutc() to now(Dates.UTC()) for a better API with TimeZones.jl

### DIFF
--- a/base/Dates.jl
+++ b/base/Dates.jl
@@ -12,7 +12,7 @@ include("dates/io.jl")
 
 export Period, DatePeriod, TimePeriod,
        Year, Month, Week, Day, Hour, Minute, Second, Millisecond,
-       TimeType, DateTime, Date,
+       TimeZone, UTC, TimeType, DateTime, Date,
        # accessors.jl
        yearmonthday, yearmonth, monthday, year, month, week, day,
        hour, minute, second, millisecond, dayofmonth,
@@ -26,7 +26,7 @@ export Period, DatePeriod, TimePeriod,
        July, August, September, October, November, December,
        Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec,
        # conversions.jl
-       unix2datetime, datetime2unix, now, nowutc, today, 
+       unix2datetime, datetime2unix, now, today, 
        rata2datetime, datetime2rata, julian2datetime, datetime2julian,
        # adjusters.jl
        firstdayofweek, lastdayofweek,

--- a/base/dates/conversions.jl
+++ b/base/dates/conversions.jl
@@ -22,7 +22,7 @@ function now()
     return DateTime(tm.year+1900,tm.month+1,tm.mday,tm.hour,tm.min,tm.sec)
 end
 today() = Date(now())
-nowutc() = unix2datetime(time())
+now(::Type{UTC}) = unix2datetime(time())
 
 rata2datetime(days) = DateTime(yearmonthday(days)...)
 datetime2rata(dt::DateTime) = days(dt)

--- a/base/dates/types.jl
+++ b/base/dates/types.jl
@@ -51,6 +51,9 @@ abstract Calendar <: AbstractTime
 # ISOCalendar provides interpretation rules for UTInstants to civil date and time parts
 immutable ISOCalendar <: Calendar end
 
+abstract TimeZone
+immutable UTC <: TimeZone end
+
 # TimeTypes wrap Instants to provide human representations of time
 abstract TimeType <: AbstractTime
 

--- a/test/dates/conversions.jl
+++ b/test/dates/conversions.jl
@@ -43,4 +43,4 @@
 
 @test typeof(Dates.now()) <: Dates.DateTime
 @test typeof(Dates.today()) <: Dates.Date
-@test typeof(Dates.nowutc()) <: Dates.DateTime
+@test typeof(Dates.now(Dates.UTC)) <: Dates.DateTime


### PR DESCRIPTION
Reference discussion: https://github.com/JuliaLang/julia/commit/5999f53169f01521d8e2613adaa4129a8ac24449#commitcomment-7544035
