### PR TITLE
Faster setindex! for RHSs with inefficient linear indexing

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -273,11 +273,11 @@ stagedfunction setindex!(A::Array, x, J::Union(Real,AbstractArray)...)
         else
             X = x
             @ncall $N setindex_shape_check X I
-            # TODO? A variant that can use cartesian indexing for RHS
-            k = 1
+            iter = eachindex(X)
+            Xs = start(iter)
             @nloops $N i d->(1:length(I_d)) d->(@inbounds offset_{d-1} = offset_d + (unsafe_getindex(I_d, i_d)-1)*stride_d) begin
-                @inbounds A[offset_0] = X[k]
-            k += 1
+                Xindex, Xs = next(iter, Xs)
+                @inbounds A[offset_0] = X[Xindex]
             end
         end
         A


### PR DESCRIPTION
This was a long-standing TODO item, for which we now have the needed infrastructure.

Provides a 7-8x speedup on the last line of this demo:

``` julia
function testset!(A, X, indexes, n)
    for i = 1:n
        setindex!(A, X, indexes...)
    end
    A
end

A = rand(1000,1001)
B = rand(800,400)
S = sub(B, 2:799, 2:399)

testset!(A, B, (101:900,101:500), 1)
testset!(A, S, (101:898,101:498), 1)

@time 1
@time testset!(A, B, (101:900,101:500), 100)
@time testset!(A, S, (101:898,101:498), 100)
```
