### PR TITLE
support user-specified permutation in CHOLMOD factorizations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -132,6 +132,10 @@ Library improvements
 
     * Added generic Cholesky factorization, and the Cholesky factorization is now parametrized on the matrix type ([#7236]).
 
+    * Sparse `cholfact` and `ldltfact` functions now accept a `perm` keyword
+      for user-provided permutations and a `shift` keyword to factorize
+      a shifted matrix ([#10844]).
+
     * Add `svds` for sparse truncated SVD. ([#9425])
 
     * Symmetric and Hermitian immutables are now parametrized on matrix type ([#7992]).
@@ -1334,3 +1338,5 @@ Too numerous to mention.
 [#10543]: https://github.com/JuliaLang/julia/issues/10543
 [#10659]: https://github.com/JuliaLang/julia/issues/10659
 [#10709]: https://github.com/JuliaLang/julia/issues/10709
+[#10747]: https://github.com/JuliaLang/julia/issues/10747
+[#10844]: https://github.com/JuliaLang/julia/issues/10844

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -439,6 +439,9 @@ end
 @deprecate dlsym_e      Libdl.dlsym_e
 @deprecate find_library Libdl.find_library
 
+@deprecate cholfact(A::AbstractMatrix, β::Number) cholfact(A, shift=β)
+@deprecate ldltfact(A::AbstractMatrix, β::Number) ldltfact(A, shift=β)
+
 # 0.4 discontinued functions
 
 @noinline function subtypetree(x::DataType, level=-1)

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -95,9 +95,14 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute the Cholesky factorization of a dense symmetric positive (semi)definite matrix ``A`` and return either a ``Cholesky`` if ``pivot==Val{false}`` or ``CholeskyPivoted`` if ``pivot==Val{true}``. ``LU`` may be ``:L`` for using the lower part or ``:U`` for the upper part. The default is to use ``:U``. The triangular matrix can be obtained from the factorization ``F`` with: ``F[:L]`` and ``F[:U]``. The following functions are available for ``Cholesky`` objects: ``size``, ``\``, ``inv``, ``det``. For ``CholeskyPivoted`` there is also defined a ``rank``. If ``pivot==Val{false}`` a ``PosDefException`` exception is thrown in case the matrix is not positive definite. The argument ``tol`` determines the tolerance for determining the rank. For negative values, the tolerance is the machine precision.
 
-.. function:: cholfact(A) -> CHOLMOD.Factor
+.. function:: cholfact(A; shift=0, perm=Int[]) -> CHOLMOD.Factor
 
    Compute the Cholesky factorization of a sparse positive definite matrix ``A``. A fill-reducing permutation is used.  The main application of this type is to solve systems of equations with ``\``, but also the methods ``diag``, ``det``, ``logdet`` are defined. The function calls the C library CHOLMOD and many other functions from the library are wrapped but not exported.
+
+   Setting optional ``shift`` keyword argument computes the factorization
+   of ``A+shift*I`` instead of ``A``.  If the ``perm`` argument is nonempty,
+   it should be a permutation of `1:size(A,1)` giving the ordering to use
+   (instead of CHOLMOD's default AMD ordering).
 
 .. function:: cholfact!(A [,LU=:U [,pivot=Val{false}]][;tol=-1.0]) -> Cholesky
 
@@ -107,9 +112,14 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute a factorization of a positive definite matrix ``A`` such that ``A=L*Diagonal(d)*L'`` where ``L`` is a unit lower triangular matrix and ``d`` is a vector with non-negative elements.
 
-.. function:: ldltfact(A) -> CHOLMOD.Factor
+.. function:: ldltfact(A; shift=0, perm=Int[]) -> CHOLMOD.Factor
 
    Compute the LDLt factorization of a sparse symmetric or Hermitian matrix ``A``. A fill-reducing permutation is used.  The main application of this type is to solve systems of equations with ``\``, but also the methods ``diag``, ``det``, ``logdet`` are defined. The function calls the C library CHOLMOD and many other functions from the library are wrapped but not exported.
+
+   Setting optional ``shift`` keyword argument computes the factorization
+   of ``A+shift*I`` instead of ``A``.  If the ``perm`` argument is nonempty,
+   it should be a permutation of `1:size(A,1)` giving the ordering to use
+   (instead of CHOLMOD's default AMD ordering).
 
 .. function:: qr(A [,pivot=Val{false}][;thin=true]) -> Q, R, [p]
 


### PR DESCRIPTION
This changes the `cholfact` and `ldltfact` sparse factorizations (via CHOLMOD) to accept a `perm` argument specifying a user-defined permutation instead of the default AMD permutation.   It also changes the (undocumented) optional `β` argument to a (documented) `shift` keyword argument.  Some of the code is consolidated a bit, and I switched to using the new-style `Ref{Complex128}` instead of `Ptr{Cdouble}` (which seems easy to misuse by passing only a single real number when CHOLMOD sometimes expects two) for a couple of ccalls.

I included a couple of other keywords args for cholmod options I was experimenting with, but was unsure whether to document them.  Passing `perm` and setting `userperm_only=false` causes CHOLMOD to try _both_ the user-specified permutation and AMD and pick the better of the two, and passing `postorder=false` omits a post-ordering pass in CHOLMOD (that doesn't affect nnz but supposedly effects supernodal efficiency).

cc @andreasnoack, who helped track down the relevant functionality (I needed it for teaching, in order to show the effect of different orderings).
