### PR TITLE
get pairwise-sum accuracy for cumsum (fix #9648)

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1441,9 +1441,9 @@ _cumsum_type(v) = typeof(v[1]+v[1])
 
 for (f, fp, op) = ((:cumsum, :cumsum_pairwise!, :+),
                    (:cumprod, :cumprod_pairwise!, :*) )
-    # in-place cumsum of c = s+v(i1:n), using pairwise summation as for sum
+    # in-place cumsum of c = s+v[range(i1,n)], using pairwise summation
     @eval function ($fp){T}(v::AbstractVector, c::AbstractVector{T}, s, i1, n)
-        local s_::T # for sum(v(i1:n)), i.e. sum without s
+        local s_::T # for sum(v[range(i1,n)]), i.e. sum without s
         if n < 128
             @inbounds s_ = v[i1]
             @inbounds c[i1] = ($op)(s, s_)
@@ -1452,7 +1452,7 @@ for (f, fp, op) = ((:cumsum, :cumsum_pairwise!, :+),
                 @inbounds c[i] = $(op)(s, s_)
             end
         else
-            n2 = div(n,2)
+            n2 = n >> 1
             s_ = ($fp)(v, c, s, i1, n2)
             s_ = $(op)(s_, ($fp)(v, c, s + s_, i1+n2, n-n2))
         end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -974,3 +974,8 @@ a = [ [ 1 0 0 ], [ 0 0 0 ] ]
 @test rotl90(a,4) == a
 @test rotr90(a,4) == a
 @test rot180(a,2) == a
+
+# issue #9648
+let x = fill(1.5f0, 10^7)
+    @test abs(1.5f7 - cumsum(x)[end]) < 3*eps(1.5f7)
+end


### PR DESCRIPTION
This fixes #9648 (our `cumsum` function had naive-summation accuracy despite using a pairwise-like algorithm).  No performance impact as far as I can tell (difference from old `Base.cumsum_pairwise` is negligible).
