### PR TITLE
RFC: handle serializing objects with cycles using a Serializer object

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -351,6 +351,17 @@ end
 
 copy(o::ObjectIdDict) = ObjectIdDict(o)
 
+# SerializationState type needed as soon as ObjectIdDict is available
+
+type SerializationState{I<:IO}
+    io::I
+    counter::Int
+    table::ObjectIdDict
+    SerializationState(io::I) = new(io, 0, ObjectIdDict())
+end
+
+SerializationState(io::IO) = SerializationState{typeof(io)}(io)
+
 # dict
 
 type Dict{K,V} <: Associative{K,V}

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -97,6 +97,7 @@ export
     RoundNearestTiesUp,
     RoundToZero,
     RoundUp,
+    SerializationState,
     Set,
     SharedArray,
     SharedMatrix,

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -205,6 +205,7 @@ function call{T<:CdoubleMax}(::Type{T}, n::BigInt, ::RoundingMode{:Up})
     x = T(n,RoundToZero)
     x < n ? nextfloat(x) : x
 end
+
 function call{T<:CdoubleMax}(::Type{T}, n::BigInt, ::RoundingMode{:Nearest})
     x = T(n,RoundToZero)
     if maxintfloat(T) <= abs(x) < T(Inf)

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -543,18 +543,18 @@ function send_add_client(rr::RemoteRef, i)
     end
 end
 
-function serialize(s, rr::RemoteRef)
-    i = worker_id_from_socket(s)
+function serialize(s::SerializationState, rr::RemoteRef)
+    i = worker_id_from_socket(s.io)
     #println("$(myid()) serializing $rr to $i")
     if i != -1
         #println("send add $rr to $i")
         send_add_client(rr, i)
     end
-    invoke(serialize, Tuple{Any, Any}, s, rr)
+    invoke(serialize, Tuple{SerializationState, Any}, s, rr)
 end
 
-function deserialize(s, t::Type{RemoteRef})
-    rr = invoke(deserialize, Tuple{Any, DataType}, s, t)
+function deserialize(s::SerializationState, t::Type{RemoteRef})
+    rr = invoke(deserialize, Tuple{SerializationState, DataType}, s, t)
     where = rr.where
     if where == myid()
         add_client(rr2id(rr), myid())

--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -278,3 +278,17 @@ create_serialization_stream() do s
     @test isa(n, Nullable)
     @test !isdefined(n, :value)
 end
+
+# cycles
+create_serialization_stream() do s
+    A = Any[1,2,3,4,5]
+    A[3] = A
+    serialize(s, A)
+    seekstart(s)
+    b = deserialize(s)
+    @test b[3] === b
+    @test b[1] == 1
+    @test b[5] == 5
+    @test length(b) == 5
+    @test isa(b,Vector{Any})
+end


### PR DESCRIPTION
Been meaning to write this up for a while.

Serializing now uses a `Serializer` object that keeps the needed state to handle cycles. In some cases it also handles repeated references to the same object.

As in my last attempt, when defining `serialize` you use

```
    serialize_cycle(s, obj) && return
```

and when defining `deserialize` you use

```
    deserialize_cycle(s, newobj, pos)
```
