### PR TITLE
Improve DISTRIBUTING.md, fix a detail in README.md

### DIFF
--- a/DISTRIBUTING.md
+++ b/DISTRIBUTING.md
@@ -10,7 +10,7 @@ order to create a portable, working Julia distribution, we have
 separated most of the notes by OS.
 
 Note that while the code for Julia is
-[MIT-licensed](https://github.com/JuliaLang/julia/blob/master/LICENSE.md),
+[MIT-licensed, with a few exceptions](https://github.com/JuliaLang/julia/blob/master/LICENSE.md),
 the distribution created by the techniques described herein will be
 GPL licensed, as various dependent libraries such as `FFTW`, `Rmath`,
 `SuiteSparse`, and `git` are GPL licensed. We do hope to have a
@@ -26,7 +26,7 @@ pregenerate the `base/version_git.jl` file with:
 
     make -C base version_git.jl.phony
 
-Juila has lots of build dependencies where we use patched versions that has not
+Julia has lots of build dependencies where we use patched versions that has not
 yet been included by the popular package managers. These dependencies will usually
 be automatically downloaded when you build, but if you want to be able to build
 Julia on a computer without internet access you should create a source-dist archive
@@ -43,6 +43,25 @@ to create a Make.user file containing:
 
     override TAGGED_RELEASE_BANNER = "my-package-repository build"
 
+Target Architectures
+--------------------
+
+By default, Julia optimizes its system image to the native architecture of
+the build machine. This is usually not what you want when building packages,
+as it will make Julia fail at startup on any machine with incompatible CPUs
+(in particular older ones with more restricted instruction sets).
+
+We therefore recommend that you pass the `MARCH` variable when calling `make`,
+setting it to the baseline target you intend to support. This will determine
+the target CPU for both the Julia executable and libraries, and the system
+image (the latter can also be set using `JULIA_CPU_TARGET`). Typically useful
+values for x86 CPUs are `x86-64` and `core2` (for 64-bit builds) and
+`pentium4` (for 32-bit builds). Unfortunately, CPUs older than Pentium 4
+are currently not supported (see
+[this issue](https://github.com/JuliaLang/julia/issues/7185)).
+
+The full list of CPU targets supported by LLVM can be obtained by running
+`llc -mattr=help`.
 
 Linux
 -----
@@ -52,9 +71,16 @@ installation. If you wish to create a distribution package such as a
 `.deb`, or `.rpm`, some extra effort is needed. See the
 [julia-debian](http://github.com/staticfloat/julia-debian) repository
 for an example of what metadata is needed for creating `.deb` packages
-for Debian and Ubuntu-based systems. Although we have not yet experimented
+for Debian and Ubuntu-based systems. See the
+[Fedora package](https://admin.fedoraproject.org/pkgdb/package/julia/)
+for RPM-based distributions. Although we have not yet experimented
 with it, [Alien](https://wiki.debian.org/Alien) could be used to
 generate Julia packages for various Linux distributions.
+
+Julia supports overriding standard installation directories via `prefix`
+and other environment variables you can pass when calling `make` and
+`make install`. See Make.inc for their list. `DESTDIR` can also be used
+to force the installation into a temporary directory.
 
 By default, Julia loads `$prefix/etc/julia/juliarc.jl` as an
 installation-wide initialization file. This file can be used by
@@ -102,8 +128,8 @@ Notes on BLAS and LAPACK
 Julia builds OpenBLAS by default, which includes the BLAS and LAPACK
 libraries. On 32-bit architectures, Julia builds OpenBLAS to use
 32-bit integers, while on 64-bit architectuers, Julia builds OpenBLAS
-to use 64-bit integers. It is essential that all Julia functions that
-call BLAS and LAPACK API routines use integers of the correct width.
+to use 64-bit integers (ILP64). It is essential that all Julia functions
+that call BLAS and LAPACK API routines use integers of the correct width.
 
 Most BLAS and LAPACK distributions provided on linux distributions,
 and even commercial implementations ship libraries that use 32-bit
@@ -119,6 +145,22 @@ use BLAS and LAPACK internally. The APIs need to be consistent across
 all libraries that depend on BLAS and LAPACK. The Julia build process
 will build all these libraries correctly, but when overriding defaults
 and using system provided libraries, this consistency must be ensured.
+
+Also note that Linux distributions sometimes ship several versions of
+OpenBLAS, some of which enable multithreading, and others only working
+in a serial fashion. For example, in Fedora, `libopenblasp.so` is threaded,
+but `libopenblas.so` is not. We recommend using the former for optimal
+performance. To choose an OpenBLAS library whose name is different from
+the default `libopenblas.so`, pass `LIBBLAS=-l$(YOURBLAS)` and
+`LIBBLASNAME=lib$(YOURBLAS)` to `make`, replacing `$(YOURBLAS)` with the
+name of your library. You can also add `.so.0` to the name of the library
+if you want your package to work without requiring the unversioned `.so`
+symlink.
+
+Finally, OpenBLAS includes its own optimized version of LAPACK. If you
+set `USE_SYSTEM_BLAS=1` and `USE_SYSTEM_LAPACK=1`, you should also set
+`LIBLAPACK=-l$(YOURBLAS)` and `LIBLAPACKNAME=lib$(YOURBLAS)`. Else, the
+reference LAPACK will be used and performance will typically be much lower.
 
 Notes on Rmath
 ==============
@@ -136,7 +178,8 @@ used.
 Compilation scripts
 ===================
 
-The [julia-nightly-packaging](https://github.com/staticfloat/julia-nightly-packaging) repository contains multiple example scripts to ease the creation of
+The [julia-nightly-packaging](https://github.com/staticfloat/julia-nightly-packaging)
+repository contains multiple example scripts to ease the creation of
 binary packages. It also includes miscellaneous tools to do things such as
 fetching the last good commit that passed the
 [Travis](https://travis-ci.org/JuliaLang/julia/builds) tests.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Julia does not install anything outside the directory it was cloned into. Julia 
 
 Julia can be built for a non-generic architecture by configuring the `ARCH` Makefile variable. See the appropriate section of `Make.inc` for additional customization options, such as `MARCH` and `JULIA_CPU_TARGET`.
 
-For example, to build for i486, set `ARCH=i486` and install the necessary system libraries for linking. On Ubuntu, these may include lib32gfortran3 (also manually call `ln -s /usr/lib32/libgfortran3.so.0 /usr/lib32/libgfortran3.so`) and lib32gcc1, lib32stdc++6, among others.
+For example, to build for Pentium 4, set `MARCH=pentium4` and install the necessary system libraries for linking. On Ubuntu, these may include lib32gfortran3 (also manually call `ln -s /usr/lib32/libgfortran3.so.0 /usr/lib32/libgfortran3.so`) and lib32gcc1, lib32stdc++6, among others.
 
 You can also set `MARCH=native` for a maximum-performance build customized for the current machine CPU.
 


### PR DESCRIPTION
Based on my sometimes painful experience.

In README.md, I replaced `ARCH` with `MARCH`, as it seems it's what should be used and it's mentioned just above that line. I also replaced `i486` because it does not work (issue #7185): better take a
correct example.
