### PR TITLE
directly call arrayset/arrayref when indexing Array with CartesianIndex

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -57,6 +57,13 @@ end
 # indexing
 getindex(index::CartesianIndex, i::Integer) = getfield(index, i)
 
+stagedfunction getindex{N}(A::Array, index::CartesianIndex{N})
+    N==0 ? :(Base.arrayref(A, 1)) : :(@ncall $N Base.arrayref A d->getfield(index,d))
+end
+stagedfunction setindex!{T,N}(A::Array{T}, v, index::CartesianIndex{N})
+    N==0 ? :(Base.arrayset(A, convert($T,v), 1)) : :(@ncall $N Base.arrayset A convert($T,v) d->getfield(index,d))
+end
+
 stagedfunction getindex{N}(A::AbstractArray, index::CartesianIndex{N})
     :(@nref $N A d->getfield(index,d))
 end


### PR DESCRIPTION
This circumvents calling `getindex` and `setindex!`, which become slow for `N>6,7`, when indexing `Array`s with a `CartesianIndex`.
