### PR TITLE
Fix issue #11281.

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -110,10 +110,15 @@ function complete_keyword(s::ByteString)
 end
 
 function complete_path(path::AbstractString, pos)
-    dir, prefix = splitdir(expanduser(path))
-    # if the path is just "~", don't consider the expanded username as a prefix
-    @unix_only if path == "~"
-        dir, prefix = expanduser(path), ""
+    if Base.is_unix(OS_NAME) && ismatch(r"^~(?:/|$)", path)
+        # if the path is just "~", don't consider the expanded username as a prefix
+        if path == "~"
+            dir, prefix = homedir(), ""
+        else
+            dir, prefix = splitdir(homedir() * path[2:end])
+        end
+    else
+        dir, prefix = splitdir(path)
     end
     local files
     try

--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -110,10 +110,11 @@ function complete_keyword(s::ByteString)
 end
 
 function complete_path(path::AbstractString, pos)
-    if ismatch(r"^~(?:/|$)", path)
-        path = homedir() * path[2:end]
+    dir, prefix = splitdir(expanduser(path))
+    # if the path is just "~", don't consider the expanded username as a prefix
+    @unix_only if path == "~"
+        dir, prefix = expanduser(path), ""
     end
-    dir, prefix = splitdir(path)
     local files
     try
         if length(dir) == 0


### PR DESCRIPTION
This does not address the issue raised in #11281 of the regular expression `r"^~(?:/|$)"` not being windows-compatible for directory expansion. However, tilde expansion is not normally supported on windows consoles, and our `expanduser` method is effectively a no-op there. So, I am tempted to mark this regex block as `@unix_only`.
