### PR TITLE
RFC: Function matchall with overlaps

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -165,7 +165,7 @@ function matchall(re::Regex, str::UTF8String, overlap::Bool=false)
         prevempty = offset == ovec[2]
         if overlap
             if !prevempty
-                offset = int32(nextind(str, offset + 1) - 1)
+                offset = int32(ovec[1]+1)
             end
         else
             offset = ovec[2]

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -16,6 +16,8 @@ for f in [matchall, collect_eachmatch]
     @test f(r"aa", "aaaa", true) == ["aa", "aa", "aa"]
     @test f(r"", "aaa") == ["", "", "", ""]
     @test f(r"", "aaa", true) == ["", "", "", ""]
+    @test f(r"GCG","GCGCG") == ["GCG"]
+    @test f(r"GCG","GCGCG",true) == ["GCG","GCG"]
 end
 
 # Issue 8278


### PR DESCRIPTION
This closes #8677.
Problem was that the offset was moving one index at a time instead of moving to the start + 1 of the last match. Therefore matching r"GCG" in "GCGCG" matched when offset was 0, 1 and 2 instead of matching with offset 0 and 2.
