### PR TITLE
Delete unnecessary allocation in empty!(::Dict)

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -457,8 +457,6 @@ end
 function empty!{K,V}(h::Dict{K,V})
     fill!(h.slots, 0x0)
     sz = length(h.slots)
-    h.keys = Array(K, sz)
-    h.vals = Array(V, sz)
     h.ndel = 0
     h.count = 0
     return h


### PR DESCRIPTION
I don't know the internal `Dict` code well, but AFAICT these allocations are completely unnecessary---if `slot[i]` is 0, it doesn't seem to matter what's in `keys[i]` or `vals[i]`.

I have an application where these accounted for 90% of the runtime, hence my interest in eliminating them. If desired, I can backport to 0.3.
