### PR TITLE
WIP: put a bow on package precompilation and merge it

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -373,7 +373,7 @@ RANLIB := $(CROSS_COMPILE)ranlib
 
 
 # if not absolute, then relative to the directory of the julia executable
-JCPPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.ji\""
+JCPPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/Base.ji\""
 
 # On Windows, we want shared library files to end up in $(build_bindir), instead of $(build_libdir)
 ifeq ($(OS),WINNT)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ default: $(JULIA_BUILD_MODE) # contains either "debug" or "release"
 all: debug release
 
 # sort is used to remove potential duplicates
-DIRS = $(sort $(build_bindir) $(build_libdir) $(build_private_libdir) $(build_libexecdir) $(build_sysconfdir)/julia $(build_datarootdir)/julia $(build_man1dir))
+DIRS = $(sort $(build_bindir) $(build_libdir) $(build_private_libdir) $(build_private_libdir)/0 $(build_libexecdir) $(build_sysconfdir)/julia $(build_datarootdir)/julia $(build_man1dir))
 
 $(foreach dir,$(DIRS),$(eval $(call dir_target,$(dir))))
 $(foreach link,base test,$(eval $(call symlink_target,$(link),$(build_datarootdir)/julia)))
@@ -61,7 +61,7 @@ julia-ui-release julia-ui-debug : julia-ui-% : julia-src-%
 	@$(MAKE) $(QUIET_MAKE) -C ui julia-$*
 
 julia-sysimg : julia-base julia-ui-$(JULIA_BUILD_MODE)
-	@$(MAKE) $(QUIET_MAKE) $(build_private_libdir)/sys.$(SHLIB_EXT) JULIA_BUILD_MODE=$(JULIA_BUILD_MODE)
+	@$(MAKE) $(QUIET_MAKE) $(build_private_libdir)/Base.$(SHLIB_EXT) JULIA_BUILD_MODE=$(JULIA_BUILD_MODE)
 
 julia-debug julia-release : julia-% : julia-ui-% julia-symlink julia-sysimg julia-libccalltest
 
@@ -131,12 +131,12 @@ $(build_sysconfdir)/julia/juliarc.jl: contrib/windows/juliarc.jl
 endif
 
 # use sys.ji if it exists, otherwise run two stages
-$(build_private_libdir)/sys%ji: $(build_private_libdir)/sys%o
+$(build_private_libdir)/%.ji: $(build_private_libdir)/%.o
 
-.SECONDARY: $(build_private_libdir)/sys.o
-.SECONDARY: $(build_private_libdir)/sys0.o
+.SECONDARY: $(build_private_libdir)/Base.o
+.SECONDARY: $(build_private_libdir)/0/Base.o
 
-$(build_private_libdir)/sys%$(SHLIB_EXT): $(build_private_libdir)/sys%o
+$(build_private_libdir)/%.$(SHLIB_EXT): $(build_private_libdir)/%.o
 ifneq ($(USEMSVC), 1)
 	@$(call PRINT_LINK, $(CXX) -shared -fPIC -L$(build_private_libdir) -L$(build_libdir) -L$(build_shlibdir) -o $@ $< \
 		$$([ $(OS) = Darwin ] && echo '' -Wl,-undefined,dynamic_lookup || echo '' -Wl,--unresolved-symbols,ignore-all ) \
@@ -146,17 +146,16 @@ else
 	@true
 endif
 
-$(build_private_libdir)/sys0.o: | $(build_private_libdir)
+$(build_private_libdir)/0/Base.o: | $(build_private_libdir)/0
 	@$(call PRINT_JULIA, cd base && \
-	$(call spawn,$(JULIA_EXECUTABLE)) -C $(JULIA_CPU_TARGET) --build $(call cygpath_w,$(build_private_libdir)/sys0) sysimg.jl)
+	$(call spawn,$(JULIA_EXECUTABLE)) -C $(JULIA_CPU_TARGET) --build $(call cygpath_w,$(build_private_libdir)/0) sysimg.jl)
 
 BASE_SRCS := $(wildcard base/*.jl base/*/*.jl base/*/*/*.jl)
 
-COMMA:=,
-$(build_private_libdir)/sys.o: VERSION $(BASE_SRCS) $(build_docdir)/helpdb.jl $(build_private_libdir)/sys0.$(SHLIB_EXT)
+$(build_private_libdir)/Base.o: VERSION $(BASE_SRCS) $(build_docdir)/helpdb.jl $(build_private_libdir)/0/Base.$(SHLIB_EXT)
 	@$(call PRINT_JULIA, cd base && \
-	$(call spawn,$(JULIA_EXECUTABLE)) -C $(JULIA_CPU_TARGET) --build $(call cygpath_w,$(build_private_libdir)/sys) \
-		-J$(call cygpath_w,$(build_private_libdir))/$$([ -e $(build_private_libdir)/sys.ji ] && echo sys.ji || echo sys0.ji) -f sysimg.jl \
+	$(call spawn,$(JULIA_EXECUTABLE)) -C $(JULIA_CPU_TARGET) --build $(call cygpath_w,$(build_private_libdir)) \
+		-J$(call cygpath_w,$(build_private_libdir))/$$([ -e $(build_private_libdir)/Base.ji ] && echo Base.ji || echo 0/Base.ji) -f sysimg.jl \
 		|| { echo '*** This error is usually fixed by running `make clean`. If the error persists$(COMMA) try `make cleanall`. ***' && false; } )
 
 $(build_bindir)/stringreplace: contrib/stringreplace.c | $(build_bindir)
@@ -282,8 +281,8 @@ endif
 endif
 	$(INSTALL_F) src/julia.h src/julia_version.h src/options.h src/support/*.h $(DESTDIR)$(includedir)/julia
 	# Copy system image
-	$(INSTALL_F) $(build_private_libdir)/sys.ji $(DESTDIR)$(private_libdir)
-	$(INSTALL_M) $(build_private_libdir)/sys.$(SHLIB_EXT) $(DESTDIR)$(private_libdir)
+	$(INSTALL_F) $(build_private_libdir)/Base.ji $(DESTDIR)$(private_libdir)
+	$(INSTALL_M) $(build_private_libdir)/Base.$(SHLIB_EXT) $(DESTDIR)$(private_libdir)
 	# Copy in system image build script
 	$(INSTALL_M) contrib/build_sysimg.jl $(DESTDIR)$(datarootdir)/julia/
 	# Copy in standalone executable build script
@@ -329,7 +328,7 @@ endif
 
 	# Overwrite JL_SYSTEM_IMAGE_PATH in julia library
 	for julia in $(DESTDIR)$(private_libdir)/libjulia*.$(SHLIB_EXT) ; do \
-		$(call spawn,$(build_bindir)/stringreplace $$(strings -t x - $$julia | grep "sys.ji$$" | awk '{print $$1;}' ) "$(private_libdir_rel)/sys.ji" 256 $(call cygpath_w,$$julia)); \
+		$(call spawn,$(build_bindir)/stringreplace $$(strings -t x - $$julia | grep "Base.ji$$" | awk '{print $$1;}' ) "$(private_libdir_rel)/Base.ji" 256 $(call cygpath_w,$$julia)); \
 	done
 endif
 
@@ -367,15 +366,15 @@ ifeq ($(OS), Darwin)
 	-cat ./contrib/mac/juliarc.jl >> $(DESTDIR)$(prefix)/etc/julia/juliarc.jl
 endif
 
-	# purge sys.{dll,so,dylib} as that file is not relocatable across processor architectures
+	# purge Base.{dll,so,dylib} as that file is not relocatable across processor architectures
 ifeq ($(JULIA_CPU_TARGET), native)
-	-rm -f $(DESTDIR)$(private_libdir)/sys.$(SHLIB_EXT)
+	-rm -f $(DESTDIR)$(private_libdir)/Base.$(SHLIB_EXT)
 endif
 
 ifeq ($(OS), WINNT)
 ifeq ($(ARCH),x86_64)
 	# If we are running on WIN64, also delete sys.dll until we switch to llvm3.5+
-	-rm -f $(DESTDIR)$(private_libdir)/sys.$(SHLIB_EXT)
+	-rm -f $(DESTDIR)$(private_libdir)/Base.$(SHLIB_EXT)
 endif
 
 	[ ! -d dist-extras ] || ( cd dist-extras && \

--- a/base/base.jl
+++ b/base/base.jl
@@ -34,6 +34,7 @@ call(T::Type{Task}, f::ANY) = Core.call(T, f)
 call(T::Type{GenSym}, n::Int) = Core.call(T, n)
 call(T::Type{WeakRef}) = Core.call(T)
 call(T::Type{WeakRef}, v::ANY) = Core.call(T, v)
+call(T::Type{Box}, contents::ANY) = Core.call(T, contents)
 
 # The specialization for 1 arg is important
 # when running with --inline=no, see #11158

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -71,8 +71,8 @@
 #    module::Module
 #end
 
-#type Box{T}
-#    contents::T
+#type Box
+#    contents::Any
 #end
 
 #abstract Ref{T}
@@ -284,6 +284,7 @@ _new(:TopNode, :Symbol)
 _new(:NewvarNode, :Symbol)
 _new(:QuoteNode, :ANY)
 _new(:GenSym, :Int)
+_new(:Box, :ANY)
 
 Module(name::Symbol=:anonymous, std_imports::Bool=true) = ccall(:jl_f_new_module, Any, (Any, Bool), name, std_imports)::Module
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -333,7 +333,7 @@ function init_load_path()
     end
     push!(LOAD_PATH,abspath(JULIA_HOME,"..","local","share","julia","site",vers))
     push!(LOAD_PATH,abspath(JULIA_HOME,"..","share","julia","site",vers))
-    push!(LOAD_CACHE_PATH,abspath(homedir(),".julia",".libs"))
+    push!(LOAD_CACHE_PATH,abspath(homedir(),".julia","libs",vers))
     push!(LOAD_CACHE_PATH,abspath(JULIA_HOME,"..","usr","lib","julia")) #TODO: fixme
 end
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -325,6 +325,7 @@ is_interactive = false
 isinteractive() = (is_interactive::Bool)
 
 const LOAD_PATH = ByteString[]
+const LOAD_CACHE_PATH = ByteString[]
 function init_load_path()
     vers = "v$(VERSION.major).$(VERSION.minor)"
     if haskey(ENV,"JULIA_LOAD_PATH")
@@ -332,6 +333,8 @@ function init_load_path()
     end
     push!(LOAD_PATH,abspath(JULIA_HOME,"..","local","share","julia","site",vers))
     push!(LOAD_PATH,abspath(JULIA_HOME,"..","share","julia","site",vers))
+    push!(LOAD_CACHE_PATH,abspath(homedir(),".julia",".libs"))
+    push!(LOAD_CACHE_PATH,abspath(JULIA_HOME,"..","usr","lib","julia")) #TODO: fixme
 end
 
 function load_juliarc()

--- a/base/file.jl
+++ b/base/file.jl
@@ -36,7 +36,13 @@ end
 end
 cd(f::Function) = cd(f, homedir())
 
-function mkdir(path::AbstractString, mode::Unsigned=0o777)
+function mkdir(path::AbstractString, mode::Unsigned=0o777; recursive::Bool=false)
+    if recursive
+        pdir = splitdir(path)[1]
+        if !isdir(pdir)
+            mkdir(pdir, mode; recursive=true)
+        end
+    end
     @unix_only ret = ccall(:mkdir, Int32, (Cstring,UInt32), path, mode)
     @windows_only ret = ccall(:_wmkdir, Int32, (Cwstring,), path)
     systemerror(:mkdir, ret != 0)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -44,6 +44,35 @@ require(f::AbstractString, fs::AbstractString...) = (require(f); for x in fs req
 # only broadcast top-level (not nested) requires and reloads
 toplevel_load = true
 
+function _require_from_serialized(content)
+    m = ccall(:jl_restore_new_module_from_buf, UInt, (Ptr{Uint8},Int), content, sizeof(content))
+    #package_list[path] = time()
+    return m
+end
+
+function require(sname::Symbol)
+    name = string(sname)
+    for prefix in LOAD_CACHE_PATH
+        path = joinpath(prefix, name*".ji")
+        if isfile(path)
+            if nprocs() == 1
+                if ccall(:jl_restore_new_module, UInt, (Ptr{Uint8},), path) != 0
+                    #package_list[path] = time()
+                    return
+                end
+            else
+                content = open(readbytes, path)
+                if _require_from_serialized(content) != 0
+                    refs = Any[ @spawnat p _require_from_serialized(content) for p in filter(x->x!=1, procs()) ]
+                    for r in refs; wait(r); end
+                    return
+                end
+            end
+        end
+    end
+    require(name)
+end
+
 function require(name::AbstractString)
     path = find_in_node1_path(name)
     path == nothing && throw(ArgumentError("$name not found in path"))

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -50,27 +50,33 @@ function _require_from_serialized(content)
     return m
 end
 
-function require(sname::Symbol)
-    name = string(sname)
+function _require_from_cache(name::AbstractString)
     for prefix in LOAD_CACHE_PATH
         path = joinpath(prefix, name*".ji")
         if isfile(path)
             if nprocs() == 1
                 if ccall(:jl_restore_new_module, UInt, (Ptr{Uint8},), path) != 0
                     #package_list[path] = time()
-                    return
+                    return true
                 end
             else
                 content = open(readbytes, path)
                 if _require_from_serialized(content) != 0
                     refs = Any[ @spawnat p _require_from_serialized(content) for p in filter(x->x!=1, procs()) ]
                     for r in refs; wait(r); end
-                    return
+                    return true
                 end
             end
         end
     end
-    require(name)
+    return false
+end
+
+function require(sname::Symbol)
+    name = string(sname)
+    if !_require_from_cache(name)
+        require(name)
+    end
 end
 
 function require(name::AbstractString)
@@ -189,7 +195,7 @@ function reload_path(path::AbstractString)
         had || delete!(package_list, path)
         rethrow(e)
     finally
-        if prev != nothing
+        if prev !== nothing
             tls[:SOURCE_PATH] = prev
         end
     end
@@ -210,3 +216,48 @@ function evalfile(path::AbstractString, args::Vector{UTF8String}=UTF8String[])
                      :(include($path))))
 end
 evalfile(path::AbstractString, args::Vector) = evalfile(path, UTF8String[args...])
+
+create_expr_cache(m::Box) = create_expr_cache(m.contents::Expr)
+function create_expr_cache(m::Expr)
+    assert(m.head === :module)
+    typeassert(m.args[2], Symbol)
+    cachepath = LOAD_CACHE_PATH[1]
+    if !isdir(cachepath)
+        mkdir(cachepath)
+    end
+    code_object = """
+        while !eof(STDIN)
+            eval(Main, deserialize(STDIN))
+        end
+        """
+    io, pobj = open(detach(setenv(`$(julia_cmd()) --build $cachepath --startup-file=no --history-file=no -E $code_object`,["JULIA_HOME=$JULIA_HOME","HOME=$(homedir())"])), "w")
+    serialize(io, quote
+        empty!(Base.LOAD_PATH)
+        append!(Base.LOAD_PATH, $LOAD_PATH)
+        empty!(Base.LOAD_CACHE_PATH)
+        append!(Base.LOAD_CACHE_PATH, $LOAD_CACHE_PATH)
+        empty!(Base.DL_LOAD_PATH)
+        append!(Base.DL_LOAD_PATH, $DL_LOAD_PATH)
+    end)
+    source = source_path(nothing)
+    if source !== nothing
+        serialize(io, quote
+            task_local_storage()[:SOURCE_PATH] = $(source)
+        end)
+    end
+    serialize(io, m)
+    if source !== nothing
+        serialize(io, quote
+            delete!(task_local_storage(), :SOURCE_PATH)
+        end)
+    end
+    close(io)
+    wait(pobj)
+    if !_require_from_cache(string(m.args[2]))
+        error("Warning: @cacheable module failed to define a module")
+    end
+end
+
+macro cacheable(m)
+    :(create_expr_cache($(Box(m))))
+end

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -21,10 +21,12 @@
 
    Returns the files and directories in the directory `dir` (or the current working directory if not given).
 
-.. function:: mkdir(path, [mode])
+.. function:: mkdir(path, [mode]; recursive=false))
 
    Make a new directory with name ``path`` and permissions ``mode``.
    ``mode`` defaults to 0o777, modified by the current file creation mask.
+   If ``recursive==true``, any missing parent directories will also be
+   created.
 
 .. function:: mkpath(path, [mode])
 

--- a/src/Windows.mk
+++ b/src/Windows.mk
@@ -47,7 +47,7 @@ LIB = $(LIB);C:\Program Files\llvm\lib\Release
 !endif
 
 CFLAGS = $(CFLAGS) -DCOPY_STACKS -D_CRT_SECURE_NO_WARNINGS
-CFLAGS = $(CFLAGS) -DJL_SYSTEM_IMAGE_PATH=\"../lib/julia/sys.ji\" -DLIBRARY_EXPORTS
+CFLAGS = $(CFLAGS) -DJL_SYSTEM_IMAGE_PATH=\"../lib/julia/Base.ji\" -DLIBRARY_EXPORTS
 
 LIBWINDOWS = \
 	kernel32.lib \

--- a/src/dump.c
+++ b/src/dump.c
@@ -1417,17 +1417,31 @@ int jl_deserialize_verify_mod_list(ios_t *s)
         ios_read(s, name, len);
         name[len] = '\0';
         uint64_t uuid = read_uint64(s);
-        jl_module_t *m = (jl_module_t*)jl_get_global(jl_main_module, jl_symbol(name));
+        jl_sym_t *sym = jl_symbol(name);
+        jl_module_t *m = (jl_module_t*)jl_get_global(jl_main_module, sym);
         if (!m) {
-            jl_printf(JL_STDERR, "error: Module %s must be loaded first\n", name);
+            static jl_value_t *require_func = NULL;
+            if (!require_func)
+                require_func = jl_get_global(jl_base_module, jl_symbol("require"));
+            JL_TRY {
+                jl_apply((jl_function_t*)require_func, (jl_value_t**)&sym, 1);
+            }
+            JL_CATCH {
+                ios_close(s);
+                jl_rethrow();
+            }
+            m = (jl_module_t*)jl_get_global(jl_main_module, sym);
+        }
+        if (!m) {
+            jl_printf(JL_STDERR, "error: requiring \"%s\" did not define a corresponding module\n", name);
             return 0;
         }
         if (!jl_is_module(m)) {
             ios_close(s);
-            jl_errorf("typeassert: expected %s::Module", name);
+            jl_errorf("invalid module path (%s does not name a module)", name);
         }
         if (m->uuid != uuid) {
-            jl_printf(JL_STDERR, "error: Module %s uuid did not match cache file\n", name);
+            jl_printf(JL_STDERR, "warning: Module %s uuid did not match cache file\n", name);
             return 0;
         }
     }
@@ -1743,20 +1757,14 @@ int jl_save_new_module(const char *fname, jl_module_t *mod)
 jl_function_t *jl_method_cache_insert(jl_methtable_t *mt, jl_tupletype_t *type,
                                       jl_function_t *method);
 
-DLLEXPORT
-jl_module_t *jl_restore_new_module(const char *fname)
+static jl_module_t *_jl_restore_new_module(ios_t *f)
 {
-    ios_t f;
-    if (ios_file(&f, fname, 1, 0, 0, 0) == NULL) {
-        jl_printf(JL_STDERR, "Cache file \"%s\" not found\n", fname);
+    if (ios_eof(f)) {
+        ios_close(f);
         return NULL;
     }
-    if (ios_eof(&f)) {
-        ios_close(&f);
-        return NULL;
-    }
-    if (!jl_deserialize_verify_mod_list(&f)) {
-        ios_close(&f);
+    if (!jl_deserialize_verify_mod_list(f)) {
+        ios_close(f);
         return NULL;
     }
     arraylist_new(&backref_list, 4000);
@@ -1768,14 +1776,14 @@ jl_module_t *jl_restore_new_module(const char *fname)
     jl_gc_disable();
     DUMP_MODES last_mode = mode;
     mode = MODE_MODULE;
-    jl_module_t *parent = (jl_module_t*)jl_deserialize_value(&f, NULL);
-    jl_sym_t *name = (jl_sym_t*)jl_deserialize_value(&f, NULL);
+    jl_module_t *parent = (jl_module_t*)jl_deserialize_value(f, NULL);
+    jl_sym_t *name = (jl_sym_t*)jl_deserialize_value(f, NULL);
     jl_binding_t *b = jl_get_binding_wr(parent, name);
     jl_declare_constant(b);
     if (b->value != NULL) {
         jl_printf(JL_STDERR, "Warning: replacing module %s\n", name->name);
     }
-    b->value = jl_deserialize_value(&f, &b->value);
+    b->value = jl_deserialize_value(f, &b->value);
 
     size_t i = 0;
     while (i < flagref_list.len) {
@@ -1838,9 +1846,9 @@ jl_module_t *jl_restore_new_module(const char *fname)
     }
 
     mode = MODE_MODULE_LAMBDAS;
-    jl_deserialize_lambdas_from_mod(&f);
+    jl_deserialize_lambdas_from_mod(f);
 
-    jl_module_init_order = (jl_array_t*)jl_deserialize_value(&f, NULL);
+    jl_module_init_order = (jl_array_t*)jl_deserialize_value(f, NULL);
 
     for (i = 0; i < methtable_list.len; i++) {
         jl_methtable_t *mt = (jl_methtable_t*)methtable_list.items[i];
@@ -1877,11 +1885,30 @@ jl_module_t *jl_restore_new_module(const char *fname)
     arraylist_free(&flagref_list);
     arraylist_free(&methtable_list);
     arraylist_free(&backref_list);
-    ios_close(&f);
+    ios_close(f);
 
     jl_init_restored_modules();
 
     return (jl_module_t*)b->value;
+}
+
+DLLEXPORT
+jl_module_t *jl_restore_new_module_from_buf(const char *buf, size_t sz)
+{
+    ios_t f;
+    ios_static_buffer(&f, (char*)buf, sz);
+    return _jl_restore_new_module(&f);
+}
+
+DLLEXPORT
+jl_module_t *jl_restore_new_module(const char *fname)
+{
+    ios_t f;
+    if (ios_file(&f, fname, 1, 0, 0, 0) == NULL) {
+        jl_printf(JL_STDERR, "Cache file \"%s\" not found\n", fname);
+        return NULL;
+    }
+    return _jl_restore_new_module(&f);
 }
 
 // --- init ---

--- a/src/init.c
+++ b/src/init.c
@@ -942,6 +942,10 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
     }
     if (jl_options.build_path)
         jl_options.build_path = abspath(jl_options.build_path);
+    if (jl_options.machinefile)
+        jl_options.machinefile = abspath(jl_options.machinefile);
+    if (jl_options.load)
+        jl_options.load = abspath(jl_options.load);
 }
 
 void _julia_init(JL_IMAGE_SEARCH rel)

--- a/src/init.c
+++ b/src/init.c
@@ -39,7 +39,6 @@
 
 #include "julia.h"
 #include "julia_internal.h"
-#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -1206,43 +1205,6 @@ DLLEXPORT void jl_install_sigint_handler()
 
 extern int asprintf(char **str, const char *fmt, ...);
 extern void *__stack_chk_guard;
-
-void jl_compile_all(void);
-
-DLLEXPORT void julia_save()
-{
-    const char *build_path = jl_options.build_path;
-    if (build_path) {
-        if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_ALL)
-            jl_compile_all();
-        char *build_ji;
-        if (asprintf(&build_ji, "%s.ji",build_path) > 0) {
-            jl_save_system_image(build_ji);
-            free(build_ji);
-            if (jl_options.dumpbitcode == JL_OPTIONS_DUMPBITCODE_ON) {
-                char *build_bc;
-                if (asprintf(&build_bc, "%s.bc",build_path) > 0) {
-                    jl_dump_bitcode(build_bc);
-                    free(build_bc);
-                }
-                else {
-                    jl_printf(JL_STDERR,"\nWARNING: failed to create string for .bc build path\n");
-                }
-            }
-            char *build_o;
-            if (asprintf(&build_o, "%s.o",build_path) > 0) {
-                jl_dump_objfile(build_o,0);
-                free(build_o);
-            }
-            else {
-                jl_printf(JL_STDERR,"\nFATAL: failed to create string for .o build path\n");
-            }
-        }
-        else {
-            jl_printf(JL_STDERR,"\nFATAL: failed to create string for .ji build path\n");
-        }
-    }
-}
 
 jl_function_t *jl_typeinf_func=NULL;
 

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -29,7 +29,7 @@ int jl_is_initialized(void) { return jl_main_module!=NULL; }
 
 // First argument is the usr/lib directory where libjulia is, or NULL to guess.
 // if that doesn't work, try the full path to the "lib" directory that
-// contains lib/julia/sys.ji
+// contains lib/julia/Base.ji
 // Second argument is the path of a system image file (*.ji) relative to the
 // first argument path, or relative to the default julia home dir. The default
 // is something like ../lib/julia/sys.ji

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -196,13 +196,15 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
                         jl_printf(JL_STDERR,"\nWARNING: failed to create string for .bc build path\n");
                     }
                 }
-                char *build_o;
-                if (asprintf(&build_o, "%s" PATHSEPSTRING "%s.o",build_path,newm->name->name) > 0) {
-                    jl_dump_objfile(build_o,0);
-                    free(build_o);
-                }
-                else {
-                    jl_printf(JL_STDERR,"\nFATAL: failed to create string for .o build path\n");
+                if (isbase) {
+                    char *build_o;
+                    if (asprintf(&build_o, "%s" PATHSEPSTRING "%s.o",build_path,newm->name->name) > 0) {
+                        jl_dump_objfile(build_o,0);
+                        free(build_o);
+                    }
+                    else {
+                        jl_printf(JL_STDERR,"\nFATAL: failed to create string for .o build path\n");
+                    }
                 }
             }
             else {
@@ -378,10 +380,7 @@ static jl_module_t *eval_import_path_(jl_array_t *args, int retrying)
                 if (require_func == NULL && jl_base_module != NULL)
                     require_func = jl_get_global(jl_base_module, jl_symbol("require"));
                 if (require_func != NULL) {
-                    jl_value_t *str = jl_cstr_to_string(var->name);
-                    JL_GC_PUSH1(&str);
-                    jl_apply((jl_function_t*)require_func, &str, 1);
-                    JL_GC_POP();
+                    jl_apply((jl_function_t*)require_func, (jl_value_t**)&var, 1);
                     return eval_import_path_(args, 1);
                 }
             }

--- a/test/file.jl
+++ b/test/file.jl
@@ -126,6 +126,13 @@ close(f)
 rm(c_tmpdir, recursive=true)
 @test !isdir(c_tmpdir)
 
+# recursive mkdir
+d_tmpdir = joinpath(c_tmpdir, "a", "b")
+@test_throws SystemError mkdir(d_tmpdir)
+mkdir(d_tmpdir, recursive=true)
+@test isdir(d_tmpdir)
+rm(c_tmpdir, recursive=true)
+
 
 #######################################################################
 # This section tests file watchers.                                   #

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -77,6 +77,7 @@ static const char opts[]  =
 
     " --track-allocation={none|user|all}, --track-allocation\n"
     "                           Count bytes allocated by each source line\n\n"
+
     " -O, --optimize\n"
     "                           Run time-intensive code optimizations\n"
     " --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)\n"
@@ -478,8 +479,6 @@ static int true_main(int argc, char *argv[])
     return 0;
 }
 
-DLLEXPORT extern void julia_save();
-
 #ifndef _OS_WINDOWS_
 int main(int argc, char *argv[])
 {
@@ -506,7 +505,6 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
     julia_init(imagepathspecified ? JL_IMAGE_CWD : JL_IMAGE_JULIA_HOME);
     int ret = true_main(argc, (char**)argv);
     jl_atexit_hook();
-    julia_save();
     return ret;
 }
 

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -41,7 +41,6 @@ extern "C" {
 static int lisp_prompt = 0;
 static int codecov  = JL_LOG_NONE;
 static int malloclog= JL_LOG_NONE;
-static char *program = NULL;
 static int imagepathspecified = 0;
 
 static const char usage[] = "julia [options] [program] [args...]\n";
@@ -346,13 +345,9 @@ void parse_opts(int *argcp, char ***argvp)
     optind -= skip;
     *argvp += optind;
     *argcp -= optind;
-    if (jl_options.image_file==NULL && *argcp > 0) {
-        if (strcmp((*argvp)[0], "-"))
-            program = (*argvp)[0];
-    }
 }
 
-static int exec_program(void)
+static int exec_program(char *program)
 {
     int err = 0;
  again: ;
@@ -428,13 +423,6 @@ static int true_main(int argc, char *argv[])
         }
     }
 
-    // run program if specified, otherwise enter REPL
-    if (program) {
-        int ret = exec_program();
-        uv_tty_reset_mode();
-        return ret;
-    }
-
     jl_function_t *start_client = jl_base_module ?
         (jl_function_t*)jl_get_global(jl_base_module, jl_symbol("_start")) : NULL;
 
@@ -443,11 +431,19 @@ static int true_main(int argc, char *argv[])
         return 0;
     }
 
+    // run program if specified, otherwise enter REPL
+    if (argc > 0) {
+        if (strcmp(argv[0], "-")) {
+            return exec_program(argv[0]);
+        }
+    }
+
     ios_puts("warning: Base._start not defined, falling back to economy mode repl.\n", ios_stdout);
     if (!jl_errorexception_type)
         ios_puts("warning: jl_errorexception_type not defined; any errors will be fatal.\n", ios_stdout);
+
     while (!ios_eof(ios_stdin)) {
-        char *line = NULL;
+        char *volatile line = NULL;
         JL_TRY {
             ios_puts("\njulia> ", ios_stdout);
             ios_flush(ios_stdout);


### PR DESCRIPTION
NOTE: this is a PR against jn/static_compile_4, not master. CC @vtjnash.

@vtjnash has done (quite some time ago) basically all the work needed for package precompilation; to merge it, we just need to wrap up a few loose ends and put a bow on it. This is my attempt to make some progress on that goal. This WIP adds a mechanism to keep track of the files associated with a package and perform an `mtime` check to see if the precompiled version needs to be updated if files have been edited.

However, I can't test this contribution because #8745 is broken in ways I don't fully understand. I am also well aware that this ignores the multiprocess case, I was just going to try to get the single process case working first.

Also note this adds `mkdir("/tmp/a/b/c", recursive=true)` and changes the location of the `libs` directory.
