### PR TITLE
Deprecate `names` for composite types in favor of `fieldnames`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -195,6 +195,9 @@ Library improvements
 Deprecated or removed
 ---------------------
 
+  * `names` for composite datatypes has been deprecated and
+    renamed to `fieldnames` ([#10332]).
+
   * The `Graphics` module has been removed from `Base` and is now a
     standalone package ([#10150], [#9862]).
 

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -94,9 +94,9 @@ macro enum(T,syms...)
         Base.typemin{E<:$(esc(typename))}(x::Type{E}) = E($lo)
         Base.typemax{E<:$(esc(typename))}(x::Type{E}) = E($hi)
         Base.length{E<:$(esc(typename))}(x::Type{E}) = $(length(vals))
-        Base.names{E<:$(esc(typename))}(x::Type{E}) = [$(map(x->Meta.quot(x[1]), vals)...)]
         Base.next{E<:$(esc(typename))}(x::Type{E},s) = (E($values[s]),s+1)
         Base.done{E<:$(esc(typename))}(x::Type{E},s) = s > $(length(values))
+        Base.names{E<:$(esc(typename))}(x::Type{E}) = [$(map(x->Meta.quot(x[1]), vals)...)]
         function Base.print{E<:$(esc(typename))}(io::IO,x::E)
             for (sym, i) in $vals
                 if i == x.val

--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -44,7 +44,7 @@ function complete_symbol(sym, ffunc)
             end
         else
             # We're now looking for a type
-            fields = t.names
+            fields = fieldnames(t)
             found = false
             for i in 1:length(fields)
                 s == fields[i] || continue
@@ -79,7 +79,7 @@ function complete_symbol(sym, ffunc)
         end
     else
         # Looking for a member of a type
-        fields = t.names
+        fields = fieldnames(t)
         for field in fields
             s = string(field)
             if startswith(s, name)

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -27,17 +27,18 @@ function deepcopy_internal(x, stackdict::ObjectIdDict)
 end
 
 function _deepcopy_t(x, T::DataType, stackdict::ObjectIdDict)
-    isbits(T) | isempty(T.names) && return x
+    nf = nfields(T)
+    (isbits(T) || nf == 0) && return x
     if T.mutable
         y = ccall(:jl_new_struct_uninit, Any, (Any,), T)
         stackdict[x] = y
-        for i in 1:length(T.names)
+        for i in 1:nf
             if isdefined(x,i)
                 y.(i) = deepcopy_internal(x.(i), stackdict)
             end
         end
     else
-        fields = Any[deepcopy_internal(x.(i), stackdict) for i in 1:length(T.names)]
+        fields = Any[deepcopy_internal(x.(i), stackdict) for i in 1:nf]
         y = ccall(:jl_new_structv, Any, (Any, Ptr{Void}, UInt32),
                   T, pointer(fields), length(fields))
     end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -301,3 +301,6 @@ end
 # 8898
 @deprecate precision(x::DateTime) eps(x)
 @deprecate precision(x::Date) eps(x)
+
+@deprecate names(t::DataType) fieldnames(t)
+@deprecate names(v) fieldnames(v)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1073,6 +1073,7 @@ export
 # types
     convert,
     fieldoffsets,
+    fieldnames,
     isleaftype,
     oftype,
     promote,

--- a/base/help.jl
+++ b/base/help.jl
@@ -126,8 +126,9 @@ function help(io::IO, fname::AbstractString, obj=0)
                     println(io)
                 end
             end
-            if length(obj.names) > 0
-                println(io, "  fields   : ", obj.names)
+            fields = fieldnames(obj)
+            if !isempty(fields)
+                println(io, "  fields   : ", fields)
             end
         elseif isgeneric(obj)
             writemime(io, "text/plain", obj); println()

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -343,7 +343,7 @@ const getfield_tfunc = function (A, s0, name)
                 end
             end
         end
-        for i=1:length(s.names)
+        for i=1:nfields(s)
             if is(s.names[i],fld)
                 R = s.types[i]
                 if s.parameters === ()
@@ -360,7 +360,7 @@ const getfield_tfunc = function (A, s0, name)
             return Bottom
         end
         i::Int = A[2]
-        if i < 1 || i > length(s.names)
+        if i < 1 || i > nfields(s)
             return Bottom
         end
         return s.types[i]

--- a/base/markdown/Julia/interp.jl
+++ b/base/markdown/Julia/interp.jl
@@ -41,7 +41,7 @@ toexpr(xs::Vector{Any}) = Expr(:cell1d, map(toexpr, xs)...)
 
 function deftoexpr(T)
     @eval function toexpr(md::$T)
-        Expr(:call, typeof(md), $(map(x->:(toexpr(md.$x)), names(T))...))
+        Expr(:call, typeof(md), $(map(x->:(toexpr(md.$x)), fieldnames(T))...))
     end
 end
 

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -110,8 +110,8 @@ type WorkerConfig
     environ::Nullable{Dict}
 
     function WorkerConfig()
-        wc=new()
-        for n in names(WorkerConfig)
+        wc = new()
+        for n in fieldnames(WorkerConfig)
             T = eltype(fieldtype(WorkerConfig, n))
             setfield!(wc, n, Nullable{T}())
         end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -26,12 +26,12 @@ let implemented = IntSet()
         # Create the types
         indextype = symbol("CartesianIndex_$N")
         if !in(N,implemented)
-            fieldnames = [symbol("I_$i") for i = 1:N]
-            fields = [Expr(:(::), fieldnames[i], :Int) for i = 1:N]
+            fnames = [symbol("I_$i") for i = 1:N]
+            fields = [Expr(:(::), fnames[i], :Int) for i = 1:N]
             extype = Expr(:type, false, Expr(:(<:), indextype, Expr(:curly, :CartesianIndex, N)), Expr(:block, fields...))
             eval(extype)
-            argsleft = [Expr(:(::), fieldnames[i], :Real) for i = 1:N]
-            argsright = [Expr(:call,:to_index,fieldnames[i]) for i=1:N]
+            argsleft = [Expr(:(::), fnames[i], :Real) for i = 1:N]
+            argsright = [Expr(:call,:to_index,fnames[i]) for i=1:N]
             exconstructor = Expr(:(=),Expr(:call,:(Base.call),:(::Type{CartesianIndex{$N}}),argsleft...),Expr(:call,indextype,argsright...))
             eval(exconstructor)
             push!(implemented,N)

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -315,11 +315,12 @@ function serialize(s, x)
         return write_as_tag(s, x)
     end
     t = typeof(x)
+    nf = nfields(t)
     serialize_type(s, t)
-    if length(t.names)==0 && t.size>0
+    if nf == 0 && t.size > 0
         write(s, x)
     else
-        for i in 1:length(t.names)
+        for i in 1:nf
             if isdefined(x, i)
                 serialize(s, getfield(x, i))
             else
@@ -527,11 +528,11 @@ end
 
 # default DataType deserializer
 function deserialize(s, t::DataType)
-    if length(t.names)==0 && t.size>0
+    nf = nfields(t)
+    if nf == 0 && t.size > 0
         # bits type
         return read(s, t)
     end
-    nf = length(t.names)
     if nf == 0
         return ccall(:jl_new_struct, Any, (Any,Any...), t)
     elseif isbits(t)
@@ -552,7 +553,7 @@ function deserialize(s, t::DataType)
         end
     else
         x = ccall(:jl_new_struct_uninit, Any, (Any,), t)
-        for i in 1:length(t.names)
+        for i in 1:nf
             tag = int32(read(s, UInt8))
             if tag==0 || !is(deser_tag[tag], UndefRefTag)
                 ccall(:jl_set_nth_field, Void, (Any, Csize_t, Any), x, i-1, handle_deserialize(s, tag))

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -795,10 +795,14 @@ sparse(D::Dense)    = sparse(Sparse(D))
 
 # Calculate the offset into the stype field of the cholmod_sparse_struct and
 # change the value
-function change_stype!(A::Sparse, i::Integer)
-    offset = fieldoffsets(C_Sparse)[names(C_Sparse) .== :stype][1]
-    unsafe_store!(convert(Ptr{Cint}, A.p), i, div(offset, 4) + 1)
-    A
+let offidx=findfirst(fieldnames(C_Sparse) .== :stype)
+
+    global change_stype!
+    function change_stype!(A::Sparse, i::Integer)
+        offset = fieldoffsets(C_Sparse)[offidx]
+        unsafe_store!(convert(Ptr{Cint}, A.p), i, div(offset, 4) + 1)
+        return A
+    end
 end
 
 free!(A::Dense) = free_dense!(A.p)


### PR DESCRIPTION
Closes #10325.
