### PR TITLE
Add --noinline startup option

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -34,6 +34,26 @@ end
 
 inference_stack = EmptyCallStack()
 
+# Julia compiler options struct (see jl_compileropts_t in src/julia.h)
+immutable JLCompilerOpts
+    julia_home::Ptr{Cchar}
+    julia_bin::Ptr{Cchar}
+    build_path::Ptr{Cchar}
+    image_file::Ptr{Cchar}
+    cpu_target::Ptr{Cchar}
+    code_coverage::Int8
+    malloc_log::Int8
+    check_bounds::Int8
+    dumpbitcode::Int8
+    int_literals::Cint
+    compile_enabled::Int8
+    opt_level::Int8
+    depwarn::Int8
+    can_inline::Int8
+end
+
+compileropts() = unsafe_load(cglobal(:jl_compileropts, JLCompilerOpts))
+
 function is_static_parameter(sv::StaticVarInfo, s::Symbol)
     sp = sv.sp
     for i=1:2:length(sp)
@@ -1554,9 +1574,11 @@ function typeinf(linfo::LambdaStaticData,atypes::Tuple,sparams::Tuple, def, cop)
 
     if !rec
         @assert fulltree.args[3].head === :body
-        fulltree.args[3] = inlining_pass(fulltree.args[3], sv, fulltree)[1]
-        # inlining can add variables
-        sv.vars = append_any(f_argnames(fulltree), fulltree.args[2][1])
+        if compileropts().can_inline == 1
+            fulltree.args[3] = inlining_pass(fulltree.args[3], sv, fulltree)[1]
+            # inlining can add variables
+            sv.vars = append_any(f_argnames(fulltree), fulltree.args[2][1])
+        end
         tuple_elim_pass(fulltree)
         tupleref_elim_pass(fulltree.args[3], sv)
         linfo.inferred = true

--- a/base/util.jl
+++ b/base/util.jl
@@ -242,25 +242,6 @@ end
 warn(err::Exception; prefix="ERROR: ", kw...) =
     warn(sprint(io->showerror(io,err)), prefix=prefix; kw...)
 
-# Julia compiler options struct (see jl_compileropts_t in src/julia.h)
-immutable JLCompilerOpts
-    julia_home::Ptr{Cchar}
-    julia_bin::Ptr{Cchar}
-    build_path::Ptr{Cchar}
-    image_file::Ptr{Cchar}
-    cpu_target::Ptr{Cchar}
-    code_coverage::Int8
-    malloc_log::Int8
-    check_bounds::Int8
-    dumpbitcode::Int8
-    int_literals::Cint
-    compile_enabled::Int8
-    opt_level::Int8
-    depwarn::Int8
-end
-
-compileropts() = unsafe_load(cglobal(:jl_compileropts, JLCompilerOpts))
-
 function julia_cmd(julia=joinpath(JULIA_HOME, "julia"))
     opts = compileropts()
     cpu_target = bytestring(opts.cpu_target)

--- a/src/init.c
+++ b/src/init.c
@@ -101,6 +101,7 @@ jl_compileropts_t jl_compileropts = { NULL, // julia_home
                                       JL_COMPILEROPT_COMPILE_DEFAULT,
                                       0,    // opt_level
                                       1,    // depwarn
+                                      1     // can_inline
 };
 
 int jl_boot_file_loaded = 0;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1331,6 +1331,7 @@ typedef struct {
     int8_t compile_enabled;
     int8_t opt_level;
     int8_t depwarn;
+    int8_t can_inline;
 } jl_compileropts_t;
 
 extern DLLEXPORT jl_compileropts_t jl_compileropts;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -72,6 +72,7 @@ static const char *opts =
     " --track-allocation={none|user|all}\n"
     "                          Count bytes allocated by each source line\n"
     " --check-bounds={yes|no}  Emit bounds checks always or never (ignoring declarations)\n"
+    " --inline={yes|no}        Control whether inlining is permitted (even for functions declared as @inline)\n"
     " -O, --optimize           Run time-intensive code optimizations\n"
     " --int-literals={32|64}   Select integer literal size independent of platform\n"
     " --dump-bitcode={yes|no}  Dump bitcode for the system image (used with --build)\n"
@@ -95,6 +96,7 @@ void parse_opts(int *argcp, char ***argvp)
         { "dump-bitcode",  required_argument, 0, 302 },
         { "compile",       required_argument, 0, 303 },
         { "depwarn",       required_argument, 0, 304 },
+        { "inline",        required_argument, 0, 305 },
         { 0, 0, 0, 0 }
     };
     int c;
@@ -195,6 +197,16 @@ void parse_opts(int *argcp, char ***argvp)
                 jl_compileropts.depwarn = 0;
             else {
                 ios_printf(ios_stderr, "julia: invalid argument to --depwarn (%s)\n", optarg);
+                exit(1);
+            }
+            break;
+        case 305:      /* inline */
+            if (!strcmp(optarg,"yes"))
+                jl_compileropts.can_inline = 1;
+            else if (!strcmp(optarg,"no"))
+                jl_compileropts.can_inline = 0;
+            else {
+                ios_printf(ios_stderr, "julia: invalid argument to --inline (%s)\n", optarg);
                 exit(1);
             }
             break;


### PR DESCRIPTION
Inlining (one of my favorite performance features of julia) can make debugging harder. This adds a `--noinline` startup option so you can turn it off. This was inspired by https://github.com/timholy/Images.jl/issues/232#issuecomment-66901770.

Demo (I temporarily commented out the line that fixed that issue): with regular startup,

``` julia
julia> using Images, Color, FixedPointNumbers
# ambiguity warning suppressed

julia> img = Image(reinterpret(Gray{Ufixed16}, rand(Uint16, 5, 5)))
Gray Images.Image with:
  data: 5x5 Array{Images.ColorTypes.Gray{FixedPointNumbers.UfixedBase{UInt16,16}},2}
  properties:

julia> imgs = subim(img, :, :)
Gray Images.Image with:
  data: 5x5 SubArray{Images.ColorTypes.Gray{FixedPointNumbers.UfixedBase{UInt16,16}},2,Array{Images.ColorTypes.Gray{FixedPointNumbers.UfixedBase{UInt16,16}},2},(Colon,Colon),2}
  properties:

julia> map(ScaleAutoMinMax(RGB24), imgs)
ERROR: reinterpret: expected bits type as first argument
 in map! at /home/tim/.julia/v0.4/Images/src/map.jl:336
 in map at /home/tim/.julia/v0.4/Images/src/map.jl:311
```

With `--noinline`:

``` julia
julia> using Images, Color, FixedPointNumbers
# ambiguity warning suppressed

julia> img = Image(reinterpret(Gray{Ufixed16}, rand(Uint16, 5, 5)))
Gray Images.Image with:
  data: 5x5 Array{Images.ColorTypes.Gray{FixedPointNumbers.UfixedBase{UInt16,16}},2}
  properties:

julia> imgs = subim(img, :, :)
Gray Images.Image with:
  data: 5x5 SubArray{Images.ColorTypes.Gray{FixedPointNumbers.UfixedBase{UInt16,16}},2,Array{Images.ColorTypes.Gray{FixedPointNumbers.UfixedBase{UInt16,16}},2},(Colon,Colon),2}
  properties:

julia> map(ScaleAutoMinMax(RGB24), imgs)
ERROR: reinterpret: expected bits type as first argument
 in reinterpret at base.jl:64
 in minfinite at /home/tim/.julia/v0.4/Images/src/algorithms.jl:164
 in call at /home/tim/.julia/v0.4/Images/src/map.jl:161
 in take at /home/tim/.julia/v0.4/Images/src/map.jl:347
 in map! at /home/tim/.julia/v0.4/Images/src/map.jl:336
 in map at /home/tim/.julia/v0.4/Images/src/map.jl:311
 in eval at no file
```

See how much easier it is debugging it this way? I especially like the fact that I wouldn't have had to use the "add @show statements"/"restart"/"reload Images (10s)" so many times.
