### PR TITLE
(±1)^-n should not throw a DomainError

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -77,7 +77,11 @@ function power_by_squaring(x, p::Integer)
     elseif p == 2
         return x*x
     elseif p < 0
-        throw(DomainError())
+        let o = one(x)
+            x == o && return o
+            x == -1 && return iseven(p) ? o : copy(x)
+            throw(DomainError())
+        end
     end
     t = trailing_zeros(p) + 1
     p >>= t

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2446,3 +2446,8 @@ for T in (Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128)
     @test_throws InexactError T(big(typemax(T))+1)
     @test_throws InexactError T(big(typemin(T))-1)
 end
+
+# Integer exponentiation with negative powers (#8900)
+@test_throws DomainError 2^(-3)
+@test 1^(-3) == 1 == (-1)^(-4)
+@test (-1)^(-3) == -1


### PR DESCRIPTION
Since this has an integer result, no need to throw an exception.
