### PR TITLE
Fix #9209

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -166,7 +166,7 @@ end
 
 function latex_completions(string, pos)
     slashpos = rsearch(string, '\\', pos)
-    if rsearch(string, whitespace_chars, pos) < slashpos && !(1 < slashpos && (string[slashpos-1]=='\\'))
+    if rsearch(string, whitespace_chars, pos) < slashpos && !(1 < slashpos && (string[prevind(string, slashpos)]=='\\'))
         # latex symbol substitution
         s = string[slashpos:pos]
         latex = get(latex_symbols, s, "")

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -73,6 +73,13 @@ c,r = test_latexcomplete(s)
 @test r == 1:length(s)
 @test length(c) == 1
 
+# test latex symbol completions after unicode #9209
+s = "α\\alpha"
+c,r = test_latexcomplete(s)
+@test c[1] == "α"
+@test r == 3:sizeof(s)
+@test length(c) == 1
+
 # test latex symbol completions in strings should not work when there
 # is a backslash in front of `\alpha` because it interferes with path completion on windows
 s = "cd(\"path_to_an_empty_folder_should_not_complete_latex\\\\\\alpha"


### PR DESCRIPTION
This fixes #9209, which is a regression from #9137. The problem was that the Latex completion code
might access an invalid index in the unicode string, if the previous
character from a `\\` was a multibyte character.

cc @tkelman @Luthaf @dhoegh
