### PR TITLE
For filename info in codegen, skip meta expressions (fixes #9695)

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -449,10 +449,7 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_tuple_t *sparams)
     li->file = null_sym;
     li->line = 0;
     if (ast != NULL && jl_is_expr(ast)) {
-        jl_expr_t *body1 = (jl_expr_t*)jl_exprarg(jl_lam_body((jl_expr_t*)ast),0);
-        if (jl_is_expr(body1) && ((jl_expr_t*)body1)->head == meta_sym
-            && jl_array_len(((jl_expr_t*)ast)->args) > 1)
-            body1 = (jl_expr_t*)jl_exprarg(jl_lam_body((jl_expr_t*)ast),1);
+        jl_value_t *body1 = skip_meta(jl_lam_body((jl_expr_t*)ast)->args);
         if (jl_is_expr(body1) && ((jl_expr_t*)body1)->head == line_sym) {
             li->file = (jl_sym_t*)jl_exprarg(body1, 1);
             li->line = jl_unbox_long(jl_exprarg(body1, 0));

--- a/src/ast.c
+++ b/src/ast.c
@@ -912,6 +912,14 @@ DLLEXPORT int jl_operator_precedence(char *sym) {
                              symbol(sym)));
 }
 
+jl_value_t* skip_meta(jl_array_t *body) {
+    jl_value_t *body1 = jl_cellref(body,0);
+    if (jl_is_expr(body1) && ((jl_expr_t*)body1)->head == meta_sym
+        && jl_array_len(body) > 1)
+        body1 = jl_cellref(body,1);
+    return body1;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3747,7 +3747,7 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
     bool in_user_code = !jl_is_submodule(lam->module, jl_base_module) && !jl_is_submodule(lam->module, jl_core_module);
     bool do_coverage = jl_compileropts.code_coverage == JL_LOG_ALL || (jl_compileropts.code_coverage == JL_LOG_USER && in_user_code);
     bool do_malloc_log = jl_compileropts.malloc_log  == JL_LOG_ALL || (jl_compileropts.malloc_log    == JL_LOG_USER && in_user_code);
-    jl_value_t *stmt = jl_cellref(stmts,0);
+    jl_value_t *stmt = skip_meta(stmts);
     std::string filename = "no file";
     char *dbgFuncName = lam->name->name;
     int lno = -1;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -108,6 +108,8 @@ jl_function_t *jl_module_get_initializer(jl_module_t *m);
 void jl_generate_fptr(jl_function_t *f);
 void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig);
 
+jl_value_t* skip_meta(jl_array_t *body);
+
 // backtraces
 #ifdef _OS_WINDOWS_
 extern volatile HANDLE hMainThread;


### PR DESCRIPTION
Having a `:meta` expression messes up line numbers in a couple of places (see also #9293). This centralizes the fix in #9298 so we can re-use it to fix #9695, too. I've searched the code for other uses of `jl_cellref(.*,0)` and not found any that are obviously related, so as far as I can tell this is the only other place that needed fixing.
