### PR TITLE
Experimental: Drop unique entry requirement on prefix searching.

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -483,7 +483,7 @@ function history_move_prefix(s::LineEdit.PrefixSearchState,
     max_idx = length(hist.history)+1
     idxs = backwards ? ((cur_idx-1):-1:1) : ((cur_idx+1):max_idx)
     for idx in idxs
-        if (idx == max_idx) || (beginswith(hist.history[idx], prefix) && (hist.history[idx] != cur_response || hist.modes[idx] != LineEdit.mode(s)))
+        if (idx == max_idx) || beginswith(hist.history[idx], prefix)
             history_move(s, hist, idx)
             if length(prefix) == 0
                 # on empty prefix search, move cursor to the end


### PR DESCRIPTION
Following discussion in #8468, this PR removes the prefix search feature of skipping entries that are identical to the current input. It is nice feature when you want it, but it also hides sections of history. I believe the current behavior is to blame for the perception of dropped history entries.

Having played with this for a little while, I can say I immediately miss the "old" behavior, mainly because when you hit a section of identical input, there is no visual indication that your input did anything. So, I think if we want to actually adopt this, we will need to think of some UI modification to indicate action without change.

CC @timholy 
