### PR TITLE
Reorder tbaa node decls so that comment indentation shows hierarchy.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -196,9 +196,9 @@ static Type *T_pfloat64;
 static Type *T_void;
 
 // type-based alias analysis nodes.  Indentation of comments indicates hierarchy.
-static MDNode* tbaa_user;           // User data
+static MDNode* tbaa_user;           // User data that is mutable
+static MDNode* tbaa_immut;          // User data inside a heap-allocated immutable
 static MDNode* tbaa_value;          // Julia value
-static MDNode* tbaa_immut;          // Data inside a heap-allocated immutable
 static MDNode* tbaa_array;              // Julia array
 static MDNode* tbaa_arrayptr;               // The pointer inside a jl_array_t
 static MDNode* tbaa_arraysize;              // A size in a jl_array_t


### PR DESCRIPTION
This is a minor comment fix to #8867.  It moves the declaration of `tbaa_immut` up a line and refines the comment for `tbaa_user` so that the comments properly form an outline of the inclusion hierarchy.  
