### PR TITLE
Minor code and style improvements in ui/repl.c

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -205,37 +205,30 @@ static int bits_equal(void *a, void *b, int sz)
     }
 }
 
-int jl_egal(jl_value_t *a, jl_value_t *b)
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+static int __declspec(noinline)
+#else
+static int __attribute__((noinline))
+#endif
+compare_tuple(jl_value_t *a, jl_value_t *b)
 {
-    if (a == b)
-        return 1;
-    jl_value_t *ta = (jl_value_t*)jl_typeof(a);
-    if (ta != (jl_value_t*)jl_typeof(b))
+    size_t l = jl_tuple_len(a);
+    if (l != jl_tuple_len(b))
         return 0;
-    if (jl_is_tuple(a)) {
-        size_t l = jl_tuple_len(a);
-        if (l != jl_tuple_len(b))
+    for(size_t i=0; i < l; i++) {
+        if (!jl_egal(jl_tupleref(a,i),jl_tupleref(b,i)))
             return 0;
-        for(size_t i=0; i < l; i++) {
-            if (!jl_egal(jl_tupleref(a,i),jl_tupleref(b,i)))
-                return 0;
-        }
-        return 1;
     }
-    jl_datatype_t *dt = (jl_datatype_t*)ta;
-    if (dt == jl_datatype_type) {
-        jl_datatype_t *dta = (jl_datatype_t*)a;
-        jl_datatype_t *dtb = (jl_datatype_t*)b;
-        return dta->name == dtb->name &&
-            jl_egal((jl_value_t*)dta->parameters, (jl_value_t*)dtb->parameters);
-    }
-    if (dt->mutabl) return 0;
-    size_t sz = dt->size;
-    if (sz == 0) return 1;
-    size_t nf = jl_tuple_len(dt->names);
-    if (nf == 0) {
-        return bits_equal(jl_data_ptr(a), jl_data_ptr(b), sz);
-    }
+    return 1;
+}
+
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+static int __declspec(noinline)
+#else
+static int __attribute__((noinline))
+#endif
+compare_fields(jl_value_t *a, jl_value_t *b, jl_datatype_t *dt, size_t nf)
+{
     for (size_t f=0; f < nf; f++) {
         size_t offs = dt->fields[f].offset;
         char *ao = (char*)jl_data_ptr(a) + offs;
@@ -254,6 +247,32 @@ int jl_egal(jl_value_t *a, jl_value_t *b)
         if (!eq) return 0;
     }
     return 1;
+}
+
+int jl_egal(jl_value_t *a, jl_value_t *b)
+{
+    if (a == b)
+        return 1;
+    jl_value_t *ta = (jl_value_t*)jl_typeof(a);
+    if (ta != (jl_value_t*)jl_typeof(b))
+        return 0;
+    if (jl_is_tuple(a))
+        return compare_tuple(a, b);
+    jl_datatype_t *dt = (jl_datatype_t*)ta;
+    if (dt == jl_datatype_type) {
+        jl_datatype_t *dta = (jl_datatype_t*)a;
+        jl_datatype_t *dtb = (jl_datatype_t*)b;
+        return dta->name == dtb->name &&
+            jl_egal((jl_value_t*)dta->parameters, (jl_value_t*)dtb->parameters);
+    }
+    if (dt->mutabl) return 0;
+    size_t sz = dt->size;
+    if (sz == 0) return 1;
+    size_t nf = jl_tuple_len(dt->names);
+    if (nf == 0) {
+        return bits_equal(jl_data_ptr(a), jl_data_ptr(b), sz);
+    }
+    return compare_fields(a, b, dt, nf);
 }
 
 JL_CALLABLE(jl_f_is)

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -127,8 +127,16 @@
 #  define STATIC_INLINE static __inline
 #  define INLINE __inline
 #else
-# define STATIC_INLINE static inline
-# define INLINE inline
+#  define STATIC_INLINE static inline
+#  define INLINE inline
+#endif
+
+#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
+#  define NOINLINE __declspec(noinline)
+#  define NOINLINE_DECL(f) __declspec(noinline) f
+#else
+#  define NOINLINE __attribute__((noinline))
+#  define NOINLINE_DECL(f) f __attribute__((noinline))
 #endif
 
 typedef int bool_t;

--- a/src/task.c
+++ b/src/task.c
@@ -74,11 +74,7 @@ static void boundlow(struct _probe_data *p)
 }
 
 // we need this function to exist so we can measure its stack frame!
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
-static void __declspec(noinline) fill(struct _probe_data *p);
-#else
-static void fill(struct _probe_data *p) __attribute__ ((noinline));
-#endif
+static void NOINLINE_DECL(fill(struct _probe_data *p));
 
 static void fill(struct _probe_data *p)
 {
@@ -166,12 +162,7 @@ void *jl_stackbase;
 static jl_jmp_buf jl_base_ctx; // base context of stack
 #endif
 
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
-static void __declspec(noinline)
-#else
-static void __attribute__((noinline))
-#endif
-save_stack(jl_task_t *t)
+static void NOINLINE save_stack(jl_task_t *t)
 {
     if (t->state == done_sym || t->state == failed_sym)
         return;
@@ -190,12 +181,7 @@ save_stack(jl_task_t *t)
     memcpy(buf, (char*)&_x, nb);
 }
 
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
-void __declspec(noinline)
-#else
-void __attribute__((noinline))
-#endif
-restore_stack(jl_task_t *t, jl_jmp_buf *where, char *p)
+void NOINLINE restore_stack(jl_task_t *t, jl_jmp_buf *where, char *p)
 {
     char *_x = (char*)jl_stackbase - t->ssize;
     if (!p) {
@@ -235,12 +221,7 @@ static void NORETURN finish_task(jl_task_t *t, jl_value_t *resultval)
     abort();
 }
 
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
-static void __declspec(noinline)
-#else
-static void __attribute__((noinline))
-#endif
-NORETURN start_task()
+static void NOINLINE NORETURN start_task()
 {
     // this runs the first time we switch to a task
     jl_task_t *t = jl_current_task;
@@ -251,12 +232,7 @@ NORETURN start_task()
 }
 
 #ifndef ASM_COPY_STACKS
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
-static void __declspec(noinline)
-#else
-static void __attribute__((noinline))
-#endif
-set_base_ctx(char *__stk)
+static void NOINLINE set_base_ctx(char *__stk)
 {
     if (jl_setjmp(jl_base_ctx, 1)) {
         start_task();

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -42,8 +42,8 @@ static int malloclog= JL_LOG_NONE;
 static char *program = NULL;
 static int imagepathspecified = 0;
 
-static const char *usage = "julia [options] [program] [args...]\n";
-static const char *opts =
+static const char usage[] = "julia [options] [program] [args...]\n";
+static const char opts[] =
     " -v, --version            Display version information\n"
     " -h, --help               Print this message\n"
     " -q, --quiet              Quiet startup without banner\n"
@@ -80,8 +80,16 @@ static const char *opts =
 
 void parse_opts(int *argcp, char ***argvp)
 {
-    static char* shortopts = "+H:hJ:C:O";
-    static struct option longopts[] = {
+    enum {
+	opt_check_bounds = 300,
+	opt_int_literals,
+	opt_dump_bitcode,
+	opt_compile,
+	opt_depwarn,
+	opt_inline
+    };
+    static const char shortopts[] = "+H:hJ:C:O";
+    static const struct option longopts[] = {
         { "home",          required_argument, 0, 'H' },
         { "build",         required_argument, 0, 'b' },
         { "lisp",          no_argument,       &lisp_prompt, 1 },
@@ -90,13 +98,13 @@ void parse_opts(int *argcp, char ***argvp)
         { "code-coverage", optional_argument, 0, 'c' },
         { "cpu-target",    required_argument, 0, 'C' },
         { "track-allocation",required_argument, 0, 'm' },
-        { "check-bounds",  required_argument, 0, 300 },
+        { "check-bounds",  required_argument, 0, opt_check_bounds },
         { "optimize",      no_argument,       0, 'O' },
-        { "int-literals",  required_argument, 0, 301 },
-        { "dump-bitcode",  required_argument, 0, 302 },
-        { "compile",       required_argument, 0, 303 },
-        { "depwarn",       required_argument, 0, 304 },
-        { "inline",        required_argument, 0, 305 },
+        { "int-literals",  required_argument, 0, opt_int_literals },
+        { "dump-bitcode",  required_argument, 0, opt_dump_bitcode },
+        { "compile",       required_argument, 0, opt_compile },
+        { "depwarn",       required_argument, 0, opt_depwarn },
+        { "inline",        required_argument, 0, opt_inline },
         { 0, 0, 0, 0 }
     };
     int c;
@@ -156,13 +164,13 @@ void parse_opts(int *argcp, char ***argvp)
                     malloclog = JL_LOG_NONE;
                 break;
             }
-        case 300:
+        case opt_check_bounds:
             if (!strcmp(optarg,"yes"))
                 jl_compileropts.check_bounds = JL_COMPILEROPT_CHECK_BOUNDS_ON;
             else if (!strcmp(optarg,"no"))
                 jl_compileropts.check_bounds = JL_COMPILEROPT_CHECK_BOUNDS_OFF;
             break;
-        case 301:
+        case opt_int_literals:
             if (!strcmp(optarg,"32"))
                 jl_compileropts.int_literals = 32;
             else if (!strcmp(optarg,"64"))
@@ -172,13 +180,13 @@ void parse_opts(int *argcp, char ***argvp)
                 exit(1);
             }
             break;
-        case 302:
+        case opt_dump_bitcode:
             if (!strcmp(optarg,"yes"))
                 jl_compileropts.dumpbitcode = JL_COMPILEROPT_DUMPBITCODE_ON;
             else if (!strcmp(optarg,"no"))
                 jl_compileropts.dumpbitcode = JL_COMPILEROPT_DUMPBITCODE_OFF;
             break;
-        case 303:
+        case opt_compile:
             if (!strcmp(optarg,"yes"))
                 jl_compileropts.compile_enabled = 1;
             else if (!strcmp(optarg,"no"))
@@ -190,7 +198,7 @@ void parse_opts(int *argcp, char ***argvp)
                 exit(1);
             }
             break;
-        case 304:
+        case opt_depwarn:
             if (!strcmp(optarg,"yes"))
                 jl_compileropts.depwarn = 1;
             else if (!strcmp(optarg,"no"))
@@ -200,7 +208,7 @@ void parse_opts(int *argcp, char ***argvp)
                 exit(1);
             }
             break;
-        case 305:      /* inline */
+        case opt_inline:      /* inline */
             if (!strcmp(optarg,"yes"))
                 jl_compileropts.can_inline = 1;
             else if (!strcmp(optarg,"no"))


### PR DESCRIPTION
- use array variables instead of pointers
- add const where possible
- use enums to assign values for high getopt options insteaf of
  possibly error-prone manual assignment.  Also documents the
  code better
