### PR TITLE
Fix bit operations between Char and Integer types

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -44,10 +44,12 @@ isless(x::Integer, y::Char) = isless(x, UInt32(y))
 -(x::Char   , y::Integer) = reinterpret(Char, Int32(x) - Int32(y))
 
 # bitwise operations
-(~)(x::Char) = Char(~UInt32(x))
-(&)(x::Char, y::Char) = Char(UInt32(x) & UInt32(y))
-(|)(x::Char, y::Char) = Char(UInt32(x) | UInt32(y))
-($)(x::Char, y::Char) = Char(UInt32(x) $ UInt32(y))
+(&)(x::Char, y::Integer) = Char(UInt32(x) & UInt32(y & 0xffffffff))
+(|)(x::Char, y::Integer) = Char(UInt32(x) | UInt32(y & 0xffffffff))
+($)(x::Char, y::Integer) = Char(UInt32(x) $ UInt32(y & 0xffffffff))
+(&)(x::Integer, y::Char) = y & x
+(|)(x::Integer, y::Char) = y | x
+($)(x::Integer, y::Char) = y $ x
 
 bswap(x::Char) = Char(bswap(UInt32(x)))
 


### PR DESCRIPTION
This fixes problems where common operations boolean operations between a Char and an Integer did not work (they got an error), and boolean operations between a Char and a Char were allowed, even though that didn't conceptually make sense.
`'a' & ~32 -> 'A'`
`'A' | 0x20 -> 'a'`
(bad examples above! I didn't mean to imply that you'd actually use this for testing upper or lower case!)
