### PR TITLE
Suppress deprecation warning when building sys0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ endif
 
 $(build_private_libdir)/sys0.o: | $(build_private_libdir)
 	@$(call PRINT_JULIA, cd base && \
-	$(call spawn,$(JULIA_EXECUTABLE)) -C $(JULIA_CPU_TARGET) --build $(call cygpath_w,$(build_private_libdir)/sys0) sysimg.jl)
+	$(call spawn,$(JULIA_EXECUTABLE)) --depwarn=no -C $(JULIA_CPU_TARGET) --build $(call cygpath_w,$(build_private_libdir)/sys0) sysimg.jl)
 
 BASE_SRCS := $(wildcard base/*.jl base/*/*.jl base/*/*/*.jl)
 


### PR DESCRIPTION
Fixes #10727.

Warnings are printed to STDERR, which is unavailable while building a
sysimg, resulting in any deprecation warnings while loading a module
failing the entire build. This is only an issue for deprecated code at
the module level, eg, in constants or macros.
