### PR TITLE
Improve performance of issym and ishermitian for sparse matrices

### DIFF
--- a/base/functors.jl
+++ b/base/functors.jl
@@ -24,6 +24,9 @@ call(::ExpFun, x) = exp(x)
 immutable LogFun <: Func{1} end
 call(::LogFun, x) = log(x)
 
+immutable ConjFun <: Func{1} end
+call(::ConjFun, x) = conj(x)
+
 immutable AndFun <: Func{2} end
 call(::AndFun, x, y) = x & y
 

--- a/base/sparse.jl
+++ b/base/sparse.jl
@@ -2,7 +2,7 @@
 
 module SparseMatrix
 
-using Base: Func, AddFun, OrFun
+using Base: Func, AddFun, OrFun, ConjFun, IdFun
 using Base.Sort: Forward
 using Base.LinAlg: AbstractTriangular
 

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -930,3 +930,41 @@ A = sparse([1.0])
 @test norm(A) == 1.0
 @test_throws ArgumentError norm(sprand(5,5,0.2),3)
 @test_throws ArgumentError norm(sprand(5,5,0.2),2)
+
+# test ishermitian and issym real matrices
+A = speye(5,5)
+@test ishermitian(A) == true
+@test issym(A) == true
+A[1,3] = 1.0
+@test ishermitian(A) == false
+@test issym(A) == false
+A[3,1] = 1.0
+@test ishermitian(A) == true
+@test issym(A) == true
+
+# test ishermitian and issym complex matrices
+A = speye(5,5) + im*speye(5,5)
+@test ishermitian(A) == false
+@test issym(A) == true
+A[1,4] = 1.0 + im
+@test ishermitian(A) == false
+@test issym(A) == false
+
+A = speye(Complex128, 5,5)
+A[3,2] = 1.0 + im
+@test ishermitian(A) == false
+@test issym(A) == false
+A[2,3] = 1.0 - im
+@test ishermitian(A) == true
+@test issym(A) == false
+
+A = sparse(zeros(5,5))
+@test ishermitian(A) == true
+@test issym(A) == true
+
+# Test with explicit zeros
+A = speye(Complex128, 5,5)
+A[3,1] = 2
+A.nzval[2] = 0.0
+@test ishermitian(A) == true
+@test issym(A) == true


### PR DESCRIPTION
This implements what @toivoh mentioned here https://github.com/JuliaLang/LinearAlgebra.jl/issues/217

My testing shows that it is about 3 times faster for hermitian matrices than the current one and for non hermitian it usually terminates right away so it gains a lot there. It also uses less memory.

The logic in this function is of course more complicated than the current one so it is important that it is tested properly. I prodded it with as many different cases I could come up with and it works for all those but maybe there should be more tests in base?

Edit:

Some small benchmarks:

``` julia
sps = [0.0001, 0.001]
ns = [10^3, 10^4, 10^5]
n_iters = 10

for n in ns
    t = 0.0
    for sp in sps
        for i = 1:n_iters
            A = sprand(n, n, sp)
            A = A + A'
            t += @elapsed issym(A)
        end
        println("n: $n, sparsity: $sp, avg time: $(t/n_iters)")
    end
end
```

Results

```
# Master
n: 1000, sparsity: 0.0001, avg time: 1.69745e-5
n: 1000, sparsity: 0.001, avg time: 5.023520000000001e-5
n: 10000, sparsity: 0.0001, avg time: 0.0004951787999999999
n: 10000, sparsity: 0.001, avg time: 0.0035960212999999997
n: 100000, sparsity: 0.0001, avg time: 0.05512627459999999
n: 100000, sparsity: 0.001, avg time: 0.5852790912

# This branch
n: 1000, sparsity: 0.0001, avg time: 3.3673e-6
n: 1000, sparsity: 0.001, avg time: 1.22526e-5
n: 10000, sparsity: 0.0001, avg time: 8.872999999999999e-5
n: 10000, sparsity: 0.001, avg time: 0.0009253101999999999
n: 100000, sparsity: 0.0001, avg time: 0.020136009700000002
n: 100000, sparsity: 0.001, avg time: 0.20595624689999997
```
