### PR TITLE
Delete using find instead of piping to xargs rm.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -44,7 +44,7 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 	# We also need to remove .pyc files
-	-find . -name *.pyc | xargs rm
+	-find . -name *.pyc -delete
 
 cleanall: clean
 


### PR DESCRIPTION
This fixes an issue where the `clean` target would fail when no files have to be deleted:

```
# We also need to remove .pyc files
find . -name *.pyc | xargs rm
rm: missing operand
```
