### PR TITLE
backport for #8407, fixes to base/linalg/blas.jl

### DIFF
--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -39,7 +39,7 @@ export
 
 const libblas = Base.libblas_name
 
-import ..LinAlg: BlasFloat, BlasChar, BlasInt, blas_int, DimensionMismatch, chksquare, axpy!
+import ..LinAlg: BlasReal, BlasComplex, BlasFloat, BlasChar, BlasInt, blas_int, DimensionMismatch, chksquare, axpy!
 
 # Level 1
 ## copy
@@ -140,17 +140,17 @@ for (fname, elty) in ((:cblas_zdotu_sub,:Complex128),
         end
     end
 end
-function dot{T<:BlasFloat}(DX::Array{T}, DY::Array{T})
+function dot{T<:BlasReal}(DX::Array{T}, DY::Array{T})
     n = length(DX)
     n==length(DY) || throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
     dot(n, DX, 1, DY, 1)
 end
-function dotc{T<:BlasFloat}(DX::Array{T}, DY::Array{T})
+function dotc{T<:BlasComplex}(DX::Array{T}, DY::Array{T})
     n = length(DX)
     n==length(DY) || throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
     dotc(n, DX, 1, DY, 1)
 end
-function dotu{T<:BlasFloat}(DX::Array{T}, DY::Array{T})
+function dotu{T<:BlasComplex}(DX::Array{T}, DY::Array{T})
     n = length(DX)
     n==length(DY) || throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
     dotu(n, DX, 1, DY, 1)
@@ -235,7 +235,6 @@ for (fname, elty) in ((:idamax_,:Float64),
                       (:icamax_,:Complex64))
     @eval begin
         function iamax(n::BlasInt, dx::Union(StridedVector{$elty}, Ptr{$elty}), incx::BlasInt)
-            n*incx >= length(x) || throw(DimensionMismatch(""))
             ccall(($(string(fname)), libblas),BlasInt,
                 (Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}),
                 &n, dx, &incx)
@@ -305,8 +304,9 @@ for (fname, elty) in ((:dgbmv_,:Float64),
             y
         end
         function gbmv(trans::BlasChar, m::Integer, kl::Integer, ku::Integer, alpha::($elty), A::StridedMatrix{$elty}, x::StridedVector{$elty})
-            n = stride(A,2)
-            gbmv!(trans, m, kl, ku, alpha, A, x, zero($elty), similar(x, $elty, n))
+            n = size(A,2)
+            leny = trans == 'N' ? m : n
+            gbmv!(trans, m, kl, ku, alpha, A, x, zero($elty), similar(x, $elty, leny))
         end
         function gbmv(trans::BlasChar, m::Integer, kl::Integer, ku::Integer, A::StridedMatrix{$elty}, x::StridedVector{$elty})
             gbmv(trans, m, kl, ku, one($elty), A, x)


### PR DESCRIPTION
- L42: import `BlasReal` and `BlasComplex`
- L143: for `dot`: `BlasFloat` to `BlasReal`
  - BLAS `dot` only applies to real numbers
- L148: for `dotc`: `BlasFloat` to `BlasComplex`
  - BLAS `dotc` only applies to complex numbers
- L153: for `dotu`: `BlasFloat` to `BlasComplex`
  - BLAS `dotu` only applies to complex numbers
- L238: remove line in `iamax`
  - `x` is not an input variable
  - cannot compute length of a pointer
- L308: fix computation of length of output vector in `gbmv`
