### PR TITLE
Make testname selection into a callable function

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Add new code to Julia's base libraries as follows:
 
  3. Add any necessary export symbols in `exports.jl`.
 
- 4. Include your tests in `test/Makefile` and `test/runtests.jl`.
+ 4. Include your tests in `test/Makefile` and `test/choosetests.jl`.
 
 Build as usual, and do `make clean testall` to test your contribution. If your contribution includes changes to Makefiles or external dependencies, make sure you can build Julia from a clean tree using `git clean -fdx` or equivalent (be careful – this command will delete any files lying around that aren't checked into git).
 

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -1,0 +1,62 @@
+@doc """
+
+`tests, net_on = choosetests(choices)` selects a set of tests to be
+run. `choices` should be a vector of test names; if empty or set to
+`["all"]`, all tests are selected.
+
+This function also supports "test collections": specifically, "linalg"
+ refers to collections of tests in the correspondingly-named
+directories.
+
+Upon return, `tests` is a vector of fully-expanded test names, and
+`net_on` is true if networking is available (required for some tests).
+""" ->
+function choosetests(choices = [])
+    testnames = [
+        "linalg", "core", "keywordargs", "numbers", "strings",
+        "dates", "dict", "hashing", "remote", "iobuffer", "staged",
+        "arrayops", "subarray", "reduce", "reducedim", "random",
+        "intfuncs", "simdloop", "blas", "fft", "dsp", "sparse",
+        "bitarray", "copy", "math", "fastmath", "functional",
+        "bigint", "sorting", "statistics", "spawn", "backtrace",
+        "priorityqueue", "arpack", "file", "version", "resolve",
+        "pollfd", "mpfr", "broadcast", "complex", "socket",
+        "floatapprox", "readdlm", "reflection", "regex", "float16",
+        "combinatorics", "sysinfo", "rounding", "ranges", "mod2pi",
+        "euler", "show", "lineedit", "replcompletions", "repl",
+        "replutil", "sets", "test", "goto", "llvmcall", "grisu",
+        "nullable", "meta", "profile", "libgit2", "docs", "markdown",
+        "base64", "parser", "serialize", "functors", "char", "misc"
+    ]
+
+    if isdir(joinpath(JULIA_HOME, Base.DOCDIR, "examples"))
+        push!(testnames, "examples")
+    end
+    @unix_only push!(testnames, "unicode")
+
+    # parallel tests depend on other workers - do them last
+    push!(testnames, "parallel")
+
+    tests = (ARGS==["all"] || isempty(ARGS)) ? testnames : ARGS
+
+    if "linalg" in tests
+        # specifically selected case
+        filter!(x -> x != "linalg", tests)
+        prepend!(tests, ["linalg1", "linalg2", "linalg3", "linalg4", "linalg/lapack", "linalg/triangular", "linalg/tridiag", "linalg/pinv", "linalg/givens", "linalg/cholesky", "linalg/lu"])
+    end
+
+    net_required_for = ["socket", "parallel"]
+    net_on = true
+    try
+        getipaddr()
+    catch
+        warn("Networking unavailable: Skipping tests [" * join(net_required_for, ", ") * "]")
+        net_on = false
+    end
+
+    if !net_on
+        filter!(x -> !(x in net_required_for), tests)
+    end
+
+    tests, net_on
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,44 +1,5 @@
-# linalg tests take the longest - start them off first
-testnames = [
-    "linalg", "core", "keywordargs", "numbers", "strings", "dates",
-    "dict", "hashing", "remote", "iobuffer", "staged", "arrayops",
-    "subarray", "reduce", "reducedim", "random", "intfuncs",
-    "simdloop", "blas", "fft", "dsp", "sparse", "bitarray", "copy", "math",
-    "fastmath", "functional", "bigint", "sorting", "statistics", "spawn",
-    "backtrace", "priorityqueue", "arpack", "file", "version",
-    "resolve", "pollfd", "mpfr", "broadcast", "complex", "socket",
-    "floatapprox", "readdlm", "reflection", "regex", "float16", "combinatorics",
-    "sysinfo", "rounding", "ranges", "mod2pi", "euler", "show",
-    "lineedit", "replcompletions", "repl", "replutil", "sets", "test", "goto",
-    "llvmcall", "grisu", "nullable", "meta", "profile",
-    "libgit2", "docs", "markdown", "base64", "parser", "serialize", "functors",
-    "char", "misc"
-]
-
-if isdir(joinpath(JULIA_HOME, Base.DOCDIR, "examples"))
-    push!(testnames, "examples")
-end
-@unix_only push!(testnames, "unicode")
-
-# parallel tests depend on other workers - do them last
-push!(testnames, "parallel")
-
-tests = (ARGS==["all"] || isempty(ARGS)) ? testnames : ARGS
-
-if "linalg" in tests
-    # specifically selected case
-    filter!(x -> x != "linalg", tests)
-    prepend!(tests, ["linalg1", "linalg2", "linalg3", "linalg4", "linalg/lapack", "linalg/triangular", "linalg/tridiag", "linalg/pinv", "linalg/givens", "linalg/cholesky", "linalg/lu"])
-end
-
-net_required_for = ["socket", "parallel"]
-net_on = true
-try
-    getipaddr()
-catch
-    warn("Networking unavailable: Skipping tests [" * join(net_required_for, ", ") * "]")
-    net_on = false
-end
+include("choosetests.jl")
+tests, net_on = choosetests(ARGS)
 
 cd(dirname(@__FILE__)) do
     n = 1
@@ -46,8 +7,6 @@ cd(dirname(@__FILE__)) do
         n = min(8, CPU_CORES, length(tests))
         n > 1 && addprocs(n; exeflags=`--check-bounds=yes`)
         blas_set_num_threads(1)
-    else
-        filter!(x -> !(x in net_required_for), tests)
     end
 
     @everywhere include("testdefs.jl")


### PR DESCRIPTION
This makes it much easier for CoverageBase to stay in sync with base. See https://github.com/JuliaLang/julia/issues/9493#issuecomment-74193468, which is still happening despite helpful efforts to keep it in sync (https://github.com/timholy/CoverageBase.jl/pull/2).
