### PR TITLE
Add eltype methods for Nullable

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -11,6 +11,10 @@ end
 
 Nullable{T}(value::T) = Nullable{T}(value)
 
+eltype{T}(::Type{Nullable{T}}) = T
+
+eltype{T}(x::Nullable{T}) = T
+
 function convert{S, T}(::Type{Nullable{T}}, x::Nullable{S})
     return isnull(x) ? Nullable{T}() : Nullable(convert(T, get(x)))
 end

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1306,6 +1306,22 @@ Dequeues
 
 Fully implemented by: ``Vector`` (aka 1-d ``Array``), ``BitVector`` (aka 1-d ``BitArray``).
 
+Nullables
+---------
+
+.. function:: get(x)
+
+   Attempt to access the value of the ``Nullable`` object, ``x``. Returns the
+   value if it is present; otherwise, throws a ``NullException``.
+
+.. function:: get(x, y)
+
+   Attempt to access the value of the ``Nullable{T}`` object, ``x``. Returns
+   the value if it is present; otherwise, returns ``convert(T, y)``.
+
+.. function:: isnull(x)
+
+   Does the ``Nullable`` object ``x`` have a value or not?
 
 Strings
 -------
@@ -3216,7 +3232,7 @@ Mathematical Functions
 .. function:: trunc([T,] x, [digits, [base]])
 
    ``trunc(x)`` returns the nearest integral value of the same type as ``x`` whose absolute
-   value is less than or equal to ``x``. 
+   value is less than or equal to ``x``.
 
    ``trunc(T, x)`` converts the result to type ``T``, throwing an
    ``InexactError`` if the value is not representable.
@@ -3228,7 +3244,7 @@ Mathematical Functions
    ``unsafe_trunc(T, x)`` returns the nearest integral value of type ``T`` whose absolute
    value is less than or equal to ``x``. If the value is not representable by
    ``T``, an arbitrary value will be returned.
-   
+
 .. function:: signif(x, digits, [base])
 
    Rounds (in the sense of ``round``) ``x`` so that there are ``digits`` significant digits, under a base ``base`` representation, default 10. E.g., ``signif(123.456, 2)`` is ``120.0``, and ``signif(357.913, 4, 2)`` is ``352.0``.

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -19,6 +19,8 @@ for T in types
     x = Nullable{T}()
     @test x.isnull === true
     @test isa(x.value, T)
+    @test eltype(Nullable{T}) === T
+    @test eltype(x) === T
 end
 
 # Nullable{T}(value::T) = new(false, value)
@@ -27,11 +29,13 @@ for T in types
     @test x.isnull === false
     @test isa(x.value, T)
     @test x.value === zero(T)
+    @test eltype(x) === T
 
     x = Nullable{T}(one(T))
     @test x.isnull === false
     @test isa(x.value, T)
     @test x.value === one(T)
+    @test eltype(x) === T
 end
 
 # immutable NullException <: Exception


### PR DESCRIPTION
This PR adds `eltype` methods for Nullable, some stdlib documentation for the non-container methods implemented by `Nullable` and fixes some small whitespace quirks in the stdlib docs.
