### PR TITLE
Remove the last 0.2 deprecations

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -69,8 +69,4 @@ test(pkgs::AbstractString...; coverage::Bool=false) = cd(Entry.test,AbstractStri
 
 dependents(packagename::AbstractString) = Reqs.dependents(packagename)
 
-@deprecate release free
-@deprecate fixup build
-@deprecate fix pin
-
 end # module


### PR DESCRIPTION
Three deprecations in Pkg was forgotten when we removed the deprecations
before releaseing 0.3.0. It seems like this is as good time as any to
remove them for good.

The deprecations was introduced in
af854d72, 51376f63 and 4b92a8cd
