### PR TITLE
Fix Pkg.update() for empty ~/.julia/v0.4

### DIFF
--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -21,9 +21,10 @@ path(pkg::AbstractString...) = normpath(path(),pkg...)
 
 function cd(f::Function, args...; kws...)
     dir = path()
-    if !isdir(dir)
+    metadata_dir = joinpath(dir, "METADATA")
+    if !isdir(metadata_dir)
         !haskey(ENV,"JULIA_PKGDIR") ? init() :
-            error("package directory $dir doesn't exist; run Pkg.init() to create it.")
+            error("Package metadata directory $metadata_dir doesn't exist; run Pkg.init() to initialize it.")
     end
     Base.cd(()->f(args...; kws...), dir)
 end
@@ -34,9 +35,10 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
     end
     dir = path()
     info("Initializing package repository $dir")
-    if isdir(joinpath(dir,"METADATA"))
+    metadata_dir = joinpath(dir, "METADATA")
+    if isdir(metadata_dir)
         info("Package directory $dir is already initialized.")
-        Git.set_remote_url(meta, dir=joinpath(dir,"METADATA"))
+        Git.set_remote_url(meta, dir=metadata_dir)
         return
     end
     try
@@ -53,7 +55,7 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
             end
         end
     catch e
-        ispath(dir) && rm(dir, recursive=true)
+        ispath(metadata_dir) && rm(metadata_dir, recursive=true)
         rethrow(e)
     end
 end


### PR DESCRIPTION
By my own clever use of the [unison](http://www.cis.upenn.edu/~bcpierce/unison/) package, I ran into a situation where ~/.julia/v0.4 existed but did not contain a METADATA directory.  If ~/.julia/v0.4 exists but ~/.julia/v0.4/METADATA does not, Pkg.update() fails with an obscure error message.  This patch fixes this.

In addition, I noticed that if the git clone of METADATA fails, the exception handling removes everything in ~/.julia/v0.4.  If the user has packages there already, this can be overkill (and lead to data loss if there are local changes), so I changed it to remove only everything in ~/.julia/v0.4/METADATA when METADATA fails to clone.
