### PR TITLE
RFC: temp path parent directory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -292,6 +292,9 @@ Library improvements
     * New function `relpath` returns a relative filepath to path either from the current
       directory or from an optional start directory ([#10893]).
 
+    * `mktemp` and `mktempdir` now take an optional argument to set which
+      directory the temporary file or directory is created in.
+
 Deprecated or removed
 ---------------------
 

--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -37,15 +37,16 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
     end
     dir = path()
     info("Initializing package repository $dir")
-    temp_dir = mktempdir()
     metadata_dir = joinpath(dir, "METADATA")
     if isdir(metadata_dir)
         info("Package directory $dir is already initialized.")
         Git.set_remote_url(meta, dir=metadata_dir)
         return
     end
+    local temp_dir
     try
-        mkpath(temp_dir)
+        mkpath(dir)
+        temp_dir = mktempdir(dir)
         Base.cd(temp_dir) do
             info("Cloning METADATA from $meta")
             run(`git clone -q -b $branch $meta METADATA`)
@@ -58,7 +59,6 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
             end
         end
         #Move TEMP to METADATA
-        mkpath(dir)
         Base.mv(joinpath(temp_dir,"METADATA"), metadata_dir)
         Base.mv(joinpath(temp_dir,"REQUIRE"), joinpath(dir,"REQUIRE"))
         Base.mv(joinpath(temp_dir,"META_BRANCH"), joinpath(dir,"META_BRANCH"))

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -147,14 +147,14 @@
 
    Obtain the path of a temporary directory (possibly shared with other processes).
 
-.. function:: mktemp()
+.. function:: mktemp([parent=tempdir()])
 
    Returns ``(path, io)``, where ``path`` is the path of a new temporary file
-   and ``io`` is an open file object for this path.
+   in ``parent`` and ``io`` is an open file object for this path.
 
-.. function:: mktempdir()
+.. function:: mktempdir([parent=tempdir()])
 
-   Create a temporary directory and return its path.
+   Create a temporary directory in the ``parent`` directory and return its path.
 
 .. function:: isblockdev(path) -> Bool
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -112,6 +112,17 @@ cp(newfile, c_file)
 @test isfile(c_file)
 @test_throws SystemError rm(c_tmpdir)
 
+# create temp dir in specific directory
+d_tmpdir = mktempdir(c_tmpdir)
+@test isdir(d_tmpdir)
+@test Base.samefile(dirname(d_tmpdir), c_tmpdir)
+
+# create temp file in specific directory
+d_tmpfile,f = mktemp(c_tmpdir)
+close(f)
+@test isfile(d_tmpfile)
+@test Base.samefile(dirname(d_tmpfile), c_tmpdir)
+
 rm(c_tmpdir, recursive=true)
 @test !isdir(c_tmpdir)
 


### PR DESCRIPTION
43c7cae adds an option to `mktemp` and `mktempdir` to control which directory the temporary file/directory is created in.

2414e9e is a workaround for #11191.
