### PR TITLE
test/perf/micro: Fix include problem caused by renaming of Rmath

### DIFF
--- a/test/perf/micro/Makefile
+++ b/test/perf/micro/Makefile
@@ -37,6 +37,7 @@ endif
 endif
 
 DSFMTDIR = $(JULIAHOME)/deps/dsfmt-$(DSFMT_VER)
+RMATHDIR = $(JULIAHOME)/deps/Rmath-julia-$(RMATH_JULIA_VER)
 
 default: benchmarks.html
 
@@ -47,6 +48,7 @@ export OPENBLAS_NUM_THREADS=1
 perf.h: $(JULIAHOME)/deps/Versions.make
 	echo '#include "$(BLASDIR)cblas.h"' > $@
 	echo '#include "$(DSFMTDIR)/dSFMT.c"' >> $@
+	echo '#include "$(RMATHDIR)/src/randmtzig.c"' >> $@
 
 bin/perf%: perf.c perf.h
 	$(CC) -std=c99 -O$* $< -o $@  -I$(DSFMTDIR) -L$(BLASDIR) $(LIBBLAS) -L$(LIBMDIR) $(LIBM) $(CFLAGS) -lpthread

--- a/test/perf/micro/perf.c
+++ b/test/perf/micro/perf.c
@@ -4,9 +4,6 @@
 #define DSFMT_MEXP 19937
 #include "perf.h"
 
-// include RNG code:
-#include "../../../deps/Rmath/src/randmtzig.c"
-
 double *myrand(int n) {
     double *d = (double *)malloc(n*sizeof(double));
     dsfmt_gv_fill_array_close_open(d, n);


### PR DESCRIPTION
Commit 8cf4e3dd3fe0b5e2d37e678e47699f1dba5ad94c renamed deps/Rmath to deps/Rmath-julia-version, breaking the build of C test. Fix it.
