### PR TITLE
Avoid use of Uint128 in sampling from a range

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -412,13 +412,12 @@ rem_knuth(a::UInt, b::UInt) = a % (b + (b == 0)) + a * (b == 0)
 rem_knuth{T<:Unsigned}(a::T, b::T) = b != 0 ? a % b : a
 
 # maximum multiple of k <= 2^bits(T) decremented by one,
-# that is 0xFFFFFFFF if k = typemax(T) - typemin(T) with intentional underflow
-maxmultiple(k::UInt32) = (div(0x0000000100000000,k + (k == 0))*k - 1) % UInt32
-maxmultiple(k::UInt64) = (div(0x00000000000000010000000000000000, k + (k == 0))*k - 1) % UInt64
-# maximum multiple of k within 1:typemax(UInt128)
-maxmultiple(k::UInt128) = div(typemax(UInt128), k + (k == 0))*k - 1
-# maximum multiple of k within 1:2^32 or 1:2^64, depending on size
-maxmultiplemix(k::UInt64) = (div((k >> 32 != 0)*0x0000000000000000FFFFFFFF00000000 + 0x0000000100000000, k + (k == 0))*k - 1) % UInt64
+# that is 0xFFFF...FFFF if k = typemax(T) - typemin(T) with intentional underflow
+# see http://stackoverflow.com/questions/29182036/integer-arithmetic-add-1-to-uint-max-and-divide-by-n-without-overflow
+maxmultiple{T<:Unsigned}(k::T) = (div(typemax(T) - k + one(k), k + (k == 0))*k + k - one(k))::T
+
+# maximum multiple of k within 1:2^32 or 1:2^64 decremented by one, depending on size
+maxmultiplemix(k::UInt64) = if k >> 32 != 0; maxmultiple(k); else (div(0x0000000100000000, k + (k == 0))*k - one(k))::Uint64; end
 
 abstract RangeGenerator
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -71,6 +71,12 @@ for T in (Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt
     end
 end
 
+@test !any([(Base.Random.maxmultiple(i)+i) > 0xFF for i in 0x00:0xFF])
+@test all([(Base.Random.maxmultiple(i)+1) % i for i in 0x01:0xFF] .== 0)
+@test all([(Base.Random.maxmultiple(i)+1+i) > 0xFF for i in 0x00:0xFF])
+@test length(0x00:0xFF)== Base.Random.maxmultiple(0x0)+1
+
+
 if sizeof(Int32) < sizeof(Int)
     r = rand(Int32(-1):typemax(Int32))
     @test typeof(r) == Int32
@@ -78,6 +84,9 @@ if sizeof(Int32) < sizeof(Int)
     @test all([div(0x00010000000000000000,k)*k - 1 == Base.Random.RangeGenerator(map(UInt64,1:k)).u for k in 13 .+ Int64(2).^(32:62)])
     @test all([div(0x00010000000000000000,k)*k - 1 == Base.Random.RangeGenerator(map(Int64,1:k)).u for k in 13 .+ Int64(2).^(32:61)])
 
+    @test Base.Random.maxmultiplemix(0x000100000000) === 0xffffffffffffffff
+    @test Base.Random.maxmultiplemix(0x0000FFFFFFFF) === 0x00000000fffffffe
+    @test Base.Random.maxmultiplemix(0x000000000000) === 0xffffffffffffffff
 end
 
 # BigInt specific


### PR DESCRIPTION
This is desired because of https://github.com/JuliaLang/julia/commit/2c327d3ffaa8a4b14219b7a2797230e80d78dedf#commitcomment-10326954

Note that this also allows to use the full entropy of Uint128 random integers to sample a Uint128 range, so I included this immediately. This means for certain cases, rand(uint128(0:i)) will be more efficient (but produce different random numbers.)

cc @rfourquet 
