### PR TITLE
Added a test to cover a untested code path.

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -197,7 +197,9 @@ function show_method_candidates(io::IO, ex::MethodError)
             t_in = typeintersect(method.sig[1:i], tuple(t_i[1:j]...))
             if t_in == None
                 if Base.have_color
-                    print(buf, "\e[1m\e[31m::$(method.sig[i])\e[0m")
+                    Base.with_output_color(:red, buf) do buf
+                        print(buf, "::$(method.sig[i])")
+                    end
                 else
                     print(buf, "!Matched::$(method.sig[i])")
                 end
@@ -225,7 +227,9 @@ function show_method_candidates(io::IO, ex::MethodError)
             for sigtype in method.sig[length(t_i)+1:end]
                 print(buf, ", ")
                 if Base.have_color
-                    print(buf, "\e[1m\e[31m::$sigtype\e[0m")
+                    Base.with_output_color(:red, buf) do buf
+                        print(buf, "::$sigtype")
+                    end
                 else
                     print(buf, "!Matched::$sigtype")
                 end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -41,3 +41,9 @@ Base.show_method_candidates(buf, Base.MethodError(method_c2,(1., 1., 2)))
 color = "\e[0m\nClosest candidates are:\n  method_c2(\e[1m\e[31m::Int32\e[0m, ::Float64, ::Any...)\n  method_c2(\e[1m\e[31m::Int32\e[0m, ::Any...)\n  method_c2{T<:Real}(::T<:Real, ::T<:Real, \e[1m\e[31m::T<:Real\e[0m)\n  ...\n\e[0m"
 no_color = no_color = "\nClosest candidates are:\n  method_c2(!Matched::Int32, ::Float64, ::Any...)\n  method_c2(!Matched::Int32, ::Any...)\n  method_c2{T<:Real}(::T<:Real, ::T<:Real, !Matched::T<:Real)\n  ...\n"
 test_have_color(buf, color, no_color)
+
+method_c3(x::Float64, y::Float64) = true
+Base.show_method_candidates(buf, Base.MethodError(method_c3,(1.,)))
+color = "\e[0m\nClosest candidates are:\n  method_c3(::Float64, \e[1m\e[31m::Float64\e[0m)\n\e[0m"
+no_color = no_color = "\nClosest candidates are:\n  method_c3(::Float64, !Matched::Float64)\n"
+test_have_color(buf, color, no_color)


### PR DESCRIPTION
I have added a test to cover a untested code path introduced in #9485 and changed the color in strings to use `with_output_color`, instead of hardcoded ANSI escape code colors. cc @timholy merge away when Travis is happy.
