### PR TITLE
Update base/complex.jl for Complex round (Fix/Workaround #10027)

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -692,13 +692,14 @@ function lexcmp(a::Complex, b::Complex)
 end
 
 #Rounding complex numbers
+# Superfluous tuple splatting in return arguments is a work around for 32-bit systems (#10027)
 #Requires two different RoundingModes for the real and imaginary components
 function round{T<:FloatingPoint, MR, MI}(z::Complex{T}, ::RoundingMode{MR}, ::RoundingMode{MI})
-    Complex(round(real(z), RoundingMode{MR}()),
-            round(imag(z), RoundingMode{MI}()))
+    Complex((round(real(z), RoundingMode{MR}()),
+            round(imag(z), RoundingMode{MI}()))...)
 end
 
-round(z::Complex) = Complex(round(real(z)), round(imag(z)))
+round(z::Complex) = Complex((round(real(z)), round(imag(z)))...)
 @vectorize_1arg Complex round
 
 function round(z::Complex, digits::Integer, base::Integer=10)


### PR DESCRIPTION
Adding superfluous tuple splatting to Complex return arguments seems to be an effective workaround for 32-bit system rounding problems for Complex types (#10027).
