### PR TITLE
Fix recent regressions in `mk_symbol`

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -508,7 +508,7 @@ static jl_sym_t *mk_symbol(const char *str)
         sym_pool = (char*)malloc(SYM_POOL_SIZE);
         pool_ptr = sym_pool;
     }
-    sym = (jl_sym_t*)&((jl_taggedvalue_t*)malloc(nb))->value;
+    sym = (jl_sym_t*)&((jl_taggedvalue_t*)pool_ptr)->value;
     pool_ptr += nb;
 #endif
     jl_set_typeof(sym, jl_sym_type);

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -502,7 +502,7 @@ static jl_sym_t *mk_symbol(const char *str)
     }
 
 #ifdef MEMDEBUG
-    sym = (jl_sym_t*)((jl_taggedvalue_t*)malloc(nb))->value;
+    sym = (jl_sym_t*)&((jl_taggedvalue_t*)malloc(nb))->value;
 #else
     if (sym_pool == NULL || pool_ptr+nb > sym_pool+SYM_POOL_SIZE) {
         sym_pool = (char*)malloc(SYM_POOL_SIZE);


### PR DESCRIPTION
This pull request fixes two recent regressions in `mk_symbol`:
1. Julia now compiles successfully again when `MEMDEBUG` is enabled (broken since fe3fea5); and
2. `mk_symbol` now uses memory pools correctly again (broken since 65cfde9).
