### PR TITLE
DOC prefix docstring by method signature

### DIFF
--- a/base/docs.jl
+++ b/base/docs.jl
@@ -95,6 +95,7 @@ function doc(f::Function)
       fd = mod.META[f]
       if isa(fd, FuncDoc)
         for m in fd.order
+          push!(docs, Base.Markdown.MD(m))
           push!(docs, fd.meta[m])
         end
       elseif length(docs) == 0


### PR DESCRIPTION
This prefixes the help text with method name:

```
julia> @doc "hello" -> f(x::Int) = ()
f (generic function with 1 method)

julia> @doc "world" -> f(x::String) = ()
f (generic function with 2 methods)

help?> f
f(x::Int64)
  hello

f(x::AbstractString)
  world
```

Previously this would have printed:

```
  hello

  world
```

which doesn't seem as useful/doesn't match the convention used currently in julia, e.g.

```
help?> +
Base.Graphics.+(bb1::BoundingBox, bb2::BoundingBox) -> BoundingBox

   Returns the smallest box containing both boxes

Base.+(x, y...)

   Addition operator. "x+y+z+..." calls this function with all
   arguments, i.e. "+(x, y, z, ...)".
```

cc @one-more-minute (apologies in advance if there's a better place in the code to put this).

_Note: this needs a test, but thought I'd throw it out there._
