### PR TITLE
RFC: cross-platform shared memory support / SharedArray extended to windows

### DIFF
--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -27,8 +27,6 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
 
     isbits(T) || error("Type of Shared Array elements must be bits types")
 
-    nbytes = prod(dims)*sizeof(T)
-
     if isempty(pids)
         # only use workers on the current host
         pids = procs(myid())

--- a/base/shmem.jl
+++ b/base/shmem.jl
@@ -60,7 +60,7 @@ function open_shm(name::String, size::Integer, create::Bool, readonly::Bool)
         szhi = sz>>32
         szlo = sz&typemax(Uint32)
         hdl = ccall(:CreateFileMappingA, stdcall, Ptr{Void}, 
-                    (Ptr{Void}, Ptr{Void}, Cint, Cint, Cint, Ptr{Uint8}),
+                    (Cptrdiff_t, Ptr{Void}, Cint, Cint, Cint, Ptr{Uint8}),
                     -1, C_NULL, ro, szhi, szlo, name)
     else
         ro = readonly ? 4 : 2

--- a/base/shmem.jl
+++ b/base/shmem.jl
@@ -1,0 +1,112 @@
+# OS-specific code
+
+@unix_only
+
+type SharedMemory
+    stream :: IOStream
+end
+
+function open_shm(name::String, size::Integer, create::Bool, readonly::Bool)
+    oflags = (create ? JL_O_CREAT : 0) | (readonly ? O_RDONLY : O_RDWR)
+    fd = ccall(:shm_open, Cint, (Ptr{Uint8}, Cint, Cint), 
+                 name, oflags, S_IRUSR | S_IWUSR)
+    if create && ccall(:ftruncate, Cint, (Cint, Cint), fd, size) != 0
+        error("unable to ftruncate shared memory segment " * name)
+    end
+    SharedMemory(fdio(name, fd, true))
+end
+
+function unlink_shm(name::String)
+    if ccall(:shm_unlink, Cint, (Ptr{Uint8},), name) != 0
+        error("unable to unlink shared memory segment " * name)
+    end
+end
+
+function mmap_array_shm{T,N}(::Type{T}, dims::NTuple{N,Integer}, shm::SharedMemory, offset::FileOffset)
+    mmap_array(T, dims, shm.stream, offset, grow=false)
+end
+
+end # @unix_only
+
+@windows_only
+
+const SHM_GRANULARITY::Int = ccall(:jl_getallocationgranularity, Clong, ())
+
+type SharedMemory
+    handle :: Ptr{Void}
+    readonly :: Bool
+end
+
+function open_shm(name::String, size::Integer, create::Bool, readonly::Bool)
+    
+    if size < 0
+        error("requested size is negative")
+    end
+    if size > typemax(Int)-SHM_GRANULARITY
+        error("size is too large to memory-map on this platform")
+    end
+    
+    if create
+        ro = readonly ? 0x02 : 0x04
+        sz = convert(Csize_t, size)
+        szhi = sz>>32
+        szlo = sz&typemax(Uint32)
+        hdl = ccall(:CreateFileMappingA, stdcall, Ptr{Void}, 
+                    (Ptr{Void}, Ptr{Void}, Cint, Cint, Cint, Ptr{Uint8}),
+                    -1, C_NULL, ro, szhi, szlo, name)
+    else
+        ro = readonly ? 4 : 2
+        hdl = ccall(:OpenFileMappingA, stdcall, Ptr{Void},
+                    (Cint, Cint, Ptr{Uint8}),
+                    ro, true, name)
+    end
+    if hdl == C_NULL
+        error("could not create shared memory object: $(FormatMessage())")
+    end
+    shm = SharedMemory(hdl)
+
+    function finalizer_closure()
+        if !bool(ccall(:CloseHandle, stdcall, Cint, (Ptr{Void},), hdl))
+            error("could not close shared memory object: $(FormatMessage())")
+        end
+    end
+    finalizer(shm,x->finalizer_closure())
+
+    shm
+end
+
+function unlink_shm(name::String)
+    # no-op in windows
+end
+
+function mmap_array_shm{T,N}(::Type{T}, dims::NTuple{N,Integer}, shm::SharedMemory, offset::FileOffset)
+    len = prod(dims)*sizeof(T)
+    pgoff::FileOffset = div(offset, SHM_GRANULARITY)*SHM_GRANULARITY
+    szf = convert(Csize_t, len+offset)
+    sza = szf - convert(Csize_t, pgoff)
+    ro = shm.readonly ? 4 : 2
+    pgoffhi = pgoff>>32
+    pgofflo = pgoff&typemax(Uint32)
+    hdl = ccall(:MapViewOfFile, stdcall, Ptr{Void},
+                (Ptr{Void}, Cint, Cint, Csize_t),
+                shm.handle, ro, pgoffhi, pgofflo, sza)
+    if hdl == C_NULL
+        error("could not create mapping view: $(FormatMessage())")
+    end
+    
+    A = pointer_to_array(convert(Ptr{T}, hdl+offset-pgoff), dims)
+
+    function finalizer_closure()
+        if !bool(ccall(:UnmapViewOfFile, stdcall, Cint, (Ptr{Void},), hdl))
+            error("could not unmap view: $(FormatMessage())")
+        end
+    end
+    finalizer(A,x->finalizer_closure())
+
+    A
+end
+
+end # @windows_only
+
+
+

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -196,6 +196,7 @@ importall .Random
 # distributed arrays and memory-mapped arrays
 include("darray.jl")
 include("mmap.jl")
+include("shmem.jl")
 include("sharedarray.jl")
 
 # utilities - version, timing, help, edit, metaprogramming

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -574,7 +574,7 @@ is ``DArray``\ -specific, but we list it here for completeness::
 
 
     
-Shared Arrays (Experimental, UNIX-only feature)
+Shared Arrays (Experimental)
 -----------------------------------------------
 
 Shared Arrays use system shared memory to map the same array across

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -29,8 +29,6 @@ map!(x->1, d)
 @test reduce(+, d) == 100
 
 
-@unix_only begin
-
 dims = (20,20,20)
 
 @linux_only begin
@@ -121,9 +119,6 @@ map!(x->1, d)
 # Boundary cases where length(S) <= length(pids)
 @test 2.0 == remotecall_fetch(id_other, D->D[2], Base.shmem_fill(2.0, 2; pids=[id_me, id_other]))
 @test 3.0 == remotecall_fetch(id_other, D->D[1], Base.shmem_fill(3.0, 1; pids=[id_me, id_other]))
-
-
-end # @unix_only(SharedArray tests)
 
 
 # Test @parallel load balancing - all processors should get either M or M+1


### PR DESCRIPTION
- Added a cross-platform (POSIX and Windows) interface to creating and mmaping shared memory in base/shmem.jl
- Updated SharedArray to use this new interface.
- Ensured the tests in test/parallel.jl pass on both linux and windows.

This is my first PR for base. Comments and general pointers very welcome.
