### PR TITLE
Simplified printing of Nullable objects

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -21,9 +21,9 @@ end
 
 function show{T}(io::IO, x::Nullable{T})
     if x.isnull
-        @printf(io, "Nullable{%s}()", repr(T))
+        @printf(io, "NULL")
     else
-        @printf(io, "Nullable(%s)", repr(x.value))
+        show(io, x.value)
     end
 end
 


### PR DESCRIPTION
Before:

``` julia
julia> Nullable{Int}()
Nullable{Int}()

julia> Nullable{Int}(1)
Nullable(1)
```

After:

``` julia
julia> Nullable{Int}()
NULL

julia> Nullable{Int}(1)
1
```

I'm not sure how we should Nullables, but this simplified printing makes working with Nullables much more enjoyable (when you already know that you're dealing with a potential source of Nullables).
