### PR TITLE
RFC: Clean up references to LLVM < 3.3

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -473,12 +473,7 @@ llvm-$(LLVM_VER)/python2_path:
 	/usr/bin/python2 -c 'import sys; sys.exit(not sys.version_info < (3, 0))' && \
 	ln -sf /usr/bin/python2 "llvm-$(LLVM_VER)/python2_path/python" && \
 	ln -sf /usr/bin/python2-config "llvm-$(LLVM_VER)/python2_path/python-config"
-ifeq ($(LLVM_VER), 3.2)
-## LLVM needs python 2.x, but doesn't check for it, so we have to use an ugly workaround to make it compile
-llvm_python_workaround=llvm-$(LLVM_VER)/python2_path
-else
-  LLVM_FLAGS += --with-python="$(shell ./find_python2)"
-endif
+LLVM_FLAGS += --with-python="$(shell ./find_python2)"
 # LLDB still relies on plenty of python 2.x infrastructure, without checking
 ifeq ($(BUILD_LLDB),1)
 llvm_python_workaround=llvm-$(LLVM_VER)/python2_path

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -99,14 +99,10 @@ static GlobalVariable *stringConst(const std::string &txt)
                                 ArrayType::get(T_int8, txt.length()+1),
                                 true,
                                 imaging_mode ? GlobalVariable::PrivateLinkage : GlobalVariable::ExternalLinkage,
-#ifndef LLVM_VERSION_MAJOR
-                                ConstantArray::get(getGlobalContext(), txt.c_str()),
-#elif LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 1
                                 ConstantDataArray::get(getGlobalContext(),
                                                        ArrayRef<unsigned char>(
                                                        (const unsigned char*)txt.c_str(),
                                                        txt.length()+1)),
-#endif
                                 vname);
         gv->setUnnamedAddr(true);
         stringConstants[txt] = gv;

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -9,18 +9,12 @@
 #include <llvm/DebugInfo/DIContext.h>
 #endif
 #include <llvm/Support/MemoryBuffer.h>
-#ifdef LLVM33
 #include <llvm/IR/Function.h>
 #include <llvm/ADT/StringRef.h>
-#else
-#include <llvm/Function.h>
-#endif
 #ifdef LLVM35
 #include <llvm/IR/DebugInfo.h>
-#elif defined(LLVM32)
-#include <llvm/DebugInfo.h>
 #else
-#include <llvm/Analysis/DebugInfo.h>
+#include <llvm/DebugInfo.h>
 #endif
 #ifdef USE_MCJIT
 #ifndef LLVM36

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -64,11 +64,7 @@
 #include <llvm/Support/system_error.h>
 #endif
 #include <llvm/ExecutionEngine/JITEventListener.h>
-#ifdef LLVM33
 #include <llvm/IR/LLVMContext.h>
-#else
-#include <llvm/LLVMContext.h>
-#endif
 #ifdef LLVM37
 #include <llvm/DebugInfo/DWARF/DIContext.h>
 #else
@@ -76,10 +72,8 @@
 #endif
 #ifdef LLVM35
 #include <llvm/IR/DebugInfo.h>
-#elif defined(LLVM32)
-#include <llvm/DebugInfo.h>
 #else
-#include <llvm/Analysis/DebugInfo.h>
+#include <llvm/DebugInfo.h>
 #endif
 #ifndef LLVM37
 #define format_hex(v, d) format("%#0" #d "x", v)

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -19,18 +19,6 @@
 
 #if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 3
 #define LLVM33 1
-#endif
-
-#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 2
-#define LLVM32 1
-#endif
-
-#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 1
-#define LLVM31 1
-#endif
-
-#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 0
-#define LLVM30 1
 #else
-#error LLVM versions < 3.0 are not supported by Julia
+#error LLVM versions < 3.3 are not supported by Julia
 #endif


### PR DESCRIPTION
[Sorry, hit enter too soon as I was typing this]

I believe this is what @tkelman was referring to [here](https://github.com/JuliaLang/julia/pull/10975#issuecomment-95797626).  ~~I'd still like to double check everything before this gets merged.~~

The obvious downside of merging this is that is may lead to some merge conflicts here and there.
