### PR TITLE
Add replhook() for REPL customization from juliarc

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -377,6 +377,21 @@ end
 import .Terminals
 import .REPL
 
+const repl_hooks = []
+
+atreplinit(f::Function) = (unshift!(repl_hooks, f); nothing)
+
+function _atreplinit(repl)
+    for f in repl_hooks
+        try
+            f(repl)
+        catch err
+            show(STDERR, err)
+            println(STDERR)
+        end
+    end
+end
+
 function _start()
     opts = JLOptions()
     try
@@ -421,6 +436,7 @@ function _start()
                     end
                 end
             else
+                _atreplinit(active_repl)
                 active_repl_backend = REPL.run_repl(active_repl)
             end
         end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1096,6 +1096,7 @@ export
 
 # misc
     atexit,
+    atreplinit,
     clipboard,
     exit,
     ntuple,

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -1199,6 +1199,16 @@ Any[
 
 "),
 
+("Base","atreplinit","atreplinit(f)
+
+   Register a one-argument function to be called before the REPL
+   interface is initialized in interactive sessions; this is useful to
+   customize the interface. The argument of \"f\" is the REPL object.
+   This function should be called from within the \".juliarc.jl\"
+   initialization file.
+
+"),
+
 ("Base","isinteractive","isinteractive() -> Bool
 
    Determine whether Julia is running an interactive session.

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -161,13 +161,11 @@ The Julia REPL makes great use of key bindings.  Several control-key bindings we
 +------------------------+----------------------------------------------------+
 | ``^T``                 | Transpose the characters about the cursor          |
 +------------------------+----------------------------------------------------+
-| Delete, ``^D``         | Forward delete one character (when buffer has text)|
-+------------------------+----------------------------------------------------+
 
 Customizing keybindings
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Julia's REPL keybindings may be fully customized to a user's preferences by passing a dictionary to ``REPL.setup_interface()``. The keys of this dictionary may be characters or strings. The key ``'*'`` refers to the default action. Control plus character ``x`` bindings are indicated with ``"^x"``. Meta plus ``x`` can be written ``"\\Mx"``. The values of the custom keymap must be ``nothing`` (indicating that the input should be ignored) or functions that accept the signature ``(PromptState, AbstractREPL, Char)``. For example, to bind the up and down arrow keys to move through history without prefix search, one could put the following code in ``.juliarc.jl``::
+Julia's REPL keybindings may be fully customized to a user's preferences by passing a dictionary to ``REPL.setup_interface()``. The keys of this dictionary may be characters or strings. The key ``'*'`` refers to the default action. Control plus character ``x`` bindings are indicated with ``"^x"``. Meta plus ``x`` can be written ``"\\Mx"``. The values of the custom keymap must be ``nothing`` (indicating that the input should be ignored) or functions that accept the signature ``(PromptState, AbstractREPL, Char)``. The ``REPL.setup_interface()`` function must be called before the REPL is initialized, by registering the operation with ``atreplinit()``. For example, to bind the up and down arrow keys to move through history without prefix search, one could put the following code in ``.juliarc.jl``::
 
     import Base: LineEdit, REPL
 
@@ -178,7 +176,11 @@ Julia's REPL keybindings may be fully customized to a user's preferences by pass
       "\e[B" => (s,o...)->(LineEdit.edit_move_up(s) || LineEdit.history_next(s, LineEdit.mode(s).hist))
     )
 
-    Base.active_repl.interface = REPL.setup_interface(Base.active_repl; extra_repl_keymap = mykeys)
+    function customize_keys(repl)
+      repl.interface = REPL.setup_interface(repl; extra_repl_keymap = mykeys)
+    end
+
+    atreplinit(customize_keys)
 
 Users should refer to ``base/LineEdit.jl`` to discover the available actions on key input.
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -32,6 +32,11 @@ Getting Around
 
    Register a zero-argument function to be called at exit.
 
+.. function:: atreplinit(f)
+
+   Register a one-argument function to be called before the REPL interface is initialized in interactive sessions; this is useful to customize the interface. The argument of ``f`` is the REPL object.
+   This function should be called from within the ``.juliarc.jl`` initialization file.
+
 .. function:: isinteractive() -> Bool
 
    Determine whether Julia is running an interactive session.


### PR DESCRIPTION
This brings back a way to customize the REPL by defining and registering hooks in .juliarc.jl.
It does so by exporting a `replhook` function, which works similarly to the `atexit` function. However, it could also be left unexported.
Partially addresses #10779.

I wanted to get some feedback before adding documentation etc.
