### PR TITLE
Name atan2 arguments consistently

### DIFF
--- a/base/float16.jl
+++ b/base/float16.jl
@@ -141,7 +141,7 @@ for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
         $func(a::Complex32) = complex32($func(complex64(a)))
     end
 end
-atan2(a::Float16, b::Float16) = float16(atan2(float32(a), float32(b)))
+atan2(y::Float16, x::Float16) = float16(atan2(float32(y), float32(x)))
 hypot(a::Float16, b::Float16) = float16(hypot(float32(a), float32(b)))
 ldexp(a::Float16, b::Integer) = float16(ldexp(float32(a), b))
 exponent(x::Float16) = exponent(float32(x))

--- a/base/math.jl
+++ b/base/math.jl
@@ -166,13 +166,13 @@ function hypot{T<:FloatingPoint}(x::T, y::T)
     x * sqrt(one(r)+r*r)
 end
 
-atan2(x::Real, y::Real) = atan2(promote(float(x),float(y))...)
-atan2{T<:FloatingPoint}(x::T, y::T) = Base.no_op_err("atan2", T)
+atan2(y::Real, x::Real) = atan2(promote(float(y),float(x))...)
+atan2{T<:FloatingPoint}(y::T, x::T) = Base.no_op_err("atan2", T)
 
 for f in (:atan2, :hypot)
     @eval begin
-        ($f)(x::Float64, y::Float64) = ccall(($(string(f)),libm), Float64, (Float64, Float64,), x, y)
-        ($f)(x::Float32, y::Float32) = ccall(($(string(f,"f")),libm), Float32, (Float32, Float32), x, y)
+        ($f)(y::Float64, x::Float64) = ccall(($(string(f)),libm), Float64, (Float64, Float64,), y, x)
+        ($f)(y::Float32, x::Float32) = ccall(($(string(f,"f")),libm), Float32, (Float32, Float32), y, x)
         @vectorize_2arg Number $f
     end
 end


### PR DESCRIPTION
Doing `methods(atan2)` reveals an inconsistency in the names of the arguments x and y. The documentation about atan2 says `atan2(y, x)`, but the names in the functions are inverted.
