### PR TITLE
Minor fixes to `@enum` macro 

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -35,7 +35,10 @@ macro enum(T,syms...)
         i += one(typeof(i))
         if isa(s,Symbol)
             # pass
-        elseif isa(s,Expr) && s.head == :(=) && length(s.args) == 2 && isa(s.args[1],Symbol)
+        elseif isa(s,Expr) &&
+               (s.head == :(=) || s.head == :kw) &&
+               length(s.args) == 2 &&
+               isa(s.args[1],Symbol)
             i = eval(s.args[2]) # allow exprs, e.g. uint128"1"
             s = s.args[1]
             hasexpr = true

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -1,6 +1,6 @@
 module Enums
 
-export @enum
+export Enum, @enum
 
 abstract Enum
 

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -16,10 +16,12 @@ end
 Base.start{T<:Enum}(::Type{T}) = 1
 Base.next{T<:Enum}(::Type{T},s) = Base.next(names(T),s)
 Base.done{T<:Enum}(::Type{T},s) = Base.done(names(T),s)
+
 # Pass Integer through to Enum constructor through Val{T}
 call{T<:Enum}(::Type{T},x::Integer) = T(Val{convert(fieldtype(T,:val),x)})
+
 # Catchall that errors when specific Enum(::Type{Val{n}}) hasn't been defined
-call{T<:Enum,n}(::Type{T},::Type{Val{n}}) = error(string("invalid enum value for $T: ",n))
+call{T<:Enum,n}(::Type{T},::Type{Val{n}}) = throw(ArgumentError("invalid value for Enum $T, $n"))
 
 macro enum(T,syms...)
     assert(!isempty(syms))

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -47,14 +47,15 @@ macro enum(T,syms...)
         end
         push!(vals, (s,i))
         I = typeof(i)
-        enumT = ifelse(length(vals) == 1, I, promote_type(enumT,I))
-        i < lo && (lo = i)
-        i > hi && (hi = i)
+        enumT = length(vals) == 1 ? I : promote_type(enumT,I)
+        lo = min(lo, i)
+        hi = max(hi, i)
     end
     if !hasexpr
         n = length(vals)
-        enumT = n < 128 ? Int8 : n < 32768 ? Int16 :
-                n < 2147483648 ? Int32 : Int64
+        enumT = n <= typemax(Int8) ? Int8 :
+                n <= typemax(Int16) ? Int16 :
+                n <= typemax(Int32) ? Int32 : Int64
     end
     blk = quote
         # enum definition

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -50,6 +50,7 @@ export
     Dict,
     Dims,
     EachLine,
+    Enum,
     Enumerate,
     Factorization,
     FileMonitor,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -290,7 +290,7 @@ import .Dates: Date, DateTime, now
 
 # enums
 include("Enums.jl")
-import .Enums: @enum
+importall .Enums
 
 # deprecated functions
 include("deprecated.jl")

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -2,12 +2,12 @@ module TestEnums
 
 using Base.Test
 
-@test_throws MethodError convert(Base.Enums.Enum, 1.0)
+@test_throws MethodError convert(Enum, 1.0)
 
 @enum Fruit apple orange kiwi
 @test typeof(Fruit) == DataType
 @test isbits(Fruit)
-@test typeof(apple) <: Fruit <: Base.Enums.Enum
+@test typeof(apple) <: Fruit <: Enum
 @test typeof(apple.val) <: Int8
 @test int(apple) == 0
 @test int(orange) == 1
@@ -63,7 +63,7 @@ end
 
 @enum(QualityofFrenchFood, ReallyGood)
 @test length(QualityofFrenchFood) == 1
-@test typeof(ReallyGood) <: QualityofFrenchFood <: Base.Enums.Enum
+@test typeof(ReallyGood) <: QualityofFrenchFood <: Enum
 @test int(ReallyGood) == 0
 
 @enum Binary _zero=0 _one=1 _two=10 _three=11

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -18,10 +18,10 @@ using Base.Test
 @test Fruit(0) == apple
 @test Fruit(1) == orange
 @test Fruit(2) == kiwi
-@test_throws ErrorException Fruit(3)
-@test_throws ErrorException Fruit(-1)
+@test_throws ArgumentError Fruit(3)
+@test_throws ArgumentError Fruit(-1)
 @test Fruit(Val{Int8(0)}) == apple
-@test_throws ErrorException Fruit(Val{3})
+@test_throws ArgumentError Fruit(Val{3})
 @test Fruit(0x00) == apple
 @test Fruit(big(0)) == apple
 @test_throws MethodError Fruit(0.0)

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -141,4 +141,15 @@ end
 @test typeof(_two_Test10.val) <: UInt8
 @test _two_Test10.val === 0x02
 
+# test macro handles keyword arguments
+@enum(Test11, _zero_Test11=2,
+              _one_Test11,
+              _two_Test11=5,
+              _three_Test11)
+
+@test Int(_zero_Test11) == 2
+@test Int(_one_Test11) == 3
+@test Int(_two_Test11) == 5
+@test Int(_three_Test11) == 6
+
 end # module


### PR DESCRIPTION
Minor fix to update the `@enum` macro to work for keyword arguments:

``` julia
@enum(Foo, bar=3, baz)
```

which makes it possible to write `Enums` with a large number of values.

Also export the abstract `Enum` type and throw a more specific `ArgumentError` for invalid `Enum` values.

cc @quinnj 
