### PR TITLE
Special case convert [convert, getindex, setindex!] in show_method_candidates Fix #9970 

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -178,6 +178,8 @@ function show_method_candidates(io::IO, ex::MethodError)
 
     lines = Array((IOBuffer, Int), 0)
     name = isgeneric(ex.f) ? ex.f.env.name : :anonymous
+    # These functions are special cased to only show if first argument is matched.
+    special = ex.f in [convert, getindex, setindex!]
     for method in methods(ex.f)
         buf = IOBuffer()
         print(buf, "  $name")
@@ -197,8 +199,11 @@ function show_method_candidates(io::IO, ex::MethodError)
             # If isvarargtype then it checks wether the rest of the input arguements matches
             # the varargtype
             j = Base.isvarargtype(method.sig[i]) ? length(t_i) : i
-            # checks if the type of arg 1:i of the input intersects with the current method
+            # Checks if the type of arg 1:i of the input intersects with the current method
             t_in = typeintersect(method.sig[1:i], tuple(t_i[1:j]...))
+            # If the function is one of the special cased then it should break the loop if
+            # the type of the first argument is not matched.
+            t_in == None && special && i == 1 && break
             if t_in == None
                 if Base.have_color
                     Base.with_output_color(:red, buf) do buf
@@ -216,6 +221,8 @@ function show_method_candidates(io::IO, ex::MethodError)
                 print(buf, "::$(method.sig[i])")
             end
         end
+        special && right_matches==0 && continue
+
         if length(t_i) > length(method.sig) && !isempty(method.sig) && Base.isvarargtype(method.sig[end])
             # It ensures that methods like f(a::AbstractString...) gets the correct
             # number of right_matches
@@ -225,21 +232,22 @@ function show_method_candidates(io::IO, ex::MethodError)
                 end
             end
         end
-        if length(t_i) < length(method.sig)
-            # If the methods args is longer than input then the method
-            # arguments is printed as not a match
-            for sigtype in method.sig[length(t_i)+1:end]
-                print(buf, ", ")
-                if Base.have_color
-                    Base.with_output_color(:red, buf) do buf
-                        print(buf, "::$sigtype")
+
+        if right_matches > 0
+            if length(t_i) < length(method.sig)
+                # If the methods args is longer than input then the method
+                # arguments is printed as not a match
+                for sigtype in method.sig[length(t_i)+1:end]
+                    print(buf, ", ")
+                    if Base.have_color
+                        Base.with_output_color(:red, buf) do buf
+                            print(buf, "::$sigtype")
+                        end
+                    else
+                        print(buf, "!Matched::$sigtype")
                     end
-                else
-                    print(buf, "!Matched::$sigtype")
                 end
             end
-        end
-        if right_matches > 0
             print(buf, ")")
             push!(lines, (buf, right_matches))
         end

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -172,6 +172,10 @@ end
 function show_method_candidates(io::IO, ex::MethodError)
     # Displays the closest candidates of the given function by looping over the
     # functions methods and counting the number of matching arguments.
+
+    return_T(val) = typeof(val)
+    return_T(val::DataType) = Type{val}
+
     lines = Array((IOBuffer, Int), 0)
     name = isgeneric(ex.f) ? ex.f.env.name : :anonymous
     for method in methods(ex.f)
@@ -186,7 +190,7 @@ function show_method_candidates(io::IO, ex::MethodError)
             show_delim_array(buf, tv, '{', ',', '}', false)
         end
         print(buf, "(")
-        t_i = Any[typeof(ex.args)...]
+        t_i = [return_T(arg) for arg in ex.args]
         right_matches = 0
         for i = 1 : min(length(t_i), length(method.sig))
             i != 1 && print(buf, ", ")

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -49,5 +49,20 @@ no_color = no_color = "\nClosest candidates are:\n  method_c3(::Float64, !Matche
 test_have_color(buf, color, no_color)
 
 # Test for the method error in issue #8651
-Base.show_method_candidates(buf, MethodError(readline,(ASCIIString,)))
+Base.show_method_candidates(buf, MethodError(readline,("",)))
 test_have_color(buf, "", "")
+
+method_c4(::Type{Float64}) = true
+Base.show_method_candidates(buf, MethodError(method_c4,(Float64,)))
+test_have_color(buf, "\e[0m\nClosest candidates are:\n  method_c4(::Type{Float64})\n\e[0m",
+                "\nClosest candidates are:\n  method_c4(::Type{Float64})\n")
+
+Base.show_method_candidates(buf, MethodError(method_c4,(Int32,)))
+test_have_color(buf, "", "")
+
+type Test_type end
+test_type = Test_type()
+for f in [getindex, setindex!]
+    Base.show_method_candidates(buf, MethodError(f,(test_type, 1,1)))
+    test_have_color(buf, "", "")
+end


### PR DESCRIPTION
This special case convert `[convert, getindex, setindex!]` in `show_method_candidates` to only show candidates that have a matching first argument. During this I found a bug in  `show_method_candidates` that made wrong matching on inputs of types before I took `typeof` the input argument like:

```
julia>typeof(Array{Int,1})
 DataType
```

Now I have created a function that dispatch if the argument is `DataType`

```
return_T(val) = typeof(val)
return_T(val::DataType) = Type{val}
```

And hence made it return the correct like:

```
Type{Array{Int,1}}
```

Which is the correct to feed into `typeintersect`

The output from @timholy case in #9970 is now:

``` julia
type ArrayContainer{T,N,I<:(Union(Int,UnitRange{Int})...)} <: AbstractArray{T,N}
           data::Array{T,N}
           indexes::I
       end

julia> ArrayContainer(zeros(3,3), (:,:))
ERROR: MethodError: `convert` has no method matching convert(::Type{ArrayContainer{T,N,I<:(Union(Int64,UnitRange{Int64})...,)}}, :
:Array{Float64,2}, ::(Colon,Colon))
This may have arisen from a call to the constructor ArrayContainer{T,N,I<:(Union(Int64,UnitRange{Int64})...,)}(...), since type co
nstructors fall back to convert methods in julia v0.4.
Closest candidates are:
  convert{T}(::Type{T}, ::T)

 in call at base.jl:36
```
