### PR TITLE
writecsv now only for vectors & matrices fix #8675

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -523,7 +523,8 @@ end
 
 writedlm{T}(io::IO, a::AbstractArray{T,0}, dlm; opts...) = writedlm(io, reshape(a,1), dlm; opts...)
 
-function writedlm(io::IO, a::AbstractArray, dlm; opts...)
+#=
+function writedlm_ndarray(io::IO, a::AbstractArray, dlm; opts...)
     tail = size(a)[3:end]
     function print_slice(idxs...)
         writedlm(io, sub(a, 1:size(a,1), 1:size(a,2), idxs...), dlm; opts...)
@@ -533,6 +534,7 @@ function writedlm(io::IO, a::AbstractArray, dlm; opts...)
     end
     cartesianmap(print_slice, tail)
 end
+=#
 
 function writedlm(io::IO, itr, dlm; opts...)
     optsd = val_opts(opts)

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -3208,7 +3208,7 @@
 
 ("Base","writedlm","writedlm(f, A, delim='t')
 
-   Write \"A\" (either an array type or an iterable collection of
+   Write \"A\" (a vector, matrix or an iterable collection of
    iterable rows) as text to \"f\" (either a filename string or an
    \"IO\" stream) using the given delimeter \"delim\" (which defaults
    to tab, but can be any printable Julia object, typically a \"Char\"

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -2168,7 +2168,7 @@ Text I/O
 
 .. function:: writedlm(f, A, delim='\t')
 
-   Write ``A`` (either an array type or an iterable collection of iterable rows) as text to ``f`` (either a filename string or an ``IO`` stream) using the given delimeter ``delim`` (which defaults to tab, but can be any printable Julia object, typically a ``Char`` or ``String``).
+   Write ``A`` (a vector, matrix or an iterable collection of iterable rows) as text to ``f`` (either a filename string or an ``IO`` stream) using the given delimeter ``delim`` (which defaults to tab, but can be any printable Julia object, typically a ``Char`` or ``String``).
 
    For example, two vectors ``x`` and ``y`` of the same length can
    be written as two columns of tab-delimited text to ``f`` by


### PR DESCRIPTION
`writecsv` methods on `AbstractArray` and iterators are now removed (commented).
