### PR TITLE
Allow info/warn to take generic arugments

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1,0 +1,27 @@
+# Tests that do not really go anywhere else
+
+# Test info
+@test contains(sprint(io->info(io,"test")), "INFO:")
+@test contains(sprint(io->info(io,"test")), "INFO: test")
+@test contains(sprint(io->info(io,"test ",1,2,3)), "INFO: test 123")
+@test contains(sprint(io->info(io,"test", prefix="MYINFO: ")), "MYINFO: test")
+
+# Test warn
+@test contains(sprint(io->Base.warn_once(io,"test")), "WARNING: test")
+@test isempty(sprint(io->Base.warn_once(io,"test")))
+
+@test contains(sprint(io->warn(io)), "WARNING:")
+@test contains(sprint(io->warn(io, "test")), "WARNING: test")
+@test contains(sprint(io->warn(io, "test ",1,2,3)), "WARNING: test 123")
+@test contains(sprint(io->warn(io, "test", prefix="MYWARNING: ")), "MYWARNING: test")
+@test contains(sprint(io->warn(io, "testonce", once=true)), "WARNING: testonce")
+@test isempty(sprint(io->warn(io, "testonce", once=true)))
+@test !isempty(sprint(io->warn(io, "testonce", once=true, key=hash("testonce",hash("testanother")))))
+let bt = backtrace()
+    ws = split(chomp(sprint(io->warn(io,"test", bt))), '\n')
+    bs = split(chomp(sprint(io->Base.show_backtrace(io,bt))), '\n')
+    @test contains(ws[1],"WARNING: test")
+    for (l,b) in zip(ws[2:end],bs)
+        @test contains(l, b)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ testnames = [
     "lineedit", "replcompletions", "repl", "replutil", "sets", "test", "goto",
     "llvmcall", "grisu", "nullable", "meta", "profile",
     "libgit2", "docs", "markdown", "base64", "parser", "serialize", "functors",
-    "char"
+    "char", "misc"
 ]
 
 if isdir(joinpath(JULIA_HOME, Base.DOCDIR, "examples"))


### PR DESCRIPTION
Restructure `info`/`warn` to take a generic `IO` type as a first argument with a fallback to output to `STDERR`

Add missing tests for `info`/`warn` methods. 

Fixes #10076
