### PR TITLE
Better show for parameterized methods (issue #10794)

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -1,6 +1,33 @@
 # Method and method-table pretty-printing
 
-function argtype_decl(n, t) # -> (argname, argtype)
+const  filler = :_ # e.g. Array{_,_}
+function replace_tvars(t::DataType, tv)
+    # Returns a string representation of t with its TypeVars replaced
+    # with the ones in tv, if found, else with *.
+    length(t.parameters)==0 && return string(t.name)
+    outstr = string(t.name) * "{"
+    for p in t.parameters
+        nstr = if isa(p,Union(DataType,TypeConstructor))
+             replace_tvars(p, tv)
+        elseif !isa(p,TypeVar)
+            string(p)
+        elseif isa(p,TypeVar)
+            # find which TypeVar features the method parameter
+            i = find([p===t for t in tv])
+            length(i)==1 ? string(tv[i[1]].name) : string(filler)
+        else
+            error("hu?")
+        end
+        outstr = outstr * nstr *","
+    end
+    return outstr[1:end-1]*"}"
+end
+function replace_tvars(t::TypeConstructor, tv)
+    tt = TypeVar(filler)
+    return string(t{[tt for i=1:length(t.parameters)]...})
+end
+
+function argtype_decl(n, t, tv) # -> (argname, argtype)
     if isa(n,Expr)
         n = n.args[1]  # handle n::T in arg list
     end
@@ -19,6 +46,8 @@ function argtype_decl(n, t) # -> (argname, argtype)
             return s, string(t.parameters[1], "...")
         end
     end
+    # If DataType/TypeConstructor replace all unbound TypeVars with *
+    isa(t,Union(DataType,TypeConstructor)) &&  return s, replace_tvars(t, tv)
     return s, string(t)
 end
 
@@ -31,7 +60,7 @@ function arg_decl_parts(m::Method)
     e = uncompressed_ast(li)
     argnames = e.args[1]
     s = symbol("?")
-    decls = [argtype_decl(get(argnames,i,s), m.sig.parameters[i]) for i=1:length(m.sig.parameters)]
+    decls = [argtype_decl(get(argnames,i,s), m.sig.types[i], tv) for i=1:length(m.sig.types)]
     return tv, decls, li.file, li.line
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -221,3 +221,27 @@ end
 
 # issue #9865
 @test ismatch(r"^Set\(\[.+….+\]\)$", replstr(Set(1:100)))
+
+# issue #10794
+let
+    filler = "_"
+    f9580(a::Vector) = 1
+    @test startswith(sprint(show, f9580.env.defs), "f9580(a::Array{$filler,1})")
+
+    f9581{T}(a::Array, b::T) = 1
+    @test startswith(sprint(show, f9581.env.defs), "f9581{T}(a::Array{$filler,$filler},b::T)" )
+
+    f9582(a::Vector{Vector}) = 1
+    @test startswith(sprint(show, f9582.env.defs), "f9582(a::Array{Array{$filler,1},1})" )
+
+    typealias VI Vector{Int32}
+    f9583(a::Vector{VI}) = 1
+    @test startswith(sprint(show,f9583.env.defs), "f9583(a::Array{Array{Int32,1},1})")
+
+    typealias II Int32
+    f9584(a::II) = 1
+    @test startswith(sprint(show, f9584.env.defs), "f9584(a::Int32)")
+
+    f9585{T,N}(a::Array, b::Array{T}, c::Array{T,N}, d::T, e::Int32, f::Vector, g::Vector{T}, h::Array{Vector,1}) = 1
+    @test startswith(sprint(show, f9585.env.defs), "f9585{T,N}(a::Array{$filler,$filler},b::Array{T,$filler},c::Array{T,N},d::T,e::Int32,f::Array{$filler,1},g::Array{T,1},h::Array{Array{$filler,1},1})" )
+end


### PR DESCRIPTION
This only prints actual function parameters:
`f{T}(a::Array, b::T)  -> f{T}(a::Array{*,*}, b::T)`

fixes #10794
