### PR TITLE
Fix and test reducedim with init=false

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -165,7 +165,7 @@ end
         nslices = div(length(A), lsiz)
         ibase = 0
         for i = 1:nslices
-            @inbounds R[i] = mapreduce_impl(f, op, A, ibase+1, ibase+lsiz)
+            @inbounds R[i] = op(R[i], mapreduce_impl(f, op, A, ibase+1, ibase+lsiz))
             ibase += lsiz
         end
     elseif size(R, 1) == 1 && sizA1 > 1
@@ -301,5 +301,3 @@ findmax!{R}(rval::AbstractArray{R}, rind::AbstractArray, A::AbstractArray; init:
 findmax{T}(A::AbstractArray{T}, region) =
     isempty(A) ? (similar(A,reduced_dims0(A,region)), zeros(Int,reduced_dims0(A,region))) :
                   _findmax!(reducedim_initarray0(A, region, typemin(T)), zeros(Int,reduced_dims0(A,region)), A)
-
-

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -28,6 +28,25 @@ for region in Any[
     @test_approx_eq maxabs!(r, Areduc) safe_maxabs(Areduc, region)
     @test_approx_eq minabs!(r, Areduc) safe_minabs(Areduc, region)
 
+    # With init=false
+    r2 = similar(r)
+    fill!(r, 1)
+    @test_approx_eq sum!(r, Areduc, init=false) safe_sum(Areduc, region)+1
+    fill!(r, 2.2)
+    @test_approx_eq prod!(r, Areduc, init=false) safe_prod(Areduc, region)*2.2
+    fill!(r, 1.8)
+    @test_approx_eq maximum!(r, Areduc, init=false) fill!(r2, 1.8)
+    fill!(r, -0.2)
+    @test_approx_eq minimum!(r, Areduc, init=false) fill!(r2, -0.2)
+    fill!(r, 8.1)
+    @test_approx_eq sumabs!(r, Areduc, init=false) safe_sumabs(Areduc, region)+8.1
+    fill!(r, 8.1)
+    @test_approx_eq sumabs2!(r, Areduc, init=false) safe_sumabs2(Areduc, region)+8.1
+    fill!(r, 1.5)
+    @test_approx_eq maxabs!(r, Areduc, init=false) fill!(r2, 1.5)
+    fill!(r, -1.5)
+    @test_approx_eq minabs!(r, Areduc, init=false) fill!(r2, -1.5)
+
     @test_approx_eq sum(Areduc, region) safe_sum(Areduc, region)
     @test_approx_eq prod(Areduc, region) safe_prod(Areduc, region)
     @test_approx_eq maximum(Areduc, region) safe_maximum(Areduc, region)
@@ -48,6 +67,23 @@ r = fill(NaN, Base.reduced_dims(size(Breduc), 1))
 @test_approx_eq sum(Breduc, 1) safe_sum(Breduc, 1)
 @test_approx_eq sumabs(Breduc, 1) safe_sumabs(Breduc, 1)
 @test_approx_eq sumabs2(Breduc, 1) safe_sumabs2(Breduc, 1)
+
+fill!(r, 4.2)
+@test_approx_eq sum!(r, Breduc, init=false) safe_sum(Breduc, 1)+4.2
+fill!(r, -6.3)
+@test_approx_eq sumabs!(r, Breduc, init=false) safe_sumabs(Breduc, 1)-6.3
+fill!(r, -1.1)
+@test_approx_eq sumabs2!(r, Breduc, init=false) safe_sumabs2(Breduc, 1)-1.1
+
+# Small arrays with init=false
+A = reshape(1:15, 3, 5)
+R = ones(Int, 3)
+@test sum!(R, A, init=false) == [36,41,46]
+R = ones(Int, 1, 5)
+@test sum!(R, A, init=false) == [7 16 25 34 43]
+R = [2]
+A = reshape(1:6, 3, 2)
+@test prod!(R, A, init=false) == [1440]
 
 # Small integers
 @test @inferred(sum(Int8[1], 1)) == [1]


### PR DESCRIPTION
This was a bit tricky to debug because we have several different branches depending on array size & type. Hopefully these new tests cover all the cases.

Presumably, this needs @juliabackports (this existed even before the previous commit to touch this line, 99193d97a2e18f02f7f6212ad9ac9348b7959ad1).
