### PR TITLE
Keep a reference to the current REPL backend in a global variable

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -403,6 +403,7 @@ function _start()
 
         local term
         global active_repl
+        global active_repl_backend
         if repl
             if !isa(STDIN,TTY)
                 global is_interactive |= !isa(STDIN,Union(File,IOStream))
@@ -441,7 +442,7 @@ function _start()
                     end
                 end
             else
-                REPL.run_repl(active_repl)
+                active_repl_backend = REPL.run_repl(active_repl)
             end
         end
     catch err

--- a/base/task.jl
+++ b/base/task.jl
@@ -94,7 +94,7 @@ function task_done_hook(t::Task)
     else
         if err && !handled
             if isa(result,InterruptException) && isdefined(Base,:active_repl_backend) &&
-                active_repl_backend.backend_task.state == :waiting && isempty(Workqueue) && 
+                active_repl_backend.backend_task.state == :waiting && isempty(Workqueue) &&
                 active_repl_backend.in_eval
                 throwto(active_repl_backend.backend_task, result)
             end

--- a/base/task.jl
+++ b/base/task.jl
@@ -93,9 +93,10 @@ function task_done_hook(t::Task)
         yieldto(nexttask, result)
     else
         if err && !handled
-            if isa(result,InterruptException) && isdefined(REPL,:interactive_task) &&
-                REPL.interactive_task.state == :waiting && isempty(Workqueue)
-                throwto(REPL.interactive_task, result)
+            if isa(result,InterruptException) && isdefined(Base,:active_repl_backend) &&
+                active_repl_backend.backend_task.state == :waiting && isempty(Workqueue) && 
+                active_repl_backend.in_eval
+                throwto(active_repl_backend.backend_task, result)
             end
             let bt = catch_backtrace()
                 # run a new task to print the error for us


### PR DESCRIPTION
A slightly more organized way to do #10416, making sure that the prompt
gets restored on an InterruptException, even if it is not currently evaluating
anything.

@JeffBezanson 
