### PR TITLE
Make install cleaning and improvements

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -86,6 +86,9 @@ libdir = $(prefix)/lib
 private_libdir = $(libdir)/julia
 libexecdir = $(prefix)/libexec
 datarootdir = $(prefix)/share
+docdir = $(datarootdir)/doc/julia
+mandir = $(datarootdir)/man
+man1dir = $(mandir)/man1
 includedir = $(prefix)/include
 sysconfdir = $(prefix)/etc
 
@@ -96,6 +99,9 @@ build_libdir = $(build_prefix)/lib
 build_private_libdir = $(build_prefix)/lib/julia
 build_libexecdir = $(build_prefix)/libexec
 build_datarootdir = $(build_prefix)/share
+build_docdir = $(build_datarootdir)/doc/julia
+build_mandir = $(build_datarootdir)/man
+build_man1dir = $(build_mandir)/man1
 build_includedir = $(build_prefix)/include
 build_sysconfdir = $(build_prefix)/etc
 
@@ -106,6 +112,7 @@ libdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(libdir))
 build_private_libdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(build_bindir) $(build_private_libdir))
 private_libdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(private_libdir))
 datarootdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(datarootdir))
+docdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(docdir))
 sysconfdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(sysconfdir))
 
 INSTALL_F = $(JULIAHOME)/contrib/install.sh 644

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,20 @@ default: release
 endif
 
 # sort is used to remove potential duplicates
-DIRS = $(sort $(build_bindir) $(build_libdir) $(build_private_libdir) $(build_libexecdir) $(build_sysconfdir)/julia $(build_datarootdir)/julia $(build_datarootdir)/man/man1)
+DIRS = $(sort $(build_bindir) $(build_libdir) $(build_private_libdir) $(build_libexecdir) $(build_sysconfdir)/julia $(build_datarootdir)/julia $(build_man1dir))
 
 $(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
-$(foreach link,base test doc examples,$(eval $(call symlink_target,$(link),$(build_datarootdir)/julia)))
+$(foreach link,base test,$(eval $(call symlink_target,$(link),$(build_datarootdir)/julia)))
+
+# doc needs to live under $(build_docdir), not under $(build_datarootdir)/julia/
+CLEAN_TARGETS += clean-$(build_docdir)
+clean-$(build_docdir):
+	@-rm -fr $(abspath $(build_docdir))
+$(subst $(abspath $(JULIAHOME))/,,$(abspath $(build_docdir))): $(build_docdir)
+$(build_docdir):
+	@mkdir -p $@/examples
+	@cp -R doc/devdocs doc/manual doc/stdlib $@
+	@cp -R examples/*.jl $@/examples/
 
 git-submodules:
 ifneq ($(NO_GIT), 1)
@@ -35,7 +45,7 @@ else
        $(warn "Submodules could not be updated because git is unavailable")
 endif
 
-debug release: | $(DIRS) $(build_datarootdir)/julia/base $(build_datarootdir)/julia/test $(build_datarootdir)/julia/doc $(build_datarootdir)/julia/examples $(build_sysconfdir)/julia/juliarc.jl $(build_datarootdir)/man/man1/julia.1
+debug release: | $(DIRS) $(build_datarootdir)/julia/base $(build_datarootdir)/julia/test $(build_docdir) $(build_sysconfdir)/julia/juliarc.jl $(build_man1dir)/julia.1
 	@$(MAKE) $(QUIET_MAKE) julia-$@
 	@export private_libdir=$(private_libdir) && \
 	$(MAKE) $(QUIET_MAKE) LD_LIBRARY_PATH=$(build_libdir):$(LD_LIBRARY_PATH) JULIA_EXECUTABLE="$(JULIA_EXECUTABLE_$@)" $(build_private_libdir)/sys.$(SHLIB_EXT)
@@ -96,11 +106,11 @@ ifndef JULIA_VAGRANT_BUILD
 endif
 endif
 
-$(build_datarootdir)/julia/helpdb.jl: doc/helpdb.jl | $(build_datarootdir)/julia
+$(build_docdir)/helpdb.jl: doc/helpdb.jl | $(build_docdir)
 	@cp $< $@
 
-$(build_datarootdir)/man/man1/julia.1: doc/man/julia.1 | $(build_datarootdir)/julia
-	@mkdir -p $(build_datarootdir)/man/man1
+$(build_man1dir)/julia.1: doc/man/julia.1 | $(build_man1dir)
+	@mkdir -p $(build_man1dir)
 	@cp $< $@
 
 $(build_sysconfdir)/julia/juliarc.jl: etc/juliarc.jl | $(build_sysconfdir)/julia
@@ -133,7 +143,7 @@ $(build_private_libdir)/sys0.o:
 BASE_SRCS := $(wildcard base/*.jl base/*/*.jl base/*/*/*.jl)
 
 ,:=,
-$(build_private_libdir)/sys.o: VERSION $(BASE_SRCS) $(build_datarootdir)/julia/helpdb.jl $(build_private_libdir)/sys0.$(SHLIB_EXT)
+$(build_private_libdir)/sys.o: VERSION $(BASE_SRCS) $(build_docdir)/helpdb.jl $(build_private_libdir)/sys0.$(SHLIB_EXT)
 	@$(call PRINT_JULIA, cd base && \
 	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys) \
 		-J$(call cygpath_w,$(build_private_libdir))/$$([ -e $(build_private_libdir)/sys.ji ] && echo sys.ji || echo sys0.ji) -f sysimg.jl \
@@ -222,7 +232,7 @@ endif
 install: $(build_bindir)/stringreplace
 	@$(MAKE) $(QUIET_MAKE) release
 	@$(MAKE) $(QUIET_MAKE) debug
-	@for subdir in $(bindir) $(libexecdir) $(datarootdir)/julia/site/$(VERSDIR) $(datarootdir)/man/man1 $(includedir)/julia $(libdir) $(private_libdir) $(sysconfdir); do \
+	@for subdir in $(bindir) $(libexecdir) $(datarootdir)/julia/site/$(VERSDIR) $(docdir) $(man1dir) $(includedir)/julia $(libdir) $(private_libdir) $(sysconfdir); do \
 		mkdir -p $(DESTDIR)$$subdir; \
 	done
 
@@ -259,12 +269,15 @@ endif
 	$(INSTALL_M) $(build_private_libdir)/sys.$(SHLIB_EXT) $(DESTDIR)$(private_libdir)
 	# Copy in all .jl sources as well
 	cp -R -L $(build_datarootdir)/julia $(DESTDIR)$(datarootdir)/
+	# Copy documentation
+	cp -R -L $(build_docdir)/* $(DESTDIR)$(docdir)/
 	# Remove perf suite
 	-rm -rf $(DESTDIR)$(datarootdir)/julia/test/perf/
 	# Remove various files which should not be installed
 	-rm -f $(DESTDIR)$(datarootdir)/julia/base/version_git.sh
 	-rm -f $(DESTDIR)$(datarootdir)/julia/test/Makefile
-	$(INSTALL_F) $(build_datarootdir)/man/man1/julia.1 $(DESTDIR)$(datarootdir)/man/man1/
+	# Copy in beautiful new man page 
+	$(INSTALL_F) $(build_man1dir)/julia.1 $(DESTDIR)$(man1dir)/
 	# Copy icon and .desktop file
 	mkdir -p $(DESTDIR)$(datarootdir)/icons/hicolor/scalable/apps/
 	$(INSTALL_F) contrib/julia.svg $(DESTDIR)$(datarootdir)/icons/hicolor/scalable/apps/

--- a/Makefile
+++ b/Makefile
@@ -259,10 +259,11 @@ endif
 	$(INSTALL_M) $(build_private_libdir)/sys.$(SHLIB_EXT) $(DESTDIR)$(private_libdir)
 	# Copy in all .jl sources as well
 	cp -R -L $(build_datarootdir)/julia $(DESTDIR)$(datarootdir)/
-	# Remove git repository of juliadoc
-	-rm -rf $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.git
-	-rm -f $(DESTDIR)$(datarootdir)/julia/doc/juliadoc/.gitignore
-	# Copy in beautiful new man page!
+	# Remove perf suite
+	-rm -rf $(DESTDIR)$(datarootdir)/julia/test/perf/
+	# Remove various files which should not be installed
+	-rm -f $(DESTDIR)$(datarootdir)/julia/base/version_git.sh
+	-rm -f $(DESTDIR)$(datarootdir)/julia/test/Makefile
 	$(INSTALL_F) $(build_datarootdir)/man/man1/julia.1 $(DESTDIR)$(datarootdir)/man/man1/
 	# Copy icon and .desktop file
 	mkdir -p $(DESTDIR)$(datarootdir)/icons/hicolor/scalable/apps/

--- a/base/Makefile
+++ b/base/Makefile
@@ -57,6 +57,7 @@ endif
 	@echo "const TAGGED_RELEASE_BANNER = \"$(TAGGED_RELEASE_BANNER)\"" >> $@
 	@echo "const SYSCONFDIR = \"$(sysconfdir_rel)\"" >> $@
 	@echo "const DATAROOTDIR = \"$(datarootdir_rel)\"" >> $@
+	@echo "const DOCDIR = \"$(docdir_rel)\"" >> $@
 
 	@# This to ensure that we always rebuild this file, but only when it is modified do we touch build_h.jl,
 	@# ensuring we rebuild the system image as infrequently as possible

--- a/base/help.jl
+++ b/base/help.jl
@@ -23,15 +23,14 @@ function decor_help_desc(func::String, mfunc::String, desc::String)
 end
 
 function helpdb_filename()
-    root = "$JULIA_HOME/../share/julia"
     file = "helpdb.jl"
     for loc in [Base.locale()]
-        fn = joinpath(root, loc, file)
+        fn = joinpath(JULIA_HOME, Base.DOCDIR, loc, file)
         if isfile(fn)
             return fn
         end
     end
-    joinpath(root, file)
+    joinpath(JULIA_HOME, Base.DOCDIR, file)
 end
 
 function init_help()

--- a/examples/wordcount.jl
+++ b/examples/wordcount.jl
@@ -6,13 +6,13 @@
 #
 # To run in parallel on a string stored in variable `text`:
 #  julia -p <N> 
-#  julia> require("<julia_dir>/examples/wordcount.jl")
+#  julia> require("<julia_doc_dir>/examples/wordcount.jl")
 #  julia> ...(define text)...
 #  julia> counts=parallel_wordcount(text)
 #
 # Or to run on a group of files, writing results to an output file:
 #  julia -p <N>
-#  julia> require("<julia_dir>/examples/wordcount.jl")
+#  julia> require("<julia_doc_dir>/examples/wordcount.jl")
 #  julia> wordcount_files("/tmp/output.txt", "/tmp/input1.txt","/tmp/input2.txt",...) 
 
 # "Map" function.

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,15 +1,17 @@
-include("../examples/bubblesort.jl")
+dir = joinpath(JULIA_HOME, Base.DOCDIR, "examples")
+
+include(joinpath(dir, "bubblesort.jl"))
 a = rand(1:100,100)
 @test issorted(sort!(a;alg=BubbleSort))
 
-include("../examples/enum.jl")
+include(joinpath(dir, "enum.jl"))
 @enum TestEnum TestEnum1 TestEnum2 TestEnum3
 @test [TestEnum1.n,TestEnum2.n,TestEnum3.n] == [0,1,2]
 
-include("../examples/lru.jl")
-include("../examples/lru_test.jl")
+include(joinpath(dir, "lru.jl"))
+include(joinpath(dir, "lru_test.jl"))
 
-include("../examples/modint.jl")
+include(joinpath(dir, "modint.jl"))
 b = ModInts.ModInt{10}(2)
 c = ModInts.ModInt{10}(4)
 @test b + c == ModInts.ModInt{10}(6)
@@ -20,7 +22,7 @@ y = inv(x)
 @test x*y == ModInts.ModInt{256}(1)
 @test_throws ErrorException inv(ModInts.ModInt{8}(4))
 
-include("../examples/ndgrid.jl")
+include(joinpath(dir, "ndgrid.jl"))
 r = repmat(1:10,1,10)
 r1, r2 = ndgrid(1:10, 1:10)
 @test r1 == r
@@ -29,13 +31,13 @@ r3, r4 = meshgrid(1:10,1:10)
 @test r3 == r'
 @test r4 == r
 
-include("../examples/queens.jl")
+include(joinpath(dir, "queens.jl"))
 @test solve(8, 8, 1) == Array{Int,1}[[1,1]]
 @test solve(8, 8, 7) == Array{Int,1}[[1,1],[2,3],[3,5],[4,2],[5,8],[7,4],[8,7]]
 
-# At least make sure code laods
-include("../examples/plife.jl")
+# At least make sure code loads
+include(joinpath(dir, "plife.jl"))
 
-include("../examples/preduce.jl")
+include(joinpath(dir, "preduce.jl"))
 
-include("../examples/wordcount.jl")
+include(joinpath(dir, "wordcount.jl"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ testnames = [
     "llvmcall", "grisu", "nullable", "meta", "staged", "profile"
 ]
 
-if isdir(joinpath(dirname(@__FILE__), "..", "examples"))
+if isdir(joinpath(JULIA_HOME, Base.DOCDIR, "examples"))
     push!(testnames, "examples")
 end
 @unix_only push!(testnames, "unicode")


### PR DESCRIPTION
The first commit makes the tree resulting from `make install` cleaner.

The second one is an attempt at fixing https://github.com/JuliaLang/julia/issues/8367, but it currently doesn't work. I'd appreciate some help from the genius who wrote Makefile:27. It should be adapted so that the symlink to `doc/` is no longer created at `$(build_datarootdir)/julia/doc`, but at `$(build_docdir)` -- Make.inc:102 should then also be made consistent with Make.inc:89.
