### PR TITLE
Avoid undefined checks for fields that are always initialized

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -585,8 +585,9 @@ jl_typename_t *jl_new_typename(jl_sym_t *name)
 jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_datatype_t *super,
                                    jl_tuple_t *parameters)
 {
-    jl_datatype_t *dt = jl_new_datatype((jl_sym_t*)name, super, parameters, jl_null, jl_null, 1, 0);
+    jl_datatype_t *dt = jl_new_datatype((jl_sym_t*)name, super, parameters, jl_null, jl_null, 1, 0, 0);
     dt->pointerfree = 0;
+    dt->undeffree = 0;
     return dt;
 }
 
@@ -631,6 +632,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
     st->alignment = alignm;
     st->size = LLT_ALIGN(sz, alignm);
     st->pointerfree = ptrfree && !st->abstract;
+    st->undeffree |= st->pointerfree;
 }
 
 extern int jl_boot_file_loaded;
@@ -638,7 +640,7 @@ extern int jl_boot_file_loaded;
 jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
                                jl_tuple_t *parameters,
                                jl_tuple_t *fnames, jl_tuple_t *ftypes,
-                               int abstract, int mutabl)
+                               int abstract, int mutabl, int undeffree)
 {
     jl_datatype_t *t=NULL;
     jl_typename_t *tn=NULL;
@@ -667,6 +669,7 @@ jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
     t->abstract = abstract;
     t->mutabl = mutabl;
     t->pointerfree = 0;
+    t->undeffree = undeffree;
     t->instance = NULL;
     t->struct_decl = NULL;
     t->size = 0;
@@ -700,12 +703,13 @@ jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
                                jl_tuple_t *parameters, size_t nbits)
 {
     jl_datatype_t *bt = jl_new_datatype((jl_sym_t*)name, super, parameters,
-                                        jl_null, jl_null, 0, 0);
+                                        jl_null, jl_null, 0, 0, 1);
     bt->size = nbits/8;
     bt->alignment = bt->size;
     if (bt->alignment > MAX_ALIGN)
         bt->alignment = MAX_ALIGN;
     bt->pointerfree = 1;
+    bt->undeffree = 1;
     return bt;
 }
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -587,7 +587,6 @@ jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_datatype_t *super,
 {
     jl_datatype_t *dt = jl_new_datatype((jl_sym_t*)name, super, parameters, jl_null, jl_null, 1, 0, 0);
     dt->pointerfree = 0;
-    dt->undeffree = 0;
     return dt;
 }
 
@@ -632,7 +631,6 @@ void jl_compute_field_offsets(jl_datatype_t *st)
     st->alignment = alignm;
     st->size = LLT_ALIGN(sz, alignm);
     st->pointerfree = ptrfree && !st->abstract;
-    st->undeffree |= st->pointerfree;
 }
 
 extern int jl_boot_file_loaded;
@@ -640,7 +638,7 @@ extern int jl_boot_file_loaded;
 jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
                                jl_tuple_t *parameters,
                                jl_tuple_t *fnames, jl_tuple_t *ftypes,
-                               int abstract, int mutabl, int undeffree)
+                               int abstract, int mutabl, int ninitialized)
 {
     jl_datatype_t *t=NULL;
     jl_typename_t *tn=NULL;
@@ -669,7 +667,7 @@ jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
     t->abstract = abstract;
     t->mutabl = mutabl;
     t->pointerfree = 0;
-    t->undeffree = undeffree;
+    t->ninitialized = ninitialized;
     t->instance = NULL;
     t->struct_decl = NULL;
     t->size = 0;
@@ -703,13 +701,12 @@ jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
                                jl_tuple_t *parameters, size_t nbits)
 {
     jl_datatype_t *bt = jl_new_datatype((jl_sym_t*)name, super, parameters,
-                                        jl_null, jl_null, 0, 0, 1);
+                                        jl_null, jl_null, 0, 0, 0);
     bt->size = nbits/8;
     bt->alignment = bt->size;
     if (bt->alignment > MAX_ALIGN)
         bt->alignment = MAX_ALIGN;
     bt->pointerfree = 1;
-    bt->undeffree = 1;
     return bt;
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1489,7 +1489,9 @@ static Value *emit_getfield(jl_value_t *expr, jl_sym_t *name, jl_codectx_t *ctx)
                 JL_GC_POP();
                 if (sty->fields[idx].isptr) {
                     Value *fldv = builder.CreateLoad(builder.CreateBitCast(addr,jl_ppvalue_llvmt));
-                    null_pointer_check(fldv, ctx);
+                    if (!sty->undeffree) {
+                        null_pointer_check(fldv, ctx);
+                    }
                     return fldv;
                 }
                 else {
@@ -1513,7 +1515,9 @@ static Value *emit_getfield(jl_value_t *expr, jl_sym_t *name, jl_codectx_t *ctx)
                     fldv = builder.CreateTrunc(fldv, T_int1);
                 }
                 else if (sty->fields[idx].isptr) {
-                    null_pointer_check(fldv, ctx);
+                    if (!sty->undeffree) {
+                        null_pointer_check(fldv, ctx);
+                    }
                 }
                 JL_GC_POP();
                 return mark_julia_type(fldv, jfty);
@@ -2142,7 +2146,9 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
                                        CreateGEP(builder.
                                                  CreateBitCast(strct, jl_ppvalue_llvmt),
                                                  builder.CreateAdd(idx,ConstantInt::get(T_size,1)))));
-                        null_pointer_check(fld, ctx);
+                        if (!stt->undeffree) {
+                            null_pointer_check(fld, ctx);
+                        }
                         JL_GC_POP();
                         return fld;
                     }

--- a/src/dump.c
+++ b/src/dump.c
@@ -377,7 +377,7 @@ static void jl_serialize_datatype(ios_t *s, jl_datatype_t *dt)
     write_uint16(s, nf);
     write_int32(s, dt->size);
     int has_instance = !!(dt->instance != NULL);
-    write_uint8(s, dt->abstract | (dt->mutabl<<1) | (dt->pointerfree<<2) | (has_instance<<3));
+    write_uint8(s, dt->abstract | (dt->mutabl<<1) | (dt->pointerfree<<2) | (has_instance<<3) | (dt->undeffree<<4));
     if (!dt->abstract && mode != MODE_MODULE && mode != MODE_MODULE_LAMBDAS)
         write_int32(s, dt->uid);
     if (has_instance)
@@ -833,6 +833,7 @@ static jl_value_t *jl_deserialize_datatype(ios_t *s, int pos, jl_value_t **loc)
         dt->instance = jl_deserialize_value(s, &dt->instance);
         dt->instance->type = (jl_value_t*)dt;
     }
+    dt->undeffree = (flags>>4)&1;
     assert(tree_literal_values==NULL && mode != MODE_AST);
     ptrhash_put(&backref_table, (void*)(ptrint_t)pos, dt);
     if (tag == 5 || tag == 8) {

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -377,7 +377,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
         temp = eval(args[2], locals, nl);  // field names
         dt = jl_new_datatype((jl_sym_t*)name, jl_any_type, (jl_tuple_t*)para,
                              (jl_tuple_t*)temp, NULL,
-                             0, args[5]==jl_true ? 1 : 0, args[6]==jl_true ? 1 : 0);
+                             0, args[5]==jl_true ? 1 : 0, jl_unbox_long(args[6]));
 
         jl_binding_t *b = jl_get_binding_wr(jl_current_module, (jl_sym_t*)name);
         temp = b->value;  // save old value

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -377,7 +377,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
         temp = eval(args[2], locals, nl);  // field names
         dt = jl_new_datatype((jl_sym_t*)name, jl_any_type, (jl_tuple_t*)para,
                              (jl_tuple_t*)temp, NULL,
-                             0, args[5]==jl_true ? 1 : 0);
+                             0, args[5]==jl_true ? 1 : 0, args[6]==jl_true ? 1 : 0);
 
         jl_binding_t *b = jl_get_binding_wr(jl_current_module, (jl_sym_t*)name);
         temp = b->value;  // save old value

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1991,6 +1991,7 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_value_t **env, size_t n,
             if (tn == jl_array_typename)
                 ndt->pointerfree = 0;
         }
+        ndt->undeffree = dt->undeffree || jl_isbits(ndt);
         if (cacheable) cache_type_((jl_value_t*)ndt);
         result = (jl_value_t*)ndt;
 
@@ -2903,7 +2904,7 @@ void jl_init_types(void)
     jl_datatype_type->name->primary = (jl_value_t*)jl_datatype_type;
     jl_datatype_type->super = jl_type_type;
     jl_datatype_type->parameters = jl_null;
-    jl_datatype_type->names = jl_tuple(10, jl_symbol("name"),
+    jl_datatype_type->names = jl_tuple(11, jl_symbol("name"),
                                        jl_symbol("super"),
                                        jl_symbol("parameters"),
                                        jl_symbol("names"),
@@ -2912,12 +2913,13 @@ void jl_init_types(void)
                                        jl_symbol("size"),
                                        jl_symbol("abstract"),
                                        jl_symbol("mutable"),
-                                       jl_symbol("pointerfree"));
-    jl_datatype_type->types = jl_tuple(10, jl_typename_type, jl_type_type,
+                                       jl_symbol("pointerfree"),
+                                       jl_symbol("undeffree"));
+    jl_datatype_type->types = jl_tuple(11, jl_typename_type, jl_type_type,
                                        jl_tuple_type, jl_tuple_type,
                                        jl_tuple_type, jl_any_type,
                                        jl_any_type, //types will be fixed later
-                                       jl_any_type, jl_any_type, jl_any_type);
+                                       jl_any_type, jl_any_type, jl_any_type, jl_any_type);
     jl_datatype_type->instance = NULL;
     jl_datatype_type->uid = jl_assign_type_uid();
     jl_datatype_type->struct_decl = NULL;
@@ -2926,6 +2928,7 @@ void jl_init_types(void)
     // NOTE: types should not really be mutable, but the instance and
     // struct_decl fields are basically caches, which are mutated.
     jl_datatype_type->mutabl = 1;
+    jl_datatype_type->undeffree = 0;
 
     jl_typename_type->name = jl_new_typename(jl_symbol("TypeName"));
     jl_typename_type->name->primary = (jl_value_t*)jl_typename_type;
@@ -2941,6 +2944,7 @@ void jl_init_types(void)
     jl_typename_type->abstract = 0;
     jl_typename_type->pointerfree = 0;
     jl_typename_type->mutabl = 1;
+    jl_typename_type->undeffree = 0;
 
     jl_sym_type->name = jl_new_typename(jl_symbol("Symbol"));
     jl_sym_type->name->primary = (jl_value_t*)jl_sym_type;
@@ -2955,10 +2959,11 @@ void jl_init_types(void)
     jl_sym_type->abstract = 0;
     jl_sym_type->pointerfree = 0;
     jl_sym_type->mutabl = 1;
+    jl_sym_type->undeffree = 0;
 
     // now they can be used to create the remaining base kinds and types
     jl_void_type = jl_new_datatype(jl_symbol("Void"), jl_any_type, jl_null,
-                                   jl_null, jl_null, 0, 0);
+                                   jl_null, jl_null, 0, 0, 1);
     jl_nothing = newstruct(jl_void_type);
     jl_void_type->instance = jl_nothing;
 
@@ -2966,7 +2971,7 @@ void jl_init_types(void)
                                         jl_type_type, jl_null,
                                         jl_tuple(1, jl_symbol("types")),
                                         jl_tuple(1, jl_tuple_type),
-                                        0, 0);
+                                        0, 0, 0);
 
     jl_bottom_type = (jl_value_t*)jl_new_struct(jl_uniontype_type, jl_null);
 
@@ -2977,7 +2982,7 @@ void jl_init_types(void)
                                             jl_symbol("bound")),
                                    jl_tuple(4, jl_sym_type, jl_type_type,
                                             jl_type_type, jl_any_type),
-                                   0, 0);
+                                   0, 0, 0);
 
     jl_undef_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Undef"),
                                         jl_any_type, jl_null);
@@ -3030,7 +3035,7 @@ void jl_init_types(void)
                         jl_tuple(7, jl_tuple_type, jl_bool_type, jl_bool_type,
                                  jl_tuple_type, jl_any_type,
                                  jl_any_type, jl_any_type),
-                        0, 1);
+                        0, 1, 0);
 
     jl_methtable_type =
         jl_new_datatype(jl_symbol("MethodTable"), jl_any_type, jl_null,
@@ -3041,7 +3046,7 @@ void jl_init_types(void)
                         jl_tuple(7, jl_sym_type, jl_any_type, jl_any_type,
                                  jl_any_type, jl_any_type, jl_long_type,
                                  jl_any_type),
-                        0, 1);
+                        0, 1, 0);
 
     tv = jl_tuple2(tvar("T"), tvar("N"));
     jl_abstractarray_type =
@@ -3062,9 +3067,10 @@ void jl_init_types(void)
                         (jl_datatype_t*)
                         jl_apply_type((jl_value_t*)jl_densearray_type, tv),
                         tv,
-                        jl_null, jl_null, 0, 1);
+                        jl_null, jl_null, 0, 1, 0);
     jl_array_typename = jl_array_type->name;
     jl_array_type->pointerfree = 0;
+    jl_array_type->undeffree = 0;
 
     jl_array_any_type =
         (jl_value_t*)jl_apply_type((jl_value_t*)jl_array_type,
@@ -3083,42 +3089,42 @@ void jl_init_types(void)
                                  jl_symbol("typ")),
                         jl_tuple(3, jl_sym_type, jl_array_any_type,
                                  jl_any_type),
-                        0, 1);
+                        0, 1, 0);
 
     jl_linenumbernode_type =
         jl_new_datatype(jl_symbol("LineNumberNode"), jl_any_type, jl_null,
                         jl_tuple(1, jl_symbol("line")),
-                        jl_tuple(1, jl_long_type), 0, 0);
+                        jl_tuple(1, jl_long_type), 0, 0, 1);
 
     jl_labelnode_type =
         jl_new_datatype(jl_symbol("LabelNode"), jl_any_type, jl_null,
                         jl_tuple(1, jl_symbol("label")),
-                        jl_tuple(1, jl_long_type), 0, 0);
+                        jl_tuple(1, jl_long_type), 0, 0, 1);
 
     jl_gotonode_type =
         jl_new_datatype(jl_symbol("GotoNode"), jl_any_type, jl_null,
                         jl_tuple(1, jl_symbol("label")),
-                        jl_tuple(1, jl_long_type), 0, 0);
+                        jl_tuple(1, jl_long_type), 0, 0, 1);
 
     jl_quotenode_type =
         jl_new_datatype(jl_symbol("QuoteNode"), jl_any_type, jl_null,
                         jl_tuple(1, jl_symbol("value")),
-                        jl_tuple(1, jl_any_type), 0, 0);
+                        jl_tuple(1, jl_any_type), 0, 0, 0);
 
     jl_newvarnode_type =
         jl_new_datatype(jl_symbol("NewvarNode"), jl_any_type, jl_null,
                         jl_tuple(1, jl_symbol("name")),
-                        jl_tuple(1, jl_sym_type), 0, 0);
+                        jl_tuple(1, jl_sym_type), 0, 0, 0);
 
     jl_topnode_type =
         jl_new_datatype(jl_symbol("TopNode"), jl_any_type, jl_null,
                         jl_tuple(1, jl_symbol("name")),
-                        jl_tuple(1, jl_sym_type), 0, 0);
+                        jl_tuple(1, jl_sym_type), 0, 0, 0);
 
     jl_module_type =
         jl_new_datatype(jl_symbol("Module"), jl_any_type, jl_null,
                         jl_tuple(2, jl_symbol("name"), jl_symbol("parent")),
-                        jl_tuple(2, jl_sym_type, jl_any_type), 0, 1);
+                        jl_tuple(2, jl_sym_type, jl_any_type), 0, 1, 0);
 
     jl_tupleset(jl_typename_type->types, 1, jl_module_type);
 
@@ -3144,13 +3150,13 @@ void jl_init_types(void)
                                  jl_any_type,
                                  jl_sym_type, jl_int32_type,
                                  jl_bool_type),
-                        0, 1);
+                        0, 1, 0);
 
     jl_box_type =
         jl_new_datatype(jl_symbol("Box"),
                         jl_any_type, jl_null,
                         jl_tuple(1, jl_symbol("contents")),
-                        jl_tuple(1, jl_any_type), 0, 1);
+                        jl_tuple(1, jl_any_type), 0, 1, 0);
     jl_box_typename = jl_box_type->name;
     jl_box_any_type = (jl_value_t*)jl_box_type;
 
@@ -3160,7 +3166,7 @@ void jl_init_types(void)
                         jl_tuple(2, jl_symbol("parameters"),
                                  jl_symbol("body")),
                         jl_tuple(2, jl_tuple_type, jl_any_type),
-                        0, 0);
+                        0, 0, 0);
 
     jl_function_type =
         jl_new_datatype(jl_symbol("Function"), jl_any_type, jl_null,
@@ -3168,7 +3174,7 @@ void jl_init_types(void)
                                  jl_symbol("code")),
                         jl_tuple(3, jl_any_type, jl_any_type,
                                  jl_lambda_info_type),
-                        0, 1);
+                        0, 1, 0);
 
     jl_tupleset(jl_method_type->types, 3, jl_function_type);
     jl_tupleset(jl_lambda_info_type->types, 6, jl_function_type);
@@ -3199,6 +3205,7 @@ void jl_init_types(void)
     jl_tupleset(jl_datatype_type->types, 7, (jl_value_t*)jl_bool_type);
     jl_tupleset(jl_datatype_type->types, 8, (jl_value_t*)jl_bool_type);
     jl_tupleset(jl_datatype_type->types, 9, (jl_value_t*)jl_bool_type);
+    jl_tupleset(jl_datatype_type->types, 10, (jl_value_t*)jl_bool_type);
     jl_tupleset(jl_function_type->types, 0, pointer_void);
     jl_tupleset(jl_tvar_type->types, 3, (jl_value_t*)jl_bool_type);
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1991,7 +1991,7 @@ static jl_value_t *inst_type_w_(jl_value_t *t, jl_value_t **env, size_t n,
             if (tn == jl_array_typename)
                 ndt->pointerfree = 0;
         }
-        ndt->undeffree = dt->undeffree || jl_isbits(ndt);
+        ndt->ninitialized = dt->ninitialized;
         if (cacheable) cache_type_((jl_value_t*)ndt);
         result = (jl_value_t*)ndt;
 
@@ -2904,7 +2904,7 @@ void jl_init_types(void)
     jl_datatype_type->name->primary = (jl_value_t*)jl_datatype_type;
     jl_datatype_type->super = jl_type_type;
     jl_datatype_type->parameters = jl_null;
-    jl_datatype_type->names = jl_tuple(11, jl_symbol("name"),
+    jl_datatype_type->names = jl_tuple(10, jl_symbol("name"),
                                        jl_symbol("super"),
                                        jl_symbol("parameters"),
                                        jl_symbol("names"),
@@ -2913,13 +2913,12 @@ void jl_init_types(void)
                                        jl_symbol("size"),
                                        jl_symbol("abstract"),
                                        jl_symbol("mutable"),
-                                       jl_symbol("pointerfree"),
-                                       jl_symbol("undeffree"));
-    jl_datatype_type->types = jl_tuple(11, jl_typename_type, jl_type_type,
+                                       jl_symbol("pointerfree"));
+    jl_datatype_type->types = jl_tuple(10, jl_typename_type, jl_type_type,
                                        jl_tuple_type, jl_tuple_type,
                                        jl_tuple_type, jl_any_type,
                                        jl_any_type, //types will be fixed later
-                                       jl_any_type, jl_any_type, jl_any_type, jl_any_type);
+                                       jl_any_type, jl_any_type, jl_any_type);
     jl_datatype_type->instance = NULL;
     jl_datatype_type->uid = jl_assign_type_uid();
     jl_datatype_type->struct_decl = NULL;
@@ -2928,7 +2927,7 @@ void jl_init_types(void)
     // NOTE: types should not really be mutable, but the instance and
     // struct_decl fields are basically caches, which are mutated.
     jl_datatype_type->mutabl = 1;
-    jl_datatype_type->undeffree = 0;
+    jl_datatype_type->ninitialized = 0;
 
     jl_typename_type->name = jl_new_typename(jl_symbol("TypeName"));
     jl_typename_type->name->primary = (jl_value_t*)jl_typename_type;
@@ -2944,7 +2943,7 @@ void jl_init_types(void)
     jl_typename_type->abstract = 0;
     jl_typename_type->pointerfree = 0;
     jl_typename_type->mutabl = 1;
-    jl_typename_type->undeffree = 0;
+    jl_typename_type->ninitialized = 0;
 
     jl_sym_type->name = jl_new_typename(jl_symbol("Symbol"));
     jl_sym_type->name->primary = (jl_value_t*)jl_sym_type;
@@ -2959,11 +2958,11 @@ void jl_init_types(void)
     jl_sym_type->abstract = 0;
     jl_sym_type->pointerfree = 0;
     jl_sym_type->mutabl = 1;
-    jl_sym_type->undeffree = 0;
+    jl_sym_type->ninitialized = 0;
 
     // now they can be used to create the remaining base kinds and types
     jl_void_type = jl_new_datatype(jl_symbol("Void"), jl_any_type, jl_null,
-                                   jl_null, jl_null, 0, 0, 1);
+                                   jl_null, jl_null, 0, 0, 0);
     jl_nothing = newstruct(jl_void_type);
     jl_void_type->instance = jl_nothing;
 
@@ -3070,7 +3069,7 @@ void jl_init_types(void)
                         jl_null, jl_null, 0, 1, 0);
     jl_array_typename = jl_array_type->name;
     jl_array_type->pointerfree = 0;
-    jl_array_type->undeffree = 0;
+    jl_array_type->ninitialized = 0;
 
     jl_array_any_type =
         (jl_value_t*)jl_apply_type((jl_value_t*)jl_array_type,
@@ -3205,7 +3204,7 @@ void jl_init_types(void)
     jl_tupleset(jl_datatype_type->types, 7, (jl_value_t*)jl_bool_type);
     jl_tupleset(jl_datatype_type->types, 8, (jl_value_t*)jl_bool_type);
     jl_tupleset(jl_datatype_type->types, 9, (jl_value_t*)jl_bool_type);
-    jl_tupleset(jl_datatype_type->types, 10, (jl_value_t*)jl_bool_type);
+    //jl_tupleset(jl_datatype_type->types, 10, jl_int32_type);
     jl_tupleset(jl_function_type->types, 0, pointer_void);
     jl_tupleset(jl_tvar_type->types, 3, (jl_value_t*)jl_bool_type);
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -855,6 +855,19 @@
 		    (ctor-def 'function name Tname params bounds '() sig ctor-body body)))
    ctor))
 
+;; check if there are any calls to new with fewer than n arguments
+(define (ctors-partial-new expr n)
+  (and (pair? expr)
+   (or
+    ((pattern-lambda
+      (call (-/ new) . args)
+      (not (length= args n))) (car expr))
+    ((pattern-lambda
+      (call (curly (-/ new) . p) . args)
+      (not (length= args n))) (car expr))
+    (ctors-partial-new (car expr) n)
+    (ctors-partial-new (cdr expr) n))))
+
 ;; remove line numbers and nested blocks
 (define (flatten-blocks e)
   (if (atom? e)
@@ -876,7 +889,8 @@
 	  (field-types (map decl-type fields))
 	  (defs2 (if (null? defs)
 		     (default-inner-ctors name field-names field-types (null? params))
-		     defs)))
+		     defs))
+	  (undeffree (not (ctors-partial-new defs (length fields)))))
      (for-each (lambda (v)
 		 (if (not (symbol? v))
 		     (error (string "field name \"" (deparse v) "\" is not a symbol"))))
@@ -886,7 +900,7 @@
 	   (global ,name) (const ,name)
 	   (composite_type ,name (tuple ,@params)
 			   (tuple ,@(map (lambda (x) `',x) field-names))
-			   ,super (tuple ,@field-types) ,mut)
+			   ,super (tuple ,@field-types) ,mut ,undeffree)
 	   (call
 	    (lambda ()
 	      (scope-block
@@ -905,7 +919,7 @@
 	     ,@(map make-assignment params (symbols->typevars params bounds #t))
 	     (composite_type ,name (tuple ,@params)
 			     (tuple ,@(map (lambda (x) `',x) field-names))
-			     ,super (tuple ,@field-types) ,mut)))
+			     ,super (tuple ,@field-types) ,mut ,undeffree)))
 	   ;; "inner" constructors
 	   (call
 	    (lambda ()

--- a/src/julia.h
+++ b/src/julia.h
@@ -209,6 +209,7 @@ typedef struct _jl_datatype_t {
     uint8_t abstract;
     uint8_t mutabl;
     uint8_t pointerfree;
+    uint8_t undeffree;
     // hidden fields:
     uint32_t alignment;  // strictest alignment over all fields
     uint32_t uid;
@@ -625,7 +626,7 @@ DLLEXPORT jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields);
 DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
                                          jl_tuple_t *parameters,
                                          jl_tuple_t *fnames, jl_tuple_t *ftypes,
-                                         int abstract, int mutabl);
+                                         int abstract, int mutabl, int undeffree);
 DLLEXPORT jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
                                          jl_tuple_t *parameters, size_t nbits);
 jl_datatype_t *jl_wrap_Type(jl_value_t *t);  // x -> Type{x}

--- a/src/julia.h
+++ b/src/julia.h
@@ -209,8 +209,8 @@ typedef struct _jl_datatype_t {
     uint8_t abstract;
     uint8_t mutabl;
     uint8_t pointerfree;
-    uint8_t undeffree;
     // hidden fields:
+    int32_t ninitialized;
     uint32_t alignment;  // strictest alignment over all fields
     uint32_t uid;
     void *struct_decl;  //llvm::Value*
@@ -626,7 +626,7 @@ DLLEXPORT jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields);
 DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
                                          jl_tuple_t *parameters,
                                          jl_tuple_t *fnames, jl_tuple_t *ftypes,
-                                         int abstract, int mutabl, int undeffree);
+                                         int abstract, int mutabl, int ninitialized);
 DLLEXPORT jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
                                          jl_tuple_t *parameters, size_t nbits);
 jl_datatype_t *jl_wrap_Type(jl_value_t *t);  // x -> Type{x}

--- a/src/task.c
+++ b/src/task.c
@@ -872,7 +872,7 @@ void jl_init_tasks(void *stack, size_t ssize)
                                             jl_any_type, jl_sym_type,
                                             jl_any_type, jl_any_type,
                                             jl_any_type, jl_any_type, jl_function_type),
-                                   0, 1);
+                                   0, 1, 0);
     jl_tupleset(jl_task_type->types, 0, (jl_value_t*)jl_task_type);
 
     done_sym = jl_symbol("done");


### PR DESCRIPTION
The approach is as follows:
- Types get an `undeffree` field that specifies whether they may contain undefined references.
- The front-end checks for calls to `new` in the type block where the number of arguments is not equal to the number of fields. (Not sure I did this right, since I don't really know Scheme.) If no such cases exist (or the type is a bits type), `undeffree` is set to true.
- In the codegen, `getfield` skips the undefined check for pointer fields if `undeffree` is true.

Another option would be to count the minimum number of arguments passed to `new` and skip undefined checks for fields at indices <= the minimum the type can be instantiated with. I could probably do that (as long as the rest of this approach seems reasonable).

Ref #3440
