### PR TITLE
Deprecate zero and one for Ptr{T}

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -215,3 +215,8 @@ end
 
 export String
 const String = AbstractString
+
+@deprecate zero{T}(::Type{Ptr{T}}) Ptr{T}(0)
+@deprecate zero{T}(x::Ptr{T})      Ptr{T}(0)
+@deprecate one{T}(::Type{Ptr{T}})  Ptr{T}(1)
+@deprecate one{T}(x::Ptr{T})       Ptr{T}(1)

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -65,8 +65,3 @@ eltype{T}(::Ptr{T}) = T
 +(x::Ptr, y::Integer) = oftype(x, uint(uint(x) + y))
 -(x::Ptr, y::Integer) = oftype(x, uint(uint(x) - y))
 +(x::Integer, y::Ptr) = y + x
-
-zero{T}(::Type{Ptr{T}}) = convert(Ptr{T}, 0)
-zero{T}(x::Ptr{T}) = convert(Ptr{T}, 0)
-one{T}(::Type{Ptr{T}}) = convert(Ptr{T}, 1)
-one{T}(x::Ptr{T}) = convert(Ptr{T}, 1)


### PR DESCRIPTION
They doesn't fulfill the documentation for zero and one about additive and multiplicative identity.

See discussion in https://github.com/JuliaLang/julia/pull/6183#issuecomment-61853347
