### PR TITLE
Call convert before filling array with fill!. Fixes #9964

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -151,7 +151,7 @@ function getindex{T<:Union(Char,Number)}(::Type{T}, r1::Range, rs::Range...)
     return a
 end
 
-function fill!{T<:Union(Int8,UInt8)}(a::Array{T}, x::Integer)
+function fill!(a::Union(Array{UInt8}, Array{Int8}), x::Integer)
     ccall(:memset, Ptr{Void}, (Ptr{Void}, Cint, Csize_t), a, x, length(a))
     return a
 end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -423,8 +423,9 @@ end
 ### from abstractarray.jl
 
 @ngenerate N typeof(A) function fill!{T,N}(A::AbstractArray{T,N}, x)
+    xT = convert(T, x)
     @nloops N i A begin
-        @inbounds (@nref N A i) = x
+        @inbounds (@nref N A i) = xT
     end
     A
 end

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -218,7 +218,8 @@ setindex!(S::SharedArray, x, I::AbstractArray) = setindex!(S.s, x, I)
 @nsplat N 1:5 setindex!(S::SharedArray, x, I::NTuple{N,Union(Real,AbstractVector)}...) = setindex!(S.s, x, I...)
 
 function fill!(S::SharedArray, v)
-    f = S->fill!(S.loc_subarr_1d, v)
+    vT = convert(eltype(S), v)
+    f = S->fill!(S.loc_subarr_1d, vT)
     @sync for p in procs(S)
         @async remotecall_wait(p, f, S)
     end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -711,6 +711,14 @@ fill!(S, 3)
 @test A == [1 1 3; 2 2 3; 1 1 1]
 rt = Base.return_types(fill!, (Array{Int32, 3}, UInt8))
 @test length(rt) == 1 && rt[1] == Array{Int32, 3}
+A = Array(Union(UInt8,Int8), 3)
+fill!(A, uint8(3))
+@test A == [0x03, 0x03, 0x03]
+# Issue #9964
+A = Array(Vector{Float64}, 2)
+fill!(A, [1, 2])
+@test A[1] == [1, 2]
+@test A[1] === A[2]
 
 # splice!
 for idx in Any[1, 2, 5, 9, 10, 1:0, 2:1, 1:1, 2:2, 1:2, 2:4, 9:8, 10:9, 9:9, 10:10,

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -138,6 +138,9 @@ d2 = map(x->1, d)
 map!(x->1, d)
 @test reduce(+, d) == 100
 
+@test fill!(d, 1) == ones(10, 10)
+@test fill!(d, 2.) == fill(2, 10, 10)
+
 # Boundary cases where length(S) <= length(pids)
 @test 2.0 == remotecall_fetch(id_other, D->D[2], Base.shmem_fill(2.0, 2; pids=[id_me, id_other]))
 @test 3.0 == remotecall_fetch(id_other, D->D[1], Base.shmem_fill(3.0, 1; pids=[id_me, id_other]))


### PR DESCRIPTION
Also fix a method signature to prevent `fill!(Array(Union(UInt8,Int8), 1), 0x01)` from crashing Julia
