### PR TITLE
julia-mode.el: improve matching of function assignment syntax

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -148,11 +148,15 @@ This function provides equivalent functionality, but makes no efforts to optimis
 
 (defconst julia-function-assignment-regex
   (rx line-start symbol-start
+      (* (seq (1+ (or word (syntax symbol))) ".")) ; module name
       (group (1+ (or word (syntax symbol))))
       (* space)
       (? "{" (* (not (any "}"))) "}")
       (* space)
-      "(" (* (not (any ")"))) ")"
+      "(" (* (or
+              (seq "(" (* (not (any "(" ")"))) ")")
+              (not (any "(" ")"))))
+      ")"
       (* space)
       "="))
 


### PR DESCRIPTION
The case when a module qualification is prepended to the function name
is handled like in normal function syntax, and support for one level of
nested parentheses is added, e.g. M.f(x::(Int,)) = 1 (tuple types) or
M.f(x, y=length(x)).
