### PR TITLE
fix #9214: canonicalize CompoundPeriod

### DIFF
--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -311,3 +311,11 @@ dt = Dates.DateTime(2014)
 @test Dates.days(Dates.Hour(24)) == 1
 @test Dates.days(d) == 1
 @test Dates.days(w) == 7
+
+# issue #9214
+@test 2s + (7ms + 1ms) == (2s + 7ms) + 1ms == 1ms + (2s + 7ms) == 1ms + (1s + 7ms) + 1s == 1ms + (2s + 3d + 7ms) + (-3d) == (1ms + (2s + 3d)) + (7ms - 3d) == (1ms + (2s + 3d)) - (3d - 7ms)
+@test 1ms - (2s + 7ms) == -((2s + 7ms) - 1ms) == (-6ms) - 2s
+emptyperiod = ((y + d) - d) - y
+@test emptyperiod == ((d + y) - y) - d == ((d + y) - d) - y
+@test emptyperiod == 0ms
+@test string(emptyperiod) == "empty period"


### PR DESCRIPTION
As discussed in #9214, this canonicalizes the `CompoundPeriod` type to merge periods of the same type, e.g. `(Dates.Second(2) + Dates.Millisecond(7)) + Dates.Millisecond(1)` now gives `2 seconds, 8 milliseconds`, and to eliminate zero periods.  This is needed to make addition of compound periods associative.

It also cleans up a couple of other problems identified in #9214: `CompoundPeriod` is now an `AbstractTime` subtype (like `Period`), addition/subtraction is no longer mutating, missing `+` and `-` methods for two `CompoundPeriod`s were added (as required for associativity), and `==` is no longer object equality.

cc: @quinnj 
