### PR TITLE
Backport of #8838 and #9143 squashed

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -1076,7 +1076,24 @@ macro mstr(s...); triplequoted(s...); end
 ## shell-like command parsing ##
 
 function shell_parse(raw::String, interp::Bool)
-    s = strip(raw)
+    s = lstrip(raw)
+    #Strips the end but respects the space when the string endswith "\\ "
+    r = RevString(s)
+    i = start(r)
+    c_old = nothing
+    while !done(r, i)
+        c, j = next(r, i)
+        if c == '\\' && c_old == ' '
+            i -= 1
+            break
+        elseif !(c in _default_delims)
+            break
+        end
+        i = j
+        c_old = c
+    end
+    s = s[1:end-i+1]
+
     last_parse = 0:-1
     isempty(s) && return interp ? (Expr(:tuple,:()),last_parse) : ({},last_parse)
 

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -157,6 +157,28 @@ c,r = test_scomplete("\$a")
     @test s[r] == "Pk"
 end
 
+let #test that it can auto complete with spaces in file/path
+    path = tempdir()
+    space_folder = randstring() * " r"
+    dir = joinpath(path, space_folder)
+    dir_space = replace(space_folder, " ", "\\ ")
+    mkdir(dir)
+    cd(path) do
+        open(joinpath(space_folder, "space .file"),"w") do f
+            s = @windows? "rm $dir_space\\\\space" : "cd $dir_space/space"
+            c,r = test_scomplete(s)
+            @test r == endof(s)-4:endof(s)
+            @test "space\\ .file" in c
+
+            s = @windows? "cd(\"$dir_space\\\\space" : "cd(\"$dir_space/space"
+            c,r = test_complete(s)
+            @test r == endof(s)-4:endof(s)
+            @test "space\\ .file\"" in c
+        end
+    end
+    rm(dir, recursive=true)
+end
+
 @windows_only begin
     tmp = tempname()
     path = dirname(tmp)


### PR DESCRIPTION
Fixes space completion in paths in the REPL like: cd C:\Program\ Files\.
@tkelman merge this when you find the timing is right.
