### PR TITLE
slight reduction in the number of comparisons for quicksort

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -264,10 +264,11 @@ function sort!(v::AbstractVector, lo::Int, hi::Int, a::QuickSortAlg, o::Ordering
             v[mi], v[lo] = v[lo], v[mi]
         end
         if lt(o, v[hi], v[mi])
-            v[hi], v[mi] = v[mi], v[hi]
-        end
-        if lt(o, v[mi], v[lo])
-            v[mi], v[lo] = v[lo], v[mi]
+            if lt(o, v[hi], v[lo])
+                v[lo], v[mi], v[hi] = v[hi], v[lo], v[mi]
+            else
+                v[hi], v[mi] = v[mi], v[hi]
+            end
         end
         v[mi], v[lo] = v[lo], v[mi]
         i, j = lo, hi


### PR DESCRIPTION
This is only about a 1% reduction at best in the number of comparisons, because most comparisons are done in the leaves and the merge phase.  It just bugged me in #8840 that one if the `if` statements could be moved inside the other `if` statement.
