### PR TITLE
Fix #11142 Added new ascii/utf8 methods

### DIFF
--- a/base/ascii.jl
+++ b/base/ascii.jl
@@ -104,6 +104,9 @@ convert(::Type{ASCIIString}, a::Vector{UInt8}) = begin
     return ASCIIString(a)
 end
 
+ascii(p::Ptr{UInt8}) = ASCIIString(bytestring(p))
+ascii(p::Ptr{UInt8}, len::Integer) = ascii(pointer_to_array(p, len))
+
 function convert(::Type{ASCIIString}, a::Array{UInt8,1}, invalids_as::ASCIIString)
     l = length(a)
     idx = 1

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -236,5 +236,8 @@ function convert(::Type{UTF8String}, a::Array{UInt8,1}, invalids_as::AbstractStr
 end
 convert(::Type{UTF8String}, s::AbstractString) = utf8(bytestring(s))
 
+utf8(p::Ptr{UInt8}) = UTF8String(bytestring(p))
+utf8(p::Ptr{UInt8}, len::Integer) = utf8(pointer_to_array(p, len))
+
 # The last case is the replacement character 0xfffd (3 bytes)
 utf8sizeof(c::Char) = c < Char(0x80) ? 1 : c < Char(0x800) ? 2 : c < Char(0x10000) ? 3 : c < Char(0x110000) ? 4 : 3

--- a/doc/stdlib/strings.rst
+++ b/doc/stdlib/strings.rst
@@ -54,9 +54,17 @@
 
    Convert a string to a contiguous ASCII string (all characters must be valid ASCII characters).
 
+.. function:: ascii(::Ptr{UInt8}, [length])
+
+   Create an ASCII string from the address of a C (0-terminated) string encoded in ASCII. A copy is made; the ptr can be safely freed. If ``length`` is specified, the string does not have to be 0-terminated.
+
 .. function:: utf8(::Array{UInt8,1})
 
    Create a UTF-8 string from a byte array.
+
+.. function:: ascii(::Ptr{UInt8}, [length])
+
+   Create a UTF-8 string from the address of a C (0-terminated) string encoded in UTF-8. A copy is made; the ptr can be safely freed. If ``length`` is specified, the string does not have to be 0-terminated.
 
 .. function:: utf8(s)
 

--- a/doc/stdlib/strings.rst
+++ b/doc/stdlib/strings.rst
@@ -62,7 +62,7 @@
 
    Create a UTF-8 string from a byte array.
 
-.. function:: ascii(::Ptr{UInt8}, [length])
+.. function:: utf8(::Ptr{UInt8}, [length])
 
    Create a UTF-8 string from the address of a C (0-terminated) string encoded in UTF-8. A copy is made; the ptr can be safely freed. If ``length`` is specified, the string does not have to be 0-terminated.
 

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1423,6 +1423,19 @@ for T in [Int8, Int16, Int32, Int64, Int128]
     end
 end
 
+# issue #11142
+s = "abcdefghij"
+sp = pointer(s)
+@test ascii(sp) == s
+@test ascii(sp,5) == "abcde"
+@test typeof(ascii(sp)) == ASCIIString
+@test typeof(utf8(sp)) == UTF8String
+s = "abcde\uff\u2000\U1f596"
+sp = pointer(s)
+@test utf8(sp) == s
+@test utf8(sp,5) == "abcde"
+@test typeof(utf8(sp)) == UTF8String
+
 @test get(tryparse(BigInt, "1234567890")) == BigInt(1234567890)
 @test isnull(tryparse(BigInt, "1234567890-"))
 


### PR DESCRIPTION
Added new type-safe methods, to replace the current non-typesafe use of bytestring(Array{UInt8} [,len]).
(deprecating those bytesting methods might be the subject of another PR)
