### PR TITLE
Added ismount function.

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1266,6 +1266,7 @@ export
     isfifo,
     isfile,
     islink,
+    ismount,
     ispath,
     isreadable,
     issetgid,

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -124,3 +124,18 @@ function samefile(a::AbstractString, b::AbstractString)
         return false
     end
 end
+
+function ismount(path...)
+    path = joinpath(path...)
+    isdir(path) || return false
+    s1 = lstat(path)
+    # Symbolic links cannot be mount points
+    islink(s1) && return false
+    parent_path = joinpath(path, "..")
+    s2 = lstat(parent_path)
+    # If a directory and its parent are on different devices,  then the
+    # directory must be a mount point
+    (s1.device != s2.device) && return true
+    (s1.inode == s2.inode) && return true
+    false
+end

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -186,6 +186,10 @@
 
    Returns ``true`` if ``path`` is a symbolic link, ``false`` otherwise.
 
+.. function:: ismount(path) -> Bool
+
+   Returns ``true`` if ``path`` is a mount point, ``false`` otherwise.
+
 .. function:: ispath(path) -> Bool
 
    Returns ``true`` if ``path`` is a valid filesystem path, ``false`` otherwise.


### PR DESCRIPTION
Equivalent functionality of Python's `os.path.ismount` function:

> os.path.ismount(path)
> Return True if pathname path is a mount point: a point in a file system where a different file system has been mounted. The function checks whether path‘s parent, path/.., is on a different device than path, or whether path/.. and path point to the same i-node on the same device — this should detect mount points for all Unix and POSIX variants.
