### PR TITLE
Update `jldownload` to use the caching server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ before_install:
         brew tap staticfloat/julia;
         brew rm --force $(brew deps --HEAD julia);
         brew update;
-        sed -i '' -e "s@https://downloads.sf.net/project/machomebrew/Bottles@http://cache.e.ip.saba.us/https://downloads.sf.net/project/machomebrew/Bottles@" /usr/local/Library/Homebrew/software_spec.rb;
-        sed -i '' -e "s@https://homebrew.bintray.com@http://cache.e.ip.saba.us/https://homebrew.bintray.com@" /usr/local/Library/Homebrew/software_spec.rb;
+        sed -i '' -e "s@https://downloads.sf.net/project/machomebrew/Bottles@https://cache.e.ip.saba.us/https://downloads.sf.net/project/machomebrew/Bottles@" /usr/local/Library/Homebrew/software_spec.rb;
+        sed -i '' -e "s@https://homebrew.bintray.com@https://cache.e.ip.saba.us/https://homebrew.bintray.com@" /usr/local/Library/Homebrew/software_spec.rb;
         brew install -v --only-dependencies --HEAD julia;
         BUILDOPTS="USECLANG=1 LLVM_CONFIG=$(brew --prefix llvm33-julia)/bin/llvm-config-3.3 VERBOSE=1 USE_BLAS64=0 SUITESPARSE_INC=-I$(brew --prefix suite-sparse-julia)/include";
         BUILDOPTS="$BUILDOPTS LIBBLAS=-lopenblas LIBBLASNAME=libopenblas LIBLAPACK=-lopenblas LIBLAPACKNAME=libopenblas";

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1687,7 +1687,7 @@ compile-patchelf: install-patchelf
 install-patchelf: $(PATCHELF_TARGET)
 
 patchelf-$(PATCHELF_VER).tar.gz:
-	$(JLDOWNLOAD) $@ https://ia601003.us.archive.org/29/items/julialang/mirror/patchelf-$(PATCHELF_VER).tar.gz
+	$(JLDOWNLOAD) $@ http://nixos.org/releases/patchelf/patchelf-$(PATCHELF_VER)/patchelf-$(PATCHELF_VER).tar.gz
 patchelf-$(PATCHELF_VER)/configure: patchelf-$(PATCHELF_VER).tar.gz
 	$(JLCHECKSUM) $<
 	$(TAR) zxf $<

--- a/deps/jldownload
+++ b/deps/jldownload
@@ -3,7 +3,7 @@
 # usage: jldownload [<output-filename>] <url>
 #
 
-MIRROR_HOST=http://d304tytmzqn1fl.cloudfront.net
+CACHE_HOST=http://cache.e.ip.saba.us
 
 WGET=$(which wget 2>/dev/null)
 CURL=$(which curl 2>/dev/null)
@@ -26,8 +26,7 @@ else
     exit 1
 fi
 
-MIRROR_BASENAME=`basename $1`
-MIRROR_URL="$MIRROR_HOST/$MIRROR_BASENAME"
+CACHE_URL="$CACHE_HOST/$2"
 
 if [ -x "$CURL" ] && $CURL -V >/dev/null; then
     GETURL="$CURL $CURL_OPTS"
@@ -41,12 +40,8 @@ else
     exit 1
 fi
 
-if [ -z "$JLDOWNLOAD_PREFER_MIRROR" ]; then
-    $GETURL $URL || $GETURL $MIRROR_URL
-else
-    # Still try downloading from the original URL if the mirror fails.
-    # User may want to get around a single failure, only to run into a dep
-    # that we haven't mirrored yet, so better to be safe than sorry and try 
-    # the original URL in that case
-    $GETURL $MIRROR_URL || $GETURL $URL
-fi
+# Try to get from the cache if it is possible.  Note that the cache will
+# forward to the original URL if it has not cached this download yet, or
+# if the URL is not cacheable.  We fallback to directly querying the
+# uncached URL to protect against cache service downtime
+$GETURL $CACHE_URL || $GETURL $URL

--- a/deps/jldownload
+++ b/deps/jldownload
@@ -3,7 +3,7 @@
 # usage: jldownload [<output-filename>] <url>
 #
 
-CACHE_HOST=http://cache.e.ip.saba.us
+CACHE_HOST=https://cache.e.ip.saba.us
 
 WGET=$(which wget 2>/dev/null)
 CURL=$(which curl 2>/dev/null)


### PR DESCRIPTION
This change should stop us from having to worry about uploading tarballs to @nolta's aws mirror from now on.  The [caching server](https://github.com/staticfloat/cache.julialang.org/) transparently redirects users to either:
- The originally requested URL if the file has not been cached yet or is not cacheable.
- A cached URL on S3 if the file has been cached

The cached URLs are all of the form `https://juliacache.s3.amazonaws.com/<filename>`.  A file is cacheable if it conforms to [a list of regexes](https://github.com/staticfloat/cache.julialang.org/blob/8077495618ec0c0e711a7f0b5affe02a8ebb2c74/cache.py#L18-L45).  If a file is cacheable but has not been cached yet, the server redirects the client to the original URL, downloads the file in the background, uploads it to S3, and then redirects to the caching server from then on.

Note that this has the possibility of increasing our AWS traffic significantly.  I have no hard data on how much this would affect things, but it could be a lot.  I'd like to get input from @StefanKarpinski, @jiahao or @ViralBShah on whether this is actually a good idea or not.

In addition, it would be really nice to get this located at `cache.julialang.org` instead of `cache.e.ip.saba.us` as it currently is (a `CNAME` is fine, since my `e.ip.saba.us` domains are dynamic DNS which is useful) so that we can do https for everything.  This would just secure the original redirection, not the actual file downloads (those are already protected by AWS)
