### PR TITLE
RFC: Move Colon translation out of the parser

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -114,6 +114,11 @@ Language changes
     macro. Instead, the string is first unindented and then `x_str` is invoked,
     as if the string had been single-quoted ([#10228]).
 
+  * Colons (`:`) within indexing expressions are no longer lowered to the range
+    `1:end`. Instead, the `:` identifier is passed directly. Custom array types
+    that implement `getindex` or `setindex!` methods must also extend those
+    methods to support arguments of type `Colon` ([#10331]).
+
 Command line option changes
 ---------------------------
 
@@ -1422,6 +1427,7 @@ Too numerous to mention.
 [#10180]: https://github.com/JuliaLang/julia/issues/10180
 [#10228]: https://github.com/JuliaLang/julia/issues/10228
 [#10328]: https://github.com/JuliaLang/julia/issues/10328
+[#10331]: https://github.com/JuliaLang/julia/issues/10331
 [#10332]: https://github.com/JuliaLang/julia/issues/10332
 [#10333]: https://github.com/JuliaLang/julia/issues/10333
 [#10380]: https://github.com/JuliaLang/julia/issues/10380

--- a/base/array.jl
+++ b/base/array.jl
@@ -347,6 +347,20 @@ function setindex!(A::Array, X::AbstractArray, I::AbstractVector{Int})
     end
     return A
 end
+function setindex!(A::Array, x, ::Colon)
+    for i in 1:length(A)
+        @inbounds A[i] = x
+    end
+    return A
+end
+function setindex!(A::Array, X::AbstractArray, ::Colon)
+    setindex_shape_check(X, length(A))
+    i = 0
+    for x in X
+        @inbounds A[i+=1] = x
+    end
+    return A
+end
 
 # Faster contiguous setindex! with copy!
 setindex!{T}(A::Array{T}, X::Array{T}, I::UnitRange{Int}) = (checkbounds(A, I); unsafe_setindex!(A, X, I))
@@ -367,7 +381,6 @@ function unsafe_setindex!{T}(A::Array{T}, X::Array{T}, ::Colon)
     end
     return A
 end
-
 
 # efficiently grow an array
 

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -222,9 +222,10 @@ The general syntax for indexing into an n-dimensional array A is::
 where each ``I_k`` may be:
 
 1. A scalar integer
-2. A ``Range`` of the form ``:``, ``a:b``, or ``a:b:c``
-3. An arbitrary integer vector, including the empty vector ``[]``
-4. A boolean vector
+2. A ``Range`` of the form ``a:b``, or ``a:b:c``
+3. A ``:`` or ``Colon()`` to select entire dimensions
+4. An arbitrary integer vector, including the empty vector ``[]``
+5. A boolean vector
 
 The result ``X`` generally has dimensions
 ``(length(I_1), length(I_2), ..., length(I_n))``, with location
@@ -286,10 +287,11 @@ The general syntax for assigning values in an n-dimensional array A is::
 
 where each ``I_k`` may be:
 
-1. A scalar value
-2. A ``Range`` of the form ``:``, ``a:b``, or ``a:b:c``
-3. An arbitrary integer vector, including the empty vector ``[]``
-4. A boolean vector
+1. A scalar integer
+2. A ``Range`` of the form ``a:b``, or ``a:b:c``
+3. A ``:`` or ``Colon()`` to select entire dimensions
+4. An arbitrary integer vector, including the empty vector ``[]``
+5. A boolean vector
 
 If ``X`` is an array, its size must be ``(length(I_1), length(I_2), ..., length(I_n))``,
 and the value in location ``i_1, i_2, ..., i_n`` of ``A`` is overwritten with


### PR DESCRIPTION
This is a work ~~in progress~~ to move the translation of `[:]` out of the parser.  I've squashed-and-split @andreasnoack's ambitious work from #9150 to exclude the bigger change (returning views from indexing with UnitRanges) and just focus on indexing with `Colon`.  While this previously included the code that adapted base array types to accept `Colon()` as an index, that portion was broken out and subsumed by #10525.  This is now _only_ the parser change.

~~This is still a work-in-progress as it hasn't made it through the test suite yet.  Right now the blocker is in `getindex(::SubArray, ::Colon)`, which is a pretty gnarly piece of metaprogramming.  But I think it's pretty close.  Would you have a chance to look into it, @timholy?~~

~~This takes a cue from SubArray and doesn't even create a range for indexing into Array types, which is really cool.  In general, this approach will require all custom `AbstractArray` types to allow indexing with `Colon`.  We could define a fallback `getindex(::AbstractArray, ::Union(Real, AbstractArray, Colon)…)` to do the lowering step, but it's then a little tricky for custom types to define their indexing methods without ambiguities.~~
### Todo:
- [x] ~~SubArray getindex~~ (subsumed by #10525)
- [x] ~~SharedArray get/setindex!~~ (subsumed by #10525)
- [x] ~~Improve inference (#10341) and revert a733b1f~~ (subsumed by #10525)
- [x] ~~Decide if we need a deprecation/warning strategy for indexing custom AbstractArray types with `:`. _I don't think this is possible in a sensible manner._~~ Became non-breaking with #10525.

Fixes #9419.
