### PR TITLE
Avoid type inference problem in chol which caused a 10x slowdown in stockcorr benchmark without breaking anything

### DIFF
--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -15,7 +15,7 @@ end
 
 function chol!{T<:BlasFloat}(A::StridedMatrix{T}, uplo::Symbol=:U)
     C, info = LAPACK.potrf!(char_uplo(uplo), A)
-    return @assertposdef Triangular(C, uplo, false) info
+    return @assertposdef Triangular{eltype(C),typeof(C),uplo,false}(C) info
 end
 
 function chol!{T}(A::AbstractMatrix{T}, uplo::Symbol=:U)

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -85,16 +85,7 @@ function cholfact(x::Number, uplo::Symbol=:U)
     Cholesky{:U, eltype(xf), typeof(xf)}(xf)
 end
 
-chol(A::AbstractMatrix, uplo::Symbol) = chol!(copy(A), uplo)
-
-function chol(A::AbstractMatrix)
-    A = copy(A)
-    C, info = LAPACK.potrf!('U', A)
-    chksquare(C)
-    T = Triangular{eltype(C),typeof(C),:U,false}(C)
-    return @assertposdef T info
-end
-
+chol(A::AbstractMatrix, uplo::Symbol=:U) = chol!(copy(A), uplo)
 function chol!(x::Number, uplo::Symbol=:U)
     rx = real(x)
     rx == abs(x) || throw(DomainError())


### PR DESCRIPTION
@JeffBezanson I could solve the problem by calling another constructor. For solve reason `Triangular{eltype(C),typeof(C),uplo,false}(C)` worked better than `Triangular(C,uplo,false)` although the latter method is defined by

```
function Triangular{T}(A::AbstractMatrix{T}, uplo::Symbol, isunit::Bool=false)
    chksquare(A)
    Triangular{T,typeof(A),uplo,isunit}(A)
end
```

Is there something wrong with the latter definition that breaks type inference?
