### PR TITLE
added more constructors for v4

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -30,10 +30,7 @@ end
 IPv4(ipstr::AbstractString) = parseipv4(ipstr)
 
 
-#constructor: ([1,2,3,4])
-function IPv4{T<:Integer}(iparr::Vector{T})
-    return IPv4(iparr...)
-end
+IPv4(iparr::Array) = [IPv4(x) for x in iparr]
 
 show(io::IO,ip::IPv4) = print(io,"ip\"",ip,"\"")
 print(io::IO,ip::IPv4) = print(io,dec((ip.host&(0xFF000000))>>24),".",

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -27,7 +27,7 @@ function IPv4(host::Integer)
 end
 
 # constructor: ("1.2.3.4")
-function IPv4(ipstr::String)
+function IPv4(ipstr::AbstractString)
     iparr = Uint32[parseint(octet) for octet in split(ipstr, ".")]
     return IPv4(iparr...)
 end

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -29,8 +29,8 @@ end
 # constructor: ("1.2.3.4")
 IPv4(ipstr::AbstractString) = parseipv4(ipstr)
 
-
-IPv4(iparr::AbstractArray) = map((x)->IPv4(x), iparr)
+# pending decision
+# IPv4(iparr::AbstractArray) = map((x)->IPv4(x), iparr)
 
 show(io::IO,ip::IPv4) = print(io,"ip\"",ip,"\"")
 print(io::IO,ip::IPv4) = print(io,dec((ip.host&(0xFF000000))>>24),".",
@@ -74,7 +74,9 @@ function IPv6(host::Integer)
 end
 
 IPv6(ipstr::AbstractString) = parseipv6(ipstr)
-IPv6(iparr::AbstractArray) = map((x)->IPv6(x), iparr)
+
+# pending decision
+# IPv6(iparr::AbstractArray) = map((x)->IPv6(x), iparr)
 
 # Suppress leading '0's and "0x"
 print_ipv6_field(io,field::UInt16) = print(io,hex(field))

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -26,6 +26,17 @@ function IPv4(host::Integer)
     end
 end
 
+# constructor: ("1.2.3.4")
+function IPv4(ipstr::String)
+    iparr = Uint32[parseint(octet) for octet in split(ipstr, ".")]
+    return IPv4(iparr...)
+end
+
+#constructor: ([1,2,3,4])
+function IPv4{T<:Integer}(iparr::Vector{T})
+    return IPv4(iparr...)
+end
+
 show(io::IO,ip::IPv4) = print(io,"ip\"",ip,"\"")
 print(io::IO,ip::IPv4) = print(io,dec((ip.host&(0xFF000000))>>24),".",
                                   dec((ip.host&(0xFF0000))>>16),".",

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -27,10 +27,8 @@ function IPv4(host::Integer)
 end
 
 # constructor: ("1.2.3.4")
-function IPv4(ipstr::AbstractString)
-    iparr = Uint32[parseint(octet) for octet in split(ipstr, ".")]
-    return IPv4(iparr...)
-end
+IPv4(ipstr::AbstractString) = parseipv4(ipstr)
+
 
 #constructor: ([1,2,3,4])
 function IPv4{T<:Integer}(iparr::Vector{T})
@@ -77,6 +75,8 @@ function IPv6(host::Integer)
         return IPv6(uint128(host))
     end
 end
+
+IPv6(ipstr::AbstractString) = parseipv6(ipstr)
 
 # Suppress leading '0's and "0x"
 print_ipv6_field(io,field::UInt16) = print(io,hex(field))

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -30,7 +30,7 @@ end
 IPv4(ipstr::AbstractString) = parseipv4(ipstr)
 
 
-IPv4(iparr::Array) = [IPv4(x) for x in iparr]
+IPv4(iparr::AbstractArray) = map((x)->IPv4(x), iparr)
 
 show(io::IO,ip::IPv4) = print(io,"ip\"",ip,"\"")
 print(io::IO,ip::IPv4) = print(io,dec((ip.host&(0xFF000000))>>24),".",
@@ -74,6 +74,7 @@ function IPv6(host::Integer)
 end
 
 IPv6(ipstr::AbstractString) = parseipv6(ipstr)
+IPv6(iparr::AbstractArray) = map((x)->IPv6(x), iparr)
 
 # Suppress leading '0's and "0x"
 print_ipv6_field(io,field::UInt16) = print(io,hex(field))


### PR DESCRIPTION
I needed a bit more flexibility in IPv4 creation, so I created two new constructors. (I'll be doing the same for v6.)

I've created a v4 network representation as well (v4 host, v4 netmask, and overriding "in" to test whether an address is within a network) but it's probably best as a separate package for now.
