### PR TITLE
deepcopy: recurse through immutable objects with mutable fields.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,8 +55,9 @@ Library improvements
 
   * New `Nullable` type for missing data ([#8152]).
 
-  * New ordschur and ordschur! functions for sorting a schur factorization by the eigenvalues
+  * New `ordschur` and `ordschur!` functions for sorting a schur factorization by the eigenvalues.
 
+  * `deepcopy` recurses through immutable types and makes copies of their mutable fields ([#8560]).
 
 Julia v0.3.0 Release Notes
 ==========================

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -27,19 +27,22 @@ function deepcopy_internal(x, stackdict::ObjectIdDict)
 end
 
 function _deepcopy_t(x, T::DataType, stackdict::ObjectIdDict)
-    if T.names===() || !T.mutable
-        return x
-    end
-    ret = ccall(:jl_new_struct_uninit, Any, (Any,), T)
-    stackdict[x] = ret
-    for i in 1:length(T.names)
-        if isdefined(x,i)
-            ret.(i) = deepcopy_internal(x.(i), stackdict)
+    isempty(T.names) && return x
+    if T.mutable
+        y = ccall(:jl_new_struct_uninit, Any, (Any,), T)
+        stackdict[x] = y
+        for i in 1:length(T.names)
+            if isdefined(x,i)
+                y.(i) = deepcopy_internal(x.(i), stackdict)
+            end
         end
+    else
+        fields = Any[deepcopy_internal(x.(i), stackdict) for i in 1:length(T.names)]
+        y = ccall(:jl_new_structv, Any, (Any, Ptr{Void}, Uint32),
+                  T, pointer(fields), length(fields))
     end
-    return ret
+    return y::T
 end
-
 
 function deepcopy_internal(x::Array, stackdict::ObjectIdDict)
     if haskey(stackdict, x)

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -27,7 +27,7 @@ function deepcopy_internal(x, stackdict::ObjectIdDict)
 end
 
 function _deepcopy_t(x, T::DataType, stackdict::ObjectIdDict)
-    isempty(T.names) && return x
+    isbits(T) | isempty(T.names) && return x
     if T.mutable
         y = ccall(:jl_new_struct_uninit, Any, (Any,), T)
         stackdict[x] = y

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -219,7 +219,7 @@ All Objects
 
 .. function:: deepcopy(x)
 
-   Create a deep copy of ``x``: everything is copied recursively, resulting in a fully independent object. For example, deep-copying an array produces a new array whose elements are deep-copies of the original elements.
+   Create a deep copy of ``x``: everything is copied recursively, resulting in a fully independent object. For example, deep-copying an array produces a new array whose elements are deep copies of the original elements. Calling `deepcopy` on an object should generally have the same effect as serializing and then deserializing it.
 
    As a special case, functions can only be actually deep-copied if they are anonymous, otherwise they are just copied. The difference is only relevant in the case of closures, i.e. functions which may contain hidden internal references.
 


### PR DESCRIPTION
I've encountered a number of cases which have caused me to believe that recursing through immutable types with mutable fields is the right thing to do. One example (currently broken on master), is OrderedDict [1] from DataStructures – this type is a lightweight, immutable wrapper around HashDict [2], which is mutable. The current deepcopy behavior means that doing `od2 = deepcopy(od1)` simply returns `od1`, which is clearly not what is wanted. This could be fixed in the DataStructures package, but I suspect wanting to copy through immutables is the rule, not the exception.

Philosophically, the only coherent way to define at a conceptual level what deepcopy _should_ do that I've come up with is that it should be functionally equivalent to serializing and then deserializing an object. That would recursively copy through immutable types with mutable fields, which is another justification for this change.

I _believe_ that not sticking immutable objects in `stackdict` is correct, but I'm not 100% sure. My reasoning is that in order for a path from the root of a data structure to have a loop, it has to have passed through a mutable object since otherwise you couldn't have constructed the structure in the first place (unless you cheated, in which case you have only yourself to blame), at which point the deepcopy recursion will stop once that mutable object is reached a second time. There may be some unnecessary copying of immutable objects, but I think it's harmless.

[1] https://github.com/JuliaLang/DataStructures.jl/blob/master/src/ordereddict.jl
[2] https://github.com/JuliaLang/DataStructures.jl/blob/master/src/hashdict.jl
