### PR TITLE
fix markdown fenced code blocks with 4 or more `s

### DIFF
--- a/base/markdown/GitHub/GitHub.jl
+++ b/base/markdown/GitHub/GitHub.jl
@@ -3,10 +3,12 @@ include("table.jl")
 @breaking true ->
 function fencedcode(stream::IO, block::MD, config::Config)
     startswith(stream, "```", padding = true) || return false
-    flavor = strip(readline(stream))
+    trailing = strip(readline(stream))
+    flavor = lstrip(trailing, '`')
+    n = 3 + length(trailing) - length(flavor)
     buffer = IOBuffer()
     while !eof(stream)
-        startswith(stream, "```") && break
+        startswith(stream, "`" ^ n) && break
         write(buffer, readline(stream))
     end
     push!(block, Code(flavor, takebuf_string(buffer) |> chomp))

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -74,6 +74,15 @@ writemime(io::IO, m::MIME"text/plain", r::Reference) =
 
 @test md"Behaves like $(ref(fft))" == md"Behaves like fft (see Julia docs)"
 
+
+@test md"""
+````julia
+foo()
+````""" == md"""
+```julia
+foo()
+```"""
+
 # GH tables
 @test md"""
     a  | b


### PR DESCRIPTION
cc @one-more-minute 

fixes https://github.com/one-more-minute/Markdown.jl/issues/18
