### PR TITLE
WIP: fix slowness of randn introduced by 84b6aec6

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -813,6 +813,9 @@ const ziggurat_exp_r      = 7.6971174701310497140446280481
 
 @inline randi(rng::MersenneTwister=GLOBAL_RNG) = reinterpret(Uint64, rand_close1_open2(rng)) & 0x000fffffffffffff
 
+# the @inline'd rand(rng) method makes randmtzig_randn slower
+rand_noinline(rng::MersenneTwister) = rand(rng)
+
 function randmtzig_randn(rng::MersenneTwister=GLOBAL_RNG)
     @inbounds begin
         while true
@@ -824,13 +827,13 @@ function randmtzig_randn(rng::MersenneTwister=GLOBAL_RNG)
                 return x # 99.3% of the time we return here 1st try
             elseif idx == 0
                 while true
-                    xx = -ziggurat_nor_inv_r*log(rand(rng))
-                    yy = -log(rand(rng))
+                    xx = -ziggurat_nor_inv_r*log(rand_noinline(rng))
+                    yy = -log(rand_noinline(rng))
                     if yy+yy > xx*xx
                         return (rabs & 0x100) != 0x000000000 ? -ziggurat_nor_r-xx : ziggurat_nor_r+xx
                     end
                 end
-            elseif (fi[idx] - fi[idx+1])*rand(rng) + fi[idx+1] < exp(-0.5*x*x)
+            elseif (fi[idx] - fi[idx+1])*rand_noinline(rng) + fi[idx+1] < exp(-0.5*x*x)
                 return x # return from the triangular area
             end
         end


### PR DESCRIPTION
Quoting @rfourquet:

@ViralBShah Great! I remember having tested inlined rand() at some point (before #8854 I think, and without other `@inlines` of this commit) but noticing degraded performances somewhere else (I think for the array version rand(n::Int)). What I find now is that this commit slows down randn[!] methods by up to 50%, do you confirm?

I just pushed a branch where randmtzig_randn uses a non-inlined version of rand which seem to restore previous perfs of randn, but this starts to make me feel uneasy with all those `@inline` tweaks. Should I open a PR? (In this branch, I also revert/modify part of this commit because I think rand_close_open is dSFMT specific so I prefer to keep rand(r::AbstractRNG) = rand(r, Float64) which I find more self-documenting, do you agree?).
