### PR TITLE
Use tempname() instead of custom file path in test/pkg.jl

### DIFF
--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -1,6 +1,6 @@
 function temp_pkg_dir(fn::Function)
   # Used in tests below to setup and teardown a sandboxed package directory
-  const tmpdir = ENV["JULIA_PKGDIR"] = abspath(string("tmp.",randstring()))
+  const tmpdir = ENV["JULIA_PKGDIR"] = tempname()
   @test !isdir(Pkg.dir())
   try
     Pkg.init()


### PR DESCRIPTION
Fixes calling Base.runtests("pkg") when Julia is installed in a
prefix where typical user does not have write access.

Please just confirm there wasn't a good reason not to use `tempname`. BTW, I can also update the docs for that function to say that it "Generate a unique temporary file or directory name", not just a "temporary filename". Or even better, a "temporary file or directory path". Right?
