### PR TITLE
searchindex: accept a Char similar to search

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -300,6 +300,8 @@ end
 searchindex(s::Union(Array{UInt8,1},Array{Int8,1}),t::Union(Array{UInt8,1},Array{Int8,1}),i) = _searchindex(s,t,i)
 searchindex(s::AbstractString, t::AbstractString, i::Integer) = _searchindex(s,t,i)
 searchindex(s::AbstractString, t::AbstractString) = searchindex(s,t,start(s))
+searchindex(s::AbstractString, c::Char, i::Integer) = _searchindex(s,c,i)
+searchindex(s::AbstractString, c::Char) = searchindex(s,c,start(s))
 
 function searchindex(s::ByteString, t::ByteString, i::Integer=1)
     if length(t) == 1


### PR DESCRIPTION
searchindex: accept a Char

The Julia documentation says:

[searchindex](http://julia.readthedocs.org/en/latest/stdlib/strings/?highlight=searchindex#Base.searchindex)
Similar to search, but return only the start index at which the substring is found, or 0 if it is not.

``` julia
julia> search("teststring", 'n')
9

julia> searchindex("teststring", 'n')
ERROR: MethodError: `searchindex` has no method matching searchindex(::ASCIIString, ::Char)
Closest candidates are:
  searchindex(::Union(UTF8String,ASCIIString), ::Union(UTF8String,ASCIIString))
  searchindex(::Union(UTF8String,ASCIIString), ::Union(UTF8String,ASCIIString), ::Integer)
  searchindex(::AbstractString, ::AbstractString, ::Integer)
  ...

julia> 
```

BTW: not sure why a Set of chars seems not to work - and rsearchindex would seem to need additional fixing to accept a char
Anywhay this would be a start to bring `searchindex` a bit closer to `search`
