### PR TITLE
Fix: libDSFMT.{SHLIB_EXT} -> libdSFMT.{SHLIB_EXT}

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -875,7 +875,7 @@ $(DSFMT_OBJ_SOURCE): dsfmt-$(DSFMT_VER)/config.status
 $(build_shlibdir)/libdSFMT%$(SHLIB_EXT) $(build_includedir)/dSFMT%h: $(DSFMT_OBJ_SOURCE) | $(build_includedir) $(build_shlibdir)
 	cp dsfmt-$(DSFMT_VER)/dSFMT.h $(build_includedir)
 	cp $< $(build_shlibdir)/libdSFMT.$(SHLIB_EXT) && \
-	$(INSTALL_NAME_CMD)libdSFMT.$(SHLIB_EXT) $(build_shlibdir)/libDSFMT.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libdSFMT.$(SHLIB_EXT) $(build_shlibdir)/libdSFMT.$(SHLIB_EXT)
 
 clean-dsfmt:
 	-rm -f dsfmt-$(DSFMT_VER)/libdSFMT.$(SHLIB_EXT)


### PR DESCRIPTION
I found that I needed this change to compile Julia on a case-sensitive file system on OSX (**Edit: from a clean build**).

I can see why it wouldn't cause any problems for a case-insensitive file system, but I'm unclear why the original change did _not_ cause issues on Linux.  

@vtjnash, you were the last person to edit this line--was this just a typo?
