### PR TITLE
Explanatory error message for ``convert`` MethodError from type constructor fallback

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -158,12 +158,10 @@ function showerror(io::IO, e::MethodError)
     end
     # Give a helpful error message if the user likely called a type constructor
     # and sees a no method error for convert
-    if e.f == Base.convert && !isempty(e.args)
-        if isa(e.args[1], Type)
-            println(io)
-            print(io, "This may have arisen from a call to the constructor $(e.args[1])(...), ")
-            print(io, "since type constructors always fall back to convert methods.")
-        end
+    if e.f == Base.convert && !isempty(e.args) && isa(e.args[1], Type)
+        println(io)
+        print(io, "This may have arisen from a call to the constructor $(e.args[1])(...), ")
+        print(io, "since type constructors fall back to convert methods in julia v0.4.")
     end
 
     # Display up to three closest candidates

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -156,6 +156,15 @@ function showerror(io::IO, e::MethodError)
         print(io, "\nNote the difference between 1d column vector [1,2,3] and 2d row vector [1 2 3].")
         print(io, "\nYou can convert to a column vector with the vec() function.")
     end
+    # Give a helpful error message if the user likely called a type constructor
+    # and sees a no method error for convert
+    if e.f == Base.convert && !isempty(e.args)
+        if isa(e.args[1], Type)
+            println(io)
+            print(io, "This may have arisen from a call to the constructor $(e.args[1])(...), ")
+            print(io, "since type constructors always fall back to convert methods.")
+        end
+    end
 
     # Display up to three closest candidates
     lines = Array((IOBuffer, Int), 0)


### PR DESCRIPTION
ref #9250, hopefully this will help explain where explain where the magical `convert` appears. This will turn up false positives for explicit calls to `convert` that are missing methods, but I'm not sure how to dig around the backtraces and make the code smart enough to disambiguate the two cases. 
