### PR TITLE
additional convert methods for Nullable

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -19,6 +19,8 @@ function convert{S, T}(::Type{Nullable{T}}, x::Nullable{S})
     return isnull(x) ? Nullable{T}() : Nullable(convert(T, get(x)))
 end
 
+convert{T}(::Type{Nullable{T}}, x::T) = Nullable{T}(x)
+
 function show{T}(io::IO, x::Nullable{T})
     if x.isnull
         @printf(io, "Nullable{%s}()", repr(T))

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -231,3 +231,15 @@ for T in types
     @test hash(x2) != hash(x4)
     @test hash(x3) != hash(x4)
 end
+
+type TestNType{T}
+    v::Nullable{T}
+end
+
+for T in types
+    x1 = TestNType{T}(Nullable{T}())
+    @test isnull(x1.v)
+    x1.v = one(T)
+    @test !isnull(x1.v)
+    @test get(x1.v, one(T)) === one(T)
+end


### PR DESCRIPTION
Allows for : 

```
julia> type Bar
         a::Nullable{Int}
         b::Nullable{Bool}

         Bar() = new(nothing, nothing)
       end

julia> bar=Bar()
Bar(Nullable{Int64}(),Nullable{Bool}())

julia> bar.a=1
Nullable(1)

julia> bar.a=nothing
Nullable{Int64}()

```

EDIT: The PR has been updated to only support assignment of a non-null value to a Nullable field. See discussion below.
