### PR TITLE
fix spdiagm to promote all the element types

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2249,7 +2249,7 @@ function spdiagm_internal(B, d)
     end
     I = Array(Int, ncoeffs)
     J = Array(Int, ncoeffs)
-    V = Array(eltype(B[1]), ncoeffs)
+    V = Array(promote_type(map(eltype, B)...), ncoeffs)
     id = 0
     i = 0
     for vec in B

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -740,3 +740,6 @@ for (m,n) in ((2,-2),(-2,2),(-2,-2))
     @test_throws ArgumentError speye(m,n)
     @test_throws ArgumentError sprand(m,n,0.2)
 end
+
+# promotion in spdiagm
+@test spdiagm(([1,2],[3.5],[4+5im]), (0,1,-1), 2,2) == [1 3.5; 4+5im 2]


### PR DESCRIPTION
Previously, `spdiagm(B, ...)` was just using the `eltype` of `B[1]`, rather than promoting all of the eltypes.   I noticed this today when I tried to create a sparse matrix where one diagonal was real and another was complex, and it threw an `InexactError`.  (cc @oskooi)
