### PR TITLE
Improve BoundsError reporting for AbstractArrays

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -75,39 +75,39 @@ linearindexing{A<:Array}(::Type{A}) = LinearFast()
 linearindexing{A<:Range}(::Type{A}) = LinearFast()
 
 ## Bounds checking ##
-checkbounds(sz::Int, i::Int) = 1 <= i <= sz || throw(BoundsError())
-checkbounds(sz::Int, i::Real) = checkbounds(sz, to_index(i))
-checkbounds(sz::Int, I::AbstractVector{Bool}) = length(I) == sz || throw(BoundsError())
-checkbounds(sz::Int, r::Range{Int}) = isempty(r) || (minimum(r) >= 1 && maximum(r) <= sz) || throw(BoundsError())
-checkbounds{T<:Real}(sz::Int, r::Range{T}) = checkbounds(sz, to_index(r))
+_checkbounds(sz::Int, i::Int) = 1 <= i <= sz || throw(BoundsError())
+_checkbounds(sz::Int, i::Real) = _checkbounds(sz, to_index(i))
+_checkbounds(sz::Int, I::AbstractVector{Bool}) = length(I) == sz || throw(BoundsError())
+_checkbounds(sz::Int, r::Range{Int}) = isempty(r) || (minimum(r) >= 1 && maximum(r) <= sz) || throw(BoundsError())
+_checkbounds{T<:Real}(sz::Int, r::Range{T}) = _checkbounds(sz, to_index(r))
 
-function checkbounds{T <: Real}(sz::Int, I::AbstractArray{T})
+function _checkbounds{T <: Real}(sz::Int, I::AbstractArray{T})
     for i in I
-        checkbounds(sz, i)
+        _checkbounds(sz, i)
     end
 end
 
 checkbounds(A::AbstractArray, I::AbstractArray{Bool}) = size(A) == size(I) || throw(BoundsError())
 
-checkbounds(A::AbstractArray, I) = checkbounds(length(A), I)
+checkbounds(A::AbstractArray, I) = _checkbounds(length(A), I)
 
 function checkbounds(A::AbstractMatrix, I::Union(Real,AbstractArray), J::Union(Real,AbstractArray))
-    checkbounds(size(A,1), I)
-    checkbounds(size(A,2), J)
+    _checkbounds(size(A,1), I)
+    _checkbounds(size(A,2), J)
 end
 
 function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray), J::Union(Real,AbstractArray))
-    checkbounds(size(A,1), I)
-    checkbounds(trailingsize(A,2), J)
+    _checkbounds(size(A,1), I)
+    _checkbounds(trailingsize(A,2), J)
 end
 
 function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray)...)
     n = length(I)
     if n > 0
         for dim = 1:(n-1)
-            checkbounds(size(A,dim), I[dim])
+            _checkbounds(size(A,dim), I[dim])
         end
-        checkbounds(trailingsize(A,n), I[n])
+        _checkbounds(trailingsize(A,n), I[n])
     end
 end
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -75,39 +75,39 @@ linearindexing{A<:Array}(::Type{A}) = LinearFast()
 linearindexing{A<:Range}(::Type{A}) = LinearFast()
 
 ## Bounds checking ##
-_checkbounds(sz::Int, i::Int) = 1 <= i <= sz || throw(BoundsError())
-_checkbounds(sz::Int, i::Real) = _checkbounds(sz, to_index(i))
-_checkbounds(sz::Int, I::AbstractVector{Bool}) = length(I) == sz || throw(BoundsError())
-_checkbounds(sz::Int, r::Range{Int}) = isempty(r) || (minimum(r) >= 1 && maximum(r) <= sz) || throw(BoundsError())
-_checkbounds{T<:Real}(sz::Int, r::Range{T}) = _checkbounds(sz, to_index(r))
+_checkbounds(sz::Int, i::Int, A::AbstractArray, J...) = 1 <= i <= sz || throw(BoundsError(A, J))
+_checkbounds(sz::Int, i::Real, A::AbstractArray, J...) = _checkbounds(sz, to_index(i), A, J...)
+_checkbounds(sz::Int, I::AbstractVector{Bool}, A::AbstractArray, J...) = length(I) == sz || throw(BoundsError(A, J))
+_checkbounds(sz::Int, r::Range{Int}, A::AbstractArray, J...) = isempty(r) || (minimum(r) >= 1 && maximum(r) <= sz) || throw(BoundsError(A, J))
+_checkbounds{T<:Real}(sz::Int, r::Range{T}, A::AbstractArray, J...) = _checkbounds(sz, to_index(r), A, J...)
 
-function _checkbounds{T <: Real}(sz::Int, I::AbstractArray{T})
+function _checkbounds{T <: Real}(sz::Int, I::AbstractArray{T}, A::AbstractArray, J...)
     for i in I
-        _checkbounds(sz, i)
+        _checkbounds(sz, i, A, J...)
     end
 end
 
-checkbounds(A::AbstractArray, I::AbstractArray{Bool}) = size(A) == size(I) || throw(BoundsError())
+checkbounds(A::AbstractArray, I::AbstractArray{Bool}) = size(A) == size(I) || throw(BoundsError(A, I))
 
-checkbounds(A::AbstractArray, I) = _checkbounds(length(A), I)
+checkbounds(A::AbstractArray, I) = _checkbounds(length(A), I, A, I)
 
 function checkbounds(A::AbstractMatrix, I::Union(Real,AbstractArray), J::Union(Real,AbstractArray))
-    _checkbounds(size(A,1), I)
-    _checkbounds(size(A,2), J)
+    _checkbounds(size(A,1), I, A, I, J)
+    _checkbounds(size(A,2), J, A, I, J)
 end
 
 function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray), J::Union(Real,AbstractArray))
-    _checkbounds(size(A,1), I)
-    _checkbounds(trailingsize(A,2), J)
+    _checkbounds(size(A,1), I, A, I, J)
+    _checkbounds(trailingsize(A,2), J, A, I, J)
 end
 
 function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray)...)
     n = length(I)
     if n > 0
         for dim = 1:(n-1)
-            _checkbounds(size(A,dim), I[dim])
+            _checkbounds(size(A,dim), I[dim], A, I...)
         end
-        _checkbounds(trailingsize(A,n), I[n])
+        _checkbounds(trailingsize(A,n), I[n], A, I...)
     end
 end
 
@@ -506,26 +506,26 @@ setindex!(t::AbstractArray, x) = throw(MethodError(setindex!, (t, x)))
 
 function getindex(A::AbstractVector, i1,i2,i3...)
     if i2*prod(i3) != 1
-        throw(BoundsError())
+        throw(BoundsError(A, tuple(i1,i2,i3...)))
     end
     A[i1]
 end
 function getindex(A::AbstractMatrix, i1,i2,i3,i4...)
     if i3*prod(i4) != 1
-        throw(BoundsError())
+        throw(BoundsError(A, tuple(i1,i2,i3,i4...)))
     end
     A[i1,i2]
 end
 
 function setindex!(A::AbstractVector, x, i1,i2,i3...)
     if i2*prod(i3) != 1
-        throw(BoundsError())
+        throw(BoundsError(A, tuple(i1,i2,i3...)))
     end
     A[i1] = x
 end
 function setindex!(A::AbstractMatrix, x, i1,i2,i3,i4...)
     if i3*prod(i4) != 1
-        throw(BoundsError())
+        throw(BoundsError(A, tuple(i1,i2,i3,i4...)))
     end
     A[i1,i2] = x
 end

--- a/base/string.jl
+++ b/base/string.jl
@@ -141,9 +141,9 @@ function nextind(s::AbstractString, i::Integer)
     next(s,e)[2] # out of range
 end
 
-checkbounds(s::AbstractString, i::Integer) = start(s) <= i <= endof(s) || throw(BoundsError())
+checkbounds(s::AbstractString, i::Integer) = start(s) <= i <= endof(s) || throw(BoundsError(s, i))
 checkbounds(s::AbstractString, i::Real) = checkbounds(s, to_index(i))
-checkbounds{T<:Integer}(s::AbstractString, r::Range{T}) = isempty(r) || (minimum(r) >= start(s) && maximum(r) <= endof(s)) || throw(BoundsError())
+checkbounds{T<:Integer}(s::AbstractString, r::Range{T}) = isempty(r) || (minimum(r) >= start(s) && maximum(r) <= endof(s)) || throw(BoundsError(s, r))
 checkbounds{T<:Real}(s::AbstractString, I::AbstractArray{T}) = all(i -> checkbounds(s, i), I)
 
 ind2chr(s::DirectIndexString, i::Integer) = begin checkbounds(s,i); i end


### PR DESCRIPTION
This uses the new interface of `BoundsError` in the `checkbounds` functions, which is used by AbstractArrays (including Arrays in some cases). In order to do that, I had to split the external (exported and documented) version of `checkbounds` and the internal one, which used a different - undocumented - interface. I called `_checkbounds` the latter, but suggestions for better names are indeed welcome, even if it's just and internal function.

Using BitArrays as an example, here is a before/after:

Before:

```
julia-0.4> b = bitrand(3);

julia-0.4> b[4] = true # does not call checkbounds
ERROR: BoundsError: attempt to access 3-element BitArray{1}:
  true
  true
 false
  at index [4]

julia-0.4> b[4] = 1
ERROR: BoundsError
 in checkbounds at abstractarray.jl:78
 in checkbounds at abstractarray.jl:110
 in setindex! at multidimensional.jl:629
```

After:

```
julia-0.4> b = bitrand(3);

julia-0.4> b[4] = true # does not call checkbounds
ERROR: BoundsError: attempt to access 3-element BitArray{1}:
  true
  true
 false
  at index [4]

julia-0.4> b[4] = 1
ERROR: BoundsError: attempt to access 3-element BitArray{1}:
  true
  true
 false
  at index [4]
 in _checkbounds at abstractarray.jl:78
 in checkbounds at abstractarray.jl:110
 in setindex! at multidimensional.jl:629
```

I tried to avoid extra allocations etc, but I'm submitting as a PR for review just to confirm that there should be no performance issues (cc @vtjnash which did the new BoundsError interface).

Out of necessity, the reporting is also not particularly precise in more convoluted cases, e.g.:

```
julia-0.4> a = rand(2,3,2);

julia-0.4> a[2,bitrand(4),2]
ERROR: BoundsError: attempt to access 2x3x2 Array{Float64,3}:
[:, :, 1] =
 0.0514813   0.573538  0.150317
 0.00485321  0.118724  0.435752

[:, :, 2] =
 0.0525793  0.731588  0.813656
 0.0234425  0.894198  0.977163
  at index [2,Bool[true,true,false,false],2]
 in _checkbounds at abstractarray.jl:80
 in checkbounds at abstractarray.jl:108
 in getindex at multidimensional.jl:188
```

where the whole indexing expression is reported; it's still much better then before though.

If this is OK I'll proceed improving the error reporting in other areas as well (e.g. Strings).
