### PR TITLE
fix #8678, reading large files on windows

### DIFF
--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -73,9 +73,12 @@ static int _enonfatal(int err)
 
 #define SLEEP_TIME 5//ms
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
 #define MAXSIZE ((1l << 31) - 1)   // OSX cannot handle blocks larger than this
 #define LIMIT_IO_SIZE(n) ((n) < MAXSIZE ? (n) : MAXSIZE)
+#elif defined(_OS_WINDOWS_)
+#define MAXSIZE (0x7fffffff)       // Windows read() takes a uint
+#define LIMIT_IO_SIZE(n) ((n) < (size_t)MAXSIZE ? (unsigned int)(n) : MAXSIZE)
 #else
 #define LIMIT_IO_SIZE(n) (n)
 #endif


### PR DESCRIPTION
read() on windows takes a uint, so apply a similar io limit per call
as done on mac (directly reusing the same code would give a compiler
warning, since long is 32 bits on windows)

@vtjnash, look ok? I was able to `read!` a 6 GB file with this change.
