### PR TITLE
Fix #10838

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -223,7 +223,7 @@ prod(A::AbstractArray{Bool}) =
 
 ## maximum & minimum
 
-function mapreduce_impl(f, op::MaxFun, A::AbstractArray{Bool}, first::Int, last::Int)
+function mapreduce_impl(f, op::MaxFun, A::AbstractArray, first::Int, last::Int)
     # locate the first non NaN number
     v = f(A[first])
     i = first + 1
@@ -241,7 +241,7 @@ function mapreduce_impl(f, op::MaxFun, A::AbstractArray{Bool}, first::Int, last:
     v
 end
 
-function mapreduce_impl(f, op::MinFun, A::AbstractArray{Bool}, first::Int, last::Int)
+function mapreduce_impl(f, op::MinFun, A::AbstractArray, first::Int, last::Int)
     # locate the first non NaN number
     v = f(A[first])
     i = first + 1
@@ -310,7 +310,7 @@ function mapfoldl(f, ::OrFun, itr)
     return false
 end
 
-function mapreduce_impl(f, op::AndFun, A::AbstractArray, ifirst::Int, ilast::Int)
+function mapreduce_impl(f, op::AndFun, A::AbstractArray{Bool}, ifirst::Int, ilast::Int)
     while ifirst <= ilast
         @inbounds x = A[ifirst]
         !f(x) && return false
@@ -319,7 +319,7 @@ function mapreduce_impl(f, op::AndFun, A::AbstractArray, ifirst::Int, ilast::Int
     return true
 end
 
-function mapreduce_impl(f, op::OrFun, A::AbstractArray, ifirst::Int, ilast::Int)
+function mapreduce_impl(f, op::OrFun, A::AbstractArray{Bool}, ifirst::Int, ilast::Int)
     while ifirst <= ilast
         @inbounds x = A[ifirst]
         f(x) && return true

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -223,7 +223,7 @@ prod(A::AbstractArray{Bool}) =
 
 ## maximum & minimum
 
-function mapreduce_impl(f, op::MaxFun, A::AbstractArray, first::Int, last::Int)
+function mapreduce_impl(f, op::MaxFun, A::AbstractArray{Bool}, first::Int, last::Int)
     # locate the first non NaN number
     v = f(A[first])
     i = first + 1
@@ -241,7 +241,7 @@ function mapreduce_impl(f, op::MaxFun, A::AbstractArray, first::Int, last::Int)
     v
 end
 
-function mapreduce_impl(f, op::MinFun, A::AbstractArray, first::Int, last::Int)
+function mapreduce_impl(f, op::MinFun, A::AbstractArray{Bool}, first::Int, last::Int)
     # locate the first non NaN number
     v = f(A[first])
     i = first + 1

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -195,10 +195,10 @@ prod2(itr) = invoke(prod, (Any,), itr)
 @test all(x->x>0, [4]) == true
 @test all(x->x>0, [-3, 4, 5]) == false
 
-@test reduce(|, fill(trues(5), 3))  == trues(5)
-@test reduce(|, fill(falses(5), 3)) == falses(5)
-@test reduce(&, fill(trues(5), 3))  == trues(5)
-@test reduce(&, fill(falses(5), 3)) == falses(5)
+@test reduce(|, fill(trues(5), 24))  == trues(5)
+@test reduce(|, fill(falses(5), 24)) == falses(5)
+@test reduce(&, fill(trues(5), 24))  == trues(5)
+@test reduce(&, fill(falses(5), 24)) == falses(5)
 
 # in
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -195,6 +195,11 @@ prod2(itr) = invoke(prod, (Any,), itr)
 @test all(x->x>0, [4]) == true
 @test all(x->x>0, [-3, 4, 5]) == false
 
+@test reduce(|, fill(trues(5), 3))  == trues(5)
+@test reduce(|, fill(falses(5), 3)) == falses(5)
+@test reduce(&, fill(trues(5), 3))  == trues(5)
+@test reduce(&, fill(falses(5), 3)) == falses(5)
+
 # in
 
 @test in(1, Int[]) == false


### PR DESCRIPTION
This patch restricts the efficient short-circuit implementation only to `AbstractArray{Bool}`, for reduction with `&` or `|` over general arrays, e.g. arrays of bool arrays, it simply falls back to the general implementation, which works fine.

Tests are added.

cc: @StefanKarpinski 
