### PR TITLE
pull with --rebase in Pkg.update()

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -247,7 +247,7 @@ function update(branch::AbstractString)
         end
         # TODO: handle merge conflicts
         Base.with_env("GIT_MERGE_AUTOEDIT","no") do
-            Git.run(`pull -q`, out=DevNull)
+            Git.run(`pull --rebase -q`, out=DevNull)
         end
     end
     avail = Read.available()


### PR DESCRIPTION
See https://groups.google.com/d/msg/julia-dev/vrVSPbHRdIM/uEIBysnh2G4J for motivation

Merge commits are messy and confusing, they accumulate in your local METADATA if you do `Pkg.tag` then `Pkg.update` a bunch of times before publishing and finally merging your new commits into the official repo. There's already a todo here about merge conflicts, I don't think preferring rebase over merge makes the situation any worse.

edit: looks like `--rebase`, but not `-r`, is supported by our minimum required version of git: http://git-scm.com/docs/git-pull/1.7.3
