### PR TITLE
Check `done` before `next` in the fallback `first`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -24,7 +24,7 @@ ndims{T<:AbstractArray}(::Type{T}) = ndims(super(T))
 length(t::AbstractArray) = prod(size(t))::Int
 endof(a::AbstractArray) = length(a)
 first(a::AbstractArray) = a[1]
-first(a) = next(a,start(a))[1]
+first(a) = (s = start(a); done(a, s) ? error("collection is empty") : next(a, s)[1])
 last(a) = a[end]
 ctranspose(a::AbstractArray) = error("ctranspose not implemented for $(typeof(a)). Consider adding parentheses, e.g. A*(B*C') instead of A*B*C' to avoid explicit calculation of the transposed matrix.")
 transpose(a::AbstractArray) = error("transpose not implemented for $(typeof(a)). Consider adding parentheses, e.g. A*(B*C.') instead of A*B*C' to avoid explicit calculation of the transposed matrix.")

--- a/test/collections.jl
+++ b/test/collections.jl
@@ -91,6 +91,9 @@ let
     @test typeof(d) == typeof(d2) == typeof(d3) == Dict{Any,Any}
 end
 
+@test_throws ErrorException first(Dict())
+@test first(Dict(:f=>2)) == (:f,2)
+
 # issue #1821
 let
     d = Dict{UTF8String, Vector{Int}}()
@@ -499,6 +502,10 @@ s3 = Set{ASCIIString}(["baz"])
 
 @test !isequal(Set{Any}([1,2,3,4]), Set{Int}([1,2,3]))
 @test !isequal(Set{Int}([1,2,3,4]), Set{Any}([1,2,3]))
+
+@test_throws ErrorException first(Set())
+@test first(Set(2)) == 2
+
 
 # ########## end of set tests ##########
 


### PR DESCRIPTION
The fallback `first` method for Any types wasn't checking the done status between `start` and `next`.  This simple patch simply adds a check and error message that is a bit more sensible than current errors.

Currently:

``` julia
julia> first(Dict())
ERROR: BoundsError: attempt to access 16-element Array{Any,1}:
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
 #undef
  at index [17]
 in first at abstractarray.jl:27
```

With this patch:

``` julia
julia> first(Dict())
ERROR: collection is empty
 in first at abstractarray.jl:27
```

(I don't think there's a better error type to throw here as it will depend on the type if it's a BoundsError or KeyError or such. Cc @jakebolewski since you've been doing some error message cleanups along these lines.)
