### PR TITLE
Explicitly qualify the library in ccall to uv_cwd as libjulia

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -3,7 +3,7 @@
 function pwd()
     b = Array(UInt8,1024)
     len = Csize_t[length(b),]
-    uv_error(:getcwd, ccall(:uv_cwd, Cint, (Ptr{UInt8}, Ptr{Csize_t}), b, len))
+    uv_error(:getcwd, ccall((:uv_cwd,"libjulia"), Cint, (Ptr{UInt8}, Ptr{Csize_t}), b, len))
     bytestring(b[1:len[1]-1])
 end
 


### PR DESCRIPTION
Yet another conflict between 2 libuv libraries that implement _cwd_ differently, and though this affects me in particular, if there were ever another possibility, this would be the correct option because base.pwd() assumes the behavior supplied by libjulia's version.
