### PR TITLE
vi editor should work w/line numbers

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -27,7 +27,7 @@ function edit(file::AbstractString, line::Integer)
     const no_line_msg = "Unknown editor: no line number information passed.\nThe method is defined at line $line."
     if startswith(edname, "emacs") || edname == "gedit"
         spawn(`$edpath +$line $file`)
-    elseif edname == "vim" || edname == "nvim" || edname == "mvim" || edname == "nano"
+    elseif edname == "vi" || edname == "vim" || edname == "nvim" || edname == "mvim" || edname == "nano"
         run(`$edpath +$line $file`)
     elseif edname == "textmate" || edname == "mate" || edname == "kate"
         spawn(`$edpath $file -l $line`)


### PR DESCRIPTION
This should disable "Unknown editor: no line number information passed." warning.
