### PR TITLE
remove extra args from do-block cd() method

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -12,22 +12,22 @@ function cd(dir::AbstractString)
 end
 cd() = cd(homedir())
 
-@unix_only function cd(f::Function, dir::AbstractString, args...)
+@unix_only function cd(f::Function, dir::AbstractString)
     fd = ccall(:open,Int32,(Ptr{UInt8},Int32),".",0)
     systemerror(:open, fd == -1)
     try
         cd(dir)
-        f(args...)
+        f()
     finally
         systemerror(:fchdir, ccall(:fchdir,Int32,(Int32,),fd) != 0)
         systemerror(:close, ccall(:close,Int32,(Int32,),fd) != 0)
     end
 end
-@windows_only function cd(f::Function, dir::AbstractString, args...)
+@windows_only function cd(f::Function, dir::AbstractString)
     old = pwd()
     try
         cd(dir)
-        f(args...)
+        f()
    finally
         cd(old)
     end


### PR DESCRIPTION
Not sure why we'd want this:

``` julia
cd(dir, 7) do x
    x + 2  # 9
end
```
