### PR TITLE
Better error message for invoke (rebased) (`invoke` improvement No. 3)

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -124,6 +124,9 @@ showerror(io::IO, ex::ArgumentError) = print(io, "ArgumentError: $(ex.msg)")
 showerror(io::IO, ex::AssertionError) = print(io, "AssertionError: $(ex.msg)")
 
 function showerror(io::IO, ex::MethodError)
+    is_arg_types = isa(ex.args, DataType)
+    arg_types = is_arg_types ? ex.args : typesof(ex.args...)
+    arg_types_param::SimpleVector = arg_types.parameters
     print(io, "MethodError: ")
     if isa(ex.f, Tuple)
         f = ex.f[1]
@@ -137,41 +140,41 @@ function showerror(io::IO, ex::MethodError)
     else
         print(io, "`$(name)` has no method matching $(name)(")
     end
-    for (i, arg) in enumerate(ex.args)
-        if isa(arg, Type) && arg != typeof(arg)
-            print(io, "::Type{$(arg)}")
-        else
-            print(io, "::$(typeof(arg))")
-        end
-        i == length(ex.args) || print(io, ", ")
+    for (i, typ) in enumerate(arg_types_param)
+        print(io, "::$typ")
+        i == length(arg_types_param) || print(io, ", ")
     end
     print(io, ")")
     # Check for local functions that shadow methods in Base
     if isdefined(Base, name)
         basef = eval(Base, name)
-        if basef !== f && isgeneric(basef) && applicable(basef, ex.args...)
+        if basef !== ex.f && isgeneric(basef) && method_exists(basef, arg_types)
             println(io)
             print(io, "you may have intended to import Base.$(name)")
         end
     end
-    # Check for row vectors used where a column vector is intended.
-    vec_args = []
-    hasrows = false
-    for arg in ex.args
-        isrow = isa(arg,Array) && ndims(arg)==2 && size(arg,1)==1
-        hasrows |= isrow
-        push!(vec_args, isrow ? vec(arg) : arg)
-    end
-    if hasrows && applicable(f, vec_args...)
-        print(io, "\n\nYou might have used a 2d row vector where a 1d column vector was required.")
-        print(io, "\nNote the difference between 1d column vector [1,2,3] and 2d row vector [1 2 3].")
-        print(io, "\nYou can convert to a column vector with the vec() function.")
+    if !is_arg_types
+        # Check for row vectors used where a column vector is intended.
+        vec_args = []
+        hasrows = false
+        for arg in ex.args
+            isrow = isa(arg,Array) && ndims(arg)==2 && size(arg,1)==1
+            hasrows |= isrow
+            push!(vec_args, isrow ? vec(arg) : arg)
+        end
+        if hasrows && applicable(f, vec_args...)
+            print(io, "\n\nYou might have used a 2d row vector where a 1d column vector was required.")
+            print(io, "\nNote the difference between 1d column vector [1,2,3] and 2d row vector [1 2 3].")
+            print(io, "\nYou can convert to a column vector with the vec() function.")
+        end
     end
     # Give a helpful error message if the user likely called a type constructor
     # and sees a no method error for convert
-    if f == Base.convert && !isempty(ex.args) && isa(ex.args[1], Type)
+    if (f == Base.convert && !isempty(arg_types_param) &&
+        isa(arg_types_param[1], Type))
+        construct_type = arg_types_param[1].parameters[1]
         println(io)
-        print(io, "This may have arisen from a call to the constructor $(ex.args[1])(...),")
+        print(io, "This may have arisen from a call to the constructor $construct_type(...),")
         print(io, "\nsince type constructors fall back to convert methods.")
     end
     show_method_candidates(io, ex)
@@ -181,6 +184,9 @@ const UNSHOWN_METHODS = ObjectIdDict(
     which(call, Tuple{Type, Vararg{Any}}) => true
 )
 function show_method_candidates(io::IO, ex::MethodError)
+    is_arg_types = isa(ex.args, DataType)
+    arg_types = is_arg_types ? ex.args : typesof(ex.args...)
+    arg_types_param::SimpleVector = arg_types.parameters
     # Displays the closest candidates of the given function by looping over the
     # functions methods and counting the number of matching arguments.
     if isa(ex.f, Tuple)
@@ -217,7 +223,7 @@ function show_method_candidates(io::IO, ex::MethodError)
                 show_delim_array(buf, tv, '{', ',', '}', false)
             end
             print(buf, "(")
-            t_i = Any[Base.REPLCompletions.method_type_of_arg(arg) for arg in ex.args]
+            t_i = Any[arg_types_param...]
             right_matches = 0
             for i = 1 : min(length(t_i), length(sig))
                 i > (use_constructor_syntax ? 2 : 1) && print(buf, ", ")
@@ -259,7 +265,7 @@ function show_method_candidates(io::IO, ex::MethodError)
             if length(t_i) > length(sig) && !isempty(sig) && Base.isvarargtype(sig[end])
                 # It ensures that methods like f(a::AbstractString...) gets the correct
                 # number of right_matches
-                for t in typeof(ex.args).parameters[length(sig):end]
+                for t in arg_types_param[length(sig):end]
                     if t <: sig[end].parameters[1]
                         right_matches += 1
                     end

--- a/src/gf.c
+++ b/src/gf.c
@@ -1301,12 +1301,22 @@ jl_methlist_t *jl_method_table_insert(jl_methtable_t *mt, jl_tupletype_t *type,
     return ml;
 }
 
+void NORETURN jl_no_method_error_bare(jl_function_t *f, jl_value_t *args)
+{
+    jl_value_t *fargs[3] = {
+        (jl_value_t*)jl_methoderror_type,
+        (jl_value_t*)f,
+        args
+    };
+    jl_throw(jl_apply(jl_module_call_func(jl_base_module), fargs, 3));
+    // not reached
+}
+
 void NORETURN jl_no_method_error(jl_function_t *f, jl_value_t **args, size_t na)
 {
     jl_value_t *argtup = jl_f_tuple(NULL, args, na);
     JL_GC_PUSH1(&argtup);
-    jl_value_t *fargs[3] = { (jl_value_t*)jl_methoderror_type, (jl_value_t*)f, argtup };
-    jl_throw(jl_apply(jl_module_call_func(jl_base_module), fargs, 3));
+    jl_no_method_error_bare(f, argtup);
     // not reached
 }
 
@@ -1683,7 +1693,7 @@ jl_value_t *jl_gf_invoke(jl_function_t *gf, jl_tupletype_t *types,
     size_t i;
 
     if ((jl_value_t*)m == jl_nothing) {
-        jl_no_method_error(gf, args, nargs);
+        jl_no_method_error_bare(gf, (jl_value_t*)types);
         // unreachable
     }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -48,6 +48,7 @@ void jl_set_t_uid_ctr(int i);
 uint32_t jl_get_gs_ctr(void);
 void jl_set_gs_ctr(uint32_t ctr);
 
+void NORETURN jl_no_method_error_bare(jl_function_t *f, jl_value_t *args);
 void NORETURN jl_no_method_error(jl_function_t *f, jl_value_t **args, size_t na);
 
 #define JL_CALLABLE(name) \

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -68,3 +68,58 @@ for f in [getindex, setindex!]
     Base.show_method_candidates(buf, MethodError(f,(test_type, 1,1)))
     test_have_color(buf, "", "")
 end
+
+
+function _except_str(expr, err_type=Exception)
+    quote
+        let
+            local err::$(esc(err_type))
+            try
+                $(esc(expr))
+            catch err
+            end
+            err
+            buff = IOBuffer()
+            showerror(buff, err)
+            takebuf_string(buff)
+        end
+    end
+end
+
+macro except_str(args...)
+    _except_str(args...)
+end
+
+# Pull Request 11007
+abstract InvokeType11007
+abstract MethodType11007 <: InvokeType11007
+type InstanceType11007 <: MethodType11007
+end
+let
+    f11007(::MethodType11007) = nothing
+    err_str = @except_str(invoke(f11007, Tuple{InvokeType11007},
+                                 InstanceType11007()), MethodError)
+    @test !contains(err_str, "::InstanceType11007")
+    @test contains(err_str, "::InvokeType11007")
+end
+
+let
+    +() = nothing
+    err_str = @except_str 1 + 2 MethodError
+    @test contains(err_str, "Base.+")
+end
+
+let
+    g11007(::AbstractVector) = nothing
+    err_str = @except_str g11007([[1] [1]])
+    @test contains(err_str, "row vector")
+    @test contains(err_str, "column vector")
+end
+
+abstract T11007
+let
+    err_str = @except_str T11007()
+    @test contains(err_str, "convert")
+    @test contains(err_str, "constructor")
+    @test contains(err_str, "T11007(...)")
+end


### PR DESCRIPTION
Rebase of #9635. I accidently ~~deleted~~ overwrote the branch so this is a new one.

Thanks to the recent change in tuple type, the breackage should be limited to only the `MethodError` raised in `invoke`.

Before

``` julia
julia> k(::Int) = nothing
k (generic function with 1 method)

julia> invoke(k, Tuple{Any}, 1)
ERROR: MethodError: `k` has no method matching k(::Int64)
Closest candidates are:
  k(::Int64)
```

After

``` julia
julia> k(::Int) = nothing
k (generic function with 1 method)

julia> invoke(k, Tuple{Any}, 1)
ERROR: MethodError: `k` has no method matching k(::Any)
Closest candidates are:
  k(::Int64)
```
