### PR TITLE
add reverse() function to Pair

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -428,6 +428,7 @@ isless(p::Pair, q::Pair) = ifelse(!isequal(p.first,q.first), isless(p.first,q.fi
                                                              isless(p.second,q.second))
 getindex(p::Pair,i::Int) = getfield(p,i)
 getindex(p::Pair,i::Real) = getfield(p, convert(Int, i))
+reverse(p::Pair) = Pair(p.second, p.first)
 
 # some operators not defined yet
 global //, >:, <|, hcat, hvcat, ⋅, ×, ∈, ∉, ∋, ∌, ⊆, ⊈, ⊊, ∩, ∪, √, ∛

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -15,3 +15,6 @@ B = [true true false]
 @test ifelse(B, 1, [2 3 4]) == [1 1 4]
 @test ifelse(B, [2 3 4], 1) == [2 3 1]
 @test ifelse(B, [2 3 4], [5 6 7]) == [2 3 7]
+
+@test reverse(Pair(1,2)) == Pair(2,1)
+@test reverse(Pair("13","24")) == Pair("24","13")


### PR DESCRIPTION
A (very simple) addition to `Pair`: `reverse(p::Pair)` returns a new `Pair` with `.first` and `.second` attributes swapped.
