### PR TITLE
[RFC] Added forward compatibility aliases for #8175

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -159,3 +159,11 @@ scale!{T<:Base.LinAlg.BlasReal}(X::Array{T}, s::Complex) = error("scale!: Cannot
 
 @deprecate which(f::Callable, args...) @which f(args...)
 @deprecate rmdir rm
+
+
+# 0.4 compatibility utilities (to simplify 0.4/0.3.1 compatibility)
+
+export TCPSocket, UDPSocket, IPAddr
+const TCPSocket = TcpSocket
+const UCPSocket = UdpSocket
+const IPAddr = IpAddr


### PR DESCRIPTION
Is this something we want for the `0.3-release` branch?

After renaming some constants in #8175, it became harder to write the
same code to target 0.3.x and 0.4-dev. This PR potentially adds aliases,
so that when 0.3.1 gets released, less mainanance intrested package
authors can drop support for 0.3.0, and be compatible with both 0.3.1
and 0.4-dev with the same code base, without version conditionals.

I have tried to fix the `split`/`rsplit` functions in the same way, but it was somewhat tricky, so I wanted to ask whether it was wanted first.
