### PR TITLE
Deprecate flipud() and fliplr() in favor of flipdim()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -244,6 +244,9 @@ Deprecated or removed
   * The operators `|>`, `.>`, `>>`, and `.>>` as used for process I/O redirection
     are replaced with the `pipe` function ([#5349]).
 
+  * `flipud(A)` and `fliplr(A)` have been deprecated in favor of `flipdim(A, 1)` and
+    `flipdim(A, 2)`, respectively ([#10446]).
+
 Julia v0.3.0 Release Notes
 ==========================
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -463,9 +463,6 @@ function flipdim(A::AbstractArray, d::Integer)
     return B
 end
 
-flipud(A::AbstractArray) = flipdim(A, 1)
-fliplr(A::AbstractArray) = flipdim(A, 2)
-
 circshift(a::AbstractArray, shiftamt::Real) = circshift(a, [Integer(shiftamt)])
 function circshift{T,N}(a::AbstractArray{T,N}, shiftamts)
     I = ()

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -417,6 +417,9 @@ for (f,t) in ((:float32, Float32), (:float64, Float64))
     end
 end
 
+@deprecate flipud(A::AbstractArray) flipdim(A, 1)
+@deprecate fliplr(A::AbstractArray) flipdim(A, 2)
+
 # 0.4 discontinued functions
 
 @noinline function subtypetree(x::DataType, level=-1)

--- a/base/dsp.jl
+++ b/base/dsp.jl
@@ -163,7 +163,7 @@ function xcorr(u, v)
     elseif sv < su
         v = [v;zeros(eltype(v),su-sv)]
     end
-    flipud(conv(flipud(u), v))
+    flipdim(conv(flipdim(u, 1), v), 1)
 end
 
 fftshift(x) = circshift(x, div([size(x)...],2))

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -519,8 +519,6 @@ export
     findnz,
     first,
     flipdim,
-    fliplr,
-    flipud,
     gradient,
     hcat,
     hvcat,

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -267,14 +267,6 @@ Indexing, Assignment, and Concatenation
 
    Reverse ``A`` in dimension ``d``.
 
-.. function:: flipud(A)
-
-   Equivalent to ``flipdim(A,1)``.
-
-.. function:: fliplr(A)
-
-   Equivalent to ``flipdim(A,2)``.
-
 .. function:: circshift(A,shifts)
 
    Circularly shift the data in an array. The second argument is a vector giving the amount to shift in each dimension.


### PR DESCRIPTION
We do not provide other convenience functions for any other
operation, like size(), and these names are obscure for
non-MATLAB users.

I found only one use of `flipud` in base, and none of `fliplr`.

BTW, I discovered something weird: if I call `flipud` first in the Julia session, calls to `fliplr` do not trigger a deprecation warning; if I call the latter first, the reverse is true. Is that expected?
