### PR TITLE
make rounding modes parametric types

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -574,16 +574,24 @@ end
 maxintfloat(x::BigFloat) = BigFloat(2)^precision(x)
 maxintfloat(::Type{BigFloat}) = BigFloat(2)^get_bigfloat_precision()
 
-function to_mpfr(r::RoundingMode)
-    c = r.code
-    if !(0 <= c <= 4)
-        error("invalid BigFloat rounding mode")
-    end
-    c
-end
+to_mpfr(::RoundingMode{:TiesToEven}) = 0
+to_mpfr(::RoundingMode{:TowardZero}) = 1
+to_mpfr(::RoundingMode{:TowardPositive}) = 2
+to_mpfr(::RoundingMode{:TowardNegative}) = 3
+to_mpfr(::RoundingMode{:AwayFromZero}) = 4
 
 function from_mpfr(c::Integer)
-    if !(0 <= c <= 4)
+    if c == 0
+        return RoundNearest
+    elseif c == 1
+        return RoundToZero
+    elseif c == 2
+        return RoundUp
+    elseif c == 3
+        return RoundDown
+    elseif c == 4
+        return RoundFromZero
+    else
         error("invalid MPFR rounding mode code")
     end
     RoundingMode(c)

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -6,31 +6,19 @@ export
     get_rounding, set_rounding, with_rounding
 
 ## rounding modes ##
-immutable RoundingMode
-    code::Int
-    RoundingMode(c::Integer) = new(c)
-end
-const RoundNearest = RoundingMode(0)
-const RoundToZero = RoundingMode(1)
-const RoundUp = RoundingMode(2)
-const RoundDown = RoundingMode(3)
-const RoundFromZero = RoundingMode(4)
+immutable RoundingMode{T} end
 
-function to_fenv(r::RoundingMode)
-    if r === RoundNearest
-        JL_FE_TONEAREST
-    elseif r === RoundToZero
-        JL_FE_TOWARDZERO
-    elseif r === RoundUp
-        JL_FE_UPWARD
-    elseif r === RoundDown
-        JL_FE_DOWNWARD
-    elseif r === RoundFromZero
-        error("unsupported rounding mode")
-    else
-        error("invalid rounding mode")
-    end
-end
+const RoundNearest = RoundingMode{:TiesToEven}()
+# const RoundNearestTiesAway = RoundingMode{:TiesToAway}() # currently unsupported
+const RoundToZero = RoundingMode{:TowardZero}()
+const RoundUp = RoundingMode{:TowardPositive}()
+const RoundDown = RoundingMode{:TowardNegative}()
+const RoundFromZero = RoundingMode{:AwayFromZero}() # mpfr only
+
+to_fenv(::RoundingMode{:TiesToEven}) = JL_FE_TONEAREST
+to_fenv(::RoundingMode{:TowardZero}) = JL_FE_TOWARDZERO
+to_fenv(::RoundingMode{:TowardPositive}) = JL_FE_UPWARD
+to_fenv(::RoundingMode{:TowardNegative}) = JL_FE_DOWNWARD
 
 function from_fenv(r::Integer)
     if r == JL_FE_TONEAREST


### PR DESCRIPTION
This makes `RoundingMode` a parametric type, which hopefully will be the first step in a sane approach to dealing with rounding modes.

The key benefit is that it allows dispatch on mode. For example, in #8463, we could use:

``` julia
convert(Float64,pi,RoundDown) == 3.141592653589793
convert(Float64,pi,RoundUp) == 3.1415926535897936
```

cc: @nolta
