### PR TITLE
remove bigfloat dependence from rationalize

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -68,54 +68,46 @@ function rationalize{T<:Integer}(::Type{T}, x::FloatingPoint; tol::Real=eps(x))
     tol < 0 && throw(ArgumentError("negative tolerance"))
     isnan(x) && return zero(T)//zero(T)
     isinf(x) && return (x < 0 ? -one(T) : one(T))//zero(T)
-    y = widen(x)
-    a::T = d::T = 1
-    b::T = c::T = 0
-    ok(r,s) = abs(oftype(x,r)/oftype(x,s) - x) <= tol
-    local n
-    const max_n = 1000
-    for n = 0:max_n
-        local f::T, p::T, q::T
+
+    p,  q  = (x < 0 ? -one(T) : one(T)), zero(T)
+    pp, qq = zero(T), one(T)
+
+    x = abs(x)
+    a = trunc(x)
+    r = x-a
+    y = one(x)
+
+    nt, t, tt = tol, zero(tol), zero(tol)
+
+    while r > nt
         try
-            f = itrunc(T,y)
-            abs(y - f) < 1 || throw(InexactError()) # XXX: remove when #3040 is fixed
+            ia = convert(T,a)
+            p, pp = checked_add(checked_mul(ia,p),pp), p
+            q, qq = checked_add(checked_mul(ia,q),qq), q
         catch e
-            isa(e,InexactError) || rethrow(e)
-            n == 0 && return (x < 0 ? -one(T) : one(T))//zero(T)
-            break
+            isa(e,InexactError) || isa(e,OverflowError) || rethrow(e)
+            return p // q
         end
-        y -= f
-        try
-            p = checked_add(checked_mul(f,a), c)
-            q = checked_add(checked_mul(f,b), d)
-        catch e
-            isa(e,OverflowError) || rethrow(e)
-            break
-        end
-        if y == 0 || ok(p, q)
-            if n > 0 && f > 1
-                # check semi-convergents
-                u::T, v::T = iceil(T,f/2), f
-                p, q = u*a+c, u*b+d
-                ok(p, q) && return p//q
-                while u + 1 < v
-                    m = div(u+v, 2)
-                    p, q = m*a+c, m*b+d
-                    if ok(p, q)
-                        v = m
-                    else
-                        u = m
-                    end
-                end
-                p, q = v*a+c, v*b+d
-            end
-            return p//q
-        end
-        a, b, c, d = p, q, a, b
-        y = inv(y)
+
+        t, tt = nt, t
+        x, y = y, r
+
+        a, r = divrem(x,y)
+        nt = a*t + tt
     end
-    @assert n < max_n
-    return a//b
+
+    # find optimal semiconvergent
+    # smallest a such that x-a*y < a*t+tt
+    a = cld(x-tt,y+t)
+    try
+        ia = convert(T,a)
+        p = checked_add(checked_mul(ia,p),pp)
+        q = checked_add(checked_mul(ia,q),qq)
+        return p // q
+    catch e
+        isa(e,InexactError) || isa(e,OverflowError) || rethrow(e)
+        return p // q
+    end
 end
 rationalize(x::FloatingPoint; kvs...) = rationalize(Int, x; kvs...)
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -82,8 +82,10 @@ function rationalize{T<:Integer}(::Type{T}, x::FloatingPoint; tol::Real=eps(x))
     while r > nt
         try
             ia = convert(T,a)
-            p, pp = checked_add(checked_mul(ia,p),pp), p
-            q, qq = checked_add(checked_mul(ia,q),qq), q
+            np = checked_add(checked_mul(ia,p),pp)
+            nq = checked_add(checked_mul(ia,q),qq)
+            p, pp = np, p
+            q, qq = nq, q
         catch e
             isa(e,InexactError) || isa(e,OverflowError) || rethrow(e)
             return p // q
@@ -101,9 +103,9 @@ function rationalize{T<:Integer}(::Type{T}, x::FloatingPoint; tol::Real=eps(x))
     a = cld(x-tt,y+t)
     try
         ia = convert(T,a)
-        p = checked_add(checked_mul(ia,p),pp)
-        q = checked_add(checked_mul(ia,q),qq)
-        return p // q
+        np = checked_add(checked_mul(ia,p),pp)
+        nq = checked_add(checked_mul(ia,q),qq)
+        return np // nq
     catch e
         isa(e,InexactError) || isa(e,OverflowError) || rethrow(e)
         return p // q

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1608,14 +1608,34 @@ approx_eq(a, b) = approx_eq(a, b, 1e-6)
 @test isa(convert(Float64, big(1)//2), Float64)
 
 # issue 5935
-@test rationalize(Int64, nextfloat(0.1)) == 1//10
-@test rationalize(Int128,nextfloat(0.1)) == 1//10
-@test rationalize(BigInt,nextfloat(0.1)) == 1//10
-@test rationalize(BigInt,nextfloat(BigFloat("0.1"))) == 1//10
-@test rationalize(Int64, nextfloat(0.1),tol=0) == 379250494936463//3792504949364629
-@test rationalize(Int128,nextfloat(0.1),tol=0) == 379250494936463//3792504949364629
-@test rationalize(BigInt,nextfloat(0.1),tol=0) == 379250494936463//3792504949364629
-@test rationalize(BigInt,nextfloat(BigFloat("0.1")),tol=0) == 5449039493520762137579811059232372134271528690147791248915651012137088453645//54490394935207621375798110592323721342715286901477912489156510121370884536449
+@test rationalize(Int8,  nextfloat(0.1)) == 1//10
+@test rationalize(Int64, nextfloat(0.1)) == 300239975158034//3002399751580339
+@test rationalize(Int128,nextfloat(0.1)) == 300239975158034//3002399751580339
+@test rationalize(BigInt,nextfloat(0.1)) == 300239975158034//3002399751580339
+@test rationalize(Int8,  nextfloat(0.1),tol=0.5eps(0.1)) == 1//10
+@test rationalize(Int64, nextfloat(0.1),tol=0.5eps(0.1)) == 379250494936463//3792504949364629
+@test rationalize(Int128,nextfloat(0.1),tol=0.5eps(0.1)) == 379250494936463//3792504949364629
+@test rationalize(BigInt,nextfloat(0.1),tol=0.5eps(0.1)) == 379250494936463//3792504949364629
+@test rationalize(Int8,  nextfloat(0.1),tol=1.5eps(0.1)) == 1//10
+@test rationalize(Int64, nextfloat(0.1),tol=1.5eps(0.1)) == 1//10
+@test rationalize(Int128,nextfloat(0.1),tol=1.5eps(0.1)) == 1//10
+@test rationalize(BigInt,nextfloat(0.1),tol=1.5eps(0.1)) == 1//10
+@test rationalize(BigInt,nextfloat(BigFloat("0.1")),tol=1.5eps(big(0.1))) == 1//10
+@test rationalize(Int64, nextfloat(0.1),tol=0) == 7205759403792795//72057594037927936
+@test rationalize(Int128,nextfloat(0.1),tol=0) == 7205759403792795//72057594037927936
+@test rationalize(BigInt,nextfloat(0.1),tol=0) == 7205759403792795//72057594037927936
+
+@test rationalize(Int8,  prevfloat(0.1)) == 1//10
+@test rationalize(Int64, prevfloat(0.1)) == 1//10
+@test rationalize(Int128,prevfloat(0.1)) == 1//10
+@test rationalize(BigInt,prevfloat(0.1)) == 1//10
+@test rationalize(BigInt,prevfloat(BigFloat("0.1"))) == 1//10
+@test rationalize(Int64, prevfloat(0.1),tol=0) == 7205759403792793//72057594037927936
+@test rationalize(Int128,prevfloat(0.1),tol=0) == 7205759403792793//72057594037927936
+@test rationalize(BigInt,prevfloat(0.1),tol=0) == 7205759403792793//72057594037927936
+
+@test rationalize(BigInt,nextfloat(BigFloat("0.1")),tol=0) == 46316835694926478169428394003475163141307993866256225615783033603165251855975//463168356949264781694283940034751631413079938662562256157830336031652518559744
+
 
 @test rationalize(Int8, 200f0) == 1//0
 @test rationalize(Int8, -200f0) == -1//0


### PR DESCRIPTION
This implements `rationalize` without `widen`ing the argument (e.g. `Float64` to `BigFloat`), and so is a fair bit quicker. 

Also the tolerance parameter is now more precise: it bounds the actual difference between the float and rational (the current behaviour bounds the difference after the rational has been converted to float). Note that this also means that `convert(Rational{T}, x)` will return the exact value if it is representable, e.g.

``` julia
julia> convert(Rational{Int64},0.1)
3602879701896397//36028797018963968

julia> ispow2(ans.den)
true
```

cc: @nolta @StefanKarpinski 
