### PR TITLE
WIP: fix invoke for overloaded call

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -1928,3 +1928,7 @@ type ConcreteThing{T<:FloatingPoint,N} <: AbstractThing{T,N}
 end
 
 @test typeintersect(AbstractThing{TypeVar(:T,true),2}, ConcreteThing) == ConcreteThing{TypeVar(:T,FloatingPoint),2}
+
+# issue #8712
+type Issue8712; end
+@test isa(invoke(Issue8712, ()), Issue8712)


### PR DESCRIPTION
This is for issue #8861.  ~~However, something is not quite working ... the following error seems rather mysterious to me:~~ (_Update: this test now passes._)

```
julia> type A; end

julia> invoke(A, ())
ERROR: `call` has no method matching call(::Type{A})

julia> methods(A)
2-element Array{Any,1}:
 call(::Type{A})                         
 call{T}(::Type{T},args...) at base.jl:34
```

I'm guessing that there is a simple tweak to my patch that will fix this, but I don't understand where the problem lies.

cc: @simonster, @JeffBezanson, @vtjnash 
