### PR TITLE
Extend :meta to allow saving extra information.

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -138,7 +138,7 @@ function popmeta!(body::Expr, sym::Symbol)
                 end
 
                 if isa(metaargs[i], Symbol)
-                    return (true, ())
+                    return (true, [])
                 elseif isa(metaargs[i], Expr)
                     return (true, metaargs[i].args)
                 end

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -103,16 +103,22 @@ function localize_vars(expr, esca)
     Expr(:localize, :(()->($expr)), v...)
 end
 
-function pushmeta!(ex::Expr, sym::Symbol)
+function pushmeta!(ex::Expr, sym::Symbol, args::Any...)
+    if length(args) == 0
+        tag = sym
+    else
+        tag = Expr(sym, args...)
+    end
+
     if ex.head == :function
         body::Expr = ex.args[2]
         if !isempty(body.args) && isa(body.args[1], Expr) && (body.args[1]::Expr).head == :meta
-            push!((body.args[1]::Expr).args, sym)
+            push!((body.args[1]::Expr).args, tag)
         else
-            unshift!(body.args, Expr(:meta, sym))
+            unshift!(body.args, Expr(:meta, tag))
         end
     elseif (ex.head == :(=) && typeof(ex.args[1]) == Expr && ex.args[1].head == :call)
-        ex = Expr(:function, ex.args[1], Expr(:block, Expr(:meta, sym), ex.args[2]))
+        ex = Expr(:function, ex.args[1], Expr(:block, Expr(:meta, tag), ex.args[2]))
 #     else
 #         ex = Expr(:withmeta, ex, sym)
     end
@@ -123,16 +129,22 @@ function popmeta!(body::Expr, sym::Symbol)
     if isa(body.args[1],Expr) && (body.args[1]::Expr).head === :meta
         metaargs = (body.args[1]::Expr).args
         for i = 1:length(metaargs)
-            if metaargs[i] == sym
+            if (isa(metaargs[i], Symbol) && metaargs[i] == sym) ||
+               (isa(metaargs[i], Expr) && metaargs[i].head == sym)
                 if length(metaargs) == 1
                     shift!(body.args)        # get rid of :meta Expr
                 else
                     deleteat!(metaargs, i)   # delete this portion of the metadata
                 end
-                return true
+
+                if isa(metaargs[i], Symbol)
+                    return (true, ())
+                elseif isa(metaargs[i], Expr)
+                    return (true, metaargs[i].args)
+                end
             end
         end
     end
-    false
+    return (false, [])
 end
-popmeta!(arg, sym) = false
+popmeta!(arg, sym) = (false, [])

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2520,7 +2520,7 @@ const inline_incompletematch_allowed = false
 
 inline_worthy(body, cost::Real) = true
 function inline_worthy(body::Expr, cost::Real=1.0) # precondition: 0<cost
-    if popmeta!(body, :inline)
+    if popmeta!(body, :inline)[1]
         return true
     end
     symlim = 1+5/cost


### PR DESCRIPTION
I wanted to use the recently added `:meta` infrastructure by @timholy to attach some more complex information to function definitions, but it turned out that currently only symbols can be pushed in the metadata expression. This PR extends the `pushmeta!`/`popmeta!` function pair to allow saving whole expressions rather than only symbols, but also allows the old behaviour where just a symbol is pushed.

This can be used in a variety of situations. For example, defining a macro `@unroll 5 ex...`, the function body would look like:

```
$(Expr(:lambda, {}, {{},{},{}}, :(begin 
        $(Expr(:meta, :($(Expr(:unroll, 5)))))
        ex...
    end)))
```

To read this metadata, `popmeta!` has been modified to return a tuple `(Bool, Array{Any})` where the `Bool` indicates whether the metadata has been found, and the `Array` matches the `args` of the found metadata expression (or just the empty array `[]` when the metadata is a simple symbol like the one produced by `@inline`).
