### PR TITLE
Add number of allocations to time/timed macros, fix realloc calculations

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1353,6 +1353,7 @@ export
     # profiling
     @time,
     @timed,
+    @timev,
     @elapsed,
     @allocated,
     @profile,

--- a/base/util.jl
+++ b/base/util.jl
@@ -7,14 +7,59 @@
 # high-resolution relative time, in nanoseconds
 time_ns() = ccall(:jl_hrtime, UInt64, ())
 
+# This type must be kept in sync with the C struct in src/gc.c
+immutable GC_Num
+    allocd      ::Int64
+    freed       ::Int64
+    malloc      ::UInt64
+    realloc     ::UInt64
+    poolalloc   ::UInt64
+    freecall    ::UInt64
+    total_time  ::UInt64
+    total_allocd::UInt64
+    since_sweep ::UInt64
+    collect     ::Csize_t
+    pause       ::Cint
+    full_sweep  ::Cint
+end
+
+gc_num() = ccall(:jl_gc_num, GC_Num, ())
+
+# This type is to represent differences in the counters, so fields may be negative
+immutable GC_Diff
+    allocd      ::Int64
+    freed       ::Int64
+    malloc      ::Int64
+    realloc     ::Int64
+    poolalloc   ::Int64
+    freecall    ::Int64
+    total_time  ::Int64
+    total_allocd::Int64
+    since_sweep ::Int64
+    pause       ::Int64
+    full_sweep  ::Int64
+end
+
+function GC_Diff(new::GC_Num, old::GC_Num)
+    return GC_Diff((new.allocd + Int64(new.collect)) - (old.allocd + Int64(old.collect)),
+                   new.freed              - old.freed,
+                   Int64(new.malloc       - old.malloc),
+                   Int64(new.realloc      - old.realloc),
+                   Int64(new.poolalloc    - old.poolalloc),
+                   Int64(new.freecall     - old.freecall),
+                   Int64(new.total_time   - old.total_time),
+                   Int64(new.total_allocd - old.total_allocd),
+                   Int64(new.since_sweep  - old.since_sweep),
+                   new.pause              - old.pause,
+                   new.full_sweep         - old.full_sweep)
+end
+
+
 # total time spend in garbage collection, in nanoseconds
 gc_time_ns() = ccall(:jl_gc_total_hrtime, UInt64, ())
 
 # total number of bytes allocated so far
 gc_bytes() = ccall(:jl_gc_total_bytes, Int64, ())
-
-gc_num_pause() = ccall(:jl_gc_num_pause, Int64, ())
-gc_num_full_sweep() = ccall(:jl_gc_num_full_sweep, Int64, ())
 
 function tic()
     t0 = time_ns()
@@ -40,34 +85,107 @@ function toc()
 end
 
 # print elapsed time, return expression value
-const _units = ["bytes", "kB", "MB"]
-function time_print(t, b, g, np, nfs)
-    i = 1
-    while b > 1024 && i < length(_units)
-        b = div(b, 1024)
-        i += 1
+const _mem_units = ["bytes", "KB", "MB", "GB", "TB", "PB"]
+const _cnt_units = ["", " k", " M", " G", " T", " P"]
+function prettyprint_getunits(value, numunits, factor)  # this really should be a private function
+    c1 = factor
+    c2 = c1 * c1
+    if value <= c1*100 ; return (value, 1) ; end
+    unit = 2
+    while value > c2*100 && (unit < numunits)
+        c1 = c2
+        c2 *= factor
+        unit += 1
     end
-    if 0 < g
-        @printf("elapsed time: %s seconds (%d %s allocated, %.2f%% gc time in %d pauses with %d full sweep)\n", t/1e9, b, _units[i], 100*g/t, np, nfs)
+    return div(value+(c1>>>1),c1), unit
+end
+
+const _sec_units = ["nanoseconds ", "microseconds", "milliseconds", "seconds     "]
+function prettyprint_nanoseconds(value::UInt64)                   # this really should be a private function
+    if value < 1000
+        return (1, value, 0)    # nanoseconds
+    elseif value < 1000000
+        mt = 2
+    elseif value < 1000000000
+        mt = 3
+        # round to nearest # of microseconds
+        value = div(value+500,1000)
+    elseif value < 1000000000000
+        mt = 4
+        # round to nearest # of milliseconds
+        value = div(value+500000,1000000)
     else
-        @printf("elapsed time: %s seconds (%d %s allocated)\n", t/1e9, b, _units[i])
+        # round to nearest # of seconds
+        return (4, div(value+500000000,1000000000), 0)
     end
+    frac::UInt64 = div(value,1000)
+    return (mt, frac, value-(frac*1000))
+end
+
+function padded_nonzero_print(value,str)        # this really should be a private function
+    if value != 0
+        blanks = "                "[1:16-length(str)]
+        println("$str:$blanks$value")
+    end
+end
+
+function time_print(elapsedtime, bytes, gctime, allocs)
+    mt, pptime, fraction = prettyprint_nanoseconds(elapsedtime)
+    (fraction != 0) ? @printf("%4d.%03d %s", pptime, fraction, _sec_units[mt]) : @printf("%8d %s",  pptime, _sec_units[mt])
+    if bytes != 0 || allocs != 0
+        bytes, mb = prettyprint_getunits(bytes, length(_mem_units), 1024)
+        allocs, ma = prettyprint_getunits(allocs, length(_cnt_units), 1000)
+        @printf(" (%d%s allocation%s: %d %s", allocs, _cnt_units[ma], allocs==1 ? "" : "s", bytes, _mem_units[mb])
+        if gctime > 0
+            @printf(", %.2f%% gc time", 100*gctime/elapsedtime)
+        end
+        print(")")
+    elseif gctime > 0
+        @printf(", %.2f%% gc time", 100*gctime/elapsedtime)
+    end
+    println()
+end
+
+function timev_print(elapsedtime, diff::GC_Diff)
+    bytes = diff.total_allocd + diff.allocd
+    allocs = diff.malloc + diff.realloc + diff.poolalloc
+    time_print(elapsedtime, bytes, diff.total_time, allocs)
+    print("elapsed time:    $elapsedtime nanoseconds\n")
+    padded_nonzero_print(diff.total_time,   "gc time")
+    padded_nonzero_print(bytes,              "bytes allocated")
+    padded_nonzero_print(diff.allocd,       "allocated")
+    padded_nonzero_print(diff.freed,        "freed")
+    padded_nonzero_print(diff.malloc,       "mallocs")
+    padded_nonzero_print(diff.realloc,      "reallocs")
+    padded_nonzero_print(diff.poolalloc,    "poolallocs")
+    padded_nonzero_print(diff.freecall,     "free calls")
+    padded_nonzero_print(diff.total_allocd, "total allocated")
+    padded_nonzero_print(diff.since_sweep,  "since sweep")
+    padded_nonzero_print(diff.pause,        "pause")
+    padded_nonzero_print(diff.full_sweep,   "full sweep")
 end
 
 macro time(ex)
     quote
-        local b0 = gc_bytes()
-        local t0 = time_ns()
-        local g0 = gc_time_ns()
-        local n0 = gc_num_pause()
-        local nfs0 = gc_num_full_sweep()
+        local stats = gc_num()
+        local elapsedtime = time_ns()
         local val = $(esc(ex))
-        local nfs1 = gc_num_full_sweep()
-        local n1 = gc_num_pause()
-        local g1 = gc_time_ns()
-        local t1 = time_ns()
-        local b1 = gc_bytes()
-        time_print(t1-t0, b1-b0, g1-g0, n1-n0, nfs1-nfs0)
+        elapsedtime = time_ns() - elapsedtime
+        local diff = GC_Diff(gc_num(), stats)
+        local bytes = diff.total_allocd + diff.allocd
+        local allocs = diff.malloc + diff.realloc + diff.poolalloc
+        time_print(elapsedtime, bytes, diff.total_time, allocs)
+        val
+    end
+end
+
+macro timev(ex)
+    quote
+        local stats = gc_num()
+        local elapsedtime = time_ns()
+        local val = $(esc(ex))
+        elapsedtime = time_ns() - elapsedtime
+        timev_print(elapsedtime, GC_Diff(gc_num(), stats))
         val
     end
 end
@@ -89,8 +207,7 @@ macro allocated(ex)
             function f()
                 b0 = gc_bytes()
                 $(esc(ex))
-                b1 = gc_bytes()
-                b1-b0
+                gc_bytes() - b0
             end
             f()
         end
@@ -100,14 +217,12 @@ end
 # print nothing, return value, elapsed time, bytes allocated & gc time
 macro timed(ex)
     quote
-        local b0 = gc_bytes()
-        local t0 = time_ns()
-        local g0 = gc_time_ns()
+        local stats = gc_num()
+        local elapsedtime = time_ns()
         local val = $(esc(ex))
-        local g1 = gc_time_ns()
-        local t1 = time_ns()
-        local b1 = gc_bytes()
-        val, (t1-t0)/1e9, b1-b0, (g1-g0)/1e9
+        elapsedtime = time_ns() - elapsedtime
+        diff = GC_Diff(gc_num(), stats)
+        val, elapsedtime/1e9, diff.total_allocd + diff.allocd, diff.total_time/1e9, diff
     end
 end
 


### PR DESCRIPTION
This adds counting of the number of allocations to `@time` and `@timed` (`@timed` also now returns the number of `free`s, and `realloc`s).
It also fixes a bug that happens if you use realloc to shrink the size of  something, it would subtract from allocd_bytes, instead of adding to freed_bytes.
