### PR TITLE
fix hashing of rationals (#9264)

### DIFF
--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -1,11 +1,11 @@
 ## efficient value-based hashing of integers ##
 
 function hash_integer(n::Integer, h::UInt)
-    h = hash_uint(uint(n & typemax(UInt)) $ h) $ h
-    n = ifelse(n < 0, oftype(n,-n), n)
+    h = hash_uint((n % UInt) $ h) $ h
+    n = abs(n)
     n >>>= sizeof(UInt) << 3
     while n != 0
-        h = hash_uint(uint(n & typemax(UInt)) $ h) $ h
+        h = hash_uint((n % UInt) $ h) $ h
         n >>>= sizeof(UInt) << 3
     end
     return h
@@ -59,7 +59,7 @@ function hash(x::Real, h::UInt)
                 left <= 63                     && return hash(int64(num) << int(pow), h)
                 signbit(num) == signbit(den)   && return hash(uint64(num) << int(pow), h)
             end # typemin(Int64) handled by Float64 case
-            left <= 1024 && left - right <= 53 && return hash(float64(num) * 2.0^pow, h)
+            left <= 1024 && left - right <= 53 && return hash(ldexp(float64(num),pow), h)
         end
     end
 
@@ -141,7 +141,7 @@ function hash{T<:Integer64}(x::Rational{T}, h::UInt)
         den >>= pow
         pow = -pow
         if den == 1 && abs(num) < 9007199254740992
-            return hash(float64(num) * 2.0^pow)
+            return hash(ldexp(float64(num),pow))
         end
     end
     h = hash_integer(den, h)

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -49,6 +49,11 @@ end
 @test hash(nextfloat(2.0^63)) == hash(uint64(nextfloat(2.0^63)))
 @test hash(prevfloat(2.0^64)) == hash(uint64(prevfloat(2.0^64)))
 
+# issue #9264
+@test hash(1//6,zero(UInt)) == invoke(hash,(Real,UInt),1//6,zero(UInt))
+@test hash(1//6) == hash(big(1)//big(6))
+@test hash(1//6) == hash(0x01//0x06)
+
 # hashing collections (e.g. issue #6870)
 vals = Any[
     [1,2,3,4], [1 3;2 4], Any[1,2,3,4], [1,3,2,4],


### PR DESCRIPTION
Fixes #9264, also replace `x*2.0^y` by faster `ldexp(x,y)`.
