### PR TITLE
Fix and test Pkg.test(pkg, coverage=true)

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -690,7 +690,7 @@ function test!(pkg::AbstractString, errs::Vector{AbstractString}, notests::Vecto
         cd(dirname(test_path)) do
             try
                 color = Base.have_color? "--color=yes" : "--color=no"
-                codecov = coverage? "--code-coverage=user --inline=no" : "--code-coverage=none"
+                codecov = coverage? ["--code-coverage=user", "--inline=no"] : ["--code-coverage=none"]
                 run(`$JULIA_HOME/julia --check-bounds=yes $codecov $color $test_path`)
                 info("$pkg tests passed")
             catch err

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -76,3 +76,45 @@ temp_pkg_dir() do
     @test err.msg == "PackageWithFailingTests had test errors"
   end
 end
+
+# Testing with code-coverage
+temp_pkg_dir() do
+  Pkg.generate("PackageWithCodeCoverage", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
+
+  src = """
+module PackageWithCodeCoverage
+
+export f1, f2, f3, untested
+
+f1(x) = 2x
+f2(x) = f1(x)
+function f3(x)
+    3x
+end
+untested(x) = 7
+
+end"""
+  linetested = [false, false, false, false, true, true, false, true, false, false]
+  open(Pkg.dir("PackageWithCodeCoverage", "src", "PackageWithCodeCoverage.jl"), "w") do f
+      println(f, src)
+  end
+  isdir(Pkg.dir("PackageWithCodeCoverage","test")) || mkdir(Pkg.dir("PackageWithCodeCoverage","test"))
+  open(Pkg.dir("PackageWithCodeCoverage", "test", "runtests.jl"),"w") do f
+    println(f,"using PackageWithCodeCoverage, Base.Test")
+    println(f,"@test f2(2) == 4")
+    println(f,"@test f3(5) == 15")
+  end
+
+  Pkg.test("PackageWithCodeCoverage")
+  covfile = Pkg.dir("PackageWithCodeCoverage","src","PackageWithCodeCoverage.jl.cov")
+  @test !isfile(covfile)
+  Pkg.test("PackageWithCodeCoverage", coverage=true)
+  @test isfile(covfile)
+  covstr = readall(covfile)
+  srclines = split(src, '\n')
+  covlines = split(covstr, '\n')
+  for i = 1:length(linetested)
+      covline = (linetested[i] ? "        1 " : "        - ")*srclines[i]
+      @test covlines[i] == covline
+  end
+end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -78,6 +78,7 @@ temp_pkg_dir() do
 end
 
 # Testing with code-coverage
+@unix_only begin                 # TODO: delete unix_only when #8911, #9654 are fixed
 temp_pkg_dir() do
   Pkg.generate("PackageWithCodeCoverage", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
 
@@ -117,4 +118,5 @@ end"""
       covline = (linetested[i] ? "        1 " : "        - ")*srclines[i]
       @test covlines[i] == covline
   end
+end
 end


### PR DESCRIPTION
It turns out that in #9658 I broke `Pkg.test(pkg, coverage=true)`, because the Cmd interpolation quoted a string with a space in it: I was generating `julia --check-bounds=yes '--code-coverage=user --inline=no' ...` rather than the unquoted form. Responsible for https://github.com/JuliaCI/travis-build/issues/1#issuecomment-69098762. This should fix that.

Beyond the one-line fix, the much bigger part of this is adding a test.

EDIT: this part deleted due to feedback below
~~Finally, the last commit contains what I expect to be the most controversial point of this PR: I added `"pkg"` to the list of our default tests. Currently the problem is that this generates a LOT of console output, and one of the tests (PackageWithFailingTests) gives the appearance, to a casual/hasty observer, of some problem. We could presumably turn it off by redirecting the IO to `/dev/null`, at least on a Unix platform. I don't know about other platforms, though.~~

~~Another potential way to turn it off is with `redirect_std{out,err}()` (we'd have to cook up a way to do this across Cmd-launched processes), but if we go that way I'm worried about #9501. But maybe we should merge this as-is anyway. Then, the following sequence of events will occur:~~
- ~~Multiple people will become annoyed by the amount of output generated during `make testall`~~
- ~~One of those people will have the skills to fix #9501, and will eventually get around to it. (That's a nasty bug, so we need to fix it anyway. This just raises the stakes.)~~
- ~~Then we can turn off the output of `test/pkg.jl` using `redirect_std{out,err}()`.~~

Thoughts?
