### PR TITLE
Handle character ranges starting at '\x00'

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -62,7 +62,7 @@ immutable UnitRange{T<:Real} <: OrdinalRange{T,Int}
     start::T
     stop::T
 
-    UnitRange(start, stop) = new(start, ifelse(stop >= start, stop, start-1))
+    UnitRange(start, stop) = new(start, stop >= start ? stop : start-1)
 end
 UnitRange{T<:Real}(start::T, stop::T) = UnitRange{T}(start, stop)
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -62,7 +62,8 @@ immutable UnitRange{T<:Real} <: OrdinalRange{T,Int}
     start::T
     stop::T
 
-    UnitRange(start, stop) = new(start, stop >= start ? stop : start-1)
+    UnitRange(start, stop) = new(start,
+                                 stop >= start ? stop : convert(T, start-true))
 end
 UnitRange{T<:Real}(start::T, stop::T) = UnitRange{T}(start, stop)
 


### PR DESCRIPTION
Do not calculate start-1 unless needed; start-1 may not be well-defined.
