### PR TITLE
addprocs : minor cleanup, added comments, rearranged code

### DIFF
--- a/base/managers.jl
+++ b/base/managers.jl
@@ -1,0 +1,313 @@
+# Built-in SSH and Local Managers
+
+immutable SSHManager <: ClusterManager
+    machines::Dict
+
+    function SSHManager(machines)
+        # machines => array of machine elements
+        # machine => address or (address, cnt)
+        # address => string of form `[user@]host[:port] bind_addr[:bind_port]`
+        # cnt => :auto or number
+        # :auto launches NUM_CORES number of workers at address
+        # number launches the specified number of workers at address
+        mhist = Dict()
+        for m in machines
+            if isa(m, Tuple)
+                host=m[1]
+                cnt=m[2]
+            else
+                host=m
+                cnt=1
+            end
+            current_cnt = get(mhist, host, 0)
+
+            if isa(cnt, Number)
+                mhist[host] = isa(current_cnt, Number) ? current_cnt + Int(cnt) : Int(cnt)
+            else
+                mhist[host] = cnt
+            end
+        end
+        new(mhist)
+    end
+end
+
+
+function check_addprocs_args(kwargs)
+    for keyname in kwargs
+        !(keyname[1] in [:dir, :exename, :exeflags]) && throw(ArgumentError("Invalid keyword argument $(keyname[1])"))
+    end
+end
+
+# SSHManager
+
+# start and connect to processes via SSH, optionally through an SSH tunnel.
+# the tunnel is only used from the head (process 1); the nodes are assumed
+# to be mutually reachable without a tunnel, as is often the case in a cluster.
+# Default value of kw arg max_parallel is the default value of MaxStartups in sshd_config
+# A machine is either a <hostname> or a tuple of (<hostname>, count)
+function addprocs(machines::AbstractVector; tunnel=false, sshflags=``, max_parallel=10, kwargs...)
+    check_addprocs_args(kwargs)
+    addprocs(SSHManager(machines); tunnel=tunnel, sshflags=sshflags, max_parallel=max_parallel, kwargs...)
+end
+
+
+function launch(manager::SSHManager, params::Dict, launched::Array, launch_ntfy::Condition)
+    # Launch one worker on each unique host in parallel. Additional workers are launched later.
+    # Wait for all launches to complete.
+    launch_tasks = cell(length(manager.machines))
+
+    for (i,(machine, cnt)) in  enumerate(manager.machines)
+        let machine=machine, cnt=cnt
+            launch_tasks[i] = @schedule try
+                    launch_on_machine(manager, machine, cnt, params, launched, launch_ntfy)
+                catch e
+                    print(STDERR, "exception launching on machine $(machine) : $(e)\n")
+                end
+        end
+    end
+
+    for t in launch_tasks
+        wait(t)
+    end
+
+    notify(launch_ntfy)
+end
+
+
+show(io::IO, manager::SSHManager) = println(io, "SSHManager(machines=", manager.machines, ")")
+
+
+function launch_on_machine(manager::SSHManager, machine, cnt, params, launched, launch_ntfy::Condition)
+    dir = params[:dir]
+    exename = params[:exename]
+    exeflags = params[:exeflags]
+
+    # machine could be of the format [user@]host[:port] bind_addr[:bind_port]
+    machine_bind = split(machine)
+    if length(machine_bind) > 1
+        exeflags = `--bind-to $(machine_bind[2]) $exeflags`
+    end
+    exeflags = `$exeflags --worker`
+
+    machine_def = machine_bind[1]
+    machine_def = split(machine_def, ':')
+    portopt = length(machine_def) == 2 ? ` -p $(machine_def[2]) ` : ``
+    sshflags = `$(params[:sshflags]) $portopt`
+
+    host = machine_def[1]
+
+    # Build up the ssh command
+    cmd = `cd $dir && $exename $exeflags` # launch julia
+    cmd = `sh -l -c $(shell_escape(cmd))` # shell to launch under
+    cmd = `ssh -T -a -x -o ClearAllForwardings=yes -n $sshflags $host $(shell_escape(cmd))` # use ssh to remote launch
+
+    # launch
+    io, pobj = open(detach(cmd), "r")
+    wconfig = WorkerConfig()
+
+    wconfig.io = io
+    wconfig.host = host
+    wconfig.sshflags = sshflags
+    wconfig.exeflags = exeflags
+    wconfig.exename = exename
+    wconfig.count = cnt
+    wconfig.max_parallel = get(params, :max_parallel, Nullable{Integer}())
+
+    push!(launched, wconfig)
+    notify(launch_ntfy)
+end
+
+
+function manage(manager::SSHManager, id::Integer, config::WorkerConfig, op::Symbol)
+    if op == :interrupt
+        ospid = get(config.ospid, 0)
+        if ospid > 0
+            host = get(config.host)
+            sshflags = get(config.sshflags)
+            if !success(`ssh -T -a -x -o ClearAllForwardings=yes -n $sshflags $host "kill -2 $ospid"`)
+                println("Error sending a Ctrl-C to julia worker $id on $machine")
+            end
+        else
+            # This state can happen immediately after an addprocs
+            println("Worker $id cannot be presently interrupted.")
+        end
+    end
+end
+
+let tunnel_port = 9201
+    global next_tunnel_port
+    function next_tunnel_port()
+        retval = tunnel_port
+        if tunnel_port > 32000
+            tunnel_port = 9201
+        else
+            tunnel_port += 1
+        end
+        retval
+    end
+end
+
+
+# establish an SSH tunnel to a remote worker
+# returns P such that localhost:P connects to host:port
+function ssh_tunnel(user, host, bind_addr, port, sshflags)
+    localp = next_tunnel_port()
+    ntries = cnt = 100
+    while !success(detach(`ssh -T -a -x -o ExitOnForwardFailure=yes -f $sshflags $(user)@$host -L $localp:$bind_addr:$(int(port)) sleep 60`)) && cnt > 0
+        localp = next_tunnel_port()
+        cnt -= 1
+    end
+    (cnt == 0) && error("Unable to create SSH tunnel after $cnt tries. No free port?")
+
+    localp
+end
+
+
+# LocalManager
+
+immutable LocalManager <: ClusterManager
+    np::Integer
+end
+
+addprocs(; kwargs...) = addprocs(Sys.CPU_CORES; kwargs...)
+function addprocs(np::Integer; kwargs...)
+    check_addprocs_args(kwargs)
+    addprocs(LocalManager(np); kwargs...)
+end
+
+show(io::IO, manager::LocalManager) = println(io, "LocalManager()")
+
+function launch(manager::LocalManager, params::Dict, launched::Array, c::Condition)
+    dir = params[:dir]
+    exename = params[:exename]
+    exeflags = params[:exeflags]
+
+    for i in 1:manager.np
+        io, pobj = open(detach(setenv(`$(julia_cmd(exename)) $exeflags --bind-to $(LPROC.bind_addr) --worker`, dir=dir)), "r")
+        wconfig = WorkerConfig()
+        wconfig.process = pobj
+        wconfig.io = io
+        push!(launched, wconfig)
+    end
+
+    notify(c)
+end
+
+function manage(manager::LocalManager, id::Integer, config::WorkerConfig, op::Symbol)
+    if op == :interrupt
+        kill(get(config.process), 2)
+    end
+end
+
+
+# DefaultClusterManager for the default TCP transport - used by both SSHManager and LocalManager
+
+immutable DefaultClusterManager <: ClusterManager
+end
+
+function connect(manager::ClusterManager, pid::Int, config::WorkerConfig)
+    if !isnull(config.connect_at)
+        # this is a worker-to-worker setup call.
+        return connect_w2w(pid, config)
+    end
+
+    # master connecting to workers
+    if !isnull(config.io)
+        (bind_addr, port) = read_worker_host_port(get(config.io))
+        pubhost=get(config.host, bind_addr)
+    else
+        pubhost=get(config.host)
+        port=get(config.port)
+        bind_addr=get(config.bind_addr, pubhost)
+    end
+
+    tunnel = get(config.tunnel, false)
+
+    s = split(pubhost,'@')
+    user = ""
+    if length(s) > 1
+        user = s[1]
+        pubhost = s[2]
+    else
+        if haskey(ENV, "USER")
+            user = ENV["USER"]
+        elseif tunnel
+            error("USER must be specified either in the environment or as part of the hostname when tunnel option is used")
+        end
+    end
+
+    if tunnel
+        sshflags = get(config.sshflags)
+        (s, bind_addr) = connect_to_worker(pubhost, bind_addr, port, user, sshflags)
+    else
+        (s, bind_addr) = connect_to_worker(bind_addr, port)
+    end
+
+    config.host = pubhost
+    config.port = port
+    config.bind_addr = bind_addr
+
+    # write out a subset of the connect_at required for further worker-worker connection setups
+    config.connect_at = (bind_addr, port)
+
+    if !isnull(config.io)
+        let pid = pid
+            redirect_worker_output(pid, get(config.io))
+        end
+    end
+
+    (s, s)
+end
+
+function connect_w2w(pid::Int, config::WorkerConfig)
+    (rhost, rport) = get(config.connect_at)
+    config.host = rhost
+    config.port = rport
+    if get(get(config.environ), :self_is_local, false) && get(get(config.environ), :r_is_local, false)
+        # If on localhost, use the loopback address - this addresses
+        # the special case of system suspend wherein the local ip
+        # may be changed upon system awake.
+        (s, bind_addr) = connect_to_worker("127.0.0.1", rport)
+    else
+        (s, bind_addr)= connect_to_worker(rhost, rport)
+    end
+
+    (s,s)
+end
+
+
+function connect_to_worker(host::AbstractString, port::Integer)
+    # Connect to the loopback port if requested host has the same ipaddress as self.
+    if host == string(LPROC.bind_addr)
+        s = connect("127.0.0.1", uint16(port))
+    else
+        s = connect(host, uint16(port))
+    end
+
+    # Avoid calling getaddrinfo if possible - involves a DNS lookup
+    # host may be a stringified ipv4 / ipv6 address or a dns name
+    if host == "localhost"
+        bind_addr = "127.0.0.1"
+    else
+        try
+            bind_addr = string(parseip(host))
+        catch
+            bind_addr = string(getaddrinfo(host))
+        end
+    end
+    (s, bind_addr)
+end
+
+
+function connect_to_worker(host::AbstractString, bind_addr::AbstractString, port::Integer, tunnel_user::AbstractString, sshflags)
+    s = connect("localhost", ssh_tunnel(tunnel_user, host, bind_addr, uint16(port), sshflags))
+    (s, bind_addr)
+end
+
+function kill(manager::ClusterManager, pid::Int, config::WorkerConfig)
+    remote_do(pid, exit) # For TCP based transports this will result in a close of the socket
+                       # at our end, which will result in a cleanup of the worker.
+    nothing
+end
+
+

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -87,6 +87,7 @@ type WorkerConfig
 
     # Used when launching additional workers at a host
     count::Nullable{Union(Int, Symbol)}
+    exename::Nullable{AbstractString}
     exeflags::Nullable{Cmd}
 
     # External cluster managers can use this to store information at a per-worker level
@@ -237,21 +238,6 @@ function get_bind_addr(w::Worker)
         end
     end
     w.config.bind_addr
-end
-
-function add_worker(pg::ProcessGroup, w)
-    # NOTE: currently only node 1 can add new nodes, since nobody else
-    # has the full list of address:port
-    assert(LPROC.id == 1)
-    rr_join = RemoteRef()
-    process_messages(w.r_stream, w.w_stream; ntfy_join_complete=rr_join)
-
-    all_locs = map(x -> isa(x, Worker) ? (get(x.config.connect_at, ()), x.id, isa(x.manager, LocalManager)) : ((), x.id, true), pg.workers)
-
-    send_msg_now(w, :join_pgrp, w.id, all_locs, isa(w.manager, LocalManager))
-
-    @schedule manage(w.manager, w.id, w.config, :register)
-    rr_join
 end
 
 myid() = LPROC.id
@@ -892,7 +878,7 @@ function create_message_handler_loop(r_stream::AsyncStream, w_stream::AsyncStrea
 
                     for (connect_at, rpid, r_is_local) in locs
                         if (rpid < self_pid) && (!(rpid == 1))
-                            # Connect to them
+                            # Connect processes with lower pids
                             wconfig = WorkerConfig()
                             wconfig.connect_at = connect_at
                             wconfig.environ = AnyDict(:self_is_local=>self_is_local, :r_is_local=>r_is_local)
@@ -903,7 +889,7 @@ function create_message_handler_loop(r_stream::AsyncStream, w_stream::AsyncStrea
                             process_messages(w.r_stream, w.w_stream)
                             send_msg_now(w, :identify_socket, self_pid)
                         else
-                            # Others will connect to us. Don't do anything just yet
+                            # Processes with higher pids connect to us. Don't do anything just yet
                             continue
                         end
                     end
@@ -964,8 +950,9 @@ end
 
 ## worker creation and setup ##
 
-# the entry point for julia worker processes. does not return.
-# argument is descriptor to write listening port # to.
+# The entry point for julia worker processes. does not return. Used for TCP transport.
+# Cluster managers implementing their own transport will provide their own.
+# Argument is descriptor to write listening port # to.
 start_worker() = start_worker(STDOUT)
 function start_worker(out::IO)
     # we only explicitly monitor worker STDOUT on the console, so redirect
@@ -995,6 +982,9 @@ function start_worker(out::IO)
     disable_nagle(sock)
 
     try
+        # To prevent hanging processes on remote machines, newly launched workers exit if the
+        # master process does not connect in time.
+        # TODO : Make timeout configurable.
         check_master_connect(60.0)
         while true; wait(); end
     catch err
@@ -1005,54 +995,141 @@ function start_worker(out::IO)
     exit(0)
 end
 
-function start_cluster_workers(manager, params, resp_arr, launched_ntfy)
-    # Get the cluster manager to launch the instance
-    #print("start_cluster_workers\n")
-    instances_ntfy = Condition()
 
+function redirect_worker_output(ident, stream)
+    @schedule while !eof(stream)
+        line = readline(stream)
+        if startswith(line, "\tFrom worker ")
+            # STDOUT's of "additional" workers started from an initial worker on a host are not available
+            # on the master directly - they are routed via the initial worker's STDOUT.
+            print(line)
+        else
+            print("\tFrom worker $(ident):\t$line")
+        end
+    end
+end
+
+
+# The default TCP transport relies on the worker listening on a free
+# port available and printing its bind address and port.
+# The master process uses this to connect to the worker and subsequently
+# setup a all-to-all network.
+function read_worker_host_port(io::IO)
+    io.line_buffered = true
+    while true
+        conninfo = readline(io)
+        bind_addr, port = parse_connection_info(conninfo)
+        if bind_addr != ""
+            return bind_addr, port
+        end
+    end
+end
+
+function parse_connection_info(str)
+    m = match(r"^julia_worker:(\d+)#(.*)", str)
+    if m != nothing
+        (m.captures[2], parseint(Int16, m.captures[1]))
+    else
+        ("", int16(-1))
+    end
+end
+
+function init_worker(manager::ClusterManager=DefaultClusterManager())
+    # On workers, the default cluster manager connects via TCP sockets. Custom
+    # transports will need to call this function with their own manager.
+    global cluster_manager
+    cluster_manager = manager
+    disable_threaded_libs()
+end
+
+
+# The main function for adding worker processes.
+# `manager` is of type ClusterManager. The respective managers are responsible
+# for launching the workers. All keyword arguments (plus a few default values)
+# are available as a dictionary to the `launch` methods
+function addprocs(manager::ClusterManager; kwargs...)
+    params = merge(default_addprocs_params(), AnyDict(kwargs))
+
+    # some libs by default start as many threads as cores which leads to
+    # inefficient use of cores in a multi-process model.
+    # Should be a keyword arg?
+    disable_threaded_libs()
+
+    # References to launched workers, filled when each worker is fully initialized and
+    # has connected to all nodes.
+    rr_launched = RemoteRef[]   # Asynchronously filled by the launch method
+
+    start_cluster_workers(manager, params, rr_launched)
+
+    # Wait for all workers to be fully connected
+    sort!([fetch(rr) for rr in rr_launched])
+end
+
+
+default_addprocs_params() = AnyDict(
+    :dir      => pwd(),
+    :exename  => joinpath(JULIA_HOME,julia_exename()),
+    :exeflags => ``)
+
+
+function start_cluster_workers(manager, params, rr_launched)
+    # The `launch` method should add an object of type WorkerConfig for every
+    # worker launched. It provides information required on how to connect
+    # to it.
     launched = WorkerConfig[]
+    launch_ntfy = Condition()
+
+    # call manager's `launch` is a separate task. This allows the master
+    # process initiate the connection setup process as and when workers come
+    # online
     t = @schedule try
-            launch(manager, params, launched, instances_ntfy)
+            launch(manager, params, launched, launch_ntfy)
         catch e
-            print(STDERR, "Error launching workers with $T : $e\n")
+            print(STDERR, "Error launching workers with $(typeof(manager)) : $e\n")
         end
 
-    workers_with_additional = []
+    # When starting workers on remote multi-core hosts, `launch` can (optionally) start only one
+    # process on the remote machine, with a request to start additional workers of the
+    # same type. This is done by setting an appropriate value to `WorkerConfig.cnt`.
+    workers_with_additional = []  # List of workers with additional on-host workers requested
+
     while true
         if length(launched) == 0
             if istaskdone(t)
                 break
             end
-            @schedule (sleep(1); notify(instances_ntfy))
-            wait(instances_ntfy)
+            @schedule (sleep(1); notify(launch_ntfy))
+            wait(launch_ntfy)
         end
 
         if length(launched) > 0
             wconfig = shift!(launched)
             w = connect_n_create_worker(manager, get_next_pid(), wconfig)
-            rr = add_worker(PGRP, w)
+            rr = setup_worker(PGRP, w)
             cnt = get(w.config.count, 1)
             if (cnt == :auto) || (cnt > 1)
                 push!(workers_with_additional, (w, rr))
             end
 
-            push!(resp_arr, rr)
-            notify(launched_ntfy)
+            push!(rr_launched, rr)
         end
     end
 
-    additional_workers = []
+    # Perform the launch of additional workers in parallel.
+    additional_workers = []     # List of workers launched via the "additional" method
     @sync begin
         for (w, rr) in workers_with_additional
-            let w=w, rr=rr, exename=params[:exename]
+            let w=w, rr=rr
                 @async begin
-                    wait(rr)
+                    wait(rr)  # :cpu_cores below is set only after we get a setup complete
+                              # message from the new worker.
                     cnt = get(w.config.count)
                     if cnt == :auto
                         cnt = get(w.config.environ)[:cpu_cores]
                     end
                     cnt = cnt - 1   # Removing self from the requested number
 
+                    exename = get(w.config.exename)
                     exeflags = get(w.config.exeflags, ``)
                     cmd = `$exename $exeflags`
 
@@ -1064,21 +1141,20 @@ function start_cluster_workers(manager, params, resp_arr, launched_ntfy)
         end
     end
 
-    process_additional(additional_workers, resp_arr, launched_ntfy)
-
-    notify(launched_ntfy)
+    # connect each of the additional workers with each other
+    process_additional(additional_workers, rr_launched)
 end
 
-function process_additional(additional_workers, resp_arr::Array, launched_ntfy::Condition)
-    # keyword argument max_parallel is only relevant for concurrent ssh connections to a unique host
+function process_additional(additional_workers, rr_launched::Array)
+    # keyword argument `max_parallel` is only relevant for concurrent ssh connections to a unique host
     # Post launch, ssh from master to workers is used only if tunnel is true
 
     while length(additional_workers) > 0
         all_new_workers=[]
-        for (w, new_workers) in additional_workers
+        for (w_initial, new_workers) in additional_workers
             num_new_w = length(new_workers)
-            tunnel = get(w.config.tunnel, false)
-            maxp = get(w.config.max_parallel, 0)
+            tunnel = get(w_initial.config.tunnel, false)
+            maxp = get(w_initial.config.max_parallel, 0)
 
             if tunnel && (maxp > 0)
                 num_in_p = min(maxp, num_new_w)
@@ -1090,34 +1166,36 @@ function process_additional(additional_workers, resp_arr::Array, launched_ntfy::
                 (pid, bind_addr, port) = shift!(new_workers)
 
                 wconfig = WorkerConfig()
-                for x in [:host, :tunnel, :sshflags, :exeflags]
-                    setfield!(wconfig, x, getfield(w.config, x))
+                for x in [:host, :tunnel, :sshflags, :exeflags, :exename]
+                    setfield!(wconfig, x, getfield(w_initial.config, x))
                 end
                 wconfig.bind_addr = bind_addr
                 wconfig.port = port
 
-                new_w = connect_n_create_worker(w.manager, pid, wconfig)
+                new_w = connect_n_create_worker(w_initial.manager, pid, wconfig)
                 push!(all_new_workers, new_w)
             end
         end
 
         rr_list=[]
         for new_w in all_new_workers
-            rr=add_worker(PGRP, new_w)
-            push!(resp_arr, rr)
+            rr=setup_worker(PGRP, new_w)
             push!(rr_list, rr)
-            notify(launched_ntfy)
+            push!(rr_launched, rr)
         end
 
-        # wait for all of this set to finish.
+        # It is important to wait for all of newly launched workers to finish
+        # connection setup, so that all the workers are aware of all other workers
         [wait(rr) for rr in rr_list]
 
-        filter!(x->((w, new_workers) = x; length(new_workers) > 0), additional_workers)
+        filter!(x->((w_initial, new_workers) = x; length(new_workers) > 0), additional_workers)
     end
 end
 
 function connect_n_create_worker(manager, pid, wconfig)
+    # initiate a connect. Does not wait for connection completion in case of TCP.
     (r_s, w_s) = connect(manager, pid, wconfig)
+
     w = Worker(pid, r_s, w_s, manager, wconfig)
     register_worker(w)
     # install a finalizer to perform cleanup if necessary
@@ -1125,7 +1203,38 @@ function connect_n_create_worker(manager, pid, wconfig)
     w
 end
 
+function setup_worker(pg::ProcessGroup, w)
+    # only node 1 can add new nodes, since nobody else has the full list of address:port
+    assert(LPROC.id == 1)
 
+    # set when the new worker has finshed connections with all other workers
+    rr_join = RemoteRef()
+
+    # Start a new task to handle inbound messages from connected worker in master.
+    # Also calls `wait_connected` on TCP streams.
+    process_messages(w.r_stream, w.w_stream; ntfy_join_complete=rr_join)
+
+    # send address information of all workers to the new worker.
+    # Cluster managers set the address of each worker in `WorkerConfig.connect_at`.
+    # A new worker uses this to setup a all-to-all network. Workers with higher pids connect to
+    # workers with lower pids. Except process 1 (master) which initiates connections
+    # to all workers.
+    # Flow:
+    # - master sends (:join_pgrp, list_of_all_worker_addresses) to all workers
+    # - On each worker
+    #   - each worker sends a :identify_socket to all workers less than its pid
+    #   - each worker then sends a :join_complete back to the master along with its OS_PID and NUM_CORES
+    # - once master receives a :join_complete it triggers rr_join (signifies that worker setup is complete)
+    all_locs = map(x -> isa(x, Worker) ? (get(x.config.connect_at, ()), x.id, isa(x.manager, LocalManager)) : ((), x.id, true), pg.workers)
+    send_msg_now(w, :join_pgrp, w.id, all_locs, isa(w.manager, LocalManager))
+
+    @schedule manage(w.manager, w.id, w.config, :register)
+    rr_join
+end
+
+
+# Called on the first worker on a remote host. Used to optimize launching
+# of multiple workers on a remote host (to leverage multi-core)
 function launch_additional(np::Integer, pids::Array, cmd::Cmd)
     assert(np == length(pids))
 
@@ -1148,382 +1257,6 @@ function launch_additional(np::Integer, pids::Array, cmd::Cmd)
 
     addresses
 end
-
-function redirect_worker_output(ident, stream)
-    @schedule while !eof(stream)
-        line = readline(stream)
-        if startswith(line, "\tFrom worker ")
-            print(line)
-        else
-            print("\tFrom worker $(ident):\t$line")
-        end
-    end
-end
-
-
-
-function read_worker_host_port(io::IO)
-    io.line_buffered = true
-    while true
-        conninfo = readline(io)
-        bind_addr, port = parse_connection_info(conninfo)
-        if bind_addr != ""
-            return bind_addr, port
-        end
-    end
-end
-
-function parse_connection_info(str)
-    m = match(r"^julia_worker:(\d+)#(.*)", str)
-    if m != nothing
-        (m.captures[2], parseint(Int16, m.captures[1]))
-    else
-        ("", int16(-1))
-    end
-end
-
-let tunnel_port = 9201
-    global next_tunnel_port
-    function next_tunnel_port()
-        retval = tunnel_port
-        if tunnel_port > 32000
-            tunnel_port = 9201
-        else
-            tunnel_port += 1
-        end
-        retval
-    end
-end
-
-
-
-# establish an SSH tunnel to a remote worker
-# returns P such that localhost:P connects to host:port
-function ssh_tunnel(user, host, bind_addr, port, sshflags)
-    localp = next_tunnel_port()
-    ntries = cnt = 100
-    while !success(detach(`ssh -T -a -x -o ExitOnForwardFailure=yes -f $sshflags $(user)@$host -L $localp:$bind_addr:$(int(port)) sleep 60`)) && cnt > 0
-        localp = next_tunnel_port()
-        cnt -= 1
-    end
-    (cnt == 0) && error("Unable to create SSH tunnel after $cnt tries. No free port?")
-
-    localp
-end
-
-immutable LocalManager <: ClusterManager
-    np::Integer
-end
-
-function init_worker(manager::ClusterManager=DefaultClusterManager())
-    global cluster_manager
-    cluster_manager = manager
-    disable_threaded_libs()
-end
-
-show(io::IO, manager::LocalManager) = println(io, "LocalManager()")
-
-function launch(manager::LocalManager, params::Dict, launched::Array, c::Condition)
-    dir = params[:dir]
-    exename = params[:exename]
-    exeflags = params[:exeflags]
-
-    for i in 1:manager.np
-        io, pobj = open(detach(setenv(`$(julia_cmd(exename)) $exeflags --bind-to $(LPROC.bind_addr) --worker`, dir=dir)), "r")
-        wconfig = WorkerConfig()
-        wconfig.process = pobj
-        wconfig.io = io
-        push!(launched, wconfig)
-    end
-
-    notify(c)
-end
-
-function manage(manager::LocalManager, id::Integer, config::WorkerConfig, op::Symbol)
-    if op == :interrupt
-        kill(get(config.process), 2)
-    end
-end
-
-function connect(manager::ClusterManager, pid::Int, config::WorkerConfig)
-    if !isnull(config.connect_at)
-        # this is a worker-to-worker setup call.
-        return connect_w2w(pid, config)
-    end
-
-    # master connecting to workers
-    if !isnull(config.io)
-        (bind_addr, port) = read_worker_host_port(get(config.io))
-        pubhost=get(config.host, bind_addr)
-    else
-        pubhost=get(config.host)
-        port=get(config.port)
-        bind_addr=get(config.bind_addr, pubhost)
-    end
-
-    tunnel = get(config.tunnel, false)
-
-    s = split(pubhost,'@')
-    user = ""
-    if length(s) > 1
-        user = s[1]
-        pubhost = s[2]
-    else
-        if haskey(ENV, "USER")
-            user = ENV["USER"]
-        elseif tunnel
-            error("USER must be specified either in the environment or as part of the hostname when tunnel option is used")
-        end
-    end
-
-    if tunnel
-        sshflags = get(config.sshflags)
-        (s, bind_addr) = connect_to_worker(pubhost, bind_addr, port, user, sshflags)
-    else
-        (s, bind_addr) = connect_to_worker(bind_addr, port)
-    end
-
-    config.host = pubhost
-    config.port = port
-    config.bind_addr = bind_addr
-
-    # write out a subset of the connect_at required for further worker-worker connection setups
-    config.connect_at = (bind_addr, port)
-
-    if !isnull(config.io)
-        let pid = pid
-            redirect_worker_output(pid, get(config.io))
-        end
-    end
-
-    (s, s)
-end
-
-function kill(manager::ClusterManager, pid::Int, config::WorkerConfig)
-    remote_do(pid, exit) # For TCP based transports this will result in a close of the socket
-                       # at our end, which will result in a cleanup of the worker.
-    nothing
-end
-
-function connect_w2w(pid::Int, config::WorkerConfig)
-    (rhost, rport) = get(config.connect_at)
-    config.host = rhost
-    config.port = rport
-    if get(get(config.environ), :self_is_local, false) && get(get(config.environ), :r_is_local, false)
-        # If on localhost, use the loopback address - this addresses
-        # the special case of system suspend wherein the local ip
-        # may be changed upon system awake.
-        (s, bind_addr) = connect_to_worker("127.0.0.1", rport)
-    else
-        (s, bind_addr)= connect_to_worker(rhost, rport)
-    end
-
-    (s,s)
-end
-
-
-function connect_to_worker(host::AbstractString, port::Integer)
-    # Connect to the loopback port if requested host has the same ipaddress as self.
-    if host == string(LPROC.bind_addr)
-        s = connect("127.0.0.1", uint16(port))
-    else
-        s = connect(host, uint16(port))
-    end
-
-    # Avoid calling getaddrinfo if possible - involves a DNS lookup
-    # host may be a stringified ipv4 / ipv6 address or a dns name
-    if host == "localhost"
-        bind_addr = "127.0.0.1"
-    else
-        try
-            bind_addr = string(parseip(host))
-        catch
-            bind_addr = string(getaddrinfo(host))
-        end
-    end
-    (s, bind_addr)
-end
-
-
-function connect_to_worker(host::AbstractString, bind_addr::AbstractString, port::Integer, tunnel_user::AbstractString, sshflags)
-    s = connect("localhost", ssh_tunnel(tunnel_user, host, bind_addr, uint16(port), sshflags))
-    (s, bind_addr)
-end
-
-
-immutable SSHManager <: ClusterManager
-    machines::Dict
-
-    function SSHManager(machines)
-        mhist = Dict()
-        for m in machines
-            if isa(m, Tuple)
-                host=m[1]
-                cnt=m[2]
-            else
-                host=m
-                cnt=1
-            end
-            current_cnt = get(mhist, host, 0)
-
-            if isa(cnt, Number)
-                mhist[host] = isa(current_cnt, Number) ? current_cnt + Int(cnt) : Int(cnt)
-            else
-                mhist[host] = cnt
-            end
-        end
-        new(mhist)
-    end
-end
-
-show(io::IO, manager::SSHManager) = println(io, "SSHManager(machines=", manager.machines, ")")
-
-function launch(manager::SSHManager, params::Dict, launched::Array, machines_launch_ntfy::Condition)
-    # Launch one worker on each unique host in parallel. Additional workers are launched later.
-    # Wait for all launches to complete.
-
-    launch_tasks = cell(length(manager.machines))
-
-    for (i,(machine, cnt)) in  enumerate(manager.machines)
-        let machine=machine, cnt=cnt
-            launch_tasks[i] = @schedule try
-                    launch_on_machine(manager, machine, cnt, params, launched, machines_launch_ntfy)
-                catch e
-                    print(STDERR, "exception launching on machine $(machine) : $(e)\n")
-                end
-        end
-    end
-
-    for t in launch_tasks
-        wait(t)
-    end
-
-    notify(machines_launch_ntfy)
-end
-
-
-function launch_on_machine(manager::SSHManager, machine, cnt, params, launched, machines_launch_ntfy::Condition)
-    dir = params[:dir]
-    exename = params[:exename]
-    exeflags = params[:exeflags]
-
-    # machine could be of the format [user@]host[:port] bind_addr[:bind_port]
-    machine_bind = split(machine)
-    if length(machine_bind) > 1
-        exeflags = `--bind-to $(machine_bind[2]) $exeflags`
-    end
-    exeflags = `$exeflags --worker`
-
-    machine_def = machine_bind[1]
-    machine_def = split(machine_def, ':')
-    portopt = length(machine_def) == 2 ? ` -p $(machine_def[2]) ` : ``
-    sshflags = `$(params[:sshflags]) $portopt`
-
-    host = machine_def[1]
-
-    # Build up the ssh command
-    cmd = `cd $dir && $exename $exeflags` # launch julia
-    cmd = `sh -l -c $(shell_escape(cmd))` # shell to launch under
-    cmd = `ssh -T -a -x -o ClearAllForwardings=yes -n $sshflags $host $(shell_escape(cmd))` # use ssh to remote launch
-
-    # launch
-    io, pobj = open(detach(cmd), "r")
-    wconfig = WorkerConfig()
-
-    wconfig.io = io
-    wconfig.host = host
-    wconfig.sshflags = sshflags
-    wconfig.exeflags = exeflags
-    wconfig.count = cnt
-    wconfig.max_parallel = get(params, :max_parallel, Nullable{Integer}())
-
-    push!(launched, wconfig)
-    notify(machines_launch_ntfy)
-end
-
-
-function manage(manager::SSHManager, id::Integer, config::WorkerConfig, op::Symbol)
-    if op == :interrupt
-        ospid = get(config.ospid, 0)
-        if ospid > 0
-            host = get(config.host)
-            sshflags = get(config.sshflags)
-            if !success(`ssh -T -a -x -o ClearAllForwardings=yes -n $sshflags $host "kill -2 $ospid"`)
-                println("Error sending a Ctrl-C to julia worker $id on $machine")
-            end
-        else
-            # This state can happen immediately after an addprocs
-            println("Worker $id cannot be presently interrupted.")
-        end
-    end
-end
-
-function addprocs(manager::ClusterManager; kwargs...)
-    params = merge(default_addprocs_params(), AnyDict(kwargs))
-    disable_threaded_libs()
-
-    rr_join = Array(RemoteRef, 0)
-
-    resp_arr = RemoteRef[]
-    c = Condition()
-
-    t = @schedule try
-            start_cluster_workers(manager, params, resp_arr, c)
-        catch e
-            print(STDERR, "Error starting cluster workers : $(e)\n")
-            display_error(e,catch_backtrace())
-        end
-
-    while true
-        if length(resp_arr) == 0
-            if istaskdone(t)
-                break
-            end
-            @schedule (sleep(1); notify(c))
-            wait(c)
-        end
-
-        if length(resp_arr) > 0
-            push!(rr_join, shift!(resp_arr))
-        end
-    end
-
-    for rr in rr_join
-        wait(rr)
-    end
-
-    new_w = sort!([fetch(rr) for rr in rr_join])
-end
-
-immutable DefaultClusterManager <: ClusterManager
-end
-
-function check_addprocs_args(kwargs)
-    for keyname in kwargs
-        !(keyname[1] in [:dir, :exename, :exeflags]) && throw(ArgumentError("Invalid keyword argument $(keyname[1])"))
-    end
-end
-
-addprocs(; kwargs...) = addprocs(Sys.CPU_CORES; kwargs...)
-function addprocs(np::Integer; kwargs...)
-    check_addprocs_args(kwargs)
-    addprocs(LocalManager(np); kwargs...)
-end
-
-# start and connect to processes via SSH, optionally through an SSH tunnel.
-# the tunnel is only used from the head (process 1); the nodes are assumed
-# to be mutually reachable without a tunnel, as is often the case in a cluster.
-# Default value of kw arg max_parallel is the default value of MaxStartups in sshd_config
-# A machine is either a <hostname> or a tuple of (<hostname>, count)
-function addprocs(machines::AbstractVector; tunnel=false, sshflags=``, max_parallel=10, kwargs...)
-    check_addprocs_args(kwargs)
-    addprocs(SSHManager(machines); tunnel=tunnel, sshflags=sshflags, max_parallel=max_parallel, kwargs...)
-end
-
-default_addprocs_params() = AnyDict(
-    :dir      => pwd(),
-    :exename  => joinpath(JULIA_HOME,julia_exename()),
-    :exeflags => ``)
 
 ## higher-level functions: spawn, pmap, pfor, etc. ##
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -197,6 +197,7 @@ include("nullable.jl")
 # concurrency and parallelism
 include("serialize.jl")
 include("multi.jl")
+include("managers.jl")
 
 # code loading
 include("loading.jl")

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -228,9 +228,7 @@ if haskey(ENV, "PTEST_FULL")
     #Issue #9951
     hosts=[]
     for i in 1:30
-        push!(hosts, "localhost")
-        push!(hosts, string(getipaddr()))
-        push!(hosts, "127.0.0.1")
+        push!(hosts, "localhost", string(getipaddr()), "127.0.0.1")
     end
 
     print("\nTesting SSH addprocs with $(length(hosts)) workers...\n")
@@ -254,16 +252,21 @@ if haskey(ENV, "PTEST_FULL")
 
     test_n_remove_pids(new_pids)
 
-    print("\nMore addprocs tests...\n")
-
-    #Other addprocs/rmprocs tests
+    print("\nMixed ssh addprocs with :auto\n")
     new_pids = sort(remotecall_fetch(1, addprocs, ["localhost", ("127.0.0.1", :auto), "localhost"]))
     @test length(new_pids) == (2 + Sys.CPU_CORES)
     test_n_remove_pids(new_pids)
 
+    print("\nMixed ssh addprocs with numbers\n")
     new_pids = sort(remotecall_fetch(1, addprocs, [("localhost", 2), ("127.0.0.1", 2), "localhost"]))
     @test length(new_pids) == 5
     test_n_remove_pids(new_pids)
+
+    print("\nssh addprocs with tunnel\n")
+    new_pids = sort(remotecall_fetch(1, ()->addprocs([("localhost", 2)]; tunnel=true)))
+    @test length(new_pids) == 2
+    test_n_remove_pids(new_pids)
+
 end
 end
 


### PR DESCRIPTION
This PR does the following:
- adds more comments to the entire `addprocs` process, explaining the steps taken
- rearranges code, specifically, the built-in managers have been moved to a new file `managers.jl`
- removes some redundant code that had crept in. The lack of comments probably resulted in lesser number of people looking at it - hope the comments help in more people looking at this part of  `multi.jl`.  
