### PR TITLE
doc: ``finally`` blocks are scope blocks too?

### DIFF
--- a/doc/manual/variables-and-scoping.rst
+++ b/doc/manual/variables-and-scoping.rst
@@ -26,6 +26,7 @@ The constructs introducing such blocks are:
 -  ``for`` loops
 -  ``try`` blocks
 -  ``catch`` blocks
+-  ``finally`` blocks 
 -  ``let`` blocks
 -  ``type`` blocks.
 


### PR DESCRIPTION
If `try` and `catch` blocks are on the list, then shouldn't `finally` blocks be too?
