### PR TITLE
fix indexin for new Dict syntax

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1148,7 +1148,7 @@ indmin(a) = findmin(a)[2]
 # similar to Matlab's ismember
 # returns a vector containing the highest index in b for each value in a that is a member of b
 function indexin(a::AbstractArray, b::AbstractArray)
-    bdict = Dict(b, 1:length(b))
+    bdict = Dict(zip(b, 1:length(b)))
     [get(bdict, i, 0) for i in a]
 end
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -902,3 +902,11 @@ function i7197()
     ind2sub(size(S), 5)
 end
 @test i7197() == (2,2)
+
+# PR #8622 and general indexin test
+function pr8622()
+    x=[1,3,5,7]
+    y=[5,4,3]
+    return indexin(x,y)
+end
+@test pr8622() == [0,3,1,0]


### PR DESCRIPTION
The new Dict syntax broke `indexin`. I think this fix is ok? Should there be a test for this?
