### PR TITLE
Add promoting method to factorial(n,k)

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -73,6 +73,7 @@ function factorial{T<:Integer}(n::T, k::T)
     end
     return f
 end
+factorial(n::Integer, k::Integer) = factorial(promote(n, k)...)
 
 function binomial{T<:Integer}(n::T, k::T)
     k < 0 && return zero(T)

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -60,6 +60,7 @@ end
 @test_throws DomainError factorial(-7,-3)
 @test factorial(0) == 1
 @test_throws DomainError factorial(-1)
+@test_throws OverflowError factorial(1000,80)
 
 @test factorial(int64(20)) == 2432902008176640000
 # issue #6579

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -60,8 +60,10 @@ end
 @test_throws DomainError factorial(-7,-3)
 @test factorial(0) == 1
 @test_throws DomainError factorial(-1)
+#Issue 9943
+@test factorial(big(100), (80)) == 1303995018204712451095685346159820800000
+#Issue 9950
 @test_throws OverflowError factorial(1000,80)
-
 @test factorial(int64(20)) == 2432902008176640000
 # issue #6579
 @test_throws OverflowError factorial(int64(21))


### PR DESCRIPTION
Add promoting method for factorial(n,k)

Closes #9943

Also adds test for overflow of factorial(n,k) which is new behavior introduced in #9950
