### PR TITLE
change argument order for rand! (fix #8246)

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -228,3 +228,6 @@ const Uint128 = UInt128
 @deprecate zero{T}(x::Ptr{T})      Ptr{T}(0)
 @deprecate one{T}(::Type{Ptr{T}})  Ptr{T}(1)
 @deprecate one{T}(x::Ptr{T})       Ptr{T}(1)
+
+@deprecate rand!(r::Range, A::AbstractArray) rand!(A, r)
+@deprecate rand!(mt::MersenneTwister, r::Range, A::AbstractArray) rand!(mt, A, r)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4081,13 +4081,9 @@ A ``MersenneTwister`` RNG can generate random numbers of the following types: ``
 
    ``S`` defaults to ``Float64``.
 
-.. function:: rand!([rng], A)
+.. function:: rand!([rng], A ,[coll])
 
-   Populate the array A with random values.
-
-.. function:: rand!([rng], r, A)
-
-   Populate the array A with random values drawn uniformly from the range ``r``.
+   Populate the array A with random values. If the indexable collection ``coll`` is specified, the values are picked randomly from ``coll``. This is equivalent to ``copy!(A, rand(rng, coll, size(A)))`` or ``copy!(A, rand(rng, eltype(A), size(A)))`` but without allocating a new array.
 
 .. function:: randbool([rng], [dims...])
 

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -46,7 +46,7 @@ for (sz,T) in allsizes
     @test isequal(convert(AbstractArray{Float64,ndims(b1)}, b1),
                   convert(AbstractArray{Float64,ndims(b1)}, bitunpack(b1)))
 
-    i1 = rand!(false:true, zeros(Bool, sz...))
+    i1 = rand!(zeros(Bool, sz...), false:true)
     @test isequal(bitunpack(bitpack(i1)), i1)
 end
 

--- a/test/perf/sort/perf.jl
+++ b/test/perf/sort/perf.jl
@@ -8,7 +8,7 @@ include("../perfutil.jl")
 sorts = [InsertionSort, QuickSort, MergeSort, HeapSort, RadixSort, TimSort]
 
 randstr_fn!(str_len::Int) = d -> (for i = 1:length(d); d[i] = randstring(str_len); end; d)
-randint_fn!(m::Int) = d -> rand!(1:m,d)
+randint_fn!(m::Int) = d -> rand!(d, 1:m)
 
 # If we're reporting to codespeed, only do a few tests.
 if codespeed

--- a/test/random.jl
+++ b/test/random.jl
@@ -35,14 +35,14 @@ rand!(MersenneTwister(0), A)
 let mt = MersenneTwister()
     srand(mt)
     @test rand(mt, 0:3:1000) in 0:3:1000
-    @test issubset(rand!(mt, 0:3:1000, Array(Int, 100)), 0:3:1000)
+    @test issubset(rand!(mt, Array(Int, 100), 0:3:1000), 0:3:1000)
     coll = Any[2, UInt128(128), big(619), "string", 'c']
     @test rand(mt, coll) in coll
     @test issubset(rand(mt, coll, 2, 3), coll)
 
     # check API with default RNG:
     rand(0:3:1000)
-    rand!(0:3:1000, Array(Int, 100))
+    rand!(Array(Int, 100), 0:3:1000)
     rand(coll)
     rand(coll, 2, 3)
 end
@@ -251,5 +251,17 @@ let mt = MersenneTwister()
         rand(mt) # this is to fill mt.vals, cf. #9040
         rand!(mt, A) # must not segfault even if Int(pointer(A)) % 16 != 0
         @test A[end-4:end] == [0.49508297796349776,0.3408340446375888,0.3211229457075784,0.9103565379264364,0.16456579813368521]
+    end
+end
+
+# test rand! API: rand!([rng], A, [coll])
+let mt = MersenneTwister(0)
+    for T in [Base.IntTypes..., Float16, Float32, Float64]
+        for A in (Array(T, 5), Array(T, 2, 2))
+            rand!(A)
+            rand!(mt, A)
+            rand!(A, T[1,2,3])
+            rand!(mt, A, T[1,2,3])
+        end
     end
 end


### PR DESCRIPTION
The current API is `rand!([rng], [r::Range], A)`. There seems to be an almost consensus (cf. #8246) to put `r::Range` as last argument, and a preference to keep `rng` before `A`, i.e: `rand!([rng], A, [::Range])`. This PR implements this solution, but can easily be changed to `rand!(A, [rng], [::Range])` if a decision is made this way.
Note: `r::Range` is also changed to `r::AbstractArray`, to match `rand`.
