### PR TITLE
Support indexing A[I1, i, I2] for CartesianIndexes I1, I2

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -55,49 +55,62 @@ length{I<:CartesianIndex}(::Type{I})=length(super(I))
 getindex(index::CartesianIndex, i::Integer) = getfield(index, i)::Int
 
 stagedfunction getindex{N}(A::Array, index::CartesianIndex{N})
-    N==0 ? :(Base.arrayref(A, 1)) : :(@ncall $N Base.arrayref A d->index[d])
+    :(Base.arrayref(A, $(cartindex_exprs((index,), (:index,))...)))
 end
 stagedfunction getindex{N}(A::Array, i::Integer, index::CartesianIndex{N})
-    N==0 ? :(Base.arrayref(A, i)) : :(@ncall $(N+1) Base.arrayref A d->(d == 1 ? i : index[d-1]))
+    :(Base.arrayref(A, $(cartindex_exprs((i, index), (:i, :index))...)))
 end
 stagedfunction getindex{M,N}(A::Array, index1::CartesianIndex{M}, i::Integer, index2::CartesianIndex{N})
-    exprs = vcat([:(index1[$d]) for d = 1:M], :i, [:(index2[$d]) for d = 1:N])
-    :(Base.arrayref(A, $(exprs...)))
+    :(Base.arrayref(A, $(cartindex_exprs((index1, i, index2), (:index1, :i, :index2))...)))
 end
 stagedfunction setindex!{T,N}(A::Array{T}, v, index::CartesianIndex{N})
-    N==0 ? :(Base.arrayset(A, convert($T,v), 1)) : :(@ncall $N Base.arrayset A convert($T,v) d->index[d])
+    :(Base.arrayset(A, convert($T,v), $(cartindex_exprs((index,), (:index,))...)))
 end
 stagedfunction setindex!{T,N}(A::Array{T}, v, i::Integer, index::CartesianIndex{N})
-    N==0 ? :(Base.arrayset(A, convert($T,v), i)) : :(@ncall $(N+1) Base.arrayset A convert($T,v) d->(d == 1 ? i : index[d-1]))
+    :(Base.arrayset(A, convert($T,v), $(cartindex_exprs((i, index), (:i, :index))...)))
 end
 stagedfunction setindex!{T,M,N}(A::Array{T}, v, index1::CartesianIndex{M}, i::Integer, index2::CartesianIndex{N})
-    exprs = vcat([:(index1[$d]) for d = 1:M], :i, [:(index2[$d]) for d = 1:N])
-    :(Base.arrayset(A, convert($T,v), $(exprs...)))
+    :(Base.arrayset(A, convert($T,v), $(cartindex_exprs((index1, i, index2), (:index1, :i, :index2))...)))
 end
 
 stagedfunction getindex{N}(A::AbstractArray, index::CartesianIndex{N})
-    :(@nref $N A d->index[d])
+    :(getindex(A, $(cartindex_exprs((index,), (:index,))...)))
 end
 stagedfunction getindex{N}(A::AbstractArray, i::Integer, index::CartesianIndex{N})
-    :(@nref $(N+1) A d->(d == 1 ? i : index[d-1]))
+    :(getindex(A, $(cartindex_exprs((i, index), (:i, :index))...)))
 end
-stagedfunction setindex!{N}(A::AbstractArray, v, index::CartesianIndex{N})
-    :((@nref $N A d->index[d]) = v)
+stagedfunction setindex!{T,N}(A::AbstractArray{T}, v, index::CartesianIndex{N})
+    :(setindex!(A, v, $(cartindex_exprs((index,), (:index,))...)))
 end
-stagedfunction setindex!{N}(A::AbstractArray, v, i::Integer, index::CartesianIndex{N})
-    :((@nref $(N+1) A d->(d == 1 ? i : index[d-1])) = v)
+stagedfunction setindex!{T,N}(A::AbstractArray{T}, v, i::Integer, index::CartesianIndex{N})
+    :(setindex!(A, v, $(cartindex_exprs((i, index), (:i, :index))...)))
 end
 for AT in (AbstractVector, AbstractMatrix, AbstractArray)  # nix ambiguity warning
     @eval begin
-        stagedfunction getindex{M,N}(A::$AT, index1::CartesianIndex{M}, i::Integer, index2::CartesianIndex{N})
-            exprs = vcat([:(index1[$d]) for d = 1:M], :i, [:(index2[$d]) for d = 1:N])
-            :(getindex(A, $(exprs...)))
+        stagedfunction getindex{M,N}(A::AbstractArray, index1::CartesianIndex{M}, i::Integer, index2::CartesianIndex{N})
+            :(getindex(A, $(cartindex_exprs((index1, i, index2), (:index1, :i, :index2))...)))
         end
-        stagedfunction setindex!{M,N}(A::$AT, v, index1::CartesianIndex{M}, i::Integer, index2::CartesianIndex{N})
-            exprs = vcat([:(index1[$d]) for d = 1:M], :i, [:(index2[$d]) for d = 1:N])
-            :(setindex!(A, v, $(exprs...)))
+        stagedfunction setindex!{T,M,N}(A::AbstractArray{T}, v, index1::CartesianIndex{M}, i::Integer, index2::CartesianIndex{N})
+            :(setindex!(A, v, $(cartindex_exprs((index1, i, index2), (:index1, :i, :index2))...)))
         end
     end
+end
+
+function cartindex_exprs(indexes, syms)
+    exprs = Any[]
+    for (i,ind) in enumerate(indexes)
+        if ind <: Number
+            push!(exprs, :($(syms[i])))
+        else
+            for j = 1:length(ind)
+                push!(exprs, :($(syms[i])[$j]))
+            end
+        end
+    end
+    if isempty(exprs)
+        push!(exprs, 1)  # Handle the zero-dimensional case
+    end
+    exprs
 end
 
 # arithmetic, min/max

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -981,6 +981,25 @@ a = ones(5,0)
 b = sub(a, :, :)
 @test mdsum(b) == 0
 
+a = reshape(1:60, 3, 4, 5)
+@test a[CartesianIndex{3}(2,3,4)] == 44
+a[CartesianIndex{3}(2,3,3)] = -1
+@test a[CartesianIndex{3}(2,3,3)] == -1
+@test a[2,CartesianIndex{2}(3,4)] == 44
+a[1,CartesianIndex{2}(3,4)] = -2
+@test a[1,CartesianIndex{2}(3,4)] == -2
+@test a[CartesianIndex{1}(2),3,CartesianIndex{1}(4)] == 44
+a[CartesianIndex{1}(2),3,CartesianIndex{1}(3)] = -3
+@test a[CartesianIndex{1}(2),3,CartesianIndex{1}(3)] == -3
+
+a = sub(zeros(3, 4, 5), :, :, :)
+a[CartesianIndex{3}(2,3,3)] = -1
+@test a[CartesianIndex{3}(2,3,3)] == -1
+a[1,CartesianIndex{2}(3,4)] = -2
+@test a[1,CartesianIndex{2}(3,4)] == -2
+a[CartesianIndex{1}(2),3,CartesianIndex{1}(3)] = -3
+@test a[CartesianIndex{1}(2),3,CartesianIndex{1}(3)] == -3
+
 I1 = CartesianIndex((2,3,0))
 I2 = CartesianIndex((-1,5,2))
 @test I1 + I2 == CartesianIndex((1,8,2))


### PR DESCRIPTION
This is useful for writing algorithms that perform a calculation along a particular dimension. Not only are the resulting algorithms much prettier, but it's easy to make them cache-friendly even when the calculation is not along dimension 1. This is in contrast with `mapslices`, for example, which slices out 1-dimensional vectors before performing the algorithm, and hence is not cache-friendly.

It's worth acknowledging that this is another step along the slow march towards support for general `getindex(A, indexes::Union(Integer, CartesianIndex)...)`. But currently we can't add that without causing massive ambiguity warnings in packages, so until #10525 gets merged I think we'd better stick with special cases.

Demo script:

``` julia
## Cache-unfriendly version (like mapslices, but optimized for 1d)
function myfilt_slow!(b::Number, A, dim)
    indexes = Any[Colon() for i = 1:ndims(A)]
    sz = ntuple(ndims(A), d->d==dim ? 1 : size(A,d))::NTuple{ndims(A),Int}
    for I in CartesianRange(sz)
        for d = 1:ndims(A)
            if d != dim
                indexes[d] = I[d]
            end
        end
        v = slice(A, indexes...)
        myfilt1d!(b, v)
    end
    A
end

function myfilt1d!(b, v)
    for i = 2:length(v)
        v[i] -= b*v[i-1]
    end
    v
end

## Cache-friendly version
function myfilt!(b::Number, A, dim)
    R1 = CartesianRange(size(A)[1:dim-1])
    R2 = CartesianRange(size(A)[dim+1:end])
    _myfilt!(b, A, R1, R2, size(A,dim))  # for type-stability
end

function _myfilt!(b, A, R1, R2, n)
    for I2 in R2
        for i = 2:n
            for I1 in R1
                A[I1, i, I2] -= b*A[I1, i-1, I2]  # in addition to being faster, isn't this just plain nicer?
            end
        end
    end
    A
end

A = rand(100, 100, 100)
B1 = mapslices(x->myfilt1d!(0.4, x), copy(A), (2,))
B2 = myfilt_slow!(0.4, copy(A), 2)
B3 = myfilt!(0.4, copy(A), 2)
using Base.Test
@test_approx_eq B1 B2
@test_approx_eq B1 B3

Ac = copy(A)
@time 1
@time mapslices(x->myfilt1d!(0.4, x), Ac, (2,))
Ac = copy(A)
@time myfilt_slow!(0.4, Ac, 2)
Ac = copy(A)
@time myfilt!(0.4, Ac, 2)
nothing
```

Results:

```
elapsed time: 0.002351136 seconds (35 kB allocated)   # @time 1   (i.e., warmup)
elapsed time: 0.045129864 seconds (20 MB allocated, 7.28% gc time in 1 pauses with 0 full sweep)  # mapslices
elapsed time: 0.020325132 seconds (3 MB allocated)   # myfilt_slow!
elapsed time: 0.003462904 seconds (664 bytes allocated)    # myfilt!
```

In addition to the usual "array & indexing ninjas" (@Jutho, @mbauman, @carlobaldassi, @JeffBezanson), CCing @tlycken (this will be useful for `interp_invert!` style operations).
