### PR TITLE
Remove UpLo parameter from Cholesky type.

### DIFF
--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -1,40 +1,41 @@
 ##########################
 # Cholesky Factorization #
 ##########################
-immutable Cholesky{T,S<:AbstractMatrix,UpLo} <: Factorization{T}
-    UL::S
-    Cholesky(UL::AbstractMatrix{T}) = new(UL)
+immutable Cholesky{T,S<:AbstractMatrix} <: Factorization{T}
+    factors::S
+    uplo::Char
 end
-Cholesky{T}(UL::AbstractMatrix{T},UpLo::Symbol) = Cholesky{T,typeof(UL),UpLo}(UL)
+Cholesky{T}(A::AbstractMatrix{T}, uplo::Symbol) = Cholesky{T,typeof(A)}(A, char_uplo(uplo))
+Cholesky{T}(A::AbstractMatrix{T}, uplo::Char) = Cholesky{T,typeof(A)}(A, uplo)
 
 immutable CholeskyPivoted{T,S<:AbstractMatrix} <: Factorization{T}
-    UL::S
+    factors::S
     uplo::Char
     piv::Vector{BlasInt}
     rank::BlasInt
     tol::Real
     info::BlasInt
-    CholeskyPivoted(UL::AbstractMatrix{T}, uplo::Char, piv::Vector{BlasInt}, rank::BlasInt, tol::Real, info::BlasInt) = new(UL, uplo, piv, rank, tol, info)
 end
-CholeskyPivoted{T}(UL::AbstractMatrix{T}, uplo::Char, piv::Vector{BlasInt}, rank::BlasInt, tol::Real, info::BlasInt) = CholeskyPivoted{T,typeof(UL)}(UL, uplo, piv, rank, tol, info)
+CholeskyPivoted{T}(A::AbstractMatrix{T}, uplo::Char, piv::Vector{BlasInt}, rank::BlasInt, tol::Real, info::BlasInt) = CholeskyPivoted{T,typeof(A)}(A, uplo, piv, rank, tol, info)
 
-function chol!{T<:BlasFloat}(A::StridedMatrix{T})
+function chol!{T<:BlasFloat}(A::StridedMatrix{T}, ::Type{Val{:U}})
     C, info = LAPACK.potrf!('U', A)
     return @assertposdef UpperTriangular(C) info
 end
-function chol!{T<:BlasFloat}(A::StridedMatrix{T}, uplo::Symbol)
-    C, info = LAPACK.potrf!(char_uplo(uplo), A)
-    return @assertposdef uplo == :U ? UpperTriangular(C) : LowerTriangular(C) info
+function chol!{T<:BlasFloat}(A::StridedMatrix{T}, ::Type{Val{:L}})
+    C, info = LAPACK.potrf!('L', A)
+    return @assertposdef LowerTriangular(C) info
 end
+chol!(A::StridedMatrix) = chol!(A, Val{:U})
 
-function chol!{T}(A::AbstractMatrix{T})
+function chol!{T}(A::AbstractMatrix{T}, ::Type{Val{:U}})
     n = chksquare(A)
     @inbounds begin
         for k = 1:n
             for i = 1:k - 1
                 A[k,k] -= A[i,k]'A[i,k]
             end
-            Akk = chol!(A[k,k], :U)
+            Akk = chol!(A[k,k], Val{:U})
             A[k,k] = Akk
             AkkInv = inv(Akk')
             for j = k + 1:n
@@ -47,100 +48,40 @@ function chol!{T}(A::AbstractMatrix{T})
     end
     return UpperTriangular(A)
 end
-function chol!{T}(A::AbstractMatrix{T}, uplo::Symbol)
+function chol!{T}(A::AbstractMatrix{T}, ::Type{Val{:L}})
     n = chksquare(A)
     @inbounds begin
-        if uplo == :L
-            for k = 1:n
-                for i = 1:k - 1
-                    A[k,k] -= A[k,i]*A[k,i]'
-                end
-                Akk = chol!(A[k,k], uplo)
-                A[k,k] = Akk
-                AkkInv = inv(Akk)
-                for j = 1:k
-                    for i = k + 1:n
-                        if j == 1
-                            A[i,k] = A[i,k]*AkkInv'
-                        end
-                        if j < k
-                            A[i,k] -= A[i,j]*A[k,j]'*AkkInv'
-                        end
+        for k = 1:n
+            for i = 1:k - 1
+                A[k,k] -= A[k,i]*A[k,i]'
+            end
+            Akk = chol!(A[k,k], Val{:L})
+            A[k,k] = Akk
+            AkkInv = inv(Akk)
+            for j = 1:k
+                for i = k + 1:n
+                    if j == 1
+                        A[i,k] = A[i,k]*AkkInv'
+                    end
+                    if j < k
+                        A[i,k] -= A[i,j]*A[k,j]'*AkkInv'
                     end
                 end
             end
-        elseif uplo == :U
-            for k = 1:n
-                for i = 1:k - 1
-                    A[k,k] -= A[i,k]'A[i,k]
-                end
-                Akk = chol!(A[k,k], uplo)
-                A[k,k] = Akk
-                AkkInv = inv(Akk')
-                for j = k + 1:n
-                    for i = 1:k - 1
-                        A[k,j] -= A[i,k]'A[i,j]
-                    end
-                    A[k,j] = AkkInv*A[k,j]
-                end
-            end
-        else
-            throw(ArgumentError("uplo must be either :U or :L but was $(uplo)"))
         end
-    end
-    return uplo == :U ? UpperTriangular(A) : LowerTriangular(A)
-end
-
-cholfact!{T<:BlasFloat}(A::StridedMatrix{T}, uplo::Symbol=:U, pivot::Union(Type{Val{false}}, Type{Val{true}})=Val{false}; tol=0.0) =
-    _cholfact!(A, pivot, uplo, tol=tol)
-function _cholfact!{T<:BlasFloat}(A::StridedMatrix{T}, ::Type{Val{false}}, uplo::Symbol=:U; tol=0.0)
-    uplochar = char_uplo(uplo)
-    return Cholesky(chol!(A, uplo).data, uplo)
-end
-function _cholfact!{T<:BlasFloat}(A::StridedMatrix{T}, ::Type{Val{true}}, uplo::Symbol=:U; tol=0.0)
-    uplochar = char_uplo(uplo)
-    A, piv, rank, info = LAPACK.pstrf!(uplochar, A, tol)
-    return CholeskyPivoted{T,StridedMatrix{T}}(A, uplochar, piv, rank, tol, info)
-end
-cholfact!(A::StridedMatrix, uplo::Symbol=:U) = Cholesky(chol!(A, uplo).data, uplo)
-
-function cholfact!{T<:BlasFloat,S,UpLo}(C::Cholesky{T,S,UpLo})
-    _, info = LAPACK.potrf!(char_uplo(UpLo), C.UL)
-    info[1]>0 && throw(PosDefException(info[1]))
-    C
-end
-
-cholfact{T<:BlasFloat}(A::StridedMatrix{T}, uplo::Symbol=:U, pivot::Union(Type{Val{false}}, Type{Val{true}})=Val{false}; tol=0.0) =
-    cholfact!(copy(A), uplo, pivot, tol=tol)
-
-
-cholfact{T}(A::StridedMatrix{T}, uplo::Symbol=:U, pivot::Union(Type{Val{false}}, Type{Val{true}})=Val{false}; tol=0.0) =
-    _cholfact(copy_oftype(A, promote_type(typeof(chol(one(T))),Float32)), pivot, uplo, tol=tol)
-_cholfact{T<:BlasFloat}(A::StridedMatrix{T}, pivot::Type{Val{true}}, uplo::Symbol=:U; tol=0.0) =
-    cholfact!(A, uplo, pivot, tol = tol)
-_cholfact{T<:BlasFloat}(A::StridedMatrix{T}, pivot::Type{Val{false}}, uplo::Symbol=:U; tol=0.0) =
-    cholfact!(A, uplo, pivot, tol = tol)
-
-_cholfact{T}(A::StridedMatrix{T}, ::Type{Val{false}}, uplo::Symbol=:U; tol=0.0) =
-    cholfact!(A, uplo)
-_cholfact{T}(A::StridedMatrix{T}, ::Type{Val{true}}, uplo::Symbol=:U; tol=0.0) =
-    throw(ArgumentError("pivot only supported for Float32, Float64, Complex{Float32} and Complex{Float64}"))
-
-
-function cholfact(x::Number, uplo::Symbol=:U)
-    xf = fill(chol!(x, uplo), 1, 1)
-    Cholesky(xf, uplo)
+     end
+    return LowerTriangular(A)
 end
 
 function chol{T}(A::AbstractMatrix{T})
     S = promote_type(typeof(chol(one(T))), Float32)
     chol!(copy_oftype(A, S))
 end
-function chol{T}(A::AbstractMatrix{T}, uplo::Symbol)
+function chol{T}(A::AbstractMatrix{T}, uplo::Union(Type{Val{:L}}, Type{Val{:U}}))
     S = promote_type(typeof(chol(one(T))), Float32)
     chol!(copy_oftype(A, S), uplo)
 end
-function chol!(x::Number, uplo::Symbol=:U)
+function chol!(x::Number, uplo)
     rx = real(x)
     rx == abs(x) || throw(DomainError())
     rxr = sqrt(rx)
@@ -148,39 +89,81 @@ function chol!(x::Number, uplo::Symbol=:U)
 end
 chol(x::Number, uplo::Symbol=:U) = chol!(x, uplo)
 
-function convert{Tnew,Told,S,UpLo}(::Type{Cholesky{Tnew}},C::Cholesky{Told,S,UpLo})
-    Cnew = convert(AbstractMatrix{Tnew}, C.UL)
-    Cholesky{Tnew, typeof(Cnew), UpLo}(Cnew)
+cholfact!{T<:BlasFloat}(A::StridedMatrix{T}, uplo::Symbol=:U, pivot::Union(Type{Val{false}}, Type{Val{true}})=Val{false}; tol=0.0) =
+    _cholfact!(A, pivot, uplo, tol=tol)
+function _cholfact!{T<:BlasFloat}(A::StridedMatrix{T}, ::Type{Val{false}}, uplo::Symbol=:U; tol=0.0)
+    return Cholesky(chol!(A, Val{uplo}).data, uplo)
 end
-function convert{T,S,UpLo}(::Type{Cholesky{T,S,UpLo}},C::Cholesky)
-    Cnew = convert(AbstractMatrix{T}, C.UL)
-    Cholesky{T, typeof(Cnew), UpLo}(Cnew)
+function _cholfact!{T<:BlasFloat}(A::StridedMatrix{T}, ::Type{Val{true}}, uplo::Symbol=:U; tol=0.0)
+    uplochar = char_uplo(uplo)
+    A, piv, rank, info = LAPACK.pstrf!(uplochar, A, tol)
+    return CholeskyPivoted{T,StridedMatrix{T}}(A, uplochar, piv, rank, tol, info)
+end
+cholfact!(A::StridedMatrix, uplo::Symbol=:U, pivot::Union(Type{Val{false}}, Type{Val{true}})=Val{false}; tol=0.0) = Cholesky(chol!(A, Val{uplo}).data, uplo)
+
+# function cholfact!{T<:BlasFloat,S}(C::Cholesky{T,S})
+#     _, info = LAPACK.potrf!(C.uplo, C.factors)
+#     info[1]>0 && throw(PosDefException(info[1]))
+#     C
+# end
+
+# cholfact{T<:BlasFloat}(A::StridedMatrix{T}, uplo::Symbol=:U, pivot::Union(Type{Val{false}}, Type{Val{true}})=Val{false}; tol=0.0) =
+#     cholfact!(copy(A), uplo, pivot, tol=tol)
+
+
+cholfact{T}(A::StridedMatrix{T}, uplo::Symbol=:U, pivot::Union(Type{Val{false}}, Type{Val{true}})=Val{false}; tol=0.0) =
+    cholfact!(copy_oftype(A, promote_type(typeof(chol(one(T))),Float32)), uplo, pivot; tol = tol)
+# _cholfact{T<:BlasFloat}(A::StridedMatrix{T}, pivot::Type{Val{true}}, uplo::Symbol=:U; tol=0.0) =
+#     cholfact!(A, uplo, pivot, tol = tol)
+# _cholfact{T<:BlasFloat}(A::StridedMatrix{T}, pivot::Type{Val{false}}, uplo::Symbol=:U; tol=0.0) =
+#     cholfact!(A, uplo, pivot, tol = tol)
+
+# _cholfact{T}(A::StridedMatrix{T}, ::Type{Val{false}}, uplo::Symbol=:U; tol=0.0) =
+#     cholfact!(A, uplo)
+# _cholfact{T}(A::StridedMatrix{T}, ::Type{Val{true}}, uplo::Symbol=:U; tol=0.0) =
+#     throw(ArgumentError("pivot only supported for Float32, Float64, Complex{Float32} and Complex{Float64}"))
+
+
+function cholfact(x::Number, uplo::Symbol=:U)
+    xf = fill(chol!(x, uplo), 1, 1)
+    Cholesky(xf, uplo)
+end
+
+function convert{Tnew,Told,S}(::Type{Cholesky{Tnew}}, C::Cholesky{Told,S})
+    Cnew = convert(AbstractMatrix{Tnew}, C.factors)
+    Cholesky{Tnew, typeof(Cnew)}(Cnew, C.uplo)
+end
+function convert{T,S}(::Type{Cholesky{T,S}}, C::Cholesky)
+    Cnew = convert(AbstractMatrix{T}, C.factors)
+    Cholesky{T, typeof(Cnew)}(Cnew, C.uplo)
 end
 convert{T}(::Type{Factorization{T}}, C::Cholesky) = convert(Cholesky{T}, C)
-convert{T}(::Type{CholeskyPivoted{T}},C::CholeskyPivoted) = CholeskyPivoted(convert(AbstractMatrix{T},C.UL),C.uplo,C.piv,C.rank,C.tol,C.info)
+convert{T}(::Type{CholeskyPivoted{T}},C::CholeskyPivoted) = CholeskyPivoted(convert(AbstractMatrix{T},C.factors),C.uplo,C.piv,C.rank,C.tol,C.info)
 convert{T}(::Type{Factorization{T}}, C::CholeskyPivoted) = convert(CholeskyPivoted{T}, C)
 
-full{T,S}(C::Cholesky{T,S,:U}) = C[:U]'C[:U]
-full{T,S}(C::Cholesky{T,S,:L}) = C[:L]*C[:L]'
+full{T,S}(C::Cholesky{T,S}) = C.uplo == 'U' ? C[:U]'C[:U] : C[:L]*C[:L]'
 full(F::CholeskyPivoted) = (ip=invperm(F[:p]); (F[:L] * F[:U])[ip,ip])
 
-size(C::Union(Cholesky, CholeskyPivoted)) = size(C.UL)
-size(C::Union(Cholesky, CholeskyPivoted), d::Integer) = size(C.UL,d)
+copy(C::Cholesky) = Cholesky(copy(C.factors), C.uplo)
+copy(C::CholeskyPivoted) = CholeskyPivoted(copy(C.factors), C.uplo, C.piv, C.rank, C.tol, C.info)
 
-function getindex{T,S,UpLo}(C::Cholesky{T,S,UpLo}, d::Symbol)
-    d == :U && return UpperTriangular(UpLo == d ? C.UL : C.UL')
-    d == :L && return LowerTriangular(UpLo == d ? C.UL : C.UL')
-    d == :UL && return UpLo == :U ? UpperTriangular(C.UL) : LowerTriangular(C.UL)
+size(C::Union(Cholesky, CholeskyPivoted)) = size(C.factors)
+size(C::Union(Cholesky, CholeskyPivoted), d::Integer) = size(C.factors, d)
+
+function getindex{T,S}(C::Cholesky{T,S}, d::Symbol)
+    d == :U && return UpperTriangular(symbol(C.uplo) == d ? C.factors : C.factors')
+    d == :L && return LowerTriangular(symbol(C.uplo) == d ? C.factors : C.factors')
+    d == :UL && return symbol(C.uplo) == :U ? UpperTriangular(C.factors) : LowerTriangular(C.factors)
     throw(KeyError(d))
 end
 function getindex{T<:BlasFloat}(C::CholeskyPivoted{T}, d::Symbol)
-    d == :U && return UpperTriangular(symbol(C.uplo) == d ? C.UL : C.UL')
-    d == :L && return LowerTriangular(symbol(C.uplo) == d ? C.UL : C.UL')
+    d == :U && return UpperTriangular(symbol(C.uplo) == d ? C.factors : C.factors')
+    d == :L && return LowerTriangular(symbol(C.uplo) == d ? C.factors : C.factors')
     d == :p && return C.piv
     if d == :P
         n = size(C, 1)
         P = zeros(T, n, n)
-        for i=1:n
+        for i = 1:n
             P[C.piv[i],i] = one(T)
         end
         return P
@@ -188,16 +171,20 @@ function getindex{T<:BlasFloat}(C::CholeskyPivoted{T}, d::Symbol)
     throw(KeyError(d))
 end
 
-show{T,S<:AbstractMatrix,UpLo}(io::IO, C::Cholesky{T,S,UpLo}) = (println("$(typeof(C)) with factor:");show(io,C[UpLo]))
+show{T,S<:AbstractMatrix}(io::IO, C::Cholesky{T,S}) = (println("$(typeof(C)) with factor:");show(io,C[:UL]))
 
-A_ldiv_B!{T<:BlasFloat,S<:AbstractMatrix}(C::Cholesky{T,S,:U}, B::StridedVecOrMat{T}) = LAPACK.potrs!('U', C.UL, B)
-A_ldiv_B!{T<:BlasFloat,S<:AbstractMatrix}(C::Cholesky{T,S,:L}, B::StridedVecOrMat{T}) = LAPACK.potrs!('L', C.UL, B)
-A_ldiv_B!{T,S<:AbstractMatrix}(C::Cholesky{T,S,:L}, B::StridedVecOrMat) = Ac_ldiv_B!(LowerTriangular(C.UL), A_ldiv_B!(LowerTriangular(C.UL), B))
-A_ldiv_B!{T,S<:AbstractMatrix}(C::Cholesky{T,S,:U}, B::StridedVecOrMat) = A_ldiv_B!(UpperTriangular(C.UL), Ac_ldiv_B!(UpperTriangular(C.UL), B))
+A_ldiv_B!{T<:BlasFloat,S<:AbstractMatrix}(C::Cholesky{T,S}, B::StridedVecOrMat{T}) = LAPACK.potrs!(C.uplo, C.factors, B)
+function A_ldiv_B!{T,S<:AbstractMatrix}(C::Cholesky{T,S}, B::StridedVecOrMat)
+    if C.uplo == 'L'
+        return Ac_ldiv_B!(LowerTriangular(C.factors), A_ldiv_B!(LowerTriangular(C.factors), B))
+    else
+        return A_ldiv_B!(UpperTriangular(C.factors), Ac_ldiv_B!(UpperTriangular(C.factors), B))
+    end
+end
 
 function A_ldiv_B!{T<:BlasFloat}(C::CholeskyPivoted{T}, B::StridedVector{T})
     chkfullrank(C)
-    ipermute!(LAPACK.potrs!(C.uplo, C.UL, permute!(B, C.piv)), C.piv)
+    ipermute!(LAPACK.potrs!(C.uplo, C.factors, permute!(B, C.piv)), C.piv)
 end
 function A_ldiv_B!{T<:BlasFloat}(C::CholeskyPivoted{T}, B::StridedMatrix{T})
     chkfullrank(C)
@@ -205,38 +192,38 @@ function A_ldiv_B!{T<:BlasFloat}(C::CholeskyPivoted{T}, B::StridedMatrix{T})
     for i=1:size(B, 2)
         permute!(sub(B, 1:n, i), C.piv)
     end
-    LAPACK.potrs!(C.uplo, C.UL, B)
+    LAPACK.potrs!(C.uplo, C.factors, B)
     for i=1:size(B, 2)
         ipermute!(sub(B, 1:n, i), C.piv)
     end
     B
 end
-A_ldiv_B!(C::CholeskyPivoted, B::StridedVector) = C.uplo=='L' ? Ac_ldiv_B!(LowerTriangular(C.UL), A_ldiv_B!(LowerTriangular(C.UL), B[C.piv]))[invperm(C.piv)] : A_ldiv_B!(UpperTriangular(C.UL), Ac_ldiv_B!(UpperTriangular(C.UL), B[C.piv]))[invperm(C.piv)]
-A_ldiv_B!(C::CholeskyPivoted, B::StridedMatrix) = C.uplo=='L' ? Ac_ldiv_B!(LowerTriangular(C.UL), A_ldiv_B!(LowerTriangular(C.UL), B[C.piv,:]))[invperm(C.piv),:] : A_ldiv_B!(UpperTriangular(C.UL), Ac_ldiv_B!(UpperTriangular(C.UL), B[C.piv,:]))[invperm(C.piv),:]
+A_ldiv_B!(C::CholeskyPivoted, B::StridedVector) = C.uplo == 'L' ? Ac_ldiv_B!(LowerTriangular(C.factors), A_ldiv_B!(LowerTriangular(C.factors), B[C.piv]))[invperm(C.piv)] : A_ldiv_B!(UpperTriangular(C.factors), Ac_ldiv_B!(UpperTriangular(C.factors), B[C.piv]))[invperm(C.piv)]
+A_ldiv_B!(C::CholeskyPivoted, B::StridedMatrix) = C.uplo == 'L' ? Ac_ldiv_B!(LowerTriangular(C.factors), A_ldiv_B!(LowerTriangular(C.factors), B[C.piv,:]))[invperm(C.piv),:] : A_ldiv_B!(UpperTriangular(C.factors), Ac_ldiv_B!(UpperTriangular(C.factors), B[C.piv,:]))[invperm(C.piv),:]
 
-function det{T,S,UpLo}(C::Cholesky{T,S,UpLo})
-    dd = one(T)
-    for i in 1:size(C.UL,1) dd *= abs2(C.UL[i,i]) end
+function det(C::Cholesky)
+    dd = one(eltype(C))
+    for i in 1:size(C.factors,1) dd *= abs2(C.factors[i,i]) end
     dd
 end
 
-det{T}(C::CholeskyPivoted{T}) = C.rank<size(C.UL,1) ? real(zero(T)) : prod(abs2(diag(C.UL)))
+det(C::CholeskyPivoted) = C.rank < size(C.factors, 1) ? real(zero(eltype(C))) : prod(abs2(diag(C.factors)))
 
-function logdet{T,S,UpLo}(C::Cholesky{T,S,UpLo})
-    dd = zero(T)
-    for i in 1:size(C.UL,1) dd += log(C.UL[i,i]) end
+function logdet(C::Cholesky)
+    dd = zero(eltype(C))
+    for i in 1:size(C.factors,1) dd += log(C.factors[i,i]) end
     dd + dd # instead of 2.0dd which can change the type
 end
 
-inv{T<:BlasFloat,S<:AbstractMatrix}(C::Cholesky{T,S,:U}) = copytri!(LAPACK.potri!('U', copy(C.UL)), 'U', true)
-inv{T<:BlasFloat,S<:AbstractMatrix}(C::Cholesky{T,S,:L}) = copytri!(LAPACK.potri!('L', copy(C.UL)), 'L', true)
+inv!{T<:BlasFloat,S<:StridedMatrix}(C::Cholesky{T,S}) = copytri!(LAPACK.potri!(C.uplo, C.factors), C.uplo, true)
+inv{T<:BlasFloat,S<:StridedMatrix}(C::Cholesky{T,S}) = inv!(copy(C))
 
 function inv(C::CholeskyPivoted)
     chkfullrank(C)
     ipiv = invperm(C.piv)
-    copytri!(LAPACK.potri!(C.uplo, copy(C.UL)), C.uplo, true)[ipiv, ipiv]
+    copytri!(LAPACK.potri!(C.uplo, copy(C.factors)), C.uplo, true)[ipiv, ipiv]
 end
 
-chkfullrank(C::CholeskyPivoted) = C.rank<size(C.UL, 1) && throw(RankDeficientException(C.info))
+chkfullrank(C::CholeskyPivoted) = C.rank < size(C.factors, 1) && throw(RankDeficientException(C.info))
 
 rank(C::CholeskyPivoted) = C.rank

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -285,17 +285,19 @@ end
 sqrtm(a::Number) = (b = sqrt(complex(a)); imag(b) == 0 ? real(b) : b)
 sqrtm(a::Complex) = sqrt(a)
 
+function inv!{S}(A::StridedMatrix{S})
+    if istriu(A)
+        Ai = inv!(UpperTriangular(A))
+    elseif istril(A)
+        Ai = inv!(LowerTriangular(A))
+    else
+        Ai = inv(lufact!(A))
+    end
+    return convert(typeof(A), Ai)
+end
 function inv{S}(A::StridedMatrix{S})
     T = typeof(one(S)/one(S))
-    Ac = convert(AbstractMatrix{T}, A)
-    if istriu(Ac)
-        Ai = inv(UpperTriangular(A))
-    elseif istril(Ac)
-        Ai = inv(LowerTriangular(A))
-    else
-        Ai = inv(lufact(Ac))
-    end
-    return convert(typeof(Ac), Ai)
+    inv!(copy_oftype(A, T))
 end
 
 function factorize{T}(A::Matrix{T})

--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -706,7 +706,7 @@ function svdvals!{T<:BlasFloat}(A::StridedMatrix{T}, B::StridedMatrix{T})
     a[1:k + l] ./ b[1:k + l]
 end
 svdvals{T<:BlasFloat}(A::StridedMatrix{T},B::StridedMatrix{T}) = svdvals!(copy(A),copy(B))
-svdvals{TA,TB}(A::StridedMatrix{TA}, B::StridedMatrix{TB}) = (S = promote_type(Float32,typeof(one(T)/norm(one(TA))),TB); svdvals!(S != TA ? convert(AbstractMatrix{S}, A) : copy(A), S != TB ? convert(AbstractMatrix{S}, B) : copy(B)))
+svdvals{TA,TB}(A::StridedMatrix{TA}, B::StridedMatrix{TB}) = (S = promote_type(Float32,typeof(one(TA)/norm(one(TA))),TB); svdvals!(S != TA ? convert(AbstractMatrix{S}, A) : copy(A), S != TB ? convert(AbstractMatrix{S}, B) : copy(B)))
 
 immutable Schur{Ty<:BlasFloat, S<:AbstractMatrix} <: Factorization{Ty}
     T::S

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -180,7 +180,7 @@ function logdet{T<:Complex,S}(A::LU{T,S})
     complex(r,a)
 end
 
-inv{T<:BlasFloat,S<:StridedMatrix}(A::LU{T,S}) = @assertnonsingular LAPACK.getri!(copy(A.factors), A.ipiv) A.info
+inv!{T<:BlasFloat,S<:StridedMatrix}(A::LU{T,S}) = @assertnonsingular LAPACK.getri!(A.factors, A.ipiv) A.info
 
 cond{T<:BlasFloat,S<:StridedMatrix}(A::LU{T,S}, p::Number) = inv(LAPACK.gecon!(p == 1 ? '1' : 'I', A.factors, norm((A[:L]*A[:U])[A[:p],:], p)))
 cond(A::LU, p::Number) = norm(A[:L]*A[:U],p)*norm(inv(A),p)

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -220,7 +220,7 @@ for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
         A_rdiv_Bc!{T<:BlasComplex,S<:StridedMatrix}(A::StridedMatrix{T}, B::$t{T,S}) = BLAS.trsm!('R', $uploc, 'C', $isunitc, one(T), B.data, A)
 
         # Matrix inverse
-        inv{T<:BlasFloat,S<:StridedMatrix}(A::$t{T,S}) = $t{T,S}(LAPACK.trtri!($uploc, $isunitc, copy(A.data)))
+        inv!{T<:BlasFloat,S<:StridedMatrix}(A::$t{T,S}) = $t{T,S}(LAPACK.trtri!($uploc, $isunitc, A.data))
 
         # Error bounds for triangular solve
         errorbounds{T<:BlasFloat,S<:StridedMatrix}(A::$t{T,S}, X::StridedVecOrMat{T}, B::StridedVecOrMat{T}) = LAPACK.trrfs!($uploc, 'N', $isunitc, A.data, B, X)

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -70,7 +70,7 @@ debug && println("(Automatic) upper Cholesky factor")
         @test_approx_eq logdet(capd) log(det(capd)) # logdet is less likely to overflow
 
         apos = apd[1,1]            # test chol(x::Number), needs x>0
-        @test_approx_eq cholfact(apos).UL √apos
+        @test_approx_eq cholfact(apos).factors √apos
 
         # test chol of 2x2 Strang matrix
         S = convert(AbstractMatrix{eltya},full(SymTridiagonal([2,2],[-1])))
@@ -87,7 +87,7 @@ debug && println("pivoted Choleksy decomposition")
         if eltya != BigFloat && eltyb != BigFloat # Note! Need to implement pivoted cholesky decomposition in julia
             cpapd = cholfact(apd, :U, Val{true})
             @test rank(cpapd) == n
-            @test all(diff(diag(real(cpapd.UL))).<=0.) # diagonal should be non-increasing
+            @test all(diff(diag(real(cpapd.factors))).<=0.) # diagonal should be non-increasing
             @test norm(apd * (cpapd\b) - b)/norm(b) <= ε*κ*n # Ad hoc, revisit
             if isreal(apd)
                 @test_approx_eq apd * inv(cpapd) eye(n)
@@ -101,8 +101,8 @@ begin
     # Cholesky factor of Matrix with non-commutative elements, here 2x2-matrices
 
     X = Matrix{Float64}[0.1*rand(2,2) for i in 1:3, j = 1:3]
-    L = full(Base.LinAlg.chol!(X*X', :L))
-    U = full(Base.LinAlg.chol!(X*X', :U))
+    L = full(Base.LinAlg.chol!(X*X', Val{:L}))
+    U = full(Base.LinAlg.chol!(X*X', Val{:U}))
     XX = full(X*X')
 
     @test sum(sum(norm, L*L' - XX)) < eps()

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -20,7 +20,7 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
                         (UnitLowerTriangular, :L))
 
         # Construct test matrix
-        A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't, uplo1)))
+        A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't, Val{uplo1})))
 
         debug && println("elty1: $elty1, A1: $t1")
 
@@ -141,7 +141,7 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
 
                 debug && println("elty1: $elty1, A1: $t1, elty2: $elty2")
 
-                A2 = t2(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t-> chol(t't, uplo2)))
+                A2 = t2(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t-> chol(t't, Val{uplo2})))
 
                 # Convert
                 if elty1 <: Real && !(elty2 <: Integer)

--- a/test/linalg4.jl
+++ b/test/linalg4.jl
@@ -53,7 +53,7 @@ for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
     end
     A = convert(Matrix{elty}, A'A)
     for ul in (:U, :L)
-        @test_approx_eq full(cholfact(A, ul)[ul]) full(invoke(Base.LinAlg.chol!, (AbstractMatrix,Symbol),copy(A), ul))
+        @test_approx_eq full(cholfact(A, ul)[ul]) full(invoke(Base.LinAlg.chol!, (AbstractMatrix, Type{Val{ul}}),copy(A), Val{ul}))
     end
 end
 


### PR DESCRIPTION
The main point of this pull request is to remove the `UpLo` type parameter from the `Cholesky` type. Like `Symmetric` and `Hermitian`, but in contrast to `Lower/UpperTriangular`, there is no reason to expose which part of the matrix that is used for storage as a type parameter. In addition, having `UpLo` as type parameter has caused quite a few type stability issues with `Cholesky`. Note that I've also changed the name of the `UL` to `factors` for consistency with other factorizations. 
