### PR TITLE
Specialize sum(r::FloatRange)

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -543,6 +543,17 @@ function sum{T<:Real}(r::Range{T})
                                      : (step(r) * l) * ((l-1)>>1))
 end
 
+function sum(r::FloatRange)
+    l = length(r)
+    if iseven(l)
+        s = r.step * (l-1) * (l>>1)
+    else
+        s = (r.step * l) * ((l-1)>>1)
+    end
+    return (l * r.start + s)/r.divisor
+end
+
+
 function mean{T<:Real}(r::Range{T})
     isempty(r) && error("mean of an empty range is undefined")
     (first(r) + last(r)) / 2

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -181,7 +181,13 @@ let s = 0
     @test s == 0
 end
 
-# sums (see #5798)
+# sums of ranges
+@test sum(1:100) == 5050
+@test sum(0:100) == 5050
+@test sum(-100:100) == 0
+@test sum(0:2:100) == 2550
+
+# overflowing sums (see #5798)
 if WORD_SIZE == 64
     @test sum(int128(1:10^18)) == div(10^18 * (int128(10^18)+1), 2)
     @test sum(int128(1:10^18-1)) == div(10^18 * (int128(10^18)-1), 2)
@@ -189,6 +195,12 @@ else
     @test sum(int64(1:10^9)) == div(10^9 * (int64(10^9)+1), 2)
     @test sum(int64(1:10^9-1)) == div(10^9 * (int64(10^9)-1), 2)
 end
+
+# Tricky sums of FloatRange #8272
+@test sum(10000.:-0.0001:0) == 5.00000005e11
+@test sum(0:0.001:1) == 500.5
+@test sum(0:0.000001:1) == 500000.5
+@test sum(0:0.1:10) == 505.
 
 # operations with scalars
 @test (1:3) - 2 == -1:1


### PR DESCRIPTION
FloatRange stores a divisor for increased accuracy, and we should use
that in `sum` to get a more correct answer there also.

Obviously I don't like the one liner used for the general `sum(r::Range)` implementation, because I find it hard to read. I'll compactify/obfuscate this also, if there is demand for that.
