### PR TITLE
`rand` sampling from an array accepts an optional rng

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4071,19 +4071,21 @@ A ``MersenneTwister`` RNG can generate random numbers of the following types: ``
 
    Create a ``MersenneTwister`` RNG object. Different RNG objects can have their own seeds, which may be useful for generating different streams of random numbers.
 
-.. function:: rand([rng], [t::Type], [dims...])
+.. function:: rand([rng], [S], [dims...])
 
-   Generate a random value or an array of random values of the given type, ``t``, which defaults to ``Float64``.
+   Pick a random element or array of random elements from the set of values specified by ``S``; ``S`` can be
+
+   * an indexable collection (for example ``1:n`` or ``['x','y','z']``), or
+
+   * a type: the set of values to pick from is then equivalent to ``typemin(S):typemax(S)`` for integers, and to [0,1) for floating point numbers;
+
+   ``S`` defaults to ``Float64``.
 
 .. function:: rand!([rng], A)
 
    Populate the array A with random values.
 
-.. function:: rand(coll, [dims...])
-
-   Pick a random element or array of random elements from the indexable collection ``coll`` (for example, ``1:n`` or ``['x','y','z']``).
-
-.. function:: rand!(r, A)
+.. function:: rand!([rng], r, A)
 
    Populate the array A with random values drawn uniformly from the range ``r``.
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -32,10 +32,20 @@ rand!(MersenneTwister(0), A)
             8690327730555225005 8435109092665372532]
 
 # rand from AbstractArray
-@test rand(0:3:1000) in 0:3:1000
-coll = Any[2, UInt128(128), big(619), "string", 'c']
-@test rand(coll) in coll
-@test issubset(rand(coll, 2, 3), coll)
+let mt = MersenneTwister()
+    srand(mt)
+    @test rand(mt, 0:3:1000) in 0:3:1000
+    @test issubset(rand!(mt, 0:3:1000, Array(Int, 100)), 0:3:1000)
+    coll = Any[2, UInt128(128), big(619), "string", 'c']
+    @test rand(mt, coll) in coll
+    @test issubset(rand(mt, coll, 2, 3), coll)
+
+    # check API with default RNG:
+    rand(0:3:1000)
+    rand!(0:3:1000, Array(Int, 100))
+    rand(coll)
+    rand(coll, 2, 3)
+end
 
 # randn
 @test randn(MersenneTwister(42)) == -0.5560268761463861


### PR DESCRIPTION
The diffs for the docs update are probably easier to read with "Split" diff (instead of "Unified"). I tentatively merged the two docs for `rand` into one text, but comments are welcome.
