### PR TITLE
Add ``Base.`` annotations to ``mapfoldl`` in docs

### DIFF
--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -418,8 +418,8 @@ Iterable Collections
       14
 
    The associativity of the reduction is implementation-dependent. Use
-   ``mapfoldl`` or ``mapfoldr`` instead for guaranteed left or right
-   associativity.
+   :func:`mapfoldl` or :func:`mapfoldr` instead for guaranteed left or 
+   right associativity.
 
 .. function:: mapreduce(f, op, itr)
 


### PR DESCRIPTION
Figured this was probably preferable to adding more exports.
