### PR TITLE
Fix the itruncalypse

### DIFF
--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -157,7 +157,7 @@ hash(x::Float16, h::Uint) = hash(float64(x), h)
 ## hashing collections ##
 const hashaa_seed = Uint === Uint64 ? 0x7f53e68ceb575e76 : 0xeb575e76
 function hash(a::AbstractArray, h::Uint)
-    h += uint(hashaa_seed)
+    h += hashaa_seed
     h += hash(size(a))
     for x in a
         h = hash(x, h)
@@ -167,7 +167,7 @@ end
 
 const hasha_seed = Uint === Uint64 ? 0x6d35bb51952d5539 : 0x952d5539
 function hash(a::Associative, h::Uint)
-    h += uint(hasha_seed)
+    h += hasha_seed
     for (k,v) in a
         h $= hash(k, hash(v))
     end
@@ -176,7 +176,7 @@ end
 
 const hashs_seed = Uint === Uint64 ? 0x852ada37cfe8e0ce : 0xcfe8e0ce
 function hash(s::Set, h::Uint)
-    h += uint(hashs_seed)
+    h += hashs_seed
     for x in s
         h $= hash(x)
     end
@@ -185,7 +185,7 @@ end
 
 const hashis_seed = Uint === Uint64 ? 0x88989f1fc7dea67d : 0xc7dea67d
 function hash(s::IntSet, h::Uint)
-    h += uint(hashis_seed)
+    h += hashis_seed
     h += hash(s.fill1s)
     filln = s.fill1s ? ~zero(eltype(s.bits)) : zero(eltype(s.bits))
     for x in s.bits
@@ -199,7 +199,7 @@ end
 # hashing ranges by component at worst leads to collisions for very similar ranges
 const hashr_seed = Uint === Uint64 ? 0x80707b6821b70087 : 0x21b70087
 function hash(r::Range, h::Uint)
-    h += uint(hashr_seed)
+    h += hashr_seed
     h = hash(first(r), h)
     h = hash(step(r), h)
     h = hash(last(r), h)

--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -155,9 +155,9 @@ end
 hash(x::Float16, h::Uint) = hash(float64(x), h)
 
 ## hashing collections ##
-
+const hashaa_seed = Uint === Uint64 ? 0x7f53e68ceb575e76 : 0xeb575e76
 function hash(a::AbstractArray, h::Uint)
-    h += uint(0x7f53e68ceb575e76)
+    h += uint(hashaa_seed)
     h += hash(size(a))
     for x in a
         h = hash(x, h)
@@ -165,22 +165,25 @@ function hash(a::AbstractArray, h::Uint)
     return h
 end
 
+const hasha_seed = Uint === Uint64 ? 0x6d35bb51952d5539 : 0x952d5539
 function hash(a::Associative, h::Uint)
-    h += uint(0x6d35bb51952d5539)
+    h += uint(hasha_seed)
     for (k,v) in a
         h $= hash(k, hash(v))
     end
     return h
 end
 
+const hashs_seed = Uint === Uint64 ? 0x852ada37cfe8e0ce : 0xcfe8e0ce
 function hash(s::Set, h::Uint)
-    h += uint(0x852ada37cfe8e0ce)
+    h += uint(hashs_seed)
     for x in s
         h $= hash(x)
     end
     return h
 end
 
+const hashis_seed = Uint === Uint64 ? 0x88989f1fc7dea67d : 0xc7dea67d
 function hash(s::IntSet, h::Uint)
     h += uint(0x88989f1fc7dea67d)
     h += hash(s.fill1s)
@@ -194,8 +197,9 @@ function hash(s::IntSet, h::Uint)
 end
 
 # hashing ranges by component at worst leads to collisions for very similar ranges
+const hashr_seed = Uint === Uint64 ? 0x80707b6821b70087 : 0x21b70087
 function hash(r::Range, h::Uint)
-    h += uint(0x80707b6821b70087)
+    h += uint(hashr_seed)
     h = hash(first(r), h)
     h = hash(step(r), h)
     h = hash(last(r), h)

--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -185,7 +185,7 @@ end
 
 const hashis_seed = Uint === Uint64 ? 0x88989f1fc7dea67d : 0xc7dea67d
 function hash(s::IntSet, h::Uint)
-    h += uint(0x88989f1fc7dea67d)
+    h += uint(hashis_seed)
     h += hash(s.fill1s)
     filln = s.fill1s ? ~zero(eltype(s.bits)) : zero(eltype(s.bits))
     for x in s.bits

--- a/base/int.jl
+++ b/base/int.jl
@@ -427,8 +427,8 @@ if WORD_SIZE==32
     end
 
     function *(u::Uint128, v::Uint128)
-        u0 = uint64(u); u1 = uint64(u>>>64)
-        v0 = uint64(v); v1 = uint64(v>>>64)
+        u0 = itrunc(Uint64,u); u1 = uint64(u>>>64)
+        v0 = itrunc(Uint64,v); v1 = uint64(v>>>64)
         lolo = widemul(u0, v0)
         lohi = widemul(u0, v1)
         hilo = widemul(u1, v0)

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -41,10 +41,12 @@ end
 
 =={S, T}(x::Nullable{S}, y::Nullable{T}) = throw(NullException())
 
+const nullablehash_seed = Uint === Uint64 ? 0x932e0143e51d0171 : 0xe51d0171
+
 function hash(x::Nullable, h::Uint)
     if x.isnull
-        return h + uint(0x932e0143e51d0171)
+        return h + uint(nullablehash_seed)
     else
-        return hash(x.value, h + uint(0x932e0143e51d0171))
+        return hash(x.value, h + uint(nullablehash_seed))
     end
 end

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -45,8 +45,8 @@ const nullablehash_seed = Uint === Uint64 ? 0x932e0143e51d0171 : 0xe51d0171
 
 function hash(x::Nullable, h::Uint)
     if x.isnull
-        return h + uint(nullablehash_seed)
+        return h + nullablehash_seed
     else
-        return hash(x.value, h + uint(nullablehash_seed))
+        return hash(x.value, h + nullablehash_seed)
     end
 end

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -14,7 +14,7 @@ type Regex
 
     function Regex(pattern::String, options::Integer)
         pattern = bytestring(pattern)
-        options = uint32(options)
+        options = int32(options)
         if (options & ~PCRE.OPTIONS_MASK) != 0
             error("invalid regex options: $options")
         end

--- a/base/string.jl
+++ b/base/string.jl
@@ -658,9 +658,16 @@ isascii(s::SubString{ASCIIString}) = true
 
 const memhash = Uint == Uint64 ? :memhash_seed : :memhash32_seed
 
-function hash{T<:ByteString}(s::Union(T,SubString{T}), h::Uint)
-    h += uint(0x71e729fd56419c81)
-    ccall(memhash, Uint, (Ptr{Uint8}, Csize_t, Uint32), s, sizeof(s), itrunc(Uint32,h)) + h
+if Uint === Uint64
+    function hash{T<:ByteString}(s::Union(T,SubString{T}), h::Uint)
+        h += uint(0x71e729fd56419c81)
+        ccall(memhash, Uint, (Ptr{Uint8}, Csize_t, Uint32), s, sizeof(s), itrunc(Uint32,h)) + h
+    end
+else
+    function hash{T<:ByteString}(s::Union(T,SubString{T}), h::Uint)
+        h += uint(0x56419c81)
+        ccall(memhash, Uint, (Ptr{Uint8}, Csize_t, Uint32), s, sizeof(s), itrunc(Uint32,h)) + h
+    end
 end
 hash(s::String, h::Uint) = hash(bytestring(s), h)
 

--- a/base/string.jl
+++ b/base/string.jl
@@ -656,18 +656,12 @@ isascii(s::SubString{ASCIIString}) = true
 
 ## hashing strings ##
 
-const memhash = Uint == Uint64 ? :memhash_seed : :memhash32_seed
+const memhash = Uint === Uint64 ? :memhash_seed : :memhash32_seed
+const memhash_seed = Uint === Uint64 ? 0x71e729fd56419c81 : 0x56419c81
 
-if Uint === Uint64
-    function hash{T<:ByteString}(s::Union(T,SubString{T}), h::Uint)
-        h += uint(0x71e729fd56419c81)
-        ccall(memhash, Uint, (Ptr{Uint8}, Csize_t, Uint32), s, sizeof(s), itrunc(Uint32,h)) + h
-    end
-else
-    function hash{T<:ByteString}(s::Union(T,SubString{T}), h::Uint)
-        h += uint(0x56419c81)
-        ccall(memhash, Uint, (Ptr{Uint8}, Csize_t, Uint32), s, sizeof(s), itrunc(Uint32,h)) + h
-    end
+function hash{T<:ByteString}(s::Union(T,SubString{T}), h::Uint)
+    h += uint(memhash_seed)
+    ccall(memhash, Uint, (Ptr{Uint8}, Csize_t, Uint32), s, sizeof(s), itrunc(Uint32,h)) + h
 end
 hash(s::String, h::Uint) = hash(bytestring(s), h)
 

--- a/base/string.jl
+++ b/base/string.jl
@@ -660,7 +660,7 @@ const memhash = Uint === Uint64 ? :memhash_seed : :memhash32_seed
 const memhash_seed = Uint === Uint64 ? 0x71e729fd56419c81 : 0x56419c81
 
 function hash{T<:ByteString}(s::Union(T,SubString{T}), h::Uint)
-    h += uint(memhash_seed)
+    h += memhash_seed
     ccall(memhash, Uint, (Ptr{Uint8}, Csize_t, Uint32), s, sizeof(s), itrunc(Uint32,h)) + h
 end
 hash(s::String, h::Uint) = hash(bytestring(s), h)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -86,7 +86,8 @@ function ==(t1::Tuple, t2::Tuple)
     return true
 end
 
-hash(::(), h::Uint) = h + uint(0x77cfa1eef01bca90)
+const tuplehash_seed = Uint === Uint64 ? 0x77cfa1eef01bca90 : 0xf01bca90
+hash(::(), h::Uint) = h + uint(tuplehash_seed)
 hash(x::(Any,), h::Uint)    = hash(x[1], hash((), h))
 hash(x::(Any,Any), h::Uint) = hash(x[1], hash(x[2], hash((), h)))
 hash(x::Tuple, h::Uint)     = hash(x[1], hash(x[2], hash(tupletail(x), h)))

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -87,7 +87,7 @@ function ==(t1::Tuple, t2::Tuple)
 end
 
 const tuplehash_seed = Uint === Uint64 ? 0x77cfa1eef01bca90 : 0xf01bca90
-hash(::(), h::Uint) = h + uint(tuplehash_seed)
+hash(::(), h::Uint) = h + tuplehash_seed
 hash(x::(Any,), h::Uint)    = hash(x[1], hash((), h))
 hash(x::(Any,Any), h::Uint) = hash(x[1], hash(x[2], hash((), h)))
 hash(x::Tuple, h::Uint)     = hash(x[1], hash(x[2], hash(tupletail(x), h)))


### PR DESCRIPTION
I have to give credit to @nolta for a name that has kept me smiling all afternoon.

This tries to excise all mention in Base of `uint(LITERAL)` where `LITERAL` is 64 bits wide.  This builds on my 32-bit VM, but I'd like a human eye to go over this and make sure I'm not doing anything horrendously stupid here.
