### PR TITLE
Speed up scalar BitArray indexing by ~25%

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -417,11 +417,11 @@ end
 (.^)(A::BitArray, B::AbstractArray{Bool}) = (B .<= A)
 (.^)(A::AbstractArray{Bool}, B::AbstractArray{Bool}) = (B .<= A)
 
-function bitcache_pow{T}(Ac::Vector{UInt64}, B::Array{T}, l::Int, ind::Int, C::Vector{Bool})
+function bitcache_pow{T}(A::BitArray, B::Array{T}, l::Int, ind::Int, C::Vector{Bool})
     left = l - ind + 1
     @inbounds begin
         for j = 1:min(bitcache_size, left)
-            C[j] = unsafe_bitgetindex(Ac, ind) ^ B[ind]
+            C[j] = unsafe_bitgetindex(A, ind) ^ B[ind]
             ind += 1
         end
         C[left+1:bitcache_size] = false
@@ -438,13 +438,12 @@ function (.^){T<:Integer}(A::BitArray, B::Array{T})
     F = BitArray(shape)
     l = length(F)
     l == 0 && return F
-    Ac = A.chunks
     Fc = F.chunks
     C = Array(Bool, bitcache_size)
     ind = 1
     cind = 1
     for i = 1:div(l + bitcache_size - 1, bitcache_size)
-        ind = bitcache_pow(Ac, B, l, ind, C)
+        ind = bitcache_pow(A, B, l, ind, C)
         dumpbitcache(Fc, cind, C)
         cind += bitcache_chunks
     end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -235,11 +235,11 @@ using .IteratorsMD
     end
 end
 
-@inline unsafe_getindex(v::BitArray, ind::Int) = Base.unsafe_bitgetindex(v.chunks, ind)
+@inline unsafe_getindex(v::BitArray, ind::Int) = Base.unsafe_bitgetindex(v, ind)
 
 @inline unsafe_setindex!{T}(v::Array{T}, x::T, ind::Int) = (@inbounds v[ind] = x; v)
 @inline unsafe_setindex!{T}(v::AbstractArray{T}, x::T, ind::Int) = (v[ind] = x; v)
-@inline unsafe_setindex!(v::BitArray, x::Bool, ind::Int) = (Base.unsafe_bitsetindex!(v.chunks, x, ind); v)
+@inline unsafe_setindex!(v::BitArray, x::Bool, ind::Int) = (Base.unsafe_bitsetindex!(v, x, ind); v)
 @inline unsafe_setindex!{T}(v::AbstractArray{T}, x::T, ind::Real) = unsafe_setindex!(v, x, to_index(ind))
 
 # Version that uses cartesian indexing for src
@@ -640,7 +640,6 @@ end
     quote
         @nexprs $N d->(I_d = I[d])
         X = BitArray(index_shape($(Isplat...)))
-        Xc = X.chunks
 
         stride_1 = 1
         @nexprs $N d->(stride_{d+1} = stride_d * size(B, d))
@@ -649,7 +648,7 @@ end
         @nloops($N, i, d->I_d,
                 d->(offset_{d-1} = offset_d + (i_d-1)*stride_d), # PRE
                 begin
-                    unsafe_bitsetindex!(Xc, B[offset_0], ind)
+                    unsafe_bitsetindex!(X, B[offset_0], ind)
                     ind += 1
                 end)
         return X


### PR DESCRIPTION
This works around issue #9974 for BitArray indexing.  BitArrays use inlined helper functions, `unsafe_bit(get|set)index`, to do the dirty work of picking bits out of the chunks array.  Previously, these helpers took the array of chunks as an argument, but that array needs a GC root since BitArrays are mutable. This changes those helper functions to work on whole BitArray itself, which enables an optimization to avoid that root (since the chunks array is only accessed as an argument to `arrayref`, which is special-cased).

The ~25% performance gain is for unsafe_getindex; the difference isn't quite as big for getindex (only ~10%) since there's still a GC root for the BoundsError. That can also be avoided, but I'd rather make that change more systematically (as `checkbounds`) with #10525 or a subset thereof.
