### PR TITLE
Make ishermitian and issym test for approx. symmetry for floats. fix #10298

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -7211,9 +7211,9 @@ Given `@osx? a : b`, do `a` on OS X and `b` elsewhere. See documentation for Han
 :@osx
 
 doc"""
-    ishermitian(A) -> Bool
+    ishermitian(A; tol=eps(eltype(real(A)))*norm(A,1)) -> Bool
 
-Test whether a matrix is Hermitian.
+Test whether a matrix is Hermitian. The `tol` keyword is only used for matrices of floating point or `Complex{T<:AbstractFloat}` numbers, where it tests `norm(A - A', Inf) < tol*norm(A,Inf)`.
 """
 ishermitian
 
@@ -7345,9 +7345,9 @@ The arguments to a function or constructor are outside the valid domain.
 DomainError
 
 doc"""
-    issym(A) -> Bool
+    issym(A; tol=eps(eltype(real(A)))*norm(A,1)) -> Bool
 
-Test whether a matrix is symmetric.
+Test whether a matrix is symmetric. The `tol` keyword is only used for matrices of floating point or `Complex{T<:AbstractFloat}` numbers, where it tests `norm(A - A', Inf) < tol*norm(A,Inf)`.
 """
 issym
 

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -105,6 +105,10 @@ function triu(A::Symmetric, k::Integer=0)
     end
 end
 
+#Test whether a matrix is positive-definite
+isposdef!(A::HermOrSym) = isposdef!(A.data, symbol(A.uplo))
+isposdef{T}(A::HermOrSym{T}) = (S = typeof(sqrt(one(T))); isposdef!(S == T ? copy(A.data) : convert(AbstractMatrix{S}, A.data), symbol(A.uplo)))
+
 ## Matvec
 A_mul_B!{T<:BlasFloat,S<:StridedMatrix}(y::StridedVector{T}, A::Symmetric{T,S}, x::StridedVector{T}) = BLAS.symv!(A.uplo, one(T), A.data, x, zero(T), y)
 A_mul_B!{T<:BlasComplex,S<:StridedMatrix}(y::StridedVector{T}, A::Hermitian{T,S}, x::StridedVector{T}) = BLAS.hemv!(A.uplo, one(T), A.data, x, zero(T), y)

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -209,3 +209,25 @@ let A = [1.0+im 2.0; 2.0 0.0]
     @test !ishermitian(A)
     @test_throws ArgumentError Hermitian(A)
 end
+
+# Tests for #10298
+for elT in [Float32, Float64]
+    A1 = ones(elT,10,10)
+    A = convert(Array{Complex{elT}}, A1)
+    A[end,1] = Complex{elT}(nextfloat((A[end,1].re)), A[end,1].im)
+    @test issym(A)
+    A = A + triu(A1)im - tril(A1)im
+    @test ishermitian(A)
+
+    D=diagm(rand(100))*100
+    D[end,1] = nextfloat((D[end,1]))
+
+    for HOrS in [Hermitian, Symmetric]
+        @test isposdef(HOrS(D))
+        @test isposdef!(copy(HOrS(D)))
+    end
+    @test ishermitian(D)
+    @test issym(D)
+    @test isposdef(D)
+end
+


### PR DESCRIPTION
This fixes JuliaLang/LinearAlgebra.jl#182. 
I do not know if the `atol,rtol` keywords should be used on `isapprox` and how they should be determined for the matrix in `issym` and `ishermitian`.
@andreasnoack would you give this a thorough review, since I am not familiar with this part of base.
