### PR TITLE
Fix #9733.  Add valgrind documentation and suppressions

### DIFF
--- a/contrib/valgrind-julia.supp
+++ b/contrib/valgrind-julia.supp
@@ -1,0 +1,10 @@
+# https://github.com/JuliaLang/julia/issues/4533
+{
+   msync unwind
+   Memcheck:Param
+   msync(start)
+   ...
+   obj:*/libpthread*.so
+   ...
+   fun:rec_backtrace_ctx
+}

--- a/doc/devdocs/C.rst
+++ b/doc/devdocs/C.rst
@@ -11,3 +11,4 @@
 
    backtraces
    debuggingtips
+   valgrind

--- a/doc/devdocs/valgrind.rst
+++ b/doc/devdocs/valgrind.rst
@@ -2,25 +2,12 @@
 Using Valgrind with Julia
 *************************
 
-`Valgrind <http://valgrind.org/>`_ is a tool for memory debugging, memory leak detection, and profiling.  This section describes a few things to keep in mind when using Valgrind to debug memory issues with Julia.
-
-"Target Architecture Mismatch" error
-------------------------------------
-
-When first running ``julia`` under Valgrind, you are likely to get the following error::
-
-    Target architecture mismatch. Please delete or regenerate sys.{so,dll,dylib}.
-
-There are a few ways to deal with this:
-
-- simply `delete sys.so or its equivalent <https://groups.google.com/d/msg/julia-dev/ATr983gW9FA/HjheEXp9s3wJ>`_.
-- recompile Julia to target an instruction set more agreeable to Valgrind (e.g. set ``JULIA_CPU_TARGET = core2`` in ``Make.user``)
-- `comment out the check <https://groups.google.com/d/msg/julia-dev/ATr983gW9FA/Z7rqPKCkjLoJ>`_ in the Julia source code
+`Valgrind <http://valgrind.org/>`_ is a tool for memory debugging, memory leak detection, and profiling.  This section describes things to keep in mind when using Valgrind to debug memory issues with Julia.
 
 Suppressions
 ------------
 
-Valgrind will also typically display spurious warnings as it runs.  To reduce the number of such warnings, it helps to provide a `suppressions file <http://valgrind.org/docs/manual/manual-core.html#manual-core.suppress>`_ to Valgrind.  A sample suppressions file is included in the Julia source distribution at ``contrib/valgrind-julia.supp``.
+Valgrind will typically display spurious warnings as it runs.  To reduce the number of such warnings, it helps to provide a `suppressions file <http://valgrind.org/docs/manual/manual-core.html#manual-core.suppress>`_ to Valgrind.  A sample suppressions file is included in the Julia source distribution at ``contrib/valgrind-julia.supp``.
 
 The suppressions file can be used from the ``julia/`` source directory as follows::
 

--- a/doc/devdocs/valgrind.rst
+++ b/doc/devdocs/valgrind.rst
@@ -1,0 +1,29 @@
+*************************
+Using Valgrind with Julia
+*************************
+
+`Valgrind <http://valgrind.org/>`_ is a tool for memory debugging, memory leak detection, and profiling.  This section describes a few things to keep in mind when using Valgrind to debug memory issues with Julia.
+
+"Target Architecture Mismatch" error
+------------------------------------
+
+When first running ``julia`` under Valgrind, you are likely to get the following error::
+
+    Target architecture mismatch. Please delete or regenerate sys.{so,dll,dylib}.
+
+There are a few ways to deal with this:
+
+- simply `delete sys.so or its equivalent <https://groups.google.com/d/msg/julia-dev/ATr983gW9FA/HjheEXp9s3wJ>`_.
+- recompile Julia to target an instruction set more agreeable to Valgrind (e.g. set ``JULIA_CPU_TARGET = core2`` in ``Make.user``)
+- `comment out the check <https://groups.google.com/d/msg/julia-dev/ATr983gW9FA/Z7rqPKCkjLoJ>`_ in the Julia source code
+
+Suppressions
+------------
+
+Valgrind will also typically display spurious warnings as it runs.  To reduce the number of such warnings, it helps to provide a `suppressions file <http://valgrind.org/docs/manual/manual-core.html#manual-core.suppress>`_ to Valgrind.  A sample suppressions file is included in the Julia source distribution at ``contrib/valgrind-julia.supp``.
+
+The suppressions file can be used from the ``julia/`` source directory as follows::
+
+    $ valgrind --suppressions=contrib/valgrind-julia.supp ./julia progname.jl
+
+Any memory errors that are displayed should either be reported as bugs or contributed as additional suppressions.  Note that some versions of Valgrind are `shipped with insufficient default suppressions <https://github.com/JuliaLang/julia/issues/8314#issuecomment-55766210>`_, so that may be one thing to consider before submitting any bugs.


### PR DESCRIPTION
Here is some documentation for using Valgrind with Julia.  With regards to the "target architecture mismatch" error, I decided to describe the status quo rather than attempt to disable the check when `RUNNING_ON_VALGRIND` is true (as suggested by @Keno).  This can always be changed once the current pull request is merged.  (I figured it may be helpful to describe the status quo in case this documentation is e.g. backported to the `release-0.3` branch.)
