### PR TITLE
re-enable the bell ("beep")

### DIFF
--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -181,7 +181,7 @@ end
 
 clear(t::UnixTerminal) = write(t.out_stream, "\x1b[H\x1b[2J")
 clear_line(t::UnixTerminal) = write(t.out_stream, "\x1b[0G\x1b[0K")
-beep(t::UnixTerminal) = write(t.err_stream,"\x7")
+beep(t::UnixTerminal) = haskey(ENV, "JULIA_NO_BELL") || write(t.err_stream,"\x7")
 
 write{T,N}(t::UnixTerminal, a::Array{T,N}) = write(t.out_stream, a)
 write(t::UnixTerminal, p::Ptr{UInt8}) = write(t.out_stream, p)

--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -181,7 +181,7 @@ end
 
 clear(t::UnixTerminal) = write(t.out_stream, "\x1b[H\x1b[2J")
 clear_line(t::UnixTerminal) = write(t.out_stream, "\x1b[0G\x1b[0K")
-#beep(t::UnixTerminal) = write(t.err_stream,"\x7")
+beep(t::UnixTerminal) = write(t.err_stream,"\x7")
 
 write{T,N}(t::UnixTerminal, a::Array{T,N}) = write(t.out_stream, a)
 write(t::UnixTerminal, p::Ptr{UInt8}) = write(t.out_stream, p)


### PR DESCRIPTION
Feedback is important. When I hit `tab` I shouldn't be stuck wondering
if the system isn't responding, or if there are just no completions.

I also agree with those that hate the audio bell but what to do with
'\a' is a terminal setting, and most terminals can be configured to
give a visual bell (a brief flash), or disable completely. So this is
not something that each shell/program needs to also have configuration
for.

How to configure the bell for assorted terminals:

  OSX: http://superuser.com/questions/163994/how-can-i-get-the-mac-terminal-to-not-beep
  Gnome Terminal: Edit -> Profile Preferences -> Terminal Bell
  KDE Konsole: Settings -> Configure Notifications
  XTerm: add the following to .Xdefaults/.Xresources: xterm_visualBell:true
  URxvt: add the following to .Xdefaults/.Xresources: URxvt_visualBell:true
  XWindows: disable across all programs by runnings: xset b off

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/julialang/julia/9710)
<!-- Reviewable:end -->
