### PR TITLE
Define Base.copy for ::AbstractTime

### DIFF
--- a/base/dates/types.jl
+++ b/base/dates/types.jl
@@ -161,3 +161,5 @@ Base.isless(x::Date,y::Date) = isless(value(x),value(y))
 Base.isless(x::DateTime,y::DateTime) = isless(value(x),value(y))
 Base.isless(x::TimeType,y::TimeType) = isless(promote(x,y)...)
 ==(x::TimeType,y::TimeType) = ===(promote(x,y)...)
+# All defined AbstractTime types are immutable
+Base.copy(x::AbstractTime) = x


### PR DESCRIPTION
This comes up when specifying the plot bounds in Dates (e.g., in https://github.com/dcjones/Gadfly.jl/issues/354).  I suppose defining this for all `::AbstractTime` is a little dangerous as others could define their own mutable subtypes. I could easily change this into a large union if desired.  But I think, in general, there should be a copy method for these types, no?
