### PR TITLE
fix `@doc`  for abstract types

### DIFF
--- a/base/docs.jl
+++ b/base/docs.jl
@@ -167,6 +167,7 @@ function docm(meta, def)
   isexpr(def′, :macro) && return namedoc(meta, def,
                                          symbol(string("@", namify(def′))))
   isexpr(def′, :type) && return namedoc(meta, def, namify(def′.args[2]))
+  isexpr(def′, :abstract) && return namedoc(meta, def, namify(def′))
   fexpr(def′) && return funcdoc(meta, def)
   isexpr(def, :macrocall) && (def = namify(def))
   return objdoc(meta, def)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1,0 +1,3 @@
+@doc "Doc abstract type" ->
+abstract C74685 <: AbstractArray
+@test stringmime("text/plain", Docs.doc(C74685))=="Doc abstract type\n"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ testnames = [
     "sysinfo", "rounding", "ranges", "mod2pi", "euler", "show",
     "lineedit", "replcompletions", "repl", "test", "goto",
     "llvmcall", "grisu", "nullable", "meta", "profile",
-    "libgit2"
+    "libgit2", "docs"
 ]
 
 if isdir(joinpath(JULIA_HOME, Base.DOCDIR, "examples"))


### PR DESCRIPTION
Documenting abstract types now works:

``` julia
@doc "Doc abstract type" ->
abstract C
Docs.doc(C)
# ->   Doc abstract type
```

I tried to add a  test for it but did not manage to compare two markdown strings.  How would I do that? `md"a"==md"a"` returns false.
