### PR TITLE
WIP: more MSVC compatibility

### DIFF
--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -141,7 +141,7 @@ if ! [ -e $f ]; then
 fi
 echo "Extracting $f"
 $SEVENZIP x -y $f >> get-deps.log
-echo 'LLVM_CONFIG = $(JULIAHOME)/usr/bin/llvm-config' >> Make.user
+echo 'override LLVM_CONFIG = $(JULIAHOME)/usr/bin/llvm-config' >> Make.user
 
 if [ -n "$APPVEYOR" ]; then
   for i in make.exe touch.exe msys-intl-8.dll msys-iconv-2.dll; do

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -790,7 +790,8 @@ DLLEXPORT jl_nullable_float64_t jl_try_substrtod(char *str, size_t offset, int l
     if (bstr != str+offset)
         free(bstr);
 
-    return (jl_nullable_float64_t){(uint8_t)err, out};
+    jl_nullable_float64_t ret = {(uint8_t)err, out};
+    return ret;
 }
 
 DLLEXPORT jl_nullable_float64_t jl_try_strtod(char *str)
@@ -811,7 +812,8 @@ DLLEXPORT jl_nullable_float64_t jl_try_strtod(char *str)
         err = str_isspace(p) ? 0 : 1;
     }
 
-    return (jl_nullable_float64_t){(uint8_t)err, out};
+    jl_nullable_float64_t ret = {(uint8_t)err, out};
+    return ret;
 }
 
 DLLEXPORT int jl_substrtod(char *str, size_t offset, int len, double *out)
@@ -876,7 +878,8 @@ DLLEXPORT jl_nullable_float32_t jl_try_substrtof(char *str, size_t offset, int l
     if (bstr != str+offset)
         free(bstr);
 
-    return (jl_nullable_float32_t){(uint8_t)err, out};
+    jl_nullable_float32_t ret = {(uint8_t)err, out};
+    return ret;
 }
 
 DLLEXPORT jl_nullable_float32_t jl_try_strtof(char *str)
@@ -900,7 +903,8 @@ DLLEXPORT jl_nullable_float32_t jl_try_strtof(char *str)
         err = str_isspace(p) ? 0 : 1;
     }
 
-    return (jl_nullable_float32_t){(uint8_t)err, out};
+    jl_nullable_float32_t ret = {(uint8_t)err, out};
+    return ret;
 }
 
 DLLEXPORT int jl_substrtof(char *str, int offset, int len, float *out)

--- a/src/julia.h
+++ b/src/julia.h
@@ -56,8 +56,12 @@ extern "C" {
 
 // core data types ------------------------------------------------------------
 
+#ifndef _COMPILER_MICROSOFT_
 #define JL_DATA_TYPE \
     struct _jl_value_t *fieldptr0[0];
+#else
+#define JL_DATA_TYPE
+#endif
 
 typedef struct _jl_value_t {
     JL_DATA_TYPE


### PR DESCRIPTION
A few things that I would have put into #10528 if I had rebased that again and caught them.

There's still a GNU extension being used to have an array of `jl_value_t` in the `jl_taggedvalue_t` struct(https://github.com/JuliaLang/julia/pull/10579#issuecomment-84537714), so don't merge this until we can find a workaround for that issue.
