### PR TITLE
markdown support all 6 headers (title/section/subsections) in terminal

### DIFF
--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -39,14 +39,26 @@ function term(io::IO, md::List, columns)
 end
 
 function term(io::IO, md::Header{1}, columns)
-    _term_header(io, md, '=', columns)
+    _term_header(io, md, '#', columns)
 end
 
 function term(io::IO, md::Header{2}, columns)
-    _term_header(io, md, '–', columns)
+    _term_header(io, md, '=', columns)
 end
 
 function term(io::IO, md::Header{3}, columns)
+    _term_header(io, md, '–', columns)
+end
+
+function term(io::IO, md::Header{4}, columns)
+    _term_header(io, md, '*', columns)
+end
+
+function term(io::IO, md::Header{5}, columns)
+    _term_header(io, md, '~', columns)
+end
+
+function term(io::IO, md::Header{6}, columns)
     _term_header(io, md, '-', columns)
 end
 


### PR DESCRIPTION
Suggestion to support all 6 headers (title/section/subsections) like most 
others e.g. `github supports all 6 headers`
# Fast Fourier Transform
## Fast Fourier Transform
### Fast Fourier Transform
#### Fast Fourier Transform
##### Fast Fourier Transform
###### Fast Fourier Transform

Example code:

```
using Base.Markdown

md"""
# Fast Fourier Transform
## Fast Fourier Transform
### Fast Fourier Transform
#### Fast Fourier Transform
##### Fast Fourier Transform
###### Fast Fourier Transform
"""


OUTPUT

     Fast Fourier Transform
    ########################

     Fast Fourier Transform
    ========================

     Fast Fourier Transform
    ––––––––––––––––––––––––

     Fast Fourier Transform
    ************************

     Fast Fourier Transform
    ~~~~~~~~~~~~~~~~~~~~~~~~

     Fast Fourier Transform
    ------------------------

```
