### PR TITLE
Only test samefile(Libdl.dlpath(dl), dl) for libraries that can be dlopen'ed

### DIFF
--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -20,7 +20,7 @@ dlls = Libdl.dllist()
 @test length(dlls) > 3 # at a bare minimum, probably have some version of libstdc, libgcc, libjulia, ...
 if @unix? true : (Base.windows_version() >= Base.WINDOWS_VISTA_VER)
     for dl in dlls
-        if isfile(dl)
+        if isfile(dl) && (Libdl.dlopen_e(dl) != C_NULL)
             @test Base.samefile(Libdl.dlpath(dl), dl)
         end
     end


### PR DESCRIPTION
related to #11268

On my Windows laptop I have some graphics-card-related dll's showing up in the output of `Libdl.dllist()`, one of which at `"C:\\Program Files (x86)\\NVIDIA Corporation\\CoProcManager\\detoured.dll"` cannot be `dlopen`ed for some reason, I'm getting

```
ERROR: could not load module C:\Program Files (x86)\NVIDIA Corporation\CoProcManager\detoured.dll: The specified module could not be found.
```

which is preventing `dlpath` from working. The only thing that dll depends on according to dependency walker is kernel32.dll.
