### PR TITLE
Reorganization of files to allow distribution of Julia for embedding without uv.h

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -5,7 +5,6 @@
 #include <string.h>
 #include <stdarg.h>
 #include <assert.h>
-#include "julia.h"
 #include "julia_internal.h"
 
 #ifdef __cplusplus

--- a/src/array.c
+++ b/src/array.c
@@ -7,7 +7,6 @@
 #ifdef _OS_WINDOWS_
 #include <malloc.h>
 #endif
-#include "julia.h"
 #include "julia_internal.h"
 
 #ifdef __cplusplus

--- a/src/ast.c
+++ b/src/ast.c
@@ -9,7 +9,6 @@
 #ifdef _OS_WINDOWS_
 #include <malloc.h>
 #endif
-#include "julia.h"
 #include "julia_internal.h"
 #include "flisp.h"
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -24,8 +24,8 @@
 #include <math.h>
 #endif
 #include <ctype.h>
-#include "julia.h"
 #include "julia_internal.h"
+#include "ios_internal.h"
 #include "builtin_proto.h"
 
 #ifdef __cplusplus

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -144,7 +144,6 @@
 #define NOMINMAX
 #endif
 
-#include "julia.h"
 #include "julia_internal.h"
 
 #include <setjmp.h>

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -5,7 +5,6 @@
 #include <sys/stat.h>
 
 #include "platform.h"
-#include "julia.h"
 #include "julia_internal.h"
 #ifdef _OS_WINDOWS_
 #include <windows.h>

--- a/src/dump.c
+++ b/src/dump.c
@@ -7,8 +7,8 @@
 #ifdef _OS_WINDOWS_
 #include <malloc.h>
 #endif
-#include "julia.h"
 #include "julia_internal.h"
+#include "ios_internal.h"
 #include "builtin_proto.h"
 
 #ifdef __cplusplus

--- a/src/flisp/flisp.c
+++ b/src/flisp/flisp.c
@@ -45,6 +45,7 @@
 
 #include "platform.h"
 #include "libsupport.h"
+#include "ios_internal.h"
 #include "flisp.h"
 #include "opcodes.h"
 

--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -6,6 +6,7 @@
 #include <sys/types.h>
 #include <setjmp.h>
 #include "flisp.h"
+#include "ios_internal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include "flisp.h"
 #include "mojibake.h"
+#include "ios_internal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/gc.c
+++ b/src/gc.c
@@ -18,7 +18,6 @@
 # include <sys/mman.h>
 # include <malloc.h>
 #endif
-#include "julia.h"
 #include "julia_internal.h"
 
 #ifdef _P64

--- a/src/gf.c
+++ b/src/gf.c
@@ -12,7 +12,6 @@
 #ifdef _OS_WINDOWS_
 #include <malloc.h>
 #endif
-#include "julia.h"
 #include "julia_internal.h"
 
 #ifdef __cplusplus

--- a/src/init.c
+++ b/src/init.c
@@ -34,7 +34,6 @@
 #include <getopt.h>
 #endif
 
-#include "julia.h"
 #include "julia_internal.h"
 #include <stdio.h>
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -4,7 +4,6 @@
 #ifdef _OS_WINDOWS_
 #include <malloc.h>
 #endif
-#include "julia.h"
 #include "julia_internal.h"
 #include "builtin_proto.h"
 

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -24,9 +24,9 @@
 #include <sys/socket.h>
 #endif
 
-#include "julia.h"
 #include "julia_internal.h"
 #include "support/ios.h"
+#include "support/ios_internal.h"
 #include "uv.h"
 
 #ifdef __cplusplus

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-#include "julia.h"
+#include "julia_internal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -10,7 +10,6 @@
 #ifdef _OS_WINDOWS_
 #include <malloc.h>
 #endif
-#include "julia.h"
 #include "julia_internal.h"
 #include "builtin_proto.h"
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -5,6 +5,18 @@
 extern "C" {
 #endif
 
+#ifndef UV_H
+typedef struct uv_stream_s uv_stream_t;
+typedef struct uv_async_s uv_async_t;
+typedef struct uv_loop_s uv_loop_t;
+typedef struct uv_process_s uv_process_t;
+typedef struct uv_pipe_s uv_pipe_t;
+typedef struct uv_handle_s uv_handle_t;
+typedef struct uv_idle_s uv_idle_t;
+typedef struct uv_timer_s uv_timer_t;
+typedef struct uv_tcp_s uv_tcp_t;
+#endif
+
 #include "options.h"
 
 #include "libsupport.h"
@@ -1244,12 +1256,6 @@ void jl_longjmp(jmp_buf _Buf,int _Value);
 #define JL_PUTS	  jl_puts
 #define JL_WRITE  jl_write
 
-DLLEXPORT int jl_spawn(char *name, char **argv, uv_loop_t *loop,
-                       uv_process_t *proc, jl_value_t *julia_struct,
-                       uv_handle_type stdin_type,uv_pipe_t *stdin_pipe,
-                       uv_handle_type stdout_type,uv_pipe_t *stdout_pipe,
-                       uv_handle_type stderr_type,uv_pipe_t *stderr_pipe, 
-                       int detach, char **env, char *cwd);
 DLLEXPORT void jl_run_event_loop(uv_loop_t *loop);
 DLLEXPORT int jl_run_once(uv_loop_t *loop);
 DLLEXPORT int jl_process_events(uv_loop_t *loop);
@@ -1290,13 +1296,6 @@ DLLEXPORT jl_value_t *jl_takebuf_string(ios_t *s);
 DLLEXPORT void *jl_takebuf_raw(ios_t *s);
 DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim);
 DLLEXPORT void jl_free2(void *p, void *hint);
-
-typedef struct {
-    void *data;
-    uv_loop_t *loop;
-    uv_handle_type type;
-    uv_file file;
-} jl_uv_file_t;
 
 DLLEXPORT size_t jl_write(uv_stream_t *stream, const char *str, size_t n);
 DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -3,10 +3,19 @@
 
 #include "options.h"
 #include "uv.h"
+#include "julia.h"
+#include "ios_internal.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef struct {
+    void *data;
+    uv_loop_t *loop;
+    uv_handle_type type;
+    uv_file file;
+} jl_uv_file_t;
 
 STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
 {
@@ -139,8 +148,15 @@ extern uv_lib_t *jl_crtdll_handle;
 extern uv_lib_t *jl_winsock_handle;
 #endif
 
+DLLEXPORT int jl_spawn(char *name, char **argv, uv_loop_t *loop,
+                       uv_process_t *proc, jl_value_t *julia_struct,
+                       uv_handle_type stdin_type,uv_pipe_t *stdin_pipe,
+                       uv_handle_type stdout_type,uv_pipe_t *stdout_pipe,
+                       uv_handle_type stderr_type,uv_pipe_t *stderr_pipe,
+                       int detach, char **env, char *cwd);
 #ifdef __cplusplus
 }
+
 #endif
 
 #endif

--- a/src/module.c
+++ b/src/module.c
@@ -2,7 +2,6 @@
   modules and top-level bindings
 */
 #include <assert.h>
-#include "julia.h"
 #include "julia_internal.h"
 
 #ifdef __cplusplus

--- a/src/profile.c
+++ b/src/profile.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <stdio.h>
-#include "julia.h"
 #include "julia_internal.h"
 
 #ifdef __cplusplus

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -25,7 +25,7 @@
 
 #include "utils.h"
 #include "utf8.h"
-#include "ios.h"
+#include "ios_internal.h"
 #include "timefuncs.h"
 
 #define MOST_OF(x) ((x) - ((x)>>4))

--- a/src/support/ios_internal.h
+++ b/src/support/ios_internal.h
@@ -1,0 +1,68 @@
+#ifndef IOS_PRIVATE_H
+#define IOS_PRIVATE_H
+
+#include "uv.h"
+#include "ios.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum { bm_none=UV_HANDLE_TYPE_MAX+1, bm_line, bm_block, bm_mem } bufmode_t;
+
+struct ios_t {
+    // the state only indicates where the underlying file position is relative
+    // to the buffer. reading: at the end. writing: at the beginning.
+    // in general, you can do any operation in any state.
+    char *buf;        // start of buffer
+
+    int errcode;
+
+#ifdef _P64
+    int _pad_bm;      // put bm at same offset as type field of uv_stream_s
+#endif
+    bufmode_t bm;     //
+    bufstate_t state;
+
+    off_t maxsize;    // space allocated to buffer
+    off_t size;       // length of valid data in buf, >=ndirty
+    off_t bpos;       // current position in buffer
+    off_t ndirty;     // # bytes at &buf[0] that need to be written
+
+    off_t fpos;       // cached file pos
+    size_t lineno;    // current line number
+
+    // pointer-size integer to support platforms where it might have
+    // to be a pointer
+    long fd;
+
+    unsigned char readable:1;
+    unsigned char writable:1;
+    unsigned char ownbuf:1;
+    unsigned char ownfd:1;
+    unsigned char _eof:1;
+
+    // this means you can read, seek back, then read the same data
+    // again any number of times. usually only true for files and strings.
+    unsigned char rereadable:1;
+
+    // this enables "stenciled writes". you can alternately write and
+    // seek without flushing in between. this performs read-before-write
+    // to populate the buffer, so "rereadable" capability is required.
+    // this is off by default.
+    //unsigned char stenciled:1;
+
+    // request durable writes (fsync)
+    // unsigned char durable:1;
+
+    int64_t userdata;
+    char local[IOS_INLSIZE];
+};
+
+DLLEXPORT int ios_bufmode(ios_t *s, bufmode_t mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/sys.c
+++ b/src/sys.c
@@ -2,8 +2,8 @@
   sys.c
   I/O and operating system utility functions
 */
-#include "julia.h"
 #include "julia_internal.h"
+#include "ios_internal.h"
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/task.c
+++ b/src/task.c
@@ -10,7 +10,6 @@
 //#include <sys/mman.h>
 #include <signal.h>
 #include <errno.h>
-#include "julia.h"
 #include "julia_internal.h"
 
 #ifdef __cplusplus

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -14,7 +14,6 @@
 #else
 #include <unistd.h>
 #endif
-#include "julia.h"
 #include "julia_internal.h"
 #include "uv.h"
 


### PR DESCRIPTION
Here is a proposal that Fixes #8690 with minimal changes to the interface.  It is partially done, but is enough for a source of discussion and/or a short term fix since no embedding can be done currently without uv.h.
## Modifications
1.  ios.h is split into ios.h and ios_internal.h
2.  Inclusion of uv.h is moved to ios_internal.h.
3.  uv struct types are left declared as incomplete-opaque but only if uv.h is not included in julia.h
4.  ios_t made incomplete-opaque in ios.h
5.  julia_internal.h is modified to include ios_internal.h and julia.h in the right order.
6.  Julia source files are modified to include julia_internal.h and/or ios_internal.h as necessary.
7.  The definition of ios_t moved to ios_internal.h
8.  The definition of jl_uv_file_t moved to julia_internal.h
9.  The declaration of jl_spawn moved to julia_internal.h
10.  The definition of ios_buffmode_t moved to ios_internal.h
11.  The declaration of ios_buffmode move to ios_internal.h
## Most of the embedding interface as been left as is except for.
1.  As mentioned above.  All of the uv_ types are opaque
2.  Also ios_t is opaque
3.  uv_handle_type is exclusively internal.
4. ios_buffmode_t is exclusively internal.
5.  jl_spawn is no longer available to embedding because it uses uv_handle_type as a parameter.
6. ios_buffmode is no longer available to embedding because it uses ios_buffmode_t
## Limitations
### Opaque uv_types

This is ok since all uv-using functions (except 2) take pointers so these type decls can be left incomplete for purposes of providing parameters, however, the embedder can no longer create the uv parameters directly, but must have a factory provided.
### missing uv_handle_type

uv_handle_type could also be made opaque, except for 1 problem, it's an enum, not a struct.  Unfortunate, but there is only 1 casualty  **jl_spawn**, which is problem, but not an insurmountable one, if the signature changed, or if there were a different function made available for embedding, then the functionality would be preserved.
### missing ios_buffmode

Similar to the above for similar reasons, **ios_buffmode** is not available.
