### PR TITLE
new__cp_function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -243,6 +243,12 @@ Library improvements
 
     * The `randexp` and `randexp!` functions are exported ([#9144])
 
+  * File
+
+    * Added function `readlink` which returns the value of a symbolic link "path" ([#10714]).
+
+    * The `cp` function now accepts keyword arguments `remove_destination` and `follow_symlinks` ([#10888]).
+
   * Other improvements
 
     * You can now tab-complete Emoji characters via their [short names](http://www.emoji-cheat-sheet.com/), using `\:name:<tab>` ([#10709]).
@@ -1374,9 +1380,11 @@ Too numerous to mention.
 [#10659]: https://github.com/JuliaLang/julia/issues/10659
 [#10679]: https://github.com/JuliaLang/julia/issues/10679
 [#10709]: https://github.com/JuliaLang/julia/issues/10709
+[#10714]: https://github.com/JuliaLang/julia/pull/10714
 [#10747]: https://github.com/JuliaLang/julia/issues/10747
 [#10844]: https://github.com/JuliaLang/julia/issues/10844
 [#10870]: https://github.com/JuliaLang/julia/issues/10870
 [#10885]: https://github.com/JuliaLang/julia/issues/10885
+[#10888]: https://github.com/JuliaLang/julia/pull/10888
 [#10893]: https://github.com/JuliaLang/julia/pull/10893
 [#10914]: https://github.com/JuliaLang/julia/issues/10914

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -5172,10 +5172,14 @@ Millisecond(v)
 
 "),
 
-("Base","cp","cp(src::AbstractString, dst::AbstractString; recursive=false)
+("Base","cp","cp(src::AbstractString, dst::AbstractString; remove_destination::Bool=false, follow_symlinks::Bool=false)
 
-   Copy a file from *src* to *dest*. Passing \"recursive=true\" will
-   enable recursive copying of directories.
+   Copy the file, link, or directory from *src* to *dest*.
+   \"remove_destination=true\" will first remove an existing `dst`.
+
+   If `follow_symlinks=false`, and src is a symbolic link, dst will be created as a symbolic link.
+   If `follow_symlinks=true` and src is a symbolic link, dst will be a copy of the file or directory
+   `src` refers to.
 
 "),
 

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -109,10 +109,14 @@
    Like uperm but gets the permissions for people who neither own the file nor are a
    member of the group owning the file
 
-.. function:: cp(src::AbstractString,dst::AbstractString; recursive=false)
+.. function:: cp(src::AbstractString, dst::AbstractString; remove_destination::Bool=false, follow_symlinks::Bool=false)
 
-   Copy a file from `src` to `dest`. Passing ``recursive=true`` will enable
-   recursive copying of directories.
+   Copy the file, link, or directory from *src* to *dest*.
+   \"remove_destination=true\" will first remove an existing `dst`.
+
+   If `follow_symlinks=false`, and src is a symbolic link, dst will be created as a symbolic link.
+   If `follow_symlinks=true` and src is a symbolic link, dst will be a copy of the file or directory
+   `src` refers to.
 
 .. function:: download(url,[localfile])
 


### PR DESCRIPTION
hi @tkelman 

This is what I came up with to address issue: #10506

I took also a look at the older conversations at: 
- RFC: Recursive cp #10448
- cp` does not work for directories #10434
  - @jiahao noted that: For comparison, Python has `shutil.copy()` and `shutil.copytree()`.
  - @simonster voted for: I'd vote for a `recursive` kwarg to match `rm`.

.

My own opinion differs from @simonster and I would prefer to remove the `recursive` kwarg altogehter and just copy directories always recursively or export `cptree`.

Anyway: I left it as it was: `cp` requires the `recursive=true` to be set to copy directories  and helper function `cptree` is not exported.

To have an option to keep symlinks as symlinks I added a kwarg `keepsym=false`.
- Python uses: If `follow_symlinks` is false and src is a symbolic link, a new symbolic 
  link will be created instead of copying the file src points to. [shutil.copy](https://docs.python.org/3.4/library/shutil.html#shutil.copy)

On Linux (x86_64) all tests Succeeded

Thanks for your help.

PS: 
- currently files can be copied over existing files
- but: directories can not be copied over existing directories

I kept it like that.

**Question:** should we add an option: `force` to overwrite also directories.
Python seems not to allow such: [shutil.copytree](https://docs.python.org/3.4/library/shutil.html#shutil.copytree)
but that does not mean `julia can't have it`.
If so - should that also apply to files or leave file to be overwritten anyway
