### PR TITLE
Update noteworthy-differences.rst

### DIFF
--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -111,8 +111,8 @@ noteworthy differences:
 - In Julia, not all data structures support logical indexing. Furthermore,
   logical indexing in Julia is supported only with vectors of length equal to
   the object being indexed. For example:
-  - In R, ``c(1, 2, 3, 4)[c(TRUE, FALSE)]`` produces ``c(1,3)``.
-  - In R, ``c(1, 2, 3, 4)[c(TRUE, FALSE, TRUE, FALSE)]`` produces ``c(1,3)``.
+  - In R, ``c(1, 2, 3, 4)[c(TRUE, FALSE)]`` produces ``1 3``.
+  - In R, ``c(1, 2, 3, 4)[c(TRUE, FALSE, TRUE, FALSE)]`` produces ``1 3``.
   - In Julia, ``[1, 2, 3, 4][[true, false]]`` throws a :exc:`BoundsError`.
   - In Julia, ``[1, 2, 3, 4][[true, false, true, false]]`` produces ``[1, 3]``.
 - Like many languages, Julia does not always allow operations on vectors of


### PR DESCRIPTION
Proposed change in presentation of output in R where the expresion `1 3` is thrown by R instead of the original `c(1,3)`
