### PR TITLE
Use run length encoding for hashing arrays

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2286,3 +2286,48 @@ function rotl90(A::SparseMatrixCSC)
     end
     return sparse(J, I, V, n, m)
 end
+
+## hashing
+
+# End the run and return the current hash
+@inline function hashrun(val, runlength::Int, h::UInt)
+    if runlength == 0
+        return h
+    elseif runlength > 1
+        h += Base.hashrle_seed
+        h = hash(runlength, h)
+    end
+    hash(val, h)
+end
+
+function hash{T}(A::SparseMatrixCSC{T}, h::UInt)
+    h += Base.hashaa_seed
+    sz = size(A)
+    h += hash(sz)
+
+    colptr = A.colptr
+    rowval = A.rowval
+    nzval = A.nzval
+    lastidx = 0
+    runlength = 0
+    lastnz = zero(T)
+    @inbounds for col = 1:size(A, 2)
+        for j = colptr[col]:colptr[col+1]-1
+            nz = nzval[j]
+            nz == 0 && continue
+            idx = sub2ind(sz, rowval[j], col)
+            if idx != lastidx+1 || nz != lastnz   # Run is over
+                h = hashrun(lastnz, runlength, h) # Hash previous run
+                h = hashrun(0, idx-lastidx-1, h)  # Hash intervening zeros
+
+                runlength = 1
+                lastnz = nz
+            else
+                runlength += 1
+            end
+            lastidx = idx
+        end
+    end
+    h = hashrun(lastnz, runlength, h) # Hash previous run
+    hashrun(0, length(A)-lastidx, h)  # Hash zeros at end
+end

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -71,7 +71,10 @@ vals = Any[
     ("a","b"), (SubString("a",1,1), SubString("b",1,1)),
     # issue #6900
     [x => x for x in 1:10],
-    Dict(7=>7,9=>9,4=>4,10=>10,2=>2,3=>3,8=>8,5=>5,6=>6,1=>1)
+    Dict(7=>7,9=>9,4=>4,10=>10,2=>2,3=>3,8=>8,5=>5,6=>6,1=>1),
+    [], [1], [2], [1, 1], [1, 2], [1, 3], [2, 2], [1, 2, 2], [1, 3, 3],
+    zeros(2, 2), spzeros(2, 2), eye(2, 2), speye(2, 2),
+    sparse(ones(2, 2)), ones(2, 2), sparse([0 0; 1 0]), [0 0; 1 0]
 ]
 
 for a in vals, b in vals
@@ -84,3 +87,9 @@ end
 @test hash(:(X.x)) != hash(:(X.y))
 
 @test hash([1,2]) == hash(sub([1,2,3,4],1:2))
+
+# test explicit zeros in SparseMatrixCSC
+x = sprand(10, 10, 0.5)
+x[1] = 1
+x.nzval[1] = 0
+@test hash(x) == hash(full(x))


### PR DESCRIPTION
Fixes  #10160. This implementation only uses run length encoding in cases where there is a repeated element. The overhead appears to be pretty small. For Float64 arrays with no runs, it's about 3-5% slower than the old `hash`. For Int arrays, it actually seems to be a couple percent faster (??). For the all zeros dense case it's >5x faster, and for SparseMatrixCSC the complexity is `O(nz)` instead of `O(m*n)`.
