### PR TITLE
Fix #11170, accessing empty env var on Windows

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -31,7 +31,7 @@ _hasenv(s::AbstractString) = _getenvlen(s)!=0 || GetLastError()!=ERROR_ENVVAR_NO
 function _jl_win_getenv(s::UTF16String,len::UInt32)
     val=zeros(UInt16,len)
     ret=ccall(:GetEnvironmentVariableW,stdcall,UInt32,(Cwstring,Ptr{UInt16},UInt32),s,val,len)
-    if ret==0 || ret != len-1 || val[end] != 0
+    if (ret == 0 && len != 1) || ret != len-1 || val[end] != 0
         error(string("getenv: ", s, ' ', len, "-1 != ", ret, ": ", FormatMessage()))
     end
     val

--- a/test/sysinfo.jl
+++ b/test/sysinfo.jl
@@ -11,3 +11,11 @@ Base.Sys.loadavg()
 @test_throws ArgumentError ENV["bad\0name"] = "ok"
 @test_throws ArgumentError ENV["okname"] = "bad\0val"
 @test_throws ArgumentError Sys.set_process_title("bad\0title")
+
+# issue #11170
+withenv("TEST"=>"nonempty") do
+    @test ENV["TEST"] == "nonempty"
+end
+withenv("TEST"=>"") do
+    @test ENV["TEST"] == ""
+end


### PR DESCRIPTION
For an empty but set environment variable, `_getenvlen` returns a length of 1 (just the null terminator), and the call to `GetEnvironmentVariableW` inside `_jl_win_getenv` returns 0. So `ret == 0` is not always an error condition. For unset environment variables, `_getenvlen` returns 0.
