### PR TITLE
partial support for out-of-tree builds of julia src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@
 *.dll
 *.do
 *.o
+*.obj
 *.dylib
 *.dSYM

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,14 +6,19 @@ override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
 override CPPFLAGS += $(JCPPFLAGS)
 
+BUILDDIR ?= .
+
 SRCS = \
 	jltypes gf ast builtins module codegen interpreter \
 	alloc dlload sys init task array dump toplevel jl_uv jlapi profile llvm-simdloop
 
+HEADERS = julia.h julia_internal.h options.h $(wildcard support/*.h) $(LIBUV_INC)/uv.h
+
 FLAGS = \
 	-D_GNU_SOURCE -Iflisp -Isupport \
 	-I$(call exec,$(LLVM_CONFIG) --includedir) \
-	-I$(LIBUV_INC) -I$(build_includedir) -DLIBRARY_EXPORTS
+	-I$(LIBUV_INC) -I$(build_includedir) -DLIBRARY_EXPORTS \
+	-I$(BUILDDIR)
 ifneq ($(USEMSVC), 1)
 FLAGS += -Wall -Wno-strict-aliasing -fno-omit-frame-pointer -fvisibility=hidden -fno-common
 endif
@@ -26,11 +31,11 @@ LLVMLINK = $(call exec,$(LLVM_CONFIG) --ldflags) -lLLVM-$(call exec,$(LLVM_CONFI
 endif
 
 COMMON_LIBS = -L$(build_shlibdir) -L$(build_libdir) $(LIBUV) $(LIBMOJIBAKE) $(NO_WHOLE_ARCHIVE) $(LLVMLINK) $(OSLIBS)
-DEBUG_LIBS = $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp-debug.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport-debug.a $(COMMON_LIBS)
-RELEASE_LIBS = $(WHOLE_ARCHIVE) $(JULIAHOME)/src/flisp/libflisp.a $(WHOLE_ARCHIVE) $(JULIAHOME)/src/support/libsupport.a $(COMMON_LIBS)
+DEBUG_LIBS = $(WHOLE_ARCHIVE) $(BUILDDIR)/flisp/libflisp-debug.a $(WHOLE_ARCHIVE) $(BUILDDIR)/support/libsupport-debug.a $(COMMON_LIBS)
+RELEASE_LIBS = $(WHOLE_ARCHIVE) $(BUILDDIR)/flisp/libflisp.a $(WHOLE_ARCHIVE) $(BUILDDIR)/support/libsupport.a $(COMMON_LIBS)
 
-OBJS = $(SRCS:%=%.o)
-DOBJS = $(SRCS:%=%.dbg.obj)
+OBJS = $(SRCS:%=$(BUILDDIR)/%.o)
+DOBJS = $(SRCS:%=$(BUILDDIR)/%.dbg.obj)
 DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
 
@@ -46,40 +51,41 @@ default: release
 
 release debug: %: libjulia-%
 
-HEADERS = julia.h julia_internal.h options.h $(wildcard support/*.h) $(LIBUV_INC)/uv.h
+$(BUILDDIR):
+	mkdir $(BUILDDIR)
 
-%.o: %.c $(HEADERS)
+$(BUILDDIR)/%.o: %.c $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(SHIPFLAGS) -DNDEBUG -c $< -o $@)
-%.dbg.obj: %.c $(HEADERS)
+$(BUILDDIR)/%.dbg.obj: %.c $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -c $< -o $@)
-%.o: %.cpp $(HEADERS)
+$(BUILDDIR)/%.o: %.cpp $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CXX) $(call exec,$(LLVM_CONFIG) --cxxflags) $(CPPFLAGS) $(CXXFLAGS) $(SHIPFLAGS) -c $< -o $@)
-%.dbg.obj: %.cpp $(HEADERS)
+$(BUILDDIR)/%.dbg.obj: %.cpp $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CXX) $(call exec,$(LLVM_CONFIG) --cxxflags) $(CPPFLAGS) $(CXXFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 
-ast.o ast.dbg.obj: julia_flisp.boot.inc flisp/*.h
+$(BUILDDIR)/julia_flisp.boot.inc: $(BUILDDIR)/julia_flisp.boot $(BUILDDIR)/flisp/libflisp.a
+	@$(call PRINT_FLISP, $(call spawn,$(BUILDDIR)/flisp/flisp) ./bin2hex.scm < $< > $@)
 
-julia_flisp.boot.inc: julia_flisp.boot flisp/libflisp.a
-	@$(call PRINT_FLISP, $(call spawn,./flisp/flisp) ./bin2hex.scm < $< > $@)
+export julia_flisp.boot=$(BUILDDIR)/julia_flisp.boot
+$(julia_flisp.boot): julia-parser.scm julia-syntax.scm \
+	match.scm utils.scm jlfrontend.scm mk_julia_flisp_boot.scm $(BUILDDIR)/flisp/libflisp.a
+	@$(call PRINT_FLISP, $(call spawn,$(BUILDDIR)/flisp/flisp) ./mk_julia_flisp_boot.scm)
 
-julia_flisp.boot: julia-parser.scm julia-syntax.scm \
-	match.scm utils.scm jlfrontend.scm mk_julia_flisp_boot.scm flisp/libflisp.a
-	@$(call PRINT_FLISP, $(call spawn,./flisp/flisp) ./mk_julia_flisp_boot.scm)
+$(BUILDDIR)/ast.o $(BUILDDIR)/ast.dbg.obj: $(BUILDDIR)/julia_flisp.boot.inc flisp/*.h
+$(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: intrinsics.cpp debuginfo.cpp cgutils.cpp ccall.cpp disasm.cpp
+$(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: table.c
 
-codegen.o codegen.dbg.obj: intrinsics.cpp debuginfo.cpp cgutils.cpp ccall.cpp disasm.cpp
-builtins.o builtins.dbg.obj: table.c
+$(BUILDDIR)/support/libsupport.a: support/*.h support/*.c
+	$(MAKE) -C support BUILDDIR='$(abspath $(BUILDDIR)/support)'
 
-support/libsupport.a: support/*.h support/*.c
-	$(MAKE) -C support
+$(BUILDDIR)/support/libsupport-debug.a: support/*.h support/*.c
+	$(MAKE) -C support debug BUILDDIR='$(abspath $(BUILDDIR)/support)'
 
-support/libsupport-debug.a: support/*.h support/*.c
-	$(MAKE) -C support debug
+$(BUILDDIR)/flisp/libflisp.a: flisp/*.h flisp/*.c $(BUILDDIR)/support/libsupport.a
+	$(MAKE) -C flisp BUILDDIR='$(abspath $(BUILDDIR)/flisp)'
 
-flisp/libflisp.a: flisp/*.h flisp/*.c support/libsupport.a
-	$(MAKE) -C flisp
-
-flisp/libflisp-debug.a: flisp/*.h flisp/*.c support/libsupport-debug.a
-	$(MAKE) -C flisp debug
+$(BUILDDIR)/flisp/libflisp-debug.a: flisp/*.h flisp/*.c $(BUILDDIR)/support/libsupport-debug.a
+	$(MAKE) -C flisp debug BUILDDIR='$(abspath $(BUILDDIR)/flisp)'
 
 ifneq ($(USEMSVC), 1)
 CXXLD = $(CXX) -shared
@@ -87,11 +93,11 @@ else
 CXXLD = $(LD) -dll -export:jl_setjmp -export:jl_longjmp
 endif
 
-$(build_shlibdir)/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) flisp/libflisp-debug.a support/libsupport-debug.a $(LIBUV)
+$(build_shlibdir)/libjulia-debug.$(SHLIB_EXT): julia.expmap $(DOBJS) $(BUILDDIR)/flisp/libflisp-debug.a $(BUILDDIR)/support/libsupport-debug.a $(LIBUV)
 	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(DEBUGFLAGS) $(DOBJS) $(RPATH_ORIGIN) -o $@ $(LDFLAGS) $(DEBUG_LIBS))
 	$(INSTALL_NAME_CMD)libjulia-debug.$(SHLIB_EXT) $@
 	$(DSYMUTIL) $@
-libjulia-debug.a: julia.expmap $(DOBJS) flisp/libflisp-debug.a support/libsupport-debug.a
+$(BUILDDIR)/libjulia-debug.a: julia.expmap $(DOBJS) $(BUILDDIR)/flisp/libflisp-debug.a $(BUILDDIR)/support/libsupport-debug.a
 	rm -f $@
 	@$(call PRINT_LINK, ar -rcs $@ $(DOBJS))
 libjulia-debug: $(build_shlibdir)/libjulia-debug.$(SHLIB_EXT)
@@ -102,25 +108,26 @@ else
   SONAME =
 endif
 
-$(build_shlibdir)/libjulia.$(SHLIB_EXT): julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a $(LIBUV)
+$(build_shlibdir)/libjulia.$(SHLIB_EXT): julia.expmap $(OBJS) $(BUILDDIR)/flisp/libflisp.a $(BUILDDIR)/support/libsupport.a $(LIBUV)
 	@$(call PRINT_LINK, $(CXXLD) $(CXXLDFLAGS) $(SHIPFLAGS) $(OBJS) $(RPATH_ORIGIN) -o $@ $(LDFLAGS) $(RELEASE_LIBS) $(SONAME)) $(CXXLDFLAGS)
 	$(INSTALL_NAME_CMD)libjulia.$(SHLIB_EXT) $@
 	$(DSYMUTIL) $@
-libjulia.a: julia.expmap $(OBJS) flisp/libflisp.a support/libsupport.a
+$(BUILDDIR)/libjulia.a: julia.expmap $(OBJS) $(BUILDDIR)/flisp/libflisp.a $(BUILDDIR)/support/libsupport.a
 	rm -f $@
 	@$(call PRINT_LINK, ar -rcs $@ $(OBJS))
 libjulia-release: $(build_shlibdir)/libjulia.$(SHLIB_EXT)
 
 clean:
 	-rm -f $(build_shlibdir)/libjulia*
-	-rm -f julia_flisp.boot julia_flisp.boot.inc
-	-rm -f *.dbg.obj *.o *~ *# *.$(SHLIB_EXT) *.a
+	-rm -f $(BUILDDIR)/julia_flisp.boot $(BUILDDIR)/julia_flisp.boot.inc
+	-rm -f $(BUILDDIR)/*.dbg.obj $(BUILDDIR)/*.o *~ $(BUILDDIR)/*.$(SHLIB_EXT) $(BUILDDIR)/*.a *#
 
 clean-flisp:
-	-$(MAKE) -C flisp clean
+	-$(MAKE) -C flisp clean BUILDDIR='$(abspath $(BUILDDIR)/flisp)'
 
 clean-support:
-	-$(MAKE) -C support clean
+	-$(MAKE) -C support clean BUILDDIR='$(abspath $(BUILDDIR)/support)'
+
 
 cleanall: clean clean-flisp clean-support
 

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -5,6 +5,8 @@ override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
 override CPPFLAGS += $(JCPPFLAGS)
 
+BUILDDIR ?= .
+
 NAME = flisp
 EXENAME = $(NAME)
 LIBTARGET = lib$(NAME)
@@ -15,10 +17,12 @@ ifeq ($(USEMSVC), 1)
 SRCS += basename.c dirname.c
 endif
 
-OBJS = $(SRCS:%.c=%.o)
-DOBJS = $(SRCS:%.c=%.dbg.obj)
+HEADERS = $(wildcard *.h) $(LIBUV_INC)/uv.h
+
+OBJS = $(SRCS:%.c=$(BUILDDIR)/%.o)
+DOBJS = $(SRCS:%.c=$(BUILDDIR)/%.dbg.obj)
 LLTDIR = ../support
-LLT = $(LLTDIR)/libsupport.a $(LIBUV) $(LIBMOJIBAKE)
+LLT = $(BUILDDIR)/$(LLTDIR)/libsupport.a $(LIBUV) $(LIBMOJIBAKE)
 
 FLAGS = -I$(LLTDIR) $(CFLAGS) $(HFILEDIRS:%=-I%) \
         -I$(LIBUV_INC) -I$(build_includedir) $(LIBDIRS:%=-L%) \
@@ -37,31 +41,32 @@ SHIPFLAGS += $(FLAGS)
 
 default: release
 
-release: $(EXENAME)
+release: $(BUILDDIR)/$(EXENAME)
 
-debug: $(EXENAME)-debug
+debug: $(BUILDDIR)/$(EXENAME)-debug
 
-HEADERS = $(wildcard *.h) $(LIBUV_INC)/uv.h
+$(BUILDDIR):
+	mkdir $(BUILDDIR)
 
-%.o: %.c $(HEADERS)
+$(BUILDDIR)/%.o: %.c $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(SHIPFLAGS) -DNDEBUG -c $< -o $@)
-%.dbg.obj: %.c $(HEADERS)
+$(BUILDDIR)/%.dbg.obj: %.c $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 
-flisp.o:   flisp.c cvalues.c types.c flisp.h print.c read.c equal.c
-flisp.dbg.obj:  flisp.c cvalues.c types.c flisp.h print.c read.c equal.c
-flmain.o:  flmain.c flisp.h
-flmain.dbg.obj: flmain.c flisp.h
+$(BUILDDIR)/flisp.o:   flisp.c cvalues.c types.c flisp.h print.c read.c equal.c
+$(BUILDDIR)/flisp.dbg.obj:  flisp.c cvalues.c types.c flisp.h print.c read.c equal.c
+$(BUILDDIR)/flmain.o:  flmain.c flisp.h
+$(BUILDDIR)/flmain.dbg.obj: flmain.c flisp.h
 
 $(LLT): $(LLTDIR)/*.h $(LLTDIR)/*.c
-	cd $(LLTDIR) && $(MAKE)
+	$(MAKE) -C $(LLTDIR) BUILDDIR='$(abspath $(BUILDDIR)/$(LLTDIR))'
 
-$(LIBTARGET)-debug.a: $(DOBJS)
+$(BUILDDIR)/$(LIBTARGET)-debug.a: $(DOBJS) | $(BUILDDIR)
 	rm -rf $@
 	@$(call PRINT_LINK, $(AR) -rcs $@ $(DOBJS))
 	ln -sf $@ $(LIBTARGET).a
 
-$(LIBTARGET).a: $(OBJS)
+$(BUILDDIR)/$(LIBTARGET).a: $(OBJS) | $(BUILDDIR)
 	rm -rf $@
 	@$(call PRINT_LINK, $(AR) -rcs $@ $(OBJS))
 
@@ -71,11 +76,14 @@ else
 CCLD = $(LD)
 endif
 
-$(EXENAME)-debug: $(DOBJS) $(LIBFILES) $(LIBTARGET)-debug.a flmain.dbg.obj
-	@$(call PRINT_LINK, $(CCLD) $(DEBUGFLAGS) $(DOBJS) flmain.dbg.obj -o $(EXENAME)-debug $(LIBTARGET).a $(LIBS) $(OSLIBS))
+$(BUILDDIR)/$(EXENAME)-debug: $(DOBJS) $(LIBFILES) $(BUILDDIR)/$(LIBTARGET)-debug.a $(BUILDDIR)/flmain.dbg.obj
+	@$(call PRINT_LINK, $(CCLD) $(DEBUGFLAGS) $(DOBJS) $(BUILDDIR)/flmain.dbg.obj -o $@ $(BUILDDIR)/$(LIBTARGET).a $(LIBS) $(OSLIBS))
 
-$(EXENAME): $(OBJS) $(LIBFILES) $(LIBTARGET).a flmain.o
-	@$(call PRINT_LINK, $(CCLD) $(SHIPFLAGS) $(OBJS) flmain.o -o $(EXENAME) $(LIBTARGET).a $(LIBS) $(OSLIBS))
+$(BUILDDIR)/$(EXENAME): $(OBJS) $(LIBFILES) $(BUILDDIR)/$(LIBTARGET).a $(BUILDDIR)/flmain.o | $(BUILDDIR)/flisp.boot
+	@$(call PRINT_LINK, $(CCLD) $(SHIPFLAGS) $(OBJS) $(BUILDDIR)/flmain.o -o $@ $(BUILDDIR)/$(LIBTARGET).a $(LIBS) $(OSLIBS))
+
+$(BUILDDIR)/flisp.boot: flisp.boot
+	cp $< $@
 
 test:
 ifneq ($(USEMSVC), 1)
@@ -83,8 +91,8 @@ ifneq ($(USEMSVC), 1)
 endif
 
 clean:
-	rm -f *.o
-	rm -f *.dbg.obj
-	rm -f *.a
-	rm -f $(EXENAME)
-	rm -f $(EXENAME)-debug
+	rm -f $(BUILDDIR)/*.o
+	rm -f $(BUILDDIR)/*.dbg.obj
+	rm -f $(BUILDDIR)/*.a
+	rm -f $(BUILDDIR)/$(EXENAME)
+	rm -f $(BUILDDIR)/$(EXENAME)-debug

--- a/src/mk_julia_flisp_boot.scm
+++ b/src/mk_julia_flisp_boot.scm
@@ -1,2 +1,2 @@
 (load "jlfrontend.scm")
-(make-system-image "julia_flisp.boot")
+(make-system-image (os.getenv "julia_flisp.boot"))

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -5,22 +5,26 @@ override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
 override CPPFLAGS += $(JCPPFLAGS)
 
-OBJS = hashing.o timefuncs.o ptrhash.o operators.o \
-	utf8.o ios.o htable.o bitvector.o \
-	int2str.o libsupportinit.o arraylist.o strtod.o
+BUILDDIR ?= .
 
+SRCS = hashing timefuncs ptrhash operators \
+	utf8 ios htable bitvector \
+	int2str libsupportinit arraylist strtod
 ifeq ($(OS),WINNT)
-OBJS += asprintf.o wcwidth.o
+SRCS += asprintf wcwidth
 ifeq ($(ARCH),i686)
-OBJS += _setjmp.win32.o _longjmp.win32.o
+SRCS += _setjmp.win32 _longjmp.win32
 else ifeq ($(ARCH),i386)
-OBJS += _setjmp.win32.o _longjmp.win32.o
+SRCS += _setjmp.win32 _longjmp.win32
 else ifeq ($(ARCH),x86_64)
-OBJS += _setjmp.win64.o _longjmp.win64.o
+SRCS += _setjmp.win64 _longjmp.win64
 endif
 endif
 
-DOBJS = $(OBJS:%.o=%.dbg.obj)
+HEADERS = $(wildcard *.h) $(LIBUV_INC)/uv.h
+
+OBJS = $(SRCS:%=$(BUILDDIR)/%.o)
+DOBJS = $(SRCS:%=$(BUILDDIR)/%.dbg.obj)
 
 FLAGS = $(CFLAGS) $(HFILEDIRS:%=-I%) -I$(LIBUV_INC) -DLIBRARY_EXPORTS
 ifneq ($(USEMSVC), 1)
@@ -32,42 +36,43 @@ SHIPFLAGS += $(FLAGS)
 
 default: release
 
-HEADERS = $(wildcard *.h) $(LIBUV_INC)/uv.h
+$(BUILDDIR):
+	mkdir $(BUILDDIR)
 
-%.o: %.c $(HEADERS)
+$(BUILDDIR)/%.o: %.c $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(SHIPFLAGS) -DNDEBUG -c $< -o $@)
-%.dbg.obj: %.c $(HEADERS)
+$(BUILDDIR)/%.dbg.obj: %.c $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 ifneq ($(USEMSVC), 1)
-%.o: %.S
+$(BUILDDIR)/%.o: %.S | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(SHIPFLAGS) -c $< -o $@)
-%.dbg.obj: %.S
+$(BUILDDIR)/%.dbg.obj: %.S | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(DEBUGFLAGS) -c $< -o $@)
 else
-%.o: %.S
+$(BUILDDIR)/%.o: %.S | $(BUILDDIR)
 	@$(call PRINT_CC, $(CPP) -P $(CPPFLAGS) $(SHIPFLAGS) $<)
 	@$(call PRINT_CC, $(AS) $(CPPFLAGS) $(SHIPFLAGS) -Fo$@ -c $*.i)
-%.dbg.obj: %.S
+$(BUILDDIR)/%.dbg.obj: %.S | $(BUILDDIR)
 	@$(call PRINT_CC, $(CPP) -P $(CPPFLAGS) $(DEBUGFLAGS) $<)
 	@$(call PRINT_CC, $(AS) $(CPPFLAGS) $(DEBUGFLAGS) -Fo$@ -c $*.i)
 endif
 
-release: libsupport.a
-debug: libsupport-debug.a
+release: $(BUILDDIR)/libsupport.a
+debug: $(BUILDDIR)/libsupport-debug.a
 
-libsupport.a: $(OBJS)
+$(BUILDDIR)/libsupport.a: $(OBJS)
 	rm -rf $@
 	@$(call PRINT_LINK, $(AR) -rcs $@ $^)
 
-libsupport-debug.a: $(DOBJS)
+$(BUILDDIR)/libsupport-debug.a: $(DOBJS)
 	rm -rf $@
 	@$(call PRINT_LINK, $(AR) -rcs $@ $^)
 
 clean:
-	rm -f *.o
-	rm -f *.dbg.obj
-	rm -f *.a
-	rm -f *~ *#
-	rm -f core*
-	rm -f libsupport.a
-	rm -f libsupport-debug.a
+	rm -f $(BUILDDIR)/*.o
+	rm -f $(BUILDDIR)/*.dbg.obj
+	rm -f $(BUILDDIR)/*.a
+	rm -f $(BUILDDIR)/*~ *#
+	rm -f $(BUILDDIR)/core*
+	rm -f $(BUILDDIR)/libsupport.a
+	rm -f $(BUILDDIR)/libsupport-debug.a


### PR DESCRIPTION
I'm not really sure, but I thought this might help with cross-compiling a sysimg, so that you could perhaps build a native version of julia alongside the cross-compile version
