### PR TITLE
enh add HorizontalRule to markdown

### DIFF
--- a/base/markdown/Common/Common.jl
+++ b/base/markdown/Common/Common.jl
@@ -1,7 +1,8 @@
 include("block.jl")
 include("inline.jl")
 
-@flavor common [list, indentcode, blockquote, hashheader, paragraph,
+@flavor common [list, indentcode, blockquote, hashheader, horizontalrule,
+                paragraph,
 
-                linebreak, escapes, en_dash, inline_code, asterisk_bold,
-                asterisk_italic, image, link]
+                linebreak, escapes, en_dash, inline_code,
+                asterisk_bold, asterisk_italic, image, link]

--- a/base/markdown/Common/block.jl
+++ b/base/markdown/Common/block.jl
@@ -164,3 +164,30 @@ function list(stream::IO, block::MD, config::Config)
         return true
     end
 end
+
+# ––––––––––––––
+# HorizontalRule
+# ––––––––––––––
+
+type HorizontalRule
+end
+
+function horizontalrule(stream::IO, block::MD, config::Config)
+   withstream(stream) do
+       n, rule = 0, ' '
+       while !eof(stream)
+           char = read(stream, Char)
+           char == '\n' && break
+           isspace(char) && continue
+           if n==0 || char==rule
+               rule = char
+               n += 1
+           else
+               return false
+           end
+       end
+       is_hr = (n ≥ 3 && rule in "*-")
+       is_hr && push!(block, HorizontalRule())
+       return is_hr
+   end
+end

--- a/base/markdown/Julia/Julia.jl
+++ b/base/markdown/Julia/Julia.jl
@@ -8,7 +8,7 @@ We start by borrowing GitHub's `fencedcode` extension – more to follow.
 include("interp.jl")
 
 @flavor julia [blocktex, blockinterp, hashheader, list, indentcode, fencedcode,
-               blockquote, github_table, paragraph,
+               blockquote, github_table, horizontalrule, paragraph,
 
-               linebreak, escapes, latex, interp, en_dash, inline_code, asterisk_bold,
-               asterisk_italic, image, link]
+               linebreak, escapes, latex, interp, en_dash, inline_code,
+               asterisk_bold, asterisk_italic, image, link]

--- a/base/markdown/render/html.jl
+++ b/base/markdown/render/html.jl
@@ -64,6 +64,10 @@ function html(io::IO, md::List)
     end
 end
 
+function html(io::IO, md::HorizontalRule)
+    tag(io, :hr)
+end
+
 html(io::IO, x) = tohtml(io, x)
 
 # Inline elements

--- a/base/markdown/render/latex.jl
+++ b/base/markdown/render/latex.jl
@@ -66,6 +66,10 @@ function writemime(io::IO, ::MIME"text/latex", md::List)
     end
 end
 
+function writemime(io::IO, ::MIME"text/latex", md::HorizontalRule)
+    println(io, "\\rule{\\textwidth}{1pt}")
+end
+
 # Inline elements
 
 function writemime(io::IO, ::MIME"text/latex", md::Plain)

--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -36,6 +36,10 @@ function plain(io::IO, list::List)
     end
 end
 
+function plain(io::IO, md::HorizontalRule)
+    println(io, "–" ^ 3)
+end
+
 plain(io::IO, x) = tohtml(io, x)
 
 # Inline elements

--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -86,6 +86,10 @@ function term(io::IO, br::LineBreak, columns)
    println(io)
 end
 
+function term(io::IO, br::HorizontalRule, columns)
+   println(io, " " ^ margin, "-" ^ (columns - 2margin))
+end
+
 term(io::IO, x, _) = writemime(io, MIME"text/plain"(), x)
 
 # Inline Content

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -33,12 +33,20 @@ foo
 @test md"#title" |> plain == "# title\n"
 @test md"## section" |> plain == "## section\n"
 @test md"## section `foo`" |> plain == "## section `foo`\n"
+@test md"""Hello
+
+---
+World""" |> plain == "Hello\n\n–––\n\nWorld\n"
 
 # HTML output
 
 @test md"foo *bar* baz" |> html == "<p>foo <em>bar</em> baz</p>\n"
 @test md"# title *blah*" |> html == "<h1>title <em>blah</em></h1>\n"
 @test md"## title *blah*" |> html == "<h2>title <em>blah</em></h2>\n"
+@test md"""Hello
+
+---
+World""" |> html == "<p>Hello</p>\n<hr />\n<p>World</p>\n"
 
 # Interpolation / Custom types
 


### PR DESCRIPTION
Adds horizontal rule, `<hr />`, like this one:

---

cc @one-more-minute (Note: this precedence required for this appears to be before paragraph.)
