### PR TITLE
parse markdown tables without dash row

### DIFF
--- a/base/markdown/GitHub/table.jl
+++ b/base/markdown/GitHub/table.jl
@@ -48,10 +48,14 @@ function github_table(stream::IO, md::MD, config::Config)
             end
             if align == nothing && length(rows) == 1 # Must have a --- row
                 align = parsealign(row)
-                (align == nothing || length(align) != cols) && return false
-            else
-                push!(rows, map(x -> parseinline(x, config), rowlength!(row, cols)))
+                if align != nothing
+                    length(align) != cols && return false
+                    continue
+                else
+                    align = [default_align for i in 1:cols]
+                end
             end
+            push!(rows, map(x -> parseinline(x, config), rowlength!(row, cols)))
         end
         length(rows) == 0 && return false
         push!(md, Table(rows, align))

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -63,6 +63,11 @@ writemime(io::IO, m::MIME"text/plain", r::Reference) =
                               ["1","2"]], [:r, :r]))
 
 @test md"""
+    a|b
+    1|2""" == MD(Table(Any[["a", "b"],
+                           ["1", "2"]], [:r, :r]))
+
+@test md"""
     | a  |  b | c |
     | :-- | --: | --- |
     | d`gh`hg | hgh**jhj**ge | f |""" == MD(Table(Any[["a","b","c"],


### PR DESCRIPTION
cc @one-more-minute 

As mentioned in https://github.com/JuliaLang/julia/commit/70353fb1fcb839ec7a8c17b6ea971288c0abca53.
