### PR TITLE
timedwait, sleep now validate arguments

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1523,6 +1523,7 @@ end
 
 
 function timedwait(testcb::Function, secs::Float64; pollint::Float64=0.1)
+    pollint > 0 || throw(ArgumentError("cannot set pollint to $pollint seconds"))
     start = time()
     done = RemoteRef()
     timercb(aw) = begin

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -520,6 +520,7 @@ function stop_timer(timer::Timer)
 end
 
 function sleep(sec::Real)
+    sec ≥ 0 || throw(ArgumentError("cannot sleep for $sec seconds"))
     w = Condition()
     timer = Timer(function (tmr)
         notify(w)

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -140,6 +140,9 @@ workloads = hist(@parallel((a,b)->[a;b], for i=1:7; myid(); end), nprocs())[2]
     @test isready(rr1)
 end
 
+@test_throws ArgumentError sleep(-1)
+@test_throws ArgumentError timedwait(()->false, 0.1, pollint=-0.5)
+
 # specify pids for pmap
 @test sort(workers()[1:2]) == sort(unique(pmap(x->(sleep(0.1);myid()), 1:10, pids = workers()[1:2])))
 


### PR DESCRIPTION
sleep now throws an error if called with a negative argument

timedwait errors if the optional pollint kwarg is set to a negative
number.

Closes #10855, #10847
