### PR TITLE
Correct "touch" option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ endif
 	# Copy icon and .desktop file
 	mkdir -p $(DESTDIR)$(datarootdir)/icons/hicolor/scalable/apps/
 	$(INSTALL_F) contrib/julia.svg $(DESTDIR)$(datarootdir)/icons/hicolor/scalable/apps/
-	-touch --no-create $(DESTDIR)$(datarootdir)/icons/hicolor/
+	-touch -c $(DESTDIR)$(datarootdir)/icons/hicolor/
 	-gtk-update-icon-cache $(DESTDIR)$(datarootdir)/icons/hicolor/
 	mkdir -p $(DESTDIR)$(datarootdir)/applications/
 	$(INSTALL_F) contrib/julia.desktop $(DESTDIR)$(datarootdir)/applications/


### PR DESCRIPTION
The option --no-create does not exist on OS X; use -c instead which exists everywhere
