### PR TITLE
RFC: Allow digits! to populate a SubArray from a pre allocated Array

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -314,7 +314,7 @@ function digits{T<:Integer}(n::Integer, base::T=10, pad::Int=1)
     return a
 end
 
-function digits!{T<:Integer}(a::Array{T,1}, n::Integer, base::T=10)
+function digits!{T<:Integer}(a::AbstractArray{T,1}, n::Integer, base::T=10)
     2 <= base || error("invalid base: $base")
     for i = 1:length(a)
         a[i] = rem(n, base)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2004,6 +2004,14 @@ let a = zeros(Int, 3)
     @test a == [1, 1, 1]
 end
 
+# Fill a pre allocated 2x4 matrix
+let a = zeros(Int,(2,4))
+    for i in 0:3
+        digits!(sub(a,:,i+1),i,2)
+    end
+    @test a == [0 1 0 1;
+                0 0 1 1]
+end
 @test_throws InexactError convert(Uint8, 256)
 @test_throws InexactError convert(Uint, -1)
 @test_throws InexactError convert(Int, big(2)^100)


### PR DESCRIPTION
Issue #7948 added digits! for Arrays. I wanted to use it to fill a pre allocated 2x4 array so:

``` julia
let a = zeros(Int,(2,4))
    for i in 0:3
        digits!(sub(a,:,i+1),i,2)
    end
    println(a)
end
```

Therefore I made the type of digits! parameter AbstractArray instead of Array.
edit: added codeblock
