### PR TITLE
Emphasize how `isimmutable` works for types.

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -402,6 +402,7 @@ Types
 .. function:: isimmutable(v)
 
    True if value ``v`` is immutable.  See :ref:`man-immutable-composite-types` for a discussion of immutability.
+   Note that this function works on values, so if you give it a type, it will tell you that a value of ``DataType`` is mutable.
 
 .. function:: isbits(T)
 


### PR DESCRIPTION
Ref: #8760

This adds the remark
`Note that this function works on values, so if you give it a type, it will tell you that a value of ``DataType`` is mutable.`
