### PR TITLE
Fix Triangular methods for the case where the diagonal is unity. 

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -7,10 +7,22 @@ function Triangular{T}(A::AbstractMatrix{T}, uplo::Symbol, isunit::Bool=false)
     return Triangular{T,typeof(A),uplo,isunit}(A)
 end
 
-+{T, MT, uplo}(A::Triangular{T, MT, uplo}, B::Triangular{T, MT, uplo}) = Triangular(A.data + B.data, uplo)
-+{T, MT, uplo1, uplo2}(A::Triangular{T, MT, uplo1}, B::Triangular{T, MT, uplo2}) = full(A) + full(B)
--{T, MT, uplo}(A::Triangular{T, MT, uplo}, B::Triangular{T, MT, uplo}) = Triangular(A.data - B.data, uplo)
--{T, MT, uplo1, uplo2}(A::Triangular{T, MT, uplo1}, B::Triangular{T, MT, uplo2}) = full(A) - full(B)
++{T, MT, uplo}(A::Triangular{T, MT, uplo, false}, B::Triangular{T, MT, uplo, false}) = Triangular(A.data + B.data, uplo)
++{T, MT}(A::Triangular{T, MT, :U, false}, B::Triangular{T, MT, :U, true}) = Triangular(A.data + triu(B.data, 1) + I, :U)
++{T, MT}(A::Triangular{T, MT, :L, false}, B::Triangular{T, MT, :L, true}) = Triangular(A.data + tril(B.data, -1) + I, :L)
++{T, MT}(A::Triangular{T, MT, :U, true}, B::Triangular{T, MT, :U, false}) = Triangular(triu(A.data, 1) + B.data + I, :U)
++{T, MT}(A::Triangular{T, MT, :L, true}, B::Triangular{T, MT, :L, false}) = Triangular(tril(A.data, -1) + B.data + I, :L)
++{T, MT}(A::Triangular{T, MT, :U, true}, B::Triangular{T, MT, :U, true}) = Triangular(triu(A.data, 1) + triu(B.data, 1) + 2I, :U)
++{T, MT}(A::Triangular{T, MT, :L, true}, B::Triangular{T, MT, :L, true}) = Triangular(tril(A.data, -1) + tril(B.data, -1) + 2I, :L)
++{T, MT, uplo1, uplo2, IsUnit1, IsUnit2}(A::Triangular{T, MT, uplo1, IsUnit1}, B::Triangular{T, MT, uplo2, IsUnit2}) = full(A) + full(B)
+-{T, MT, uplo}(A::Triangular{T, MT, uplo, false}, B::Triangular{T, MT, uplo, false}) = Triangular(A.data - B.data, uplo)
+-{T, MT}(A::Triangular{T, MT, :U, false}, B::Triangular{T, MT, :U, true}) = Triangular(A.data - triu(B.data, 1) - I, :U)
+-{T, MT}(A::Triangular{T, MT, :L, false}, B::Triangular{T, MT, :L, true}) = Triangular(A.data - tril(B.data, -1) - I, :L)
+-{T, MT}(A::Triangular{T, MT, :U, true}, B::Triangular{T, MT, :U, false}) = Triangular(triu(A.data, 1) - B.data + I, :U)
+-{T, MT}(A::Triangular{T, MT, :L, true}, B::Triangular{T, MT, :L, false}) = Triangular(tril(A.data, -1) - B.data + I, :L)
+-{T, MT}(A::Triangular{T, MT, :U, true}, B::Triangular{T, MT, :U, true}) = Triangular(triu(A.data, 1) - triu(B.data, 1), :U)
+-{T, MT}(A::Triangular{T, MT, :L, true}, B::Triangular{T, MT, :L, true}) = Triangular(tril(A.data, -1) - tril(B.data, -1), :L)
+-{T, MT, uplo1, uplo2, IsUnit1, IsUnit2}(A::Triangular{T, MT, uplo1, IsUnit1}, B::Triangular{T, MT, uplo2, IsUnit2}) = full(A) - full(B)
 
 ######################
 # BlasFloat routines #
@@ -160,7 +172,7 @@ function (*){T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, x::Number)
             B[i,j] = (i == j && IsUnit ? x : B[i,j]*x)
         end
     end
-    Triangular{T,S,UpLo,IsUnit}(B)
+    Triangular{T,S,UpLo,false}(B)
 end
 function (*){T,S,UpLo,IsUnit}(x::Number, A::Triangular{T,S,UpLo,IsUnit})
     n = size(A,1)
@@ -170,29 +182,29 @@ function (*){T,S,UpLo,IsUnit}(x::Number, A::Triangular{T,S,UpLo,IsUnit})
             B[i,j] = i == j && IsUnit ? x : x*B[i,j]
         end
     end
-    Triangular{T,S,UpLo,IsUnit}(B)
+    Triangular{T,S,UpLo,false}(B)
 end
 function (/){T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, x::Number)
     n = size(A,1)
     B = copy(A.data)
-    invx = inv(x)
+    invx = one(T)/x
     for j = 1:n
         for i = UpLo == :L ? (j:n) : (1:j)
-            B[i,j] = (i == j && IsUnit ? invx : B[i,j]*invx)
+            B[i,j] = (i == j && IsUnit ? invx : B[i,j]/x)
         end
     end
-    Triangular{T,S,UpLo,IsUnit}(B)
+    Triangular{T,S,UpLo,false}(B)
 end
 function (\){T,S,UpLo,IsUnit}(x::Number, A::Triangular{T,S,UpLo,IsUnit})
     n = size(A,1)
     B = copy(A.data)
-    invx = inv(x)
+    invx = one(T)/x
     for j = 1:n
         for i = UpLo == :L ? (j:n) : (1:j)
-            B[i,j] = i == j && IsUnit ? invx : invx*B[i,j]
+            B[i,j] = i == j && IsUnit ? invx : x\B[i,j]
         end
     end
-    Triangular{T,S,UpLo,IsUnit}(B)
+    Triangular{T,S,UpLo,false}(B)
 end
 
 A_mul_B!{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::Triangular{T,S,UpLo,IsUnit}) = Triangular{T,S,UpLo,IsUnit}(A*full!(B))

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -1,0 +1,77 @@
+debug = false
+using Base.Test
+using Base.LinAlg: BlasFloat, naivesub!
+
+debug && println("Triangular matrices")
+n = 11
+for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
+
+    debug && println("elty is $(elty), relty is $(relty)")
+    A = convert(Matrix{elty}, randn(n, n))
+    b = convert(Matrix{elty}, randn(n, 2))
+    if elty <: Complex
+        A += im*convert(Matrix{elty}, randn(n, n))
+        b += im*convert(Matrix{elty}, randn(n, 2))
+    end
+
+    for M1 in (Triangular(A, :U), Triangular(A, :L), Triangular(A, :U, true), Triangular(A, :L, true))
+    	debug && println("M1 is of $(typeof(M1))")
+    	for M2 in (Triangular(A, :U), Triangular(A, :L), Triangular(A, :U, true), Triangular(A, :L, true))
+    		debug && println("M2 is of $(typeof(M2))")
+    		@test full(M1 + M2) == full(M1) + full(M2)
+    		@test full(M1 - M2) == full(M1) - full(M2)
+    	end
+    	α = randn()
+    	@test full(α*M1) == full(M1*α)
+    	@test full(M1*α) == full(M1)*α
+    	@test full(α\M1) == full(M1/α)
+    	@test full(M1/α) == full(M1)/α
+    end
+
+    for (M, TM) in ((triu(A), Triangular(A, :U)), 
+    				(tril(A), Triangular(A, :L)))
+        
+        ##Idempotent tests #XXX - not implemented
+        #for func in (conj, transpose, ctranspose)
+        #    @test full(func(func(TM))) == M
+        #end
+
+        debug && println("Linear solver")
+        x = M \ b
+        tx = TM \ b
+        condM = elty <:BlasFloat ? cond(TM, Inf) : convert(relty, cond(complex128(M), Inf))
+        @test norm(x-tx,Inf) <= 4*condM*max(eps()*norm(tx,Inf), eps(relty)*norm(x,Inf))
+        if elty <: BlasFloat #test naivesub! against LAPACK
+            tx = [naivesub!(TM, b[:,1]) naivesub!(TM, b[:,2])]
+            @test norm(x-tx,Inf) <= 4*condM*max(eps()*norm(tx,Inf), eps(relty)*norm(x,Inf))
+        end
+
+        debug && println("Eigensystems")
+        vals1, vecs1 = eig(complex128(M))
+        vals2, vecs2 = eig(TM)
+        res1=norm(complex128(vecs1*diagm(vals1)*inv(vecs1) - M))
+        res2=norm(complex128(vecs2*diagm(vals2)*inv(vecs2) - full(TM)))
+        @test_approx_eq_eps res1 res2 res1+res2
+
+        if elty <:BlasFloat
+            debug && println("Condition number tests - can be VERY approximate")
+            for p in [1.0, Inf]
+                @test_approx_eq_eps cond(TM, p) cond(M, p) (cond(TM,p)+cond(M,p))
+            end
+        end
+
+        debug && println("Binary operations")
+        B = convert(Matrix{elty}, randn(n, n))
+        for (M2, TM2) in ((triu(B), Triangular(B, :U)), (tril(B), Triangular(B, :L)))
+            for op in (*, +, -)
+                @test_approx_eq full(op(TM, TM2)) op(M, M2)
+                @test_approx_eq full(op(TM, M2)) op(M, M2)
+                @test_approx_eq full(op(M, TM2)) op(M, M2)
+            end
+            @test M2*0.5 == full(TM2*0.5)
+            @test 0.5*M2 == full(0.5*TM2)
+            @test M2/0.5 == full(TM2/0.5)
+            @test 0.5\M2 == full(0.5\TM2)
+        end
+    end
+end

--- a/test/linalg4.jl
+++ b/test/linalg4.jl
@@ -25,63 +25,6 @@ end
 
 n=12 #Size of matrix problem to test
 
-debug && println("Triangular matrices")
-for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
-    debug && println("elty is $(elty), relty is $(relty)")
-    A = convert(Matrix{elty}, randn(n, n))
-    b = convert(Matrix{elty}, randn(n, 2))
-    if elty <: Complex
-        A += im*convert(Matrix{elty}, randn(n, n))
-        b += im*convert(Matrix{elty}, randn(n, 2))
-    end
-
-    for (M, TM) in ((triu(A), Triangular(A, :U)), (tril(A), Triangular(A, :L)))
-        
-        ##Idempotent tests #XXX - not implemented
-        #for func in (conj, transpose, ctranspose)
-        #    @test full(func(func(TM))) == M
-        #end
-
-        debug && println("Linear solver")
-        x = M \ b
-        tx = TM \ b
-        condM = elty <:BlasFloat ? cond(TM, Inf) : convert(relty, cond(complex128(M), Inf))
-        @test norm(x-tx,Inf) <= 4*condM*max(eps()*norm(tx,Inf), eps(relty)*norm(x,Inf))
-        if elty <: BlasFloat #test naivesub! against LAPACK
-            tx = [LinAlg.naivesub!(TM, b[:,1]) LinAlg.naivesub!(TM, b[:,2])]
-            @test norm(x-tx,Inf) <= 4*condM*max(eps()*norm(tx,Inf), eps(relty)*norm(x,Inf))
-        end
-
-        debug && println("Eigensystems")
-        vals1, vecs1 = eig(complex128(M))
-        vals2, vecs2 = eig(TM)
-        res1=norm(complex128(vecs1*diagm(vals1)*inv(vecs1) - M))
-        res2=norm(complex128(vecs2*diagm(vals2)*inv(vecs2) - full(TM)))
-        @test_approx_eq_eps res1 res2 res1+res2
-
-        if elty <:BlasFloat
-            debug && println("Condition number tests - can be VERY approximate")
-            for p in [1.0, Inf]
-                @test_approx_eq_eps cond(TM, p) cond(M, p) (cond(TM,p)+cond(M,p))
-            end
-        end
-
-        debug && println("Binary operations")
-        B = convert(Matrix{elty}, randn(n, n))
-        for (M2, TM2) in ((triu(B), Triangular(B, :U)), (tril(B), Triangular(B, :L)))
-            for op in (*, +, -)
-                @test_approx_eq full(op(TM, TM2)) op(M, M2)
-                @test_approx_eq full(op(TM, M2)) op(M, M2)
-                @test_approx_eq full(op(M, TM2)) op(M, M2)
-            end
-            @test M2*0.5 == full(TM2*0.5)
-            @test 0.5*M2 == full(0.5*TM2)
-            @test M2/0.5 == full(TM2/0.5)
-            @test 0.5\M2 == full(0.5\TM2)
-        end
-    end
-end
-
 debug && println("Tridiagonal matrices")
 for relty in (Float32, Float64), elty in (relty, Complex{relty})
     debug && println("relty is $(relty), elty is $(elty)")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ tests = (ARGS==["all"] || isempty(ARGS)) ? testnames : ARGS
 if "linalg" in tests
     # specifically selected case
     filter!(x -> x != "linalg", tests)
-    prepend!(tests, ["linalg1", "linalg2", "linalg3", "linalg4"])
+    prepend!(tests, ["linalg1", "linalg2", "linalg3", "linalg4", "linalg/triangular"])
 end
 
 net_required_for = ["socket", "parallel"]


### PR DESCRIPTION
@dmbates pointed out that some of the methods for `Triangular` were broken when the diagonal was set to be unity. This pull request should hopefully fix that.

I have also added some tests and put all the triangular tests into their own file. Eventually I'd like to organize the linalg tests into files corresponding the files in `base/linalg`. This is a small first step.
