### PR TITLE
Eigs: warn if not converged

### DIFF
--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -106,9 +106,13 @@ function eigs(A, B;
        ARPACK.aupd_wrapper(T, matvecA, matvecB, solveSI, n, sym, iscmplx, bmat, nev, ncv, whichstr, tol, maxiter, mode, v0)
 
     # Postprocessing to get eigenvalues and eigenvectors
-    return ARPACK.eupd_wrapper(T, n, sym, iscmplx, bmat, nev, whichstr, ritzvec, TOL,
+    output = ARPACK.eupd_wrapper(T, n, sym, iscmplx, bmat, nev, whichstr, ritzvec, TOL,
                                  resid, ncv, v, ldv, sigma, iparam, ipntr, workd, workl, lworkl, rwork)
 
+    # Issue 10495: Check that all eigenvalues are converged
+    length(output[1]) == output[3] || warn("not all Ritz pairs are converged. Requested: $(length(output[1])), converged: $(output[3])")
+
+    return output
 end
 
 


### PR DESCRIPTION
Fix JuliaLang/LinearAlgebra.jl#188

Note: this branch is forked from `cjh/fix-10671` (merge JuliaLang/julia#10672 first).

To verify:

```
using MatrixDepot
MatrixDepot.get("GHS_indef/laser") #Download matrix
A = matrixdepot("laser", :r)
D, V, nconv = eigs(A, nev = 10, ncv = 30, which=:LM, maxiter=300)
println("Number of requested Ritz values:", length(D)) JuliaLang/julia#10
println("Number of converged Ritz values:", nconv) #0
```

now emits the warning:

```
WARNING: not all Ritz pairs are converged. Requested: 10, converged: 0
```
