### PR TITLE
Remove necessity of sort 'by' and 'lt' parameters being Function types

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -29,12 +29,12 @@ const Reverse = ReverseOrdering(Forward)
 immutable LexicographicOrdering <: Ordering end
 const Lexicographic = LexicographicOrdering()
 
-immutable By <: Ordering
-    by::Function
+immutable By{T} <: Ordering
+    by::T
 end
 
-immutable Lt <: Ordering
-    lt::Function
+immutable Lt{T} <: Ordering
+    lt::T
 end
 
 immutable Perm{O<:Ordering,V<:AbstractVector} <: Ordering
@@ -65,7 +65,7 @@ ordtype(o::Perm,            vs::AbstractArray) = ordtype(o.order, o.data)
 ordtype(o::By,              vs::AbstractArray) = try typeof(o.by(vs[1])) catch; Any end
 ordtype(o::Ordering,        vs::AbstractArray) = eltype(vs)
 
-function ord(lt::Function, by::Function, rev::Bool, order::Ordering=Forward)
+function ord(lt, by, rev::Bool, order::Ordering=Forward)
     o = (lt===isless) & (by===identity) ? order  :
         (lt===isless) & (by!==identity) ? By(by) :
         (lt!==isless) & (by===identity) ? Lt(lt) :

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -52,7 +52,7 @@ function issorted(itr, order::Ordering)
     return true
 end
 issorted(itr;
-    lt::Function=isless, by::Function=identity, rev::Bool=false, order::Ordering=Forward) =
+    lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward) =
     issorted(itr, ord(lt,by,rev,order))
 
 function select!(v::AbstractVector, k::Int, lo::Int, hi::Int, o::Ordering)
@@ -117,7 +117,7 @@ end
 
 select!(v::AbstractVector, k::Union(Int,OrdinalRange), o::Ordering) = select!(v,k,1,length(v),o)
 select!(v::AbstractVector, k::Union(Int,OrdinalRange);
-    lt::Function=isless, by::Function=identity, rev::Bool=false, order::Ordering=Forward) =
+    lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward) =
     select!(v, k, ord(lt,by,rev,order))
 
 select(v::AbstractVector, k::Union(Int,OrdinalRange); kws...) = select!(copy(v), k; kws...)
@@ -235,7 +235,7 @@ for s in [:searchsortedfirst, :searchsortedlast, :searchsorted]
     @eval begin
         $s(v::AbstractVector, x, o::Ordering) = $s(v,x,1,length(v),o)
         $s(v::AbstractVector, x;
-           lt::Function=isless, by::Function=identity, rev::Bool=false, order::Ordering=Forward) =
+           lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward) =
             $s(v,x,ord(lt,by,rev,order))
     end
 end
@@ -360,8 +360,8 @@ sort!(v::AbstractVector, alg::Algorithm, order::Ordering) = sort!(v,1,length(v),
 
 function sort!(v::AbstractVector;
                alg::Algorithm=defalg(v),
-               lt::Function=isless,
-               by::Function=identity,
+               lt=isless,
+               by=identity,
                rev::Bool=false,
                order::Ordering=Forward)
     sort!(v, alg, ord(lt,by,rev,order))
@@ -373,8 +373,8 @@ sort(v::AbstractVector; kws...) = sort!(copy(v); kws...)
 
 function sortperm(v::AbstractVector;
                   alg::Algorithm=DEFAULT_UNSTABLE,
-                  lt::Function=isless,
-                  by::Function=identity,
+                  lt=isless,
+                  by=identity,
                   rev::Bool=false,
                   order::Ordering=Forward)
     sort!(collect(1:length(v)), alg, Perm(ord(lt,by,rev,order),v))
@@ -382,8 +382,8 @@ end
 
 function sortperm!{I<:Integer}(x::AbstractVector{I}, v::AbstractVector;
                                alg::Algorithm=DEFAULT_UNSTABLE,
-                               lt::Function=isless,
-                               by::Function=identity,
+                               lt=isless,
+                               by=identity,
                                rev::Bool=false,
                                order::Ordering=Forward,
                                initialized::Bool=false)


### PR DESCRIPTION
Now that `call` is overloadable, it doesn't make sense to require that the `sort` comparison function can only be a `Function` type. I ran into this when using https://github.com/timholy/FastAnonymous.jl.
