### PR TITLE
Type instability in collect

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -252,7 +252,7 @@ convert{T,n,S}(::Type{Array{T,n}}, x::Array{S,n}) = copy!(similar(x,T), x)
 
 promote_rule{T,n,S}(::Type{Array{T,n}}, ::Type{Array{S,n}}) = Array{promote_type(T,S),n}
 
-function collect(T::Type, itr)
+function collect{T}(::Type{T}, itr)
     if applicable(length, itr)
         # when length() isn't defined this branch might pollute the
         # type of the other.


### PR DESCRIPTION
``` julia
julia> function collect_range()
           collect(1:2)
           @time collect(1:1_000_000)
       end
collect_range (generic function with 1 method)

julia> function collect_array()
           collect([1,2])
           arr = [i for i=1:1_000_000]
           @time collect(arr)
       end
collect_array (generic function with 1 method)

julia> collect_range();
elapsed time: 0.010505716 seconds (7 MB allocated)

julia> collect_array();
elapsed time: 0.085192319 seconds (68 MB allocated, 3.53% gc time in 3 pauses with 0 full sweep)
```

There's no point in looping over the array in the second case, since it's already "an array of all items in a collection". So does making `collect(v::Vector)` just return `v` seem reasonable? The only thing I can think of is that people might expect `collect()` to return a copy. 
