### PR TITLE
Add git hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,15 @@ Make sure that [Travis](http://www.travis-ci.org) greenlights the pull request w
      `git rebase --whitespace=fix HEAD~1`.
    - To remove whitespace relative to the `master` branch, run
      `git rebase --whitespace=fix master`.
+ - We recommend you run the following commands from the root of your Julia repository to set up git commit hooks:
+
+   ```
+   ln -s ../../contrib/check-whitespace.sh .git/hooks/pre-commit
+   ln -s ../../contrib/git/prepare-commit-msg.jl .git/hooks/prepare-commit-msg
+   ln -s ../../contrib/git/commit-msg.jl .git/hooks/commit-msg
+   ```
+
+   The `pre-commit` hook checks for trailing whitespace before creating a commit. The `prepare-commit-msg` hook determines whether only documentation files have been modified, and if so, adds `[ci skip]` to the commit message. The `commit-msg` hook replaces @ with ＠ (`\uff20`) when it encounters macros defined in Base or Base.Test to avoid triggering GitHub notifications.
 
 ## Getting help
 

--- a/contrib/git/commit-msg.jl
+++ b/contrib/git/commit-msg.jl
@@ -1,0 +1,18 @@
+#!/usr/bin/env julia
+# Replace @macros with ＠macros to avoid triggering GitHub notifications
+
+msg = readall(ARGS[1])
+newmsg = msg
+
+for binding in [names(Base); names(Base.Test)]
+	str = string(binding)
+	if startswith(str, '@')
+		newmsg = replace(newmsg, str, string('＠', str[2:end]))
+	end
+end
+
+if newmsg != msg
+	f = open(ARGS[1], "w")
+	write(f, newmsg)
+	close(f)
+end

--- a/contrib/git/prepare-commit-msg.jl
+++ b/contrib/git/prepare-commit-msg.jl
@@ -1,0 +1,25 @@
+#!/usr/bin/env julia
+# Checks for documentation or contrib-only commits and adds [ci skip]
+# to the commit message
+
+if length(ARGS) == 3 && ARGS[2] == "commit"
+	cmd = `git diff --cached --name-only $(ARGS[3])`
+elseif length(ARGS) == 1
+	cmd = `git diff --cached --name-only`
+else
+	exit()
+end
+
+io, proc = open(cmd)
+for path in readlines(io)
+	(startswith(path, "contrib") || startswith(path, "doc") || endswith(path, ".md")) && continue
+	exit()
+end
+close(io)
+
+msg = readall(ARGS[1])
+contains(msg, "[ci skip]") && exit()
+newmsg = string("\n\n[ci skip]", msg)
+f = open(ARGS[1], "w")
+write(f, newmsg)
+close(f)


### PR DESCRIPTION
- `prepare-commit-msg.jl` adds [ci skip] to commit message when commit
  does not contain modifications outside of contrib/ or doc/, or all
  modifications are to files ending in .md
- `commit-msg.jl` automatically replaces @ with ＠ for macros defined in
  Base or Base.Test
