### PR TITLE
RFC: Give AbstractArrays smart and performant indexing behaviors for free

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -192,11 +192,22 @@ Library improvements
 
     * `is_valid_char(c)` now correctly handles Unicode "non-characters", which are valid Unicode codepoints. ([#11171])
 
-  * Data-structure processing
+  * Array and AbstractArray improvements
 
     * New multidimensional iterators and index types for efficient iteration over `AbstractArray`s. Array iteration should generally be written as `for i in eachindex(A) ... end` rather than `for i = 1:length(A) ... end`.  ([#8432])
 
     * New implementation of SubArrays with substantial performance and functionality improvements ([#8501]).
+
+    * AbstractArray subtypes only need to implement `size` and `getindex`
+      for scalar indices to support indexing; all other indexing behaviors
+      (including logical idexing, ranges of indices, vectors, colons, etc.) are
+      implemented in default fallbacks. Similarly, they only need to implement
+      scalar `setindex!` to support all forms of indexed assingment ([#10525]).
+
+    * AbstractArrays that do not extend `similar` now return an `Array` by
+      default ([#10525]).
+
+  * Data-structure processing
 
     * New `sortperm!` function for pre-allocated index arrays ([#8792]).
 
@@ -1417,6 +1428,7 @@ Too numerous to mention.
 [#10400]: https://github.com/JuliaLang/julia/issues/10400
 [#10446]: https://github.com/JuliaLang/julia/issues/10446
 [#10458]: https://github.com/JuliaLang/julia/issues/10458
+[#10525]: https://github.com/JuliaLang/julia/issues/10525
 [#10543]: https://github.com/JuliaLang/julia/issues/10543
 [#10659]: https://github.com/JuliaLang/julia/issues/10659
 [#10679]: https://github.com/JuliaLang/julia/issues/10679

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -119,12 +119,12 @@ linearindexing{T<:Range}(::Type{T}) = LinearFast()
 *(::LinearSlow, ::LinearSlow) = LinearSlow()
 
 ## Bounds checking ##
-checkbounds(sz::Int, ::Colon) = nothing
 checkbounds(sz::Int, i::Int) = 1 <= i <= sz || throw(BoundsError())
 checkbounds(sz::Int, i::Real) = checkbounds(sz, to_index(i))
 checkbounds(sz::Int, I::AbstractVector{Bool}) = length(I) == sz || throw(BoundsError())
 checkbounds(sz::Int, r::Range{Int}) = isempty(r) || (minimum(r) >= 1 && maximum(r) <= sz) || throw(BoundsError())
 checkbounds{T<:Real}(sz::Int, r::Range{T}) = checkbounds(sz, to_index(r))
+checkbounds(sc::Int, ::Colon) = true
 
 function checkbounds{T <: Real}(sz::Int, I::AbstractArray{T})
     for i in I
@@ -136,17 +136,17 @@ checkbounds(A::AbstractArray, I::AbstractArray{Bool}) = size(A) == size(I) || th
 
 checkbounds(A::AbstractArray, I) = checkbounds(length(A), I)
 
-function checkbounds(A::AbstractMatrix, I::Union(Real,Colon,AbstractArray), J::Union(Real,Colon,AbstractArray))
+function checkbounds(A::AbstractMatrix, I::Union(Real,AbstractArray,Colon), J::Union(Real,AbstractArray,Colon))
     checkbounds(size(A,1), I)
     checkbounds(size(A,2), J)
 end
 
-function checkbounds(A::AbstractArray, I::Union(Real,Colon,AbstractArray), J::Union(Real,Colon,AbstractArray))
+function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray,Colon), J::Union(Real,AbstractArray,Colon))
     checkbounds(size(A,1), I)
     checkbounds(trailingsize(A,2), J)
 end
 
-function checkbounds(A::AbstractArray, I::Union(Real,Colon,AbstractArray)...)
+function checkbounds(A::AbstractArray, I::Union(Real,AbstractArray,Colon)...)
     n = length(I)
     if n > 0
         for dim = 1:(n-1)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -128,14 +128,13 @@ macro _noinline_meta()
 end
 
 ## Bounds checking ##
-_checkbounds(sz::Int, i::Int) = 1 <= i <= sz
-_checkbounds(sz::Int, i::Real) = (@_inline_meta; _checkbounds(sz, to_index(i)))
-_checkbounds(sz::Int, I::AbstractVector{Bool}) = length(I) == sz
-_checkbounds(sz::Int, I::AbstractArray{Bool}) = length(I) == sz # setindex! allows this
-_checkbounds(sz::Int, r::Range{Int}) = (@_inline_meta; isempty(r) || (minimum(r) >= 1 && maximum(r) <= sz))
-_checkbounds{T<:Real}(sz::Int, r::Range{T}) = (@_inline_meta; _checkbounds(sz, to_index(r)))
-_checkbounds(sz::Int, ::Colon) = true
-function _checkbounds{T <: Real}(sz::Int, I::AbstractArray{T})
+_checkbounds(sz, i::Integer) = 1 <= i <= sz
+_checkbounds(sz, i::Real) = 1 <= to_index(i) <= sz
+_checkbounds(sz, I::AbstractVector{Bool}) = length(I) == sz
+_checkbounds(sz, r::Range{Int}) = (@_inline_meta; isempty(r) || (minimum(r) >= 1 && maximum(r) <= sz))
+_checkbounds{T<:Real}(sz, r::Range{T}) = (@_inline_meta; _checkbounds(sz, to_index(r)))
+_checkbounds(sz, ::Colon) = true
+function _checkbounds{T <: Real}(sz, I::AbstractArray{T})
     @_inline_meta
     b = true
     for i in I

--- a/base/array.jl
+++ b/base/array.jl
@@ -330,6 +330,9 @@ function getindex(A::Range, I::AbstractVector{Bool})
     return [ A[i] for i in to_index(I) ]
 end
 
+function getindex(A::Array, ::Colon)
+    return [ a for a in A ]
+end
 
 # logical indexing
 # (when the indexing is provided as an Array{Bool} or a BitArray we can be
@@ -409,6 +412,7 @@ function setindex!{T<:Real}(A::Array, X::AbstractArray, I::AbstractVector{T})
     return A
 end
 
+setindex!(A::Array, x, I::Colon) = setindex!(A, x, 1:length(A))
 
 # logical indexing
 # (when the indexing is provided as an Array{Bool} or a BitArray we can be

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -348,60 +348,8 @@ bitpack{T,N}(A::AbstractArray{T,N}) = convert(BitArray{N}, A)
     return r
 end
 
-@inline function getindex(B::BitArray, i::Int)
-    1 <= i <= length(B) || throw(BoundsError(B, i))
-    return unsafe_bitgetindex(B.chunks, i)
-end
-
-getindex(B::BitArray, i::Real) = getindex(B, to_index(i))
-
-getindex(B::BitArray) = getindex(B, 1)
-
-# 0d bitarray
-getindex(B::BitArray{0}) = unsafe_bitgetindex(B.chunks, 1)
-
-function getindex{T<:Real}(B::BitArray, I::AbstractVector{T})
-    X = BitArray(length(I))
-    lB = length(B)
-    Xc = X.chunks
-    Bc = B.chunks
-    ind = 1
-    for i in I
-        # faster X[ind] = B[i]
-        j = to_index(i)
-        1 <= j <= lB || throw(BoundsError(B, j))
-        unsafe_bitsetindex!(Xc, unsafe_bitgetindex(Bc, j), ind)
-        ind += 1
-    end
-    return X
-end
-
-# logical indexing
-# (when the indexing is provided as an Array{Bool} or a BitArray we can be
-# sure about the behaviour and use unsafe_getindex; in the general case
-# we can't and must use getindex, otherwise silent corruption can happen)
-# (multiple signatures for disambiguation)
-for IT in [AbstractVector{Bool}, AbstractArray{Bool}]
-    @eval @generated function getindex(B::BitArray, I::$IT)
-        idxop = I <: Union(Array{Bool}, BitArray) ? :unsafe_getindex : :getindex
-        quote
-            checkbounds(B, I)
-            n = sum(I)
-            X = BitArray(n)
-            Xc = X.chunks
-            Bc = B.chunks
-            ind = 1
-            for i = 1:length(I)
-                if $idxop(I, i)
-                    # faster X[ind] = B[i]
-                    unsafe_bitsetindex!(Xc, unsafe_bitgetindex(Bc, i), ind)
-                    ind += 1
-                end
-            end
-            return X
-        end
-    end
-end
+@inline getindex(B::BitArray, i::Int) = (checkbounds(B, i); unsafe_getindex(B, i))
+@inline unsafe_getindex(B::BitArray, i::Int) = unsafe_bitgetindex(B.chunks, i)
 
 ## Indexing: setindex! ##
 
@@ -417,11 +365,9 @@ end
     end
 end
 
-setindex!(B::BitArray, x) = setindex!(B, convert(Bool,x), 1)
-
-function setindex!(B::BitArray, x::Bool, i::Int)
-    1 <= i <= length(B) || throw(BoundsError(B, i))
-    unsafe_bitsetindex!(B.chunks, x, i)
+setindex!(B::BitArray, x, i::Int) = (checkbounds(B, i); unsafe_setindex!(B, x, i))
+@inline function unsafe_setindex!(B::BitArray, x, i::Int)
+    unsafe_bitsetindex!(B.chunks, convert(Bool, x), i)
     return B
 end
 
@@ -430,12 +376,13 @@ end
 # sure about the behaviour and use unsafe_getindex; in the general case
 # we can't and must use getindex, otherwise silent corruption can happen)
 
-function setindex!(B::BitArray, x, I::BitArray)
-    checkbounds(B, I)
+# When indexing with a BitArray, we can operate whole chunks at a time for a ~100x gain
+setindex!(B::BitArray, x, I::BitArray) = (checkbounds(B, I); unsafe_setindex!(B, x, I))
+function unsafe_setindex!(B::BitArray, x, I::BitArray)
     y = convert(Bool, x)
     Bc = B.chunks
     Ic = I.chunks
-    @assert length(Bc) == length(Ic)
+    length(Bc) == length(Ic) || throw_boundserror(B, I)
     @inbounds if y
         for i = 1:length(Bc)
             Bc[i] |= Ic[i]
@@ -448,26 +395,15 @@ function setindex!(B::BitArray, x, I::BitArray)
     return B
 end
 
-@generated function setindex!(B::BitArray, x, I::AbstractArray{Bool})
-    idxop = I <: Array{Bool} ? :unsafe_getindex : :getindex
-    quote
-        checkbounds(B, I)
-        y = convert(Bool, x)
-        Bc = B.chunks
-        for i = 1:length(I)
-            # faster I[i] && B[i] = y
-            $idxop(I, i) && unsafe_bitsetindex!(Bc, y, i)
-        end
-        return B
-    end
-end
-
-function setindex!(B::BitArray, X::AbstractArray, I::BitArray)
-    checkbounds(B, I)
+# Assigning an array of bools is more complicated, but we can still do some
+# work on chunks by combining X and I 64 bits at a time to improve perf by ~40%
+setindex!(B::BitArray, X::AbstractArray, I::BitArray) = (checkbounds(B, I); unsafe_setindex!(B, X, I))
+function unsafe_setindex!(B::BitArray, X::AbstractArray, I::BitArray)
     Bc = B.chunks
     Ic = I.chunks
-    @assert length(Bc) == length(Ic)
+    length(Bc) == length(Ic) || throw_boundserror(B, I)
     lc = length(Bc)
+    lx = length(X)
     last_chunk_len = Base._mod64(length(B)-1)+1
 
     c = 1
@@ -477,7 +413,8 @@ function setindex!(B::BitArray, X::AbstractArray, I::BitArray)
         u = UInt64(1)
         for j = 1:(i < lc ? 64 : last_chunk_len)
             if Imsk & u != 0
-                x = convert(Bool, X[c])
+                lx < c && throw_setindex_mismatch(X, c)
+                x = convert(Bool, unsafe_getindex(X, c))
                 if x
                     C |= u
                 else
@@ -490,29 +427,9 @@ function setindex!(B::BitArray, X::AbstractArray, I::BitArray)
         @inbounds Bc[i] = C
     end
     if length(X) != c-1
-        throw(DimensionMismatch("assigned $(length(X)) elements to length $(c-1) destination"))
+        throw_setindex_mismatch(X, c-1)
     end
     return B
-end
-
-@generated function setindex!(B::BitArray, X::AbstractArray, I::AbstractArray{Bool})
-    idxop = I <: Array{Bool} ? :unsafe_getindex : :getindex
-    quote
-        checkbounds(B, I)
-        Bc = B.chunks
-        c = 1
-        for i = 1:length(I)
-            if $idxop(I, i)
-                # faster B[i] = X[c]
-                unsafe_bitsetindex!(Bc, convert(Bool, X[c]), i)
-                c += 1
-            end
-        end
-        if length(X) != c-1
-            throw(DimensionMismatch("assigned $(length(X)) elements to length $(c-1) destination"))
-        end
-        return B
-    end
 end
 
 ## Dequeue functionality ##

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -273,7 +273,7 @@ end
             X = x
             # To call setindex_shape_check, we need to create fake 1-d indexes of the proper size
             @nexprs $N d->(fakeI_d = 1:shape_d)
-            Base.setindex_shape_check(X, (@ntuple $N fakeI)...)
+            @ncall $N Base.setindex_shape_check X shape
             k = 1
             @nloops $N i d->(1:shape_d) d->(@nexprs $N k->(j_d_k = size(I_k, d) == 1 ? 1 : i_d)) begin
                 @nexprs $N k->(@inbounds J_k = @nref $N I_k d->j_d_k)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -489,3 +489,12 @@ function chol(A::AbstractMatrix, uplo::Symbol)
         "use chol(a::AbstractMatrix, uplo::Union(Val{:L},Val{:U})) instead"), :chol)
     chol(A, Val{uplo})
 end
+
+_ensure_vector(A::AbstractArray) = vec(A)
+_ensure_vector(A) = A
+_ensure_vectors() = ()
+_ensure_vectors(A, As...) = (_ensure_vector(A), _ensure_vectors(As...)...)
+function _unsafe_setindex!(l::LinearIndexing, A::AbstractArray, x, J::Union(Real,AbstractArray,Colon)...)
+    depwarn("multidimensional indexed assignment with multidimensional arrays is deprecated, use vec to convert indices to vectors", :_unsafe_setindex!)
+    _unsafe_setindex!(l, A, x, _ensure_vectors(J...)...)
+end

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -34,14 +34,8 @@ end
 fill!(D::Diagonal, x) = (fill!(D.diag, x); D)
 
 full(D::Diagonal) = diagm(D.diag)
-getindex(D::Diagonal, i::Integer, j::Integer) = i == j ? D.diag[i] : zero(eltype(D.diag))
-
-function getindex(D::Diagonal, i::Integer)
-    n = length(D.diag)
-    id = div(i-1, n)
-    id + id * n == i-1 && return D.diag[id+1]
-    zero(eltype(D.diag))
-end
+getindex(D::Diagonal, i::Int, j::Int) = i == j ? D.diag[i] : zero(eltype(D.diag))
+unsafe_getindex(D::Diagonal, i::Int, j::Int) = i == j ? unsafe_getindex(D.diag, i) : zero(eltype(D.diag))
 
 ishermitian{T<:Real}(D::Diagonal{T}) = true
 ishermitian(D::Diagonal) = all(D.diag .== real(D.diag))

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -23,9 +23,10 @@ typealias HermOrSym{T,S} Union(Hermitian{T,S}, Symmetric{T,S})
 typealias RealHermSymComplexHerm{T<:Real,S} Union(Hermitian{T,S}, Symmetric{T,S}, Hermitian{Complex{T},S})
 
 size(A::HermOrSym, args...) = size(A.data, args...)
-getindex(A::HermOrSym, i::Integer) = ((q, r) = divrem(i - 1, size(A, 1)); A[r + 1, q + 1])
 getindex(A::Symmetric, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? getindex(A.data, i, j) : getindex(A.data, j, i)
 getindex(A::Hermitian, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? getindex(A.data, i, j) : conj(getindex(A.data, j, i))
+unsafe_getindex(A::Symmetric, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? unsafe_getindex(A.data, i, j) : unsafe_getindex(A.data, j, i)
+unsafe_getindex(A::Hermitian, i::Integer, j::Integer) = (A.uplo == 'U') == (i < j) ? unsafe_getindex(A.data, i, j) : conj(unsafe_getindex(A.data, j, i))
 full(A::Symmetric) = copytri!(copy(A.data), A.uplo)
 full(A::Hermitian) = copytri!(copy(A.data), A.uplo, true)
 convert{T,S<:AbstractMatrix}(::Type{Symmetric{T,S}},A::Symmetric{T,S}) = A

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -107,7 +107,6 @@ function full!{T,S}(A::UnitUpperTriangular{T,S})
     B
 end
 
-getindex(A::AbstractTriangular, i::Integer) = ((m, n) = divrem(i - 1, size(A, 1)); A[n + 1, m + 1])
 getindex{T,S}(A::UnitLowerTriangular{T,S}, i::Integer, j::Integer) = i == j ? one(T) : (i > j ? A.data[i,j] : zero(A.data[i,j]))
 getindex{T,S}(A::LowerTriangular{T,S}, i::Integer, j::Integer) = i >= j ? A.data[i,j] : zero(A.data[i,j])
 getindex{T,S}(A::UnitUpperTriangular{T,S}, i::Integer, j::Integer) = i == j ? one(T) : (i < j ? A.data[i,j] : zero(A.data[i,j]))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -231,10 +231,13 @@ using .IteratorsMD
 
 @generated function checksize(A::AbstractArray, I...)
     N = length(I)
-    quote
-        @nexprs $N d->(size(A, d) == length(I[d]) || throw(DimensionMismatch("index $d has length $(length(I[d])), but size(A, $d) = $(size(A,d))")))
-        nothing
+    ex = Expr(:block)
+    push!(ex.args, :(idxlens = index_lengths(A, I...)))
+    for d=1:N
+        push!(ex.args, :(size(A, $d) == idxlens[$d] || throw(DimensionMismatch("index ", $d, " has length ", idxlens[$d], ", but size(A, ", $d, ") = ", size(A,$d)))))
     end
+    push!(ex.args, :(nothing))
+    ex
 end
 
 @inline unsafe_getindex(v::BitArray, ind::Int) = Base.unsafe_bitgetindex(v.chunks, ind)
@@ -245,7 +248,7 @@ end
 @inline unsafe_setindex!{T}(v::AbstractArray{T}, x::T, ind::Real) = unsafe_setindex!(v, x, to_index(ind))
 
 # Version that uses cartesian indexing for src
-@generated function _getindex!(dest::Array, src::AbstractArray, I::Union(Int,AbstractVector)...)
+@generated function _getindex!(dest::Array, src::AbstractArray, I::Union(Int,AbstractVector,Colon)...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     quote
@@ -260,7 +263,7 @@ end
 end
 
 # Version that uses linear indexing for src
-@generated function _getindex!(dest::Array, src::Array, I::Union(Int,AbstractVector)...)
+@generated function _getindex!(dest::Array, src::Array, I::Union(Int,AbstractVector,Colon)...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     quote
@@ -279,12 +282,12 @@ end
 
 # It's most efficient to call checkbounds first, then to_index, and finally
 # allocate the output. Hence the different variants.
-_getindex(A, I::Tuple{Vararg{Union(Int,AbstractVector),}}) =
-    _getindex!(similar(A, index_shape(I...)), A, I...)
+_getindex(A, I::Tuple{Vararg{Union(Int,AbstractVector,Colon),}}) =
+    _getindex!(similar(A, index_shape(A, I...)), A, I...)
 
 # The @generated function here is just to work around the performance hit
 # of splatting
-@generated function getindex(A::Array, I::Union(Real,AbstractVector)...)
+@generated function getindex(A::Array, I::Union(Real,AbstractVector,Colon)...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     quote
@@ -294,7 +297,7 @@ _getindex(A, I::Tuple{Vararg{Union(Int,AbstractVector),}}) =
 end
 
 # Also a safe version of getindex!
-@generated function getindex!(dest, src, I::Union(Real,AbstractVector)...)
+@generated function getindex!(dest, src, I::Union(Real,AbstractVector,Colon)...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     Jsplat = Expr[:(to_index(I[$d])) for d = 1:N]
@@ -305,21 +308,23 @@ end
 end
 
 
-@generated function setindex!(A::Array, x, J::Union(Real,AbstractArray)...)
+@generated function setindex!(A::Array, x, J::Union(Real,AbstractArray,Colon)...)
     N = length(J)
     if x<:AbstractArray
         ex=quote
             X = x
-            @ncall $N setindex_shape_check X I
+            idxlens = @ncall $N index_lengths A I
+            setindex_shape_check(X, idxlens...)
             Xs = start(X)
-            @nloops $N i d->(1:length(I_d)) d->(@inbounds offset_{d-1} = offset_d + (unsafe_getindex(I_d, i_d)-1)*stride_d) begin
+            @nloops $N i d->(1:idxlens[d]) d->(@inbounds offset_{d-1} = offset_d + (unsafe_getindex(I_d, i_d)-1)*stride_d) begin
                 v, Xs = next(X, Xs)
                 @inbounds A[offset_0] = v
             end
         end
     else
         ex=quote
-            @nloops $N i d->(1:length(I_d)) d->(@inbounds offset_{d-1} = offset_d + (unsafe_getindex(I_d, i_d)-1)*stride_d) begin
+            idxlens = @ncall $N index_lengths A I
+            @nloops $N i d->(1:idxlens[d]) d->(@inbounds offset_{d-1} = offset_d + (unsafe_getindex(I_d, i_d)-1)*stride_d) begin
                 @inbounds A[offset_0] = x
             end
         end
@@ -355,20 +360,23 @@ end
 
 ### subarray.jl
 
+# This is the code-generation block for SubArray's staged setindex! function:
+# _setindex!(V::SubArray, x, J::Union(Real,AbstractVector,Colon)...)
 function gen_setindex_body(N::Int)
     quote
         Base.Cartesian.@nexprs $N d->(J_d = J[d])
         Base.Cartesian.@ncall $N checkbounds V J
         Base.Cartesian.@nexprs $N d->(I_d = Base.to_index(J_d))
+        idxlens = @ncall $N index_lengths V I
         if !isa(x, AbstractArray)
-            Base.Cartesian.@nloops $N i d->(1:length(I_d)) d->(@inbounds j_d = Base.unsafe_getindex(I_d, i_d)) begin
+            Base.Cartesian.@nloops $N i d->(1:idxlens[d]) d->(@inbounds j_d = Base.unsafe_getindex(I_d, i_d)) begin
                 @inbounds (Base.Cartesian.@nref $N V j) = x
             end
         else
             X = x
-            Base.Cartesian.@ncall $N Base.setindex_shape_check X I
+            setindex_shape_check(X, idxlens...)
             k = 1
-            Base.Cartesian.@nloops $N i d->(1:length(I_d)) d->(@inbounds j_d = Base.unsafe_getindex(I_d, i_d)) begin
+            Base.Cartesian.@nloops $N i d->(1:idxlens[d]) d->(@inbounds j_d = Base.unsafe_getindex(I_d, i_d)) begin
                 @inbounds (Base.Cartesian.@nref $N V j) = X[k]
                 k += 1
             end
@@ -436,6 +444,26 @@ function merge_indexes(V, parentindexes::NTuple, parentdims::Dims, linindex, lin
         return merge_indexes_in(V, parentindexes, parentdims, linindex, lindim)
     end
     merge_indexes_div(V, parentindexes, parentdims, linindex, lindim)
+end
+
+# Even simpler is the case where the linear index is ::Colon: return all indexes
+@generated function merge_indexes(V, indexes::NTuple, dims::Dims, ::Colon)
+    N = length(indexes)
+    N > 0 || throw(ArgumentError("cannot merge empty indexes"))
+    quote
+        Base.Cartesian.@nexprs $N d->(I_d = indexes[d])
+        dimoffset = ndims(V.parent) - length(dims)
+        n = prod(map(length, indexes))
+        Pstride_1 = 1   # parent strides
+        Base.Cartesian.@nexprs $(N-1) d->(Pstride_{d+1} = Pstride_d*dims[d])
+        Base.Cartesian.@nexprs $N d->(offset_d = 1)  # offset_0 is a linear index into parent
+        k = 0
+        index = Array(Int, n)
+        Base.Cartesian.@nloops $N i d->(1:dimsize(V, d+dimoffset, I_d)) d->(offset_{d-1} = offset_d + (I_d[i_d]-1)*Pstride_d) begin
+            index[k+=1] = offset_0
+        end
+        index
+    end
 end
 
 # This could be written as a regular function, but performance
@@ -599,20 +627,27 @@ function getindex(B::BitArray, I0::UnitRange{Int})
     return unsafe_getindex(B, I0)
 end
 
+function getindex(B::BitArray, ::Colon)
+    X = BitArray(0)
+    X.chunks = copy(B.chunks)
+    X.len = length(B)
+    return X
+end
+
 getindex{T<:Real}(B::BitArray, I0::UnitRange{T}) = getindex(B, to_index(I0))
 
-@generated function unsafe_getindex(B::BitArray, I0::UnitRange{Int}, I::Union(Int,UnitRange{Int})...)
+@generated function unsafe_getindex(B::BitArray, I0::Union(Colon,UnitRange{Int}), I::Union(Int,UnitRange{Int},Colon)...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     quote
         @nexprs $N d->(I_d = I[d])
-        X = BitArray(index_shape(I0, $(Isplat...)))
+        X = BitArray(index_shape(B, I0, $(Isplat...)))
 
         f0 = first(I0)
-        l0 = length(I0)
+        l0 = size(X, 1)
 
         gap_lst_1 = 0
-        @nexprs $N d->(gap_lst_{d+1} = length(I_d))
+        @nexprs $N d->(gap_lst_{d+1} = size(X, d+1))
         stride = 1
         ind = f0
         @nexprs $N d->begin
@@ -636,20 +671,21 @@ end
 
 # general multidimensional non-scalar indexing
 
-@generated function unsafe_getindex(B::BitArray, I::Union(Int,AbstractVector{Int})...)
+@generated function unsafe_getindex(B::BitArray, I::Union(Int,AbstractVector{Int},Colon)...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     quote
         @nexprs $N d->(I_d = I[d])
-        X = BitArray(index_shape($(Isplat...)))
+        shape = @ncall $N index_shape B I
+        X = BitArray(shape)
         Xc = X.chunks
 
         stride_1 = 1
         @nexprs $N d->(stride_{d+1} = stride_d * size(B, d))
         @nexprs 1 d->(offset_{$N} = 1)
         ind = 1
-        @nloops($N, i, d->I_d,
-                d->(offset_{d-1} = offset_d + (i_d-1)*stride_d), # PRE
+        @nloops($N, i, X, d->(@inbounds j_d = unsafe_getindex(I[d], i_d);
+                              offset_{d-1} = offset_d + (j_d-1)*stride_d), # PRE
                 begin
                     unsafe_bitsetindex!(Xc, B[offset_0], ind)
                     ind += 1
@@ -660,7 +696,7 @@ end
 
 # general version with Real (or logical) indexing which dispatches on the appropriate method
 
-@generated function getindex(B::BitArray, I::Union(Real,AbstractVector)...)
+@generated function getindex(B::BitArray, I::Union(Real,AbstractVector,Colon)...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     Jsplat = Expr[:(to_index(I[$d])) for d = 1:N]
@@ -790,25 +826,27 @@ end
 
 # general multidimensional non-scalar indexing
 
-@generated function unsafe_setindex!(B::BitArray, X::AbstractArray, I::Union(Int,AbstractArray{Int})...)
+@generated function unsafe_setindex!(B::BitArray, X::AbstractArray, I::Union(Int,AbstractArray{Int},Colon)...)
     N = length(I)
     quote
         refind = 1
         @nexprs $N d->(I_d = I[d])
-        @nloops $N i d->I_d @inbounds begin
-            @ncall $N unsafe_setindex! B convert(Bool,X[refind]) i
+        idxlens = @ncall $N index_lengths B I
+        @nloops $N i d->(1:idxlens[d]) d->(J_d = I_d[i_d]) @inbounds begin
+            @ncall $N unsafe_setindex! B convert(Bool,X[refind]) J
             refind += 1
         end
         return B
     end
 end
 
-@generated function unsafe_setindex!(B::BitArray, x::Bool, I::Union(Int,AbstractArray{Int})...)
+@generated function unsafe_setindex!(B::BitArray, x::Bool, I::Union(Int,AbstractArray{Int},Colon)...)
     N = length(I)
     quote
         @nexprs $N d->(I_d = I[d])
-        @nloops $N i d->I_d begin
-            @ncall $N unsafe_setindex! B x i
+        idxlens = @ncall $N index_lengths B I
+        @nloops $N i d->(1:idxlens[d]) d->(J_d = I_d[i_d]) begin
+            @ncall $N unsafe_setindex! B x J
         end
         return B
     end
@@ -822,7 +860,7 @@ function setindex!(B::BitArray, x, i::Real)
     return unsafe_setindex!(B, convert(Bool,x), to_index(i))
 end
 
-@generated function setindex!(B::BitArray, x, I::Union(Real,AbstractArray)...)
+@generated function setindex!(B::BitArray, x, I::Union(Real,AbstractArray,Colon)...)
     N = length(I)
     quote
         checkbounds(B, I...)
@@ -837,16 +875,17 @@ end
 function setindex!(B::BitArray, X::AbstractArray, i::Real)
     checkbounds(B, i)
     j = to_index(i)
-    setindex_shape_check(X, j)
+    setindex_shape_check(X, index_lengths(A, j)[1])
     return unsafe_setindex!(B, X, j)
 end
 
-@generated function setindex!(B::BitArray, X::AbstractArray, I::Union(Real,AbstractArray)...)
+@generated function setindex!(B::BitArray, X::AbstractArray, I::Union(Real,AbstractArray,Colon)...)
     N = length(I)
     quote
         checkbounds(B, I...)
         @nexprs $N d->(J_d = to_index(I[d]))
-        @ncall $N setindex_shape_check X J
+        idxlens = @ncall $N index_lengths B J
+        setindex_shape_check(X, idxlens...)
         return @ncall $N unsafe_setindex! B X J
     end
 end

--- a/base/number.jl
+++ b/base/number.jl
@@ -15,6 +15,7 @@ getindex(x::Number) = x
 getindex(x::Number, i::Integer) = i == 1 ? x : throw(BoundsError())
 getindex(x::Number, I::Integer...) = all([i == 1 for i in I]) ? x : throw(BoundsError())
 getindex(x::Number, I::Real...) = getindex(x, to_index(I)...)
+unsafe_getindex(x::Real, i::Real) = x
 first(x::Number) = x
 last(x::Number) = x
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -221,22 +221,6 @@ function promote_shape(a::Dims, b::Dims)
     return a
 end
 
-# The lengths of the given indices, lowering : to the appropriate size
-index_lengths(A::AbstractArray, I...) = index_lengths_dim(A, 1, I...)
-index_lengths_dim(A, dim)                = ()
-index_lengths_dim(A, dim, ::Colon)       = dim == 1 ? (length(A),) : (trailingsize(A, dim),)
-index_lengths_dim(A, dim, ::Colon, I...) = tuple(size(A, dim), index_lengths_dim(A, dim+1, I...)...)
-index_lengths_dim(A, dim, ::Real, I...)  = tuple(1, index_lengths_dim(A, dim+1, I...)...)
-index_lengths_dim(A, dim, i, I...)       = tuple(length(i), index_lengths_dim(A, dim+1, I...)...)
-
-# shape of array to create for getindex() with indexes I
-# drop dimensions indexed with trailing scalars
-index_shape(A::AbstractArray, I...) = index_shape_dim(A, 1, I...)
-index_shape_dim(A, dim, I::Real...)    = ()
-index_shape_dim(A, dim, ::Colon)       = dim == 1 ? (length(A),) : (trailingsize(A, dim),)
-index_shape_dim(A, dim, ::Colon, I...) = tuple(size(A, dim), index_shape_dim(A, dim+1, I...)...)
-index_shape_dim(A, dim, i, I...)       = tuple(length(i), index_shape_dim(A, dim+1, I...)...)
-
 function throw_setindex_mismatch(X, I)
     if length(I) == 1
         throw(DimensionMismatch("tried to assign $(length(X)) elements to $(I[1]) destinations"))
@@ -287,16 +271,16 @@ end
 setindex_shape_check(X::AbstractArray) =
     (length(X)==1 || throw_setindex_mismatch(X,()))
 
-setindex_shape_check(X::AbstractArray, i) =
+setindex_shape_check(X::AbstractArray, i::Int) =
     (length(X)==i || throw_setindex_mismatch(X, (i,)))
 
-setindex_shape_check{T}(X::AbstractArray{T,1}, i) =
+setindex_shape_check{T}(X::AbstractArray{T,1}, i::Int) =
     (length(X)==i || throw_setindex_mismatch(X, (i,)))
 
-setindex_shape_check{T}(X::AbstractArray{T,1}, i, j) =
+setindex_shape_check{T}(X::AbstractArray{T,1}, i::Int, j::Int) =
     (length(X)==i*j || throw_setindex_mismatch(X, (i,j)))
 
-function setindex_shape_check{T}(X::AbstractArray{T,2}, i, j)
+function setindex_shape_check{T}(X::AbstractArray{T,2}, i::Int, j::Int)
     if length(X) != i*j
         throw_setindex_mismatch(X, (i,j))
     end
@@ -305,6 +289,7 @@ function setindex_shape_check{T}(X::AbstractArray{T,2}, i, j)
         throw_setindex_mismatch(X, (i,j))
     end
 end
+setindex_shape_check(X, I::Int...) = nothing # Non-arrays broadcast to all idxs
 
 # convert to integer index
 to_index(i::Int) = i

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -221,16 +221,27 @@ function promote_shape(a::Dims, b::Dims)
     return a
 end
 
+# The lengths of the given indices, lowering : to the appropriate size
+index_lengths(A::AbstractArray, I...) = index_lengths_dim(A, 1, I...)
+index_lengths_dim(A, dim)                = ()
+index_lengths_dim(A, dim, ::Colon)       = dim == 1 ? (length(A),) : (trailingsize(A, dim),)
+index_lengths_dim(A, dim, ::Colon, I...) = tuple(size(A, dim), index_lengths_dim(A, dim+1, I...)...)
+index_lengths_dim(A, dim, ::Real, I...)  = tuple(1, index_lengths_dim(A, dim+1, I...)...)
+index_lengths_dim(A, dim, i, I...)       = tuple(length(i), index_lengths_dim(A, dim+1, I...)...)
+
 # shape of array to create for getindex() with indexes I
 # drop dimensions indexed with trailing scalars
-index_shape(I::Real...) = ()
-index_shape(i, I...) = tuple(length(i), index_shape(I...)...)
+index_shape(A::AbstractArray, I...) = index_shape_dim(A, 1, I...)
+index_shape_dim(A, dim, I::Real...)    = ()
+index_shape_dim(A, dim, ::Colon)       = dim == 1 ? (length(A),) : (trailingsize(A, dim),)
+index_shape_dim(A, dim, ::Colon, I...) = tuple(size(A, dim), index_shape_dim(A, dim+1, I...)...)
+index_shape_dim(A, dim, i, I...)       = tuple(length(i), index_shape_dim(A, dim+1, I...)...)
 
 function throw_setindex_mismatch(X, I)
     if length(I) == 1
-        throw(DimensionMismatch("tried to assign $(length(X)) elements to $(length(I[1])) destinations"))
+        throw(DimensionMismatch("tried to assign $(length(X)) elements to $(I[1]) destinations"))
     else
-        throw(DimensionMismatch("tried to assign $(dims2string(size(X))) array to $(dims2string(map(length,I))) destination"))
+        throw(DimensionMismatch("tried to assign $(dims2string(size(X))) array to $(dims2string(I)) destination"))
     end
 end
 
@@ -239,13 +250,13 @@ end
 # for permutations that leave array elements in the same linear order.
 # those are the permutations that preserve the order of the non-singleton
 # dimensions.
-function setindex_shape_check(X::AbstractArray, I...)
+function setindex_shape_check(X::AbstractArray, I::Int...)
     li = ndims(X)
     lj = length(I)
     i = j = 1
     while true
         ii = size(X,i)
-        jj = length(I[j])::Int
+        jj = I[j]
         if i == li || j == lj
             while i < li
                 i += 1
@@ -253,7 +264,7 @@ function setindex_shape_check(X::AbstractArray, I...)
             end
             while j < lj
                 j += 1
-                jj *= length(I[j])::Int
+                jj *= I[j]
             end
             if ii != jj
                 throw_setindex_mismatch(X, I)
@@ -277,21 +288,20 @@ setindex_shape_check(X::AbstractArray) =
     (length(X)==1 || throw_setindex_mismatch(X,()))
 
 setindex_shape_check(X::AbstractArray, i) =
-    (length(X)==length(i) || throw_setindex_mismatch(X, (i,)))
+    (length(X)==i || throw_setindex_mismatch(X, (i,)))
 
 setindex_shape_check{T}(X::AbstractArray{T,1}, i) =
-    (length(X)==length(i) || throw_setindex_mismatch(X, (i,)))
+    (length(X)==i || throw_setindex_mismatch(X, (i,)))
 
 setindex_shape_check{T}(X::AbstractArray{T,1}, i, j) =
-    (length(X)==length(i)*length(j) || throw_setindex_mismatch(X, (i,j)))
+    (length(X)==i*j || throw_setindex_mismatch(X, (i,j)))
 
 function setindex_shape_check{T}(X::AbstractArray{T,2}, i, j)
-    li, lj = length(i), length(j)
-    if length(X) != li*lj
+    if length(X) != i*j
         throw_setindex_mismatch(X, (i,j))
     end
     sx1 = size(X,1)
-    if !(li == 1 || li == sx1 || sx1 == 1)
+    if !(i == 1 || i == sx1 || sx1 == 1)
         throw_setindex_mismatch(X, (i,j))
     end
 end
@@ -305,6 +315,7 @@ to_index(I::UnitRange{Bool}) = find(I)
 to_index(I::Range{Bool}) = find(I)
 to_index{T<:Integer}(r::UnitRange{T}) = to_index(first(r)):to_index(last(r))
 to_index{T<:Integer}(r::StepRange{T}) = to_index(first(r)):to_index(step(r)):to_index(last(r))
+to_index(c::Colon) = c
 to_index(I::AbstractArray{Bool}) = find(I)
 to_index(A::AbstractArray{Int}) = A
 to_index{T<:Integer}(A::AbstractArray{T}) = [to_index(x) for x in A]

--- a/base/range.jl
+++ b/base/range.jl
@@ -362,6 +362,9 @@ function getindex{T}(r::LinSpace{T}, i::Integer)
     convert(T, ((r.len-i)*r.start + (i-1)*r.stop)/r.divisor)
 end
 
+getindex(r::Range, ::Colon) = copy(r)
+unsafe_getindex(r::Range, ::Colon) = copy(r)
+
 function check_indexingrange(s, r)
     sl = length(s)
     rl = length(r)

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -213,7 +213,8 @@ convert(::Type{Array}, S::SharedArray) = S.s
 getindex(S::SharedArray) = getindex(S.s)
 getindex(S::SharedArray, I::Real) = getindex(S.s, I)
 getindex(S::SharedArray, I::AbstractArray) = getindex(S.s, I)
-@generated function getindex(S::SharedArray, I::Union(Real,AbstractVector)...)
+getindex(S::SharedArray, I::Colon) = getindex(S.s, I)
+@generated function getindex(S::SharedArray, I::Union(Real,AbstractVector,Colon)...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     quote
@@ -224,7 +225,8 @@ end
 setindex!(S::SharedArray, x) = setindex!(S.s, x)
 setindex!(S::SharedArray, x, I::Real) = setindex!(S.s, x, I)
 setindex!(S::SharedArray, x, I::AbstractArray) = setindex!(S.s, x, I)
-@generated function setindex!(S::SharedArray, x, I::Union(Real,AbstractVector)...)
+setindex!(S::SharedArray, x, I::Colon) = setindex!(S.s, x, I)
+@generated function setindex!(S::SharedArray, x, I::Union(Real,AbstractVector,Colon)...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     quote

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -2,7 +2,8 @@
 
 module CHOLMOD
 
-import Base: (*), convert, copy, eltype, getindex, show, size
+import Base: (*), convert, copy, eltype, getindex, show, size,
+             linearindexing, LinearFast, LinearSlow
 
 import Base.LinAlg: (\), A_mul_Bc, A_mul_Bt, Ac_ldiv_B, Ac_mul_B, At_ldiv_B, At_mul_B,
                  cholfact, cholfact!, det, diag, ishermitian, isposdef,
@@ -935,19 +936,14 @@ function size(F::Factor, i::Integer)
     return 1
 end
 
+linearindexing(::Dense) = LinearFast()
 function getindex(A::Dense, i::Integer)
     s = unsafe_load(A.p)
     0 < i <= s.nrow*s.ncol || throw(BoundsError())
     unsafe_load(s.x, i)
 end
-function getindex(A::Dense, i::Integer, j::Integer)
-    s = unsafe_load(A.p)
-    0 < i <= s.nrow || throw(BoundsError())
-    0 < j <= s.ncol || throw(BoundsError())
-    unsafe_load(s.x, i + (j - 1)*s.d)
-end
 
-getindex(A::Sparse, i::Integer) = getindex(A, ind2sub(size(A),i)...)
+linearindexing(::Sparse) = LinearSlow()
 function getindex{T}(A::Sparse{T}, i0::Integer, i1::Integer)
     s = unsafe_load(A.p)
     !(1 <= i0 <= s.nrow && 1 <= i1 <= s.ncol) && throw(BoundsError())

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1240,6 +1240,12 @@ end
 getindex{T<:Integer}(A::SparseMatrixCSC, I::AbstractVector{T}, j::Integer) = getindex(A,I,[j])
 getindex{T<:Integer}(A::SparseMatrixCSC, i::Integer, J::AbstractVector{T}) = getindex(A,[i],J)
 
+# Colon translation (this could be done more efficiently)
+getindex(A::SparseMatrixCSC, ::Colon)          = getindex(A, 1:length(A))
+getindex(A::SparseMatrixCSC, ::Colon, ::Colon) = getindex(A, 1:size(A, 1), 1:size(A, 2))
+getindex(A::SparseMatrixCSC, ::Colon, j)       = getindex(A, 1:size(A, 1), j)
+getindex(A::SparseMatrixCSC, i, ::Colon)       = getindex(A, i, 1:size(A, 2))
+
 function getindex_cols{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, J::AbstractVector)
     # for indexing whole columns
     (m, n) = size(A)
@@ -1722,6 +1728,12 @@ setindex!{T<:Integer}(A::SparseMatrixCSC, v::AbstractMatrix, I::AbstractVector{T
 
 setindex!{T<:Integer}(A::SparseMatrixCSC, x::Number, i::Integer, J::AbstractVector{T}) = setindex!(A, x, [i], J)
 setindex!{T<:Integer}(A::SparseMatrixCSC, x::Number, I::AbstractVector{T}, j::Integer) = setindex!(A, x, I, [j])
+
+# Colon translation
+setindex!(A::SparseMatrixCSC, x, ::Colon)          = setindex!(A, x, 1:length(A))
+setindex!(A::SparseMatrixCSC, x, ::Colon, ::Colon) = setindex!(A, x, 1:size(A, 1), 1:size(A,2))
+setindex!(A::SparseMatrixCSC, x, ::Colon, j::Union(Integer, AbstractVector)) = setindex!(A, x, 1:size(A, 1), j)
+setindex!(A::SparseMatrixCSC, x, i::Union(Integer, AbstractVector), ::Colon) = setindex!(A, x, i, 1:size(A, 2))
 
 setindex!{Tv,T<:Integer}(A::SparseMatrixCSC{Tv}, x::Number, I::AbstractVector{T}, J::AbstractVector{T}) =
     (0 == x) ? spdelete!(A, I, J) : spset!(A, convert(Tv,x), I, J)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -146,7 +146,6 @@ copy(S::SparseMatrixCSC) =
     SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), copy(S.nzval))
 
 similar(S::SparseMatrixCSC, Tv::Type=eltype(S))   = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), Array(Tv, length(S.nzval)))
-similar{Tv,Ti,TvNew}(S::SparseMatrixCSC{Tv,Ti}, ::Type{TvNew}, ::Type{Ti}) = similar(S, TvNew)
 similar{Tv,Ti,TvNew,TiNew}(S::SparseMatrixCSC{Tv,Ti}, ::Type{TvNew}, ::Type{TiNew}) = SparseMatrixCSC(S.m, S.n, convert(Array{TiNew},S.colptr), convert(Array{TiNew}, S.rowval), Array(TvNew, length(S.nzval)))
 similar{Tv}(S::SparseMatrixCSC, ::Type{Tv}, d::NTuple{Integer}) = spzeros(Tv, d...)
 
@@ -1225,7 +1224,6 @@ function rangesearch(haystack::Range, needle)
     (rem==0 && 1<=i+1<=length(haystack)) ? i+1 : 0
 end
 
-getindex(A::SparseMatrixCSC, i::Integer) = isempty(A) ? throw(BoundsError()) : getindex(A, ind2sub(size(A),i))
 getindex(A::SparseMatrixCSC, I::Tuple{Integer,Integer}) = getindex(A, I[1], I[2])
 
 function getindex{T}(A::SparseMatrixCSC{T}, i0::Integer, i1::Integer)
@@ -1687,8 +1685,6 @@ end
 
 
 ## setindex!
-setindex!(A::SparseMatrixCSC, v, i::Integer) = setindex!(A, v, ind2sub(size(A),i)...)
-
 function setindex!{T,Ti}(A::SparseMatrixCSC{T,Ti}, v, i0::Integer, i1::Integer)
     i0 = convert(Ti, i0)
     i1 = convert(Ti, i1)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -342,9 +342,8 @@ end
     length(I.parameters) == LD ? (:(LinearFast())) : (:(LinearSlow()))
 end
 
-getindex(::Colon, ::Colon) = Colon()
-getindex{T}(v::AbstractArray{T,1}, ::Colon) = v
-getindex(::Colon, i) = i
+getindex(::Colon, i) = to_index(i)
+unsafe_getindex(v::Colon, i) = to_index(i)
 
 step(::Colon) = 1
 first(::Colon) = 1

--- a/base/subarray2.jl
+++ b/base/subarray2.jl
@@ -85,7 +85,7 @@ end
 # is just a matter of deleting the explicit call to copy.
 getindex{T,N,P,IV}(V::SubArray{T,N,P,IV}, I::ViewIndex...) = copy(sub(V, I...))
 getindex{T,N,P,IV}(V::SubArray{T,N,P,IV}, I::AbstractArray{Bool,N}) = copy(sub(V, find(I)))   # this could be much better optimized
-getindex{T,N,P,IV}(V::SubArray{T,N,P,IV}, I::Union(Real, AbstractVector)...) = getindex(V, to_index(I)...)
+getindex{T,N,P,IV}(V::SubArray{T,N,P,IV}, I::Union(Real, AbstractVector, Colon)...) = getindex(V, to_index(I)...)
 
 function setindex!{T,P,IV}(V::SubArray{T,1,P,IV}, v, I::AbstractArray{Bool,1})
     length(I) == length(V) || throw(DimensionMismatch("logical vector must match array length"))
@@ -99,9 +99,9 @@ function setindex!{T,N,P,IV}(V::SubArray{T,N,P,IV}, v, I::AbstractArray{Bool,N})
     size(I) == size(V) || throw(DimensionMismatch("size of Boolean mask must match array size"))
     _setindex!(V, v, find(I))  # this could be better optimized
 end
-setindex!{T,N,P,IV}(V::SubArray{T,N,P,IV}, v, I::Union(Real,AbstractVector)...) = setindex!(V, v, to_index(I)...)
-setindex!{T,N,P,IV}(V::SubArray{T,N,P,IV}, x, J::Union(Int,AbstractVector)...) = _setindex!(V, x, J...)
-@generated function _setindex!(V::SubArray, x, J::Union(Real,AbstractVector)...)
+setindex!{T,N,P,IV}(V::SubArray{T,N,P,IV}, v, I::Union(Real,AbstractVector,Colon)...) = setindex!(V, v, to_index(I)...)
+setindex!{T,N,P,IV}(V::SubArray{T,N,P,IV}, x, J::Union(Int,AbstractVector,Colon)...) = _setindex!(V, x, J...)
+@generated function _setindex!(V::SubArray, x, J::Union(Real,AbstractVector,Colon)...)
     gen_setindex_body(length(J))
 end
 

--- a/base/subarray2.jl
+++ b/base/subarray2.jl
@@ -176,4 +176,3 @@ unsafe_getindex(v::Range, ind::Int) = first(v) + (ind-1)*step(v)
 @inline unsafe_getindex(v::Array, ind::Int) = (@inbounds x = v[ind]; x)
 unsafe_getindex(v::AbstractArray, ind::Int) = v[ind]
 unsafe_getindex(v::Colon, ind::Int) = ind
-unsafe_getindex(v, ind::Real) = unsafe_getindex(v, to_index(ind))

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -124,6 +124,9 @@ map!(x->1, d)
 
 @test fill!(d, 1) == ones(10, 10)
 @test fill!(d, 2.) == fill(2, 10, 10)
+@test d[:] == fill(2, 100)
+@test d[:,1] == fill(2, 10)
+@test d[1,:] == fill(2, 1, 10)
 
 # Boundary cases where length(S) <= length(pids)
 @test 2.0 == remotecall_fetch(id_other, D->D[2], Base.shmem_fill(2.0, 2; pids=[id_me, id_other]))

--- a/test/perf/array/indexing.jl
+++ b/test/perf/array/indexing.jl
@@ -1,0 +1,172 @@
+# Performance testing
+
+import Base: unsafe_getindex
+# @inline unsafe_getindex(xs...) = Base.getindex(xs...)
+
+function sumelt(A, n)
+    s = zero(eltype(A)) + zero(eltype(A))
+    for k = 1:n
+        for a in A
+            s += a
+        end
+    end
+    s
+end
+
+function sumeach(A, n)
+    s = zero(eltype(A)) + zero(eltype(A))
+    for k = 1:n
+        for I in eachindex(A)
+            val = unsafe_getindex(A, I)
+            s += val
+        end
+    end
+    s
+end
+
+function sumlinear(A, n)
+    s = zero(eltype(A)) + zero(eltype(A))
+    for k = 1:n
+        for I in 1:length(A)
+            val = unsafe_getindex(A, I)
+            s += val
+        end
+    end
+    s
+end
+function sumcartesian(A, n)
+    s = zero(eltype(A)) + zero(eltype(A))
+    for k = 1:n
+        for I in CartesianRange(size(A))
+            val = unsafe_getindex(A, I)
+            s += val
+        end
+    end
+    s
+end
+
+function sumcolon(A, n)
+    s = zero(eltype(A)) + zero(eltype(A))
+    nrows = size(A, 1)
+    ncols = size(A, 2)
+    c = Colon()
+    for k = 1:n
+        @simd for i = 1:ncols
+            val = unsafe_getindex(A, c, i)
+            s += first(val)
+        end
+    end
+    s
+end
+
+function sumrange(A, n)
+    s = zero(eltype(A)) + zero(eltype(A))
+    nrows = size(A, 1)
+    ncols = size(A, 2)
+    r = 1:nrows
+    for k = 1:n
+        @simd for i = 1:ncols
+            val = unsafe_getindex(A, r, i)
+            s += first(val)
+        end
+    end
+    s
+end
+
+function sumlogical(A, n)
+    s = zero(eltype(A)) + zero(eltype(A))
+    nrows = size(A, 1)
+    ncols = size(A, 2)
+    r = falses(nrows)
+    r[1:4:end] = true
+    for k = 1:n
+        @simd for i = 1:ncols
+            val = unsafe_getindex(A, r, i)
+            s += first(val)
+        end
+    end
+    s
+end
+
+function sumvector(A, n)
+    s = zero(eltype(A)) + zero(eltype(A))
+    nrows = size(A, 1)
+    ncols = size(A, 2)
+    r = rand(1:nrows, 5)
+    for k = 1:n
+        @simd for i = 1:ncols
+            val = unsafe_getindex(A, r, i)
+            s += first(val)
+        end
+    end
+    s
+end
+
+abstract MyArray{T,N} <: AbstractArray{T,N}
+
+immutable ArrayLS{T,N} <: MyArray{T,N}  # LinearSlow
+    data::Array{T,N}
+end
+immutable ArrayLSLS{T,N} <: MyArray{T,N}  # LinearSlow with LinearSlow similar
+    data::Array{T,N}
+end
+Base.similar{T}(A::ArrayLSLS, ::Type{T}, dims::Tuple{Vararg{Int}}) = ArrayLSLS(similar(A.data, T, dims))
+@inline Base.setindex!(A::ArrayLSLS, v, I::Int...) = A.data[I...] = v
+@inline Base.unsafe_setindex!(A::ArrayLSLS, v, I::Int...) = Base.unsafe_setindex!(A.data, v, I...)
+Base.first(A::ArrayLSLS) = first(A.data)
+
+immutable ArrayLF{T,N} <: MyArray{T,N}  # LinearFast
+    data::Array{T,N}
+end
+immutable ArrayStrides{T,N} <: MyArray{T,N}
+    data::Array{T,N}
+    strides::NTuple{N,Int}
+end
+ArrayStrides(A::Array) = ArrayStrides(A, strides(A))
+
+immutable ArrayStrides1{T} <: MyArray{T,2}
+    data::Matrix{T}
+    stride1::Int
+end
+ArrayStrides1(A::Array) = ArrayStrides1(A, size(A,1))
+
+Base.size(A::MyArray) = size(A.data)
+
+@inline Base.getindex(A::ArrayLF, i::Int) = getindex(A.data, i)
+@inline Base.getindex(A::ArrayLF, i::Int, i2::Int) = getindex(A.data, i, i2)
+@inline Base.getindex(A::Union(ArrayLS, ArrayLSLS), i::Int, j::Int) = getindex(A.data, i, j)
+@inline Base.unsafe_getindex(A::ArrayLF, indx::Int) = unsafe_getindex(A.data, indx)
+@inline Base.unsafe_getindex(A::Union(ArrayLS, ArrayLSLS), i::Int, j::Int) = unsafe_getindex(A.data, i, j)
+
+@inline Base.getindex{T}(A::ArrayStrides{T,2}, i::Real, j::Real) = getindex(A.data, 1+A.strides[1]*(i-1)+A.strides[2]*(j-1))
+@inline Base.getindex(A::ArrayStrides1, i::Real, j::Real) = getindex(A.data, i + A.stride1*(j-1))
+@inline Base.unsafe_getindex{T}(A::ArrayStrides{T,2}, i::Real, j::Real) = unsafe_getindex(A.data, 1+A.strides[1]*(i-1)+A.strides[2]*(j-1))
+@inline Base.unsafe_getindex(A::ArrayStrides1, i::Real, j::Real) = unsafe_getindex(A.data, i + A.stride1*(j-1))
+
+# Using the qualified Base.LinearFast() in the linearindexing definition
+# requires looking up the symbol in the module on each call.
+import Base: LinearFast
+Base.linearindexing{T<:ArrayLF}(::Type{T}) = LinearFast()
+
+if !applicable(unsafe_getindex, [1 2], 1:1, 2)
+    @inline Base.unsafe_getindex(A::Array, I...) = @inbounds return A[I...]
+    @inline Base.unsafe_getindex(A::MyArray, I...) = @inbounds return A[I...]
+    @inline Base.unsafe_getindex(A::SubArray, I...) = @inbounds return A[I...]
+    @inline Base.unsafe_getindex(A::BitArray, I1::BitArray, I2::Int) = unsafe_getindex(A, Base.to_index(I1), I2)
+end
+
+function makearrays{T}(::Type{T}, sz)
+    L = prod(sz)
+    A = reshape(convert(Vector{T}, [1:L;]), sz)
+    AS = ArrayLS(A)
+    ASS = ArrayLSLS(A)
+    AF = ArrayLF(A)
+    Astrd = ArrayStrides(A)
+    Astrd1 = ArrayStrides1(A)
+    outersz = (sz[1]+1,sz[2]+2)
+    B = reshape(convert(Vector{T}, [1:prod(outersz);]), outersz)
+    Asub = sub(B, 1:sz[1], 2:sz[2]+1)
+    Bit = trues(sz)
+    (A, AS, AF, AS, ASS, AF, Asub, Bit,)
+end
+

--- a/test/perf/array/perf.jl
+++ b/test/perf/array/perf.jl
@@ -1,0 +1,57 @@
+include("../perfutil.jl")
+
+include("indexing.jl")
+
+briefname(A) = typeof(A).name.name
+
+# Small array tests
+sz = (3,5)
+Alist = makearrays(Int, sz)
+for Ar in Alist
+    @timeit sumelt(Ar, 10^5) string("sumeltIs ", briefname(Ar)) string("for a in A indexing, ", briefname(Ar)) sz
+    @timeit sumeach(Ar, 10^5) string("sumeachIs ", briefname(Ar)) string("for I in eachindex(A), ", briefname(Ar)) sz
+    @timeit sumlinear(Ar, 10^5) string("sumlinearIs ", briefname(Ar)) string("for I in 1:length(A), ", briefname(Ar)) sz
+    @timeit sumcartesian(Ar, 10^5) string("sumcartesianIs ", briefname(Ar)) string("for I in CartesianRange(size(A)), ", briefname(Ar)) sz
+    @timeit sumcolon(Ar, 10^5) string("sumcolonIs ", briefname(Ar)) string("colon indexing, ", briefname(Ar)) sz
+    @timeit sumrange(Ar, 10^5) string("sumrangeIs ", briefname(Ar)) string("range indexing, ", briefname(Ar)) sz
+    @timeit sumlogical(Ar, 10^5) string("sumlogicalIs ", briefname(Ar)) string("logical indexing, ", briefname(Ar)) sz
+    @timeit sumvector(Ar, 10^5) string("sumvectorIs ", briefname(Ar)) string("vector indexing, ", briefname(Ar)) sz
+end
+
+Alist = makearrays(Float32, sz)   # SIMD-able
+for Ar in Alist
+    @timeit sumelt(Ar, 10^5) string("sumeltFs ", briefname(Ar)) string("for a in A indexing, ", briefname(Ar)) sz
+    @timeit sumeach(Ar, 10^5) string("sumeachFs ", briefname(Ar)) string("for I in eachindex(A), ", briefname(Ar)) sz
+    @timeit sumlinear(Ar, 10^5) string("sumlinearFs ", briefname(Ar)) string("for I in 1:length(A), ", briefname(Ar)) sz
+    @timeit sumcartesian(Ar, 10^5) string("sumcartesianFs ", briefname(Ar)) string("for I in CartesianRange(size(A)), ", briefname(Ar)) sz
+    @timeit sumcolon(Ar, 10^5) string("sumcolonFs ", briefname(Ar)) string("colon indexing, ", briefname(Ar)) sz
+    @timeit sumrange(Ar, 10^5) string("sumrangeFs ", briefname(Ar)) string("range indexing, ", briefname(Ar)) sz
+    @timeit sumlogical(Ar, 10^5) string("sumlogicalFs ", briefname(Ar)) string("logical indexing, ", briefname(Ar)) sz
+    @timeit sumvector(Ar, 10^5) string("sumvectorFs ", briefname(Ar)) string("vector indexing, ", briefname(Ar)) sz
+end
+
+# Big array tests
+sz = (300,500)
+Alist = makearrays(Int, sz)
+for Ar in Alist
+    @timeit sumelt(Ar, 100) string("sumeltIb ", briefname(Ar)) string("for a in A indexing, ", briefname(Ar)) sz
+    @timeit sumeach(Ar, 100) string("sumeachIb ", briefname(Ar)) string("for I in eachindex(A), ", briefname(Ar)) sz
+    @timeit sumlinear(Ar, 100) string("sumlinearIb ", briefname(Ar)) string("for I in 1:length(A), ", briefname(Ar)) sz
+    @timeit sumcartesian(Ar, 100) string("sumcartesianIb ", briefname(Ar)) string("for I in CartesianRange(size(A)), ", briefname(Ar)) sz
+    @timeit sumcolon(Ar, 100) string("sumcolonIb ", briefname(Ar)) string("colon indexing, ", briefname(Ar)) sz
+    @timeit sumrange(Ar, 100) string("sumrangeIb ", briefname(Ar)) string("range indexing, ", briefname(Ar)) sz
+    @timeit sumlogical(Ar, 100) string("sumlogicalIb ", briefname(Ar)) string("logical indexing, ", briefname(Ar)) sz
+    @timeit sumvector(Ar, 100) string("sumvectorIb ", briefname(Ar)) string("vector indexing, ", briefname(Ar)) sz
+end
+
+Alist = makearrays(Float32, sz)   # SIMD-able
+for Ar in Alist
+    @timeit sumelt(Ar, 100) string("sumeltFb ", briefname(Ar)) string("for a in A indexing, ", briefname(Ar)) sz
+    @timeit sumeach(Ar, 100) string("sumeachFb ", briefname(Ar)) string("for I in eachindex(A), ", briefname(Ar)) sz
+    @timeit sumlinear(Ar, 100) string("sumlinearFb ", briefname(Ar)) string("for I in 1:length(A), ", briefname(Ar)) sz
+    @timeit sumcartesian(Ar, 100) string("sumcartesianFb ", briefname(Ar)) string("for I in CartesianRange(size(A)), ", briefname(Ar)) sz
+    @timeit sumcolon(Ar, 100) string("sumcolonFb ", briefname(Ar)) string("colon indexing, ", briefname(Ar)) sz
+    @timeit sumrange(Ar, 100) string("sumrangeFb ", briefname(Ar)) string("range indexing, ", briefname(Ar)) sz
+    @timeit sumlogical(Ar, 100) string("sumlogicalFb ", briefname(Ar)) string("logical indexing, ", briefname(Ar)) sz
+    @timeit sumvector(Ar, 100) string("sumvectorFb ", briefname(Ar)) string("vector indexing, ", briefname(Ar)) sz
+end

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -746,6 +746,7 @@ end
 @test sparse([]') == reshape(sparse([]), 1, 0)
 @test full(sparse([])) == zeros(0, 1)
 @test_throws BoundsError sparse([])[1]
+@test_throws BoundsError sparse([])[1] = 1
 x = speye(100)
 @test_throws BoundsError x[-10:10]
 

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -742,11 +742,6 @@ a = SparseMatrixCSC(2, 2, [1, 3, 5], [1, 2, 1, 2], [1.0, 0.0, 0.0, 1.0])
 @test_approx_eq cholfact(a)\[2.0, 3.0] [2.0, 3.0]
 end
 
-# issue #10113
-let S = spzeros(5,1), I = [false,true,false,true,false]
-    @test_throws BoundsError S[I]
-end
-
 # issue #9917
 @test sparse([]') == reshape(sparse([]), 1, 0)
 @test full(sparse([])) == zeros(0, 1)

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -395,6 +395,8 @@ sA = sub(A, 1:2:3, 1:3:5, 1:2:8)
 @test sA[:] == A[1:2:3, 1:3:5, 1:2:8][:]
 # issue #8807
 @test sub(sub([1:5;], 1:5), 1:5) == [1:5;]
+# Test with mixed types
+@test sA[:, Int16[1,2], big(2)] == [31 40; 33 42]
 
 # sub logical indexing #4763
 A = sub([1:10;], 5:8)


### PR DESCRIPTION
~~This is still a work in progress, but I'd like to get some feedback on the architecture and design here before applying this same sort of scheme to `setindex!`.~~

The basic idea is that the only getindex method defined in base for abstract arrays is `getindex(::AbstractArray, I...)`. And the only methods that an AbstractArray subtype must define are `size` and just one `getindex` method:

``` julia
getindex(::T, ::Int) # if linearindexing(T) == LinearFast()
getindex(::T, ::Int, ::Int, #=...ndims(A) indices...=#) if LinearSlow()
```

Unfortunately, it is currently impossible to express the latter method for arbitrary dimensionalities, but in practice it's not a big issue: most LinearSlow() arrays have a fixed dimension.

This is achieved through dispatch on an internal `_getindex` method, which recomputes the indices such that it can call the canonical `getindex` method that the user must define.  If the user has not defined their canonical method, it will fall back to an error method in `_getindex`.  I use similar scheme for `unsafe_getindex`, with the exception that we can fallback to the safe version if the subtype hasn't defined the canonical unsafe method.  This enables fast vector indexing by checking bounds of the index vectors instead of on each element.  And once `@inbounds` is extensible, AbstractArrays will be able to support it by default.

The difficulty with all this redirection is that an extra function call can wreck indexing performance, and it can be hard to avoid.  ~~I've had particular difficulty getting good performance with `CartesianIndexes`, and I still lag in performance there by 20x for big arrays.  I think call site inline annotations would be a magic bullet, but there may be other tricks we can use, too.  I've not looked into this very carefully yet, though.~~ (Fixed with a more sensible inlining strategy)

TL/DR:

In my cursory performance tests [hacked onto Tim's indexing perf suite from his reshape work](https://gist.github.com/mbauman/39bb490ce2bee52417f1) (more tests are needed), I'm close to matching _or outperforming_ master with `Array` with only these definitions:

``` julia
julia> methods(getindex, (Array, Any...))
3-element Array{Any,1}:
 getindex(A::Array{T,N},i::Int) at array.jl:304
 getindex{T<:Real}(A::Array{T,N},I::Range{T<:Real}) at array.jl:347 # Needed for bootstrap
 getindex(A::AbstractArray{T,N},I...) at abstractarray.jl:492
```

(Of course, in places where we're not quite able to close the gap we can always reinstate the specialized methods. This is just a very useful stress-test of both functionality and performance.)

cc: @timholy 
