### PR TITLE
Fix stdout/stderr redirect after tests that print to stdout and stderr

### DIFF
--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1,4 +1,4 @@
-# code_native (issue #8239)
+# code_native / code_llvm (issue #8239)
 
 # redirect stdout and stderr to avoid spam during tests.
 oldout = STDOUT
@@ -17,14 +17,13 @@ redirect_stderr()
 @test code_llvm(+, (Array{Float32}, Array{Float32})) == nothing
 
 redirect_stdout(oldout)
-redirect_stdout(olderr)
+redirect_stderr(olderr)
 
 @test_throws Exception code_native(+, Int, Int)
 @test_throws Exception code_native(+, Array{Float32}, Array{Float32})
 
 @test_throws Exception code_llvm(+, Int, Int)
 @test_throws Exception code_llvm(+, Array{Float32}, Array{Float32})
-
 
 # isbits
 


### PR DESCRIPTION
This fixes the bug introduced by the new tests in #8251, where stdout/stderr weren't restored correctly.
