### PR TITLE
Expand test suite for triangular matrices and adjust triangular code accordingly.

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -189,6 +189,11 @@ macro chkuplo()
 Valid choices are 'U' (upper) or 'L' (lower).""")))
 end
 
+const CHARU = 'U'
+const CHARL = 'L'
+char_uplo(uplo::Symbol) = uplo == :U ? CHARU : (uplo == :L ? CHARL : throw(ArgumentError("uplo argument must be either :U or :L")))
+
+
 include("linalg/exceptions.jl")
 include("linalg/generic.jl")
 

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -1995,23 +1995,29 @@ for (trcon, trevc, trrfs, elty) in
         # LOGICAL            SELECT( * )
         # DOUBLE PRECISION   T( LDT, * ), VL( LDVL, * ), VR( LDVR, * ),
         #$                   WORK( * )
-        function trevc!(side::BlasChar, howmny::BlasChar,
-                select::Vector{Bool}, A::StridedMatrix{$elty},
-                VL::StridedMatrix{$elty}=similar(A), VR::StridedMatrix{$elty}=similar(A))
-            chkstride1(A)
-            chksquare(A)
-            ldt, n = size(A)
-            ldvl, mm = size(VL)
-            ldvr, mm = size(VR)
+        function trevc!(side::Char, howmny::Char, select::Vector{BlasInt}, T::StridedMatrix{$elty},
+                VL::StridedMatrix{$elty} = similar(T), VR::StridedMatrix{$elty} = similar(T))
+            # Extract
+            n, mm = chksquare(T), size(VL, 2)
+            ldt, ldvl, ldvr = stride(T, 2), stride(VL, 2), stride(VR, 2)
+            
+            # Check
+            chkstride1(T)
+
+            # Allocate
             m = Array(BlasInt, 1)
             work = Array($elty, 3n)
             info = Array(BlasInt, 1)
+            
             ccall(($(string(trevc)),liblapack), Void,
-            (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{Bool}, Ptr{BlasInt}, Ptr{$elty},
-            Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
-            Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}),
-            &side, &howmny, select, &n, A, &ldt, VL, &ldvl, VR, &ldvr, &mm,
-            m, work, info)
+                (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt}, 
+                 Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, 
+                 Ptr{$elty}, Ptr{BlasInt},Ptr{BlasInt}, Ptr{BlasInt}, 
+                 Ptr{$elty}, Ptr{BlasInt}),
+                &side, &howmny, select, &n, 
+                T, &ldt, VL, &ldvl, 
+                VR, &ldvr, &mm, m, 
+                work, info)
             @lapackerror
 
             #Decide what exactly to return
@@ -2106,25 +2112,31 @@ for (trcon, trevc, trrfs, elty, relty) in
         # LOGICAL            SELECT( * )
         # DOUBLE PRECISION   RWORK( * )
         # COMPLEX*16         T( LDT, * ), VL( LDVL, * ), VR( LDVR, * ),
-        #$                   WORK( * )
-        function trevc!(side::BlasChar, howmny::BlasChar,
-                select::Vector{Bool}, A::StridedMatrix{$elty},
-                VL::StridedMatrix{$elty}=similar(A), VR::StridedMatrix{$elty}=similar(A))
-            chkstride1(A)
-            chksquare(A)
-            ldt, n = size(A)
-            ldvl, mm = size(VL)
-            ldvr, mm = size(VR)
+        #$                   WORK( * ) 
+        function trevc!(side::Char, howmny::Char, select::Vector{BlasInt}, T::StridedMatrix{$elty},
+                VL::StridedMatrix{$elty} = similar(T), VR::StridedMatrix{$elty} = similar(T))
+            # Extract
+            n, mm = chksquare(T), size(VL, 2)
+            ldt, ldvl, ldvr = stride(T, 2), stride(VL, 2), stride(VR, 2)
+            
+            # Check
+            chkstride1(T)
+
+            # Allocate
             m = Array(BlasInt, 1)
             work = Array($elty, 2n)
             rwork = Array($relty, n)
             info = Array(BlasInt, 1)
+            
             ccall(($(string(trevc)),liblapack), Void,
-            (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{Bool}, Ptr{BlasInt}, Ptr{$elty},
-            Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
-            Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$relty}, Ptr{BlasInt}),
-            &side, &howmny, select, &n, A, &ldt, VL, &ldvl, VR, &ldvr, &mm,
-            m, work, rwork, info)
+                (Ptr{Char}, Ptr{Char}, Ptr{BlasInt}, Ptr{BlasInt}, 
+                 Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, 
+                 Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}, 
+                 Ptr{$elty}, Ptr{$relty}, Ptr{BlasInt}),
+                &side, &howmny, select, &n, 
+                T, &ldt, VL, &ldvl, 
+                VR, &ldvr, &mm, m, 
+                work, rwork, info)
             @lapackerror
 
             #Decide what exactly to return
@@ -2146,7 +2158,6 @@ for (trcon, trevc, trrfs, elty, relty) in
                 end
             end
         end
-
         # SUBROUTINE ZTRRFS( UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, X,
         #                    LDX, FERR, BERR, WORK, IWORK, INFO )
         # .. Scalar Arguments ..

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -4,118 +4,14 @@ immutable Triangular{T,S<:AbstractMatrix,UpLo,IsUnit} <: AbstractMatrix{T}
 end
 function Triangular{T}(A::AbstractMatrix{T}, uplo::Symbol, isunit::Bool=false)
     chksquare(A)
-    uplo != :L && uplo != :U && throw(ArgumentError("uplo argument must be either :U or :L"))
-    return Triangular{T,typeof(A),uplo,isunit}(A)
+    Triangular{T,typeof(A),uplo,isunit}(A)
 end
-
-const CHARU = 'U'
-const CHARL = 'L'
-char_uplo(uplo::Symbol) = uplo == :U ? CHARU : (uplo == :L ? CHARL : throw(ArgumentError("uplo argument must be either :U or :L")))
-
-+{T, MT, uplo}(A::Triangular{T, MT, uplo, false}, B::Triangular{T, MT, uplo, false}) = Triangular(A.data + B.data, uplo)
-+{T, MT}(A::Triangular{T, MT, :U, false}, B::Triangular{T, MT, :U, true}) = Triangular(A.data + triu(B.data, 1) + I, :U)
-+{T, MT}(A::Triangular{T, MT, :L, false}, B::Triangular{T, MT, :L, true}) = Triangular(A.data + tril(B.data, -1) + I, :L)
-+{T, MT}(A::Triangular{T, MT, :U, true}, B::Triangular{T, MT, :U, false}) = Triangular(triu(A.data, 1) + B.data + I, :U)
-+{T, MT}(A::Triangular{T, MT, :L, true}, B::Triangular{T, MT, :L, false}) = Triangular(tril(A.data, -1) + B.data + I, :L)
-+{T, MT}(A::Triangular{T, MT, :U, true}, B::Triangular{T, MT, :U, true}) = Triangular(triu(A.data, 1) + triu(B.data, 1) + 2I, :U)
-+{T, MT}(A::Triangular{T, MT, :L, true}, B::Triangular{T, MT, :L, true}) = Triangular(tril(A.data, -1) + tril(B.data, -1) + 2I, :L)
-+{T, MT, uplo1, uplo2, IsUnit1, IsUnit2}(A::Triangular{T, MT, uplo1, IsUnit1}, B::Triangular{T, MT, uplo2, IsUnit2}) = full(A) + full(B)
--{T, MT, uplo}(A::Triangular{T, MT, uplo, false}, B::Triangular{T, MT, uplo, false}) = Triangular(A.data - B.data, uplo)
--{T, MT}(A::Triangular{T, MT, :U, false}, B::Triangular{T, MT, :U, true}) = Triangular(A.data - triu(B.data, 1) - I, :U)
--{T, MT}(A::Triangular{T, MT, :L, false}, B::Triangular{T, MT, :L, true}) = Triangular(A.data - tril(B.data, -1) - I, :L)
--{T, MT}(A::Triangular{T, MT, :U, true}, B::Triangular{T, MT, :U, false}) = Triangular(triu(A.data, 1) - B.data + I, :U)
--{T, MT}(A::Triangular{T, MT, :L, true}, B::Triangular{T, MT, :L, false}) = Triangular(tril(A.data, -1) - B.data + I, :L)
--{T, MT}(A::Triangular{T, MT, :U, true}, B::Triangular{T, MT, :U, true}) = Triangular(triu(A.data, 1) - triu(B.data, 1), :U)
--{T, MT}(A::Triangular{T, MT, :L, true}, B::Triangular{T, MT, :L, true}) = Triangular(tril(A.data, -1) - tril(B.data, -1), :L)
--{T, MT, uplo1, uplo2, IsUnit1, IsUnit2}(A::Triangular{T, MT, uplo1, IsUnit1}, B::Triangular{T, MT, uplo2, IsUnit2}) = full(A) - full(B)
-
-######################
-# BlasFloat routines #
-######################
-
-### Note! the BlasFloat restriction can be removed if generic triangular multiplication methods are written.
-for (func1, func2) in ((:*, :A_mul_B!), (:Ac_mul_B, :Ac_mul_B!), (:/, :A_rdiv_B!))
-    @eval begin
-        ($func1){T<:BlasFloat,S<:StridedMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::Triangular{T,S,UpLo,IsUnit}) = ($func2)(A, full(B))
-    end
-end
-
-# Vector multiplication
-A_mul_B!{T<:BlasFloat,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, b::StridedVector{T}) = BLAS.trmv!(UpLo == :L ? 'L' : 'U', 'N', IsUnit ? 'U' : 'N', A.data, b)
-Ac_mul_B!{T<:BlasReal,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, b::StridedVector{T}) = BLAS.trmv!(UpLo == :L ? 'L' : 'U', 'T', IsUnit ? 'U' : 'N', A.data, b)
-Ac_mul_B!{T<:BlasComplex,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, b::StridedVector{T}) = BLAS.trmv!(UpLo == :L ? 'L' : 'U', 'C', IsUnit ? 'U' : 'N', A.data, b)
-At_mul_B!{T<:BlasFloat,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, b::StridedVector{T}) = BLAS.trmv!(UpLo == :L ? 'L' : 'U', 'T', IsUnit ? 'U' : 'N', A.data, b)
-
-# Matrix multiplication
-A_mul_B!{T<:BlasFloat,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedMatrix{T}) = BLAS.trmm!('L', UpLo == :L ? 'L' : 'U', 'N', IsUnit ? 'U' : 'N', one(T), A.data, B)
-A_mul_B!{T<:BlasFloat,S,UpLo,IsUnit}(A::StridedMatrix{T}, B::Triangular{T,S,UpLo,IsUnit}) = BLAS.trmm!('R', UpLo == :L ? 'L' : 'U', 'N', IsUnit ? 'U' : 'N', one(T), B.data, A)
-Ac_mul_B!{T<:BlasComplex,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedMatrix{T}) = BLAS.trmm!('L', UpLo == :L ? 'L' : 'U', 'C', IsUnit ? 'U' : 'N', one(T), A.data, B)
-Ac_mul_B!{T<:BlasReal,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedMatrix{T}) = BLAS.trmm!('L', UpLo == :L ? 'L' : 'U', 'T', IsUnit ? 'U' : 'N', one(T), A.data, B)
-A_mul_Bc!{T<:BlasComplex,S,UpLo,IsUnit}(A::StridedMatrix{T}, B::Triangular{T,S,UpLo,IsUnit}) = BLAS.trmm!('R', UpLo == :L ? 'L' : 'U', 'C', IsUnit ? 'U' : 'N', one(T), B.data, A)
-A_mul_Bc!{T<:BlasReal,S,UpLo,IsUnit}(A::StridedMatrix{T}, B::Triangular{T,S,UpLo,IsUnit}) = BLAS.trmm!('R', UpLo == :L ? 'L' : 'U', 'T', IsUnit ? 'U' : 'N', one(T), B.data, A)
-
-A_ldiv_B!{T<:BlasFloat,S<:StridedMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedVecOrMat{T}) = LAPACK.trtrs!(UpLo == :L ? 'L' : 'U', 'N', IsUnit ? 'U' : 'N', A.data, B)
-Ac_ldiv_B!{T<:BlasReal,S<:StridedMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedVecOrMat{T}) = LAPACK.trtrs!(UpLo == :L ? 'L' : 'U', 'T', IsUnit ? 'U' : 'N', A.data, B)
-Ac_ldiv_B!{T<:BlasComplex,S<:StridedMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::StridedVecOrMat{T}) = LAPACK.trtrs!(UpLo == :L ? 'L' : 'U', 'C', IsUnit ? 'U' : 'N', A.data, B)
-
-A_rdiv_B!{T<:BlasFloat,S<:AbstractMatrix,UpLo,IsUnit}(A::StridedVecOrMat{T}, B::Triangular{T,S,UpLo,IsUnit}) = BLAS.trsm!('R', UpLo == :L ? 'L' : 'U', 'N', IsUnit ? 'U' : 'N', one(T), B.data, A)
-A_rdiv_Bc!{T<:BlasReal,S<:AbstractMatrix,UpLo,IsUnit}(A::StridedMatrix{T}, B::Triangular{T,S,UpLo,IsUnit}) = BLAS.trsm!('R', UpLo == :L ? 'L' : 'U', 'T', IsUnit ? 'U' : 'N', one(T), B.data, A)
-A_rdiv_Bc!{T<:BlasComplex,S<:AbstractMatrix,UpLo,IsUnit}(A::StridedMatrix{T}, B::Triangular{T,S,UpLo,IsUnit}) = BLAS.trsm!('R', UpLo == :L ? 'L' : 'U', 'C', IsUnit ? 'U' : 'N', one(T), B.data, A)
-
-inv{T<:BlasFloat,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}) = Triangular{T,S,UpLo,IsUnit}(LAPACK.trtri!(UpLo == :L ? 'L' : 'U', IsUnit ? 'U' : 'N', copy(A.data)))
-
-function \{T,AT,UpLo,S}(A::Triangular{T,AT,UpLo,true}, B::AbstractVecOrMat{S})
-    TS = typeof(zero(T)*zero(S) + zero(T)*zero(S))
-    TS == S ? A_ldiv_B!(A, copy(B)) : A_ldiv_B!(A, convert(AbstractArray{TS}, B))
-end
-
-function \{T,AT,UpLo,S}(A::Triangular{T,AT,UpLo,false}, B::AbstractVecOrMat{S})
-    TS = typeof((zero(T)*zero(S) + zero(T)*zero(S))/one(S))
-    TS == S ? A_ldiv_B!(A, copy(B)) : A_ldiv_B!(A, convert(AbstractArray{TS}, B))
-end
-
-errorbounds{T<:BlasFloat,S<:StridedMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, X::StridedVecOrMat{T}, B::StridedVecOrMat{T}) = LAPACK.trrfs!(UpLo == :L ? 'L' : 'U', 'N', IsUnit ? 'U' : 'N', A.data, B, X)
-function errorbounds{TA<:Number,S<:StridedMatrix,UpLo,IsUnit,TX<:Number,TB<:Number}(A::Triangular{TA,S,UpLo,IsUnit}, X::StridedVecOrMat{TX}, B::StridedVecOrMat{TB})
-    TAXB = promote_type(TA, TB, TX, Float32)
-    errorbounds(convert(AbstractMatrix{TAXB}, A), convert(AbstractArray{TAXB}, X), convert(AbstractArray{TAXB}, B))
-end
-
-#Eigensystems
-function eigvecs{T<:BlasFloat,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit})
-    if UpLo == :U
-        V = LAPACK.trevc!('R', 'A', Array(Bool,1), A.data)
-    else # Uplo == :L
-        V = LAPACK.trevc!('L', 'A', Array(Bool,1), A.data')
-    end
-    for i=1:size(V,2) #Normalize
-        V[:,i] /= norm(V[:,i])
-    end
-    V
-end
-
-function cond{T<:BlasFloat,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, p::Real=2)
-    chksquare(A)
-    if p==1
-        return inv(LAPACK.trcon!('O', UpLo == :L ? 'L' : 'U', IsUnit ? 'U' : 'N', A.data))
-    elseif p==Inf
-        return inv(LAPACK.trcon!('I', UpLo == :L ? 'L' : 'U', IsUnit ? 'U' : 'N', A.data))
-    else #use fallback
-        return cond(full(A), p)
-    end
-end
-
-####################
-# Generic routines #
-####################
 
 size(A::Triangular, args...) = size(A.data, args...)
 
-convert{T,S<:AbstractMatrix,UpLo,IsUnit}(::Type{Triangular{T,S,UpLo,IsUnit}}, A::Triangular{T,S,UpLo,IsUnit}) = A
-convert{T,S<:AbstractMatrix,UpLo,IsUnit}(::Type{Triangular{T,S,UpLo,IsUnit}}, A::Triangular) = Triangular{T,S,UpLo,IsUnit}(convert(AbstractMatrix{T}, A.data))
-function convert{T,TA,S,UpLo,IsUnit}(::Type{AbstractMatrix{T}}, A::Triangular{TA,S,UpLo,IsUnit})
-    M = convert(AbstractMatrix{T}, A.data)
-    Triangular{T,typeof(M),UpLo,IsUnit}(M)
-end
+convert{T,S,UpLo,IsUnit}(::Type{Triangular{T}}, A::Triangular{T,S,UpLo,IsUnit}) = A
+convert{Tnew,Told,S,UpLo,IsUnit}(::Type{Triangular{Tnew}}, A::Triangular{Told,S,UpLo,IsUnit}) = (Anew = convert(AbstractMatrix{Tnew}, A.data); Triangular(Anew, UpLo, IsUnit))
+convert{Tnew,Told,S,UpLo,IsUnit}(::Type{AbstractMatrix{Tnew}}, A::Triangular{Told,S,UpLo,IsUnit}) = convert(Triangular{Tnew}, A)
 function convert{Tret,T,S,UpLo,IsUnit}(::Type{Matrix{Tret}}, A::Triangular{T,S,UpLo,IsUnit})
     B = Array(Tret, size(A, 1), size(A, 1))
     copy!(B, A.data)
@@ -150,13 +46,13 @@ function similar{T,S,UpLo,IsUnit,Tnew}(A::Triangular{T,S,UpLo,IsUnit}, ::Type{Tn
     return Triangular{Tnew, typeof(A), UpLo, IsUnit}(A)
 end
 
-copy{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}) = Triangular{T,S,UpLo,IsUnit}(copy(A))
+copy{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}) = Triangular{T,S,UpLo,IsUnit}(copy(A.data))
 
+getindex(A::Triangular, i::Integer) = ((m, n) = divrem(i - 1, size(A, 1)); A[n + 1, m + 1])
 getindex{T,S}(A::Triangular{T,S,:L,true}, i::Integer, j::Integer) = i == j ? one(T) : (i > j ? A.data[i,j] : zero(A.data[i,j]))
 getindex{T,S}(A::Triangular{T,S,:L,false}, i::Integer, j::Integer) = i >= j ? A.data[i,j] : zero(A.data[i,j])
 getindex{T,S}(A::Triangular{T,S,:U,true}, i::Integer, j::Integer) = i == j ? one(T) : (i < j ? A.data[i,j] : zero(A.data[i,j]))
 getindex{T,S}(A::Triangular{T,S,:U,false}, i::Integer, j::Integer) = i <= j ? A.data[i,j] : zero(A.data[i,j])
-getindex(A::Triangular, i::Integer) = ((m, n) = divrem(i - 1, size(A,1)); A[m + 1, n + 1])
 
 istril{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}) = UpLo == :L
 istriu{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}) = UpLo == :U
@@ -174,84 +70,261 @@ end
 real{T<:Real}(A::Triangular{T}) = A
 real{T<:Complex,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}) = (B = real(A.data); Triangular{eltype(B), typeof(B), UpLo, IsUnit}(B))
 
-function (*){T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, x::Number)
-    n = size(A,1)
-    B = copy(A.data)
-    for j = 1:n
-        for i = UpLo == :L ? (j:n) : (1:j)
-            B[i,j] = (i == j && IsUnit ? x : B[i,j]*x)
-        end
+# Unary operations
+-{T, S, UpLo}(A::Triangular{T, S, UpLo, false}) = Triangular{T, S, UpLo, false}(-A.data)
+function -{T, S, UpLo}(A::Triangular{T, S, UpLo, true})
+    Anew = -A.data
+    for i = 1:size(A, 1)
+        Anew[i, i] = -1
     end
-    Triangular{T,S,UpLo,false}(B)
-end
-function (*){T,S,UpLo,IsUnit}(x::Number, A::Triangular{T,S,UpLo,IsUnit})
-    n = size(A,1)
-    B = copy(A.data)
-    for j = 1:n
-        for i = UpLo == :L ? (j:n) : (1:j)
-            B[i,j] = i == j && IsUnit ? x : x*B[i,j]
-        end
-    end
-    Triangular{T,S,UpLo,false}(B)
-end
-function (/){T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, x::Number)
-    n = size(A,1)
-    B = copy(A.data)
-    invx = one(T)/x
-    for j = 1:n
-        for i = UpLo == :L ? (j:n) : (1:j)
-            B[i,j] = (i == j && IsUnit ? invx : B[i,j]/x)
-        end
-    end
-    Triangular{T,S,UpLo,false}(B)
-end
-function (\){T,S,UpLo,IsUnit}(x::Number, A::Triangular{T,S,UpLo,IsUnit})
-    n = size(A,1)
-    B = copy(A.data)
-    invx = one(T)/x
-    for j = 1:n
-        for i = UpLo == :L ? (j:n) : (1:j)
-            B[i,j] = i == j && IsUnit ? invx : x\B[i,j]
-        end
-    end
-    Triangular{T,S,UpLo,false}(B)
+    Triangular{T, S, UpLo, false}(Anew)
 end
 
-A_mul_B!{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::Triangular{T,S,UpLo,IsUnit}) = Triangular{T,S,UpLo,IsUnit}(A*full!(B))
-A_mul_B!(A::Tridiagonal, B::Triangular) = A*full!(B)
-A_mul_B!(C::AbstractVecOrMat, A::Triangular, B::AbstractVecOrMat) = A_mul_B!(A, copy!(C, B))
+# Binary operations
++{TA, TB, SA, SB, uplo}(A::Triangular{TA, SA, uplo, false}, B::Triangular{TB, SB, uplo, false}) = Triangular(A.data + B.data, uplo)
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, false}, B::Triangular{TB, SB, :U, true}) = Triangular(A.data + triu(B.data, 1) + I, :U)
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, false}, B::Triangular{TB, SB, :L, true}) = Triangular(A.data + tril(B.data, -1) + I, :L)
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, false}) = Triangular(triu(A.data, 1) + B.data + I, :U)
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, false}) = Triangular(tril(A.data, -1) + B.data + I, :L)
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, true}) = Triangular(triu(A.data, 1) + triu(B.data, 1) + 2I, :U)
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, true}) = Triangular(tril(A.data, -1) + tril(B.data, -1) + 2I, :L)
++{TA, SA, TB, SB, uplo1, uplo2, IsUnit1, IsUnit2}(A::Triangular{TA, SA, uplo1, IsUnit1}, B::Triangular{TB, SB, uplo2, IsUnit2}) = full(A) + full(B)
+-{TA, SA, TB, SB, uplo}(A::Triangular{TA, SA, uplo, false}, B::Triangular{TB, SB, uplo, false}) = Triangular(A.data - B.data, uplo)
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, false}, B::Triangular{TB, SB, :U, true}) = Triangular(A.data - triu(B.data, 1) - I, :U)
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, false}, B::Triangular{TB, SB, :L, true}) = Triangular(A.data - tril(B.data, -1) - I, :L)
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, false}) = Triangular(triu(A.data, 1) - B.data + I, :U)
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, false}) = Triangular(tril(A.data, -1) - B.data + I, :L)
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, true}) = Triangular(triu(A.data, 1) - triu(B.data, 1), :U)
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, true}) = Triangular(tril(A.data, -1) - tril(B.data, -1), :L)
+-{TA, SA, TB, SB, uplo1, uplo2, IsUnit1, IsUnit2}(A::Triangular{TA, SA, uplo1, IsUnit1}, B::Triangular{TB, SB, uplo2, IsUnit2}) = full(A) - full(B)
 
-A_mul_Bc!(C::AbstractVecOrMat, A::Triangular, B::AbstractVecOrMat) = A_mul_Bc!(A, copy!(C, B))
+######################
+# BlasFloat routines #
+######################
 
-#Generic multiplication
-*(A::Tridiagonal, B::Triangular) = A_mul_B!(full(A), B)
-for func in (:*, :Ac_mul_B, :A_mul_Bc, :/, :A_rdiv_Bc)
-    @eval begin
-        ($func){TA,TB,SA<:AbstractMatrix,SB<:AbstractMatrix,UpLoA,UpLoB,IsUnitA,IsUnitB}(A::Triangular{TA,SA,UpLoA,IsUnitA}, B::Triangular{TB,SB,UpLoB,IsUnitB}) = ($func)(A, full(B))
-        ($func){T,S<:AbstractMatrix,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, B::AbstractVecOrMat) = ($func)(full(A), B)
-        ($func){T,S<:AbstractMatrix,UpLo,IsUnit}(A::AbstractMatrix, B::Triangular{T,S,UpLo,IsUnit}) = ($func)(A, full(B))
-    end
-end
+for (uplos, uploc) in ((:(:U), 'U'), (:(:L), 'L'))
+    for (isunitb, isunitc) in ((true, 'U'), (false, 'N'))
+        @eval begin
+        # Vector multiplication
+        A_mul_B!{T<:BlasFloat,S<:StridedMatrix}(A::Triangular{T,S,$uplos,$isunitb}, b::StridedVector{T}) = BLAS.trmv!($uploc, 'N', $isunitc, A.data, b)
+        
+        # Matrix multiplication
+        A_mul_B!{T<:BlasFloat,S<:StridedMatrix}(A::Triangular{T,S,$uplos,$isunitb}, B::StridedMatrix{T}) = BLAS.trmm!('L', $uploc, 'N', $isunitc, one(T), A.data, B)
+        A_mul_B!{T<:BlasFloat,S<:StridedMatrix}(A::StridedMatrix{T}, B::Triangular{T,S,$uplos,$isunitb}) = BLAS.trmm!('R', $uploc, 'N', $isunitc, one(T), B.data, A)
+        
+        Ac_mul_B!{T<:BlasComplex,S<:StridedMatrix}(A::Triangular{T,S,$uplos,$isunitb}, B::StridedMatrix{T}) = BLAS.trmm!('L', $uploc, 'C', $isunitc, one(T), A.data, B)
+        Ac_mul_B!{T<:BlasReal,S<:StridedMatrix}(A::Triangular{T,S,$uplos,$isunitb}, B::StridedMatrix{T}) = BLAS.trmm!('L', $uploc, 'T', $isunitc, one(T), A.data, B)
+        
+        A_mul_Bc!{T<:BlasComplex,S<:StridedMatrix}(A::StridedMatrix{T}, B::Triangular{T,S,$uplos,$isunitb}) = BLAS.trmm!('R', $uploc, 'C', $isunitc, one(T), B.data, A)
+        A_mul_Bc!{T<:BlasReal,S<:StridedMatrix}(A::StridedMatrix{T}, B::Triangular{T,S,$uplos,$isunitb}) = BLAS.trmm!('R', $uploc, 'T', $isunitc, one(T), B.data, A)
+        
+        # Left division
+        A_ldiv_B!{T<:BlasFloat,S<:StridedMatrix}(A::Triangular{T,S,$uplos,$isunitb}, B::StridedVecOrMat{T}) = LAPACK.trtrs!($uploc, 'N', $isunitc, A.data, B)
+        Ac_ldiv_B!{T<:BlasReal,S<:StridedMatrix}(A::Triangular{T,S,$uplos,$isunitb}, B::StridedVecOrMat{T}) = LAPACK.trtrs!($uploc, 'T', $isunitc, A.data, B)
+        Ac_ldiv_B!{T<:BlasComplex,S<:StridedMatrix}(A::Triangular{T,S,$uplos,$isunitb}, B::StridedVecOrMat{T}) = LAPACK.trtrs!($uploc, 'C', $isunitc, A.data, B)
 
-function sqrtm{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit})
-    n = size(A, 1)
-    R = zeros(T, n, n)
-    if UpLo == :U
-        for j = 1:n
-            (T<:Complex || A[j,j]>=0) ? (R[j,j] = IsUnit ? one(T) : sqrt(A[j,j])) : throw(SingularException(j))
-            for i = j-1:-1:1
-                r = A[i,j]
-                for k = i+1:j-1
-                    r -= R[i,k]*R[k,j]
-                end
-                r==0 || (R[i,j] = r / (R[i,i] + R[j,j]))
+        # Right division
+        A_rdiv_B!{T<:BlasFloat,S<:StridedMatrix}(A::StridedVecOrMat{T}, B::Triangular{T,S,$uplos,$isunitb}) = BLAS.trsm!('R', $uploc, 'N', $isunitc, one(T), B.data, A)
+        A_rdiv_Bc!{T<:BlasReal,S<:StridedMatrix}(A::StridedMatrix{T}, B::Triangular{T,S,$uplos,$isunitb}) = BLAS.trsm!('R', $uploc, 'T', $isunitc, one(T), B.data, A)
+        A_rdiv_Bc!{T<:BlasComplex,S<:StridedMatrix}(A::StridedMatrix{T}, B::Triangular{T,S,$uplos,$isunitb}) = BLAS.trsm!('R', $uploc, 'C', $isunitc, one(T), B.data, A)
+
+        # Matrix inverse
+        inv{T<:BlasFloat,S<:StridedMatrix}(A::Triangular{T,S,$uplos,$isunitb}) = Triangular{T,S,$uplos,$isunitb}(LAPACK.trtri!($uploc, $isunitc, copy(A.data)))
+
+        # Error bounds for triangular solve
+        errorbounds{T<:BlasFloat,S<:StridedMatrix}(A::Triangular{T,S,$uplos,$isunitb}, X::StridedVecOrMat{T}, B::StridedVecOrMat{T}) = LAPACK.trrfs!($uploc, 'N', $isunitc, A.data, B, X)
+
+        # Condition numbers
+        function cond{T<:BlasFloat,S}(A::Triangular{T,S,$uplos,$isunitb}, p::Real=2)
+            chksquare(A)
+            if p==1
+                return inv(LAPACK.trcon!('O', $uploc, $isunitc, A.data))
+            elseif p==Inf
+                return inv(LAPACK.trcon!('I', $uploc, $isunitc, A.data))
+            else #use fallback
+                return cond(full(A), p)
             end
         end
-        return Triangular{T,S,UpLo,IsUnit}(R)
-    else # UpLo == :L #Not the usual case
-        return sqrtm(A.').'
+    end
     end
 end
+
+errorbounds{T<:Union(BigFloat, Complex{BigFloat}),S<:StridedMatrix}(A::Triangular{T,S}, X::StridedVecOrMat{T}, B::StridedVecOrMat{T}) = error("not implemented yet! Please submit a pull request.")
+function errorbounds{TA<:Number,S<:StridedMatrix,UpLo,IsUnit,TX<:Number,TB<:Number}(A::Triangular{TA,S,UpLo,IsUnit}, X::StridedVecOrMat{TX}, B::StridedVecOrMat{TB})
+    TAXB = promote_type(TA, TB, TX, Float32)
+    errorbounds(convert(AbstractMatrix{TAXB}, A), convert(AbstractArray{TAXB}, X), convert(AbstractArray{TAXB}, B))
+end
+
+# Eigensystems
+## Notice that trecv works for quasi-triangular matrices and therefore the lower sub diagonal must be zeroed before calling the subroutine
+eigvecs{T<:BlasFloat,S<:StridedMatrix}(A::Triangular{T,S,:U,false}) = LAPACK.trevc!('R', 'A', BlasInt[], triu!(A.data))
+eigvecs{T<:BlasFloat,S<:StridedMatrix}(A::Triangular{T,S,:U,true}) = (for i = 1:size(A, 1); A.data[i,i] = 1;end;LAPACK.trevc!('R', 'A', BlasInt[], triu!(A.data)))
+eigvecs{T<:BlasFloat,S<:StridedMatrix}(A::Triangular{T,S,:L,false}) = LAPACK.trevc!('L', 'A', BlasInt[], tril!(A.data)')
+eigvecs{T<:BlasFloat,S<:StridedMatrix}(A::Triangular{T,S,:L,true}) = (for i = 1:size(A, 1); A.data[i,i] = 1;end;LAPACK.trevc!('L', 'A', BlasInt[], tril!(A.data)'))
+
+####################
+# Generic routines #
+####################
+
+(*){T,S,UpLo}(A::Triangular{T,S,UpLo,false}, x::Number) = Triangular(A.data*x, UpLo)
+function (*){T,S,UpLo}(A::Triangular{T,S,UpLo,true}, x::Number)
+    B = A.data*x
+    for i = 1:size(A, 1)
+        B[i,i] = x
+    end
+    Triangular(B, UpLo)
+end
+(*){T,S,UpLo}(x::Number, A::Triangular{T,S,UpLo,false}) = Triangular(x*A.data, UpLo)
+function (*){T,S,UpLo}(x::Number, A::Triangular{T,S,UpLo,true})
+    B = x*A.data
+    for i = 1:size(A, 1)
+        B[i,i] = x
+    end
+    Triangular(B, UpLo)
+end
+(/){T,S,UpLo}(A::Triangular{T,S,UpLo,false}, x::Number) = Triangular(A.data/x, UpLo)
+function (/){T,S,UpLo}(A::Triangular{T,S,UpLo,true}, x::Number)
+    B = A.data*x
+    invx = inv(x)
+    for i = 1:size(A, 1)
+        B[i,i] = x
+    end
+    Triangular(B, UpLo)
+end
+(\){T,S,UpLo}(x::Number, A::Triangular{T,S,UpLo,false}) = Triangular(x\A.data, UpLo)
+function (\){T,S,UpLo}(x::Number, A::Triangular{T,S,UpLo,true})
+    B = x\A.data
+    invx = inv(x)
+    for i = 1:size(A, 1)
+        B[i,i] = invx
+    end
+    Triangular(B, UpLo)
+end
+
+## Generic triangular multiplication
+function A_mul_B!{T,S<:AbstractMatrix,IsUnit}(A::Triangular{T,S,:U,IsUnit}, B::StridedVecOrMat)
+    m, n = size(B, 1), size(B, 2)
+    m == size(A, 1) || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for j = 1:n
+        for i = 1:m
+            Bij = ifelse(IsUnit, B[i,j], A.data[i,i]*B[i,j])
+            for k = i + 1:m
+                Bij += A.data[i,k]*B[k,j]
+            end
+            B[i,j] = Bij
+        end
+    end
+    B
+end
+
+function A_mul_B!{T,S<:AbstractMatrix,IsUnit}(A::Triangular{T,S,:L,IsUnit}, B::StridedVecOrMat)
+    m, n = size(B, 1), size(B, 2)
+    m == size(A, 1) || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for j = 1:n
+        for i = m:-1:1
+            Bij = ifelse(IsUnit, B[i,j], A.data[i,i]*B[i,j])
+            for k = 1:i - 1
+                Bij += A.data[i,k]*B[k,j]
+            end
+            B[i,j] = Bij
+        end
+    end
+    B
+end
+
+function Ac_mul_B!{T,S<:AbstractMatrix,IsUnit}(A::Triangular{T,S,:U,IsUnit}, B::StridedVecOrMat)
+    m, n = size(B, 1), size(B, 2)
+    m == size(A, 1) || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for j = 1:n
+        for i = m:-1:1
+            Bij = ifelse(IsUnit, B[i,j], A.data[i,i]*B[i,j])
+            for k = 1:i - 1
+                Bij += A.data[k,i]'B[k,j]
+            end
+            B[i,j] = Bij
+        end
+    end
+    B
+end
+
+function Ac_mul_B!{T,S<:AbstractMatrix,IsUnit}(A::Triangular{T,S,:L,IsUnit}, B::StridedVecOrMat)
+    m, n = size(B, 1), size(B, 2)
+    m == size(A, 1) || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for j = 1:n
+        for i = 1:m
+            Bij = ifelse(IsUnit, B[i,j], A.data[i,i]*B[i,j])
+            for k = i + 1:m
+                Bij += A.data[k,i]'B[k,j]
+            end
+            B[i,j] = Bij
+        end
+    end
+    B
+end
+
+function A_mul_B!{T,S<:AbstractMatrix,IsUnit}(A::StridedMatrix, B::Triangular{T,S,:U,IsUnit})
+    m, n = size(A)
+    size(B, 1) == n || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for i = 1:m
+        for j = n:-1:1
+            Aij = ifelse(IsUnit, A[i,j], A[i,j]*B[j,j])
+            for k = 1:j - 1
+                Aij += A[i,k]*B.data[k,j]
+            end
+            A[i,j] = Aij
+        end
+    end
+    A
+end
+
+function A_mul_B!{T,S<:AbstractMatrix,IsUnit}(A::StridedMatrix, B::Triangular{T,S,:L,IsUnit})
+    m, n = size(A)
+    size(B, 1) == n || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for i = 1:m
+        for j = 1:n
+            Aij = ifelse(IsUnit, A[i,j], A[i,j]*B[j,j])
+            for k = j + 1:n
+                Aij += A[i,k]*B.data[k,j]
+            end
+            A[i,j] = Aij
+        end
+    end
+    A
+end
+
+function A_mul_Bc!{T,S<:AbstractMatrix,IsUnit}(A::StridedMatrix, B::Triangular{T,S,:U,IsUnit})
+    m, n = size(A)
+    size(B, 1) == n || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for i = 1:m
+        for j = 1:n
+            Aij = ifelse(IsUnit, A[i,j], A[i,j]*B[j,j])
+            for k = j + 1:n
+                Aij += A[i,k]*B.data[j,k]'
+            end
+            A[i,j] = Aij
+        end
+    end
+    A
+end
+
+function A_mul_Bc!{T,S<:AbstractMatrix,IsUnit}(A::StridedMatrix, B::Triangular{T,S,:L,IsUnit})
+    m, n = size(A)
+    size(B, 1) == n || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for i = 1:m
+        for j = n:-1:1
+            Aij = ifelse(IsUnit, A[i,j], A[i,j]*B[j,j])
+            for k = 1:j - 1
+                Aij += A[i,k]*B.data[j,k]'
+            end
+            A[i,j] = Aij
+        end
+    end
+    A
+end
+
+A_mul_B!(A::Tridiagonal, B::Triangular) = A*full!(B)
+A_mul_B!(C::AbstractVecOrMat, A::Triangular, B::AbstractVecOrMat) = A_mul_B!(A, copy!(C, B))
+A_mul_Bc!(C::AbstractVecOrMat, A::Triangular, B::AbstractVecOrMat) = A_mul_Bc!(A, copy!(C, B))
 
 #Generic solver using naive substitution
 function naivesub!{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, b::AbstractVector, x::AbstractVector=b)
@@ -284,48 +357,173 @@ function naivesub!{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, b::AbstractV
     x
 end
 
-#Generic eigensystems
-eigvals(A::Triangular) = diag(A.data)
-det(A::Triangular) = prod(eigvals(A))
-
-function eigvecs{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit})
-    N = size(A,1)
-    evecs = zeros(T, N, N)
-    if IsUnit #Trivial
-        return eye(A)
-    elseif UpLo == :L #do forward substitution
-        for i=1:N
-            evecs[i,i] = one(T)
-            for j = i+1:N
-                for k = i:j-1
-                    evecs[j,i] -= A[j,k] * evecs[k,i]
-                end
-                evecs[j,i] /= A[j,j] - A[i,i]
+function A_rdiv_B!{T,S,IsUnit}(A::StridedMatrix, B::Triangular{T,S,:U,IsUnit})
+    m, n = size(A)
+    size(A, 1) == n || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for i = 1:m
+        for j = 1:n
+            Aij = A[i,j]
+            for k = 1:j - 1
+                Aij -= A[i,k]*B.data[k,j]
             end
-            evecs[i:N, i] /= norm(evecs[i:N, i])
+            A[i,j] = ifelse(IsUnit, Aij, Aij/B[j,j])
         end
-        evecs
-    elseif UpLo == :U #do backward substitution
-        for i=1:N
-            evecs[i,i] = one(T)
-            for j = i-1:-1:1
-                for k = j+1:i
-                    evecs[j,i] -= A[j,k] * evecs[k,i]
-                end
-                evecs[j,i] /= A[j,j]-A[i,i]
-            end
-            evecs[1:i, i] /= norm(evecs[1:i, i])
-        end
-    else
-        throw(ArgumentError("Unknown uplo=$(UpLo)"))
     end
-    evecs
+    A
 end
+
+function A_rdiv_B!{T,S,IsUnit}(A::StridedMatrix, B::Triangular{T,S,:L,IsUnit})
+    m, n = size(A)
+    size(A, 1) == n || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for i = 1:m
+        for j = n:-1:1
+            Aij = A[i,j]
+            for k = j + 1:n
+                Aij -= A[i,k]*B.data[k,j]
+            end
+            A[i,j] = ifelse(IsUnit, Aij, Aij/B[j,j])
+        end
+    end
+    A
+end
+
+function A_rdiv_Bc!{T,S,IsUnit}(A::StridedMatrix, B::Triangular{T,S,:U,IsUnit})
+    m, n = size(A)
+    size(A, 1) == n || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for i = 1:m
+        for j = n:-1:1
+            Aij = A[i,j]
+            for k = j + 1:n
+                Aij -= A[i,k]*B.data[j,k]'
+            end
+            A[i,j] = ifelse(IsUnit, Aij, Aij/B[j,j])
+        end
+    end
+    A
+end
+
+function A_rdiv_Bc!{T,S,IsUnit}(A::StridedMatrix, B::Triangular{T,S,:L,IsUnit})
+    m, n = size(A)
+    size(A, 1) == n || throw(DimensionMismatch("left and right hand side doesn't fit"))
+    for i = 1:m
+        for j = 1:n
+            Aij = A[i,j]
+            for k = 1:j - 1
+                Aij -= A[i,k]*B.data[j,k]'
+            end
+            A[i,j] = ifelse(IsUnit, Aij, Aij/B[j,j])
+        end
+    end
+    A
+end
+
+# Promotion
+## Promotion methods in matmul doesn't apply to triangular multiplication since it is inplace. Hence we have to make very similar definitions, but without allocation of a result array. For multiplication and unit diagonal division the element type doesn't have to be stable under division whereas that is necessary in the general triangular solve problem.
+
+## Some Triangular-Triangular cases. We might want to write taylored methods for these cases, but I'm not sure it is worth it.
+*(A::Tridiagonal, B::Triangular) = A_mul_B!(full(A), B)
+for f in (:*, :Ac_mul_B, :At_mul_B, :A_mul_Bc, :A_mul_Bt, :Ac_mul_Bc, :At_mul_Bt, :\, :Ac_ldiv_B, :At_ldiv_B)
+    @eval begin
+        ($f)(A::Triangular, B::Triangular) = ($f)(A, full(B))
+    end
+end
+for f in (:A_mul_Bc, :A_mul_Bt, :Ac_mul_Bc, :At_mul_Bt, :/, :A_rdiv_Bc, :A_rdiv_Bt)
+    @eval begin
+        ($f)(A::Triangular, B::Triangular) = ($f)(full(A), B)
+    end
+end
+
+## The general promotion methods
+### Multiplication with triangle to the left and hence rhs cannot be transposed.
+for (f, g) in ((:*, :A_mul_B!), (:Ac_mul_B, :Ac_mul_B!), (:At_mul_B, :At_mul_B!))
+    @eval begin
+        function ($f){TA,TB}(A::Triangular{TA}, B::StridedVecOrMat{TB})
+            TAB = typeof(zero(TA)*zero(TB) + zero(TA)*zero(TB))
+            ($g)(TA == TAB ? copy(A) : convert(AbstractArray{TAB}, A), TB == TAB ? copy(B) : convert(AbstractArray{TAB}, B))
+        end
+    end
+end
+### Left division with triangle to the left hence rhs cannot be transposed. No quotients.
+for (f, g) in ((:\, :A_ldiv_B!), (:Ac_ldiv_B, :Ac_ldiv_B!), (:At_ldiv_B, :At_ldiv_B!))
+    @eval begin
+        function ($f){TA,TB,S,UpLo}(A::Triangular{TA,S,UpLo,true}, B::StridedVecOrMat{TB})
+            TAB = typeof(zero(TA)*zero(TB) + zero(TA)*zero(TB))
+            ($g)(TA == TAB ? copy(A) : convert(AbstractArray{TAB}, A), TB == TAB ? copy(B) : convert(AbstractArray{TAB}, B))
+        end
+    end
+end
+### Left division with triangle to the left hence rhs cannot be transposed. Quotients.
+for (f, g) in ((:\, :A_ldiv_B!), (:Ac_ldiv_B, :Ac_ldiv_B!), (:At_ldiv_B, :At_ldiv_B!))
+    @eval begin
+        function ($f){TA,TB,S,UpLo}(A::Triangular{TA,S,UpLo,false}, B::StridedVecOrMat{TB})
+            TAB = typeof((zero(TA)*zero(TB) + zero(TA)*zero(TB))/one(TA))
+            ($g)(TA == TAB ? copy(A) : convert(AbstractArray{TAB}, A), TB == TAB ? copy(B) : convert(AbstractArray{TAB}, B))
+        end
+    end
+end
+### Multiplication with triangle to the rigth and hence lhs cannot be transposed.
+for (f, g) in ((:*, :A_mul_B!), (:A_mul_Bc, :A_mul_Bc!), (:A_mul_Bt, :A_mul_Bt!))
+    @eval begin
+        function ($f){TA,TB}(A::StridedVecOrMat{TA}, B::Triangular{TB})
+            TAB = typeof(zero(TA)*zero(TB) + zero(TA)*zero(TB))
+            ($g)(TA == TAB ? copy(A) : convert(AbstractArray{TAB}, A), TB == TAB ? copy(B) : convert(AbstractArray{TAB}, B))
+        end
+    end
+end
+### Right division with triangle to the right hence lhs cannot be transposed. No quotients.
+for (f, g) in ((:/, :A_rdiv_B!), (:A_rdiv_Bc, :A_rdiv_Bc!), (:A_rdiv_Bt, :A_rdiv_Bt!))
+    @eval begin
+        function ($f){TA,TB,S,UpLo}(A::StridedVecOrMat{TA}, B::Triangular{TB,S,UpLo,true})
+            TAB = typeof(zero(TA)*zero(TB) + zero(TA)*zero(TB))
+            ($g)(TA == TAB ? copy(A) : convert(AbstractArray{TAB}, A), TB == TAB ? copy(B) : convert(AbstractArray{TAB}, B))
+        end
+    end
+end
+### Right division with triangle to the right hence lhs cannot be transposed. Quotients.
+for (f, g) in ((:/, :A_rdiv_B!), (:A_rdiv_Bc, :A_rdiv_Bc!), (:A_rdiv_Bt, :A_rdiv_Bt!))
+    @eval begin
+        function ($f){TA,TB,S,UpLo}(A::StridedVecOrMat{TA}, B::Triangular{TB,S,UpLo,false})
+            TAB = typeof((zero(TA)*zero(TB) + zero(TA)*zero(TB))/one(TA))
+            ($g)(TA == TAB ? copy(A) : convert(AbstractArray{TAB}, A), TB == TAB ? copy(B) : convert(AbstractArray{TAB}, B))
+        end
+    end
+end
+
+function sqrtm{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit})
+    n = size(A, 1)
+    TT = typeof(sqrt(zero(T)))
+    R = zeros(TT, n, n)
+    if UpLo == :U
+        for j = 1:n
+            (T<:Complex || A[j,j]>=0) ? (R[j,j] = IsUnit ? one(T) : sqrt(A[j,j])) : throw(SingularException(j))
+            for i = j-1:-1:1
+                r = A[i,j]
+                for k = i+1:j-1
+                    r -= R[i,k]*R[k,j]
+                end
+                r==0 || (R[i,j] = r / (R[i,i] + R[j,j]))
+            end
+        end
+        return Triangular(R, :U, IsUnit)
+    else # UpLo == :L #Not the usual case
+        return sqrtm(A.').'
+    end
+end
+
+#Generic eigensystems
+eigvals(A::Triangular) = diag(A)
+function eigvecs{T}(A::Triangular{T})
+    TT = promote_type(T, Float32)
+    TT <: BlasFloat && return eigvecs(convert(AbstractMatrix{TT}, A))
+    error("type not handled yet. Please submit a pull request.")
+end
+det{T,S,UpLo}(A::Triangular{T,S,UpLo,true}) = one(T)*one(T)
+det{T,S,UpLo}(A::Triangular{T,S,UpLo,false}) = prod(diag(A.data))
 
 eigfact(A::Triangular) = Eigen(eigvals(A), eigvecs(A))
 
 #Generic singular systems
-for func in (:svd, :svdfact, :svdfact!, :svdvals, :svdvecs)
+for func in (:svd, :svdfact, :svdfact!, :svdvals)
     @eval begin
         ($func)(A::Triangular) = ($func)(full(A))
     end

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -1,13 +1,157 @@
 debug = false
 using Base.Test
-using Base.LinAlg: BlasFloat, errorbounds, naivesub!
+using Base.LinAlg: BlasFloat, errorbounds, full!, naivesub!, transpose!
 
 debug && println("Triangular matrices")
 
-n = 20
+n = 9
 srand(123)
 
-# A = rand(n, n)
+debug && println("Test basic type functionality")
+@test_throws DimensionMismatch Triangular(randn(5, 4), :L)
+@test Triangular(randn(3, 3), :L) |> t -> [size(t, i) for i = 1:3] == [size(full(t), i) for i = 1:3]
+
+# The following test block tries to call all methods in base/linalg/triangular.jl in order for a combination of input element types. Keep the ordering when adding code.
+for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
+    for elty2 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
+        for uplo1 in (:U, :L)
+            for uplo2 in (:U, :L)
+                for isunit1 in (true, false)
+                    for isunit2 in (true, false)
+                        A1 = Triangular(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t-> chol(t't, uplo1)), uplo1, isunit1)
+                        A2 = Triangular(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t-> chol(t't, uplo2)), uplo2, isunit2)
+
+                        for eltyB in (Float32, Float64, Complex64, Complex128)
+                            B = convert(Matrix{eltyB}, elty1 <: Complex ? real(A1)*ones(n, n) : A1*ones(n, n))
+
+                            debug && println("A1: $elty1, $uplo1, $isunit1.A2: $elty2, $uplo2, $isunit2. B: $eltyB")
+
+                            # Convert
+                            @test convert(Triangular{elty1}, A1) == A1
+                            if elty1 <: Real && !(elty2 <: Integer)
+                                @test convert(Triangular{elty2}, A1) == Triangular(convert(Matrix{elty2}, A1.data), uplo1, isunit1)
+                            elseif elty2 <: Real && !(elty1 <: Integer)
+                                @test_throws InexactError convert(Triangular{elty2}, A1) == Triangular(convert(Matrix{elty2}, A1.data), uplo1, isunit1)
+                            end
+                            @test convert(Matrix, A1) == full(A1)
+
+                            # full!
+                            @test full!(copy(A1)) == full(A1)
+
+                            # fill!
+                            @test full!(fill!(copy(A1), 1)) == full(Triangular(ones(size(A1)...), uplo1, isunit1))
+
+                            # similar
+                            @test isa(similar(A1), Triangular{elty1, Matrix{elty1}, uplo1, isunit1})
+
+                            # Linear indexing
+                            for i = 1:length(A1)
+                                @test A1[i] == full(A1)[i]
+                            end
+
+                            # istril/istriu
+                            if uplo1 == :L
+                                @test istril(A1)
+                                @test !istriu(A1)
+                            else
+                                @test istriu(A1)
+                                @test !istril(A1)
+                            end
+
+                            # (c)transpose
+                            @test full(A1') == full(A1)'
+                            @test full(A1.') == full(A1).'
+                            @test transpose!(copy(A1)) == A1.'
+
+                            # diag
+                            @test diag(A1) == diag(full(A1))
+
+                            # real
+                            @test full(real(A1)) == real(full(A1))
+
+                            # Unary operations
+                            @test full(-A1) == -full(A1)
+
+                            # Binary operations
+                            @test full(A1 + A2) == full(A1) + full(A2)
+                            @test full(A1 - A2) == full(A1) - full(A2)
+                            @test A1*0.5 == full(A1*0.5)
+                            @test 0.5*A1 == full(0.5*A1)
+                            @test A1/0.5 == full(A1/0.5)
+                            @test 0.5\A1 == full(0.5\A1)
+
+                            # Triangular-Triangular multiplication and division
+                            elty1 != BigFloat && elty2 != BigFloat && @test_approx_eq full(A1*A2) full(A1)*full(A2)
+                            @test_approx_eq full(A1'A2) full(A1)'full(A2)
+                            @test_approx_eq full(A1*A2') full(A1)*full(A2)'
+                            @test_approx_eq full(A1'A2') full(A1)'full(A2)'
+                            @test_approx_eq full(A1/A2) full(A1)/full(A2)
+
+                            # Triangular-dense Matrix/vector multiplication
+                            @test_approx_eq A1*B[:,1] full(A1)*B[:,1]
+                            @test_approx_eq A1*B full(A1)*B
+                            @test_approx_eq A1'B[:,1] full(A1)'B[:,1]
+                            @test_approx_eq A1'B full(A1)'B
+                            @test_approx_eq A1*B' full(A1)*B'
+                            @test_approx_eq B*A1 B*full(A1)
+                            @test_approx_eq B[:,1]'A1 B[:,1]'full(A1)
+                            @test_approx_eq B'A1 B'full(A1)
+                            @test_approx_eq B*A1' B*full(A1)'
+                            @test_approx_eq B[:,1]'A1' B[:,1]'full(A1)'
+                            @test_approx_eq B'A1' B'full(A1)'
+
+                            # ... and division
+                            @test_approx_eq A1\B[:,1] full(A1)\B[:,1]
+                            @test_approx_eq A1\B full(A1)\B
+                            @test_approx_eq A1'\B[:,1] full(A1)'\B[:,1]
+                            @test_approx_eq A1'\B full(A1)'\B
+                            @test_approx_eq A1\B' full(A1)\B'
+                            @test_approx_eq A1'\B' full(A1)'\B'
+                            @test_approx_eq B/A1 B/full(A1)
+                            @test_approx_eq B/A1' B/full(A1)'
+                            @test_approx_eq B'/A1 B'/full(A1)
+                            @test_approx_eq B'/A1' B'/full(A1)'
+
+                            # inversion
+                            @test_approx_eq inv(A1) inv(lufact(full(A1)))
+
+                            # Error bounds
+                            elty1 != BigFloat && errorbounds(A1, A1\B, B)
+                            
+                            # Determinant
+                            @test_approx_eq det(A1) det(lufact(full(A1)))
+
+                            # Matri square root
+                            @test_approx_eq sqrtm(A1) |> t->t*t A1
+
+                            # eigenproblems
+                            if elty1 != BigFloat # Not handled yet
+                                vals, vecs = eig(A1)
+                                if !isunit1 && elty1 != Int # Cannot really handle degenerate eigen space and Int matrices will probably have repeated eigenvalues.
+                                    @test_approx_eq_eps vecs*diagm(vals)/vecs full(A1) sqrt(eps(float(real(one(vals[1])))))*(norm(A1, Inf)*n)^2
+                                end
+                            end
+
+                            # Condition number tests - can be VERY approximate
+                            if elty1 <:BlasFloat
+                                for p in (1.0, Inf)
+                                    @test_approx_eq_eps cond(A1, p) cond(A1, p) (cond(A1, p) + cond(A1, p))
+                                end
+                            end
+
+                            if elty1 != BigFloat # Not implemented yet
+                                svd(A1)
+                                svdfact(A1)
+                                elty1 <: BlasFloat && svdfact!(copy(A1))
+                                svdvals(A1)
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
 
 Areal   = randn(n, n)/2
 Aimg    = randn(n, n)/2
@@ -23,8 +167,8 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         εb = eps(abs(float(one(eltyb))))
         ε = max(εa,εb)
 
-        debug && println("\ntype of A: ", eltya, " type of b: ", eltyb, "\n")
-    
+        debug && println("\ntype of A: ", eltya, " type of b: ", eltyb, "\n")        
+
         debug && println("Solve upper triangular system")
         Atri = Triangular(lufact(A)[:U], :U) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
         b = convert(Matrix{eltyb}, eltya <: Complex ? full(Atri)*ones(n, 2) : full(Atri)*ones(n, 2))
@@ -83,74 +227,3 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         end
     end
 end
-
-n = 11
-for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
-
-    debug && println("elty is $(elty), relty is $(relty)")
-    A = convert(Matrix{elty}, randn(n, n))
-    b = convert(Matrix{elty}, randn(n, 2))
-    if elty <: Complex
-        A += im*convert(Matrix{elty}, randn(n, n))
-        b += im*convert(Matrix{elty}, randn(n, 2))
-    end
-
-    for M1 in (Triangular(A, :U), Triangular(A, :L), Triangular(A, :U, true), Triangular(A, :L, true))
-    	debug && println("M1 is of $(typeof(M1))")
-    	for M2 in (Triangular(A, :U), Triangular(A, :L), Triangular(A, :U, true), Triangular(A, :L, true))
-    		debug && println("M2 is of $(typeof(M2))")
-    		@test full(M1 + M2) == full(M1) + full(M2)
-    		@test full(M1 - M2) == full(M1) - full(M2)
-    	end
-    	α = randn()
-    	@test full(α*M1) == full(M1*α)
-    	@test full(M1*α) == full(M1)*α
-    	@test full(α\M1) == full(M1/α)
-    	@test full(M1/α) == full(M1)/α
-    end
-
-    for (M, TM) in ((triu(A), Triangular(A, :U)), 
-    				(tril(A), Triangular(A, :L)))
-
-        debug && println("Linear solver")
-        x = M \ b
-        tx = TM \ b
-        condM = elty <:BlasFloat ? cond(TM, Inf) : convert(relty, cond(complex128(M), Inf))
-        @test norm(x - tx,Inf) <= 4*condM*max(eps()*norm(tx,Inf), eps(relty)*norm(x,Inf))
-        if elty <: BlasFloat #test naivesub! against LAPACK
-            tx = [naivesub!(TM, b[:,1]) naivesub!(TM, b[:,2])]
-            @test norm(x-tx,Inf) <= 4*condM*max(eps()*norm(tx,Inf), eps(relty)*norm(x,Inf))
-        end
-
-        debug && println("Eigensystems")
-        vals1, vecs1 = eig(complex128(M))
-        vals2, vecs2 = eig(TM)
-        res1=norm(complex128(vecs1*diagm(vals1)*inv(vecs1) - M))
-        res2=norm(complex128(vecs2*diagm(vals2)*inv(vecs2) - full(TM)))
-        @test_approx_eq_eps res1 res2 res1+res2
-
-        if elty <:BlasFloat
-            debug && println("Condition number tests - can be VERY approximate")
-            for p in [1.0, Inf]
-                @test_approx_eq_eps cond(TM, p) cond(M, p) (cond(TM,p)+cond(M,p))
-            end
-        end
-
-        debug && println("Binary operations")
-        B = convert(Matrix{elty}, randn(n, n))
-        for (M2, TM2) in ((triu(B), Triangular(B, :U)), (tril(B), Triangular(B, :L)))
-            for op in (*, +, -)
-                @test_approx_eq full(op(TM, TM2)) op(M, M2)
-                @test_approx_eq full(op(TM, M2)) op(M, M2)
-                @test_approx_eq full(op(M, TM2)) op(M, M2)
-            end
-            @test M2*0.5 == full(TM2*0.5)
-            @test 0.5*M2 == full(0.5*TM2)
-            @test M2/0.5 == full(TM2/0.5)
-            @test 0.5\M2 == full(0.5\TM2)
-        end
-    end
-end
-
-@test_throws DimensionMismatch Triangular(randn(5, 4), :L)
-


### PR DESCRIPTION
I decided to ensure that all linear algebra code is covered by tests. Here is the expanded tests for triangular matrices. There is quite a few possible combinations of input to the methods.

The good thing is that the new tests revealed some issues with promotion and a severe bug (which?). The bad thing is that it makes the linear algebra test suite slower. However, the triangular tests are now in a separate file so the parallelisation should be better.
