### PR TITLE
Allow sparse / sparsevec constructors to work for AbstractMatrix argument types.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,8 @@ Compiler improvements
 Library improvements
 --------------------
 
+  * `sparse(A)` now takes any `AbstractMatrix` A as an argument. ([#10031])
+
   * Factorization api is now type-stable, functions dispatch on `Val{false}` or `Val{true}` instead of a boolean value ([#9575]).
 
   * `convert` now checks for overflow when truncating integers or converting between

--- a/base/array.jl
+++ b/base/array.jl
@@ -1162,7 +1162,7 @@ function findn(A::StridedMatrix)
     return (I, J)
 end
 
-function findnz{T}(A::StridedMatrix{T})
+function findnz{T}(A::AbstractMatrix{T})
     nnzA = countnz(A)
     I = zeros(Int, nnzA)
     J = zeros(Int, nnzA)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -162,7 +162,7 @@ function convert{Tv,TvS,TiS}(::Type{SparseMatrixCSC{Tv}}, S::SparseMatrixCSC{TvS
     end
 end
 
-function convert{Tv,Ti}(::Type{SparseMatrixCSC{Tv,Ti}}, M::Matrix)
+function convert{Tv,Ti}(::Type{SparseMatrixCSC{Tv,Ti}}, M::AbstractMatrix)
     m, n = size(M)
     (I, J, V) = findnz(M)
     return sparse_IJ_sorted!(convert(Vector{Ti},I),
@@ -231,7 +231,7 @@ sparse(a::Vector) = sparsevec(a)
 
 ## Construct a sparse matrix
 
-sparse{Tv}(A::Matrix{Tv}) = convert(SparseMatrixCSC{Tv,Int}, A)
+sparse{Tv}(A::AbstractMatrix{Tv}) = convert(SparseMatrixCSC{Tv,Int}, A)
 
 sparse(S::SparseMatrixCSC) = copy(S)
 

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -670,7 +670,7 @@ Sparse matrices support much of the same set of operations as dense matrices. Th
 
 .. function:: sparse(A)
 
-   Convert a dense matrix ``A`` into a sparse matrix.
+   Convert an AbstractMatrix ``A`` into a sparse matrix.
 
 .. function:: sparsevec(A)
 

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -655,3 +655,15 @@ let S = sprand(10, 10, 0.1)
     @test_throws BoundsError S[[0,2,1], [1,2]]
     @test_throws BoundsError S[[2,1], [0,1,2]]
 end
+
+# Test that sparse / sparsevec constructors work for AbstractMatrix subtypes
+let D = Diagonal(ones(10,10)),
+    sm = sparse(D),
+    sv = sparsevec(D)
+
+    @test countnz(sm) == 10
+    @test countnz(sv) == 10
+
+    @test countnz(sparse(Diagonal(Int[]))) == 0
+    @test countnz(sparsevec(Diagonal(Int[]))) == 0
+end


### PR DESCRIPTION
This used to only work for generic `Matrix` subtypes.
