### PR TITLE
New debug flag MEMNOFREE that disables all calls to free

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -33,6 +33,11 @@
 // catch invalid accesses.
 //#define MEMDEBUG
 
+// with MEMNOFREE, freed objects are not actually freed so that their
+// memory region is not reused. this helps track down memory bugs
+// since these objects then stay inaccessible.
+//#define MEMNOFREE
+
 // profiling options
 
 // GC_FINAL_STATS prints total GC stats at exit


### PR DESCRIPTION
I'm still debugging my segfault in Julia #8551 . In the course of this, I theorized that memory may be freed and then reused by other objects, causing the segfault. To investigate, I added a build option MEMNOFREE that never frees memory. This applies both to memory freed by garbage collection, as well as memory freed explicitly e.g. by strings, arrays, or other buffers.

This patch wraps plain `malloc`, `realloc`, and `free` via macros, and then redefines these macros to never free memory. (In particular, `realloc` becomes `malloc` and `memcpy`.)

I think this facility is useful for debugging in general, and propose to make it official.
