### PR TITLE
add more Period conversions

### DIFF
--- a/test/dates/conversions.jl
+++ b/test/dates/conversions.jl
@@ -44,3 +44,28 @@
 @test typeof(Dates.now()) <: Dates.DateTime
 @test typeof(Dates.today()) <: Dates.Date
 @test typeof(Dates.now(Dates.UTC)) <: Dates.DateTime
+
+# Issue #9171, #9169
+let t = Dates.Period[Dates.Week(2), Dates.Day(14), Dates.Hour(14*24), Dates.Minute(14*24*60), Dates.Second(14*24*60*60), Dates.Millisecond(14*24*60*60*1000)]
+    for i = 1:length(t)
+        Pi = typeof(t[i])
+        for j = 1:length(t)
+            @test t[i] == t[j]
+            @test Int(convert(Pi,t[j])) == Int(t[i])
+        end
+        for j = i+1:length(t)
+            Pj = typeof(t[j])
+            tj1 = t[j] + one(Pj)
+            @test t[i] < tj1
+            @test_throws InexactError Pi(tj1)
+            @test_throws InexactError Pj(Pi(typemax(Int64)))
+            @test_throws InexactError Pj(Pi(typemin(Int64)))
+        end
+    end
+end
+@test Dates.Year(3) == Dates.Month(36)
+@test Int(convert(Dates.Month, Dates.Year(3))) == 36
+@test Int(convert(Dates.Year, Dates.Month(36))) == 3
+@test Dates.Year(3) < Dates.Month(37)
+@test_throws InexactError convert(Dates.Year, Dates.Month(37))
+@test_throws InexactError Dates.Month(Dates.Year(typemax(Int64)))

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -116,7 +116,7 @@ y2 = Dates.Year(2)
 @test Dates.Year(false) != y
 @test_throws MethodError Dates.Year(:hey) == y
 @test Dates.Year(real(1)) == y
-@test_throws MethodError Dates.Year(m) == y
+@test_throws InexactError Dates.Year(m) == y
 @test_throws MethodError Dates.Year(w) == y
 @test_throws MethodError Dates.Year(d) == y
 @test_throws MethodError Dates.Year(h) == y
@@ -133,8 +133,8 @@ y2 = Dates.Year(2)
 @test typeof(y+mi) <: Dates.CompoundPeriod
 @test typeof(y+s) <: Dates.CompoundPeriod
 @test typeof(y+ms) <: Dates.CompoundPeriod
-@test_throws MethodError y > m
-@test_throws MethodError d < w
+@test y > m
+@test d < w
 @test typemax(Dates.Year) == Dates.Year(typemax(Int64))
 @test typemax(Dates.Year) + y == Dates.Year(-9223372036854775808)
 @test typemin(Dates.Year) == Dates.Year(-9223372036854775808)
@@ -283,3 +283,6 @@ emptyperiod = ((y + d) - d) - y
 @test emptyperiod == ((d + y) - y) - d == ((d + y) - d) - y
 @test emptyperiod == 0ms
 @test string(emptyperiod) == "empty period"
+@test 8d - s == 1w + 23h + 59mi + 59s
+@test h + 3mi == 63mi
+@test y - m == 11m


### PR DESCRIPTION
This patch adds `convert` methods so that you can now do e.g. `Second(Day(1))` and get 86400s, for all of the `FixedPeriod` types which correspond to fixed time intervals.  It also supports conversions of `Month` to `Year` since a calendar year always has 12 months, but conversions of `Month` to `Week` etcetera is not implemented because the length of a `Month` varies.  Fixes #9171.

Previously, `Period` conversion was only supported to `Millisecond` and `Day`.  Previously, conversion to `Day` would silently truncate the results (e.g. for `Day(Hour(23))`), but now this throws an `InexactError`; see #9169.

Also, this expands upon #9217 by further canonicalizing `CompoundPeriod` types to ensure that `0 < ms < 1000`, `0 < s < 60`, etcetera.  For example, `Dates.Day(8) - Dates.Second(1)` gives `1 week, 23 hours, 59 minutes, 59 seconds`.   This allows reliable `==` comparison of `CompoundPeriod` types.

cc: @quinnj 
