### PR TITLE
Change precision to eps for TimeType

### DIFF
--- a/base/dates/types.jl
+++ b/base/dates/types.jl
@@ -136,8 +136,8 @@ Date(y,m=1,d=1) = Date(_c(y),_c(m),_c(d))
 Base.isfinite{T<:TimeType}(::Union(Type{T},T)) = true
 calendar(dt::DateTime) = ISOCalendar
 calendar(dt::Date) = ISOCalendar
-Base.precision(dt::DateTime) = Millisecond
-Base.precision(dt::Date) = Day
+Base.eps(dt::DateTime) = Millisecond(1)
+Base.eps(dt::Date) = Day(1)
 Base.typemax(::Union(DateTime,Type{DateTime})) = DateTime(146138512,12,31,23,59,59)
 Base.typemin(::Union(DateTime,Type{DateTime})) = DateTime(-146138511,1,1,0,0,0)
 Base.typemax(::Union(Date,Type{Date})) = Date(252522163911149,12,31)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -286,3 +286,7 @@ function subtypetree(x::DataType, level=-1)
     depwarn("`subtypetree` is discontinued", :subtypetree)
     (level == 0 ? (x, []) : (x, Any[subtypetree(y, level-1) for y in subtypes(x)]))
 end
+
+# 8898
+@deprecate precision(x::DateTime) eps(x)
+@deprecate precision(x::Date) eps(x)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -276,9 +276,6 @@ importall .QuadGK
 include("fastmath.jl")
 importall .FastMath
 
-# deprecated functions
-include("deprecated.jl")
-
 # package manager
 include("pkg.jl")
 const Git = Pkg.Git
@@ -293,6 +290,9 @@ importall .Profile
 # dates
 include("Dates.jl")
 import .Dates: Date, DateTime, now
+
+# deprecated functions
+include("deprecated.jl")
 
 # Some basic documentation
 include("basedocs.jl")

--- a/doc/stdlib/dates.rst
+++ b/doc/stdlib/dates.rst
@@ -136,6 +136,11 @@ alternatively, you could call ``using Dates`` to bring all exported functions in
    Returns a DateTime corresponding to the user's system
    time as UTC/GMT.
 
+.. function:: eps(::DateTime) -> Millisecond
+              eps(::Date) -> Day
+
+   Returns ``Millisecond(1)`` for ``DateTime`` values and ``Day(1)`` for ``Date`` values.
+
 Accessor Functions
 ~~~~~~~~~~~~~~~~~~
 
@@ -384,7 +389,7 @@ Constants
 Days of the Week:
 
 =============== ========= =============
-Variable        Abbr.     Value (Int64)
+Variable        Abbr.     Value (Int)
 --------------- --------- -------------
 ``Monday``      ``Mon``   1
 ``Tuesday``     ``Tue``   2
@@ -398,7 +403,7 @@ Variable        Abbr.     Value (Int64)
 Months of the Year:
 
 =============== ========= =============
-Variable        Abbr.     Value (Int64)
+Variable        Abbr.     Value (Int)
 --------------- --------- -------------
 ``January``     ``Jan``   1
 ``February``    ``Feb``   2

--- a/test/dates/types.jl
+++ b/test/dates/types.jl
@@ -105,8 +105,8 @@ a = Dates.DateTime(2000)
 b = Dates.Date(2000)
 @test Dates.calendar(a) == Dates.ISOCalendar
 @test Dates.calendar(b) == Dates.ISOCalendar
-@test Dates.precision(a) == Dates.Millisecond
-@test Dates.precision(b) == Dates.Day
+@test eps(a) == Dates.Millisecond(1)
+@test eps(b) == Dates.Day(1)
 @test string(typemax(Dates.DateTime)) == "146138512-12-31T23:59:59"
 @test string(typemin(Dates.DateTime)) == "-146138511-01-01T00:00:00"
 @test typemax(Dates.DateTime) - typemin(Dates.DateTime) == Dates.Millisecond(9223372017043199000)


### PR DESCRIPTION
Deprecate Dates.precision(x::TimeType) => Dates.eps(x::TimeType). Closes #8898.
