### PR TITLE
Make Bool conversion consistent with other conversions

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -180,8 +180,8 @@ end
 finalize(o::ANY) = ccall(:jl_finalize, Void, (Any,), o)
 
 gc(full::Bool=true) = ccall(:jl_gc_collect, Void, (Cint,), full)
-gc_enable() = Bool(ccall(:jl_gc_enable, Cint, ()))
-gc_disable() = Bool(ccall(:jl_gc_disable, Cint, ()))
+gc_enable() = ccall(:jl_gc_enable, Cint, ())!=0
+gc_disable() = ccall(:jl_gc_disable, Cint, ())!=0
 
 bytestring(str::ByteString) = str
 

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -309,7 +309,7 @@ function convert{T,N}(::Type{BitArray{N}}, A::AbstractArray{T,N})
             u = UInt64(1)
             c = UInt64(0)
             for j = 0:63
-                Bool(A[ind]) && (c |= u)
+                A[ind]!=0 && (c |= u)
                 ind += 1
                 u <<= 1
             end
@@ -318,7 +318,7 @@ function convert{T,N}(::Type{BitArray{N}}, A::AbstractArray{T,N})
         u = UInt64(1)
         c = UInt64(0)
         for j = 0:_mod64(l-1)
-            Bool(A[ind]) && (c |= u)
+            A[ind]!=0 && (c |= u)
             ind += 1
             u <<= 1
         end

--- a/base/bool.jl
+++ b/base/bool.jl
@@ -1,7 +1,7 @@
 ## boolean conversions ##
 
 convert(::Type{Bool}, x::Bool) = x
-convert(::Type{Bool}, x::Real) = (x!=0)
+convert(::Type{Bool}, x::Real) = x==0 ? false : x==1 ? true : throw(InexactError())
 
 # promote Bool to any other numeric type
 promote_rule{T<:Number}(::Type{Bool}, ::Type{T}) = T

--- a/base/client.jl
+++ b/base/client.jl
@@ -139,7 +139,7 @@ end
 _repl_start = Condition()
 
 syntax_deprecation_warnings(warn::Bool) =
-    Bool(ccall(:jl_parse_depwarn, Cint, (Cint,), warn))
+    ccall(:jl_parse_depwarn, Cint, (Cint,), warn)!=0
 
 function parse_input_line(s::AbstractString)
     # s = bytestring(s)
@@ -246,17 +246,17 @@ let reqarg = Set(UTF8String["--home",          "-H",
         end
         repl                  = true
         startup               = (opts.startupfile != 2)
-        history_file          = Bool(opts.historyfile)
-        quiet                 = Bool(opts.quiet)
+        history_file          = (opts.historyfile != 0)
+        quiet                 = (opts.quiet != 0)
         color_set             = (opts.color != 0)
         global have_color     = (opts.color == 1)
-        global is_interactive = Bool(opts.isinteractive)
+        global is_interactive = (opts.isinteractive != 0)
         while true
             # load ~/.juliarc file
             startup && load_juliarc()
 
             # startup worker
-            if Bool(opts.worker)
+            if opts.worker != 0
                 start_worker() # does not return
             end
             # add processors

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -309,7 +309,7 @@ function dlm_fill(T::DataType, offarr::Vector{Vector{Int}}, dims::NTuple{2,Integ
         while idx <= length(offsets)
             row = offsets[idx]
             col = offsets[idx+1]
-            quoted = Bool(offsets[idx+2])
+            quoted = offsets[idx+2] != 0
             startpos = offsets[idx+3]
             endpos = offsets[idx+4]
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -36,7 +36,7 @@ macro deprecate(old,new)
 end
 
 function depwarn(msg, funcsym)
-    if Bool(JLOptions().depwarn)
+    if JLOptions().depwarn!=0
         bt = backtrace()
         caller = firstcaller(bt, funcsym)
         warn(msg, once=(caller!=C_NULL), key=caller, bt=bt)
@@ -352,7 +352,7 @@ end
 @deprecate int(x)  Int(x)
 @deprecate uint(x) UInt(x)
 
-@deprecate bool(x::Number)  Bool(x)
+@deprecate bool(x::Number)  x!=0
 
 @deprecate char(x)                 Char(x)
 @deprecate char(x::FloatingPoint)  Char(round(UInt32,x))

--- a/base/int.jl
+++ b/base/int.jl
@@ -18,7 +18,7 @@ end
 /(x::Integer, y::Integer) = float(x)/float(y)
 inv(x::Integer) = float(one(x))/float(x)
 
-isodd(n::Integer) = Bool(rem(n,2))
+isodd(n::Integer) = rem(n,2) != 0
 iseven(n::Integer) = !isodd(n)
 
 signbit(x::Integer) = x < 0

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -27,15 +27,15 @@ show(io::IO, s::IOStream) = print(io, "IOStream(", s.name, ")")
 fd(s::IOStream) = Int(ccall(:jl_ios_fd, Clong, (Ptr{Void},), s.ios))
 stat(s::IOStream) = stat(fd(s))
 close(s::IOStream) = ccall(:ios_close, Void, (Ptr{Void},), s.ios)
-isopen(s::IOStream) = Bool(ccall(:ios_isopen, Cint, (Ptr{Void},), s.ios))
+isopen(s::IOStream) = ccall(:ios_isopen, Cint, (Ptr{Void},), s.ios)!=0
 function flush(s::IOStream)
     sigatomic_begin()
     systemerror("flush", ccall(:ios_flush, Cint, (Ptr{Void},), s.ios) != 0)
     sigatomic_end()
     s
 end
-iswritable(s::IOStream) = Bool(ccall(:ios_get_writable, Cint, (Ptr{Void},), s.ios))
-isreadable(s::IOStream) = Bool(ccall(:ios_get_readable, Cint, (Ptr{Void},), s.ios))
+iswritable(s::IOStream) = ccall(:ios_get_writable, Cint, (Ptr{Void},), s.ios)!=0
+isreadable(s::IOStream) = ccall(:ios_get_readable, Cint, (Ptr{Void},), s.ios)!=0
 
 function truncate(s::IOStream, n::Integer)
     systemerror("truncate", ccall(:ios_trunc, Int32, (Ptr{Void}, UInt), s.ios, n) != 0)

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -205,15 +205,15 @@ end
 
 @windows_only begin
 function munmap(viewhandle::Ptr, mmaphandle::Ptr)
-    status = Bool(ccall(:UnmapViewOfFile, stdcall, Cint, (Ptr{Void},), viewhandle))
-    status |= Bool(ccall(:CloseHandle, stdcall, Cint, (Ptr{Void},), mmaphandle))
+    status = ccall(:UnmapViewOfFile, stdcall, Cint, (Ptr{Void},), viewhandle)!=0
+    status |= ccall(:CloseHandle, stdcall, Cint, (Ptr{Void},), mmaphandle)!=0
     if !status
         error("could not unmap view: $(FormatMessage())")
     end
 end
 
 function msync(p::Ptr, len::Integer)
-    status = Bool(ccall(:FlushViewOfFile, stdcall, Cint, (Ptr{Void}, Csize_t), p, len))
+    status = ccall(:FlushViewOfFile, stdcall, Cint, (Ptr{Void}, Csize_t), p, len)!=0
     if !status
         error("could not msync: $(FormatMessage())")
     end

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -153,13 +153,13 @@ Ac_ldiv_Bc(A::LU, B::StridedVecOrMat) = Ac_ldiv_B(A, ctranspose(B))
 function det{T,S}(A::LU{T,S})
     n = chksquare(A)
     A.info > 0 && return zero(typeof(A.factors[1]))
-    return prod(diag(A.factors)) * (Bool(sum(A.ipiv .!= 1:n) % 2) ? -one(T) : one(T))
+    return prod(diag(A.factors)) * (isodd(sum(A.ipiv .!= 1:n)) ? -one(T) : one(T))
 end
 
 function logdet2{T<:Real,S}(A::LU{T,S})  # return log(abs(det)) and sign(det)
     n = chksquare(A)
     dg = diag(A.factors)
-    s = (Bool(sum(A.ipiv .!= 1:n) % 2) ? -one(T) : one(T)) * prod(sign(dg))
+    s = (isodd(sum(A.ipiv .!= 1:n)) ? -one(T) : one(T)) * prod(sign(dg))
     sum(log(abs(dg))), s
 end
 
@@ -172,7 +172,7 @@ end
 function logdet{T<:Complex,S}(A::LU{T,S})
     n = chksquare(A)
     s = sum(log(diag(A.factors)))
-    if Bool(sum(A.ipiv .!= 1:n) % 2)
+    if isodd(sum(A.ipiv .!= 1:n))
         s = Complex(real(s), imag(s)+π)
     end
     r, a = reim(s)

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -122,7 +122,7 @@ start_timer() = ccall(:jl_profile_start_timer, Cint, ())
 
 stop_timer() = ccall(:jl_profile_stop_timer, Void, ())
 
-is_running() = Bool(ccall(:jl_profile_is_running, Cint, ()))
+is_running() = ccall(:jl_profile_is_running, Cint, ())!=0
 
 get_data_pointer() = convert(Ptr{UInt}, ccall(:jl_profile_get_data, Ptr{UInt8}, ()))
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -67,6 +67,8 @@ immutable UnitRange{T<:Real} <: OrdinalRange{T,Int}
 
     UnitRange(start, stop) =
         new(start, ifelse(stop >= start, stop, convert(T,start-one(stop-start))))
+
+    UnitRange(start::Bool, stop::Bool) = new(start, stop)
 end
 UnitRange{T<:Real}(start::T, stop::T) = UnitRange{T}(start, stop)
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -61,7 +61,7 @@ convert{T<:Integer}(::Type{Rational{T}}, x::Integer) = Rational{T}(convert(T,x),
 convert(::Type{Rational}, x::Rational) = x
 convert(::Type{Rational}, x::Integer) = convert(Rational{typeof(x)},x)
 
-convert(::Type{Bool}, x::Rational) = (x!=0) # to resolve ambiguity
+convert(::Type{Bool}, x::Rational) = x==0 ? false : x==1 ? true : throw(InexactError()) # to resolve ambiguity
 convert{T<:Integer}(::Type{T}, x::Rational) = (isinteger(x) ? convert(T, x.num) : throw(InexactError()))
 
 convert(::Type{FloatingPoint}, x::Rational) = float(x.num)/float(x.den)

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -469,7 +469,7 @@ function deserialize(s, ::Type{Array})
             i = 1
             while i <= n
                 b = read(s, UInt8)
-                v = Bool(b>>7)
+                v = b>>7 != 0
                 count = b&0x7f
                 nxt = i+count
                 while i < nxt

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -190,7 +190,7 @@ type TTY <: AsyncStream
             false,Condition(),
             false,Condition(),
             nothing, ReentrantLock())
-        @windows_only tty.ispty = Bool(ccall(:jl_ispty, Cint, (Ptr{Void},), handle))
+        @windows_only tty.ispty = ccall(:jl_ispty, Cint, (Ptr{Void},), handle)!=0
         tty
     end
 end
@@ -211,9 +211,9 @@ end
 # note that uv_is_readable/writable work for any subtype of
 # uv_stream_t, including uv_tty_t and uv_pipe_t
 isreadable(io::Union(Pipe,TTY)) =
-    Bool(ccall(:uv_is_readable, Cint, (Ptr{Void},), io.handle))
+    ccall(:uv_is_readable, Cint, (Ptr{Void},), io.handle)!=0
 iswritable(io::Union(Pipe,TTY)) =
-    Bool(ccall(:uv_is_writable, Cint, (Ptr{Void},), io.handle))
+    ccall(:uv_is_writable, Cint, (Ptr{Void},), io.handle)!=0
 
 nb_available(stream::UVStream) = nb_available(stream.buffer)
 

--- a/base/utf8proc.jl
+++ b/base/utf8proc.jl
@@ -11,7 +11,7 @@ export normalize_string, graphemes, is_valid_char, is_assigned_char, charwidth,
    iscntrl, ispunct, isspace, isprint, isgraph, isblank
 
 # whether codepoints are valid Unicode
-is_valid_char(c::Union(UInt8,UInt16,UInt32,Char)) = Bool(ccall(:utf8proc_codepoint_valid, Cuchar, (UInt32,), c))
+is_valid_char(c::Union(UInt8,UInt16,UInt32,Char)) = ccall(:utf8proc_codepoint_valid, Cuchar, (UInt32,), c)!=0
 is_valid_char(c::Integer) = (0x0 <= c <= 0x110000) && is_valid_char(UInt32(c))
 
 # utf8 category constants

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -444,7 +444,7 @@ for m1 = 1 : v1 + 1
             @test b == i
             b2 = copy(b1)
             i2 = copy(i1)
-            i3 = [j => rand(0:3) for j = 1:v2]
+            i3 = [j => rand(0:1) for j = 1:v2]
             b = splice!(b2, m1:m2, values(i3))
             i = splice!(i2, m1:m2, values(i3))
             @test isequal(bitunpack(b2), i2)
@@ -474,7 +474,7 @@ for m1 = 1 : v1
         @test b == i
         b2 = copy(b1)
         i2 = copy(i1)
-        i3 = [j => rand(0:3) for j = 1:v2]
+        i3 = [j => rand(0:1) for j = 1:v2]
         b = splice!(b2, m1:m2, values(i3))
         i = splice!(i2, m1:m2, values(i3))
         @test isequal(bitunpack(b2), i2)

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -46,7 +46,7 @@ using Base.Test
 @test convert(BigInt,apple) == 0
 @test convert(Bool,apple) == false
 @test convert(Bool,orange) == true
-@test convert(Bool,kiwi)
+@test_throws InexactError convert(Bool,kiwi)
 @test names(Fruit) == [:apple, :orange, :kiwi]
 
 f(x::Fruit) = "hey, I'm a Fruit"

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -18,16 +18,11 @@ vals = vcat(
 
 function coerce(T::Type, x)
     if T<:Rational
-        return convert(T, coerce(typeof(num(zero(T))), x))
-    end
-    if !(T<:Integer) || T===Bool
+        convert(T, coerce(typeof(num(zero(T))), x))
+    elseif !(T<:Integer)
         convert(T, x)
-    elseif sizeof(T) < sizeof(x)
-        x % T
-    elseif sizeof(T) == sizeof(x)
-        reinterpret(T, x)
     else
-        convert(T, x)
+        x % T
     end
 end
 

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -139,7 +139,7 @@ debug && println("Reorder Schur")
         S = schurfact(ordschura)
         select = bitrand(n)
         O = ordschur(S, select)
-        Bool(sum(select)) && @test_approx_eq S[:values][find(select)] O[:values][1:sum(select)]
+        sum(select) != 0 && @test_approx_eq S[:values][find(select)] O[:values][1:sum(select)]
         @test_approx_eq O[:vectors]*O[:Schur]*O[:vectors]' ordschura
     end
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -32,17 +32,17 @@
 @test Bool(true) == true
 @test Bool(0) == false
 @test Bool(1) == true
-@test Bool(-1) == true
+@test_throws InexactError Bool(-1)
 @test Bool(0.0) == false
 @test Bool(1.0) == true
-@test Bool(0.1) == true
-@test Bool(-1.0) == true
+@test_throws InexactError Bool(0.1)
+@test_throws InexactError Bool(-1.0)
 @test Bool(Complex(0,0)) == false
 @test Bool(Complex(1,0)) == true
-@test_throws InexactError Bool(Complex(0,1)) == true
+@test_throws InexactError Bool(Complex(0,1))
 @test Bool(0//1) == false
 @test Bool(1//1) == true
-@test Bool(1//2) == true
+@test_throws InexactError Bool(1//2)
 
 # basic arithmetic
 @test 2 + 3 == 5

--- a/test/random.jl
+++ b/test/random.jl
@@ -300,10 +300,11 @@ for rng in ([], [MersenneTwister()], [RandomDevice()])
             end
         end
         for A in (Array(T, 5), Array(T, 2, 3))
+            X = T == Bool ? T[0,1] : T[0,1,2]
             rand!(rng..., A)            ::typeof(A)
-            rand!(rng..., A, T[0,1,2])  ::typeof(A)
+            rand!(rng..., A, X)  ::typeof(A)
             rand!(rng..., sparse(A))            ::typeof(sparse(A))
-            rand!(rng..., sparse(A), T[0,1,2])  ::typeof(sparse(A))
+            rand!(rng..., sparse(A), X)  ::typeof(sparse(A))
         end
     end
 end


### PR DESCRIPTION
Throws `InexactError` for values other than 0/1. Fixes #10712.
