### PR TITLE
Avoid attempting to poll on non-existent file

### DIFF
--- a/base/poll.jl
+++ b/base/poll.jl
@@ -306,6 +306,10 @@ function poll_fd(s, seconds::Real; readable=false, writable=false)
 end
 
 function poll_file(s, interval_seconds::Real, seconds::Real)
+    if !isfile(s)
+        throw(ErrorException("No such file or directory $s"))
+    end
+
     wt = Condition()
     pfw = PollingFileWatcher(s)
 


### PR DESCRIPTION
`poll_file` doesn't work if you poll on a file that doesn't exist. Even if you create the named file before the timeout and modify it, `poll_file` will wait until the timeout and then return false.

This will probably fail the travis build because the [build has been broken for half a day](https://travis-ci.org/JuliaLang/julia/builds/36942408).
