### PR TITLE
code_* cleanup, and strip IR metadata from code_llvm output

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -264,7 +264,8 @@ function gen_call_with_extracted_types(fcn, ex0)
     exret
 end
 
-for fname in [:which, :less, :edit, :code_typed, :code_warntype, :code_lowered, :code_llvm, :code_native]
+for fname in [:which, :less, :edit, :code_typed, :code_warntype,
+              :code_lowered, :code_llvm, :code_llvm_raw, :code_native]
     @eval begin
         macro ($fname)(ex0)
             gen_call_with_extracted_types($(Expr(:quote,fname)), ex0)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -892,43 +892,8 @@ extern int jl_get_llvmf_info(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
 #endif
     );
 
-extern "C"
-void jl_dump_function_asm(uintptr_t Fptr, size_t Fsize, size_t slide,
-#ifdef USE_MCJIT
-                          const object::ObjectFile *objectfile,
-#else
-                          std::vector<JITEvent_EmittedFunctionDetails::LineStart> lineinfo,
-#endif
-                          formatted_raw_ostream &stream);
 
-const jl_value_t *jl_dump_llvmf(void *f, bool dumpasm)
-{
-    std::string code;
-    llvm::raw_string_ostream stream(code);
-    llvm::formatted_raw_ostream fstream(stream);
-    Function *llvmf = (Function*)f;
-    if (dumpasm == false) {
-        llvmf->print(stream);
-    }
-    else {
-        uint64_t symsize, slide;
-#ifdef USE_MCJIT
-        uint64_t fptr = jl_ExecutionEngine->getFunctionAddress(llvmf->getName());
-        const object::ObjectFile *object;
-#else
-        uint64_t fptr = (uintptr_t)jl_ExecutionEngine->getPointerToFunction(llvmf);
-        std::vector<JITEvent_EmittedFunctionDetails::LineStart> object;
-#endif
-        assert(fptr != 0);
-        if (jl_get_llvmf_info(fptr, &symsize, &slide, &object))
-            jl_dump_function_asm(fptr, symsize, slide, object, fstream);
-        else
-            jl_printf(JL_STDERR, "Warning: Unable to find function pointer\n");
-        fstream.flush();
-    }
-    return jl_cstr_to_string(const_cast<char*>(stream.str().c_str()));
-}
-
+// Get pointer to llvm::Function instance, compiling if necessary
 extern "C" DLLEXPORT
 void *jl_get_llvmf(jl_function_t *f, jl_tuple_t *types, bool getwrapper)
 {
@@ -968,13 +933,53 @@ void *jl_get_llvmf(jl_function_t *f, jl_tuple_t *types, bool getwrapper)
     return llvmf;
 }
 
-extern "C" DLLEXPORT
-const jl_value_t *jl_dump_function(jl_function_t *f, jl_tuple_t *types, bool dumpasm, bool dumpwrapper)
+// Pre-declaration. Definition in disasm.cpp
+extern "C"
+void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
+#ifdef USE_MCJIT
+                          const object::ObjectFile *objectfile,
+#else
+                          std::vector<JITEvent_EmittedFunctionDetails::LineStart> lineinfo,
+#endif
+                          formatted_raw_ostream &stream);
+
+extern "C"
+const jl_value_t *jl_dump_function_ir(void *f)
 {
-    void *llvmf = jl_get_llvmf(f,types,dumpwrapper);
-    if (llvmf == NULL)
-        return jl_cstr_to_string(const_cast<char*>(""));
-    return jl_dump_llvmf(llvmf,dumpasm);
+    std::string code;
+    llvm::raw_string_ostream stream(code);
+ 
+    Function *llvmf = (Function*)f;
+    llvmf->print(stream);
+    return jl_cstr_to_string(const_cast<char*>(stream.str().c_str()));
+} 
+
+extern "C"
+const jl_value_t *jl_dump_function_asm(void *f)
+{
+    std::string code;
+    llvm::raw_string_ostream stream(code);
+    llvm::formatted_raw_ostream fstream(stream);
+    Function *llvmf = (Function*)f;
+
+    // Dump assembly code
+    uint64_t symsize, slide;
+#ifdef USE_MCJIT
+    uint64_t fptr = jl_ExecutionEngine->getFunctionAddress(llvmf->getName());
+    const object::ObjectFile *object;
+#else
+    uint64_t fptr = (uintptr_t)jl_ExecutionEngine->getPointerToFunction(llvmf);
+    std::vector<JITEvent_EmittedFunctionDetails::LineStart> object;
+#endif
+    assert(fptr != 0);
+    if (jl_get_llvmf_info(fptr, &symsize, &slide, &object)) {
+        jl_dump_asm_internal(fptr, symsize, slide, object, fstream);
+    } else {
+        jl_printf(JL_STDERR, "Warning: Unable to find function pointer\n");
+    }
+    fstream.flush();
+
+    return jl_cstr_to_string(const_cast<char*>(stream.str().c_str()));
 }
 
 // Code coverage

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -245,7 +245,7 @@ int OpInfoLookup(void *DisInfo, uint64_t PC,
 } // namespace
 
 extern "C"
-void jl_dump_function_asm(uintptr_t Fptr, size_t Fsize, size_t slide,
+void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
 #ifndef USE_MCJIT
                           std::vector<JITEvent_EmittedFunctionDetails::LineStart> lineinfo,
 #else

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -167,6 +167,9 @@ DLLEXPORT void jl_atexit_hook();
 #define HAVE_CPUID
 #endif
 
+DLLEXPORT const jl_value_t* jl_dump_llvm_ir(void*);
+DLLEXPORT const jl_value_t* jl_dump_llvm_asm(void*);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The first commit cleans up the `code_native` and `code_llvm` pathways a little bit by removing an intermediate function and calling the one we want directly from Julia code.

The second commit changes the behavior of `code_llvm` to strip all metadata before printing the IR. This reduces the work needed to run `code_llvm` output with `lli` for debugging purposes. I also added a `code_llvm_raw` version with the current behavior. If people don't think stripped should be the default I'll switch it around.

before:

```
; Function Attrs: uwtable
define void @julia_bf_112785(i32, i64) #0 {
top:
  call void @llvm.dbg.value(metadata i32 %0, i64 0, metadata !11, metadata !17)
  call void @llvm.dbg.value(metadata i64 %1, i64 0, metadata !18, metadata !17)
  %sext = shl i32 %0, 24, !dbg !19
  %2 = ashr exact i32 %sext, 24, !dbg !19
  %3 = icmp eq i32 %2, %0, !dbg !19
  br i1 %3, label %pass, label %fail, !dbg !19
...
```

after:

```
; Function Attrs: uwtable
define void @julia_bf_112785(i32, i64) #-1 {
top:
  call void @llvm.dbg.value(metadata i32 %0, i64 0, metadata !0, metadata !13)
  call void @llvm.dbg.value(metadata i64 %1, i64 0, metadata !14, metadata !13)
  %sext = shl i32 %0, 24
  %2 = ashr exact i32 %sext, 24
  %3 = icmp eq i32 %2, %0
  br i1 %3, label %pass, label %fail
```
