### PR TITLE
Fix hangs and segfaults when egregiously long symbol is used

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -462,6 +462,10 @@ static jl_sym_t *mk_symbol(const char *str)
     size_t len = strlen(str);
     size_t nb = (sizeof(jl_sym_t)+len+1+7)&-8;
 
+    if (len >= SYM_POOL_SIZE) {
+        jl_error("Symbol length exceeds maximum length");
+    }
+
 #ifdef MEMDEBUG
     sym = (jl_sym_t*)malloc(nb);
 #else

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -462,7 +462,7 @@ static jl_sym_t *mk_symbol(const char *str)
     size_t len = strlen(str);
     size_t nb = (sizeof(jl_sym_t)+len+1+7)&-8;
 
-    if (len >= SYM_POOL_SIZE) {
+    if (nb >= SYM_POOL_SIZE) {
         jl_error("Symbol length exceeds maximum length");
     }
 


### PR DESCRIPTION
Julia hangs when I have a program with a symbol of length `2**19`. It then segfaults when I ^C. Longer symbols segfault immediately. Oddly, a symbol of length 2**19 causes julia to segfault immediately when I run it under gdb.

This causes an julia to error out instead hanging or segfaulting.
