### PR TITLE
julia-mode.el: syntax entry for '/' and '.'

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -51,7 +51,6 @@
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?_ "w" table)   ; underscores in words
     (modify-syntax-entry ?@ "w" table)
-    (modify-syntax-entry ?. "_" table)
     (modify-syntax-entry ?# "< 14" table)  ; # single-line and multiline start
     (modify-syntax-entry ?= ". 23bn" table)
     (modify-syntax-entry ?\n ">" table)  ; \n single-line comment end
@@ -66,10 +65,12 @@
     (modify-syntax-entry ?\" "\"" table)
     (modify-syntax-entry ?` "\"" table)
     ;; (modify-syntax-entry ?\" "." table)
+    (modify-syntax-entry ?. "." table)
     (modify-syntax-entry ?? "." table)
     (modify-syntax-entry ?$ "." table)
     (modify-syntax-entry ?& "." table)
     (modify-syntax-entry ?* "." table)
+    (modify-syntax-entry ?/ "." table)
     (modify-syntax-entry ?+ "." table)
     (modify-syntax-entry ?- "." table)
     (modify-syntax-entry ?< "." table)


### PR DESCRIPTION
The division operator '/' was missing from the syntax table.  Also it would be better to classify '.' as a punctuation character.
