### PR TITLE
Add _nref method specifically for type inference (fixes #9135)

### DIFF
--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -314,6 +314,7 @@ function _nref(N::Int, A::Symbol, ex)
     vars = [ inlineanonymous(ex,i) for i = 1:N ]
     Expr(:escape, Expr(:ref, A, vars...))
 end
+_nref(::TypeVar, A::Symbol, ex) = Expr(:escape, Expr(:ref, A, 0))
 
 # Generate f(arg1, arg2, ...)
 macro ncall(N, f, sym...)


### PR DESCRIPTION
I'm not sure whether this is a good idea or not, especially in light of https://github.com/JuliaLang/julia/issues/8818#issuecomment-60523682. So I'll wait for comments.
