### PR TITLE
Greedy solver for Pkg (speeds up Pkg.publish)

### DIFF
--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -157,7 +157,7 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
     # For each package, we examine the dependencies of its versions
     # and put together those which are equal.
     # While we're at it, we also collect all dependencies into alldeps
-    alldeps = Set{(ByteString,VersionSet)}()
+    alldeps = Dict{ByteString,Set{VersionSet}}()
     for (p, fdepsp) in filtered_deps
 
         # Extract unique dependencies lists (aka classes), thereby
@@ -165,8 +165,9 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
         uniqdepssets = unique(values(fdepsp))
 
         # Store all dependencies seen so far for later use
-        for a in uniqdepssets, r in a.requires
-            push!(alldeps, r)
+        for a in uniqdepssets, (rp,rvs) in a.requires
+            haskey(alldeps, rp) || (alldeps[rp] = Set{VersionSet}())
+            push!(alldeps[rp], rvs)
         end
 
         # If the package has just one version, it's uninteresting
@@ -191,7 +192,7 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
     end
 
     # Produce dependency patterns.
-    for (p,vs) in alldeps
+    for (p,vss) in alldeps, vs in vss
         # packages with just one version, or dependencies
         # which do not distiguish between versions, are not
         # interesting

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -11,33 +11,36 @@ export resolve, sanity_check
 # Use the max-sum algorithm to resolve packages dependencies
 function resolve(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber,Available}})
 
-    # init structures
+    # init interface structures
     interface = Interface(reqs, deps)
 
-    graph = Graph(interface)
-    msgs = Messages(interface, graph)
+    # attempt trivial solution first
+    ok, sol = greedysolver(interface)
+    if !ok
+        # trivial solution failed, use maxsum solver
+        graph = Graph(interface)
+        msgs = Messages(interface, graph)
 
-    # find solution
-    local sol::Vector{Int}
-    try
-        sol = maxsum(graph, msgs)
-    catch err
-        if isa(err, UnsatError)
-            p = interface.pkgs[err.info]
-            msg = "unsatisfiable package requirements detected: " *
-                  "no feasible version could be found for package: $p"
-            if msgs.num_nondecimated != graph.np
-                msg *= "\n  (you may try increasing the value of the" *
-                       "\n   JULIA_PKGRESOLVE_ACCURACY environment variable)"
+        try
+            sol = maxsum(graph, msgs)
+        catch err
+            if isa(err, UnsatError)
+                p = interface.pkgs[err.info]
+                msg = "unsatisfiable package requirements detected: " *
+                      "no feasible version could be found for package: $p"
+                if msgs.num_nondecimated != graph.np
+                    msg *= "\n  (you may try increasing the value of the" *
+                           "\n   JULIA_PKGRESOLVE_ACCURACY environment variable)"
+                end
+                error(msg)
             end
-            error(msg)
+            rethrow(err)
         end
-        rethrow(err)
-    end
 
-    # verify solution (debug code) and enforce its optimality
-    verify_solution(sol, interface)
-    enforce_optimality!(sol, interface)
+        # verify solution (debug code) and enforce its optimality
+        @assert verify_solution(sol, interface)
+        enforce_optimality!(sol, interface)
+    end
 
     # return the solution as a Dict mapping package_name => sha1
     return compute_output_dict(sol, interface)
@@ -90,18 +93,28 @@ function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs
 
         interface = Interface(sub_reqs, sub_deps)
 
-        graph = Graph(interface)
-        msgs = Messages(interface, graph)
-
         red_pkgs = interface.pkgs
         red_np = interface.np
         red_spp = interface.spp
         red_pvers = interface.pvers
 
-        local sol::Vector{Int}
-        try
-            sol = maxsum(graph, msgs)
-            verify_solution(sol, interface)
+        ok, sol = greedysolver(interface)
+        if !ok
+            try
+                graph = Graph(interface)
+                msgs = Messages(interface, graph)
+                sol = maxsum(graph, msgs)
+                ok = verify_solution(sol, interface)
+                @assert ok
+            catch err
+                isa(err, UnsatError) || rethrow(err)
+                pp = red_pkgs[err.info]
+                for vneq in eq_classes[p][vn]
+                    push!(problematic, (p, vneq, pp))
+                end
+            end
+        end
+        if ok
             let
                 p0 = interface.pdict[p]
                 svn = red_pvers[p0][sol[p0]]
@@ -116,12 +129,6 @@ function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs
                 end
             end
             checked[i] = true
-        catch err
-            isa(err, UnsatError) || rethrow(err)
-            pp = red_pkgs[err.info]
-            for vneq in eq_classes[p][vn]
-                push!(problematic, (p, vneq, pp))
-            end
         end
         i += 1
     end

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -89,8 +89,7 @@ function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs
         end
 
         sub_reqs = Dict{ByteString,VersionSet}(p=>VersionSet([vn, nvn]))
-        sub_deps = Query.prune_dependencies(sub_reqs, deps)
-
+        sub_deps = Query.filter_dependencies(sub_reqs, deps)
         interface = Interface(sub_reqs, sub_deps)
 
         red_pkgs = interface.pkgs
@@ -99,6 +98,7 @@ function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs
         red_pvers = interface.pvers
 
         ok, sol = greedysolver(interface)
+
         if !ok
             try
                 graph = Graph(interface)

--- a/base/pkg/resolve/interface.jl
+++ b/base/pkg/resolve/interface.jl
@@ -2,7 +2,7 @@ module PkgToMaxSumInterface
 
 using ...Types, ...Query, ..VersionWeights
 
-export Interface, compute_output_dict,
+export Interface, compute_output_dict, greedysolver,
        verify_solution, enforce_optimality!
 
 # A collection of objects which allow interfacing external (Pkg) and
@@ -116,6 +116,69 @@ function compute_output_dict(sol::Vector{Int}, interface::Interface)
     return want
 end
 
+# Produce a trivial solution: try to maximize each version;
+# bail out as soon as some non-trivial requirements are detected.
+function greedysolver(interface::Interface)
+    reqs = interface.reqs
+    deps = interface.deps
+    spp = interface.spp
+    pdict = interface.pdict
+    pvers = interface.pvers
+    np = interface.np
+
+    # initialize solution: all uninstalled
+    sol = [spp[p0] for p0 = 1:np]
+
+    # we start from required packages and explore the graph
+    # following dependencies
+    staged = Set{ByteString}(keys(reqs))
+    seen = copy(staged)
+
+    while !isempty(staged)
+        staged_next = Set{ByteString}()
+        for p in staged
+            p0 = pdict[p]
+            # set the package state to installed in case it wasn't
+            # (the latter case should only happen for required packages, and
+            # in then we use the maximum available version)
+            sol[p0] = min(sol[p0], spp[p0] - 1)
+            vn = pvers[p0][sol[p0]]
+            a = deps[p][vn]
+
+            # scan dependencies
+            for (rp,rvs) in a.requires
+                rp0 = pdict[rp]
+                # look for the highest version which satisfies the requirements
+                rv = spp[rp0] - 1
+                while rv > 0
+                    rvn = pvers[rp0][rv]
+                    rvn in rvs && break
+                    rv -= 1
+                end
+                # if we found a version, and the package was uninstalled
+                # or the same version was already selected, we're ok;
+                # otherwise we can't be sure what the optimal configuration is
+                # and we bail out
+                if rv > 0 && (sol[rp0] == spp[rp0] || sol[rp0] == rv)
+                    sol[rp0] = rv
+                else
+                    return (false, Int[])
+                end
+
+                if !(rp in seen)
+                    push!(staged_next, rp)
+                end
+            end
+        end
+        union!(seen, staged_next)
+        staged = staged_next
+    end
+
+    @assert verify_solution(sol, interface)
+
+    return true, sol
+end
+
 # verifies that the solution fulfills all hard constraints
 # (requirements and dependencies)
 function verify_solution(sol::Vector{Int}, interface::Interface)
@@ -130,9 +193,9 @@ function verify_solution(sol::Vector{Int}, interface::Interface)
     # verify requirements
     for (p,vs) in reqs
         p0 = pdict[p]
-        @assert sol[p0] != spp[p0]
+        sol[p0] != spp[p0] || return false
         vn = pvers[p0][sol[p0]]
-        @assert in(vn, vs)
+        vn in vs || return false
     end
 
     # verify dependencies
@@ -144,14 +207,14 @@ function verify_solution(sol::Vector{Int}, interface::Interface)
             if sol[p0] == v0
                 for (rp, rvs) in a.requires
                     p1 = pdict[rp]
-                    @assert sol[p1] != spp[p1]
+                    sol[p1] != spp[p1] || return false
                     vn = pvers[p1][sol[p1]]
-                    @assert in(vn, rvs)
+                    vn in rvs || return false
                 end
             end
         end
     end
-
+    return true
 end
 
 # Push the given solution to a local optimium if needed

--- a/base/pkg/resolve/interface.jl
+++ b/base/pkg/resolve/interface.jl
@@ -130,6 +130,20 @@ function greedysolver(interface::Interface)
     # initialize solution: all uninstalled
     sol = [spp[p0] for p0 = 1:np]
 
+    # set up required packages to their highest allowed versions
+    for (rp,rvs) in reqs
+        rp0 = pdict[rp]
+        # look for the highest version which satisfies the requirements
+        rv = spp[rp0] - 1
+        while rv > 0
+            rvn = pvers[rp0][rv]
+            rvn in rvs && break
+            rv -= 1
+        end
+        @assert rv > 0
+        sol[rp0] = rv
+    end
+
     # we start from required packages and explore the graph
     # following dependencies
     staged = Set{ByteString}(keys(reqs))
@@ -139,10 +153,7 @@ function greedysolver(interface::Interface)
         staged_next = Set{ByteString}()
         for p in staged
             p0 = pdict[p]
-            # set the package state to installed in case it wasn't
-            # (the latter case should only happen for required packages, and
-            # in then we use the maximum available version)
-            sol[p0] = min(sol[p0], spp[p0] - 1)
+            @assert sol[p0] < spp[p0]
             vn = pvers[p0][sol[p0]]
             a = deps[p][vn]
 

--- a/base/pkg/resolve/interface.jl
+++ b/base/pkg/resolve/interface.jl
@@ -69,9 +69,10 @@ type Interface
         for (p,depsp) in deps
             p0 = pdict[p]
             vdict0 = vdict[p0]
+            pvers0 = pvers[p0]
             for vn in keys(depsp)
-                for v0 in 1:length(pvers[p0])
-                    if pvers[p0][v0] == vn
+                for v0 in 1:length(pvers0)
+                    if pvers0[v0] == vn
                         vdict0[vn] = v0
                         break
                     end


### PR DESCRIPTION
Still tackling #10323.
This implements a greedy algorithm which tries to find a trivial solution to the Pkg constrained optimization problem, and resorts to the previous max-sum implementation as soon as it detects some non-trivial requirements.
On my machine, `sanity_check` takes 10s now, compared to 108s at the time #10323 was opened (and 30s before this commit).

Submitting as a PR for testing.
