### PR TITLE
backport of fast Pkg.publish

### DIFF
--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -138,7 +138,7 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
             allowedp[vn] = vn in vs
         end
         @assert !isempty(allowedp)
-        @assert any(collect(values(allowedp)))
+        @assert any(values(allowedp))
     end
 
     filtered_deps = (ByteString=>Dict{VersionNumber,Available})[]
@@ -299,28 +299,12 @@ end
 prune_versions(deps::Dict{ByteString,Dict{VersionNumber,Available}}) =
     prune_versions((ByteString=>VersionSet)[], deps)
 
-# Build a subgraph incuding only the (direct and indirect) dependencies
-# of a given package set
-function dependencies_subset(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs::Set{ByteString})
-
-    np = length(deps)
-
-    staged = pkgs
-    allpkgs = pkgs
-    while !isempty(staged)
-        staged_next = Set{ByteString}()
-        for p in staged, a in values(deps[p]), rp in keys(a.requires)
-            if !(rp in allpkgs)
-                push!(staged_next, rp)
-            end
-        end
-        allpkgs = union(allpkgs, staged_next)
-        staged = staged_next
-    end
+# Build a graph restricted to a subset of the packages
+function subdeps(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs::Set{ByteString})
 
     sub_deps = Dict{ByteString,Dict{VersionNumber,Available}}()
-    for p in allpkgs
-        haskey(sub_deps, p) || (sub_deps[p] = (VersionNumber=>Available)[])
+    for p in pkgs
+        haskey(sub_deps, p) || (sub_deps[p] = Dict{VersionNumber,Available}())
         sub_depsp = sub_deps[p]
         for (vn, a) in deps[p]
             sub_depsp[vn] = a
@@ -328,6 +312,57 @@ function dependencies_subset(deps::Dict{ByteString,Dict{VersionNumber,Available}
     end
 
     return sub_deps
+end
+
+# Build a subgraph incuding only the (direct and indirect) dependencies
+# of a given package set
+function dependencies_subset(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs::Set{ByteString})
+
+    staged = pkgs
+    allpkgs = copy(pkgs)
+    while !isempty(staged)
+        staged_next = Set{ByteString}()
+        for p in staged, a in values(deps[p]), rp in keys(a.requires)
+            if !(rp in allpkgs)
+                push!(staged_next, rp)
+            end
+        end
+        union!(allpkgs, staged_next)
+        staged = staged_next
+    end
+
+    return subdeps(deps, allpkgs)
+end
+
+# Build a subgraph incuding only the (direct and indirect) dependencies and dependants
+# of a given package set
+function undirected_dependencies_subset(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs::Set{ByteString})
+
+    graph = Dict{ByteString, Set{ByteString}}()
+
+    for (p,d) in deps
+        haskey(graph, p) || (graph[p] = Set{ByteString}())
+        for a in values(d), rp in keys(a.requires)
+            push!(graph[p], rp)
+            haskey(graph, rp) || (graph[rp] = Set{ByteString}())
+            push!(graph[rp], p)
+        end
+    end
+
+    staged = pkgs
+    allpkgs = copy(pkgs)
+    while !isempty(staged)
+        staged_next = Set{ByteString}()
+        for p in staged, rp in graph[p]
+            if !(rp in allpkgs)
+                push!(staged_next, rp)
+            end
+        end
+        union!(allpkgs, staged_next)
+        staged = staged_next
+    end
+
+    return subdeps(deps, allpkgs)
 end
 
 function prune_dependencies(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber,Available}})

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -157,7 +157,7 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
     # For each package, we examine the dependencies of its versions
     # and put together those which are equal.
     # While we're at it, we also collect all dependencies into alldeps
-    alldeps = Set{(ByteString,VersionSet)}()
+    alldeps = Dict{ByteString,Set{VersionSet}}()
     for (p, fdepsp) in filtered_deps
 
         # Extract unique dependencies lists (aka classes), thereby
@@ -165,8 +165,9 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
         uniqdepssets = unique(values(fdepsp))
 
         # Store all dependencies seen so far for later use
-        for a in uniqdepssets, r in a.requires
-            push!(alldeps, r)
+        for a in uniqdepssets, (rp,rvs) in a.requires
+            haskey(alldeps, rp) || (alldeps[rp] = Set{VersionSet}())
+            push!(alldeps[rp], rvs)
         end
 
         # If the package has just one version, it's uninteresting
@@ -191,7 +192,7 @@ function prune_versions(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber
     end
 
     # Produce dependency patterns.
-    for (p,vs) in alldeps
+    for (p,vss) in alldeps, vs in vss
         # packages with just one version, or dependencies
         # which do not distiguish between versions, are not
         # interesting

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -44,7 +44,9 @@ function resolve(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber,Availa
 end
 
 # Scan dependencies for (explicit or implicit) contradictions
-function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}})
+function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs::Set{ByteString} = Set{ByteString}())
+
+    isempty(pkgs) || (deps = Query.undirected_dependencies_subset(deps, pkgs))
 
     deps, eq_classes = Query.prune_versions(deps)
 

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -89,7 +89,7 @@ function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs
         end
 
         sub_reqs = (ByteString=>VersionSet)[p=>VersionSet([vn, nvn])]
-        sub_deps = Query.prune_dependencies(sub_reqs, deps)
+        sub_deps = Query.filter_dependencies(sub_reqs, deps)
 
         interface = Interface(sub_reqs, sub_deps)
 
@@ -99,6 +99,7 @@ function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs
         red_pvers = interface.pvers
 
         ok, sol = greedysolver(interface)
+
         if !ok
             try
                 graph = Graph(interface)

--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -11,33 +11,36 @@ export resolve, sanity_check
 # Use the max-sum algorithm to resolve packages dependencies
 function resolve(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber,Available}})
 
-    # init structures
+    # init interface structures
     interface = Interface(reqs, deps)
 
-    graph = Graph(interface)
-    msgs = Messages(interface, graph)
+    # attempt trivial solution first
+    ok, sol = greedysolver(interface)
+    if !ok
+        # trivial solution failed, use maxsum solver
+        graph = Graph(interface)
+        msgs = Messages(interface, graph)
 
-    # find solution
-    local sol::Vector{Int}
-    try
-        sol = maxsum(graph, msgs)
-    catch err
-        if isa(err, UnsatError)
-            p = interface.pkgs[err.info]
-            msg = "unsatisfiable package requirements detected: " *
-                  "no feasible version could be found for package: $p"
-            if msgs.num_nondecimated != graph.np
-                msg *= "\n  (you may try increasing the value of the" *
-                       "\n   JULIA_PKGRESOLVE_ACCURACY environment variable)"
+        try
+            sol = maxsum(graph, msgs)
+        catch err
+            if isa(err, UnsatError)
+                p = interface.pkgs[err.info]
+                msg = "unsatisfiable package requirements detected: " *
+                      "no feasible version could be found for package: $p"
+                if msgs.num_nondecimated != graph.np
+                    msg *= "\n  (you may try increasing the value of the" *
+                           "\n   JULIA_PKGRESOLVE_ACCURACY environment variable)"
+                end
+                error(msg)
             end
-            error(msg)
+            rethrow(err)
         end
-        rethrow(err)
-    end
 
-    # verify solution (debug code) and enforce its optimality
-    verify_solution(sol, interface)
-    enforce_optimality!(sol, interface)
+        # verify solution (debug code) and enforce its optimality
+        @assert verify_solution(sol, interface)
+        enforce_optimality!(sol, interface)
+    end
 
     # return the solution as a Dict mapping package_name => sha1
     return compute_output_dict(sol, interface)
@@ -90,18 +93,28 @@ function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs
 
         interface = Interface(sub_reqs, sub_deps)
 
-        graph = Graph(interface)
-        msgs = Messages(interface, graph)
-
         red_pkgs = interface.pkgs
         red_np = interface.np
         red_spp = interface.spp
         red_pvers = interface.pvers
 
-        local sol::Vector{Int}
-        try
-            sol = maxsum(graph, msgs)
-            verify_solution(sol, interface)
+        ok, sol = greedysolver(interface)
+        if !ok
+            try
+                graph = Graph(interface)
+                msgs = Messages(interface, graph)
+                sol = maxsum(graph, msgs)
+                ok = verify_solution(sol, interface)
+                @assert ok
+            catch err
+                isa(err, UnsatError) || rethrow(err)
+                pp = red_pkgs[err.info]
+                for vneq in eq_classes[p][vn]
+                    push!(problematic, (p, vneq, pp))
+                end
+            end
+        end
+        if ok
             let
                 p0 = interface.pdict[p]
                 svn = red_pvers[p0][sol[p0]]
@@ -116,12 +129,6 @@ function sanity_check(deps::Dict{ByteString,Dict{VersionNumber,Available}}, pkgs
                 end
             end
             checked[i] = true
-        catch err
-            isa(err, UnsatError) || rethrow(err)
-            pp = red_pkgs[err.info]
-            for vneq in eq_classes[p][vn]
-                push!(problematic, (p, vneq, pp))
-            end
         end
         i += 1
     end

--- a/base/pkg/resolve/interface.jl
+++ b/base/pkg/resolve/interface.jl
@@ -2,7 +2,7 @@ module PkgToMaxSumInterface
 
 using ...Types, ...Query, ..VersionWeights
 
-export Interface, compute_output_dict,
+export Interface, compute_output_dict, greedysolver,
        verify_solution, enforce_optimality!
 
 # A collection of objects which allow interfacing external (Pkg) and
@@ -116,6 +116,69 @@ function compute_output_dict(sol::Vector{Int}, interface::Interface)
     return want
 end
 
+# Produce a trivial solution: try to maximize each version;
+# bail out as soon as some non-trivial requirements are detected.
+function greedysolver(interface::Interface)
+    reqs = interface.reqs
+    deps = interface.deps
+    spp = interface.spp
+    pdict = interface.pdict
+    pvers = interface.pvers
+    np = interface.np
+
+    # initialize solution: all uninstalled
+    sol = [spp[p0] for p0 = 1:np]
+
+    # we start from required packages and explore the graph
+    # following dependencies
+    staged = Set{ByteString}(keys(reqs))
+    seen = copy(staged)
+
+    while !isempty(staged)
+        staged_next = Set{ByteString}()
+        for p in staged
+            p0 = pdict[p]
+            # set the package state to installed in case it wasn't
+            # (the latter case should only happen for required packages, and
+            # in then we use the maximum available version)
+            sol[p0] = min(sol[p0], spp[p0] - 1)
+            vn = pvers[p0][sol[p0]]
+            a = deps[p][vn]
+
+            # scan dependencies
+            for (rp,rvs) in a.requires
+                rp0 = pdict[rp]
+                # look for the highest version which satisfies the requirements
+                rv = spp[rp0] - 1
+                while rv > 0
+                    rvn = pvers[rp0][rv]
+                    rvn in rvs && break
+                    rv -= 1
+                end
+                # if we found a version, and the package was uninstalled
+                # or the same version was already selected, we're ok;
+                # otherwise we can't be sure what the optimal configuration is
+                # and we bail out
+                if rv > 0 && (sol[rp0] == spp[rp0] || sol[rp0] == rv)
+                    sol[rp0] = rv
+                else
+                    return (false, Int[])
+                end
+
+                if !(rp in seen)
+                    push!(staged_next, rp)
+                end
+            end
+        end
+        union!(seen, staged_next)
+        staged = staged_next
+    end
+
+    @assert verify_solution(sol, interface)
+
+    return true, sol
+end
+
 # verifies that the solution fulfills all hard constraints
 # (requirements and dependencies)
 function verify_solution(sol::Vector{Int}, interface::Interface)
@@ -130,9 +193,9 @@ function verify_solution(sol::Vector{Int}, interface::Interface)
     # verify requirements
     for (p,vs) in reqs
         p0 = pdict[p]
-        @assert sol[p0] != spp[p0]
+        sol[p0] != spp[p0] || return false
         vn = pvers[p0][sol[p0]]
-        @assert in(vn, vs)
+        vn in vs || return false
     end
 
     # verify dependencies
@@ -144,14 +207,14 @@ function verify_solution(sol::Vector{Int}, interface::Interface)
             if sol[p0] == v0
                 for (rp, rvs) in a.requires
                     p1 = pdict[rp]
-                    @assert sol[p1] != spp[p1]
+                    sol[p1] != spp[p1] || return false
                     vn = pvers[p1][sol[p1]]
-                    @assert in(vn, rvs)
+                    vn in rvs || return false
                 end
             end
         end
     end
-
+    return true
 end
 
 # Push the given solution to a local optimium if needed

--- a/base/pkg/resolve/interface.jl
+++ b/base/pkg/resolve/interface.jl
@@ -130,6 +130,20 @@ function greedysolver(interface::Interface)
     # initialize solution: all uninstalled
     sol = [spp[p0] for p0 = 1:np]
 
+    # set up required packages to their highest allowed versions
+    for (rp,rvs) in reqs
+        rp0 = pdict[rp]
+        # look for the highest version which satisfies the requirements
+        rv = spp[rp0] - 1
+        while rv > 0
+            rvn = pvers[rp0][rv]
+            rvn in rvs && break
+            rv -= 1
+        end
+        @assert rv > 0
+        sol[rp0] = rv
+    end
+
     # we start from required packages and explore the graph
     # following dependencies
     staged = Set{ByteString}(keys(reqs))
@@ -139,10 +153,7 @@ function greedysolver(interface::Interface)
         staged_next = Set{ByteString}()
         for p in staged
             p0 = pdict[p]
-            # set the package state to installed in case it wasn't
-            # (the latter case should only happen for required packages, and
-            # in then we use the maximum available version)
-            sol[p0] = min(sol[p0], spp[p0] - 1)
+            @assert sol[p0] < spp[p0]
             vn = pvers[p0][sol[p0]]
             a = deps[p][vn]
 

--- a/base/pkg/resolve/interface.jl
+++ b/base/pkg/resolve/interface.jl
@@ -69,9 +69,10 @@ type Interface
         for (p,depsp) in deps
             p0 = pdict[p]
             vdict0 = vdict[p0]
+            pvers0 = pvers[p0]
             for vn in keys(depsp)
-                for v0 in 1:length(pvers[p0])
-                    if pvers[p0][v0] == vn
+                for v0 in 1:length(pvers0)
+                    if pvers0[v0] == vn
                         vdict0[vn] = v0
                         break
                     end

--- a/base/pkg/resolve/versionweight.jl
+++ b/base/pkg/resolve/versionweight.jl
@@ -48,7 +48,6 @@ function Base.cmp{T}(a::HierarchicalValue{T}, b::HierarchicalValue{T})
     l0 = min(la, lb)
     l1 = max(la, lb)
     ld = la - lb
-    rv = Array(T, l1)
     @inbounds for i = 1:l0
         c = cmp(av[i], bv[i]); c != 0 && return c
     end

--- a/base/pkg/resolve/versionweight.jl
+++ b/base/pkg/resolve/versionweight.jl
@@ -60,7 +60,7 @@ function Base.cmp{T}(a::HierarchicalValue{T}, b::HierarchicalValue{T})
     return cmp(a.rest, b.rest)
 end
 Base.isless{T}(a::HierarchicalValue{T}, b::HierarchicalValue{T}) = cmp(a,b) < 0
-=={T}(a::HierarchicalValue{T}, b::HierarchicalValue{T}) = a.v == b.v && a.rest == b.rest
+=={T}(a::HierarchicalValue{T}, b::HierarchicalValue{T}) = cmp(a,b) == 0
 
 Base.abs{T}(a::HierarchicalValue{T}) = HierarchicalValue(T[abs(x) for x in a.v], abs(a.rest))
 
@@ -97,8 +97,10 @@ immutable VWPreBuild
     w::HierarchicalValue{VWPreBuildItem}
 end
 
+const _vwprebuild_zero = VWPreBuild(0, HierarchicalValue(VWPreBuildItem))
+
 function VWPreBuild(ispre::Bool, desc::(Union(Int,ASCIIString)...))
-    isempty(desc) && return VWPreBuild(0, HierarchicalValue(VWPreBuildItem))
+    isempty(desc) && return _vwprebuild_zero
     desc == ("",) && return VWPreBuild(ispre ? -1 : 1, HierarchicalValue(VWPreBuildItem[]))
     nonempty = ispre ? -1 : 0
     w = Array(VWPreBuildItem, length(desc))
@@ -109,25 +111,41 @@ function VWPreBuild(ispre::Bool, desc::(Union(Int,ASCIIString)...))
     end
     return VWPreBuild(nonempty, HierarchicalValue(w))
 end
-VWPreBuild() = VWPreBuild(0, HierarchicalValue(VWPreBuildItem))
+VWPreBuild() = _vwprebuild_zero
 
 Base.zero(::Type{VWPreBuild}) = VWPreBuild()
 
-Base.typemin(::Type{VWPreBuild}) = VWPreBuild(typemin(Int), typemin(HierarchicalValue{VWPreBuildItem}))
+const _vwprebuild_min = VWPreBuild(typemin(Int), typemin(HierarchicalValue{VWPreBuildItem}))
+Base.typemin(::Type{VWPreBuild}) = _vwprebuild_min
 
-Base.(:-)(a::VWPreBuild, b::VWPreBuild) = VWPreBuild(a.nonempty-b.nonempty, a.w-b.w)
-Base.(:+)(a::VWPreBuild, b::VWPreBuild) = VWPreBuild(a.nonempty+b.nonempty, a.w+b.w)
+function Base.(:-)(a::VWPreBuild, b::VWPreBuild)
+    b === _vwprebuild_zero && return a
+    a === _vwprebuild_zero && return -b
+    VWPreBuild(a.nonempty-b.nonempty, a.w-b.w)
+end
+function Base.(:+)(a::VWPreBuild, b::VWPreBuild)
+    b === _vwprebuild_zero && return a
+    a === _vwprebuild_zero && return b
+    VWPreBuild(a.nonempty+b.nonempty, a.w+b.w)
+end
 
-Base.(:-)(a::VWPreBuild) = VWPreBuild(-a.nonempty, -a.w)
+function Base.(:-)(a::VWPreBuild)
+    a === _vwprebuild_zero && return a
+    VWPreBuild(-a.nonempty, -a.w)
+end
 
 function Base.cmp(a::VWPreBuild, b::VWPreBuild)
+    a === _vwprebuild_zero && b === _vwprebuild_zero && return 0
     c = cmp(a.nonempty, b.nonempty); c != 0 && return c
     return cmp(a.w, b.w)
 end
 Base.isless(a::VWPreBuild, b::VWPreBuild) = cmp(a,b) < 0
 ==(a::VWPreBuild, b::VWPreBuild) = cmp(a,b) == 0
 
-Base.abs(a::VWPreBuild) = VWPreBuild(abs(a.nonempty), abs(a.w))
+function Base.abs(a::VWPreBuild)
+    a === _vwprebuild_zero && return a
+    VWPreBuild(abs(a.nonempty), abs(a.w))
+end
 
 # The numeric type used to determine how the different
 # versions of a package should be weighed

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -84,18 +84,18 @@ function reqs_from_data(reqs_data)
     end
     reqs
 end
-function sanity_tst(deps_data, expected_result)
+function sanity_tst(deps_data, expected_result; pkgs={})
     deps = deps_from_data(deps_data)
     #println("deps=$deps")
     #println()
-    result = sanity_check(deps)
+    result = sanity_check(deps, Set(ByteString[pkgs...]))
     length(result) == length(expected_result) || return false
     for (p, vn, pp) in result
         in((p, vn), expected_result) || return  false
     end
     return true
 end
-sanity_tst(deps_data) = sanity_tst(deps_data, {})
+sanity_tst(deps_data; kw...) = sanity_tst(deps_data, {}; kw...)
 
 function resolve_tst(deps_data, reqs_data)
     deps = deps_from_data(deps_data)
@@ -117,6 +117,9 @@ deps_data = {
 }
 
 @test sanity_tst(deps_data)
+@test sanity_tst(deps_data, pkgs=["A", "B"])
+@test sanity_tst(deps_data, pkgs=["B"])
+@test sanity_tst(deps_data, pkgs=["A"])
 
 # require just B
 reqs_data = {
@@ -214,6 +217,7 @@ deps_data = {
 }
 
 @test sanity_tst(deps_data, {("A", v"1")})
+@test sanity_tst(deps_data, {("A", v"1")}, pkgs=["B"])
 
 # require B (must not give errors)
 reqs_data = {
@@ -236,6 +240,8 @@ deps_data = {
 }
 
 @test sanity_tst(deps_data, {("A", v"2")})
+@test sanity_tst(deps_data, {("A", v"2")}, pkgs=["B"])
+@test sanity_tst(deps_data, {("A", v"2")}, pkgs=["C"])
 
 # require A, any version (must use the highest non-inconsistent)
 reqs_data = {
@@ -477,3 +483,48 @@ reqs_data = {
 want = resolve_tst(deps_data, reqs_data)
 @test want == ["A"=>v"2", "B"=>v"1.0.1", "C"=>v"1+BLD",
                "D"=>v"2", "E"=>v"1", "F"=>v"2-rc.1"]
+
+## DEPENDENCY SCHEME 11: FIVE PACKAGES, SAME AS SCHEMES 5 + 1, UNCONNECTED
+deps_data = {
+    {"A", v"1", "B", v"2"},
+    {"A", v"1", "C", v"2"},
+    {"A", v"2", "B", v"1", v"2"},
+    {"A", v"2", "C", v"1", v"2"},
+    {"B", v"1", "C", v"2"},
+    {"B", v"2", "C", v"2"},
+    {"C", v"1"},
+    {"C", v"2"},
+    {"D", v"1", "E", v"1"},
+    {"D", v"2", "E", v"2"},
+    {"E", v"1"},
+    {"E", v"2"}
+}
+
+@test sanity_tst(deps_data, {("A", v"2")})
+@test sanity_tst(deps_data, {("A", v"2")}, pkgs=["B"])
+@test sanity_tst(deps_data, pkgs=["D"])
+@test sanity_tst(deps_data, pkgs=["E"])
+@test sanity_tst(deps_data, {("A", v"2")}, pkgs=["B", "D"])
+
+# require A, any version (must use the highest non-inconsistent)
+reqs_data = {
+    {"A"}
+}
+want = resolve_tst(deps_data, reqs_data)
+@test want == ["A"=>v"1", "B"=>v"2", "C"=>v"2"]
+
+# require just D: must bring in E
+reqs_data = {
+    {"D"}
+}
+want = resolve_tst(deps_data, reqs_data)
+@test want == ["D"=>v"2", "E"=>v"2"]
+
+
+# require A and D, must be the merge of the previous two cases
+reqs_data = {
+    {"A"},
+    {"D"}
+}
+want = resolve_tst(deps_data, reqs_data)
+@test want == ["A"=>v"1", "B"=>v"2", "C"=>v"2", "D"=>v"2", "E"=>v"2"]


### PR DESCRIPTION
This is a PR against the release-0.3 branch, to backport the changes which sped up `Pkg.publish`, i.e. #10323, #10396 and #10417.

It's a fairly large and not quite trivial batch of changes, but the sluggishness of the publishing process on 0.3 is such that this speed up may well be considered a bug fix. Also, it's been on 0.4 without problems for a while now.

Everything seems to work as it should on my machine (about 4s to check the whole metadata...), so unless there are CI surprises or objections I'll merge this in a while.
