### PR TITLE
Fix so latex completion do not interfere with path completion in strings on windows.

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -166,7 +166,7 @@ end
 
 function latex_completions(string, pos)
     slashpos = rsearch(string, '\\', pos)
-    if rsearch(string, whitespace_chars, pos) < slashpos
+    if rsearch(string, whitespace_chars, pos) < slashpos && !(1 < slashpos && (string[slashpos-1]=='\\'))
         # latex symbol substitution
         s = string[slashpos:pos]
         latex = get(latex_symbols, s, "")

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -73,6 +73,12 @@ c,r = test_latexcomplete(s)
 @test r == 1:length(s)
 @test length(c) == 1
 
+# test latex symbol completions in strings should not work when there
+# is a backslash in front of `\alpha` because it interferes with path completion on windows
+s = "cd(\"path_to_an_empty_folder_should_not_complete_latex\\\\\\alpha"
+c,r,res = test_complete(s)
+@test length(c) == 0
+
 # test latex symbol completions in strings
 s = "\"C:\\\\ \\alpha"
 c,r,res = test_complete(s)


### PR DESCRIPTION
See disscusion #8983.
Is this what you imagined @tkelman?
It can just not complete when there two is a backslash

```
\\alpha<tab> #do not work anymore
```

but I can't really imagine it would be a problem, else a keyword argument can fix it.
