### PR TITLE
export globalRNG()

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -900,6 +900,7 @@ export
 # random numbers
     AbstractRNG,
     MersenneTwister,
+    globalRNG,
     rand!,
     rand,
     randbool,

--- a/base/random.jl
+++ b/base/random.jl
@@ -8,7 +8,8 @@ export srand,
        randn, randn!,
        randexp, randexp!,
        randbool,
-       AbstractRNG, RNG, MersenneTwister
+       AbstractRNG, MersenneTwister,
+       globalRNG
 
 
 abstract AbstractRNG

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4097,6 +4097,10 @@ A ``MersenneTwister`` RNG can generate random numbers of the following types: ``
 
    Create a ``MersenneTwister`` RNG object. Different RNG objects can have their own seeds, which may be useful for generating different streams of random numbers.
 
+.. function:: globalRNG()
+
+   Return the global RNG object.
+
 .. function:: rand([rng], [S], [dims...])
 
    Pick a random element or array of random elements from the set of values specified by ``S``; ``S`` can be


### PR DESCRIPTION
When a user adds a `rand!` method for her objects, she may want to have the `rng` object default to the global one, e.g:

```
Base.rand(rng::AbstractRNG, ::Type{MyObject}) = MyObject(rand(rng))
# no need to define Base.rand(::Type{MyObject})
Base.rand!(rng::AbstractRNG, x::MyObject) = (x.field = rand(rng); x)
Base.rand!(x::MyObject) = rand!(globalRNG(), x)
```

For this simple case, we could simply unconstrain the `rand!` methods which currently are `rand!(A::AbstractArray)` and `rand!(A::AbstractArray, r::AbstractArray)` by letting `A` be anything, but I still think that exporting `globalRNG()` is needed for more complicated cases (i.e. more parameters need to be passed to `rand[!]`).

We could directly export the global variable itself, but I feel that with multi-threading, we would have one such global variable per thread to avoid synchronization, and then `globalRNG()` would return this thread-local "global" RNG object. But I don't know much these questions, I can be wrong.
