### PR TITLE
check indices in sparsevec(::Dict). fixes #8363

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -210,6 +210,7 @@ function sparsevec(I::AbstractVector, V, m::Integer, combine::Function)
     p = sortperm(I)
     @inbounds I = I[p]
     (nI==0 || m >= I[end]) || throw(DimensionMismatch("indices cannot be larger than length of vector"))
+    (nI==0 || I[1] > 0) || throw(BoundsError())
     V = V[p]
     sparse_IJ_sorted!(I, ones(eltype(I), nI), V, m, 1, combine)
 end

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -453,3 +453,6 @@ end
 # issue #8225
 @test_throws BoundsError sparse([0],[-1],[1.0],2,2)
 
+# issue #8363
+@test_throws BoundsError sparsevec([-1=>1,1=>2])
+


### PR DESCRIPTION
Now:

```
julia> w = sparsevec([-1=>1,1=>2])
ERROR: BoundsError()
 in sparsevec at sparse/sparsematrix.jl:213
 in sparsevec at sparse/sparsematrix.jl:201
```
