### PR TITLE
fix #8698: cp(src,dst) should truncate dst if it already exists

### DIFF
--- a/base/fs.jl
+++ b/base/fs.jl
@@ -125,15 +125,13 @@ end
 
 # For copy command
 function sendfile(src::String, dst::String)
-    flags = JL_O_RDONLY
-    src_file = open(src, flags)
+    src_file = open(src, JL_O_RDONLY)
     if !src_file.open
         error("Src file is not open")
     end
 
-    flags = JL_O_CREAT | JL_O_RDWR
-    mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP| S_IROTH | S_IWOTH
-    dst_file = open(dst, flags, mode)
+    dst_file = open(dst, JL_O_CREAT | JL_O_TRUNC | JL_O_WRONLY,
+                    S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP| S_IROTH | S_IWOTH)
     if !dst_file.open
         error("Dst file is not open")
     end

--- a/test/file.jl
+++ b/test/file.jl
@@ -295,14 +295,24 @@ write(af, "This is indeed a test")
 bfile = joinpath(dir, "b.txt")
 cp(afile, bfile)
 
+# issue #8698
+cfile = joinpath(dir, "c.txt")
+open(cfile, "w") do cf
+    write(cf, "This is longer than the contents of afile")
+end
+cp(afile, cfile)
+
 a_stat = stat(afile)
 b_stat = stat(bfile)
+c_stat = stat(cfile)
 @test a_stat.mode == b_stat.mode
 @test a_stat.size == b_stat.size
+@test a_stat.size == c_stat.size
 
 close(af)
 rm(afile)
 rm(bfile)
+rm(cfile)
 
 ###################
 # FILE* interface #


### PR DESCRIPTION
See #8698: `cp` was opening its destination file with `JL_O_CREAT | JL_O_RDWR`, when it should have used `JL_O_CREAT | JL_O_TRUNC | JL_O_WRONLY`.
