### PR TITLE
Fix that REPL crashes in shell mode on $a<tab>

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -264,6 +264,7 @@ function shell_completions(string, pos)
         range += first(r) - 1
         return ret, range, true
     end
+    return UTF8String[], 0:-1, false
 end
 
 end # module

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -99,6 +99,9 @@ c,r = test_latexcomplete(s)
 #    rm(Pkg.dir("CompletionFooPackage"))
 #end
 
+#This should not throw an error
+c,r = test_scomplete("\$a")
+
 @unix_only begin
     #Assume that we can rely on the existence and accessibility of /tmp
 


### PR DESCRIPTION
This fixes that the REPL crashes if:

``` julia
shell>$a<tab>
```

Line 267 is necessary to make the REPL not crash when the input does not match the if conditions.
~~line 260 enables the auto completion for `shell>$a` instead of it only works of `shell>$(a` I can't find any negative effects of removing the additional conditions. Can @nolta  or @Keno approve the removal of the conditions?~~

I did not know that the repl could insert variables in shell mode by `$` before I looked into this problem is there a place for documenting this?

EDIT
I have changed the pull request to only contain what is necessary to stop the terminal from a crash and hence making the pull request very simple by just adding the return content to match what is expected by the repl.
