### PR TITLE
Fix memory leak in jl_getaddrinfo

### DIFF
--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -210,6 +210,7 @@ DLLEXPORT void jl_uv_connectioncb(uv_stream_t *stream, int status)
 DLLEXPORT void jl_uv_getaddrinfocb(uv_getaddrinfo_t *req,int status, struct addrinfo *addr)
 {
     JULIA_CB(getaddrinfo,req->data,2,CB_PTR,addr,CB_INT32,status);
+    free(req);
 }
 
 DLLEXPORT void jl_uv_asynccb(uv_handle_t *handle)


### PR DESCRIPTION
This one should be fairly non-controversial (but feel free to grill me on it!) :)

The memory is allocated [here](https://github.com/JuliaLang/julia/blob/3961eed0aa8b7e606de355833f215acbf01490b9/src/jl_uv.c#L736).  There are other callback functions in the same file that call `free` already; this is the only one that is missing its `free`.
