### PR TITLE
Don't hard-code `#include` paths

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -34,7 +34,7 @@
 #endif
 
 #if defined(USE_MCJIT) && !defined(LLVM36) && defined(_OS_DARWIN_)
-#include "../deps/llvm-3.5.0/lib/ExecutionEngine/MCJIT/MCJIT.h"
+#include <llvm/ExecutionEngine/MCJIT/MCJIT.h>
 #endif
 
 #include "julia.h"

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -34,7 +34,7 @@
 #endif
 
 #if defined(USE_MCJIT) && !defined(LLVM36) && defined(_OS_DARWIN_)
-#include <llvm/ExecutionEngine/MCJIT/MCJIT.h>
+#include <llvm/ExecutionEngine/MCJIT.h>
 #endif
 
 #include "julia.h"


### PR DESCRIPTION
Otherwise I can't compile on OS X with LLVM 3.5.1.
