### PR TITLE
Speed up compilation by 20 seconds

### DIFF
--- a/base/precompile.jl
+++ b/base/precompile.jl
@@ -1,5 +1,9 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+ccall(:jl_, Void, (Any,), "Precompiling")
+ccall(:jl_, Void, (Any,), unsafe_load(cglobal(:jl_current_module, Ptr{Void})))
+ccall(:jl_, Void, (Any,), unsafe_load(cglobal(:jl_base_module, Ptr{Void})))
+
 # prime method cache with some things we know we'll need right after startup
 precompile(!=, (Bool, Bool))
 precompile(!=, (SubString{ASCIIString}, ASCIIString))


### PR DESCRIPTION
Do not run precompilation for `sys0`. It is pretty much a waste of time and many of the precompiled function are not useful for bootstrap anyway. There might be other files that can be omitted for `sys0` but this should be the safest one.

On my laptop after this change the compilation time of `sys.so` changed from `2:26` to `2:28` (which is smaller than the fluctuation) and the compilation time of `sys0.so` plus `sys.so` goes down from `5:04` to `4:44`.

For clean compilation, this should save some time. For recompilation, `sys.so` is usually used anyway so it shouldn't be slower.

P.S. The main purpose of this PR is to make me feel less guilty by making the CI slower with #11358 and #11359 .

P.P.S. (Edit) Hopefully no one have mis-read my title as `20x`. No, sadly it's only 20 seconds.
