### PR TITLE
Add a julia-config script for configuration of externals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,6 +304,8 @@ endif
 	$(INSTALL_M) contrib/build_sysimg.jl $(DESTDIR)$(datarootdir)/julia/
 	# Copy in standalone executable build script
 	$(INSTALL_M) contrib/build_executable.jl $(DESTDIR)$(datarootdir)/julia/
+	# Copy in standalone julia-config script
+	$(INSTALL_M) contrib/julia-config.jl $(DESTDIR)$(datarootdir)/julia/
 	# Copy in all .jl sources as well
 	cp -R -L $(build_datarootdir)/julia $(DESTDIR)$(datarootdir)/
 	# Copy documentation

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -30,7 +30,7 @@ function ldflags()
 end
 
 function ldlibs()
-    @unix_only return replace("""-Wl,-rpath $(libDir()) -ljulia""","\\","\\\\");
+    @unix_only return replace("""-Wl,-rpath,$(libDir()) -ljulia""","\\","\\\\");
     @windows_only return replace("""-ljulia""","\\","\\\\");
 end
 

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -21,8 +21,8 @@ function includeDir()
 end
 
 function initDir()
-    @unix_only return match(r"(.*)(julia/sys.ji)",imagePath()).captures[1];
-    @windows_only return match(r"(.*)(julia\\sys.ji)",imagePath()).captures[1];
+    @unix_only return match(r"(.*)(/julia/sys.ji)",imagePath()).captures[1];
+    @windows_only return match(r"(.*)(\\julia\\sys.ji)",imagePath()).captures[1];
 end
 
 function ldflags()
@@ -35,7 +35,7 @@ function ldlibs()
 end
 
 function cflags()
-    arg1 = replace(initDir(),"\\","\\\\");
+    arg1 = replace(initDir(),"\\","\\\\\\\\");
     arg2 = replace(includeDir(),"\\","\\\\");
     return """-DJULIA_INIT_DIR=\\"$arg1\\" -I$arg2""";
 end

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -1,3 +1,5 @@
+#!/usr/bin/env julia
+
 const options =
 [
     "--cflags",

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -8,7 +8,7 @@ const options =
 ];
 
 function imagePath()
-    opts = Base.compileropts();
+    opts = Base.JLOptions();
     bytestring(opts.image_file);
 end
 

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -1,52 +1,54 @@
 const options =
 [
-   "--cflags",
-   "--ldflags"
+    "--cflags",
+    "--ldflags"
 ];
 
 function imagePath()
-   opts = Base.compileropts();
-   image_path = bytestring(opts.image_file);
+    opts = Base.compileropts();
+    bytestring(opts.image_file);
 end
 
 function libDir()
-   @windows_only dir = joinpath(Base.JULIA_HOME, "julia");
-   @unix_only dir = match(r"(.*)(sys.ji)",imagePath()).captures[1];
+    @unix_only return match(r"(.*)(sys.ji)",imagePath()).captures[1];
+    @windows_only return Base.JULIA_HOME;
 end
 
 function includeDir()
-   dir = match(r"(.*)(bin)",JULIA_HOME).captures[1]*"include/julia";
+    joinpath(match(r"(.*)(bin)",JULIA_HOME).captures[1],"include","julia");
 end
 
 function initDir()
-   @unix_only dir = match(r"(.*)(julia/sys.ji)",imagePath()).captures[1];
+    @unix_only return match(r"(.*)(julia/sys.ji)",imagePath()).captures[1];
+    @windows_only return match(r"(.*)(julia\sys.ji)",imagePath()).captures[1];
 end
 
 function ldflags()
-   @unix_only "-L$(libDir()) -Wl,-rpath $(libDir()) -ljulia";
+    @unix_only return "-L$(libDir()) -Wl,-rpath $(libDir()) -ljulia";
+    @windows_only return "-L$(libDir()) -ljulia";
 end
 
 function cflags()
-   @unix_only "-DJULIA_INIT_DIR=\"$(initDir())\" -I$(includeDir())";
+    "-DJULIA_INIT_DIR=\"$(initDir())\" -I$(includeDir())";
 end
 
 function check_args(args)
-   checked = intersect(args,options);
-   if length(checked) == 0 || length(checked) != length(args)
-      println(STDERR,"Usage: julia-config [",reduce((x,y)->"$x|$y",options),"]");
-      exit(1);
-   end
+    checked = intersect(args,options);
+    if length(checked) == 0 || length(checked) != length(args)
+        println(STDERR,"Usage: julia-config [",reduce((x,y)->"$x|$y",options),"]");
+        exit(1);
+    end
 end
 
 function main()
-   check_args(ARGS);
-   for args in ARGS
-      if args == "--ldflags"
-         println(ldflags());
-      elseif args == "--cflags"
-         println(cflags());
-      end
-   end
+    check_args(ARGS);
+    for args in ARGS
+        if args == "--ldflags"
+            println(ldflags());
+        elseif args == "--cflags"
+            println(cflags());
+        end
+    end
 end
 
 main();

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -12,8 +12,7 @@ function imagePath()
 end
 
 function libDir()
-    @unix_only return match(r"(.*)(sys.ji)",imagePath()).captures[1];
-    @windows_only return Base.JULIA_HOME;
+    return  abspath(dirname(Sys.dlpath("libjulia")));
 end
 
 function includeDir()

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -1,0 +1,45 @@
+const options =
+[
+   "--cflags",
+   "--ldflags"
+];
+
+function libdir()
+   opts = Base.compileropts();
+   image_path = bytestring(opts.image_file);
+   @windows_only dir = joinpath(Base.JULIA_HOME, "julia");
+   @unix_only dir = match(r"(.*)(sys.ji)",image_path).captures[1];
+end
+
+function includedir()
+   dir = match(r"(.*)(bin)",JULIA_HOME).captures[1]*"include/julia";
+end
+
+function ldflags()
+   @unix_only "-L$(libdir()) -Wl,-rpath $(libdir()) -ljulia";
+end
+
+function cflags()
+   @unix_only "-I$(includedir())";
+end
+
+function check_args(args)
+   checked = intersect(args,options);
+   if length(checked) == 0 || length(checked) != length(args)
+      println(STDERR,"Usage: julia-config [",reduce((x,y)->"$x|$y",options),"]");
+      exit(1);
+   end
+end
+
+function main()
+   check_args(ARGS);
+   for args in ARGS
+      if args == "--ldflags"
+         println(ldflags());
+      elseif args == "--cflags"
+         println(cflags());
+      end
+   end
+end
+
+main();

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -4,23 +4,30 @@ const options =
    "--ldflags"
 ];
 
-function libdir()
+function imagePath()
    opts = Base.compileropts();
    image_path = bytestring(opts.image_file);
-   @windows_only dir = joinpath(Base.JULIA_HOME, "julia");
-   @unix_only dir = match(r"(.*)(sys.ji)",image_path).captures[1];
 end
 
-function includedir()
+function libDir()
+   @windows_only dir = joinpath(Base.JULIA_HOME, "julia");
+   @unix_only dir = match(r"(.*)(sys.ji)",imagePath()).captures[1];
+end
+
+function includeDir()
    dir = match(r"(.*)(bin)",JULIA_HOME).captures[1]*"include/julia";
 end
 
+function initDir()
+   @unix_only dir = match(r"(.*)(julia/sys.ji)",imagePath()).captures[1];
+end
+
 function ldflags()
-   @unix_only "-L$(libdir()) -Wl,-rpath $(libdir()) -ljulia";
+   @unix_only "-L$(libDir()) -Wl,-rpath $(libDir()) -ljulia";
 end
 
 function cflags()
-   @unix_only "-I$(includedir())";
+   @unix_only "-DJULIA_INIT_DIR=\"$(initDir())\" -I$(includeDir())";
 end
 
 function check_args(args)

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -3,7 +3,8 @@
 const options =
 [
     "--cflags",
-    "--ldflags"
+    "--ldflags",
+    "--ldlibs"
 ];
 
 function imagePath()
@@ -12,7 +13,7 @@ function imagePath()
 end
 
 function libDir()
-    return  abspath(dirname(Sys.dlpath("libjulia")));
+    abspath(dirname(Sys.dlpath("libjulia")));
 end
 
 function includeDir()
@@ -25,12 +26,18 @@ function initDir()
 end
 
 function ldflags()
-    @unix_only return replace("""-L$(libDir()) -Wl,-rpath $(libDir()) -ljulia""","\\","\\\\");
-    @windows_only return replace("""-L$(libDir()) -ljulia""","\\","\\\\");
+    replace("""-L$(libDir())""","\\","\\\\");
+end
+
+function ldlibs()
+    @unix_only return replace("""-Wl,-rpath $(libDir()) -ljulia""","\\","\\\\");
+    @windows_only return replace("""-ljulia""","\\","\\\\");
 end
 
 function cflags()
-    replace("""-DJULIA_INIT_DIR="$(initDir())" -I$(includeDir())""","\\","\\\\");
+    arg1 = replace(initDir(),"\\","\\\\");
+    arg2 = replace(includeDir(),"\\","\\\\");
+    return """-DJULIA_INIT_DIR=\\"$arg1\\" -I$arg2""";
 end
 
 function check_args(args)
@@ -48,6 +55,8 @@ function main()
             println(ldflags());
         elseif args == "--cflags"
             println(cflags());
+        elseif args == "--ldlibs"
+            println(ldlibs());
         end
     end
 end

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -20,16 +20,16 @@ end
 
 function initDir()
     @unix_only return match(r"(.*)(julia/sys.ji)",imagePath()).captures[1];
-    @windows_only return match(r"(.*)(julia\sys.ji)",imagePath()).captures[1];
+    @windows_only return match(r"(.*)(julia\\sys.ji)",imagePath()).captures[1];
 end
 
 function ldflags()
-    @unix_only return "-L$(libDir()) -Wl,-rpath $(libDir()) -ljulia";
-    @windows_only return "-L$(libDir()) -ljulia";
+    @unix_only return replace("""-L$(libDir()) -Wl,-rpath $(libDir()) -ljulia""","\\","\\\\");
+    @windows_only return replace("""-L$(libDir()) -ljulia""","\\","\\\\");
 end
 
 function cflags()
-    "-DJULIA_INIT_DIR=\"$(initDir())\" -I$(includeDir())";
+    replace("""-DJULIA_INIT_DIR="$(initDir())" -I$(includeDir())""","\\","\\\\");
 end
 
 function check_args(args)

--- a/doc/manual/embedding.rst
+++ b/doc/manual/embedding.rst
@@ -45,6 +45,59 @@ The second statement in the test program evaluates a Julia statement using a cal
 
 Before the program terminates, it is strongly recommended to call ``jl_atexit_hook``.  The above example program calls this before returning from ``main``.
 
+## Using julia-config to automatically determine build parameters
+
+The script *julia-config.jl* was created to aid in determining what build parameters are required by a program that uses embedded Julia.  This script uses the
+build parameters and system configuration of the particular Julia distribution it is invoked by to export the necessary compiler flags for an embedding program to
+interact with that distribution.  This script is located in the Julia shared data directory.
+
+### Example
+
+Below is essentially the same as above with one small change; the argument to ``jl_init`` is now **JULIA_INIT_DIR** which is defined by *julia-config.jl*.
+
+    #include <julia.h>
+
+    int main(int argc, char *argv[])
+    {
+       jl_init(JULIA_INIT_DIR);
+       (void)jl_eval_string("println(sqrt(2.0))");
+       jl_atexit_hook();
+       return 0;
+    }
+
+
+### On the command line
+
+A simple use of this script is from the command line.  Assuming that *julia-config.jl* is located in */usr/local/julia/share/julia*, it can be invoked on
+the command line directly and takes any combination of 3 flags
+
+    /usr/local/julia/share/julia/julia-config.jl
+    Usage: julia-config [--cflags|--ldflags|--ldlibs]
+
+If the above example source is saved in the file *embed_exmaple.c*, then the following command will compile it into a running program on Linux and Windows (MSYS2 environment),
+or if on OS/X, then substitute clang for gcc.
+
+    /usr/local/julia/share/julia/julia-config.jl --cflags --ldflags --ldlibs | xargs gcc embed_example.c
+
+### Use in Makefiles
+
+But in general, embedding projects will be more complicated than the above, and so the following allows general makefile support as well -- assuming GNU make because
+of the use of the **shell** macro expansions.  Additionally, though many times *julia-config.jl* may be found in the directory */usr/local*, this is not necessarily the case,
+but Julia can be used to locate *julia-config.jl* too, and the makefile can be used to take advantage of that.  The above example is extended to use a Makefile
+
+Makefile:
+
+    JL_SHARE = $(shell julia -e 'print(joinpath(JULIA_HOME,Base.DATAROOTDIR,"julia"))')
+    CFLAGS   += $(shell $(JL_SHARE)/julia-config.jl --cflags)
+    CXXFLAGS += $(shell $(JL_SHARE)/julia-config.jl --cflags)
+    LDFLAGS  += $(shell $(JL_SHARE)/julia-config.jl --ldflags)
+    LDLIBS   += $(shell $(JL_SHARE)/julia-config.jl --ldlibs)
+
+    all: embed_example
+
+Now the build command is simply **make**.
+
+
 Converting Types
 ========================
 


### PR DESCRIPTION
First step, related to #8757.  This script is styled after various other frameworks
configuration scripts such as **pg_config** and **python-config**.  Currently
there are only 2 arguments --ldflags and --cflags to allow embedding applications
to automatically have the necessary compiler flags set.

```
bizarro% julia /usr/local/julia/share/julia/julia-config.jl
Usage: julia-config [--cflags|--ldflags]
```

A workaround for  current issue with **jl_init** as described in #9981 is provided for
by a compiler flag _-DJULIA_INIT_DIR_ which can be used as an argument for jl_init,
however, both can work together and this approach is currently incomplete especially
w.r.t. Windows.  Tested on  Linux and OS/X.  Uses **compileropts()**, 

For exmaple if an embedding program _embed.cpp_ contains the following

```
#include <julia.h>

int main(int argc, char *argv[])
{
    jl_init(JULIA_INIT_DIR);

    jl_value_t *res = (jl_value_t*)jl_eval_string("println(sqrt(2.0))");

    return 0;
}
```

it can be compiled using the following on OS/X

```
clang `julia /usr/local/julia/share/julia/julia-config.jl --cflags --ldflags` embed.cpp
```

and on Linux (note how the command has to be split as gcc fails when libraries come before source files).

```
gcc `julia /usr/local/julia/share/julia/julia-config.jl --cflags` embed.cpp `julia /usr/local/julia/share/julia/julia-config.jl --ldflags`
```

and then run

```
bizarro% ./a.out
1.4142135623730951
```

also on windows (using the msys2 environment for example)

```
gcc `julia /c/Julia/julia-e2ccda028b/share/julia/julia-config.jl --cflags` embed.cpp `julia /c/Julia/julia-e2ccda028b/share/julia/julia-config.jl --ldflags`
```

and then run (a.exe instead of a.out)

```
./a.exe
1.4142135623730951
```

Though the shortened form also works on Windows gcc because rpath is not used

```
gcc `julia /c/Julia/julia-e2ccda028b/share/julia/julia-config.jl --cflags --ldflags` embed.cpp
```

Also, running directly not as an argument to julia is possible

```
clang `/usr/local/julia/share/julia/julia-config.jl --cflags --ldflags` embed.cpp
```
