### PR TITLE
Add inline macro via :meta expressions

### DIFF
--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -30,6 +30,9 @@ const CARTESIAN_DIMS = 4
 #   myfunction(A::AbstractArray, I::Int...N)
 # where N can be an integer or symbol. Currently T...N generates a parser error.
 macro ngenerate(itersym, returntypeexpr, funcexpr)
+    if isa(funcexpr, Expr) && funcexpr.head == :macrocall && funcexpr.args[1] == symbol("@inline")
+        funcexpr = Base._inline(funcexpr.args[2])
+    end
     isfuncexpr(funcexpr) || error("Requires a function expression")
     esc(ngenerate(itersym, returntypeexpr, funcexpr.args[1], N->sreplace!(copy(funcexpr.args[2]), itersym, N)))
 end
@@ -56,6 +59,9 @@ macro nsplat(itersym, args...)
         rng = rangeexpr.args[1]:rangeexpr.args[2]
     else
         error("Wrong number of arguments")
+    end
+    if isa(funcexpr, Expr) && funcexpr.head == :macrocall && funcexpr.args[1] == symbol("@inline")
+        funcexpr = Base._inline(funcexpr.args[2])
     end
     isfuncexpr(funcexpr) || error("Second argument must be a function expression")
     prototype = funcexpr.args[1]

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1384,4 +1384,5 @@ export
     @inbounds,
     @simd,
     @label,
-    @goto
+    @goto,
+    @inline

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -63,6 +63,13 @@ macro eval(x)
     :($(esc(:eval))($(Expr(:quote,x))))
 end
 
+macro inline(ex)
+    esc(_inline(ex))
+end
+
+_inline(ex::Expr) = pushmeta!(ex, :inline)
+_inline(arg) = arg
+
 ## some macro utilities ##
 
 find_vars(e) = find_vars(e, {})
@@ -95,3 +102,37 @@ function localize_vars(expr, esca)
     end
     Expr(:localize, :(()->($expr)), v...)
 end
+
+function pushmeta!(ex::Expr, sym::Symbol)
+    if ex.head == :function
+        body::Expr = ex.args[2]
+        if !isempty(body.args) && isa(body.args[1], Expr) && (body.args[1]::Expr).head == :meta
+            push!((body.args[1]::Expr).args, sym)
+        else
+            unshift!(body.args, Expr(:meta, sym))
+        end
+    elseif (ex.head == :(=) && typeof(ex.args[1]) == Expr && ex.args[1].head == :call)
+        ex = Expr(:function, ex.args[1], Expr(:block, Expr(:meta, sym), ex.args[2]))
+#     else
+#         ex = Expr(:withmeta, ex, sym)
+    end
+    ex
+end
+
+function popmeta!(body::Expr, sym::Symbol)
+    if isa(body.args[1],Expr) && (body.args[1]::Expr).head === :meta
+        metaargs = (body.args[1]::Expr).args
+        for i = 1:length(metaargs)
+            if metaargs[i] == sym
+                if length(metaargs) == 1
+                    shift!(body.args)        # get rid of :meta Expr
+                else
+                    deleteat!(metaargs, i)   # delete this portion of the metadata
+                end
+                return true
+            end
+        end
+    end
+    false
+end
+popmeta!(arg, sym) = false

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2496,10 +2496,9 @@ const inline_incompletematch_allowed = false
 
 inline_worthy(body, cost::Real) = true
 function inline_worthy(body::Expr, cost::Real=1.0) # precondition: 0<cost
-#    if isa(body.args[1],QuoteNode) && (body.args[1]::QuoteNode).value === :inline
-#        shift!(body.args)
-#        return true
-#    end
+    if popmeta!(body, :inline)
+        return true
+    end
     symlim = 1+5/cost
     if length(body.args) < symlim
         symlim *= 16

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -91,7 +91,7 @@ jl_sym_t *compositetype_sym; jl_sym_t *type_goto_sym;
 jl_sym_t *global_sym; jl_sym_t *tuple_sym;
 jl_sym_t *dot_sym;    jl_sym_t *newvar_sym;
 jl_sym_t *boundscheck_sym; jl_sym_t *copyast_sym;
-jl_sym_t *simdloop_sym;
+jl_sym_t *simdloop_sym; jl_sym_t *meta_sym;
 
 typedef struct {
     int64_t a;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3006,6 +3006,9 @@ static Value *emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed,
                       "Warning: could not attach metadata for @simd loop.\n");
         return NULL;
     }
+    else if (head == meta_sym) {
+        return literal_pointer_val((jl_value_t*)jl_nothing);  // will change as new metadata gets added
+    }
     else {
         if (!strcmp(head->name, "$"))
             jl_error("syntax: prefix $ in non-quoted expression");

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -455,6 +455,9 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
     else if (ex->head == simdloop_sym) {
         return (jl_value_t*)jl_nothing;
     }
+    else if (ex->head == meta_sym) {
+        return (jl_value_t*)jl_nothing;
+    }
     jl_errorf("unsupported or misplaced expression %s", ex->head->name);
     return (jl_value_t*)jl_nothing;
 }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3261,6 +3261,7 @@ void jl_init_types(void)
     newvar_sym = jl_symbol("newvar");
     copyast_sym = jl_symbol("copyast");
     simdloop_sym = jl_symbol("simdloop");
+    meta_sym = jl_symbol("meta");
 }
 
 #ifdef __cplusplus

--- a/src/julia.h
+++ b/src/julia.h
@@ -421,7 +421,7 @@ extern jl_sym_t *abstracttype_sym; extern jl_sym_t *bitstype_sym;
 extern jl_sym_t *compositetype_sym; extern jl_sym_t *type_goto_sym;
 extern jl_sym_t *global_sym;  extern jl_sym_t *tuple_sym;
 extern jl_sym_t *boundscheck_sym; extern jl_sym_t *copyast_sym;
-extern jl_sym_t *simdloop_sym;
+extern jl_sym_t *simdloop_sym; extern jl_sym_t *meta_sym;
 
 
 // object accessors -----------------------------------------------------------

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ TESTS = all core keywordargs numbers strings unicode collections hashing	\
 	suitesparse complex version pollfd mpfr	broadcast socket floatapprox	\
 	priorityqueue readdlm reflection regex float16 combinatorics dates	\
 	sysinfo rounding ranges mod2pi euler show lineedit replcompletions	\
-	backtrace repl test examples goto llvmcall grisu
+	backtrace repl test examples goto llvmcall grisu meta
 
 default: all
 

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -1,0 +1,27 @@
+# test meta-expressions that annotate blocks of code
+
+module MetaTest
+
+using Base.Test
+
+function f(x)
+    y = x+5
+    z = y*y
+    q = z/y
+    m = q-3
+end
+
+@inline function f_inlined(x)
+    y = x+5
+    z = y*y
+    q = z/y
+    m = q-3
+end
+
+g(x) = f(2x)
+g_inlined(x) = f_inlined(2x)
+
+@test g(3) == g_inlined(3)
+@test f(3) == f_inlined(3)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ testnames = [
     "floatapprox", "readdlm", "reflection", "regex", "float16", "combinatorics",
     "sysinfo", "rounding", "ranges", "mod2pi", "euler", "show",
     "lineedit", "replcompletions", "repl", "test", "examples", "goto",
-    "llvmcall", "grisu", "nullable"
+    "llvmcall", "grisu", "nullable", "meta"
 ]
 @unix_only push!(testnames, "unicode")
 


### PR DESCRIPTION
This reinstates @vtjnash's contribution of the ability to declare that a function should be inlined. However, this implementation does it with an `@inline` macro and a new `Expr(:meta, <metadata>...)` construct. meta-expressions can be used for other things too (I wonder if @ArchRobison may be interested in using it to introduce `@SLPvectorize`...)

Demo:

``` julia
function f(x)
    y = x+5
    z = y*y
    q = z/y
    m = q-3
end

@inline function f_inlined(x)
    y = x+5
    z = y*y
    q = z/y
    m = q-3
end

g(x) = f(2x)
g_inlined(x) = f_inlined(2x)

julia> code_typed(g, (Int,))
1-element Array{Any,1}:
 :($(Expr(:lambda, {:x}, {{},{{:x,Int64,0}},{}}, :(begin  # none, line 1:
        return f((top(box))(Int64,(top(mul_int))(2,x::Int64))::Int64)::Float64
    end::Float64))))

julia> code_typed(g_inlined, (Int,))
1-element Array{Any,1}:
 :($(Expr(:lambda, {:x}, {{:_var0,:_var1,:_var2,:_var3,:_var4},{{:x,Int64,0},{:_var0,Int64,18},{:_var1,Int64,18},{:_var2,Float64,18},{:_var3,Float64,18},{:_var4,Float64,18}},{}}, :(begin  # none, line 1:
        _var0 = (top(box))(Int64,(top(add_int))((top(box))(Int64,(top(mul_int))(2,x::Int64))::Int64,5))::Int64
        _var1 = (top(box))(Int64,(top(mul_int))(_var0::Int64,_var0::Int64))::Int64
        _var2 = (top(box))(Float64,(top(div_float))((top(box))(Float64,(top(sitofp))(Float64,_var1::Int64))::Float64,(top(box))(Float64,(top(sitofp))(Float64,_var0::Int64))::Float64))::Float64
        _var3 = (top(box))(Float64,(top(sub_float))(_var2::Float64,(top(box))(Float64,(top(sitofp))(Float64,3))::Float64))::Float64
        _var4 = _var3::Float64
        return _var3::Float64
    end::Float64))))
```

Everything seems to work, ~~except for some reason my attempt to "register" the `meta_sym` doesn't seem to have succeeded~~(EDIT: see below):

``` julia
julia> g(3)
8.0

julia> g_inlined(3)
8.0

julia> f(3)
5.0

julia> f_inlined(3)
ERROR: error compiling f_inlined: unsupported or misplaced expression meta in function f_inlined
```

Anyone know why? @ArchRobison, you had to go through this with `simdloop_sym`, any tips?

Reference: discussion starting at https://github.com/JuliaLang/julia/pull/3796#issuecomment-21433164.

Also CC @carlobaldassi (cartesian iteration).
