### PR TITLE
Seem that libmojibake was replaced with utf8proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Julia uses the following external libraries, which are automatically downloaded 
 - **[GMP]** (>= 5.0)         — GNU multiple precision arithmetic library, needed for `BigInt` support.
 - **[MPFR]** (>= 3.0)        — GNU multiple precision floating point library, needed for arbitrary precision floating point (`BigFloat`) support.
 - **[libgit2]** (>= 0.21)    — Git linkable library, used by Julia's package manager
-- **[utf8proc](http://julialang.org/utf8proc/)**             — a library for processing UTF-8 encoded Unicode strings
+- **[utf8proc]**             — a library for processing UTF-8 encoded Unicode strings
 - **[libosxunwind]**         — clone of [libunwind], a library that determines the call-chain of a program
 - **[Rmath-julia]**          — library for commonly used statistical functions from the R project.
 
@@ -318,8 +318,7 @@ For a longer overview of Julia's dependencies, see these [slides](https://github
 [double-conversion]: http://double-conversion.googlecode.com
 [libuv]:        https://github.com/JuliaLang/libuv
 [libgit2]:      https://libgit2.github.com/
-[utf8proc]:     http://www.public-software-group.org/utf8proc
-[libmojibake]:  https://github.com/JuliaLang/libmojibake
+[utf8proc]:     http://julialang.org/utf8proc/
 [libosxunwind]: https://github.com/JuliaLang/libosxunwind
 [libunwind]:    http://www.nongnu.org/libunwind
 [Rmath-julia]:  https://github.com/JuliaLang/Rmath-julia

--- a/README.md
+++ b/README.md
@@ -283,9 +283,9 @@ Julia uses the following external libraries, which are automatically downloaded 
 - **[GMP]** (>= 5.0)         — GNU multiple precision arithmetic library, needed for `BigInt` support.
 - **[MPFR]** (>= 3.0)        — GNU multiple precision floating point library, needed for arbitrary precision floating point (`BigFloat`) support.
 - **[libgit2]** (>= 0.21)    — Git linkable library, used by Julia's package manager
-- **[libmojibake]**          - fork of [utf8proc], a library for processing UTF-8 encoded Unicode strings
-- **[libosxunwind]**         - clone of [libunwind], a library that determines the call-chain of a program
-- **[Rmath-julia]**          - library for commonly used statistical functions from the R project.
+- **[utf8proc](http://julialang.org/utf8proc/)**             — a library for processing UTF-8 encoded Unicode strings
+- **[libosxunwind]**         — clone of [libunwind], a library that determines the call-chain of a program
+- **[Rmath-julia]**          — library for commonly used statistical functions from the R project.
 
 For a longer overview of Julia's dependencies, see these [slides](https://github.com/tkelman/BAJUtalk-Dec2014/blob/master/BAJUtalkDec2014.pdf?raw=true).
 


### PR DESCRIPTION
Seem that libmojibake was replaced with utf8proc: https://github.com/JuliaLang/julia/commit/58578b0d9010523d2d8ed0d657eba60b4553d4ad

Plus link update to the new julia utf8proc page
