### PR TITLE
Use alternative for length(partitions(::Array)), bell(n::Int)

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -446,7 +446,7 @@ immutable SetPartitions{T<:AbstractVector}
     s::T
 end
 
-length(p::SetPartitions) = nsetpartitions(length(p.s))
+length(p::SetPartitions) = bell(length(p.s)) ## nsetpartitions(length(p.s))
 
 partitions(s::AbstractVector) = SetPartitions(s)
 
@@ -506,6 +506,36 @@ let _nsetpartitions = Dict{Int,Int}()
             _nsetpartitions[n] = wn
         end
     end
+end
+
+function bell(n::Int)
+    if n<0
+        0
+    elseif n <= 25
+        bell(n, Int64)
+    elseif n <= 42
+        bell(n, Int128)
+    else
+        bell(n, BigInt)
+    end
+end
+
+## calculation via Bell triangle, no need for recursion
+## http://en.wikipedia.org/wiki/Bell_number#Triangle_scheme_for_calculations
+function bell(n::Int, T::Type)
+    b = Vector{T}[]
+    push!(b, ones(T,1))
+    while length(b) < n
+        lastb = last(b)
+        c = last(lastb)
+        next = [c]
+        for i in lastb
+            c += i
+            push!(next, c)
+        end
+        push!(b, next)
+    end
+    last(last(b))
 end
 
 immutable FixedSetPartitions{T<:AbstractVector}


### PR DESCRIPTION
(Sorry about the messiness of my pull requests---I am obviously not very skilled in these matters). 

I have a new PR, about the Bell number, a.k.a. bell(n) = length(partitions([1:n])).

I had this implementation after Wikipedia lying around, and I think it is more efficient than the current implementation (no recursion), and I believe there is no more need for a cache.

Also---the current implementation doesn't go beyond n=25, after which bell(n) > 1<<63 . In this PR the return type of bell(n) ups to Int128 or even Bigint for larger n. 

You may not want to have such type instability and you may not want to depend on Bigint in combinatorics.jl, I can't tell.

Conversely, you may also consider to export bell() if you like the implementation, (see http://en.wikipedia.org/wiki/Bell_number), and similarly one could consider to export nfixedsetpartitions(n,k) as stirling2(n,k) (see http://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind#Definition --- the current implementation of nfixedsetpartitions() ) . I have myself use Bigint versions of stirling2() as one runs out quickly of bits for representing these numbers...
