### PR TITLE
Throw ArgumentError when trying to reduce along dim <= 0

### DIFF
--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -126,3 +126,17 @@ A = [1.0 3.0 6.0;
 @test std(FloatingPoint[1,2,3], 1) == [1.0]
 @test sum(Any[1 2;3 4],1) == [4 6]
 @test sum(Vector{Int}[[1,2],[4,3]], 1)[1] == [5,5]
+
+# issue #10461
+Areduc = rand(3, 4, 5, 6)
+for region in Any[-1, 0, (-1, 2), [0, 1], (1,-2,3), [0 1;
+                                                     2 3]]
+    @test_throws ArgumentError sum(Areduc, region)
+    @test_throws ArgumentError prod(Areduc, region)
+    @test_throws ArgumentError maximum(Areduc, region)
+    @test_throws ArgumentError minimum(Areduc, region)
+    @test_throws ArgumentError sumabs(Areduc, region)
+    @test_throws ArgumentError sumabs2(Areduc, region)
+    @test_throws ArgumentError maxabs(Areduc, region)
+    @test_throws ArgumentError minabs(Areduc, region)
+end


### PR DESCRIPTION
Partial fix for #10461. 

``` julia
julia> A = randn(5,5);

julia> sum(A,-1)
ERROR: ArgumentError: dimension must be ≥ 1, got -1
 in reduced_dims at reducedim.jl:13
 in mapreducedim at reducedim.jl:238
 in sum at reducedim.jl:259

julia> sum(A,(0,1))
ERROR: ArgumentError: region dimension(s) must be ≥ 1, got 0
 in reduced_dims at reducedim.jl:41
 in sum at reducedim.jl:259
```

however the following still works:

``` julia
julia> sum(A, '💩')
5x5 Array{Float64,2}:
 -1.61494    0.00957967   1.36983    -0.103583   0.229828
 -0.392741   0.115102     1.55382     1.00709    1.14214
  0.904887  -0.149392    -0.605863    0.789693  -0.278489
 -0.682415  -1.79694      0.120298    0.907222   1.73478
  1.06015   -0.378494     0.0169756  -2.10546    0.299774
```

We may want to constrain the input types of dim / region to be `Integers` and deprecate the current behavior.
