### PR TITLE
Indentation fixes for julia-mode

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -189,24 +189,10 @@
     (or (equal item (car lst))
 	(julia-member item (cdr lst)))))
 
-(if (not (fboundp 'evenp))
-    (defun evenp (x) (zerop (% x 2))))
-
-(defun julia-find-comment-open (p0)
-  (if (< (point) p0)
-      nil
-    (if (and (equal (char-after (point)) ?#)
-	     (evenp (julia-strcount
-		     (buffer-substring p0 (point)) ?\")))
-	t
-      (if (= (point) p0)
-	  nil
-	(progn (backward-char 1)
-	       (julia-find-comment-open p0))))))
-
 (defun julia-in-comment ()
-  (save-excursion
-    (julia-find-comment-open (line-beginning-position))))
+  "Return non-nil if point is inside a comment.
+Handles both single-line and multi-line comments."
+  (nth 4 (syntax-ppss)))
 
 (defun julia-strcount (str chr)
   (let ((i 0)

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -348,7 +348,7 @@ Do not move back beyond MIN."
 
 (defvar julia-latexsubs (make-hash-table :test 'equal))
 
-(defun julia-latexsub (arg)
+(defun julia-latexsub ()
   "Perform a LaTeX-like Unicode symbol substitution."
   (interactive "*i")
   (let ((orig-pt (point)))
@@ -371,8 +371,8 @@ Do not move back beyond MIN."
 (defun julia-latexsub-or-indent (arg)
   "Either indent according to mode or perform a LaTeX-like symbol substution"
   (interactive "*i")
-  (if (latexsub arg)
-      (indent-according-to-mode)))
+  (if (latexsub)
+      (indent-for-tab-command arg)))
 (define-key julia-mode-map (kbd "TAB") 'julia-latexsub-or-indent)
 
 (defalias 'latexsub-or-indent 'julia-latexsub-or-indent)


### PR DESCRIPTION
The first commit fixes #8538, ensuring we indent correctly on older Emacs versions.

The second commit fixes #8634, where we weren't indenting regions even if a region was highlighted.
