### PR TITLE
fix a bug in code that restores the prompt on ^C

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -39,6 +39,8 @@ type REPLBackend
     ans
 end
 
+in_eval = false
+
 function eval_user_input(ast::ANY, backend::REPLBackend)
     iserr, lasterr, bt = false, (), nothing
     while true
@@ -51,7 +53,9 @@ function eval_user_input(ast::ANY, backend::REPLBackend)
                 # note: value wrapped in a non-syntax value to avoid evaluating
                 # possibly-invalid syntax (issue #6763).
                 eval(Main, :(ans = $(Any[ans])[1]))
+                global in_eval = true
                 value = eval(Main, ast)
+                in_eval = false
                 backend.ans = value
                 put!(backend.response_channel, (value, nothing))
             end

--- a/base/task.jl
+++ b/base/task.jl
@@ -94,7 +94,7 @@ function task_done_hook(t::Task)
     else
         if err && !handled
             if isa(result,InterruptException) && isdefined(REPL,:interactive_task) &&
-                REPL.interactive_task.state == :waiting && isempty(Workqueue)
+                REPL.interactive_task.state == :waiting && isempty(Workqueue) && REPL.in_eval
                 throwto(REPL.interactive_task, result)
             end
             let bt = catch_backtrace()


### PR DESCRIPTION
While fixing #10405 I noticed a bug in the mechanism that gives control back to the REPL on ^C:

```
julia> T = @schedule sleep(100000)
Task (waiting) @0x00007fa4c77f51e0

julia> S = @schedule wait(T)
Task (waiting) @0x00007fa4c77f5600

julia> schedule(T, InterruptException(),error=true)
ERROR (unhandled task failure): InterruptException:
 in wait at ./task.jl:304
 in wait at ./task.jl:220
 in wait_full at ./multi.jl:567
 in take! at ./multi.jl:739
 in take_ref at ./multi.jl:746
 in call_on_owner at ./multi.jl:712
 in anonymous at task.jl:82
Task (failed) @0x00007fa4c77f51e0

julia> 1+2

```

and the REPL is dead and never comes back. The problem is that when task S dies (as expected), it sees the REPL is "waiting" and so throws the error to it. But the REPL is actually waiting for the backend channel (I think) and not for something that should be interrupted.

My fix is to only throw the error to the REPL if the REPL is in the middle of evaluating something. This patch works but is clearly pretty hacky. Would like to figure out the right way to do this. cc @Keno 
