### PR TITLE
Get libgcc dlls from opensuse as part of make win-extras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,7 +388,7 @@ ifeq ($(ARCH),x86_64)
 endif
 
 	[ ! -d dist-extras ] || ( cd dist-extras && \
-		cp 7z.exe 7z.dll libexpat-1.dll zlib1.dll $(bindir) && \
+		cp 7z.exe 7z.dll libexpat-1.dll zlib1.dll libgfortran-3.dll libquadmath-0.dll libstdc++-6.dll libgcc_s_s*-1.dll libssp-0.dll $(bindir) && \
 	    mkdir $(DESTDIR)$(prefix)/Git && \
 	    7z x PortableGit.7z -o"$(DESTDIR)$(prefix)/Git" && \
 	    echo "[core] eol = lf" >> "$(DESTDIR)$(prefix)/Git/etc/gitconfig" && \
@@ -496,20 +496,16 @@ ifneq (,$(filter $(ARCH), i386 i486 i586 i686))
 	cd dist-extras && \
 	$(JLDOWNLOAD) http://downloads.sourceforge.net/sevenzip/7z920.exe && \
 	7z x -y 7z920.exe 7z.exe 7z.dll && \
-	$(JLDOWNLOAD) http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_13.1/noarch/mingw32-libexpat1-2.0.1-8.1.noarch.rpm && \
-	mv mingw32-libexpat1-*.rpm mingw-libexpat.rpm && \
-	$(JLDOWNLOAD) http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_13.1/noarch/mingw32-zlib-1.2.8-3.12.noarch.rpm && \
-	mv mingw32-zlib-*.rpm mingw-zlib.rpm
+	../contrib/windows/winrpm.sh http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_13.1/ \
+	"mingw32-libgfortran3 mingw32-libquadmath0 mingw32-libstdc++6 mingw32-libgcc_s_sjlj1 mingw32-libssp0 mingw32-libexpat1 mingw32-zlib1"
 else ifeq ($(ARCH),x86_64)
 	cd dist-extras && \
 	$(JLDOWNLOAD) 7z920-x64.msi http://downloads.sourceforge.net/sevenzip/7z920-x64.msi && \
 	7z x -y 7z920-x64.msi _7z.exe _7z.dll && \
 	mv _7z.dll 7z.dll && \
 	mv _7z.exe 7z.exe && \
-	$(JLDOWNLOAD) http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_13.1/noarch/mingw64-libexpat1-2.0.1-7.1.noarch.rpm && \
-	mv mingw64-libexpat1-*.rpm mingw-libexpat.rpm && \
-	$(JLDOWNLOAD) http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_13.1/noarch/mingw64-zlib-1.2.8-3.1.noarch.rpm && \
-	mv mingw64-zlib-*.rpm mingw-zlib.rpm
+	../contrib/windows/winrpm.sh http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_13.1/ \
+	"mingw64-libgfortran3 mingw64-libquadmath0 mingw64-libstdc++6 mingw64-libgcc_s_seh1 mingw64-libssp0 mingw64-libexpat1 mingw64-zlib1"
 else
 	$(error no win-extras target for ARCH=$(ARCH))
 endif
@@ -522,8 +518,4 @@ endif
 	$(call spawn,./7z.exe) x -y -onsis nsis-2.46.5-Unicode-setup.exe && \
 	chmod a+x ./nsis/makensis.exe && \
 	chmod a+x busybox.exe && \
-	7z x -y mingw-libexpat.rpm -so > mingw-libexpat.cpio && \
-	7z e -y mingw-libexpat.cpio && \
-	7z x -y mingw-zlib.rpm -so > mingw-zlib.cpio && \
-	7z e -y mingw-zlib.cpio && \
 	$(JLDOWNLOAD) PortableGit.7z https://github.com/msysgit/msysgit/releases/download/Git-1.9.5-preview20141217/PortableGit-1.9.5-preview20141217.7z

--- a/contrib/windows/winrpm.sh
+++ b/contrib/windows/winrpm.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# build-time mini version of WinRPM, usage:
+# ./winrpm.sh http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_13.1/ mingw64-zlib1
+# depends on curl, xmllint, gunzip, sort -V, sha256sum, and p7zip
+
+set -e
+url=$1
+toinstall=$2
+# run in dist-extras
+mkdir -p $(dirname "$0")/../../dist-extras
+cd $(dirname "$0")/../../dist-extras
+
+# there is a curl --retry flag but it wasn't working here for some reason
+retry_curl() {
+  for i in $(seq 10); do
+    curl -fLsS $1 && return
+    #sleep 2
+  done
+  echo "failed to download $1" >&2
+  exit 1
+}
+
+xp="xmllint --xpath"
+# the local-name() complication here is due to xml namespaces
+loc="local-name()="
+eval $(retry_curl $url/repodata/repomd.xml | $xp "/*[$loc'repomd'] \
+  /*[$loc'data'][@type='primary']/*[$loc'location']/@href" -)
+
+case $href in
+  *.gz)
+    primary=$(retry_curl $url/$href | gunzip);;
+  *)
+    primary=$(retry_curl $url/$href);;
+esac
+
+# outputs <package> xml string for newest version
+# don't include arch=src packages, those will list build-time dependencies
+rpm_select() {
+  candidates="<c>$(echo $primary | $xp "//*[$loc'package'] \
+    [./*[$loc'name' and .='$1']][./*[$loc'arch' and .='noarch']]" - \
+    2>/dev/null | sed -e 's|<rpm:|<|g' -e 's|</rpm:|</|g')</c>"
+  # remove rpm namespacing so output can be parsed by xmllint later
+  if [ "$candidates" = "<c></c>" ]; then
+    echo "error: no package candidates found for $1" >&2
+    exit 1
+  fi
+  epochs=""
+  for i in $(echo $candidates | $xp "/c/package/version/@epoch" -); do
+    eval $i
+    epochs="$epochs $epoch"
+  done
+  maxepoch=$(echo $epochs | sed 's/ /\n/g' | sort -V -u | tail -n 1)
+  vers=""
+  for i in $(echo $candidates | $xp "/c/package/version \
+      [@epoch='$maxepoch']/@ver" -); do
+    eval $i
+    vers="$vers $ver"
+  done
+  maxver=$(echo $vers | sed 's/ /\n/g' | sort -V -u | tail -n 1)
+  rels=""
+  for i in $(echo $candidates | $xp "/c/package/version \
+      [@epoch='$maxepoch'][@ver='$maxver']/@rel" -); do
+    eval $i
+    rels="$rels $rel"
+  done
+  maxrel=$(echo $rels | sed 's/ /\n/g' | sort -V -u | tail -n 1)
+  repeats=$(echo $rels | sed 's/ /\n/g' | sort -V | uniq -d | tail -n 1)
+  if [ "$repeats" = "$maxrel" ]; then
+    echo "warning: multiple candidates found for $1 with same version:" >&2
+    echo "epoch $maxepoch, ver $maxver, rel $maxrel, picking at random" >&2
+  fi
+  echo $candidates | $xp "/c/package[version[@epoch='$maxepoch'] \
+    [@ver='$maxver'][@rel='$maxrel']][1]" -
+}
+
+mkdir -p noarch
+for i in $toinstall; do
+  pkgi=$(rpm_select $i)
+  # fail if no available candidates for requested packages
+  if [ -z "$pkgi" ]; then
+    exit 1
+  fi
+  checksum=$(echo $pkgi | $xp "/package/checksum/text()" -)
+  eval $(echo $pkgi | $xp "/package/location/@href" -)
+  echo "downloading $href"
+  retry_curl $url/$href > $href
+  echo "$checksum *$href" | sha256sum -c
+  7z x -y $href
+  cpiofile=$(basename $href | sed 's/.rpm$/.cpio/')
+  rm $href
+  7z e -y $cpiofile
+  rm $cpiofile
+done
+rmdir --ignore-fail-on-non-empty noarch


### PR DESCRIPTION
This is to address https://github.com/JuliaLang/ZMQ.jl/issues/69

I originally wanted to make the `win-extras` target shorter, with an aim of getting rid of it as soon as we can expunge our dependency on command-line git for Pkg. Unfortunately putting these dll's in `usr/bin` breaks `llvm-config.exe` when compiled with Cygwin's version of MinGW-w64. Doing it as part of `win-extras` appears to work though, they get downloaded into `dist-extras` and only copied into the installed folder during `make dist`. No more need to restart Julia for dlopen of ZMQ or Cbc dll's to work.

This runs the risk of making the buildbots susceptible to opensuse connectivity flakiness, we'll have to see.
