### PR TITLE
Make copy(DArray) copy

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,8 @@ Library improvements
 
   * Added `recvfrom` to get source address of UDP packets ([#9418])
 
+  * copy(DArray) will now make a copy of the DArray ([#9745])
+
 Deprecated or removed
 ---------------------
 

--- a/base/darray.jl
+++ b/base/darray.jl
@@ -245,7 +245,13 @@ end
 getindex(d::DArray) = d[1]
 getindex(d::DArray, I::Union(Int,UnitRange{Int})...) = sub(d,I...)
 
-copy(d::SubOrDArray) = d
+function copy!(dest::SubOrDArray, src::SubOrDArray)
+    dest.dims == src.dims && dest.pmap == src.pmap && dest.indexes == src.indexes && dest.cuts == src.cuts || throw(ArgumentError("destination array doesn't fit to source array"))
+    for p in dest.pmap
+        @spawnat p copy!(localpart(dest), localpart(src))
+    end
+    dest
+end
 
 # local copies are obtained by convert(Array, ) or assigning from
 # a SubDArray to a local Array.

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -13,6 +13,12 @@ id_other = filter(x -> x != id_me, procs())[rand(1:(nprocs()-1))]
 @fetch begin myid() end
 
 d = drand((200,200), [id_me, id_other])
+dc = copy(d)
+
+@test d == dc                                           # Should be identical
+@spawnat workers()[1] localpart(dc)[1] = 0
+@test fetch(@spawnat workers()[1] localpart(d)[1] != 0) # but not point to the same memory
+
 s = convert(Matrix{Float64}, d[1:150, 1:150])
 a = convert(Matrix{Float64}, d)
 @test a[1:150,1:150] == s


### PR DESCRIPTION
Right now `copy(DArray)` is a noop. I don't see why this is necessary and I'd like to be able to copy my `DArray`s when passing them to mutating linear algebra functions.

cc: @JeffBezanson 
