### PR TITLE
Enable 64-bit vectorization

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1289,7 +1289,8 @@ static Value *emit_arraylen_prim(Value *t, jl_value_t *ty)
 {
 #ifdef STORE_ARRAY_LEN
     (void)ty;
-    return emit_nthptr_recast(t, 2, tbaa_arraylen, T_psize);
+    Value* addr = builder.CreateStructGEP(builder.CreateBitCast(t,jl_parray_llvmt), 2);
+    return tbaa_decorate(tbaa_arraylen, builder.CreateLoad(addr, false));
 #else
     jl_value_t *p1 = jl_tparam1(ty);
     if (jl_is_long(p1)) {
@@ -1320,7 +1321,8 @@ static Value *emit_arraylen(Value *t, jl_value_t *ex, jl_codectx_t *ctx)
 
 static Value *emit_arrayptr(Value *t)
 {
-    return emit_nthptr(t, 1, tbaa_arrayptr);
+    Value* addr = builder.CreateStructGEP(builder.CreateBitCast(t,jl_parray_llvmt), 1);
+    return tbaa_decorate(tbaa_arrayptr, builder.CreateLoad(addr, false));
 }
 
 static Value *emit_arrayptr(Value *t, jl_value_t *ex, jl_codectx_t *ctx)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -211,6 +211,7 @@ static bool imaging_mode = false;
 static Type *jl_value_llvmt;
 static Type *jl_pvalue_llvmt;
 static Type *jl_ppvalue_llvmt;
+static Type* jl_parray_llvmt;
 static FunctionType *jl_func_sig;
 static Type *jl_pfptr_llvmt;
 static Type *T_int1;
@@ -4154,6 +4155,17 @@ static void init_julia_llvm_env(Module *m)
     jl_func_sig = FunctionType::get(jl_pvalue_llvmt, ftargs, false);
     assert(jl_func_sig != NULL);
     jl_pfptr_llvmt = PointerType::get(PointerType::get(jl_func_sig, 0), 0);
+
+    Type* vaelts[] = {valueStructElts[0], T_pint8
+#ifdef STORE_ARRAY_LEN
+                                        , T_size
+#endif
+    };
+    Type* jl_array_llvmt = 
+        StructType::create(getGlobalContext(), 
+                           ArrayRef<Type*>(vaelts,sizeof(vaelts)/sizeof(vaelts[0])), 
+                           "jl_array_t");
+    jl_parray_llvmt = PointerType::get(jl_array_llvmt,0);
 
 #ifdef JL_GC_MARKSWEEP
     jlpgcstack_var =

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4162,7 +4162,7 @@ static void init_julia_llvm_env(Module *m)
 #endif
     };
     Type* jl_array_llvmt = 
-        StructType::create(getGlobalContext(), 
+        StructType::create(jl_LLVMContext,
                            ArrayRef<Type*>(vaelts,sizeof(vaelts)/sizeof(vaelts[0])), 
                            "jl_array_t");
     jl_parray_llvmt = PointerType::get(jl_array_llvmt,0);


### PR DESCRIPTION
Yes, the title is correct despite the innocent appearance of the diff. The patch represents `jl_array_t` more accurately in LLVM.  I implemented only the `data` and `length` fields since there was no clear benefit for representing the rest of the fields.

Julia's pointer casting was confusing stride computations in LLVM's vectorizer, so it mistook unit-stride load/store as high cost gather/scatter.  I had been wondering why the vectorizer was pricing a vector load at 51 clock cycles! I don't know why the problem did not exist for `Float32`, but it seemed some LLVM transform was  pushing casts around differently when the size of the array element type matched `sizeof(jl_value_t*)`. So maybe title is wrong for 32-bit targets :-)

Though we could try to get LLVM fixed, I think it's better for the code generator to "say what it means" and generate code closer to what Clang generates, since Clang is a prime client of LLVM. 

With LLVM 3.3, the 64-bit versions of the benchmarks in `test/perf/simd` ran 1.6x to 3.9x faster for me with the patch than without, using an Intel 4th Generation Core i7 processor ("Haswell").
