### PR TITLE
Replace the use of randbool()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -159,12 +159,14 @@ Deprecated or removed
   `trunc{T<:Integer}(T,x)`, `floor{T<:Integer}(T,x)`, etc.. `trunc` is now
   always bound-checked;`Base.unsafe_trunc` provides the old unchecked `itrunc`
   behaviour ([#9133]).
- 
+
   * `squeeze` now requires that passed dimension(s) are an `Int` or tuple of `Int`s;
     calling `squeeze` with an arbitrary iterator is deprecated ([#9271]).
     Additionally, passed dimensions must be unique and correspond to extant
     dimensions of the input array.
-  
+
+  * `randbool` is deprecated. Use `rand(Bool)` to produce a random boolean value, and
+    `bitrand` to produce a random BitArray ([#9105], [#9569]).
 
 Julia v0.3.0 Release Notes
 ==========================
@@ -1113,6 +1115,7 @@ Too numerous to mention.
 [#8660]: https://github.com/JuliaLang/julia/issues/8660
 [#8712]: https://github.com/JuliaLang/julia/issues/8712
 [#8734]: https://github.com/JuliaLang/julia/issues/8734
+[#8750]: https://github.com/JuliaLang/julia/issues/8750
 [#8776]: https://github.com/JuliaLang/julia/issues/8776
 [#8791]: https://github.com/JuliaLang/julia/issues/8791
 [#8792]: https://github.com/JuliaLang/julia/issues/8792
@@ -1131,6 +1134,7 @@ Too numerous to mention.
 [#9049]: https://github.com/JuliaLang/julia/issues/9049
 [#9065]: https://github.com/JuliaLang/julia/issues/9065
 [#9083]: https://github.com/JuliaLang/julia/issues/9083
+[#9105]: https://github.com/JuliaLang/julia/issues/9105
 [#9122]: https://github.com/JuliaLang/julia/issues/9122
 [#9126]: https://github.com/JuliaLang/julia/issues/9126
 [#9132]: https://github.com/JuliaLang/julia/issues/9132
@@ -1140,3 +1144,4 @@ Too numerous to mention.
 [#9261]: https://github.com/JuliaLang/julia/issues/9261
 [#9271]: https://github.com/JuliaLang/julia/issues/9271
 [#9294]: https://github.com/JuliaLang/julia/issues/9294
+[#9569]: https://github.com/JuliaLang/julia/issues/9569

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -329,16 +329,6 @@ reinterpret{N}(B::BitArray, dims::NTuple{N,Int}) = reshape(B, dims)
 bitunpack{N}(B::BitArray{N}) = convert(Array{Bool,N}, B)
 bitpack{T,N}(A::AbstractArray{T,N}) = convert(BitArray{N}, A)
 
-## Random ##
-
-function bitarray_rand_fill!(rng, B::BitArray) # rng is an AbstractRNG
-    length(B) == 0 && return B
-    Bc = B.chunks
-    rand!(rng, Bc)
-    Bc[end] &= @_msk_end length(B)
-    return B
-end
-
 ## Indexing: getindex ##
 
 function unsafe_bitgetindex(Bc::Vector{UInt64}, i::Int)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -185,8 +185,6 @@ const IpAddr = IPAddr
 @deprecate isblank(c::Char) c == ' ' || c == '\t'
 @deprecate isblank(s::AbstractString) all(c -> c == ' ' || c == '\t', s)
 
-@deprecate randbool! rand!
-
 export Nothing
 const Nothing = Void
 
@@ -259,3 +257,10 @@ const base64 = base64encode
 
 @deprecate sizehint(A, n) sizehint!(A, n)
 
+@deprecate randbool!                               rand!
+@deprecate randbool()                              rand(Bool)
+@deprecate randbool(r::AbstractRNG)                rand(r, Bool)
+@deprecate randbool(dims::Dims)                    bitrand(dims)
+@deprecate randbool(dims::Int...)                  bitrand(dims)
+@deprecate randbool(r::AbstractRNG, dims::Dims)    bitrand(r, dims)
+@deprecate randbool(r::AbstractRNG, dims::Int...)  bitrand(r, dims)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -916,12 +916,12 @@ export
     RandomDevice,
     rand!,
     rand,
-    randbool,
     randn!,
     randn,
     randexp!,
     randexp,
     srand,
+    bitrand,
 
 # bigfloat & precision
     precision,

--- a/base/random.jl
+++ b/base/random.jl
@@ -7,7 +7,7 @@ export srand,
        rand, rand!,
        randn, randn!,
        randexp, randexp!,
-       randbool,
+       bitrand,
        AbstractRNG, RNG, MersenneTwister, RandomDevice
 
 
@@ -552,16 +552,19 @@ rand(rng::AbstractRNG, r::AbstractArray, dims::Int...) = rand(rng, r, dims)
 
 ## random BitArrays (AbstractRNG)
 
-rand!(r::AbstractRNG, B::BitArray) = Base.bitarray_rand_fill!(r, B)
+function rand!(rng::AbstractRNG, B::BitArray)
+    length(B) == 0 && return B
+    Bc = B.chunks
+    rand!(rng, Bc)
+    Bc[end] &= Base.@_msk_end length(B)
+    return B
+end
 
-randbool(r::AbstractRNG, dims::Dims)   = rand!(r, BitArray(dims))
-randbool(r::AbstractRNG, dims::Int...) = rand!(r, BitArray(dims))
+bitrand(r::AbstractRNG, dims::Dims)   = rand!(r, BitArray(dims))
+bitrand(r::AbstractRNG, dims::Int...) = rand!(r, BitArray(dims))
 
-randbool(dims::Dims)   = rand!(BitArray(dims))
-randbool(dims::Int...) = rand!(BitArray(dims))
-
-randbool(r::AbstractRNG=GLOBAL_RNG) = rand(r, Bool)
-
+bitrand(dims::Dims)   = rand!(BitArray(dims))
+bitrand(dims::Int...) = rand!(BitArray(dims))
 
 ## randn() - Normally distributed random numbers using Ziggurat algorithm
 

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -65,7 +65,7 @@ Function                                            Description
 =================================================== =====================================================================
 :func:`Array(type, dims...) <Array>`                an uninitialized dense array
 :func:`cell(dims...) <cell>`                        an uninitialized cell array (heterogeneous array)
-:func:`zeros(type, dims...) <zeros>`                an array of all zeros of specified type, defaults to ``Float64`` if 
+:func:`zeros(type, dims...) <zeros>`                an array of all zeros of specified type, defaults to ``Float64`` if
                                                     ``type`` not specified
 :func:`zeros(A) <zeros>`                            an array of all zeros of same element type and shape of ``A``
 :func:`ones(type, dims...) <ones>`                  an array of all ones of specified type, defaults to ``Float64`` if
@@ -191,7 +191,7 @@ and its left and right neighbor along a 1-d grid. :
      0.699456
      0.977653
      0.994953
-     0.41084 
+     0.41084
      0.809411
 
     julia> [ 0.25*x[i-1] + 0.5*x[i] + 0.25*x[i+1] for i=2:length(x)-1 ]
@@ -200,7 +200,7 @@ and its left and right neighbor along a 1-d grid. :
      0.57468
      0.685417
      0.912429
-     0.8446  
+     0.8446
      0.656511
 
 .. note:: In the above example, ``x`` is declared as constant because type
@@ -259,7 +259,7 @@ Example:
      7  11
 
 Empty ranges of the form ``n:n-1`` are sometimes used to indicate the inter-index
-location between ``n-1`` and ``n``.  For example, the :func:`searchsorted` function uses 
+location between ``n-1`` and ``n``.  For example, the :func:`searchsorted` function uses
 this convention to indicate the insertion point of a value not found in a sorted
 array:
 
@@ -564,9 +564,9 @@ beyond the point of insertion have to be moved one place over.
 All operations on sparse matrices are carefully implemented to exploit
 the CSC data structure for performance, and to avoid expensive operations.
 
-If you have data in CSC format from a different application or library, 
+If you have data in CSC format from a different application or library,
 and wish to import it in Julia, make sure that you use 1-based indexing.
-The row indices in every column need to be sorted. If your `SparseMatrixCSC` 
+The row indices in every column need to be sorted. If your `SparseMatrixCSC`
 object contains unsorted row indices, one quick way to sort them is by
 doing a double transpose.
 
@@ -640,7 +640,7 @@ into a sparse matrix using the :func:`sparse` function:
             [4, 4]  =  1.0
             [5, 5]  =  1.0
 
-You can go in the other direction using the :func:`full` function. The 
+You can go in the other direction using the :func:`full` function. The
 :func:`issparse` function can be used to query if a matrix is sparse.
 
 .. doctest::
@@ -705,10 +705,8 @@ reference.
 |                                        |                                  | distribution. (Requires the                |
 |                                        |                                  | ``Distributions`` package.)                |
 +----------------------------------------+----------------------------------+--------------------------------------------+
-| :func:`sprandbool(m,n,d) <sprandbool>` | :func:`randbool(m,n) <randbool>` | Creates a *m*-by-*n* random matrix (of     |
+| :func:`sprandbool(m,n,d) <sprandbool>` | :func:`rand(Bool,m,n) <rand>`    | Creates a *m*-by-*n* random matrix (of     |
 |                                        |                                  | density *d*) with non-zero  ``Bool``       |
 |                                        |                                  | elements with probability *d* (*d* =0.5    |
-|                                        |                                  | for :func:`randbool`.)                     |
+|                                        |                                  | for :func:`rand(Bool) <rand>`.)            |
 +----------------------------------------+----------------------------------+--------------------------------------------+
-
-

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -269,7 +269,7 @@ following function in ``count_heads.jl``::
     function count_heads(n)
         c::Int = 0
         for i=1:n
-            c += randbool()
+            c += rand(Bool)
         end
         c
     end
@@ -303,7 +303,7 @@ we can use a *parallel for loop*, which can be written in Julia like
 this::
 
     nheads = @parallel (+) for i=1:200000000
-      int(randbool())
+      int(rand(Bool))
     end
 
 This construct implements the pattern of assigning iterations to

--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -289,7 +289,7 @@ For example, the following contrived function returns an array of a
 randomly-chosen type::
 
     function strange_twos(n)
-        a = Array(randbool() ? Int64 : Float64, n)
+        a = Array(rand(Bool) ? Int64 : Float64, n)
         for i = 1:n
             a[i] = 2
         end
@@ -305,7 +305,7 @@ This should be written as::
     end
 
     function strange_twos(n)
-        a = Array(randbool() ? Int64 : Float64, n)
+        a = Array(rand(Bool) ? Int64 : Float64, n)
         fill_twos!(a)
         return a
     end

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -535,9 +535,9 @@ As ``BigInt`` represents unbounded integers, the interval must be specified (e.g
 
    Populate the array A with random values. If the indexable collection ``coll`` is specified, the values are picked randomly from ``coll``. This is equivalent to ``copy!(A, rand(rng, coll, size(A)))`` or ``copy!(A, rand(rng, eltype(A), size(A)))`` but without allocating a new array.
 
-.. function:: randbool([rng], [dims...])
+.. function:: bitrand([rng], [dims...])
 
-   Generate a random boolean value. Optionally, generate a ``BitArray`` of random boolean values.
+   Generate a ``BitArray`` of random boolean values.
 
 .. function:: randn([rng], [dims...])
 
@@ -554,4 +554,3 @@ As ``BigInt`` represents unbounded integers, the interval must be specified (e.g
 .. function:: randexp!([rng], A::Array{Float64,N})
 
    Fill the array A with random numbers following the exponential distribution (with scale 1).
-

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -54,7 +54,7 @@ timesofar("conversions")
 
 ## utility functions ##
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 @test isequal(fill!(b1, true), trues(size(b1)))
 @test isequal(fill!(b1, false), falses(size(b1)))
 
@@ -105,16 +105,16 @@ for (sz,T) in allsizes[2:end]
     end
     @check_bit_operation getindex(b1, 1.0:100.0) BitVector
 
-    t1 = find(randbool(l))
+    t1 = find(bitrand(l))
     @check_bit_operation getindex(b1, t1)        BitVector
     @check_bit_operation getindex(b1, float(t1)) BitVector
 
     for j = 1:l
-        x = randbool()
+        x = rand(Bool)
         @check_bit_operation setindex!(b1, x, j) T
     end
 
-    x = randbool()
+    x = rand(Bool)
     @check_bit_operation setindex!(b1, x, 100.0) T
     y = rand(0.0:1.0)
     @check_bit_operation setindex!(b1, y, 100) T
@@ -122,54 +122,54 @@ for (sz,T) in allsizes[2:end]
     @check_bit_operation setindex!(b1, y, 100.0) T
 
     for j in [1, 63, 64, 65, 127, 128, 129, 191, 192, 193, l-1]
-        x = randbool()
+        x = rand(Bool)
         @check_bit_operation setindex!(b1, x, 1:j) T
-        b2 = randbool(j)
+        b2 = bitrand(j)
         @check_bit_operation setindex!(b1, b2, 1:j) T
-        x = randbool()
+        x = rand(Bool)
         @check_bit_operation setindex!(b1, x, j+1:l) T
-        b2 = randbool(l-j)
+        b2 = bitrand(l-j)
         @check_bit_operation setindex!(b1, b2, j+1:l) T
     end
     for j in [1, 63, 64, 65, 127, 128, 129, div(l,2)]
         m1 = j:(l-j)
-        x = randbool()
+        x = rand(Bool)
         @check_bit_operation setindex!(b1, x, m1) T
-        b2 = randbool(length(m1))
+        b2 = bitrand(length(m1))
         @check_bit_operation setindex!(b1, b2, m1) T
     end
-    x = randbool()
+    x = rand(Bool)
     @check_bit_operation setindex!(b1, x, 1.0:100.0) T
-    b2 = randbool(100)
+    b2 = bitrand(100)
     @check_bit_operation setindex!(b1, b2, 1.0:100.0) T
 
     y = rand(0.0:1.0)
     @check_bit_operation setindex!(b1, y, 1:100) T
-    f2 = float(randbool(100))
+    f2 = float(bitrand(100))
     @check_bit_operation setindex!(b1, f2, 1:100) T
-    f2 = float(randbool(100))
+    f2 = float(bitrand(100))
     @check_bit_operation setindex!(b1, f2, 1.0:100.0) T
 
-    t1 = find(randbool(l))
-    x = randbool()
+    t1 = find(bitrand(l))
+    x = rand(Bool)
     @check_bit_operation setindex!(b1, x, t1) T
-    b2 = randbool(length(t1))
+    b2 = bitrand(length(t1))
     @check_bit_operation setindex!(b1, b2, t1) T
 
     y = rand(0.0:1.0)
     @check_bit_operation setindex!(b1, y, t1) T
-    f2 = float(randbool(length(t1)))
+    f2 = float(bitrand(length(t1)))
     @check_bit_operation setindex!(b1, f2, t1) T
 
     ft1 = float(t1)
-    x = randbool()
+    x = rand(Bool)
     @check_bit_operation setindex!(b1, x, ft1) T
-    b2 = randbool(length(t1))
+    b2 = bitrand(length(t1))
     @check_bit_operation setindex!(b1, b2, ft1) T
 
     y = rand(0.0:1.0)
     @check_bit_operation setindex!(b1, y, ft1) T
-    f2 = float(randbool(length(t1)))
+    f2 = float(bitrand(length(t1)))
     @check_bit_operation setindex!(b1, f2, ft1) T
 end
 
@@ -177,10 +177,10 @@ end
 
 rand_m1m2() = rand(1:n1), rand(1:n2)
 
-b1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
 
 m1, m2 = rand_m1m2()
-b2 = randbool(m1, m2)
+b2 = bitrand(m1, m2)
 @check_bit_operation copy!(b1, b2) BitMatrix
 
 function gen_getindex_data()
@@ -220,31 +220,31 @@ end
 
 function gen_setindex_data()
     m1, m2 = rand_m1m2()
-    produce((randbool(), m1, m2))
+    produce((rand(Bool), m1, m2))
     m1, m2 = rand_m1m2()
-    produce((randbool(), m1, 1:m2))
-    produce((randbool(m2), m1, 1:m2))
+    produce((rand(Bool), m1, 1:m2))
+    produce((bitrand(m2), m1, 1:m2))
     m1, m2 = rand_m1m2()
-    produce((randbool(), m1, randperm(m2)))
-    produce((randbool(m2), m1, randperm(m2)))
+    produce((rand(Bool), m1, randperm(m2)))
+    produce((bitrand(m2), m1, randperm(m2)))
     m1, m2 = rand_m1m2()
-    produce((randbool(), 1:m1, m2))
-    produce((randbool(m1), 1:m1, m2))
+    produce((rand(Bool), 1:m1, m2))
+    produce((bitrand(m1), 1:m1, m2))
     m1, m2 = rand_m1m2()
-    produce((randbool(), 1:m1, 1:m2))
-    produce((randbool(m1, m2), 1:m1, 1:m2))
+    produce((rand(Bool), 1:m1, 1:m2))
+    produce((bitrand(m1, m2), 1:m1, 1:m2))
     m1, m2 = rand_m1m2()
-    produce((randbool(), 1:m1, randperm(m2)))
-    produce((randbool(m1, m2), 1:m1, randperm(m2)))
+    produce((rand(Bool), 1:m1, randperm(m2)))
+    produce((bitrand(m1, m2), 1:m1, randperm(m2)))
     m1, m2 = rand_m1m2()
-    produce((randbool(), randperm(m1), m2))
-    produce((randbool(m1), randperm(m1), m2))
+    produce((rand(Bool), randperm(m1), m2))
+    produce((bitrand(m1), randperm(m1), m2))
     m1, m2 = rand_m1m2()
-    produce((randbool(), randperm(m1), 1:m2))
-    produce((randbool(m1,m2), randperm(m1), 1:m2))
+    produce((rand(Bool), randperm(m1), 1:m2))
+    produce((bitrand(m1,m2), randperm(m1), 1:m2))
     m1, m2 = rand_m1m2()
-    produce((randbool(), randperm(m1), randperm(m2)))
-    produce((randbool(m1,m2), randperm(m1), randperm(m2)))
+    produce((rand(Bool), randperm(m1), randperm(m2)))
+    produce((bitrand(m1,m2), randperm(m1), randperm(m2)))
 end
 
 for (b2, k1, k2) in Task(gen_setindex_data)
@@ -263,55 +263,55 @@ for (b2, k1, k2) in Task(gen_setindex_data)
 end
 
 m1, m2 = rand_m1m2()
-b2 = randbool(1, 1, m2)
+b2 = bitrand(1, 1, m2)
 @check_bit_operation setindex!(b1, b2, m1, 1:m2) BitMatrix
-x = randbool()
-b2 = randbool(1, m2, 1)
+x = rand(Bool)
+b2 = bitrand(1, m2, 1)
 @check_bit_operation setindex!(b1, x, m1, 1:m2, 1)  BitMatrix
 @check_bit_operation setindex!(b1, b2, m1, 1:m2, 1) BitMatrix
 
 for p1 = [rand(1:v1) 1 63 64 65 191 192 193]
     for p2 = [rand(1:v1) 1 63 64 65 191 192 193]
         for n = 0 : min(v1 - p1 + 1, v1 - p2 + 1)
-            b1 = randbool(v1)
-            b2 = randbool(v1)
+            b1 = bitrand(v1)
+            b2 = bitrand(v1)
             @check_bit_operation copy!(b1, p1, b2, p2, n) BitVector
         end
     end
 end
 
 # logical indexing
-b1 = randbool(n1, n2)
-t1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
+t1 = bitrand(n1, n2)
 @test isequal(bitunpack(b1[t1]), bitunpack(b1)[t1])
 @test isequal(bitunpack(b1[t1]), bitunpack(b1)[bitunpack(t1)])
 
-t1 = randbool(n1)
-t2 = randbool(n2)
+t1 = bitrand(n1)
+t2 = bitrand(n2)
 @test isequal(bitunpack(b1[t1, t2]), bitunpack(b1)[t1, t2])
 @test isequal(bitunpack(b1[t1, t2]), bitunpack(b1)[bitunpack(t1), bitunpack(t2)])
 
 
-b1 = randbool(n1, n2)
-t1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
+t1 = bitrand(n1, n2)
 @check_bit_operation setindex!(b1, true, t1) BitMatrix
 
-t1 = randbool(n1, n2)
-b2 = randbool(countnz(t1))
+t1 = bitrand(n1, n2)
+b2 = bitrand(countnz(t1))
 @check_bit_operation setindex!(b1, b2, t1) BitMatrix
 
 m1 = rand(1:n1)
 m2 = rand(1:n2)
 
-t1 = randbool(n1)
-b2 = randbool(countnz(t1), m2)
+t1 = bitrand(n1)
+b2 = bitrand(countnz(t1), m2)
 k2 = randperm(m2)
 @check_bit_operation setindex!(b1, b2, t1, 1:m2)       BitMatrix
 @check_bit_operation setindex!(b1, b2, t1, n2-m2+1:n2) BitMatrix
 @check_bit_operation setindex!(b1, b2, t1, k2)         BitMatrix
 
-t2 = randbool(n2)
-b2 = randbool(m1, countnz(t2))
+t2 = bitrand(n2)
+b2 = bitrand(m1, countnz(t2))
 k1 = randperm(m1)
 @check_bit_operation setindex!(b1, b2, 1:m1, t2)       BitMatrix
 @check_bit_operation setindex!(b1, b2, n1-m1+1:n1, t2) BitMatrix
@@ -324,7 +324,7 @@ timesofar("indexing")
 b1 = BitArray(0)
 i1 = Bool[]
 for m = 1 : v1
-    x = randbool()
+    x = rand(Bool)
     push!(b1, x)
     push!(i1, x)
     @test isequal(bitunpack(b1), i1)
@@ -332,8 +332,8 @@ end
 
 for m1 = 0 : v1
     for m2 = [0, 1, 63, 64, 65, 127, 128, 129]
-        b1 = randbool(m1)
-        b2 = randbool(m2)
+        b1 = bitrand(m1)
+        b2 = bitrand(m2)
         i1 = bitunpack(b1)
         i2 = bitunpack(b2)
         @test isequal(bitunpack(append!(b1, b2)), append!(i1, i2))
@@ -342,15 +342,15 @@ end
 
 for m1 = 0 : v1
     for m2 = [0, 1, 63, 64, 65, 127, 128, 129]
-        b1 = randbool(m1)
-        b2 = randbool(m2)
+        b1 = bitrand(m1)
+        b2 = bitrand(m2)
         i1 = bitunpack(b1)
         i2 = bitunpack(b2)
         @test isequal(bitunpack(prepend!(b1, b2)), prepend!(i1, i2))
     end
 end
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for m = 1 : v1
     jb = pop!(b1)
@@ -364,14 +364,14 @@ end
 b1 = BitArray(0)
 i1 = Bool[]
 for m = 1 : v1
-    x = randbool()
+    x = rand(Bool)
     unshift!(b1, x)
     unshift!(i1, x)
     @test isequal(bitunpack(b1), i1)
 end
 
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for m = 1 : v1
     jb = shift!(b1)
@@ -387,13 +387,13 @@ b1 = BitArray(0)
 i1 = bitunpack(b1)
 for m = 1 : v1
     j = rand(1:m)
-    x = randbool()
+    x = rand(Bool)
     @test insert!(b1, j, x) === b1
     insert!(i1, j, x)
     @test isequal(bitunpack(b1), i1)
 end
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
     x = rand(0:1)
@@ -402,7 +402,7 @@ for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
     @test isequal(bitunpack(b1), i1)
 end
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for m = v1 : -1 : 1
     j = rand(1:m)
@@ -413,7 +413,7 @@ for m = v1 : -1 : 1
 end
 @test length(b1) == 0
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for m = v1 : -1 : 1
     j = rand(1:m)
@@ -423,7 +423,7 @@ for m = v1 : -1 : 1
 end
 @test length(b1) == 0
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
     b = splice!(b1, j)
@@ -432,7 +432,7 @@ for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
     @test b == i
 end
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
     deleteat!(b1, j)
@@ -440,7 +440,7 @@ for j in [63, 64, 65, 127, 128, 129, 191, 192, 193]
     @test isequal(bitunpack(b1), i1)
 end
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for m1 = 1 : v1
     for m2 = m1 : v1
@@ -453,7 +453,7 @@ for m1 = 1 : v1
     end
 end
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for m1 = 1 : v1
     for m2 = m1 : v1
@@ -465,14 +465,14 @@ for m1 = 1 : v1
     end
 end
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for m1 = 1 : v1 + 1
     for m2 = m1 - 1 : v1
         for v2 = [0, 1, 63, 64, 65, 127, 128, 129, 191, 192, 193, rand(1:v1)]
             b2 = copy(b1)
             i2 = copy(i1)
-            b3 = randbool(v2)
+            b3 = bitrand(v2)
             i3 = bitunpack(b3)
             b = splice!(b2, m1:m2, b3)
             i = splice!(i2, m1:m2, i3)
@@ -480,7 +480,7 @@ for m1 = 1 : v1 + 1
             @test b == i
             b2 = copy(b1)
             i2 = copy(i1)
-            i3 = int(randbool(v2))
+            i3 = int(bitrand(v2))
             b = splice!(b2, m1:m2, i3)
             i = splice!(i2, m1:m2, i3)
             @test isequal(bitunpack(b2), i2)
@@ -496,13 +496,13 @@ for m1 = 1 : v1 + 1
     end
 end
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for m1 = 1 : v1
     for v2 = [0, 1, 63, 64, 65, 127, 128, 129, 191, 192, 193, rand(1:v1)]
         b2 = copy(b1)
         i2 = copy(i1)
-        b3 = randbool(v2)
+        b3 = bitrand(v2)
         i3 = bitunpack(b3)
         b = splice!(b2, m1, b3)
         i = splice!(i2, m1, i3)
@@ -510,7 +510,7 @@ for m1 = 1 : v1
         @test b == i
         b2 = copy(b1)
         i2 = copy(i1)
-        i3 = int(randbool(v2))
+        i3 = int(bitrand(v2))
         b = splice!(b2, m1:m2, i3)
         i = splice!(i2, m1:m2, i3)
         @test isequal(bitunpack(b2), i2)
@@ -525,11 +525,11 @@ for m1 = 1 : v1
     end
 end
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 for m1 = 1 : v1 - 1
     for m2 = m1 + 1 : v1
-        locs = randbool(m2-m1+1)
+        locs = bitrand(m2-m1+1)
         m = [m1:m2...][locs]
         b2 = copy(b1)
         i2 = copy(i1)
@@ -539,7 +539,7 @@ for m1 = 1 : v1 - 1
     end
 end
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 i1 = bitunpack(b1)
 empty!(b1)
 empty!(i1)
@@ -549,7 +549,7 @@ timesofar("dequeue")
 
 ## Unary operators ##
 
-b1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
 @check_bit_operation (~)(b1)  BitMatrix
 @check_bit_operation (!)(b1)  BitMatrix
 @check_bit_operation (-)(b1)  Matrix{Int}
@@ -570,8 +570,8 @@ timesofar("unary arithmetic")
 
 # Matrix{Bool}/Matrix{Bool}
 
-b1 = randbool(n1, n2)
-b2 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
+b2 = bitrand(n1, n2)
 @check_bit_operation (&)(b1, b2)  BitMatrix
 @check_bit_operation (|)(b1, b2)  BitMatrix
 @check_bit_operation ($)(b1, b2)  BitMatrix
@@ -587,12 +587,12 @@ b2 = trues(n1, n2)
 
 while true
     global b1
-    b1 = randbool(n1, n1)
+    b1 = bitrand(n1, n1)
     if abs(det(float64(b1))) > 1e-6
         break
     end
 end
-b2 = randbool(n1, n1)
+b2 = bitrand(n1, n1)
 
 @check_bit_operation (*)(b1, b2) Matrix{Int}
 @check_bit_operation (/)(b1, b1) Matrix{Float64}
@@ -606,7 +606,7 @@ b0 = falses(0)
 @check_bit_operation (*)(b0, b0') Matrix{Int}
 
 # Matrix{Bool}/Matrix{Int}
-b1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
 i2 = rand(1:10, n1, n2)
 @check_bit_operation (&)(b1, i2)  Matrix{Int}
 @check_bit_operation (|)(b1, i2)  Matrix{Int}
@@ -620,7 +620,7 @@ i2 = rand(1:10, n1, n2)
 @check_bit_operation mod(b1, i2)  Matrix{Int}
 
 # Matrix{Bool}/Matrix{Float64}
-b1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
 f2 = 1.0 .+ rand(n1, n2)
 @check_bit_operation (.*)(b1, f2) Matrix{Float64}
 @check_bit_operation (./)(b1, f2) Matrix{Float64}
@@ -629,7 +629,7 @@ f2 = 1.0 .+ rand(n1, n2)
 @check_bit_operation mod(b1, f2)  Matrix{Float64}
 
 # Number/Matrix
-b2 = randbool(n1, n2)
+b2 = bitrand(n1, n2)
 i1 = rand(1:10)
 u1 = uint8(i1)
 f1 = float64(i1)
@@ -684,7 +684,7 @@ b2 = trues(n1, n2)
 @check_bit_operation (./)(cu1, b2) Matrix{Complex128}
 @check_bit_operation (./)(cf1, b2) Matrix{Complex128}
 
-b2 = randbool(n1, n2)
+b2 = bitrand(n1, n2)
 @check_bit_operation (.^)(false, b2) BitMatrix
 @check_bit_operation (.^)(true, b2)  BitMatrix
 @check_bit_operation (.^)(0x0, b2)   Matrix{UInt8}
@@ -702,7 +702,7 @@ b2 = randbool(n1, n2)
 @check_bit_operation (.^)(0x1im, b2) Matrix{Complex{UInt8}}
 
 # Matrix/Number
-b1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
 i2 = rand(1:10)
 u2 = uint8(i2)
 f2 = float64(i2)
@@ -793,8 +793,8 @@ timesofar("binary arithmetic")
 
 ## Binary comparison operators ##
 
-b1 = randbool(n1, n2)
-b2 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
+b2 = bitrand(n1, n2)
 @check_bit_operation (.==)(b1, b2) BitMatrix
 @check_bit_operation (.!=)(b1, b2) BitMatrix
 @check_bit_operation (.<)(b1, b2) BitMatrix
@@ -804,7 +804,7 @@ timesofar("binary comparison")
 
 ## Data movement ##
 
-b1 = randbool(s1, s2, s3, s4)
+b1 = bitrand(s1, s2, s3, s4)
 for d = 1 : 4
     j = rand(1:size(b1, d))
     #for j = 1 : size(b1, d)
@@ -813,17 +813,17 @@ for d = 1 : 4
     @check_bit_operation flipdim(b1, d) BitArray{4}
 end
 
-b1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
 for k = 1 : 4
     @check_bit_operation rotl90(b1, k) BitMatrix
 end
 
 for m = 0 : v1
-    b1 = randbool(m)
+    b1 = bitrand(m)
     @check_bit_operation reverse(b1) BitVector
 end
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 for m = [rand(1:v1)-1 0 1 63 64 65 191 192 193 v1-1]
     @test isequal(b1 << m, [ b1[m+1:end]; falses(m) ])
     @test isequal(b1 >>> m, [ falses(m); b1[1:end-m] ])
@@ -837,7 +837,7 @@ timesofar("datamove")
 
 ## countnz & find ##
 
-for m = 0:v1, b1 in Any[randbool(m), trues(m), falses(m)]
+for m = 0:v1, b1 in Any[bitrand(m), trues(m), falses(m)]
     @check_bit_operation countnz(b1) Int
 
     @check_bit_operation findfirst(b1) Int
@@ -868,14 +868,14 @@ for i = 3:v1-1
     end
 end
 
-b1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
 @check_bit_operation findnz(b1) (Vector{Int}, Vector{Int}, BitArray)
 
 timesofar("nnz&find")
 
 ## Reductions ##
 
-b1 = randbool(s1, s2, s3, s4)
+b1 = bitrand(s1, s2, s3, s4)
 m1 = 1
 m2 = 3
 @check_bit_operation maximum(b1, (m1, m2)) BitArray{4}
@@ -905,12 +905,12 @@ timesofar("reductions")
 
 ## Transpose ##
 
-b1 = randbool(v1)
+b1 = bitrand(v1)
 @check_bit_operation transpose(b1) BitMatrix
 
 for m1 = 0 : n1
     for m2 = 0 : n2
-        b1 = randbool(m1, m2)
+        b1 = bitrand(m1, m2)
         @check_bit_operation transpose(b1) BitMatrix
     end
 end
@@ -919,7 +919,7 @@ timesofar("transpose")
 
 ## Permutedims ##
 
-b1 = randbool(s1, s2, s3, s4)
+b1 = bitrand(s1, s2, s3, s4)
 p = randperm(4)
 @check_bit_operation permutedims(b1, p) BitArray{4}
 @check_bit_operation permutedims(b1, tuple(p...)) BitArray{4}
@@ -928,33 +928,33 @@ timesofar("permutedims")
 
 ## Concatenation ##
 
-b1 = randbool(v1)
-b2 = randbool(v1)
+b1 = bitrand(v1)
+b2 = bitrand(v1)
 @check_bit_operation hcat(b1, b2) BitMatrix
 for m = 1 : v1 - 1
     @check_bit_operation vcat(b1[1:m], b1[m+1:end]) BitVector
 end
 
-b1 = randbool(n1, n2)
-b2 = randbool(n1)
-b3 = randbool(n1, n2)
-b4 = randbool(1, n2)
+b1 = bitrand(n1, n2)
+b2 = bitrand(n1)
+b3 = bitrand(n1, n2)
+b4 = bitrand(1, n2)
 @check_bit_operation hcat(b1, b2, b3) BitMatrix
 @check_bit_operation vcat(b1, b4, b3) BitMatrix
 
-b1 = randbool(s1, s2, s3, s4)
-b2 = randbool(s1, s3, s3, s4)
-b3 = randbool(s1, s2, s3, s1)
+b1 = bitrand(s1, s2, s3, s4)
+b2 = bitrand(s1, s3, s3, s4)
+b3 = bitrand(s1, s2, s3, s1)
 @check_bit_operation cat(2, b1, b2) BitArray{4}
 @check_bit_operation cat(4, b1, b3) BitArray{4}
 @check_bit_operation cat(6, b1, b1) BitArray{6}
 
-b1 = randbool(1, v1, 1)
+b1 = bitrand(1, v1, 1)
 @check_bit_operation cat(2, 0, b1, 1, 1, b1) Array{Int,3}
 @check_bit_operation cat(2, 3, b1, 4, 5, b1) Array{Int,3}
 @check_bit_operation cat(2, false, b1, true, true, b1) BitArray{3}
 
-b1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
 for m1 = 1 : n1 - 1
     for m2 = 1 : n2 - 1
         @test isequal([b1[1:m1,1:m2] b1[1:m1,m2+1:end]; b1[m1+1:end,1:m2] b1[m1+1:end,m2+1:end]], b1)
@@ -965,59 +965,59 @@ timesofar("cat")
 
 # Linear algebra
 
-b1 = randbool(v1)
-b2 = randbool(v1)
+b1 = bitrand(v1)
+b2 = bitrand(v1)
 @check_bit_operation dot(b1, b2) Int
 
-b1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
 for k = -max(n1,n2) : max(n1,n2)
     @check_bit_operation tril(b1, k) BitMatrix
     @check_bit_operation triu(b1, k) BitMatrix
 end
 
-b1 = randbool(n1, n1)
+b1 = bitrand(n1, n1)
 @check_bit_operation istril(b1) Bool
-b1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
 @check_bit_operation istril(b1) Bool
-b1 = randbool(n2, n1)
-@check_bit_operation istril(b1) Bool
-
-b1 = tril(randbool(n1, n1))
-@check_bit_operation istril(b1) Bool
-b1 = tril(randbool(n1, n2))
-@check_bit_operation istril(b1) Bool
-b1 = tril(randbool(n2, n1))
+b1 = bitrand(n2, n1)
 @check_bit_operation istril(b1) Bool
 
-b1 = randbool(n1, n1)
+b1 = tril(bitrand(n1, n1))
+@check_bit_operation istril(b1) Bool
+b1 = tril(bitrand(n1, n2))
+@check_bit_operation istril(b1) Bool
+b1 = tril(bitrand(n2, n1))
+@check_bit_operation istril(b1) Bool
+
+b1 = bitrand(n1, n1)
 @check_bit_operation istriu(b1) Bool
-b1 = randbool(n1, n2)
+b1 = bitrand(n1, n2)
 @check_bit_operation istriu(b1) Bool
-b1 = randbool(n2, n1)
+b1 = bitrand(n2, n1)
 @check_bit_operation istriu(b1) Bool
 
-b1 = triu(randbool(n1, n1))
+b1 = triu(bitrand(n1, n1))
 @check_bit_operation istriu(b1) Bool
-b1 = triu(randbool(n1, n2))
+b1 = triu(bitrand(n1, n2))
 @check_bit_operation istriu(b1) Bool
-b1 = triu(randbool(n2, n1))
+b1 = triu(bitrand(n2, n1))
 @check_bit_operation istriu(b1) Bool
 
-b1 = randbool(n1,n1)
+b1 = bitrand(n1,n1)
 b1 |= b1.'
 @check_bit_operation issym(b1) Bool
 
-b1 = randbool(n1)
-b2 = randbool(n2)
+b1 = bitrand(n1)
+b2 = bitrand(n2)
 @check_bit_operation kron(b1, b2) BitVector
 
-b1 = randbool(s1, s2)
-b2 = randbool(s3, s4)
+b1 = bitrand(s1, s2)
+b2 = bitrand(s3, s4)
 @check_bit_operation kron(b1, b2) BitMatrix
 
-#b1 = randbool(v1)
+#b1 = bitrand(v1)
 #@check_bit_operation diff(b1) Vector{Int}
-#b1 = randbool(n1, n2)
+#b1 = bitrand(n1, n2)
 #@check_bit_operation diff(b1) Vector{Int}
 
 timesofar("linalg")

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -93,7 +93,7 @@ for arr in (identity, as_sub)
         bittest(f, ewf, arr(rand(rb, n1, n2, n3)), arr(rand(rb, n1, n2, n3)))
         bittest(f, ewf, arr(rand(rb,  1, n2, n3)), arr(rand(rb, n1,  1, n3)))
         bittest(f, ewf, arr(rand(rb,  1, n2,  1)), arr(rand(rb, n1,  1, n3)))
-        bittest(f, ewf, arr(randbool(n1, n2, n3)), arr(randbool(n1, n2, n3)))
+        bittest(f, ewf, arr(bitrand(n1, n2, n3)), arr(bitrand(n1, n2, n3)))
     end
 end
 

--- a/test/linalg2.jl
+++ b/test/linalg2.jl
@@ -376,7 +376,7 @@ J = UniformScaling(λ)
 @test I + I === UniformScaling(2) # +
 @test inv(I) == I
 @test inv(J) == UniformScaling(inv(λ))
-B = randbool(2,2)
+B = bitrand(2,2)
 @test B + I == B + eye(B)
 @test I + B == B + eye(B)
 A = randn(2,2)
@@ -468,4 +468,3 @@ let
     Q=full(qrfact(A)[:Q])
     @test vecnorm(A-Q) < eps()
 end
-

--- a/test/random.jl
+++ b/test/random.jl
@@ -11,7 +11,7 @@ srand(0); rand(); x = rand(384);
 @test(typeof(rand(false:true)) == Bool)
 
 @test length(randn(4, 5)) == 20
-@test length(randbool(4, 5)) == 20
+@test length(bitrand(4, 5)) == 20
 
 @test rand(MersenneTwister()) == 0.8236475079774124
 @test rand(MersenneTwister(0)) == 0.8236475079774124
@@ -276,9 +276,8 @@ for rng in ([], [MersenneTwister()], [RandomDevice()])
         f!(rng..., Array(Float64, 2, 3)) ::Array{Float64, 2}
     end
 
-    randbool(rng...)               ::Bool
-    randbool(rng..., 5)            ::BitArray{1}
-    randbool(rng..., 2, 3)         ::BitArray{2}
+    bitrand(rng..., 5)             ::BitArray{1}
+    bitrand(rng..., 2, 3)          ::BitArray{2}
     rand!(rng..., BitArray(5))     ::BitArray{1}
     rand!(rng..., BitArray(2, 3))  ::BitArray{2}
 

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -65,7 +65,7 @@ end
 @test isequaldlm(readcsv(IOBuffer("1,2\n\n4,5"), skipblanks=false), reshape(Any[1.0,"",4.0,2.0,"",5.0], 3, 2), Any)
 @test isequaldlm(readcsv(IOBuffer("1,2\n\n4,5"), skipblanks=true), reshape([1.0,4.0,2.0,5.0], 2, 2), Float64)
 
-let x = randbool(5, 10), io = IOBuffer()
+let x = bitrand(5, 10), io = IOBuffer()
     writedlm(io, x)
     seek(io, 0)
     @test readdlm(io, Bool) == x
@@ -197,4 +197,3 @@ let i18n_data = ["Origin (English)", "Name (English)", "Origin (Native)", "Name 
     writedlm(i18n_buff, i18n_arr, '\t')
     @test (data, hdr) == readdlm(i18n_buff, '\t', header=true)
 end
-

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -297,8 +297,8 @@ for (aa116, ss116) in [(a116, s116), (ad116, sd116)]
     @test full(ss116[p,p]) == aa116[p,p]
 
     # bool indexing
-    li = randbool(size(aa116,1))
-    lj = randbool(size(aa116,2))
+    li = bitrand(size(aa116,1))
+    lj = bitrand(size(aa116,2))
     @test full(ss116[li,j]) == aa116[li,j]''
     @test full(ss116[li,:]) == aa116[li,:]
     @test full(ss116[i,lj]) == aa116[i,lj]


### PR DESCRIPTION
Deprecate randbool (#9105).
For a random Bool, instead of randbool(), use rand(Bool)
Instead of randbool(dims), use bitrand(dims)
