### PR TITLE
add reverseind(s, i): convert indices in reverse(s) to indices in s

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -102,6 +102,9 @@ Library improvements
     to provide uniform cross-platform behavior and up-to-date, locale-independent support
     for Unicode standards ([#5939]).
 
+  * `reverseind` function to convert indices in reversed strings (e.g. from
+    reversed regex searches) to indices in the original string ([#9249]).
+
   * New `Nullable` type for missing data ([#8152]).
 
   * New `ordschur` and `ordschur!` functions for sorting a schur factorization by the eigenvalues.
@@ -1126,4 +1129,5 @@ Too numerous to mention.
 [#9132]: https://github.com/JuliaLang/julia/issues/9132
 [#9133]: https://github.com/JuliaLang/julia/issues/9133
 [#9144]: https://github.com/JuliaLang/julia/issues/9144
+[#9249]: https://github.com/JuliaLang/julia/issues/9249
 [#9271]: https://github.com/JuliaLang/julia/issues/9271

--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -160,7 +160,7 @@ function afterusing(string::ByteString, startpos::Int)
     rstr = reverse(str)
     r = search(rstr, r"\s(gnisu|tropmi)\b")
     isempty(r) && return false
-    fr = chr2ind(str, length(str)-ind2chr(rstr, last(r))+1)
+    fr = reverseind(str, last(r))
     return ismatch(r"^\b(using|import)\s*(\w+\s*,\s*)*\w*$", str[fr:end])
 end
 
@@ -188,7 +188,7 @@ function completions(string, pos)
     inc_tag = Base.incomplete_tag(parse(partial , raise=false))
     if inc_tag in [:cmd, :string]
         m = match(r"[\t\n\r\"'`@\$><=;|&\{]| (?!\\)", reverse(partial))
-        startpos = nextind(partial, endof(partial)) - m.offset + 1
+        startpos = nextind(partial, reverseind(partial, m.offset))
         r = startpos:pos
         paths, r, success = complete_path(replace(string[r], r"\\ ", " "), pos)
         if inc_tag == :string &&

--- a/base/array.jl
+++ b/base/array.jl
@@ -981,6 +981,7 @@ function reverse(A::AbstractVector, s=1, n=length(A))
     end
     B
 end
+reverseind(a::AbstractVector, i::Integer) = length(a) + 1 - i
 
 reverse(v::StridedVector) = (n=length(v); [ v[n-i+1] for i=1:n ])
 reverse(v::StridedVector, s, n=length(v)) = reverse!(copy(v), s, n)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -870,6 +870,7 @@ export
     repeat,
     replace,
     repr,
+    reverseind,
     rpad,
     rsearch,
     rsearchindex,

--- a/base/string.jl
+++ b/base/string.jl
@@ -748,6 +748,15 @@ reverse(s::RevString) = s.string
 
 isascii(s::RevString{ASCIIString}) = true
 
+## reverse an index i so that reverse(s)[i] == s[reverseind(s,i)]
+
+reverseind(s::Union(DirectIndexString,SubString{DirectIndexString}), i::Integer) = length(s) + 1 - i
+reverseind(s::RevString, i::Integer) = endof(s) - i + 1
+lastidx(s::AbstractString) = nextind(s, endof(s)) - 1
+lastidx(s::DirectIndexString) = length(s)
+reverseind(s::SubString, i::Integer) =
+    reverseind(s.string, lastidx(s.string)-s.offset-s.endof+i) - s.offset
+
 ## ropes for efficient concatenation, etc. ##
 
 immutable RopeString <: AbstractString

--- a/base/utf16.jl
+++ b/base/utf16.jl
@@ -28,6 +28,26 @@ function next(s::UTF16String, i::Int)
     error("invalid UTF-16 character index")
 end
 
+function reverseind(s::UTF16String, i::Integer)
+    j = length(s.data) - i
+    return Base.utf16_is_trail(s.data[j]) ? j-1 : j
+end
+lastidx(s::UTF16String) = length(s.data) - 1 # s.data includes NULL terminator
+
+function reverse(s::UTF16String)
+    d =s.data
+    out = similar(d)
+    out[end] = 0 # NULL termination
+    n = length(d)
+    for i = 1:n-1
+        out[i] = d[n-i]
+        if Base.utf16_is_lead(out[i])
+            out[i],out[i-1] = out[i-1],out[i]
+        end
+    end
+    return UTF16String(out)
+end
+
 # TODO: optmize this
 function encode16(s::AbstractString)
     buf = UInt16[]

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -87,9 +87,20 @@ function first_utf8_byte(ch::Char)
                   uint8((c>>18) | 0xf0)
 end
 
+function reverseind(s::UTF8String, i::Integer)
+    j = lastidx(s) + 1 - i
+    d = s.data
+    while !is_utf8_start(d[j])
+        j -= 1
+    end
+    return j
+end
+
 ## overload methods for efficiency ##
 
 sizeof(s::UTF8String) = sizeof(s.data)
+
+lastidx(s::UTF8String) = length(s.data)
 
 isvalid(s::UTF8String, i::Integer) =
     (1 <= i <= endof(s.data)) && is_utf8_start(s.data[i])

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4672,6 +4672,12 @@ Combinatorics
 
    Return a copy of ``v`` reversed from start to stop.
 
+.. function:: reverseind(v, i)
+
+   Given an index ``i`` in ``reverse(v)``, return the corresponding
+   index in ``v`` so that ``v[reverseind(v,i)] == reverse(v)[i]``.
+   (This can be nontrivial in the case where ``v`` is a Unicode string.)
+
 .. function:: reverse!(v [, start=1 [, stop=length(v) ]]) -> v
 
    In-place version of :func:`reverse`.

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1266,3 +1266,26 @@ Base.start(jt::i9178) = (jt.nnext=0 ; jt.ndone=0 ; 0)
 Base.done(jt::i9178, n) = (jt.ndone += 1 ; n > 3)
 Base.next(jt::i9178, n) = (jt.nnext += 1 ; ("$(jt.nnext),$(jt.ndone)", n+1))
 @test join(i9178(0,0), ";") == "1,1;2,2;3,3;4,4"
+
+# reverseind
+for T in (ASCIIString, UTF8String, UTF16String, UTF32String)
+    for prefix in ("", "abcd", "\U0001d6a4\U0001d4c1", "\U0001d6a4\U0001d4c1c", " \U0001d6a4\U0001d4c1")
+        for suffix in ("", "abcde", "\U0001d4c1β\U0001d6a4", "\U0001d4c1β\U0001d6a4c", " \U0001d4c1β\U0001d6a4")
+            for c in ('X', 'δ', '\U0001d6a5')
+                T != ASCIIString || (isascii(prefix) && isascii(suffix) && isascii(c)) || continue
+                s = convert(T, string(prefix, c, suffix))
+                ri = search(reverse(s), c)
+                @test reverse(s) == RevString(s)
+                @test c == s[reverseind(s, ri)] == reverse(s)[ri]
+                s = RevString(s)
+                ri = search(reverse(s), c)
+                @test c == s[reverseind(s, ri)] == reverse(s)[ri]
+                s = convert(T, string(prefix, prefix, c, suffix, suffix))
+                pre = convert(T, prefix)
+                sb = SubString(s, nextind(pre, endof(pre)), endof(convert(T, string(prefix, prefix, c, suffix))))
+                ri = search(reverse(sb), c)
+                @test c == sb[reverseind(sb, ri)] == reverse(sb)[ri]
+            end
+        end
+    end
+end


### PR DESCRIPTION
The main use of `reverse(s::String)` appears to be regex searching backwards in a string (see the discussion in #6165), but it is insanely hard to correctly convert the resulting indices (of matches in the reversed string) back to indices in the original string (see e.g. #9227).   `reverseind(s, i)` solves this problem: `reverse(s)[i] == s[reverseind(s, i)]`.

For example, in REPLCompletions this replaces code that is either tricky (`nextind(partial, endof(partial)) - m.offset`, which relies on the fact that the match is ASCII and that ASCII is encoded by a single code unit in all of our encodings) or slow `chr2ind(str, length(str)-ind2chr(rstr, last(r))+1)` (which is linear time in `length(str)`).

(It might be useful to check whether reversed strings are being searched in other packages, and whether the indices are handled correctly.)

cc: @dhoegh, @jiahao 
