### PR TITLE
WIP: Rewrite git://github.com to https://github.com in package URLs.

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -2,9 +2,9 @@
 
 module Pkg
 
-export Git, Dir, Types, Reqs, Cache, Read, Query, Resolve, Write, Entry, Git
+export Dir, Types, Reqs, Cache, Read, Query, Resolve, Write, Entry, Git
 export dir, init, rm, add, available, installed, status, clone, checkout,
-       update, resolve, test, build, free, pin, PkgError
+       update, resolve, test, build, free, pin, PkgError, setprotocol!
 
 const DEFAULT_META = "https://github.com/JuliaLang/METADATA.jl"
 const META_BRANCH = "metadata-v2"
@@ -55,6 +55,8 @@ test(;coverage::Bool=false) = cd(Entry.test; coverage=coverage)
 test(pkgs::AbstractString...; coverage::Bool=false) = cd(Entry.test,AbstractString[pkgs...]; coverage=coverage)
 
 dependents(packagename::AbstractString) = Reqs.dependents(packagename)
+
+setprotocol!(proto::AbstractString) = Cache.setprotocol!(proto)
 
 
 # point users to PkgDev

--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -5,6 +5,11 @@ module Cache
 import ...LibGit2, ..Dir, ...Pkg.PkgError
 using ..Types
 
+rewrite_url_to = "https"
+
+const GITHUB_REGEX =
+    r"^(?:git@|git://|https://(?:[\w\.\+\-]+@)?)github.com[:/](([^/].+)/(.+?))(?:\.git)?$"i
+
 path(pkg::AbstractString) = abspath(".cache", pkg)
 
 function mkcachedir()
@@ -30,23 +35,24 @@ end
 
 function prefetch(pkg::AbstractString, url::AbstractString, sha1s::Vector)
     isdir(".cache") || mkcachedir()
-    #TODO: force switch to https
-    #url = LibGit2.normalize_url(url)
+
     cache = path(pkg)
+    normalized_url = normalize_url(url)
+
     repo = if isdir(cache)
         LibGit2.GitRepo(cache) # open repo, free it at the end
     else
-        info("Cloning cache of $pkg from $url")
+        info("Cloning cache of $pkg from $normalized_url")
         try
             # clone repo, free it at the end
-            LibGit2.clone(url, cache, isbare = true, remote_cb = LibGit2.mirror_cb())
+            LibGit2.clone(normalized_url, cache, isbare = true, remote_cb = LibGit2.mirror_cb())
         catch err
             isdir(cache) && rm(cache, recursive=true)
-            throw(PkgError("Cannot clone $pkg from $url. $(err.msg)"))
+            throw(PkgError("Cannot clone $pkg from $normalized_url. $(err.msg)"))
         end
     end
     try
-        LibGit2.set_remote_url(repo, url)
+        LibGit2.set_remote_url(repo, normalized_url)
         in_cache = BitArray(map(sha1->LibGit2.iscommit(sha1, repo), sha1s))
         if !all(in_cache)
             info("Updating cache of $pkg...")
@@ -60,5 +66,24 @@ function prefetch(pkg::AbstractString, url::AbstractString, sha1s::Vector)
 end
 prefetch(pkg::AbstractString, url::AbstractString, sha1::AbstractString...) =
     prefetch(pkg, url, AbstractString[sha1...])
+
+function setprotocol!(proto::AbstractString)
+    global rewrite_url_to
+
+    if length(proto) == 0
+        rewrite_url_to = nothing
+    else
+        rewrite_url_to = proto
+    end
+end
+
+function normalize_url(url::AbstractString)
+    global rewrite_url_to
+
+    m = match(GITHUB_REGEX,url)
+    (m === nothing || rewrite_url_to === nothing) ?
+        url : "$rewrite_url_to://github.com/$(m.captures[1]).git"
+
+end
 
 end # module

--- a/base/pkg/write.jl
+++ b/base/pkg/write.jl
@@ -27,7 +27,7 @@ function fetch(repo::GitRepo, pkg::AbstractString, sha1::AbstractString)
 end
 
 function checkout(repo::GitRepo, pkg::AbstractString, sha1::AbstractString)
-    LibGit2.set_remote_url(repo, Read.url(pkg))
+    LibGit2.set_remote_url(repo, Cache.normalize_url(Read.url(pkg)))
     LibGit2.checkout!(repo, sha1)
 end
 


### PR DESCRIPTION
## Introduction

As git:// URLs cannot be loaded behind proxies, the current package manager is broken for many institutional users without manual configuration of Git using the "git://".insteadOf workaround.  This is a major usability problem, and leaves a bad first impression for new users who are used to the polished installer of Matlab.

As discussed in #7005, the git:// protocol also provides no security against man-in-the-middle attacks, to which the current system is vulnerable due to the lack of digital signatures in the process.

The Pkg package has therefore been made to automatically change all git://github.com URLs to https://github.com.  URLs pointing to other domains will be unaffected.  If a complete change from git:// to https:// is made, then it is anticipated that existing URLs in METADATA.jl will be changed from git:// to https://.  This may render the URL normalisation part of these changes unnecessary, however it would still be necessary to change the METADATA.jl URL to use HTTPS.
## Changes
1. The JuliaLang/METADATA.jl repository URL has been changed from git:// to https:// .
2. Generated URLS have all been changed from git:// to https://
3. The existing URL normalisation code in base/pkg/git.jl has been modified so that it normalises to https:// rather than git://
4. All URLs are now normalised before being passed to "git clone" or Git.set_remote_url.

Together, these changes allow packages to be installed without access to the git:// port.
## Test procedure
1. Compile Julia in Vagrant-setup virtual machine
2. Run 'sudo iptables -I OUTPUT -p tcp --dport 9418 -j REJECT'
3. Ensure that port is blocked by running 'git clone git://github.com/JuliaLang/Example.jl'.
4. Run 'jlmake test-pkg'
