### PR TITLE
Fix so windows opens the default editor when `@edit` is used

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -24,6 +24,7 @@ function edit(file::String, line::Integer)
         f = find_source_file(file)
         f != nothing && (file = f)
     end
+    no_line_msg = "Unknown editor: no line number information passed.\nThe method is defined at line $line."
     if beginswith(edname, "emacs")
         spawn(`$edpath +$line $file`)
     elseif edname == "vim"
@@ -33,15 +34,18 @@ function edit(file::String, line::Integer)
     elseif beginswith(edname, "subl")
         spawn(`$(shell_split(edpath)) $file:$line`)
     elseif OS_NAME == :Windows && (edname == "start" || edname == "open")
-        spawn(`start /b $file`)
+        spawn(`cmd /c start /b $file`)
+        println(no_line_msg)
     elseif OS_NAME == :Darwin && (edname == "start" || edname == "open")
         spawn(`open -t $file`)
+        println(no_line_msg)
     elseif edname == "kate"
         spawn(`$edpath $file -l $line`)
     elseif edname == "nano"
         run(`$edpath +$line $file`)
     else
         run(`$(shell_split(edpath)) $file`)
+        println(no_line_msg)
     end
     nothing
 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -28,7 +28,7 @@ function find_source_file(file)
     (isabspath(file) || isfile(file)) && return file
     file2 = find_in_path(file)
     file2 != nothing && return file2
-    file2 = "$JULIA_HOME/../share/julia/base/$file"
+    file2 = joinpath(JULIA_HOME, DATAROOTDIR, "julia", "base", file)
     isfile(file2) ? file2 : nothing
 end
 


### PR DESCRIPTION
This fixes so windows can open source files with `@edit` macro using the default editor and I have added a notice to the user where to find the function when no line number info is sent to the editor.
