### PR TITLE
Specify ::IO for writemime

### DIFF
--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -38,7 +38,7 @@ mimewritable{mime}(::MIME{mime}, x) =
   method_exists(writemime, (IO, MIME{mime}, typeof(x)))
 
 # it is convenient to accept strings instead of ::MIME
-writemime(io, m::String, x) = writemime(io, MIME(m), x)
+writemime(io::IO, m::String, x) = writemime(io, MIME(m), x)
 mimewritable(m::String, x) = mimewritable(MIME(m), x)
 
 ###########################################################################

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -1,5 +1,5 @@
 # fallback text/plain representation of any type:
-writemime(io, ::MIME"text/plain", x) = showlimited(io, x)
+writemime(io::IO, ::MIME"text/plain", x) = showlimited(io, x)
 
 function writemime(io::IO, ::MIME"text/plain", f::Function)
     if isgeneric(f)


### PR DESCRIPTION
As far as I can tell, these functions pass `io` to something that requires `io::IO`, so this PR doesn't restrict the functions anymore than they're already restricted.

With the current code, there's one to two levels of indirection in the error message:

```
julia> writemime(STDOUT,"text/plain","halp")
"halp"

julia> writemime("bogus","text/plain","halp")
ERROR: `showlimited` has no method matching showlimited(::ASCIIString,
::ASCIIString)
 in writemime at replutil.jl:2
 in writemime at multimedia.jl:41

julia> writemime("bogus","bogus","halp")
ERROR: `writemime` has no method matching writemime(::ASCIIString, ::MIME{:bogus}, ::ASCIIString)
 in writemime at multimedia.jl:41
```

With this PR, that becomes:

```
julia> writemime(STDOUT,"text/plain","halp")
"halp"

julia> writemime("bogus","text/plain","halp")
ERROR: `writemime` has no method matching writemime(::ASCIIString, ::ASCIIString, ::ASCIIString)

julia> writemime("bogus","bogus","halp")
ERROR: `writemime` has no method matching writemime(::ASCIIString, ::ASCIIString, ::ASCIIString)
```
