### PR TITLE
make cumsum result type consistent with sum

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,7 +79,7 @@ Library improvements
   * Arithmetic is type-preserving for more types; e.g. `(x::Int8) + (y::Int8)` now
     yields an `Int8` ([#3759]).
 
-  * Reductions (e.g. `reduce`, `sum`) widen small types (integers smaller than `Int`, and `Float16`).
+  * Reductions (e.g. `reduce`, `sum`) widen small types (integers smaller than `Int`, and `Float16`).  Similarly for `cumsum` ([#9665]).
 
   * New `Dates` module for calendar dates and other time-interval calculations ([#7654]).
 
@@ -1149,5 +1149,8 @@ Too numerous to mention.
 [#9261]: https://github.com/JuliaLang/julia/issues/9261
 [#9271]: https://github.com/JuliaLang/julia/issues/9271
 [#9294]: https://github.com/JuliaLang/julia/issues/9294
-[#9569]: https://github.com/JuliaLang/julia/issues/9569
+[#9418]: https://github.com/JuliaLang/julia/issues/9418
 [#9452]: https://github.com/JuliaLang/julia/issues/9452
+[#9569]: https://github.com/JuliaLang/julia/issues/9569
+[#9578]: https://github.com/JuliaLang/julia/issues/9578
+[#9665]: https://github.com/JuliaLang/julia/issues/9665

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -978,4 +978,11 @@ a = [ [ 1 0 0 ], [ 0 0 0 ] ]
 # issue #9648
 let x = fill(1.5f0, 10^7)
     @test abs(1.5f7 - cumsum(x)[end]) < 3*eps(1.5f7)
+    @test cumsum(x) == cumsum!(similar(x), x)
+end
+
+# cumsum type consistency (discussed in #9650)
+let x = Uint8[1,2,3,4,6,7]
+    @test eltype(cumsum(x)) == typeof(sum(x)) == eltype(cumsum(reshape(x,3,2)))
+    @test cumsum(x) == cumsum!(similar(x),x) == cumsum!(similar(x,Int), x)
 end


### PR DESCRIPTION
This means that `cumsum(Int8[1,2,3])` is `Int[1,3,6]` rather than an `Int8` array, for example.  If you really want to do the sum as `Int8`, you can still do `cumsum!(Array(Int8,3), Int8[1,2,3])`.

In principle, this is a breaking change, but I'm not sure if any code in the wild actually relied on the lack of promotion in the cumsum results?  (The most common usage seems to be for `Float64` and `Float32` arrays, which are unaffected.)

Also, this makes `cumsum!` and `cumsum` use the same pairwise code for 1d arrays (whereas previously `cumsum!` used a completely different codepath based on the one for multidimensional arrays, which just does naive summation).   Ideally, we'd use the pairwise algorithm for multidimensional arrays too, but that requires a much bigger code rewrite.

(See discussion in JuliaLang/julia#9650 with @timholy.)
