### PR TITLE
[release-0.3] Stop thinking about release-0.3 as a fork

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -211,7 +211,7 @@ function banner(io::IO = STDOUT)
         commit = GIT_VERSION_INFO.commit_short
 
         if distance == 0
-            commit_string = "Commit $(commit) ($(days) $(unit) old master)"
+            commit_string = "Commit $(commit) ($(days) $(unit) old release-0.3)"
         else
             branch = GIT_VERSION_INFO.branch
             commit_string = "$(branch)/$(commit) (fork: $(distance) commits, $(days) $(unit))"

--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -56,8 +56,8 @@ if [ $(git describe --tags --exact-match 2> /dev/null) ]; then
 else
     tagged_commit="false"
 fi
-fork_master_distance=$(git rev-list HEAD ^"$(echo $origin)master" | wc -l | sed -e 's/[^[:digit:]]//g')
-fork_master_timestamp=$(git show -s $(git merge-base HEAD $(echo $origin)master) --format=format:"%ct")
+fork_master_distance=$(git rev-list HEAD ^"$(echo $origin)release-0.3" | wc -l | sed -e 's/[^[:digit:]]//g')
+fork_master_timestamp=$(git show -s $(git merge-base HEAD $(echo $origin)release-0.3) --format=format:"%ct")
 
 # Check for errrors and emit default value for missing numbers.
 if [ -z "$build_number" ]; then


### PR DESCRIPTION
This changes the splash screen to the more reasonable view that treats release-0.3 as the master branch.

```
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "help()" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.3.2-pre+2 (2014-10-22 01:21 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 6babc84 (0 days old release-0.3)
|__/                   |  x86_64-apple-darwin13.4.0
```

I should've done this ages ago, but late is better than never.
