### PR TITLE
WIP: cleanup of output functions

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -14,7 +14,7 @@ import Base:
     AsyncStream,
     Display,
     display,
-    writemime,
+    write,
     AnyDict
 
 import ..LineEdit:
@@ -115,10 +115,10 @@ end
 function display(d::REPLDisplay, ::MIME"text/plain", x)
     io = outstream(d.repl)
     Base.have_color && write(io, answer_color(d.repl))
-    writemime(io, MIME("text/plain"), x)
+    write(io, TEXTPLAIN, x)
     println(io)
 end
-display(d::REPLDisplay, x) = display(d, MIME("text/plain"), x)
+display(d::REPLDisplay, x) = display(d, TEXTPLAIN, x)
 
 function print_response(repl::AbstractREPL, val::ANY, bt, show_value::Bool, have_color::Bool)
     repl.waserror = bt !== nothing

--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -31,7 +31,6 @@ import Base:
     start_reading,
     stop_reading,
     write,
-    writemime,
     reseteof
 
 ## TextTerminal ##

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -553,7 +553,7 @@ end
 writedlm(io, a; opts...) = writedlm(io, a, '\t'; opts...)
 writecsv(io, a; opts...) = writedlm(io, a, ','; opts...)
 
-writemime(io::IO, ::MIME"text/csv", a::AbstractVecOrMat) = writedlm(io, a, ',')
-writemime(io::IO, ::MIME"text/tab-separated-values", a::AbstractVecOrMat) = writedlm(io, a, '\t')
+write(io::IO, ::MIME"text/csv", a::AbstractVecOrMat) = writedlm(io, a, ',')
+write(io::IO, ::MIME"text/tab-separated-values", a::AbstractVecOrMat) = writedlm(io, a, '\t')
 
 end # module DataFmt

--- a/base/docs.jl
+++ b/base/docs.jl
@@ -224,7 +224,7 @@ end
 
 # Text / HTML objects
 
-import Base: print, writemime
+import Base: print, write
 
 export HTML, @html_str, @html_mstr
 
@@ -248,13 +248,13 @@ end
 function HTML(xs...)
   HTML() do io
     for x in xs
-      writemime(io, MIME"text/html"(), x)
+      write(io, TEXTHTML, x)
     end
   end
 end
 
-writemime(io::IO, ::MIME"text/html", h::HTML) = print(io, h.content)
-writemime(io::IO, ::MIME"text/html", h::HTML{Function}) = h.content(io)
+write(io::IO, ::MIME"text/html", h::HTML) = print(io, h.content)
+write(io::IO, ::MIME"text/html", h::HTML{Function}) = h.content(io)
 
 @doc "Create an `HTML` object from a literal string." ->
 macro html_str (s)
@@ -269,7 +269,7 @@ end
 function catdoc(xs::HTML...)
   HTML() do io
     for x in xs
-      writemime(io, MIME"text/html"(), x)
+      write(io, TEXTHTML, x)
     end
   end
 end
@@ -293,7 +293,7 @@ end
 
 print(io::IO, t::Text) = print(io, t.content)
 print(io::IO, t::Text{Function}) = t.content(io)
-writemime(io::IO, ::MIME"text/plain", t::Text) = print(io, t)
+write(io::IO, ::MIME"text/plain", t::Text) = print(io, t)
 
 @doc "Create a `Text` object from a literal string." ->
 macro text_str (s)
@@ -308,7 +308,7 @@ end
 function catdoc(xs::Text...)
   Text() do io
     for x in xs
-      writemime(io, MIME"text/plain"(), x)
+      write(io, TEXTPLAIN, x)
     end
   end
 end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1217,13 +1217,14 @@ export
     @MIME_str,
     reprmime,
     stringmime,
-    writemime,
     mimewritable,
     popdisplay,
     pushdisplay,
     redisplay,
     HTML,
     Text,
+    TEXTPLAIN,
+    TEXTHTML,
 
 # distributed arrays
     dfill,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1214,7 +1214,6 @@ export
     TextDisplay,
     istext,
     MIME,
-    @MIME,
     @MIME_str,
     reprmime,
     stringmime,

--- a/base/help.jl
+++ b/base/help.jl
@@ -115,7 +115,7 @@ function help(io::IO, fname::AbstractString, obj=0)
     if !found
         if isa(obj, DataType)
             print(io, "DataType   : ")
-            writemime(io, "text/plain", obj)
+            write(io, TEXTPLAIN, obj)
             println(io)
             println(io, "  supertype: ", super(obj))
             if obj.abstract
@@ -130,7 +130,7 @@ function help(io::IO, fname::AbstractString, obj=0)
                 println(io, "  fields   : ", obj.names)
             end
         elseif isgeneric(obj)
-            writemime(io, "text/plain", obj); println()
+            write(io, TEXTPLAIN, obj); println()
         else
             println(io, "Symbol not found. Falling back on apropos search ...")
             apropos(io, fname)

--- a/base/markdown/IPython/IPython.jl
+++ b/base/markdown/IPython/IPython.jl
@@ -20,7 +20,7 @@ function blocktex(stream::IO, md::MD, config::Config)
   end
 end
 
-writemime(io::IO, ::MIME"text/plain", tex::LaTeX) =
+write(io::IO, ::MIME"text/plain", tex::LaTeX) =
   print(io, '$', tex.formula, '$')
 
 term(io::IO, tex::LaTeX, cols) = print_with_format(:magenta, io, tex.formula)

--- a/base/markdown/Markdown.jl
+++ b/base/markdown/Markdown.jl
@@ -1,6 +1,6 @@
 module Markdown
 
-import Base: writemime
+import Base: write
 
 typealias String AbstractString
 

--- a/base/markdown/render/html.jl
+++ b/base/markdown/render/html.jl
@@ -106,7 +106,7 @@ export html
 
 html(md) = sprint(html, md)
 
-function writemime(io::IO, ::MIME"text/html", md::MD)
+function write(io::IO, ::MIME"text/html", md::MD)
   println(io, """<div class="markdown">""")
   html(io, md)
   println(io, """</div>""")

--- a/base/markdown/render/latex.jl
+++ b/base/markdown/render/latex.jl
@@ -12,18 +12,18 @@ function wrapinline(f, io, cmd)
     print(io, "}")
 end
 
-writemime(io::IO, ::MIME"text/latex", md::Content) =
-  writemime(io, "text/plain", md)
+write(io::IO, ::MIME"text/latex", md::Content) =
+  write(io, TEXTPLAIN, md)
 
-function writemime(io::IO, mime::MIME"text/latex", block::Block)
+function write(io::IO, mime::MIME"text/latex", block::Block)
   for md in block.content[1:end-1]
-    writemime(io::IO, mime, md)
+    write(io::IO, mime, md)
     println(io)
   end
-  writemime(io::IO, mime, block.content[end])
+  write(io::IO, mime, block.content[end])
 end
 
-function writemime{l}(io::IO, mime::MIME"text/latex", header::Header{l})
+function write{l}(io::IO, mime::MIME"text/latex", header::Header{l})
   tag = l < 4 ? "sub"^(l-1) * "section" : "sub"^(l-4) * "paragraph"
   wrapinline(io, tag) do
     print(io, header.text)
@@ -31,32 +31,34 @@ function writemime{l}(io::IO, mime::MIME"text/latex", header::Header{l})
   println(io)
 end
 
-function writemime(io::IO, ::MIME"text/latex", code::BlockCode)
+function write(io::IO, ::MIME"text/latex", code::BlockCode)
   wrapblock(io, "verbatim") do
     println(io, code.code)
   end
 end
 
-function writemime(io::IO, ::MIME"text/latex", code::InlineCode)
+function write(io::IO, ::MIME"text/latex", code::InlineCode)
   wrapinline(io, "texttt") do
     print(io, code.code)
   end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::Paragraph)
+function write(io::IO, ::MIME"text/latex", md::Paragraph)
   for md in md.content
     latex_inline(io, md)
   end
   println(io)
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::BlockQuote)
+const TEXTLATEX = MIME("text/latex")
+
+function write(io::IO, ::MIME"text/latex", md::BlockQuote)
   wrapblock(io, "quote") do
-    writemime(io, "text/latex", Block(md.content))
+    write(io, TEXTLATEX, Block(md.content))
   end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::List)
+function write(io::IO, ::MIME"text/latex", md::List)
   wrapblock(io, "itemize") do
     for item in md.content
       print(io, "\\item ")
@@ -68,23 +70,23 @@ end
 
 # Inline elements
 
-function writemime(io::IO, ::MIME"text/latex", md::Plain)
+function write(io::IO, ::MIME"text/latex", md::Plain)
   print(io, md.text)
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::Bold)
+function write(io::IO, ::MIME"text/latex", md::Bold)
   wrapinline(io, "textbf") do
     print(io, md.text)
   end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::Italic)
+function write(io::IO, ::MIME"text/latex", md::Italic)
   wrapinline(io, "emph") do
     print(io, md.text)
   end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::Image)
+function write(io::IO, ::MIME"text/latex", md::Image)
   wrapblock(io, "figure") do
     println(io, "\\centering")
     wrapinline(io, "includegraphics") do
@@ -98,13 +100,13 @@ function writemime(io::IO, ::MIME"text/latex", md::Image)
   end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::Link)
+function write(io::IO, ::MIME"text/latex", md::Link)
   wrapinline(io, "href") do
     print(io, md.url)
   end
   print(io, "{", md.text, "}")
 end
 
-latex_inline(io::IO, el::Content) = writemime(io, "text/latex", el)
+latex_inline(io::IO, el::Content) = write(io, TEXTLATEX, el)
 
-latex(md::Content) = stringmime("text/latex", md)
+latex(md::Content) = stringmime(TEXTLATEX, md)

--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -57,8 +57,8 @@ plaininline(io::IO, md::Italic) = print(io, "*", md.text, "*")
 
 plaininline(io::IO, md::Code) = print(io, "`", md.code, "`")
 
-plaininline(io::IO, x) = writemime(io, MIME"text/plain"(), x)
+plaininline(io::IO, x) = write(io, TEXTPLAIN, x)
 
-# writemime
+# write
 
-Base.writemime(io::IO, ::MIME"text/plain", md::MD) = plain(io, md)
+Base.write(io::IO, ::MIME"text/plain", md::MD) = plain(io, md)

--- a/base/markdown/render/rich.jl
+++ b/base/markdown/render/rich.jl
@@ -1,9 +1,9 @@
 function tohtml(io::IO, m::MIME"text/html", x)
-  writemime(io, m, x)
+  write(io, m, x)
 end
 
 function tohtml(io::IO, m::MIME"text/plain", x)
-  writemime(io, m, x)
+  write(io, m, x)
 end
 
 function tohtml(io::IO, m::MIME"image/png", img)
@@ -13,7 +13,7 @@ function tohtml(io::IO, m::MIME"image/png", img)
 end
 
 function tohtml(m::MIME"image/svg+xml", img)
-  writemime(io, m, img)
+  write(io, m, img)
 end
 
 # Display infrastructure

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -103,7 +103,7 @@ function url(m::Method)
     end
 end
 
-function writemime(io::IO, ::MIME"text/html", m::Method)
+function write(io::IO, ::MIME"text/html", m::Method)
     print(io, m.func.code.name)
     tv, decls, file, line = arg_decl_parts(m)
     if !isempty(tv)
@@ -126,7 +126,7 @@ function writemime(io::IO, ::MIME"text/html", m::Method)
     end
 end
 
-function writemime(io::IO, mime::MIME"text/html", mt::MethodTable)
+function write(io::IO, mime::MIME"text/html", mt::MethodTable)
     name = mt.name
     n = length(mt)
     meths = n==1 ? "method" : "methods"
@@ -134,7 +134,7 @@ function writemime(io::IO, mime::MIME"text/html", mt::MethodTable)
     d = mt.defs
     while !is(d,())
         print(io, "<li> ")
-        writemime(io, mime, d)
+        write(io, mime, d)
         d = d.next
     end
     print(io, "</ul>")
@@ -142,18 +142,18 @@ end
 
 # pretty-printing of Vector{Method} for output of methodswith:
 
-function writemime(io::IO, mime::MIME"text/html", mt::AbstractVector{Method})
+function write(io::IO, mime::MIME"text/html", mt::AbstractVector{Method})
     print(io, summary(mt))
     if !isempty(mt)
         print(io, ":<ul>")
         for d in mt
             print(io, "<li> ")
-            writemime(io, mime, d)
+            write(io, mime, d)
         end
         print(io, "</ul>")
     end
 end
 
 # override usual show method for Vector{Method}: don't abbreviate long lists
-writemime(io::IO, mime::MIME"text/plain", mt::AbstractVector{Method}) =
+write(io::IO, mime::MIME"text/plain", mt::AbstractVector{Method}) =
     showarray(io, mt, limit=false)

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -1,15 +1,15 @@
 module Multimedia
 
 export Display, display, pushdisplay, popdisplay, displayable, redisplay,
-   MIME, @MIME_str, writemime, reprmime, stringmime, istext,
-   mimewritable, TextDisplay
+   MIME, @MIME_str, reprmime, stringmime, istext,
+   mimewritable, TextDisplay, TEXTPLAIN, TEXTHTML
 
 ###########################################################################
 # We define a type MIME{mime symbol} for each MIME type, so that
 # Julia's dispatch and overloading mechanisms can be used to dispatch
-# writemime and to add conversions for new types.  Each MIME instance
+# write and to add conversions for new types.  Each MIME instance
 # contains a little dictionary of parameters used to pass information
-# to the writemime object.
+# to the write function.
 
 immutable MIME{mime} <: Associative{Symbol,Any}
     params::Vector{(Symbol,Any)} # use array, not dict, since will be small
@@ -17,7 +17,7 @@ immutable MIME{mime} <: Associative{Symbol,Any}
     MIME(; kws...) = new(copy!(Array((Symbol,Any), length(kws)), kws))
 end
 
-import Base: show, print, string, convert, similar, copy, get, start, done, next, length
+import Base: show, print, string, convert, similar, copy, get, start, done, next, length, write
 
 # implement read-only Associative methods for MIME parameters
 similar{mime}(::MIME{mime}) = MIME{mime}()
@@ -39,24 +39,38 @@ macro MIME_str(s)
     :(MIME{$(Expr(:quote, symbol(s)))})
 end
 
-function writemime{mime}(io::IO, ::MIME"text/plain", m::MIME{mime})
+function write{mime}(io::IO, ::MIME"text/plain", m::MIME{mime})
     print(io, mime)
     for (k,v) in m.params
         print(io, "; ", k, "=")
         show(io, v)
     end
 end
-show(io::IO, m::MIME) = writemime(io, MIME("text/plain"), m)
+
+# we so commonly need these that it makes sense to declare constants
+const TEXTPLAIN = MIME("text/plain")
+const TEXTHTML = MIME("text/html")
+
+show(io::IO, m::MIME) = write(io, TEXTPLAIN, m)
 
 ###########################################################################
-# For any type T one can define writemime(io, ::MIME"type", x::T) = ...
+# For any type T one can define write(io, ::MIME"type", x::T) = ...
 # in order to provide a way to export T as a given mime type.
+# We provide an explicit function to check whether MIME output is
+# available; this can be overloaded if outputability needs to be
+# determined at runtime (see e.g. PyCall).
 
-mimewritable{mime}(::MIME{mime}, x) =
-  method_exists(writemime, (IO, MIME{mime}, typeof(x)))
+function mimewritable{mime}(::MIME{mime}, x)
+    # a method always exists, e.g. the generic write(io, ...) function
+    # in io.jl.  We only consider mimewritable to be true if
+    # the second argument of the method is specifically a MIME type
+    # (or a union of MIME types etcetera).
+    sig = which(write, (IO, MIME{mime}, typeof(x))).sig
+    return length(sig) > 2 && !(Dict{Symbol,Any} <: sig[2])
+end
 
-# it is convenient to accept strings instead of ::MIME
-writemime(io::IO, m::AbstractString, x) = writemime(io, MIME(m), x)
+# it is convenient to accept strings instead of ::MIME, but
+# only where it is unambiguous (i.e. not for write)
 mimewritable(m::AbstractString, x) = mimewritable(MIME(m), x)
 
 ###########################################################################
@@ -78,14 +92,14 @@ macro textmime(mime)
         mimeT = MIME{symbol($mime)}
         # avoid method ambiguities with the general definitions below:
         # (Q: should we treat Vector{UInt8} as a bytestring?)
-        Base.Multimedia.reprmime(m::mimeT, x::Vector{UInt8}) = sprint(writemime, m, x)
+        Base.Multimedia.reprmime(m::mimeT, x::Vector{UInt8}) = sprint(write, m, x)
         Base.Multimedia.stringmime(m::mimeT, x::Vector{UInt8}) = reprmime(m, x)
 
         Base.Multimedia.istext(::mimeT) = true
         if $(mime != "text/plain") # strings are shown escaped for text/plain
             Base.Multimedia.reprmime(m::mimeT, x::AbstractString) = x
         end
-        Base.Multimedia.reprmime(m::mimeT, x) = sprint(writemime, m, x)
+        Base.Multimedia.reprmime(m::mimeT, x) = sprint(write, m, x)
         Base.Multimedia.stringmime(m::mimeT, x) = reprmime(m, x)
     end
 end
@@ -93,11 +107,11 @@ end
 istext(::MIME) = false
 function reprmime(m::MIME, x)
     s = IOBuffer()
-    writemime(s, m, x)
+    write(s, m, x)
     takebuf_array(s)
 end
 reprmime(m::MIME, x::Vector{UInt8}) = x
-stringmime(m::MIME, x) = base64(writemime, m, x)
+stringmime(m::MIME, x) = base64(write, m, x)
 stringmime(m::MIME, x::Vector{UInt8}) = base64(write, x)
 
 # it is convenient to accept strings instead of ::MIME
@@ -132,8 +146,8 @@ displayable(mime::AbstractString) = displayable(MIME(mime))
 immutable TextDisplay <: Display
     io::IO
 end
-display(d::TextDisplay, M::MIME"text/plain", x) = writemime(d.io, M, x)
-display(d::TextDisplay, x) = display(d, MIME"text/plain"(), x)
+display(d::TextDisplay, M::MIME"text/plain", x) = write(d.io, M, x)
+display(d::TextDisplay, x) = display(d, TEXTPLAIN, x)
 
 import Base: close, flush
 flush(d::TextDisplay) = flush(d.io)
@@ -166,7 +180,7 @@ macro try_display(expr)
   quote
     try $(esc(expr))
     catch e
-      isa(e, MethodError) && e.f in (display, redisplay, writemime) ||
+      isa(e, MethodError) && e.f in (display, redisplay, write) ||
         rethrow()
     end
   end

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -1,7 +1,7 @@
 module Multimedia
 
 export Display, display, pushdisplay, popdisplay, displayable, redisplay,
-   MIME, @MIME, @MIME_str, writemime, reprmime, stringmime, istext,
+   MIME, @MIME_str, writemime, reprmime, stringmime, istext,
    mimewritable, TextDisplay
 
 ###########################################################################
@@ -34,16 +34,6 @@ next(t::MIME, i) = done(t.params, i)
 length(t::MIME) = length(t.params)
 
 MIME(s; kws...) = MIME{symbol(s)}(; kws...)
-
-# needs to be a macro so that we can use ::@mime(s) in type declarations
-macro MIME(s)
-    Base.warn_once("@MIME(\"\") is deprecated, use MIME\"\" instead.")
-    if isa(s,AbstractString)
-        :(MIME{$(Expr(:quote, symbol(s)))})
-    else
-        :(MIME{symbol($s)})
-    end
-end
 
 macro MIME_str(s)
     :(MIME{$(Expr(:quote, symbol(s)))})

--- a/base/precompile.jl
+++ b/base/precompile.jl
@@ -311,7 +311,7 @@ precompile(Base.work_result, (Base.RemoteValue,))
 precompile(Base.write, (Base.Terminals.TTYTerminal, ASCIIString))
 precompile(Base.write, (Base.Terminals.TerminalBuffer, ASCIIString))
 precompile(Base.write, (IOBuffer, Vector{UInt8}))
-precompile(Base.writemime, (Base.Terminals.TTYTerminal, Base.Multimedia.MIME{symbol("text/plain")}, Int))
+precompile(Base.write, (Base.Terminals.TTYTerminal, Base.Multimedia.MIME{symbol("text/plain")}, Int))
 precompile(push!, (Array{Base.Multimedia.Display, 1}, Base.Multimedia.TextDisplay))
 
 precompile(Base.Terminals.TTYTerminal, (ASCIIString, Base.TTY, Base.TTY, Base.TTY))

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -1,7 +1,7 @@
 # fallback text/plain representation of any type:
-writemime(io::IO, ::MIME"text/plain", x) = showlimited(io, x)
+write(io::IO, ::MIME"text/plain", x) = showlimited(io, x)
 
-function writemime(io::IO, ::MIME"text/plain", f::Function)
+function write(io::IO, ::MIME"text/plain", f::Function)
     if isgeneric(f)
         n = length(f.env)
         m = n==1 ? "method" : "methods"
@@ -11,7 +11,7 @@ function writemime(io::IO, ::MIME"text/plain", f::Function)
     end
 end
 
-function writemime(io::IO, ::MIME"text/plain", v::AbstractVector)
+function write(io::IO, ::MIME"text/plain", v::AbstractVector)
     if isa(v, Range)
         show(io, v)
     else
@@ -23,17 +23,17 @@ function writemime(io::IO, ::MIME"text/plain", v::AbstractVector)
     end
 end
 
-writemime(io::IO, ::MIME"text/plain", v::AbstractArray) =
+write(io::IO, ::MIME"text/plain", v::AbstractArray) =
     with_output_limit(()->showarray(io, v, header=true, repr=false))
 
-function writemime(io::IO, ::MIME"text/plain", v::DataType)
+function write(io::IO, ::MIME"text/plain", v::DataType)
     show(io, v)
     # TODO: maybe show constructor info?
 end
 
-writemime(io::IO, ::MIME"text/plain", t::Associative) =
+write(io::IO, ::MIME"text/plain", t::Associative) =
     showdict(io, t, limit=true)
-writemime(io::IO, ::MIME"text/plain", t::Union(KeyIterator, ValueIterator)) =
+write(io::IO, ::MIME"text/plain", t::Union(KeyIterator, ValueIterator)) =
     showkv(io, t, limit=true)
 
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,4 +1,4 @@
-replstr(x) = sprint((io,x) -> writemime(io,MIME("text/plain"),x), x)
+replstr(x) = sprint((io,x) -> write(io,TEXTPLAIN,x), x)
 
 @test replstr(cell(2)) == "2-element Array{Any,1}:\n #undef\n #undef"
 @test replstr(cell(2,2)) == "2x2 Array{Any,2}:\n #undef  #undef\n #undef  #undef"


### PR DESCRIPTION
This is a branch for a cleanup along the lines of #7959:
- [x] `MIME` types should be a `{Symbol,Any}` dictionary of properties
- [x] Rename `writemime(io, mime, x)` to `write(io, mime, x)`
  - [ ] figure out how to handle deprecation
- [ ] Replace `showall`, `showcompact` etcetera with a numeric `detail` property of the MIME types, probably with a `detail(mime)` convenience accessor, describing an ordered sequence of detail levels (`0=`summary, `1=`pretty but possibly truncated, `2=`pretty and untruncated, `3=`parseable, ...?)
- [ ] Deprecate `show` in favor of `write`.   (`print` is just `write` to `text/plain`).
- [ ] Decide on any other properties (e.g. floating-point precision) that we want to standardize/document.

cc: @jiahao, @ivarne, @StefanKarpinski, @JeffBezanson 
