### PR TITLE
inline invoke

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2284,12 +2284,13 @@ function inlineable_invoke(f::Function, e::Expr, atypes, sv,
         return NF
     end
 
+    fexpr = argexprs[1]
     stmts = Any[argexprs[2]]
     argexprs = argexprs[3:end]
     atypes = atypes[3:end]
 
     if isleaftype(invoke_types) && invoke_types == atypes
-        new_e = Expr(:call, f, argexprs...)
+        new_e = Expr(:call, fexpr, argexprs...)
         new_e.typ = e.typ
         res = inlineable_gf(f, new_e, invoke_types, sv,
                             enclosing_ast, argexprs)
@@ -2343,7 +2344,7 @@ function inlineable_invoke(f::Function, e::Expr, atypes, sv,
     atypes = tuple(atypes_l...)
 
     match_meth = _match_method(meth, atypes)
-    new_e = Expr(:call, f, argexprs...)
+    new_e = Expr(:call, fexpr, argexprs...)
     new_e.typ = e.typ
     if length(match_meth) == 1
         match_meth = match_meth[1]::Tuple

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2315,7 +2315,7 @@ function inlineable_invoke(f::Function, e::Expr, atypes, sv,
         push!(stmts, tmp_ex)
         if !issubtype(atypes_l[i], invoke_types[i])
             atypes_l[i] = typeintersect(atypes_l[i], invoke_types[i])
-            check_type = :($isa($arg_name, $(invoke_types[i])))
+            check_type = :($(TopNode(:isa))($arg_name, $(invoke_types[i])))
             check_type.typ = Bool
             push!(check_stmts, Expr(:gotoifnot, check_type, err_label.label))
         end
@@ -2325,7 +2325,7 @@ function inlineable_invoke(f::Function, e::Expr, atypes, sv,
         append!(stmts, check_stmts)
         push!(stmts, gn(after_err_label))
         push!(stmts, err_label)
-        check_error = :($error("invoke: argument type error"))
+        check_error = :($(TopNode(:error))("invoke: argument type error"))
         check_error.typ = None
         push!(stmts, check_error)
         push!(stmts, after_err_label)

--- a/src/ast.c
+++ b/src/ast.c
@@ -910,7 +910,7 @@ static void eval_decl_types(jl_array_t *vi, jl_value_t *ast, jl_tuple_t *spenv)
         assert(jl_array_len(v) > 1);
         jl_value_t *ty = jl_static_eval(jl_cellref(v,1), NULL, jl_current_module,
                                         (jl_value_t*)spenv, (jl_expr_t*)ast, 1, 1);
-        if (ty != NULL && (jl_is_type(ty) || jl_is_typevar(ty))) {
+        if (ty != NULL && jl_is_type(ty)) {
             jl_cellset(v, 1, ty);
         }
         else {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -956,7 +956,7 @@ JL_CALLABLE(jl_f_union)
     size_t i;
     jl_tuple_t *argt = jl_alloc_tuple_uninit(nargs);
     for(i=0; i < nargs; i++) {
-        if (!jl_is_type(args[i]) && !jl_is_typevar(args[i])) {
+        if (!jl_is_type(args[i])) {
             jl_error("invalid union type");
         }
         else {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1108,7 +1108,7 @@ static jl_value_t *expr_type(jl_value_t *e, jl_codectx_t *ctx)
             return (jl_value_t*)jl_any_type;
     }
 type_of_constant:
-    if (jl_is_datatype(e) || jl_is_uniontype(e) || jl_is_typector(e))
+    if (jl_is_type(e))
         return (jl_value_t*)jl_wrap_Type(e);
     return (jl_value_t*)jl_typeof(e);
 }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1108,8 +1108,9 @@ static jl_value_t *expr_type(jl_value_t *e, jl_codectx_t *ctx)
             return (jl_value_t*)jl_any_type;
     }
 type_of_constant:
-    if (jl_is_type(e))
+    if (jl_is_datatype(e) || jl_is_uniontype(e) || jl_is_typector(e)) {
         return (jl_value_t*)jl_wrap_Type(e);
+    }
     return (jl_value_t*)jl_typeof(e);
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2563,12 +2563,10 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
             return NULL;
         }
         assert(mfunc->linfo->functionObject != NULL);
+        jl_cstyle_compile(mfunc);
         emit_expr(args[2], ctx);
         Value *_theF = literal_pointer_val((jl_value_t*)mfunc);
         Value *_theFptr = (Value*)mfunc->linfo->functionObject;
-        if (mfunc->linfo->cFunctionObject == NULL) {
-            jl_cstyle_compile(mfunc);
-        }
         Value *result = emit_call_function_object(mfunc, _theF, _theFptr, true,
                                                   args + 2, nargs - 2, ctx);
         return result;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1768,7 +1768,7 @@ jl_gf_invoke_get_specialization(jl_function_t *gf, jl_tuple_t *types,
         m->invokes = new_method_table(mt->name);
         // this private method table has just this one definition
         jl_method_list_insert(&m->invokes->defs, m->sig, m->func,
-                              m->tvars, 0, 0);
+                              m->tvars, 0, 0, (jl_value_t*)m->invokes);
     }
     newsig = (jl_tuple_t*)m->sig;
 
@@ -1781,7 +1781,7 @@ jl_gf_invoke_get_specialization(jl_function_t *gf, jl_tuple_t *types,
         for (size_t i = 0;i < jl_tuple_len(tt);i++) {
             if (jl_is_tuple(jl_tupleref(tt, i))) {
                 newsig = (jl_tuple_t*)jl_instantiate_type_with(
-                    (jl_value_t*)m->sig, &jl_tupleref(tpenv, 0),
+                    (jl_value_t*)m->sig, jl_tuple_data(tpenv),
                     jl_tuple_len(tpenv) / 2);
                 break;
             }

--- a/src/gf.c
+++ b/src/gf.c
@@ -123,7 +123,7 @@ static inline int cache_match(jl_value_t **args, size_t n, jl_tuple_t *sig,
         }
         else if (jl_is_type_type(decl) &&
                  (jl_is_nontuple_type(a) ||
-                  (jl_is_tuple(a)&&jl_is_type(a)))) {
+                  (jl_is_tuple(a) && jl_is_type(a)))) {
             jl_value_t *tp0 = jl_tparam0(decl);
             if (tp0 == (jl_value_t*)jl_typetype_tvar) {
                 // in the case of Type{T}, the types don't have

--- a/src/gf.c
+++ b/src/gf.c
@@ -1791,6 +1791,7 @@ jl_gf_invoke_get_specialization(jl_function_t *gf, jl_tuple_t *types,
     }
     mfunc = cache_method(m->invokes, tt, m->func, newsig, tpenv);
     JL_GC_POP();
+    jl_compile(mfunc);
     return mfunc;
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -1733,6 +1733,67 @@ DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_function_t *gf, jl_tuple_t *types)
     return (jl_value_t*)m;
 }
 
+jl_function_t*
+jl_gf_invoke_get_specialization(jl_function_t *gf, jl_tuple_t *types,
+                                jl_tuple_t *tt)
+{
+    assert(jl_is_gf(gf));
+    jl_methtable_t *mt = jl_gf_mtable(gf);
+    jl_methlist_t *m = (jl_methlist_t*)jl_gf_invoke_lookup(gf, types);
+
+    if ((jl_value_t*)m == jl_nothing) {
+        return NULL;
+    }
+
+    // now we have found the matching definition.
+    // next look for or create a specialization of this definition.
+
+    jl_function_t *mfunc;
+    if (m->invokes == JL_NULL) {
+        mfunc = jl_bottom_func;
+    } else {
+        mfunc = jl_method_table_assoc_exact_by_type(m->invokes, tt);
+    }
+    if (mfunc != jl_bottom_func) {
+        return mfunc;
+    }
+
+    jl_tuple_t *tpenv = jl_null;
+    jl_tuple_t *newsig = NULL;
+    JL_GC_PUSH2(&tpenv, &newsig);
+
+    if (m->invokes == JL_NULL) {
+        m->invokes = new_method_table(mt->name);
+        // this private method table has just this one definition
+        jl_method_list_insert(&m->invokes->defs, m->sig, m->func,
+                              m->tvars, 0, 0);
+    }
+    newsig = (jl_tuple_t*)m->sig;
+
+    if (m->tvars != jl_null) {
+        jl_value_t *ti =
+            lookup_match((jl_value_t*)tt, (jl_value_t*)m->sig, &tpenv, m->tvars);
+        assert(ti != (jl_value_t*)jl_bottom_type);
+        (void)ti;
+        // don't bother computing this if no arguments are tuples
+        size_t i;
+        for (i = 0;i < jl_tuple_len(tt);i++) {
+            if (jl_is_tuple(jl_tupleref(tt,i))) {
+                break;
+            }
+        }
+        if (i < jl_tuple_len(tt)) {
+            newsig =
+                (jl_tuple_t*)jl_instantiate_type_with((jl_value_t*)m->sig,
+                                                      &jl_tupleref(tpenv, 0),
+                                                      jl_tuple_len(tpenv) / 2);
+        }
+    }
+    mfunc = cache_method(m->invokes, tt, m->func, newsig, tpenv);
+    JL_GC_POP();
+    return mfunc;
+}
+
 // invoke()
 // this does method dispatch with a set of types to match other than the
 // types of the actual arguments. this means it sometimes does NOT call the

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1656,7 +1656,7 @@ static int valid_type_param(jl_value_t *v)
     }
     else {
         // TODO: maybe more things
-        return jl_is_type(v) || jl_is_typevar(v) || jl_is_symbol(v) || jl_isbits(jl_typeof(v));
+        return jl_is_type(v) || jl_is_symbol(v) || jl_isbits(jl_typeof(v));
     }
 }
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1013,6 +1013,7 @@ void jl_type_infer(jl_lambda_info_t *li, jl_tuple_t *argtypes,
 jl_function_t *jl_method_lookup_by_type(jl_methtable_t *mt, jl_tuple_t *types,
                                         int cache, int inexact);
 jl_function_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t nargs, int cache);
+jl_value_t *jl_gf_invoke_lookup(jl_function_t *gf, jl_tuple_t *types);
 jl_value_t *jl_gf_invoke(jl_function_t *gf, jl_tuple_t *types,
                          jl_value_t **args, size_t nargs);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -116,6 +116,9 @@ DLLEXPORT void jl_read_sonames(void);
 jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_tuple_t *sp);
 jl_function_t *jl_get_specialization(jl_function_t *f, jl_tuple_t *types);
 jl_function_t *jl_module_get_initializer(jl_module_t *m);
+jl_function_t *jl_gf_invoke_get_specialization(jl_function_t *gf,
+                                               jl_tuple_t *types,
+                                               jl_tuple_t *tt);
 void jl_generate_fptr(jl_function_t *f);
 void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig);
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -604,8 +604,8 @@ void jl_reinstantiate_inner_types(jl_datatype_t *t);
 void jl_check_type_tuple(jl_tuple_t *t, jl_sym_t *name, const char *ctx)
 {
     for(size_t i=0; i < jl_tuple_len(t); i++) {
-        jl_value_t *elt = jl_tupleref(t,i);
-        if (!jl_is_type(elt) && !jl_is_typevar(elt)) {
+        jl_value_t *elt = jl_tupleref(t, i);
+        if (!jl_is_type(elt)) {
             jl_type_error_rt(name->name, ctx, (jl_value_t*)jl_type_type, elt);
         }
     }
@@ -727,7 +727,7 @@ DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_value_t 
     size_t na = jl_tuple_len(argtypes);
     for(size_t i=0; i < na; i++) {
         jl_value_t *elt = jl_tupleref(argtypes,i);
-        if (!jl_is_type(elt) && !jl_is_typevar(elt)) {
+        if (!jl_is_type(elt)) {
             jl_lambda_info_t *li = f->linfo;
             jl_exceptionf(jl_argumenterror_type, "invalid type for argument %s in method definition for %s at %s:%d",
                           jl_lam_argname(li,i)->name, name->name, li->file->name, li->line);

--- a/test/core.jl
+++ b/test/core.jl
@@ -2189,8 +2189,8 @@ let
     end
 
     function g9642()
-        invoke(f, (get_type_9642(Any), get_type_9642(Any)),
+        invoke(f9642, (get_type_9642(Any), get_type_9642(Any)),
                get_next_9642(), get_next_9642())
     end
-    @test g_type() == 7
+    @test g9642() == 7
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -2175,3 +2175,22 @@ immutable B9378{T} end
 typealias FooB9378{T} Foo9378{T,B9378}
 immutable CFoo9378 <: FooB9378{Float64} end
 @test isa(CFoo9378(),FooB9378)
+
+# pull request #9642
+let
+    f9642(a, b) = a + b
+    counter = 0
+    @noinline function get_next_9642()
+        return (counter = counter + 1)
+    end
+    @noinline function get_type_9642(t)
+        get_next_9642()
+        return t
+    end
+
+    function g9642()
+        invoke(f, (get_type_9642(Any), get_type_9642(Any)),
+               get_next_9642(), get_next_9642())
+    end
+    @test g_type() == 7
+end


### PR DESCRIPTION
This is my attempt to improve issue #9608. I'm pretty sure there is sth I'm still missing though....

Benchmark with the following script

``` julia
#!/usr/bin/julia

function f(a::Any, b::Any)
    global c = a + b * 2
end

function f(a::Integer, b::Integer)
    global c = a + b * 3
end

function f(a::Int, b::Int)
    global c = a + b * 4
end

macro timing(ex)
    quote
        println($(Expr(:quote, ex)))
        gc()
        @time for i in 1:10000000
            $(esc(ex))
        end
    end
end

function call_any()
    f(1.2, 3.4)
end

function call_integer()
    f(Int32(1), Int32(2))
end

function call_int()
    f(1, 2)
end

const f_any = (@which f(1.2, 3.4)).func
const f_integer = (@which f(Int32(1), Int32(2))).func
const f_int = (@which f(1, 2)).func

function meth_any()
    f_any(1.2, 3.4)
end

function meth_integer()
    f_integer(Int32(1), Int32(2))
end

function meth_int()
    f_int(1, 2)
end

function invoke_any()
    invoke(f, (Float64, Float64), 1.2, 3.4)
end

function invoke_integer()
    invoke(f, (Int32, Int32), Int32(1), Int32(2))
end

function invoke_int()
    invoke(f, (Int, Int), 1, 2)
end

function invoke_any_int()
    invoke(f, (Any, Any), 1, 2)
end

function invoke_integer_int()
    invoke(f, (Integer, Integer), 1, 2)
end

@timing call_any()
@timing call_integer()
@timing call_int()
println()
@timing meth_any()
@timing meth_integer()
@timing meth_int()
println()
@timing invoke_any()
@timing invoke_integer()
@timing invoke_int()
println()
@timing invoke_any_int()
@timing invoke_integer_int()
println()
```

Before,

```
call_any()
elapsed time: 0.150808637 seconds (160000000 bytes allocated, 37.06% gc time)
call_integer()
elapsed time: 0.041882309 seconds (0 bytes allocated)
call_int()
elapsed time: 0.041811296 seconds (0 bytes allocated)

meth_any()
elapsed time: 0.679259604 seconds (320001472 bytes allocated, 16.23% gc time)
meth_integer()
elapsed time: 0.4619528 seconds (5424 bytes allocated)
meth_int()
elapsed time: 0.452719865 seconds (1472 bytes allocated)

invoke_any()
elapsed time: 2.057187642 seconds (320002880 bytes allocated, 5.51% gc time)
invoke_integer()
elapsed time: 1.650398796 seconds (3136 bytes allocated)
invoke_int()
elapsed time: 1.255498639 seconds (2624 bytes allocated)

invoke_any_int()
elapsed time: 1.695137055 seconds (2112 bytes allocated)
invoke_integer_int()
elapsed time: 1.562752127 seconds (2112 bytes allocated)
```

After

```
call_any()
elapsed time: 0.140487996 seconds (160000000 bytes allocated, 35.90% gc time)
call_integer()
elapsed time: 0.04067296 seconds (0 bytes allocated)
call_int()
elapsed time: 0.041081744 seconds (0 bytes allocated)

meth_any()
elapsed time: 0.636057861 seconds (320001472 bytes allocated, 16.59% gc time)
meth_integer()
elapsed time: 0.364873117 seconds (5424 bytes allocated)
meth_int()
elapsed time: 0.389887527 seconds (1472 bytes allocated)

invoke_any()
elapsed time: 0.139580889 seconds (160000000 bytes allocated, 39.45% gc time)
invoke_integer()
elapsed time: 0.040794216 seconds (0 bytes allocated)
invoke_int()
elapsed time: 0.041527671 seconds (0 bytes allocated)

invoke_any_int()
elapsed time: 0.062740047 seconds (0 bytes allocated)
invoke_integer_int()
elapsed time: 0.063173429 seconds (0 bytes allocated)
```
