### PR TITLE
RFC: Fix coverage on Windows

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -891,6 +891,8 @@ static void coverageVisitLine(std::string filename, int line)
                         v);
 }
 
+extern "C" int isabspath(const char *in);
+
 void write_log_data(logdata_t logData, const char *extension)
 {
     std::string base = std::string(jl_compileropts.julia_home);
@@ -900,7 +902,7 @@ void write_log_data(logdata_t logData, const char *extension)
         std::string filename = (*it).first;
         std::vector<GlobalVariable*> &values = (*it).second;
         if (values.size() > 1) {
-            if (filename[0] != '/')
+            if (!isabspath(filename.c_str()))
                 filename = base + filename;
             std::ifstream inf(filename.c_str());
             if (inf.is_open()) {

--- a/src/init.c
+++ b/src/init.c
@@ -789,7 +789,7 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
 
 #endif
 
-static int isabspath(const char *in)
+int isabspath(const char *in)
 {
 #ifdef _OS_WINDOWS_
     char c0 = in[0];

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -78,7 +78,6 @@ temp_pkg_dir() do
 end
 
 # Testing with code-coverage
-@unix_only begin                 # TODO: delete unix_only when #8911, #9654 are fixed
 temp_pkg_dir() do
   Pkg.generate("PackageWithCodeCoverage", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
 
@@ -118,5 +117,4 @@ end"""
       covline = (linetested[i] ? "        1 " : "        - ")*srclines[i]
       @test covlines[i] == covline
   end
-end
 end


### PR DESCRIPTION
use isabspath function from init.c

fixes #8911, does not seem to help with #9654 though.
