### PR TITLE
base.rst: Update 'Combinatorics' documentation

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4485,7 +4485,7 @@ Combinatorics
 
    Generate all permutations of an indexable object.  Because the
    number of permutations can be very large, this function returns an
-   iterator object. Use ``collect(permutations(array,n))`` to get an array
+   iterator object. Use ``collect(permutations(array))`` to get an array
    of all permutations.
 
 .. function:: partitions(n)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4474,18 +4474,18 @@ Combinatorics
 
    In-place version of :func:`reverse`.
 
-.. function:: combinations(arr, n)
+.. function:: combinations(array, n)
 
    Generate all combinations of ``n`` elements from an indexable
    object.  Because the number of combinations can be very large, this
    function returns an iterator object. Use
-   ``collect(combinations(a,n))`` to get an array of all combinations.
+   ``collect(combinations(array,n))`` to get an array of all combinations.
 
-.. function:: permutations(arr)
+.. function:: permutations(array)
 
    Generate all permutations of an indexable object.  Because the
    number of permutations can be very large, this function returns an
-   iterator object. Use ``collect(permutations(a,n))`` to get an array
+   iterator object. Use ``collect(permutations(array,n))`` to get an array
    of all permutations.
 
 .. function:: partitions(n)


### PR DESCRIPTION
- Use 'array' consistently, instead of a mixture of 'a', 'arr', 'array'.
- Correct example for collecting permutations
