### PR TITLE
Fix GC_VERIFY and two gc write barrier issue. Thanks @carnaval

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2031,9 +2031,9 @@ static void gc_verify(void)
         gcval_t* v = (gcval_t*)bits_save[i >= clean_len ? GC_QUEUED : GC_CLEAN].items[i >= clean_len ? i - clean_len : i];
         if (gc_marked(v)) {
             jl_printf(JL_STDERR, "Error. Early free of 0x%lx type :", (uptrint_t)v);
-            jl_(jl_typeof(v));
+            jl_(jl_typeof(jl_valueof(v)));
             jl_printf(JL_STDERR, "val : ");
-            jl_(v);
+            jl_(jl_valueof(v));
             jl_printf(JL_STDERR, "Let's try to backtrack the missing write barrier :\n");
             lostval = v;
             break;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -420,8 +420,10 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
             ((jl_tvar_t*)jl_svecref(para,i))->bound = 0;
         }
         jl_compute_field_offsets(dt);
-        if (para == (jl_value_t*)jl_emptysvec && jl_is_datatype_singleton(dt))
+        if (para == (jl_value_t*)jl_emptysvec && jl_is_datatype_singleton(dt)) {
             dt->instance = newstruct(dt);
+            gc_wb(dt, dt->instance);
+        }
 
         b->value = temp;
         if (temp==NULL || !equiv_type(dt, (jl_datatype_t*)temp)) {


### PR DESCRIPTION
This PR and 871f059e2beca9af66ae6706d082f5badca76b35 were the result of a hours long debuging using always-full-gc approach this afternoon as mentioned in #11151. @carnaval did most of the work and my job was mainly learning, moral support, and providing a system that is somehow more vulnerable to GC issues....

@carnaval: I know you said you want to forget about this for the weekend, but could you do a last check of the codegen fix. IMHO, from the comment in this function, `needroots` feels like the proper value to decide whether a barrier to use than or'ing if any of the privious fields needs root. (Also, shouldn't the fields after a certain field rather than before it determines if it needs root, if not only the field itself)
