### PR TITLE
RFC: enabled `selctg` to reorder eigen values from within gees/gges

### DIFF
--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -685,9 +685,23 @@ immutable Schur{Ty<:BlasFloat, S<:AbstractMatrix} <: Factorization{Ty}
 end
 Schur{Ty}(T::AbstractMatrix{Ty}, Z::AbstractMatrix{Ty}, values::Vector) = Schur{Ty, typeof(T)}(T, Z, values)
 
-schurfact!{T<:BlasFloat}(A::StridedMatrix{T}) = Schur(LinAlg.LAPACK.gees!('V', A)...)
-schurfact{T<:BlasFloat}(A::StridedMatrix{T}) = schurfact!(copy(A))
-schurfact{T}(A::StridedMatrix{T}) = (S = promote_type(Float32,typeof(one(T)/norm(one(T)))); S != T ? schurfact!(convert(AbstractMatrix{S},A)) : schurfact!(copy(A)))
+function schurfact!{T<:BlasFloat}(A::StridedMatrix{T},
+                                  selctg::Union(Function, Ptr{Void})=C_NULL)
+    Schur(LinAlg.LAPACK.gees!('V', A, selctg)...)
+end
+function schurfact{T<:BlasFloat}(A::StridedMatrix{T},
+                                 selctg::Union(Function, Ptr{Void})=C_NULL)
+    schurfact!(copy(A), selctg)
+end
+function schurfact{T}(A::StridedMatrix{T},
+                      selctg::Union(Function, Ptr{Void})=C_NULL)
+    S = promote_type(Float32,typeof(one(T)/norm(one(T))))
+    if S != T
+        schurfact!(convert(AbstractMatrix{S},A), selctg)
+    else
+        schurfact!(copy(A), selctg)
+    end
+end
 
 function getindex(F::Schur, d::Symbol)
     (d == :T || d == :Schur) && return F.T
@@ -696,15 +710,17 @@ function getindex(F::Schur, d::Symbol)
     throw(KeyError(d))
 end
 
-function schur(A::AbstractMatrix)
-    SchurF = schurfact(A)
+function schur(A::AbstractMatrix, selctg::Union(Function, Ptr{Void})=C_NULL)
+    SchurF = schurfact(A, selctg)
     SchurF[:T], SchurF[:Z], SchurF[:values]
 end
 
+# For ordering after computing the decomposition
 ordschur!{Ty<:BlasFloat}(Q::StridedMatrix{Ty}, T::StridedMatrix{Ty}, select::Array{Int}) = Schur(LinAlg.LAPACK.trsen!(select, T , Q)...)
 ordschur{Ty<:BlasFloat}(Q::StridedMatrix{Ty}, T::StridedMatrix{Ty}, select::Array{Int}) = ordschur!(copy(Q), copy(T), select)
 ordschur!{Ty<:BlasFloat}(schur::Schur{Ty}, select::Array{Int}) = (res=ordschur!(schur.Z, schur.T, select); schur[:values][:]=res[:values]; res)
 ordschur{Ty<:BlasFloat}(schur::Schur{Ty}, select::Array{Int}) = ordschur(schur.Z, schur.T, select)
+
 
 immutable GeneralizedSchur{Ty<:BlasFloat, M<:AbstractMatrix} <: Factorization{Ty}
     S::M
@@ -717,9 +733,23 @@ immutable GeneralizedSchur{Ty<:BlasFloat, M<:AbstractMatrix} <: Factorization{Ty
 end
 GeneralizedSchur{Ty}(S::AbstractMatrix{Ty}, T::AbstractMatrix{Ty}, alpha::Vector, beta::Vector{Ty}, Q::AbstractMatrix{Ty}, Z::AbstractMatrix{Ty}) = GeneralizedSchur{Ty,typeof(S)}(S, T, alpha, beta, Q, Z)
 
-schurfact!{T<:BlasFloat}(A::StridedMatrix{T}, B::StridedMatrix{T}) = GeneralizedSchur(LinAlg.LAPACK.gges!('V', 'V', A, B)...)
-schurfact{T<:BlasFloat}(A::StridedMatrix{T},B::StridedMatrix{T}) = schurfact!(copy(A),copy(B))
-schurfact{TA,TB}(A::StridedMatrix{TA}, B::StridedMatrix{TB}) = (S = promote_type(Float32,typeof(one(TA)/norm(one(TA))),TB); schurfact!(S != TA ? convert(AbstractMatrix{S},A) : copy(A), S != TB ? convert(AbstractMatrix{S},B) : copy(B)))
+function schurfact!{T<:BlasFloat}(A::StridedMatrix{T}, B::StridedMatrix{T},
+                                  selctg::Union(Function, Ptr{Void})=C_NULL)
+    GeneralizedSchur(LinAlg.LAPACK.gges!('V', 'V', A, B, selctg)...)
+end
+
+function schurfact{T<:BlasFloat}(A::StridedMatrix{T},B::StridedMatrix{T},
+                                 selctg::Union(Function, Ptr{Void})=C_NULL)
+    schurfact!(copy(A), copy(B), selctg)
+end
+
+function schurfact{TA,TB}(A::StridedMatrix{TA}, B::StridedMatrix{TB},
+                          selctg::Union(Function, Ptr{Void})=C_NULL)
+    S = promote_type(Float32,typeof(one(TA)/norm(one(TA))),TB)
+    schurfact!(S != TA ? convert(AbstractMatrix{S},A) : copy(A),
+               S != TB ? convert(AbstractMatrix{S},B) : copy(B),
+               selctg)
+end
 
 function getindex(F::GeneralizedSchur, d::Symbol)
     d == :S && return F.S
@@ -732,8 +762,9 @@ function getindex(F::GeneralizedSchur, d::Symbol)
     throw(KeyError(d))
 end
 
-function schur(A::AbstractMatrix, B::AbstractMatrix)
-    SchurF = schurfact(A, B)
+function schur(A::AbstractMatrix, B::AbstractMatrix,
+               selctg::Union(Function, Ptr{Void})=C_NULL)
+    SchurF = schurfact(A, B, selctg)
     SchurF[:S], SchurF[:T], SchurF[:Q], SchurF[:Z]
 end
 

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -3364,7 +3364,7 @@ __selctg = C_NULL  # use global so we can compile cfunction dynamically
 
 function selctg2c{T}(a::T, b::T, c::T)
     global __selctg  # get current global for __selctg. Updated in gees/gges
-    return __selctg(a, b, c)::BlasInt
+    return convert(BlasInt, __selctg(a, b, c))::BlasInt
 end
 
 
@@ -3498,7 +3498,7 @@ end
 # Complex Schur forms
 function zselctg2c{T}(a::T, b::T)
     global __selctg  # get current __selctg. Updated in zgees/zgges
-    return __selctg(a, b)::BlasInt
+    return convert(BlasInt, __selctg(a, b))::BlasInt
 end
 
 for (gees, gges, elty, relty) in

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -217,7 +217,7 @@ debug && println("Reorder Schur")
 debug && println("Sorted Generalized (with selctg)")
     if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
         if eltya <: Complex
-            selctg(a, b) = abs(a) <= 1.0 ? 1 : 0
+            selctg(a, b) = abs(a) == 0.0 ? 1 : 0
         else
             selctg(a, b, c) = (a+b)/c <= 1 ? 1 : 0
         end

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -188,6 +188,20 @@ debug && println("Schur")
         @test istriu(f[:Schur]) || iseltype(a,Real)
     end
 
+debug && println("Sorted Schur (with selctg)")
+    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+        if eltya <: Complex
+            selctg(a, b) = abs(a / b) <= 1 ? 1 : 0
+        else
+            selctg(a, b, c) = (a+b)/c <= 1 ? 1 : 0
+        end
+        f = schurfact(a, selctg)
+        @test_approx_eq f[:vectors]*f[:Schur]*f[:vectors]' a
+        @test_approx_eq sort(real(f[:values])) sort(real(d))
+        @test_approx_eq sort(imag(f[:values])) sort(imag(d))
+        @test istriu(f[:Schur]) || iseltype(a,Real)
+    end
+
 debug && println("Reorder Schur")
     if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
         # use asym for real schur to enforce tridiag structure
@@ -198,6 +212,21 @@ debug && println("Reorder Schur")
         O = ordschur(S, select)
         bool(sum(select)) && @test_approx_eq S[:values][find(select)] O[:values][1:sum(select)]
         @test_approx_eq O[:vectors]*O[:Schur]*O[:vectors]' ordschura
+    end
+
+debug && println("Sorted Generalized (with selctg)")
+    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+        if eltya <: Complex
+            selctg(a, b) = abs(a) <= 1.0 ? 1 : 0
+        else
+            selctg(a, b, c) = (a+b)/c <= 1 ? 1 : 0
+        end
+
+        f = schurfact(a[1:5,1:5], a[6:10,6:10], selctg)
+        @test_approx_eq f[:Q]*f[:S]*f[:Z]' a[1:5,1:5]
+        @test_approx_eq f[:Q]*f[:T]*f[:Z]' a[6:10,6:10]
+        @test istriu(f[:S]) || iseltype(a,Real)
+        @test istriu(f[:T]) || iseltype(a,Real)
     end
 
 debug && println("Generalized Schur")


### PR DESCRIPTION
The Schur and generalized Schur routines in LAPACK have the ability to sort the result based on a callback function (parameter named `selctg`) that analyzes the eigenvalues. 

This RFC enables this feature for each of the `gees` and `gges` routines as well the corresponding `shurfact`, `schurfact!`, and `schur` methods.

I have implemented basic tests that make sure the factorization still holds, but we should write better tests to see if the reordering is happening as expected. The problem is I don't know exactly what the answer _should_ be, so it is hard to know if this is doing the right thing. Do we have any LAPACK experts out there who could come up with a good test case?

I was considering implementing the [test case for the scipy qz function](https://github.com/scipy/scipy/blob/v0.14.0/scipy/linalg/tests/test_decomp.py#L1809-L1864), but I am not getting the same answers as scipy. Could the difference possibly be attributed to differences in LAPACK implementation or platform dependence?

CC: @cc7768
