### PR TITLE
do not set CPU affinity on Linux (see #3097)

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -370,6 +370,9 @@ end
 
 function early_init()
     global const JULIA_HOME = ccall(:jl_get_julia_home, Any, ())
+    # make sure OpenBLAS does not set CPU affinity (#1070, #9639)
+    ENV["OPENBLAS_MAIN_FREE"] = get(ENV, "OPENBLAS_MAIN_FREE",
+                                    get(ENV, "GOTOBLAS_MAIN_FREE", "1"))
     Sys.init_sysinfo()
     if CPU_CORES > 8 && !("OPENBLAS_NUM_THREADS" in keys(ENV)) && !("OMP_NUM_THREADS" in keys(ENV))
         # Prevent openblas from stating to many threads, unless/until specifically requested

--- a/src/init.c
+++ b/src/init.c
@@ -77,10 +77,6 @@ void __cdecl fpreset (void);
 extern int needsSymRefreshModuleList;
 extern BOOL (WINAPI *hSymRefreshModuleList)(HANDLE);
 #endif
-#if defined(__linux__)
-//#define _GNU_SOURCE
-#include <sched.h>   // for setting CPU affinity
-#endif
 
 DLLEXPORT void jlbacktrace();
 DLLEXPORT void gdbbacktrace();
@@ -971,18 +967,6 @@ void _julia_init(JL_IMAGE_SEARCH rel)
         if (SIGSTKSZ < 1<<16)
             sig_stack_size = 1<<16;
 #endif
-    }
-#endif
-
-#if defined(__linux__)
-    int ncores = jl_cpu_cores();
-    if (ncores > 1) {
-        cpu_set_t cpumask;
-        CPU_ZERO(&cpumask);
-        for(int i=0; i < ncores; i++) {
-            CPU_SET(i, &cpumask);
-        }
-        sched_setaffinity(0, sizeof(cpu_set_t), &cpumask);
     }
 #endif
 


### PR DESCRIPTION
See the discussion in #3097 and [#1802](https://github.com/JuliaLang/julia/issues/1802#issuecomment-17175787) as well as [this mailing-list thread](https://groups.google.com/d/msg/julia-users/LymjKbmkCeA/Drji4QaHhQ0J).  Julia should not touch the CPU affinity by default; not only is this a hack that degrades overall system usability to inflate benchmark numbers, but it also prevents people from using `taskset` manually.
