### PR TITLE
RFC: Add filtering behavior to whos()

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1119,17 +1119,25 @@ function show_nd(io::IO, a::AbstractArray, limit, print_matrix, label_slices)
     cartesianmap(print_slice, tail)
 end
 
-function whos(m::Module, pattern::Regex)
-    for v in sort(names(m))
-        s = string(v)
-        if isdefined(m,v) && ismatch(pattern, s)
-            println(rpad(s, 30), summary(eval(m,v)))
+function whos(m::Module, pattern::Regex; filter=[])
+    filtertypes = applicable(start, filter) ?
+        filter : [filter]
+    for ft in filtertypes
+        isa(ft, DataType) ||
+        throw(ArgumentError("Non-type object given to filter keyword"))
+    end
+    filtertest(var) = ! any(T -> typeof(var) <: T, filtertypes)
+    for n in sort(names(m))
+        s = string(n)
+        v = eval(m,n)
+        if isdefined(m,n) && ismatch(pattern, s) && filtertest(v)
+            println(rpad(s, 30), summary(v))
         end
     end
 end
-whos() = whos(r"")
-whos(m::Module) = whos(m, r"")
-whos(pat::Regex) = whos(current_module(), pat)
+whos(;filter=Module) = whos(r""; filter=filter)
+whos(m::Module; filter=[]) = whos(m, r""; filter=filter)
+whos(pat::Regex; filter=Module) = whos(current_module(), pat; filter=filter)
 
 # global flag for limiting output
 # TODO: this should be replaced with a better mechanism. currently it is only

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -41,10 +41,16 @@ Getting Around
 
    Determine whether Julia is running an interactive session.
 
-.. function:: whos([Module,] [pattern::Regex])
+.. function:: whos([Module,] [pattern::Regex]; [filter=Module])
 
-   Print information about exported global variables in a module, optionally restricted
-   to those matching ``pattern``.
+   Print information about exported global variables in a module (defaults to
+   the current module), optionally restricted to those matching ``pattern``.
+
+   The ``filter`` keyword is either a single type or iterable object of types.
+   Variables who are of type or subtype of an element in ``filter`` will not be
+   displayed. E.g., ``filter=Any`` will prevent any output. If the function is
+   called with an explicit Module argument, nothing will be filtered.
+   Otherwise, submodules in the current module will not be displayed.
 
 .. function:: edit(file::AbstractString, [line])
 


### PR DESCRIPTION
This change adds a `filter` keyword argument to the `whos` methods that takes one or more types that should not be displayed. It changes the default behavior to not display `Module` types.

I raised this issue in #9902 but didn't get any discussion going. I don't see any real use-case of needing to see what modules have been imported into `Main`, and as my example in the issue shows, it can be quite a large number. I think it makes sense to keep it less cluttered and to allow the current behavior through an additional argument. Plus it allows for other interesting options like excluding `Function`s and/or `DataType`s.
