### PR TITLE
fix repl rsearch with one-char query

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -538,17 +538,17 @@ function history_search(hist::REPLHistoryProvider, query_buffer::IOBuffer, respo
 
     # Alright, first try to see if the current match still works
     a = position(response_buffer) + 1
-    b = a + sizeof(searchdata) - 1
-    if !skip_current && (0 < a <= b <= response_buffer.size) &&
-       searchdata == bytestring(response_buffer.data[a:b])
-        return true
-    end
+    b = min(endof(response_str), prevind(response_str, a + sizeof(searchdata)))
 
-    searchfunc, searchstart = backwards ? (rsearch, b-1) : (search, a+1)
+    !skip_current && searchdata == response_str[a:b] && return true
+
+    searchfunc, searchstart, skipfunc = backwards ? (rsearch, b, prevind) :
+                                                    (search,  a, nextind)
+    skip_current && (searchstart = skipfunc(response_str, searchstart))
 
     # Start searching
     # First the current response buffer
-    if 1 <= searchstart <= length(response_str)
+    if 1 <= searchstart <= endof(response_str)
         match = searchfunc(response_str, searchdata, searchstart)
         if match != 0:-1
             seek(response_buffer, first(match)-1)

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -544,12 +544,12 @@ function history_search(hist::REPLHistoryProvider, query_buffer::IOBuffer, respo
         return true
     end
 
-    searchfunc,delta = backwards ? (rsearch,0) : (search,1)
+    searchfunc, searchstart = backwards ? (rsearch, b-1) : (search, a+1)
 
     # Start searching
     # First the current response buffer
-    if 1 <= a+delta <= length(response_str)
-        match = searchfunc(response_str, searchdata, a+delta)
+    if 1 <= searchstart <= length(response_str)
+        match = searchfunc(response_str, searchdata, searchstart)
         if match != 0:-1
             seek(response_buffer, first(match)-1)
             return true

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -281,6 +281,17 @@ begin
     @test LineEdit.mode(s) == shell_mode
     @test buffercontents(LineEdit.buffer(s)) == "ll"
 
+    # Test that searching backwards with a one-letter query doesn't
+    # return indefinitely the same match.
+    LineEdit.enter_search(s, histp, true)
+    write(ss.query_buffer, "l")
+    LineEdit.update_display_buffer(ss, ss)
+    LineEdit.history_next_result(s, ss)
+    LineEdit.update_display_buffer(ss, ss)
+    LineEdit.accept_result(s, histp)
+    @test LineEdit.mode(s) == repl_mode
+    @test buffercontents(LineEdit.buffer(s)) == "shell"
+
     # Issue #7551
     # Enter search mode and try accepting an empty result
     REPL.history_reset_state(hp)


### PR DESCRIPTION
The backward i-search needs to set the "start" parameter of rsearch
to the end (minus 1) of the current search window.
This fixes e.g.:
- searching backwards only one character remains stuck on the same match
- searching backwards 'aaa' skips one of the matches in 'aaaa'
