### PR TITLE
Changes to C code needed to use clang++ to generate callgraphs

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -137,9 +137,11 @@ static uv_lib_t *jl_load_dynamic_library_(const char *modname, unsigned flags, i
     }
 
 #if defined(__linux__) || defined(__FreeBSD__)
-    const char *soname = jl_lookup_soname(modname, strlen(modname));
-    error = (soname==NULL) || jl_uv_dlopen(soname, handle, flags);
-    if (!error) goto done;
+    {
+        const char *soname = jl_lookup_soname(modname, strlen(modname));
+        error = (soname==NULL) || jl_uv_dlopen(soname, handle, flags);
+        if (!error) goto done;
+    }
 #endif
 
     if (throw_err) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -1395,7 +1395,7 @@ const char * jl_get_system_image_cpu_target(const char *fname)
         *fname_shlib_dot = 0;
 
     // Get handle to sys.so
-    uv_lib_t * sysimg_handle = jl_load_dynamic_library_e(fname_shlib, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
+    uv_lib_t * sysimg_handle = (uv_lib_t*)jl_load_dynamic_library_e(fname_shlib, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
 
     // Return jl_sysimg_cpu_target if we can
     if (sysimg_handle)

--- a/src/gc.c
+++ b/src/gc.c
@@ -23,6 +23,10 @@
 #endif
 #endif
 
+#ifdef GC_VERIFY
+void jl_(void *jl_value);
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -174,7 +174,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         return e;
     }
     jl_expr_t *ex = (jl_expr_t*)e;
-    jl_value_t **args = jl_array_data(ex->args);
+    jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
     size_t nargs = jl_array_len(ex->args);
     if (ex->head == call_sym ||  ex->head == call1_sym) {
         if (jl_is_lambda_info(args[0])) {

--- a/src/sys.c
+++ b/src/sys.c
@@ -389,9 +389,9 @@ int jl_process_stop_signal(int status) { return WSTOPSIG(status); }
 
 // -- access to std filehandles --
 
-JL_STREAM *JL_STDIN  = (void*)STDIN_FILENO;
-JL_STREAM *JL_STDOUT = (void*)STDOUT_FILENO;
-JL_STREAM *JL_STDERR = (void*)STDERR_FILENO;
+JL_STREAM *JL_STDIN  = (JL_STREAM*)STDIN_FILENO;
+JL_STREAM *JL_STDOUT = (JL_STREAM*)STDOUT_FILENO;
+JL_STREAM *JL_STDERR = (JL_STREAM*)STDERR_FILENO;
 
 JL_STREAM *jl_stdin_stream(void)  { return JL_STDIN; }
 JL_STREAM *jl_stdout_stream(void) { return JL_STDOUT; }


### PR DESCRIPTION
I'm working on generating a callgraph for Julia's C code. These are changes I found I needed to get the following script working:

``` sh
#!/bin/bash

SRC=( jltypes.c gc.c gf.c ast.c builtins.c module.c codegen.cpp disasm.cpp debuginfo.cpp interpreter.c alloc.c dlload.c sys.c init.c task.c array.c dump.c toplevel.c jl_uv.c jlapi.c profile.c llvm-simdloop.cpp )

for fl in ${SRC[@]}
do
    clang++ -Isupport -Iflisp -I../usr/include -I../deps/valgrind -imacros callgraph.macros -S -emit-llvm $fl -o - | opt-3.4 -analyze -dot-callgraph
    cat callgraph.dot | c++filt > $fl.dot
done
rm callgraph.dot
```

The intent is to determine which functions might trigger GC, and thereby help spot missing roots.
