### PR TITLE
allow conversion of Int to/from Ptr (fix #9786)

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -3,11 +3,12 @@
 const C_NULL = box(Ptr{Void}, 0)
 
 # pointer to integer
-convert(::Type{UInt}, x::Ptr) = box(UInt, unbox(Ptr,x))
+convert{T<:Union(Int,UInt)}(::Type{T}, x::Ptr) = box(T, unbox(Ptr,x))
 convert{T<:Integer}(::Type{T}, x::Ptr) = convert(T,unsigned(x))
 
 # integer to pointer
 convert{T}(::Type{Ptr{T}}, x::Integer) = box(Ptr{T},unbox(UInt,uint(x)))
+convert{T}(::Type{Ptr{T}}, x::Signed) = box(Ptr{T},unbox(Int,int(x)))
 
 # pointer to pointer
 convert{T}(::Type{Ptr{T}}, p::Ptr{T}) = p

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -102,3 +102,12 @@ for i = 1:1000
     @test (s+1)*(s+1) > n
 end
 
+# issue #9786
+let ptr = Ptr{Void}(typemax(UInt))
+    for T in (Int, Cssize_t)
+        @test T(ptr) == -1
+        @test ptr == Ptr{Void}(T(ptr))
+        @test typeof(Ptr{Float64}(T(ptr))) == Ptr{Float64}
+    end
+    @test ptr == Ptr{Void}(Int8(-1)) # signed values are sign-extended to Int
+end


### PR DESCRIPTION
This fixes #9786, by allowing `convert(Int, ::Ptr)` and `convert(Ptr{T}, ::Int)` without spurious inexact errors when the sign bit is set.   Also allows `convert(Ptr{T}, ::Signed)` via conversion to `Int`, similar to C.
