### PR TITLE
Better suggestion for replacement of [a]

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -17,7 +17,7 @@ if _oldstyle_array_vcat_
     function oldstyle_vcat_warning(n::Int)
         if n == 1
             before = "a"
-            after  = "a;"
+            after  = "collect(a)"
         elseif n == 2
             before = "a,b"
             after  = "a;b"


### PR DESCRIPTION
On Julia master:

```
julia> [1:5]
WARNING: [a] concatenation is deprecated; use [a;] instead
...
```

With this PR:

```
julia> [1:5]
WARNING: [a] concatenation is deprecated; use collect(a) instead
...
```

Ever since this was introduced, I've been silently annoyed by the suggestion to use `[a;]` - the syntax feels like a hack, and for users that aren't familiar with Julia already, it's far from obvious why there's a semi-colon there, and what the difference between `[a]` and `[a;]` is. However, I stayed silent, since I didn't have a better suggestion.

Now I do :)

I suggest we use `collect(a)` instead, for the following reasons:
- it's obvious what it does, much more so than `[a;]`
- it generalizes nicely when you want a different `eltype`, e.g. `collect(Float64, 1:5)`
- from what I understand of the discussion in #8599 most of the opinions raised favored `collect(a)` over `[a:]` - not sure why it didn't happen. The only argument against `collect` was that it's slower (for `UnitRange`s, specifically), but Jeff quickly retorted that with ["No problem, I will make collect faster."](https://github.com/JuliaLang/julia/pull/8599#issuecomment-74193482)
- it just feels more Julian to me :)

I do realize that it doesn't generalize as nicely to higher dimensions, but since part of my problem with using `;` in the 1D case is that it feels like something that belongs with multidimensional arrays, I don't really see that as an argument against this change.
