### PR TITLE
disable raise test on windows again

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -2022,9 +2022,11 @@ let x = [1,2,3]
 end
 
 # sig 2 is SIGINT per the POSIX.1-1990 standard
-ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
-@test_throws InterruptException ccall(:raise, Void, (Cint,), 2)
-ccall(:jl_exit_on_sigint, Void, (Cint,), 1)
+if Base.is_unix(OS_NAME)
+    ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
+    @test_throws InterruptException ccall(:raise, Void, (Cint,), 2)
+    ccall(:jl_exit_on_sigint, Void, (Cint,), 1)
+end
 
 # pull request #9534
 @test try; a,b,c = 1,2; catch ex; (ex::BoundsError).a === (1,2) && ex.i == 3; end


### PR DESCRIPTION
~~see whether this avoids intermittent codegen segfaults like https://travis-ci.org/JuliaLang/julia/jobs/45751116 and https://ci.appveyor.com/project/StefanKarpinski/julia/build/1.0.1074/job/hqdwovpc9mqs4kng ?~~

windows problem still isn't fixed, https://github.com/JuliaLang/julia/commit/3b350f114d2a6065c45565b379a3b58d440bd135#commitcomment-9144851

ref #9544
