### PR TITLE
Update type docs to 0.4-dev

### DIFF
--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -120,13 +120,13 @@ using the ``convert`` function:
 .. doctest:: foo-func
 
     julia> function foo()
-             x::Int8 = 1000
+             x::Int8 = 100
              x
            end
     foo (generic function with 1 method)
 
     julia> foo()
-    -24
+    100
 
     julia> typeof(ans)
     Int8

--- a/doc/manual/types.rst
+++ b/doc/manual/types.rst
@@ -629,14 +629,13 @@ union of no types is the "bottom" type, ``None``:
 
 .. doctest::
 
-    julia> Union()
-    None
+    julia> None
+    Union()
 
 Recall from the `discussion above <#Any+and+None>`_ that ``None`` is the
 abstract type which is the subtype of all other types, and which no
-object is an instance of. Since a zero-argument ``Union`` call has no
-argument types for objects to be instances of, it should produce a
-type which no objects are instances of — i.e. ``None``.
+object is an instance of. ``None`` is therefore synonymous with a zero-argument
+``Union`` type, which has no argument types for objects to be instances of.
 
 .. _man-parametric-types:
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -3845,7 +3845,7 @@ Integers
 
    .. doctest::
 
-      julia> leading_ones(int32(2 ^ 32 - 2))
+      julia> leading_ones(uint32(2 ^ 32 - 2))
       31
 
 .. function:: trailing_zeros(x::Integer) -> Integer


### PR DESCRIPTION
Building upon #8658, this PR contains updates to the type documentation for 0.4-dev.

With this PR and #8658, the doctests now pass on 0.4-dev.

Submitting as separate PR since the proposed changes might be more controversial.
