### PR TITLE
Ignore `@inbounds` when running Pkg tests on Travis

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -152,7 +152,7 @@ function travis(pkg::AbstractString; force::Bool=false)
           - sudo apt-get install libpcre3-dev julia -y
           - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
         script:
-          - julia -e 'versioninfo(); Pkg.init(); Pkg.clone(pwd()); Pkg.test("$pkg")'
+          - julia --check-bounds=yes -e 'versioninfo(); Pkg.init(); Pkg.clone(pwd()); Pkg.test("$pkg")'
         """)
     end
 end


### PR DESCRIPTION
While many people have good reasons to add `@inbounds` to their code, when running tests it seems better to use full bounds checking.

Might be relevant for PkgEvaluator, too.
