### PR TITLE
Some type stability improvements to linalg

### DIFF
--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -44,6 +44,8 @@ debug && println("\ntype of a: ", eltya, " type of b: ", eltyb, "\n")
 
 debug && println("(Automatic) upper Cholesky factor")
 
+        @inferred cholfact(apd)
+        @inferred chol(apd)
         capd  = factorize(apd)
         r     = capd[:U]
         κ     = cond(apd, 1) #condition number
@@ -67,7 +69,7 @@ debug && println("(Automatic) upper Cholesky factor")
         @test_approx_eq apd * inv(capd) eye(n)
         @test norm(a*(capd\(a'*b)) - b,1)/norm(b,1) <= ε*κ*n # Ad hoc, revisit
         @test abs((det(capd) - det(apd))/det(capd)) <= ε*κ*n # Ad hoc, but statistically verified, revisit
-        @test_approx_eq logdet(capd) log(det(capd)) # logdet is less likely to overflow
+        @test_approx_eq @inferred(logdet(capd)) log(det(capd)) # logdet is less likely to overflow
 
         apos = apd[1,1]            # test chol(x::Number), needs x>0
         @test_approx_eq cholfact(apos).factors √apos

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -37,7 +37,7 @@ debug && println("(Automatic) Square LU decomposition")
         @test_approx_eq full(lua) a
 
 debug && println("Thin LU")
-        lua   = lufact(a[:,1:n1])
+        lua   = @inferred lufact(a[:,1:n1])
         @test_approx_eq lua[:L]*lua[:U] lua[:P]*a[:,1:n1]
 
 debug && println("Fat LU")
@@ -50,6 +50,7 @@ end
 ## Integrate in general tests when more linear algebra is implemented in julia
 a = convert(Matrix{Rational{BigInt}}, rand(1:10//1,n,n))/n
 b = rand(1:10,n,2)
+@inferred lufact(a)
 lua   = factorize(a)
 l,u,p = lua[:L], lua[:U], lua[:p]
 @test_approx_eq l*u a[p,:]
@@ -80,4 +81,4 @@ for elty in (Float32, Float64, Complex64, Complex128)
     # @test norm(F[:vectors]*Diagonal(F[:values])/F[:vectors] - A) > 0.01
 end
 
-@test logdet(Complex64[1.0f0 0.5f0; 0.5f0 -1.0f0]) === 0.22314355f0 + 3.1415927f0im
+@test @inferred(logdet(Complex64[1.0f0 0.5f0; 0.5f0 -1.0f0])) === 0.22314355f0 + 3.1415927f0im

--- a/test/linalg/pinv.jl
+++ b/test/linalg/pinv.jl
@@ -90,7 +90,7 @@ end
 
 function test_pinv(a,m,n,tol1,tol2,tol3)
     debug && println("=== julia/matlab pinv, default tol=eps(1.0)*max(size(a)) ===")
-    apinv = pinv(a);
+    apinv = @inferred pinv(a)
 
     @test_approx_eq_eps vecnorm(a*apinv*a - a)/vecnorm(a) 0 tol1
     x0 = randn(n); b = a*x0; x = apinv*b;


### PR DESCRIPTION
This fixes various type stabilities in the linear algebra code by consistently applying `copy_oftype` when promoting element types and by avoiding the type unstable `getindex(Factorization, Symbol)` methods in `pinv` and `nullspace`.
