### PR TITLE
Microbenchmarks fixes (C, R, Octave)

### DIFF
--- a/test/perf/micro/perf.R
+++ b/test/perf/micro/perf.R
@@ -32,7 +32,7 @@ timeit("fib", fib, 20)
 parseintperf = function(t) {
     for (i in 1:t) {
         # R doesn't support uint32 values
-        n = floor(runif(1, min=0, max=2^31-1))
+        n = floor(runif(1, min=0, max=2^32-1))
         s = sprintf("0x%x", n)
         m = as.numeric(s)
         assert(m == n)

--- a/test/perf/micro/perf.c
+++ b/test/perf/micro/perf.c
@@ -238,8 +238,8 @@ int main() {
     assert(fib(20) == 6765);
     int f = 0;
     tmin = INFINITY;
+    volatile int fibarg = 20; // prevent constant propagation
     for (int i=0; i<NITER; ++i) {
-        volatile int fibarg = 20; // prevent constant propagation
         t = clock_now();
         f += fib(fibarg);
         t = clock_now()-t;

--- a/test/perf/micro/perf.c
+++ b/test/perf/micro/perf.c
@@ -239,8 +239,9 @@ int main() {
     int f = 0;
     tmin = INFINITY;
     for (int i=0; i<NITER; ++i) {
+        volatile int fibarg = 20; // prevent constant propagation
         t = clock_now();
-        f += fib(20);
+        f += fib(fibarg);
         t = clock_now()-t;
         if (t < tmin) tmin = t;
     }

--- a/test/perf/micro/perf.m
+++ b/test/perf/micro/perf.m
@@ -1,9 +1,60 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%  Main function. All the tests are run here.           %%
+%%  The functions declarations can be found at the end.  %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 function perf()
 
-warning off;
-if exist('OCTAVE_VERSION') == 0
-    maxNumCompThreads(1);
+	warning off;
+	if exist('OCTAVE_VERSION') == 0
+    	maxNumCompThreads(1);
+	end
+	
+	f = fib(20);
+	assert(f == 6765)
+	timeit('fib', @fib, 20)
+	
+	timeit('parse_int', @parseintperf, 1000)
+	
+	%% array constructors %%
+
+	%o = ones(200,200);
+	%assert(all(o) == 1)
+	%timeit('ones', @ones, 200, 200)
+	
+	%assert(all(matmul(o) == 200))
+	%timeit('AtA', @matmul, o)
+	
+	mandel(complex(-.53,.68));
+	assert(sum(sum(mandelperf(true))) == 14791)
+	timeit('mandel', @mandelperf, true)
+	
+	assert(issorted(sortperf(5000)))
+	timeit('quicksort', @sortperf, 5000)
+	
+	s = pisum(true);
+	assert(abs(s-1.644834071848065) < 1e-12);
+	timeit('pi_sum',@pisum, true)
+	
+	%s = pisumvec(true);
+	%assert(abs(s-1.644834071848065) < 1e-12);
+	%timeit('pi_sum_vec',@pisumvec, true)
+	
+	[s1, s2] = randmatstat(1000);
+	assert(round(10*s1) > 5 && round(10*s1) < 10);
+	timeit('rand_mat_stat', @randmatstat, 1000)
+	
+	timeit('rand_mat_mul', @randmatmul, 1000);
+	
+	printfd(1)
+	timeit('printfd', @printfd, 100000)
+
 end
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%  Functions declarations  %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 function assert(bool)
    if ~bool
@@ -39,10 +90,6 @@ function f = fib(n)
     end
 end
 
-f = fib(20);
-assert(f == 6765)
-timeit('fib', @fib, 20)
-
 %% parse int %%
 
 function n = parseintperf(t)
@@ -53,21 +100,12 @@ function n = parseintperf(t)
         assert(m == n);
     end
 end
-timeit('parse_int', @parseintperf, 1000)
-
-%% array constructors %%
-
-%o = ones(200,200);
-%assert(all(o) == 1)
-% timeit('ones', @ones, 200, 200)
 
 %% matmul and transpose %%
 
 %function oo = matmul(o)
 %    oo = o * o.';
 %end
-%assert(all(matmul(o) == 200))
-% timeit('AtA', @matmul, o)
 
 %% mandelbrot set: complex arithmetic and comprehensions %%
 
@@ -83,8 +121,6 @@ function n = mandel(z)
     n = 80;
 end
 
-mandel(complex(-.53,.68));
-
 function M = mandelperf(ignore)
   M = zeros(length(-2.0:.1:0.5), length(-1:.1:1));
   count = 1;
@@ -95,8 +131,6 @@ function M = mandelperf(ignore)
     end
   end
 end
-assert(sum(sum(mandelperf(true))) == 14791)
-timeit('mandel', @mandelperf, true)
 
 %% numeric vector quicksort %%
 
@@ -130,8 +164,6 @@ function v = sortperf(n)
     v = rand(n,1);
     v = qsort(v);
 end
-assert(issorted(sortperf(5000)))
-timeit('quicksort', @sortperf, 5000)
 
 %% slow pi series %%
 
@@ -145,10 +177,6 @@ function sum = pisum(ignore)
     end
 end
 
-s = pisum(true);
-assert(abs(s-1.644834071848065) < 1e-12);
-timeit('pi_sum',@pisum, true)
-
 %% slow pi series, vectorized %%
 
 function s = pisumvec(ignore)
@@ -157,10 +185,6 @@ function s = pisumvec(ignore)
         s = sum( 1./(a.^2));
     end
 end
-
-%s = pisumvec(true);
-%assert(abs(s-1.644834071848065) < 1e-12);
-%timeit('pi_sum_vec',@pisumvec, true)
 
 %% random matrix statistics %%
 
@@ -182,10 +206,6 @@ function [s1, s2] = randmatstat(t)
     s2 = std(w)/mean(w);
 end
 
-[s1, s2] = randmatstat(1000);
-assert(round(10*s1) > 5 && round(10*s1) < 10);
-timeit('rand_mat_stat', @randmatstat, 1000)
-
 function t = mytranspose(x)
     [m, n] = size(x);
     t = zeros(n, m);
@@ -202,8 +222,6 @@ function X = randmatmul(n)
     X = rand(n,n)*rand(n,n);
 end
 
-timeit('rand_mat_mul', @randmatmul, 1000);
-
 %% printf %%
 
 function printfd(n)
@@ -212,9 +230,4 @@ function printfd(n)
         fprintf(f, '%d %d\n', i, i);
     end
     fclose(f);
-end
-
-printfd(1)
-timeit('printfd', @printfd, 100000)
-
 end


### PR DESCRIPTION
Originally there was an issue in the R code that wasn't addressed with the last commit. The `parseintperf` function was using random numbers between 0 and 2^31-1 but it should have been 0 and 2^32-1 instead.

I added the `volatile` keyword to the fib test in `perf.c`. This should be a first step to fix #4821, but the Fortran issue is still not solved.

Using this <a href="https://github.com/JuliaLang/julia/issues/6791#issuecomment-53108229">suggestion</a>, I updated the Octave/MATLAB microbenchmark. I tested it in Octave and seems to be working. I don't have access to MATLAB, so it should be verified first that it does not break anything in MATLAB. If that's the case, this should fix #6791.
