### PR TITLE
Change some arguments from `T::Type` → `::Type{T}`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -665,7 +665,7 @@ function cat(catdims, X...)
     cat_t(catdims, T, X...)
 end
 
-function cat_t(catdims, typeC::Type, X...)
+function cat_t{typeC}(catdims, ::Type{typeC}, X...)
     catdims = collect(catdims)
     nargs = length(X)
     ndimsX = Int[isa(a,AbstractArray) ? ndims(a) : 0 for a in X]
@@ -711,8 +711,8 @@ end
 vcat(X...) = cat(1, X...)
 hcat(X...) = cat(2, X...)
 
-typed_vcat(T::Type, X...) = cat_t(1, T, X...)
-typed_hcat(T::Type, X...) = cat_t(2, T, X...)
+typed_vcat{T}(::Type{T}, X...) = cat_t(1, T, X...)
+typed_hcat{T}(::Type{T}, X...) = cat_t(2, T, X...)
 
 cat{T}(catdims, A::AbstractArray{T}...) = cat_t(catdims, T, A...)
 
@@ -721,8 +721,8 @@ cat(catdims, A::AbstractArray...) = cat_t(catdims, promote_eltype(A...), A...)
 vcat(A::AbstractArray...) = cat(1, A...)
 hcat(A::AbstractArray...) = cat(2, A...)
 
-typed_vcat(T::Type, A::AbstractArray...) = cat_t(1, T, A...)
-typed_hcat(T::Type, A::AbstractArray...) = cat_t(2, T, A...)
+typed_vcat{T}(::Type{T}, A::AbstractArray...) = cat_t(1, T, A...)
+typed_hcat{T}(::Type{T}, A::AbstractArray...) = cat_t(2, T, A...)
 
 # 2d horizontal and vertical concatenation
 
@@ -814,7 +814,7 @@ function hvcat_fill(a, xs)
     a
 end
 
-function typed_hvcat(T::Type, rows::Tuple{Vararg{Int}}, xs::Number...)
+function typed_hvcat{T}(::Type{T}, rows::Tuple{Vararg{Int}}, xs::Number...)
     nr = length(rows)
     nc = rows[1]
     for i = 2:nr
@@ -846,7 +846,7 @@ function hvcat(rows::Tuple{Vararg{Int}}, as...)
     vcat(rs...)
 end
 
-function typed_hvcat(T::Type, rows::Tuple{Vararg{Int}}, as...)
+function typed_hvcat{T}(::Type{T}, rows::Tuple{Vararg{Int}}, as...)
     nbr = length(rows)  # number of block rows
     rs = cell(nbr)
     a = 1

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -38,16 +38,16 @@ function countlines(io::IO, eol::Char)
     nl
 end
 
-readdlm(input, T::Type; opts...) = readdlm(input, invalid_dlm, T, '\n'; opts...)
-readdlm(input, dlm::Char, T::Type; opts...) = readdlm(input, dlm, T, '\n'; opts...)
+readdlm{T}(input, ::Type{T}; opts...) = readdlm(input, invalid_dlm, T, '\n'; opts...)
+readdlm{T}(input, dlm::Char, ::Type{T}; opts...) = readdlm(input, dlm, T, '\n'; opts...)
 
 readdlm(input; opts...) = readdlm(input, invalid_dlm, '\n'; opts...)
 readdlm(input, dlm::Char; opts...) = readdlm(input, dlm, '\n'; opts...)
 
 readdlm(input, dlm::Char, eol::Char; opts...) = readdlm_auto(input, dlm, Float64, eol, true; opts...)
-readdlm(input, dlm::Char, T::Type, eol::Char; opts...) = readdlm_auto(input, dlm, T, eol, false; opts...)
+readdlm{T}(input, dlm::Char, ::Type{T}, eol::Char; opts...) = readdlm_auto(input, dlm, T, eol, false; opts...)
 
-function readdlm_auto(input, dlm::Char, T::Type, eol::Char, auto::Bool; opts...)
+function readdlm_auto{T}(input, dlm::Char, ::Type{T}, eol::Char, auto::Bool; opts...)
     optsd = val_opts(opts)
     use_mmap = get(optsd, :use_mmap, @windows ? false : true)
     isa(input, AbstractString) && (fsz = filesize(input); input = use_mmap && (fsz > 0) && fsz < typemax(Int) ? as_mmap(input,fsz) : readall(input))
@@ -241,7 +241,7 @@ function result{T}(dlmstore::DLMStore{T})
 end
 
 
-function readdlm_string(sbuff::ByteString, dlm::Char, T::Type, eol::Char, auto::Bool, optsd::Dict)
+function readdlm_string{T}(sbuff::ByteString, dlm::Char, ::Type{T}, eol::Char, auto::Bool, optsd::Dict)
     ign_empty = (dlm == invalid_dlm)
     quotes = get(optsd, :quotes, true)
     comments = get(optsd, :comments, true)
@@ -298,7 +298,7 @@ function val_opts(opts)
     d
 end
 
-function dlm_fill(T::DataType, offarr::Vector{Vector{Int}}, dims::NTuple{2,Integer}, has_header::Bool, sbuff::ByteString, auto::Bool, eol::Char)
+function dlm_fill{T}(::Type{T}, offarr::Vector{Vector{Int}}, dims::NTuple{2,Integer}, has_header::Bool, sbuff::ByteString, auto::Bool, eol::Char)
     idx = 1
     offidx = 1
     offsets = offarr[1]
@@ -530,7 +530,7 @@ function dlm_parse{T,D}(dbuff::T, eol::D, dlm::D, qchar::D, cchar::D, ign_adj_dl
 end
 
 readcsv(io; opts...)          = readdlm(io, ','; opts...)
-readcsv(io, T::Type; opts...) = readdlm(io, ',', T; opts...)
+readcsv{T}(io, ::Type{T}; opts...) = readdlm(io, ',', T; opts...)
 
 # todo: keyword argument for # of digits to print
 writedlm_cell(io::IO, elt::FloatingPoint, dlm, quotes) = print_shortest(io, elt)


### PR DESCRIPTION
Some of these were likely doing just fine because they got inlined (in which case I think this change is purely cosmetic).  And while this may cause more specialized methods to be compiled, I believe that these are cases where we want them to be specialized.  That said, I'm unfamiliar with these portions of the codebase (cc @Jutho for concatenation, @tanmaykm for readdlm) and these were purely mechanical changes spurred by #10988 (`ack '::(Data)?Type[^{]' base`).

This may help readdlm performance (#10428), but I've done no testing.
