### PR TITLE
Fix #9504. Check second stride before calling BLAS.

### DIFF
--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -107,7 +107,7 @@ d[5,1:2:4,8] = 19
 AA = rand(4,2)
 A = convert(SharedArray, AA)
 B = convert(SharedArray, AA')
-@test B*A == AA'*AA
+@test B*A == ctranspose(AA)*AA
 
 d=SharedArray(Int64, (10,10); init = D->fill!(D.loc_subarr_1d, myid()), pids=[id_me, id_other])
 d2 = map(x->1, d)


### PR DESCRIPTION
This commit changes the multiplication methods to use the generic multiplication methods unless we can verify that it is okay to call BLAS. This makes it possible to use funky strides as in JuliaLang/LinearAlgebra.jl#155.

@timholy is it possible to construct a funky view with `sub`? I think the example from JuliaLang/LinearAlgebra.jl#155 exploits linear indexing from `ArrayViews` which makes it difficult to write a test in base for this fix.
