### PR TITLE
Do not require new line or ";" at the end of import expression

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1293,9 +1293,9 @@
          (from  (and (eq? next ':) (not (ts:space? s))))
          (done  (cond ((or from (eqv? next #\,))
                        (begin (take-token s) #f))
-                      ((memv next '(#\newline #\;)) #t)
-                      ((eof-object? next) #t)
-                      (else #f)))
+                      ((or (eq? next '|.|)
+                           (eqv? (string.sub (string next) 0 1) ".")) #f)
+                      (else #t)))
          (rest  (if done
                     '()
                     (parse-comma-separated s (lambda (s)
@@ -1341,7 +1341,7 @@
         (loop (cons (symbol (string.sub (string nxt) 1))
                     path)))
        (else
-        (error (string "invalid \"" word "\" statement")))))))
+        `(,word ,@(reverse path)))))))
 
 ; parse comma-separated assignments, like "i=1:n,j=1:m,..."
 (define (parse-comma-separated s what)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -86,3 +86,26 @@ macro test999_str(args...); args; end
 
 # issue #10985
 @test expand(:(f(::Int...) = 1)).head == :method
+
+# issue #10910
+@test parse(":(using A)") == Expr(:quote, Expr(:using, :A))
+@test parse(":(using A.b, B)") == Expr(:quote,
+                                       Expr(:toplevel,
+                                            Expr(:using, :A, :b),
+                                            Expr(:using, :B)))
+@test parse(":(using A: b, c.d)") == Expr(:quote,
+                                          Expr(:toplevel,
+                                               Expr(:using, :A, :b),
+                                               Expr(:using, :A, :c, :d)))
+
+@test parse(":(importall A)") == Expr(:quote, Expr(:importall, :A))
+
+@test parse(":(import A)") == Expr(:quote, Expr(:import, :A))
+@test parse(":(import A.b, B)") == Expr(:quote,
+                                        Expr(:toplevel,
+                                             Expr(:import, :A, :b),
+                                             Expr(:import, :B)))
+@test parse(":(import A: b, c.d)") == Expr(:quote,
+                                           Expr(:toplevel,
+                                                Expr(:import, :A, :b),
+                                                Expr(:import, :A, :c, :d)))


### PR DESCRIPTION
This is the first time I write scheme so it's very likely I've got sth wrong.

``` julia
julia> :(using A)
:(using A)

julia> :(using A.b, B.c)
:($(Expr(:toplevel, :(using A.b), :(using B.c))))

julia> :(using A: b, c.d)
:($(Expr(:toplevel, :(using A.b), :(using A.c.d))))

julia> :(importall A)
:(importall A)

julia> :(import A.b, C)
:($(Expr(:toplevel, :(import A.b), :(import C))))
```

Fix #10910 
@mlubin 
@JeffBezanson 
