### PR TITLE
make cumsum call cumsum! 

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1455,8 +1455,8 @@ symdiff(a, b, rest...) = symdiff(a, symdiff(b, rest...))
 _cumsum_type{T<:Number}(v::AbstractArray{T}) = typeof(+zero(T))
 _cumsum_type(v) = typeof(v[1]+v[1])
 
-for (f, fp, op) = ((:cumsum, :cumsum_pairwise!, :+),
-                   (:cumprod, :cumprod_pairwise!, :*) )
+for (f, f!, fp, op) = ((:cumsum, :cumsum!, :cumsum_pairwise!, :+),
+                       (:cumprod, :cumprod!, :cumprod_pairwise!, :*) )
     # in-place cumsum of c = s+v[range(i1,n)], using pairwise summation
     @eval function ($fp){T}(v::AbstractVector, c::AbstractVector{T}, s, i1, n)
         local s_::T # for sum(v[range(i1,n)]), i.e. sum without s
@@ -1475,16 +1475,17 @@ for (f, fp, op) = ((:cumsum, :cumsum_pairwise!, :+),
         return s_
     end
 
-    @eval function ($f)(v::AbstractVector)
+    @eval function ($f!)(result::AbstractVector, v::AbstractVector)
         n = length(v)
-        c = $(op===:+ ? (:(similar(v,_cumsum_type(v)))) :
-                        (:(similar(v))))
-        if n == 0; return c; end
-        ($fp)(v, c, $(op==:+ ? :(zero(v[1])) : :(one(v[1]))), 1, n)
-        return c
+        if n == 0; return result; end
+        ($fp)(v, result, $(op==:+ ? :(zero(v[1])) : :(one(v[1]))), 1, n)
+        return result
     end
 
-    @eval ($f)(A::AbstractArray) = ($f)(A, 1)
+    @eval function ($f)(v::AbstractVector)
+        c = $(op===:+ ? (:(similar(v,_cumsum_type(v)))) : (:(similar(v))))
+        return ($f!)(c, v)
+    end
 end
 
 for (f, op) = ((:cummin, :min), (:cummax, :max))

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -397,8 +397,10 @@ Array functions
 
 .. function:: cumprod(A, [dim])
 
-   Cumulative product along a dimension.
-   The dimension defaults to 1.
+   Cumulative product along a dimension ``dim`` (defaults to 1).
+   See also :func:`cumprod!` to use a preallocated output array,
+   both for performance and to control the precision of the
+   output (e.g. to avoid overflow).
 
 .. function:: cumprod!(B, A, [dim])
 
@@ -407,8 +409,10 @@ Array functions
 
 .. function:: cumsum(A, [dim])
 
-   Cumulative sum along a dimension.
-   The dimension defaults to 1.
+   Cumulative sum along a dimension ``dim`` (defaults to 1).
+   See also :func:`cumsum!` to use a preallocated output array,
+   both for performance and to control the precision of the
+   output (e.g. to avoid overflow).
 
 .. function:: cumsum!(B, A, [dim])
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -978,4 +978,5 @@ a = [ [ 1 0 0 ], [ 0 0 0 ] ]
 # issue #9648
 let x = fill(1.5f0, 10^7)
     @test abs(1.5f7 - cumsum(x)[end]) < 3*eps(1.5f7)
+    @test cumsum(x) == cumsum!(similar(x), x)
 end


### PR DESCRIPTION
See #9665: this makes `cumsum!` and `cumsum` use the same pairwise code for 1d arrays (whereas previously `cumsum!` used a completely different codepath based on the one for multidimensional arrays, which just does naive summation). Ideally, we'd use the pairwise algorithm for multidimensional arrays too, but that requires a much bigger code rewrite.  Also updates the docs to mention using `cumsum!` to control the precision.

cc: @timholy, @ivarne
