### PR TITLE
PR promised for issue #7812

### DIFF
--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -6,8 +6,9 @@ arithtype(::Type{Bool}) = Int
 # multiply by diagonal matrix as vector
 function scale!(C::AbstractMatrix, A::AbstractMatrix, b::AbstractVector)
     m, n = size(A)
-    n == length(b) || throw(DimensionMismatch())
-    for j = 1:n
+    p, q = size(C)
+    n == length(b) && p == m && q == n || throw(DimensionMismatch())
+    @inbounds for j = 1:n
         bj = b[j]
         for i = 1:m
             C[i,j] = A[i,j]*bj
@@ -18,8 +19,9 @@ end
 
 function scale!(C::AbstractMatrix, b::AbstractVector, A::AbstractMatrix)
     m, n = size(A)
-    m == length(b) || throw(DimensionMismatch())
-    for j = 1:n, i = 1:m
+    p, q = size(C)
+    m == length(b) && p == m && q == n || throw(DimensionMismatch())
+    @inbounds for j = 1:n, i = 1:m
         C[i,j] = A[i,j]*b[i]
     end
     C

--- a/test/linalg3.jl
+++ b/test/linalg3.jl
@@ -211,6 +211,9 @@ Ai = int(ceil(Ar*100))
 @test isequal(scale(BigFloat[1.0], 2.0im),     Complex{BigFloat}[2.0im])
 @test isequal(scale(BigFloat[1.0], 2.0f0im),   Complex{BigFloat}[2.0im])
 
+# test 3-argument version of scale!
+@test_throws DimensionMismatch scale!(Array(Float64,(3,2)),reshape([1.:6],(2,3)), ones(3))
+
 # issue #6450
 @test dot(Any[1.0,2.0], Any[3.5,4.5]) === 12.5
 


### PR DESCRIPTION
Check dimensions on the 3-argument version of scale!.  When the dimensions are checked the loop can be run under `@inbounds`
