### PR TITLE
Deprecate Euler number e in favor of ℯ (U+212F)

### DIFF
--- a/base/constants.jl
+++ b/base/constants.jl
@@ -99,33 +99,33 @@ big(x::MathConst) = convert(BigFloat,x)
 ## specific mathematical constants
 
 @math_const π        3.14159265358979323846  pi
-@math_const e        2.71828182845904523536  exp(big(1))
+@math_const ℯ        2.71828182845904523536  exp(big(1))
 @math_const γ        0.57721566490153286061  euler
 @math_const catalan  0.91596559417721901505  catalan
 @math_const φ        1.61803398874989484820  (1+sqrt(big(5)))/2
 
 # aliases
 const pi = π
-const eu = e
+const eu = ℯ
 const eulergamma = γ
 const golden = φ
 
 # special behaviors
 
-# use exp for e^x or e.^x, as in
-#    ^(::MathConst{:e}, x::Number) = exp(x)
-#    .^(::MathConst{:e}, x) = exp(x)
+# use exp for ℯ^x or ℯ.^x, as in
+#    ^(::MathConst{:ℯ}, x::Number) = exp(x)
+#    .^(::MathConst{:ℯ}, x) = exp(x)
 # but need to loop over types to prevent ambiguity with generic rules for ^(::Number, x) etc.
 for T in (MathConst, Rational, Integer, Number)
-    ^(::MathConst{:e}, x::T) = exp(x)
+    ^(::MathConst{:ℯ}, x::T) = exp(x)
 end
 for T in (Range, BitArray, SparseMatrixCSC, StridedArray, AbstractArray)
-    .^(::MathConst{:e}, x::T) = exp(x)
+    .^(::MathConst{:ℯ}, x::T) = exp(x)
 end
-^(::MathConst{:e}, x::AbstractMatrix) = expm(x)
+^(::MathConst{:ℯ}, x::AbstractMatrix) = expm(x)
 
-log(::MathConst{:e}) = 1 # use 1 to correctly promote expressions like log(x)/log(e)
-log(::MathConst{:e}, x) = log(x)
+log(::MathConst{:ℯ}) = 1 # use 1 to correctly promote expressions like log(x)/log(ℯ)
+log(::MathConst{:ℯ}, x) = log(x)
 
 #Align along = for nice Array printing
 function alignment(x::MathConst)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1,3 +1,21 @@
+# Deprecated functions and objects
+#
+# Please add new deprecations at the bottom of the file.
+# A function deprecated in a release will be removed in the next one.
+# Please also add a reference to the pull request which introduced the
+# deprecation.
+#
+# For simple cases where a direct replacement is available, use @deprecate:
+# the first argument is the signature of the deprecated method, the second one
+# is the call which replaces it. Remove the definition of the deprecated method
+# and its documentation, and unexport it, as @deprecate takes care of calling
+# the replacement and of exporting the function.
+#
+# For more complex cases, move the body of the deprecated method in this file,
+# and call depwarn() directly from inside it. The symbol depwarn() expects is
+# the name of the function, which is used to ensure that the deprecation warning
+# is only printed the first time for each call place.
+
 macro deprecate(old,new)
     meta = Expr(:meta, :noinline)
     if isa(old,Symbol)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -522,3 +522,46 @@ export float32_isvalid, float64_isvalid
 @deprecate parseint(s,base)           parse(Int, s, base)
 @deprecate parseint(T::Type, s)       parse(T, s)
 @deprecate parseint(T::Type, s, base) parse(T, s, base)
+
+# Deprecation of e MathConst (#10612)
+export e
+const e = MathConst{:e}()
+
+e_depwarn(sym::Symbol) = depwarn("e mathematical constant is deprecated, use ℯ (\\e[tab]) or eu instead", sym)
+
+<(::MathConst{:e}, y::Rational{BigInt}) = (e_depwarn(symbol("<")); <(ℯ, y))
+<(x::Rational{BigInt}, ::MathConst{:e}) = (e_depwarn(symbol("<")); <(x, ℯ))
+
+<(::MathConst{:e}, y::Rational) = (e_depwarn(symbol("<")); <(ℯ, y))
+<(x::Rational, ::MathConst{:e}) =(e_depwarn(symbol("<"));  <(x, ℯ))
+
+<=(x::MathConst{:e}, y::Rational) = (e_depwarn(symbol("<=")); <=(ℯ, y))
+<=(x::Rational, y::MathConst{:e}) = (e_depwarn(symbol("<=")); <=(x, ℯ))
+
+hash(x::MathConst{:e}, h::UInt) = (e_depwarn(:hash); hash(ℯ, h))
+
+-(x::MathConst{:e}) = (e_depwarn(:-); -ℯ)
+for op in Symbol[:+, :-, :*, :/, :^]
+    @eval $op(x::MathConst{:e}, y::MathConst{:e}) = (e_depwarn(op); $op(ℯ, ℯ))
+end
+
+call(::Type{BigFloat}, ::MathConst{:e}) = (Base.e_depwarn(:call); BigFloat(ℯ))
+call(::Type{Float64}, ::MathConst{:e}) = (Base.e_depwarn(:call); Float64(ℯ))
+call(::Type{Float32}, ::MathConst{:e}) = (Base.e_depwarn(:call); Float32(ℯ))
+
+convert(::Type{BigFloat}, ::MathConst{:e}) = (e_depwarn(:convert); convert(BigFloat, ℯ))
+convert(::Type{Float64}, ::MathConst{:e}) = (e_depwarn(:convert); convert(Float64, ℯ))
+convert(::Type{Float32}, ::MathConst{:e}) = (e_depwarn(:convert); convert(Float32, ℯ))
+
+big(x::MathConst{:e}) = (e_depwarn(:big); big(ℯ))
+
+for T in (MathConst, Rational, Integer, Number)
+    ^(::MathConst{:e}, x::T) = (e_depwarn(:^); ^(ℯ, x))
+end
+for T in (Range, BitArray, SparseMatrixCSC, StridedArray, AbstractArray)
+    .^(::MathConst{:e}, x::T) = (e_depwarn(:.^); .^(ℯ, x))
+end
+^(::MathConst{:e}, x::AbstractMatrix) = (e_depwarn(:^); ^(ℯ, x))
+
+log(::MathConst{:e}) = (e_depwarn(:log); log(ℯ))
+log(::MathConst{:e}, x) = (e_depwarn(:log); log(ℯ, x))

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -184,7 +184,7 @@ export
     NaN32,
     im,
     π, pi,
-    e, eu,
+    ℯ, eu,
     γ, eulergamma,
     catalan,
     φ, golden,

--- a/base/latex_symbols.jl
+++ b/base/latex_symbols.jl
@@ -76,6 +76,7 @@ const latex_symbols = Dict(
     "\\pppprime" => "⁗",
     "\\backpprime" => "‶",
     "\\backppprime" => "‷",
+    "\\e" => "ℯ",
 
     # Superscripts
     "\\^0" => "⁰",

--- a/contrib/julia.xml
+++ b/contrib/julia.xml
@@ -316,7 +316,7 @@
       <item> im </item>
       <item> π </item>
       <item> pi </item>
-      <item> e </item>
+      <item> ℯ </item>
       <item> eu </item>
       <item> γ </item>
       <item> eulergamma </item>

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -138,10 +138,10 @@ General Number Functions and Constants
 
    The imaginary unit
 
-.. data:: e
+.. data:: ℯ
           eu
 
-   The constant e
+   The constant e (base of natural logarithm, a.k.a Euler's number or Napier's constant)
 
 .. data:: catalan
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2320,7 +2320,7 @@ end
 @test bswap(reinterpret(Float32,0x0000c03f)) === 1.5f0
 
 #isreal(x::Real) = true
-for x in [1.23, 7, e, 4//5] #[FP, Int, MathConst, Rat]
+for x in [1.23, 7, ℯ, 4//5] #[FP, Int, MathConst, Rat]
     @test isreal(x) == true
 end
 
@@ -2335,20 +2335,20 @@ for x in [subtypes(Complex); subtypes(Real)]
 end
 
 #getindex(x::Number) = x
-for x in [1.23, 7, e, 4//5] #[FP, Int, MathConst, Rat]
+for x in [1.23, 7, ℯ, 4//5] #[FP, Int, MathConst, Rat]
     @test getindex(x) == x
 end
 
 #copysign(x::Real, y::Real) = ifelse(signbit(x)!=signbit(y), -x, x)
 #same sign
-for x in [1.23, 7, e, 4//5]
-    for y in [1.23, 7, e, 4//5]
+for x in [1.23, 7, ℯ, 4//5]
+    for y in [1.23, 7, ℯ, 4//5]
         @test copysign(x,y) == x
     end
 end
 #different sign
-for x in [1.23, 7, e, 4//5]
-    for y in [1.23, 7, e, 4//5]
+for x in [1.23, 7, ℯ, 4//5]
+    for y in [1.23, 7, ℯ, 4//5]
         @test copysign(x, -y) == -x
     end
 end
@@ -2361,7 +2361,7 @@ end
 #in(x::Number, y::Number) = x == y
 @test in(3,3) == true #Int
 @test in(2.0,2.0) == true #FP
-@test in(e,e) == true #Const
+@test in(ℯ,ℯ) == true #Const
 @test in(4//5,4//5) == true #Rat
 @test in(1+2im, 1+2im) == true #Imag
 @test in(3, 3.0) == true #mixed

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -108,7 +108,7 @@ end
 for T in [Float32,Float64]
     for v in [sqrt(big(2.0)),-big(1.0)/big(3.0),nextfloat(big(1.0)),
               prevfloat(big(1.0)),nextfloat(big(0.0)),prevfloat(big(0.0)),
-              pi,e,eulergamma,catalan,golden,
+              pi,ℯ,eulergamma,catalan,golden,
               typemax(Int64),typemax(UInt64),typemax(Int128),typemax(UInt128),0xa2f30f6001bb2ec6]
         pn = T(v,RoundNearest)
         @test pn == convert(T,BigFloat(v))


### PR DESCRIPTION
This reduces confusion with variables called e, and ℯ is
the Unicode character for "natural exponent". It also
makes this constant more similar to others, which have
both a "special letter" and longer ASCII form.

Cf. #10607

Reference : http://en.wikipedia.org/wiki/Numerals_in_Unicode#Characters_for_mathematical_constants

(Shortest branch name ever!)
