### PR TITLE
Check for whitespace errors in `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ debug release: | $(DIRS) $(build_datarootdir)/julia/base $(build_datarootdir)/ju
 	@export private_libdir=$(private_libdir) && \
 	$(MAKE) $(QUIET_MAKE) LD_LIBRARY_PATH=$(build_libdir):$(LD_LIBRARY_PATH) JULIA_EXECUTABLE="$(JULIA_EXECUTABLE_$@)" $(build_private_libdir)/sys.$(SHLIB_EXT)
 
+check-whitespace:
+	bin/check-whitespace.sh
+
 release-candidate: release test
 	@#Check documentation
 	@./julia doc/NEWS-update.jl #Add missing cross-references to NEWS.md
@@ -429,7 +432,8 @@ distcleanall: cleanall
 	@$(MAKE) -C doc cleanall
 	rm -fr $(build_prefix)
 
-.PHONY: default debug release julia-debug julia-release \
+.PHONY: default debug release check-whitespace release-candidate \
+	julia-debug julia-release \
 	test testall testall1 test-* clean distcleanall cleanall \
 	run-julia run-julia-debug run-julia-release run \
 	install dist source-dist git-submodules

--- a/bin/check-whitespace.sh
+++ b/bin/check-whitespace.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+
+# Check for trailing white space in source files;
+# report an error if so
+
+# Files to check:
+file_patterns='
+*.1
+*.c
+*.cpp
+*.h
+*.jl
+*.lsp
+*.scm
+'
+
+# These patterns are disabled until the respective source files are
+# corrected:
+# *.inc
+# *.make
+# *.md
+# *.rst
+# *.sh
+# *.yml
+# *Makefile
+
+# TODO: Look also for trailing empty lines, and missing '\n' after the
+# last line
+if git --no-pager grep --color -n --full-name -e ' $' -- $file_patterns; then
+    echo "Error: trailing whitespace found in source file(s)"
+    exit 1
+fi


### PR DESCRIPTION
Add new make target `check-whitespace`.
Require this target for `test`.

This should alert people to white-space errors before they ask Travis to do so.

Note: Quite a few source file patterns are currently disabled since they contain trailing white space. These should be enabled once the respective source files are corrected.
