### PR TITLE
Fix OPENBLAS_OBJ_TARGET on Linux.

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -861,7 +861,8 @@ $(OPENBLAS_OBJ_SOURCE): openblas-$(OPENBLAS_VER)/config.status
 $(OPENBLAS_OBJ_TARGET): $(OPENBLAS_OBJ_SOURCE) | $(build_shlibdir)
 	cp -f openblas-$(OPENBLAS_VER)/libopenblas.$(SHLIB_EXT) $(build_shlibdir)
 ifeq ($(OS), Linux)
-	ln -sf $(build_shlibdir)/libopenblas.$(SHLIB_EXT) $(build_shlibdir)/libopenblas.$(SHLIB_EXT).0
+	cd $(build_shlibdir)
+	ln -sf libopenblas.$(SHLIB_EXT) libopenblas.$(SHLIB_EXT).0
 endif
 	$(INSTALL_NAME_CMD)libopenblas.$(SHLIB_EXT) $(build_shlibdir)/libopenblas.$(SHLIB_EXT)
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -861,7 +861,7 @@ $(OPENBLAS_OBJ_SOURCE): openblas-$(OPENBLAS_VER)/config.status
 $(OPENBLAS_OBJ_TARGET): $(OPENBLAS_OBJ_SOURCE) | $(build_shlibdir)
 	cp -f openblas-$(OPENBLAS_VER)/libopenblas.$(SHLIB_EXT) $(build_shlibdir)
 ifeq ($(OS), Linux)
-	cd $(build_shlibdir)
+	cd $(build_shlibdir) && \
 	ln -sf libopenblas.$(SHLIB_EXT) libopenblas.$(SHLIB_EXT).0
 endif
 	$(INSTALL_NAME_CMD)libopenblas.$(SHLIB_EXT) $(build_shlibdir)/libopenblas.$(SHLIB_EXT)


### PR DESCRIPTION
Currently symlink to libopenblas.so.0 from libopenblas.so contains full path, which is not correct. So I had following case

```
[baur@linux julia-89cafb9b8a]$ ll lib/julia/libopenblas*
-rwxr-xr-x 1 baur baur 32582112 Sep 15 12:08 lib/julia/libopenblas.so
lrwxrwxrwx 1 baur baur       55 Sep 15 15:32 lib/julia/libopenblas.so.0 -> /builddir/build/BUILD/julia-test/usr/lib/libopenblas.so
```

You can see that libopenblas.so.0 was symlinked with incorrect path.
