### PR TITLE
Pkg.generate: call Pkg.build() in `.travis.yml`

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -152,7 +152,7 @@ function travis(pkg::AbstractString; force::Bool=false)
           - sudo apt-get install libpcre3-dev julia -y
           - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
         script:
-          - julia --check-bounds=yes -e 'versioninfo(); Pkg.init(); Pkg.clone(pwd()); Pkg.test("$pkg")'
+          - julia --check-bounds=yes -e 'versioninfo(); Pkg.init(); Pkg.clone(pwd()); Pkg.build("$pkg"); Pkg.test("$pkg")'
         """)
     end
 end


### PR DESCRIPTION
Some packages require external dependencies, which are typically setup with `Pkg.build`. Calling it will ensure the default `.travis.yml` works for these packages.

I ran into this with [GLFW.jl](https://github.com/JuliaGL/GLFW.jl).

cc: @StefanKarpinski
