### PR TITLE
Added fallback <= method

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -217,7 +217,8 @@ muladd{T<:Number}(x::T, y::T, z::T) = x*y+z
 ($){T<:Integer}(x::T, y::T) = no_op_err("\$", T)
 
 =={T<:Number}(x::T, y::T) = x === y
-<{T<:Real}(x::T, y::T) = no_op_err("<", T)
+ <{T<:Real}(x::T, y::T) = no_op_err("<" , T)
+<={T<:Real}(x::T, y::T) = no_op_err("<=", T)
 
 div{T<:Real}(x::T, y::T) = no_op_err("div", T)
 fld{T<:Real}(x::T, y::T) = no_op_err("fld", T)


### PR DESCRIPTION
Here is the current behavior:

```
julia> immutable X <: Real
       t::Float64
       end

julia> X(1) <= X(2)
ERROR: StackOverflowError:
 in <= at promotion.jl:182 (repeats 79996 times)
```

All the promoting operators in `promotion.jl` have fallbacks that give errors except for `<=`. Was there a reason for this or was it just an oversight?
