### PR TITLE
fix deprecation warning, use UInt rather than unsigned in task

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -1,6 +1,6 @@
 ## basic task functions and TLS
 
-show(io::IO, t::Task) = print(io, "Task ($(t.state)) @0x$(hex(unsigned(pointer_from_objref(t)), WORD_SIZE>>2))")
+show(io::IO, t::Task) = print(io, "Task ($(t.state)) @0x$(hex(convert(UInt, pointer_from_objref(t)), WORD_SIZE>>2))")
 
 macro task(ex)
     :(Task(()->$(esc(ex))))


### PR DESCRIPTION
This fixes a dep warning which you see if you show/print a task. Previously:

```
WARNING: unsigned(x::Ptr) is deprecated, use convert(UInt,x) instead.
```
