### PR TITLE
#11081 Add C/C++ section to Noteworthy differences documentation

### DIFF
--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -251,3 +251,72 @@ Noteworthy differences from Python
   returns a new random number every time it is invoked without argument. On the
   other hand, the function ``g(x=[1,2]) = push!(x,3)`` returns ``[1,2,3]`` every
   time it is called as ``g()``.
+
+
+Noteworthy differences from C/C++
+----------------------------------
+
+- Julia arrays are indexed with square brackets, and can have more than one
+  dimension ``A[i,j]``.
+- In Julia, indexing of arrays, strings, etc. is 1-based not 0-based.
+- Julia arrays are assigned by reference. After ``A=B``, changing elements of
+  ``B`` will modify ``A`` as well.
+- Julia values are passed and assigned by reference. If a function modifies an
+  array, the changes will be visible in the caller.
+- In Julia, literal numbers without a decimal point (such as ``42``) create signed
+  integers, of type Int, but literals too large to fit in the machine word size
+  will automatically be promoted to a larger size type, such as Int64 (if Int is Int32),
+  Int128, or the arbitrarily large BigInt type.
+  There are no numeric literal suffixes, such as L, LL, U, UL, ULL to indicate unsigned
+  and/or signed vs. unsigned.
+  Decimal literals are always signed, and hexadecimal literals (which start with 0x like C/C++),
+  are unsigned (except if they are >128 bits, in which case they become signed BigInt type).
+  Hexadecimal literals also, unlike C/C++/Java and unlike decimal literals in Julia,
+  have a type based on the *length* of the literal, including leading 0s.  For example,
+  ``0x0`` and ``0x00` have type UInt8, ``0x000`` and ``0x0000`` have type UInt16, then
+  literals with 5 to 8 hex digits have type UInt32, 9 to 16 hex digits type UInt64, and more than
+  16 hex digits end up a signed BigInt type.  This needs to be taken into account when defining
+  hexadecimal masks, for example ~0xf is very different from ~0x000f.
+  Unlike either decimal integer or hexadecimal literals, floating point literals are always
+  64-bits, Float64, and don't get promoted to the BigFloat type.  This is closer in
+  behavior to C/C++.
+- String literals can be delimited with either " or """
+  They can also have string interpolation, indicated by $variablename or $(exprssion),
+  which evaluates the variable name or the expression in the context of the function.
+- `//` indicates a Ration number, and not a single-line comment (which is # in Julia)
+- `#=` indicates the start of a multiline comment, and =# ends it.
+- Functions in Julia return values from their last expression(s) or the ``return``
+  keyword.  Multiple values can be returned from functions and assigned as tuples, e.g.
+  ``(a, b) = myfunction()`` or ``a, b = myfunction()``, instead of having to pass pointers
+  to values as one would have to do in C/C++ (i.e. ``a = myfunction(&b)``.
+- Julia discourages the used of semicolons to end statements. The results of
+  statements are not automatically printed (except at the interactive prompt),
+  and lines of code do not need to end with semicolons. :func:`println` or
+  :func:`@printf` can be used to print specific output.
+- In Julia, the operator :obj:`$` performs the bitwise XOR operation, i.e. :obj:`^`
+  in C/C++.  Also, these the bitwise operators do not have the same precedence as C/++.
+  They can operate on scalars or element-wise across arrays and can be used to
+  combine logical arrays, but note the difference in order of operations:
+  parentheses may be required (e.g., to select elements of ``A`` equal to 1 or
+  2 use ``(A .== 1) | (A .== 2)``).
+- Julia's ``->`` creates an anonymous function, it does not access a member via a pointer.
+- Julia does not require parentheses when writing ``if`` statements or
+  ``for``/``while`` loops: use ``for i in [1, 2, 3]`` instead of
+  ``for (i in c(1, 2, 3))`` and ``if i == 1`` instead of ``if (i == 1)``.
+- Julia does not treat the numbers ``0`` and ``1`` as Booleans.
+  You cannot write ``if (1)`` in Julia, because ``if`` statements accept only
+  booleans. Instead, you can write ``if true``, ``if Bool(1)``, or ``if 1==1``.
+- In Julia, ``return`` does not require parentheses.
+- Julia uses ``end`` to denote the end of conditional blocks, like ``if``,
+  loop blocks, like ``while``/``for``, and functions. In lieu of the one-line
+  ``if ( cond ) statement``, Julia allows statements of the form
+  ``if cond; statement; end``, ``cond && statement`` and
+  ``!cond || statement``. Assignment statements in the latter two syntaxes must
+  be explicitly wrapped in parentheses, e.g. ``cond && (x = value)``.
+- Julia has no line continuation syntax: if, at the end of a line, the input so
+  far is a complete expression, it is considered done; otherwise the input
+  continues. One way to force an expression to continue is to wrap it in
+  parentheses.
+- By convention, functions that modify their arguments have a ! at the end of the name,
+  for example push!.
+

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -263,6 +263,10 @@ Noteworthy differences from C/C++
 - In Julia, indexing of arrays, strings, etc. is 1-based not 0-based.
 - Julia arrays are assigned by reference. After ``A=B``, changing elements of
   ``B`` will modify ``A`` as well.
+- Julia arrays are column major (Fortran ordered) whereas C/C++ arrays are row
+  major ordered by default. To get optimal performance when looping over
+  arrays, the order of the loops should be reversed in Julia relative to C/C++
+  (see relevant section of :ref:`man-performance-tips`).
 - Julia values are passed and assigned by reference. If a function modifies an
   array, the changes will be visible in the caller.
 - In Julia, whitespace is significant, unlike C/C++, so care must be taken when adding/removing
@@ -318,7 +322,6 @@ Noteworthy differences from C/C++
 - Julia does not treat the numbers ``0`` and ``1`` as Booleans.
   You cannot write ``if (1)`` in Julia, because ``if`` statements accept only
   booleans. Instead, you can write ``if true``, ``if Bool(1)``, or ``if 1==1``.
-- In Julia, ``return`` does not require parentheses.
 - Julia uses ``end`` to denote the end of conditional blocks, like ``if``,
   loop blocks, like ``while``/``for``, and functions. In lieu of the one-line
   ``if ( cond ) statement``, Julia allows statements of the form
@@ -333,12 +336,12 @@ Noteworthy differences from C/C++
 - Julia has an incredibly powerful macro facility, and macros are always indicated by the ``@``
   character.  Unlike C/C++, macros operate on parsed expressions, not on the text of the program.
   There are two forms for using a macro, ``@mymacro(arg1, arg2, arg3)`` or ``@mymacro arg1 arg2 arg3``
-  The first form is useful if you need to have a macro call that spreads multiple lines (``@Enum`` is a good
+  The first form is useful if you need to have a macro call that spreads multiple lines (``@enum`` is a good
   case), and the second form allows handling calls like: ``@parallel for i=1:1000``.
   Note: the second form can continue onto multiple lines, if the last expression on a line goes over to another line...
   This can be a bit tricky to determine sometimes just where the macro ends.
-- Julia now has an enumeration type, expressed using the macro ``@Enum(name, value1, value2, ...)``
-  For example: ``@Enum(Fruit, Banana=1, Apple, Pear)``
+- Julia now has an enumeration type, expressed using the macro ``@enum(name, value1, value2, ...)``
+  For example: ``@enum(Fruit, Banana=1, Apple, Pear)``
 - By convention, functions that modify their arguments have a ``!`` at the end of the name,
   for example ``push!``.
 

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -184,7 +184,7 @@ noteworthy differences:
   but is a specialized :obj:`Range` that is used for iteration without high
   memory overhead. To convert a range into a vector, you need to wrap the range
   with brackets ``[a:b]``.
-- Julia's :func:`max`` and :func:`min` are the equivalent of ``pmax`` and
+- Julia's :func:`max` and :func:`min` are the equivalent of ``pmax`` and
   ``pmin`` respectively in R, but both arguments need to have the same
   dimensions.  While :func:`maximum` and :func:`minimum` replace ``max`` and
   ``min`` in R, there are important differences.
@@ -273,18 +273,19 @@ Noteworthy differences from C/C++
   are unsigned (except if they are >128 bits, in which case they become signed BigInt type).
   Hexadecimal literals also, unlike C/C++/Java and unlike decimal literals in Julia,
   have a type based on the *length* of the literal, including leading 0s.  For example,
-  ``0x0`` and ``0x00` have type UInt8, ``0x000`` and ``0x0000`` have type UInt16, then
+  ``0x0`` and ``0x00`` have type UInt8, ``0x000`` and ``0x0000`` have type UInt16, then
   literals with 5 to 8 hex digits have type UInt32, 9 to 16 hex digits type UInt64, and more than
   16 hex digits end up a signed BigInt type.  This needs to be taken into account when defining
-  hexadecimal masks, for example ~0xf is very different from ~0x000f.
+  hexadecimal masks, for example `~0xf` is very different from `~0x000f`.
   Unlike either decimal integer or hexadecimal literals, floating point literals are always
   64-bits, Float64, and don't get promoted to the BigFloat type.  This is closer in
   behavior to C/C++.
-- String literals can be delimited with either " or """
-  They can also have string interpolation, indicated by $variablename or $(exprssion),
+- String literals can be delimited with either `"`  or `"""`, `"""` delimited literals can contain `"` characters without
+  quoting it like `"\\\""`
+  They can also have string interpolation, indicated by $variablename or $(expression),
   which evaluates the variable name or the expression in the context of the function.
-- `//` indicates a Ration number, and not a single-line comment (which is # in Julia)
-- `#=` indicates the start of a multiline comment, and =# ends it.
+- `//` indicates a Rational number, and not a single-line comment (which is # in Julia)
+- `#=` indicates the start of a multiline comment, and `=#` ends it.
 - Functions in Julia return values from their last expression(s) or the ``return``
   keyword.  Multiple values can be returned from functions and assigned as tuples, e.g.
   ``(a, b) = myfunction()`` or ``a, b = myfunction()``, instead of having to pass pointers
@@ -299,6 +300,7 @@ Noteworthy differences from C/C++
   combine logical arrays, but note the difference in order of operations:
   parentheses may be required (e.g., to select elements of ``A`` equal to 1 or
   2 use ``(A .== 1) | (A .== 2)``).
+- Julia's :obj:`^` is exponentiation, not bitwise XOR as in C/C++ (use :obj:`$` in Julia)
 - Julia's ``->`` creates an anonymous function, it does not access a member via a pointer.
 - Julia does not require parentheses when writing ``if`` statements or
   ``for``/``while`` loops: use ``for i in [1, 2, 3]`` instead of
@@ -312,11 +314,12 @@ Noteworthy differences from C/C++
   ``if ( cond ) statement``, Julia allows statements of the form
   ``if cond; statement; end``, ``cond && statement`` and
   ``!cond || statement``. Assignment statements in the latter two syntaxes must
-  be explicitly wrapped in parentheses, e.g. ``cond && (x = value)``.
+  be explicitly wrapped in parentheses, e.g. ``cond && (x = value)``, because
+  of the operator precedence.
 - Julia has no line continuation syntax: if, at the end of a line, the input so
   far is a complete expression, it is considered done; otherwise the input
   continues. One way to force an expression to continue is to wrap it in
   parentheses.
 - By convention, functions that modify their arguments have a ! at the end of the name,
-  for example push!.
+  for example `push!`.
 

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -258,34 +258,40 @@ Noteworthy differences from C/C++
 
 - Julia arrays are indexed with square brackets, and can have more than one
   dimension ``A[i,j]``.
+  This syntax is not just syntactic sugar for a reference to a pointer or address as in C/C++.
+  See the Julia documentation for the syntax for array construction (it has changed between versions).
 - In Julia, indexing of arrays, strings, etc. is 1-based not 0-based.
 - Julia arrays are assigned by reference. After ``A=B``, changing elements of
   ``B`` will modify ``A`` as well.
 - Julia values are passed and assigned by reference. If a function modifies an
   array, the changes will be visible in the caller.
+- In Julia, whitespace is significant, unlike C/C++, so care must be taken when adding/removing
+  whitespace from a Julia program.
 - In Julia, literal numbers without a decimal point (such as ``42``) create signed
-  integers, of type Int, but literals too large to fit in the machine word size
-  will automatically be promoted to a larger size type, such as Int64 (if Int is Int32),
-  Int128, or the arbitrarily large BigInt type.
-  There are no numeric literal suffixes, such as L, LL, U, UL, ULL to indicate unsigned
+  integers, of type ``Int``, but literals too large to fit in the machine word size
+  will automatically be promoted to a larger size type, such as ``Int64`` (if ``Int`` is ``Int32``),
+  ``Int128``, or the arbitrarily large ``BigInt`` type.
+  There are no numeric literal suffixes, such as ``L``, ``LL``, ``U``, ``UL``, ``ULL`` to indicate unsigned
   and/or signed vs. unsigned.
-  Decimal literals are always signed, and hexadecimal literals (which start with 0x like C/C++),
-  are unsigned (except if they are >128 bits, in which case they become signed BigInt type).
+  Decimal literals are always signed, and hexadecimal literals (which start with ``0x`` like C/C++),
+  are unsigned (except if they are >128 bits, in which case they become signed ``BigInt`` type).
   Hexadecimal literals also, unlike C/C++/Java and unlike decimal literals in Julia,
   have a type based on the *length* of the literal, including leading 0s.  For example,
-  ``0x0`` and ``0x00`` have type UInt8, ``0x000`` and ``0x0000`` have type UInt16, then
-  literals with 5 to 8 hex digits have type UInt32, 9 to 16 hex digits type UInt64, and more than
-  16 hex digits end up a signed BigInt type.  This needs to be taken into account when defining
-  hexadecimal masks, for example `~0xf` is very different from `~0x000f`.
+  ``0x0`` and ``0x00`` have type UInt8, ``0x000`` and ``0x0000`` have type ``UInt16``, then
+  literals with 5 to 8 hex digits have type ``UInt32``, 9 to 16 hex digits type ``UInt64``, and more than
+  16 hex digits end up a signed ``BigInt`` type.  This needs to be taken into account when defining
+  hexadecimal masks, for example ``~0xf`` is very different from ``~0x000f``.
   Unlike either decimal integer or hexadecimal literals, floating point literals are always
-  64-bits, Float64, and don't get promoted to the BigFloat type.  This is closer in
+  64-bits, ``Float64``, and don't get promoted to the ``BigFloat`` type.  This is closer in
   behavior to C/C++.
-- String literals can be delimited with either `"`  or `"""`, `"""` delimited literals can contain `"`
-  characters without quoting it like `"\\\""`
+  Octal (prefixed with ``0o``) and binary (prefixed with ``0b``) literals are also treated as unsigned
+  (with the same current exception that they become signed ``BigInt`` type if they can't fit in a ``UInt128``).
+- String literals can be delimited with either ``"``  or ``"""``, ``"""`` delimited literals can contain ``"``
+  characters without quoting it like ``"\\\""``
   String literals can have values of other variables or expressions interpolated into them,
-  indicated by `$variablename` or `$(expression)`, which evaluates the variable name or the expression in the context of the function.
-- `//` indicates a Rational number, and not a single-line comment (which is # in Julia)
-- `#=` indicates the start of a multiline comment, and `=#` ends it.
+  indicated by ``$variablename`` or ``$(expression)``, which evaluates the variable name or the expression in the context of the function.
+- ``//`` indicates a ``Rational`` number, and not a single-line comment (which is # in Julia)
+- ``#=`` indicates the start of a multiline comment, and ``=#`` ends it.
 - Functions in Julia return values from their last expression(s) or the ``return``
   keyword.  Multiple values can be returned from functions and assigned as tuples, e.g.
   ``(a, b) = myfunction()`` or ``a, b = myfunction()``, instead of having to pass pointers
@@ -317,15 +323,15 @@ Noteworthy differences from C/C++
   far is a complete expression, it is considered done; otherwise the input
   continues. One way to force an expression to continue is to wrap it in
   parentheses.
-- Julia has an incredibly powerful macro facility, and macros are always indicated by the `@`
+- Julia has an incredibly powerful macro facility, and macros are always indicated by the ``@``
   character.  Unlike C/C++, macros operate on parsed expressions, not on the text of the program.
-  There are two forms for using a macro, `@mymacro(arg1, arg2, arg3)` or `@mymacro arg1 arg2 arg3`
-  The first form is useful if you need to have a macro call that spreads multiple lines (`@Enum` is a good
-  case), and the second form allows handling calls like: `@parallel for i=1:1000`.
+  There are two forms for using a macro, ``@mymacro(arg1, arg2, arg3)`` or ``@mymacro arg1 arg2 arg3``
+  The first form is useful if you need to have a macro call that spreads multiple lines (``@Enum`` is a good
+  case), and the second form allows handling calls like: ``@parallel for i=1:1000``.
   Note: the second form can continue onto multiple lines, if the last expression on a line goes over to another line...
   This can be a bit tricky to determine sometimes just where the macro ends.
-- Julia now has an enumeration type, expressed using the macro `@Enum(name, value1, value2, ...)`
-  For example: `@Enum(Fruit, Banana=1, Apple, Pear)`
-- By convention, functions that modify their arguments have a ! at the end of the name,
-  for example `push!`.
+- Julia now has an enumeration type, expressed using the macro ``@Enum(name, value1, value2, ...)``
+  For example: ``@Enum(Fruit, Banana=1, Apple, Pear)``
+- By convention, functions that modify their arguments have a ``!`` at the end of the name,
+  for example ``push!``.
 

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -295,7 +295,7 @@ Noteworthy differences from C/C++
   and lines of code do not need to end with semicolons. :func:`println` or
   :func:`@printf` can be used to print specific output.
 - In Julia, the operator :obj:`$` performs the bitwise XOR operation, i.e. :obj:`^`
-  in C/C++.  Also, these the bitwise operators do not have the same precedence as C/++.
+  in C/C++.  Also, the bitwise operators do not have the same precedence as C/++.
   They can operate on scalars or element-wise across arrays and can be used to
   combine logical arrays, but note the difference in order of operations:
   parentheses may be required (e.g., to select elements of ``A`` equal to 1 or

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -297,13 +297,20 @@ Noteworthy differences from C/C++
   ``(a, b) = myfunction()`` or ``a, b = myfunction()``, instead of having to pass pointers
   to values as one would have to do in C/C++ (i.e. ``a = myfunction(&b)``.
 - Julia discourages the used of semicolons to end statements. The results of
-  statements are not automatically printed (except at the interactive prompt),
+  statements are not automatically printed (except at the interactive prompt, i.e. the REPL),
   and lines of code do not need to end with semicolons. :func:`println` or
   :func:`@printf` can be used to print specific output.
+  In the REPL, ``;`` can be used to suppress output.
+  ``;`` also has a different meaning within ``[ ]``, something to watch out for.
+  ``;`` can be used to separate 'statements' on a line, but are not strictly necessary in many cases,
+  and are more an aid to readability.
 - In Julia, the operator :obj:`$` performs the bitwise XOR operation, i.e. :obj:`^`
   in C/C++.  Also, the bitwise operators do not have the same precedence as C/++,
   so parenthesis may be required.
-- Julia's :obj:`^` is exponentiation, not bitwise XOR as in C/C++ (use :obj:`$` in Julia)
+- Julia's :obj:`^` is exponentiation (pow), not bitwise XOR as in C/C++ (use :obj:`$` in Julia)
+- Julia has two right-shift operators, ``>>`` and ``>>>``.  ``>>>`` performs an arithmetic shift,
+  ``>>`` always performs a logical shift, unlike C/C++,
+  where the meaning of ``>>`` depends on the type of the value being shifted.
 - Julia's ``->`` creates an anonymous function, it does not access a member via a pointer.
 - Julia does not require parentheses when writing ``if`` statements or
   ``for``/``while`` loops: use ``for i in [1, 2, 3]`` instead of

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -280,10 +280,10 @@ Noteworthy differences from C/C++
   Unlike either decimal integer or hexadecimal literals, floating point literals are always
   64-bits, Float64, and don't get promoted to the BigFloat type.  This is closer in
   behavior to C/C++.
-- String literals can be delimited with either `"`  or `"""`, `"""` delimited literals can contain `"` characters without
-  quoting it like `"\\\""`
-  They can also have string interpolation, indicated by $variablename or $(expression),
-  which evaluates the variable name or the expression in the context of the function.
+- String literals can be delimited with either `"`  or `"""`, `"""` delimited literals can contain `"`
+  characters without quoting it like `"\\\""`
+  String literals can have values of other variables or expressions interpolated into them,
+  indicated by `$variablename` or `$(expression)`, which evaluates the variable name or the expression in the context of the function.
 - `//` indicates a Rational number, and not a single-line comment (which is # in Julia)
 - `#=` indicates the start of a multiline comment, and `=#` ends it.
 - Functions in Julia return values from their last expression(s) or the ``return``
@@ -295,11 +295,8 @@ Noteworthy differences from C/C++
   and lines of code do not need to end with semicolons. :func:`println` or
   :func:`@printf` can be used to print specific output.
 - In Julia, the operator :obj:`$` performs the bitwise XOR operation, i.e. :obj:`^`
-  in C/C++.  Also, the bitwise operators do not have the same precedence as C/++.
-  They can operate on scalars or element-wise across arrays and can be used to
-  combine logical arrays, but note the difference in order of operations:
-  parentheses may be required (e.g., to select elements of ``A`` equal to 1 or
-  2 use ``(A .== 1) | (A .== 2)``).
+  in C/C++.  Also, the bitwise operators do not have the same precedence as C/++,
+  so parenthesis may be required.
 - Julia's :obj:`^` is exponentiation, not bitwise XOR as in C/C++ (use :obj:`$` in Julia)
 - Julia's ``->`` creates an anonymous function, it does not access a member via a pointer.
 - Julia does not require parentheses when writing ``if`` statements or
@@ -320,6 +317,15 @@ Noteworthy differences from C/C++
   far is a complete expression, it is considered done; otherwise the input
   continues. One way to force an expression to continue is to wrap it in
   parentheses.
+- Julia has an incredibly powerful macro facility, and macros are always indicated by the `@`
+  character.  Unlike C/C++, macros operate on parsed expressions, not on the text of the program.
+  There are two forms for using a macro, `@mymacro(arg1, arg2, arg3)` or `@mymacro arg1 arg2 arg3`
+  The first form is useful if you need to have a macro call that spreads multiple lines (`@Enum` is a good
+  case), and the second form allows handling calls like: `@parallel for i=1:1000`.
+  Note: the second form can continue onto multiple lines, if the last expression on a line goes over to another line...
+  This can be a bit tricky to determine sometimes just where the macro ends.
+- Julia now has an enumeration type, expressed using the macro `@Enum(name, value1, value2, ...)`
+  For example: `@Enum(Fruit, Banana=1, Apple, Pear)`
 - By convention, functions that modify their arguments have a ! at the end of the name,
   for example `push!`.
 

--- a/doc/manual/noteworthy-differences.rst
+++ b/doc/manual/noteworthy-differences.rst
@@ -344,4 +344,7 @@ Noteworthy differences from C/C++
   For example: ``@enum(Fruit, Banana=1, Apple, Pear)``
 - By convention, functions that modify their arguments have a ``!`` at the end of the name,
   for example ``push!``.
-
+- In C++, by default, you have static dispatch, i.e. you need to annotate a function as virtual,
+  in order to have dynamic dispatch.
+  On the other hand, in Julia every method is "virtual" (although it's more general than that
+  since methods are dispatched on every argument type, not only ``this``, using the most-specific-declaration rule).


### PR DESCRIPTION
Updated doc/manual/noteworthy-differences.rst to have a section of a number of the differences between C/C++ and Jullia that I found confusion initally, coming from a C/C++ background.
