### PR TITLE
Fix #11140 Added `is_valid_utf32`

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -824,6 +824,7 @@ export
     is_valid_char,
     is_valid_utf8,
     is_valid_utf16,
+    is_valid_utf32,
     isalnum,
     isalpha,
     isascii,

--- a/base/utf32.jl
+++ b/base/utf32.jl
@@ -92,6 +92,14 @@ function convert(T::Type{UTF32String}, bytes::AbstractArray{UInt8})
     UTF32String(d)
 end
 
+function is_valid_utf32(s::Union(Vector{Char}, Vector{UInt32}))
+    for i=1:length(s)
+        @inbounds if !is_valid_char(reinterpret(UInt32, s[i])) ; return false ; end
+    end
+    return true
+end
+is_valid_utf32(s::UTF32String) = is_valid_utf32(s.data)
+
 utf32(p::Ptr{Char}, len::Integer) = utf32(pointer_to_array(p, len))
 utf32(p::Union(Ptr{UInt32}, Ptr{Int32}), len::Integer) = utf32(convert(Ptr{Char}, p), len)
 function utf32(p::Union(Ptr{Char}, Ptr{UInt32}, Ptr{Int32}))

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1290,6 +1290,11 @@ end
 @test is_valid_utf16(utf16("\ud800")) == false
 # TODO is_valid_utf8
 
+# Issue #11140
+@test is_valid_utf32(utf32("a")) == true
+@test is_valid_utf32(utf32("\x00")) == true
+@test is_valid_utf32(UInt32[0xd800,0]) == false
+
 # This caused JuliaLang/JSON.jl#82
 @test first('\x00':'\x7f') === '\x00'
 @test last('\x00':'\x7f') === '\x7f'


### PR DESCRIPTION
Added a new function, which corresponds to the is_valid_ascii, is_valid_utf8, is_valid_utf16 functions.
Added some simple testing (same as what was done for the other is_valid_\* functions).
[more should be done in the future]
