### PR TITLE
Deprecate ntuple(n::Integer, f::Function)

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -279,3 +279,5 @@ const base64 = base64encode
 
 #9295
 @deprecate push!(t::Associative, key, v)  setindex!(t, v, key)
+
+@deprecate ntuple(n::Integer, f::Function) ntuple(f,n)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -26,7 +26,6 @@ eltype{T}(x::(T...)) = T
 
 ## mapping ##
 
-ntuple(n::Integer, f::Function) = ntuple(f, n) # TODO: deprecate this?
 ntuple(f::Function, n::Integer) =
     n<=0 ? () :
     n==1 ? (f(1),) :


### PR DESCRIPTION
[edited]
