### PR TITLE
Gc return

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -1104,6 +1104,11 @@ STATIC_INLINE void *alloc_4w() { return allocobj(4*sizeof(void*)); }
 #define allocobj(nb)  malloc(nb)
 #endif
 
+#define JL_GC_RETURN(expr...) do {              \
+        JL_GC_POP();                            \
+        return expr;                            \
+    } while (0)
+
 // async signal handling ------------------------------------------------------
 
 #include <signal.h>


### PR DESCRIPTION
This is the `JL_GC_RETURN` macro mentioned in #9642 with some clean up in type casting (mainly removing the `(jl_value_t*)` on `jl_nothing` and `jl_false`).
