### PR TITLE
Error on duplicate values in declaration of`@enum`

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -50,10 +50,10 @@ macro enum(T,syms...)
             throw(ArgumentError(string("invalid argument for Enum ", T, ", ", s)))
         end
         if !isa(i, Integer) || !isbits(i)
-            throw(ArgumentError("Invalid value for Enum $T, $s=$i. Enum values must be integer bits types."))
+            throw(ArgumentError("invalid value for Enum $T, $s=$i. Enum values must be integer bits types."))
         end
         if !Base.isidentifier(s)
-            throw(ArgumentError("Invalid name for Enum $T, $s is not a valid identifier."))
+            throw(ArgumentError("invalid name for Enum $T, $s is not a valid identifier."))
         end
         push!(vals, (s,i))
         I = typeof(i)
@@ -61,7 +61,17 @@ macro enum(T,syms...)
         lo = min(lo, i)
         hi = max(hi, i)
     end
-    if !hasexpr
+    if hasexpr
+        seen = Dict{Integer,Symbol}()
+        for (sym,i) in vals
+            if haskey(seen, i)
+                i = convert(enumT,i)
+                throw(ArgumentError("@enum argument values must be unique, $(seen[i])=$i and $sym=$i"))
+            else
+                seen[i] = sym
+            end
+        end
+    else
         n = length(vals)
         enumT = n <= typemax(Int8) ? Int8 :
                 n <= typemax(Int16) ? Int16 :

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -160,4 +160,6 @@ end
 # we can't handle widening to BigInt's
 @test_throws ArgumentError eval(:(@enum(Test13, _zero_Test13=0xffffffffffffffffffffffffffffffff, _one_Test13)))
 
+# test for unique Enum values
+@test_throws ArgumentError eval(:(@enum(Test14, _zero_Test14, _one_Test14, _two_Test14=0)))
 end # module


### PR DESCRIPTION
This PR causes `@enum(Foo, bar, baz, bing=0)` to throw an `ArgumentError` as both `bing` and `bar` are mapped to the value `1`.

See discussion in  https://github.com/JuliaLang/julia/pull/10168.

cc @StefanKarpinski, @quinnj 
