### PR TITLE
Codegen updates for llvm 3.7

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9,11 +9,15 @@
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/JITEventListener.h>
 #include <llvm/PassManager.h>
-#include <llvm/Target/TargetLibraryInfo.h>
 #include <llvm/Target/TargetSubtargetInfo.h>
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Analysis/Passes.h>
 #include <llvm/Bitcode/ReaderWriter.h>
+#ifdef LLVM37
+#include <llvm/Analysis/TargetLibraryInfo.h>
+#else
+#include <llvm/Target/TargetLibraryInfo.h>
+#endif
 #ifdef LLVM35
 #include <llvm/IR/Verifier.h>
 #include <llvm/Object/ObjectFile.h>
@@ -418,7 +422,11 @@ void jl_dump_objfile(char *fname, int jit_model)
         ));
 
     PassManager PM;
+#ifndef LLVM37
     PM.add(new TargetLibraryInfo(Triple(jl_TargetMachine->getTargetTriple())));
+#else
+    PM.add(new TargetLibraryInfoWrapperPass(Triple(jl_TargetMachine->getTargetTriple())));
+#endif
 #ifdef LLVM36
     PM.add(new DataLayoutPass());
 #elif LLVM35

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -1,5 +1,9 @@
 #include <llvm/Config/llvm-config.h>
 
+#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 7
+#define LLVM37 1
+#endif
+
 #if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 6
 #define LLVM36 1
 #endif


### PR DESCRIPTION
Target/TargetLibraryInfo.h was moved to Analysis/ and TargetLibraryInfo renamed to TargetLibraryInfoWrapperPass

See: https://github.com/llvm-mirror/llvm/commit/eeeec3ce0d358ac43148030636ec9d4372953165 and https://github.com/llvm-mirror/llvm/commit/bda134910ab021c647ed05bfba8176cba4696c82

This is my first time touching anything in src/ and related to LLVM, so I have zero confidence this is correct or a correct interpretation of the changes on LLVM svn. However, it builds and passes tests on my Debian box.
