### PR TITLE
advisory locking on any object

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -260,8 +260,6 @@ type TCPSocket <: Socket
     closecb::Callback
     closenotify::Condition
     sendbuf::Nullable{IOBuffer}
-    lock_task::Nullable{Task}
-    lock_wait::Condition
 
     TCPSocket(handle) = new(
         handle,
@@ -271,7 +269,7 @@ type TCPSocket <: Socket
         false, Condition(),
         false, Condition(),
         false, Condition(),
-        nothing,nothing,Condition()
+        nothing
     )
 end
 function TCPSocket()

--- a/base/string.jl
+++ b/base/string.jl
@@ -1,7 +1,11 @@
 ## core text I/O ##
 
 print(io::IO, x) = show(io, x)
-print(io::IO, xs...) = for x in xs print(io, x) end
+function print(io::IO, xs...)
+    lock(io) do io
+        for x in xs print(io, x) end
+    end
+end
 println(io::IO, xs...) = print(io, xs..., '\n')
 
 print(xs...)   = print(STDOUT, xs...)

--- a/base/util.jl
+++ b/base/util.jl
@@ -269,36 +269,60 @@ end
 
 julia_exename() = ccall(:jl_is_debugbuild,Cint,())==0 ? "julia" : "julia-debug"
 
+# Advisory reentrant lock
+type ReentrantLock
+    locked_by::Nullable{Task}
+    cond_wait::Condition
+    reentrancy_cnt::Int
+
+    ReentrantLock() = new(nothing, Condition(), 0)
+end
+
 # Lock object during function execution. Recursive calls by the same task is OK.
-const LOCK_MODE_ADVISORY=1
-const adv_locks_map = Dict{UInt64, Tuple}()
-function lock(f::Function, o::Any; mode=LOCK_MODE_ADVISORY)
-    # Currently only advisory locks are supported.
-    t = current_task()
-    release_lock = true
-    oid = object_id(o)
-    while true
-        if !haskey(adv_locks_map, oid)
-            adv_locks_map[oid] = (t, Condition()); break
-        else
-            (locked_by, c) = adv_locks_map[oid]
-            if t == locked_by
-                release_lock = false; break
-            end
-            wait(c)
-        end
+const adv_locks_map = WeakKeyDict{Any, ReentrantLock}()
+function lock(f::Function, o::Any)
+    rl = get(adv_locks_map, o, nothing)
+    if rl == nothing
+        rl = ReentrantLock()
+        adv_locks_map[o] = rl
     end
+    lock(rl)
 
     try
         f(o)
     finally
-        if release_lock
-            (_, c) = pop!(adv_locks_map, oid)
-            notify(c)
-        end
+        unlock(o)
     end
 end
 
+function lock(rl::ReentrantLock)
+    t = current_task()
+    while true
+        if rl.reentrancy_cnt == 0
+            rl.locked_by = t
+            rl.reentrancy_cnt = 1
+            return
+        elseif t == get(rl.locked_by)
+            rl.reentrancy_cnt += 1
+            return
+        end
+        wait(rl.cond_wait)
+    end
+end
 
+function unlock(o::Any)
+    rl = adv_locks_map[o]
+    unlock(rl)
+end
 
+function unlock(rl::ReentrantLock)
+    rl.reentrancy_cnt = rl.reentrancy_cnt - 1
+    if rl.reentrancy_cnt == 0
+        rl.locked_by = nothing
+        notify(rl.cond_wait)
+    elseif rl.reentrancy_cnt < 0
+        AssertionError("unlock count must match lock count")
+    end
+    rl
+end
 


### PR DESCRIPTION
This PR provides for obtaining an advisory (or unenforced) lock on any object. Consequently, locks fields which were implemented as part of AsyncStream objects have been changed to use the new implementation.

Also, `println` which is a common method of printing debugging statements, acquires an advisory lock on the `io` object. It closes https://github.com/JuliaLang/julia/issues/3787 and thus addresses common instances of intermixed output while printing concurrently from different tasks.
