### PR TITLE
Added sortperm!

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -600,6 +600,7 @@ export
     sort,
     sortcols,
     sortperm,
+    sortperm!,
     sortrows,
     squeeze,
     step,

--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -47,12 +47,12 @@ lt(o::By,                    a, b) = isless(o.by(a),o.by(b))
 lt(o::Lt,                    a, b) = o.lt(a,b)
 lt(o::LexicographicOrdering, a, b) = lexcmp(a,b) < 0
 
-function lt(p::Perm, a::Int, b::Int)
+function lt(p::Perm, a::Integer, b::Integer)
     da = p.data[a]
     db = p.data[b]
     lt(p.order, da, db) | (!lt(p.order, db, da) & (a < b))
 end
-function lt(p::Perm{LexicographicOrdering}, a::Int, b::Int)
+function lt(p::Perm{LexicographicOrdering}, a::Integer, b::Integer)
     c = lexcmp(p.data[a], p.data[b])
     c != 0 ? c < 0 : a < b
 end

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -20,6 +20,7 @@ export # also exported by Base
     sort,
     sort!,
     sortperm,
+    sortperm!,
     sortrows,
     sortcols,
     # algorithms:
@@ -340,6 +341,14 @@ sort(v::AbstractVector; kws...) = sort!(copy(v); kws...)
 sortperm(v::AbstractVector; alg::Algorithm=DEFAULT_UNSTABLE,
     lt::Function=isless, by::Function=identity, rev::Bool=false, order::Ordering=Forward) =
     sort!([1:length(v)], alg, Perm(ord(lt,by,rev,order),v))
+
+function sortperm!{I<:Integer}(x::Vector{I}, v::AbstractVector; alg::Algorithm=DEFAULT_UNSTABLE,
+                               lt::Function=isless, by::Function=identity, rev::Bool=false, order::Ordering=Forward,
+                               initialized::Bool=false)
+    length(x) != length(v) && throw(ArgumentError("Index vector must be the same length as the source vector."))
+    !initialized && @inbounds for i = 1:length(v); x[i] = i; end
+    sort!(x, alg, Perm(ord(lt,by,rev,order),v))
+end
 
 ## sorting multi-dimensional arrays ##
 

--- a/doc/stdlib/sort.rst
+++ b/doc/stdlib/sort.rst
@@ -146,6 +146,15 @@ Sorting Functions
    sorting algorithm such as ``QuickSort``, a different permutation that puts the array
    into order may be returned. The order is specified using the same keywords as ``sort!``.
 
+   See also :func:`sortperm!`
+
+.. function:: sortperm!(ix, v, [alg=<algorithm>,] [by=<transform>,] [lt=<comparison>,] [rev=false,] [initialized=false])
+
+   Like ``sortperm``, but accepts a preallocated index vector ``ix``.  If ``initialized`` is ``false``
+   (the default), ix is initialized to contain the values ``1:length(v)``.
+
+   See also :func:`sortperm`
+
 .. function:: sortrows(A, [alg=<algorithm>,] [by=<transform>,] [lt=<comparison>,] [rev=false])
 
    Sort the rows of matrix ``A`` lexicographically.

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -1,6 +1,7 @@
 @test sort([2,3,1]) == [1,2,3]
 @test sort([2,3,1], rev=true) == [3,2,1]
 @test sortperm([2,3,1]) == [3,1,2]
+@test sortperm!([1,2,3], [2,3,1]) == [3,1,2]
 @test !issorted([2,3,1])
 @test issorted([1,2,3])
 @test reverse([2,3,1]) == [1,3,2]
@@ -66,9 +67,19 @@ for alg in [InsertionSort, MergeSort]
     @test issorted(b)
     @test a[ix] == b
 
+    sortperm!(ix, a, alg=alg)
+    b = a[ix]
+    @test issorted(b)
+    @test a[ix] == b
+
     b = sort(a, alg=alg, rev=true)
     @test issorted(b, rev=true)
     ix = sortperm(a, alg=alg, rev=true)
+    b = a[ix]
+    @test issorted(b, rev=true)
+    @test a[ix] == b
+
+    sortperm!(ix, a, alg=alg, rev=true)
     b = a[ix]
     @test issorted(b, rev=true)
     @test a[ix] == b
@@ -77,6 +88,10 @@ for alg in [InsertionSort, MergeSort]
     @test issorted(b, by=x->1/x)
     ix = sortperm(a, alg=alg, by=x->1/x)
     b = a[ix]
+    @test issorted(b, by=x->1/x)
+    @test a[ix] == b
+
+    sortperm!(ix, a, alg=alg, by=x->1/x)
     @test issorted(b, by=x->1/x)
     @test a[ix] == b
 


### PR DESCRIPTION
- Allows preallocation (and therefore, reuse) of an index array
- Useful for https://github.com/JuliaLang/julia/pull/8316#issuecomment-60220521

One change which I'm unsure of here is loosening the types allowed for `lt(p::Perm, a, b)` from `Int` to `Integer`.  I did it with the idea that, if a user is providing a preallocated array, she could choose to use a different integer type (e.g., a large `Int32` array might have better cache performance than `Int64`).

That said, restricting the `sortperm` array type to `Vector{Int}` would be fine as well.  Thoughts?

Cc: @ViralBShah, @StefanKarpinski 
