### PR TITLE
Reduce test matrices in linalg2. Avoid repeating tests in triangular.

### DIFF
--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -162,40 +162,40 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
                 @test_approx_eq full(A1/A2) full(A1)/full(A2)
 
             end
+        end
 
-            for eltyB in (Float32, Float64, Complex64, Complex128)
-                B = convert(Matrix{eltyB}, elty1 <: Complex ? real(A1)*ones(n, n) : A1*ones(n, n))
+        for eltyB in (Float32, Float64, Complex64, Complex128)
+            B = convert(Matrix{eltyB}, elty1 <: Complex ? real(A1)*ones(n, n) : A1*ones(n, n))
 
-                debug && println("elty1: $elty1, A1: $t1, B: $eltyB")
+            debug && println("elty1: $elty1, A1: $t1, B: $eltyB")
 
-                # Triangular-dense Matrix/vector multiplication
-                @test_approx_eq A1*B[:,1] full(A1)*B[:,1]
-                @test_approx_eq A1*B full(A1)*B
-                @test_approx_eq A1'B[:,1] full(A1)'B[:,1]
-                @test_approx_eq A1'B full(A1)'B
-                @test_approx_eq A1*B' full(A1)*B'
-                @test_approx_eq B*A1 B*full(A1)
-                @test_approx_eq B[:,1]'A1 B[:,1]'full(A1)
-                @test_approx_eq B'A1 B'full(A1)
-                @test_approx_eq B*A1' B*full(A1)'
-                @test_approx_eq B[:,1]'A1' B[:,1]'full(A1)'
-                @test_approx_eq B'A1' B'full(A1)'
+            # Triangular-dense Matrix/vector multiplication
+            @test_approx_eq A1*B[:,1] full(A1)*B[:,1]
+            @test_approx_eq A1*B full(A1)*B
+            @test_approx_eq A1'B[:,1] full(A1)'B[:,1]
+            @test_approx_eq A1'B full(A1)'B
+            @test_approx_eq A1*B' full(A1)*B'
+            @test_approx_eq B*A1 B*full(A1)
+            @test_approx_eq B[:,1]'A1 B[:,1]'full(A1)
+            @test_approx_eq B'A1 B'full(A1)
+            @test_approx_eq B*A1' B*full(A1)'
+            @test_approx_eq B[:,1]'A1' B[:,1]'full(A1)'
+            @test_approx_eq B'A1' B'full(A1)'
 
-                # ... and division
-                @test_approx_eq A1\B[:,1] full(A1)\B[:,1]
-                @test_approx_eq A1\B full(A1)\B
-                @test_approx_eq A1'\B[:,1] full(A1)'\B[:,1]
-                @test_approx_eq A1'\B full(A1)'\B
-                @test_approx_eq A1\B' full(A1)\B'
-                @test_approx_eq A1'\B' full(A1)'\B'
-                @test_approx_eq B/A1 B/full(A1)
-                @test_approx_eq B/A1' B/full(A1)'
-                @test_approx_eq B'/A1 B'/full(A1)
-                @test_approx_eq B'/A1' B'/full(A1)'
+            # ... and division
+            @test_approx_eq A1\B[:,1] full(A1)\B[:,1]
+            @test_approx_eq A1\B full(A1)\B
+            @test_approx_eq A1'\B[:,1] full(A1)'\B[:,1]
+            @test_approx_eq A1'\B full(A1)'\B
+            @test_approx_eq A1\B' full(A1)\B'
+            @test_approx_eq A1'\B' full(A1)'\B'
+            @test_approx_eq B/A1 B/full(A1)
+            @test_approx_eq B/A1' B/full(A1)'
+            @test_approx_eq B'/A1 B'/full(A1)
+            @test_approx_eq B'/A1' B'/full(A1)'
 
-                # Error bounds
-                elty1 != BigFloat && errorbounds(A1, A1\B, B)
-            end
+            # Error bounds
+            elty1 != BigFloat && errorbounds(A1, A1\B, B)
         end
     end
 end

--- a/test/linalg2.jl
+++ b/test/linalg2.jl
@@ -215,9 +215,9 @@ for elty in (Float32, Float64, Complex64, Complex128)
 end
 
 # Tests norms
-nnorm = 1000
-mmat = 100
-nmat = 80
+nnorm = 10
+mmat = 10
+nmat = 8
 for elty in (Float32, Float64, BigFloat, Complex{Float32}, Complex{Float64}, Complex{BigFloat}, Int32, Int64, BigInt)
     debug && println(elty)
 


### PR DESCRIPTION
Following up on @timholy's comment in https://github.com/JuliaLang/julia/commit/3540419b14994679b9edb6b92d3ccd80a2e8da4d#commitcomment-10409160. I think this reduces the `linalg2` tests with approximately 20 seconds. I also found some unnecessary repetition in the `triangular` tests, but that doesn't change much because most of the time is spent on compilation.
