### PR TITLE
readlink` function incl. wrapper in C in ``jl_uv.c``, docs

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1276,6 +1276,7 @@ export
     mv,
     operm,
     pwd,
+    readlink,
     rm,
     stat,
     symlink,

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -5000,6 +5000,15 @@ Millisecond(v)
 
 "),
 
+("Base","readlink","readlink(path) -> AbstractString
+
+   Returns the value of a symbolic link \"path\".
+
+   Note: This function raises an error under operating systems that
+     do not support soft symbolic links, such as Windows XP.
+
+"),
+
 ("Base","chmod","chmod(path, mode)
 
    Change the permissions mode of \"path\" to \"mode\". Only integer

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -40,6 +40,15 @@
       This function raises an error under operating systems that do not support
       soft symbolic links, such as Windows XP.
 
+.. function:: readlink(path) -> AbstractString
+
+   Returns the value of a symbolic link ``path``.
+
+   .. note::
+
+      This function raises an error under operating systems that do not support
+      soft symbolic links, such as Windows XP.
+
 .. function:: chmod(path, mode)
 
    Change the permissions mode of ``path`` to ``mode``. Only integer ``mode``\ s

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -448,6 +448,11 @@ DLLEXPORT int jl_fs_symlink(char *path, char *new_path, int flags)
     return ret;
 }
 
+DLLEXPORT int jl_fs_readlink(const char *path, uv_fs_t *readlink_req)
+{
+    return uv_fs_readlink(uv_default_loop(), readlink_req, path, NULL);
+}
+
 DLLEXPORT int jl_fs_chmod(char *path, int mode)
 {
     uv_fs_t req;

--- a/test/file.jl
+++ b/test/file.jl
@@ -52,6 +52,9 @@ end
     @test isdir(dirlink) == true
 end
 
+# test readlink
+@unix_only @test readlink(link) == file
+
 # rename file
 newfile = joinpath(dir, "bfile.txt")
 mv(file, newfile)


### PR DESCRIPTION
Adds wrapper function in C in `jl_uv.c` as well as the necessary
documentations and tests.

As requested by @tkelman and @Keno in #10571: adds wrapper function in C in `jl_uv.c` as well as the necessary documentations.

@ninjin There was a also a small error in #10571 when the `path` pointed to a
regular file.

```
ERROR: LoadError: ArgumentError: cannot convert NULL to string
```

Added a note that this is not yet tested on Windows (not sure if _libuv_
readlink will proper work on Windows ??)

This is pre-required for #10506 which I could finish tomorrow.
