### PR TITLE
correctly parse integer types in readdlm. fixes #9289

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -76,10 +76,9 @@ signed(x::BigInt) = x
 BigInt(x::BigInt) = x
 BigInt(s::AbstractString) = parse(BigInt,s)
 
-function tryparse_internal(::Type{BigInt}, s::AbstractString, base::Int, raise::Bool)
+function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, endpos::Int, base::Int, raise::Bool)
     _n = Nullable{BigInt}()
-    s = bytestring(s)
-    sgn, base, i = Base.parseint_preamble(true,s,base)
+    sgn, base, i = Base.parseint_preamble(true,base,s,startpos,endpos)
     if i == 0
         raise && throw(ArgumentError("premature end of integer: $(repr(s))"))
         return _n
@@ -87,7 +86,7 @@ function tryparse_internal(::Type{BigInt}, s::AbstractString, base::Int, raise::
     z = BigInt()
     err = ccall((:__gmpz_set_str, :libgmp),
                Int32, (Ptr{BigInt}, Ptr{UInt8}, Int32),
-               &z, SubString(s,i), base)
+               &z, SubString(s,i,endpos), base)
     if err != 0
         raise && throw(ArgumentError("invalid BigInt: $(repr(s))"))
         return _n

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -197,3 +197,8 @@ let i18n_data = ["Origin (English)", "Name (English)", "Origin (Native)", "Name 
     writedlm(i18n_buff, i18n_arr, '\t')
     @test (data, hdr) == readdlm(i18n_buff, '\t', header=true)
 end
+
+@test isequaldlm(readcsv(IOBuffer("1,22222222222222222222222222222222222222,0x3,10e6\n2000.1,true,false,-10.34"), Any),
+    reshape(Any[1,2000.1,Float64(22222222222222222222222222222222222222),true,0x3,false,10e6,-10.34], 2, 4), Any)
+
+@test isequaldlm(readcsv(IOBuffer("-9223355253176920979,9223355253176920979"), Int64), Int64[-9223355253176920979  9223355253176920979], Int64)


### PR DESCRIPTION
Continued from #9316 
- Separate `colval` method for `Integer`s.
- Used `tryparse_internal` methods instead of `float64_isvalid`.
- Modified `tryparse_internal` to be able to parse a section of a string (avoids unnecessary `SubString` creation).
- If return array is of `Any` type, try parsing as the most common types (`Int`, `Bool` and `Float64`) before falling back to `SubString`. The previous behavior was to try `Float64` only.

There is no significant impact on performance with this change.
