### PR TITLE
rework of cluster manager. support additional launches via a worker

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -189,7 +189,7 @@ function init_bind_addr(args::Vector{UTF8String})
     btoidx = findfirst(args, "--bind-to")
     if btoidx > 0
         bind_to = split(args[btoidx+1], ":")
-        bind_addr = parseip(bind_to[1])
+        bind_addr = string(parseip(bind_to[1]))
         if length(bind_to) > 1
             bind_port = parseint(bind_to[2])
         else
@@ -198,11 +198,11 @@ function init_bind_addr(args::Vector{UTF8String})
     else
         bind_port = 0
         try
-            bind_addr = getipaddr()
+            bind_addr = string(getipaddr())
         catch
             # All networking is unavailable, initialize bind_addr to the loopback address
             # Will cause an exception to be raised only when used.
-            bind_addr = ip"127.0.0.1"
+            bind_addr = "127.0.0.1"
         end
     end
     global LPROC
@@ -355,11 +355,12 @@ function load_juliarc()
 end
 
 function load_machine_file(path::AbstractString)
-    machines = AbstractString[]
+    machines = []
     for line in split(readall(path),'\n'; keep=false)
-        s = split(line,'*'; keep=false)
+        s = map!(strip, split(line,'*'; keep=false))
         if length(s) > 1
-            append!(machines,fill(s[2],int(s[1])))
+            cnt = isnumber(s[1]) ? int(s[1]) : symbol(s[1])
+            push!(machines,(s[2], cnt))
         else
             push!(machines,line)
         end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -115,6 +115,7 @@ export
     WeakKeyDict,
     WeakRef,
     Woodbury,
+    WorkerConfig,
     WString,
     Zip,
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -138,16 +138,6 @@ include("multidimensional.jl")
 
 include("primes.jl")
 
-# concurrency and parallelism
-include("serialize.jl")
-include("multi.jl")
-
-# Polling (requires multi.jl)
-include("poll.jl")
-
-# code loading
-include("loading.jl")
-
 begin
     SOURCE_PATH = ""
     include = function(path)
@@ -196,6 +186,23 @@ include("dSFMT.jl")
 include("random.jl")
 importall .Random
 
+# (s)printf macros
+include("printf.jl")
+importall .Printf
+
+# nullable types
+include("nullable.jl")
+
+# concurrency and parallelism
+include("serialize.jl")
+include("multi.jl")
+
+# code loading
+include("loading.jl")
+
+# Polling (requires multi.jl)
+include("poll.jl")
+
 # distributed arrays and memory-mapped arrays
 include("darray.jl")
 include("mmap.jl")
@@ -228,10 +235,6 @@ include("markdown/Markdown.jl")
 include("docs.jl")
 using .Docs
 using .Markdown
-
-# (s)printf macros
-include("printf.jl")
-importall .Printf
 
 # misc useful functions & macros
 include("util.jl")
@@ -282,9 +285,6 @@ importall .Profile
 # dates
 include("Dates.jl")
 import .Dates: Date, DateTime, now
-
-# nullable types
-include("nullable.jl")
 
 # Some basic documentation
 include("basedocs.jl")

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -5319,37 +5319,57 @@ some built-in integration support in Julia.
 Parallel Computing
 ------------------
 
-.. function:: addprocs(n; manager::ClusterManager=LocalManager()) -> List of process identifiers
+.. function:: addprocs(n::Integer; exeflags=``) -> List of process identifiers
 
-   ``addprocs(4)`` will add 4 processes on the local machine. This can be used to take
-   advantage of multiple cores.
+   Launches workers using the in-built ``LocalManager`` which only launches workers on the local host.
+   This can be used to take advantage of multiple cores. `addprocs(4)`` will add 4 processes on the local machine.
 
-   Keyword argument ``manager`` can be used to provide a custom cluster manager to start workers.
+.. function:: addprocs() -> List of process identifiers
+
+    Equivalent to ``addprocs(CPU_CORES)``
+
+.. function:: addprocs(machines; tunnel=false, sshflags=``, max_parallel=10, exeflags=``) -> List of process identifiers
+
+   Add processes on remote machines via SSH.
+   Requires julia to be installed in the same location on each node, or to be available via a shared file system.
+
+   ``machines`` is a vector of machine specifications.  Worker are started for each specification.
+
+   A machine specification is either a string ``machine_spec`` or a tuple - ``(machine_spec, count)``
+
+   ``machine_spec`` is a string of the form ``[user@]host[:port] [bind_addr[:port]]``. ``user`` defaults
+   to current user, ``port`` to the standard ssh port. If ``[bind_addr[:port]]`` is specified, other
+   workers will connect to this worker at the specified ``bind_addr`` and ``port``.
+
+   ``count`` is the number of workers to be launched on the specified host. If specified as ``"auto"``
+   or ``:auto`` it will launch as many workers as the number of cores on the specific host.
+
+
+   Keyword arguments:
+
+   ``tunnel`` : if ``true`` then SSH tunneling will be used to connect to the worker from the master process.
+
+   ``sshflags`` : specifies additional ssh options, e.g. :literal:`sshflags=\`-i /home/foo/bar.pem\`` .
+
+   ``max_parallel`` : specifies the maximum number of workers connected to in parallel at a host. Defaults to 10.
+
+   ``dir`` :  specifies the location of the julia binaries on the worker nodes. Defaults to JULIA_HOME.
+
+   ``exename`` :  name of the julia executable. Defaults to "./julia" or "./julia-debug" as the case may be.
+
+   ``exeflags`` :  additional flags passed to the worker processes.
+
+
+.. function:: addprocs(manager::ClusterManager; kwargs...) -> List of process identifiers
+
+   Launches worker processes via the specified cluster manager.
+
    For example Beowulf clusters are  supported via a custom cluster manager implemented
    in  package ``ClusterManagers``.
 
    See the documentation for package ``ClusterManagers`` for more information on how to
    write a custom cluster manager.
 
-.. function:: addprocs(machines; tunnel=false, dir=JULIA_HOME, sshflags::Cmd=``) -> List of process identifiers
-
-   Add processes on remote machines via SSH.
-   Requires julia to be installed in the same location on each node, or to be available via a shared file system.
-
-   ``machines`` is a vector of host definitions of the form ``[user@]host[:port] [bind_addr[:port]]``. ``user`` defaults
-   to current user, ``port`` to the standard ssh port. A worker is started at each host definition.
-   If the optional ``[bind_addr[:port]]`` is specified, other workers will connect to this worker at the
-   specified ``bind_addr`` and ``port``.
-
-   Keyword arguments:
-
-   ``tunnel`` : if ``true`` then SSH tunneling will be used to connect to the worker.
-
-   ``dir`` :  specifies the location of the julia binaries on the worker nodes.
-
-   ``sshflags`` : specifies additional ssh options, e.g. :literal:`sshflags=\`-i /home/foo/bar.pem\`` .
-
-   ``max_parallel`` : specifies the maximum number of workers being launched in parallel at a host. Defaults to 10.
 
 .. function:: nprocs()
 


### PR DESCRIPTION
This PR does the following:
- simplifies the cluster manager interface
- starts additional workers at a host _from the first worker_ . Will both speed up and remove the 
  need for unecessary ssh connections for each worker launch.
- has the framework in place to support custom transport mechanisms at a later stage
- `addprocs` can accept an array of hosts / tuples. Each tuple of the type `(host, count)`.
  `count` can be `"auto"` or `:auto`, in which case it will launch as many workers as the number
  of cores on `host` . machinefile too supports synatx `auto * foo@bar.com` for a machine definition.

Consequently, it supersedes #9202 and #9046 
