### PR TITLE
Move test_approx_eq_modphase into Base.Test

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -168,4 +168,33 @@ macro inferred(ex)
     end
 end
 
+#Test approximate equality of vectors or columns of matrices modulo floating
+#point roundoff and phase (sign) differences.
+#
+#This function is design to test for equality between vectors of floating point
+#numbers when the vectors are defined only up to a global phase or sign, such as
+#normalized eigenvectors or singular vectors. The global phase is usually
+#defined consistently, but may occasionally change due to small differences in
+#floating point rounding noise or rounding modes, or through the use of
+#different conventions in different algorithms. As a result, most tests checking
+#such vectors have to detect and discard such overall phase differences.
+#
+#Inputs:
+#    a, b:: StridedVecOrMat to be compared
+#    err :: Default: m^3*(eps(S)+eps(T)), where m is the number of rows
+#
+#Raises an error if any columnwise vector norm exceeds err. Otherwise, returns
+#nothing.
+function test_approx_eq_modphase{S<:Real,T<:Real}(
+        a::StridedVecOrMat{S}, b::StridedVecOrMat{T}, err=nothing)
+
+    m, n = size(a)
+    @test n==size(b, 2) && m==size(b, 1)
+    err==nothing && (err=m^3*(eps(S)+eps(T)))
+    for i=1:n
+        v1, v2 = a[:, i], b[:, i]
+        @test_approx_eq_eps min(abs(norm(v1-v2)), abs(norm(v1+v2))) 0.0 err
+    end
+end
+
 end # module

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -629,7 +629,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
    The following keyword arguments are supported:
     * ``nev``: Number of eigenvalues
     * ``ncv``: Number of Krylov vectors used in the computation; should satisfy
-        ``nev+1 <= ncv <= n`` for real symmetric problems and ``nev+2 <= ncv <= n``
+       ``nev+1 <= ncv <= n`` for real symmetric problems and ``nev+2 <= ncv <= n``
        for other problems, where ``n`` is the size of the input matrix ``A``.
        The default is ``ncv = max(20,2*nev+1)``.
        Note that these restrictions limit the input matrix ``A`` to be of
@@ -668,7 +668,9 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 .. function:: svds(A; nsv=6, ritzvec=true, tol=0.0, maxiter=1000) -> (left_sv, s, right_sv, nconv, niter, nmult, resid)
 
    ``svds`` computes largest singular values ``s`` of ``A`` using Lanczos or Arnoldi iterations.
-   Uses :func:`eigs` underneath. Inputs are:
+   Uses :func:`eigs` underneath.
+
+   Inputs are:
     * ``A``: Linear operator. It can either subtype of ``AbstractArray`` (e.g., sparse matrix) or duck typed. For duck typing ``A`` has to support ``size(A)``, ``eltype(A)``, ``A * vector`` and ``A' * vector``.
     * ``nsv``: Number of singular values.
     * ``ritzvec``: Whether to return the left and right singular vectors ``left_sv`` and ``right_sv``, default is ``true``. If ``false`` the singular vectors are omitted from the output.


### PR DESCRIPTION
This PR provides a new test function for testing the approximate equality of two vectors (or columns of two matrices) up to a global sign difference. The global sign difference occasionally shows up when testing equality between eigenvectors or singular vectors. These vectors, when normalized, are uniquely defined only up to a global phase (or global sign for the real case). The global phase is usually defined consistently, but may occasionally change due to small differences in floating point rounding noise or rounding modes, or through the use of different conventions. As a result, most tests checking such vectors have to detect and discard such overall phase differences.

`test_approx_eq_vecs` was originally defined within the `linalg` tests as an internal function, but I've since seen situations in other packages (like MultivariateStats.jl) where the same test is required. So it seems useful to have in `Base.Test`. I've left it unexported, as it feels like an expert function of limited use.
