### PR TITLE
Export Callable

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -28,6 +28,7 @@ export
     BitArray,
     BitMatrix,
     BitVector,
+    Callable,
     CFILE,
     Cmd,
     Colon,


### PR DESCRIPTION
Is there a reason this has not been exported?  Is it reasonable to do so?

`Function` and `DataType` are both exported.
