### PR TITLE
Inline callsite of invoke when possible (`invoke` improvement No. 1)

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1675,6 +1675,89 @@ DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_function_t *gf, jl_datatype_t *type
     return (jl_value_t*)m;
 }
 
+static jl_function_t*
+invoke_specialize(jl_methlist_t *m, jl_methtable_t *mt, jl_tupletype_t *tt)
+{
+    jl_svec_t *tpenv = jl_emptysvec;
+    jl_tupletype_t *newsig = NULL;
+    JL_GC_PUSH2(&tpenv, &newsig);
+
+    if (m->invokes == (void*)jl_nothing) {
+        m->invokes = new_method_table(mt->name);
+        gc_wb(m, m->invokes);
+        update_max_args(m->invokes, tt);
+        // this private method table has just this one definition
+        jl_method_list_insert(&m->invokes->defs, m->sig, m->func,
+                              m->tvars, 0, 0, (jl_value_t*)m->invokes);
+    }
+
+    newsig = m->sig;
+
+    if (m->tvars != jl_emptysvec) {
+        jl_value_t *ti = lookup_match((jl_value_t*)tt, (jl_value_t*)m->sig,
+                                      &tpenv, m->tvars);
+        assert(ti != (jl_value_t*)jl_bottom_type);
+        (void)ti;
+        // don't bother computing this if no arguments are tuples
+        for (size_t i = 0;i < jl_nparams(tt);i++) {
+            if (jl_is_tuple_type(jl_tparam(tt, i))) {
+                newsig = (jl_tupletype_t*)jl_instantiate_type_with(
+                    (jl_value_t*)m->sig,
+                    jl_svec_data(tpenv),
+                    jl_svec_len(tpenv) / 2);
+                break;
+            }
+        }
+    }
+    jl_function_t *mfunc =
+        cache_method(m->invokes, tt, m->func, newsig, tpenv, m->isstaged);
+    JL_GC_POP();
+    return mfunc;
+}
+
+// compile-time method lookup
+jl_function_t*
+jl_gf_invoke_get_specialization(jl_function_t *gf, jl_tupletype_t *types,
+                                jl_tupletype_t *tt)
+{
+    assert(jl_is_gf(gf));
+    jl_methtable_t *mt = jl_gf_mtable(gf);
+    jl_methlist_t *m = (jl_methlist_t*)jl_gf_invoke_lookup(gf, types);
+    size_t i;
+
+    if ((jl_value_t*)m == jl_nothing) {
+        return NULL;
+    }
+
+    // now we have found the matching definition.
+    // next look for or create a specialization of this definition.
+
+    jl_function_t *mfunc;
+    if (m->invokes == (void*)jl_nothing)
+        mfunc = jl_bottom_func;
+    else
+        mfunc = jl_method_table_assoc_exact_by_type(m->invokes, tt);
+    JL_GC_PUSH1(&mfunc);
+    if (mfunc != jl_bottom_func) {
+        if (mfunc->linfo == NULL || mfunc->linfo->inInference ||
+            mfunc->linfo->inCompile) {
+            JL_GC_POP();
+            return NULL;
+        }
+    } else {
+        mfunc = invoke_specialize(m, mt, tt);
+    }
+    if (mfunc->linfo->functionObject == NULL) {
+        if (mfunc->fptr != &jl_trampoline) {
+            JL_GC_POP();
+            return NULL;
+        }
+        jl_compile(mfunc);
+    }
+    JL_GC_POP();
+    return mfunc;
+}
+
 // invoke()
 // this does method dispatch with a set of types to match other than the
 // types of the actual arguments. this means it sometimes does NOT call the
@@ -1721,38 +1804,9 @@ jl_value_t *jl_gf_invoke(jl_function_t *gf, jl_tupletype_t *types,
         }
     }
     else {
-        jl_svec_t *tpenv=jl_emptysvec;
-        jl_tupletype_t *newsig=NULL;
-        jl_tupletype_t *tt=NULL;
-        JL_GC_PUSH3(&tpenv, &newsig, &tt);
-        tt = arg_type_tuple(args, nargs);
-        if (m->invokes == (void*)jl_nothing) {
-            m->invokes = new_method_table(mt->name);
-            gc_wb(m, m->invokes);
-            update_max_args(m->invokes, tt);
-            // this private method table has just this one definition
-            jl_method_list_insert(&m->invokes->defs,m->sig,m->func,m->tvars,0,0,(jl_value_t*)m->invokes);
-        }
-
-        newsig = m->sig;
-
-        if (m->tvars != jl_emptysvec) {
-            jl_value_t *ti =
-                lookup_match((jl_value_t*)tt, (jl_value_t*)m->sig, &tpenv, m->tvars);
-            assert(ti != (jl_value_t*)jl_bottom_type);
-            (void)ti;
-            // don't bother computing this if no arguments are tuples
-            for(i=0; i < jl_nparams(tt); i++) {
-                if (jl_is_tuple_type(jl_tparam(tt,i)))
-                    break;
-            }
-            if (i < jl_nparams(tt)) {
-                newsig = (jl_tupletype_t*)jl_instantiate_type_with((jl_value_t*)m->sig,
-                                                                   jl_svec_data(tpenv),
-                                                                   jl_svec_len(tpenv)/2);
-            }
-        }
-        mfunc = cache_method(m->invokes, tt, m->func, newsig, tpenv, m->isstaged);
+        jl_tupletype_t *tt = arg_type_tuple(args, nargs);
+        JL_GC_PUSH1(&tt);
+        mfunc = invoke_specialize(m, mt, tt);
         JL_GC_POP();
     }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -130,6 +130,9 @@ DLLEXPORT void jl_read_sonames(void);
 jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t *sp);
 jl_function_t *jl_get_specialization(jl_function_t *f, jl_tupletype_t *types);
 jl_function_t *jl_module_get_initializer(jl_module_t *m);
+jl_function_t *jl_gf_invoke_get_specialization(jl_function_t *gf,
+                                               jl_tupletype_t *types,
+                                               jl_tupletype_t *tt);
 void jl_generate_fptr(jl_function_t *f);
 void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig);
 


### PR DESCRIPTION
This is the refactor of my previous attempt to improve the performance of invoke (#9642).

As I mentioned [on the mailing list](https://groups.google.com/forum/#!topic/julia-dev/uBd1dmZx-AM), the previous PR need to be refactored and I decide to start sth relatively self-contained and (hopefully) decoupled from other parts. Hopefully this can also make it easier to be reviewed.

The patch only deal with the new signature of `invoke` (i.e. the second parameter is a tuple type rather than a tuple of types) mainly because it's much easier to handle. It should not do anything for the old signature.

Thanks @vtjnash for very helpful suggestions.

Tested with the following script.

``` julia
@noinline f1(a, b) = a + b

g1_1() = f1(1, 2)
g1_2() = invoke(f1, Tuple{Any, Any}, 1, 2)

@assert g1_1() == g1_2()

@code_llvm g1_1()
@code_llvm g1_2()
```

Output on current master

``` llvm
define i64 @julia_g1_1_43908() {
top:
  %0 = call i64 @julia_f1_43896(i64 1, i64 2)
  ret i64 %0
}

define i64 @julia_g1_2_43911() {
top:
  %0 = alloca [6 x %jl_value_t*], align 8
  %.sub = getelementptr inbounds [6 x %jl_value_t*]* %0, i64 0, i64 0
  %1 = getelementptr [6 x %jl_value_t*]* %0, i64 0, i64 2
  %2 = bitcast [6 x %jl_value_t*]* %0 to i64*
  store i64 8, i64* %2, align 8
  %3 = getelementptr [6 x %jl_value_t*]* %0, i64 0, i64 1
  %4 = bitcast %jl_value_t** %3 to %jl_value_t***
  %5 = load %jl_value_t*** @jl_pgcstack, align 8
  store %jl_value_t** %5, %jl_value_t*** %4, align 8
  store %jl_value_t** %.sub, %jl_value_t*** @jl_pgcstack, align 8
  store %jl_value_t* null, %jl_value_t** %1, align 8
  %6 = getelementptr [6 x %jl_value_t*]* %0, i64 0, i64 3
  store %jl_value_t* null, %jl_value_t** %6, align 8
  %7 = getelementptr [6 x %jl_value_t*]* %0, i64 0, i64 4
  store %jl_value_t* null, %jl_value_t** %7, align 8
  %8 = getelementptr [6 x %jl_value_t*]* %0, i64 0, i64 5
  store %jl_value_t* null, %jl_value_t** %8, align 8
  %9 = load %jl_value_t** inttoptr (i64 140525719411568 to %jl_value_t**), align 16
  store %jl_value_t* %9, %jl_value_t** %1, align 8
  %10 = load %jl_value_t** inttoptr (i64 140525686087088 to %jl_value_t**), align 16
  store %jl_value_t* %10, %jl_value_t** %6, align 8
  %11 = load %jl_value_t** inttoptr (i64 140525686091216 to %jl_value_t**), align 16
  store %jl_value_t* %11, %jl_value_t** %7, align 8
  %12 = load %jl_value_t** inttoptr (i64 140525686091216 to %jl_value_t**), align 16
  store %jl_value_t* %12, %jl_value_t** %8, align 8
  %13 = call %jl_value_t* @jl_f_instantiate_type(%jl_value_t* null, %jl_value_t** %6, i32 3)
  store %jl_value_t* %13, %jl_value_t** %6, align 8
  store %jl_value_t* inttoptr (i64 140525686161872 to %jl_value_t*), %jl_value_t** %7, align 8
  store %jl_value_t* inttoptr (i64 140525686161968 to %jl_value_t*), %jl_value_t** %8, align 8
  %14 = call %jl_value_t* @jl_f_invoke(%jl_value_t* null, %jl_value_t** %1, i32 4)
  %15 = bitcast %jl_value_t* %14 to i64*
  %16 = load i64* %15, align 8
  %17 = load %jl_value_t*** %4, align 8
  store %jl_value_t** %17, %jl_value_t*** @jl_pgcstack, align 8
  ret i64 %16
}
```

With this patch

``` llvm
define i64 @julia_g1_1_43911() {
top:
  %0 = call i64 @julia_f1_43899(i64 1, i64 2)
  ret i64 %0
}

define i64 @julia_g1_2_43914() {
top:
  %0 = call i64 @julia_f1_43899(i64 1, i64 2)
  ret i64 %0
}
```
