### PR TITLE
WIP:Make LinAlg more type stable

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -33,6 +33,7 @@ export
     Triangular,
     Diagonal,
     UniformScaling,
+    Token,
 
 # Functions
     axpy!,
@@ -189,10 +190,14 @@ macro chkuplo()
 Valid choices are 'U' (upper) or 'L' (lower).""")))
 end
 
+immutable Token{T}
+end
+
+char_uplo(::Type{Token{:U}}) = 'U'
+char_uplo(::Type{Token{:L}}) = 'L'
 const CHARU = 'U'
 const CHARL = 'L'
 char_uplo(uplo::Symbol) = uplo == :U ? CHARU : (uplo == :L ? CHARL : throw(ArgumentError("uplo argument must be either :U or :L")))
-
 
 include("linalg/exceptions.jl")
 include("linalg/generic.jl")

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -303,7 +303,7 @@ function sqrtm{T<:Real}(A::StridedMatrix{T})
     issym(A) && return sqrtm(Symmetric(A))
     n = chksquare(A)
     SchurF = schurfact(complex(A))
-    R = full(sqrtm(Triangular(SchurF[:T], :U, false)))
+    R = full(sqrtm(Triangular(SchurF[:T], Token{:U})))
     retmat = SchurF[:vectors]*R*SchurF[:vectors]'
     all(imag(retmat) .== 0) ? real(retmat) : retmat
 end
@@ -311,7 +311,7 @@ function sqrtm{T<:Complex}(A::StridedMatrix{T})
     ishermitian(A) && return sqrtm(Hermitian(A))
     n = chksquare(A)
     SchurF = schurfact(A)
-    R = full(sqrtm(Triangular(SchurF[:T], :U, false)))
+    R = full(sqrtm(Triangular(SchurF[:T], Token{:U})))
     SchurF[:vectors]*R*SchurF[:vectors]'
 end
 sqrtm(a::Number) = (b = sqrt(complex(a)); imag(b) == 0 ? real(b) : b)
@@ -321,9 +321,9 @@ function inv{S}(A::StridedMatrix{S})
     T = typeof(one(S)/one(S))
     Ac = convert(AbstractMatrix{T}, A)
     if istriu(Ac)
-        Ai = inv(Triangular(A, :U, false))
+        Ai = inv(Triangular(A, Token{:U}))
     elseif istril(Ac) 
-        Ai = inv(Triangular(A, :L, false))
+        Ai = inv(Triangular(A, Token{:L}))
     else 
         Ai = inv(lufact(Ac))
     end
@@ -373,7 +373,7 @@ function factorize{T}(A::Matrix{T})
                 if utri1
                     return Bidiagonal(diag(A), diag(A, -1), false)
                 end
-                return Triangular(A, :L)
+                return Triangular(A, Token{:L})
             end
             if utri
                 return Bidiagonal(diag(A), diag(A, 1), true)
@@ -388,7 +388,7 @@ function factorize{T}(A::Matrix{T})
             end
         end
         if utri
-            return Triangular(A, :U)
+            return Triangular(A, Token{:U})
         end
         if herm
             try
@@ -409,9 +409,9 @@ function (\)(A::StridedMatrix, B::StridedVecOrMat)
     m, n = size(A)
     if m == n
         if istril(A)
-            return istriu(A) ? \(Diagonal(A),B) : \(Triangular(A, :L),B) 
+            return istriu(A) ? \(Diagonal(A),B) : \(Triangular(A, Token{:L}),B) 
         end
-        istriu(A) && return \(Triangular(A, :U),B)
+        istriu(A) && return \(Triangular(A, Token{:U}),B)
         return \(lufact(A),B)
     end
     return qrfact(A,pivot=eltype(A)<:BlasFloat)\B

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -289,7 +289,7 @@ function A_ldiv_B!{T<:BlasFloat}(A::Union(QRCompactWY{T},QRPivoted{T}), B::Strid
         # if cond(r[1:rnk, 1:rnk])*rcond < 1 break end
     end
     C, τ = LAPACK.tzrzf!(A.factors[1:rnk,:])
-    A_ldiv_B!(Triangular(C[1:rnk,1:rnk],:U),sub(Ac_mul_B!(getq(A),sub(B, 1:mA, 1:nrhs)),1:rnk,1:nrhs))
+    A_ldiv_B!(Triangular(C[1:rnk,1:rnk], Token{:U}), sub(Ac_mul_B!(getq(A), sub(B, 1:mA, 1:nrhs)), 1:rnk, 1:nrhs))
     B[rnk+1:end,:] = zero(T)
     LAPACK.ormrz!('L', iseltype(B, Complex) ? 'C' : 'T', C, τ, sub(B,1:nA,1:nrhs))
     return isa(A,QRPivoted) ? B[invperm(A[:p]::Vector{BlasInt}),:] : B[1:nA,:], rnk

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -424,7 +424,7 @@ function elementaryRightTrapezoid!(A::AbstractMatrix, row::Integer)
 end
 
 function det(A::AbstractMatrix)
-    (istriu(A) || istril(A)) && return det(Triangular(A, :U, false))
+    (istriu(A) || istril(A)) && return det(Triangular(A, Token{:U}))
     return det(lufact(A))
 end
 det(x::Number) = x

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -112,8 +112,8 @@ function getindex{T,S<:StridedMatrix}(A::LU{T,S}, d::Symbol)
 end
 
 A_ldiv_B!{T<:BlasFloat, S<:StridedMatrix}(A::LU{T, S}, B::StridedVecOrMat{T}) = @assertnonsingular LAPACK.getrs!('N', A.factors, A.ipiv, B) A.info
-A_ldiv_B!{T,S<:StridedMatrix}(A::LU{T,S}, b::StridedVector) = A_ldiv_B!(Triangular(A.factors, :U, false), A_ldiv_B!(Triangular(A.factors, :L, true), b[ipiv2perm(A.ipiv, length(b))]))
-A_ldiv_B!{T,S<:StridedMatrix}(A::LU{T,S}, B::StridedMatrix) = A_ldiv_B!(Triangular(A.factors, :U, false), A_ldiv_B!(Triangular(A.factors, :L, true), B[ipiv2perm(A.ipiv, size(B, 1)),:]))
+A_ldiv_B!{T,S<:StridedMatrix}(A::LU{T,S}, b::StridedVector) = A_ldiv_B!(Triangular(A.factors, Token{:U}), A_ldiv_B!(Triangular(A.factors, Token{:L}, Token{true}), b[ipiv2perm(A.ipiv, length(b))]))
+A_ldiv_B!{T,S<:StridedMatrix}(A::LU{T,S}, B::StridedMatrix) = A_ldiv_B!(Triangular(A.factors, Token{:U}), A_ldiv_B!(Triangular(A.factors, Token{:L}, Token{true}), B[ipiv2perm(A.ipiv, size(B, 1)),:]))
 At_ldiv_B{T<:BlasFloat,S<:StridedMatrix}(A::LU{T,S}, B::StridedVecOrMat{T}) = @assertnonsingular LAPACK.getrs!('T', A.factors, A.ipiv, copy(B)) A.info
 Ac_ldiv_B{T<:BlasComplex,S<:StridedMatrix}(A::LU{T,S}, B::StridedVecOrMat{T}) = @assertnonsingular LAPACK.getrs!('C', A.factors, A.ipiv, copy(B)) A.info
 At_ldiv_Bt{T<:BlasFloat,S<:StridedMatrix}(A::LU{T,S}, B::StridedVecOrMat{T}) = @assertnonsingular LAPACK.getrs!('T', A.factors, A.ipiv, transpose(B)) A.info

--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -4,8 +4,8 @@
 convert{T}(::Type{Bidiagonal}, A::Diagonal{T})=Bidiagonal(A.diag, zeros(T, size(A.diag,1)-1), true)
 convert{T}(::Type{SymTridiagonal}, A::Diagonal{T})=SymTridiagonal(A.diag, zeros(T, size(A.diag,1)-1))
 convert{T}(::Type{Tridiagonal}, A::Diagonal{T})=Tridiagonal(zeros(T, size(A.diag,1)-1), A.diag, zeros(T, size(A.diag,1)-1))
-convert(::Type{Triangular}, A::Diagonal) = Triangular(full(A), :L)
-convert(::Type{Triangular}, A::Bidiagonal) = Triangular(full(A), A.isupper ? :U : :L)
+convert(::Type{Triangular}, A::Diagonal) = Triangular(full(A), Token{:L})
+convert(::Type{Triangular}, A::Bidiagonal) = Triangular(full(A), Token{A.isupper ? :U : :L})
 convert(::Type{Matrix}, D::Diagonal) = diagm(D.diag)
 
 function convert(::Type{Diagonal}, A::Union(Bidiagonal, SymTridiagonal))

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -2,15 +2,27 @@
 immutable Triangular{T,S<:AbstractMatrix,UpLo,IsUnit} <: AbstractMatrix{T}
     data::S
 end
-function Triangular{T}(A::AbstractMatrix{T}, uplo::Symbol, isunit::Bool=false)
-    chksquare(A)
-    Triangular{T,typeof(A),uplo,isunit}(A)
+for uplo in (:(:U), :(:L))
+    for isunit in (true, false)
+        @eval begin
+            function Triangular{T}(A::AbstractMatrix{T}, ::Type{Token{$uplo}}, ::Type{Token{$isunit}})
+                chksquare(A)
+                Triangular{T,typeof(A),$uplo,$isunit}(A)
+            end
+        end
+    end
+    @eval begin
+        function Triangular{T}(A::AbstractMatrix{T}, ::Type{Token{$uplo}})
+            chksquare(A)
+            Triangular{T,typeof(A),$uplo,false}(A)
+        end
+    end
 end
 
 size(A::Triangular, args...) = size(A.data, args...)
 
 convert{T,S,UpLo,IsUnit}(::Type{Triangular{T}}, A::Triangular{T,S,UpLo,IsUnit}) = A
-convert{Tnew,Told,S,UpLo,IsUnit}(::Type{Triangular{Tnew}}, A::Triangular{Told,S,UpLo,IsUnit}) = (Anew = convert(AbstractMatrix{Tnew}, A.data); Triangular(Anew, UpLo, IsUnit))
+convert{Tnew,Told,S,UpLo,IsUnit}(::Type{Triangular{Tnew}}, A::Triangular{Told,S,UpLo,IsUnit}) = (Anew = convert(AbstractMatrix{Tnew}, A.data); Triangular(Anew, Token{UpLo}, Token{IsUnit}))
 convert{Tnew,Told,S,UpLo,IsUnit}(::Type{AbstractMatrix{Tnew}}, A::Triangular{Told,S,UpLo,IsUnit}) = convert(Triangular{Tnew}, A)
 function convert{Tret,T,S,UpLo,IsUnit}(::Type{Matrix{Tret}}, A::Triangular{T,S,UpLo,IsUnit})
     B = Array(Tret, size(A, 1), size(A, 1))
@@ -81,21 +93,21 @@ function -{T, S, UpLo}(A::Triangular{T, S, UpLo, true})
 end
 
 # Binary operations
-+{TA, TB, SA, SB, uplo}(A::Triangular{TA, SA, uplo, false}, B::Triangular{TB, SB, uplo, false}) = Triangular(A.data + B.data, uplo)
-+{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, false}, B::Triangular{TB, SB, :U, true}) = Triangular(A.data + triu(B.data, 1) + I, :U)
-+{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, false}, B::Triangular{TB, SB, :L, true}) = Triangular(A.data + tril(B.data, -1) + I, :L)
-+{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, false}) = Triangular(triu(A.data, 1) + B.data + I, :U)
-+{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, false}) = Triangular(tril(A.data, -1) + B.data + I, :L)
-+{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, true}) = Triangular(triu(A.data, 1) + triu(B.data, 1) + 2I, :U)
-+{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, true}) = Triangular(tril(A.data, -1) + tril(B.data, -1) + 2I, :L)
++{TA, TB, SA, SB, uplo}(A::Triangular{TA, SA, uplo, false}, B::Triangular{TB, SB, uplo, false}) = Triangular(A.data + B.data, Token{uplo})
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, false}, B::Triangular{TB, SB, :U, true}) = Triangular(A.data + triu(B.data, 1) + I, Token{:U})
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, false}, B::Triangular{TB, SB, :L, true}) = Triangular(A.data + tril(B.data, -1) + I, Token{:L})
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, false}) = Triangular(triu(A.data, 1) + B.data + I, Token{:U})
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, false}) = Triangular(tril(A.data, -1) + B.data + I, Token{:L})
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, true}) = Triangular(triu(A.data, 1) + triu(B.data, 1) + 2I, Token{:U})
++{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, true}) = Triangular(tril(A.data, -1) + tril(B.data, -1) + 2I, Token{:L})
 +{TA, SA, TB, SB, uplo1, uplo2, IsUnit1, IsUnit2}(A::Triangular{TA, SA, uplo1, IsUnit1}, B::Triangular{TB, SB, uplo2, IsUnit2}) = full(A) + full(B)
--{TA, SA, TB, SB, uplo}(A::Triangular{TA, SA, uplo, false}, B::Triangular{TB, SB, uplo, false}) = Triangular(A.data - B.data, uplo)
--{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, false}, B::Triangular{TB, SB, :U, true}) = Triangular(A.data - triu(B.data, 1) - I, :U)
--{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, false}, B::Triangular{TB, SB, :L, true}) = Triangular(A.data - tril(B.data, -1) - I, :L)
--{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, false}) = Triangular(triu(A.data, 1) - B.data + I, :U)
--{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, false}) = Triangular(tril(A.data, -1) - B.data + I, :L)
--{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, true}) = Triangular(triu(A.data, 1) - triu(B.data, 1), :U)
--{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, true}) = Triangular(tril(A.data, -1) - tril(B.data, -1), :L)
+-{TA, SA, TB, SB, uplo}(A::Triangular{TA, SA, uplo, false}, B::Triangular{TB, SB, uplo, false}) = Triangular(A.data - B.data, Token{uplo})
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, false}, B::Triangular{TB, SB, :U, true}) = Triangular(A.data - triu(B.data, 1) - I, Token{:U})
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, false}, B::Triangular{TB, SB, :L, true}) = Triangular(A.data - tril(B.data, -1) - I, Token{:L})
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, false}) = Triangular(triu(A.data, 1) - B.data + I, Token{:U})
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, false}) = Triangular(tril(A.data, -1) - B.data + I, Token{:L})
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :U, true}, B::Triangular{TB, SB, :U, true}) = Triangular(triu(A.data, 1) - triu(B.data, 1), Token{:U})
+-{TA, SA, TB, SB}(A::Triangular{TA, SA, :L, true}, B::Triangular{TB, SB, :L, true}) = Triangular(tril(A.data, -1) - tril(B.data, -1), Token{:L})
 -{TA, SA, TB, SB, uplo1, uplo2, IsUnit1, IsUnit2}(A::Triangular{TA, SA, uplo1, IsUnit1}, B::Triangular{TB, SB, uplo2, IsUnit2}) = full(A) - full(B)
 
 ######################
@@ -166,39 +178,39 @@ eigvecs{T<:BlasFloat,S<:StridedMatrix}(A::Triangular{T,S,:L,true}) = (for i = 1:
 # Generic routines #
 ####################
 
-(*){T,S,UpLo}(A::Triangular{T,S,UpLo,false}, x::Number) = Triangular(A.data*x, UpLo)
+(*){T,S,UpLo}(A::Triangular{T,S,UpLo,false}, x::Number) = Triangular(A.data*x, Token{UpLo})
 function (*){T,S,UpLo}(A::Triangular{T,S,UpLo,true}, x::Number)
     B = A.data*x
     for i = 1:size(A, 1)
         B[i,i] = x
     end
-    Triangular(B, UpLo)
+    Triangular(B, Token{UpLo})
 end
-(*){T,S,UpLo}(x::Number, A::Triangular{T,S,UpLo,false}) = Triangular(x*A.data, UpLo)
+(*){T,S,UpLo}(x::Number, A::Triangular{T,S,UpLo,false}) = Triangular(x*A.data, Token{UpLo})
 function (*){T,S,UpLo}(x::Number, A::Triangular{T,S,UpLo,true})
     B = x*A.data
     for i = 1:size(A, 1)
         B[i,i] = x
     end
-    Triangular(B, UpLo)
+    Triangular(B, Token{UpLo})
 end
-(/){T,S,UpLo}(A::Triangular{T,S,UpLo,false}, x::Number) = Triangular(A.data/x, UpLo)
+(/){T,S,UpLo}(A::Triangular{T,S,UpLo,false}, x::Number) = Triangular(A.data/x, Token{UpLo})
 function (/){T,S,UpLo}(A::Triangular{T,S,UpLo,true}, x::Number)
     B = A.data*x
     invx = inv(x)
     for i = 1:size(A, 1)
         B[i,i] = x
     end
-    Triangular(B, UpLo)
+    Triangular(B, Token{UpLo})
 end
-(\){T,S,UpLo}(x::Number, A::Triangular{T,S,UpLo,false}) = Triangular(x\A.data, UpLo)
+(\){T,S,UpLo}(x::Number, A::Triangular{T,S,UpLo,false}) = Triangular(x\A.data, Token{UpLo})
 function (\){T,S,UpLo}(x::Number, A::Triangular{T,S,UpLo,true})
     B = x\A.data
     invx = inv(x)
     for i = 1:size(A, 1)
         B[i,i] = invx
     end
-    Triangular(B, UpLo)
+    Triangular(B, Token{UpLo})
 end
 
 ## Generic triangular multiplication
@@ -504,7 +516,7 @@ function sqrtm{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit})
                 r==0 || (R[i,j] = r / (R[i,i] + R[j,j]))
             end
         end
-        return Triangular(R, :U, IsUnit)
+        return Triangular(R, Token{:U}, Token{IsUnit})
     else # UpLo == :L #Not the usual case
         return sqrtm(A.').'
     end

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -1,6 +1,6 @@
 debug = false
 
-import Base.LinAlg: BlasComplex, BlasFloat, BlasReal, QRPivoted
+using Base.LinAlg: BlasComplex, BlasFloat, BlasReal, QRPivoted, Token
 
 n = 10
 srand(1234321)
@@ -64,14 +64,14 @@ debug && println("(Automatic) upper Cholesky factor")
     @test_approx_eq logdet(capd) log(det(capd)) # logdet is less likely to overflow
 
 debug && println("lower Cholesky factor")
-    lapd = cholfact(apd, :L)
+    lapd = cholfact(apd, Token{:L})
     @test_approx_eq full(lapd) apd
     l = lapd[:L]
     @test_approx_eq l*l' apd
 
 debug && println("pivoted Choleksy decomposition")
     if eltya != BigFloat && eltyb != BigFloat # Note! Need to implement pivoted cholesky decomposition in julia
-        cpapd = cholfact(apd, pivot=true)
+        cpapd = cholfact(apd, Token{:pivot})
         @test rank(cpapd) == n
         @test all(diff(diag(real(cpapd.UL))).<=0.) # diagonal should be non-increasing
         @test norm(apd * (cpapd\b) - b)/norm(b) <= ε*κ*n # Ad hoc, revisit

--- a/test/linalg2.jl
+++ b/test/linalg2.jl
@@ -1,7 +1,7 @@
 debug = false
 
-import Base.LinAlg
-import Base.LinAlg: BlasComplex, BlasFloat, BlasReal
+using Base.LinAlg
+using Base.LinAlg: BlasComplex, BlasFloat, BlasReal
 
 # basic tridiagonal operations
 n = 5
@@ -422,7 +422,7 @@ S = sprandn(3,3,0.5)
 @test A/I == A
 @test I/λ === UniformScaling(1/λ)
 @test I\J === J
-T = Triangular(randn(3,3),:L)
+T = Triangular(randn(3,3), Token{:L})
 @test T\I == inv(T)
 @test I\A == A
 @test A\I == inv(A)

--- a/test/linalg4.jl
+++ b/test/linalg4.jl
@@ -1,7 +1,7 @@
 debug = false
 
-import Base.LinAlg
-import Base.LinAlg: BlasComplex, BlasFloat, BlasReal
+using Base.LinAlg
+using Base.LinAlg: BlasComplex, BlasFloat, BlasReal
 
 srand(1)
 
@@ -173,17 +173,17 @@ for isupper in (true, false)
     end
 end
 
-A=SymTridiagonal(a, [1.0:n-1])
+A = SymTridiagonal(a, [1.0:n-1])
 for newtype in [Tridiagonal, Matrix]
     @test full(convert(newtype, A)) == full(A)
 end
 
-A=Tridiagonal(zeros(n-1), [1.0:n], zeros(n-1)) #morally Diagonal
+A = Tridiagonal(zeros(n-1), [1.0:n], zeros(n-1)) # morally Diagonal
 for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Matrix]
     @test full(convert(newtype, A)) == full(A)
 end
 
-A=Triangular(full(Diagonal(a)), :L) #morally Diagonal
+A=Triangular(full(Diagonal(a)), Token{:L}) # morally Diagonal
 for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Triangular, Matrix]
     @test full(convert(newtype, A)) == full(A)
 end
@@ -197,7 +197,7 @@ for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
     end
     A = convert(Matrix{elty}, A'A)
     for ul in (:U, :L)
-        @test_approx_eq full(cholfact(A, ul)[ul]) full(invoke(Base.LinAlg.chol!, (AbstractMatrix,Symbol),copy(A), ul))
+        @test_approx_eq full(cholfact(A, Token{ul})[ul]) full(invoke(Base.LinAlg.chol!, (AbstractMatrix,Type{Token{ul}}),copy(A), Token{ul}))
     end
 end
 


### PR DESCRIPTION
This is a followup on JuliaLang/LinearAlgebra.jl#144. This is a first attempt to make the code in `LinAlg` a bit more type stable. It is very convenient to dispatch on whether a matrix is upper or lower triangular, e.g. `Triangular{:U}+Triangular{:U} = Triangular{:U}` but `Triangular{:U}+Triangular{:L} = Matrix`. Unfortunately, it makes it them a bit more complicated to construct because the two first parameters are the element matrix types which is inferred from the input matrix whereas the last two determines if the matrix is upper or lower and if it has unit diagonal. The last two are useful to provide as a user, such that a non-triangular matrix can be interpreted as triangular. 

As a consequence, the present convenience constructor is not type stable, which can cause significant allocation. To solve the problem, I have introduced a parametric type with the only purpose of wrapping the arguments of the convenience constructor, such that they are types instead of value. For now, I have named the type `Token`, because we couldn't really find a good name in JuliaLang/LinearAlgebra.jl#144. Hopefully, we can avoid the new type and just wrap a value in curly brackets and have it interpreted as a type.
