### PR TITLE
SparseMatrixCSC checks for negative dimensions and fixes for maximum and minimum

### DIFF
--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -323,7 +323,7 @@ function triu{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti}, k::Integer)
     end
     rowval = Array(Ti, nnz)
     nzval = Array(Tv, nnz)
-    A = SparseMatrixCSC{Tv,Ti}(m, n, colptr, rowval, nzval)
+    A = SparseMatrixCSC(m, n, colptr, rowval, nzval)
     for col = max(k+1,1) : n
         c1 = S.colptr[col]
         for c2 = A.colptr[col] : A.colptr[col+1]-1
@@ -353,7 +353,7 @@ function tril{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti}, k::Integer)
     end
     rowval = Array(Ti, nnz)
     nzval = Array(Tv, nnz)
-    A = SparseMatrixCSC{Tv,Ti}(m, n, colptr, rowval, nzval)
+    A = SparseMatrixCSC(m, n, colptr, rowval, nzval)
     for col = 1 : min(n, m+k)
         c1 = S.colptr[col+1]-1
         l2 = A.colptr[col+1]-1
@@ -370,7 +370,7 @@ end
 
 function sparse_diff1{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
     m,n = size(S)
-    m > 1 || return SparseMatrixCSC{Tv,Ti}(0, n, ones(n+1), Ti[], Tv[])
+    m > 1 || return SparseMatrixCSC(0, n, ones(Ti,n+1), Ti[], Tv[])
     colptr = Array(Ti, n+1)
     numnz = 2 * nnz(S) # upper bound; will shrink later
     rowval = Array(Ti, numnz)
@@ -405,7 +405,7 @@ function sparse_diff1{Tv,Ti}(S::SparseMatrixCSC{Tv,Ti})
     end
     deleteat!(rowval, numnz+1:length(rowval))
     deleteat!(nzval, numnz+1:length(nzval))
-    return SparseMatrixCSC{Tv,Ti}(m-1, n, colptr, rowval, nzval)
+    return SparseMatrixCSC(m-1, n, colptr, rowval, nzval)
 end
 
 function sparse_diff2{Tv,Ti}(a::SparseMatrixCSC{Tv,Ti})
@@ -425,7 +425,7 @@ function sparse_diff2{Tv,Ti}(a::SparseMatrixCSC{Tv,Ti})
     ptrS = 1
     colptr[1] = 1
 
-    n == 0 && return SparseMatrixCSC{Tv,Ti}(m, n, colptr, rowval, nzval)
+    n == 0 && return SparseMatrixCSC(m, n, colptr, rowval, nzval)
 
     startA = colptr_a[1]
     stopA = colptr_a[2]
@@ -495,7 +495,7 @@ function sparse_diff2{Tv,Ti}(a::SparseMatrixCSC{Tv,Ti})
     end
     deleteat!(rowval, ptrS:length(rowval))
     deleteat!(nzval, ptrS:length(nzval))
-    return SparseMatrixCSC{Tv,Ti}(m, n-1, colptr, rowval, nzval)
+    return SparseMatrixCSC(m, n-1, colptr, rowval, nzval)
 end
 
 diff(a::SparseMatrixCSC, dim::Integer)= dim==1 ? sparse_diff1(a) : sparse_diff2(a)

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -695,3 +695,14 @@ for T in (Int, Float16, Float32, Float64, BigInt, BigFloat)
         @test abs2(S) == abs2(D)
     end
 end
+
+# issue #10407
+@test maximum(spzeros(5, 5)) == 0.0
+@test minimum(spzeros(5, 5)) == 0.0
+
+# issue #10411
+for (m,n) in ((2,-2),(-2,2),(-2,-2))
+    @test_throws ArgumentError spzeros(m,n)
+    @test_throws ArgumentError speye(m,n)
+    @test_throws ArgumentError sprand(m,n,0.2)
+end


### PR DESCRIPTION
- Refactored sparse matrix constructor and added check for dimensions. Also added dimensions check to `spzeros` and `sprand` (fixes #10411)
- Added `nnz` check to `maximum` and `minimum` (fixes #10407)
