### PR TITLE
isspace: reduce need for category_code call, and inline

### DIFF
--- a/base/utf8proc.jl
+++ b/base/utf8proc.jl
@@ -155,8 +155,9 @@ iscntrl(c::Char) = (c <= Char(0x1f) || Char(0x7f) <= c <= Char(0x9f))
 
 ispunct(c::Char) = (UTF8PROC_CATEGORY_PC <= category_code(c) <= UTF8PROC_CATEGORY_PO)
 
-# 0x85 is the Unicode Next Line (NEL) character
-isspace(c::Char) = c == ' ' || '\t' <= c <='\r' || c == Char(0x85) || category_code(c)==UTF8PROC_CATEGORY_ZS
+# \u85 is the Unicode Next Line (NEL) character
+# the check for \ufffd allows for branch removal on ASCIIStrings
+@inline isspace(c::Char) = c == ' ' || '\t' <= c <='\r' || c == '\u85' || '\ua0' <= c && c != '\ufffd' && category_code(c)==UTF8PROC_CATEGORY_ZS
 
 isprint(c::Char) = (UTF8PROC_CATEGORY_LU <= category_code(c) <= UTF8PROC_CATEGORY_ZS)
 


### PR DESCRIPTION
I did some profiling of some string processing code, and I found that `isspace` was unnecessarily slow. This adds an extra check to determine if the call to `category_code` is required (which should never be needed for ASCII), and forces inlining. 

It doubles the speed of the following function:

``` julia
function hasspace(s)
    for c in s
        isspace(c) && return true
    end
    false
end
```
