### PR TITLE
Fix mod1

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -131,7 +131,7 @@ const % = rem
 const ÷ = div
 
 # mod returns in [0,y) whereas mod1 returns in (0,y]
-mod1{T<:Real}(x::T, y::T) = y-mod(y-x,y)
+mod1{T<:Real}(x::T, y::T) = (m=mod(x,y); ifelse(m==0, y, m))
 rem1{T<:Real}(x::T, y::T) = rem(x-1,y)+1
 fld1{T<:Real}(x::T, y::T) = fld(x-1,y)+1
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2122,3 +2122,7 @@ end
 
 # test second branch, after all small primes in list have been searched
 @test factor(10009 * int128(1000000000000037)) == Dict(10009=>1,1000000000000037=>1)
+
+#Issue #5570
+@test map(x -> int(mod1(uint(x),uint(5))), 0:15) == [5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
+


### PR DESCRIPTION
Restore old implementation of mod1 that was overwritten in 384242204aa33888610a70a5e3749db8d738e4a6

Adds test of mod1 behavior from #5570

Note: #5570 is not fixed for fld1, rem1. The documentation bug of #8108 is not fixed.

cc: @GunnarFarneback @StefanKarpinski @mschauer
