### PR TITLE
improve accuracy of --track-allocation

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4232,11 +4232,15 @@ static Function *emit_function(jl_lambda_info_t *lam, bool cstyle)
         else {
             prevlabel = false;
         }
-        if (do_malloc_log && lno != prevlno) {
-            // Check memory allocation only after finishing a line
-            if (prevlno != -1)
-                mallocVisitLine(filename, prevlno);
-            prevlno = lno;
+        if (do_malloc_log) {
+            // Check memory allocation after finishing a line or hitting the next branch
+            if (lno != prevlno ||
+                (jl_is_expr(stmt) && ((jl_expr_t*)stmt)->head == goto_ifnot_sym) ||
+                jl_is_gotonode(stmt)) {
+                if (prevlno != -1)
+                    mallocVisitLine(filename, prevlno);
+                prevlno = lno;
+            }
         }
         if (jl_is_expr(stmt) && ((jl_expr_t*)stmt)->head == return_sym) {
             jl_expr_t *ex = (jl_expr_t*)stmt;


### PR DESCRIPTION
Before:

```
        - function unique(C)
      240     out = Array(eltype(C),0)
      376     seen = Set{eltype(C)}()
  2098256     for x in C
        0         if !in(x, seen)
  3147235             push!(seen, x)
        0             push!(out, x)
        -         end
        -     end
        0     out
        - end
```

After:

```
        - function unique(C)
      240     out = Array(eltype(C),0)
      376     seen = Set{eltype(C)}()
        0     for x in C
        0         if !in(x, seen)
  3147235             push!(seen, x)
  2098256             push!(out, x)
        -         end
        -     end
        0     out
        - end
```

I believe the problem was that at the end of a loop, the next line number that executes is actually at the top. I think this fix also works for branches within a line using `?`, it's just less efficient in that case since it will increment the counter multiple times for the same line.
