### PR TITLE
fix base64decode to return array of decoded bytes

### DIFF
--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -436,8 +436,8 @@ Text I/O
 
 .. function:: base64decode(string)
 
-   Decodes the base64-encoded ``string`` and returns the obtained bytes.
-
+   Decodes the base64-encoded ``string`` and returns a ``Vector{UInt8}``
+   of the decoded bytes.
 
 Multimedia I/O
 --------------

--- a/test/base64.jl
+++ b/test/base64.jl
@@ -24,7 +24,7 @@ end
 rm(fname)
 
 # Encode to string and decode
-@test base64decode(base64encode(inputText)) == inputText
+@test utf8(base64decode(base64encode(inputText))) == inputText
 
 # Decode with max line chars = 76 and padding
 ipipe = Base64DecodePipe(IOBuffer(encodedMaxLine76))


### PR DESCRIPTION
`base64decode` (added in #9157) was returning a string, which is incorrect; it should return an array of bytes, since not all base64 streams will represent valid UTF-8 data.

(Also makes a couple of other slight cleanups to the code.)

In retrospect, having base64 functions in base was probably a mistake, and I suspect that these should be moved to Codecs.jl or whatever, but as long as we have them we should make sure they are correct.
