### PR TITLE
parse md"##section" correctly

### DIFF
--- a/base/markdown/Julia/interp.jl
+++ b/base/markdown/Julia/interp.jl
@@ -1,38 +1,38 @@
 function Base.parse(stream::IOBuffer; greedy::Bool = true, raise::Bool = true)
-  pos = position(stream)
-  ex, Δ = Base.parse(readall(stream), 1, greedy = greedy, raise = raise)
-  seek(stream, pos + Δ - 1)
-  return ex
+    pos = position(stream)
+    ex, Δ = Base.parse(readall(stream), 1, greedy = greedy, raise = raise)
+    seek(stream, pos + Δ - 1)
+    return ex
 end
 
 function interpinner(stream::IO, greedy = false)
-  startswith(stream, '$') || return
-  (eof(stream) || peek(stream) in whitespace) && return
-  try
-    return Base.parse(stream::IOBuffer, greedy = greedy)
-  catch e
-    return
-  end
+    startswith(stream, '$') || return
+    (eof(stream) || peek(stream) in whitespace) && return
+    try
+        return Base.parse(stream::IOBuffer, greedy = greedy)
+    catch e
+        return
+    end
 end
 
 @trigger '$' ->
 function interp(stream::IO)
-  withstream(stream) do
-    ex = interpinner(stream)
-    return ex
-  end
+    withstream(stream) do
+        ex = interpinner(stream)
+        return ex
+    end
 end
 
 function blockinterp(stream::IO, md::MD, config::Config)
-  withstream(stream) do
-    ex = interpinner(stream)
-    if ex ≡ nothing
-      return false
-    else
-      push!(md, ex)
-      return true
+    withstream(stream) do
+        ex = interpinner(stream)
+        if ex ≡ nothing
+            return false
+        else
+            push!(md, ex)
+            return true
+        end
     end
-  end
 end
 
 toexpr(x) = x
@@ -40,9 +40,9 @@ toexpr(x) = x
 toexpr(xs::Vector{Any}) = Expr(:cell1d, map(toexpr, xs)...)
 
 function deftoexpr(T)
-  @eval function toexpr(md::$T)
-    Expr(:call, $T, $(map(x->:(toexpr(md.$x)), names(T))...))
-  end
+    @eval function toexpr(md::$T)
+        Expr(:call, typeof(md), $(map(x->:(toexpr(md.$x)), names(T))...))
+    end
 end
 
 map(deftoexpr, [MD, Paragraph, Header,


### PR DESCRIPTION
fixes #9850.

Currently `md"## Section"` is read the same as `md"#Section"` (as discussed in the issue), this fixes that.

I also fixes some whitespace, which I somehow missed in previous PR, not whitespace diff is [here](https://github.com/JuliaLang/julia/pull/9887/files?w=1):

``` diff
-         Expr(:call, $T, $(map(x->:(toexpr(md.$x)), names(T))...))
+        Expr(:call, typeof(md), $(map(x->:(toexpr(md.$x)), names(T))...))
```

_Note: this is a bug in `toexpr` rather than `parse`._

cc @one-more-minute 
