### PR TITLE
properly show transpose expressions

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -618,6 +618,11 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         print(io, '&')
         show_unquoted(io, args[1])
 
+    # transpose
+    elseif is(head, symbol('\'')) && length(args) == 1
+        show_unquoted(io, args[1])
+        print(io, '\'')
+
     # print anything else as "Expr(head, args...)"
     else
         print(io, "\$(Expr(")

--- a/test/show.jl
+++ b/test/show.jl
@@ -171,3 +171,5 @@ end"""
 
 @test_repr "Int[i for i=1:10]"
 @test_repr "Int[(i, j) for (i, j) in zip(1:10,1:0)]"
+
+@test_repr "[1 2 3; 4 5 6; 7 8 9]'"


### PR DESCRIPTION
``` julia
# Before
julia> :([1 2 3; 4 5 6; 7 8 9]')
:($(Expr(:', :([1 2 3;4 5 6;7 8 9]))))

# After
julia> :([1 2 3; 4 5 6; 7 8 9]')
:([1 2 3;4 5 6;7 8 9]')
```
