### PR TITLE
Bugfix for building with LLVM35: ObjectInfo.slide is only for LLVM36

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -809,7 +809,11 @@ int jl_get_llvmf_info(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
     if (fit != objmap.end()) {
         *symsize = fit->second.size;
         *object = fit->second.object;
+#ifdef LLVM36
         *slide = fit->second.slide;
+#else
+        *slide = 0;
+#endif
         return 1;
     }
     return 0;


### PR DESCRIPTION
According to these lines: https://github.com/JuliaLang/julia/blob/master/src/debuginfo.cpp#L77, field `slide` is only present when `LLVM36` is defined, so line 814 breaks the building for other LLVM versions.
