### PR TITLE
Throw OverflowError when the field offset / size overflows.

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -534,6 +534,8 @@ void jl_compute_field_offsets(jl_datatype_t *st)
         size_t fsz, al;
         if (jl_isbits(ty) && jl_is_leaf_type(ty)) {
             fsz = jl_datatype_size(ty);
+            if (__unlikely(fsz > JL_FIELD_MAX_SIZE))
+                jl_throw(jl_overflow_exception);
             al = ((jl_datatype_t*)ty)->alignment;
             st->fields[i].isptr = 0;
         }
@@ -550,6 +552,8 @@ void jl_compute_field_offsets(jl_datatype_t *st)
             if (al > alignm)
                 alignm = al;
         }
+        if (__unlikely(sz > JL_FIELD_MAX_OFFSET))
+            jl_throw(jl_overflow_exception);
         st->fields[i].offset = sz;
         st->fields[i].size = fsz;
         sz += fsz;

--- a/src/julia.h
+++ b/src/julia.h
@@ -265,6 +265,9 @@ typedef struct {
     uint16_t isptr:1;
 } jl_fielddesc_t;
 
+#define JL_FIELD_MAX_OFFSET ((1ul << 16) - 1ul)
+#define JL_FIELD_MAX_SIZE ((1ul << 15) - 1ul)
+
 typedef struct _jl_datatype_t {
     JL_DATA_TYPE
     jl_typename_t *name;


### PR DESCRIPTION
Improve #11320.

This doesn't completely fix it but should be the right thing to do anyway.

@ScottPJones
