### PR TITLE
Fix segfault when code_llvm or code_native are called on a C function

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -861,8 +861,14 @@ void *jl_get_llvmf(jl_function_t *f, jl_tuple_t *types, bool getwrapper)
                   "Warning: Returned code may not match what actually runs.\n");
     }
     Function *llvmf;
-    if (sf->linfo->functionObject == NULL) {
-      jl_compile(sf);
+    if (getwrapper || sf->linfo->specTypes == NULL) {
+        if (sf->linfo->functionObject == NULL) {
+            jl_compile(sf);
+        }
+    } else {
+        if (sf->linfo->cFunctionObject == NULL) {
+            jl_cstyle_compile(sf);
+        }
     }
     if (sf->fptr == &jl_trampoline) {
         if (!getwrapper && sf->linfo->cFunctionObject != NULL)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -861,14 +861,8 @@ void *jl_get_llvmf(jl_function_t *f, jl_tuple_t *types, bool getwrapper)
                   "Warning: Returned code may not match what actually runs.\n");
     }
     Function *llvmf;
-    if (getwrapper) {
-        if (sf->linfo->functionObject == NULL) {
-            jl_compile(sf);
-        }
-    } else {
-        if (sf->linfo->cFunctionObject == NULL) {
-            jl_cstyle_compile(sf);
-        }
+    if (sf->linfo->functionObject == NULL) {
+      jl_compile(sf);
     }
     if (sf->fptr == &jl_trampoline) {
         if (!getwrapper && sf->linfo->cFunctionObject != NULL)


### PR DESCRIPTION
Code that segfaults on current master includes any of the following, and other similar things:

```
 code_llvm(match,(Regex,String))
 code_native(match,(Regex,String))
 code_llvm(*,(Array{Int}, Array{Int}))
 code_native(*,(Array{Int}, Array{Int}))
```

Backtrace looks something like:

```
# Program received signal SIGSEGV, Segmentation fault.                                                                            
# 0x00007ffff6d9f424 in emit_function (lam=0x1c7fcf0, cstyle=true) at codegen.cpp:3445                                            
#3445            for(size_t i=0; i < jl_tuple_len(lam->specTypes); i++) {                                                        
# (gdb) bt                                                                                                                        
# #0  0x00007ffff6d9f424 in emit_function (lam=0x1c7fcf0, cstyle=true) at codegen.cpp:3445                                        
# #1  0x00007ffff6d7cd2f in to_function (li=0x1c7fcf0, cstyle=true) at codegen.cpp:570                                            
# #2  0x00007ffff6d7d253 in jl_cstyle_compile (f=0x1c6e780) at codegen.cpp:698                                                    
# #3  0x00007ffff6d803c7 in jl_get_llvmf (f=0x1c6e6a0, types=0x2b4b300, getwrapper=false)                                         
#     at codegen.cpp:870                                                                                                          
# #4  0x00007ffff6d80492 in jl_dump_function (f=0x1c6e6a0, types=0x2b4b300, dumpasm=true,                                         
#     dumpwrapper=false) at codegen.cpp:888                                                                                       
# #5  0x00007ffff4aa8f77 in ?? ()                                                                                                 
# #6  0x0000000000000006 in ?? ()                                                                                                 
# #7  0x00007fffffffcd40 in ?? ()                                                                                                 
# #8  0x0000000000000000 in ?? ()                                                                                                 
```

The current 0.3 RC (.3.1-pre+42) seems immune to this bug.
