### PR TITLE
Disable 'dist' and 'source-dist' make targets

### DIFF
--- a/DISTRIBUTING.md
+++ b/DISTRIBUTING.md
@@ -29,10 +29,10 @@ pregenerate the `base/version_git.jl` file with:
 Julia has lots of build dependencies where we use patched versions that has not
 yet been included by the popular package managers. These dependencies will usually
 be automatically downloaded when you build, but if you want to be able to build
-Julia on a computer without internet access you should create a source-dist archive
-with the special make target
+Julia on a computer without internet access you should create a full-source-dist
+archive with the special make target
 
-    make source-dist
+    make full-source-dist
 
 that creates a julia-version-commit.tar.gz archive with all required dependencies.
 
@@ -66,9 +66,9 @@ The full list of CPU targets supported by LLVM can be obtained by running
 Linux
 -----
 
-On Linux, `make dist` creates a tarball that contains a fully functional Julia
-installation. If you wish to create a distribution package such as a
-`.deb`, or `.rpm`, some extra effort is needed. See the
+On Linux, `make binary-dist` creates a tarball that contains a fully
+functional Julia installation. If you wish to create a distribution
+package such as a `.deb`, or `.rpm`, some extra effort is needed. See the
 [julia-debian](http://github.com/staticfloat/julia-debian) repository
 for an example of what metadata is needed for creating `.deb` packages
 for Debian and Ubuntu-based systems. See the
@@ -118,7 +118,7 @@ is to cross-compile from a Linux distribution such as Ubuntu. In-depth
 compilation instructions [are
 available](https://github.com/JuliaLang/julia/blob/master/README.windows.md).
 However the important steps for redistribution are to ensure to `make
-win-extras` in between `make` and `make dist`.  After that process is
+win-extras` in between `make` and `make binary-dist`.  After that process is
 completed, the `.zip` file created in the head Julia directory will
 hold a completely self-contained Julia.
 

--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,10 @@ endif
 distclean dist-clean:
 	rm -fr julia-*.tar.gz julia*.exe julia-*.7z julia-$(JULIA_COMMIT)
 
-binary-dist dist: distclean
+dist:
+	@echo \'dist\' target is deprecated: use \'binary-dist\' instead.
+
+binary-dist: distclean
 ifeq ($(USE_SYSTEM_BLAS),0)
 ifneq ($(OPENBLAS_DYNAMIC_ARCH),1)
 	@echo OpenBLAS must be rebuilt with OPENBLAS_DYNAMIC_ARCH=1 to use binary-dist target
@@ -451,8 +454,11 @@ light-source-dist: light-source-dist.tmp
 	sed -e "s_.*_$$DIRNAME/&_" light-source-dist.tmp > light-source-dist.tmp1; \
 	cd ../ && tar -cz -T $$DIRNAME/light-source-dist.tmp1 --no-recursion -f $$DIRNAME/julia-$(JULIA_VERSION)_$(JULIA_COMMIT).tar.gz
 
+source-dist:
+	@echo \'source-dist\' target is deprecated: use \'full-source-dist\' instead.
+
 # Make tarball with Julia code plus all dependencies
-full-source-dist source-dist: light-source-dist.tmp
+full-source-dist: light-source-dist.tmp
 	# Get all the dependencies downloaded
 	@$(MAKE) -C deps getall NO_GIT=1
 

--- a/README.windows.md
+++ b/README.windows.md
@@ -279,8 +279,8 @@ Finally, the build and install process for Julia:
 1. `git clone https://github.com/JuliaLang/julia.git julia-win32`
 2. `echo override XC_HOST = i686-w64-mingw32 >> Make.user`
 3. `make`
-4. `make win-extras` (Necessary before running `make dist`p)
-5. `make dist`
+4. `make win-extras` (Necessary before running `make binary-dist`p)
+5. `make binary-dist`
 6. move the julia-* directory / zip file to the target machine
 
 If you are building for 64-bit windows, the steps are essentially the same. Just replace i686 in XC_HOST with x86_64. (note: on Mac, wine only runs in 32-bit mode)


### PR DESCRIPTION
Yet another step towards making 'dist' equivalent to 'light-source-dist', as in most projects.

Cf. https://github.com/JuliaLang/julia/pull/10253. I could have first added the warning and still called the real target, but I don't think many people would notice it, would they? The fix is quite easy to apply.

Next step will be to change the meaning of `dist`, when everybody will have switched (probably before 0.4?).

CC: @tkelman @staticfloat 
