### PR TITLE
Remove warnings from linear algebra code

### DIFF
--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -42,7 +42,7 @@ QRPivoted{T}(factors::AbstractMatrix{T}, τ::Vector{T}, jpvt::Vector{BlasInt}) =
 
 qrfact!{T<:BlasFloat}(A::StridedMatrix{T}; pivot=false) = pivot ? QRPivoted(LAPACK.geqp3!(A)...) : QRCompactWY(LAPACK.geqrt!(A, min(minimum(size(A)), 36))...)
 function qrfact!{T}(A::AbstractMatrix{T}; pivot=false)
-    pivot && warn("pivoting only implemented for Float32, Float64, Complex64 and Complex128")
+    pivot && throw(ArgumentError("pivoting only implemented for Float32, Float64, Complex64 and Complex128 types, got $T"))
     m, n = size(A)
     τ = zeros(T, min(m,n))
     @inbounds begin

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -640,7 +640,8 @@ for (gesvx, elty) in
               &fact, &trans, &n, &nrhs, A, &lda, AF, &ldaf, ipiv, &equed, R, C, B,
               &ldb, X, &n, rcond, ferr, berr, work, iwork, info)
             @lapackerror
-            if info[1] == n+1 warn("Matrix is singular to working precision.")
+            if info[1] == n+1
+                #TODO: API decision
             else @assertnonsingular
             end
             #WORK(1) contains the reciprocal pivot growth factor norm(A)/norm(U)
@@ -695,7 +696,8 @@ for (gesvx, elty, relty) in
               &fact, &trans, &n, &nrhs, A, &lda, AF, &ldaf, ipiv, &equed, R, C, B,
               &ldb, X, &n, rcond, ferr, berr, work, rwork, info)
             @lapackerror
-            if info[1] == n+1 warn("Matrix is singular to working precision.")
+            if info[1] == n+1
+                #TODO: API decision
             else @assertnonsingular end
             #RWORK(1) contains the reciprocal pivot growth factor norm(A)/norm(U)
             X, equed, R, C, B, rcond[1], ferr, berr, rwork[1]
@@ -3182,7 +3184,6 @@ for (bdsdc, elty) in
             if compq == 'N'
                 lwork = 6n
             elseif compq == 'P'
-                warn("COMPQ='P' is not tested")
                 #TODO turn this into an actual LAPACK call
                 #smlsiz=ilaenv(9, $elty==:Float64 ? 'dbdsqr' : 'sbdsqr', string(uplo, compq), n,n,n,n)
                 smlsiz=100 #For now, completely overkill


### PR DESCRIPTION
Right now some methods in the linear algebra codebase throw warnings instead of raising an error or returning an output value of the condition that raised the warning.  Warnings are nice for humans, but not for computers.  I feel if we want warnings raised, that should be a behavior opted into by the user but turned off by default.

cc @andreasnoack 
