### PR TITLE
Fix misplaced variable in Docs.docm (fixes #11348)

### DIFF
--- a/base/docs.jl
+++ b/base/docs.jl
@@ -190,7 +190,7 @@ function docm(meta, def)
     isexpr(def′, :type) && return namedoc(meta, def, namify(def′.args[2]))
     isexpr(def′, :abstract) && return namedoc(meta, def, namify(def′))
     fexpr(def′) && return funcdoc(meta, def)
-    isexpr(def, :macrocall) && (def = namify(def))
+    isexpr(def′, :macrocall) && (def = namify(def′))
     return objdoc(meta, def)
 end
 

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -3,3 +3,8 @@
 @doc "Doc abstract type" ->
 abstract C74685 <: AbstractArray
 @test stringmime("text/plain", Docs.doc(C74685))=="Doc abstract type\n"
+
+macro macro_doctest() end
+@doc "Helps test if macros can be documented with `@doc \"...\" -> @...`." ->
+@macro_doctest
+@test (@doc @macro_doctest) != nothing


### PR DESCRIPTION
The `isexpr(_, :macrocall)` and `namify` should use `def′` instead of `def`, as otherwise it will, for example, try to test\namify `quote @macro end` instead of `@macro` when `@doc "x" -> @macro` is called.
