### PR TITLE
add RoundingMode argument to convert

### DIFF
--- a/base/constants.jl
+++ b/base/constants.jl
@@ -13,6 +13,11 @@ convert(::Type{Float16}, x::MathConst) = float16(float32(x))
 convert{T<:Real}(::Type{Complex{T}}, x::MathConst) = convert(Complex{T}, convert(T,x))
 convert{T<:Integer}(::Type{Rational{T}}, x::MathConst) = convert(Rational{T}, float64(x))
 
+stagedfunction convert{T<:Union(Float32,Float64),s}(t::Type{T},c::MathConst{s},r::RoundingMode)
+    f = convert(T,big(c()),r())
+    :($f)
+end
+
 =={s}(::MathConst{s}, ::MathConst{s}) = true
 ==(::MathConst, ::MathConst) = false
 

--- a/base/constants.jl
+++ b/base/constants.jl
@@ -13,8 +13,8 @@ convert(::Type{Float16}, x::MathConst) = float16(float32(x))
 convert{T<:Real}(::Type{Complex{T}}, x::MathConst) = convert(Complex{T}, convert(T,x))
 convert{T<:Integer}(::Type{Rational{T}}, x::MathConst) = convert(Rational{T}, float64(x))
 
-stagedfunction convert{T<:Union(Float32,Float64),s}(t::Type{T},c::MathConst{s},r::RoundingMode)
-    f = convert(T,big(c()),r())
+stagedfunction call{T<:Union(Float32,Float64),s}(t::Type{T},c::MathConst{s},r::RoundingMode)
+    f = T(big(c()),r())
     :($f)
 end
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -20,6 +20,8 @@ import
         realmin, realmax, get_rounding, set_rounding, maxintfloat, widen,
         significand, frexp
 
+import Base.Rounding: get_rounding_raw, set_rounding_raw
+
 import Base.GMP: ClongMax, CulongMax, CdoubleMax
 
 import Base.Math.lgamma_r
@@ -117,6 +119,11 @@ convert(::Type{Float64}, x::BigFloat) =
     ccall((:mpfr_get_d,:libmpfr), Float64, (Ptr{BigFloat},Int32), &x, ROUNDING_MODE[end])
 convert(::Type{Float32}, x::BigFloat) =
     ccall((:mpfr_get_flt,:libmpfr), Float32, (Ptr{BigFloat},Int32), &x, ROUNDING_MODE[end])
+
+convert(::Type{Float64}, x::BigFloat, r::RoundingMode) =
+    ccall((:mpfr_get_d,:libmpfr), Float64, (Ptr{BigFloat},Int32), &x, to_mpfr(r))
+convert(::Type{Float32}, x::BigFloat, r::RoundingMode) =
+    ccall((:mpfr_get_flt,:libmpfr), Float32, (Ptr{BigFloat},Int32), &x, to_mpfr(r))
 
 convert(::Type{Integer}, x::BigFloat) = convert(BigInt, x)
 
@@ -597,8 +604,10 @@ function from_mpfr(c::Integer)
     RoundingMode(c)
 end
 
-get_rounding(::Type{BigFloat}) = from_mpfr(ROUNDING_MODE[end])
-set_rounding(::Type{BigFloat},r::RoundingMode) = ROUNDING_MODE[end] = to_mpfr(r)
+get_rounding_raw(::Type{BigFloat}) = ROUNDING_MODE[end]
+set_rounding_raw(::Type{BigFloat},i::Integer) = ROUNDING_MODE[end] = i
+get_rounding(::Type{BigFloat}) = from_mpfr(get_rounding_raw(BigFloat))
+set_rounding(::Type{BigFloat},r::RoundingMode) = set_rounding_raw(BigFloat,to_mpfr(r))
 
 function copysign(x::BigFloat, y::BigFloat)
     z = BigFloat()

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -120,9 +120,9 @@ convert(::Type{Float64}, x::BigFloat) =
 convert(::Type{Float32}, x::BigFloat) =
     ccall((:mpfr_get_flt,:libmpfr), Float32, (Ptr{BigFloat},Int32), &x, ROUNDING_MODE[end])
 
-convert(::Type{Float64}, x::BigFloat, r::RoundingMode) =
+call(::Type{Float64}, x::BigFloat, r::RoundingMode) =
     ccall((:mpfr_get_d,:libmpfr), Float64, (Ptr{BigFloat},Int32), &x, to_mpfr(r))
-convert(::Type{Float32}, x::BigFloat, r::RoundingMode) =
+call(::Type{Float32}, x::BigFloat, r::RoundingMode) =
     ccall((:mpfr_get_flt,:libmpfr), Float32, (Ptr{BigFloat},Int32), &x, to_mpfr(r))
 
 convert(::Type{Integer}, x::BigFloat) = convert(BigInt, x)

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -52,8 +52,31 @@ function with_rounding{T}(f::Function, ::Type{T}, rounding::RoundingMode)
     end
 end
 
-convert(::Type{Float32},x::Float64,r::RoundingMode) = with_rounding(Float64,r) do
-    convert(Float32,x)
+
+# Should be equivalent to:
+#   convert(::Type{Float32},x::Float64,r::RoundingMode) = with_rounding(Float64,r) do
+#       convert(Float32,x)
+#   end
+# but explicit checks are currently quicker (~20x). 
+# Assumes current rounding mode is RoundToNearest
+
+convert(::Type{Float32},x::Float64,r::RoundingMode{:TiesToEven}) = convert(Float32,x)
+
+function convert(::Type{Float32},x::Float64,r::RoundingMode{:TowardNegative})
+    y = convert(Float32,x)
+    y > x ? prevfloat(y) : y
+end
+function convert(::Type{Float32},x::Float64,r::RoundingMode{:TowardPositive})
+    y = convert(Float32,x)
+    y < x ? nextfloat(y) : y
+end
+function convert(::Type{Float32},x::Float64,r::RoundingMode{:TowardZero})
+    y = convert(Float32,x)
+    if x > 0.0
+        y > x ? prevfloat(y) : y
+    else
+        y < x ? nextfloat(y) : y
+    end
 end
 
 end #module

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -1,8 +1,6 @@
 module Rounding
 include("fenv_constants.jl")
 
-import Base: convert
-
 export
     RoundingMode, RoundNearest, RoundToZero, RoundUp, RoundDown, RoundFromZero,
     get_rounding, set_rounding, with_rounding
@@ -54,23 +52,23 @@ end
 
 
 # Should be equivalent to:
-#   convert(::Type{Float32},x::Float64,r::RoundingMode) = with_rounding(Float64,r) do
+#   call(::Type{Float32},x::Float64,r::RoundingMode) = with_rounding(Float64,r) do
 #       convert(Float32,x)
 #   end
 # but explicit checks are currently quicker (~20x). 
 # Assumes current rounding mode is RoundToNearest
 
-convert(::Type{Float32},x::Float64,r::RoundingMode{:TiesToEven}) = convert(Float32,x)
+call(::Type{Float32},x::Float64,r::RoundingMode{:TiesToEven}) = convert(Float32,x)
 
-function convert(::Type{Float32},x::Float64,r::RoundingMode{:TowardNegative})
+function call(::Type{Float32},x::Float64,r::RoundingMode{:TowardNegative})
     y = convert(Float32,x)
     y > x ? prevfloat(y) : y
 end
-function convert(::Type{Float32},x::Float64,r::RoundingMode{:TowardPositive})
+function call(::Type{Float32},x::Float64,r::RoundingMode{:TowardPositive})
     y = convert(Float32,x)
     y < x ? nextfloat(y) : y
 end
-function convert(::Type{Float32},x::Float64,r::RoundingMode{:TowardZero})
+function call(::Type{Float32},x::Float64,r::RoundingMode{:TowardZero})
     y = convert(Float32,x)
     if x > 0.0
         y > x ? prevfloat(y) : y

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -1,6 +1,8 @@
 module Rounding
 include("fenv_constants.jl")
 
+import Base: convert
+
 export
     RoundingMode, RoundNearest, RoundToZero, RoundUp, RoundDown, RoundFromZero,
     get_rounding, set_rounding, with_rounding
@@ -34,17 +36,24 @@ function from_fenv(r::Integer)
     end
 end
 
-set_rounding{T<:Union(Float32,Float64)}(::Type{T},r::RoundingMode) = ccall(:fesetround, Cint, (Cint,), to_fenv(r))
-get_rounding{T<:Union(Float32,Float64)}(::Type{T}) = from_fenv(ccall(:fegetround, Cint, ()))
+set_rounding_raw{T<:Union(Float32,Float64)}(::Type{T},i::Integer) = ccall(:fesetround, Cint, (Cint,), i)
+get_rounding_raw{T<:Union(Float32,Float64)}(::Type{T}) = ccall(:fegetround, Cint, ())
+
+set_rounding{T<:Union(Float32,Float64)}(::Type{T},r::RoundingMode) = set_rounding_raw(T,to_fenv(r))
+get_rounding{T<:Union(Float32,Float64)}(::Type{T}) = from_fenv(get_rounding_raw(T))
 
 function with_rounding{T}(f::Function, ::Type{T}, rounding::RoundingMode)
-    old_rounding = get_rounding(T)
+    old_rounding_raw = get_rounding_raw(T)
     set_rounding(T,rounding)
     try
         return f()
     finally
-        set_rounding(T,old_rounding)
+        set_rounding_raw(T,old_rounding_raw)
     end
+end
+
+convert(::Type{Float32},x::Float64,r::RoundingMode) = with_rounding(Float64,r) do
+    convert(Float32,x)
 end
 
 end #module

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -369,9 +369,9 @@ Any[
 
 "),
 
-("Base","convert","convert(T, x[, r::RoundingMode])
+("Base","convert","convert(T, x)
 
-   Convert the \"x\" to a value of type \"T\".
+   Convert \"x\" to a value of type \"T\".
 
    If \"T\" is an \"Integer\" type, an \"InexactError\" will be raised
    if \"x\" is not representable by \"T\", for example if \"x\" is not
@@ -385,10 +385,7 @@ Any[
        in convert at int.jl:185
 
    If \"T\" is a \"FloatingPoint\" or \"Rational\" type, then it will
-   return the closest value to \"x\" representable by \"T\". If \"T\"
-   is a \"FloatingPoint\" type that is smaller than that of \"x\",
-   then the method accepts an optional argument \"r\" which determines
-   the direction of rounding.
+   return the closest value to \"x\" representable by \"T\".
 
       julia> x = 1/3
       0.3333333333333333
@@ -401,12 +398,6 @@ Any[
 
       julia> convert(Rational{Int64}, x)
       6004799503160661//18014398509481984
-
-      julia> convert(Float32, x, RoundDown)
-      0.3333333f0
-
-      julia> convert(Float32, x, RoundUp)
-      0.33333334f0
 
 "),
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -233,9 +233,9 @@ All Objects
    With a single symbol argument, tests whether a global variable with that
    name is defined in ``current_module()``.
 
-.. function:: convert(T, x [, r::RoundingMode])
+.. function:: convert(T, x)
 
-   Convert the ``x`` to a value of type ``T``.
+   Convert ``x`` to a value of type ``T``.
 
    If ``T`` is an ``Integer`` type, an ``InexactError`` will be raised if
    ``x`` is not representable by ``T``, for example if ``x`` is not
@@ -251,10 +251,7 @@ All Objects
        in convert at int.jl:185
 
    If ``T`` is a ``FloatingPoint`` or ``Rational`` type, then it will return
-   the closest value to ``x`` representable by ``T``. If ``T`` is a
-   ``FloatingPoint`` type that is smaller than that of ``x``, then the method
-   accepts an optional argument ``r`` which determines the direction of
-   rounding.
+   the closest value to ``x`` representable by ``T``.
 
    .. doctest::
 
@@ -269,13 +266,6 @@ All Objects
 
       julia> convert(Rational{Int64}, x)
       6004799503160661//18014398509481984
-
-      julia> convert(Float32, x, RoundDown)
-      0.3333333f0
-
-      julia> convert(Float32, x, RoundUp)
-      0.33333334f0
-
 
 .. function:: promote(xs...)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -233,9 +233,49 @@ All Objects
    With a single symbol argument, tests whether a global variable with that
    name is defined in ``current_module()``.
 
-.. function:: convert(type, x)
+.. function:: convert(T, x [, r::RoundingMode])
 
-   Try to convert ``x`` to the given type. Conversion to a different numeric type will raise an ``InexactError`` if ``x`` cannot be represented exactly in the new type.
+   Convert the ``x`` to a value of type ``T``.
+
+   If ``T`` is an ``Integer`` type, an ``InexactError`` will be raised if
+   ``x`` is not representable by ``T``, for example if ``x`` is not
+   integer-valued, or is outside the range supported by ``T``.
+
+   .. doctest::
+
+      julia> convert(Int, 3.0)
+      3
+
+      julia> convert(Int, 3.5)
+      ERROR: InexactError()
+       in convert at int.jl:185
+
+   If ``T`` is a ``FloatingPoint`` or ``Rational`` type, then it will return
+   the closest value to ``x`` representable by ``T``. If ``T`` is a
+   ``FloatingPoint`` type that is smaller than that of ``x``, then the method
+   accepts an optional argument ``r`` which determines the direction of
+   rounding.
+
+   .. doctest::
+
+      julia> x = 1/3
+      0.3333333333333333
+
+      julia> convert(Float32, x)
+      0.33333334f0
+
+      julia> convert(Rational{Int32}, x)
+      1//3
+
+      julia> convert(Rational{Int64}, x)
+      6004799503160661//18014398509481984
+
+      julia> convert(Float32, x, RoundDown)
+      0.3333333f0
+
+      julia> convert(Float32, x, RoundUp)
+      0.33333334f0
+
 
 .. function:: promote(xs...)
 

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -91,13 +91,13 @@ end
 # convert with rounding
 for v = [sqrt(2),-1/3,nextfloat(1.0),prevfloat(1.0),nextfloat(-1.0),
          prevfloat(-1.0),nextfloat(0.0),prevfloat(0.0)]
-    pn = convert(Float32,v)
-    @test pn == convert(Float32,v,RoundNearest)
-    pz = convert(Float32,v,RoundToZero)
+    pn = Float32(v,RoundNearest)
+    @test pn == convert(Float32,v)
+    pz = Float32(v,RoundToZero)
     @test pz == with_rounding(()->convert(Float32,v), Float64, RoundToZero)
-    pd = convert(Float32,v,RoundDown)
+    pd = Float32(v,RoundDown)
     @test pd == with_rounding(()->convert(Float32,v), Float64, RoundDown)
-    pu = convert(Float32,v,RoundUp)
+    pu = Float32(v,RoundUp)
     @test pu == with_rounding(()->convert(Float32,v), Float64, RoundUp)
 
     @test pn == pd || pn == pu
@@ -109,13 +109,13 @@ for T in [Float32,Float64]
     for v in [sqrt(big(2.0)),-big(1.0)/big(3.0),nextfloat(big(1.0)),
               prevfloat(big(1.0)),nextfloat(big(0.0)),prevfloat(big(0.0)),
               pi,e,eulergamma,catalan,golden,]
-        pn = convert(T,v)
-        @test pn == convert(T,v,RoundNearest)
-        pz = convert(T,v,RoundToZero)
+        pn = T(v,RoundNearest)
+        @test pn == convert(T,v)
+        pz = T(v,RoundToZero)
         @test pz == with_rounding(()->convert(T,v), BigFloat, RoundToZero)
-        pd = convert(T,v,RoundDown)
+        pd = T(v,RoundDown)
         @test pd == with_rounding(()->convert(T,v), BigFloat, RoundDown)
-        pu = convert(T,v,RoundUp)
+        pu = T(v,RoundUp)
         @test pu == with_rounding(()->convert(T,v), BigFloat, RoundUp)
 
         @test pn == pd || pn == pu

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -89,12 +89,17 @@ with_rounding(Float32,RoundDown) do
 end
 
 # convert with rounding
-for v = [sqrt(2),-1/3,nextfloat(1.0),prevfloat(1.0),nextfloat(-1.0),prevfloat(-1.0)]
+for v = [sqrt(2),-1/3,nextfloat(1.0),prevfloat(1.0),nextfloat(-1.0),
+         prevfloat(-1.0),nextfloat(0.0),prevfloat(0.0)]
     pn = convert(Float32,v)
     @test pn == convert(Float32,v,RoundNearest)
     pz = convert(Float32,v,RoundToZero)
+    @test pz == with_rounding(()->convert(Float32,v), Float64, RoundToZero)
     pd = convert(Float32,v,RoundDown)
+    @test pd == with_rounding(()->convert(Float32,v), Float64, RoundDown)
     pu = convert(Float32,v,RoundUp)
+    @test pu == with_rounding(()->convert(Float32,v), Float64, RoundUp)
+
     @test pn == pd || pn == pu
     @test v > 0 ? pz == pd : pz == pu
     @test pu - pd == eps(pz)
@@ -102,12 +107,17 @@ end
 
 for T in [Float32,Float64]
     for v in [sqrt(big(2.0)),-big(1.0)/big(3.0),nextfloat(big(1.0)),
-              pi,e,eulergamma,catalan,golden]
+              prevfloat(big(1.0)),nextfloat(big(0.0)),prevfloat(big(0.0)),
+              pi,e,eulergamma,catalan,golden,]
         pn = convert(T,v)
         @test pn == convert(T,v,RoundNearest)
         pz = convert(T,v,RoundToZero)
+        @test pz == with_rounding(()->convert(T,v), BigFloat, RoundToZero)
         pd = convert(T,v,RoundDown)
+        @test pd == with_rounding(()->convert(T,v), BigFloat, RoundDown)
         pu = convert(T,v,RoundUp)
+        @test pu == with_rounding(()->convert(T,v), BigFloat, RoundUp)
+
         @test pn == pd || pn == pu
         @test v > 0 ? pz == pd : pz == pu
         @test pu - pd == eps(pz)

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -87,3 +87,29 @@ with_rounding(Float32,RoundDown) do
     @test a32 - b32 === -c32
     @test b32 - a32 === c32
 end
+
+# convert with rounding
+for v = [sqrt(2),-1/3,nextfloat(1.0),prevfloat(1.0),nextfloat(-1.0),prevfloat(-1.0)]
+    pn = convert(Float32,v)
+    @test pn == convert(Float32,v,RoundNearest)
+    pz = convert(Float32,v,RoundToZero)
+    pd = convert(Float32,v,RoundDown)
+    pu = convert(Float32,v,RoundUp)
+    @test pn == pd || pn == pu
+    @test v > 0 ? pz == pd : pz == pu
+    @test pu - pd == eps(pz)
+end
+
+for T in [Float32,Float64]
+    for v in [sqrt(big(2.0)),-big(1.0)/big(3.0),nextfloat(big(1.0)),
+              pi,e,eulergamma,catalan,golden]
+        pn = convert(T,v)
+        @test pn == convert(T,v,RoundNearest)
+        pz = convert(T,v,RoundToZero)
+        pd = convert(T,v,RoundDown)
+        pu = convert(T,v,RoundUp)
+        @test pn == pd || pn == pu
+        @test v > 0 ? pz == pd : pz == pu
+        @test pu - pd == eps(pz)
+    end
+end


### PR DESCRIPTION
Adds an extra `RoundingMode` argument to some `convert` calls. This allows things like

``` julia
julia> Float64(pi,RoundDown)
3.141592653589793

julia> Float64(pi,RoundUp)
3.1415926535897936
```

This uses stagedfunctions internally, so reduce to constants at runtime. I've also tried to improve the docs a bit.

It occurs to me that we could also use also stagedfunctions to get rid of the "value" argument in the `@math_const` macro.

cc: @nolta 
