### PR TITLE
Fix #10222.

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -946,30 +946,40 @@ end
 const escape_defaults = merge!(
     AnyDict([char(i) => nothing for i=vcat(1:26, 28:31)]), # Ignore control characters by default
     AnyDict( # And ignore other escape sequences by default
-    "\e*" => nothing,
-    "\e[*" => nothing,
-    "\eO*" => nothing,
-    # Also ignore extended escape sequences
-    # TODO: Support ranges of characters
-    "\e[1**" => nothing,
-    "\e[2**" => nothing,
-    "\e[3**" => nothing,
-    "\e[4**" => nothing,
-    "\e[5**" => nothing,
-    "\e[6**" => nothing,
-    # These are different spellings of arrow keys, home keys, etc.
-    # and should always do the same as the canonical key sequence
-    "\e[1~" => KeyAlias("\e[H"),
-    "\e[4~" => KeyAlias("\e[F"),
-    "\e[7~" => KeyAlias("\e[H"),
-    "\e[8~" => KeyAlias("\e[F"),
-    "\eOA"  => KeyAlias("\e[A"),
-    "\eOB"  => KeyAlias("\e[B"),
-    "\eOC"  => KeyAlias("\e[C"),
-    "\eOD"  => KeyAlias("\e[D"),
-    "\eOH"  => KeyAlias("\e[H"),
-    "\eOF"  => KeyAlias("\e[F"),
-))
+        "\e*" => nothing,
+        "\e[*" => nothing,
+        "\eO*" => nothing,
+        # Also ignore extended escape sequences
+        # TODO: Support ranges of characters
+        "\e[1**" => nothing,
+        "\e[2**" => nothing,
+        "\e[3**" => nothing,
+        "\e[4**" => nothing,
+        "\e[5**" => nothing,
+        "\e[6**" => nothing,
+        # less commonly used VT220 editing keys
+        "\e[2~" => nothing, # insert
+        "\e[3~" => nothing, # delete
+        "\e[5~" => nothing, # page up
+        "\e[6~" => nothing, # page down
+        # These are different spellings of arrow keys, home keys, etc.
+        # and should always do the same as the canonical key sequence
+        "\e[1~" => KeyAlias("\e[H"), # home
+        "\e[4~" => KeyAlias("\e[F"), # end
+        "\e[7~" => KeyAlias("\e[H"), # home
+        "\e[8~" => KeyAlias("\e[F"), # end
+        "\eOA"  => KeyAlias("\e[A"),
+        "\eOB"  => KeyAlias("\e[B"),
+        "\eOC"  => KeyAlias("\e[C"),
+        "\eOD"  => KeyAlias("\e[D"),
+        "\eOH"  => KeyAlias("\e[H"),
+        "\eOF"  => KeyAlias("\e[F"),
+    ),
+    # set mode commands
+    AnyDict(["\e[$(c)h" => nothing for c in 1:20]),
+    # reset mode commands
+    AnyDict(["\e[$(c)l" => nothing for c in 1:20])
+    )
 
 function write_response_buffer(s::PromptState, data)
     offset = s.input_buffer.ptr
@@ -1416,31 +1426,32 @@ const history_keymap = AnyDict(
     "\e[6~" => (s,o...)->(history_next(s, mode(s).hist))
 )
 
-const prefix_history_keymap = AnyDict(
-    # Up Arrow
-    "\e[A" => (s,data,c)->history_prev_prefix(data, data.histprompt.hp, data.prefix),
-    # Down Arrow
-    "\e[B" => (s,data,c)->history_next_prefix(data, data.histprompt.hp, data.prefix),
-    # by default, pass thru to the parent mode
-    "*"    => (s,data,c)->begin
-        accept_result(s, data.histprompt);
-        ps = state(s, mode(s))
-        map = keymap(ps, mode(s))
-        match_input(map, s, IOBuffer(c))(s, keymap_data(ps, mode(s)))
-    end,
-    # match escape sequences for pass thru
-    "\e*" => "*",
-    "\e[*" => "*",
-    "\eO*"  => "*",
-    "\e[1~" => "*",
-    "\e[3~" => "*",
-    "\e[4~" => "*",
-    "\e[5~" => "*",
-    "\e[6~" => "*",
-    "\e[7~" => "*",
-    "\e[8~" => "*",
-    "\e[1;5*" => "*", # Ctrl-Arrow
-    "\e[200~" => "*"
+const prefix_history_keymap = merge!(
+    AnyDict(
+        # Up Arrow
+        "\e[A" => (s,data,c)->history_prev_prefix(data, data.histprompt.hp, data.prefix),
+        # Down Arrow
+        "\e[B" => (s,data,c)->history_next_prefix(data, data.histprompt.hp, data.prefix),
+        # by default, pass thru to the parent mode
+        "*"    => (s,data,c)->begin
+            accept_result(s, data.histprompt);
+            ps = state(s, mode(s))
+            map = keymap(ps, mode(s))
+            match_input(map, s, IOBuffer(c))(s, keymap_data(ps, mode(s)))
+        end,
+        # match escape sequences for pass thru
+        "\e*" => "*",
+        "\e[*" => "*",
+        "\eO*"  => "*",
+        "\e[1;5*" => "*", # Ctrl-Arrow
+        "\e[200~" => "*"
+    ),
+    # VT220 editing commands
+    AnyDict(["\e[$(n)~" => "*" for n in 1:8]),
+    # set mode commands
+    AnyDict(["\e[$(c)h" => "*" for c in 1:20]),
+    # reset mode commands
+    AnyDict(["\e[$(c)l" => "*" for c in 1:20])
 )
 
 function setup_prefix_keymap(hp, parent_prompt)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -89,6 +89,24 @@ readuntil(stdout_read, "\n")
 @test pwd() == homedir()
 rm(tmpdir)
 cd(origpwd)
+
+# Issue #10222
+# Test ignoring insert key in standard and prefix search modes
+write(stdin_write, "\e[2h\e[2h\n") # insert (VT100-style)
+@test search(readline(stdout_read), "[2h") == 0:-1
+readline(stdout_read)
+write(stdin_write, "\e[2~\e[2~\n") # insert (VT220-style)
+@test search(readline(stdout_read), "[2~") == 0:-1
+readline(stdout_read)
+write(stdin_write, "1+1\n") # populate history with a trivial input
+readline(stdout_read)
+write(stdin_write, "\e[A\e[2h\n") # up arrow, insert (VT100-style)
+readline(stdout_read)
+readline(stdout_read)
+write(stdin_write, "\e[A\e[2~\n") # up arrow, insert (VT220-style)
+readline(stdout_read)
+readline(stdout_read)
+
 # Close REPL ^D
 write(stdin_write, '\x04')
 wait(repltask)


### PR DESCRIPTION
Add terminal mode changes to `escape_defaults`. Catches things like pressing the
insert key on some terminal emulators.

@flpf please confirm that this fixes the reported issue.
