### PR TITLE
Speeding up Pkg.publish()

### DIFF
--- a/base/pkg/resolve/versionweight.jl
+++ b/base/pkg/resolve/versionweight.jl
@@ -48,7 +48,6 @@ function Base.cmp{T}(a::HierarchicalValue{T}, b::HierarchicalValue{T})
     l0 = min(la, lb)
     l1 = max(la, lb)
     ld = la - lb
-    rv = Array(T, l1)
     @inbounds for i = 1:l0
         c = cmp(av[i], bv[i]); c != 0 && return c
     end


### PR DESCRIPTION
`Pkg.publish()` has gotten so slow it's in danger of becoming useless. For a long time I just assumed this was something that would be fixed by the transition to libgit, but today I did this:

``` julia
Profile.init(delay=0.01)    # avoid filling up the profile buffer
@profile Pkg.publish()
using ProfileView
ProfileView.view()
```

Much to my surprise, all (>90%) the time was spent inside `versionweight.jl`. (I should note that on my machine, some of the line numbers seem to be off by a few, so the profile is not quite as useful as one could hope. But at least it gets one in the right ballpark.)

The attached one-line patch shaves a full minute off the execution time for me:

```
Pre:
$ time julia -e "Pkg.publish()"
INFO: Validating METADATA
INFO: Pushing Winston permanent tags: v0.11.8
INFO: Submitting METADATA changes
INFO: Forking JuliaLang/METADATA.jl to timholy
INFO: Pushing changes as branch pull-request/84d9e630
INFO: To create a pull-request, open:

  https://github.com/timholy/METADATA.jl/compare/pull-request/84d9e630

real    4m26.361s
user    4m22.444s
sys     0m1.627s


Post:
$ time julia -e "Pkg.publish()"
INFO: Validating METADATA
INFO: Pushing Winston permanent tags: v0.11.8
INFO: Submitting METADATA changes
INFO: Forking JuliaLang/METADATA.jl to timholy
INFO: Pushing changes as branch pull-request/84d9e630
INFO: To create a pull-request, open:

  https://github.com/timholy/METADATA.jl/compare/pull-request/84d9e630

real    3m28.462s
user    3m24.587s
sys     0m1.504s
```

As far as I can tell, `versionweight` spends an almost all of its time amount of time allocating, destroying, adding, and subtracting arrays. I see two routes to optimization:
- Low level: AFAICT, almost all of these arrays are empty. Could we store a reusable pool of empty arrays, or reuse one of the inputs as an output when the inputs are empty? (This won't work if the arrays grow at some later point.)
- High level: it seems to cycle through every version of every package ever published and do some serious analysis for each potential stepwise upgrade. Is this necessary? (AFAICT it also _doesn't_ do things that I might find more useful, like check that I didn't forget to push the sha1 I just tagged to my repo.)

@StefanKarpinski, can you please take a look and see what can be done?
