### PR TITLE
[RFC] Map for Nullable

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -56,3 +56,9 @@ function hash(x::Nullable, h::UInt)
         return hash(x.value, h + nullablehash_seed)
     end
 end
+
+# Specialized map over Nullable
+function map(f::Callable, x::Nullable)
+    isnull(x) && return Nullable{Union()}()
+    Nullable(f(get(x)))
+end

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -243,3 +243,11 @@ for T in types
     @test !isnull(x1.v)
     @test get(x1.v, one(T)) === one(T)
 end
+
+# test map
+@test map(x->x, Nullable{Union()}()) === Nullable{Union()}()
+
+for T in types
+    @test isequal(map(x->x, Nullable{T}()), Nullable{Union()}())
+    @test map(x->x, Nullable(one(T))) === Nullable(one(T))
+end


### PR DESCRIPTION
For me `Nullable` is very similar to the Option type used in functional languages. Most of the functional languages I encountered treat Option as a container with one array and define operations like map over it. 

One possible way would be to define the iterator interface for `Nullable` thus allowing `for value in Nullable(value)` and all other method that depend on it. I personally see little to no value in that and thus only implemented the one operation that I find most useful: `map`

`map` over Nullables allows for using Nullable unaware function with Nullable values and codifies a common pattern.

This PR only implements `map` over a singular Nullable and for me the  question is open whether a `map` for multiple Nullable has a well defined meaning and is useful.
