### PR TITLE
RFC: Activate IPv6 getaddrinfo, and return all addresses

### DIFF
--- a/test/socket.jl
+++ b/test/socket.jl
@@ -89,7 +89,7 @@ for T in (ASCIIString, UTF8String, UTF16String) # test for issue #9435
 end
 
 @test_throws Base.UVError getaddrinfo(".invalid")
-@test_throws Base.UVError connect("localhost", 21452)
+@test_throws Base.UVError connect("127.0.0.1", 21452)
 
 # test invalid port
 @test_throws ArgumentError connect(ip"127.0.0.1",-1)
@@ -108,7 +108,7 @@ close(server)
 wait(tsk)
 
 port, server = listenany(defaultport)
-@async connect("localhost",port)
+@async connect("127.0.0.1",port)
 s1 = accept(server)
 @test_throws ErrorException accept(server,s1)
 @test_throws Base.UVError listen(port)


### PR DESCRIPTION
ref #9892 

before:

```
julia> getaddrinfo("localhost")
ip"127.0.0.1"  #could be either IPv4 or IPv6 based on host OS, and OS settings
```

after:

```
julia> getaddrinfo("localhost")
2-element Array{Base.IPAddr,1}:
 ip"::1"
 ip"127.0.0.1"
```

This is the opposite of my suggestion last night. But, after some reading, I believe this is the expected behavior of this function on both POSIX and Windows. This would be a breaking change for functions that rely on the current behavior of `connect!`, which is to take whatever address the system provides first. I'm punting on changing all of that until I get some opinions on whether it is worth fixing the API now to fully support IPv6, or continuing to put it off until someone actually needs it. @vtjnash had some concerns about OS inconsistencies last night on IRC.

Could just do the minimum to fix the broken test in #9892 instead.

@vtjnash @amitmurthy @keno
