### PR TITLE
Broaden type-constraints from StridedArray to AbstractArray

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -728,39 +728,32 @@ promote_array_type{S<:Union(Complex, Real), AT<:FloatingPoint}(::Type{S}, ::Type
 promote_array_type{S<:Integer, A<:Integer}(::Type{S}, ::Type{A}) = A
 promote_array_type{S<:Integer}(::Type{S}, ::Type{Bool}) = S
 
-./{T<:Integer}(x::Integer, y::StridedArray{T}) =
-    reshape([ x    ./ y[i] for i=1:length(y) ], size(y))
-./{T<:Integer}(x::StridedArray{T}, y::Integer) =
-    reshape([ x[i] ./ y    for i=1:length(x) ], size(x))
-
-./{T<:Integer}(x::Integer, y::StridedArray{Complex{T}}) =
-    reshape([ x    ./ y[i] for i=1:length(y) ], size(y))
-./{T<:Integer}(x::StridedArray{Complex{T}}, y::Integer) =
-    reshape([ x[i] ./ y    for i=1:length(x) ], size(x))
-./{S<:Integer,T<:Integer}(x::Complex{S}, y::StridedArray{T}) =
-    reshape([ x    ./ y[i] for i=1:length(y) ], size(y))
-./{S<:Integer,T<:Integer}(x::StridedArray{S}, y::Complex{T}) =
-    reshape([ x[i] ./ y    for i=1:length(x) ], size(x))
-
-# ^ is difficult, since negative exponents give a different type
-
-.^(x::Number, y::StridedArray) =
-    reshape([ x ^ y[i] for i=1:length(y) ], size(y))
-
-.^(x::StridedArray, y::Number      ) =
-    reshape([ x[i] ^ y for i=1:length(x) ], size(x))
+# Handle operations that return different types
+./(x::Number, Y::AbstractArray) =
+    reshape([ x ./ y for y in Y ], size(Y))
+./(X::AbstractArray, y::Number) =
+    reshape([ x ./ y for x in X ], size(X))
+.\(x::Number, Y::AbstractArray) =
+    reshape([ x .\ y for y in Y ], size(Y))
+.\(X::AbstractArray, y::Number) =
+    reshape([ x .\ y for x in X ], size(X))
+.^(x::Number, Y::AbstractArray) =
+    reshape([ x ^ y for y in Y ], size(Y))
+.^(X::AbstractArray, y::Number      ) =
+    reshape([ x ^ y for x in X ], size(X))
 
 for f in (:+, :-, :div, :mod, :&, :|, :$)
     @eval begin
-        function ($f){S,T}(A::StridedArray{S}, B::StridedArray{T})
+        function ($f){S,T}(A::Range{S}, B::Range{T})
             F = similar(A, promote_type(S,T), promote_shape(size(A),size(B)))
-            for i=1:length(A)
-                @inbounds F[i] = ($f)(A[i], B[i])
+            i = 1
+            for (a,b) in zip(A,B)
+                @inbounds F[i] = ($f)(a, b)
+                i += 1
             end
             return F
         end
-        # interaction with Ranges
-        function ($f){S,T<:Real}(A::StridedArray{S}, B::Range{T})
+        function ($f){S,T}(A::AbstractArray{S}, B::Range{T})
             F = similar(A, promote_type(S,T), promote_shape(size(A),size(B)))
             i = 1
             for b in B
@@ -769,7 +762,7 @@ for f in (:+, :-, :div, :mod, :&, :|, :$)
             end
             return F
         end
-        function ($f){S<:Real,T}(A::Range{S}, B::StridedArray{T})
+        function ($f){S,T}(A::Range{S}, B::AbstractArray{T})
             F = similar(B, promote_type(S,T), promote_shape(size(A),size(B)))
             i = 1
             for a in A
@@ -778,18 +771,25 @@ for f in (:+, :-, :div, :mod, :&, :|, :$)
             end
             return F
         end
+        function ($f){S,T}(A::AbstractArray{S}, B::AbstractArray{T})
+            F = similar(A, promote_type(S,T), promote_shape(size(A),size(B)))
+            for i=1:length(A)
+                @inbounds F[i] = ($f)(A[i], B[i])
+            end
+            return F
+        end
     end
 end
-for f in (:.+, :.-, :.*, :./, :.\, :.%, :.<<, :.>>, :div, :mod, :rem, :&, :|, :$)
+for f in (:.+, :.-, :.*, :.%, :.<<, :.>>, :div, :mod, :rem, :&, :|, :$)
     @eval begin
-        function ($f){T}(A::Number, B::StridedArray{T})
+        function ($f){T}(A::Number, B::AbstractArray{T})
             F = similar(B, promote_array_type(typeof(A),T))
             for i=1:length(B)
                 @inbounds F[i] = ($f)(A, B[i])
             end
             return F
         end
-        function ($f){T}(A::StridedArray{T}, B::Number)
+        function ($f){T}(A::AbstractArray{T}, B::Number)
             F = similar(A, promote_array_type(typeof(B),T))
             for i=1:length(A)
                 @inbounds F[i] = ($f)(A[i], B)


### PR DESCRIPTION
On current master (and also on julia 0.3), the following works:

``` julia
julia> mod([1:4;], 3)
4-element Array{Int64,1}:                                                                                                                                                                                                                                                      
 1                                                                                                                                                                                                                                                                             
 2                                                                                                                                                                                                                                                                             
 0                                                                                                                                                                                                                                                                             
 1                                                                                                                                                                                                                                                                             
```

but

``` julia
julia> mod(1:4, 3)
ERROR: MethodError: `mod` has no method matching mod(::UnitRange{Int64}, ::Int64)                                                                                                                                                                                              
Closest candidates are:                                                                                                                                                                                                                                                        
  mod(::Unsigned, ::Signed)
  mod{T<:Union(Int8,Int64,Int16,Int32)}(::T<:Union(Int8,Int64,Int16,Int32), ::T<:Union(Int8,Int64,Int16,Int32))
  mod{P<:Base.Dates.Period}(::Union(DenseArray{P<:Base.Dates.Period,N},SubArray{P<:Base.Dates.Period,N,A<:DenseArray{T,N},I<:(Union(Int64,Colon,Range{Int64})...,),LD}), ::Integer)
  ...
```

It's always a little dangerous to broaden typing due to the risk of a deluge of method ambiguities. But in this case I fail to see why these (and indeed, many of the surrounding functions) are limited to `StridedArray`s.
