### PR TITLE
Constify char * arguments in various API functions

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -71,7 +71,7 @@ extern "C" DLLEXPORT void jl_read_sonames(void)
     pclose(ldc);
 }
 
-extern "C" DLLEXPORT const char *jl_lookup_soname(char *pfx, size_t n)
+extern "C" DLLEXPORT const char *jl_lookup_soname(const char *pfx, size_t n)
 {
     if (!got_sonames) {
         jl_read_sonames();

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -183,7 +183,7 @@ void *jl_dlsym(jl_uv_libhandle handle, const char *symbol)
 
 #ifdef _OS_WINDOWS_
 //Look for symbols in win32 libraries
-char *jl_dlfind_win32(char *f_name)
+char *jl_dlfind_win32(const char *f_name)
 {
     if (jl_dlsym_e(jl_exe_handle, f_name))
         return (char*)1;

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -75,7 +75,7 @@ DLLEXPORT int jl_uv_dlopen(const char *filename, jl_uv_libhandle lib_, unsigned 
 #endif
 }
 
-static uv_lib_t *jl_load_dynamic_library_(char *modname, unsigned flags, int throw_err)
+static uv_lib_t *jl_load_dynamic_library_(const char *modname, unsigned flags, int throw_err)
 {
     int error;
     char *ext;
@@ -153,17 +153,17 @@ done:
     return handle;
 }
 
-jl_uv_libhandle jl_load_dynamic_library_e(char *modname, unsigned flags)
+jl_uv_libhandle jl_load_dynamic_library_e(const char *modname, unsigned flags)
 {
     return (jl_uv_libhandle) jl_load_dynamic_library_(modname, flags, 0);
 }
 
-jl_uv_libhandle jl_load_dynamic_library(char *modname, unsigned flags)
+jl_uv_libhandle jl_load_dynamic_library(const char *modname, unsigned flags)
 {
     return (jl_uv_libhandle) jl_load_dynamic_library_(modname, flags, 1);
 }
 
-void *jl_dlsym_e(jl_uv_libhandle handle, char *symbol)
+void *jl_dlsym_e(jl_uv_libhandle handle, const char *symbol)
 {
     void *ptr;
     int  error=uv_dlsym((uv_lib_t *) handle, symbol, &ptr);
@@ -171,7 +171,7 @@ void *jl_dlsym_e(jl_uv_libhandle handle, char *symbol)
     return ptr;
 }
 
-void *jl_dlsym(jl_uv_libhandle handle, char *symbol)
+void *jl_dlsym(jl_uv_libhandle handle, const char *symbol)
 {
     void *ptr;
     int  error = uv_dlsym((uv_lib_t *) handle, symbol, &ptr);

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -508,7 +508,7 @@ DLLEXPORT int jl_fs_close(int handle)
 }
 
 //units are in ms
-DLLEXPORT int jl_puts(char *str, uv_stream_t *stream)
+DLLEXPORT int jl_puts(const char *str, uv_stream_t *stream)
 {
     if (!stream) return 0;
     return jl_write(stream,str,strlen(str));

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -22,7 +22,7 @@ DLLEXPORT char * __cdecl basename(char *);
 #include <libgen.h>
 #endif
 
-DLLEXPORT void *jl_eval_string(char *str);
+DLLEXPORT void *jl_eval_string(const char *str);
 
 int jl_is_initialized(void) { return jl_main_module!=NULL; }
 
@@ -32,7 +32,7 @@ int jl_is_initialized(void) { return jl_main_module!=NULL; }
 // Second argument is the path of a system image file (*.ji) relative to the
 // first argument path, or relative to the default julia home dir. The default
 // is something like ../lib/julia/sys.ji
-DLLEXPORT void jl_init_with_image(char *julia_home_dir, char *image_relative_path)
+DLLEXPORT void jl_init_with_image(const char *julia_home_dir, const char *image_relative_path)
 {
     if (jl_is_initialized()) return;
     libsupport_init();
@@ -49,12 +49,12 @@ DLLEXPORT void jl_init_with_image(char *julia_home_dir, char *image_relative_pat
     jl_exception_clear();
 }
 
-DLLEXPORT void jl_init(char *julia_home_dir)
+DLLEXPORT void jl_init(const char *julia_home_dir)
 {
     jl_init_with_image(julia_home_dir, NULL);
 }
 
-DLLEXPORT void *jl_eval_string(char *str)
+DLLEXPORT void *jl_eval_string(const char *str)
 {
     jl_value_t *r;
     JL_TRY {

--- a/src/julia.h
+++ b/src/julia.h
@@ -861,10 +861,10 @@ typedef enum {
     //JL_IMAGE_LIBJULIA = 2,
 } JL_IMAGE_SEARCH;
 DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel);
-DLLEXPORT void jl_init(char *julia_home_dir);
-DLLEXPORT void jl_init_with_image(char *julia_home_dir, char *image_relative_path);
+DLLEXPORT void jl_init(const char *julia_home_dir);
+DLLEXPORT void jl_init_with_image(const char *julia_home_dir, const char *image_relative_path);
 DLLEXPORT int jl_is_initialized(void);
-DLLEXPORT int julia_trampoline(int argc, char *argv[], int (*pmain)(int ac,char *av[]));
+DLLEXPORT int julia_trampoline(int argc, const char *argv[], int (*pmain)(int ac,char *av[]));
 DLLEXPORT void jl_atexit_hook(void);
 DLLEXPORT void NORETURN jl_exit(int status);
 
@@ -885,7 +885,7 @@ jl_value_t *jl_parse_next(void);
 DLLEXPORT jl_value_t *jl_load_file_string(const char *text, char *filename);
 DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr);
 jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr);
-DLLEXPORT void *jl_eval_string(char *str);
+DLLEXPORT void *jl_eval_string(const char *str);
 
 // external libraries
 enum JL_RTLD_CONSTANT {
@@ -899,17 +899,17 @@ enum JL_RTLD_CONSTANT {
 #define JL_RTLD_DEFAULT (JL_RTLD_LAZY | JL_RTLD_DEEPBIND)
 
 typedef void *jl_uv_libhandle; // uv_lib_t* (avoid uv.h dependency)
-DLLEXPORT jl_uv_libhandle jl_load_dynamic_library(char *fname, unsigned flags);
-DLLEXPORT jl_uv_libhandle jl_load_dynamic_library_e(char *fname, unsigned flags);
-DLLEXPORT void *jl_dlsym_e(jl_uv_libhandle handle, char *symbol);
-DLLEXPORT void *jl_dlsym(jl_uv_libhandle handle, char *symbol);
+DLLEXPORT jl_uv_libhandle jl_load_dynamic_library(const char *fname, unsigned flags);
+DLLEXPORT jl_uv_libhandle jl_load_dynamic_library_e(const char *fname, unsigned flags);
+DLLEXPORT void *jl_dlsym_e(jl_uv_libhandle handle, const char *symbol);
+DLLEXPORT void *jl_dlsym(jl_uv_libhandle handle, const char *symbol);
 DLLEXPORT int jl_uv_dlopen(const char *filename, jl_uv_libhandle lib, unsigned flags);
 DLLEXPORT jl_uv_libhandle jl_wrap_raw_dl_handle(void *handle);
-char *jl_dlfind_win32(char *name);
+char *jl_dlfind_win32(const char *name);
 DLLEXPORT int add_library_mapping(char *lib, void *hnd);
 
 #if defined(__linux__) || defined(__FreeBSD__)
-DLLEXPORT const char *jl_lookup_soname(char *pfx, size_t n);
+DLLEXPORT const char *jl_lookup_soname(const char *pfx, size_t n);
 #endif
 
 // compiler
@@ -918,7 +918,7 @@ DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v);
 DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex);
 jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);
 DLLEXPORT jl_value_t *jl_load(const char *fname);
-jl_value_t *jl_parse_eval_all(char *fname);
+jl_value_t *jl_parse_eval_all(const char *fname);
 jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam);
 jl_value_t *jl_interpret_toplevel_thunk_with(jl_lambda_info_t *lam,
                                              jl_value_t **loc, size_t nl);
@@ -1261,7 +1261,7 @@ DLLEXPORT int jl_idle_start(uv_idle_t *idle);
 DLLEXPORT int jl_idle_stop(uv_idle_t *idle);
 
 DLLEXPORT int jl_putc(char c, uv_stream_t *stream);
-DLLEXPORT int jl_puts(char *str, uv_stream_t *stream);
+DLLEXPORT int jl_puts(const char *str, uv_stream_t *stream);
 DLLEXPORT int jl_pututf8(uv_stream_t *s, uint32_t wchar);
 
 DLLEXPORT uv_timer_t *jl_make_timer(uv_loop_t *loop, jl_value_t *julia_struct);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -522,7 +522,7 @@ jl_value_t *jl_toplevel_eval(jl_value_t *v)
 }
 
 // repeatedly call jl_parse_next and eval everything
-jl_value_t *jl_parse_eval_all(char *fname)
+jl_value_t *jl_parse_eval_all(const char *fname)
 {
     //jl_printf(JL_STDERR, "***** loading %s\n", fname);
     int last_lineno = jl_lineno;


### PR DESCRIPTION
This commit constifies some char \* arguments to the jl_\* APIs. It closes issue #9408 
