### PR TITLE
Remove (c)transpose definitions from operators.jl. Add them to string.jl

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -135,11 +135,6 @@ mod1{T<:Real}(x::T, y::T) = y-mod(y-x,y)
 rem1{T<:Real}(x::T, y::T) = rem(x-1,y)+1
 fld1{T<:Real}(x::T, y::T) = fld(x-1,y)+1
 
-# transpose
-transpose(x) = x
-ctranspose(x) = conj(transpose(x))
-conj(x) = x
-
 # transposed multiply
 Ac_mul_B (a,b) = ctranspose(a)*b
 A_mul_Bc (a,b) = a*ctranspose(b)

--- a/base/string.jl
+++ b/base/string.jl
@@ -76,6 +76,10 @@ eltype{T<:AbstractString}(::Type{T}) = Char
 (*)(s::AbstractString...) = string(s...)
 (^)(s::AbstractString, r::Integer) = repeat(s,r)
 
+ctranspose(s::AbstractString) = s
+transpose(s::AbstractString) = s
+conj(s::AbstractString) = s
+
 length(s::DirectIndexString) = endof(s)
 function length(s::AbstractString)
     i = start(s)


### PR DESCRIPTION
The definitions give silent errors for matrix types that don't define `transpose` whenever the `*(A,B,C)` method is called. See the example below.

``` julia
julia> Qf = qrfact(randn(4,4));

julia> Q = full(Qf[:Q]);

julia> A = eye(4)
4x4 Array{Float64,2}:
 1.0  0.0  0.0  0.0
 0.0  1.0  0.0  0.0
 0.0  0.0  1.0  0.0
 0.0  0.0  0.0  1.0

julia> Q'*A*Q #Matrix-transpose * Matrix * Matrix, should be approximately A
4x4 Array{Float64,2}:
  1.0          -2.22045e-16  -1.11022e-16  1.11022e-16
 -1.11022e-16   1.0           1.66533e-16  5.55112e-17
  0.0           3.33067e-16   1.0          8.32667e-17
  8.32667e-17   5.55112e-17   5.55112e-17  1.0        

julia> Qf[:Q]'*A*Qf[:Q] #QRCompactWYQ-transpose * Matrix * QRCompactWYQ, should be approximately A but isn't
4x4 Array{Float64,2}:
 -0.171812    -0.967699   -0.114264  -0.144855
 -0.592102     0.220933   -0.754075  -0.178816
  0.787293    -0.0461806  -0.594673  -0.156207
 -0.00810461  -0.112316   -0.25432    0.960542
```
