### PR TITLE
fix incorrect mod rounding

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -134,7 +134,17 @@ rem(x::Float64, y::Float64) = box(Float64,rem_float(unbox(Float64,x),unbox(Float
 
 cld{T<:FloatingPoint}(x::T, y::T) = -fld(-x,y)
 
-mod{T<:FloatingPoint}(x::T, y::T) = rem(y+rem(x,y),y)
+function mod{T<:FloatingPoint}(x::T, y::T)
+    r = rem(x,y)
+    if r == 0
+        copysign(r,y)
+    elseif (r > 0) $ (y > 0)
+        r+y
+    else
+        r
+    end
+end
+
 
 ## floating point comparisons ##
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -2519,22 +2519,23 @@ Mathematical Operators
 
    Element-wise exponentiation operator.
 
-.. function:: div(a,b)
-              ÷(a,b)
+.. function:: div(x, y)
+              ÷(x, y)
 
-   Compute a/b, truncating to an integer.
+   The quotient from Euclidean division. Computes ``x/y``, truncated to an integer.
 
-.. function:: fld(a,b)
+.. function:: fld(x, y)
 
-   Largest integer less than or equal to a/b.
+   Largest integer less than or equal to ``x/y``.
 
-.. function:: cld(a,b)
+.. function:: cld(x, y)
 
-   Smallest integer larger than or equal to a/b.
+   Smallest integer larger than or equal to ``x/y``.
 
-.. function:: mod(x,m)
+.. function:: mod(x, y)
 
-   Modulus after division, returning in the range [0,m).
+   Modulus after division, returning in the range [0,``y``), if ``y`` is
+   positive, or (``y``,0] if ``y`` is negative.
 
 .. function:: mod2pi(x)
 
@@ -2545,18 +2546,15 @@ Mathematical Operators
    mod(x,2pi), which would compute the modulus of x relative to division by the
    floating-point number 2pi.
 
-.. function:: rem(x, m)
+.. function:: rem(x, y)
+              %(x, y)
 
-   Remainder after division.
+   Remainder from Euclidean division, returning a value of the same sign
+   as``x``, and smaller in magnitude than ``y``. This value is always exact.
 
 .. function:: divrem(x, y)
 
-   Returns ``(x/y, x%y)``.
-
-.. _%:
-.. function:: %(x, m)
-
-   Remainder after division. The operator form of ``rem``.
+   The quotient and remainder from Euclidean division. Equivalent to ``(x÷y, x%y)``.
 
 .. function:: mod1(x,m)
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1263,6 +1263,10 @@ end
 @test div(0.3,0.01) == 29.0
 # see https://github.com/JuliaLang/julia/issues/3127
 
+# issue #8831
+@test rem(prevfloat(1.0),1.0) == prevfloat(1.0)
+@test mod(prevfloat(1.0),1.0) == prevfloat(1.0)
+
 # issue #3046
 @test mod(int64(2),typemax(Int64)) == 2
 


### PR DESCRIPTION
`mod` currently gives some incorrect values when it should be exact, e.g.:

``` julia
julia> mod(prevfloat(1.0),1.0)
0.0

julia> rem(prevfloat(1.0),1.0)
0.9999999999999999
```

This should fix those problems. I've also tried to improve the documentation of the related functions.
