### PR TITLE
Simplify real givensAlgorithm.

### DIFF
--- a/base/linalg/givens.jl
+++ b/base/linalg/givens.jl
@@ -35,76 +35,10 @@ realmin2(::Type{Float32}) = reinterpret(Float32, 0x26000000)
 realmin2(::Type{Float64}) = reinterpret(Float64, 0x21a0000000000000)
 realmin2{T}(::Type{T}) = (twopar = 2one(T); twopar^trunc(Integer,log(realmin(T)/eps(T))/log(twopar)/twopar))
 
-# derived from LAPACK's dlartg
-# Copyright:
-# Univ. of Tennessee
-# Univ. of California Berkeley
-# Univ. of Colorado Denver
-# NAG Ltd.
-function givensAlgorithm{T<:FloatingPoint}(f::T, g::T)
-    zeropar = zero(T)
-    onepar = one(T)
-    twopar = 2one(T)
-
-    safmin = realmin(T)
-    epspar = eps(T)
-    safmn2 = realmin2(T)
-    safmx2 = onepar/safmn2
-
-    if g == 0
-        cs = onepar
-        sn = zeropar
-        r = f
-    elseif f == 0
-        cs = zeropar
-        sn = onepar
-        r = g
-    else
-        f1 = f
-        g1 = g
-        scalepar = max(abs(f1), abs(g1))
-        if scalepar >= safmx2
-            count = 0
-            while true
-                count += 1
-                f1 *= safmn2
-                g1 *= safmn2
-                scalepar = max(abs(f1), abs(g1))
-                if scalepar < safmx2 break end
-            end
-            r = sqrt(f1*f1 + g1*g1)
-            cs = f1/r
-            sn = g1/r
-            for i = 1:count
-                r *= safmx2
-            end
-        elseif scalepar <= safmn2
-            count = 0
-            while true
-                count += 1
-                f1 *= safmx2
-                g1 *= safmx2
-                scalepar = max(abs(f1), abs(g1))
-                if scalepar > safmn2 break end
-            end
-            r = sqrt(f1*f1 + g1*g1)
-            cs = f1/r
-            sn = g1/r
-            for i = 1:count
-                r *= safmn2
-            end
-        else
-            r = sqrt(f1*f1 + g1*g1)
-            cs = f1/r
-            sn = g1/r
-        end
-        if abs(f) > abs(g) && cs < 0
-            cs = -cs
-            sn = -sn
-            r = -r
-        end
-    end
-    return cs, sn, r
+function givensAlgorithm(f::Real, g::Real)
+    h = hypot(f,g)
+    hi = inv(h)
+    f*hi, g*hi, h
 end
 
 # derived from LAPACK's zlartg


### PR DESCRIPTION
So far, we have been using a translation of the real givens rotations subroutine DLARTG from LAPACK. However, it is basically reimplementing `hypot` so I think we can make the implementation much simpler by just using our `hypot` function and it is also approxmately 20 pct. faster.

``` julia
julia> let
       f, g = randn(2)
       @time for i = 1:10^8; tmp1 = LinAlg.givensAlgorithm(f, g); end # New Givens
       @time for i = 1:10^8; Hypot.givensAlgorithm(f, g); end  # LAPACK Givens
       end
elapsed time: 0.901623412 seconds (0 bytes allocated)
elapsed time: 1.182648847 seconds (0 bytes allocated)
```

Furthermore, the simplification makes the cosine and sine continuous in the angle which the LAPACK version is not. 

![lapackgivens](https://cloud.githubusercontent.com/assets/505001/6757861/ab279ff0-cf0a-11e4-8206-53f57cfc77f0.png)
![newgivens](https://cloud.githubusercontent.com/assets/505001/6757862/aea801c4-cf0a-11e4-953d-d7891e3e160c.png)
This note

http://www.netlib.org/lapack/lawnspdf/lawn150.pdf

argues that continuity is useful, but for some reason, the LAPACK authors haven't followed the advice.

cc: @alanedelman, @stevengj 
