### PR TITLE
Faster and more general reductions for sparse matrices

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -93,6 +93,8 @@ immutable CentralizedAbs2Fun{T<:Number} <: Func{1}
     m::T
 end
 call(f::CentralizedAbs2Fun, x) = abs2(x - f.m)
+centralize_sumabs2(A::AbstractArray, m::Number) =
+    mapreduce(CentralizedAbs2Fun(m), AddFun(), A)
 centralize_sumabs2(A::AbstractArray, m::Number, ifirst::Int, ilast::Int) =
     mapreduce_impl(CentralizedAbs2Fun(m), AddFun(), A, ifirst, ilast)
 
@@ -137,7 +139,7 @@ function varm{T}(A::AbstractArray{T}, m::Number; corrected::Bool=true)
     n = length(A)
     n == 0 && return convert(momenttype(T), NaN)
     n == 1 && return convert(momenttype(T), abs2(A[1] - m)/(1 - Int(corrected)))
-    return centralize_sumabs2(A, m, 1, n) / (n - Int(corrected))
+    return centralize_sumabs2(A, m) / (n - Int(corrected))
 end
 
 function varm!{S}(R::AbstractArray{S}, A::AbstractArray, m::AbstractArray; corrected::Bool=true)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -249,12 +249,12 @@ const × = cross
 include("broadcast.jl")
 importall .Broadcast
 
+# statistics
+include("statistics.jl")
+
 # sparse matrices and sparse linear algebra
 include("sparse.jl")
 importall .SparseMatrix
-
-# statistics
-include("statistics.jl")
 
 # signal processing
 include("fftw.jl")

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -464,16 +464,18 @@ Iterable Collections
    :func:`mapreduce` is functionally equivalent to calling ``reduce(op,
    v0, map(f, itr))``, but will in general execute faster since no
    intermediate collection needs to be created. See documentation for
-   :func:`reduce` and ``map``.
+   :func:`reduce` and :func:`map`.
 
    .. doctest::
 
       julia> mapreduce(x->x^2, +, [1:3]) # == 1 + 4 + 9
       14
 
-   The associativity of the reduction is implementation-dependent. Use
-   :func:`mapfoldl` or :func:`mapfoldr` instead for guaranteed left or
-   right associativity.
+   The associativity of the reduction is implementation-dependent.
+   Additionally, some implementations may reuse the return value of
+   ``f`` for elements that appear multiple times in ``itr``.
+   Use :func:`mapfoldl` or :func:`mapfoldr` instead for guaranteed
+   left or right associativity and invocation of ``f`` for every value.
 
 .. function:: mapreduce(f, op, itr)
 


### PR DESCRIPTION
This hooks sparse matrix reductions into the `mapreduce`/`mapreducedim` framework so that reductions based on those two functions (`sum`, `prod`, `maximum`, `minimum`,  `sumabs`, `sumabs2`, `maxabs`, `minabs`, and others) are fast for sparse matrices. I also implemented a method of `centralize_sumabs2!`, which is the function that computes the reduction for `var` and `std`. This required a tiny tweak to `statistics.jl`.

Before:

``` julia
julia> A = sprand(10000, 10000, 0.01);

julia> @time sum(A);
elapsed time: 0.000725368 seconds (128 bytes allocated)

julia> @time sum(A, 1);
elapsed time: 0.050776048 seconds (31 MB allocated, 31.91% gc time in 2 pauses with 1 full sweep)

julia> @time sum(A, 2);
elapsed time: 0.150387959 seconds (76 MB allocated, 16.90% gc time in 3 pauses with 0 full sweep)

julia> @time minimum(A);
elapsed time: 0.000895639 seconds (128 bytes allocated)

julia> @time minimum(A, 1);
elapsed time: 0.025368923 seconds (31 MB allocated, 16.27% gc time in 2 pauses with 0 full sweep)

julia> @time minimum(A, 2);
elapsed time: 0.099724495 seconds (76 MB allocated, 5.97% gc time in 3 pauses with 0 full sweep)

julia> @time sumabs2(A);
elapsed time: 2.84146989 seconds (128 bytes allocated)

julia> @time sumabs2(A, 1);
elapsed time: 1.347525703 seconds (592 kB allocated)

julia> @time sumabs2(A, 2);
elapsed time: 9.477093327 seconds (514 kB allocated)

julia> @time var(A);
elapsed time: 2.861990251 seconds (224 bytes allocated)

julia> @time var(A, 1);
elapsed time: 1.378826771 seconds (31 MB allocated, 0.29% gc time in 2 pauses with 0 full sweep)

julia> @time var(A, 2);
elapsed time: 9.576421764 seconds (76 MB allocated, 0.06% gc time in 3 pauses with 0 full sweep)
```

After:

``` julia
julia> A = sprand(10000, 10000, 0.01);

julia> @time sum(A);
elapsed time: 0.00059218 seconds (96 bytes allocated)

julia> @time sum(A, 1);
elapsed time: 0.000527368 seconds (78 kB allocated)

julia> @time sum(A, 2);
elapsed time: 0.001874181 seconds (78 kB allocated)

julia> @time minimum(A);
elapsed time: 0.000835505 seconds (96 bytes allocated)

julia> @time minimum(A, 1);
elapsed time: 0.00154097 seconds (78 kB allocated)

julia> @time minimum(A, 2);
elapsed time: 0.003695277 seconds (156 kB allocated)

julia> @time sumabs2(A);
elapsed time: 0.000476106 seconds (96 bytes allocated)

julia> @time sumabs2(A, 1);
elapsed time: 0.000620605 seconds (78 kB allocated)

julia> @time sumabs2(A, 2);
elapsed time: 0.001989696 seconds (78 kB allocated)

julia> @time var(A);
elapsed time: 0.000910167 seconds (192 bytes allocated)

julia> @time var(A, 1);
elapsed time: 0.001041256 seconds (157 kB allocated)

julia> @time var(A, 2);
elapsed time: 0.006364037 seconds (235 kB allocated)
```

All times are after warmup.
