### PR TITLE
Convert profile test to busywait to avoid Travis failures

### DIFF
--- a/test/profile.jl
+++ b/test/profile.jl
@@ -1,4 +1,9 @@
-@profile sleep(0.1)
+function busywait(t)
+    tend = time() + t
+    while time() < tend end
+end
+
+@profile busywait(1)
 let iobuf = IOBuffer()
     Profile.print(iobuf)
     str = takebuf_string(iobuf)


### PR DESCRIPTION
May fix https://github.com/JuliaLang/julia/commit/fbd44636e4647014a588aef60a6b2cca7a2b990c#commitcomment-8088099. This passed both linux and osx. The old failure might have been intermittent, though, so it's hard to say. Still, seems worth merging.
