### PR TITLE
RFC: Missing values by Sentinels

### DIFF
--- a/base/sentinels.jl
+++ b/base/sentinels.jl
@@ -1,0 +1,158 @@
+# TODO
+# Comprehensive arithmetic operators
+# Comprehensive elementary math functions
+# Many cases of Number should actually be {Bool, Int32, ...} for all Optionable types
+# Subclass Option <: Number - this causes many ambiguities
+#   zero, one, inverse functions after Number subclass
+
+import Base
+import Base.show
+import Base.sin
+import Base.promote_rule
+import Base.convert
+
+immutable Option{T<:Number}
+    val::T
+end
+
+const _na_bool = 2
+const _na_int32 = -2147483648               # Smallest integer
+const _na_int64 = -9223372036854775808      # Smallest integer
+const _na_float32 = 0x7f8007a2              # NaN + 1954 mantissa
+const _na_float64 = 0x7ff00000000007a2      # NaN + 1954 mantissa
+
+NAof(::Bool) = _na_bool
+NAof(::Int32) = _na_int32
+NAof(::Int64) = _na_int64
+NAof(::Float32) = _na_float32
+NAof(::Float64) = _na_float64
+NAof(x::Complex) = Complex(NAof(x.real), NAof(x.imag))
+
+isNA(v::Any) = false
+isNA(v::Option) = v.val == NAof(v.val)
+
+
+function show(io::IO, x::Option)
+    if isNA(x)
+        print(io, "NA")
+    else
+        show(io, x.val)
+    end
+end
+
+
+function convert{T<:Number}(::Type{Option{T}}, x::Number)
+    if x == NAof(x)  # This should be very rare
+        throw(TypeError("Value overlaps with NA sentinel value"))
+    else
+        return Option{T}(x)
+    end
+end
+
+
+# Not certain if all of these are necessary
+promote_rule{T<:Number, S<:Number}(::Type{Option{T}}, ::Type{Option{S}}) =
+    Option{promote_rule(T, S)}
+promote_rule{T<:Number, S<:Number}(::Type{T}, ::Type{Option{S}}) =
+    Option{promote_rule(T, S)}
+promote_rule{T<:Number, S<:Number}(::Type{Option{T}}, ::Type{S}) =
+    Option{promote_rule(T, S)}
+
+
+# Remove NA values from an Option array
+# > x = Array{Option{Int32}}([1, 2, NA, 4])
+# > nonnull(x)
+# [1, 2, 4]
+function nonnull{T}(arr::Array{Option{T}})
+    result = Array{T}([])
+    for item in x
+        if !isNA(item)
+            push!(result, item.val)
+        end
+    end
+    return result
+end
+
+
+# Fill an Option array with concrete values
+# > x = Array{Option{Int32}}([1, 2, NA, 4])
+# > fill(x, -1)
+# [1, 2, -1, 4]
+function fill{T, S}(arr::Array{Option{T}}, fillvalue::S)
+    result = Array{promote_type(T, S)}([])
+    for item in x
+        if isNA(item)
+            push!(result, fillvalue)
+        else
+            push!(result, item.val)
+        end
+    end
+    return result
+end
+
+
+# Arithmetic binary operators
+^(x::Option, y::Integer) = isNA(x) ? x : $op(x.val, y)  # To avoid an ambiguity
+for op in [:+, :-, :/, :*, :^, :%]
+    @eval function $op(x::Option, y::Option)  # and make sure this is replicated
+        if isNA(x)
+            return x
+        elseif isNA(y)
+            return y
+        else
+            return Option($op(x.val, y.val))
+        end
+    end
+    @eval $op(x::Option, y::Number) = isNA(x) ? x : Option($op(x.val, y))
+    @eval $op(x::Number, y::Option) = isNA(y) ? y : Option($op(x, y.val))
+end
+
+
+# Boolean binary operators
+for op in [:(Base.(:(==))), :(Base.(:(<=))), :(Base.(:(>=))), :(Base.(:(<))),
+    :(Base.(:(>)))]
+    @eval function $op(x::Option, y::Option)  # and make sure this is replicated
+        if isNA(x) | isNA(y)
+            result = NA_Bool
+        else
+            result = x.val == y.val
+        end
+        return Option(result)
+    end
+    @eval $op(x::Option, y::Number) = isNA(x) ? x : Option{Bool}($op(x.val, y))
+    @eval $op(x::Number, y::Option) = isNA(y) ? y : Option{Bool}($op(x, y.val))
+end
+
+
+# Unary operators
+!(x::Option{Bool}) = isNA(x) ? x : Option{Bool}(!x.val)
+-(x::Option{Number}) = isNA(x) ? x : Option(-x.val)
+
+
+# Mathematical Unary Functions -- TODO: need more extensive list
+for op in [:(Base.sin), :(Base.cos), :(Base.tan), :(Base.exp), :(Base.log)]
+    @eval $op(x::Option) = isNA(x) ? x : Option($op(x.val))
+end
+
+
+const NA_Bool = Option{Bool}(_na_bool)
+const NA_Int32 = Option{Int32}(_na_int32)
+const NA_Int64 = Option{Int64}(_na_int64)
+const NA_Float32 = Option{Float32}(_na_float32)
+const NA_Float64 = Option{Float64}(_na_float64)
+
+
+# Singleton NA value
+# x = Array{Option{Int32}}([1, 2, NA, 4])
+# Should this share an abstract `Optional` type with `Option`?
+immutable NA_Type end
+
+const NA = NA_Type()
+isNA(::NA_Type) = true
+
+promote_rule{T}(::Type{NA_Type}, ::Type{Option{T}}) = Option{T}
+
+convert{T}(::Type{Option{T}}, ::NA_Type) = Option{T}(NAof(T(0)))
+function show(io::IO, x::NA_Type)
+    print(io, "NA")
+end


### PR DESCRIPTION
Here is a draft for missing value support by sentinels.  This is my first real go at Julia so I suspect I'm doing many things badly.  Still, hopefully the general design is sound.  More on missing bits at the end of this comment.  Work was done with @dchudz.

Sentinels represent missing values (NA) by rarely used values within the domain of a datatype.  In particular we use the following values for the following types:
- `Bool`: The integer 2
- `Float32/64`: The exponent signalling `NaN` and the mantissa 1954 (the birth year of an R creator)
- `Int32/64`: The minimum integer -2**31/63 + 1
- `Complex`: The float definition of `NA` for both real and imaginary parts

We extend arithmetic and mathematical operations to respect the new semantics of these special values.  Each operation is now accompanied by an `isNA` check.

The choice of sentinel values here agrees with the choices made by the R language and subsequently by the DyND project in Python (cc @mwiebe) ([article on R sentinels](http://www.markvanderloo.eu/yaRb/2012/07/08/representation-of-numerical-nas-in-r-and-the-1954-enigma/).)

Adopting this as a cross-language standard for missing values might be of some use.
## Example

``` julia

julia> x = Option(1)
1

julia> x + 3.14
4.140000000000001

julia> typeof(x + 3.14)
Option{Float64}

julia> x = Array{Option{Int32}}([1, 2, NA, 4])
4-element Array{Option{Int32},1}:
 1
 2
 NA
 4

julia> x[4] = NA
NA

julia> x
4-element Array{Option{Int32},1}:
 1
 2
 NA
 NA

julia> mean(x)
NA

julia> mean(nonnull(x))
1.5
```
## Issues

I have no idea if this is an appropriate solution for missing values in Julia.  `DataArray` (masked arrays) and `Nullable` (explicitly boxed) are two other fine solutions in various contexts.  This is just a third.

If this is an appropriate solution then certainly my implementation could use a lot of work.  In particular
1.  Option should be a subtype of Number.  When I do this I run into a large number of dispatch ambiguities.
2.  We need to extend all elementary mathematical functions.  Is there a list in Base somewhere?  DataArray has such a list.  It'd be nice if that were moved somewhere closer to core.
3.  I haven't yet invested in learning how to properly test while developing in Julia.  As a result there are no tests.
4.  In many cases when we use `Number` we really mean `{Int32, Int64, Float32, Float64, ...}` all of the Optionable types.  `Option` does not extend to non-primitive numeric types.
5.  The singleton `NA` could use better interaction with promotion rules and such.

Also, presumably people have discussed this before.  I'm coming into this without much context.  My apologies.
