### PR TITLE
fix float vs rational comparisons

### DIFF
--- a/base/constants.jl
+++ b/base/constants.jl
@@ -16,6 +16,15 @@ convert{T<:Integer}(::Type{Rational{T}}, x::MathConst) = convert(Rational{T}, fl
 =={s}(::MathConst{s}, ::MathConst{s}) = true
 ==(::MathConst, ::MathConst) = false
 
+<(x::MathConst, y::MathConst) = float(x) < float(y)
+<(x::Real, y::MathConst) = x <= prevfloat(y)
+<(x::MathConst, y::Real) = nextfloat(x) <= y
+<=(x::MathConst, y::MathConst) = float(x) <= float(y)
+<=(x::Real, y::MathConst) = x < y
+<=(x::MathConst, y::Real) = x < y
+
+# TODO: BigFloat, Rationals
+
 hash(x::MathConst, h::Uint) = hash(object_id(x), h)
 
 -(x::MathConst) = -float64(x)
@@ -41,6 +50,9 @@ macro math_const(sym, val, def)
         const $esym = MathConst{$qsym}()
         $bigconvert
         Base.convert(::Type{Float64}, ::MathConst{$qsym}) = $val
+        # TODO: fix this
+        Base.prevfloat(::MathConst{$qsym}) = $val
+        Base.nextfloat(::MathConst{$qsym}) = $val
         Base.convert(::Type{Float32}, ::MathConst{$qsym}) = $(float32(val))
         @assert isa(big($esym), BigFloat)
         @assert float64($esym) == float64(big($esym))

--- a/base/constants.jl
+++ b/base/constants.jl
@@ -94,11 +94,11 @@ macro math_const(sym, val, def)
         const $esym = MathConst{$qsym}()
         $bigconvert
         Base.convert(::Type{Float64}, ::MathConst{$qsym}) = $val
-        # TODO: fix this
         Base.convert(::Type{Float32}, ::MathConst{$qsym}) = $(float32(val))
         @assert isa(big($esym), BigFloat)
         @assert float64($esym) == float64(big($esym))
         @assert float32($esym) == float32(big($esym))
+        @assert float($esym) == prevfloat($esym) || float($esym) == nextfloat($esym)
     end
 end
 

--- a/base/constants.jl
+++ b/base/constants.jl
@@ -17,13 +17,42 @@ convert{T<:Integer}(::Type{Rational{T}}, x::MathConst) = convert(Rational{T}, fl
 ==(::MathConst, ::MathConst) = false
 
 <(x::MathConst, y::MathConst) = float(x) < float(y)
+<=(x::MathConst, y::MathConst) = float(x) <= float(y)
+
 <(x::Real, y::MathConst) = x <= prevfloat(y)
 <(x::MathConst, y::Real) = nextfloat(x) <= y
-<=(x::MathConst, y::MathConst) = float(x) <= float(y)
+
+function <(x::BigFloat, c::MathConst)
+    p = precision(x)
+    y = with_bigfloat_precision(p) do
+        big(c)
+    end
+    while x == y
+        p += 16
+        y = with_bigfloat_precision(p) do
+            big(c)
+        end
+    end
+    x < y
+end
+function <(c::MathConst, x::BigFloat)
+    p = precision(x)
+    y = with_bigfloat_precision(p) do
+        big(c)
+    end
+    while x == y
+        p += 16
+        y = with_bigfloat_precision(p) do
+            big(c)
+        end
+    end
+    y < x
+end
+
 <=(x::Real, y::MathConst) = x < y
 <=(x::MathConst, y::Real) = x < y
 
-# TODO: BigFloat, Rationals
+# TODO: Rationals
 
 hash(x::MathConst, h::Uint) = hash(object_id(x), h)
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -161,6 +161,16 @@ function cmp(x::FloatingPoint, y::FloatingPoint)
     ifelse(x<y, -1, ifelse(x>y, 1, 0))
 end
 
+function cmp(x::Union(Float16,Float32,Float64), y::Union(Signed,Unsigned))
+    isnan(x) && throw(DomainError())
+    ifelse(x<y, -1, ifelse(x>y, 1, 0))
+end
+function cmp(x::Union(Signed,Unsigned), y::Union(Float16,Float32,Float64))
+    isnan(y) && throw(DomainError())
+    ifelse(x<y, -1, ifelse(x>y, 1, 0))
+end
+
+
 ==(x::Float64, y::Int64  ) = eqfsi64(unbox(Float64,x),unbox(Int64,y))
 ==(x::Float64, y::Uint64 ) = eqfui64(unbox(Float64,x),unbox(Uint64,y))
 ==(x::Int64  , y::Float64) = eqfsi64(unbox(Float64,y),unbox(Int64,x))
@@ -191,21 +201,12 @@ end
 <=(x::Int64  , y::Float32) = lesif64(unbox(Int64,x),unbox(Float64,float64(y)))
 <=(x::Uint64 , y::Float32) = leuif64(unbox(Uint64,x),unbox(Float64,float64(y)))
 
-==(x::Float32, y::Union(Int32,Uint32)) = float64(x)==float64(y)
-==(x::Union(Int32,Uint32), y::Float32) = float64(x)==float64(y)
-
-<(x::Float32, y::Union(Int32,Uint32)) = float64(x)<float64(y)
-<(x::Union(Int32,Uint32), y::Float32) = float64(x)<float64(y)
-
-<=(x::Float32, y::Union(Int32,Uint32)) = float64(x)<=float64(y)
-<=(x::Union(Int32,Uint32), y::Float32) = float64(x)<=float64(y)
-
-==(x::Float16,y::Union(Signed,Unsigned)) = float32(x) == y
-==(x::Union(Signed,Unsigned),y::Float16) = x == float32(y)
-< (x::Float16,y::Union(Signed,Unsigned)) = float32(x) < y
-< (x::Union(Signed,Unsigned),y::Float16) = x < float32(y)
-<=(x::Float16,y::Union(Signed,Unsigned)) = float32(x) <= y
-<=(x::Union(Signed,Unsigned),y::Float16) = x <= float32(y)
+==(x::Union(Float16,Float32,Float64), y::Union(Signed,Unsigned)) = float64(x)==float64(y)
+==(x::Union(Signed,Unsigned), y::Union(Float16,Float32,Float64)) = float64(x)==float64(y)
+<(x::Union(Float16,Float32,Float64), y::Union(Signed,Unsigned)) = float64(x)<float64(y)
+<(x::Union(Signed,Unsigned), y::Union(Float16,Float32,Float64)) = float64(x)<float64(y)
+<=(x::Union(Float16,Float32,Float64), y::Union(Signed,Unsigned)) = float64(x)<=float64(y)
+<=(x::Union(Signed,Unsigned), y::Union(Float16,Float32,Float64)) = float64(x)<=float64(y)
 
 
 abs(x::Float64) = box(Float64,abs_float(unbox(Float64,x)))

--- a/base/float.jl
+++ b/base/float.jl
@@ -161,16 +161,6 @@ function cmp(x::FloatingPoint, y::FloatingPoint)
     ifelse(x<y, -1, ifelse(x>y, 1, 0))
 end
 
-function cmp(x::Real, y::FloatingPoint)
-    isnan(y) && throw(DomainError())
-    ifelse(x<y, -1, ifelse(x>y, 1, 0))
-end
-
-function cmp(x::FloatingPoint, y::Real)
-    isnan(x) && throw(DomainError())
-    ifelse(x<y, -1, ifelse(x>y, 1, 0))
-end
-
 ==(x::Float64, y::Int64  ) = eqfsi64(unbox(Float64,x),unbox(Int64,y))
 ==(x::Float64, y::Uint64 ) = eqfui64(unbox(Float64,x),unbox(Uint64,y))
 ==(x::Int64  , y::Float64) = eqfsi64(unbox(Float64,y),unbox(Int64,x))
@@ -210,12 +200,12 @@ end
 <=(x::Float32, y::Union(Int32,Uint32)) = float64(x)<=float64(y)
 <=(x::Union(Int32,Uint32), y::Float32) = float64(x)<=float64(y)
 
-==(x::Float16,y::Integer) = float32(x) == y
-==(x::Integer,y::Float16) = x == float32(y)
-< (x::Float16,y::Integer) = float32(x) < y
-< (x::Integer,y::Float16) = x < float32(y)
-<=(x::Float16,y::Integer) = float32(x) <= y
-<=(x::Integer,y::Float16) = x <= float32(y)
+==(x::Float16,y::Union(Signed,Unsigned)) = float32(x) == y
+==(x::Union(Signed,Unsigned),y::Float16) = x == float32(y)
+< (x::Float16,y::Union(Signed,Unsigned)) = float32(x) < y
+< (x::Union(Signed,Unsigned),y::Float16) = x < float32(y)
+<=(x::Float16,y::Union(Signed,Unsigned)) = float32(x) <= y
+<=(x::Union(Signed,Unsigned),y::Float16) = x <= float32(y)
 
 
 abs(x::Float64) = box(Float64,abs_float(unbox(Float64,x)))

--- a/base/float.jl
+++ b/base/float.jl
@@ -137,6 +137,10 @@ cld{T<:FloatingPoint}(x::T, y::T) = -fld(-x,y)
 mod{T<:FloatingPoint}(x::T, y::T) = rem(y+rem(x,y),y)
 
 ## floating point comparisons ##
+==(x::FloatingPoint, y::FloatingPoint) = (==)(promote(x,y)...)
+< (x::FloatingPoint, y::FloatingPoint) = (< )(promote(x,y)...)
+<=(x::FloatingPoint, y::FloatingPoint) = (<=)(promote(x,y)...)
+
 
 ==(x::Float32, y::Float32) = eq_float(unbox(Float32,x),unbox(Float32,y))
 ==(x::Float64, y::Float64) = eq_float(unbox(Float64,x),unbox(Float64,y))

--- a/base/float.jl
+++ b/base/float.jl
@@ -210,6 +210,14 @@ end
 <=(x::Float32, y::Union(Int32,Uint32)) = float64(x)<=float64(y)
 <=(x::Union(Int32,Uint32), y::Float32) = float64(x)<=float64(y)
 
+==(x::Float16,y::Integer) = float32(x) == y
+==(x::Integer,y::Float16) = x == float32(y)
+< (x::Float16,y::Integer) = float32(x) < y
+< (x::Integer,y::Float16) = x < float32(y)
+<=(x::Float16,y::Integer) = float32(x) <= y
+<=(x::Integer,y::Float16) = x <= float32(y)
+
+
 abs(x::Float64) = box(Float64,abs_float(unbox(Float64,x)))
 abs(x::Float32) = box(Float32,abs_float(unbox(Float32,x)))
 

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -417,20 +417,14 @@ binomial(n::BigInt, k::Integer) = k < 0 ? throw(DomainError()) : binomial(n, uin
 ==(x::BigInt, y::BigInt) = cmp(x,y) == 0
 ==(x::BigInt, i::Integer) = cmp(x,i) == 0
 ==(i::Integer, x::BigInt) = cmp(x,i) == 0
-==(x::BigInt, f::CdoubleMax) = isnan(f) ? false : cmp(x,f) == 0
-==(f::CdoubleMax, x::BigInt) = isnan(f) ? false : cmp(x,f) == 0
 
 <=(x::BigInt, y::BigInt) = cmp(x,y) <= 0
 <=(x::BigInt, i::Integer) = cmp(x,i) <= 0
 <=(i::Integer, x::BigInt) = cmp(x,i) >= 0
-<=(x::BigInt, f::CdoubleMax) = isnan(f) ? false : cmp(x,f) <= 0
-<=(f::CdoubleMax, x::BigInt) = isnan(f) ? false : cmp(x,f) >= 0
 
 <(x::BigInt, y::BigInt) = cmp(x,y) < 0
 <(x::BigInt, i::Integer) = cmp(x,i) < 0
 <(i::Integer, x::BigInt) = cmp(x,i) > 0
-<(x::BigInt, f::CdoubleMax) = isnan(f) ? false : cmp(x,f) < 0
-<(f::CdoubleMax, x::BigInt) = isnan(f) ? false : cmp(x,f) > 0
 
 string(x::BigInt) = dec(x)
 show(io::IO, x::BigInt) = print(io, string(x))

--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -94,6 +94,17 @@ Special values:
 decompose(x::Integer) = x, 0, 1
 decompose(x::Rational) = num(x), 0, den(x)
 
+function decompose(x::Float16)
+    isnan(x) && return 0, 0, 0
+    isinf(x) && return ifelse(x < 0, -1, 1), 0, 0
+    n = reinterpret(Int16, x)
+    s = int16(n & 0x03ff)
+    e = int16(n & 0x7c00 >> 10)
+    s |= int16(e != 0) << 10
+    d = ifelse(signbit(n), -1, 1)
+    int(s), int(e - 25 + (e == 0)), d
+end
+
 function decompose(x::Float32)
     isnan(x) && return 0, 0, 0
     isinf(x) && return ifelse(x < 0, -1, 1), 0, 0

--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -276,17 +276,6 @@ function cmp(x::Real, y::Real)
     end
 end
 
-function ==(x::Real, y::Real)
-    (isnan(x) || isnan(y)) && return false
-    cmp(x,y) == 0
-end
-
-function <(x::Real, y::Real)
-    (isnan(x) || isnan(y)) && return false
-    cmp(x,y) < 0
-end
-
-function <=(x::Real, y::Real)
-    (isnan(x) || isnan(y)) && return false
-    cmp(x,y) <= 0
-end
+==(x::Real, y::Real) = !isnan(x) && !isnan(y) && cmp(x,y) == 0
+<(x::Real, y::Real) = !isnan(x) && !isnan(y) && cmp(x,y) < 0
+<=(x::Real, y::Real) = !isnan(x) && !isnan(y) && cmp(x,y) <= 0

--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -275,8 +275,6 @@ function cmp(x::Real, y::Real)
         return c
     end
 end
-    
-    
 
 function ==(x::Real, y::Real)
     (isnan(x) || isnan(y)) && return false

--- a/base/int.jl
+++ b/base/int.jl
@@ -365,7 +365,7 @@ typemax(::Type{Uint64}) = 0xffffffffffffffff
 @eval typemax(::Type{Int128} ) = $(box(Int128,unbox(Uint128,typemax(Uint128)>>int32(1))))
 
 widen(::Type{Bool}) = Int
-widen(::Type{Char}) = Int
+widen(::Type{Char}) = Int64
 widen(::Type{Int8}) = Int
 widen(::Type{Int16}) = Int
 widen(::Type{Int32}) = Int64

--- a/base/int.jl
+++ b/base/int.jl
@@ -365,6 +365,7 @@ typemax(::Type{Uint64}) = 0xffffffffffffffff
 @eval typemax(::Type{Int128} ) = $(box(Int128,unbox(Uint128,typemax(Uint128)>>int32(1))))
 
 widen(::Type{Bool}) = Int
+widen(::Type{Char}) = Int
 widen(::Type{Int8}) = Int
 widen(::Type{Int16}) = Int
 widen(::Type{Int32}) = Int64

--- a/base/int.jl
+++ b/base/int.jl
@@ -127,6 +127,10 @@ leading_ones (x::Integer) = leading_zeros(~x)
 trailing_ones(x::Integer) = trailing_zeros(~x)
 
 ## integer comparisons ##
+< (x::Integer, y::Integer) = (< )(promote(x,y)...)
+<=(x::Integer, y::Integer) = (<=)(promote(x,y)...)
+==(x::Integer, y::Integer) = (==)(promote(x,y)...)
+=={T<:Integer}(x::T, y::T) = x === y
 
 for T in IntTypes
     if issubtype(T,Signed)
@@ -360,6 +364,7 @@ typemax(::Type{Uint64}) = 0xffffffffffffffff
 @eval typemin(::Type{Int128} ) = $(convert(Int128,1)<<int32(127))
 @eval typemax(::Type{Int128} ) = $(box(Int128,unbox(Uint128,typemax(Uint128)>>int32(1))))
 
+widen(::Type{Bool}) = Int
 widen(::Type{Int8}) = Int
 widen(::Type{Int16}) = Int
 widen(::Type{Int32}) = Int64

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -198,6 +198,10 @@ ndigits(x::Unsigned)             = x==0 ? 1 : ndigits0z(x)
 ndigits(x::Integer, b::Integer) = b >= 0 ? ndigits(unsigned(abs(x)),int(b)) : ndigitsnb(x, b)
 ndigits(x::Integer) = ndigits(unsigned(abs(x)))
 
+nbits(x::Integer) = ndigits(x,2) # fallback
+nbits(x::Unsigned) = x == 0 ? 1 : 8*sizeof(x)-leading_zeros(x)
+nbits(x::Signed) = x == 0 ? 1 : 8*sizeof(x)-leading_zeros(abs(x))
+
 ## integer to string functions ##
 
 function bin(x::Unsigned, pad::Int, neg::Bool)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -557,13 +557,6 @@ cmp(x::CdoubleMax, y::BigFloat) = -cmp(y,x)
 <=(x::BigFloat, y::CdoubleMax) = !isnan(x) && !isnan(y) && cmp(x,y) <= 0
 <=(x::CdoubleMax, y::BigFloat) = !isnan(x) && !isnan(y) && cmp(y,x) >= 0
 
-==(i::Integer,f::BigFloat) = big(i) == f
-==(f::BigFloat,i::Integer) = f == big(i)
-<(i::Integer,f::BigFloat) = big(i) < f
-<(f::BigFloat,i::Integer) = f < big(i)
-<=(i::Integer,f::BigFloat) = big(i) <= f
-<=(f::BigFloat,i::Integer) = f <= big(i)
-
 signbit(x::BigFloat) = ccall((:mpfr_signbit, :libmpfr), Int32, (Ptr{BigFloat},), &x) != 0
 
 function precision(x::BigFloat)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -557,6 +557,13 @@ cmp(x::CdoubleMax, y::BigFloat) = -cmp(y,x)
 <=(x::BigFloat, y::CdoubleMax) = !isnan(x) && !isnan(y) && cmp(x,y) <= 0
 <=(x::CdoubleMax, y::BigFloat) = !isnan(x) && !isnan(y) && cmp(y,x) >= 0
 
+==(i::Integer,f::BigFloat) = big(i) == f
+==(f::BigFloat,i::Integer) = f == big(i)
+<(i::Integer,f::BigFloat) = big(i) < f
+<(f::BigFloat,i::Integer) = f < big(i)
+<=(i::Integer,f::BigFloat) = big(i) <= f
+<=(f::BigFloat,i::Integer) = f <= big(i)
+
 signbit(x::BigFloat) = ccall((:mpfr_signbit, :libmpfr), Int32, (Ptr{BigFloat},), &x) != 0
 
 function precision(x::BigFloat)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -542,21 +542,6 @@ function cmp(x::BigFloat, y::CdoubleMax)
 end
 cmp(x::CdoubleMax, y::BigFloat) = -cmp(y,x)
 
-==(x::BigFloat, y::Integer)   = !isnan(x) && cmp(x,y) == 0
-==(x::Integer, y::BigFloat)   = y == x
-==(x::BigFloat, y::CdoubleMax) = !isnan(x) && !isnan(y) && cmp(x,y) == 0
-==(x::CdoubleMax, y::BigFloat) = y == x
-
-<(x::BigFloat, y::Integer)   = !isnan(x) && cmp(x,y) < 0
-<(x::Integer, y::BigFloat)   = !isnan(y) && cmp(y,x) > 0
-<(x::BigFloat, y::CdoubleMax) = !isnan(x) && !isnan(y) && cmp(x,y) < 0
-<(x::CdoubleMax, y::BigFloat) = !isnan(x) && !isnan(y) && cmp(y,x) > 0
-
-<=(x::BigFloat, y::Integer)   = !isnan(x) && cmp(x,y) <= 0
-<=(x::Integer, y::BigFloat)   = !isnan(y) && cmp(y,x) >= 0
-<=(x::BigFloat, y::CdoubleMax) = !isnan(x) && !isnan(y) && cmp(x,y) <= 0
-<=(x::CdoubleMax, y::BigFloat) = !isnan(x) && !isnan(y) && cmp(y,x) >= 0
-
 signbit(x::BigFloat) = ccall((:mpfr_signbit, :libmpfr), Int32, (Ptr{BigFloat},), &x) != 0
 
 function precision(x::BigFloat)

--- a/base/number.jl
+++ b/base/number.jl
@@ -32,6 +32,8 @@ inv(x::Number) = one(x)/x
 angle(z::Real) = atan2(zero(z), z)
 
 widemul(x::Number, y::Number) = widen(x)*widen(y)
+widemul(x::Int64, y::Uint64) = widen(x)*int128(y)
+widemul(x::Uint64, y::Int64) = int128(x)*widen(y)
 
 start(x::Number) = false
 next(x::Number, state) = (x, true)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -166,8 +166,6 @@ promote_to_super{T<:Number,S<:Number}(::Type{T}, ::Type{S}, ::Type) =
 ($)(x::Integer, y::Integer) = ($)(promote(x,y)...)
 
 ==(x::Number, y::Number) = (==)(promote(x,y)...)
-< (x::Real, y::Real)     = (< )(promote(x,y)...)
-<=(x::Real, y::Real)     = (<=)(promote(x,y)...)
 
 div(x::Real, y::Real) = div(promote(x,y)...)
 fld(x::Real, y::Real) = fld(promote(x,y)...)
@@ -197,6 +195,7 @@ no_op_err(name, T) = error(name," not defined for ",T)
 ($){T<:Integer}(x::T, y::T) = no_op_err("\$", T)
 
 =={T<:Number}(x::T, y::T) = x === y
+=={T<:Real}(x::T, y::T) = x === y
 <{T<:Real}(x::T, y::T) = no_op_err("<", T)
 
 max{T<:Real}(x::T, y::T) = ifelse(y < x, x, y)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -133,6 +133,8 @@ typemin{T<:Integer}(::Type{Rational{T}}) = -one(T)//zero(T)
 typemax{T<:Integer}(::Type{Rational{T}}) = one(T)//zero(T)
 
 isinteger(x::Rational) = x.den == 1
+isinf(x::Rational) = x.den == 0
+isfinite(x::Rational) = x.den != 0
 
 -(x::Rational) = (-x.num) // x.den
 for op in (:+, :-, :rem, :mod)
@@ -155,23 +157,15 @@ end
 ==(z::Complex , x::Rational) = isreal(z) & (real(z) == x)
 ==(x::Rational, z::Complex ) = isreal(z) & (real(z) == x)
 
-==(x::FloatingPoint, q::Rational) = count_ones(q.den) <= 1 & (x == q.num/q.den) & (x*q.den == q.num)
-==(q::Rational, x::FloatingPoint) = count_ones(q.den) <= 1 & (x == q.num/q.den) & (x*q.den == q.num)
-
-# TODO: fix inequalities to be in line with equality check
 < (x::Rational, y::Rational) = x.den == y.den ? x.num < y.num :
                                widemul(x.num,y.den) < widemul(x.den,y.num)
 < (x::Rational, y::Integer ) = x.num < widemul(x.den,y)
-< (x::Rational, y::Real    ) = x.num < x.den*y
 < (x::Integer , y::Rational) = widemul(x,y.den) < y.num
-< (x::Real    , y::Rational) = x*y.den < y.num
 
 <=(x::Rational, y::Rational) = x.den == y.den ? x.num <= y.num :
                                widemul(x.num,y.den) <= widemul(x.den,y.num)
 <=(x::Rational, y::Integer ) = x.num <= widemul(x.den,y)
-<=(x::Rational, y::Real    ) = x.num <= x.den*y
 <=(x::Integer , y::Rational) = widemul(x,y.den) <= y.num
-<=(x::Real    , y::Rational) = x*y.den <= y.num
 
 div(x::Rational, y::Rational) = div(x.num*y.den, x.den*y.num)
 div(x::Rational, y::Real    ) = div(x.num, x.den*y)

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -13,7 +13,7 @@ vals = [
     integer(maxintfloat(Float32))+(-1:4),
     typemax(Int32),
     int64(maxintfloat(Float64))+Int64[-1:4],
-    typemax(Int64),
+    typemax(Int64), 
 ]
 
 function coerce(T::Type, x)
@@ -32,13 +32,12 @@ function coerce(T::Type, x)
 end
 
 for T=types, S=types, x=vals
+    # println("$T $S $x")
     a = coerce(T,x)
     b = coerce(S,x)
     if (isa(a,Char) && !is_valid_char(a)) || (isa(b,Char) && !is_valid_char(b))
         continue
     end
-    #println("$(typeof(a)) $a")
-    #println("$(typeof(b)) $b")
     @test isequal(a,b) == (hash(a)==hash(b))
     # for y=vals
     #     println("T=$T; S=$S; x=$x; y=$y")
@@ -47,6 +46,20 @@ for T=types, S=types, x=vals
     #     @test !isequal(a,b) || hash(a)==hash(b)
     # end
 end
+
+fvals = {-0.0,0.0,0.5,1e3,-1/3,1/3,sqrt(2f0),sqrt(2.0),float(pi)}
+ftypes = {Float16,Float32,Float64}
+
+for T=ftypes, S=ftypes, x=fvals
+    # println("$T $S $x")
+    a = coerce(T,x)
+    b = coerce(S,x)
+    if (isa(a,Char) && !is_valid_char(a)) || (isa(b,Char) && !is_valid_char(b))
+        continue
+    end
+    @test isequal(a,b) == (hash(a)==hash(b))
+end
+
 
 # hashing collections (e.g. issue #6870)
 vals = {[1,2,3,4], [1 3;2 4], {1,2,3,4}, [1,3,2,4],

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -782,6 +782,16 @@ end
 @test nextfloat(0.0) == 1//(BigInt(2)^1074)
 @test nextfloat(0.0) != 1//(BigInt(2)^1074-1)
 
+@test 1/3 < 1//3
+@test !(1//3 < 1/3)
+@test -1/3 < 1//3
+@test -1/3 > -1//3
+@test 1/3 > -1//3
+@test 1//3 < Inf
+@test 0//1 < Inf
+@test !(1//0 < Inf)
+@test !(1//3 < NaN)
+
 @test sqrt(2) == 1.4142135623730951
 
 @test 1+1.5 == 2.5

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -799,6 +799,11 @@ end
 @test !(1//3 == NaN)
 @test !(1//3 > NaN)
 
+@test float(pi) < pi
+@test !(float(pi) > pi)
+@test float(pi) <= pi
+@test !(float(pi) >= pi)
+@test float(pi) != pi
 
 @test sqrt(2) == 1.4142135623730951
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -787,10 +787,18 @@ end
 @test -1/3 < 1//3
 @test -1/3 > -1//3
 @test 1/3 > -1//3
+@test 1/5 > 1//5
 @test 1//3 < Inf
 @test 0//1 < Inf
+@test 1//0 == Inf
+@test -1//0 == -Inf
+@test -1//0 != Inf
+@test 1//0 != -Inf
 @test !(1//0 < Inf)
 @test !(1//3 < NaN)
+@test !(1//3 == NaN)
+@test !(1//3 > NaN)
+
 
 @test sqrt(2) == 1.4142135623730951
 


### PR DESCRIPTION
This (should) fix `FloatingPoint` vs `Rational` comparisons (mentioned in #2960 and #8411), and should be easily extendable to other binary `Real` types such as [FixedPointNumbers.jl](https://github.com/JeffBezanson/FixedPointNumbers.jl).

It does change the dispatch of comparison operators considerably, so there is a chance that this could break something, or cause a performance regression.
