### PR TITLE
fix infinite loop in `rand(::Range(BigInt))`

### DIFF
--- a/test/random.jl
+++ b/test/random.jl
@@ -53,6 +53,20 @@ if sizeof(Int32) < sizeof(Int)
 
 end
 
+# BigInt specific
+s = big(typemax(Uint128)-1000):(big(typemax(Uint128)) + 10000)
+@test rand(s) != rand(s)
+@test big(typemax(Uint128)-1000) <= rand(s) <= big(typemax(Uint128)) + 10000
+r = rand(s, 1, 2)
+@test size(r) == (1, 2)
+@test typeof(r) == Matrix{BigInt}
+
+srand(0)
+r = rand(s)
+srand(0)
+@test rand(s) == r
+
+
 randn(100000)
 randn!(Array(Float64, 100000))
 randn(MersenneTwister(10), 100000)

--- a/test/random.jl
+++ b/test/random.jl
@@ -33,7 +33,7 @@ randn!(MersenneTwister(42), A)
 @test A == [-0.5560268761463861  0.027155338009193845;
             -0.444383357109696  -0.29948409035891055]
 
-for T in (Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64, Int128, Uint128,
+for T in (Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64, Int128, Uint128, BigInt,
           Char, Float16, Float32, Float64, Rational{Int})
     r = rand(convert(T, 97):convert(T, 122))
     @test typeof(r) == T


### PR DESCRIPTION
The call `rand(big(1):big(2))` was causing a stack overflow. It's not the best possible fix, as this works now only for ranges whose length fit in an `Int`. The simplest other solutions I see is to use `rand(UnitRange{Uint128})` to implement `rand(r::Range{BigInt})` (for big ranges of length up to `typemax(Uint128)`), or to constrain the `T` in `rand{T}(r::Range{T})` (random.jl line 210) to prevent (hopefully temporarily) a call to `rand` with a big range altogether. 
