### PR TITLE
Document differences between @allocated and @time macros

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -199,7 +199,13 @@ macro elapsed(ex)
     end
 end
 
-# measure bytes allocated without any contamination from compilation
+# measure bytes allocated without *most* contamination from compilation
+# Note: This reports a different value from the @time macros, because
+# it wraps the call in a function, however, this means that things
+# like:  @allocated y = foo()
+# will not work correctly, because it will set y in the context of
+# the local function made by the macro, not the current function
+
 macro allocated(ex)
     quote
         let

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -759,6 +759,9 @@ System
 .. function:: @allocated
 
    A macro to evaluate an expression, discarding the resulting value, instead returning the total number of bytes allocated during evaluation of the expression.
+   Note: the expression is evaluated inside a local function, instead of the current context, in order to eliminate the effects of compilation,
+   however, there still may be some allocations due to JIT compilation.  This also makes the results inconsistent with the ``@time`` macros,
+   which do not try to adjust for the effects of compilation.
 
 .. function:: EnvHash() -> EnvHash
 


### PR DESCRIPTION
Previously, `@allocated` used a trick to not show allocations caused by compilation, but the `@time*` macros did not.  This corrects that oversight.  (could be backported to 0.3.x as well)
