### PR TITLE
RFC: Add native Array slices/views with shared data

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -220,6 +220,18 @@ linspace(start::Real, stop::Real) = linspace(start, stop, 100)
 logspace(start::Real, stop::Real, n::Integer) = 10.^linspace(start, stop, n)
 logspace(start::Real, stop::Real) = logspace(start, stop, 50)
 
+
+arrayslice(A, i::Int, n::Int) = arrayslice(A, i, (n,))
+arrayslice(A, dims::Tuple, n::Tuple) = arrayslice(A, sub2ind(size(A),dims...), n)
+arrayslice(A, dims::Tuple, n::Int) = arrayslice(A, dims, (n,))
+function arrayslice{T, N}(A::Array{T}, i::Int, n::NTuple{N,Int})
+    0 <= minimum(n) || throw(ArgumentError("negative dimension"))
+    0 < i <= length(A) || throw(BoundsError())
+    i-1+prod(n) <= length(A) || throw(BoundsError())
+    ccall(:jl_slice_owned_array, Array{T,N}, (Any, Any, Any, Uint),
+          Array{T,N}, A, n, uint(i-1))
+end
+
 ## Conversions ##
 
 convert{T,n}(::Type{Array{T}}, x::Array{T,n}) = x

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -491,6 +491,7 @@ export
     zeta,
 
 # arrays
+    arrayslice,
     bitbroadcast,
     broadcast!,
     broadcast!_function,

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -5964,6 +5964,15 @@ popdisplay(d::Display)
 
 "),
 
+("Base","arrayslice","arrayslice(A, pos, dims)
+
+   Create an array of size \"dims\" with the data shared with the 
+   given array. The returned array uses the contiguous memory of 
+   \"A\" starting at \"pos\" of length \"prod(dims)\". The \"pos\" and 
+   \"dims\" arguments may be tuple or integer arguments.
+
+"),
+
 ("Base","broadcast","broadcast(f, As...)
 
    Broadcasts the arrays \"As\" to a common size by expanding

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4104,6 +4104,11 @@ Constructors
 
    Construct a vector of ``n`` logarithmically-spaced numbers from ``10^start`` to ``10^stop``.
 
+.. function:: arrayslice(A, pos, dims)
+
+   Create an array of size ``dims`` with the data shared with the given array. The returned array uses the contiguous memory of ``A`` starting at ``pos`` of length ``prod(dims)``. The ``pos`` and ``dims`` arguments may be tuple or integer arguments.
+
+
 Mathematical operators and functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -735,6 +735,8 @@ DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
                                          size_t nel, int own_buffer);
 DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
                                       jl_tuple_t *dims, int own_buffer);
+DLLEXPORT jl_array_t *jl_slice_owned_array(jl_value_t *atype, jl_array_t *data, 
+                                           jl_tuple_t *dims, size_t offset);
 int jl_array_store_unboxed(jl_value_t *el_type);
 
 DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr);

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -695,6 +695,23 @@ begin
     @test size(n1) == (6,1,4) && size(n2) == (6,3,1)  && size(n3) == (2,6,1)
 end
 
+# arrayslice
+x = rand(3,5)
+y = arrayslice(x,7,(3,3))
+y[:] *= 5
+x[7:end] = y[:]*2
+@test reshape(x[7:end],(3,3)) == y
+y = arrayslice(x,1,4)
+@test Array{eltype(x),1} == typeof(y)
+@test length(y) == 4
+y = arrayslice(x,1,0)
+@test y == eltype(y)[]
+y = arrayslice(x,(1,3),2)
+@test y[1] == x[1,3]
+y = arrayslice(x,(3,1),(1,2))
+@test y[:] == x[3:4]
+y = arrayslice(x,1,(5,3))
+@test reshape(x,(5,3)) == y
 
 # single multidimensional index
 let


### PR DESCRIPTION
Add method `arrayslice(A, pos, dim)` which returns a slice of type `Array` and is memory safe. The slices use contiguous parts of memory from A and can be any dimensional. The advantage for this special case compared to ArrayViews/SubArrays is performance and compatibility with any code for Arrays.

The C function `jl_slice_owned_array` is actually a general case of `jl_reshape_array`, so there is a question whether the code duplication is ok, or whether to make the reshape function call the slice function.

Memory check (same as with `reshape`):

``` julia
n=int(1e8)
x=rand(n);
gc() # nothing happens
y=arrayslice(x,101,20)
gc() # nothing happens
x=1
gc() # nothing happens
y=1
gc() # memory usage reduces
```

Code example:

``` julia
julia> x=rand(3,5)
3x5 Array{Float64,2}:
 0.839011   0.954     0.185297  0.236349  0.0152856
 0.0864201  0.561014  0.215385  0.219099  0.948724 
 0.708425   0.489022  0.20037   0.907779  0.399409 

julia> y=arrayslice(x,7,(3,3))
3x3 Array{Float64,2}:
 0.185297  0.236349  0.0152856
 0.215385  0.219099  0.948724 
 0.20037   0.907779  0.399409 

julia> I=eye(3);

julia> copy!(y,I);

julia> x
3x5 Array{Float64,2}:
 0.839011   0.954     1.0  0.0  0.0
 0.0864201  0.561014  0.0  1.0  0.0
 0.708425   0.489022  0.0  0.0  1.0

julia> y=arrayslice(x,1,3)
3-element Array{Float64,1}:
 0.839011
 0.0864201
 0.708425

julia> scale!(100,y);

julia> x
3x5 Array{Float64,2}:
 83.9011   0.954     1.0  0.0  0.0
  8.64201  0.561014  0.0  1.0  0.0
 70.8425   0.489022  0.0  0.0  1.0
```

See also #8795
