### PR TITLE
fix #10958: buggy handling of embedded NUL chars

### DIFF
--- a/base/string.jl
+++ b/base/string.jl
@@ -541,8 +541,6 @@ startswith(a::Array{UInt8,1}, b::Array{UInt8,1}) =
 ## character column width function ##
 
 strwidth(s::AbstractString) = (w=0; for c in s; w += charwidth(c); end; w)
-strwidth(s::ByteString) = Int(ccall(:u8_strwidth, Csize_t, (Ptr{UInt8},), s.data))
-# TODO: implement and use u8_strnwidth that takes a length argument
 
 isascii(c::Char) = c < Char(0x80)
 isascii(s::AbstractString) = all(isascii, s)

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -37,7 +37,8 @@ function endof(s::UTF8String)
     end
     i
 end
-length(s::UTF8String) = Int(ccall(:u8_strlen, Csize_t, (Ptr{UInt8},), s.data))
+length(s::UTF8String) = Int(ccall(:u8_charnum, Csize_t, (Ptr{UInt8}, Csize_t),
+                                  s.data, length(s.data)))
 
 function next(s::UTF8String, i::Int)
     # potentially faster version

--- a/test/unicode.jl
+++ b/test/unicode.jl
@@ -129,3 +129,8 @@ end
 
 # up-to-date character widths (#3721, #6939)
 @test charwidth('\U1f355') == strwidth("\U1f355") == strwidth(utf16("\U1f355")) == strwidth("\U1f355\u0302") == strwidth(utf16("\U1f355\u0302")) == 2
+
+# handling of embedded NUL chars (#10958)
+@test length("\0w") == length("\0α") == 2
+@test strwidth("\0w") == strwidth("\0α") == 1
+@test normalize_string("\0W", casefold=true) == "\0w"


### PR DESCRIPTION
This fixes the `length("\0w")` bug brought up in #10958 and a couple of related bugs.  (cc @ScottPJones, @jiahao).

Strings with embedded NUL chars are still silently truncated when passed to external C routines in many places (e.g. all of the libuv filesystem routines).  My plan is to submit a separate PR defining new `Cstring` and `Cwstring` types to use in `ccall` (instead of `Ptr{UInt8}` and `Ptr{Cwchar_t}`, respectively) for NUL-terminated strings, which throw an exception on `convert` for strings with embedded NULs.
