### PR TITLE
Macro expand step for (s)printf

### DIFF
--- a/base/printf.jl
+++ b/base/printf.jl
@@ -1044,6 +1044,7 @@ end
 
 macro printf(args...)
     !isempty(args) || error("@printf: called with zero arguments")
+    args = map(macroexpand, args)
     if isa(args[1], AbstractString) || is_str_expr(args[1])
         _printf("@printf", :STDOUT, args[1], args[2:end])
     else
@@ -1055,6 +1056,7 @@ end
 
 macro sprintf(args...)
     !isempty(args) || error("@sprintf: called with zero arguments")
+    args = map(macroexpand, args)
     isa(args[1], AbstractString) || is_str_expr(args[1]) ||
         error("@sprintf: first argument must be a format string")
     blk = _printf("@sprintf", :(IOBuffer()), args[1], args[2:end])


### PR DESCRIPTION
This just makes `@printf` and `@sprintf` macroexpand their arguments. I don't think there should be any horrible consequences to changing the order of macro expansion, but we could always check that the expression is a macro call before doing this and/or only replace those that expand to strings.

The idea of this is to allow, for example

``` julia
macro fmt()
  "%.2d"
end
@sprintf(@fmt, n)
```

Which is obviously useful when you want to use the same format string more than once.
