### PR TITLE
fix #8584 ((0:1//2:2)[1:2:3] was failing)

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -85,7 +85,7 @@ colon{T<:Real}(start::T, step, stop::T) = StepRange(start, step, stop)
 
 colon{T}(start::T, step, stop::T) = StepRange(start, step, stop)
 
-range{T,S}(a::T, step::S, len::Integer) = StepRange{T,S}(a, step, a+step*(len-1))
+range{T,S}(a::T, step::S, len::Integer) = StepRange{T,S}(a, step, convert(T, a+step*(len-1)))
 
 ## floating point ranges
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -372,3 +372,6 @@ let smallint = (Int === Int64 ?
         @test length(typemin(T):typemax(T)) == 2^(8*sizeof(T))
     end
 end
+
+# issue #8584
+@test (0:1//2:2)[1:2:3] == 0:1//1:1


### PR DESCRIPTION
I'm not sure if this is a comprehensive enough fix.
