### PR TITLE
More informative error messages for `test_throws`

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -54,7 +54,7 @@ end
 function do_test_throws(body, qex, bt, extype)
     handler()(try
         body()
-        Failure(qex)
+        Failure(qex, "$qex did not throw $(extype == nothing ? "anything" : extype)")
     catch err
         if extype == nothing
             Base.warn("""
@@ -66,7 +66,7 @@ function do_test_throws(body, qex, bt, extype)
             if isa(err, extype)
                 Success(qex)
             else
-                Failure(qex)
+                Failure(qex, "$err was thrown instead of $extype")
             end
         end
     end)


### PR DESCRIPTION
Before:

```
julia> using Base.Test ; @test_throws ErrorException sqrt(-1)
ERROR: test failed in expression: sqrt(-1)
 in error at error.jl:21
 in default_handler at test.jl:27
 in do_test_throws at test.jl:69
```

After:

```
julia> using Base.Test ; @test_throws ErrorException sqrt(-1)
ERROR: test failed: DomainError() was thrown instead of ErrorException
 in expression: sqrt(-1)
 in error at error.jl:21
 in default_handler at test.jl:27
 in do_test_throws at test.jl:69
```
