### PR TITLE
optimize primary constructors of Core types

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -266,12 +266,13 @@ TypeConstructor(p::ANY, t::ANY) = ccall(:jl_new_type_constructor, Any, (Any, Any
 
 Expr(args::ANY...) = _expr(args...)
 
-LineNumberNode(n::Int) = ccall(:jl_new_struct, Any, (Any,Any...), LineNumberNode, n)::LineNumberNode
-LabelNode(n::Int) = ccall(:jl_new_struct, Any, (Any,Any...), LabelNode, n)::LabelNode
-GotoNode(n::Int) = ccall(:jl_new_struct, Any, (Any,Any...), GotoNode, n)::GotoNode
-QuoteNode(x::ANY) = ccall(:jl_new_struct, Any, (Any,Any...), QuoteNode, x)::QuoteNode
-NewvarNode(s::Symbol) = ccall(:jl_new_struct, Any, (Any,Any...), NewvarNode, s)::NewvarNode
-TopNode(s::Symbol) = ccall(:jl_new_struct, Any, (Any,Any...), TopNode, s)::TopNode
+_new(typ::Symbol, argty::Symbol) = eval(:(Core.call(::$(Expr(:call, :(Core.apply_type), :Type, typ)), n::$argty) = $(Expr(:new, typ, :n))))
+_new(:LineNumberNode, :Int)
+_new(:LabelNode, :Int)
+_new(:GotoNode, :Int)
+_new(:TopNode, :Symbol)
+_new(:NewvarNode, :Symbol)
+_new(:QuoteNode, :ANY)
 
 Module(name::Symbol) = ccall(:jl_f_new_module, Any, (Any,), name)::Module
 Module() = Module(:anonymous)


### PR DESCRIPTION
this allows julia to optimize the Core type constructors

``` julia
julia> f() = TopNode(:asdf)
f (generic function with 1 method)

julia> code_typed(f,())
1-element Array{Any,1}:
 :($(Expr(:lambda, Any[], Any[Any[],Any[],Any[]], :(begin  # none, line 1:
        return $(Expr(:new, :TopNode, :(:asdf)))
    end::TopNode))))

julia> code_llvm(f,())

define %jl_value_t* @julia_f_42804() {
top:
  %0 = call %jl_value_t* @allocobj(i64 16), !dbg !642
  %1 = getelementptr inbounds %jl_value_t* %0, i64 0, i32 0, !dbg !642
  store %jl_value_t* inttoptr (i64 19729664 to %jl_value_t*), %jl_value_t** %1, align 8, !dbg !642
  %2 = getelementptr inbounds %jl_value_t* %0, i64 1, i32 0, !dbg !642
  store %jl_value_t* inttoptr (i64 140523989960712 to %jl_value_t*), %jl_value_t** %2, align 8, !dbg !642
  ret %jl_value_t* %0, !dbg !642
}

julia> f(x) = GotoNode(x)
f (generic function with 2 methods)

julia> f(2)
:(goto 2)

julia> code_llvm(f,(Int,))

define %GotoNode @julia_f_42866(i64) {
top:
  %1 = insertvalue %GotoNode undef, i64 %0, 0, !dbg !822, !julia_type !824
  ret %GotoNode %1, !dbg !822
}
```
