### PR TITLE
RFC: Show the PID of each worker when running under valgrind

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -981,6 +981,10 @@ function start_worker(out::IO)
 
     disable_nagle(sock)
 
+    if ccall(:jl_running_on_valgrind,Cint,()) != 0
+        println(out, "PID = $(getpid())")
+    end
+
     try
         # To prevent hanging processes on remote machines, newly launched workers exit if the
         # master process does not connect in time.


### PR DESCRIPTION
When valgrind outputs any warning/error messages, it does so along with a banner of the `getpid()` that the error is coming from.  This is immensely helpful when working to debug programs that fork multiple processes.

This patch causes each such julia worker process to output the `getpid()` of the worker when the worker starts (but only when running under valgrind).  This allows a person to determine which worker number each error/warning comes from.  For instance, given the following (schematic) output, it is now possible to determine that the "invalid read" warning is due to the `linalg1` tests.

```
$ valgrind -q --smc-check=all-non-file --trace-children=yes --suppressions=$PWD/../contrib/valgrind-julia.supp ../julia runtests.jl linalg
    From worker 2:  PID = 12609
    From worker 3:  PID = 12610
==12609== Invalid read of size 16
[snip]
From worker 3:       * linalg2
From worker 3:       * linalg3
From worker 2:       * linalg1
```

I put this patch where I thought it would fit, but I'd be happy to move it if there's a better place.
