### PR TITLE
change README to recommend removing old installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Once it is built, you can run the `julia` executable using its full path in the 
 
 - add the `julia` directory to your executable path permanently (e.g. in `.bash_profile`), or
 
-- write `prefix=/path/to/install/folder` into `Make.user` and then run `make install`.
+- write `prefix=/path/to/install/folder` into `Make.user` and then run `make install`. If there is a version of Julia already installed in this folder, you should delete it before running `make install`.
 
 Now you should be able to run Julia like this:
 


### PR DESCRIPTION
This documentation change makes a recommendation to the user to avoid a problem I found.

The command line option --inline was not accepted and not listed by --help with a freshly built julia from master. I did `make install` more than once. The banner showed that the correct version of julia was indeed starting. I ran it from various directories.

I ran `rm /path/to/julia/installation` and then `make install` and the problem was fixed.
