### PR TITLE
doc: `@time f_improved` results

### DIFF
--- a/doc/manual/performance-tips.rst
+++ b/doc/manual/performance-tips.rst
@@ -86,11 +86,10 @@ generated for your function is far from optimal. Take such indications
 seriously and follow the advice below.
 
 As a teaser, note that an improved version of this function allocates
-no memory (except to pass back the result back to the REPL) and has
-thirty-fold faster execution::
+no additional memory and has thirty-fold faster execution::
 
     julia> @time f_improved(10^6)
-    elapsed time: 0.00253829 seconds (112 bytes allocated)
+    elapsed time: 0.00253829 seconds (75344 bytes allocated)
     2.5000025e11
 
 Below you'll learn how to spot the problem with ``f`` and how to fix it.


### PR DESCRIPTION
In the [Performance Tips example](https://github.com/JuliaLang/julia/blob/master/doc/manual/performance-tips.rst#measure-performance-with-objtime-and-pay-attention-to-memory-allocation), I was unable to obtain `112 bytes allocated` for `f_improved` (all I did was change `s = 0` to `s = 0.0`) except on **repeated** calls to `@time f_improved(10^6)`... Repeated calls also change the memory allocated for `@time f(1)`...

Here are my results, using 64-bit Julia 0.3.7 on Windows 8.1:

```
julia> function f_improved(n)
           s = 0.0
           # rest of function unchanged... is that really all it takes?
       end

julia> @time f(1)       # manual: (93784 bytes allocated)
elapsed time: 0.004260129 seconds (90824 bytes allocated)

julia> @time f(1)       # results change on repeated call
elapsed time: 2.45e-6 seconds (80 bytes allocated)

julia> @time f(10^6)    # manual: (32002136 bytes allocated)
elapsed time: 0.052752041 seconds (32003256 bytes allocated, 20.53% gc time)

julia> @time f_improved(10^6)   # (112 bytes allocated) in manual
elapsed time: 0.004055749 seconds (75344 bytes allocated)

julia> @time f_improved(10^6)
elapsed time: 0.000867914 seconds (112 bytes allocated)
```

You probably won't want to keep my `75344` number in the manual though, since my other results were all slightly different...

Other possibilities
- Am I missing something for `f_improved`?  If so, please consider "open-sourcing" it in the manual explicitly
- Maybe this is a platform-dependent (Windows-only) issue? But my other numbers for `@time f` are all pretty close...

Thank you!
