### PR TITLE
check pipe initialization using a status code

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -293,7 +293,7 @@ macro setup_stdio()
         close_in,close_out,close_err = false,false,false
         in,out,err = stdios
         if isa(stdios[1], Pipe)
-            if stdios[1].handle == C_NULL
+            if stdios[1].status == StatusUninit
                 error("pipes passed to spawn must be initialized")
             end
         elseif isa(stdios[1], FileRedirect)
@@ -303,7 +303,7 @@ macro setup_stdio()
             in = FS.File(RawFD(fd(stdios[1])))
         end
         if isa(stdios[2], Pipe)
-            if stdios[2].handle == C_NULL
+            if stdios[2].status == StatusUninit
                 error("pipes passed to spawn must be initialized")
             end
         elseif isa(stdios[2], FileRedirect)
@@ -313,7 +313,7 @@ macro setup_stdio()
             out = FS.File(RawFD(fd(stdios[2])))
         end
         if isa(stdios[3], Pipe)
-            if stdios[3].handle == C_NULL
+            if stdios[3].status == StatusUninit
                 error("pipes passed to spawn must be initialized")
             end
         elseif isa(stdios[3], FileRedirect)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -92,6 +92,9 @@ rm(file)
     end
 end
 
+# Uninitialized input pipes cannot be piped to a program
+@test_throws ErrorException run(pipe(Base.Pipe(C_NULL), `cat`))
+
 readall(setenv(`sh -c "echo \$TEST"`,["TEST=Hello World"])) == "Hello World\n"
 readall(setenv(`sh -c "echo \$TEST"`,Dict("TEST"=>"Hello World"))) == "Hello World\n"
 readall(setenv(`sh -c "pwd"`;dir="/")) == readall(setenv(`sh -c "cd / && pwd"`))


### PR DESCRIPTION
Checking initialization of a pipe with its handler can cause false-positive assertion error when `STDIN` is piped (ref: #8529).
This seems to be caused by immediate release of a handler of the pipe after reading all data from it (ref: https://github.com/JuliaLang/julia/issues/8529#issuecomment-76599873).
The `.status` field of a `Pipe` can distinguish "once initialized" pipes from "never initialized" ones.
This issue may be related to #6957 as well.
