### PR TITLE
fix turn back on latex output for markdown

### DIFF
--- a/base/markdown/GitHub/table.jl
+++ b/base/markdown/GitHub/table.jl
@@ -126,14 +126,14 @@ function term(io::IO, md::Table, columns)
     end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::Table)
+function latex(io::IO, md::Table)
     wrapblock(io, "tabular") do
         align = md.align
         println(io, "{$(join(align, " | "))}")
         for (i, row) in enumerate(md.rows)
             for (j, cell) in enumerate(row)
                 j != 1 && print(io, " & ")
-                latex_inline(io, cell)
+                latexinline(io, cell)
             end
             println(io, " \\\\")
             if i == 1

--- a/base/markdown/Markdown.jl
+++ b/base/markdown/Markdown.jl
@@ -15,7 +15,7 @@ include("Julia/Julia.jl")
 
 include("render/plain.jl")
 include("render/html.jl")
-# include("render/latex.jl")
+include("render/latex.jl")
 
 include("render/terminal/render.jl")
 

--- a/base/markdown/render/latex.jl
+++ b/base/markdown/render/latex.jl
@@ -12,55 +12,56 @@ function wrapinline(f, io, cmd)
     print(io, "}")
 end
 
-writemime(io::IO, ::MIME"text/latex", md::Content) =
-    writemime(io, "text/plain", md)
+# Block elements
 
-function writemime(io::IO, mime::MIME"text/latex", block::Block)
-    for md in block.content[1:end-1]
-        writemime(io::IO, mime, md)
-        println(io)
+latex(io::IO, md::MD) = latex(io, md.content)
+
+function latex(io::IO, content::Vector)
+    for c in content
+        latex(io, c)
     end
-    writemime(io::IO, mime, block.content[end])
 end
 
-function writemime{l}(io::IO, mime::MIME"text/latex", header::Header{l})
+function latex{l}(io::IO, header::Header{l})
     tag = l < 4 ? "sub"^(l-1) * "section" : "sub"^(l-4) * "paragraph"
     wrapinline(io, tag) do
-        print(io, header.text)
+        latexinline(io, header.text)
     end
     println(io)
 end
 
-function writemime(io::IO, ::MIME"text/latex", code::BlockCode)
+function latex(io::IO, code::Code)
     wrapblock(io, "verbatim") do
+        # TODO latex escape
         println(io, code.code)
     end
 end
 
-function writemime(io::IO, ::MIME"text/latex", code::InlineCode)
+function latexinline(io::IO, code::Code)
     wrapinline(io, "texttt") do
         print(io, code.code)
     end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::Paragraph)
+function latex(io::IO, md::Paragraph)
     for md in md.content
-        latex_inline(io, md)
+        latexinline(io, md)
     end
     println(io)
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::BlockQuote)
+function latex(io::IO, md::BlockQuote)
     wrapblock(io, "quote") do
-        writemime(io, "text/latex", Block(md.content))
+        latex(io, md.content)
     end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::List)
-    wrapblock(io, "itemize") do
-        for item in md.content
+function latex(io::IO, md::List)
+    env = md.ordered ? "enumerate" : "itemize"
+    wrapblock(io, env) do
+        for item in md.items
             print(io, "\\item ")
-            latex_inline(io, item)
+            latexinline(io, item)
             println(io)
         end
     end
@@ -72,23 +73,29 @@ end
 
 # Inline elements
 
-function writemime(io::IO, ::MIME"text/latex", md::Plain)
-    print(io, md.text)
+function latexinline(io::IO, md::Vector)
+    for c in md
+        latexinline(io, c)
+    end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::Bold)
+function latexinline(io::IO, md::String)
+    print(io, md)
+end
+
+function latexinline(io::IO, md::Bold)
     wrapinline(io, "textbf") do
-        print(io, md.text)
+        latexinline(io, md.text)
     end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::Italic)
+function latexinline(io::IO, md::Italic)
     wrapinline(io, "emph") do
-        print(io, md.text)
+        latexinline(io, md.text)
     end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::Image)
+function latexinline(io::IO, md::Image)
     wrapblock(io, "figure") do
         println(io, "\\centering")
         wrapinline(io, "includegraphics") do
@@ -96,19 +103,23 @@ function writemime(io::IO, ::MIME"text/latex", md::Image)
         end
         println(io)
         wrapinline(io, "caption") do
-            print(io, md.alt)
+            latexinline(io, md.alt)
         end
         println(io)
     end
 end
 
-function writemime(io::IO, ::MIME"text/latex", md::Link)
+function latexinline(io::IO, md::Link)
     wrapinline(io, "href") do
         print(io, md.url)
     end
-    print(io, "{", md.text, "}")
+    print(io, "{")
+    latexinline(io, md.text)
+    print(io, "}")
 end
 
-latex_inline(io::IO, el::Content) = writemime(io, "text/latex", el)
+latex(md) = sprint(latex, md)
+latexinline(md) = sprint(latexinline, md)
 
-latex(md::Content) = stringmime("text/latex", md)
+writemime(io::IO, ::MIME"text/latex", md::MD) = latex(io, md)
+#writemime(io::IO, ::MIME"text/latex", md::MD) = writemime(io, "text/plain", md)

--- a/base/markdown/render/latex.jl
+++ b/base/markdown/render/latex.jl
@@ -80,7 +80,7 @@ function latexinline(io::IO, md::Vector)
 end
 
 function latexinline(io::IO, md::String)
-    print(io, md)
+    latexesc(io, md)
 end
 
 function latexinline(io::IO, md::Bold)
@@ -118,8 +118,21 @@ function latexinline(io::IO, md::Link)
     print(io, "}")
 end
 
+const _latexescape_chars = Dict{Char, String}(
+   '~'=>"{\\sim}", '^'=>"\\^{}", '\\'=>"{\\textbackslash}")
+for ch in "&%\$#_{}"
+    _latexescape_chars[ch] = "\\$ch"
+end
+
+function latexesc(io, s::String)
+    for ch in s
+        print(io, get(_latexescape_chars, ch, ch))
+    end
+end
+
 latex(md) = sprint(latex, md)
 latexinline(md) = sprint(latexinline, md)
+latexesc(s) = sprint(latexesc, s)
 
 writemime(io::IO, ::MIME"text/latex", md::MD) = latex(io, md)
 #writemime(io::IO, ::MIME"text/latex", md::MD) = writemime(io, "text/plain", md)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -59,6 +59,23 @@ World""" |> plain == "Hello\n\n–––\n\nWorld\n"
 ---
 World""" |> html == "<p>Hello</p>\n<hr />\n<p>World</p>\n"
 
+# Latex output
+book = md"""
+# Title
+
+Some discussion
+
+> A quote
+
+## Section *important*
+
+Some **bolded**
+
+- list1
+- list2
+"""
+@test latex(book) == "\\section{Title}\nSome discussion\n\\begin{quote}\nA quote\n\\end{quote}\n\\subsection{Section \\emph{important}}\nSome \\textbf{bolded}\n\\begin{itemize}\n\\item list1\n\\item list2\n\\end{itemize}\n"
+
 # Interpolation / Custom types
 
 type Reference


### PR DESCRIPTION
fixes https://github.com/one-more-minute/Markdown.jl/issues/15

Reworks latex.jl to be more like html.jl and updates for newer Markdown types; uses a latex method rather than writemime (writemime is defined only for the MD type).

cc @one-more-minute @MichaelHatherly
