### PR TITLE
Terminate argument parsing on `--`

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -231,9 +231,18 @@ let reqarg = Set(UTF8String["--home",          "-H",
                             "--bind-to"])
     global process_options
     function process_options(opts::JLOptions, args::Vector{UTF8String})
-        if !isempty(args) && (arg = first(args); !isempty(arg) && arg[1] == '-' && in(arg, reqarg))
-            println(STDERR, "julia: option `$arg` is missing an argument")
-            exit(1)
+        if !isempty(args)
+            arg = first(args)
+            if !isempty(arg) && arg[1] == '-' && in(arg, reqarg)
+                println(STDERR, "julia: option `$arg` is missing an argument")
+                exit(1)
+            end
+            idxs = find(x -> x == "--", args)
+            if length(idxs) > 1
+                println(STDERR, "julia: redundant option terminator `--`")
+                exit(1)
+            end
+            deleteat!(ARGS, idxs)
         end
         repl                  = true
         startup               = (opts.startupfile != 2)
@@ -264,7 +273,6 @@ let reqarg = Set(UTF8String["--home",          "-H",
             if opts.machinefile != C_NULL
                 addprocs(load_machine_file(bytestring(opts.machinefile)))
             end
-
             # load file immediately on all processors
             if opts.load != C_NULL
                 require(bytestring(opts.load))

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -165,9 +165,13 @@ let exename = joinpath(JULIA_HOME, Base.julia_exename())
             # write a julia source file that just prints ARGS to STDOUT and exits
             open(testfile, "w") do io
                 println(io, "println(ARGS)")
+                println(io, "exit(0)")
             end
             @test readchomp(`$exename $testfile foo -bar --baz`) ==  "UTF8String[\"foo\",\"-bar\",\"--baz\"]"
+            @test readchomp(`$exename $testfile -- foo -bar --baz`) ==  "UTF8String[\"foo\",\"-bar\",\"--baz\"]"
+            @test readchomp(`$exename -L $testfile -- foo -bar --baz`) ==  "UTF8String[\"foo\",\"-bar\",\"--baz\"]"
             @test !success(`$exename --foo $testfile`)
+            @test !success(`$exename -L $testfile -- foo -bar -- baz`)
         finally
             rm(testfile)
         end

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -138,12 +138,22 @@ void parse_opts(int *argcp, char ***argvp)
         { "lisp",            no_argument,       &lisp_prompt, 1 },
         { 0, 0, 0, 0 }
     };
+    // getopt handles argument parsing up to -- delineator
+    int lastind = optind;
+    int argc = *argcp;
+    if (argc > 0) {
+        for (int i=0; i < argc; i++) {
+            if (!strcmp((*argvp)[i], "--")) {
+                argc = i;
+                break;
+            }
+        }
+    }
     int c;
     char *endptr;
     opterr = 0;
     int skip = 0;
-    int lastind = optind;
-    while ((c = getopt_long(*argcp,*argvp,shortopts,longopts,0)) != -1) {
+    while ((c = getopt_long(argc,*argvp,shortopts,longopts,0)) != -1) {
         switch (c) {
         case 0:
             break;
@@ -334,9 +344,8 @@ void parse_opts(int *argcp, char ***argvp)
     *argvp += optind;
     *argcp -= optind;
     if (jl_options.image_file==NULL && *argcp > 0) {
-        if (strcmp((*argvp)[0], "-")) {
+        if (strcmp((*argvp)[0], "-"))
             program = (*argvp)[0];
-        }
     }
 }
 


### PR DESCRIPTION
encountering a -- terminates getopt option parsing
and the rest of the options are part of ARGS

closes #10226
