### PR TITLE
eliminate globals in linalg tests, wrap tests in let blocks

### DIFF
--- a/test/linalg/givens.jl
+++ b/test/linalg/givens.jl
@@ -1,34 +1,33 @@
-let
 debug = false
 
-# Test givens rotations
-for elty in (Float32, Float64, Complex64, Complex128)
+let
+    # Test givens rotations
+    for elty in (Float32, Float64, Complex64, Complex128)
 
-    debug && println("elty is $elty")
+        debug && println("elty is $elty")
 
-    if elty <: Real
-        A = convert(Matrix{elty}, randn(10,10))
-    else
-        A = convert(Matrix{elty}, complex(randn(10,10),randn(10,10)))
-    end
-    Ac = copy(A)
-    R = Base.LinAlg.Rotation(Base.LinAlg.Givens{elty}[])
-    for j = 1:8
-        for i = j+2:10
-            G, _ = givens(A, j+1, i, j)
-            A_mul_B!(G, A)
-            A_mul_Bc!(A, G)
-            A_mul_B!(G, R)
-
-            # test transposes
-            @test_approx_eq ctranspose(G)*G*eye(10) eye(elty, 10)
-            @test_approx_eq ctranspose(R)*(R*eye(10)) eye(elty, 10)
-            @test_throws ErrorException transpose(G)
-            @test_throws ErrorException transpose(R)
+        if elty <: Real
+            A = convert(Matrix{elty}, randn(10,10))
+        else
+            A = convert(Matrix{elty}, complex(randn(10,10),randn(10,10)))
         end
-    end
-    @test_approx_eq abs(A) abs(hessfact(Ac)[:H])
-    @test_approx_eq norm(R*eye(elty, 10)) one(elty)
+        Ac = copy(A)
+        R = Base.LinAlg.Rotation(Base.LinAlg.Givens{elty}[])
+        for j = 1:8
+            for i = j+2:10
+                G, _ = givens(A, j+1, i, j)
+                A_mul_B!(G, A)
+                A_mul_Bc!(A, G)
+                A_mul_B!(G, R)
 
-end
+                # test transposes
+                @test_approx_eq ctranspose(G)*G*eye(10) eye(elty, 10)
+                @test_approx_eq ctranspose(R)*(R*eye(10)) eye(elty, 10)
+                @test_throws ErrorException transpose(G)
+                @test_throws ErrorException transpose(R)
+            end
+        end
+        @test_approx_eq abs(A) abs(hessfact(Ac)[:H])
+        @test_approx_eq norm(R*eye(elty, 10)) one(elty)
+    end
 end #let

--- a/test/linalg/pinv.jl
+++ b/test/linalg/pinv.jl
@@ -85,10 +85,8 @@ function randn_float32(m::Integer, n::Integer)
     return b
 end
 
-
-
-
 function test_pinv(a,m,n,tol1,tol2,tol3)
+
     debug && println("=== julia/matlab pinv, default tol=eps(1.0)*max(size(a)) ===")
     apinv = pinv(a);
 
@@ -110,9 +108,9 @@ function test_pinv(a,m,n,tol1,tol2,tol3)
 end
 
 
-srand(12345)
 
 let
+    srand(12345)
     for eltya in (Float64, Complex128)
 
         debug && println("\n\n<<<<<", eltya, ">>>>>")
@@ -188,141 +186,146 @@ let
     end
 end
 
+let
+    srand(12345)
+    for eltya in (Float32, Complex64)
 
-for eltya in (Float32, Complex64)
+        debug && println("\n\n<<<<<", eltya, ">>>>>")
 
-    debug && println("\n\n<<<<<", eltya, ">>>>>")
+        m = 1000
+        n = 100
+        debug && println("\n\n n = ", n, ", m = ",m)
 
-    m = 1000
-    n = 100
-    debug && println("\n\n n = ", n, ", m = ",m)
+        default_tol = (real(one(eltya))) * max(m,n) * 10
 
-    default_tol = (real(one(eltya))) * max(m,n) * 10
+        debug && println("\n--- dense/ill-conditioned matrix ---\n");
+    ###    a = randn_float32(m,n) * hilb(eltya,n);
+        a = hilb(eltya,m,n);
+        test_pinv(a,m,n,1e0,1e-2,1e-2)
 
-    debug && println("\n--- dense/ill-conditioned matrix ---\n");
-###    a = randn_float32(m,n) * hilb(eltya,n);
-    a = hilb(eltya,m,n);
-    test_pinv(a,m,n,1e0,1e-2,1e-2)
+        debug && println("\n--- dense/diagonal matrix ---\n");
+        a = onediag(eltya,m,n);
+        test_pinv(a,m,n,default_tol,default_tol,default_tol)
 
-    debug && println("\n--- dense/diagonal matrix ---\n");
-    a = onediag(eltya,m,n);
-    test_pinv(a,m,n,default_tol,default_tol,default_tol)
+        debug && println("\n--- dense/tri-diagonal matrix ---\n");
+        a = tridiag(eltya,m,n);
+        test_pinv(a,m,n,default_tol,1e-2,default_tol)
 
-    debug && println("\n--- dense/tri-diagonal matrix ---\n");
-    a = tridiag(eltya,m,n);
-    test_pinv(a,m,n,default_tol,1e-2,default_tol)
+        debug && println("\n--- Diagonal matrix ---\n");
+        a = onediag_sparse(eltya,m);
+        test_pinv(a,m,m,default_tol,default_tol,default_tol)
 
-    debug && println("\n--- Diagonal matrix ---\n");
-    a = onediag_sparse(eltya,m);
-    test_pinv(a,m,m,default_tol,default_tol,default_tol)
+        m = 100
+        n = 100
+        debug && println("\n\n n = ", n, ", m = ",m)
 
-    m = 100
-    n = 100
-    debug && println("\n\n n = ", n, ", m = ",m)
+        default_tol = (real(one(eltya))) * max(m,n) * 10
 
-    default_tol = (real(one(eltya))) * max(m,n) * 10
+        debug && println("\n--- dense/ill-conditioned matrix ---\n");
+    ###    a = randn_float32(m,n) * hilb(eltya,n);
+        a = hilb(eltya,m,n);
+        test_pinv(a,m,n,1e0,1e-2,1e-2)
 
-    debug && println("\n--- dense/ill-conditioned matrix ---\n");
-###    a = randn_float32(m,n) * hilb(eltya,n);
-    a = hilb(eltya,m,n);
-    test_pinv(a,m,n,1e0,1e-2,1e-2)
+        debug && println("\n--- dense/diagonal matrix ---\n");
+        a = onediag(eltya,m,n);
+        test_pinv(a,m,n,default_tol,default_tol,default_tol)
 
-    debug && println("\n--- dense/diagonal matrix ---\n");
-    a = onediag(eltya,m,n);
-    test_pinv(a,m,n,default_tol,default_tol,default_tol)
+        debug && println("\n--- dense/tri-diagonal matrix ---\n");
+        a = tridiag(eltya,m,n);
+        test_pinv(a,m,n,default_tol,1e-2,default_tol)
 
-    debug && println("\n--- dense/tri-diagonal matrix ---\n");
-    a = tridiag(eltya,m,n);
-    test_pinv(a,m,n,default_tol,1e-2,default_tol)
+        debug && println("\n--- Diagonal matrix ---\n");
+        a = onediag_sparse(eltya,m);
+        test_pinv(a,m,m,default_tol,default_tol,default_tol)
 
-    debug && println("\n--- Diagonal matrix ---\n");
-    a = onediag_sparse(eltya,m);
-    test_pinv(a,m,m,default_tol,default_tol,default_tol)
+        m = 100
+        n = 1000
+        debug && println("\n\n n = ", n, ", m = ",m)
 
-    m = 100
-    n = 1000
-    debug && println("\n\n n = ", n, ", m = ",m)
+        default_tol = (real(one(eltya))) * max(m,n) * 10
 
-    default_tol = (real(one(eltya))) * max(m,n) * 10
+        debug && println("\n--- dense/ill-conditioned matrix ---\n");
+    ###    a = randn_float32(m,n) * hilb(eltya,n);
+        a = hilb(eltya,m,n);
+        test_pinv(a,m,n,1e0,1e-2,1e-2)
 
-    debug && println("\n--- dense/ill-conditioned matrix ---\n");
-###    a = randn_float32(m,n) * hilb(eltya,n);
-    a = hilb(eltya,m,n);
-    test_pinv(a,m,n,1e0,1e-2,1e-2)
+        debug && println("\n--- dense/diagonal matrix ---\n");
+        a = onediag(eltya,m,n);
+        test_pinv(a,m,n,default_tol,default_tol,default_tol)
 
-    debug && println("\n--- dense/diagonal matrix ---\n");
-    a = onediag(eltya,m,n);
-    test_pinv(a,m,n,default_tol,default_tol,default_tol)
+        debug && println("\n--- dense/tri-diagonal matrix ---\n");
+        a = tridiag(eltya,m,n);
+        test_pinv(a,m,n,default_tol,1e-2,default_tol)
 
-    debug && println("\n--- dense/tri-diagonal matrix ---\n");
-    a = tridiag(eltya,m,n);
-    test_pinv(a,m,n,default_tol,1e-2,default_tol)
+        debug && println("\n--- Diagonal matrix ---\n");
+        a = onediag_sparse(eltya,m);
+        test_pinv(a,m,m,default_tol,default_tol,default_tol)
 
-    debug && println("\n--- Diagonal matrix ---\n");
-    a = onediag_sparse(eltya,m);
-    test_pinv(a,m,m,default_tol,default_tol,default_tol)
-
+    end
 end
 
 # test zero matrices
-for eltya in (Float32, Float64, Complex64, Complex128)
-    debug && println("\n\n<<<<<", eltya, ">>>>>")
-    debug && println("\n--- zero constant ---")
-    a = pinv(zero(eltya))
-    @test_approx_eq a 0.0
-end
+let
+    for eltya in (Float32, Float64, Complex64, Complex128)
+        debug && println("\n\n<<<<<", eltya, ">>>>>")
+        debug && println("\n--- zero constant ---")
+        a = pinv(zero(eltya))
+        @test_approx_eq a 0.0
+    end
 
-for eltya in (Float32, Float64, Complex64, Complex128)
-    debug && println("\n\n<<<<<", eltya, ">>>>>")
-    debug && println("\n--- zero vector ---")
-    a = pinv([zero(eltya); zero(eltya)])
-    @test_approx_eq a[1] 0.0
-    @test_approx_eq a[2] 0.0
-end
+    for eltya in (Float32, Float64, Complex64, Complex128)
+        debug && println("\n\n<<<<<", eltya, ">>>>>")
+        debug && println("\n--- zero vector ---")
+        a = pinv([zero(eltya); zero(eltya)])
+        @test_approx_eq a[1] 0.0
+        @test_approx_eq a[2] 0.0
+    end
 
-for eltya in (Float32, Float64, Complex64, Complex128)
-    debug && println("\n\n<<<<<", eltya, ">>>>>")
-    debug && println("\n--- zero Diagonal matrix ---")
-    a = pinv(Diagonal([zero(eltya); zero(eltya)]))
-    @test_approx_eq a.diag[1] 0.0
-    @test_approx_eq a.diag[2] 0.0
+    for eltya in (Float32, Float64, Complex64, Complex128)
+        debug && println("\n\n<<<<<", eltya, ">>>>>")
+        debug && println("\n--- zero Diagonal matrix ---")
+        a = pinv(Diagonal([zero(eltya); zero(eltya)]))
+        @test_approx_eq a.diag[1] 0.0
+        @test_approx_eq a.diag[2] 0.0
+    end
 end
 
 # test sub-normal matrices
-for eltya in (Float32, Float64)
-    debug && println("\n\n<<<<<", eltya, ">>>>>")
-    debug && println("\n--- sub-normal constant ---")
-    a = pinv(realmin(eltya)/100)
-    @test_approx_eq a 0.0
-    debug && println("\n\n<<<<<Complex{", eltya, "}>>>>>")
-    debug && println("\n--- sub-normal constant ---")
-    a = pinv(realmin(eltya)/100*(1+1im))
-    @test_approx_eq a 0.0
-end
+let
+    for eltya in (Float32, Float64)
+        debug && println("\n\n<<<<<", eltya, ">>>>>")
+        debug && println("\n--- sub-normal constant ---")
+        a = pinv(realmin(eltya)/100)
+        @test_approx_eq a 0.0
+        debug && println("\n\n<<<<<Complex{", eltya, "}>>>>>")
+        debug && println("\n--- sub-normal constant ---")
+        a = pinv(realmin(eltya)/100*(1+1im))
+        @test_approx_eq a 0.0
+    end
 
-for eltya in (Float32, Float64)
-    debug && println("\n\n<<<<<", eltya, ">>>>>")
-    debug && println("\n--- sub-normal vector ---")
-    a = pinv([realmin(eltya); realmin(eltya)]/100)
-    @test_approx_eq a[1] 0.0
-    @test_approx_eq a[2] 0.0
-    debug && println("\n\n<<<<<Complex{", eltya, "}>>>>>")
-    debug && println("\n--- sub-normal vector ---")
-    a = pinv([realmin(eltya); realmin(eltya)]/100*(1+1im))
-    @test_approx_eq a[1] 0.0
-    @test_approx_eq a[2] 0.0
-end
+    for eltya in (Float32, Float64)
+        debug && println("\n\n<<<<<", eltya, ">>>>>")
+        debug && println("\n--- sub-normal vector ---")
+        a = pinv([realmin(eltya); realmin(eltya)]/100)
+        @test_approx_eq a[1] 0.0
+        @test_approx_eq a[2] 0.0
+        debug && println("\n\n<<<<<Complex{", eltya, "}>>>>>")
+        debug && println("\n--- sub-normal vector ---")
+        a = pinv([realmin(eltya); realmin(eltya)]/100*(1+1im))
+        @test_approx_eq a[1] 0.0
+        @test_approx_eq a[2] 0.0
+    end
 
-for eltya in (Float32, Float64)
-    debug && println("\n\n<<<<<", eltya, ">>>>>")
-    debug && println("\n--- sub-normal Diagonal matrix ---")
-    a = pinv(Diagonal([realmin(eltya); realmin(eltya)]/100))
-    @test_approx_eq a.diag[1] 0.0
-    @test_approx_eq a.diag[2] 0.0
-    debug && println("\n\n<<<<<Complex{", eltya, "}>>>>>")
-    debug && println("\n--- sub-normal Diagonal matrix ---")
-    a = pinv(Diagonal([realmin(eltya); realmin(eltya)]/100*(1+1im)))
-    @test_approx_eq a.diag[1] 0.0
-    @test_approx_eq a.diag[2] 0.0
+    for eltya in (Float32, Float64)
+        debug && println("\n\n<<<<<", eltya, ">>>>>")
+        debug && println("\n--- sub-normal Diagonal matrix ---")
+        a = pinv(Diagonal([realmin(eltya); realmin(eltya)]/100))
+        @test_approx_eq a.diag[1] 0.0
+        @test_approx_eq a.diag[2] 0.0
+        debug && println("\n\n<<<<<Complex{", eltya, "}>>>>>")
+        debug && println("\n--- sub-normal Diagonal matrix ---")
+        a = pinv(Diagonal([realmin(eltya); realmin(eltya)]/100*(1+1im)))
+        @test_approx_eq a.diag[1] 0.0
+        @test_approx_eq a.diag[2] 0.0
+    end
 end
-

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -1,276 +1,283 @@
 debug = false
+
 using Base.Test
 using Base.LinAlg: BlasFloat, errorbounds, full!, naivesub!, transpose!, UnitUpperTriangular, UnitLowerTriangular
 
 debug && println("Triangular matrices")
 
-n = 9
-srand(123)
+let n = 9
+    srand(123)
 
-debug && println("Test basic type functionality")
-@test_throws DimensionMismatch LowerTriangular(randn(5, 4))
-@test LowerTriangular(randn(3, 3)) |> t -> [size(t, i) for i = 1:3] == [size(full(t), i) for i = 1:3]
+    debug && println("Test basic type functionality")
+    @test_throws DimensionMismatch LowerTriangular(randn(5, 4))
+    @test LowerTriangular(randn(3, 3)) |> t -> [size(t, i) for i = 1:3] == [size(full(t), i) for i = 1:3]
 
-# The following test block tries to call all methods in base/linalg/triangular.jl in order for a combination of input element types. Keep the ordering when adding code.
-for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
-    # Begin loop for first Triangular matrix
-    for (t1, uplo1) in ((UpperTriangular, :U),
-                        (UnitUpperTriangular, :U),
-                        (LowerTriangular, :L),
-                        (UnitLowerTriangular, :L))
+    # The following test block tries to call all methods in base/linalg/triangular.jl in order
+    # for a combination of input element types. Keep the ordering when adding code.
+    for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
+        # Begin loop for first Triangular matrix
+        for (t1, uplo1) in ((UpperTriangular, :U),
+                            (UnitUpperTriangular, :U),
+                            (LowerTriangular, :L),
+                            (UnitLowerTriangular, :L))
 
-        # Construct test matrix
-        A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't, uplo1)))
+            # Construct test matrix
+            A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't, uplo1)))
 
-        debug && println("elty1: $elty1, A1: $t1")
+            debug && println("elty1: $elty1, A1: $t1")
 
-        # Convert
-        @test convert(AbstractMatrix{elty1}, A1) == A1
-        @test convert(Matrix, A1) == full(A1)
+            # Convert
+            @test convert(AbstractMatrix{elty1}, A1) == A1
+            @test convert(Matrix, A1) == full(A1)
 
-        # full!
-        @test full!(copy(A1)) == full(A1)
+            # full!
+            @test full!(copy(A1)) == full(A1)
 
-        # fill!
-        @test full!(fill!(copy(A1), 1)) == full(t1(ones(size(A1)...)))
+            # fill!
+            @test full!(fill!(copy(A1), 1)) == full(t1(ones(size(A1)...)))
 
-        # similar
-        @test isa(similar(A1), t1)
+            # similar
+            @test isa(similar(A1), t1)
 
-        # getindex
-        ## Linear indexing
-        for i = 1:length(A1)
-            @test A1[i] == full(A1)[i]
-        end
-
-        ## Cartesian indexing
-        for i = 1:size(A1, 1)
-            for j = 1:size(A1, 2)
-                @test A1[i,j] == full(A1)[i,j]
+            # getindex
+            ## Linear indexing
+            for i = 1:length(A1)
+                @test A1[i] == full(A1)[i]
             end
-        end
 
-        # setindex! (and copy)
-        A1c = copy(A1)
-        for i = 1:size(A1, 1)
-            for j = 1:size(A1, 2)
-                if uplo1 == :U
-                    if i > j || (i == j && t1 == UnitUpperTriangular)
-                        @test_throws BoundsError A1c[i,j] = 0
+            ## Cartesian indexing
+            for i = 1:size(A1, 1)
+                for j = 1:size(A1, 2)
+                    @test A1[i,j] == full(A1)[i,j]
+                end
+            end
+
+            # setindex! (and copy)
+            A1c = copy(A1)
+            for i = 1:size(A1, 1)
+                for j = 1:size(A1, 2)
+                    if uplo1 == :U
+                        if i > j || (i == j && t1 == UnitUpperTriangular)
+                            @test_throws BoundsError A1c[i,j] = 0
+                        else
+                            A1c[i,j] = 0
+                            @test A1c[i,j] == 0
+                        end
                     else
-                        A1c[i,j] = 0
-                        @test A1c[i,j] == 0
-                    end
-                else
-                    if i < j || (i == j && t1 == UnitLowerTriangular)
-                        @test_throws BoundsError A1c[i,j] = 0
-                    else
-                        A1c[i,j] = 0
-                        @test A1c[i,j] == 0
+                        if i < j || (i == j && t1 == UnitLowerTriangular)
+                            @test_throws BoundsError A1c[i,j] = 0
+                        else
+                            A1c[i,j] = 0
+                            @test A1c[i,j] == 0
+                        end
                     end
                 end
             end
-        end
 
-        # istril/istriu
-        if uplo1 == :L
-            @test istril(A1)
-            @test !istriu(A1)
-        else
-            @test istriu(A1)
-            @test !istril(A1)
-        end
-
-        # (c)transpose
-        @test full(A1') == full(A1)'
-        @test full(A1.') == full(A1).'
-        @test transpose!(copy(A1)) == A1.'
-
-        # diag
-        @test diag(A1) == diag(full(A1))
-
-        # real
-        @test full(real(A1)) == real(full(A1))
-
-        # Unary operations
-        @test full(-A1) == -full(A1)
-
-        # Binary operations
-        @test A1*0.5 == full(A1*0.5)
-        @test 0.5*A1 == full(0.5*A1)
-        @test A1/0.5 == full(A1/0.5)
-        @test 0.5\A1 == full(0.5\A1)
-
-        # inversion
-        @test_approx_eq inv(A1) inv(lufact(full(A1)))
-
-        # Determinant
-        @test_approx_eq_eps det(A1) det(lufact(full(A1))) sqrt(eps(real(float(one(elty1)))))*n*n
-
-        # Matrix square root
-        @test_approx_eq sqrtm(A1) |> t->t*t A1
-
-        # eigenproblems
-        if elty1 != BigFloat # Not handled yet
-            vals, vecs = eig(A1)
-            if (t1 == UpperTriangular || t1 == LowerTriangular) && elty1 != Int # Cannot really handle degenerate eigen space and Int matrices will probably have repeated eigenvalues.
-                @test_approx_eq_eps vecs*diagm(vals)/vecs full(A1) sqrt(eps(float(real(one(vals[1])))))*(norm(A1, Inf)*n)^2
+            # istril/istriu
+            if uplo1 == :L
+                @test istril(A1)
+                @test !istriu(A1)
+            else
+                @test istriu(A1)
+                @test !istril(A1)
             end
-        end
 
-        # Condition number tests - can be VERY approximate
-        if elty1 <:BlasFloat
-            for p in (1.0, Inf)
-                @test_approx_eq_eps cond(A1, p) cond(A1, p) (cond(A1, p) + cond(A1, p))
+            # (c)transpose
+            @test full(A1') == full(A1)'
+            @test full(A1.') == full(A1).'
+            @test transpose!(copy(A1)) == A1.'
+
+            # diag
+            @test diag(A1) == diag(full(A1))
+
+            # real
+            @test full(real(A1)) == real(full(A1))
+
+            # Unary operations
+            @test full(-A1) == -full(A1)
+
+            # Binary operations
+            @test A1*0.5 == full(A1*0.5)
+            @test 0.5*A1 == full(0.5*A1)
+            @test A1/0.5 == full(A1/0.5)
+            @test 0.5\A1 == full(0.5\A1)
+
+            # inversion
+            @test_approx_eq inv(A1) inv(lufact(full(A1)))
+
+            # Determinant
+            @test_approx_eq_eps det(A1) det(lufact(full(A1))) sqrt(eps(real(float(one(elty1)))))*n*n
+
+            # Matrix square root
+            @test_approx_eq sqrtm(A1) |> t->t*t A1
+
+            # eigenproblems
+            if elty1 != BigFloat # Not handled yet
+                vals, vecs = eig(A1)
+                if (t1 == UpperTriangular || t1 == LowerTriangular) && elty1 != Int # Cannot really handle degenerate eigen space and Int matrices will probably have repeated eigenvalues.
+                    @test_approx_eq_eps vecs*diagm(vals)/vecs full(A1) sqrt(eps(float(real(one(vals[1])))))*(norm(A1, Inf)*n)^2
+                end
             end
-        end
 
-        if elty1 != BigFloat # Not implemented yet
-            svd(A1)
-            svdfact(A1)
-            elty1 <: BlasFloat && svdfact!(copy(A1))
-            svdvals(A1)
-        end
+            # Condition number tests - can be VERY approximate
+            if elty1 <:BlasFloat
+                for p in (1.0, Inf)
+                    @test_approx_eq_eps cond(A1, p) cond(A1, p) (cond(A1, p) + cond(A1, p))
+                end
+            end
 
-        # Begin loop for second Triangular matrix
-        for elty2 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
-            for (t2, uplo2) in ((UpperTriangular, :U),
-                                (UnitUpperTriangular, :U),
-                                (LowerTriangular, :L),
-                                (UnitLowerTriangular, :L))
+            if elty1 != BigFloat # Not implemented yet
+                svd(A1)
+                svdfact(A1)
+                elty1 <: BlasFloat && svdfact!(copy(A1))
+                svdvals(A1)
+            end
 
-                debug && println("elty1: $elty1, A1: $t1, elty2: $elty2")
+            # Begin loop for second Triangular matrix
+            for elty2 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
+                for (t2, uplo2) in ((UpperTriangular, :U),
+                                    (UnitUpperTriangular, :U),
+                                    (LowerTriangular, :L),
+                                    (UnitLowerTriangular, :L))
 
-                A2 = t2(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t-> chol(t't, uplo2)))
+                    debug && println("elty1: $elty1, A1: $t1, elty2: $elty2")
 
-                # Convert
-                if elty1 <: Real && !(elty2 <: Integer)
-                    @test convert(AbstractMatrix{elty2}, A1) == t1(convert(Matrix{elty2}, A1.data))
-                elseif elty2 <: Real && !(elty1 <: Integer)
-                    @test_throws InexactError convert(AbstractMatrix{elty2}, A1) == t1(convert(Matrix{elty2}, A1.data))
+                    A2 = t2(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t-> chol(t't, uplo2)))
+
+                    # Convert
+                    if elty1 <: Real && !(elty2 <: Integer)
+                        @test convert(AbstractMatrix{elty2}, A1) == t1(convert(Matrix{elty2}, A1.data))
+                    elseif elty2 <: Real && !(elty1 <: Integer)
+                        @test_throws InexactError convert(AbstractMatrix{elty2}, A1) == t1(convert(Matrix{elty2}, A1.data))
+                    end
+
+                    # Binary operations
+                    @test full(A1 + A2) == full(A1) + full(A2)
+                    @test full(A1 - A2) == full(A1) - full(A2)
+
+                    # Triangular-Triangular multiplication and division
+                    elty1 != BigFloat && elty2 != BigFloat && @test_approx_eq full(A1*A2) full(A1)*full(A2)
+                    @test_approx_eq full(A1'A2) full(A1)'full(A2)
+                    @test_approx_eq full(A1*A2') full(A1)*full(A2)'
+                    @test_approx_eq full(A1'A2') full(A1)'full(A2)'
+                    @test_approx_eq full(A1/A2) full(A1)/full(A2)
+
                 end
 
-                # Binary operations
-                @test full(A1 + A2) == full(A1) + full(A2)
-                @test full(A1 - A2) == full(A1) - full(A2)
+                for eltyB in (Float32, Float64, Complex64, Complex128)
+                    B = convert(Matrix{eltyB}, elty1 <: Complex ? real(A1)*ones(n, n) : A1*ones(n, n))
 
-                # Triangular-Triangular multiplication and division
-                elty1 != BigFloat && elty2 != BigFloat && @test_approx_eq full(A1*A2) full(A1)*full(A2)
-                @test_approx_eq full(A1'A2) full(A1)'full(A2)
-                @test_approx_eq full(A1*A2') full(A1)*full(A2)'
-                @test_approx_eq full(A1'A2') full(A1)'full(A2)'
-                @test_approx_eq full(A1/A2) full(A1)/full(A2)
+                    debug && println("elty1: $elty1, A1: $t1, B: $eltyB")
 
-            end
+                    # Triangular-dense Matrix/vector multiplication
+                    @test_approx_eq A1*B[:,1] full(A1)*B[:,1]
+                    @test_approx_eq A1*B full(A1)*B
+                    @test_approx_eq A1'B[:,1] full(A1)'B[:,1]
+                    @test_approx_eq A1'B full(A1)'B
+                    @test_approx_eq A1*B' full(A1)*B'
+                    @test_approx_eq B*A1 B*full(A1)
+                    @test_approx_eq B[:,1]'A1 B[:,1]'full(A1)
+                    @test_approx_eq B'A1 B'full(A1)
+                    @test_approx_eq B*A1' B*full(A1)'
+                    @test_approx_eq B[:,1]'A1' B[:,1]'full(A1)'
+                    @test_approx_eq B'A1' B'full(A1)'
 
-            for eltyB in (Float32, Float64, Complex64, Complex128)
-                B = convert(Matrix{eltyB}, elty1 <: Complex ? real(A1)*ones(n, n) : A1*ones(n, n))
+                    # ... and division
+                    @test_approx_eq A1\B[:,1] full(A1)\B[:,1]
+                    @test_approx_eq A1\B full(A1)\B
+                    @test_approx_eq A1'\B[:,1] full(A1)'\B[:,1]
+                    @test_approx_eq A1'\B full(A1)'\B
+                    @test_approx_eq A1\B' full(A1)\B'
+                    @test_approx_eq A1'\B' full(A1)'\B'
+                    @test_approx_eq B/A1 B/full(A1)
+                    @test_approx_eq B/A1' B/full(A1)'
+                    @test_approx_eq B'/A1 B'/full(A1)
+                    @test_approx_eq B'/A1' B'/full(A1)'
 
-                debug && println("elty1: $elty1, A1: $t1, B: $eltyB")
-
-                # Triangular-dense Matrix/vector multiplication
-                @test_approx_eq A1*B[:,1] full(A1)*B[:,1]
-                @test_approx_eq A1*B full(A1)*B
-                @test_approx_eq A1'B[:,1] full(A1)'B[:,1]
-                @test_approx_eq A1'B full(A1)'B
-                @test_approx_eq A1*B' full(A1)*B'
-                @test_approx_eq B*A1 B*full(A1)
-                @test_approx_eq B[:,1]'A1 B[:,1]'full(A1)
-                @test_approx_eq B'A1 B'full(A1)
-                @test_approx_eq B*A1' B*full(A1)'
-                @test_approx_eq B[:,1]'A1' B[:,1]'full(A1)'
-                @test_approx_eq B'A1' B'full(A1)'
-
-                # ... and division
-                @test_approx_eq A1\B[:,1] full(A1)\B[:,1]
-                @test_approx_eq A1\B full(A1)\B
-                @test_approx_eq A1'\B[:,1] full(A1)'\B[:,1]
-                @test_approx_eq A1'\B full(A1)'\B
-                @test_approx_eq A1\B' full(A1)\B'
-                @test_approx_eq A1'\B' full(A1)'\B'
-                @test_approx_eq B/A1 B/full(A1)
-                @test_approx_eq B/A1' B/full(A1)'
-                @test_approx_eq B'/A1 B'/full(A1)
-                @test_approx_eq B'/A1' B'/full(A1)'
-
-                # Error bounds
-                elty1 != BigFloat && errorbounds(A1, A1\B, B)
+                    # Error bounds
+                    elty1 != BigFloat && errorbounds(A1, A1\B, B)
+                end
             end
         end
     end
 end
 
-Areal   = randn(n, n)/2
-Aimg    = randn(n, n)/2
-A2real  = randn(n, n)/2
-A2img   = randn(n, n)/2
+let n = 9
+    srand(123)
 
-for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
-    A = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(Areal, Aimg) : Areal)
-    # a2 = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(a2real, a2img) : a2real)
-    εa = eps(abs(float(one(eltya))))
+    Areal   = randn(n, n)/2
+    Aimg    = randn(n, n)/2
+    A2real  = randn(n, n)/2
+    A2img   = randn(n, n)/2
 
-    for eltyb in (Float32, Float64, Complex64, Complex128)
-        εb = eps(abs(float(one(eltyb))))
-        ε = max(εa,εb)
+    for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
+        A = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(Areal, Aimg) : Areal)
+        # a2 = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(a2real, a2img) : a2real)
+        εa = eps(abs(float(one(eltya))))
 
-        debug && println("\ntype of A: ", eltya, " type of b: ", eltyb, "\n")
+        for eltyb in (Float32, Float64, Complex64, Complex128)
+            εb = eps(abs(float(one(eltyb))))
+            ε = max(εa,εb)
 
-        debug && println("Solve upper triangular system")
-        Atri = UpperTriangular(lufact(A)[:U]) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
-        b = convert(Matrix{eltyb}, eltya <: Complex ? full(Atri)*ones(n, 2) : full(Atri)*ones(n, 2))
-        x = full(Atri) \ b
+            debug && println("\ntype of A: ", eltya, " type of b: ", eltyb, "\n")
 
-        debug && println("Test error estimates")
-        if eltya != BigFloat && eltyb != BigFloat
-            for i = 1:2
-                @test  norm(x[:,1] .- 1) <= errorbounds(UpperTriangular(A), x, b)[1][i]
+            debug && println("Solve upper triangular system")
+            Atri = UpperTriangular(lufact(A)[:U]) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
+            b = convert(Matrix{eltyb}, eltya <: Complex ? full(Atri)*ones(n, 2) : full(Atri)*ones(n, 2))
+            x = full(Atri) \ b
+
+            debug && println("Test error estimates")
+            if eltya != BigFloat && eltyb != BigFloat
+                for i = 1:2
+                    @test  norm(x[:,1] .- 1) <= errorbounds(UpperTriangular(A), x, b)[1][i]
+                end
             end
-        end
-        debug && println("Test forward error [JIN 5705] if this is not a BigFloat")
+            debug && println("Test forward error [JIN 5705] if this is not a BigFloat")
 
-        x = Atri \ b
-        γ = n*ε/(1 - n*ε)
-        if eltya != BigFloat
-            bigA = big(Atri)
-            x̂ = ones(n, 2)
+            x = Atri \ b
+            γ = n*ε/(1 - n*ε)
+            if eltya != BigFloat
+                bigA = big(Atri)
+                x̂ = ones(n, 2)
+                for i = 1:size(b, 2)
+                    @test norm(x̂[:,i] - x[:,i], Inf)/norm(x̂[:,i], Inf) <= condskeel(bigA, x̂[:,i])*γ/(1 - condskeel(bigA)*γ)
+                end
+            end
+
+            debug && println("Test backward error [JIN 5705]")
             for i = 1:size(b, 2)
-                @test norm(x̂[:,i] - x[:,i], Inf)/norm(x̂[:,i], Inf) <= condskeel(bigA, x̂[:,i])*γ/(1 - condskeel(bigA)*γ)
+                @test norm(abs(b[:,i] - Atri*x[:,i]), Inf) <= γ * norm(Atri, Inf) * norm(x[:,i], Inf)
             end
-        end
 
-        debug && println("Test backward error [JIN 5705]")
-        for i = 1:size(b, 2)
-            @test norm(abs(b[:,i] - Atri*x[:,i]), Inf) <= γ * norm(Atri, Inf) * norm(x[:,i], Inf)
-        end
+            debug && println("Solve lower triangular system")
+            Atri = UpperTriangular(lufact(A)[:U]) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
+            b = convert(Matrix{eltyb}, eltya <: Complex ? full(Atri)*ones(n, 2) : full(Atri)*ones(n, 2))
+            x = full(Atri)\b
 
-        debug && println("Solve lower triangular system")
-        Atri = UpperTriangular(lufact(A)[:U]) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
-        b = convert(Matrix{eltyb}, eltya <: Complex ? full(Atri)*ones(n, 2) : full(Atri)*ones(n, 2))
-        x = full(Atri)\b
-
-        debug && println("Test error estimates")
-        if eltya != BigFloat && eltyb != BigFloat
-            for i = 1:2
-                @test  norm(x[:,1] .- 1) <= errorbounds(UpperTriangular(A), x, b)[1][i]
+            debug && println("Test error estimates")
+            if eltya != BigFloat && eltyb != BigFloat
+                for i = 1:2
+                    @test  norm(x[:,1] .- 1) <= errorbounds(UpperTriangular(A), x, b)[1][i]
+                end
             end
-        end
 
-        debug && println("Test forward error [JIN 5705] if this is not a BigFloat")
-        b = eltyb == Int ? trunc(Int,Atri*ones(n, 2)) : convert(Matrix{eltyb}, Atri*ones(eltya, n, 2))
-        x = Atri \ b
-        γ = n*ε/(1 - n*ε)
-        if eltya != BigFloat
-            bigA = big(Atri)
-            x̂ = ones(n, 2)
+            debug && println("Test forward error [JIN 5705] if this is not a BigFloat")
+            b = eltyb == Int ? trunc(Int,Atri*ones(n, 2)) : convert(Matrix{eltyb}, Atri*ones(eltya, n, 2))
+            x = Atri \ b
+            γ = n*ε/(1 - n*ε)
+            if eltya != BigFloat
+                bigA = big(Atri)
+                x̂ = ones(n, 2)
+                for i = 1:size(b, 2)
+                    @test norm(x̂[:,i] - x[:,i], Inf)/norm(x̂[:,i], Inf) <= condskeel(bigA, x̂[:,i])*γ/(1 - condskeel(bigA)*γ)
+                end
+            end
+
+            debug && println("Test backward error [JIN 5705]")
             for i = 1:size(b, 2)
-                @test norm(x̂[:,i] - x[:,i], Inf)/norm(x̂[:,i], Inf) <= condskeel(bigA, x̂[:,i])*γ/(1 - condskeel(bigA)*γ)
+                @test norm(abs(b[:,i] - Atri*x[:,i]), Inf) <= γ * norm(Atri, Inf) * norm(x[:,i], Inf)
             end
-        end
-
-        debug && println("Test backward error [JIN 5705]")
-        for i = 1:size(b, 2)
-            @test norm(abs(b[:,i] - Atri*x[:,i]), Inf) <= γ * norm(Atri, Inf) * norm(x[:,i], Inf)
         end
     end
 end

--- a/test/linalg/umfpack.jl
+++ b/test/linalg/umfpack.jl
@@ -1,46 +1,55 @@
-se33 = speye(3)
-do33 = ones(3)
-@test isequal(se33 \ do33, do33)
+using Base.SparseMatrix.UMFPACK.increment!
+
+let se33 = speye(3),
+    do33 = ones(3)
+
+    @test isequal(se33 \ do33, do33)
+end
 
 # based on deps/Suitesparse-4.0.2/UMFPACK/Demo/umfpack_di_demo.c
 
-using Base.SparseMatrix.UMFPACK.increment!
+let A0 = sparse(increment!([0,4,1,1,2,2,0,1,2,3,4,4]),
+                increment!([0,4,0,2,1,2,1,4,3,2,1,2]),
+                [2.,1.,3.,4.,-1.,-3.,3.,6.,2.,1.,4.,2.], 5, 5)
 
-A0 = sparse(increment!([0,4,1,1,2,2,0,1,2,3,4,4]),
-           increment!([0,4,0,2,1,2,1,4,3,2,1,2]),
-           [2.,1.,3.,4.,-1.,-3.,3.,6.,2.,1.,4.,2.], 5, 5)
+    for Tv in (Float64, Complex128)
+        for Ti in Base.SparseMatrix.UMFPACK.UMFITypes.types
+            A = convert(SparseMatrixCSC{Tv,Ti}, A0)
+            lua = lufact(A)
+            L,U,p,q,Rs = lua[:(:)]
+            @test_approx_eq scale(Rs,A)[p,q] L*U
 
-for Tv in (Float64, Complex128)
-    for Ti in Base.SparseMatrix.UMFPACK.UMFITypes.types
-        A = convert(SparseMatrixCSC{Tv,Ti}, A0)
-        lua = lufact(A)
-        L,U,p,q,Rs = lua[:(:)]
-        @test_approx_eq scale(Rs,A)[p,q] L*U
+            @test_approx_eq det(lua) det(full(A))
 
-        @test_approx_eq det(lua) det(full(A))
+            b = [8., 45., -3., 3., 19.]
+            x = lua\b
+            @test_approx_eq x float([1:5])
 
-        b = [8., 45., -3., 3., 19.]
-        x = lua\b
-        @test_approx_eq x float([1:5])
+            @test norm(A*x-b,1) < eps(1e4)
 
-        @test norm(A*x-b,1) < eps(1e4)
+            b = [8., 20., 13., 6., 17.]
+            x = lua'\b
+            @test_approx_eq x float([1:5])
 
-        b = [8., 20., 13., 6., 17.]
-        x = lua'\b
-        @test_approx_eq x float([1:5])
-
-        @test norm(A'*x-b,1) < eps(1e4)
+            @test norm(A'*x-b,1) < eps(1e4)
+        end
     end
 end
 
-Ac0 = complex(A0,A0)
-for Ti in Base.SparseMatrix.UMFPACK.UMFITypes.types
-    Ac = convert(SparseMatrixCSC{Complex128,Ti}, Ac0)
-    lua = lufact(Ac)
-    L,U,p,q,Rs = lua[:(:)]
-    @test_approx_eq scale(Rs,Ac)[p,q] L*U
+let A0 = sparse(increment!([0,4,1,1,2,2,0,1,2,3,4,4]),
+                increment!([0,4,0,2,1,2,1,4,3,2,1,2]),
+                [2.,1.,3.,4.,-1.,-3.,3.,6.,2.,1.,4.,2.], 5, 5),
+    Ac0 = complex(A0,A0)
+
+    for Ti in Base.SparseMatrix.UMFPACK.UMFITypes.types
+        Ac = convert(SparseMatrixCSC{Complex128,Ti}, Ac0)
+        lua = lufact(Ac)
+        L,U,p,q,Rs = lua[:(:)]
+        @test_approx_eq scale(Rs,Ac)[p,q] L*U
+    end
 end
 
 #4523 - complex sparse \
-x = speye(2) + im * speye(2)
-@test_approx_eq ((lufact(x) \ ones(2)) * x) (complex(ones(2)))
+let x = speye(2) + im * speye(2)
+    @test_approx_eq ((lufact(x) \ ones(2)) * x) (complex(ones(2)))
+end

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -2,302 +2,302 @@ debug = false
 
 import Base.LinAlg: BlasComplex, BlasFloat, BlasReal, QRPivoted
 
-n = 10
-
 # Split n into 2 parts for tests needing two matrices
-n1 = div(n, 2)
-n2 = 2*n1
+let n = 10,
+    n1 = div(n, 2),
+    n2 = 2*n1
 
-srand(1234321)
+    srand(1234321)
 
-a = rand(n,n)
-for elty in (Float32, Float64, Complex64, Complex128)
-    a = convert(Matrix{elty}, a)
-    # cond
-    @test_approx_eq_eps cond(a, 1) 4.837320054554436e+02 0.01
-    @test_approx_eq_eps cond(a, 2) 1.960057871514615e+02 0.01
-    @test_approx_eq_eps cond(a, Inf) 3.757017682707787e+02 0.01
-    @test_approx_eq_eps cond(a[:,1:5]) 10.233059337453463 0.01
+    a = rand(n,n)
+    for elty in (Float32, Float64, Complex64, Complex128)
+        a = convert(Matrix{elty}, a)
+        # cond
+        @test_approx_eq_eps cond(a, 1) 4.837320054554436e+02 0.01
+        @test_approx_eq_eps cond(a, 2) 1.960057871514615e+02 0.01
+        @test_approx_eq_eps cond(a, Inf) 3.757017682707787e+02 0.01
+        @test_approx_eq_eps cond(a[:,1:5]) 10.233059337453463 0.01
+    end
+
+    areal = randn(n,n)/2
+    aimg  = randn(n,n)/2
+    a2real = randn(n,n)/2
+    a2img  = randn(n,n)/2
+    breal = randn(n,2)/2
+    bimg  = randn(n,2)/2
+
+    for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
+        a = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(areal, aimg) : areal)
+        a2 = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(a2real, a2img) : a2real)
+        asym = a'+a                  # symmetric indefinite
+        apd  = a'*a                 # symmetric positive-definite
+        ε = εa = eps(abs(float(one(eltya))))
+
+        for eltyb in (Float32, Float64, Complex64, Complex128, Int)
+            b = eltyb == Int ? rand(1:5, n, 2) : convert(Matrix{eltyb}, eltyb <: Complex ? complex(breal, bimg) : breal)
+            εb = eps(abs(float(one(eltyb))))
+            ε = max(εa,εb)
+
+    debug && println("\ntype of a: ", eltya, " type of b: ", eltyb, "\n")
+
+    debug && println("(Automatic) upper Cholesky factor")
+
+        capd  = factorize(apd)
+        r     = capd[:U]
+        κ     = cond(apd, 1) #condition number
+
+        #Test error bound on reconstruction of matrix: LAWNS 14, Lemma 2.1
+        E = abs(apd - r'*r)
+        for i=1:n, j=1:n
+            @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
+        end
+        E = abs(apd - full(capd))
+        for i=1:n, j=1:n
+            @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
+        end
+
+        #Test error bound on linear solver: LAWNS 14, Theorem 2.1
+        #This is a surprisingly loose bound...
+        x = capd\b
+        @test norm(x-apd\b,1)/norm(x,1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
+        @test norm(apd*x-b,1)/norm(b,1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
+
+        @test_approx_eq apd * inv(capd) eye(n)
+        @test norm(a*(capd\(a'*b)) - b,1)/norm(b,1) <= ε*κ*n # Ad hoc, revisit
+        @test abs((det(capd) - det(apd))/det(capd)) <= ε*κ*n # Ad hoc, but statistically verified, revisit
+        @test_approx_eq logdet(capd) log(det(capd)) # logdet is less likely to overflow
+
+        apos = asym[1,1]            # test chol(x::Number), needs x>0
+        @test_approx_eq cholfact(apos).UL √apos
+
+        # test chol of 2x2 Strang matrix
+        S = convert(AbstractMatrix{eltya},full(SymTridiagonal([2,2],[-1])))
+        U = Bidiagonal([2,sqrt(eltya(3))],[-1],true) / sqrt(eltya(2))
+        @test_approx_eq full(chol(S)) full(U)
+
+    debug && println("lower Cholesky factor")
+        lapd = cholfact(apd, :L)
+        @test_approx_eq full(lapd) apd
+        l = lapd[:L]
+        @test_approx_eq l*l' apd
+
+    debug && println("pivoted Choleksy decomposition")
+        if eltya != BigFloat && eltyb != BigFloat # Note! Need to implement pivoted cholesky decomposition in julia
+            cpapd = cholfact(apd, :U, Val{true})
+            @test rank(cpapd) == n
+            @test all(diff(diag(real(cpapd.UL))).<=0.) # diagonal should be non-increasing
+            @test norm(apd * (cpapd\b) - b)/norm(b) <= ε*κ*n # Ad hoc, revisit
+            if isreal(apd)
+                @test_approx_eq apd * inv(cpapd) eye(n)
+            end
+        end
+
+    debug && println("(Automatic) Bunch-Kaufman factor of indefinite matrix")
+        if eltya != BigFloat && eltyb != BigFloat # Not implemented for BigFloat and I don't think it will.
+            bc1 = factorize(asym)
+            @test_approx_eq inv(bc1) * asym eye(n)
+            @test_approx_eq_eps asym * (bc1\b) b 1000ε
+
+    debug && println("Bunch-Kaufman factors of a pos-def matrix")
+            bc2 = bkfact(apd)
+            @test_approx_eq inv(bc2) * apd eye(n)
+            @test_approx_eq_eps apd * (bc2\b) b 60000ε
+        end
+
+    debug && println("(Automatic) Square LU decomposition")
+        κ     = cond(a,1)
+        lua   = factorize(a)
+        l,u,p = lua[:L], lua[:U], lua[:p]
+        @test_approx_eq l*u a[p,:]
+        @test_approx_eq (l*u)[invperm(p),:] a
+        @test_approx_eq a * inv(lua) eye(n)
+        @test norm(a*(lua\b) - b, 1) < ε*κ*n*2 # Two because the right hand side has two columns
+
+    debug && println("Thin LU")
+        lua   = lufact(a[:,1:n1])
+        @test_approx_eq lua[:L]*lua[:U] lua[:P]*a[:,1:n1]
+
+    debug && println("Fat LU")
+        lua   = lufact(a[1:n1,:])
+        @test_approx_eq lua[:L]*lua[:U] lua[:P]*a[1:n1,:]
+
+    debug && println("QR decomposition (without pivoting)")
+        qra   = qrfact(a, Val{false})
+        q,r   = qra[:Q], qra[:R]
+        @test_approx_eq q'*full(q, thin=false) eye(n)
+        @test_approx_eq q*full(q, thin=false)' eye(n)
+        @test_approx_eq q*r a
+        @test_approx_eq_eps a*(qra\b) b 3000ε
+
+    debug && println("(Automatic) Fat (pivoted) QR decomposition") # Pivoting is only implemented for BlasFloats
+        qrpa  = factorize(a[1:n1,:])
+        q,r = qrpa[:Q], qrpa[:R]
+        if isa(qrpa,QRPivoted) p = qrpa[:p] end # Reconsider if pivoted QR gets implemented in julia
+        @test_approx_eq q'*full(q, thin=false) eye(n1)
+        @test_approx_eq q*full(q, thin=false)' eye(n1)
+        @test_approx_eq q*r isa(qrpa,QRPivoted) ? a[1:n1,p] : a[1:n1,:]
+        @test_approx_eq isa(qrpa, QRPivoted) ? q*r[:,invperm(p)] : q*r a[1:n1,:]
+        @test_approx_eq_eps a[1:n1,:]*(qrpa\b[1:n1]) b[1:n1] 5000ε
+
+    debug && println("(Automatic) Thin (pivoted) QR decomposition") # Pivoting is only implemented for BlasFloats
+        qrpa  = factorize(a[:,1:n1])
+        q,r = qrpa[:Q], qrpa[:R]
+        if isa(qrpa, QRPivoted) p = qrpa[:p] end # Reconsider if pivoted QR gets implemented in julia
+        @test_approx_eq q'*full(q, thin=false) eye(n)
+        @test_approx_eq q*full(q, thin=false)' eye(n)
+        @test_approx_eq q*r isa(qrpa, QRPivoted) ? a[:,p] : a[:,1:n1]
+        @test_approx_eq isa(qrpa, QRPivoted) ? q*r[:,invperm(p)] : q*r a[:,1:n1]
+
+    debug && println("symmetric eigen-decomposition")
+        if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+            d,v   = eig(asym)
+            @test_approx_eq asym*v[:,1] d[1]*v[:,1]
+            @test_approx_eq v*Diagonal(d)*v' asym
+            @test isequal(eigvals(asym[1]), eigvals(asym[1:1,1:1]))
+            @test_approx_eq abs(eigfact(Hermitian(asym), 1:2)[:vectors]'v[:,1:2]) eye(eltya, 2)
+            eig(Hermitian(asym), 1:2) # same result, but checks that method works
+            @test_approx_eq abs(eigfact(Hermitian(asym), d[1]-10*eps(d[1]), d[2]+10*eps(d[2]))[:vectors]'v[:,1:2]) eye(eltya, 2)
+            eig(Hermitian(asym), d[1]-10*eps(d[1]), d[2]+10*eps(d[2])) # same result, but checks that method works
+            @test_approx_eq eigvals(Hermitian(asym), 1:2) d[1:2]
+            @test_approx_eq eigvals(Hermitian(asym), d[1]-10*eps(d[1]), d[2]+10*eps(d[2])) d[1:2]
+        end
+
+    debug && println("non-symmetric eigen decomposition")
+        if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+            d,v   = eig(a)
+            for i in 1:size(a,2) @test_approx_eq a*v[:,i] d[i]*v[:,i] end
+        end
+
+    debug && println("symmetric generalized eigenproblem")
+        if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+            asym_sg = asym[1:n1, 1:n1]
+            a_sg = a[:,n1+1:n2]
+            f = eigfact(asym_sg, a_sg'a_sg)
+            eig(asym_sg, a_sg'a_sg) # same result, but checks that method works
+            @test_approx_eq asym_sg*f[:vectors] scale(a_sg'a_sg*f[:vectors], f[:values])
+            @test_approx_eq f[:values] eigvals(asym_sg, a_sg'a_sg)
+            @test_approx_eq_eps prod(f[:values]) prod(eigvals(asym_sg/(a_sg'a_sg))) 200ε
+        end
+
+    debug && println("Non-symmetric generalized eigenproblem")
+        if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+            a1_nsg = a[1:n1, 1:n1]
+            a2_nsg = a[n1+1:n2, n1+1:n2]
+            f = eigfact(a1_nsg, a2_nsg)
+            eig(a1_nsg, a2_nsg) # same result, but checks that method works
+            @test_approx_eq a1_nsg*f[:vectors] scale(a2_nsg*f[:vectors], f[:values])
+            @test_approx_eq f[:values] eigvals(a1_nsg, a2_nsg)
+            @test_approx_eq_eps prod(f[:values]) prod(eigvals(a1_nsg/a2_nsg)) 50000ε
+        end
+
+    debug && println("Schur")
+        if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+            f = schurfact(a)
+            @test_approx_eq f[:vectors]*f[:Schur]*f[:vectors]' a
+            @test_approx_eq sort(real(f[:values])) sort(real(d))
+            @test_approx_eq sort(imag(f[:values])) sort(imag(d))
+            @test istriu(f[:Schur]) || iseltype(a,Real)
+        end
+
+    debug && println("Reorder Schur")
+        if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+            # use asym for real schur to enforce tridiag structure
+            # avoiding partly selection of conj. eigenvalues
+            ordschura = eltya <: Complex ? a : asym
+            S = schurfact(ordschura)
+            select = rand(range(0,2), n)
+            O = ordschur(S, select)
+            bool(sum(select)) && @test_approx_eq S[:values][find(select)] O[:values][1:sum(select)]
+            @test_approx_eq O[:vectors]*O[:Schur]*O[:vectors]' ordschura
+        end
+
+    debug && println("Generalized Schur")
+        if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+            a1_sf = a[1:n1, 1:n1]
+            a2_sf = a[n1+1:n2, n1+1:n2]
+            f = schurfact(a1_sf, a2_sf)
+            @test_approx_eq f[:Q]*f[:S]*f[:Z]' a1_sf
+            @test_approx_eq f[:Q]*f[:T]*f[:Z]' a2_sf
+            @test istriu(f[:S]) || iseltype(a,Real)
+            @test istriu(f[:T]) || iseltype(a,Real)
+        end
+
+    debug && println("Reorder Generalized Schur")
+        if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in Julia
+            a1_sf = a[1:n1, 1:n1]
+            a2_sf = a[n1+1:n2, n1+1:n2]
+            NS = schurfact(a1_sf, a2_sf)
+            # Currently just testing with selecting gen eig values < 1
+            select = int(real(NS[:values] .* conj(NS[:values])) .< 1)
+            m = sum(select)
+            S = ordschur(NS, select)
+            # Make sure that the new factorization stil factors matrix
+            @test_approx_eq S[:Q]*S[:S]*S[:Z]' a1_sf
+            @test_approx_eq S[:Q]*S[:T]*S[:Z]' a2_sf
+            # Make sure that we have sorted it correctly
+            @test_approx_eq NS[:values][find(select)] S[:values][1:m]
+        end
+
+    debug && println("singular value decomposition")
+        if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+            usv = svdfact(a)
+            @test_approx_eq usv[:U]*scale(usv[:S],usv[:Vt]) a
+        end
+
+    debug && println("Generalized svd")
+        if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+            a_svd = a[1:n1, :]
+            gsvd = svdfact(a,a_svd)
+            @test_approx_eq gsvd[:U]*gsvd[:D1]*gsvd[:R]*gsvd[:Q]' a
+            @test_approx_eq gsvd[:V]*gsvd[:D2]*gsvd[:R]*gsvd[:Q]' a_svd
+        end
+
+    debug && println("Solve square general system of equations")
+        κ = cond(a,1)
+        x = a \ b
+        @test_throws DimensionMismatch b'\b
+        @test_throws DimensionMismatch b\b'
+        @test norm(a*x - b, 1)/norm(b) < ε*κ*n*2 # Ad hoc, revisit!
+
+    debug && println("Test nullspace")
+        if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
+            a15null = nullspace(a[:,1:n1]')
+            @test rank([a[:,1:n1] a15null]) == 10
+            @test_approx_eq_eps norm(a[:,1:n1]'a15null, Inf) zero(eltya) 300ε
+            @test_approx_eq_eps norm(a15null'a[:,1:n1], Inf) zero(eltya) 400ε
+            @test size(nullspace(b), 2) == 0
+        end
+        end # for eltyb
+
+    debug && println("\ntype of a: ", eltya, "\n")
+
+    debug && println("Test pinv")
+        if eltya != BigFloat # Revisit when implemented in julia
+            pinva15 = pinv(a[:,1:n1])
+            @test_approx_eq a[:,1:n1]*pinva15*a[:,1:n1] a[:,1:n1]
+            @test_approx_eq pinva15*a[:,1:n1]*pinva15 pinva15
+        end
+
+        # if isreal(a)
+    debug && println("Matrix square root")
+        if eltya != BigFloat # Revisit when implemented in julia
+            asq = sqrtm(a)
+            @test_approx_eq asq*asq a
+            asymsq = sqrtm(asym)
+            @test_approx_eq asymsq*asymsq asym
+        end
+
+    debug && println("Lyapunov/Sylvester")
+        if eltya != BigFloat
+            let
+                x = lyap(a, a2)
+                @test_approx_eq -a2 a*x + x*a'
+                x2 = sylvester(a[1:3, 1:3], a[4:n, 4:n], a2[1:3,4:n])
+                @test_approx_eq -a2[1:3, 4:n] a[1:3, 1:3]*x2 + x2*a[4:n, 4:n]
+            end
+        end
+    end # for eltya
 end
-
-areal = randn(n,n)/2
-aimg  = randn(n,n)/2
-a2real = randn(n,n)/2
-a2img  = randn(n,n)/2
-breal = randn(n,2)/2
-bimg  = randn(n,2)/2
-
-for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
-    a = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(areal, aimg) : areal)
-    a2 = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex(a2real, a2img) : a2real)
-    asym = a'+a                  # symmetric indefinite
-    apd  = a'*a                 # symmetric positive-definite
-    ε = εa = eps(abs(float(one(eltya))))
-
-    for eltyb in (Float32, Float64, Complex64, Complex128, Int)
-        b = eltyb == Int ? rand(1:5, n, 2) : convert(Matrix{eltyb}, eltyb <: Complex ? complex(breal, bimg) : breal)
-        εb = eps(abs(float(one(eltyb))))
-        ε = max(εa,εb)
-
-debug && println("\ntype of a: ", eltya, " type of b: ", eltyb, "\n")
-
-debug && println("(Automatic) upper Cholesky factor")
-
-    capd  = factorize(apd)
-    r     = capd[:U]
-    κ     = cond(apd, 1) #condition number
-
-    #Test error bound on reconstruction of matrix: LAWNS 14, Lemma 2.1
-    E = abs(apd - r'*r)
-    for i=1:n, j=1:n
-        @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
-    end
-    E = abs(apd - full(capd))
-    for i=1:n, j=1:n
-        @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
-    end
-
-    #Test error bound on linear solver: LAWNS 14, Theorem 2.1
-    #This is a surprisingly loose bound...
-    x = capd\b
-    @test norm(x-apd\b,1)/norm(x,1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
-    @test norm(apd*x-b,1)/norm(b,1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
-
-    @test_approx_eq apd * inv(capd) eye(n)
-    @test norm(a*(capd\(a'*b)) - b,1)/norm(b,1) <= ε*κ*n # Ad hoc, revisit
-    @test abs((det(capd) - det(apd))/det(capd)) <= ε*κ*n # Ad hoc, but statistically verified, revisit
-    @test_approx_eq logdet(capd) log(det(capd)) # logdet is less likely to overflow
-
-    apos = asym[1,1]            # test chol(x::Number), needs x>0
-    @test_approx_eq cholfact(apos).UL √apos
-
-    # test chol of 2x2 Strang matrix
-    S = convert(AbstractMatrix{eltya},full(SymTridiagonal([2,2],[-1])))
-    U = Bidiagonal([2,sqrt(eltya(3))],[-1],true) / sqrt(eltya(2))
-    @test_approx_eq full(chol(S)) full(U)
-
-debug && println("lower Cholesky factor")
-    lapd = cholfact(apd, :L)
-    @test_approx_eq full(lapd) apd
-    l = lapd[:L]
-    @test_approx_eq l*l' apd
-
-debug && println("pivoted Choleksy decomposition")
-    if eltya != BigFloat && eltyb != BigFloat # Note! Need to implement pivoted cholesky decomposition in julia
-        cpapd = cholfact(apd, :U, Val{true})
-        @test rank(cpapd) == n
-        @test all(diff(diag(real(cpapd.UL))).<=0.) # diagonal should be non-increasing
-        @test norm(apd * (cpapd\b) - b)/norm(b) <= ε*κ*n # Ad hoc, revisit
-        if isreal(apd)
-            @test_approx_eq apd * inv(cpapd) eye(n)
-        end
-    end
-
-debug && println("(Automatic) Bunch-Kaufman factor of indefinite matrix")
-    if eltya != BigFloat && eltyb != BigFloat # Not implemented for BigFloat and I don't think it will.
-        bc1 = factorize(asym)
-        @test_approx_eq inv(bc1) * asym eye(n)
-        @test_approx_eq_eps asym * (bc1\b) b 1000ε
-
-debug && println("Bunch-Kaufman factors of a pos-def matrix")
-        bc2 = bkfact(apd)
-        @test_approx_eq inv(bc2) * apd eye(n)
-        @test_approx_eq_eps apd * (bc2\b) b 60000ε
-    end
-
-debug && println("(Automatic) Square LU decomposition")
-    κ     = cond(a,1)
-    lua   = factorize(a)
-    l,u,p = lua[:L], lua[:U], lua[:p]
-    @test_approx_eq l*u a[p,:]
-    @test_approx_eq (l*u)[invperm(p),:] a
-    @test_approx_eq a * inv(lua) eye(n)
-    @test norm(a*(lua\b) - b, 1) < ε*κ*n*2 # Two because the right hand side has two columns
-
-debug && println("Thin LU")
-    lua   = lufact(a[:,1:n1])
-    @test_approx_eq lua[:L]*lua[:U] lua[:P]*a[:,1:n1]
-
-debug && println("Fat LU")
-    lua   = lufact(a[1:n1,:])
-    @test_approx_eq lua[:L]*lua[:U] lua[:P]*a[1:n1,:]
-
-debug && println("QR decomposition (without pivoting)")
-    qra   = qrfact(a, Val{false})
-    q,r   = qra[:Q], qra[:R]
-    @test_approx_eq q'*full(q, thin=false) eye(n)
-    @test_approx_eq q*full(q, thin=false)' eye(n)
-    @test_approx_eq q*r a
-    @test_approx_eq_eps a*(qra\b) b 3000ε
-
-debug && println("(Automatic) Fat (pivoted) QR decomposition") # Pivoting is only implemented for BlasFloats
-    qrpa  = factorize(a[1:n1,:])
-    q,r = qrpa[:Q], qrpa[:R]
-    if isa(qrpa,QRPivoted) p = qrpa[:p] end # Reconsider if pivoted QR gets implemented in julia
-    @test_approx_eq q'*full(q, thin=false) eye(n1)
-    @test_approx_eq q*full(q, thin=false)' eye(n1)
-    @test_approx_eq q*r isa(qrpa,QRPivoted) ? a[1:n1,p] : a[1:n1,:]
-    @test_approx_eq isa(qrpa, QRPivoted) ? q*r[:,invperm(p)] : q*r a[1:n1,:]
-    @test_approx_eq_eps a[1:n1,:]*(qrpa\b[1:n1]) b[1:n1] 5000ε
-
-debug && println("(Automatic) Thin (pivoted) QR decomposition") # Pivoting is only implemented for BlasFloats
-    qrpa  = factorize(a[:,1:n1])
-    q,r = qrpa[:Q], qrpa[:R]
-    if isa(qrpa, QRPivoted) p = qrpa[:p] end # Reconsider if pivoted QR gets implemented in julia
-    @test_approx_eq q'*full(q, thin=false) eye(n)
-    @test_approx_eq q*full(q, thin=false)' eye(n)
-    @test_approx_eq q*r isa(qrpa, QRPivoted) ? a[:,p] : a[:,1:n1]
-    @test_approx_eq isa(qrpa, QRPivoted) ? q*r[:,invperm(p)] : q*r a[:,1:n1]
-
-debug && println("symmetric eigen-decomposition")
-    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
-        d,v   = eig(asym)
-        @test_approx_eq asym*v[:,1] d[1]*v[:,1]
-        @test_approx_eq v*Diagonal(d)*v' asym
-        @test isequal(eigvals(asym[1]), eigvals(asym[1:1,1:1]))
-        @test_approx_eq abs(eigfact(Hermitian(asym), 1:2)[:vectors]'v[:,1:2]) eye(eltya, 2)
-        eig(Hermitian(asym), 1:2) # same result, but checks that method works
-        @test_approx_eq abs(eigfact(Hermitian(asym), d[1]-10*eps(d[1]), d[2]+10*eps(d[2]))[:vectors]'v[:,1:2]) eye(eltya, 2)
-        eig(Hermitian(asym), d[1]-10*eps(d[1]), d[2]+10*eps(d[2])) # same result, but checks that method works
-        @test_approx_eq eigvals(Hermitian(asym), 1:2) d[1:2]
-        @test_approx_eq eigvals(Hermitian(asym), d[1]-10*eps(d[1]), d[2]+10*eps(d[2])) d[1:2]
-    end
-
-debug && println("non-symmetric eigen decomposition")
-    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
-        d,v   = eig(a)
-        for i in 1:size(a,2) @test_approx_eq a*v[:,i] d[i]*v[:,i] end
-    end
-
-debug && println("symmetric generalized eigenproblem")
-    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
-        asym_sg = asym[1:n1, 1:n1]
-        a_sg = a[:,n1+1:n2]
-        f = eigfact(asym_sg, a_sg'a_sg)
-        eig(asym_sg, a_sg'a_sg) # same result, but checks that method works
-        @test_approx_eq asym_sg*f[:vectors] scale(a_sg'a_sg*f[:vectors], f[:values])
-        @test_approx_eq f[:values] eigvals(asym_sg, a_sg'a_sg)
-        @test_approx_eq_eps prod(f[:values]) prod(eigvals(asym_sg/(a_sg'a_sg))) 200ε
-    end
-
-debug && println("Non-symmetric generalized eigenproblem")
-    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
-        a1_nsg = a[1:n1, 1:n1]
-        a2_nsg = a[n1+1:n2, n1+1:n2]
-        f = eigfact(a1_nsg, a2_nsg)
-        eig(a1_nsg, a2_nsg) # same result, but checks that method works
-        @test_approx_eq a1_nsg*f[:vectors] scale(a2_nsg*f[:vectors], f[:values])
-        @test_approx_eq f[:values] eigvals(a1_nsg, a2_nsg)
-        @test_approx_eq_eps prod(f[:values]) prod(eigvals(a1_nsg/a2_nsg)) 50000ε
-    end
-
-debug && println("Schur")
-    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
-        f = schurfact(a)
-        @test_approx_eq f[:vectors]*f[:Schur]*f[:vectors]' a
-        @test_approx_eq sort(real(f[:values])) sort(real(d))
-        @test_approx_eq sort(imag(f[:values])) sort(imag(d))
-        @test istriu(f[:Schur]) || iseltype(a,Real)
-    end
-
-debug && println("Reorder Schur")
-    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
-        # use asym for real schur to enforce tridiag structure
-        # avoiding partly selection of conj. eigenvalues
-        ordschura = eltya <: Complex ? a : asym
-        S = schurfact(ordschura)
-        select = rand(range(0,2), n)
-        O = ordschur(S, select)
-        bool(sum(select)) && @test_approx_eq S[:values][find(select)] O[:values][1:sum(select)]
-        @test_approx_eq O[:vectors]*O[:Schur]*O[:vectors]' ordschura
-    end
-
-debug && println("Generalized Schur")
-    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
-        a1_sf = a[1:n1, 1:n1]
-        a2_sf = a[n1+1:n2, n1+1:n2]
-        f = schurfact(a1_sf, a2_sf)
-        @test_approx_eq f[:Q]*f[:S]*f[:Z]' a1_sf
-        @test_approx_eq f[:Q]*f[:T]*f[:Z]' a2_sf
-        @test istriu(f[:S]) || iseltype(a,Real)
-        @test istriu(f[:T]) || iseltype(a,Real)
-    end
-
-debug && println("Reorder Generalized Schur")
-    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in Julia
-        a1_sf = a[1:n1, 1:n1]
-        a2_sf = a[n1+1:n2, n1+1:n2]
-        NS = schurfact(a1_sf, a2_sf)
-        # Currently just testing with selecting gen eig values < 1
-        select = int(real(NS[:values] .* conj(NS[:values])) .< 1)
-        m = sum(select)
-        S = ordschur(NS, select)
-        # Make sure that the new factorization stil factors matrix
-        @test_approx_eq S[:Q]*S[:S]*S[:Z]' a1_sf
-        @test_approx_eq S[:Q]*S[:T]*S[:Z]' a2_sf
-        # Make sure that we have sorted it correctly
-        @test_approx_eq NS[:values][find(select)] S[:values][1:m]
-    end
-
-debug && println("singular value decomposition")
-    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
-        usv = svdfact(a)
-        @test_approx_eq usv[:U]*scale(usv[:S],usv[:Vt]) a
-    end
-
-debug && println("Generalized svd")
-    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
-        a_svd = a[1:n1, :]
-        gsvd = svdfact(a,a_svd)
-        @test_approx_eq gsvd[:U]*gsvd[:D1]*gsvd[:R]*gsvd[:Q]' a
-        @test_approx_eq gsvd[:V]*gsvd[:D2]*gsvd[:R]*gsvd[:Q]' a_svd
-    end
-
-debug && println("Solve square general system of equations")
-    κ = cond(a,1)
-    x = a \ b
-    @test_throws DimensionMismatch b'\b
-    @test_throws DimensionMismatch b\b'
-    @test norm(a*x - b, 1)/norm(b) < ε*κ*n*2 # Ad hoc, revisit!
-
-debug && println("Test nullspace")
-    if eltya != BigFloat && eltyb != BigFloat # Revisit when implemented in julia
-        a15null = nullspace(a[:,1:n1]')
-        @test rank([a[:,1:n1] a15null]) == 10
-        @test_approx_eq_eps norm(a[:,1:n1]'a15null, Inf) zero(eltya) 300ε
-        @test_approx_eq_eps norm(a15null'a[:,1:n1], Inf) zero(eltya) 400ε
-        @test size(nullspace(b), 2) == 0
-    end
-    end # for eltyb
-
-debug && println("\ntype of a: ", eltya, "\n")
-
-debug && println("Test pinv")
-    if eltya != BigFloat # Revisit when implemented in julia
-        pinva15 = pinv(a[:,1:n1])
-        @test_approx_eq a[:,1:n1]*pinva15*a[:,1:n1] a[:,1:n1]
-        @test_approx_eq pinva15*a[:,1:n1]*pinva15 pinva15
-    end
-
-    # if isreal(a)
-debug && println("Matrix square root")
-    if eltya != BigFloat # Revisit when implemented in julia
-        asq = sqrtm(a)
-        @test_approx_eq asq*asq a
-        asymsq = sqrtm(asym)
-        @test_approx_eq asymsq*asymsq asym
-    end
-
-debug && println("Lyapunov/Sylvester")
-    if eltya != BigFloat
-        let
-            x = lyap(a, a2)
-            @test_approx_eq -a2 a*x + x*a'
-            x2 = sylvester(a[1:3, 1:3], a[4:n, 4:n], a2[1:3,4:n])
-            @test_approx_eq -a2[1:3, 4:n] a[1:3, 1:3]*x2 + x2*a[4:n, 4:n]
-        end
-    end
-end # for eltya
 
 #6941
 #@test (ones(10^7,4)*ones(4))[3] == 4.0

--- a/test/linalg2.jl
+++ b/test/linalg2.jl
@@ -4,385 +4,409 @@ import Base.LinAlg
 import Base.LinAlg: BlasComplex, BlasFloat, BlasReal
 
 # basic tridiagonal operations
-n = 5
+let n = 5
 
-srand(123)
+    srand(123)
 
-d = 1 .+ rand(n)
-dl = -rand(n-1)
-du = -rand(n-1)
-v = randn(n)
-B = randn(n,2)
+    d = 1 .+ rand(n)
+    dl = -rand(n-1)
+    du = -rand(n-1)
+    v = randn(n)
+    B = randn(n,2)
 
-for elty in (Float32, Float64, Complex64, Complex128, Int)
-    if elty == Int
-        srand(61516384)
-        d = rand(1:100, n)
-        dl = -rand(0:10, n-1)
-        du = -rand(0:10, n-1)
-        v = rand(1:100, n)
-        B = rand(1:100, n, 2)
-    else
-        d = convert(Vector{elty}, d)
-        dl = convert(Vector{elty}, dl)
-        du = convert(Vector{elty}, du)
-        v = convert(Vector{elty}, v)
-        B = convert(Matrix{elty}, B)
-    end
-    ε = eps(abs2(float(one(elty))))
-    T = Tridiagonal(dl, d, du)
-    @test size(T, 1) == n
-    @test size(T) == (n, n)
-    F = diagm(d)
-    for i = 1:n-1
-        F[i,i+1] = du[i]
-        F[i+1,i] = dl[i]
-    end
-    @test full(T) == F
+    for elty in (Float32, Float64, Complex64, Complex128, Int)
+        if elty == Int
+            srand(61516384)
+            d = rand(1:100, n)
+            dl = -rand(0:10, n-1)
+            du = -rand(0:10, n-1)
+            v = rand(1:100, n)
+            B = rand(1:100, n, 2)
+        else
+            d = convert(Vector{elty}, d)
+            dl = convert(Vector{elty}, dl)
+            du = convert(Vector{elty}, du)
+            v = convert(Vector{elty}, v)
+            B = convert(Matrix{elty}, B)
+        end
+        ε = eps(abs2(float(one(elty))))
+        T = Tridiagonal(dl, d, du)
+        @test size(T, 1) == n
+        @test size(T) == (n, n)
+        F = diagm(d)
+        for i = 1:n-1
+            F[i,i+1] = du[i]
+            F[i+1,i] = dl[i]
+        end
+        @test full(T) == F
 
-    # elementary operations on tridiagonals
-    @test conj(T) == Tridiagonal(conj(dl), conj(d), conj(du))
-    @test transpose(T) == Tridiagonal(du, d, dl)
-    @test ctranspose(T) == Tridiagonal(conj(du), conj(d), conj(dl))
+        # elementary operations on tridiagonals
+        @test conj(T) == Tridiagonal(conj(dl), conj(d), conj(du))
+        @test transpose(T) == Tridiagonal(du, d, dl)
+        @test ctranspose(T) == Tridiagonal(conj(du), conj(d), conj(dl))
 
-    # test interconversion of Tridiagonal and SymTridiagonal
-    @test Tridiagonal(dl, d, dl) == SymTridiagonal(d, dl)
-    @test Tridiagonal(dl, d, du) + Tridiagonal(du, d, dl) == SymTridiagonal(2d, dl+du)
-    @test SymTridiagonal(d, dl) + Tridiagonal(du, d, du) == SymTridiagonal(2d, dl+du)
+        # test interconversion of Tridiagonal and SymTridiagonal
+        @test Tridiagonal(dl, d, dl) == SymTridiagonal(d, dl)
+        @test Tridiagonal(dl, d, du) + Tridiagonal(du, d, dl) == SymTridiagonal(2d, dl+du)
+        @test SymTridiagonal(d, dl) + Tridiagonal(du, d, du) == SymTridiagonal(2d, dl+du)
 
-    # tridiagonal linear algebra
-    @test_approx_eq T*v F*v
-    invFv = F\v
-    @test_approx_eq T\v invFv
-    # @test_approx_eq Base.solve(T,v) invFv
-    # @test_approx_eq Base.solve(T, B) F\B
-    Tlu = factorize(T)
-    x = Tlu\v
-    @test_approx_eq x invFv
-    @test_approx_eq det(T) det(F)
+        # tridiagonal linear algebra
+        @test_approx_eq T*v F*v
+        invFv = F\v
+        @test_approx_eq T\v invFv
+        # @test_approx_eq Base.solve(T,v) invFv
+        # @test_approx_eq Base.solve(T, B) F\B
+        Tlu = factorize(T)
+        x = Tlu\v
+        @test_approx_eq x invFv
+        @test_approx_eq det(T) det(F)
 
-    # symmetric tridiagonal
-    if elty <: Real
-        Ts = SymTridiagonal(d, dl)
-        Fs = full(Ts)
-        invFsv = Fs\v
-        Tldlt = ldltfact(Ts)
-        x = Tldlt\v
-        @test_approx_eq x invFsv
-    end
-
-    # eigenvalues/eigenvectors of symmetric tridiagonal
-    if elty === Float32 || elty === Float64
-        DT, VT = eig(Ts)
-        D, Vecs = eig(Fs)
-        @test_approx_eq DT D
-        @test_approx_eq abs(VT'Vecs) eye(elty, n)
-    end
-
-    # Test det(A::Matrix)
-    # In the long run, these tests should step through Strang's
-    #  axiomatic definition of determinants.
-    # If all axioms are satisfied and all the composition rules work,
-    #  all determinants will be correct except for floating point errors.
-
-    # The determinant of the identity matrix should always be 1.
-    for i = 1:10
-        A = eye(elty, i)
-        @test_approx_eq det(A) one(elty)
-    end
-
-    # The determinant of a Householder reflection matrix should always be -1.
-    for i = 1:10
-        A = eye(elty, 10)
-        A[i, i] = -one(elty)
-        @test_approx_eq det(A) -one(elty)
-    end
-
-    # The determinant of a rotation matrix should always be 1.
-    if elty != Int
-        for theta = convert(Vector{elty}, pi ./ [1:4])
-            R = [cos(theta) -sin(theta);
-                 sin(theta) cos(theta)]
-            @test_approx_eq convert(elty, det(R)) one(elty)
+        # symmetric tridiagonal
+        if elty <: Real
+            Ts = SymTridiagonal(d, dl)
+            Fs = full(Ts)
+            invFsv = Fs\v
+            Tldlt = ldltfact(Ts)
+            x = Tldlt\v
+            @test_approx_eq x invFsv
         end
 
-    # issue #1490
-    @test_approx_eq_eps det(ones(elty, 3,3)) zero(elty) 3*eps(real(one(elty)))
+        # eigenvalues/eigenvectors of symmetric tridiagonal
+        if elty === Float32 || elty === Float64
+            DT, VT = eig(Ts)
+            D, Vecs = eig(Fs)
+            @test_approx_eq DT D
+            @test_approx_eq abs(VT'Vecs) eye(elty, n)
+        end
+
+        # Test det(A::Matrix)
+        # In the long run, these tests should step through Strang's
+        #  axiomatic definition of determinants.
+        # If all axioms are satisfied and all the composition rules work,
+        #  all determinants will be correct except for floating point errors.
+
+        # The determinant of the identity matrix should always be 1.
+        for i = 1:10
+            A = eye(elty, i)
+            @test_approx_eq det(A) one(elty)
+        end
+
+        # The determinant of a Householder reflection matrix should always be -1.
+        for i = 1:10
+            A = eye(elty, 10)
+            A[i, i] = -one(elty)
+            @test_approx_eq det(A) -one(elty)
+        end
+
+        # The determinant of a rotation matrix should always be 1.
+        if elty != Int
+            for theta = convert(Vector{elty}, pi ./ [1:4])
+                R = [cos(theta) -sin(theta);
+                     sin(theta) cos(theta)]
+                @test_approx_eq convert(elty, det(R)) one(elty)
+            end
+
+        # issue #1490
+        @test_approx_eq_eps det(ones(elty, 3,3)) zero(elty) 3*eps(real(one(elty)))
+        end
     end
 end
 
 # Generic BLAS tests
-srand(100)
-# syr2k! and her2k!
-for elty in (Float32, Float64, Complex64, Complex128)
-    U = randn(5,2)
-    V = randn(5,2)
-    if elty == Complex64 || elty == Complex128
-        U = complex(U, U)
-        V = complex(V, V)
+let
+    srand(100)
+    # syr2k! and her2k!
+    for elty in (Float32, Float64, Complex64, Complex128)
+        U = randn(5,2)
+        V = randn(5,2)
+        if elty == Complex64 || elty == Complex128
+            U = complex(U, U)
+            V = complex(V, V)
+        end
+        U = convert(Array{elty, 2}, U)
+        V = convert(Array{elty, 2}, V)
+        @test_approx_eq tril(LinAlg.BLAS.syr2k('L','N',U,V)) tril(U*V.' + V*U.')
+        @test_approx_eq triu(LinAlg.BLAS.syr2k('U','N',U,V)) triu(U*V.' + V*U.')
+        @test_approx_eq tril(LinAlg.BLAS.syr2k('L','T',U,V)) tril(U.'*V + V.'*U)
+        @test_approx_eq triu(LinAlg.BLAS.syr2k('U','T',U,V)) triu(U.'*V + V.'*U)
     end
-    U = convert(Array{elty, 2}, U)
-    V = convert(Array{elty, 2}, V)
-    @test_approx_eq tril(LinAlg.BLAS.syr2k('L','N',U,V)) tril(U*V.' + V*U.')
-    @test_approx_eq triu(LinAlg.BLAS.syr2k('U','N',U,V)) triu(U*V.' + V*U.')
-    @test_approx_eq tril(LinAlg.BLAS.syr2k('L','T',U,V)) tril(U.'*V + V.'*U)
-    @test_approx_eq triu(LinAlg.BLAS.syr2k('U','T',U,V)) triu(U.'*V + V.'*U)
+
+    for elty in (Complex64, Complex128)
+        U = randn(5,2)
+        V = randn(5,2)
+        if elty == Complex64 || elty == Complex128
+            U = complex(U, U)
+            V = complex(V, V)
+        end
+        U = convert(Array{elty, 2}, U)
+        V = convert(Array{elty, 2}, V)
+        @test_approx_eq tril(LinAlg.BLAS.her2k('L','N',U,V)) tril(U*V' + V*U')
+        @test_approx_eq triu(LinAlg.BLAS.her2k('U','N',U,V)) triu(U*V' + V*U')
+        @test_approx_eq tril(LinAlg.BLAS.her2k('L','C',U,V)) tril(U'*V + V'*U)
+        @test_approx_eq triu(LinAlg.BLAS.her2k('U','C',U,V)) triu(U'*V + V'*U)
+    end
 end
 
-for elty in (Complex64, Complex128)
-    U = randn(5,2)
-    V = randn(5,2)
-    if elty == Complex64 || elty == Complex128
-        U = complex(U, U)
-        V = complex(V, V)
+let
+    # Test gradient
+    for elty in (Int32, Int64, Float32, Float64, Complex64, Complex128)
+        if elty <: Real
+            x = convert(Vector{elty}, [1:3])
+            g = ones(elty, 3)
+        else
+            x = convert(Vector{elty}, complex([1:3],[1:3]))
+            g = convert(Vector{elty}, complex(ones(3), ones(3)))
+        end
+        @test_approx_eq gradient(x) g
     end
-    U = convert(Array{elty, 2}, U)
-    V = convert(Array{elty, 2}, V)
-    @test_approx_eq tril(LinAlg.BLAS.her2k('L','N',U,V)) tril(U*V' + V*U')
-    @test_approx_eq triu(LinAlg.BLAS.her2k('U','N',U,V)) triu(U*V' + V*U')
-    @test_approx_eq tril(LinAlg.BLAS.her2k('L','C',U,V)) tril(U'*V + V'*U)
-    @test_approx_eq triu(LinAlg.BLAS.her2k('U','C',U,V)) triu(U'*V + V'*U)
 end
 
-# Test gradient
-for elty in (Int32, Int64, Float32, Float64, Complex64, Complex128)
-    if elty <: Real
-        x = convert(Vector{elty}, [1:3])
-        g = ones(elty, 3)
-    else
-        x = convert(Vector{elty}, complex([1:3],[1:3]))
-        g = convert(Vector{elty}, complex(ones(3), ones(3)))
-    end
-    @test_approx_eq gradient(x) g
-end
 
 # Test our own linear algebra functionaly against LAPACK
-for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
-    for nn in (5,10,15)
-        if elty <: Real
-            A = convert(Matrix{elty}, randn(10,nn))
-        else
-            A = convert(Matrix{elty}, complex(randn(10,nn),randn(10,nn)))
-        end    ## LU (only equal for real because LAPACK uses different absolute value when choosing permutations)
-        if elty <: Real
-            FJulia  = Base.LinAlg.generic_lufact!(copy(A))
-            FLAPACK = Base.LinAlg.LAPACK.getrf!(copy(A))
-            @test_approx_eq FJulia.factors FLAPACK[1]
-            @test_approx_eq FJulia.ipiv FLAPACK[2]
-            @test_approx_eq FJulia.info FLAPACK[3]
-        end
+let
+    srand(100)
+    for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
+        for nn in (5,10,15)
+            if elty <: Real
+                A = convert(Matrix{elty}, randn(10,nn))
+            else
+                A = convert(Matrix{elty}, complex(randn(10,nn),randn(10,nn)))
+            end    ## LU (only equal for real because LAPACK uses different absolute value when choosing permutations)
+            if elty <: Real
+                FJulia  = Base.LinAlg.generic_lufact!(copy(A))
+                FLAPACK = Base.LinAlg.LAPACK.getrf!(copy(A))
+                @test_approx_eq FJulia.factors FLAPACK[1]
+                @test_approx_eq FJulia.ipiv FLAPACK[2]
+                @test_approx_eq FJulia.info FLAPACK[3]
+            end
 
-        ## QR
-        FJulia  = invoke(qrfact!, (AbstractMatrix,Type{Val{false}}), copy(A), Val{false})
-        FLAPACK = Base.LinAlg.LAPACK.geqrf!(copy(A))
-        @test_approx_eq FJulia.factors FLAPACK[1]
-        @test_approx_eq FJulia.τ FLAPACK[2]
+            ## QR
+            FJulia  = invoke(qrfact!, (AbstractMatrix,Type{Val{false}}), copy(A), Val{false})
+            FLAPACK = Base.LinAlg.LAPACK.geqrf!(copy(A))
+            @test_approx_eq FJulia.factors FLAPACK[1]
+            @test_approx_eq FJulia.τ FLAPACK[2]
+        end
     end
 end
 
-# Test rational matrices
-## Integrate in general tests when more linear algebra is implemented in julia
-a = convert(Matrix{Rational{BigInt}}, rand(1:10//1,n,n))/n
-b = rand(1:10,n,2)
-lua   = factorize(a)
-l,u,p = lua[:L], lua[:U], lua[:p]
-@test_approx_eq l*u a[p,:]
-@test_approx_eq l[invperm(p),:]*u a
-@test_approx_eq a * inv(lua) eye(n)
-@test_approx_eq a*(lua\b) b
-@test_approx_eq det(a) det(float64(float(a)))
-## Hilbert Matrix (very ill conditioned)
-## Testing Rational{BigInt} and BigFloat version
-nHilbert = 50
-H = Rational{BigInt}[1//(i+j-1) for i = 1:nHilbert,j = 1:nHilbert]
-Hinv = Rational{BigInt}[(-1)^(i+j)*(i+j-1)*binomial(nHilbert+i-1,nHilbert-j)*binomial(nHilbert+j-1,nHilbert-i)*binomial(i+j-2,i-1)^2 for i = big(1):nHilbert,j=big(1):nHilbert]
-@test inv(H) == Hinv
-with_bigfloat_precision(2^10) do
-    @test norm(float64(inv(float(H)) - float(Hinv))) < 1e-100
+let n = 5
+    srand(100)
+    # Test rational matrices
+    ## Integrate in general tests when more linear algebra is implemented in julia
+    a = convert(Matrix{Rational{BigInt}}, rand(1:10//1,n,n))/n
+    b = rand(1:10,n,2)
+    lua   = factorize(a)
+    l,u,p = lua[:L], lua[:U], lua[:p]
+    @test_approx_eq l*u a[p,:]
+    @test_approx_eq l[invperm(p),:]*u a
+    @test_approx_eq a * inv(lua) eye(n)
+    @test_approx_eq a*(lua\b) b
+    @test_approx_eq det(a) det(float64(float(a)))
+    ## Hilbert Matrix (very ill conditioned)
+    ## Testing Rational{BigInt} and BigFloat version
+    nHilbert = 50
+    H = Rational{BigInt}[1//(i+j-1) for i = 1:nHilbert,j = 1:nHilbert]
+    Hinv = Rational{BigInt}[(-1)^(i+j)*(i+j-1)*binomial(nHilbert+i-1,nHilbert-j)*binomial(nHilbert+j-1,nHilbert-i)*binomial(i+j-2,i-1)^2
+                            for i = big(1):nHilbert,j=big(1):nHilbert]
+    @test inv(H) == Hinv
+    with_bigfloat_precision(2^10) do
+        @test norm(float64(inv(float(H)) - float(Hinv))) < 1e-100
+    end
 end
 
+
 # Test balancing in eigenvector calculations
-for elty in (Float32, Float64, Complex64, Complex128)
-    A = convert(Matrix{elty}, [ 3.0     -2.0      -0.9     2*eps(real(one(elty)));
-                               -2.0      4.0       1.0    -eps(real(one(elty)));
-                               -eps(real(one(elty)))/4  eps(real(one(elty)))/2  -1.0     0;
-                               -0.5     -0.5       0.1     1.0])
-    F = eigfact(A, permute=false, scale=false)
-    eig(A, permute=false, scale=false)
-    @test_approx_eq F[:vectors]*Diagonal(F[:values])/F[:vectors] A
-    F = eigfact(A)
-    # @test norm(F[:vectors]*Diagonal(F[:values])/F[:vectors] - A) > 0.01
+let
+    for elty in (Float32, Float64, Complex64, Complex128)
+        A = convert(Matrix{elty}, [ 3.0     -2.0      -0.9     2*eps(real(one(elty)));
+                                   -2.0      4.0       1.0    -eps(real(one(elty)));
+                                   -eps(real(one(elty)))/4  eps(real(one(elty)))/2  -1.0     0;
+                                   -0.5     -0.5       0.1     1.0])
+        F = eigfact(A, permute=false, scale=false)
+        eig(A, permute=false, scale=false)
+        @test_approx_eq F[:vectors]*Diagonal(F[:values])/F[:vectors] A
+        F = eigfact(A)
+        # @test norm(F[:vectors]*Diagonal(F[:values])/F[:vectors] - A) > 0.01
+    end
 end
 
 # Tests norms
-nnorm = 1000
-mmat = 100
-nmat = 80
-for elty in (Float32, Float64, BigFloat, Complex{Float32}, Complex{Float64}, Complex{BigFloat}, Int32, Int64, BigInt)
-    debug && println(elty)
+let nnorm = 1000,
+    mmat = 100,
+    nmat = 80
 
-    ## Vector
-    x = ones(elty,10)
-    xs = sub(x,1:2:10)
-    @test_approx_eq norm(x, -Inf) 1
-    @test_approx_eq norm(x, -1) 1/10
-    @test_approx_eq norm(x, 0) 10
-    @test_approx_eq norm(x, 1) 10
-    @test_approx_eq norm(x, 2) sqrt(10)
-    @test_approx_eq norm(x, 3) cbrt(10)
-    @test_approx_eq norm(x, Inf) 1
-    @test_approx_eq norm(xs, -Inf) 1
-    @test_approx_eq norm(xs, -1) 1/5
-    @test_approx_eq norm(xs, 0) 5
-    @test_approx_eq norm(xs, 1) 5
-    @test_approx_eq norm(xs, 2) sqrt(5)
-    @test_approx_eq norm(xs, 3) cbrt(5)
-    @test_approx_eq norm(xs, Inf) 1
+    srand(100)
+    for elty in (Float32, Float64, BigFloat,
+                 Complex{Float32}, Complex{Float64}, Complex{BigFloat},
+                 Int32, Int64, BigInt)
+        debug && println(elty)
 
-    ## Number
-    norm(x[1:1]) === norm(x[1], -Inf)
-    norm(x[1:1]) === norm(x[1], 0)
-    norm(x[1:1]) === norm(x[1], 1)
-    norm(x[1:1]) === norm(x[1], 2)
-    norm(x[1:1]) === norm(x[1], Inf)
+        ## Vector
+        x = ones(elty,10)
+        xs = sub(x,1:2:10)
+        @test_approx_eq norm(x, -Inf) 1
+        @test_approx_eq norm(x, -1) 1/10
+        @test_approx_eq norm(x, 0) 10
+        @test_approx_eq norm(x, 1) 10
+        @test_approx_eq norm(x, 2) sqrt(10)
+        @test_approx_eq norm(x, 3) cbrt(10)
+        @test_approx_eq norm(x, Inf) 1
+        @test_approx_eq norm(xs, -Inf) 1
+        @test_approx_eq norm(xs, -1) 1/5
+        @test_approx_eq norm(xs, 0) 5
+        @test_approx_eq norm(xs, 1) 5
+        @test_approx_eq norm(xs, 2) sqrt(5)
+        @test_approx_eq norm(xs, 3) cbrt(5)
+        @test_approx_eq norm(xs, Inf) 1
 
-    for i = 1:10
-        x = elty <: Integer ? convert(Vector{elty}, rand(1:10, nnorm)) :
-            elty <: Complex ? convert(Vector{elty}, complex(randn(nnorm), randn(nnorm))) :
-            convert(Vector{elty}, randn(nnorm))
-        xs = sub(x,1:2:nnorm)
-        y = elty <: Integer ? convert(Vector{elty}, rand(1:10, nnorm)) :
-            elty <: Complex ? convert(Vector{elty}, complex(randn(nnorm), randn(nnorm))) :
-            convert(Vector{elty}, randn(nnorm))
-        ys = sub(y,1:2:nnorm)
-        α = elty <: Integer ? randn() :
-            elty <: Complex ? convert(elty, complex(randn(),randn())) :
-            convert(elty, randn())
-        # Absolute homogeneity
-        @test_approx_eq norm(α*x,-Inf) abs(α)*norm(x,-Inf)
-        @test_approx_eq norm(α*x,-1) abs(α)*norm(x,-1)
-        @test_approx_eq norm(α*x,1) abs(α)*norm(x,1)
-        @test_approx_eq norm(α*x) abs(α)*norm(x) # two is default
-        @test_approx_eq norm(α*x,3) abs(α)*norm(x,3)
-        @test_approx_eq norm(α*x,Inf) abs(α)*norm(x,Inf)
+        ## Number
+        norm(x[1:1]) === norm(x[1], -Inf)
+        norm(x[1:1]) === norm(x[1], 0)
+        norm(x[1:1]) === norm(x[1], 1)
+        norm(x[1:1]) === norm(x[1], 2)
+        norm(x[1:1]) === norm(x[1], Inf)
 
-        @test_approx_eq norm(α*xs,-Inf) abs(α)*norm(xs,-Inf)
-        @test_approx_eq norm(α*xs,-1) abs(α)*norm(xs,-1)
-        @test_approx_eq norm(α*xs,1) abs(α)*norm(xs,1)
-        @test_approx_eq norm(α*xs) abs(α)*norm(xs) # two is default
-        @test_approx_eq norm(α*xs,3) abs(α)*norm(xs,3)
-        @test_approx_eq norm(α*xs,Inf) abs(α)*norm(xs,Inf)
+        for i = 1:10
+            x = elty <: Integer ? convert(Vector{elty}, rand(1:10, nnorm)) :
+                elty <: Complex ? convert(Vector{elty}, complex(randn(nnorm), randn(nnorm))) :
+                convert(Vector{elty}, randn(nnorm))
+            xs = sub(x,1:2:nnorm)
+            y = elty <: Integer ? convert(Vector{elty}, rand(1:10, nnorm)) :
+                elty <: Complex ? convert(Vector{elty}, complex(randn(nnorm), randn(nnorm))) :
+                convert(Vector{elty}, randn(nnorm))
+            ys = sub(y,1:2:nnorm)
+            α = elty <: Integer ? randn() :
+                elty <: Complex ? convert(elty, complex(randn(),randn())) :
+                convert(elty, randn())
+            # Absolute homogeneity
+            @test_approx_eq norm(α*x,-Inf) abs(α)*norm(x,-Inf)
+            @test_approx_eq norm(α*x,-1) abs(α)*norm(x,-1)
+            @test_approx_eq norm(α*x,1) abs(α)*norm(x,1)
+            @test_approx_eq norm(α*x) abs(α)*norm(x) # two is default
+            @test_approx_eq norm(α*x,3) abs(α)*norm(x,3)
+            @test_approx_eq norm(α*x,Inf) abs(α)*norm(x,Inf)
 
-        # Triangle inequality
-        @test norm(x + y,1) <= norm(x,1) + norm(y,1)
-        @test norm(x + y) <= norm(x) + norm(y) # two is default
-        @test norm(x + y,3) <= norm(x,3) + norm(y,3)
-        @test norm(x + y,Inf) <= norm(x,Inf) + norm(y,Inf)
+            @test_approx_eq norm(α*xs,-Inf) abs(α)*norm(xs,-Inf)
+            @test_approx_eq norm(α*xs,-1) abs(α)*norm(xs,-1)
+            @test_approx_eq norm(α*xs,1) abs(α)*norm(xs,1)
+            @test_approx_eq norm(α*xs) abs(α)*norm(xs) # two is default
+            @test_approx_eq norm(α*xs,3) abs(α)*norm(xs,3)
+            @test_approx_eq norm(α*xs,Inf) abs(α)*norm(xs,Inf)
 
-        @test norm(xs + ys,1) <= norm(xs,1) + norm(ys,1)
-        @test norm(xs + ys) <= norm(xs) + norm(ys) # two is default
-        @test norm(xs + ys,3) <= norm(xs,3) + norm(ys,3)
-        @test norm(xs + ys,Inf) <= norm(xs,Inf) + norm(ys,Inf)
+            # Triangle inequality
+            @test norm(x + y,1) <= norm(x,1) + norm(y,1)
+            @test norm(x + y) <= norm(x) + norm(y) # two is default
+            @test norm(x + y,3) <= norm(x,3) + norm(y,3)
+            @test norm(x + y,Inf) <= norm(x,Inf) + norm(y,Inf)
 
-        # Against vectorized versions
-        @test_approx_eq norm(x,-Inf) minimum(abs(x))
-        @test_approx_eq norm(x,-1) inv(sum(1./abs(x)))
-        @test_approx_eq norm(x,0) sum(x .!= 0)
-        @test_approx_eq norm(x,1) sum(abs(x))
-        @test_approx_eq norm(x) sqrt(sum(abs2(x)))
-        @test_approx_eq norm(x,3) cbrt(sum(abs(x).^3.))
-        @test_approx_eq norm(x,Inf) maximum(abs(x))
-    end
-    ## Matrix (Operator)
-        A = ones(elty,10,10)
-        As = sub(A,1:5,1:5)
-        @test_approx_eq norm(A, 1) 10
-        elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test_approx_eq norm(A, 2) 10
-        @test_approx_eq norm(A, Inf) 10
-        @test_approx_eq norm(As, 1) 5
-        elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test_approx_eq norm(As, 2) 5
-        @test_approx_eq norm(As, Inf) 5
+            @test norm(xs + ys,1) <= norm(xs,1) + norm(ys,1)
+            @test norm(xs + ys) <= norm(xs) + norm(ys) # two is default
+            @test norm(xs + ys,3) <= norm(xs,3) + norm(ys,3)
+            @test norm(xs + ys,Inf) <= norm(xs,Inf) + norm(ys,Inf)
 
-    for i = 1:10
-        A = elty <: Integer ? convert(Matrix{elty}, rand(1:10, mmat, nmat)) :
-            elty <: Complex ? convert(Matrix{elty}, complex(randn(mmat, nmat), randn(mmat, nmat))) :
-            convert(Matrix{elty}, randn(mmat, nmat))
-        As = sub(A,1:nmat,1:nmat)
-        B = elty <: Integer ? convert(Matrix{elty}, rand(1:10, mmat, nmat)) :
-            elty <: Complex ? convert(Matrix{elty}, complex(randn(mmat, nmat), randn(mmat, nmat))) :
-            convert(Matrix{elty}, randn(mmat, nmat))
-        Bs = sub(B,1:nmat,1:nmat)
-        α = elty <: Integer ? randn() :
-            elty <: Complex ? convert(elty, complex(randn(),randn())) :
-            convert(elty, randn())
+            # Against vectorized versions
+            @test_approx_eq norm(x,-Inf) minimum(abs(x))
+            @test_approx_eq norm(x,-1) inv(sum(1./abs(x)))
+            @test_approx_eq norm(x,0) sum(x .!= 0)
+            @test_approx_eq norm(x,1) sum(abs(x))
+            @test_approx_eq norm(x) sqrt(sum(abs2(x)))
+            @test_approx_eq norm(x,3) cbrt(sum(abs(x).^3.))
+            @test_approx_eq norm(x,Inf) maximum(abs(x))
+        end
+        ## Matrix (Operator)
+            A = ones(elty,10,10)
+            As = sub(A,1:5,1:5)
+            @test_approx_eq norm(A, 1) 10
+            elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test_approx_eq norm(A, 2) 10
+            @test_approx_eq norm(A, Inf) 10
+            @test_approx_eq norm(As, 1) 5
+            elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test_approx_eq norm(As, 2) 5
+            @test_approx_eq norm(As, Inf) 5
 
-        # Absolute homogeneity
-        @test_approx_eq norm(α*A,1) abs(α)*norm(A,1)
-        elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test_approx_eq norm(α*A) abs(α)*norm(A) # two is default
-        @test_approx_eq norm(α*A,Inf) abs(α)*norm(A,Inf)
+        for i = 1:10
+            A = elty <: Integer ? convert(Matrix{elty}, rand(1:10, mmat, nmat)) :
+                elty <: Complex ? convert(Matrix{elty}, complex(randn(mmat, nmat), randn(mmat, nmat))) :
+                convert(Matrix{elty}, randn(mmat, nmat))
+            As = sub(A,1:nmat,1:nmat)
+            B = elty <: Integer ? convert(Matrix{elty}, rand(1:10, mmat, nmat)) :
+                elty <: Complex ? convert(Matrix{elty}, complex(randn(mmat, nmat), randn(mmat, nmat))) :
+                convert(Matrix{elty}, randn(mmat, nmat))
+            Bs = sub(B,1:nmat,1:nmat)
+            α = elty <: Integer ? randn() :
+                elty <: Complex ? convert(elty, complex(randn(),randn())) :
+                convert(elty, randn())
 
-        @test_approx_eq norm(α*As,1) abs(α)*norm(As,1)
-        elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test_approx_eq norm(α*As) abs(α)*norm(As) # two is default
-        @test_approx_eq norm(α*As,Inf) abs(α)*norm(As,Inf)
+            # Absolute homogeneity
+            @test_approx_eq norm(α*A,1) abs(α)*norm(A,1)
+            elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test_approx_eq norm(α*A) abs(α)*norm(A) # two is default
+            @test_approx_eq norm(α*A,Inf) abs(α)*norm(A,Inf)
 
-        # Triangle inequality
-        @test norm(A + B,1) <= norm(A,1) + norm(B,1)
-        elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test norm(A + B) <= norm(A) + norm(B) # two is default
-        @test norm(A + B,Inf) <= norm(A,Inf) + norm(B,Inf)
+            @test_approx_eq norm(α*As,1) abs(α)*norm(As,1)
+            elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test_approx_eq norm(α*As) abs(α)*norm(As) # two is default
+            @test_approx_eq norm(α*As,Inf) abs(α)*norm(As,Inf)
 
-        @test norm(As + Bs,1) <= norm(As,1) + norm(Bs,1)
-        elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test norm(As + Bs) <= norm(As) + norm(Bs) # two is default
-        @test norm(As + Bs,Inf) <= norm(As,Inf) + norm(Bs,Inf)
+            # Triangle inequality
+            @test norm(A + B,1) <= norm(A,1) + norm(B,1)
+            elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test norm(A + B) <= norm(A) + norm(B) # two is default
+            @test norm(A + B,Inf) <= norm(A,Inf) + norm(B,Inf)
 
-        # vecnorm:
-        for p = -2:3
-            @test norm(reshape(A, length(A)), p) == vecnorm(A, p)
+            @test norm(As + Bs,1) <= norm(As,1) + norm(Bs,1)
+            elty <: Union(BigFloat,Complex{BigFloat},BigInt) || @test norm(As + Bs) <= norm(As) + norm(Bs) # two is default
+            @test norm(As + Bs,Inf) <= norm(As,Inf) + norm(Bs,Inf)
+
+            # vecnorm:
+            for p = -2:3
+                @test norm(reshape(A, length(A)), p) == vecnorm(A, p)
+            end
         end
     end
 end
 
 # Uniform scaling
-@test I[1,1] == 1 # getindex
-@test I[1,2] == 0 # getindex
-@test I === I' # transpose
-λ = complex(randn(),randn())
-J = UniformScaling(λ)
-@test J*eye(2) == conj(J'eye(2)) # ctranpose (and A(c)_mul_B)
-@test I + I === UniformScaling(2) # +
-@test inv(I) == I
-@test inv(J) == UniformScaling(inv(λ))
-B = bitrand(2,2)
-@test B + I == B + eye(B)
-@test I + B == B + eye(B)
-A = randn(2,2)
-@test A + I == A + eye(A)
-@test I + A == A + eye(A)
-@test I - I === UniformScaling(0)
-@test B - I == B - eye(B)
-@test I - B == eye(B) - B
-@test A - I == A - eye(A)
-@test I - A == eye(A) - A
-@test I*J === UniformScaling(λ)
-@test B*J == B*λ
-@test J*B == B*λ
-S = sprandn(3,3,0.5)
-@test S*J == S*λ
-@test J*S == S*λ
-@test A*J == A*λ
-@test J*A == A*λ
-@test J*ones(3) == ones(3)*λ
-@test λ*J === UniformScaling(λ*J.λ)
-@test J*λ === UniformScaling(λ*J.λ)
-@test J/I === J
-@test I/A == inv(A)
-@test A/I == A
-@test I/λ === UniformScaling(1/λ)
-@test I\J === J
-T = LowerTriangular(randn(3,3))
-@test T\I == inv(T)
-@test I\A == A
-@test A\I == inv(A)
-@test λ\I === UniformScaling(1/λ)
+let
+    srand(100)
+    @test I[1,1] == 1 # getindex
+    @test I[1,2] == 0 # getindex
+    @test I === I' # transpose
+    λ = complex(randn(),randn())
+    J = UniformScaling(λ)
+    @test J*eye(2) == conj(J'eye(2)) # ctranpose (and A(c)_mul_B)
+    @test I + I === UniformScaling(2) # +
+    @test inv(I) == I
+    @test inv(J) == UniformScaling(inv(λ))
+    B = bitrand(2,2)
+    @test B + I == B + eye(B)
+    @test I + B == B + eye(B)
+    A = randn(2,2)
+    @test A + I == A + eye(A)
+    @test I + A == A + eye(A)
+    @test I - I === UniformScaling(0)
+    @test B - I == B - eye(B)
+    @test I - B == eye(B) - B
+    @test A - I == A - eye(A)
+    @test I - A == eye(A) - A
+    @test I*J === UniformScaling(λ)
+    @test B*J == B*λ
+    @test J*B == B*λ
+    S = sprandn(3,3,0.5)
+    @test S*J == S*λ
+    @test J*S == S*λ
+    @test A*J == A*λ
+    @test J*A == A*λ
+    @test J*ones(3) == ones(3)*λ
+    @test λ*J === UniformScaling(λ*J.λ)
+    @test J*λ === UniformScaling(λ*J.λ)
+    @test J/I === J
+    @test I/A == inv(A)
+    @test A/I == A
+    @test I/λ === UniformScaling(1/λ)
+    @test I\J === J
+    T = LowerTriangular(randn(3,3))
+    @test T\I == inv(T)
+    @test I\A == A
+    @test A\I == inv(A)
+    @test λ\I === UniformScaling(1/λ)
+end
 
 ## Issue related tests
 # issue #1447
@@ -404,8 +428,7 @@ let
     @test_approx_eq A2sq*A2sq A2
 end
 
-let
-    N = 3
+let N = 3
     @test_approx_eq log(det(eye(N))) logdet(eye(N))
 end
 

--- a/test/linalg3.jl
+++ b/test/linalg3.jl
@@ -1,238 +1,279 @@
 ## Least squares solutions
-a = [ones(20) 1:20 1:20]
-b = reshape(eye(8, 5), 20, 2)
-for elty in (Float32, Float64, Complex64, Complex128)
-    a = convert(Matrix{elty}, a)
-    b = convert(Matrix{elty}, b)
+let a = [ones(20) 1:20 1:20],
+    b = reshape(eye(8, 5), 20, 2)
 
-    # Vector rhs
-    x = a[:,1:2]\b[:,1]
-    @test_approx_eq ((a[:,1:2]*x-b[:,1])'*(a[:,1:2]*x-b[:,1]))[1] convert(elty, 2.546616541353384)
+    for elty in (Float32, Float64, Complex64, Complex128)
+        a = convert(Matrix{elty}, a)
+        b = convert(Matrix{elty}, b)
 
-    # Matrix rhs
-    x = a[:,1:2]\b
-    @test_approx_eq det((a[:,1:2]*x-b)'*(a[:,1:2]*x-b)) convert(elty, 4.437969924812031)
+        # Vector rhs
+        x = a[:,1:2]\b[:,1]
+        @test_approx_eq ((a[:,1:2]*x-b[:,1])'*(a[:,1:2]*x-b[:,1]))[1] convert(elty, 2.546616541353384)
 
-    # Rank deficient
-    x = a\b
-    @test_approx_eq det((a*x-b)'*(a*x-b)) convert(elty, 4.437969924812031)
+        # Matrix rhs
+        x = a[:,1:2]\b
+        @test_approx_eq det((a[:,1:2]*x-b)'*(a[:,1:2]*x-b)) convert(elty, 4.437969924812031)
 
-    # Underdetermined minimum norm
-    x = convert(Matrix{elty}, [1 0 0; 0 1 -1]) \ convert(Vector{elty}, [1,1])
-    @test_approx_eq x convert(Vector{elty}, [1, 0.5, -0.5])
+        # Rank deficient
+        x = a\b
+        @test_approx_eq det((a*x-b)'*(a*x-b)) convert(elty, 4.437969924812031)
 
-    # symmetric, positive definite
-    @test_approx_eq inv(convert(Matrix{elty}, [6. 2; 2 1])) convert(Matrix{elty}, [0.5 -1; -1 3])
+        # Underdetermined minimum norm
+        x = convert(Matrix{elty}, [1 0 0; 0 1 -1]) \ convert(Vector{elty}, [1,1])
+        @test_approx_eq x convert(Vector{elty}, [1, 0.5, -0.5])
 
-    # symmetric, indefinite
-    @test_approx_eq inv(convert(Matrix{elty}, [1. 2; 2 1])) convert(Matrix{elty}, [-1. 2; 2 -1]/3)
+        # symmetric, positive definite
+        @test_approx_eq inv(convert(Matrix{elty}, [6. 2; 2 1])) convert(Matrix{elty}, [0.5 -1; -1 3])
+
+        # symmetric, indefinite
+        @test_approx_eq inv(convert(Matrix{elty}, [1. 2; 2 1])) convert(Matrix{elty}, [-1. 2; 2 -1]/3)
+    end
 end
 
 ## Test Julia fallbacks to BLAS routines
 
 # matrices with zero dimensions
-for i = 1:10
-    @test ones(0,5)*ones(5,3) == zeros(0,3)
-    @test ones(3,5)*ones(5,0) == zeros(3,0)
-    @test ones(3,0)*ones(0,4) == zeros(3,4)
-    @test ones(0,5)*ones(5,0) == zeros(0,0)
-    @test ones(0,0)*ones(0,4) == zeros(0,4)
-    @test ones(3,0)*ones(0,0) == zeros(3,0)
-    @test ones(0,0)*ones(0,0) == zeros(0,0)
-    @test Array(Float64, 5, 0) |> t -> t't == zeros(0,0)
-    @test Array(Float64, 5, 0) |> t -> t*t' == zeros(5,5)
-    @test Array(Complex128, 5, 0) |> t -> t't == zeros(0,0)
-    @test Array(Complex128, 5, 0) |> t -> t*t' == zeros(5,5)
+let
+    for i = 1:10
+        @test ones(0,5)*ones(5,3) == zeros(0,3)
+        @test ones(3,5)*ones(5,0) == zeros(3,0)
+        @test ones(3,0)*ones(0,4) == zeros(3,4)
+        @test ones(0,5)*ones(5,0) == zeros(0,0)
+        @test ones(0,0)*ones(0,4) == zeros(0,4)
+        @test ones(3,0)*ones(0,0) == zeros(3,0)
+        @test ones(0,0)*ones(0,0) == zeros(0,0)
+        @test Array(Float64, 5, 0) |> t -> t't == zeros(0,0)
+        @test Array(Float64, 5, 0) |> t -> t*t' == zeros(5,5)
+        @test Array(Complex128, 5, 0) |> t -> t't == zeros(0,0)
+        @test Array(Complex128, 5, 0) |> t -> t*t' == zeros(5,5)
+    end
 end
 
 # 2x2
-A = [1 2; 3 4]
-B = [5 6; 7 8]
-@test A*B == [19 22; 43 50]
-@test At_mul_B(A, B) == [26 30; 38 44]
-@test A_mul_Bt(A, B) == [17 23; 39 53]
-@test At_mul_Bt(A, B) == [23 31; 34 46]
-Ai = A+(0.5*im).*B
-Bi = B+(2.5*im).*A[[2,1],[2,1]]
-@test Ai*Bi == [-21+53.5im -4.25+51.5im; -12+95.5im 13.75+85.5im]
-@test Ac_mul_B(Ai, Bi) == [68.5-12im 57.5-28im; 88-3im 76.5-25im]
-@test A_mul_Bc(Ai, Bi) == [64.5+5.5im 43+31.5im; 104-18.5im 80.5+31.5im]
-@test Ac_mul_Bc(Ai, Bi) == [-28.25-66im 9.75-58im; -26-89im 21-73im]
+let A = [1 2; 3 4],
+    B = [5 6; 7 8]
+
+    @test A*B == [19 22; 43 50]
+    @test At_mul_B(A, B) == [26 30; 38 44]
+    @test A_mul_Bt(A, B) == [17 23; 39 53]
+    @test At_mul_Bt(A, B) == [23 31; 34 46]
+    Ai = A+(0.5*im).*B
+    Bi = B+(2.5*im).*A[[2,1],[2,1]]
+    @test Ai*Bi == [-21+53.5im -4.25+51.5im; -12+95.5im 13.75+85.5im]
+    @test Ac_mul_B(Ai, Bi) == [68.5-12im 57.5-28im; 88-3im 76.5-25im]
+    @test A_mul_Bc(Ai, Bi) == [64.5+5.5im 43+31.5im; 104-18.5im 80.5+31.5im]
+    @test Ac_mul_Bc(Ai, Bi) == [-28.25-66im 9.75-58im; -26-89im 21-73im]
+end
 
 # 3x3
-A = [1 2 3; 4 5 6; 7 8 9].-5
-B = [1 0 5; 6 -10 3; 2 -4 -1]
-@test A*B == [-26 38 -27; 1 -4 -6; 28 -46 15]
-@test Ac_mul_B(A, B) == [-6 2 -25; 3 -12 -18; 12 -26 -11]
-@test A_mul_Bc(A, B) == [-14 0 6; 4 -3 -3; 22 -6 -12]
-@test Ac_mul_Bc(A, B) == [6 -8 -6; 12 -9 -9; 18 -10 -12]
-Ai = A+(0.5*im).*B
-Bi = B+(2.5*im).*A[[2,1,3],[2,3,1]]
-@test Ai*Bi == [-44.75+13im 11.75-25im -38.25+30im; -47.75-16.5im -51.5+51.5im -56+6im; 16.75-4.5im -53.5+52im -15.5im]
-@test Ac_mul_B(Ai, Bi) == [-21+2im -1.75+49im -51.25+19.5im; 25.5+56.5im -7-35.5im 22+35.5im; -3+12im -32.25+43im -34.75-2.5im]
-@test A_mul_Bc(Ai, Bi) == [-20.25+15.5im -28.75-54.5im 22.25+68.5im; -12.25+13im -15.5+75im -23+27im; 18.25+im 1.5+94.5im -27-54.5im]
-@test Ac_mul_Bc(Ai, Bi) == [1+2im 20.75+9im -44.75+42im; 19.5+17.5im -54-36.5im 51-14.5im; 13+7.5im 11.25+31.5im -43.25-14.5im]
+let A = [1 2 3; 4 5 6; 7 8 9].-5,
+    B = [1 0 5; 6 -10 3; 2 -4 -1],
+    Ai = A+(0.5*im).*B,
+    Bi = B+(2.5*im).*A[[2,1,3],[2,3,1]]
+
+    @test A*B == [-26 38 -27; 1 -4 -6; 28 -46 15]
+    @test Ac_mul_B(A, B) == [-6 2 -25; 3 -12 -18; 12 -26 -11]
+    @test A_mul_Bc(A, B) == [-14 0 6; 4 -3 -3; 22 -6 -12]
+    @test Ac_mul_Bc(A, B) == [6 -8 -6; 12 -9 -9; 18 -10 -12]
+    @test Ai*Bi == [-44.75+13im 11.75-25im -38.25+30im; -47.75-16.5im -51.5+51.5im -56+6im; 16.75-4.5im -53.5+52im -15.5im]
+    @test Ac_mul_B(Ai, Bi) == [-21+2im -1.75+49im -51.25+19.5im; 25.5+56.5im -7-35.5im 22+35.5im; -3+12im -32.25+43im -34.75-2.5im]
+    @test A_mul_Bc(Ai, Bi) == [-20.25+15.5im -28.75-54.5im 22.25+68.5im; -12.25+13im -15.5+75im -23+27im; 18.25+im 1.5+94.5im -27-54.5im]
+    @test Ac_mul_Bc(Ai, Bi) == [1+2im 20.75+9im -44.75+42im; 19.5+17.5im -54-36.5im 51-14.5im; 13+7.5im 11.25+31.5im -43.25-14.5im]
+end
 
 # Generic integer matrix multiplication
-A = [1 2 3; 4 5 6] .- 3
-B = [2 -2; 3 -5; -4 7]
-@test A*B == [-7 9; -4 9]
-@test At_mul_Bt(A, B) == [-6 -11 15; -6 -13 18; -6 -15 21]
-A = ones(Int, 2, 100)
-B = ones(Int, 100, 3)
-@test A*B == [100 100 100; 100 100 100]
-A = rand(1:20, 5, 5) .- 10
-B = rand(1:20, 5, 5) .- 10
-@test At_mul_B(A, B) == A'*B
-@test A_mul_Bt(A, B) == A*B'
+let A = [1 2 3; 4 5 6] .- 3,
+    B = [2 -2; 3 -5; -4 7]
 
-# Preallocated
-C = Array(Int, size(A, 1), size(B, 2))
-@test A_mul_B!(C, A, B) == A*B
-@test At_mul_B!(C, A, B) == A'*B
-@test A_mul_Bt!(C, A, B) == A*B'
-@test At_mul_Bt!(C, A, B) == A'*B'
-v = [1,2,3]
-C = Array(Int, 3, 3)
-@test A_mul_Bt!(C, v, v) == v*v'
-vf = float64(v)
-C = Array(Float64, 3, 3)
-@test A_mul_Bt!(C, v, v) == v*v'
+    @test A*B == [-7 9; -4 9]
+    @test At_mul_Bt(A, B) == [-6 -11 15; -6 -13 18; -6 -15 21]
+end
+let A = ones(Int, 2, 100),
+    B = ones(Int, 100, 3)
+
+    @test A*B == [100 100 100; 100 100 100]
+end
+let
+    srand(123)
+    A = rand(1:20, 5, 5) .- 10
+    B = rand(1:20, 5, 5) .- 10
+
+    @test At_mul_B(A, B) == A'*B
+    @test A_mul_Bt(A, B) == A*B'
+
+    # Preallocated
+    C = Array(Int, size(A, 1), size(B, 2))
+    @test A_mul_B!(C, A, B) == A*B
+    @test At_mul_B!(C, A, B) == A'*B
+    @test A_mul_Bt!(C, A, B) == A*B'
+    @test At_mul_Bt!(C, A, B) == A'*B'
+    v = [1,2,3]
+    C = Array(Int, 3, 3)
+    @test A_mul_Bt!(C, v, v) == v*v'
+    vf = float64(v)
+    C = Array(Float64, 3, 3)
+    @test A_mul_Bt!(C, v, v) == v*v'
+end
 
 # matrix algebra with subarrays of floats (stride != 1)
-A = reshape(float64(1:20),5,4)
-Aref = A[1:2:end,1:2:end]
-Asub = sub(A, 1:2:5, 1:2:4)
-b = [1.2,-2.5]
-@test (Aref*b) == (Asub*b)
-@test At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
-@test A_mul_Bt(Asub, Asub) == A_mul_Bt(Aref, Aref)
-Ai = A .+ im
-Aref = Ai[1:2:end,1:2:end]
-Asub = sub(Ai, 1:2:5, 1:2:4)
-@test Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
-@test A_mul_Bc(Asub, Asub) == A_mul_Bc(Aref, Aref)
+let
+    A = reshape(float64(1:20),5,4)
+    Aref = A[1:2:end,1:2:end]
+    Asub = sub(A, 1:2:5, 1:2:4)
+    b = [1.2,-2.5]
+    @test (Aref*b) == (Asub*b)
+    @test At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
+    @test A_mul_Bt(Asub, Asub) == A_mul_Bt(Aref, Aref)
+    Ai = A .+ im
+    Aref = Ai[1:2:end,1:2:end]
+    Asub = sub(Ai, 1:2:5, 1:2:4)
+    @test Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
+    @test A_mul_Bc(Asub, Asub) == A_mul_Bc(Aref, Aref)
+end
 
 # syrk & herk
-A = reshape(1:1503, 501, 3).-750.0
-res = float64([135228751 9979252 -115270247; 9979252 10481254 10983256; -115270247 10983256 137236759])
-@test At_mul_B(A, A) == res
-@test A_mul_Bt(A',A') == res
-cutoff = 501
-A = reshape(1:6*cutoff,2*cutoff,3).-(6*cutoff)/2
-Asub = sub(A, 1:2:2*cutoff, 1:3)
-Aref = A[1:2:2*cutoff, 1:3]
-@test At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
-Ai = A .- im
-Asub = sub(Ai, 1:2:2*cutoff, 1:3)
-Aref = Ai[1:2:2*cutoff, 1:3]
-@test Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
+let A = reshape(1:1503, 501, 3).-750.0,
+    res = float64([135228751 9979252 -115270247; 9979252 10481254 10983256; -115270247 10983256 137236759])
+
+    @test At_mul_B(A, A) == res
+    @test A_mul_Bt(A',A') == res
+    cutoff = 501
+    A = reshape(1:6*cutoff,2*cutoff,3).-(6*cutoff)/2
+    Asub = sub(A, 1:2:2*cutoff, 1:3)
+    Aref = A[1:2:2*cutoff, 1:3]
+    @test At_mul_B(Asub, Asub) == At_mul_B(Aref, Aref)
+    Ai = A .- im
+    Asub = sub(Ai, 1:2:2*cutoff, 1:3)
+    Aref = Ai[1:2:2*cutoff, 1:3]
+    @test Ac_mul_B(Asub, Asub) == Ac_mul_B(Aref, Aref)
+end
 
 # Matrix exponential
-for elty in (Float32, Float64, Complex64, Complex128)
-        A1  = convert(Matrix{elty}, [4 2 0; 1 4 1; 1 1 4])
-        eA1 = convert(Matrix{elty}, [147.866622446369 127.781085523181  127.781085523182;
-        183.765138646367 183.765138646366  163.679601723179;
-        71.797032399996  91.8825693231832 111.968106246371]')
-        @test_approx_eq expm(A1) eA1
+let
+    for elty in (Float32, Float64, Complex64, Complex128)
+            A1  = convert(Matrix{elty}, [4 2 0; 1 4 1; 1 1 4])
+            eA1 = convert(Matrix{elty}, [147.866622446369 127.781085523181  127.781085523182;
+            183.765138646367 183.765138646366  163.679601723179;
+            71.797032399996  91.8825693231832 111.968106246371]')
+            @test_approx_eq expm(A1) eA1
 
-        A2  = convert(Matrix{elty},
-            [29.87942128909879    0.7815750847907159 -2.289519314033932;
-            0.7815750847907159 25.72656945571064    8.680737820540137;
-            -2.289519314033932   8.680737820540137  34.39400925519054])
-        eA2 = convert(Matrix{elty},
-            [  5496313853692458.0 -18231880972009236.0 -30475770808580460.0;
-             -18231880972009252.0  60605228702221920.0 101291842930249760.0;
-             -30475770808580480.0 101291842930249728.0 169294411240851968.0])
-        @test_approx_eq expm(A2) eA2
+            A2  = convert(Matrix{elty},
+                [29.87942128909879    0.7815750847907159 -2.289519314033932;
+                0.7815750847907159 25.72656945571064    8.680737820540137;
+                -2.289519314033932   8.680737820540137  34.39400925519054])
+            eA2 = convert(Matrix{elty},
+                [  5496313853692458.0 -18231880972009236.0 -30475770808580460.0;
+                 -18231880972009252.0  60605228702221920.0 101291842930249760.0;
+                 -30475770808580480.0 101291842930249728.0 169294411240851968.0])
+            @test_approx_eq expm(A2) eA2
 
-        A3  = convert(Matrix{elty}, [-131 19 18;-390 56 54;-387 57 52])
-        eA3 = convert(Matrix{elty}, [-1.50964415879218 -5.6325707998812  -4.934938326092;
-        0.367879439109187 1.47151775849686  1.10363831732856;
-        0.135335281175235 0.406005843524598 0.541341126763207]')
-        @test_approx_eq expm(A3) eA3
+            A3  = convert(Matrix{elty}, [-131 19 18;-390 56 54;-387 57 52])
+            eA3 = convert(Matrix{elty}, [-1.50964415879218 -5.6325707998812  -4.934938326092;
+            0.367879439109187 1.47151775849686  1.10363831732856;
+            0.135335281175235 0.406005843524598 0.541341126763207]')
+            @test_approx_eq expm(A3) eA3
 
-        # issue 5116
-        A4  = [0 10 0 0; -1 0 0 0; 0 0 0 0; -2 0 0 0]
-        eA4 = [-0.999786072879326  -0.065407069689389   0.0   0.0
-                0.006540706968939  -0.999786072879326   0.0   0.0
-                0.0                 0.0                 1.0   0.0
-                0.013081413937878  -3.999572145758650   0.0   1.0]
-        @test_approx_eq expm(A4) eA4
+            # issue 5116
+            A4  = [0 10 0 0; -1 0 0 0; 0 0 0 0; -2 0 0 0]
+            eA4 = [-0.999786072879326  -0.065407069689389   0.0   0.0
+                    0.006540706968939  -0.999786072879326   0.0   0.0
+                    0.0                 0.0                 1.0   0.0
+                    0.013081413937878  -3.999572145758650   0.0   1.0]
+            @test_approx_eq expm(A4) eA4
 
-        # issue 5116
-        A5  = [ 0. 0. 0. 0. ; 0. 0. -im 0.; 0. im 0. 0.; 0. 0. 0. 0.]
-        eA5 = [ 1.0+0.0im   0.0+0.0im                 0.0+0.0im                0.0+0.0im
-                0.0+0.0im   1.543080634815244+0.0im   0.0-1.175201193643801im  0.0+0.0im
-                0.0+0.0im   0.0+1.175201193643801im   1.543080634815243+0.0im  0.0+0.0im
-                0.0+0.0im   0.0+0.0im                 0.0+0.0im                1.0+0.0im]
-        @test_approx_eq expm(A5) eA5
+            # issue 5116
+            A5  = [ 0. 0. 0. 0. ; 0. 0. -im 0.; 0. im 0. 0.; 0. 0. 0. 0.]
+            eA5 = [ 1.0+0.0im   0.0+0.0im                 0.0+0.0im                0.0+0.0im
+                    0.0+0.0im   1.543080634815244+0.0im   0.0-1.175201193643801im  0.0+0.0im
+                    0.0+0.0im   0.0+1.175201193643801im   1.543080634815243+0.0im  0.0+0.0im
+                    0.0+0.0im   0.0+0.0im                 0.0+0.0im                1.0+0.0im]
+            @test_approx_eq expm(A5) eA5
 
-        # Hessenberg
-        @test_approx_eq hessfact(A1)[:H] convert(Matrix{elty},
-                        [4.000000000000000  -1.414213562373094  -1.414213562373095
-                        -1.414213562373095   4.999999999999996  -0.000000000000000
-                                         0  -0.000000000000002   3.000000000000000])
+            # Hessenberg
+            @test_approx_eq hessfact(A1)[:H] convert(Matrix{elty},
+                            [4.000000000000000  -1.414213562373094  -1.414213562373095
+                            -1.414213562373095   4.999999999999996  -0.000000000000000
+                                             0  -0.000000000000002   3.000000000000000])
+    end
 end
 
 # Hermitian matrix exponential
-A1 = randn(4,4) + im*randn(4,4)
-A2 = A1 + A1'
-@test_approx_eq expm(A2) expm(Hermitian(A2))
+let
+    srand(123)
+    A1 = randn(4,4) + im*randn(4,4)
+    A2 = A1 + A1'
+
+    @test_approx_eq expm(A2) expm(Hermitian(A2))
+end
 
 # matmul for types w/o sizeof (issue #1282)
-A = Array(Complex{Int},10,10)
-A[:] = complex(1,1)
-A2 = A^2
-@test A2[1,1] == 20im
+let A = Array(Complex{Int},10,10)
+
+    A[:] = complex(1,1)
+    A2 = A^2
+    @test A2[1,1] == 20im
+end
 
 # test sparse matrix norms
-Ac = sprandn(10,10,.1) + im* sprandn(10,10,.1)
-Ar = sprandn(10,10,.1)
-Ai = int(ceil(Ar*100))
-@test_approx_eq norm(Ac,1)     norm(full(Ac),1)
-@test_approx_eq norm(Ac,Inf)   norm(full(Ac),Inf)
-@test_approx_eq vecnorm(Ac)    vecnorm(full(Ac))
-@test_approx_eq norm(Ar,1)     norm(full(Ar),1)
-@test_approx_eq norm(Ar,Inf)   norm(full(Ar),Inf)
-@test_approx_eq vecnorm(Ar)    vecnorm(full(Ar))
-@test_approx_eq norm(Ai,1)     norm(full(Ai),1)
-@test_approx_eq norm(Ai,Inf)   norm(full(Ai),Inf)
-@test_approx_eq vecnorm(Ai)    vecnorm(full(Ai))
+let
+    srand(123)
+    Ac = sprandn(10,10,.1) + im* sprandn(10,10,.1)
+    Ar = sprandn(10,10,.1)
+    Ai = int(ceil(Ar*100))
+
+    @test_approx_eq norm(Ac,1)     norm(full(Ac),1)
+    @test_approx_eq norm(Ac,Inf)   norm(full(Ac),Inf)
+    @test_approx_eq vecnorm(Ac)    vecnorm(full(Ac))
+    @test_approx_eq norm(Ar,1)     norm(full(Ar),1)
+    @test_approx_eq norm(Ar,Inf)   norm(full(Ar),Inf)
+    @test_approx_eq vecnorm(Ar)    vecnorm(full(Ar))
+    @test_approx_eq norm(Ai,1)     norm(full(Ai),1)
+    @test_approx_eq norm(Ai,Inf)   norm(full(Ai),Inf)
+    @test_approx_eq vecnorm(Ai)    vecnorm(full(Ai))
+end
 
 # 2-argument version of scale
-a = reshape([1.:6], (2,3))
-@test scale(a, 5.) == a*5
-@test scale(5., a) == a*5
-@test scale(a, [1.; 2.; 3.]) == a.*[1 2 3]
-@test scale([1.; 2.], a) == a.*[1; 2]
-@test scale(a, [1; 2; 3]) == a.*[1 2 3]
-@test scale([1; 2], a) == a.*[1; 2]
-@test_throws DimensionMismatch scale(a, ones(2))
-@test_throws DimensionMismatch scale(ones(3), a)
+let a = reshape([1.:6], (2,3))
+
+    @test scale(a, 5.) == a*5
+    @test scale(5., a) == a*5
+    @test scale(a, [1.; 2.; 3.]) == a.*[1 2 3]
+    @test scale([1.; 2.], a) == a.*[1; 2]
+    @test scale(a, [1; 2; 3]) == a.*[1 2 3]
+    @test scale([1; 2], a) == a.*[1; 2]
+    @test_throws DimensionMismatch scale(a, ones(2))
+    @test_throws DimensionMismatch scale(ones(3), a)
+end
 
 # 2-argument version of scale!
-@test scale!(copy(a), 5.) == a*5
-@test scale!(5., copy(a)) == a*5
-b = randn(Base.LinAlg.SCAL_CUTOFF) # make sure we try BLAS path
-@test scale!(copy(b), 5.) == b*5
-@test scale!(copy(a), [1.; 2.; 3.]) == a.*[1 2 3]
-@test scale!([1.; 2.], copy(a)) == a.*[1; 2]
-@test scale!(copy(a), [1; 2; 3]) == a.*[1 2 3]
-@test scale!([1; 2], copy(a)) == a.*[1; 2]
-@test_throws DimensionMismatch scale!(a, ones(2))
-@test_throws DimensionMismatch scale!(ones(3), a)
+let a = reshape([1.:6], (2,3))
+
+    srand(123)
+    @test scale!(copy(a), 5.) == a*5
+    @test scale!(5., copy(a)) == a*5
+    b = randn(Base.LinAlg.SCAL_CUTOFF) # make sure we try BLAS path
+    @test scale!(copy(b), 5.) == b*5
+    @test scale!(copy(a), [1.; 2.; 3.]) == a.*[1 2 3]
+    @test scale!([1.; 2.], copy(a)) == a.*[1; 2]
+    @test scale!(copy(a), [1; 2; 3]) == a.*[1 2 3]
+    @test scale!([1; 2], copy(a)) == a.*[1; 2]
+    @test_throws DimensionMismatch scale!(a, ones(2))
+    @test_throws DimensionMismatch scale!(ones(3), a)
+end
 
 # 3-argument version of scale!
-@test scale!(similar(a), 5., a) == a*5
-@test scale!(similar(a), a, 5.) == a*5
-@test scale!(similar(a), a, [1.; 2.; 3.]) == a.*[1 2 3]
-@test scale!(similar(a), [1.; 2.], a) == a.*[1; 2]
-@test scale!(similar(a), a, [1; 2; 3]) == a.*[1 2 3]
-@test scale!(similar(a), [1; 2], a) == a.*[1; 2]
-@test_throws DimensionMismatch scale!(similar(a), a, ones(2))
-@test_throws DimensionMismatch scale!(similar(a), ones(3), a)
-@test_throws DimensionMismatch scale!(Array(Float64, 3, 2), a, ones(3))
+let a = reshape([1.:6], (2,3))
+
+    @test scale!(similar(a), 5., a) == a*5
+    @test scale!(similar(a), a, 5.) == a*5
+    @test scale!(similar(a), a, [1.; 2.; 3.]) == a.*[1 2 3]
+    @test scale!(similar(a), [1.; 2.], a) == a.*[1; 2]
+    @test scale!(similar(a), a, [1; 2; 3]) == a.*[1 2 3]
+    @test scale!(similar(a), [1; 2], a) == a.*[1; 2]
+    @test_throws DimensionMismatch scale!(similar(a), a, ones(2))
+    @test_throws DimensionMismatch scale!(similar(a), ones(3), a)
+    @test_throws DimensionMismatch scale!(Array(Float64, 3, 2), a, ones(3))
+end
 
 # scale real matrix by complex type
 @test_throws ErrorException scale!([1.0], 2.0im)
@@ -250,31 +291,33 @@ b = randn(Base.LinAlg.SCAL_CUTOFF) # make sure we try BLAS path
 @test dot(Any[1.0,2.0], Any[3.5,4.5]) === 12.5
 
 # issue #7181
-A = [ 1  5  9
-      2  6 10
-      3  7 11
-      4  8 12 ]
-@test_throws BoundsError diag(A, -5)
-@test diag(A,-4) == []
-@test diag(A,-3) == [4]
-@test diag(A,-2) == [3,8]
-@test diag(A,-1) == [2,7,12]
-@test diag(A, 0) == [1,6,11]
-@test diag(A, 1) == [5,10]
-@test diag(A, 2) == [9]
-@test diag(A, 3) == []
-@test_throws BoundsError diag(A, 4)
+let A = [ 1  5  9
+          2  6 10
+          3  7 11
+          4  8 12 ]
 
-@test diag(zeros(0,0)) == []
-@test_throws BoundsError diag(zeros(0,0),1)
-@test_throws BoundsError diag(zeros(0,0),-1)
+    @test_throws BoundsError diag(A, -5)
+    @test diag(A,-4) == []
+    @test diag(A,-3) == [4]
+    @test diag(A,-2) == [3,8]
+    @test diag(A,-1) == [2,7,12]
+    @test diag(A, 0) == [1,6,11]
+    @test diag(A, 1) == [5,10]
+    @test diag(A, 2) == [9]
+    @test diag(A, 3) == []
+    @test_throws BoundsError diag(A, 4)
 
-@test diag(zeros(1,0)) == []
-@test diag(zeros(1,0),-1) == []
-@test_throws BoundsError diag(zeros(1,0),1)
-@test_throws BoundsError diag(zeros(1,0),-2)
+    @test diag(zeros(0,0)) == []
+    @test_throws BoundsError diag(zeros(0,0),1)
+    @test_throws BoundsError diag(zeros(0,0),-1)
 
-@test diag(zeros(0,1)) == []
-@test diag(zeros(0,1),1) == []
-@test_throws BoundsError diag(zeros(0,1),-1)
-@test_throws BoundsError diag(zeros(0,1),2)
+    @test diag(zeros(1,0)) == []
+    @test diag(zeros(1,0),-1) == []
+    @test_throws BoundsError diag(zeros(1,0),1)
+    @test_throws BoundsError diag(zeros(1,0),-2)
+
+    @test diag(zeros(0,1)) == []
+    @test diag(zeros(0,1),1) == []
+    @test_throws BoundsError diag(zeros(0,1),-1)
+    @test_throws BoundsError diag(zeros(0,1),2)
+end

--- a/test/linalg4.jl
+++ b/test/linalg4.jl
@@ -3,7 +3,6 @@ debug = false
 import Base.LinAlg
 import Base.LinAlg: BlasComplex, BlasFloat, BlasReal
 
-srand(1)
 
 #Test equivalence of eigenvectors/singular vectors taking into account possible phase (sign) differences
 function test_approx_eq_vecs{S<:Real,T<:Real}(a::StridedVecOrMat{S}, b::StridedVecOrMat{T}, error=nothing)
@@ -23,221 +22,240 @@ end
 # Tests for special matrices #
 ##############################
 
-n=12 #Size of matrix problem to test
+let n=12 #Size of matrix problem to test
 
-#Issue #7647: test xsyevr, xheevr, xstevr drivers
-for Mi7647 in (Symmetric(diagm([1.0:3.0])),
-               Hermitian(diagm([1.0:3.0])),
-               Hermitian(diagm(complex([1.0:3.0]))),
-               SymTridiagonal([1.0:3.0], zeros(2)))
-    debug && println("Eigenvalues in interval for $(typeof(Mi7647))")
-    @test eigmin(Mi7647)  == eigvals(Mi7647, 0.5, 1.5)[1] == 1.0
-    @test eigmax(Mi7647)  == eigvals(Mi7647, 2.5, 3.5)[1] == 3.0
-    @test eigvals(Mi7647) == eigvals(Mi7647, 0.5, 3.5) == [1.0:3.0]
-end
-
-debug && println("Bidiagonal matrices")
-for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
-    debug && println("elty is $(elty), relty is $(relty)")
-    dv = convert(Vector{elty}, randn(n))
-    ev = convert(Vector{elty}, randn(n-1))
-    b = convert(Matrix{elty}, randn(n, 2))
-    if (elty <: Complex)
-        dv += im*convert(Vector{elty}, randn(n))
-        ev += im*convert(Vector{elty}, randn(n-1))
-        b += im*convert(Matrix{elty}, randn(n, 2))
+    srand(1)
+    #Issue #7647: test xsyevr, xheevr, xstevr drivers
+    for Mi7647 in (Symmetric(diagm([1.0:3.0])),
+                   Hermitian(diagm([1.0:3.0])),
+                   Hermitian(diagm(complex([1.0:3.0]))),
+                   SymTridiagonal([1.0:3.0], zeros(2)))
+        debug && println("Eigenvalues in interval for $(typeof(Mi7647))")
+        @test eigmin(Mi7647)  == eigvals(Mi7647, 0.5, 1.5)[1] == 1.0
+        @test eigmax(Mi7647)  == eigvals(Mi7647, 2.5, 3.5)[1] == 3.0
+        @test eigvals(Mi7647) == eigvals(Mi7647, 0.5, 3.5) == [1.0:3.0]
     end
 
-    debug && println("Test upper and lower bidiagonal matrices")
-    for isupper in (true, false)
-        debug && println("isupper is: $(isupper)")
-        T = Bidiagonal(dv, ev, isupper)
-
-        @test size(T, 1) == size(T, 2) == n
-        @test size(T) == (n, n)
-        @test full(T) == diagm(dv) + diagm(ev, isupper?1:-1)
-        @test Bidiagonal(full(T), isupper) == T
-        z = zeros(elty, n)
-
-        debug && println("Idempotent tests")
-        for func in (conj, transpose, ctranspose)
-            @test func(func(T)) == T
+    debug && println("Bidiagonal matrices")
+    for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
+        debug && println("elty is $(elty), relty is $(relty)")
+        dv = convert(Vector{elty}, randn(n))
+        ev = convert(Vector{elty}, randn(n-1))
+        b = convert(Matrix{elty}, randn(n, 2))
+        if (elty <: Complex)
+            dv += im*convert(Vector{elty}, randn(n))
+            ev += im*convert(Vector{elty}, randn(n-1))
+            b += im*convert(Matrix{elty}, randn(n, 2))
         end
 
-        debug && println("Linear solver")
-        Tfull = full(T)
-        condT = cond(complex128(Tfull))
-        x = T \ b
-        tx = Tfull \ b
-        @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(relty)*norm(x,Inf))
+        debug && println("Test upper and lower bidiagonal matrices")
+        for isupper in (true, false)
+            debug && println("isupper is: $(isupper)")
+            T = Bidiagonal(dv, ev, isupper)
 
-        debug && println("Eigensystems")
-        d1, v1 = eig(T)
-        d2, v2 = eig((elty<:Complex?complex128:float64)(Tfull))
-        @test_approx_eq isupper?d1:reverse(d1) d2
-        if elty <: Real
-            test_approx_eq_vecs(v1, isupper?v2:v2[:,n:-1:1])
-        end
+            @test size(T, 1) == size(T, 2) == n
+            @test size(T) == (n, n)
+            @test full(T) == diagm(dv) + diagm(ev, isupper?1:-1)
+            @test Bidiagonal(full(T), isupper) == T
+            z = zeros(elty, n)
 
-        debug && println("Singular systems")
-        if (elty <: BlasReal)
-            @test_approx_eq svdvals(Tfull) svdvals(T)
-            u1, d1, v1 = svd(Tfull)
-            u2, d2, v2 = svd(T)
-            @test_approx_eq d1 d2
+            debug && println("Idempotent tests")
+            for func in (conj, transpose, ctranspose)
+                @test func(func(T)) == T
+            end
+
+            debug && println("Linear solver")
+            Tfull = full(T)
+            condT = cond(complex128(Tfull))
+            x = T \ b
+            tx = Tfull \ b
+            @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(relty)*norm(x,Inf))
+
+            debug && println("Eigensystems")
+            d1, v1 = eig(T)
+            d2, v2 = eig((elty<:Complex?complex128:float64)(Tfull))
+            @test_approx_eq isupper?d1:reverse(d1) d2
             if elty <: Real
-                test_approx_eq_vecs(u1, u2)
-                test_approx_eq_vecs(v1, v2)
+                test_approx_eq_vecs(v1, isupper?v2:v2[:,n:-1:1])
             end
-            @test_approx_eq_eps 0 vecnorm(u2*diagm(d2)*v2'-Tfull) n*max(n^2*eps(relty), vecnorm(u1*diagm(d1)*v1'-Tfull))
+
+            debug && println("Singular systems")
+            if (elty <: BlasReal)
+                @test_approx_eq svdvals(Tfull) svdvals(T)
+                u1, d1, v1 = svd(Tfull)
+                u2, d2, v2 = svd(T)
+                @test_approx_eq d1 d2
+                if elty <: Real
+                    test_approx_eq_vecs(u1, u2)
+                    test_approx_eq_vecs(v1, v2)
+                end
+                @test_approx_eq_eps 0 vecnorm(u2*diagm(d2)*v2'-Tfull) n*max(n^2*eps(relty), vecnorm(u1*diagm(d1)*v1'-Tfull))
+            end
+
+            debug && println("Binary operations")
+            for isupper2 in (true, false)
+                dv = convert(Vector{elty}, randn(n))
+                ev = convert(Vector{elty}, randn(n-1))
+                T2 = Bidiagonal(dv, ev, isupper2)
+                Tfull2 = full(T2)
+                for op in (+, -, *)
+                    @test_approx_eq full(op(T, T2)) op(Tfull, Tfull2)
+                end
+            end
+        end
+    end
+end
+
+let n=12 #Size of matrix problem to test
+    srand(1)
+
+    debug && println("Diagonal matrices")
+    for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
+        debug && println("elty is $(elty), relty is $(relty)")
+        d=convert(Vector{elty}, randn(n))
+        v=convert(Vector{elty}, randn(n))
+        U=convert(Matrix{elty}, randn(n,n))
+        if elty <: Complex
+            d+=im*convert(Vector{elty}, randn(n))
+            v+=im*convert(Vector{elty}, randn(n))
+            U+=im*convert(Matrix{elty}, randn(n,n))
+        end
+        D = Diagonal(d)
+        DM = diagm(d)
+
+        debug && println("Linear solve")
+        @test_approx_eq_eps D*v DM*v n*eps(relty)*(elty<:Complex ? 2:1)
+        @test_approx_eq_eps D*U DM*U n^2*eps(relty)*(elty<:Complex ? 2:1)
+        if relty != BigFloat
+            @test_approx_eq_eps D\v DM\v 2n^2*eps(relty)*(elty<:Complex ? 2:1)
+            @test_approx_eq_eps D\U DM\U 2n^3*eps(relty)*(elty<:Complex ? 2:1)
         end
 
+        debug && println("Simple unary functions")
+        for func in (det, trace)
+            @test_approx_eq_eps func(D) func(DM) n^2*eps(relty)*(elty<:Complex ? 2:1)
+        end
+        if relty <: BlasFloat
+            for func in (expm,)
+                @test_approx_eq_eps func(D) func(DM) n^3*eps(relty)
+            end
+        end
+        if elty <: BlasComplex
+            for func in (logdet, sqrtm)
+                @test_approx_eq_eps func(D) func(DM) n^2*eps(relty)*2
+            end
+        end
         debug && println("Binary operations")
-        for isupper2 in (true, false)
-            dv = convert(Vector{elty}, randn(n))
-            ev = convert(Vector{elty}, randn(n-1))
-            T2 = Bidiagonal(dv, ev, isupper2)
-            Tfull2 = full(T2)
-            for op in (+, -, *)
-                @test_approx_eq full(op(T, T2)) op(Tfull, Tfull2)
-            end
+        d = convert(Vector{elty}, randn(n))
+        D2 = Diagonal(d)
+        DM2= diagm(d)
+        for op in (+, -, *)
+            @test_approx_eq full(op(D, D2)) op(DM, DM2)
+        end
+
+        #10036
+        @test issym(D2)
+        @test ishermitian(D2)
+        if elty <: Complex
+            dc = d + im*convert(Vector{elty}, ones(n))
+            D3 = Diagonal(dc)
+            @test issym(D3)
+            @test !ishermitian(D3)
         end
     end
 end
-
-debug && println("Diagonal matrices")
-for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
-    debug && println("elty is $(elty), relty is $(relty)")
-    d=convert(Vector{elty}, randn(n))
-    v=convert(Vector{elty}, randn(n))
-    U=convert(Matrix{elty}, randn(n,n))
-    if elty <: Complex
-        d+=im*convert(Vector{elty}, randn(n))
-        v+=im*convert(Vector{elty}, randn(n))
-        U+=im*convert(Matrix{elty}, randn(n,n))
-    end
-    D = Diagonal(d)
-    DM = diagm(d)
-
-    debug && println("Linear solve")
-    @test_approx_eq_eps D*v DM*v n*eps(relty)*(elty<:Complex ? 2:1)
-    @test_approx_eq_eps D*U DM*U n^2*eps(relty)*(elty<:Complex ? 2:1)
-    if relty != BigFloat
-        @test_approx_eq_eps D\v DM\v 2n^2*eps(relty)*(elty<:Complex ? 2:1)
-        @test_approx_eq_eps D\U DM\U 2n^3*eps(relty)*(elty<:Complex ? 2:1)
-    end
-
-    debug && println("Simple unary functions")
-    for func in (det, trace)
-        @test_approx_eq_eps func(D) func(DM) n^2*eps(relty)*(elty<:Complex ? 2:1)
-    end
-    if relty <: BlasFloat
-        for func in (expm,)
-            @test_approx_eq_eps func(D) func(DM) n^3*eps(relty)
-        end
-    end
-    if elty <: BlasComplex
-        for func in (logdet, sqrtm)
-            @test_approx_eq_eps func(D) func(DM) n^2*eps(relty)*2
-        end
-    end
-    debug && println("Binary operations")
-    d = convert(Vector{elty}, randn(n))
-    D2 = Diagonal(d)
-    DM2= diagm(d)
-    for op in (+, -, *)
-        @test_approx_eq full(op(D, D2)) op(DM, DM2)
-    end
-
-    #10036
-    @test issym(D2)
-    @test ishermitian(D2)
-    if elty <: Complex
-        dc = d + im*convert(Vector{elty}, ones(n))
-        D3 = Diagonal(dc)
-        @test issym(D3)
-        @test !ishermitian(D3)
-    end
-end
-
 
 debug && println("Test interconversion between special matrix types")
-a=[1.0:n]
-A=Diagonal(a)
-for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, LowerTriangular, UpperTriangular, Matrix]
-    debug && println("newtype is $(newtype)")
-    @test full(convert(newtype, A)) == full(A)
-end
+let n =12, a = [1.0:n]
 
-for isupper in (true, false)
-    debug && println("isupper is $(isupper)")
-    A=Bidiagonal(a, [1.0:n-1], isupper)
-    for newtype in [Bidiagonal, Tridiagonal, isupper ? UpperTriangular : LowerTriangular, Matrix]
+    A = Diagonal(a)
+    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, LowerTriangular, UpperTriangular, Matrix]
         debug && println("newtype is $(newtype)")
         @test full(convert(newtype, A)) == full(A)
-        @test full(newtype(A)) == full(A)
     end
-    A=Bidiagonal(a, zeros(n-1), isupper) #morally Diagonal
-    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, isupper ? UpperTriangular : LowerTriangular, Matrix]
-        debug && println("newtype is $(newtype)")
+
+    for isupper in (true, false)
+        debug && println("isupper is $(isupper)")
+        A = Bidiagonal(a, [1.0:n-1], isupper)
+        for newtype in [Bidiagonal, Tridiagonal, isupper ? UpperTriangular : LowerTriangular, Matrix]
+            debug && println("newtype is $(newtype)")
+            @test full(convert(newtype, A)) == full(A)
+            @test full(newtype(A)) == full(A)
+        end
+        A = Bidiagonal(a, zeros(n-1), isupper) #morally Diagonal
+        for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, isupper ? UpperTriangular : LowerTriangular, Matrix]
+            debug && println("newtype is $(newtype)")
+            @test full(convert(newtype, A)) == full(A)
+            @test full(newtype(A)) == full(A)
+        end
+    end
+
+    A = SymTridiagonal(a, [1.0:n-1])
+    for newtype in [Tridiagonal, Matrix]
         @test full(convert(newtype, A)) == full(A)
-        @test full(newtype(A)) == full(A)
     end
-end
 
-A = SymTridiagonal(a, [1.0:n-1])
-for newtype in [Tridiagonal, Matrix]
-    @test full(convert(newtype, A)) == full(A)
-end
+    A = Tridiagonal(zeros(n-1), [1.0:n], zeros(n-1)) #morally Diagonal
+    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Matrix]
+        @test full(convert(newtype, A)) == full(A)
+    end
 
-A = Tridiagonal(zeros(n-1), [1.0:n], zeros(n-1)) #morally Diagonal
-for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Matrix]
-    @test full(convert(newtype, A)) == full(A)
-end
-
-A = LowerTriangular(full(Diagonal(a))) #morally Diagonal
-for newtype in [Diagonal, Bidiagonal, SymTridiagonal, LowerTriangular, Matrix]
-    @test full(convert(newtype, A)) == full(A)
+    A = LowerTriangular(full(Diagonal(a))) #morally Diagonal
+    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, LowerTriangular, Matrix]
+        @test full(convert(newtype, A)) == full(A)
+    end
 end
 
 # Test generic cholfact!
-for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
-    if elty <: Complex
-        A = complex(randn(5,5), randn(5,5))
-    else
-        A = randn(5,5)
-    end
-    A = convert(Matrix{elty}, A'A)
-    for ul in (:U, :L)
-        @test_approx_eq full(cholfact(A, ul)[ul]) full(invoke(Base.LinAlg.chol!, (AbstractMatrix,Symbol),copy(A), ul))
+let
+    srand(1)
+    for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
+        if elty <: Complex
+            A = complex(randn(5,5), randn(5,5))
+        else
+            A = randn(5,5)
+        end
+        A = convert(Matrix{elty}, A'A)
+        for ul in (:U, :L)
+            @test_approx_eq full(cholfact(A, ul)[ul]) full(invoke(Base.LinAlg.chol!, (AbstractMatrix,Symbol),copy(A), ul))
+        end
     end
 end
 
 # Because transpose(x) == x
-@test_throws ErrorException transpose(qrfact(randn(3,3)))
-@test_throws ErrorException ctranspose(qrfact(randn(3,3)))
-@test_throws ErrorException transpose(qrfact(randn(3,3), Val{false}))
-@test_throws ErrorException ctranspose(qrfact(randn(3,3), Val{false}))
-@test_throws ErrorException transpose(qrfact(big(randn(3,3))))
-@test_throws ErrorException ctranspose(qrfact(big(randn(3,3))))
-@test_throws ErrorException transpose(sub(sprandn(10, 10, 0.3), 1:4, 1:4))
-@test_throws ErrorException ctranspose(sub(sprandn(10, 10, 0.3), 1:4, 1:4))
+let
+    srand(1)
+    @test_throws ErrorException transpose(qrfact(randn(3,3)))
+    @test_throws ErrorException ctranspose(qrfact(randn(3,3)))
+    @test_throws ErrorException transpose(qrfact(randn(3,3), Val{false}))
+    @test_throws ErrorException ctranspose(qrfact(randn(3,3), Val{false}))
+    @test_throws ErrorException transpose(qrfact(big(randn(3,3))))
+    @test_throws ErrorException ctranspose(qrfact(big(randn(3,3))))
+    @test_throws ErrorException transpose(sub(sprandn(10, 10, 0.3), 1:4, 1:4))
+    @test_throws ErrorException ctranspose(sub(sprandn(10, 10, 0.3), 1:4, 1:4))
+end
 
 # Issue #7933
-A7933 = [1 2; 3 4]
-B7933 = copy(A7933)
-C7933 = full(Symmetric(A7933))
-@test A7933 == B7933
+let A7933 = [1 2; 3 4],
+    B7933 = copy(A7933),
+    C7933 = full(Symmetric(A7933))
+
+    @test A7933 == B7933
+end
 
 # Issues #8057 and #8058
-for f in (eigfact, eigvals, eig)
-    for A in (Symmetric(randn(2,2)), Hermitian(complex(randn(2,2), randn(2,2))))
-        @test_throws ArgumentError f(A, 3, 2)
-        @test_throws ArgumentError f(A, 1:4)
+let
+    srand(1)
+    for f in (eigfact, eigvals, eig)
+        for A in (Symmetric(randn(2,2)), Hermitian(complex(randn(2,2), randn(2,2))))
+            @test_throws ArgumentError f(A, 3, 2)
+            @test_throws ArgumentError f(A, 1:4)
+        end
     end
 end
 
 # test diag
-A = eye(4)
-@test diag(A) == ones(4)
-@test diag(sub(A, 1:3, 1:3)) == ones(3)
+let A = eye(4)
+    @test diag(A) == ones(4)
+    @test diag(sub(A, 1:3, 1:3)) == ones(3)
+end


### PR DESCRIPTION
There was some weird interdependencies in the tests due to use of global test variables.
