### PR TITLE
libuv_readlink_function

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1280,6 +1280,7 @@ export
     mv,
     operm,
     pwd,
+    readlink,
     rm,
     stat,
     symlink,

--- a/base/fs.jl
+++ b/base/fs.jl
@@ -23,6 +23,7 @@ export File,
        rename,
        sendfile,
        symlink,
+       readlink,
        chmod,
        futime,
        JL_O_WRONLY,
@@ -162,6 +163,18 @@ end
 end
 @windowsxp_only symlink(p::AbstractString, np::AbstractString) =
     error("WindowsXP does not support soft symlinks")
+
+function readlink(path::AbstractString)
+    req = Libc.malloc(_sizeof_uv_fs)
+    ret = ccall(:uv_fs_readlink, Int32,
+        (Ptr{Void}, Ptr{Void}, Ptr{UInt8}, Ptr{Void}),
+        eventloop(), req, path, C_NULL)
+    uv_error("readlink", ret)
+    tgt = bytestring(ccall(:jl_uv_fs_t_ptr, Ptr{Cchar}, (Ptr{Void}, ), req))
+    ccall(:uv_fs_req_cleanup, Void, (Ptr{Void}, ), req)
+    Libc.free(req)
+    tgt
+end
 
 function chmod(p::AbstractString, mode::Integer)
     err = ccall(:jl_fs_chmod, Int32, (Ptr{UInt8}, Cint), p, mode)

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -5021,6 +5021,12 @@ Millisecond(v)
 
 "),
 
+("Base","readlink","readlink(path) -> AbstractString
+
+    Returns the value of a symbolic link \"path\".
+
+"),
+
 ("Base","chmod","chmod(path, mode)
 
    Change the permissions mode of \"path\" to \"mode\". Only integer

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -40,6 +40,10 @@
       This function raises an error under operating systems that do not support
       soft symbolic links, such as Windows XP.
 
+.. function:: readlink(path) -> AbstractString
+
+   Returns the value of a symbolic link ``path``.
+
 .. function:: chmod(path, mode)
 
    Change the permissions mode of ``path`` to ``mode``. Only integer ``mode``\ s


### PR DESCRIPTION
libuv_readlink_function: This replaces the PR #10687.

As requested by @tkelman and @Keno in #10571: adds wrapper function in C in jl_uv.c as well as the necessary documentations and tests.

This is pre-required for #10506

**make test file**

```
[user@evo test]$ make test file
    JULIA test/test
     * test                 in   0.61 seconds
    SUCCESS
    JULIA test/file
     * file                 in   9.63 seconds
    SUCCESS
[user@evo test]$ 

julia> versioninfo()
Julia Version 0.4.0-dev+4125
Commit e10405d* (2015-04-01 15:04 UTC)
Platform Info:
  System: Linux (x86_64-unknown-linux-gnu)
  CPU: Intel(R) Core(TM) i3-2310M CPU @ 2.10GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Sandybridge)
  LAPACK: libopenblas
  LIBM: libopenlibm
  LLVM: libLLVM-3.3
```

```
```
