### PR TITLE
Add a Makefile setting for buildign with ccache.

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -298,6 +298,19 @@ DEBUGFLAGS = -O0 -g -DJL_DEBUG_BUILD -fstack-protector-all
 SHIPFLAGS = -O3 -g -falign-functions
 endif
 
+ifeq ($(USECCACHE), 1)
+CC := ccache $(CC)
+CXX := ccache $(CXX)
+ifeq ($(USECLANG),1)
+# ccache and Clang don't do well together
+# http://petereisentraut.blogspot.be/2011/05/ccache-and-clang.html
+CC += -Qunused-arguments -fcolor-diagnostics
+CXX += -Qunused-arguments -fcolor-diagnostics
+# http://petereisentraut.blogspot.be/2011/09/ccache-and-clang-part-2.html
+export CCACHE_CPP2 := yes
+endif
+endif
+
 ifeq ($(LLVM_VER),svn)
 JCXXFLAGS += -std=c++11
 endif


### PR DESCRIPTION
This greatly speeds up the build when frequently rebuilding from scratch
(e.g. in case of a buildbot). Some hacks are added for using ccache in
combination with Clang.

Some numbers (on high-end consumer hardware):

```
Build type: distcleanall -> make julia-debug
Including all deps (without download), built using Clang, LLVM+Debug+Assertions

Initial ccache build:
real    12m51.734s
user    81m21.656s
sys     5m34.256s

Subsequent full rebuilds:
real    3m59.535s
user    18m12.236s
sys     1m28.120s
```
