### PR TITLE
Towards typed lambdas

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -62,7 +62,7 @@ cconvert(T, x) = convert(T, x)
 cconvert{T}(::Type{Ptr{Ptr{T}}}, a::Array) = a
 # convert strings to ByteString to pass as pointers
 cconvert{P<:Union(Int8,UInt8)}(::Type{Ptr{P}}, s::AbstractString) = bytestring(s)
-
+_print(x::ANY) = ccall(:jl_, Void, (Any,), x)
 reinterpret{T,S}(::Type{T}, x::S) = box(T,unbox(S,x))
 
 abstract IO

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -930,6 +930,15 @@ function abstract_call(f, fargs, argtypes, vtypes, sv::StaticVarInfo, e)
         # TODO: call() case
         return Any
     end
+    # TODO investigate why this makes bootstrap fail. probably a simple mistake.
+#=    if isa(f,Function)
+        ft = typeof(f)
+        if isleaftype(ft)
+            argtt = tuple(argtypes...)
+            argtt <: ft.parameters[1] || return Bottom
+            return ft.parameters[2]
+        end
+    end=#
     if !isa(f,Function) && !isa(f,IntrinsicFunction) && _iisdefined(:call)
         call_func = _ieval(:call)
         if isa(call_func,Function)
@@ -959,6 +968,7 @@ function abstract_eval_call(e, vtypes, sv::StaticVarInfo)
     end
     called = e.args[1]
     func = isconstantfunc(called, sv)
+#    _print(("ABS E CALL ", e, "\n"))
     if is(func,false)
         if isa(called, LambdaStaticData)
             # called lambda expression (let)
@@ -966,7 +976,14 @@ function abstract_eval_call(e, vtypes, sv::StaticVarInfo)
                                   true)
             return result
         end
+
         ft = abstract_eval(called, vtypes, sv)
+        if ft <: Function && isleaftype(ft)
+            argtt = tuple(argtypes...)
+            argtt <: ft.parameters[1] || return Bottom
+            return ft.parameters[2]
+        end
+
         if !(Function <: ft) && _iisdefined(:call)
             call_func = _ieval(:call)
             if isa(call_func,Function)
@@ -978,6 +995,24 @@ function abstract_eval_call(e, vtypes, sv::StaticVarInfo)
     #print("call ", e.args[1], argtypes, " ")
     f = _ieval(func)
     return abstract_call(f, fargs, argtypes, vtypes, sv, e)
+end
+
+function abstract_eval_lambda(e::ANY, vtypes, sv::StaticVarInfo)
+    tt = abstract_eval(ccall(:jl_lam_argtypes, Any, (Any,), e), vtypes, sv)
+    if isa(tt, Tuple)
+        aty = map(t -> isType(t) ? t.parameters[1] : Any, tt)
+    else
+        aty = Tuple
+    end
+    rtptr = ccall(:jl_lam_retsigty, Ptr{Void}, (Any,), e)
+    if rtptr == C_NULL
+        rt = Any
+    else
+        rt = abstract_eval(Intrinsics.pointertoref(unbox(Ptr{Void},rtptr)),
+                           vtypes, sv)
+        rt = isType(rt) ? rt.parameters[1] : Any
+    end
+    Function{aty, rt}
 end
 
 function abstract_eval(e::ANY, vtypes, sv::StaticVarInfo)
@@ -992,7 +1027,9 @@ function abstract_eval(e::ANY, vtypes, sv::StaticVarInfo)
     elseif isa(e,GenSym)
         return abstract_eval_gensym(e::GenSym, sv)
     elseif isa(e,LambdaStaticData)
-        return Function
+        #isa(e.ast, Expr) ||
+#        return Function
+        return abstract_eval_lambda(e.ast, vtypes, sv)
     elseif isa(e,GetfieldNode)
         return abstract_eval_global(e.value::Module, e.name)
     end

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -404,8 +404,8 @@ function deserialize(s, ::Type{Function})
     end
     env = deserialize(s)
     linfo = deserialize(s)
-    ccall(:jl_new_closure, Any, (Ptr{Void}, Any, Any),
-          C_NULL, env, linfo)::Function
+    ccall(:jl_new_closure, Any, (Ptr{Void}, Any, Any, Any, Any),
+          C_NULL, env, linfo, C_NULL, C_NULL)::Function
 end
 
 function deserialize(s, ::Type{LambdaStaticData})

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1096,7 +1096,8 @@ static void add_builtin(const char *name, jl_value_t *v)
 static void add_builtin_func(const char *name, jl_fptr_t f)
 {
     add_builtin(name, (jl_value_t*)
-                jl_new_closure(f, (jl_value_t*)jl_symbol(name), NULL));
+                jl_new_closure(f, (jl_value_t*)jl_symbol(name), NULL,
+                               NULL, NULL));
 }
 
 void jl_init_primitives(void)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -942,6 +942,8 @@ static Value *emit_bounds_check(Value *a, jl_value_t *ty, Value *i, Value *len, 
     return im1;
 }
 
+static Value *emit_nthptr(Value *base, size_t n, MDNode* tbaa);
+
 // --- loading and storing ---
 
 static Value *emit_nthptr_addr(Value *v, size_t n)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -617,7 +617,7 @@ static Function *to_function(jl_lambda_info_t *li, bool cstyle)
     }
     assert(f != NULL);
     nested_compile = last_n_c;
-#ifdef JL_DEBUG_BUILD
+    //#ifdef JL_DEBUG_BUILD
 #ifdef LLVM35
     llvm::raw_fd_ostream out(1,false);
 #endif
@@ -631,7 +631,7 @@ static Function *to_function(jl_lambda_info_t *li, bool cstyle)
         f->dump();
         abort();
     }
-#endif
+    //#endif
     FPM->run(*f);
     //n_compile++;
     // print out the function's LLVM code
@@ -754,8 +754,8 @@ static Function *jl_cfunction_object(jl_function_t *f, jl_value_t *rt, jl_value_
     }
     JL_TYPECHK(jl_function_ptr, tuple, argt);
     JL_TYPECHK(jl_function_ptr, type, argt);
-    if (jl_is_gf(f) && (rt == NULL || jl_is_leaf_type(rt)) && jl_is_leaf_type(argt)) {
-        jl_function_t *ff = jl_get_specialization(f, (jl_tuple_t*)argt);
+    if ((rt == NULL || jl_is_leaf_type(rt)) && jl_is_leaf_type(argt)) {
+        jl_function_t *ff = jl_is_gf(f) ? jl_get_specialization(f, (jl_tuple_t*)argt) : f;
         if (ff != NULL && ff->env==(jl_value_t*)jl_null && ff->linfo != NULL) {
             if (ff->linfo->cFunctionObject == NULL) {
                 jl_cstyle_compile(ff);
@@ -781,11 +781,12 @@ static Function *jl_cfunction_object(jl_function_t *f, jl_value_t *rt, jl_value_
                         }
                     }
                 }
-                return (Function*)ff->linfo->cFunctionObject;
             }
         }
+        return (Function*)f->linfo->cFunctionObject;
     }
-    jl_error("function is not yet c-callable");
+    //jl_static_show(JL_STDOUT, (jl_value_t*)jl_uncompress_ast(f->linfo, f->linfo->ast));
+    //    jl_error("function is not yet c-callable");
     return NULL;
 }
 
@@ -794,12 +795,14 @@ extern "C" DLLEXPORT
 void *jl_function_ptr(jl_function_t *f, jl_value_t *rt, jl_value_t *argt)
 {
     Function *llvmf = jl_cfunction_object(f, rt, argt);
-    assert(llvmf);
+    if (llvmf) {
 #ifdef USE_MCJIT
-    return (void*)(intptr_t)jl_ExecutionEngine->getFunctionAddress(llvmf->getName());
+        return (void*)jl_ExecutionEngine->getFunctionAddress(llvmf->getName());
 #else
-    return jl_ExecutionEngine->getPointerToFunction(llvmf);
+        return jl_ExecutionEngine->getPointerToFunction(llvmf);
 #endif
+    }
+    return NULL;
 }
 
 // export a C-callable entry point for a function, with a given name
@@ -1337,7 +1340,7 @@ static void simple_escape_analysis(jl_value_t *expr, bool esc, jl_codectx_t *ctx
                         if (ff->fptr == jl_f_tuplelen ||
                             ff->fptr == jl_f_tupleref ||
                             (ff->fptr == jl_f_apply && alen==4 &&
-                             expr_type(jl_exprarg(e,2),ctx) == (jl_value_t*)jl_function_type)) {
+                             jl_is_functype(expr_type(jl_exprarg(e,2),ctx)))) {
                             esc = false;
                         }
                     }
@@ -1591,17 +1594,20 @@ static Value *emit_lambda_closure(jl_value_t *expr, jl_codectx_t *ctx)
         capt = jl_lam_capt((jl_expr_t*)ast);
     else
         capt = (jl_array_t*)((jl_lambda_info_t*)expr)->capt;
-    if (capt == NULL || jl_array_dim0(capt) == 0) {
+    // disabled for now
+    // we should check if the args & ret types are statically known
+    // and lift only in that case
+    if (0 && (capt == NULL || jl_array_dim0(capt) == 0)) {
         // no captured vars; lift
         jl_value_t *fun =
             (jl_value_t*)jl_new_closure(NULL, (jl_value_t*)jl_null,
-                                        (jl_lambda_info_t*)expr);
+                                        (jl_lambda_info_t*)expr, NULL, NULL);
         jl_add_linfo_root(ctx->linfo, fun);
         return literal_pointer_val(fun);
     }
 
     int argStart = ctx->argDepth;
-    size_t clen = jl_array_dim0(capt);
+    size_t clen = capt ? jl_array_dim0(capt) : 0;
     Value **captured = (Value**) alloca((1+clen)*sizeof(Value*));
     captured[0] = ConstantInt::get(T_size, clen);
     for(i=0; i < clen; i++) {
@@ -1639,16 +1645,24 @@ static Value *emit_lambda_closure(jl_value_t *expr, jl_codectx_t *ctx)
         }
         captured[i+1] = val;
     }
+    if (!jl_is_expr(ast)) ast = jl_uncompress_ast((jl_lambda_info_t*)expr, ast);
+
     Value *env_tuple;
     env_tuple = builder.CreateCall(prepare_call(jlntuple_func),
                                    ArrayRef<Value*>(&captured[0],
                                                     1+clen));
     ctx->argDepth = argStart;
     make_gcroot(env_tuple, ctx);
-    Value *result = builder.CreateCall3(prepare_call(jlclosure_func),
+    Value *argtypes = emit_expr((jl_value_t*)jl_lam_argtypes((jl_expr_t*)ast), ctx);
+    jl_expr_t *retexpr = jl_lam_retsigty((jl_expr_t*)ast);
+    Value *retty = retexpr ? emit_expr((jl_value_t*)retexpr, ctx) : literal_pointer_val((jl_value_t*)jl_any_type);
+    make_gcroot(argtypes, ctx);
+    make_gcroot(retty, ctx);
+    Value *result = builder.CreateCall5(prepare_call(jlclosure_func),
                                         Constant::getNullValue(T_pint8),
-                                        env_tuple, literal_pointer_val(expr));
-    ctx->argDepth--;
+                                        env_tuple, literal_pointer_val(expr),
+                                        argtypes, retty);
+    ctx->argDepth = argStart;
     return result;
 }
 
@@ -2033,7 +2047,7 @@ static Value *emit_known_call(jl_value_t *ff, jl_value_t **args, size_t nargs,
         }
     }
     else if (f->fptr == &jl_f_apply && nargs==3 && ctx->vaStack &&
-             symbol_eq(args[3], ctx->vaName) && expr_type(args[2],ctx) == (jl_value_t*)jl_function_type) {
+             symbol_eq(args[3], ctx->vaName) && jl_is_functype(expr_type(args[2],ctx))) {
         Value *theF = emit_expr(args[2],ctx);
         Value *theFptr = emit_nthptr_recast(theF,1, tbaa_func, jl_pfptr_llvmt);
         Value *nva = emit_n_varargs(ctx);
@@ -2527,26 +2541,49 @@ static Value *emit_jlcall(Value *theFptr, Value *theF, jl_value_t **args,
 
 static Value *emit_call_function_object(jl_function_t *f, Value *theF, Value *theFptr,
                                         bool specialized,
-                                        jl_value_t **args, size_t nargs,
+                                        jl_value_t **args, size_t nargs, jl_value_t* expr,
                                         jl_codectx_t *ctx)
 {
     Value *result;
-    if (f!=NULL && specialized && f->linfo!=NULL && f->linfo->cFunctionObject!=NULL) {
+    jl_value_t *specTypes = NULL;
+    jl_value_t *retType = NULL;
+    JL_GC_PUSH2(&specTypes, &retType);
+    Function *cf = NULL; // compile time Function target
+    Value *rcf = NULL; // runtime function pointer target
+    if (1) {
+        if (specialized && f != NULL && f->linfo != NULL && f->linfo->cFunctionObject != NULL) {
+            // statically known function
+            cf = (Function*)f->linfo->cFunctionObject;
+            specTypes = (jl_value_t*)f->linfo->specTypes;
+            retType = jl_ast_rettype(f->linfo, f->linfo->ast);
+        } else {
+            jl_value_t* ftype = expr_type(expr, ctx);
+            if (jl_is_functype(ftype)) {
+                // statically known function type
+                specTypes = jl_tparam0(ftype);
+                retType = jl_tparam1(ftype);
+                if (!jl_is_leaf_type(specTypes) || !jl_is_leaf_type(retType)) {
+                    specTypes = NULL; retType = NULL;
+                } else {
+                    rcf = emit_nthptr(theF, 4, tbaa_func);
+                }
+            }
+        }
+    }
+    if (specTypes != NULL && retType != NULL && (rcf != NULL || cf != NULL)) {
         // emit specialized call site
-        Function *cf = (Function*)f->linfo->cFunctionObject;
-        FunctionType *cft = cf->getFunctionType();
-        size_t nfargs = cft->getNumParams();
-        Value **argvals = (Value**)alloca(nfargs*sizeof(Value*));
+        Value **argvals = (Value**)alloca(nargs*sizeof(Value*));
+        Type **argtypes = (Type**)alloca(nargs*sizeof(Type*));
         unsigned idx = 0;
         for(size_t i=0; i < nargs; i++) {
-            Type *at = cft->getParamType(idx);
-            Type *et = julia_type_to_llvm(jl_tupleref(f->linfo->specTypes,i));
+            Type *et = julia_type_to_llvm(jl_tupleref(specTypes,i));
+            argtypes[idx] = et;
             if (et == T_void || et->isEmptyTy()) {
                 // Still emit the expression in case it has side effects
                 emit_expr(args[i+1], ctx);
                 continue;
             }
-            if (at == jl_pvalue_llvmt) {
+            if (et == jl_pvalue_llvmt) {
                 Value *origval = emit_expr(args[i+1], ctx);
                 argvals[idx] = boxed(origval,ctx,expr_type(args[i+1],ctx));
                 assert(dyn_cast<UndefValue>(argvals[idx]) == 0);
@@ -2558,28 +2595,37 @@ static Value *emit_call_function_object(jl_function_t *f, Value *theF, Value *th
                 }
             }
             else {
-                assert(at == et);
-                argvals[idx] = emit_unbox(at, emit_unboxed(args[i+1], ctx),
-                                          jl_tupleref(f->linfo->specTypes,i));
+                //                assert(at == et);
+                argvals[idx] = emit_unbox(et, emit_unboxed(args[i+1], ctx),
+                                          jl_tupleref(specTypes,i));
                 assert(dyn_cast<UndefValue>(argvals[idx]) == 0);
             }
             idx++;
         }
-        assert(idx == nfargs);
-        result = builder.CreateCall(prepare_call(cf), ArrayRef<Value*>(&argvals[0],nfargs));
-        result = mark_julia_type(result, jl_ast_rettype(f->linfo, f->linfo->ast));
+        size_t nfargs = idx;
+        if (cf) {
+            result = builder.CreateCall(prepare_call(cf), ArrayRef<Value*>(&argvals[0],nfargs));
+        } else {
+            FunctionType *fty = FunctionType::get(julia_type_to_llvm(retType),
+                                                  ArrayRef<Type*>(&argtypes[0],nfargs), false);
+            rcf = builder.CreateBitCast(rcf, PointerType::get(fty,0));
+            result = builder.CreateCall(rcf, ArrayRef<Value*>(&argvals[0],nfargs));
+        }
+        result = mark_julia_type(result, retType);
     }
     else {
         result = emit_jlcall(theFptr, theF, &args[1], nargs, ctx);
     }
+    JL_GC_POP();
     return result;
 }
 
 static Value *emit_is_function(Value *x, jl_codectx_t *ctx)
 {
     Value *xty = emit_typeof(x);
+    Value *xtyname = emit_nthptr(xty, 1, tbaa_user);
     Value *isfunc =
-        builder.CreateICmpEQ(xty, literal_pointer_val((jl_value_t*)jl_function_type));
+        builder.CreateICmpEQ(xtyname, literal_pointer_val((jl_value_t*)jl_function_typename));
     return isfunc;
 }
 
@@ -2612,7 +2658,7 @@ static Value *emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx, jl_
     }
 
     hdtype = expr_type(a0, ctx);
-    definitely_function |= (hdtype == (jl_value_t*)jl_function_type);
+    definitely_function |= jl_is_functype(hdtype);
     definitely_not_function |= (jl_is_leaf_type(hdtype) && !definitely_function);
 
     assert(!(definitely_function && definitely_not_function));
@@ -2630,7 +2676,7 @@ static Value *emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx, jl_
         }
         else {
             theF = literal_pointer_val((jl_value_t*)f);
-            result = emit_call_function_object(f, theF, theFptr, true, args-1, nargs+1, ctx);
+            result = emit_call_function_object(f, theF, theFptr, true, args-1, nargs+1, a0, ctx);
         }
     }
     else if (definitely_function) {
@@ -2651,7 +2697,7 @@ static Value *emit_call(jl_value_t **args, size_t arglen, jl_codectx_t *ctx, jl_
         else {
             theF = literal_pointer_val((jl_value_t*)f);
         }
-        result = emit_call_function_object(f, theF, theFptr, specialized, args, nargs, ctx);
+        result = emit_call_function_object(f, theF, theFptr, specialized, args, nargs, a0, ctx);
     }
     else {
         // either direct function, or use call(), based on run-time branch
@@ -4992,6 +5038,8 @@ static void init_julia_llvm_env(Module *m)
 
     std::vector<Type*> args4(0);
     args4.push_back(T_pint8);
+    args4.push_back(jl_pvalue_llvmt);
+    args4.push_back(jl_pvalue_llvmt);
     args4.push_back(jl_pvalue_llvmt);
     args4.push_back(jl_pvalue_llvmt);
     jlclosure_func =

--- a/src/dump.c
+++ b/src/dump.c
@@ -908,7 +908,8 @@ static jl_value_t *jl_deserialize_datatype(ios_t *s, int pos, jl_value_t **loc)
         if (dt->name == jl_array_type->name || dt->name == jl_pointer_type->name ||
             dt->name == jl_type_type->name || dt->name == jl_vararg_type->name ||
             dt->name == jl_abstractarray_type->name ||
-            dt->name == jl_densearray_type->name) {
+            dt->name == jl_densearray_type->name ||
+            dt->name == jl_function_type->name) {
             // builtin types are not serialized, so their caches aren't
             // explicitly saved. so we reconstruct the caches of builtin
             // parametric types here.
@@ -1080,7 +1081,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
     }
     else if (vtag == (jl_value_t*)jl_function_type) {
         jl_function_t *f =
-            (jl_function_t*)newobj((jl_value_t*)jl_function_type, 3);
+            (jl_function_t*)newobj((jl_value_t*)jl_function_any_type, 3);
         if (usetable)
             arraylist_push(&backref_list, f);
         f->linfo = (jl_lambda_info_t*)jl_deserialize_value(s, (jl_value_t**)&f->linfo);
@@ -1854,7 +1855,7 @@ void jl_init_serializer(void)
                      jl_typetype_type, jl_typetype_tvar, jl_ANY_flag, jl_array_any_type,
                      jl_intrinsic_type, jl_method_type, jl_methtable_type,
                      jl_voidpointer_type, jl_newvarnode_type, jl_array_symbol_type,
-                     jl_tupleref(jl_tuple_type,0),
+                     jl_tupleref(jl_tuple_type,0), jl_function_any_type,
 
                      jl_symbol_type->name, jl_gensym_type->name, jl_pointer_type->name,
                      jl_datatype_type->name, jl_uniontype_type->name, jl_array_type->name,

--- a/src/gf.c
+++ b/src/gf.c
@@ -307,7 +307,7 @@ jl_function_t *jl_instantiate_method(jl_function_t *f, jl_tuple_t *sp)
 {
     if (f->linfo == NULL)
         return f;
-    jl_function_t *nf = jl_new_closure(f->fptr, f->env, NULL);
+    jl_function_t *nf = jl_new_closure(f->fptr, f->env, NULL, NULL, NULL);
     JL_GC_PUSH1(&nf);
     nf->linfo = jl_add_static_parameters(f->linfo, sp);
     gc_wb(nf, nf->linfo);
@@ -327,7 +327,7 @@ static jl_function_t *with_appended_env(jl_function_t *meth, jl_tuple_t *sparams
         jl_tupleset(temp, i, jl_tupleref(sparams,i*2+1));
     }
     temp = (jl_value_t*)jl_tuple_append((jl_tuple_t*)meth->env, (jl_tuple_t*)temp);
-    meth = jl_new_closure(meth->fptr, temp, meth->linfo);
+    meth = jl_new_closure(meth->fptr, temp, meth->linfo, NULL, NULL);
     JL_GC_POP();
     return meth;
 }
@@ -335,7 +335,7 @@ static jl_function_t *with_appended_env(jl_function_t *meth, jl_tuple_t *sparams
 // make a new method that calls the generated code from the given linfo
 jl_function_t *jl_reinstantiate_method(jl_function_t *f, jl_lambda_info_t *li)
 {
-    return jl_new_closure(NULL, f->env, li);
+    return jl_new_closure(NULL, f->env, li, NULL, NULL);
 }
 
 static
@@ -858,7 +858,7 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tuple_t *type,
             if (method->env == (jl_value_t*)jl_null)
                 newmeth = unspec;
             else
-                newmeth = jl_new_closure(unspec->fptr, method->env, unspec->linfo);
+                newmeth = jl_new_closure(unspec->fptr, method->env, unspec->linfo, NULL, NULL);
 
             if (sparams != jl_null) {
                 newmeth = with_appended_env(newmeth, sparams);
@@ -1611,7 +1611,7 @@ static void _compile_all(jl_module_t *m, htable_t *h)
             jl_value_t *el = jl_cellref(m->constant_table,i);
             if (jl_is_lambda_info(el)) {
                 jl_lambda_info_t *li = (jl_lambda_info_t*)el;
-                jl_function_t *func = jl_new_closure(li->fptr, (jl_value_t*)jl_null, li);
+                jl_function_t *func = jl_new_closure(li->fptr, (jl_value_t*)jl_null, li, NULL, NULL);
                 li->unspecialized = func;
                 gc_wb(li, func);
                 precompile_unspecialized(func, NULL, jl_null);
@@ -1835,7 +1835,7 @@ void jl_initialize_generic_function(jl_function_t *f, jl_sym_t *name)
 
 jl_function_t *jl_new_generic_function(jl_sym_t *name)
 {
-    jl_function_t *f = jl_new_closure(jl_apply_generic, NULL, NULL);
+    jl_function_t *f = jl_new_closure(jl_apply_generic, NULL, NULL, NULL, NULL);
     JL_GC_PUSH1(&f);
     jl_initialize_generic_function(f, name);
     JL_GC_POP();
@@ -1844,7 +1844,7 @@ jl_function_t *jl_new_generic_function(jl_sym_t *name)
 
 DLLEXPORT jl_function_t *jl_new_gf_internal(jl_value_t *env)
 {
-    return jl_new_closure(jl_apply_generic, env, NULL);
+    return jl_new_closure(jl_apply_generic, env, NULL, NULL, NULL);
 }
 
 void jl_add_method(jl_function_t *gf, jl_tuple_t *types, jl_function_t *meth,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3218,18 +3218,18 @@ void jl_init_types(void)
                         jl_tuple(2, jl_tuple_type, jl_any_type),
                         0, 0, 0);
 
+    tv = jl_tuple2(tvar("A"),tvar("R"));
     jl_function_type =
-        jl_new_datatype(jl_symbol("Function"), jl_any_type, jl_null,
-                        jl_tuple(3, jl_symbol("fptr"), jl_symbol("env"),
-                                 jl_symbol("code")),
-                        jl_tuple(3, jl_any_type, jl_any_type,
-                                 jl_lambda_info_type),
+        jl_new_datatype(jl_symbol("Function"), jl_any_type, tv,
+                        jl_tuple(4, jl_symbol("fptr"), jl_symbol("env"),
+                                 jl_symbol("code"), jl_symbol("fptrSpec")),
+                        jl_tuple(4, jl_any_type, jl_any_type,
+                                 jl_lambda_info_type, jl_long_type),
                         0, 1, 0);
+    jl_function_typename = jl_function_type->name;
 
     jl_tupleset(jl_method_type->types, 4, jl_function_type);
     jl_tupleset(jl_lambda_info_type->types, 6, jl_function_type);
-
-    jl_bottom_func = jl_new_closure(jl_f_no_function, (jl_value_t*)JL_NULL, NULL);
 
     jl_intrinsic_type = jl_new_bitstype((jl_value_t*)jl_symbol("IntrinsicFunction"),
                                         jl_any_type, jl_null, 32);
@@ -3258,6 +3258,9 @@ void jl_init_types(void)
     //jl_tupleset(jl_datatype_type->types, 10, jl_int32_type);
     jl_tupleset(jl_function_type->types, 0, pointer_void);
     jl_tupleset(jl_tvar_type->types, 3, (jl_value_t*)jl_bool_type);
+    jl_function_any_type =
+        (jl_value_t*)jl_apply_type((jl_value_t*)jl_function_type, jl_tuple2(jl_tuple_type, jl_any_type));
+    jl_bottom_func = jl_new_closure(jl_f_no_function, (jl_value_t*)JL_NULL, NULL, NULL, NULL);
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);
@@ -3329,6 +3332,7 @@ void jl_init_types(void)
     meta_sym = jl_symbol("meta");
     arrow_sym = jl_symbol("->");
     ldots_sym = jl_symbol("...");
+    typeassert_sym = jl_symbol("typeassert");
 }
 
 #ifdef __cplusplus

--- a/src/task.c
+++ b/src/task.c
@@ -943,7 +943,7 @@ void jl_init_tasks(void *stack, size_t ssize)
 
     jl_exception_in_transit = (jl_value_t*)jl_null;
     jl_task_arg_in_transit = (jl_value_t*)jl_null;
-    jl_unprotect_stack_func = jl_new_closure(jl_unprotect_stack, (jl_value_t*)jl_null, NULL);
+    jl_unprotect_stack_func = jl_new_closure(jl_unprotect_stack, (jl_value_t*)jl_null, NULL, NULL, NULL);
 }
 
 #ifdef __cplusplus

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -507,7 +507,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast)
     }
 
     if (ewc) {
-        thunk = (jl_value_t*)jl_new_closure(NULL, (jl_value_t*)jl_null, thk);
+        thunk = (jl_value_t*)jl_new_closure(NULL, (jl_value_t*)jl_null, thk, NULL, NULL);
         if (!jl_in_inference) {
             jl_type_infer(thk, jl_tuple_type, thk);
         }


### PR DESCRIPTION
As promised in #1864, here is something somewhat working on top of current master.
There are ~5 parts to this :
- Make the Function type parametric (and fatter by 1 pointer, to hold the specialized fptr)
  Was easier than expected. I did not take care of the serializer so any A->B going through the system image should get out as (Any...,)->Any for now.
  Also the function types are standard parametric DataTypes so there is no co/contra variance on ret/arg types.
- Annotate function AST with return/arg types
  Currently this is done in a dirty way. For the return type I'm just looking at the last instruction of the function to see if it is of the form return blah::X. This is not even correct.
  To integrate this properly syntax should probably be discussed and the frontend modified to insert the necessary information in a proper field of the lambda ast node. (see jl_lam_(arg|ret)type in ast.c). We should also decide whether to let the user access inferred types here, or force explicit annotations.
- Teach inference the reduction rules
  Straightforward, see changes in inference.jl. I'm not doing anything when the Function type is not leaf so it could be smarter and look at TypeVar upper/lower bounds.
- Codegen early (on definition) for lambdas annotated with leaf return & arg types.
- Generate specialized calls through Function objects with tightly inferred type.
  This part I'm not very confident I didn't break anything. In particular, are there cases where a specialized function requires boxing even if we can't tell looking at the julia signature ? Here we need to generate a C specialized call with this as only information whereas the current code relies on the known llvm signature. (Not sure if I'm clear but looking at the changes in codegen.cpp should explain my point better...).

Examples :

```
julia> typeof(x::Int -> (x+1)::Int) # Typed lambda
Function{(Int64,),Int64}
```

```
julia> function mymap{A,R}(f::Function{(A,), R}, v::Vector{A})
         n = length(v)
         r = Array(R, n)
         for i=1:n
           r[i] = f(v[i])
         end
         r
       end
mymap (generic function with 1 method)
julia> mymap(x::Int->(x+1)::Int, [1,2,3]) # Correct return type
3-element Array{Int64,1}:
 2
 3
 4
```

```
julia> mycall{A,R}(f::Function{(A,),R}, x::A) = f(x)
mycall (generic function with 1 method)
julia> @code_llvm(mycall(x::Int->(x+1)::Int, 0)) # Fast "C" call
define i64 @julia_mycall_42900(%jl_value_t*, i64) {
top:
  call void @llvm.dbg.value(metadata i64 %1, i64 0, metadata !14, metadata !16)
  %2 = getelementptr inbounds %jl_value_t* %0, i64 4, i32 0, !dbg !17
  %3 = bitcast %jl_value_t** %2 to i64 (i64)**, !dbg !17
  %4 = load i64 (i64)** %3, align 8, !dbg !17, !tbaa !19
  %5 = call i64 %4(i64 %1), !dbg !17
  ret i64 %5, !dbg !17
}
```

About generic functions, there are some big issues I can see, namely : mutability of the "generic signature", hard to avoid introducing a separate type for each function, hard to dispatch on.

As I said before, this is very early POC, probably broken in several ways, and I won't be able to spend much time on it right now. Might be a good basis for discussion however.
