### PR TITLE
Speed up map(::DataType, ::BitArray) and friends

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1574,14 +1574,14 @@ maximum(B::BitArray) = isempty(B) ? throw(ArgumentError("argument must be non-em
 # arrays since there can be a 64x speedup by working at the level of Int64
 # instead of looping bit-by-bit.
 
-map(f::Callable, A::BitArray) = map(specialized_bitwise_unary(f), A)
-map(f::Callable, A::BitArray, B::BitArray) = map(specialized_bitwise_binary(f), A, B)
+map(f::Function, A::BitArray) = map(specialized_bitwise_unary(f), A)
+map(f::Function, A::BitArray, B::BitArray) = map(specialized_bitwise_binary(f), A, B)
 map(f::BitFunctorUnary, A::BitArray) = map!(f, similar(A), A)
 map(f::BitFunctorBinary, A::BitArray, B::BitArray) = map!(f, similar(A), A, B)
 
 map!(f, A::BitArray) = map!(f, A, A)
-map!(f::Callable, dest::BitArray, A::BitArray) = map!(specialized_bitwise_unary(f), dest, A)
-map!(f::Callable, dest::BitArray, A::BitArray, B::BitArray) = map!(specialized_bitwise_binary(f), dest, A, B)
+map!(f::Function, dest::BitArray, A::BitArray) = map!(specialized_bitwise_unary(f), dest, A)
+map!(f::Function, dest::BitArray, A::BitArray, B::BitArray) = map!(specialized_bitwise_binary(f), dest, A, B)
 
 # If we were able to specialize the function to a known bitwise operation,
 # map across the chunks. Otherwise, fall-back to the AbstractArray method that

--- a/base/functors.jl
+++ b/base/functors.jl
@@ -48,10 +48,9 @@ call(::MoreFun, x, y) = x > y
 
 # a fallback unspecialized functor that allows code using functors to not care
 # whether they were able to specialize on the function value or not
-immutable UnspecializedFun{N,T<:Callable} <: Func{N}
-    f::T
+immutable UnspecializedFun{N} <: Func{N}
+    f::Function
 end
-call{N,T}(::Type{UnspecializedFun{N}}, f::T) = UnspecializedFun{N,T}(f)
 call(f::UnspecializedFun{1}, x) = f.f(x)
 call(f::UnspecializedFun{2}, x, y) = f.f(x,y)
 
@@ -105,7 +104,7 @@ call(::BitFunctorBinary{false, true,  true,  true }, p, q) = ~(p & q)
 
 # Specializations by value
 
-function specialized_unary(f::Callable)
+function specialized_unary(f::Function)
     is(f, identity) ? IdFun()   :
     is(f, abs)      ? AbsFun()  :
     is(f, abs2)     ? Abs2Fun() :
@@ -113,7 +112,7 @@ function specialized_unary(f::Callable)
     is(f, log)      ? LogFun()  :
     UnspecializedFun{1}(f)
 end
-function specialized_binary(f::Callable)
+function specialized_binary(f::Function)
     is(f, +) ? AddFun() :
     is(f, *) ? MulFun() :
     is(f, &) ? AndFun() :
@@ -121,14 +120,14 @@ function specialized_binary(f::Callable)
     UnspecializedFun{2}(f)
 end
 
-function specialized_bitwise_unary(f::Callable)
+function specialized_bitwise_unary(f::Function)
     is(f, identity)     ? BitFunctorUnary{true,  false}() :
     is(f, !) | is(f, ~) ? BitFunctorUnary{false, true }() :
     is(f, one)          ? BitFunctorUnary{true,  true }() :
     is(f, zero)         ? BitFunctorUnary{false, false}() :
     UnspecializedFun{1}(f)
 end
-function specialized_bitwise_binary(f::Callable)
+function specialized_bitwise_binary(f::Function)
     is(f, &)  | is(f, *) | is(f, min) ? BitFunctorBinary{true,  false, false, false}() :
     is(f, |)  | is(f, max)            ? BitFunctorBinary{true,  true,  true,  false}() :
     is(f, $)  | is(f, !=)             ? BitFunctorBinary{false, true,  true,  false}() :


### PR DESCRIPTION
Previously, `map(T::DataType, x::BitArray)` would call `map(UnspecializedFun{1,DataType}(T), x)`, which was slow because we couldn't specialize on T. Since `specialized_unary` and friends only do useful things for functions, I restricted their arguments and the methods that call them to functions, so we just call the general map method directly for `map(::DataType, ::BitArray)`.

Before:

``` julia
julia> x = bitrand(10^8);

julia> @time map(Int, x);
elapsed time: 4.609210289 seconds (762 MB allocated)
```

After:

``` julia
julia> x = bitrand(10^8);

julia> @time map(Int, x);
elapsed time: 0.207114191 seconds (762 MB allocated)
```

cc @mbauman 
