### PR TITLE
Improve efficiency in case of one large prime factor in factor()

### DIFF
--- a/base/primes.jl
+++ b/base/primes.jl
@@ -93,6 +93,10 @@ function factor{T<:Integer}(n::T)
                 n = oftype(n, div(n,p))
             end
             n == 1 && return h
+            if isprime(n)
+                h[n] = 1
+                return h
+            end
             s = isqrt(n)
         end
     end
@@ -103,7 +107,9 @@ function factor{T<:Integer}(n::T)
                 h[p] = get(h,p,0)+1
                 n = oftype(n, div(n,p))
             end
-            if n == 1
+            n == 1 && return h
+            if isprime(n)
+                h[n] = 1
                 return h
             end
             s = isqrt(n)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2086,3 +2086,9 @@ end
 let x = big(-0.0)
     @test signbit(x) && !signbit(abs(x))
 end
+
+# issue #9611
+@test factor(int128(2)^101+1) == Dict(3=>1,845100400152152934331135470251=>1)
+
+# test second branch, after all small primes in list have been searched
+@test factor(10009 * int128(1000000000000037)) == Dict(10009=>1,1000000000000037=>1)


### PR DESCRIPTION
Numbers with only one very large prime factor can not be factored.
The proposed change allows them to be factored. An example is

``` julia
factor(int128(2)^101+1)
Dict{Int128,Int64} with 2 entries:
  3                              => 1
  845100400152152934331135470251 => 1
```
