### PR TITLE
Fix character ranges starting at '\0'

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -27,10 +27,10 @@ promote_rule(::Type{Char}, ::Type{Uint128}) = Uint128
 +(x::Char   , y::Char   ) = int(x)+int(y)
 
 # ordinal operations
-+(x::Char   , y::Integer) = char(int(x)+int(y))
++(x::Char   , y::Integer) = char(itrunc(Uint32, int(x)+int(y)))
 +(x::Integer, y::Char   ) = y+x
 -(x::Char   , y::Char   ) = int(x)-int(y)
--(x::Char   , y::Integer) = char(int(x)-int(y))
+-(x::Char   , y::Integer) = char(itrunc(Uint32, int(x)-int(y)))
 
 # bitwise operations
 (~)(x::Char) = char(~uint32(x))

--- a/base/range.jl
+++ b/base/range.jl
@@ -62,7 +62,7 @@ immutable UnitRange{T<:Real} <: OrdinalRange{T,Int}
     start::T
     stop::T
 
-    UnitRange(start, stop) = new(start, ifelse(stop >= start, stop, start-1))
+    UnitRange(start, stop) = new(start, ifelse(stop >= start, stop, convert(T, start-true)))
 end
 UnitRange{T<:Real}(start::T, stop::T) = UnitRange{T}(start, stop)
 

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1241,3 +1241,7 @@ end
 @test isalpha("23435")==false
 @test iscntrl( string(char(0x0080))) == true
 @test ispunct( "‡؟჻") ==true
+
+# This caused JuliaLang/JSON.jl#82
+@test first('\x00':'\x7f') === '\x00'
+@test last('\x00':'\x7f') === '\x7f'


### PR DESCRIPTION
Also fix type stability issue in UnitRange constructor for small types
