### PR TITLE
fix bounds bug in getindex(a:b, c:d) with c<1

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -263,45 +263,35 @@ function getindex{T}(r::FloatRange{T}, i::Integer)
     oftype(T, (r.start + (i-1)*r.step)/r.divisor)
 end
 
-function getindex(r::UnitRange, s::UnitRange{Int})
+function check_indexingrange(s, r)
     sl = length(s)
-    if sl > 0
-        if !(1 <= last(s) <= length(r))
-            throw(BoundsError())
-        end
-    end
+    rl = length(r)
+    sl == 0 || 1 <= first(s) <= rl &&
+               1 <=  last(s) <= rl || throw(BoundsError())
+    sl
+end
+
+function getindex(r::UnitRange, s::UnitRange{Int})
+    sl = check_indexingrange(s, r)
     st = oftype(r.start, r.start + s.start-1)
     range(st, sl)
 end
 
 function getindex(r::UnitRange, s::StepRange{Int})
-    sl = length(s)
-    if sl > 0
-        if !(1 <= first(s) <= length(r) && 1 <= last(s) <= length(r))
-            throw(BoundsError())
-        end
-    end
+    sl = check_indexingrange(s, r)
     st = oftype(r.start, r.start + s.start-1)
     range(st, step(s), sl)
 end
 
 function getindex(r::StepRange, s::Range{Int})
-    sl = length(s)
-    if sl > 0
-        if !(1 <= last(s) <= length(r))
-            throw(BoundsError())
-        end
-        st = r[first(s)]
-    else
-        st = oftype(r.start, r.start + (first(s)-1)*step(r))
-    end
+    sl = check_indexingrange(s, r)
+    st = oftype(r.start, r.start + (first(s)-1)*step(r))
     range(st, step(r)*step(s), sl)
 end
 
 function getindex(r::FloatRange, s::OrdinalRange)
-    isempty(s) || 1 <= first(s) <= length(r) &&
-                  1 <=  last(s) <= length(r) || throw(BoundsError())
-    FloatRange(r.start + (first(s)-1)*r.step, step(s)*r.step, length(s), r.divisor)
+    sl = check_indexingrange(s, r)
+    FloatRange(r.start + (first(s)-1)*r.step, step(s)*r.step, sl, r.divisor)
 end
 
 function show(io::IO, r::Range)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -115,6 +115,11 @@ r = (-4*int64(maxintfloat(is(Int,Int32) ? Float32 : Float64))):5
 @test (0:2:10)[7:6] == 12:2:10
 @test_throws BoundsError (0:2:10)[7:7]
 
+# indexing with negative ranges (#8351)
+for a={3:6, 0:2:10}, b={0:1, 2:-1:0}
+    @test_throws BoundsError a[b]
+end
+
 # avoiding intermediate overflow (#5065)
 @test length(1:4:typemax(Int)) == div(typemax(Int),4) + 1
 


### PR DESCRIPTION
Ex: `(3:6)[0:1] == 2:3`.

I'm not particularly proud of the `check_indexingrange` function name, ideas welcome.
