### PR TITLE
Force push! and unshift! to need at least one item

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -197,6 +197,8 @@ Library improvements
 Deprecated or removed
 ---------------------
 
+  * `push!(A)` has been deprecated, use `append!` instead of splatting arguments to `push!` ([#10400]).
+
   * `names` for composite datatypes has been deprecated and
     renamed to `fieldnames` ([#10332]).
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1453,10 +1453,8 @@ end
 
 # multi-item push!, unshift! (built on top of type-specific 1-item version)
 # (note: must not cause a dispatch loop when 1-item case is not defined)
-push!(A) = A
 push!(A, a, b) = push!(push!(A, a), b)
 push!(A, a, b, c...) = push!(push!(A, a, b), c...)
-unshift!(A) = A
 unshift!(A, a, b) = unshift!(unshift!(A, b), a)
 unshift!(A, a, b, c...) = unshift!(unshift!(A, c...), a, b)
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -307,3 +307,8 @@ end
 
 @deprecate names(t::DataType) fieldnames(t)
 @deprecate names(v) fieldnames(v)
+
+function push!(A)
+    depwarn("push!(A) has been deprecated", :push!)
+    A
+end

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -800,7 +800,7 @@ Dequeues
 
 .. function:: push!(collection, items...) -> collection
 
-   Insert zero or more ``items`` at the end of ``collection``.
+   Insert one or more ``items`` at the end of ``collection``.
 
    .. doctest::
 
@@ -846,7 +846,7 @@ Dequeues
 
 .. function:: unshift!(collection, items...) -> collection
 
-   Insert zero or more ``items`` at the beginning of ``collection``.
+   Insert one or more ``items`` at the beginning of ``collection``.
 
    .. doctest::
 


### PR DESCRIPTION
Is there any reason for this fallback (I'm guessing to support splatting of potentially zero arguments)?  Otherwise it can be a source of subtle bugs.

cc @andreasnoack 
