### PR TITLE
Update docs for 0.4-dev

### DIFF
--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -29,7 +29,7 @@ technical computing languages pass arrays by value, and this is
 convenient in many cases. In Julia, modifications made to input arrays
 within a function will be visible in the parent function. The entire
 Julia array library ensures that inputs are not modified by library
-functions. User code, if it needs to exhibit similar behaviour, should
+functions. User code, if it needs to exhibit similar behavior, should
 take care to create a copy of inputs that it may modify.
 
 Arrays

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -130,20 +130,6 @@ An array with a specific element type can be constructed using the syntax
 ``T[A, B, C, ...]``. This will construct a 1-d array with element type
 ``T``, initialized to contain elements ``A``, ``B``, ``C``, etc.
 
-Special syntax is available for constructing arrays with element type
-``Any``:
-
-=================== =========
-Expression          Yields
-=================== =========
-``{A B C ...}``     A 1xN ``Any`` array
-``{A, B, C, ...}``  A 1-d ``Any`` array (vector)
-``{A B; C D; ...}`` A 2-d ``Any`` array
-=================== =========
-
-Note that this form does not do any concatenation; each argument becomes
-an element of the resulting array.
-
 .. _comprehensions:
 
 Comprehensions

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -130,6 +130,28 @@ An array with a specific element type can be constructed using the syntax
 ``T[A, B, C, ...]``. This will construct a 1-d array with element type
 ``T``, initialized to contain elements ``A``, ``B``, ``C``, etc.
 
+An array constructed with an explicit type annotation does not automatically concatenate its arguments.
+
+.. doctest::
+
+    julia> [[1 2] [3 4]]
+    1x4 Array{Int64,2}:
+     1  2  3  4
+
+    julia> Int64[[1 2] [3 4]]
+    ERROR: `convert` has no method matching convert(::Type{Int64}, ::Array{Int64,2})
+    <BLANKLINE>
+    You might have used a 2d row vector where a 1d column vector was required.
+    Note the difference between 1d column vector [1,2,3] and 2d row vector [1 2 3].
+    You can convert to a column vector with the vec() function.
+     in setindex! at array.jl:307
+
+    julia> Array[[1 2] [3 4]]
+    1x2 Array{Array{T,N},2}:
+     1x2 Array{Int64,2}:
+     1  2  1x2 Array{Int64,2}:
+     3  4
+
 .. _comprehensions:
 
 Comprehensions

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -212,17 +212,6 @@ that the result is of type ``Float64`` by writing::
 
     Float64[ 0.25*x[i-1] + 0.5*x[i] + 0.25*x[i+1] for i=2:length(x)-1 ]
 
-Using curly brackets instead of square brackets is a shorthand notation for an
-array of type ``Any``:
-
-.. doctest::
-
-    julia> { i/2 for i = 1:3 }
-    3-element Array{Any,1}:
-     0.5
-     1.0
-     1.5
-
 .. _man-array-indexing:
 
 Indexing

--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -158,7 +158,7 @@ versus ``-1 + 0im`` even though ``-1 == -1 + 0im``:
     ERROR: DomainError
     sqrt will only return a complex result if called with a complex argument.
     try sqrt(complex(x))
-     in sqrt at math.jl:131
+     in sqrt at math.jl:132
 
     julia> sqrt(-1 + 0im)
     0.0 + 1.0im

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -588,7 +588,7 @@ negative real value:
     ERROR: DomainError
     sqrt will only return a complex result if called with a complex argument.
     try sqrt(complex(x))
-     in sqrt at math.jl:131
+     in sqrt at math.jl:132
 
 You may define your own exceptions in the following way:
 

--- a/doc/manual/conversion-and-promotion.rst
+++ b/doc/manual/conversion-and-promotion.rst
@@ -294,7 +294,7 @@ This allows calls like the following to work:
     -3//1
 
     julia> typeof(ans)
-    Rational{Int64} (constructor with 1 method)
+    Rational{Int32} (constructor with 1 method)
 
 For most user-defined types, it is better practice to require
 programmers to supply the expected types to constructor functions

--- a/doc/manual/conversion-and-promotion.rst
+++ b/doc/manual/conversion-and-promotion.rst
@@ -98,7 +98,7 @@ requested conversion:
 
     julia> convert(FloatingPoint, "foo")
     ERROR: `convert` has no method matching convert(::Type{FloatingPoint}, ::ASCIIString)
-     in convert at base.jl:13
+     in convert at base.jl:9
 
 Some languages consider parsing strings as numbers or formatting
 numbers as strings to be conversions (many dynamic languages will even
@@ -138,7 +138,7 @@ to zero:
 
     julia> convert(Bool, 1im)
     ERROR: InexactError()
-     in convert at complex.jl:18
+     in convert at complex.jl:16
 
     julia> convert(Bool, 0im)
     false

--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -188,7 +188,7 @@ such as integers are given by the ``typemin`` and ``typemax`` functions:
     julia> (typemin(Int32), typemax(Int32))
     (-2147483648,2147483647)
 
-    julia> for T = {Int8,Int16,Int32,Int64,Int128,Uint8,Uint16,Uint32,Uint64,Uint128}
+    julia> for T in [Int8,Int16,Int32,Int64,Int128,Uint8,Uint16,Uint32,Uint64,Uint128]
              println("$(lpad(T,7)): [$(typemin(T)),$(typemax(T))]")
            end
        Int8: [-128,127]


### PR DESCRIPTION
This PR updates the doctest behaviors to 0.4-dev.
- Remove all uses of `{}` from the doctests.
- Add note that typed array constructor `T[...]` does not automatically concatenate
- Line number changes in error messages
- Updated integer promotion rules

The doctests still fail for the types documentation, which will be addressed separately.
