### PR TITLE
Faster Pkg.Publish()

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -314,9 +314,7 @@ function publish(branch::AbstractString)
     ahead_remote > 0 && error("METADATA is behind origin/$branch – run `Pkg.update()` before publishing")
     ahead_local == 0 && error("There are no METADATA changes to publish")
 
-    info("Validating METADATA")
-    check_metadata()
-    tags = Dict{ASCIIString,Vector{ASCIIString}}()
+    tags = Dict{ByteString,Vector{ASCIIString}}()
     Git.run(`update-index -q --really-refresh`, dir="METADATA")
     cmd = `diff --name-only --diff-filter=AMR origin/$branch HEAD --`
     for line in eachline(Git.cmd(cmd, dir="METADATA"))
@@ -337,6 +335,8 @@ function publish(branch::AbstractString)
         end || error("$pkg v$ver is incorrectly tagged – $sha1 expected")
     end
     isempty(tags) && info("No new package versions to publish")
+    info("Validating METADATA")
+    check_metadata(Set(keys(tags)))
     @sync for pkg in sort!([keys(tags)...])
         @async begin
             forced = ASCIIString[]
@@ -585,7 +585,7 @@ function tag(pkg::AbstractString, ver::Union(Symbol,VersionNumber), force::Bool=
     end
 end
 
-function check_metadata()
+function check_metadata(pkgs::Set{ByteString} = Set{ByteString}())
     avail = Read.available()
     deps, conflicts = Query.dependencies(avail)
 
@@ -593,7 +593,7 @@ function check_metadata()
         haskey(deps, p) || error("package $dp v$v requires a non-registered package: $p")
     end
 
-    problematic = Resolve.sanity_check(deps)
+    problematic = Resolve.sanity_check(deps, pkgs)
     if !isempty(problematic)
         msg = "packages with unsatisfiable requirements found:\n"
         for (p, vn, rp) in problematic

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -44,7 +44,9 @@ function resolve(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber,Availa
 end
 
 # Scan dependencies for (explicit or implicit) contradictions
-function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}})
+function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs::Set{ByteString} = Set{ByteString}())
+
+    isempty(pkgs) || (deps = Query.undirected_dependencies_subset(deps, pkgs))
 
     deps, eq_classes = Query.prune_versions(deps)
 


### PR DESCRIPTION
First step at dealing with #10323 issues. Restricts checking to potentially affected packages.
Unfortunately, it doesn't help as much as I hoped, since the (undirected) dependency graph basically percolates through Compat. Needs more smartness; it's a start though.

@StefanKarpinski: I moved the check later in `Pkg.publish`, I think it should be ok, but please check.
