### PR TITLE
Accept any Number type as dimension size in Array() constructor

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -279,11 +279,11 @@ Array{T}(::Type{T}, m::Int,n::Int,o::Int) =
     ccall(:jl_alloc_array_3d, Array{T,3}, (Any,Int,Int,Int), Array{T,3}, m,n,o)
 
 Array(T::Type, d::Int...) = Array(T, d)
-Array(T::Type, d::Integer...) = Array(T, convert((Int...), d))
+Array(T::Type, d::Real...) = Array(T, convert((Int...), d))
 
-Array{T}(::Type{T}, m::Integer) =
+Array{T}(::Type{T}, m::Real) =
     ccall(:jl_alloc_array_1d, Array{T,1}, (Any,Int), Array{T,1}, m)
-Array{T}(::Type{T}, m::Integer,n::Integer) =
+Array{T}(::Type{T}, m::Real,n::Real) =
     ccall(:jl_alloc_array_2d, Array{T,2}, (Any,Int,Int), Array{T,2}, m, n)
-Array{T}(::Type{T}, m::Integer,n::Integer,o::Integer) =
+Array{T}(::Type{T}, m::Real,n::Real,o::Real) =
     ccall(:jl_alloc_array_3d, Array{T,3}, (Any,Int,Int,Int), Array{T,3}, m, n, o)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -29,6 +29,21 @@ b = a+a
 @test isequal([1,2,5].<<[1,2,5], [2,8,160])
 @test isequal([10,20,50].>>[1,2,5], [5,5,1])
 
+a = ones(2)
+b = ones(2,2)
+c = ones(2,2,2)
+d = ones(2,2,2,2)
+for T in (Int32, Int64, Int128, UInt16, UInt32, UInt64, UInt128, Float16, Float32, Float64, BigInt, BigFloat, Rational)
+    @test ones(T(2)) == a
+    @test ones(T(2),T(2)) == b
+    @test ones(T(2),T(2),T(2)) == c
+    @test ones(T(2),T(2),T(2),T(2)) == d
+
+    @test_throws InexactError ones(T(2.5))
+    @test_throws InexactError ones(T(2.5),T(2.5))
+    @test_throws InexactError ones(T(2.5),T(2.5),T(2.5))
+    @test_throws InexactError ones(T(2.5),T(2.5),T(2.5),T(2.5))
+end
 
 a = ones(2,2)
 a[1,1] = 1


### PR DESCRIPTION
More consistent with e.g. gextindex().

This was mentioned on julia-users today. Any reason not to support this?

Regarding the tests, I guess there must be a more direct way than listing all concrete `Number` types, right?

Also, why is there a definition of `Array` with only `Int` dimensions, and another broader one for `Integer` (that I changed to `Number`)?
