### PR TITLE
fix a bug introduced #9676 and improve method completion when type of argument cannot be determined.

### DIFF
--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -27,6 +27,9 @@ module CompletionFoo
     test2(x::AbstractString) = pass
     test2(x::Char) = pass
 
+    test3(x::AbstractArray{Int}, y::Int) = pass
+    test3(x::AbstractArray{Float64}, y::Float64) = pass
+
     array = [1, 1]
 end
 
@@ -210,6 +213,18 @@ for (T, arg) in [(ASCIIString,"\")\""),(Char, "')'")]
     @test r == 5:23
     @test s[r] == "CompletionFoo.test2"
 end
+
+s = "CompletionFoo.test3([1.,2.],"
+c, r, res = test_complete(s)
+@test !res
+@test length(c) == 2
+
+s = "CompletionFoo.test3([1.,2.], 1.,"
+c, r, res = test_complete(s)
+@test !res
+@test c[1] == string(methods(CompletionFoo.test3, (Array{Float64, 1}, Float64))[1])
+@test r == 1:19
+@test s[r] == "CompletionFoo.test3"
 
 # Test completion in multi-line comments
 s = "#=\n\\alpha"

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -24,6 +24,9 @@ module CompletionFoo
 
     test1(x::Type{Float64}) = pass
 
+    test2(x::AbstractString) = pass
+    test2(x::Char) = pass
+
     array = [1, 1]
 end
 
@@ -198,6 +201,15 @@ c, r, res = test_complete(s)
 @test c[1] == string(methods(prevind, (UTF8String, Int))[1])
 @test r == 1:7
 @test s[r] == "prevind"
+
+for (T, arg) in [(ASCIIString,"\")\""),(Char, "')'")]
+    s = "(1, CompletionFoo.test2($arg,"
+    c, r, res = test_complete(s)
+    @test length(c) == 1
+    @test c[1] == string(methods(CompletionFoo.test2, (T,))[1])
+    @test r == 5:23
+    @test s[r] == "CompletionFoo.test2"
+end
 
 # Test completion in multi-line comments
 s = "#=\n\\alpha"


### PR DESCRIPTION
- First of #9676 has a bug, so if `prevind("(",<tab>` cannot find the method due to `find_start_brace` did not take into account if a brace occur in a string. This is fixed in  0ce12e9
- Commit  c4e0385 changes the so if the type of the argument cannot be determined, then it says the argument can be type `Any` instead of returning no method suggestions. It will still remove methods that where the `typeof` the argument can be determined, but is not matched. See example

```
julia> max([1,2],1,<tab>
max{T<:Real}(x::T<:Real,y::T<:Real) at promotion.jl:218
max(x::Real,y::Real) at promotion.jl:184
max{T1<:Real,T2<:Real}(::AbstractArray{T1<:Real,N},::T2<:Real) at operators.jl:371
max(x,y) at operators.jl:56
max(a,b,c) at operators.jl:83
max(a,b,c,xs...) at operators.jl:84
```

This seems more helpful than not to return anything or return all 10 methods defined for `max`.
@blakejohnson could you review these changes?
