### PR TITLE
Fix Pkg.test to look at julia_exename()

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -693,7 +693,8 @@ function test!(pkg::AbstractString, errs::Vector{AbstractString}, notests::Vecto
             try
                 color = Base.have_color? "--color=yes" : "--color=no"
                 codecov = coverage? ["--code-coverage=user", "--inline=no"] : ["--code-coverage=none"]
-                run(`$JULIA_HOME/julia --check-bounds=yes $codecov $color $test_path`)
+                julia_exe = joinpath(JULIA_HOME, Base.julia_exename())
+                run(`$julia_exe --check-bounds=yes $codecov $color $test_path`)
                 info("$pkg tests passed")
             catch err
                 warnbanner(err, label="[ ERROR: $pkg ]")


### PR DESCRIPTION
My tests of all packages were failing, and it turned out that it was because I had done a debug build of julia.

With this patch, package tests will work if `julia-debug` is compiled without a "release" build of `julia` alongside it.

See [`test/cmdlineargs.jl`](https://github.com/JuliaLang/julia/blob/62b9817e8b9aad0ed062318adbf4322bb1c36690/test/cmdlineargs.jl#L1), where a similar thing is done, so I expect this shouldn't break anything on Windows.
