### PR TITLE
RFC: Try to generate reusable jlcall wrapper

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -342,6 +342,7 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams)
     li->roots = NULL;
     li->functionObject = NULL;
     li->specFunctionObject = NULL;
+    li->specFunctionPtr = NULL;
     li->cFunctionList = NULL;
     li->functionID = 0;
     li->specFunctionID = 0;
@@ -354,6 +355,7 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams)
     li->name = anonymous_sym;
     li->def = li;
     li->capt = NULL;
+    li->hasJLWrapper = 0;
     return li;
 }
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -735,6 +735,7 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
         // save functionObject pointers
         write_int32(s, li->functionID);
         write_int32(s, li->specFunctionID);
+        write_int8(s, li->hasJLWrapper);
     }
     else if (jl_typeis(v, jl_module_type)) {
         jl_serialize_module(s, (jl_module_t*)v);
@@ -1205,6 +1206,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         li->functionObject = NULL;
         li->cFunctionList = NULL;
         li->specFunctionObject = NULL;
+        li->specFunctionPtr = NULL;
         li->inInference = 0;
         li->inCompile = 0;
         li->unspecialized = (jl_function_t*)jl_deserialize_value(s, (jl_value_t**)&li->unspecialized);
@@ -1213,6 +1215,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         int32_t cfunc_llvm, func_llvm;
         func_llvm = read_int32(s);
         cfunc_llvm = read_int32(s);
+        li->hasJLWrapper = read_int8(s);
         jl_delayed_fptrs(li, func_llvm, cfunc_llvm);
         return (jl_value_t*)li;
     }

--- a/src/julia.h
+++ b/src/julia.h
@@ -221,9 +221,11 @@ typedef struct _jl_lambda_info_t {
     void *cFunctionList;        // c callable llvm Functions
 
     // specialized llvm Function (common core for the other two)
-    void *specFunctionObject;
+    void *specFunctionObject; // Function*
+    void *specFunctionPtr; // function address
     int32_t functionID; // index that this function will have in the codegen table
     int32_t specFunctionID; // index that this specFunction will have in the codegen table
+    int8_t hasJLWrapper; // Whether the functionObject is a generic wrapper
 } jl_lambda_info_t;
 
 typedef struct _jl_function_t {


### PR DESCRIPTION
Update2:

The goal of this PR is to lower the overhead of creating jlcall wrappers by generating a generic version of the wrapper that looks up the function pointer in the function object passed in and cache them in a global table. The wrapper function can be later used on other functions with the same signature.

This PR should be "feature complete" now. A few things that I'm not so sure about is listed here:
1. The table that caches the functions is a `std::map`.
2. I assume the return type (`jl_value_t`) is cached and never freed, it that always true? (and if not, how do I tell if it is cached and only cache the wrapper function in that case)
3. Reloading the functions from the cache works. However, I don't know how to teach llvm about the global function that I want to inject. Currently I'm using a wrapper function to fallback on looking up in a map I set up in order to test if it works. I suppose there must be better ways to do it.

As for performance.
1. The number of wrappers goes down from 2400+ to 500+. `sys.so` size goes from `3.4M` to `3.3M`.
2. This should also allow more aggressive c specialization as in https://github.com/JuliaLang/julia/pull/11306 without overhead of generating the wrapper.
3. The wrapper will probably be slower. I hope that doesn't matter and I don't know how to benchmark it because AFAIK, the jlcall wrapper is only used in slow path anyway.
4. There's probably some other optimizations that can be done (use the original `jl_lambda_info_t` instead of a new one) but I think I would like to get feedback on the overall design first.

Original messages and other updates see first comment below.
