### PR TITLE
Refactor linalg tests to make them faster. Add timings to tests.

### DIFF
--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -1,8 +1,9 @@
 using Base.Test
 
 function runtests(name)
-    println("     \033[1m*\033[0m \033[31m$(name)\033[0m")
-    Core.include("$name.jl")
+    @printf("     \033[1m*\033[0m \033[31m%-20s\033[0m", name)
+    tt = @elapsed Core.include("$name.jl")
+    @printf(" in %6.2f seconds\n", tt)
     nothing
 end
 


### PR DESCRIPTION
This PR refactors the triangular tests to avoid repetition of the same code paths. For most element types repetition doesn't matter much, but for `BigFloat` and `Complex{BigFloat}` it makes a difference. I have also added timings to each test result. Hopefully it will make it easier to follow degradations.  

There were quite a bit unnecessary reparations in the triangular tests so the end result is 61 seconds instead of 133 seconds. As the timings below show, most of the time (85 pct.) is now spent on compilation.

``` julia
julia> @time include("test/linalg/triangular.jl")
elapsed time: 61.000181977 seconds (5492470520 bytes allocated, 9.81% gc time)

julia> @time include("test/linalg/triangular.jl")
elapsed time: 9.42074814 seconds (2054950740 bytes allocated, 48.03% gc time)
```

For the other linalg tests, I have not been able to cut down the time because they spend the time on compilation and `BigFloat`s (and not repeating the same tests). The good news is that the new gc will help a lot because `BigFloat`s get much faster. E.g.

``` julia
# Old GC
julia> @time include("test/linalg2.jl")
elapsed time: 61.344400677 seconds (5697450436 bytes allocated, 25.18% gc time)

# New GC
julia> @time include("test/linalg2.jl")
elapsed time: 43.37265016 seconds (5253 MB allocated, 7.34% gc time in 240 pauses with 0 full sweep)
```
