### PR TITLE
Fix #9389 Uint handling for `searchsorted*` methods

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -1,6 +1,6 @@
 ## conversions to floating-point ##
 convert(::Type{Float16}, x::Integer) = convert(Float16, convert(Float32,x))
-for t in (Int8,Int16,Int32,Int64,UInt8,UInt16,UInt32,UInt64)
+for t in (Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128)
     @eval promote_rule(::Type{Float16}, ::Type{$t}) = Float32
 end
 promote_rule(::Type{Float16}, ::Type{Bool}) = Float16

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -210,6 +210,22 @@ function searchsortedfirst{T<:Integer}(a::Range{T}, x::Real, o::DirectOrdering)
     end
 end
 
+function searchsortedfirst{T<:Integer}(a::Range{T}, x::Unsigned, o::DirectOrdering)
+    if step(a) == 0
+        lt(o, first(a), x) ? length(a)+1 : 1
+    else
+        max(min(-fld(first(a)-signed(x),step(a))+1,length(a)+1),1)
+    end
+end
+
+function searchsortedlast{T<:Integer}(a::Range{T}, x::Unsigned, o::DirectOrdering)
+    if step(a) == 0
+        lt(o, x, first(a)) ? 0 : length(a)
+    else
+        max(min(fld(signed(x)-first(a),step(a))+1,length(a)),0)
+    end
+end
+
 searchsorted{T<:Real}(a::Range{T}, x::Real, o::DirectOrdering) =
     searchsortedfirst(a,x,o):searchsortedlast(a,x,o)
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -18,16 +18,27 @@ end
 @test sum(randperm(6)) == 21
 @test nthperm([0,1,2],3) == [1,0,2]
 
-@test searchsorted([1, 1, 2, 2, 3, 3], 0) == 1:0
-@test searchsorted([1, 1, 2, 2, 3, 3], 1) == 1:2
-@test searchsorted([1, 1, 2, 2, 3, 3], 2) == 3:4
-@test searchsorted([1, 1, 2, 2, 3, 3], 4) == 7:6
-@test searchsorted([1.0, 1, 2, 2, 3, 3], 2.5) == 5:4
+numTypes = [ Int8,  Int16,  Int32,  Int64,  Int128,
+            UInt8, UInt16, UInt32, UInt64, UInt128,
+            Float16, Float32, Float64, BigInt, BigFloat]
 
-@test searchsorted([1:10], 1, by=(x -> x >= 5)) == 1:4
-@test searchsorted([1:10], 10, by=(x -> x >= 5)) == 5:10
-@test searchsorted([1:5, 1:5, 1:5], 1, 6, 10, Base.Order.Forward) == 6:6
-@test searchsorted(ones(15), 1, 6, 10, Base.Order.Forward) == 6:10
+for R in numTypes, T in numTypes
+    @test searchsorted(R[1, 1, 2, 2, 3, 3], T(0)) == 1:0
+    @test searchsorted(R[1, 1, 2, 2, 3, 3], T(1)) == 1:2
+    @test searchsorted(R[1, 1, 2, 2, 3, 3], T(2)) == 3:4
+    @test searchsorted(R[1, 1, 2, 2, 3, 3], T(4)) == 7:6
+    @test searchsorted(R[1, 1, 2, 2, 3, 3], 2.5) == 5:4
+
+    @test searchsorted(1:3, T(0)) == 1:0
+    @test searchsorted(1:3, T(1)) == 1:1
+    @test searchsorted(1:3, T(2)) == 2:2
+    @test searchsorted(1:3, T(4)) == 4:3
+
+    @test searchsorted(R[1:10], T(1), by=(x -> x >= 5)) == 1:4
+    @test searchsorted(R[1:10], T(10), by=(x -> x >= 5)) == 5:10
+    @test searchsorted(R[1:5, 1:5, 1:5], T(1), 6, 10, Base.Order.Forward) == 6:6
+    @test searchsorted(ones(R, 15), T(1), 6, 10, Base.Order.Forward) == 6:10
+end
 
 for (rg,I) in [(49:57,47:59), (1:2:17,-1:19), (-3:0.5:2,-5:.5:4)]
     rg_r = reverse(rg)


### PR DESCRIPTION
`searchsortedfirst(a::Range{Integer}, x::Real)` is not working as expected when `typeof(x) == UInt8`.  This is caused by [`floor(Integer, -x)`](https://github.com/darwindarak/julia/blob/313ba4014783708ba3554f6bc76cf53d311e5935/base/sort.jl#L209), where the negation of the unsigned `x` does not give us what we need.  This PR adds a method for `searchsortedfirst` just to handle unsigned `x`.

I suppose you could just do `floor(Integer, -1x)` or `floor(Integer, 0-x)`, but that feels wrong somehow.
