### PR TITLE
remove darray construction from comprehension in @parallel

### DIFF
--- a/base/linalg/distributed.jl
+++ b/base/linalg/distributed.jl
@@ -1,5 +1,0 @@
-function scale!(A::DArray, x::Number)
-    @sync for p in procs(A)
-        @spawnat p scale!(localpart(A), x)
-    end
-end

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1473,18 +1473,6 @@ macro parallel(args...)
     na = length(args)
     if na==1
         loop = args[1]
-        if isa(loop,Expr) && loop.head === :comprehension
-            ex = loop.args[1]
-            loop.args[1] = esc(ex)
-            nd = length(loop.args)-1
-            ranges = map(e->esc(e.args[2]), loop.args[2:end])
-            for i=1:nd
-                var = loop.args[1+i].args[1]
-                loop.args[1+i] = :( $(esc(var)) = ($(ranges[i]))[I[$i]] )
-            end
-            return :( DArray((I::(UnitRange{Int}...))->($loop),
-                             tuple($(map(r->:(length($r)),ranges)...))) )
-        end
     elseif na==2
         reducer = args[1]
         loop = args[2]


### PR DESCRIPTION
Closes #10485

@jakebolewski , the deleted code for constructing DArrays from a comprehension can be added to DistributedArrays, maybe calling it `@darray` ?

For regular `@darray` can just `distribute` the same. 
