### PR TITLE
Remove redundant `require`

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -38,7 +38,6 @@ end
 package_list = Dict{ByteString,Float64}()
 # to synchronize multiple tasks trying to require something
 package_locks = Dict{ByteString,Any}()
-require(fname::AbstractString) = require(bytestring(fname))
 require(f::AbstractString, fs::AbstractString...) = (require(f); for x in fs require(x); end)
 
 # only broadcast top-level (not nested) requires and reloads


### PR DESCRIPTION
Clean up for https://github.com/JuliaLang/julia/commit/6afe305e245cdd685fea6e0263a94156a2c15368

See ~5 lines below the deleted line.

I'm glad the method was ordered this way (or maybe it's bad because we'd notice this much earlier?).
