### PR TITLE
Extended printing at a MethodError.

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -165,27 +165,62 @@ function showerror(io::IO, ex::MethodError)
         print(io, "since type constructors fall back to convert methods in julia v0.4.")
     end
 
-    # Display up to three closest candidates
+    show_method_candidates(io, ex)
+end
+
+function show_method_candidates(io::IO, ex::MethodError)
+    # Displays the closest candidates of the given function by looping over the
+    # functions methods and counting the number of matching arguments.
     lines = Array((IOBuffer, Int), 0)
+    name = isgeneric(ex.f) ? ex.f.env.name : :anonymous
     for method in methods(ex.f)
-        n = length(ex.args)
-        if n != length(method.sig)
-            continue
-        end
         buf = IOBuffer()
-        print(buf, "  $(ex.f.env.name)(")
-        first = true
+        print(buf, "  $name")
         right_matches = 0
-        for (arg, sigtype) in Zip2{Any,Any}(ex.args, method.sig)
-            if first
-                first = false
+        tv = method.tvars
+        if !isa(tv,Tuple)
+            tv = (tv,)
+        end
+        if !isempty(tv)
+            show_delim_array(buf, tv, '{', ',', '}', false)
+        end
+        print(buf, "(")
+        t_i = Any[typeof(ex.args)...]
+        right_matches = 0
+        for i = 1 : min(length(t_i), length(method.sig))
+            i != 1 && print(buf, ", ")
+            # If isvarargtype then it checks wether the rest of the input arguements matches
+            # the varargtype
+			j = Base.isvarargtype(method.sig[i]) ? length(t_i) : i
+            # checks if the type of arg 1:i of the input intersects with the current method
+            t_in = typeintersect(method.sig[1:i], tuple(t_i[1:j]...))
+            if t_in == None
+                # If there is no typeintersect then the type signature from the method is
+                # inserted in t_i this insures if the type at the next i matches the type
+                # signature then there will be a type intersect
+                t_i[i] = method.sig[i]
+                Base.with_output_color(:red, buf) do buf
+                    print(buf, "::$(method.sig[i])")
+                end
             else
-                print(buf, ", ")
+                right_matches += j==i ? 1 : 0
+                print(buf, "::$(method.sig[i])")
             end
-            if typeof(arg) <: sigtype
-                right_matches += 1
-                print(buf, "::$(sigtype)")
-            else
+        end
+        if length(t_i) > length(method.sig) && Base.isvarargtype(method.sig[end])
+            # It insures that methods like f(a::AbstractString...) gets the correct
+            # number of right_matches
+            for t in typeof(ex.args)[length(method.sig):end]
+                if t <: method.sig[end].parameters[1]
+                    right_matches += 1
+                end
+            end
+        end
+        if length(t_i) < length(method.sig)
+            # If the methods args is longer than input then the method
+            # arguments is printed as not a match
+            for sigtype in method.sig[length(t_i)+1:end]
+                print(buf, ", ")
                 Base.with_output_color(:red, buf) do buf
                     print(buf, "::$(sigtype)")
                 end
@@ -196,7 +231,7 @@ function showerror(io::IO, ex::MethodError)
             push!(lines, (buf, right_matches))
         end
     end
-    if length(lines) != 0
+    if length(lines) != 0 # Display up to three closest candidates
         Base.with_output_color(:normal, io) do io
             println(io, "\nClosest candidates are:")
             sort!(lines, by = x -> -x[2])

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -191,12 +191,12 @@ function show_method_candidates(io::IO, ex::MethodError)
             i != 1 && print(buf, ", ")
             # If isvarargtype then it checks wether the rest of the input arguements matches
             # the varargtype
-			j = Base.isvarargtype(method.sig[i]) ? length(t_i) : i
+            j = Base.isvarargtype(method.sig[i]) ? length(t_i) : i
             # checks if the type of arg 1:i of the input intersects with the current method
             t_in = typeintersect(method.sig[1:i], tuple(t_i[1:j]...))
             if t_in == None
                 # If there is no typeintersect then the type signature from the method is
-                # inserted in t_i this insures if the type at the next i matches the type
+                # inserted in t_i this ensures if the type at the next i matches the type
                 # signature then there will be a type intersect
                 t_i[i] = method.sig[i]
                 Base.with_output_color(:red, buf) do buf
@@ -208,7 +208,7 @@ function show_method_candidates(io::IO, ex::MethodError)
             end
         end
         if length(t_i) > length(method.sig) && Base.isvarargtype(method.sig[end])
-            # It insures that methods like f(a::AbstractString...) gets the correct
+            # It ensures that methods like f(a::AbstractString...) gets the correct
             # number of right_matches
             for t in typeof(ex.args)[length(method.sig):end]
                 if t <: method.sig[end].parameters[1]

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -195,13 +195,15 @@ function show_method_candidates(io::IO, ex::MethodError)
             # checks if the type of arg 1:i of the input intersects with the current method
             t_in = typeintersect(method.sig[1:i], tuple(t_i[1:j]...))
             if t_in == None
+                if Base.have_color
+                    print(buf, "\e[1m\e[31m::$(method.sig[i])\e[0m")
+                else
+                    print(buf, "!Matched::$(method.sig[i])")
+                end
                 # If there is no typeintersect then the type signature from the method is
                 # inserted in t_i this ensures if the type at the next i matches the type
                 # signature then there will be a type intersect
                 t_i[i] = method.sig[i]
-                Base.with_output_color(:red, buf) do buf
-                    print(buf, "::$(method.sig[i])")
-                end
             else
                 right_matches += j==i ? 1 : 0
                 print(buf, "::$(method.sig[i])")
@@ -221,8 +223,10 @@ function show_method_candidates(io::IO, ex::MethodError)
             # arguments is printed as not a match
             for sigtype in method.sig[length(t_i)+1:end]
                 print(buf, ", ")
-                Base.with_output_color(:red, buf) do buf
-                    print(buf, "::$(sigtype)")
+                if Base.have_color
+                    print(buf, "\e[1m\e[31m::$sigtype\e[0m")
+                else
+                    print(buf, "!Matched::$sigtype")
                 end
             end
         end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -1,0 +1,41 @@
+function test_have_color(buf, color, no_color)
+    if Base.have_color
+        @test takebuf_string(buf) == color
+    else
+        @test takebuf_string(buf) == no_color
+    end
+end
+
+method_c1(x::Float64, s::AbstractString...) = true
+
+buf = IOBuffer()
+Base.show_method_candidates(buf, Base.MethodError(method_c1,(1, 1, "")))
+no_color = "\nClosest candidates are:\n  method_c1(::Float64, ::AbstractString...)\n"
+test_have_color(buf,
+                "\e[0m\nClosest candidates are:\n  method_c1(\e[1m\e[31m::Float64\e[0m, \e[1m\e[31m::AbstractString...\e[0m)\n\e[0m",
+                no_color)
+
+Base.show_method_candidates(buf, Base.MethodError(method_c1,(1, "", "")))
+test_have_color(buf,
+                "\e[0m\nClosest candidates are:\n  method_c1(\e[1m\e[31m::Float64\e[0m, ::AbstractString...)\n\e[0m",
+                no_color)
+
+# should match
+Base.show_method_candidates(buf, Base.MethodError(method_c1,(1., "", "")))
+test_have_color(buf,
+                "\e[0m\nClosest candidates are:\n  method_c1(::Float64, ::AbstractString...)\n\e[0m",
+                no_color)
+
+# Have no matches so should return empty
+Base.show_method_candidates(buf, Base.MethodError(method_c1,(1, 1, 1)))
+test_have_color(buf, "", "")
+
+method_c2(x::Int32, args...) = true
+method_c2(x::Int32, y::Float64 ,args...) = true
+method_c2(x::Int32, y::Float64) = true
+method_c2{T<:Real}(x::T, y::T, z::T) = true
+
+Base.show_method_candidates(buf, Base.MethodError(method_c2,(1., 1., 2)))
+color = "\e[0m\nClosest candidates are:\n  method_c2(\e[1m\e[31m::Int32\e[0m, ::Float64, ::Any...)\n  method_c2(\e[1m\e[31m::Int32\e[0m, ::Any...)\n  method_c2{T<:Real}(::T<:Real, ::T<:Real, \e[1m\e[31m::T<:Real\e[0m)\n  ...\n\e[0m"
+no_color = no_color = "\nClosest candidates are:\n  method_c2(::Int32, ::Float64, ::Any...)\n  method_c2(::Int32, ::Any...)\n  method_c2{T<:Real}(::T<:Real, ::T<:Real, ::T<:Real)\n  ...\n"
+test_have_color(buf, color, no_color)

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -10,17 +10,19 @@ method_c1(x::Float64, s::AbstractString...) = true
 
 buf = IOBuffer()
 Base.show_method_candidates(buf, Base.MethodError(method_c1,(1, 1, "")))
-no_color = "\nClosest candidates are:\n  method_c1(::Float64, ::AbstractString...)\n"
+no_color = "\nClosest candidates are:\n  method_c1(!Matched::Float64, !Matched::AbstractString...)\n"
 test_have_color(buf,
                 "\e[0m\nClosest candidates are:\n  method_c1(\e[1m\e[31m::Float64\e[0m, \e[1m\e[31m::AbstractString...\e[0m)\n\e[0m",
                 no_color)
 
+no_color = "\nClosest candidates are:\n  method_c1(!Matched::Float64, ::AbstractString...)\n"
 Base.show_method_candidates(buf, Base.MethodError(method_c1,(1, "", "")))
 test_have_color(buf,
                 "\e[0m\nClosest candidates are:\n  method_c1(\e[1m\e[31m::Float64\e[0m, ::AbstractString...)\n\e[0m",
                 no_color)
 
 # should match
+no_color = "\nClosest candidates are:\n  method_c1(::Float64, ::AbstractString...)\n"
 Base.show_method_candidates(buf, Base.MethodError(method_c1,(1., "", "")))
 test_have_color(buf,
                 "\e[0m\nClosest candidates are:\n  method_c1(::Float64, ::AbstractString...)\n\e[0m",
@@ -37,5 +39,5 @@ method_c2{T<:Real}(x::T, y::T, z::T) = true
 
 Base.show_method_candidates(buf, Base.MethodError(method_c2,(1., 1., 2)))
 color = "\e[0m\nClosest candidates are:\n  method_c2(\e[1m\e[31m::Int32\e[0m, ::Float64, ::Any...)\n  method_c2(\e[1m\e[31m::Int32\e[0m, ::Any...)\n  method_c2{T<:Real}(::T<:Real, ::T<:Real, \e[1m\e[31m::T<:Real\e[0m)\n  ...\n\e[0m"
-no_color = no_color = "\nClosest candidates are:\n  method_c2(::Int32, ::Float64, ::Any...)\n  method_c2(::Int32, ::Any...)\n  method_c2{T<:Real}(::T<:Real, ::T<:Real, ::T<:Real)\n  ...\n"
+no_color = no_color = "\nClosest candidates are:\n  method_c2(!Matched::Int32, ::Float64, ::Any...)\n  method_c2(!Matched::Int32, ::Any...)\n  method_c2{T<:Real}(::T<:Real, ::T<:Real, !Matched::T<:Real)\n  ...\n"
 test_have_color(buf, color, no_color)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ testnames = [
     "resolve", "pollfd", "mpfr", "broadcast", "complex", "socket",
     "floatapprox", "readdlm", "reflection", "regex", "float16", "combinatorics",
     "sysinfo", "rounding", "ranges", "mod2pi", "euler", "show",
-    "lineedit", "replcompletions", "repl", "sets", "test", "goto",
+    "lineedit", "replcompletions", "repl", "replutil", "sets", "test", "goto",
     "llvmcall", "grisu", "nullable", "meta", "profile",
     "libgit2", "docs", "base64", "parser"
 ]


### PR DESCRIPTION
I have extended #7714 with the following:
- Take into account that args... is a match and removed the requirement of equal lengths of arguements of the input and method. 
- The match also takes into account that parametric methods args needs to have the same type for one T variable. Plus added some printing for parametric methods.
- Lastly I have added so the file and line number for the function also are printed

The following will demo the difference, suppose you have the following methods deffined:

``` julia
g(x::Int, args...) = pass
g(x::Int, y::Float64 ,args...) = pass
g(x::Int, y::Float64) = pass
g{T<:Real}(x::T, y::T, z::T) = pass
```

Before you would get:
![image](https://cloud.githubusercontent.com/assets/7973946/5569921/0dc14f48-8f79-11e4-98f6-49b9b61425bb.png)
Where it shows that the parametric type matches all arguments and the second is two arguments from matching but in reality if you change the first argument to an Int then it matches. With this pull-request it displays:
![image](https://cloud.githubusercontent.com/assets/7973946/5569946/468c6830-8f79-11e4-84bb-f2593ca3c8f3.png)

@jhasse could you approve/comment on my changes since you are the original author of this, nice work and idea by the way. Also pinging some of the reviewers in #7714 to hear their opinion, @ivarne, @simonster, @mbauman.
