### PR TITLE
JL_STD* vs ios_std* cleanup

### DIFF
--- a/base/fs.jl
+++ b/base/fs.jl
@@ -177,14 +177,7 @@ function write(f::File, buf::Ptr{UInt8}, len::Integer, offset::Integer=-1)
     len
 end
 
-function write(f::File, c::UInt8)
-    if !f.open
-        throw(ArgumentError("file \"$(f.path)\" is not open"))
-    end
-    err = ccall(:jl_fs_write_byte, Int32, (Int32, Cchar), f.handle, c)
-    uv_error("write",err)
-    1
-end
+write(f::File, c::UInt8) = write(f,[c])
 
 function write{T}(f::File, a::Array{T})
     if isbits(T)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -227,8 +227,6 @@ convert(T::Type{Ptr{Void}}, s::AsyncStream) = convert(T, s.handle)
 handle(s::AsyncStream) = s.handle
 handle(s::Ptr{Void}) = s
 
-make_stdout_stream() = _uv_tty2tty(ccall(:jl_stdout_stream, Ptr{Void}, ()))
-
 associate_julia_struct(handle::Ptr{Void},jlobj::ANY) =
     ccall(:jl_uv_associate_julia_struct,Void,(Ptr{Void},Any),handle,jlobj)
 disassociate_julia_struct(uv) = disassociate_julia_struct(uv.handle)
@@ -239,6 +237,8 @@ function init_stdio(handle)
     t = ccall(:jl_uv_handle_type,Int32,(Ptr{Void},),handle)
     if t == UV_FILE
         return fdio(ccall(:jl_uv_file_handle,Int32,(Ptr{Void},),handle))
+#       Replace ios.c filw with libuv file?
+#       return File(RawFD(ccall(:jl_uv_file_handle,Int32,(Ptr{Void},),handle)))
     else
         if t == UV_TTY
             ret = TTY(handle)
@@ -272,7 +272,6 @@ function reinit_stdio()
     global uv_jl_readcb = cglobal(:jl_uv_readcb)
     global uv_jl_connectioncb = cglobal(:jl_uv_connectioncb)
     global uv_jl_connectcb = cglobal(:jl_uv_connectcb)
-    global uv_jl_writecb = cglobal(:jl_uv_writecb)
     global uv_jl_writecb_task = cglobal(:jl_uv_writecb_task)
     global uv_eventloop = ccall(:jl_global_event_loop, Ptr{Void}, ())
     global STDIN = init_stdio(ccall(:jl_stdin_stream ,Ptr{Void},()))
@@ -726,93 +725,54 @@ end
 #    finish_read(state...)
 #end
 
-macro uv_write(n,call)
+macro uv_write(stream, data, len)
     esc(quote
         check_open(s)
-        uvw = c_malloc(_sizeof_uv_write+$(n))
-        err = $call
+        uvw = c_malloc(_sizeof_uv_write)
+        uv_req_set_data(uvw,C_NULL)
+        err = ccall(:jl_uv_write,
+                    Int32,
+                    (Ptr{Void}, Ptr{Void}, UInt, Ptr{Void}, Ptr{Void}),
+                    handle($(stream)), $(data), $(len), uvw,
+                    uv_jl_writecb_task::Ptr{Void})
         if err < 0
             c_free(uvw)
             uv_error("write", err)
         end
+        ct = current_task()
+        uv_req_set_data(uvw,ct)
+        ct.state = :waiting
+        stream_wait(ct)
+        c_free(uvw)
     end)
 end
 
 ## low-level calls ##
 
-function write!{T}(s::AsyncStream, a::Array{T})
-    if isbits(T)
-        n = uint(length(a)*sizeof(T))
-        @uv_write n ccall(:jl_write_no_copy, Int32, (Ptr{Void}, Ptr{Void}, UInt, Ptr{Void}, Ptr{Void}), handle(s), a, n, uvw, uv_jl_writecb::Ptr{Void})
-        return int(length(a)*sizeof(T))
-    else
-        throw(MethodError(write,(s,a)))
-    end
-end
-function write!(s::AsyncStream, p::Ptr, nb::Integer)
-    @uv_write nb ccall(:jl_write_no_copy, Int32, (Ptr{Void}, Ptr{Void}, UInt, Ptr{Void}, Ptr{Void}), handle(s), p, nb, uvw, uv_jl_writecb::Ptr{Void})
-    return nb
-end
-write!(s::AsyncStream, string::ByteString) = write!(s,string.data)
-
-function _uv_hook_writecb(s::AsyncStream, req::Ptr{Void}, status::Int32)
-    if status < 0
-        err = UVError("write",status)
-        showerror(STDERR, err, backtrace())
-    end
-    nothing
-end
-
-function write(s::AsyncStream, b::UInt8)
-    @uv_write 1 ccall(:jl_putc_copy, Int32, (UInt8, Ptr{Void}, Ptr{Void}, Ptr{Void}), b, handle(s), uvw, uv_jl_writecb_task::Ptr{Void})
-    ct = current_task()
-    uv_req_set_data(uvw,ct)
-    ct.state = :waiting
-    stream_wait(ct)
-    return 1
-end
-function write(s::AsyncStream, c::Char)
-    nb = utf8sizeof(c)
-    @uv_write nb ccall(:jl_pututf8_copy, Int32, (Ptr{Void}, UInt32, Ptr{Void}, Ptr{Void}), handle(s), c, uvw, uv_jl_writecb_task::Ptr{Void})
-    ct = current_task()
-    uv_req_set_data(uvw,ct)
-    ct.state = :waiting
-    stream_wait(ct)
-    return nb
-end
+write(s::AsyncStream, b::UInt8) = write(s, [b])
+write(s::AsyncStream, c::Char) = write(s, string(c))
 function write{T}(s::AsyncStream, a::Array{T})
     if isbits(T)
         n = uint(length(a)*sizeof(T))
-        @uv_write n ccall(:jl_write_no_copy, Int32, (Ptr{Void}, Ptr{Void}, UInt, Ptr{Void}, Ptr{Void}), handle(s), a, n, uvw, uv_jl_writecb_task::Ptr{Void})
-        ct = current_task()
-        uv_req_set_data(uvw,ct)
-        ct.state = :waiting
-        stream_wait(ct)
-        return int(length(a)*sizeof(T))
+        @uv_write s a n
+        return int(n)
     else
         check_open(s)
         invoke(write,(IO,Array),s,a)
     end
 end
-function write(s::AsyncStream, p::Ptr, nb::Integer)
-    @uv_write nb ccall(:jl_write_no_copy, Int32, (Ptr{Void}, Ptr{Void}, UInt, Ptr{Void}, Ptr{Void}), handle(s), p, nb, uvw, uv_jl_writecb_task::Ptr{Void})
-    ct = current_task()
-    uv_req_set_data(uvw,ct)
-    ct.state = :waiting
-    stream_wait(ct)
-    return int(nb)
+function write(s::AsyncStream, p::Ptr, n::Integer)
+    @uv_write s p n
+    return int(n)
 end
 
 function _uv_hook_writecb_task(s::AsyncStream,req::Ptr{Void},status::Int32)
     d = uv_req_data(req)
+    @assert d != C_NULL
     if status < 0
         err = UVError("write",status)
-        if d != C_NULL
-            schedule(unsafe_pointer_to_objref(d)::Task,err,error=true)
-        else
-            showerror(STDERR, err, backtrace())
-        end
-    elseif d != C_NULL
+        schedule(unsafe_pointer_to_objref(d)::Task,err,error=true)
+    else
         schedule(unsafe_pointer_to_objref(d)::Task)
     end
 end

--- a/doc/devdocs/julia.rst
+++ b/doc/devdocs/julia.rst
@@ -14,3 +14,4 @@
    subarrays
    sysimg
    llvm
+   stdio

--- a/doc/devdocs/stdio.rst
+++ b/doc/devdocs/stdio.rst
@@ -1,0 +1,116 @@
+***************************************
+printf() and stdio in the Julia runtime
+***************************************
+
+Libuv wrappers for stdio
+------------------------
+
+julia.h defines `libuv <http://docs.libuv.org>`_ wrappers for the
+<stdio.h> streams::
+
+    uv_stream_t *JL_STDIN;
+    uv_stream_t *JL_STDOUT;
+    uv_stream_t *JL_STDERR;
+
+... and corresponding output functions::
+
+    int jl_printf(uv_stream_t *s, const char *format, ...);
+    int jl_vprintf(uv_stream_t *s, const char *format, va_list args);
+
+These printf functions are used by :code:`julia/{src,ui}/*.c` wherever stdio
+is needed to ensure that output buffering is handled in a unified
+way.
+
+In special cases, like signal handlers, where the full libuv
+infrastructure is too heavy, :func:`jl_safe_printf` can be used to
+:code:`write(2)` directly to :data:`STDERR_FILENO`::
+
+    void jl_safe_printf(const char \*str, ...);
+
+
+
+Interface between JL_STD* and Julia code
+----------------------------------------
+
+:data:`Base.STDIN`, :data:`Base.STDOUT` and :data:`Base.STDERR` are
+bound to the :code:`JL_STD*` `libuv <http://docs.libuv.org>`_ streams
+defined in the runtime.
+
+Julia's :func:`__init__` function (inbase/sysimg.jl) calls
+:func:`reinit_stdio` (in base/stream.jl) to create Julia objects
+for :data:`Base.STDIN`, :data:`Base.STDOUT` and :data:`Base.STDERR`.
+
+:func:`reinit_stdio` uses :func:`ccall` to retrieve pointers to
+:code:`JL_STD*` and calls :func:`jl_uv_handle_type()` to inspect
+the type of each stream.  It then creates a Julia :code:`Base.File`,
+:code:`Base.TTY` or :code:`Base.Pipe` object to represent each
+stream. e.g::
+
+    $ julia -e 'typeof((STDIN, STDOUT, STDERR))'
+    (TTY,TTY,TTY)
+
+    $ julia -e 'println(typeof((STDIN, STDOUT, STDERR)))' < /dev/null 2>/dev/null
+    (Base.FS.File,TTY,Base.FS.File)
+
+    $ echo hello | julia -e 'println(typeof((STDIN, STDOUT, STDERR)))' | cat
+    (Pipe,Pipe,TTY)
+
+The :func:`Base.read()` and :func:`Base.write()` methods for these
+streams use :func:`ccall` to call libuv wrappers in :code:`src/jl_uv.c`. e.g::
+
+    stream.jl: function write(s::AsyncStream, p::Ptr, nb::Integer)
+                   -> ccall(:jl_write_no_copy, ...)
+      jl_uv.c:          -> int jl_write_no_copy(uv_stream_t *stream, ...)
+                            -> uv_write(uvw, stream, buf, ...)
+
+printf() during initialisation
+------------------------------
+
+The libuv streams relied apon by :func:`jl_printf` etc are not
+available until mid-way through initialisation of the runtime (see
+init.c, :func:`init_stdio`).  Error messages or warnings that need
+to be printed before this are routed to the standard C library
+:func:`fwrite` function by the following mechanism:
+
+In sys.c the :code:`JL_STD*` stream pointers are statically initialised
+to integer constants: STD*_FILENO (0, 1 and 2). In jl_uv.c the
+:func:`jl_write` function checks its :code:`uv_stream_t* stream`
+argument and calls :func:`fwrite` if stream is set to STDOUT_FILENO
+or STDERR_FILENO.
+
+This allows for uniform use of :func:`jl_printf()` throughout the
+runtime regardless of whether or not any particular piece of code
+is reachable before initialisation is complete.
+
+
+
+Legacy ios.c library
+--------------------
+
+The :code:`julia/src/support/ios.c` library is inherited from `femptolisp <http://github.com/JeffBezanson/femtolisp>`_.
+It provides cross-platform buffered file IO and in-memory temporary buffers.
+
+:code:`ios.c` is still used by:
+
+    - :code:`julia/src/flisp/*.c`
+    - :code:`julia/src/dump.c` -- for serialisation file IO and for memory buffers.
+    - :code:`base/iostream.jl` -- for file IO (see :code:`base/fs.jl` for libuv equivalent).
+
+Use of :code:`ios.c` in these modules is mostly self contained and
+seperated from the libuv io system. However, there is `one place
+<http://github.com/JuliaLang/julia/blob/master/src/flisp/print.c#L654>`_
+where femptolisp calls though to :func:`jl_printf` with a legacy :code:`ios_t` stream.
+
+There is a hack in :code:`ios.h` that makes the :code:`ios_t.bm`
+field line up with the :code:`uv_stream_t.type` and ensures that
+the values used for :code:`ios_t.bm` to not overlap with valid
+UV_HANDLE_TYPE values.  This allows :code:`uv_stream_t` pointers
+to point to :code:`ios_t` streams.
+
+This is needed because :func`jl_printf` caller :func`jl_static_show`
+is passed an :code:`ios_t` stream by femptolisp's :func:`fl_print` function.
+Julia's :func:`jl_write` function has special handling for this::
+
+    if (stream->type > UV_HANDLE_TYPE_MAX) {
+        return ios_write((ios_t*)stream, str, n);
+    }

--- a/examples/embedding.c
+++ b/examples/embedding.c
@@ -90,7 +90,7 @@ int main()
 
         if (jl_exception_occurred()) {
             jl_show(jl_stderr_obj(), jl_exception_occurred());
-            JL_PRINTF(jl_stderr_stream(), "\n");
+            jl_printf(jl_stderr_stream(), "\n");
         }
     }
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -27,7 +27,6 @@ static uint8_t flisp_system_image[] = {
 #include "julia_flisp.boot.inc"
 };
 
-extern fltype_t *iostreamtype;
 static fltype_t *jvtype=NULL;
 
 static value_t true_sym;
@@ -120,13 +119,10 @@ extern int jl_parse_depwarn(int warn);
 void jl_init_frontend(void)
 {
     fl_init(4*1024*1024);
-    value_t img = cvalue(iostreamtype, sizeof(ios_t));
-    ios_t *pi = value2c(ios_t*, img);
-    ios_static_buffer(pi, (char*)flisp_system_image, sizeof(flisp_system_image));
 
-    if (fl_load_system_image(img)) {
-        JL_PRINTF(JL_STDERR, "fatal error loading system image\n");
-        jl_exit(1);
+    if (fl_load_system_image_str((char*)flisp_system_image,
+                                 sizeof(flisp_system_image))) {
+        jl_error("fatal error loading system image\n");
     }
 
     fl_applyn(0, symbol_value(symbol("__init_globals")));

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -31,7 +31,7 @@ extern "C" {
 DLLEXPORT void NORETURN jl_error(const char *str)
 {
     if (jl_errorexception_type == NULL) {
-        JL_PRINTF(JL_STDERR, "%s", str);
+        jl_printf(JL_STDERR, "%s", str);
         jl_exit(1);
     }
     jl_value_t *msg = jl_pchar_to_string((char*)str, strlen(str));
@@ -42,17 +42,20 @@ DLLEXPORT void NORETURN jl_error(const char *str)
 DLLEXPORT void NORETURN jl_errorf(const char *fmt, ...)
 {
     va_list args;
-    ios_t buf;
-    ios_mem(&buf, 0);
     va_start(args, fmt);
-    ios_vprintf(&buf, fmt, args);
-    va_end(args);
+
     if (jl_errorexception_type == NULL) {
-        ios_write(&buf, "", 1); // null terminate the buffer
-        JL_PRINTF(JL_STDERR, "%s", buf.buf);
+        jl_vprintf(JL_STDERR, fmt, args);
         jl_exit(1);
     }
-    jl_value_t *msg = jl_takebuf_string(&buf);
+
+    char* str = NULL;
+    vasprintf(&str, fmt, args);
+
+    va_end(args);
+
+    jl_value_t *msg = jl_pchar_to_string(str, strlen(str));
+    free(str);
     JL_GC_PUSH1(&msg);
     jl_throw(jl_new_struct(jl_errorexception_type, msg));
 }
@@ -728,17 +731,6 @@ DLLEXPORT void *jl_value_ptr(jl_value_t *a)
 
 // printing -------------------------------------------------------------------
 
-DLLEXPORT void jl_print_symbol(JL_STREAM *s, jl_sym_t *sym)
-{
-    JL_PUTS(sym->name,s);
-}
-
-// for bootstrap
-DLLEXPORT void jl_print_int64(JL_STREAM *s, int64_t i)
-{
-    JL_PRINTF(s, "%lld", i);
-}
-
 DLLEXPORT int jl_substrtod(char *str, size_t offset, int len, double *out)
 {
     char *p;
@@ -882,7 +874,7 @@ void jl_show(jl_value_t *stream, jl_value_t *v)
             jl_show_gf = (jl_function_t*)jl_get_global(jl_base_module, jl_symbol("show"));
         }
         if (jl_show_gf==NULL || stream==NULL) {
-            JL_PRINTF(JL_STDERR, " could not show value of type %s",
+            jl_printf(JL_STDERR, " could not show value of type %s",
                       jl_is_tuple(v) ? "Tuple" :
                       ((jl_datatype_t*)jl_typeof(v))->name->name->name);
             return;
@@ -1191,16 +1183,16 @@ void jl_init_primitives(void)
 static size_t jl_show_tuple(JL_STREAM *out, jl_tuple_t *t, char *opn, char *cls, int comma_one, int depth)
 {
     size_t i, n=0, len = jl_tuple_len(t);
-    n += JL_PRINTF(out, "(");
+    n += jl_printf(out, "(");
     for (i = 0; i < len; i++) {
         jl_value_t *v = jl_tupleref(t,i);
         n += jl_static_show(out, v);
         if (len == 1)
-            n += JL_PRINTF(out, ",");
+            n += jl_printf(out, ",");
         else if (i != len-1)
-            n += JL_PRINTF(out, ", ");
+            n += jl_printf(out, ", ");
     }
-    n += JL_PRINTF(out, ")");
+    n += jl_printf(out, ")");
     return n;
 }
 
@@ -1213,27 +1205,27 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
     if(depth > MAX_DEPTH) return 0; // cheap way of bailing out of cycles
     depth++;
     if (v == NULL) {
-        n += JL_PRINTF(out, "#<null>");
+        n += jl_printf(out, "#<null>");
     }
     else if (jl_typeof(v) == NULL) {
-        n += JL_PRINTF(out, "<?::#null>");
+        n += jl_printf(out, "<?::#null>");
     }
     else if ((uptrint_t)v->type < 4096U) {
-        n += JL_PRINTF(out, "<?::#%d>", (int)(uptrint_t)v->type);
+        n += jl_printf(out, "<?::#%d>", (int)(uptrint_t)v->type);
     }
     else if (jl_is_lambda_info(v)) {
         jl_lambda_info_t *li = (jl_lambda_info_t*)v;
         n += jl_static_show_x(out, (jl_value_t*)li->module, depth);
-        n += JL_PRINTF(out, ".%s", li->name->name);
+        n += jl_printf(out, ".%s", li->name->name);
         if (li->specTypes) {
             n += jl_static_show_x(out, (jl_value_t*)li->specTypes, depth);
         }
         else {
-            n += JL_PRINTF(out, "(?)");
+            n += jl_printf(out, "(?)");
         }
         // The following is nice for debugging, but allocates memory and generates a lot of output
         // so it may not be a good idea to to have it active
-        //JL_PRINTF(out, " -> ");
+        //jl_printf(out, " -> ");
         //jl_static_show(out, !jl_is_expr(li->ast) ? jl_uncompress_ast(li, li->ast) : li->ast);
     }
     else if (jl_is_tuple(v)) {
@@ -1241,91 +1233,91 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
     }
     else if (jl_is_vararg_type(v)) {
         n += jl_static_show_x(out, jl_tparam0(v), depth);
-        n += JL_PRINTF(out, "...");
+        n += jl_printf(out, "...");
     }
     else if (jl_is_datatype(v)) {
         jl_datatype_t *dv = (jl_datatype_t*)v;
         if (dv->name->module != jl_core_module) {
             n += jl_static_show_x(out, (jl_value_t*)dv->name->module, depth);
-            JL_PUTS(".", out); n += 1;
+            jl_printf(out, "."); n += 1;
         }
-        n += JL_PRINTF(out, "%s", dv->name->name->name);
+        n += jl_printf(out, "%s", dv->name->name->name);
         if (dv->parameters && (jl_value_t*)dv != dv->name->primary) {
             size_t j, tlen = jl_tuple_len(dv->parameters);
             if (tlen > 0) {
-                n += JL_PRINTF(out, "{");
+                n += jl_printf(out, "{");
                 for (j = 0; j < tlen; j++) {
                     jl_value_t *p = jl_tupleref(dv->parameters,j);
                     n += jl_static_show_x(out, p, depth);
                     if (j != tlen-1)
-                        n += JL_PRINTF(out, ", ");
+                        n += jl_printf(out, ", ");
                 }
-                n += JL_PRINTF(out, "}");
+                n += jl_printf(out, "}");
             }
         }
     }
     else if (jl_is_func(v)) {
         if (jl_is_gf(v)) {
-            n += JL_PRINTF(out, "%s", jl_gf_name(v)->name);
+            n += jl_printf(out, "%s", jl_gf_name(v)->name);
         }
         else {
-            n += JL_PRINTF(out, "#<function>");
+            n += jl_printf(out, "#<function>");
         }
     }
     else if (jl_typeis(v, jl_intrinsic_type)) {
-        n += JL_PRINTF(out, "#<intrinsic function %d>", *(uint32_t*)jl_data_ptr(v));
+        n += jl_printf(out, "#<intrinsic function %d>", *(uint32_t*)jl_data_ptr(v));
     }
     else if (jl_is_int64(v)) {
-        n += JL_PRINTF(out, "%lld", jl_unbox_int64(v));
+        n += jl_printf(out, "%lld", jl_unbox_int64(v));
     }
     else if (jl_is_int32(v)) {
-        n += JL_PRINTF(out, "%d", jl_unbox_int32(v));
+        n += jl_printf(out, "%d", jl_unbox_int32(v));
     }
     else if (jl_typeis(v,jl_int16_type)) {
-        n += JL_PRINTF(out, "%hd", jl_unbox_int16(v));
+        n += jl_printf(out, "%hd", jl_unbox_int16(v));
     }
     else if (jl_typeis(v,jl_int8_type)) {
-        n += JL_PRINTF(out, "%hhd", jl_unbox_int8(v));
+        n += jl_printf(out, "%hhd", jl_unbox_int8(v));
     }
     else if (jl_is_uint64(v)) {
-        n += JL_PRINTF(out, "0x%016llx", jl_unbox_uint64(v));
+        n += jl_printf(out, "0x%016llx", jl_unbox_uint64(v));
     }
     else if (jl_is_uint32(v)) {
-        n += JL_PRINTF(out, "0x%08x", jl_unbox_uint32(v));
+        n += jl_printf(out, "0x%08x", jl_unbox_uint32(v));
     }
     else if (jl_typeis(v,jl_uint16_type)) {
-        n += JL_PRINTF(out, "0x%04hx", jl_unbox_uint16(v));
+        n += jl_printf(out, "0x%04hx", jl_unbox_uint16(v));
     }
     else if (jl_typeis(v,jl_uint8_type)) {
-        n += JL_PRINTF(out, "0x%02hhx", jl_unbox_uint8(v));
+        n += jl_printf(out, "0x%02hhx", jl_unbox_uint8(v));
     }
     else if (jl_is_cpointer(v)) {
 #ifdef _P64
-        n += JL_PRINTF(out, "0x%016llx", jl_unbox_voidpointer(v));
+        n += jl_printf(out, "0x%016llx", jl_unbox_voidpointer(v));
 #else
-        n += JL_PRINTF(out, "0x%08x", jl_unbox_voidpointer(v));
+        n += jl_printf(out, "0x%08x", jl_unbox_voidpointer(v));
 #endif
     }
     else if (jl_is_float32(v)) {
-        n += JL_PRINTF(out, "%g", jl_unbox_float32(v));
+        n += jl_printf(out, "%g", jl_unbox_float32(v));
     }
     else if (jl_is_float64(v)) {
-        n += JL_PRINTF(out, "%g", jl_unbox_float64(v));
+        n += jl_printf(out, "%g", jl_unbox_float64(v));
     }
     else if (v == jl_true) {
-        n += JL_PRINTF(out, "true");
+        n += jl_printf(out, "true");
     }
     else if (v == jl_false) {
-        n += JL_PRINTF(out, "false");
+        n += jl_printf(out, "false");
     }
     else if (v == jl_nothing) {
-        n += JL_PRINTF(out, "nothing");
+        n += jl_printf(out, "nothing");
     }
     else if (jl_is_byte_string(v)) {
-        n += JL_PRINTF(out, "\"%s\"", jl_iostr_data(v));
+        n += jl_printf(out, "\"%s\"", jl_iostr_data(v));
     }
     else if (jl_is_uniontype(v)) {
-        n += JL_PRINTF(out, "Union");
+        n += jl_printf(out, "Union");
         n += jl_static_show_x(out, (jl_value_t*)((jl_uniontype_t*)v)->types, depth);
     }
     else if (jl_is_typector(v)) {
@@ -1334,84 +1326,84 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
     else if (jl_is_typevar(v)) {
         if (((jl_tvar_t*)v)->lb != jl_bottom_type) {
             n += jl_static_show(out, ((jl_tvar_t*)v)->lb);
-            n += JL_PRINTF(out, "<:");
+            n += jl_printf(out, "<:");
         }
-        n += JL_PRINTF(out, "%s%s<:", (((jl_tvar_t*)v)->bound)?"#":"", ((jl_tvar_t*)v)->name->name);
+        n += jl_printf(out, "%s%s<:", (((jl_tvar_t*)v)->bound)?"#":"", ((jl_tvar_t*)v)->name->name);
         n += jl_static_show(out, ((jl_tvar_t*)v)->ub);
     }
     else if (jl_is_module(v)) {
         jl_module_t *m = (jl_module_t*)v;
         if (m->parent != m && m->parent != jl_main_module) {
             n += jl_static_show_x(out, (jl_value_t*)m->parent, depth);
-            n += JL_PRINTF(out, ".");
+            n += jl_printf(out, ".");
         }
-        n += JL_PRINTF(out, "%s", m->name->name);
+        n += jl_printf(out, "%s", m->name->name);
     }
     else if (jl_is_symbol(v)) {
-        n += JL_PRINTF(out, ":%s", ((jl_sym_t*)v)->name);
+        n += jl_printf(out, ":%s", ((jl_sym_t*)v)->name);
     }
     else if (jl_is_gensym(v)) {
-        n += JL_PRINTF(out, "GenSym(%d)", ((jl_gensym_t*)v)->id);
+        n += jl_printf(out, "GenSym(%d)", ((jl_gensym_t*)v)->id);
     }
     else if (jl_is_symbolnode(v)) {
-        n += JL_PRINTF(out, "%s::", jl_symbolnode_sym(v)->name);
+        n += jl_printf(out, "%s::", jl_symbolnode_sym(v)->name);
         n += jl_static_show_x(out, jl_symbolnode_type(v), depth);
     }
     else if (jl_is_getfieldnode(v)) {
         n += jl_static_show_x(out, jl_getfieldnode_val(v), depth);
-        n += JL_PRINTF(out, ".%s", jl_getfieldnode_name(v)->name);
-        n += JL_PRINTF(out, "::");
+        n += jl_printf(out, ".%s", jl_getfieldnode_name(v)->name);
+        n += jl_printf(out, "::");
         n += jl_static_show_x(out, jl_getfieldnode_type(v), depth);
     }
     else if (jl_is_labelnode(v)) {
-        n += JL_PRINTF(out, "%d:", jl_labelnode_label(v));
+        n += jl_printf(out, "%d:", jl_labelnode_label(v));
     }
     else if (jl_is_gotonode(v)) {
-        n += JL_PRINTF(out, "goto %d", jl_gotonode_label(v));
+        n += jl_printf(out, "goto %d", jl_gotonode_label(v));
     }
     else if (jl_is_quotenode(v)) {
         jl_value_t *qv = jl_fieldref(v,0);
-        if (!jl_is_symbol(qv)) { n += JL_PRINTF(out, "quote "); }
+        if (!jl_is_symbol(qv)) { n += jl_printf(out, "quote "); }
         n += jl_static_show_x(out, jl_fieldref(v,0), depth);
-        if (!jl_is_symbol(qv)) { n += JL_PRINTF(out, " end"); }
+        if (!jl_is_symbol(qv)) { n += jl_printf(out, " end"); }
     }
     else if (jl_is_newvarnode(v)) {
-        n += JL_PRINTF(out, "<newvar ");
+        n += jl_printf(out, "<newvar ");
         n += jl_static_show_x(out, jl_fieldref(v,0), depth);
-        n += JL_PRINTF(out, ">");
+        n += jl_printf(out, ">");
     }
     else if (jl_is_topnode(v)) {
-        n += JL_PRINTF(out, "top(");
+        n += jl_printf(out, "top(");
         n += jl_static_show_x(out, jl_fieldref(v,0), depth);
-        n += JL_PRINTF(out, ")");
+        n += jl_printf(out, ")");
     }
     else if (jl_is_linenode(v)) {
-        n += JL_PRINTF(out, "# line %d", jl_linenode_line(v));
+        n += jl_printf(out, "# line %d", jl_linenode_line(v));
     }
     else if (jl_is_expr(v)) {
         jl_expr_t *e = (jl_expr_t*)v;
         if (e->head == assign_sym && jl_array_len(e->args) == 2) {
             n += jl_static_show_x(out, jl_exprarg(e,0), depth);
-            n += JL_PRINTF(out, " = ");
+            n += jl_printf(out, " = ");
             n += jl_static_show_x(out, jl_exprarg(e,1), depth);
         }
         else {
             char sep = ' ';
             if (e->head == body_sym)
                 sep = '\n';
-            n += JL_PRINTF(out, "Expr(:%s", e->head->name);
+            n += jl_printf(out, "Expr(:%s", e->head->name);
             size_t i, len = jl_array_len(e->args);
             for (i = 0; i < len; i++) {
-                n += JL_PRINTF(out, ",%c", sep);
+                n += jl_printf(out, ",%c", sep);
                 n += jl_static_show_x(out, jl_exprarg(e,i), depth);
             }
-            n += JL_PRINTF(out, ")::");
+            n += jl_printf(out, ")::");
             n += jl_static_show_x(out, e->etype, depth);
         }
     }
     else if (jl_is_array(v)) {
         n += jl_static_show_x(out, jl_typeof(v), depth);
-        n += JL_PRINTF(out, "[");
+        n += jl_printf(out, "[");
         size_t j, tlen = jl_array_len(v);
         for (j = 0; j < tlen; j++) {
             jl_value_t *elt;
@@ -1421,57 +1413,57 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
                 elt = jl_arrayref((jl_array_t*)v,j);
             n += jl_static_show_x(out, elt, depth);
             if (j != tlen-1)
-                n += JL_PRINTF(out, ", ");
+                n += jl_printf(out, ", ");
         }
-        if(j < tlen) n += JL_PRINTF(out, " ...");
-        n += JL_PRINTF(out, "]");
+        if(j < tlen) n += jl_printf(out, " ...");
+        n += jl_printf(out, "]");
     }
     else if (jl_typeis(v,jl_loaderror_type)) {
-        n += JL_PRINTF(out, "LoadError(at ");
+        n += jl_printf(out, "LoadError(at ");
         n += jl_static_show_x(out, jl_fieldref(v, 0), depth);
-        n += JL_PRINTF(out, " line ");
+        n += jl_printf(out, " line ");
         n += jl_static_show_x(out, jl_fieldref(v, 1), depth);
-        n += JL_PRINTF(out, ": ");
+        n += jl_printf(out, ": ");
         n += jl_static_show_x(out, jl_fieldref(v, 2), depth);
-        n += JL_PRINTF(out, ")");
+        n += jl_printf(out, ")");
     }
     else if (jl_typeis(v,jl_errorexception_type)) {
-        n += JL_PRINTF(out, "ErrorException(");
+        n += jl_printf(out, "ErrorException(");
         n += jl_static_show_x(out, jl_fieldref(v, 0), depth);
-        n += JL_PRINTF(out, ")");
+        n += jl_printf(out, ")");
     }
     else if (jl_is_datatype(jl_typeof(v))) {
         jl_datatype_t *t = (jl_datatype_t*)jl_typeof(v);
         n += jl_static_show_x(out, (jl_value_t*)t, depth);
-        n += JL_PRINTF(out, "(");
+        n += jl_printf(out, "(");
         size_t nb = jl_datatype_size(t);
         size_t tlen = jl_tuple_len(t->names);
         if (nb > 0 && tlen == 0) {
             char *data = (char*)jl_data_ptr(v);
-            n += JL_PRINTF(out, "0x");
+            n += jl_printf(out, "0x");
             for(int i=nb-1; i >= 0; --i)
-                n += JL_PRINTF(out, "%02hhx", data[i]);
+                n += jl_printf(out, "%02hhx", data[i]);
         }
         else {
             jl_value_t *fldval=NULL;
             JL_GC_PUSH1(&fldval);
             for (size_t i = 0; i < tlen; i++) {
-                n += JL_PRINTF(out, ((jl_sym_t*)jl_tupleref(t->names, i))->name);
+                n += jl_printf(out, ((jl_sym_t*)jl_tupleref(t->names, i))->name);
                 //jl_fielddesc_t f = t->fields[i];
-                n += JL_PRINTF(out, "=");
+                n += jl_printf(out, "=");
                 fldval = jl_get_nth_field(v, i);
                 n += jl_static_show_x(out, fldval, depth);
                 if (i != tlen-1)
-                    n += JL_PRINTF(out, ", ");
+                    n += jl_printf(out, ", ");
             }
             JL_GC_POP();
         }
-        n += JL_PRINTF(out, ")");
+        n += jl_printf(out, ")");
     }
     else {
-        n += JL_PRINTF(out, "<?::");
+        n += jl_printf(out, "<?::");
         n += jl_static_show_x(out, jl_typeof(v), depth);
-        n += JL_PRINTF(out, ">");
+        n += jl_printf(out, ">");
     }
     return n;
 }
@@ -1489,10 +1481,10 @@ DLLEXPORT void jl_(void *jl_value)
     in_jl_++;
     JL_TRY {
         (void)jl_static_show(JL_STDOUT, (jl_value_t*)jl_value);
-        JL_PRINTF(JL_STDOUT,"\n");
+        jl_printf(JL_STDOUT,"\n");
     }
     JL_CATCH {
-        JL_PRINTF(JL_STDOUT, "\n!!! ERROR in jl_ -- ABORTING !!!\n");
+        jl_printf(JL_STDOUT, "\n!!! ERROR in jl_ -- ABORTING !!!\n");
     }
     in_jl_--;
 }

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -552,7 +552,7 @@ static Value *emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     else if (sym.fptr != NULL) {
         res = literal_static_pointer_val(sym.fptr, lrt);
         if (imaging_mode)
-            JL_PRINTF(JL_STDERR,"warning: literal address used in cglobal for %s; code cannot be statically compiled\n", sym.f_name);
+            jl_printf(JL_STDERR,"warning: literal address used in cglobal for %s; code cannot be statically compiled\n", sym.f_name);
     }
     else {
         if (imaging_mode) {
@@ -1045,25 +1045,6 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         savespot = &_savespot;
     }
 
-    if (0 && f_name != NULL) {
-        // print the f_name before each ccall
-        Value *zeros[2] = { ConstantInt::get(T_int32, 0),
-                            ConstantInt::get(T_int32, 0) };
-        std::stringstream msg;
-            msg << "ccall: ";
-            msg << f_name;
-            msg << "(...)";
-            if (f_lib != NULL && (intptr_t)f_lib != 1 && (intptr_t)f_lib != 2) {
-                msg << " in library ";
-                msg << f_lib;
-            }
-            msg << "\n";
-        builder.CreateCall2(prepare_call(jlputs_func),
-                            builder.CreateGEP(stringConst(msg.str()),
-                                         ArrayRef<Value*>(zeros)),
-                            prepare_global(jlstderr_var));
-    }
-
     // emit arguments
     Value **argvals = (Value**) alloca(((nargs-3)/2 + sret)*sizeof(Value*));
     Value *result;
@@ -1159,7 +1140,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         Type *funcptype = PointerType::get(functype,0);
         llvmf = literal_static_pointer_val(fptr, funcptype);
         if (imaging_mode)
-            JL_PRINTF(JL_STDERR,"warning: literal address used in ccall for %s; code cannot be statically compiled\n", f_name);
+            jl_printf(JL_STDERR,"warning: literal address used in ccall for %s; code cannot be statically compiled\n", f_name);
     }
     else {
         assert(f_name != NULL);
@@ -1258,7 +1239,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     if (!sret && lrt == T_void)
         return literal_pointer_val((jl_value_t*)jl_nothing);
     if (lrt->isStructTy()) {
-        //fprintf(stderr, "ccall rt: %s -> %s\n", f_name, ((jl_tag_type_t*)rt)->name->name->name);
+        //jl_printf(JL_STDERR, "ccall rt: %s -> %s\n", f_name, ((jl_tag_type_t*)rt)->name->name->name);
         assert(jl_is_structtype(rt));
         Value *strct =
             builder.CreateCall(prepare_call(jlallocobj_func),

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -320,7 +320,6 @@ static Function *box8_func;
 static Function *box16_func;
 static Function *box32_func;
 static Function *box64_func;
-static Function *jlputs_func;
 static Function *wbfunc;
 static Function *queuerootfun;
 static Function *expect_func;
@@ -596,7 +595,7 @@ static Function *to_function(jl_lambda_info_t *li, bool cstyle)
     Function *f = NULL;
     JL_TRY {
         f = emit_function(li, cstyle);
-        //JL_PRINTF(JL_STDOUT, "emit %s\n", li->name->name);
+        //jl_printf(JL_STDOUT, "emit %s\n", li->name->name);
         //n_emit++;
     }
     JL_CATCH {
@@ -630,7 +629,7 @@ static Function *to_function(jl_lambda_info_t *li, bool cstyle)
     FPM->run(*f);
     //n_compile++;
     // print out the function's LLVM code
-    //ios_printf(ios_stderr, "%s:%d\n",
+    //jl_printf(JL_STDERR, "%s:%d\n",
     //           ((jl_sym_t*)li->file)->name, li->line);
     //if (verifyFunction(*f,PrintMessageAction)) {
     //    f->dump();
@@ -853,7 +852,7 @@ const jl_value_t *jl_dump_llvmf(void *f, bool dumpasm)
         if (jl_get_llvmf_info(fptr, &symsize, &object))
             jl_dump_function_asm((char *)fptr, symsize, object, fstream);
         else
-            JL_PRINTF(JL_STDERR, "Warning: Unable to find function pointer\n");
+            jl_printf(JL_STDERR, "Warning: Unable to find function pointer\n");
         fstream.flush();
     }
     return jl_cstr_to_string(const_cast<char*>(stream.str().c_str()));
@@ -872,7 +871,7 @@ void *jl_get_llvmf(jl_function_t *f, jl_tuple_t *types, bool getwrapper)
         sf = jl_method_lookup_by_type(jl_gf_mtable(f), types, 0, 0);
         if (sf == jl_bottom_func)
             return NULL;
-        JL_PRINTF(JL_STDERR,
+        jl_printf(JL_STDERR,
                   "Warning: Returned code may not match what actually runs.\n");
     }
     Function *llvmf;
@@ -1902,7 +1901,7 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
             if (aty != NULL) {
                 /*
                   if (trace) {
-                      JL_PRINTF(JL_STDOUT, "call %s%s\n",
+                      jl_printf(JL_STDOUT, "call %s%s\n",
                       jl_sprint(args[0]),
                       jl_sprint((jl_value_t*)aty));
                   }
@@ -3395,7 +3394,7 @@ static Value *emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed,
     }
     else if (head == simdloop_sym) {
         if (!llvm::annotateSimdLoop(builder.GetInsertBlock()))
-            JL_PRINTF(JL_STDERR, "Warning: could not attach metadata for @simd loop.\n");
+            jl_printf(JL_STDERR, "Warning: could not attach metadata for @simd loop.\n");
         return NULL;
     }
     else if (head == meta_sym) {
@@ -3691,8 +3690,8 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
     }
     assert(jl_is_expr(ast));
     sparams = jl_tuple_tvars_to_symbols(lam->sparams);
-    //JL_PRINTF((jl_value_t*)ast);
-    //JL_PRINTF(JL_STDOUT, "\n");
+    //jl_printf((jl_value_t*)ast);
+    //jl_printf(JL_STDOUT, "\n");
     std::map<jl_sym_t*, jl_arrayvar_t> arrayvars;
     std::map<int, BasicBlock*> labels;
     std::map<int, Value*> handlers;
@@ -3950,7 +3949,7 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
     BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", f);
     builder.SetInsertPoint(b0);
 
-    //ios_printf(ios_stderr, "\n*** compiling %s at %s:%d\n\n",
+    //jl_printf(JL_STDERR, "\n*** compiling %s at %s:%d\n\n",
     //           lam->name->name, filename.c_str(), lno);
 
     DebugLoc noDbg;
@@ -5128,15 +5127,6 @@ static void init_julia_llvm_env(Module *m)
                          "jl_alloc_tuple", m);
     add_named_global(jl_alloc_tuple_func, (void*)&jl_alloc_tuple);
 
-    std::vector<Type *> puts_args(0);
-    puts_args.push_back(T_pint8);
-    puts_args.push_back(T_pint8);
-    jlputs_func =
-        Function::Create(FunctionType::get(T_void, puts_args, false),
-                         Function::ExternalLinkage,
-                         "jl_puts", m);
-    add_named_global(jlputs_func, (void*)&jl_puts);
-
     std::vector<Type *> dlsym_args(0);
     dlsym_args.push_back(T_pint8);
     dlsym_args.push_back(T_pint8);
@@ -5421,9 +5411,9 @@ extern "C" void jl_init_codegen(void)
     engine_module->setDataLayout(jl_TargetMachine->getDataLayout()->getStringRepresentation());
 #endif
     jl_ExecutionEngine = eb->create(jl_TargetMachine);
-    //ios_printf(ios_stderr,"%s\n",jl_ExecutionEngine->getDataLayout()->getStringRepresentation().c_str());
+    //jl_printf(JL_STDERR,"%s\n",jl_ExecutionEngine->getDataLayout()->getStringRepresentation().c_str());
     if (!jl_ExecutionEngine) {
-        JL_PRINTF(JL_STDERR, "Critical error initializing llvm: ", ErrorStr.c_str());
+        jl_printf(JL_STDERR, "Critical error initializing llvm: ", ErrorStr.c_str());
         exit(1);
     }
 #ifdef LLVM35

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -130,7 +130,7 @@ static void create_PRUNTIME_FUNCTION(uint8_t *Code, size_t Size, StringRef fnnam
 #endif
             static int warned = 0;
             if (!warned) {
-                JL_PRINTF(JL_STDERR, "WARNING: failed to insert module info for backtrace: %d\n", GetLastError());
+                jl_printf(JL_STDERR, "WARNING: failed to insert module info for backtrace: %d\n", GetLastError());
                 warned = 1;
             }
         }
@@ -143,7 +143,7 @@ static void create_PRUNTIME_FUNCTION(uint8_t *Code, size_t Size, StringRef fnnam
             name[len-1] = 0;
             if (!SymAddSymbol(GetCurrentProcess(), (ULONG64)Section, name,
                         (DWORD64)Code, (DWORD)Size, 0)) {
-                JL_PRINTF(JL_STDERR, "WARNING: failed to insert function name %s into debug info: %d\n", name, GetLastError());
+                jl_printf(JL_STDERR, "WARNING: failed to insert function name %s into debug info: %d\n", name, GetLastError());
             }
         }
         jl_in_stackwalk = 0;
@@ -152,7 +152,7 @@ static void create_PRUNTIME_FUNCTION(uint8_t *Code, size_t Size, StringRef fnnam
     if (!RtlAddFunctionTable(tbl, 1, (DWORD64)Section)) {
         static int warned = 0;
         if (!warned) {
-            JL_PRINTF(JL_STDERR, "WARNING: failed to insert function stack unwind info: %d\n", GetLastError());
+            jl_printf(JL_STDERR, "WARNING: failed to insert function stack unwind info: %d\n", GetLastError());
             warned = 1;
         }
     }
@@ -528,7 +528,7 @@ void jl_getDylibFunctionInfo(const char **name, size_t *line, const char **filen
         }
         else {
             // SymFromAddr failed
-            //fprintf(stderr,"SymFromAddr returned error : %lu\n", GetLastError());
+            //jl_printf(JL_STDERR,"SymFromAddr returned error : %lu\n", GetLastError());
         }
 
         frame_info_line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -304,7 +304,7 @@ void jl_dump_function_asm(const char *Fptr, size_t Fsize,
     OwningPtr<MCDisassembler> DisAsm(TheTarget->createMCDisassembler(*STI));
 #endif
     if (!DisAsm) {
-        JL_PRINTF(JL_STDERR, "error: no disassembler for target", TripleName.c_str(), "\n");
+        jl_printf(JL_STDERR, "error: no disassembler for target", TripleName.c_str(), "\n");
         return;
     }
 

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -143,7 +143,7 @@ static uv_lib_t *jl_load_dynamic_library_(const char *modname, unsigned flags, i
 #endif
 
     if (throw_err) {
-        //JL_PRINTF(JL_STDERR, "could not load module %s (%d): %s\n", modname, error, uv_dlerror(handle));
+        //jl_printf(JL_STDERR, "could not load module %s (%d): %s\n", modname, error, uv_dlerror(handle));
         jl_errorf("could not load module %s: %s", modname, uv_dlerror(handle));
     }
     uv_dlclose(handle);

--- a/src/dump.c
+++ b/src/dump.c
@@ -322,7 +322,7 @@ static void jl_delayed_fptrs(jl_lambda_info_t *li, int32_t func, int32_t cfunc)
 
 static void jl_update_all_fptrs()
 {
-    //printf("delayed_fptrs_n: %d\n", delayed_fptrs_n);
+    //jl_printf(JL_STDOUT, "delayed_fptrs_n: %d\n", delayed_fptrs_n);
     jl_value_t ***gvars = sysimg_gvars;
     if (gvars == 0) return;
     // jl_fptr_to_llvm needs to decompress some ASTs, therefore this needs to be NULL
@@ -743,7 +743,7 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
     }
 }
 
-void jl_serialize_methtable_from_mod(ios_t *s, jl_module_t *m, jl_sym_t *name, jl_methtable_t *mt, int8_t iskw)
+static void jl_serialize_methtable_from_mod(ios_t *s, jl_module_t *m, jl_sym_t *name, jl_methtable_t *mt, int8_t iskw)
 {
     if (iskw) {
         if (!mt->kwsorter)
@@ -783,7 +783,7 @@ void jl_serialize_methtable_from_mod(ios_t *s, jl_module_t *m, jl_sym_t *name, j
     }
 }
 
-void jl_serialize_lambdas_from_mod(ios_t *s, jl_module_t *m)
+static void jl_serialize_lambdas_from_mod(ios_t *s, jl_module_t *m)
 {
     if (m == jl_current_module) return;
     size_t i;
@@ -1337,8 +1337,7 @@ DLLEXPORT void jl_save_system_image(const char *fname)
     htable_reset(&backref_table, 250000);
     ios_t f;
     if (ios_file(&f, fname, 1, 1, 1, 1) == NULL) {
-        JL_PRINTF(JL_STDERR, "Cannot open system image file \"%s\" for writing.\n", fname);
-        exit(1);
+        jl_errorf("Cannot open system image file \"%s\" for writing.\n", fname);
     }
 
     // orphan old Base module if present
@@ -1411,8 +1410,7 @@ void jl_restore_system_image(const char *fname)
 {
     ios_t f;
     if (ios_file(&f, fname, 1, 0, 0, 0) == NULL) {
-        JL_PRINTF(JL_STDERR, "System image file \"%s\" not found\n", fname);
-        exit(1);
+        jl_errorf("System image file \"%s\" not found\n", fname);
     }
     int build_mode = 0;
 #ifdef _OS_WINDOWS_
@@ -1475,7 +1473,7 @@ void jl_restore_system_image(const char *fname)
     jl_set_t_uid_ctr(read_int32(&f));
     jl_set_gs_ctr(read_int32(&f));
 
-    //ios_printf(ios_stderr, "backref_list.len = %d\n", backref_list.len);
+    //jl_printf(JL_STDERR, "backref_list.len = %d\n", backref_list.len);
     arraylist_free(&backref_list);
     ios_close(&f);
 
@@ -1550,7 +1548,7 @@ jl_value_t *jl_compress_ast(jl_lambda_info_t *li, jl_value_t *ast)
     jl_serialize_value(&dest, jl_lam_body((jl_expr_t*)ast)->etype);
     jl_serialize_value(&dest, ast);
 
-    //JL_PRINTF(JL_STDERR, "%d bytes, %d values\n", dest.size, vals->length);
+    //jl_printf(JL_STDERR, "%d bytes, %d values\n", dest.size, vals->length);
 
     jl_value_t *v = (jl_value_t*)jl_takebuf_array(&dest);
     if (jl_array_len(tree_literal_values) == 0 && last_tlv == NULL) {
@@ -1590,7 +1588,7 @@ int jl_save_new_module(const char *fname, jl_module_t *mod)
 {
     ios_t f;
     if (ios_file(&f, fname, 1, 1, 1, 1) == NULL) {
-        JL_PRINTF(JL_STDERR, "Cannot open cache file \"%s\" for writing.\n", fname);
+        jl_printf(JL_STDERR, "Cannot open cache file \"%s\" for writing.\n", fname);
         return 1;
     }
     htable_new(&backref_table, 5000);
@@ -1628,7 +1626,7 @@ jl_module_t *jl_restore_new_module(const char *fname)
 {
     ios_t f;
     if (ios_file(&f, fname, 1, 0, 0, 0) == NULL) {
-        JL_PRINTF(JL_STDERR, "Cache file \"%s\" not found\n", fname);
+        jl_printf(JL_STDERR, "Cache file \"%s\" not found\n", fname);
         return NULL;
     }
     if (ios_eof(&f)) {
@@ -1649,7 +1647,7 @@ jl_module_t *jl_restore_new_module(const char *fname)
     jl_binding_t *b = jl_get_binding_wr(parent, name);
     jl_declare_constant(b);
     if (b->value != NULL) {
-        JL_PRINTF(JL_STDERR, "Warning: replacing module %s\n", name->name);
+        jl_printf(JL_STDERR, "Warning: replacing module %s\n", name->name);
     }
     b->value = jl_deserialize_value(&f, &b->value);
 

--- a/src/flisp/flisp.c
+++ b/src/flisp/flisp.c
@@ -2443,6 +2443,18 @@ void fl_init(size_t initial_heapsize)
     fl_init_julia_extensions();
 }
 
+extern fltype_t *iostreamtype;
+
+int fl_load_system_image_str(char* str, size_t len)
+{
+    value_t img = cvalue(iostreamtype, sizeof(ios_t));
+    ios_t *pi = value2c(ios_t*, img);
+    ios_static_buffer(pi, str, len);
+
+    return fl_load_system_image(img);
+}
+
+
 int fl_load_system_image(value_t sys_image_iostream)
 {
     value_t e;

--- a/src/flisp/flisp.h
+++ b/src/flisp/flisp.h
@@ -386,6 +386,7 @@ value_t cvalue_wchar(value_t *args, uint32_t nargs);
 
 void fl_init(size_t initial_heapsize);
 int fl_load_system_image(value_t ios);
+int fl_load_system_image_str(char* str, size_t len);
 
 /* julia extensions */
 DLLEXPORT int jl_id_char(uint32_t wc);

--- a/src/gc.c
+++ b/src/gc.c
@@ -279,25 +279,25 @@ static void add_lostval_parent(jl_value_t* parent)
 
 #define verify_val(v) do {                                              \
         if(lostval == (jl_value_t*)(v) && (v) != 0) {                   \
-            JL_PRINTF(JL_STDOUT,                                        \
+            jl_printf(JL_STDOUT,                                        \
                       "Found lostval 0x%lx at %s:%d oftype: ",          \
                       (uintptr_t)(lostval), __FILE__, __LINE__);        \
             jl_static_show(JL_STDOUT, jl_typeof(v));                    \
-            JL_PRINTF(JL_STDOUT, "\n");                                 \
+            jl_printf(JL_STDOUT, "\n");                                 \
         }                                                               \
     } while(0);
 
 
 #define verify_parent(ty, obj, slot, args...) do {                      \
         if(*(jl_value_t**)(slot) == lostval && (obj) != lostval) {      \
-            JL_PRINTF(JL_STDOUT, "Found parent %s 0x%lx at %s:%d\n",    \
+            jl_printf(JL_STDOUT, "Found parent %s 0x%lx at %s:%d\n",    \
                       ty, (uintptr_t)(obj), __FILE__, __LINE__);        \
-            JL_PRINTF(JL_STDOUT, "\tloc 0x%lx : ", (uintptr_t)(slot));  \
-            JL_PRINTF(JL_STDOUT, args);                                 \
-            JL_PRINTF(JL_STDOUT, "\n");                                 \
-            JL_PRINTF(JL_STDOUT, "\ttype: ");                           \
+            jl_printf(JL_STDOUT, "\tloc 0x%lx : ", (uintptr_t)(slot));  \
+            jl_printf(JL_STDOUT, args);                                 \
+            jl_printf(JL_STDOUT, "\n");                                 \
+            jl_printf(JL_STDOUT, "\ttype: ");                           \
             jl_static_show(JL_STDOUT, jl_typeof(obj));                  \
-            JL_PRINTF(JL_STDOUT, "\n");                                 \
+            jl_printf(JL_STDOUT, "\n");                                 \
             add_lostval_parent((jl_value_t*)(obj));                     \
         }                                                               \
     } while(0);
@@ -707,9 +707,9 @@ static void run_finalizer(jl_value_t *o, jl_value_t *ff)
         jl_apply(f, (jl_value_t**)&o, 1);
     }
     JL_CATCH {
-        JL_PRINTF(JL_STDERR, "error in running finalizer: ");
+        jl_printf(JL_STDERR, "error in running finalizer: ");
         jl_static_show(JL_STDERR, jl_exception_in_transit);
-        JL_PUTC('\n',JL_STDERR);
+        jl_printf(JL_STDERR, "\n");
     }
 }
 
@@ -1259,7 +1259,7 @@ static void gc_sweep_once(int sweep_mask)
 #endif
     sweep_malloced_arrays();
 #ifdef GC_TIME
-    JL_PRINTF(JL_STDOUT, "GC sweep arrays %.2f (freed %d/%d)\n", (clock_now() - t0)*1000, mallocd_array_freed, mallocd_array_total);
+    jl_printf(JL_STDOUT, "GC sweep arrays %.2f (freed %d/%d)\n", (clock_now() - t0)*1000, mallocd_array_freed, mallocd_array_total);
     t0 = clock_now();
     big_total = 0;
     big_freed = 0;
@@ -1267,13 +1267,13 @@ static void gc_sweep_once(int sweep_mask)
 #endif
     sweep_big(sweep_mask);
 #ifdef GC_TIME
-    JL_PRINTF(JL_STDOUT, "GC sweep big %.2f (freed %d/%d with %d rst)\n", (clock_now() - t0)*1000, big_freed, big_total, big_reset);
+    jl_printf(JL_STDOUT, "GC sweep big %.2f (freed %d/%d with %d rst)\n", (clock_now() - t0)*1000, big_freed, big_total, big_reset);
     t0 = clock_now();
 #endif
     if (sweep_mask == GC_MARKED)
         jl_unmark_symbols();
 #ifdef GC_TIME
-    JL_PRINTF(JL_STDOUT, "GC sweep symbols %.2f\n", (clock_now() - t0)*1000);
+    jl_printf(JL_STDOUT, "GC sweep symbols %.2f\n", (clock_now() - t0)*1000);
 #endif
 }
 
@@ -1298,7 +1298,7 @@ static int gc_sweep_inc(int sweep_mask)
 #ifdef GC_TIME
     double sweep_pool_sec = clock_now() - t0;
     double sweep_speed = ((((double)total_pages)*GC_PAGE_SZ)/(1024*1024*1024))/sweep_pool_sec;
-    JL_PRINTF(JL_STDOUT, "GC sweep pools %s %.2f at %.1f GB/s (skipped %d%% of %d, done %d pgs, %d freed with %d lazily) mask %d\n", finished ? "end" : "inc", sweep_pool_sec*1000, sweep_speed, total_pages ? (skipped_pages*100)/total_pages : 0, total_pages, page_done, freed_pages, lazy_freed_pages,  sweep_mask);
+    jl_printf(JL_STDOUT, "GC sweep pools %s %.2f at %.1f GB/s (skipped %d%% of %d, done %d pgs, %d freed with %d lazily) mask %d\n", finished ? "end" : "inc", sweep_pool_sec*1000, sweep_speed, total_pages ? (skipped_pages*100)/total_pages : 0, total_pages, page_done, freed_pages, lazy_freed_pages,  sweep_mask);
 #endif
     return finished;
 }
@@ -1318,7 +1318,7 @@ void grow_mark_stack(void)
     size_t offset = mark_stack - mark_stack_base;
     mark_stack_base = (jl_value_t**)realloc(mark_stack_base, newsz*sizeof(void*));
     if (mark_stack_base == NULL) {
-        JL_PRINTF(JL_STDERR, "Could'nt grow mark stack to : %d\n", newsz);
+        jl_printf(JL_STDERR, "Could'nt grow mark stack to : %d\n", newsz);
         exit(1);
     }
     mark_stack = mark_stack_base + offset;
@@ -1638,7 +1638,7 @@ static int push_root(jl_value_t *v, int d, int bits)
     }
 #ifdef GC_VERIFY
     else {
-        JL_PRINTF(JL_STDOUT, "GC error (probable corruption) :\n");
+        jl_printf(JL_STDOUT, "GC error (probable corruption) :\n");
         jl_(vt);
         abort();
     }
@@ -2083,7 +2083,7 @@ void jl_gc_collect(int full)
         uint64_t mark_pause = jl_hrtime() - t0;
 #endif
 #ifdef GC_TIME
-        JL_PRINTF(JL_STDOUT, "GC mark pause %.2f ms | scanned %ld kB = %ld + %ld | stack %d -> %d (wb %d) | remset %d %d\n", NS2MS(mark_pause), (scanned_bytes + perm_scanned_bytes)/1024, scanned_bytes/1024, perm_scanned_bytes/1024, saved_mark_sp, mark_sp, wb_activations, last_remset->len, allocd_bytes/1024);
+        jl_printf(JL_STDOUT, "GC mark pause %.2f ms | scanned %ld kB = %ld + %ld | stack %d -> %d (wb %d) | remset %d %d\n", NS2MS(mark_pause), (scanned_bytes + perm_scanned_bytes)/1024, scanned_bytes/1024, perm_scanned_bytes/1024, saved_mark_sp, mark_sp, wb_activations, last_remset->len, allocd_bytes/1024);
         saved_mark_sp = mark_sp;
 #endif
 #ifdef GC_FINAL_STATS
@@ -2214,7 +2214,7 @@ void jl_gc_collect(int full)
         total_fin_time += finalize_time + post_time;
 #endif
 #ifdef GC_TIME
-        JL_PRINTF(JL_STDOUT, "GC sweep pause %.2f ms live %ld kB (freed %d kB EST %d kB [error %d] = %d%% of allocd %d kB b/r %ld/%ld) (%.2f ms in post_mark, %.2f ms in %d fin) (marked in %d inc) mask %d | next in %d kB\n", NS2MS(sweep_pause), live_bytes/1024, SAVE2/1024, estimate_freed/1024, (SAVE2 - estimate_freed), pct, SAVE3/1024, bonus/1024, SAVE/1024, NS2MS(post_time), NS2MS(finalize_time), n_finalized, inc_count, sweep_mask, -allocd_bytes/1024);
+        jl_printf(JL_STDOUT, "GC sweep pause %.2f ms live %ld kB (freed %d kB EST %d kB [error %d] = %d%% of allocd %d kB b/r %ld/%ld) (%.2f ms in post_mark, %.2f ms in %d fin) (marked in %d inc) mask %d | next in %d kB\n", NS2MS(sweep_pause), live_bytes/1024, SAVE2/1024, estimate_freed/1024, (SAVE2 - estimate_freed), pct, SAVE3/1024, bonus/1024, SAVE/1024, NS2MS(post_time), NS2MS(finalize_time), n_finalized, inc_count, sweep_mask, -allocd_bytes/1024);
 #endif
     }
     n_pause++;
@@ -2434,7 +2434,7 @@ static size_t pool_stats(pool_t *p, size_t *pwaste, size_t *np, size_t *pnold)
     *np = npgs;
     *pnold = nold;
     if (npgs != 0) {
-        JL_PRINTF(JL_STDOUT,
+        jl_printf(JL_STDOUT,
                   "%4d : %7d/%7d objects (%3d%% old), %5d pages, %5d kB, %5d kB waste\n",
                   p->osize,
                   nused,
@@ -2460,7 +2460,7 @@ static void all_pool_stats(void)
         nold += nol;
         noldbytes += nol*norm_pools[i].osize;
     }
-    JL_PRINTF(JL_STDOUT,
+    jl_printf(JL_STDOUT,
               "%d objects (%d%% old), %d kB (%d%% old) total allocated, %d total fragments (%d%% overhead), in %d pages\n",
               no, (nold*100)/no, nb/1024, (noldbytes*100)/nb, tw, (tw*100)/nb, tp);
 }
@@ -2495,7 +2495,7 @@ static void big_obj_stats(void)
         ma = ma->next;
     }
 
-    JL_PRINTF(JL_STDOUT, "%d kB (%d%% old) in %d large objects (%d%% old)\n", (nbytes + nbytes_old)/1024, nbytes + nbytes_old ? (nbytes_old*100)/(nbytes + nbytes_old) : 0, nused + nused_old, nused+nused_old ? (nused_old*100)/(nused + nused_old) : 0);
+    jl_printf(JL_STDOUT, "%d kB (%d%% old) in %d large objects (%d%% old)\n", (nbytes + nbytes_old)/1024, nbytes + nbytes_old ? (nbytes_old*100)/(nbytes + nbytes_old) : 0, nused + nused_old, nused+nused_old ? (nused_old*100)/(nused + nused_old) : 0);
 }
 #endif //MEMPROFILE
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -408,9 +408,9 @@ void jl_type_infer(jl_lambda_info_t *li, jl_tuple_t *argtypes,
         fargs[2] = (jl_value_t*)jl_null;
         fargs[3] = (jl_value_t*)def;
 #ifdef TRACE_INFERENCE
-        JL_PRINTF(JL_STDERR,"inference on %s", li->name->name);
+        jl_printf(JL_STDERR,"inference on %s", li->name->name);
         jl_static_show(JL_STDERR, (jl_value_t*)argtypes);
-        JL_PRINTF(JL_STDERR, "\n");
+        jl_printf(JL_STDERR, "\n");
 #endif
 #ifdef ENABLE_INFERENCE
         jl_value_t *newast = jl_apply(jl_typeinf_func, fargs, 4);
@@ -829,9 +829,9 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tuple_t *type,
     else {
         if (jl_compileropts.compile_enabled == 0) {
             if (method->linfo->unspecialized == NULL) {
-                JL_PRINTF(JL_STDERR,"code missing for %s", method->linfo->name->name);
+                jl_printf(JL_STDERR,"code missing for %s", method->linfo->name->name);
                 jl_static_show(JL_STDERR, (jl_value_t*)type);
-                JL_PRINTF(JL_STDERR, "\n");
+                jl_printf(JL_STDERR, "\n");
                 exit(1);
             }
             jl_function_t *unspec = method->linfo->unspecialized;
@@ -1185,15 +1185,15 @@ static void check_ambiguous(jl_methlist_t *ml, jl_tuple_t *type,
         n = fname->name;
         errstream = jl_stderr_obj();
         s = JL_STDERR;
-        JL_PRINTF(s, "Warning: New definition \n    %s", n);
+        jl_printf(s, "Warning: New definition \n    %s", n);
         jl_show(errstream, (jl_value_t*)type);
         print_func_loc(s, linfo);
-        JL_PRINTF(s, "\nis ambiguous with: \n    %s", n);
+        jl_printf(s, "\nis ambiguous with: \n    %s", n);
         jl_show(errstream, (jl_value_t*)sig);
         print_func_loc(s, oldmeth->func->linfo);
-        JL_PRINTF(s, ".\nTo fix, define \n    %s", n);
+        jl_printf(s, ".\nTo fix, define \n    %s", n);
         jl_show(errstream, isect);
-        JL_PRINTF(s, "\nbefore the new definition.\n");
+        jl_printf(s, "\nbefore the new definition.\n");
     done_chk_amb:
         JL_GC_POP();
     }
@@ -1229,13 +1229,13 @@ jl_methlist_t *jl_method_list_insert(jl_methlist_t **pml, jl_tuple_t *type,
                 jl_module_t *newmod = method->linfo->module;
                 jl_value_t *errstream = jl_stderr_obj();
                 JL_STREAM *s = JL_STDERR;
-                JL_PRINTF(s, "Warning: Method definition %s", method->linfo->name->name);
+                jl_printf(s, "Warning: Method definition %s", method->linfo->name->name);
                 jl_show(errstream, (jl_value_t*)type);
-                JL_PRINTF(s, " in module %s", l->func->linfo->module->name->name);
+                jl_printf(s, " in module %s", l->func->linfo->module->name->name);
                 print_func_loc(s, l->func->linfo);
-                JL_PRINTF(s, " overwritten in module %s", newmod->name->name);
+                jl_printf(s, " overwritten in module %s", newmod->name->name);
                 print_func_loc(s, method->linfo);
-                JL_PRINTF(s, ".\n");
+                jl_printf(s, ".\n");
             }
             JL_SIGATOMIC_BEGIN();
             l->sig = type;
@@ -1618,12 +1618,12 @@ static int error_en = 1;
 static void __attribute__ ((unused)) enable_trace(int x) { trace_en=x; }
 static void show_call(jl_value_t *F, jl_value_t **args, uint32_t nargs)
 {
-    JL_PRINTF(JL_STDOUT, "%s(",  jl_gf_name(F)->name);
+    jl_printf(JL_STDOUT, "%s(",  jl_gf_name(F)->name);
     for(size_t i=0; i < nargs; i++) {
-        if (i > 0) JL_PRINTF(JL_STDOUT, ", ");
+        if (i > 0) jl_printf(JL_STDOUT, ", ");
         jl_static_show(JL_STDOUT, jl_typeof(args[i]));
     }
-    JL_PRINTF(JL_STDOUT, ")\n");
+    jl_printf(JL_STDOUT, ")\n");
 }
 #endif
 
@@ -1802,7 +1802,7 @@ void print_func_loc(JL_STREAM *s, jl_lambda_info_t *li)
     long lno = li->line;
     if (lno > 0) {
         char *fname = ((jl_sym_t*)li->file)->name;
-        JL_PRINTF(s, " at %s:%d", fname, lno);
+        jl_printf(s, " at %s:%d", fname, lno);
     }
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -212,7 +212,7 @@ void sigdie_handler(int sig, siginfo_t *info, void *context)
         sigprocmask(SIG_UNBLOCK, &sset, NULL);
         signal(sig, SIG_DFL);
     }
-    ios_printf(ios_stderr,"\nsignal (%d): %s\n", sig, strsignal(sig));
+    jl_safe_printf("\nsignal (%d): %s\n", sig, strsignal(sig));
 #ifdef __APPLE__
     bt_size = rec_backtrace_ctx(bt_data, MAX_BT_SIZE, (bt_context_t)&((ucontext64_t*)context)->uc_mcontext64->__ss);
 #else
@@ -305,7 +305,7 @@ static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guara
         jl_signal_pending = 0;
         if ((DWORD)-1 == SuspendThread(hMainThread)) {
             //error
-            fputs("error: SuspendThread failed\n",stderr);
+            jl_safe_printf("error: SuspendThread failed\n");
             return 0;
         }
         CONTEXT ctxThread;
@@ -313,18 +313,18 @@ static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guara
         ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
         if (!GetThreadContext(hMainThread, &ctxThread)) {
             //error
-            fputs("error: GetThreadContext failed\n",stderr);
+            jl_safe_printf("error: GetThreadContext failed\n");
             return 0;
         }
         jl_throw_in_ctx(jl_interrupt_exception, &ctxThread, 1);
         ctxThread.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
         if (!SetThreadContext(hMainThread,&ctxThread)) {
-            fputs("error: SetThreadContext failed\n",stderr);
+            jl_safe_printf("error: SetThreadContext failed\n");
             //error
             return 0;
         }
         if ((DWORD)-1 == ResumeThread(hMainThread)) {
-            fputs("error: ResumeThread failed\n",stderr);
+            jl_safe_printf("error: ResumeThread failed\n");
             //error
             return 0;
         }
@@ -344,52 +344,52 @@ static LONG WINAPI _exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo,
                 jl_throw_in_ctx(jl_stackovf_exception, ExceptionInfo->ContextRecord,in_ctx&&pSetThreadStackGuarantee);
                 return EXCEPTION_CONTINUE_EXECUTION;
         }
-        ios_puts("\nPlease submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.\nException: ", ios_stderr);
+        jl_safe_printf("\nPlease submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.\nException: ");
         switch (ExceptionInfo->ExceptionRecord->ExceptionCode) {
             case EXCEPTION_ACCESS_VIOLATION:
-                ios_puts("EXCEPTION_ACCESS_VIOLATION", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_ACCESS_VIOLATION"); break;
             case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
-                ios_puts("EXCEPTION_ARRAY_BOUNDS_EXCEEDED", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_ARRAY_BOUNDS_EXCEEDED"); break;
             case EXCEPTION_BREAKPOINT:
-                ios_puts("EXCEPTION_BREAKPOINT", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_BREAKPOINT"); break;
             case EXCEPTION_DATATYPE_MISALIGNMENT:
-                ios_puts("EXCEPTION_DATATYPE_MISALIGNMENT", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_DATATYPE_MISALIGNMENT"); break;
             case EXCEPTION_FLT_DENORMAL_OPERAND:
-                ios_puts("EXCEPTION_FLT_DENORMAL_OPERAND", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_FLT_DENORMAL_OPERAND"); break;
             case EXCEPTION_FLT_DIVIDE_BY_ZERO:
-                ios_puts("EXCEPTION_FLT_DIVIDE_BY_ZERO", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_FLT_DIVIDE_BY_ZERO"); break;
             case EXCEPTION_FLT_INEXACT_RESULT:
-                ios_puts("EXCEPTION_FLT_INEXACT_RESULT", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_FLT_INEXACT_RESULT"); break;
             case EXCEPTION_FLT_INVALID_OPERATION:
-                ios_puts("EXCEPTION_FLT_INVALID_OPERATION", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_FLT_INVALID_OPERATION"); break;
             case EXCEPTION_FLT_OVERFLOW:
-                ios_puts("EXCEPTION_FLT_OVERFLOW", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_FLT_OVERFLOW"); break;
             case EXCEPTION_FLT_STACK_CHECK:
-                ios_puts("EXCEPTION_FLT_STACK_CHECK", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_FLT_STACK_CHECK"); break;
             case EXCEPTION_FLT_UNDERFLOW:
-                ios_puts("EXCEPTION_FLT_UNDERFLOW", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_FLT_UNDERFLOW"); break;
             case EXCEPTION_ILLEGAL_INSTRUCTION:
-                ios_puts("EXCEPTION_ILLEGAL_INSTRUCTION", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_ILLEGAL_INSTRUCTION"); break;
             case EXCEPTION_IN_PAGE_ERROR:
-                ios_puts("EXCEPTION_IN_PAGE_ERROR", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_IN_PAGE_ERROR"); break;
             case EXCEPTION_INT_DIVIDE_BY_ZERO:
-                ios_puts("EXCEPTION_INT_DIVIDE_BY_ZERO", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_INT_DIVIDE_BY_ZERO"); break;
             case EXCEPTION_INT_OVERFLOW:
-                ios_puts("EXCEPTION_INT_OVERFLOW", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_INT_OVERFLOW"); break;
             case EXCEPTION_INVALID_DISPOSITION:
-                ios_puts("EXCEPTION_INVALID_DISPOSITION", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_INVALID_DISPOSITION"); break;
             case EXCEPTION_NONCONTINUABLE_EXCEPTION:
-                ios_puts("EXCEPTION_NONCONTINUABLE_EXCEPTION", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_NONCONTINUABLE_EXCEPTION"); break;
             case EXCEPTION_PRIV_INSTRUCTION:
-                ios_puts("EXCEPTION_PRIV_INSTRUCTION", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_PRIV_INSTRUCTION"); break;
             case EXCEPTION_SINGLE_STEP:
-                ios_puts("EXCEPTION_SINGLE_STEP", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_SINGLE_STEP"); break;
             case EXCEPTION_STACK_OVERFLOW:
-                ios_puts("EXCEPTION_STACK_OVERFLOW", ios_stderr); break;
+                jl_safe_printf("EXCEPTION_STACK_OVERFLOW"); break;
             default:
-                ios_puts("UNKNOWN", ios_stderr); break;
+                jl_safe_printf("UNKNOWN"); break;
         }
-        ios_printf(ios_stderr," at 0x%Ix -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+        jl_safe_printf(" at 0x%Ix -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
         gdblookup((ptrint_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
         bt_size = rec_backtrace_ctx(bt_data, MAX_BT_SIZE, ExceptionInfo->ContextRecord);
         jlbacktrace();
@@ -470,7 +470,7 @@ static void jl_uv_exitcleanup_add(uv_handle_t *handle, struct uv_shutdown_queue 
 
 static void jl_uv_exitcleanup_walk(uv_handle_t *handle, void *arg)
 {
-    if (handle != (uv_handle_t*)jl_uv_stdout && handle != (uv_handle_t*)jl_uv_stderr)
+    if (handle != (uv_handle_t*)JL_STDOUT && handle != (uv_handle_t*)JL_STDERR)
         jl_uv_exitcleanup_add(handle, (struct uv_shutdown_queue*)arg);
 }
 
@@ -493,7 +493,7 @@ DLLEXPORT void jl_atexit_hook()
                 jl_apply((jl_function_t*)f, NULL, 0);
             }
             JL_CATCH {
-                JL_PRINTF(JL_STDERR, "\natexit hook threw an error: ");
+                jl_printf(JL_STDERR, "\natexit hook threw an error: ");
                 jl_show(jl_stderr_obj(),jl_exception_in_transit);
             }
         }
@@ -502,14 +502,21 @@ DLLEXPORT void jl_atexit_hook()
     jl_gc_run_all_finalizers();
 
     uv_loop_t *loop = jl_global_event_loop();
+
+    if (loop == NULL) {
+        return;
+    }
+
     struct uv_shutdown_queue queue = {NULL, NULL};
     uv_walk(loop, jl_uv_exitcleanup_walk, &queue);
     // close stdout and stderr last, since we like being
     // able to show stuff (incl. printf's)
-    jl_uv_exitcleanup_add((uv_handle_t*)jl_uv_stdout, &queue);
-    jl_uv_exitcleanup_add((uv_handle_t*)jl_uv_stderr, &queue);
-    //uv_unref((uv_handle_t*)jl_uv_stdout);
-    //uv_unref((uv_handle_t*)jl_uv_stderr);
+    if (JL_STDOUT != (void*) STDOUT_FILENO)
+        jl_uv_exitcleanup_add((uv_handle_t*)JL_STDOUT, &queue);
+    if (JL_STDERR != (void*) STDERR_FILENO)
+        jl_uv_exitcleanup_add((uv_handle_t*)JL_STDERR, &queue);
+    //uv_unref((uv_handle_t*)JL_STDOUT);
+    //uv_unref((uv_handle_t*)JL_STDERR);
     struct uv_shutdown_queue_item *item = queue.first;
     while (item) {
         JL_TRY {
@@ -593,13 +600,12 @@ void *init_stdio_handle(uv_file fd,int readable)
     // unnecessary.
     fd = dup(fd);
 #endif
-    //printf("%d: %d -- %d\n", fd, type, 0);
+    //jl_printf(JL_STDOUT, "%d: %d -- %d\n", fd, type, 0);
     switch(type) {
         case UV_TTY:
             handle = malloc(sizeof(uv_tty_t));
             if (uv_tty_init(jl_io_loop,(uv_tty_t*)handle,fd,readable)) {
                 jl_errorf("Error initializing stdio in uv_tty_init (%d, %d)\n", fd, type);
-                abort();
             }
             ((uv_tty_t*)handle)->data=0;
             uv_tty_set_mode((uv_tty_t*)handle,0); //cooked stdio
@@ -624,11 +630,9 @@ void *init_stdio_handle(uv_file fd,int readable)
             handle = malloc(sizeof(uv_pipe_t));
             if (uv_pipe_init(jl_io_loop, (uv_pipe_t*)handle, (readable?UV_PIPE_READABLE:UV_PIPE_WRITABLE))) {
                 jl_errorf("Error initializing stdio in uv_pipe_init (%d, %d)\n", fd, type);
-                abort();
             }
             if (uv_pipe_open((uv_pipe_t*)handle,fd)) {
                 jl_errorf("Error initializing stdio in uv_pipe_open (%d, %d)\n", fd, type);
-                abort();
             }
             ((uv_pipe_t*)handle)->data=0;
             break;
@@ -636,18 +640,15 @@ void *init_stdio_handle(uv_file fd,int readable)
             handle = malloc(sizeof(uv_tcp_t));
             if (uv_tcp_init(jl_io_loop, (uv_tcp_t*)handle)) {
                 jl_errorf("Error initializing stdio in uv_tcp_init (%d, %d)\n", fd, type);
-                abort();
             }
             if (uv_tcp_open((uv_tcp_t*)handle,fd)) {
                 jl_errorf("Error initializing stdio in uv_tcp_open (%d, %d)\n", fd, type);
-                abort();
             }
             ((uv_tcp_t*)handle)->data=0;
             break;
         case UV_UDP:
         default:
             jl_errorf("This type of handle for stdio is not yet supported (%d, %d)!\n", fd, type);
-            handle = NULL;
             break;
     }
     return handle;
@@ -655,9 +656,11 @@ void *init_stdio_handle(uv_file fd,int readable)
 
 void init_stdio()
 {   //order must be 2,1,0
-    JL_STDERR = (uv_stream_t*)init_stdio_handle(2,0);
-    JL_STDOUT = (uv_stream_t*)init_stdio_handle(1,0);
-    JL_STDIN = (uv_stream_t*)init_stdio_handle(0,1);
+    JL_STDERR = (uv_stream_t*)init_stdio_handle(STDERR_FILENO,0);
+    JL_STDOUT = (uv_stream_t*)init_stdio_handle(STDOUT_FILENO,0);
+    JL_STDIN  = (uv_stream_t*)init_stdio_handle(STDIN_FILENO,1);
+
+    jl_flush_cstdio();
 }
 
 #ifdef JL_USE_INTEL_JITEVENTS
@@ -689,7 +692,7 @@ void *mach_segv_listener(void *arg)
     (void)arg;
     while (1) {
         int ret = mach_msg_server(exc_server,2048,segv_port,MACH_MSG_TIMEOUT_NONE);
-        printf("mach_msg_server: %s\n", mach_error_string(ret));
+        jl_safe_printf("mach_msg_server: %s\n", mach_error_string(ret));
         jl_exit(1);
     }
 }
@@ -781,7 +784,7 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
     else {
         ret = thread_get_state(thread,x86_THREAD_STATE64,(thread_state_t)&state,&count);
         HANDLE_MACH_ERROR("thread_get_state(3)",ret);
-        ios_printf(ios_stderr,"\nsignal (%d): %s\n", SIGSEGV, strsignal(SIGSEGV));
+        jl_safe_printf("\nsignal (%d): %s\n", SIGSEGV, strsignal(SIGSEGV));
         bt_size = rec_backtrace_ctx(bt_data, MAX_BT_SIZE, (unw_context_t*)&state);
         jlbacktrace();
         return KERN_INVALID_ARGUMENT;
@@ -824,12 +827,10 @@ static char *abspath(const char *in)
             size_t len = strlen(in);
             char *path = (char*)malloc(PATH_MAX);
             if (uv_cwd(path, &path_size)) {
-                ios_printf(ios_stderr, "fatal error: unexpected error while retrieving current working directory\n");
-                exit(1);
+                jl_error("fatal error: unexpected error while retrieving current working directory\n");
             }
             if (path_size + len + 1 >= PATH_MAX) {
-                ios_printf(ios_stderr, "fatal error: current working directory path too long\n");
-                exit(1);
+                jl_error("fatal error: current working directory path too long\n");
             }
             path[path_size-1] = PATHSEPSTRING[0];
             memcpy(path+path_size, in, len+1);
@@ -840,14 +841,12 @@ static char *abspath(const char *in)
 #else
     DWORD n = GetFullPathName(in, 0, NULL, NULL);
     if (n <= 0) {
-        ios_printf(ios_stderr, "fatal error: jl_compileropts.image_file path too long or GetFullPathName failed\n");
-        exit(1);
+        jl_error("fatal error: jl_compileropts.image_file path too long or GetFullPathName failed\n");
     }
     char *out = (char*)malloc(n);
     DWORD m = GetFullPathName(in, n, out, NULL);
     if (n != m + 1) {
-        ios_printf(ios_stderr, "fatal error: jl_compileropts.image_file path too long or GetFullPathName failed\n");
-        exit(1);
+        jl_error("fatal error: jl_compileropts.image_file path too long or GetFullPathName failed\n");
     }
 #endif
     return out;
@@ -864,12 +863,10 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
     char *free_path = (char*)malloc(PATH_MAX);
     size_t path_size = PATH_MAX;
     if (uv_exepath(free_path, &path_size)) {
-        ios_printf(ios_stderr, "fatal error: unexpected error while retrieving exepath\n");
-        exit(1);
+        jl_error("fatal error: unexpected error while retrieving exepath\n");
     }
     if (path_size >= PATH_MAX) {
-        ios_printf(ios_stderr, "fatal error: jl_compileropts.julia_bin path too long\n");
-        exit(1);
+        jl_error("fatal error: jl_compileropts.julia_bin path too long\n");
     }
     jl_compileropts.julia_bin = strdup(free_path);
     if (!jl_compileropts.julia_home) {
@@ -889,8 +886,7 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
             int n = snprintf(free_path, PATH_MAX, "%s" PATHSEPSTRING "%s",
                      jl_compileropts.julia_home, jl_compileropts.image_file);
             if (n >= PATH_MAX || n < 0) {
-                ios_printf(ios_stderr, "fatal error: jl_compileropts.image_file path too long\n");
-                exit(1);
+                jl_error("fatal error: jl_compileropts.image_file path too long\n");
             }
             jl_compileropts.image_file = free_path;
         }
@@ -943,11 +939,11 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     if (!DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),
                          GetCurrentProcess(), (PHANDLE)&hMainThread, 0,
                          TRUE, DUPLICATE_SAME_ACCESS)) {
-        ios_printf(ios_stderr, "WARNING: failed to access handle to main thread\n");
+        jl_printf(JL_STDERR, "WARNING: failed to access handle to main thread\n");
     }
     SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES);
     if (!SymInitialize(GetCurrentProcess(), NULL, 1)) {
-        ios_printf(ios_stderr, "WARNING: failed to initialize stack walk info\n");
+        jl_printf(JL_STDERR, "WARNING: failed to initialize stack walk info\n");
     }
     needsSymRefreshModuleList = 0;
     uv_lib_t jl_dbghelp;
@@ -958,7 +954,6 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     if (uv_dlsym(jl_kernel32_handle, "SetThreadStackGuarantee", (void**)&pSetThreadStackGuarantee) || !pSetThreadStackGuarantee(&StackSizeInBytes))
         pSetThreadStackGuarantee = NULL;
 #endif
-    init_stdio();
 
 #if defined(JL_USE_INTEL_JITEVENTS)
     const char *jit_profiling = getenv("ENABLE_JITPROFILING");
@@ -979,9 +974,12 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     jl_init_frontend();
     jl_init_types();
     jl_init_tasks(jl_stack_lo, jl_stack_hi-jl_stack_lo);
+
+    init_stdio();
+    // libuv stdio cleanup depends on jl_init_tasks() because JL_TRY is used in jl_atexit_hook()
+
     jl_init_codegen();
     jl_an_empty_cell = (jl_value_t*)jl_alloc_cell_1d(0);
-
     jl_init_serializer();
 
     if (!jl_compileropts.image_file) {
@@ -1006,9 +1004,9 @@ void _julia_init(JL_IMAGE_SEARCH rel)
             jl_restore_system_image(jl_compileropts.image_file);
         }
         JL_CATCH {
-            JL_PRINTF(JL_STDERR, "error during init:\n");
+            jl_printf(JL_STDERR, "error during init:\n");
             jl_show(jl_stderr_obj(), jl_exception_in_transit);
-            JL_PRINTF(JL_STDERR, "\n");
+            jl_printf(JL_STDERR, "\n");
             jl_exit(1);
         }
     }
@@ -1045,12 +1043,10 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     actf.sa_handler = fpe_handler;
     actf.sa_flags = 0;
     if (sigaction(SIGFPE, &actf, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
-        jl_exit(1);
+        jl_errorf("fatal error: sigaction: %s\n", strerror(errno));
     }
     if (signal(SIGPIPE,SIG_IGN) == SIG_ERR) {
-        JL_PRINTF(JL_STDERR, "fatal error: Couldn't set SIGPIPE\n");
-        jl_exit(1);
+        jl_error("fatal error: Couldn't set SIGPIPE\n");
     }
 #if defined (_OS_DARWIN_)
     kern_return_t ret;
@@ -1064,13 +1060,11 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     pthread_t thread;
     pthread_attr_t attr;
     if (pthread_attr_init(&attr) != 0) {
-        JL_PRINTF(JL_STDERR, "pthread_attr_init failed");
-        jl_exit(1);
+        jl_error("pthread_attr_init failed");
     }
     pthread_attr_setdetachstate(&attr,PTHREAD_CREATE_DETACHED);
     if (pthread_create(&thread,&attr,mach_segv_listener,NULL) != 0) {
-        JL_PRINTF(JL_STDERR, "pthread_create failed");
-        jl_exit(1);
+        jl_error("pthread_create failed");
     }
     pthread_attr_destroy(&attr);
 
@@ -1082,8 +1076,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     ss.ss_size = sig_stack_size;
     ss.ss_sp = signal_stack;
     if (sigaltstack(&ss, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaltstack: %s\n", strerror(errno));
-        jl_exit(1);
+        jl_errorf("fatal error: sigaltstack: %s\n", strerror(errno));
     }
 
     struct sigaction act;
@@ -1092,8 +1085,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     act.sa_sigaction = segv_handler;
     act.sa_flags = SA_ONSTACK | SA_SIGINFO;
     if (sigaction(SIGSEGV, &act, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
-        jl_exit(1);
+        jl_errorf("fatal error: sigaction: %s\n", strerror(errno));
     }
 #endif // defined(_OS_DARWIN_)
     struct sigaction act_die;
@@ -1102,53 +1094,41 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     act_die.sa_sigaction = sigdie_handler;
     act_die.sa_flags = SA_SIGINFO;
     if (sigaction(SIGINFO, &act_die, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
-        jl_exit(1);
+        jl_errorf("fatal error: sigaction: %s\n", strerror(errno));
     }
     if (sigaction(SIGBUS, &act_die, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
-        jl_exit(1);
+        jl_errorf("fatal error: sigaction: %s\n", strerror(errno));
     }
     if (sigaction(SIGILL, &act_die, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
-        jl_exit(1);
+        jl_errorf("fatal error: sigaction: %s\n", strerror(errno));
     }
     if (sigaction(SIGTERM, &act_die, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
-        jl_exit(1);
+        jl_errorf("fatal error: sigaction: %s\n", strerror(errno));
     }
     if (sigaction(SIGABRT, &act_die, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
-        jl_exit(1);
+        jl_errorf("fatal error: sigaction: %s\n", strerror(errno));
     }
     if (sigaction(SIGQUIT, &act_die, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
-        jl_exit(1);
+        jl_errorf("fatal error: sigaction: %s\n", strerror(errno));
     }
     if (sigaction(SIGSYS, &act_die, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
-        jl_exit(1);
+        jl_errorf("fatal error: sigaction: %s\n", strerror(errno));
     }
 #else // defined(_OS_WINDOWS_)
     if (signal(SIGFPE, (void (__cdecl *)(int))crt_sig_handler) == SIG_ERR) {
-        JL_PRINTF(JL_STDERR, "fatal error: Couldn't set SIGFPE\n");
-        jl_exit(1);
+        jl_error("fatal error: Couldn't set SIGFPE\n");
     }
     if (signal(SIGILL, (void (__cdecl *)(int))crt_sig_handler) == SIG_ERR) {
-        JL_PRINTF(JL_STDERR, "fatal error: Couldn't set SIGILL\n");
-        jl_exit(1);
+        jl_error("fatal error: Couldn't set SIGILL\n");
     }
     if (signal(SIGINT, (void (__cdecl *)(int))crt_sig_handler) == SIG_ERR) {
-        JL_PRINTF(JL_STDERR, "fatal error: Couldn't set SIGINT\n");
-        jl_exit(1);
+        jl_error("fatal error: Couldn't set SIGINT\n");
     }
     if (signal(SIGSEGV, (void (__cdecl *)(int))crt_sig_handler) == SIG_ERR) {
-        JL_PRINTF(JL_STDERR, "fatal error: Couldn't set SIGSEGV\n");
-        jl_exit(1);
+        jl_error("fatal error: Couldn't set SIGSEGV\n");
     }
     if (signal(SIGTERM, (void (__cdecl *)(int))crt_sig_handler) == SIG_ERR) {
-        JL_PRINTF(JL_STDERR, "fatal error: Couldn't set SIGTERM\n");
-        jl_exit(1);
+        jl_error("fatal error: Couldn't set SIGTERM\n");
     }
     SetUnhandledExceptionFilter(exception_handler);
 #endif
@@ -1174,8 +1154,7 @@ DLLEXPORT void jl_install_sigint_handler()
     act.sa_sigaction = sigint_handler;
     act.sa_flags = SA_SIGINFO;
     if (sigaction(SIGINT, &act, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
-        jl_exit(1);
+        jl_errorf("fatal error: sigaction: %s\n", strerror(errno));
     }
 #endif
 }
@@ -1202,7 +1181,7 @@ DLLEXPORT void julia_save()
                     free(build_bc);
                 }
                 else {
-                    ios_printf(ios_stderr,"\nWARNING: failed to create string for .bc build path\n");
+                    jl_printf(JL_STDERR,"\nWARNING: failed to create string for .bc build path\n");
                 }
             }
             char *build_o;
@@ -1211,11 +1190,11 @@ DLLEXPORT void julia_save()
                 free(build_o);
             }
             else {
-                ios_printf(ios_stderr,"\nFATAL: failed to create string for .o build path\n");
+                jl_printf(JL_STDERR,"\nFATAL: failed to create string for .o build path\n");
             }
         }
         else {
-            ios_printf(ios_stderr,"\nFATAL: failed to create string for .ji build path\n");
+            jl_printf(JL_STDERR,"\nFATAL: failed to create string for .ji build path\n");
         }
     }
 }

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -605,6 +605,7 @@ int jl_printf(uv_stream_t *s, const char *format, ...)
 DLLEXPORT void jl_safe_printf(const char *fmt, ...)
 {
     static char buf[1000];
+    buf[0] = '\0';
 
     va_list args;
     va_start(args, fmt);
@@ -612,6 +613,7 @@ DLLEXPORT void jl_safe_printf(const char *fmt, ...)
     vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
 
+    buf[999] = '\0';
     write(STDERR_FILENO, buf, strlen(buf));
 }
 

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -2,11 +2,11 @@
 
 /*
  * There is no need to define WINVER because it is already defined in Makefile.
- */
 #if defined(_COMPILER_MINGW_)
 #define WINVER                 _WIN32_WINNT
 #define _WIN32_WINDOWS         _WIN32_WINNT
 #endif
+ */
 
 #include <stdio.h>
 #include <stddef.h>
@@ -66,7 +66,6 @@ enum CALLBACK_TYPE { CB_PTR, CB_INT32, CB_UINT32, CB_INT64, CB_UINT64 };
     XX(fspollcb) \
     XX(isopen) \
     XX(fseventscb) \
-    XX(writecb) \
     XX(writecb_task) \
     XX(recv) \
     XX(send)
@@ -452,24 +451,13 @@ DLLEXPORT int jl_fs_chmod(char *path, int mode)
     return ret;
 }
 
-DLLEXPORT int jl_fs_write(int handle, char *data, size_t len, int64_t offset)
+DLLEXPORT int jl_fs_write(int handle, const char *data, size_t len, int64_t offset)
 {
     uv_fs_t req;
     uv_buf_t buf[1];
-    buf[0].base = data;
+    buf[0].base = (char*)data;
     buf[0].len = len;
     int ret = uv_fs_write(jl_io_loop, &req, handle, buf, 1, offset, NULL);
-    uv_fs_req_cleanup(&req);
-    return ret;
-}
-
-DLLEXPORT int jl_fs_write_byte(int handle, char c)
-{
-    uv_fs_t req;
-    uv_buf_t buf[1];
-    buf[0].base = &c;
-    buf[0].len = 1;
-    int ret = uv_fs_write(jl_io_loop, &req, handle, buf, 1, -1, NULL);
     uv_fs_req_cleanup(&req);
     return ret;
 }
@@ -507,143 +495,76 @@ DLLEXPORT int jl_fs_close(int handle)
     return ret;
 }
 
-//units are in ms
-DLLEXPORT int jl_puts(const char *str, uv_stream_t *stream)
+DLLEXPORT void jl_uv_writecb_task(uv_write_t *req, int status)
 {
-    if (!stream) return 0;
-    return jl_write(stream,str,strlen(str));
+    JULIA_CB(writecb_task, req->handle->data, 2, CB_PTR, req, CB_INT32, status);
+}
+
+DLLEXPORT int jl_uv_write(uv_stream_t *stream, const char *data, size_t n, uv_write_t *uvw, void *writecb)
+{
+    uv_buf_t buf[1];
+    buf[0].base = (char*) data;
+    buf[0].len = n;
+    JL_SIGATOMIC_BEGIN();
+    int err = uv_write(uvw,stream,buf,1,(uv_write_cb)writecb);
+    JL_SIGATOMIC_END();
+    return err;
 }
 
 DLLEXPORT void jl_uv_writecb(uv_write_t *req, int status)
 {
-    if (req->data) {
-        JULIA_CB(writecb, req->data, 2, CB_PTR, req, CB_INT32, status);
-    }
     free(req);
-}
-
-DLLEXPORT void jl_uv_writecb_task(uv_write_t *req, int status)
-{
-    JULIA_CB(writecb_task, req->handle->data, 2, CB_PTR, req, CB_INT32, status);
-    free(req);
-}
-
-DLLEXPORT int jl_write_copy(uv_stream_t *stream, const char *str, size_t n, uv_write_t *uvw, void *writecb)
-{
-    JL_SIGATOMIC_BEGIN();
-    char *data = (char*)uvw+sizeof(*uvw);
-    memcpy(data,str,n);
-    uv_buf_t buf[1];
-    buf[0].base = data;
-    buf[0].len = n;
-    uvw->data = NULL;
-    int err = uv_write(uvw,stream,buf,1,(uv_write_cb)writecb);
-    JL_SIGATOMIC_END();
-    return err;
-}
-
-DLLEXPORT int jl_putc(char c, uv_stream_t *stream)
-{
-    int err;
-    if (stream!=0) {
-        if (stream->type<UV_HANDLE_TYPE_MAX) { //is uv handle
-            if (stream->type == UV_FILE) {
-                JL_SIGATOMIC_BEGIN();
-                jl_uv_file_t *file = (jl_uv_file_t *)stream;
-                // Do a blocking write for now
-                uv_fs_t req;
-                uv_buf_t buf[1];
-                buf[0].base = &c;
-                buf[0].len = 1;
-                err = uv_fs_write(file->loop, &req, file->file, buf, 1, -1, NULL);
-                JL_SIGATOMIC_END();
-                return err ? 0 : 1;
-            }
-            else {
-                uv_write_t *uvw = (uv_write_t*)malloc(sizeof(uv_write_t)+1);
-                err = jl_write_copy(stream,(char*)&c,1,uvw, (void*)&jl_uv_writecb);
-                if (err < 0) {
-                    free(uvw);
-                    return 0;
-                }
-                return 1;
-            }
-        }
-        else {
-            ios_t *handle = (ios_t*)stream;
-            return ios_putc(c,handle);
-        }
+    if (status < 0) {
+        jl_safe_printf("jl_uv_writecb() ERROR: %s %s\n",
+                       uv_strerror(status), uv_err_name(status));
     }
-    return 0;
 }
 
-DLLEXPORT int jl_write_no_copy(uv_stream_t *stream, char *data, size_t n, uv_write_t *uvw, void *writecb)
-{
-    uv_buf_t buf[1];
-    buf[0].base = data;
-    buf[0].len = n;
-    JL_SIGATOMIC_BEGIN();
-    int err = uv_write(uvw,stream,buf,1,(uv_write_cb)writecb);
-    uvw->data = NULL;
-    JL_SIGATOMIC_END();
-    return err;
-}
+// Note: jl_write() is called only by jl_vprintf().
+// See: doc/devdocs/stdio.rst
 
-DLLEXPORT int jl_putc_copy(unsigned char c, uv_stream_t *stream, void *uvw, void *writecb)
+static void jl_write(uv_stream_t *stream, const char *str, size_t n)
 {
-    return jl_write_copy(stream,(char *)&c,1,(uv_write_t*)uvw,writecb);
-}
+    assert(stream);
 
-DLLEXPORT int jl_pututf8(uv_stream_t *s, uint32_t wchar )
-{
-    char buf[8];
-    if (wchar < 0x80)
-        return jl_putc((int)wchar, s);
-    size_t n = u8_toutf8(buf, 8, &wchar, 1);
-    return jl_write(s, buf, n);
-}
+    uv_file fd = 0;
 
-DLLEXPORT int jl_pututf8_copy(uv_stream_t *s, uint32_t wchar, void *uvw, void *writecb)
-{
-    char buf[8];
-    if (wchar < 0x80)
-        return jl_putc_copy((int)wchar, s, uvw, writecb);
-    size_t n = u8_toutf8(buf, 8, &wchar, 1);
-    return jl_write_copy(s, buf, n, (uv_write_t*)uvw, writecb);
-}
+    // Fallback for output during early initialisation...
+    if (stream == (void*)STDOUT_FILENO
+    ||  stream == (void*)STDERR_FILENO) {
+        jl_io_loop = uv_default_loop();
+        fd = (uv_file)stream;
+    } else if (stream->type == UV_FILE){
+        fd = ((jl_uv_file_t *)stream)->file;
+    }
 
-DLLEXPORT size_t jl_write(uv_stream_t *stream, const char *str, size_t n)
-{
-    int err;
-    //TODO: BAD!! Needed because Julia can't yet detect null stdio
-    if (stream == 0)
-        return 0;
-    if (stream->type<UV_HANDLE_TYPE_MAX) { //is uv handle
-        if (stream->type == UV_FILE) {
-            JL_SIGATOMIC_BEGIN();
-            jl_uv_file_t *file = (jl_uv_file_t *)stream;
-            // Do a blocking write for now
-            uv_fs_t req;
-            uv_buf_t buf[1];
-            buf[0].base = (char*)str;
-            buf[0].len = n;
-            err = uv_fs_write(file->loop, &req, file->file, buf, 1, -1, NULL);
-            JL_SIGATOMIC_END();
-            return err ? 0 : n;
-        }
-        else {
-            uv_write_t *uvw = (uv_write_t*)malloc(sizeof(uv_write_t)+n);
-            err = jl_write_copy(stream,str,n,uvw, (void*)&jl_uv_writecb);
-            if (err < 0) {
-                free(uvw);
-                return 0;
-            }
-            return n;
-        }
+    if (fd) {
+        // Write to file descriptor...
+        jl_fs_write(fd, str, n, -1);
+    }
+    else if (stream->type > UV_HANDLE_TYPE_MAX) {
+        // Write to ios.c stream...
+        // This is needed because caller jl_static_show() in builtins.c can be
+        // called from fl_print in flisp/print.c (via cvalue_printdata()),
+        // and cvalue_printdata() passes ios_t* to jl_static_show().
+        ios_write((ios_t*)stream, str, n);
     }
     else {
-        ios_t *handle = (ios_t*)stream;
-        return ios_write(handle,str,n);
+        // Write to libuv stream...
+        uv_write_t *req = (uv_write_t*)malloc(sizeof(uv_write_t)+n);
+        char *data = (char*)(req+1);
+        memcpy(data,str,n);
+        uv_buf_t buf[1];
+        buf[0].base = data;
+        buf[0].len = n;
+        req->data = NULL;
+        JL_SIGATOMIC_BEGIN();
+        int status = uv_write(req, stream, buf, 1,
+                              (uv_write_cb)jl_uv_writecb);
+        JL_SIGATOMIC_END();
+        if (status < 0) {
+            jl_uv_writecb(req, status);
+        }
     }
 }
 
@@ -664,7 +585,7 @@ int jl_vprintf(uv_stream_t *s, const char *format, va_list args)
 
     if (c >= 0) {
         jl_write(s, str, c);
-        LLT_FREE(str);
+        free(str);
     }
     va_end(al);
     return c;
@@ -681,10 +602,19 @@ int jl_printf(uv_stream_t *s, const char *format, ...)
     return c;
 }
 
-char *jl_bufptr(ios_t *s)
+DLLEXPORT void jl_safe_printf(const char *fmt, ...)
 {
-    return s->buf;
+    static char buf[1000];
+
+    va_list args;
+    va_start(args, fmt);
+    // Not async signal safe on some platforms?
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+
+    write(STDERR_FILENO, buf, strlen(buf));
 }
+
 
 DLLEXPORT void jl_exit(int exitcode)
 {
@@ -900,11 +830,6 @@ DLLEXPORT int jl_tcp_quickack(uv_tcp_t *handle, int on)
 }
 #endif
 
-DLLEXPORT char *jl_ios_buf_base(ios_t *ios)
-{
-    return ios->buf;
-}
-
 DLLEXPORT jl_uv_libhandle jl_wrap_raw_dl_handle(void *handle)
 {
     uv_lib_t *lib = (uv_lib_t*)malloc(sizeof(uv_lib_t));
@@ -949,7 +874,7 @@ DLLEXPORT int jl_ispty(uv_pipe_t *pipe)
     if (uv_pipe_getsockname(pipe, name, &len)) return 0;
     // return true if name matches regex:
     // ^\\\\?\\pipe\\(msys|cygwin)-[0-9a-z]{16}-[pt]ty[1-9][0-9]*-
-    //JL_PRINTF(JL_STDERR,"pipe_name: %s\n", name);
+    //jl_printf(JL_STDERR,"pipe_name: %s\n", name);
     int n = 0;
     if (!strncmp(name,"\\\\?\\pipe\\msys-",14))
         n = 14;
@@ -957,16 +882,16 @@ DLLEXPORT int jl_ispty(uv_pipe_t *pipe)
         n = 16;
     else
         return 0;
-    //JL_PRINTF(JL_STDERR,"prefix pass\n");
+    //jl_printf(JL_STDERR,"prefix pass\n");
     name += n;
     for (int n = 0; n < 16; n++)
         if (!ishexchar(*name++)) return 0;
-    //JL_PRINTF(JL_STDERR,"hex pass\n");
+    //jl_printf(JL_STDERR,"hex pass\n");
     if ((*name++)!='-') return 0;
     if (*name != 'p' && *name != 't') return 0;
     name++;
     if (*name++ != 't' || *name++ != 'y') return 0;
-    //JL_PRINTF(JL_STDERR,"tty pass\n");
+    //jl_printf(JL_STDERR,"tty pass\n");
     return 1;
 }
 #endif

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1264,11 +1264,11 @@ void print_env(cenv_t *soln)
     for(int i=0; i < soln->n; i+=2) {
         jl_value_t *T, *S;
         T = soln->data[i]; S = soln->data[i+1];
-        JL_PRINTF(JL_STDOUT, "%s@%x=", ((jl_tvar_t*)T)->name->name, T);
+        jl_printf(JL_STDOUT, "%s@%x=", ((jl_tvar_t*)T)->name->name, T);
         jl_static_show(JL_STDOUT, S);
-        JL_PRINTF(JL_STDOUT, " ");
+        jl_printf(JL_STDOUT, " ");
     }
-    JL_PRINTF(JL_STDOUT, "\n");
+    jl_printf(JL_STDOUT, "\n");
 }
 */
 
@@ -1458,8 +1458,8 @@ jl_value_t *jl_type_intersection_matching(jl_value_t *a, jl_value_t *b,
         JL_GC_POP();
         return (jl_value_t*)jl_bottom_type;
     }
-    //JL_PRINTF(JL_STDOUT, "env: "); print_env(&env);
-    //JL_PRINTF(JL_STDOUT, "sol: "); print_env(&eqc);
+    //jl_printf(JL_STDOUT, "env: "); print_env(&env);
+    //jl_printf(JL_STDOUT, "sol: "); print_env(&eqc);
 
     int env0 = eqc.n;
     jl_value_t **tvs;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1313,10 +1313,6 @@ void jl_longjmp(jmp_buf _Buf,int _Value);
 #define JL_STDOUT jl_uv_stdout
 #define JL_STDERR jl_uv_stderr
 #define JL_STDIN  jl_uv_stdin
-#define JL_PRINTF jl_printf
-#define JL_PUTC	  jl_putc
-#define JL_PUTS	  jl_puts
-#define JL_WRITE  jl_write
 
 DLLEXPORT int jl_spawn(char *name, char **argv, uv_loop_t *loop,
                        uv_process_t *proc, jl_value_t *julia_struct,
@@ -1343,10 +1339,6 @@ DLLEXPORT uv_idle_t * jl_make_idle(uv_loop_t *loop, jl_value_t *julia_struct);
 DLLEXPORT int jl_idle_start(uv_idle_t *idle);
 DLLEXPORT int jl_idle_stop(uv_idle_t *idle);
 
-DLLEXPORT int jl_putc(char c, uv_stream_t *stream);
-DLLEXPORT int jl_puts(const char *str, uv_stream_t *stream);
-DLLEXPORT int jl_pututf8(uv_stream_t *s, uint32_t wchar);
-
 DLLEXPORT uv_timer_t *jl_make_timer(uv_loop_t *loop, jl_value_t *julia_struct);
 DLLEXPORT int jl_timer_stop(uv_timer_t *timer);
 
@@ -1372,13 +1364,13 @@ typedef struct {
     uv_file file;
 } jl_uv_file_t;
 
-DLLEXPORT size_t jl_write(uv_stream_t *stream, const char *str, size_t n);
 DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...);
 DLLEXPORT int jl_vprintf(uv_stream_t *s, const char *format, va_list args);
+DLLEXPORT void jl_safe_printf(const char *str, ...);
 
-extern DLLEXPORT uv_stream_t *jl_uv_stdin;
-extern DLLEXPORT uv_stream_t *jl_uv_stdout;
-extern DLLEXPORT uv_stream_t *jl_uv_stderr;
+extern DLLEXPORT JL_STREAM *JL_STDIN;
+extern DLLEXPORT JL_STREAM *JL_STDOUT;
+extern DLLEXPORT JL_STREAM *JL_STDERR;
 
 DLLEXPORT JL_STREAM *jl_stdout_stream(void);
 DLLEXPORT JL_STREAM *jl_stdin_stream(void);

--- a/src/module.c
+++ b/src/module.c
@@ -364,7 +364,7 @@ DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
                 jl_is_type(rhs) || jl_is_function(rhs) || jl_is_module(rhs)) {
                 jl_errorf("invalid redefinition of constant %s", b->name->name);
             }
-            JL_PRINTF(JL_STDERR,"Warning: redefining constant %s\n",b->name->name);
+            jl_printf(JL_STDERR,"Warning: redefining constant %s\n",b->name->name);
         }
     }
     b->value = rhs;
@@ -444,9 +444,9 @@ void jl_module_run_initializer(jl_module_t *m)
         jl_apply(f, NULL, 0);
     }
     JL_CATCH {
-        JL_PRINTF(JL_STDERR, "Warning: error initializing module %s:\n", m->name->name);
+        jl_printf(JL_STDERR, "Warning: error initializing module %s:\n", m->name->name);
         jl_static_show(JL_STDERR, jl_exception_in_transit);
-        JL_PRINTF(JL_STDERR, "\n");
+        jl_printf(JL_STDERR, "\n");
     }
 }
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -27,6 +27,8 @@ DLLEXPORT int jl_profile_start_timer(void);
 volatile HANDLE hBtThread = 0;
 static DWORD WINAPI profile_bt( LPVOID lparam )
 {
+    // Note: illegal to use jl_* functions from this thread
+
     TIMECAPS tc;
     if (MMSYSERR_NOERROR!=timeGetDevCaps(&tc, sizeof(tc))) {
         fputs("failed to get timer resolution",stderr);
@@ -216,7 +218,7 @@ void *mach_profile_listener(void *arg)
                 bt_size_cur += rec_backtrace_ctx_dwarf((ptrint_t*)bt_data_prof+bt_size_cur, bt_size_max-bt_size_cur-1, &uc);
             }
             else if (forceDwarf == -1) {
-                JL_PRINTF(JL_STDERR, "Warning: Profiler attempt to access an invalid memory location\n");
+                jl_printf(JL_STDERR, "Warning: Profiler attempt to access an invalid memory location\n");
             }
 
             forceDwarf = -2;
@@ -254,13 +256,11 @@ DLLEXPORT int jl_profile_start_timer(void)
         // Alright, create a thread to serve as the listener for exceptions
         pthread_attr_t attr;
         if (pthread_attr_init(&attr) != 0) {
-            JL_PRINTF(JL_STDERR, "pthread_attr_init failed");
-            jl_exit(1);
+            jl_error("pthread_attr_init failed");
         }
         pthread_attr_setdetachstate(&attr,PTHREAD_CREATE_DETACHED);
         if (pthread_create(&profiler_thread,&attr,mach_profile_listener,NULL) != 0) {
-            JL_PRINTF(JL_STDERR, "pthread_create failed");
-            jl_exit(1);
+            jl_error("pthread_create failed");
         }
         pthread_attr_destroy(&attr);
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -218,7 +218,7 @@ void *mach_profile_listener(void *arg)
                 bt_size_cur += rec_backtrace_ctx_dwarf((ptrint_t*)bt_data_prof+bt_size_cur, bt_size_max-bt_size_cur-1, &uc);
             }
             else if (forceDwarf == -1) {
-                jl_printf(JL_STDERR, "Warning: Profiler attempt to access an invalid memory location\n");
+                jl_safe_printf("Warning: Profiler attempt to access an invalid memory location\n");
             }
 
             forceDwarf = -2;

--- a/src/sys.c
+++ b/src/sys.c
@@ -58,8 +58,6 @@ DLLEXPORT uint32_t jl_getutf8(ios_t *s)
     return wc;
 }
 
-DLLEXPORT size_t jl_ios_size(ios_t *s) { return s->size; }
-
 DLLEXPORT int jl_sizeof_off_t(void) { return sizeof(off_t); }
 #ifndef _OS_WINDOWS_
 DLLEXPORT off_t jl_lseek(int fd, off_t offset, int whence) { return lseek(fd, offset, whence); }
@@ -391,13 +389,13 @@ int jl_process_stop_signal(int status) { return WSTOPSIG(status); }
 
 // -- access to std filehandles --
 
-JL_STREAM *JL_STDIN=0;
-JL_STREAM *JL_STDOUT=0;
-JL_STREAM *JL_STDERR=0;
+JL_STREAM *JL_STDIN  = (void*)STDIN_FILENO;
+JL_STREAM *JL_STDOUT = (void*)STDOUT_FILENO;
+JL_STREAM *JL_STDERR = (void*)STDERR_FILENO;
 
-JL_STREAM *jl_stdin_stream(void)  { return (JL_STREAM*)JL_STDIN; }
-JL_STREAM *jl_stdout_stream(void) { return (JL_STREAM*)JL_STDOUT; }
-JL_STREAM *jl_stderr_stream(void) { return (JL_STREAM*)JL_STDERR; }
+JL_STREAM *jl_stdin_stream(void)  { return JL_STDIN; }
+JL_STREAM *jl_stdout_stream(void) { return JL_STDOUT; }
+JL_STREAM *jl_stderr_stream(void) { return JL_STDERR; }
 
 // CPUID
 

--- a/src/task.c
+++ b/src/task.c
@@ -739,7 +739,7 @@ DLLEXPORT void gdblookup(ptrint_t ip)
         if (line_num == ip)
             jl_safe_printf("unknown function (ip: %d)\n", line_num);
         else if (line_num == -1)
-            jl_safe_printf("%s at %s (unknown line)\n", func_name, file_name, line_num);
+            jl_safe_printf("%s at %s (unknown line)\n", func_name, file_name);
         else
             jl_safe_printf("%s at %s:%d\n", func_name, file_name, line_num);
     }

--- a/src/task.c
+++ b/src/task.c
@@ -510,7 +510,7 @@ static PVOID CALLBACK JuliaFunctionTableAccess64(
         _In_  HANDLE hProcess,
         _In_  DWORD64 AddrBase)
 {
-    //printf("lookup %d\n", AddrBase);
+    //jl_printf(JL_STDOUT, "lookup %d\n", AddrBase);
 #ifdef _CPU_X86_64_
     DWORD64 ImageBase;
     PRUNTIME_FUNCTION fn = RtlLookupFunctionEntry(AddrBase, &ImageBase, &HistoryTable);
@@ -530,7 +530,7 @@ static DWORD64 WINAPI JuliaGetModuleBase64(
         _In_  HANDLE hProcess,
         _In_  DWORD64 dwAddr)
 {
-    //printf("lookup base %d\n", dwAddr);
+    //jl_printf(JL_STDOUT, "lookup base %d\n", dwAddr);
 #ifdef _CPU_X86_64_
     DWORD64 ImageBase;
     PRUNTIME_FUNCTION fn = RtlLookupFunctionEntry(dwAddr, &ImageBase, &HistoryTable);
@@ -737,11 +737,11 @@ DLLEXPORT void gdblookup(ptrint_t ip)
     frame_info_from_ip(&func_name, &line_num, &file_name, ip, 0);
     if (func_name != NULL) {
         if (line_num == ip)
-            ios_printf(ios_stderr, "unknown function (ip: %d)\n", line_num);
+            jl_safe_printf("unknown function (ip: %d)\n", line_num);
         else if (line_num == -1)
-            ios_printf(ios_stderr, "%s at %s (unknown line)\n", func_name, file_name, line_num);
+            jl_safe_printf("%s at %s (unknown line)\n", func_name, file_name, line_num);
         else
-            ios_printf(ios_stderr, "%s at %s:%d\n", func_name, file_name, line_num);
+            jl_safe_printf("%s at %s:%d\n", func_name, file_name, line_num);
     }
 }
 
@@ -769,9 +769,9 @@ void NORETURN throw_internal(jl_value_t *e)
     }
     else {
         if (jl_current_task == jl_root_task) {
-            JL_PRINTF(JL_STDERR, "fatal: error thrown and no exception handler available.\n");
+            jl_printf(JL_STDERR, "fatal: error thrown and no exception handler available.\n");
             jl_static_show(JL_STDERR, e);
-            JL_PRINTF(JL_STDERR, "\n");
+            jl_printf(JL_STDERR, "\n");
             jlbacktrace();
             jl_exit(1);
         }
@@ -779,7 +779,7 @@ void NORETURN throw_internal(jl_value_t *e)
         finish_task(jl_current_task, e);
         assert(0);
     }
-    jl_exit(1);
+    assert(0);
 }
 
 // record backtrace and raise an error

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -106,7 +106,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
     jl_binding_t *b = jl_get_binding_wr(parent_module, name);
     jl_declare_constant(b);
     if (b->value != NULL) {
-        JL_PRINTF(JL_STDERR, "Warning: replacing module %s\n", name->name);
+        jl_printf(JL_STDERR, "Warning: replacing module %s\n", name->name);
     }
     jl_module_t *newm = jl_new_module(name);
     newm->parent = parent_module;
@@ -341,7 +341,7 @@ static jl_module_t *eval_import_path_(jl_array_t *args, int retrying)
             }
         }
         if (retrying && require_func) {
-            JL_PRINTF(JL_STDERR, "Warning: requiring \"%s\" did not define a corresponding module.\n", var->name);
+            jl_printf(JL_STDERR, "Warning: requiring \"%s\" did not define a corresponding module.\n", var->name);
             return NULL;
         }
         else {
@@ -380,7 +380,7 @@ int jl_is_toplevel_only_expr(jl_value_t *e)
 jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast)
 {
     //jl_show(ex);
-    //JL_PRINTF(JL_STDOUT, "\n");
+    //jl_printf(JL_STDOUT, "\n");
     if (!jl_is_expr(e))
         return jl_interpret_toplevel_expr(e);
 
@@ -741,10 +741,10 @@ DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_value_t 
         if (!jl_is_typevar(tv))
             jl_type_error_rt(name->name, "method definition", (jl_value_t*)jl_tvar_type, tv);
         if (!ishidden && !type_contains((jl_value_t*)argtypes, tv)) {
-            JL_PRINTF(JL_STDERR, "Warning: static parameter %s does not occur in signature for %s",
+            jl_printf(JL_STDERR, "Warning: static parameter %s does not occur in signature for %s",
                       ((jl_tvar_t*)tv)->name->name, name->name);
             print_func_loc(JL_STDERR, f->linfo);
-            JL_PRINTF(JL_STDERR, ".\nThe method will not be callable.\n");
+            jl_printf(JL_STDERR, ".\nThe method will not be callable.\n");
         }
     }
 
@@ -785,11 +785,11 @@ void jl_check_static_parameter_conflicts(jl_lambda_info_t *li, jl_tuple_t *t, jl
                 if (jl_is_typevar(tv)) {
                     if ((jl_sym_t*)jl_arrayref((jl_array_t*)jl_arrayref(vinfo,j),0) ==
                         ((jl_tvar_t*)tv)->name) {
-                        JL_PRINTF(JL_STDERR,
+                        jl_printf(JL_STDERR,
                                   "Warning: local variable %s conflicts with a static parameter in %s",
                                   ((jl_tvar_t*)tv)->name->name, fname->name);
                         print_func_loc(JL_STDERR, li);
-                        JL_PRINTF(JL_STDERR, ".\n");
+                        jl_printf(JL_STDERR, ".\n");
                     }
                 }
             }

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -139,7 +139,7 @@ void parse_opts(int *argcp, char ***argvp)
             jl_compileropts.cpu_target = strdup(optarg);
             break;
         case 'h':
-            jl_printf(JL_STDERR, "%s%s", usage, opts);
+            jl_printf(JL_STDOUT, "%s%s", usage, opts);
             jl_exit(0);
         case 'O':
             jl_compileropts.opt_level = 1;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -139,8 +139,8 @@ void parse_opts(int *argcp, char ***argvp)
             jl_compileropts.cpu_target = strdup(optarg);
             break;
         case 'h':
-            ios_printf(ios_stdout, "%s%s", usage, opts);
-            exit(0);
+            jl_printf(JL_STDERR, "%s%s", usage, opts);
+            jl_exit(0);
         case 'O':
             jl_compileropts.opt_level = 1;
             break;
@@ -180,8 +180,7 @@ void parse_opts(int *argcp, char ***argvp)
             else if (!strcmp(optarg,"64"))
                 jl_compileropts.int_literals = 64;
             else {
-                ios_printf(ios_stderr, "julia: invalid integer literal size (%s)\n", optarg);
-                exit(1);
+                jl_errorf("julia: invalid integer literal size (%s)\n", optarg);
             }
             break;
         case opt_dump_bitcode:
@@ -198,8 +197,7 @@ void parse_opts(int *argcp, char ***argvp)
             else if (!strcmp(optarg,"all"))
                 jl_compileropts.compile_enabled = 2;
             else {
-                ios_printf(ios_stderr, "julia: invalid argument to --compile (%s)\n", optarg);
-                exit(1);
+                jl_errorf("julia: invalid argument to --compile (%s)\n", optarg);
             }
             break;
         case opt_depwarn:
@@ -208,8 +206,7 @@ void parse_opts(int *argcp, char ***argvp)
             else if (!strcmp(optarg,"no"))
                 jl_compileropts.depwarn = 0;
             else {
-                ios_printf(ios_stderr, "julia: invalid argument to --depwarn (%s)\n", optarg);
-                exit(1);
+                jl_errorf("julia: invalid argument to --depwarn (%s)\n", optarg);
             }
             break;
         case opt_inline:      /* inline */
@@ -233,9 +230,8 @@ void parse_opts(int *argcp, char ***argvp)
             }
             break;
         default:
-            ios_printf(ios_stderr, "julia: unhandled option -- %c\n",  c);
-            ios_printf(ios_stderr, "This is a bug, please report it.\n");
-            exit(1);
+            jl_errorf("julia: unhandled option -- %c\n"
+                      "This is a bug, please report it.\n", c);
         }
     }
     jl_compileropts.code_coverage = codecov;
@@ -264,7 +260,7 @@ static int exec_program(void)
             else {
                 jl_printf(JL_STDERR, "error during bootstrap:\n");
                 jl_static_show(JL_STDERR, e);
-                JL_PUTS("\n",JL_STDERR);
+                jl_printf(JL_STDERR, "\n");
                 jlbacktrace();
             }
             jl_printf(JL_STDERR, "\n");
@@ -299,7 +295,7 @@ static void print_profile(void)
             jl_binding_t *b = (jl_binding_t*)table[i];
             if (b->value != NULL && jl_is_function(b->value) &&
                 jl_is_gf(b->value)) {
-                ios_printf(ios_stdout, "%d\t%s\n",
+                jl_printf(JL_STDERR, "%d\t%s\n",
                            jl_gf_mtable(b->value)->ncalls,
                            jl_gf_name(b->value)->name);
             }
@@ -355,9 +351,9 @@ static int true_main(int argc, char *argv[])
     }
     JL_CATCH {
         iserr = 1;
-        JL_PUTS("error during run:\n",JL_STDERR);
+        jl_printf(JL_STDERR, "error during run:\n");
         jl_show(jl_stderr_obj(),jl_exception_in_transit);
-        JL_PUTS("\n",JL_STDERR);
+        jl_printf(JL_STDERR, "\n");
         jlbacktrace();
         goto again;
     }


### PR DESCRIPTION
Use jl_printf(), jl_puts() etc instead of ios_printf(), JL_PRINTF(), fprintf() etc for consistency.

Make jl_printf(JL_STD*, ...), jl_puts() safe in very early stages of initialisation.

Try to remove miscellaneous ios.c dependencies.
Remaining ios.c dependencies are:
- flisp/*
- iostream.jl (and supporting C functions in sys.c) -- uses ios.c to do file IO.
- dump.c, -- uses ios_mem() for RAM buffers and ios_file() to read/write files.

See detail in commit logs and discussion here:
https://groups.google.com/forum/?fromgroups=#!topic/julia-dev/UlfIRvX0_nw
