### PR TITLE
Added tests for math.jl functions

### DIFF
--- a/test/math.jl
+++ b/test/math.jl
@@ -362,3 +362,22 @@ end
 for z in (1.234, 1.234 + 5.678im, [1.234, 5.678])
     @test_approx_eq cis(z) exp(im*z)
 end
+
+# modf
+for elty in (Float32, Float64)
+    @test_approx_eq modf( convert(elty,1.2) )[1] convert(elty,0.2)
+    @test_approx_eq modf( convert(elty,1.2) )[2] convert(elty,1.0)
+    @test_approx_eq modf( convert(elty,1.0) )[1] convert(elty,0.0)
+    @test_approx_eq modf( convert(elty,1.0) )[2] convert(elty,1.0)
+end
+
+# frexp
+for elty in (Float32, Float64)
+    @test frexp( convert(elty,0.5) ) == (convert(elty,0.5),0)
+    @test frexp( convert(elty,4.0) ) == (convert(elty,0.5),3)
+    @test_approx_eq frexp( convert(elty,10.5) )[1] convert(elty,0.65625)
+    @test frexp( convert(elty,10.5) )[2] == 4
+    @test_approx_eq frexp( [ convert(elty,4.0) convert(elty,10.5) ] )[1][1] convert(elty,0.5)
+    @test_approx_eq frexp( [ convert(elty,4.0) convert(elty,10.5) ] )[1][2] convert(elty,0.65625)
+    @test frexp( [ convert(elty,4.0) convert(elty,10.5) ] )[2] == [ 3 4 ]
+end


### PR DESCRIPTION
`mod2pi` and `modf` had no tests at all so I added enough that all branches are covered. There might be one or two extraneous ones. `frexp` had one test but most of the function (the array version, the `Float32` and `Float64` specializations) was not covered so I added tests for that as well. `@test_approx_eq` didn't seem to want to work with tuples - if there's a way to do this I can change the `modf` and `frexp` tests to be more concise.
