### PR TITLE
RFC: NTuple{Float64,Int} type intersection

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -829,6 +829,10 @@ static jl_value_t *jl_type_intersect(jl_value_t *a, jl_value_t *b,
             has_ntuple_intersect_tuple = 1;
             jl_value_t *lenvar = jl_tparam0(b);
             jl_value_t *elty = jl_tparam1(b);
+            if (!jl_is_typevar(lenvar)) {
+                JL_GC_POP();
+                return (jl_value_t*)jl_bottom_type;
+            }
             int i;
             for(i=0; i < eqc->n; i+=2) {
                 if (eqc->data[i] == lenvar) {
@@ -2122,6 +2126,7 @@ static int jl_subtype_le(jl_value_t *a, jl_value_t *b, int ta, int invariant)
         if ((jl_tuple_t*)b == jl_tuple_type && !invariant) return 1;
         if (jl_is_datatype(b)) {
             if (((jl_datatype_t*)b)->name == jl_ntuple_typename) {
+                if (!jl_is_typevar(jl_tparam0(b))) return 0;
                 jl_value_t *tp = jl_tupleref(((jl_datatype_t*)b)->parameters, 1);
                 if (tuple_all_subtype((jl_tuple_t*)a, tp, ta, invariant)) {
                     if (invariant) {

--- a/test/core.jl
+++ b/test/core.jl
@@ -88,6 +88,7 @@ let N = TypeVar(:N,true)
 
     @test isequal(typeintersect((Type{Void},Type{Void}), Type{NTuple{N,Void}}),
                   Type{(Void,Void)})
+    @test isequal(typeintersect(NTuple{Float64,Int},(Int,Int)), None)
 end
 @test is(Bottom, typeintersect(Type{Any},Type{Complex}))
 @test is(Bottom, typeintersect(Type{Any},Type{TypeVar(:T,Real)}))


### PR DESCRIPTION
Issue https://github.com/JuliaLang/julia/issues/9233

Type intersection for NTuples handles NTuple parameters which are typevars, as in NTuple{T,Int}, or parameters which are explicit, such as NTuple{2,Int}. Type intersection in jltypes.c handles most of the possible combinations correctly. The syntax error, NTuple{Float64,Int}, is an example of a case where all arguments are datatypes, but earlier processing steps haven't expanded the NTuple to a regular tuple. We can catch that by asking whether arguments are typevars in two places.

If the first NTuple parameter is, for instance, a 3, as in NTuple{3,Float32}, then that 3 is assigned a jl_type of jl_is_typevar(). If that is an incorrect assignment, then this bug is better solved at an earlier stage.
