### PR TITLE
fix type inconsistency in _uv_hook_return_spawn

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -226,7 +226,7 @@ function uvfinalize(proc::Process)
 end
 
 function _uv_hook_return_spawn(proc::Process, exit_status::Int64, termsignal::Int32)
-    proc.exitcode = exit_status
+    proc.exitcode = int32(exit_status)
     proc.termsignal = termsignal
     if isa(proc.exitcb, Function) proc.exitcb(proc, exit_status, termsignal) end
     ccall(:jl_close_uv, Void, (Ptr{Void},), proc.handle)


### PR DESCRIPTION
proc.exitcode is an Int32, see line 173

This was causing `InexactError()` when I hit a test failure on Windows.
