### PR TITLE
Avoid half-written sys.o files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,15 +121,19 @@ $(build_private_libdir)/sys%$(SHLIB_EXT): $(build_private_libdir)/sys%o
 
 $(build_private_libdir)/sys0.o:
 	@$(QUIET_JULIA) cd base && \
-	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys0) sysimg.jl
+	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys0-tmp) sysimg.jl
+	mv $(build_private_libdir)/sys0-tmp.ji $(build_private_libdir)/sys0.ji
+	mv $(build_private_libdir)/sys0-tmp.o $(build_private_libdir)/sys0.o
 
 BASE_SRCS := $(wildcard base/*.jl base/*/*.jl base/*/*/*.jl)
 
 $(build_private_libdir)/sys.o: VERSION $(BASE_SRCS) $(build_datarootdir)/julia/helpdb.jl $(build_private_libdir)/sys0.$(SHLIB_EXT)
 	@$(QUIET_JULIA) cd base && \
-	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys) \
+	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys-tmp) \
 		-J$(call cygpath_w,$(build_private_libdir))/$$([ -e $(build_private_libdir)/sys.ji ] && echo sys.ji || echo sys0.ji) -f sysimg.jl \
 		|| (echo "*** This error is usually fixed by running 'make clean'. If the error persists, try 'make cleanall'. ***" && false)
+	mv $(build_private_libdir)/sys-tmp.ji $(build_private_libdir)/sys.ji
+	mv $(build_private_libdir)/sys-tmp.o $(build_private_libdir)/sys.o
 
 run-julia-debug run-julia-release: run-julia-%:
 	$(MAKE) $(QUIET_MAKE) run-julia JULIA_EXECUTABLE="$(JULIA_EXECUTABLE_$*)"

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,8 @@ endif
 # use sys.ji if it exists, otherwise run two stages
 $(build_private_libdir)/sys%ji: $(build_private_libdir)/sys%o
 
-.PRECIOUS: $(build_private_libdir)/sys%o
+.SECONDARY: $(build_private_libdir)/sys.o
+.SECONDARY: $(build_private_libdir)/sys0.o
 
 $(build_private_libdir)/sys%$(SHLIB_EXT): $(build_private_libdir)/sys%o
 	$(CXX) -shared -fPIC -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -o $@ $< \
@@ -121,19 +122,15 @@ $(build_private_libdir)/sys%$(SHLIB_EXT): $(build_private_libdir)/sys%o
 
 $(build_private_libdir)/sys0.o:
 	@$(QUIET_JULIA) cd base && \
-	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys0-tmp) sysimg.jl
-	mv $(build_private_libdir)/sys0-tmp.ji $(build_private_libdir)/sys0.ji
-	mv $(build_private_libdir)/sys0-tmp.o $(build_private_libdir)/sys0.o
+	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys0) sysimg.jl
 
 BASE_SRCS := $(wildcard base/*.jl base/*/*.jl base/*/*/*.jl)
 
 $(build_private_libdir)/sys.o: VERSION $(BASE_SRCS) $(build_datarootdir)/julia/helpdb.jl $(build_private_libdir)/sys0.$(SHLIB_EXT)
 	@$(QUIET_JULIA) cd base && \
-	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys-tmp) \
+	$(call spawn,$(JULIA_EXECUTABLE)) --build $(call cygpath_w,$(build_private_libdir)/sys) \
 		-J$(call cygpath_w,$(build_private_libdir))/$$([ -e $(build_private_libdir)/sys.ji ] && echo sys.ji || echo sys0.ji) -f sysimg.jl \
 		|| (echo "*** This error is usually fixed by running 'make clean'. If the error persists, try 'make cleanall'. ***" && false)
-	mv $(build_private_libdir)/sys-tmp.ji $(build_private_libdir)/sys.ji
-	mv $(build_private_libdir)/sys-tmp.o $(build_private_libdir)/sys.o
 
 run-julia-debug run-julia-release: run-julia-%:
 	$(MAKE) $(QUIET_MAKE) run-julia JULIA_EXECUTABLE="$(JULIA_EXECUTABLE_$*)"


### PR DESCRIPTION
If make is interrupted while generating sys.o (and this step takes a long time), then an empty sys.o file may be left. If make is then re-run, it will not attempt to re-generate sys.o, requiring a "make clean".
