### PR TITLE
Relax dimensionality requirements in `A*_mul_B*!` and `transpose!`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -201,7 +201,7 @@ end
 
 copy(a::AbstractArray) = copy!(similar(a), a)
 
-function copy!{R,S}(B::AbstractMatrix{R}, ir_dest::Range{Int}, jr_dest::Range{Int}, A::AbstractMatrix{S}, ir_src::Range{Int}, jr_src::Range{Int})
+function copy!{R,S}(B::AbstractVecOrMat{R}, ir_dest::Range{Int}, jr_dest::Range{Int}, A::AbstractVecOrMat{S}, ir_src::Range{Int}, jr_src::Range{Int})
     if length(ir_dest) != length(ir_src) || length(jr_dest) != length(jr_src)
         error("source and destination must have same size")
     end
@@ -219,7 +219,7 @@ function copy!{R,S}(B::AbstractMatrix{R}, ir_dest::Range{Int}, jr_dest::Range{In
     return B
 end
 
-function copy_transpose!{R,S}(B::AbstractMatrix{R}, ir_dest::Range{Int}, jr_dest::Range{Int}, A::AbstractVecOrMat{S}, ir_src::Range{Int}, jr_src::Range{Int})
+function copy_transpose!{R,S}(B::AbstractVecOrMat{R}, ir_dest::Range{Int}, jr_dest::Range{Int}, A::AbstractVecOrMat{S}, ir_src::Range{Int}, jr_src::Range{Int})
     if length(ir_dest) != length(jr_src) || length(jr_dest) != length(ir_src)
         error("source and destination must have same size")
     end

--- a/base/array.jl
+++ b/base/array.jl
@@ -1229,9 +1229,9 @@ end
 
 ## Transpose ##
 const transposebaselength=64
-function transpose!(B::StridedMatrix,A::StridedMatrix)
+function transpose!(B::StridedVecOrMat,A::StridedMatrix)
     m, n = size(A)
-    size(B) == (n,m) || throw(DimensionMismatch("transpose"))
+    size(B,1) == n && size(B,2) == m || throw(DimensionMismatch("transpose"))
 
     if m*n<=4*transposebaselength
         @inbounds begin
@@ -1246,7 +1246,7 @@ function transpose!(B::StridedMatrix,A::StridedMatrix)
     end
     return B
 end
-function transposeblock!(B::StridedMatrix,A::StridedMatrix,m::Int,n::Int,offseti::Int,offsetj::Int)
+function transposeblock!(B::StridedVecOrMat,A::StridedMatrix,m::Int,n::Int,offseti::Int,offsetj::Int)
     if m*n<=transposebaselength
         @inbounds begin
             for j = offsetj+(1:n)
@@ -1266,9 +1266,9 @@ function transposeblock!(B::StridedMatrix,A::StridedMatrix,m::Int,n::Int,offseti
     end
     return B
 end
-function ctranspose!(B::StridedMatrix,A::StridedMatrix)
+function ctranspose!(B::StridedVecOrMat,A::StridedMatrix)
     m, n = size(A)
-    size(B) == (n,m) || throw(DimensionMismatch("transpose"))
+    size(B,1) == n && size(B,2) == m || throw(DimensionMismatch("transpose"))
 
     if m*n<=4*transposebaselength
         @inbounds begin
@@ -1283,7 +1283,7 @@ function ctranspose!(B::StridedMatrix,A::StridedMatrix)
     end
     return B
 end
-function ctransposeblock!(B::StridedMatrix,A::StridedMatrix,m::Int,n::Int,offseti::Int,offsetj::Int)
+function ctransposeblock!(B::StridedVecOrMat,A::StridedMatrix,m::Int,n::Int,offseti::Int,offsetj::Int)
     if m*n<=transposebaselength
         @inbounds begin
             for j = offsetj+(1:n)

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -272,8 +272,8 @@ for (fname, elty) in ((:dgemv_,:Float64),
              #      CHARACTER TRANS
              #*     .. Array Arguments ..
              #      DOUBLE PRECISION A(LDA,*),X(*),Y(*)
-        function gemv!(trans::BlasChar, alpha::($elty), A::StridedMatrix{$elty}, X::StridedVector{$elty}, beta::($elty), Y::StridedVector{$elty})
-            m,n = size(A)
+        function gemv!(trans::BlasChar, alpha::($elty), A::StridedVecOrMat{$elty}, X::StridedVector{$elty}, beta::($elty), Y::StridedVector{$elty})
+            m,n = size(A,1),size(A,2)
             length(X) == (trans == 'N' ? n : m) && length(Y) == (trans == 'N' ? m : n) || throw(DimensionMismatch(""))
             ccall(($(string(fname)),libblas), Void,
                 (Ptr{Uint8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, 
@@ -556,7 +556,7 @@ for (gemm, elty) in
              #       CHARACTER TRANSA,TRANSB
              # *     .. Array Arguments ..
              #       DOUBLE PRECISION A(LDA,*),B(LDB,*),C(LDC,*)
-        function gemm!(transA::BlasChar, transB::BlasChar, alpha::($elty), A::StridedVecOrMat{$elty}, B::StridedMatrix{$elty}, beta::($elty), C::StridedVecOrMat{$elty})
+        function gemm!(transA::BlasChar, transB::BlasChar, alpha::($elty), A::StridedVecOrMat{$elty}, B::StridedVecOrMat{$elty}, beta::($elty), C::StridedVecOrMat{$elty})
 #           if any([stride(A,1), stride(B,1), stride(C,1)] .!= 1)
 #               error("gemm!: BLAS module requires contiguous matrix columns")
 #           end  # should this be checked on every call?

--- a/test/linalg3.jl
+++ b/test/linalg3.jl
@@ -92,6 +92,12 @@ C = Array(Int, size(A, 1), size(B, 2))
 @test At_mul_B!(C, A, B) == A'*B
 @test A_mul_Bt!(C, A, B) == A*B'
 @test At_mul_Bt!(C, A, B) == A'*B'
+v = [1,2,3]
+C = Array(Int, 3, 3)
+@test A_mul_Bt!(C, v, v) == v*v'
+vf = float64(v)
+C = Array(Float64, 3, 3)
+@test A_mul_Bt!(C, v, v) == v*v'
 
 # matrix algebra with subarrays of floats (stride != 1)
 A = reshape(float64(1:20),5,4)


### PR DESCRIPTION
This implements support for various pre-allocated operations with `Vector`s that were formerly supported only for `Matrix`es. As a prototype of what this was designed to solve, this works:

```
julia> v = rand(5)
5-element Array{Float64,1}:
 0.5895  
 0.912975
 0.225657
 0.944821
 0.663553

julia> C = v*v'
5x5 Array{Float64,2}:
 0.34751   0.538199  0.133025   0.556972  0.391164
 0.538199  0.833523  0.206019   0.862598  0.605807
 0.133025  0.206019  0.0509211  0.213206  0.149735
 0.556972  0.862598  0.213206   0.892687  0.626939
 0.391164  0.605807  0.149735   0.626939  0.440302
```

but

```
julia> A_mul_Bt!(C, v, v)
ERROR: `A_mul_Bt!` has no method matching A_mul_Bt!(::Array{Float64,2}, ::Array{Float64,1}, ::Array{Float64,1})
```

With this pull request, such operations are supported.

CC @andreasnoack, @Jutho.
