### PR TITLE
enable [av skip] functionality

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,10 @@ branches:
     - master
     - release-0.3
 
+skip_commits:
+# Add [av skip] to commit messages for docfixes, etc to reduce load on queue
+  message: /\[av skip\]/ 
+
 notifications:
   - provider: Email
     on_build_success: false


### PR DESCRIPTION
To lessen the load on the AppVeyor queue, for doc-only fixes this allows you to add `[av skip]` in the commit message. Travis will still build it (unless you do `[ci skip]` which will disable both services), but since Travis allows multiple concurrent builds the queue time doesn't get quite as long there.
