### PR TITLE
Make copy! methods consistent, fix copy! bugs

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -168,36 +168,36 @@ end
 # copy with minimal requirements on src
 # if src is not an AbstractArray, moving to the offset might be O(n)
 function copy!(dest::AbstractArray, doffs::Integer, src, soffs::Integer=1)
+    soffs < 1 && throw(BoundsError())
     st = start(src)
     for j = 1:(soffs-1)
+        done(src, st) && throw(BoundsError())
         _, st = next(src, st)
     end
+    dn = done(src, st)
+    dn && throw(BoundsError())
     i = doffs
-    while !done(src,st)
+    while !dn
         val, st = next(src, st)
         dest[i] = val
         i += 1
+        dn = done(src, st)
     end
-    return dest
-end
-
-# NOTE: this is to avoid ambiguity with the deprecation of
-#   copy!(dest::AbstractArray, src, doffs::Integer)
-# Remove this when that deprecation is removed.
-function copy!(dest::AbstractArray, doffs::Integer, src::Integer)
-    dest[doffs] = src
     return dest
 end
 
 # this method must be separate from the above since src might not have a length
 function copy!(dest::AbstractArray, doffs::Integer, src, soffs::Integer, n::Integer)
+    n < 0 && throw(BoundsError())
     n == 0 && return dest
+    soffs < 1 && throw(BoundsError())
     st = start(src)
     for j = 1:(soffs-1)
+        done(src, st) && throw(BoundsError())
         _, st = next(src, st)
     end
     for i = doffs:(doffs+n-1)
-        done(src,st) && throw(BoundsError())
+        done(src, st) && throw(BoundsError())
         val, st = next(src, st)
         dest[i] = val
     end
@@ -205,7 +205,12 @@ function copy!(dest::AbstractArray, doffs::Integer, src, soffs::Integer, n::Inte
 end
 
 # if src is an AbstractArray and a source offset is passed, use indexing
-function copy!(dest::AbstractArray, doffs::Integer, src::AbstractArray, soffs::Integer, n::Integer=length(src))
+function copy!(dest::AbstractArray, doffs::Integer, src::AbstractArray, soffs::Integer)
+    soffs > length(src) && throw(BoundsError())
+    copy!(dest, doffs, src, soffs, length(src)-soffs+1)
+end
+function copy!(dest::AbstractArray, doffs::Integer, src::AbstractArray, soffs::Integer, n::Integer)
+    n < 0 && throw(BoundsError())
     for i = 0:(n-1)
         dest[doffs+i] = src[soffs+i]
     end

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -238,16 +238,15 @@ function one(x::BitMatrix)
 end
 
 function copy!(dest::BitArray, src::BitArray)
+    length(src) > length(dest) && throw(BoundsError())
     destc = dest.chunks; srcc = src.chunks
-    nc_d = length(destc)
-    nc_s = length(srcc)
-    nc = min(nc_s, nc_d)
+    nc = min(length(destc), length(srcc))
     nc == 0 && return dest
     @inbounds begin
         for i = 1 : nc - 1
             destc[i] = srcc[i]
         end
-        if length(src) >= length(dest)
+        if length(src) == length(dest)
             destc[nc] = srcc[nc]
         else
             msk_s = @_msk_end length(src)
@@ -258,11 +257,12 @@ function copy!(dest::BitArray, src::BitArray)
     return dest
 end
 
-function copy!(dest::BitArray, pos_d::Integer, src::BitArray, pos_s::Integer, numbits::Integer)
-    if pos_s+numbits-1 > length(src) || pos_d+numbits-1 > length(dest) || pos_d < 1 || pos_s < 1
+function copy!(dest::BitArray, doffs::Integer, src::BitArray, soffs::Integer, n::Integer)
+    n == 0 && return dest
+    if soffs+n-1 > length(src) || doffs+n-1 > length(dest) || doffs < 1 || soffs < 1
         throw(BoundsError())
     end
-    copy_chunks!(dest.chunks, pos_d, src.chunks, pos_s, numbits)
+    copy_chunks!(dest.chunks, doffs, src.chunks, soffs, n)
     return dest
 end
 

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -1,0 +1,48 @@
+mainres = ([4, 5, 3],
+           [1, 5, 3])
+bitres = ([true, true, false],
+          [false, true, false])
+
+type Tsk
+    t::Task
+    f::Function
+    function Tsk(x)
+        fx() = for i in x produce(i) end
+        new(Task(fx), fx)
+    end
+end
+Base.start(itr::Tsk) = (itr.t = Task(itr.f); nothing)
+Base.done(itr::Tsk, _) = done(itr.t, _)
+Base.next(itr::Tsk, _) = next(itr.t, _)
+
+for (dest, src, bigsrc, res) in [
+    ([1, 2, 3], [4, 5], [1, 2, 3, 4, 5], mainres),
+    ([1, 2, 3], 4:5, 1:5, mainres),
+    ([1, 2, 3], Tsk(4:5), Tsk(1:5), mainres),
+    (falses(3), trues(2), trues(5), bitres)]
+
+    @test copy!(copy(dest), src) == res[1]
+    @test copy!(copy(dest), 1, src) == res[1]
+    @test copy!(copy(dest), 2, src, 2) == res[2]
+    @test copy!(copy(dest), 2, src, 2, 1) == res[2]
+
+    @test copy!(copy(dest), 99, src, 99, 0) == dest
+
+    for idx in [0, 4]
+        @test_throws BoundsError copy!(dest, idx, src)
+        @test_throws BoundsError copy!(dest, idx, src, 1)
+        @test_throws BoundsError copy!(dest, idx, src, 1, 1)
+        @test_throws BoundsError copy!(dest, 1, src, idx)
+        @test_throws BoundsError copy!(dest, 1, src, idx, 1)
+    end
+
+    @test_throws BoundsError copy!(dest, 1, src, 1, -1)
+
+    @test_throws BoundsError copy!(dest, bigsrc)
+
+    @test_throws BoundsError copy!(dest, 3, src)
+    @test_throws BoundsError copy!(dest, 3, src, 1)
+    @test_throws BoundsError copy!(dest, 3, src, 1, 2)
+
+    @test_throws BoundsError copy!(dest, 1, src, 2, 2)
+end

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -3,46 +3,36 @@ mainres = ([4, 5, 3],
 bitres = ([true, true, false],
           [false, true, false])
 
-type Tsk
-    t::Task
-    f::Function
-    function Tsk(x)
-        fx() = for i in x produce(i) end
-        new(Task(fx), fx)
-    end
-end
-Base.start(itr::Tsk) = (itr.t = Task(itr.f); nothing)
-Base.done(itr::Tsk, _) = done(itr.t, _)
-Base.next(itr::Tsk, _) = next(itr.t, _)
+tsk(x) = @task for i in x; produce(i); end
 
 for (dest, src, bigsrc, res) in [
-    ([1, 2, 3], [4, 5], [1, 2, 3, 4, 5], mainres),
-    ([1, 2, 3], 4:5, 1:5, mainres),
-    ([1, 2, 3], Tsk(4:5), Tsk(1:5), mainres),
-    (falses(3), trues(2), trues(5), bitres)]
+    ([1, 2, 3], () -> [4, 5], () -> [1, 2, 3, 4, 5], mainres),
+    ([1, 2, 3], () -> 4:5, () -> 1:5, mainres),
+    ([1, 2, 3], () -> tsk(4:5), () -> tsk(1:5), mainres),
+    (falses(3), () -> trues(2), () -> trues(5), bitres)]
 
-    @test copy!(copy(dest), src) == res[1]
-    @test copy!(copy(dest), 1, src) == res[1]
-    @test copy!(copy(dest), 2, src, 2) == res[2]
-    @test copy!(copy(dest), 2, src, 2, 1) == res[2]
+    @test copy!(copy(dest), src()) == res[1]
+    @test copy!(copy(dest), 1, src()) == res[1]
+    @test copy!(copy(dest), 2, src(), 2) == res[2]
+    @test copy!(copy(dest), 2, src(), 2, 1) == res[2]
 
-    @test copy!(copy(dest), 99, src, 99, 0) == dest
+    @test copy!(copy(dest), 99, src(), 99, 0) == dest
 
     for idx in [0, 4]
-        @test_throws BoundsError copy!(dest, idx, src)
-        @test_throws BoundsError copy!(dest, idx, src, 1)
-        @test_throws BoundsError copy!(dest, idx, src, 1, 1)
-        @test_throws BoundsError copy!(dest, 1, src, idx)
-        @test_throws BoundsError copy!(dest, 1, src, idx, 1)
+        @test_throws BoundsError copy!(dest, idx, src())
+        @test_throws BoundsError copy!(dest, idx, src(), 1)
+        @test_throws BoundsError copy!(dest, idx, src(), 1, 1)
+        @test_throws BoundsError copy!(dest, 1, src(), idx)
+        @test_throws BoundsError copy!(dest, 1, src(), idx, 1)
     end
 
-    @test_throws BoundsError copy!(dest, 1, src, 1, -1)
+    @test_throws BoundsError copy!(dest, 1, src(), 1, -1)
 
-    @test_throws BoundsError copy!(dest, bigsrc)
+    @test_throws BoundsError copy!(dest, bigsrc())
 
-    @test_throws BoundsError copy!(dest, 3, src)
-    @test_throws BoundsError copy!(dest, 3, src, 1)
-    @test_throws BoundsError copy!(dest, 3, src, 1, 2)
+    @test_throws BoundsError copy!(dest, 3, src())
+    @test_throws BoundsError copy!(dest, 3, src(), 1)
+    @test_throws BoundsError copy!(dest, 3, src(), 1, 2)
 
-    @test_throws BoundsError copy!(dest, 1, src, 2, 2)
+    @test_throws BoundsError copy!(dest, 1, src(), 2, 2)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ testnames = [
     "linalg", "core", "keywordargs", "numbers", "strings", "dates",
     "collections", "hashing", "remote", "iobuffer", "staged", "arrayops",
     "subarray", "reduce", "reducedim", "random", "intfuncs",
-    "simdloop", "blas", "fft", "dsp", "sparse", "bitarray", "math",
+    "simdloop", "blas", "fft", "dsp", "sparse", "bitarray", "copy", "math",
     "functional", "bigint", "sorting", "statistics", "spawn",
     "backtrace", "priorityqueue", "arpack", "file", "suitesparse", "version",
     "resolve", "pollfd", "mpfr", "broadcast", "complex", "socket",


### PR DESCRIPTION
`copy!` was doing some thing that surprised me, so I fixed a couple of bugs, standardized the names, and standardized the behavior of all the methods (to what looked like the majority intent across methods -- all happened to seem sensible).

Basics:
- trying to copy more than destination can hold is an error.
- n < 0 is an error
- when n == 0, return dest without checking bounds
- soffs & doffs must be inbounds otherwise
