### PR TITLE
clean up argument processing order

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -236,7 +236,7 @@ let reqarg = Set(UTF8String["--home",          "-H",
             exit(1)
         end
         repl                  = true
-        startup               = (opts.startupfile == 1)
+        startup               = (opts.startupfile != 2)
         history_file          = Bool(opts.historyfile)
         quiet                 = Bool(opts.quiet)
         color_set             = (opts.color != 0)


### PR DESCRIPTION
- load juliarc very early, before start_worker or starting processes
- load juliarc in only one place
- handle -L after starting workers, like the help says
- shorten some of the code

see #10692
