### PR TITLE
replace VLA with alloca for MSVC

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -140,7 +140,7 @@ int OpInfoLookup(void *DisInfo, uint64_t PC,
     if (TagType != 1)
         return 0;               // Unknown data format
     LLVMOpInfo1 *info = (LLVMOpInfo1*)TagBuf;
-    uint8_t bytes[Size];
+    uint8_t *bytes = (uint8_t*) alloca(Size*sizeof(uint8_t));
     for (uint64_t i=0; i<Size; ++i)
         SymTab->getMemoryObject().readByte(PC+Offset+i, &bytes[i]);
     size_t pointer;


### PR DESCRIPTION
VLA's are C99, but technically a GNU extension in C++. MSVC 2013 chokes on them.

```
/d/code/msys64/home/Tony/julia/deps/libuv/compile cl -nologo -MD -Z7 -TP -EHsc -
DNDEBUG -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORM
AT_MACROS -D__STDC_LIMIT_MACROS -DJL_SYSTEM_IMAGE_PATH="../lib/julia/sys.ji" -DJ
ULIA_TARGET_ARCH=x86-64 -DSYSTEM_LLVM -D_WIN32_WINNT=0x0600 -D_GNU_SOURCE -Iflis
p -Isupport -I/d/code/msys64/home/Tony/julia/usr/bin/../include -I/d/code/msys64
/home/Tony/julia/deps/libuv/include -I/d/code/msys64/home/Tony/julia/usr/include
 -DLIBRARY_EXPORTS -c codegen.cpp -o codegen.o
codegen.cpp
d:\code\msys64\home\tony\julia\src\disasm.cpp(143) : error C2057: expected const
ant expression
d:\code\msys64\home\tony\julia\src\disasm.cpp(143) : error C2466: cannot allocat
e an array of constant size 0
d:\code\msys64\home\tony\julia\src\disasm.cpp(143) : error C2133: 'bytes' : unkn
own size
make[2]: *** [codegen.o] Error 2
make[2]: Leaving directory `/d/code/msys64/home/Tony/julia/src'
```

cc @eschnett
