### PR TITLE
RFC: Fix type instability for \

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -16,6 +16,7 @@ export
     Markdown,
 
 # Types
+    €,
     AbstractMatrix,
     AbstractSparseArray,
     AbstractSparseMatrix,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -9,6 +9,7 @@ export
     BLAS,
 
 # Types
+    €,
     SymTridiagonal,
     Tridiagonal,
     Bidiagonal,
@@ -193,6 +194,7 @@ const CHARU = 'U'
 const CHARL = 'L'
 char_uplo(uplo::Symbol) = uplo == :U ? CHARU : (uplo == :L ? CHARL : throw(ArgumentError("uplo argument must be either :U or :L")))
 
+immutable €{T} end
 
 include("linalg/exceptions.jl")
 include("linalg/generic.jl")

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -307,16 +307,16 @@ function sqrtm{T<:Real}(A::StridedMatrix{T})
     issym(A) && return sqrtm(Symmetric(A))
     n = chksquare(A)
     SchurF = schurfact(complex(A))
-    R = full(sqrtm(Triangular(SchurF[:T], :U, false)))
-    retmat = SchurF[:vectors]*R*SchurF[:vectors]'
+    R = full(sqrtm(Triangular(SchurF[€{:T}], €{:U}, €{false})))
+    retmat = SchurF[€{:vectors}]*R*SchurF[€{:vectors}]'
     all(imag(retmat) .== 0) ? real(retmat) : retmat
 end
 function sqrtm{T<:Complex}(A::StridedMatrix{T})
     ishermitian(A) && return sqrtm(Hermitian(A))
     n = chksquare(A)
     SchurF = schurfact(A)
-    R = full(sqrtm(Triangular(SchurF[:T], :U, false)))
-    SchurF[:vectors]*R*SchurF[:vectors]'
+    R = full(sqrtm(Triangular(SchurF[€{:T}], €{:U}, €{false})))
+    SchurF[€{:vectors}]*R*SchurF[€{:vectors}]'
 end
 sqrtm(a::Number) = (b = sqrt(complex(a)); imag(b) == 0 ? real(b) : b)
 sqrtm(a::Complex) = sqrt(a)
@@ -325,9 +325,9 @@ function inv{S}(A::StridedMatrix{S})
     T = typeof(one(S)/one(S))
     Ac = convert(AbstractMatrix{T}, A)
     if istriu(Ac)
-        Ai = inv(Triangular(A, :U, false))
+        Ai = inv(Triangular(A, €{:U}, €{false}))
     elseif istril(Ac)
-        Ai = inv(Triangular(A, :L, false))
+        Ai = inv(Triangular(A, €{:L}, €{false}))
     else
         Ai = inv(lufact(Ac))
     end
@@ -377,7 +377,7 @@ function factorize{T}(A::Matrix{T})
                 if utri1
                     return Bidiagonal(diag(A), diag(A, -1), false)
                 end
-                return Triangular(A, :L)
+                return Triangular(A, €{:L})
             end
             if utri
                 return Bidiagonal(diag(A), diag(A, 1), true)
@@ -392,7 +392,7 @@ function factorize{T}(A::Matrix{T})
             end
         end
         if utri
-            return Triangular(A, :U)
+            return Triangular(A, €{:U})
         end
         if herm
             try
@@ -413,9 +413,9 @@ function (\)(A::StridedMatrix, B::StridedVecOrMat)
     m, n = size(A)
     if m == n
         if istril(A)
-            return istriu(A) ? \(Diagonal(A),B) : \(Triangular(A, :L),B)
+            return istriu(A) ? \(Diagonal(A),B) : \(Triangular(A, €{:L}),B)
         end
-        istriu(A) && return \(Triangular(A, :U),B)
+        istriu(A) && return \(Triangular(A, €{:U}),B)
         return \(lufact(A),B)
     end
     return qrfact(A,pivot=eltype(A)<:BlasFloat)\B
@@ -440,12 +440,12 @@ function pinv{T}(A::StridedMatrix{T}, tol::Real)
        end
     end
     SVD         = svdfact(A, thin=true)
-    S           = eltype(SVD[:S])
-    Sinv        = zeros(S, length(SVD[:S]))
-    index       = SVD[:S] .> tol*maximum(SVD[:S])
-    Sinv[index] = one(S) ./ SVD[:S][index]
+    S           = eltype(SVD[€{:S}])
+    Sinv        = zeros(S, length(SVD[€{:S}]))
+    index       = SVD[€{:S}] .> tol*maximum(SVD[€{:S}])
+    Sinv[index] = one(S) ./ SVD[€{:S}][index]
     Sinv[find(!isfinite(Sinv))] = zero(S)
-    return SVD[:Vt]'scale(Sinv, SVD[:U]')
+    return SVD[€{:Vt}]'scale(Sinv, SVD[€{:U}]')
 end
 function pinv{T}(A::StridedMatrix{T})
     tol = eps(real(float(one(T))))*maximum(size(A))
@@ -459,8 +459,8 @@ function null{T}(A::StridedMatrix{T})
     m, n = size(A)
     (m == 0 || n == 0) && return eye(T, n)
     SVD = svdfact(A, thin=false)
-    indstart = sum(SVD[:S] .> max(m,n)*maximum(SVD[:S])*eps(eltype(SVD[:S]))) + 1
-    return SVD[:V][:,indstart:end]
+    indstart = sum(SVD[€{:S}] .> max(m,n)*maximum(SVD[€{:S}])*eps(eltype(SVD[€{:S}]))) + 1
+    return SVD[€{:V}][:,indstart:end]
 end
 null(a::StridedVector) = null(reshape(a, length(a), 1))
 

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -265,8 +265,8 @@ function A_mul_Bc{TA,TB}(A::AbstractArray{TA}, B::Union(QRCompactWYQ{TB},QRPacke
               convert(AbstractMatrix{TAB}, B))
 end
 
-A_ldiv_B!{T<:BlasFloat}(A::QRCompactWY{T}, B::StridedVector{T}) = A_ldiv_B!(Triangular(A[:R], :U), sub(Ac_mul_B!(A[:Q], B), 1:size(A, 2)))
-A_ldiv_B!{T<:BlasFloat}(A::QRCompactWY{T}, B::StridedMatrix{T}) = A_ldiv_B!(Triangular(A[:R], :U), sub(Ac_mul_B!(A[:Q], B), 1:size(A, 2), 1:size(B, 2)))
+A_ldiv_B!{T<:BlasFloat}(A::QRCompactWY{T}, b::StridedVector{T}) = (A_ldiv_B!(Triangular(A[:R], :U), sub(Ac_mul_B!(A[:Q], b), 1:size(A, 2))); b)
+A_ldiv_B!{T<:BlasFloat}(A::QRCompactWY{T}, B::StridedMatrix{T}) = (A_ldiv_B!(Triangular(A[:R], :U), sub(Ac_mul_B!(A[:Q], B), 1:size(A, 2), 1:size(B, 2))); B)
 
 # Julia implementation similarly to xgelsy
 function A_ldiv_B!{T<:BlasFloat}(A::QRPivoted{T}, B::StridedMatrix{T}, rcond::Real)
@@ -297,7 +297,8 @@ function A_ldiv_B!{T<:BlasFloat}(A::QRPivoted{T}, B::StridedMatrix{T}, rcond::Re
     A_ldiv_B!(Triangular(C[1:rnk,1:rnk],:U),sub(Ac_mul_B!(getq(A),sub(B, 1:mA, 1:nrhs)),1:rnk,1:nrhs))
     B[rnk+1:end,:] = zero(T)
     LAPACK.ormrz!('L', iseltype(B, Complex) ? 'C' : 'T', C, τ, sub(B,1:nA,1:nrhs))
-    return isa(A,QRPivoted) ? B[invperm(A[:p]::Vector{BlasInt}),:] : B[1:nA,:], rnk
+    B[1:nA,:] = sub(B, 1:nA, :)[invperm(A[:p]::Vector{BlasInt}),:]
+    return B, rnk
 end
 A_ldiv_B!{T<:BlasFloat}(A::QRPivoted{T}, B::StridedVector{T}) = vec(A_ldiv_B!(A,reshape(B,length(B),1)))
 A_ldiv_B!{T<:BlasFloat}(A::QRPivoted{T}, B::StridedVecOrMat{T}) = A_ldiv_B!(A, B, maximum(size(A))*eps(real(float(one(eltype(B))))))[1]
@@ -350,22 +351,32 @@ function A_ldiv_B!{T}(A::QR{T},B::StridedMatrix{T})
             end
         end
     end
-    return B[1:n,:]
+    return B
 end
 A_ldiv_B!(A::QR, B::StridedVector) = A_ldiv_B!(A, reshape(B, length(B), 1))[:]
-A_ldiv_B!(A::QRPivoted, B::StridedVector) = A_ldiv_B!(QR(A.factors,A.τ),B)[invperm(A.jpvt)]
-A_ldiv_B!(A::QRPivoted, B::StridedMatrix) = A_ldiv_B!(QR(A.factors,A.τ),B)[invperm(A.jpvt),:]
+function A_ldiv_B!(A::QRPivoted, b::StridedVector)
+    A_ldiv_B!(QR(A.factors,A.τ), b)
+    b[1:size(A.factors, 2)] = sub(b, 1:size(A.factors, 2))[invperm(A.jpvt)]
+    b
+end
+function A_ldiv_B!(A::QRPivoted, B::StridedMatrix)
+    A_ldiv_B!(QR(A.factors, A.τ), B)
+    B[1:size(A.factors, 2),:] = sub(B, 1:size(A.factors, 2), :)[invperm(A.jpvt)]
+    B
+end
 function \{TA,Tb}(A::Union(QR{TA},QRCompactWY{TA},QRPivoted{TA}),b::StridedVector{Tb})
     S = promote_type(TA,Tb)
     m,n = size(A)
     m == length(b) || throw(DimensionMismatch("left hand side has $m rows, but right hand side has length $(length(b))"))
-    n > m ? A_ldiv_B!(convert(Factorization{S},A),[b,zeros(S,n-m)]) : A_ldiv_B!(convert(Factorization{S},A), S == Tb ? copy(b) : convert(AbstractVector{S}, b))
+    x = n > m ? A_ldiv_B!(convert(Factorization{S},A),[b,zeros(S,n-m)]) : A_ldiv_B!(convert(Factorization{S},A), S == Tb ? copy(b) : convert(AbstractVector{S}, b))
+    return length(x) > n ? x[1:n] : x
 end
 function \{TA,TB}(A::Union(QR{TA},QRCompactWY{TA},QRPivoted{TA}),B::StridedMatrix{TB})
     S = promote_type(TA,TB)
     m,n = size(A)
     m == size(B,1) || throw(DimensionMismatch("left hand side has $m rows, but right hand side has $(size(B,1)) rows"))
-    n > m ? A_ldiv_B!(convert(Factorization{S},A),[B;zeros(S,n-m,size(B,2))]) : A_ldiv_B!(convert(Factorization{S},A), S == TB ? copy(B) : convert(AbstractMatrix{S}, B))
+    X = n > m ? A_ldiv_B!(convert(Factorization{S},A),[B;zeros(S,n-m,size(B,2))]) : A_ldiv_B!(convert(Factorization{S},A), S == TB ? copy(B) : convert(AbstractMatrix{S}, B))
+    return size(X, 1) > n ? X[1:n,:] : X
 end
 
 ##TODO:  Add methods for rank(A::QRP{T}) and adjust the (\) method accordingly

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -424,7 +424,7 @@ function elementaryRightTrapezoid!(A::AbstractMatrix, row::Integer)
 end
 
 function det(A::AbstractMatrix)
-    (istriu(A) || istril(A)) && return det(Triangular(A, :U, false))
+    (istriu(A) || istril(A)) && return det(Triangular(A, €{:U}, €{false}))
     return det(lufact(A))
 end
 det(x::Number) = x

--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -4,8 +4,8 @@
 convert{T}(::Type{Bidiagonal}, A::Diagonal{T})=Bidiagonal(A.diag, zeros(T, size(A.diag,1)-1), true)
 convert{T}(::Type{SymTridiagonal}, A::Diagonal{T})=SymTridiagonal(A.diag, zeros(T, size(A.diag,1)-1))
 convert{T}(::Type{Tridiagonal}, A::Diagonal{T})=Tridiagonal(zeros(T, size(A.diag,1)-1), A.diag, zeros(T, size(A.diag,1)-1))
-convert(::Type{Triangular}, A::Diagonal) = Triangular(full(A), :L)
-convert(::Type{Triangular}, A::Bidiagonal) = Triangular(full(A), A.isupper ? :U : :L)
+convert(::Type{Triangular}, A::Diagonal) = Triangular(full(A), €{:L})
+convert(::Type{Triangular}, A::Bidiagonal) = Triangular(full(A), A.isupper ? €{:U} : €{:L})
 convert(::Type{Matrix}, D::Diagonal) = diagm(D.diag)
 
 function convert(::Type{Diagonal}, A::Union(Bidiagonal, SymTridiagonal))

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -8,8 +8,8 @@ n = 9
 srand(123)
 
 debug && println("Test basic type functionality")
-@test_throws DimensionMismatch Triangular(randn(5, 4), :L)
-@test Triangular(randn(3, 3), :L) |> t -> [size(t, i) for i = 1:3] == [size(full(t), i) for i = 1:3]
+@test_throws DimensionMismatch Triangular(randn(5, 4), €{:L})
+@test Triangular(randn(3, 3), €{:L}) |> t -> [size(t, i) for i = 1:3] == [size(full(t), i) for i = 1:3]
 
 # The following test block tries to call all methods in base/linalg/triangular.jl in order for a combination of input element types. Keep the ordering when adding code.
 for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
@@ -18,8 +18,8 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
             for uplo2 in (:U, :L)
                 for isunit1 in (true, false)
                     for isunit2 in (true, false)
-                        A1 = Triangular(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t-> chol(t't, uplo1)), uplo1, isunit1)
-                        A2 = Triangular(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t-> chol(t't, uplo2)), uplo2, isunit2)
+                        A1 = Triangular(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t-> chol(t't, €{uplo1})), €{uplo1}, €{isunit1})
+                        A2 = Triangular(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t-> chol(t't, €{uplo2})), €{uplo2}, €{isunit2})
 
                         for eltyB in (Float32, Float64, Complex64, Complex128)
                             B = convert(Matrix{eltyB}, elty1 <: Complex ? real(A1)*ones(n, n) : A1*ones(n, n))
@@ -29,9 +29,9 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
                             # Convert
                             @test convert(Triangular{elty1}, A1) == A1
                             if elty1 <: Real && !(elty2 <: Integer)
-                                @test convert(Triangular{elty2}, A1) == Triangular(convert(Matrix{elty2}, A1.data), uplo1, isunit1)
+                                @test convert(Triangular{elty2}, A1) == Triangular(convert(Matrix{elty2}, A1.data), €{uplo1}, €{isunit1})
                             elseif elty2 <: Real && !(elty1 <: Integer)
-                                @test_throws InexactError convert(Triangular{elty2}, A1) == Triangular(convert(Matrix{elty2}, A1.data), uplo1, isunit1)
+                                @test_throws InexactError convert(Triangular{elty2}, A1) == Triangular(convert(Matrix{elty2}, A1.data), €{uplo1}, €{isunit1})
                             end
                             @test convert(Matrix, A1) == full(A1)
 
@@ -39,7 +39,7 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
                             @test full!(copy(A1)) == full(A1)
 
                             # fill!
-                            @test full!(fill!(copy(A1), 1)) == full(Triangular(ones(size(A1)...), uplo1, isunit1))
+                            @test full!(fill!(copy(A1), 1)) == full(Triangular(ones(size(A1)...), €{uplo1}, €{isunit1}))
 
                             # similar
                             @test isa(similar(A1), Triangular{elty1, Matrix{elty1}, uplo1, isunit1})
@@ -170,14 +170,14 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         debug && println("\ntype of A: ", eltya, " type of b: ", eltyb, "\n")
 
         debug && println("Solve upper triangular system")
-        Atri = Triangular(lufact(A)[:U], :U) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
+        Atri = Triangular(lufact(A)[€{:U}], €{:U}) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
         b = convert(Matrix{eltyb}, eltya <: Complex ? full(Atri)*ones(n, 2) : full(Atri)*ones(n, 2))
         x = full(Atri) \ b
 
         debug && println("Test error estimates")
         if eltya != BigFloat && eltyb != BigFloat
             for i = 1:2
-                @test  norm(x[:,1] .- 1) <= errorbounds(Triangular(A, :U), x, b)[1][i]
+                @test  norm(x[:,1] .- 1) <= errorbounds(Triangular(A, €{:U}), x, b)[1][i]
             end
         end
         debug && println("Test forward error [JIN 5705] if this is not a BigFloat")
@@ -198,14 +198,14 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         end
 
         debug && println("Solve lower triangular system")
-        Atri = Triangular(lufact(A)[:U], :U) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
+        Atri = Triangular(lufact(A)[€{:U}], €{:U}) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
         b = convert(Matrix{eltyb}, eltya <: Complex ? full(Atri)*ones(n, 2) : full(Atri)*ones(n, 2))
         x = full(Atri)\b
 
         debug && println("Test error estimates")
         if eltya != BigFloat && eltyb != BigFloat
             for i = 1:2
-                @test  norm(x[:,1] .- 1) <= errorbounds(Triangular(A, :U), x, b)[1][i]
+                @test  norm(x[:,1] .- 1) <= errorbounds(Triangular(A, €{:U}), x, b)[1][i]
             end
         end
 

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -39,7 +39,7 @@ debug && println("\ntype of a: ", eltya, " type of b: ", eltyb, "\n")
 debug && println("(Automatic) upper Cholesky factor")
 
     capd  = factorize(apd)
-    r     = capd[:U]
+    r     = capd[€{:U}]
     κ     = cond(apd, 1) #condition number
 
     #Test error bound on reconstruction of matrix: LAWNS 14, Lemma 2.1
@@ -64,9 +64,9 @@ debug && println("(Automatic) upper Cholesky factor")
     @test_approx_eq logdet(capd) log(det(capd)) # logdet is less likely to overflow
 
 debug && println("lower Cholesky factor")
-    lapd = cholfact(apd, :L)
+    lapd = cholfact(apd, €{:L})
     @test_approx_eq full(lapd) apd
-    l = lapd[:L]
+    l = lapd[€{:L}]
     @test_approx_eq l*l' apd
 
 debug && println("pivoted Choleksy decomposition")
@@ -95,7 +95,7 @@ debug && println("Bunch-Kaufman factors of a pos-def matrix")
 debug && println("(Automatic) Square LU decomposition")
     κ     = cond(a,1)
     lua   = factorize(a)
-    l,u,p = lua[:L], lua[:U], lua[:p]
+    l,u,p = lua[€{:L}], lua[€{:U}], lua[€{:p}]
     @test_approx_eq l*u a[p,:]
     @test_approx_eq (l*u)[invperm(p),:] a
     @test_approx_eq a * inv(lua) eye(n)
@@ -103,15 +103,15 @@ debug && println("(Automatic) Square LU decomposition")
 
 debug && println("Thin LU")
     lua   = lufact(a[:,1:5])
-    @test_approx_eq lua[:L]*lua[:U] lua[:P]*a[:,1:5]
+    @test_approx_eq lua[€{:L}]*lua[€{:U}] lua[€{:P}]*a[:,1:5]
 
 debug && println("Fat LU")
     lua   = lufact(a[1:5,:])
-    @test_approx_eq lua[:L]*lua[:U] lua[:P]*a[1:5,:]
+    @test_approx_eq lua[€{:L}]*lua[€{:U}] lua[€{:P}]*a[1:5,:]
 
 debug && println("QR decomposition (without pivoting)")
     qra   = qrfact(a, pivot=false)
-    q,r   = qra[:Q], qra[:R]
+    q,r   = qra[€{:Q}], qra[€{:R}]
     @test_approx_eq q'*full(q, thin=false) eye(n)
     @test_approx_eq q*full(q, thin=false)' eye(n)
     @test_approx_eq q*r a
@@ -119,8 +119,8 @@ debug && println("QR decomposition (without pivoting)")
 
 debug && println("(Automatic) Fat (pivoted) QR decomposition") # Pivoting is only implemented for BlasFloats
     qrpa  = factorize(a[1:5,:])
-    q,r = qrpa[:Q], qrpa[:R]
-    if isa(qrpa,QRPivoted) p = qrpa[:p] end # Reconsider if pivoted QR gets implemented in julia
+    q,r = qrpa[€{:Q}], qrpa[€{:R}]
+    if isa(qrpa,QRPivoted) p = qrpa[€{:p}] end # Reconsider if pivoted QR gets implemented in julia
     @test_approx_eq q'*full(q, thin=false) eye(5)
     @test_approx_eq q*full(q, thin=false)' eye(5)
     @test_approx_eq q*r isa(qrpa,QRPivoted) ? a[1:5,p] : a[1:5,:]
@@ -129,8 +129,8 @@ debug && println("(Automatic) Fat (pivoted) QR decomposition") # Pivoting is onl
 
 debug && println("(Automatic) Thin (pivoted) QR decomposition") # Pivoting is only implemented for BlasFloats
     qrpa  = factorize(a[:,1:5])
-    q,r = qrpa[:Q], qrpa[:R]
-    if isa(qrpa, QRPivoted) p = qrpa[:p] end # Reconsider if pivoted QR gets implemented in julia
+    q,r = qrpa[€{:Q}], qrpa[€{:R}]
+    if isa(qrpa, QRPivoted) p = qrpa[€{:p}] end # Reconsider if pivoted QR gets implemented in julia
     @test_approx_eq q'*full(q, thin=false) eye(n)
     @test_approx_eq q*full(q, thin=false)' eye(n)
     @test_approx_eq q*r isa(qrpa, QRPivoted) ? a[:,p] : a[:,1:5]
@@ -142,8 +142,8 @@ debug && println("symmetric eigen-decomposition")
         @test_approx_eq asym*v[:,1] d[1]*v[:,1]
         @test_approx_eq v*Diagonal(d)*v' asym
         @test isequal(eigvals(asym[1]), eigvals(asym[1:1,1:1]))
-        @test_approx_eq abs(eigfact(Hermitian(asym), 1:2)[:vectors]'v[:,1:2]) eye(eltya, 2)
-        @test_approx_eq abs(eigfact(Hermitian(asym), d[1]-10*eps(d[1]), d[2]+10*eps(d[2]))[:vectors]'v[:,1:2]) eye(eltya, 2)
+        @test_approx_eq abs(eigfact(Hermitian(asym), 1:2)[€{:vectors}]'v[:,1:2]) eye(eltya, 2)
+        @test_approx_eq abs(eigfact(Hermitian(asym), d[1]-10*eps(d[1]), d[2]+10*eps(d[2]))[€{:vectors}]'v[:,1:2]) eye(eltya, 2)
         @test_approx_eq eigvals(Hermitian(asym), 1:2) d[1:2]
         @test_approx_eq eigvals(Hermitian(asym), d[1]-10*eps(d[1]), d[2]+10*eps(d[2])) d[1:2]
     end
@@ -158,26 +158,26 @@ debug && println("symmetric generalized eigenproblem")
     if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
         a610 = a[:,6:10]
         f = eigfact(asym[1:5,1:5], a610'a610)
-        @test_approx_eq asym[1:5,1:5]*f[:vectors] scale(a610'a610*f[:vectors], f[:values])
-        @test_approx_eq f[:values] eigvals(asym[1:5,1:5], a610'a610)
-        @test_approx_eq_eps prod(f[:values]) prod(eigvals(asym[1:5,1:5]/(a610'a610))) 200ε
+        @test_approx_eq asym[1:5,1:5]*f[€{:vectors}] scale(a610'a610*f[€{:vectors}], f[€{:values}])
+        @test_approx_eq f[€{:values}] eigvals(asym[1:5,1:5], a610'a610)
+        @test_approx_eq_eps prod(f[€{:values}]) prod(eigvals(asym[1:5,1:5]/(a610'a610))) 200ε
     end
 
 debug && println("Non-symmetric generalized eigenproblem")
     if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
         f = eigfact(a[1:5,1:5], a[6:10,6:10])
-        @test_approx_eq a[1:5,1:5]*f[:vectors] scale(a[6:10,6:10]*f[:vectors], f[:values])
-        @test_approx_eq f[:values] eigvals(a[1:5,1:5], a[6:10,6:10])
-        @test_approx_eq_eps prod(f[:values]) prod(eigvals(a[1:5,1:5]/a[6:10,6:10])) 50000ε
+        @test_approx_eq a[1:5,1:5]*f[€{:vectors}] scale(a[6:10,6:10]*f[€{:vectors}], f[€{:values}])
+        @test_approx_eq f[€{:values}] eigvals(a[1:5,1:5], a[6:10,6:10])
+        @test_approx_eq_eps prod(f[€{:values}]) prod(eigvals(a[1:5,1:5]/a[6:10,6:10])) 50000ε
     end
 
 debug && println("Schur")
     if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
         f = schurfact(a)
-        @test_approx_eq f[:vectors]*f[:Schur]*f[:vectors]' a
-        @test_approx_eq sort(real(f[:values])) sort(real(d))
-        @test_approx_eq sort(imag(f[:values])) sort(imag(d))
-        @test istriu(f[:Schur]) || iseltype(a,Real)
+        @test_approx_eq f[€{:vectors}]*f[€{:Schur}]*f[€{:vectors}]' a
+        @test_approx_eq sort(real(f[€{:values}])) sort(real(d))
+        @test_approx_eq sort(imag(f[€{:values}])) sort(imag(d))
+        @test istriu(f[€{:Schur}]) || iseltype(a,Real)
     end
 
 debug && println("Reorder Schur")
@@ -188,30 +188,30 @@ debug && println("Reorder Schur")
         S = schurfact(ordschura)
         select = rand(range(0,2), n)
         O = ordschur(S, select)
-        bool(sum(select)) && @test_approx_eq S[:values][find(select)] O[:values][1:sum(select)]
-        @test_approx_eq O[:vectors]*O[:Schur]*O[:vectors]' ordschura
+        bool(sum(select)) && @test_approx_eq S[€{:values}][find(select)] O[€{:values}][1:sum(select)]
+        @test_approx_eq O[€{:vectors}]*O[€{:Schur}]*O[€{:vectors}]' ordschura
     end
 
 debug && println("Generalized Schur")
     if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
         f = schurfact(a[1:5,1:5], a[6:10,6:10])
-        @test_approx_eq f[:Q]*f[:S]*f[:Z]' a[1:5,1:5]
-        @test_approx_eq f[:Q]*f[:T]*f[:Z]' a[6:10,6:10]
-        @test istriu(f[:S]) || iseltype(a,Real)
-        @test istriu(f[:T]) || iseltype(a,Real)
+        @test_approx_eq f[€{:Q}]*f[€{:S}]*f[€{:Z}]' a[1:5,1:5]
+        @test_approx_eq f[€{:Q}]*f[€{:T}]*f[€{:Z}]' a[6:10,6:10]
+        @test istriu(f[€{:S}]) || iseltype(a,Real)
+        @test istriu(f[€{:T}]) || iseltype(a,Real)
     end
 
 debug && println("singular value decomposition")
     if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
         usv = svdfact(a)
-        @test_approx_eq usv[:U]*scale(usv[:S],usv[:Vt]) a
+        @test_approx_eq usv[€{:U}]*scale(usv[€{:S}],usv[€{:Vt}]) a
     end
 
 debug && println("Generalized svd")
     if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
         gsvd = svdfact(a,a[1:5,:])
-        @test_approx_eq gsvd[:U]*gsvd[:D1]*gsvd[:R]*gsvd[:Q]' a
-        @test_approx_eq gsvd[:V]*gsvd[:D2]*gsvd[:R]*gsvd[:Q]' a[1:5,:]
+        @test_approx_eq gsvd[€{:U}]*gsvd[€{:D1}]*gsvd[€{:R}]*gsvd[€{:Q}]' a
+        @test_approx_eq gsvd[€{:V}]*gsvd[€{:D2}]*gsvd[€{:R}]*gsvd[€{:Q}]' a[1:5,:]
     end
 
 debug && println("Solve square general system of equations")

--- a/test/linalg2.jl
+++ b/test/linalg2.jl
@@ -187,7 +187,7 @@ for elty in (Float32, Float64, Complex64, Complex128)
             A_mul_B!(G, R)
         end
     end
-    @test_approx_eq abs(A) abs(hessfact(Ac)[:H])
+    @test_approx_eq abs(A) abs(hessfact(Ac)[€{:H}])
     @test_approx_eq norm(R*eye(elty, 10)) one(elty)
 end
 
@@ -232,7 +232,7 @@ end
 a = convert(Matrix{Rational{BigInt}}, rand(1:10//1,n,n))/n
 b = rand(1:10,n,2)
 lua   = factorize(a)
-l,u,p = lua[:L], lua[:U], lua[:p]
+l,u,p = lua[€{:L}], lua[€{:U}], lua[€{:p}]
 @test_approx_eq l*u a[p,:]
 @test_approx_eq l[invperm(p),:]*u a
 @test_approx_eq a * inv(lua) eye(n)
@@ -255,7 +255,7 @@ for elty in (Float32, Float64, Complex64, Complex128)
                                -eps(real(one(elty)))/4  eps(real(one(elty)))/2  -1.0     0;
                                -0.5     -0.5       0.1     1.0])
     F = eigfact(A,permute=false,scale=false)
-    @test_approx_eq F[:vectors]*Diagonal(F[:values])/F[:vectors] A
+    @test_approx_eq F[€{:vectors}]*Diagonal(F[€{:values}])/F[€{:vectors}] A
     F = eigfact(A)
     # @test norm(F[:vectors]*Diagonal(F[:values])/F[:vectors] - A) > 0.01
 end
@@ -422,7 +422,7 @@ S = sprandn(3,3,0.5)
 @test A/I == A
 @test I/λ === UniformScaling(1/λ)
 @test I\J === J
-T = Triangular(randn(3,3),:L)
+T = Triangular(randn(3,3), €{:L})
 @test T\I == inv(T)
 @test I\A == A
 @test A\I == inv(A)
@@ -484,7 +484,7 @@ end
 #Issue 7304
 let
     A=[-√.5 -√.5; -√.5 √.5]
-    Q=full(qrfact(A)[:Q])
+    Q=full(qrfact(A)[€{:Q}])
     @test vecnorm(A-Q) < eps()
 end
 

--- a/test/linalg3.jl
+++ b/test/linalg3.jl
@@ -169,7 +169,7 @@ for elty in (Float32, Float64, Complex64, Complex128)
         @test_approx_eq expm(A5) eA5
 
         # Hessenberg
-        @test_approx_eq hessfact(A1)[:H] convert(Matrix{elty},
+        @test_approx_eq hessfact(A1)[€{:H}] convert(Matrix{elty},
                         [4.000000000000000  -1.414213562373094  -1.414213562373095
                         -1.414213562373095   4.999999999999996  -0.000000000000000
                                          0  -0.000000000000002   3.000000000000000])

--- a/test/linalg4.jl
+++ b/test/linalg4.jl
@@ -173,17 +173,17 @@ for isupper in (true, false)
     end
 end
 
-A=SymTridiagonal(a, [1.0:n-1])
+A = SymTridiagonal(a, [1.0:n-1])
 for newtype in [Tridiagonal, Matrix]
     @test full(convert(newtype, A)) == full(A)
 end
 
-A=Tridiagonal(zeros(n-1), [1.0:n], zeros(n-1)) #morally Diagonal
+A = Tridiagonal(zeros(n-1), [1.0:n], zeros(n-1)) #morally Diagonal
 for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Matrix]
     @test full(convert(newtype, A)) == full(A)
 end
 
-A=Triangular(full(Diagonal(a)), :L) #morally Diagonal
+A = Triangular(full(Diagonal(a)), €{:L}) #morally Diagonal
 for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Triangular, Matrix]
     @test full(convert(newtype, A)) == full(A)
 end
@@ -196,8 +196,8 @@ for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
         A = randn(5,5)
     end
     A = convert(Matrix{elty}, A'A)
-    for ul in (:U, :L)
-        @test_approx_eq full(cholfact(A, ul)[ul]) full(invoke(Base.LinAlg.chol!, (AbstractMatrix,Symbol),copy(A), ul))
+    for ul in (€{:U}, €{:L})
+        @test_approx_eq full(cholfact(A, ul)[ul]) full(invoke(Base.LinAlg.chol!, (AbstractMatrix,Type{ul}),copy(A), ul))
     end
 end
 


### PR DESCRIPTION
The first of these two commits is a straight forward fix of JuliaLang/LinearAlgebra.jl#152 for 0.3 and it partly fixes the issue for 0.4. However, the type inference problems (see JuliaLang/LinearAlgebra.jl#144) for `Triangular` on 0.4 requires move work to make `\` type stable.

The second commit makes `Triangular` type stable by introducing a dummy parametric immutable to use for dispatch only. Hence, this pr supersedes JuliaLang/julia#8796. I have decided to use `€` as the name for the dummy type because it is short and fairly easy to type on an American Mac keyboard. Hence, a matrix is declared triangular with `Triangular(A,€{:L})` instead of `Triangular(A,:L)`. This change also makes it possible to extract properties from a `Factorization` in a type stable way, e.g. `lufact(A)[€{:L}]`.

The extra methods doesn't have an impact on the time consumption of the `LinAlg` test suite and for the performance tests, it improves `stockcorr` (which was broken again), `laplace_vec` and `vectorize` as far as I can see.
