### PR TITLE
Add isless for enum types

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -101,6 +101,7 @@ macro enum(T,syms...)
         Base.next{E<:$(esc(typename))}(x::Type{E},s) = (E($values[s]),s+1)
         Base.done{E<:$(esc(typename))}(x::Type{E},s) = s > $(length(values))
         Base.names{E<:$(esc(typename))}(x::Type{E}) = [$(map(x->Meta.quot(x[1]), vals)...)]
+        Base.isless{E<:$(esc(typename))}(x::E, y::E) = isless(x.val, y.val)
         function Base.print{E<:$(esc(typename))}(io::IO,x::E)
             for (sym, i) in $vals
                 if i == x.val

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -167,4 +167,7 @@ end
 @test repr(apple) == "apple::"*string(Fruit)
 @test string(apple) == "apple"
 
+@enum LogLevel DEBUG INFO WARN ERROR CRITICAL
+@test DEBUG < CRITICAL
+
 end # module


### PR DESCRIPTION
I have a copy of Jameson's original enum.jl in Logging.jl.  While updating for v0.4, I wanted to switch to `Base`'s enum, but found that `isless` wasn't defined (whereas it was in the original).

I know isless might not make sense for many/most enums, but for something like log levels, it does.  No other use cases come to mind, though, so if it's preferrable, I can just define this Logging.jl.  I don't think it hurts anything, though.

Cc: @quinnj @JeffBezanson 
