### PR TITLE
 Keep acronyms all upper-case

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -169,3 +169,8 @@ scale!{T<:Base.LinAlg.BlasReal}(X::Array{T}, s::Complex) = error("scale!: Cannot
 @deprecate rsplit(x,y,l::Integer,k::Bool) rsplit(x,y;limit=l,keep=k)
 @deprecate rsplit(x,y,l::Integer) rsplit(x,y;limit=l)
 @deprecate rsplit(x,y,k::Bool) rsplit(x,y;keep=k)
+
+export TcpSocket, UdpSocket, IpAddr
+const TcpSocket = TCPSocket
+const UdpSocket = UDPSocket
+const IpAddr = IPAddr

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1172,7 +1172,7 @@ export
     write,
     writecsv,
     writedlm,
-    UdpSocket,
+    UDPSocket,
 
 # multiprocessing
     addprocs,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1172,6 +1172,7 @@ export
     write,
     writecsv,
     writedlm,
+    TCPSocket,
     UDPSocket,
 
 # multiprocessing

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -90,20 +90,20 @@ abstract ClusterManager
 type Worker
     host::ByteString
     port::Uint16
-    socket::TcpSocket
+    socket::TCPSocket
     sendbuf::IOBuffer
     del_msgs::Array{Any,1}
     add_msgs::Array{Any,1}
     id::Int
     gcflag::Bool
-    bind_addr::IpAddr
+    bind_addr::IPAddr
     manage::Function
     config::Dict
     
-    Worker(host::String, port::Integer, sock::TcpSocket, id::Int) =
+    Worker(host::String, port::Integer, sock::TCPSocket, id::Int) =
         new(bytestring(host), uint16(port), sock, IOBuffer(), {}, {}, id, false)
 end
-Worker(host::String, port::Integer, sock::TcpSocket) =
+Worker(host::String, port::Integer, sock::TCPSocket) =
     Worker(host, port, sock, 0)
 function Worker(host::String, port::Integer) 
     # Connect to the loopback port if requested host has the same ipaddress as self.
@@ -158,7 +158,7 @@ function flush_gc_msgs(w::Worker)
 end
 
 #TODO: Move to different Thread
-function enq_send_req(sock::TcpSocket,buf,now::Bool)
+function enq_send_req(sock::TCPSocket, buf, now::Bool)
     arr=takebuf_array(buf)
     write(sock,arr)
     #TODO implement "now"
@@ -194,7 +194,7 @@ end
 
 type LocalProcess
     id::Int
-    bind_addr::IpAddr
+    bind_addr::IPAddr
     LocalProcess() = new(1)
 end
 
@@ -816,7 +816,7 @@ notify_empty(rv::RemoteValue) = notify(rv.empty)
 ## message event handlers ##
 
 # activity on accept fd
-function accept_handler(server::TcpServer, status::Int32)
+function accept_handler(server::TCPServer, status::Int32)
     if status == -1
         error("an error occured during the creation of the server")
     end

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -243,7 +243,7 @@ function init_stdio(handle)
         if t == UV_TTY
             ret = TTY(handle)
         elseif t == UV_TCP
-            ret = TcpSocket(handle)
+            ret = TCPSocket(handle)
         elseif t == UV_NAMED_PIPE
             ret = Pipe(handle)
         else

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -67,8 +67,8 @@ close(server)
 
 @test_throws Base.UVError connect(".invalid",80)
 
-a = UdpSocket()
-b = UdpSocket()
+a = UDPSocket()
+b = UDPSocket()
 bind(a,ip"127.0.0.1",port)
 bind(b,ip"127.0.0.1",port+1)
 
@@ -85,7 +85,7 @@ end
 send(b,ip"127.0.0.1",port,"Hello World")
 wait(c)
 
-@test_throws MethodError bind(UdpSocket(),port)
+@test_throws MethodError bind(UDPSocket(),port)
 
 close(a)
 close(b)


### PR DESCRIPTION
Renames TcpSocket, UdpSocket, IpAddr to follow upper case acronym convention in base. #8165
