### PR TITLE
RFC: Speed up Pkg.update()

### DIFF
--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -40,12 +40,14 @@ function prefetch(pkg::AbstractString, url::AbstractString, sha1s::Vector)
         end
     end
     Git.set_remote_url(url, dir=cache)
-    if !all(sha1->Git.iscommit(sha1, dir=cache), sha1s)
+    in_cache = Git.iscommit(sha1s, dir=cache)
+    if !all(in_cache)
         info("Updating cache of $pkg...")
         Git.success(`remote update`, dir=cache) ||
         error("couldn't update $cache using `git remote update`")
+        in_cache = Git.iscommit(sha1s, dir=cache)
     end
-    filter(sha1->!Git.iscommit(sha1, dir=cache), sha1s)
+    sha1s[!in_cache]
 end
 prefetch(pkg::AbstractString, url::AbstractString, sha1::AbstractString...) = prefetch(pkg, url, AbstractString[sha1...])
 

--- a/base/pkg/git.jl
+++ b/base/pkg/git.jl
@@ -58,6 +58,10 @@ attached(; dir="") = success(`symbolic-ref -q HEAD`, dir=dir)
 branch(; dir="") = readchomp(`rev-parse --symbolic-full-name --abbrev-ref HEAD`, dir=dir)
 head(; dir="") = readchomp(`rev-parse HEAD`, dir=dir)
 
+function iscommit(sha1s::Vector; dir="")
+    indexin(sha1s,split(readchomp(`log --all --format=%H`, dir=dir),"\n")).!=0
+end
+
 immutable State
     head::ASCIIString
     index::ASCIIString


### PR DESCRIPTION
I get a major speed improvement in `Pkg.update()` with this patch. The idea is to use `git log --all` to extract all valid hashes instead of calling `git` on every single hash. This can be used in `Cache.prefetch()`, which currently makes multiple passes through every version of every installed package.

It would probably be good to get some independent testing before merging.

Should improve #9944 somewhat, will eventually be superceded by #7584 (libgit2).
