### PR TITLE
use `jl_gf_invoke_lookup` in `invoke_tfunc` to lookup the method to be called (`invoke` improvement No. 2)

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -709,26 +709,18 @@ function invoke_tfunc(f, types, argtype)
     if is(argtype,Bottom)
         return Bottom
     end
-    applicable = _methods(f, types, -1)
-    if isempty(applicable)
-        return Any
-    end
-    for (m::SimpleVector) in applicable
-        local linfo
-        try
-            linfo = func_for_method(m[3],types,m[2])
-        catch
+    try
+        meth = ccall(:jl_gf_invoke_lookup, Any, (Any, Any), f, types)
+        if is(meth, nothing)
             return Any
         end
-        if typeseq(m[1],types)
-            tvars = m[2][1:2:end]
-            (ti, env) = ccall(:jl_match_method, Any, (Any,Any,Any),
-                              argtype, m[1], tvars)::SimpleVector
-            (_tree,rt) = typeinf(linfo, ti, env, linfo)
-            return rt
-        end
+        (ti, env) = ccall(:jl_match_method, Any, (Any, Any, Any),
+                          argtype, meth.sig, meth.tvars)::SimpleVector
+        linfo = func_for_method(meth, types, env)
+        return typeinf(linfo, ti, env, linfo)[2]
+    catch
+        return Any
     end
-    return Any
 end
 
 # `types` is an array of inferred types for expressions in `args`.


### PR DESCRIPTION
This is the second one from the break down of my old PR (#9642) to improve the performance of `invoke`. The original commit was [here](https://github.com/yuyichao/julia/commit/b0d5045a7e703de916398a49dcae9a0fb92fc4f8).

This particular commit might not have much impact on the performance but IMHO, since we already have `jl_gf_invoke_lookup` to find the method to be called by invoke, we might as well use it to simplify the code.
