### PR TITLE
Simplify middle() and fix docs

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -447,6 +447,7 @@ end
 
 ##### median & quantiles #####
 
+# Specialized functions for real types allow for improved performance
 middle(x::Union(Bool,Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128)) = float64(x)
 middle(x::FloatingPoint) = x
 middle(x::Float16) = float32(x)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4640,18 +4640,18 @@ Statistics
 
 .. function:: middle(x)
 
-   Compute the middle of a scalar value, which is equivalent to ``x`` itself.
-   Note: the value is converted to ``float``.
+   Compute the middle of a scalar value, which is equivalent to ``x`` itself,
+   but of the type of ``middle(x, x)`` for consistency.
 
 .. function:: middle(x, y)
 
    Compute the middle of two reals ``x`` and ``y``, which is equivalent
-   to computing their mean (``(x + y) / 2``).
-   Note: As with ``middle(x)``, the returned value is of type ``float``.
+   with regard the value and the type of the result to computing their mean
+   (``(x + y) / 2``).
 
 .. function:: middle(range)
 
-   Compute the middle of a range, that is, compute the mean of its extrema.
+   Compute the middle of a range, which consists in computing the mean of its extrema.
    Since a range is sorted, the mean is performed with the first and last element.
 
 .. function:: middle(array)


### PR DESCRIPTION
The special cases gave the same result as the general rule, which is
the only intelligible one. Fix the docs and explain the rule as regards
the result type.

I'd like somebody to check this is correct as I don't understand why special cases would have been created if they weren't necessary. I'm also not sure whether the `+ zero(x)` is really needed (maybe just in case for a new type addition changes type?).

CC: @remusao about the docs
