### PR TITLE
Minor correction to documentation

### DIFF
--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -139,6 +139,30 @@ So, we could have defined the ``test`` function above as
              println("x is ", relation, " than y.")
            end
 
+The variable ``relation`` is declared inside the ``if`` block, but used
+outside. However, when depending on this behavior, make sure all possible
+code paths define a value for the variable. The following change to
+the above function results in a runtime error
+
+.. doctest::
+
+    julia> function test(x,y)
+             if x < y
+               relation = "less than"
+             elseif x == y
+               relation = "equal to"
+             end
+             println("x is ", relation, " than y.")
+           end
+    test (generic function with 1 method)
+
+    julia> test(1,2)
+    x is less than than y.
+
+    julia> test(2,1)
+    ERROR: UndefVarError: relation not defined
+     in test at none:7
+
 ``if`` blocks also return a value, which may seem unintuitive to users
 coming from many other languages. This value is simply the return value
 of the last executed statement in the branch that was chosen, so


### PR DESCRIPTION
This is just an addition to the documentation, manual/control-flow.rst. I have added an line to the description of an existing example. Without pointing out which variable declaration is leaky, I didn't understand the example initially. Moreover, such declaration / usage cause other issues shown in a following new example. The only change in earlier example is the removal of an else block.
