### PR TITLE
Make `Pkg.build` error message clearer.

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -639,7 +639,7 @@ function build(pkgs::Vector)
     WARNING: $(join(map(x->x[1],errs),", "," and ")) had build errors.
 
      - packages with build errors remain installed in $(pwd())
-     - build a package and all its dependencies with `Pkg.build(pkg)`
+     - build the package(s) and all dependencies with `Pkg.build("$(join(map(x->x[1],errs),"\", \""))")`
      - build a single package by running its `deps/build.jl` script
     """)
 end


### PR DESCRIPTION
An itch I've long wanted to scratch.

Old:

```
WARNING: Images and IJulia had build errors.

 - packages with build errors remain installed in /home/beyer/.julia
 - build a package and all its dependencies with `Pkg.build(pkg)`
 - build a single package by running its `deps/build.jl` script
```

New:

```
WARNING: Images and IJulia had build errors.

 - packages with build errors remain installed in /home/beyer/.julia
 - build the package(s) and all dependencies with `Pkg.build("Images", "IJulia")`
 - build a single package by running its `deps/build.jl` script
```
