### PR TITLE
doc: line count of rational.jl

### DIFF
--- a/doc/manual/constructors.rst
+++ b/doc/manual/constructors.rst
@@ -550,8 +550,7 @@ Thus, although the :obj:`//` operator usually returns an instance of
 return an instance of ``Complex{Rational}`` instead. The interested
 reader should consider perusing the rest of
 `rational.jl <https://github.com/JuliaLang/julia/blob/master/base/rational.jl>`_:
-it is short, self-contained, and implements an entire basic Julia type
-in just a little over a hundred lines of code.
+it is short, self-contained, and implements an entire basic Julia type.
 
 Constructors, Call, and Conversion
 ----------------------------------


### PR DESCRIPTION
The line count is out of date; the current version of [rational.jl](https://github.com/JuliaLang/julia/blob/master/base/rational.jl) is just over 300 lines...  Please consider deleting the line count to avoid having to sync the docs with rational.jl.
