### PR TITLE
simplify int128_str, uint128_str, bigint_str macros

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -246,24 +246,16 @@ floor{T<:Integer}(::Type{T},x::Integer) = convert(T,x)
 
 ## integer construction ##
 
-macro int128_str(x)
-    if isa(x,AbstractString)
-        parse(Int128,x)
-    else
-        Int128(x)
-    end
+macro int128_str(s)
+    parse(Int128,s)
 end
 
-macro uint128_str(x)
-    if isa(x,AbstractString)
-        parse(UInt128,x)
-    else
-        UInt128(x)
-    end
+macro uint128_str(s)
+    parse(UInt128,s)
 end
 
-macro bigint_str(str)
-    BigInt(str)
+macro bigint_str(s)
+    parse(BigInt,s)
 end
 
 ## system word size ##

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -322,7 +322,7 @@
             ((eq? pred char-bin?) (fix-uint-neg neg (sized-uint-literal n s 1)))
             (is-float32-literal   (float n))
             (n (if (and (integer? n) (> n 9223372036854775807))
-                   `(macrocall @int128_str ,n)
+                   `(macrocall @int128_str ,s)
                    n))
             ((within-int128? s) `(macrocall @int128_str ,s))
             (else `(macrocall @bigint_str ,s))))))


### PR DESCRIPTION
- pass through string argument to parse
- get rid of behavior where UInt64 values were being used to pass through
  Int128 literals through the `@int128_str` macro.
