### PR TITLE
Purge C samples before counting samples when printing flat Profile data

### DIFF
--- a/base/profile.jl
+++ b/base/profile.jl
@@ -193,6 +193,9 @@ function parse_flat(iplist, n, lidict, C::Bool)
 end
 
 function flat{T<:Unsigned}(io::IO, data::Vector{T}, lidict::Dict, C::Bool, combine::Bool, cols::Integer)
+    if !C
+        data = purgeC(data, lidict)
+    end
     iplist, n = count_flat(data)
     if isempty(n)
         warning_empty()


### PR DESCRIPTION
This avoids the error `ERROR: Reducing over an empty array is not allowed.` when calling Profile.print(format=:flat) on a profile sample set that has only C samples.  @timholy does this seem reasonable?
