### PR TITLE
Fixes: ERROR: `dlext` not defined

### DIFF
--- a/contrib/build_executable.jl
+++ b/contrib/build_executable.jl
@@ -88,7 +88,7 @@ function build_executable(exename, script_file, targetdir=nothing; force=false)
     sys = SysFile(exename)
 
     if !force
-        for f in [cfile, userimgjl, "$(sys.buildfile).$(Sys.dlext)", "$(sys.buildfile).ji", exe_release.buildfile, exe_debug.buildfile]
+        for f in [cfile, userimgjl, "$(sys.buildfile).$(Libdl.dlext)", "$(sys.buildfile).ji", exe_release.buildfile, exe_debug.buildfile]
             if isfile(f)
                 println("ERROR: File '$(f)' already exists. Delete it or use --force.")
                 return 1
@@ -135,12 +135,12 @@ function build_executable(exename, script_file, targetdir=nothing; force=false)
 
     if targetdir != nothing
         # Move created files to target directory
-        for file in [exe_release.buildfile, exe_debug.buildfile, sys.buildfile*".$(Sys.dlext)", sys.buildfile*".ji"]
+        for file in [exe_release.buildfile, exe_debug.buildfile, sys.buildfile*".$(Libdl.dlext)", sys.buildfile*".ji"]
             mv(file,joinpath(targetdir, basename(file)))
         end
 
         # Copy needed shared libraries to the target directory
-        tmp = ".*\.$(Sys.dlext).*"
+        tmp = ".*\.$(Libdl.dlext).*"
         shlibs = filter(Regex(tmp),readdir(sys.buildpath))
         for shlib in shlibs
             cp(joinpath(sys.buildpath, shlib), joinpath(targetdir, shlib))

--- a/contrib/build_sysimg.jl
+++ b/contrib/build_sysimg.jl
@@ -10,7 +10,7 @@ function build_sysimg(sysimg_path=default_sysimg_path, cpu_target="native", user
     # Quit out if a sysimg is already loaded and is in the same spot as sysimg_path, unless forcing
     sysimg = dlopen_e("sys")
     if sysimg != C_NULL
-        if !force && Base.samefile(Libdl.dlpath(sysimg), "$(sysimg_path).$(Sys.dlext)")
+        if !force && Base.samefile(Libdl.dlpath(sysimg), "$(sysimg_path).$(Libdl.dlext)")
             info("System image already loaded at $(Libdl.dlpath(sysimg)), set force to override")
             return
         end
@@ -130,10 +130,10 @@ function link_sysimg(sysimg_path=default_sysimg_path, ld=find_system_linker())
     end
     @windows_only append!(FLAGS, ["-ljulia", "-lssp-0"])
 
-    info("Linking sys.$(Sys.dlext)")
-    run(`$ld $FLAGS -o $sysimg_path.$(Sys.dlext) $sysimg_path.o`)
+    info("Linking sys.$(Libdl.dlext)")
+    run(`$ld $FLAGS -o $sysimg_path.$(Libdl.dlext) $sysimg_path.o`)
 
-    info("System image successfully built at $sysimg_path.$(Sys.dlext)")
+    info("System image successfully built at $sysimg_path.$(Libdl.dlext)")
     @windows_only begin
         if convert(VersionNumber, Base.libllvm_version) < v"3.5.0"
             LLVM_msg = "Building sys.dll on Windows against LLVM < 3.5.0 can cause incorrect backtraces!"


### PR DESCRIPTION
Fixes: ERROR: `dlext` not defined

Seems to be forgotten when parts of `Sys` moved to `Libdl`
