### PR TITLE
Add to style guide: avoid float literals

### DIFF
--- a/doc/manual/style-guide.rst
+++ b/doc/manual/style-guide.rst
@@ -332,7 +332,7 @@ As you can see, the second version, where we used an :obj:`Int` literal, preserv
 the type of the input argument, while the first didn't. This is because e.g. 
 ``promote_type(Int, Float64) == Float64``, and promotion happens with the 
 multiplication. Similarly, :obj:`Rational` literals are less type disruptive than
-:obj:`Float64` literals, but more disruptive than :obj:`Int`s:
+:obj:`Float64` literals, but more disruptive than :obj:`Int`\ s:
 
 .. doctest::
 

--- a/doc/manual/style-guide.rst
+++ b/doc/manual/style-guide.rst
@@ -298,6 +298,8 @@ type that will affect the arguments as little as possible through promotion.
 
 For example,
 
+.. doctest::
+
     julia> f(x) = 2.0 * x
     f (generic function with 1 method)
     
@@ -312,6 +314,8 @@ For example,
     
 while
 
+.. doctest::
+
     julia> g(x) = 2 * x
     g (generic function with 1 method)
     
@@ -324,11 +328,13 @@ while
     julia> g(2)
     4
     
-As you can see, the second version, where we used an `Int` literal, preserved
+As you can see, the second version, where we used an :obj:`Int` literal, preserved
 the type of the input argument, while the first didn't. This is because e.g. 
 ``promote_type(Int, Float64) == Float64``, and promotion happens with the 
-multiplication. Similarly, ``Rational`` literals are less type disruptive than 
-``Float64`` literals, but more disruptive than ``Int``s:
+multiplication. Similarly, :obj:`Rational` literals are less type disruptive than
+:obj:`Float64` literals, but more disruptive than :obj:`Int`s:
+
+.. doctest::
 
     julia> h(x) = 2//1 * x
     h (generic function with 1 method)
@@ -342,5 +348,5 @@ multiplication. Similarly, ``Rational`` literals are less type disruptive than
     julia> h(1)
     2//1
 
-Thus, use ``Int`` literals when possible, with ``Rational{Int}`` for literal 
+Thus, use :obj:`Int` literals when possible, with :obj:`Rational{Int}` for literal
 non-integer numbers, in order to make it easier to use your code.

--- a/doc/manual/style-guide.rst
+++ b/doc/manual/style-guide.rst
@@ -289,3 +289,58 @@ But any function can be passed directly, without being "wrapped" in an
 anonymous function. Instead of writing ``map(x->f(x), a)``, write
 :func:`map(f, a) <map>`.
 
+Avoid using floats for numeric literals in generic code when possible
+---------------------------------------------------------------------
+
+If you write generic code which handles numbers, and which can be expected to
+run with many different numeric type arguments, try using literals of a numeric
+type that will affect the arguments as little as possible through promotion.
+
+For example,
+
+    julia> f(x) = 2.0 * x
+    f (generic function with 1 method)
+    
+    julia> f(1//2)
+    1.0
+    
+    julia> f(1/2)
+    1.0
+    
+    julia> f(1)
+    2.0
+    
+while
+
+    julia> g(x) = 2 * x
+    g (generic function with 1 method)
+    
+    julia> g(1//2)
+    1//1
+    
+    julia> g(1/2)
+    1.0
+    
+    julia> g(2)
+    4
+    
+As you can see, the second version, where we used an `Int` literal, preserved
+the type of the input argument, while the first didn't. This is because e.g. 
+``promote_type(Int, Float64) == Float64``, and promotion happens with the 
+multiplication. Similarly, ``Rational`` literals are less type disruptive than 
+``Float64`` literals, but more disruptive than ``Int``s:
+
+    julia> h(x) = 2//1 * x
+    h (generic function with 1 method)
+    
+    julia> h(1//2)
+    1//1
+    
+    julia> h(1/2)
+    1.0
+    
+    julia> h(1)
+    2//1
+
+Thus, use ``Int`` literals when possible, with ``Rational{Int}`` for literal 
+non-integer numbers, in order to make it easier to use your code.


### PR DESCRIPTION
In a discussion with @timholy just now, I learned that numeric literals are way less disruptive to the types of other variables if specified as `Int`s or `Rational`s than if they're specified with floats (which is the intuitive thing to do for non-integer values. Therefore, I propose adding something about this to the style guide - if this is (and/or should be) considered a best practice, of course.

I am very open to suggestion about wording, choice of examples and positioning in the manual.
