### PR TITLE
 Suggestion: add to whos() documentation that it only displays exported variables #8375 

### DIFF
--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -30,7 +30,7 @@
 
 ("Base","whos","whos([Module,] [pattern::Regex])
 
-   Print information about global variables in a module, optionally
+   Print information about exported global variables in a module, optionally
    restricted to those matching \"pattern\".
 
 "),

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -38,7 +38,7 @@ Getting Around
 
 .. function:: whos([Module,] [pattern::Regex])
 
-   Print information about global variables in a module, optionally restricted
+   Print information about exported global variables in a module, optionally restricted
    to those matching ``pattern``.
 
 .. function:: edit(file::String, [line])


### PR DESCRIPTION
Updated helpdb.jl, and stdlib/base.rst to specify in whos() documentation that the visible variables are only the exported subset.
