### PR TITLE
improve error message for failed fetch (fix #8702)

### DIFF
--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -167,4 +167,11 @@ function free(inst::Dict=installed())
     return pkgs
 end
 
+function issue_url(pkg::String)
+    ispath(pkg,".git") || return ""
+    m = match(Git.GITHUB_REGEX, url(pkg))
+    m == nothing && return ""
+    return "https://github.com/" * m.captures[1] * "/issues"
+end
+
 end # module

--- a/base/pkg/write.jl
+++ b/base/pkg/write.jl
@@ -12,7 +12,12 @@ function fetch(pkg::String, sha1::String)
     Git.run(`fetch -q $(Cache.path(pkg)) $refspec`, dir=pkg)
     Git.iscommit(sha1, dir=pkg) && return
     f = Git.iscommit(sha1, dir=Cache.path(pkg)) ? "fetch" : "prefetch"
-    error("$pkg: $f failed to get commit $(sha1[1:10]), please file a bug")
+    url = Read.issue_url(pkg)
+    if isempty(url)
+        error("$pkg: $f failed to get commit $(sha1[1:10]), please file a bug report with the package author.")
+    else
+        error("$pkg: $f failed to get commit $(sha1[1:10]), please file an issue at $url")
+    end
 end
 
 function checkout(pkg::String, sha1::String)


### PR DESCRIPTION
The error message now includes where to file issues (with the URL if possible), as discussed in #8702.

(In the future, we might want to include similar information for other Pkg errors.)
