### PR TITLE
Add missing ARM dependencies

### DIFF
--- a/README.arm.md
+++ b/README.arm.md
@@ -8,7 +8,7 @@ available.
 In addition to the standard `build-essentials` toolchain the following
 libraries must be installed to build on ARM:
 
-- libblas3gf, liblapack3gf, libfftw3-dev, libgmp3-dev, libmpfr-dev
+- libblas3gf, liblapack3gf, libfftw3-dev, libgmp3-dev, libmpfr-dev, libblas-dev, liblapack-dev
 
 Please start from the standard [build
 instructions](README.md#source-download-and-compilation), in


### PR DESCRIPTION
I had to `apt-get install libblas-dev liblapack-dev` to get past the `configure` step, even after installing `libblas3gf` and `liblapack3gf`. From the mailing list, it sounds like I'm not the only one who had that problem.
