### PR TITLE
Throw exceptions with arguments without creating a GC frame

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -49,3 +49,13 @@ macro assert(ex, msgs...)
     end
     :($(esc(ex)) ? $(nothing) : throw(Main.Base.AssertionError($msg)))
 end
+
+throw_with_args(typ::ANY) = (@_meta(noinline); throw(typ()))
+throw_with_args(typ::ANY, arg1) = (@_meta(noinline); throw(typ(arg1)))
+throw_with_args(typ::ANY, arg1, arg2) =
+    (@_meta(noinline); throw(typ(arg1, arg2)))
+throw_with_args(typ::ANY, arg1, arg2, arg3) =
+    (@_meta(noinline); throw(typ(arg1, arg2, arg3)))
+throw_with_args(typ::ANY, arg1, arg2, arg3, arg4) =
+    (@_meta(noinline); throw(typ(arg1, arg2, arg3, arg4)))
+throw_with_args(typ::ANY, args...) = throw(typ(args...))

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -62,6 +62,10 @@ macroexpand(x) = ccall(:jl_macroexpand, Any, (Any,), x)
 
 ## misc syntax ##
 
+macro _meta(args...)
+    Expr(:meta, args...)
+end
+
 macro eval(x)
     :($(esc(:eval))($(Expr(:quote,x))))
 end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2228,6 +2228,20 @@ function inlineable(f::ANY, e::Expr, atype::ANY, sv::StaticVarInfo, enclosing_as
             end
         end
     end
+    # Special case for throw. Use push the construction of the exception into
+    # a helper function to avoid creating a GC frame. This hack can be removed
+    # when codegen is smarter on inserting GC frames or if creating GC frames
+    # no longer affect performance.
+    if is(f, throw) && length(atypes) == 1 && isa(argexprs[1], Expr)
+        throw_expr::Expr = argexprs[1]
+        throw_args = throw_expr.args
+        if !is(throw_expr.head, :new)
+            return NF
+        end
+        expr = Expr(:call, TopNode(:throw_with_args), throw_args...)
+        expr.typ = Bottom
+        return (expr, ())
+    end
     if isa(f,IntrinsicFunction)
         return NF
     end


### PR DESCRIPTION
This pull request is trying to address the issue brought up in https://github.com/JuliaLang/julia/pull/11244 and the issue that throwing an error with argument can bring down the performance of the non-error path because of the creation of gc frames.

As mentioned in the comment of that pull request, the idea here is to NOT inline the constructor of the error but create specialized function for the arguments in order to avoid boxing.

This function can probably be used in many other places as well but I'm just using it for `SimpleVector` for benchmarking before getting more feedback. (Edit: and if this PR is accepted, I will probably replace a number of other places to use this function either in this PR or in a new one)
- Not sure if function name choice is good (and as a fact I'm bad at naming).
- Maybe this can be exported if it is useful for user code as well.
- The manual specialization is necessary because currently a vararg function will still require boxing of the argument and creating a tuple which defeat the purpose of those functions. Related https://github.com/JuliaLang/julia/issues/11248.

Benchmark:
Code

``` julia
sv = Base.svec(1, 2)

@code_llvm getindex(sv, 1)

function time_func(f::Function, args...)
    println(f)
    f(args...)
    gc()
    @time for i in 1:100000000
        f(args...)
    end
    gc()
end

f(v, i) = v[i]
time_func(f, sv, 1)
```

Before

``` llvm
define %jl_value_t* @julia_getindex_67410(%jl_value_t*, i64) {
top:
  %2 = alloca [3 x %jl_value_t*], align 8
  %.sub = getelementptr inbounds [3 x %jl_value_t*]* %2, i64 0, i64 0
  %3 = getelementptr [3 x %jl_value_t*]* %2, i64 0, i64 2
  %4 = bitcast [3 x %jl_value_t*]* %2 to i64*
  store i64 2, i64* %4, align 8
  %5 = getelementptr [3 x %jl_value_t*]* %2, i64 0, i64 1
  %6 = bitcast %jl_value_t** %5 to %jl_value_t***
  %7 = load %jl_value_t*** @jl_pgcstack, align 8
  store %jl_value_t** %7, %jl_value_t*** %6, align 8
  store %jl_value_t** %.sub, %jl_value_t*** @jl_pgcstack, align 8
  store %jl_value_t* null, %jl_value_t** %3, align 8
  %8 = icmp slt i64 %1, 1
  br i1 %8, label %if2, label %L1

L1:                                               ; preds = %top
  %9 = bitcast %jl_value_t* %0 to i64*
  %10 = load i64* %9, align 8
  %phitmp8 = icmp slt i64 %10, %1
  br i1 %phitmp8, label %if2, label %L4

if2:                                              ; preds = %L1, %top
  %11 = call %jl_value_t* @alloc_2w()
  %12 = getelementptr inbounds %jl_value_t* %11, i64 -1, i32 0
  store %jl_value_t* inttoptr (i64 139927411285136 to %jl_value_t*), %jl_value_t** %12, align 8
  %13 = getelementptr inbounds %jl_value_t* %11, i64 0, i32 0
  store %jl_value_t* %0, %jl_value_t** %13, align 8
  %14 = getelementptr inbounds %jl_value_t* %11, i64 1, i32 0
  store %jl_value_t* null, %jl_value_t** %14, align 8
  store %jl_value_t* %11, %jl_value_t** %3, align 8
  %15 = call %jl_value_t* @jl_box_int64(i64 signext %1)
  store %jl_value_t* %15, %jl_value_t** %14, align 8
  %16 = icmp eq %jl_value_t* %15, null
  br i1 %16, label %cont3, label %wb_not_null

wb_not_null:                                      ; preds = %if2
  %17 = bitcast %jl_value_t** %12 to i64*
  %18 = load i64* %17, align 8
  %19 = and i64 %18, 1
  %20 = icmp eq i64 %19, 0
  br i1 %20, label %cont3, label %wb_may_trigger

wb_may_trigger:                                   ; preds = %wb_not_null
  %21 = getelementptr inbounds %jl_value_t* %15, i64 -1, i32 0
  %22 = bitcast %jl_value_t** %21 to i64*
  %23 = load i64* %22, align 8
  %24 = and i64 %23, 1
  %25 = icmp eq i64 %24, 0
  br i1 %25, label %wb_trigger, label %cont3

wb_trigger:                                       ; preds = %wb_may_trigger
  call void @gc_queue_root(%jl_value_t* %11)
  br label %cont3

cont3:                                            ; preds = %wb_trigger, %wb_may_trigger, %wb_not_null, %if2
  call void @jl_throw_with_superfluous_argument(%jl_value_t* %11, i32 302)
  br label %L4

L4:                                               ; preds = %cont3, %L1
  %26 = ptrtoint %jl_value_t* %0 to i64
  %27 = shl i64 %1, 3
  %28 = add i64 %27, %26
  %29 = inttoptr i64 %28 to i8**
  %30 = load i8** %29, align 1
  %31 = icmp eq i8* %30, null
  br i1 %31, label %if5, label %L7

if5:                                              ; preds = %L4
  call void @jl_throw_with_superfluous_argument(%jl_value_t* inttoptr (i64 139927411359824 to %jl_value_t*), i32 305)
  br label %L7

L7:                                               ; preds = %if5, %L4
  %32 = bitcast i8* %30 to %jl_value_t*
  %33 = load %jl_value_t*** %6, align 8
  store %jl_value_t** %33, %jl_value_t*** @jl_pgcstack, align 8
  ret %jl_value_t* %32
}
f
elapsed time: 1.8844901 seconds (0 bytes allocated)
```

After

``` llvm
define %jl_value_t* @julia_getindex_44351(%jl_value_t*, i64) {
top:
  %2 = icmp slt i64 %1, 1
  br i1 %2, label %if2, label %L1

L1:                                               ; preds = %top
  %3 = bitcast %jl_value_t* %0 to i64*
  %4 = load i64* %3, align 8
  %phitmp7 = icmp slt i64 %4, %1
  br i1 %phitmp7, label %if2, label %L3

if2:                                              ; preds = %L1, %top
  %5 = load %jl_value_t** inttoptr (i64 139845508162200 to %jl_value_t**), align 8
  call void @julia_throw_with_args3419(%jl_value_t* %5, %jl_value_t* %0, i64 %1)
  br label %L3

L3:                                               ; preds = %if2, %L1
  %6 = ptrtoint %jl_value_t* %0 to i64
  %7 = shl i64 %1, 3
  %8 = add i64 %7, %6
  %9 = inttoptr i64 %8 to i8**
  %10 = load i8** %9, align 1
  %11 = icmp eq i8* %10, null
  br i1 %11, label %if4, label %L6

if4:                                              ; preds = %L3
  call void @jl_throw_with_superfluous_argument(%jl_value_t* inttoptr (i64 139845508137040 to %jl_value_t*), i32 319)
  br label %L6

L6:                                               ; preds = %if4, %L3
  %12 = bitcast i8* %10 to %jl_value_t*
  ret %jl_value_t* %12
}
f
elapsed time: 1.7220829 seconds (0 bytes allocated)
```

Note: the benchmark time fluctuate for both but the new version (1.72-1.82s) is consistently faster than the original one (1.80-1.92s). Also it is probably hard to quantify the impact of a gc frame but at least it should be clear from the llvm ir that no gc frame was created in the function anymore.
