### PR TITLE
Improve docs for similar

### DIFF
--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -145,7 +145,7 @@ Constructors
 
 .. function:: similar(array, element_type, dims)
 
-   Create an uninitialized array of the same type as the given array, but with the specified element type and dimensions. The second and third arguments are both optional. The ``dims`` argument may be a tuple or a series of integer arguments.
+   Create an uninitialized array of the same type as the given array, but with the specified element type and dimensions. The second and third arguments are both optional. The ``dims`` argument may be a tuple or a series of integer arguments. For some special ``AbstractArray`` objects which are not real containers (like ranges), this function returns a standard ``Array`` to allow operating on elements.
 
 .. function:: reinterpret(type, A)
 


### PR DESCRIPTION
This came up on the mailing list today. Contrary to what the docs implies, `similar` does not always return an array of the same type, at least not for all `AbstractArray`s. AFAICT the rule is that the return value must be reasonably array-like for it to be useful: e.g. you must be able to call `map` or `sort` on it. I tried to make this rule more explicit with the idea that one should be able to "operate on elements" of the array.

Please suggest any better definition/wording if you can find one.
