### PR TITLE
Add mapreducedim for DArrays

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -785,6 +785,7 @@ export
     mapfoldl,
     mapfoldr,
     mapreduce,
+    mapreducedim,
     merge!,
     merge,
     #pop!,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -203,6 +203,7 @@ include("linalg/matmul.jl")
 include("linalg/lapack.jl")
 
 include("linalg/dense.jl")
+include("linalg/distributed.jl")
 include("linalg/tridiag.jl")
 include("linalg/triangular.jl")
 include("linalg/factorization.jl")

--- a/base/linalg/distributed.jl
+++ b/base/linalg/distributed.jl
@@ -1,0 +1,5 @@
+function scale!(A::DArray, x::Number)
+    @sync for p in procs(A)
+        @spawnat p scale!(localpart(A), x)
+    end
+end

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -198,7 +198,7 @@ function to_op(op::Function)
     is(op, |) ? OrFun() : op
 end
 
-mapreducedim!(f::Function, op, R::AbstractArray, A::AbstractArray) =
+mapreducedim!(f, op, R::AbstractArray, A::AbstractArray) =
     _mapreducedim!(f, to_op(op), R, A)
 
 reducedim!{RT}(op, R::AbstractArray{RT}, A::AbstractArray) =

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -18,13 +18,7 @@ mean(A::AbstractArray) = sum(A) / length(A)
 
 function mean!{T}(R::AbstractArray{T}, A::AbstractArray)
     sum!(R, A; init=true)
-    lenR = length(R)
-    rs = convert(T, length(A) / lenR)
-    if rs != 1
-        for i = 1:lenR
-            @inbounds R[i] /= rs
-        end
-    end
+    scale!(R, length(R) / length(A))
     return R
 end
 
@@ -33,7 +27,7 @@ momenttype(::Type{Float32}) = Float32
 momenttype{T<:Union(Float64,Int32,Int64,UInt32,UInt64)}(::Type{T}) = Float64
 
 mean{T}(A::AbstractArray{T}, region) =
-    mean!(Array(momenttype(T), reduced_dims(size(A), region)), A)
+    mean!(reducedim_initarray(A, region, 0, momenttype(T)), A)
 
 
 ##### variances #####
@@ -93,7 +87,7 @@ function varzm!{S}(R::AbstractArray{S}, A::AbstractArray; corrected::Bool=true)
 end
 
 varzm{T}(A::AbstractArray{T}, region; corrected::Bool=true) =
-    varzm!(Array(momenttype(T), reduced_dims(A, region)), A; corrected=corrected)
+    varzm!(reducedim_initarray(A, region, 0, momenttype(T)), A; corrected=corrected)
 
 immutable CentralizedAbs2Fun{T<:Number} <: Func{1}
     m::T
@@ -155,7 +149,7 @@ function varm!{S}(R::AbstractArray{S}, A::AbstractArray, m::AbstractArray; corre
 end
 
 varm{T}(A::AbstractArray{T}, m::AbstractArray, region; corrected::Bool=true) =
-    varm!(Array(momenttype(T), reduced_dims(size(A), region)), A, m; corrected=corrected)
+    varm!(reducedim_initarray(A, region, 0, momenttype(T)), A, m; corrected=corrected)
 
 
 function var{T}(A::AbstractArray{T}; corrected::Bool=true, mean=nothing)

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -471,15 +471,21 @@ Array functions
    Rotate matrix ``A`` right 90 degrees an integer ``k`` number of times. If ``k``
    is zero or a multiple of four, this is equivalent to a ``copy``.
 
-.. function:: reducedim(f, A, dims, initial)
+.. function:: reducedim(f, A, dims[, initial])
 
    Reduce 2-argument function ``f`` along dimensions of ``A``. ``dims`` is a
    vector specifying the dimensions to reduce, and ``initial`` is the initial
-   value to use in the reductions.
+   value to use in the reductions. For `+`, `*`, `max` and `min` the `initial`
+   argument is optional.
 
    The associativity of the reduction is implementation-dependent; if you
    need a particular associativity, e.g. left-to-right, you should write
    your own loop. See documentation for ``reduce``.
+
+.. function:: mapreducedim(f, op, A, dims[, initial])
+
+   Evaluates to the same as `reducedim(op, map(f, A), dims, f(initial))`, but
+   is generally faster because the intermediate array is avoided.
 
 .. function:: mapslices(f, A, dims)
 


### PR DESCRIPTION
This commit extends `mapreducedim` to work for `DArray`s. The speedup factor is, in some cases, even more than the number of processors because garbage collection can be avoided. E.g.

``` julia
julia> addprocs(4)
4-element Array{Any,1}:
 2
 3
 4
 5

julia> D = drandn(2000,2000);

julia> A = convert(Array, D);

julia> gc(); @time sA = reducedim(+, A, 2);
elapsed time: 0.444332935 seconds (239664512 bytes allocated, 34.97% gc time)

julia> gc(); @time sD = reducedim(+, D, 2);
elapsed time: 0.094834243 seconds (136784 bytes allocated)

julia> 0.444332935/0.094834243
4.685363861659127

julia> gc(); @time sA = mapreducedim(t -> t*t/2000, +, A, 2);
elapsed time: 0.707075865 seconds (367666000 bytes allocated, 31.57% gc time)

julia> gc(); @time sD = mapreducedim(t -> t*t/2000, +, D, 2);
elapsed time: 0.183450491 seconds (149952 bytes allocated)

julia> 0.707075865/0.183450491
3.854314377386976
```
