### PR TITLE
Add a performance disclaimer to the banner

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -220,7 +220,9 @@ function banner(io::IO = STDOUT)
         end
     end
     commit_date = GIT_VERSION_INFO.date_string != "" ? " ($(GIT_VERSION_INFO.date_string))": ""
-
+    disclaimer = """Note that the REPL is only meant for prototype development. If you are
+    interested in the performance of a piece of code, please put that code
+    inside of a function so that Julia's JIT compiler can optimize it."""
     if have_color
         tx = "\033[0m\033[1m" # text
         jl = "\033[0m\033[1m" # julia
@@ -238,7 +240,9 @@ function banner(io::IO = STDOUT)
          $(jl)_/ |\\__'_|_|_|\\__'_|$(tx)  |  $(commit_string)
         $(jl)|__/$(tx)                   |  $(Sys.MACHINE)
 
-        \033[0m""")
+        $(disclaimer)
+        \033[0m
+        """)
     else
         print(io,"""
                        _
@@ -249,6 +253,8 @@ function banner(io::IO = STDOUT)
           | | |_| | | | (_| |  |  Version $(VERSION)$(commit_date)
          _/ |\\__'_|_|_|\\__'_|  |  $(commit_string)
         |__/                   |  $(Sys.MACHINE)
+
+        $(disclaimer)
 
         """)
     end


### PR DESCRIPTION
I sincerely believe that adding this disclaimer (or one like it) to the start of every interactive Julia session will substantially decrease the confusion that new Julia users experience. Obviously this is a last-resort kind of measure, but we've had the same performance problems being reported for years. I would argue that the lack of optimization in the global namespace is the single easiest thing newcomers can complain about it, since it makes Julia's fabled C-like performance seem like a lie.

@stevengj also noted on julia-users that we could add this behavior to `toc`, although I couldn't tell if he was being sarcastic or not.
