### PR TITLE
People might mistake this for Raspberry Pi 2?

### DIFF
--- a/README.arm.md
+++ b/README.arm.md
@@ -43,7 +43,7 @@ Then proceed to build as described in the primary README. Just typing
 If you run in to issues building LLVM, see these notes:
 [http://llvm.org/docs/HowToBuildOnARM.html](http://llvm.org/docs/HowToBuildOnARM.html)
 
-# Raspberry Pi
+# Raspberry Pi (the original)
 
 The Raspberry Pi ARM CPU is not correctly detected by LLVM. Before
 starting the build, `export JULIA_CPU_ARCH=arm1176jzf-s`. This tells


### PR DESCRIPTION
JULIA_CPU_ARCH=arm1176jzf-s

means ARMv6 (that is the original). Not clear from this text that Raspberry Pi 2 also work, at least wouldn't with this option. Is my understanding correct that it also (just) "works", with no flags? (And Odroid?) How fast is the startup (and compile 70 hours?) time? Add warning about both? Since you are working on it, I assume, startup could be fast eventually (precompile and/or "standalone exe"), but just not yet, and expectations should be set..
