### PR TITLE
Modify transpose, matrix-vector multiplication, and matrix-matrix multiplication to truncate trailing singleton dimensions.

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1433,11 +1433,19 @@ function ccopy!(B, A)
 end
 
 function transpose(A::StridedMatrix)
-    B = similar(A, size(A, 2), size(A, 1))
+    if size(A, 1) == 1
+        B = similar(A, size(A,2))
+    else
+        B = similar(A, size(A, 2), size(A, 1))
+    end
     transpose!(B, A)
 end
 function ctranspose(A::StridedMatrix)
-    B = similar(A, size(A, 2), size(A, 1))
+    if size(A, 1) == 1
+        B = similar(A, size(A,2))
+    else
+        B = similar(A, size(A, 2), size(A, 1))
+    end
     ctranspose!(B, A)
 end
 ctranspose{T<:Real}(A::StridedVecOrMat{T}) = transpose(A)


### PR DESCRIPTION
This implements the suggestion in my May 16, 2015 comment on julialang/julia issue JuliaLang/LinearAlgebra.jl#42 . If A is a matrix and x and y are vectors, then x'*y is a scalar and x''==x. For consistency, trailing singleton dimensions are truncated whenever they arise from matrix-matrix multiplication as well.
