### PR TITLE
fix sysimg path on Unix in build_sysimg.jl

### DIFF
--- a/contrib/build_sysimg.jl
+++ b/contrib/build_sysimg.jl
@@ -4,7 +4,7 @@
 # next to libjulia (except on Windows, where it goes in $JULIA_HOME\..\lib\julia)
 # Allow insertion of a userimg via userimg_path.  If sysimg_path.dlext is currently loaded into memory,
 # don't continue unless force is set to true.  Allow targeting of a CPU architecture via cpu_target
-@unix_only const default_sysimg_path = joinpath(dirname(Libdl.dlpath("libjulia")),"sys")
+@unix_only const default_sysimg_path = joinpath(dirname(Libdl.dlpath("libjulia")),"julia","sys")
 @windows_only const default_sysimg_path = joinpath(JULIA_HOME,"..","lib","julia","sys")
 function build_sysimg(sysimg_path=default_sysimg_path, cpu_target="native", userimg_path=nothing; force=false)
     # Quit out if a sysimg is already loaded and is in the same spot as sysimg_path, unless forcing


### PR DESCRIPTION
`sys.so`/`sys.dylib` are located in `usr/lib/julia/` on OSX and Linux, not `usr/lib/`. Tested on 10.9 and Ubuntu.

cc @tkelman 
