### PR TITLE
fix logic for hashing long tuples

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -88,7 +88,7 @@ const tuplehash_seed = UInt === UInt64 ? 0x77cfa1eef01bca90 : 0xf01bca90
 hash( ::Tuple{}, h::UInt)        = h + tuplehash_seed
 hash(x::Tuple{Any,}, h::UInt)    = hash(x[1], hash((), h))
 hash(x::Tuple{Any,Any}, h::UInt) = hash(x[1], hash(x[2], hash((), h)))
-hash(x::Tuple, h::UInt)          = hash(x[1], hash(x[2], hash(tail(x), h)))
+hash(x::Tuple, h::UInt)          = hash(x[1], hash(x[2], hash(tail(tail(x)), h)))
 
 function isless(t1::Tuple, t2::Tuple)
     n1, n2 = length(t1), length(t2)


### PR DESCRIPTION
Convex.jl has been broken on 0.4 for a while and I traced the issue to unexpected hash collisions. The current logic seems off because the second element of the tuple gets hashed in twice.

Before (on JuliaOpt/Convex.jl#77 branch):

``` julia
julia> using Convex; x = Variable(); y = Variable();
julia> hash((x,Constant(-1),:(<=)))
0xe119670b66003fb7

julia> hash((x,y,:(<=)))
0xe119670b66003fb7
```

After:

``` julia
julia> hash((x,Constant(-1),:(<=)))
0x0be17f1e5478ffe6

julia> hash((x,y,:(<=)))
0x0dc4e3c54d029730
```

@JeffBezanson @madeleineudell
