### PR TITLE
 "font-lock-syntactic-keywords -> syntax-propertize-function"

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -422,10 +422,10 @@ before point. Returns nil if we're not within nested parens."
   (set (make-local-variable 'comment-start) "# ")
   (set (make-local-variable 'comment-start-skip) "#+\\s-*")
   (set (make-local-variable 'font-lock-defaults) '(julia-font-lock-keywords))
-  (set (make-local-variable 'font-lock-syntactic-keywords)
+  (set (make-local-variable 'syntax-propertize-function)
        (list
 	(list "\\(\\\\\\)\\s-*\".*?\"" 1 julia-mode-char-syntax-table)))
-  (set (make-local-variable 'font-lock-syntactic-keywords)
+  (set (make-local-variable 'syntax-propertize-function)
         (list
  	(list julia-char-regex 2
  	      julia-mode-char-syntax-table)


### PR DESCRIPTION
I tried byte-compiling julia-mode.el to make it load faster. However, in emacs 24.3.1, the function `font-lock-syntactic-keywords` is marked as obsolete. The compiler gave a warning:

```
julia-mode.el:431:15:Warning: `font-lock-syntactic-keywords' is an obsolete
    variable (as of 24.1); use `syntax-propertize-function' instead.
```

So I changed it to `syntax-propertize-function`. 
The warning message no longer appears when I byte-compile.
