### PR TITLE
Bump MAX_TYPE_DEPTH

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1,6 +1,6 @@
 # parameters limiting potentially-infinite types
 const MAX_TYPEUNION_LEN = 3
-const MAX_TYPE_DEPTH = 4
+const MAX_TYPE_DEPTH = 5
 const MAX_TUPLETYPE_LEN  = 8
 const MAX_TUPLE_DEPTH = 4
 


### PR DESCRIPTION
Bumping `MAX_TYPE_DEPTH` enables efficient use of types parameterized by `GenericGraph` objects from the Graphs package. See JuliaLang/Graphs.jl#171.

CC @JeffBezanson 
