### PR TITLE
handling blank lines in readdlm

### DIFF
--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -3059,7 +3059,7 @@
 
 "),
 
-("Base","readdlm","readdlm(source, delim::Char, T::Type, eol::Char; header=false, skipstart=0, use_mmap, ignore_invalid_chars=false, quotes=true, dims, comments=true, comment_char='#')
+("Base","readdlm","readdlm(source, delim::Char, T::Type, eol::Char; header=false, skipstart=0, skipblanks=true, use_mmap, ignore_invalid_chars=false, quotes=true, dims, comments=true, comment_char='#')
 
    Read a matrix from the source where each line (separated by
    \"eol\") gives one row, with elements separated by the given
@@ -3078,6 +3078,9 @@
 
    Specifying \"skipstart\" will ignore the corresponding number of
    initial lines from the input.
+
+   If \"skipblanks\" is \"true\", blank lines in the input will be 
+   ignored.
 
    If \"use_mmap\" is \"true\", the file specified by \"source\" is
    memory mapped for potential speedups. Default is \"true\" except on

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -2111,7 +2111,7 @@ Text I/O
 
    Create an iterable object that will yield each line from a stream.
 
-.. function:: readdlm(source, delim::Char, T::Type, eol::Char; header=false, skipstart=0, use_mmap, ignore_invalid_chars=false, quotes=true, dims, comments=true, comment_char='#')
+.. function:: readdlm(source, delim::Char, T::Type, eol::Char; header=false, skipstart=0, skipblanks=true, use_mmap, ignore_invalid_chars=false, quotes=true, dims, comments=true, comment_char='#')
 
    Read a matrix from the source where each line (separated by ``eol``) gives one row, with elements separated by the given delimeter. The source can be a text file, stream or byte array. Memory mapped files can be used by passing the byte array representation of the mapped segment as source. 
 
@@ -2120,6 +2120,8 @@ Text I/O
    If ``header`` is ``true``, the first row of data will be read as header and the tuple ``(data_cells, header_cells)`` is returned instead of only ``data_cells``.
 
    Specifying ``skipstart`` will ignore the corresponding number of initial lines from the input.
+
+   If ``skipblanks`` is ``true``, blank lines in the input will be ignored.
 
    If ``use_mmap`` is ``true``, the file specified by ``source`` is memory mapped for potential speedups. Default is ``true`` except on Windows. On Windows, you may want to specify ``true`` if the file is large, and is only read once and not written to.
 

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -66,8 +66,10 @@ let result1 = reshape({"t", "c", "", "c"}, 2, 2),
     @test isequaldlm(readdlm(IOBuffer("t t \n\"\"\"c\" c")), result2, Any)
 end
 
-@test isequaldlm(readcsv(IOBuffer("\n1,2,3\n4,5,6\n\n\n")), reshape({"",1.0,4.0,"","","",2.0,5.0,"","","",3.0,6.0,"",""}, 5, 3), Any)
-@test isequaldlm(readcsv(IOBuffer("1,2\n\n4,5")), reshape({1.0,"",4.0,2.0,"",5.0}, 3, 2), Any)
+@test isequaldlm(readcsv(IOBuffer("\n1,2,3\n4,5,6\n\n\n"), skipblanks=false), reshape({"",1.0,4.0,"","","",2.0,5.0,"","","",3.0,6.0,"",""}, 5, 3), Any)
+@test isequaldlm(readcsv(IOBuffer("\n1,2,3\n4,5,6\n\n\n"), skipblanks=true), reshape([1.0,4.0,2.0,5.0,3.0,6.0], 2, 3), Float64)
+@test isequaldlm(readcsv(IOBuffer("1,2\n\n4,5"), skipblanks=false), reshape({1.0,"",4.0,2.0,"",5.0}, 3, 2), Any)
+@test isequaldlm(readcsv(IOBuffer("1,2\n\n4,5"), skipblanks=true), reshape([1.0,4.0,2.0,5.0], 2, 2), Float64)
 
 let x = randbool(5, 10), io = IOBuffer()
     writedlm(io, x)

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -67,6 +67,7 @@ let result1 = reshape({"t", "c", "", "c"}, 2, 2),
 end
 
 @test isequaldlm(readcsv(IOBuffer("\n1,2,3\n4,5,6\n\n\n")), reshape({"",1.0,4.0,"","","",2.0,5.0,"","","",3.0,6.0,"",""}, 5, 3), Any)
+@test isequaldlm(readcsv(IOBuffer("1,2\n\n4,5")), reshape({1.0,"",4.0,2.0,"",5.0}, 3, 2), Any)
 
 let x = randbool(5, 10), io = IOBuffer()
     writedlm(io, x)


### PR DESCRIPTION
This fixes #8171 by handling blank lines between rows of the input.

Also introduces a `skipblanks` option to ignore blank lines in the input. It is set to `true` by default to be consistent with `readtable` from `DataFrames`. It will break code that depended on the previous behavior of returning a row of empty strings. But such instances should be rare.
