### PR TITLE
RFC: add a few GC roots to ast.c

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -666,11 +666,14 @@ jl_array_t *jl_lam_args(jl_expr_t *l)
 jl_sym_t *jl_lam_argname(jl_lambda_info_t *li, int i)
 {
     jl_expr_t *ast;
+    JL_GC_PUSH1(&ast);
     if (jl_is_expr(li->ast))
         ast = (jl_expr_t*)li->ast;
     else
         ast = (jl_expr_t*)jl_uncompress_ast(li, li->ast);
-    return (jl_sym_t*)jl_arrayref(jl_lam_args(ast),i);
+    jl_sym_t *result = (jl_sym_t*)jl_arrayref(jl_lam_args(ast),i);
+    JL_GC_POP();
+    return result;
 }
 
 // get array of local var symbols

--- a/src/ast.c
+++ b/src/ast.c
@@ -167,12 +167,14 @@ static jl_value_t *full_list(value_t e, int expronly)
     size_t ln = llength(e);
     if (ln == 0) return jl_an_empty_cell;
     jl_array_t *ar = jl_alloc_cell_1d(ln);
+    JL_GC_PUSH1(&ar);
     size_t i=0;
     while (iscons(e)) {
         jl_cellset(ar, i, scm_to_julia_(car_(e), expronly));
         e = cdr_(e);
         i++;
     }
+    JL_GC_POP();
     return (jl_value_t*)ar;
 }
 
@@ -181,12 +183,14 @@ static jl_value_t *full_list_of_lists(value_t e, int expronly)
     size_t ln = llength(e);
     if (ln == 0) return jl_an_empty_cell;
     jl_array_t *ar = jl_alloc_cell_1d(ln);
+    JL_GC_PUSH1(&ar);
     size_t i=0;
     while (iscons(e)) {
         jl_cellset(ar, i, full_list(car_(e),expronly));
         e = cdr_(e);
         i++;
     }
+    JL_GC_POP();
     return (jl_value_t*)ar;
 }
 


### PR DESCRIPTION
This is me playing around with the callgraph stuff I mentioned in #10248. Here I'm testing my understanding and asking for review; I'm going to take the liberty of assigning @JeffBezanson since this gets into interactions with flisp, and no one understands the flisp code like Jeff. 

If my understanding is clear, the ~~first~~ second commit seems pretty straightforwardly necessary. The ~~second~~ first I understand less well, and I suspect there's a good chance that either it's unnecessary or, worse, a half-measure that needs much more serious surgery. To me `scm_to_julia_` looks problematic: after [`iscons(e)`](https://github.com/JuliaLang/julia/blob/235576d7410808095c56d1686413f9f3be881de6/src/ast.c#L280) there seems to be a heap of unsafe code, which is why I suspect that `scm_to_julia` simply [disables gc](https://github.com/JuliaLang/julia/blob/235576d7410808095c56d1686413f9f3be881de6/src/ast.c#L195-L197). The problem is, this isn't the only route into the function: it's also called by [`full_list`](https://github.com/JuliaLang/julia/blob/235576d7410808095c56d1686413f9f3be881de6/src/ast.c#L172), which does not take similar precautions. I don't know what `car_(e)` does---maybe it guarantees that `iscons(e)` will be false?---but I thought I'd better raise the concern for someone with suitable expertise to address.
