### PR TITLE
correct behavior of skip(::IOBuffer, n) for n < 0 (fix #10658)

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -110,7 +110,7 @@ position(io::IOBuffer) = io.ptr-1
 
 function skip(io::IOBuffer, n::Integer)
     seekto = io.ptr + n
-    n < 0 && return seek(io, seekto) # Does error checking
+    n < 0 && return seek(io, seekto-1) # Does error checking
     io.ptr = min(seekto, io.size+1)
     return io
 end

--- a/base/markdown/GitHub/GitHub.jl
+++ b/base/markdown/GitHub/GitHub.jl
@@ -4,7 +4,7 @@ include("table.jl")
 function fencedcode(stream::IO, block::MD)
     withstream(stream) do
         startswith(stream, "~~~", padding = true) || startswith(stream, "```", padding = true) || return false
-        skip(stream, -2)
+        skip(stream, -1)
         ch = read(stream, Char)
         trailing = strip(readline(stream))
         flavor = lstrip(trailing, ch)

--- a/base/markdown/parse/util.jl
+++ b/base/markdown/parse/util.jl
@@ -172,7 +172,7 @@ function parse_inline_wrapper(stream::IO, delimiter::String; rep = false)
     withstream(stream) do
         if position(stream) >= 1
             # check the previous byte isn't a delimiter
-            skip(stream, -2)
+            skip(stream, -1)
             (read(stream, Char) in delimiter) && return nothing
         end
         n = nmin

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -135,3 +135,12 @@ let io=IOBuffer("asdf")
     @test position(seek(io, -1)) == 0
     @test position(seek(io, 6)) == 4
 end
+
+# issue #10658
+let io=IOBuffer("hello")
+    @test position(skip(io, 4)) == 4
+    @test position(skip(io, 10)) == 5
+    @test position(skip(io, -2)) == 3
+    @test position(skip(io, -3)) == 0
+    @test position(skip(io, -3)) == 0
+end


### PR DESCRIPTION
fixes #10658 (and reliance on this bug that subsequently crept into the markdown code); see also #8238

cc: @kmsquire, @hayd
