### PR TITLE
support basic core affinities in LocalManager and SSHManager

### DIFF
--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -636,6 +636,7 @@ object (with appropriate fields initialized) to ``launched`` ::
      count::Nullable{Union(Int, Symbol)}
      exename::Nullable{AbstractString}
      exeflags::Nullable{Cmd}
+     affinity::Nullable{Symbol}
 
      # External cluster managers can use this to store information at a per-worker level
      # Can be a dict if multiple fields need to be stored.
@@ -662,12 +663,15 @@ to be configured manually.
 
 If ``io`` is not specified, ``host`` and ``port`` are used to connect.
 
-``count``, ``exename`` and ``exeflags`` are relevant for launching additional workers from a worker.
-For example, a cluster manager may launch a single worker per node, and use that to launch
-additional workers. ``count`` with an integer value ``n`` will launch a total of ``n`` workers,
-while a value of ``:auto`` will launch as many workers as cores on that machine.
+``count``, ``exename``, ``exeflags`` and ``affinity`` are relevant for launching additional workers
+from an initial worker. For example, a cluster manager may launch a single worker per node, and
+use that to launch additional workers. ``count`` with an integer value ``n`` will launch a total
+of ``n`` workers, while a value of ``:auto`` will launch as many workers as cores on that machine.
 ``exename`` is the name of the julia executable including the full path.
 ``exeflags`` should be set to the required command line arguments for new workers.
+``affinity``, if set, should be either ``:compact`` or ``:balanced``. If ``:compact``, launched
+workers are associated with specific cores in a serial manner. If ``:balanced``, the workers
+are distributed across available cores.
 
 ``tunnel``, ``bind_addr``, ``sshflags`` and ``max_parallel`` are used when a ssh tunnel is
 required to connect to the workers from the master process.

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -118,7 +118,7 @@ Tasks
 General Parallel Computing Support
 ----------------------------------
 
-.. function:: addprocs(n::Integer; exeflags=``) -> List of process identifiers
+.. function:: addprocs(n::Integer; exeflags=``, affinity=[:compact|:balanced]) -> List of process identifiers
 
    Launches workers using the in-built ``LocalManager`` which only launches workers on the local host.
    This can be used to take advantage of multiple cores. ``addprocs(4)`` will add 4 processes on the local machine.
@@ -158,6 +158,11 @@ General Parallel Computing Support
 
    ``exeflags`` :  additional flags passed to the worker processes.
 
+   ``affinity`` :  Linux only feature. Uses the ``taskset`` command to associate each worker with a specific core.
+                   If specified as ``:compact`` cores will be associated in a serial manner. For example, adding 3 workers
+                   on a machine with 8 cores will result in core0 -> worker1, core1 -> worker2,... and so on.
+                   If specified as ``:balanced`` workers will be distributed across cores. For example, adding 3 workers
+                   on a machine with 8 cores will result in core0 -> worker1, core3 -> worker2 and core7 -> worker3.
 
 .. function:: addprocs(manager::ClusterManager; kwargs...) -> List of process identifiers
 


### PR DESCRIPTION
Allows pinning workers to cores. Linux only feature, requires the `taskset` command to be installed on the system.

Closes https://github.com/JuliaLang/julia/issues/10645
