### PR TITLE
Fix help for .+ in the REPL

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -654,7 +654,7 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
         complete = replc,
         # When we're done transform the entered line into a call to help("$line")
         on_done = respond(repl, julia_prompt) do line
-            parse("Base.@help $line", raise=false)
+            parse("Base.@help \"$line\"", raise=false)
         end)
 
     # Set up shell mode


### PR DESCRIPTION
fixes #8903.

There is a slight oddity here (though not sure if this is related), this changes the current help e.g. for add:

```
julia> eval(parse("Base.@help(add)"))   # current help
add (generic function with 2 methods)

julia> eval(parse("Base.@help(\"add\")"))  # this PR
Base.Pkg.add(pkg, vers...)

   Add a requirement entry for "pkg" to "Pkg.dir("REQUIRE")" and
   call "Pkg.resolve()". If "vers" are given, they must be
   "VersionNumber" objects and they specify acceptable version
   intervals for "pkg".
```

(Note: Not sure how this small change fits in with docile/md upheaval #8588 #8791?)
