### PR TITLE
RFC: Fix some "definite" memory leaks

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -38,7 +38,7 @@ dlopen_e(s::AbstractString, flags::Integer = RTLD_LAZY | RTLD_DEEPBIND) =
 
 dlopen_e(s::Symbol, flags::Integer = RTLD_LAZY | RTLD_DEEPBIND) = dlopen_e(string(s), flags)
 
-dlclose(p::Ptr) = if p!=C_NULL; ccall(:uv_dlclose,Void,(Ptr{Void},),p); end
+dlclose(p::Ptr) = if p!=C_NULL; ccall(:uv_dlclose,Void,(Ptr{Void},),p); Libc.free(p); end
 
 function find_library{T<:ByteString, S<:ByteString}(libnames::Array{T,1}, extrapaths::Array{S,1}=ASCIIString[])
     for lib in libnames

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -609,7 +609,9 @@ function getipaddr()
         end
         sockaddr = ccall(:jl_uv_interface_address_sockaddr,Ptr{Void},(Ptr{UInt8},),current_addr)
         if ccall(:jl_sockaddr_in_is_ip4,Int32,(Ptr{Void},),sockaddr) == 1
-            return IPv4(ntoh(ccall(:jl_sockaddr_host4,UInt32,(Ptr{Void},),sockaddr)))
+            rv = IPv4(ntoh(ccall(:jl_sockaddr_host4,UInt32,(Ptr{Void},),sockaddr)))
+            ccall(:uv_free_interface_addresses,Void,(Ptr{UInt8},Int32),addr,count)
+            return rv
         # Uncomment to enbable IPv6
         #elseif ccall(:jl_sockaddr_in_is_ip6,Int32,(Ptr{Void},),sockaddr) == 1
         #   host = Array(UInt128,1)

--- a/doc/devdocs/valgrind.rst
+++ b/doc/devdocs/valgrind.rst
@@ -33,6 +33,8 @@ It is possible to run the entire Julia test suite under Valgrind, but it does ta
 
     valgrind --smc-check=all-non-file --trace-children=yes --suppressions=$PWD/../contrib/valgrind-julia.supp ../julia runtests.jl all
 
+If you would like to see a report of "definite" memory leaks, pass the flags ``--leak-check=full --show-leak-kinds=definite`` to ``valgrind`` as well.
+
 Caveats
 -------
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5612,12 +5612,12 @@ extern "C" void jl_init_codegen(void)
     SmallVector<std::string, 4> MAttrs(mattr, mattr+2);
 #endif
 #ifdef LLVM36
-    EngineBuilder *eb = new EngineBuilder(std::unique_ptr<Module>(engine_module));
+    EngineBuilder eb(std::move(std::unique_ptr<Module>(engine_module)));
 #else
-    EngineBuilder *eb = new EngineBuilder(engine_module);
+    EngineBuilder eb(engine_module);
 #endif
     std::string ErrorStr;
-    eb  ->setEngineKind(EngineKind::JIT)
+    eb  .setEngineKind(EngineKind::JIT)
 #if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_) && !defined(USE_MCJIT)
         .setJITMemoryManager(createJITMemoryManagerWin())
 #endif
@@ -5632,7 +5632,7 @@ extern "C" void jl_init_codegen(void)
 #if (defined(_OS_WINDOWS_) || defined(FORCE_ELF)) && defined(USE_MCJIT)
     TheTriple.setObjectFormat(Triple::ELF);
 #endif
-    jl_TargetMachine = eb->selectTarget(
+    jl_TargetMachine = eb.selectTarget(
             TheTriple,
             "",
 #if LLVM35
@@ -5667,7 +5667,7 @@ extern "C" void jl_init_codegen(void)
 #else
     engine_module->setDataLayout(jl_TargetMachine->getDataLayout()->getStringRepresentation());
 #endif
-    jl_ExecutionEngine = eb->create(jl_TargetMachine);
+    jl_ExecutionEngine = eb.create(jl_TargetMachine);
     //jl_printf(JL_STDERR,"%s\n",jl_ExecutionEngine->getDataLayout()->getStringRepresentation().c_str());
     if (!jl_ExecutionEngine) {
         jl_printf(JL_STDERR, "Critical error initializing llvm: ", ErrorStr.c_str());

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5632,7 +5632,7 @@ extern "C" void jl_init_codegen(void)
 #if (defined(_OS_WINDOWS_) || defined(FORCE_ELF)) && defined(USE_MCJIT)
     TheTriple.setObjectFormat(Triple::ELF);
 #endif
-    jl_TargetMachine = eb.selectTarget(
+    TargetMachine *targetMachine = eb.selectTarget(
             TheTriple,
             "",
 #if LLVM35
@@ -5641,11 +5641,11 @@ extern "C" void jl_init_codegen(void)
             strcmp(jl_options.cpu_target,"native") ? jl_options.cpu_target : "",
 #endif
             MAttrs);
-    jl_TargetMachine = jl_TargetMachine->getTarget().createTargetMachine(
+    jl_TargetMachine = targetMachine->getTarget().createTargetMachine(
             TheTriple.getTriple(),
-            jl_TargetMachine->getTargetCPU(),
-            jl_TargetMachine->getTargetFeatureString(),
-            jl_TargetMachine->Options,
+            targetMachine->getTargetCPU(),
+            targetMachine->getTargetFeatureString(),
+            targetMachine->Options,
 #ifdef CODEGEN_TLS
             Reloc::PIC_,
             CodeModel::Small,
@@ -5659,6 +5659,7 @@ extern "C" void jl_init_codegen(void)
             CodeGenOpt::Aggressive // -O3
 #endif
             );
+    delete targetMachine;
     assert(jl_TargetMachine);
 #if defined(LLVM36) && !defined(LLVM37)
     engine_module->setDataLayout(jl_TargetMachine->getSubtargetImpl()->getDataLayout());

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -63,10 +63,14 @@ DLLEXPORT int jl_uv_dlopen(const char *filename, jl_uv_libhandle lib_, unsigned 
 #endif
                          );
     if (lib->handle) {
+        if (lib->errmsg)
+            free(lib->errmsg);
         lib->errmsg = NULL;
         return 0;
     }
     else {
+        if (lib->errmsg)
+            free(lib->errmsg);
         lib->errmsg = strdup(dlerror());
         return -1;
     }


### PR DESCRIPTION
The goal here is to identify and remove many of the "definite" memory leaks in julia.  (See the [valgrind documentation](http://valgrind.org/docs/manual/mc-manual.html#mc-manual.leaks) for definitions of different types of leaks.)  This pull request reduces the number of "definite leaks" when running `julia -e ""` from 7 to 3.  (The remaining ones all involve aspects of `dlopen`.)  In fact, with the additionally provided fix of a memory leak in `getipaddr`, I can even run a nontrivial program (e.g. the `tuple` tests) and see only these three memory leaks.  Some other tests (for instance, the `core` tests) still have plenty of memory leaks though.

I made a point to test the changes on LLVM 3.6 as well as 3.3.
