### PR TITLE
Let sign(x) work on unsigned arguments

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -20,7 +20,7 @@ last(x::Number) = x
 
 divrem(x,y) = (div(x,y),rem(x,y))
 signbit(x::Real) = x < 0
-sign(x::Real) = ifelse(x < 0, oftype(x,-1), ifelse(x > 0, one(x), x))
+sign(x::Real) = x < 0 ? oftype(x,-1) : ifelse(x > 0, one(x), x)
 abs(x::Real) = ifelse(signbit(x), -x, x)
 abs2(x::Real) = x*x
 copysign(x::Real, y::Real) = ifelse(signbit(x)!=signbit(y), -x, x)

--- a/base/number.jl
+++ b/base/number.jl
@@ -20,7 +20,8 @@ last(x::Number) = x
 
 divrem(x,y) = (div(x,y),rem(x,y))
 signbit(x::Real) = x < 0
-sign(x::Real) = x < 0 ? oftype(x,-1) : ifelse(x > 0, one(x), x)
+sign(x::Real) = ifelse(x < 0, oftype(x,-1), ifelse(x > 0, one(x), x))
+sign(x::Unsigned) = ifelse(x > 0, one(x), x)
 abs(x::Real) = ifelse(signbit(x), -x, x)
 abs2(x::Real) = x*x
 copysign(x::Real, y::Real) = ifelse(signbit(x)!=signbit(y), -x, x)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -310,6 +310,8 @@ end
 @test sign(-0//1) == 0
 @test sign(1//0) == 1
 @test sign(-1//0) == -1
+@test sign(one(UInt)) == 1
+@test sign(zero(UInt)) == 0
 
 @test signbit(1) == 0
 @test signbit(0) == 0


### PR DESCRIPTION
I figured I would just directly create the pull request for this very small change and have the discussion here rather than starting with an issue.

Currently, the `sign` function throws an `InexactError` on unsigned arguments because it uses `ifelse` and therefore `oftype(x, -1)` is evaluated before `x < 0`.

In case this was actually a design choice, I would suggest it should still be changed, as `sign` has a clear mathematical definition independent of it's argument type, and other computing environments I've tried have no problem returning `1` for an unsigned integer.
