### PR TITLE
added `getsockname` for determining a socket name (address & port) of the running server

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -7463,9 +7463,10 @@ true
 all(p, itr)
 
 doc"""
-    bind(socket::Union{UDPSocket, TCPSocket}, host::IPv4, port::Integer)
+    bind(socket::Union{UDPSocket, TCPSocket}, host::IPAddr, port::Integer; ipv6only=false)
 
 Bind `socket` to the given `host:port`. Note that `0.0.0.0` will listen on all devices.
+`ipv6only` parameter disables dual stack mode. If it's `true`, only IPv6 stack is created.
 """
 bind
 
@@ -8474,9 +8475,9 @@ Get the current working directory.
 pwd
 
 doc"""
-    getipaddr() -> AbstractString
+    getipaddr() -> IPAddr
 
-Get the IP address of the local machine, as a string of the form "x.x.x.x".
+Get the IP address of the local machine.
 """
 getipaddr
 
@@ -12031,3 +12032,11 @@ Bitwise exclusive or
 ```
 """
 Base.(:$)(x, y)
+
+doc"""
+    getsockname(sock::Union{TCPServer, TCPSocket}) -> (IPAddr,UInt16)
+
+Get the IP address and the port of the TCP server socket, to which it is bound,
+or the peer connected to the TCP server socket.
+"""
+getsockname

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1152,6 +1152,7 @@ export
     getaddrinfo,
     gethostname,
     getipaddr,
+    getsockname,
     htol,
     hton,
     ismarked,

--- a/base/managers.jl
+++ b/base/managers.jl
@@ -313,10 +313,7 @@ function socket_reuse_port()
             elseif rc < 0
                 throw(SystemError("setsockopt() SO_REUSEPORT : "))
             end
-
-            ccall(:jl_tcp_getsockname_v4, Int32,
-                        (Ptr{Void}, Ref{Cuint}, Ref{Cushort}),
-                        s.handle, client_host, client_port) < 0 && throw(SystemError("getsockname() : "))
+            getsockname(s)
         catch e
             # This is an issue only on systems with lots of client connections, hence delay the warning....
             nworkers() > 128 && warn_once("Error trying to reuse client port number, falling back to plain socket : ", e)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -893,7 +893,7 @@ System
 
    Get the local machine's host name.
 
-.. function:: getipaddr()
+.. function:: getipaddr() -> IPAddr
 
    .. Docstring generated from Julia source
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -893,11 +893,12 @@ System
 
    Get the local machine's host name.
 
-.. function:: getipaddr() -> AbstractString
+.. function:: getipaddr()
 
    .. Docstring generated from Julia source
 
-   Get the IP address of the local machine, as a string of the form "x.x.x.x".
+   Get the IP address of the local machine.
+
 
 .. function:: getpid() -> Int32
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -766,7 +766,7 @@ Memory-mapped I/O
 Network I/O
 -----------
 
-.. function:: connect([host],port) -> TcpSocket
+.. function:: connect([host],port) -> TCPSocket
 
    .. Docstring generated from Julia source
 
@@ -778,7 +778,7 @@ Network I/O
 
    Connect to the Named Pipe / Domain Socket at ``path``
 
-.. function:: listen([addr,]port) -> TcpServer
+.. function:: listen([addr,]port) -> TCPServer
 
    .. Docstring generated from Julia source
 
@@ -795,6 +795,11 @@ Network I/O
    .. Docstring generated from Julia source
 
    Gets the IP address of the ``host`` (may have to do a DNS lookup)
+
+.. function:: getsockname(sock::Union{TCPServer, TCPSocket}) -> (IPAddr,UInt16)
+
+   Get the IP address and the port of the TCP server socket, to which it is bound,
+   or the peer connected to the TCP server socket.
 
 .. function:: parseip(addr)
 
@@ -826,11 +831,11 @@ Network I/O
 
    Accepts a connection on the given server and returns a connection to the client. An uninitialized client stream may be provided, in which case it will be used instead of creating a new stream.
 
-.. function:: listenany(port_hint) -> (UInt16,TcpServer)
+.. function:: listenany(port_hint) -> (UInt16,TCPServer)
 
    .. Docstring generated from Julia source
 
-   Create a TcpServer on any port, using hint as a starting point. Returns a tuple of the actual port that the server was created on and the server itself.
+   Create a TCPServer on any port, using hint as a starting point. Returns a tuple of the actual port that the server was created on and the server itself.
 
 .. function:: poll_fd(fd, timeout_s::Real; readable=false, writable=false)
 

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -185,3 +185,56 @@ if @unix? true : (Base.windows_version() >= Base.WINDOWS_VISTA_VER)
     send(b, ip"::1", port, "Hello World")
     wait(tsk)
 end
+
+begin
+    default_port = UInt16(11011)
+    default_addr = IPv4("127.0.0.1")
+
+    sock = Base.TCPServer()
+    bind(sock,Base.InetAddr(default_addr,default_port))
+    listen(sock)
+
+    new_addr, new_port = getsockname(sock)
+
+    @test default_addr == new_addr
+    @test default_port == new_port
+    close(sock)
+end
+
+begin
+    default_port = UInt16(21011)
+    default_addr = IPv6("::1")
+
+    sock = Base.TCPServer()
+    addr = Base.InetAddr(default_addr,default_port)
+    bind(sock,addr)
+    listen(sock)
+
+    new_addr, new_port = getsockname(sock)
+
+    @test default_addr == new_addr
+    @test default_port == new_port
+    close(sock)
+end
+
+begin
+    default_port = UInt16(11011)
+    default_addr = getipaddr()
+
+    sock = Base.TCPServer()
+    bind(sock,Base.InetAddr(default_addr,default_port))
+    listen(sock)
+
+    @async begin
+        sleep(1)
+        ssock = connect(default_addr, default_port)
+    end
+
+    csock = accept(sock)
+    new_addr, new_port = getsockname(csock)
+
+    @test default_addr == new_addr
+    @test new_port > 0
+    close(csock)
+    close(sock)
+end


### PR DESCRIPTION
I added `getsockname` for determining a socket name (address & port) of the running server. When server socket bound to `INPORT_ANY` port (0), during `listen` call the socket is automatically bound to a random free port. By calling  `getsockname`, you can get value of the assigned port.

In addition, I fixed a missing IPv6 support for `bind` and some documentation.
