### PR TITLE
Slightly better ccall error when return type is not defined

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2020,7 +2020,10 @@
            (begin
              (if (not (and (pair? argtypes)
                            (eq? (car argtypes) 'tuple)))
-                 (error "ccall argument types must be a tuple; try \"(T,)\""))
+	       (if (and (pair? RT)
+			(eq? (car RT) 'tuple))
+                 (error "ccall argument types must be a tuple; try \"(T,)\" and check if you specified a correct return type")
+                 (error "ccall argument types must be a tuple; try \"(T,)\"")))
              (expand-forms
               (lower-ccall name RT (cdr argtypes) args))))
          e))


### PR DESCRIPTION
Gives the error message a bit more context in this specific case.
