### PR TITLE
RFC: Add generic copy stagedfunction for all types

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -31,8 +31,6 @@ copy(e::Expr) = (n = Expr(e.head);
                  n.args = astcopy(e.args);
                  n.typ = e.typ;
                  n)
-copy(s::SymbolNode) = SymbolNode(s.name, s.typ)
-copy(n::GetfieldNode) = GetfieldNode(n.value, n.name, n.typ)
 
 # copy parts of an AST that the compiler mutates
 astcopy(x::Union(SymbolNode,GetfieldNode,Expr)) = copy(x)

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -12,7 +12,6 @@ ndims(J::UniformScaling) = 2
 getindex(J::UniformScaling, i::Integer,j::Integer) = ifelse(i==j,J.λ,zero(J.λ))
 
 show(io::IO, J::UniformScaling) = print(io, "$(typeof(J))\n$(J.λ)*I")
-copy(J::UniformScaling) = UniformScaling(J.λ)
 
 transpose(J::UniformScaling) = J
 ctranspose(J::UniformScaling) = UniformScaling(conj(J.λ))

--- a/base/process.jl
+++ b/base/process.jl
@@ -100,7 +100,6 @@ end
 
 immutable DevNullStream <: AsyncStream end
 const DevNull = DevNullStream()
-copy(::DevNullStream) = DevNull
 uvhandle(::DevNullStream) = C_NULL
 uvhandle(x::Ptr) = x
 uvtype(::Ptr) = UV_STREAM

--- a/base/range.jl
+++ b/base/range.jl
@@ -228,7 +228,7 @@ maximum(r::Range)  = isempty(r) ? error("range must be non-empty") : max(first(r
 ctranspose(r::Range) = [x for _=1, x=r]
 transpose(r::Range) = r'
 
-# Ranges are immutable
+# Ranges are immutable, but the AbstractArray copy method doesn't know that
 copy(r::Range) = r
 
 


### PR DESCRIPTION
It is a no-op for all immutable types, and tries to call the default constructor for mutable types.  Fields are not copied.

Supersedes #9246; see that issue for some discussion of this.
