### PR TITLE
Pkg: Don't spawn git processes asynchronously

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -254,18 +254,18 @@ function update(branch::AbstractString)
     end
     avail = Read.available()
     # this has to happen before computing free/fixed
-    @sync for pkg in filter!(Read.isinstalled,collect(keys(avail)))
-        @async Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail[pkg]])
+    for pkg in filter!(Read.isinstalled,collect(keys(avail)))
+        Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail[pkg]])
     end
     instd = Read.installed(avail)
     free = Read.free(instd)
-    @sync for (pkg,ver) in free
-        @async Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail[pkg]])
+    for (pkg,ver) in free
+        Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail[pkg]])
     end
     fixed = Read.fixed(avail,instd)
-    @sync for (pkg,ver) in fixed
+    for (pkg,ver) in fixed
         ispath(pkg,".git") || continue
-        @async begin
+        begin
             if Git.attached(dir=pkg) && !Git.dirty(dir=pkg)
                 info("Updating $pkg...")
                 @recover begin


### PR DESCRIPTION
This change significantly reduces the system overhead from spawning many
git commands asynchronously. By running each git command sequentially,
this change also restores Pkg.update() functionality to Mac OS X
systems rendered unusable by #8601. (Manually trying to raise the default
per-process file handles from 10,240 to 102,400 and the total number of system
file handles from 12,800 to 200,000 did not help on an OS X build with every
registered package checked out.)

This PR is the simplest possible fix for #8601, and might also be useful for
performance complaints on Windows platforms also. Ref: #9944, #10480.
