### PR TITLE
Layout pmap property corresponding to the grid in DArray

### DIFF
--- a/base/darray.jl
+++ b/base/darray.jl
@@ -4,7 +4,7 @@ type DArray{T,N,A} <: AbstractArray{T,N}
     chunks::Array{RemoteRef,N}
 
     # pmap[i]==p ⇒ processor p has piece i
-    pmap::Vector{Int}
+    pmap::Array{Int,N}
 
     # indexes held by piece i
     indexes::Array{NTuple{N,UnitRange{Int}},N}
@@ -16,7 +16,7 @@ type DArray{T,N,A} <: AbstractArray{T,N}
         assert(size(chunks) == size(indexes))
         assert(length(chunks) == length(pmap))
         assert(dims == map(last,last(indexes)))
-        new(dims, chunks, pmap, indexes, cuts)
+        new(dims, chunks, reshape(pmap, size(chunks)), indexes, cuts)
     end
 end
 
@@ -111,7 +111,7 @@ function chunk_idxs(dims, chunks)
     idxs, cuts
 end
 
-function localpartindex(pmap::Vector{Int})
+function localpartindex(pmap::Array{Int})
     mi = myid()
     for i = 1:length(pmap)
         if pmap[i] == mi


### PR DESCRIPTION
This makes it slightly easier to find the process number on a grid because the grid coordinate can be used in `A.pmap`.

```
julia> addprocs(4)
4-element Array{Any,1}:
 2
 3
 4
 5

julia> A = drandn(4,4);

julia> A.pmap
2x2 Array{Int64,2}:
 2  4
 3  5

julia> A.chunks
2x2 Array{RemoteRef,2}:
 RemoteRef(2,1,6)  RemoteRef(4,1,8)
 RemoteRef(3,1,7)  RemoteRef(5,1,9)
```
