### PR TITLE
Test coverage of VersionNumber

### DIFF
--- a/test/version.jl
+++ b/test/version.jl
@@ -1,10 +1,13 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # parsing tests
-
 @test v"1" == VersionNumber(1)
 @test v"2.1" == VersionNumber(2, 1)
 @test v"3.2.1" == VersionNumber(3, 2, 1)
+
+@test v"2-" == VersionNumber(2, 0, 0, ("",), ())
+@test v"3.2-" == VersionNumber(3, 2, 0, ("",), ())
+@test v"4.3.2-" == VersionNumber(4, 3, 2, ("",), ())
 
 @test v"2-1" == VersionNumber(2, 0, 0, (1,), ())
 @test v"3.2-1" == VersionNumber(3, 2, 0, (1,), ())
@@ -30,6 +33,10 @@
 @test v"3.2-1.a" == VersionNumber(3, 2, 0, (1, "a"), ())
 @test v"4.3.2-1.a" == VersionNumber(4, 3, 2, (1, "a"), ())
 
+@test v"2+" == VersionNumber(2, 0, 0, (), ("",))
+@test v"3.2+" == VersionNumber(3, 2, 0, (), ("",))
+@test v"4.3.2+" == VersionNumber(4, 3, 2, (), ("",))
+
 @test v"2+1" == VersionNumber(2, 0, 0, (), (1,))
 @test v"3.2+1" == VersionNumber(3, 2, 0, (), (1,))
 @test v"4.3.2+1" == VersionNumber(4, 3, 2, (), (1,))
@@ -54,16 +61,66 @@
 @test v"3.2+1.a" == VersionNumber(3, 2, 0, (), (1, "a"))
 @test v"4.3.2+1.a" == VersionNumber(4, 3, 2, (), (1, "a"))
 
-# basic comparison
+# ArgumentErrors in constructor
+@test_throws ArgumentError VersionNumber(4, 3, 2, ("nonalphanumeric!",), ())
+@test_throws ArgumentError VersionNumber(4, 3, 2, ("nonalphanumeric!", 1), ())
+@test_throws ArgumentError VersionNumber(4, 3, 2, (1, "nonalphanumeric!"), ())
 
-@test VersionNumber(2,3,1) == VersionNumber(Int8(2),UInt32(3),Int32(1)) == v"2.3.1"
+@test_throws ArgumentError VersionNumber(4, 3, 2, ("", 1), ())
+@test_throws ArgumentError VersionNumber(4, 3, 2, (1, ""), ())
+@test_throws ArgumentError VersionNumber(4, 3, 2, ("",), ("",))
+@test_throws ArgumentError VersionNumber(4, 3, 2, ("",), ("nonempty", 1))
+
+@test_throws ArgumentError VersionNumber(4, 3, 2, (), ("nonalphanumeric!",))
+@test_throws ArgumentError VersionNumber(4, 3, 2, (), ("nonalphanumeric!", 1))
+@test_throws ArgumentError VersionNumber(4, 3, 2, (), (1, "nonalphanumeric!"))
+
+@test_throws ArgumentError VersionNumber(4, 3, 2, (), ("", 1))
+
+# conversion from Int
+@test convert(VersionNumber, 2) == v"2.0.0"
+
+# conversion from Tuple
+@test convert(VersionNumber, (2,)) == v"2.0.0"
+@test convert(VersionNumber, (3, 2)) == v"3.2.0"
+
+# typemin and typemax
+@test typemin(VersionNumber) == v"0-"
+@test typemax(VersionNumber) ==
+  VersionNumber(typemax(Int),typemax(Int),typemax(Int),(),("",))
+
+# issupbuild
+import Base.issupbuild
+@test issupbuild(v"4.3.2+")
+@test ~issupbuild(v"4.3.2")
+@test ~issupbuild(v"4.3.2-")
+@test ~issupbuild(v"4.3.2-a")
+@test ~issupbuild(v"4.3.2-a1")
+@test ~issupbuild(v"4.3.2-1")
+@test ~issupbuild(v"4.3.2-a.1")
+@test ~issupbuild(v"4.3.2-1a")
+@test ~issupbuild(v"4.3.2+a")
+@test ~issupbuild(v"4.3.2+a1")
+@test ~issupbuild(v"4.3.2+1")
+@test ~issupbuild(v"4.3.2+a.1")
+@test ~issupbuild(v"4.3.2+1a")
+
+# basic comparison
+VersionNumber(2,3,1) == VersionNumber(Int8(2),UInt32(3),Int32(1)) == v"2.3.1"
 @test v"2.3.0" < v"2.3.1" < v"2.4.8" < v"3.7.2"
 
-# advanced comparison & manipulation
+#lowerbound and upperbound
+import Base: lowerbound, upperbound
+@test lowerbound(v"4.3.2") == v"4.3.2-"
+@test lowerbound(v"4.3.2-") == v"4.3.2-"
+@test lowerbound(v"4.3.2+") == v"4.3.2-"
+@test upperbound(v"4.3.2") == v"4.3.2+"
+@test upperbound(v"4.3.2-") == v"4.3.2+"
+@test upperbound(v"4.3.2+") == v"4.3.2+"
 
+# advanced comparison & manipulation
 import Base: thispatch, thisminor, thismajor,
              nextpatch, nextminor, nextmajor, check_new_version
-
 @test v"1.2.3" == thispatch(v"1.2.3-")
 @test v"1.2.3" == thispatch(v"1.2.3-pre")
 @test v"1.2.3" == thispatch(v"1.2.3")
@@ -136,8 +193,27 @@ for major=0:3, minor=0:3, patch=0:3
     end
 end
 
-# julia_version.h version test
+# check_new_version
+import Base.check_new_version
+@test check_new_version([v"1", v"2"], v"3") == nothing
+@test_throws AssertionError check_new_version([v"2", v"1"], v"3")
+@test_throws ErrorException check_new_version([v"1", v"2"], v"2")
+@test check_new_version(VersionNumber[], v"0") == nothing
+@test check_new_version(VersionNumber[], v"0.0.1") == nothing
+@test_throws MethodError check_new_version(VersionNumber,[], v"0.0.2")
+@test check_new_version(VersionNumber[], v"0.1") == nothing
+@test_throws MethodError check_new_version(VersionNumber, [], v"0.2")
+@test check_new_version(VersionNumber[], v"1") == nothing
+@test_throws MethodError check_new_version(VersionNumber, [], v"2")
+@test_throws ErrorException check_new_version(VersionNumber[v"1", v"2", v"3"], v"2")
+@test_throws ErrorException check_new_version([v"1", v"2"], v"4")
+@test_throws ErrorException check_new_version([v"1", v"2"], v"2-rc")
 
+# banner
+import Base.banner
+@test banner() == nothing
+
+# julia_version.h version test
 @test VERSION.major == ccall(:jl_ver_major,Cint,())
 @test VERSION.minor == ccall(:jl_ver_minor,Cint,())
 @test VERSION.patch == ccall(:jl_ver_patch,Cint,())


### PR DESCRIPTION
Following @timholy's test coverage issue #9493, here is an update of the test file for `version.jl` — covered at 66.91% so far.
The `banner()` function is not thoroughly covered, since I only tested function termination. I guess that it should be necessary to manipulate Base.GIT_VERSION_INFO to achieve this.
Can you please confirm that version numbers such as "0.4.8-" and "0.4.8+" should be valid ?
