### PR TITLE
Add JL_THREAD to mark thread-local variables

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1718,7 +1718,7 @@ static void visit_mark_stack(int mark_mode)
 
 void jl_mark_box_caches(void);
 
-extern jl_value_t * volatile jl_task_arg_in_transit;
+extern JL_THREAD jl_value_t * volatile jl_task_arg_in_transit;
 #if defined(GCTIME) || defined(GC_FINAL_STATS)
 double clock_now(void);
 #endif

--- a/src/julia.h
+++ b/src/julia.h
@@ -54,6 +54,22 @@ extern "C" {
 #define JL_ATTRIBUTE_ALIGN_PTRSIZE(x)
 #endif
 
+// threading ------------------------------------------------------------------
+
+// WARNING: Threading support is incomplete.  Changing the 1 to a 0 will break Julia.
+// Nonetheless, we define JL_THREAD and use it to give advanced notice to maintainers
+// of what eventual threading support will change.
+#if 1
+// Definition for compiling non-thread-safe Julia.
+#  define JL_THREAD
+#elif !defined(_OS_WINDOWS_)
+// Definition for compiling Julia on platforms with GCC __thread.
+#  define JL_THREAD __thread
+#else
+// Definition for compiling Julia on Windows
+#  define JL_THREAD __declspec(thread)
+#endif
+
 // core data types ------------------------------------------------------------
 
 #ifndef _COMPILER_MICROSOFT_
@@ -1147,7 +1163,7 @@ typedef struct _jl_gcframe_t {
 // jl_value_t *x=NULL, *y=NULL; JL_GC_PUSH(&x, &y);
 // x = f(); y = g(); foo(x, y)
 
-extern DLLEXPORT jl_gcframe_t *jl_pgcstack;
+extern DLLEXPORT JL_THREAD jl_gcframe_t *jl_pgcstack;
 
 #define JL_GC_PUSH(...)                                                   \
   void *__gc_stkf[] = {(void*)((VA_NARG(__VA_ARGS__)<<1)|1), jl_pgcstack, \
@@ -1295,9 +1311,9 @@ typedef struct _jl_task_t {
     jl_module_t *current_module;
 } jl_task_t;
 
-extern DLLEXPORT jl_task_t * volatile jl_current_task;
-extern DLLEXPORT jl_task_t *jl_root_task;
-extern DLLEXPORT jl_value_t *jl_exception_in_transit;
+extern DLLEXPORT JL_THREAD jl_task_t * volatile jl_current_task;
+extern DLLEXPORT JL_THREAD jl_task_t *jl_root_task;
+extern DLLEXPORT JL_THREAD jl_value_t *jl_exception_in_transit;
 
 DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize);
 jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -102,7 +102,7 @@ void jl_init_tasks(void *stack, size_t ssize);
 void jl_init_serializer(void);
 void _julia_init(JL_IMAGE_SEARCH rel);
 #ifdef COPY_STACKS
-extern void *jl_stackbase;
+extern JL_THREAD void *jl_stackbase;
 #endif
 
 void jl_dump_bitcode(char *fname);

--- a/src/task.c
+++ b/src/task.c
@@ -141,24 +141,24 @@ static jl_sym_t *runnable_sym;
 
 extern size_t jl_page_size;
 jl_datatype_t *jl_task_type;
-DLLEXPORT jl_task_t * volatile jl_current_task;
-jl_task_t *jl_root_task;
-jl_value_t * volatile jl_task_arg_in_transit;
-jl_value_t *jl_exception_in_transit;
+DLLEXPORT JL_THREAD jl_task_t * volatile jl_current_task;
+JL_THREAD jl_task_t *jl_root_task;
+JL_THREAD jl_value_t * volatile jl_task_arg_in_transit;
+JL_THREAD jl_value_t *jl_exception_in_transit;
 #ifdef JL_GC_MARKSWEEP
-jl_gcframe_t *jl_pgcstack = NULL;
+JL_THREAD jl_gcframe_t *jl_pgcstack = NULL;
 #endif
 
 #ifdef COPY_STACKS
-static jl_jmp_buf * volatile jl_jmp_target;
+static JL_THREAD jl_jmp_buf * volatile jl_jmp_target;
 
 #if (defined(_CPU_X86_64_) || defined(_CPU_X86_)) && !defined(_COMPILER_MICROSOFT_)
 #define ASM_COPY_STACKS
 #endif
-void *jl_stackbase;
+JL_THREAD void *jl_stackbase;
 
 #ifndef ASM_COPY_STACKS
-static jl_jmp_buf jl_base_ctx; // base context of stack
+static JL_THREAD jl_jmp_buf jl_base_ctx; // base context of stack
 #endif
 
 static void NOINLINE save_stack(jl_task_t *t)


### PR DESCRIPTION
This patch is a first step in getting some [trivial changes needed](https://github.com/JuliaLang/julia/issues/10421#issuecomment-85196953) (but not sufficient) for threading into master.

The patch adds `JL_THREAD` annotations to global variables that will become thread-local once threading is implemented.  The annotations expand to whitespace, and there is a loud warning to maintainers who might set it otherwise.

The  `threading` branch currently spells the macro `__JL_THREAD`, but I dropped the leading double underscore for two reasons:
1. Consistency: No other JL_ identifier has a leading double-underscore.
2. Standards conformance: C standard reserves `__` prefixed identifiers to standard library implementers.

I'll edit the `threading` branch to match if this patch is accepted.
