### PR TITLE
in zip2, use short-circuit logical or in "done"

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -58,7 +58,7 @@ function next(z::Zip2, st)
     n2 = next(z.b,st[2])
     return ((n1[1], n2[1]), (n1[2], n2[2]))
 end
-done(z::Zip2, st) = done(z.a,st[1]) | done(z.b,st[2])
+done(z::Zip2, st) = done(z.a,st[1]) || done(z.b,st[2])
 
 eltype(z::Zip2) = (eltype(z.a), eltype(z.b))
 


### PR DESCRIPTION
any specific reason to use bitwise or here?
done(z::Zip2, st) = done(z.a,st[1]) | done(z.b,st[2])
do we want both "done"s to be evaluated always??
