### PR TITLE
Fix compiling with system llvm 3.4

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -383,6 +383,11 @@ void jl_dump_function_asm(const char *Fptr, size_t Fsize,
                         OpInfoLookup,
                         SymbolLookup,
                         &DisInfo)));
+#elif defined LLVM34
+            OwningPtr<MCRelocationInfo> relinfo(new MCRelocationInfo(Ctx));
+            DisAsm->setupForSymbolicDisassembly(
+                    OpInfoLookup, SymbolLookup, &DisInfo, &Ctx,
+                    relinfo);
 #else
             DisAsm->setupForSymbolicDisassembly(
                     OpInfoLookup, SymbolLookup, &DisInfo, &Ctx);
@@ -479,7 +484,7 @@ void jl_dump_function_asm(const char *Fptr, size_t Fsize,
                     // Pass 0: Record all branch targets
                     if (MCIA->isBranch(Inst)) {
                         uint64_t addr;
-#ifdef LLVM35
+#ifdef LLVM34
                         if (MCIA->evaluateBranch(Inst, Index, insSize, addr))
 #else
                         if ((addr = MCIA->evaluateBranch(Inst, Index, insSize)) != (uint64_t)-1)


### PR DESCRIPTION
I don't know whether nobody ever tried it, but I need this patch when I try to compile with the system llvm on my old Fedora 20 system.  Seems to work correctly with this patch, without it doesn't compile.  The only question is whether there are multiple llvm 3.4 ABIs.  I hope not in which case this patch is correct.
