### PR TITLE
Push `Pair`s to `Associative`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -276,3 +276,6 @@ const base64 = base64encode
 
 @deprecate map!(f::Callable, dest::StridedArray, A::StridedArray, B::Number) broadcast!(f, dest, A, B)
 @deprecate map!(f::Callable, dest::StridedArray, A::Number, B::StridedArray) broadcast!(f, dest, A, B)
+
+#9295
+@deprecate push!(t::Associative, key, v)  setindex!(t, v, key)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -247,6 +247,8 @@ getindex(t::Associative, k1, k2, ks...) = getindex(t, tuple(k1,k2,ks...))
 setindex!(t::Associative, v, k1, k2, ks...) = setindex!(t, v, tuple(k1,k2,ks...))
 
 push!(t::Associative, p::Pair) = setindex!(t, p.second, p.first)
+push!(t::Associative, p::Pair, q::Pair) = push!(push!(t, p), q)
+push!(t::Associative, p::Pair, q::Pair, r::Pair...) = push!(push!(push!(t, p), q), r...)
 
 # hashing objects by identity
 

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -246,7 +246,7 @@ end
 getindex(t::Associative, k1, k2, ks...) = getindex(t, tuple(k1,k2,ks...))
 setindex!(t::Associative, v, k1, k2, ks...) = setindex!(t, v, tuple(k1,k2,ks...))
 
-push!(t::Associative, key, v) = setindex!(t, v, key)
+push!(t::Associative, p::Pair) = setindex!(t, p.second, p.first)
 
 # hashing objects by identity
 

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -269,3 +269,18 @@ let
     b = Dict("フー" => 17, "バー" => 4711)
     @test is(typeof(merge(a, b)), Dict{UTF8String,Float64})
 end
+
+# issue 9295
+let
+    d = Dict()
+    @test is(push!(d, 'a' => 1), d)
+    @test d['a'] == 1
+    @test is(push!(d, 'b' => 2, 'c' => 3), d)
+    @test d['b'] == 2
+    @test d['c'] == 3
+    @test is(push!(d, 'd' => 4, 'e' => 5, 'f' => 6), d)
+    @test d['d'] == 4
+    @test d['e'] == 5
+    @test d['f'] == 6
+    @test length(d) == 6
+end


### PR DESCRIPTION
ref: #9295

N.B. The apparent backward incompatibility is pushing a pair of `Pair` key and `Pair` value to the `Associative`:

``` julia
d = Dict{Pair{Int,Int},Pair{Int,Int}}()
push!(d, 1 => 2, 3 => 4)  # ERROR!
```
