### PR TITLE
RFC: Run the tests on julia-debug if JULIA_DEBUG==1

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -875,9 +875,15 @@ wine_pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(shell printf %s\n '
 endif
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(2)))))
 
+ifeq ($(JULIA_DEBUG), 1)
+JULIA_BUILD_MODE = debug
+else
+JULIA_BUILD_MODE = release
+endif
+
 JULIA_EXECUTABLE_debug = $(build_bindir)/julia-debug$(EXE)
 JULIA_EXECUTABLE_release = $(build_bindir)/julia$(EXE)
-JULIA_EXECUTABLE = $(JULIA_EXECUTABLE_release)
+JULIA_EXECUTABLE = $(JULIA_EXECUTABLE_$(JULIA_BUILD_MODE))
 
 # Colors for make
 ifndef VERBOSE

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,7 @@ ifeq ($(JULIA_BINARYDIST_TARNAME),)
 	JULIA_BINARYDIST_TARNAME = julia-$(JULIA_COMMIT)-$(OS)-$(ARCH)
 endif
 
-ifeq ($(JULIA_DEBUG), 1)
-default: debug
-else
-default: release
-endif
+default: $(JULIA_BUILD_MODE) # contains either "debug" or "release"
 all: debug release
 
 # sort is used to remove potential duplicates
@@ -481,17 +477,17 @@ distcleanall: cleanall
 	install binary-dist light-source-dist.tmp light-source-dist \
 	dist full-source-dist source-dist
 
-test: check-whitespace release
+test: check-whitespace $(JULIA_BUILD_MODE)
 	@$(MAKE) $(QUIET_MAKE) -C test default
 
-testall: check-whitespace release
+testall: check-whitespace $(JULIA_BUILD_MODE)
 	cp $(build_prefix)/lib/julia/sys.ji local.ji && $(JULIA_EXECUTABLE) -J local.ji -e 'true' && rm local.ji
 	@$(MAKE) $(QUIET_MAKE) -C test all
 
-testall1: check-whitespace release
+testall1: check-whitespace $(JULIA_BUILD_MODE)
 	@env JULIA_CPU_CORES=1 $(MAKE) $(QUIET_MAKE) -C test all
 
-test-%: check-whitespace release
+test-%: check-whitespace $(JULIA_BUILD_MODE)
 	@$(MAKE) $(QUIET_MAKE) -C test $*
 
 perf: release


### PR DESCRIPTION
This modifies the `Makefile` so that  `make test` and its siblings will use a debug build of julia if `JULIA_DEBUG` is set to `1`.  Previously, `make test` would always make a release build of julia and then run the tests, even if `make` had just made a debug build of julia due to `JULIA_DEBUG` being set.
