### PR TITLE
Set BigFloat to use maximum possible exponent range

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -26,6 +26,12 @@ import Base.GMP: ClongMax, CulongMax, CdoubleMax
 
 import Base.Math.lgamma_r
 
+function __init__()
+    # set exponent to full range by default
+    set_emin!(get_emin_min())
+    set_emax!(get_emax_max())
+end
+
 const ROUNDING_MODE = Cint[0]
 const DEFAULT_PRECISION = [256]
 
@@ -769,5 +775,17 @@ end
 print(io::IO, b::BigFloat) = print(io, string(b))
 show(io::IO, b::BigFloat) = print(io, string(b), " with $(precision(b)) bits of precision")
 showcompact(io::IO, b::BigFloat) = print(io, string(b))
+
+# get/set exponent min/max
+get_emax() = ccall((:mpfr_get_emax, :libmpfr), Clong, ())
+get_emax_min() = ccall((:mpfr_get_emax_min, :libmpfr), Clong, ())
+get_emax_max() = ccall((:mpfr_get_emax_max, :libmpfr), Clong, ())
+
+get_emin() = ccall((:mpfr_get_emin, :libmpfr), Clong, ())
+get_emin_min() = ccall((:mpfr_get_emin_min, :libmpfr), Clong, ())
+get_emin_max() = ccall((:mpfr_get_emin_max, :libmpfr), Clong, ())
+
+set_emax!(x) = ccall((:mpfr_set_emax, :libmpfr), Void, (Clong,), x)
+set_emin!(x) = ccall((:mpfr_set_emin, :libmpfr), Void, (Clong,), x)
 
 end #module

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -813,5 +813,10 @@ err(z, x) = abs(z - x) / abs(x)
 @test 1e-60 > err(eta(BigFloat("1.005")), BigFloat("0.693945708117842473436705502427198307157819636785324430166786"))
 @test 1e-60 > err(exp(eta(big(1.0))), 2.0)
 
-# issue 8318
+# issue #8318
 @test convert(Int64,big(500_000_000_000_000.)) == 500_000_000_000_000
+
+# issue #9816
+# check exponent range is set to max possible
+@test MPFR.get_emin() == MPFR.get_emin_min()
+@test MPFR.get_emax() == MPFR.get_emax_max()


### PR DESCRIPTION
Should fix issues outlined in #9816. Sets exponent to maximum range allowed on the given hardware.
