### PR TITLE
Use system_clock instead of cpu_time

### DIFF
--- a/test/perf/micro/perf.f90
+++ b/test/perf/micro/perf.f90
@@ -1,17 +1,19 @@
 module types
 implicit none
 private
-public dp
+public dp, i64
 integer, parameter :: dp=kind(0.d0)          ! double precision
+integer, parameter :: i64 = selected_int_kind(18) ! At least 64-bit integer
 end module
 
 
 module utils
 ! Various utilities
-use types, only: dp
+use types, only: dp, i64
 implicit none
 private
-public trace, mean, std, init_random_seed, randn, assert, stop_error
+public trace, mean, std, init_random_seed, randn, assert, stop_error, &
+     sysclock2ms
 
 contains
 
@@ -129,6 +131,17 @@ do j = 1, size(A, 2)
     end do
 end do
 end subroutine
+
+! Convert a number of clock ticks, as returned by system_clock called
+! with integer(i64) arguments, to milliseconds
+function sysclock2ms(t)
+  integer(i64), intent(in) :: t
+  integer(i64) :: rate
+  real(dp) :: sysclock2ms, r
+  call system_clock(count_rate=rate)
+  r = 1000._dp / rate
+  sysclock2ms = t * r
+end function sysclock2ms
 
 end module
 
@@ -295,35 +308,36 @@ end subroutine
 end module
 
 program perf
-use types, only: dp
-use utils, only: assert, init_random_seed
+use types, only: dp, i64
+use utils, only: assert, init_random_seed, sysclock2ms
 use bench, only: fib, parse_int, quicksort, mandelperf, pisum, randmatstat, &
     randmatmul
 implicit none
 
 integer, parameter :: NRUNS = 1000
 integer :: i, f, n, m, k, k2
-real(dp) :: t1, t2, tmin, pi, s1, s2
+integer(i64) :: t1, t2, tmin
+real(dp) :: pi, s1, s2
 real(dp), allocatable :: C(:, :), d(:)
 character(len=11) :: s
 
 call init_random_seed()
 
-tmin = 1e9_dp
+tmin = huge(0_i64)
 do i = 1, 5
-    call cpu_time(t1)
+    call system_clock(t1)
     do k = 1, NRUNS
         f = fib(20)
     end do
-    call cpu_time(t2)
+    call system_clock(t2)
     if (t2-t1 < tmin) tmin = t2-t1
 end do
 call assert(f == 6765)
-print "('fortran,fib,',f0.6)", tmin*1000._dp / NRUNS
+print "('fortran,fib,',f0.6)", sysclock2ms(tmin) / NRUNS
 
-tmin = 1e9_dp
+tmin = huge(0_i64)
 do i = 1, 5
-    call cpu_time(t1)
+    call system_clock(t1)
     do k2 = 1, NRUNS
         do k = 1, 1000
             call random_number(s1)
@@ -333,66 +347,66 @@ do i = 1, 5
             call assert(m == n)
         end do
     end do
-    call cpu_time(t2)
+    call system_clock(t2)
     if (t2-t1 < tmin) tmin = t2-t1
 end do
-print "('fortran,parse_int,',f0.6)", tmin*1000._dp / NRUNS
+print "('fortran,parse_int,',f0.6)", sysclock2ms(tmin) / NRUNS
 
-tmin = 1e9_dp
+tmin = huge(0_i64)
 do i = 1, 5
-    call cpu_time(t1)
+    call system_clock(t1)
     do k = 1, NRUNS
         f = mandelperf()
     end do
-    call cpu_time(t2)
+    call system_clock(t2)
     if (t2-t1 < tmin) tmin = t2-t1
 end do
 call assert(f == 14791)
-print "('fortran,mandel,',f0.6)", tmin*1000._dp / NRUNS
+print "('fortran,mandel,',f0.6)", sysclock2ms(tmin) / NRUNS
 
-tmin = 1e9_dp
+tmin = huge(0_i64)
 do i = 1, 5
-    call cpu_time(t1)
+    call system_clock(t1)
     do k = 1, NRUNS
         allocate(d(5000))
         call random_number(d)
         call quicksort(d, 1, size(d))
         deallocate(d)
     end do
-    call cpu_time(t2)
+    call system_clock(t2)
     if (t2-t1 < tmin) tmin = t2-t1
 end do
-print "('fortran,quicksort,',f0.6)", tmin*1000._dp / NRUNS
+print "('fortran,quicksort,',f0.6)", sysclock2ms(tmin) / NRUNS
 
-tmin = 1e9_dp
+tmin = huge(0_i64)
 do i = 1, 5
-    call cpu_time(t1)
+    call system_clock(t1)
     pi = pisum()
-    call cpu_time(t2)
+    call system_clock(t2)
     if (t2-t1 < tmin) tmin = t2-t1
 end do
 call assert(abs(pi - 1.644834071848065_dp) < 1e-6_dp)
-print "('fortran,pi_sum,',f0.6)", tmin*1000
+print "('fortran,pi_sum,',f0.6)", sysclock2ms(tmin)
 
-tmin = 1e9_dp
+tmin = huge(0_i64)
 do i = 1, 5
-    call cpu_time(t1)
+    call system_clock(t1)
     call randmatstat(1000, s1, s2)
-    call cpu_time(t2)
+    call system_clock(t2)
     if (t2-t1 < tmin) tmin = t2-t1
 end do
 ! call assert(s1 > 0.5_dp .and. s1 < 1)
 ! call assert(s2 > 0.5_dp .and. s2 < 1)
-print "('fortran,rand_mat_stat,',f0.6)", tmin*1000
+print "('fortran,rand_mat_stat,',f0.6)", sysclock2ms(tmin)
 
-tmin = 1e9_dp
+tmin = huge(0_i64)
 do i = 1, 5
-    call cpu_time(t1)
+    call system_clock(t1)
     call randmatmul(1000, C)
     call assert(C(1, 1) >= 0)
-    call cpu_time(t2)
+    call system_clock(t2)
     if (t2-t1 < tmin) tmin = t2-t1
 end do
-print "('fortran,rand_mat_mul,',f0.6)", tmin*1000
+print "('fortran,rand_mat_mul,',f0.6)", sysclock2ms(tmin)
 
 end program


### PR DESCRIPTION
Hi,

this pull requests changes the Fortran performance microbenchmark to use system_clock instead of cpu_time for timing, meaning that one gets wallclock time instead of cpu time. See https://github.com/JuliaLang/julia/issues/10157 for discussion.
