### PR TITLE
Make k, n < 0 no longer valid for factorial(n, k)

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -64,7 +64,7 @@ factorial(x::Number) = gamma(x + 1) # fallback for x not Integer
 # computes n!/k!
 function factorial{T<:Integer}(n::T, k::T)
     if k < 0 || n < 0 || k > n
-        return zero(T)
+        throw(DomainError())
     end
     f = one(T)
     while n > k

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -8949,8 +8949,9 @@ popdisplay(d::Display)
 
 ("Base","factorial","factorial(n, k)
 
-   Compute \"factorial(n)/factorial(k)\"
+   Compute \"factorial(n) ÷ factorial(k)\"
 
+   Throws DomainError when k > n
 "),
 
 ("Base","factor","factor(n) -> Dict

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -55,6 +55,9 @@ end
 
 @test factorial(7) == 5040
 @test factorial(7,3) == 7*6*5*4
+@test_throws DomainError factorial(3,7)
+@test_throws DomainError factorial(-3,-7)
+@test_throws DomainError factorial(-7,-3)
 @test factorial(0) == 1
 @test_throws DomainError factorial(-1)
 


### PR DESCRIPTION
Commits are squashed but it caused errors so I created a new one.
