### PR TITLE
Added bounds checking to triu/tril.

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -66,6 +66,9 @@ vecnorm2{T<:BlasFloat}(x::Union(Array{T},StridedVector{T})) =
 
 function triu!(M::AbstractMatrix, k::Integer)
     m, n = size(M)
+    if (k > 0 && k > n) || (k < 0 && -k > m)
+        throw(BoundsError())
+    end
     idx = 1
     for j = 0:n-1
         ii = min(max(0, j+1-k), m)
@@ -81,6 +84,9 @@ triu(M::Matrix, k::Integer) = triu!(copy(M), k)
 
 function tril!(M::AbstractMatrix, k::Integer)
     m, n = size(M)
+    if (k > 0 && k > n) || (k < 0 && -k > m)
+        throw(BoundsError())
+    end
     idx = 1
     for j = 0:n-1
         ii = min(max(0, j-k), m)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1117,7 +1117,7 @@ b2 = bitrand(v1)
 @check_bit_operation dot(b1, b2) Int
 
 b1 = bitrand(n1, n2)
-for k = -max(n1,n2) : max(n1,n2)
+for k = -n1 : n2
     @check_bit_operation tril(b1, k) BitMatrix
     @check_bit_operation triu(b1, k) BitMatrix
 end

--- a/test/linalg4.jl
+++ b/test/linalg4.jl
@@ -72,3 +72,10 @@ let A = eye(4)
     @test diag(A) == ones(4)
     @test diag(sub(A, 1:3, 1:3)) == ones(3)
 end
+
+# test triu/tril bounds checking
+A = rand(5,7)
+@test_throws(BoundsError,triu(A,8))
+@test_throws(BoundsError,triu(A,-6))
+@test_throws(BoundsError,tril(A,8))
+@test_throws(BoundsError,tril(A,-6))


### PR DESCRIPTION
Re JuliaLang/LinearAlgebra.jl#161, added bounds checking for `triu!` and `tril!`. Added tests as well. There was one test in `test/bitarray.jl` that was asking for out-of-bounds sub/superdiagonals which I modified as well.
