### PR TITLE
 Extend llvmcall with support for entering declarations.

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -2,15 +2,15 @@
 
 // --- the ccall intrinsic ---
 
+// keep track of llvmcall declarations
+static std::set<u_int64_t> llvmcallDecls;
+
 // --- library symbol lookup ---
 
 // map from "libX" to full soname "libX.so.ver"
 #if defined(__linux__) || defined(__FreeBSD__)
 static std::map<std::string, std::string> sonameMap;
 static bool got_sonames = false;
-
-// keep track of llvmcall declarations
-static std::set<u_int64_t> llvmcallDecls;
 
 extern "C" DLLEXPORT void jl_read_sonames(void)
 {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3444,6 +3444,8 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
     else {
         m = shadow_module;
     }
+    // clear the list of llvmcall declarations as we'll be using a clean module
+    llvmcallDecls.clear();
 #ifndef LLVM35
     funcName << ";";
 #endif

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -31,3 +31,44 @@ baremodule PlusTest
     end
     @test int32(1)+int32(2)==int32(3)
 end
+
+# Test whether declarations work properly
+function undeclared_ceil(x::Float64)
+    llvmcall("""%2 = call double @llvm.ceil.f64(double %0)
+        ret double %2""", Float64, (Float64,), x)
+end
+@test_throws ErrorException undeclared_ceil(4.2)
+# KNOWN ISSUE: although the llvmcall in undeclare_ceil did error(), the LLVM
+# module contains the generated IR referencing the ceil intrinsic. At some
+# point, a declaration for that intrinsic is added, breaking any future
+# llvmcall((conflicting declaration, ...), ...). Not an issue in LLVM 3.5+.
+function declared_floor(x::Float64)
+    llvmcall(
+        ("""declare double @llvm.floor.f64(double)""",
+         """%2 = call double @llvm.floor.f64(double %0)
+            ret double %2"""),
+    Float64, (Float64,), x)
+end
+@test_approx_eq declared_floor(4.2) 4.
+function doubly_declared_floor(x::Float64)
+    llvmcall(
+        ("""declare double @llvm.floor.f64(double)""",
+         """%2 = call double @llvm.floor.f64(double %0)
+            ret double %2"""),
+    Float64, (Float64,), x+1)-1
+end
+@test_approx_eq doubly_declared_floor(4.2) 4.
+function doubly_declared2_trunc(x::Float64)
+    a = llvmcall(
+        ("""declare double @llvm.trunc.f64(double)""",
+         """%2 = call double @llvm.trunc.f64(double %0)
+            ret double %2"""),
+    Float64, (Float64,), x)
+    b = llvmcall(
+        ("""declare double @llvm.trunc.f64(double)""",
+         """%2 = call double @llvm.trunc.f64(double %0)
+            ret double %2"""),
+    Float64, (Float64,), x+1)-1
+    a + b
+end
+@test_approx_eq doubly_declared2_trunc(4.2) 8.


### PR DESCRIPTION
_This is a copy of PR #8673 -- I accidentally created the old PR from my `master` branch, which isn't very clean._

This PR adds support to `llvmcall` for inserting required declarations in the module. This is useful when you want to `llvmcall` intrinsics, because LLVM refuses to parse IR with undeclared identifiers (for example, see [this thread](https://groups.google.com/forum/#!searchin/julia-dev/llvmcall/julia-dev/X0k-AErZBYk/f5DoyAFwhkAJ)).

The idea behind this solution is to allow passing a tuple `(decls, ir)`as first argument to `llvmcall`, where currently only an IR string or a pointer to a LLVM function is allowed. The `decls` IR is then pasted before the function `llvmcall` generates. In order to avoid duplicate declarations, which LLVM does not like, a global set keeps track of the declarations added to the current module.

Example usage:

``` julia
function floor(x::Float64)
  llvmcall(
    ("""declare double @llvm.floor.f64(double)""",
     """%2 = call double @llvm.floor.f64(double %0)
        ret double %2"""),
    Float64, (Float64,), x)
end
```

As mentioned in issue #8308 I also tried other approaches, such as automatically parsing identifiers in the IR, but that turned out pretty fragile.
