### PR TITLE
update to module initialization lib

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -779,6 +779,7 @@ extern DLLEXPORT jl_module_t *jl_core_module;
 extern DLLEXPORT jl_module_t *jl_base_module;
 extern DLLEXPORT jl_module_t *jl_current_module;
 DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name);
+DLLEXPORT jl_value_t *jl_f_new_module(jl_sym_t *name);
 // get binding for reading
 DLLEXPORT jl_binding_t *jl_get_binding(jl_module_t *m, jl_sym_t *var);
 // get binding for assignment

--- a/src/module.c
+++ b/src/module.c
@@ -23,6 +23,7 @@ jl_module_t *jl_new_module(jl_sym_t *name)
     m->name = name;
     m->constant_table = NULL;
     m->call_func = NULL;
+    m->parent = NULL;
     htable_new(&m->bindings, 0);
     arraylist_new(&m->usings, 0);
     if (jl_core_module) {


### PR DESCRIPTION
- Adds the declaration of **jl_f_new_module** to _julia.h_
- Modify the initialization in **jl_new_module**: set parent to NULL.

Fixes #9661 
