### PR TITLE
[RFC] Address space preserving bitcasts

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -507,12 +507,28 @@ static Value *literal_pointer_val(jl_binding_t *p)
     return julia_gv("jl_bnd#", p->name, p->owner, p);
 }
 
+static Value *preserving_bitcast(Value *v, Type *jl_value)
+{
+    // bitcast a value, but preserve its address space
+    // note that this is only meaningful for pointer types
+    if (isa<PointerType>(jl_value) &&
+        v->getType()->getPointerAddressSpace() != jl_value->getPointerAddressSpace()) {
+        // Cast to the proper address space
+        Type *jl_value_addr =
+                PointerType::get(cast<PointerType>(jl_value)->getElementType(),
+                                 v->getType()->getPointerAddressSpace());
+        return builder.CreateBitCast(v, jl_value_addr);
+    } else {
+        return builder.CreateBitCast(v, jl_value);
+    }
+}
+
 static Value *julia_binding_gv(jl_binding_t *b)
 {
     // emit a literal_pointer_val to the value field of a jl_binding_t
     // binding->value are prefixed with *
     Value *bv = imaging_mode ?
-        builder.CreateBitCast(julia_gv("*", b->name, b->owner, b), jl_ppvalue_llvmt) :
+        preserving_bitcast(julia_gv("*", b->name, b->owner, b), jl_ppvalue_llvmt) :
         literal_static_pointer_val(b,jl_ppvalue_llvmt);
     return builder.CreateGEP(bv,ConstantInt::get(T_size,
                 offsetof(jl_binding_t,value)/sizeof(size_t)));
@@ -841,7 +857,7 @@ static Value *emit_typeof(Value *p)
 {
     // given p, a jl_value_t*, compute its type tag
     if (p->getType() == jl_pvalue_llvmt) {
-        Value *tt = builder.CreateBitCast(p, jl_ppvalue_llvmt);
+        Value *tt = preserving_bitcast(p, jl_ppvalue_llvmt);
         tt = builder.CreateLoad(emit_typeptr_addr(tt), false);
 #ifdef OVERLAP_SVEC_LEN
         tt = builder.CreateIntToPtr(builder.CreateAnd(
@@ -1080,7 +1096,7 @@ static Value *typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
     if (elty==T_int1) { elty = T_int8; isbool=true; }
     Value *data;
     if (ptr->getType()->getContainedType(0) != elty)
-        data = builder.CreateBitCast(ptr, PointerType::get(elty, 0));
+        data = preserving_bitcast(ptr, PointerType::get(elty, 0));
     else
         data = ptr;
     Value *elt = tbaa_decorate(tbaa, builder.CreateAlignedLoad(builder.CreateGEP(data, idx_0based),
@@ -1113,7 +1129,7 @@ static void typed_store(Value *ptr, Value *idx_0based, Value *rhs,
     }
     Value *data;
     if (ptr->getType()->getContainedType(0) != elty)
-        data = builder.CreateBitCast(ptr, PointerType::get(elty, 0));
+        data = preserving_bitcast(ptr, PointerType::get(elty, 0));
     else
         data = ptr;
     tbaa_decorate(tbaa, builder.CreateAlignedStore(rhs, builder.CreateGEP(data, idx_0based), alignment));
@@ -1215,7 +1231,7 @@ static void jl_add_linfo_root(jl_lambda_info_t *li, jl_value_t *val);
 
 static Value *data_pointer(Value *x)
 {
-    return builder.CreateBitCast(x, jl_ppvalue_llvmt);
+    return preserving_bitcast(x, jl_ppvalue_llvmt);
 }
 
 static Value *emit_getfield_unknownidx(Value *strct, Value *idx, jl_datatype_t *stt, jl_codectx_t *ctx)
@@ -1227,7 +1243,7 @@ static Value *emit_getfield_unknownidx(Value *strct, Value *idx, jl_datatype_t *
             idx = emit_bounds_check(strct, NULL, idx, ConstantInt::get(T_size, nfields), ctx);
             Value *fld = tbaa_decorate(tbaa_user, builder.CreateLoad(
                         builder.CreateGEP(
-                            builder.CreateBitCast(strct, jl_ppvalue_llvmt),
+                            preserving_bitcast(strct, jl_ppvalue_llvmt),
                             idx)));
             if ((unsigned)stt->ninitialized != nfields)
                 null_pointer_check(fld, ctx);
@@ -1292,11 +1308,11 @@ static Value *emit_getfield_knownidx(Value *strct, unsigned idx, jl_datatype_t *
     Value *fldv = NULL;
     if (strct->getType() == jl_pvalue_llvmt) {
         Value *addr =
-            builder.CreateGEP(builder.CreateBitCast(strct, T_pint8),
+            builder.CreateGEP(preserving_bitcast(strct, T_pint8),
                               ConstantInt::get(T_size, jl_field_offset(jt,idx)));
         MDNode *tbaa = jt->mutabl ? tbaa_user : tbaa_immut;
         if (jl_field_isptr(jt,idx)) {
-            Value *fldv = tbaa_decorate(tbaa, builder.CreateLoad(builder.CreateBitCast(addr,jl_ppvalue_llvmt)));
+            Value *fldv = tbaa_decorate(tbaa, builder.CreateLoad(preserving_bitcast(addr,jl_ppvalue_llvmt)));
             if (idx >= (unsigned)jt->ninitialized)
                 null_pointer_check(fldv, ctx);
             return fldv;
@@ -1371,7 +1387,7 @@ static Value *emit_arraylen_prim(Value *t, jl_value_t *ty)
 #ifdef LLVM37
                                           nullptr,
 #endif
-                                          builder.CreateBitCast(t,jl_parray_llvmt),
+                                          preserving_bitcast(t,jl_parray_llvmt),
                                           1); //index (not offset) of length field in jl_parray_llvmt
 
     return tbaa_decorate(tbaa_arraylen, builder.CreateLoad(addr, false));
@@ -1409,7 +1425,7 @@ static Value *emit_arrayptr(Value *t)
 #ifdef LLVM37
                                           nullptr,
 #endif
-                                          builder.CreateBitCast(t,jl_parray_llvmt),
+                                          preserving_bitcast(t,jl_parray_llvmt),
                                           0); //index (not offset) of data field in jl_parray_llvmt
 
     return tbaa_decorate(tbaa_arrayptr, builder.CreateLoad(addr, false));
@@ -1443,7 +1459,7 @@ static Value *emit_arrayflags(Value *t, jl_codectx_t *ctx)
 
 static void assign_arrayvar(jl_arrayvar_t &av, Value *ar)
 {
-    tbaa_decorate(tbaa_arrayptr,builder.CreateStore(builder.CreateBitCast(emit_arrayptr(ar),
+    tbaa_decorate(tbaa_arrayptr,builder.CreateStore(preserving_bitcast(emit_arrayptr(ar),
                                                     av.dataptr->getType()->getContainedType(0)),
                                                     av.dataptr));
     builder.CreateStore(emit_arraylen_prim(ar, av.ty), av.len);
@@ -1528,9 +1544,9 @@ static Value *tpropagate(Value *a, Value *b)
 
 static Value *init_bits_value(Value *newv, Value *jt, Type *t, Value *v)
 {
-    builder.CreateStore(jt, builder.CreateBitCast(emit_typeptr_addr(newv), jl_ppvalue_llvmt));
+    builder.CreateStore(jt, preserving_bitcast(emit_typeptr_addr(newv), jl_ppvalue_llvmt));
     // TODO: stricter alignment if possible
-    builder.CreateAlignedStore(v, builder.CreateBitCast(data_pointer(newv), PointerType::get(t,0)), sizeof(void*));
+    builder.CreateAlignedStore(v, preserving_bitcast(data_pointer(newv), PointerType::get(t,0)), sizeof(void*));
     return newv;
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3402,9 +3402,9 @@ static void allocate_gc_frame(size_t n_roots, BasicBlock *b0, jl_codectx_t *ctx)
     ctx->argTemp = (Instruction*)builder.CreateConstGEP1_32(ctx->argTemp, 2);
     ctx->storeFrameSize =
         builder.CreateStore(ConstantInt::get(T_size, n_roots<<1),
-                            builder.CreateBitCast(builder.CreateConstGEP1_32(ctx->gcframe, 0), T_psize));
+                            preserving_bitcast(builder.CreateConstGEP1_32(ctx->gcframe, 0), T_psize));
     builder.CreateStore(builder.CreateLoad(prepare_global(jlpgcstack_var), false),
-                        builder.CreateBitCast(builder.CreateConstGEP1_32(ctx->gcframe, 1), PointerType::get(jl_ppvalue_llvmt,0)));
+                        preserving_bitcast(builder.CreateConstGEP1_32(ctx->gcframe, 1), PointerType::get(jl_ppvalue_llvmt,0)));
     Instruction *linst = builder.CreateStore(ctx->gcframe, prepare_global(jlpgcstack_var), false);
     ctx->argSpaceInits = &b0->back();
 #else
@@ -3794,7 +3794,7 @@ static Function *gen_jlcall_wrapper(jl_lambda_info_t *lam, jl_expr_t *ast, Funct
 #ifdef JL_GC_MARKSWEEP
     Instruction *gcpop = (Instruction*)builder.CreateConstGEP1_32(ctx.gcframe, 1);
     ctx.gc_frame_pops.push_back(gcpop);
-    builder.CreateStore(builder.CreateBitCast(builder.CreateLoad(gcpop, false), jl_ppvalue_llvmt),
+    builder.CreateStore(preserving_bitcast(builder.CreateLoad(gcpop, false), jl_ppvalue_llvmt),
                         prepare_global(jlpgcstack_var));
 #endif
     finalize_gc_frame(&ctx);
@@ -4658,7 +4658,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
 #ifdef JL_GC_MARKSWEEP
             Instruction *gcpop = (Instruction*)builder.CreateConstGEP1_32(ctx.gcframe, 1);
             ctx.gc_frame_pops.push_back(gcpop);
-            builder.CreateStore(builder.CreateBitCast(builder.CreateLoad(gcpop, false), jl_ppvalue_llvmt),
+            builder.CreateStore(preserving_bitcast(builder.CreateLoad(gcpop, false), jl_ppvalue_llvmt),
                                 prepare_global(jlpgcstack_var));
 #endif
             if (do_malloc_log && lno != -1)


### PR DESCRIPTION
@maleadt worked towards supporting the CUDA/PTX backend in llvm in Julia. He presented his work in https://groups.google.com/forum/#!topic/julia-dev/doQUqQabC8A, because he will not be able to spend much time on it in the coming months. 

I personally would like to see support for this in Julia and planned to work on something similar for the OpenCL/SPIR backend in llvm. 

In order to integrate @maleadt work with upstream Julia I plan to submit PRs for separated concerns so that they can be properly discussed. 

First up is address space preserving bitcasts.

@maleadt do you have time to explain shortly the rational behind this?

Cherry-picked from:
6c4fbcc and  855bb43
