### PR TITLE
Fix two memory errors

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1148,15 +1148,17 @@ static void check_ambiguous(jl_methlist_t *ml, jl_tuple_t *type,
         !jl_args_morespecific((jl_value_t*)sig, (jl_value_t*)type)) {
         jl_value_t *isect = jl_type_intersection((jl_value_t*)type,
                                                  (jl_value_t*)sig);
+        JL_GC_PUSH1(&isect);
         if (isect == (jl_value_t*)jl_bottom_type ||
             // we're ok if the new definition is actually the one we just
             // inferred to be required (see issue #3609). ideally this would
             // never happen, since if New ⊓ Old == New then we should have
             // considered New more specific, but jl_args_morespecific is not
             // perfect, so this is a useful fallback.
-            sigs_eq(isect, (jl_value_t*)type, 1))
+            sigs_eq(isect, (jl_value_t*)type, 1)) {
+            JL_GC_POP();
             return;
-        JL_GC_PUSH1(&isect);
+        }
         jl_methlist_t *l = ml;
         char *n;
         jl_value_t *errstream;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -420,6 +420,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
         jl_sym_t *nm = (jl_sym_t*)args[0];
         assert(jl_is_symbol(nm));
         jl_function_t *f = (jl_function_t*)eval(args[1], locals, nl);
+        JL_GC_PUSH1(&f);
         assert(jl_is_function(f));
         if (jl_boot_file_loaded &&
             f->linfo && f->linfo->ast && jl_is_expr(f->linfo->ast)) {
@@ -428,6 +429,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
             li->name = nm;
         }
         jl_set_global(jl_current_module, nm, (jl_value_t*)f);
+        JL_GC_POP();
         return (jl_value_t*)jl_nothing;
     }
     else if (ex->head == line_sym) {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -244,7 +244,7 @@ jl_tuple_t *jl_compute_type_union(jl_tuple_t *types)
 {
     size_t n = count_union_components(types);
     jl_value_t **temp;
-    JL_GC_PUSHARGS(temp, n);
+    JL_GC_PUSHARGS(temp, n+1);
     size_t idx=0;
     flatten_type_union(types, temp, &idx);
     assert(idx == n);
@@ -266,6 +266,7 @@ jl_tuple_t *jl_compute_type_union(jl_tuple_t *types)
         }
     }
     jl_tuple_t *result = jl_alloc_tuple_uninit(n - ndel);
+    temp[n] = result; // root result tuple while sorting
     j=0;
     for(i=0; i < n; i++) {
         if (temp[i] != NULL) {


### PR DESCRIPTION
`sigs_eq` and `jl_set_global` can allocate so we must not forget to root values across those calls.
