### PR TITLE
Fixing a small typo in Strings documentation

### DIFF
--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -93,7 +93,7 @@ convert an integer value back to a :obj:`Char` just as easily:
 
 .. doctest::
 
-    julia> Char(120)
+    julia> char(120)
     'x'
 
 Not all integer values are valid Unicode code points, but for


### PR DESCRIPTION
Should be Base.char(x) instead of the datatype itself
