### PR TITLE
Fix some edge cases with current enum macro

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -267,6 +267,7 @@ function isidentifier(s::AbstractString)
     end
     return true
 end
+isidentifier(s::Symbol) = isidentifier(string(s))
 
 isoperator(s::Symbol) = ccall(:jl_is_operator, Cint, (Ptr{UInt8},), s) != 0
 operator_precedence(s::Symbol) = int(ccall(:jl_operator_precedence,


### PR DESCRIPTION
- Widen `Enum` values and do not overflow by default.
- Throw `ArgumentError`'s for invalid `Enum` arguments.
- Check invalid arguments before code generation to prevent
  generation of invalid `Enum` types.

CC @quinnj 
