### PR TITLE
RFC: use contrib/install.sh to install gmp

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -108,6 +108,9 @@ private_libdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(p
 datarootdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(datarootdir))
 sysconfdir_rel = $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(sysconfdir))
 
+INSTALL_F = $(JULIAHOME)/contrib/install.sh 644
+INSTALL_M = $(JULIAHOME)/contrib/install.sh 755
+
 # This used for debian packaging, to conform to library layout guidelines
 ifeq ($(MULTIARCH_INSTALL), 1)
 MULTIARCH = $(shell gcc -print-multiarch)

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ include $(JULIAHOME)/Make.inc
 # so that prefix/share/julia/VERSDIR can be overwritten without touching
 # third-party code).
 VERSDIR = v`cut -d. -f1-2 < VERSION`
-INSTALL_F = contrib/install.sh 644
-INSTALL_M = contrib/install.sh 755
 
 #file name of make dist result
 ifeq ($(JULIA_DIST_TARNAME),)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1487,8 +1487,6 @@ endif
 	touch -c $@
 gmp-$(GMP_VER)/config.status: gmp-$(GMP_VER)/configure
 	cd gmp-$(GMP_VER) && \
-	sed -ibackup 's|includeexecdir = $$(exec_prefix)/include|includeexecdir = $$(includedir)|g' Makefile.in && \
-	sed -ibackup 's|includeexecdir = $$(exec_prefix)/include|includeexecdir = $$(includedir)|g' Makefile.am && \
 	./configure $(CONFIGURE_COMMON) F77= --enable-shared --disable-static
 	touch -c $@
 $(GMP_SRC_TARGET): gmp-$(GMP_VER)/config.status
@@ -1498,13 +1496,10 @@ ifeq ($(OS),$(BUILD_OS))
 	$(MAKE) -C gmp-$(GMP_VER) $(LIBTOOL_CCLD) check
 endif
 	echo 1 > $@
-$(GMP_OBJ_TARGET): $(GMP_SRC_TARGET) gmp-$(GMP_VER)/checked
-	$(MAKE) -C gmp-$(GMP_VER) $(LIBTOOL_CCLD) install $(MAKE_COMMON)
-ifeq ($(OS),WINNT)
-	mv -f $(build_libdir)/libgmp.$(SHLIB_EXT) $@
-endif
+$(GMP_OBJ_TARGET): $(GMP_SRC_TARGET) gmp-$(GMP_VER)/checked | $(build_shlibdir) $(build_includedir)
+	$(INSTALL_M) gmp-$(GMP_VER)/.libs/libgmp.*$(SHLIB_EXT)* $(build_shlibdir)
+	$(INSTALL_F) gmp-$(GMP_VER)/gmp.h $(build_includedir)
 	$(INSTALL_NAME_CMD)libgmp.$(SHLIB_EXT) $@
-	touch -c $@
 
 clean-gmp:
 	-$(MAKE) -C gmp-$(GMP_VER) clean


### PR DESCRIPTION
This replaces some `sed` patching (added in #7316) and Windows special-casing. Should be functionally equivalent, though now we're not installing a couple of extra files that we weren't using.

Removing the `touch` means MPFR no longer rebuilds every time after `make cleanall`
Before: `make cleanall && time(make -C deps install-mpfr)` took 2 minutes,
after it takes one second.

@staticfloat and @crayxt, can you take a look over this?

What's generally the purpose of the `touch` at the end of the `_OBJ_TARGET` rules? Openblas for example (which doesn't use autotools) doesn't have it, so none of the other large-ish dependencies need to recompile after `make cleanall`, they just need to reinstall which is quicker.

This tests fine on Linux and Windows, doing `make -C deps distclean-gmp distclean-mpfr && rm -rf usr` for good measure. Would appreciate testing on Mac - I put in another `*` before `$(SHLIB_EXT)` because I remember seeing somewhere that versioned dylibs put the numbers before the extension? Travis doesn't tell us too much for dependency build changes.
