### PR TITLE
Change backslash to forwardslash: Unix file path

### DIFF
--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -77,7 +77,7 @@ same location as the current host. Each machine definition takes the form
     
     
 If you have code that you want executed whenever julia is run, you can
-put it in ``~\.juliarc.jl``:
+put it in ``~/.juliarc.jl``:
 
 .. raw:: latex
 


### PR DESCRIPTION
I think the change speaks for itself for any Unix-based command-line user. Also, look a few lines below about the related example code box.
