### PR TITLE
RFC: store system image as part of object file

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -371,9 +371,6 @@ endif #USEMSVC
 RANLIB := $(CROSS_COMPILE)ranlib
 
 
-# if not absolute, then relative to the directory of the julia executable
-JCPPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.ji\""
-
 # On Windows, we want shared library files to end up in $(build_bindir), instead of $(build_libdir)
 ifeq ($(OS),WINNT)
 build_shlibdir = $(build_bindir)
@@ -784,6 +781,11 @@ CLDFLAGS += -static-intel
 LDFLAGS += -cxxlib-nostd -static-intel
 endif
 endif
+
+# default system image path
+
+# if not absolute, then relative to the directory of the julia executable
+JCPPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.$(SHLIB_EXT)\""
 
 # Make tricks
 

--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,6 @@ ifeq ($(OS), WINNT)
 $(build_sysconfdir)/julia/juliarc.jl: contrib/windows/juliarc.jl
 endif
 
-# use sys.ji if it exists, otherwise run two stages
-$(build_private_libdir)/sys%ji: $(build_private_libdir)/sys%o
-
 .SECONDARY: $(build_private_libdir)/sys.o
 .SECONDARY: $(build_private_libdir)/sys0.o
 
@@ -148,7 +145,7 @@ BASE_SRCS := $(wildcard base/*.jl base/*/*.jl base/*/*/*.jl)
 $(build_private_libdir)/sys.o: VERSION $(BASE_SRCS) $(build_docdir)/helpdb.jl $(build_private_libdir)/sys0.$(SHLIB_EXT)
 	@$(call PRINT_JULIA, cd base && \
 	$(call spawn,$(JULIA_EXECUTABLE)) -C $(JULIA_CPU_TARGET) --build $(call cygpath_w,$(build_private_libdir)/sys) \
-		-J$(call cygpath_w,$(build_private_libdir))/$$([ -e $(build_private_libdir)/sys.ji ] && echo sys.ji || echo sys0.ji) -f sysimg.jl \
+		-J$(call cygpath_w,$(build_private_libdir))/$$([ -e $(build_private_libdir)/sys.$(SHLIB_EXT) ] && echo sys.$(SHLIB_EXT) || echo sys0.$(SHLIB_EXT)) -f sysimg.jl \
 		|| { echo '*** This error is usually fixed by running `make clean`. If the error persists$(,) try `make cleanall`. ***' && false; } )
 
 $(build_bindir)/stringreplace: contrib/stringreplace.c | $(build_bindir)
@@ -269,7 +266,6 @@ endif
 endif
 	$(INSTALL_F) src/julia.h src/julia_version.h src/options.h src/support/*.h $(DESTDIR)$(includedir)/julia
 	# Copy system image
-	$(INSTALL_F) $(build_private_libdir)/sys.ji $(DESTDIR)$(private_libdir)
 	$(INSTALL_M) $(build_private_libdir)/sys.$(SHLIB_EXT) $(DESTDIR)$(private_libdir)
 	# Copy in system image build script
 	$(INSTALL_M) contrib/build_sysimg.jl $(DESTDIR)$(datarootdir)/julia/
@@ -310,7 +306,7 @@ endif
 
 	# Overwrite JL_SYSTEM_IMAGE_PATH in julia library
 	for julia in $(DESTDIR)$(private_libdir)/libjulia*.$(SHLIB_EXT) ; do \
-		$(call spawn,$(build_bindir)/stringreplace $$(strings -t x - $$julia | grep "sys.ji$$" | awk '{print $$1;}' ) "$(private_libdir_rel)/sys.ji" 256 $(call cygpath_w,$$julia)); \
+		$(call spawn,$(build_bindir)/stringreplace $$(strings -t x - $$julia | grep "sys.$(SHLIB_EXT)$$" | awk '{print $$1;}' ) "$(private_libdir_rel)/sys.$(SHLIB_EXT)" 256 $(call cygpath_w,$$julia)); \
 	done
 endif
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -320,6 +320,16 @@ static void jl_gen_llvm_gv_array(llvm::Module *mod, SmallVector<GlobalVariable*,
     }
 }
 
+static void jl_sysimg_to_llvm(llvm::Module *mod, const char *sysimg_data, size_t sysimg_len)
+{
+    Constant *data = ConstantDataArray::get(jl_LLVMContext, ArrayRef<uint8_t>((const unsigned char*)sysimg_data, sysimg_len));
+    addComdat(new GlobalVariable(*mod, data->getType(), true, GlobalVariable::ExternalLinkage,
+                                 data, "jl_system_image_data"));
+    Constant *len = ConstantInt::get(T_size, sysimg_len);
+    addComdat(new GlobalVariable(*mod, len->getType(), true, GlobalVariable::ExternalLinkage,
+                                 len, "jl_system_image_size"));
+}
+
 static int32_t jl_assign_functionID(Function *functionObject)
 {
     // give the function an index in the constant lookup table

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -347,6 +347,7 @@ struct jl_varinfo_t {
 
 // --- helpers for reloading IR image
 static void jl_gen_llvm_gv_array(llvm::Module *mod, SmallVector<GlobalVariable*, 8> &globalvars);
+static void jl_sysimg_to_llvm(llvm::Module *mod, const char *sysimg_data, size_t sysimg_len);
 
 extern "C"
 void jl_dump_bitcode(char *fname)
@@ -376,7 +377,7 @@ void jl_dump_bitcode(char *fname)
 }
 
 extern "C"
-void jl_dump_objfile(char *fname, int jit_model)
+void jl_dump_objfile(char *fname, int jit_model, const char *sysimg_data, size_t sysimg_len)
 {
 #ifdef LLVM36
     std::error_code err;
@@ -432,9 +433,11 @@ void jl_dump_objfile(char *fname, int jit_model)
 
     SmallVector<GlobalVariable*, 8> globalvars;
 #ifdef USE_MCJIT
+    jl_sysimg_to_llvm(shadow_module, sysimg_data, sysimg_len);
     jl_gen_llvm_gv_array(shadow_module, globalvars);
     PM.run(*shadow_module);
 #else
+    jl_sysimg_to_llvm(jl_Module, sysimg_data, sysimg_len);
     jl_gen_llvm_gv_array(jl_Module, globalvars);
     PM.run(*jl_Module);
 #endif

--- a/src/julia.h
+++ b/src/julia.h
@@ -875,8 +875,9 @@ DLLEXPORT void jl_atexit_hook(void);
 DLLEXPORT void NORETURN jl_exit(int status);
 
 DLLEXPORT const char * jl_get_system_image_cpu_target(const char *fname);
-DLLEXPORT void jl_save_system_image(const char *fname);
-DLLEXPORT void jl_restore_system_image(const char *fname);
+DLLEXPORT void *jl_create_system_image();
+DLLEXPORT void jl_restore_system_image(const char *buf, size_t len);
+DLLEXPORT void jl_load_sysimg_so(const char *fname);
 DLLEXPORT int jl_save_new_module(const char *fname, jl_module_t *mod);
 DLLEXPORT jl_module_t *jl_restore_new_module(const char *fname);
 void jl_init_restored_modules();

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -95,7 +95,7 @@ extern void *jl_stackbase;
 #endif
 
 void jl_dump_bitcode(char *fname);
-void jl_dump_objfile(char *fname, int jit_model);
+void jl_dump_objfile(char *fname, int jit_model, const char *sysimg_data, size_t sysimg_len);
 int32_t jl_get_llvm_gv(jl_value_t *p);
 
 #ifdef _OS_LINUX_


### PR DESCRIPTION
This eliminates *.ji and makes the system image just a shared library. This has been discussed a bit; time to do it.

The makefile part probably needs review.

We also might want to add a command line option like `--code-cache=no` that does what deleting `sys.dll` used to do, i.e. make it not use the cached code.
