### PR TITLE
fix #8473

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -21,7 +21,8 @@ function edit(file::String, line::Integer)
     end
     issrc = length(file)>2 && file[end-2:end] == ".jl"
     if issrc
-        file = find_source_file(file)
+        f = find_source_file(file)
+        f != nothing && (file = f)
     end
     if beginswith(edname, "emacs")
         spawn(`$edpath +$line $file`)


### PR DESCRIPTION
[`find_source_file`](https://github.com/JuliaLang/julia/blob/02546dea4ebb51a9b2f0872a3d8b23998a0b2cfd/base/loading.jl#L27) has a `Union(String, Nothing)` return type. In this case, the performance does not matter, but it seems like a pattern that we usually discourage anyway. Any suggestions?
