### PR TITLE
code_* cleanup, and strip IR metadata from code_llvm output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -242,6 +242,8 @@ Library improvements
     * `lock` and `unlock` which operate on `ReentrantLock`. Useful to lock a stream during
       concurrent writes from multiple tasks
 
+    * `code_llvm` now outputs stripped IR without debug info or other attached metadata.
+      Use `code_llvm_raw` for the unstripped output ([#10747]).
 
 Deprecated or removed
 ---------------------

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -264,7 +264,8 @@ function gen_call_with_extracted_types(fcn, ex0)
     exret
 end
 
-for fname in [:which, :less, :edit, :code_typed, :code_warntype, :code_lowered, :code_llvm, :code_native]
+for fname in [:which, :less, :edit, :code_typed, :code_warntype,
+              :code_lowered, :code_llvm, :code_llvm_raw, :code_native]
     @eval begin
         macro ($fname)(ex0)
             gen_call_with_extracted_types($(Expr(:quote,fname)), ex0)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -985,6 +985,8 @@ Internals
 
    Prints the LLVM bitcodes generated for running the method matching the given generic function and type signature to :const:`STDOUT`.
 
+   All metadata and dbg.* calls are removed from the printed bitcode. Use code_llvm_raw for the full IR.
+
 .. function:: @code_llvm
 
    Evaluates the arguments to the function call, determines their types, and calls :func:`code_llvm` on the resulting expression

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -962,7 +962,6 @@ const jl_value_t *jl_dump_function_ir(void *f, bool strip_ir_metadata)
     } else {
         // make a copy of the function and strip metadata from the copy
         llvm::ValueToValueMapTy VMap;
-        std::vector<Instruction> dbgInsts;
         Function* f2 = llvm::CloneFunction(llvmf, VMap, false);
         Function::BasicBlockListType::iterator f2_bb = f2->getBasicBlockList().begin();
         // iterate over all basic blocks in the function
@@ -987,7 +986,6 @@ const jl_value_t *jl_dump_function_ir(void *f, bool strip_ir_metadata)
                 }
             }
         }
-
         f2->print(stream);
         delete f2;
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -863,6 +863,12 @@ void *jl_function_ptr(jl_function_t *f, jl_value_t *rt, jl_value_t *argt)
 #endif
 }
 
+
+extern "C" DLLEXPORT
+void *jl_function_ptr_by_llvm_name(char* name) {
+    return (void*)(intptr_t)jl_ExecutionEngine->FindFunctionNamed(name);
+}
+
 // export a C-callable entry point for a function, with a given name
 extern "C" DLLEXPORT
 void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -945,7 +945,10 @@ const jl_value_t *jl_dump_function_ir(void *f, bool strip_ir_metadata)
 {
     std::string code;
     llvm::raw_string_ostream stream(code);
-    Function *llvmf = (Function*)f;
+
+    Function *llvmf = dyn_cast<Function>((Function*)f);
+    if (!llvmf)
+        jl_error("jl_dump_function_ir: Expected Function*");
 
     if (!strip_ir_metadata) {
         // print the function IR as-is
@@ -992,7 +995,10 @@ const jl_value_t *jl_dump_function_asm(void *f)
     std::string code;
     llvm::raw_string_ostream stream(code);
     llvm::formatted_raw_ostream fstream(stream);
-    Function *llvmf = (Function*)f;
+
+    Function *llvmf = dyn_cast<Function>((Function*)f);
+    if (!llvmf)
+        jl_error("jl_dump_function_asm: Expected Function*");
 
     // Dump assembly code
     uint64_t symsize, slide;

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -248,7 +248,7 @@ int OpInfoLookup(void *DisInfo, uint64_t PC,
 } // namespace
 
 extern "C"
-void jl_dump_function_asm(uintptr_t Fptr, size_t Fsize, size_t slide,
+void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
 #ifndef USE_MCJIT
                           std::vector<JITEvent_EmittedFunctionDetails::LineStart> lineinfo,
 #else

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -167,6 +167,9 @@ DLLEXPORT void jl_atexit_hook();
 #define HAVE_CPUID
 #endif
 
+DLLEXPORT const jl_value_t* jl_dump_llvm_ir(void*);
+DLLEXPORT const jl_value_t* jl_dump_llvm_asm(void*);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -167,9 +167,6 @@ DLLEXPORT void jl_atexit_hook();
 #define HAVE_CPUID
 #endif
 
-DLLEXPORT const jl_value_t* jl_dump_llvm_ir(void*);
-DLLEXPORT const jl_value_t* jl_dump_llvm_asm(void*);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
(replaces #10741 ... because github)

The first commit cleans up the `code_native` and `code_llvm` pathways a little bit by removing an intermediate function and calling the one we want directly from Julia code.

The second commit changes the behavior of `code_llvm` to strip all metadata before printing the IR. This reduces the work needed to run `code_llvm` output with `lli` for debugging purposes. I also added a `code_llvm_raw` version with the current behavior. If people don't think stripped should be the default I'll switch it around.

Should now compile against gcc 4.6.

before:

```
; Function Attrs: uwtable
define void @julia_bf_112785(i32, i64) #0 {
top:
  call void @llvm.dbg.value(metadata i32 %0, i64 0, metadata !11, metadata !17)
  call void @llvm.dbg.value(metadata i64 %1, i64 0, metadata !18, metadata !17)
  %sext = shl i32 %0, 24, !dbg !19
  %2 = ashr exact i32 %sext, 24, !dbg !19
  %3 = icmp eq i32 %2, %0, !dbg !19
  br i1 %3, label %pass, label %fail, !dbg !19
...
```

after:

```
; Function Attrs: uwtable
define void @julia_bf_112785(i32, i64) #-1 {
top:
  %sext = shl i32 %0, 24
  %2 = ashr exact i32 %sext, 24
  %3 = icmp eq i32 %2, %0
  br i1 %3, label %pass, label %fail
```
