### PR TITLE
RFC: Safer, extensible ﹫inbounds

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -375,6 +375,8 @@ imag{T<:Real}(x::AbstractArray{T}) = zero(x)
 
 getindex(t::AbstractArray, i::Real) = error("indexing not defined for ", typeof(t))
 
+unsafe_getindex(args...) = getindex(args...)
+
 # linear indexing with a single multi-dimensional index
 function getindex(A::AbstractArray, I::AbstractArray)
     x = similar(A, size(I))
@@ -440,6 +442,8 @@ end
 setindex!(t::AbstractArray, x, i::Real) =
     error("setindex! not defined for ",typeof(t))
 setindex!(t::AbstractArray, x) = throw(MethodError(setindex!, (t, x)))
+
+unsafe_setindex!(args...) = setindex!(args...)
 
 ## Indexing: handle more indices than dimensions if "extra" indices are 1
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -241,21 +241,25 @@ collect(itr) = collect(eltype(itr), itr)
 
 ## Indexing: getindex ##
 
-getindex(a::Array) = arrayref(a,1)
+for (getindexfn, transform) in ((:getindex, x->x), (:unsafe_getindex, x->:(@boundscheck false return $x)))
+    @eval begin
+        $getindexfn(a::Array) = $(transform(:(arrayref(a,1))))
 
-getindex(A::Array, i0::Real) = arrayref(A,to_index(i0))
-getindex(A::Array, i0::Real, i1::Real) = arrayref(A,to_index(i0),to_index(i1))
-getindex(A::Array, i0::Real, i1::Real, i2::Real) =
-    arrayref(A,to_index(i0),to_index(i1),to_index(i2))
-getindex(A::Array, i0::Real, i1::Real, i2::Real, i3::Real) =
-    arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3))
-getindex(A::Array, i0::Real, i1::Real, i2::Real, i3::Real,  i4::Real) =
-    arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3),to_index(i4))
-getindex(A::Array, i0::Real, i1::Real, i2::Real, i3::Real,  i4::Real, i5::Real) =
-    arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3),to_index(i4),to_index(i5))
+        $getindexfn(A::Array, i0::Real) = $(transform(:(arrayref(A,to_index(i0)))))
+        $getindexfn(A::Array, i0::Real, i1::Real) = $(transform(:(arrayref(A,to_index(i0),to_index(i1)))))
+        $getindexfn(A::Array, i0::Real, i1::Real, i2::Real) =
+            $(transform(:(arrayref(A,to_index(i0),to_index(i1),to_index(i2)))))
+        $getindexfn(A::Array, i0::Real, i1::Real, i2::Real, i3::Real) =
+            $(transform(:(arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3)))))
+        $getindexfn(A::Array, i0::Real, i1::Real, i2::Real, i3::Real,  i4::Real) =
+            $(transform(:(arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3),to_index(i4)))))
+        $getindexfn(A::Array, i0::Real, i1::Real, i2::Real, i3::Real,  i4::Real, i5::Real) =
+            $(transform(:(arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3),to_index(i4),to_index(i5)))))
 
-getindex(A::Array, i0::Real, i1::Real, i2::Real, i3::Real,  i4::Real, i5::Real, I::Real...) =
-    arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3),to_index(i4),to_index(i5),to_index(I)...)
+        $getindexfn(A::Array, i0::Real, i1::Real, i2::Real, i3::Real,  i4::Real, i5::Real, I::Real...) =
+            $(transform(:(arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3),to_index(i4),to_index(i5),to_index(I)...))))
+    end
+end
 
 # Fast copy using copy! for UnitRange
 function getindex(A::Array, I::UnitRange{Int})
@@ -302,21 +306,26 @@ getindex(A::Array, I::AbstractArray{Bool}) = getindex_bool_1d(A, I)
 
 
 ## Indexing: setindex! ##
-setindex!{T}(A::Array{T}, x) = arrayset(A, convert(T,x), 1)
 
-setindex!{T}(A::Array{T}, x, i0::Real) = arrayset(A, convert(T,x), to_index(i0))
-setindex!{T}(A::Array{T}, x, i0::Real, i1::Real) =
-    arrayset(A, convert(T,x), to_index(i0), to_index(i1))
-setindex!{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real) =
-    arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2))
-setindex!{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real) =
-    arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3))
-setindex!{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real) =
-    arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4))
-setindex!{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real) =
-    arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4), to_index(i5))
-setindex!{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real, I::Real...) =
-    arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4), to_index(i5), to_index(I)...)
+for (setindexfn, transform) in ((:setindex!, x->x), (:unsafe_setindex!, x->:(@boundscheck false return $x)))
+    @eval begin
+        $setindexfn{T}(A::Array{T}, x) = $(transform(:(arrayset(A, convert(T,x), 1))))
+
+        $setindexfn{T}(A::Array{T}, x, i0::Real) = $(transform(:(arrayset(A, convert(T,x), to_index(i0)))))
+        $setindexfn{T}(A::Array{T}, x, i0::Real, i1::Real) =
+            $(transform(:(arrayset(A, convert(T,x), to_index(i0), to_index(i1)))))
+        $setindexfn{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real) =
+            $(transform(:(arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2)))))
+        $setindexfn{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real) =
+            $(transform(:(arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3)))))
+        $setindexfn{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real) =
+            $(transform(:(arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4)))))
+        $setindexfn{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real) =
+            $(transform(:(arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4), to_index(i5)))))
+        $setindexfn{T}(A::Array{T}, x, i0::Real, i1::Real, i2::Real, i3::Real, i4::Real, i5::Real, I::Real...) =
+            $(transform(:(arrayset(A, convert(T,x), to_index(i0), to_index(i1), to_index(i2), to_index(i3), to_index(i4), to_index(i5), to_index(I)...))))
+    end
+end
 
 function setindex!{T<:Real}(A::Array, x, I::AbstractVector{T})
     for i in I

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -342,8 +342,9 @@ end
 ## Indexing: getindex ##
 
 function unsafe_bitgetindex(Bc::Vector{Uint64}, i::Int)
-    return (Bc[@_div64(i-1)+1] & (uint64(1)<<@_mod64(i-1))) != 0
+    return @inbounds (Bc[@_div64(i-1)+1] & (uint64(1)<<@_mod64(i-1))) != 0
 end
+unsafe_getindex(v::BitArray, ind::Int) = Base.unsafe_bitgetindex(v.chunks, ind)
 
 function getindex(B::BitArray, i::Int)
     1 <= i <= length(B) || throw(BoundsError())
@@ -408,6 +409,7 @@ function unsafe_bitsetindex!(Bc::Array{Uint64}, x::Bool, i::Int)
         end
     end
 end
+unsafe_setindex!(v::BitArray, x::Bool, ind::Int) = (Base.unsafe_bitsetindex!(v.chunks, x, ind); v)
 
 setindex!(B::BitArray, x) = setindex!(B, convert(Bool,x), 1)
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -776,6 +776,8 @@ export
     union!,
     union,
     unique,
+    unsafe_getindex,
+    unsafe_setindex!,
     values,
     ∈,
     ∉,

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -5,16 +5,6 @@
     nothing
 end
 
-unsafe_getindex(v::Real, ind::Int) = v
-unsafe_getindex(v::Range, ind::Int) = first(v) + (ind-1)*step(v)
-unsafe_getindex(v::BitArray, ind::Int) = Base.unsafe_bitgetindex(v.chunks, ind)
-unsafe_getindex(v::AbstractArray, ind::Int) = v[ind]
-unsafe_getindex(v, ind::Real) = unsafe_getindex(v, to_index(ind))
-
-unsafe_setindex!{T}(v::AbstractArray{T}, x::T, ind::Int) = (v[ind] = x; v)
-unsafe_setindex!(v::BitArray, x::Bool, ind::Int) = (Base.unsafe_bitsetindex!(v.chunks, x, ind); v)
-unsafe_setindex!{T}(v::AbstractArray{T}, x::T, ind::Real) = unsafe_setindex!(v, x, to_index(ind))
-
 # Version that uses cartesian indexing for src
 @ngenerate N typeof(dest) function _getindex!(dest::Array, src::AbstractArray, I::NTuple{N,Union(Int,AbstractVector)}...)
     checksize(dest, I...)

--- a/base/number.jl
+++ b/base/number.jl
@@ -15,6 +15,8 @@ getindex(x::Number) = x
 getindex(x::Number, i::Integer) = i == 1 ? x : throw(BoundsError())
 getindex(x::Number, I::Integer...) = all([i == 1 for i in I]) ? x : throw(BoundsError())
 getindex(x::Number, I::Real...) = getindex(x, to_index(i)...)
+unsafe_getindex(x::Number, i::Real) = x
+unsafe_getindex(x::Number, i::Real...) = x
 first(x::Number) = x
 last(x::Number) = x
 


### PR DESCRIPTION
This implements my proposal from https://github.com/JuliaLang/julia/issues/7799#issuecomment-51723448. `unsafe_getindex`/`unsafe_setindex!` provide `getindex`/`setindex!` functionality without bounds checks, and `@inbounds` rewrites the AST to call the unsafe versions of these functions. `@inbounds` only affects the expression it's applied to, not all inlined function calls. `@boundscheck` still works and provides the old behavior in case there's a really good reason to use it. As a bonus, this variant of `@inbounds` could be made to pass through the value of the enclosed expression, ~~although at the moment I don't think the behavior is as expected for `setindex!` expressions~~.

This would have been a lot easier if it didn't require reimplementing the expansion of expressions containing `ref` into `getindex`/`setindex!` in Julia before `array.jl` is loaded. It may be a better idea to adjust the femtolisp code so that it can perform this expansion without expanding anything else. Being able to rewrite `getindex`/`setindex!` with a macro may also be useful for the transition to arrays as views.
