### PR TITLE
Permit declarations of the form `f(x::Vararg{Any})`

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -96,6 +96,7 @@ jl_sym_t *boundscheck_sym; jl_sym_t *copyast_sym;
 jl_sym_t *fastmath_sym;
 jl_sym_t *simdloop_sym; jl_sym_t *meta_sym;
 jl_sym_t *arrow_sym;  jl_sym_t *inert_sym;
+jl_sym_t *vararg_sym;
 
 typedef struct {
     int64_t a;

--- a/src/ast.c
+++ b/src/ast.c
@@ -750,7 +750,11 @@ int jl_is_rest_arg(jl_value_t *ex)
     if (((jl_expr_t*)ex)->head != colons_sym) return 0;
     jl_expr_t *atype = (jl_expr_t*)jl_exprarg(ex,1);
     if (!jl_is_expr(atype)) return 0;
-    return ((jl_expr_t*)atype)->head == dots_sym;
+    if (((jl_expr_t*)atype)->head == dots_sym)
+        return 1;
+    if (atype->head != call_sym || jl_array_len(atype->args) < 3 || jl_array_len(atype->args) > 4)
+         return 0;
+    return ((jl_sym_t*)jl_exprarg(atype,1)) == vararg_sym;
 }
 
 static jl_value_t *copy_ast(jl_value_t *expr, jl_svec_t *sp, int do_sp)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3061,6 +3061,7 @@ void jl_init_types(void)
     jl_svec_t *tv;
     tv = jl_svec1(tvar("T"));
     jl_vararg_type = jl_new_abstracttype((jl_value_t*)jl_symbol("Vararg"), jl_any_type, tv);
+    vararg_sym = jl_symbol("Vararg");
 
     jl_anytuple_type = jl_new_datatype(jl_symbol("Tuple"), jl_any_type, jl_emptysvec,
                                        jl_emptysvec, jl_emptysvec, 0, 0, 0);

--- a/src/julia.h
+++ b/src/julia.h
@@ -457,7 +457,7 @@ DLLEXPORT extern jl_value_t *jl_nothing;
 // some important symbols
 extern jl_sym_t *call_sym;
 extern jl_sym_t *call1_sym;
-extern jl_sym_t *dots_sym;
+extern jl_sym_t *dots_sym;    extern jl_sym_t *vararg_sym;
 extern jl_sym_t *quote_sym;   extern jl_sym_t *newvar_sym;
 extern jl_sym_t *top_sym;     extern jl_sym_t *dot_sym;
 extern jl_sym_t *line_sym;    extern jl_sym_t *toplevel_sym;

--- a/test/core.jl
+++ b/test/core.jl
@@ -518,6 +518,17 @@ begin
     @test firstlast(Val{false}) == "Last"
 end
 
+# x::Vararg{Any} declarations
+begin
+    local f1, f2, f3
+    f1(x...) = [x...]
+    f2(x::Vararg{Any}) = [x...]
+    f3(x::Vararg) = [x...]
+    @test f1(1,2,3) == [1,2,3]
+    @test f2(1,2,3) == [1,2,3]
+    @test f3(1,2,3) == [1,2,3]
+end
+
 # try/finally
 begin
     after = 0


### PR DESCRIPTION
There are a couple of things here that prepare for #10911 (e.g., checking for `Vararg`s with two parameters), but nothing that should hurt anything.

Fixes #10925
