### PR TITLE
Fix conversion from Bidiagonal to Tridiagonal

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -43,7 +43,7 @@ promote_rule{T,S}(::Type{Matrix{T}}, ::Type{Bidiagonal{S}})=Matrix{promote_type(
 Tridiagonal{T}(M::Bidiagonal{T}) = convert(Tridiagonal{T}, M)
 function convert{T}(::Type{Tridiagonal{T}}, A::Bidiagonal{T})
     z = zeros(T, size(A)[1]-1)
-    A.isupper ? Tridiagonal(A.ev, A.dv, z) : Tridiagonal(z, A.dv, A.ev)
+    A.isupper ? Tridiagonal(z, A.dv, A.ev) : Tridiagonal(A.ev, A.dv, z)
 end
 promote_rule{T,S}(::Type{Tridiagonal{T}}, ::Type{Bidiagonal{S}})=Tridiagonal{promote_type(T,S)}
 

--- a/test/linalg4.jl
+++ b/test/linalg4.jl
@@ -175,11 +175,13 @@ for isupper in (true, false)
     for newtype in [Bidiagonal, Tridiagonal, isupper ? UpperTriangular : LowerTriangular, Matrix]
         debug && println("newtype is $(newtype)")
         @test full(convert(newtype, A)) == full(A)
+        @test full(newtype(A)) == full(A)
     end
     A=Bidiagonal(a, zeros(n-1), isupper) #morally Diagonal
     for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, isupper ? UpperTriangular : LowerTriangular, Matrix]
         debug && println("newtype is $(newtype)")
         @test full(convert(newtype, A)) == full(A)
+        @test full(newtype(A)) == full(A)
     end
 end
 


### PR DESCRIPTION
These were backwards, I'm going to guess @jiahao never tested this.

```
julia> A = Bidiagonal(rand(5), rand(4), false)
5x5 Base.LinAlg.Bidiagonal{Float64}:
 0.736088  0.0       0.0       0.0       0.0
 0.889034  0.814527  0.0       0.0       0.0
 0.0       0.192649  0.998929  0.0       0.0
 0.0       0.0       0.568169  0.522361  0.0
 0.0       0.0       0.0       0.82861   0.198964

julia> Tridiagonal(A)
5x5 Base.LinAlg.Tridiagonal{Float64}:
 0.736088  0.889034  0.0       0.0       0.0
 0.0       0.814527  0.192649  0.0       0.0
 0.0       0.0       0.998929  0.568169  0.0
 0.0       0.0       0.0       0.522361  0.82861
 0.0       0.0       0.0       0.0       0.198964
```
