### PR TITLE
Make rand work with AbstractArray instead of only with Range 

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -146,7 +146,7 @@ rand{T<:Number}(::Type{T}) = error("no random number generator for type $T; try 
 rand{T<:Number}(::Type{T}, dims::Int...) = rand(T, dims)
 
 
-## Generate random integer within a range
+## Generate random integer within a range 1:n
 
 # remainder function according to Knuth, where rem_knuth(a, 0) = a
 rem_knuth(a::Uint, b::Uint) = a % (b + (b == 0)) + a * (b == 0)
@@ -208,9 +208,15 @@ function rand{T<:Integer, U<:Unsigned}(g::RandIntGen{T,U})
     itrunc(T, one(U) + rem_knuth(x, g.k))
 end
 
-rand{T}(r::Range{T}) = r[rand(randintgen(length(r)))]
 
-function rand!(r::Range, A::AbstractArray)
+## Randomly draw a sample from an AbstractArray r
+# (e.g. r is a range 0:2:8 or a vector [2, 3, 5, 7])
+
+rand(r::AbstractArray) = r[rand(randintgen(length(r)))]
+
+# Arrays of random integers
+
+function rand!(r::AbstractArray, A::AbstractArray)
     g = randintgen(length(r))
     for i = 1 : length(A)
         @inbounds A[i] = r[rand(g)]
@@ -218,8 +224,8 @@ function rand!(r::Range, A::AbstractArray)
     return A
 end
 
-rand{T}(r::Range{T}, dims::Dims) = rand!(r, Array(T, dims))
-rand(r::Range, dims::Int...) = rand(r, dims)
+rand{T}(r::AbstractArray{T}, dims::Dims) = rand!(r, Array(T, dims))
+rand(r::AbstractArray, dims::Int...) = rand(r, dims)
 
 
 ## random Bools

--- a/base/random.jl
+++ b/base/random.jl
@@ -210,13 +210,6 @@ end
 
 rand{T}(r::Range{T}) = r[rand(randintgen(length(r)))]
 
-function rand!(g::RandIntGen, A::AbstractArray)
-    for i = 1 : length(A)
-        @inbounds A[i] = rand(g)
-    end    
-    return A
-end
-
 function rand!(r::Range, A::AbstractArray)
     g = randintgen(length(r))
     for i = 1 : length(A)

--- a/base/random.jl
+++ b/base/random.jl
@@ -204,7 +204,10 @@ rand(r::AbstractArray) = r[rand(randintgen(length(r)))]
 
 # Arrays of random integers
 
-function rand!(r::AbstractArray, A::AbstractArray)
+rand!(r::Range, A::AbstractArray) = rand!(r, A, ())
+
+# TODO: this more general version is "disabled" until #8246 is resolved
+function rand!(r::AbstractArray, A::AbstractArray, ::())
     g = randintgen(length(r))
     for i = 1 : length(A)
         @inbounds A[i] = r[rand(g)]
@@ -212,7 +215,7 @@ function rand!(r::AbstractArray, A::AbstractArray)
     return A
 end
 
-rand{T}(r::AbstractArray{T}, dims::Dims) = rand!(r, Array(T, dims))
+rand{T}(r::AbstractArray{T}, dims::Dims) = rand!(r, Array(T, dims), ())
 rand(r::AbstractArray, dims::Int...) = rand(r, dims)
 
 

--- a/base/random.jl
+++ b/base/random.jl
@@ -162,25 +162,24 @@ maxmultiple(k::Uint128) = div(typemax(Uint128), k + (k == 0))*k - 1
 maxmultiplemix(k::Uint64) = itrunc(Uint64, div((k >> 32 != 0)*0x0000000000000000FFFFFFFF00000000 + 0x0000000100000000, k + (k == 0))*k - 1)
 
 immutable RandIntGen{T<:Integer, U<:Unsigned}
-    a::T   # first element of the range
-    k::U   # range length or zero for full range
+    k::U   # range length (or zero for full range)
     u::U   # rejection threshold
 end
 # generators with 32, 128 bits entropy
-RandIntGen{T, U<:Union(Uint32, Uint128)}(a::T, k::U) = RandIntGen{T, U}(a, k, maxmultiple(k))
+RandIntGen{U<:Union(Uint32, Uint128)}(T::Type, k::U) = RandIntGen{T, U}(k, maxmultiple(k))
 # mixed 32/64 bits entropy generator
-RandIntGen{T}(a::T, k::Uint64) = RandIntGen{T,Uint64}(a, k, maxmultiplemix(k))
+RandIntGen(T::Type, k::Uint64) = RandIntGen{T,Uint64}(k, maxmultiplemix(k))
 
 
-# generator for ranges
-RandIntGen{T<:Unsigned}(r::UnitRange{T}) = isempty(r) ? error("range must be non-empty") : RandIntGen(first(r), last(r) - first(r) + one(T))
-
+# generator API
+# randintgen(k) returns a helper object for generating random integers in the range 1:k
+randintgen{T<:Unsigned}(k::T) = k<1 ? error("range must be non-empty") : RandIntGen(T, k)
 # specialized versions
 for (T, U) in [(Uint8, Uint32), (Uint16, Uint32),
                (Int8, Uint32), (Int16, Uint32), (Int32, Uint32), (Int64, Uint64), (Int128, Uint128),
                (Bool, Uint32), (Char, Uint32)]
 
-    @eval RandIntGen(r::UnitRange{$T}) = isempty(r) ? error("range must be non-empty") : RandIntGen(first(r), convert($U, unsigned(last(r) - first(r)) + one($U))) # overflow ok
+    @eval randintgen(k::$T) = k<1 ? error("range must be non-empty") : RandIntGen($T, convert($U, k)) # overflow ok
 end
 
 # this function uses 32 bit entropy for small ranges of length <= typemax(Uint32) + 1
@@ -198,7 +197,7 @@ function rand{T<:Union(Uint64, Int64)}(g::RandIntGen{T,Uint64})
             x = rand(Uint64)
         end
     end
-    return reinterpret(T, reinterpret(Uint64, g.a) + rem_knuth(x, g.k))
+    return reinterpret(T, one(Uint64) + rem_knuth(x, g.k))
 end
 
 function rand{T<:Integer, U<:Unsigned}(g::RandIntGen{T,U})
@@ -206,11 +205,10 @@ function rand{T<:Integer, U<:Unsigned}(g::RandIntGen{T,U})
     while x > g.u
         x = rand(U)
     end
-    itrunc(T, unsigned(g.a) + rem_knuth(x, g.k))
+    itrunc(T, one(U) + rem_knuth(x, g.k))
 end
 
-rand{T<:Union(Signed,Unsigned,Bool,Char)}(r::UnitRange{T}) = rand(RandIntGen(r))
-rand{T}(r::Range{T}) = r[rand(1:(length(r)))]
+rand{T}(r::Range{T}) = r[rand(randintgen(length(r)))]
 
 function rand!(g::RandIntGen, A::AbstractArray)
     for i = 1 : length(A)
@@ -219,10 +217,8 @@ function rand!(g::RandIntGen, A::AbstractArray)
     return A
 end
 
-rand!{T<:Union(Signed,Unsigned,Bool,Char)}(r::UnitRange{T}, A::AbstractArray) = rand!(RandIntGen(r), A)
-
 function rand!(r::Range, A::AbstractArray)
-    g = RandIntGen(1:(length(r)))
+    g = randintgen(length(r))
     for i = 1 : length(A)
         @inbounds A[i] = r[rand(g)]
     end

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3964,9 +3964,9 @@ Random number generation in Julia uses the `Mersenne Twister library <http://www
 
    Pick a random element or array of random elements from the indexable collection  ``coll`` (for example, ``1:n`` or ``['x','y','z']``).
 
-.. function:: rand!(coll, A)
+.. function:: rand!(r, A)
 
-   Populate the array A with random values drawn uniformly from the indexable collection ``coll``.
+   Populate the array A with random values drawn uniformly from the range ``r``.
 
 .. function:: randbool([dims...])
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3946,7 +3946,7 @@ Random number generation in Julia uses the `Mersenne Twister library <http://www
 
 .. function:: rand!([rng], A)
 
-   Populate the array A with random number generated from the specified RNG.
+   Populate the array A with random numbers generated from the specified RNG.
 
 .. function:: rand(rng::AbstractRNG, [dims...])
 
@@ -3960,9 +3960,13 @@ Random number generation in Julia uses the `Mersenne Twister library <http://www
 
    Generate a random number or array of random numbes of the given type.
 
-.. function:: rand(r, [dims...])
+.. function:: rand(coll, [dims...])
 
-   Pick a random element or array of random elements from range ``r`` (for example, ``1:n`` or ``0:2:10``).
+   Pick a random element or array of random elements from the indexable collection  ``coll`` (for example, ``1:n`` or ``['x','y','z']``).
+
+.. function:: rand!(coll, A)
+
+   Populate the array A with random values drawn uniformly from the indexable collection ``coll``.
 
 .. function:: randbool([dims...])
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -54,8 +54,8 @@ if sizeof(Int32) < sizeof(Int)
     r = rand(int32(-1):typemax(Int32))
     @test typeof(r) == Int32
     @test -1 <= r <= typemax(Int32)
-    @test all([div(0x00010000000000000000,k)*k - 1 == Base.Random.RandIntGen(uint64(1:k)).u for k in 13 .+ int64(2).^(32:62)])
-    @test all([div(0x00010000000000000000,k)*k - 1 == Base.Random.RandIntGen(int64(1:k)).u for k in 13 .+ int64(2).^(32:61)])
+    @test all([div(0x00010000000000000000,k)*k - 1 == Base.Random.randintgen(uint64(k)).u for k in 13 .+ int64(2).^(32:62)])
+    @test all([div(0x00010000000000000000,k)*k - 1 == Base.Random.randintgen(int64(k)).u for k in 13 .+ int64(2).^(32:61)])
 
 end
 
@@ -160,8 +160,8 @@ r = uint64(rand(uint32(97:122)))
 srand(seed)
 @test r == rand(uint64(97:122))
 
-@test all([div(0x000100000000,k)*k - 1 == Base.Random.RandIntGen(uint64(1:k)).u for k in 13 .+ int64(2).^(1:30)])
-@test all([div(0x000100000000,k)*k - 1 == Base.Random.RandIntGen(int64(1:k)).u for k in 13 .+ int64(2).^(1:30)])
+@test all([div(0x000100000000,k)*k - 1 == Base.Random.randintgen(uint64(k)).u for k in 13 .+ int64(2).^(1:30)])
+@test all([div(0x000100000000,k)*k - 1 == Base.Random.randintgen(int64(k)).u for k in 13 .+ int64(2).^(1:30)])
 
 import Base.Random: uuid4, UUID
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -49,9 +49,18 @@ for T in (Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64, Int128, Uint
     @test mod(r,2)==1
 
     if T<:Integer && T!==Char
-        x = rand(typemin(T):typemax(T))
-        @test isa(x,T)
-        @test typemin(T) <= x <= typemax(T)
+        if T.size < Int.size
+            x = rand(typemin(T):typemax(T))
+            @test isa(x,T)
+            @test typemin(T) <= x <= typemax(T)
+        else # we bound the length of the range to typemax(T) so that there is no overflow
+            for (a, b) in ((typemin(T),typemin(T)+typemax(T)-one(T)),
+                           (one(T),typemax(T)))
+                x = rand(a:b)
+                @test isa(x,T)
+                @test a <= x <= b
+            end
+        end
     end
 end
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -29,7 +29,7 @@ rand!(MersenneTwister(0), A)
 @test rand(0:3:1000) in 0:3:1000
 coll = {2, uint128(128), big(619), "string", 'c'}
 @test rand(coll) in coll
-@test issubset(rand!(coll, cell(10)), coll)
+@test issubset(rand(coll, 2, 3), coll)
 
 # randn
 @test randn(MersenneTwister(42)) == -0.5560268761463861

--- a/test/random.jl
+++ b/test/random.jl
@@ -26,6 +26,11 @@ rand!(MersenneTwister(0), A)
 @test A == [0.8236475079774124  0.16456579813368521;
             0.9103565379264364  0.17732884646626457]
 
+@test rand(0:3:1000) in 0:3:1000
+coll = {2, uint128(128), big(619), "string", 'c'}
+@test rand(coll) in coll
+@test issubset(rand!(coll, cell(10)), coll)
+
 # randn
 @test randn(MersenneTwister(42)) == -0.5560268761463861
 A = zeros(2, 2)


### PR DESCRIPTION
This is essentially two changes:
1) the semi-public API to get a RandIntGen object generating random integers in `1:n` is via a call to `randintgen(n)`. This is to be able in particular to extend the mechanism to `BigInt` for which the existing type `RandIntGen` doesn't fit well (cf. https://github.com/JuliaLang/julia/pull/8255). In the process, `RandIntGen` was simplified by making the first element of the range equal to 1: this was only used with this value AFAICS, and this was duplicating indexing logic as noted by @ivarne (who found that this change should not break packages in METADATA.jl). It seems this was first implemented in commit ab97911 by @lindahua: was there a use for the first element field `.a` that I overlooked?
2) allow `rand(r)` to work for any indexable `r`, not only with ranges (e.g. `rand(["head", "tail"])`. It is really the continuation of commit 48f27bc, and overlaps a bit with #6003. This change is so small that I think it is harmless, whatever is done wrt #6003.

ps: I think the random.jl tests are not very safe as the seed is set the same at each run. Could the content of `__init__` function from base/random.jl be made a public function named e.g. `srand()`, which could be used in the tests?
