### PR TITLE
Do much the same for libstdc++ as we do for libgfortran on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,6 +355,9 @@ endif
 ifneq ($(OS), WINNT)
 	-./contrib/fixup-libgfortran.sh $(DESTDIR)$(private_libdir)
 endif
+ifeq ($(OS), Linux)
+	-./contrib/fixup-libstdc++.sh $(DESTDIR)$(private_libdir)
+endif
 	# Copy in juliarc.jl files per-platform for binary distributions as well
 	# Note that we don't install to sysconfdir: we always install to $(DESTDIR)$(prefix)/etc.
 	# If you want to make a distribution with a hardcoded path, you take care of installation

--- a/contrib/fixup-libstdc++.sh
+++ b/contrib/fixup-libstdc++.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Run as: fixup-libstdc++.sh <$private_libdir>
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <private_libdir>"
+    exit 1
+fi
+
+private_libdir=$1
+
+if [ ! -f "$private_libdir/libjulia.so" ]; then
+    echo "ERROR: Could not open $private_libdir/libjulia.so" >&2
+    exit 2
+fi
+
+find_shlib ()
+{
+    if [ -f "$private_libdir/lib$1.so" ]; then
+        ldd "$private_libdir/lib$1.so" | grep $2 | cut -d' ' -f3 | xargs
+    fi
+}
+
+# Discover libstdc++ location and name
+LIBSTD=$(find_shlib "julia" "libstdc++.so")
+LIBSTD_NAME=$(basename $LIBSTD)
+LIBSTD_DIR=$(dirname $LIBSTD)
+
+if [ ! -f "$private_libdir/$LIBSTD_NAME" ] && [ -f "$LIBSTD_DIR/$LIBSTD_NAME" ]; then
+    cp -v "$LIBSTD_DIR/$LIBSTD_NAME" "$private_libdir"
+    chmod 755 "$private_libdir/$LIBSTD_NAME"
+fi


### PR DESCRIPTION
This distributes the system `libstdc++.so.X` alongside Julia when you `make dist`.

@tkelman
