### PR TITLE
jl_errorf: null terminate buffer before printing

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -48,6 +48,7 @@ DLLEXPORT void NORETURN jl_errorf(const char *fmt, ...)
     ios_vprintf(&buf, fmt, args);
     va_end(args);
     if (jl_errorexception_type == NULL) {
+        ios_write(&buf, "", 1); // null terminate the buffer
         JL_PRINTF(JL_STDERR, "%s", buf.buf);
         jl_exit(1);
     }


### PR DESCRIPTION
(I noticed this issue when adding an entry to `sysimg.jl` that `include`s a file that does not exist.  The resulting error message had extra characters due to a string that was not properly null terminated.)
