### PR TITLE
throw MethodError, not ArgumentError, for undefined Period/Time/Date ops

### DIFF
--- a/base/dates/arithmetic.jl
+++ b/base/dates/arithmetic.jl
@@ -1,14 +1,8 @@
 # Instant arithmetic
-for op in (:+,:*,:%,:/)
-    @eval ($op)(x::Instant,y::Instant) = throw(ArgumentError("Operation not defined for Instants"))
-end
 (+)(x::Instant) = x
 (-){T<:Instant}(x::T,y::T) = x.periods - y.periods
 
 # TimeType arithmetic
-for op in (:+,:*,:%,:/)
-    @eval ($op)(x::TimeType,y::TimeType) = throw(ArgumentError("Operation not defined for TimeTypes"))
-end
 (+)(x::TimeType) = x
 (-){T<:TimeType}(x::T,y::T) = x.instant - y.instant
 

--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -5,10 +5,6 @@ value{P<:Period}(x::P) = x.value
 # P(x) = new((convert(Int64,x))
 # The following definitions are for Period-specific safety
 for p in (:Year,:Month,:Week,:Day,:Hour,:Minute,:Second,:Millisecond)
-    # This ensures that we can't convert between Periods
-    @eval $p(x::Period) = throw(ArgumentError("Can't convert $(typeof(x)) to $($p)"))
-    # Unless the Periods are the same type
-    @eval $p(x::$p) = x
     # Convenience method for show()
     @eval _units(x::$p) = $(" " * lowercase(string(p))) * (abs(value(x)) == 1 ? "" : "s")
     # periodisless
@@ -42,9 +38,6 @@ Base.isless{R<:Real}(y::R,x::Period) = isless(int64(y),value(x))
 =={P<:Period}(x::P,y::P) = ===(value(x),value(y))
 =={R<:Real}(x::Period,y::R) = ==(int64(y),value(x))
 =={R<:Real}(y::R,x::Period) = ==(int64(y),value(x))
-
-Base.isless(x::Period,y::Period) = throw(ArgumentError("Can't compare $(typeof(x)) and $(typeof(y))"))
-==(x::Period,y::Period) = throw(ArgumentError("Can't compare $(typeof(x)) and $(typeof(y))"))
 
 #Period Arithmetic:
 import Base.div, Base.mod, Base.gcd, Base.lcm

--- a/base/dates/types.jl
+++ b/base/dates/types.jl
@@ -4,30 +4,17 @@ abstract Period     <: AbstractTime
 abstract DatePeriod <: Period
 abstract TimePeriod <: Period
 
-immutable Year <: DatePeriod
-    value::Int64
+for T in (:Year,:Month,:Week,:Day)
+    @eval immutable $T <: DatePeriod
+        value::Int64
+        $T(v::Number) = new(v)
+    end
 end
-immutable Month <: DatePeriod
-    value::Int64
-end
-immutable Week <: DatePeriod
-    value::Int64
-end
-immutable Day <: DatePeriod
-    value::Int64
-end
-
-immutable Hour <: TimePeriod
-    value::Int64
-end
-immutable Minute <: TimePeriod
-    value::Int64
-end
-immutable Second <: TimePeriod
-    value::Int64
-end
-immutable Millisecond <: TimePeriod
-    value::Int64
+for T in (:Hour,:Minute,:Second,:Millisecond)
+    @eval immutable $T <: TimePeriod
+        value::Int64
+        $T(v::Number) = new(v)
+    end
 end
 
 # Instant types represent different monotonically increasing timelines

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -77,14 +77,6 @@ ms = Dates.Millisecond(1)
 @test mi == mi
 @test s == s
 @test ms == ms
-@test_throws ArgumentError y != m
-@test_throws ArgumentError m != w
-@test_throws ArgumentError w != d
-@test_throws ArgumentError d != h
-@test_throws ArgumentError h != mi
-@test_throws ArgumentError mi != s
-@test_throws ArgumentError s != ms
-@test_throws ArgumentError ms != y
 y2 = Dates.Year(2)
 @test y < y2
 @test y2 > y
@@ -116,13 +108,13 @@ y2 = Dates.Year(2)
 @test Dates.Year(false) != y
 @test_throws MethodError Dates.Year(:hey) == y
 @test Dates.Year(real(1)) == y
-@test_throws ArgumentError Dates.Year(m) == y
-@test_throws ArgumentError Dates.Year(w) == y
-@test_throws ArgumentError Dates.Year(d) == y
-@test_throws ArgumentError Dates.Year(h) == y
-@test_throws ArgumentError Dates.Year(mi) == y
-@test_throws ArgumentError Dates.Year(s) == y
-@test_throws ArgumentError Dates.Year(ms) == y
+@test_throws MethodError Dates.Year(m) == y
+@test_throws MethodError Dates.Year(w) == y
+@test_throws MethodError Dates.Year(d) == y
+@test_throws MethodError Dates.Year(h) == y
+@test_throws MethodError Dates.Year(mi) == y
+@test_throws MethodError Dates.Year(s) == y
+@test_throws MethodError Dates.Year(ms) == y
 @test Dates.Year(Dates.Date(2013,1,1)) == Dates.Year(2013)
 @test Dates.Year(Dates.DateTime(2013,1,1)) == Dates.Year(2013)
 @test typeof(y+m) <: Dates.CompoundPeriod
@@ -133,8 +125,8 @@ y2 = Dates.Year(2)
 @test typeof(y+mi) <: Dates.CompoundPeriod
 @test typeof(y+s) <: Dates.CompoundPeriod
 @test typeof(y+ms) <: Dates.CompoundPeriod
-@test_throws ArgumentError y > m
-@test_throws ArgumentError d < w
+@test_throws MethodError y > m
+@test_throws MethodError d < w
 @test typemax(Dates.Year) == Dates.Year(typemax(Int64))
 @test typemax(Dates.Year) + y == Dates.Year(-9223372036854775808)
 @test typemin(Dates.Year) == Dates.Year(-9223372036854775808)
@@ -262,8 +254,7 @@ test = ((((((((dt + y) - m) + w) - d) + h) - mi) + s) - ms)
 @test 1 == Dates.Millisecond(1)
 @test (Dates.Millisecond(1) < 1) == false
 @test (1 < Dates.Millisecond(1)) == false
-@test_throws ArgumentError Dates.Year(1) < Dates.Millisecond(1)
-@test_throws ArgumentError Dates.Year(1) == Dates.Millisecond(1)
+@test_throws MethodError Dates.Year(1) < Dates.Millisecond(1)
 
 @test Dates.Year("1") == y
 @test Dates.Month("1") == m


### PR DESCRIPTION
As discussed in commit 6fb633083f4d01a2b7f1d8d4db8bfb22258c889f, it is a bit odd that we explicitly define methods only to throw an `ArgumentError` that the operation is not defined.  It is more Julian to simply leave the method undefined and throw a `MethodError`.

cc: @quinnj 
