### PR TITLE
replace itrunc(Uint8, 1234) => mod(1234, Uint8), etc. [fix #8646]

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -338,7 +338,7 @@ function dlm_parse{T,D}(dbuff::T, eol::D, dlm::D, qchar::D, cchar::D, ign_adj_dl
     all_ascii = (D <: Uint8) || (isascii(eol) && isascii(dlm) && (!allow_quote || isascii(qchar)) && (!allow_comments || isascii(cchar)))
     (T <: UTF8String) && all_ascii && (return dlm_parse(dbuff.data, uint8(eol), uint8(dlm), uint8(qchar), uint8(cchar), ign_adj_dlm, allow_quote, allow_comments, skipstart, skipblanks, dh))
     ncols = nrows = col = 0
-    is_default_dlm = (dlm == mod(invalid_dlm, D))
+    is_default_dlm = (dlm == invalid_dlm % D)
     error_str = ""
     # 0: begin field, 1: quoted field, 2: unquoted field, 3: second quote (could either be end of field or escape character), 4: comment, 5: skipstart
     state = (skipstart > 0) ? 5 : 0

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -338,7 +338,7 @@ function dlm_parse{T,D}(dbuff::T, eol::D, dlm::D, qchar::D, cchar::D, ign_adj_dl
     all_ascii = (D <: Uint8) || (isascii(eol) && isascii(dlm) && (!allow_quote || isascii(qchar)) && (!allow_comments || isascii(cchar)))
     (T <: UTF8String) && all_ascii && (return dlm_parse(dbuff.data, uint8(eol), uint8(dlm), uint8(qchar), uint8(cchar), ign_adj_dlm, allow_quote, allow_comments, skipstart, skipblanks, dh))
     ncols = nrows = col = 0
-    is_default_dlm = (dlm == itrunc(D, invalid_dlm))
+    is_default_dlm = (dlm == mod(invalid_dlm, D))
     error_str = ""
     # 0: begin field, 1: quoted field, 2: unquoted field, 3: second quote (could either be end of field or escape character), 4: comment, 5: skipstart
     state = (skipstart > 0) ? 5 : 0

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -195,3 +195,5 @@ const None = Union()
 @deprecate Dict{K}(ks::(K...), vs::Tuple)                        Dict{K,Any}(zip(ks, vs))
 @deprecate Dict{V}(ks::Tuple, vs::(V...))                        Dict{Any,V}(zip(ks, vs))
 @deprecate Dict(ks, vs)                                          Dict{Any,Any}(zip(ks, vs))
+
+@deprecate itrunc{T<:Integer}(::Type{T}, n::Integer) mod(n, T)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -196,4 +196,4 @@ const None = Union()
 @deprecate Dict{V}(ks::Tuple, vs::(V...))                        Dict{Any,V}(zip(ks, vs))
 @deprecate Dict(ks, vs)                                          Dict{Any,Any}(zip(ks, vs))
 
-@deprecate itrunc{T<:Integer}(::Type{T}, n::Integer) mod(n, T)
+@deprecate itrunc{T<:Integer}(::Type{T}, n::Integer) (n % T)

--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -29,7 +29,7 @@ function hash_64_32(n::Uint64)
     a =  a $ a >> 11
     a =  a + a << 6
     a =  a $ a >> 22
-    return itrunc(Uint32, a)
+    return mod(a, Uint32)
 end
 
 function hash_32_32(n::Uint32)

--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -29,7 +29,7 @@ function hash_64_32(n::Uint64)
     a =  a $ a >> 11
     a =  a + a << 6
     a =  a $ a >> 22
-    return mod(a, Uint32)
+    return a % Uint32
 end
 
 function hash_32_32(n::Uint32)

--- a/base/int.jl
+++ b/base/int.jl
@@ -430,8 +430,8 @@ if WORD_SIZE==32
     end
 
     function *(u::Uint128, v::Uint128)
-        u0 = u % Uint64; u1 = int64(u>>64)
-        v0 = v % Uint64; v1 = int64(v>>64)
+        u0 = u % Uint64; u1 = uint64(u>>>64)
+        v0 = v % Uint64; v1 = uint64(v>>>64)
         lolo = widemul(u0, v0)
         lohi = widemul(u0, v1)
         hilo = widemul(u1, v0)

--- a/base/int.jl
+++ b/base/int.jl
@@ -155,7 +155,7 @@ for to in tuple(IntTypes...,Char), from in tuple(IntTypes...,Char,Bool)
             else
                 @eval convert(::Type{$to}, x::($from)) = box($to,checked_trunc_uint($to,unbox($from,x)))
             end
-            @eval itrunc(::Type{$to}, x::($from)) = box($to,trunc_int($to,unbox($from,x)))
+            @eval mod(x::($from), ::Type{$to}) = box($to,trunc_int($to,unbox($from,x)))
         elseif from.size < to.size || from===Bool
             if issubtype(from, Signed)
                 @eval convert(::Type{$to}, x::($from)) = box($to,sext_int($to,unbox($from,x)))
@@ -174,8 +174,8 @@ for to in tuple(IntTypes...,Char), from in tuple(IntTypes...,Char,Bool)
     end
 end
 
-itrunc{T<:Integer}(::Type{T}, x::T) = x
-itrunc(::Type{Bool}, x::Integer) = ((x&1)!=0)
+mod{T<:Integer}(x::T, ::Type{T}) = x
+mod(x::Integer, ::Type{Bool}) = ((x&1)!=0)
 
 for to in (Int8, Int16, Int32, Int64)
     @eval begin
@@ -238,10 +238,10 @@ int32(x) = convert(Int32,x)
 int64(x) = convert(Int64,x)
 int128(x) = convert(Int128,x)
 
-uint8(x) = convert(Uint8, x)
-uint8(x::Integer) = itrunc(Uint8,x)
+uint8(x) = convert(Uint8,x)
+uint8(x::Integer) = mod(x,Uint8)
 uint8(x::Int8) = box(Uint8,unbox(Int8,x))
-uint8(x::Bool) = convert(Uint8, x)
+uint8(x::Bool) = convert(Uint8,x)
 
 uint16(x) = convert(Uint16,x)
 uint32(x) = convert(Uint32,x)
@@ -417,8 +417,8 @@ if WORD_SIZE==32
     end
 
     function *(u::Int128, v::Int128)
-        u0 = itrunc(Uint64,u); u1 = int64(u>>64)
-        v0 = itrunc(Uint64,v); v1 = int64(v>>64)
+        u0 = mod(u,Uint64); u1 = int64(u>>64)
+        v0 = mod(v,Uint64); v1 = int64(v>>64)
         lolo = widemul(u0, v0)
         lohi = widemul(reinterpret(Int64,u0), v1)
         hilo = widemul(u1, reinterpret(Int64,v0))
@@ -428,8 +428,8 @@ if WORD_SIZE==32
     end
 
     function *(u::Uint128, v::Uint128)
-        u0 = itrunc(Uint64,u); u1 = uint64(u>>>64)
-        v0 = itrunc(Uint64,v); v1 = uint64(v>>>64)
+        u0 = mod(u,Uint64); u1 = int64(u>>64)
+        v0 = mod(v,Uint64); v1 = int64(v>>64)
         lolo = widemul(u0, v0)
         lohi = widemul(u0, v1)
         hilo = widemul(u1, v0)
@@ -496,7 +496,7 @@ for T in (Int8,Uint8)
     @eval function checked_mul(x::$T, y::$T)
         xy = widemul(x,y)
         (typemin($T) <= xy <= typemax($T)) || throw(OverflowError())
-        return itrunc($T,xy)
+        return mod(xy,$T)
     end
 end
 
@@ -505,7 +505,7 @@ for T in (Int64,Uint64)
     @eval function checked_mul(x::$T, y::$T)
         xy = int128(x)*int128(y)
         (typemin($T) <= xy <= typemax($T)) || throw(OverflowError())
-        return itrunc($T,xy)
+        return mod(xy,$T)
     end
 end
 else

--- a/base/int.jl
+++ b/base/int.jl
@@ -155,14 +155,14 @@ for to in tuple(IntTypes...,Char), from in tuple(IntTypes...,Char,Bool)
             else
                 @eval convert(::Type{$to}, x::($from)) = box($to,checked_trunc_uint($to,unbox($from,x)))
             end
-            @eval mod(x::($from), ::Type{$to}) = box($to,trunc_int($to,unbox($from,x)))
+            @eval rem(x::($from), ::Type{$to}) = box($to,trunc_int($to,unbox($from,x)))
         elseif from.size < to.size || from === Bool
             if issubtype(from, Signed)
                 @eval convert(::Type{$to}, x::($from)) = box($to,sext_int($to,unbox($from,x)))
             else
                 @eval convert(::Type{$to}, x::($from)) = box($to,zext_int($to,unbox($from,x)))
             end
-            @eval mod(x::($from), ::Type{$to}) = convert($to,x)
+            @eval rem(x::($from), ::Type{$to}) = convert($to,x)
         else
             if !(issubtype(from,Signed) === issubtype(to,Signed))
                 # raise InexactError if x's top bit is set
@@ -170,13 +170,14 @@ for to in tuple(IntTypes...,Char), from in tuple(IntTypes...,Char,Bool)
             else
                 @eval convert(::Type{$to}, x::($from)) = box($to,unbox($from,x))
             end
-            @eval mod(x::($from), ::Type{$to}) = box($to,unbox($from,x))
+            @eval rem(x::($from), ::Type{$to}) = box($to,unbox($from,x))
         end
     end
 end
 
-mod{T<:Integer}(x::T, ::Type{T}) = x
-mod(x::Integer, ::Type{Bool}) = ((x&1)!=0)
+rem{T<:Integer}(x::T, ::Type{T}) = x
+rem(x::Integer, ::Type{Bool}) = ((x&1)!=0)
+mod{T<:Integer}(x::Integer, ::Type{T}) = rem(x, T)
 
 for to in (Int8, Int16, Int32, Int64)
     @eval begin
@@ -240,7 +241,7 @@ int64(x) = convert(Int64,x)
 int128(x) = convert(Int128,x)
 
 uint8(x) = convert(Uint8,x)
-uint8(x::Integer) = mod(x,Uint8)
+uint8(x::Integer) = x % Uint8
 uint8(x::Int8) = box(Uint8,unbox(Int8,x))
 uint8(x::Bool) = convert(Uint8,x)
 
@@ -418,8 +419,8 @@ if WORD_SIZE==32
     end
 
     function *(u::Int128, v::Int128)
-        u0 = mod(u,Uint64); u1 = int64(u>>64)
-        v0 = mod(v,Uint64); v1 = int64(v>>64)
+        u0 = u % Uint64; u1 = int64(u>>64)
+        v0 = v % Uint64; v1 = int64(v>>64)
         lolo = widemul(u0, v0)
         lohi = widemul(reinterpret(Int64,u0), v1)
         hilo = widemul(u1, reinterpret(Int64,v0))
@@ -429,8 +430,8 @@ if WORD_SIZE==32
     end
 
     function *(u::Uint128, v::Uint128)
-        u0 = mod(u,Uint64); u1 = int64(u>>64)
-        v0 = mod(v,Uint64); v1 = int64(v>>64)
+        u0 = u % Uint64; u1 = int64(u>>64)
+        v0 = v % Uint64; v1 = int64(v>>64)
         lolo = widemul(u0, v0)
         lohi = widemul(u0, v1)
         hilo = widemul(u1, v0)
@@ -497,7 +498,7 @@ for T in (Int8,Uint8)
     @eval function checked_mul(x::$T, y::$T)
         xy = widemul(x,y)
         (typemin($T) <= xy <= typemax($T)) || throw(OverflowError())
-        return mod(xy,$T)
+        return xy % $T
     end
 end
 
@@ -506,7 +507,7 @@ for T in (Int64,Uint64)
     @eval function checked_mul(x::$T, y::$T)
         xy = int128(x)*int128(y)
         (typemin($T) <= xy <= typemax($T)) || throw(OverflowError())
-        return mod(xy,$T)
+        return xy % $T
     end
 end
 else

--- a/base/int.jl
+++ b/base/int.jl
@@ -156,12 +156,13 @@ for to in tuple(IntTypes...,Char), from in tuple(IntTypes...,Char,Bool)
                 @eval convert(::Type{$to}, x::($from)) = box($to,checked_trunc_uint($to,unbox($from,x)))
             end
             @eval mod(x::($from), ::Type{$to}) = box($to,trunc_int($to,unbox($from,x)))
-        elseif from.size < to.size || from===Bool
+        elseif from.size < to.size || from === Bool
             if issubtype(from, Signed)
                 @eval convert(::Type{$to}, x::($from)) = box($to,sext_int($to,unbox($from,x)))
             else
                 @eval convert(::Type{$to}, x::($from)) = box($to,zext_int($to,unbox($from,x)))
             end
+            @eval mod(x::($from), ::Type{$to}) = convert($to,x)
         else
             if !(issubtype(from,Signed) === issubtype(to,Signed))
                 # raise InexactError if x's top bit is set
@@ -169,7 +170,7 @@ for to in tuple(IntTypes...,Char), from in tuple(IntTypes...,Char,Bool)
             else
                 @eval convert(::Type{$to}, x::($from)) = box($to,unbox($from,x))
             end
-            @eval itrunc(::Type{$to}, x::($from)) = box($to,unbox($from,x))
+            @eval mod(x::($from), ::Type{$to}) = box($to,unbox($from,x))
         end
     end
 end

--- a/base/pkg/types.jl
+++ b/base/pkg/types.jl
@@ -44,7 +44,7 @@ function intersect(A::VersionSet, B::VersionSet)
     VersionSet(ivals)
 end
 ==(A::VersionSet, B::VersionSet) = A.intervals == B.intervals
-hash(s::VersionSet, h::Uint) = hash(s.intervals, h + itrunc(Uint,0x2fd2ca6efa023f44))
+hash(s::VersionSet, h::Uint) = hash(s.intervals, h + mod(0x2fd2ca6efa023f44,Uint))
 deepcopy_internal(vs::VersionSet, ::ObjectIdDict) = VersionSet(copy(vs.intervals))
 
 typealias Requires Dict{ByteString,VersionSet}

--- a/base/pkg/types.jl
+++ b/base/pkg/types.jl
@@ -44,7 +44,7 @@ function intersect(A::VersionSet, B::VersionSet)
     VersionSet(ivals)
 end
 ==(A::VersionSet, B::VersionSet) = A.intervals == B.intervals
-hash(s::VersionSet, h::Uint) = hash(s.intervals, h + mod(0x2fd2ca6efa023f44,Uint))
+hash(s::VersionSet, h::Uint) = hash(s.intervals, h + (0x2fd2ca6efa023f44 % Uint))
 deepcopy_internal(vs::VersionSet, ::ObjectIdDict) = VersionSet(copy(vs.intervals))
 
 typealias Requires Dict{ByteString,VersionSet}

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -104,7 +104,7 @@ const UNKNOWN = LineInfo("?", "?", -1, true, 0)
 ==(a::LineInfo, b::LineInfo) = a.line == b.line && a.fromC == b.fromC && a.func == b.func && a.file == b.file
 
 function hash(li::LineInfo, h::Uint)
-    h += mod(0xf4fbda67fe20ce88,Uint)
+    h += 0xf4fbda67fe20ce88 % Uint
     h = hash(li.line, h)
     h = hash(li.file, h)
     h = hash(li.func, h)

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -104,7 +104,7 @@ const UNKNOWN = LineInfo("?", "?", -1, true, 0)
 ==(a::LineInfo, b::LineInfo) = a.line == b.line && a.fromC == b.fromC && a.func == b.func && a.file == b.file
 
 function hash(li::LineInfo, h::Uint)
-    h += itrunc(Uint,0xf4fbda67fe20ce88)
+    h += mod(0xf4fbda67fe20ce88,Uint)
     h = hash(li.line, h)
     h = hash(li.file, h)
     h = hash(li.func, h)

--- a/base/random.jl
+++ b/base/random.jl
@@ -104,14 +104,14 @@ rand(r::MersenneTwister) = dsfmt_genrand_close_open(r.state)
 dsfmt_randui32() = dsfmt_gv_genrand_uint32()
 dsfmt_randui64() = uint64(dsfmt_randui32()) | (uint64(dsfmt_randui32())<<32)
 
-rand(::Type{Uint8})   = itrunc(Uint8,rand(Uint32))
-rand(::Type{Uint16})  = itrunc(Uint16,rand(Uint32))
+rand(::Type{Uint8})   = mod(rand(Uint32),Uint8)
+rand(::Type{Uint16})  = mod(rand(Uint32),Uint16)
 rand(::Type{Uint32})  = dsfmt_randui32()
 rand(::Type{Uint64})  = dsfmt_randui64()
 rand(::Type{Uint128}) = uint128(rand(Uint64))<<64 | rand(Uint64)
 
-rand(::Type{Int8})    = itrunc(Int8,rand(Uint32))
-rand(::Type{Int16})   = itrunc(Int16,rand(Uint32))
+rand(::Type{Int8})    = mod(rand(Uint32),Int8)
+rand(::Type{Int16})   = mod(rand(Uint32),Int16)
 rand(::Type{Int32})   = reinterpret(Int32,rand(Uint32))
 rand(::Type{Int64})   = reinterpret(Int64,rand(Uint64))
 rand(::Type{Int128})  = reinterpret(Int128,rand(Uint128))
@@ -154,12 +154,12 @@ rem_knuth{T<:Unsigned}(a::T, b::T) = b != 0 ? a % b : a
 
 # maximum multiple of k <= 2^bits(T) decremented by one,
 # that is 0xFFFFFFFF if k = typemax(T) - typemin(T) with intentional underflow
-maxmultiple(k::Uint32) = itrunc(Uint32, div(0x0000000100000000,k + (k == 0))*k - 1)
-maxmultiple(k::Uint64) = itrunc(Uint64, div(0x00000000000000010000000000000000, k + (k == 0))*k - 1)
+maxmultiple(k::Uint32) = mod(div(0x0000000100000000,k + (k == 0))*k - 1, Uint32)
+maxmultiple(k::Uint64) = mod(div(0x00000000000000010000000000000000, k + (k == 0))*k - 1, Uint64)
 # maximum multiple of k within 1:typemax(Uint128)
 maxmultiple(k::Uint128) = div(typemax(Uint128), k + (k == 0))*k - 1
 # maximum multiple of k within 1:2^32 or 1:2^64, depending on size
-maxmultiplemix(k::Uint64) = itrunc(Uint64, div((k >> 32 != 0)*0x0000000000000000FFFFFFFF00000000 + 0x0000000100000000, k + (k == 0))*k - 1)
+maxmultiplemix(k::Uint64) = mod(div((k >> 32 != 0)*0x0000000000000000FFFFFFFF00000000 + 0x0000000100000000, k + (k == 0))*k - 1, Uint64)
 
 immutable RandIntGen{T<:Integer, U<:Unsigned}
     a::T   # first element of the range
@@ -206,7 +206,7 @@ function rand{T<:Integer, U<:Unsigned}(g::RandIntGen{T,U})
     while x > g.u
         x = rand(U)
     end
-    itrunc(T, unsigned(g.a) + rem_knuth(x, g.k))
+    mod(unsigned(g.a) + rem_knuth(x, g.k), T)
 end
 
 rand{T<:Union(Signed,Unsigned,Bool,Char)}(r::UnitRange{T}) = rand(RandIntGen(r))

--- a/base/random.jl
+++ b/base/random.jl
@@ -104,14 +104,14 @@ rand(r::MersenneTwister) = dsfmt_genrand_close_open(r.state)
 dsfmt_randui32() = dsfmt_gv_genrand_uint32()
 dsfmt_randui64() = uint64(dsfmt_randui32()) | (uint64(dsfmt_randui32())<<32)
 
-rand(::Type{Uint8})   = mod(rand(Uint32),Uint8)
-rand(::Type{Uint16})  = mod(rand(Uint32),Uint16)
+rand(::Type{Uint8})   = rand(Uint32) % Uint8
+rand(::Type{Uint16})  = rand(Uint32) % Uint16
 rand(::Type{Uint32})  = dsfmt_randui32()
 rand(::Type{Uint64})  = dsfmt_randui64()
 rand(::Type{Uint128}) = uint128(rand(Uint64))<<64 | rand(Uint64)
 
-rand(::Type{Int8})    = mod(rand(Uint32),Int8)
-rand(::Type{Int16})   = mod(rand(Uint32),Int16)
+rand(::Type{Int8})    = rand(Uint32) % Int8
+rand(::Type{Int16})   = rand(Uint32) % Int16
 rand(::Type{Int32})   = reinterpret(Int32,rand(Uint32))
 rand(::Type{Int64})   = reinterpret(Int64,rand(Uint64))
 rand(::Type{Int128})  = reinterpret(Int128,rand(Uint128))
@@ -154,12 +154,12 @@ rem_knuth{T<:Unsigned}(a::T, b::T) = b != 0 ? a % b : a
 
 # maximum multiple of k <= 2^bits(T) decremented by one,
 # that is 0xFFFFFFFF if k = typemax(T) - typemin(T) with intentional underflow
-maxmultiple(k::Uint32) = mod(div(0x0000000100000000,k + (k == 0))*k - 1, Uint32)
-maxmultiple(k::Uint64) = mod(div(0x00000000000000010000000000000000, k + (k == 0))*k - 1, Uint64)
+maxmultiple(k::Uint32) = (div(0x0000000100000000,k + (k == 0))*k - 1) % Uint32
+maxmultiple(k::Uint64) = (div(0x00000000000000010000000000000000, k + (k == 0))*k - 1) % Uint64
 # maximum multiple of k within 1:typemax(Uint128)
 maxmultiple(k::Uint128) = div(typemax(Uint128), k + (k == 0))*k - 1
 # maximum multiple of k within 1:2^32 or 1:2^64, depending on size
-maxmultiplemix(k::Uint64) = mod(div((k >> 32 != 0)*0x0000000000000000FFFFFFFF00000000 + 0x0000000100000000, k + (k == 0))*k - 1, Uint64)
+maxmultiplemix(k::Uint64) = (div((k >> 32 != 0)*0x0000000000000000FFFFFFFF00000000 + 0x0000000100000000, k + (k == 0))*k - 1) % Uint64
 
 immutable RandIntGen{T<:Integer, U<:Unsigned}
     a::T   # first element of the range
@@ -206,7 +206,7 @@ function rand{T<:Integer, U<:Unsigned}(g::RandIntGen{T,U})
     while x > g.u
         x = rand(U)
     end
-    mod(unsigned(g.a) + rem_knuth(x, g.k), T)
+    (unsigned(g.a) + rem_knuth(x, g.k)) % T
 end
 
 rand{T<:Union(Signed,Unsigned,Bool,Char)}(r::UnitRange{T}) = rand(RandIntGen(r))

--- a/base/string.jl
+++ b/base/string.jl
@@ -661,7 +661,7 @@ const memhash_seed = Uint === Uint64 ? 0x71e729fd56419c81 : 0x56419c81
 
 function hash{T<:ByteString}(s::Union(T,SubString{T}), h::Uint)
     h += memhash_seed
-    ccall(memhash, Uint, (Ptr{Uint8}, Csize_t, Uint32), s, sizeof(s), itrunc(Uint32,h)) + h
+    ccall(memhash, Uint, (Ptr{Uint8}, Csize_t, Uint32), s, sizeof(s), mod(h,Uint32)) + h
 end
 hash(s::String, h::Uint) = hash(bytestring(s), h)
 

--- a/base/string.jl
+++ b/base/string.jl
@@ -661,7 +661,7 @@ const memhash_seed = Uint === Uint64 ? 0x71e729fd56419c81 : 0x56419c81
 
 function hash{T<:ByteString}(s::Union(T,SubString{T}), h::Uint)
     h += memhash_seed
-    ccall(memhash, Uint, (Ptr{Uint8}, Csize_t, Uint32), s, sizeof(s), mod(h,Uint32)) + h
+    ccall(memhash, Uint, (Ptr{Uint8}, Csize_t, Uint32), s, sizeof(s), h % Uint32) + h
 end
 hash(s::String, h::Uint) = hash(bytestring(s), h)
 

--- a/base/version.jl
+++ b/base/version.jl
@@ -151,7 +151,7 @@ function isless(a::VersionNumber, b::VersionNumber)
 end
 
 function hash(v::VersionNumber, h::Uint)
-    h += itrunc(Uint,0x8ff4ffdb75f9fede)
+    h += mod(0x8ff4ffdb75f9fede,Uint)
     h = hash(v.major, h)
     h = hash(v.minor, h)
     h = hash(v.patch, h)

--- a/base/version.jl
+++ b/base/version.jl
@@ -151,7 +151,7 @@ function isless(a::VersionNumber, b::VersionNumber)
 end
 
 function hash(v::VersionNumber, h::Uint)
-    h += mod(0x8ff4ffdb75f9fede,Uint)
+    h += 0x8ff4ffdb75f9fede % Uint
     h = hash(v.major, h)
     h = hash(v.minor, h)
     h = hash(v.patch, h)

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -23,7 +23,7 @@ function coerce(T::Type, x)
     if !(T<:Integer) || T===Bool
         convert(T, x)
     elseif sizeof(T) < sizeof(x)
-        mod(x, T)
+        x % T
     elseif sizeof(T) == sizeof(x)
         reinterpret(T, x)
     else

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -23,7 +23,7 @@ function coerce(T::Type, x)
     if !(T<:Integer) || T===Bool
         convert(T, x)
     elseif sizeof(T) < sizeof(x)
-        itrunc(T, x)
+        mod(x, T)
     elseif sizeof(T) == sizeof(x)
         reinterpret(T, x)
     else


### PR DESCRIPTION
Here's the proposal I put forth in #8646 to replace `itrunc(Uint8, 1234)` etc. with `mod(1234, Uint8)`. Not necessarily how we want to do this, but at least it (hopefully) identifies all the places in base where this needs to be changed.
