### PR TITLE
Throw more specific exception `ArgumentError` for builtin functions

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -50,6 +50,7 @@ jl_datatype_t *jl_method_type;
 jl_datatype_t *jl_lambda_info_type;
 jl_datatype_t *jl_module_type;
 jl_datatype_t *jl_errorexception_type=NULL;
+jl_datatype_t *jl_argumenterror_type;
 jl_datatype_t *jl_typeerror_type;
 jl_datatype_t *jl_methoderror_type;
 jl_datatype_t *jl_loaderror_type;
@@ -488,7 +489,7 @@ static jl_sym_t *mk_symbol(const char *str)
     size_t nb = (sizeof(jl_sym_t)+len+1+7)&-8;
 
     if (nb >= SYM_POOL_SIZE) {
-        jl_error("Symbol length exceeds maximum length");
+        jl_exceptionf(jl_argumenterror_type, "Symbol length exceeds maximum length");
     }
 
 #ifdef MEMDEBUG
@@ -561,7 +562,7 @@ DLLEXPORT jl_sym_t *jl_symbol_n(const char *str, int32_t len)
     memcpy(name, str, len);
     name[len] = '\0';
     if (strlen(name) != len)
-        jl_error("Symbol name may not contain \\0");
+        jl_exceptionf(jl_argumenterror_type, "Symbol name may not contain \\0");
     return jl_symbol(name);
 }
 
@@ -591,7 +592,7 @@ DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len)
     n = uint2str(gs_name, sizeof(gs_name), gs_ctr, 10);
     memcpy(name+3+len, n, sizeof(gs_name)-(n-gs_name));
     if (strlen(name) != len+3+sizeof(gs_name)-(n-gs_name)-1)
-        jl_error("Symbol name may not contain \\0");
+        jl_exceptionf(jl_argumenterror_type, "Symbol name may not contain \\0");
     gs_ctr++;
     return jl_symbol(name);
 }

--- a/src/init.c
+++ b/src/init.c
@@ -1288,6 +1288,7 @@ DLLEXPORT void jl_get_system_hooks(void)
     if (jl_errorexception_type) return; // only do this once
 
     jl_errorexception_type = (jl_datatype_t*)basemod("ErrorException");
+    jl_argumenterror_type = (jl_datatype_t*)basemod("ArgumentError");
     jl_typeerror_type = (jl_datatype_t*)basemod("TypeError");
     jl_methoderror_type = (jl_datatype_t*)basemod("MethodError");
     jl_loaderror_type = (jl_datatype_t*)basemod("LoadError");

--- a/src/julia.h
+++ b/src/julia.h
@@ -328,6 +328,7 @@ extern DLLEXPORT jl_datatype_t *jl_weakref_type;
 extern DLLEXPORT jl_datatype_t *jl_ascii_string_type;
 extern DLLEXPORT jl_datatype_t *jl_utf8_string_type;
 extern DLLEXPORT jl_datatype_t *jl_errorexception_type;
+extern DLLEXPORT jl_datatype_t *jl_argumenterror_type;
 extern DLLEXPORT jl_datatype_t *jl_loaderror_type;
 extern DLLEXPORT jl_datatype_t *jl_typeerror_type;
 extern DLLEXPORT jl_datatype_t *jl_methoderror_type;
@@ -827,6 +828,7 @@ DLLEXPORT jl_value_t *jl_environ(int i);
 // throwing common exceptions
 DLLEXPORT void NORETURN jl_error(const char *str);
 DLLEXPORT void NORETURN jl_errorf(const char *fmt, ...);
+DLLEXPORT void NORETURN jl_exceptionf(jl_datatype_t *ty, const char *fmt, ...);
 DLLEXPORT void NORETURN jl_too_few_args(const char *fname, int min);
 DLLEXPORT void NORETURN jl_too_many_args(const char *fname, int max);
 DLLEXPORT void NORETURN jl_type_error(const char *fname, jl_value_t *expected, jl_value_t *got);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -118,6 +118,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
         // reinitialize global variables
         // to pick up new types from Base
         jl_errorexception_type = NULL;
+        jl_argumenterror_type = NULL;
         jl_typeerror_type = NULL;
         jl_methoderror_type = NULL;
         jl_loaderror_type = NULL;
@@ -722,8 +723,8 @@ DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_binding_
         jl_value_t *elt = jl_tupleref(argtypes,i);
         if (!jl_is_type(elt) && !jl_is_typevar(elt)) {
             jl_lambda_info_t *li = f->linfo;
-            jl_errorf("invalid type for argument %s in method definition for %s at %s:%d",
-                      jl_lam_argname(li,i)->name, name->name, li->file->name, li->line);
+            jl_exceptionf(jl_argumenterror_type, "invalid type for argument %s in method definition for %s at %s:%d",
+                          jl_lam_argname(li,i)->name, name->name, li->file->name, li->line);
         }
     }
 

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1020,8 +1020,8 @@ end
 @test gensym("asdf") != gensym("asdf")
 @test gensym() != gensym()
 @test startswith(string(gensym()),"##")
-@test_throws ErrorException symbol("ab\0")
-@test_throws ErrorException gensym("ab\0")
+@test_throws ArgumentError symbol("ab\0")
+@test_throws ArgumentError gensym("ab\0")
 
 # issue #6949
 let f =IOBuffer(),


### PR DESCRIPTION
This throws an `ArgumentError` when passing too few or too many arguments to methods defined in the `Core` module.   Right now, an `ErrorException` is thrown.
