### PR TITLE
Add support for zero(::Array{Array})

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -237,7 +237,7 @@ function copy_transpose!{R,S}(B::AbstractVecOrMat{R}, ir_dest::Range{Int}, jr_de
     return B
 end
 
-zero{T}(x::AbstractArray{T}) = fill!(similar(x), zero(T))
+zero{T}(x::AbstractArray{T}) = fill!(similar(x), zero(isempty(x) ? T : x[1]))
 
 ## iteration support for arrays as ranges ##
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -910,3 +910,8 @@ function pr8622()
     return indexin(x,y)
 end
 @test pr8622() == [0,3,1,0]
+
+#Array of Array tests
+let A = [zeros(2,2) for i=1:2, j=1:2]
+    @test zero(A) == A
+end


### PR DESCRIPTION
The problem with the existing definition is that it tries to call zero(::Type{Array}), which fails because it doesn't know what size the eltype should be.

The solution here is simple - if the outer Array is not empty, call zero on its first element.

A similar problem occurs with one() but that is harder to fix.
