### PR TITLE
deprecate error(::Exception) and error(::Type{Exception})

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,9 @@ New language features
 Language changes
 ----------------
 
+  * `error(::Exception)` and `error(::Type{Exception})` have been deprecated
+     in favor of using an explicit `throw` ([#9690]).
+
   * `Uint` et al. are now spelled `UInt` ([#8905]).
 
   * `String` has been renamed to `AbstractString` ([#8872]).

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -270,3 +270,6 @@ const base64 = base64encode
 @deprecate functionlocs(f,t)  map(functionloc, methods(f,t))
 
 @deprecate null nullspace
+
+@deprecate error(ex::Exception) throw(ex)
+@deprecate error{E<:Exception}(::Type{E}) throw(E())

--- a/base/error.jl
+++ b/base/error.jl
@@ -16,10 +16,8 @@
 
 ## native julia error handling ##
 
-error(e::Exception) = throw(e)
-error{E<:Exception}(::Type{E}) = throw(E())
 error(s::AbstractString) = throw(ErrorException(s))
-error(s...)      = throw(ErrorException(string(s...)))
+error(s...) = throw(ErrorException(string(s...)))
 
 macro unexpected()
     :(error("unexpected branch reached"))

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -136,16 +136,14 @@ function exec(regex::Ptr{Void}, extra::Ptr{Void},
               len::Integer, options::Integer,
               ovec::Vector{Int32})
     if offset < 0 || len < offset || len+shift > sizeof(str)
-        error(BoundsError)
+        throw(BoundsError())
     end
     n = ccall((:pcre_exec, :libpcre), Int32,
               (Ptr{Void}, Ptr{Void}, Ptr{UInt8}, Int32,
                Int32, Int32, Ptr{Int32}, Int32),
               regex, extra, pointer(str.data,shift+1), len,
               offset, options, ovec, length(ovec))
-    if n < -1
-        error("error $n")
-    end
+    n < -1 && error("PCRE.exec error code $n")
     return n > -1
 end
 

--- a/base/process.jl
+++ b/base/process.jl
@@ -482,7 +482,8 @@ const SIGPIPE = 13
 function test_success(proc::Process)
     assert(process_exited(proc))
     if proc.exitcode < 0
-        error(UVError("could not start process "*string(proc.cmd), proc.exitcode))
+        #TODO: this codepath is not currently tested
+        throw(UVError("could not start process $(string(proc.cmd))", proc.exitcode))
     end
     proc.exitcode == 0 && (proc.termsignal == 0 || proc.termsignal == SIGPIPE)
 end

--- a/base/random.jl
+++ b/base/random.jl
@@ -1152,7 +1152,7 @@ function Base.convert(::Type{UUID}, s::AbstractString)
     s = lowercase(s)
 
     if !ismatch(r"^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$", s)
-        error(ArgumentError("Malformed UUID string"))
+        throw(ArgumentError("Malformed UUID string"))
     end
 
     u = uint128(0)

--- a/base/range.jl
+++ b/base/range.jl
@@ -256,11 +256,11 @@ done(r::UnitRange, i) = i==oftype(i,r.stop)+1
 getindex(r::Range, i::Real) = getindex(r, to_index(i))
 
 function getindex{T}(r::Range{T}, i::Integer)
-    1 <= i <= length(r) || error(BoundsError)
+    1 <= i <= length(r) || throw(BoundsError())
     convert(T, first(r) + (i-1)*step(r))
 end
 function getindex{T}(r::FloatRange{T}, i::Integer)
-    1 <= i <= length(r) || error(BoundsError)
+    1 <= i <= length(r) || throw(BoundsError())
     convert(T, (r.start + (i-1)*r.step)/r.divisor)
 end
 

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -276,9 +276,10 @@ function TCPSocket()
     err = ccall(:uv_tcp_init,Cint,(Ptr{Void},Ptr{Void}),
                   eventloop(),this.handle)
     if err != 0
+        #TODO: this codepath is not currently tested
         c_free(this.handle)
         this.handle = C_NULL
-        error(UVError("failed to create tcp socket",err))
+        throw(UVError("failed to create tcp socket",err))
     end
     this.status = StatusInit
     this
@@ -306,9 +307,10 @@ function TCPServer()
     err = ccall(:uv_tcp_init,Cint,(Ptr{Void},Ptr{Void}),
                   eventloop(),this.handle)
     if err != 0
+        #TODO: this codepath is not currently tested
         c_free(this.handle)
         this.handle = C_NULL
-        error(UVError("failed to create tcp server",err))
+        throw(UVError("failed to create tcp server",err))
     end
     this.status = StatusInit
     this
@@ -374,9 +376,10 @@ function UDPSocket()
                   eventloop(),this.handle)
     finalizer(this, uvfinalize)
     if err != 0
+        #TODO: this codepath is not currently tested
         c_free(this.handle)
         this.handle = C_NULL
-        error(UVError("failed to create udp socket",err))
+        throw(UVError("failed to create udp socket",err))
     end
     this.status = StatusInit
     this
@@ -410,7 +413,8 @@ function bind(sock::Union(TCPServer,UDPSocket), host::IPv4, port::Integer)
     err = _bind(sock,host,uint16(port))
     if err < 0
         if err != UV_EADDRINUSE && err != UV_EACCES
-            error(UVError("bind",err))
+            #TODO: this codepath is not currently tested
+            throw(UVError("bind",err))
         else
             return false
         end
@@ -430,7 +434,8 @@ function bind(sock::UDPSocket, host::IPv6, port::UInt16; ipv6only = false)
     err = _bind(sock,host,port, uint32(ipv6only ? UV_UDP_IPV6ONLY : 0))
     if err < 0
         if err != UV_EADDRINUSE && err != UV_EACCES
-            error(UVError("bind",err))
+            #TODO: this codepath is not currently tested
+            throw(UVError("bind",err))
         else
             return false
         end

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -454,9 +454,10 @@ type Timer <: AsyncWork
         disassociate_julia_struct(this.handle)
         err = ccall(:uv_timer_init,Cint,(Ptr{Void},Ptr{Void}),eventloop(),this.handle)
         if err != 0
+            #TODO: this codepath is currently not tested
             c_free(this.handle)
             this.handle = C_NULL
-            error(UVError("uv_make_timer",err))
+            throw(UVError("uv_make_timer",err))
         end
         finalizer(this,uvfinalize)
         this
@@ -882,7 +883,8 @@ function bind(server::PipeServer, name::ASCIIString)
                 server.handle, name)
     if err != 0
         if err != UV_EADDRINUSE && err != UV_EACCES
-            error(UVError("bind",err))
+            #TODO: this codepath is currently not tested
+            throw(UVError("bind",err))
         else
             return false
         end

--- a/test/core.jl
+++ b/test/core.jl
@@ -2067,10 +2067,10 @@ f9534f(x) = (a=IOBuffer(); a.(x))
 @test try; f9534f(typemin(Int)+2) catch ex; isa((ex::BoundsError).a,IOBuffer) && ex.i == typemin(Int)+2; end
 x9634 = 3
 @test try; getfield(1+2im, x9634); catch ex; (ex::BoundsError).a === 1+2im && ex.i == 3; end
-@test try; error(BoundsError()) catch ex; !isdefined((ex::BoundsError), :a) && !isdefined((ex::BoundsError), :i); end
-@test try; error(BoundsError(Int)) catch ex; (ex::BoundsError).a == Int && !isdefined((ex::BoundsError), :i); end
-@test try; error(BoundsError(Int, typemin(Int))) catch ex; (ex::BoundsError).a == Int && (ex::BoundsError).i == typemin(Int); end
-@test try; error(BoundsError(Int, (:a,))) catch ex; (ex::BoundsError).a == Int && (ex::BoundsError).i == (:a,); end
+@test try; throw(BoundsError()) catch ex; !isdefined((ex::BoundsError), :a) && !isdefined((ex::BoundsError), :i); end
+@test try; throw(BoundsError(Int)) catch ex; (ex::BoundsError).a == Int && !isdefined((ex::BoundsError), :i); end
+@test try; throw(BoundsError(Int, typemin(Int))) catch ex; (ex::BoundsError).a == Int && (ex::BoundsError).i == typemin(Int); end
+@test try; throw(BoundsError(Int, (:a,))) catch ex; (ex::BoundsError).a == Int && (ex::BoundsError).i == (:a,); end
 f9534g(a,b,c...) = c[0]
 @test try; f9534g(1,2,3,4,5,6) catch ex; (ex::BoundsError).a === (3,4,5,6) && ex.i == 0; end
 f9534h(a,b,c...) = c[a]


### PR DESCRIPTION
These are redundant and currently just defer to throw.  I feel we want move away from generic `error()` messages where possible, so we should encourage people to throw more specific Exception types.

cc @ivarne 
