### PR TITLE
static compile part 3 (modules)

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1141,6 +1141,8 @@ DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v)
         else {
             n += JL_PRINTF(out, "(?)");
         }
+        JL_PRINTF(out, " -> ");
+        jl_static_show(out, !jl_is_expr(li->ast) ? jl_uncompress_ast(li, li->ast) : li->ast);
     }
     else if (jl_is_tuple(v)) {
         n += jl_show_tuple(out, (jl_tuple_t*)v, "(", ")", 1);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1131,6 +1131,12 @@ DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v)
     if (v == NULL) {
         n += JL_PRINTF(out, "#<null>");
     }
+    else if (v->type == NULL) {
+        n += JL_PRINTF(out, "<?::#null>");
+    }
+    else if ((uptrint_t)v->type < 4096U) {
+        n += JL_PRINTF(out, "<?::#%d>", (int)(uptrint_t)v->type);
+    }
     else if (jl_is_lambda_info(v)) {
         jl_lambda_info_t *li = (jl_lambda_info_t*)v;
         n += jl_static_show(out, (jl_value_t*)li->module);
@@ -1241,7 +1247,7 @@ DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v)
     }
     else if (jl_is_typevar(v)) {
         n += jl_static_show(out, ((jl_tvar_t*)v)->lb);
-        n += JL_PRINTF(out, "<:%s<:", ((jl_tvar_t*)v)->name->name);
+        n += JL_PRINTF(out, "<:%s%s<:", (((jl_tvar_t*)v)->bound)?"#":"", ((jl_tvar_t*)v)->name->name); 
         n += jl_static_show(out, ((jl_tvar_t*)v)->ub);
     }
     else if (jl_is_module(v)) {

--- a/src/gf.c
+++ b/src/gf.c
@@ -156,7 +156,7 @@ jl_methlist_t *mtcache_hash_lookup(jl_array_t *a, jl_value_t *ty, int tparam)
     return (jl_methlist_t*)JL_NULL;
 }
 
-static void mtcache_rehash(jl_array_t **pa)
+void mtcache_rehash(jl_array_t **pa)
 {
     size_t len = (*pa)->nrows;
     jl_value_t **d = (jl_value_t**)(*pa)->data;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1386,7 +1386,6 @@ jl_function_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t na
     return sf;
 }
 
-void jl_add_constructors(jl_datatype_t *t);
 DLLEXPORT jl_value_t *jl_matching_methods(jl_function_t *gf, jl_value_t *type, int lim);
 
 // compile-time method lookup

--- a/src/gf.c
+++ b/src/gf.c
@@ -156,7 +156,7 @@ jl_methlist_t *mtcache_hash_lookup(jl_array_t *a, jl_value_t *ty, int tparam)
     return (jl_methlist_t*)JL_NULL;
 }
 
-void mtcache_rehash(jl_array_t **pa)
+static void mtcache_rehash(jl_array_t **pa)
 {
     size_t len = (*pa)->nrows;
     jl_value_t **d = (jl_value_t**)(*pa)->data;
@@ -324,7 +324,6 @@ jl_methlist_t *jl_method_list_insert(jl_methlist_t **pml, jl_tuple_t *type,
                                      jl_function_t *method, jl_tuple_t *tvars,
                                      int check_amb, int8_t isstaged);
 
-static
 jl_function_t *jl_method_cache_insert(jl_methtable_t *mt, jl_tuple_t *type,
                                       jl_function_t *method)
 {

--- a/src/gf.c
+++ b/src/gf.c
@@ -841,7 +841,7 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tuple_t *type,
     assert(!(newmeth->linfo && newmeth->linfo->ast) ||
            newmeth->fptr == &jl_trampoline);
     */
-    if (newmeth->linfo&&newmeth->linfo->ast&&newmeth->fptr!=&jl_trampoline) {
+    if (newmeth->linfo && newmeth->linfo->ast && newmeth->fptr != &jl_trampoline) {
         newmeth->fptr = &jl_trampoline;
     }
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -55,8 +55,6 @@ jl_datatype_t *jl_number_type;
 jl_tuple_t *jl_null;
 jl_value_t *jl_nothing;
 
-void jl_add_constructors(jl_datatype_t *t);
-
 // --- type properties and predicates ---
 
 int jl_is_type(jl_value_t *v)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1725,7 +1725,8 @@ void jl_set_t_uid_ctr(int i) { t_uid_ctr=i; }
 
 int jl_assign_type_uid(void)
 {
-    return int32hash(t_uid_ctr++);
+    assert(t_uid_ctr != 0);
+    return t_uid_ctr++;
 }
 
 static void cache_type_(jl_value_t *type)

--- a/src/julia.h
+++ b/src/julia.h
@@ -877,6 +877,8 @@ DLLEXPORT extern char *julia_home;
 
 DLLEXPORT void jl_save_system_image(char *fname);
 DLLEXPORT void jl_restore_system_image(char *fname);
+int jl_save_new_module(char *fname, jl_module_t *mod);
+jl_module_t *jl_restore_new_module(char *fname);
 void jl_init_restored_modules();
 
 // front end interface
@@ -1050,6 +1052,10 @@ extern DLLEXPORT jl_gcframe_t *jl_pgcstack;
 
 #define JL_GC_PUSH4(arg1, arg2, arg3, arg4)                               \
   void *__gc_stkf[] = {(void*)9, jl_pgcstack, arg1, arg2, arg3, arg4};    \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+
+#define JL_GC_PUSH5(arg1, arg2, arg3, arg4, arg5)                               \
+  void *__gc_stkf[] = {(void*)11, jl_pgcstack, arg1, arg2, arg3, arg4, arg5};    \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 
 #define JL_GC_PUSHARGS(rts_var,n)                               \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -72,6 +72,7 @@ int jl_types_equal_generic(jl_value_t *a, jl_value_t *b, int useenv);
 
 void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super);
 void jl_initialize_generic_function(jl_function_t *f, jl_sym_t *name);
+void jl_add_constructors(jl_datatype_t *t);
 
 void jl_compute_field_offsets(jl_datatype_t *st);
 jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, size_t *dims,

--- a/src/support/arraylist.c
+++ b/src/support/arraylist.c
@@ -35,7 +35,7 @@ void arraylist_free(arraylist_t *a)
     a->items = &a->_space[0];
 }
 
-static void al_grow(arraylist_t *a, size_t n)
+void arraylist_grow(arraylist_t *a, size_t n)
 {
     if (a->len+n > a->max) {
         if (a->items == &a->_space[0]) {
@@ -60,7 +60,7 @@ static void al_grow(arraylist_t *a, size_t n)
 
 void arraylist_push(arraylist_t *a, void *elt)
 {
-    al_grow(a, 1);
+    arraylist_grow(a, 1);
     a->items[a->len-1] = elt;
 }
 

--- a/src/support/arraylist.h
+++ b/src/support/arraylist.h
@@ -19,6 +19,7 @@ void arraylist_free(arraylist_t *a);
 
 void arraylist_push(arraylist_t *a, void *elt);
 void *arraylist_pop(arraylist_t *a);
+void arraylist_grow(arraylist_t *a, size_t n);
 
 #ifdef __cplusplus
 }

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -624,7 +624,6 @@ void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super)
 // method definition ----------------------------------------------------------
 
 extern int jl_boot_file_loaded;
-void jl_add_constructors(jl_datatype_t *t);
 
 static int type_contains(jl_value_t *ty, jl_value_t *x)
 {

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -135,29 +135,29 @@ void parse_opts(int *argcp, char ***argvp)
         case 'h':
             printf("%s%s", usage, opts);
             exit(0);
-	case 'c':
-	    if (optarg != NULL) {
-		if (!strcmp(optarg,"user"))
-		    codecov = JL_LOG_USER;
-		else if (!strcmp(optarg,"all"))
-		    codecov = JL_LOG_ALL;
-		else if (!strcmp(optarg,"none"))
-		    codecov = JL_LOG_NONE;
-	        break;
-	    }
-	    else
-		codecov = JL_LOG_USER;
-	    break;
-	case 'm':
-	    if (optarg != NULL) {
-		if (!strcmp(optarg,"user"))
-		    malloclog = JL_LOG_USER;
-		else if (!strcmp(optarg,"all"))
-		    malloclog = JL_LOG_ALL;
-		else if (!strcmp(optarg,"none"))
-		    malloclog = JL_LOG_NONE;
-	        break;
-	    }
+        case 'c':
+            if (optarg != NULL) {
+            if (!strcmp(optarg,"user"))
+                codecov = JL_LOG_USER;
+            else if (!strcmp(optarg,"all"))
+                codecov = JL_LOG_ALL;
+            else if (!strcmp(optarg,"none"))
+                codecov = JL_LOG_NONE;
+                break;
+            }
+            else
+            codecov = JL_LOG_USER;
+            break;
+        case 'm':
+            if (optarg != NULL) {
+            if (!strcmp(optarg,"user"))
+                malloclog = JL_LOG_USER;
+            else if (!strcmp(optarg,"all"))
+                malloclog = JL_LOG_ALL;
+            else if (!strcmp(optarg,"none"))
+                malloclog = JL_LOG_NONE;
+                break;
+            }
         case 300:
             if (!strcmp(optarg,"yes"))
                 jl_compileropts.check_bounds = JL_COMPILEROPT_CHECK_BOUNDS_ON;


### PR DESCRIPTION
This prepares the serializer to be able to handle incremental loading (aka module caching). Currently there is no interface to it exposed to the user (other than the raw interface I demonstrate below for testing). Static compile part 4 to add the user-friendly interface will be developed shortly, but I wanted to go ahead and get this merged first since that is a separate task. Part 4 is expected to be easy technically but has more UI questions to answer.

``` julia
julia> @time begin
           FP = ccall(:jl_restore_new_module, Any, (Ptr{Uint8},), "FixedPointNumbers_cache.jlc")
           C = ccall(:jl_restore_new_module, Any, (Ptr{Uint8},), "Color_cache.jlc")
           C2 = ccall(:jl_restore_new_module, Any, (Ptr{Uint8},), "Cairo_cache.jlc")
           G = ccall(:jl_restore_new_module, Any, (Ptr{Uint8},), "Gtk_cache.jlc")
           Gtk.GLib.__init__()
           Gtk.__init__()
       end
elapsed time: 0.691674234 seconds (14420556 bytes allocated)

julia> evalfile(Pkg.dir("FixedPointNumbers/test/runtests.jl"))

julia> evalfile(Pkg.dir("Color/test/runtests.jl"))

julia> evalfile(Pkg.dir("Cairo/test/test_speed.jl"))
<output clipped>

julia> evalfile(Pkg.dir("Gtk/test/tests.jl"))

julia> # All tests passed :)
```

note: this would have been fully compatible with the current serializer, except that I changed the deser_tag hash-table (with indexes from 0 to 255) into an array.
