### PR TITLE
RFC: Fail fast on AppVeyor for repeated commits to the same PR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ cache:
   - llvm-3.3-i686-w64-mingw32-juliadeps.7z
   - llvm-3.3-x86_64-w64-mingw32-juliadeps.7z
   - make-3.81-2-msys-1.0.11-bin.tar.lzma
+  - jq.exe
 
 build_script:
 # Remove C:\MinGW\bin from the path, the version of MinGW installed on

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -9,6 +9,22 @@ cd `dirname "$0"`/../..
 # Stop on error
 set -e
 
+# Fail fast on AppVeyor if there are newer pending commits in this PR
+curlflags="curl --retry 10 -k -L -y 5"
+if [ -n "$APPVEYOR_PULL_REQUEST_NUMBER" ]; then
+  # download a handy cli json parser
+  if ! [ -e jq.exe ]; then
+    $curlflags -O http://stedolan.github.io/jq/download/win64/jq.exe
+  fi
+  av_api_url="https://ci.appveyor.com/api/projects/StefanKarpinski/julia/history?recordsNumber=50"
+  query=".builds | map(select(.pullRequestId == \"$APPVEYOR_PULL_REQUEST_NUMBER\"))[0].buildNumber"
+  latestbuild="$(curl $av_api_url | ./jq "$query")"
+  if [ -n "$latestbuild" -a "$latestbuild" != "null" -a "$latestbuild" != "$APPVEYOR_BUILD_NUMBER" ]; then
+    echo "There are newer queued builds for this pull request, failing early."
+    exit 1
+  fi
+fi
+
 # If ARCH environment variable not set, choose based on uname -m
 if [ -z "$ARCH" -a -z "$XC_HOST" ]; then
   export ARCH=`uname -m`
@@ -60,8 +76,6 @@ case $(uname) in
     SEVENZIP="7z"
     ;;
 esac
-
-curlflags="curl --retry 10 -k -L -y 5"
 
 # Download most recent Julia binary for dependencies
 if ! [ -e julia-installer.exe ]; then


### PR DESCRIPTION
To cut down on queue times. Opening this to test a few things.

AppVeyor runs:

```
git fetch -q origin +refs/pull/$APPVEYOR_PULL_REQUEST_NUMBER/merge:
git checkout -qf FETCH_HEAD
```

at the start of a PR build. For queued builds to master we would need some more complicated logic but we might want to build every commit to master separately anyway.

The simple version of this (just checking `$APPVEYOR_REPO_COMMIT` against `git rev-parse HEAD`) won't work if there's a new commit to master between the time the build gets queued and the time the build starts running, regardless of whether there are any newer commits to the PR branch.
