### PR TITLE
Update docs to reflect new use of Dates.UTC

### DIFF
--- a/doc/stdlib/dates.rst
+++ b/doc/stdlib/dates.rst
@@ -131,7 +131,7 @@ alternatively, you could call ``using Dates`` to bring all exported functions in
    Returns a DateTime corresponding to the user's system
    time including the system timezone locale.
 
-.. function:: nowutc() -> DateTime
+.. function:: now(::Type{UTC}) -> DateTime
   
    Returns a DateTime corresponding to the user's system
    time as UTC/GMT.


### PR DESCRIPTION
Removes reference to `nowutc()`.
