### PR TITLE
Tests and bugfix for sharedarrays

### DIFF
--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -249,7 +249,7 @@ function rand!{T}(S::SharedArray{T})
 end
 
 function randn!(S::SharedArray)
-    f = S->map!(x->randn, S.loc_subarr_1d)
+    f = S->map!(x->randn(), S.loc_subarr_1d)
     @sync for p in procs(S)
         @async remotecall_wait(p, f, S)
     end

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -60,6 +60,8 @@ copy!(s, d)
 s = Base.shmem_rand(dims)
 copy!(s, sdata(d))
 @test s == d
+a = rand(dims)
+@test sdata(a) == a
 
 d = SharedArray(Int, dims; init = D->fill!(D.loc_subarr_1d, myid()))
 for p in procs(d)
@@ -69,6 +71,24 @@ for p in procs(d)
     @test d[idxf] == p
     @test d[idxl] == p
 end
+
+# reshape
+
+d = Base.shmem_fill(1.0, (10,10,10))
+@test ones(100, 10) == reshape(d,(100,10))
+d = Base.shmem_fill(1.0, (10,10,10))
+@test_throws DimensionMismatch reshape(d,(50,))
+
+# rand, randn
+d = Base.shmem_rand(dims)
+@test size(rand!(d)) == dims
+d = Base.shmem_fill(1.0, dims)
+@test size(randn!(d)) == dims
+
+# similar
+d = Base.shmem_rand(dims)
+@test size(similar(d, Complex128)) == dims
+@test size(similar(d, dims)) == dims
 
 # issue #6362
 d = Base.shmem_rand(dims)


### PR DESCRIPTION
`randn(S)` where `S` is a `SharedArray` would error out with a `convert` error. Added a test for this, `rand(S)`, `reshape`, `similar`, and `sdata`.
