### PR TITLE
Fixes error: undefined reference to `JL_PRINTF' see: https://github.com/...

### DIFF
--- a/contrib/build_executable.jl
+++ b/contrib/build_executable.jl
@@ -216,7 +216,7 @@ function emit_cmain(cfile, exename, relocation)
             if (jl_exception_occurred())
             {
                 jl_show(jl_stderr_obj(), jl_exception_occurred());
-                JL_PRINTF(jl_stderr_stream(), \"\\n\");
+                jl_printf(jl_stderr_stream(), \"\\n\");
                 ret = 1;
             }
 


### PR DESCRIPTION
...JuliaLang/julia/issues/10371

Fixes https://github.com/JuliaLang/julia/issues/10371

seems that some time ago `JL_PRINTF' was removed and`DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...);` is used instead

Cheers
P
