### PR TITLE
Change `for i=1:length(A)` to `for i in eachindex(A)`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -204,7 +204,7 @@ function fill!{T<:Union(Integer,FloatingPoint)}(a::Array{T}, x)
         ccall(:memset, Ptr{Void}, (Ptr{Void}, Cint, Csize_t),
               a, 0, length(a)*sizeof(T))
     else
-        for i = 1:length(a)
+        for i in eachindex(a)
             @inbounds a[i] = xT
         end
     end
@@ -703,7 +703,7 @@ end
 ## Unary operators ##
 
 function conj!{T<:Number}(A::AbstractArray{T})
-    for i=1:length(A)
+    for i in eachindex(A)
         A[i] = conj(A[i])
     end
     return A
@@ -713,7 +713,7 @@ for f in (:-, :~, :conj, :sign)
     @eval begin
         function ($f)(A::StridedArray)
             F = similar(A)
-            for i=1:length(A)
+            for i in eachindex(A)
                 F[i] = ($f)(A[i])
             end
             return F
@@ -721,7 +721,7 @@ for f in (:-, :~, :conj, :sign)
     end
 end
 
-(-)(A::StridedArray{Bool}) = reshape([ -A[i] for i=1:length(A) ], size(A))
+(-)(A::StridedArray{Bool}) = reshape([ -A[i] for i in eachindex(A) ], size(A))
 
 real(A::StridedArray) = reshape([ real(x) for x in A ], size(A))
 imag(A::StridedArray) = reshape([ imag(x) for x in A ], size(A))
@@ -730,7 +730,7 @@ imag{T<:Real}(x::StridedArray{T}) = zero(x)
 
 function !(A::StridedArray{Bool})
     F = similar(A)
-    for i=1:length(A)
+    for i in eachindex(A)
         F[i] = !A[i]
     end
     return F
@@ -789,7 +789,7 @@ for f in (:+, :-, :div, :mod, :&, :|, :$)
         end
         function ($f){S,T}(A::AbstractArray{S}, B::AbstractArray{T})
             F = similar(A, promote_type(S,T), promote_shape(size(A),size(B)))
-            for i=1:length(A)
+            for i in eachindex(A,B)
                 @inbounds F[i] = ($f)(A[i], B[i])
             end
             return F
@@ -800,14 +800,14 @@ for f in (:.+, :.-, :.*, :.%, :.<<, :.>>, :div, :mod, :rem, :&, :|, :$)
     @eval begin
         function ($f){T}(A::Number, B::AbstractArray{T})
             F = similar(B, promote_array_type(typeof(A),T))
-            for i=1:length(B)
+            for i in eachindex(B)
                 @inbounds F[i] = ($f)(A, B[i])
             end
             return F
         end
         function ($f){T}(A::AbstractArray{T}, B::Number)
             F = similar(A, promote_array_type(typeof(B),T))
-            for i=1:length(A)
+            for i in eachindex(A)
                 @inbounds F[i] = ($f)(A[i], B)
             end
             return F
@@ -830,14 +830,14 @@ for f in (:.+, :.-)
     @eval begin
         function ($f)(A::Bool, B::StridedArray{Bool})
             F = similar(B, Int, size(B))
-            for i=1:length(B)
+            for i in eachindex(B)
                 @inbounds F[i] = ($f)(A, B[i])
             end
             return F
         end
         function ($f)(A::StridedArray{Bool}, B::Bool)
             F = similar(A, Int, size(A))
-            for i=1:length(A)
+            for i in eachindex(A)
                 @inbounds F[i] = ($f)(A[i], B)
             end
             return F
@@ -848,7 +848,7 @@ for f in (:+, :-)
     @eval begin
         function ($f)(A::StridedArray{Bool}, B::StridedArray{Bool})
             F = similar(A, Int, promote_shape(size(A), size(B)))
-            for i=1:length(A)
+            for i in eachindex(A,B)
                 @inbounds F[i] = ($f)(A[i], B[i])
             end
             return F
@@ -861,7 +861,7 @@ end
 function complex{S<:Real,T<:Real}(A::Array{S}, B::Array{T})
     if size(A) != size(B); throw(DimensionMismatch()); end
     F = similar(A, typeof(complex(zero(S),zero(T))))
-    for i=1:length(A)
+    for i in eachindex(A)
         @inbounds F[i] = complex(A[i], B[i])
     end
     return F
@@ -869,7 +869,7 @@ end
 
 function complex{T<:Real}(A::Real, B::Array{T})
     F = similar(B, typeof(complex(A,zero(T))))
-    for i=1:length(B)
+    for i in eachindex(B)
         @inbounds F[i] = complex(A, B[i])
     end
     return F
@@ -877,7 +877,7 @@ end
 
 function complex{T<:Real}(A::Array{T}, B::Real)
     F = similar(A, typeof(complex(zero(T),B)))
-    for i=1:length(A)
+    for i in eachindex(A)
         @inbounds F[i] = complex(A[i], B)
     end
     return F

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -73,7 +73,7 @@ for f in (:trunc,:floor,:ceil,:round)
             [ ($f)(T, x[i,j])::T for i = 1:size(x,1), j = 1:size(x,2) ]
         end
         function ($f){T}(::Type{T}, x::AbstractArray)
-            reshape([ ($f)(T, x[i])::T for i = 1:length(x) ], size(x))
+            reshape([ ($f)(T, x[i])::T for i in eachindex(x) ], size(x))
         end
     end
 end
@@ -85,7 +85,7 @@ function round{R}(x::AbstractArray{R,2}, r::RoundingMode)
     [ round(x[i,j], r) for i = 1:size(x,1), j = 1:size(x,2) ]
 end
 function round(x::AbstractArray, r::RoundingMode)
-    reshape([ round(x[i], r) for i = 1:length(x) ], size(x))
+    reshape([ round(x[i], r) for i in eachindex(x) ], size(x))
 end
 
 function round{T,R}(::Type{T}, x::AbstractArray{R,1}, r::RoundingMode)
@@ -95,7 +95,7 @@ function round{T,R}(::Type{T}, x::AbstractArray{R,2}, r::RoundingMode)
     [ round(T, x[i,j], r)::T for i = 1:size(x,1), j = 1:size(x,2) ]
 end
 function round{T}(::Type{T}, x::AbstractArray, r::RoundingMode)
-    reshape([ round(T, x[i], r)::T for i = 1:length(x) ], size(x))
+    reshape([ round(T, x[i], r)::T for i in eachindex(x) ], size(x))
 end
 
 # adapted from Matlab File Exchange roundsd: http://www.mathworks.com/matlabcentral/fileexchange/26212

--- a/base/io.jl
+++ b/base/io.jl
@@ -57,7 +57,7 @@ write(s::IO, x::Float64) = write(s, reinterpret(Int64,x))
 
 function write(s::IO, a::AbstractArray)
     nb = 0
-    for i = 1:length(a)
+    for i in eachindex(a)
         nb += write(s, a[i])
     end
     nb
@@ -125,7 +125,7 @@ read{T}(s::IO, t::Type{T}, d1::Integer, dims::Integer...) =
 read{T}(s::IO, ::Type{T}, dims::Dims) = read!(s, Array(T, dims))
 
 function read!{T}(s::IO, a::Array{T})
-    for i = 1:length(a)
+    for i in eachindex(a)
         a[i] = read(s, T)
     end
     return a

--- a/base/math.jl
+++ b/base/math.jl
@@ -241,7 +241,7 @@ end
 function frexp{T<:FloatingPoint}(A::Array{T})
     f = similar(A)
     e = Array(Int, size(A))
-    for i = 1:length(A)
+    for i in eachindex(A)
         f[i], e[i] = frexp(A[i])
     end
     return (f, e)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -149,6 +149,14 @@ stagedfunction eachindex{T,N}(::LinearSlow, A::AbstractArray{T,N})
     :($meta; CartesianRange(CartesianIndex{$N}($(startargs...)), CartesianIndex{$N}($(stopargs...))))
 end
 
+stagedfunction eachindex{S,T,M,N}(::LinearSlow, A::AbstractArray{S,M}, B::AbstractArray{T,N})
+    K = max(M,N)
+    startargs = fill(1, K)
+    stopargs = [:(max(size(A,$i),size(B,$i))) for i=1:K]
+    meta = Expr(:meta, :inline)
+    :($meta; CartesianRange(CartesianIndex{$K}($(startargs...)), CartesianIndex{$K}($(stopargs...))))
+end
+
 eltype{I}(::Type{CartesianRange{I}}) = I
 eltype{I}(::CartesianRange{I}) = I
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -358,7 +358,7 @@ macro vectorize_1arg(S,f)
         ($f){$T<:$S}(x::AbstractArray{$T,2}) =
             [ ($f)(x[i,j]) for i=1:size(x,1), j=1:size(x,2) ]
         ($f){$T<:$S}(x::AbstractArray{$T}) =
-            reshape([ ($f)(x[i]) for i=1:length(x) ], size(x))
+            reshape([ ($f)(x[i]) for i in eachindex(x) ], size(x))
     end
 end
 
@@ -366,13 +366,13 @@ macro vectorize_2arg(S,f)
     S = esc(S); f = esc(f); T1 = esc(:T1); T2 = esc(:T2)
     quote
         ($f){$T1<:$S, $T2<:$S}(x::($T1), y::AbstractArray{$T2}) =
-            reshape([ ($f)(x, y[i]) for i=1:length(y) ], size(y))
+            reshape([ ($f)(x, y[i]) for i in eachindex(y) ], size(y))
         ($f){$T1<:$S, $T2<:$S}(x::AbstractArray{$T1}, y::($T2)) =
-            reshape([ ($f)(x[i], y) for i=1:length(x) ], size(x))
+            reshape([ ($f)(x[i], y) for i in eachindex(x) ], size(x))
 
         function ($f){$T1<:$S, $T2<:$S}(x::AbstractArray{$T1}, y::AbstractArray{$T2})
             shp = promote_shape(size(x),size(y))
-            reshape([ ($f)(x[i], y[i]) for i=1:length(x) ], shp)
+            reshape([ ($f)(x[i], y[i]) for i in eachindex(x,y) ], shp)
         end
     end
 end

--- a/base/random.jl
+++ b/base/random.jl
@@ -262,7 +262,7 @@ rand(r::AbstractRNG, T::Type, d1::Integer, dims::Integer...) = rand(r, T, tuple(
 # moreover, a call like rand(r, NotImplementedType()) would be an infinite loop
 
 function rand!{T}(r::AbstractRNG, A::AbstractArray{T})
-    for i = 1:length(A)
+    for i in eachindex(A)
         @inbounds A[i] = rand(r, T)
     end
     A
@@ -356,7 +356,7 @@ end
 function rand!{T<:Union(Float16, Float32)}(r::MersenneTwister, A::Array{T}, ::Type{CloseOpen})
     rand!(r, A, Close1Open2)
     I32 = one(Float32)
-    for i in 1:length(A)
+    for i in eachindex(A)
         @inbounds A[i] = T(Float32(A[i])-I32) # faster than "A[i] -= one(T)" for T==Float16
     end
     A
@@ -1104,7 +1104,7 @@ function randn_unlikely(rng, idx, rabs, x)
 end
 
 function randn!(rng::AbstractRNG, A::AbstractArray{Float64})
-    for i = 1:length(A)
+    for i in eachindex(A)
         @inbounds A[i] = randn(rng)
     end
     A
@@ -1137,7 +1137,7 @@ function randexp_unlikely(rng, idx, x)
 end
 
 function randexp!(rng::AbstractRNG, A::Array{Float64})
-    for i = 1:length(A)
+    for i in eachindex(A)
         @inbounds A[i] = randexp(rng)
     end
     A

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -190,7 +190,7 @@ end
 ##### standard deviation #####
 
 function sqrt!(A::AbstractArray)
-    for i = 1:length(A)
+    for i in eachindex(A)
         @inbounds A[i] = sqrt(A[i])
     end
     A
@@ -657,4 +657,3 @@ hist2d(v::AbstractMatrix, n1::Integer, n2::Integer) =
     hist2d(v, histrange(sub(v,:,1),n1), histrange(sub(v,:,2),n2))
 hist2d(v::AbstractMatrix, n::Integer) = hist2d(v, n, n)
 hist2d(v::AbstractMatrix) = hist2d(v, sturges(size(v,1)))
-

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1053,6 +1053,12 @@ val, state = next(itr, state)
 @test r[val] == 8
 @test done(itr, state)
 
+R = CartesianRange((1,3))
+@test done(R, start(R)) == false
+R = CartesianRange((0,3))
+@test done(R, start(R)) == true
+R = CartesianRange((3,0))
+@test done(R, start(R)) == true
 
 #rotates
 


### PR DESCRIPTION
PSA: when writing algorithms with potentially-multidimensional `AbstractArray`s, please write `for i in eachindex(A)` rather than `for i = 1:length(A)` whenever you don't have some reason to insist that `i` be an integer.

This fixes performance problems for many operations (see https://github.com/JuliaLang/julia/issues/1168#issuecomment-93804453).

There are a few outstanding issues, some of which arise when trying to use one index for two different arrays in circumstances in which we have not previously required the shapes to match:
- [ ] `map!`, https://github.com/JuliaLang/julia/blob/ef062117bab19959a6905b1bb6d7963b42dddea4/base/abstractarray.jl#L1300 and https://github.com/JuliaLang/julia/blob/ef062117bab19959a6905b1bb6d7963b42dddea4/base/abstractarray.jl#L1337
- [ ] logical indexing, https://github.com/JuliaLang/julia/blob/ef062117bab19959a6905b1bb6d7963b42dddea4/base/array.jl#L332, https://github.com/JuliaLang/julia/blob/ef062117bab19959a6905b1bb6d7963b42dddea4/base/array.jl#L408, https://github.com/JuliaLang/julia/blob/ef062117bab19959a6905b1bb6d7963b42dddea4/base/array.jl#L422
- [ ] `ccopy!`, https://github.com/JuliaLang/julia/blob/ef062117bab19959a6905b1bb6d7963b42dddea4/base/array.jl#L1421

and others of which pertain to returning an index to the user (should we return `CartesianIndex`es?)
- [ ] `find`, https://github.com/JuliaLang/julia/blob/ef062117bab19959a6905b1bb6d7963b42dddea4/base/array.jl#L1150 and https://github.com/JuliaLang/julia/blob/ef062117bab19959a6905b1bb6d7963b42dddea4/base/array.jl#L1164
- [ ] `findin`, https://github.com/JuliaLang/julia/blob/ef062117bab19959a6905b1bb6d7963b42dddea4/base/array.jl#L1271

and finally others where we may want to change the algorithm:
- [ ] `cummin/min/cummax/max`, https://github.com/JuliaLang/julia/blob/ef062117bab19959a6905b1bb6d7963b42dddea4/base/array.jl#L1558
