### PR TITLE
Add LLVM intrinsics for floor/ceil/trunc/abs.

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -168,8 +168,11 @@ round {T<:Integer}(::Type{T}, x::FloatingPoint) = trunc(T,round(x))
 
 
 # this is needed very early because it is used by Range and colon
-round(x::Float64) = ccall((:round, Base.libm_name), Float64, (Float64,), x)
-floor(x::Float64) = ccall((:floor, Base.libm_name), Float64, (Float64,), x)
+function round(x::Float64)
+    y = trunc(x)
+    ifelse(x==y,y,trunc(2.0*x-y))
+end
+floor(x::Float64) = box(Float64,floor_llvm(unbox(Float64,x)))
 
 ## floating point promotions ##
 promote_rule(::Type{Float32}, ::Type{Float16}) = Float32

--- a/base/math.jl
+++ b/base/math.jl
@@ -25,7 +25,7 @@ import Base: log, exp, sin, cos, tan, sinh, cosh, tanh, asin,
              max, min, minmax, ceil, floor, trunc, round, ^, exp2,
              exp10, expm1, log1p
 
-import Core.Intrinsics: nan_dom_err, sqrt_llvm, box, unbox, powi_llvm
+import Core.Intrinsics: nan_dom_err, ceil_llvm, floor_llvm, trunc_llvm, sqrt_llvm, box, unbox, powi_llvm
 
 # non-type specific math functions
 
@@ -132,7 +132,15 @@ sqrt(x::Float32) = box(Float32,sqrt_llvm(unbox(Float32,x)))
 sqrt(x::Real) = sqrt(float(x))
 @vectorize_1arg Number sqrt
 
-for f in (:ceil, :trunc, :significand, :rint) # :nearbyint
+ceil(x::Float64) = box(Float64,ceil_llvm(unbox(Float64,x)))
+ceil(x::Float32) = box(Float32,ceil_llvm(unbox(Float32,x)))
+@vectorize_1arg Real ceil
+
+trunc(x::Float64) = box(Float64,trunc_llvm(unbox(Float64,x)))
+trunc(x::Float32) = box(Float32,trunc_llvm(unbox(Float32,x)))
+@vectorize_1arg Real trunc
+
+for f in (:significand, :rint) # :nearbyint
     @eval begin
         ($f)(x::Float64) = ccall(($(string(f)),libm), Float64, (Float64,), x)
         ($f)(x::Float32) = ccall(($(string(f,"f")),libm), Float32, (Float32,), x)
@@ -140,10 +148,13 @@ for f in (:ceil, :trunc, :significand, :rint) # :nearbyint
     end
 end
 
-round(x::Float32) = ccall((:roundf, libm), Float32, (Float32,), x)
+function round(x::Float32)
+    y = trunc(x)
+    ifelse(x==y,y,trunc(2.f0*x-y))
+end
 @vectorize_1arg Real round
 
-floor(x::Float32) = ccall((:floorf, libm), Float32, (Float32,), x)
+floor(x::Float32) = box(Float32,floor_llvm(unbox(Float32,x)))
 @vectorize_1arg Real floor
 
 hypot(x::Real, y::Real) = hypot(promote(float(x), float(y))...)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1330,6 +1330,21 @@ for x = 2^24-10:2^24+10
     @test ceil(Int,y)      == i
 end
 
+# rounding vectors
+let ≈(x,y) = x==y && typeof(x)==typeof(y)
+    for t in [Float32,Float64]
+        # try different vector lengths
+        for n in [0,3,255,256]
+            r = (1:n)-div(n,2)
+            y = t[x/4 for x in r]
+            @test trunc(y) ≈ t[div(i,4) for i in r]
+            @test round(y) ≈ t[(i+1+(i>=0))>>2 for i in r]
+            @test floor(y) ≈ t[i>>2 for i in r]
+            @test ceil(y)  ≈ t[(i+3)>>2 for i in r]
+        end
+    end
+end
+
 @test_throws InexactError round(Int,Inf)
 @test_throws InexactError round(Int,NaN)
 @test round(Int,2.5) == 3


### PR DESCRIPTION
This PR adds intrinsics for floor/ceil/trunc.   For this example:

```
function f(b,a)
    @simd for i=1:length(a)
        @inbounds b[i]=floor(a[i])
    end
end
```

with LLVM 3.5 I'm seeing an improvement of about 28x on a Haswell processor for `Float32 arrays`.  For `Float64` arrays, I'm getting about 4x improvement.  Even with just LLVM 3.3, which can't vectorize `floor`, I'm seeing about 2.8x improvement for both `Float32` and `Float64`.  

The patch improves the "vector" `floor` from `base/math.jl` by about 1.4x (`Float32`) or 1.8x (`Float64`) using LLVM 3.3.

While writing this patch, I discovered that the tests do not test whether "vector" `floor`, `ceil`, and `trunc` work at all.  I'm happy to write such tests.  I'm just not sure whether they belong in `test/math.jl` or `test/numbers.jl`.  Latter is where the scalar tests for `floor`, `ceil`, and `trunc` are.
