### PR TITLE
Warn that break, goto, or continue in an @simd loop may cause wrong results

### DIFF
--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -603,14 +603,24 @@ properties of the loop:
    possibly causing different results than without ``@simd``.
 -  No iteration ever waits on another iteration to make forward progress.
 
+A ``break``, ``continue``, or ``goto`` in an ``@simd`` loop may cause
+wrong results.
+
 Using ``@simd`` merely gives the compiler license to vectorize. Whether 
 it actually does so depends on the compiler. To actually benefit from the 
 current implementation, your loop should have the following additional 
 properties:
 
 -  The loop must be an innermost loop.
--  The loop body must be straight-line code. This is why ``@inbounds`` is currently needed for all array accesses.
--  Accesses must have a stride pattern and cannot be "gathers" (random-index reads) or "scatters" (random-index writes).
-- The stride should be unit stride.
-- In some simple cases, for example with 2-3 arrays accessed in a loop, the LLVM auto-vectorization may kick in automatically, leading to no further speedup with ``@simd``. 
+-  The loop body must be straight-line code. This is why ``@inbounds`` is 
+   currently needed for all array accesses. The compiler can sometimes turn
+   short ``&&``, ``||``, and ``?:`` expressions into straight-line code, 
+   if it is safe to evaluate all operands unconditionally. Consider using 
+   ``ifelse`` instead of ``?:`` in the loop if it is safe to do so.
+-  Accesses must have a stride pattern and cannot be "gathers" (random-index reads) 
+   or "scatters" (random-index writes).
+-  The stride should be unit stride.
+-  In some simple cases, for example with 2-3 arrays accessed in a loop, the 
+   LLVM auto-vectorization may kick in automatically, leading to no further 
+   speedup with ``@simd``. 
 


### PR DESCRIPTION
Cherry picked and edited from commit a3a0d6c6d794fd52c29901ed5699162bf887d482 .
Backport of #8704
