### PR TITLE
Multiset Combinations, Multiset Permutations, K-Permutations and Combinations with Replacement.

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -288,6 +288,65 @@ end
 
 done(p::Permutations, s) = !isempty(s) && max(s[1], p.t) > length(p.a) ||  (isempty(s) && p.t > 0)
 
+immutable MultiSetPermutations{T}
+    m::T
+    f::Vector{Int}
+    t::Int
+    ref::Vector{Int}
+end
+
+eltype{T}(::Type{MultiSetPermutations{T}}) = Vector{eltype(T)}
+
+function length(c::MultiSetPermutations)
+    t = c.t
+    if t > length(c.ref)
+        return 0
+    end
+    if t > 20
+        g = [factorial(big(i)) for i in 0:t]
+    else
+        g = [factorial(i) for i in 0:t]
+    end
+    p = [g[t+1]; zeros(Float64,t)]
+    for i in 1:length(c.f)
+        f = c.f[i]
+        if i == 1
+            for j in 1:min(f, t)
+                p[j+1] = g[t+1]/g[j+1]
+            end
+        else
+            for j in t:-1:1
+                q = 0
+                for k in (j+1):-1:max(1,j+1-f)
+                    q += p[k]/g[j+2-k]
+                end
+                p[j+1] = q
+            end
+        end
+    end
+    return round(Int, p[t+1])
+end
+
+function multiset_permutations{T<:Integer}(m, f::Vector{T}, t::Integer)
+    length(m) == length(f) || error("Lengths of m and f are not the same.")
+    ref = length(f) > 0 ? vcat([[i for j in 1:f[i] ] for i in 1:length(f)]...) : Int[]
+    if t < 0
+        t = length(ref) + 1
+    end
+    MultiSetPermutations(m, f, t, ref)
+end
+
+function multiset_permutations{T}(a::T, t::Integer)
+    m = unique(collect(a))
+    f = [sum([c == x for c in a]) for x in m]
+    multiset_permutations(m, f, t)
+end
+
+start(p::MultiSetPermutations) = p.ref
+next(p::MultiSetPermutations, s) = nextpermutation(p.m, length(p.ref), p.t, s)
+done(p::MultiSetPermutations, s) =
+    !isempty(s) && max(s[1], p.t) > length(p.ref) ||  (isempty(s) && p.t > 0)
+
 # Integer Partitions
 
 immutable IntegerPartitions

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -283,6 +283,43 @@ end
 done(c::MultiSetCombinations, s) =
     (!isempty(s) && max(s[1], c.t) > length(c.ref)) ||  (isempty(s) && c.t > 0)
 
+immutable WithReplacementCombinations{T}
+    a::T
+    t::Int
+end
+
+eltype{T}(::Type{WithReplacementCombinations{T}}) = Vector{eltype(T)}
+
+length(c::WithReplacementCombinations) = binomial(length(c.a)+c.t-1, c.t)
+
+with_replacement_combinations(a, t::Integer) = WithReplacementCombinations(a, t)
+
+start(c::WithReplacementCombinations) = [1 for i in 1:c.t]
+function next(c::WithReplacementCombinations, s)
+    n = length(c.a)
+    t = c.t
+    comb = [c.a[si] for si in s]
+    if t > 0
+        s = copy(s)
+        changed = false
+        for i in t:-1:1
+            if s[i] < n
+                s[i] += 1
+                for j in (i+1):t
+                    s[j] = s[i]
+                end
+                changed = true
+                break
+            end
+        end
+        !changed && (s[1] = n+1)
+    else
+        s = [n+1]
+    end
+    (comb, s)
+end
+done(c::WithReplacementCombinations, s) = !isempty(s) && s[1] > length(c.a) || c.t < 0
+
 immutable Permutations{T}
     a::T
     t::Int

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -208,6 +208,81 @@ function next(c::Combinations, s)
 end
 done(c::Combinations, s) = !isempty(s) && s[1] > length(c.a)-c.t+1
 
+immutable MultiSetCombinations{T}
+    m::T
+    f::Vector{Int}
+    t::Int
+    ref::Vector{Int}
+end
+
+eltype{T}(::Type{MultiSetCombinations{T}}) = Vector{eltype(T)}
+
+function length(c::MultiSetCombinations)
+    t = c.t
+    if t > length(c.ref)
+        return 0
+    end
+    p = [1; zeros(Int,t)]
+    for i in 1:length(c.f)
+        f = c.f[i]
+        if i == 1
+            for j in 1:min(f, t)
+                p[j+1] = 1
+            end
+        else
+            for j in t:-1:1
+                p[j+1] = sum(p[max(1,j+1-f):(j+1)])
+            end
+        end
+    end
+    return p[t+1]
+end
+
+function multiset_combinations{T<:Integer}(m, f::Vector{T}, t::Integer)
+    length(m) == length(f) || error("Lengths of m and f are not the same.")
+    ref = length(f) > 0 ? vcat([[i for j in 1:f[i] ] for i in 1:length(f)]...) : Int[]
+    if t < 0
+        t = length(ref) + 1
+    end
+    MultiSetCombinations(m, f, t, ref)
+end
+
+function multiset_combinations{T}(a::T, t::Integer)
+    m = unique(collect(a))
+    f = Int[sum([c == x for c in a]) for x in m]
+    multiset_combinations(m, f, t)
+end
+
+start(c::MultiSetCombinations) = c.ref
+function next(c::MultiSetCombinations, s)
+    ref = c.ref
+    n = length(ref)
+    t = c.t
+    changed = false
+    comb = [c.m[s[i]] for i in 1:t]
+    if t > 0
+        s = copy(s)
+        for i in t:-1:1
+            if s[i] < ref[i + (n - t)]
+                j = 1
+                while ref[j] <= s[i]; j += 1; end
+                s[i] = ref[j]
+                for l in (i+1):t
+                    s[l] = ref[j+=1]
+                end
+                changed = true
+                break
+            end
+        end
+        !changed && (s[1] = n+1)
+    else
+        s = [n+1]
+    end
+    (comb, s)
+end
+done(c::MultiSetCombinations, s) =
+    (!isempty(s) && max(s[1], c.t) > length(c.ref)) ||  (isempty(s) && c.t > 0)
+
 immutable Permutations{T}
     a::T
     t::Int

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -307,7 +307,6 @@ export
     clamp,
     cld,
     cmp,
-    combinations,
     complex,
     conj,
     copysign,
@@ -488,6 +487,7 @@ export
     checkbounds,
     circshift,
     colon,
+    combinations,
     conj!,
     copy!,
     cummax,
@@ -541,6 +541,8 @@ export
     minimum!,
     minimum,
     minmax,
+    multiset_combinations,
+    multiset_permutations,
     ndims,
     nnz,
     nonzeros,
@@ -603,6 +605,7 @@ export
     sum_kbn,
     vcat,
     vec,
+    with_replacement_combinations,
     zeros,
 
 # linear algebra

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -40,6 +40,15 @@ a = randcycle(10)
 @test collect(permutations("", 0)) == Any[Char[]]
 @test collect(permutations("", -1)) == Any[]
 
+@test collect(multiset_permutations("aabc", 5)) == Any[]
+@test collect(multiset_permutations("aabc", 2)) == Any[['a','a'],['a','b'], ['a','c'],['b','a'],
+                                                       ['b','c'],['c','a'],['c','b']]
+@test collect(multiset_permutations("aabc", 0)) == Any[Char[]]
+@test collect(multiset_permutations("aabc", -1)) == Any[]
+@test collect(multiset_permutations("", 1)) == Any[]
+@test collect(multiset_permutations("", 0)) == Any[Char[]]
+@test collect(multiset_permutations("", -1)) == Any[]
+
 @test collect(filter(x->(iseven(x[1])),permutations([1,2,3]))) == Any[[2,1,3],[2,3,1]]
 @test collect(filter(x->(iseven(x[3])),permutations([1,2,3]))) == Any[[1,3,2],[3,1,2]]
 @test collect(filter(x->(iseven(x[1])),combinations([1,2,3],2))) == Any[[2,3]]

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -39,6 +39,15 @@ a = randcycle(10)
 @test collect(multiset_combinations("", 0)) == Any[Char[]]
 @test collect(multiset_combinations("", -1)) == Any[]
 
+@test collect(with_replacement_combinations("abc", 2)) == Any[['a','a'],['a','b'],['a','c'],
+                                                              ['b','b'],['b','c'],['c','c']]
+@test collect(with_replacement_combinations("abc", 1)) == Any[['a'],['b'],['c']]
+@test collect(with_replacement_combinations("abc", 0)) == Any[Char[]]
+@test collect(with_replacement_combinations("abc", -1)) == Any[]
+@test collect(with_replacement_combinations("", 1)) == Any[]
+@test collect(with_replacement_combinations("", 0)) == Any[Char[]]
+@test collect(with_replacement_combinations("", -1)) == Any[]
+
 @test collect(permutations("abc")) == Any[['a','b','c'],['a','c','b'],['b','a','c'],
                                           ['b','c','a'],['c','a','b'],['c','b','a']]
 @test collect(permutations("abc", 4)) == Any[]

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -29,6 +29,16 @@ a = randcycle(10)
 @test collect(combinations("abc",1)) == Any[['a'],['b'],['c']]
 @test collect(combinations("abc",0)) == Any[Char[]]
 @test collect(combinations("abc",-1)) == Any[]
+
+@test collect(multiset_combinations("aabc", 5)) == Any[]
+@test collect(multiset_combinations("aabc", 2)) == Any[['a','a'],['a','b'],['a','c'],['b','c']]
+@test collect(multiset_combinations("aabc", 1)) == Any[['a'],['b'],['c']]
+@test collect(multiset_combinations("aabc", 0)) == Any[Char[]]
+@test collect(multiset_combinations("aabc", -1)) == Any[]
+@test collect(multiset_combinations("", 1)) == Any[]
+@test collect(multiset_combinations("", 0)) == Any[Char[]]
+@test collect(multiset_combinations("", -1)) == Any[]
+
 @test collect(permutations("abc")) == Any[['a','b','c'],['a','c','b'],['b','a','c'],
                                           ['b','c','a'],['c','a','b'],['c','b','a']]
 @test collect(permutations("abc", 4)) == Any[]

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -31,6 +31,14 @@ a = randcycle(10)
 @test collect(combinations("abc",-1)) == Any[]
 @test collect(permutations("abc")) == Any[['a','b','c'],['a','c','b'],['b','a','c'],
                                           ['b','c','a'],['c','a','b'],['c','b','a']]
+@test collect(permutations("abc", 4)) == Any[]
+@test collect(permutations("abc", 2)) == Any[['a','b'],['a','c'],['b','a'],
+                                             ['b','c'],['c','a'],['c','b']]
+@test collect(permutations("abc", 0)) == Any[Char[]]
+@test collect(permutations("abc", -1)) == Any[]
+@test collect(permutations("", 1)) == Any[]
+@test collect(permutations("", 0)) == Any[Char[]]
+@test collect(permutations("", -1)) == Any[]
 
 @test collect(filter(x->(iseven(x[1])),permutations([1,2,3]))) == Any[[2,1,3],[2,3,1]]
 @test collect(filter(x->(iseven(x[3])),permutations([1,2,3]))) == Any[[1,3,2],[3,1,2]]


### PR DESCRIPTION
Hi developers,

Four different arrangements are added:
1. Multiset Combinations
2. Combinations with Replacement.
3. Multiset Permutations
4. K-Permutations

Not sure if they should be placed in a separate package or should be merged to julia base. But I would love to put them in julia base.

I am not good at naming functions, please suggest better names for them if you have any ideas. It may also make sense to introduce abstract types `AbstractCombinations` and `AbstractPermutations` or even a super type `AbstractArrangement`.

Demo:

``` julia
julia> import Base: multiset_combinations, with_replacement_combinations, multiset_permutations

julia> collect(multiset_combinations("aabc", 2))
4-element Array{Array{Char,1},1}:
 ['a','a']
 ['a','b']
 ['a','c']
 ['b','c']

julia> collect(with_replacement_combinations("abc", 2))
6-element Array{Array{Char,1},1}:
 ['a','a']
 ['a','b']
 ['a','c']
 ['b','b']
 ['b','c']
 ['c','c']

julia> collect(multiset_permutations("aabc", 2))
7-element Array{Array{Char,1},1}:
 ['a','a']
 ['a','b']
 ['a','c']
 ['b','a']
 ['b','c']
 ['c','a']
 ['c','b']

julia> collect(permutations("abc", 2))
6-element Array{Array{Char,1},1}:
 ['a','b']
 ['a','c']
 ['b','a']
 ['b','c']
 ['c','a']
 ['c','b']
```

Details:

There are three new types: `MultiSetCombinations`, `WithReplacementCombinations`, `MultiSetPermutations`. For k-permutations, one more field is added to the `Permutations` type to store the value of k.

There are also two functions `nextpermutation` and  `nextpermutation0`. `nextpermutation0` is the actually not new, it is the original permutation algorithm used. The other function `nextpermutation` does permutations with multiset and k-permutations. I have tested the different permutation functions on n-permutations and there are not much differences.

``` julia
julia> @time collect(permutations("abcdefgh"));
   7.135 milliseconds (121 k allocations: 10395 KB)

julia> @time collect(multiset_permutations("abcdefgh", 8));
   7.675 milliseconds (121 k allocations: 10405 KB)
```
