### PR TITLE
Introduce USE_GPL_LIBS Makefile flag to build Julia without GPL libraries

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -91,6 +91,9 @@ else
 JULIA_COMMIT = $(JULIA_VERSION)
 endif
 
+# Whether to use GPL libraries or not.
+USE_GPL_LIBS ?= 1
+
 # Directories where said libraries get installed to
 prefix ?= $(abspath julia-$(JULIA_COMMIT))
 bindir = $(prefix)/bin

--- a/NEWS.md
+++ b/NEWS.md
@@ -119,6 +119,8 @@ Compiler improvements
 Library improvements
 --------------------
 
+  * Build with USE_GPL_LIBS=0 to exclude all GPL libraries and code. ([#10870])
+
   * Linear algebra
 
     * The `LinAlg` module is now exported.
@@ -1360,3 +1362,4 @@ Too numerous to mention.
 [#10709]: https://github.com/JuliaLang/julia/issues/10709
 [#10747]: https://github.com/JuliaLang/julia/issues/10747
 [#10844]: https://github.com/JuliaLang/julia/issues/10844
+[#10870]: https://github.com/JuliaLang/julia/issues/10870

--- a/base/Makefile
+++ b/base/Makefile
@@ -50,6 +50,11 @@ ifeq ($(USE_BLAS64), 1)
 else
 	@echo "const USE_BLAS64 = false" >> $@
 endif
+ifeq ($(USE_GPL_LIBS), 1)
+	@echo "const USE_GPL_LIBS = true" >> $@
+else
+	@echo "const USE_GPL_LIBS = false" >> $@
+endif
 	@echo "const libfftw_name = \"$(LIBFFTWNAME)\"" >> $@
 	@echo "const libfftwf_name = \"$(LIBFFTWFNAME)\"" >> $@
 	@echo "const libllvm_version = \"$(LLVM_VER)\"" >> $@

--- a/base/basedocs.jl
+++ b/base/basedocs.jl
@@ -321,6 +321,8 @@ keywords[:immutable] = doc"""
       push!([1,2,3], 4) == [1,2,3,4]
   """ push!
 
+if Base.USE_GPL_LIBS
+
 @doc doc"""
       fft(A[, dims])
 
@@ -346,6 +348,8 @@ keywords[:immutable] = doc"""
   `FFTW.set_num_threads(np)` to use `np` threads, if you have `np`
   processors.
   """ fft
+
+end # USE_GPL_LIBS
 
 @doc doc"""
       include("file.jl")

--- a/base/precompile.jl
+++ b/base/precompile.jl
@@ -452,6 +452,8 @@ precompile(Base.spawn, (Cmd, (Base.TTY, Base.TTY, Base.TTY), Bool, Bool))
 precompile(Base.spawn, (Cmd,))
 
 # Speed up repl help
-sprint(Markdown.term, @doc fft)
-sprint(Docs.repl_search, "fft")
-sprint(Docs.repl_corrections, "fft")
+if Base.USE_GPL_LIBS
+    sprint(Markdown.term, @doc fft)
+    sprint(Docs.repl_search, "fft")
+    sprint(Docs.repl_corrections, "fft")
+end

--- a/base/sparse.jl
+++ b/base/sparse.jl
@@ -20,8 +20,10 @@ include("sparse/sparsematrix.jl")
 include("sparse/csparse.jl")
 
 include("sparse/linalg.jl")
-include("sparse/umfpack.jl")
-include("sparse/cholmod.jl")
-include("sparse/spqr.jl")
+if Base.USE_GPL_LIBS
+    include("sparse/umfpack.jl")
+    include("sparse/cholmod.jl")
+    include("sparse/spqr.jl")
+end
 
 end # module SparseMatrix

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -261,9 +261,11 @@ include("sparse.jl")
 importall .SparseMatrix
 
 # signal processing
-include("fftw.jl")
-include("dsp.jl")
-importall .DSP
+if USE_GPL_LIBS
+    include("fftw.jl")
+    include("dsp.jl")
+    importall .DSP
+end
 
 # system information
 include("sysinfo.jl")

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -61,9 +61,15 @@ MAKE_COMMON = DESTDIR="" prefix=$(build_prefix) bindir=$(build_bindir) libdir=$(
 # prevent installing libs into usr/lib64 on opensuse
 unexport CONFIG_SITE
 
+ifeq ($(USE_GPL_LIBS), 1)
 STAGE1_DEPS =
 STAGE2_DEPS = Rmath-julia
 STAGE3_DEPS = suitesparse-wrapper
+else
+STAGE1_DEPS =
+STAGE2_DEPS =
+STAGE3_DEPS =
+endif
 
 ifeq ($(USE_SYSTEM_LIBUV), 0)
 STAGE1_DEPS += libuv
@@ -121,8 +127,10 @@ endif
 endif
 endif
 
+ifeq ($(USE_GPL_LIBS), 1)
 ifeq ($(USE_SYSTEM_FFTW), 0)
 STAGE1_DEPS += fftw
+endif
 endif
 
 ifeq ($(USE_SYSTEM_GMP), 0)
@@ -149,8 +157,10 @@ ifeq ($(USE_SYSTEM_ARPACK), 0)
 STAGE2_DEPS += arpack
 endif
 
+ifeq ($(USE_GPL_LIBS), 1)
 ifeq ($(USE_SYSTEM_SUITESPARSE), 0)
 STAGE2_DEPS += suitesparse
+endif
 endif
 
 ifeq ($(USE_SYSTEM_UTF8PROC), 0)

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -16,7 +16,7 @@ function choosetests(choices = [])
         "linalg", "core", "keywordargs", "numbers", "strings",
         "dates", "dict", "hashing", "remote", "iobuffer", "staged",
         "arrayops", "tuple", "subarray", "reduce", "reducedim", "random",
-        "intfuncs", "simdloop", "blas", "fft", "dsp", "sparse",
+        "intfuncs", "simdloop", "blas", "sparse",
         "bitarray", "copy", "math", "fastmath", "functional",
         "operators", "path", "ccall",
         "bigint", "sorting", "statistics", "spawn", "backtrace",
@@ -31,6 +31,10 @@ function choosetests(choices = [])
         "enums", "cmdlineargs", "i18n"
     ]
 
+    if Base.USE_GPL_LIBS
+        testnames = [testnames, "fft", "dsp"; ]
+    end
+
     if isdir(joinpath(JULIA_HOME, Base.DOCDIR, "examples"))
         push!(testnames, "examples")
     end
@@ -44,12 +48,16 @@ function choosetests(choices = [])
     if "linalg" in tests
         # specifically selected case
         filter!(x -> x != "linalg", tests)
-        prepend!(tests, ["linalg1", "linalg2", "linalg3", "linalg4",
-            "linalg/lapack", "linalg/triangular", "linalg/tridiag",
-            "linalg/bidiag", "linalg/diagonal",
-            "linalg/pinv", "linalg/givens", "linalg/cholesky", "linalg/lu",
-            "linalg/arnoldi", "linalg/symmetric"])
+        linalgtests = ["linalg1", "linalg2", "linalg3", "linalg4",
+                       "linalg/lapack", "linalg/triangular", "linalg/tridiag",
+                       "linalg/bidiag", "linalg/diagonal",
+                       "linalg/pinv", "linalg/givens", "linalg/cholesky", "linalg/lu",
+                       "linalg/symmetric"]
+        if Base.USE_GPL_LIBS
+            push!(linalgtests, "linalg/arnoldi")
         end
+        prepend!(tests, linalgtests)
+    end
 
     net_required_for = ["socket", "parallel"]
     net_on = true

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -122,6 +122,8 @@ end
 
 ref(x) = Reference(x)
 
+if Base.USE_GPL_LIBS
+
 ref(fft)
 
 writemime(io::IO, m::MIME"text/plain", r::Reference) =
@@ -137,6 +139,7 @@ writemime(io::IO, m::MIME"text/html", r::Reference) =
     end
 @test html(fft_ref) == "<p>Behaves like <a href=\"test\">fft &#40;see Julia docs&#41;</a></p>\n"
 
+end # USE_GPL_LIBS
 
 @test md"""
 ````julia

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -1,4 +1,6 @@
 include("sparsedir/sparse.jl")
-include("sparsedir/umfpack.jl")
-include("sparsedir/cholmod.jl")
-include("sparsedir/spqr.jl")
+if Base.USE_GPL_LIBS
+    include("sparsedir/umfpack.jl")
+    include("sparsedir/cholmod.jl")
+    include("sparsedir/spqr.jl")
+end

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -74,6 +74,7 @@ for i = 1:5
 end
 
 # complex matrix-vector multiplication and left-division
+if Base.USE_GPL_LIBS
 for i = 1:5
     a = speye(5) + 0.1*sprandn(5, 5, 0.2)
     b = randn(5,3) + im*randn(5,3)
@@ -145,6 +146,7 @@ for i = 1:5
     @test (maximum(abs(a\b - full(a)\b)) < 1000*eps())
     @test (maximum(abs(a'\b - full(a')\b)) < 1000*eps())
     @test (maximum(abs(a.'\b - full(a.')\b)) < 1000*eps())
+end
 end
 
 # matrix multiplication and kron
@@ -705,9 +707,11 @@ let D = Diagonal(ones(10,10)),
 end
 
 # explicit zeros
+if Base.USE_GPL_LIBS
 a = SparseMatrixCSC(2, 2, [1, 3, 5], [1, 2, 1, 2], [1.0, 0.0, 0.0, 1.0])
 @test_approx_eq lufact(a)\[2.0, 3.0] [2.0, 3.0]
 @test_approx_eq cholfact(a)\[2.0, 3.0] [2.0, 3.0]
+end
 
 # issue #10113
 let S = spzeros(5,1), I = [false,true,false,true,false]


### PR DESCRIPTION
Disable Rmath, FFTW, and SuiteSparse builds if USE_GPL_LIBS=0
Remove inclusion of julia bindings in sysimg if USE_GPL_LIBS=0
