### PR TITLE
julia-mode.el: Tell compiler that `julia--should-indent` is defined

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -426,6 +426,9 @@ before point. Returns nil if we're not within nested parens."
        (should (equal (buffer-substring-no-properties (point-min) (point-max))
                       ,to))))
 
+  ;; Tell the byte compiler that `julia--should-indent` is defined.
+  (declare-function julia--should-indent "julia-mode.el" (from to))
+
   (ert-deftest julia--test-indent-if ()
     "We should indent inside if bodies."
     (julia--should-indent


### PR DESCRIPTION
I just installed julia-mode via `M-x package-install`. After installing it, the `*Compile-Log*` buffer looks like this:

```
Compiling file /home/lkuper/.emacs.d/elpa/julia-mode-20150101.1747/julia-mode-pkg.el at Mon Feb 23 14:05:30 2015
Entering directory `/home/lkuper/.emacs.d/elpa/julia-mode-20150101.1747/'

Compiling file /home/lkuper/.emacs.d/elpa/julia-mode-20150101.1747/julia-mode.el at Mon Feb 23 14:05:30 2015
julia-mode.el:39:1:Warning: cl package required at runtime

In end of data:
julia-mode.el:3106:1:Warning: the function `julia--should-indent' is not known
    to be defined.
```

Not that these warnings are a big deal, but still, according to [the Emacs Lisp manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html) we can suppress the second warning with the appropriate `declare-function` statement, so that's what this patch does.

Thanks!
