### PR TITLE
fix #6179 (née #8828, non-specific error line number)

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3123,8 +3123,11 @@ static Value *emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed,
                 jl_errorf("macro definition not allowed inside a local scope");
             }
             else {
-                jl_errorf("unsupported or misplaced expression \"%s\" in function %s",
-                          head->name, ctx->linfo->name->name);
+                std::ostringstream err;
+                err << "unsupported or misplaced expression '" << head->name
+                    << "' in function '" << ctx->linfo->name->name << "'";
+                emit_error(err.str(), ctx);
+                return V_null;
             }
         }
     }


### PR DESCRIPTION
Possibly fix #6179 (née #8828).

```
$ cat test.jl
for i=1:10
    if false |           #Should error on line 2.
        continue
    end
end
```

``` jlcon
julia> include("test.jl")
ERROR: unsupported or misplaced expression 'break' in function 'anonymous'
 in anonymous at no file:2
 in include at ./boot.jl:242
 in include_from_node1 at ./loading.jl:128
while loading /Users/nolta/julia/tt.jl, in expression starting on line 1
```
