### PR TITLE
Limit type-annotation highlighting to code_warntype

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -204,9 +204,10 @@ versioninfo(verbose::Bool) = versioninfo(STDOUT,verbose)
 
 function code_warntype(io::IO, f, t::ANY)
     global show_expr_type_emphasize
+    global may_show_expr_type_emphasize
     state = show_expr_type_emphasize::Bool
     ct = code_typed(f, t)
-    show_expr_type_emphasize::Bool = true
+    show_expr_type_emphasize::Bool = may_show_expr_type_emphasize::Bool = true
     for ast in ct
         println(io, "Variables:")
         vars = ast.args[2][2]
@@ -219,7 +220,7 @@ function code_warntype(io::IO, f, t::ANY)
         show_unquoted(io, ast.args[3], 2)
         print(io, '\n')
     end
-    show_expr_type_emphasize::Bool = false
+    show_expr_type_emphasize::Bool = may_show_expr_type_emphasize::Bool = false
     nothing
 end
 code_warntype(f, t::ANY) = code_warntype(STDOUT, f, t)

--- a/base/show.jl
+++ b/base/show.jl
@@ -298,6 +298,7 @@ unquoted(ex::Expr)       = ex.args[1]
 ## AST printing helpers ##
 
 const indent_width = 4
+may_show_expr_type_emphasize = false
 show_expr_type_emphasize = false
 
 function show_expr_type(io::IO, ty)
@@ -694,7 +695,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
     # print anything else as "Expr(head, args...)"
     else
         show_type = false
-        show_expr_type_emphasize::Bool = in(ex.head, (:lambda, :method))
+        show_expr_type_emphasize::Bool = may_show_expr_type_emphasize::Bool && in(ex.head, (:lambda, :method))
         print(io, "\$(Expr(")
         show(io, ex.head)
         for arg in args

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -79,6 +79,25 @@ code_warntype(iob, getindex, Tuple{Stable{Float64},Int})
 str = takebuf_string(iob)
 @test !isempty(search(str, tag))
 
+function funfun(x)
+    function internal(y)
+        return 2y
+    end
+    z = internal(3)
+    x
+end
+
+tag = Base.have_color ? string("2y",Base.text_colors[:red],"::Any") : "2y::ANY"
+code_warntype(iob, funfun, Tuple{Float64})
+str = takebuf_string(iob)
+@test !isempty(search(str, tag))
+
+# Make sure emphasis is not used for other functions
+tag = Base.have_color ? Base.text_colors[:red] : "ANY"
+show(iob, expand(:(x->x^2)))
+str = takebuf_string(iob)
+@test isempty(search(str, tag))
+
 end
 
 # isbits


### PR DESCRIPTION
Highlighting was only ever intended to be used for `code_warntype`, but it seems there was an escapee. This should corral it back. 
