### PR TITLE
Make Julia play nice with NeoVim.

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -27,7 +27,7 @@ function edit(file::AbstractString, line::Integer)
     no_line_msg = "Unknown editor: no line number information passed.\nThe method is defined at line $line."
     if beginswith(edname, "emacs") || edname == "gedit"
         spawn(`$edpath +$line $file`)
-    elseif edname == "vim" || edname == "nano"
+    elseif edname == "vim" || edname == "nvim" || edname == "nano"
         run(`$edpath +$line $file`)
     elseif edname == "textmate" || edname == "mate" || edname == "kate"
         spawn(`$edpath $file -l $line`)


### PR DESCRIPTION
`nvim` is the canonical name for the NeoVim executable and in in almost all cases can be treated identically to Vim. I had a quick `grep` through the source files as well and this is the only place where Vim is treated specially.
