### PR TITLE
RFC Markdown sections

### DIFF
--- a/base/markdown/render/terminal/formatting.jl
+++ b/base/markdown/render/terminal/formatting.jl
@@ -85,6 +85,7 @@ function print_wrapped(io::IO, s...; width = 80, pre = "", i = 0)
     for line in lines[2:end]
         println(io, pre, line)
     end
+    length(lines), length(pre) + ansi_length(lines[end])
 end
 
 print_wrapped(f::Function, io::IO, args...; kws...) = print_wrapped(io, f, args...; kws...)
@@ -95,6 +96,7 @@ function print_centred(io::IO, s...; columns = 80, width = columns)
         print(io, " "^(div(columns-ansi_length(line), 2)))
         println(io, line)
     end
+    length(lines), length(pre) + length(lines[end])
 end
 
 function centred(s, columns)

--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -39,17 +39,38 @@ function term(io::IO, md::List, columns)
 end
 
 function term(io::IO, md::Header{1}, columns)
-    text = terminline(md.text)
-    with_output_format(:bold, io) do io
-        print_centred(io, text, width = columns - 4margin, columns = columns)
-    end
-    print_centred(io, "-"*"–"^min(length(text), div(columns, 2))*"-", columns = columns)
+    _term_header(io, md, '=', columns)
 end
 
+function term(io::IO, md::Header{2}, columns)
+    _term_header(io, md, '–', columns)
+end
+
+function term(io::IO, md::Header{3}, columns)
+    _term_header(io, md, '-', columns)
+end
+
+function _term_header(io::IO, md, char, columns)
+    text = terminline(md.text)
+    with_output_format(:bold, io) do io
+        print(io, " ")
+        line_no, lastline_width = print_wrapped(io, text,
+                                                width=columns - 4margin; pre=" ")
+        line_width = min(1 + lastline_width, columns)
+        if line_no > 1
+            line_width = max(line_width, div(columns, 3))
+        end
+        println(io, string(char) ^ line_width)
+    end
+end
+
+
 function term{l}(io::IO, md::Header{l}, columns)
-    print(io, "#"^l, " ")
-    terminline(io, md.text)
-    println(io)
+    with_output_format(:bold, io) do io
+        print(io, "#"^l, " ")
+        terminline(io, md.text)
+        println(io)
+    end
 end
 
 function term(io::IO, md::Code, columns)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -9,6 +9,11 @@ import Base: writemime
 @test md"foo" == MD(Paragraph("foo"))
 @test md"foo *bar* baz" == MD(Paragraph(["foo ", Italic("bar"), " baz"]))
 
+@test md"#title" == Markdown.MD(Markdown.Header{1}("title"))
+@test md"## section" == Markdown.MD(Markdown.Header{2}("section"))
+@test md"# title *foo* `bar` **baz**" == Markdown.MD(Markdown.Header{1}(["title ",
+    Markdown.Italic("foo")," ",Markdown.Code("bar")," ",Markdown.Bold("baz")]))
+
 @test md"**foo *bar* baz**" == MD(Paragraph(Bold(["foo ", Italic("bar"), " baz"])))
 # @test md"**foo *bar* baz**" == MD(Paragraph(Italic(["foo ", Bold("bar"), " baz"])))
 
@@ -20,10 +25,15 @@ import Base: writemime
 
 @test md"foo" |> plain == "foo\n"
 @test md"foo *bar* baz" |> plain == "foo *bar* baz\n"
+@test md"#title" |> plain == "# title\n"
+@test md"## section" |> plain == "## section\n"
+@test md"## section `foo`" |> plain == "## section `foo`\n"
 
 # HTML output
 
 @test md"foo *bar* baz" |> html == "<p>foo <em>bar</em> baz</p>\n"
+@test md"# title *blah*" |> html == "<h1>title <em>blah</em></h1>\n"
+@test md"## title *blah*" |> html == "<h2>title <em>blah</em></h2>\n"
 
 # Interpolation / Custom types
 


### PR DESCRIPTION
~~_This is on the top of #9852 (whitespace changes to Markdown) so please excuse the large diff in the first commit._~~

This adds methods for sections and subsections in the terminal, as a partial fix for #9850.

```
julia> Base.Markdown.parse("#Title")
                                                           Title
                                                          -=====-

julia> Base.Markdown.parse("##Section")
                                                          Section
                                                         -–––––––-

julia> Base.Markdown.parse("###Subsection")
Subsection
––––––––––
```

I don't feel strongly about what these actually are (very happy to amend), but thought I would put this out there.

cc @one-more-minute 
