### PR TITLE
process events should be called after flushing

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -91,7 +91,10 @@ disable_sigint(f::Function) = try sigatomic_begin(); f(); finally sigatomic_end(
 reenable_sigint(f::Function) = try sigatomic_end(); f(); finally sigatomic_begin(); end
 
 # flush C stdio output from external libraries
-flush_cstdio() = ccall(:jl_flush_cstdio, Void, ())
+function flush_cstdio()
+    ccall(:jl_flush_cstdio, Void, ())
+    process_events(true)
+end
 
 function find_library{T<:ByteString, S<:ByteString}(libnames::Array{T,1}, extrapaths::Array{S,1}=ASCIIString[])
     for lib in libnames


### PR DESCRIPTION
It is discovered [[1]](https://github.com/JuliaLang/IJulia.jl/issues/238) [[2]](https://github.com/JuliaLang/IJulia.jl/pull/240) that `flush_cstdio` doesn't flush stdio immediately. To illustrate it, consider

```
julia> read_stdout, = redirect_stdout()
(Pipe(open, 0 bytes waiting),Pipe(open, 0 bytes waiting))

julia> start_reading(read_stdout);

julia> ccall((:printf, "libc"), Int, (Ptr{Uint8},), "foo");

julia> flush_cstdio(); nb_available(read_stdout)
0
```

```
julia> read_stdout, = redirect_stdout()
(Pipe(open, 0 bytes waiting),Pipe(open, 0 bytes waiting))

julia> start_reading(read_stdout);

julia> ccall((:printf, "libc"), Int, (Ptr{Uint8},), "foo");

julia> flush_cstdio(); Base.process_events(true); nb_available(read_stdout)
3
```

`nb_available` yields a different result if we do `Base.process_events`.

cc: @stevengj 
