### PR TITLE
Faster and more capable hist

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -516,7 +516,7 @@ end
 
 ## nice-valued ranges for histograms
 
-function histrange{T<:FloatingPoint,N}(v::AbstractArray{T,N}, n::Integer)
+function histrange{T<:FloatingPoint}(v::AbstractArray{T}, n::Integer)
     if length(v) == 0
         return 0.0:1.0:0.0
     end
@@ -540,7 +540,7 @@ function histrange{T<:FloatingPoint,N}(v::AbstractArray{T,N}, n::Integer)
     start:step:(start + nm1*step)
 end
 
-function histrange{T<:Integer,N}(v::AbstractArray{T,N}, n::Integer)
+function histrange{T<:Integer}(v::AbstractArray{T}, n::Integer)
     if length(v) == 0
         return 0:1:0
     end
@@ -564,6 +564,17 @@ function histrange{T<:Integer,N}(v::AbstractArray{T,N}, n::Integer)
     start = step*(ceil(lo/step)-1)
     nm1 = iceil((hi - start)/step)
     start:step:(start + nm1*step)
+end
+
+function histrange{T}(v::AbstractArray{T}, n::Integer)
+    if isempty(v)
+        return range(zero(T), one(T)/1, 0)
+    end
+    lo, hi = extrema(v)
+    if hi == lo
+        return range(lo, one(T)/1, 1)
+    end
+    range(lo, (hi-lo)/n, n+1)
 end
 
 ## midpoints of intervals

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -583,9 +583,25 @@ function hist!{HT}(h::AbstractArray{HT}, v::AbstractVector, edg::AbstractVector;
         fill!(h, zero(HT))
     end
     for x in v
-        i = searchsortedfirst(edg, x)-1
+        i = searchsortedfirst(edg, x, Order.Forward)-1
         if 1 <= i <= n
             h[i] += 1
+        end
+    end
+    edg, h
+end
+
+function hist!{HT}(h::AbstractArray{HT}, v::AbstractVector, edg::Range; init::Bool=true)
+    n = length(edg) - 1
+    length(h) == n || error("length(h) must equal length(edg) - 1.")
+    if init
+        fill!(h, zero(HT))
+    end
+    step(edg) <= 0 && error("step(edg) must be positive")
+    for x in v
+        f = (x-first(edg))/step(edg)
+        if 0 < f <= n
+            h[iceil(f)] += 1
         end
     end
     edg, h
@@ -641,4 +657,3 @@ hist2d(v::AbstractMatrix, n1::Integer, n2::Integer) =
     hist2d(v, histrange(sub(v,:,1),n1), histrange(sub(v,:,2),n2))
 hist2d(v::AbstractMatrix, n::Integer) = hist2d(v, n, n)
 hist2d(v::AbstractMatrix) = hist2d(v, sturges(size(v,1)))
-


### PR DESCRIPTION
In https://groups.google.com/d/msg/julia-users/pqHDmP-VJEc/BNFnHIIHV_QJ, some limitations of our `hist` function were exposed. This PR should largely fix those problems, but has at least one controversial element.

The first commit includes a version of `hist` specialized for Ranges. The problem is that it's not quite as careful about floating-point roundoff as the original (I expect this difference to cause a Travis failure, so a decision is needed here). For reference, avoiding the keyword argument results in a 3x speed improvement and a huge reduction in memory usage; the version specialized for Ranges only adds a further improvement of 60%. Seems nice to have, but if folks prefer we could get rid of the specialized version.

The second commit makes `hist(x, 200)` work even for `FixedPoint` numbers (for example).
