### PR TITLE
implement RandomDevice RNG

### DIFF
--- a/base/dSFMT.jl
+++ b/base/dSFMT.jl
@@ -67,8 +67,8 @@ end
 ## Windows entropy
 
 @windows_only begin
-    function win32_SystemFunction036!(a::Array{UInt32})
-        ccall((:SystemFunction036,:Advapi32),stdcall,UInt8,(Ptr{Void},UInt32),a,length(a)*sizeof(eltype(a)))
+    function win32_SystemFunction036!{T}(a::Array{T})
+        ccall((:SystemFunction036,:Advapi32),stdcall,UInt8,(Ptr{Void},UInt32),a,sizeof(a))
     end
 end
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -901,6 +901,7 @@ export
 # random numbers
     AbstractRNG,
     MersenneTwister,
+    RandomDevice,
     rand!,
     rand,
     randbool,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4099,19 +4099,33 @@ The `BigFloat` type implements arbitrary-precision floating-point arithmetic usi
 Random Numbers
 --------------
 
-Random number generation in Julia uses the `Mersenne Twister library <http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/#dSFMT>`_. Julia has a global RNG, which is used by default. Multiple RNGs can be plugged in using the ``AbstractRNG`` object, which can then be used to have multiple streams of random numbers. Currently, only ``MersenneTwister`` is supported.
+Random number generation in Julia uses the `Mersenne Twister library <http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/#dSFMT>`_ via ``MersenneTwister`` objects.
+Julia has a global RNG, which is used by default. Other RNG types can be plugged in by inheriting the ``AbstractRNG`` type;
+they can then be used to have multiple streams of random numbers.
+Besides ``MersenneTwister``, Julia also provides the ``RandomDevice`` RNG type, which is a wrapper over the OS provided entropy.
 
-Most functions related to random generation accept an optional ``AbstractRNG`` as the first argument, ``rng`` , which defaults to the global one if not provided. Morever, some of them accept optionally dimension specifications ``dims...`` (which can be given as a tuple) to generate arrays of random values.
+Most functions related to random generation accept an optional ``AbstractRNG`` as the first argument, ``rng`` , which defaults to the global one if not provided.
+Morever, some of them accept optionally dimension specifications ``dims...`` (which can be given as a tuple) to generate arrays of random values.
 
-A ``MersenneTwister`` RNG can generate random numbers of the following types: ``Float16``, ``Float32``, ``Float64``, ``Bool``, ``Int8``, ``UInt8``, ``Int16``, ``UInt16``, ``Int32``, ``UInt32``, ``Int64``, ``UInt64``, ``Int128``, ``UInt128``, ``BigInt`` (or complex numbers of those types). Random floating point numbers are generated uniformly in [0,1). As ``BigInt`` represents unbounded integers, the interval must be specified (e.g. ``rand(big(1:6))``).
+A ``MersenneTwister`` or ``RandomDevice`` RNG can generate random numbers of the following types:
+``Float16``, ``Float32``, ``Float64``, ``Bool``, ``Int8``, ``UInt8``, ``Int16``, ``UInt16``,
+``Int32``, ``UInt32``, ``Int64``, ``UInt64``, ``Int128``, ``UInt128``, ``BigInt``
+(or complex numbers of those types). Random floating point numbers are generated uniformly in [0,1).
+As ``BigInt`` represents unbounded integers, the interval must be specified (e.g. ``rand(big(1:6))``).
 
 .. function:: srand([rng], [seed])
 
-   Reseed the random number generator. If a ``seed`` is provided, the RNG will give a reproducible sequence of numbers, otherwise Julia will get entropy from the system. The ``seed`` may be a non-negative integer, a vector of ``UInt32`` integers or a filename, in which case the seed is read from a file.
+   Reseed the random number generator. If a ``seed`` is provided, the RNG will give a reproducible sequence of numbers, otherwise Julia will get entropy from the system.
+   For ``MersenneTwister``, the ``seed`` may be a non-negative integer, a vector of ``UInt32`` integers or a filename, in which case the seed is read from a file.
+   ``RandomDevice`` does not support seeding.
 
 .. function:: MersenneTwister([seed])
 
    Create a ``MersenneTwister`` RNG object. Different RNG objects can have their own seeds, which may be useful for generating different streams of random numbers.
+
+.. function:: RandomDevice()
+
+   Create a ``RandomDevice`` RNG object. Two such objects will always generate different streams of random numbers.
 
 .. function:: rand([rng], [S], [dims...])
 


### PR DESCRIPTION
This introduces a new `AbstractRNG` in Base, whose logic was already used to seed RNGs from OS entropy pool. See #9274 where the discussion on this statred.
