### PR TITLE
Don't export deprecated TcpSocket, IpAddr

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -177,7 +177,7 @@ scale!{T<:Base.LinAlg.BlasReal}(X::Array{T}, s::Complex) = error("scale!: Cannot
 @deprecate rsplit(x,y,l::Integer) rsplit(x,y;limit=l)
 @deprecate rsplit(x,y,k::Bool) rsplit(x,y;keep=k)
 
-export TcpSocket, UdpSocket, IpAddr
+export UdpSocket
 const TcpSocket = TCPSocket
 const UdpSocket = UDPSocket
 const IpAddr = IPAddr


### PR DESCRIPTION
These weren't exported in 0.3

CC @sbromberger @jakebolewski 
