### PR TITLE
Add test for issue #10221

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -2182,3 +2182,19 @@ const N10281 = 1000
     for i in 1:N10281
     end
 end === nothing
+
+# issue #10221
+module GCbrokentype
+OLD_STDOUT = STDOUT
+file = open(tempname(), "w")
+redirect_stdout(file)
+versioninfo()
+try
+    type Foo{T}
+        val::Bar{T}
+    end
+end
+gc()
+redirect_stdout(OLD_STDOUT)
+close(file)
+end


### PR DESCRIPTION
Adds a test for the segfault in #10221.

Like @JeffBezanson and @carnaval, I found that when run as part of a script I needed the `versioninfo()` call, and am redirecting stdio to suppress output. (For whatever reason, `versioninfo(IOBuffer())` did not trigger the segfault.) I remember some rare Travis failures in conjunction with #8251, which also used I/O redirection, so I suppose there is some risk here (hence the PR). But I also wonder if those might have been due to the interesting observations made by @garrison in #10218.
