### PR TITLE
Packages incompatible with your Julia version

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -373,8 +373,12 @@ function resolve(
 
     for pkg in keys(reqs)
         if !haskey(deps,pkg)
-            error("$pkg's requirements can't be satisfied because of the following fixed packages: ",
+            if "julia" in conflicts[pkg]
+                error("$pkg can't be installed because it has no versions that support ", VERSION, " of julia")
+            else
+                error("$pkg's requirements can't be satisfied because of the following fixed packages: ",
                    join(conflicts[pkg], ", ", " and "))
+            end
         end
     end
 


### PR DESCRIPTION
If a package doesn't have any tagged versions compatible with your julia
version, it complains that

``` julia
FixedPoint's requirements can't be satisfied because of the following fixed packages: julia
```

It seems confusing to consider julia a fixed package, so I changed the
message to.

```
ERROR: FixedPoint can't be installed because it has no versions that
support 0.4.0-dev+473 of julia
```

PS: I found this because I had forgot that `FixedPoint` has been renamed to `FixedPointNumbers`
