### PR TITLE
Remove error bounds calculation from triangular solver

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -123,35 +123,27 @@ end
 
 
 #Linear solvers
-function \{TA<:Number,Tb<:Number}(A::Union(Bidiagonal{TA},Triangular{TA}), b::AbstractVector{Tb})
-    TAb = typeof(one(TA)/one(Tb))
-    naivesub!(A, b, similar(b, TAb))
-end
-function \{TA<:Number,TB<:Number}(A::Union(Bidiagonal{TA},Triangular{TA}), B::AbstractMatrix{TB})
-    TAB = typeof(one(TA)/one(TB))
-    hcat([naivesub!(A, B[:,i], similar(B[:,i], TAB)) for i=1:size(B,2)]...)
-end
-A_ldiv_B!(A::Union(Bidiagonal,Triangular), b::AbstractVector)=naivesub!(A,b)
-At_ldiv_B!(A::Union(Bidiagonal,Triangular), b::AbstractVector)=naivesub!(transpose(A),b)
-Ac_ldiv_B!(A::Union(Bidiagonal,Triangular), b::AbstractVector)=naivesub!(ctranspose(A),b)
+A_ldiv_B!(A::Union(Bidiagonal, Triangular), b::AbstractVector) = naivesub!(A, b)
+At_ldiv_B!(A::Union(Bidiagonal, Triangular), b::AbstractVector) = naivesub!(transpose(A), b)
+Ac_ldiv_B!(A::Union(Bidiagonal, Triangular), b::AbstractVector) = naivesub!(ctranspose(A), b)
 for func in (:A_ldiv_B!, :Ac_ldiv_B!, :At_ldiv_B!) @eval begin
-    function ($func)(A::Union(Bidiagonal,Triangular), B::AbstractMatrix)
+    function ($func)(A::Union(Bidiagonal, Triangular), B::AbstractMatrix)
         tmp = similar(B[:,1])
         n = size(B, 1)
-        for i=1:size(B,2)
-            copy!(tmp, 1, B, (i-1)*n+1, n)
+        for i = 1:size(B,2)
+            copy!(tmp, 1, B, (i - 1)*n + 1, n)
             ($func)(A, tmp)
-            copy!(B, (i-1)*n+1, tmp, 1, n) # Modify this when array view are implemented.
+            copy!(B, (i - 1)*n + 1, tmp, 1, n) # Modify this when array view are implemented.
         end
         B
     end
 end end
 for func in (:A_ldiv_Bt!, :Ac_ldiv_Bt!, :At_ldiv_Bt!) @eval begin
-    function ($func)(A::Union(Bidiagonal,Triangular), B::AbstractMatrix)
-        tmp = similar(B[:,2])
+    function ($func)(A::Union(Bidiagonal, Triangular), B::AbstractMatrix)
+        tmp = similar(B[:, 2])
         m, n = size(B)
         nm = n*m
-        for i=1:size(B,1)
+        for i = 1:size(B, 1)
             copy!(tmp, 1, B, i:m:nm, n)
             ($func)(A, tmp)
             copy!(B, i:m:nm, tmp, 1, n)
@@ -161,47 +153,52 @@ for func in (:A_ldiv_Bt!, :Ac_ldiv_Bt!, :At_ldiv_Bt!) @eval begin
 end end
 
 #Generic solver using naive substitution
-function naivesub!{T}(A::Bidiagonal{T}, b::AbstractVector, x::AbstractVector=b)
+function naivesub!{T}(A::Bidiagonal{T}, b::AbstractVector, x::AbstractVector = b)
     N = size(A, 2)
-    N==length(b)==length(x) || throw(DimensionMismatch(""))
+    N == length(b) == length(x) || throw(DimensionMismatch(""))
 
     if !A.isupper #do forward substitution
         for j = 1:N
             x[j] = b[j]
-            j>1 && (x[j] -= A.ev[j-1] * x[j-1])
-            x[j]/= A.dv[j]==zero(T) ? throw(SingularException(j)) : A.dv[j]
+            j > 1 && (x[j] -= A.ev[j-1] * x[j-1])
+            x[j] /= A.dv[j] == zero(T) ? throw(SingularException(j)) : A.dv[j]
         end
     else #do backward substitution
         for j = N:-1:1
             x[j] = b[j]
-            j<N && (x[j] -= A.ev[j] * x[j+1])
-            x[j]/= A.dv[j]==zero(T) ? throw(SingularException(j)) : A.dv[j]
+            j < N && (x[j] -= A.ev[j] * x[j+1])
+            x[j] /= A.dv[j] == zero(T) ? throw(SingularException(j)) : A.dv[j]
         end
     end
     x
+end
+
+function \{T,S}(A::Bidiagonal{T}, B::AbstractVecOrMat{S})
+    TS = typeof(zero(T)*zero(S) + zero(T)*zero(S))
+    TS == S ? A_ldiv_B!(A, copy(B)) : A_ldiv_B!(A, convert(AbstractArray{TS}, B))
 end
 
 # Eigensystems
 eigvals(M::Bidiagonal) = M.dv
 function eigvecs{T}(M::Bidiagonal{T})
     n = length(M.dv)
-    Q=Array(T, n, n)
-    blks = [0; find(x->x==0, M.ev); n]
+    Q = Array(T, n, n)
+    blks = [0; find(x -> x == 0, M.ev); n]
     if M.isupper
-        for idx_block=1:length(blks)-1, i=blks[idx_block]+1:blks[idx_block+1] #index of eigenvector
+        for idx_block = 1:length(blks) - 1, i = blks[idx_block] + 1:blks[idx_block + 1] #index of eigenvector
             v=zeros(T, n)
-            v[blks[idx_block]+1] = one(T)
-            for j=blks[idx_block]+1:i-1 #Starting from j=i, eigenvector elements will be 0
-                v[j+1] = (M.dv[i]-M.dv[j])/M.ev[j] * v[j]
+            v[blks[idx_block] + 1] = one(T)
+            for j = blks[idx_block] + 1:i - 1 #Starting from j=i, eigenvector elements will be 0
+                v[j+1] = (M.dv[i] - M.dv[j])/M.ev[j] * v[j]
             end
-            Q[:,i] = v/norm(v)
+            Q[:, i] = v/norm(v)
         end
     else
-        for idx_block=1:length(blks)-1, i=blks[idx_block+1]:-1:blks[idx_block]+1 #index of eigenvector
-            v=zeros(T, n)
+        for idx_block = 1:length(blks) - 1, i = blks[idx_block + 1]:-1:blks[idx_block] + 1 #index of eigenvector
+            v = zeros(T, n)
             v[blks[idx_block+1]] = one(T)
-            for j=(blks[idx_block+1]-1):-1:max(1,(i-1)) #Starting from j=i, eigenvector elements will be 0
-                v[j] = (M.dv[i]-M.dv[j+1])/M.ev[j] * v[j+1]
+            for j = (blks[idx_block+1] - 1):-1:max(1, (i - 1)) #Starting from j=i, eigenvector elements will be 0
+                v[j] = (M.dv[i] - M.dv[j+1])/M.ev[j] * v[j+1]
             end
             Q[:,i] = v/norm(v)
         end

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -2044,14 +2044,14 @@ for (trcon, trevc, trrfs, elty) in
         #$                   WORK( * ), X( LDX, * )
         function trrfs!(uplo::BlasChar, trans::BlasChar, diag::BlasChar,
                 A::StridedMatrix{$elty}, B::StridedVecOrMat{$elty}, X::StridedVecOrMat{$elty},
-                Ferr::StridedVector{$elty}=similar(B, $elty, size(B,2)), Berr::StridedVector{$elty}=similar(B, $elty, size(B,2)))
+                Ferr::StridedVector{$elty}=similar(B, $elty, size(B,2)), Berr::StridedVector{$elty} = similar(B, $elty, size(B,2)))
             @chkuplo
-            n=size(A,2)
-            nrhs=size(B,2)
-            nrhs==size(X,2) || throw(DimensionMismatch(""))
-            work=Array($elty, 3n)
-            iwork=Array(BlasInt, n)
-            info=Array(BlasInt, 1)
+            n = size(A,2)
+            nrhs = size(B,2)
+            nrhs == size(X,2) || throw(DimensionMismatch(""))
+            work = Array($elty, 3n)
+            iwork = Array(BlasInt, n)
+            info = Array(BlasInt, 1)
             ccall(($(string(trrfs)),liblapack), Void,
                 (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, 
                  Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -37,12 +37,6 @@ char_uplo(uplo::Symbol) = uplo == :U ? CHARU : (uplo == :L ? CHARL : throw(Argum
 for (func1, func2) in ((:*, :A_mul_B!), (:Ac_mul_B, :Ac_mul_B!), (:/, :A_rdiv_B!))
     @eval begin
         ($func1){T<:BlasFloat,S<:StridedMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::Triangular{T,S,UpLo,IsUnit}) = ($func2)(A, full(B))
-        ($func1){T<:BlasFloat,S<:StridedMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedVecOrMat) = ($func2)(A, copy(B))
-    end
-end
-for (func1, func2) in ((:A_mul_Bc, :A_mul_Bc!), (:A_rdiv_Bc, :A_rdiv_Bc!))
-    @eval begin
-        ($func1){T<:BlasFloat,S<:StridedMatrix,UpLo,IsUnit}(A::StridedMatrix, B::Triangular{T,S,UpLo,IsUnit}) = ($func2)(copy(A), B)
     end
 end
 
@@ -60,25 +54,31 @@ Ac_mul_B!{T<:BlasReal,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedM
 A_mul_Bc!{T<:BlasComplex,S,UpLo,IsUnit}(A::StridedMatrix{T}, B::Triangular{T,S,UpLo,IsUnit}) = BLAS.trmm!('R', UpLo == :L ? 'L' : 'U', 'C', IsUnit ? 'U' : 'N', one(T), B.data, A)
 A_mul_Bc!{T<:BlasReal,S,UpLo,IsUnit}(A::StridedMatrix{T}, B::Triangular{T,S,UpLo,IsUnit}) = BLAS.trmm!('R', UpLo == :L ? 'L' : 'U', 'T', IsUnit ? 'U' : 'N', one(T), B.data, A)
 
-A_ldiv_B!{T<:BlasFloat,S<:AbstractMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedVecOrMat{T}) = LAPACK.trtrs!(UpLo == :L ? 'L' : 'U', 'N', IsUnit ? 'U' : 'N', A.data, B)
-function \{T<:BlasFloat,S<:AbstractMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedVecOrMat{T})
-    x = A_ldiv_B!(A, copy(B))
-    errors = LAPACK.trrfs!(UpLo == :L ? 'L' : 'U', 'N', IsUnit ? 'U' : 'N', A.data, B, x)
-    all(isfinite, [errors...]) || all([errors...] .< one(T)/eps(T)) || warn("""Unreasonably large error in computed solution:
-forward errors:
-$(errors[1])
-backward errors:
-$(errors[2])""")
-    x
-end
-Ac_ldiv_B!{T<:BlasReal,S<:AbstractMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedVecOrMat{T}) = LAPACK.trtrs!(UpLo == :L ? 'L' : 'U', 'T', IsUnit ? 'U' : 'N', A.data, B)
-Ac_ldiv_B!{T<:BlasComplex,S<:AbstractMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedVecOrMat{T}) = LAPACK.trtrs!(UpLo == :L ? 'L' : 'U', 'C', IsUnit ? 'U' : 'N', A.data, B)
+A_ldiv_B!{T<:BlasFloat,S<:StridedMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedVecOrMat{T}) = LAPACK.trtrs!(UpLo == :L ? 'L' : 'U', 'N', IsUnit ? 'U' : 'N', A.data, B)
+Ac_ldiv_B!{T<:BlasReal,S<:StridedMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedVecOrMat{T}) = LAPACK.trtrs!(UpLo == :L ? 'L' : 'U', 'T', IsUnit ? 'U' : 'N', A.data, B)
+Ac_ldiv_B!{T<:BlasComplex,S<:StridedMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedVecOrMat{T}) = LAPACK.trtrs!(UpLo == :L ? 'L' : 'U', 'C', IsUnit ? 'U' : 'N', A.data, B)
 
 A_rdiv_B!{T<:BlasFloat,S<:AbstractMatrix,UpLo,IsUnit}(A::StridedVecOrMat{T}, B::Triangular{T,S,UpLo,IsUnit}) = BLAS.trsm!('R', UpLo == :L ? 'L' : 'U', 'N', IsUnit ? 'U' : 'N', one(T), B.data, A)
 A_rdiv_Bc!{T<:BlasReal,S<:AbstractMatrix,UpLo,IsUnit}(A::StridedMatrix{T}, B::Triangular{T,S,UpLo,IsUnit}) = BLAS.trsm!('R', UpLo == :L ? 'L' : 'U', 'T', IsUnit ? 'U' : 'N', one(T), B.data, A)
 A_rdiv_Bc!{T<:BlasComplex,S<:AbstractMatrix,UpLo,IsUnit}(A::StridedMatrix{T}, B::Triangular{T,S,UpLo,IsUnit}) = BLAS.trsm!('R', UpLo == :L ? 'L' : 'U', 'C', IsUnit ? 'U' : 'N', one(T), B.data, A)
 
 inv{T<:BlasFloat,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}) = Triangular{T,S,UpLo,IsUnit}(LAPACK.trtri!(UpLo == :L ? 'L' : 'U', IsUnit ? 'U' : 'N', copy(A.data)))
+
+function \{T,AT,UpLo,S}(A::Triangular{T,AT,UpLo,true}, B::AbstractVecOrMat{S})
+    TS = typeof(zero(T)*zero(S) + zero(T)*zero(S))
+    TS == S ? A_ldiv_B!(A, copy(B)) : A_ldiv_B!(A, convert(AbstractArray{TS}, B))
+end
+
+function \{T,AT,UpLo,S}(A::Triangular{T,AT,UpLo,false}, B::AbstractVecOrMat{S})
+    TS = typeof((zero(T)*zero(S) + zero(T)*zero(S))/one(S))
+    TS == S ? A_ldiv_B!(A, copy(B)) : A_ldiv_B!(A, convert(AbstractArray{TS}, B))
+end
+
+errorbounds{T<:BlasFloat,S<:StridedMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, X::StridedVecOrMat{T}, B::StridedVecOrMat{T}) = LAPACK.trrfs!(UpLo == :L ? 'L' : 'U', 'N', IsUnit ? 'U' : 'N', A.data, B, X)
+function errorbounds{TA<:Number,S<:StridedMatrix,UpLo,IsUnit,TX<:Number,TB<:Number}(A::Triangular{TA,S,UpLo,IsUnit}, X::StridedVecOrMat{TX}, B::StridedVecOrMat{TB})
+    TAXB = promote_type(TA, TB, TX, Float32)
+    errorbounds(convert(AbstractMatrix{TAXB}, A), convert(AbstractArray{TAXB}, X), convert(AbstractArray{TAXB}, B))
+end
 
 #Eigensystems
 function eigvecs{T<:BlasFloat,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit})
@@ -150,6 +150,8 @@ function similar{T,S,UpLo,IsUnit,Tnew}(A::Triangular{T,S,UpLo,IsUnit}, ::Type{Tn
     return Triangular{Tnew, typeof(A), UpLo, IsUnit}(A)
 end
 
+copy{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}) = Triangular{T,S,UpLo,IsUnit}(copy(A))
+
 getindex{T,S}(A::Triangular{T,S,:L,true}, i::Integer, j::Integer) = i == j ? one(T) : (i > j ? A.data[i,j] : zero(A.data[i,j]))
 getindex{T,S}(A::Triangular{T,S,:L,false}, i::Integer, j::Integer) = i >= j ? A.data[i,j] : zero(A.data[i,j])
 getindex{T,S}(A::Triangular{T,S,:U,true}, i::Integer, j::Integer) = i == j ? one(T) : (i < j ? A.data[i,j] : zero(A.data[i,j]))
@@ -166,8 +168,11 @@ ctranspose!{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}) = Triangular{T, S, 
 diag{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}) = IsUnit ? ones(T, size(A,1)) : diag(A.data)
 function big{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit})
     M = big(A.data)
-    Triangular{T,typeof(M),UpLo,IsUnit}(M)
+    Triangular{eltype(M),typeof(M),UpLo,IsUnit}(M)
 end
+
+real{T<:Real}(A::Triangular{T}) = A
+real{T<:Complex,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}) = (B = real(A.data); Triangular{eltype(B), typeof(B), UpLo, IsUnit}(B))
 
 function (*){T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, x::Number)
     n = size(A,1)

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -221,40 +221,6 @@ debug && println("Solve square general system of equations")
     @test_throws DimensionMismatch b\b'
     @test norm(a*x - b, 1)/norm(b) < ε*κ*n*2 # Ad hoc, revisit!
 
-debug && println("Solve upper triangular system")
-    x = triu(a) \ b
-
-    #Test forward error [JIN 5705] if this is not a BigFloat
-    γ = n*ε/(1-n*ε)
-    if eltya != BigFloat
-        bigA = big(triu(a))
-        x̂ = bigA \ b
-        for i=1:size(b, 2)
-            @test norm(x̂[:,i]-x[:,i], Inf)/norm(x[:,i], Inf) <= abs(condskeel(bigA, x[:,i])*γ/(1-condskeel(bigA)*γ))
-        end
-    end
-    #Test backward error [JIN 5705]
-    for i=1:size(b, 2)
-        @test norm(abs(b[:,i] - triu(a)*x[:,i]), Inf) <= γ * norm(triu(a), Inf) * norm(x[:,i], Inf)
-    end
-
-debug && println("Solve lower triangular system")
-    x = tril(a)\b
-
-    #Test forward error [JIN 5705] if this is not a BigFloat
-    γ = n*ε/(1-n*ε)
-    if eltya != BigFloat
-        bigA = big(tril(a))
-        x̂ = bigA \ b
-        for i=1:size(b, 2)
-            @test norm(x̂[:,i]-x[:,i], Inf)/norm(x[:,i], Inf) <= abs(condskeel(bigA, x[:,i])*γ/(1-condskeel(bigA)*γ))
-        end
-    end
-    #Test backward error [JIN 5705]
-    for i=1:size(b, 2)
-        @test norm(abs(b[:,i] - tril(a)*x[:,i]), Inf) <= γ * norm(tril(a), Inf) * norm(x[:,i], Inf)
-    end
-
 debug && println("Test null")
     if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
         a15null = null(a[:,1:5]')


### PR DESCRIPTION
Thanks to @ivanslapnicar for pointing out that out triangular solver was very slow. This pull request makes a 1000x1000 problem with 1000 right hand sides about 70 times faster. The reason was that an error bounds calculation was done inside the solver. It could right as well be done outside the solver.
