### PR TITLE
Make srand work similarly for global RNG and MersenneTwister instance

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3929,7 +3929,7 @@ Random number generation in Julia uses the `Mersenne Twister library <http://www
 
 .. function:: srand([rng], [seed])
 
-   Reseed the random number generator. If a ``seed`` is provided, the RNG will give a reproducible sequence of numbers, otherwise Julia will get entropy from the system. The ``seed`` may be an unsigned integer, a vector of unsigned integers or a filename, in which case the seed is read from a file. If the argument ``rng`` is not provided, the default global RNG is seeded.
+   Reseed the random number generator. If a ``seed`` is provided, the RNG will give a reproducible sequence of numbers, otherwise Julia will get entropy from the system. The ``seed`` may be a non-negative integer, a vector of ``Uint32`` integers or a filename, in which case the seed is read from a file. If the argument ``rng`` is not provided, the default global RNG is seeded.
 
 .. function:: MersenneTwister([seed])
 


### PR DESCRIPTION
The docs pretended it did, but were lying.
Also, the first commit simplifies (see commit message) MersenneTwister in order to homogeneize how its constructor and its srand method work (the constructor now calls srand). 

I would like to add another change (which is more breaking), but need feed-back: `MersenneTwister()` returns always a "similiar" instance by calling `MersenneTwister(0)` (I find this surprising), whereas `srand(r::MersenneTwister)` seeds `r` with the help of OS' provided entropy. This is not consistent and I'd prefer the second behavior for both methods (i.e. `MersenneTwister() = (m = MersenneTwister(0); srand(m); m)` or equivalent).
In fact I would like MersenneTwister having a unique constructor with unconstrained parameter which calls srand (boils down to adding string to the possible parameter types). 
