### PR TITLE
Add function for machine precision number to avoid expensive calculations in the Givens rotation algorithms

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -75,6 +75,8 @@ Library improvements
 
   * `deepcopy` recurses through immutable types and makes copies of their mutable fields ([#8560]).
 
+  * Givens type doesn't have a size anymore and is no longer a subtype of AbstractMatrix ([#8660])
+
 Deprecated or removed
 ---------------------
 


### PR DESCRIPTION
That appears to give more than three times speedup.

This pr also removes the subtype relation to AbstractMatrix and therefore also the now unnecessary ambiguity avoiding method definitions. The size parameter is remove as it is an unnecessary restriction. Finally, the pr adds `@simd` and `@inbounds` in the methods for applying Givens rotations.

[pao: quoting]
