### PR TITLE
Throw genuine ErrorException.

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -80,7 +80,7 @@ end
 function BigFloat(x::AbstractString, base::Int)
     z = BigFloat()
     err = ccall((:mpfr_set_str, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{UInt8}, Int32, Int32), &z, x, base, ROUNDING_MODE[end])
-    err == 0 || throw("incorrectly formatted number \"$x\"")
+    err == 0 || error("incorrectly formatted number \"$x\"")
     return z
 end
 BigFloat(x::AbstractString) = BigFloat(x, 10)


### PR DESCRIPTION
Compare the result of

```
julia> try throw("foobar"); catch e; dump(e);end
ASCIIString "foobar"

julia> try error("foobar"); catch e; dump(e);end
ErrorException 
  msg: ASCIIString "foobar"
```

See also #11146
