### PR TITLE
fix object_id usage in dump deserializer

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -119,6 +119,7 @@ extern JL_THREAD void *jl_stackbase;
 void jl_dump_bitcode(char *fname);
 void jl_dump_objfile(char *fname, int jit_model);
 int32_t jl_get_llvm_gv(jl_value_t *p);
+void jl_idtable_rehash(jl_array_t **pa, size_t newsz);
 
 #ifdef _OS_LINUX_
 DLLEXPORT void jl_read_sonames(void);


### PR DESCRIPTION
switch to a more general-purpose mechanism for doing post-processing work after deserializing the system image

starting with 7ec501d6, object_id required more than just object identity for types to compute their hash. the deserializer may not be in a sufficiently consistent state to allow doing this in-situ, so this switches to a more general mechanism for maintaining a list of reinit functions

@JeffBezanson 
