### PR TITLE
add @inline so that rand(Bool) is inlined

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -226,7 +226,7 @@ rand(r::Union(RandomDevice,MersenneTwister), ::Type{Float32}) =
 
 # MersenneTwister
 
-rand{T<:Union(Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32)}(r::MersenneTwister, ::Type{T}) = rand_ui52_raw(r) % T
+@inline rand{T<:Union(Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32)}(r::MersenneTwister, ::Type{T}) = rand_ui52_raw(r) % T
 
 function rand(r::MersenneTwister, ::Type{UInt64})
     reserve(r, 2)


### PR DESCRIPTION
`rand(Bool)` in v0.4 about 2x slower than randbool() in v0.3 when called repeatedly in a loop.

After adding this `@inline` macro call, I can no longer detect a significant difference in speed between
randbool() in v0.3 and rand(Bool) in v0.4.
