### PR TITLE
nnz methods for sparse factorizations

### DIFF
--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -6,7 +6,7 @@ import Base.LinAlg: (\), A_mul_Bc, A_mul_Bt, Ac_ldiv_B, Ac_mul_B, At_ldiv_B, At_
                  cholfact, cholfact!, det, diag, ishermitian, isposdef,
                  issym, ldltfact, logdet
 
-import Base.SparseMatrix: sparse
+import Base.SparseMatrix: sparse, nnz
 
 export
     Dense,
@@ -884,13 +884,15 @@ eltype{T<:VTypes}(A::Dense{T}) = T
 eltype{T<:VTypes}(A::Factor{T}) = T
 eltype{T<:VTypes}(A::Sparse{T}) = T
 
+nnz(F::Factor) = nnz(Sparse(F))
+
 function show(io::IO, F::Factor)
     s = unsafe_load(F.p)
     println(io, typeof(F))
     @printf(io, "type: %12s\n", Bool(s.is_ll) ? "LLt" : "LDLt")
     @printf(io, "method: %10s\n", Bool(s.is_super) ? "supernodal" : "simplicial")
     @printf(io, "maxnnz: %10d\n", Int(s.nzmax))
-    @printf(io, "nnz: %13d\n", nnz(Sparse(F)))
+    @printf(io, "nnz: %13d\n", nnz(F))
 end
 
 isvalid(A::Dense) = check_dense(A)

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -6,7 +6,7 @@ import Base: (\), Ac_ldiv_B, At_ldiv_B, findnz, getindex, show, size
 import Base.LinAlg: A_ldiv_B!, Ac_ldiv_B!, At_ldiv_B!, Factorization, det, lufact
 
 importall Base.SparseMatrix
-import Base.SparseMatrix: increment, increment!, decrement, decrement!
+import Base.SparseMatrix: increment, increment!, decrement, decrement!, nnz
 
 include("umfpack_h.jl")
 type MatrixIllConditionedException <: Exception
@@ -321,6 +321,11 @@ for itype in UmfpackIndexTypes
              increment!(P), increment!(Q), Rs)
         end
     end
+end
+
+function nnz(lu::UmfpackLU)
+    lnz, unz, = umf_lunz(lu)
+    return Int(lnz + unz)
 end
 
 ### Solve with Factorization

--- a/test/sparsedir/cholmod.jl
+++ b/test/sparsedir/cholmod.jl
@@ -104,6 +104,7 @@ chma = cholfact(A)                      # LL' form
 @test unsafe_load(chma.p).is_ll == 1    # check that it is in fact an LLt
 x = chma\B
 @test_approx_eq x ones(size(x))
+@test nnz(chma) == 489
 
 #lp_afiro example
 afiro = CHOLMOD.Sparse(27, 51,

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -14,6 +14,7 @@ for Tv in (Float64, Complex128)
     for Ti in Base.SparseMatrix.UMFPACK.UMFITypes.types
         A = convert(SparseMatrixCSC{Tv,Ti}, A0)
         lua = lufact(A)
+        @test nnz(lua) == 18
         L,U,p,q,Rs = lua[:(:)]
         @test_approx_eq scale(Rs,A)[p,q] L*U
 


### PR DESCRIPTION
This patch provides `nnz` methods for the sparse `cholfact` and `lufact` objects, which is useful to know how good a job the sparse factorization is doing.
