### PR TITLE
fix #10234, and correct overflow scaling of vecnorm(x,p) for p < 0

### DIFF
--- a/test/linalg2.jl
+++ b/test/linalg2.jl
@@ -338,8 +338,26 @@ for elty in (Float32, Float64, BigFloat, Complex{Float32}, Complex{Float64}, Com
         for p = -2:3
             @test norm(reshape(A, length(A)), p) == vecnorm(A, p)
         end
+
+        # issue #10234
+        if elty <: FloatingPoint || elty <: Complex
+            let z = zeros(elty, 100)
+                z[1] = -Inf
+                for p in [-2,-1.5,-1,-0.5,0.5,1,1.5,2,Inf]
+                    @test norm(z, p) == (p < 0 ? 0 : Inf)
+                    @test norm(elty[Inf],p) == Inf
+                end
+            end
+        end
     end
 end
+
+# issue #10234
+@test norm(Any[Inf],-2) == norm(Any[Inf],-1) == norm(Any[Inf],1) == norm(Any[Inf],1.5) == norm(Any[Inf],2) == norm(Any[Inf],Inf) == Inf
+
+# overflow/underflow in norms:
+@test_approx_eq norm(Float64[1e-300, 1], -3)*1e300 1
+@test_approx_eq norm(Float64[1e300, 1], 3)*1e-300 1
 
 # Uniform scaling
 @test I[1,1] == 1 # getindex


### PR DESCRIPTION
`vecnorm(x,p)` rescales x before summing for `abs(p) > 1`, but we need to check for an infinite maximum in order to avoid spurious NaNs from Inf/Inf as in #10234.    Also, I noticed that the scaling was incorrect for the `p < -1` "norms", where one needs to scale by the minimum rather than the maximum of `abs(x)`.
