### PR TITLE
htmlescape markdown

### DIFF
--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -40,8 +40,6 @@ function plain(io::IO, md::HorizontalRule)
     println(io, "–" ^ 3)
 end
 
-plain(io::IO, x) = tohtml(io, x)
-
 # Inline elements
 
 plaininline(x) = sprint(plaininline, x)

--- a/base/markdown/render/rich.jl
+++ b/base/markdown/render/rich.jl
@@ -3,7 +3,7 @@ function tohtml(io::IO, m::MIME"text/html", x)
 end
 
 function tohtml(io::IO, m::MIME"text/plain", x)
-    writemime(io, m, x)
+    htmlesc(io, sprint(writemime, m, x))
 end
 
 function tohtml(io::IO, m::MIME"image/png", img)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -58,6 +58,7 @@ World""" |> plain == "Hello\n\n–––\n\nWorld\n"
 
 ---
 World""" |> html == "<p>Hello</p>\n<hr />\n<p>World</p>\n"
+@test md"`escape</code>`" |> html == "<p><code>escape&lt;/code&gt;</code></p>\n"
 
 # Latex output
 book = md"""
@@ -89,7 +90,20 @@ ref(fft)
 writemime(io::IO, m::MIME"text/plain", r::Reference) =
     print(io, "$(r.ref) (see Julia docs)")
 
-@test md"Behaves like $(ref(fft))" == md"Behaves like fft (see Julia docs)"
+#writemime(io::IO, m::MIME"text/html", r::Reference) =
+#    Markdown.withtag(io, :a, :href=>"test") do
+#        Markdown.htmlesc(io, Markdown.plaininline(r))
+#    end
+
+fft_ref = md"Behaves like $(ref(fft))"
+@test plain(fft_ref) == "Behaves like fft (see Julia docs)\n"
+@test html(fft_ref) == "<p>Behaves like fft &#40;see Julia docs&#41;</p>\n"
+
+writemime(io::IO, m::MIME"text/html", r::Reference) =
+    Markdown.withtag(io, :a, :href=>"test") do
+        Markdown.htmlesc(io, Markdown.plaininline(r))
+    end
+@test html(fft_ref) == "<p>Behaves like <a href=\"test\">fft &#40;see Julia docs&#41;</a></p>\n"
 
 
 @test md"""


### PR DESCRIPTION
Throwing this out there, IMO html escaping is required for rendering markdown in html.

cc @one-more-minute @MichaelHatherly

~~Note: This breaks the Ref test, so I'm not sure what I should do to fix it?~~

I need to read the Markdown spec a little more carefully, I'm not sure what the precise rules for escaping are. http://spec.commonmark.org/ I think I'm doing a little too much here (e.g. I wonder if links need different behaviour).

_This was mentioned in #5239 and #9933._
