### PR TITLE
More robust detection of user code

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3734,7 +3734,7 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
     ctx.f = f;
 
     // step 5. set up debug info context and create first basic block
-    bool in_user_code = lam->module != jl_base_module && lam->module != jl_core_module;
+    bool in_user_code = !is_submodule(jl_base_module, lam->module);
     bool do_coverage = jl_compileropts.code_coverage == JL_LOG_ALL || (jl_compileropts.code_coverage == JL_LOG_USER && in_user_code);
     bool do_malloc_log = jl_compileropts.malloc_log  == JL_LOG_ALL || (jl_compileropts.malloc_log    == JL_LOG_USER && in_user_code);
     jl_value_t *stmt = jl_cellref(stmts,0);

--- a/src/dump.c
+++ b/src/dump.c
@@ -338,7 +338,7 @@ static void jl_update_all_fptrs()
     delayed_fptrs = NULL;
 }
 
-static int is_submodule(jl_module_t *parent, jl_module_t *child)
+int is_submodule(jl_module_t *parent, jl_module_t *child)
 {
     while (1) {
         if (parent == child)

--- a/src/julia.h
+++ b/src/julia.h
@@ -806,6 +806,7 @@ STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
 }
 DLLEXPORT void jl_module_run_initializer(jl_module_t *m);
 jl_function_t *jl_module_call_func(jl_module_t *m);
+int is_submodule(jl_module_t *parent, jl_module_t *child);
 
 // eq hash tables
 DLLEXPORT jl_array_t *jl_eqtable_put(jl_array_t *h, void *key, void *val);


### PR DESCRIPTION
I noticed that `--track-allocation=user` reports allocation for a subset of files in `base/` (I'm sure `--code-coverage=user` would do the same). This appears to fix the main problems; for some reason, a file `multi.jl.mem` still gets written in `base`, and I have no idea why that would happen.
