### PR TITLE
RFC: Add windows support for shared memory and SharedArray.

### DIFF
--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -26,7 +26,6 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
     N = length(dims)
 
     isbits(T) || error("Type of Shared Array elements must be bits types")
-    @windows_only error(" SharedArray is not supported on Windows yet.")
 
     if isempty(pids)
         # only use workers on the current host
@@ -49,18 +48,21 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
         shm_seg_name = string("/jl", getpid(), int64(time() * 10^9))
         if onlocalhost
             shmmem_create_pid = myid()
-            s = shm_mmap_array(T, dims, shm_seg_name, JL_O_CREAT | JL_O_RDWR)
+            s = mmap_array_shm(T, dims, shm_seg_name, true)
         else
             # The shared array is created on a remote machine....
             shmmem_create_pid = pids[1]
-            remotecall_fetch(pids[1], () -> begin shm_mmap_array(T, dims, shm_seg_name, JL_O_CREAT | JL_O_RDWR); nothing end)
+            remotecall_fetch(pids[1], () -> begin
+                mmap_array_shm(T, dims, shm_seg_name, true);
+                nothing
+            end)
         end
-
-        func_mapshmem = () -> shm_mmap_array(T, dims, shm_seg_name, JL_O_RDWR)
 
         refs = Array(RemoteRef, length(pids))
         for (i, p) in enumerate(pids)
-            refs[i] = remotecall(p, func_mapshmem)
+            refs[i] = remotecall(p, () -> begin
+                mmap_array_shm(T, dims, shm_seg_name, false)
+            end) 
         end
 
         # Wait till all the workers have mapped the segment
@@ -71,9 +73,9 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
         # All good, immediately unlink the segment.
         if prod(dims) > 0
             if onlocalhost
-                shm_unlink(shm_seg_name)
+                unlink_shm(shm_seg_name)
             else
-                remotecall_fetch(shmmem_create_pid, shm_unlink, shm_seg_name)
+                remotecall_fetch(shmmem_create_pid, unlink_shm, shm_seg_name)
             end
         end
         S = SharedArray{T,N}(dims, pids, refs, shm_seg_name)
@@ -100,7 +102,7 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
 
     finally
         if shm_seg_name != ""
-            remotecall_fetch(shmmem_create_pid, shm_unlink, shm_seg_name)
+            remotecall_fetch(shmmem_create_pid, unlink_shm, shm_seg_name)
         end
     end
     S
@@ -330,50 +332,5 @@ function print_shmem_limits(slen)
         nothing # Ignore any errors in this...
     end
 end
-
-# utilities
-function shm_mmap_array(T, dims, shm_seg_name, mode)
-    local s = nothing
-    local A = nothing
-
-    if prod(dims) == 0
-        return Array(T, dims)
-    end
-    
-    try
-        fd_mem = shm_open(shm_seg_name, mode, S_IRUSR | S_IWUSR)
-        systemerror("shm_open() failed for " * shm_seg_name, fd_mem <= 0)
-
-        s = fdio(fd_mem, true)
-
-        # On OSX, ftruncate must to used to set size of segment, just lseek does not work.
-        # and only at creation time
-        if (mode & JL_O_CREAT) == JL_O_CREAT
-            rc = ccall(:ftruncate, Int, (Int, Int), fd_mem, prod(dims)*sizeof(T))
-            systemerror("ftruncate() failed for shm segment " * shm_seg_name, rc != 0)
-        end
-
-        A = mmap_array(T, dims, s, zero(FileOffset), grow=false)
-    catch e
-        print_shmem_limits(prod(dims)*sizeof(T))
-        rethrow(e)
-
-    finally
-        if s != nothing
-            close(s)
-        end
-    end
-    A
-end
-
-@unix_only begin
-function shm_unlink(shm_seg_name)
-    rc = ccall(:shm_unlink, Cint, (Ptr{Uint8},), shm_seg_name)
-    systemerror("Error unlinking shmem segment " * shm_seg_name, rc != 0)
-    rc
-end
-end
-
-@unix_only shm_open(shm_seg_name, oflags, permissions) = ccall(:shm_open, Int, (Ptr{Uint8}, Int, Int), shm_seg_name, oflags, permissions)
 
 

--- a/base/shmem.jl
+++ b/base/shmem.jl
@@ -1,0 +1,119 @@
+function mmap_array_shm{T,N}(::Type{T}, dims::NTuple{N,Integer}, name::String, create::Bool, readonly::Bool)
+    sz = prod(dims)*sizeof(T)
+    shm = open_shm(name, sz, create, readonly)
+    mmap_array_shm(T, dims, shm, 0)
+end
+
+mmap_array_shm{T,N}(::Type{T}, dims::NTuple{N,Integer}, name::String, create::Bool) = mmap_array_shm(T, dims, name, create, false)
+
+
+# OS-specific code
+
+@unix_only type SharedMemory
+    stream :: IOStream
+end
+
+@unix_only begin
+
+function open_shm(name::String, size::Integer, create::Bool, readonly::Bool)
+    oflags = (create ? JL_O_CREAT : 0) | (readonly ? JL_O_RDONLY : JL_O_RDWR)
+    fd = ccall(:shm_open, Cint, (Ptr{Uint8}, Cint, Cint), 
+                 name, oflags, S_IRUSR | S_IWUSR)
+    if create && ccall(:ftruncate, Cint, (Cint, Cint), fd, size) != 0
+        error("unable to ftruncate shared memory segment " * name)
+    end
+    SharedMemory(fdio(name, fd, true))
+end
+
+function unlink_shm(name::String)
+    if ccall(:shm_unlink, Cint, (Ptr{Uint8},), name) != 0
+        error("unable to unlink shared memory segment " * name)
+    end
+end
+
+function mmap_array_shm{T,N}(::Type{T}, dims::NTuple{N,Integer}, shm::SharedMemory, offset::Integer)
+    mmap_array(T, dims, shm.stream, offset, grow=false)
+end
+
+end # @unix_only
+
+@windows_only type SharedMemory
+    handle :: Ptr{Void}
+    readonly :: Bool
+end
+
+@windows_only begin
+
+function open_shm(name::String, size::Integer, create::Bool, readonly::Bool)
+    const granularity::Int = ccall(:jl_getallocationgranularity, Clong, ())
+    
+    if size < 0
+        error("requested size is negative")
+    end
+    if size > typemax(Int)-granularity
+        error("size is too large to memory-map on this platform")
+    end
+    
+    if create
+        ro = readonly ? 0x02 : 0x04
+        sz = convert(Csize_t, size)
+        szhi = sz>>32
+        szlo = sz&typemax(Uint32)
+        hdl = ccall(:CreateFileMappingA, stdcall, Ptr{Void}, 
+                    (Cptrdiff_t, Ptr{Void}, Cint, Cint, Cint, Ptr{Uint8}),
+                    -1, C_NULL, ro, szhi, szlo, name)
+    else
+        ro = readonly ? 4 : 2
+        hdl = ccall(:OpenFileMappingA, stdcall, Ptr{Void},
+                    (Cint, Cint, Ptr{Uint8}),
+                    ro, true, name)
+    end
+    if hdl == C_NULL
+        error("could not create shared memory object: $(FormatMessage())")
+    end
+    shm = SharedMemory(hdl,readonly)
+
+    finalizer(shm,x -> begin
+        if !bool(ccall(:CloseHandle, stdcall, Cint, (Ptr{Void},), hdl))
+            error("could not close shared memory object: $(FormatMessage())")
+        end
+    end)        
+
+    shm
+end
+
+function unlink_shm(name::String)
+    # no-op in windows
+end
+
+function mmap_array_shm{T,N}(::Type{T}, dims::NTuple{N,Integer}, shm::SharedMemory, offset::Integer)
+    const granularity::Int = ccall(:jl_getallocationgranularity, Clong, ())
+    
+    len = prod(dims)*sizeof(T)
+    pgoff::FileOffset = div(offset, granularity)*granularity
+    szf = convert(Csize_t, len+offset)
+    sza = szf - convert(Csize_t, pgoff)
+    ro = shm.readonly ? 4 : 2
+    pgoffhi = pgoff>>32
+    pgofflo = pgoff&typemax(Uint32)
+    hdl = ccall(:MapViewOfFile, stdcall, Ptr{Void},
+                (Ptr{Void}, Cint, Cint, Cint, Csize_t),
+                shm.handle, ro, pgoffhi, pgofflo, sza)
+    if hdl == C_NULL
+        error("could not create mapping view: $(FormatMessage())")
+    end
+    
+    A = pointer_to_array(convert(Ptr{T}, hdl+offset-pgoff), dims)
+
+    finalizer(A,x -> begin
+        if !bool(ccall(:UnmapViewOfFile, stdcall, Cint, (Ptr{Void},), hdl))
+            error("could not unmap view: $(FormatMessage())")
+        end
+    end)
+    A
+end
+
+end # @windows_only
+
+
+

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -195,6 +195,7 @@ importall .Random
 # distributed arrays and memory-mapped arrays
 include("darray.jl")
 include("mmap.jl")
+include("shmem.jl")
 include("sharedarray.jl")
 
 # utilities - version, timing, help, edit, metaprogramming

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -574,7 +574,7 @@ is ``DArray``\ -specific, but we list it here for completeness::
 
 
     
-Shared Arrays (Experimental, UNIX-only feature)
+Shared Arrays (Experimental)
 -----------------------------------------------
 
 Shared Arrays use system shared memory to map the same array across

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -29,8 +29,6 @@ map!(x->1, d)
 @test reduce(+, d) == 100
 
 
-@unix_only begin
-
 dims = (20,20,20)
 
 @linux_only begin
@@ -121,9 +119,6 @@ map!(x->1, d)
 # Boundary cases where length(S) <= length(pids)
 @test 2.0 == remotecall_fetch(id_other, D->D[2], Base.shmem_fill(2.0, 2; pids=[id_me, id_other]))
 @test 3.0 == remotecall_fetch(id_other, D->D[1], Base.shmem_fill(3.0, 1; pids=[id_me, id_other]))
-
-
-end # @unix_only(SharedArray tests)
 
 
 # Test @parallel load balancing - all processors should get either M or M+1


### PR DESCRIPTION
- Added cross-platform (POSIX and windows) interface for shared memory (in `base/shmem.jl`).
- Edited `SharedArray` to use this new interface.
- Edited the test scripts and documentation to reflect the new support for windows.
- Verified `test/parallel.jl` runs successfully on 32-bit and 64-bit windows and 64-bit linux.
