### PR TITLE
Fix #10829, freeing of uninitialized pointer

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -63,14 +63,10 @@ DLLEXPORT int jl_uv_dlopen(const char *filename, jl_uv_libhandle lib_, unsigned 
 #endif
                          );
     if (lib->handle) {
-        if (lib->errmsg)
-            free(lib->errmsg);
         lib->errmsg = NULL;
         return 0;
     }
     else {
-        if (lib->errmsg)
-            free(lib->errmsg);
         lib->errmsg = strdup(dlerror());
         return -1;
     }
@@ -124,6 +120,10 @@ static uv_lib_t *jl_load_dynamic_library_(const char *modname, unsigned flags, i
                         snprintf(path, PATHBUF, "%s%s%s", dl_path, modname, ext);
                     else
                         snprintf(path, PATHBUF, "%s" PATHSEPSTRING "%s%s", dl_path, modname, ext);
+                    if (handle->errmsg) {
+                        free(handle->errmsg);
+                        handle->errmsg = NULL;
+                    }
                     error = jl_uv_dlopen(path, handle, flags);
                     if (!error) goto done;
                 }
@@ -136,6 +136,10 @@ static uv_lib_t *jl_load_dynamic_library_(const char *modname, unsigned flags, i
         handle->handle = NULL;
         /* try loading from standard library path */
         snprintf(path, PATHBUF, "%s%s", modname, ext);
+        if (handle->errmsg) {
+            free(handle->errmsg);
+            handle->errmsg = NULL;
+        }
         error = jl_uv_dlopen(path, handle, flags);
         if (!error) goto done;
     }
@@ -143,6 +147,10 @@ static uv_lib_t *jl_load_dynamic_library_(const char *modname, unsigned flags, i
 #if defined(__linux__) || defined(__FreeBSD__)
     {
         const char *soname = jl_lookup_soname(modname, strlen(modname));
+        if (handle->errmsg) {
+            free(handle->errmsg);
+            handle->errmsg = NULL;
+        }
         error = (soname==NULL) || jl_uv_dlopen(soname, handle, flags);
         if (!error) goto done;
     }


### PR DESCRIPTION
The change in 11a0f43 made the assumption that `handle->errmsg` would be initialized to NUL.  This is true within julia itself, but BinDeps violates this assumption.  The current commit changes things to fix the memory leak at its actual source, in `jl_load_dynamic_library_`.
