### PR TITLE
re-enable full typeinf

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1261,10 +1261,6 @@ function typeinf(linfo::LambdaStaticData,atypes::Tuple,sparams::Tuple, def, cop)
             end
         end
     end
-    # TODO: typeinf currently gets stuck without this
-    if linfo.name === :abstract_interpret || linfo.name === :tuple_elim_pass || linfo.name === :abstract_call_gf
-        return (linfo.ast, Any)
-    end
 
     ast0 = def.ast
 


### PR DESCRIPTION
This reverts a temporary change introduced by @JeffBezanson in 51a30691c50a86542ac9b0ba052017bb66df9d77. Bootstraps cleanly and all tests pass on x86_64-linux

It looks like this change was only intended to be temporary while the constructor/call change was being implemented.
