### PR TITLE
faster randmtzig_exprnd (separate unlikely branch + inline) and rename it "randexp"

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -905,6 +905,8 @@ export
     randbool,
     randn!,
     randn,
+    randexp!,
+    randexp,
     srand,
 
 # bigfloat & precision

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4119,6 +4119,14 @@ A ``MersenneTwister`` RNG can generate random numbers of the following types: ``
 
    Fill the array A with normally-distributed (mean 0, standard deviation 1) random numbers. Also see the rand function.
 
+.. function:: randexp([rng], [dims...])
+
+   Generate a random number according to the exponential distribution with scale 1. Optionally generate an array of such random numbers.
+
+.. function:: randexp!([rng], A::Array{Float64,N})
+
+   Fill the array A with random numbers following the exponential distribution (with scale 1).
+
 Arrays
 ------
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -80,10 +80,19 @@ if sizeof(Int32) < sizeof(Int)
 
 end
 
+randn()
 randn(100000)
 randn!(Array(Float64, 100000))
+randn(MersenneTwister(10))
 randn(MersenneTwister(10), 100000)
 randn!(MersenneTwister(10), Array(Float64, 100000))
+
+randexp()
+randexp(100000)
+randexp!(Array(Float64, 100000))
+randexp(MersenneTwister(10))
+randexp(MersenneTwister(10), 100000)
+randexp!(MersenneTwister(10), Array(Float64, 100000))
 
 # Test ziggurat tables
 ziggurat_table_size = 256


### PR DESCRIPTION
Same transformation as was done recently on `randn`.
The rename was suggested by @ViralBShah. It turns out that this function is not exported by Base (nor documented it seems), should it be? If yes, I will write the array version `randexp!` too.
