### PR TITLE
Missing operations for LinSpace. Fix #11049

### DIFF
--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -541,3 +541,47 @@ for x in r
     i += 2
 end
 @test i == 7
+
+# Issue 11049 and related
+@test promote(linspace(0f0, 1f0, 3), linspace(0., 5., 2)) ===
+    (linspace(0., 1., 3), linspace(0., 5., 2))
+@test convert(LinSpace{Float64}, linspace(0., 1., 3)) === linspace(0., 1., 3)
+@test convert(LinSpace{Float64}, linspace(0f0, 1f0, 3)) === linspace(0., 1., 3)
+
+@test promote(linspace(0., 1., 3), 0:5) === (linspace(0., 1., 3),
+                                             linspace(0., 5., 6))
+@test convert(LinSpace{Float64}, 0:5) === linspace(0., 5., 6)
+@test convert(LinSpace{Float64}, 0:1:5) === linspace(0., 5., 6)
+@test convert(LinSpace, 0:5) === linspace(0., 5., 6)
+@test convert(LinSpace, 0:1:5) === linspace(0., 5., 6)
+
+function test_range_index(r, s)
+    @test typeof(r[s]) == typeof(r)
+    @test [r;][s] == [r[s];]
+end
+test_range_index(linspace(0.1, 0.3, 3), 1:2)
+test_range_index(linspace(0.1, 0.3, 3), 1:0)
+test_range_index(linspace(1.0, 1.0, 1), 1:1)
+test_range_index(linspace(1.0, 1.0, 1), 1:0)
+test_range_index(linspace(1.0, 2.0, 0), 1:0)
+
+function test_linspace_identity(r, mr)
+    @test -r == mr
+    @test isa(-r, LinSpace)
+
+    @test 1 + r + (-1) == r
+    @test isa(1 + r + (-1), LinSpace)
+    @test 1 - r - 1 == mr
+    @test isa(1 - r - 1, LinSpace)
+
+    @test 1 * r * 1 == r
+    @test isa(1 * r * 1, LinSpace)
+    @test r / 1 == r
+    @test isa(r / 1, LinSpace)
+end
+
+test_linspace_identity(linspace(1.0, 27.0, 1275), linspace(-1.0, -27.0, 1275))
+
+@test reverse(linspace(1.0, 27.0, 1275)) == linspace(27.0, 1.0, 1275)
+@test [reverse(linspace(1.0, 27.0, 1275));] ==
+    reverse([linspace(1.0, 27.0, 1275);])


### PR DESCRIPTION
Make it as closed to `FloatRange` as possible. Hopefully I'm using the right algorithm....

``` julia
julia> linspace(0, 10, 20)
linspace(0.0,10.0,20)

julia> 0 + linspace(0, 10, 20) + 0
linspace(0.0,10.0,20)

julia> 0 - linspace(0, 10, 20) - 0
linspace(0.0,-10.0,20)

julia> 1 * linspace(0, 10, 20) * 1
linspace(0.0,10.0,20)

julia> linspace(0, 10, 20) / 1
linspace(0.0,10.0,20)

julia> -linspace(0, 10, 20)
linspace(-0.0,-10.0,20)
```

The divided by 0 case is a little different from `FloatRange`

``` julia
julia> linspace(0, 10, 21) / 0
linspace(NaN,Inf,21)

julia> 0.0:0.5:10.0 / 0
0.0:0.5:Inf

julia> [linspace(0, 10, 21) / 0;]
21-element Array{Float64,1}:
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN
 NaN

julia> [0.0:0.5:10.0 / 0;]
ERROR: InexactError()
 in vcat at ./range.jl:650
```

IMHO both are wrong because

``` julia
julia> [linspace(0, 10, 21);] / 0
21-element Array{Float64,1}:
 NaN
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf

julia> [0.0:0.5:10.0;] / 0
21-element Array{Float64,1}:
 NaN
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
 Inf
```

But I'm waiting to see what ppl think...
