### PR TITLE
Fix invoke for vararg methods.

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1066,10 +1066,13 @@ static jl_function_t *jl_mt_assoc_by_type(jl_methtable_t *mt, jl_datatype_t *tt,
             func = m->func;
             if (m->isstaged)
                 func = jl_instantiate_staged(m,tt,env);
-            JL_GC_POP();
-            if (!cache)
+            if (!cache) {
+                JL_GC_POP();
                 return func;
-            return cache_method(mt, tt, func, m->sig, jl_emptysvec, m->isstaged);
+            }
+            jl_function_t *res = cache_method(mt, tt, func, m->sig, jl_emptysvec, m->isstaged);
+            JL_GC_POP();
+            return res;
         }
         JL_GC_POP();
         return jl_bottom_func;

--- a/test/core.jl
+++ b/test/core.jl
@@ -2812,3 +2812,7 @@ f10995(T::TupleType10978) = (while false; end; @assert isa(T, TupleType10978))
 g10995(x) = f10995(typeof(x))
 g10995((1, 2))
 @test g10995(UInt8) === nothing
+
+# issue #11149
+@noinline f11149(a,b,args...) = (a,b,args...)
+@test f11149(1,2,3) == invoke(f11149, Tuple{Int,Int,Int}, 1,2,3)


### PR DESCRIPTION
When the invoke private method table is created we insert into the
method list manually instead of going through method_table_insert.
This codepath was forgetting to update the max_arg field which is
used to correctly compute the specialized signature for variable
argument methods. Should fix #11149.
