### PR TITLE
Allow construction of anonymous bare modules

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -283,8 +283,7 @@ _new(:NewvarNode, :Symbol)
 _new(:QuoteNode, :ANY)
 _new(:GenSym, :Int)
 
-Module(name::Symbol) = ccall(:jl_f_new_module, Any, (Any,), name)::Module
-Module() = Module(:anonymous)
+Module(name::Symbol=:anonymous, std_imports::Bool=true) = ccall(:jl_f_new_module, Any, (Any, Int32), name, std_imports)::Module
 
 Task(f::ANY) = ccall(:jl_new_task, Any, (Any, Int), f::Function, 0)::Task
 

--- a/src/module.c
+++ b/src/module.c
@@ -36,12 +36,12 @@ jl_module_t *jl_new_module(jl_sym_t *name)
     return m;
 }
 
-DLLEXPORT jl_value_t *jl_f_new_module(jl_sym_t *name)
+DLLEXPORT jl_value_t *jl_f_new_module(jl_sym_t *name, int std_imports)
 {
     jl_module_t *m = jl_new_module(name);
     m->parent = jl_main_module;
     gc_wb(m, m->parent);
-    jl_add_standard_imports(m);
+    if (std_imports) jl_add_standard_imports(m);
     return (jl_value_t*)m;
 }
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -579,6 +579,10 @@ let
     @test x == 1
 end
 
+# Module() constructor
+@test names(Module(:anonymous), true, true) != [:anonymous]
+@test names(Module(:anonymous, false), true, true) == [:anonymous]
+
 # issue #7307
 function test7307(a, ret)
     try


### PR DESCRIPTION
See https://groups.google.com/forum/#!msg/julia-users/pxyjT2VmcLo/Zf0gSwKsuE8J. I worked around this in https://github.com/stevengj/PyCall.jl/pull/110, but that's definitely a hack. If this seems reasonable I'll add a couple tests.
