### PR TITLE
Fix building with USECCACHE=1.

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -320,8 +320,15 @@ SHIPFLAGS = -O3 -g -falign-functions
 endif
 
 ifeq ($(USECCACHE), 1)
-CC := ccache $(CC)
-CXX := ccache $(CXX)
+# expand CC and CXX at declaration time because we will redefine them
+CC_ARG   := $(CC)         # Expand CC and CXX here already because we want
+CXX_ARG  := $(CXX)        # the original definition and not the ccache version.
+CC_FULL  := ccache $(CC)  # Expand CC and CXX here already to avoid recursive
+CXX_FULL := ccache $(CXX) # referencing.
+CC        = $(CC_FULL)    # Add an extra indirection to make CC/CXX non-simple
+CXX       = $(CXX_FULL)   # vars (because of how -m$(BINARY) is added later on).
+CC_BASE   = ccache
+CXX_BASE  = ccache
 ifeq ($(USECLANG),1)
 # ccache and Clang don't do well together
 # http://petereisentraut.blogspot.be/2011/05/ccache-and-clang.html

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -14,6 +14,16 @@ endif
 endif
 CONFIGURE_COMMON += F77="$(FC)" CC="$(CC)" CXX="$(CXX)"
 
+# prepare CMAKE_CC and CMAKE_CXX flags
+CMAKE_CC = -DCMAKE_C_COMPILER="$(CC_BASE)"
+ifdef CC_ARG
+CMAKE_CC += -DCMAKE_C_COMPILER_ARG1="$(CC_ARG)"
+endif
+CMAKE_CXX = -DCMAKE_CXX_COMPILER="$(CXX_BASE)"
+ifdef CXX_ARG
+CMAKE_CXX += -DCMAKE_CXX_COMPILER_ARG1="$(CXX_ARG)"
+endif
+
 # If the top-level Makefile is called with environment variables,
 # they will override the values passed above to ./configure
 MAKE_COMMON = DESTDIR="" prefix=$(build_prefix) bindir=$(build_bindir) libdir=$(build_libdir) libexecdir=$(build_libexecdir) datarootdir=$(build_datarootdir) includedir=$(build_includedir) sysconfdir=$(build_sysconfdir)
@@ -363,12 +373,12 @@ libcxx-build:
 	mkdir -p libcxx-build
 libcxx-build/Makefile: llvm-$(LLVM_VER)/projects/libcxx | llvm-$(LLVM_VER)/projects/libcxxabi libcxx-build
 	cd libcxx-build && \
-		$(CMAKE) -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_LIBCXXABI_INCLUDE_PATHS="../llvm-$(LLVM_VER)/projects/libcxxabi/include" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(build_prefix) ../llvm-$(LLVM_VER)/projects/libcxx -DCMAKE_C_COMPILER="$(CC_BASE)" -DCMAKE_CXX_COMPILER="$(CXX_BASE)"  -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir) -Bstatic -lirc -Bdynamic" -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
+		$(CMAKE) -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_LIBCXXABI_INCLUDE_PATHS="../llvm-$(LLVM_VER)/projects/libcxxabi/include" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(build_prefix) ../llvm-$(LLVM_VER)/projects/libcxx $(CMAKE_CC) $(CMAKE_CXX) -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir) -Bstatic -lirc -Bdynamic" -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
 libcxxabi-build:
 	mkdir -p libcxxabi-build
 libcxxabi-build/Makefile: llvm-$(LLVM_VER)/projects/libcxxabi | libcxxabi-build
 	cd libcxxabi-build && \
-        $(CMAKE) -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DLLVM_MAIN_SRC_DIR=../llvm-svn -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(build_prefix) ../llvm-$(LLVM_VER)/projects/libcxxabi -DCMAKE_C_COMPILER="$(CC_BASE)" -DCMAKE_CXX_COMPILER="$(CXX_BASE)" -DLIBCXXABI_CXX_ABI_LIBRARIES="-Bstatic -lirc -Bdynamic" -DCMAKE_CXX_FLAGS="$(CXXFLAGS) -std=c++11"
+        $(CMAKE) -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DLLVM_MAIN_SRC_DIR=../llvm-svn -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(build_prefix) ../llvm-$(LLVM_VER)/projects/libcxxabi $(CMAKE_CC) $(CMAKE_CXX) -DLIBCXXABI_CXX_ABI_LIBRARIES="-Bstatic -lirc -Bdynamic" -DCMAKE_CXX_FLAGS="$(CXXFLAGS) -std=c++11"
 llvm-$(LLVM_VER)/projects/libcxxabi/lib/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi | llvm-$(LLVM_VER)/projects/libcxx
 libcxxabi-build/libc++abi.so.1.0: | libcxxabi-build/Makefile
 	cd libcxxabi-build && $(MAKE)
@@ -1701,7 +1711,7 @@ install-virtualenv: $(VIRTUALENV_TARGET)
 LIBGIT2_OBJ_SOURCE = libgit2-$(LIBGIT2_VER)/build/libgit2.$(SHLIB_EXT)
 LIBGIT2_OBJ_TARGET = $(build_shlibdir)/libgit2.$(SHLIB_EXT)
 
-LIBGIT2_OPTS = -DTHREADSAFE=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="$(CC_BASE)"
+LIBGIT2_OPTS = -DTHREADSAFE=ON -DCMAKE_BUILD_TYPE=Release $(CMAKE_CC)
 ifeq ($(OS),WINNT)
 LIBGIT2_OPTS += -DWIN32=ON -DMINGW=ON -DUSE_SSH=OFF -DCMAKE_SYSTEM_NAME=Windows
 ifeq ($(BUILD_OS),WINNT)


### PR DESCRIPTION
After 6300cbe5307056d9185d85fb4b9b22ab7d471fb9, building with `USECCACHE=1` was broken due to the alterations to `CC` and `CXX`, causing `$(BINARY)` to expand badly and ending up with `-m` rather than `-m64` in the compilation command.

This fixes it, although to be honest I'm not completely sure about this. Maybe some `Make` guru can comment on whether this is the proper way to prepend `ccache` to the recursively expanding `CC` and `CXX` variables.
