### PR TITLE
RFC: warn and don't import when two `usings` provide the same name

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -1079,6 +1079,7 @@ DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
 DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
 DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from);
 DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
+DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s);
 DLLEXPORT jl_module_t *jl_new_main_module(void);
 DLLEXPORT void jl_add_standard_imports(jl_module_t *m);
 STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -314,11 +314,12 @@ static jl_module_t *eval_import_path_(jl_array_t *args, int retrying)
         if (jl_binding_resolved_p(m, var)) {
             jl_binding_t *mb = jl_get_binding(m, var);
             jl_module_t *m0 = m;
+            int isimp = jl_is_imported(m, var);
             assert(mb != NULL);
-            if (mb->owner == m0 || mb->imported) {
+            if (mb->owner == m0 || isimp) {
                 m = (jl_module_t*)mb->value;
                 if ((mb->owner == m0 && m != NULL && !jl_is_module(m)) ||
-                    (mb->imported && (m == NULL || !jl_is_module(m))))
+                    (isimp && (m == NULL || !jl_is_module(m))))
                     jl_errorf("invalid module path (%s does not name a module)", var->name);
                 // If the binding has been resolved but is (1) undefined, and (2) owned
                 // by the module we're importing into, then allow the import into the


### PR DESCRIPTION
fixes #4345

Does the following:

```
julia> module A
       export foo
       foo() = 1
       end

julia> module B
       export foo
       foo() = 2
       end

julia> using A

julia> using B

julia> foo()
Warning: both B and A export foo; uses of it in module Main must be qualified
ERROR: UndefVarError: foo not defined
```

`importall` is a bit of a different story. It's hard to provide the same behavior there, since it's an imperative: the names are imported right when the importall statement runs. Fortunately it's used far less often than `using`, and we already give a warning for conflicts in that case.

Will update news and docs if this is to be merged.
