### PR TITLE
Make names method deterministic

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -24,7 +24,7 @@ function fullname(m::Module)
     end
 end
 
-names(m::Module, all::Bool, imported::Bool) = ccall(:jl_module_names, Array{Symbol,1}, (Any,Int32,Int32), m, all, imported)
+names(m::Module, all::Bool, imported::Bool) = sort(ccall(:jl_module_names, Array{Symbol,1}, (Any,Int32,Int32), m, all, imported))
 names(m::Module, all::Bool) = names(m, all, false)
 names(m::Module) = names(m, false, false)
 names(t::DataType) = collect(t.names)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -24,7 +24,7 @@ function fullname(m::Module)
     end
 end
 
-names(m::Module, all::Bool, imported::Bool) = sort(ccall(:jl_module_names, Array{Symbol,1}, (Any,Int32,Int32), m, all, imported))
+names(m::Module, all::Bool, imported::Bool) = sort!(ccall(:jl_module_names, Array{Symbol,1}, (Any,Int32,Int32), m, all, imported))
 names(m::Module, all::Bool) = names(m, all, false)
 names(m::Module) = names(m, false, false)
 names(t::DataType) = collect(t.names)


### PR DESCRIPTION
`names(Base)` returns methods in the same order within on invocation of Julia, but in a different order on different invocations. As far as I can tell, this is due to address space randomization; this goes away if I run inside `gdb`, which disables address space randomization.

The obvious argument against this is that this has a performance penalty and that people can call `sort` if they want a sorted list.

My argument for this is that non-determinism in a single threaded application tends to be surprising, and it should be removed where possible if there isn't a compelling reason. My guess is that `names(Base)` is not in the critical path of much code.

At the moment, there are two julia bugs (bugs in julia itself, not in my julia code) that I've been putting off debugging because they're non-deterministic and I'm pretty sure they'll be hard to track down. One is a segfault and the other seems to be a memory leak or something like one. In one case, In one case, I was eventually able to get a reproducibly failing test case that fails after maybe 5 minutes of execution, but it seems like it will be obnoxious to shrink the failing test down, and in the other case I haven't been able to get a reproducibly failing case at all.

It's not that I think this is related. I'm fairly certain it's not. But it's conceivable that this could, somehow, cause some otherwise simple fix bug to became hard to track down, the same way some piece of non-determinism is making the two bugs mentioned above difficult.
