### PR TITLE
Rotation functions for sparse matrices

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2159,20 +2159,18 @@ function rotr90(A::SparseMatrixCSC)
     I,J,V = findnz(A)
     m,n = size(A)
     #old col inds are new row inds
-    newJ = similar(J)
-    for i=1:length(newJ)
-        newJ[i] = m - I[i] + 1
+    for i=1:length(I)
+        I[i] = m - I[i] + 1
     end
-    return sparse(J, newJ, V, n, m)
+    return sparse(J, I, V, n, m)
 end
 
 function rotl90(A::SparseMatrixCSC)
     I,J,V = findnz(A)
     m,n = size(A)
     #old row inds are new col inds
-    newI = similar(I)
-    for i=1:length(newI)
-        newI[i] = n - J[i] + 1
+    for i=1:length(J)
+        J[i] = n - J[i] + 1
     end
-    return sparse(newI, I, V, n, m)
+    return sparse(J, I, V, n, m)
 end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2142,3 +2142,37 @@ function sortSparseMatrixCSC!{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}; sortindices::Sym
 
     return A
 end
+
+## rotations
+
+function rot180(A::SparseMatrixCSC)
+    I,J,V = findnz(A)
+    m,n = size(A)
+    for i=1:length(I)
+        I[i] = m - I[i] + 1
+        J[i] = n - J[i] + 1
+    end
+    return sparse(I,J,V,m,n)
+end
+
+function rotr90(A::SparseMatrixCSC)
+    I,J,V = findnz(A)
+    m,n = size(A)
+    #old col inds are new row inds
+    newJ = similar(J)
+    for i=1:length(newJ)
+        newJ[i] = m - I[i] + 1
+    end
+    return sparse(J, newJ, V, n, m)
+end
+
+function rotl90(A::SparseMatrixCSC)
+    I,J,V = findnz(A)
+    m,n = size(A)
+    #old row inds are new col inds
+    newI = similar(I)
+    for i=1:length(newI)
+        newI[i] = n - J[i] + 1
+    end
+    return sparse(newI, I, V, n, m)
+end

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -480,3 +480,22 @@ end
 b = findn( speye(4) )
 @test (length(b[1]) == 4)
 @test (length(b[2]) == 4)
+
+#rotations
+a = sparse( [1,1,2,3], [1,3,4,1], [1,2,3,4] )
+
+@test rot180(a,2) == a
+@test rot180(a,1) == sparse( [3,3,2,1], [4,2,1,4], [1,2,3,4] )
+@test rotr90(a,1) == sparse( [1,3,4,1], [3,3,2,1], [1,2,3,4] )
+@test rotl90(a,1) == sparse( [4,2,1,4], [1,1,2,3], [1,2,3,4] )
+@test rotl90(a,2) == rot180(a)
+@test rotr90(a,2) == rot180(a)
+@test rotl90(a,3) == rotr90(a)
+@test rotr90(a,3) == rotl90(a)
+
+#ensure we have preserved the correct dimensions!
+
+a = speye(3,5)
+@test size(rot180(a)) == (3,5)
+@test size(rotr90(a)) == (5,3)
+@test size(rotl90(a)) == (5,3)


### PR DESCRIPTION
Although `rot180(A::AbstractArray, k::Int)`, `rotr90(A::AbstractArray, k::Int)`, and `rotl90(A::AbstractArray, k::Int)` are supposed to accept `AbstractArray`s, if you actually tried to use them with sparse matrices they'd fail because the matrix-argument-only versions only supported `StridedMatrix` objects. I added rotations for `SparseMatrixCSC` matrices as well as some tests. 
