### PR TITLE
RFC: Fix #11356

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -138,7 +138,26 @@ for f in (:round, :ceil, :floor, :trunc)
         function ($f)(x, digits::Integer, base::Integer=10)
             x = float(x)
             og = convert(eltype(x),base)^digits
-            ($f)(x * og) / og
+            r = ($f)(x * og) / og
+
+            if !isfinite(r)
+                if digits > 0
+                    return x
+                elseif x > 0
+                    if ceil == $f
+                        return convert(eltype(x), Inf)
+                    end
+                    return zero(x)
+                elseif x < 0
+                    if floor == $f
+                        return -convert(eltype(x), Inf)
+                    end
+                    return -zero(x)
+                else
+                    return x
+                end
+            end
+            return r
         end
     end
 end

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1833,6 +1833,29 @@ approx_eq(a, b) = approx_eq(a, b, 1e-6)
 @test approx_eq(ceil(-123.456,1), -123.4)
 @test approx_eq(floor(123.456,1), 123.4)
 @test approx_eq(floor(-123.456,1), -123.5)
+# rounding with too much (or too few) precision
+for x in (12345.6789, 0, -12345.6789)
+    y = float(x)
+    @test y == trunc(x, 1000)
+    @test y == round(x, 1000)
+    @test y == floor(x, 1000)
+    @test y == ceil(x, 1000)
+end
+x = 12345.6789
+@test 0.0 == trunc(x, -1000)
+@test 0.0 == round(x, -1000)
+@test 0.0 == floor(x, -1000)
+@test Inf == ceil(x, -1000)
+x = -12345.6789
+@test -0.0 == trunc(x, -1000)
+@test -0.0 == round(x, -1000)
+@test -Inf == floor(x, -1000)
+@test -0.0 == ceil(x, -1000)
+x = 0.0
+@test 0.0 == trunc(x, -1000)
+@test 0.0 == round(x, -1000)
+@test 0.0 == floor(x, -1000)
+@test 0.0 == ceil(x, -1000)
 # rounding in other bases
 @test approx_eq(round(pi,2,2), 3.25)
 @test approx_eq(round(pi,3,2), 3.125)


### PR DESCRIPTION
Hello Julia!

I just started learning the language and I figured I should try to contribute by tackling an "up for grabs" issue.

I'm pretty sure my code is not up to the Julia standards, and I don't know if I implemented the expected behavior so I'd love if you could give me some feedback.

The behavior I chose is coherent with what we see with large precision:
- Too much precision always return the original number
- Too few precision returns zero (with the sign of the orignal number) but for 2 edge cases with `ceil` and `floor`

Thanks in advance, cheers!
