### PR TITLE
make `big` map ranges to ranges

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -345,7 +345,7 @@ for fn in _numeric_conversion_func_names
     end
 end
 
-for fn in (:float,:float16,:float32,:float64)
+for fn in (:float,:float16,:float32,:float64,:big)
     @eval begin
         $fn(r::FloatRange) = FloatRange($fn(r.start), $fn(r.step), r.len, $fn(r.divisor))
     end

--- a/base/number.jl
+++ b/base/number.jl
@@ -56,4 +56,5 @@ one{T<:Number}(::Type{T}) = oftype(T,1)
 const _numeric_conversion_func_names =
     (:int,:integer,:signed,:int8,:int16,:int32,:int64,:int128,
      :uint,:unsigned,:uint8,:uint16,:uint32,:uint64,:uint128,
-     :float,:float16,:float32,:float64)
+     :float,:float16,:float32,:float64,
+     :big)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -176,7 +176,6 @@ importall .MPFR
 big(n::Integer) = convert(BigInt,n)
 big(x::FloatingPoint) = convert(BigFloat,x)
 big(q::Rational) = big(num(q))//big(den(q))
-big(z::Complex) = complex(big(real(z)),big(imag(z)))
 
 # more hashing definitions
 include("hashing2.jl")


### PR DESCRIPTION
This makes `big` more similar to other conversion functions (`int`, `float`, etc.), eg `big(1:10)` is now a `UnitRange{BigInt}` instead of an array.
There are many other small possible improvements (e.g. implement `BigFloat(1:10)`), but I guess that resolving issue #1470 first will help having more coherent conversion functions.
