### PR TITLE
Added windows support for SharedArray

### DIFF
--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -119,7 +119,7 @@ end
 ### Windows implementation ###
 
 @windows_only type SharedMemSpec
-    name :: String
+    name :: AbstractString
     readonly :: Bool
     create :: Bool
 end

--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -117,15 +117,31 @@ end
 end
 
 ### Windows implementation ###
+
+@windows_only type SharedMemSpec
+    name :: String
+    readonly :: Bool
+    create :: Bool
+end
+
 @windows_only begin
 # Mmapped-array constructor
-function mmap_array{T,N}(::Type{T}, dims::NTuple{N,Integer}, s::IO, offset::FileOffset)
-    shandle = _get_osfhandle(RawFD(fd(s)))
-    if int(shandle.handle) == -1
-        error("could not get handle for file to map: $(FormatMessage())")
+function mmap_array{T,N}(::Type{T}, dims::NTuple{N,Integer}, s::Union(IO,SharedMemSpec), offset::FileOffset)
+    if isa(s,IO)
+        hdl = _get_osfhandle(RawFD(fd(s))).handle
+        if int(hdl) == -1
+            error("could not get handle for file to map: $(FormatMessage())")
+        end
+        name = C_NULL
+        ro = isreadonly(s)
+        create = true
+    else
+        # shared memory
+        hdl = -1
+        name = utf16(s.name)
+        ro = s.readonly
+        create = s.create
     end
-    ro = isreadonly(s)
-    flprotect = ro ? 0x02 : 0x04
     len = prod(dims)*sizeof(T)
     const granularity::Int = ccall(:jl_getallocationgranularity, Clong, ())
     if len < 0
@@ -138,12 +154,18 @@ function mmap_array{T,N}(::Type{T}, dims::NTuple{N,Integer}, s::IO, offset::File
     offset_page::FileOffset = div(offset, granularity)*granularity
     szfile = convert(Csize_t, len + offset)
     szarray = szfile - convert(Csize_t, offset_page)
-    mmaphandle = ccall(:CreateFileMappingW, stdcall, Ptr{Void}, (Ptr{Void}, Ptr{Void}, Cint, Cint, Cint, Ptr{UInt16}),
-        shandle.handle, C_NULL, flprotect, szfile>>32, szfile&typemax(UInt32), C_NULL)
+    access = ro ? 4 : 2
+    if create
+        flprotect = ro ? 0x02 : 0x04
+        mmaphandle = ccall(:CreateFileMappingW, stdcall, Ptr{Void}, (Cptrdiff_t, Ptr{Void}, Cint, Cint, Cint, Ptr{UInt16}),
+            hdl, C_NULL, flprotect, szfile>>32, szfile&typemax(UInt32), name)
+    else
+        mmaphandle = ccall(:OpenFileMappingW, stdcall, Ptr{Void}, (Cint, Cint, Ptr{Uint16}),
+            access, true, name)
+    end
     if mmaphandle == C_NULL
         error("could not create file mapping: $(FormatMessage())")
     end
-    access = ro ? 4 : 2
     viewhandle = ccall(:MapViewOfFile, stdcall, Ptr{Void}, (Ptr{Void}, Cint, Cint, Cint, Csize_t),
         mmaphandle, access, offset_page>>32, offset_page&typemax(UInt32), szarray)
     if viewhandle == C_NULL

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -26,7 +26,6 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
     N = length(dims)
 
     isbits(T) || error("Type of Shared Array elements must be bits types")
-    @windows_only error(" SharedArray is not supported on Windows yet.")
 
     if isempty(pids)
         # only use workers on the current host
@@ -75,10 +74,11 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
         # All good, immediately unlink the segment.
         if prod(dims) > 0
             if onlocalhost
-                shm_unlink(shm_seg_name)
+                rc = shm_unlink(shm_seg_name)
             else
-                remotecall_fetch(shmmem_create_pid, shm_unlink, shm_seg_name)
+                rc = remotecall_fetch(shmmem_create_pid, shm_unlink, shm_seg_name)
             end
+            systemerror("Error unlinking shmem segment " * shm_seg_name, rc != 0)
         end
         S = SharedArray{T,N}(dims, pids, refs, shm_seg_name)
         shm_seg_name = ""
@@ -343,19 +343,7 @@ function shm_mmap_array(T, dims, shm_seg_name, mode)
     end
 
     try
-        fd_mem = shm_open(shm_seg_name, mode, S_IRUSR | S_IWUSR)
-        systemerror("shm_open() failed for " * shm_seg_name, fd_mem <= 0)
-
-        s = fdio(fd_mem, true)
-
-        # On OSX, ftruncate must to used to set size of segment, just lseek does not work.
-        # and only at creation time
-        if (mode & JL_O_CREAT) == JL_O_CREAT
-            rc = ccall(:ftruncate, Int, (Int, Int), fd_mem, prod(dims)*sizeof(T))
-            systemerror("ftruncate() failed for shm segment " * shm_seg_name, rc != 0)
-        end
-
-        A = mmap_array(T, dims, s, zero(FileOffset), grow=false)
+        A = _shm_mmap_array(T, dims, shm_seg_name, mode)
     catch e
         print_shmem_limits(prod(dims)*sizeof(T))
         rethrow(e)
@@ -368,12 +356,42 @@ function shm_mmap_array(T, dims, shm_seg_name, mode)
     A
 end
 
+
+# platform-specific code
+
 @unix_only begin
-function shm_unlink(shm_seg_name)
-    rc = ccall(:shm_unlink, Cint, (Ptr{UInt8},), shm_seg_name)
-    systemerror("Error unlinking shmem segment " * shm_seg_name, rc != 0)
-    rc
-end
+
+function _shm_mmap_array(T, dims, shm_seg_name, mode)
+    fd_mem = shm_open(shm_seg_name, mode, S_IRUSR | S_IWUSR)
+    systemerror("shm_open() failed for " * shm_seg_name, fd_mem <= 0)
+
+    s = fdio(fd_mem, true)
+
+    # On OSX, ftruncate must to used to set size of segment, just lseek does not work.
+    # and only at creation time
+    if (mode & JL_O_CREAT) == JL_O_CREAT
+        rc = ccall(:ftruncate, Int, (Int, Int), fd_mem, prod(dims)*sizeof(T))
+        systemerror("ftruncate() failed for shm segment " * shm_seg_name, rc != 0)
+    end
+
+    mmap_array(T, dims, s, zero(FileOffset), grow=false)
 end
 
-@unix_only shm_open(shm_seg_name, oflags, permissions) = ccall(:shm_open, Int, (Ptr{UInt8}, Int, Int), shm_seg_name, oflags, permissions)
+shm_unlink(shm_seg_name) = ccall(:shm_unlink, Cint, (Ptr{UInt8},), shm_seg_name)
+shm_open(shm_seg_name, oflags, permissions) = ccall(:shm_open, Int, (Ptr{UInt8}, Int, Int), shm_seg_name, oflags, permissions)
+
+end # @unix_only
+
+@windows_only begin
+
+function _shm_mmap_array(T, dims, shm_seg_name, mode)
+    readonly = !((mode & JL_O_RDWR) == JL_O_RDWR)
+    create = (mode & JL_O_CREAT) == JL_O_CREAT
+    s = SharedMemSpec(shm_seg_name, readonly, create)
+    mmap_array(T, dims, s, zero(FileOffset))
+end
+
+# no-op in windows
+shm_unlink(shm_seg_name) = 0
+
+end # @windows_only

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -574,7 +574,7 @@ is ``DArray``\ -specific, but we list it here for completeness::
 
 
     
-Shared Arrays (Experimental, UNIX-only feature)
+Shared Arrays (Experimental)
 -----------------------------------------------
 
 Shared Arrays use system shared memory to map the same array across

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -29,8 +29,6 @@ map!(x->1, d)
 @test reduce(+, d) == 100
 
 
-@unix_only begin
-
 dims = (20,20,20)
 
 @linux_only begin
@@ -122,9 +120,6 @@ map!(x->1, d)
 # Boundary cases where length(S) <= length(pids)
 @test 2.0 == remotecall_fetch(id_other, D->D[2], Base.shmem_fill(2.0, 2; pids=[id_me, id_other]))
 @test 3.0 == remotecall_fetch(id_other, D->D[1], Base.shmem_fill(3.0, 1; pids=[id_me, id_other]))
-
-
-end # @unix_only(SharedArray tests)
 
 
 # Test @parallel load balancing - all processors should get either M or M+1


### PR DESCRIPTION
I made every effort to implement this with the least amount of change to existing code. This includes trying to maximize reuse of the existing windows version of the  `mmap_array` function. One not-so-pleasing side effect of this is a clunkier looking signature with a `Union` type and a couple of new `if-else` blocks in the body.

I verified that `test/parallel.jl` passes on linux-64, windows-32, and windows-64 on my machine.
