### PR TITLE
{leading/trailing/count}_{zeros/ones} do not widen their arguments

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -117,9 +117,9 @@ bswap(x::UInt128) = box(UInt128,bswap_int(unbox(UInt128,x)))
 
 for T in IntTypes
     @eval begin
-        count_ones(x::$T)     = Int(box($T,ctpop_int(unbox($T,x))))
-        leading_zeros(x::$T)  = Int(box($T,ctlz_int(unbox($T,x))))
-        trailing_zeros(x::$T) = Int(box($T,cttz_int(unbox($T,x))))
+        count_ones(x::$T)     = signed($T(box($T,ctpop_int(unbox($T,x)))))
+        leading_zeros(x::$T)  = signed($T(box($T,ctlz_int(unbox($T,x)))))
+        trailing_zeros(x::$T) = signed($T(box($T,cttz_int(unbox($T,x)))))
     end
 end
 count_zeros  (x::Integer) = count_ones(~x)


### PR DESCRIPTION
These intrinsics now return a signed integer of the same width as
their argument. This contributes to type-stable code when working
with non-native integer sizes. Note that they still returned a
signed value even when their argument is unsigned. This is so that
counting zeros, for instance, does not push an entire calculation
to be unsigned.

If you return the exact type, i.e. allowing counts of unsigned ints
to be unsigned, there are dozens of breaks in the tests as code
which previously returned signed integers changes.
