### PR TITLE
Consistent varargs specialization in stagedfunctions (fix #8944)

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -469,7 +469,7 @@ static jl_value_t *ml_matches(jl_methlist_t *ml, jl_value_t *type,
 
 static jl_function_t *cache_method(jl_methtable_t *mt, jl_tuple_t *type,
                                    jl_function_t *method, jl_tuple_t *decl,
-                                   jl_tuple_t *sparams, int isstaged)
+                                   jl_tuple_t *sparams)
 {
     size_t i;
     int need_guard_entries = 0;
@@ -724,7 +724,7 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tuple_t *type,
     // in general, here we want to find the biggest type that's not a
     // supertype of any other method signatures. so far we are conservative
     // and the types we find should be bigger.
-    if (!isstaged && jl_tuple_len(type) > mt->max_args &&
+    if (!mt->defs->isstaged && jl_tuple_len(type) > mt->max_args &&
         jl_is_vararg_type(jl_tupleref(decl,jl_tuple_len(decl)-1))) {
         size_t nspec = mt->max_args + 2;
         jl_tuple_t *limited = jl_alloc_tuple(nspec);
@@ -1031,7 +1031,7 @@ static jl_function_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_tuple_t *tt, in
             JL_GC_POP();
             if (!cache)
                 return func;
-            return cache_method(mt, tt, func, (jl_tuple_t*)m->sig, jl_null, m->isstaged);
+            return cache_method(mt, tt, func, (jl_tuple_t*)m->sig, jl_null);
         }
         JL_GC_POP();
         return jl_bottom_func;
@@ -1061,7 +1061,7 @@ static jl_function_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_tuple_t *tt, in
     if (!cache)
         nf = func;
     else
-        nf = cache_method(mt, tt, func, newsig, env, 0);
+        nf = cache_method(mt, tt, func, newsig, env);
     JL_GC_POP();
     return nf;
 }
@@ -1735,7 +1735,7 @@ jl_value_t *jl_gf_invoke(jl_function_t *gf, jl_tuple_t *types,
                                                           jl_tuple_len(tpenv)/2);
             }
         }
-        mfunc = cache_method(m->invokes, tt, m->func, newsig, tpenv, 0);
+        mfunc = cache_method(m->invokes, tt, m->func, newsig, tpenv);
         JL_GC_POP();
     }
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 # linalg tests take the longest - start them off first
 testnames = [
     "linalg", "core", "keywordargs", "numbers", "strings", "dates",
-    "collections", "hashing", "remote", "iobuffer", "arrayops", "reduce", "reducedim",
+    "collections", "hashing", "remote", "iobuffer", "staged", "arrayops",
+    "reduce", "reducedim",
     "simdloop", "blas", "fft", "dsp", "sparse", "bitarray", "math",
     "functional", "bigint", "sorting", "statistics", "spawn",
     "backtrace", "priorityqueue", "arpack", "file", "suitesparse", "version",
@@ -9,7 +10,7 @@ testnames = [
     "floatapprox", "readdlm", "reflection", "regex", "float16", "combinatorics",
     "sysinfo", "rounding", "ranges", "mod2pi", "euler", "show",
     "lineedit", "replcompletions", "repl", "test", "goto",
-    "llvmcall", "grisu", "nullable", "meta", "staged", "profile",
+    "llvmcall", "grisu", "nullable", "meta", "profile",
     "libgit2"
 ]
 

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -53,8 +53,17 @@ splat2(1:5, 3:3)
 splat2(3, 3:5)
 @test takebuf_string(stagediobuf) == "($intstr,UnitRange{$intstr})"
 
-
+# varargs specialization with parametric stagedfunctions (issue #8944)
+stagedfunction splat3{T,N}(A::AbstractArray{T,N}, indx::RangeIndex...)
+    print(stagediobuf, indx)
+    :(nothing)
+end
 A = rand(5,5,3);
+splat3(A, 1:2, 1:2, 1)
+@test takebuf_string(stagediobuf) == "(UnitRange{$intstr},UnitRange{$intstr},$intstr)"
+splat3(A, 1:2, 1, 1:2)
+@test takebuf_string(stagediobuf) == "(UnitRange{$intstr},$intstr,UnitRange{$intstr})"
+
 B = slice(A, 1:3, 2, 1:3);
 stagedfunction mygetindex(S::SubArray, indexes::Real...)
     T, N, A, I = S.parameters


### PR DESCRIPTION
This is basically an alternative version of @mlubin's fix. Anyone who is using stagedfunctions in their own code may want to test, but for me this appears likely to finally clear the path to merging the SubArray work. I'll wait until the Travis test clears, of course. (Sadly, `make testall` now force-reboots my laptop about 10% of the time, presumably due to memory-exhaustion, so I run it less and less. Thank goodness for Travis.)

While I would appreciate a code-review from Dr. Bezanson, Mr. Bezanson need not bother. Dr. Bezanson can clean up any messes I make, later.
