### PR TITLE
Improve type inference for generic dot

### DIFF
--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -45,15 +45,15 @@ function dot{T<:BlasComplex, TI<:Integer}(x::Vector{T}, rx::Union(UnitRange{TI},
     end
     BLAS.dotc(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
 end
-function dot(x::AbstractVector, y::AbstractVector)
-    lx = length(x)
-    lx==length(y) || throw(DimensionMismatch(""))
-    if lx == 0
-        return zero(eltype(x))*zero(eltype(y))
-    end
-    s = conj(x[1])*y[1]
-    @inbounds for i = 2:lx
-        s += conj(x[i])*y[i]
+function dot{Tx,Ty}(x::AbstractVector{Tx}, y::AbstractVector{Ty})
+    lx = length(x) == length(y) || throw(DimensionMismatch("vectors must have same length"))
+    T = promote_type(Int, arithtype(Tx), arithtype(Ty))
+    lx == 0 && return zero(T)
+    @inbounds begin
+        s::T = x[1]'y[1]
+        for i = 2:lx
+            s += x[i]'y[i]
+        end
     end
     s
 end


### PR DESCRIPTION
Right now the type inference for the generic `dot` is not doing so well:

```
julia> Base.return_types(dot, (AbstractVector{Float64}, AbstractVector{Float64}))
2-element Array{Any,1}:
 Float64
 Any 
```

and it causes a significant penalty when working with views. E.g.

```
julia> using ArrayViews
julia> x = randn(10^7);xv = view(x, 1:length(x));
julia> @time dot(xv, xv);
elapsed time: 0.034378086 seconds (96 bytes allocated)
```

and with this pr

```
julia> using ArrayViews
julia> x = randn(10^7);xv = view(x, 1:length(x));
julia> @time dot(xv, xv);
elapsed time: 7.263e-6 seconds (96 bytes allocated)
```
