### PR TITLE
Prevent Array(foo, n) from returning an array of the wrong size

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -231,19 +231,35 @@ Array{T}(::Type{T}, m::Int,n::Int,o::Int) =
     ccall(:jl_alloc_array_3d, Array{T,3}, (Any,Int,Int,Int), Array{T,3}, m,n,o)
 
 Array(T::Type, d::Int...) = Array(T, d)
-Array(T::Type, d::Integer...) = Array(T, convert((Int...), d))
+function Array(T::Type, ds::Integer...)
+    for d in ds
+        if d > typemax(Int) || d < 0
+            throw(ArgumentError("invalid Array dimensions"))
+        end
+    end
+    Array(T, convert((Int...), ds))
+end
 
 function Array{T}(::Type{T}, m::Integer)
-    abs(m) > typemax(Int) && throw(MemoryError)
+    if m > typemax(Int) || m < 0
+        throw(ArgumentError("invalid Array dimensions"))
+    end
     ccall(:jl_alloc_array_1d, Array{T,1}, (Any,Int), Array{T,1}, m)
 end
 
 function Array{T}(::Type{T}, m::Integer,n::Integer)
-    abs(m) > typemax(Int) && abs(n) > typemax(Int) && throw(MemoryError)
+    if (m > typemax(Int) || m < 0) ||
+       (n > typemax(Int) || n < 0)
+        throw(ArgumentError("invalid Array dimensions"))
+    end
     ccall(:jl_alloc_array_2d, Array{T,2}, (Any,Int,Int), Array{T,2}, m, n)
 end
 
 function Array{T}(::Type{T}, m::Integer,n::Integer,o::Integer)
-    abs(m) > typemax(Int) && abs(n) > typemax(Int) && abs(o) > typemax(Int) && throw(MemoryError)
+    if (m > typemax(Int) || m < 0) ||
+       (n > typemax(Int) || n < 0) ||
+       (o > typemax(Int) || n < 0)
+        throw(ArgumentError("invalid Array dimensions"))
+    end
     ccall(:jl_alloc_array_3d, Array{T,3}, (Any,Int,Int,Int), Array{T,3}, m, n, o)
 end

--- a/base/base.jl
+++ b/base/base.jl
@@ -233,9 +233,17 @@ Array{T}(::Type{T}, m::Int,n::Int,o::Int) =
 Array(T::Type, d::Int...) = Array(T, d)
 Array(T::Type, d::Integer...) = Array(T, convert((Int...), d))
 
-Array{T}(::Type{T}, m::Integer) =
+function Array{T}(::Type{T}, m::Integer)
+    abs(m) > typemax(Int) && throw(MemoryError)
     ccall(:jl_alloc_array_1d, Array{T,1}, (Any,Int), Array{T,1}, m)
-Array{T}(::Type{T}, m::Integer,n::Integer) =
+end
+
+function Array{T}(::Type{T}, m::Integer,n::Integer)
+    abs(m) > typemax(Int) && abs(n) > typemax(Int) && throw(MemoryError)
     ccall(:jl_alloc_array_2d, Array{T,2}, (Any,Int,Int), Array{T,2}, m, n)
-Array{T}(::Type{T}, m::Integer,n::Integer,o::Integer) =
+end
+
+function Array{T}(::Type{T}, m::Integer,n::Integer,o::Integer)
+    abs(m) > typemax(Int) && abs(n) > typemax(Int) && abs(o) > typemax(Int) && throw(MemoryError)
     ccall(:jl_alloc_array_3d, Array{T,3}, (Any,Int,Int,Int), Array{T,3}, m, n, o)
+end


### PR DESCRIPTION
```
julia> Array(Int, -14195763867060736356299439484696781493)
4611694853239872843-element Array{Int64,1}:
...

julia> x = int128(2)^65+10
36893488147419103242

julia> Array(Int, x)
10-element Array{Int64,1}:
...
```

The first statement only fails on my mac (10.9.2), but the second returns a mis-sized array on both linux and mac.

This could also be fixed by passing an `Int128` to `jl_alloc_array*` and changing `_new_array_`. But, currently, both of my machines use `uint64_t` for the internal calculations because of this typedef:

```
#if defined(_P64) && defined(UINT128MAX)
typedef __uint128_t wideint_t;
#else
typedef uint64_t wideint_t;
#endif
```

Sorry for the all of the weird corner case issue spam; I spent a few minutes writing [a really simplistic fuzzer](https://github.com/danluu/Fuzz.jl). It's found a couple of bugs I could imagine actually running into, and a bunch of obscure issues like this one. IME, it's more effective to fix these really unlikely bugs than it is to try to target "good" bugs, and I've heard that mozilla had the same experience with [jsfunfuzz](https://bugzilla.mozilla.org/show_bug.cgi?id=jsfunfuzz).
