### PR TITLE
deprecated syntax in 0.3 now raises an error in 0.4

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -668,8 +668,8 @@
 			ex)
 		 (let ((argument
 			(cond ((closing-token? (peek-token s))
-			       (syntax-deprecation-warning s "x[i:]" "x[i:end]")
-			       ':)  ; missing last argument
+			       (error  (string "missing last argument in \"" 
+					       (deparse ex) ":\" range expression ")))
 			      ((newline? (peek-token s))
 			       (error "line break in \":\" expression"))
 			      (else


### PR DESCRIPTION
Example output

``` julia
julia> a = rand(10,10);

julia> a[1:]
ERROR: syntax: missing last argument in "1:" range expression

julia> a[1:2:]
ERROR: syntax: missing last argument in "1:2:" range expression

julia> a[(1+1):]
ERROR: syntax: missing last argument in "+(1,1):" range expression
```
