### PR TITLE
Added tests for rot and expanded arrayop/sparse tests

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -154,6 +154,9 @@ v = pop!(l)
 v = pop!(l)
 @test v == 3
 @test length(l)==2
+m = Any[]
+@test_throws ErrorException pop!(m)
+@test_throws ErrorException shift!(m)
 unshift!(l,4,7,5)
 @test l[1]==4 && l[2]==7 && l[3]==5 && l[4]==1 && l[5]==2
 v = shift!(l)
@@ -727,7 +730,9 @@ for idx in Any[1, 2, 5, 9, 10, 1:0, 2:1, 1:1, 2:2, 1:2, 2:4, 9:8, 10:9, 9:9, 10:
 end
 a = [1:10]
 @test deleteat!(a, [1,3,5,7:10...]) == [2,4,6]
-
+@test_throws BoundsError deleteat!(a, 13)
+@test_throws BoundsError deleteat!(a, [1,13])
+@test_throws ErrorException deleteat!(a, [5,3])
 
 # comprehensions
 X = [ i+2j for i=1:5, j=1:5 ]
@@ -957,3 +962,15 @@ I2 = CartesianIndex((-1,5,2))
 
 @test min(CartesianIndex((2,3)), CartesianIndex((5,2))) == CartesianIndex((2,2))
 @test max(CartesianIndex((2,3)), CartesianIndex((5,2))) == CartesianIndex((5,3))
+
+#rotates
+
+a = [ [ 1 0 0 ], [ 0 0 0 ] ]
+@test rotr90(a,1) == [ [ 0 1 ], [ 0 0 ], [ 0 0 ] ]
+@test rotr90(a,2) == rot180(a,1)
+@test rotr90(a,3) == rotl90(a,1)
+@test rotl90(a,3) == rotr90(a,1)
+@test rotl90(a,1) == rotr90(a,3)
+@test rotl90(a,4) == a
+@test rotr90(a,4) == a
+@test rot180(a,2) == a

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -475,3 +475,8 @@ end
 
 # issue #9525
 @test_throws BoundsError sparse([3], [5], 1.0, 3, 3)
+
+#findn
+b = findn( speye(4) )
+@test (length(b[1]) == 4)
+@test (length(b[2]) == 4)


### PR DESCRIPTION
Added some tests to make sure exceptions are thrown, added tests for `rot180`, `rotr90`, and `rotl90`, and wrote a test for `findn` for sparse matrices (I'm pretty sure this wasn't covered).
