### PR TITLE
Fix hang/incorrect result for ndigits(n,b) when b < 0

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -429,6 +429,7 @@ function base(b::Integer, n::BigInt)
 end
 
 function ndigits0z(x::BigInt, b::Integer=10)
+    b < 0 && throw(DomainError()) # TODO: make this work correctly.
     # mpz_sizeinbase might return an answer 1 too big
     n = int(ccall((:__gmpz_sizeinbase,:libgmp), Culong, (Ptr{BigInt}, Int32), &x, b))
     abs(x) < big(b)^(n-1) ? n-1 : n

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -158,6 +158,23 @@ ndigits0z(x::Integer) = ndigits0z(unsigned(abs(x)))
 
 const ndigits_max_mul = WORD_SIZE==32 ? 69000000 : 290000000000000000
 
+function ndigits0zpos(n::Unsigned, b::Int)
+
+end
+
+function ndigitsnb(n::Int, b::Int)
+    if n == 0
+        return 1
+    end
+
+    d = 0
+    while n != 0
+        n = iceil(n/b)
+        d += 1
+    end
+    return d
+end
+
 function ndigits0z(n::Unsigned, b::Int)
     b == 2  && return (sizeof(n)<<3-leading_zeros(n))
     b == 8  && return div((sizeof(n)<<3)-leading_zeros(n)+2,3)
@@ -180,7 +197,7 @@ ndigits0z(x::Integer, b::Integer) = ndigits0z(unsigned(abs(x)),int(b))
 ndigits(x::Unsigned, b::Integer) = x==0 ? 1 : ndigits0z(x,int(b))
 ndigits(x::Unsigned)             = x==0 ? 1 : ndigits0z(x)
 
-ndigits(x::Integer, b::Integer) = ndigits(unsigned(abs(x)),int(b))
+ndigits(x::Integer, b::Integer) = b >= 0 ? ndigits(unsigned(abs(x)),int(b)) : ndigitsnb(x, b)
 ndigits(x::Integer) = ndigits(unsigned(abs(x)))
 
 ## integer to string functions ##

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -165,26 +165,31 @@ function ndigitsnb(n::Int, b::Int)
 
     d = 0
     while n != 0
-        n = iceil(n/b)
+        # cld, while #8111 is waiting to be merged.
+        n = div(n,b)+(!signbit(n$b)&(rem(n,b)!=0))
         d += 1
     end
     return d
 end
 
 function ndigits0z(n::Unsigned, b::Int)
-    b == 2  && return (sizeof(n)<<3-leading_zeros(n))
-    b == 8  && return div((sizeof(n)<<3)-leading_zeros(n)+2,3)
-    b == 16 && return (sizeof(n)<<1)-(leading_zeros(n)>>2)
-    b == 10 && return ndigits0z(n)
     d = 0
-    while ndigits_max_mul < n
-        n = div(n,b)
-        d += 1
-    end
-    m = 1
-    while m <= n
-        m *= b
-        d += 1
+    if b < 0
+        d = ndigitsnb(signed(n), b)
+    else
+        b == 2  && return (sizeof(n)<<3-leading_zeros(n))
+        b == 8  && return div((sizeof(n)<<3)-leading_zeros(n)+2,3)
+        b == 16 && return (sizeof(n)<<1)-(leading_zeros(n)>>2)
+        b == 10 && return ndigits0z(n)
+        while ndigits_max_mul < n
+            n = div(n,b)
+            d += 1
+        end
+        m = 1
+        while m <= n
+            m *= b
+            d += 1
+        end
     end
     return d
 end
@@ -193,7 +198,7 @@ ndigits0z(x::Integer, b::Integer) = ndigits0z(unsigned(abs(x)),int(b))
 ndigits(x::Unsigned, b::Integer) = x==0 ? 1 : ndigits0z(x,int(b))
 ndigits(x::Unsigned)             = x==0 ? 1 : ndigits0z(x)
 
-ndigits(x::Integer, b::Integer) = b >= 0 ? ndigits(unsigned(abs(x)),int(b)) : ndigitsnb(x, b)
+ndigits(x::Integer, b::Integer) = ndigits(unsigned(abs(x)),int(b))
 ndigits(x::Integer) = ndigits(unsigned(abs(x)))
 
 ## integer to string functions ##

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -158,10 +158,6 @@ ndigits0z(x::Integer) = ndigits0z(unsigned(abs(x)))
 
 const ndigits_max_mul = WORD_SIZE==32 ? 69000000 : 290000000000000000
 
-function ndigits0zpos(n::Unsigned, b::Int)
-
-end
-
 function ndigitsnb(n::Int, b::Int)
     if n == 0
         return 1

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -158,11 +158,7 @@ ndigits0z(x::Integer) = ndigits0z(unsigned(abs(x)))
 
 const ndigits_max_mul = WORD_SIZE==32 ? 69000000 : 290000000000000000
 
-function ndigitsnb(n::Int, b::Int)
-    if n == 0
-        return 1
-    end
-
+function ndigits0znb(n::Int, b::Int)
     d = 0
     while n != 0
         n = cld(n,b)
@@ -193,6 +189,8 @@ function ndigits0z(n::Unsigned, b::Int)
     return d
 end
 ndigits0z(x::Integer, b::Integer) = ndigits0z(unsigned(abs(x)),int(b))
+
+ndigitsnb(x::Integer, b::Integer) = x==0 ? 1 : ndigits0znb(x, b)
 
 ndigits(x::Unsigned, b::Integer) = x==0 ? 1 : ndigits0z(x,int(b))
 ndigits(x::Unsigned)             = x==0 ? 1 : ndigits0z(x)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -170,7 +170,7 @@ end
 function ndigits0z(n::Unsigned, b::Int)
     d = 0
     if b < 0
-        d = ndigitsnb(signed(n), b)
+        d = ndigits0znb(signed(n), b)
     else
         b == 2  && return (sizeof(n)<<3-leading_zeros(n))
         b == 8  && return div((sizeof(n)<<3)-leading_zeros(n)+2,3)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -198,7 +198,7 @@ ndigits0z(x::Integer, b::Integer) = ndigits0z(unsigned(abs(x)),int(b))
 ndigits(x::Unsigned, b::Integer) = x==0 ? 1 : ndigits0z(x,int(b))
 ndigits(x::Unsigned)             = x==0 ? 1 : ndigits0z(x)
 
-ndigits(x::Integer, b::Integer) = ndigits(unsigned(abs(x)),int(b))
+ndigits(x::Integer, b::Integer) = b >= 0 ? ndigits(unsigned(abs(x)),int(b)) : ndigitsnb(x, b)
 ndigits(x::Integer) = ndigits(unsigned(abs(x)))
 
 ## integer to string functions ##

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -165,8 +165,7 @@ function ndigitsnb(n::Int, b::Int)
 
     d = 0
     while n != 0
-        # cld, while #8111 is waiting to be merged.
-        n = div(n,b)+(!signbit(n$b)&(rem(n,b)!=0))
+        n = cld(n,b)
         d += 1
     end
     return d

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@ JULIAHOME = $(abspath ..)
 include ../Make.inc
 
 TESTS = all core keywordargs numbers strings unicode collections hashing	\
-	remote iobuffer arrayops reduce reducedim \
+	remote iobuffer arrayops reduce reducedim intfuncs \
 	simdloop linalg blas fft dsp sparse bitarray random \
 	math functional bigint sorting statistics spawn parallel arpack file	\
 	git pkg resolve suitesparse complex version pollfd mpfr	broadcast       \

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -10,6 +10,7 @@
 @test ndigits(10, -10) == 3
 @test ndigits(17, 10) == 2
 @test ndigits(17, -10) == 3
+@test ndigits(unsigned(17), -10) == 3
 
 @test ndigits(146, -3) == 5
 

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -1,0 +1,15 @@
+# issue #8266
+
+@test ndigits(-15, 10) == 2
+@test ndigits(-15, -10) == 2
+@test ndigits(-1, 10) == 1
+@test ndigits(-1, -10) == 2
+@test ndigits(2, 10) == 1
+@test ndigits(2, -10) == 1
+@test ndigits(10, 10) == 2
+@test ndigits(10, -10) == 3
+@test ndigits(17, 10) == 2
+@test ndigits(17, -10) == 3
+
+@test ndigits(146, -3) == 5
+


### PR DESCRIPTION
This presently hangs for n large enough to trigger the slow division code path in `ndigits0z`, since we have n::unsigned and we try to put a negative number in there, which turns into a huge unsigned number.

For smaller n, the result is wrong in most cases when b < 0.

This PR doesn't optimize the negative base version the same way the positive base version is optimized, but it at least doesn't hang and works for the cases I've tried.
