### PR TITLE
Fix #10502 (properly cache vararg stagedfunctions)

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -479,7 +479,7 @@ static jl_value_t *ml_matches(jl_methlist_t *ml, jl_value_t *type,
 
 static jl_function_t *cache_method(jl_methtable_t *mt, jl_tuple_t *type,
                                    jl_function_t *method, jl_tuple_t *decl,
-                                   jl_tuple_t *sparams)
+                                   jl_tuple_t *sparams, int8_t isstaged)
 {
     size_t i;
     int need_guard_entries = 0;
@@ -738,7 +738,7 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tuple_t *type,
     // in general, here we want to find the biggest type that's not a
     // supertype of any other method signatures. so far we are conservative
     // and the types we find should be bigger.
-    if (!mt->defs->isstaged && jl_tuple_len(type) > mt->max_args &&
+    if (!isstaged && jl_tuple_len(type) > mt->max_args &&
         jl_is_vararg_type(jl_tupleref(decl,jl_tuple_len(decl)-1))) {
         size_t nspec = mt->max_args + 2;
         limited = jl_alloc_tuple(nspec);
@@ -1066,7 +1066,7 @@ static jl_function_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_tuple_t *tt, in
             JL_GC_POP();
             if (!cache)
                 return func;
-            return cache_method(mt, tt, func, (jl_tuple_t*)m->sig, jl_null);
+            return cache_method(mt, tt, func, (jl_tuple_t*)m->sig, jl_null, m->isstaged);
         }
         JL_GC_POP();
         return jl_bottom_func;
@@ -1096,7 +1096,7 @@ static jl_function_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_tuple_t *tt, in
     if (!cache)
         nf = func;
     else
-        nf = cache_method(mt, tt, func, newsig, env);
+        nf = cache_method(mt, tt, func, newsig, env, m->isstaged);
     JL_GC_POP();
     return nf;
 }
@@ -1811,7 +1811,7 @@ jl_value_t *jl_gf_invoke(jl_function_t *gf, jl_tuple_t *types,
                                                           jl_tuple_len(tpenv)/2);
             }
         }
-        mfunc = cache_method(m->invokes, tt, m->func, newsig, tpenv);
+        mfunc = cache_method(m->invokes, tt, m->func, newsig, tpenv, m->isstaged);
         JL_GC_POP();
     }
 

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -112,3 +112,12 @@ stagedfunction f9088(x, a=5)
     :(x+a)
 end
 @test f9088(7) == 12
+
+# issue #10502
+stagedfunction f10502(x...)
+    :($x)
+end
+f10502() = ()
+@test f10502(1) == (Int,)
+@test f10502(1,2) == (Int,Int)
+@test f10502(1,2,3) == (Int,Int,Int)


### PR DESCRIPTION
Previously, we only checked if the first method in the method table was staged in order to determine whether or not to newly cache a vararg type.  This patch changes the `cache_method` function to get an extra argument - `isstaged` for the specific method it is caching.

This is a fairly simple fix, but I'd like a second set of eyes to make sure I'm doing this correctly as I'm not as familiar with the C source.  cc: @JeffBezanson @Keno 
