### PR TITLE
FIx misleading `addprocs` documentation

### DIFF
--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -132,9 +132,9 @@ General Parallel Computing Support
 
    ``max_parallel`` : specifies the maximum number of workers connected to in parallel at a host. Defaults to 10.
 
-   ``dir`` :  specifies the location of the julia binaries on the worker nodes. Defaults to JULIA_HOME.
+   ``dir`` :  specifies the working directory on the workers. Defaults to the host's current directory (as found by `pwd()`)
 
-   ``exename`` :  name of the julia executable. Defaults to "./julia" or "./julia-debug" as the case may be.
+   ``exename`` :  name of the julia executable. Defaults to "$JULIA_HOME/julia" or "$JULIA_HOME/julia-debug" as the case may be.
 
    ``exeflags`` :  additional flags passed to the worker processes.
 


### PR DESCRIPTION
I'm not 100% sure of this change, but my experimentation seems to indicate that this more accurately reflects `addprocs`'s behavior.
