### PR TITLE
support arbitrary meta branch, #8370

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -39,7 +39,7 @@ free(pkg::AbstractString) = cd(Entry.free,pkg)
 pin(pkg::AbstractString) = cd(Entry.pin,pkg)
 pin(pkg::AbstractString, ver::VersionNumber) = cd(Entry.pin,pkg,ver)
 
-update() = cd(Entry.update,META_BRANCH)
+update() = cd(Entry.update,Dir.getmetabranch())
 resolve() = cd(Entry.resolve)
 
 register(pkg::AbstractString) = cd(Entry.register,pkg)
@@ -55,7 +55,7 @@ tag(pkg::AbstractString, ver::VersionNumber, commit::AbstractString; force::Bool
 submit(pkg::AbstractString) = cd(Entry.submit,pkg)
 submit(pkg::AbstractString, commit::AbstractString) = cd(Entry.submit,pkg,commit)
 
-publish() = cd(Entry.publish,META_BRANCH)
+publish() = cd(Entry.publish,Dir.getmetabranch())
 
 build() = cd(Entry.build)
 build(pkgs::AbstractString...) = cd(Entry.build,[pkgs...])

--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -45,11 +45,26 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
             info("Cloning METADATA from $meta")
             run(`git clone -q -b $branch $meta METADATA`)
             Git.set_remote_url(meta, dir="METADATA")
-            run(`touch REQUIRE`)
+            touch("REQUIRE")
+            touch("META_BRANCH")
+            open("META_BRANCH", "w") do io
+                write(io, branch)
+                close(io)
+            end
         end
     catch e
         rm(dir, recursive=true)
         rethrow(e)
+    end
+end
+
+function getmetabranch()
+    try
+        open(joinpath(path(),"META_BRANCH")) do io
+          chomp(readuntil(io, "/n"))
+        end
+    catch
+        META_BRANCH
     end
 end
 

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -1,7 +1,7 @@
 module Entry
 
 import Base: thispatch, nextpatch, nextminor, nextmajor, check_new_version
-import ..Git, ..Reqs, ..Read, ..Query, ..Resolve, ..Cache, ..Write, ..GitHub
+import ..Git, ..Reqs, ..Read, ..Query, ..Resolve, ..Cache, ..Write, ..GitHub, ..Dir
 using ..Types
 
 macro recover(ex)
@@ -47,7 +47,7 @@ function add(pkg::AbstractString, vers::VersionSet)
             ispath(pkg) || error("unknown package $pkg")
             info("Nothing to be done")
         end
-        branch = Pkg.META_BRANCH
+        branch = Dir.getmetabranch()
         if Git.branch(dir="METADATA") == branch
             if !Git.success(`diff --quiet origin/$branch`, dir="METADATA")
                 outdated = :yes


### PR DESCRIPTION
Hi,
I've added support for a user-specified meta branch. This removes the hard-coding of `metadata-v2` but still leaves it as the default.

Please let me know any feedback and I will incorporate!
