### PR TITLE
floatfuncs: fix OverflowError in hex2num

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -30,9 +30,9 @@ num2hex(x::Float64) = hex(box(UInt64,unbox(Float64,x)),16)
 
 function hex2num(s::AbstractString)
     if length(s) <= 8
-        return box(Float32,unbox(Int32,parse(Int32,s,16)))
+        return box(Float32,unbox(UInt32,parse(UInt32,s,16)))
     end
-    return box(Float64,unbox(Int64,parse(Int64,s,16)))
+    return box(Float64,unbox(UInt64,parse(UInt64,s,16)))
 end
 
 @vectorize_1arg Number abs

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -375,7 +375,18 @@ end
 @test base(12,typemax(Int128)) == "2a695925806818735399a37a20a31b3534a7"
 
 @test hex2num("3ff0000000000000") == 1.
+@test hex2num("bff0000000000000") == -1.
 @test hex2num("4000000000000000") == 2.
+@test hex2num("7ff0000000000000") == Inf
+@test hex2num("fff0000000000000") == -Inf
+@test isnan(hex2num("7ff8000000000000"))
+@test isnan(hex2num("fff8000000000000"))
+@test hex2num("3f800000") == 1.0f0
+@test hex2num("bf800000") == -1.0f0
+@test hex2num("7f800000") == Inf32
+@test hex2num("ff800000") == -Inf32
+@test isnan(hex2num("7fc00000"))
+@test isnan(hex2num("ffc00000"))
 
 # floating-point printing
 @test repr(1.0) == "1.0"


### PR DESCRIPTION
hex2num tried to parse the given string into a 32/64-bit signed
integer, which caused overflow on negative IEEE float values.

Fixes #10797.
