### PR TITLE
fix #8690: remove uv.h dependency from julia.h

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -102,7 +102,7 @@ static uv_lib_t *get_library(char *lib)
     hnd = libMap[lib];
     if (hnd != NULL)
         return hnd;
-    hnd = jl_load_dynamic_library(lib, JL_RTLD_DEFAULT);
+    hnd = (uv_lib_t *) jl_load_dynamic_library(lib, JL_RTLD_DEFAULT);
     if (hnd != NULL)
         libMap[lib] = hnd;
     return hnd;

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -6,7 +6,7 @@
 
 #include "platform.h"
 #include "julia.h"
-#include "uv.h"
+#include "julia_internal.h"
 #ifdef _OS_WINDOWS_
 #include <windows.h>
 #include <direct.h>
@@ -38,8 +38,9 @@ extern char *julia_home;
 
 #define JL_RTLD(flags, FLAG) (flags & JL_RTLD_ ## FLAG ? RTLD_ ## FLAG : 0)
 
-DLLEXPORT int jl_uv_dlopen(const char *filename, uv_lib_t *lib, unsigned flags)
+DLLEXPORT int jl_uv_dlopen(const char *filename, jl_uv_libhandle lib_, unsigned flags)
 {
+    uv_lib_t *lib = (uv_lib_t *) lib_;
 #if defined(_OS_WINDOWS_)
     needsSymRefreshModuleList = 1;
 #endif
@@ -152,28 +153,28 @@ done:
     return handle;
 }
 
-uv_lib_t *jl_load_dynamic_library_e(char *modname, unsigned flags)
+jl_uv_libhandle jl_load_dynamic_library_e(char *modname, unsigned flags)
 {
-    return jl_load_dynamic_library_(modname, flags, 0);
+    return (jl_uv_libhandle) jl_load_dynamic_library_(modname, flags, 0);
 }
 
-uv_lib_t *jl_load_dynamic_library(char *modname, unsigned flags)
+jl_uv_libhandle jl_load_dynamic_library(char *modname, unsigned flags)
 {
-    return jl_load_dynamic_library_(modname, flags, 1);
+    return (jl_uv_libhandle) jl_load_dynamic_library_(modname, flags, 1);
 }
 
-void *jl_dlsym_e(uv_lib_t *handle, char *symbol)
+void *jl_dlsym_e(jl_uv_libhandle handle, char *symbol)
 {
     void *ptr;
-    int  error=uv_dlsym(handle, symbol, &ptr);
+    int  error=uv_dlsym((uv_lib_t *) handle, symbol, &ptr);
     if (error) ptr=NULL;
     return ptr;
 }
 
-void *jl_dlsym(uv_lib_t *handle, char *symbol)
+void *jl_dlsym(jl_uv_libhandle handle, char *symbol)
 {
     void *ptr;
-    int  error = uv_dlsym(handle, symbol, &ptr);
+    int  error = uv_dlsym((uv_lib_t *) handle, symbol, &ptr);
     if (error != 0) {
         jl_printf(JL_STDERR, "symbol could not be found %s (%d): %s\n", symbol, error, uv_dlerror(handle));
     }

--- a/src/dump.c
+++ b/src/dump.c
@@ -151,7 +151,7 @@ static void jl_load_sysimg_so(char *fname)
     // attempt to load the pre-compiled sysimg at fname
     // if this succeeds, sysimg_gvars will be a valid array
     // otherwise, it will be NULL
-    jl_sysimg_handle = jl_load_dynamic_library_e(fname, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
+    jl_sysimg_handle = (uv_lib_t *) jl_load_dynamic_library_e(fname, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
     if (jl_sysimg_handle != 0) {
         sysimg_gvars = (jl_value_t***)jl_dlsym(jl_sysimg_handle, "jl_sysimg_gvars");
         globalUnique = *(size_t*)jl_dlsym(jl_sysimg_handle, "jl_globalUnique");

--- a/src/init.c
+++ b/src/init.c
@@ -732,7 +732,7 @@ void julia_init(char *imageFile)
     jl_page_size = jl_getpagesize();
     jl_arr_xtralloc_limit = uv_get_total_memory() / 100;  // Extra allocation limited to 1% of total RAM 
     jl_find_stack_bottom();
-    jl_dl_handle = jl_load_dynamic_library(NULL, JL_RTLD_DEFAULT);
+    jl_dl_handle = (uv_lib_t *) jl_load_dynamic_library(NULL, JL_RTLD_DEFAULT);
 #ifdef RTLD_DEFAULT
     jl_RTLD_DEFAULT_handle->handle = RTLD_DEFAULT;
 #else

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -907,7 +907,7 @@ DLLEXPORT char *jl_ios_buf_base(ios_t *ios)
     return ios->buf;
 }
 
-DLLEXPORT uv_lib_t *jl_wrap_raw_dl_handle(void *handle)
+DLLEXPORT jl_uv_libhandle jl_wrap_raw_dl_handle(void *handle)
 {
     uv_lib_t *lib = (uv_lib_t*)malloc(sizeof(uv_lib_t));
     #ifdef _OS_WINDOWS_
@@ -916,7 +916,7 @@ DLLEXPORT uv_lib_t *jl_wrap_raw_dl_handle(void *handle)
     lib->handle=handle;
     #endif
     lib->errmsg=NULL;
-    return lib;
+    return (jl_uv_libhandle) lib;
 }
 
 #ifndef _OS_WINDOWS_

--- a/src/julia.h
+++ b/src/julia.h
@@ -9,7 +9,6 @@ extern "C" {
 
 #include "libsupport.h"
 #include <stdint.h>
-#include "uv.h"
 
 #include "htable.h"
 #include "arraylist.h"
@@ -385,17 +384,6 @@ extern DLLEXPORT jl_tuple_t *jl_null;
 DLLEXPORT extern jl_value_t *jl_true;
 DLLEXPORT extern jl_value_t *jl_false;
 DLLEXPORT extern jl_value_t *jl_nothing;
-
-DLLEXPORT extern uv_lib_t *jl_dl_handle;
-DLLEXPORT extern uv_lib_t *jl_RTLD_DEFAULT_handle;
-
-#if defined(_OS_WINDOWS_)
-DLLEXPORT extern uv_lib_t *jl_exe_handle;
-extern uv_lib_t *jl_ntdll_handle;
-extern uv_lib_t *jl_kernel32_handle;
-extern uv_lib_t *jl_crtdll_handle;
-extern uv_lib_t *jl_winsock_handle;
-#endif
 
 // some important symbols
 extern jl_sym_t *call_sym;
@@ -902,12 +890,14 @@ enum JL_RTLD_CONSTANT {
      /* MacOS X 10.5+: */ JL_RTLD_FIRST=64U
 };
 #define JL_RTLD_DEFAULT (JL_RTLD_LAZY | JL_RTLD_DEEPBIND)
-DLLEXPORT uv_lib_t *jl_load_dynamic_library(char *fname, unsigned flags);
-DLLEXPORT uv_lib_t *jl_load_dynamic_library_e(char *fname, unsigned flags);
-DLLEXPORT void *jl_dlsym_e(uv_lib_t *handle, char *symbol);
-DLLEXPORT void *jl_dlsym(uv_lib_t *handle, char *symbol);
-DLLEXPORT int jl_uv_dlopen(const char *filename, uv_lib_t *lib, unsigned flags);
-DLLEXPORT uv_lib_t *jl_wrap_raw_dl_handle(void *handle);
+
+typedef void *jl_uv_libhandle; // uv_lib_t* (avoid uv.h dependency)
+DLLEXPORT jl_uv_libhandle jl_load_dynamic_library(char *fname, unsigned flags);
+DLLEXPORT jl_uv_libhandle jl_load_dynamic_library_e(char *fname, unsigned flags);
+DLLEXPORT void *jl_dlsym_e(jl_uv_libhandle handle, char *symbol);
+DLLEXPORT void *jl_dlsym(jl_uv_libhandle handle, char *symbol);
+DLLEXPORT int jl_uv_dlopen(const char *filename, jl_uv_libhandle lib, unsigned flags);
+DLLEXPORT jl_uv_libhandle jl_wrap_raw_dl_handle(void *handle);
 char *jl_dlfind_win32(char *name);
 DLLEXPORT int add_library_mapping(char *lib, void *hnd);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2,6 +2,7 @@
 #define JULIA_INTERNAL_H
 
 #include "options.h"
+#include "uv.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -129,6 +130,17 @@ DLLEXPORT void jl_raise_debugger(void);
 // timers
 // Returns time in nanosec
 DLLEXPORT uint64_t jl_hrtime(void);
+
+// libuv stuff:
+DLLEXPORT extern uv_lib_t *jl_dl_handle;
+DLLEXPORT extern uv_lib_t *jl_RTLD_DEFAULT_handle;
+#if defined(_OS_WINDOWS_)
+DLLEXPORT extern uv_lib_t *jl_exe_handle;
+extern uv_lib_t *jl_ntdll_handle;
+extern uv_lib_t *jl_kernel32_handle;
+extern uv_lib_t *jl_crtdll_handle;
+extern uv_lib_t *jl_winsock_handle;
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/sys.c
+++ b/src/sys.c
@@ -3,7 +3,7 @@
   I/O and operating system utility functions
 */
 #include "julia.h"
-#include "uv.h"
+#include "julia_internal.h"
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
See #8690: this moves the `uv.h` stuff from `julia.h` to `julia_internal.h`, and modifies the `dlopen`-related functions to use `void*` (aliased to `jl_uv_libhandle`) rather than `uv_lib_t*`.
