### PR TITLE
WIP: cleanup blas.jl scal!

### DIFF
--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -87,6 +87,7 @@ for (fname, elty) in ((:dscal_,:Float64),
         end
         function scal!(DA::$elty, DX::Union(StridedVector{$elty},Array{$elty}))
             scal!(length(DX), DA, pointer(DX), stride(DX,1))
+            DX
         end
         function scal(DA::$elty, DX::Union(StridedVector{$elty},Array{$elty}))
             scal!(DA,copy(DX))
@@ -111,7 +112,7 @@ for (fname, elty, celty) in ((:sscal_, :Float32, :Complex64),
             DX
         end
         function scal!(DA::$elty, DX::Array{$celty})
-            scal!(length(DX), DA, pointer(DX), stride(DX,1))
+            scal!(length(DX), DA, DX, stride(DX,1))
         end
         function scal(DA::$elty, DX::Array{$celty})
             scal!(DA,copy(DX))

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -103,7 +103,7 @@ for (fname, elty, celty) in ((:sscal_, :Float32, :Complex64),
             # contiguously, sscal and dscal will stride over individual numbers,
             # not pairs of numbers
             if incx != 1
-                throw ArgumentError("scal! requires incx == 1 in case where DA is real and DX is complex")
+                throw(ArgumentError("scal! requires incx == 1 in case where DA is real and DX is complex"))
             end
             ccall(($(string(fname)),libblas), Void,
                   (Ptr{BlasInt}, Ptr{$elty}, Ptr{$celty}, Ptr{BlasInt}),


### PR DESCRIPTION
This pull request addresses the issue discussed in JuliaLang/LinearAlgebra.jl#141.
1. `scal!` is no longer a method for `StridedArray`s
2. helper methods are added for `StridedVector`s
3. an issue with `scal!` when scaling a complex array with a real number is uncovered
   the technique to save flops assumes `incx == 1`
   a check for this is added, however this may not be a desirable solution
4. another solution to issue 3 above is to use 2 calls to the appropriate blas function.  The method could then be extended to `StridedVector`s
