### PR TITLE
Fix windows support for `build_executable.jl`. fix #9973

### DIFF
--- a/contrib/build_executable.jl
+++ b/contrib/build_executable.jl
@@ -110,7 +110,7 @@ function build_executable(exename, script_file, targetdir=nothing; force=false)
 
     gcc = find_system_gcc()
     # This argument is needed for the gcc, see issue #9973
-    win_arg = @windows ? "-D_WIN32_WINNT=0x0502" : ""
+    win_arg = @windows ? `-D_WIN32_WINNT=0x0502` : ``
     incs = get_includes()
     ENV2 = deepcopy(ENV)
     @windows_only begin
@@ -197,9 +197,9 @@ function emit_cmain(cfile, exename, relocation)
     if relocation
         sysji = joinpath("lib"*exename)
     else
-        sysji = joinpath("..", "lib", "lib"*exename)
+        sysji = joinpath(dirname(Sys.dlpath("libjulia")), "lib"*exename)
     end
-
+    sysji = escape_string(sysji)
     f = open(cfile, "w")
     write( f, """
         #include <julia.h>

--- a/contrib/build_executable.jl
+++ b/contrib/build_executable.jl
@@ -57,10 +57,9 @@ function build_executable(exename, script_file, targetdir=nothing; force=false)
     julia = abspath(joinpath(JULIA_HOME, "julia"))
     build_sysimg = abspath(joinpath(dirname(@__FILE__), "build_sysimg.jl"))
 
-    patchelf = nothing
     if targetdir != nothing
         patchelf = find_patchelf()
-        if patchelf == nothing
+        if patchelf == nothing && !(OS_NAME == :Windows)
             println("ERROR: Using the 'targetdir' option requires the 'patchelf' utility. Please install it.")
             return 1
         end
@@ -109,37 +108,62 @@ function build_executable(exename, script_file, targetdir=nothing; force=false)
     run(`$(julia) $(build_sysimg) $(sys.buildfile) native $(userimgjl) --force`)
     println()
 
+    gcc = find_system_gcc()
+    # This argument is needed for the gcc, see issue #9973
+    win_arg = @windows ? "-D_WIN32_WINNT=0x0600" : ""
+    @windowsxp_only win_arg = "-D_WINVER=0x0502"
+    incs = get_includes()
+    @windows_only begin
+        if contains(gcc, "WinRPM")
+            # This should not bee necessary, it is done due to WinRPM's gcc's
+            # include paths is not correct see WinRPM.jl issue #38
+            old_path = ENV["path"]
+            ENV["path"] = old_path*";"*dirname(gcc)
+            push!(incs, "-I"*abspath(joinpath(dirname(gcc),"..","include")))
+        else
+            gcc = Base.shell_split(gcc)
+        end
+    end
+
     for exe in [exe_release, exe_debug]
-        incs = join(get_includes(), " ")
-        println("running: gcc -g -Wl,--no-as-needed $(incs) $(cfile) -o $(exe.buildfile) -Wl,-rpath,$(sys.buildpath) -L$(sys.buildpath) $(exe.libjulia) -l$(exename)")
-        run(`gcc -g -Wl,--no-as-needed $(get_includes()) $(cfile) -o $(exe.buildfile) -Wl,-rpath,$(sys.buildpath) -L$(sys.buildpath) $(exe.libjulia) -l$(exename)`)
+        println("running: $gcc -g -Wl,--no-as-needed $win_arg $(join(incs, " ")) $(cfile) -o $(exe.buildfile) -Wl,-rpath,$(sys.buildpath) -L$(sys.buildpath) $(exe.libjulia) -l$(exename)")
+        run(`$gcc -g -Wl,--no-as-needed $win_arg $(incs) $(cfile) -o $(exe.buildfile) -Wl,-rpath,$(sys.buildpath) -L$(sys.buildpath) $(exe.libjulia) -l$(exename)`)
         println()
+    end
+    @windows_only begin
+        if contains(gcc, "WinRPM")
+            ENV["path"] = old_path
+        end
     end
 
     println("running: rm -rf $(tmpdir) $(sys.buildfile).o $(sys.buildfile0).o $(sys.buildfile0).ji")
-    run(`rm -rf $(tmpdir) $(sys.buildfile).o $(sys.buildfile0).o $(sys.buildfile0).ji`)
+    map(f-> rm(f, recursive=true), [tmpdir, sys.buildfile*".o", sys.buildfile0*".o", sys.buildfile0*".ji"])
     println()
 
     if targetdir != nothing
         # Move created files to target directory
-        run(`mv $(exe_release.buildfile) $(exe_debug.buildfile) $(sys.buildfile).$(Sys.dlext) $(sys.buildfile).ji $(targetdir)`)
+        for file in [exe_release.buildfile, exe_debug.buildfile, sys.buildfile*".$(Sys.dlext)", sys.buildfile*".ji"]
+            mv(file,joinpath(targetdir, basename(file)))
+        end
 
         # Copy needed shared libraries to the target directory
         tmp = ".*\.$(Sys.dlext).*"
         shlibs = filter(Regex(tmp),readdir(sys.buildpath))
         for shlib in shlibs
-            run(`cp $(joinpath(sys.buildpath, shlib)) $(targetdir)`)
+            cp(joinpath(sys.buildpath, shlib), joinpath(targetdir, shlib))
         end
 
-        # Fix rpath in executable and shared libraries
-        shlibs = filter(Regex(tmp),readdir(targetdir))
-        push!(shlibs, exe_release.filename)
-        push!(shlibs, exe_debug.filename)
-
-        for shlib in shlibs
-            rpath = readall(`$(patchelf) --print-rpath $(joinpath(targetdir, shlib))`)[1:end-1]
-            if Base.samefile(rpath, sys.buildpath)
-                run(`$(patchelf) --set-rpath $(targetdir) $(joinpath(targetdir, shlib))`)
+        @unix_only begin
+            # Fix rpath in executable and shared libraries
+            shlibs = filter(Regex(tmp),readdir(targetdir))
+            push!(shlibs, exe_release.filename)
+            push!(shlibs, exe_debug.filename)
+            println(shlibs)
+            for shlib in shlibs
+                rpath = readall(`$(patchelf) --print-rpath $(joinpath(targetdir, shlib))`)[1:end-1]
+                if Base.samefile(rpath, sys.buildpath)
+                    run(`$(patchelf) --set-rpath $(targetdir) $(joinpath(targetdir, shlib))`)
+                end
             end
         end
     end
@@ -151,20 +175,13 @@ function build_executable(exename, script_file, targetdir=nothing; force=false)
 end
 
 function find_patchelf()
-    patchelf = nothing
-
-    for x in [joinpath(JULIA_HOME, "patchelf"), "patchelf"]
-        patchelf = x
-        works = true
+    for patchelf in [joinpath(JULIA_HOME, "patchelf"), "patchelf"]
         try
-            x=readall(`$(patchelf) --version`)
-        catch
-            works = false
+            if success(`$(patchelf) --version`)
+                return patchelf
+            end
         end
-        works && break
     end
-
-    patchelf
 end
 
 function get_includes()
@@ -219,12 +236,30 @@ function emit_cmain(cfile, exename, relocation)
 end
 
 function emit_userimgjl(userimgjl, script_file)
-    f = open(userimgjl, "w")
-    write( f, """
-        include(\"$(script_file)\")
-        """
-    )
-    close(f)
+    open(userimgjl, "w") do f
+        write( f, "include(\"$(escape_string(script_file))\")")
+    end
+end
+
+function find_system_gcc()
+    # On Windows, check to see if WinRPM is installed, and if so, see if gcc is installed
+    @windows_only try
+        require("WinRPM")
+        winrpmgcc = joinpath(WinRPM.installdir,"usr","$(Sys.ARCH)-w64-mingw32",
+            "sys-root","mingw","bin","gcc.exe")
+        if success(`$winrpmgcc --version`)
+            return winrpmgcc
+        end
+    end
+
+    # See if `gcc` exists
+    try
+        if success(@windows ? `cmd /c gcc -v` : `gcc -v`)
+            return @windows ? "cmd /c gcc" : "gcc"
+        end
+    end
+
+    error( "GCC not found on system: " * @windows? "GCC can be installed via `Pkg.add(\"WinRPM\"); WinRPM.install(\"gcc\")`" : "" )
 end
 
 if !isinteractive()


### PR DESCRIPTION
The changes made to the script allow for use on windows.

I have changed how `gcc` is found, the setup for the compiler and the changes in the copying/moving files. The things I would like to get thorough review is:
- That I have disabled the fix rpath on windows, https://github.com/dhoegh/julia/blob/b76f234f777cb37f4686af11200e9ec928622908/contrib/build_executable.jl#L156-L168. The results still works also if the containing folder is moved, I do not know if this is correct please enlighten me.
-  Changes in `find_patchelf` function. I changed it due to it did not return `nothing` when `patchelf` is not installed, which I think is not the intention.

It would also be great if someone could test it on windows, if possible windows xp due to https://github.com/dhoegh/julia/blob/b76f234f777cb37f4686af11200e9ec928622908/contrib/build_executable.jl#L114 which I have not tested but brought up in #9973.

@few could you review my changes?
