### PR TITLE
Deprecate conversion to Int for "non-obvious" index types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -203,6 +203,8 @@ Library improvements
 Deprecated or removed
 ---------------------
 
+  * indexing with Reals that are not subtypes of Integers (Rationals, FloatingPoint, etc.) has been deprecated ([#10458]).
+
   * `push!(A)` has been deprecated, use `append!` instead of splatting arguments to `push!` ([#10400]).
 
   * `names` for composite datatypes has been deprecated and

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -451,3 +451,26 @@ function push!(A)
     depwarn("push!(A) has been deprecated", :push!)
     A
 end
+
+# 10458
+to_index_nodep(i::Real) = convert(Int,i)::Int
+
+function to_index(i::Real)
+    depwarn("indexing with non Integer Reals is deprecated", :to_index)
+    to_index_nodep(i)
+end
+
+function to_index{T<:Real}(r::UnitRange{T})
+    depwarn("indexing with non Integer UnitRanges is deprecated", :to_index)
+    to_index_nodep(first(r)):to_index_nodep(last(r))
+end
+
+function to_index{T<:Real}(r::StepRange{T})
+    depwarn("indexing with non Integer StepRanges is deprecated", :to_index)
+    to_index_nodep(first(r)):to_index_nodep(step(r)):to_index_nodep(last(r))
+end
+
+function to_index{T<:Real}(A::AbstractArray{T})
+    depwarn("indexing with non Integer AbstractArrays is deprecated", :to_index)
+    Int[to_index_nodep(x) for x in A]
+end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -301,16 +301,16 @@ end
 
 # convert to integer index
 to_index(i::Int) = i
-to_index(i::Real) = convert(Int,i)::Int
+to_index(i::Integer) = convert(Int,i)::Int
 to_index(r::UnitRange{Int}) = r
 to_index(r::Range{Int}) = r
 to_index(I::UnitRange{Bool}) = find(I)
 to_index(I::Range{Bool}) = find(I)
-to_index{T<:Real}(r::UnitRange{T}) = to_index(first(r)):to_index(last(r))
-to_index{T<:Real}(r::StepRange{T}) = to_index(first(r)):to_index(step(r)):to_index(last(r))
+to_index{T<:Integer}(r::UnitRange{T}) = to_index(first(r)):to_index(last(r))
+to_index{T<:Integer}(r::StepRange{T}) = to_index(first(r)):to_index(step(r)):to_index(last(r))
 to_index(I::AbstractArray{Bool}) = find(I)
 to_index(A::AbstractArray{Int}) = A
-to_index{T<:Real}(A::AbstractArray{T}) = [to_index(x) for x in A]
+to_index{T<:Integer}(A::AbstractArray{T}) = [to_index(x) for x in A]
 to_index(i1, i2)         = to_index(i1), to_index(i2)
 to_index(i1, i2, i3)     = to_index(i1), to_index(i2), to_index(i3)
 to_index(i1, i2, i3, i4) = to_index(i1), to_index(i2), to_index(i3), to_index(i4)

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -120,7 +120,7 @@ function match(re::Regex, str::UTF8String, idx::Integer, add_opts::Int32=Int32(0
     if !PCRE.exec(re.regex, re.extra, str, idx-1, opts, re.ovec)
         return nothing
     end
-    n = length(re.ovec)/3 - 1
+    n = div(length(re.ovec),3) - 1
     mat = SubString(str, re.ovec[1]+1, re.ovec[2])
     cap = Union(Void,SubString{UTF8String})[
             re.ovec[2i+1] < 0 ? nothing : SubString(str, re.ovec[2i+1]+1, re.ovec[2i+2]) for i=1:n ]

--- a/doc/manual/arrays.rst
+++ b/doc/manual/arrays.rst
@@ -220,7 +220,7 @@ The general syntax for indexing into an n-dimensional array A is::
 
 where each I\_k may be:
 
-1. A scalar value
+1. A scalar integer
 2. A ``Range`` of the form ``:``, ``a:b``, or ``a:b:c``
 3. An arbitrary integer vector, including the empty vector ``[]``
 4. A boolean vector

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -893,11 +893,6 @@ function pr8622()
 end
 @test pr8622() == [0,3,1,0]
 
-# commit b718cbc72e90, getindex(::Number, ::Real)
-b718cbc = 5
-@test b718cbc[1.0] == 5
-@test_throws InexactError b718cbc[1.1]
-
 #6828 - size of specific dimensions
 a = Array(Float64, 10)
 @test size(a) == (10,)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -83,7 +83,6 @@ for (sz,T) in allsizes
     @check_bit_operation getindex(b1)         Bool
     @check_bit_operation setindex!(b1, true)  T
     @check_bit_operation setindex!(b1, false) T
-    @check_bit_operation setindex!(b1, 1.0)  T
 end
 
 # linear
@@ -93,7 +92,6 @@ for (sz,T) in allsizes[2:end]
     for j = 1:l
         @check_bit_operation getindex(b1, j) Bool
     end
-    @check_bit_operation getindex(b1, 100.0) Bool
 
     for j in [0, 1, 63, 64, 65, 127, 128, 129, 191, 192, 193, l-1, l]
         @check_bit_operation getindex(b1, 1:j)   BitVector
@@ -103,23 +101,17 @@ for (sz,T) in allsizes[2:end]
         m1 = j:(l-j)
         @check_bit_operation getindex(b1, m1) BitVector
     end
-    @check_bit_operation getindex(b1, 1.0:100.0) BitVector
 
     t1 = find(bitrand(l))
     @check_bit_operation getindex(b1, t1)        BitVector
-    @check_bit_operation getindex(b1, float(t1)) BitVector
 
     for j = 1:l
         x = rand(Bool)
         @check_bit_operation setindex!(b1, x, j) T
     end
 
-    x = rand(Bool)
-    @check_bit_operation setindex!(b1, x, 100.0) T
     y = rand(0.0:1.0)
     @check_bit_operation setindex!(b1, y, 100) T
-    y = rand(0.0:1.0)
-    @check_bit_operation setindex!(b1, y, 100.0) T
 
     for j in [1, 63, 64, 65, 127, 128, 129, 191, 192, 193, l-1]
         x = rand(Bool)
@@ -139,16 +131,12 @@ for (sz,T) in allsizes[2:end]
         @check_bit_operation setindex!(b1, b2, m1) T
     end
     x = rand(Bool)
-    @check_bit_operation setindex!(b1, x, 1.0:100.0) T
+    @check_bit_operation setindex!(b1, x, 1:100) T
     b2 = bitrand(100)
-    @check_bit_operation setindex!(b1, b2, 1.0:100.0) T
+    @check_bit_operation setindex!(b1, b2, 1:100) T
 
     y = rand(0.0:1.0)
     @check_bit_operation setindex!(b1, y, 1:100) T
-    f2 = float(bitrand(100))
-    @check_bit_operation setindex!(b1, f2, 1:100) T
-    f2 = float(bitrand(100))
-    @check_bit_operation setindex!(b1, f2, 1.0:100.0) T
 
     t1 = find(bitrand(l))
     x = rand(Bool)
@@ -158,19 +146,6 @@ for (sz,T) in allsizes[2:end]
 
     y = rand(0.0:1.0)
     @check_bit_operation setindex!(b1, y, t1) T
-    f2 = float(bitrand(length(t1)))
-    @check_bit_operation setindex!(b1, f2, t1) T
-
-    ft1 = float(t1)
-    x = rand(Bool)
-    @check_bit_operation setindex!(b1, x, ft1) T
-    b2 = bitrand(length(t1))
-    @check_bit_operation setindex!(b1, b2, ft1) T
-
-    y = rand(0.0:1.0)
-    @check_bit_operation setindex!(b1, y, ft1) T
-    f2 = float(bitrand(length(t1)))
-    @check_bit_operation setindex!(b1, f2, ft1) T
 end
 
 # multidimensional
@@ -208,14 +183,6 @@ for (k1, k2, T) in Task(gen_getindex_data)
     # println(typeof(k1), " ", typeof(k2), " ", T) # uncomment to debug
     @check_bit_operation getindex(b1, k1, k2) T
     @check_bit_operation getindex(b1, k1, k2, 1) T
-
-    #@check_bit_operation getindex(b1, float(k1), k2) T
-    #@check_bit_operation getindex(b1, k1, float(k2)) T
-
-    @check_bit_operation getindex(b1, float(k1), float(k2)) T
-
-    @check_bit_operation getindex(b1, k1, k2, 1.0) T
-    #@check_bit_operation getindex(b1, float(k1), float(k2), 1.0) T
 end
 
 function gen_setindex_data()
@@ -250,16 +217,6 @@ end
 for (b2, k1, k2) in Task(gen_setindex_data)
     # println(typeof(b2), " ", typeof(k1), " ", typeof(k2)) # uncomment to debug
     @check_bit_operation setindex!(b1, b2, k1, k2) BitMatrix
-
-    @check_bit_operation setindex!(b1, float(b2), k1, k2) BitMatrix
-    @check_bit_operation setindex!(b1, b2, float(k1), k2) BitMatrix
-    #@check_bit_operation setindex!(b1, b2, k1, float(k2)) BitMatrix
-
-    #@check_bit_operation setindex!(b1, float(b2), float(k1), k2) BitMatrix
-    #@check_bit_operation setindex!(b1, float(b2), k1, float(k2)) BitMatrix
-    #@check_bit_operation setindex!(b1, b2, float(k1), float(k2)) BitMatrix
-
-    @check_bit_operation setindex!(b1, float(b2), float(k1), float(k2)) BitMatrix
 end
 
 m1, m2 = rand_m1m2()

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1385,7 +1385,6 @@ gstr = Base.GenericString("12");
 @test convert(Symbol, gstr)==symbol("12")
 
 @test getindex(gstr, Bool(1))=='1'
-@test getindex(gstr, 1.0)=='1'
 @test getindex(gstr,Bool(1):Bool(1))=="1"
 @test getindex(gstr,AbstractVector([Bool(1):Bool(1);]))=="1"
 
@@ -1398,8 +1397,6 @@ gstr = Base.GenericString("12");
 @test getindex(gstr,AbstractVector([Bool(1):Bool(1);]))=="1"
 
 @test nextind(AbstractArray([Bool(1):Bool(1);]),1)==2
-
-@test checkbounds(gstr,1.0)==true
 
 @test ind2chr(gstr,2)==2
 


### PR DESCRIPTION
- Deprecate `to_index(::Real)` in favor of `to_index(::Integer)`.
- In the future require index values which are floating point, rationals, etc. to be explicitly converted to `Int`.
- Delete tests that currently test for floating point indexing support.

Closes #10154
