### PR TITLE
Only throw one warning for syntax deprecations when working in the REPL

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -555,7 +555,9 @@ LineEdit.reset_state(hist::REPLHistoryProvider) = history_reset_state(hist)
 const julia_green = "\033[1m\033[32m"
 
 function return_callback(s)
-    ast = Base.parse_input_line(bytestring(LineEdit.buffer(s)))
+    ast = Base.syntax_deprecation_warnings(false) do
+        Base.parse_input_line(bytestring(LineEdit.buffer(s)))
+    end
     if  !isa(ast, Expr) || (ast.head != :continue && ast.head != :incomplete)
         return true
     else
@@ -682,7 +684,9 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
             line = strip(line)
             haskey(Docs.keywords, symbol(line)) ? # Special-case keywords, which won't parse
                 :(Base.Docs.@repl $(symbol(line))) :
-                parse("Base.Docs.@repl $line", raise=false)
+                Base.syntax_deprecation_warnings(false) do
+                    parse("Base.Docs.@repl $line", raise=false)
+                end
         end)
 
     # Set up shell mode
@@ -771,7 +775,9 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
             sz = sizeof(string)
             while pos <= sz
                 oldpos = pos
-                ast, pos = Base.parse(string, pos, raise=false)
+                ast, pos = Base.syntax_deprecation_warnings(false) do
+                    Base.parse(string, pos, raise=false)
+                end
                 if isa(ast, Expr) && ast.head == :error
                     # Insert all the remaining text as one line (might be empty)
                     LineEdit.replace_line(s, strip(bytestring(string.data[max(oldpos, 1):end])))

--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -284,7 +284,9 @@ end
 function completions(string, pos)
     # First parse everything up to the current position
     partial = string[1:pos]
-    inc_tag = Base.incomplete_tag(parse(partial , raise=false))
+    inc_tag = Base.syntax_deprecation_warnings(false) do
+        Base.incomplete_tag(parse(partial, raise=false))
+    end
     if inc_tag in [:cmd, :string]
         m = match(r"[\t\n\r\"'`@\$><=;|&\{]| (?!\\)", reverse(partial))
         startpos = nextind(partial, reverseind(partial, m.offset))
@@ -308,7 +310,9 @@ function completions(string, pos)
 
      if inc_tag == :other && should_method_complete(partial)
         frange, method_name_end = find_start_brace(partial)
-        ex = parse(partial[frange] * ")", raise=false)
+        ex = Base.syntax_deprecation_warnings(false) do
+            parse(partial[frange] * ")", raise=false)
+        end
         if isa(ex, Expr) && ex.head==:call
             return complete_methods(ex), start(frange):method_name_end, false
         end

--- a/base/client.jl
+++ b/base/client.jl
@@ -141,6 +141,15 @@ _repl_start = Condition()
 syntax_deprecation_warnings(warn::Bool) =
     Bool(ccall(:jl_parse_depwarn, Cint, (Cint,), warn))
 
+function syntax_deprecation_warnings(f::Function, warn::Bool)
+    prev = syntax_deprecation_warnings(warn)
+    try
+        f()
+    finally
+        syntax_deprecation_warnings(prev)
+    end
+end
+
 function parse_input_line(s::AbstractString)
     # s = bytestring(s)
     # (expr, pos) = parse(s, 1)


### PR DESCRIPTION
This gets rid of the annoying multiple syntax deprecation warnings when working in the REPL.  Also, prevent throwing syntax warnings in help and other places where parse is used on incomplete input.
