### PR TITLE
refine fieldtype_tfunc's computation of Types

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -111,7 +111,7 @@ type WorkerConfig
 
     function WorkerConfig()
         wc = new()
-        for n in fieldnames(WorkerConfig)
+        for n in 1:length(WorkerConfig.types)
             T = eltype(fieldtype(WorkerConfig, n))
             setfield!(wc, n, Nullable{T}())
         end

--- a/test/core.jl
+++ b/test/core.jl
@@ -1614,7 +1614,7 @@ macro m6031(x); x; end
 # issue #6050
 @test Base.getfield_tfunc([nothing, QuoteNode(:vals)],
                           Dict{Int64,Tuple{UnitRange{Int64},UnitRange{Int64}}},
-                          :vals) == Array{Tuple{UnitRange{Int64},UnitRange{Int64}},1}
+                          :vals) == (Array{Tuple{UnitRange{Int64},UnitRange{Int64}},1},true)
 
 # issue #6068
 x6068 = 1


### PR DESCRIPTION
for explicitly untyped fields (such as `::Any` or `::Union(stuff)`), fieldtype can return an exact type rather than a typevar. this helps inference specialize on those fields better.

@JeffBezanson @carnaval can you help review whether i've made any logic errors here before I merge?
