### PR TITLE
initial svds support based on eigs

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -690,6 +690,7 @@ export
     svd,
     svdfact!,
     svdfact,
+    svds,
     svdvals!,
     svdvals,
     sylvester,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -102,6 +102,7 @@ export
     svd,
     svdfact!,
     svdfact,
+    svds,
     svdvals!,
     svdvals,
     sylvester,

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -118,11 +118,13 @@ end
 size(s::SvdX)  = size(s.X, 2), size(s.X, 2)
 issym(s::SvdX) = true
 
-function svds(X; args...)
-  ex = eigs(SvdX(X), I; args...)
-  ## calculating left-side singular vectors
-  left_sv = X * ex[2]
-  return left_sv ./ sqrt(sum(left_sv.^2, 1)), sqrt(ex[1]), ex[2], ex[3], ex[4], ex[5], ex[6]
+function svds(X; ritzvec::Bool = true, args...)
+    ex = eigs(SvdX(X), I; ritzvec = ritzvec, args...)
+    if ! ritzvec
+        return sqrt(ex[1]), ex[2], ex[3], ex[4], ex[5]
+    end
+
+    ## calculating left-side singular vectors
+    left_sv = X * ex[2]
+    return left_sv ./ sqrt(sum(left_sv.^2, 1)), sqrt(ex[1]), ex[2], ex[3], ex[4], ex[5], ex[6]
 end
-
-

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -144,11 +144,11 @@ function svds{S}(X::S; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, m
   ex    = eigs(SVDOperator{otype,S}(X), I; ritzvec = ritzvec, nev = 2*nsv, tol = tol, maxiter = maxiter)
   ind   = [1:2:nsv*2]
   sval  = abs(ex[1][ind])
-  
+
   if ! ritzvec
     return sval, ex[2], ex[3], ex[4], ex[5]
   end
-  
+
   ## calculating singular vectors
   left_sv  = sqrt(2) * ex[2][ 1:size(X,1),     ind ] .* sign(ex[1][ind]')
   right_sv = sqrt(2) * ex[2][ size(X,1)+1:end, ind ]

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -110,16 +110,16 @@ end
 
 ## svds
 
-type SvdX <: AbstractArray{Float64, 2}
+type SVDOperator <: AbstractArray{Float64, 2}
     X
 end
 
-*(s::SvdX, v::Vector{Float64}) = s.X' * (s.X * v)
-size(s::SvdX)  = size(s.X, 2), size(s.X, 2)
-issym(s::SvdX) = true
+*(s::SVDOperator, v::Vector{Float64}) = s.X' * (s.X * v)
+size(s::SVDOperator)  = size(s.X, 2), size(s.X, 2)
+issym(s::SVDOperator) = true
 
 function svds(X; ritzvec::Bool = true, args...)
-    ex = eigs(SvdX(X), I; ritzvec = ritzvec, args...)
+    ex = eigs(SVDOperator(X), I; ritzvec = ritzvec, args...)
     if ! ritzvec
         return sqrt(ex[1]), ex[2], ex[3], ex[4], ex[5]
     end

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -106,3 +106,23 @@ function eigs(A, B;
                                  resid, ncv, v, ldv, sigma, iparam, ipntr, workd, workl, lworkl, rwork)
 
 end
+
+
+## svds
+
+type SvdX <: AbstractArray{Float64, 2}
+    X
+end
+
+*(s::SvdX, v::Vector{Float64}) = s.X' * (s.X * v)
+size(s::SvdX)  = size(s.X, 2), size(s.X, 2)
+issym(s::SvdX) = true
+
+function svds(X; args...)
+  ex = eigs(SvdX(X), I; args...)
+  ## calculating left-side singular vectors
+  left_sv = X * ex[2]
+  return left_sv ./ sqrt(sum(left_sv.^2, 1)), sqrt(ex[1]), ex[2], ex[3], ex[4], ex[5], ex[6]
+end
+
+

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -123,6 +123,8 @@ size(s::SVDOperator)  = s.m + s.n, s.m + s.n
 issym(s::SVDOperator) = true
 
 function svds{S}(X::S; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxiter::Int = 1000)
+  if nsv > minimum(size(X)); error("nsv($nsv) should be at most $(minimum(size(X)))"); end
+
   otype = eltype(X)
   ex    = eigs(SVDOperator{otype,S}(X), I; ritzvec = ritzvec, nev = 2*nsv, tol = tol, maxiter = maxiter)
   ind   = [1:2:nsv*2]

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -122,25 +122,8 @@ end
 size(s::SVDOperator)  = s.m + s.n, s.m + s.n
 issym(s::SVDOperator) = true
 
-function getOperatorType(X)
-  et = eltype(X)
-  if et <: Integer || et <: Float64
-    return Float64
-  end
-  if et <: Complex64
-    return Complex64
-  end
-  if et <: Complex
-    return Complex128
-  end
-  if et <: Float32
-    return Float32
-  end
-  error("Element type $et is not supported for 'svds'.")
-end
-
 function svds{S}(X::S; nsv::Int = 6, ritzvec::Bool = true, tol::Float64 = 0.0, maxiter::Int = 1000)
-  otype = getOperatorType(X)
+  otype = eltype(X)
   ex    = eigs(SVDOperator{otype,S}(X), I; ritzvec = ritzvec, nev = 2*nsv, tol = tol, maxiter = maxiter)
   ind   = [1:2:nsv*2]
   sval  = abs(ex[1][ind])

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -564,7 +564,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Conjugate transpose array ``src`` and store the result in the preallocated array ``dest``, which should have a size corresponding to ``(size(src,2),size(src,1))``. No in-place transposition is supported and unexpected results will happen if `src` and `dest` have overlapping memory regions.
 
-.. function:: eigs(A, [B,]; nev=6, which="LM", tol=0.0, maxiter=1000, sigma=nothing, ritzvec=true, v0=zeros((0,))) -> (d,[v,],nconv,niter,nmult,resid)
+.. function:: eigs(A, [B,]; nev=6, which="LM", tol=0.0, maxiter=300, sigma=nothing, ritzvec=true, v0=zeros((0,))) -> (d,[v,],nconv,niter,nmult,resid)
 
    ``eigs`` computes eigenvalues ``d`` of ``A`` using Lanczos or Arnoldi iterations for real symmetric or general nonsymmetric matrices respectively. If ``B`` is provided, the generalized eigen-problem is solved.  The following keyword arguments are supported:
     * ``nev``: Number of eigenvalues
@@ -599,6 +599,23 @@ Linear algebra functions in Julia are largely implemented by calling functions f
       ``nothing``     ordinary (forward)                 :math:`A`
       real or complex inverse with level shift ``sigma`` :math:`(A - \sigma I )^{-1}`
       =============== ================================== ==================================
+
+.. function:: svds(A; ritzvec=true, args...) -> (left_sv, s, right_sv, nconv, niter, nmult, resid)
+
+   ``svds`` computes singular values ``s`` of ``A`` using Lanczos or Arnoldi iterations. Uses ``eigs`` underneath so following keyword arguments are supported:
+    * ``nev``: Number of singular values.
+    * ``ncv``: Number of Krylov vectors used in the computation; see ``eigs`` manual.
+    * ``ritzvec``: Whether to return the left and right singular vectors ``left_sv`` and ``right_sv``, default is ``true``. If ``false`` the singular vectors are omitted from the output.
+    * ``which``: type of singular values (and vectors) to compute, default is largest values. See ``eigs`` manual.
+    * ``tol``: tolerance, see ``eigs``.
+    * ``maxiter``: Maximum number of iterations, see ``eigs``.
+    * ``sigma``: See ``eigs``.
+    * ``v0``: starting vector of right singular vector from which to start the iterations.
+
+   **Example**::
+
+      X = sprand(10, 5, 0.2)
+      svds(X, nev = 2)
 
 .. function:: peakflops(n; parallel=false)
 

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -1,0 +1,20 @@
+using Base.Test
+
+let # svds test
+    A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], [2.0, -1.0, 6.1, 7.0, 1.5])
+    S1 = svds(A, nev = 2)
+    S2 = svd(full(A))
+
+    ## singular values match:
+    @test_approx_eq S1[2] S2[2][1:2]
+
+    ## 1st left singular vector 
+    s1_left = sign(S1[1][3,1]) * S1[1][:,1]
+    s2_left = sign(S2[1][3,1]) * S2[1][:,1]
+    @test_approx_eq s1_left s2_left
+
+    ## 1st right singular vector 
+    s1_right = sign(S1[3][3,1]) * S1[3][:,1]
+    s2_right = sign(S2[3][3,1]) * S2[3][:,1]
+    @test_approx_eq s1_right s2_right
+end

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -2,7 +2,7 @@ using Base.Test
 
 let # svds test
     A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], [2.0, -1.0, 6.1, 7.0, 1.5])
-    S1 = svds(A, nev = 2)
+    S1 = svds(A, nsv = 2)
     S2 = svd(full(A))
 
     ## singular values match:

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -8,12 +8,12 @@ let # svds test
     ## singular values match:
     @test_approx_eq S1[2] S2[2][1:2]
 
-    ## 1st left singular vector 
+    ## 1st left singular vector
     s1_left = sign(S1[1][3,1]) * S1[1][:,1]
     s2_left = sign(S2[1][3,1]) * S2[1][:,1]
     @test_approx_eq s1_left s2_left
 
-    ## 1st right singular vector 
+    ## 1st right singular vector
     s1_right = sign(S1[3][3,1]) * S1[3][:,1]
     s2_right = sign(S2[3][3,1]) * S2[3][:,1]
     @test_approx_eq s1_right s2_right

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -18,3 +18,41 @@ let # svds test
     s2_right = sign(S2[3][3,1]) * S2[3][:,1]
     @test_approx_eq s1_right s2_right
 end
+
+let # svd test with boolean matrix
+    B = [true true false; false true false; true false true; false true true]
+    S1 = svds(B, nsv = 2)
+    S2 = svd(B)
+
+    ## singular values match:
+    @test_approx_eq S1[2] S2[2][1:2]
+
+    ## 1st left singular vector
+    s1_left = sign(S1[1][1,1]) * S1[1][:,1]
+    s2_left = sign(S2[1][1,1]) * S2[1][:,1]
+    @test_approx_eq s1_left s2_left
+
+    ## 1st right singular vector
+    s1_right = sign(S1[3][1,1]) * S1[3][:,1]
+    s2_right = sign(S2[3][1,1]) * S2[3][:,1]
+    @test_approx_eq s1_right s2_right
+end
+
+let # complex svds test
+    A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], exp(im*[2.0:2:10]))
+    S1 = svds(A, nsv = 2)
+    S2 = svd(full(A))
+
+    ## singular values match:
+    @test_approx_eq S1[2] S2[2][1:2]
+
+    ## left singular vectors
+    s1_left = abs(S1[1][:,1:2])
+    s2_left = abs(S2[1][:,1:2])
+    @test_approx_eq s1_left s2_left
+
+    ## right singular vectors
+    s1_right = abs(S1[3][:,1:2])
+    s2_right = abs(S2[3][:,1:2])
+    @test_approx_eq s1_right s2_right
+end

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -19,25 +19,6 @@ let # svds test
     @test_approx_eq s1_right s2_right
 end
 
-let # svd test with boolean matrix
-    B = [true true false; false true false; true false true; false true true]
-    S1 = svds(B, nsv = 2)
-    S2 = svd(B)
-
-    ## singular values match:
-    @test_approx_eq S1[2] S2[2][1:2]
-
-    ## 1st left singular vector
-    s1_left = sign(S1[1][1,1]) * S1[1][:,1]
-    s2_left = sign(S2[1][1,1]) * S2[1][:,1]
-    @test_approx_eq s1_left s2_left
-
-    ## 1st right singular vector
-    s1_right = sign(S1[3][1,1]) * S1[3][:,1]
-    s2_right = sign(S2[3][1,1]) * S2[3][:,1]
-    @test_approx_eq s1_right s2_right
-end
-
 let # complex svds test
     A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], exp(im*[2.0:2:10]))
     S1 = svds(A, nsv = 2)


### PR DESCRIPTION
Added support for sparse truncated SVD based on `eigs`. Keyword inputs are the same as for `eigs`. Returns left singular vectors, singular values, right singular vectors (and also outputs from eigs). Added a test case.
