### PR TITLE
README: Update instructions for Intel compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,8 +341,10 @@ To use the Intel [MKL] BLAS and LAPACK libraries, make sure that MKL version 10.
 For a 64-bit architecture, the environment should be set up as follows:
 
     # bash
+    source /path/to/intel/bin/compilervars.sh intel64
     source /path/to/mkl/bin/mklvars.sh intel64 ilp64
     export MKL_INTERFACE_LAYER=ILP64
+    export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/include/x86_64-linux-gnu/c++/4.8 #replace 4.8 with gcc version; required for some external dependencies
 
 It is recommended that Intel compilers be used to build Julia when using MKL.
 Add the following to the `Make.user` file:


### PR DESCRIPTION
Remind users to set Intel compiler variables also, not just the MKL ones.

Also, building LLVM 3.3 appears to require gcc includes even if icpc is used:

```
/usr/include/c++/4.8/cstddef(41): catastrophic error: cannot open source file "bits/c++config.h"
```

 I got LLVM to build by manually setting the C++ include path.
