### PR TITLE
Generalize scalar indexing and implement reducedim without stagedfunctions

### DIFF
--- a/base/functors.jl
+++ b/base/functors.jl
@@ -40,6 +40,12 @@ call(::MaxFun, x, y) = scalarmax(x,y)
 immutable MinFun <: Func{2} end
 call(::MinFun, x, y) = scalarmin(x, y)
 
+immutable LessFun <: Func{2} end
+call(::LessFun, x, y) = x < y
+
+immutable MoreFun <: Func{2} end
+call(::MoreFun, x, y) = x > y
+
 # a fallback unspecialized functor that allows code using functors to not care
 # whether they were able to specialize on the function value or not
 immutable UnspecializedFun{N,T<:Callable} <: Func{N}

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -51,15 +51,27 @@ getindex(index::CartesianIndex, i::Integer) = getfield(index, i)::Int
 stagedfunction getindex{N}(A::Array, index::CartesianIndex{N})
     N==0 ? :(Base.arrayref(A, 1)) : :(@ncall $N Base.arrayref A d->index[d])
 end
+stagedfunction getindex{N}(A::Array, i::Integer, index::CartesianIndex{N})
+    N==0 ? :(Base.arrayref(A, i)) : :(@ncall $(N+1) Base.arrayref A d->(d == 1 ? i : index[d-1]))
+end
 stagedfunction setindex!{T,N}(A::Array{T}, v, index::CartesianIndex{N})
     N==0 ? :(Base.arrayset(A, convert($T,v), 1)) : :(@ncall $N Base.arrayset A convert($T,v) d->index[d])
+end
+stagedfunction setindex!{T,N}(A::Array{T}, v, i::Integer, index::CartesianIndex{N})
+    N==0 ? :(Base.arrayset(A, convert($T,v), i)) : :(@ncall $(N+1) Base.arrayset A convert($T,v) d->(d == 1 ? i : index[d-1]))
 end
 
 stagedfunction getindex{N}(A::AbstractArray, index::CartesianIndex{N})
     :(@nref $N A d->index[d])
 end
+stagedfunction getindex{N}(A::AbstractArray, i::Integer, index::CartesianIndex{N})
+    :(@nref $(N+1) A d->(d == 1 ? i : index[d-1]))
+end
 stagedfunction setindex!{N}(A::AbstractArray, v, index::CartesianIndex{N})
     :((@nref $N A d->index[d]) = v)
+end
+stagedfunction setindex!{N}(A::AbstractArray, v, i::Integer, index::CartesianIndex{N})
+    :((@nref $(N+1) A d->(d == 1 ? i : index[d-1])) = v)
 end
 
 # arithmetic, min/max

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -18,7 +18,13 @@ stagedfunction Base.call{N}(::Type{CartesianIndex},index::NTuple{N,Real})
     indextype = gen_cartesian(N)
     return Expr(:call,indextype,[:(to_index(index[$i])) for i=1:N]...)
 end
-Base.call{N}(::Type{CartesianIndex{N}},index::Real...) = CartesianIndex(index::NTuple{N,Real})
+stagedfunction Base.call{N}(::Type{CartesianIndex{N}},index::Real...)
+    length(index) == N && return :(CartesianIndex(index))
+    length(index) > N && throw(DimensionMismatch("Cannot create CartesianIndex{$N} from $(length(index)) indexes"))
+    args = [i <= length(index) ? :(index[$i]) : 1 for i = 1:N]
+    :(CartesianIndex(tuple($(args...))))
+end
+Base.call{M,N}(::Type{CartesianIndex{N}},index::NTuple{M,Real}) = CartesianIndex{N}(index...)
 
 let implemented = IntSet()
     global gen_cartesian

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -14,17 +14,17 @@ linearindexing{A<:BitArray}(::Type{A}) = LinearFast()
 # CartesianIndex
 abstract CartesianIndex{N}
 
-stagedfunction Base.call{N}(::Type{CartesianIndex},index::NTuple{N,Real})
+stagedfunction Base.call{N}(::Type{CartesianIndex},index::NTuple{N,Integer})
     indextype = gen_cartesian(N)
     return Expr(:call,indextype,[:(to_index(index[$i])) for i=1:N]...)
 end
-stagedfunction Base.call{N}(::Type{CartesianIndex{N}},index::Real...)
+stagedfunction Base.call{N}(::Type{CartesianIndex{N}},index::Integer...)
     length(index) == N && return :(CartesianIndex(index))
     length(index) > N && throw(DimensionMismatch("Cannot create CartesianIndex{$N} from $(length(index)) indexes"))
     args = [i <= length(index) ? :(index[$i]) : 1 for i = 1:N]
     :(CartesianIndex(tuple($(args...))))
 end
-Base.call{M,N}(::Type{CartesianIndex{N}},index::NTuple{M,Real}) = CartesianIndex{N}(index...)
+Base.call{M,N}(::Type{CartesianIndex{N}},index::NTuple{M,Integer}) = CartesianIndex{N}(index...)
 
 let implemented = IntSet()
     global gen_cartesian
@@ -36,7 +36,7 @@ let implemented = IntSet()
             fields = [Expr(:(::), fnames[i], :Int) for i = 1:N]
             extype = Expr(:type, false, Expr(:(<:), indextype, Expr(:curly, :CartesianIndex, N)), Expr(:block, fields...))
             eval(extype)
-            argsleft = [Expr(:(::), fnames[i], :Real) for i = 1:N]
+            argsleft = [Expr(:(::), fnames[i], :Integer) for i = 1:N]
             argsright = [Expr(:call,:to_index,fnames[i]) for i=1:N]
             exconstructor = Expr(:(=),Expr(:call,:(Base.call),:(::Type{CartesianIndex{$N}}),argsleft...),Expr(:call,indextype,argsright...))
             eval(exconstructor)

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -200,14 +200,14 @@ function _mapreducedim!{T,N}(f, op, R::AbstractArray, A::AbstractArray{T,N})
         @inbounds for IA in CartesianRange(sizeA1)
             IR = min(sizeR1, IA)
             r = R[1,IR]
-            for i = 1:size(A, 1)
+            @simd for i = 1:size(A, 1)
                 r = op(r, f(A[i, IA]))
             end
             R[1,IR] = r
         end
     else
         sizeR = CartesianIndex{N}(size(R))
-        @inbounds for IA in eachindex(A)
+        @inbounds @simd for IA in eachindex(A)
             IR = min(IA, sizeR)
             R[IR] = op(R[IR], f(A[IA]))
         end


### PR DESCRIPTION
This generalizes CartesianIndex indexing to allow a construct like `A[i::Int,I::CartesianIndex]`. This allows one to split out the innermost loop for special treatment. We did that already for the special case of `@simd`, this just generalizes it in a way that allows one to exploit it for pure julia code, too.

CC @Jutho, @mbauman. Some day we probably will want to go further, and allow full `getindex(A, indexes::Union(Integer, CartesianIndex)...)`. But for now we can't add that without generating ambiguity warnings, and I don't currently need the general case for anything.

I then used this to rewrite the algorithms in `reducedim.jl` without using Base.Cartesian or any staged functions, with no loss of performance. (In fact, the `sum!(R2, A)` case is about 15% faster.)

``` julia
 julia> A = rand(10^4, 10^4);

julia> R1 = zeros(1, size(A,2));   # for reducing along dimension 1

julia> R2 = zeros(size(A,1), 1);   # for reducing along dimension 2

julia> R12 = zeros(1, 1);       # for reducing along dimensions 1 and 2

julia> @time sum!(R1, A);
elapsed time: 0.350055697 seconds (4 MB allocated)

julia> @time sum!(R2, A);
elapsed time: 0.188841453 seconds (144 bytes allocated)

julia> @time sum!(R12, A);
elapsed time: 0.128383574 seconds (144 bytes allocated)

julia> @time sum!(R1, A);
elapsed time: 0.131577355 seconds (144 bytes allocated)

julia> @time sum!(R2, A);
elapsed time: 0.18379862 seconds (144 bytes allocated)

julia> @time sum!(R12, A);
elapsed time: 0.129456885 seconds (144 bytes allocated)

julia> B = sub(A, 1:size(A,1), 1:size(A,2));  # defeat fast linear indexing

julia> Base.linearindexing(B)
Base.LinearSlow()

julia> @time sum!(R1, B);
elapsed time: 0.598274799 seconds (7 MB allocated, 3.22% gc time in 1 pauses with 1 full sweep)

julia> @time sum!(R1, B);
elapsed time: 0.125478658 seconds (144 bytes allocated)

julia> @time sum!(R2, B);
elapsed time: 0.421974903 seconds (144 bytes allocated)

julia> @time sum!(R12, B);
elapsed time: 0.125809267 seconds (144 bytes allocated)
```

Reference: https://github.com/JuliaLang/julia/pull/10310#issuecomment-75822766 and the comments above (this makes the "blows out of the water" comment no longer apply).
