### PR TITLE
Add a keyword argument to `showerror` to control backtrace printing

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -78,22 +78,22 @@ function showerror(io::IO, ex::TypeError)
     end
 end
 
-function showerror(io::IO, ex, bt)
+function showerror(io::IO, ex, bt; backtrace=true)
     try
         showerror(io, ex)
     finally
-        show_backtrace(io, bt)
+        backtrace && show_backtrace(io, bt)
     end
 end
 
-function showerror(io::IO, ex::LoadError, bt)
+function showerror(io::IO, ex::LoadError, bt; backtrace=true)
     print(io, "LoadError: ")
-    showerror(io, ex.error, bt)
+    showerror(io, ex.error, bt, backtrace=backtrace)
     print(io, "\nwhile loading $(ex.file), in expression starting on line $(ex.line)")
 end
 showerror(io::IO, ex::LoadError) = showerror(io, ex, [])
 
-function showerror(io::IO, ex::DomainError, bt)
+function showerror(io::IO, ex::DomainError, bt; backtrace=true)
     print(io, "DomainError:")
     for b in bt
         code = ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), b-1, true)
@@ -108,7 +108,8 @@ function showerror(io::IO, ex::DomainError, bt)
             break
         end
     end
-    show_backtrace(io, bt)
+    backtrace && show_backtrace(io, bt)
+    nothing
 end
 
 showerror(io::IO, ex::SystemError) = print(io, "SystemError: $(ex.prefix): $(Libc.strerror(ex.errnum))")


### PR DESCRIPTION
~~Refactoring `showerror` function into two functions, an exported `showerror` and a `showerr_message`.  The `showerror` function will call the `showerr_message` and afterwards show the backtraces.~~

~~This separation is to allow IJulia to call showerr_message and then handle the printing of backtraces separately, see https://github.com/JuliaLang/IJulia.jl/issues/305. This is not possible today because the `showerror(io::IO, ex::DomainError, bt)` uses the backtrace to generate a more informative error message, but it also prints the backtraces which is unwanted. This PR separate `showerror` into two functions to handle cases were just the error message is wanted.~~

Edit:
This add a keyword argument to `showerror` to control whether the backtraces is printed in order to fix https://github.com/JuliaLang/IJulia.jl/issues/305.

CC @stevengj
