### PR TITLE
Bundle libssl and libcrypto on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ release-candidate: release test
 
 	@echo 1. Remove deprecations in base/deprecated.jl
 	@echo 2. Bump VERSION
-	@echo 3. Create tag, push to github "\(git tag v\`cat VERSION\` && git push --tags\)"
-	@echo 4. Clean out old .tar.gz files living in deps/, "\`git clean -fdx\`" seems to work
+	@echo 3. Create tag, push to github "\(git tag v\`cat VERSION\` && git push --tags\)"		#"` # These comments deal with incompetent syntax highlighting rules
+	@echo 4. Clean out old .tar.gz files living in deps/, "\`git clean -fdx\`" seems to work	#"`
 	@echo 5. Replace github release tarball with tarball created from make source-dist
 	@echo 6. Follow packaging instructions in DISTRIBUTING.md to create binary packages for all platforms
 	@echo 7. Upload to AWS, update http://julialang.org/downloads and http://status.julialang.org/stable links

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1805,6 +1805,15 @@ endif
 	echo 1 > $@
 $(LIBGIT2_OBJ_TARGET): $(LIBGIT2_OBJ_SOURCE) | $(build_shlibdir)
 	cp $< $@
+ifeq ($(OS),Linux)
+	# If we're on linux, copy over libssl and libcrypto for libgit2
+	-LIBGIT_LIBS=$$(ldd "$@" | tail -n +2 | awk '{print $$(NF-1)}'); \
+	for LIB in libssl libcrypto; do \
+		LIB_PATH=$$(echo "$$LIBGIT_LIBS" | grep "$$LIB"); \
+		echo "LIB_PATH for $$LIB: $$LIB_PATH"; \
+		[ ! -z "$$LIB_PATH" ] && cp -v "$$LIB_PATH" $(build_shlibdir); \
+	done
+endif
 
 clean-libgit2:
 	-rm -rf libgit2-$(LIBGIT2_VER)/build/


### PR DESCRIPTION
This causes `install-libgit2` to copy in the `libssl` and `libcrypto` that it picks up from the system into `$(build_shlibdir)`.  This is important because without it, `libgit2` won't load, as it refuses to link against newer `libssl` implementations.

This isn't a problem on OSX or Windows, because OSX's `libssl` is consistent enough across versions, and Windows doesn't have a native one so we bundle everything anyway.
