### PR TITLE
Further Emacs highlighting improvements

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -126,7 +126,7 @@
   (rx "<:" (1+ space) (group (1+ (or word ?_))) (0+ space) (or "\n" "{" "end")))
 
 (defconst julia-macro-regex
-  "@\\w+")
+  (rx symbol-start (group  "@" (1+ (or word ?_ ?!)))))
 
 (defconst julia-keyword-regex
   (regexp-opt

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -113,6 +113,16 @@
       ;; The function name itself
       (group (1+ (or word ?_ ?!)))))
 
+(defconst julia-function-assignment-regex
+  (rx line-start symbol-start
+      (group (1+ (or word ?_ ?!)))
+      (* space)
+      (? "{" (* (not (any "}"))) "}")
+      (* space)
+      "(" (* (not (any ")"))) ")"
+      (* space)
+      "="))
+
 (defconst julia-type-regex
   (rx symbol-start (or "immutable" "type" "abstract") (1+ space) (group (1+ (or word ?_)))))
 
@@ -158,6 +168,7 @@
     (list julia-char-regex 2 'font-lock-string-face)
     (list julia-forloop-in-regex 1 'font-lock-keyword-face)
     (list julia-function-regex 1 'font-lock-function-name-face)
+    (list julia-function-assignment-regex 1 'font-lock-function-name-face)
     (list julia-type-regex 1 'font-lock-type-face)
     (list julia-type-annotation-regex 1 'font-lock-type-face)
     ;;(list julia-type-parameter-regex 1 'font-lock-type-face)


### PR DESCRIPTION
Two simple improvements to Julia's syntax highlighting.

The first fixes #8259, ensuring code like `@swap!(x, y)` is highlighted correctly. Previously, the exclamation mark was not highlighted as part of the macro invocation.

The second commit improves function highlighting. If a function is defined using the terse assignment syntax, e.g. `foo(x, y) = 1`, this is now highlighted as a function definition. It's not perfect, but it handles the vast majority of functions I've tested it on.
