### PR TITLE
Improve the performance of serialization by > 2x while maintaining backwards compatibility

### DIFF
--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -14,73 +14,98 @@ abstract LongTuple
 abstract LongExpr
 abstract UndefRefTag
 
-const ser_version = 2 # do not make changes without bumping the version #!
-const ser_tag = ObjectIdDict()
-const deser_tag = ObjectIdDict()
-let i = 2
-    global ser_tag, deser_tag
-    for t = Any[
-             Symbol, Int8, UInt8, Int16, UInt16, Int32, UInt32,
-             Int64, UInt64, Int128, UInt128, Float32, Float64, Char, Ptr,
-             DataType, UnionType, Function,
-             Tuple, Array, Expr, LongSymbol, LongTuple, LongExpr,
-             LineNumberNode, SymbolNode, LabelNode, GotoNode,
-             QuoteNode, TopNode, TypeVar, Box, LambdaStaticData,
-             Module, UndefRefTag, Task, ASCIIString, UTF8String,
-             UTF16String, UTF32String, Float16,
-             SimpleVector, :reserved10, :reserved11, :reserved12,
+const TAGS = Any[
+    Symbol, Int8, UInt8, Int16, UInt16, Int32, UInt32,
+    Int64, UInt64, Int128, UInt128, Float32, Float64, Char, Ptr,
+    DataType, UnionType, Function,
+    Tuple, Array, Expr, LongSymbol, LongTuple, LongExpr,
+    LineNumberNode, SymbolNode, LabelNode, GotoNode,
+    QuoteNode, TopNode, TypeVar, Box, LambdaStaticData,
+    Module, UndefRefTag, Task, ASCIIString, UTF8String,
+    UTF16String, UTF32String, Float16,
+    SimpleVector, :reserved10, :reserved11, :reserved12,
 
-             (), Bool, Any, :Any, Bottom, :reserved21, :reserved22, Type,
-             :Array, :TypeVar, :Box,
-             :lambda, :body, :return, :call, symbol("::"),
-             :(=), :null, :gotoifnot, :A, :B, :C, :M, :N, :T, :S, :X, :Y,
-             :a, :b, :c, :d, :e, :f, :g, :h, :i, :j, :k, :l, :m, :n, :o,
-             :p, :q, :r, :s, :t, :u, :v, :w, :x, :y, :z,
-             :add_int, :sub_int, :mul_int, :add_float, :sub_float,
-             :mul_float, :unbox, :box,
-             :eq_int, :slt_int, :sle_int, :ne_int,
-             :arrayset, :arrayref,
-             :Core, :Base, svec(), Tuple{},
-             :reserved17, :reserved18, :reserved19, :reserved20,
-             false, true, nothing, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
-             12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
-             28, 29, 30, 31, 32]
-        ser_tag[t] = Int32(i)
-        deser_tag[Int32(i)] = t
+    (), Bool, Any, :Any, Bottom, :reserved21, :reserved22, Type,
+    :Array, :TypeVar, :Box,
+    :lambda, :body, :return, :call, symbol("::"),
+    :(=), :null, :gotoifnot, :A, :B, :C, :M, :N, :T, :S, :X, :Y,
+    :a, :b, :c, :d, :e, :f, :g, :h, :i, :j, :k, :l, :m, :n, :o,
+    :p, :q, :r, :s, :t, :u, :v, :w, :x, :y, :z,
+    :add_int, :sub_int, :mul_int, :add_float, :sub_float,
+    :mul_float, :unbox, :box,
+    :eq_int, :slt_int, :sle_int, :ne_int,
+    :arrayset, :arrayref,
+    :Core, :Base, svec(), Tuple{},
+    :reserved17, :reserved18, :reserved19, :reserved20,
+    false, true, nothing, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+    12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+    28, 29, 30, 31, 32
+]
+
+const ser_version = 2 # do not make changes without bumping the version #!
+const SER_TAG = ObjectIdDict()
+const DESER_TAG = ObjectIdDict()
+let i = 2
+    for t = TAGS
+        SER_TAG[t] = Int32(i)
+        DESER_TAG[Int32(i)] = t
         i += 1
     end
 end
 
-# tags >= this just represent themselves, their whole representation is 1 byte
-const VALUE_TAGS = ser_tag[()]
+const NTAGS = length(TAGS)
+const TAG_PTRS = Array(Ptr{Void}, NTAGS)
 
-const EMPTY_TUPLE_TAG = ser_tag[()]
-const ZERO_TAG = ser_tag[0]
-const INT_TAG = ser_tag[Int]
-
-writetag(s, x) = write(s, UInt8(ser_tag[x]))
-
-function write_as_tag(s, x)
-    t = ser_tag[x]
-    if t < VALUE_TAGS
-        write(s, UInt8(0))
+function sertag(v::ANY)
+    idx = 2
+    ptr = pointer_from_objref(v)
+    @inbounds @simd for i = 1:NTAGS
+        ptr == TAG_PTRS[i] && return Int32(idx)
+        idx += 1
     end
-    write(s, UInt8(t))
+    return Int32(-1)
+end
+desertag(i::Int32) = TAGS[i-1]
+
+function __init__()
+    for i in 1:NTAGS
+        TAG_PTRS[i] = pointer_from_objref(TAGS[i])
+    end
 end
 
-serialize(s, x::Bool) = write_as_tag(s, x)
+function test_roundtrip(obj)
+    io = IOBuffer()
+    serialize(io, obj)
+    seekstart(io)
+    dobj = deserialize(io)
+    return dobj == obj, dobj
+end
+
+# tags >= this just represent themselves, their whole representation is 1 byte
+const VALUE_TAGS = SER_TAG[()]
+const ZERO_TAG = SER_TAG[0]
+
+writetag(s, tag) = write(s, UInt8(tag))
+
+function write_as_tag(s, tag)
+    tag < VALUE_TAGS && write(s, UInt8(0))
+    write(s, UInt8(tag))
+end
+
+@eval serialize(s, x::Bool) = x ? writetag(s, $(SER_TAG[true])) :
+                                  writetag(s, $(SER_TAG[false]))
 
 serialize(s, ::Ptr) = error("cannot serialize a pointer")
 
-serialize(s, ::Tuple{}) = write(s, UInt8(EMPTY_TUPLE_TAG)) # write_as_tag(s, ())
+@eval serialize(s, ::Tuple{}) = writetag(s, $(SER_TAG[()]))
 
-function serialize(s, t::Tuple)
+@eval function serialize(s, t::Tuple)
     l = length(t)
     if l <= 255
-        writetag(s, Tuple)
+        writetag(s, $(SER_TAG[Tuple]))
         write(s, UInt8(l))
     else
-        writetag(s, LongTuple)
+        writetag(s, $(SER_TAG[LongTuple]))
         write(s, Int32(l))
     end
     for i = 1:l
@@ -88,25 +113,26 @@ function serialize(s, t::Tuple)
     end
 end
 
-function serialize(s, v::SimpleVector)
-    writetag(s, SimpleVector)
+@eval function serialize(s, v::SimpleVector)
+    writetag(s, $(SER_TAG[SimpleVector]))
     write(s, Int32(length(v)))
     for i = 1:length(v)
         serialize(s, v[i])
     end
 end
 
-function serialize(s, x::Symbol)
-    if haskey(ser_tag, x)
-        return write_as_tag(s, x)
+@eval function serialize(s, x::Symbol)
+    tag = sertag(x)
+    if tag > 0
+        return write_as_tag(s, tag)
     end
     pname = unsafe_convert(Ptr{UInt8}, x)
     ln = Int(ccall(:strlen, Csize_t, (Ptr{UInt8},), pname))
     if ln <= 255
-        writetag(s, Symbol)
+        writetag(s, $(SER_TAG[Symbol]))
         write(s, UInt8(ln))
     else
-        writetag(s, LongSymbol)
+        writetag(s, $(SER_TAG[LongSymbol]))
         write(s, Int32(ln))
     end
     write(s, pname, ln)
@@ -132,8 +158,8 @@ function serialize_array_data(s, a)
     end
 end
 
-function serialize(s, a::Array)
-    writetag(s, Array)
+@eval function serialize(s, a::Array)
+    writetag(s, $(SER_TAG[Array]))
     elty = eltype(a)
     if elty !== UInt8
         serialize(s, elty)
@@ -150,17 +176,17 @@ function serialize(s, a::Array)
             if isdefined(a, i)
                 serialize(s, a[i])
             else
-                writetag(s, UndefRefTag)
+                writetag(s, $(SER_TAG[UndefRefTag]))
             end
         end
     end
 end
 
-function serialize{T,N,A<:Array}(s, a::SubArray{T,N,A})
+@eval function serialize{T,N,A<:Array}(s, a::SubArray{T,N,A})
     if !isbits(T) || stride(a,1)!=1
         return serialize(s, copy(a))
     end
-    writetag(s, Array)
+    writetag(s, $(SER_TAG[Array]))
     serialize(s, T)
     serialize(s, size(a))
     serialize_array_data(s, a)
@@ -173,34 +199,33 @@ end
 
 # Don't serialize the pointers
 function serialize(s, r::Regex)
-    Serializer.serialize_type(s, typeof(r))
+    serialize_type(s, typeof(r))
     serialize(s, r.pattern)
     serialize(s, r.options)
 end
 
 function serialize(s, n::BigInt)
-    Serializer.serialize_type(s, BigInt)
+    serialize_type(s, BigInt)
     serialize(s, base(62,n))
 end
 
-
 function serialize(s, n::BigFloat)
-    Serializer.serialize_type(s, BigFloat)
+    serialize_type(s, BigFloat)
     serialize(s, string(n))
 end
 
-function serialize(s, e::Expr)
-    l = length(e.args)
+@eval function serialize(s, ex::Expr)
+    l = length(ex.args)
     if l <= 255
-        writetag(s, Expr)
+        writetag(s, $(SER_TAG[Expr]))
         write(s, UInt8(l))
     else
-        writetag(s, LongExpr)
+        writetag(s, $(SER_TAG[LongExpr]))
         write(s, Int32(l))
     end
-    serialize(s, e.head)
-    serialize(s, e.typ)
-    for a = e.args
+    serialize(s, ex.head)
+    serialize(s, ex.typ)
+    for a = ex.args
         serialize(s, a)
     end
 end
@@ -214,7 +239,6 @@ function serialize(s, t::Dict)
     end
 end
 
-
 function serialize_mod_names(s, m::Module)
     p = module_parent(m)
     if m !== p
@@ -223,15 +247,14 @@ function serialize_mod_names(s, m::Module)
     end
 end
 
-function serialize(s, m::Module)
-    writetag(s, Module)
+@eval function serialize(s, m::Module)
+    writetag(s, $(SER_TAG[Module]))
     serialize_mod_names(s, m)
-    serialize(s, ())
-    nothing
+    writetag(s, $(SER_TAG[()]))
 end
 
-function serialize(s, f::Function)
-    writetag(s, Function)
+@eval function serialize(s, f::Function)
+    writetag(s, $(SER_TAG[Function]))
     name = false
     if isgeneric(f)
         name = f.env.name
@@ -239,7 +262,7 @@ function serialize(s, f::Function)
         name = f.env
     end
     if isa(name,Symbol)
-        if isdefined(Base,name) && is(f,eval(Base,name))
+        if isdefined(Base,name) && is(f,getfield(Base,name))
             write(s, UInt8(0))
             serialize(s, name)
             return
@@ -251,7 +274,7 @@ function serialize(s, f::Function)
             mod = f.env.defs.func.code.module
         end
         if mod !== ()
-            if isdefined(mod,name) && is(f,eval(mod,name))
+            if isdefined(mod,name) && is(f,getfield(mod,name))
                 # toplevel named func
                 write(s, UInt8(2))
                 serialize(s, mod)
@@ -285,8 +308,8 @@ function lambda_number(l::LambdaStaticData)
     return ln
 end
 
-function serialize(s, linfo::LambdaStaticData)
-    writetag(s, LambdaStaticData)
+@eval function serialize(s, linfo::LambdaStaticData)
+    writetag(s, $(SER_TAG[LambdaStaticData]))
     serialize(s, lambda_number(linfo))
     serialize(s, uncompressed_ast(linfo))
     if isdefined(linfo.def, :roots)
@@ -304,11 +327,11 @@ function serialize(s, linfo::LambdaStaticData)
     end
 end
 
-function serialize(s, t::Task)
+@eval function serialize(s, t::Task)
     if istaskstarted(t) && !istaskdone(t)
         error("cannot serialize a running Task")
     end
-    writetag(s, Task)
+    writetag(s, $(SER_TAG[Task]))
     serialize(s, t.code)
     serialize(s, t.storage)
     serialize(s, t.state == :queued || t.state == :waiting ? (:runnable) : t.state)
@@ -322,7 +345,7 @@ function serialize_type_data(s, t)
     mod = t.name.module
     serialize(s, mod)
     if length(t.parameters) > 0
-        if isdefined(mod,tname) && is(t,eval(mod,tname))
+        if isdefined(mod,tname) && is(t,getfield(mod,tname))
             serialize(s, svec())
         else
             serialize(s, t.parameters)
@@ -330,39 +353,39 @@ function serialize_type_data(s, t)
     end
 end
 
-function serialize(s, t::DataType)
-    if haskey(ser_tag,t)
-        write_as_tag(s, t)
-    else
-        writetag(s, DataType)
-        write(s, UInt8(0))
-        serialize_type_data(s, t)
+@eval function serialize(s, t::DataType)
+    tag = sertag(t)
+    if tag > 0
+        return write_as_tag(s, tag)
     end
+    writetag(s, $(SER_TAG[DataType]))
+    write(s, UInt8(0))
+    serialize_type_data(s, t)
 end
 
-function serialize_type(s, t::DataType)
-    if haskey(ser_tag,t)
-        writetag(s, t)
-    else
-        writetag(s, DataType)
-        write(s, UInt8(1))
-        serialize_type_data(s, t)
+@eval function serialize_type(s, t::DataType)
+    tag = sertag(t)
+    if tag > 0
+        return writetag(s, tag)
     end
+    writetag(s, $(SER_TAG[DataType]))
+    write(s, UInt8(1))
+    serialize_type_data(s, t)
 end
 
-function serialize(s, n::Int)
+@eval function serialize(s, n::Int)
     if 0 <= n <= 32
         write(s, UInt8(ZERO_TAG+n))
         return
     end
-    write(s, UInt8(INT_TAG))
+    writetag(s, $(SER_TAG[Int]))
     write(s, n)
-    nothing
 end
 
-function serialize(s, x)
-    if haskey(ser_tag,x)
-        return write_as_tag(s, x)
+@eval function serialize(s, x)
+    tag = sertag(x)
+    if tag > 0
+        return write_as_tag(s, tag)
     end
     t = typeof(x)
     nf = nfields(t)
@@ -374,7 +397,7 @@ function serialize(s, x)
             if isdefined(x, i)
                 serialize(s, getfield(x, i))
             else
-                writetag(s, UndefRefTag)
+                writetag(s, $(SER_TAG[UndefRefTag]))
             end
         end
     end
@@ -382,15 +405,14 @@ end
 
 ## deserializing values ##
 
-function deserialize(s)
+deserialize(s) =
     handle_deserialize(s, Int32(read(s, UInt8)))
-end
 
 function handle_deserialize(s, b)
     if b == 0
-        return deser_tag[Int32(read(s, UInt8))]
+        return desertag(Int32(read(s, UInt8)))
     end
-    tag = deser_tag[b]
+    tag = desertag(b)
     if b >= VALUE_TAGS
         return tag
     elseif is(tag,Tuple)
@@ -422,7 +444,7 @@ function deserialize(s, ::Type{Module})
             if !isdefined(m,mname)
                 warn("Module $mname not defined on process $(myid())")  # an error seemingly fails
             end
-            m = eval(m,mname)::Module
+            m = getfield(m,mname)::Module
         end
     else
         mname = path
@@ -430,7 +452,7 @@ function deserialize(s, ::Type{Module})
             if !isdefined(m,mname)
                 warn("Module $mname not defined on process $(myid())")  # an error seemingly fails
             end
-            m = eval(m,mname)::Module
+            m = getfield(m,mname)::Module
             mname = deserialize(s)
         end
     end
@@ -446,14 +468,14 @@ function deserialize(s, ::Type{Function})
         if !isdefined(Base,name)
             return (args...)->error("function $name not defined on process $(myid())")
         end
-        return eval(Base,name)::Function
+        return getfield(Base,name)::Function
     elseif b==2
         mod = deserialize(s)::Module
         name = deserialize(s)::Symbol
         if !isdefined(mod,name)
             return (args...)->error("function $name not defined on process $(myid())")
         end
-        return eval(mod,name)::Function
+        return getfield(mod,name)::Function
     elseif b==3
         env = deserialize(s)
         return ccall(:jl_new_gf_internal, Any, (Any,), env)::Function
@@ -525,7 +547,7 @@ function deserialize(s, ::Type{Array})
     A = Array(elty, dims)
     for i = 1:length(A)
         tag = Int32(read(s, UInt8))
-        if tag==0 || !is(deser_tag[tag], UndefRefTag)
+        if tag==0 || !is(desertag(tag), UndefRefTag)
             A[i] = handle_deserialize(s, tag)
         end
     end
@@ -553,7 +575,7 @@ function deserialize(s, ::Type{DataType})
     form = read(s, UInt8)
     name = deserialize(s)::Symbol
     mod = deserialize(s)::Module
-    ty = eval(mod,name)
+    ty = getfield(mod,name)
     if length(ty.parameters) == 0
         t = ty
     else
@@ -606,7 +628,7 @@ function deserialize(s, t::DataType)
         x = ccall(:jl_new_struct_uninit, Any, (Any,), t)
         for i in 1:nf
             tag = Int32(read(s, UInt8))
-            if tag==0 || !is(deser_tag[tag], UndefRefTag)
+            if tag==0 || !is(desertag(tag), UndefRefTag)
                 ccall(:jl_set_nth_field, Void, (Any, Csize_t, Any), x, i-1, handle_deserialize(s, tag))
             end
         end

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -193,7 +193,8 @@ function serialize(s, S::SharedArray)
     Serializer.serialize_type(s, typeof(S))
     for n in SharedArray.name.names
         if n in [:s, :pidx, :loc_subarr_1d]
-            Serializer.writetag(s, Serializer.UndefRefTag)
+            Serializer.writetag(s,
+                Serializer.sertag(Serializer.UndefRefTag))
         else
             serialize(s, getfield(S, n))
         end

--- a/test/remote.jl
+++ b/test/remote.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # Check that serializer hasn't gone out-of-frame
-@test Serializer.ser_tag[Symbol] == 2
-@test Serializer.ser_tag[()] == 47
-@test Serializer.ser_tag[false] == 123
+@test Serializer.sertag(Symbol) == 2
+@test Serializer.sertag(()) == 47
+@test Serializer.sertag(false) == 123
 
 # issue #1770
 let

--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -10,20 +10,20 @@ end
 
 # Tags
 create_serialization_stream() do s
-    Serializer.writetag(s, Bool)
-    @test takebuf_array(s)[end] == UInt8(Serializer.ser_tag[Bool])
+    Serializer.writetag(s, Serializer.sertag(Bool))
+    @test takebuf_array(s)[end] == UInt8(Serializer.sertag(Bool))
 end
 
 create_serialization_stream() do s
-    Serializer.write_as_tag(s, Bool)
-    @test takebuf_array(s)[end] == UInt8(Serializer.ser_tag[Bool])
+    Serializer.write_as_tag(s, Serializer.sertag(Bool))
+    @test takebuf_array(s)[end] == UInt8(Serializer.sertag(Bool))
 end
 
 create_serialization_stream() do s
-    Serializer.write_as_tag(s, Symbol)
+    Serializer.write_as_tag(s, Serializer.sertag(Symbol))
     data = takebuf_array(s)
     @test data[end-1] == 0x00
-    @test data[end] == UInt8(Serializer.ser_tag[Symbol])
+    @test data[end] == UInt8(Serializer.sertag(Symbol))
 end
 
 # Boolean & Empty & Nothing


### PR DESCRIPTION
Use a vector of object pointers and linear search instead of looking up tag from an `ObjectIdDict`.  Also, compute constant tag values at compile time.

Deserialization performance is about 20% better.  To improve performance further we probably need to reduce the dynamic dispatch overhead.
