### PR TITLE
Apply custom keymaps to all prompt modes and document it.

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -799,6 +799,7 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
     }
 
     b = Dict{Any,Any}[hkeymap, mode_keymap, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults]
+    prepend!(b, extra_repl_keymap)
 
     shell_mode.keymap_func = help_mode.keymap_func = LineEdit.keymap(b)
 

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -162,6 +162,24 @@ The Julia REPL makes great use of key bindings.  Several control-key bindings we
 | Delete, ``^D``         | Forward delete one character (when buffer has text)|
 +------------------------+----------------------------------------------------+
 
+Customizing keybindings
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Julia's REPL keybindings may be fully customized to a user's preferences by passing a dictionary to ``REPL.setup_interface()``. The keys of this dictionary may be characters or strings. The key ``'*'`` refers to the default action. Control plus character ``x`` bindings are indicated with ``"^x"``. Meta plus ``x`` can be written ``"\\Mx"``. The values of the custom keymap must be ``nothing`` (indicating that the input should be ignored) or functions that accept the signature ``(PromptState, AbstractREPL, Char)``. For example, to bind the up and down arrow keys to move through history without prefix search, one could put the following code in ``.juliarc.jl``::
+
+    import Base: LineEdit, REPL
+
+    const mykeys = {
+      # Up Arrow
+      "\e[A" => (s,o...)->(LineEdit.edit_move_up(s) || LineEdit.history_prev(s, LineEdit.mode(s).hist)),
+      # Down Arrow
+      "\e[B" => (s,o...)->(LineEdit.edit_move_up(s) || LineEdit.history_next(s, LineEdit.mode(s).hist))
+    }
+
+    Base.active_repl.interface = REPL.setup_interface(Base.active_repl; extra_repl_keymap = mykeys)
+
+Users should refer to ``base/LineEdit.jl`` to discover the available actions on key input.
+
 Tab completion
 --------------
 


### PR DESCRIPTION
Fixes the issue @carlobaldassi discovered with custom keymaps not being applied in all prompt modes. Also documents use of custom keymaps.
