### PR TITLE
Fix Windows XP macro

### DIFF
--- a/base/osutils.jl
+++ b/base/osutils.jl
@@ -55,14 +55,10 @@ end
 
 WINDOWS_XP_VER = (5,1)
 
-macro windowsxp(qm,ex)
-    _os_test(qm, ex, OS_NAME===:Windows && windows_version() <= WINDOWS_XP_VER)
-end
-
 macro windowsxp_only(ex)
-    @windowsxp? esc(ex) : nothing
+    _os_test(:?, Expr(:(:), ex, nothing), OS_NAME===:Windows && windows_version() <= WINDOWS_XP_VER)
 end
 
 macro non_windowsxp_only(ex)
-    @windowsxp? nothing : esc(ex)
+    _os_test(:?, Expr(:(:), nothing, ex), OS_NAME===:Windows && windows_version() <= WINDOWS_XP_VER)
 end

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -16,8 +16,8 @@ end
 dlls = Libdl.dllist()
 @test !isempty(dlls)
 @test length(dlls) > 3 # at a bare minimum, probably have some version of libstdc, libgcc, libjulia, ...
-@test Base.samefile(Libdl.dlpath(dlls[1]), dlls[1])
-@test Base.samefile(Libdl.dlpath(dlls[end]), dlls[end])
+@non_windowsxp_only @test Base.samefile(Libdl.dlpath(dlls[1]), dlls[1])
+@non_windowsxp_only @test Base.samefile(Libdl.dlpath(dlls[end]), dlls[end])
 @test length(filter(dlls) do dl
         return ismatch(Regex("^libjulia(?:.*)\.$(Libdl.dlext)(?:\..+)?\$"), basename(dl))
     end) == 1 # look for something libjulia-like (but only one)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -25,7 +25,7 @@ ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
 # in the mix. If verification needs to be done, keep it to the bare minimum. Basically
 # this should make sure nothing crashes without depending on how exactly the control
 # characters are being used.
-begin
+@non_windowsxp_only begin
 stdin_write, stdout_read, stdout_read, repl = fake_repl()
 
 repl.specialdisplay = Base.REPL.REPLDisplay(repl)
@@ -235,7 +235,7 @@ end
 
 ccall(:jl_exit_on_sigint, Void, (Cint,), 1)
 
-let exename = joinpath(JULIA_HOME, Base.julia_exename())
+@non_windowsxp_only let exename = joinpath(JULIA_HOME, Base.julia_exename())
 
 # Test REPL in dumb mode
 @unix_only begin

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -159,7 +159,7 @@ begin
     close(a)
     close(b)
 end
-begin
+@non_windowsxp_only begin
     a = UDPSocket()
     b = UDPSocket()
     bind(a, ip"::1", UInt16(port))


### PR DESCRIPTION
We probably want to get rid of this macro, along with XP support, at some point. But for now we use it in a handful of places, mostly related to symlinks.

The current implementation is actually broken, since the Windows version check was getting run at system image compile time on the build machines (building Julia from source on XP doesn't work, something in LLVM failed to link IIRC from the last time I tried) instead of at runtime.
