### PR TITLE
Coherent map and comprehension, the imminent death of type_goto

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -305,15 +305,15 @@ function getindex(A::Array, I::UnitRange{Int})
     return X
 end
 
-function getindex{T<:Real}(A::Array, I::AbstractVector{T})
-    return [ A[i] for i in to_index(I) ]
+function getindex{T<:Real,V}(A::Array{V}, I::AbstractVector{T})
+    return V[ A[i] for i in to_index(I) ]
 end
-function getindex{T<:Real}(A::Range, I::AbstractVector{T})
-    return [ A[i] for i in to_index(I) ]
+function getindex{T<:Real,V}(A::Range{V}, I::AbstractVector{T})
+    return V[ A[i] for i in to_index(I) ]
 end
-function getindex(A::Range, I::AbstractVector{Bool})
+function getindex{V}(A::Range{V}, I::AbstractVector{Bool})
     checkbounds(A, I)
-    return [ A[i] for i in to_index(I) ]
+    return V[ A[i] for i in to_index(I) ]
 end
 
 
@@ -505,7 +505,9 @@ end
 
 function push!{T}(a::Array{T,1}, item)
     # convert first so we don't grow the array if the assignment won't work
-    item = convert(T, item)
+    if T !== Union()
+        item = convert(T, item)
+    end
     ccall(:jl_array_grow_end, Void, (Any, UInt), a, 1)
     a[end] = item
     return a

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2232,8 +2232,8 @@ end
 
 function vcat(X::SparseMatrixCSC...)
     num = length(X)
-    mX = [ size(x, 1) for x in X ]
-    nX = [ size(x, 2) for x in X ]
+    mX = Int[ size(x, 1) for x in X ]
+    nX = Int[ size(x, 2) for x in X ]
     m = sum(mX)
     n = nX[1]
 
@@ -2250,7 +2250,7 @@ function vcat(X::SparseMatrixCSC...)
         Ti = promote_type(Ti, eltype(X[i].rowval))
     end
 
-    nnzX = [ nnz(x) for x in X ]
+    nnzX = Int[ nnz(x) for x in X ]
     nnz_res = sum(nnzX)
     colptr = Array(Ti, n + 1)
     rowval = Array(Ti, nnz_res)
@@ -2292,8 +2292,8 @@ end
 
 function hcat(X::SparseMatrixCSC...)
     num = length(X)
-    mX = [ size(x, 1) for x in X ]
-    nX = [ size(x, 2) for x in X ]
+    mX = Int[ size(x, 1) for x in X ]
+    nX = Int[ size(x, 2) for x in X ]
     m = mX[1]
     for i = 2 : num
         if mX[i] != m; throw(DimensionMismatch("")); end
@@ -2304,7 +2304,7 @@ function hcat(X::SparseMatrixCSC...)
     Ti = promote_type(map(x->eltype(x.rowval), X)...)
 
     colptr = Array(Ti, n + 1)
-    nnzX = [ nnz(x) for x in X ]
+    nnzX = Int[ nnz(x) for x in X ]
     nnz_res = sum(nnzX)
     rowval = Array(Ti, nnz_res)
     nzval = Array(Tv, nnz_res)
@@ -2342,8 +2342,8 @@ end
 
 function blkdiag(X::SparseMatrixCSC...)
     num = length(X)
-    mX = [ size(x, 1) for x in X ]
-    nX = [ size(x, 2) for x in X ]
+    mX = Int[ size(x, 1) for x in X ]
+    nX = Int[ size(x, 2) for x in X ]
     m = sum(mX)
     n = sum(nX)
 
@@ -2351,7 +2351,7 @@ function blkdiag(X::SparseMatrixCSC...)
     Ti = promote_type(map(x->eltype(x.rowval), X)...)
 
     colptr = Array(Ti, n + 1)
-    nnzX = [ nnz(x) for x in X ]
+    nnzX = Int[ nnz(x) for x in X ]
     nnz_res = sum(nnzX)
     rowval = Array(Ti, nnz_res)
     nzval = Array(Tv, nnz_res)
@@ -2519,7 +2519,7 @@ function trace{Tv}(A::SparseMatrixCSC{Tv})
     s
 end
 
-diag(A::SparseMatrixCSC) = [d for d in SpDiagIterator(A)]
+diag{Tv}(A::SparseMatrixCSC{Tv}) = Tv[d for d in SpDiagIterator(A)]
 
 function diagm{Tv,Ti}(v::SparseMatrixCSC{Tv,Ti})
     if (size(v,1) != 1 && size(v,2) != 1)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2158,6 +2158,7 @@
                          ,@lengths))
         (= ,ri 1)
         ,(construct-loops (reverse ranges) (reverse rv) is states (reverse lengths))
+        ,@(if atype '() `((call (top freeze!) ,result)))
         ,result))))))
 
 (define (lower-dict-comprehension expr ranges)

--- a/src/julia.h
+++ b/src/julia.h
@@ -144,7 +144,7 @@ typedef struct {
     size_t length;
 #endif
 
-    unsigned short ndims:10;
+    unsigned short ndims:9;
     unsigned short pooled:1;
     unsigned short ptrarray:1;  // representation is pointer array
     /*
@@ -157,6 +157,7 @@ typedef struct {
     unsigned short how:2;
     unsigned short isshared:1;  // data is shared by multiple Arrays
     unsigned short isaligned:1; // data allocated with memalign
+    unsigned short fixed_len:1; // data cannot be resized (1d only)
     uint16_t elsize;
     uint32_t offset;  // for 1-d only. does not need to get big.
 
@@ -1040,6 +1041,7 @@ DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec);
 DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz);
 DLLEXPORT void jl_cell_1d_push(jl_array_t *a, jl_value_t *item);
 DLLEXPORT jl_value_t *jl_apply_array_type(jl_datatype_t *type, size_t dim);
+DLLEXPORT void jl_array_freeze(jl_array_t*);
 // property access
 DLLEXPORT void *jl_array_ptr(jl_array_t *a);
 DLLEXPORT void *jl_array_eltype(jl_value_t *a);


### PR DESCRIPTION
Let's have this be the basis for discussion. The properties I feel we need are :
(1) `map(Y->X,Z)` and `[X for Y in Z]` have the same semantics
(2) We can specify julia's runtime execution without mentions of type inference
(3) The case where `isempty(Z)` should be the least surprising possible for the user, both from a semantic and performance standpoint

Choosing a type for `map(f,T[])` gives us then 3 choices per rule (2) : either Any, Bottom, or T. Choosing T feels completly arbitrary to me, and, as I explained in https://github.com/JuliaLang/julia/issues/7258#issuecomment-96288936, Bottom is quite convenient.
Choosing Any is a performance pitfall which violates rule (3), unless we always return Vector{Any} for not-explicitly-typed `map`s and comprehensions.

Choosing Bottom has a problem with (3) which is that the empty case is no longer resizable which is "fixed" by making all the cases immutable length : this is what this PR implements.

I then see essentially only two options :
A) this PR
B) the simpler rule of returning only Any arrays except when explicitly asked for a return type (@jakebolewski's prefered solution).

Any opinion on this topic would have to argue one of the following : A) is the way to go, B) is the way to go, one of (1-3) should be broken, my reasoning is incorrect.
