### PR TITLE
Change algorithm for symmetric tridiagonal problems to PWK instead of MRRR when all values are calculated.

### DIFF
--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -96,7 +96,7 @@ eigfact{T}(A::SymTridiagonal{T}, irange::UnitRange) = (S = promote_type(Float32,
 eigfact!{T<:BlasReal}(A::SymTridiagonal{T}, vl::Real, vu::Real) = Eigen(LAPACK.stegr!('V', A.dv, A.ev, convert(T, vl), convert(T, vu), 0, 0)...)
 eigfact{T}(A::SymTridiagonal{T}, vl::Real, vu::Real) = (S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigfact!(S != T ? convert(SymTridiagonal{S}, A) : copy(A), vl, vu))
 
-eigvals!{T<:BlasReal}(A::SymTridiagonal{T}) = LAPACK.stegr!('N', 'A', A.dv, A.ev, 0.0, 0.0, 0, 0)[1]
+eigvals!{T<:BlasReal}(A::SymTridiagonal{T}) = LAPACK.stev!('N', A.dv, A.ev)[1]
 eigvals{T}(A::SymTridiagonal{T}) = (S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigvals!(S != T ? convert(SymTridiagonal{S}, A) : copy(A)))
 
 eigvals!{T<:BlasReal}(A::SymTridiagonal{T}, irange::UnitRange) = LAPACK.stegr!('N', 'I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)[1]


### PR DESCRIPTION
Because it is faster and no less precise.
