### PR TITLE
Work around compilation failure in gc.c with gcc <= 4.4

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -37,6 +37,9 @@ typedef struct {
             uintptr_t pooled:1;
         };
     };
+    // Work around a bug affecting gcc up to (at least) version 4.4.7
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36839
+    int _dummy[0];
     char data[];
 } buff_t;
 


### PR DESCRIPTION
Older gcc versions complain with
"error: flexible array member in otherwise empty struct"
when the struct only contains unnamed members before the array.

I noticed this build failure on RHEL6, but I cannot confirm whether gcc 4.4 builds Julia fine or whether there are other failures (I only used gcc 4.4 instead of 4.8 during `make install` by mistake). At least README.md says we require 4.4, so I figured fixing this failure is a good step.

I couldn't find out what gcc version fixed this, only that it's not present in 4.7.
