### PR TITLE
Memory sanitizer support revisited

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -388,9 +388,16 @@ include $(JULIAHOME)/Make.user
 endif
 
 ifeq ($(SANITIZE),1)
-JCXXFLAGS += -fsanitize=address -mllvm -asan-stack=0
-JCFLAGS += -fsanitize=address -mllvm -asan-stack=0
-LDFLAGS += -fsanitize=address
+ifeq ($(SANITIZE_MEMORY),1)
+SANITIZE_OPTS = -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer
+else
+SANITIZE_OPTS = -fsanitize=address -mllvm -asan-stack=0
+endif
+JCXXFLAGS += $(SANITIZE_OPTS)
+JCFLAGS += $(SANITIZE_OPTS)
+LDFLAGS += $(SANITIZE_OPTS)
+DEPS_CFLAGS += $(SANITIZE_OPTS)
+DEPS_CXXFLAGS += $(SANITIZE_OPTS)
 endif
 
 TAR=`which gtar 2>/dev/null || which tar 2>/dev/null`
@@ -668,7 +675,14 @@ else ifneq ($(USEMSVC), 1)
 endif
 
 ifeq ($(OS), Linux)
-OSLIBS += -ldl -lrt -lpthread -Wl,--export-dynamic -Wl,--version-script=$(JULIAHOME)/src/julia.expmap -Wl,--no-whole-archive $(LIBUNWIND)
+OSLIBS += -ldl -lrt -lpthread -Wl,--export-dynamic -Wl,--no-whole-archive $(LIBUNWIND)
+ifneq ($(SANITIZE),1)
+ifneq ($(SANITIZE_MEMORY),1)
+ifneq ($(LLVM_SANITIZE),1)
+OSLIBS += -Wl,--version-script=$(JULIAHOME)/src/julia.expmap
+endif
+endif
+endif
 JLDFLAGS = -Wl,-Bdynamic
 ifeq (-Bsymbolic-functions, $(shell $(LD) --help | grep -o -e "-Bsymbolic-functions"))
 JLIBLDFLAGS = -Wl,-Bsymbolic-functions
@@ -792,6 +806,7 @@ ifeq ($(BUILD_CUSTOM_LIBCXX),1)
 LDFLAGS += -L$(build_libdir) -lc++abi
 CXXLDFLAGS += -L$(build_libdir) -lc++abi -stdlib=libc++ -lc++
 CPPFLAGS += -I$(build_includedir)/c++/v1
+CUSTOM_LD_LIBRARY_PATH = LD_LIBRARY_PATH="$(build_libdir)"
 ifeq ($(USEICC),1)
 CXXFLAGS += -cxxlib-nostd -static-intel
 CLDFLAGS += -static-intel

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -14,6 +14,7 @@
 /libosxunwind-*
 /lighttpd-*
 /libcxx-*
+/libcxxabi-*
 /libffi-*
 /libgit*
 /llvm-*

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -24,7 +24,7 @@ include $(JULIAHOME)/Make.inc
 
 ## Some shared configuration options ##
 
-CONFIGURE_COMMON = --prefix=$(abspath $(build_prefix)) --build=$(BUILD_MACHINE) --libdir=$(abspath $(build_libdir))
+CONFIGURE_COMMON = --prefix=$(abspath $(build_prefix)) --build=$(BUILD_MACHINE) --libdir=$(abspath $(build_libdir)) $(CUSTOM_LD_LIBRARY_PATH)
 ifneq ($(XC_HOST),)
 CONFIGURE_COMMON += --host=$(XC_HOST)
 endif
@@ -33,19 +33,22 @@ ifneq ($(USEMSVC), 1)
 CONFIGURE_COMMON += LDFLAGS=-Wl,--stack,8388608
 endif
 endif
-CONFIGURE_COMMON += F77="$(FC)" CC="$(CC)" CXX="$(CXX)"
+CONFIGURE_COMMON += F77="$(FC)" CC="$(CC) $(DEPS_CFLAGS)" CXX="$(CXX) $(DEPS_CXXFLAGS)"
+
+CMAKE_CC_ARG = $(CC_ARG) $(DEPS_CFLAGS)
+CMAKE_CXX_ARG = $(CXX_ARG) $(DEPS_CXXFLAGS)
 
 CMAKE_COMMON = -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DCMAKE_BUILD_TYPE=Release
 ifneq ($(VERBOSE), 0)
 CMAKE_COMMON += -DCMAKE_VERBOSE_MAKEFILE=ON
 endif
 CMAKE_COMMON += -DCMAKE_C_COMPILER="$(CC_BASE)"
-ifdef CC_ARG
-CMAKE_COMMON += -DCMAKE_C_COMPILER_ARG1="$(CC_ARG)"
+ifneq ($(strip $(CMAKE_CC_ARG)),)
+CMAKE_COMMON += -DCMAKE_C_COMPILER_ARG1="$(CMAKE_CC_ARG)"
 endif
 CMAKE_COMMON += -DCMAKE_CXX_COMPILER="$(CXX_BASE)"
-ifdef CXX_ARG
-CMAKE_COMMON += -DCMAKE_CXX_COMPILER_ARG1="$(CXX_ARG)"
+ifneq ($(strip $(CMAKE_CXX_ARG)),)
+CMAKE_COMMON += -DCMAKE_CXX_COMPILER_ARG1="$(CMAKE_CXX_ARG)"
 endif
 
 # If the top-level Makefile is called with environment variables,
@@ -133,7 +136,7 @@ endif
 ifeq ($(USE_SYSTEM_MPFR), 0)
 STAGE2_DEPS += mpfr
 ifeq ($(USE_SYSTEM_GMP), 0)
-MPFR_OPTS = --with-gmp-include=$(abspath $(build_includedir)) --with-gmp-lib=$(abspath $(build_shlibdir))
+MPFR_OPTS = --with-gmp-include=$(abspath $(build_includedir)) --with-gmp-lib=$(abspath $(build_shlibdir)) CFLAGS="-O0 -g"
 endif
 endif
 ifeq ($(BUILD_OS),WINNT)
@@ -232,7 +235,11 @@ LLVM_BUILDTYPE := $(LLVM_BUILDTYPE)+Asserts
 endif
 LLVM_FLAVOR := $(LLVM_BUILDTYPE)
 ifeq ($(LLVM_SANITIZE),1)
-LLVM_BUILDTYPE := $(LLVM_BUILDTYPE)+Sanitize
+ifeq ($(SANITIZE_MEMORY),1)
+LLVM_BUILDTYPE := $(LLVM_BUILDTYPE)+MSAN
+else
+LLVM_BUILDTYPE := $(LLVM_BUILDTYPE)+ASAN
+endif
 endif
 
 LLVM_LIB_FILE = libLLVMCodeGen.a
@@ -331,9 +338,17 @@ endif # ARCH == ppc64
 
 
 ifeq ($(LLVM_SANITIZE),1)
+ifeq ($(SANITIZE_MEMORY),1)
+LLVM_CC = CFLAGS="-fsanitize=memory -fsanitize-memory-track-origins"
+LLVM_LDFLAGS += -fsanitize=memory -fsanitize-memory-track-origins
+LLVM_CXXFLAGS += -fsanitize=memory -fsanitize-memory-track-origins
+LLVM_CMAKE += -DLLVM_USE_SANITIZER="MemoryWithOrigins"
+else
 LLVM_CC = CFLAGS="-fsanitize=address"
 LLVM_LDFLAGS += -fsanitize=address
 LLVM_CXXFLAGS += -fsanitize=address
+LLVM_CMAKE += -DLLVM_USE_SANITIZER="Address"
+endif
 LLVM_MFLAGS += TOOL_NO_EXPORTS= HAVE_LINK_VERSION_SCRIPT=0
 else
 LLVM_CC =
@@ -346,9 +361,9 @@ endif # LLVM_CXXFLAGS
 LLVM_MFLAGS += $(LLVM_CC)
 
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
-LLVM_LDFLAGS += -Wl,-R$(build_libdir)
+LLVM_LDFLAGS += -Wl,-R$(build_libdir) -lc++ -lc++abi
 ifeq ($(USEICC),1)
-LLVM_LDFLAGS += -no_cpprt -lc++ -lc++abi
+LLVM_LDFLAGS += -no_cpprt
 endif # USEICC
 endif # BUILD_CUSTOM_LIBCXX
 
@@ -425,12 +440,12 @@ libcxx-build:
 	mkdir -p libcxx-build
 libcxx-build/Makefile: llvm-$(LLVM_VER)/projects/libcxx | llvm-$(LLVM_VER)/projects/libcxxabi libcxx-build
 	cd libcxx-build && \
-		$(CMAKE) -G "Unix Makefiles" $(CMAKE_COMMON) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_LIBCXXABI_INCLUDE_PATHS="../llvm-$(LLVM_VER)/projects/libcxxabi/include" ../llvm-$(LLVM_VER)/projects/libcxx -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir) $(LIBCXX_EXTRA_FLAGS)" -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
+		$(CMAKE) -G "Unix Makefiles" $(CMAKE_COMMON) $(LLVM_CMAKE) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_CXX_ABI_INCLUDE_PATHS="../llvm-$(LLVM_VER)/projects/libcxxabi/include" ../llvm-$(LLVM_VER)/projects/libcxx -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir) $(LIBCXX_EXTRA_FLAGS)" -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
 libcxxabi-build:
 	mkdir -p libcxxabi-build
 libcxxabi-build/Makefile: llvm-$(LLVM_VER)/projects/libcxxabi | llvm-$(LLVM_VER)/projects/libcxx libcxxabi-build
 	cd libcxxabi-build && \
-        $(CMAKE) -G "Unix Makefiles" $(CMAKE_COMMON) -DLLVM_PATH="../llvm-$(LLVM_VER)" ../llvm-$(LLVM_VER)/projects/libcxxabi -DLIBCXXABI_CXX_ABI_LIBRARIES="$(LIBCXX_EXTRA_FLAGS)" -DCMAKE_CXX_FLAGS="$(CXXFLAGS) -std=c++11"
+        $(CMAKE) -G "Unix Makefiles" $(CMAKE_COMMON) $(LLVM_CMAKE) -DLLVM_ABI_BREAKING_CHECKS="WITH_ASSERTS" -DLLVM_PATH="../llvm-$(LLVM_VER)" ../llvm-$(LLVM_VER)/projects/libcxxabi -DLIBCXXABI_CXX_ABI_LIBRARIES="$(LIBCXX_EXTRA_FLAGS)" -DCMAKE_CXX_FLAGS="$(CXXFLAGS) -std=c++11"
 llvm-$(LLVM_VER)/projects/libcxxabi/lib/libc++abi.so.1.0: llvm-$(LLVM_VER)/projects/libcxxabi | llvm-$(LLVM_VER)/projects/libcxx
 libcxxabi-build/lib/libc++abi.so.1.0: | libcxxabi-build/Makefile
 	cd libcxxabi-build && $(MAKE)
@@ -1390,7 +1405,7 @@ ifeq (exists, $(shell [ -d $(JULIAHOME)/.git/modules/deps/utf8proc ] && echo exi
 $(UTF8PROC_SRC_TARGET): $(JULIAHOME)/.git/modules/deps/utf8proc/HEAD
 endif
 $(UTF8PROC_SRC_TARGET): utf8proc/Makefile
-	$(MAKE) -C utf8proc cc="$(CC) -O2 -std=c99 $(fPIC) -DUTF8PROC_EXPORTS" AR="$(AR)" libutf8proc.a
+	$(MAKE) -C utf8proc cc="$(CC) -O2 -std=c99 $(fPIC) -DUTF8PROC_EXPORTS $(DEPS_CFLAGS)" AR="$(AR)" libutf8proc.a
 	touch -c $@
 utf8proc/checked: $(UTF8PROC_SRC_TARGET)
 ifeq ($(OS),$(BUILD_OS))
@@ -1620,6 +1635,10 @@ install-osxunwind: $(OSXUNWIND_OBJ_TARGET)
 GMP_SRC_TARGET = gmp-$(GMP_VER)/.libs/libgmp.$(SHLIB_EXT)
 GMP_OBJ_TARGET = $(build_shlibdir)/libgmp.$(SHLIB_EXT)
 
+ifneq ($(SANITIZE),)
+GMP_CONFIGURE_OPTS += --disable-assembly
+endif
+
 gmp-$(GMP_VER).tar.bz2:
 	$(JLDOWNLOAD) $@ https://gmplib.org/download/gmp/$@
 gmp-$(GMP_VER)/configure: gmp-$(GMP_VER).tar.bz2
@@ -1631,7 +1650,7 @@ endif
 	touch -c $@
 gmp-$(GMP_VER)/config.status: gmp-$(GMP_VER)/configure
 	cd gmp-$(GMP_VER) && \
-	./configure $(CONFIGURE_COMMON) F77= --enable-shared --disable-static
+	./configure $(CONFIGURE_COMMON) F77= --enable-shared --disable-static $(GMP_CONFIGURE_OPTS)
 	touch -c $@
 $(GMP_SRC_TARGET): gmp-$(GMP_VER)/config.status
 	$(MAKE) -C gmp-$(GMP_VER) $(LIBTOOL_CCLD)
@@ -1668,6 +1687,11 @@ MPFR_SRC_TARGET = mpfr-$(MPFR_VER)/src/.libs/libmpfr.$(SHLIB_EXT)
 MPFR_OBJ_TARGET = $(build_shlibdir)/libmpfr.$(SHLIB_EXT)
 ifeq ($(OS),Darwin)
 MPFR_CHECK_MFLAGS = LDFLAGS="-Wl,-rpath,'$(build_libdir)'"
+endif
+
+ifneq ($(SANITIZE),)
+# Force generic C build
+MPFR_OPTS += --host=none-unknown-linux
 endif
 
 mpfr-$(MPFR_VER).tar.bz2:

--- a/src/options.h
+++ b/src/options.h
@@ -20,6 +20,13 @@
 // original object
 #define ARRAY_INLINE_NBYTES (2048*sizeof(void*))
 
+// codegen options ------------------------------------------------------------
+
+// (Experimental) codegen support for thread-local storage
+// #define CODEGEN_TLS
+
+// with KEEP_BODIES, we keep LLVM function bodies around for later debugging
+// #define KEEP_BODIES
 
 // GC options -----------------------------------------------------------------
 
@@ -31,7 +38,7 @@
 // with MEMDEBUG, every object is allocated explicitly with malloc, and
 // filled with 0xbb before being freed. this helps tools like valgrind
 // catch invalid accesses.
-//#define MEMDEBUG
+// #define MEMDEBUG
 
 // GC_VERIFY force a full verification gc along with every quick gc to ensure no
 // reachable memory is freed
@@ -77,5 +84,20 @@
 #ifndef COPY_STACKS
 #define COPY_STACKS
 #endif
+
+// sanitizer defaults ---------------------------------------------------------
+
+// Automatically enable MEMDEBUG and KEEP_BODIES for the sanitizers
+#if defined(__has_feature)
+#  if __has_feature(address_sanitizer) || __has_feature(memory_sanitizer)
+#  define MEMDEBUG
+#  define KEEP_BODIES
+#  endif
+// Memory sanitizer also needs thread-local storage
+#  if __has_feature(memory_sanitizer)
+#  define CODEGEN_TLS
+#  endif
+#endif
+
 
 #endif

--- a/src/sys.c
+++ b/src/sys.c
@@ -41,6 +41,12 @@
 #include <intrin.h>
 #endif
 
+#ifdef __has_feature
+#if __has_feature(memory_sanitizer)
+#include <sanitizer/msan_interface.h>
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -660,6 +666,15 @@ DLLEXPORT const char *jl_pathname_for_handle(uv_lib_t *uv_lib)
 
     struct link_map *map;
     dlinfo(handle, RTLD_DI_LINKMAP, &map);
+#ifdef __has_feature
+#if __has_feature(memory_sanitizer)
+    __msan_unpoison(&map,sizeof(struct link_map*));
+    if (map) {
+      __msan_unpoison(map, sizeof(struct link_map));
+      __msan_unpoison_string(map->l_name);
+    }
+#endif
+#endif
     if (map)
         return map->l_name;
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -1,6 +1,8 @@
 #############################################
 # Create some temporary files & directories #
 #############################################
+
+starttime = time()
 dir = mktempdir()
 file = joinpath(dir, "afile.txt")
 close(open(file,"w")) # like touch, but lets the operating system update the timestamp for greater precision on some platforms (windows)
@@ -37,8 +39,9 @@ chmod(file, filemode(file) | 0o222)
 # files and is thus zero in this case.
 @windows_only @test filesize(dir) == 0
 @unix_only @test filesize(dir) > 0
-let skew = 10  # allow 10s skew
-    now   = time()
+now = time()
+# Allow 10s skew in addition to the time it took us to actually execute this code
+let skew = 10 + (now - starttime)
     mfile = mtime(file)
     mdir  = mtime(dir)
     @test abs(now - mfile) <= skew && abs(now - mdir) <= skew && abs(mfile - mdir) <= skew


### PR DESCRIPTION
With a new, stable LLVM patch for thread local storage support, I decided to revisit memory sanitizer support for julia. With this branch and a few upstream commits which are currently pending review, I am able to run julia's test suite under msan, without having msan report any failures (though there was a stream error which may or may not be related):

```
   JULIA test/all
    From worker 14:      * linalg/lu            in  19.81 seconds
    From worker 18:      * keywordargs          in  39.09 seconds
    From worker 12:      * linalg/givens        in  90.51 seconds
    From worker 12:      * remote               in   7.42 seconds
    From worker 12:      * iobuffer             in  27.20 seconds
    From worker 12:      * staged               in  20.33 seconds
    From worker 6:       * linalg/lapack        in 178.97 seconds
    From worker 5:       * linalg4              in 183.56 seconds
    From worker 14:      * dict                 in 181.65 seconds
    From worker 6:       * tuple                in  35.45 seconds
    From worker 8:       * linalg/tridiag       in 231.06 seconds
    From worker 18:      * hashing              in 208.93 seconds
    From worker 11:      * linalg/pinv          in 256.57 seconds
    From worker 18:      * intfuncs             in  44.19 seconds
    From worker 11:      * simdloop             in  44.31 seconds
    From worker 15:      * linalg/arnoldi       in 324.30 seconds
    From worker 14:      * reduce               in 128.32 seconds
    From worker 16:      * linalg/symmetric     in 331.67 seconds
    From worker 17:      * core                 in 336.32 seconds
    From worker 17:      * copy                 in  36.32 seconds
    From worker 10:      * linalg/diagonal      in 413.32 seconds
    From worker 11:      * fft                  in 121.43 seconds
    From worker 18:      * blas                 in 134.04 seconds
    From worker 18:      * operators            in  11.05 seconds
    From worker 18:      * path                 in   2.18 seconds
    From worker 11:      * functional           in  39.98 seconds
    From worker 15:      * dsp                  in 147.04 seconds
    From worker 9:       * linalg/bidiag        in 506.74 seconds
    From worker 20:      * strings              in 511.06 seconds
    From worker 18:      * ccall                in  79.63 seconds
    From worker 18:      * backtrace            in   6.94 seconds
    From worker 6:       * reducedim            in 329.53 seconds
    From worker 20:      * spawn                      [stdio passthrough ok]
    From worker 18:      * priorityqueue        in  32.88 seconds
    From worker 11:      * bigint               in 116.71 seconds
    From worker 4:       * linalg3              in 611.40 seconds
    From worker 18:      * version              in  55.95 seconds
    From worker 10:      * fastmath             in 215.24 seconds
    From worker 8:       * random               in 400.20 seconds
    From worker 4:       * pollfd               in  30.37 seconds
    From worker 6:       * file                 in 101.88 seconds
    From worker 20:  in 145.61 seconds
    From worker 6:       * floatapprox          in  19.65 seconds
The following 'Returned code...' warnings indicate normal behavior:
Warning: Returned code may not match what actually runs.
Warning: Returned code may not match what actually runs.
Warning: Returned code may not match what actually runs.
Warning: Returned code may not match what actually runs.
    From worker 6:       * reflection           in  24.44 seconds
    From worker 6:       * regex                in  19.87 seconds
    From worker 4:       * socket               in  67.92 seconds
    From worker 17:      * math                 in 362.75 seconds
    From worker 11:      * resolve              in 163.58 seconds
    From worker 17:      * sysinfo              in  13.89 seconds
    From worker 6:       * float16              in  69.50 seconds
    From worker 11:      * rounding             in  43.59 seconds
    From worker 6:       * mod2pi               in  16.28 seconds
    From worker 9:       * statistics           in 309.23 seconds
    From worker 4:       * combinatorics        in 111.36 seconds
    From worker 11:      * euler                in  42.55 seconds
    From worker 20:      * readdlm              in 203.69 seconds
    From worker 8:       * complex              in 236.80 seconds
    From worker 6:       * show                 in  81.90 seconds
    From worker 20:      * replutil             in  26.62 seconds
    From worker 20:      * goto                 in   3.87 seconds
    From worker 20:      * llvmcall             in   4.51 seconds
    From worker 6:       * test                 in  21.35 seconds
    From worker 9:       * lineedit             in 116.17 seconds
    From worker 9:       * meta                 in  14.65 seconds
    From worker 13:      * linalg/cholesky      in 944.91 seconds
    From worker 13:      * libgit2              in   1.26 seconds
    From worker 13:      * docs                 in   4.92 seconds
    From worker 18:      * mpfr                 in 353.37 seconds
    From worker 4:       * replcompletions      in 148.67 seconds
    From worker 4:       * parser               in  12.80 seconds
    From worker 18:      * base64               in  15.39 seconds
    From worker 9:       * profile              in  46.44 seconds
    From worker 8:       * sets                 in 142.41 seconds
    From worker 11:      * repl                 in 181.91 seconds
    From worker 9:       * char                 in  33.61 seconds
    From worker 18:      * functors             in  59.25 seconds
    From worker 6:       * nullable             in 145.81 seconds
    From worker 18:      * i18n                 in   4.07 seconds
    From worker 8:       * misc                 in  45.78 seconds
    From worker 10:      * broadcast            in 427.78 seconds
    From worker 13:      * markdown             in 126.58 seconds
    From worker 4:       * serialize            in 132.69 seconds
    From worker 12:      * arrayops             in 987.30 seconds
    From worker 18:      * unicode              in 126.44 seconds
    From worker 11:      * enums                in 197.65 seconds
    From worker 20:      * grisu                in 327.78 seconds
    From worker 21:      * dates                in 1228.74 seconds
    From worker 3:       * linalg2              in 1249.12 seconds
ArgumentError("stream is closed or unusable")
    From worker 6:       * examples             in 228.83 seconds
WARNING: Forcibly interrupting busy workers
WARNING: rmprocs: process 1 not removed
    From worker 2:       * linalg1              in 1347.09 seconds
    From worker 17:      * ranges               in 645.29 seconds
    From worker 16:      * bitarray             in 1109.57 seconds
    From worker 19:      * numbers              in 1452.90 seconds
    From worker 9:       * cmdlineargs          in 659.74 seconds
    From worker 15:      * sorting              in 1231.75 seconds
    From worker 14:      * sparse               in 1521.88 seconds
    From worker 5:       * subarray             in 4307.21 seconds
    From worker 7:       * linalg/triangular    in 5029.93 seconds
``
```
