### PR TITLE
Fix #9932

### DIFF
--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -35,6 +35,7 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
     end
     dir = path()
     info("Initializing package repository $dir")
+    temp_dir = mktempdir()
     metadata_dir = joinpath(dir, "METADATA")
     if isdir(metadata_dir)
         info("Package directory $dir is already initialized.")
@@ -42,8 +43,8 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
         return
     end
     try
-        mkpath(dir)
-        Base.cd(dir) do
+        mkpath(temp_dir)
+        Base.cd(temp_dir) do
             info("Cloning METADATA from $meta")
             run(`git clone -q -b $branch $meta METADATA`)
             Git.set_remote_url(meta, dir="METADATA")
@@ -54,8 +55,15 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
                 close(io)
             end
         end
+        #Move TEMP to METADATA
+        mkpath(dir)
+        Base.mv(joinpath(temp_dir,"METADATA"), metadata_dir)
+        Base.mv(joinpath(temp_dir,"REQUIRE"), joinpath(dir,"REQUIRE"))
+        Base.mv(joinpath(temp_dir,"META_BRANCH"), joinpath(dir,"META_BRANCH"))
+        rm(temp_dir)
     catch e
         ispath(metadata_dir) && rm(metadata_dir, recursive=true)
+        ispath(temp_dir) && rm(temp_dir, recursive=true)
         rethrow(e)
     end
 end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -13,8 +13,11 @@ function temp_pkg_dir(fn::Function)
   end
 end
 
-# Test adding a removing a package
+# Test adding or removing a package
+#Also test for the existence of REUIRE and META_Branch
 temp_pkg_dir() do
+  @test isfile(joinpath(Pkg.dir(),"REQUIRE"))
+  @test isfile(joinpath(Pkg.dir(),"META_BRANCH"))
   @test isempty(Pkg.installed())
   Pkg.add("Example")
   @test [keys(Pkg.installed())...] == ["Example"]


### PR DESCRIPTION
This fixes #9932 by first creating a TEMP directory to clone into. Once the clone is complete the contents of TEMP are copied into METADATA.

I am not sure if the comments are excessive. Will prune if necessary.
