### PR TITLE
WIP stack scrubbing

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -100,9 +100,6 @@ typedef struct {
 #endif
         };
     };
-#ifdef _P64
-    uintptr_t realign16;
-#endif
     jl_value_t value;
 } jl_taggedvalue_t;
 
@@ -110,15 +107,7 @@ typedef struct {
 #define jl_typeof__MACRO(v) ((jl_value_t*)(jl_astaggedvalue__MACRO(v)->type_bits&~(size_t)3))
 #define jl_astaggedvalue jl_astaggedvalue__MACRO
 #define jl_typeof jl_typeof__MACRO
-//#define jl_set_typeof(v,t) (jl_astaggedvalue(v)->type = (jl_value_t*)(t))
-static inline void jl_set_typeof(void *v, void *t)
-{
-    jl_taggedvalue_t *tag = jl_astaggedvalue(v);
-#ifdef _P64
-    tag->realign16 = 0xA1164A1164A11640ull;
-#endif
-    tag->type = (jl_value_t*)t;
-}
+#define jl_set_typeof(v,t) (jl_astaggedvalue(v)->type = (jl_value_t*)(t))
 #define jl_typeis(v,t) (jl_typeof(v)==(jl_value_t*)(t))
 
 typedef struct _jl_sym_t {


### PR DESCRIPTION
Overwrite everything on the stack that looks like a pointer to a small julia object with `0xdead00000000 | offset` where offset is its position in the memory region.
It should allow for guaranteed failure when an object is not rooted on the stack.
Doesn't work yet for big objects (we'll have to do a bit more work since we can't know the size given an interior pointer).
Probably a reasonable first step before conservative stack scanning.
(this branch also reverts Jameson's windows alignment fix because it was making it annoying to debug, but I hope we'll fix it for real before merging this PR).
I managed to crash it on a `make testall` run so there are still missing roots somewhere, this will make it easier to find them hopefully.
