### PR TITLE
Add -Bsymbolic-functions on Linux

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -629,7 +629,7 @@ endif
 
 ifeq ($(OS), Linux)
 OSLIBS += -ldl -lrt -lpthread -Wl,--export-dynamic -Wl,--version-script=$(JULIAHOME)/src/julia.expmap -Wl,--no-whole-archive $(LIBUNWIND)
-JLDFLAGS = -Wl,-Bdynamic
+JLDFLAGS = -Wl,-Bdynamic -Wl,-Bsymbolic-functions
 endif
 
 ifeq ($(OS), FreeBSD)


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/julia-dev/wxYgZy70Nd0 for why this is useful, namely so that you can load `libjulia.so` into node and not crash.
