### PR TITLE
RFC: Pass file/column/line information to custom string literals (#9577)

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -216,7 +216,7 @@ end
 map(f::Callable, a::Array{Any,1}) = Any[ f(a[i]) for i=1:length(a) ]
 
 macro thunk(ex); :(()->$(esc(ex))); end
-macro L_str(s); s; end
+macro L_str(s,args...); s; end
 
 function precompile(f::ANY, args::Tuple)
     if isa(f,DataType)

--- a/base/docs.jl
+++ b/base/docs.jl
@@ -134,9 +134,9 @@ namify(sy::Symbol) = sy
 
 function mdify(ex)
   if isa(ex, AbstractString)
-    :(@doc_str $(esc(ex)))
+    Markdown.docexpr(ex)
   elseif isexpr(ex, :macrocall) && namify(ex) == symbol("@mstr")
-    :(@doc_mstr $(esc(ex.args[2])))
+    Markdown.docexpr(ex.args[2])
   else
     esc(ex)
   end
@@ -268,12 +268,12 @@ writemime(io::IO, ::MIME"text/html", h::HTML) = print(io, h.content)
 writemime(io::IO, ::MIME"text/html", h::HTML{Function}) = h.content(io)
 
 @doc "Create an `HTML` object from a literal string." ->
-macro html_str (s)
+macro html_str (s,args...)
   :(HTML($s))
 end
 
 @doc (@doc html"") ->
-macro html_mstr (s)
+macro html_mstr (s,args...)
   :(HTML($(Base.triplequoted(s))))
 end
 
@@ -307,12 +307,12 @@ print(io::IO, t::Text{Function}) = t.content(io)
 writemime(io::IO, ::MIME"text/plain", t::Text) = print(io, t)
 
 @doc "Create a `Text` object from a literal string." ->
-macro text_str (s)
+macro text_str (s,args...)
   :(Text($s))
 end
 
 @doc (@doc text"") ->
-macro text_mstr (s)
+macro text_mstr (s,args...)
   :(Text($(Base.triplequoted(s))))
 end
 

--- a/base/markdown/Markdown.jl
+++ b/base/markdown/Markdown.jl
@@ -45,20 +45,20 @@ function docexpr(s, flavor = :julia)
   end
 end
 
-macro md_str(s, t...)
+macro md_str(s, filename, line, col, t...)
   mdexpr(s, t...)
 end
 
-macro md_mstr(s, t...)
+macro md_mstr(s, filename, line, col, t...)
   s = Base.triplequoted(s)
   mdexpr(s, t...)
 end
 
-macro doc_str(s, t...)
+macro doc_str(s, filename, line, col, t...)
   docexpr(s, t...)
 end
 
-macro doc_mstr(s, t...)
+macro doc_mstr(s, filename, line, col, t...)
   s = Base.triplequoted(s)
   docexpr(s, t...)
 end

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -26,7 +26,7 @@ macro MIME(s)
     end
 end
 
-macro MIME_str(s)
+macro MIME_str(s,args...)
     :(MIME{$(Expr(:quote, symbol(s)))})
 end
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -52,8 +52,8 @@ function compile(regex::Regex)
     regex
 end
 
-macro r_str(pattern, flags...) Regex(pattern, flags...) end
-macro r_mstr(pattern, flags...) Regex(pattern, flags...) end
+macro r_str(pattern, filename, line, col, flags...) Regex(pattern, flags...) end
+macro r_mstr(pattern, filename, line, col, flags...) Regex(pattern, flags...) end
 
 copy(r::Regex) = r
 

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -227,7 +227,7 @@ function parseip(str)
     end
 end
 
-macro ip_str(str)
+macro ip_str(str, args...)
     return parseip(str)
 end
 

--- a/base/string.jl
+++ b/base/string.jl
@@ -1077,7 +1077,7 @@ end
 
 ## core string macros ##
 
-macro b_str(s); :($(unescape_string(s)).data); end
+macro b_str(s,args...); :($(unescape_string(s)).data); end
 
 macro mstr(s...); triplequoted(s...); end
 

--- a/base/version.jl
+++ b/base/version.jl
@@ -96,7 +96,7 @@ end
 
 convert(::Type{VersionNumber}, v::AbstractString) = VersionNumber(v)
 
-macro v_str(v); VersionNumber(v); end
+macro v_str(v,args...); VersionNumber(v); end
 
 typemin(::Type{VersionNumber}) = v"0-"
 typemax(::Type{VersionNumber}) = VersionNumber(typemax(Int),typemax(Int),typemax(Int),(),("",))

--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -212,6 +212,13 @@ value_t fl_iolineno(value_t *args, u_int32_t nargs)
     return size_wrap(s->lineno);
 }
 
+value_t fl_iocolno(value_t *args, u_int32_t nargs)
+{
+    argcount("input-port-column", nargs, 1);
+    ios_t *s = toiostream(args[0], "input-port-column");
+    return size_wrap(s->colno);
+}
+
 value_t fl_ioseek(value_t *args, u_int32_t nargs)
 {
     argcount("io.seek", nargs, 2);
@@ -426,6 +433,7 @@ static builtinspec_t iostreamfunc_info[] = {
     { "io.copyuntil", fl_iocopyuntil },
     { "io.tostring!", fl_iotostring },
     { "input-port-line", fl_iolineno },
+    { "input-port-column", fl_iocolno },
 
     { NULL, NULL }
 };

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -992,18 +992,21 @@
 	     (if (and (symbol? ex) (not (operator? ex))
 		      (not (ts:space? s)))
 		 ;; custom prefixed string literals, x"s" => @x_str "s"
-		 (let* ((str (begin (take-token s)
-				    (parse-string-literal s #t)))
+         (begin (take-token s) (let* (
+            (lineno (input-port-line (ts:port s)))
+            (colno (input-port-column (ts:port s)))
+            (str (parse-string-literal s #t))
 			(nxt (peek-token s))
 			(suffix (if (triplequote-string-literal? str) '_mstr '_str))
+            (textcolno (if (triplequote-string-literal? str) (+ colno 2) colno))
 			(macname (symbol (string #\@ ex suffix)))
 			(macstr (cdr str)))
 		   (if (and (symbol? nxt) (not (operator? nxt))
 			    (not (ts:space? s)))
 		       ;; string literal suffix, "s"x
-		       (loop `(macrocall ,macname ,@macstr
+		       (loop `(macrocall ,macname ,@macstr ,current-filename ,lineno ,textcolno
 					 ,(string (take-token s))))
-		       (loop `(macrocall ,macname ,@macstr))))
+		       (loop `(macrocall ,macname ,@macstr ,current-filename ,lineno ,textcolno)))))
 		 ex))
 	    (else ex))))))
 

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -825,6 +825,7 @@ static void _ios_init(ios_t *s)
     s->ndirty = 0;
     s->fpos = -1;
     s->lineno = 1;
+    s->colno = 0;
     s->fd = -1;
     s->ownbuf = 1;
     s->ownfd = 0;
@@ -955,7 +956,11 @@ int ios_getc(ios_t *s)
         if (ios_read(s, &ch, 1) < 1)
             return IOS_EOF;
     }
-    if (ch == '\n') s->lineno++;
+    s->colno++;
+    if (ch == '\n') {
+        s->lineno++;
+        s->colno = 1;
+    }
     return (unsigned char)ch;
 }
 

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -40,6 +40,7 @@ typedef struct {
 
     off_t fpos;       // cached file pos
     size_t lineno;    // current line number
+    size_t colno;     // current column number
 
     // pointer-size integer to support platforms where it might have
     // to be a pointer

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1294,3 +1294,22 @@ for T in (ASCIIString, UTF8String, UTF16String, UTF32String)
         end
     end
 end
+
+# Test passing of line/column numbers to custom string literals
+macro linecoltest_str(s,file,line,col)
+    # Change these if the file/line numbers change
+    @test s == "HELLO WORLD"
+    @test endswith(string(file),"strings.jl")
+    @test line == 1306
+    @test col == 13
+end
+linecoltest"HELLO WORLD"
+
+macro linecoltest_mstr(s,file,line,col)
+    # Change these if the file/line numbers change
+    @test endswith(string(file),"strings.jl")
+    @test line == 1314
+    @test col == 15
+end
+linecoltest"""HELLO
+WORLD"""


### PR DESCRIPTION
This is one possible way to handle #9577, but I'm not sure if it's ideal, because it forces people to declare the arguments to every `_str` macro even if they have no intention of doing anything with it. The other alternative I mentioned in #9577 is to save this information in a global variable that can be retrieved through a function call. That alternative seems more hacky though as it adds new global state and I'm not sure what would happen with quoted string literals. Alternative thoughts appreciated.
