### PR TITLE
fix for #11305 "subl" option in interactiveutil.jl

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -33,7 +33,7 @@ function edit(file::AbstractString, line::Integer)
         run(`$edpath +$line $file`)
     elseif edname == "textmate" || edname == "mate" || edname == "kate"
         spawn(`$edpath $file -l $line`)
-    elseif startswith(edname, "subl") || edname == "atom"
+    elseif startswith(edname, "subl") || edname == "atom" || endswith(string(edname),"subl")
         spawn(`$(shell_split(edpath)) $file:$line`)
     elseif OS_NAME == :Windows && (edname == "start" || edname == "open")
         spawn(`cmd /c start /b $file`)


### PR DESCRIPTION
I think I figured out a solution to issue #11305 function edit seems to create bad path for sublime text option (i.e. "subl") in interactiveutil.jl

I think I figured it out if I change the path from:
ENV["JULIA_EDITOR"]="/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl"
ENV["JULIA_EDITOR"]="/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl"
edname stays as: 
"/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl" and not "subl" as it should while shell_split(edpath) produces the correct:
"/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"

in order to fix it we need to change:
in 0.3.8 interactiveutil.jl line 34
from:   elseif beginswith(edname, "subl")
to:       elseif beginswith(edname, "subl") || endswith(string(edname),"subl")

and in the latest pre 0.4 from
in 0.3.8 interactiveutil.jl line 36
from:   startswith(edname, "subl") || edname == "atom"
to:      startswith(edname, "subl") || edname == "atom" || endswith(string(edname),"subl")

This is a pull request to change the code for the latest pre 0.4  I am not sure how to make a pull reqest to fix if for the latest 0.3 version.
