### PR TITLE
change finalizer argument order to allow for do-block syntax

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -682,7 +682,7 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
     if !repl.no_history_file
         try
             f = open(find_hist_file(), true, true, true, false, false)
-            finalizer(replc, replc->close(f))
+            finalizer(_->close(f), replc)
             hist_from_file(hp, f)
         catch e
             print_response(repl, e, catch_backtrace(), true, Base.have_color)

--- a/base/base.jl
+++ b/base/base.jl
@@ -139,10 +139,10 @@ const (:) = Colon()
 ==(w::WeakRef, v) = isequal(w.value, v)
 ==(w, v::WeakRef) = isequal(w, v.value)
 
-function finalizer(o::ANY, f::Union(Function,Ptr))
-    if isimmutable(o)
-        error("objects of type ", typeof(o), " cannot be finalized")
-    end
+finalizer(o::Function, f::Function) = error("invalid finalizer(f::Function, o::Function)")
+finalizer(o::Ptr, f::Ptr) = error("invalid finalizer(f::Ptr, o::Ptr)")
+finalizer(f::Union(Function,Ptr), o::ANY) = begin
+    isimmutable(o) && error("objects of type ", typeof(o), " cannot be finalized")
     ccall(:jl_gc_add_finalizer, Void, (Any,Any), o, f)
 end
 

--- a/base/base64.jl
+++ b/base/base64.jl
@@ -21,7 +21,7 @@ type Base64Pipe <: IO
 
     function Base64Pipe(io::IO)
         b = new(io,0,0,0)
-        finalizer(b, close)
+        finalizer(close, b)
         return b
     end
 end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -206,7 +206,14 @@ end
 
 @deprecate oftype{T}(::Type{T},c)  convert(T,c)
 
+
 @deprecate inf(x::FloatingPoint)  oftype(x,Inf)
 @deprecate nan(x::FloatingPoint)  oftype(x,NaN)
 @deprecate inf{T<:FloatingPoint}(::Type{T})  convert(T,Inf)
 @deprecate nan{T<:FloatingPoint}(::Type{T})  convert(T,NaN)
+
+function finalizer(o::Any, f::Union(Function,Ptr))
+    depwarn("finalizer(o::Any, f::Union(Function,Ptr)) is deprecated, " *
+            "use finalizer(f::Union(Function,Ptr), o::Any) instead", :finalizer)
+    finalizer(f, o)
+end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -717,7 +717,7 @@ function add_weak_key(t::Dict, k, v)
     # TODO: it might be better to avoid the finalizer, allow
     # wiped WeakRefs to remain in the table, and delete them as
     # they are discovered by getindex and setindex!.
-    finalizer(k, t.deleter)
+    finalizer(t.deleter, k)
     return t
 end
 
@@ -731,7 +731,7 @@ end
 
 function add_weak_value(t::Dict, k, v)
     t[k] = WeakRef(v)
-    finalizer(v, x->weak_value_delete!(t, k, x))
+    finalizer(x->weak_value_delete!(t, k, x), v)
     return t
 end
 

--- a/base/fftw.jl
+++ b/base/fftw.jl
@@ -222,7 +222,7 @@ type Plan{T<:fftwNumber}
     ialign::Int32 # alignment mod 16 of input
     function Plan(plan::Ptr{Void}, sz::Dims, istride::Dims, ialign::Int32)
         p = new(plan,sz,istride,ialign)
-        finalizer(p, p -> destroy_plan(T, p.plan))
+        finalizer(p -> destroy_plan(T, p.plan), p)
         return p
     end
 end

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -25,7 +25,7 @@ type BigInt <: Integer
     function BigInt()
         b = new(zero(Cint), zero(Cint), C_NULL)
         ccall((:__gmpz_init,:libgmp), Void, (Ptr{BigInt},), &b)
-        finalizer(b, _gmp_clear_func)
+        finalizer(_gmp_clear_func, b)
         return b
     end
 end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -16,7 +16,7 @@ function IOStream(name::String, finalize::Bool)
     buf = zeros(Uint8,sizeof_ios_t)
     x = IOStream(name, buf)
     if finalize
-        finalizer(x, close)
+        finalizer(close, x)
     end
     return x
 end

--- a/base/linalg/umfpack.jl
+++ b/base/linalg/umfpack.jl
@@ -114,7 +114,7 @@ function lufact{Tv<:UMFVTypes,Ti<:UMFITypes}(S::SparseMatrixCSC{Tv,Ti})
                     zerobased ? copy(S.colptr) : decrement(S.colptr),
                     zerobased ? copy(S.rowval) : decrement(S.rowval),
                     copy(S.nzval))
-    finalizer(res, umfpack_free_symbolic)
+    finalizer(umfpack_free_symbolic, res)
     umfpack_numeric!(res)
 end
 
@@ -126,7 +126,7 @@ function lufact!{Tv<:UMFVTypes,Ti<:UMFITypes}(S::SparseMatrixCSC{Tv,Ti})
                     zerobased ? S.colptr : decrement!(S.colptr),
                     zerobased ? S.rowval : decrement!(S.rowval),
                     S.nzval)
-    finalizer(res, umfpack_free_symbolic)
+    finalizer(umfpack_free_symbolic, res)
     umfpack_numeric!(res)
 end
 

--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -110,7 +110,7 @@ function mmap_array{T,N}(::Type{T}, dims::NTuple{N,Integer}, s::IO, offset::File
         pmap, delta = mmap(len, prot, flags, fd(s), offset)
     end
     A = pointer_to_array(convert(Ptr{T}, uint(pmap)+delta), dims)
-    finalizer(A,x->munmap(pmap,len+delta))
+    finalizer(x->munmap(pmap,len+delta), A)
     return A
 end
 
@@ -150,7 +150,7 @@ function mmap_array{T,N}(::Type{T}, dims::NTuple{N,Integer}, s::IO, offset::File
         error("could not create mapping view: $(FormatMessage())")
     end
     A = pointer_to_array(convert(Ptr{T}, viewhandle+offset-offset_page), dims)
-    finalizer(A, x->munmap(viewhandle, mmaphandle))
+    finalizer(x->munmap(viewhandle, mmaphandle), A)
     return A
 end
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -38,7 +38,7 @@ type BigFloat <: FloatingPoint
         N = get_bigfloat_precision()
         z = new(zero(Clong), zero(Cint), zero(Clong), C_NULL)
         ccall((:mpfr_init2,:libmpfr), Void, (Ptr{BigFloat}, Clong), &z, N)
-        finalizer(z, Base.GMP._mpfr_clear_func)
+        finalizer(Base.GMP._mpfr_clear_func, z)
         return z
     end
     # Not recommended for general use

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -412,7 +412,7 @@ type RemoteRef
             return found
         end
         client_refs[r] = true
-        finalizer(r, send_del_client)
+        finalizer(send_del_client, r)
         r
     end
 
@@ -1072,8 +1072,9 @@ function create_worker(bind_addr, port, pubhost, stream, config, manager)
     end
 
     # install a finalizer to perform cleanup if necessary
-    finalizer(w, (w)->if myid() == 1 manage(w.manager, w.id, w.config, :finalize) end)
-
+    finalizer(w) do w
+        myid() == 1 && manage(w.manager, w.id, w.config, :finalize)
+    end
     w
 end
 

--- a/base/poll.jl
+++ b/base/poll.jl
@@ -12,7 +12,7 @@ type FileMonitor
         end
         this = new(handle,cb,false,Condition())
         associate_julia_struct(handle,this)
-        finalizer(this,uvfinalize)
+        finalizer(uvfinalize, this)
         this        
     end
     FileMonitor(file) = FileMonitor(false,file)
@@ -80,7 +80,7 @@ type PollingFileWatcher <: UVPollingWatcher
         end
         this = new(handle, file, false, Condition(), cb)
         associate_julia_struct(handle,this)
-        finalizer(this,uvfinalize)
+        finalizer(uvfinalize, this)
         this
     end  
     PollingFileWatcher(file) =  PollingFileWatcher(false,file)
@@ -116,7 +116,7 @@ function FDWatcher(fd::RawFD)
     end
     this = FDWatcher(handle,fd,false,Condition(),false,FDEvent())
     associate_julia_struct(handle,this)
-    finalizer(this,uvfinalize)
+    finalizer(uvfinalize, this)
     this
 end
 @windows_only function FDWatcher(fd::WindowsRawSocket)
@@ -129,7 +129,7 @@ end
     end
     this = FDWatcher(handle,fd,false,Condition(),false,FDEvent())
     associate_julia_struct(handle,this)
-    finalizer(this,uvfinalize)
+    finalizer(uvfinalize, this)
     this
 end
 

--- a/base/process.jl
+++ b/base/process.jl
@@ -187,7 +187,7 @@ type Process
             err=DevNull
         end
         this = new(cmd, handle, in, out, err, typemin(Int32), typemin(Int32), false, Condition(), false, Condition())
-        finalizer(this, uvfinalize)
+        finalizer(uvfinalize, this)
         this
     end
 end

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -19,11 +19,10 @@ type Regex
             error("invalid regex options: $options")
         end
         re = compile(new(pattern, options, C_NULL, C_NULL, Array(Int32, 0)))
-        finalizer(re,
-            function(re::Regex)
-                re.extra != C_NULL && PCRE.free_study(re.extra)
-                re.regex != C_NULL && PCRE.free(re.regex)
-            end)
+        finalizer(re) do re
+            re.extra != C_NULL && PCRE.free_study(re.extra)
+            re.regex != C_NULL && PCRE.free(re.regex)
+        end
         re
     end
 end

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -264,7 +264,7 @@ end
 function TCPSocket()
     this = TCPSocket(c_malloc(_sizeof_uv_tcp))
     associate_julia_struct(this.handle,this)
-    finalizer(this,uvfinalize)
+    finalizer(uvfinalize, this)
     err = ccall(:uv_tcp_init,Cint,(Ptr{Void},Ptr{Void}),
                   eventloop(),this.handle)
     if err != 0 
@@ -294,7 +294,7 @@ end
 function TCPServer()
     this = TCPServer(c_malloc(_sizeof_uv_tcp))
     associate_julia_struct(this.handle, this)
-    finalizer(this,uvfinalize)
+    finalizer(uvfinalize, this)
     err = ccall(:uv_tcp_init,Cint,(Ptr{Void},Ptr{Void}),
                   eventloop(),this.handle)
     if err != 0 
@@ -364,7 +364,7 @@ function UDPSocket()
     associate_julia_struct(this.handle, this)
     err = ccall(:uv_udp_init,Cint,(Ptr{Void},Ptr{Void}),
                   eventloop(),this.handle)
-    finalizer(this, uvfinalize)
+    finalizer(uvfinalize, this)
     if err != 0 
         c_free(this.handle)
         this.handle = C_NULL

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -121,7 +121,7 @@ function Pipe()
     try
         ret = Pipe(handle)
         associate_julia_struct(ret.handle,ret)
-        finalizer(ret,uvfinalize)
+        finalizer(uvfinalize, ret)
         return init_pipe!(ret;readable=true)
     catch
         c_free(handle)
@@ -159,7 +159,7 @@ function PipeServer()
     try
         ret = PipeServer(handle)
         associate_julia_struct(ret.handle,ret)
-        finalizer(ret,uvfinalize)
+        finalizer(uvfinalize, ret)
         return init_pipe!(ret;readable=true)
     catch
         c_free(handle)
@@ -199,7 +199,7 @@ function TTY(fd::RawFD; readable::Bool = false)
     handle = c_malloc(_sizeof_uv_tty)
     ret = TTY(handle)
     associate_julia_struct(handle,ret)
-    finalizer(ret,uvfinalize)
+    finalizer(uvfinalize, ret)
     # This needs to go after associate_julia_struct so that there 
     # is no garbage in the ->data field
     uv_error("TTY",ccall(:uv_tty_init,Int32,(Ptr{Void},Ptr{Void},Int32,Int32),eventloop(),handle,fd.fd,readable))
@@ -252,7 +252,7 @@ function init_stdio(handle)
         ret.status = StatusOpen
         ret.line_buffered = false  
         associate_julia_struct(ret.handle,ret)
-        finalizer(ret,uvfinalize)
+        finalizer(uvfinalize, ret)
         return ret
     end
 end
@@ -458,7 +458,7 @@ type Timer <: AsyncWork
             this.handle = C_NULL
             error(UVError("uv_make_timer",err))
         end
-        finalizer(this,uvfinalize)
+        finalizer(uvfinalize, this)
         this
     end
 end
@@ -544,7 +544,7 @@ end
 function malloc_julia_pipe(x) 
     x.handle = c_malloc(_sizeof_uv_named_pipe)
     associate_julia_struct(x.handle,x)
-    finalizer(x,uvfinalize)
+    finalizer(uvfinalize, x)
 end
 
 _link_pipe(read_end::Ptr{Void},write_end::Ptr{Void}) = uv_error("pipe_link",ccall(:uv_pipe_link, Int32, (Ptr{Void}, Ptr{Void}), read_end, write_end))

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -319,7 +319,7 @@ Any[
 
 "),
 
-("Base","finalizer","finalizer(x, function)
+("Base","finalizer","finalizer(function, x)
 
    Register a function \"f(x)\" to be called when there are no
    program-accessible references to \"x\". The behavior of this

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -209,7 +209,7 @@ All Objects
    The optional second argument ``h`` is a hash code to be mixed with the result.
    New types should implement the 2-argument form.
 
-.. function:: finalizer(x, function)
+.. function:: finalizer(function, x)
 
    Register a function ``f(x)`` to be called when there are no program-accessible references to ``x``. The behavior of this function is unpredictable if ``x`` is of a bits type.
 


### PR DESCRIPTION
Implements #6454.  There are some warnings due to method ambiguity errors when building the system image, I couldn't find a way to remove them while deprecating the old argument order.
