### PR TITLE
Fix multiple problems with views-of-views

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -345,33 +345,35 @@ end
 # the corresponding cartesian index into the parent, and then uses
 # dims to convert back to a linear index into the parent array.
 #
-# However, a common case is linindex::UnitRange.
-# Since div is slow and in(j::Int, linindex::UnitRange) is fast,
+# However, a common case is linindex::Range.
+# Since div is slow and in(j::Int, linindex::Range) is fast,
 # it can be much faster to generate all possibilities and
 # then test whether the corresponding linear index is in linindex.
 # One exception occurs when only a small subset of the total
 # is desired, in which case we fall back to the div-based algorithm.
-stagedfunction merge_indexes(V, indexes::NTuple, dims::Dims, linindex::UnitRange{Int})
-    N = length(indexes)
+#stagedfunction merge_indexes{T<:Integer}(V, parentindexes::NTuple, parentdims::Dims, linindex::Union(Colon,Range{T}), lindim)
+stagedfunction merge_indexes_in{TT}(V, parentindexes::TT, parentdims::Dims, linindex, lindim)
+    N = length(parentindexes)   # number of parent axes we're merging
     N > 0 || throw(ArgumentError("cannot merge empty indexes"))
+    lengthexpr = linindex == Colon ? (:(prod(size(V)[lindim:end]))) : (:(length(linindex)))
+    L = symbol(string("Istride_", N+1))  # length of V's trailing dimensions
     quote
-        n = length(linindex)
-        Base.Cartesian.@nexprs $N d->(I_d = indexes[d])
-        L = 1
-        dimoffset = ndims(V.parent) - length(dims)
-        Base.Cartesian.@nexprs $N d->(L *= dimsize(V.parent, d+dimoffset, I_d))
-        if n < 0.1L   # this has not been carefully tuned
-            return merge_indexes_div(V, indexes, dims, linindex)
+        n = $lengthexpr
+        Base.Cartesian.@nexprs $N d->(I_d = parentindexes[d])
+        pdimoffset = ndims(V.parent) - length(parentdims)
+        Istride_1 = 1   # parentindexes strides
+        Base.Cartesian.@nexprs $N d->(Istride_{d+1} = Istride_d*dimsize(V.parent, d+pdimoffset, I_d))
+        Istridet = Base.Cartesian.@ntuple $(N+1) d->Istride_d
+        if n < 0.1*$L   # this has not been carefully tuned
+            return merge_indexes_div(V, parentindexes, parentdims, linindex, lindim)
         end
         Pstride_1 = 1   # parent strides
-        Base.Cartesian.@nexprs $(N-1) d->(Pstride_{d+1} = Pstride_d*dims[d])
-        Istride_1 = 1   # indexes strides
-        Base.Cartesian.@nexprs $(N-1) d->(Istride_{d+1} = Istride_d*dimsize(V, d+dimoffset, I_d))
-        Base.Cartesian.@nexprs $N d->(counter_d = 1) # counter_0 is a linear index into indexes
+        Base.Cartesian.@nexprs $(N-1) d->(Pstride_{d+1} = Pstride_d*parentdims[d])
+        Base.Cartesian.@nexprs $N d->(counter_d = 1) # counter_0 is a linear index into parentindexes
         Base.Cartesian.@nexprs $N d->(offset_d = 1)  # offset_0 is a linear index into parent
         k = 0
         index = Array(Int, n)
-        Base.Cartesian.@nloops $N i d->(1:dimsize(V, d+dimoffset, I_d)) d->(offset_{d-1} = offset_d + (I_d[i_d]-1)*Pstride_d; counter_{d-1} = counter_d + (i_d-1)*Istride_d) begin
+        Base.Cartesian.@nloops $N i d->(1:dimsize(V.parent, d+pdimoffset, I_d)) d->(offset_{d-1} = offset_d + (I_d[i_d]-1)*Pstride_d; counter_{d-1} = counter_d + (i_d-1)*Istride_d) begin
             if in(counter_0, linindex)
                 index[k+=1] = offset_0
             end
@@ -379,27 +381,35 @@ stagedfunction merge_indexes(V, indexes::NTuple, dims::Dims, linindex::UnitRange
         index
     end
 end
-merge_indexes(V, indexes::NTuple, dims::Dims, linindex) = merge_indexes_div(V, indexes, dims, linindex)
+
+# HACK: dispatch seemingly wasn't working properly
+function merge_indexes(V, parentindexes::NTuple, parentdims::Dims, linindex, lindim)
+    if isa(linindex, Colon) || isa(linindex, Range)
+        return merge_indexes_in(V, parentindexes, parentdims, linindex, lindim)
+    end
+    merge_indexes_div(V, parentindexes, parentdims, linindex, lindim)
+end
 
 # This could be written as a regular function, but performance
 # will be better using Cartesian macros to avoid the heap and
 # an extra loop.
-stagedfunction merge_indexes_div(V, indexes::NTuple, dims::Dims, linindex)
-    N = length(indexes)
+stagedfunction merge_indexes_div{TT}(V, parentindexes::TT, parentdims::Dims, linindex, lindim)
+    N = length(parentindexes)
     N > 0 || throw(ArgumentError("cannot merge empty indexes"))
     Istride_N = symbol("Istride_$N")
+    lengthexpr = :(length(linindex))
     quote
-        Base.Cartesian.@nexprs $N d->(I_d = indexes[d])
+        Base.Cartesian.@nexprs $N d->(I_d = parentindexes[d])
         Pstride_1 = 1   # parent strides
-        Base.Cartesian.@nexprs $(N-1) d->(Pstride_{d+1} = Pstride_d*dims[d])
-        Istride_1 = 1   # indexes strides
-        dimoffset = ndims(V.parent) - length(dims)
-        Base.Cartesian.@nexprs $(N-1) d->(Istride_{d+1} = Istride_d*dimsize(V.parent, d+dimoffset, I_d))
-        n = length(linindex)
-        L = $(Istride_N) * dimsize(V.parent, $N+dimoffset, indexes[end])
+        Base.Cartesian.@nexprs $(N-1) d->(Pstride_{d+1} = Pstride_d*parentdims[d])
+        Istride_1 = 1   # parentindexes strides
+        pdimoffset = ndims(V.parent) - length(parentdims)
+        Base.Cartesian.@nexprs $(N-1) d->(Istride_{d+1} = Istride_d*dimsize(V.parent, d+pdimoffset, I_d))
+        n = $lengthexpr
+        L = $(Istride_N) * dimsize(V.parent, $N+pdimoffset, parentindexes[end])
         index = Array(Int, n)
         for i = 1:n
-            k = linindex[i] # k is the indexes-centered linear index
+            k = linindex[i] # k is the parentindexes-centered linear index
             1 <= k <= L || throw(BoundsError())
             k -= 1
             j = 0  # j will be the new parent-centered linear index

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -167,8 +167,8 @@ function test_linear(A, B)
 end
 
 # "mixed" means 2 indexes even for N-dimensional arrays
-test_mixed{T}(A::AbstractArray{T,1}, B::Array) = nothing
-test_mixed{T}(A::AbstractArray{T,2}, B::Array) = nothing
+test_mixed{T}(::AbstractArray{T,1}, ::Array) = nothing
+test_mixed{T}(::AbstractArray{T,2}, ::Array) = nothing
 test_mixed(A, B::Array) = _test_mixed(A, reshape(B, size(A)))
 function _test_mixed(A, B)
     L = length(A)
@@ -194,10 +194,11 @@ function err_li(I::Tuple, ld::Int, ldc::Int)
     error("Linear indexing inference mismatch")
 end
 
-function err_li(S::SubArray, ldc::Int)
+function err_li(S::SubArray, ld::Int, szC)
     println(summary(S))
     @show S.indexes
-    @show ldc
+    @show ld
+    @show szC
     error("Linear indexing inference mismatch")
 end
 
@@ -228,18 +229,35 @@ function runtests(A::SubArray, I...)
     AA = copy_to_array(A)
     # Direct test of linear indexing inference
     C = Agen_nodrop(AA, I...)
-    ld = single_stride_dim(C)
+    Cld = ld = single_stride_dim(C)
+    Cdim = AIindex = 0
+    while Cdim <= Cld && AIindex < length(A.indexes)
+        AIindex += 1
+        if isa(A.indexes[AIindex], Real)
+            ld += 1
+        else
+            Cdim += 1
+        end
+    end
     # sub
-    S = sub(A, I...)
+    local S
+    try
+        S = sub(A, I...)
+    catch err
+        @show typeof(A)
+        @show A.indexes
+        @show I
+        rethrow(err)
+    end
     ldc = getLD(S)
-    ldc <= ld || err_li(S, ld)
+    ldc <= ld || err_li(S, ld, size(C))
     test_linear(S, C)
     test_cartesian(S, C)
     test_mixed(S, C)
     # slice
     S = slice(A, I...)
     ldc = getLD(S)
-    ldc <= ld || err_li(S, ld)
+    ldc <= ld || err_li(S, ld, size(C))
     test_linear(S, C)
     test_cartesian(S, C)
     test_mixed(S, C)
@@ -248,28 +266,28 @@ end
 # indexN is a cartesian index, indexNN is a linear index for 2 dimensions, and indexNNN is a linear index for 3 dimensions
 function runviews{T}(SB::AbstractArray{T,3}, indexN, indexNN, indexNNN)
     for i3 in indexN, i2 in indexN, i1 in indexN
-        runtests(A, i1, i2, i3)
+        runtests(SB, i1, i2, i3)
     end
     for i2 in indexNN, i1 in indexN
-        runtests(A, i1, i2)
+        runtests(SB, i1, i2)
     end
     for i1 in indexNNN
-        runtests(A, i1)
+        runtests(SB, i1)
     end
 end
 
 function runviews{T}(SB::AbstractArray{T,2}, indexN, indexNN, indexNNN)
     for i2 in indexN, i1 in indexN
-        runtests(A, i1, i2)
+        runtests(SB, i1, i2)
     end
     for i1 in indexNN
-        runtests(A, i1)
+        runtests(SB, i1)
     end
 end
 
 function runviews{T}(SB::AbstractArray{T,1}, indexN, indexNN, indexNNN)
     for i1 in indexN
-        runtests(A, i1)
+        runtests(SB, i1)
     end
 end
 
@@ -279,21 +297,24 @@ runviews{T}(SB::AbstractArray{T,0}, indexN, indexNN, indexNNN) = nothing
 
 ### Views from Arrays ###
 
-A = reshape(1:5*7*11, 11, 7, 5)
 index5 = (2, :, 2:5, 1:2:5, [4,1,5])  # all work with at least size 5
 index25 = (8, :, 2:11, 12:3:22, [4,1,5,9])
 index125 = (113, :, 85:121, 2:15:92, [99,14,103])
-runviews(A, index5, index25, index125)
+
+let A = reshape(1:5*7*11, 11, 7, 5)
+    runviews(A, index5, index25, index125)
+end
 
 ### Views from views ###
 
-B = reshape(1:13^3, 13, 13, 13)
 # "outer" indexes create snips that have at least size 5 along each dimension, with the exception of Int-slicing
 oindex = (:, 6, 3:7, 13:-2:1, [8,4,6,12,5,7])
 
-for o3 in oindex, o2 in oindex, o1 in oindex
-    sliceB = slice(B, o1, o2, o3)
-    runviews(sliceB, index5, index25, index125)
+let B = reshape(1:13^3, 13, 13, 13)
+    for o3 in oindex, o2 in oindex, o1 in oindex
+        sliceB = slice(B, o1, o2, o3)
+        runviews(sliceB, index5, index25, index125)
+    end
 end
 
 


### PR DESCRIPTION
This is a public service announcement from your local "oh, crap" department.

Due to what was probably a copy/paste error, the SubArray tests were [grabbing a global variable `A` rather than an argument `SB`](https://github.com/JuliaLang/julia/blob/21199e321d0a8454a5bed07461d4bd160f191d93/test/subarray.jl#L249-L274). `A` happened to be a plain array, with the consequence that the SubArray tests were not thoroughly testing views-of-views:

``` julia
A = rand(20, 20, 20)
B = slice(A, 1:5, 6, 6:9)  # a view (2-dimensional)
C = sub(B, 6:14)           # a view of a view (1-dimensional)
```

I note that, had I passed that file through Lint, it would have caught the problem.

Unsurprisingly, fixing this test problem uncovered bugs in my implementation of SubArrays. Many "simple"  (hah!) things worked because I had tested quite a lot via the command line, and also copied in some old hand-written tests. But constructs like the one above---specifically, those that use linear indexing in creation of a view-of-view, when one of the uber-parent dimensions had been sliced out---certainly had problems. I _think_ people would have quickly gotten `BoundsError`s if this were being commonly used, so the fact that this hasn't been noticed until now is a good sign. Once we start returning views from indexing operations, views-of-views are going to be really common, so it surely would have turned up then.

One major downside to this fix is that, now that the tests are running properly, the `subarray` test **takes (on my machine) 14 minutes to complete**. I think that's probably too long. However, I also don't think the test is excessive in its thoroughness:
- it only goes up to 3 dimensions, which I've found to be the absolute minimum for uncovering errors in logic. Originally I used 4 dimensions.
- the slow part (views-of-views) uses just [5 different instances of indexes](https://github.com/JuliaLang/julia/blob/9a86698f7c120914f84203664a7996d0ba34e147/test/subarray.jl#L311): one `Colon`, one `Int`, one `UnitRange{Int}`, one `StepRange{Int}`, and one `Vector{Int}`. It uses all possible combinations of these, leading to 125 views. It then creates views-of-views using [indexes of the same types](https://github.com/JuliaLang/julia/blob/9a86698f7c120914f84203664a7996d0ba34e147/test/subarray.jl#L300-L302), for [1, 2, and 3-dimensional indexing](https://github.com/JuliaLang/julia/blob/9a86698f7c120914f84203664a7996d0ba34e147/test/subarray.jl#L267-L277). That's a lot of combinations (and a lot of code to compile), but the different choices have really important consequences for both cartesian indexing and inference of `LD` (the maximum dimension with a uniform stride), which is key to our current SubArrays' ability to perform fast linear indexing in many situations. The logic behind this inference is quite complicated, and seems to demand thorough testing.

I suspect there's no alternative but to hand-pick a subset of these combinations for routine testing, and perhaps save the exhaustive tests for a rarely-run test suite. But I didn't want to start decreasing the stringency of our tests without discussing it first, especially when an accidental lack of stringency led to bugs going unnoticed.

[Note that the large size of this commit partly reflects cleanup as well as bugfixes.]

Sorry, all!
