### PR TITLE
WIP/RFC: Testing optimizations to broadcast type of calls

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1382,6 +1382,7 @@ export
     @async,
     @spawn,
     @spawnat,
+    @spawnall,
     @fetch,
     @fetchfrom,
     @everywhere,

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -680,6 +680,10 @@ function remotecall(ws::Array, f, args...)
         let worker_specific_data=worker_specific_data, w=w, rr=rr
             @async begin
                 flush_gc_msgs(w)
+
+                # TODO - The socket must be "locked" as in PR# 6876 around
+                # the following two socket writes. Needs PR# 6876 to be merged
+                # first
                 enq_send_req(w.socket, common_data)
                 enq_send_req(w.socket, worker_specific_data)
             end


### PR DESCRIPTION
Just trying out possibilities of optimizing calls which execute the same thunk on all workers.

With the regular master branch, and 8 workers, sending 10^7 Floats to all workers in parallel takes around 0.72 seconds:

```
function foo(n)
    t=time()
    a=fill(t, 10^n)
    @time @sync begin
        for p in workers()
            @spawnat p global bar=a
        end
    end

    #validate that the array has been sent over the network
    for p in workers()
        assert(remotecall_fetch(p, ()->length(bar)) == 10^n) 
        assert(remotecall_fetch(p, ()->bar[1]) == t) 
    end
end
```

```
julia> foo(7)
elapsed time: 0.722923702 seconds (1073779440 bytes allocated, 23.18% gc time)
```

With this PR, which implements a new macro `@spawnall`, the time is around 0.21 seconds

```
function foo(n)
    t=time()
    a=fill(t, 10^n)
    @time @sync @spawnall global bar=a

    #validate that the array has been sent over the network
    for p in workers()
        assert(remotecall_fetch(p, ()->length(bar)) == 10^n) 
        assert(remotecall_fetch(p, ()->bar[1]) == t) 
    end
end
```

```
julia> foo(7)
elapsed time: 0.218541978 seconds (134273124 bytes allocated, 7.87% gc time)
```

`@spawnall` serializes the request once and then sends the same buffer to all the workers.
