### PR TITLE
WIP: Modified Date types to allow use of Float for definitive periods.

### DIFF
--- a/base/Dates.jl
+++ b/base/Dates.jl
@@ -10,7 +10,7 @@ include("dates/ranges.jl")
 include("dates/adjusters.jl")
 include("dates/io.jl")
 
-export Period, DatePeriod, TimePeriod,
+export Period, CalendarPeriod, TimePeriod,
        Year, Month, Week, Day, Hour, Minute, Second, Millisecond,
        TimeZone, UTC, TimeType, DateTime, Date,
        # accessors.jl

--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -28,8 +28,16 @@ Base.typemin{P<:Period}(::Type{P}) = P(typemin(Int64))
 Base.typemax{P<:Period}(::Type{P}) = P(typemax(Int64))
 
 # Default values (as used by TimeTypes)
-default{T<:DatePeriod}(p::Union(T,Type{T})) = one(p)
-default{T<:TimePeriod}(p::Union(T,Type{T})) = zero(p)
+for t in (:Year,:Month,:Week,:Day)
+	@eval begin
+		default{T<:$t}(p::Union(T,Type{T})) = one(p)
+	end
+end
+for t in (:Hour, :Minute, :Second, :Millisecond)
+	@eval begin
+		default{T<:$t}(p::Union(T,Type{T})) = zero(p)
+	end
+end
 
 (-){P<:Period}(x::P) = P(-value(x))
 Base.isless{P<:Period}(x::P,y::P) = isless(value(x),value(y))
@@ -247,7 +255,7 @@ for i = 1:length(fixedperiod_conversions)
     N = n
     for j = i+1:length(fixedperiod_conversions) # more-precise periods
         (Tc,nc) = fixedperiod_conversions[j]
-        @eval Base.convert(::Type{$T}, x::$Tc) = $T(divexact(value(x), $N))
+        @eval Base.convert(::Type{$T}, x::$Tc) = $T(value(x)/$N)
         @eval Base.promote_rule(::Type{$T},::Type{$Tc}) = $Tc
         N *= nc
     end

--- a/test/dates/conversions.jl
+++ b/test/dates/conversions.jl
@@ -57,9 +57,6 @@ let t = Dates.Period[Dates.Week(2), Dates.Day(14), Dates.Hour(14*24), Dates.Minu
             Pj = typeof(t[j])
             tj1 = t[j] + one(Pj)
             @test t[i] < tj1
-            @test_throws InexactError Pi(tj1)
-            @test_throws InexactError Pj(Pi(typemax(Int64)))
-            @test_throws InexactError Pj(Pi(typemin(Int64)))
         end
     end
 end

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -286,3 +286,7 @@ emptyperiod = ((y + d) - d) - y
 @test 8d - s == 1w + 23h + 59mi + 59s
 @test h + 3mi == 63mi
 @test y - m == 11m
+
+
+#Gadfly issue with date_bar
+@test Dates.Day(40)/39 == Dates.Day(40/39)

--- a/test/dates/ranges.jl
+++ b/test/dates/ranges.jl
@@ -5,7 +5,7 @@ function test_all_combos()
         f3 = T(-2000); l3 = T(2000)
         f4 = typemin(T); l4 = typemax(T)
 
-        for P in subtypes(Dates.DatePeriod)
+        for P in subtypes(Dates.CalendarPeriod)
             for pos_step in (P(1),P(2),P(50),P(2048),P(10000))
                 # empty range
                 dr = f1:pos_step:l1


### PR DESCRIPTION
modified Types such that Year and Month are part of CalendarPeriod wrapp...ed around Int
Week, Day, Hour, Minute, Second are wrapped around Real to allow for both Int and Float types
Millisecond remained wrapped around Int
Ref Issue #9393
