### PR TITLE
Improve performance of length on UTF8String and UTF16String

### DIFF
--- a/base/utf16.jl
+++ b/base/utf16.jl
@@ -8,9 +8,9 @@ immutable UTF16String <: AbstractString
     end
 end
 
-@inline utf16_is_lead(c::UInt16) = (c & 0xfc00) == 0xd800
-@inline utf16_is_trail(c::UInt16) = (c & 0xfc00) == 0xdc00
-@inline utf16_is_surrogate(c::UInt16) = (c & 0xf800) == 0xd800
+utf16_is_lead(c::UInt16) = (c & 0xfc00) == 0xd800
+utf16_is_trail(c::UInt16) = (c & 0xfc00) == 0xdc00
+utf16_is_surrogate(c::UInt16) = (c & 0xf800) == 0xd800
 utf16_get_supplementary(lead::UInt16, trail::UInt16) = Char(UInt32(lead-0xd7f7)<<10 + trail)
 
 function length(s::UTF16String)

--- a/base/utf16.jl
+++ b/base/utf16.jl
@@ -13,6 +13,13 @@ utf16_is_trail(c::UInt16) = (c & 0xfc00) == 0xdc00
 utf16_is_surrogate(c::UInt16) = (c & 0xf800) == 0xd800
 utf16_get_supplementary(lead::UInt16, trail::UInt16) = Char(UInt32(lead-0xd7f7)<<10 + trail)
 
+function length(s::UTF16String)
+    d = s.data
+    len = length(d) - 1
+    len == 0 && return 0
+    ccall(:u16_charnum, Int, (Ptr{Void}, Csize_t), d, len)
+end
+
 function endof(s::UTF16String)
     d = s.data
     i = length(d) - 1

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -38,7 +38,7 @@ function endof(s::UTF8String)
     i
 end
 
-@inline is_utf8_continuation(byte::UInt8) = ((byte&0xc0)==0x80)
+is_utf8_continuation(byte::UInt8) = ((byte&0xc0) == 0x80)
 
 function length(s::UTF8String)
     d = s.data

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -37,8 +37,17 @@ function endof(s::UTF8String)
     end
     i
 end
-length(s::UTF8String) = Int(ccall(:u8_charnum, Csize_t, (Ptr{UInt8}, Csize_t),
-                                  s.data, length(s.data)))
+
+@inline is_utf8_continuation(byte::UInt8) = ((byte&0xc0)==0x80)
+
+function length(s::UTF8String)
+    d = s.data
+    cnum = 0
+    for i = 1:length(d)
+        @inbounds cnum += !is_utf8_continuation(d[i])
+    end
+    cnum
+end
 
 function next(s::UTF8String, i::Int)
     # potentially faster version

--- a/src/support/utf8.c
+++ b/src/support/utf8.c
@@ -254,47 +254,6 @@ size_t u8_charnum(const char *s, size_t offset)
     return charnum;
 }
 
-/**
- * @brief      Calculates number of characters in a UTF-16 string
- *
- * @param[in]  iStr UTF-16 encoded string
- * @param[in]  iLen Length of the string in 16-bit words
- *
- * @return     number of logical characters (or codepoints)
- */
-DLLEXPORT size_t u16_charnum(const uint16_t *iStr, size_t iLen)
-{
-    size_t logChar = 0; // # of logical characters
-    if (iLen) {
-        do {
-            // Simply don't count trailing surrogate characters
-            // Since we are not doing validation anyway, we can just
-            // assume this is a valid UTF-16 string
-            logChar += !is_surrogate_trail(*iStr);
-            iStr++;
-        } while (--iLen);
-    }
-    return logChar;
-}
-
-/* number of characters in NUL-terminated string */
-size_t u8_strlen(const char *s)
-{
-    size_t count = 0;
-    size_t i = 0, lasti;
-
-    while (1) {
-        lasti = i;
-        while (s[i] > 0)
-            i++;
-        count += (i-lasti);
-        if (s[i++]==0) break;
-        (void)(isutf(s[++i]) || isutf(s[++i]) || ++i);
-        count++;
-    }
-    return count;
-}
-
 size_t u8_strwidth(const char *s)
 {
     uint32_t ch;

--- a/src/support/utf8.c
+++ b/src/support/utf8.c
@@ -232,7 +232,14 @@ size_t u8_offset(const char *s, size_t charnum)
     return i;
 }
 
-/* byte offset => charnum */
+/**
+ * @brief      Calculates number of characters in a UTF-8 string
+ * 
+ * @param[in]  iStr UTF-8 encoded string
+ * @param[in]  iLen Length of the string in bytes
+ *
+ * @return number of logical characters
+ */
 size_t u8_charnum(const char *s, size_t offset)
 {
     size_t charnum = 0;
@@ -245,6 +252,29 @@ size_t u8_charnum(const char *s, size_t offset)
        } while (--offset);
     }
     return charnum;
+}
+
+/**
+ * @brief      Calculates number of characters in a UTF-16 string
+ * 
+ * @param[in]  iStr UTF-16 encoded string
+ * @param[in]  iLen Length of the string in 16-bit words
+ *
+ * @return number of logical characters
+ */
+DLLEXPORT size_t u16_charnum(const uint16_t *iStr, size_t iLen)
+{
+    size_t logChar = 0;	// # of logical characters
+    if (iLen) {
+	do {
+	    // Simply don't count trailing surrogate characters
+	    // Since we are not doing validation anyway, we can just
+	    // assume this is a valid UTF-16 string
+	    logChar += !is_surrogate_trail(*iStr);
+	    iStr++;
+	} while (--iLen);
+    }
+    return logChar;
 }
 
 /* number of characters in NUL-terminated string */

--- a/src/support/utf8.c
+++ b/src/support/utf8.c
@@ -232,14 +232,7 @@ size_t u8_offset(const char *s, size_t charnum)
     return i;
 }
 
-/**
- * @brief      Calculates number of characters in a UTF-8 string
- *
- * @param[in]  s      UTF-8 encoded string
- * @param[in]  offset Length of the string (or substring) in bytes
- *
- * @return     Number of logical characters (or codepoints)
- */
+/* byte offset => charnum */
 size_t u8_charnum(const char *s, size_t offset)
 {
     size_t charnum = 0;

--- a/src/support/utf8.c
+++ b/src/support/utf8.c
@@ -234,11 +234,11 @@ size_t u8_offset(const char *s, size_t charnum)
 
 /**
  * @brief      Calculates number of characters in a UTF-8 string
- * 
- * @param[in]  iStr UTF-8 encoded string
- * @param[in]  iLen Length of the string in bytes
  *
- * @return number of logical characters
+ * @param[in]  s      UTF-8 encoded string
+ * @param[in]  offset Length of the string (or substring) in bytes
+ *
+ * @return     Number of logical characters (or codepoints)
  */
 size_t u8_charnum(const char *s, size_t offset)
 {
@@ -256,23 +256,23 @@ size_t u8_charnum(const char *s, size_t offset)
 
 /**
  * @brief      Calculates number of characters in a UTF-16 string
- * 
+ *
  * @param[in]  iStr UTF-16 encoded string
  * @param[in]  iLen Length of the string in 16-bit words
  *
- * @return number of logical characters
+ * @return     number of logical characters (or codepoints)
  */
 DLLEXPORT size_t u16_charnum(const uint16_t *iStr, size_t iLen)
 {
-    size_t logChar = 0;	// # of logical characters
+    size_t logChar = 0; // # of logical characters
     if (iLen) {
-	do {
-	    // Simply don't count trailing surrogate characters
-	    // Since we are not doing validation anyway, we can just
-	    // assume this is a valid UTF-16 string
-	    logChar += !is_surrogate_trail(*iStr);
-	    iStr++;
-	} while (--iLen);
+        do {
+            // Simply don't count trailing surrogate characters
+            // Since we are not doing validation anyway, we can just
+            // assume this is a valid UTF-16 string
+            logChar += !is_surrogate_trail(*iStr);
+            iStr++;
+        } while (--iLen);
     }
     return logChar;
 }

--- a/src/support/utf8.h
+++ b/src/support/utf8.h
@@ -8,15 +8,6 @@ extern "C" {
 /* is c the start of a utf8 sequence? */
 #define isutf(c) (((c)&0xC0)!=0x80)
 
-//! Return if a 16-bit or 32-bit character is a surrogate character
-#define	is_surrogate_char(ch)  (((ch) & ~0x7ff) == 0xd800)
-//! Return if a 16-bit or 32-bit character is a leading surrogate character
-#define	is_surrogate_lead(ch)  (((ch) & ~0x3ff) == 0xd800)
-//! Return if a 16-bit or 32-bit character is a trailing surrogate character
-#define	is_surrogate_trail(ch) (((ch) & ~0x3ff) == 0xdc00)
-//! Return if a byte is a valid UTF-8 continuation character
-#define	is_valid_continuation(ch) ((ch & 0xc0) == 0x80)
-
 #define UEOF ((uint32_t)-1)
 
 /* convert UTF-8 data to wide character */

--- a/src/support/utf8.h
+++ b/src/support/utf8.h
@@ -33,21 +33,21 @@ DLLEXPORT size_t u8_offset(const char *str, size_t charnum);
 
 /**
  * @brief      Calculates number of characters in UTF-8 encoded string
- * 
- * @param[in]  iStr UTF-8 encoded string
+ *
+ * @param[in]  iStr UTF-8 encoded string (or substring)
  * @param[in]  iLen Length of string (or substring) in bytes
  *
- * @return     Number of logical characters in string (or substring)
+ * @return     Number of logical characters (or codepoints) in string (or substring)
  */
-DLLEXPORT size_t u8_charnum(const char *iStr, size_t iOffset);
+DLLEXPORT size_t u8_charnum(const char *iStr, size_t iLen);
 
 /**
  * @brief      Calculates number of characters in UTF-16 encoded string
- * 
+ *
  * @param[in]  iStr UTF-16 encoded string
  * @param[in]  iLen Length of the string (or substring) in 16-bit words
  *
- * @return     Number of logical characters in string (or substring)
+ * @return     Number of logical characters (or codepoints) in string (or substring)
  */
 DLLEXPORT size_t u16_charnum(const uint16_t *iStr, size_t iLen);
 

--- a/src/support/utf8.h
+++ b/src/support/utf8.h
@@ -22,15 +22,8 @@ size_t u8_wc_toutf8(char *dest, uint32_t ch);
 /* character number to byte offset */
 DLLEXPORT size_t u8_offset(const char *str, size_t charnum);
 
-/**
- * @brief      Calculates number of characters in UTF-8 encoded string
- *
- * @param[in]  iStr UTF-8 encoded string (or substring)
- * @param[in]  iLen Length of string (or substring) in bytes
- *
- * @return     Number of logical characters (or codepoints) in string (or substring)
- */
-DLLEXPORT size_t u8_charnum(const char *iStr, size_t iLen);
+/* byte offset to character number */
+DLLEXPORT size_t u8_charnum(const char *str, size_t offset);
 
 /* return next character, updating an index variable */
 uint32_t u8_nextchar(const char *s, size_t *i);

--- a/src/support/utf8.h
+++ b/src/support/utf8.h
@@ -41,16 +41,6 @@ DLLEXPORT size_t u8_offset(const char *str, size_t charnum);
  */
 DLLEXPORT size_t u8_charnum(const char *iStr, size_t iLen);
 
-/**
- * @brief      Calculates number of characters in UTF-16 encoded string
- *
- * @param[in]  iStr UTF-16 encoded string
- * @param[in]  iLen Length of the string (or substring) in 16-bit words
- *
- * @return     Number of logical characters (or codepoints) in string (or substring)
- */
-DLLEXPORT size_t u16_charnum(const uint16_t *iStr, size_t iLen);
-
 /* return next character, updating an index variable */
 uint32_t u8_nextchar(const char *s, size_t *i);
 
@@ -118,9 +108,6 @@ char *u8_strchr(const char *s, uint32_t ch, size_t *charn);
 char *u8_memchr(const char *s, uint32_t ch, size_t sz, size_t *charn);
 
 char *u8_memrchr(const char *s, uint32_t ch, size_t sz);
-
-/* count the number of characters in a UTF-8 string */
-DLLEXPORT size_t u8_strlen(const char *s);
 
 /* number of columns occupied by a string */
 DLLEXPORT size_t u8_strwidth(const char *s);

--- a/src/support/utf8.h
+++ b/src/support/utf8.h
@@ -8,6 +8,15 @@ extern "C" {
 /* is c the start of a utf8 sequence? */
 #define isutf(c) (((c)&0xC0)!=0x80)
 
+//! Return if a 16-bit or 32-bit character is a surrogate character
+#define	is_surrogate_char(ch)  (((ch) & ~0x7ff) == 0xd800)
+//! Return if a 16-bit or 32-bit character is a leading surrogate character
+#define	is_surrogate_lead(ch)  (((ch) & ~0x3ff) == 0xd800)
+//! Return if a 16-bit or 32-bit character is a trailing surrogate character
+#define	is_surrogate_trail(ch) (((ch) & ~0x3ff) == 0xdc00)
+//! Return if a byte is a valid UTF-8 continuation character
+#define	is_valid_continuation(ch) ((ch & 0xc0) == 0x80)
+
 #define UEOF ((uint32_t)-1)
 
 /* convert UTF-8 data to wide character */
@@ -22,8 +31,25 @@ size_t u8_wc_toutf8(char *dest, uint32_t ch);
 /* character number to byte offset */
 DLLEXPORT size_t u8_offset(const char *str, size_t charnum);
 
-/* byte offset to character number */
-DLLEXPORT size_t u8_charnum(const char *s, size_t offset);
+/**
+ * @brief      Calculates number of characters in UTF-8 encoded string
+ * 
+ * @param[in]  iStr UTF-8 encoded string
+ * @param[in]  iLen Length of string (or substring) in bytes
+ *
+ * @return     Number of logical characters in string (or substring)
+ */
+DLLEXPORT size_t u8_charnum(const char *iStr, size_t iOffset);
+
+/**
+ * @brief      Calculates number of characters in UTF-16 encoded string
+ * 
+ * @param[in]  iStr UTF-16 encoded string
+ * @param[in]  iLen Length of the string (or substring) in 16-bit words
+ *
+ * @return     Number of logical characters in string (or substring)
+ */
+DLLEXPORT size_t u16_charnum(const uint16_t *iStr, size_t iLen);
 
 /* return next character, updating an index variable */
 uint32_t u8_nextchar(const char *s, size_t *i);


### PR DESCRIPTION
This adds an optimized version to get the length of a UTF16String, it is about an order of magnitude faster (it is still O(n) like UTF8String, instead of O(1) like ASCIIString or UTF32String, though)
