### PR TITLE
Add a macro @nifs to Base.Cartesian

### DIFF
--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -1,6 +1,6 @@
 module Cartesian
 
-export @ngenerate, @nsplat, @nloops, @nref, @ncall, @nexprs, @nextract, @nall, @ntuple, @nif, ngenerate
+export @ngenerate, @nsplat, @nloops, @nref, @ncall, @nexprs, @nextract, @nall, @ntuple, @nif, @nifs, ngenerate
 
 const CARTESIAN_DIMS = 4
 
@@ -382,6 +382,27 @@ macro nif(N, condition, operation...)
     # Make the nested if statements
     for i = N-1:-1:1
         ex = Expr(:if, esc(inlineanonymous(condition,i)), esc(inlineanonymous(operation[1],i)), ex)
+    end
+    ex
+end
+
+# Similar to @nif, but doesn't nest the if clauses:
+# if condition1; op_if_true1; else op_if_false1; end; if condition2...
+# or, alternatively,
+# if condition1; op_if_true1; end; if condition2...
+#
+# Call syntax (last argument is optional):
+# @nifs N d->condition_d d->op_if_true_d d->op_if_false_d
+macro nifs(N,condition,operation...)
+    ex = Expr(:block)
+    for i = 1:N
+        ifex = Expr(:if)
+        push!(ifex.args, esc(inlineanonymous(condition, i)))
+        push!(ifex.args, esc(inlineanonymous(operation[1], i)))
+        if (length(operation) > 1)
+            push!(ifex.args, esc(inlineanonymous(operation[2], i)))
+        end
+        push!(ex.args, ifex)
     end
     ex
 end

--- a/doc/devdocs/cartesian.rst
+++ b/doc/devdocs/cartesian.rst
@@ -302,6 +302,31 @@ Macros for function bodies
 	    println("All OK")
 	end
 
+-- function:: @nifs N conditionexpr expr
+              @nifs N conditionexpr expr elseexpr
+
+    Similar to ``@nif``, but doesn't nest the if statements with ``elseif``, but
+    rather executes them all in order. To re-use the sample above::
+
+        @nifs 3 d->(i_d >= size(A,d)) d->(error("Dimension", d, " too big")) d->(println("Dimension "*string(d)*" OK"))
+
+    would generate::
+
+        if i_1 >= size(A,1)
+            error("Dimension", 1, " too big")
+        else
+            println("Dimension "*string(1)*" OK")
+        end
+        if i_2 >= size(A,2)
+            error("Dimension", 2, " too big")
+        else
+            println("Dimension "*string(2)*" OK")
+        end
+        if i_3 >= size(A,3)
+            error("Dimension", 3, " too big")
+        else
+            println("Dimension "*string(3)*" OK")
+        end
 
 Frequently asked questions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -1,0 +1,31 @@
+# Encapsulate tests in a module, to avoid any scoping problems
+# All test code is run in the model root scope
+module CartesianTests
+
+using Base.Cartesian, Base.Test
+
+ex = macroexpand(:(@nifs 3 d->(d in dims) d->(println(d))))
+
+@test ex.head == :block
+@test length(ex.args) == 3
+for i in 1:3
+    x = ex.args[i]
+    @test x.head == :if
+    @test length(x.args) == 2
+    @test x.args[1] == :($i in dims)
+    @test x.args[2] == :(println($i))
+end
+
+ex = macroexpand(:(@nifs 2 d->(d in dims) d->(println(d)) d->println("not "*string(d))))
+@test ex.head == :block
+@test length(ex.args) == 2
+for i in 1:2
+    x = ex.args[i]
+    @test x.head == :if
+    @test length(x.args) == 3
+    @test x.args[1] == :($i in dims)
+    @test x.args[2] == :(println($i))
+    @test x.args[3] == :(println("not "*string($i)))
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ testnames = [
     "sysinfo", "rounding", "ranges", "mod2pi", "euler", "show",
     "lineedit", "replcompletions", "repl", "test", "goto",
     "llvmcall", "grisu", "nullable", "meta", "profile",
-    "libgit2", "docs"
+    "libgit2", "docs", "cartesian"
 ]
 
 if isdir(joinpath(JULIA_HOME, Base.DOCDIR, "examples"))


### PR DESCRIPTION
When building some stuff for Interpolations.jl, I found myself in need of the following macro:

``` julia
macro nifs(N,condition,operation...)
    ex = Expr(:block)
    for i = 1:N
        ifex = Expr(:if)
        push!(ifex.args, esc(inlineanonymous(condition, i)))
        push!(ifex.args, esc(inlineanonymous(operation[1], i)))
        if (length(operation) > 1)
            push!(ifex.args, esc(inlineanonymous(operation[2], i)))
        end
        push!(ex.args, ifex)
    end
    ex
end
```

which generates `N` if statements with optional else clauses. I'm not entirely happy with how it incrementally adds elements to the `args` members, but it does what I want it to do:

``` julia
julia> macroexpand(:(@nifs 3 d->(d in dims) d->println(d)))
quote 
    if $(Expr(:in, 1, :dims))
        println(1)
    end
    if $(Expr(:in, 2, :dims))
        println(2)
    end
    if $(Expr(:in, 3, :dims))
        println(3)
    end
end

julia> macroexpand(:(@nifs 3 d->(d in dims) d->println(d) d->println("nope"*string(d))))
quote 
    if $(Expr(:in, 1, :dims))
        println(1)
    else 
        println("nope"*string(1))
    end
    if $(Expr(:in, 2, :dims))
        println(2)
    else 
        println("nope"*string(2))
    end
    if $(Expr(:in, 3, :dims))
        println(3)
    else 
        println("nope"*string(3))
    end
end
```

I also took the chance to start building a test suite for `Base.Cartesian`, although I admittedly did not write tests for anything but this single macro. Also, the tests are a little contrived - I basically designed the macro by trial and error until I got the result I wanted, and then used introspection on the resulting expressions to design the tests.
