### PR TITLE
Docs: remove 2nd "Constants" section in stdlib by moving it under "Dates...

### DIFF
--- a/doc/stdlib/dates.rst
+++ b/doc/stdlib/dates.rst
@@ -340,7 +340,7 @@ Conversion Functions
 
 
 Constants
----------
+~~~~~~~~~
 
 Days of the Week:
 


### PR DESCRIPTION
In the latest document, there are two identically named sections "Constants" under "Standard Library", and it's confusing.

Upon looking their contents, the second "Constants" seems to be a subsection of "Dates Functions". This PR tries to move this out of the navigation panel and TOC page.
