### PR TITLE
SubArray: infer contiguity, skip multiply in indexing

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -310,6 +310,23 @@ function stride1expr(Atype::Type, Itypes::Tuple, Aexpr, Inewsym, LD)
     ex
 end
 
+# This might be conservative, but better safe than sorry
+function iscontiguous{T,N,P,I,LD}(::Type{SubArray{T,N,P,I,LD}})
+    LD == length(I) || return false
+    length(I) < 1 && return true
+    I[1] == Colon && return true
+    if I[1] <: UnitRange
+        # It might be stride1 == 1, or this might be because `sub` was
+        # used with an integer for the first index
+        for j = 2:length(I)
+            (I[j] == Colon || (I[j] <: AbstractVector)) && return false
+        end
+        return true
+    end
+    false
+end
+iscontiguous(S::SubArray) = iscontiguous(typeof(S))
+
 first_index(V::SubArray) = first_index(V.parent, V.indexes)
 function first_index(P::AbstractArray, indexes::Tuple)
     f = 1

--- a/base/subarray2.jl
+++ b/base/subarray2.jl
@@ -23,6 +23,9 @@ for i = 1:4
     @eval begin
         stagedfunction getindex{T,N,P,IV,LD}(V::SubArray{T,N,P,IV,LD}, $(varsInt...))
             if $i == 1 && length(IV) == LD  # linear indexing
+                if iscontiguous(V)
+                    return :(V.parent[V.first_index + i_1 - 1])
+                end
                 return :(V.parent[V.first_index + V.stride1*(i_1-1)])
             end
             exhead, ex = index_generate(ndims(P), IV, :V, [$(vars...)])
@@ -33,6 +36,9 @@ for i = 1:4
         end
         stagedfunction setindex!{T,N,P,IV,LD}(V::SubArray{T,N,P,IV,LD}, v, $(varsInt...))
             if $i == 1 && length(IV) == LD  # linear indexing
+                if iscontiguous(V)
+                    return :(V.parent[V.first_index + i_1 - 1] = v)
+                end
                 return :(V.parent[V.first_index + V.stride1*(i_1-1)] = v)
             end
             exhead, ex = index_generate(ndims(P), IV, :V, [$(vars...)])

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -5,11 +5,12 @@ print_underestimates = false
 
 ######## Utilities ###########
 
-# Generate an array similar to A[indx1, indx2, ...], but only call getindex
-# with scalar-valued indexes. This will be safe even after getindex starts calling sub/slice.
+# Generate an array similar to A[indx1, indx2, ...], but only call
+# getindex with scalar-valued indexes. This will be safe even after
+# getindex starts calling sub/slice.
 
-# The "nodrop" variant is similar to current getindex/sub, except it doesn't drop any dimensions
-# (not even trailing ones)
+# The "nodrop" variant is similar to current getindex/sub, except it
+# doesn't drop any dimensions (not even trailing ones)
 function Agen_nodrop(A::AbstractArray, I...)
     irep = replace_colon(A, I)
     _Agen(A, irep...)
@@ -51,9 +52,11 @@ function copy_to_array(A::AbstractArray)
     copy!(Ac, A)
 end
 
-# Discover the highest dimension along which the values in A are separated by a single increment.
-# If A was extracted via getindex from reshape(1:N, ...), this is equivalent to finding the
-# highest dimension of the SubArray consistent with a single stride in the parent array.
+# Discover the highest dimension along which the values in A are
+# separated by a single increment.  If A was extracted via getindex
+# from reshape(1:N, ...), this is equivalent to finding the highest
+# dimension of the SubArray consistent with a single stride in the
+# parent array.
 function single_stride_dim(A::Array)
     ld = 0
     while ld < ndims(A)
@@ -207,6 +210,9 @@ function runtests(A::Array, I...)
     # sub
     S = sub(A, I...)
     getLD(S) == ldc || err_li(S, ldc)
+    if Base.iscontiguous(S)
+        @test S.stride1 == 1
+    end
     test_linear(S, C)
     test_cartesian(S, C)
     test_mixed(S, C)
@@ -368,4 +374,3 @@ msk[2,1] = false
 sA = sub(A, :, :, 1)
 sA[msk] = 1.0
 @test sA[msk] == ones(countnz(msk))
-


### PR DESCRIPTION
This seems to fix the vectorization issue described in #9322. CC @simonster.
