### PR TITLE
Rename stagedfunction → ＠generated function

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -322,7 +322,7 @@ end
 # sure about the behaviour and use unsafe_getindex; in the general case
 # we can't and must use getindex, otherwise silent corruption can happen)
 
-stagedfunction getindex_bool_1d(A::Array, I::AbstractArray{Bool})
+@generated function getindex_bool_1d(A::Array, I::AbstractArray{Bool})
     idxop = I <: Union(Array{Bool}, BitArray) ? :unsafe_getindex : :getindex
     quote
         checkbounds(A, I)
@@ -401,7 +401,7 @@ end
 # sure about the behaviour and use unsafe_getindex; in the general case
 # we can't and must use getindex, otherwise silent corruption can happen)
 
-stagedfunction assign_bool_scalar_1d!(A::Array, x, I::AbstractArray{Bool})
+@generated function assign_bool_scalar_1d!(A::Array, x, I::AbstractArray{Bool})
     idxop = I <: Union(Array{Bool}, BitArray) ? :unsafe_getindex : :getindex
     quote
         checkbounds(A, I)
@@ -414,7 +414,7 @@ stagedfunction assign_bool_scalar_1d!(A::Array, x, I::AbstractArray{Bool})
     end
 end
 
-stagedfunction assign_bool_vector_1d!(A::Array, X::AbstractArray, I::AbstractArray{Bool})
+@generated function assign_bool_vector_1d!(A::Array, X::AbstractArray, I::AbstractArray{Bool})
     idxop = I <: Union(Array{Bool}, BitArray) ? :unsafe_getindex : :getindex
     quote
         checkbounds(A, I)

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -380,7 +380,7 @@ end
 # we can't and must use getindex, otherwise silent corruption can happen)
 # (multiple signatures for disambiguation)
 for IT in [AbstractVector{Bool}, AbstractArray{Bool}]
-    @eval stagedfunction getindex(B::BitArray, I::$IT)
+    @eval @generated function getindex(B::BitArray, I::$IT)
         idxop = I <: Union(Array{Bool}, BitArray) ? :unsafe_getindex : :getindex
         quote
             checkbounds(B, I)
@@ -446,7 +446,7 @@ function setindex!(B::BitArray, x, I::BitArray)
     return B
 end
 
-stagedfunction setindex!(B::BitArray, x, I::AbstractArray{Bool})
+@generated function setindex!(B::BitArray, x, I::AbstractArray{Bool})
     idxop = I <: Array{Bool} ? :unsafe_getindex : :getindex
     quote
         checkbounds(B, I)
@@ -493,7 +493,7 @@ function setindex!(B::BitArray, X::AbstractArray, I::BitArray)
     return B
 end
 
-stagedfunction setindex!(B::BitArray, X::AbstractArray, I::AbstractArray{Bool})
+@generated function setindex!(B::BitArray, X::AbstractArray, I::AbstractArray{Bool})
     idxop = I <: Array{Bool} ? :unsafe_getindex : :getindex
     quote
         checkbounds(B, I)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -239,7 +239,7 @@ broadcast!_function(f::Function) = (B, As...) -> broadcast!(f, B, As...)
 broadcast_function(f::Function) = (As...) -> broadcast(f, As...)
 
 broadcast_getindex(src::AbstractArray, I::AbstractArray...) = broadcast_getindex!(Array(eltype(src), broadcast_shape(I...)), src, I...)
-stagedfunction broadcast_getindex!(dest::AbstractArray, src::AbstractArray, I::AbstractArray...)
+@generated function broadcast_getindex!(dest::AbstractArray, src::AbstractArray, I::AbstractArray...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     quote
@@ -254,7 +254,7 @@ stagedfunction broadcast_getindex!(dest::AbstractArray, src::AbstractArray, I::A
     end
 end
 
-stagedfunction broadcast_setindex!(A::AbstractArray, x, I::AbstractArray...)
+@generated function broadcast_setindex!(A::AbstractArray, x, I::AbstractArray...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     quote

--- a/base/constants.jl
+++ b/base/constants.jl
@@ -13,7 +13,7 @@ convert(::Type{Float16}, x::MathConst) = Float16(Float32(x))
 convert{T<:Real}(::Type{Complex{T}}, x::MathConst) = convert(Complex{T}, convert(T,x))
 convert{T<:Integer}(::Type{Rational{T}}, x::MathConst) = convert(Rational{T}, Float64(x))
 
-stagedfunction call{T<:Union(Float32,Float64),s}(t::Type{T},c::MathConst{s},r::RoundingMode)
+@generated function call{T<:Union(Float32,Float64),s}(t::Type{T},c::MathConst{s},r::RoundingMode)
     f = T(big(c()),r())
     :($f)
 end
@@ -43,13 +43,13 @@ end
 <=(x::FloatingPoint,y::MathConst) = x < y
 
 # MathConst vs Rational
-stagedfunction <{T}(x::MathConst, y::Rational{T})
+@generated function <{T}(x::MathConst, y::Rational{T})
     bx = big(x())
     bx < 0 && T <: Unsigned && return true
     rx = rationalize(T,bx,tol=0)
     rx < bx ? :($rx < y) : :($rx <= y)
 end
-stagedfunction <{T}(x::Rational{T}, y::MathConst)
+@generated function <{T}(x::Rational{T}, y::MathConst)
     by = big(y())
     by < 0 && T <: Unsigned && return false
     ry = rationalize(T,by,tol=0)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1385,6 +1385,7 @@ export
     @parallel,
 
     # metaprogramming utilities
+    @generated,
     @gensym,
     @eval,
     @vectorize_1arg,

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -43,7 +43,7 @@ immutable Zip{I, Z<:AbstractZipIterator} <: AbstractZipIterator
 end
 zip(a, b, c...) = Zip(a, zip(b, c...))
 length(z::Zip) = min(length(z.a), length(z.z))
-stagedfunction tuple_type_cons{S,T<:Tuple}(::Type{S}, ::Type{T})
+@generated function tuple_type_cons{S,T<:Tuple}(::Type{S}, ::Type{T})
     Tuple{S, T.parameters...}
 end
 eltype{I,Z}(::Type{Zip{I,Z}}) = tuple_type_cons(eltype(I), eltype(Z))

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -210,7 +210,7 @@ convert(::Type{Array}, S::SharedArray) = S.s
 getindex(S::SharedArray) = getindex(S.s)
 getindex(S::SharedArray, I::Real) = getindex(S.s, I)
 getindex(S::SharedArray, I::AbstractArray) = getindex(S.s, I)
-stagedfunction getindex(S::SharedArray, I::Union(Real,AbstractVector)...)
+@generated function getindex(S::SharedArray, I::Union(Real,AbstractVector)...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     quote
@@ -221,7 +221,7 @@ end
 setindex!(S::SharedArray, x) = setindex!(S.s, x)
 setindex!(S::SharedArray, x, I::Real) = setindex!(S.s, x, I)
 setindex!(S::SharedArray, x, I::AbstractArray) = setindex!(S.s, x, I)
-stagedfunction setindex!(S::SharedArray, x, I::Union(Real,AbstractVector)...)
+@generated function setindex!(S::SharedArray, x, I::Union(Real,AbstractVector)...)
     N = length(I)
     Isplat = Expr[:(I[$d]) for d = 1:N]
     quote

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -98,7 +98,7 @@ centralize_sumabs2(A::AbstractArray, m::Number) =
 centralize_sumabs2(A::AbstractArray, m::Number, ifirst::Int, ilast::Int) =
     mapreduce_impl(CentralizedAbs2Fun(m), AddFun(), A, ifirst, ilast)
 
-stagedfunction centralize_sumabs2!{S,T,N}(R::AbstractArray{S}, A::AbstractArray{T,N}, means::AbstractArray)
+@generated function centralize_sumabs2!{S,T,N}(R::AbstractArray{S}, A::AbstractArray{T,N}, means::AbstractArray)
     quote
         # following the implementation of _mapreducedim! at base/reducedim.jl
         lsiz = check_reducedims(R,A)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -57,7 +57,7 @@ end
 # For S4, J[1] corresponds to I[2], because of the slice along
 # dimension 1 in S2
 
-stagedfunction slice_unsafe{T,NP,IndTypes}(A::AbstractArray{T,NP}, J::IndTypes)
+@generated function slice_unsafe{T,NP,IndTypes}(A::AbstractArray{T,NP}, J::IndTypes)
     N = 0
     sizeexprs = Array(Any, 0)
     Jp = J.parameters
@@ -87,7 +87,7 @@ function _sub(A, I)
     sub_unsafe(A, I)
 end
 
-stagedfunction sub_unsafe{T,NP,IndTypes}(A::AbstractArray{T,NP}, J::IndTypes)
+@generated function sub_unsafe{T,NP,IndTypes}(A::AbstractArray{T,NP}, J::IndTypes)
     sizeexprs = Array(Any, 0)
     Itypes = Array(Any, 0)
     Iexprs = Array(Any, 0)
@@ -123,7 +123,7 @@ end
 
 # Constructing from another SubArray
 # This "pops" the old SubArray and creates a more compact one
-stagedfunction slice_unsafe{T,NV,PV,IV,PLD,IndTypes}(V::SubArray{T,NV,PV,IV,PLD}, J::IndTypes)
+@generated function slice_unsafe{T,NV,PV,IV,PLD,IndTypes}(V::SubArray{T,NV,PV,IV,PLD}, J::IndTypes)
     N = 0
     sizeexprs = Array(Any, 0)
     indexexprs = Array(Any, 0)
@@ -214,7 +214,7 @@ stagedfunction slice_unsafe{T,NV,PV,IV,PLD,IndTypes}(V::SubArray{T,NV,PV,IV,PLD}
     end
 end
 
-stagedfunction sub_unsafe{T,NV,PV,IV,PLD,IndTypes}(V::SubArray{T,NV,PV,IV,PLD}, J::IndTypes)
+@generated function sub_unsafe{T,NV,PV,IV,PLD,IndTypes}(V::SubArray{T,NV,PV,IV,PLD}, J::IndTypes)
     Jp = J.parameters
     IVp = IV.parameters
     N = length(Jp)
@@ -332,10 +332,10 @@ function tailsize(P, d)
     s
 end
 
-stagedfunction linearindexing{T,N,P,I,LD}(A::SubArray{T,N,P,I,LD})
+@generated function linearindexing{T,N,P,I,LD}(A::SubArray{T,N,P,I,LD})
     length(I.parameters) == LD ? (:(LinearFast())) : (:(LinearSlow()))
 end
-stagedfunction linearindexing{A<:SubArray}(::Type{A})
+@generated function linearindexing{A<:SubArray}(::Type{A})
     T,N,P,I,LD = A.parameters
     length(I.parameters) == LD ? (:(LinearFast())) : (:(LinearSlow()))
 end
@@ -349,7 +349,7 @@ first(::Colon) = 1
 in(::Int, ::Colon) = true
 
 ## Strides
-stagedfunction strides{T,N,P,I}(V::SubArray{T,N,P,I})
+@generated function strides{T,N,P,I}(V::SubArray{T,N,P,I})
     Ip = I.parameters
     all(map(x->x<:Union(RangeIndex,Colon), Ip)) || throw(ArgumentError("strides valid only for RangeIndex indexing"))
     strideexprs = Array(Any, N+1)

--- a/base/subarray2.jl
+++ b/base/subarray2.jl
@@ -21,7 +21,7 @@ for i = 1:4
         setindex!{T,N,P,IV}(V::SubArray{T,N,P,IV}, v, $(varsOther...)) = setindex!(V, v, $(vars_toindex...))
     end
     @eval begin
-        stagedfunction getindex{T,N,P,IV,LD}(V::SubArray{T,N,P,IV,LD}, $(varsInt...))
+        @generated function getindex{T,N,P,IV,LD}(V::SubArray{T,N,P,IV,LD}, $(varsInt...))
             if $i == 1 && length(IV.parameters) == LD  # linear indexing
                 meta = Expr(:meta, :inline)
                 if iscontiguous(V)
@@ -35,7 +35,7 @@ for i = 1:4
                 $ex
             end
         end
-        stagedfunction setindex!{T,N,P,IV,LD}(V::SubArray{T,N,P,IV,LD}, v, $(varsInt...))
+        @generated function setindex!{T,N,P,IV,LD}(V::SubArray{T,N,P,IV,LD}, v, $(varsInt...))
             if $i == 1 && length(IV.parameters) == LD  # linear indexing
                 meta = Expr(:meta, :inline)
                 if iscontiguous(V)
@@ -53,7 +53,7 @@ for i = 1:4
     end
 end
 # V[] notation (extracts the first element)
-stagedfunction getindex{T,N,P,IV}(V::SubArray{T,N,P,IV})
+@generated function getindex{T,N,P,IV}(V::SubArray{T,N,P,IV})
     Isyms = ones(Int, N)
     exhead, ex = index_generate(ndims(P), IV, :V, Isyms)
     quote
@@ -62,7 +62,7 @@ stagedfunction getindex{T,N,P,IV}(V::SubArray{T,N,P,IV})
     end
 end
 # Splatting variants
-stagedfunction getindex{T,N,P,IV}(V::SubArray{T,N,P,IV}, I::Int...)
+@generated function getindex{T,N,P,IV}(V::SubArray{T,N,P,IV}, I::Int...)
     Isyms = [:(I[$d]) for d = 1:length(I)]
     exhead, ex = index_generate(ndims(P), IV, :V, Isyms)
     quote
@@ -70,7 +70,7 @@ stagedfunction getindex{T,N,P,IV}(V::SubArray{T,N,P,IV}, I::Int...)
         $ex
     end
 end
-stagedfunction setindex!{T,N,P,IV}(V::SubArray{T,N,P,IV}, v, I::Int...)
+@generated function setindex!{T,N,P,IV}(V::SubArray{T,N,P,IV}, v, I::Int...)
     Isyms = [:(I[$d]) for d = 1:length(I)]
     exhead, ex = index_generate(ndims(P), IV, :V, Isyms)
     quote
@@ -99,7 +99,7 @@ function setindex!{T,N,P,IV}(V::SubArray{T,N,P,IV}, v, I::AbstractArray{Bool,N})
 end
 setindex!{T,N,P,IV}(V::SubArray{T,N,P,IV}, v, I::Union(Real,AbstractVector)...) = setindex!(V, v, to_index(I)...)
 setindex!{T,N,P,IV}(V::SubArray{T,N,P,IV}, x, J::Union(Int,AbstractVector)...) = _setindex!(V, x, J...)
-stagedfunction _setindex!(V::SubArray, x, J::Union(Real,AbstractVector)...)
+@generated function _setindex!(V::SubArray, x, J::Union(Real,AbstractVector)...)
     gen_setindex_body(length(J))
 end
 

--- a/doc/devdocs/cartesian.rst
+++ b/doc/devdocs/cartesian.rst
@@ -81,9 +81,9 @@ you need to work with older julia versions, currently you
 should use the ``@ngenerate`` macro described in `an older version of this documentation <http://docs.julialang.org/en/release-0.3/devdocs/cartesian/#supplying-the-number-of-expressions>`_.
 
 Starting in Julia 0.4-pre, the recommended approach is to use
-a ``stagedfunction``.  Here's an example::
+a ``@generated function``.  Here's an example::
 
-  stagedfunction mysum{T,N}(A::Array{T,N})
+  @generated function mysum{T,N}(A::Array{T,N})
       quote
           s = zero(T)
           @nloops $N i A begin

--- a/doc/devdocs/subarrays.rst
+++ b/doc/devdocs/subarrays.rst
@@ -148,7 +148,7 @@ The better approach is to dispatch to specific methods to handle each
 type of input.  Note, however, that the number of distinct methods
 needed grows exponentially in the number of dimensions, and since
 Julia supports arrays of any dimension the number of methods required
-is in fact infinite.  Fortunately, ``stagedfunction``\s allow one to
+is in fact infinite.  Fortunately, ``@generated function``\s allow one to
 generate the necessary methods quite straightforwardly.  The resulting
 code looks quite a lot like the runtime approach above, but all of the
 type analysis is performed at the time of method instantiation.  For a
@@ -270,7 +270,7 @@ A few details
   about which of these three notions of dimensionality is relevant in
   each circumstance.
 
-- Because the processing needed to implement all of the stagedfunction
+- Because the processing needed to implement all of the ``@generated``
   expressions isn't readily available at the time ``subarray.jl``
   appears in the bootstrap process, ``SubArray`` functionality is
   split into two files, the second being ``subarray2.jl``.

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1120,6 +1120,7 @@
            `(const ,expr)
            expr)))
     ((stagedfunction function macro)
+     (if (eq? word 'stagedfunction) (syntax-deprecation-warning s "stagedfunction" "@generated function"))
      (let* ((paren (eqv? (require-token s) #\())
             (sig   (parse-call s))
             (def   (if (or (symbol? sig)

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -1,4 +1,4 @@
-stagedfunction staged_t1(a,b)
+@generated function staged_t1(a,b)
     if a == Int
         return :(a+b)
     else
@@ -15,14 +15,14 @@ tinline(a,b) = staged_t1(a,b)
 @test !isa(tinline(1,2),Expr)
 @test tinline(1,0.5) == 1.5
 
-stagedfunction splat(a,b...)
+@generated function splat(a,b...)
     :( ($a,$b,a,b) )
 end
 
 @test splat(1,2,3) == (Int,(Int,Int),1,(2,3))
 
 stagediobuf = IOBuffer()
-stagedfunction splat2(a...)
+@generated function splat2(a...)
     print(stagediobuf, a)
     :(nothing)
 end
@@ -53,8 +53,8 @@ splat2(1:5, 3:3)
 splat2(3, 3:5)
 @test takebuf_string(stagediobuf) == "($intstr,UnitRange{$intstr})"
 
-# varargs specialization with parametric stagedfunctions (issue #8944)
-stagedfunction splat3{T,N}(A::AbstractArray{T,N}, indx::RangeIndex...)
+# varargs specialization with parametric @generated functions (issue #8944)
+@generated function splat3{T,N}(A::AbstractArray{T,N}, indx::RangeIndex...)
     print(stagediobuf, indx)
     :(nothing)
 end
@@ -65,7 +65,7 @@ splat3(A, 1:2, 1, 1:2)
 @test takebuf_string(stagediobuf) == "(UnitRange{$intstr},$intstr,UnitRange{$intstr})"
 
 B = slice(A, 1:3, 2, 1:3);
-stagedfunction mygetindex(S::SubArray, indexes::Real...)
+@generated function mygetindex(S::SubArray, indexes::Real...)
     T, N, A, I = S.parameters
     if N != length(indexes)
         error("Wrong number of indexes supplied")
@@ -90,7 +90,7 @@ end
 # issue #8497
 module MyTest8497
 internalfunction(x) = x+1
-stagedfunction h(x)
+@generated function h(x)
     quote
         internalfunction(x)
     end
@@ -99,26 +99,30 @@ end
 @test MyTest8497.h(3) == 4
 
 # static parameters (issue #8505)
-stagedfunction foo1{N,T}(a::Array{T,N})
+@generated function foo1{N,T}(a::Array{T,N})
     "N = $N, T = $T"
 end
-stagedfunction foo2{T,N}(a::Array{T,N})
+@generated function foo2{T,N}(a::Array{T,N})
     "N = $N, T = $T"
 end
 @test foo1(randn(3,3)) == "N = 2, T = Float64"
 @test foo2(randn(3,3)) == "N = 2, T = Float64"
 
 # issue #9088
-stagedfunction f9088(x, a=5)
+@generated function f9088(x, a=5)
     :(x+a)
 end
 @test f9088(7) == 12
 
 # issue #10502
-stagedfunction f10502(x...)
+@generated function f10502(x...)
     :($x)
 end
 f10502() = ()
 @test f10502(1) == (Int,)
 @test f10502(1,2) == (Int,Int)
 @test f10502(1,2,3) == (Int,Int,Int)
+
+# One-line @generated functions
+@generated oneliner(x,y) = :($x, x, $y, y)
+@test oneliner(1, 2.) == (Int, 1, Float64, 2.)


### PR DESCRIPTION
This fixes the long-standing name "bug".  Note that it only affects surface syntax.  Internally, generated functions still use the old language (e.g., `Expr(:stagedfunction, …)`, `isstaged`, `stagedcache`, etc).

This adds a temporary deprecation to the `stagedfunction` keyword -- the keyword should be entirely removed before the 0.4 release.

Given that we have an outstanding PR for documentation (#10673), it'd be nice to use it's real name… if this is its real name.  It was a long time ago, but I believe this was the preferred naming.

This also enables one-liner `@generated` functions, because it's easy.
