### PR TITLE
clarify what evalfile does

### DIFF
--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -544,7 +544,7 @@ Syntax
 
 .. function:: evalfile(path::AbstractString)
 
-   Evaluate all expressions in the given file, and return the value of the last one. No other processing (path searching, fetching from node 1, etc.) is performed.
+   Load the file using ``include``, evaluate all expressions, and return the value of the last one.
 
 .. function:: esc(e::ANY)
 


### PR DESCRIPTION
I dont believe the current documentation is correct, as `evalfile` uses `include` internally, which _does_ include recursively and loads from PID `1`.

To really evaluate a worker-local file one needs to use

``` jl
eval(include_string(readall(filename)))
```
