### PR TITLE
showdict: use endof instead of sizeof

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -54,7 +54,7 @@ function _truncate_at_width_or_chars(str, width, chars="", truncmark="…")
 
     lastidx != 0 && str[lastidx] in chars && (lastidx = prevind(str, lastidx))
     truncidx == 0 && (truncidx = lastidx)
-    if lastidx < sizeof(str)
+    if lastidx < endof(str)
         return bytestring(SubString(str, 1, truncidx) * truncmark)
     else
         return bytestring(str)

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -236,6 +236,12 @@ for d in (Dict("\n" => "\n", "1" => "\n", "\n" => "2"),
     @test !isempty(summary(values(d)))
 end
 
+# issue #9463
+type Alpha end
+Base.show(io::IO, ::Alpha) = print(io,"α")
+sbuff = IOBuffer()
+Base.showdict(sbuff, Dict(Alpha()=>1), limit=true, sz=(10,20))
+@test !contains(bytestring(sbuff), "…")
 
 # issue #2540
 d = Dict{Any,Any}([x => 1 for x in ['a', 'b', 'c']])


### PR DESCRIPTION
Sometimes, the output showed the truncation mark "…" even
when nothing was truncated.
