### PR TITLE
Added documentation of rotation functions [ci skip]

### DIFF
--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -444,13 +444,28 @@ Array functions
 
    Rotate matrix ``A`` 180 degrees.
 
+.. function:: rot180(A, k)
+
+   Rotate matrix ``A`` 180 degrees an integer ``k`` number of times.
+   If ``k`` is even, this is equivalent to a ``copy``.
+
 .. function:: rotl90(A)
 
    Rotate matrix ``A`` left 90 degrees.
 
+.. function:: rotl90(A, k)
+
+   Rotate matrix ``A`` left 90 degrees an integer ``k`` number of times. If ``k``
+   is zero or a multiple of four, this is equivalent to a ``copy``.
+
 .. function:: rotr90(A)
 
    Rotate matrix ``A`` right 90 degrees.
+
+.. function:: rotr90(A, k)
+
+   Rotate matrix ``A`` right 90 degrees an integer ``k`` number of times. If ``k``
+   is zero or a multiple of four, this is equivalent to a ``copy``.
 
 .. function:: reducedim(f, A, dims, initial)
 


### PR DESCRIPTION
`rotr90(A, k)`, `rotl90(A, k)`, and `rot180(A, k)` had no documentation. Now they have some.
