### PR TITLE
Code generation for fieldtype of unknown DataType

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -844,6 +844,16 @@ static Value *emit_typeof(Value *p)
     return literal_pointer_val(julia_type_of(p));
 }
 
+static Value *emit_datatype_types(Value *dt)
+{
+    return builder.
+        CreateLoad(builder.
+                   CreateBitCast(builder.
+                                 CreateGEP(builder.CreateBitCast(dt, T_pint8),
+                                           ConstantInt::get(T_size, offsetof(jl_datatype_t, types))),
+                                 jl_ppvalue_llvmt));
+}
+
 static Value *emit_datatype_nfields(Value *dt)
 {
     Value *nf = builder.


### PR DESCRIPTION
This PR adds code generation for `fieldtype` when the DataType (and the index) is unknown at compile time. It helps a lot for the following kind of code (which is writing every field to an IO) that we don't want to specialize on every possible type :

``` julia
function bla(io::IO, x::ANY)
    t = typeof(x)
    n = nfields(t)
    ptr = pointer_from_objref(x)
    for i=1:n
        ofs = Base.field_offset(t, Int32(i))
        ft = fieldtype(t,i)
        sz = sizeof(ft)
        write(io, ptr + ofs, sz)
    end
end
```

With this change we don't allocate more memory than needed to write the actual fields.

Soon to be used in the serializer speedup.
