### PR TITLE
Add --ignore-theme-index to skip checking existence of index.theme[gtk-update-icon-cache]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ endif
 	mkdir -p $(DESTDIR)$(datarootdir)/icons/hicolor/scalable/apps/
 	$(INSTALL_F) contrib/julia.svg $(DESTDIR)$(datarootdir)/icons/hicolor/scalable/apps/
 	-touch --no-create $(DESTDIR)$(datarootdir)/icons/hicolor/
-	-gtk-update-icon-cache $(DESTDIR)$(datarootdir)/icons/hicolor/
+	-gtk-update-icon-cache --ignore-theme-index $(DESTDIR)$(datarootdir)/icons/hicolor/
 	mkdir -p $(DESTDIR)$(datarootdir)/applications/
 	$(INSTALL_F) contrib/julia.desktop $(DESTDIR)$(datarootdir)/applications/
 


### PR DESCRIPTION
Relevant Backtrace: http://pastebin.com/zn4Wwkce

See: https://developer.gnome.org/gtk3/stable/gtk-update-icon-cache.html

Tested On: Ubuntu 14.04 x86_64
