### PR TITLE
Implement `@fastmath`

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -242,6 +242,24 @@ macro inbounds(blk)
     :(@boundscheck false $(esc(blk)))
 end
 
+function make_fastmath(expr)
+    if isa(expr, Expr)
+        Expr(make_fastmath(expr.head), map(make_fastmath, expr.args)...)
+    elseif expr==:+; :add_fast
+    elseif expr==:-; :sub_fast
+    elseif expr==:*; :mul_fast
+    elseif expr==:/; :div_fast
+    elseif expr==:rem; :rem_fast
+    elseif expr==:mod; :mod_fast
+    elseif expr==:cmp; :cmp_fast
+    else expr
+    end
+end
+
+macro fastmath(expr)
+    make_fastmath(esc(expr))
+end
+
 macro label(name::Symbol)
     Expr(:symboliclabel, name)
 end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -464,6 +464,15 @@ export
     √,
     ∛,
 
+# fast math
+    add_fast,
+    sub_fast,
+    mul_fast,
+    div_fast,
+    rem_fast,
+    mod_fast,
+    cmp_fast,
+
 # specfun
     airy,
     airyai,
@@ -1417,6 +1426,7 @@ export
     @deprecate,
     @boundscheck,
     @inbounds,
+    @fastmath,
     @simd,
     @label,
     @goto,

--- a/base/float.jl
+++ b/base/float.jl
@@ -204,6 +204,35 @@ widen(::Type{Float32}) = Float64
 rem(x::Float32, y::Float32) = box(Float32,rem_float(unbox(Float32,x),unbox(Float32,y)))
 rem(x::Float64, y::Float64) = box(Float64,rem_float(unbox(Float64,x),unbox(Float64,y)))
 
+# fast versions that may violate strict IEEE semantics
+# TODO: provide isnan_fast and friends
+for (op_fast, op) in ((:add_fast, :+), (:sub_fast, :-),
+                      (:mul_fast, :*), (:div_fast, :/),
+                      (:rem_fast, :rem), (:mod_fast, :mod),
+                      (:cmp_fast, :cmp))
+    @eval begin
+        # fall-back implementation for non-numeric types
+        ($op_fast)(xs...) = ($op)(xs...)
+        # type promotion
+        ($op_fast)(x::Number, y::Number, zs::Number...) =
+            ($op_fast)(promote(x,y,zs...)...)
+        # fall-back implementation that applies after promotion
+        ($op_fast){T<:Number}(x::T,ys::T...) = ($op)(x,ys...)
+    end
+end
+for T in (Float32, Float64)
+    @eval begin
+        sub_fast(x::$T) = box($T,neg_float_fast(unbox($T,x)))
+        add_fast(x::$T, y::$T) = box($T,add_float_fast(unbox($T,x),unbox($T,y)))
+        sub_fast(x::$T, y::$T) = box($T,sub_float_fast(unbox($T,x),unbox($T,y)))
+        mul_fast(x::$T, y::$T) = box($T,mul_float_fast(unbox($T,x),unbox($T,y)))
+        div_fast(x::$T, y::$T) = box($T,div_float_fast(unbox($T,x),unbox($T,y)))
+        rem_fast(x::$T, y::$T) = box($T,rem_float_fast(unbox($T,x),unbox($T,y)))
+        add_fast(x::$T, y::$T, zs::$T...) = add_fast(add_fast(x, y), zs...)
+        mul_fast(x::$T, y::$T, zs::$T...) = mul_fast(mul_fast(x, y), zs...)
+    end
+end
+
 cld{T<:FloatingPoint}(x::T, y::T) = -fld(-x,y)
 
 function mod{T<:FloatingPoint}(x::T, y::T)
@@ -217,6 +246,16 @@ function mod{T<:FloatingPoint}(x::T, y::T)
     end
 end
 
+function mod_fast{T<:FloatingPoint}(x::T, y::T)
+    r = rem_fast(x,y)
+    if r == 0
+        copysign(r,y)
+    elseif (r > 0) $ (y > 0)
+        r+y
+    else
+        r
+    end
+end
 
 ## floating point comparisons ##
 ==(x::Float32, y::Float32) = eq_float(unbox(Float32,x),unbox(Float32,y))
@@ -247,6 +286,9 @@ function cmp(x::FloatingPoint, y::Real)
     isnan(x) && throw(DomainError())
     ifelse(x<y, -1, ifelse(x>y, 1, 0))
 end
+
+cmp_fast(x::Float32, y::Float32) = ifelse(x<y, -1, ifelse(x>y, 1, 0))
+cmp_fast(x::Float64, y::Float64) = ifelse(x<y, -1, ifelse(x>y, 1, 0))
 
 for Ti in (Int64,UInt64,Int128,UInt128)
     for Tf in (Float32,Float64)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -50,6 +50,7 @@ immutable JLCompilerOpts
     opt_level::Int8
     depwarn::Int8
     can_inline::Int8
+    fast_math::Int8
 end
 
 compileropts() = unsafe_load(cglobal(:jl_compileropts, JLCompilerOpts))

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -121,6 +121,11 @@ Enable or disable color text
 Emit bounds checks always or never (ignoring declarations)
 
 .TP
+--math-mode={ieee|user}
+Always use IEEE semantics for math (ignoring declarations),
+or adhere to declarations in source code
+
+.TP
 --int-literals={32|64}
 Select integer literal size independent of platform
 

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -130,6 +130,8 @@ those available for the ``perl`` and ``ruby`` programs::
      --track-allocation={none|user|all}
                               Count bytes allocated by each source line
      --check-bounds={yes|no}  Emit bounds checks always or never (ignoring declarations)
+     --math-mode={ieee|user}  Always use IEEE semantics for math (ignoring declarations),
+                              or adhere to declarations in source code
      -O, --optimize           Run time-intensive code optimizations
      --int-literals={32|64}   Select integer literal size independent of platform
      --dump-bitcode={yes|no}  Dump bitcode for the system image (used with --build)

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -546,6 +546,10 @@ properties.
 -  Use :obj:`@inbounds` to eliminate array bounds checking within expressions.
    Be certain before doing this. If the subscripts are ever out of bounds,
    you may suffer crashes or silent corruption.
+-  Use :obj:`@fastmath` to allow floating point optimizations that are
+   correct for real numbers, but lead to differences for IEEE numbers.
+   Be careful when doing this, as this may change numerical results.
+   This corresponds to the ``-ffast-math`` option of clang.
 -  Write :obj:`@simd` in front of ``for`` loops that are amenable to vectorization.
    **This feature is experimental** and could change or disappear in future
    versions of Julia.

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -554,7 +554,7 @@ properties.
    **This feature is experimental** and could change or disappear in future
    versions of Julia.
 
-Here is an example with both forms of markup::
+Here is an example with both :obj:`@inbounds` and :obj:`@simd` markup::
 
     function inner( x, y )
         s = zero(eltype(x))
@@ -624,6 +624,95 @@ properties:
 -  In some simple cases, for example with 2-3 arrays accessed in a loop, the
    LLVM auto-vectorization may kick in automatically, leading to no further
    speedup with :obj:`@simd`.
+
+Here is an example with all three kinds of markup. This program first
+calculates the finite difference of a one-dimensional array, and then
+evaluates the L2-norm of the result::
+
+    function init!(u)
+        n = length(u)
+        dx = 1.0 / (n-1)
+        @fastmath @inbounds @simd for i in 1:n
+            u[i] = sin(2pi*dx*i)
+        end
+    end
+     
+    function deriv!(u, du)
+        n = length(u)
+        dx = 1.0 / (n-1)
+        @fastmath @inbounds du[1] = (u[2] - u[1]) / dx
+        @fastmath @inbounds @simd for i in 2:n-1
+            du[i] = (u[i+1] - u[i-1]) / (2*dx)
+        end
+        @fastmath @inbounds du[n] = (u[n] - u[n-1]) / dx
+    end
+     
+    function norm(u)
+        n = length(u)
+        T = eltype(u)
+        s = zero(T)
+        @fastmath @inbounds @simd for i in 1:n
+            s += u[i]^2
+        end
+        @fastmath @inbounds return sqrt(s/n)
+    end
+     
+    function main()
+        n = 2000
+        u = Array(Float64, n)
+        init!(u)
+        du = similar(u)
+        
+        deriv!(u, du)
+        nu = norm(du)
+        
+        @time for i in 1:10^6
+            deriv!(u, du)
+            nu = norm(du)
+        end
+        
+        println(nu)
+    end
+     
+    main()
+
+On a computer with a 2.7 GHz Intel Core i7 processor, this produces::
+
+    $ julia wave.jl
+    elapsed time: 1.207814709 seconds (0 bytes allocated)
+    4.443986180758243
+
+    $ julia --math-mode=ieee wave.jl
+    elapsed time: 4.487083643 seconds (0 bytes allocated)
+    4.443986180758243
+
+Here, the option ``--math-mode=ieee`` disables the :opt:`@fastmath`
+macro, so that we can compare results.
+
+In this case, the speedup due to :opt:`@fastmath` is a factor of about
+3.7. This is unusually large -- in general, the speedup will be
+smaller. (In this particular example, the working set of the benchmark
+is small enough to fit into the L1 cache of the processor, so that
+memory access latency does not play a role, and computing time is
+dominated by CPU usage. In many real world programs this is not the
+case.) Also, in this case this optimization does not change the result
+-- in general, the result will be slightly different. In some cases,
+especially for numerically unstable algorithms, the result can be very
+different.
+
+The annotation :opt:`@fastmath` re-arranges floating point
+expressions, e.g. changing the order of evaluation, or assuming that
+certain special cases (inf, nan) cannot occur. In this case (and on
+this particular computer), the main difference is that the expression
+``1 / (2*dx)`` in the function ``deriv`` is hoisted out of the loop
+(i.e. calculated outside the loop), as if one had written ``idx = 1 /
+(2*dx)``. In the loop, the expression ``... / (2*dx)`` then becomes
+``... * idx``, which is much faster to evaluate. Of course, both the
+actual optimization that is applied by the compiler as well as the
+resulting speedup depend very much on the hardware. You can examine
+the change in generated code by using Julia's :obj:`code_native`
+function.
+
 
 .. _man-code-warntype:
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -93,6 +93,7 @@ jl_sym_t *compositetype_sym; jl_sym_t *type_goto_sym;
 jl_sym_t *global_sym; jl_sym_t *tuple_sym;
 jl_sym_t *dot_sym;    jl_sym_t *newvar_sym;
 jl_sym_t *boundscheck_sym; jl_sym_t *copyast_sym;
+jl_sym_t *fastmath_sym;
 jl_sym_t *simdloop_sym; jl_sym_t *meta_sym;
 jl_sym_t *arrow_sym; jl_sym_t *ldots_sym;
 

--- a/src/init.c
+++ b/src/init.c
@@ -97,7 +97,8 @@ jl_compileropts_t jl_compileropts = { NULL, // julia_home
                                       JL_COMPILEROPT_COMPILE_DEFAULT,
                                       0,    // opt_level
                                       1,    // depwarn
-                                      1     // can_inline
+                                      1,    // can_inline
+                                      JL_COMPILEROPT_FAST_MATH_DEFAULT
 };
 
 int jl_boot_file_loaded = 0;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -449,6 +449,9 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
     else if (ex->head == boundscheck_sym) {
         return (jl_value_t*)jl_nothing;
     }
+    else if (ex->head == fastmath_sym) {
+        return (jl_value_t*)jl_nothing;
+    }
     else if (ex->head == simdloop_sym) {
         return (jl_value_t*)jl_nothing;
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3279,6 +3279,7 @@ void jl_init_types(void)
     kw_sym = jl_symbol("kw");
     dot_sym = jl_symbol(".");
     boundscheck_sym = jl_symbol("boundscheck");
+    fastmath_sym = jl_symbol("fastmath");
     newvar_sym = jl_symbol("newvar");
     copyast_sym = jl_symbol("copyast");
     simdloop_sym = jl_symbol("simdloop");

--- a/src/julia.h
+++ b/src/julia.h
@@ -411,6 +411,7 @@ extern jl_sym_t *abstracttype_sym; extern jl_sym_t *bitstype_sym;
 extern jl_sym_t *compositetype_sym; extern jl_sym_t *type_goto_sym;
 extern jl_sym_t *global_sym;  extern jl_sym_t *tuple_sym;
 extern jl_sym_t *boundscheck_sym; extern jl_sym_t *copyast_sym;
+extern jl_sym_t *fastmath_sym;
 extern jl_sym_t *simdloop_sym; extern jl_sym_t *meta_sym;
 extern jl_sym_t *arrow_sym; extern jl_sym_t *ldots_sym;
 
@@ -1327,6 +1328,8 @@ void show_execution_point(char *filename, int lno);
 
 // compiler options -----------------------------------------------------------
 
+// Note: need to keep this in sync with its initialization in
+// src/init.c, and with JLCompilerOpts in base/inference.jl
 typedef struct {
     const char *julia_home;
     const char *julia_bin;
@@ -1342,6 +1345,7 @@ typedef struct {
     int8_t opt_level;
     int8_t depwarn;
     int8_t can_inline;
+    int8_t fast_math;
 } jl_compileropts_t;
 
 extern DLLEXPORT jl_compileropts_t jl_compileropts;
@@ -1354,6 +1358,9 @@ extern DLLEXPORT jl_compileropts_t jl_compileropts;
 #define JL_COMPILEROPT_CHECK_BOUNDS_DEFAULT 0
 #define JL_COMPILEROPT_CHECK_BOUNDS_ON 1
 #define JL_COMPILEROPT_CHECK_BOUNDS_OFF 2
+#define JL_COMPILEROPT_FAST_MATH_DEFAULT 0
+#define JL_COMPILEROPT_FAST_MATH_ON 1
+#define JL_COMPILEROPT_FAST_MATH_OFF 2
 #define JL_COMPILEROPT_COMPILE_DEFAULT 1
 #define JL_COMPILEROPT_COMPILE_OFF 0
 #define JL_COMPILEROPT_COMPILE_ON  1

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -59,6 +59,36 @@
 @test minmax(NaN, 3.) == (3., 3.)
 @test isequal(minmax(NaN, NaN), (NaN, NaN))
 
+# fast math
+const one32 = one(Float32)
+const eps32 = eps(Float32)
+const eps32_2 = eps32/2
+# Note: Cannot use local functions since these are not yet optimized
+fm_ieee_32(x) = x + eps32_2 + eps32_2
+fm_fast_32(x) = @fastmath x + eps32_2 + eps32_2
+@test fm_ieee_32(one32) == one32
+@test (fm_fast_32(one32) == one32 ||
+       fm_fast_32(one32) == one32 + eps32 > one32)
+
+const one64 = one(Float64)
+const eps64 = eps(Float64)
+const eps64_2 = eps64/2
+# Note: Cannot use local functions since these are not yet optimized
+fm_ieee_64(x) = x + eps64_2 + eps64_2
+fm_fast_64(x) = @fastmath x + eps64_2 + eps64_2
+@test fm_ieee_64(one64) == one64
+@test (fm_fast_64(one64) == one64 ||
+       fm_fast_64(one64) == one64 + eps64 > one64)
+
+let epsf = 1.0f0/2^15, one_epsf = 1+epsf
+    @test isapprox((@fastmath one_epsf * one_epsf - 1),
+                   float32(65537/1073741824))
+end
+let eps = 1.0/2^30, one_eps = 1+eps
+    @test isapprox((@fastmath one_eps * one_eps - 1),
+                   2147483649/1152921504606846976)
+end
+
 # lexing typemin(Int64)
 @test (-9223372036854775808)^1 == -9223372036854775808
 @test [1 -1 -9223372036854775808] == [1 -1 typemin(Int64)]

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -86,7 +86,8 @@ void parse_opts(int *argcp, char ***argvp)
 	opt_dump_bitcode,
 	opt_compile,
 	opt_depwarn,
-	opt_inline
+	opt_inline,
+        opt_math_mode
     };
     static const char shortopts[] = "+H:hJ:C:O";
     static const struct option longopts[] = {
@@ -105,6 +106,7 @@ void parse_opts(int *argcp, char ***argvp)
         { "compile",       required_argument, 0, opt_compile },
         { "depwarn",       required_argument, 0, opt_depwarn },
         { "inline",        required_argument, 0, opt_inline },
+        { "math-mode",     required_argument, 0, opt_math_mode },
         { 0, 0, 0, 0 }
     };
     int c;
@@ -215,6 +217,16 @@ void parse_opts(int *argcp, char ***argvp)
                 jl_compileropts.can_inline = 0;
             else {
                 ios_printf(ios_stderr, "julia: invalid argument to --inline (%s)\n", optarg);
+                exit(1);
+            }
+            break;
+        case opt_math_mode:
+            if (!strcmp(optarg, "ieee"))
+                jl_compileropts.fast_math = JL_COMPILEROPT_FAST_MATH_OFF;
+            else if (!strcmp(optarg, "user"))
+                jl_compileropts.fast_math = JL_COMPILEROPT_FAST_MATH_DEFAULT;
+            else {
+                ios_printf(ios_stderr, "julia: invalid argument to --math-mode (%s)\n", optarg);
                 exit(1);
             }
             break;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -73,6 +73,8 @@ static const char opts[] =
     "                          Count bytes allocated by each source line\n"
     " --check-bounds={yes|no}  Emit bounds checks always or never (ignoring declarations)\n"
     " --inline={yes|no}        Control whether inlining is permitted (even for functions declared as @inline)\n"
+    " --math-mode={ieee|user}  Always use IEEE semantics for math (ignoring declarations),\n"
+    "                          or adhere to declarations in source code\n"
     " -O, --optimize           Run time-intensive code optimizations\n"
     " --int-literals={32|64}   Select integer literal size independent of platform\n"
     " --dump-bitcode={yes|no}  Dump bitcode for the system image (used with --build)\n"


### PR DESCRIPTION
This implements a macro `@fastmath` that works similar to `@inbounds`: expressions evaluated this way have LLVM's "fast-math" flag set, which is equivalent to calling clang with the `-ffast-math` option.

I experimented with two different ways to implement this. Both work, but obviously only one of them should be used, the other should be removed again.

**Implementation 1:** Math functions such as `+`, `-` have fast-math equivalent called `add_fast`, `sub_fast`, etc. These have their own intrinsics. A macro `@fastmath` (easy to implement, but not yet done) would convert math operations to their fast form. Advantage: This gives programmers full control over when to use fast math operations, and when not. Disadvantage: The macro needs to convert a parse tree, which may be slow. I believe `@simd` goes this way.

**Implementation 2:** The Julia compiler maintains a global state variable that describes whether fast-math is in effect or not. The `@fastmath` macro (this is how it is currently implemented) toggles this flag. Advantage: Very fast. Disadvantage: Uses global state, I can't tell whether the toggling works at the right times. This is equivalent to how `@inbounds` is working.

Please comment, both on the general idea of having `@fastmath` (I believe there is consensus that this is a good and necessary thing), as well as on the implementations. I will continue to update the branch with suggestions.
