### PR TITLE
More tweaks for sparse scale/scale!

### DIFF
--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -157,13 +157,23 @@ end
 
 # scale and scale!
 sA = sprandn(3, 7, 0.5)
+sC = similar(sA)
 dA = full(sA)
 b = randn(7)
 @test scale(dA, b) == scale(sA, b)
+@test scale(dA, b) == scale!(sC, sA, b)
 @test scale(dA, b) == scale!(copy(sA), b)
 b = randn(3)
 @test scale(b, dA) == scale(b, sA)
+@test scale(b, dA) == scale!(sC, b, sA)
 @test scale(b, dA) == scale!(b, copy(sA))
+
+@test scale(dA, 0.5) == scale(sA, 0.5)
+@test scale(dA, 0.5) == scale!(sC, sA, 0.5)
+@test scale(dA, 0.5) == scale!(copy(sA), 0.5)
+@test scale(0.5, dA) == scale(0.5, sA)
+@test scale(0.5, dA) == scale!(sC, sA, 0.5)
+@test scale(0.5, dA) == scale!(0.5, copy(sA))
 
 # reductions
 @test sum(se33)[1] == 3.0


### PR DESCRIPTION
- Implement scalar `scale`/`scale!` variants
- Copy `colptr` and `rowval` from the source to the destination instead of assigning them. This costs more memory, but otherwise adding new values to the scaled matrix would corrupt the original and vice-versa.
