### PR TITLE
Allow to specify pids for pmap

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1338,7 +1338,7 @@ pmap(f) = f()
 # rsym(n) = (a=rand(n,n);a*a')
 # L = {rsym(200),rsym(1000),rsym(200),rsym(1000),rsym(200),rsym(1000),rsym(200),rsym(1000)};
 # pmap(eig, L);
-function pmap(f, lsts...; err_retry=true, err_stop=false)
+function pmap(f, lsts...; err_retry=true, err_stop=false, pids = workers())
     len = length(lsts)
 
     results = Dict{Int,Any}()
@@ -1368,7 +1368,7 @@ function pmap(f, lsts...; err_retry=true, err_stop=false)
     end
 
     @sync begin
-        for wpid in workers()
+        for wpid in pids
             @async begin
                 tasklet = getnext_tasklet()
                 while (tasklet != nothing)

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -177,11 +177,11 @@ General Parallel Computing Support
 
    Get the id of the current process.
 
-.. function:: pmap(f, lsts...; err_retry=true, err_stop=false)
+.. function:: pmap(f, lsts...; err_retry=true, err_stop=false, pids=workers())
 
    Transform collections ``lsts`` by applying ``f`` to each element in parallel.
    If ``nprocs() > 1``, the calling process will be dedicated to assigning tasks.
-   All other available processes will be used as parallel workers.
+   All other available processes will be used as parallel workers, or on the processes specified by ``pids``.
 
    If ``err_retry`` is true, it retries a failed application of ``f`` on a different worker.
    If ``err_stop`` is true, it takes precedence over the value of ``err_retry`` and ``pmap`` stops execution on the first error.

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -182,6 +182,8 @@ workloads = hist(@parallel((a,b)->[a,b], for i=1:7; myid(); end), nprocs())[2]
     @test isready(rr1)
 end
 
+# specify pids for pmap
+@test sort(workers()[1:2]) == sort(unique(pmap(x->(sleep(0.1);myid()), 1:10, pids = workers()[1:2])))
 
 # TODO: The below block should be always enabled but the error is printed by the event loop
 


### PR DESCRIPTION
- new keyword arg `pids` for `pmap`, defaulting to `Base.workers()` (i.e. default == same behavior as currently)
- incl test + docs change

This is crucial when only some hosts have e.g. a GPU, enough RAM, that file in the local filesystem etc..
