### PR TITLE
Latex completion in string, fix #8983

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -196,11 +196,14 @@ function completions(string, pos)
            (length(string) <= pos || string[pos+1] != '"')    # or there's already a " at the cursor.
             paths[1] *= "\""
         end
-        return sort(paths), r, success
+        #Latex symbols can be completed for strings
+        (success || inc_tag==:cmd) && return sort(paths), r, success
     end
 
     ok, ret = latex_completions(string, pos)
     ok && return ret
+    # Make sure that only latex_completions is working on strings
+    inc_tag==:string && return UTF8String[], 0:-1, false
 
     if inc_tag == :other && string[pos] == '('
         endpos = prevind(string, pos)

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -73,6 +73,13 @@ c,r = test_latexcomplete(s)
 @test r == 1:length(s)
 @test length(c) == 1
 
+# test latex symbol completions in strings
+s = "\"C:\\\\ \\alpha"
+c,r,res = test_complete(s)
+@test c[1] == "α"
+@test r == 7:12
+@test length(c) == 1
+
 ## Test completion of packages
 #mkp(p) = ((@assert !isdir(p)); mkdir(p))
 #temp_pkg_dir() do


### PR DESCRIPTION
This enables Latex completion in strings as suggested in #8983.
This pull request fixes the mess in #8988.
