### PR TITLE
Fix printing of LaTeX markdown to IPython and plain text.

### DIFF
--- a/base/markdown/IPython/IPython.jl
+++ b/base/markdown/IPython/IPython.jl
@@ -25,5 +25,11 @@ end
 writemime(io::IO, ::MIME"text/plain", tex::LaTeX) =
     print(io, '$', tex.formula, '$')
 
+latex(io::IO, tex::LaTeX) =
+    print(io, "\$\$", tex.formula, "\$\$")
+
+latexinline(io::IO, tex::LaTeX) =
+    print(io, '$', tex.formula, '$')
+
 term(io::IO, tex::LaTeX, cols) = println_with_format(:magenta, io, tex.formula)
 terminline(io::IO, tex::LaTeX) = print_with_format(:magenta, io, tex.formula)

--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -42,6 +42,8 @@ function plain(io::IO, md::HorizontalRule)
     println(io, "–" ^ 3)
 end
 
+plain(io::IO, md) = writemime(io, "text/plain", md)
+
 # Inline elements
 
 plaininline(x) = sprint(plaininline, x)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 using Base.Markdown
-import Base.Markdown: MD, Paragraph, Header, Italic, Bold, plain, term, html, Table, Code
+import Base.Markdown: MD, Paragraph, Header, Italic, Bold, plain, term, html, Table, Code, LaTeX
 import Base: writemime
 
 # Basics
@@ -176,3 +176,18 @@ t = """a   |   b
 1   |   2
 """
 @test plain(Markdown.parse(t)) == t
+
+
+# LaTeX extension
+latex_doc = md"""
+We have $x^2 < x$ whenever:
+
+$|x| < 1$"""
+
+@test latex_doc == MD(Any[Paragraph(Any["We have ",
+                                        LaTeX("x^2 < x"),
+                                        " whenever:"]),
+                          LaTeX("|x| < 1")])
+
+
+@test latex(latex_doc) == "We have \$x^2 < x\$ whenever:\n\$\$|x| < 1\$\$"


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/IJulia.jl/issues/304, which was caused by two separate issues: 
- First, `plain(::IO, ::LaTeX)` wasn't defined, even though Base defines it for all other Markdown elements. The previous definition of `writemime(..., ::LaTeX)` is now implicitly defined via the `Base.writemime(io::IO, ::MIME"text/plain", md::MD) = plain(io, md)` definition. 
- Second, `latex(::IO, ::LaTeX)` wasn't defined. 
