### PR TITLE
Accept all integers for as dimension arguments in rand and randn

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -159,16 +159,16 @@ globalRNG() = GLOBAL_RNG
 @inline rand(T::Type) = rand(GLOBAL_RNG, T)
 rand(::()) = rand(GLOBAL_RNG, ()) # needed to resolve ambiguity
 rand(dims::Dims) = rand(GLOBAL_RNG, dims)
-rand(dims::Int...) = rand(dims)
+rand(dims::Integer...) = rand(convert((Int...), dims))
 rand(T::Type, dims::Dims) = rand(GLOBAL_RNG, T, dims)
-rand(T::Type, d1::Int, dims::Int...) = rand(T, tuple(d1, dims...))
+rand(T::Type, d1::Integer, dims::Integer...) = rand(T, tuple(int(d1), convert((Int...), dims)...))
 rand!(A::AbstractArray) = rand!(GLOBAL_RNG, A)
 
 rand(r::AbstractArray) = rand(GLOBAL_RNG, r)
 rand!(A::AbstractArray, r::AbstractArray) = rand!(GLOBAL_RNG, A, r)
 
 rand(r::AbstractArray, dims::Dims) = rand(GLOBAL_RNG, r, dims)
-rand(r::AbstractArray, dims::Int...) = rand(GLOBAL_RNG, r, dims)
+rand(r::AbstractArray, dims::Integer...) = rand(GLOBAL_RNG, r, convert((Int...), dims))
 
 ## random floating point values
 
@@ -204,10 +204,10 @@ rand{T<:Real}(r::AbstractRNG, ::Type{Complex{T}}) = complex(rand(r, T), rand(r, 
 ## Arrays of random numbers
 
 rand(r::AbstractRNG, dims::Dims) = rand(r, Float64, dims)
-rand(r::AbstractRNG, dims::Int...) = rand(r, dims)
+rand(r::AbstractRNG, dims::Integer...) = rand(r, convert((Int...), dims))
 
 rand(r::AbstractRNG, T::Type, dims::Dims) = rand!(r, Array(T, dims))
-rand(r::AbstractRNG, T::Type, d1::Int, dims::Int...) = rand(r, T, tuple(d1, dims...))
+rand(r::AbstractRNG, T::Type, d1::Integer, dims::Integer...) = rand(r, T, tuple(int(d1), convert((Int...), dims)...))
 # note: the above method would trigger an ambiguity warning if d1 was not separated out:
 # rand(r, ()) would match both this method and rand(r, dims::Dims)
 # moreover, a call like rand(r, NotImplementedType()) would be an infinite loop
@@ -1049,9 +1049,9 @@ end
 
 randn!(A::Array{Float64}) = randn!(GLOBAL_RNG, A)
 randn(dims::Dims) = randn!(Array(Float64, dims))
-randn(dims::Int...) = randn!(Array(Float64, dims...))
+randn(dims::Integer...) = randn!(Array(Float64, dims...))
 randn(rng::MersenneTwister, dims::Dims) = randn!(rng, Array(Float64, dims))
-randn(rng::MersenneTwister, dims::Int...) = randn!(rng, Array(Float64, dims...))
+randn(rng::MersenneTwister, dims::Integer...) = randn!(rng, Array(Float64, dims...))
 
 @inline function randexp(rng::MersenneTwister=GLOBAL_RNG)
     @inbounds begin


### PR DESCRIPTION
This is similar to what the `Array` constructor allows for. It came up when working with a library returning `Int32`s values for the the size of a random matrix.
