### PR TITLE
use the new signature of invoke

### DIFF
--- a/base/Terminals.jl
+++ b/base/Terminals.jl
@@ -78,7 +78,7 @@ function writepos{T}(t::TextTerminal, x, y, b::Array{T})
         writepos(t, x, y, reinterpret(UInt8, b))
     else
         cmove(t, x, y)
-        invoke(write, (IO, Array), s, a)
+        invoke(write, Tuple{IO, Array}, s, a)
     end
 end
 function writepos(t::TextTerminal, x, y, args...)

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -16,7 +16,7 @@ function deepcopy_internal(x::Function, stackdict::ObjectIdDict)
     if isa(x.env, Union(MethodTable, Symbol)) || x.env === ()
         return x
     end
-    invoke(deepcopy_internal, (Any, ObjectIdDict), x, stackdict)
+    invoke(deepcopy_internal, Tuple{Any, ObjectIdDict}, x, stackdict)
 end
 
 function deepcopy_internal(x, stackdict::ObjectIdDict)

--- a/base/docs.jl
+++ b/base/docs.jl
@@ -114,7 +114,7 @@ catdoc(xs...) = vcat(xs...)
 # Modules
 
 function doc(m::Module)
-    md = invoke(doc, (Any,), m)
+    md = invoke(doc, Tuple{Any}, m)
     md == nothing || return md
     readme = Pkg.dir(string(m), "README.md")
     if isfile(readme)

--- a/base/fs.jl
+++ b/base/fs.jl
@@ -197,7 +197,7 @@ function write{T}(f::File, a::Array{T})
     if isbits(T)
         write(f,pointer(a),length(a)*sizeof(eltype(a)))
     else
-        invoke(write, (IO, Array), f, a)
+        invoke(write, Tuple{IO, Array}, f, a)
     end
 end
 
@@ -238,7 +238,7 @@ function read!{T}(f::File, a::Array{T}, nel=length(a))
                     f.handle, a, nb)
         uv_error("read",ret)
     else
-        invoke(read, (IO, Array), s, a)
+        invoke(read, Tuple{IO, Array}, s, a)
     end
     a
 end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -126,7 +126,7 @@ function write{T}(s::IOStream, a::Array{T})
         Int(ccall(:ios_write, UInt, (Ptr{Void}, Ptr{Void}, UInt),
                   s.ios, a, length(a)*sizeof(T)))
     else
-        invoke(write, (IO, Array), s, a)
+        invoke(write, Tuple{IO, Array}, s, a)
     end
 end
 
@@ -139,7 +139,7 @@ end
 
 function write{T,N,A<:Array}(s::IOStream, a::SubArray{T,N,A})
     if !isbits(T) || stride(a,1)!=1
-        return invoke(write, (Any, AbstractArray), s, a)
+        return invoke(write, Tuple{Any, AbstractArray}, s, a)
     end
     colsz = size(a,1)*sizeof(T)
     if N<=1
@@ -170,7 +170,7 @@ function read!{T}(s::IOStream, a::Array{T})
             throw(EOFError())
         end
     else
-        invoke(read!, (IO, Array), s, a)
+        invoke(read!, Tuple{IO, Array}, s, a)
     end
     a
 end

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -532,11 +532,11 @@ function serialize(s, rr::RemoteRef)
         #println("send add $rr to $i")
         send_add_client(rr, i)
     end
-    invoke(serialize, (Any, Any), s, rr)
+    invoke(serialize, Tuple{Any, Any}, s, rr)
 end
 
 function deserialize(s, t::Type{RemoteRef})
-    rr = invoke(deserialize, (Any, DataType), s, t)
+    rr = invoke(deserialize, Tuple{Any, DataType}, s, t)
     where = rr.where
     if where == myid()
         add_client(rr2id(rr), myid())

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -166,7 +166,7 @@ end
 
 function serialize{T<:AbstractString}(s, ss::SubString{T})
     # avoid saving a copy of the parent string, keeping the type of ss
-    invoke(serialize, (Any,Any), s, convert(SubString{T}, convert(T,ss)))
+    invoke(serialize, Tuple{Any, Any}, s, convert(SubString{T}, convert(T,ss)))
 end
 
 # Don't serialize the pointers

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -199,7 +199,7 @@ function serialize(s, S::SharedArray)
 end
 
 function deserialize{T,N}(s, t::Type{SharedArray{T,N}})
-    S = invoke(deserialize, (Any, DataType), s, t)
+    S = invoke(deserialize, Tuple{Any, DataType}, s, t)
     init_loc_flds(S)
     S
 end

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -29,7 +29,7 @@ function (*){TvA,TiA,TvB,TiB}(A::SparseMatrixCSC{TvA,TiA}, B::SparseMatrixCSC{Tv
     A * B
 end
 
-(*){TvA,TiA}(A::SparseMatrixCSC{TvA,TiA}, X::BitArray{1}) = invoke(*, (SparseMatrixCSC, AbstractVector), A, X)
+(*){TvA,TiA}(A::SparseMatrixCSC{TvA,TiA}, X::BitArray{1}) = invoke(*, Tuple{SparseMatrixCSC, AbstractVector}, A, X)
 # In matrix-vector multiplication, the correct orientation of the vector is assumed.
 function A_mul_B!(α::Number, A::SparseMatrixCSC, x::AbstractVector, β::Number, y::AbstractVector)
     A.n == length(x) || throw(DimensionMismatch())
@@ -113,7 +113,7 @@ function At_mul_B{TA,S,Tx}(A::SparseMatrixCSC{TA,S}, x::AbstractVector{Tx})
     At_mul_B!(one(T), A, x, zero(T), Array(T, A.n))
 end
 
-*(X::BitArray{1}, A::SparseMatrixCSC) = invoke(*, (AbstractVector, SparseMatrixCSC), X, A)
+*(X::BitArray{1}, A::SparseMatrixCSC) = invoke(*, Tuple{AbstractVector, SparseMatrixCSC}, X, A)
 # In vector-matrix multiplication, the correct orientation of the vector is assumed.
 # XXX: this is wrong (i.e. not what Arrays would do)!!
 function *{T1,T2}(X::AbstractVector{T1}, A::SparseMatrixCSC{T2})
@@ -127,7 +127,7 @@ function *{T1,T2}(X::AbstractVector{T1}, A::SparseMatrixCSC{T2})
     Y
 end
 
-*{TvA,TiA}(A::SparseMatrixCSC{TvA,TiA}, X::BitArray{2}) = invoke(*, (SparseMatrixCSC, AbstractMatrix), A, X)
+*{TvA,TiA}(A::SparseMatrixCSC{TvA,TiA}, X::BitArray{2}) = invoke(*, Tuple{SparseMatrixCSC, AbstractMatrix}, A, X)
 function (*){TvA,TiA,TX}(A::SparseMatrixCSC{TvA,TiA}, X::AbstractMatrix{TX})
     mX, nX = size(X)
     A.n==mX || throw(DimensionMismatch())
@@ -144,9 +144,9 @@ function (*){TvA,TiA,TX}(A::SparseMatrixCSC{TvA,TiA}, X::AbstractMatrix{TX})
     Y
 end
 
-*{TvA,TiA}(X::BitArray{2}, A::SparseMatrixCSC{TvA,TiA}) = invoke(*, (AbstractMatrix, SparseMatrixCSC), X, A)
+*{TvA,TiA}(X::BitArray{2}, A::SparseMatrixCSC{TvA,TiA}) = invoke(*, Tuple{AbstractMatrix, SparseMatrixCSC}, X, A)
 # TODO: Tridiagonal * Sparse should be implemented more efficiently
-*{TX,TvA,TiA}(X::Tridiagonal{TX}, A::SparseMatrixCSC{TvA,TiA}) = invoke(*, (Tridiagonal, AbstractMatrix), X, A)
+*{TX,TvA,TiA}(X::Tridiagonal{TX}, A::SparseMatrixCSC{TvA,TiA}) = invoke(*, Tuple{Tridiagonal, AbstractMatrix}, X, A)
 *{TvA,TiA}(X::AbstractTriangular, A::SparseMatrixCSC{TvA,TiA}) = full(X)*A
 function *{TX,TvA,TiA}(X::AbstractMatrix{TX}, A::SparseMatrixCSC{TvA,TiA})
     mX, nX = size(X)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -811,7 +811,7 @@ function write{T}(s::AsyncStream, a::Array{T})
         return buffer_or_write(s, pointer(a), n);
     else
         check_open(s)
-        invoke(write,(IO,Array),s,a)
+        invoke(write, Tuple{IO, Array},s,a)
     end
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -2052,6 +2052,13 @@ f9520c(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, args...) = 46
 @test invoke(f9520b, Tuple{Any, Any, Any, Any, Any, Any}, 1, 2, 3, 4, 5, 6) == 23
 @test invoke(f9520c, Tuple{Any, Any, Any, Any, Any, Any}, 1, 2, 3, 4, 5, 6) == 46
 @test invoke(f9520c, Tuple{Any, Any, Any, Any, Any, Any, Any}, 1, 2, 3, 4, 5, 6, 7) == 46
+# Keep until the old signature of invoke is dropped.
+@test invoke(f9520a, (Any, Any), 1, 2) == 15
+@test invoke(f9520a, (Any, Any, Any), 1, 2, 3) == 15
+@test invoke(f9520b, (Any, Any, Any), 1, 2, 3) == 23
+@test invoke(f9520b, (Any, Any, Any, Any, Any, Any), 1, 2, 3, 4, 5, 6) == 23
+@test invoke(f9520c, (Any, Any, Any, Any, Any, Any), 1, 2, 3, 4, 5, 6) == 46
+@test invoke(f9520c, (Any, Any, Any, Any, Any, Any, Any), 1, 2, 3, 4, 5, 6, 7) == 46
 
 # jl_new_bits testing
 let x = [1,2,3]

--- a/test/core.jl
+++ b/test/core.jl
@@ -951,7 +951,7 @@ end
 # issue #2169
 let
     i2169{T}(a::Array{T}) = typemin(T)
-    @test invoke(i2169,(Array,),Int8[1]) === Int8(-128)
+    @test invoke(i2169, Tuple{Array} ,Int8[1]) === Int8(-128)
 end
 
 # issue #2365
@@ -2046,12 +2046,12 @@ end
 f9520a(::Any, ::Any, args...) = 15
 f9520b(::Any, ::Any, ::Any, args...) = 23
 f9520c(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, args...) = 46
-@test invoke(f9520a, (Any, Any), 1, 2) == 15
-@test invoke(f9520a, (Any, Any, Any), 1, 2, 3) == 15
-@test invoke(f9520b, (Any, Any, Any), 1, 2, 3) == 23
-@test invoke(f9520b, (Any, Any, Any, Any, Any, Any), 1, 2, 3, 4, 5, 6) == 23
-@test invoke(f9520c, (Any, Any, Any, Any, Any, Any), 1, 2, 3, 4, 5, 6) == 46
-@test invoke(f9520c, (Any, Any, Any, Any, Any, Any, Any), 1, 2, 3, 4, 5, 6, 7) == 46
+@test invoke(f9520a, Tuple{Any, Any}, 1, 2) == 15
+@test invoke(f9520a, Tuple{Any, Any, Any}, 1, 2, 3) == 15
+@test invoke(f9520b, Tuple{Any, Any, Any}, 1, 2, 3) == 23
+@test invoke(f9520b, Tuple{Any, Any, Any, Any, Any, Any}, 1, 2, 3, 4, 5, 6) == 23
+@test invoke(f9520c, Tuple{Any, Any, Any, Any, Any, Any}, 1, 2, 3, 4, 5, 6) == 46
+@test invoke(f9520c, Tuple{Any, Any, Any, Any, Any, Any, Any}, 1, 2, 3, 4, 5, 6, 7) == 46
 
 # jl_new_bits testing
 let x = [1,2,3]

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -28,7 +28,7 @@ end
 
 for T=types[2:end], x=vals
     a = coerce(T,x)
-    @test hash(a,zero(UInt)) == invoke(hash,(Real,UInt),a,zero(UInt))
+    @test hash(a,zero(UInt)) == invoke(hash, Tuple{Real, UInt}, a, zero(UInt))
 end
 
 for T=types, S=types, x=vals
@@ -50,7 +50,7 @@ end
 @test hash(prevfloat(2.0^64)) == hash(UInt64(prevfloat(2.0^64)))
 
 # issue #9264
-@test hash(1//6,zero(UInt)) == invoke(hash,(Real,UInt),1//6,zero(UInt))
+@test hash(1//6,zero(UInt)) == invoke(hash, Tuple{Real, UInt}, 1//6, zero(UInt))
 @test hash(1//6) == hash(big(1)//big(6))
 @test hash(1//6) == hash(0x01//0x06)
 

--- a/test/linalg2.jl
+++ b/test/linalg2.jl
@@ -174,7 +174,8 @@ for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
         end
 
         ## QR
-        FJulia  = invoke(qrfact!, (AbstractMatrix,Type{Val{false}}), copy(A), Val{false})
+        FJulia  = invoke(qrfact!, Tuple{AbstractMatrix, Type{Val{false}}},
+                         copy(A), Val{false})
         FLAPACK = Base.LinAlg.LAPACK.geqrf!(copy(A))
         @test_approx_eq FJulia.factors FLAPACK[1]
         @test_approx_eq FJulia.τ FLAPACK[2]

--- a/test/linalg4.jl
+++ b/test/linalg4.jl
@@ -53,7 +53,7 @@ for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
     end
     A = convert(Matrix{elty}, A'A)
     for ul in (:U, :L)
-        @test_approx_eq full(cholfact(A, ul)[ul]) full(invoke(Base.LinAlg.chol!, (AbstractMatrix, Type{Val{ul}}),copy(A), Val{ul}))
+        @test_approx_eq full(cholfact(A, ul)[ul]) full(invoke(Base.LinAlg.chol!, Tuple{AbstractMatrix, Type{Val{ul}}},copy(A), Val{ul}))
     end
 end
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -74,16 +74,16 @@ b = complex(randn(32), randn(32))
 @test_approx_eq sumabs2(b) sum(abs2(b))
 
 # check variants of summation for type-stability and other issues (#6069)
-sum2(itr) = invoke(sum, (Any,), itr)
+sum2(itr) = invoke(sum, Tuple{Any}, itr)
 plus(x,y) = x + y
 sum3(A) = reduce(plus, A)
-sum4(itr) = invoke(reduce, (Function, Any), plus, itr)
+sum4(itr) = invoke(reduce, Tuple{Function, Any}, plus, itr)
 sum5(A) = reduce(plus, 0, A)
-sum6(itr) = invoke(reduce, (Function, Int, Any), plus, 0, itr)
+sum6(itr) = invoke(reduce, Tuple{Function, Int, Any}, plus, 0, itr)
 sum7(A) = mapreduce(x->x, plus, A)
-sum8(itr) = invoke(mapreduce, (Function, Function, Any), x->x, plus, itr)
+sum8(itr) = invoke(mapreduce, Tuple{Function, Function, Any}, x->x, plus, itr)
 sum9(A) = mapreduce(x->x, plus, 0, A)
-sum10(itr) = invoke(mapreduce, (Function, Function, Int, Any), x->x,plus,0,itr)
+sum10(itr) = invoke(mapreduce, Tuple{Function, Function, Int, Any}, x->x,plus,0,itr)
 for f in (sum2, sum5, sum6, sum9, sum10)
     @test sum(z) == f(z)
     @test sum(Int[]) == f(Int[]) == 0
@@ -117,7 +117,7 @@ end
 @test prod(big(typemax(Int64)):big(typemax(Int64))+16) == parse(BigInt,"25300281663413827620486300433089141956148633919452440329174083959168114253708467653081909888307573358090001734956158476311046124934597861626299416732205795533726326734482449215730132757595422510465791525610410023802664753402501982524443370512346073948799084936298007821432734720004795146875180123558814648586972474376192000")
 
 # check type-stability
-prod2(itr) = invoke(prod, (Any,), itr)
+prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test prod(Int[]) === prod2(Int[]) === 1
 @test prod(Int[7]) === prod2(Int[7]) === 7
 @test typeof(prod(Int8[])) == typeof(prod(Int8[1])) == typeof(prod(Int8[1, 7])) == Int

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1043,7 +1043,7 @@ let f =IOBuffer(),
     x = split("1 2 3")
     @test write(f, x) == 3
     @test takebuf_string(f) == "123"
-    @test invoke(write, (IO, AbstractArray), f, x) == 3
+    @test invoke(write, Tuple{IO, AbstractArray}, f, x) == 3
     @test takebuf_string(f) == "123"
 end
 


### PR DESCRIPTION
Replace all `invoke(f, (...), ...)` with `invoke(f, Tuple{...}, ...)`

If the CI fails, it's probably either a typo or a bug.
