### PR TITLE
Remove T from julia.lang as a type-related special constant

### DIFF
--- a/contrib/julia.lang
+++ b/contrib/julia.lang
@@ -119,7 +119,6 @@
       <keyword>STDIN</keyword>
       <keyword>STDOUT</keyword>
       <!-- type-related -->
-      <keyword>T</keyword>
       <keyword>ANY</keyword>
     </context>
 


### PR DESCRIPTION
This causes, for instance, syntax highlighting issues when defining T as a variable.
