### PR TITLE
Fetch busybox.exe using http

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -537,7 +537,7 @@ endif
 	cd dist-extras && \
 	$(JLDOWNLOAD) http://downloads.sourceforge.net/sevenzip/7z920_extra.7z && \
 	$(JLDOWNLOAD) https://unsis.googlecode.com/files/nsis-2.46.5-Unicode-setup.exe && \
-	$(JLDOWNLOAD) ftp://ftp.tigress.co.uk/public/gpl/6.0.0/busybox/busybox.exe && \
+	$(JLDOWNLOAD) http://intgat.tigress.co.uk/rmy/files/busybox/busybox.exe && \
 	chmod a+x 7z.exe && \
 	chmod a+x 7z.dll && \
 	$(call spawn,./7z.exe) x -y -onsis nsis-2.46.5-Unicode-setup.exe && \


### PR DESCRIPTION
busybox.exe is now available via http.  This is preferable to ftp
because it will allow the link to be redirected if necessary.
