### PR TITLE
Fix various details about strings in docs

### DIFF
--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -392,6 +392,7 @@ but leaves expressions alone::
     julia> eval(ex)
     42
 
+.. _man-macros:
 
 Macros
 ------
@@ -728,8 +729,6 @@ following macro sets ``x`` to zero in the call environment::
 This kind of manipulation of variables should be used judiciously, but
 is occasionally quite handy.
 
-.. _man-non-standard-string-literals2:
-
 Code Generation
 ---------------
 
@@ -780,10 +779,10 @@ cause a compile-time error:
     julia> $a + b
     ERROR: unsupported or misplaced expression $
 
-.. _man-macros:
+.. _man-non-standard-string-literals2:
 
-Non-Standard AbstractString Literals
-------------------------------------
+Non-Standard String Literals
+----------------------------
 
 Recall from :ref:`Strings <man-non-standard-string-literals>` that
 string literals prefixed by an identifier are called non-standard string

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -183,10 +183,10 @@ You can do comparisons and a limited amount of arithmetic with
     julia> 'A' + 1
     'B'
 
-:obj:`AbstractString` Basics
-----------------------------
+String Basics
+-------------
 
-:obj:`AbstractString` literals are delimited by double quotes or triple double quotes:
+String literals are delimited by double quotes or triple double quotes:
 
 .. doctest::
 
@@ -544,8 +544,8 @@ Some other useful functions include:
 
 .. _man-non-standard-string-literals:
 
-Non-Standard AbstractString Literals
-------------------------------------
+Non-Standard String Literals
+----------------------------
 
 There are situations when you want to construct a string or use string
 semantics, but the behavior of the standard string construct is not

--- a/doc/stdlib/c.rst
+++ b/doc/stdlib/c.rst
@@ -6,7 +6,7 @@
 
 .. function:: ccall((symbol, library) or fptr, RetType, (ArgType1, ...), ArgVar1, ...)
 
-   Call function in C-exported shared library, specified by ``(function name, library)`` tuple, where each component is a AbstractString or :Symbol. Alternatively,
+   Call function in C-exported shared library, specified by ``(function name, library)`` tuple, where each component is an ``AbstractString`` or ``Symbol``. Alternatively,
    ccall may be used to call a function pointer returned by dlsym, but note that this usage is generally discouraged to facilitate future static compilation.
    Note that the argument type tuple must be a literal tuple, and not a tuple-valued variable or expression.
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -539,23 +539,23 @@ Julia environments (such as the IPython-based IJulia notebook).
 
 .. function:: reprmime(mime, x)
 
-   Returns a ``AbstractString`` or ``Vector{UInt8}`` containing the
+   Returns an ``AbstractString`` or ``Vector{UInt8}`` containing the
    representation of ``x`` in the requested ``mime`` type, as written
    by ``writemime`` (throwing a ``MethodError`` if no appropriate
-   ``writemime`` is available).  A ``AbstractString`` is returned for MIME
+   ``writemime`` is available).  An ``AbstractString`` is returned for MIME
    types with textual representations (such as ``"text/html"`` or
    ``"application/postscript"``), whereas binary data is returned as
    ``Vector{UInt8}``.  (The function ``istext(mime)`` returns whether
    or not Julia treats a given ``mime`` type as text.)
 
-   As a special case, if ``x`` is a ``AbstractString`` (for textual MIME types)
+   As a special case, if ``x`` is an ``AbstractString`` (for textual MIME types)
    or a ``Vector{UInt8}`` (for binary MIME types), the ``reprmime`` function
    assumes that ``x`` is already in the requested ``mime`` format and
    simply returns ``x``.
 
 .. function:: stringmime(mime, x)
 
-   Returns a ``AbstractString`` containing the representation of ``x`` in the
+   Returns an ``AbstractString`` containing the representation of ``x`` in the
    requested ``mime`` type.  This is similar to ``reprmime`` except
    that binary data is base64-encoded as an ASCII string.
 

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -335,13 +335,13 @@ General Number Functions and Constants
 
 .. function:: BigInt(x)
 
-   Create an arbitrary precision integer. ``x`` may be an ``Int`` (or anything that can be converted to an ``Int``) or a ``AbstractString``.
+   Create an arbitrary precision integer. ``x`` may be an ``Int`` (or anything that can be converted to an ``Int``) or an ``AbstractString``.
    The usual mathematical operators are defined for this type, and results are promoted to a ``BigInt``.
 
 .. function:: BigFloat(x)
 
    Create an arbitrary precision floating point number. ``x`` may be
-   an ``Integer``, a ``Float64``, a ``AbstractString`` or a ``BigInt``. The
+   an ``Integer``, a ``Float64``, an ``AbstractString`` or a ``BigInt``. The
    usual mathematical operators are defined for this type, and results
    are promoted to a ``BigFloat``. Note that because floating-point
    numbers are not exactly-representable in decimal notation,


### PR DESCRIPTION
The references obviously did not point to the correct place.
Also fix a few syntax errors coming from the mass replacement
in 5a25360.

[av-skip]
