### PR TITLE
Sort SparseCSC elements function and speed up sparse matrix multiplication

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -1,7 +1,7 @@
 module LinAlg
 
 importall Base
-import Base: USE_BLAS64, size, copy, copy_transpose!, power_by_squaring, print_matrix, transpose!
+import Base: USE_BLAS64, size, copy, copy_transpose!, power_by_squaring, print_matrix, transpose!, sortCSC!
 
 export 
 # Modules

--- a/base/linalg/sparse.jl
+++ b/base/linalg/sparse.jl
@@ -190,8 +190,9 @@ function *{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti})
     deleteat!(nzvalC, colptrC[end]:length(nzvalC))
 
     # The Gustavson algorithm does not guarantee the product to have sorted row indices.
-    Cunsorted = SparseMatrixCSC(mA, nB, colptrC, rowvalC, nzvalC)
-    return sortCSC!(Cunsorted)
+    C = SparseMatrixCSC(mA, nB, colptrC, rowvalC, nzvalC)
+    sortCSC!(C)
+    return C
 end
 
 ## solvers

--- a/base/linalg/sparse.jl
+++ b/base/linalg/sparse.jl
@@ -191,8 +191,7 @@ function *{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti})
 
     # The Gustavson algorithm does not guarantee the product to have sorted row indices.
     Cunsorted = SparseMatrixCSC(mA, nB, colptrC, rowvalC, nzvalC)
-    Ct = Cunsorted.'
-    Ctt = Base.SparseMatrix.transpose!(Ct, SparseMatrixCSC(mA, nB, colptrC, rowvalC, nzvalC))
+    return sortCSC!(Cunsorted)
 end
 
 ## solvers

--- a/base/sparse.jl
+++ b/base/sparse.jl
@@ -8,7 +8,7 @@ import Base.NonTupleType, Base.float, Base.Order, Base.Sort.Forward
 export SparseMatrixCSC, 
        blkdiag, dense, diag, diagm, droptol!, dropzeros!, etree, full, 
        getindex, ishermitian, issparse, issym, istril, istriu, nnz,
-       setindex!, sparse, sparsevec, spdiagm, speye, spones, 
+       setindex!, sortCSC!, sparse, sparsevec, spdiagm, speye, spones, 
        sprand, sprandbool, sprandn, spzeros, symperm, trace, tril, tril!, 
        triu, triu!, nonzeros
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -177,6 +177,38 @@ function full{Tv}(S::SparseMatrixCSC{Tv})
     return A
 end
 
+function sortCSC!{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti})
+  m, n = size(A)
+
+  colptr = A.colptr; rowval = A.rowval; nzval = A.nzval
+
+	for i = 1:n
+  		col_start = colptr[i]
+		col_end = colptr[i+1] -1
+ 
+   		numrows = (col_end - col_start) +1;
+    	row = Array(Ti, numrows)
+      	val = Array(Tv, numrows)
+
+      	jj = 1
+      	@simd for j = col_start:col_end
+        	@inbounds row[jj] = rowval[j]
+        	@inbounds val[jj] = nzval[j]
+        	jj += 1
+      	end
+
+      	index = sortperm(row)
+
+      	jj = 1;
+      	@simd for j = col_start:col_end
+        	@inbounds rowval[j] = row[index[jj]]
+        	@inbounds nzval[j] = val[index[jj]]
+        	jj += 1
+      	end
+    end
+end
+
+
 float(S::SparseMatrixCSC) = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), float(copy(S.nzval)))
 
 complex(S::SparseMatrixCSC) = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), complex(copy(S.nzval)))

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -178,33 +178,33 @@ function full{Tv}(S::SparseMatrixCSC{Tv})
 end
 
 function sortCSC!{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti})
-  m, n = size(A)
+    m, n = size(A)
 
-  colptr = A.colptr; rowval = A.rowval; nzval = A.nzval
+    colptr = A.colptr; rowval = A.rowval; nzval = A.nzval
 
-	for i = 1:n
-  		col_start = colptr[i]
-		col_end = colptr[i+1] -1
+    for i = 1:n
+        col_start = colptr[i]
+        col_end = colptr[i+1] -1
  
-   		numrows = (col_end - col_start) +1;
-    	row = Array(Ti, numrows)
-      	val = Array(Tv, numrows)
+        numrows = (col_end - col_start) +1;
+        row = Array(Ti, numrows)
+        val = Array(Tv, numrows)
 
-      	jj = 1
-      	@simd for j = col_start:col_end
-        	@inbounds row[jj] = rowval[j]
-        	@inbounds val[jj] = nzval[j]
-        	jj += 1
-      	end
+        jj = 1
+        @simd for j = col_start:col_end
+            @inbounds row[jj] = rowval[j]
+            @inbounds val[jj] = nzval[j]
+            jj += 1
+        end
 
-      	index = sortperm(row)
+        index = sortperm(row)
 
-      	jj = 1;
-      	@simd for j = col_start:col_end
-        	@inbounds rowval[j] = row[index[jj]]
-        	@inbounds nzval[j] = val[index[jj]]
-        	jj += 1
-      	end
+        jj = 1;
+        @simd for j = col_start:col_end
+            @inbounds rowval[j] = row[index[jj]]
+            @inbounds nzval[j] = val[index[jj]]
+            jj += 1
+        end
     end
 end
 


### PR DESCRIPTION
A suggested addition.

Replacing the dual transpose used in the sparse matrix multiplication with an in place sort of the rowval and nzval elements. This seems to outperform in particular with larger matrices. 

```
julia> x = sprand(n, m, 0.0002);

julia> s = sprand(m, k, 0.001);

julia> @time y = x * s;
elapsed time: 56.447965143 seconds (11903648416 bytes allocated, 0.23% gc time)

julia> @time y = spmm(x, s);
elapsed time: 35.558409459 seconds (13790626144 bytes allocated, 5.49% gc time)
```

Avoiding the gc time by improving the allocation of the two Array's would further improve performance, I did test with a if statement to avoid allocations, but that seemed to decrease perf particularly with smaller pairs of matrix.

Either way, I assume a Sparse sort function would have some longer term benefit.

[pao: quoting code block]
