### PR TITLE
Fix typo in markdown BlockQuote rendering (fixes #9409)

### DIFF
--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -22,7 +22,7 @@ function term(io::IO, md::Paragraph, columns)
 end
 
 function term(io::IO, md::BlockQuote, columns)
-  s = sprint(io->term(io, Block(md.content), columns - 10))
+  s = sprint(io->term(io, md.content, columns - 10))
   for line in split(rstrip(s), "\n")
     println(io, " "^margin, "|", line)
   end


### PR DESCRIPTION
I have no idea what I'm doing here, so it would be great if @one-more-minute would review.
