### PR TITLE
Fix ambiguous method warning printing

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1603,6 +1603,34 @@ DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v)
     return jl_static_show_x(out, v, 0);
 }
 
+DLLEXPORT size_t
+jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type)
+{
+    if (!jl_is_tuple_type(type)) {
+        return jl_static_show(s, type);
+    }
+    size_t n = 0;
+    size_t tl = jl_nparams(type);
+    n += jl_printf(s, "(");
+    size_t i;
+    for (i = 0;i < tl;i++) {
+        jl_value_t *tp = jl_tparam(type, i);
+        if (i != tl - 1) {
+            n += jl_static_show(s, tp);
+            n += jl_printf(s, ", ");
+        } else {
+            if (jl_is_vararg_type(tp)) {
+                n += jl_static_show(s, jl_tparam0(tp));
+                n += jl_printf(s, "...");
+            } else {
+                n += jl_static_show(s, tp);
+            }
+        }
+    }
+    n += jl_printf(s, ")");
+    return n;
+}
+
 int in_jl_ = 0;
 DLLEXPORT void jl_(void *jl_value)
 {

--- a/src/gf.c
+++ b/src/gf.c
@@ -422,7 +422,7 @@ void jl_type_infer(jl_lambda_info_t *li, jl_tupletype_t *argtypes, jl_lambda_inf
         fargs[3] = (jl_value_t*)def;
 #ifdef TRACE_INFERENCE
         jl_printf(JL_STDERR,"inference on %s", li->name->name);
-        jl_static_show(JL_STDERR, (jl_value_t*)argtypes);
+        jl_static_show_func_sig(JL_STDERR, (jl_value_t*)argtypes);
         jl_printf(JL_STDERR, "\n");
 #endif
 #ifdef ENABLE_INFERENCE
@@ -852,7 +852,7 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tupletype_t *type,
         if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_OFF) {
             if (method->linfo->unspecialized == NULL) {
                 jl_printf(JL_STDERR,"code missing for %s", method->linfo->name->name);
-                jl_static_show(JL_STDERR, (jl_value_t*)type);
+                jl_static_show_func_sig(JL_STDERR, (jl_value_t*)type);
                 jl_printf(JL_STDERR, "  sysimg may not have been built with --compile=all\n");
                 exit(1);
             }
@@ -1147,6 +1147,33 @@ DLLEXPORT int jl_args_morespecific(jl_value_t *a, jl_value_t *b)
 
 void print_func_loc(JL_STREAM *s, jl_lambda_info_t *li);
 
+static void
+show_func_sig(JL_STREAM *s, jl_value_t *errstream, jl_value_t *type)
+{
+    if (!jl_is_tuple_type(type)) {
+        jl_show(errstream, type);
+        return;
+    }
+    size_t tl = jl_nparams(type);
+    jl_printf(s, "(");
+    size_t i;
+    for (i = 0;i < tl;i++) {
+        jl_value_t *tp = jl_tparam(type, i);
+        if (i != tl - 1) {
+            jl_show(errstream, tp);
+            jl_printf(s, ", ");
+        } else {
+            if (jl_is_vararg_type(tp)) {
+                jl_show(errstream, jl_tparam0(tp));
+                jl_printf(s, "...");
+            } else {
+                jl_show(errstream, tp);
+            }
+        }
+    }
+    jl_printf(s, ")");
+}
+
 /*
   warn about ambiguous method priorities
 
@@ -1203,13 +1230,13 @@ static void check_ambiguous(jl_methlist_t *ml, jl_tupletype_t *type,
         errstream = jl_stderr_obj();
         s = JL_STDERR;
         jl_printf(s, "Warning: New definition \n    %s", n);
-        jl_show(errstream, (jl_value_t*)type);
+        show_func_sig(s, errstream, (jl_value_t*)type);
         print_func_loc(s, linfo);
         jl_printf(s, "\nis ambiguous with: \n    %s", n);
-        jl_show(errstream, (jl_value_t*)sig);
+        show_func_sig(s, errstream, (jl_value_t*)sig);
         print_func_loc(s, oldmeth->func->linfo);
         jl_printf(s, ".\nTo fix, define \n    %s", n);
-        jl_show(errstream, isect);
+        show_func_sig(s, errstream, isect);
         jl_printf(s, "\nbefore the new definition.\n");
     done_chk_amb:
         JL_GC_POP();
@@ -1247,7 +1274,7 @@ jl_methlist_t *jl_method_list_insert(jl_methlist_t **pml, jl_tupletype_t *type,
                 jl_value_t *errstream = jl_stderr_obj();
                 JL_STREAM *s = JL_STDERR;
                 jl_printf(s, "Warning: Method definition %s", method->linfo->name->name);
-                jl_show(errstream, (jl_value_t*)type);
+                show_func_sig(s, errstream, (jl_value_t*)type);
                 jl_printf(s, " in module %s", l->func->linfo->module->name->name);
                 print_func_loc(s, l->func->linfo);
                 jl_printf(s, " overwritten in module %s", newmod->name->name);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1491,6 +1491,7 @@ DLLEXPORT void jl_flush_cstdio(void);
 DLLEXPORT jl_value_t *jl_stdout_obj(void);
 DLLEXPORT jl_value_t *jl_stderr_obj(void);
 DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v);
+DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type);
 DLLEXPORT void jlbacktrace(void);
 
 #if defined(GC_FINAL_STATS) && defined(JL_GC_MARKSWEEP)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -117,3 +117,18 @@ end
 immutable NoMethodHasThisType end
 @test isempty(methodswith(NoMethodHasThisType))
 @test !isempty(methodswith(Int))
+
+# PR #10984
+let
+    redir_err = "redirect_stderr(STDOUT)"
+    exename = joinpath(JULIA_HOME, Base.julia_exename())
+    script = "$redir_err; f(a::Number, b...) = 1;f(a, b::Number) = 1"
+    warning_str = readall(`$exename -f -e $script`)
+    @test contains(warning_str, "f(Any, Number)")
+    @test contains(warning_str, "f(Number, Any...)")
+    @test contains(warning_str, "f(Number, Number)")
+
+    script = "$redir_err; module A; f() = 1; end; A.f() = 1"
+    warning_str = readall(`$exename -f -e $script`)
+    @test contains(warning_str, "f()")
+end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -119,7 +119,8 @@ immutable NoMethodHasThisType end
 @test !isempty(methodswith(Int))
 
 # PR #10984
-let
+# Disable on windows because of issue (missing flush) when redirecting STDERR.
+@unix_only let
     redir_err = "redirect_stderr(STDOUT)"
     exename = joinpath(JULIA_HOME, Base.julia_exename())
     script = "$redir_err; f(a::Number, b...) = 1;f(a, b::Number) = 1"


### PR DESCRIPTION
Warning printing before

``` julia
julia> f(a::Any, b::Real) = 1
f (generic function with 1 method)

julia> f(a::Number, b::Any...) = 1
Warning: New definition 
    fTuple{Number,Vararg{Any}} at none:1
is ambiguous with: 
    fTuple{Any,Real} at none:1.
To fix, define 
    fTuple{Number,Real}
before the new definition.
f (generic function with 2 methods)
```

After

``` julia
julia> f(a::Any, b::Real) = 1
f (generic function with 1 method)

julia> f(a::Number, b::Any...) = 1
Warning: New definition 
    f(Number, Any...) at none:1
is ambiguous with: 
    f(Any, Real) at none:1.
To fix, define 
    f(Number, Real)
before the new definition.
f (generic function with 2 methods)
```
