### PR TITLE
Add <(::Ptr, ::Ptr)

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -60,6 +60,7 @@ eltype{T}(::Ptr{T}) = T
 ## limited pointer arithmetic & comparison ##
 
 ==(x::Ptr, y::Ptr) = uint(x) == uint(y)
+isless(x::Ptr, y::Ptr) = isless(uint(x), uint(y))
 -(x::Ptr, y::Ptr) = uint(x) - uint(y)
 
 +(x::Ptr, y::Integer) = oftype(x, (uint(x) + (y % UInt) % UInt))

--- a/test/core.jl
+++ b/test/core.jl
@@ -712,6 +712,24 @@ begin
     @test typeof(b) === SI{1,-2,1}
 end
 
+# pointer arithmetic
+begin
+   local a,b,c
+   a = C_NULL
+   b = C_NULL + 1
+   c = C_NULL - 1
+
+   @test a != b != c
+   @test UInt(a) == 0
+   @test UInt(b) == 1
+   @test UInt(c) == typemax(UInt)
+
+   @test b - a == -(a - b) == 1
+   @test c - a == -(a - c) == typemax(UInt)
+   @test c - b == -(b - c) == typemax(UInt) - 1
+   @test a < b < c
+end
+
 # pull request 1270
 begin
     local a,p, a2,p2


### PR DESCRIPTION
Can be useful to check whether a pointer is in a memory range,
e.g. for arrays.
