### PR TITLE
allow all bits values as type parameters. closes #6081

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1592,7 +1592,7 @@ static int valid_type_param(jl_value_t *v)
     }
     else {
         // TODO: maybe more things
-        return jl_is_type(v) || jl_is_long(v) || jl_is_symbol(v) || jl_is_typevar(v) || jl_is_bool(v);
+        return jl_is_type(v) || jl_is_typevar(v) || jl_is_symbol(v) || jl_isbits(jl_typeof(v));
     }
 }
 


### PR DESCRIPTION
This backports b429303dd6824299801fcd6ded7a23c12794d72a. Any reason not to do this?
