### PR TITLE
Test approximate over exact equality.

### DIFF
--- a/test/math.jl
+++ b/test/math.jl
@@ -198,7 +198,11 @@ end
 @test_approx_eq lbeta(-1/2, 3) log(16/3)
 
 # gamma, lgamma (complex argument)
-@test gamma(1:25) == gamma(Float64[1:25])
+if Base.Math.libm == "libopenlibm"
+    @test gamma(Float64[1:25]) == gamma(1:25)
+else
+    @test_approx_eq gamma(Float64[1:25]) gamma(1:25)
+end
 @test_approx_eq gamma(1/2) sqrt(π)
 @test_approx_eq gamma(-1/2) -2sqrt(π)
 @test_approx_eq lgamma(-1/2) log(abs(gamma(-1/2)))


### PR DESCRIPTION
I open this pull request to get the discussion starting on whether a less-precise system libm implementation (which can be used officially with `USE_SYSTEM_LIBM=1`) should result in errors while testing julia. The issue came up originally in staticfloat/homebrew-julia#125 for OS X.

These changes are required in order to make Julia's math tests succeed with a OS X system libm.

As one can expect, the inaccuracies are small:

```
julia> x = zeros(25, 2);

julia> x[:,1] = gamma(1:25);

julia> x[:,2] = gamma(Float64[1:25]);

julia> show(x)
[1.0 1.0
 1.0 1.0
 2.0 2.0
 6.0 6.0
 24.0 24.0
 120.0 120.0
 720.0 720.0
 5040.0 5040.0
 40320.0 40320.0
 362880.0 362880.0
 3.6288e6 3.6288e6
 3.99168e7 3.991680000000003e7
 4.790016e8 4.790015999999976e8
 6.2270208e9 6.227020799999989e9
 8.71782912e10 8.717829119999985e10
 1.307674368e12 1.3076743679999983e12
 2.0922789888e13 2.0922789888000055e13
 3.55687428096e14 3.556874280960007e14
 6.402373705728e15 6.402373705727994e15
 1.21645100408832e17 1.2164510040883208e17
 2.43290200817664e18 2.43290200817664e18
 5.109094217170942e19 5.109094217170942e19
 1.1240007277776115e21 1.1240007277776115e21
 2.5852016738885247e22 2.5852016738885247e22
 6.204484017332391e23 6.204484017332391e23]
julia> filter(x -> x > 0, abs(1 - x[:,1] ./ x[:,2]))
9-element Array{Float64,1}:
 7.77156e-16
 4.88498e-15
 1.77636e-15
 1.77636e-15
 1.33227e-15
 2.66454e-15
 1.88738e-15
 8.88178e-16
 6.66134e-16
```

Probably one could even change the tests to `@test_approx_eq_eps ... ... 1e-10` if that is necessary.
