### PR TITLE
Fix off-by-one error in ==(s1::IntSet, s2::IntSet)

### DIFF
--- a/base/intset.jl
+++ b/base/intset.jl
@@ -281,7 +281,7 @@ function ==(s1::IntSet, s2::IntSet)
             end
         end
     else
-        for i = lim1:lim2
+        for i = lim1+1:lim2
             if s2.bits[i] != filln
                 return false
             end

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -239,6 +239,10 @@ setdiff!(s2, IntSet([2, 4, 5, 6]))
 
 @test s2 == IntSet([1, 3])
 
+# == with last-bit set (groups.google.com/forum/#!topic/julia-users/vZNjiIEG_sY)
+s = IntSet(255)
+@test s == s
+
 # issue #7851
 @test_throws ArgumentError IntSet(-1)
 @test !(-1 in IntSet(0:10))


### PR DESCRIPTION
In the case that s1 is shorter than or the same length as s2, fix an off-by-one error where the last chunk of s1 is overridden and that chunk in s2 is erroneously compared to zeros or fill1s.

Ref: https://groups.google.com/forum/#!topic/julia-users/vZNjiIEG_sY

This is good to go once CI gives the green light.
