### PR TITLE
WIP/RFC: make find, filter, count more consistent

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1076,7 +1076,7 @@ end
 find(A::AbstractArray, v) = find(EqX(v), A)
 
 function find(A::StridedArray)
-    nnzA = countnz(A)
+    nnzA = count(A)
     I = similar(A, Int, nnzA)
     count = 1
     for i=1:length(A)
@@ -1094,7 +1094,7 @@ find(testf::Predicate, x::Number) = !testf(x) ? Array(Int,0) : [1]
 findn(A::AbstractVector) = find(A)
 
 function findn(A::StridedMatrix)
-    nnzA = countnz(A)
+    nnzA = count(A)
     I = similar(A, Int, nnzA)
     J = similar(A, Int, nnzA)
     count = 1
@@ -1109,7 +1109,7 @@ function findn(A::StridedMatrix)
 end
 
 function findnz{T}(A::StridedMatrix{T})
-    nnzA = countnz(A)
+    nnzA = count(A)
     I = zeros(Int, nnzA)
     J = zeros(Int, nnzA)
     NZs = zeros(T, nnzA)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1049,7 +1049,7 @@ end
 findfirst(A,v) = findnext(A,v,1)
 
 # returns the index of the next element for which the function returns true
-function findnext(testf::Function, A, start::Integer)
+function findnext(testf::Predicate, A, start::Integer)
     for i = start:length(A)
         if testf(A[i])
             return i
@@ -1059,7 +1059,7 @@ function findnext(testf::Function, A, start::Integer)
 end
 findfirst(testf::Function, A) = findnext(testf, A, 1)
 
-function find(testf::Function, A::AbstractArray)
+function find(testf::Predicate, A::AbstractArray)
     # use a dynamic-length array to store the indexes, then copy to a non-padded
     # array for the return
     tmpI = Array(Int, 0)
@@ -1072,6 +1072,8 @@ function find(testf::Function, A::AbstractArray)
     copy!(I, tmpI)
     I
 end
+
+find(A::AbstractArray, v) = find(EqX(v), A)
 
 function find(A::StridedArray)
     nnzA = countnz(A)
@@ -1087,7 +1089,7 @@ function find(A::StridedArray)
 end
 
 find(x::Number) = x == 0 ? Array(Int,0) : [1]
-find(testf::Function, x::Number) = !testf(x) ? Array(Int,0) : [1]
+find(testf::Predicate, x::Number) = !testf(x) ? Array(Int,0) : [1]
 
 findn(A::AbstractVector) = find(A)
 
@@ -1219,9 +1221,9 @@ end
 ## Filter ##
 
 # given a function returning a boolean and an array, return matching elements
-filter(f::Function, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
+filter(f::Predicate, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 
-function filter!(f::Function, a::Vector)
+function filter!(f::Predicate, a::Vector)
     insrt = 1
     for curr = 1:length(a)
         if f(a[curr])
@@ -1233,7 +1235,7 @@ function filter!(f::Function, a::Vector)
     return a
 end
 
-function filter(f::Function, a::Vector)
+function filter(f::Predicate, a::Vector)
     r = Array(eltype(a), 0)
     for i = 1:length(a)
         if f(a[i])
@@ -1242,6 +1244,7 @@ function filter(f::Function, a::Vector)
     end
     return r
 end
+
 
 ## Transpose ##
 const transposebaselength=64

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1463,7 +1463,7 @@ end
 
 ## Filter ##
 
-function filter(f::Function, Bs::BitArray)
+function filter(f::Predicate, Bs::BitArray)
     boolmap::Array{Bool} = map(f, Bs)
     Bs[boolmap]
 end

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1239,9 +1239,9 @@ end
 
 #TODO: rol!, ror!
 
-## countnz & find ##
+## count & find ##
 
-function countnz(B::BitArray)
+function count(B::BitArray)
     n = 0
     Bc = B.chunks
     @inbounds for i = 1:length(Bc)
@@ -1330,7 +1330,7 @@ end
 
 function find(B::BitArray)
     l = length(B)
-    nnzB = countnz(B)
+    nnzB = count(B)
     I = Array(Int, nnzB)
     nnzB == 0 && return I
     Bc = B.chunks
@@ -1364,7 +1364,7 @@ end
 findn(B::BitVector) = find(B)
 
 function findn(B::BitMatrix)
-    nnzB = countnz(B)
+    nnzB = count(B)
     I = Array(Int, nnzB)
     J = Array(Int, nnzB)
     count = 1
@@ -1386,7 +1386,7 @@ end
 ## Reductions ##
 
 sum(A::BitArray, region) = reducedim(AddFun(), A, region)
-sum(B::BitArray) = countnz(B)
+sum(B::BitArray) = count(B)
 
 function all(B::BitArray)
     length(B) == 0 && return true

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -70,8 +70,8 @@ end
 export nfilled
 
 @deprecate nonzeros(A::StridedArray) filter(A)
-@deprecate nonzeros(B::BitArray) trues(countnz(B))
-@deprecate nnz(A::StridedArray) countnz(A)
+@deprecate nonzeros(B::BitArray) trues(count(B))
+@deprecate nnz(A::StridedArray) count(A)
 
 @deprecate dense  full
 
@@ -252,3 +252,5 @@ const Uint128 = UInt128
 @deprecate squeeze(X, dims) squeeze(X, tuple(dims...))
 
 @deprecate sizehint(A, n) sizehint!(A, n)
+
+@deprecate countnz(A) count(A)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -69,7 +69,7 @@ function nfilled(X)
 end
 export nfilled
 
-@deprecate nonzeros(A::StridedArray) A[find(A)]
+@deprecate nonzeros(A::StridedArray) filter(A)
 @deprecate nonzeros(B::BitArray) trues(countnz(B))
 @deprecate nnz(A::StridedArray) countnz(A)
 

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -191,7 +191,7 @@ function merge(d::Associative, others::Associative...)
     merge!(Dict{K,V}(), d, others...)
 end
 
-function filter!(f::Function, d::Associative)
+function filter!(f::Predicate, d::Associative)
     for (k,v) in d
         if !f(k,v)
             delete!(d,k)
@@ -199,7 +199,15 @@ function filter!(f::Function, d::Associative)
     end
     return d
 end
-filter(f::Function, d::Associative) = filter!(f,copy(d))
+filter(f::Predicate, d::Associative) = filter!(f,copy(d))
+
+filter( d::Associative, value) = filter( Apply2nd(EqX(value)), d)
+filter!(d::Associative, value) = filter!(Apply2nd(EqX(value)), d)
+
+filter( d::Associative) = filter( Apply2nd(NotEqZero()), d)
+filter!(d::Associative) = filter!(Apply2nd(NotEqZero()), d)
+
+
 
 eltype{K,V}(a::Associative{K,V}) = (K,V)
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -560,7 +560,6 @@ export
     nonzeros,
     nthperm!,
     nthperm,
-    countnz,
     ones,
     parent,
     parentindexes,

--- a/base/functors.jl
+++ b/base/functors.jl
@@ -1,0 +1,66 @@
+###### Functors ######
+
+# Note that functors are merely used as internal machinery to enhance code reuse.
+# They are not exported.
+# When function arguments can be inlined, the use of functors can be removed.
+
+abstract Func{N}
+
+immutable IdFun <: Func{1} end
+call(::IdFun, x)  = x
+
+immutable AbsFun <: Func{1} end
+call(::AbsFun, x) = abs(x)
+
+immutable Abs2Fun <: Func{1} end
+call(::Abs2Fun, x) = abs2(x)
+
+immutable ExpFun <: Func{1} end
+call(::ExpFun, x) = exp(x)
+
+immutable LogFun <: Func{1} end
+call(::LogFun, x) = log(x)
+
+immutable AddFun <: Func{2} end
+call(::AddFun, x, y) = x + y
+
+immutable MulFun <: Func{2} end
+call(::MulFun, x, y) = x * y
+
+immutable AndFun <: Func{2} end
+call(::AndFun, x, y) = x & y
+
+immutable OrFun <: Func{2} end
+call(::OrFun, x, y) =  x | y
+
+immutable MaxFun <: Func{2} end
+call(::MaxFun, x, y) = scalarmax(x,y)
+
+immutable MinFun <: Func{2} end
+call(::MinFun, x, y) = scalarmin(x, y)
+
+immutable EqX{T} <: Func{1}
+    x::T
+end
+call(f::EqX, y) = f.x == y
+
+immutable NotEqZero <: Func{1} end
+call(::NotEqZero, x) = x != 0
+
+# apply a functor on the second passed-in argument
+immutable Apply2nd{F<:Func{1}} <: Func{1}
+    f::F
+end
+call(f::Apply2nd, x, y) = f.f(y)
+
+# loose aliases, as we can't check that a Callable is unary
+# or a predicate, but serves at least as documentation
+typealias UnaryCallable Union(Callable, Func{1})
+typealias Predicate UnaryCallable
+
+
+filter(a, v)  = filter( EqX(v), a)
+filter!(a, v) = filter!(EqX(v), a)
+
+filter(a)  = filter( NotEqZero(), a)
+filter!(a) = filter!(NotEqZero(), a)

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -68,7 +68,7 @@ immutable Filter{I}
     flt::Function
     itr::I
 end
-filter(flt::Function, itr) = Filter(flt, itr)
+filter(flt::Predicate, itr) = Filter(flt, itr)
 
 start(f::Filter) = start_filter(f.flt, f.itr)
 function start_filter(pred, itr)

--- a/base/linalg/bitarray.jl
+++ b/base/linalg/bitarray.jl
@@ -132,7 +132,7 @@ end
 
 ## Structure query functions
 
-issym(A::BitMatrix) = size(A, 1)==size(A, 2) && countnz(A - A.')==0
+issym(A::BitMatrix) = size(A, 1)==size(A, 2) && count(A - A.')==0
 ishermitian(A::BitMatrix) = issym(A)
 
 function nonzero_chunks(chunks::Vector{UInt64}, pos0::Int, pos1::Int)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -153,7 +153,7 @@ function vecnorm(itr, p::Real=2)
     p == 1 && return vecnorm1(itr)
     p == Inf && return vecnormInf(itr)
     p == 0 && return convert(typeof(float(real(zero(eltype(itr))))),
-                             countnz(itr))
+                             count(itr))
     p == -Inf && return vecnormMinusInf(itr)
     vecnormp(itr,p)
 end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -208,7 +208,7 @@ end
 
 
 @ngenerate N NTuple{N,Vector{Int}} function findn{T,N}(A::AbstractArray{T,N})
-    nnzA = countnz(A)
+    nnzA = count(A)
     @nexprs N d->(I_d = Array(Int, nnzA))
     k = 1
     @nloops N i A begin
@@ -644,7 +644,7 @@ end
 ## findn
 
 @ngenerate N NTuple{N,Vector{Int}} function findn{N}(B::BitArray{N})
-    nnzB = countnz(B)
+    nnzB = count(B)
     I = ntuple(N, x->Array(Int, nnzB))
     if nnzB > 0
         count = 1

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -194,7 +194,7 @@ mapreduce_impl(f, op::AddFun, A::AbstractArray, ifirst::Int, ilast::Int) =
 
 sum(f::UnaryCallable, a) = mapreduce(f, AddFun(), a)
 sum(a) = mapreduce(IdFun(), AddFun(), a)
-sum(a::AbstractArray{Bool}) = countnz(a)
+sum(a::AbstractArray{Bool}) = count(a)
 sumabs(a) = mapreduce(AbsFun(), AddFun(), a)
 sumabs2(a) = mapreduce(Abs2Fun(), AddFun(), a)
 
@@ -359,7 +359,7 @@ function contains(eq::Function, itr, x)
 end
 
 
-## countnz & count
+## count
 
 function count(pred::Predicate, itr)
     n = 0
@@ -382,4 +382,3 @@ end
 count(itr, v) = count(EqX(v), itr)
 
 count(itr) = count(NotEqZero(), itr)
-countnz(itr) = count(itr)

--- a/base/set.jl
+++ b/base/set.jl
@@ -118,7 +118,7 @@ function unique(C)
     out
 end
 
-function filter!(f::Function, s::Set)
+function filter!(f::Predicate, s::Set)
     for x in s
         if !f(x)
             delete!(s, x)
@@ -126,7 +126,7 @@ function filter!(f::Function, s::Set)
     end
     return s
 end
-function filter(f::Function, s::Set)
+function filter(f::Predicate, s::Set)
     u = similar(s)
     for x in s
         if f(x)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -16,7 +16,7 @@ SparseMatrixCSC{Tv,Ti}(m::Integer, n::Integer, colptr::Vector{Ti}, rowval::Vecto
 
 size(S::SparseMatrixCSC) = (S.m, S.n)
 nnz(S::SparseMatrixCSC) = int(S.colptr[end]-1)
-countnz(S::SparseMatrixCSC) = countnz(S.nzval)
+count(S::SparseMatrixCSC) = count(S.nzval)
 
 nonzeros(S::SparseMatrixCSC) = S.nzval
 rowvals(S::SparseMatrixCSC) = S.rowval
@@ -868,7 +868,7 @@ mean(A::SparseMatrixCSC, region::Integer) = sum(A, region) / size(A, region)
 #all(A::SparseMatrixCSC{Bool}, region) = reducedim(all,A,region,true)
 #any(A::SparseMatrixCSC{Bool}, region) = reducedim(any,A,region,false)
 #sum(A::SparseMatrixCSC{Bool}, region) = reducedim(+,A,region,0,Int)
-#sum(A::SparseMatrixCSC{Bool}) = countnz(A)
+#sum(A::SparseMatrixCSC{Bool}) = count(A)
 
 ## getindex
 function rangesearch(haystack::Range, needle)
@@ -1899,13 +1899,13 @@ end
 function issym(A::SparseMatrixCSC)
     m, n = size(A)
     if m != n; return false; end
-    return countnz(A - A.') == 0
+    return count(A - A.') == 0
 end
 
 function ishermitian(A::SparseMatrixCSC)
     m, n = size(A)
     if m != n; return false; end
-    return countnz(A - A') == 0
+    return count(A - A') == 0
 end
 
 function istriu{Tv}(A::SparseMatrixCSC{Tv})

--- a/base/string.jl
+++ b/base/string.jl
@@ -1729,4 +1729,3 @@ pointer{T<:ByteString}(x::SubString{T}, i::Integer) = pointer(x.string.data) + x
 pointer(x::Union(UTF16String,UTF32String), i::Integer) = pointer(x)+(i-1)*sizeof(eltype(x.data))
 pointer{T<:Union(UTF16String,UTF32String)}(x::SubString{T}) = pointer(x.string.data) + x.offset*sizeof(eltype(x.data))
 pointer{T<:Union(UTF16String,UTF32String)}(x::SubString{T}, i::Integer) = pointer(x.string.data) + (x.offset + (i-1))*sizeof(eltype(x.data))
-

--- a/base/string.jl
+++ b/base/string.jl
@@ -837,7 +837,7 @@ function map(f::Function, s::AbstractString)
     map_result(s, takebuf_array(out))
 end
 
-function filter(f::Function, s::AbstractString)
+function filter(f::Predicate, s::AbstractString)
     out = IOBuffer(Array(UInt8,endof(s)),true,true)
     truncate(out,0)
     for c in s

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -50,6 +50,9 @@ include("float.jl")
 include("complex.jl")
 include("rational.jl")
 
+# used by array.jl, reduce.jl, etc.
+include("functors.jl")
+
 # core data structures (used by type inference)
 include("abstractarray.jl")
 include("subarray.jl")

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -884,9 +884,12 @@ Iterable Collections
    Test whether all values in ``A`` along the singleton dimensions of ``r`` are true,
    and write results to ``r``.
 
-.. function:: count(p, itr) -> Integer
+.. function:: count([predicate,] itr [, value]) -> Integer
 
-   Count the number of elements in ``itr`` for which predicate ``p`` returns true.
+   Count the number of elements in ``itr`` for which ``predicate``
+   returns true, or which are equal to ``value``, or which are not
+   equal to zero (``value`` and ``predicate`` are mutually exclusive
+   parameters)
 
 .. function:: any(p, itr) -> Bool
 
@@ -1010,15 +1013,22 @@ Iterable Collections
    Determine whether every element of ``a`` is also in ``b``, using the
    ``in`` function.
 
-.. function:: filter(function, collection)
+.. function:: filter([predicate,] collection [, value])
 
-   Return a copy of ``collection``, removing elements for which ``function`` is false.
-   For associative collections, the function is passed two arguments (key and value).
+   Return a copy of ``collection``, removing elements for which
+   ``predicate`` evaluates to false, or not equal to ``value``, or
+   equal to ``0`` if neither ``predicate`` nor ``value`` is provided
+   (``value`` and ``predicate`` are mutally exclusive parameters). For
+   associative collections, ``predicate`` is passed two arguments (key
+   and value).
 
-.. function:: filter!(function, collection)
+.. function:: filter!([predicate,] collection [, value])
 
-   Update ``collection``, removing elements for which ``function`` is false.
-   For associative collections, the function is passed two arguments (key and value).
+   Update ``collection``, removing elements for which ``predicate``
+   evaluates to false, or not equal to ``value``, or equal to ``0`` if
+   neither ``predicate`` nor ``value`` is provided (``value`` and
+   ``predicate`` are mutally exclusive parameters). For associative
+   collections, ``predicate`` is passed two arguments (key and value).
 
 
 Indexable Collections
@@ -4429,6 +4439,10 @@ Indexing, Assignment, and Concatenation
    (determined by ``A[i]!=0``).  A common use of this is to convert a
    boolean array to an array of indexes of the ``true``
    elements.
+
+.. function:: find(A,v)
+
+   Return a vector of the linear indexes of ``A`` elements equal to ``v``.
 
 .. function:: find(f,A)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -4213,10 +4213,6 @@ Basic functions
     (iter.I_1,iter.I_2) = (2,3)
     A[iter] = 0.9916142534546522
 
-.. function:: countnz(A)
-
-   Counts the number of nonzero values in array A (dense or sparse). Note that this is not a constant-time operation. For sparse matrices, one should usually use ``nnz``, which returns the number of stored values.
-
 .. function:: conj!(A)
 
    Convert an array to its complex conjugate in-place


### PR DESCRIPTION
This is about adding the method `count(A, value)`, as `count(x -> x==value, A)` is frustratingly verbose and slow. Then it is tempting to homogeneize a group of functions which can have those three methods:
1. f(pred, A) -> pred is applied to all A elements
2. f(A, val)  <==> f(x -> x == val)
3. f(A)       <==> f(x -> x != 0)

`findnext` and `findfirst` already have them, `count` had only 1. (and 3. via `countnz`), `find` had 1. and 3.
- I started applying the same for `any` and `all`, but then it is conflicting with `any(A, dims)` taking dimensions. This seems OK to leave it as it is (at least for `any(A, value)` <==> `value in A`).
- if `A` is a `Dict`, I chose to interpret `filter(A, value)` as comparing `value` to the values of `A`, not its keys. But then `Regex` makes the opposite choice, which I find surprising: `filter!(r::Regex, d::Dict) = filter!((k,v)->ismatch(r,k),d)`. WDYT?
- `findn` and `findnz` would be happy to have those methods added too, but `findnz` looks like it finds non-zeros, so it should be renamed in this case. What does the `n` in `findn` stand for?

If this makes sense, I will add some tests before removing WIP. 
