### PR TITLE
RFC: add the ability to disable syntax deprecation warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,8 @@ Compiler improvements
 
   * Accessing fields that are always initialized no longer produces undefined checks ([#8827]).
 
+  * `--depwarn={yes|no}` command line flag added to enable / disable syntax and method deprecation warnings ([#9294]).
+
 Library improvements
 --------------------
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -129,6 +129,9 @@ end
 
 _repl_start = Condition()
 
+syntax_deprecation_warnings(warn::Bool) =
+    bool(ccall(:jl_parse_depwarn, Cint, (Cint,), warn))
+
 function parse_input_line(s::AbstractString)
     # s = bytestring(s)
     # (expr, pos) = parse(s, 1)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -36,9 +36,11 @@ macro deprecate(old,new)
 end
 
 function depwarn(msg, funcsym)
-    bt = backtrace()
-    caller = firstcaller(bt, funcsym)
-    warn(msg, once=(caller!=C_NULL), key=caller, bt=bt)
+    if bool(compileropts().depwarn)
+        bt = backtrace()
+        caller = firstcaller(bt, funcsym)
+        warn(msg, once=(caller!=C_NULL), key=caller, bt=bt)
+    end
 end
 
 function firstcaller(bt::Array{Ptr{Void},1}, funcsym::Symbol)

--- a/base/util.jl
+++ b/base/util.jl
@@ -241,3 +241,22 @@ end
 
 warn(err::Exception; prefix="ERROR: ", kw...) =
     warn(sprint(io->showerror(io,err)), prefix=prefix; kw...)
+
+# Julia compiler options struct (see jl_compileropts_t in src/julia.h)
+immutable JLCompilerOpts
+    julia_home::Ptr{Cchar}
+    julia_bin::Ptr{Cchar}
+    build_path::Ptr{Cchar}
+    image_file::Ptr{Cchar}
+    cpu_target::Ptr{Cchar}
+    code_coverage::Int8
+    malloc_log::Int8
+    check_bounds::Int8
+    dumpbitcode::Int8
+    int_literals::Cint
+    compile_enabled::Int8
+    opt_level::Int8
+    depwarn::Int8
+end
+
+compileropts() = unsafe_load(cglobal(:jl_compileropts, JLCompilerOpts))

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -110,22 +110,30 @@ those available for the ``perl`` and ``ruby`` programs::
 
      -e, --eval <expr>        Evaluate <expr>
      -E, --print <expr>       Evaluate and show <expr>
-     -P, --post-boot <expr>   Evaluate <expr> right after boot
-     -L, --load <file>        Load <file> right after boot on all processors
+     -P, --post-boot <expr>   Evaluate <expr>, but don't disable interactive mode
+     -L, --load <file>        Load <file> immediately on all processors
      -J, --sysimage <file>    Start up with the given system image file
 
      -p <n>                   Run n local processes
      --machinefile <file>     Run processes on hosts listed in <file>
-
+               
      -i                       Force isinteractive() to be true
      --no-history-file        Don't load or save history
      -f, --no-startup         Don't load ~/.juliarc.jl
      -F                       Load ~/.juliarc.jl, then handle remaining inputs
      --color={yes|no}         Enable or disable color text
 
-     --code-coverage          Count executions of source lines
+     --compile={yes|no|all}   Enable or disable compiler, or request exhaustive compilation
+                     
+     --code-coverage={none|user|all}, --code-coverage
+                              Count executions of source lines (omitting setting is equivalent to 'user')
+     --track-allocation={none|user|all}
+                              Count bytes allocated by each source line
      --check-bounds={yes|no}  Emit bounds checks always or never (ignoring declarations)
+     -O, --optimize           Run time-intensive code optimizations
      --int-literals={32|64}   Select integer literal size independent of platform
+     --dump-bitcode={yes|no}  Dump bitcode for the system image (used with --build)
+     --depwarn={yes|no}       Enable or disable syntax and method deprecation warnings
 
 
 Resources

--- a/src/ast.c
+++ b/src/ast.c
@@ -114,6 +114,8 @@ static builtinspec_t julia_flisp_ast_ext[] = {
     { NULL, NULL }
 };
 
+extern int jl_parse_depwarn(int warn);
+
 void jl_init_frontend(void)
 {
     fl_init(4*1024*1024);
@@ -136,6 +138,9 @@ void jl_init_frontend(void)
     false_sym = symbol("false");
     fl_error_sym = symbol("error");
     fl_null_sym = symbol("null");
+
+    // Enable / disable syntax deprecation warnings
+    jl_parse_depwarn((int)jl_compileropts.depwarn);
 }
 
 DLLEXPORT void jl_lisp_prompt(void)
@@ -505,6 +510,12 @@ int jl_start_parsing_file(const char *fname)
 void jl_stop_parsing(void)
 {
     fl_applyn(0, symbol_value(symbol("jl-parser-close-stream")));
+}
+
+DLLEXPORT int jl_parse_depwarn(int warn)
+{
+    value_t prev = fl_applyn(1, symbol_value(symbol("jl-parser-depwarn")), warn? FL_T : FL_F);
+    return prev == FL_T ? 1 : 0;
 }
 
 extern int jl_lineno;

--- a/src/init.c
+++ b/src/init.c
@@ -99,7 +99,8 @@ jl_compileropts_t jl_compileropts = { NULL, // julia_home
                                       JL_COMPILEROPT_DUMPBITCODE_OFF,
                                       0,    // int_literals
                                       JL_COMPILEROPT_COMPILE_DEFAULT,
-                                      0     // opt_level
+                                      0,    // opt_level
+                                      1,    // depwarn
 };
 
 int jl_boot_file_loaded = 0;

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -187,6 +187,12 @@
   (set! *filename-stack* (cdr *filename-stack*))
   (set! *ts-stack* (cdr *ts-stack*)))
 
+(define *depwarn* #t)
+(define (jl-parser-depwarn w)
+  (let ((prev *depwarn*))
+    (set! *depwarn* (eq? w #t))
+    prev))
+
 (define (jl-parser-next)
   (let* ((err (parser-wrap
 	       (lambda ()

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -501,17 +501,18 @@
 ;; --- misc ---
 
 (define (syntax-deprecation-warning s what instead)
-  (io.write
-   *stderr*
-   (string
-    #\newline "WARNING: deprecated syntax \"" what "\""
-    (if (eq? current-filename 'none)
-	""
-	(string " at " current-filename ":" (input-port-line (ts:port s))))
-    "."
-    (if (equal? instead "")
-	""
-	(string #\newline "Use \"" instead "\" instead." #\newline)))))
+  (if *depwarn*
+    (io.write
+     *stderr*
+     (string
+      #\newline "WARNING: deprecated syntax \"" what "\""
+      (if (eq? current-filename 'none)
+	  ""
+	  (string " at " current-filename ":" (input-port-line (ts:port s))))
+      "."
+      (if (equal? instead "")
+	  ""
+	  (string #\newline "Use \"" instead "\" instead." #\newline))))))
 
 ;; --- parser ---
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -878,6 +878,7 @@ void jl_init_restored_modules();
 // front end interface
 DLLEXPORT jl_value_t *jl_parse_input_line(const char *str);
 DLLEXPORT jl_value_t *jl_parse_string(const char *str, int pos0, int greedy);
+DLLEXPORT int jl_parse_depwarn(int warn);
 int jl_start_parsing_file(const char *fname);
 void jl_stop_parsing(void);
 jl_value_t *jl_parse_next(void);
@@ -1329,6 +1330,7 @@ typedef struct {
     int int_literals;
     int8_t compile_enabled;
     int8_t opt_level;
+    int8_t depwarn;
 } jl_compileropts_t;
 
 extern DLLEXPORT jl_compileropts_t jl_compileropts;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -74,7 +74,8 @@ static const char *opts =
     " --check-bounds={yes|no}  Emit bounds checks always or never (ignoring declarations)\n"
     " -O, --optimize           Run time-intensive code optimizations\n"
     " --int-literals={32|64}   Select integer literal size independent of platform\n"
-    " --dump-bitcode={yes|no}  Dump bitcode for the system image (used with --build)\n";
+    " --dump-bitcode={yes|no}  Dump bitcode for the system image (used with --build)\n"
+    " --depwarn={yes|no}       Enable or disable syntax and method deprecation warnings\n";
 
 void parse_opts(int *argcp, char ***argvp)
 {
@@ -93,6 +94,7 @@ void parse_opts(int *argcp, char ***argvp)
         { "int-literals",  required_argument, 0, 301 },
         { "dump-bitcode",  required_argument, 0, 302 },
         { "compile",       required_argument, 0, 303 },
+        { "depwarn",       required_argument, 0, 304 },
         { 0, 0, 0, 0 }
     };
     int c;
@@ -186,6 +188,16 @@ void parse_opts(int *argcp, char ***argvp)
                 exit(1);
             }
             break;
+	case 304:
+	    if (!strcmp(optarg,"yes"))
+                jl_compileropts.depwarn = 1;
+	    else if (!strcmp(optarg,"no"))
+                jl_compileropts.depwarn = 0;
+            else {
+                ios_printf(ios_stderr, "julia: invalid argument to --depwarn (%s)\n", optarg);
+                exit(1);
+            }
+	    break;
         default:
             ios_printf(ios_stderr, "julia: unhandled option -- %c\n",  c);
             ios_printf(ios_stderr, "This is a bug, please report it.\n");


### PR DESCRIPTION
Adds the ability to turn off syntax deprecations in the parser with a command line flag `--no-depwarn` or at runtime:

``` julia
julia> a = {1,2,3}
WARNING: deprecated syntax "{a,b, ...}".
Use "Any[a,b, ...]" instead.
julia> a = {1,2,3}

WARNING: deprecated syntax "{a,b, ...}".
Use "Any[a,b, ...]" instead.
3-element Array{Any,1}:
 1
 2
 3

julia> Base.syntax_deprecation_warnings(false)
false

julia> a = {1,2,3}
3-element Array{Any,1}:
 1
 2
 3
```
