### PR TITLE
add vecdot, in analogy with vecnorm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -156,6 +156,8 @@ Library improvements
 
     * OpenBLAS 64-bit (ILP64) interface is now compiled with a `64_` suffix ([#8734]) to avoid conflicts with external libraries using a 32-bit BLAS ([#4923]).
 
+    * New `vecdot` function, analogous to `vecnorm`, for Euclidean inner products over any iterable container ([#11067]).
+
   * Strings
 
     * NUL-terminated strings should now be passed to C via the new `Cstring` type, not `Ptr{UInt8}` or `Ptr{Cchar}`,
@@ -1393,3 +1395,4 @@ Too numerous to mention.
 [#10893]: https://github.com/JuliaLang/julia/issues/10893
 [#10914]: https://github.com/JuliaLang/julia/issues/10914
 [#10994]: https://github.com/JuliaLang/julia/issues/10994
+[#11067]: https://github.com/JuliaLang/julia/issues/11067

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -685,6 +685,7 @@ export
     tril,
     triu!,
     triu,
+    vecdot,
     vecnorm,
     ⋅,
     ×,

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -115,6 +115,7 @@ export
     triu,
     tril!,
     triu!,
+    vecdot,
     vecnorm,
 
 # Operators

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -33,8 +33,8 @@ scale(b::Vector, A::Matrix) = scale!(similar(b, promote_type(eltype(A),eltype(b)
 
 # Dot products
 
-dot{T<:BlasReal}(x::StridedVector{T}, y::StridedVector{T}) = BLAS.dot(x, y)
-dot{T<:BlasComplex}(x::StridedVector{T}, y::StridedVector{T}) = BLAS.dotc(x, y)
+vecdot{T<:BlasReal}(x::Union(DenseArray{T},StridedVector{T}), y::Union(DenseArray{T},StridedVector{T})) = BLAS.dot(x, y)
+vecdot{T<:BlasComplex}(x::Union(DenseArray{T},StridedVector{T}), y::Union(DenseArray{T},StridedVector{T})) = BLAS.dotc(x, y)
 function dot{T<:BlasReal, TI<:Integer}(x::Vector{T}, rx::Union(UnitRange{TI},Range{TI}), y::Vector{T}, ry::Union(UnitRange{TI},Range{TI}))
     length(rx)==length(ry) || throw(DimensionMismatch())
     if minimum(rx) < 1 || maximum(rx) > length(x) || minimum(ry) < 1 || maximum(ry) > length(y)
@@ -49,19 +49,7 @@ function dot{T<:BlasComplex, TI<:Integer}(x::Vector{T}, rx::Union(UnitRange{TI},
     end
     BLAS.dotc(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
 end
-function dot(x::AbstractVector, y::AbstractVector)
-    lx = length(x)
-    lx==length(y) || throw(DimensionMismatch())
-    if lx == 0
-        return zero(eltype(x))*zero(eltype(y))
-    end
-    s = conj(x[1])*y[1]
-    @inbounds for i = 2:lx
-        s += conj(x[i])*y[i]
-    end
-    s
-end
-dot(x::Number, y::Number) = conj(x) * y
+
 Ac_mul_B(x::AbstractVector, y::AbstractVector) = [dot(x, y)]
 At_mul_B{T<:Real}(x::AbstractVector{T}, y::AbstractVector{T}) = [dot(x, y)]
 At_mul_B{T<:BlasComplex}(x::StridedVector{T}, y::StridedVector{T}) = [BLAS.dotu(x, y)]

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -30,6 +30,13 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute the dot product. For complex vectors, the first vector is conjugated.
 
+.. function:: vecdot(x, y)
+
+   For any iterable containers ``x`` and ``y`` (including arrays of
+   any dimension) of numbers (or any element type for which ``dot`` is
+   defined), compute the Euclidean dot product (the sum of
+   ``dot(x[i],y[i])``) as if they were vectors.
+
 .. function:: cross(x, y)
               ×(x,y)
 
@@ -493,9 +500,10 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
 .. function:: vecnorm(A, [p])
 
-   For any iterable container ``A`` (including arrays of any dimension)
-   of numbers, compute the ``p``-norm (defaulting to ``p=2``) as if ``A``
-   were a vector of the corresponding length.
+   For any iterable container ``A`` (including arrays of any
+   dimension) of numbers (or any element type for which ``norm`` is
+   defined), compute the ``p``-norm (defaulting to ``p=2``) as if
+   ``A`` were a vector of the corresponding length.
 
    For example, if ``A`` is a matrix and ``p=2``, then this is equivalent
    to the Frobenius norm.

--- a/test/linalg3.jl
+++ b/test/linalg3.jl
@@ -275,3 +275,18 @@ A = [ 1  5  9
 @test diag(zeros(0,1),1) == []
 @test_throws BoundsError diag(zeros(0,1),-1)
 @test_throws BoundsError diag(zeros(0,1),2)
+
+vecdot_(x,y) = invoke(vecdot, (Any,Any), x,y) # generic vecdot
+let A = [1+2im 3+4im; 5+6im 7+8im], B = [2+7im 4+1im; 3+8im 6+5im]
+    @test vecdot(A,B) == dot(vec(A),vec(B)) == vecdot_(A,B) == vecdot(float(A),float(B))
+    @test vecdot(Int[], Int[]) == 0 == vecdot_(Int[], Int[])
+    @test_throws MethodError vecdot(Any[], Any[])
+    @test_throws MethodError vecdot_(Any[], Any[])
+    for n1 = 0:2, n2 = 0:2, d in (vecdot, vecdot_)
+        if n1 != n2
+            @test_throws DimensionMismatch d(1:n1, 1:n2)
+        else
+            @test_approx_eq d(1:n1, 1:n2) vecnorm(1:n1)^2
+        end
+    end
+end


### PR DESCRIPTION
As discussed in JuliaLang/LinearAlgebra.jl#206, if we have a `vecnorm` function (computing the Euclidean norm of any iterable container, equivalent to `norm(vec(x))`), we should really also have a `vecdot` (computing the Euclidean dot product of any iterable container, equivalent to `dot(vec(x),vec(y))`).

(If, as @jiahao argued in JuliaLang/julia#7990, we renamed `vecnorm` to `normfro`, then for consistency we should use `dotfro` here.   I don't care too much either way as long as we are consistent, but I would point out that if you're worried about the inherent ambiguity of the terms "norm" and "dot product", that would argue against having `norm` and `dot` functions at all.)
