### PR TITLE
RFC: Fixes #11413

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -484,13 +484,8 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         if is(head, :tuple) && nargs == 1; print(io, ','); end
         head !== :row && print(io, cl)
 
-    # function declaration (like :call but always printed with parens)
-    # (:calldecl is a "fake" expr node created when we find a :function expr)
-    elseif head == :calldecl && nargs >= 1
-        show_call(io, head, args[1], args[2:end], indent)
-
     # function call
-    elseif haskey(expr_calls, head) && nargs >= 1  # :call/:ref/:curly
+    elseif head == :call && nargs >= 1
         func = args[1]
         func_prec = operator_precedence(func)
         func_args = args[2:end]
@@ -535,10 +530,14 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
                 show_enclosed_list(io, op, func_args, ",", cl, indent)
             end
 
-        # normal function (i.e. "f(x,y)" or "A[x,y]")
+        # normal function (i.e. "f(x,y)")
         else
             show_call(io, head, func, func_args, indent)
         end
+
+    # other call-like expressions ("A[1,2]", "T{X,Y}")
+    elseif haskey(expr_calls, head) && nargs >= 1  # :ref/:curly/:calldecl
+        show_call(io, head, ex.args[1], ex.args[2:end], indent)
 
     # comprehensions
     elseif (head === :typed_comprehension || head === :typed_dict_comprehension) && length(args) == 3

--- a/test/show.jl
+++ b/test/show.jl
@@ -233,3 +233,8 @@ end
 
 # issue #9865
 @test ismatch(r"^Set\(\[.+….+\]\)$", replstr(Set(1:100)))
+
+# issue 11413
+@test string(:(*{1,2})) == "*{1,2}"
+@test string(:(*{1,x})) == "*{1,x}"
+@test string(:(-{x}))   == "-{x}"


### PR DESCRIPTION
Moves `:call` exclusive patterns to its own `if` clause.

WIP because I don't know if

``` julia
if in(ex.args[1], (:box, TopNode(:box), :throw))
    show_expr_type_emphasize::Bool = show_type = false
end
```

applies to `:ref` and `:curly` expressions or not, so I don't know if it can be safely removed.
(I assume not, but I want to be sure)
