### PR TITLE
Backport of #8989 and #9137 squashed.

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -166,7 +166,7 @@ end
 
 function latex_completions(string, pos)
     slashpos = rsearch(string, '\\', pos)
-    if rsearch(string, whitespace_chars, pos) < slashpos
+    if rsearch(string, whitespace_chars, pos) < slashpos && !(1 < slashpos && (string[slashpos-1]=='\\'))
         # latex symbol substitution
         s = string[slashpos:pos]
         latex = get(latex_symbols, s, "")
@@ -196,11 +196,14 @@ function completions(string, pos)
            (length(string) <= pos || string[pos+1] != '"')    # or there's already a " at the cursor.
             paths[1] *= "\""
         end
-        return sort(paths), r, success
+        #Latex symbols can be completed for strings
+        (success || inc_tag==:cmd) && return sort(paths), r, success
     end
 
     ok, ret = latex_completions(string, pos)
     ok && return ret
+    # Make sure that only latex_completions is working on strings
+    inc_tag==:string && return UTF8String[], 0:-1, false
 
     if inc_tag == :other && string[pos] == '('
         endpos = prevind(string, pos)

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -73,6 +73,19 @@ c,r = test_latexcomplete(s)
 @test r == 1:length(s)
 @test length(c) == 1
 
+# test latex symbol completions in strings should not work when there
+# is a backslash in front of `\alpha` because it interferes with path completion on windows
+s = "cd(\"path_to_an_empty_folder_should_not_complete_latex\\\\\\alpha"
+c,r,res = test_complete(s)
+@test length(c) == 0
+
+# test latex symbol completions in strings
+s = "\"C:\\\\ \\alpha"
+c,r,res = test_complete(s)
+@test c[1] == "α"
+@test r == 7:12
+@test length(c) == 1
+
 ## Test completion of packages
 #mkp(p) = ((@assert !isdir(p)); mkdir(p))
 #temp_pkg_dir() do


### PR DESCRIPTION
Make Latex completion work in strings.
@tkelman merge this when you find the timing is right.
