### PR TITLE
RFC: New method to concatenate symbols

### DIFF
--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -96,7 +96,7 @@ function ngenerate(itersym, returntypeexpr, prototype, bodyfunc, dims=1:CARTESIA
         extractvarargs = N -> Expr(:block, map(popescape, _nextract(N, s, s).args)...)
     end
     fsym = funcsym(prototype)
-    dictname = symbol(string(fsym)*"_cache")
+    dictname = symbol(fsym,"_cache")
     fargs = funcargs(prototype)
     if !isempty(varname)
         fargs[end] = Expr(:..., fargs[end].args[1])
@@ -158,10 +158,10 @@ end
 # Replace splatted with desplatted for a specific number of arguments
 function resolvesplat!(prototype, varname, T::Union(Type,Symbol,Expr), N::Int)
     if !isempty(varname)
-        prototype.args[end] = N > 0 ? Expr(:(::), symbol(string(varname, "_1")), T) :
+        prototype.args[end] = N > 0 ? Expr(:(::), symbol(varname, "_1"), T) :
                                       Expr(:(::), symbol(varname), T)
         for i = 2:N
-            push!(prototype.args, Expr(:(::), symbol(string(varname, "_", i)), T))
+            push!(prototype.args, Expr(:(::), symbol(varname, "_", i), T))
         end
     end
     prototype
@@ -186,9 +186,9 @@ function resolvesplats!(ex::Expr, varname, N::Int)
         end
         a = ex.args[end]
         if isa(a, Expr) && a.head == :... && a.args[1] == symbol(varname)
-            ex.args[end] = symbol(string(varname, "_1"))
+            ex.args[end] = symbol(varname, "_1")
             for i = 2:N
-                push!(ex.args, symbol(string(varname, "_", i)))
+                push!(ex.args, symbol(varname, "_", i))
             end
         else
             resolvesplats!(a, varname, N)
@@ -404,7 +404,7 @@ function inlineanonymous(ex::Expr, val)
 end
 
 # Given :i and 3, this generates :i_3
-inlineanonymous(base::Symbol, ext) = symbol(string(base)*"_"*string(ext))
+inlineanonymous(base::Symbol, ext) = symbol(base,"_",string(ext))
 
 # Replace a symbol by a value or a "coded" symbol
 # E.g., for d = 3,
@@ -425,7 +425,7 @@ function lreplace!(ex::Expr, sym::Symbol, val, r)
     if ex.head == :curly && length(ex.args) == 2 && isa(ex.args[1], Symbol) && endswith(string(ex.args[1]), "_")
         excurly = exprresolve(lreplace!(ex.args[2], sym, val, r))
         if isa(excurly, Number)
-            return symbol(string(ex.args[1])*string(excurly))
+            return symbol(ex.args[1],excurly)
         else
             ex.args[2] = excurly
             return ex

--- a/base/docs.jl
+++ b/base/docs.jl
@@ -173,8 +173,7 @@ fexpr(ex) = isexpr(ex, :function) || (isexpr(ex, :(=)) && isexpr(ex.args[1], :ca
 
 function docm(meta, def)
   def′ = unblock(def)
-  isexpr(def′, :macro) && return namedoc(meta, def,
-                                         symbol(string("@", namify(def′))))
+  isexpr(def′, :macro) && return namedoc(meta, def, symbol("@", namify(def′)))
   isexpr(def′, :type) && return namedoc(meta, def, namify(def′.args[2]))
   isexpr(def′, :abstract) && return namedoc(meta, def, namify(def′))
   fexpr(def′) && return funcdoc(meta, def)

--- a/base/dsp.jl
+++ b/base/dsp.jl
@@ -187,10 +187,10 @@ fftwcopy{T<:Complex}(X::StridedArray{T}) = complex128(X)
 
 for (f, fr2r, Y, Tx) in ((:dct, :r2r, :Y, :Number),
                          (:dct!, :r2r!, :X, :fftwNumber))
-    plan_f = symbol(string("plan_",f))
-    plan_fr2r = symbol(string("plan_",fr2r))
-    fi = symbol(string("i",f))
-    plan_fi = symbol(string("plan_",fi))
+    plan_f = symbol("plan_",f)
+    plan_fr2r = symbol("plan_",fr2r)
+    fi = symbol("i",f)
+    plan_fi = symbol("plan_",fi)
     Ycopy = Y == :X ? 0 : :(Y = fftwcopy(X))
     @eval begin
         function $f{T<:$Tx}(X::StridedArray{T}, region)

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -5,7 +5,7 @@ symbol(s::ASCIIString) = symbol(s.data)
 symbol(s::UTF8String) = symbol(s.data)
 symbol(a::Array{UInt8,1}) =
     ccall(:jl_symbol_n, Any, (Ptr{UInt8}, Int32), a, length(a))::Symbol
-symbol(x::Char) = symbol(string(x))
+symbol(x...) = symbol(string(x...))
 
 gensym() = ccall(:jl_gensym, Any, ())::Symbol
 

--- a/base/fftw.jl
+++ b/base/fftw.jl
@@ -417,9 +417,9 @@ complexfloat{T<:Complex}(X::StridedArray{T}) = complex128(X)
 # along with in-place variants fft! and plan_fft! if feasible.
 
 for (f,direction) in ((:fft,:FORWARD), (:bfft,:BACKWARD))
-    f! = symbol(string(f,"!"))
-    plan_f = symbol(string("plan_",f))
-    plan_f! = symbol(string("plan_",f,"!"))
+    f! = symbol(f,"!")
+    plan_f = symbol("plan_",f)
+    plan_f! = symbol("plan_",f,"!")
     @eval begin
         function $f{T<:fftwComplex}(X::StridedArray{T}, region)
             Y = similar(X, T)
@@ -503,8 +503,8 @@ normalization(X::StridedArray) = 1 / length(X)
 # Normalized ifft inverse transforms:
 
 for (f,fb) in ((:ifft,:bfft), (:ifft!,:bfft!))
-    pf = symbol(string("plan_", f))
-    pfb = symbol(string("plan_", fb))
+    pf = symbol("plan_", f)
+    pfb = symbol("plan_", fb)
     @eval begin
         $f(X, region) = scale!($fb(X, region), normalization(X, region))
         $f(X) = scale!($fb(X), normalization(X))

--- a/base/math.jl
+++ b/base/math.jl
@@ -59,7 +59,7 @@ macro evalpoly(z, p...)
     b = :($(esc(p[end-1])))
     as = []
     for i = length(p)-2:-1:1
-        ai = symbol(string("a", i))
+        ai = symbol("a", i)
         push!(as, :($ai = $a))
         a = :($b + r*$ai)
         b = :($(esc(p[i])) - s * $ai)

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -219,7 +219,7 @@ for (fname, Op) in [(:sum, :AddFun), (:prod, :MulFun),
                     (:maximum, :MaxFun), (:minimum, :MinFun),
                     (:all, :AndFun), (:any, :OrFun)]
 
-    fname! = symbol(string(fname, '!'))
+    fname! = symbol(fname, '!')
     @eval begin
         $(fname!)(f::Union(Function,Func{1}), r::AbstractArray, A::AbstractArray; init::Bool=true) =
             mapreducedim!(f, $(Op)(), initarray!(r, $(Op)(), init), A)
@@ -235,8 +235,8 @@ for (fname, fbase, Fun) in [(:sumabs, :sum, :AbsFun),
                             (:sumabs2, :sum, :Abs2Fun),
                             (:maxabs, :maximum, :AbsFun),
                             (:minabs, :minimum, :AbsFun)]
-    fname! = symbol(string(fname, '!'))
-    fbase! = symbol(string(fbase, '!'))
+    fname! = symbol(fname, '!')
+    fbase! = symbol(fbase, '!')
     @eval begin
         $(fname!)(r::AbstractArray, A::AbstractArray; init::Bool=true) =
             $(fbase!)($(Fun)(), r, A; init=init)

--- a/base/special/bessel.jl
+++ b/base/special/bessel.jl
@@ -1,7 +1,7 @@
 for jy in ("j","y"), nu in (0,1)
-    jynu = Expr(:quote, symbol(string(jy,nu)))
-    jynuf = Expr(:quote, symbol(string(jy,nu,"f")))
-    bjynu = symbol(string("bessel",jy,nu))
+    jynu = Expr(:quote, symbol(jy,nu))
+    jynuf = Expr(:quote, symbol(jy,nu,"f"))
+    bjynu = symbol("bessel",jy,nu)
     if jy == "y"
         @eval begin
             $bjynu(x::Float64) = nan_dom_err(ccall(($jynu,libm),  Float64, (Float64,), x), x)
@@ -15,7 +15,7 @@ for jy in ("j","y"), nu in (0,1)
     end
     @eval begin
         $bjynu(x::Real) = $bjynu(float(x))
-        $bjynu(x::Complex) = $(symbol(string("bessel",jy)))($nu,x)
+        $bjynu(x::Complex) = $(symbol("bessel",jy))($nu,x)
         @vectorize_1arg Number $bjynu
     end
 end
@@ -365,7 +365,7 @@ function besselyx(nu::Real, x::FloatingPoint)
 end
 
 for f in ("i", "ix", "j", "jx", "k", "kx", "y", "yx")
-    bfn = symbol(string("bessel", f))
+    bfn = symbol("bessel", f)
     @eval begin
         $bfn(nu::Real, z::Complex64) = complex64($bfn(float64(nu), complex128(z)))
         $bfn(nu::Real, z::Complex) = $bfn(float64(nu), complex128(z))

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -931,7 +931,7 @@ _fd(x::IOStream) = RawFD(fd(x))
 
 for (x,writable,unix_fd,c_symbol) in ((:STDIN,false,0,:jl_uv_stdin),(:STDOUT,true,1,:jl_uv_stdout),(:STDERR,true,2,:jl_uv_stderr))
     f = symbol("redirect_"*lowercase(string(x)))
-    _f = symbol(string("_",f))
+    _f = symbol("_",f)
     @eval begin
         function ($_f)(stream)
             global $x

--- a/base/utf8proc.jl
+++ b/base/utf8proc.jl
@@ -159,7 +159,7 @@ isgraph(c::Char) = (UTF8PROC_CATEGORY_LU <= category_code(c) <= UTF8PROC_CATEGOR
 
 for name = ("alnum", "alpha", "cntrl", "digit", "number", "graph",
             "lower", "print", "punct", "space", "upper")
-    f = symbol(string("is",name))
+    f = symbol("is",name)
     @eval begin
         function $f(s::AbstractString)
             for c in s

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -138,16 +138,20 @@ used as one building-block of expressions:
     julia> typeof(ans)
     Symbol
 
-:obj:`Symbol`\ s can also be created using :func:`symbol`, which takes
-a character or string as its argument:
+:obj:`Symbol`\ s can also be created using :func:`symbol`, which takes any
+number of arguments and creates a new symbol by concatenating their string
+representations together:
 
 .. doctest::
 
     julia> :foo == symbol("foo")
     true
 
-    julia> symbol("'")
-    :'
+    julia> symbol("func",10)
+    :func10
+
+    julia> symbol(:var,'_',"sym")
+    :var_sym
 
 In the context of an expression, symbols are used to indicate access to
 variables; when an expression is evaluated, a symbol is replaced with

--- a/doc/stdlib/strings.rst
+++ b/doc/stdlib/strings.rst
@@ -335,9 +335,9 @@
    Tests whether a character is a valid hexadecimal digit, or whether this
    is true for all elements of a string.
 
-.. function:: symbol(str) -> Symbol
+.. function:: symbol(x...) -> Symbol
 
-   Convert a string to a ``Symbol``.
+   Create a ``Symbol`` by concatenating the string representations of the arguments together.
 
 .. function:: escape_string(str::AbstractString) -> AbstractString
 

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1019,6 +1019,7 @@ let
 end
 
 @test symbol("asdf") === :asdf
+@test symbol(:abc,"def",'g',"hi",0) === :abcdefghi0
 @test startswith(string(gensym("asdf")),"##asdf#")
 @test gensym("asdf") != gensym("asdf")
 @test gensym() != gensym()


### PR DESCRIPTION
See this thread for some context: https://groups.google.com/forum/#!topic/julia-users/quK8LJxKv-Q

A few times I've wanted to combine symbols in macros, and seeing the thread got me interested in trying to implement a \* method that combines without a string intermediate. Results:

```
julia> @time for i=1:1_000_000
       :abc * :def
       end
elapsed time: 0.304592634 seconds (208000000 bytes allocated, 26.69% gc time)

julia> @time for i=1:1_000_000
       symbol(string(:abc,:def))
       end
elapsed time: 0.843511444 seconds (300000000 bytes allocated, 13.45% gc time)
```

(However, because it creates an intermediate byte array for each \* operation, it has worse performance when you combine 4 or more symbols in a single call.)

Would like some comments on whether this would be good functionality to have, and if so, how the implementation might be improved as I'm still a total novice regarding the Julia internals.
