### PR TITLE
Allow to pass extra flags to make deps.

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -16,7 +16,8 @@ CONFIGURE_COMMON += F77="$(FC)" CC="$(CC)" CXX="$(CXX)"
 
 # If the top-level Makefile is called with environment variables,
 # they will override the values passed above to ./configure
-MAKE_COMMON = DESTDIR="" prefix=$(build_prefix) bindir=$(build_bindir) libdir=$(build_libdir) libexecdir=$(build_libexecdir) datarootdir=$(build_datarootdir) includedir=$(build_includedir) sysconfdir=$(build_sysconfdir)
+MAKE_DEPS_OPTFLAGS ?= -j1
+MAKE_COMMON = $(MAKE_DEPS_OPTFLAGS) DESTDIR="" prefix=$(build_prefix) bindir=$(build_bindir) libdir=$(build_libdir) libexecdir=$(build_libexecdir) datarootdir=$(build_datarootdir) includedir=$(build_includedir) sysconfdir=$(build_sysconfdir)
 
 #autoconf configure-driven scripts: llvm pcre arpack fftw unwind gmp mpfr patchelf uv
 #custom Makefile rules: openlibm Rmath dsfmt suitesparse-wrapper suitesparse lapack openblas mojibake


### PR DESCRIPTION
I've seen somewhere here that it is recommended to build Julia in single thread, like `make -j1`.
But it means that dependencies will also be built in single thread. With this change, I hope to speed up compilation of dependencies on multi-cpu systems, by setting (according to cpu count) `MAKE_DEPS_OPTFLAGS = -j4` in `Make.user` file. Will that work?
