### PR TITLE
interrupt interactive task on ^C if we would be "stuck" otherwise

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -82,7 +82,7 @@ end
 
 function start_repl_backend(repl_channel::RemoteRef, response_channel::RemoteRef)
     backend = REPLBackend(repl_channel, response_channel, nothing)
-    @async begin
+    global interactive_task = @schedule begin
         # include looks at this to determine the relative include path
         # nothing means cwd
         while true

--- a/base/task.jl
+++ b/base/task.jl
@@ -80,6 +80,10 @@ function task_done_hook(t::Task)
         end
         yieldto(nexttask, result)
     else
+        if err && isa(result,InterruptException) && isdefined(REPL,:interactive_task) &&
+            REPL.interactive_task.state == :waiting && isempty(Workqueue)
+            throwto(REPL.interactive_task, result)
+        end
         wait()
     end
 end


### PR DESCRIPTION
Commit message:

> This keeps the existing behavior that ^C interrupts either the currently running task, or the last task to call `wait()`. If, however, the resulting cascade of interrupts ends with no runnable tasks, then forcibly interrupt the REPL's evaluation task to get the prompt back.

I think this is a good behavior for ^C. It's basically backwards-compatible, but adds a fallback step to make sure we can almost always get the prompt back.
