### PR TITLE
Simplify and improve performance of rand(Char)

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -253,14 +253,10 @@ rand(r::MersenneTwister, ::Type{Int128})  = reinterpret(Int128, rand(r, UInt128)
 rand{T<:Real}(r::AbstractRNG, ::Type{Complex{T}}) = complex(rand(r, T), rand(r, T))
 
 # random Char values
-# use simple rejection sampling over valid Char codepoint range
+# returns a random valid Unicode scalar value (i.e. 0 - 0xd7ff, 0xe000 - # 0x10ffff)
 function rand(r::AbstractRNG, ::Type{Char})
-    while true
-        c = rand(0x00000000:0x0010fffd)
-        if is_valid_char(c)
-            return reinterpret(Char,c)
-        end
-    end
+    c = rand(0x00000000:0x0010f7ff)
+    (c < 0xd800) ? Char(c) : Char(c+0x800)
 end
 
 ## Arrays of random numbers


### PR DESCRIPTION
This also fixes a minor issue that two valid code points (0x10fffe and 0x10ffff) would not be produced.
[They are valid code points or scalar values, even though they are part of the set of 66 "NonCharacters",
and per the Unicode standard, need to be allowed].
On testing on my laptop, this took about 83% of the time of the original code...
[kudos to @jakebolewski for #11033 in the first place!]
