### PR TITLE
minor cleanup of DimensionMismatch error

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -808,7 +808,7 @@ end
 ## promotion to complex ##
 
 function complex{S<:Real,T<:Real}(A::Array{S}, B::Array{T})
-    if size(A) != size(B); throw(DimensionMismatch("")); end
+    if size(A) != size(B); throw(DimensionMismatch()); end
     F = similar(A, typeof(complex(zero(S),zero(T))))
     for i=1:length(A)
         @inbounds F[i] = complex(A[i], B[i])

--- a/base/base.jl
+++ b/base/base.jl
@@ -113,8 +113,9 @@ end
 type EOFError <: Exception end
 
 type DimensionMismatch <: Exception
-    name::ASCIIString
+    msg::AbstractString
 end
+DimensionMismatch() = DimensionMismatch("")
 
 type WeakRef
     value

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -51,7 +51,7 @@ function eigs(A, B;
     sigma = isshift ? convert(T,sigma) : zero(T)
 
     if !isempty(v0)
-        length(v0)==n || throw(DimensionMismatch(""))
+        length(v0)==n || throw(DimensionMismatch())
         eltype(v0)==T || error("Starting vector must have eltype $T")
     end
 

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -4,7 +4,7 @@ type Bidiagonal{T} <: AbstractMatrix{T}
     ev::Vector{T} # sub/super diagonal
     isupper::Bool # is upper bidiagonal (true) or lower (false)
     function Bidiagonal{T}(dv::Vector{T}, ev::Vector{T}, isupper::Bool)
-        length(ev)==length(dv)-1 ? new(dv, ev, isupper) : throw(DimensionMismatch(""))
+        length(ev)==length(dv)-1 ? new(dv, ev, isupper) : throw(DimensionMismatch())
     end
 end
 
@@ -159,7 +159,7 @@ end end
 #Generic solver using naive substitution
 function naivesub!{T}(A::Bidiagonal{T}, b::AbstractVector, x::AbstractVector = b)
     N = size(A, 2)
-    N == length(b) == length(x) || throw(DimensionMismatch(""))
+    N == length(b) == length(x) || throw(DimensionMismatch())
 
     if !A.isupper #do forward substitution
         for j = 1:N

--- a/base/linalg/bitarray.jl
+++ b/base/linalg/bitarray.jl
@@ -1,6 +1,6 @@
 function dot(x::BitVector, y::BitVector)
     # simplest way to mimic Array dot behavior
-    length(x) == length(y) || throw(DimensionMismatch(""))
+    length(x) == length(y) || throw(DimensionMismatch())
     s = 0
     xc = x.chunks
     yc = y.chunks
@@ -17,7 +17,7 @@ end
     #(mA, nA) = size(A)
     #(mB, nB) = size(B)
     #C = falses(nA, nB)
-    #if mA != mB; throw(DimensionMismatch("")) end
+    #if mA != mB; throw(DimensionMismatch()) end
     #if mA == 0; return C; end
     #col_ch = num_bit_chunks(mA)
     ## TODO: avoid using aux chunks and copy (?)
@@ -85,7 +85,7 @@ function diag(B::BitMatrix)
 end
 
 function diagm(v::Union(BitVector,BitMatrix))
-    isa(v, BitMatrix) && size(v,1)==1 || size(v,2)==1 || throw(DimensionMismatch(""))
+    isa(v, BitMatrix) && size(v,1)==1 || size(v,2)==1 || throw(DimensionMismatch())
     n = length(v)
     a = falses(n, n)
     for i=1:n

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -222,7 +222,7 @@ end
 function axpy!{T<:BlasFloat,Ta<:Number,Ti<:Integer}(alpha::Ta, x::Array{T}, rx::Union(UnitRange{Ti},Range{Ti}),
                                          y::Array{T}, ry::Union(UnitRange{Ti},Range{Ti}))
 
-    length(rx)==length(ry) || throw(DimensionMismatch(""))
+    length(rx)==length(ry) || throw(DimensionMismatch())
 
     if minimum(rx) < 1 || maximum(rx) > length(x) || minimum(ry) < 1 || maximum(ry) > length(y)
         throw(BoundsError())
@@ -264,7 +264,7 @@ for (fname, elty) in ((:dgemv_,:Float64),
              #      DOUBLE PRECISION A(LDA,*),X(*),Y(*)
         function gemv!(trans::BlasChar, alpha::($elty), A::StridedVecOrMat{$elty}, X::StridedVector{$elty}, beta::($elty), Y::StridedVector{$elty})
             m,n = size(A,1),size(A,2)
-            length(X) == (trans == 'N' ? n : m) && length(Y) == (trans == 'N' ? m : n) || throw(DimensionMismatch(""))
+            length(X) == (trans == 'N' ? n : m) && length(Y) == (trans == 'N' ? m : n) || throw(DimensionMismatch())
             ccall(($(blasfunc(fname)), libblas), Void,
                 (Ptr{UInt8}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty},
                  Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt},
@@ -335,7 +335,7 @@ for (fname, elty) in ((:dsymv_,:Float64),
         function symv!(uplo::BlasChar, alpha::($elty), A::StridedMatrix{$elty}, x::StridedVector{$elty},beta::($elty), y::StridedVector{$elty})
             m, n = size(A)
             if m != n throw(DimensionMismatch("Matrix A is $m by $n but must be square")) end
-            if m != length(x) || m != length(y) throw(DimensionMismatch("")) end
+            if m != length(x) || m != length(y) throw(DimensionMismatch()) end
             ccall(($(blasfunc(fname)), libblas), Void,
                 (Ptr{UInt8}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty},
                  Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
@@ -360,8 +360,8 @@ for (fname, elty) in ((:zhemv_,:Complex128),
     @eval begin
         function hemv!(uplo::Char, α::$elty, A::StridedMatrix{$elty}, x::StridedVector{$elty}, β::$elty, y::StridedVector{$elty})
             n = size(A, 2)
-            n == length(x) || throw(DimensionMismatch(""))
-            size(A, 1) == length(y) || throw(DimensionMismatch(""))
+            n == length(x) || throw(DimensionMismatch())
+            size(A, 1) == length(y) || throw(DimensionMismatch())
             lda = max(1, stride(A, 2))
             incx = stride(x, 1)
             incy = stride(y, 1)
@@ -481,8 +481,8 @@ for (fname, elty) in ((:dger_,:Float64),
     @eval begin
         function ger!(α::$elty, x::StridedVector{$elty}, y::StridedVector{$elty}, A::StridedMatrix{$elty})
             m, n = size(A)
-            m == length(x) || throw(DimensionMismatch(""))
-            n == length(y) || throw(DimensionMismatch(""))
+            m == length(x) || throw(DimensionMismatch())
+            n == length(y) || throw(DimensionMismatch())
             ccall(($(blasfunc(fname)), libblas), Void,
                 (Ptr{BlasInt}, Ptr{BlasInt}, Ptr{$elty}, Ptr{$elty},
                  Ptr{BlasInt}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},
@@ -554,7 +554,7 @@ for (gemm, elty) in
             k = size(A, transA == 'N' ? 2 : 1)
             n = size(B, transB == 'N' ? 2 : 1)
             if m != size(C,1) || n != size(C,2)
-                throw(DimensionMismatch(""))
+                throw(DimensionMismatch())
             end
             ccall(($(blasfunc(gemm)), libblas), Void,
                 (Ptr{UInt8}, Ptr{UInt8}, Ptr{BlasInt}, Ptr{BlasInt},
@@ -592,7 +592,7 @@ for (mfname, elty) in ((:dsymm_,:Float64),
         function symm!(side::BlasChar, uplo::BlasChar, alpha::($elty), A::StridedMatrix{$elty}, B::StridedMatrix{$elty}, beta::($elty), C::StridedMatrix{$elty})
             m, n = size(C)
             j = chksquare(A)
-            if j != (side == 'L' ? m : n) || size(B,2) != n throw(DimensionMismatch("")) end
+            if j != (side == 'L' ? m : n) || size(B,2) != n throw(DimensionMismatch()) end
             ccall(($(blasfunc(mfname)), libblas), Void,
                 (Ptr{UInt8}, Ptr{UInt8}, Ptr{BlasInt}, Ptr{BlasInt},
                  Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{$elty},

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -60,7 +60,7 @@ Ac_mul_B!(A::Diagonal,B::AbstractMatrix)= scale!(conj(A.diag),B)
 
 /(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag ./ Db.diag )
 function A_ldiv_B!{T}(D::Diagonal{T}, v::AbstractVector{T})
-    length(v)==length(D.diag) || throw(DimensionMismatch(""))
+    length(v)==length(D.diag) || throw(DimensionMismatch())
     for i=1:length(D.diag)
         d = D.diag[i]
         d==zero(T) && throw(SingularException(i))
@@ -69,7 +69,7 @@ function A_ldiv_B!{T}(D::Diagonal{T}, v::AbstractVector{T})
     v
 end
 function A_ldiv_B!{T}(D::Diagonal{T}, V::AbstractMatrix{T})
-    size(V,1)==length(D.diag) || throw(DimensionMismatch(""))
+    size(V,1)==length(D.diag) || throw(DimensionMismatch())
     for i=1:length(D.diag)
         d = D.diag[i]
         d==zero(T) && throw(SingularException(i))
@@ -99,7 +99,7 @@ sqrtm(D::Diagonal) = Diagonal(sqrt(D.diag))
 #Linear solver
 function \{TD<:Number,TA<:Number}(D::Diagonal{TD}, A::AbstractArray{TA,1})
     m, n = size(A,2)==1 ? (size(A,1),1) : size(A)
-    m==length(D.diag) || throw(DimensionMismatch(""))
+    m==length(D.diag) || throw(DimensionMismatch())
     (m == 0 || n == 0) && return A
     C = Array(typeof(one(TD)/one(TA)),size(A))
     for j = 1:n

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -137,7 +137,7 @@ A_mul_B!{T<:BlasFloat}(A::QRPackedQ{T}, B::StridedVecOrMat{T}) = LAPACK.ormqr!('
 function A_mul_B!{T}(A::QRPackedQ{T}, B::AbstractVecOrMat{T})
     mA, nA = size(A.factors)
     mB, nB = size(B,1), size(B,2)
-    mA == mB || throw(DimensionMismatch(""))
+    mA == mB || throw(DimensionMismatch())
     Afactors = A.factors
     @inbounds begin
         for k = min(mA,nA):-1:1
@@ -159,13 +159,13 @@ end
 function *{TA,Tb}(A::Union(QRPackedQ{TA},QRCompactWYQ{TA}), b::StridedVector{Tb})
     TAb = promote_type(TA,Tb)
     Anew = convert(AbstractMatrix{TAb},A)
-    bnew = size(A.factors,1) == length(b) ? (Tb == TAb ? copy(b) : convert(Vector{TAb}, b)) : (size(A.factors,2) == length(b) ? [b,zeros(TAb, size(A.factors,1)-length(b))] : throw(DimensionMismatch("")))
+    bnew = size(A.factors,1) == length(b) ? (Tb == TAb ? copy(b) : convert(Vector{TAb}, b)) : (size(A.factors,2) == length(b) ? [b,zeros(TAb, size(A.factors,1)-length(b))] : throw(DimensionMismatch()))
     A_mul_B!(Anew,bnew)
 end
 function *{TA,TB}(A::Union(QRPackedQ{TA},QRCompactWYQ{TA}), B::StridedMatrix{TB})
     TAB = promote_type(TA,TB)
     Anew = convert(AbstractMatrix{TAB},A)
-    Bnew = size(A.factors,1) == size(B,1) ? (TB == TAB ? copy(B) : convert(AbstractMatrix{TAB}, B)) : (size(A.factors,2) == size(B,1) ? [B;zeros(TAB, size(A.factors,1)-size(B,1),size(B,2))] : throw(DimensionMismatch("")))
+    Bnew = size(A.factors,1) == size(B,1) ? (TB == TAB ? copy(B) : convert(AbstractMatrix{TAB}, B)) : (size(A.factors,2) == size(B,1) ? [B;zeros(TAB, size(A.factors,1)-size(B,1),size(B,2))] : throw(DimensionMismatch()))
     A_mul_B!(Anew,Bnew)
 end
 ### QcB
@@ -176,7 +176,7 @@ Ac_mul_B!{T<:BlasComplex}(A::QRPackedQ{T}, B::StridedVecOrMat{T}) = LAPACK.ormqr
 function Ac_mul_B!{T}(A::QRPackedQ{T}, B::AbstractVecOrMat{T})
     mA, nA = size(A.factors)
     mB, nB = size(B,1), size(B,2)
-    mA == mB || throw(DimensionMismatch(""))
+    mA == mB || throw(DimensionMismatch())
     Afactors = A.factors
     @inbounds begin
         for k = 1:min(mA,nA)
@@ -205,7 +205,7 @@ A_mul_B!(A::StridedVecOrMat, B::QRPackedQ) = LAPACK.ormqr!('R', 'N', B.factors, 
 function A_mul_B!{T}(A::StridedMatrix{T},Q::QRPackedQ{T})
     mQ, nQ = size(Q.factors)
     mA, nA = size(A,1), size(A,2)
-    nA == mQ || throw(DimensionMismatch(""))
+    nA == mQ || throw(DimensionMismatch())
     Qfactors = Q.factors
     @inbounds begin
         for k = 1:min(mQ,nQ)
@@ -236,7 +236,7 @@ A_mul_Bc!{T<:BlasComplex}(A::StridedVecOrMat{T}, B::QRPackedQ{T}) = LAPACK.ormqr
 function A_mul_Bc!{T}(A::AbstractMatrix{T},Q::QRPackedQ{T})
     mQ, nQ = size(Q.factors)
     mA, nA = size(A,1), size(A,2)
-    nA == mQ || throw(DimensionMismatch(""))
+    nA == mQ || throw(DimensionMismatch())
     Qfactors = Q.factors
     @inbounds begin
         for k = min(mQ,nQ):-1:1
@@ -260,7 +260,7 @@ function A_mul_Bc{TA,TB}(A::AbstractArray{TA}, B::Union(QRCompactWYQ{TB},QRPacke
     TAB = promote_type(TA,TB)
     A_mul_Bc!(size(A,2)==size(B.factors,1) ? (TA == TAB ? copy(A) : convert(AbstractMatrix{TAB}, A)) :
               size(A,2)==size(B.factors,2) ? [A zeros(TAB, size(A, 1), size(B.factors, 1) - size(B.factors, 2))] :
-              throw(DimensionMismatch("")),
+              throw(DimensionMismatch()),
 
               convert(AbstractMatrix{TAB}, B))
 end

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -341,14 +341,14 @@ end
 #                                          for BlasFloat Arrays)
 function axpy!(alpha, x::AbstractArray, y::AbstractArray)
     n = length(x)
-    n==length(y) || throw(DimensionMismatch(""))
+    n==length(y) || throw(DimensionMismatch())
     for i = 1:n
         @inbounds y[i] += alpha * x[i]
     end
     y
 end
 function axpy!{Ti<:Integer,Tj<:Integer}(alpha, x::AbstractArray, rx::AbstractArray{Ti}, y::AbstractArray, ry::AbstractArray{Tj})
-    length(x)==length(y) || throw(DimensionMismatch(""))
+    length(x)==length(y) || throw(DimensionMismatch())
     if minimum(rx) < 1 || maximum(rx) > length(x) || minimum(ry) < 1 || maximum(ry) > length(y) || length(rx) != length(ry)
         throw(BoundsError())
     end

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -1111,7 +1111,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
         function ggsvd!(jobu::BlasChar, jobv::BlasChar, jobq::BlasChar, A::Matrix{$elty}, B::Matrix{$elty})
             chkstride1(A, B)
             m, n = size(A)
-            if size(B, 2) != n; throw(DimensionMismatch("")); end
+            if size(B, 2) != n; throw(DimensionMismatch()); end
             p = size(B, 1)
             k = Array(BlasInt, 1)
             l = Array(BlasInt, 1)
@@ -1600,8 +1600,8 @@ for (orglq, orgqr, ormlq, ormqr, gemqrt, elty) in
             m, n = ndims(C)==2 ? size(C) : (size(C, 1), 1)
             nA    = size(A, 2)
             k     = length(tau)
-            if side == 'L' && m != nA throw(DimensionMismatch("")) end
-            if side == 'R' && n != nA throw(DimensionMismatch("")) end
+            if side == 'L' && m != nA throw(DimensionMismatch()) end
+            if side == 'R' && n != nA throw(DimensionMismatch()) end
             if (side == 'L' && k > m) || (side == 'R' && k > n) throw(DimensionMismatch("invalid number of reflectors")) end
             work  = Array($elty, 1)
             lwork = blas_int(-1)
@@ -1634,8 +1634,8 @@ for (orglq, orgqr, ormlq, ormqr, gemqrt, elty) in
             m, n = ndims(C)==2 ? size(C) : (size(C, 1), 1)
             mA    = size(A, 1)
             k     = length(tau)
-            if side == 'L' && m != mA throw(DimensionMismatch("")) end
-            if side == 'R' && n != mA throw(DimensionMismatch("")) end
+            if side == 'L' && m != mA throw(DimensionMismatch()) end
+            if side == 'R' && n != mA throw(DimensionMismatch()) end
             if (side == 'L' && k > m) || (side == 'R' && k > n) throw(DimensionMismatch("invalid number of reflectors")) end
             work  = Array($elty, 1)
             lwork = blas_int(-1)
@@ -1665,13 +1665,13 @@ for (orglq, orgqr, ormlq, ormqr, gemqrt, elty) in
             if k == 0 return C end
             if side == 'L'
                 0 <= k <= m || throw(DimensionMismatch("Wrong value for k"))
-                m == size(V,1) || throw(DimensionMismatch(""))
+                m == size(V,1) || throw(DimensionMismatch())
                 ldv = stride(V,2)
                 ldv >= max(1, m) || throw(DimensionMismatch("Q and C don't fit"))
                 wss = n*k
             elseif side == 'R'
                 0 <= k <= n || throw(DimensionMismatch("Wrong value for k"))
-                n == size(V,1) || throw(DimensionMismatch(""))
+                n == size(V,1) || throw(DimensionMismatch())
                 ldv = stride(V,2)
                 ldv >= max(1, n) || throw(DimensionMismatch("stride error"))
                 wss = m*k
@@ -1942,7 +1942,7 @@ for (trtri, trtrs, elty) in
             chkstride1(A)
             n = chksquare(A)
             @chkuplo
-            size(B,1)==n || throw(DimensionMismatch(""))
+            size(B,1)==n || throw(DimensionMismatch())
             info = Array(BlasInt, 1)
             ccall(($(blasfunc(trtrs)), liblapack), Void,
                   (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt}, Ptr{BlasInt},
@@ -2056,7 +2056,7 @@ for (trcon, trevc, trrfs, elty) in
             @chkuplo
             n = size(A,2)
             nrhs = size(B,2)
-            nrhs == size(X,2) || throw(DimensionMismatch(""))
+            nrhs == size(X,2) || throw(DimensionMismatch())
             work = Array($elty, 3n)
             iwork = Array(BlasInt, n)
             info = Array(BlasInt, 1)
@@ -2175,7 +2175,7 @@ for (trcon, trevc, trrfs, elty, relty) in
             @chkuplo
             n=size(A,2)
             nrhs=size(B,2)
-            nrhs==size(X,2) || throw(DimensionMismatch(""))
+            nrhs==size(X,2) || throw(DimensionMismatch())
             work=Array($elty, 2n)
             rwork=Array($relty, n)
             info=Array(BlasInt, 1)
@@ -3333,7 +3333,7 @@ for (orghr, elty) in
 #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
             chkstride1(A)
             n = chksquare(A)
-            if n - length(tau) != 1 throw(DimensionMismatch("")) end
+            if n - length(tau) != 1 throw(DimensionMismatch()) end
             work = Array($elty, 1)
             lwork = blas_int(-1)
             info = Array(BlasInt, 1)
@@ -3739,7 +3739,7 @@ for (fn, elty) in ((:dtfsm_, :Float64),
         function pftrs!(transr::Char, side::Char, uplo::Char, trans::Char, diag::Char, alpha::Real, A::StridedVector{$elty}, B::StridedMatrix{$elty})
             chkstride1(B)
             m, n = size(B)
-            if int(div(sqrt(8length(A)), 2)) != m throw(DimensionMismatch("")) end
+            if int(div(sqrt(8length(A)), 2)) != m throw(DimensionMismatch()) end
             ldb = max(1, stride(B, 2))
             ccall(($(blasfunc(fn)), liblapack), Void,
                 (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar},
@@ -3830,7 +3830,7 @@ for (fn, elty, relty) in ((:dtrsyl_, :Float64, :Float64),
             lda = max(1, stride(A, 2))
             ldb = max(1, stride(B, 2))
             m1, n1 = size(C)
-            if m != m1 || n != n1 throw(DimensionMismatch("")) end
+            if m != m1 || n != n1 throw(DimensionMismatch()) end
             ldc = max(1, stride(C, 2))
 
             scale = Array($relty, 1)

--- a/base/linalg/ldlt.jl
+++ b/base/linalg/ldlt.jl
@@ -32,7 +32,7 @@ factorize(S::SymTridiagonal) = ldltfact(S)
 
 function A_ldiv_B!{T}(S::LDLt{T,SymTridiagonal{T}}, B::AbstractVecOrMat{T})
     n, nrhs = size(B, 1), size(B, 2)
-    size(S,1) == n || throw(DimensionMismatch(""))
+    size(S,1) == n || throw(DimensionMismatch())
     d = S.data.dv
     l = S.data.ev
     @inbounds begin

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -224,7 +224,7 @@ factorize(A::Tridiagonal) = lufact(A)
 # See dgtts2.f
 function A_ldiv_B!{T}(A::LU{T,Tridiagonal{T}}, B::AbstractVecOrMat)
     n = size(A,1)
-    n == size(B,1) || throw(DimensionMismatch(""))
+    n == size(B,1) || throw(DimensionMismatch())
     nrhs = size(B,2)
     dl = A.factors.dl
     d = A.factors.d

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -6,7 +6,7 @@ arithtype(::Type{Bool}) = Int
 # multiply by diagonal matrix as vector
 function scale!(C::AbstractMatrix, A::AbstractMatrix, b::AbstractVector)
     m, n = size(A)
-    n == length(b) || throw(DimensionMismatch(""))
+    n == length(b) || throw(DimensionMismatch())
     for j = 1:n
         bj = b[j]
         for i = 1:m
@@ -18,7 +18,7 @@ end
 
 function scale!(C::AbstractMatrix, b::AbstractVector, A::AbstractMatrix)
     m, n = size(A)
-    m == length(b) || throw(DimensionMismatch(""))
+    m == length(b) || throw(DimensionMismatch())
     for j = 1:n, i = 1:m
         C[i,j] = A[i,j]*b[i]
     end
@@ -32,14 +32,14 @@ scale(b::Vector, A::Matrix) = scale!(similar(b, promote_type(eltype(A),eltype(b)
 dot{T<:BlasReal}(x::StridedVector{T}, y::StridedVector{T}) = BLAS.dot(x, y)
 dot{T<:BlasComplex}(x::StridedVector{T}, y::StridedVector{T}) = BLAS.dotc(x, y)
 function dot{T<:BlasReal, TI<:Integer}(x::Vector{T}, rx::Union(UnitRange{TI},Range{TI}), y::Vector{T}, ry::Union(UnitRange{TI},Range{TI}))
-    length(rx)==length(ry) || throw(DimensionMismatch(""))
+    length(rx)==length(ry) || throw(DimensionMismatch())
     if minimum(rx) < 1 || maximum(rx) > length(x) || minimum(ry) < 1 || maximum(ry) > length(y)
         throw(BoundsError())
     end
     BLAS.dot(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
 end
 function dot{T<:BlasComplex, TI<:Integer}(x::Vector{T}, rx::Union(UnitRange{TI},Range{TI}), y::Vector{T}, ry::Union(UnitRange{TI},Range{TI}))
-    length(rx)==length(ry) || throw(DimensionMismatch(""))
+    length(rx)==length(ry) || throw(DimensionMismatch())
     if minimum(rx) < 1 || maximum(rx) > length(x) || minimum(ry) < 1 || maximum(ry) > length(y)
         throw(BoundsError())
     end
@@ -47,7 +47,7 @@ function dot{T<:BlasComplex, TI<:Integer}(x::Vector{T}, rx::Union(UnitRange{TI},
 end
 function dot(x::AbstractVector, y::AbstractVector)
     lx = length(x)
-    lx==length(y) || throw(DimensionMismatch(""))
+    lx==length(y) || throw(DimensionMismatch())
     if lx == 0
         return zero(eltype(x))*zero(eltype(y))
     end
@@ -206,8 +206,8 @@ end
 function gemv!{T<:BlasFloat}(y::StridedVector{T}, tA::Char, A::StridedVecOrMat{T}, x::StridedVector{T})
     stride(A, 1)==1 || return generic_matvecmul!(y, tA, A, x)
     mA, nA = lapack_size(tA, A)
-    nA==length(x) || throw(DimensionMismatch(""))
-    mA==length(y) || throw(DimensionMismatch(""))
+    nA==length(x) || throw(DimensionMismatch())
+    mA==length(y) || throw(DimensionMismatch())
     mA == 0 && return y
     nA == 0 && return fill!(y,0)
     return BLAS.gemv!(tA, one(T), A, x, zero(T), y)
@@ -271,7 +271,7 @@ function gemm_wrapper!{T<:BlasFloat}(C::StridedVecOrMat{T}, tA::Char, tB::Char,
     nA==mB || throw(DimensionMismatch("*"))
 
     if mA == 0 || nA == 0 || nB == 0
-        size(C) == (mA, nB) || throw(DimensionMismatch(""))
+        size(C) == (mA, nB) || throw(DimensionMismatch())
         return fill!(C,0)
     end
     if mA == 2 && nA == 2 && nB == 2; return matmul2x2!(C,tA,tB,A,B); end

--- a/base/linalg/sparse.jl
+++ b/base/linalg/sparse.jl
@@ -11,8 +11,8 @@ end
 (*){TvA,TiA}(A::SparseMatrixCSC{TvA,TiA}, X::BitArray{1}) = invoke(*, (SparseMatrixCSC, AbstractVector), A, X)
 # In matrix-vector multiplication, the correct orientation of the vector is assumed.
 function A_mul_B!(α::Number, A::SparseMatrixCSC, x::AbstractVector, β::Number, y::AbstractVector)
-    A.n == length(x) || throw(DimensionMismatch(""))
-    A.m == length(y) || throw(DimensionMismatch(""))
+    A.n == length(x) || throw(DimensionMismatch())
+    A.m == length(y) || throw(DimensionMismatch())
     if β != 1
         β != 0 ? scale!(y,β) : fill!(y,zero(eltype(y)))
     end
@@ -34,8 +34,8 @@ function *{TA,S,Tx}(A::SparseMatrixCSC{TA,S}, x::AbstractVector{Tx})
 end
 
 function Ac_mul_B!(α::Number, A::SparseMatrixCSC, x::AbstractVector, β::Number, y::AbstractVector)
-    A.n == length(y) || throw(DimensionMismatch(""))
-    A.m == length(x) || throw(DimensionMismatch(""))
+    A.n == length(y) || throw(DimensionMismatch())
+    A.m == length(x) || throw(DimensionMismatch())
     nzv = A.nzval
     rv = A.rowval
     zro = zero(eltype(y))
@@ -59,8 +59,8 @@ function Ac_mul_B!(α::Number, A::SparseMatrixCSC, x::AbstractVector, β::Number
 end
 Ac_mul_B!(y::AbstractVector, A::SparseMatrixCSC, x::AbstractVector) = Ac_mul_B!(one(eltype(x)), A, x, zero(eltype(y)), y)
 function At_mul_B!(α::Number, A::SparseMatrixCSC, x::AbstractVector, β::Number, y::AbstractVector)
-    A.n == length(y) || throw(DimensionMismatch(""))
-    A.m == length(x) || throw(DimensionMismatch(""))
+    A.n == length(y) || throw(DimensionMismatch())
+    A.m == length(x) || throw(DimensionMismatch())
     nzv = A.nzval
     rv = A.rowval
     zro = zero(eltype(y))
@@ -96,7 +96,7 @@ end
 # In vector-matrix multiplication, the correct orientation of the vector is assumed.
 # XXX: this is wrong (i.e. not what Arrays would do)!!
 function *{T1,T2}(X::AbstractVector{T1}, A::SparseMatrixCSC{T2})
-    A.m==length(X) || throw(DimensionMismatch(""))
+    A.m==length(X) || throw(DimensionMismatch())
     Y = zeros(promote_type(T1,T2), A.n)
     nzv = A.nzval
     rv = A.rowval
@@ -109,7 +109,7 @@ end
 *{TvA,TiA}(A::SparseMatrixCSC{TvA,TiA}, X::BitArray{2}) = invoke(*, (SparseMatrixCSC, AbstractMatrix), A, X)
 function (*){TvA,TiA,TX}(A::SparseMatrixCSC{TvA,TiA}, X::AbstractMatrix{TX})
     mX, nX = size(X)
-    A.n==mX || throw(DimensionMismatch(""))
+    A.n==mX || throw(DimensionMismatch())
     Y = zeros(promote_type(TvA,TX), A.m, nX)
     nzv = A.nzval
     rv = A.rowval
@@ -129,7 +129,7 @@ end
 *{TvA,TiA}(X::Triangular, A::SparseMatrixCSC{TvA,TiA}) = full(X)*A
 function *{TX,TvA,TiA}(X::AbstractMatrix{TX}, A::SparseMatrixCSC{TvA,TiA})
     mX, nX = size(X)
-    nX == A.m || throw(DimensionMismatch(""))
+    nX == A.m || throw(DimensionMismatch())
     Y = zeros(promote_type(TX,TvA), mX, A.n)
     for multivec_row=1:mX, col=1:A.n, k=A.colptr[col]:(A.colptr[col+1]-1)
         Y[multivec_row, col] += X[multivec_row, A.rowval[k]] * A.nzval[k]
@@ -146,7 +146,7 @@ function spmatmul{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti};
                          sortindices::Symbol = :sortcols)
     mA, nA = size(A)
     mB, nB = size(B)
-    nA==mB || throw(DimensionMismatch(""))
+    nA==mB || throw(DimensionMismatch())
 
     colptrA = A.colptr; rowvalA = A.rowval; nzvalA = A.nzval
     colptrB = B.colptr; rowvalB = B.rowval; nzvalB = B.nzval
@@ -596,7 +596,7 @@ inv(A::SparseMatrixCSC) = error("The inverse of a sparse matrix can often be den
 # multiply by diagonal matrix as vector
 function scale!{Tv,Ti}(C::SparseMatrixCSC{Tv,Ti}, A::SparseMatrixCSC, b::Vector)
     m, n = size(A)
-    (n==length(b) && size(A)==size(C)) || throw(DimensionMismatch(""))
+    (n==length(b) && size(A)==size(C)) || throw(DimensionMismatch())
     numnz = nnz(A)
     C.colptr = convert(Array{Ti}, A.colptr)
     C.rowval = convert(Array{Ti}, A.rowval)
@@ -609,7 +609,7 @@ end
 
 function scale!{Tv,Ti}(C::SparseMatrixCSC{Tv,Ti}, b::Vector, A::SparseMatrixCSC)
     m, n = size(A)
-    (n==length(b) && size(A)==size(C)) || throw(DimensionMismatch(""))
+    (n==length(b) && size(A)==size(C)) || throw(DimensionMismatch())
     numnz = nnz(A)
     C.colptr = convert(Array{Ti}, A.colptr)
     C.rowval = convert(Array{Ti}, A.rowval)

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -329,7 +329,7 @@ A_mul_Bc!(C::AbstractVecOrMat, A::Triangular, B::AbstractVecOrMat) = A_mul_Bc!(A
 #Generic solver using naive substitution
 function naivesub!{T,S,UpLo,IsUnit}(A::Triangular{T,S,UpLo,IsUnit}, b::AbstractVector, x::AbstractVector=b)
     N = size(A, 2)
-    N==length(b)==length(x) || throw(DimensionMismatch(""))
+    N==length(b)==length(x) || throw(DimensionMismatch())
 
     if UpLo == :L #do forward substitution
         for j = 1:N

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -51,8 +51,8 @@ end
 
 function A_mul_B!(C::StridedVecOrMat, S::SymTridiagonal, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
-    m == size(S, 1) == size(C, 1) || throw(DimensionMismatch(""))
-    n == size(C, 2) || throw(DimensionMismatch(""))
+    m == size(S, 1) == size(C, 1) || throw(DimensionMismatch())
+    n == size(C, 2) || throw(DimensionMismatch())
 
     α = S.dv
     β = S.ev
@@ -194,7 +194,7 @@ end
 convert{T}(::Type{Matrix}, M::Tridiagonal{T}) = convert(Matrix{T}, M)
 function similar(M::Tridiagonal, T, dims::Dims)
     if length(dims) != 2 || dims[1] != dims[2]
-        throw(DimensionMismatch("Tridiagonal matrices must be square"))
+        throw(DimensionMismatch())
     end
     Tridiagonal{T}(similar(M.dl), similar(M.d), similar(M.du), similar(M.du2))
 end
@@ -255,8 +255,8 @@ convert{T}(::Type{SymTridiagonal{T}}, M::Tridiagonal) = M.dl==M.du ? (SymTridiag
 convert{T}(::Type{SymTridiagonal{T}},M::SymTridiagonal) = SymTridiagonal(convert(Vector{T}, M.dv), convert(Vector{T}, M.ev))
 
 function A_mul_B!(C::AbstractVecOrMat, A::Tridiagonal, B::AbstractVecOrMat)
-    size(C,1) == size(B,1) == (nA = size(A,1)) || throw(DimensionMismatch(""))
-    size(C,2) == (nB = size(B,2)) || throw(DimensionMismatch(""))
+    size(C,1) == size(B,1) == (nA = size(A,1)) || throw(DimensionMismatch())
+    size(C,2) == (nB = size(B,2)) || throw(DimensionMismatch())
     l = A.dl
     d = A.d
     u = A.du

--- a/base/linalg/umfpack.jl
+++ b/base/linalg/umfpack.jl
@@ -201,7 +201,7 @@ for (sym_r,sym_c,num_r,num_c,sol_r,sol_c,det_r,det_z,lunz_r,lunz_z,get_num_r,get
         end
         function solve(lu::UmfpackLU{Float64,$itype}, b::VecOrMat{Float64}, typ::Integer)
             umfpack_numeric!(lu)
-            size(b,1)==lu.m || throw(DimensionMismatch(""))
+            size(b,1)==lu.m || throw(DimensionMismatch())
             x = similar(b)
             joff = 1
             for k = 1:size(b,2)
@@ -215,7 +215,7 @@ for (sym_r,sym_c,num_r,num_c,sol_r,sol_c,det_r,det_z,lunz_r,lunz_z,get_num_r,get
         end
         function solve(lu::UmfpackLU{Complex128,$itype}, b::VecOrMat{Complex128}, typ::Integer)
             umfpack_numeric!(lu)
-            size(b,1)==lu.m || throw(DimensionMismatch(""))
+            size(b,1)==lu.m || throw(DimensionMismatch())
             x = similar(b)
             n = size(b,1)
             br = Array(Float64, n)

--- a/base/linalg/woodbury.jl
+++ b/base/linalg/woodbury.jl
@@ -15,11 +15,11 @@ type Woodbury{T} <: AbstractMatrix{T}
         N = size(A, 1)
         k = size(U, 2)
         if size(A, 2) != N || size(U, 1) != N || size(V, 1) != k || size(V, 2) != N
-            throw(DimensionMismatch(""))
+            throw(DimensionMismatch())
         end
         if k > 1
             if size(C, 1) != k || size(C, 2) != k
-                throw(DimensionMismatch(""))
+                throw(DimensionMismatch())
             end
         end
         Cp = inv(inv(C) + V*(A\U))
@@ -57,7 +57,7 @@ full{T}(W::Woodbury{T}) = convert(Matrix{T}, W)
 convert{T}(::Type{Matrix{T}}, W::Woodbury{T}) = full(W.A) + W.U*W.C*W.V
 
 function similar(W::Woodbury, T, dims::Dims)
-    (length(dims) == 2 && dims[1] == dims[2] ) || throw(DimensionMismatch(""))
+    (length(dims) == 2 && dims[1] == dims[2] ) || throw(DimensionMismatch())
     n = size(W, 1)
     k = size(W.U, 2)
     Woodbury{T}(similar(W.A), Array(T, n, k), Array(T, k, k), Array(T, k, n))


### PR DESCRIPTION
- change field name from `name` to `msg` to align with other error types
  The majority of `DimensionMismatch` errors do not return the original
  method name so this is a bit of a misnomer
- change type of msg from `ASCIIString` -> `AbstractString` (closes #8984)
- Add convenience constructor `DimensionMismatch()` for the common case
  where no error message is provided
