### PR TITLE
Delete absolute paths in gdb bootstrap debugging

### DIFF
--- a/doc/devdocs/debuggingtips.rst
+++ b/doc/devdocs/debuggingtips.rst
@@ -83,13 +83,13 @@ Errors that occur during ``make`` need special handling. Julia is built in two s
 At the time of this writing, you can debug build errors during the ``sys0`` phase from the ``base``
 directory using::
 
-    julia/base$ gdb --args ../usr/bin/julia-debug -C native --build ../usr/lib/julia/sys0 sysimg.jl
+    julia/base$ gdb --args julia -C native --build sys0 sysimg.jl
 
 You might need to delete all the files in ``usr/lib/julia/`` to get this to work.
 
 You can debug the ``sys.ji`` phase using::
 
-    julia/base$ gdb --args .../usr/bin/julia-debug -C native --build ../usr/lib/julia/sys -J ../usr/lib/julia/sys0.ji sysimg.jl
+    julia/base$ gdb --args julia -C native --build sys -J sys0.ji sysimg.jl
 
 Mozilla's Record and Replay Framework (rr)
 ---------------------------------------------


### PR DESCRIPTION
Ref. https://github.com/JuliaLang/julia/commit/c991a239548f708fe71991929bdcf79e3bf90c29#commitcomment-10963835. CC @ihnorton. (Correct?)
