### PR TITLE
nicer alignment of MathConst arrays

### DIFF
--- a/base/constants.jl
+++ b/base/constants.jl
@@ -85,3 +85,10 @@ end
 
 log(::MathConst{:e}) = 1 # use 1 to correctly promote expressions like log(x)/log(e)
 log(::MathConst{:e}, x) = log(x)
+
+#Align along = for nice Array printing
+function alignment(x::MathConst)
+    m = match(r"^(.*?)(=.*)$", sprint(showcompact_lim, x))
+    m == nothing ? (length(sprint(showcompact_lim, x)), 0) :
+    (length(m.captures[1]), length(m.captures[2]))
+end


### PR DESCRIPTION
this should fix issue #8427. This change results in

```
julia> c = MathConst[π, e, γ, catalan, φ]
5-element Array{MathConst{sym},1}:
       π = 3.1415926535897...
       e = 2.7182818284590...
       γ = 0.5772156649015...
 catalan = 0.9159655941772...
       φ = 1.6180339887498...
```
