### PR TITLE
WIP: Change calculation of default distribution cuts

### DIFF
--- a/base/darray.jl
+++ b/base/darray.jl
@@ -65,7 +65,7 @@ chunktype{T,N,A}(d::DArray{T,N,A}) = A
 # decide how to divide each dimension
 # returns size of chunks array
 function defaultdist(dims, procs)
-    dims = [dims...]
+    dims = vcat(dims...)
     chunks = ones(Int, length(dims))
     np = length(procs)
     f = sort!(collect(keys(factor(np))), rev=true)
@@ -94,9 +94,10 @@ end
 # get array of start indexes for dividing sz into nc chunks
 function defaultdist(sz::Int, nc::Int)
     if sz >= nc
-        round(Int,linspace(1, sz+1, nc+1))
+        d, r = divrem(sz, nc)
+        r == 0 ? vcat(1:d:sz+1) : vcat(vcat(1:d+1:sz+1), [sz+1])
     else
-        [[1:(sz+1)], zeros(Int, nc-sz)]
+        vcat(vcat(1:(sz+1)), zeros(Int, nc-sz))
     end
 end
 
@@ -111,7 +112,8 @@ function chunk_idxs(dims, chunks)
     idxs, cuts
 end
 
-function localpartindex(pmap::Array{Int})
+
+function localpartindex(pmap::AbstractArray{Int})
     mi = myid()
     for i = 1:length(pmap)
         if pmap[i] == mi

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -42,7 +42,7 @@ begin
 
     # Test that it is functionally equivalent to the standard method
     for _ = 1:25, f = [x -> 2x, x -> x^2, x -> x^2 + 2x - 1], opt = [+, *]
-        n = rand(2:50)
+        n = rand(5:50)
         arr = rand(1:100, n)
         darr = distribute(arr)
 


### PR DESCRIPTION
This change make ensures that all but the last column or row in the distribution have the same size. The old behavior would distribute a size of ten in four blocks as

``` julia
julia> diff(Base.defaultdist(10, 4))
4-element Array{Int64,1}:
 3
 2
 3
 2
```

whereas the new behavior would be

``` julia
julia> diff(Base.defaultdist(10, 4))
4-element Array{Int64,1}:
 3
 3
 3
 1
```

In general, I think it is useful to have as many as the blocks as possible to be of the same size, but the main reason for this change is to make it possible to use `DArray`s when calling ScaLAPACK routines.

I've also loosened the signature such that ranges can be used when specifying the processes over which an array is to be distributed.
