### PR TITLE
Re-enable linalg warnings pending API discussion in #4286

### DIFF
--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -18,12 +18,12 @@ function eigs(A, B;
     nevmax=sym ? n-1 : n-2
     if nev > nevmax
         nev = nevmax
-        isinteractive() && warn("nev should be at most $nevmax")
+        warn("nev should be at most $nevmax")
     end
     nev > 0 || throw(ArgumentError("requested number of eigen values (nev) must be ≥ 1, got $nev"))
     ncvmin = nev + (sym ? 1 : 2)
     if ncv < ncvmin
-        isinteractive() && warn("ncv should be at least $ncvmin")
+        warn("ncv should be at least $ncvmin")
         ncv = ncvmin
     end
     ncv = blas_int(min(ncv, n))
@@ -32,7 +32,7 @@ function eigs(A, B;
     isshift = sigma !== nothing
 
     if isa(which,AbstractString)
-        isinteractive() && warn("Use symbols instead of strings for specifying which eigenvalues to compute")
+        warn("Use symbols instead of strings for specifying which eigenvalues to compute")
         which=symbol(which)
     end
     if (which != :LM && which != :SM && which != :LR && which != :SR &&
@@ -40,11 +40,8 @@ function eigs(A, B;
        throw(ArgumentError("which must be :LM, :SM, :LR, :SR, :LI, :SI, or :BE, got $(repr(which))"))
     end
     which != :BE || sym || throw(ArgumentError("which=:BE only possible for real symmetric problem"))
-    if isshift && which == :SM
-        if isinteractive()
-            warn("use of :SM in shift-and-invert mode is not recommended, use :LM to find eigenvalues closest to sigma")
-        end
-    end
+    isshift && which == :SM && warn("use of :SM in shift-and-invert mode is not recommended, use :LM to find eigenvalues closest to sigma")
+
     if which==:SM && !isshift # transform into shift-and-invert method with sigma = 0
         isshift=true
         sigma=zero(T)

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -639,8 +639,8 @@ for (gesvx, elty) in
               &fact, &trans, &n, &nrhs, A, &lda, AF, &ldaf, ipiv, &equed, R, C, B,
               &ldb, X, &n, rcond, ferr, berr, work, iwork, info)
             @lapackerror
-            if info[1] == n+1 && isinteractive()
-                warn("Matrix is singular to working precision.")
+            if info[1] == n+1 warn("Matrix is singular to working precision.")
+            else @assertnonsingular
             end
             #WORK(1) contains the reciprocal pivot growth factor norm(A)/norm(U)
             X, equed, R, C, B, rcond[1], ferr, berr, work[1]
@@ -694,9 +694,8 @@ for (gesvx, elty, relty) in
               &fact, &trans, &n, &nrhs, A, &lda, AF, &ldaf, ipiv, &equed, R, C, B,
               &ldb, X, &n, rcond, ferr, berr, work, rwork, info)
             @lapackerror
-            if info[1] == n+1 && isinteractive()
-                warn("Matrix is singular to working precision.")
-            end
+            if info[1] == n+1 warn("Matrix is singular to working precision.")
+            else @assertnonsingular end
             #RWORK(1) contains the reciprocal pivot growth factor norm(A)/norm(U)
             X, equed, R, C, B, rcond[1], ferr, berr, rwork[1]
         end
@@ -3182,7 +3181,7 @@ for (bdsdc, elty) in
             if compq == 'N'
                 lwork = 6n
             elseif compq == 'P'
-                isinteractive() && warn("COMPQ='P' is not tested")
+                warn("COMPQ='P' is not tested")
                 #TODO turn this into an actual LAPACK call
                 #smlsiz=ilaenv(9, $elty==:Float64 ? 'dbdsqr' : 'sbdsqr', string(uplo, compq), n,n,n,n)
                 smlsiz=100 #For now, completely overkill


### PR DESCRIPTION
`isinteractive()` means we're in an interactive REPL (or julia was started with `-i`), and should not
be used for deciding whether or not to display numerical warnings.

Reverts 4bf31d868ce1a93b921dbb21032c3fff272a0ece
