### PR TITLE
Fix git lldb build

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -211,6 +211,14 @@ else
 LLVM_TAR=llvm-$(LLVM_VER).src.tar.xz
 endif
 
+ifeq ($(BUILD_LLDB),1)
+ifeq ($(LLVM_VER), 3.5.0)
+LLVM_LLDB_TAR=lldb-$(LLVM_VER).src.tar.xz
+else
+LLVM_LLDB_TAR=lldb-$(LLVM_VER).src.tar.gz
+endif # LLVM_VER == 3.5.0
+endif # BUILD_LLDB
+
 ifeq ($(BUILD_LLVM_CLANG),1)
 ifeq ($(LLVM_VER), 3.0)
 LLVM_CLANG_TAR=clang-$(LLVM_VER).tar.gz
@@ -224,19 +232,17 @@ LLVM_COMPILER_RT_TAR=compiler-rt-$(LLVM_VER).src.tar.xz
 else
 LLVM_CLANG_TAR=clang-$(LLVM_VER).src.tar.gz
 LLVM_COMPILER_RT_TAR=compiler-rt-$(LLVM_VER).src.tar.gz
-endif
+endif # LLVM_VER
 else
 LLVM_CLANG_TAR=
 LLVM_COMPILER_RT_TAR=
 LLVM_LIBCXX_TAR=
-endif
-endif
+endif # BUILD_LLVM_CLANG
 
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
-ifneq ($(LLVM_VER),svn)
 LLVM_LIBCXX_TAR=libcxx-$(LLVM_VER).src.tar.gz
 endif
-endif
+endif # LLVM_VER != svn
 
 LLVM_CXXFLAGS = $(CXXFLAGS)
 LLVM_CPPFLAGS = $(CPPFLAGS)
@@ -248,51 +254,43 @@ ifeq ($(LLVM_ASSERTIONS), 1)
 LLVM_FLAGS += --enable-assertions
 ifeq ($(OS), WINNT)
 LLVM_FLAGS += --disable-embed-stdcxx
-endif
+endif # OS == WINNT
 else
 LLVM_FLAGS += --disable-assertions
-endif
+endif # LLVM_ASSERTIONS
 ifeq ($(LLVM_DEBUG), 1)
 LLVM_FLAGS += --disable-optimized --enable-debug-symbols --enable-keep-symbols
 else
 LLVM_FLAGS += --enable-optimized
-endif
+endif # LLVM_DEBUG
 ifeq ($(USE_LIBCPP), 1)
 LLVM_FLAGS += --enable-libcpp
-endif
+endif # USE_LIBCPP
 ifeq ($(OS), WINNT)
 LLVM_FLAGS += --with-extra-ld-options="-Wl,--stack,8388608" LDFLAGS="" --disable-shared
 LLVM_CPPFLAGS += -D__USING_SJLJ_EXCEPTIONS__ -D__CRT__NO_INLINE
-endif
+endif # OS == WINNT
 ifeq ($(USE_INTEL_JITEVENTS), 1)
 LLVM_FLAGS += --with-intel-jitevents
 ifeq ($(OS), WINNT)
 LLVM_FLAGS += --disable-threads
-endif
+endif # OS == WINNT
 else
 LLVM_FLAGS += --disable-threads
-endif
-
-ifeq ($(BUILD_LLDB),1)
-ifeq ($(LLVM_VER), 3.5.0)
-LLVM_LLDB_TAR=lldb-$(LLVM_VER).src.tar.xz
-else
-LLVM_LLDB_TAR=lldb-$(LLVM_VER).src.tar.gz
-endif
+endif # USE_INTEL_JITEVENTS
 
 ifeq ($(USECLANG),1)
 LLVM_FLAGS += --enable-cxx11
 else
 LLVM_CXXFLAGS += -std=c++0x
-endif
+endif # USECLANG
 ifeq ($(LLDB_DISABLE_PYTHON),1)
 LLVM_CXXFLAGS += -DLLDB_DISABLE_PYTHON
-endif
-endif
+endif # LLDB_DISABLE_PYTHON
 
 ifeq ($(ARCH), ppc64)
 LLVM_CXXFLAGS += -mminimal-toc
-endif
+endif # ARCH == ppc64
 
 
 ifeq ($(LLVM_SANITIZE),1)
@@ -302,20 +300,20 @@ LLVM_CXXFLAGS += -fsanitize=address
 LLVM_MFLAGS += TOOL_NO_EXPORTS= HAVE_LINK_VERSION_SCRIPT=0
 else
 LLVM_CC =
-endif
+endif # LLVM_SANITIZE
 
 ifneq ($(LLVM_CXXFLAGS),)
 LLVM_FLAGS += CXXFLAGS="$(LLVM_CXXFLAGS)"
 LLVM_MFLAGS += CXXFLAGS="$(LLVM_CXXFLAGS)"
-endif
+endif # LLVM_CXXFLAGS
 LLVM_MFLAGS += $(LLVM_CC)
 
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
 LLVM_LDFLAGS += -Wl,-R$(build_libdir)
 ifeq ($(USEICC),1)
 LLVM_LDFLAGS += -no_cpprt -lc++ -lc++abi
-endif
-endif
+endif # USEICC
+endif # BUILD_CUSTOM_LIBCXX
 
 ifneq ($(LLVM_CPPFLAGS),)
 LLVM_FLAGS += CPPFLAGS="$(LLVM_CPPFLAGS)"


### PR DESCRIPTION
`LLVM_LLDB_TAR` should only be set if we're not pulling from git. Also add a couple of comments to show which if the endif corresponds to since I found that confusing in fixing this. cc @maleadt to make sure this doesn't break his use case. Fixes an issue brought up in https://github.com/Keno/Cxx.jl/issues/4
