### PR TITLE
expressions -> functions in REPL code. Fixes #7178

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -1232,13 +1232,13 @@ const history_keymap = {
     "^P" => (s,o...)->(history_prev(s, mode(s).hist)),
     "^N" => (s,o...)->(history_next(s, mode(s).hist)),
     # Up Arrow
-    "\e[A" => (s,o...)->(edit_move_up(s) || history_prev(s, mode(s).hist)),
+    "\e[A" => (s,o...)->(edit_move_up(s) || history_prev_prefix(s, mode(s).hist)),
     # Down Arrow
-    "\e[B" => (s,o...)->(edit_move_down(s) || history_next(s, mode(s).hist)),
+    "\e[B" => (s,o...)->(edit_move_down(s) || history_next_prefix(s, mode(s).hist)),
     # Page Up
-    "\e[5~" => (s,o...)->(history_prev_prefix(s, mode(s).hist)),
+    "\e[5~" => (s,o...)->(history_prev(s, mode(s).hist)),
     # Page Down
-    "\e[6~" => (s,o...)->(history_next_prefix(s, mode(s).hist))
+    "\e[6~" => (s,o...)->(history_next(s, mode(s).hist))
 }
 
 function deactivate(p::Union(Prompt,HistoryPrompt), s::Union(SearchState,PromptState), termbuf)

--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -9,7 +9,7 @@ import Base: ensureroom, peek, show
 
 abstract TextInterface
 
-export run_interface, Prompt, ModalInterface, transition, reset_state, edit_insert
+export run_interface, Prompt, ModalInterface, transition, reset_state, edit_insert, keymap
 
 immutable ModalInterface <: TextInterface
     modes
@@ -82,7 +82,7 @@ end
 
 reset_state(::EmptyHistoryProvider) = nothing
 
-complete_line(c::EmptyCompletionProvider, s) = []
+complete_line(c::EmptyCompletionProvider, s) = [], true, true
 
 terminal(s::IO) = s
 terminal(s::PromptState) = s.terminal
@@ -684,90 +684,67 @@ function normalize_key(key::String)
     return takebuf_string(buf)
 end
 
+function normalize_keys(keymap::Dict)
+    return [normalize_key(k) => v for (k,v) in keymap]
+end
+
+function add_nested_key!(keymap::Dict, key, value)
+    i = start(key)
+    while !done(key, i)
+        c, i = next(key, i)
+        if c in keys(keymap)
+            if !isa(keymap[c], Dict)
+                error("Conflicting Definitions for keyseq " * escape_string(key) * " within one keymap")
+            end
+        elseif done(key, i)
+            keymap[c] = value
+            break
+        else
+            keymap[c] = Dict{Char,Any}()
+        end
+        keymap = keymap[c]
+    end
+end
+
 # Turn a Dict{Any,Any} into a Dict{Char,Any}
 # For now we use \0 to represent unknown chars so that they are sorted before everything else
 # If we ever actually want to match \0 in input, this will have to be reworked
 function normalize_keymap(keymap::Dict)
     ret = Dict{Char,Any}()
-    for key in keys(keymap)
-        newkey = normalize_key(key)
-        current = ret
-        i = start(newkey)
-        while !done(newkey, i)
-            c, i = next(newkey, i)
-            if haskey(current, c)
-                if !isa(current[c], Dict)
-                    println(ret)
-                    error("Conflicting Definitions for keyseq " * escape_string(newkey) * " within one keymap")
-                end
-            elseif done(newkey, i)
-                if isa(keymap[key], String)
-                    current[c] = normalize_key(keymap[key])
-                else
-                    current[c] = keymap[key]
-                end
-                break
-            else
-                current[c] = Dict{Char,Any}()
-            end
-            current = current[c]
-        end
+    direct_keys = filter((k,v) -> isa(v, Union(Function, Nothing)), keymap)
+    # first direct entries
+    for key in keys(direct_keys)
+        add_nested_key!(ret, key, keymap[key])
+    end
+    # then redirected entries
+    for key in setdiff(keys(keymap), keys(direct_keys))
+        value = normalize_key(keymap[key])
+        haskey(keymap, value) || error("Could not find redirected value " * escape_string(keymap[key]))
+        add_nested_key!(ret, key, keymap[value])
     end
     ret
 end
 
-keymap_gen_body(keymaps, body::Expr, level) = body
-keymap_gen_body(keymaps, body::Function, level) = keymap_gen_body(keymaps, :($(body)(s)))
-keymap_gen_body(keymaps, body::Char, level) = keymap_gen_body(keymaps, keymaps[body])
-keymap_gen_body(keymaps, body::Nothing, level) = nothing
-function keymap_gen_body(keymaps, body::String, level)
-    if length(body) == 1
-        return keymap_gen_body(keymaps, body[1], level)
-    end
-    current = keymaps
-    for c in body
-        if haskey(current, c)
-            if isa(current[c], Dict)
-                current = current[c]
-            else
-                return keymap_gen_body(keymaps, current[c], level)
-            end
-        elseif haskey(current, '\0')
-            return keymap_gen_body(keymaps, current['\0'], level)
-        else
-            error("No match for redirected key $body")
-        end
-    end
-    error("No exact match for redirected key $body")
+match_input(k::Function, s, cs) = (update_key_repeats(s, cs); return keymap_fcn(k, s, last(cs)))
+match_input(k::Nothing, s, cs) = (s,p) -> return :ok
+function match_input(keymap::Dict, s, cs=Char[])
+    c = read(terminal(s), Char)
+    push!(cs, c)
+    k = haskey(keymap, c) ? c : '\0'
+    return match_input(keymap[k], s, cs)
+    # perhaps better would be: match_input(get(keymap, k, nothing), s, cs) ?
 end
 
-keymap_gen_body(a, b) = keymap_gen_body(a, b, 1)
-function keymap_gen_body(dict, subdict::Dict, level)
-    block = Expr(:block)
-    bc = symbol("c" * string(level))
-    push!(block.args, :($bc = read(LineEdit.terminal(s), Char)))
-
-    last_if = Expr(:block)
-    haskey(subdict, '\0') && push!(last_if.args, keymap_gen_body(dict, subdict['\0'], level+1))
-    level == 1 && push!(last_if.args, :(LineEdit.update_key_repeats(s, [$bc])))
-
-    for c in keys(subdict)
-        c == '\0' && continue
-        cblock = Expr(:if, :($bc == $c))
-        cthen = Expr(:block)
-        if !isa(subdict[c], Dict)
-            cs = [symbol("c" * string(i)) for i=1:level]
-            push!(cthen.args, :(LineEdit.update_key_repeats(s, [$(cs...)])))
+keymap_fcn(f::Nothing, s, c) = (s, p) -> return :ok
+function keymap_fcn(f::Function, s, c::Char)
+    return (s, p) -> begin
+        r = f(s, p, c)
+        if isa(r, Symbol)
+            return r
+        else
+            return :ok
         end
-        push!(cthen.args, keymap_gen_body(dict, subdict[c], level+1))
-
-        push!(cblock.args, cthen)
-        push!(cblock.args, last_if)
-        last_if = cblock
     end
-
-    push!(block.args, last_if)
-    return block
 end
 
 update_key_repeats(s, keystroke) = nothing
@@ -776,8 +753,6 @@ function update_key_repeats(s::MIState, keystroke)
     s.previous_key = keystroke
     return
 end
-
-export @keymap
 
 # deep merge where target has higher precedence
 function keymap_merge!(target::Dict, source::Dict)
@@ -795,8 +770,8 @@ end
 fixup_keymaps!(d, l, s, sk) = nothing
 function fixup_keymaps!(dict::Dict, level, s, subkeymap)
     if level > 1
-        for d in dict
-            fixup_keymaps!(d[2], level-1, s, subkeymap)
+        for d in values(dict)
+            fixup_keymaps!(d, level-1, s, subkeymap)
         end
     else
         if haskey(dict, s)
@@ -826,19 +801,19 @@ function fix_conflicts!(dict::Dict, level)
     if haskey(dict, '\0')
         add_specialisations(dict, dict, level)
     end
-    for d in dict
-        d[1] == '\0' && continue
-        fix_conflicts!(d[2], level+1)
+    for (k,v) in dict
+        k == '\0' && continue
+        fix_conflicts!(v, level+1)
     end
 end
 
-keymap_prepare(keymaps::Expr) = keymap_prepare(eval(keymaps))
-keymap_prepare(keymaps::Dict) = keymap_prepare([keymaps])
-function keymap_prepare{D<:Dict}(keymaps::Array{D})
-    push!(keymaps, {"*"=>:(error("Unrecognized input"))})
-    keymaps = map(normalize_keymap, keymaps)
-    map(fix_conflicts!, keymaps)
-    keymaps
+function keymap_prepare(keymap::Dict)
+    if !haskey(keymap, "\0")
+        keymap["\0"] = (o...)->error("Unrecognized input")
+    end
+    keymap = normalize_keymap(keymap)
+    fix_conflicts!(keymap)
+    keymap
 end
 
 function keymap_unify(keymaps)
@@ -851,19 +826,15 @@ function keymap_unify(keymaps)
     return ret
 end
 
-macro keymap(keymaps)
-    dict = keymap_unify(keymap_prepare(keymaps))
-    body = keymap_gen_body(dict, dict)
-    esc(quote
-        (s, data) -> begin
-            $body
-            return :ok
-        end
-    end)
+function keymap{D<:Dict}(keymaps::Array{D})
+    # keymaps is a vector of prioritized keymaps, with highest priority first
+    dict = map(normalize_keys, keymaps)
+    dict = keymap_prepare(merge(reverse(dict)...))
+    return (s,p)->match_input(dict, s)(s,p)
 end
 
 const escape_defaults = merge!(
-    {i => nothing for i=1:31}, # Ignore control characters by default
+    {char(i) => nothing for i=[1:26, 28:31]}, # Ignore control characters by default
     { # And ignore other escape sequences by default
     "\e*" => nothing,
     "\e[*" => nothing,
@@ -1027,88 +998,81 @@ end
 function setup_search_keymap(hp)
     p = HistoryPrompt(hp)
     pkeymap = {
-        "^R"      => :(LineEdit.history_set_backward(data, true); LineEdit.history_next_result(s, data)),
-        "^S"      => :(LineEdit.history_set_backward(data, false); LineEdit.history_next_result(s, data)),
-        '\r'      => s->accept_result(s, p),
+        "^R"      => (s,data,c)->(history_set_backward(data, true); history_next_result(s, data)),
+        "^S"      => (s,data,c)->(history_set_backward(data, false); history_next_result(s, data)),
+        '\r'      => (s,o...)->accept_result(s, p),
         '\n'      => '\r',
         # Limited form of tab completions
-        '\t'      => :(LineEdit.complete_line(s); LineEdit.update_display_buffer(s, data)),
-        "^L"      => :(Terminals.clear(LineEdit.terminal(s)); LineEdit.update_display_buffer(s, data)),
+        '\t'      => (s,data,c)->(complete_line(s); update_display_buffer(s, data)),
+        "^L"      => (s,data,c)->(Terminals.clear(terminal(s)); update_display_buffer(s, data)),
 
         # Backspace/^H
-        '\b'      => :(LineEdit.edit_backspace(data.query_buffer) ?
-                        LineEdit.update_display_buffer(s, data) : beep(LineEdit.terminal(s))),
+        '\b'      => (s,data,c)->(edit_backspace(data.query_buffer) ?
+                        update_display_buffer(s, data) : beep(terminal(s))),
         127       => '\b',
         # Meta Backspace
-        "\e\b"    => :(LineEdit.edit_delete_prev_word(data.query_buffer) ?
-                        LineEdit.update_display_buffer(s, data) : beep(LineEdit.terminal(s))),
+        "\e\b"    => (s,data,c)->(edit_delete_prev_word(data.query_buffer) ?
+                        update_display_buffer(s, data) : beep(terminal(s))),
         "\e\x7f"  => "\e\b",
         # Word erase to whitespace
-        "^W"      => :(LineEdit.edit_werase(data.query_buffer) ?
-                        LineEdit.update_display_buffer(s, data) : beep(LineEdit.terminal(s))),
+        "^W"      => (s,data,c)->(edit_werase(data.query_buffer) ?
+                        update_display_buffer(s, data) : beep(terminal(s))),
         # ^C and ^D
-        "^C"      => :(LineEdit.edit_clear(data.query_buffer);
-                       LineEdit.edit_clear(data.response_buffer);
-                       LineEdit.update_display_buffer(s, data);
-                       LineEdit.reset_state(data.histprompt.hp);
-                       LineEdit.transition(s, data.parent)),
+        "^C"      => (s,data,c)->(edit_clear(data.query_buffer);
+                       edit_clear(data.response_buffer);
+                       update_display_buffer(s, data);
+                       reset_state(data.histprompt.hp);
+                       transition(s, data.parent)),
         "^D"      => "^C",
         # Other ways to cancel search mode (it's difficult to bind \e itself)
         "^G"      => "^C",
         "\e\e"    => "^C",
-        # ^K
-        11        => s->transition(s, state(s, p).parent),
-        # ^Y
-        25        => :(LineEdit.edit_yank(s); LineEdit.update_display_buffer(s, data)),
-        # ^U
-        21        => :(LineEdit.edit_clear(data.query_buffer);
-                       LineEdit.edit_clear(data.response_buffer);
-                       LineEdit.update_display_buffer(s, data)),
+        "^K"      => (s,o...)->transition(s, state(s, p).parent),
+        "^Y"      => (s,data,c)->(edit_yank(s); update_display_buffer(s, data)),
+        "^U"      => (s,data,c)->(edit_clear(data.query_buffer);
+                     edit_clear(data.response_buffer);
+                     update_display_buffer(s, data)),
         # Right Arrow
-        "\e[C"    => s->(accept_result(s, p); edit_move_right(s)),
+        "\e[C"    => (s,o...)->(accept_result(s, p); edit_move_right(s)),
         # Left Arrow
-        "\e[D"    => s->(accept_result(s, p); edit_move_left(s)),
+        "\e[D"    => (s,o...)->(accept_result(s, p); edit_move_left(s)),
         # Up Arrow
-        "\e[A"    => s->(accept_result(s, p); edit_move_up(s)),
+        "\e[A"    => (s,o...)->(accept_result(s, p); edit_move_up(s)),
         # Down Arrow
-        "\e[B"    => s->(accept_result(s, p); edit_move_down(s)),
-        # ^B
-        2         => s->(accept_result(s, p); edit_move_left(s)),
-        # ^F
-        6         => s->(accept_result(s, p); edit_move_right(s)),
+        "\e[B"    => (s,o...)->(accept_result(s, p); edit_move_down(s)),
+        "^B"      => (s,o...)->(accept_result(s, p); edit_move_left(s)),
+        "^F"      => (s,o...)->(accept_result(s, p); edit_move_right(s)),
         # Meta B
-        "\eb"     => s->(accept_result(s, p); edit_move_word_left(s)),
+        "\eb"     => (s,o...)->(accept_result(s, p); edit_move_word_left(s)),
         # Meta F
-        "\ef"     => s->(accept_result(s, p); edit_move_word_right(s)),
+        "\ef"     => (s,o...)->(accept_result(s, p); edit_move_word_right(s)),
         # Ctrl-Left Arrow
         "\e[1;5D" => "\eb",
         # Ctrl-Right Arrow
         "\e[1;5C" => "\ef",
-        # ^A
-        1         => s->(accept_result(s, p); move_line_start(s); refresh_line(s)),
-        # ^E
-        5         => s->(accept_result(s, p); move_line_end(s); refresh_line(s)),
-        "^Z"      => :(return :suspend),
+        "^A"         => (s,o...)->(accept_result(s, p); move_line_start(s); refresh_line(s)),
+        "^E"         => (s,o...)->(accept_result(s, p); move_line_end(s); refresh_line(s)),
+        "^Z"      => (s,o...)->(return :suspend),
         # Try to catch all Home/End keys
-        "\e[H"    => s->(accept_result(s, p); move_input_start(s); refresh_line(s)),
-        "\e[F"    => s->(accept_result(s, p); move_input_end(s); refresh_line(s)),
+        "\e[H"    => (s,o...)->(accept_result(s, p); move_input_start(s); refresh_line(s)),
+        "\e[F"    => (s,o...)->(accept_result(s, p); move_input_end(s); refresh_line(s)),
         # Use ^N and ^P to change search directions and iterate through results
-        "^N"      => :(LineEdit.history_set_backward(data, false); LineEdit.history_next_result(s, data)),
-        "^P"      => :(LineEdit.history_set_backward(data, true); LineEdit.history_next_result(s, data)),
+        "^N"      => (s,data,c)->(history_set_backward(data, false); history_next_result(s, data)),
+        "^P"      => (s,data,c)->(history_set_backward(data, true); history_next_result(s, data)),
         # Bracketed paste mode
-        "\e[200~" => quote
-            ps = LineEdit.state(s, LineEdit.mode(s))
+        "\e[200~" => (s,data,c)-> begin
+            ps = state(s, mode(s))
             input = readuntil(ps.terminal, "\e[201~")[1:(end-6)]
-            LineEdit.edit_insert(data.query_buffer, input); LineEdit.update_display_buffer(s, data)
+            edit_insert(data.query_buffer, input); update_display_buffer(s, data)
         end,
-        "*"       => :(LineEdit.edit_insert(data.query_buffer, c1); LineEdit.update_display_buffer(s, data))
+        "*"       => (s,data,c)->(edit_insert(data.query_buffer, c); update_display_buffer(s, data))
     }
-    p.keymap_func = @eval @LineEdit.keymap $([pkeymap, escape_defaults])
-    keymap = {
-        "^R"    => s->(enter_search(s, p, true)),
-        "^S"    => s->(enter_search(s, p, false)),
+    p.keymap_func = keymap([pkeymap, escape_defaults])
+    skeymap = {
+        "^R"    => (s,o...)->(enter_search(s, p, true)),
+        "^S"    => (s,o...)->(enter_search(s, p, false)),
     }
-    (p, keymap)
+    (p, skeymap)
 end
 
 keymap(state, p::HistoryPrompt) = p.keymap_func
@@ -1156,7 +1120,7 @@ end
 const default_keymap =
 {
     # Tab
-    '\t' => s->begin
+    '\t' => (s,o...)->begin
         buf = buffer(s)
         # Yes, we are ignoring the possiblity
         # the we could be in the middle of a multi-byte
@@ -1178,68 +1142,58 @@ const default_keymap =
         refresh_line(s)
     end,
     # Enter
-    '\r' => quote
-        if LineEdit.on_enter(s) || (eof(LineEdit.buffer(s)) && s.key_repeats > 1)
-            LineEdit.commit_line(s)
+    '\r' => (s,o...)->begin
+        if on_enter(s) || (eof(buffer(s)) && s.key_repeats > 1)
+            commit_line(s)
             return :done
         else
-            LineEdit.edit_insert(s, '\n')
+            edit_insert(s, '\n')
         end
     end,
     '\n' => '\r',
     # Backspace/^H
-    '\b' => edit_backspace,
+    '\b' => (s,o...)->edit_backspace(s),
     127 => '\b',
     # Meta Backspace
-    "\e\b" => edit_delete_prev_word,
+    "\e\b" => (s,o...)->edit_delete_prev_word(s),
     "\e\x7f" => "\e\b",
     # ^D
-    4 => quote
-        if LineEdit.buffer(s).size > 0
-            LineEdit.edit_delete(s)
+    "^D" => (s,o...)->begin
+        if buffer(s).size > 0
+            edit_delete(s)
         else
-            println(LineEdit.terminal(s))
+            println(terminal(s))
             return :abort
         end
     end,
-    # ^B
-    2 => edit_move_left,
-    # ^F
-    6 => edit_move_right,
+    "^B" => (s,o...)->edit_move_left(s),
+    "^F" => (s,o...)->edit_move_right(s),
     # Meta B
-    "\eb" => edit_move_word_left,
+    "\eb" => (s,o...)->edit_move_word_left(s),
     # Meta F
-    "\ef" => edit_move_word_right,
+    "\ef" => (s,o...)->edit_move_word_right(s),
     # Ctrl-Left Arrow
     "\e[1;5D" => "\eb",
     # Ctrl-Right Arrow
     "\e[1;5C" => "\ef",
     # Meta Enter
-    "\e\r" => :(LineEdit.edit_insert(s, '\n')),
+    "\e\r" => (s,o...)->(edit_insert(s, '\n')),
     "\e\n" => "\e\r",
     # Simply insert it into the buffer by default
-    "*" => :(LineEdit.edit_insert(s, c1)),
-    # ^U
-    21 => edit_clear,
-    # ^K
-    11 => edit_kill_line,
-    # ^Y
-    25 => edit_yank,
-    # ^A
-    1 => :(LineEdit.move_line_start(s); LineEdit.refresh_line(s)),
-    # ^E
-    5 => :(LineEdit.move_line_end(s); LineEdit.refresh_line(s)),
+    "*" => (s,data,c)->(edit_insert(s, c)),
+    "^U" => (s,o...)->edit_clear(s),
+    "^K" => (s,o...)->edit_kill_line(s),
+    "^Y" => (s,o...)->edit_yank(s),
+    "^A" => (s,o...)->(move_line_start(s); refresh_line(s)),
+    "^E" => (s,o...)->(move_line_end(s); refresh_line(s)),
     # Try to catch all Home/End keys
-    "\e[H"  => :(LineEdit.move_input_start(s); LineEdit.refresh_line(s)),
-    "\e[F"  => :(LineEdit.move_input_end(s); LineEdit.refresh_line(s)),
-    # ^L
-    12 => :(Terminals.clear(LineEdit.terminal(s)); LineEdit.refresh_line(s)),
-    # ^W
-    23 => edit_werase,
+    "\e[H"  => (s,o...)->(move_input_start(s); refresh_line(s)),
+    "\e[F"  => (s,o...)->(move_input_end(s); refresh_line(s)),
+    "^L" => (s,o...)->(Terminals.clear(terminal(s)); refresh_line(s)),
+    "^W" => (s,o...)->edit_werase(s),
     # Meta D
-    "\ed" => edit_delete_next_word,
-    # ^C
-    "^C" => s->begin
+    "\ed" => (s,o...)->edit_delete_next_word(s),
+    "^C" => (s,o...)->begin
         try # raise the debugger if present
             ccall(:jl_raise_debugger, Int, ())
         end
@@ -1249,19 +1203,19 @@ const default_keymap =
         transition(s, :reset)
         refresh_line(s)
     end,
-    "^Z" => :(return :suspend),
+    "^Z" => (s,o...)->(return :suspend),
     # Right Arrow
-    "\e[C" => edit_move_right,
+    "\e[C" => (s,o...)->edit_move_right(s),
     # Left Arrow
-    "\e[D" => edit_move_left,
+    "\e[D" => (s,o...)->edit_move_left(s),
     # Up Arrow
-    "\e[A" => edit_move_up,
+    "\e[A" => (s,o...)->edit_move_up(s),
     # Down Arrow
-    "\e[B" => edit_move_down,
+    "\e[B" => (s,o...)->edit_move_down(s),
     # Delete
-    "\e[3~" => edit_delete,
+    "\e[3~" => (s,o...)->edit_delete(s),
     # Bracketed Paste Mode
-    "\e[200~" => s->begin
+    "\e[200~" => (s,o...)->begin
         ps = state(s, mode(s))
         input = readuntil(ps.terminal, "\e[201~")[1:(end-6)]
         input = replace(input, '\r', '\n')
@@ -1271,25 +1225,21 @@ const default_keymap =
         end
         edit_insert(s, input)
     end,
-    "^T"      => edit_transpose,
+    "^T" => edit_transpose,
 }
 
-function history_keymap(hist)
-    return {
-        # ^P
-        16 => :(LineEdit.history_prev(s, $hist)),
-        # ^N
-        14 => :(LineEdit.history_next(s, $hist)),
-        # Up Arrow
-        "\e[A" => :(LineEdit.edit_move_up(s) || LineEdit.history_prev(s, $hist)),
-        # Down Arrow
-        "\e[B" => :(LineEdit.edit_move_down(s) || LineEdit.history_next(s, $hist)),
-        # Page Up
-        "\e[5~" => :(LineEdit.history_prev_prefix(s, $hist)),
-        # Page Down
-        "\e[6~" => :(LineEdit.history_next_prefix(s, $hist))
-    }
-end
+const history_keymap = {
+    "^P" => (s,o...)->(history_prev(s, mode(s).hist)),
+    "^N" => (s,o...)->(history_next(s, mode(s).hist)),
+    # Up Arrow
+    "\e[A" => (s,o...)->(edit_move_up(s) || history_prev(s, mode(s).hist)),
+    # Down Arrow
+    "\e[B" => (s,o...)->(edit_move_down(s) || history_next(s, mode(s).hist)),
+    # Page Up
+    "\e[5~" => (s,o...)->(history_prev_prefix(s, mode(s).hist)),
+    # Page Down
+    "\e[6~" => (s,o...)->(history_next_prefix(s, mode(s).hist))
+}
 
 function deactivate(p::Union(Prompt,HistoryPrompt), s::Union(SearchState,PromptState), termbuf)
     clear_input_area(termbuf, s)
@@ -1337,7 +1287,7 @@ function reset_state(s::MIState)
     end
 end
 
-const default_keymap_func = @LineEdit.keymap [LineEdit.default_keymap, LineEdit.escape_defaults]
+const default_keymap_func = keymap([default_keymap, escape_defaults])
 
 function Prompt(prompt;
     first_prompt = prompt,

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -700,7 +700,7 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
     end
 
     const repl_keymap = {
-        ';' => function (s)
+        ';' => function (s,o...)
             if isempty(s) || position(LineEdit.buffer(s)) == 0
                 buf = copy(LineEdit.buffer(s))
                 transition(s, shell_mode)
@@ -710,7 +710,7 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
                 edit_insert(s, ';')
             end
         end,
-        '?' => function (s)
+        '?' => function (s,o...)
             if isempty(s) || position(LineEdit.buffer(s)) == 0
                 buf = copy(LineEdit.buffer(s))
                 transition(s, help_mode)
@@ -722,7 +722,7 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
         end,
 
         # Bracketed Paste Mode
-        "\e[200~" => s->begin
+        "\e[200~" => (s,o...)->begin
             ps = LineEdit.state(s, LineEdit.mode(s))
             input = readuntil(ps.terminal, "\e[201~")[1:(end-6)]
             input = replace(input, '\r', '\n')
@@ -772,13 +772,13 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
         end,
     }
 
-    a = Dict{Any,Any}[hkeymap, repl_keymap, LineEdit.history_keymap(hp), LineEdit.default_keymap, LineEdit.escape_defaults]
+    a = Dict{Any,Any}[hkeymap, repl_keymap, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults]
     prepend!(a, extra_repl_keymap)
 
-    julia_prompt.keymap_func = @eval @LineEdit.keymap $(a)
+    julia_prompt.keymap_func = LineEdit.keymap(a)
 
     const mode_keymap = {
-        '\b' => function (s)
+        '\b' => function (s,o...)
             if isempty(s) || position(LineEdit.buffer(s)) == 0
                 buf = copy(LineEdit.buffer(s))
                 transition(s, julia_prompt)
@@ -788,7 +788,7 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
                 LineEdit.edit_backspace(s)
             end
         end,
-        "^C" => function (s)
+        "^C" => function (s,o...)
             LineEdit.move_input_end(s)
             LineEdit.refresh_line(s)
             print(LineEdit.terminal(s), "^C\n\n")
@@ -798,9 +798,9 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
         end
     }
 
-    b = Dict{Any,Any}[hkeymap, mode_keymap, LineEdit.history_keymap(hp), LineEdit.default_keymap, LineEdit.escape_defaults]
+    b = Dict{Any,Any}[hkeymap, mode_keymap, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults]
 
-    shell_mode.keymap_func = help_mode.keymap_func = @eval @LineEdit.keymap $(b)
+    shell_mode.keymap_func = help_mode.keymap_func = LineEdit.keymap(b)
 
     ModalInterface([julia_prompt, shell_mode, help_mode,hkp])
 end

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -4,24 +4,24 @@ using TestHelpers
 a_foo = 0
 
 const foo_keymap = {
-    'a' => :( global a_foo; a_foo += 1)
+    'a' => (o...)->(global a_foo; a_foo += 1)
 }
 
 b_foo = 0
 
 const foo2_keymap = {
-    'b' => :( global b_foo; b_foo += 1)
+    'b' => (o...)->(global b_foo; b_foo += 1)
 }
 
 a_bar = 0
 b_bar = 0
 
 const bar_keymap = {
-    'a' => :( global a_bar; a_bar += 1),
-    'b' => :( global b_bar; b_bar += 1)
+    'a' => (o...)->(global a_bar; a_bar += 1),
+    'b' => (o...)->(global b_bar; b_bar += 1)
 }
 
-test1_func = @eval @LineEdit.keymap $foo_keymap
+test1_func = LineEdit.keymap([foo_keymap])
 
 function run_test(f,buf)
     global a_foo, a_bar, b_bar
@@ -34,13 +34,13 @@ end
 run_test(test1_func,IOBuffer("aa"))
 @test a_foo == 2
 
-test2_func = @eval @LineEdit.keymap $([foo2_keymap, foo_keymap])
+test2_func = LineEdit.keymap([foo2_keymap, foo_keymap])
 
 run_test(test2_func,IOBuffer("aaabb"))
 @test a_foo == 3
 @test b_foo == 2
 
-test3_func = @eval @LineEdit.keymap $([bar_keymap, foo_keymap])
+test3_func = LineEdit.keymap([bar_keymap, foo_keymap])
 
 run_test(test3_func,IOBuffer("aab"))
 @test a_bar == 2
@@ -186,7 +186,7 @@ end
 
 let
     term = TestHelpers.FakeTerminal(IOBuffer(), IOBuffer(), IOBuffer())
-    s = LineEdit.init_state(term, Base.REPL.ModalInterface([Base.REPL.Prompt("test> ")]))
+    s = LineEdit.init_state(term, ModalInterface([Prompt("test> ")]))
     buf = LineEdit.buffer(s)
 
     LineEdit.edit_insert(s,"first line\nsecond line\nthird line")


### PR DESCRIPTION
This replaces the macro and expression code in LineEdit with higher-order functions. It is _mostly_ working. Things that don't work yet: bracketed paste mode and some escape keys like page up/down. There may be others. Nonetheless, standard expression input, command, help, and history search modes appear to work.

I've mostly kept the keymap data structures unchanged. The biggest difference is that keymap values now must be functions that are callable with the signature `(PromptState, AbstractREPL, Char)`. It would be nice to automatically normalize keymap functions to accept this signature, but I have punted on that for now.

I have no idea yet what the performance impact will be of leaning so heavily on anonymous functions in LineEdit. It will certainly be slower than the old code, but the difference isn't large enough for me to notice in interactive use on my machine.
