### PR TITLE
In inference, make string constants module local

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3520,9 +3520,15 @@ static void finalize_gc_frame(jl_codectx_t *ctx)
         Instruction *after = ctx->argSpaceInits;
 
         for(size_t i=0; i < (size_t)ctx->maxDepth; i++) {
+#ifdef LLVM37
+            Instruction *argTempi =
+                GetElementPtrInst::Create(NULL,newgcframe,
+                                          ConstantInt::get(T_int32, i+ctx->argSpaceOffs+2));
+#else
             Instruction *argTempi =
                 GetElementPtrInst::Create(newgcframe,
                                           ConstantInt::get(T_int32, i+ctx->argSpaceOffs+2));
+#endif
             instList.insertAfter(after, argTempi);
             after = new StoreInst(V_null, argTempi);
             instList.insertAfter(argTempi, after);


### PR DESCRIPTION
During inference, we can end up in a situation where the stack looks like

COMPILE B
CALL B
COMPILE A
CALL A

If A and B are methods of the same functions, it is likely that they share
string constants, but in MCJIT these will be allocated in the module for A,
so when B references them, the call to B tries to materialize the modules for
both A and B, leading to an assertion failure, because the compile for A is
not finished yet. Work around this by disabling string constant pooling in
inference. The proper fix is to write an LLVM pass that records the location
of global constants before the module is emitted and merges them there.

Fixes the assertion failure in #10341 in a non horrible way (there were huge performance implications from the other patch). Unfortunately this patch may not fix @vtjnash 's issue from the same thread.
