### PR TITLE
RFC: controlling dispatch with varargs of defined length

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,9 @@ New language features
     and macros in packages and user code ([#8791]). Type `?@doc` at the repl
     to see the current syntax and more information.
 
+  * Varargs functions may now declare the varargs length as `x...N` to
+    restrict dispatch.
+
 Language changes
 ----------------
 

--- a/doc/manual/functions.rst
+++ b/doc/manual/functions.rst
@@ -304,6 +304,8 @@ You can also return multiple values via an explicit usage of the
 
 This has the exact same effect as the previous definition of ``foo``.
 
+.. _man-vararg-functions:
+
 Varargs Functions
 -----------------
 
@@ -338,6 +340,8 @@ the zero or more values passed to ``bar`` after its first two arguments:
 
 In all these cases, ``x`` is bound to a tuple of the trailing values
 passed to ``bar``.
+
+It is possible to constrain the number of values passed as a variable argument; this will be discussed later in :ref:`man-vararg-fixedlen`.
 
 On the flip side, it is often handy to "splice" the values contained in
 an iterable collection into a function call as individual arguments. To

--- a/doc/manual/methods.rst
+++ b/doc/manual/methods.rst
@@ -523,6 +523,32 @@ can also constrain type parameters of methods::
 The ``same_type_numeric`` function behaves much like the ``same_type``
 function defined above, but is only defined for pairs of numbers.
 
+.. _man-vararg-fixedlen:
+
+Parametrically-constrained Varargs methods
+------------------------------------------
+
+Function parameters can also be used to constrain the number of arguments that may be supplied to a "varargs" function (:ref:`man-vararg-functions`).  The notation ``...N`` is used to indicate such a constraint.  For example:
+
+.. doctest::
+
+    julia> bar(a,b,x...2) = (a,b,x)
+
+    julia> bar(1,2,3)
+    ERROR: MethodError: `bar` has no matching method bar(::Int, ::Int, ::Int)
+
+    julia> bar(1,2,3,4)
+    (1,2,(3,4))
+
+    julia> bar(1,2,3,4,5)
+    ERROR: MethodError: `bar` has no method matching bar(::Int, ::Int, ::Int, ::Int, ::Int)
+
+More usefully, it is possible to constrain varargs methods by a parameter.  For example::
+
+    function getindex{T,N}(A::AbstractArray{T,N}, indexes::Number...N)
+
+would be called only when the number of ``indexes`` matches the dimensionality of the array.
+
 Note on Optional and keyword Arguments
 --------------------------------------
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -752,7 +752,7 @@ int jl_is_rest_arg(jl_value_t *ex)
     if (((jl_expr_t*)ex)->head != colons_sym) return 0;
     jl_expr_t *atype = (jl_expr_t*)jl_exprarg(ex,1);
     if (!jl_is_expr(atype)) return 0;
-    if (atype->head != call_sym || jl_array_len(atype->args) != 3)
+    if (atype->head != call_sym || jl_array_len(atype->args) < 3 || jl_array_len(atype->args) > 4)
         return 0;
     if ((jl_sym_t*)jl_exprarg(atype,1) != dots_sym)
         return 0;

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1319,6 +1319,7 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
     else if (jl_is_vararg_type(v)) {
         n += jl_static_show_x(out, jl_tparam0(v), depth);
         n += jl_printf(out, "...");
+        n += jl_static_show_x(out, jl_tparam1(v), depth);
     }
     else if (jl_is_datatype(v)) {
         jl_datatype_t *dv = (jl_datatype_t*)v;

--- a/src/gf.c
+++ b/src/gf.c
@@ -924,6 +924,8 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tuple_t *type,
     return newmeth;
 }
 
+// a holds the argument types, b the argument signature, tvars the parameters.
+// On output, *penv holds (parameter1, value1, ...) pairs from intersection.
 static jl_value_t *lookup_match(jl_value_t *a, jl_value_t *b, jl_tuple_t **penv,
                                 jl_tuple_t *tvars)
 {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -486,6 +486,22 @@ static jl_value_t *intersect_tuple(jl_tuple_t *a, jl_tuple_t *b,
             if (valen != (ai-bi+1))
                 result = (jl_value_t*)jl_bottom_type;
         }
+        else if (jl_is_typevar(bn) && ((jl_tvar_t*)bn)->bound) {
+            // set eqc parameter from valen, to support func{N}(x...N)
+            int found = 0;
+            long valen = ai-bi+1;
+            for (i = 0; i < eqc->n; i+=2)
+                if (eqc->data[i] == bn) {
+                    eqc->data[i+1] = jl_box_long(valen);
+                    found = 1;
+                    break;
+                }
+            if (!found) {
+                eqc->data[eqc->n] = bn;
+                eqc->data[eqc->n+1] = jl_box_long(valen);
+                eqc->n += 2;
+            }
+        }
     }
  done_intersect_tuple:
     JL_GC_POP();

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2172,14 +2172,26 @@ static int jl_subtype_le(jl_value_t *a, jl_value_t *b, int ta, int invariant);
 static int jl_tuple_subtype_(jl_value_t **child, size_t cl,
                              jl_value_t **parent, size_t pl, int ta, int invariant)
 {
-    size_t ci=0, pi=0;
+    size_t ci=0, pi=0, pseqci=0;
+    int pseq=0;
     while (1) {
+        if (!pseq)
+            pseqci = ci;
         int cseq = !ta && (ci<cl) && jl_is_vararg_type(child[ci]);
-        int pseq = (pi<pl) && jl_is_vararg_type(parent[pi]);
+        pseq = (pi<pl) && jl_is_vararg_type(parent[pi]);
         if (cseq && !pseq)
             return 0;
-        if (ci >= cl)
-            return pi>=pl || (pseq && !invariant);
+        if (ci >= cl) {
+            if (pi >= pl)
+                return 1;
+            if (!(pseq && !invariant))
+                return 0;
+            jl_value_t *lastarg = parent[pl-1];
+            if (!jl_is_vararg_fixedlen(lastarg))
+                return 1;
+            return (jl_is_long(jl_tparam1(lastarg)) &&
+                    ci-pseqci == jl_unbox_long(jl_tparam1(lastarg)));
+        }
         if (pi >= pl)
             return 0;
         jl_value_t *ce = child[ci];
@@ -2190,7 +2202,8 @@ static int jl_tuple_subtype_(jl_value_t **child, size_t cl,
         if (!jl_subtype_le(ce, pe, ta, invariant))
             return 0;
 
-        if (cseq && pseq) return 1;
+        if (cseq && pseq)
+            return !jl_is_vararg_fixedlen(parent[pi]);
         if (!cseq) ci++;
         if (!pseq) pi++;
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -474,13 +474,14 @@ static jl_value_t *intersect_tuple(jl_tuple_t *a, jl_tuple_t *b,
     }
     // Check for a length-constrained vararg
     if (bseq) {
-        if (!jl_is_long(bn))
+        if (!jl_is_long(bn)) {
             // set bn from eqc parameters
             for (i = 0; i < eqc->n; i+=2)
                 if (eqc->data[i] == bn) {
                     bn = eqc->data[i+1];
                     break;
                 }
+        }
         if (jl_is_long(bn)) {
             long valen = jl_unbox_long(bn);
             if (valen != (ai-bi+1))
@@ -488,19 +489,7 @@ static jl_value_t *intersect_tuple(jl_tuple_t *a, jl_tuple_t *b,
         }
         else if (jl_is_typevar(bn) && ((jl_tvar_t*)bn)->bound) {
             // set eqc parameter from valen, to support func{N}(x...N)
-            int found = 0;
-            long valen = ai-bi+1;
-            for (i = 0; i < eqc->n; i+=2)
-                if (eqc->data[i] == bn) {
-                    eqc->data[i+1] = jl_box_long(valen);
-                    found = 1;
-                    break;
-                }
-            if (!found) {
-                eqc->data[eqc->n] = bn;
-                eqc->data[eqc->n+1] = jl_box_long(valen);
-                eqc->n += 2;
-            }
+            extend(bn, jl_box_long(ai-bi+1), eqc);
         }
     }
  done_intersect_tuple:

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3081,7 +3081,8 @@ void jl_init_types(void)
     jl_type_type->parameters = jl_tuple(1, tttvar);
 
     jl_tuple_t *tv;
-    tv = jl_tuple1(tvar("T"));
+    //tv = jl_tuple1(tvar("T"));
+    tv = jl_tuple2(tvar("T"), tvar("N"));
     jl_vararg_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Vararg"),
                                          jl_any_type, tv);
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -691,7 +691,7 @@
             ((eq? t '...)
              (take-token s)
              (let ((tnxt (peek-token s)))
-               (if (or (number? tnxt) (symbol? tnxt))
+               (if (and (or (number? tnxt) (symbol? tnxt)) (not (ts:space? s)))
                    (begin
                      (take-token s)
                      (set! t (list t tnxt))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -690,7 +690,13 @@
                        (loop (append ex (list argument)) #t)))))
             ((eq? t '...)
              (take-token s)
-             (list '... ex))
+             (let ((tnxt (peek-token s)))
+               (if (or (number? tnxt) (symbol? tnxt))
+                   (begin
+                     (take-token s)
+                     (set! t (list t tnxt))
+                     )))
+             (list t ex))
             (else ex)))))
 
 ; the principal non-terminals follow, in increasing precedence order
@@ -775,6 +781,9 @@
 (define (parse-comparison s)
   (let loop ((ex (parse-in s))
              (first #t))
+    ;; convert (('... N) var) into ('... var N)
+    (if (and (pair? ex) (pair? (car ex)) (eq? (car (car ex)) '...))
+        (set! ex (list '... (cadr ex) (cadr (car ex)))))
     (let ((t (peek-token s)))
       (if (not (is-prec-comparison? t))
           ex

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -110,7 +110,9 @@
          (bad-formal-argument v))
         (else
          (case (car v)
-           ((...)         `(... ,(decl-type (cadr v))))
+           ((...) (if (eq? (length v) 3)
+                      `(... ,(decl-type (cadr v)) ,(caddr v))
+                      `(... ,(decl-type (cadr v)))))
            ((|::|)
             (if (not (symbol? (cadr v)))
                 (bad-formal-argument (cadr v)))
@@ -384,8 +386,12 @@
                     (cons (replace-end (expand-index-colon idx) a n tuples last)
                           ret)))))))
 
+(define (make-vararg t) (if (eq? (length t) 3)
+                            `(curly Vararg ,(cadr t) ,(caddr t))
+                            `(curly Vararg ,(cadr t))))
+
 (define (make-decl n t) `(|::| ,n ,(if (and (pair? t) (eq? (car t) '...))
-                                       `(curly Vararg ,(cadr t))
+                                       (make-vararg t)
                                        t)))
 
 (define (function-expr argl body)
@@ -1809,7 +1815,7 @@
                          (error "assignment not allowed inside tuple"))
                      (expand-forms
                       (if (vararg? x)
-                          `(curly Vararg ,(cadr x))
+                          (make-vararg x)
                           x)))
                    (cdr e))))
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -407,9 +407,13 @@
 ;; except for rest arg
 (define (method-lambda-expr argl body)
   (let ((argl (map (lambda (x)
-                     (if (and (pair? x) (eq? (car x) '...))
+                     (if (vararg? x)
                          (make-decl (arg-name x) (arg-type x))
-                         (arg-name x)))
+                         (if (varargexpr? x)
+                             (if (pair? (caddr x))
+                                 x
+                                 `(|::| ,(arg-name x) (curly Vararg Any)))
+                             (arg-name x))))
                    argl)))
     `(lambda ,argl
        (scope-block ,body))))
@@ -482,6 +486,15 @@
                     ,body ,isstaged))))))
 
 (define (vararg? x) (and (pair? x) (eq? (car x) '...)))
+(define (varargexpr? x) (and
+                         (pair? x)
+                         (eq? (car x) '::)
+                         (or
+                          (eq? (caddr x) 'Vararg)
+                          (and
+                           (pair? (caddr x))
+                           (length> (caddr x) 1)
+                           (eq? (cadr (caddr x)) 'Vararg)))))
 (define (trans?  x) (and (pair? x) (eq? (car x) '|.'|)))
 (define (ctrans? x) (and (pair? x) (eq? (car x) '|'|)))
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -710,6 +710,14 @@ STATIC_INLINE int jl_is_vararg_type(jl_value_t *v)
             ((jl_datatype_t*)(v))->name == jl_vararg_type->name);
 }
 
+STATIC_INLINE int jl_is_vararg_fixedlen(jl_value_t *v)
+{
+    assert(jl_is_vararg_type(v));
+    jl_value_t *lenv = jl_tparam1(v);
+    assert(jl_is_typevar(lenv));
+    return ((jl_tvar_t*)lenv)->bound != 0;
+}
+
 STATIC_INLINE int jl_is_ntuple_type(jl_value_t *v)
 {
     return (jl_is_datatype(v) &&

--- a/src/julia.h
+++ b/src/julia.h
@@ -710,14 +710,6 @@ STATIC_INLINE int jl_is_vararg_type(jl_value_t *v)
             ((jl_datatype_t*)(v))->name == jl_vararg_type->name);
 }
 
-STATIC_INLINE int jl_is_vararg_fixedlen(jl_value_t *v)
-{
-    assert(jl_is_vararg_type(v));
-    jl_value_t *lenv = jl_tparam1(v);
-    assert(jl_is_typevar(lenv));
-    return ((jl_tvar_t*)lenv)->bound != 0;
-}
-
 STATIC_INLINE int jl_is_ntuple_type(jl_value_t *v)
 {
     return (jl_is_datatype(v) &&
@@ -852,6 +844,15 @@ DLLEXPORT ssize_t jl_unbox_gensym(jl_value_t *v);
 #define jl_is_long(x)    jl_is_int32(x)
 #define jl_long_type     jl_int32_type
 #endif
+
+STATIC_INLINE int jl_is_vararg_fixedlen(jl_value_t *v)
+{
+    assert(jl_is_vararg_type(v));
+    jl_value_t *lenv = jl_tparam1(v);
+    if (jl_is_typevar(lenv))
+        return ((jl_tvar_t*)lenv)->bound != 0;
+    return jl_is_long(lenv);
+}
 
 // structs
 DLLEXPORT int         jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err);

--- a/test/core.jl
+++ b/test/core.jl
@@ -519,6 +519,17 @@ begin
     @test firstlast(Val{false}) == "Last"
 end
 
+# x::Vararg{Any} declarations
+begin
+    local f1, f2, f3
+    f1(x...) = [x...]
+    f2(x::Vararg{Any}) = [x...]
+    f3(x::Vararg) = [x...]
+    @test f1(1,2,3) == [1,2,3]
+    @test f2(1,2,3) == [1,2,3]
+    @test f3(1,2,3) == [1,2,3]
+end
+
 # dispatch with fixed-length varargs
 begin
     local gi, mysum, mysum2

--- a/test/core.jl
+++ b/test/core.jl
@@ -521,7 +521,7 @@ end
 
 # dispatch with fixed-length varargs
 begin
-    local gi, mysum
+    local gi, mysum, mysum2
     function gi{T,N}(A::AbstractArray{T,N}, indexes...N)
         return true
     end
@@ -539,6 +539,12 @@ begin
     end
     @test mysum(1,2,3) == 6
     @test mysum(1,2,3,4) == 10
+    function mysum2(x::Int...3)
+        x[1] + x[2] + x[3]
+    end
+    @test_throws MethodError mysum2(1,2)
+    @test mysum2(1,2,3) == 6
+    @test_throws MethodError mysum2(1,2,3,4)
 end
 
 # try/finally

--- a/test/core.jl
+++ b/test/core.jl
@@ -519,6 +519,28 @@ begin
     @test firstlast(Val{false}) == "Last"
 end
 
+# dispatch with fixed-length varargs
+begin
+    local gi, mysum
+    function gi{T,N}(A::AbstractArray{T,N}, indexes...N)
+        return true
+    end
+    @test_throws MethodError gi(zeros(2,2), 1)
+    @test gi(zeros(2,2), 1, 1)
+    @test_throws MethodError gi(zeros(2,2), 1, 1, 1)
+    @test gi(zeros(2,2,2), 1, 1, 1)
+    @test_throws MethodError gi(zeros(2,2,2), 1, 1)
+    function mysum{N}(x::Int...N)
+        s = 0
+        for i = 1:N
+            s += x[i]
+        end
+        s
+    end
+    @test mysum(1,2,3) == 6
+    @test mysum(1,2,3,4) == 10
+end
+
 # try/finally
 begin
     after = 0


### PR DESCRIPTION
This implements the syntax `x...N` to specify a varargs argument of length `N`. The purpose is to be able to control dispatch to functions like

``` julia
function getindex{T,N}(A::AbstractArray{T,N}, indexes...N)
...
end
```

so that this method only gets called when the number of `indexes` matches the dimensionality of the array. This is motivated by #10525.

Incidentally, this adds a number of comments to "core" code, particularly `inference.jl`.
