### PR TITLE
ByteVec: immediate / remote immutable byte vectors + intrinsics.

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -128,7 +128,7 @@ export
     Int32, Int64, Int128, Ptr, Real, Signed, UInt, UInt8, UInt16, UInt32,
     UInt64, UInt128, Unsigned,
     # string types
-    Char, ASCIIString, ByteString, DirectIndexString, AbstractString, UTF8String,
+    Char, ByteVec, ASCIIString, ByteString, DirectIndexString, AbstractString, UTF8String,
     # errors
     BoundsError, DivideError, DomainError, Exception,
     InexactError, InterruptException, MemoryError, OverflowError,
@@ -195,9 +195,19 @@ bitstype 128 UInt128 <: Unsigned
 
 if is(Int,Int64)
     typealias UInt UInt64
+    immutable ByteVec <: DenseArray{UInt8,1}
+        x::Int128
+    end
 else
     typealias UInt UInt32
+    immutable ByteVec <: DenseArray{UInt8,1}
+        x::Int64
+    end
 end
+
+## kind of want this but doesn't work:
+#
+# bitstype 128 ByteVec <: DenseArray{UInt8,1}
 
 abstract Exception
 

--- a/base/bytes.jl
+++ b/base/bytes.jl
@@ -4,14 +4,10 @@ export ByteVec, Str
 ByteVec(a::Vector{UInt8}) = ccall(:jl_bytevec, ByteVec, (Ptr{UInt8}, Csize_t), a, length(a))
 ByteVec(s::AbstractString) = ByteVec(bytestring(s).data)
 
-length(b::ByteVec) = box(Int, bytevec_len(unbox(typeof(b.x), b.x)))
 size(b::ByteVec) = (length(b),)
-
-function getindex(b::ByteVec, i::Int)
-    1 <= i <= length(b) || throw(BoundsError())
-    box(Uint8, bytevec_ref(unbox(typeof(b.x), b.x), unbox(Int, i)))
-end
-getindex(b::ByteVec, i::Real) = b[Int(i)]
+length(b::ByteVec) = box(Int, bytevec_len(unbox(typeof(b.x), b.x)))
+getindex(b::ByteVec, i::Real) =
+    box(Uint8, bytevec_ref(unbox(typeof(b.x), b.x), unbox(Int, Int(i))))
 
 # ==(x::ByteVec, y::ByteVec) = bytevec_eq(x, y)
 # cmp(x::ByteVec, y::ByteVec) = bytevec_cmp(x, y)

--- a/base/bytes.jl
+++ b/base/bytes.jl
@@ -67,12 +67,13 @@ end
 
 function next(s::Str, i::Int)
     x = bswap(getu32(s.data, i))
-    n = max(1, leading_ones(x))
+    l = leading_ones(x)
+    n = max(1, l)
     y = ((0x808080 $ x) << n) >>> (32 - 7n)
     z = (((y >>> 24) & 0xff) << 18) |
         (((y >>> 16) & 0xff) << 12) |
         (((y >>>  8) & 0xff) <<  6) | (y & 0xff)
-    return Char(z), i + n
+    ifelse(l == 1, '\ufffd', Char(z)), i + n
 end
 
 const mask = div(typemax(UInt),typemax(UInt8))

--- a/base/bytes.jl
+++ b/base/bytes.jl
@@ -58,16 +58,21 @@ immutable Str <: AbstractString
 end
 Str(s::AbstractString) = Str(ByteVec(s))
 
-function endof(s::Str)
+@inline function endof(s::Str)
     n = length(s.data)
     @inbounds u = getu32(s.data, n-3)
     x = (u & 0xc0c0c0c0) $ 0x80808080
     n - leading_zeros(x) >>> 3
 end
 
-@inline function next(s::Str, i::Int)
-    x = s.data.x
-    box(Char, bytevec_utf8_ref(unbox(typeof(x), x), unbox(Int, i))), i + 1
+function next(s::Str, i::Int)
+    x = bswap(getu32(s.data, i))
+    n = max(1, leading_ones(x))
+    y = ((0x808080 $ x) << n) >>> (32 - 7n)
+    z = (((y >>> 24) & 0xff) << 18) |
+        (((y >>> 16) & 0xff) << 12) |
+        (((y >>>  8) & 0xff) <<  6) | (y & 0xff)
+    return Char(z), i + n
 end
 
 const mask = div(typemax(UInt),typemax(UInt8))

--- a/base/bytes.jl
+++ b/base/bytes.jl
@@ -67,16 +67,16 @@ end
 
 function next(s::Str, k::Int)
     a = bswap(getu32(s.data, k))
+    0 <= reinterpret(Int32, a) && return Char(a >> 24), k + 1
     l = leading_ones(a)
-    n = l + (~a >> 31)
-    b = (a << n >> n) $ 0x808080
-    r = 32 - 8n
+    b = (a << l >> l) $ 0x808080
+    r = 32 - 8l
     c = b >> r
     t = (l != 1) & (l <= 4) & ((b & 0xc0c0c0) >> r == 0)
     d = ( (c >> 24)         << 18) |
         (((c >> 16) & 0xff) << 12) |
         (((c >>  8) & 0xff) <<  6) | (c & 0xff)
-    ifelse(t, Char(d), '\ufffd'), k + ifelse(t, n, 1)
+    ifelse(t, Char(d), '\ufffd'), k + ifelse(t, l, 1)
 end
 
 const mask = div(typemax(UInt),typemax(UInt8))

--- a/base/bytes.jl
+++ b/base/bytes.jl
@@ -1,0 +1,68 @@
+import Core.ByteVec
+export ByteVec, Str
+
+ByteVec(a::Vector{UInt8}) = ccall(:jl_bytevec, ByteVec, (Ptr{UInt8}, Csize_t), a, length(a))
+ByteVec(s::AbstractString) = ByteVec(bytestring(s).data)
+
+length(b::ByteVec) = box(Int, bytevec_len(unbox(typeof(b.x), b.x)))
+size(b::ByteVec) = (length(b),)
+
+function getindex(b::ByteVec, i::Int)
+    1 <= i <= length(b) || throw(BoundsError())
+    box(Uint8, bytevec_ref(unbox(typeof(b.x), b.x), unbox(Int, i)))
+end
+getindex(b::ByteVec, i::Real) = b[Int(i)]
+
+# ==(x::ByteVec, y::ByteVec) = bytevec_eq(x, y)
+# cmp(x::ByteVec, y::ByteVec) = bytevec_cmp(x, y)
+# isless(x::ByteVec, y::ByteVec) = cmp(x, y) < 0
+
+start(b::ByteVec) = 1
+next(b::ByteVec, i::Int) = (b[i], i+1)
+done(b::ByteVec, i::Int) = length(b) < i
+
+## ByteVec-based string type ##
+
+immutable Str <: AbstractString
+    data::ByteVec
+end
+Str(s::AbstractString) = Str(ByteVec(s))
+
+function endof(s::Str)
+    d = s.data
+    i = length(d)
+    i == 0 && return i
+    while !is_utf8_start(d[i])
+        i -= 1
+    end
+    i
+end
+
+function length(s::Str)
+    d = s.data
+    n = 0
+    for i = 1:length(s.data)
+        n += is_utf8_start(d[i])
+    end
+    return n
+end
+
+function next(s::Str, i::Int)
+    d = s.data
+    a::UInt32 = d[i]
+    a < 0x80 && return Char(a), i+1
+    # is_utf8_start(a) || error("invalid UTF-8 character index")
+    b::UInt32 = a << 6 + d[i+1]
+    a < 0xe0 && return Char(b - 0x00003080), i+2
+    c::UInt32 = b << 6 + d[i+2]
+    a < 0xf0 && return Char(c - 0x000e2080), i+3
+    return Char(c << 6 + d[i+3] - 0x03c82080), i+4
+end
+
+## overload methods for efficiency ##
+
+sizeof(s::Str) = length(s.data)
+
+isless(x::Str, y::Str) = isless(x.data, y.data)
+   cmp(x::Str, y::Str) =    cmp(x.data, y.data)
+

--- a/base/bytes.jl
+++ b/base/bytes.jl
@@ -59,13 +59,10 @@ end
 Str(s::AbstractString) = Str(ByteVec(s))
 
 function endof(s::Str)
-    d = s.data
-    i = length(d)
-    i == 0 && return i
-    @inbounds while !is_utf8_start(d[i])
-        i -= 1
-    end
-    i
+    n = length(s.data)
+    @inbounds u = getu32(s.data, n-3)
+    x = (u & 0xc0c0c0c0) $ 0x80808080
+    n - leading_zeros(x) >>> 3
 end
 
 function length(s::Str)

--- a/base/bytes.jl
+++ b/base/bytes.jl
@@ -10,8 +10,8 @@ getindex(b::ByteVec, i::Real) =
     box(Uint8, bytevec_ref(unbox(typeof(b.x), b.x), unbox(Int, Int(i))))
 getu32(b::ByteVec, i::Int) =
     box(Uint32, bytevec_ref32(unbox(typeof(b.x), b.x), unbox(Int, i)))
-
-# ==(x::ByteVec, y::ByteVec) = bytevec_eq(x, y)
+==(a::ByteVec, b::ByteVec) =
+    box(Bool, bytevec_eq(unbox(typeof(a.x), a.x), unbox(typeof(b.x), b.x)))
 # cmp(x::ByteVec, y::ByteVec) = bytevec_cmp(x, y)
 # isless(x::ByteVec, y::ByteVec) = cmp(x, y) < 0
 
@@ -61,6 +61,7 @@ end
 
 sizeof(s::Str) = length(s.data)
 
-isless(x::Str, y::Str) = isless(x.data, y.data)
-   cmp(x::Str, y::Str) =    cmp(x.data, y.data)
+    ==(s::Str, t::Str) =     ==(s.data, t.data)
+isless(s::Str, t::Str) = isless(s.data, t.data)
+   cmp(s::Str, t::Str) =    cmp(s.data, t.data)
 

--- a/base/bytes.jl
+++ b/base/bytes.jl
@@ -77,16 +77,8 @@ function length(s::Str)
 end
 
 @inline function next(s::Str, i::Int)
-    u = getu32(s.data, i)
-    a::UInt32 = u & 0xff
-    a < 0x80 && return Char(a), i+1
-    is_utf8_start(a) || error("invalid UTF-8 character index")
-    b::UInt32 = a << 6 + (u >> 8) & 0xff
-    a < 0xe0 && return Char(b - 0x00003080), i+2
-    c::UInt32 = b << 6 + (u >> 16) & 0xff
-    a < 0xf0 && return Char(c - 0x000e2080), i+3
-    d::Uint32 = c << 6 + (u >> 24) & 0xff
-                return Char(d - 0x03c82080), i+4
+    x = s.data.x
+    box(Char, bytevec_utf8_ref(unbox(typeof(x), x), unbox(Int, i))), i + 1
 end
 
 ## overload methods for efficiency ##

--- a/base/bytes.jl
+++ b/base/bytes.jl
@@ -6,7 +6,12 @@ ByteVec(s::AbstractString) = ByteVec(bytestring(s).data)
 
 size(b::ByteVec) = (length(b),)
 
-length(b::ByteVec) = box(Int, bytevec_len(unbox(typeof(b.x), b.x)))
+function length(b::ByteVec)
+    here = ((b.x >>> 8*(sizeof(b.x)-1)) % Int) & 255
+    there = -(b.x >> 8*sizeof(Int)) % Int
+    ifelse(b.x < 0, there, here)
+end
+
 getindex(b::ByteVec, i::Real) =
     box(Uint8, bytevec_ref(unbox(typeof(b.x), b.x), unbox(Int, Int(i))))
 getu32(b::ByteVec, i::Int) =

--- a/base/bytes.jl
+++ b/base/bytes.jl
@@ -28,17 +28,16 @@ function endof(s::Str)
     d = s.data
     i = length(d)
     i == 0 && return i
-    while !is_utf8_start(d[i])
+    @inbounds while !is_utf8_start(d[i])
         i -= 1
     end
     i
 end
 
 function length(s::Str)
-    d = s.data
     n = 0
-    for i = 1:length(s.data)
-        n += is_utf8_start(d[i])
+    @inbounds for b in s.data
+        n += is_utf8_start(b)
     end
     return n
 end

--- a/base/bytes.jl
+++ b/base/bytes.jl
@@ -70,7 +70,7 @@ end
     box(Char, bytevec_utf8_ref(unbox(typeof(x), x), unbox(Int, i))), i + 1
 end
 
-const mask = Int == Int64 ? 0x0101010101010101 : 0x01010101
+const mask = div(typemax(UInt),typemax(UInt8))
 
 function length(s::Str)
     x = s.data.x

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -30,6 +30,7 @@ export
     BitArray,
     BitMatrix,
     BitVector,
+    ByteVec,
     CFILE,
     Cmd,
     Colon,

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -111,9 +111,9 @@ const .≠ = .!=
 <<(x,y::Int32)    = no_op_err("<<", typeof(x))
 >>(x,y::Int32)    = no_op_err(">>", typeof(x))
 >>>(x,y::Int32)   = no_op_err(">>>", typeof(x))
-<<(x,y::Integer)  = x << convert(Int32,y)
->>(x,y::Integer)  = x >> convert(Int32,y)
->>>(x,y::Integer) = x >>> convert(Int32,y)
+<<(x,y::Integer)  = x << (y % Int32)
+>>(x,y::Integer)  = x >> (y % Int32)
+>>>(x,y::Integer) = x >>> (y % Int32)
 
 # fallback div, fld, and cld implementations
 # NOTE: C89 fmod() and x87 FPREM implicitly provide truncating float division,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -80,6 +80,7 @@ const DL_LOAD_PATH = ByteString[]
 
 # strings & printing
 include("char.jl")
+include("bytes.jl")
 include("ascii.jl")
 include("utf8.jl")
 include("utf16.jl")

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -24,7 +24,7 @@ const utf8_trailing = [
     2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, 3,3,3,3,3,3,3,3,4,4,4,4,5,5,5,5,
 ]
 
-is_utf8_start(byte::UInt8) = ((byte&0xc0)!=0x80)
+is_utf8_start(byte::Integer) = (byte & 0xc0) != 0x80
 
 ## required core functionality ##
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -396,6 +396,21 @@ jl_tuple_t *jl_tuple_fill(size_t n, jl_value_t *v)
     return tup;
 }
 
+DLLEXPORT jl_bytevec_struct_t jl_bytevec(const uint8_t *data, size_t n)
+{
+    jl_bytevec_struct_t b;
+    if (n < 2*sizeof(void*)) {
+        memcpy(b.here.data, data, n);
+        memset(b.here.data + n, 0, (2*sizeof(void*)-1) - n);
+        b.here.length = n;
+    } else {
+        b.there.data = allocb(n);
+        memcpy(b.there.data, data, n);
+        b.there.neglen = -n;
+    }
+    return b;
+}
+
 DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t fptr, jl_value_t *env,
                                         jl_lambda_info_t *linfo)
 {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1016,9 +1016,9 @@ void jl_init_primitives(void)
     add_builtin_func("tupleref",  jl_f_tupleref);
     add_builtin_func("tuplelen",  jl_f_tuplelen);
     add_builtin_func("getfield",  jl_f_get_field);
-    add_builtin_func("setfield!",  jl_f_set_field);
+    add_builtin_func("setfield!", jl_f_set_field);
     add_builtin_func("fieldtype", jl_f_field_type);
-    add_builtin_func("_expr", jl_f_new_expr);
+    add_builtin_func("_expr",     jl_f_new_expr);
 
     add_builtin_func("arraylen", jl_f_arraylen);
     add_builtin_func("arrayref", jl_f_arrayref);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -236,6 +236,8 @@ static Type *T_pfloat32;
 static Type *T_float64;
 static Type *T_pfloat64;
 static Type *T_void;
+static Type *T_vec_2word_ints;
+static Type *T_vec_2word_bytes;
 
 // type-based alias analysis nodes.  Indentation of comments indicates hierarchy.
 static MDNode* tbaa_user;           // User data
@@ -4228,6 +4230,9 @@ static void init_julia_llvm_env(Module *m)
     T_float64 = Type::getDoubleTy(getGlobalContext());
     T_pfloat64 = PointerType::get(T_float64, 0);
     T_void = Type::getVoidTy(jl_LLVMContext);
+    // vector types for byte vector code generation
+    T_vec_2word_ints = VectorType::get(T_size, 2);
+    T_vec_2word_bytes = VectorType::get(T_int8, 2*sizeof(void*));
 
     // This type is used to create undef Values which carry
     // metadata.

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -215,22 +215,25 @@ static Type *jl_ppvalue_llvmt;
 static Type* jl_parray_llvmt;
 static FunctionType *jl_func_sig;
 static Type *jl_pfptr_llvmt;
-static Type *T_int1;
-static Type *T_int8;
+
+static IntegerType *T_int1;
+static IntegerType *T_int8;
+static IntegerType *T_uint8;
+static IntegerType *T_int16;
+static IntegerType *T_uint16;
+static IntegerType *T_int32;
+static IntegerType *T_uint32;
+static IntegerType *T_int64;
+static IntegerType *T_uint64;
+static IntegerType *T_char;
+static IntegerType *T_size;
+
 static Type *T_pint8;
-static Type *T_uint8;
-static Type *T_int16;
 static Type *T_pint16;
-static Type *T_uint16;
-static Type *T_int32;
 static Type *T_pint32;
-static Type *T_uint32;
-static Type *T_int64;
 static Type *T_pint64;
-static Type *T_uint64;
-static Type *T_char;
-static Type *T_size;
 static Type *T_psize;
+
 static Type *T_float32;
 static Type *T_pfloat32;
 static Type *T_float64;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4663,6 +4663,7 @@ static void init_julia_llvm_env(Module *m)
     // LoopRotate strips metadata from terminator, so run LowerSIMD afterwards
     FPM->add(createLowerSimdLoopPass());        // Annotate loop marked with "simdloop" as LLVM parallel loop
     FPM->add(createLICMPass());                 // Hoist loop invariants
+    FPM->add(createEarlyCSEPass());             // Common subexpression elimination
     FPM->add(createLoopUnswitchPass());         // Unswitch loops.
     // Subsequent passes not stripping metadata from terminator
 #ifndef INSTCOMBINE_BUG

--- a/src/gc.c
+++ b/src/gc.c
@@ -764,6 +764,11 @@ static void push_root(jl_value_t *v, int d)
                 gc_push_root(elt, d);
         }
     }
+    else if (vt == (jl_value_t*)jl_bytevec_type) {
+        jl_bytevec_struct_t b = *(jl_bytevec_struct_t*)jl_data_ptr(v);
+        if (b.there.neglen < 0)
+            gc_setmark_buf(b.there.data);
+    }
     else if (((jl_datatype_t*)(vt))->name == jl_array_typename) {
         jl_array_t *a = (jl_array_t*)v;
         if (a->how == 3) {

--- a/src/init.c
+++ b/src/init.c
@@ -1102,6 +1102,8 @@ void jl_get_builtin_hooks(void)
     jl_bounds_exception    = jl_new_struct((jl_datatype_t*)core("BoundsError"));
     jl_memory_exception    = jl_new_struct((jl_datatype_t*)core("MemoryError"));
 
+    jl_bytevec_type = (jl_datatype_t*)core("ByteVec");
+    jl_bytevec_type->pointerfree = 0;
     jl_ascii_string_type = (jl_datatype_t*)core("ASCIIString");
     jl_utf8_string_type = (jl_datatype_t*)core("UTF8String");
     jl_symbolnode_type = (jl_datatype_t*)core("SymbolNode");

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1228,7 +1228,7 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         builder.CreateBr(done);
 
         builder.SetInsertPoint(there_or_utf8);
-        cond = check_bounds ? is_here : builder.CreateAnd(is_here, here_inbounds);
+        cond = check_bounds ? builder.CreateAnd(is_here, here_inbounds) : is_here;
         builder.CreateCondBr(cond, here_utf8, check_bounds ? there_or_oob : there);
 
         builder.SetInsertPoint(here_utf8);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1051,6 +1051,7 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         Value *here_len = builder.CreateZExt(hi_byte, T_size);
         Value *is_here = builder.CreateICmpSGE(hi_byte, ConstantInt::get(T_uint8, 0));
         builder.CreateCondBr(
+            !check_bounds ? is_here :
             builder.CreateAnd(is_here, builder.CreateICmpULT(i, here_len)),
             here, check_bounds ? check : there
         );

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1077,7 +1077,7 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         Value *lo_word = builder.CreateExtractElement(words, ConstantInt::get(T_int32, 0));
         Value *addr = builder.CreateAdd(lo_word, i);
         Value *ptr = builder.CreateIntToPtr(addr, T_pint8);
-        Value *there_byte = builder.CreateLoad(ptr, false);
+        Value *there_byte = tbaa_decorate(tbaa_const, builder.CreateLoad(ptr, false));
         builder.CreateBr(cont);
 
         // raise out-of-bounds error

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -37,7 +37,7 @@ namespace JL_I {
         abs_float, copysign_float, flipsign_int, select_value,
         sqrt_llvm, powi_llvm,
         // byte vectors
-        bytevec_ref, bytevec_ref32, bytevec_utf8_ref,
+        bytevec_ref, bytevec_ref32,
         // pointer access
         pointerref, pointerset, pointertoref,
         // c interface
@@ -1187,109 +1187,6 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         builder.Insert(ret);
         return ret;
     }
-    HANDLE(bytevec_utf8_ref,2) {
-        Value *b = JL_INT(x);
-        Value *i = builder.CreateSub(JL_INT(y), ConstantInt::get(T_size, 1));
-        bool check_bounds =
-#if CHECK_BOUNDS==1
-            ((ctx->boundsCheck.empty() || ctx->boundsCheck.back() == true) &&
-             jl_compileropts.check_bounds != JL_COMPILEROPT_CHECK_BOUNDS_OFF) ||
-              jl_compileropts.check_bounds == JL_COMPILEROPT_CHECK_BOUNDS_ON;
-#else
-            0;
-#endif
-        BasicBlock *here_ascii    = BasicBlock::Create(getGlobalContext(), "here_ascii", ctx->f);
-        BasicBlock *there_or_utf8 = BasicBlock::Create(getGlobalContext(), "there_or_utf8", ctx->f);
-        BasicBlock *here_utf8     = BasicBlock::Create(getGlobalContext(), "here_utf8", ctx->f);
-        BasicBlock *there_or_oob  = BasicBlock::Create(getGlobalContext(), "there_or_oob", ctx->f);
-        BasicBlock *there         = BasicBlock::Create(getGlobalContext(), "there", ctx->f);
-        BasicBlock *there_ascii   = BasicBlock::Create(getGlobalContext(), "there_ascii", ctx->f);
-        BasicBlock *decode_utf8   = BasicBlock::Create(getGlobalContext(), "decode_utf8", ctx->f);
-        BasicBlock *oob           = BasicBlock::Create(getGlobalContext(), "out_of_bounds", ctx->f);
-        BasicBlock *done          = BasicBlock::Create(getGlobalContext(), "done", ctx->f);
-
-        Value *is_here = builder.CreateICmpSGE(b, ConstantInt::get(b->getType(), 0));
-        Value *here_shifted = builder.CreateLShr(
-            b, builder.CreateZExt(builder.CreateShl(i, ConstantInt::get(T_size, 3)), b->getType())
-        );
-        Value *here_byte = builder.CreateTrunc(here_shifted, T_uint8);
-        Value *cond = builder.CreateAnd(
-            is_here, builder.CreateICmpSGE(here_byte, ConstantInt::get(T_uint8, 0))
-        );
-        Value *here_len = builder.CreateTrunc(
-            builder.CreateLShr(b, ConstantInt::get(b->getType(), 8*(2*sizeof(void*)-1))), T_size
-        );
-        Value *here_inbounds = builder.CreateICmpULT(i, here_len);
-        if (check_bounds) cond = builder.CreateAnd(cond, here_inbounds);
-        builder.CreateCondBr(cond, here_ascii, there_or_utf8);
-
-        builder.SetInsertPoint(here_ascii);
-        Value *here_ascii_val = builder.CreateZExt(here_byte, T_uint32);
-        builder.CreateBr(done);
-
-        builder.SetInsertPoint(there_or_utf8);
-        cond = check_bounds ? builder.CreateAnd(is_here, here_inbounds) : is_here;
-        builder.CreateCondBr(cond, here_utf8, check_bounds ? there_or_oob : there);
-
-        builder.SetInsertPoint(here_utf8);
-        Value *here_uint32 = builder.CreateTrunc(here_shifted, T_uint32);
-        builder.CreateBr(decode_utf8);
-
-        if (check_bounds) {
-            builder.SetInsertPoint(there_or_oob);
-            Value *there_len = builder.CreateSub(
-                ConstantInt::get(T_size, 0),
-                builder.CreateTrunc(
-                    builder.CreateAShr(b, ConstantInt::get(b->getType(), 8*sizeof(void*))),
-                    T_size
-                )
-            );
-            builder.CreateCondBr(
-                builder.CreateAnd(builder.CreateNot(is_here), builder.CreateICmpULT(i, there_len)),
-                there, oob
-            );
-
-            // raise out-of-bounds error
-            builder.SetInsertPoint(oob);
-            builder.CreateCall2(
-                prepare_call(jlthrow_line_func),
-                tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlboundserr_var))),
-                ConstantInt::get(T_int32, ctx->lineno)
-            );
-            builder.CreateUnreachable();
-        }
-
-        builder.SetInsertPoint(there);
-        Value *lo_word = builder.CreateTrunc(b, T_size);
-        Value *addr = builder.CreateAdd(lo_word, i);
-        Value *ptr = builder.CreateIntToPtr(addr, T_pint32);
-        Value *there_uint32 = tbaa_decorate(tbaa_const, builder.CreateLoad(ptr, false));
-        Value *there_byte = builder.CreateTrunc(there_uint32, T_uint8);
-        builder.CreateCondBr(
-            builder.CreateICmpSGE(there_byte, ConstantInt::get(T_uint8, 0)),
-            there_ascii, decode_utf8
-        );
-
-        builder.SetInsertPoint(there_ascii);
-        Value *there_ascii_val = builder.CreateZExt(there_byte, T_uint32);
-        builder.CreateBr(done);
-
-        builder.SetInsertPoint(decode_utf8);
-        PHINode *uint32 = PHINode::Create(T_uint32, 2);
-        uint32->addIncoming(here_uint32, here_utf8);
-        uint32->addIncoming(there_uint32, there);
-        // TODO: decode UTF-8 byte
-        Value *decode_utf8_val = builder.Insert(uint32);
-        builder.CreateBr(done);
-
-        builder.SetInsertPoint(done);
-        PHINode *ret = PHINode::Create(T_uint32, 3);
-        ret->addIncoming(here_ascii_val, here_ascii);
-        ret->addIncoming(there_ascii_val, there_ascii);
-        ret->addIncoming(decode_utf8_val, decode_utf8);
-        builder.Insert(ret);
-        return ret;
-    }
     HANDLE(neg_int,1) return builder.CreateSub(ConstantInt::get(t, 0), JL_INT(x));
     HANDLE(add_int,2) return builder.CreateAdd(JL_INT(x), JL_INT(y));
     HANDLE(sub_int,2) return builder.CreateSub(JL_INT(x), JL_INT(y));
@@ -1792,7 +1689,7 @@ extern "C" void jl_init_intrinsic_functions(void)
     ADD_I(abs_float); ADD_I(copysign_float);
     ADD_I(flipsign_int); ADD_I(select_value); ADD_I(sqrt_llvm);
     ADD_I(powi_llvm);
-    ADD_I(bytevec_ref); ADD_I(bytevec_ref32); ADD_I(bytevec_utf8_ref);
+    ADD_I(bytevec_ref); ADD_I(bytevec_ref32);
     ADD_I(pointerref); ADD_I(pointerset); ADD_I(pointertoref);
     ADD_I(checked_sadd); ADD_I(checked_uadd);
     ADD_I(checked_ssub); ADD_I(checked_usub);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1069,6 +1069,15 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
                 builder.CreateAnd(builder.CreateNot(is_here), builder.CreateICmpULT(i, there_len)),
                 there, oob
             );
+
+            // raise out-of-bounds error
+            builder.SetInsertPoint(oob);
+            builder.CreateCall2(
+                prepare_call(jlthrow_line_func),
+                tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlboundserr_var))),
+                ConstantInt::get(T_int32, ctx->lineno)
+            );
+            builder.CreateUnreachable();
         }
 
         // decode there byte (known to be in-bounds)
@@ -1078,17 +1087,6 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         Value *ptr = builder.CreateIntToPtr(addr, T_pint8);
         Value *there_byte = tbaa_decorate(tbaa_const, builder.CreateLoad(ptr, false));
         builder.CreateBr(cont);
-
-        // raise out-of-bounds error
-        if (check_bounds) {
-            builder.SetInsertPoint(oob);
-            builder.CreateCall2(
-                prepare_call(jlthrow_line_func),
-                tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlboundserr_var))),
-                ConstantInt::get(T_int32, ctx->lineno)
-            );
-            builder.CreateUnreachable();
-        }
 
         // merge branches
         builder.SetInsertPoint(cont);
@@ -1158,6 +1156,15 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
                 builder.CreateAnd(builder.CreateNot(is_here), builder.CreateICmpULT(i, there_len)),
                 there, oob
             );
+
+            // raise out-of-bounds error
+            builder.SetInsertPoint(oob);
+            builder.CreateCall2(
+                prepare_call(jlthrow_line_func),
+                tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlboundserr_var))),
+                ConstantInt::get(T_int32, ctx->lineno)
+            );
+            builder.CreateUnreachable();
         }
 
         // decode there byte (known to be in-bounds)
@@ -1167,17 +1174,6 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         Value *ptr = builder.CreateIntToPtr(addr, T_pint32);
         Value *there_uint32 = tbaa_decorate(tbaa_const, builder.CreateLoad(ptr, false));
         builder.CreateBr(cont);
-
-        // raise out-of-bounds error
-        if (check_bounds) {
-            builder.SetInsertPoint(oob);
-            builder.CreateCall2(
-                prepare_call(jlthrow_line_func),
-                tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlboundserr_var))),
-                ConstantInt::get(T_int32, ctx->lineno)
-            );
-            builder.CreateUnreachable();
-        }
 
         // merge branches
         builder.SetInsertPoint(cont);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -37,7 +37,7 @@ namespace JL_I {
         abs_float, copysign_float, flipsign_int, select_value,
         sqrt_llvm, powi_llvm,
         // byte vectors
-        bytevec_len, bytevec_ref, bytevec_ref32,
+        bytevec_ref, bytevec_ref32,
         bytevec_eq,
         // pointer access
         pointerref, pointerset, pointertoref,
@@ -1010,22 +1010,6 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
     Value *den;
     Value *typemin;
     switch (f) {
-    HANDLE(bytevec_len,1) {
-        Value *b = JL_INT(x);
-        Value *hi_byte = builder.CreateExtractElement(
-            builder.CreateBitCast(b, T_vec_2word_bytes),
-            ConstantInt::get(T_int32, 2*sizeof(void*)-1)
-        );
-        Value *hi_word = builder.CreateExtractElement(
-            builder.CreateBitCast(b, T_vec_2word_ints),
-            ConstantInt::get(T_int32, 1)
-        );
-        return builder.CreateSelect(
-            builder.CreateICmpSLT(hi_byte, ConstantInt::get(T_uint8, 0)),
-            builder.CreateSub(ConstantInt::get(T_size, 0), hi_word),
-            builder.CreateZExt(hi_byte, T_size)
-        );
-    }
     HANDLE(bytevec_ref,2) {
         Value *b = JL_INT(x);
         Value *i = builder.CreateSub(JL_INT(y), ConstantInt::get(T_size, 1));
@@ -1730,7 +1714,7 @@ extern "C" void jl_init_intrinsic_functions(void)
     ADD_I(abs_float); ADD_I(copysign_float);
     ADD_I(flipsign_int); ADD_I(select_value); ADD_I(sqrt_llvm);
     ADD_I(powi_llvm);
-    ADD_I(bytevec_len); ADD_I(bytevec_ref); ADD_I(bytevec_ref32);
+    ADD_I(bytevec_ref); ADD_I(bytevec_ref32);
     ADD_I(bytevec_eq);
     ADD_I(pointerref); ADD_I(pointerset); ADD_I(pointertoref);
     ADD_I(checked_sadd); ADD_I(checked_uadd);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -38,7 +38,6 @@ namespace JL_I {
         sqrt_llvm, powi_llvm,
         // byte vectors
         bytevec_ref, bytevec_ref32,
-        bytevec_eq,
         // pointer access
         pointerref, pointerset, pointertoref,
         // c interface
@@ -1167,51 +1166,6 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         builder.Insert(ret);
         return ret;
     }
-    HANDLE(bytevec_eq,2) {
-        Value *a = JL_INT(x);
-        Value *b = JL_INT(y);
-        BasicBlock *here  = BasicBlock::Create(getGlobalContext(), "here",  ctx->f);
-        BasicBlock *there = BasicBlock::Create(getGlobalContext(), "there", ctx->f);
-        BasicBlock *cont  = BasicBlock::Create(getGlobalContext(), "cont",  ctx->f);
-
-        Value *a_words = builder.CreateBitCast(a, T_vec_2word_ints);
-        Value *b_words = builder.CreateBitCast(b, T_vec_2word_ints);
-        Value *a_hi_word = builder.CreateExtractElement(a_words, ConstantInt::get(T_int32, 1));
-        Value *b_hi_word = builder.CreateExtractElement(b_words, ConstantInt::get(T_int32, 1));
-
-        builder.CreateCondBr(
-            builder.CreateOr(
-                builder.CreateICmpNE(a_hi_word, b_hi_word),
-                builder.CreateOr(
-                    builder.CreateICmpSGE(a_hi_word, ConstantInt::get(T_size, 0)),
-                    builder.CreateICmpSGE(a_hi_word, ConstantInt::get(T_size, 0))
-                )
-            ), here, there
-        );
-
-        builder.SetInsertPoint(here);
-        Value *here_eq = builder.CreateICmpEQ(a, b);
-        builder.CreateBr(cont);
-
-        builder.SetInsertPoint(there);
-        Value *a_lo_word = builder.CreateExtractElement(a_words, ConstantInt::get(T_int32, 0));
-        Value *b_lo_word = builder.CreateExtractElement(b_words, ConstantInt::get(T_int32, 0));
-        Value *cmp = builder.CreateCall3(
-            jl_Module->getOrInsertFunction("memcmp", T_int32, T_pint8, T_pint8, T_size, NULL),
-            builder.CreateIntToPtr(a_lo_word, T_pint8),
-            builder.CreateIntToPtr(b_lo_word, T_pint8),
-            builder.CreateNeg(a_hi_word)
-        );
-        Value *there_eq = builder.CreateICmpEQ(cmp, ConstantInt::get(T_int32, 0));
-        builder.CreateBr(cont);
-
-        builder.SetInsertPoint(cont);
-        PHINode *ret = PHINode::Create(T_int1, 2);
-        ret->addIncoming(here_eq, here);
-        ret->addIncoming(there_eq, there);
-        builder.Insert(ret);
-        return ret;
-    }
     HANDLE(neg_int,1) return builder.CreateSub(ConstantInt::get(t, 0), JL_INT(x));
     HANDLE(add_int,2) return builder.CreateAdd(JL_INT(x), JL_INT(y));
     HANDLE(sub_int,2) return builder.CreateSub(JL_INT(x), JL_INT(y));
@@ -1715,7 +1669,6 @@ extern "C" void jl_init_intrinsic_functions(void)
     ADD_I(flipsign_int); ADD_I(select_value); ADD_I(sqrt_llvm);
     ADD_I(powi_llvm);
     ADD_I(bytevec_ref); ADD_I(bytevec_ref32);
-    ADD_I(bytevec_eq);
     ADD_I(pointerref); ADD_I(pointerset); ADD_I(pointertoref);
     ADD_I(checked_sadd); ADD_I(checked_uadd);
     ADD_I(checked_ssub); ADD_I(checked_usub);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1101,13 +1101,14 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         BasicBlock *cont  = BasicBlock::Create(getGlobalContext(), "cont",  ctx->f);
 
         // branch: "here" or "there"
-        Value *words = builder.CreateBitCast(b, T_vec_2word_ints);
-        Value *bytes = builder.CreateBitCast(b, T_vec_2word_bytes);
-        Value *hi_byte = builder.CreateExtractElement(
-            bytes, ConstantInt::get(T_int32, 2*sizeof(void*)-1)
+        Value *is_here = builder.CreateICmpSGE(b, ConstantInt::get(b->getType(), 0));
+        Value *here_len = builder.CreateZExt(
+            builder.CreateTrunc(
+                builder.CreateLShr(
+                    b, ConstantInt::get(b->getType(), 8*(2*sizeof(void*)-1))
+                ), T_uint8
+            ), T_size
         );
-        Value *here_len = builder.CreateZExt(hi_byte, T_size);
-        Value *is_here = builder.CreateICmpSGE(hi_byte, ConstantInt::get(T_uint8, 0));
         builder.CreateCondBr(
             !check_bounds ? is_here :
             builder.CreateAnd(is_here, builder.CreateICmpULT(i, here_len)),
@@ -1131,8 +1132,13 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         // check bounds (here & there)
         if (check_bounds) {
             builder.SetInsertPoint(check);
-            Value *hi_word = builder.CreateExtractElement(words, ConstantInt::get(T_int32, 1));
-            Value *there_len = builder.CreateSub(ConstantInt::get(T_size, 0), hi_word);
+            Value *there_len = builder.CreateSub(
+                ConstantInt::get(T_size, 0),
+                builder.CreateTrunc(
+                   builder.CreateAShr(b, ConstantInt::get(b->getType(), 8*sizeof(void*))),
+                   T_size
+                )
+            );
             builder.CreateCondBr(
                 builder.CreateAnd(builder.CreateNot(is_here), builder.CreateICmpULT(i, there_len)),
                 there, oob
@@ -1141,7 +1147,7 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
 
         // decode there byte (known to be in-bounds)
         builder.SetInsertPoint(there);
-        Value *lo_word = builder.CreateExtractElement(words, ConstantInt::get(T_int32, 0));
+        Value *lo_word = builder.CreateTrunc(b, T_size);
         Value *addr = builder.CreateAdd(lo_word, i);
         Value *ptr = builder.CreateIntToPtr(addr, T_pint32);
         Value *there_uint32 = tbaa_decorate(tbaa_const, builder.CreateLoad(ptr, false));
@@ -1219,7 +1225,8 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
             Value *there_len = builder.CreateSub(
                 ConstantInt::get(T_size, 0),
                 builder.CreateTrunc(
-                    builder.CreateAShr(b, ConstantInt::get(b->getType(), 8*sizeof(void*))), T_size
+                    builder.CreateAShr(b, ConstantInt::get(b->getType(), 8*sizeof(void*))),
+                    T_size
                 )
             );
             builder.CreateCondBr(

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -27,6 +27,7 @@ jl_tuple_t *jl_tuple_type;
 jl_value_t *jl_tupletype_type;
 jl_datatype_t *jl_ntuple_type;
 jl_typename_t *jl_ntuple_typename;
+jl_datatype_t *jl_bytevec_type;
 jl_datatype_t *jl_tvar_type;
 jl_datatype_t *jl_uniontype_type;
 jl_datatype_t *jl_datatype_type;

--- a/src/julia.h
+++ b/src/julia.h
@@ -132,7 +132,7 @@ typedef struct {
         } here;
         struct {
             uint8_t *data;
-            long neglen;
+            intptr_t neglen;
         } there;
     };
 } jl_bytevec_struct_t;

--- a/src/julia.h
+++ b/src/julia.h
@@ -124,6 +124,19 @@ STATIC_INLINE int jl_array_ndimwords(uint32_t ndims)
     return (ndims < 3 ? 0 : ndims-2);
 }
 
+typedef struct {
+    union {
+        struct {
+            uint8_t data[2*sizeof(void*)-1];
+            uint8_t length;
+        } here;
+        struct {
+            uint8_t *data;
+            long neglen;
+        } there;
+    };
+} jl_bytevec_struct_t;
+
 typedef jl_value_t *(*jl_fptr_t)(jl_value_t*, jl_value_t**, uint32_t);
 
 typedef struct _jl_lambda_info_t {
@@ -308,6 +321,7 @@ extern DLLEXPORT jl_tuple_t *jl_tuple_type;
 extern DLLEXPORT jl_value_t *jl_tupletype_type;
 extern DLLEXPORT jl_datatype_t *jl_ntuple_type;
 extern DLLEXPORT jl_typename_t *jl_ntuple_typename;
+extern DLLEXPORT jl_datatype_t *jl_bytevec_type;
 extern DLLEXPORT jl_datatype_t *jl_tvar_type;
 extern DLLEXPORT jl_datatype_t *jl_task_type;
 
@@ -708,6 +722,9 @@ DLLEXPORT void *jl_unbox_voidpointer(jl_value_t *v);
 #define jl_is_long(x)    jl_is_int32(x)
 #define jl_long_type     jl_int32_type
 #endif
+
+// byte vectors
+DLLEXPORT jl_bytevec_struct_t jl_bytevec(const uint8_t *data, size_t n);
 
 // structs
 DLLEXPORT int         jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err);


### PR DESCRIPTION
I ended up going with @vtjnash's suggestion of representing this as an Int128 since that makes the code generation easier: you can cast the `Int128` to various vector types like `Uint8 x 8` or `Int x 2`, which are both handy for writing `bytevec_len` and `bytevec_ref` intrinsics.

The code generation is already pretty decent, e.g.:

```
julia> s = Str("Hello")
"Hello"

julia> @code_native sizeof(s)
    .section    __TEXT,__text,regular,pure_instructions
Filename: bytes.jl
Source line: 64
    push    RBP
    mov RBP, RSP
Source line: 64
    mov RAX, QWORD PTR [RDI + 8]
    vmovq   XMM0, QWORD PTR [RAX + 16]
    vmovq   XMM1, QWORD PTR [RAX + 8]
    vpunpcklqdq XMM0, XMM1, XMM0 ## xmm0 = xmm1[0],xmm0[0]
    vpextrq RAX, XMM0, 1
    neg RAX
    vpextrb ECX, XMM0, 15
    test    CL, CL
    cmovns  RAX, RCX
    pop RBP
    ret
```

One area to investigate optimization is to try to make sure that the checks involved in loading a single byte can be hoisted out of loops _and_ ideally, we want, instead of a loop with a branch inside of it a branch with a loop inside of each path, but that's a bit of a more tricky optimization than I think we're doing now. But with that code that iterates strings could really fly.

Next steps are to implement `bytevec_eq` and `bytevec_cmp` intrinsics. I know these aren't strictly necessary, but I suspect that the built-in versions can be made very efficient.
