### PR TITLE
Improve method completion to work `prevind("θ",<tab>.

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -173,9 +173,6 @@ function show_method_candidates(io::IO, ex::MethodError)
     # Displays the closest candidates of the given function by looping over the
     # functions methods and counting the number of matching arguments.
 
-    return_T(val) = typeof(val)
-    return_T(val::DataType) = Type{val}
-
     lines = Array((IOBuffer, Int), 0)
     name = isgeneric(ex.f) ? ex.f.env.name : :anonymous
     # These functions are special cased to only show if first argument is matched.
@@ -192,7 +189,7 @@ function show_method_candidates(io::IO, ex::MethodError)
             show_delim_array(buf, tv, '{', ',', '}', false)
         end
         print(buf, "(")
-        t_i = [return_T(arg) for arg in ex.args]
+        t_i = [Base.REPLCompletions.method_type_of_arg(arg) for arg in ex.args]
         right_matches = 0
         for i = 1 : min(length(t_i), length(method.sig))
             i != 1 && print(buf, ", ")

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -16,6 +16,13 @@ module CompletionFoo
     macro foobar()
         :()
     end
+
+    test{T<:Real}(x::T, y::T) = pass
+    test(x::Real, y::Real) = pass
+    test{T<:Real}(x::AbstractArray{T}, y) = pass
+    test(args...) = pass
+
+    array = [1, 1]
 end
 
 function temp_pkg_dir(fn::Function)
@@ -143,8 +150,40 @@ s = "max("
 c, r, res = test_complete(s)
 @test !res
 @test c[1] == string(start(methods(max)))
-@test r == 1:3
-@test s[r] == "max"
+@test r == 1:4
+@test s[r] == "max("
+
+let
+
+    s = "CompletionFoo.test(1,1, "
+    c, r, res = test_complete(s)
+    @test !res
+    @test c[1] == string(methods(CompletionFoo.test, (Int, Int))[1])
+    @test length(c) == 3
+    @test r == 1:24
+    @test s[r] == "CompletionFoo.test(1,1, "
+
+    s = "CompletionFoo.test(CompletionFoo.array,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test c[1] == string(methods(CompletionFoo.test, (Array{Int, 1}, Any))[1])
+    @test length(c) == 2
+    @test r == 1:39
+    @test s[r] == "CompletionFoo.test(CompletionFoo.array,"
+
+    s = "CompletionFoo.test(1,1,1,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test c[1] == string(methods(CompletionFoo.test, (Any, Any, Any))[1])
+    @test r == 1:25
+    @test s[r] == "CompletionFoo.test(1,1,1,"
+end
+
+s = "prevind(\"θ\",1,"
+c, r, res = test_complete(s)
+@test c[1] == string(methods(prevind, (UTF8String, Int))[1])
+@test r == 1:15
+@test s[r] == "prevind(\"θ\",1,"
 
 # Test completion in multi-line comments
 s = "#=\n\\alpha"

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -22,6 +22,8 @@ module CompletionFoo
     test{T<:Real}(x::AbstractArray{T}, y) = pass
     test(args...) = pass
 
+    test1(x::Type{Float64}) = pass
+
     array = [1, 1]
 end
 
@@ -150,40 +152,52 @@ s = "max("
 c, r, res = test_complete(s)
 @test !res
 @test c[1] == string(start(methods(max)))
-@test r == 1:4
-@test s[r] == "max("
+@test r == 1:3
+@test s[r] == "max"
 
-let
+# Test completion of methods with input args
+s = "CompletionFoo.test(1,1, "
+c, r, res = test_complete(s)
+@test !res
+@test c[1] == string(methods(CompletionFoo.test, (Int, Int))[1])
+@test length(c) == 3
+@test r == 1:18
+@test s[r] == "CompletionFoo.test"
 
-    s = "CompletionFoo.test(1,1, "
-    c, r, res = test_complete(s)
-    @test !res
-    @test c[1] == string(methods(CompletionFoo.test, (Int, Int))[1])
-    @test length(c) == 3
-    @test r == 1:24
-    @test s[r] == "CompletionFoo.test(1,1, "
+s = "CompletionFoo.test(CompletionFoo.array,"
+c, r, res = test_complete(s)
+@test !res
+@test c[1] == string(methods(CompletionFoo.test, (Array{Int, 1}, Any))[1])
+@test length(c) == 2
+@test r == 1:18
+@test s[r] == "CompletionFoo.test"
 
-    s = "CompletionFoo.test(CompletionFoo.array,"
-    c, r, res = test_complete(s)
-    @test !res
-    @test c[1] == string(methods(CompletionFoo.test, (Array{Int, 1}, Any))[1])
-    @test length(c) == 2
-    @test r == 1:39
-    @test s[r] == "CompletionFoo.test(CompletionFoo.array,"
+s = "CompletionFoo.test(1,1,1,"
+c, r, res = test_complete(s)
+@test !res
+@test c[1] == string(methods(CompletionFoo.test, (Any, Any, Any))[1])
+@test r == 1:18
+@test s[r] == "CompletionFoo.test"
 
-    s = "CompletionFoo.test(1,1,1,"
-    c, r, res = test_complete(s)
-    @test !res
-    @test c[1] == string(methods(CompletionFoo.test, (Any, Any, Any))[1])
-    @test r == 1:25
-    @test s[r] == "CompletionFoo.test(1,1,1,"
-end
+s = "CompletionFoo.test1(Int,"
+c, r, res = test_complete(s)
+@test !res
+@test length(c) == 0
+@test r == 1:19
+@test s[r] == "CompletionFoo.test1"
+
+s = "CompletionFoo.test1(Float64,"
+c, r, res = test_complete(s)
+@test !res
+@test length(c) == 1
+@test r == 1:19
+@test s[r] == "CompletionFoo.test1"
 
 s = "prevind(\"θ\",1,"
 c, r, res = test_complete(s)
 @test c[1] == string(methods(prevind, (UTF8String, Int))[1])
-@test r == 1:15
-@test s[r] == "prevind(\"θ\",1,"
+@test r == 1:7
+@test s[r] == "prevind"
 
 # Test completion in multi-line comments
 s = "#=\n\\alpha"


### PR DESCRIPTION
I have improved method completion to also work when `max(1,<tab>` and it will only show the methods that matches the type of the given args. If the type of the arguments can’t be determined it does not return any suggestions. Example of use:

```
a = [1, 1]
julia> max(a, <tab>
max{T1<:Real,T2<:Real}(::AbstractArray{T1<:Real,N},::T2<:Real) at operators.jl:3
72
max{T1<:Real,T2<:Real}(::AbstractArray{T1<:Real,N},::AbstractArray{T2<:Real,N})
at operators.jl:376
max(x,y) at operators.jl:56
max(a,b,c) at operators.jl:83
max(a,b,c,xs...) at operators.jl:84
julia> max(a, 
```

But it do not return anything by doing:

```
julia>max([1, 2],<tab>
```

For further examples, see the test cases.
