### PR TITLE
Allow cluster managers to specify specific bind ports

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -176,8 +176,15 @@ function init_bind_addr(args::Vector{UTF8String})
     # --worker, -n and --machinefile options are affected by it
     btoidx = findfirst(args, "--bind-to")
     if btoidx > 0
-        bind_addr = parseip(args[btoidx+1])
+        bind_to = split(args[btoidx+1], ":")
+        bind_addr = parseip(bind_to[1])
+        if length(bind_to) > 1
+            bind_port = parseint(bind_to[2])
+        else
+            bind_port = 0
+        end
     else
+        bind_port = 0
         try
             bind_addr = getipaddr()
         catch
@@ -188,6 +195,7 @@ function init_bind_addr(args::Vector{UTF8String})
     end
     global LPROC
     LPROC.bind_addr = bind_addr
+    LPROC.bind_port = uint16(bind_port)
 end
 
 

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -71,9 +71,10 @@ worker processes, while ``--machinefile file`` will launch a worker
 for each line in file ``file``. The machines defined in ``file`` must be 
 accessible via a passwordless ``ssh`` login, with Julia installed at the
 same location as the current host. Each machine definition takes the form 
-``[user@]host[:port] [bind_addr]`` . ``user`` defaults to current user, 
-``port`` to the standard ssh port. Optionally, in case of multi-homed hosts, 
-``bind_addr`` may be used to explicitly specify an interface.
+``[user@]host[:port] [bind_addr[:port]]`` . ``user`` defaults to current user, 
+``port`` to the standard ssh port. The optional ``bind-to bind_addr[:port]`` 
+specifies the ip-address and port that other workers should use to 
+connect to this worker.
     
     
 If you have code that you want executed whenever julia is run, you can

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -665,7 +665,10 @@ The ``launch`` method takes the following arguments:
                        
 The ``launch`` method is called asynchronously in a separate task. The termination of this task 
 signals that all requested workers have been launched. Hence the ``launch`` function MUST exit as soon 
-as all the requested workers have been launched.
+as all the requested workers have been launched. The julia worker MUST be launched with a ``--worker``
+argument. Optionally ``--bind-to bind_addr[:port]`` may also be specified to enable other workers 
+to connect to it only at the specified ``bind_addr`` and ``port``.
+
 
 Arrays of worker information tuples that are appended to ``resp_arr`` can take any one of 
 the following forms::

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -5061,9 +5061,10 @@ Parallel Computing
    Add processes on remote machines via SSH. 
    Requires julia to be installed in the same location on each node, or to be available via a shared file system.
    
-   ``machines`` is a vector of host definitions of the form ``[user@]host[:port] [bind_addr]``. ``user`` defaults 
-   to current user, ``port`` to the standard ssh port. Optionally, in case of multi-homed hosts, ``bind_addr`` 
-   may be used to explicitly specify an interface.
+   ``machines`` is a vector of host definitions of the form ``[user@]host[:port] [bind_addr[:port]]``. ``user`` defaults 
+   to current user, ``port`` to the standard ssh port. A worker is started at each host definition. 
+   If the optional ``[bind_addr[:port]]`` is specified, other workers will connect to this worker at the 
+   specified ``bind_addr`` and ``port``.
    
    Keyword arguments:
 


### PR DESCRIPTION
This requirement came up in the context of writing a custom cluster manager for https://github.com/JuliaLang/JuliaBox, where we need to specify the port number a worker should listen at. 

The `--bind-to` julia argument has been extended from `bind_addr` to `bind_addr[:port]`  

@tanmaykm , does this work for you?
