### PR TITLE
Misc LLVM 3.6.0 fixes

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -232,26 +232,20 @@ LLVM_TAR=llvm-$(LLVM_VER).src.tar.xz
 endif
 
 ifeq ($(BUILD_LLDB),1)
-ifeq ($(LLVM_VER), 3.5.0)
-LLVM_LLDB_TAR=lldb-$(LLVM_VER).src.tar.xz
-else
+ifeq ($(LLVM_VER), 3.3)
 LLVM_LLDB_TAR=lldb-$(LLVM_VER).src.tar.gz
-endif # LLVM_VER == 3.5.0
+else
+LLVM_LLDB_TAR=lldb-$(LLVM_VER).src.tar.xz
+endif # LLVM_VER == 3.3
 endif # BUILD_LLDB
 
 ifeq ($(BUILD_LLVM_CLANG),1)
-ifeq ($(LLVM_VER), 3.0)
-LLVM_CLANG_TAR=clang-$(LLVM_VER).tar.gz
-LLVM_COMPILER_RT_TAR=
-else ifeq ($(LLVM_VER), 3.3)
+ifeq ($(LLVM_VER), 3.3)
 LLVM_CLANG_TAR=cfe-$(LLVM_VER).src.tar.gz
 LLVM_COMPILER_RT_TAR=compiler-rt-$(LLVM_VER).src.tar.gz
-else ifeq ($(LLVM_VER), 3.5.0)
+else
 LLVM_CLANG_TAR=cfe-$(LLVM_VER).src.tar.xz
 LLVM_COMPILER_RT_TAR=compiler-rt-$(LLVM_VER).src.tar.xz
-else
-LLVM_CLANG_TAR=clang-$(LLVM_VER).src.tar.gz
-LLVM_COMPILER_RT_TAR=compiler-rt-$(LLVM_VER).src.tar.gz
 endif # LLVM_VER
 else
 LLVM_CLANG_TAR=

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -633,9 +633,7 @@ void jl_getDylibFunctionInfo(const char **name, size_t *line, const char **filen
 #endif
 #endif // ifdef _OS_DARWIN_
             if (errorobj) {
-#if LLVM36 && defined(_OS_WINDOWS_)
-                obj = errorobj.get().release();
-#elif LLVM36
+#if LLVM36
                 auto binary = errorobj.get().takeBinary();
                 obj = binary.first.release();
                 binary.second.release();


### PR DESCRIPTION
Switch direction of ifeqs in deps/Makefile, since 3.5.0, 3.5.1, and 3.6.0 all come as .tar.xz files. 3.3 is the only still-important version we need to worry about that comes as .tar.gz, I think.

Something changed in LLVM between December and now, https://github.com/JuliaLang/julia/commit/1f4ea2bb19eed22b9cf19c7c9b552ccb1fac12aa apparently needs to be reverted to build against 3.6.0 release on Windows. cc @ihnorton
