### PR TITLE
Generalize convert for dict

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -366,7 +366,7 @@ dict_with_eltype(kv, t) = Dict{Any,Any}(kv)
 similar{K,V}(d::Dict{K,V}) = Dict{K,V}()
 
 # conversion between Dict types
-function convert{K,V}(::Type{Dict{K,V}},d::Dict)
+function convert{K,V}(::Type{Dict{K,V}},d::Associative)
     h = Dict{K,V}()
     for (k,v) in d
         ck = convert(K,k)


### PR DESCRIPTION
The convert function's second argument can be any associative type, not just another dict, so it should be written more generally.
