### PR TITLE
Deprecate prevind(::Any, ::Integer)

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -240,3 +240,6 @@ const Uint128 = UInt128
 @deprecate ifloor{T}(::Type{T},x) floor(T,x)
 @deprecate iround(x)              round(Integer,x)
 @deprecate iround{T}(::Type{T},x) round(T,x)
+
+@deprecate prevind(a::Any, i::Integer)   i-1
+@deprecate nextind(a::Any, i::Integer)   i+1

--- a/base/string.jl
+++ b/base/string.jl
@@ -106,9 +106,9 @@ function isvalid(s::AbstractString, i::Integer)
 end
 
 prevind(s::DirectIndexString, i::Integer) = i-1
-prevind(s                   , i::Integer) = i-1
+prevind(s::AbstractArray   , i::Integer) = i-1
 nextind(s::DirectIndexString, i::Integer) = i+1
-nextind(s                   , i::Integer) = i+1
+nextind(s::AbstractArray   , i::Integer) = i+1
 
 function prevind(s::AbstractString, i::Integer)
     e = endof(s)


### PR DESCRIPTION
See discussion in #9209 

It seems likely that users that trigger the deprecation rather would have a `MethodError`, and the suggestion to use `i-1` instead is probably bad advise. What do people think?
