### PR TITLE
add _IO_stdin_used to julia.expmap

### DIFF
--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -35,6 +35,7 @@
     gc_queue_root;
     gc_wb_slow;
     jlbacktrace;
+    _IO_stdin_used;
 
     /* freebsd */
     environ;


### PR DESCRIPTION
fixes #10982 
cc @garrison
