### PR TITLE
Fix tab completion segfault in reverse search

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -927,6 +927,8 @@ function history_set_backward(s::SearchState, backward)
     s.backward = backward
 end
 
+input_string(s::SearchState) = bytestring(pointer(s.query_buffer.data), s.query_buffer.size)
+
 refresh_multi_line(termbuf::TerminalBuffer, term, s::Union(SearchState,PromptState)) = (@assert term == terminal(s); refresh_multi_line(termbuf,s))
 function refresh_multi_line(termbuf::TerminalBuffer, s::SearchState)
     buf = IOBuffer()


### PR DESCRIPTION
If I happen to hit the tab key while in reverse search mode Julia crashes with the error message

```
(reverse-i-search)`': ERROR: `input_string` has no method matching input_string(::SearchState)
 in complete_line at REPL.jl:294
 in complete_line at LineEdit.jl:988
 in complete_line at LineEdit.jl:139
 in anonymous at LineEdit.jl:1100
 in prompt! at ./LineEdit.jl:1397
 in run_interface at ./LineEdit.jl:1372
 in run_interface at /Users/andreasnoackjensen/julia/usr/lib/julia/sys.dylib
 in run_frontend at ./REPL.jl:819
 in run_repl at ./REPL.jl:170
 in _start at ./client.jl:399
 in _start at /Users/andreasnoackjensen/julia/usr/lib/julia/sys.dylib
```

@jakebolewski proposed this change, which seems to fix the problem.
cc: @keno
