### PR TITLE
Remove rref

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -694,7 +694,6 @@ export
     qrfact!,
     qrfact,
     rank,
-    rref,
     scale!,
     scale,
     schur,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -93,7 +93,6 @@ export
     qrfact!,
     qrfact,
     rank,
-    rref,
     scale,
     scale!,
     schur,

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -169,42 +169,6 @@ function ^(A::Matrix, p::Number)
     scale(X, v.^p)*Xinv
 end
 
-function rref{T}(A::Matrix{T})
-    nr, nc = size(A)
-    U = copy!(similar(A, T <: Complex ? Complex128 : Float64), A)
-    e = eps(norm(U,Inf))
-    i = j = 1
-    while i <= nr && j <= nc
-        (m, mi) = findmax(abs(U[i:nr,j]))
-        mi = mi+i - 1
-        if m <= e
-            U[i:nr,j] = 0
-            j += 1
-        else
-            for k=j:nc
-                U[i, k], U[mi, k] = U[mi, k], U[i, k]
-            end
-            d = U[i,j]
-            for k = j:nc
-                U[i,k] /= d
-            end
-            for k = 1:nr
-                if k != i
-                    d = U[k,j]
-                    for l = j:nc
-                        U[k,l] -= d*U[i,l]
-                    end
-                end
-            end
-            i += 1
-            j += 1
-        end
-    end
-    U
-end
-
-rref(x::Number) = one(x)
-
 # Matrix exponential
 expm{T<:BlasFloat}(A::StridedMatrix{T}) = expm!(copy(A))
 expm{T<:Integer}(A::StridedMatrix{T}) = expm!(float(A))

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -327,8 +327,6 @@ scale!(b::AbstractVector, A::AbstractMatrix) = scale!(A,b,A)
 #findmax(a::AbstractArray)
 #findmin(a::AbstractArray)
 
-#rref{T}(A::AbstractMatrix{T})
-
 function peakflops(n::Integer=2000; parallel::Bool=false)
     a = rand(100,100)
     t = @elapsed a*a

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -33,10 +33,6 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute the cross product of two 3-vectors.
 
-.. function:: rref(A)
-
-   Compute the reduced row echelon form of the matrix A.
-
 .. function:: factorize(A)
 
    Compute a convenient factorization (including LU, Cholesky, Bunch-Kaufman, Triangular) of A, based upon the type of the input matrix. The return value can then be reused for efficient solving of multiple systems. For example: ``A=factorize(A); x=A\\b; y=A\\C``.


### PR DESCRIPTION
I don't think this function is useful in base. Better to use `\`.

See JuliaLang/LinearAlgebra.jl#131
