### PR TITLE
more tupocolypse updates

### DIFF
--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -35,7 +35,7 @@ end
 # in order to provide a way to export T as a given mime type.
 
 mimewritable{mime}(::MIME{mime}, x) =
-  method_exists(writemime, (IO, MIME{mime}, typeof(x)))
+  method_exists(writemime, Tuple{IO, MIME{mime}, typeof(x)})
 
 # it is convenient to accept strings instead of ::MIME
 writemime(io::IO, m::AbstractString, x) = writemime(io, MIME(m), x)
@@ -173,7 +173,7 @@ function display(m::MIME, x)
 end
 
 displayable{D<:Display,mime}(d::D, ::MIME{mime}) =
-  method_exists(display, (D, MIME{mime}, Any))
+  method_exists(display, Tuple{D, MIME{mime}, Any})
 
 function displayable(m::MIME)
     for d in displays

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -94,7 +94,7 @@ promote_union(T::UnionType) = promote_type(T.types...)
 promote_union(T) = T
 function reducedim_init{S}(f, op::AddFun, A::AbstractArray{S}, region)
     T = promote_union(S)
-    if method_exists(zero, (Type{T},))
+    if method_exists(zero, Tuple{Type{T}})
         x = f(zero(T))
         z = zero(x) + zero(x)
         Tr = typeof(z) == typeof(x) && !isbits(T) ? T : typeof(z)
@@ -107,7 +107,7 @@ end
 
 function reducedim_init{S}(f, op::MulFun, A::AbstractArray{S}, region)
     T = promote_union(S)
-    if method_exists(zero, (Type{T},))
+    if method_exists(zero, Tuple{Type{T}})
         x = f(zero(T))
         z = one(x) * one(x)
         Tr = typeof(z) == typeof(x) && !isbits(T) ? T : typeof(z)

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -263,7 +263,7 @@ Indexing, Assignment, and Concatenation
 
    Concatenate along dimension 2
 
-.. function:: hvcat(rows::(Int...), values...)
+.. function:: hvcat(rows::Tuple{Vararg{Int}}, values...)
 
    Horizontal and vertical concatenation in one call. This function is called for
    block matrix syntax. The first argument specifies the number of arguments to

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -394,7 +394,7 @@ Types
       julia> structinfo(T) = [zip(fieldoffsets(T),fieldnames(T),T.types)...];
 
       julia> structinfo(StatStruct)
-      12-element Array{(Int64,Symbol,DataType),1}:
+      12-element Array{Tuple{Int64,Symbol,DataType},1}:
        (0,:device,UInt64)
        (8,:inode,UInt64)
        (16,:mode,UInt64)
@@ -490,13 +490,13 @@ Generic Functions
    ``apply`` is called to implement the ``...`` argument splicing syntax,
    and is usually not called directly: ``apply(f,x) === f(x...)``
 
-.. function:: method_exists(f, tuple) -> Bool
+.. function:: method_exists(f, Tuple type) -> Bool
 
-   Determine whether the given generic function has a method matching the given tuple of argument types.
+   Determine whether the given generic function has a method matching the given ``Tuple`` of argument types.
 
    .. doctest::
 
-   	julia> method_exists(length, (Array,))
+   	julia> method_exists(length, Tuple{Array})
    	true
 
 .. function:: applicable(f, args...) -> Bool
@@ -1004,6 +1004,6 @@ Internals
 
    Evaluates the arguments to the function call, determines their types, and calls :func:`code_native` on the resulting expression
 
-.. function:: precompile(f,args::(Any...,))
+.. function:: precompile(f,args::Tuple{Vararg{Any}})
 
    Compile the given function ``f`` for the argument tuple (of types) ``args``, but do not execute it.

--- a/doc/stdlib/profile.rst
+++ b/doc/stdlib/profile.rst
@@ -68,7 +68,7 @@ The methods in :mod:`Base.Profile` are not exported and need to be called e.g. a
    number. This function allows you to save profiling results for
    future analysis.
 
-.. function:: callers(funcname, [data, lidict], [filename=<filename>], [linerange=<start:stop>]) -> Vector{(count, linfo)}
+.. function:: callers(funcname, [data, lidict], [filename=<filename>], [linerange=<start:stop>]) -> Vector{Tuple{count, linfo}}
 
    Given a previous profiling run, determine who called a particular
    function. Supplying the filename (and optionally, range of line

--- a/examples/juliatypes.jl
+++ b/examples/juliatypes.jl
@@ -606,7 +606,7 @@ function test_no_diagonal()
     @test issub(Ty((Int,String,Vector{Any})),
                 @UnionAll T tupletype(T, T, inst(ArrayT,T,1)))
 
-    @test isequal_type(Ty(Array{(Integer,Integer),1}),
+    @test isequal_type(Ty(Array{Tuple{Integer,Integer},1}),
                        inst(ArrayT, (@UnionAll T<:Ty(Integer) tupletype(T,T)), 1))
 
     @test issub(Ty((Float32,Array{Real,1})),
@@ -667,18 +667,18 @@ function test_3()
                  @UnionAll T tupletype(T, T, inst(ArrayT,T,1)))
     @test !issub(Ty((String,Int,Vector{Integer})),
                  @UnionAll T tupletype(T, T, inst(ArrayT,T,1)))
-    @test !issub(Ty((Int,String,Vector{(Integer,)})),
+    @test !issub(Ty((Int,String,Vector{Tuple{Integer}})),
                  @UnionAll T tupletype(T,T,inst(ArrayT,tupletype(T),1)))
 
     @test !issub(Ty((Int,String,Vector{Any})),
                  @UnionAll T tupletype(T, T, inst(ArrayT,T,1)))
 
     @test isequal_type(Ty(Array{Int,1}), inst(ArrayT, (@UnionAll T<:Ty(Int) T), 1))
-    @test isequal_type(Ty(Array{(Any,),1}), inst(ArrayT, (@UnionAll T tupletype(T)), 1))
+    @test isequal_type(Ty(Array{Tuple{Any},1}), inst(ArrayT, (@UnionAll T tupletype(T)), 1))
 
-    @test isequal_type(Ty(Array{(Int,Int),1}),
+    @test isequal_type(Ty(Array{Tuple{Int,Int},1}),
                        inst(ArrayT, (@UnionAll T<:Ty(Int) tupletype(T,T)), 1))
-    @test !issub(Ty(Array{(Int,Integer),1}),
+    @test !issub(Ty(Array{Tuple{Int,Integer},1}),
                  inst(ArrayT, (@UnionAll T<:Ty(Integer) tupletype(T,T)), 1))
 
 


### PR DESCRIPTION
More updates to the examples and docs from the tuple changes (#10380).  Also changed `method_exists` calls to use `Tuple`; although the old syntax is still supported it seems prudent to update now.
