### PR TITLE
RFC: sizehint! changes, sizehint!, resize!, and empty! tests

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -508,21 +508,23 @@ function prepend!{T}(a::Array{T,1}, items::AbstractVector)
     return a
 end
 
-function resize!(a::Vector, nl::Integer)
+function resize!(a::Vector, n::Integer)
     l = length(a)
-    if nl > l
-        ccall(:jl_array_grow_end, Void, (Any, UInt), a, nl-l)
+    if n > l
+        ccall(:jl_array_grow_end, Void, (Any, UInt), a, n-l)
     else
-        if nl < 0
+        if n < 0
             throw(ArgumentError("new length must be ≥ 0"))
         end
-        ccall(:jl_array_del_end, Void, (Any, UInt), a, l-nl)
+        ccall(:jl_array_del_end, Void, (Any, UInt), a, l-n)
     end
     return a
 end
 
-function sizehint!(a::Vector, sz::Integer)
-    ccall(:jl_array_sizehint, Void, (Any, UInt), a, sz)
+function sizehint!(a::Vector, n::Integer)
+    if n > length(a)
+        ccall(:jl_array_sizehint, Void, (Any, UInt), a, n)
+    end
     a
 end
 

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -576,15 +576,15 @@ end
 prepend!(B::BitVector, items::AbstractVector{Bool}) = prepend!(B, bitpack(items))
 prepend!(A::Vector{Bool}, items::BitVector) = prepend!(A, bitunpack(items))
 
-function sizehint!(B::BitVector, sz::Integer)
-    ccall(:jl_array_sizehint, Void, (Any, UInt), B.chunks, num_bit_chunks(sz))
+function sizehint!(B::BitVector, n::Integer)
+    ccall(:jl_array_sizehint, Void, (Any, UInt), B.chunks, num_bit_chunks(n))
     return B
 end
 
 function resize!(B::BitVector, n::Integer)
     n0 = length(B)
     n == n0 && return B
-    n >= 0 || throw(BoundsError(B, n))
+    n >= 0 || throw(ArgumentError("new length must be ≥ 0"))
     if n < n0
         deleteat!(B, n+1:n0)
         return B

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -470,8 +470,9 @@ function rehash!{K,V}(h::Dict{K,V}, newsz = length(h.keys))
     return h
 end
 
-function sizehint!(d::Dict, newsz)
+function sizehint!(d::Dict, n::Integer)
     oldsz = length(d.slots)
+    newsz = ceil(Int, 1.5*n) # _setindex! currently rehashes when 2/3 full
     if newsz <= oldsz
         # todo: shrink
         # be careful: rehash!() assumes everything fits. it was only designed

--- a/base/intset.jl
+++ b/base/intset.jl
@@ -32,16 +32,16 @@ end
 copy(s::IntSet) = union!(IntSet(), s)
 
 
-function sizehint!(s::IntSet, top::Integer)
-    if top >= s.limit
-        lim = ((top+31) & -32)>>>5
+function sizehint!(s::IntSet, n::Integer)
+    if n >= s.limit
+        lim = ((n+31) & -32)>>>5
         olsz = length(s.bits)
         if olsz < lim
             resize!(s.bits, lim)
             fill = s.fill1s ? uint32(-1) : uint32(0)
             for i=(olsz+1):lim; s.bits[i] = fill; end
         end
-        s.limit = top
+        s.limit = n
     end
     s
 end

--- a/base/set.jl
+++ b/base/set.jl
@@ -32,7 +32,7 @@ delete!(s::Set, x) = (delete!(s.dict, x); s)
 
 copy(s::Set) = union!(similar(s), s)
 
-sizehint!(s::Set, newsz) = (sizehint!(s.dict, newsz); s)
+sizehint!(s::Set, n::Integer) = (sizehint!(s.dict, n); s)
 empty!{T}(s::Set{T}) = (empty!(s.dict); s)
 rehash!(s::Set) = (rehash!(s.dict); s)
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -172,6 +172,37 @@ for i = 1:4
 end
 @test_throws BoundsError insert!(v, 5, 5)
 
+## sizehint!, resize!, empty!
+a = [1,2]
+
+resize!(a, 4)
+@test length(a) == 4
+resize!(a, 3)
+@test length(a) == 3
+@test_throws ArgumentError resize!(a, -1)
+
+sizehint!(a, 1000)
+@test length(a) == 3
+sizehint!(a, 0)
+sizehint!(a, -1)
+@test length(a) == 3
+
+a = Int[]
+b = Int[]
+sizehint!(a, 99)
+sizehint!(b, 100)
+bytes_a = @allocated for _ = 1:100; push!(a, 1); end
+bytes_b = @allocated for _ = 1:100; push!(b, 1); end
+@test bytes_a > 0
+@test bytes_b == 0
+bytes_b101 = @allocated push!(b, 1)
+@test bytes_b101 > 0
+
+empty!(a)
+@test length(a) == 0
+bytes_a = @allocated for _ = 1:100; push!(a, 1); end
+@test bytes_a == 0
+
 # concatenation
 @test isequal([ones(2,2)  2*ones(2,1)], [1. 1 2; 1 1 2])
 @test isequal([ones(2,2), 2*ones(1,2)], [1. 1; 1 1; 2 2])

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -545,6 +545,37 @@ empty!(b1)
 empty!(i1)
 @test isequal(bitunpack(b1), i1)
 
+## sizehint!, resize!, empty!
+b = bitrand(2)
+
+resize!(b, 4)
+@test length(b) == 4
+resize!(b, 3)
+@test length(b) == 3
+@test_throws ArgumentError resize!(b, -1)
+
+sizehint!(b, 1000)
+@test length(b) == 3
+sizehint!(b, 0)
+sizehint!(b, -1)
+@test length(b) == 3
+
+b1= BitArray(0)
+b2 = BitArray(0)
+sizehint!(b2, 256)
+sizehint!(b2, 512)
+bytes_b1 = @allocated for _ = 1:512; push!(b1, true); end
+bytes_b2 = @allocated for _ = 1:512; push!(b2, true); end
+@test bytes_b1> 0
+@test bytes_b2 == 0
+bytes_b2_513 = @allocated push!(b2, true)
+@test bytes_b2_513 > 0
+
+empty!(b1)
+@test length(b1) == 0
+bytes_b1 = @allocated for _ = 1:512; push!(b1, true); end
+@test bytes_b1 == 0
+
 timesofar("dequeue")
 
 ## Unary operators ##

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -93,6 +93,37 @@ end
 @test_throws ArgumentError first(Dict())
 @test first(Dict(:f=>2)) == (:f,2)
 
+# sizehint!, empty!
+a = Dict(1 => true, 2 => false)
+sizehint!(a, 1000)
+@test length(a) == 2
+sizehint!(a, 0)
+sizehint!(a, -1)
+@test length(a) == 2
+
+let
+    local hint
+    min_a = typemax(Int)
+    min_b = typemax(Int)
+    for hint in 32:100
+        a = Dict{Int, Bool}()
+        b = Dict{Int, Bool}()
+        sizehint!(b, hint)
+        min_a = min(min_a, @allocated(for i = 1:hint; a[i] = true; end))
+        min_b = min(min_b, @allocated(for i = 1:hint; b[i] = true; end))
+    end
+    @test min_a > 0
+    @test min_b == 0
+
+    a = Dict{Int, Bool}()
+    bytes_new_a = @allocated for i = 1:100; a[i] = true; end
+    @test bytes_new_a > 0
+    empty!(a)
+    @test length(a) == 0
+    bytes_empty_a = @allocated for i = 1:100; a[i] = true; end
+    @test bytes_empty_a == 0
+end
+
 # issue #1821
 let
     d = Dict{UTF8String, Vector{Int}}()


### PR DESCRIPTION
`sizehint!` is more efficient for `Dict` and `Set` (only rehashes sometimes, vs always, before reaching hinted size)
`resize!` throws consistent errors across methods
argument name `n` consistent across methods
tests added

Decision: `sizehint!(x, -1)` was inconsistent about throwing an error -- I made it never throw -- seemed reasonable as requests to shrink `x` also don't throw.

Decision: I left `jl_array_sizehint` alone (taking n of `size_t`) rather than pushing the `n < 0` check into it -- not familiar with C or project style.
