### PR TITLE
int16 conversion instead of int8

### DIFF
--- a/test/perf/kernel/raytracer.jl
+++ b/test/perf/kernel/raytracer.jl
@@ -131,7 +131,7 @@ function Raytracer(levels, n, ss)
                     g += ray_trace(light, ray, scene);
                 end
             end
-            # write(f, int8(0.5 + 255. * g / (ss*ss)))
+            # write(f, int16(0.5 + 255. * g / (ss*ss)))
         end
     end
     # close(f)


### PR DESCRIPTION
On my Mac (OSX 10.9.5) if I test the raytracer by writing to a file, it fails with: ERROR: InexactError(). Changing to convert to int16 fixes it. Not sure if this needed here, but just thought I would mention if it helps. Feel free to close this PR and implement it differently as a comment or something.
