### PR TITLE
Split `jl_init_tasks` into one-time initialization and per-thread initialization

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -986,7 +986,8 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 #endif
     jl_init_frontend();
     jl_init_types();
-    jl_init_tasks(jl_stack_lo, jl_stack_hi-jl_stack_lo);
+    jl_init_tasks();
+    jl_init_root_task(jl_stack_lo, jl_stack_hi-jl_stack_lo);
 
     init_stdio();
     // libuv stdio cleanup depends on jl_init_tasks() because JL_TRY is used in jl_atexit_hook()

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -98,7 +98,8 @@ void jl_init_frontend(void);
 void jl_init_primitives(void);
 void jl_init_codegen(void);
 void jl_init_intrinsic_functions(void);
-void jl_init_tasks(void *stack, size_t ssize);
+void jl_init_tasks(void);
+void jl_init_root_task(void *stack, size_t ssize);
 void jl_init_serializer(void);
 void _julia_init(JL_IMAGE_SEARCH rel);
 #ifdef COPY_STACKS

--- a/src/task.c
+++ b/src/task.c
@@ -894,7 +894,8 @@ DLLEXPORT jl_value_t *jl_get_current_task(void)
 
 jl_function_t *jl_unprotect_stack_func;
 
-void jl_init_tasks(void *stack, size_t ssize)
+// Do one-time initializations for task system
+void jl_init_tasks(void)
 {
     _probe_arch();
     jl_task_type = jl_new_datatype(jl_symbol("Task"),
@@ -922,6 +923,12 @@ void jl_init_tasks(void *stack, size_t ssize)
     failed_sym = jl_symbol("failed");
     runnable_sym = jl_symbol("runnable");
 
+    jl_unprotect_stack_func = jl_new_closure(jl_unprotect_stack, (jl_value_t*)jl_null, NULL);
+}
+
+// Initialize a root task using the given stack.
+void jl_init_root_task(void *stack, size_t ssize)
+{
     jl_current_task = (jl_task_t*)allocobj(sizeof(jl_task_t));
     jl_set_typeof(jl_current_task, jl_task_type);
 #ifdef COPY_STACKS
@@ -951,7 +958,6 @@ void jl_init_tasks(void *stack, size_t ssize)
 
     jl_exception_in_transit = (jl_value_t*)jl_null;
     jl_task_arg_in_transit = (jl_value_t*)jl_null;
-    jl_unprotect_stack_func = jl_new_closure(jl_unprotect_stack, (jl_value_t*)jl_null, NULL);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR splits `jl_init_tasks` into a part that does one-time initialization for tasking and part that does per-thread initialization for tasking.  The goal is to nudge the `master` branch a little closer to the `threading` branch. 

Later, I'll shove the tasking in the `threading` branch closer to `master`.
