### PR TITLE
julia-mode.el: Further syntax/highlighting bugfixes

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -154,10 +154,24 @@
    '()
    'symbols))
 
+(defconst julia-builtin-types-regex
+  (regexp-opt
+   '("Number" "Real" "BigInt" "Integer"
+     "Uint" "Uint8" "Uint16" "Uint32" "Uint64" "Uint128"
+     "Int" "Int8" "Int16" "Int32" "Int64" "Int128"
+     "BigFloat" "FloatingPoint" "Float16" "Float32" "Float64"
+     "Complex128" "Complex64" "ComplexPair"
+     "Bool"
+     "Char" "ASCIIString" "UTF8String" "ByteString" "SubString"
+     "Array" "DArray" "AbstractArray" "AbstractVector" "AbstractMatrix" "AbstractSparseMatrix" "SubArray" "StridedArray" "StridedVector" "StridedMatrix" "VecOrMat" "StridedVecOrMat" "DenseArray" "SparseMatrixCSC"
+     "Range" "Range1" "OrdinalRange" "StepRange" "UnitRange" "FloatRange"
+     "Tuple" "NTuple"
+     "DataType" "Symbol" "Function" "Vector" "Matrix" "Union" "Type" "Any" "Complex" "None" "String" "Ptr" "Void" "Exception" "Task" "Signed" "Unsigned" "Associative" "Dict" "IO" "IOStream" "Ranges" "Rational" "Regex" "RegexMatch" "Set" "IntSet" "Expr" "WeakRef" "Nothing" "ObjectIdDict")
+   'symbols))
+
 (defconst julia-font-lock-keywords
   (list
-   '("\\<\\(\\|Uint\\(8\\|16\\|32\\|64\\|128\\)\\|Int\\(8\\|16\\|32\\|64\\|128\\)\\|BigInt\\|Integer\\|BigFloat\\|FloatingPoint\\|Float16\\|Float32\\|Float64\\|Complex128\\|Complex64\\|ComplexPair\\|Bool\\|Char\\|DataType\\|Number\\|Real\\|Int\\|Uint\\|Array\\|DArray\\|AbstractArray\\|AbstractVector\\|AbstractMatrix\\|AbstractSparseMatrix\\|SubArray\\|StridedArray\\|StridedVector\\|StridedMatrix\\|VecOrMat\\|StridedVecOrMat\\|DenseArray\\|Range\\|OrdinalRange\\|StepRange\\|UnitRange\\|FloatRange\\|SparseMatrixCSC\\|Tuple\\|NTuple\\|Symbol\\|Function\\|Vector\\|Matrix\\|Union\\|Type\\|Any\\|Complex\\|String\\|Ptr\\|Void\\|Exception\\|Task\\|Signed\\|Unsigned\\|Associative\\|Dict\\|IO\\|IOStream\\|Rational\\|Regex\\|RegexMatch\\|Set\\|IntSet\\|ASCIIString\\|UTF8String\\|ByteString\\|Expr\\|WeakRef\\|ObjectIdDict\\|SubString\\)\\>" .
-     font-lock-type-face)
+    (cons julia-builtin-types-regex 'font-lock-type-face)
     (cons julia-keyword-regex 'font-lock-keyword-face)
     (cons julia-macro-regex 'font-lock-keyword-face)
     (cons

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -47,6 +47,19 @@
 (when (not (fboundp 'ignore-errors))
   (defmacro ignore-errors (body) `(condition-case nil ,body (error nil))))
 
+(defun julia--regexp-opt (strings &optional paren)
+  "Emacs 23 provides `regexp-opt', but it does not support PAREN taking the value 'symbols.
+This function provides equivalent functionality, but makes no efforts to optimise the regexp."
+  (cond
+   ((>= emacs-major-version 24)
+    (regexp-opt strings paren))
+   ((not (eq paren 'symbols))
+    (regexp-opt strings paren))
+   ((null strings)
+    "")
+   ('t
+    (rx-to-string `(seq symbol-start (or ,@strings) symbol-end)))))
+
 (defvar julia-mode-syntax-table
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?_ "_" table)
@@ -140,7 +153,7 @@
   (rx symbol-start (group "@" (1+ (or word (syntax symbol))))))
 
 (defconst julia-keyword-regex
-  (regexp-opt
+  (julia--regexp-opt
    '("if" "else" "elseif" "while" "for" "begin" "end" "quote"
      "try" "catch" "return" "local" "abstract" "function" "macro" "ccall"
      "finally" "typealias" "break" "continue" "type" "global"
@@ -149,13 +162,13 @@
    'symbols))
 
 (defconst julia-builtin-regex
-  (regexp-opt
+  (julia--regexp-opt
    ;;'("error" "throw")
    '()
    'symbols))
 
 (defconst julia-builtin-types-regex
-  (regexp-opt
+  (julia--regexp-opt
    '("Number" "Real" "BigInt" "Integer"
      "Uint" "Uint8" "Uint16" "Uint32" "Uint64" "Uint128"
      "Int" "Int8" "Int16" "Int32" "Int64" "Int128"
@@ -171,25 +184,25 @@
 
 (defconst julia-font-lock-keywords
   (list
-    (cons julia-builtin-types-regex 'font-lock-type-face)
-    (cons julia-keyword-regex 'font-lock-keyword-face)
-    (cons julia-macro-regex 'font-lock-keyword-face)
-    (cons
-     (regexp-opt
-      '("true" "false" "C_NULL" "Inf" "NaN" "Inf32" "NaN32" "nothing")
-      'symbols)
-     'font-lock-constant-face)
-    (list julia-unquote-regex 2 'font-lock-constant-face)
-    (list julia-char-regex 2 'font-lock-string-face)
-    (list julia-forloop-in-regex 1 'font-lock-keyword-face)
-    (list julia-function-regex 1 'font-lock-function-name-face)
-    (list julia-function-assignment-regex 1 'font-lock-function-name-face)
-    (list julia-type-regex 1 'font-lock-type-face)
-    (list julia-type-annotation-regex 1 'font-lock-type-face)
-    ;;(list julia-type-parameter-regex 1 'font-lock-type-face)
-    (list julia-subtype-regex 1 'font-lock-type-face)
-    (list julia-builtin-regex 1 'font-lock-builtin-face)
-))
+   (cons julia-builtin-types-regex 'font-lock-type-face)
+   (cons julia-keyword-regex 'font-lock-keyword-face)
+   (cons julia-macro-regex 'font-lock-keyword-face)
+   (cons
+    (julia--regexp-opt
+     '("true" "false" "C_NULL" "Inf" "NaN" "Inf32" "NaN32" "nothing")
+     'symbols)
+    'font-lock-constant-face)
+   (list julia-unquote-regex 2 'font-lock-constant-face)
+   (list julia-char-regex 2 'font-lock-string-face)
+   (list julia-forloop-in-regex 1 'font-lock-keyword-face)
+   (list julia-function-regex 1 'font-lock-function-name-face)
+   (list julia-function-assignment-regex 1 'font-lock-function-name-face)
+   (list julia-type-regex 1 'font-lock-type-face)
+   (list julia-type-annotation-regex 1 'font-lock-type-face)
+   ;;(list julia-type-parameter-regex 1 'font-lock-type-face)
+   (list julia-subtype-regex 1 'font-lock-type-face)
+   (list julia-builtin-regex 1 'font-lock-builtin-face)
+   ))
 
 (defconst julia-block-start-keywords
   (list "if" "while" "for" "begin" "try" "function" "type" "let" "macro"

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -49,8 +49,9 @@
 
 (defvar julia-mode-syntax-table
   (let ((table (make-syntax-table)))
-    (modify-syntax-entry ?_ "w" table)   ; underscores in words
-    (modify-syntax-entry ?@ "w" table)
+    (modify-syntax-entry ?_ "_" table)
+    (modify-syntax-entry ?@ "_" table)
+    (modify-syntax-entry ?! "_" table)
     (modify-syntax-entry ?# "< 14" table)  ; # single-line and multiline start
     (modify-syntax-entry ?= ". 23bn" table)
     (modify-syntax-entry ?\n ">" table)  ; \n single-line comment end
@@ -106,16 +107,16 @@
 ].* \\(in\\)\\(\\s-\\|$\\)+")
 
 (defconst julia-function-regex
-  (rx symbol-start "function"
+  (rx line-start symbol-start "function"
       (1+ space)
       ;; Don't highlight module names in function declarations:
-      (* (seq (1+ (or word ?_)) "."))
+      (* (seq (1+ (or word (syntax symbol))) "."))
       ;; The function name itself
-      (group (1+ (or word ?_ ?!)))))
+      (group (1+ (or word (syntax symbol))))))
 
 (defconst julia-function-assignment-regex
   (rx line-start symbol-start
-      (group (1+ (or word ?_ ?!)))
+      (group (1+ (or word (syntax symbol))))
       (* space)
       (? "{" (* (not (any "}"))) "}")
       (* space)
@@ -124,19 +125,19 @@
       "="))
 
 (defconst julia-type-regex
-  (rx symbol-start (or "immutable" "type" "abstract") (1+ space) (group (1+ (or word ?_)))))
+  (rx symbol-start (or "immutable" "type" "abstract") (1+ space) (group (1+ (or word (syntax symbol))))))
 
 (defconst julia-type-annotation-regex
-  (rx "::" (group (1+ (or word ?_)))))
+  (rx "::" (group (1+ (or word (syntax symbol))))))
 
 ;;(defconst julia-type-parameter-regex
-;;  (rx symbol-start (1+ (or word ?_)) "{" (group (1+ (or word ?_))) "}"))
+;;  (rx symbol-start (1+ (or (or word (syntax symbol)) ?_)) "{" (group (1+ (or (or word (syntax symbol)) ?_))) "}"))
 
 (defconst julia-subtype-regex
-  (rx "<:" (1+ space) (group (1+ (or word ?_))) (0+ space) (or "\n" "{" "end")))
+  (rx "<:" (1+ space) (group (1+ (or word (syntax symbol)))) (0+ space) (or "\n" "{" "end")))
 
 (defconst julia-macro-regex
-  (rx symbol-start (group  "@" (1+ (or word ?_ ?!)))))
+  (rx symbol-start (group "@" (1+ (or word (syntax symbol))))))
 
 (defconst julia-keyword-regex
   (regexp-opt


### PR DESCRIPTION
These four commits improve Emacs' understanding of Julia syntax.

I've taken the syntax table improvements by @Clemens-H in #8026 and extended them. These ensure that `forward-word` and `forward-symbol` work correctly for Julia code, and enable us to simplify our regexps to just say `(or word (syntax symbol))`.

(I've also just realised that me preparing this branch has probably spammed Clemens with notifications, sorry about that!)

Finally, I've fixed #8537 by re-implementing `regexp-opt` in an Emacs 23 friendly way.
