### PR TITLE
added isless() for IPAddrs - enables sorting and comparisons

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -1,6 +1,9 @@
 ## IP ADDRESS HANDLING ##
 abstract IPAddr
 
+
+Base.isless{T<:IPAddr}(a::T, b::T) = isless(a.host, b.host)
+
 immutable IPv4 <: IPAddr
     host::UInt32
     IPv4(host::UInt32) = new(host)

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -17,6 +17,12 @@
 
 @test ip"0:0:0:0:0:ffff:127.0.0.1" == IPv6(0xffff7f000001)
 
+# isless and comparisons
+@test ip"1.2.3.4" < ip"1.2.3.7" < ip"2.3.4.5"
+@test ip"1.2.3.4" >= ip"1.2.3.4" >= ip"1.2.3.1"
+@test isless(ip"1.2.3.4", ip"1.2.3.5")
+@test_throws MethodError sort[ip"2.3.4.5", ip"1.2.3.4", ip"2001:1:2::1"]
+
 # RFC 5952 Compliance
 
 @test repr(ip"2001:db8:0:0:0:0:2:1") == "ip\"2001:db8::2:1\""


### PR DESCRIPTION
Hi -

Following on `IPAddr` enhancements, I'd appreciate consideration of this PR. Because `IPAddr.host` is `UInt32` for v4 and `UInt128` for v6, we can implement `isless()` for the addresses themselves. This will allow rapid sorting of arrays of `IPAddr` types.
