### PR TITLE
print user-defined type names fully qualified.

### DIFF
--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -10,7 +10,7 @@ for p in (:Year,:Month,:Week,:Day,:Hour,:Minute,:Second,:Millisecond)
     # Unless the Periods are the same type
     @eval $p(x::$p) = x
     # Convenience method for show()
-    @eval _units(x::$p) = " " * lowercase(string($p)) * (abs(value(x)) == 1 ? "" : "s")
+    @eval _units(x::$p) = $(" " * lowercase(string(p))) * (abs(value(x)) == 1 ? "" : "s")
     # periodisless
     @eval periodisless(x::$p,y::$p) = value(x) < value(y)
     # AbstractString parsing (mainly for IO code)

--- a/base/show.jl
+++ b/base/show.jl
@@ -80,7 +80,7 @@ function show(io::IO, x::DataType)
     if isvarargtype(x)
         print(io, x.parameters[1], "...")
     else
-        print(io, x.name.name)
+        show(io, x.name)
         if length(x.parameters) > 0
             show_comma_array(io, x.parameters, '{', '}')
         end
@@ -103,7 +103,14 @@ macro show(exs...)
     return blk
 end
 
-show(io::IO, tn::TypeName) = print(io, tn.name)
+function show(io::IO, tn::TypeName)
+    if tn.module == Core || tn.module == Base || tn.module == Main
+        print(io, tn.name)
+    else
+        print(io, tn.module, '.', tn.name)
+    end
+end
+
 show(io::IO, ::Void) = print(io, "nothing")
 show(io::IO, b::Bool) = print(io, b ? "true" : "false")
 show(io::IO, n::Signed) = (write(io, dec(n)); nothing)


### PR DESCRIPTION
This seems significantly more helpful and informative to me much of the time.
