### PR TITLE
set LLVM_VER from LLVM_CONFIG when using system LLVM

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -523,6 +523,7 @@ ifeq ($(USE_SYSTEM_LLVM), 1)
 LLVM_CONFIG ?= llvm-config$(EXE)
 LLVM_LLC ?= llc$(EXE)
 JCPPFLAGS+=-DSYSTEM_LLVM
+LLVM_VER = $(shell $(LLVM_CONFIG) --version)
 else
 LLVM_CONFIG=$(build_bindir)/llvm-config$(EXE)
 LLVM_LLC=$(build_bindir)/llc$(EXE)


### PR DESCRIPTION
ref #9563, the LLVM info from `versioninfo()` can be wrong if `USE_SYSTEM_LLVM` is set but `LLVM_VER` isn't.

cc @staticfloat @nalimilan
