### PR TITLE
julia-mode.el: Highlight triple-quoted strings and characters.

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -117,7 +117,7 @@ This function provides equivalent functionality, but makes no efforts to optimis
                     (syntax whitespace)
                     bol))
       (submatch "'"
-                (or (repeat 0 7 (not (any "'"))) (not (any "\\"))
+                (or (repeat 0 8 (not (any "'"))) (not (any "\\"))
                     "\\\\")
                 "'")))
 

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -108,6 +108,18 @@ This function provides equivalent functionality, but makes no efforts to optimis
            "\\\\"))
       (group "'")))
 
+(defconst julia-triple-quoted-string-regex
+  ;; We deliberately put a group on the first and last delimiter, so
+  ;; we can mark these as string delimiters for font-lock.
+  (rx (group "\"")
+      (group "\"\""
+             ;; After the delimiter, we're a sequence of
+             ;; non-backslashes or blackslashes paired with something.
+             (*? (or (not (any "\\"))
+                     (seq "\\" anything)))
+             "\"\"")
+      (group "\"")))
+
 (defconst julia-unquote-regex
   "\\(\\s(\\|\\s-\\|-\\|[,%=<>\\+*/?&|!\\^~\\\\;:]\\|^\\)\\($[a-zA-Z0-9_]+\\)")
 
@@ -385,10 +397,14 @@ before point. Returns nil if we're not within nested parens."
   (set (make-local-variable 'font-lock-defaults) '(julia-font-lock-keywords))
   (set (make-local-variable 'font-lock-syntactic-keywords)
        (list
- 	`(,julia-char-regex
+        `(,julia-char-regex
           (1 "\"") ; Treat ' as a string delimiter.
           (2 ".") ; Don't highlight anything between the open and close '.
-          (3 "\"")) ; Treat the close ' as a string delimiter.
+          (3 "\"")); Treat the close ' as a string delimiter.
+        `(,julia-triple-quoted-string-regex
+          (1 "\"") ; Treat the first " in """ as a string delimiter.
+          (2 ".") ; Don't highlight anything between.
+          (3 "\"")) ; Treat the last " in """ as a string delimiter.
 	))
   (set (make-local-variable 'indent-line-function) 'julia-indent-line)
   (set (make-local-variable 'julia-basic-offset) 4)

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -226,35 +226,10 @@ Handles both single-line and multi-line comments."
   (nth 4 (syntax-ppss)))
 
 (defun julia-in-string ()
-  "Return non-nil if point is inside a string."
+  "Return non-nil if point is inside a string.
+Note this is Emacs' notion of what is highlighted as a string.
+As a result, it is true inside \"foo\", `foo` and 'f'."
   (nth 3 (syntax-ppss)))
-
-(defun julia-in-char ()
-  "Return non-nil if point is inside a character."
-  (cond
-   ((julia-in-comment) nil)
-   ((julia-in-string) nil)
-   ((<= (point) (1+ (point-min))) nil)
-   (:else
-    (save-excursion
-      ;; See if point is inside a character, e.g. '|x'
-      ;;
-      ;; Move back past the single quote.
-      (backward-char 1)
-      ;; Move back one more character, as julia-char-regex checks
-      ;; for whitespace/paren/etc before the single quote.
-      (ignore-errors (backward-char 1)) ; ignore error from being at (point-min)
-
-      (if (looking-at julia-char-regex)
-          t
-        ;; If point was in a \ character (i.e. we started at '\|\'),
-        ;; we need to move back once more.
-        (ignore-errors
-          (if (looking-at (rx "'\\"))
-              (progn
-                (backward-char 1)
-                (looking-at julia-char-regex))
-            nil)))))))
 
 (defun julia-in-brackets ()
   "Return non-nil if point is inside square brackets."
@@ -266,7 +241,7 @@ Handles both single-line and multi-line comments."
 
       (while (< (point) start-pos)
         ;; Don't count [ or ] inside strings, characters or comments.
-        (unless (or (julia-in-string) (julia-in-char) (julia-in-comment))
+        (unless (or (julia-in-string) (julia-in-comment))
 
           (when (looking-at (rx "["))
             (incf open-count))
@@ -341,7 +316,7 @@ before point. Returns nil if we're not within nested parens."
                   (not (plusp open-count)))
 
         (when (looking-at (rx (any "[" "]" "(" ")")))
-          (unless (or (julia-in-string) (julia-in-char) (julia-in-comment))
+          (unless (or (julia-in-string) (julia-in-comment))
             (cond ((looking-at (rx (any "[" "(")))
                    (incf open-count))
                   ((looking-at (rx (any "]" ")")))

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -2904,5 +2904,6 @@ before point. Returns nil if we're not within nested parens."
 
 ;; Local Variables:
 ;; coding: utf-8
+;; byte-compile-warnings: (not obsolete)
 ;; End:
 ;;; julia-mode.el ends here


### PR DESCRIPTION
These commits improve julia-mode's string and character highlighting. We now correctly highlight all legal Julia character literals. I've also added proper support for highlighting triple quoted strings.

My refactoring also ensures we always set string delimeters as string syntax, which fixes #8714.
