### PR TITLE
Fix #10816, improve interpolation syntax error.

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1624,7 +1624,7 @@
                     (take-token s)
                     ex)
                    (else (error "invalid interpolation syntax")))))
-          (else (error (string "invalid interpolation syntax: \"" c "\""))))))
+          (else (error (string "invalid interpolation syntax: \"$" c "\""))))))
 
 (define (tostr custom io)
   (if custom


### PR DESCRIPTION
it was less clear when the dollar sign ($) was the last character in the
string.
