### PR TITLE
fix incorrect rsearchindex with utf8 query

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -441,10 +441,11 @@ function rsearchindex(s::ByteString, t::ByteString)
 end
 
 function rsearchindex(s::ByteString, t::ByteString, i::Integer)
-    if length(t) == 1
+    l = length(t)
+    if l == 1
         rsearch(s, t[1], i)
     else
-        rsearchindex(s.data, t.data, i)
+        rsearchindex(s.data, t.data, l==0 ? i : nextind(s, i)-1)
     end
 end
 
@@ -1729,4 +1730,3 @@ pointer{T<:ByteString}(x::SubString{T}, i::Integer) = pointer(x.string.data) + x
 pointer(x::Union(UTF16String,UTF32String), i::Integer) = pointer(x)+(i-1)*sizeof(eltype(x.data))
 pointer{T<:Union(UTF16String,UTF32String)}(x::SubString{T}) = pointer(x.string.data) + x.offset*sizeof(eltype(x.data))
 pointer{T<:Union(UTF16String,UTF32String)}(x::SubString{T}, i::Integer) = pointer(x.string.data) + (x.offset + (i-1))*sizeof(eltype(x.data))
-

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -742,6 +742,12 @@ u = SubString(str, 1, 5)
 @test rsearch(u, 'z') == 0
 @test rsearch(u, "ll") == 3:4
 
+# rsearch with a two utf8-characters query (issue #9365)
+@test rsearch("ééé", "éé") == 3:5
+@test rsearchindex("ééé", "éé", endof("ééé")) == 3
+@test rsearch("€€€", "€€") == 4:7
+@test rsearchindex("€€€", "€€", endof("€€€")) == 4
+
 # quotes + interpolation (issue #455)
 @test "$("string")" == "string"
 arr = ["a","b","c"]


### PR DESCRIPTION
Disclaimer: I don't know much about UTF8, so am not sure it's the good fix.

In `rsearchindex(s::ByteString, t::ByteString, i::Integer)`, the call to
`rsearchindex` on the underlying data must account for the possibility
that `s[i]` is a non-ASCII character, i.e. `i` must be augmented to
reference the last byte of `s[i]`.
