### PR TITLE
Revise `@simd` documentation.

### DIFF
--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -603,14 +603,24 @@ properties of the loop:
    possibly causing different results than without ``@simd``.
 -  No iteration ever waits on another iteration to make forward progress.
 
+A loop containing ``break``, ``continue``, or ``goto`` will cause a 
+compile-time error.
+
 Using ``@simd`` merely gives the compiler license to vectorize. Whether 
 it actually does so depends on the compiler. To actually benefit from the 
 current implementation, your loop should have the following additional 
 properties:
 
 -  The loop must be an innermost loop.
--  The loop body must be straight-line code. This is why ``@inbounds`` is currently needed for all array accesses.
--  Accesses must have a stride pattern and cannot be "gathers" (random-index reads) or "scatters" (random-index writes).
-- The stride should be unit stride.
-- In some simple cases, for example with 2-3 arrays accessed in a loop, the LLVM auto-vectorization may kick in automatically, leading to no further speedup with ``@simd``. 
+-  The loop body must be straight-line code. This is why ``@inbounds`` is 
+   currently needed for all array accesses. The compiler can sometimes turn
+   short ``&&``, ``||``, and ``?:`` expressions into straight-line code, 
+   if it is safe to evaluate all operands unconditionally. Consider using 
+   ``ifelse`` instead of ``?:`` in the loop if it is safe to do so.
+-  Accesses must have a stride pattern and cannot be "gathers" (random-index reads) 
+   or "scatters" (random-index writes).
+-  The stride should be unit stride.
+-  In some simple cases, for example with 2-3 arrays accessed in a loop, the 
+   LLVM auto-vectorization may kick in automatically, leading to no further 
+   speedup with ``@simd``. 
 


### PR DESCRIPTION
Three changes:
- Document that break, continue, and goto are not allowed (PR #8624).
- Mention that `&&`, `||`, and `?:` sometimes vectorize and use of `ifelse` instead of `?:`.
- Clean up `.rst` source to avoid excessively long lines and have consistent indentation.
