### PR TITLE
binary search in sparse getindex with sorted rows

### DIFF
--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -509,3 +509,53 @@ a = speye(3,5)
 @test size(rot180(a)) == (3,5)
 @test size(rotr90(a)) == (5,3)
 @test size(rotl90(a)) == (5,3)
+
+function test_getindex_algs{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, J::AbstractVector, alg::Int)
+    # Sorted vectors for indexing rows.
+    # Similar to getindex_general but without the transpose trick.
+    (m, n) = size(A)
+    minj, maxj = extrema(J)
+    ((I[1] < 1) || (I[end] > m) || (minj < 1) || (maxj > n)) && BoundsError()
+
+    (alg == 0) ? Base.SparseMatrix.getindex_I_sorted_bsearch_A(A, I, J) :
+    (alg == 1) ? Base.SparseMatrix.getindex_I_sorted_bsearch_I(A, I, J) :
+    Base.SparseMatrix.getindex_I_sorted_linear(A, I, J)
+end
+
+let M=2^14, N=2^4
+    Irand = randperm(M);
+    Jrand = randperm(N);
+    SA = [sprand(M, N, d) for d in [1, 0.1, 0.01, 0.001, 0.0001]];
+    IA = [sort(Irand[1:int(n)]) for n in [M, M*0.1, M*0.01, M*0.001, M*0.0001]];
+    debug = false
+
+    if debug
+        println("row sizes: $([int(nnz(S)/S.n) for S in SA])");
+        println("I sizes: $([length(I) for I in IA])");
+        @printf("    S    |    I    | binary S | binary I |  linear  | best\n")
+    end
+
+    J = Jrand;
+    for I in IA
+        for S in SA
+            res = Any[1,2,3]
+            times = Float64[0,0,0]
+            best = [typemax(Float64), 0]
+            for searchtype in [0, 1, 2]
+                tres = @timed test_getindex_algs(S, I, J, searchtype)
+                res[searchtype+1] = tres[1]
+                times[searchtype+1] = tres[2]
+                if best[1] > tres[2]
+                    best[1] = tres[2]
+                    best[2] = searchtype
+                end
+            end
+
+            if debug
+                @printf(" %7d | %7d | %4.2e | %4.2e | %4.2e | %s\n", int(nnz(S)/S.n), length(I), times[1], times[2], times[3],
+                            (0 == best[2]) ? "binary S" : (1 == best[2]) ? "binary I" : "linear")
+            end
+            @assert res[1] == res[2] == res[3]
+        end
+    end
+end


### PR DESCRIPTION
fixes #9668 

Given:
- S = sparse matrix
- I = rows being fetched
- n = average row count in S

Do:
- binary search on `I` if `length(I)` much larger `(>2^10)` than `n`
- binary search on `S.rowval` if `n` much larger `(>2^8)` than `length(I)`
- linear search walk through `I` and `S.rowval` otherwise

Currently the threshold values are determined heuristically based on the tests done.

With this, the test code mentioned in #9668 results in:

```
     N   |   assembly |   slice   |   lufact  | slice / N^4 
---------|------------|-----------|-----------|-------------
 8.0e+00 |  1.63e-04  | 1.60e-05  |  9.37e-04 |   3.90e-09 
 1.6e+01 |  4.70e-05  | 1.36e-04  |  1.60e-03 |   2.07e-09 
 3.2e+01 |  2.07e-04  | 1.18e-04  |  6.56e-03 |   1.13e-10 
 6.4e+01 |  7.00e-04  | 4.34e-04  |  2.80e-02 |   2.59e-11 
 1.3e+02 |  2.31e-03  | 1.78e-03  |  1.29e-01 |   6.62e-12 
 2.6e+02 |  8.23e-03  | 8.19e-03  |  6.82e-01 |   1.91e-12 
```
