### PR TITLE
Fix least squares

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -424,7 +424,7 @@ function pinv{T}(A::StridedMatrix{T})
     m, n        = size(A)
     (m == 0 || n == 0) && return Array(S, n, m)
     Sinv        = zeros(S, length(SVD[:S]))
-    index       = SVD[:S] .> eps(real(float(one(T))))*max(m,n)*maximum(SVD[:S])
+    index       = SVD[:S] .> sqrt(eps(real(float(one(T))))*maximum(SVD[:S]))
     Sinv[index] = one(S) ./ SVD[:S][index]
     return SVD[:Vt]'scale(Sinv, SVD[:U]')
 end

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -295,7 +295,7 @@ function A_ldiv_B!{T<:BlasFloat}(A::Union(QRCompactWY{T},QRPivoted{T}), B::Strid
     return isa(A,QRPivoted) ? B[invperm(A[:p]::Vector{BlasInt}),:] : B[1:nA,:], rnk
 end
 A_ldiv_B!{T<:BlasFloat}(A::Union(QRCompactWY{T},QRPivoted{T}), B::StridedVector{T}) = vec(A_ldiv_B!(A,reshape(B,length(B),1)))
-A_ldiv_B!{T<:BlasFloat}(A::Union(QRCompactWY{T},QRPivoted{T}), B::StridedVecOrMat{T}) = A_ldiv_B!(A, B, sqrt(eps(real(float(one(eltype(B)))))))[1]
+A_ldiv_B!{T<:BlasFloat}(A::Union(QRCompactWY{T},QRPivoted{T}), B::StridedVecOrMat{T})=A_ldiv_B!(A, B, maximum(size(A))*eps(real(float(one(eltype(B))))))[1]
 function A_ldiv_B!{T}(A::QR{T},B::StridedMatrix{T})
     m, n = size(A)
     minmn = min(m,n)
@@ -570,8 +570,9 @@ svdvals(x::Number) = [abs(x)]
 function \{T<:BlasFloat}(A::SVD{T}, B::StridedVecOrMat{T})
     n = length(A.S)
     Sinv = zeros(T, n)
-    Sinv[A.S .> sqrt(eps())] = 1.0 ./ A.S
-    scale(A.Vt', Sinv) * A.U[:,1:n]'B
+    k = length(find(A.S .> eps(real(float(one(T))))*maximum(A.S)))
+    Sinv[1:k] = one(T) ./ A.S[1:k]
+    A.Vt[1:k,:]' * (Sinv[1:k] .* (A.U[:,1:k]' * B))
 end
 
 # Generalized svd


### PR DESCRIPTION
The least squares routines lose accuracy in Julia 0.3. This branch
applies a set of simple fixes to address this issue. We test the implementation
of least squares by forming an ill-conditioned operator A, a right hand
side b in the range of A, and finding a least squares solution x. The
error in norm(a*x-b) then should be within the machine precision, even
for ill-conditioned matrices.

Also, the SVD based least squares code fails completely for
non-square matrices in Julia 0.3. 

Note that the pseudoinverse is not precise in Matlab/Octave either. 
The above test should be accurate to a square root of machine precision 
in this case.

The tests scripts and results for Julia 0.3, Octave 3.4.3, and Matlab R2012a follow:

---

Julia 0.3

After fixes:

``` julia
julia> include("test_rdiv_lsquares.jl")
6.602160352047045e-14

julia> include("test_svd_lsquares.jl")
6.533966983681165e-14

julia> include("test_pinv.jl")
9.439277699982046e-7
```

---

Julia 0.3

Before fixes:

``` julia
julia> include("test_rdiv_lsquares.jl")
8.788416928121552e-7

julia> include("test_svd_lsquares.jl")
ERROR: DimensionMismatch("assigned 100 elements to length 13 destination")
 in assign_bool_vector_1d! at array.jl:382
 in \ at linalg/factorization.jl:573
 in include at ./boot.jl:242
 in include_from_node1 at ./loading.jl:128
while loading /local/tmp/zng2/github-contrib/julia/test_svd_lsquares.jl, in expression starting on line 25

julia> include("test_pinv.jl")
0.00035320238415246054
```

---

Octave 3.4.3

``` matlab
octave> test_rdiv_lsquares
ans =  3.8725e-14

octave> test_svd_lsquares
ans =  3.9309e-14

octave> test_pinv
ans =  4.3197e-04
```

---

Matlab R2012a

``` matlab
matlab> test_rdiv_lsquares
ans =

   1.0821e-13

matlab> test_svd_lsquares
ans =

   1.0564e-13

octave> test_pinv
ans =

   2.0777e-05
```
###### 

``` julia
 ## === test_rdiv_lsquares.jl ===

 function hilb(n::Integer)
    a=Array(typeof(1.0),n,n)
    for i=1:n
      for j=1:n
        a[j,i]=1.0/(i+j-1.0)
      end
    end
    return a
 end

 m = 1000
 n = 100

 # form an ill-conditioned matrix
 a = randn(m,n) * hilb(n);

 # create a right hand side in the range of a
 x0 = randn(n);
 b = a*x0;

 # find the least squares solution
 x = a\b;

 # the error in rhs should be within machine precision
 norm(a*x - b)
```
###### 

``` matlab
%% === test_rdiv_lsquares.m ===

m = 1000
n = 100

% form an ill-conditioned matrix
a = randn(m,n) * hilb(n);

% create a right hand side in the range of a
x0 = randn(n,1);
b = a*x0;

% find the least squares solution
x = a\b;

% the error in rhs should be within machine precision
norm(a*x - b)
```
###### 

``` julia
 ## === test_svd_lsquares.jl ===

 function hilb(n::Integer)
    a=Array(typeof(1.0),n,n)
    for i=1:n
      for j=1:n
        a[j,i]=1.0/(i+j-1.0)
      end
    end
    return a
 end

m = 1000
n = 100

 # form an ill-conditioned matrix
a = randn(m,n) * hilb(n);

 # create a right hand side in the range of a
x0 = randn(n);
b = a*x0;

 # find the least squares solution
x = svdfact(a)\b;

 # the error in rhs should be within machine precision
norm(a*x - b)
```
###### 

``` matlab
%% === test_svd_lsquares.m ===

m = 1000
n = 100

% form an ill-conditioned matrix
a = randn(m,n) * hilb(n);

% create a right hand side in the range of a
x0 = randn(n,1);
b = a*x0;

% find the least squares solution
[u,s,v] = svd(a,0);
s = diag(s);
k = sum(s > eps*s(1))
s = diag(s);

s = s(1:k,1:k);
u = u(:,1:k);
v = v(:,1:k);
x = v*(s^(-1)*(u'*b));

% the error in rhs should be within machine precision
norm(a*x - b)
```
###### 

``` julia
 ## === test_pinv.jl ===

function hilb(n::Integer)
    a=Array(typeof(1.0),n,n)
    for i=1:n
      for j=1:n
        a[j,i]=1.0/(i+j-1.0)
      end
    end
    return a
end

m = 1000
n = 100

 # form an ill-conditioned matrix
a = randn(m,n) * hilb(n);

 # create a right hand side in the range of a
x0 = randn(n);
b = a*x0;

 # find the pseudo-inverse solution
x = pinv(a)*b;

 # the error in rhs should be within the square root of machine precision
norm(a*x - b)
```
###### 

``` julia
%% === test_pinv.m ===

m = 1000
n = 100

% form an ill-conditioned matrix
a = randn(m,n) * hilb(n);

% create a right hand side in the range of a
x0 = randn(n,1);
b = a*x0;

% find the pseudo-inverse solution
x = pinv(a)*b;

% the error in rhs should be within the square root of machine precision
norm(a*x - b)
```
###### 

[jiahao: formatting code blocks]
