### PR TITLE
README.windows: corrected git config args

### DIFF
--- a/README.windows.md
+++ b/README.windows.md
@@ -35,8 +35,8 @@ The 64-bit (x86_64) binary will only run on 64-bit Windows and will otherwise re
 
 Julia uses binary-mode files exclusively. Unlike many other Windows programs, if you write '\n' to a file, you get a '\n' in the file, not some other bit pattern. This matches the behavior exhibited by other operating systems. If you have installed msysGit, it is suggested, but not required, that you configure your system msysGit to use the same convention:
 
-    git config --global core.eol = lf
-    git config --global core.autocrlf = input
+    git config --global core.eol lf
+    git config --global core.autocrlf input
     
 or edit `%USERPROFILE%\.gitconfig` and add/edit the lines:
     


### PR DESCRIPTION
Passing equals sign confuses git to the point that manual edit of configuration is required.
