### PR TITLE
pinv: fix the tolerance parameter for diagonal matrices 

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -419,20 +419,24 @@ end
 
 ## Moore-Penrose inverse
 function pinv{T}(A::StridedMatrix{T}, tol::Real)
-    if( abs(tol) == 0 ) return pinv_adaptive(A); end
+## for __dense__ ill-conditioned matrices, please use
+## the threshold tol = sqrt(eps(real(float(one(T)))))
     m, n        = size(A)
+    (m == 0 || n == 0) && return Array(T, n, m)
     if istril(A)
        if( istriu(A) )
+          maxabsA = maximum(abs(diag(A)))
           B = zeros(T,n,m);
           for i = 1:min(m,n)
-             if( isfinite(one(T)/A[i,i]) ) B[i,i] = one(T)/A[i,i]; end
+             if( abs(A[i,i]) > tol*maxabsA && isfinite(one(T)/A[i,i]) )
+                 B[i,i] = one(T)/A[i,i]
+             end
           end
 	  return B;
        end
     end
     SVD         = svdfact(A, thin=true)
     S           = eltype(SVD[:S])
-    (m == 0 || n == 0) && return Array(S, n, m)
     Sinv        = zeros(S, length(SVD[:S]))
     index       = SVD[:S] .> tol*maximum(SVD[:S])
     Sinv[index] = one(S) ./ SVD[:S][index]
@@ -440,50 +444,11 @@ function pinv{T}(A::StridedMatrix{T}, tol::Real)
     return SVD[:Vt]'scale(Sinv, SVD[:U]')
 end
 function pinv{T}(A::StridedMatrix{T})
-    tol = eps(real(float(one(T))))*maximum(size(A));
+    tol = eps(real(float(one(T))))*maximum(size(A))
     return pinv(A, tol)
 end
 pinv(a::StridedVector) = pinv(reshape(a, length(a), 1))
 pinv(x::Number) = isfinite(one(x)/x) ? one(x)/x : zero(x)
-## Moore-Penrose inverse with adaptive tolerance thresholding
-function pinv_adaptive{T}(A::StridedMatrix{T})
-    m, n        = size(A)
-    if istril(A)
-       if( istriu(A) )
-          B = zeros(T,n,m);
-          for i = 1:min(m,n)
-             if( isfinite(one(T)/A[i,i]) ) B[i,i] = one(T)/A[i,i]; end
-          end
-	  return B;
-       end
-    end
-    SVD         = svdfact(A, thin=true)
-    S           = eltype(SVD[:S])
-    (m == 0 || n == 0) && return Array(S, n, m)
-
-    Sinv        = zeros(S, length(SVD[:S]))
-    tol1 = eps(real(float(one(T))))*maximum(size(A))
-    index       = SVD[:S] .> tol1*maximum(SVD[:S])
-    Sinv[index] = one(S) ./ SVD[:S][index]
-    Sinv[find(!isfinite(Sinv))] = zero(S)
-    Apinv1 = SVD[:Vt]'scale(Sinv, SVD[:U]')
-
-    Sinv        = zeros(S, length(SVD[:S]))
-    tol2 = sqrt(eps(real(float(one(T)))))
-    index       = SVD[:S] .> tol2*maximum(SVD[:S])
-    Sinv[index] = one(S) ./ SVD[:S][index]
-    Sinv[find(!isfinite(Sinv))] = zero(S)
-    Apinv2 = SVD[:Vt]'scale(Sinv, SVD[:U]')
-
-    if ( m > n )
-    err1 = vecnorm(A*(Apinv1*A)-A)
-    err2 = vecnorm(A*(Apinv2*A)-A)
-    else
-    err1 = vecnorm((A*Apinv1)*A-A)
-    err2 = vecnorm((A*Apinv2)*A-A)
-    end
-    return ((err1 < err2) ? Apinv1 : Apinv2)
-end
 
 ## Basis for null space
 function null{T}(A::StridedMatrix{T})

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -129,7 +129,18 @@ function pinv{T}(D::Diagonal{T})
     end
     Diagonal(Di)
 end
-pinv{T}(D::Diagonal{T}, tol::Real) = pinv(D)
+function pinv{T}(D::Diagonal{T}, tol::Real)
+    Di = similar(D.diag)
+    if( length(D.diag) != 0 ) maxabsD = maximum(abs(D.diag)) end
+    for i = 1:length(D.diag)
+        if( abs(D.diag[i]) > tol*maxabsD && isfinite(inv(D.diag[i])) )
+            Di[i]=inv(D.diag[i])
+        else
+            Di[i]=zero(T)
+        end
+    end
+    Diagonal(Di)
+end
 
 #Eigensystem
 eigvals{T<:Number}(D::Diagonal{T}) = D.diag

--- a/test/linalg/pinv.jl
+++ b/test/linalg/pinv.jl
@@ -109,16 +109,6 @@ x0 = randn(n); b = a*x0; x = apinv*b;
 debug && println(vecnorm(a*apinv*a - a)/vecnorm(a))
 debug && println(vecnorm(a*x-b)/vecnorm(b))
 
-
-debug && println("=== julia pinv, adaptive threshold ===")
-apinv = pinv(a,0);
-
-@test_approx_eq_eps vecnorm(a*apinv*a - a)/vecnorm(a) 0 tol3
-x0 = randn(n); b = a*x0; x = apinv*b;
-@test_approx_eq_eps vecnorm(a*x-b)/vecnorm(b) 0 tol3
-debug && println(vecnorm(a*apinv*a - a)/vecnorm(a))
-debug && println(vecnorm(a*x-b)/vecnorm(b))
-
 end
 
 


### PR DESCRIPTION
Following the yesterday's bug fixes and discussions, I looked more into the related issue JuliaLang/LinearAlgebra.jl#59. This pull request addresses consistency requirements (users expect `pinv` to be similar to `\`) discussed in the thread above and simplifies implementation logic.

For consistency, this branch implements the threshold parameter for all diagonal matrices (dense and sparse), and `pinv(a,0)` will use all singular vectors to compute the pseudo-inverse. The pinv operator now behaves similarly to the one in matlab, in fact, this code is quite similar to the original Andreas' implementation plus some tweaks for speed and guarding for zero and denormalized numbers.

Unfortunately, the adaptive thresholding option had to go, but that can be addressed by simply documenting the fact that general dense ill-conditioned matrices will benefit from using the threshold parameter `sqrt(eps(real(float(one(T)))))`.  The test driver was updated accordingly.
