### PR TITLE
Fix write barrier for shared arrays.

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -505,7 +505,11 @@ void jl_arrayset(jl_array_t *a, jl_value_t *rhs, size_t i)
     }
     else {
         ((jl_value_t**)a->data)[i] = rhs;
-        gc_wb(a, rhs);
+        jl_value_t *owner = (jl_value_t*)a;
+        if (a->how == 3) {
+            owner = jl_array_data_owner(a);
+        }
+        gc_wb(owner, rhs);
     }
 }
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1381,6 +1381,16 @@ static Value *emit_arraysize(Value *t, jl_value_t *ex, int dim, jl_codectx_t *ct
     return emit_arraysize(t, dim);
 }
 
+static Value *emit_arrayflags(Value *t, jl_codectx_t *ctx)
+{
+    Value *addr = builder.CreateStructGEP(
+#ifdef LLVM37
+                            nullptr,
+#endif
+                            builder.CreateBitCast(t,jl_parray_llvmt), 2);
+    return builder.CreateLoad(addr); // TODO tbaa
+}
+
 static void assign_arrayvar(jl_arrayvar_t &av, Value *ar)
 {
     tbaa_decorate(tbaa_arrayptr,builder.CreateStore(builder.CreateBitCast(emit_arrayptr(ar),

--- a/src/gc.c
+++ b/src/gc.c
@@ -2036,7 +2036,7 @@ static void gc_verify(void)
             jl_printf(JL_STDERR, "val : ");
             jl_(jl_valueof(v));
             jl_printf(JL_STDERR, "Let's try to backtrack the missing write barrier :\n");
-            lostval = v;
+            lostval = jl_valueof(v);
             break;
         }
     }


### PR DESCRIPTION
Before this change it was possible to avoid the write barrier by storing a young pointer to an old array through a young shared array wrapper (e.g. with reshape). This unfortunately requires adding a branch to every pointer array setindex!.

I also changed the order of the flags bitfield in arrays to make my life easier in codegen. Can revert if someone has feelings about this.

@yuyichao Could you please double check that it fixes what you found ? It does fix the reproduction I had locally but better be sure.
