### PR TITLE
start_timer: Saturate arguments to be at least zero

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -502,6 +502,8 @@ function _uv_hook_asynccb(async::AsyncWork)
 end
 
 function start_timer(timer::Timer, timeout::Real, repeat::Real)
+    timeout ≤ 0 && (timeout = 0)
+    repeat ≤ 0 && (repeat = 0)
     associate_julia_struct(timer.handle, timer)
     preserve_handle(timer)
     ccall(:uv_update_time,Void,(Ptr{Void},),eventloop())


### PR DESCRIPTION
Negative timeout or repeat arguments are converted to 0 before calling
:uv_timer_start.

Fixes InexactErrors caused by code that use streams in such a way as to
call start_timer with negative timeouts.

See comment in ssfrr/AudioIO#7 for an example of when negative timeouts
can be produced in code:

https://github.com/ssfrr/AudioIO.jl/issues/7#issuecomment-93656623
