### PR TITLE
Use language: julia in default Travis

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -136,23 +136,17 @@ end
 function travis(pkg::AbstractString; force::Bool=false)
     genfile(pkg,".travis.yml",force) do io
         print(io, """
-        language: cpp
-        compiler:
-          - clang
+        language: julia
+        os:
+          - linux
+          - osx
+        julia:
+          - release
+          - nightly
         notifications:
           email: false
-        env:
-          matrix:
-            - JULIAVERSION="juliareleases"
-            - JULIAVERSION="julianightlies"
-        before_install:
-          - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-          - sudo add-apt-repository ppa:staticfloat/\${JULIAVERSION} -y
-          - sudo apt-get update -qq -y
-          - sudo apt-get install libpcre3-dev julia -y
-          - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-        script:
-          - julia --check-bounds=yes -e 'versioninfo(); Pkg.init(); Pkg.clone(pwd()); Pkg.build("$pkg"); Pkg.test("$pkg")'
+        #script:
+        #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("$pkg"); Pkg.test("$pkg")'
         """)
     end
 end

--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -145,7 +145,9 @@ function travis(pkg::AbstractString; force::Bool=false)
           - nightly
         notifications:
           email: false
+        # uncomment the following lines to override the default test script
         #script:
+        #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
         #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("$pkg"); Pkg.test("$pkg")'
         """)
     end

--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -148,7 +148,7 @@ function travis(pkg::AbstractString; force::Bool=false)
         # uncomment the following lines to override the default test script
         #script:
         #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-        #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("$pkg"); Pkg.test("$pkg")'
+        #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("$pkg"); Pkg.test("$pkg"; coverage=true)'
         """)
     end
 end


### PR DESCRIPTION
Edit 12/10/14: redid this to use the new `language: julia`

former content:

---

Ref #7364 and https://github.com/JuliaLang/julialang.github.com/issues/151 - I put together a shell script to handle installing Julia binaries on different platforms, now I'm proposing to use it in the default `.travis.yml` from `Pkg.generate`. I've got a [otherwise unfinished] test package using this script across a matrix of linux and mac on both release and nightlies [here](https://travis-ci.org/tkelman/BLIS.jl/builds/38539365), though it looks like the osx builds are going to be queued for a while.

Also add the `os:` section for osx testing (has to be explicitly enabled by sending an email to support@travis-ci.com, see http://docs.travis-ci.com/user/multi-os, it doesn't do anything if it hasn't been enabled yet).
