### PR TITLE
Make SubArrays immutable

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -5,7 +5,7 @@ typealias RangeIndex Union(Int, Range{Int}, UnitRange{Int}, Colon)
 # LD is the last dimension up through which this object has efficient
 # linear indexing. If LD==N, then the object itself has efficient
 # linear indexing.
-type SubArray{T,N,P<:AbstractArray,I<:(ViewIndex...),LD} <: AbstractArray{T,N}
+immutable SubArray{T,N,P<:AbstractArray,I<:(ViewIndex...),LD} <: AbstractArray{T,N}
     parent::P
     indexes::I
     dims::NTuple{N,Int}


### PR DESCRIPTION
Since #8867 this actually makes a difference in the optimizations LLVM is able to perform. On the benchmark from #8809, the effect is quite dramatic. The code is:

``` julia
function f1(x,v)
    for j=1:length(x)
        @inbounds x[j] += v
    end
end
let
    n = 600
    tn = 10^7
    x = randn(n,3)
    v = 1.00001
    xslice = sub(x,:, 2)
    @time for i=1:tn
        f1(xslice,v)
    end
end
```

Before, this took ~9 seconds to execute. With this change, it takes ~2.5. However, LLVM 3.3 still won't vectorize it, even though it vectorizes with Arrays and ArrayViews. It looks like there's an extra `mul` in the inner loop.
