### PR TITLE
update intel compiler instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,16 +334,17 @@ Please be aware that this procedure is not officially supported, as it introduce
 
 SuiteSparse is a special case, since it is typically only installed as a static library, while `USE_SYSTEM_SUITESPARSE=1` requires that it is a shared library. Running the script `contrib/repackage_system_suitesparse4.make` will copy your static system SuiteSparse installation into the shared library format required by Julia. `make USE_SYSTEM_SUITESPARSE=1` will then use the SuiteSparse that has been copied into Julia's directory, but will not build a new SuiteSparse library from scratch.
 
-### Intel compilers and Math Kernel Libraries
+### Intel compilers and Math Kernel Library (MKL)
 
-To use the Intel [MKL] BLAS and LAPACK libraries, make sure that MKL version 10.3.6 or higher is installed.
+To build Julia using the Intel compilers (icc, icpc, ifort), and link against
+the [MKL] BLAS and LAPACK libraries, first make sure you have a recent version
+of the compiler suite (version 15 or later).
+
 For a 64-bit architecture, the environment should be set up as follows:
 
     # bash
-    source /path/to/mkl/bin/mklvars.sh intel64 ilp64
-    export MKL_INTERFACE_LAYER=ILP64
+    source /path/to/intel/bin/compilervars.sh intel64
 
-It is recommended that Intel compilers be used to build Julia when using MKL.
 Add the following to the `Make.user` file:
 
     USEICC = 1


### PR DESCRIPTION
Recommend using v15 or greater. Older versions either fail to build or fail the test suite.

closes #8294, #9656, #10181
