### PR TITLE
Don't bail out on test errors by default

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,8 +10,15 @@ cd(dirname(@__FILE__)) do
 
     @everywhere include("testdefs.jl")
 
-    reduce(propagate_errors, nothing, pmap(runtests, tests; err_retry=false, err_stop=true))
+    err_stop = haskey(ENV, "JL_TESTFAILURE_STOP")
+    results = reduce(propagate_errors, nothing, pmap(runtests, tests; err_retry=false, err_stop=err_stop))
 
     @unix_only n > 1 && rmprocs(workers(), waitfor=5.0)
+
+    # exit(1) if any test raised an error so that travis knows the build failed.
+    if any(x -> x==true, results)
+        exit(1)
+    end
+
     println("    \033[32;1mSUCCESS\033[0m")
 end

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -8,13 +8,18 @@ function runtests(name)
 end
 
 function propagate_errors(a,b)
-    if isa(a,Exception)
+    err_stop = haskey(ENV, "JL_TESTFAILURE_STOP")
+    err = false
+    if isa(a, Exception) || isa(b, Exception)
+        err = true
+    end
+    if isa(a,Exception) && err_stop
         rethrow(a)
     end
-    if isa(b,Exception)
+    if isa(b,Exception) && err_stop
         rethrow(b)
     end
-    nothing
+    err
 end
 
 # looking in . messes things up badly


### PR DESCRIPTION
I don't always run tests
But when I do, I ignore the failures.

Seriously though: when I run all tests locally, it is because I want to know the status of all of them for individual investigation later (e.g. #10394). Tests are slow in general, really slow on Windows, and painfully slow with MCJIT on Windows. Stopping the run due to a (possibly random) failure in the middle of the list is unhelpful because it only tells me about one test failure at a time. (I usually go away when running tests because my 2-core 3320 gets really sluggish). 

This PR makes the test suite continue through errors by default, and adds a check for the environment variable `JL_TESTFAILURE_STOP` for use on the CI systems.
