### PR TITLE
Add io arguments to code_*, and improve reflection tests

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -205,26 +205,27 @@ end
 
 # displaying type-ambiguity warnings
 
-function code_warntype(f, t::(Type...))
-    global show_expr_type_colorize
-    state = show_expr_type_colorize::Bool
+function code_warntype(io::IO, f, t::(Type...))
+    global show_expr_type_emphasize
+    state = show_expr_type_emphasize::Bool
     ct = code_typed(f, t)
-    show_expr_type_colorize::Bool = true
+    show_expr_type_emphasize::Bool = true
     for ast in ct
-        println(STDOUT, "Variables:")
+        println(io, "Variables:")
         vars = ast.args[2][2]
         for v in vars
-            print(STDOUT, "  ", v[1])
-            show_expr_type(STDOUT, v[2])
-            print(STDOUT, '\n')
+            print(io, "  ", v[1])
+            show_expr_type(io, v[2])
+            print(io, '\n')
         end
-        print(STDOUT, "\nBody:\n  ")
-        show_unquoted(STDOUT, ast.args[3], 2)
-        print(STDOUT, '\n')
+        print(io, "\nBody:\n  ")
+        show_unquoted(io, ast.args[3], 2)
+        print(io, '\n')
     end
-    show_expr_type_colorize::Bool = false
+    show_expr_type_emphasize::Bool = false
     nothing
 end
+code_warntype(f, t::(Type...)) = code_warntype(STDOUT, f, t)
 
 typesof(args...) = map(a->(isa(a,Type) ? Type{a} : typeof(a)), args)
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -155,8 +155,10 @@ function _dump_function(f, t::ANY, native, wrapper)
     str
 end
 
-code_llvm  (f::Function, types::(Type...)) = print(_dump_function(f, types, false, false))
-code_native(f::Function, types::(Type...)) = print(_dump_function(f, types, true, false))
+code_llvm(io::IO, f::Function, types::(Type...)) = print(io, _dump_function(f, types, false, false))
+code_llvm(f::Function, types::(Type...)) = code_llvm(STDOUT, f, types)
+code_native(io::IO, f::Function, types::(Type...)) = print(io, _dump_function(f, types, true, false))
+code_native(f::Function, types::(Type...)) = code_native(STDOUT, f, types)
 
 function functionlocs(f::ANY, types=(Type...))
     locs = Any[]

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1,29 +1,67 @@
 # code_native / code_llvm (issue #8239)
-
-# redirect stdout and stderr to avoid spam during tests.
-oldout = STDOUT
-olderr = STDERR
-redirect_stdout()
-redirect_stderr()
-
 # It's hard to really test these, but just running them should be
 # sufficient to catch segfault bugs.
-@test code_native(ismatch, (Regex, AbstractString)) == nothing
-@test code_native(+, (Int, Int)) == nothing
-@test code_native(+, (Array{Float32}, Array{Float32})) == nothing
 
-@test code_llvm(ismatch, (Regex, AbstractString)) == nothing
-@test code_llvm(+, (Int, Int)) == nothing
-@test code_llvm(+, (Array{Float32}, Array{Float32})) == nothing
+function test_code_reflection(freflect, f, types)
+    iob = IOBuffer()
+    freflect(iob, f, types)
+    str = takebuf_string(iob)
+    @test !isempty(str)
+end
 
-redirect_stdout(oldout)
-redirect_stderr(olderr)
+println(STDERR, "The following 'Returned code...' warnings indicate normal behavior:")
+test_code_reflection(code_native, ismatch, (Regex, AbstractString))
+test_code_reflection(code_native, +, (Int, Int))
+test_code_reflection(code_native, +, (Array{Float32}, Array{Float32}))
+
+test_code_reflection(code_llvm, ismatch, (Regex, AbstractString))
+test_code_reflection(code_llvm, +, (Int, Int))
+test_code_reflection(code_llvm, +, (Array{Float32}, Array{Float32}))
 
 @test_throws Exception code_native(+, Int, Int)
 @test_throws Exception code_native(+, Array{Float32}, Array{Float32})
 
 @test_throws Exception code_llvm(+, Int, Int)
 @test_throws Exception code_llvm(+, Array{Float32}, Array{Float32})
+
+# code_warntype
+module WarnType
+using Base.Test
+
+iob = IOBuffer()
+
+pos_stable(x) = x > 0 ? x : zero(x)
+pos_unstable(x) = x > 0 ? x : 0
+
+tag = Base.have_color ? Base.text_colors[:red] : "UNION"
+code_warntype(iob, pos_unstable, (Float64,))
+str = takebuf_string(iob)
+@test !isempty(search(str, tag))
+code_warntype(iob, pos_stable, (Float64,))
+str = takebuf_string(iob)
+@test isempty(search(str, tag))
+
+type Stable{T,N}
+    A::Array{T,N}
+end
+type Unstable{T}
+    A::Array{T}
+end
+Base.getindex(A::Stable, i) = A.A[i]
+Base.getindex(A::Unstable, i) = A.A[i]
+
+tag = Base.have_color ? Base.text_colors[:red] : "ARRAY{FLOAT64,N}"
+code_warntype(iob, getindex, (Unstable{Float64},Int))
+str = takebuf_string(iob)
+@test !isempty(search(str, tag))
+code_warntype(iob, getindex, (Stable{Float64,2},Int))
+str = takebuf_string(iob)
+@test isempty(search(str, tag))
+code_warntype(iob, getindex, (Stable{Float64},Int))
+str = takebuf_string(iob)
+@test !isempty(search(str, tag))
+
+end
 
 # isbits
 


### PR DESCRIPTION
code_native, code_llvm, and code_warntype display their results rather than returning an AST. This allows one to specify an IO argument to control where that output ends up. In turn, this allows one to write better tests for these functions.

For `code_warntype`, this also adds all-caps emphasis for when `Base.have_color == false`, and for good measure throws in a more careful disabling of emphasis when printing "raw" `Expr` objects.

@tkelman, I wonder if this might work around #9501? If so, it would suggest that `redirect_stdout` and `redirect_stderr` might have problems.
