### PR TITLE
skip julia startup when -v option is requested

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -252,12 +252,6 @@ let reqarg = Set(UTF8String["--home",          "-H",
         global have_color     = (opts.color == 1)
         global is_interactive = Bool(opts.isinteractive)
         while true
-            # show julia VERSION and quit
-            if Bool(opts.version)
-                println(STDOUT, "julia version ", VERSION)
-                exit(0)
-            end
-
             # load ~/.juliarc file
             startup && load_juliarc()
 

--- a/base/options.jl
+++ b/base/options.jl
@@ -1,6 +1,5 @@
 # NOTE: This type needs to be kept in sync with jl_options in src/julia.h
 immutable JLOptions
-    version::Int8
     quiet::Int8
     julia_home::Ptr{Cchar}
     julia_bin::Ptr{Cchar}

--- a/src/init.c
+++ b/src/init.c
@@ -84,8 +84,7 @@ DLLEXPORT void gdblookup(ptrint_t ip);
 
 static const char system_image_path[256] = JL_SYSTEM_IMAGE_PATH;
 
-jl_options_t jl_options = { 0,    // version
-                            0,    // quiet
+jl_options_t jl_options = { 0,    // quiet
                             NULL, // julia_home
                             NULL, // julia_bin
                             NULL, // build_path

--- a/src/julia.h
+++ b/src/julia.h
@@ -1488,7 +1488,6 @@ void show_execution_point(char *filename, int lno);
 // julia options -----------------------------------------------------------
 // NOTE: This struct needs to be kept in sync with JLOptions type in base/options.jl
 typedef struct {
-    int8_t version;
     int8_t quiet;
     const char *julia_home;
     const char *julia_bin;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -1,7 +1,7 @@
 let exename = joinpath(JULIA_HOME, Base.julia_exename())
     # --version
     let v = split(readall(`$exename -v`), "julia version ")[end]
-        @test VERSION == VersionNumber(v)
+        @test Base.VERSION_STRING == chomp(v)
     end
     @test readall(`$exename -v`) == readall(`$exename --version`)
 

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -162,8 +162,8 @@ void parse_opts(int *argcp, char ***argvp)
             lastind = optind;
             break;
         case 'v': // version
-            jl_options.version = 1;
-            break;
+            jl_printf(JL_STDOUT, "julia version %s\n", JULIA_VERSION_STRING);
+            jl_exit(0);
         case 'h': // help
             jl_printf(JL_STDOUT, "%s%s", usage, opts);
             jl_exit(0);


### PR DESCRIPTION
We're working with the developers of solverstudio (http://solverstudio.org/) who are trying to embed Julia and JuMP within Excel. Their workflow is based on calling the `julia` executable instead of using the C API, and apparently just requesting the version number with `julia -v` can take up to 4 seconds on a windows machine. This PR returns the version string from C when requested instead of spinning up Julia.

The only UI change here is that the version string no longer includes the build number, but I don't think that's essential for most use cases (and can be requested more explicitly with `julia -E VERSION` if needed).
