### PR TITLE
Replace RemoteRef in loading.jl with a (Bool, Condition)

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -59,7 +59,8 @@ end
 function _require(path)
     global toplevel_load
     if haskey(package_list,path)
-        wait(package_locks[path])
+        loaded, c = package_locks[path]
+        !loaded && wait(c)
     else
         last = toplevel_load
         toplevel_load = false
@@ -143,7 +144,7 @@ end
 function reload_path(path::AbstractString)
     had = haskey(package_list, path)
     if !had
-        package_locks[path] = RemoteRef()
+        package_locks[path] = (false, Condition())
     end
     package_list[path] = time()
     tls = task_local_storage()
@@ -158,8 +159,10 @@ function reload_path(path::AbstractString)
             tls[:SOURCE_PATH] = prev
         end
     end
-    if !isready(package_locks[path])
-        put!(package_locks[path],nothing)
+    reloaded, c = package_locks[path]
+    if !reloaded
+        package_locks[path] = (true, c)
+        notify(c, all=true)
     end
     nothing
 end


### PR DESCRIPTION
A bit of unfinished work from https://github.com/JuliaLang/julia/pull/10419  

This is to avoid a chicken-and-egg situation that comes up with creating RemoteRef's before a process has been initialized as a worker. RemoteRef's need the a correct local pid and a worker receives its pid as part of the first message from the master process.  The situation occurs when a custom transport has been implemented in a package, and the package needs to be loaded for the connection setup.
