### PR TITLE
Make eltype work for Array{T}

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -47,6 +47,7 @@ end
 
 size{T,n}(t::AbstractArray{T,n}, d) = d <= n ? size(t)[d] : 1
 size(x, d1::Integer, d2::Integer, dx::Integer...) = tuple(size(x, d1), size(x, d2, dx...)...)
+eltype{T}(::Type{AbstractArray{T}}) = T
 eltype{T,n}(::Type{AbstractArray{T,n}}) = T
 iseltype(x,T) = eltype(x) <: T
 elsize{T}(::AbstractArray{T}) = sizeof(T)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1051,3 +1051,11 @@ let x = fill(1.5f0, 10^7)
     @test abs(1.5f7 - cumsum(x)[end]) < 3*eps(1.5f7)
     @test cumsum(x) == cumsum!(similar(x), x)
 end
+
+# PR #10164
+let
+    A = Array{Int}
+    V = Array{Int,1}
+    @test eltype(A) == Int
+    @test eltype(V) == Int
+end


### PR DESCRIPTION
This would work with `eltype(Array{Int})` which currently returns `Any`. But maybe that is intentional? 
