### PR TITLE
fixed `cumprod` and `cumprod!`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1509,7 +1509,7 @@ for (f, f!, fp, op) = ((:cumsum, :cumsum!, :cumsum_pairwise!, :+),
         else
             n2 = n >> 1
             s_ = ($fp)(v, c, s, i1, n2)
-            s_ = $(op)(s_, ($fp)(v, c, s + s_, i1+n2, n-n2))
+            s_ = $(op)(s_, ($fp)(v, c, ($op)(s, s_), i1+n2, n-n2))
         end
         return s_
     end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1092,3 +1092,8 @@ end
 # PR #10164
 @test eltype(Array{Int}) == Int
 @test eltype(Array{Int,1}) == Int
+
+# PR #11080
+let x = fill(0.9, 1000)
+    @test_approx_eq prod(x) cumprod(x)[end]
+end


### PR DESCRIPTION
`cumprod` and `cumprod!` return wrong answer for a long array (length >= 128).
A test code and the result are following :

```
julia> xs = fill(0.9, 1000);

julia> Test.@test_approx_eq prod(xs) cumprod(xs)[end]
ERROR: assertion failed: |prod(xs) - (cumprod(xs))[end]| <= 2.117582368135751e-18
  prod(xs) = 1.7478712517226966e-46
  (cumprod(xs))[end] = 1.9068411172040859e-6
  difference = 1.9068411172040859e-6 > 2.117582368135751e-18
 in error at error.jl:20
 in test_approx_eq at test.jl:137
 in test_approx_eq at test.jl:147
```

`VERSION >= v"0.3.6"` have this bug.
