### PR TITLE
Fix the tab completion of paths containing `\t\n`

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -130,7 +130,7 @@ function complete_path(path::AbstractString, pos)
             push!(matches, id ? file * (@windows? "\\\\" : "/") : file)
         end
     end
-    matches = UTF8String[replace(s, r"\s", "\\ ") for s in matches]
+    matches = UTF8String[replace(s, r"\s", whitespace_escape) for s in matches]
     return matches, nextind(path, pos - sizeof(prefix) - length(matchall(r" ", prefix))):pos, length(matches) > 0
 end
 
@@ -232,6 +232,8 @@ include("latex_symbols.jl")
 
 const non_identifier_chars = [" \t\n\r\"\\'`\$><=:;|&{}()[],+-*/?%^~"...]
 const whitespace_chars = [" \t\n\r"...]
+whitespace_escape(s) = "\\"*s
+whitespace_unescape(s) = s[2:end]
 
 # Aux function to detect whether we're right after a
 # using or import keyword
@@ -272,10 +274,10 @@ function completions(string, pos)
         m = match(r"[\t\n\r\"'`@\$><=;|&\{]| (?!\\)", reverse(partial))
         startpos = nextind(partial, reverseind(partial, m.offset))
         r = startpos:pos
-        paths, r, success = complete_path(replace(string[r], r"\\ ", " "), pos)
+        paths, r, success = complete_path(replace(string[r], r"\\\s", whitespace_unescape), pos)
         if inc_tag == :string &&
            length(paths) == 1 &&                              # Only close if there's a single choice,
-           !isdir(replace(string[startpos:start(r)-1] * paths[1], r"\\ ", " ")) &&  # except if it's a directory
+           !isdir(replace(string[startpos:start(r)-1] * paths[1], r"\\\s", whitespace_unescape)) &&  # except if it's a directory
            (length(string) <= pos || string[pos+1] != '"')    # or there's already a " at the cursor.
             paths[1] *= "\""
         end

--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -271,7 +271,7 @@ function completions(string, pos)
     partial = string[1:pos]
     inc_tag = Base.incomplete_tag(parse(partial , raise=false))
     if inc_tag in [:cmd, :string]
-        m = match(r"[\t\n\r\"'`@\$><=;|&\{]| (?!\\)", reverse(partial))
+        m = match(r"[\"'`@\$><=;|&\{]|[\t\n\r ](?!\\)", reverse(partial))
         startpos = nextind(partial, reverseind(partial, m.offset))
         r = startpos:pos
         paths, r, success = complete_path(replace(string[r], r"\\\s", whitespace_unescape), pos)

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -343,24 +343,26 @@ end
 
 let #test that it can auto complete with spaces in file/path
     path = tempdir()
-    space_folder = randstring() * " α"
-    dir = joinpath(path, space_folder)
-    dir_space = replace(space_folder, " ", "\\ ")
-    mkdir(dir)
-    cd(path) do
-        open(joinpath(space_folder, "space .file"),"w") do f
-            s = @windows? "rm $dir_space\\\\space" : "cd $dir_space/space"
-            c,r = test_scomplete(s)
-            @test r == endof(s)-4:endof(s)
-            @test "space\\ .file" in c
+    for whitspace in @windows? [" "] : [" ","\t","\n"]
+        space_folder = randstring() * "$(whitspace)α"
+        dir = joinpath(path, space_folder)
+        dir_space = replace(space_folder, "$(whitspace)", "\\$(whitspace)")
+        mkdir(dir)
+        cd(path) do
+            open(joinpath(space_folder, "space$(whitspace).file"),"w") do f
+                s = @windows? "rm $dir_space\\\\space" : "cd $dir_space/space"
+                c,r = test_scomplete(s)
+                @test r == endof(s)-4:endof(s)
+                @test "space\\$(whitspace).file" in c
 
-            s = @windows? "cd(\"β $dir_space\\\\space" : "cd(\"β $dir_space/space"
-            c,r = test_complete(s)
-            @test r == endof(s)-4:endof(s)
-            @test "space\\ .file\"" in c
+                s = @windows? "cd(\"β $dir_space\\\\space" : "cd(\"β $dir_space/space"
+                c,r = test_complete(s)
+                @test r == endof(s)-4:endof(s)
+                @test "space\\$(whitspace).file\"" in c
+            end
         end
+        rm(dir, recursive=true)
     end
-    rm(dir, recursive=true)
 end
 
 @windows_only begin


### PR DESCRIPTION
This is my fix to the issue with path completion for paths containing `\t\n` discussed in #10336.
