### PR TITLE
Specialize findprev for BitArrays

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1377,11 +1377,13 @@ end
 function findnext(testf::Function, B::BitArray, start::Integer)
     f0::Bool = testf(false)
     f1::Bool = testf(true)
-    length(B) == 0 && return 0
-    f0 || f1 || return 0
-    f0 && f1 && return 1
     !f0 && f1 && return findnext(B, start)
-    return findnextnot(B, start)
+    f0 && !f1 && return findnextnot(B, start)
+
+    start > 0 || throw(BoundsError(B, start))
+    start > length(B) && return 0
+    f0 && f1 && return Int(start)
+    return 0 # last case: !f0 && !f1
 end
 #findfirst(testf::Function, B::BitArray) = findnext(testf, B, 1)  ## defined in array.jl
 

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1385,6 +1385,76 @@ function findnext(testf::Function, B::BitArray, start::Integer)
 end
 #findfirst(testf::Function, B::BitArray) = findnext(testf, B, 1)  ## defined in array.jl
 
+# returns the index of the previous non-zero element, or 0 if all zeros
+function findprev(B::BitArray, start::Integer)
+    start > 0 || return 0
+    start > length(B) && throw(BoundsError(B, start))
+
+    Bc = B.chunks
+
+    chunk_start = _div64(start-1)+1
+    mask = _msk_end(start)
+
+    @inbounds begin
+        if Bc[chunk_start] & mask != 0
+            return (chunk_start-1) << 6 + (64 - leading_zeros(Bc[chunk_start] & mask))
+        end
+
+        for i = chunk_start-1:-1:1
+            if Bc[i] != 0
+                return (i-1) << 6 + (64 - leading_zeros(Bc[i]))
+            end
+        end
+    end
+    return 0
+end
+
+function findprevnot(B::BitArray, start::Integer)
+    start > 0 || return 0
+    start > length(B) && throw(BoundsError(B, start))
+
+    Bc = B.chunks
+
+    chunk_start = _div64(start-1)+1
+    mask = ~_msk_end(start)
+
+    @inbounds begin
+        if Bc[chunk_start] | mask != _msk64
+            return (chunk_start-1) << 6 + (64 - leading_ones(Bc[chunk_start] | mask))
+        end
+
+        for i = chunk_start-1:-1:1
+            if Bc[i] != _msk64
+                return (i-1) << 6 + (64 - leading_ones(Bc[i]))
+            end
+        end
+    end
+    return 0
+end
+findlastnot(B::BitArray) = findprevnot(B, length(B))
+
+# returns the index of the previous matching element
+function findprev(B::BitArray, v, start::Integer)
+    v == false && return findprevnot(B, start)
+    v == true && return findprev(B, start)
+    return 0
+end
+#findlast(B::BitArray, v) = findprev(B, 1, v)  ## defined in array.jl
+
+# returns the index of the previous element for which the function returns true
+function findprev(testf::Function, B::BitArray, start::Integer)
+    f0::Bool = testf(false)
+    f1::Bool = testf(true)
+    !f0 && f1 && return findprev(B, start)
+    f0 && !f1 && return findprevnot(B, start)
+
+    start > 0 || return 0
+    start > length(B) && throw(BoundsError(B, start))
+    f0 && f1 && return Int(start)
+    return 0 # last case: !f0 && !f1
+end
+#findlast(testf::Function, B::BitArray) = findprev(testf, B, 1)  ## defined in array.jl
+
 function find(B::BitArray)
     l = length(B)
     nnzB = countnz(B)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -873,6 +873,122 @@ b1 = bitrand(n1, n2)
 
 timesofar("nnz&find")
 
+## Findnext/findprev ##
+B = trues(100)
+B′ = falses(100)
+for i=1:100
+    @test findprev(B,i)     == findprev(B,true,i) == findprev(identity,B,i)
+          Base.findprevnot(B′,i) == findprev(!,B′,i)   == i
+end
+
+odds = bitbroadcast(isodd, 1:2000)
+evens = bitbroadcast(iseven, 1:2000)
+for i=1:2:2000
+    @test findprev(odds,i)  == Base.findprevnot(evens,i) == i
+    @test findnext(odds,i)  == Base.findnextnot(evens,i) == i
+    @test findprev(evens,i) == Base.findprevnot(odds,i)  == i-1
+    @test findnext(evens,i) == Base.findnextnot(odds,i)  == (i < 2000 ? i+1 : 0)
+end
+for i=2:2:2000
+    @test findprev(odds,i)  == Base.findprevnot(evens,i) == i-1
+    @test findprev(evens,i) == Base.findprevnot(odds,i)  == i
+    @test findnext(evens,i) == Base.findnextnot(odds,i)  == i
+    @test findnext(odds,i)  == Base.findnextnot(evens,i) == (i < 2000 ? i+1 : 0)
+end
+
+elts = (1:64:64*64+1) .+ (0:64)
+B1 = falses(maximum(elts))
+B1[elts] = true
+B1′ = ~B1
+B2 = fill!(Array(Bool, maximum(elts)), false)
+B2[elts] = true
+@test B1 == B2
+@test all(B1 .== B2)
+for i=1:length(maximum(elts))
+    @test findprev(B1,i) == findprev(B2, i) == Base.findprevnot(B1′, i) == findprev(!, B1′, i)
+    @test findnext(B1,i) == findnext(B2, i) == Base.findnextnot(B1′, i) == findnext(!, B1′, i)
+end
+B1 = ~B1
+B2 = ~B2
+B1′ = ~B1
+@test B1 == B2
+@test all(B1 .== B2)
+for i=1:length(maximum(elts))
+    @test findprev(B1,i) == findprev(B2, i) == Base.findprevnot(B1′, i) == findprev(!, B1′, i)
+    @test findnext(B1,i) == findnext(B2, i) == Base.findnextnot(B1′, i) == findnext(!, B1′, i)
+end
+
+B = falses(1000)
+B[77] = true
+B[777] = true
+B′ = ~B
+@test_throws BoundsError findprev(B, 1001)
+@test_throws BoundsError Base.findprevnot(B′, 1001)
+@test_throws BoundsError findprev(!, B′, 1001)
+@test_throws BoundsError findprev(identity, B, 1001)
+@test_throws BoundsError findprev(x->false, B, 1001)
+@test_throws BoundsError findprev(x->true, B, 1001)
+@test findprev(B, 1000) == Base.findprevnot(B′, 1000) == findprev(!, B′, 1000) == 777
+@test findprev(B, 777)  == Base.findprevnot(B′, 777)  == findprev(!, B′, 777)  == 777
+@test findprev(B, 776)  == Base.findprevnot(B′, 776)  == findprev(!, B′, 776)  == 77
+@test findprev(B, 77)   == Base.findprevnot(B′, 77)   == findprev(!, B′, 77)   == 77
+@test findprev(B, 76)   == Base.findprevnot(B′, 76)   == findprev(!, B′, 76)   == 0
+@test findprev(B, -1)   == Base.findprevnot(B′, -1)   == findprev(!, B′, -1)   == 0
+@test findprev(identity, B, -1) == findprev(x->false, B, -1) == findprev(x->true, B, -1) == 0
+@test_throws BoundsError findnext(B, -1)
+@test_throws BoundsError Base.findnextnot(B′, -1)
+@test_throws BoundsError findnext(!, B′, -1)
+@test_throws BoundsError findnext(identity, B, -1)
+# @test_throws BoundsError findnext(x->false, B, -1)
+# @test_throws BoundsError findnext(x->true, B, -1)
+@test findnext(B, 1)    == Base.findnextnot(B′, 1)    == findnext(!, B′, 1)    == 77
+@test findnext(B, 77)   == Base.findnextnot(B′, 77)   == findnext(!, B′, 77)   == 77
+@test findnext(B, 78)   == Base.findnextnot(B′, 78)   == findnext(!, B′, 78)   == 777
+@test findnext(B, 777)  == Base.findnextnot(B′, 777)  == findnext(!, B′, 777)  == 777
+@test findnext(B, 778)  == Base.findnextnot(B′, 778)  == findnext(!, B′, 778)  == 0
+@test findnext(B, 1001) == Base.findnextnot(B′, 1001) == findnext(!, B′, 1001) == 0
+# @test findnext(identity, B, 1001) == findnext(x->false, B, 1001) == findnext(x->true, B, 1001) == 0
+
+@test findlast(B) == Base.findlastnot(B′) == 777
+@test findfirst(B) == Base.findfirstnot(B′) == 77
+
+emptyvec = BitVector(0)
+@test findprev(x->true, emptyvec, -1) == 0
+@test_throws BoundsError findprev(x->true, emptyvec, 1)
+# @test_throws BoundsError findnext(x->true, emptyvec, -1)
+@test findnext(x->true, emptyvec, 1) == 0
+
+B = falses(10)
+@test findprev(x->true, B, 5) == 5
+# @test findnext(x->true, B, 5) == 5
+@test findprev(x->true, B, -1) == 0
+# @test findnext(x->true, B, 11) == 0
+@test findprev(x->false, B, 5) == 0
+@test findnext(x->false, B, 5) == 0
+@test findprev(x->false, B, -1) == 0
+@test findnext(x->false, B, 11) == 0
+@test_throws BoundsError findprev(x->true, B, 11)
+# @test_throws BoundsError findnext(x->true, B, -1)
+
+for l = [1,63,64,65,127,128,129]
+    f = falses(l)
+    t = trues(l)
+    @test findprev(f, l) == Base.findprevnot(t, l) == 0
+    @test findprev(t, l) == Base.findprevnot(f, l) == l
+    B = falses(l)
+    B[end] = true
+    B′ = ~B
+    @test findprev(B, l) == Base.findprevnot(B′, l) == l
+    @test Base.findprevnot(B, l) == findprev(B′, l) == l-1
+    if l > 1
+        B = falses(l)
+        B[end-1] = true
+        B′ = ~B
+        @test findprev(B, l) == Base.findprevnot(B′, l) == l-1
+        @test Base.findprevnot(B, l) == findprev(B′, l) == l
+    end
+end
+
 ## Reductions ##
 
 b1 = bitrand(s1, s2, s3, s4)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -939,15 +939,15 @@ B′ = ~B
 @test_throws BoundsError Base.findnextnot(B′, -1)
 @test_throws BoundsError findnext(!, B′, -1)
 @test_throws BoundsError findnext(identity, B, -1)
-# @test_throws BoundsError findnext(x->false, B, -1)
-# @test_throws BoundsError findnext(x->true, B, -1)
+@test_throws BoundsError findnext(x->false, B, -1)
+@test_throws BoundsError findnext(x->true, B, -1)
 @test findnext(B, 1)    == Base.findnextnot(B′, 1)    == findnext(!, B′, 1)    == 77
 @test findnext(B, 77)   == Base.findnextnot(B′, 77)   == findnext(!, B′, 77)   == 77
 @test findnext(B, 78)   == Base.findnextnot(B′, 78)   == findnext(!, B′, 78)   == 777
 @test findnext(B, 777)  == Base.findnextnot(B′, 777)  == findnext(!, B′, 777)  == 777
 @test findnext(B, 778)  == Base.findnextnot(B′, 778)  == findnext(!, B′, 778)  == 0
 @test findnext(B, 1001) == Base.findnextnot(B′, 1001) == findnext(!, B′, 1001) == 0
-# @test findnext(identity, B, 1001) == findnext(x->false, B, 1001) == findnext(x->true, B, 1001) == 0
+@test findnext(identity, B, 1001) == findnext(x->false, B, 1001) == findnext(x->true, B, 1001) == 0
 
 @test findlast(B) == Base.findlastnot(B′) == 777
 @test findfirst(B) == Base.findfirstnot(B′) == 77
@@ -955,20 +955,20 @@ B′ = ~B
 emptyvec = BitVector(0)
 @test findprev(x->true, emptyvec, -1) == 0
 @test_throws BoundsError findprev(x->true, emptyvec, 1)
-# @test_throws BoundsError findnext(x->true, emptyvec, -1)
+@test_throws BoundsError findnext(x->true, emptyvec, -1)
 @test findnext(x->true, emptyvec, 1) == 0
 
 B = falses(10)
 @test findprev(x->true, B, 5) == 5
-# @test findnext(x->true, B, 5) == 5
+@test findnext(x->true, B, 5) == 5
 @test findprev(x->true, B, -1) == 0
-# @test findnext(x->true, B, 11) == 0
+@test findnext(x->true, B, 11) == 0
 @test findprev(x->false, B, 5) == 0
 @test findnext(x->false, B, 5) == 0
 @test findprev(x->false, B, -1) == 0
 @test findnext(x->false, B, 11) == 0
 @test_throws BoundsError findprev(x->true, B, 11)
-# @test_throws BoundsError findnext(x->true, B, -1)
+@test_throws BoundsError findnext(x->true, B, -1)
 
 for l = [1,63,64,65,127,128,129]
     f = falses(l)


### PR DESCRIPTION
This is the first part of merging my refactor of IntSets to use BitArrays (ref. [IntSets.jl](https://github.com/mbauman/IntSets.jl) and #9679).

This adds a specialized `findprev` method for BitArrays (similar to `findnext`) that searches through the array 64 bits at a time.  Here's an exaggerated example of how much this can improve performance:

``` julia
julia> b = falses(10^10); b[10] = true;

julia> findprev(b,10^10); @time findprev(b,10^10) # Before:
elapsed time: 19.229230915 seconds (13824 bytes allocated)
10

julia> findprev(b,10^10); @time findprev(b,10^10) # After:
elapsed time: 0.265889115 seconds (96 bytes allocated)
10
```

Also adds and tests an unexported `findprevnot` (like `findnextnot`).

Secondly, in the course of writing the additional tests, I discovered that there was a bug in `findnext(::Function, ::BitArray, …)`. It did not check bounds or could return the wrong result if the function was always true or always false.  This fixes it and adds tests.

cc @carlobaldassi
