### PR TITLE
Update networking-and-streams.rst

### DIFF
--- a/doc/manual/networking-and-streams.rst
+++ b/doc/manual/networking-and-streams.rst
@@ -34,7 +34,7 @@ data to be read as the second argument. For example, to read a simple byte array
      0x00
      0x00
 
-    julia> read(STDIN,x)
+    julia> read!(STDIN,x)
     abcd 
     4-element Array{UInt8,1}:
      0x61


### PR DESCRIPTION
`read(stream, array)` is deprecated in favor of `read!()`
