### PR TITLE
add --handle-signals option for disabling signal handling

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -29,6 +29,7 @@ immutable JLOptions
     fast_math::Int8
     worker::Int8
     bindto::Ptr{UInt8}
+    handle_signals::Int8
 end
 
 JLOptions() = unsafe_load(cglobal(:jl_options, JLOptions))

--- a/src/julia.h
+++ b/src/julia.h
@@ -1327,9 +1327,10 @@ DLLEXPORT extern volatile sig_atomic_t jl_defer_signal;
 
 DLLEXPORT void jl_sigint_action(void);
 DLLEXPORT void restore_signals(void);
-DLLEXPORT void jl_install_sigint_handler();
+DLLEXPORT void jl_install_sigint_handler(void);
 DLLEXPORT void jl_sigatomic_begin(void);
 DLLEXPORT void jl_sigatomic_end(void);
+void jl_install_default_signal_handlers(void);
 
 
 // tasks and exceptions -------------------------------------------------------
@@ -1555,6 +1556,7 @@ typedef struct {
     int8_t fast_math;
     int8_t worker;
     const char *bindto;
+    int8_t handle_signals;
 } jl_options_t;
 
 extern DLLEXPORT jl_options_t jl_options;
@@ -1589,6 +1591,9 @@ extern DLLEXPORT jl_options_t jl_options;
 #define JL_OPTIONS_FAST_MATH_ON 1
 #define JL_OPTIONS_FAST_MATH_OFF 2
 #define JL_OPTIONS_FAST_MATH_DEFAULT 0
+
+#define JL_OPTIONS_HANDLE_SIGNALS_ON 1
+#define JL_OPTIONS_HANDLE_SIGNALS_OFF 0
 
 // Version information
 #include "julia_version.h"

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -53,7 +53,8 @@ static const char opts[]  =
     " -H, --home <dir>          Set location of julia executable\n"
     " --startup-file={yes|no}   Load ~/.juliarc.jl\n"
     " -f, --no-startup          Don't load ~/.juliarc (deprecated, use --startup-file=no)\n"
-    " -F                        Load ~/.juliarc (deprecated, use --startup-file=yes)\n\n"
+    " -F                        Load ~/.juliarc (deprecated, use --startup-file=yes)\n"
+    " --handle-signals={yes|no} Enable or disable Julia's default signal handlers\n\n"
 
     // actions
     " -e, --eval <expr>         Evaluate <expr>\n"
@@ -110,7 +111,8 @@ void parse_opts(int *argcp, char ***argvp)
            opt_inline,
            opt_math_mode,
            opt_worker,
-           opt_bind_to
+           opt_bind_to,
+           opt_handle_signals
     };
     static char* shortopts = "+vhqFfH:e:E:P:L:J:C:ip:Ob:";
     static struct option longopts[] = {
@@ -143,6 +145,7 @@ void parse_opts(int *argcp, char ***argvp)
         { "depwarn",         required_argument, 0, opt_depwarn },
         { "inline",          required_argument, 0, opt_inline },
         { "math-mode",       required_argument, 0, opt_math_mode },
+        { "handle-signals",  required_argument, 0, opt_handle_signals },
         // hidden command line options
         { "build",           required_argument, 0, 'b' },
         { "worker",          no_argument,       0, opt_worker },
@@ -347,6 +350,14 @@ void parse_opts(int *argcp, char ***argvp)
             break;
         case opt_bind_to:
             jl_options.bindto = strdup(optarg);
+            break;
+        case opt_handle_signals:
+            if (!strcmp(optarg,"yes"))
+                jl_options.handle_signals = JL_OPTIONS_HANDLE_SIGNALS_ON;
+            else if (!strcmp(optarg,"no"))
+                jl_options.handle_signals = JL_OPTIONS_HANDLE_SIGNALS_OFF;
+            else
+                jl_errorf("julia: invalid argument to --handle-signals (%s)\n", optarg);
             break;
         default:
             jl_errorf("julia: unhandled option -- %c\n"


### PR DESCRIPTION
It needs to be possible to turn off our signal handlers. The primary (maybe only) use case for this is when julia is embedded, but I figure it's simplest to handle all options the same way.
