### PR TITLE
cleanup julia_init options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,8 +300,8 @@ else ifeq ($(OS), Linux)
 	done
 endif
 
-	# Overwrite JL_SYSTEM_IMAGE_PATH in julia binaries
-	for julia in $(DESTDIR)$(bindir)/julia* ; do \
+	# Overwrite JL_SYSTEM_IMAGE_PATH in julia library
+	for julia in $(DESTDIR)$(private_libdir)/libjulia*.$(SHLIB_EXT) ; do \
 		$(call spawn,$(build_bindir)/stringreplace $$(strings -t x - $$julia | grep "sys.ji$$" | awk '{print $$1;}' ) "$(private_libdir_rel)/sys.ji" 256 $(call cygpath_w,$$julia)); \
 	done
 endif

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -147,7 +147,7 @@ export
     # method reflection
     applicable, invoke, method_exists,
     # constants
-    JULIA_HOME, nothing, Main,
+    nothing, Main,
     # intrinsics module
     Intrinsics
     #ccall, cglobal, llvmcall, abs_float, add_float, add_int, and_int, ashr_int,

--- a/base/client.jl
+++ b/base/client.jl
@@ -372,13 +372,10 @@ import .Terminals
 import .REPL
 
 function _start()
-    early_init()
-
     try
         init_parallel()
         init_bind_addr(ARGS)
         any(a->(a=="--worker"), ARGS) || init_head_sched()
-        init_load_path()
         (quiet,repl,startup,color_set,no_history_file) = process_options(copy(ARGS))
 
         local term

--- a/base/client.jl
+++ b/base/client.jl
@@ -426,11 +426,8 @@ function _start()
         println()
         exit(1)
     end
-    if is_interactive
-        if have_color
-            print(color_normal)
-        end
-        println()
+    if is_interactive && have_color
+        print(color_normal)
     end
 end
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -163,6 +163,7 @@ export
     Inf,
     Inf16,
     Inf32,
+    JULIA_HOME,
     LOAD_PATH,
     MS_ASYNC,
     MS_INVALIDATE,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -294,6 +294,8 @@ function __init__()
     reinit_stdio()
     Multimedia.reinit_displays() # since Multimedia.displays uses STDOUT as fallback
     fdwatcher_init()
+    early_init()
+    init_load_path()
 end
 
 include("precompile.jl")

--- a/doc/manual/embedding.rst
+++ b/doc/manual/embedding.rst
@@ -18,11 +18,25 @@ We start with a simple C program that initializes Julia and calls some Julia cod
 
   int main(int argc, char *argv[])
   {
-      jl_init(NULL);
-      JL_SET_STACK_BASE;
+      /* optional: randomize the stack guard */
+      char a, b, c;
+      SET_STACK_CHK_GUARD(a,b,c);
 
+      /* required: setup the julia context */
+      jl_init(NULL);
+
+      /* run julia commands */
       jl_eval_string("print(sqrt(2.0))");
 
+      /* strongly recommended: notify julia that the
+           program is about to terminate. this allows
+           julia time to cleanup pending write requests
+           and run all finalizers
+      */
+      jl_atexit_hook();
+
+      /* if the stack guard is set: reset the stack guard */
+      CLR_STACK_CHK_GUARD(a,b,c);
       return 0;
   }
 
@@ -30,7 +44,7 @@ In order to build this program you have to put the path to the Julia header into
 
     gcc -o test -I$JULIA_DIR/include/julia -L$JULIA_DIR/usr/lib -ljulia test.c
 
-Alternatively, look at the ``embedding.c`` program in the julia source tree in the ``examples/`` folder.
+Alternatively, look at the ``embedding.c`` program in the julia source tree in the ``examples/`` folder. The file ``ui/repl.c`` program is another simple example of how to set ``jl_compileropts`` options while linking against libjulia.
 
 The first thing that has to be done before calling any other Julia C function is to initialize Julia. This is done by calling ``jl_init``, which takes as argument a C string (``const char*``) to the location where Julia is installed. When the argument is ``NULL``, Julia tries to determine the install location automatically.
 

--- a/examples/embedding.c
+++ b/examples/embedding.c
@@ -9,8 +9,9 @@ double my_c_sqrt(double x)
 
 int main()
 {
+    char a, b, c;
+    SET_STACK_CHK_GUARD(a,b,c);
     jl_init(NULL);
-    JL_SET_STACK_BASE;
 
     {
         // Simple running Julia code
@@ -94,5 +95,7 @@ int main()
         }
     }
 
+    jl_atexit_hook();
+    CLR_STACK_CHK_GUARD(a,b,c);
     return 0;
 }

--- a/src/ast.c
+++ b/src/ast.c
@@ -114,7 +114,7 @@ static builtinspec_t julia_flisp_ast_ext[] = {
     { NULL, NULL }
 };
 
-DLLEXPORT void jl_init_frontend(void)
+void jl_init_frontend(void)
 {
     fl_init(4*1024*1024);
     value_t img = cvalue(iostreamtype, sizeof(ios_t));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -869,7 +869,7 @@ static void coverageVisitLine(std::string filename, int line)
 
 void write_log_data(logdata_t logData, const char *extension)
 {
-    std::string base = std::string(julia_home);
+    std::string base = std::string(jl_compileropts.julia_home);
     base = base + "/../share/julia/base/";
     logdata_t::iterator it = logData.begin();
     for (; it != logData.end(); it++) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -130,9 +130,8 @@ void __attribute__(()) __stack_chk_fail()
 #endif
 {
     /* put your panic function or similar in here */
-    fprintf(stderr, "warning: stack corruption detected\n");
-    //assert(0 && "stack corruption detected");
-    //abort();
+    fprintf(stderr, "fatal error: stack corruption detected\n");
+    abort(); // end with abort, since the compiler destroyed the stack upon entry to this function
 }
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -121,7 +121,7 @@ extern "C" {
 
 #include "builtin_proto.h"
 
-void *__stack_chk_guard = NULL;
+DLLEXPORT void *__stack_chk_guard = NULL;
 
 #if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
 void __stack_chk_fail()

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -482,7 +482,7 @@ void jl_dump_function_asm(const char *Fptr, size_t Fsize,
 #ifdef LLVM35
                         if (MCIA->evaluateBranch(Inst, Index, insSize, addr))
 #else
-                        if ((addr = MCIA->evaluateBranch(Inst, Index, insSize)) != -1)
+                        if ((addr = MCIA->evaluateBranch(Inst, Index, insSize)) != (uint64_t)-1)
 #endif
                             DisInfo.insertAddress(addr);
                     }

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -116,7 +116,7 @@ static uv_lib_t *jl_load_dynamic_library_(char *modname, unsigned flags, int thr
                     ext = extensions[i];
                     path[0] = '\0';
                     handle->handle = NULL;
-                    if (dl_path[len-1] == PATHSEP)
+                    if (dl_path[len-1] == PATHSEPSTRING[0])
                         snprintf(path, PATHBUF, "%s%s%s", dl_path, modname, ext);
                     else
                         snprintf(path, PATHBUF, "%s" PATHSEPSTRING "%s%s", dl_path, modname, ext);

--- a/src/dump.c
+++ b/src/dump.c
@@ -1330,10 +1330,8 @@ DLLEXPORT void jl_save_system_image(const char *fname)
     // save module initialization order
     if (jl_module_init_order != NULL) {
         for(i=0; i < jl_array_len(jl_module_init_order); i++) {
-            // NULL out any modules that weren't saved
-            jl_value_t *mod = jl_cellref(jl_module_init_order, i);
-            (void)mod;
-            assert(ptrhash_get(&backref_table, mod) != HT_NOTFOUND);
+            // verify that all these modules were saved
+            assert(ptrhash_get(&backref_table, jl_cellref(jl_module_init_order, i)) != HT_NOTFOUND);
         }
     }
     jl_serialize_value(&f, jl_module_init_order);

--- a/src/gc.c
+++ b/src/gc.c
@@ -712,7 +712,7 @@ static void gc_mark_task(jl_task_t *ta, int d)
             gc_mark_stack(jl_pgcstack, offset, d);
         }
         else {
-            offset = (char *)ta->stkbuf - ((char *)ta->stackbase - ta->ssize);
+            offset = (char *)ta->stkbuf - ((char *)jl_stackbase - ta->ssize);
             gc_mark_stack(ta->gcstack, offset, d);
         }
 #else

--- a/src/init.c
+++ b/src/init.c
@@ -765,13 +765,13 @@ static char *abspath(const char *in)
         }
     }
 #else
-    DWORD n = GetFullPathName(in, 0, NULL, C_NULL);
+    DWORD n = GetFullPathName(in, 0, NULL, NULL);
     if (n <= 0) {
         ios_printf(ios_stderr, "fatal error: jl_compileropts.image_file path too long or GetFullPathName failed\n");
         exit(1);
     }
     char *out = (char*)malloc(n);
-    DWORD m = GetFullPathName(in, n, out, C_NULL);
+    DWORD m = GetFullPathName(in, n, out, NULL);
     if (n != m + 1) {
         ios_printf(ios_stderr, "fatal error: jl_compileropts.image_file path too long or GetFullPathName failed\n");
         exit(1);
@@ -1096,7 +1096,7 @@ extern void *__stack_chk_guard;
 
 void jl_compile_all(void);
 
-DLLEXPORT int julia_save()
+DLLEXPORT void julia_save()
 {
     const char *build_path = jl_compileropts.build_path;
     if (build_path) {

--- a/src/init.c
+++ b/src/init.c
@@ -848,6 +848,7 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
 
 void _julia_init(JL_IMAGE_SEARCH rel)
 {
+    libsupport_init();
     jl_io_loop = uv_default_loop(); // this loop will internal events (spawning process etc.),
                                     // best to call this first, since it also initializes libuv
     jl_resolve_sysimg_location(rel);

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -686,14 +686,10 @@ char *jl_bufptr(ios_t *s)
     return s->buf;
 }
 
-DLLEXPORT void uv_atexit_hook();
 DLLEXPORT void jl_exit(int exitcode)
 {
-    /*if (jl_io_loop) {
-        jl_process_events(&jl_io_loop);
-    }*/
     uv_tty_reset_mode();
-    uv_atexit_hook();
+    jl_atexit_hook();
     exit(exitcode);
 }
 

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -22,24 +22,6 @@ DLLEXPORT char * __cdecl basename(char *);
 #include <libgen.h>
 #endif
 
-DLLEXPORT char *jl_locate_sysimg(char *jlhome, char *imgpath)
-{
-    if (jlhome == NULL) {
-        char *julia_path = (char*)malloc(512);
-        size_t path_size = 512;
-        uv_exepath(julia_path, &path_size);
-        julia_home = strdup(dirname(julia_path));
-        free(julia_path);
-    }
-    else {
-        julia_home = jlhome;
-    }
-    char path[512];
-    snprintf(path, sizeof(path), "%s%s%s",
-             julia_home, PATHSEPSTRING, imgpath);
-    return strdup(path);
-}
-
 DLLEXPORT void *jl_eval_string(char *str);
 
 int jl_is_initialized(void) { return jl_main_module!=NULL; }
@@ -54,22 +36,22 @@ DLLEXPORT void jl_init_with_image(char *julia_home_dir, char *image_relative_pat
 {
     if (jl_is_initialized()) return;
     libsupport_init();
-    if (image_relative_path == NULL)
-        image_relative_path = JL_SYSTEM_IMAGE_PATH;
-    char *image_file = jl_locate_sysimg(julia_home_dir, image_relative_path);
-    julia_init(image_file);
-    jl_set_const(jl_core_module, jl_symbol("JULIA_HOME"),
-                 jl_cstr_to_string(julia_home));
-    jl_module_export(jl_core_module, jl_symbol("JULIA_HOME"));
-    jl_eval_string("Base.early_init()");
+    jl_compileropts.julia_home = julia_home_dir;
+    if (image_relative_path != NULL)
+        jl_compileropts.image_file = image_relative_path;
+    julia_init();
+    //TODO: these should be part of Multi.__init__()
+    //currently, we have them here since we may not want them
+    //getting unconditionally set from Base.__init__()
+    jl_eval_string("Base.init_parallel()");
+    jl_eval_string("Base.init_bind_addr(ARGS)");
     jl_eval_string("Base.init_head_sched()");
-    jl_eval_string("Base.init_load_path()");
     jl_exception_clear();
 }
 
 DLLEXPORT void jl_init(char *julia_home_dir)
 {
-    jl_init_with_image(julia_home_dir, JL_SYSTEM_IMAGE_PATH);
+    jl_init_with_image(julia_home_dir, NULL);
 }
 
 DLLEXPORT void *jl_eval_string(char *str)

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -56,12 +56,6 @@ DLLEXPORT void jl_init(char *julia_home_dir)
 
 DLLEXPORT void *jl_eval_string(char *str)
 {
-#ifdef COPY_STACKS
-    int outside_task = (jl_root_task->stackbase == NULL);
-    if (outside_task) {
-        JL_SET_STACK_BASE;
-    }
-#endif
     jl_value_t *r;
     JL_TRY {
         jl_value_t *ast = jl_parse_input_line(str);
@@ -74,11 +68,6 @@ DLLEXPORT void *jl_eval_string(char *str)
         //jl_show(jl_stderr_obj(), jl_exception_in_transit);
         r = NULL;
     }
-#ifdef COPY_STACKS
-    if (outside_task) {
-        jl_root_task->stackbase = NULL;
-    }
-#endif
     return r;
 }
 
@@ -253,6 +242,21 @@ DLLEXPORT int jl_is_debugbuild(void)
 #else
     return 0;
 #endif
+}
+
+DLLEXPORT jl_value_t *jl_get_julia_home(void)
+{
+    return jl_cstr_to_string(jl_compileropts.julia_home);
+}
+
+DLLEXPORT jl_value_t *jl_get_julia_bin(void)
+{
+    return jl_cstr_to_string(jl_compileropts.julia_bin);
+}
+
+DLLEXPORT jl_value_t *jl_get_image_file(void)
+{
+    return jl_cstr_to_string(jl_compileropts.image_file);
 }
 
 #ifdef __cplusplus

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -39,7 +39,7 @@ DLLEXPORT void jl_init_with_image(char *julia_home_dir, char *image_relative_pat
     jl_compileropts.julia_home = julia_home_dir;
     if (image_relative_path != NULL)
         jl_compileropts.image_file = image_relative_path;
-    julia_init();
+    julia_init(JL_IMAGE_JULIA_HOME);
     //TODO: these should be part of Multi.__init__()
     //currently, we have them here since we may not want them
     //getting unconditionally set from Base.__init__()

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -1,6 +1,7 @@
 {
   global:
     __asan*;
+    __stack_chk_guard;
     alloc_*w;
     allocobj;
     asprintf;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1342,7 +1342,7 @@ extern DLLEXPORT jl_compileropts_t jl_compileropts;
 #define JL_COMPILEROPT_DUMPBITCODE_ON 1
 #define JL_COMPILEROPT_DUMPBITCODE_OFF 2
 
-extern void *__stack_chk_guard;
+DLLEXPORT extern void *__stack_chk_guard;
 #define SET_STACK_CHK_GUARD(a,b,c) do {                         \
         unsigned char *p = (unsigned char *)&__stack_chk_guard; \
         a = p[sizeof(__stack_chk_guard)-1];                     \

--- a/src/julia.h
+++ b/src/julia.h
@@ -814,7 +814,6 @@ DLLEXPORT jl_value_t *jl_eqtable_get(jl_array_t *h, void *key, jl_value_t *deflt
 DLLEXPORT int jl_errno(void);
 DLLEXPORT void jl_set_errno(int e);
 DLLEXPORT int32_t jl_stat(const char *path, char *statbuf);
-DLLEXPORT void NORETURN jl_exit(int status);
 DLLEXPORT int jl_cpu_cores(void);
 DLLEXPORT long jl_getpagesize(void);
 DLLEXPORT long jl_getallocationgranularity(void);
@@ -856,11 +855,13 @@ DLLEXPORT void jl_exception_clear(void);
     }
 
 // initialization functions
-DLLEXPORT void julia_init();
+DLLEXPORT void julia_init(void);
 DLLEXPORT void jl_init(char *julia_home_dir);
 DLLEXPORT void jl_init_with_image(char *julia_home_dir, char *image_relative_path);
 DLLEXPORT int jl_is_initialized(void);
 DLLEXPORT int julia_trampoline(int argc, char *argv[], int (*pmain)(int ac,char *av[]));
+DLLEXPORT void jl_atexit_hook(void);
+DLLEXPORT void NORETURN jl_exit(int status);
 
 DLLEXPORT void jl_save_system_image(const char *fname);
 DLLEXPORT void jl_restore_system_image(const char *fname);
@@ -989,22 +990,6 @@ DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a, jl_value_t *b, j
 
 // interfacing with Task runtime
 DLLEXPORT void jl_yield();
-DLLEXPORT void jl_handle_stack_start();
-
-#ifdef COPY_STACKS
-// initialize base context of root task
-extern DLLEXPORT jl_jmp_buf jl_base_ctx;
-#define JL_SET_STACK_BASE                               \
-    do {                                                \
-        int __stk;                                      \
-        jl_root_task->stackbase = (char*)&__stk;        \
-        if (jl_setjmp(jl_base_ctx, 1)) {                \
-            jl_handle_stack_start();                    \
-        }                                               \
-    } while (0)
-#else
-#define JL_SET_STACK_BASE
-#endif
 
 // gc -------------------------------------------------------------------------
 
@@ -1148,10 +1133,9 @@ typedef struct _jl_task_t {
     jl_value_t *exception;
     jl_function_t *start;
     jl_jmp_buf ctx;
-    union {
-        void *stackbase;
-        void *stack;
-    };
+#ifndef COPY_STACKS
+    void *stack;
+#endif
     size_t bufsz;
     void *stkbuf;
     size_t ssize;
@@ -1328,6 +1312,7 @@ void show_execution_point(char *filename, int lno);
 
 typedef struct {
     const char *julia_home;
+    const char *julia_bin;
     const char *build_path;
     const char *image_file;
     int8_t code_coverage;
@@ -1356,6 +1341,26 @@ extern DLLEXPORT jl_compileropts_t jl_compileropts;
 
 #define JL_COMPILEROPT_DUMPBITCODE_ON 1
 #define JL_COMPILEROPT_DUMPBITCODE_OFF 2
+
+extern void *__stack_chk_guard;
+#define SET_STACK_CHK_GUARD(a,b,c) do {                         \
+        unsigned char *p = (unsigned char *)&__stack_chk_guard; \
+        a = p[sizeof(__stack_chk_guard)-1];                     \
+        b = p[sizeof(__stack_chk_guard)-2];                     \
+        c = p[0];                                               \
+        /* If you have the ability to generate random numbers
+         * in your kernel then they should be used here */      \
+        p[sizeof(__stack_chk_guard)-1] = 255;                   \
+        p[sizeof(__stack_chk_guard)-2] = '\n';                  \
+        p[0] = 0;                                               \
+    } while (0)
+
+#define CLR_STACK_CHK_GUARD(a,b,c) do {                         \
+        unsigned char *p = (unsigned char *)&__stack_chk_guard; \
+        p[sizeof(__stack_chk_guard)-1] = a;                     \
+        p[sizeof(__stack_chk_guard)-2] = b;                     \
+        p[0] = c;                                               \
+    } while (0)
 
 #ifdef __cplusplus
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -855,7 +855,12 @@ DLLEXPORT void jl_exception_clear(void);
     }
 
 // initialization functions
-DLLEXPORT void julia_init(void);
+typedef enum {
+    JL_IMAGE_CWD = 0,
+    JL_IMAGE_JULIA_HOME = 1,
+    //JL_IMAGE_LIBJULIA = 2,
+} JL_IMAGE_SEARCH;
+DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel);
 DLLEXPORT void jl_init(char *julia_home_dir);
 DLLEXPORT void jl_init_with_image(char *julia_home_dir, char *image_relative_path);
 DLLEXPORT int jl_is_initialized(void);

--- a/src/julia.h
+++ b/src/julia.h
@@ -856,17 +856,16 @@ DLLEXPORT void jl_exception_clear(void);
     }
 
 // initialization functions
-DLLEXPORT void julia_init(char *imageFile);
-DLLEXPORT int julia_trampoline(int argc, char *argv[], int (*pmain)(int ac,char *av[]));
+DLLEXPORT void julia_init();
 DLLEXPORT void jl_init(char *julia_home_dir);
 DLLEXPORT void jl_init_with_image(char *julia_home_dir, char *image_relative_path);
 DLLEXPORT int jl_is_initialized(void);
-DLLEXPORT extern char *julia_home;
+DLLEXPORT int julia_trampoline(int argc, char *argv[], int (*pmain)(int ac,char *av[]));
 
-DLLEXPORT void jl_save_system_image(char *fname);
-DLLEXPORT void jl_restore_system_image(char *fname);
-DLLEXPORT int jl_save_new_module(char *fname, jl_module_t *mod);
-DLLEXPORT jl_module_t *jl_restore_new_module(char *fname);
+DLLEXPORT void jl_save_system_image(const char *fname);
+DLLEXPORT void jl_restore_system_image(const char *fname);
+DLLEXPORT int jl_save_new_module(const char *fname, jl_module_t *mod);
+DLLEXPORT jl_module_t *jl_restore_new_module(const char *fname);
 void jl_init_restored_modules();
 
 // front end interface
@@ -1328,7 +1327,9 @@ void show_execution_point(char *filename, int lno);
 // compiler options -----------------------------------------------------------
 
 typedef struct {
-    char *build_path;
+    const char *julia_home;
+    const char *build_path;
+    const char *image_file;
     int8_t code_coverage;
     int8_t malloc_log;
     int8_t check_bounds;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -87,7 +87,7 @@ void jl_init_codegen(void);
 void jl_init_intrinsic_functions(void);
 void jl_init_tasks(void *stack, size_t ssize);
 void jl_init_serializer(void);
-void _julia_init(void);
+void _julia_init(JL_IMAGE_SEARCH rel);
 #ifdef COPY_STACKS
 extern void *jl_stackbase;
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -81,12 +81,16 @@ extern size_t jl_arr_xtralloc_limit;
 
 void jl_init_types(void);
 void jl_init_box_caches(void);
-DLLEXPORT void jl_init_frontend(void);
+void jl_init_frontend(void);
 void jl_init_primitives(void);
 void jl_init_codegen(void);
 void jl_init_intrinsic_functions(void);
 void jl_init_tasks(void *stack, size_t ssize);
 void jl_init_serializer(void);
+void _julia_init(void);
+#ifdef COPY_STACKS
+extern void *jl_stackbase;
+#endif
 
 void jl_dump_bitcode(char *fname);
 void jl_dump_objfile(char *fname, int jit_model);
@@ -140,6 +144,8 @@ extern uv_lib_t *jl_kernel32_handle;
 extern uv_lib_t *jl_crtdll_handle;
 extern uv_lib_t *jl_winsock_handle;
 #endif
+
+DLLEXPORT void jl_atexit_hook();
 
 #ifdef __cplusplus
 }

--- a/src/support/dirpath.h
+++ b/src/support/dirpath.h
@@ -2,18 +2,15 @@
 #define DIRPATH_H
 
 #ifdef _OS_WINDOWS_
-#define PATHSEP '\\'
 #define PATHSEPSTRING "\\"
-#define PATHLISTSEP ';'
 #define PATHLISTSEPSTRING ";"
-#define ISPATHSEP(c) ((c)=='/' || (c)=='\\')
-#define MAXPATHLEN 1024
+#ifdef _MSC_VER
+#define PATH_MAX MAX_PATH
+#endif
 #else
-#define PATHSEP '/'
 #define PATHSEPSTRING "/"
-#define PATHLISTSEP ':'
 #define PATHLISTSEPSTRING ":"
-#define ISPATHSEP(c) ((c)=='/')
+#define PATH_MAX 1024
 #endif
 
 #endif

--- a/src/support/dirpath.h
+++ b/src/support/dirpath.h
@@ -10,7 +10,9 @@
 #else
 #define PATHSEPSTRING "/"
 #define PATHLISTSEPSTRING ":"
+#ifndef PATH_MAX // many platforms don't have a max path, we define one anyways
 #define PATH_MAX 1024
+#endif
 #endif
 
 #endif

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -836,7 +836,7 @@ static void _ios_init(ios_t *s)
 
 /* stream object initializers. we do no allocation. */
 
-ios_t *ios_file(ios_t *s, char *fname, int rd, int wr, int create, int trunc)
+ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc)
 {
     int flags;
     int fd;

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -100,7 +100,7 @@ DLLEXPORT size_t ios_readprep(ios_t *from, size_t n);
 
 /* stream creation */
 DLLEXPORT
-ios_t *ios_file(ios_t *s, char *fname, int rd, int wr, int create, int trunc);
+ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc);
 DLLEXPORT ios_t *ios_mem(ios_t *s, size_t initsize);
 ios_t *ios_str(ios_t *s, char *str);
 ios_t *ios_static_buffer(ios_t *s, char *buf, size_t sz);

--- a/src/task.c
+++ b/src/task.c
@@ -264,10 +264,10 @@ void set_base_ctx(char *__stk) { }
 #endif
 
 
-DLLEXPORT void julia_init()
+DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 { // keep this function small, since we want to keep the stack frame
   // leading up to this also quite small
-    _julia_init();
+    _julia_init(rel);
 #ifdef COPY_STACKS
     char __stk;
     jl_stackbase = (char*)(((uptrint_t)&__stk + sizeof(__stk))&-16); // also ensures stackbase is 16-byte aligned

--- a/src/task.c
+++ b/src/task.c
@@ -154,18 +154,24 @@ jl_value_t *jl_exception_in_transit;
 jl_gcframe_t *jl_pgcstack = NULL;
 #endif
 
-static void start_task(jl_task_t *t);
-
 #ifdef COPY_STACKS
-jl_jmp_buf * volatile jl_jmp_target;
-DLLEXPORT jl_jmp_buf jl_base_ctx;
+static jl_jmp_buf * volatile jl_jmp_target;
+
+#if defined(_CPU_X86_64_) || defined(_CPU_X86_)
+#define ASM_COPY_STACKS
+#endif
+void *jl_stackbase;
+
+#ifndef ASM_COPY_STACKS
+static jl_jmp_buf jl_base_ctx; // base context of stack
+#endif
 
 static void save_stack(jl_task_t *t)
 {
     if (t->state == done_sym || t->state == failed_sym)
         return;
     volatile int _x;
-    size_t nb = (char*)t->stackbase - (char*)&_x;
+    size_t nb = (char*)jl_stackbase - (char*)&_x;
     char *buf;
     if (t->stkbuf == NULL || t->bufsz < nb) {
         buf = (char*)allocb(nb);
@@ -180,12 +186,13 @@ static void save_stack(jl_task_t *t)
 }
 
 #if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
-void __declspec(noinline) restore_stack(jl_task_t *t, jl_jmp_buf *where, char *p)
+void __declspec(noinline)
 #else
-void __attribute__((noinline)) restore_stack(jl_task_t *t, jl_jmp_buf *where, char *p)
+void __attribute__((noinline))
 #endif
+restore_stack(jl_task_t *t, jl_jmp_buf *where, char *p)
 {
-    char *_x = (char*)t->stackbase - t->ssize;
+    char *_x = (char*)jl_stackbase - t->ssize;
     if (!p) {
         p = _x;
         if ((char*)&_x > _x) {
@@ -199,6 +206,94 @@ void __attribute__((noinline)) restore_stack(jl_task_t *t, jl_jmp_buf *where, ch
         memcpy(_x, t->stkbuf, t->ssize);
     }
     jl_longjmp(*jl_jmp_target, 1);
+}
+#endif
+
+static jl_function_t *task_done_hook_func=NULL;
+
+static void NORETURN finish_task(jl_task_t *t, jl_value_t *resultval)
+{
+    if (t->exception != jl_nothing)
+        t->state = failed_sym;
+    else
+        t->state = done_sym;
+    t->result = resultval;
+    // TODO: early free of t->stkbuf
+#ifdef COPY_STACKS
+    t->stkbuf = NULL;
+#endif
+    if (task_done_hook_func == NULL) {
+        task_done_hook_func = (jl_function_t*)jl_get_global(jl_base_module,
+                                                            jl_symbol("task_done_hook"));
+    }
+    if (task_done_hook_func != NULL) {
+        jl_apply(task_done_hook_func, (jl_value_t**)&t, 1);
+    }
+    abort();
+}
+
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+void __declspec(noinline)
+#else
+void __attribute__((noinline))
+#endif
+NORETURN start_task()
+{
+    // this runs the first time we switch to a task
+    jl_task_t *t = jl_current_task;
+    jl_value_t *arg = jl_task_arg_in_transit;
+    jl_value_t *res;
+    JL_GC_PUSH1(&arg);
+    res = jl_apply(t->start, NULL, 0);
+    JL_GC_POP();
+    finish_task(t, res);
+    abort();
+}
+
+#ifndef ASM_COPY_STACKS
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+static void __declspec(noinline)
+#else
+static void __attribute__((noinline))
+#endif
+set_base_ctx(char *__stk)
+{
+    if (jl_setjmp(jl_base_ctx, 1)) {
+        start_task();
+    }
+}
+#else
+void set_base_ctx(char *__stk) { }
+#endif
+
+
+DLLEXPORT void julia_init()
+{ // keep this function small, since we want to keep the stack frame
+  // leading up to this also quite small
+    _julia_init();
+#ifdef COPY_STACKS
+    char __stk;
+    jl_stackbase = (char*)(((uptrint_t)&__stk + sizeof(__stk))&-16); // also ensures stackbase is 16-byte aligned
+    set_base_ctx(&__stk); // separate function, to record the size of a stack frame
+#endif
+}
+
+#ifndef COPY_STACKS
+static void init_task(jl_task_t *t)
+{
+    if (jl_setjmp(t->ctx, 0)) {
+        start_task();
+    }
+    // this runs when the task is created
+    ptrint_t local_sp = (ptrint_t)&t;
+    ptrint_t new_sp = (ptrint_t)t->stack + t->ssize - _frame_offset;
+#ifdef _P64
+    // SP must be 16-byte aligned
+    new_sp = new_sp&-16;
+    local_sp = local_sp&-16;
+#endif
+    memcpy((void*)new_sp, (void*)local_sp, _frame_offset);
+    rebase_state(&t->ctx, local_sp, new_sp);
 }
 #endif
 
@@ -248,7 +343,25 @@ static void ctx_switch(jl_task_t *t, jl_jmp_buf *where)
         if (t->stkbuf) {
             restore_stack(t, where, NULL);
         } else {
+#ifdef ASM_COPY_STACKS
+#ifdef _CPU_X86_64_
+            asm(" movq %0, %%rsp;\n"
+                " xorq %%rbp, %%rbp;\n"
+                " push %%rbp;\n" // instead of RSP
+                " jmp _start_task" // call stack_task with fake stack frame
+                : : "r"(jl_stackbase-0x10) : );
+#elif defined(_CPU_X86_)
+            asm(" movl %0, %%esp;\n"
+                " xorl %%ebp, %%ebp;\n"
+                " push %%ebp;\n" // instead of ESP
+                " jmp _start_task" // call stack_task with fake stack frame
+                : : "r"(jl_stackbase-0x10) : );
+#else
+#error ASM_COPY_STACKS not supported on this platform
+#endif
+#else // ASM_COPY_STACKS
             jl_longjmp(jl_base_ctx, 1);
+#endif
         }
 #else
         jl_longjmp(*where, 1);
@@ -367,74 +480,6 @@ jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg)
     jl_task_arg_in_transit = arg;
     return switchto(t);
 }
-
-static jl_function_t *task_done_hook_func=NULL;
-
-static void finish_task(jl_task_t *t, jl_value_t *resultval)
-{
-    if (t->exception != jl_nothing)
-        t->state = failed_sym;
-    else
-        t->state = done_sym;
-    t->result = resultval;
-    // TODO: early free of t->stkbuf
-#ifdef COPY_STACKS
-    t->stkbuf = NULL;
-#endif
-    if (task_done_hook_func == NULL) {
-        task_done_hook_func = (jl_function_t*)jl_get_global(jl_base_module,
-                                                            jl_symbol("task_done_hook"));
-    }
-    if (task_done_hook_func != NULL) {
-        jl_apply(task_done_hook_func, (jl_value_t**)&t, 1);
-    }
-    assert(0);
-}
-
-static void start_task(jl_task_t *t)
-{
-    // this runs the first time we switch to t
-    jl_value_t *arg = jl_task_arg_in_transit;
-    jl_value_t *res;
-    JL_GC_PUSH1(&arg);
-
-#ifdef COPY_STACKS
-    ptrint_t local_sp = (ptrint_t)jl_pgcstack;
-    // here we attempt to figure out how big our stack frame is, since we
-    // might need to copy all of it later. this is a bit of a fuzzy guess.
-    local_sp += sizeof(jl_gcframe_t);
-    local_sp += 12*sizeof(void*);
-    t->stackbase = (void*)(local_sp + _frame_offset);
-#endif
-    res = jl_apply(t->start, NULL, 0);
-    JL_GC_POP();
-    finish_task(t, res);
-    assert(0);
-}
-
-DLLEXPORT void jl_handle_stack_start()
-{
-    start_task(jl_current_task);
-}
-
-#ifndef COPY_STACKS
-static void init_task(jl_task_t *t)
-{
-    if (jl_setjmp(t->ctx, 0)) {
-        start_task(t);
-    }
-    // this runs when the task is created
-    ptrint_t local_sp = (ptrint_t)&t;
-    ptrint_t new_sp = (ptrint_t)t->stack + t->ssize - _frame_offset;
-#ifdef _P64
-    // SP must be 16-byte aligned
-    new_sp = new_sp&-16;
-    local_sp = local_sp&-16;
-#endif
-    memcpy((void*)new_sp, (void*)local_sp, _frame_offset);
-    rebase_state(&t->ctx, local_sp, new_sp);
-}
-#endif
 
 ptrint_t bt_data[MAX_BT_SIZE+1];
 size_t bt_size = 0;
@@ -581,9 +626,8 @@ DLLEXPORT size_t rec_backtrace_ctx(ptrint_t *data, size_t maxsize, unw_context_t
     do {
         if (n >= maxsize)
             break;
-        if (unw_get_reg(&cursor, UNW_REG_IP, &ip) < 0) {
+        if (unw_get_reg(&cursor, UNW_REG_IP, &ip) < 0)
             break;
-        }
         data[n++] = ip;
     } while (unw_step(&cursor) > 0);
     return n;
@@ -602,9 +646,8 @@ size_t rec_backtrace_ctx_dwarf(ptrint_t *data, size_t maxsize, unw_context_t *uc
     do {
         if (n >= maxsize)
             break;
-        if (unw_get_reg(&cursor, UNW_REG_IP, &ip) < 0) {
+        if (unw_get_reg(&cursor, UNW_REG_IP, &ip) < 0)
             break;
-        }
         data[n++] = ip;
     } while (unw_step(&cursor) > 0);
     return n;
@@ -849,7 +892,6 @@ void jl_init_tasks(void *stack, size_t ssize)
     jl_current_task = (jl_task_t*)allocobj(sizeof(jl_task_t));
     jl_current_task->type = (jl_value_t*)jl_task_type;
 #ifdef COPY_STACKS
-    jl_current_task->stackbase = NULL;
     jl_current_task->ssize = 0;  // size of saved piece
     jl_current_task->bufsz = 0;
 #else

--- a/src/task.c
+++ b/src/task.c
@@ -241,11 +241,8 @@ NORETURN start_task()
 {
     // this runs the first time we switch to a task
     jl_task_t *t = jl_current_task;
-    jl_value_t *arg = jl_task_arg_in_transit;
     jl_value_t *res;
-    JL_GC_PUSH1(&arg);
     res = jl_apply(t->start, NULL, 0);
-    JL_GC_POP();
     finish_task(t, res);
     abort();
 }

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -58,7 +58,6 @@ julia_res.o: $(JULIAHOME)/contrib/windows/julia.rc
 	$(CROSS_COMPILE)windres $< -O coff -o $@ -DJLVER=$$JLVERi -DJLVER_STR=\\\"$$JLVER\\\"
 $(build_bindir)/julia$(EXE): julia_res.o
 $(build_bindir)/julia-debug$(EXE): julia_res.o
-JLDFLAGS += julia_res.o
 endif
 endif
 

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -40,6 +40,7 @@ static int lisp_prompt = 0;
 static int codecov  = JL_LOG_NONE;
 static int malloclog= JL_LOG_NONE;
 static char *program = NULL;
+static int imagepathspecified = 0;
 
 static const char *usage = "julia [options] [program] [args...]\n";
 static const char *opts =
@@ -95,7 +96,6 @@ void parse_opts(int *argcp, char ***argvp)
     };
     int c;
     opterr = 0;
-    int imagepathspecified=0;
     int skip = 0;
     int lastind = optind;
     while ((c = getopt_long(*argcp,*argvp,shortopts,longopts,0)) != -1) {
@@ -338,7 +338,7 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
         jl_lisp_prompt();
         return 0;
     }
-    julia_init();
+    julia_init(imagepathspecified ? JL_IMAGE_CWD : JL_IMAGE_JULIA_HOME);
     int ret = true_main(argc, (char**)argv);
     jl_atexit_hook();
     julia_save();

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -311,7 +311,7 @@ static int true_main(int argc, char *argv[])
     return iserr;
 }
 
-DLLEXPORT extern int julia_save();
+DLLEXPORT extern void julia_save();
 
 #ifndef _OS_WINDOWS_
 int main(int argc, char *argv[])


### PR DESCRIPTION
this attempts to be more consistent and centralized about initializing julia paths (build_path, image_file, julia_home). this is in an attempt to make embedding julia easier. also, it should help with spawning child processes (by providing more reliable access to the parameters, without dependence of the working directory)
1. moves all configuration options into jl_compileropts
2. computes the abspath/realpath of file paths in the config to avoid issues with chdir causing files to end up in the wrong location

@tkelman @ihnorton @staticfloat
