### PR TITLE
use default SIGPIPE handler by default, enable backtrace on SIGPIPE for tests

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -619,3 +619,14 @@ wait(x::Process)      = if !process_exited(x); stream_wait(x, x.exitnotify); end
 wait(x::ProcessChain) = for p in x.processes; wait(p); end
 
 show(io::IO, p::Process) = print(io, "Process(", p.cmd, ", ", process_status(p), ")")
+
+@unix_only function set_signal_act_die(sig)
+    err = ccall(:jl_set_signal_act_die, Int, (Int,), sig)
+    if err != 0
+        error("Couldn't set signal handler for $sig: $(strerror(err))")
+    end
+end
+
+@unix_only function set_sigpipe_act_die()
+    set_signal_act_die(SIGPIPE)
+end

--- a/base/process.jl
+++ b/base/process.jl
@@ -623,7 +623,7 @@ show(io::IO, p::Process) = print(io, "Process(", p.cmd, ", ", process_status(p),
 @unix_only function set_signal_act_die(sig)
     err = ccall(:jl_set_signal_act_die, Int, (Int,), sig)
     if err != 0
-        error("Couldn't set signal handler for $sig: $(strerror(err))")
+        throw(SystemError("Couldn't set signal handler for $sig", err))
     end
 end
 

--- a/src/init.c
+++ b/src/init.c
@@ -903,6 +903,22 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
         jl_compileropts.build_path = abspath(jl_compileropts.build_path);
 }
 
+#ifndef _OS_WINDOWS_
+DLLEXPORT int
+jl_set_signal_act_die(int sig)
+{
+    struct sigaction act_die;
+    memset(&act_die, 0, sizeof(struct sigaction));
+    sigemptyset(&act_die.sa_mask);
+    act_die.sa_sigaction = sigdie_handler;
+    act_die.sa_flags = SA_SIGINFO;
+    if (sigaction(SIGPIPE, &act_die, NULL) < 0) {
+        return errno;
+    }
+    return 0;
+}
+#endif
+
 void _julia_init(JL_IMAGE_SEARCH rel)
 {
     libsupport_init();
@@ -1046,10 +1062,6 @@ void _julia_init(JL_IMAGE_SEARCH rel)
         JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
         jl_exit(1);
     }
-    if (signal(SIGPIPE,SIG_IGN) == SIG_ERR) {
-        JL_PRINTF(JL_STDERR, "fatal error: Couldn't set SIGPIPE\n");
-        jl_exit(1);
-    }
 #if defined (_OS_DARWIN_)
     kern_return_t ret;
     mach_port_t self = mach_task_self();
@@ -1124,10 +1136,6 @@ void _julia_init(JL_IMAGE_SEARCH rel)
         jl_exit(1);
     }
     if (sigaction(SIGSYS, &act_die, NULL) < 0) {
-        JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
-        jl_exit(1);
-    }
-    if (sigaction(SIGPIPE, &act_die, NULL) < 0) {
         JL_PRINTF(JL_STDERR, "fatal error: sigaction: %s\n", strerror(errno));
         jl_exit(1);
     }

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ cd(dirname(@__FILE__)) do
     end
 
     @everywhere include("testdefs.jl")
+    @unix_only Base.set_sigpipe_act_die()
 
     reduce(propagate_errors, nothing, pmap(runtests, tests; err_retry=false, err_stop=true))
 

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -2,6 +2,7 @@ using Base.Test
 
 function runtests(name)
     println("     \033[1m*\033[0m \033[31m$(name)\033[0m")
+    @unix_only Base.set_sigpipe_act_die()
     Core.include("$name.jl")
     nothing
 end


### PR DESCRIPTION
Fix #9719.

This implement the 1 and 2 [discussed in #9719](https://github.com/JuliaLang/julia/issues/9719#issuecomment-69485778)
1. Use the default handler on SIGPIPE by default
2. Set the backgrace handler in runtest

I haven't checked how does multiprocessing handle child process terminated by signal but the behavior with runtests should be the same with before and it should probably be discussed somewhere else if the handling of child signal really has an issue.

I'm not sure how/whether to handle windows and I'm also not very good at coming up with good function names so suggestions are definitely welcome........

```
yyc2:~/projects/contrib/julia
yuyichao% LANG=C ./julia -f -e 'sleep(1); println()' | :
yyc2:~/projects/contrib/julia
yuyichao% LANG=C ./julia -f -e 'Base.set_sigpipe_act_die(); sleep(1); println()' | :
ERROR: Couldn't set signal handler for 13: Success
 in error at ./error.jl:21
 in set_sigpipe_act_die at ./process.jl:629
 in process_options at ./client.jl:234
 in _start at ./client.jl:396

signal (13): Broken pipe
write at /usr/lib/libpthread.so.0 (unknown line)
uv__write at /home/yuyichao/projects/contrib/julia/deps/libuv/src/unix/stream.c:798
uv_write2 at /home/yuyichao/projects/contrib/julia/deps/libuv/src/unix/stream.c:1343
uv_write at /home/yuyichao/projects/contrib/julia/deps/libuv/src/unix/stream.c:1369
jl_write_copy at /home/yuyichao/projects/contrib/julia/src/jl_uv.c:541
jl_putc_copy at /home/yuyichao/projects/contrib/julia/src/jl_uv.c:595
jl_pututf8_copy at /home/yuyichao/projects/contrib/julia/src/jl_uv.c:613
write at ./stream.jl:732
println at ./string.jl:5
jl_apply_generic at /home/yuyichao/projects/contrib/julia/src/gf.c:1644
_start at ./client.jl:444
jlcall__start_40668 at /home/yuyichao/projects/contrib/julia/usr/lib/julia/sys.so (unknown line)
jl_apply_generic at /home/yuyichao/projects/contrib/julia/src/gf.c:1646
unknown function (ip: 4200066)
unknown function (ip: 4199034)
__libc_start_main at /usr/lib/libc.so.6 (unknown line)
unknown function (ip: 4199109)
unknown function (ip: 0)
```
