### PR TITLE
RFH (request for help): LLVM assertion

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -742,8 +742,17 @@ function abstract_call_gf(f, fargs, argtypes, e)
         # limit argument type tuple based on size of definition signature.
         # for example, given function f(T, Any...), limit to 3 arguments
         # instead of the default (MAX_TUPLETYPE_LEN)
+        sp = inference_stack
+        limit = false
+        # look at the stack to detect recursive calls with growing argument lists
+        while sp !== EmptyCallStack()
+            if linfo.ast === sp.ast && length(argtypes) > length(sp.types)
+                limit = true; break
+            end
+            sp = sp.prev
+        end
         ls = length(sig)
-        if ls > lsig+1 && !(isdefined(Main.Base,:promote_typeof) && f === Main.Base.promote_typeof)
+        if limit && ls > lsig+1 && !(isdefined(Main.Base,:promote_typeof) && f === Main.Base.promote_typeof)
             fst = sig[lsig+1]
             allsame = true
             # allow specializing on longer arglists if all the trailing


### PR DESCRIPTION
This change is intended to improve type inference in cases mentioned in #10331. However it fails at the start of the tests, when trying to load a system image without a sys.so:

```
cp usr/lib/julia/sys.ji local.ji
./julia -J local.ji

...

define %jl_value_t* @jlcall_typeinf_222(%jl_value_t*, %jl_value_t**, i32) {
top:
  %3 = getelementptr %jl_value_t** %1, i64 0
  %4 = load %jl_value_t** %3
  %5 = getelementptr %jl_value_t** %1, i64 1
  %6 = load %jl_value_t** %5
  %7 = getelementptr %jl_value_t** %1, i64 2
  %8 = load %jl_value_t** %7
  %9 = getelementptr %jl_value_t** %1, i64 3
  %10 = load %jl_value_t** %9
  %11 = getelementptr %jl_value_t** %1, i64 4
  %12 = load %jl_value_t** %11
  %13 = bitcast %jl_value_t* %12 to %jl_value_t**
  %14 = getelementptr %jl_value_t** %13, i64 1
  %15 = bitcast %jl_value_t** %14 to i8*
  %16 = load i8* %15
  %17 = trunc i8 %16 to i1
  %18 = call %jl_value_t* @julia_typeinf_222(%jl_value_t* %4, %jl_value_t* %6, %jl_value_t* %8, %jl_value_t* %10, i1 %17)
  ret %jl_value_t* %18
}

julia: /home/jeff/src/julia/deps/llvm-3.3/include/llvm/Support/Casting.h:97: static bool llvm::isa_impl_cl<To, const From*>::doit(const From*) [with To = llvm::BranchInst, From = llvm::TerminatorInst]: Assertion `Val && "isa<> used on a null pointer"' failed.
```

With sys.so, this doesn't happen. Stack trace:

```
#2  0x00007ffff621ba76 in __assert_fail_base (
    fmt=0x7ffff636d2b0 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", 
    assertion=assertion@entry=0x7ffff74d8160 "Val && \"isa<> used on a null pointer\"", 
    file=file@entry=0x7ffff74d8118 "/home/jeff/src/julia/deps/llvm-3.3/include/llvm/Support/Casting.h", line=line@entry=97, 
    function=function@entry=0x7ffff76e46c0 <_ZZN4llvm11isa_impl_clINS_10BranchInstEPKNS_14TerminatorInstEE4doitES4_E19__PRETTY_FUNCTION__> "static bool llvm::isa_impl_cl<To, const From*>::doit(const From*) [with To = llvm::BranchInst, From = llvm::TerminatorInst]") at assert.c:92
#3  0x00007ffff621bb22 in __GI___assert_fail (
    assertion=0x7ffff74d8160 "Val && \"isa<> used on a null pointer\"", 
    file=0x7ffff74d8118 "/home/jeff/src/julia/deps/llvm-3.3/include/llvm/Support/Casting.h", line=97, 
    function=0x7ffff76e46c0 <_ZZN4llvm11isa_impl_clINS_10BranchInstEPKNS_14TerminatorInstEE4doitES4_E19__PRETTY_FUNCTION__> "static bool llvm::isa_impl_cl<To, const From*>::doit(const From*) [with To = llvm::BranchInst, From = llvm::TerminatorInst]") at assert.c:101
#4  0x00007ffff68a0251 in llvm::enable_if<llvm::is_same<llvm::TerminatorInst, llvm::simplify_type<llvm::TerminatorInst>::SimpleType>, llvm::cast_retty<llvm::BranchInst, llvm::TerminatorInst*>::ret_type>::type llvm::dyn_cast<llvm::BranchInst, llvm::TerminatorInst>(llvm::TerminatorInst*) [clone .part.635] ()
   from /home/jeff/src/julia/usr/bin/../lib/libjulia-debug.so
#5  0x00007ffff6f97c5b in (anonymous namespace)::CodeGenPrepare::runOnFunction(llvm::Function&) () from /home/jeff/src/julia/usr/bin/../lib/libjulia-debug.so
---Type <return> to continue, or q <return> to quit---
#6  0x00007ffff73986ef in llvm::FPPassManager::runOnFunction(llvm::Function&)
    () from /home/jeff/src/julia/usr/bin/../lib/libjulia-debug.so
#7  0x00007ffff7398829 in llvm::FunctionPassManagerImpl::run(llvm::Function&)
    () from /home/jeff/src/julia/usr/bin/../lib/libjulia-debug.so
#8  0x00007ffff7398a2d in llvm::FunctionPassManager::run(llvm::Function&) ()
   from /home/jeff/src/julia/usr/bin/../lib/libjulia-debug.so
#9  0x00007ffff6d9742e in llvm::JIT::jitTheFunction(llvm::Function*, llvm::MutexGuard const&) () from /home/jeff/src/julia/usr/bin/../lib/libjulia-debug.so
#10 0x00007ffff6d97b4d in llvm::JIT::runJITOnFunctionUnlocked(llvm::Function*, llvm::MutexGuard const&) ()
   from /home/jeff/src/julia/usr/bin/../lib/libjulia-debug.so
#11 0x00007ffff6d97df7 in llvm::JIT::getPointerToFunction(llvm::Function*) ()
   from /home/jeff/src/julia/usr/bin/../lib/libjulia-debug.so
#12 0x00007ffff68f6031 in jl_generate_fptr (f=0x7ffdf49595e0)
    at codegen.cpp:705
#13 0x00007ffff68e6dcf in jl_trampoline_compile_function (f=0x7ffdf49595e0, 
    always_infer=0, sig=0x7ffdf39e4000) at builtins.c:920
#14 0x00007ffff68e6ee8 in jl_trampoline (F=0x7ffdf49595e0, 
    args=0x7fffffff43e8, nargs=5) at builtins.c:931
```

I'm not sure what's going on. I could use some help debugging this (cc @vtjnash, @keno).
