### PR TITLE
Avoid warning for possibly non-existing file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ release-candidate: release test
 	@echo
 	@echo To complete the release candidate checklist:
 	@echo
-	
 	@echo 1. Remove deprecations in base/deprecated.jl
 	@echo 2. Bump VERSION
 	@echo 3. Create tag, push to github "\(git tag v\`cat VERSION\` && git push --tags\)"
@@ -251,8 +250,8 @@ endif
 	# Copy in all .jl sources as well
 	cp -R -L $(build_datarootdir)/julia $(DESTDIR)$(datarootdir)/
 	# Remove git repository of juliadoc
-	-rm -rf $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.git
-	-rm $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.gitignore
+	rm -rf $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.git
+	rm -f $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.gitignore
 	# Copy in beautiful new man page!
 	$(INSTALL_F) $(build_datarootdir)/man/man1/julia.1 $(DESTDIR)$(datarootdir)/man/man1/
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ release-candidate: release test
 	@echo
 	@echo To complete the release candidate checklist:
 	@echo
-	
+
 	@echo 1. Remove deprecations in base/deprecated.jl
 	@echo 2. Bump VERSION
 	@echo 3. Create tag, push to github "\(git tag v\`cat VERSION\` && git push --tags\)"

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ release-candidate: release test
 	@echo
 	@echo To complete the release candidate checklist:
 	@echo
+	
 	@echo 1. Remove deprecations in base/deprecated.jl
 	@echo 2. Bump VERSION
 	@echo 3. Create tag, push to github "\(git tag v\`cat VERSION\` && git push --tags\)"
@@ -250,8 +251,8 @@ endif
 	# Copy in all .jl sources as well
 	cp -R -L $(build_datarootdir)/julia $(DESTDIR)$(datarootdir)/
 	# Remove git repository of juliadoc
-	rm -rf $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.git
-	rm -f $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.gitignore
+	-rm -rf $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.git
+	-rm $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.gitignore
 	# Copy in beautiful new man page!
 	$(INSTALL_F) $(build_datarootdir)/man/man1/julia.1 $(DESTDIR)$(datarootdir)/man/man1/
 

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ endif
 	cp -R -L $(build_datarootdir)/julia $(DESTDIR)$(datarootdir)/
 	# Remove git repository of juliadoc
 	-rm -rf $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.git
-	-rm $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.gitignore
+	-rm -f $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.gitignore
 	# Copy in beautiful new man page!
 	$(INSTALL_F) $(build_datarootdir)/man/man1/julia.1 $(DESTDIR)$(datarootdir)/man/man1/
 


### PR DESCRIPTION
"rm -f" does not fail for a non-existing file, while a pure "rm" would.
