### PR TITLE
Package completion for package names in directories in `[Pkg.dir(), LOAD_PATH, pwd()]`

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -228,12 +228,19 @@ function completions(string, pos)
         # also search for packages
         s = string[startpos:pos]
         if dotpos <= startpos
-            append!(suggestions, filter(isdir(Pkg.dir()) ? readdir(Pkg.dir()) : Union(ASCIIString,UTF8String)[]) do pname
-                pname[1] != '.' &&
-                pname != "METADATA" &&
-                pname != "REQUIRE" &&
-                startswith(pname, s)
-            end)
+            for dir in [Pkg.dir(), LOAD_PATH, pwd()]
+                !isdir(dir) && continue
+                for pname in readdir(dir)
+                    if pname[1] != '.' && pname != "METADATA" &&
+                          pname != "REQUIRE" && startswith(pname, s)
+                        if isfile(joinpath(dir, pname))
+                            endswith(pname, ".jl") && push!(suggestions, pname[1:end-3])
+                        else
+                            push!(suggestions, pname)
+                        end
+                    end
+                end
+            end
         end
         ffunc = (mod,x)->(isdefined(mod, x) && isa(mod.(x), Module))
         comp_keywords = false

--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -229,7 +229,7 @@ function completions(string, pos)
         s = string[startpos:pos]
         if dotpos <= startpos
             for dir in [Pkg.dir(), LOAD_PATH, pwd()]
-                !isdir(dir) && continue
+                isdir(dir) || continue
                 for pname in readdir(dir)
                     if pname[1] != '.' && pname != "METADATA" &&
                           pname != "REQUIRE" && startswith(pname, s)

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -170,6 +170,31 @@ temp_pkg_dir() do
     @test s[r] == "Completion"
 end
 
+path = joinpath(tempdir(),randstring())
+push!(LOAD_PATH, path)
+try
+    # Should not throw an error even though the path do no exist
+    test_complete("using ")
+    Pack_folder = joinpath(path,"Test_pack")
+    mkpath(Pack_folder)
+
+    # Test it completes on folders
+    c,r,res = test_complete("using Test_p")
+    @test "Test_pack" in c
+
+    # Test that it also completes on .jl files in pwd()
+    cd(Pack_folder) do
+        open("Text.txt","w") do f end
+        open("Pack.jl","w") do f end
+        c,r,res = test_complete("using ")
+        @test "Pack" in c
+        @test !("Text.txt" in c)
+    end
+finally
+    @test pop!(LOAD_PATH) == path
+    rm(path, recursive=true)
+end
+
 # Test $ in shell-mode
 s = "cd \$(max"
 c, r, res = test_scomplete(s)


### PR DESCRIPTION
This is a fix for the completion of packages in LOAD_PATH mentioned in https://groups.google.com/forum/m/?fromgroups#!topic/julia-users/9lQZJlLs99M
Since completion of package names is now also works outside Pkg.dir() I have added that files should end on `".jl"`. I do not know if its appropriate to include `pwd()` in the search but it is easy to remove. cc @timholy 
