### PR TITLE
Blas scal cleanup

### DIFF
--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -79,7 +79,7 @@ for (fname, elty) in ((:dscal_,:Float64),
                       (:cscal_,:Complex64))
     @eval begin
         # SUBROUTINE DSCAL(N,DA,DX,INCX)
-        function scal!(n::Integer, DA::$elty, DX::Union(Ptr{$elty},StridedArray{$elty}), incx::Integer)
+        function scal!(n::Integer, DA::$elty, DX::Union(Ptr{$elty},DenseArray{$elty}), incx::Integer)
             ccall(($(blasfunc(fname)), libblas), Void,
                   (Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}),
                   &n, &DA, DX, &incx)
@@ -89,17 +89,17 @@ for (fname, elty) in ((:dscal_,:Float64),
 end
 scal(n, DA, DX, incx) = scal!(n, DA, copy(DX), incx)
 # In case DX is complex, and DA is real, use dscal/sscal to save flops
-for (fname, elty, celty) in ((:sscal_, :Float32, :Complex64),
-                             (:dscal_, :Float64, :Complex128))
-    @eval begin
-        function scal!(n::Integer, DA::$elty, DX::Union(Ptr{$celty},StridedArray{$celty}), incx::Integer)
-            ccall(($(blasfunc(fname)), libblas), Void,
-                  (Ptr{BlasInt}, Ptr{$elty}, Ptr{$celty}, Ptr{BlasInt}),
-                  &(2*n), &DA, DX, &incx)
-            DX
-        end
-    end
-end
+#for (fname, elty, celty) in ((:sscal_, :Float32, :Complex64),
+#                             (:dscal_, :Float64, :Complex128))
+#    @eval begin
+#        function scal!(n::Integer, DA::$elty, DX::Union(Ptr{$celty},StridedArray{$celty}), incx::Integer)
+#            ccall(($(blasfunc(fname)), libblas), Void,
+#                  (Ptr{BlasInt}, Ptr{$elty}, Ptr{$celty}, Ptr{BlasInt}),
+#                  &(2*n), &DA, DX, &incx)
+#            DX
+#        end
+#    end
+#end
 
 ## dot
 for (fname, elty) in ((:ddot_,:Float64),

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -17,7 +17,10 @@ function scale!{T<:BlasFloat}(X::Array{T}, s::T)
 end
 
 scale!{T<:BlasFloat}(X::Array{T}, s::Number) = scale!(X, convert(T, s))
-scale!{T<:BlasComplex}(X::Array{T}, s::Real) = BLAS.scal!(length(X), oftype(real(zero(T)),s), X, 1)
+function scale!{T<:BlasComplex}(X::Array{T}, s::Real)
+    R = typeof(real(zero(T)))
+    BLAS.scal!(2*length(X), convert(R,s), convert(Ptr{R},pointer(X)), 1)
+end
 
 #Test whether a matrix is positive-definite
 isposdef!{T<:BlasFloat}(A::StridedMatrix{T}, UL::Symbol) = LAPACK.potrf!(char_uplo(UL), A)[2] == 0

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -20,6 +20,7 @@ scale!{T<:BlasFloat}(X::Array{T}, s::Number) = scale!(X, convert(T, s))
 function scale!{T<:BlasComplex}(X::Array{T}, s::Real)
     R = typeof(real(zero(T)))
     BLAS.scal!(2*length(X), convert(R,s), convert(Ptr{R},pointer(X)), 1)
+    X
 end
 
 #Test whether a matrix is positive-definite


### PR DESCRIPTION
Clean up of `BLAS.scal!`.  It is a update to https://github.com/JuliaLang/julia/pull/8499.  Issue is discussed in https://github.com/JuliaLang/LinearAlgebra.jl/issues/141.
1. `BLAS.scal!` is no longer a method for `StridedArray`s
2. Behavior for real-scalar, complex-array is moved to `dense.jl`
