### PR TITLE
Fix help for operators starting with a dot

### DIFF
--- a/base/help.jl
+++ b/base/help.jl
@@ -97,7 +97,7 @@ function help(io::IO, fname::AbstractString, obj=0)
         for mod in allmods
             mfname = isempty(mod) ? fname : mod * "." * fname
             if isgeneric(obj)
-                mf = eval(func_expr_from_symbols(map(symbol, split(mfname, "."))))
+                mf = eval(func_expr_from_symbols(map(symbol, split(mfname, r"(?<!\.)\."))))
                 if mf === obj
                     append!(alldesc, FUNCTION_DICT[mfname])
                     found = true


### PR DESCRIPTION
This fixes #8903 and supersedes #8922 (cc @hayd). Basically, when you pass a function to the help system (instead of just its name), the system can go through all the modules and only returns those methods that actually extend the same function.  The way it does this, however, is a little hacky... using string concatenation to combine the function name with the module names, and then splitting it back apart again on dots to get the functions within each module.  This simply improves the splitting logic with a regex to handle the leading dot.
