### PR TITLE
fix #10987, tests fail when run from a symlink

### DIFF
--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -99,7 +99,7 @@ end
 @test readall(setenv(`sh -c "echo \$TEST"`,"TEST"=>"Hello World")) == "Hello World\n"
 @test (withenv("TEST"=>"Hello World") do
        readall(`sh -c "echo \$TEST"`); end) == "Hello World\n"
-@test readall(setenv(`sh -c "pwd"`;dir="..")) == readall(setenv(`sh -c "cd .. && pwd"`))
+@test readall(setenv(`sh -c "pwd -P"`;dir="..")) == readall(setenv(`sh -c "cd .. && pwd -P"`))
 
 # Here we test that if we close a stream with pending writes, we don't lose the writes.
 str = ""


### PR DESCRIPTION
`pwd -P` is posix, so hopefully should work in every `sh` that we might spawn here
