### PR TITLE
suggest running Pkg.update() in error message

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -374,7 +374,8 @@ function resolve(
     for pkg in keys(reqs)
         if !haskey(deps,pkg)
             if "julia" in conflicts[pkg]
-                error("$pkg can't be installed because it has no versions that support ", VERSION, " of julia")
+                error("$pkg can't be installed because it has no versions that support ", VERSION, " of julia. " *
+                   "You may need to update METADATA by running `Pkg.update()`")
             else
                 error("$pkg's requirements can't be satisfied because of the following fixed packages: ",
                    join(conflicts[pkg], ", ", " and "))


### PR DESCRIPTION
This error happened to a colleague of mine who had a stale version of METADATA that wouldn't allow her to `Pkg.add("IJulia")` with Julia 0.3.2.
