### PR TITLE
RFC: Add a cache for stagedfunctions

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -618,11 +618,19 @@ const limit_tuple_type_n = function (t::Tuple, lim::Int)
     return t
 end
 
-function func_for_method(m::Method, tt, env)
-    if !m.isstaged
-        return m.func.code
+let stagedcache=Dict{Any,Any}()
+    global func_for_method
+    function func_for_method(m::Method, tt, env)
+        if !m.isstaged
+            return m.func.code
+        elseif haskey(stagedcache,(m,tt,env))
+            return stagedcache[(m,tt,env)].code
+        else
+            f=ccall(:jl_instantiate_staged,Any,(Any,Any,Any),m,tt,env)
+            stagedcache[(m,tt,env)]=f
+            return f.code
+        end
     end
-    (ccall(:jl_instantiate_staged,Any,(Any,Any,Any),m,tt,env)).code
 end
 
 function abstract_call_gf(f, fargs, argtypes, e)


### PR DESCRIPTION
This adds a cache for the generation of `stagedfunction`s in `func_for_method` in inference.jl. This is probably not the way to do it, but it fixes the problems with using recursive staged functions reported in #8853 and serves as a start to get the discussion going. 
