### PR TITLE
real,imag,abs,abs2 for sparse matrices of complex numbers

### DIFF
--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -682,3 +682,16 @@ end
 
 # issue #9917
 @test sparse([]') == reshape(sparse([]), 1, 0)
+
+for T in (Int, Float16, Float32, Float64, BigInt, BigFloat)
+    let R=rand(T[1:100;],2,2), I=rand(T[1:100;],2,2)
+        D = R + I*im
+        S = sparse(D)
+        @test R == real(S)
+        @test I == imag(S)
+        @test real(sparse(R)) == R
+        @test nnz(imag(sparse(R))) == 0
+        @test abs(S) == abs(D)
+        @test abs2(S) == abs2(D)
+    end
+end


### PR DESCRIPTION
Added `real` and `imag`. fixes #10412
Added `abs` and `abs2` for of sparse matrices of complex numbers.
