### PR TITLE
Fix find() when called with function and non-StridedArray

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1054,7 +1054,7 @@ function findnext(testf::Function, A, start::Integer)
 end
 findfirst(testf::Function, A) = findnext(testf, A, 1)
 
-function find(testf::Function, A::StridedArray)
+function find(testf::Function, A::AbstractArray)
     # use a dynamic-length array to store the indexes, then copy to a non-padded
     # array for the return
     tmpI = Array(Int, 0)
@@ -1063,7 +1063,7 @@ function find(testf::Function, A::StridedArray)
             push!(tmpI, i)
         end
     end
-    I = similar(A, Int, length(tmpI))
+    I = Array(Int, length(tmpI))
     copy!(I, tmpI)
     I
 end
@@ -1082,7 +1082,7 @@ function find(A::StridedArray)
 end
 
 find(x::Number) = x == 0 ? Array(Int,0) : [1]
-find(testf::Function, x) = find(testf(x))
+find(testf::Function, x::Number) = testf(x) == 0 ? Array(Int,0) : [1]
 
 findn(A::AbstractVector) = find(A)
 

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -190,6 +190,10 @@ mfe22 = eye(Float64, 2)
 K,J,V = findnz(SparseMatrixCSC(2,1,[1,3],[1,2],[1.0,0.0]))
 @test length(K) == length(J) == length(V) == 1
 
+# https://groups.google.com/d/msg/julia-users/Yq4dh8NOWBQ/GU57L90FZ3EJ
+A = speye(Bool, 5)
+@test find(A) == find(x -> x == true, A) == find(full(A))
+
 # issue #5437
 @test nnz(sparse([1,2,3],[1,2,3],[0.0,1.0,2.0])) == 2
 


### PR DESCRIPTION
The previous code expected testfun to be vectorized, which does not match
the behavior of other methods, nor the documentation. Especially visible
when passing a sparse matrix. Always return an Array rather than an object
similar to the input, because it makes no sense to return a sparse vector.
Remove the method matching any object so that an error is raised rather
than returning incorrect results on non-AbstractArray (e.g. Set).

This fixes the bug reported by i.pallikarakis-11 on the mailing list, namely:

``` julia
A=speye(Bool,10)
find(x->x==true,A)
->0-element Array{Int64,1}

find(x->x==true,full(A))
->10-element Array{Int64,1}:
   1
  12
  23
  34
  45
  56
  67
  78
  89
 100
```

I'm not completely sure about the `AbstractArray` requirement, but it doesn't make sense to me to return _indexes_ for non-arrays. The previous code would happily work on `Set`s, but would return nonsensical results.

(BTW, I'm aware that calling `find(testf, x)` with `x` a sparse matrix is not very efficient, but at least it must not give wrong results.)
