### PR TITLE
Set default for USE_BLAS64 to 0 when using non MKL system BLAS

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -574,9 +574,17 @@ else
 PCRE_CONFIG = $(build_bindir)/pcre-config
 endif
 
-# Use 64-bit libraries by default on 64-bit architectures
+# Use ILP64 BLAS interface when building openblas from source on 64-bit architectures
 ifeq ($(BINARY), 64)
+ifeq ($(USE_SYSTEM_BLAS), 1)
+ifeq ($(USE_INTEL_MKL), 1)
 USE_BLAS64 ?= 1
+else # non MKL system blas is most likely LP64
+USE_BLAS64 ?= 0
+endif
+else
+USE_BLAS64 ?= 1
+endif
 endif
 
 ifeq ($(USE_SYSTEM_BLAS), 1)

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -41,6 +41,7 @@ if [ "$ARCH" = x86_64 ]; then
   bits=64
   archsuffix=64
   echo "override MARCH = x86-64" >> Make.user
+  echo 'USE_BLAS64 = 1' >> Make.user
 else
   bits=32
   archsuffix=86


### PR DESCRIPTION
fixes #10457, fixes #11417
