### PR TITLE
define factorial(x)=gamma(x+1) fallback

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -59,6 +59,8 @@ function factorial(n::Integer)
     return f
 end
 
+factorial(x::Number) = gamma(x + 1) # fallback for x not Integer
+
 # computes n!/k!
 function factorial{T<:Integer}(n::T, k::T)
     if k < 0 || n < 0 || k > n

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -813,7 +813,12 @@ Mathematical Functions
 
 .. function:: factorial(n)
 
-   Factorial of n
+   Factorial of ``n``.  If ``n`` is an :func:`Integer`, the factorial
+   is computed as an integer (promoted to at least 32 bits).  Note
+   that this may overflow if ``n`` is not small, but you can use
+   ``factorial(big(n))`` to compute the result exactly in arbitrary
+   precision.  If ``n`` is not an ``Integer``, ``factorial(n)`` is
+   equivalent to :func:`gamma(n+1) <gamma>`.
 
 .. function:: factorial(n,k)
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -209,6 +209,10 @@ end
 @test_approx_eq lgamma(1.4+3.7im) -3.7094025330996841898 + 2.4568090502768651184im
 @test_approx_eq lgamma(1.4+3.7im) log(gamma(1.4+3.7im))
 @test_approx_eq lgamma(-4.2+0im) lgamma(-4.2)-pi*im
+@test factorial(3.0) == gamma(4.0) == factorial(3)
+for x in (3.2, 2+1im, 3//2, 3.2+0.1im)
+    @test factorial(x) == gamma(1+x)
+end
 
 # digamma
 for elty in (Float32, Float64)


### PR DESCRIPTION
As [discussed on the mailing list](https://groups.google.com/d/msg/julia-users/2HFSLvFub7g/mhvJ4UIwV0IJ), it's a bit odd that we don't define `factorial(x)` for non-integer `x`, since there is a well-defined meaning in terms of the gamma function. 

This patch adds a `factorial(x::Number) = gamma(x + 1)` fallback method.

Matlab and Octave only allow integer arguments to their `factorial` method, and print an error otherwise.    (However, they compute the factorial of integers using floating-point arithmetic, which allows them to postpone overflow at the price of roundoff errors, which we previously didn't allow.)  The [SciPy factorial](http://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.misc.factorial.html) function is defined to use the gamma function (and accepts non-integer arguments) unless you specifically request an exact integer result for integer args.

cc: @andreasnoack, @ivarne 
