### PR TITLE
Improve zero checks in sparse and reduce

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -428,6 +428,6 @@ function count(pred::Union(Function,Func{1}), a::AbstractArray)
 end
 
 immutable NotEqZero <: Func{1} end
-call(::NotEqZero, x) = x != 0
+call(::NotEqZero, x) = x != zero(x)
 
 countnz(a) = count(NotEqZero(), a)

--- a/base/sparse/csparse.jl
+++ b/base/sparse/csparse.jl
@@ -29,7 +29,7 @@ function sparse{Tv,Ti<:Integer}(I::AbstractVector{Ti}, J::AbstractVector{Ti},
     Rnz[1] = 1
     nz = 0
     for k=1:N
-        if V[k] != 0
+        if V[k] != zero(Tv)
             Rnz[I[k]+1] += 1
             nz += 1
         end
@@ -49,7 +49,7 @@ function sparse{Tv,Ti<:Integer}(I::AbstractVector{Ti}, J::AbstractVector{Ti},
         ((iind > 0) && (jind > 0)) || throw(BoundsError())
         p = Wj[iind]
         Vk = V[k]
-        if Vk != 0
+        if Vk != zero(Tv)
             Wj[iind] += 1
             Rx[p] = Vk
             Ri[p] = jind

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -314,7 +314,7 @@ function findn{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
 
     count = 1
     @inbounds for col = 1 : S.n, k = S.colptr[col] : (S.colptr[col+1]-1)
-        if S.nzval[k] != 0
+        if S.nzval[k] != zero(Tv)
             I[count] = S.rowval[k]
             J[count] = col
             count += 1
@@ -338,7 +338,7 @@ function findnz{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
 
     count = 1
     @inbounds for col = 1 : S.n, k = S.colptr[col] : (S.colptr[col+1]-1)
-        if S.nzval[k] != 0
+        if S.nzval[k] != zero(Tv)
             I[count] = S.rowval[k]
             J[count] = col
             V[count] = S.nzval[k]
@@ -1224,7 +1224,7 @@ function setindex!{T,Ti}(A::SparseMatrixCSC{T,Ti}, v, i0::Integer, i1::Integer)
     v = convert(T, v)
     r1 = int(A.colptr[i1])
     r2 = int(A.colptr[i1+1]-1)
-    if v == 0 #either do nothing or delete entry if it exists
+    if v == zero(T) #either do nothing or delete entry if it exists
         if r1 <= r2
             r1 = searchsortedfirst(A.rowval, i0, r1, r2, Forward)
             if (r1 <= r2) && (A.rowval[r1] == i0)


### PR DESCRIPTION
Just noticed some checks with `0` that don't play nice with custom types. There are probably more of these, but I'm not sure about a systematic way to find them.

This is only my second "real" commit I think, so not sure my test code is kosher style-wise.
