### PR TITLE
Add benchmark to track Julia's array allocation performance relative to Python

### DIFF
--- a/test/perf/arrayalloc/Makefile
+++ b/test/perf/arrayalloc/Makefile
@@ -1,14 +1,14 @@
-ifndef JULIABIN
-	JULIABIN = julia
-endif
+JULIAHOME = $(abspath ../../..)
+include $(JULIAHOME)/Make.inc
+
 ifndef PYTHONBIN
-	PYTHONBIN = python3
+	PYTHONBIN = python
 endif
 
 python:
 	$(PYTHONBIN) lucompletepiv.py
 
 julia:
-	$(JULIABIN) lucompletepiv.jl
+	@$(call spawn,$(JULIA_EXECUTABLE)) lucompletepiv.jl
 
 all: python julia

--- a/test/perf/arrayalloc/Makefile
+++ b/test/perf/arrayalloc/Makefile
@@ -1,0 +1,14 @@
+ifndef JULIABIN
+	JULIABIN = julia
+endif
+ifndef PYTHONBIN
+	PYTHONBIN = python3
+endif
+
+python:
+	$(PYTHONBIN) lucompletepiv.py
+
+julia:
+	$(JULIABIN) lucompletepiv.jl
+
+all: python julia

--- a/test/perf/arrayalloc/lucompletepiv.jl
+++ b/test/perf/arrayalloc/lucompletepiv.jl
@@ -1,0 +1,53 @@
+function lucompletepivCopy!(A)
+    n = size(A, 1)
+    rowpiv=zeros(Int, n-1)
+    colpiv=zeros(Int, n-1)
+    for k = 1:n-1
+        As = abs(A[k:n, k:n])
+        μ, λ = ind2sub(size(As), indmax(As))
+        μ += k-1; λ += k-1
+        rowpiv[k] = μ
+        A[[k,μ], 1:n] = A[[μ,k], 1:n]
+        colpiv[k] = λ
+        A[1:n, [k,λ]] = A[1:n, [λ,k]]
+        if A[k,k] ≠ 0
+            ρ = k+1:n
+            A[ρ, k] = A[ρ, k]/A[k, k]
+            A[ρ, ρ] = A[ρ, ρ] - A[ρ, k] * A[k, ρ]
+        end
+    end
+    return (A, rowpiv, colpiv)
+end
+
+function lucompletepivSub!(A)
+    n = size(A, 1)
+    rowpiv=zeros(Int, n-1)
+    colpiv=zeros(Int, n-1)
+    for k = 1:n-1
+        As = abs(sub(A, k:n, k:n))
+        μ, λ = ind2sub(size(As), indmax(As))
+        μ += k-1; λ += k-1
+        rowpiv[k] = μ
+        A[[k,μ], 1:n] = sub(A, [μ,k], 1:n)
+        colpiv[k] = λ
+        A[1:n, [k,λ]] = sub(A, 1:n, [λ,k])
+        if A[k,k] ≠ 0
+            ρ = k+1:n
+            A[ρ, k] = sub(A, ρ, k)/A[k, k]
+            A[ρ, ρ] = sub(A, ρ, ρ) - sub(A, ρ, k) * sub(A, k, ρ)
+        end
+    end
+    return (A, rowpiv, colpiv)
+end
+
+println("Julia version with copy slices")
+for n = [100, 250, 500, 1000]
+    A = randn(n,n)
+    @printf("size %4d matrix factorized in %6.3f seconds\n", n, mean([@elapsed lucompletepivCopy!(copy(A)) for i = 1:3]))
+end
+
+println("\nJulia version with view slices")
+for n = [100, 250, 500, 1000]
+    A = randn(n,n)
+    @printf("size %4d matrix factorized in %6.3f seconds\n", n, mean([@elapsed lucompletepivSub!(copy(A)) for i = 1:3]))
+end

--- a/test/perf/arrayalloc/lucompletepiv.py
+++ b/test/perf/arrayalloc/lucompletepiv.py
@@ -1,0 +1,35 @@
+import numpy as np
+import time
+
+def lucompletepiv(A):
+    assert np.size(A, 0) == np.size(A, 1)
+    n = np.size(A, 1)
+    rowpiv = np.zeros(n-1, dtype=int)
+    colpiv = np.zeros(n-1, dtype=int)
+    for k in range(n-1):
+        Asub = abs(A[k:n, k:n])
+        mu, lam = np.unravel_index(np.argmax(Asub), np.shape(Asub))
+        mu, lam = mu + k, lam + k
+        rowpiv[k] = mu
+        A[[k, mu], :n] = A[[mu, k], :n]
+        colpiv[k] = lam
+        A[:n, [k, lam]] = A[:n, [lam, k]]
+        if A[k, k] != 0:
+            rho = slice(k+1, n)
+            A[rho, k] = A[rho, k]/A[k, k]
+            A[rho, rho] -= np.dot(np.reshape(A[rho, k], (n - (k + 1), 1)),
+                                  np.reshape(A[k, rho], (1, n - (k + 1))))
+    return (A, rowpiv, colpiv)
+
+
+for n in [100, 250, 500, 1000]:
+    tt = []
+    for rep in range(3):
+        A = np.random.randn(n, n)
+        t0 = time.time()
+        lucompletepiv(A.copy())
+        tt.append(time.time() - t0)
+
+    print("size %4d matrix factorized in %6.3f seconds" % (n, sum(tt)/3))
+
+print("")


### PR DESCRIPTION
Although Julia is often very fast, it is less fast when the code is written in a traditional MATLAB/Numpy style with a lot of temporary arrays. It was recently experienced in a linear algebra benchmark suggested by @jiahao for which a Numpy implementation was quite a bit faster than Julia.

This PR adds the benchmark to then benchmark suite such that it is easier to track improvements in our array allocation/reuse speed. The benchmarks are written for Python 3 because it appeared to be faster the 2 on my machine. In the timings below, I use latest Julia master.

It should be noticed that the new GC has already helped a lot.

``` sh
python3 lucompletepiv.py
size  100 matrix factorized in  0.005 seconds
size  250 matrix factorized in  0.038 seconds
size  500 matrix factorized in  0.218 seconds
size 1000 matrix factorized in  1.713 seconds

julia-dev lucompletepiv.jl
Julia version with copy slices
size  100 matrix factorized in  0.015 seconds
size  250 matrix factorized in  0.104 seconds
size  500 matrix factorized in  0.538 seconds
size 1000 matrix factorized in  4.027 seconds

Julia version with view slices
size  100 matrix factorized in  0.004 seconds
size  250 matrix factorized in  0.079 seconds
size  500 matrix factorized in  0.442 seconds
size 1000 matrix factorized in  3.632 seconds
```

cc: @ViralBShah 
