### PR TITLE
added built-in exception UndefVarError to manual

### DIFF
--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -576,6 +576,8 @@ built-in ``Exception``\ s listed below all interrupt the normal flow of control.
 +------------------------+
 | ``UndefRefError``      |
 +------------------------+
+| ``UndefVarError``      |
++------------------------+
 
 For example, the ``sqrt`` function throws a ``DomainError()`` if applied to a
 negative real value:


### PR DESCRIPTION
Just noticed this was missing.
