### PR TITLE
Pkg.test: always check bounds, disable inlining if coverage=true

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -690,8 +690,8 @@ function test!(pkg::AbstractString, errs::Vector{AbstractString}, notests::Vecto
         cd(dirname(test_path)) do
             try
                 color = Base.have_color? "--color=yes" : "--color=no"
-                codecov = coverage? "--code-coverage=user" : "--code-coverage=none"
-                run(`$JULIA_HOME/julia $codecov $color $test_path`)
+                codecov = coverage? "--code-coverage=user --inline=no" : "--code-coverage=none"
+                run(`$JULIA_HOME/julia --check-bounds=yes $codecov $color $test_path`)
                 info("$pkg tests passed")
             catch err
                 warnbanner(err, label="[ ERROR: $pkg ]")


### PR DESCRIPTION
The aim of this is to be more stringent in tests (always check bounds), and to provide more accurate coverage information (when requested) by disabling inlining.
