### PR TITLE
Add option to run REPL after running a program

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -236,6 +236,7 @@ let reqarg = Set(UTF8String["--home",          "-H",
             exit(1)
         end
         repl = true
+        force_repl = false
         startup = true
         history_file = true
         quiet = false
@@ -274,6 +275,7 @@ let reqarg = Set(UTF8String["--home",          "-H",
                 addprocs(load_machine_file(bytestring(opts.machinefile)))
             end
             global is_interactive = Bool(opts.isinteractive)
+            force_repl = Bool(opts.forcerepl)
             # REPL color
             if opts.color == 0
                 color_set = false
@@ -322,7 +324,7 @@ let reqarg = Set(UTF8String["--home",          "-H",
             end
             break
         end
-        return (quiet,repl,startup,color_set,history_file)
+        return (quiet,repl|force_repl,startup,color_set,history_file)
     end
 end
 

--- a/base/options.jl
+++ b/base/options.jl
@@ -14,6 +14,7 @@ immutable JLOptions
     nprocs::Clong
     machinefile::Ptr{Cchar}
     isinteractive::Int8
+    forcerepl::Int8
     color::Int8
     historyfile::Int8
     startupfile::Int8

--- a/src/init.c
+++ b/src/init.c
@@ -98,6 +98,7 @@ jl_options_t jl_options = { 0,    // version
                             0,    // nprocs
                             NULL, // machinefile
                             0,    // isinteractive
+                            0,    // forcerepl
                             0,    // color
                             JL_OPTIONS_HISTORYFILE_ON, // historyfile
                             0,    // startupfile

--- a/src/julia.h
+++ b/src/julia.h
@@ -1502,6 +1502,7 @@ typedef struct {
     long   nprocs;
     const char *machinefile;
     int8_t isinteractive;
+    int8_t forcerepl;
     int8_t color;
     int8_t historyfile;
     int8_t startupfile;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -61,6 +61,7 @@ static const char opts[]  =
     " --machinefile <file>      Run processes on hosts listed in <file>\n\n"
 
     " -i                        Force isinteractive() to be true\n"
+    " -I, --force-repl          Don't disable interactive mode under any circumstances\n"
     " --color={yes|no}          Enable or disable color text\n\n"
     " --history-file={yes|no}   Load or save history\n"
     " --no-history-file         Don't load history file (deprecated, use --history-file=no)\n"
@@ -100,7 +101,7 @@ void parse_opts(int *argcp, char ***argvp)
            opt_worker,
            opt_bind_to
     };
-    static char* shortopts = "+vhqFfH:e:E:P:L:J:C:ip:Ob:";
+    static char* shortopts = "+vhqFfH:e:E:P:L:J:C:iIp:Ob:";
     static struct option longopts[] = {
         // exposed command line options
         // NOTE: This set of required arguments need to be kept in sync
@@ -117,6 +118,7 @@ void parse_opts(int *argcp, char ***argvp)
         { "cpu-target",      required_argument, 0, 'C' },
         { "procs",           required_argument, 0, 'p' },
         { "machinefile",     required_argument, 0, opt_machinefile },
+        { "force-repl",      no_argument,       0, 'I' },
         { "color",           required_argument, 0, opt_color },
         { "history-file",    required_argument, 0, opt_history_file },
         { "no-history-file", no_argument,       0, opt_no_history_file }, // deprecated
@@ -195,6 +197,9 @@ void parse_opts(int *argcp, char ***argvp)
             break;
         case opt_machinefile:
             jl_options.machinefile = strdup(optarg);
+            break;
+        case 'I':
+            jl_options.forcerepl = 1;
             break;
         case opt_color:
             if (!strcmp(optarg,"yes"))


### PR DESCRIPTION
Currently, running `julia program.jl` causes Julia to exit after the program finishes.  For program development, it frequently makes sense to stay in the REPL after the program finishes.  This pull request adds the `-I` option (`--force-repl` long option) to do this.
