### PR TITLE
Clean up stagedfunction

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -151,7 +151,7 @@ CartesianRange{N}(sz::NTuple{N,Int}) = CartesianRange(CartesianIndex(sz))
     :($meta; CartesianRange(CartesianIndex{$N}($(startargs...)), CartesianIndex{$N}($(stopargs...))))
 end
 
-stagedfunction eachindex{S,T,M,N}(::LinearSlow, A::AbstractArray{S,M}, B::AbstractArray{T,N})
+@generated function eachindex{S,T,M,N}(::LinearSlow, A::AbstractArray{S,M}, B::AbstractArray{T,N})
     K = max(M,N)
     startargs = fill(1, K)
     stopargs = [:(max(size(A,$i),size(B,$i))) for i=1:K]

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -143,7 +143,7 @@ This function provides equivalent functionality, but makes no efforts to optimis
 
 (defconst julia-function-regex
   (rx line-start (* (or space "@inline" "@noinline")) symbol-start
-      (or "function" "stagedfunction")
+      "function"
       (1+ space)
       ;; Don't highlight module names in function declarations:
       (* (seq (1+ (or word (syntax symbol))) "."))
@@ -183,7 +183,7 @@ This function provides equivalent functionality, but makes no efforts to optimis
 (defconst julia-keyword-regex
   (julia--regexp-opt
    '("if" "else" "elseif" "while" "for" "begin" "end" "quote"
-     "try" "catch" "return" "local" "abstract" "function" "stagedfunction" "macro" "ccall"
+     "try" "catch" "return" "local" "abstract" "function" "macro" "ccall"
      "finally" "typealias" "break" "continue" "type" "global"
      "module" "using" "import" "export" "const" "let" "bitstype" "do" "in"
      "baremodule" "importall" "immutable")
@@ -248,8 +248,8 @@ This function provides equivalent functionality, but makes no efforts to optimis
    ))
 
 (defconst julia-block-start-keywords
-  (list "if" "while" "for" "begin" "try" "function" "stagedfunction" "type" "let" "macro"
-	"quote" "do" "immutable"))
+  (list "if" "while" "for" "begin" "try" "function" "type" "let" "macro"
+        "quote" "do" "immutable"))
 
 (defconst julia-block-end-keywords
   (list "end" "else" "elseif" "catch" "finally"))

--- a/contrib/julia.xml
+++ b/contrib/julia.xml
@@ -37,7 +37,6 @@
       <item> do </item>
       <item> for </item>
       <item> function </item>
-      <item> stagedfunction </item>
       <item> if </item>
       <item> immutable </item>
       <item> let </item>


### PR DESCRIPTION
Clean up some left overs from #10884 .
Mainly from editor syntax files. but there also seems to be [one missing](https://github.com/JuliaLang/julia/commit/fa1174a2e747e7df4068b042b726212be96642cb#diff-89e97f67f8058d32eac8d917db5bbdbfR152) in `Base`.
