### PR TITLE
FIX read code flavor from fenced code block

### DIFF
--- a/base/markdown/GitHub/GitHub.jl
+++ b/base/markdown/GitHub/GitHub.jl
@@ -3,13 +3,13 @@ include("table.jl")
 @breaking true ->
 function fencedcode(stream::IO, block::MD, config::Config)
     startswith(stream, "```", padding = true) || return false
-    readline(stream)
+    flavor = strip(readline(stream))
     buffer = IOBuffer()
     while !eof(stream)
         startswith(stream, "```") && break
         write(buffer, readline(stream))
     end
-    push!(block, Code(takebuf_string(buffer) |> chomp))
+    push!(block, Code(flavor, takebuf_string(buffer) |> chomp))
     return true
 end
 

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -17,6 +17,11 @@ import Base: writemime
 @test md"**foo *bar* baz**" == MD(Paragraph(Bold(["foo ", Italic("bar"), " baz"])))
 # @test md"**foo *bar* baz**" == MD(Paragraph(Italic(["foo ", Bold("bar"), " baz"])))
 
+@test md"""```julia
+foo
+```
+""" == MD(Code("julia", "foo"))
+
 @test md"Foo [bar]" == MD(Paragraph("Foo [bar]"))
 @test md"Foo [bar](baz)" != MD(Paragraph("Foo [bar](baz)"))
 @test md"Foo \[bar](baz)" == MD(Paragraph("Foo [bar](baz)"))


### PR DESCRIPTION
cc @one-more-minute 

(This needs a rebase over one of my other PRs, where Code is imported in markdown tests. But posting it anyway - hoping they'll be merged soon.)

I was thinking this may be useful for doctests as

``````
```doctest
```
``````
