### PR TITLE
Backport #9227 "Fix path completion when UTF8 char is occurring before match characters."

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -188,7 +188,7 @@ function completions(string, pos)
     inc_tag = Base.incomplete_tag(parse(partial , raise=false))
     if inc_tag in [:cmd, :string]
         m = match(r"[\t\n\r\"'`@\$><=;|&\{]| (?!\\)", reverse(partial))
-        startpos = length(partial) - (m == nothing ? 1 : m.offset) + 2
+        startpos = nextind(partial, endof(partial)) - m.offset + 1
         r = startpos:pos
         paths, r, success = complete_path(replace(string[r], r"\\ ", " "), pos)
         if inc_tag == :string &&

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -172,7 +172,7 @@ end
 
 let #test that it can auto complete with spaces in file/path
     path = tempdir()
-    space_folder = randstring() * " r"
+    space_folder = randstring() * " α"
     dir = joinpath(path, space_folder)
     dir_space = replace(space_folder, " ", "\\ ")
     mkdir(dir)
@@ -183,7 +183,7 @@ let #test that it can auto complete with spaces in file/path
             @test r == endof(s)-4:endof(s)
             @test "space\\ .file" in c
 
-            s = @windows? "cd(\"$dir_space\\\\space" : "cd(\"$dir_space/space"
+            s = @windows? "cd(\"β $dir_space\\\\space" : "cd(\"β $dir_space/space"
             c,r = test_complete(s)
             @test r == endof(s)-4:endof(s)
             @test "space\\ .file\"" in c


### PR DESCRIPTION
I have backported #9227 "Fix path completion when UTF8 char is occurring before match characters." to 0.3.3 @stevengj
