### PR TITLE
WIP: Add ability to run test suite under valgrind

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -8,6 +8,9 @@ default: all
 $(TESTS) ::
 	@$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes -f ./runtests.jl $@)
 
+valgrind-all:
+	valgrind --suppressions=../contrib/valgrind-julia.supp $(JULIA_EXECUTABLE) ./runtests.jl all
+
 perf:
 	@$(MAKE) -C perf all
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,14 +40,16 @@ catch
     net_on = false
 end
 
+valgrind_on = (ccall(:jl_running_on_valgrind,Cint,()) != 0)
+
 cd(dirname(@__FILE__)) do
     n = 1
-    if net_on
+    if !net_on
+        filter!(x -> !(x in net_required_for), tests)
+    elseif !valgrind_on
         n = min(8, CPU_CORES, length(tests))
         n > 1 && addprocs(n; exeflags=`--check-bounds=yes`)
         blas_set_num_threads(1)
-    else
-        filter!(x -> !(x in net_required_for), tests)
     end
 
     @everywhere include("testdefs.jl")


### PR DESCRIPTION
It would be great to be able to run the entire Julia test suite under Valgrind.  Here is an initial attempt ~~but the tests fail in `broadcast.jl` (only under valgrind) for reasons I do not understand~~.

CC: @Keno
