### PR TITLE
RFC: backport appveyor to release-0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </a>
 </div>
 
-[![Build Status](https://api.travis-ci.org/JuliaLang/julia.svg?branch=master)](https://travis-ci.org/JuliaLang/julia)
+Linux, OSX: [![Build Status](https://api.travis-ci.org/JuliaLang/julia.svg?branch=release-0.3)](https://travis-ci.org/JuliaLang/julia) Windows: [![Build status](https://ci.appveyor.com/api/projects/status/4vr88cmgo7u02644/branch/release-0.3?svg=true)](https://ci.appveyor.com/project/StefanKarpinski/julia/branch/release-0.3)
 
 <a name="The-Julia-Language"/>
 ## The Julia Language

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 environment:
-#  USEMSVC: "1"
   matrix:
   - ARCH: "i686"
   - ARCH: "x86_64"
@@ -9,7 +8,7 @@ environment:
 branches:
   only:
     - master
-# TODO: - release-0.3
+    - release-0.3
 
 clone_depth: 50
 
@@ -18,12 +17,9 @@ init:
   - git config --global core.autocrlf input
 
 build_script:
-# temporarily disable backtrace test, failing right now for win64 on master
-  - sed -i 's/"backtrace",//' test/runtests.jl
 # Remove C:\MinGW\bin from the path, the version of MinGW installed on
 # AppVeyor is not compatible with the cross-compiled Julia Windows binaries
   - set PATH=%PATH:C:\MinGW\bin;=%
-#  - '"%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64'
 # Since the AppVeyor VMs have Git installed, they have MSYS1
   - sh --login /c/projects/julia/contrib/windows/msys_build.sh
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+environment:
+#  USEMSVC: "1"
+  matrix:
+  - ARCH: "i686"
+  - ARCH: "x86_64"
+
+# Only build on master and PR's for now, not personal branches
+# Whether or not PR's get built is determined in the webhook settings
+branches:
+  only:
+    - master
+# TODO: - release-0.3
+
+clone_depth: 50
+
+init:
+# Carriage returns are bad
+  - git config --global core.autocrlf input
+
+build_script:
+# temporarily disable backtrace test, failing right now for win64 on master
+  - sed -i 's/"backtrace",//' test/runtests.jl
+# Remove C:\MinGW\bin from the path, the version of MinGW installed on
+# AppVeyor is not compatible with the cross-compiled Julia Windows binaries
+  - set PATH=%PATH:C:\MinGW\bin;=%
+#  - '"%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64'
+# Since the AppVeyor VMs have Git installed, they have MSYS1
+  - sh --login /c/projects/julia/contrib/windows/msys_build.sh
+
+test_script:
+  - cd test && ..\usr\bin\julia runtests.jl all

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -1,0 +1,180 @@
+#!/bin/sh
+# Script to compile Windows Julia, using binary dependencies from nightlies.
+# Should work in MSYS assuming 7zip is installed and on the path,
+# or Cygwin or Linux assuming make, curl, p7zip, and mingw64-$ARCH-gcc-g++
+# are installed
+
+# Run in top-level Julia directory
+cd `dirname "$0"`/../..
+# Stop on error
+set -e
+
+# If ARCH environment variable not set, choose based on uname -m
+if [ -z "$ARCH" -a -z "$XC_HOST" ]; then
+  export ARCH=`uname -m`
+elif [ -z "$ARCH" ]; then
+  ARCH=`echo $XC_HOST | sed 's/-w64-mingw32//'`
+fi
+if [ "$ARCH" = x86_64 ]; then
+  bits=64
+else
+  bits=32
+fi
+echo "" > Make.user
+echo "" > get-deps.log
+
+# Set XC_HOST if in Cygwin or Linux
+case $(uname) in
+  CYGWIN*)
+    if [ -z "$XC_HOST" ]; then
+      XC_HOST="$ARCH-w64-mingw32"
+      echo "XC_HOST = $XC_HOST" >> Make.user
+    fi
+    CROSS_COMPILE="$XC_HOST-"
+    # Set BUILD_MACHINE and HOSTCC in case we don't have Cygwin gcc installed
+    echo "override BUILD_MACHINE = $ARCH-pc-cygwin" >> Make.user
+    if [ -z "`which gcc 2>/dev/null`" ]; then
+      echo 'override HOSTCC = $(CROSS_COMPILE)gcc' >> Make.user
+    fi
+    make win-extras >> get-deps.log
+    SEVENZIP="dist-extras/7z"
+    ;;
+  Linux)
+    if [ -z "$XC_HOST" ]; then
+      XC_HOST="$ARCH-w64-mingw32"
+      echo "XC_HOST = $XC_HOST" >> Make.user
+    fi
+    CROSS_COMPILE="$XC_HOST-"
+    make win-extras >> get-deps.log
+    SEVENZIP="wine dist-extras/7z.exe"
+    ;;
+  *)
+    CROSS_COMPILE=""
+    SEVENZIP="7z"
+    ;;
+esac
+
+# Download most recent Julia binary for dependencies
+if ! [ -e julia-installer.exe ]; then
+  f=julia-nightly-win$bits.exe
+  echo "Downloading $f"
+  curl -kLsSo $f http://status.julialang.org/download/win$bits
+  echo "Extracting $f"
+  $SEVENZIP x -y $f >> get-deps.log
+fi
+for i in bin/*.dll Git/bin/msys-1.0.dll Git/bin/msys-perl5_8.dll Git/bin/*.exe; do
+  $SEVENZIP e -y julia-installer.exe "\$_OUTDIR/$i" \
+    -ousr\\`dirname $i | sed -e 's|/julia||' -e 's|/|\\\\|g'` >> get-deps.log
+done
+for i in share/julia/base/pcre_h.jl; do
+  $SEVENZIP e -y julia-installer.exe "\$_OUTDIR/$i" -obase >> get-deps.log
+done
+# Remove libjulia.dll if it was copied from downloaded binary
+rm -f usr/bin/libjulia.dll
+rm -f usr/bin/libjulia-debug.dll
+
+mingw=http://sourceforge.net/projects/mingw
+if [ -z "$USEMSVC" ]; then
+  if [ -z "`which ${CROSS_COMPILE}gcc 2>/dev/null`" ]; then
+    f=mingw-w$bits-bin-$ARCH-20140102.7z
+    if ! [ -e $f ]; then
+      echo "Downloading $f"
+      curl -kLOsS $mingw-w64-dgn/files/mingw-w64/$f
+    fi
+    echo "Extracting $f"
+    $SEVENZIP x -y $f >> get-deps.log
+    export PATH=$PATH:$PWD/mingw$bits/bin
+    # If there is a version of make.exe here, it is mingw32-make which won't work
+    rm -f mingw$bits/bin/make.exe
+  fi
+  export AR=${CROSS_COMPILE}ar
+
+  f=llvm-3.3-$ARCH-w64-mingw32-juliadeps.7z
+  # The MinGW binary version of LLVM doesn't include libgtest or libgtest_main
+  mkdir -p usr/lib
+  $AR cr usr/lib/libgtest.a
+  $AR cr usr/lib/libgtest_main.a
+else
+  echo "override USEMSVC = 1" >> Make.user
+  echo "override ARCH = $ARCH" >> Make.user
+  if [ $ARCH = x86_64 ]; then
+    echo "override MARCH = x86-64" >> Make.user
+  else
+    echo "override MARCH = $ARCH" >> Make.user
+  fi
+  echo "override XC_HOST = " >> Make.user
+  export CC="$PWD/deps/libuv/compile cl -nologo -MD -Z7"
+  export AR="$PWD/deps/libuv/ar-lib lib"
+  export LD="$PWD/linkld link"
+  echo "override CC = $CC" >> Make.user
+  echo 'override CXX = $(CC) -EHsc' >> Make.user
+  echo "override AR = $AR" >> Make.user
+  echo "override LD = $LD -DEBUG" >> Make.user
+
+  f=llvm-3.3-$ARCH-msvc12-juliadeps.7z
+fi
+
+if ! [ -e $f ]; then
+  echo "Downloading $f"
+  curl -kLOsS http://sourceforge.net/projects/juliadeps-win/files/$f
+fi
+echo "Extracting $f"
+$SEVENZIP x -y $f >> get-deps.log
+echo 'LLVM_CONFIG = $(JULIAHOME)/usr/bin/llvm-config' >> Make.user
+
+if [ -z "`which make 2>/dev/null`" ]; then
+  if [ -n "`uname | grep CYGWIN`" ]; then
+    echo "Install the Cygwin package for 'make' and try again."
+    exit 1
+  fi
+  f="/make/make-3.81-2/make-3.81-2-msys-1.0.11-bin.tar"
+  if ! [ -e `basename $f.lzma` ]; then
+    echo "Downloading `basename $f`"
+    curl -kLOsS $mingw/files/MSYS/Base$f.lzma
+  fi
+  $SEVENZIP x -y `basename $f.lzma` >> get-deps.log
+  tar -xf `basename $f`
+  # msysgit has an ancient version of touch that fails with `touch -c nonexistent`
+  cp usr/Git/bin/echo.exe bin/touch.exe
+  export PATH=$PWD/bin:$PATH
+fi
+
+for lib in LLVM SUITESPARSE ARPACK BLAS LAPACK FFTW \
+    GMP MPFR PCRE LIBUNWIND RMATH OPENSPECFUN; do
+  echo "USE_SYSTEM_$lib = 1" >> Make.user
+done
+echo 'LIBBLAS = -L$(JULIAHOME)/usr/bin -lopenblas' >> Make.user
+echo 'LIBBLASNAME = libopenblas' >> Make.user
+echo 'override LIBLAPACK = $(LIBBLAS)' >> Make.user
+echo 'override LIBLAPACKNAME = $(LIBBLASNAME)' >> Make.user
+
+# Remaining dependencies:
+# libuv since its static lib is no longer included in the binaries
+# openlibm since we need it as a static library to work properly
+# mojibake since its headers are not in the binary download
+echo 'override STAGE1_DEPS = uv' >> Make.user
+echo 'override STAGE2_DEPS = mojibake' >> Make.user
+echo 'override STAGE3_DEPS = ' >> Make.user
+make -C deps get-uv
+
+if [ -n "$USEMSVC" ]; then
+  # Create a modified version of compile for wrapping link
+  sed -e 's/-link//' -e 's/cl/link/g' -e 's/ -Fe/ -OUT:/' \
+    -e 's|$dir/$lib|$dir/lib$lib|g' deps/libuv/compile > linkld
+  chmod +x linkld
+
+  # Openlibm doesn't build well with MSVC right now
+  echo 'USE_SYSTEM_OPENLIBM = 1' >> Make.user
+  # Since we don't have a static library for openlibm
+  echo 'override UNTRUSTED_SYSTEM_LIBM = 0' >> Make.user
+
+  # Compile libuv and mojibake without -TP first, then add -TP
+  make -C deps install-uv install-mojibake
+  cp usr/lib/uv.lib usr/lib/libuv.a
+  echo 'override CC += -TP' >> Make.user
+else
+  echo 'override STAGE1_DEPS += openlibm' >> Make.user
+fi
+
+make
+#make debug

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -56,9 +56,9 @@ esac
 
 # Download most recent Julia binary for dependencies
 if ! [ -e julia-installer.exe ]; then
-  f=julia-nightly-win$bits.exe
+  f=julia-release-win$bits.exe
   echo "Downloading $f"
-  curl -kLsSo $f http://status.julialang.org/download/win$bits
+  curl -kLsSo $f http://status.julialang.org/stable/win$bits
   echo "Extracting $f"
   $SEVENZIP x -y $f >> get-deps.log
 fi
@@ -151,11 +151,11 @@ echo 'override LIBLAPACKNAME = $(LIBBLASNAME)' >> Make.user
 # Remaining dependencies:
 # libuv since its static lib is no longer included in the binaries
 # openlibm since we need it as a static library to work properly
-# mojibake since its headers are not in the binary download
+# utf8proc since its headers are not in the binary download
 echo 'override STAGE1_DEPS = uv' >> Make.user
-echo 'override STAGE2_DEPS = mojibake' >> Make.user
+echo 'override STAGE2_DEPS = utf8proc' >> Make.user
 echo 'override STAGE3_DEPS = ' >> Make.user
-make -C deps get-uv
+make -C deps get-uv get-utf8proc
 
 if [ -n "$USEMSVC" ]; then
   # Create a modified version of compile for wrapping link

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -176,5 +176,5 @@ else
   echo 'override STAGE1_DEPS += openlibm' >> Make.user
 fi
 
-make
+make -j2
 #make debug


### PR DESCRIPTION
the MSVC parts of the script probably won't work on release-0.3, but that's okay we don't really need them to
