### PR TITLE
Give a better error message for invalid input to histrange

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -518,7 +518,13 @@ end
 ## nice-valued ranges for histograms
 
 function histrange{T<:FloatingPoint,N}(v::AbstractArray{T,N}, n::Integer)
-    if length(v) == 0
+    nv = length(v)
+    if nv == 0 && n < 0
+        throw(ArgumentError("number of bins must be ≥ 0 for an empty array, got $n"))
+    elseif nv > 0 && n < 1
+        throw(ArgumentError("number of bins must be ≥ 1 for a non-empty array, got $n"))
+    end
+    if nv == 0
         return 0.0:1.0:0.0
     end
     lo, hi = extrema(v)
@@ -542,7 +548,13 @@ function histrange{T<:FloatingPoint,N}(v::AbstractArray{T,N}, n::Integer)
 end
 
 function histrange{T<:Integer,N}(v::AbstractArray{T,N}, n::Integer)
-    if length(v) == 0
+    nv = length(v)
+    if nv == 0 && n < 0
+        throw(ArgumentError("number of bins must be ≥ 0 for an empty array, got $n"))
+    elseif nv > 0 && n < 1
+        throw(ArgumentError("number of bins must be ≥ 1 for a non-empty array, got $n"))
+    end
+    if nv == 0
         return 0:1:0
     end
     lo, hi = extrema(v)

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -264,3 +264,12 @@ end
 @test quantile([1,2,3,4],0.5) == 2.5
 @test quantile([1., 3],[.25,.5,.75])[2] == median([1., 3])
 @test quantile([0.:100.],[.1,.2,.3,.4,.5,.6,.7,.8,.9])[1] == 10.0
+
+
+# test invalid hist nbins argument (#9999)
+@test_throws ArgumentError hist(Int[], -1)
+@test hist(Int[], 0)[2] == Int[]
+@test_throws ArgumentError hist([1,2,3], -1)
+@test_throws ArgumentError hist([1,2,3], 0)
+@test_throws ArgumentError hist([1.0,2.0,3.0], -1)
+@test_throws ArgumentError hist([1.0,2.0,3.0], 0)


### PR DESCRIPTION
This used to return a `DomainError` for negative number of bins, or `InexactError` when the number of bins was zero.
