### PR TITLE
RFC: Return views from UnitRange indexing of Arrays

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -432,10 +432,10 @@ function edit_move_up(s)
 end
 
 function edit_move_down(buf::IOBuffer)
-    npos = rsearch(buf.data[1:buf.size], '\n', position(buf))
+    npos = rsearch(copy(buf.data[1:buf.size]), '\n', position(buf))
     # We're interested in character count, not byte count
     offset = length(bytestring(buf.data[(npos+1):(position(buf))]))
-    npos2 = search(buf.data[1:buf.size], '\n', position(buf)+1)
+    npos2 = search(copy(buf.data[1:buf.size]), '\n', position(buf)+1)
     if npos2 == 0 #we're in the last line
         return false
     end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -77,6 +77,7 @@ checkbounds(sz::Int, i::Real) = checkbounds(sz, to_index(i))
 checkbounds(sz::Int, I::AbstractVector{Bool}) = length(I) == sz || throw(BoundsError())
 checkbounds(sz::Int, r::Range{Int}) = isempty(r) || (minimum(r) >= 1 && maximum(r) <= sz) || throw(BoundsError())
 checkbounds{T<:Real}(sz::Int, r::Range{T}) = checkbounds(sz, to_index(r))
+checkbounds(sc::Int, ::Colon) = true
 
 function checkbounds{T <: Real}(sz::Int, I::AbstractArray{T})
     for i in I
@@ -88,17 +89,17 @@ checkbounds(A::AbstractArray, I::AbstractArray{Bool}) = size(A) == size(I) || th
 
 checkbounds(A::AbstractArray, I) = checkbounds(length(A), I)
 
-function checkbounds(A::AbstractMatrix, I::Union(Real,AbstractArray), J::Union(Real,AbstractArray))
+function checkbounds(A::AbstractMatrix, I::Union(Real,AbstractArray,Colon), J::Union(Real,AbstractArray,Colon))
     checkbounds(size(A,1), I)
     checkbounds(size(A,2), J)
 end
 
-function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray), J::Union(Real,AbstractArray))
+function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray,Colon), J::Union(Real,AbstractArray,Colon))
     checkbounds(size(A,1), I)
     checkbounds(trailingsize(A,2), J)
 end
 
-function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray)...)
+function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray,Colon)...)
     n = length(I)
     if n > 0
         for dim = 1:(n-1)

--- a/base/array.jl
+++ b/base/array.jl
@@ -609,7 +609,7 @@ function splice!(a::Vector, i::Integer, ins=_default_splice)
 end
 
 function splice!{T<:Integer}(a::Vector, r::UnitRange{T}, ins=_default_splice)
-    v = a[r]
+    v = copy(a[r])
     m = length(ins)
     if m == 0
         deleteat!(a, r)

--- a/base/array.jl
+++ b/base/array.jl
@@ -271,14 +271,15 @@ getindex(A::Array, i0::Real, i1::Real, i2::Real, i3::Real,  i4::Real, i5::Real, 
     arrayref(A,to_index(i0),to_index(i1),to_index(i2),to_index(i3),to_index(i4),to_index(i5),to_index(I)...)
 
 # Fast copy using copy! for UnitRange
-function getindex(A::Array, I::UnitRange{Int})
-    lI = length(I)
-    X = similar(A, lI)
-    if lI > 0
-        copy!(X, 1, A, first(I), lI)
-    end
-    return X
-end
+getindex(A::Array, I::UnitRange{Int}) = slice(A, I)
+# function getindex(A::Array, I::UnitRange{Int})
+#     lI = length(I)
+#     X = similar(A, lI)
+#     if lI > 0
+#         copy!(X, 1, A, first(I), lI)
+#     end
+#     return X
+# end
 
 function getindex{T<:Real}(A::Array, I::AbstractVector{T})
     return [ A[i] for i in to_index(I) ]

--- a/base/array.jl
+++ b/base/array.jl
@@ -362,6 +362,7 @@ function setindex!{T<:Real}(A::Array, X::AbstractArray, I::AbstractVector{T})
     return A
 end
 
+setindex!(A::Array, x, I::Colon) = setindex!(A, x, 1:length(x))
 
 # logical indexing
 

--- a/base/ascii.jl
+++ b/base/ascii.jl
@@ -14,9 +14,9 @@ getindex(s::ASCIIString, i::Int) = (x=s.data[i]; x < 0x80 ? char(x) : '\ufffd')
 
 sizeof(s::ASCIIString) = sizeof(s.data)
 
-getindex(s::ASCIIString, r::Vector) = ASCIIString(getindex(s.data,r))
-getindex(s::ASCIIString, r::UnitRange{Int}) = ASCIIString(getindex(s.data,r))
-getindex(s::ASCIIString, indx::AbstractVector{Int}) = ASCIIString(s.data[indx])
+getindex(s::ASCIIString, r::Vector) = ASCIIString([s.data[i] for i = r])
+getindex(s::ASCIIString, r::UnitRange{Int}) = ASCIIString([s.data[i] for i = r])
+getindex(s::ASCIIString, indx::AbstractVector{Int}) = ASCIIString([s.data[i] for i = indx])
 search(s::ASCIIString, c::Char, i::Integer) = c < char(0x80) ? search(s.data,uint8(c),i) : 0
 rsearch(s::ASCIIString, c::Char, i::Integer) = c < char(0x80) ? rsearch(s.data,uint8(c),i) : 0
 

--- a/base/darray.jl
+++ b/base/darray.jl
@@ -111,7 +111,7 @@ function chunk_idxs(dims, chunks)
     idxs, cuts
 end
 
-function localpartindex(pmap::Vector{Int})
+function localpartindex(pmap::StridedVector{Int})
     mi = myid()
     for i = 1:length(pmap)
         if pmap[i] == mi

--- a/base/help.jl
+++ b/base/help.jl
@@ -83,7 +83,7 @@ function print_help_entries(io::IO, entries)
     end
 end
 
-func_expr_from_symbols(s::Vector{Symbol}) = length(s) == 1 ? s[1] : Expr(:., func_expr_from_symbols(s[1:end-1]), Expr(:quote, s[end]))
+func_expr_from_symbols(s::Vector{Symbol}) = length(s) == 1 ? s[1] : Expr(:., func_expr_from_symbols(copy(s[1:end-1])), Expr(:quote, s[end]))
 
 function help(io::IO, fname::AbstractString, obj=0)
     init_help()

--- a/base/linalg/cholmod.jl
+++ b/base/linalg/cholmod.jl
@@ -38,13 +38,13 @@ const chm_l_com  = fill(0xff, chm_com_sz)
 ## chm_com and chm_l_com must be initialized at runtime because they contain pointers
 ## to functions in libc.so, whose addresses can change
 function cmn(::Type{Int32})
-    if isnan(reinterpret(Float64,chm_com[1:8])[1])
+    if isnan(reinterpret(Float64, copy(chm_com[1:8]))[1])
         @isok ccall((:cholmod_start, :libcholmod), Cint, (Ptr{UInt8},), chm_com)
     end
     chm_com
 end
 function cmn(::Type{Int64})
-    if isnan(reinterpret(Float64,chm_l_com[1:8])[1])
+    if isnan(reinterpret(Float64, copy(chm_l_com[1:8]))[1])
         @isok ccall((:cholmod_l_start, :libcholmod), Cint, (Ptr{UInt8},), chm_l_com)
     end
     chm_l_com
@@ -839,7 +839,7 @@ end
 
 A_ldiv_B!(L::CholmodFactor, B) = L\B # Revisit this to see if allocation can be avoided. It should be possible at least for the right hand side.
 (\){T<:CHMVTypes}(L::CholmodFactor{T}, B::CholmodDense{T}) = solve(L, B, CHOLMOD_A)
-(\){T<:CHMVTypes}(L::CholmodFactor{T}, b::Vector{T}) = reshape(solve(L, CholmodDense!(b), CHOLMOD_A).mat, length(b))
+(\){T<:CHMVTypes}(L::CholmodFactor{T}, b::StridedVector{T}) = reshape(solve(L, CholmodDense!(convert(Vector{T}, b)), CHOLMOD_A).mat, length(b))
 (\){T<:CHMVTypes}(L::CholmodFactor{T}, B::Matrix{T}) = solve(L, CholmodDense!(B),CHOLMOD_A).mat
 function (\){Tv<:CHMVTypes,Ti<:CHMITypes}(L::CholmodFactor{Tv,Ti},B::CholmodSparse{Tv,Ti})
     solve(L,B,CHOLMOD_A)

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -334,7 +334,7 @@ function inv{S}(A::StridedMatrix{S})
     return convert(typeof(Ac), Ai)
 end
 
-function factorize{T}(A::Matrix{T})
+function factorize{T}(A::StridedMatrix{T})
     m, n = size(A)
     if m == n
         if m == 1 return A[1] end

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -79,19 +79,19 @@ convert{T}(::Type{Factorization{T}}, A::QRPivoted) = convert(QRPivoted{T}, A)
 
 function getindex(A::QR, d::Symbol)
     m, n = size(A)
-    d == :R && return triu!(A.factors[1:min(m,n), 1:n])
+    d == :R && return triu(A.factors[1:min(m,n), 1:n])
     d == :Q && return QRPackedQ(A.factors,A.τ)
     throw(KeyError(d))
 end
 function getindex(A::QRCompactWY, d::Symbol)
     m, n = size(A)
-    d == :R && return triu!(A.factors[1:min(m,n), 1:n])
+    d == :R && return triu(A.factors[1:min(m,n), 1:n])
     d == :Q && return QRCompactWYQ(A.factors,A.T)
     throw(KeyError(d))
 end
 function getindex{T}(A::QRPivoted{T}, d::Symbol)
     m, n = size(A)
-    d == :R && return triu!(A.factors[1:min(m,n), 1:n])
+    d == :R && return triu(A.factors[1:min(m,n), 1:n])
     d == :Q && return QRPackedQ(A.factors,A.τ)
     d == :p && return A.jpvt
     if d == :P

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -94,11 +94,11 @@ end
 function getindex{T,S<:StridedMatrix}(A::LU{T,S}, d::Symbol)
     m, n = size(A)
     if d == :L
-        L = tril!(A.factors[1:m, 1:min(m,n)])
+        L = tril(A.factors[1:m, 1:min(m,n)])
         for i = 1:min(m,n); L[i,i] = one(T); end
         return L
     end
-    d == :U && return triu!(A.factors[1:min(m,n), 1:n])
+    d == :U && return triu(A.factors[1:min(m,n), 1:n])
     d == :p && return ipiv2perm(A.ipiv, m)
     if d == :P
         p = A[:p]

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -24,8 +24,8 @@ function scale!(C::AbstractMatrix, b::AbstractVector, A::AbstractMatrix)
     end
     C
 end
-scale(A::Matrix, b::Vector) = scale!(similar(A, promote_type(eltype(A),eltype(b))), A, b)
-scale(b::Vector, A::Matrix) = scale!(similar(b, promote_type(eltype(A),eltype(b)), size(A)), b, A)
+scale(A::AbstractMatrix, b::AbstractVector) = scale!(similar(A, promote_type(eltype(A),eltype(b))), A, b)
+scale(b::AbstractVector, A::AbstractMatrix) = scale!(similar(b, promote_type(eltype(A),eltype(b)), size(A)), b, A)
 
 # Dot products
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -171,12 +171,12 @@ end
 _getindex(A, I::(Union(Int,AbstractVector)...)) =
     _getindex!(similar(A, index_shape(I...)), A, I...)
 
-@nsplat N function getindex(A::Array, I::NTuple{N,UnitRange{Int}}...)
+@nsplat N function getindex(A::Array, I::NTuple{N,Union(Real,UnitRange{Int},Colon)}...)
     checkbounds(A, I...)
     slice(A, I...)
 end
 
-@nsplat N function getindex(A::Array, I::NTuple{N,Union(Real,AbstractVector)}...)
+@nsplat N function getindex(A::Array, I::NTuple{N,AbstractVector}...)
     checkbounds(A, I...)
     _getindex(A, to_index(I...))
 end
@@ -188,7 +188,7 @@ end
 end
 
 
-@ngenerate N typeof(A) function setindex!(A::Array, x, J::NTuple{N,Union(Real,AbstractArray)}...)
+@ngenerate N typeof(A) function setindex!(A::Array, x, J::NTuple{N,Union(Real,AbstractArray,Colon)}...)
     @ncall N checkbounds A J
     @nexprs N d->(I_d = to_index(J_d))
     stride_1 = 1

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -171,6 +171,8 @@ end
 _getindex(A, I::(Union(Int,AbstractVector)...)) =
     _getindex!(similar(A, index_shape(I...)), A, I...)
 
+@nsplat N getindex(A::Array, I::NTuple{N,UnitRange{Int}}...) = slice(A, I...)
+
 @nsplat N function getindex(A::Array, I::NTuple{N,Union(Real,AbstractVector)}...)
     checkbounds(A, I...)
     _getindex(A, to_index(I...))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -171,7 +171,10 @@ end
 _getindex(A, I::(Union(Int,AbstractVector)...)) =
     _getindex!(similar(A, index_shape(I...)), A, I...)
 
-@nsplat N getindex(A::Array, I::NTuple{N,UnitRange{Int}}...) = slice(A, I...)
+@nsplat N function getindex(A::Array, I::NTuple{N,UnitRange{Int}}...)
+    checkbounds(A, I...)
+    slice(A, I...)
+end
 
 @nsplat N function getindex(A::Array, I::NTuple{N,Union(Real,AbstractVector)}...)
     checkbounds(A, I...)

--- a/base/range.jl
+++ b/base/range.jl
@@ -66,6 +66,8 @@ immutable UnitRange{T<:Real} <: OrdinalRange{T,Int}
 end
 UnitRange{T<:Real}(start::T, stop::T) = UnitRange{T}(start, stop)
 
+colon() = Colon()
+
 colon(a::Real, b::Real) = colon(promote(a,b)...)
 
 colon{T<:Real}(start::T, stop::T) = UnitRange{T}(start, stop)

--- a/base/show.jl
+++ b/base/show.jl
@@ -360,7 +360,7 @@ function show_call(io::IO, head, func, func_args, indent)
     end
     if !isempty(func_args) && isa(func_args[1], Expr) && func_args[1].head === :parameters
         print(io, op)
-        show_list(io, func_args[2:end], ',', indent, 0)
+        show_list(io, [func_args[i] for i = 2:length(func_args)], ',', indent, 0)
         print(io, "; ")
         show_list(io, func_args[1].args, ',', indent, 0)
         print(io, cl)
@@ -452,13 +452,13 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
     # function declaration (like :call but always printed with parens)
     # (:calldecl is a "fake" expr node created when we find a :function expr)
     elseif head == :calldecl && nargs >= 1
-        show_call(io, head, args[1], args[2:end], indent)
+        show_call(io, head, args[1], [args[i] for i = 2:length(args)], indent)
 
     # function call
     elseif haskey(expr_calls, head) && nargs >= 1  # :call/:ref/:curly
         func = args[1]
         func_prec = operator_precedence(func)
-        func_args = args[2:end]
+        func_args = [args[i] for i = 2:length(args)]
 
         # scalar multiplication (i.e. "100x")
         if (func == :(*) && length(func_args)==2 &&
@@ -587,7 +587,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         print(io, "end")
 
     elseif is(head, :let) && nargs >= 1
-        show_block(io, "let", args[2:end], args[1], indent); print(io, "end")
+        show_block(io, "let", [args[i] for i = 2:length(args)], args[1], indent); print(io, "end")
 
     elseif is(head, :block) || is(head, :body)
         show_block(io, "begin", ex, indent); print(io, "end")

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -477,7 +477,7 @@ function _uv_hook_recv(sock::UDPSocket, nread::Int, buf_addr::Ptr{Void}, buf_siz
         notify_error(sock.recvnotify,"Partial message received")
     end
     buf = pointer_to_array(convert(Ptr{UInt8},buf_addr),int(buf_size),true)
-    notify(sock.recvnotify,buf[1:nread])
+    notify(sock.recvnotify, copy(buf[1:nread]))
 end
 
 function _send(sock::UDPSocket,ipaddr::IPv4,port::UInt16,buf)

--- a/base/string.jl
+++ b/base/string.jl
@@ -32,6 +32,7 @@ string(xs...) = print_to_string(xs...)
 
 bytestring() = ""
 bytestring(s::Array{UInt8,1}) = bytestring(pointer(s),length(s))
+bytestring{N}(s::SubArray{UInt8,1,Array{UInt8,N},(UnitRange{Int64},),1}) = bytestring(pointer(s),length(s))
 bytestring(s::AbstractString...) = print_to_string(s...)
 
 function bytestring(p::Union(Ptr{UInt8},Ptr{Int8}))

--- a/base/string.jl
+++ b/base/string.jl
@@ -1040,7 +1040,7 @@ function triplequoted(args...)
         for s in sx
             if isa(s,ByteString)
                 lines = split(s,'\n')
-                for line in lines[2:end]
+                for line in [lines[i] for i = 2:length(lines)]
                     n,blank = indentation(line)
                     if !blank
                         indent = min(indent, n)

--- a/base/utf32.jl
+++ b/base/utf32.jl
@@ -45,8 +45,10 @@ function convert(::Type{UTF32String}, data::AbstractVector{Char})
     UTF32String(copy!(d,1, data,1, len))
 end
 
-convert{T<:Union(Int32,UInt32)}(::Type{UTF32String}, data::AbstractVector{T}) =
+convert{T<:Union(Int32,UInt32)}(::Type{UTF32String}, data::Vector{T}) =
     convert(UTF32String, reinterpret(Char, data))
+convert{T<:Union(Int32,UInt32)}(::Type{UTF32String}, data::AbstractVector{T}) =
+    convert(UTF32String, reinterpret(Char, convert(Array, data)))
 
 convert{T<:AbstractString}(::Type{T}, v::AbstractVector{Char}) = convert(T, utf32(v))
 

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -107,7 +107,7 @@ function getindex(s::UTF8String, r::UnitRange{Int})
         throw(BoundsError())
     end
     j = nextind(s,j)-1
-    UTF8String(d[i:j])
+    UTF8String([d[k] for k = i:j])
 end
 
 function search(s::UTF8String, c::Char, i::Integer)

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -182,6 +182,7 @@ function convert(::Type{UTF8String}, a::Array{UInt8,1}, invalids_as::AbstractStr
     end
     UTF8String(a)
 end
+convert(::Type{UTF8String}, s::AbstractVector{UInt8}) = convert(UTF8String, convert(Array, s))
 convert(::Type{UTF8String}, s::AbstractString) = utf8(bytestring(s))
 
 # The last case is the replacement character 0xfffd (3 bytes)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -319,7 +319,7 @@
 
 ; translate index x from colons to ranges
 (define (expand-index-colon x)
-  (cond ((eq? x ':) `(call colon 1 end))
+  (cond ((eq? x ':) `(call colon))
 	((and (pair? x)
 	      (eq? (car x) ':))
 	 (cond ((length= x 3)

--- a/test/arpack.jl
+++ b/test/arpack.jl
@@ -92,21 +92,21 @@ size(Phi::CPM)=(size(Phi.kraus,1)^2,size(Phi.kraus,3)^2)
 issym(Phi::CPM)=false
 ishermitian(Phi::CPM)=false
 
-function *{T<:Base.LinAlg.BlasFloat}(Phi::CPM{T},rho::Vector{T})
-	rho=reshape(rho,(size(Phi.kraus,3),size(Phi.kraus,3)))
-	rho2=zeros(T,(size(Phi.kraus,1),size(Phi.kraus,1)))
-	for s=1:size(Phi.kraus,2)
-		As=slice(Phi.kraus,:,s,:)
-		rho2+=As*rho*As'
+function *{T<:Base.LinAlg.BlasFloat}(Phi::CPM{T}, rho::StridedVector{T})
+	rho = reshape(rho, (size(Phi.kraus, 3), size(Phi.kraus, 3)))
+	rho2 = zeros(T, (size(Phi.kraus, 1), size(Phi.kraus, 1)))
+	for s = 1:size(Phi.kraus, 2)
+		As = slice(Phi.kraus, :, s, :)
+		rho2 += As*rho*As'
 	end
-	return reshape(rho2,(size(Phi.kraus,1)^2,))
+	return reshape(rho2, (size(Phi.kraus,1)^2,))
 end
 # Generate random isometry
-(Q,R)=qr(randn(100,50))
-Q=reshape(Q,(50,2,50))
+(Q,R) = qr(randn(100,50))
+Q = reshape(Q,(50,2,50))
 # Construct trace-preserving completely positive map from this
-Phi=CPM(Q)
-(d,v,nconv,numiter,numop,resid) = eigs(Phi,nev=1,which=:LM)
+Phi = CPM(Q)
+(d,v,nconv,numiter,numop,resid) = eigs(Phi, nev=1, which=:LM)
 # Properties: largest eigenvalue should be 1, largest eigenvector, when reshaped as matrix
 # should be a Hermitian positive definite matrix (up to an arbitrary phase)
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -774,7 +774,7 @@ Nmax = 3 # TODO: go up to CARTESIAN_DIMS+2 (currently this exposes problems)
 for N = 1:Nmax
     #indexing with (Range1, Range1, Range1)
     args = ntuple(N, d->Range1{Int})
-    @test Base.return_types(getindex, tuple(Array{Float32, N}, args...)) == [Array{Float32, N}]
+    @test Base.return_types(getindex, tuple(Array{Float32, N}, args...)) == [SubArray{Float32,N,Array{Float32,N},ntuple(N, d->UnitRange{Int64}),1}]
     @test Base.return_types(getindex, tuple(BitArray{N}, args...)) == Any[BitArray{N}]
     @test Base.return_types(setindex!, tuple(Array{Float32, N}, Array{Int, 1}, args...)) == [Array{Float32, N}]
     # Indexing with (Range1, Range1, Float64)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1,5 +1,6 @@
 tc{N}(r1::NTuple{N}, r2::NTuple{N}) = all(map(x->tc(x...), [zip(r1,r2)...]))
 tc{N}(r1::BitArray{N}, r2::Union(BitArray{N},Array{Bool,N})) = true
+tc{N,M}(r1::BitArray{N}, r2::SubArray{Bool,N,Array{Bool,M},NTuple{N,UnitRange{Int64}},1}) = true
 tc{T}(r1::T, r2::T) = true
 tc(r1,r2) = false
 

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -6,7 +6,7 @@ if nprocs() < 3
 end
 
 id_me = myid()
-id_other = filter(x -> x != id_me, procs())[rand(1:(nprocs()-1))]
+id_other = filter(x -> x != id_me, procs())[rand(1:(nprocs() - 1))]
 
 @test fetch(@spawnat id_other myid()) == id_other
 @test @fetchfrom id_other begin myid() end == id_other


### PR DESCRIPTION
This PR changes the behavior of array indexing to return a `SubArray` of the original array instead of an `Array`. This should reduce the number of intermediate arrays allocated in computations and hopefully that change will not be notified much in casual command prompt use of Julia.

I have decided to use `slice` instead of `sub` which is a change in indexing convention. However, this can easily be changed in the pull request if we decide to stick with the present convention. Because of this, I haven't adjusted the `arrayops.jl` tests yet. I'll only do that when we have decided to use either `sub` or `slice`. The rest of the tests should have been through the necessary adjustments.

Examples:

``` julia
julia> A = randn(4,4)
4x4 Array{Float64,2}:
  0.735034   2.32154     1.40147    -1.6871  
 -0.683693   0.72711     0.105667    1.30328 
  1.03254    0.038653   -0.0259387  -1.46718 
  0.600892  -0.0290964  -1.52698    -0.194185

julia> A[1:3,1:3]
3x3 SubArray{Float64,2,Array{Float64,2},(UnitRange{Int64},UnitRange{Int64}),1}:
  0.735034  2.32154    1.40147  
 -0.683693  0.72711    0.105667 
  1.03254   0.038653  -0.0259387

julia> A[1,:]
4-element SubArray{Float64,1,Array{Float64,2},(Int64,Colon),2}:
  0.735034
  2.32154 
  1.40147 
 -1.6871  
```

@carlobaldassi I have made some adjustments to the `BitArray` tests because indexing `Array{Bool}` now behaves differently. I haven't changed the behavior of `BitArray` indexing.

I have also not made any changes to indexing of `SparseMatrixCSC`.

@JeffBezanson I had to change quite a few places in `inference.jl` to avoid the creation of `SubArray`s there. You might want to take a look and see if the changes there are okay.
