### PR TITLE
Fix error in whitespace check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
         make $BUILDOPTS -C contrib -f repackage_system_suitesparse4.make;
       fi
 script:
-    - ! git grep ' $' -- \*.jl \*.scm \*.c \*.cpp \*.h > /dev/null || { echo "trailing whitespace found in source file"; exit 1; }
+    - git grep ' $' -- \*.jl \*.scm \*.c \*.cpp \*.h > /dev/null && { echo "trailing whitespace found in source file"; exit 1; }
     - make $BUILDOPTS prefix=/tmp/julia install
     - if [ `uname` = "Darwin" ]; then
         for name in spqr umfpack colamd cholmod amd suitesparse_wrapper; do


### PR DESCRIPTION
This should fix the whitespace check that has been causing problems with travis. It looks like the negation was not being applied before the `||`.
