### PR TITLE
Improve docs for tempname() and tempdir()

### DIFF
--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -128,11 +128,11 @@ Filesystem
 
 .. function:: tempname()
 
-   Generate a unique temporary filename.
+   Generate a unique temporary file path.
 
 .. function:: tempdir()
 
-   Obtain the path of a temporary directory.
+   Obtain the path of a temporary directory (possibly shared with other processes).
 
 .. function:: mktemp()
 


### PR DESCRIPTION
I find that "filename" is quite confusing in the docs for `tempname`. I guess for most users "filename" means the part of the path up to the parent directory. The man page for `tempnam` doesn't say what's the definition of "filename", but I guess that's defined in POSIX. I think `path` is clearer, else you'd want to concatenate `tempdir()` and `tempname()` to get the path to a file.
