### PR TITLE
Update socket.jl to allow easy conversion from IPAddr to Integer 

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -2,6 +2,7 @@
 abstract IPAddr
 
 Base.isless{T<:IPAddr}(a::T, b::T) = isless(a.host, b.host)
+Base.convert{T<:Integer}(dt::Type{T}, ip::IPAddr) = dt(ip.host)
 
 immutable IPv4 <: IPAddr
     host::UInt32

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -6,6 +6,12 @@
 @test ip"192.0xFFFFFF" == IPv4(192,255,255,255)
 @test ip"022.0.0.1" == IPv4(18,0,0,1)
 
+@test UInt(IPv4(0x01020304)) == 0x01020304
+@test Int(IPv4("1.2.3.4")) == Int(0x01020304) == Int32(0x01020304)
+@test Int128(IPv6("2001:1::2")) == 42540488241204005274814694018844196866
+@test_throws InexactError Int16(IPv4("1.2.3.4"))
+@test_throws InexactError Int64(IPv6("2001:1::2"))
+
 let ipv = parseip("127.0.0.1")
     @test isa(ipv, IPv4)
     @test ipv == ip"127.0.0.1"


### PR DESCRIPTION
Added conversion to Integers for IP addresses. Will throw InexactError when the width of the type requested is less than the width of the address (e.g., on `UInt8(ip"1.2.3.4")` or `Int64(ip"2001::1")`)

Examples:

```
julia> Int(ip"1.2.3.4")
16909060

julia> UInt(ip"1.2.3.4")
0x0000000001020304

julia> UInt32(ip"1.2.3.4")
0x01020304

julia> BigInt(ip"2001::1")
42540488161975842760550356425300246529

julia> Int128(ip"2001::1")
42540488161975842760550356425300246529

julia> Int64(ip"2001::1")   # IPv6 addresses are 128 bits
ERROR: InexactError()
 in call at base.jl:38
```
