### PR TITLE
Promote (Float16, Bool) to Float16 instead of Float32

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -1,8 +1,9 @@
 ## conversions to floating-point ##
 convert(::Type{Float16}, x::Integer) = convert(Float16, convert(Float32,x))
-for t in (Bool,Int8,Int16,Int32,Int64,UInt8,UInt16,UInt32,UInt64)
+for t in (Int8,Int16,Int32,Int64,UInt8,UInt16,UInt32,UInt64)
     @eval promote_rule(::Type{Float16}, ::Type{$t}) = Float32
 end
+promote_rule(::Type{Float16}, ::Type{Bool}) = Float16
 
 for t1 in (Float32,Float64)
     for st in (Int8,Int16,Int32,Int64)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -756,3 +756,11 @@ end
 # float #8291
 @test float(Complex(1, 2)) == Complex(1.0, 2.0)
 @test round(float(Complex(π, e)),3) == Complex(3.142, 2.718)
+
+# Complex32 arithmetic #10003
+@test float16(1)+float16(1)im === Complex32(1, 1)
+@test float16(1)-float16(1)im === float16(1)+float16(-1)im === Complex32(1, -1)
+@test float16(1)*im === Complex32(im)
+@test float16(1)/im === 1.0f0/im === Complex(0.0, -1.0)
+@test float16(1)^im === Complex32(1) === float16(1)+float16(0)im
+


### PR DESCRIPTION
This change makes it possible to construct `Complex32` numbers using the literal syntax `a+b*im`, since `b*im` relies on this promotion rule.

Ref: #5942
