### PR TITLE
RFC: Add Vector and Matrix constructors

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -16,7 +16,14 @@ typealias StridedMatrix{T,A<:DenseArray,I<:Tuple{Vararg{RangeIndex}}}  Union(Den
 typealias StridedVecOrMat{T} Union(StridedVector{T}, StridedMatrix{T})
 
 call{T}(::Type{Vector{T}}, m::Integer) = Array{T}(m)
+call{T}(::Type{Vector{T}}) = Array{T}(0)
+call(::Type{Vector}, m::Integer) = Array{Any}(m)
+call(::Type{Vector}) = Array{Any}(0)
+
 call{T}(::Type{Matrix{T}}, m::Integer, n::Integer) = Array{T}(m, n)
+call{T}(::Type{Matrix{T}}) = Array{T}(0, 0)
+call(::Type{Matrix}, m::Integer, n::Integer) = Array{Any}(m, n)
+call(::Type{Matrix}) = Array{Any}(0, 0)
 
 ## Basic functions ##
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -122,6 +122,25 @@ ind = findin(a, b)
 rt = Base.return_types(setindex!, Tuple{Array{Int32, 3}, UInt8, Vector{Int}, Float64, UnitRange{Int}})
 @test length(rt) == 1 && rt[1] == Array{Int32, 3}
 
+# construction
+@test typeof(Vector{Int}(3)) == Vector{Int}
+@test typeof(Vector{Int}()) == Vector{Int}
+@test typeof(Vector(3)) == Vector{Any}
+@test typeof(Vector()) == Vector{Any}
+@test typeof(Matrix{Int}(2,3)) == Matrix{Int}
+@test typeof(Matrix{Int}()) == Matrix{Int}
+@test typeof(Matrix(2,3)) == Matrix{Any}
+@test typeof(Matrix()) == Matrix{Any}
+
+@test size(Vector{Int}(3)) == (3,)
+@test size(Vector{Int}()) == (0,)
+@test size(Vector(3)) == (3,)
+@test size(Vector()) == (0,)
+@test size(Matrix{Int}(2,3)) == (2,3)
+@test size(Matrix{Int}()) == (0,0)
+@test size(Matrix(2,3)) == (2,3)
+@test size(Matrix()) == (0,0)
+
 # get
 let
     A = reshape(1:24, 3, 8)


### PR DESCRIPTION
One of my very earliest stumblings with julia was trying to create empty vectors.  The syntax `Int[]` was non-obvious to me, and I kept trying to do things like `Vector{Int}()`.  JuliaLang/julia#3214 is a step in the right direction, as it allows `Vector{T}(0)`.  But is there any reason not to allow `Vector{T}()`?  It would be in line with `Dict()` (or `Dict{K,V}()`), which creates an empty dictionary. (Not to mention C++'s `auto v = std::vector<int>();`, python's `x = list()`, etc., which are in the same style and may form a mental model for people coming from other languages.)

~~On the other hand I don't think `Matrix{T}()` makes sense, as matrices are not meant to be easily resized in the same way vectors can be, so I have not implemented it.~~
