### PR TITLE
fix missing promotion in log(b,x)

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -91,6 +91,9 @@ deg2rad(z::Integer) = deg2rad(float(z))
 @vectorize_1arg Real rad2deg
 @vectorize_1arg Real deg2rad
 
+log{T<:Number}(b::T, x::T) = log(x) / log(b)
+log(b::Number, x::Number) = log(promote(b, x)...)
+@vectorize_2arg Number log
 log(b,x) = log(x)./log(b)
 
 # type specific math functions

--- a/test/math.jl
+++ b/test/math.jl
@@ -431,3 +431,9 @@ for x in X
         end
     end
 end
+
+# promotion in 2-argument log
+@test_approx_eq_eps log(2,big(2)^100) 100 eps(BigFloat) * 1e3
+@test_approx_eq_eps log([2],big(2)^100)[1] 100 eps(BigFloat) * 1e3
+@test_approx_eq_eps log(2,[big(2)^100])[1] 100 eps(BigFloat) * 1e3
+@test_approx_eq_eps log([2],[big(2)^100])[1] 100 eps(BigFloat) * 1e3


### PR DESCRIPTION
This fixes `log(b,x)` so that it promotes its arguments to the same type before computing `log(x)/log(b)`.   This fixes a spurious loss of accuracy, e.g. in `log(2,big(2)^100)`, as [reported on the mailing list](https://groups.google.com/d/msg/julia-users/niVn2FKivuQ/GqlULNIF2S0J).

Incidentally, it also makes `log(b,x)` faster for the case where `b` and/or `x` is an array, by using `@vectorize_2arg` rather that allocating temporary arrays and dividing them.

`log(2, z::Complex)` will get slower because `log(2)` is now computed as a complex log.   If we care about this case it would be easy to add another method to speed it up.

cc: @StefanKarpinski 
