### PR TITLE
RFC: Vectorize ntoh() hton() ltoh() and htol()

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -22,6 +22,12 @@ else
     error("seriously? what is this machine?")
 end
 
+NumberOrChar = Union(Number,Char)
+@vectorize_1arg NumberOrChar ntoh
+@vectorize_1arg NumberOrChar hton
+@vectorize_1arg NumberOrChar ltoh
+@vectorize_1arg NumberOrChar htol
+
 isreadonly(s) = isreadable(s) && !iswritable(s)
 
 ## binary I/O ##


### PR DESCRIPTION
When writing [IDXParser](https://github.com/Elzair/IDXParser.jl), I found it useful to execute `ntoh()` over an array of data, so I vectorized it and its three companion functions: `hton()`, `ltoh()`, and `htol()`.
