### PR TITLE
New default help string

### DIFF
--- a/base/docs.jl
+++ b/base/docs.jl
@@ -318,4 +318,35 @@ end
 
 catdoc(md::MD...) = MD(md...)
 
+# REPL help
+
+const intro = doc"""
+  **Welcome to Julia $(string(VERSION)).** The full manual is available at
+
+      http://docs.julialang.org/
+
+  as well many great tutorials and learning resources:
+
+      http://julialang.org/learning/
+
+  For help on a specific function or macro, type `?` followed
+  by its name, e.g. `?fft`, `?@time` or `?html""`, and press
+  enter.
+
+  You can also use `apropos("...")` to search the documentation.
+  """
+
+function replhelp(ex)
+  if ex === :? || ex === :help
+    return intro
+  else
+    quote
+      # Backwards-compatible with the previous help system, for now
+      let doc = @doc $(esc(ex))
+        doc ≠ nothing ? doc : Base.Help.@help_ $(esc(ex))
+      end
+    end
+  end
+end
+
 end

--- a/base/help.jl
+++ b/base/help.jl
@@ -200,29 +200,7 @@ macro help_(ex)
 end
 
 macro help (ex)
-  if ex === :? || ex === :help
-    return esc(:(Base.Markdown.parse("""
-    Welcome to Julia. The full manual is available at
-
-        http://docs.julialang.org
-
-    as well many tutorials and learning resources here:
-
-        http://julialang.org/learning/
-
-    For help on a specific function or macro, type `?` followed
-    by its name, e.g. `?fft`, `?@time` or `?html""`, and press
-    enter.
-
-    You can also call `apropos("...")` to search the documentation.
-    """)))
-  else
-    quote
-      let doc = @doc $(esc(ex))
-        doc ≠ nothing ? doc : @help_ $(esc(ex))
-      end
-    end
-  end
+  Base.Docs.replhelp(ex)
 end
 
 end # module

--- a/base/help.jl
+++ b/base/help.jl
@@ -201,7 +201,21 @@ end
 
 macro help (ex)
   if ex === :? || ex === :help
-    return :(@help_ $(esc(ex)))
+    return esc(:(Base.Markdown.parse("""
+    Welcome to Julia. The full manual is available at
+
+        http://docs.julialang.org
+
+    as well many tutorials and learning resources here:
+
+        http://julialang.org/learning/
+
+    For help on a specific function or macro, type `?` followed
+    by its name, e.g. `?fft`, `?@time` or `?html""`, and press
+    enter.
+
+    You can also call `apropos("...")` to search the documentation.
+    """)))
   else
     quote
       let doc = @doc $(esc(ex))

--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -74,7 +74,7 @@ function terminline(io::IO, content::Vector)
 end
 
 function terminline(io::IO, md::String)
-  print_with_format(:normal, io, md)
+  print(io, md)
 end
 
 function terminline(io::IO, md::Bold)


### PR DESCRIPTION
The help string that appears when you type `??` or `?help` at the repl is pretty out of date. This one mentions the `?` help shortcut as well as the now-rather-useful julialang/learning.

Let me know if there's any other good help resources I could add on.
