### PR TITLE
Make qrfact and qrfact! type-stable

### DIFF
--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -65,7 +65,8 @@ function qrfact!{T}(A::AbstractMatrix{T}, pivot::Union(Type{Val{false}}, Type{Va
     end
     QR(A, τ)
 end
-qrfact!{T<:BlasFloat}(A::StridedMatrix{T}, pivot::Union(Type{Val{false}}, Type{Val{true}})=Val{false}) = pivot==Val{true} ? QRPivoted(LAPACK.geqp3!(A)...) : QRCompactWY(LAPACK.geqrt!(A, min(minimum(size(A)), 36))...)
+qrfact!{T<:BlasFloat}(A::StridedMatrix{T}, pivot::Type{Val{false}} = Val{false}) = QRCompactWY(LAPACK.geqrt!(A, min(minimum(size(A)), 36))...)
+qrfact!{T<:BlasFloat}(A::StridedMatrix{T}, pivot::Type{Val{true}}) = QRPivoted(LAPACK.geqp3!(A)...)
 qrfact{T<:BlasFloat}(A::StridedMatrix{T}, pivot::Union(Type{Val{false}}, Type{Val{true}})=Val{false}) = qrfact!(copy(A), pivot)
 copy_oftype{T}(A::StridedMatrix{T}, ::Type{T}) = copy(A)
 copy_oftype{T,S}(A::StridedMatrix{T}, ::Type{S}) = convert(AbstractMatrix{S}, A)

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -59,7 +59,11 @@ debug && println("Bunch-Kaufman factors of a pos-def matrix")
 debug && println("QR decomposition (without pivoting)")
     for i = 1:2
         let a = i == 1 ? a : sub(a, 1:n - 1, 1:n - 1), b = i == 1 ? b : sub(b, 1:n - 1), n = i == 1 ? n : n - 1
-            qra   = qrfact(a, Val{false})
+            @inferred qrfact(a)
+            if eltya <: BlasFloat
+                @inferred qrfact(a, Val{true})
+            end
+            qra   = @inferred qrfact(a, Val{false})
             q, r  = qra[:Q], qra[:R]
             @test_approx_eq q'*full(q, thin = false) eye(n)
             @test_approx_eq q*full(q, thin = false)' eye(n)
@@ -68,7 +72,7 @@ debug && println("QR decomposition (without pivoting)")
             @test_approx_eq full(qra) a
 
 debug && println("Thin QR decomposition (without pivoting)")
-            qra   = qrfact(a[:,1:n1], Val{false})
+            qra   = @inferred qrfact(a[:,1:n1], Val{false})
             q,r   = qra[:Q], qra[:R]
             @test_approx_eq q'*full(q, thin=false) eye(n)
             @test_approx_eq q'*full(q) eye(n, n1)


### PR DESCRIPTION
As reported in http://stackoverflow.com/questions/30155465/fast-tensor-initialisation-in-julia, qr factorization is not type-stable. This fixes part of the problem, but it's not enough on its own to make `qr` type-stable (even if you supply a `Val{true}`). I suspect it comes down to the `F[:Q]` syntax. This is just drive-by bugfixing, so I didn't make any difficult decisions.
