### PR TITLE
Fix #11117

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -257,7 +257,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl)
             }
             gf = eval((jl_value_t*)fname, locals, nl);
             assert(jl_is_function(gf));
-            assert(jl_is_gf(gf));
+            if (!jl_is_gf(gf)) jl_error("cannot redefine non-generic function");
             if (jl_is_expr(fname))
                 fname = (jl_sym_t*)jl_fieldref(jl_exprarg(fname, 2), 0);
             if (!kw)


### PR DESCRIPTION
It's croaking [here](https://github.com/JuliaLang/julia/blob/79599ada444fcc63cb08aed64b4ff6a415bb4d29/src/interpreter.c#L260).
We backported 97381df5 (fix for #9773) which gives the nice error message,
but didn't remove the related assert, which was removed in 2604610c5.

I think this is safe to remove, but I don't have a 0.3 build handy. cc @tkelman 
