### PR TITLE
add apropos fallback to help prompt; addresses #8262

### DIFF
--- a/base/help.jl
+++ b/base/help.jl
@@ -188,6 +188,7 @@ isname(ex::Expr) = ((ex.head == :. && isname(ex.args[1]) && isname(ex.args[2]))
                     || (ex.head == :quote && isname(ex.args[1])))
 
 macro help(ex)
+    ex = isdefined(ex.args[1]) ? eval(ex.args[1]) : "$(ex.args[1])"
     if ex === :? || ex === :help
         return Expr(:call, :help)
     elseif !isa(ex, Expr) || isname(ex)


### PR DESCRIPTION
I think this should work, although it assumes that the expression passed to `Base.@help` only has one element in `args`.
