### PR TITLE
export Base.withenv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -266,6 +266,9 @@ Library improvements
     * `code_llvm` now outputs stripped IR without debug info or other attached metadata.
       Use `code_llvm_raw` for the unstripped output ([#10747]).
 
+    * New `withenv(var=>val, ...) do ... end` function to temporarily
+      modify environment variables ([#10914]).
+
 Deprecated or removed
 ---------------------
 
@@ -1366,3 +1369,5 @@ Too numerous to mention.
 [#10747]: https://github.com/JuliaLang/julia/issues/10747
 [#10844]: https://github.com/JuliaLang/julia/issues/10844
 [#10870]: https://github.com/JuliaLang/julia/issues/10870
+[#10885]: https://github.com/JuliaLang/julia/issues/10885
+[#10914]: https://github.com/JuliaLang/julia/issues/10914

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -442,6 +442,8 @@ end
 @deprecate cholfact(A::AbstractMatrix, β::Number) cholfact(A, shift=β)
 @deprecate ldltfact(A::AbstractMatrix, β::Number) ldltfact(A, shift=β)
 
+@deprecate with_env(f::Function, key::AbstractString, val) withenv(f, key=>val)
+
 # 0.4 discontinued functions
 
 @noinline function subtypetree(x::DataType, level=-1)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1299,6 +1299,7 @@ export
     setenv,
     spawn,
     success,
+    withenv,
 
 # C interface
     cfunction,

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -246,7 +246,7 @@ function update(branch::AbstractString)
             Git.run(`checkout -q $branch`)
         end
         # TODO: handle merge conflicts
-        Base.with_env("GIT_MERGE_AUTOEDIT","no") do
+        Base.withenv("GIT_MERGE_AUTOEDIT"=>"no") do
             Git.run(`pull --rebase -q`, out=DevNull)
         end
     end

--- a/base/process.jl
+++ b/base/process.jl
@@ -119,6 +119,7 @@ detach(cmd::Cmd) = (cmd.detach=true; cmd)
 
 setenv{S<:ByteString}(cmd::Cmd, env::Array{S}; dir="") = (cmd.env = ByteString[x for x in env]; setenv(cmd, dir=dir); cmd)
 setenv(cmd::Cmd, env::Associative; dir="") = (cmd.env = ByteString[string(k)*"="*string(v) for (k,v) in env]; setenv(cmd, dir=dir); cmd)
+setenv{T<:AbstractString}(cmd::Cmd, env::Pair{T}...; dir="") = (cmd.env = ByteString[k*"="*string(v) for (k,v) in env]; setenv(cmd, dir=dir); cmd)
 setenv(cmd::Cmd; dir="") = (cmd.dir = dir; cmd)
 
 (&)(left::AbstractCmd, right::AbstractCmd) = AndCmds(left, right)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -671,12 +671,19 @@ System
 
 .. function:: setenv(command, env; dir=working_dir)
 
-   Set environment variables to use when running the given command. ``env`` is either
-   a dictionary mapping strings to strings, or an array of strings of the form
-   ``"var=val"``.
+   Set environment variables to use when running the given
+   command. ``env`` is either a dictionary mapping strings to strings,
+   an array of strings of the form ``"var=val"``, or zero or more
+   ``"var"=>val`` pair arguments.  In order to modify (rather than
+   replace) the existing environment, create ``env`` by ``copy(ENV)``
+   and then setting ``env["var"]=val`` as desired, or use ``withenv``.
 
-   The ``dir`` keyword argument can be used to specify a working directory for the
-   command.
+   The ``dir`` keyword argument can be used to specify a working
+   directory for the command.
+
+.. function:: withenv(f::Function, kv::Pair...)
+
+   Execute ``f()`` in an environment that is temporarily modified (not replaced as in ``setenv``) by zero or more ``"var"=>val`` arguments ``kv``.  ``withenv`` is generally used via the ``withenv(kv...) do ... end`` syntax.  A value of ``nothing`` can be used to temporarily unset an environment variable (if it is set).  When ``withenv`` returns, the original environment has been restored.
 
 .. function:: pipe(from, to, ...)
 

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -92,9 +92,12 @@ rm(file)
     end
 end
 
-readall(setenv(`sh -c "echo \$TEST"`,["TEST=Hello World"])) == "Hello World\n"
-readall(setenv(`sh -c "echo \$TEST"`,Dict("TEST"=>"Hello World"))) == "Hello World\n"
-readall(setenv(`sh -c "pwd"`;dir="/")) == readall(setenv(`sh -c "cd / && pwd"`))
+@test readall(setenv(`sh -c "echo \$TEST"`,["TEST=Hello World"])) == "Hello World\n"
+@test readall(setenv(`sh -c "echo \$TEST"`,Dict("TEST"=>"Hello World"))) == "Hello World\n"
+@test readall(setenv(`sh -c "echo \$TEST"`,"TEST"=>"Hello World")) == "Hello World\n"
+@test (withenv("TEST"=>"Hello World") do
+       readall(`sh -c "echo \$TEST"`); end) == "Hello World\n"
+@test readall(setenv(`sh -c "pwd"`;dir="..")) == readall(setenv(`sh -c "cd .. && pwd"`))
 
 # Here we test that if we close a stream with pending writes, we don't lose the writes.
 str = ""


### PR DESCRIPTION
As discussed in #10836, this exports `Base.withenv` (renamed from `with_env` for consistency with `setenv`); it now takes zero or more `var=>val` arguments to specify the changes to the environment.

For consistency, I added a `setenv` method taking `var=>val` arguments (`Pair...`).  However, the main usage pattern for `setenv` seems to be to `copy(ENV)` and modify/set one environment variable.  Maybe `setenv` should be deprecated entirely in favor of `withenv`?

Note also that the `setenv` test results weren't actually being checked.
