### PR TITLE
Allow parsing multi-line strings in completions.

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -291,7 +291,7 @@ function completions(string, pos)
     # First parse everything up to the current position
     partial = string[1:pos]
     inc_tag = Base.syntax_deprecation_warnings(false) do
-        Base.incomplete_tag(parse(partial, raise=false))
+        Base.incomplete_tag(Base.parse_input_line(partial))
     end
     if inc_tag in [:cmd, :string]
         m = match(r"[\t\n\r\"'`@\$><=;|&\{]| (?!\\)", reverse(partial))

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -199,20 +199,22 @@ end
 
 # Test method completions
 s = "max("
-c, r, res = test_complete(s)
-@test !res
-@test c[1] == string(start(methods(max)))
-@test r == 1:3
-@test s[r] == "max"
+for (s, delta) in multiline(s):
+    c, r, res = test_complete(s)
+    @test !res
+    @test c[1] == string(start(methods(max)))
+    @test r == 1+delta:3+delta
+    @test s[r] == "max"
+end
 
 # Test completion of methods with input args
 s = "CompletionFoo.test(1,1, "
-c, r, res = test_complete(s)
-@test !res
-@test c[1] == string(methods(CompletionFoo.test, Tuple{Int, Int})[1])
-@test length(c) == 3
-@test r == 1:18
-@test s[r] == "CompletionFoo.test"
+    c, r, res = test_complete(s)
+    @test !res
+    @test c[1] == string(methods(CompletionFoo.test, Tuple{Int, Int})[1])
+    @test length(c) == 3
+    @test r == 1:18
+    @test s[r] == "CompletionFoo.test"
 
 s = "CompletionFoo.test(CompletionFoo.array,"
 c, r, res = test_complete(s)
@@ -438,27 +440,35 @@ let #test that it can auto complete with spaces in file/path
     cd(path) do
         open(joinpath(space_folder, "space .file"),"w") do f
             s = @windows? "rm $dir_space\\\\space" : "cd $dir_space/space"
-            c,r = test_scomplete(s)
-            @test r == endof(s)-4:endof(s)
-            @test "space\\ .file" in c
+            for (s, delta) in multiline(s):
+                c,r = test_scomplete(s)
+                @test r == endof(s)-4+delta:endof(s)_delta
+                @test "space\\ .file" in c
+            end
 
             s = @windows? "cd(\"β $dir_space\\\\space" : "cd(\"β $dir_space/space"
-            c,r = test_complete(s)
-            @test r == endof(s)-4:endof(s)
-            @test "space\\ .file\"" in c
+            for (s, delta) in multiline(s):
+                c,r = test_complete(s)
+                @test r == endof(s)-4+delta:endof(s)+delta
+                @test "space\\ .file\"" in c
+            end
         end
         # Test for issue #10324
-        s = "cd(\"$dir_space"
-        c,r = test_complete(s)
-        @test r == 5:15
-        @test s[r] ==  dir_space
+        for (s, delta) in multiline(s):
+            s = "cd(\"$dir_space"
+            c,r = test_complete(s)
+            @test r == 5+delta:15+delta
+            @test s[r+delta] ==  dir_space
+        end
     end
     rm(dir, recursive=true)
 end
 
 # Test the completion returns nothing when the folder do not exist
-c,r = test_complete("cd(\"folder_do_not_exist_77/file")
-@test length(c) == 0
+for (s, delta) in multiline("cd(\"folder_do_not_exist_77/file"):
+    c,r = test_complete(s)
+    @test length(c) == 0
+end
 
 @windows_only begin
     tmp = tempname()
@@ -467,24 +477,32 @@ c,r = test_complete("cd(\"folder_do_not_exist_77/file")
     temp_name = basename(path)
     cd(path) do
         s = "cd ..\\\\"
-        c,r = test_scomplete(s)
-        @test r == length(s)+1:length(s)
-        @test temp_name * "\\\\" in c
+        for (s,delta) in multiline(s):
+            c,r = test_scomplete(s)
+            @test r == length(s)+1:length(s)
+            @test temp_name * "\\\\" in c
+        end
 
         s = "ls $(file[1:2])"
-        c,r = test_scomplete(s)
-        @test r == length(s)-1:length(s)
-        @test file in c
+        for (s,delta) in multiline(s):
+            c,r = test_scomplete(s)
+            @test r == length(s)-1:length(s)
+            @test file in c
+        end
 
         s = "cd(\"..\\"
-        c,r = test_complete(s)
-        @test r == length(s)+1:length(s)
-        @test temp_name * "\\\\" in c
+        for (s,delta) in multiline(s):
+            c,r = test_complete(s)
+            @test r == length(s)+1:length(s)
+            @test temp_name * "\\\\" in c
+        end
 
         s = "cd(\"$(file[1:2])"
-        c,r = test_complete(s)
-        @test r == length(s) - 1:length(s)
-        @test file  in c
+        for (s,delta) in multiline(s):
+            c,r = test_complete(s)
+            @test r == length(s) - 1:length(s)
+            @test file  in c
+        end
     end
     rm(tmp)
 end

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -199,7 +199,7 @@ end
 
 # Test method completions
 s = "max("
-for (s, delta) in multiline(s):
+for (s, delta) in multiline(s)
     c, r, res = test_complete(s)
     @test !res
     @test c[1] == string(start(methods(max)))
@@ -209,12 +209,14 @@ end
 
 # Test completion of methods with input args
 s = "CompletionFoo.test(1,1, "
+for (s, delta) in multiline(s)
     c, r, res = test_complete(s)
     @test !res
     @test c[1] == string(methods(CompletionFoo.test, Tuple{Int, Int})[1])
     @test length(c) == 3
-    @test r == 1:18
+    @test r == 1+delta:18+delta
     @test s[r] == "CompletionFoo.test"
+end
 
 s = "CompletionFoo.test(CompletionFoo.array,"
 c, r, res = test_complete(s)
@@ -440,32 +442,26 @@ let #test that it can auto complete with spaces in file/path
     cd(path) do
         open(joinpath(space_folder, "space .file"),"w") do f
             s = @windows? "rm $dir_space\\\\space" : "cd $dir_space/space"
-            for (s, delta) in multiline(s):
-                c,r = test_scomplete(s)
-                @test r == endof(s)-4+delta:endof(s)_delta
-                @test "space\\ .file" in c
-            end
+            c,r = test_scomplete(s)
+            @test r == endof(s)-4:endof(s)
+            @test "space\\ .file" in c
 
             s = @windows? "cd(\"β $dir_space\\\\space" : "cd(\"β $dir_space/space"
-            for (s, delta) in multiline(s):
-                c,r = test_complete(s)
-                @test r == endof(s)-4+delta:endof(s)+delta
-                @test "space\\ .file\"" in c
-            end
+            c,r = test_complete(s)
+            @test r == endof(s)-4:endof(s)
+            @test "space\\ .file\"" in c
         end
         # Test for issue #10324
-        for (s, delta) in multiline(s):
-            s = "cd(\"$dir_space"
-            c,r = test_complete(s)
-            @test r == 5+delta:15+delta
-            @test s[r+delta] ==  dir_space
-        end
+        s = "cd(\"$dir_space"
+        c,r = test_complete(s)
+        @test r == 5:15
+        @test s[r] ==  dir_space
     end
     rm(dir, recursive=true)
 end
 
 # Test the completion returns nothing when the folder do not exist
-for (s, delta) in multiline("cd(\"folder_do_not_exist_77/file"):
+for (s, delta) in multiline("cd(\"folder_do_not_exist_77/file")
     c,r = test_complete(s)
     @test length(c) == 0
 end
@@ -477,28 +473,28 @@ end
     temp_name = basename(path)
     cd(path) do
         s = "cd ..\\\\"
-        for (s,delta) in multiline(s):
+        for (s,delta) in multiline(s)
             c,r = test_scomplete(s)
             @test r == length(s)+1:length(s)
             @test temp_name * "\\\\" in c
         end
 
         s = "ls $(file[1:2])"
-        for (s,delta) in multiline(s):
+        for (s,delta) in multiline(s)
             c,r = test_scomplete(s)
             @test r == length(s)-1:length(s)
             @test file in c
         end
 
         s = "cd(\"..\\"
-        for (s,delta) in multiline(s):
+        for (s,delta) in multiline(s)
             c,r = test_complete(s)
             @test r == length(s)+1:length(s)
             @test temp_name * "\\\\" in c
         end
 
         s = "cd(\"$(file[1:2])"
-        for (s,delta) in multiline(s):
+        for (s,delta) in multiline(s)
             c,r = test_complete(s)
             @test r == length(s) - 1:length(s)
             @test file  in c

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -53,7 +53,7 @@ test_complete(s) = completions(s,endof(s))
 test_scomplete(s) = shell_completions(s,endof(s))
 test_bslashcomplete(s) = bslash_completions(s,endof(s))[2]
 
-function multiline(s::String)
+function multiline(s::AbstractString)
     return [(s,0),
         ("multiline = true\n"*s, 17)
     ]


### PR DESCRIPTION
Mostly needed later for IJulia, as for Jupyter/IPython
and the new v5 message spec the completion send the all code cell
as well as the cursor position, so this methods is almost perfect to be
used, except it does not accept more than one expression before raising.

This fixes that by allowing parsing of multiple line string

---

I might be missing something though, so I would appreciate feedback, and any guide on this part of the internals of julia. 
