### PR TITLE
Conversion, binary op tests for special types and bugfix

### DIFF
--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -38,7 +38,7 @@ end
 
 function convert(::Type{Bidiagonal}, A::Tridiagonal)
     if all(A.dl .== 0) return Bidiagonal(A.d, A.du, true)
-    elseif all(A.du .== 0) return Bidiagonal(A.d, A.dl, true)
+    elseif all(A.du .== 0) return Bidiagonal(A.d, A.dl, false)
     else throw(ArgumentError("Matrix cannot be represented as Bidiagonal"))
     end
 end
@@ -58,7 +58,7 @@ function convert(::Type{Bidiagonal}, A::AbstractTriangular)
     if fA == diagm(diag(A)) + diagm(diag(fA, 1), 1)
         return Bidiagonal(diag(A), diag(fA,1), true)
     elseif fA == diagm(diag(A)) + diagm(diag(fA, -1), -1)
-        return Bidiagonal(diag(A), diag(fA,-1), true)
+        return Bidiagonal(diag(A), diag(fA,-1), false)
     else
         throw(ArgumentError("Matrix cannot be represented as Bidiagonal"))
     end

--- a/test/linalg4.jl
+++ b/test/linalg4.jl
@@ -22,6 +22,7 @@ let a=[1.0:n;]
             @test full(convert(newtype, A)) == full(A)
             @test full(newtype(A)) == full(A)
         end
+        @test_throws ArgumentError convert(SymTridiagonal, A)
         A=Bidiagonal(a, zeros(n-1), isupper) #morally Diagonal
         for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, isupper ? UpperTriangular : LowerTriangular, Matrix]
             debug && println("newtype is $(newtype)")
@@ -34,15 +35,62 @@ let a=[1.0:n;]
     for newtype in [Tridiagonal, Matrix]
         @test full(convert(newtype, A)) == full(A)
     end
+    for newtype in [Diagonal, Bidiagonal]
+        @test_throws ArgumentError convert(newtype,A)
+    end
 
     A = Tridiagonal(zeros(n-1), [1.0:n;], zeros(n-1)) #morally Diagonal
     for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Matrix]
         @test full(convert(newtype, A)) == full(A)
     end
+    A = Tridiagonal(ones(n-1), [1.0:n;], ones(n-1)) #not morally Diagonal
+    for newtype in [SymTridiagonal, Matrix]
+        @test full(convert(newtype, A)) == full(A)
+    end
+    for newtype in [Diagonal, Bidiagonal]
+        @test_throws ArgumentError convert(newtype,A)
+    end
+    A = Tridiagonal(zeros(n-1), [1.0:n;], ones(n-1)) #not morally Diagonal
+    @test full(convert(Bidiagonal, A)) == full(A)
+    A = UpperTriangular(Tridiagonal(zeros(n-1), [1.0:n;], ones(n-1)))
+    @test full(convert(Bidiagonal, A)) == full(A)
+    A = Tridiagonal(ones(n-1), [1.0:n;], zeros(n-1)) #not morally Diagonal
+    @test full(convert(Bidiagonal, A)) == full(A)
+    A = LowerTriangular(Tridiagonal(ones(n-1), [1.0:n;], zeros(n-1)))
+    @test full(convert(Bidiagonal, A)) == full(A)
 
     A = LowerTriangular(full(Diagonal(a))) #morally Diagonal
     for newtype in [Diagonal, Bidiagonal, SymTridiagonal, LowerTriangular, Matrix]
         @test full(convert(newtype, A)) == full(A)
+    end
+    A = UpperTriangular(full(Diagonal(a))) #morally Diagonal
+    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, UpperTriangular, Matrix]
+        @test full(convert(newtype, A)) == full(A)
+    end
+    A = UpperTriangular(triu(rand(n,n)))
+    for newtype in [Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal]
+        @test_throws ArgumentError convert(newtype,A)
+    end
+end
+
+# Binary ops among special types
+let a=[1.0:n;]
+    A=Diagonal(a)
+    Spectypes = [Diagonal, Bidiagonal, Tridiagonal, Matrix]
+    for (idx, type1) in enumerate(Spectypes)
+        for type2 in Spectypes
+            B = convert(type1,A)
+            C = convert(type2,A)
+            @test_approx_eq full(B + C) full(A + A)
+            @test_approx_eq full(B - C) full(A - A)
+        end
+    end
+    B = SymTridiagonal(a, ones(n-1))
+    for Spectype in [Diagonal, Bidiagonal, Tridiagonal, Matrix]
+        @test_approx_eq full(B + convert(Spectype,A)) full(B + A)
+        @test_approx_eq full(convert(Spectype,A) + B) full(B + A)
+        @test_approx_eq full(B - convert(Spectype,A)) full(B - A)
+        @test_approx_eq full(convert(Spectype,A) - B) full(A - B)
     end
 end
 


### PR DESCRIPTION
Added tests for conversions between the special matrix types, and adding/subtracting them. I also found and fixed a bug converting from `Tridiagonal` or `AbstractTriangular` matrices to `Bidiagonal`.
