### PR TITLE
MSVC casts

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -620,7 +620,7 @@ JL_CALLABLE(jl_f_tuple)
     if (nargs == 0) return (jl_value_t*)jl_emptytuple;
     jl_datatype_t *tt;
     if (nargs < jl_page_size/sizeof(jl_value_t*)) {
-        jl_value_t **types = alloca(nargs*sizeof(jl_value_t*));
+        jl_value_t **types = (jl_value_t**)alloca(nargs*sizeof(jl_value_t*));
         for(i=0; i < nargs; i++)
             types[i] = jl_typeof(args[i]);
         tt = jl_inst_concrete_tupletype_v(types, nargs);

--- a/src/dump.c
+++ b/src/dump.c
@@ -1611,7 +1611,7 @@ void jl_restore_system_image_from_stream(ios_t *f)
 
 DLLEXPORT void jl_restore_system_image(const char *fname)
 {
-    char *dot = strrchr(fname, '.');
+    char *dot = (char*) strrchr(fname, '.');
     int is_ji = (dot && !strcmp(dot, ".ji"));
 
     jl_load_sysimg_so();
@@ -1886,8 +1886,8 @@ jl_module_t *jl_restore_new_module(const char *fname)
         jl_methtable_t *mt = (jl_methtable_t*)methtable_list.items[i];
         jl_array_t *cache_targ = mt->cache_targ;
         jl_array_t *cache_arg1 = mt->cache_arg1;
-        mt->cache_targ = (void*)jl_nothing;
-        mt->cache_arg1 = (void*)jl_nothing;
+        mt->cache_targ = (jl_array_t*)jl_nothing;
+        mt->cache_arg1 = (jl_array_t*)jl_nothing;
         if (cache_targ != (void*)jl_nothing) {
             size_t j, l = jl_array_len(cache_targ);
             for (j = 0; j < l; j++) {

--- a/src/gc.c
+++ b/src/gc.c
@@ -251,7 +251,11 @@ typedef struct {
     char pages[REGION_PG_COUNT][GC_PAGE_SZ]; // must be first, to preserve page alignment
     uint32_t freemap[REGION_PG_COUNT/32];
     gcpage_t meta[REGION_PG_COUNT];
-} region_t __attribute__((aligned(GC_PAGE_SZ)));
+} region_t
+#ifndef _COMPILER_MICROSOFT_
+__attribute__((aligned(GC_PAGE_SZ)))
+#endif
+;
 static region_t *regions[REGION_COUNT] = {NULL};
 // store a lower bound of the first free page in each region
 static int regions_lb[REGION_COUNT] = {0};

--- a/src/gc.c
+++ b/src/gc.c
@@ -280,7 +280,7 @@ static region_t *find_region(void *ptr)
 static gcpage_t *page_metadata(void *data)
 {
     region_t *r = find_region(data);
-    int pg_idx = PAGE_INDEX(r, data);
+    int pg_idx = PAGE_INDEX(r, (char*)data);
     return &r->meta[pg_idx];
 }
 

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -193,7 +193,7 @@ DLLEXPORT void jl_uv_alloc_buf(uv_handle_t *handle, size_t suggested_size, uv_bu
         JL_GC_PUSH1(&ret);
         // TODO: jl_fieldref allocates boxes here. should avoid that.
         assert(jl_is_tuple(ret) && jl_nfields(ret)==2 && jl_is_pointer(jl_fieldref(ret,0)));
-        buf->base = jl_unbox_voidpointer(jl_fieldref(ret,0));
+        buf->base = (char*)jl_unbox_voidpointer(jl_fieldref(ret,0));
 #ifdef _P64
         assert(jl_is_uint64(jl_fieldref(ret,1)));
         buf->len = jl_unbox_uint64(jl_fieldref(ret,1));

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -447,7 +447,7 @@ static int true_main(int argc, char *argv[])
             ios_puts("\njulia> ", ios_stdout);
             ios_flush(ios_stdout);
             line = ios_readline(ios_stdin);
-            jl_value_t *val = jl_eval_string(line);
+            jl_value_t *val = (jl_value_t*)jl_eval_string(line);
             if (jl_exception_occurred()) {
                 jl_printf(JL_STDERR, "error during run:\n");
                 jl_static_show(JL_STDERR, jl_exception_in_transit);


### PR DESCRIPTION
Still getting segfaults in `jl_setjmp` due to some compiler-dependent difference in alignment here, so this doesn't really need to be merged right away. If anyone has any ideas, see the discussion at https://github.com/JuliaLang/julia/commit/8b8b26193093ae2a0663b3b0d83341719826fcad#commitcomment-11018031
