### PR TITLE
dSFMT: use fill_array_* API instead of genrand_* API

### DIFF
--- a/base/dSFMT.jl
+++ b/base/dSFMT.jl
@@ -6,6 +6,7 @@ export DSFMT_state, dsfmt_get_min_array_size, dsfmt_get_idstring,
        dsfmt_genrand_close1_open2, dsfmt_gv_genrand_close1_open2,
        dsfmt_genrand_close_open, dsfmt_gv_genrand_close_open, 
        dsfmt_genrand_uint32, dsfmt_gv_genrand_uint32, 
+       dsfmt_fill_array_close_open!, dsfmt_fill_array_close1_open2!,
        win32_SystemFunction036!
 
 type DSFMT_state
@@ -93,6 +94,24 @@ function dsfmt_gv_genrand_uint32()
     ccall((:dsfmt_gv_genrand_uint32,:libdSFMT),
           Uint32,
           ())
+end
+
+# precondition for dsfmt_fill_array_*:
+# the underlying C array must be 16-byte aligned, which is the case for "Array"
+function dsfmt_fill_array_close1_open2!(s::DSFMT_state, A::Array{Float64}, n::Int)
+    @assert dsfmt_min_array_size <= n <= length(A)  && iseven(n)
+    ccall((:dsfmt_fill_array_close1_open2,:libdSFMT),
+          Void,
+          (Ptr{Void}, Ptr{Float64}, Int),
+          s.val, A, n)
+end
+
+function dsfmt_fill_array_close_open!(s::DSFMT_state, A::Array{Float64}, n::Int)
+    @assert dsfmt_min_array_size <= n <= length(A)  && iseven(n)
+    ccall((:dsfmt_fill_array_close_open,:libdSFMT),
+          Void,
+          (Ptr{Void}, Ptr{Float64}, Int),
+          s.val, A, n)
 end
 
 ## Windows entropy

--- a/base/random.jl
+++ b/base/random.jl
@@ -14,14 +14,21 @@ abstract AbstractRNG
 type MersenneTwister <: AbstractRNG
     state::DSFMT_state
     seed::Union(Uint32,Vector{Uint32})
+    vals::Vector{Float64}
+    idx::Int
 
     function MersenneTwister(seed::Vector{Uint32})
         state = DSFMT_state()
         dsfmt_init_by_array(state, seed)
-        return new(state, seed)
+        return new(state, seed, Array(Float64, dsfmt_get_min_array_size()), dsfmt_get_min_array_size())
     end
 
     MersenneTwister(seed=0) = MersenneTwister(make_seed(seed))
+end
+
+function gen_rand(r::MersenneTwister)
+    dsfmt_fill_array_close1_open2!(r.state, r.vals, length(r.vals))
+    r.idx = 0
 end
 
 function srand(r::MersenneTwister, seed)
@@ -96,8 +103,8 @@ rand(::Type{Float16}) = float16(rand())
 
 rand{T<:Real}(::Type{Complex{T}}) = complex(rand(T),rand(T))
 
-
-rand(r::MersenneTwister) = dsfmt_genrand_close_open(r.state)
+@inline rand_inbounds(r::MersenneTwister) =  (r.idx += 1; @inbounds return r.vals[r.idx] - 1.0)
+@inline rand(r::MersenneTwister) = (r.idx == length(r.vals) && gen_rand(r); rand_inbounds(r))
 
 ## random integers
 
@@ -137,6 +144,27 @@ end
 function rand!(r::AbstractRNG, A::AbstractArray)
     for i=1:length(A)
         @inbounds A[i] = rand(r)
+    end
+    A
+end
+
+function rand!(r::MersenneTwister, A::Array{Float64})
+    n = length(A)
+    if n < dsfmt_get_min_array_size()
+        s = length(r.vals) - r.idx
+        m = min(n, s)
+        for i=1:m
+            @inbounds A[i] = rand_inbounds(r)
+        end
+        if n > s
+            gen_rand(r)
+            for i=m+1:n
+                @inbounds A[i] = rand_inbounds(r)
+            end
+        end
+    else
+        dsfmt_fill_array_close_open!(r.state, A, n & (0xfffffffffffffffe % Int))
+        isodd(n) && (A[n] = rand(r))
     end
     A
 end


### PR DESCRIPTION
Mixing both APIs led to bug #6573. As a result `fill_array_*` functions were no more used. This PR proposes instead to use them exclusively with `MersenneTwister` objects (I could do the same for the global RNG if there is interest), for faster random generation (up to 2x or 3x on my machine).

Looking at the dSFMT code, my understanding is that both take advantage of simd instructions, but use different algorithms:
- `fill_array_*` generates random values (considering only `Float64` values for now) into an array of size (at least) `dsfmt_min_array_size`, using a state array of size `dsfmt_min_array_size`,
- whereas `genrand_*` cyclically overwrites a state array of size `dsfmt_min_array_size` filled with random values with new random values.

All it takes to use `fill_array_*` functions is to add a `Float64` array of size `dsfmt_min_array_size` to `MersenneTwister` instances (which then allocate roughly twice as much), to be cyclically filled with random values (via `fill_array_*`), which allows `rand(r::MersenneTwister)` to pick those values one by one.

I guess the same speed differences could be observed for integer generation, but currently `MersenneTwister` RNGs generate only floats (I would be happy to enable this if #8380 or equivalent got merged, which the use of `dsfmt_fill_array_close1_open2` anticipates here).
