### PR TITLE
doc: clarified use of ellipsis in manual to refer to splice only

### DIFF
--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -54,28 +54,28 @@ Construction and Initialization
 -------------------------------
 
 Many functions for constructing and initializing arrays are provided. In
-the following list of such functions, calls with a ``dims...`` argument
+the following list of such functions, calls with a ``dims,⋯`` argument
 can either take a single tuple of dimension sizes or a series of
 dimension sizes passed as a variable number of arguments.
 
 ===================================== =====================================================================
 Function                              Description
 ===================================== =====================================================================
-``Array(type, dims...)``              an uninitialized dense array
-``cell(dims...)``                     an uninitialized cell array (heterogeneous array)
-``zeros(type, dims...)``              an array of all zeros of specified type, defaults to ``Float64`` if 
+``Array(type, dims,⋯)``              an uninitialized dense array
+``cell(dims,⋯)``                     an uninitialized cell array (heterogeneous array)
+``zeros(type, dims,⋯)``              an array of all zeros of specified type, defaults to ``Float64`` if
                                       ``type`` not specified
 ``zeros(A)``                          an array of all zeros of same element type and shape of ``A``
-``ones(type, dims...)``               an array of all ones of specified type, defaults to ``Float64`` if
+``ones(type, dims,⋯)``               an array of all ones of specified type, defaults to ``Float64`` if
                                       if ``type`` not specified
 ``ones(A)``                           an array of all ones of same element type and shape of ``A``
-``trues(dims...)``                    a ``Bool`` array with all values ``true``
-``falses(dims...)``                   a ``Bool`` array with all values ``false``
-``reshape(A, dims...)``               an array with the same data as the given array, but with
+``trues(dims,⋯)``                    a ``Bool`` array with all values ``true``
+``falses(dims,⋯)``                   a ``Bool`` array with all values ``false``
+``reshape(A, dims,⋯)``               an array with the same data as the given array, but with
                                       different dimensions.
 ``copy(A)``                           copy ``A``
 ``deepcopy(A)``                       copy ``A``, recursively copying its elements
-``similar(A, element_type, dims...)`` an uninitialized array of the same type as the given array
+``similar(A, element_type, dims,⋯)`` an uninitialized array of the same type as the given array
                                       (dense, sparse, etc.), but with the specified element type and
                                       dimensions. The second and third arguments are both optional,
                                       defaulting to the element type and dimensions of ``A`` if omitted.
@@ -103,9 +103,9 @@ functions:
 ================ ======================================================
 Function         Description
 ================ ======================================================
-``cat(k, A...)`` concatenate input n-d arrays along the dimension ``k``
-``vcat(A...)``   shorthand for ``cat(1, A...)``
-``hcat(A...)``   shorthand for ``cat(2, A...)``
+``cat(k, A,⋯)`` concatenate input n-d arrays along the dimension ``k``
+``vcat(A,⋯)``   shorthand for ``cat(1, A,⋯)``
+``hcat(A,⋯)``   shorthand for ``cat(2, A,⋯)``
 ================ ======================================================
 
 Scalar values passed to these functions are treated as 1-element arrays.
@@ -115,9 +115,9 @@ The concatenation functions are used so often that they have special syntax:
 =================== =========
 Expression          Calls
 =================== =========
-``[A B C ...]``     ``hcat``
-``[A, B, C, ...]``  ``vcat``
-``[A B; C D; ...]`` ``hvcat``
+``[A B C ⋯]``      ``hcat``
+``[A, B, C, ⋯]``   ``vcat``
+``[A B; C D; ⋯]``  ``hvcat``
 =================== =========
 
 ``hvcat`` concatenates in both dimension 1 (with semicolons) and dimension 2
@@ -127,7 +127,7 @@ Typed array initializers
 ------------------------
 
 An array with a specific element type can be constructed using the syntax
-``T[A, B, C, ...]``. This will construct a 1-d array with element type
+``T[A, B, C, ⋯]``. This will construct a 1-d array with element type
 ``T``, initialized to contain elements ``A``, ``B``, ``C``, etc.
 
 Special syntax is available for constructing arrays with element type
@@ -136,9 +136,9 @@ Special syntax is available for constructing arrays with element type
 =================== =========
 Expression          Yields
 =================== =========
-``{A B C ...}``     A 1xN ``Any`` array
-``{A, B, C, ...}``  A 1-d ``Any`` array (vector)
-``{A B; C D; ...}`` A 2-d ``Any`` array
+``{A B C ⋯}``     A 1xN ``Any`` array
+``{A, B, C, ⋯}``  A 1-d ``Any`` array (vector)
+``{A B; C D; ⋯}`` A 2-d ``Any`` array
 =================== =========
 
 Note that this form does not do any concatenation; each argument becomes
@@ -153,15 +153,15 @@ Comprehensions provide a general and powerful way to construct arrays.
 Comprehension syntax is similar to set construction notation in
 mathematics::
 
-    A = [ F(x,y,...) for x=rx, y=ry, ... ]
+    A = [ F(x,y,⋯) for x=rx, y=ry, ⋯ ]
 
-The meaning of this form is that ``F(x,y,...)`` is evaluated with the
+The meaning of this form is that ``F(x,y,⋯)`` is evaluated with the
 variables ``x``, ``y``, etc. taking on each value in their given list of
 values. Values can be specified as any iterable object, but will
 commonly be ranges like ``1:n`` or ``2:(n-1)``, or explicit arrays of
 values like ``[1.2, 3.4, 5.7]``. The result is an N-d dense array with
 dimensions that are the concatenation of the dimensions of the variable
-ranges ``rx``, ``ry``, etc. and each ``F(x,y,...)`` evaluation returns a
+ranges ``rx``, ``ry``, etc. and each ``F(x,y,⋯)`` evaluation returns a
 scalar.
 
 The following example computes a weighted average of the current element
@@ -222,7 +222,7 @@ Indexing
 
 The general syntax for indexing into an n-dimensional array A is::
 
-    X = A[I_1, I_2, ..., I_n]
+    X = A[I_1, I_2, ⋯, I_n]
 
 where each I\_k may be:
 
@@ -232,16 +232,16 @@ where each I\_k may be:
 4. A boolean vector
 
 The result X generally has dimensions
-``(length(I_1), length(I_2), ..., length(I_n))``, with location
-``(i_1, i_2, ..., i_n)`` of X containing the value
-``A[I_1[i_1], I_2[i_2], ..., I_n[i_n]]``. Trailing dimensions indexed with
+``(length(I_1), length(I_2), ⋯, length(I_n))``, with location
+``(i_1, i_2, ⋯, i_n)`` of X containing the value
+``A[I_1[i_1], I_2[i_2], ⋯, I_n[i_n]]``. Trailing dimensions indexed with
 scalars are dropped. For example, the dimensions of ``A[I, 1]`` will be
 ``(length(I),)``. Boolean vectors are first transformed with ``find``; the size of
 a dimension indexed by a boolean vector will be the number of true values in the vector.
 
 Indexing syntax is equivalent to a call to ``getindex``::
 
-    X = getindex(A, I_1, I_2, ..., I_n)
+    X = getindex(A, I_1, I_2, ⋯, I_n)
 
 Example:
 
@@ -276,7 +276,7 @@ Assignment
 
 The general syntax for assigning values in an n-dimensional array A is::
 
-    A[I_1, I_2, ..., I_n] = X
+    A[I_1, I_2, ⋯, I_n] = X
 
 where each I\_k may be:
 
@@ -285,9 +285,9 @@ where each I\_k may be:
 3. An arbitrary integer vector, including the empty vector ``[]``
 4. A boolean vector
 
-If ``X`` is an array, its size must be ``(length(I_1), length(I_2), ..., length(I_n))``,
-and the value in location ``i_1, i_2, ..., i_n`` of ``A`` is overwritten with
-the value ``X[I_1[i_1], I_2[i_2], ..., I_n[i_n]]``. If ``X`` is not an array, its
+If ``X`` is an array, its size must be ``(length(I_1), length(I_2), ⋯, length(I_n))``,
+and the value in location ``i_1, i_2, ⋯, i_n`` of ``A`` is overwritten with
+the value ``X[I_1[i_1], I_2[i_2], ⋯, I_n[i_n]]``. If ``X`` is not an array, its
 value is written to all referenced locations of ``A``.
 
 A boolean vector used as an index behaves as in ``getindex`` (it is first transformed
@@ -295,7 +295,7 @@ with ``find``).
 
 Index assignment syntax is equivalent to a call to ``setindex!``::
 
-      setindex!(A, X, I_1, I_2, ..., I_n)
+      setindex!(A, X, I_1, I_2, ⋯, I_n)
 
 Example:
 
@@ -448,7 +448,7 @@ implementations of it might be quite different from conventional
 arrays. For example, elements might be computed on request rather than
 stored.  However, any concrete ``AbstractArray{T,N}`` type should
 generally implement at least ``size(A)`` (returing an ``Int`` tuple),
-``getindex(A,i)`` and ``getindex(A,i1,...,iN)`` (returning an element
+``getindex(A,i)`` and ``getindex(A,i1,⋯,iN)`` (returning an element
 of type ``T``); mutable arrays should also implement ``setindex!``.  It
 is recommended that these operations have nearly constant time complexity,
 or technically Õ(1) complexity, as otherwise some array functions may

--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -403,7 +403,7 @@ A ``(name, library)`` function specification must be a constant expression.
 However, it is possible to use computed values as function names by staging
 through ``eval`` as follows::
 
-    @eval ccall(($(string("a","b")),"lib"), ...
+    @eval ccall(($(string("a","b")),"lib"), ⋯
 
 This expression constructs a name using ``string``, then substitutes this
 name into a new ``ccall`` expression, which is then evaluated. Keep in mind that

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -917,7 +917,7 @@ function <man-anonymous-functions>`. This can be done either
 directly or by use of a convenience macro::
 
     function mytask(myarg)
-        ...
+        ⋮
     end
 
     taskHdl = Task(() -> mytask(7))

--- a/doc/manual/embedding.rst
+++ b/doc/manual/embedding.rst
@@ -50,9 +50,9 @@ Real applications will not just need to execute expressions, but also return the
         printf("sqrt(2.0) in C: %e \n", ret_unboxed);
     }
 
-In order to check whether ``ret`` is of a specific Julia type, we can use the ``jl_is_...`` functions. By typing ``typeof(sqrt(2.0))`` into the Julia shell we can see that the return type is ``Float64`` (``double`` in C). To convert the boxed Julia value into a C double the ``jl_unbox_float64`` function is used in the above code snippet.
+In order to check whether ``ret`` is of a specific Julia type, we can use the ``jl_is_⋯`` functions. By typing ``typeof(sqrt(2.0))`` into the Julia shell we can see that the return type is ``Float64`` (``double`` in C). To convert the boxed Julia value into a C double the ``jl_unbox_float64`` function is used in the above code snippet.
 
-Corresponding ``jl_box_...`` functions are used to convert the other way::
+Corresponding ``jl_box_⋯`` functions are used to convert the other way::
 
     jl_value_t *a = jl_box_float64(3.0);
     jl_value_t *b = jl_box_float32(3.0f);
@@ -97,7 +97,7 @@ Several Julia values can be pushed at once using the ``JL_GC_PUSH2`` , ``JL_GC_P
     JL_GC_PUSHARGS(args, 2); // args can now hold 2 `jl_value_t*` objects
     args[0] = some_value;
     args[1] = some_other_value;
-    // Do something with args (e.g. call jl_... functions)
+    // Do something with args (e.g. call jl_⋯ functions)
     JL_GC_POP();
 
 Manipulating the Garbage Collector
@@ -212,7 +212,7 @@ When writing Julia callable functions, it might be necessary to validate argumen
 General exceptions can be raised using the funtions::
 
     void jl_error(const char *str);
-    void jl_errorf(const char *fmt, ...);
+    void jl_errorf(const char *fmt, ⋯);
 
 ``jl_error`` takes a C string, and ``jl_errorf`` is called like ``printf``::
 

--- a/doc/manual/faq.rst
+++ b/doc/manual/faq.rst
@@ -46,7 +46,7 @@ while developing you might use a workflow something like this::
     obj1 = MyModule.ObjConstructor(a, b) # old objects are no longer valid, must reconstruct
     obj2 = MyModule.somefunction(obj1)   # this time it worked!
     obj3 = MyModule.someotherfunction(obj2, c)
-    ...
+    ⋮
 
 Functions
 ---------
@@ -97,8 +97,8 @@ inside a specific function or set of functions, you have two options:
 1.  Use ``import``::
 
         import Foo
-        function bar(...)
-            ... refer to Foo symbols via Foo.baz ...
+        function bar(⋯)
+            ⋯ refer to Foo symbols via Foo.baz ⋯
         end
 
 
@@ -113,8 +113,8 @@ inside a specific function or set of functions, you have two options:
         module Bar
         export bar
         using Foo
-        function bar(...)
-            ... refer to Foo.baz as simply baz ....
+        function bar(⋯)
+            ⋯ refer to Foo.baz as simply baz ⋯.
         end
         end
         using Bar
@@ -602,10 +602,10 @@ versions of the outer function for different element types of
 ``a``. You could do it like this::
 
     function myfun{T<:FloatingPoint}(c::MySimpleContainer{Vector{T}})
-        ...
+        ⋮
     end
     function myfun{T<:Integer}(c::MySimpleContainer{Vector{T}})
-        ...
+        ⋮
     end
 
 This works fine for ``Vector{T}``, but we'd also have to write

--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -185,9 +185,9 @@ names. These are:
 =================== ==============
 Expression          Calls
 =================== ==============
-``[A B C ...]``     ``hcat``
-``[A, B, C, ...]``  ``vcat``
-``[A B; C D; ...]`` ``hvcat``
+``[A B C ⋯]``     ``hcat``
+``[A, B, C, ⋯]``  ``vcat``
+``[A B; C D; ⋯]`` ``hvcat``
 ``A'``              ``ctranspose``
 ``A.'``             ``transpose``
 ``1:n``             ``colon``
@@ -304,16 +304,17 @@ It is often convenient to be able to write functions taking an arbitrary
 number of arguments. Such functions are traditionally known as "varargs"
 functions, which is short for "variable number of arguments". You can
 define a varargs function by following the last argument with an
-ellipsis:
+ellipsis ``...`` (three periods in a row):
 
 .. doctest::
 
     julia> bar(a,b,x...) = (a,b,x)
     bar (generic function with 1 method)
 
-The variables ``a`` and ``b`` are bound to the first two argument values
-as usual, and the variable ``x`` is bound to an iterable collection of
-the zero or more values passed to ``bar`` after its first two arguments:
+The variables ``a`` and ``b`` are bound to the first two
+argument values as usual, and the variable ``x`` is bound to ("slurps") an
+iterable collection of the zero or more values passed to ``bar`` after its
+first two arguments:
 
 .. doctest::
 
@@ -332,8 +333,8 @@ the zero or more values passed to ``bar`` after its first two arguments:
 In all these cases, ``x`` is bound to a tuple of the trailing values
 passed to ``bar``.
 
-On the flip side, it is often handy to "splice" the values contained in
-an iterable collection into a function call as individual arguments. To
+On the flip side, it is often handy to "splice" or "splat" the values contained
+in an iterable collection into a function call as individual arguments. To
 do this, one also uses ``...`` but in the function call instead:
 
 .. doctest::
@@ -344,8 +345,8 @@ do this, one also uses ``...`` but in the function call instead:
     julia> bar(1,2,x...)
     (1,2,(3,4))
 
-In this case a tuple of values is spliced into a varargs call precisely
-where the variable number of arguments go. This need not be the case,
+In this case a tuple of values is spliced (splatted) into a varargs call
+precisely where the variable number of arguments go. This need not be the case,
 however:
 
 .. doctest::
@@ -468,8 +469,8 @@ signature::
         ###
     end
 
-Extra keyword arguments can be collected using ``...``, as in varargs
-functions::
+Extra keyword arguments can be collected ("slurped") using ``...``, as in
+varargs functions::
 
     function f(x; y=0, args...)
         ###
@@ -543,7 +544,7 @@ The ``do x`` syntax creates an anonymous function with argument ``x``
 and passes it as the first argument to ``map``. Similarly, ``do a,b``
 would create a two-argument anonymous function, and a plain ``do``
 would declare that what follows is an anonymous function of the form
-``() -> ...``.
+``() -> ⋯``.
 
 How these arguments are initialized depends on the "outer" function;
 here, ``map`` will sequentially set ``x`` to ``A``, ``B``, ``C``,

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -45,7 +45,7 @@ To evaluate expressions written in a source file ``file.jl``, write
 To run code in a file non-interactively, you can give it as the first
 argument to the julia command::
 
-    $ julia script.jl arg1 arg2...
+    $ julia script.jl arg1 arg2⋯
 
 As the example implies, the following command-line arguments to julia
 are taken as command-line arguments to the program ``script.jl``, passed
@@ -89,8 +89,8 @@ put it in ``~/.juliarc.jl``:
     $ echo 'println("Greetings! 你好! 안녕하세요?")' > ~/.juliarc.jl
     $ julia
     Greetings! 你好! 안녕하세요?
-    
-    ...
+
+    ⋮
 
 .. raw:: latex
 
@@ -99,7 +99,7 @@ put it in ``~/.juliarc.jl``:
 There are various ways to run Julia code and provide options, similar to
 those available for the ``perl`` and ``ruby`` programs::
 
-    julia [options] [program] [args...]
+    julia [options] [program] [args⋯]
      -v, --version            Display version information
      -h, --help               Print this message
      -q, --quiet              Quiet startup without banner

--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -364,8 +364,8 @@ Function        Description
 ``divrem(x,y)`` returns ``(div(x,y),rem(x,y))``
 ``mod(x,y)``    modulus; satisfies ``x == fld(x,y)*y + mod(x,y)``; sign matches ``y``
 ``mod2pi(x)``   modulus with respect to 2pi;  ``0 <= mod2pi(x)  < 2pi``
-``gcd(x,y...)`` greatest common divisor of ``x``, ``y``,...; sign matches ``x``
-``lcm(x,y...)`` least common multiple of ``x``, ``y``,...; sign matches ``x``
+``gcd(x,y,⋯)`` greatest common divisor of ``x``, ``y``,⋯; sign matches ``x``
+``lcm(x,y,⋯)`` least common multiple of ``x``, ``y``,⋯; sign matches ``x``
 =============== =======================================================================
 
 Sign and absolute value functions

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -47,7 +47,7 @@ There is special syntax for "quoting" code (analogous to quoting
 strings) that makes it easy to create expression objects without
 explicitly constructing ``Expr`` objects. There are two forms: a short
 form for inline expressions using ``:`` followed by a single expression,
-and a long form for blocks of code, enclosed in ``quote ... end``. Here
+and a long form for blocks of code, enclosed in ``quote ⋯ end``. Here
 is an example of the short form used to quote an arithmetic expression:
 
 .. doctest::
@@ -274,7 +274,7 @@ slightly more tersely using the ``:`` prefix quoting form::
     end
 
 This sort of in-language code generation, however, using the
-``eval(quote(...))`` pattern, is common enough that Julia comes with a
+``eval(quote(⋯))`` pattern, is common enough that Julia comes with a
 macro to abbreviate this pattern::
 
     for op = (:+, :*, :&, :|, :$)
@@ -310,24 +310,24 @@ written code to a resulting expression, which then takes the place of
 the macro call in the final syntax tree. Macros are invoked with the
 following general syntax::
 
-    @name expr1 expr2 ...
-    @name(expr1, expr2, ...)
+    @name expr1 expr2 ⋯
+    @name(expr1, expr2, ⋯)
 
 Note the distinguishing ``@`` before the macro name and the lack of
 commas between the argument expressions in the first form, and the
 lack of whitespace after ``@name`` in the second form. The two styles
 should not be mixed. For example, the following syntax is different
-from the examples above; it passes the tuple ``(expr1, expr2, ...)`` as
+from the examples above; it passes the tuple ``(expr1, expr2, ⋯)`` as
 one argument to the macro::
 
-    @name (expr1, expr2, ...)
+    @name (expr1, expr2, ⋯)
 
 Before the program runs, this statement will be replaced with the
 returned result of calling an expander function for ``@name`` on the
 expression arguments. Expanders are defined with the ``macro`` keyword::
 
-    macro name(expr1, expr2, ...)
-        ...
+    macro name(expr1, expr2, ⋯)
+        ⋮
         return resulting_expr
     end
 
@@ -498,7 +498,7 @@ One problem remains however. Consider the following use of this macro::
     module MyModule
     import Base.@time
 
-    time() = ... # compute something
+    time() = ⋯ # compute something
 
     @time time()
     end
@@ -510,9 +510,9 @@ macro call environment. This is done by "escaping" the expression with
 the ``esc`` function::
 
     macro time(ex)
-        ...
+        ⋮
         local val = $(esc(ex))
-        ...
+        ⋮
     end
 
 An expression wrapped in this manner is left alone by the macro expander

--- a/doc/manual/modules.rst
+++ b/doc/manual/modules.rst
@@ -7,7 +7,7 @@
 .. index:: module, baremodule, using, import, export, importall
 
 Modules in Julia are separate global variable workspaces. They are
-delimited syntactically, inside ``module Name ... end``. Modules allow
+delimited syntactically, inside ``module Name ⋯ end``. Modules allow
 you to create top-level definitions without worrying about name conflicts
 when your code is used together with somebody else's. Within a module, you
 can control which names from other modules are visible (via importing),
@@ -179,7 +179,7 @@ keyword ``baremodule`` instead. In terms of ``baremodule``, a standard
     eval(x) = Core.eval(Mod, x)
     eval(m,x) = Core.eval(m, x)
 
-    ...
+    ⋮
 
     end
 
@@ -202,12 +202,12 @@ any of its enclosing modules::
     module Parent
 
     module Utils
-    ...
+    ⋮
     end
 
     using .Utils
 
-    ...
+    ⋮
     end
 
 Here module ``Parent`` contains a submodule ``Utils``, and code in

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -71,8 +71,8 @@ differences that may trip up Julia users accustomed to MATLAB:
    across arrays and can be used to combine logical arrays, but note the
    difference in order of operations—parentheses may be required (e.g.,
    to select elements of ``A`` equal to 1 or 2 use ``(A .== 1) | (A .== 2)``).
--  The elements of a collection can be passed as arguments to a function
-   using ``...``, as in ``xs=[1,2]; f(xs...)``.
+-  The elements of a collection can be passed ("splatted") as arguments to a
+   function using ``...``, as in ``xs=[1,2]; f(xs...)``.
 -  Julia's ``svd`` returns singular values as a vector instead of as a
    full diagonal matrix.
 -  In Julia, ``...`` is not used to continue lines of code. Instead, incomplete

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -228,12 +228,12 @@ random matrix::
     # method 1
     A = rand(1000,1000)
     Bref = @spawn A^2
-    ...
+    ⋮
     fetch(Bref)
 
     # method 2
     Bref = @spawn rand(1000,1000)^2
-    ...
+    ⋮
     fetch(Bref)
 
 The difference seems trivial, but in fact is quite significant due to

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -185,7 +185,7 @@ share this knowledge with the compiler::
     function foo(a::Array{Any,1})
         x = a[1]::Int32
         b = x+1
-        ...
+        ⋮
     end
 
 Here, we happened to know that the first element of ``a`` would be an
@@ -199,7 +199,7 @@ Declare types of keyword arguments
 Keyword arguments can have declared types::
 
     function with_keyword(x; name::Int = 1)
-        ...
+        ⋮
     end
 
 Functions are specialized on the types of keyword arguments, so these

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -543,7 +543,7 @@ which are parsed into a state machine that can be used to efficiently
 search for patterns in strings. In Julia, regular expressions are input
 using non-standard string literals prefixed with various identifiers
 beginning with ``r``. The most basic regular expression literal without
-any options turned on just uses ``r"..."``:
+any options turned on just uses ``r"⋯"``:
 
 .. doctest::
 
@@ -718,7 +718,7 @@ For example, the following regex has all three flags turned on:
     julia> match(r"a+.*b+.*?d$"ism, "Goodbye,\nOh, angry,\nBad world\n")
     RegexMatch("angry,\nBad world")
 
-Triple-quoted regex strings, of the form ``r"""..."""``, are also
+Triple-quoted regex strings, of the form ``r"""⋯"""``, are also
 supported (and may be convenient for regular expressions containing
 quotation marks or newlines).
 
@@ -726,7 +726,7 @@ Byte Array Literals
 -------------------
 
 Another useful non-standard string literal is the byte-array string
-literal: ``b"..."``. This form lets you use string notation to express
+literal: ``b"⋯"``. This form lets you use string notation to express
 literal byte arrays — i.e. arrays of ``Uint8`` values. The convention is
 that non-standard literals with uppercase prefixes produce actual string
 objects, while those with lowercase prefixes produce non-string objects
@@ -815,7 +815,7 @@ Version Number Literals
 -----------------------
 
 Version numbers can easily be expressed with non-standard string literals of
-the form ``v"..."``. Version number literals create ``VersionNumber`` objects
+the form ``v"⋯"``. Version number literals create ``VersionNumber`` objects
 which follow the specifications of `semantic versioning <http://semver.org>`_,
 and therefore are composed of major, minor and patch numeric values, followed
 by pre-release and build alpha-numeric annotations. For example,

--- a/doc/manual/style-guide.rst
+++ b/doc/manual/style-guide.rst
@@ -71,14 +71,14 @@ Instead of::
 
     function foo(x, y)
         x = int(x); y = int(y)
-        ...
+        ⋮
     end
     foo(x, y)
 
 use::
 
     function foo(x::Int, y::Int)
-        ...
+        ⋮
     end
     foo(int(x), int(y))
 
@@ -191,11 +191,11 @@ Don't use unnecessary static parameters
 
 A function signature::
 
-    foo{T<:Real}(x::T) = ...
+    foo{T<:Real}(x::T) = ⋯
 
 should be written as::
 
-    foo(x::Real) = ...
+    foo(x::Real) = ⋯
 
 instead, especially if ``T`` is not used in the function body.
 Even if ``T`` is used, it can be replaced with ``typeof(x)`` if convenient.
@@ -212,7 +212,7 @@ Avoid confusion about whether something is an instance or a type
 
 Sets of definitions like the following are confusing::
 
-    foo(::Type{MyType}) = ...
+    foo(::Type{MyType}) = ⋯
     foo(::MyType) = foo(MyType)
 
 Decide whether the concept in question will be written as ``MyType`` or
@@ -245,7 +245,7 @@ If you have a type that uses a native pointer::
 
     type NativeType
         p::Ptr{Uint8}
-        ...
+        ⋮
     end
 
 don't write definitions like the following::
@@ -263,7 +263,7 @@ Don't overload methods of base container types
 
 It is possible to write definitions like the following::
 
-    show(io::IO, v::Vector{MyType}) = ...
+    show(io::IO, v::Vector{MyType}) = ⋯
 
 This would provide custom showing of vectors with a specific new element type.
 While tempting, this should be avoided. The trouble is that users will expect

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -106,7 +106,7 @@ exception is thrown, otherwise, the left-hand value is returned:
 
 This allows a type assertion to be attached to any expression
 in-place. The most common usage of ``::`` as an assertion is in
-function/methods signatures, such as ``f(x::Int8) = ...`` (see
+function/methods signatures, such as ``f(x::Int8) = ⋯`` (see
 :ref:`man-methods`).
 
 


### PR DESCRIPTION
This is a second attempt at a pull request associated with #8593. The complaint was that "..." is a keyword, but was sometimes used in documentation to mean "etc." and not splice/splat/slurp. To remove ambiguity, the suggestion was made to use "⋯" (midline ellipsis) for "etc." I have tried it out and I like it. I have attempted to preserve all appearances of "..." for splicing (and occasionally "⋮" to mean lines of code), but would appreciate a close look to make sure I did not accidentally change the wrong thing.

A few discussion points:
1. It was pointed out that "dims..." might be what was intended, but I converted these to "dims,⋯" because I believe that agrees best with the accompanying text for that section. The problem is that "dims..." is perfectly legal and _might_ be intended sometimes. I believe the documentation is intended to explain basic syntax, and those familiar with splicing would understand that splicing could apply here.
2. It was pointed out that "⋯" is unicode and might cause font problems for some. On my Mac, the character tool shows midline ellipsis rendered correctly in all 66 font variations shown. So I believe this is an acceptable solution, better than a keyword being used ambiguously. Also, note that the documentation uses unicode characters such as Chinese in various places, as well as pi. But if it is decided that the unicode midline ellipsis is unacceptable, then I suggest that the original "dims..." should be written as "dims, ..." because that is at least more clearly not legal code, whereas the former was completely ambiguous. When "etc." is intended, it should be written in such a way that it is absolutely umambiguous.
3. I have sprinkled in the terms "splat" and "slurp" in a few cases. It was pointed out [elsewhere](https://groups.google.com/forum/#!msg/julia-dev/mj3I8hqc71g/8-J7nMvC5-0J) that "splicing" is used inconsistently and does not capture direction. The term "splatting" is more specific and is recognized e.g. in Python as such. The term "slurping" was suggested in that same discussion. I'm not sure how serious people were, but one of my edits uses it; please delete if you don't like it. (Although I do think it would help two separate terms to distinguish the two different uses, and splicing is problematic due to ambiguity.)
4. A completely other possible solution is to retain "..." in documentation to mean "etc." This is what it means in the docs for many other languages, and when new docs are written, it is not guaranteed that people will know to use midline ellipsis. But that means the language syntax should change to _not_ use ellipsis. A possible idea would be "args >.." to mean splatting and "args <.." to mean slurping or ">.. args" as a prefix slurp. This is probably not a popular idea, but I thought I'd throw it out there.

This is my second attempt at a pull request. I messed up horribly on my previous attempt, due to ignorance of how git works. I apologize for my mistake and hope this one works better.
