### PR TITLE
enh parse ordered lists in markdown

### DIFF
--- a/base/markdown/render/html.jl
+++ b/base/markdown/render/html.jl
@@ -49,17 +49,17 @@ end
 
 function html(io::IO, md::BlockQuote)
     withtag(io, :blockquote) do
-        html(io, block.content)
+        html(io, md.content)
     end
 end
 
 function html(io::IO, md::List)
-    withtag(io, :ul) do
+    withtag(io, md.ordered ? :ol : :ul) do
         for item in md.items
             withtag(io, :li) do
                 htmlinline(io, item)
-                println(io)
             end
+            println(io)
         end
     end
 end

--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -29,8 +29,8 @@ function plain(io::IO, p::Paragraph)
 end
 
 function plain(io::IO, list::List)
-    for item in list.items
-        print(io, "  * ")
+    for (i, item) in enumerate(list.items)
+        print(io, list.ordered ? "$i. " : "  * ")
         plaininline(io, item)
         println(io)
     end

--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -30,8 +30,8 @@ function term(io::IO, md::BlockQuote, columns)
 end
 
 function term(io::IO, md::List, columns)
-    for point in md.items
-        print(io, " "^2margin, "• ")
+    for (i, point) in enumerate(md.items)
+        print(io, " "^2margin, md.ordered ? "$i. " : "•  ")
         print_wrapped(io, width = columns-(4margin+2), pre = " "^(2margin+2), i = 2margin+2) do io
             terminline(io, point)
         end

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -22,6 +22,15 @@ foo
 ```
 """ == MD(Code("julia", "foo"))
 
+@test md"""
+* one
+* two
+
+1. pirate
+2. ninja
+3. zombie""" == Markdown.MD([Markdown.List(["one", "two"]),
+                             Markdown.List(["pirate", "ninja", "zombie"], true)])
+
 @test md"Foo [bar]" == MD(Paragraph("Foo [bar]"))
 @test md"Foo [bar](baz)" != MD(Paragraph("Foo [bar](baz)"))
 @test md"Foo \[bar](baz)" == MD(Paragraph("Foo [bar](baz)"))
@@ -37,6 +46,8 @@ foo
 # HTML output
 
 @test md"foo *bar* baz" |> html == "<p>foo <em>bar</em> baz</p>\n"
+@test md"1. Hello" |> html == "<ol><li>Hello</li>\n</ol>\n"
+@test md"* World" |> html == "<ul><li>World</li>\n</ul>\n"
 @test md"# title *blah*" |> html == "<h1>title <em>blah</em></h1>\n"
 @test md"## title *blah*" |> html == "<h2>title <em>blah</em></h2>\n"
 


### PR DESCRIPTION
Parses:

```
1.
2.

1)
2)
```

as ordered lists, and render these in the terminal and html (already does so in latex).

I think CommonMark also suggests using a start parameter, very easy to add that in.

cc @one-more-minute 
