### PR TITLE
Let Pkg.free take an iterable to free multiple packages

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -37,7 +37,7 @@ clone(url::AbstractString, pkg::AbstractString) = cd(Entry.clone,url,pkg)
 checkout(pkg::AbstractString, branch::AbstractString="master"; merge::Bool=true, pull::Bool=true) =
     cd(Entry.checkout,pkg,branch,merge,pull)
 
-free(pkg::AbstractString) = cd(Entry.free,pkg)
+free(pkg) = cd(Entry.free,pkg)
 
 pin(pkg::AbstractString) = cd(Entry.pin,pkg)
 pin(pkg::AbstractString, ver::VersionNumber) = cd(Entry.pin,pkg,ver)

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -217,6 +217,30 @@ function free(pkg::AbstractString)
     end
 end
 
+function free(pkgs)
+    try
+        for pkg in pkgs
+            ispath(pkg,".git") || error("$pkg is not a git repo")
+            Read.isinstalled(pkg) || error("$pkg cannot be freed – not an installed package")
+            avail = Read.available(pkg)
+            isempty(avail) && error("$pkg cannot be freed – not a registered package")
+            Git.dirty(dir=pkg) && error("$pkg cannot be freed – repo is dirty")
+            info("Freeing $pkg")
+            vers = sort!(collect(keys(avail)), rev=true)
+            for ver in vers
+                sha1 = avail[ver].sha1
+                Git.iscommit(sha1, dir=pkg) || continue
+                Git.run(`checkout -q $sha1`, dir=pkg)
+                break
+            end
+            isempty(Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail])) && continue
+            error("can't find any registered versions of $pkg to checkout")
+        end
+    finally
+        resolve()
+    end
+end
+
 function pin(pkg::AbstractString, head::AbstractString)
     ispath(pkg,".git") || error("$pkg is not a git repo")
     branch = "pinned.$(head[1:8]).tmp"

--- a/doc/stdlib/pkg.rst
+++ b/doc/stdlib/pkg.rst
@@ -105,6 +105,9 @@ to use them, you'll need to prefix each function call with an explicit ``Pkg.``,
    It calls ``Pkg.resolve()`` to determine optimal package versions after.
    This is an inverse for both ``Pkg.checkout`` and ``Pkg.pin``.
 
+   You can also supply an iterable collection of package names, e.g.,
+   ``Pkg.free(("Pkg1", "Pkg2"))`` to free multiple packages at once.
+
 .. function:: build()
 
    Run the build scripts for all installed packages in depth-first recursive order.
@@ -142,4 +145,3 @@ to use them, you'll need to prefix each function call with an explicit ``Pkg.``,
 .. function:: test(pkgs...)
 
    Run the tests for each package in ``pkgs`` ensuring that each package's test dependencies are installed for the duration of the test. A package is tested by running its ``test/runtests.jl`` file and test dependencies are specified in ``test/REQUIRE``.
-

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -15,14 +15,29 @@ function temp_pkg_dir(fn::Function)
   end
 end
 
-# Test adding or removing a package
-#Also test for the existence of REUIRE and META_Branch
+# Test basic operations: adding or removing a package, status, free
+#Also test for the existence of REQUIRE and META_Branch
 temp_pkg_dir() do
   @test isfile(joinpath(Pkg.dir(),"REQUIRE"))
   @test isfile(joinpath(Pkg.dir(),"META_BRANCH"))
   @test isempty(Pkg.installed())
   Pkg.add("Example")
   @test [keys(Pkg.installed())...] == ["Example"]
+  iob = IOBuffer()
+  Pkg.checkout("Example")
+  Pkg.status("Example", iob)
+  str = chomp(takebuf_string(iob))
+  @test startswith(str, " - Example")
+  @test endswith(str, "master")
+  Pkg.free("Example")
+  Pkg.status("Example", iob)
+  str = chomp(takebuf_string(iob))
+  @test endswith(str, string(Pkg.installed("Example")))
+  Pkg.checkout("Example")
+  Pkg.free(("Example",))
+  Pkg.status("Example", iob)
+  str = chomp(takebuf_string(iob))
+  @test endswith(str, string(Pkg.installed("Example")))
   Pkg.rm("Example")
   @test isempty(Pkg.installed())
 end


### PR DESCRIPTION
Use it like this:

``` jl
Pkg.free(["Distances", "Graphics", "HyperDualNumbers", "JuliaParser", "ProfileView", "HDF5", "Grid", "ProgressMeter", "FixedPointNumbers", "GnuTLS", "MLBase", "SIUnits", "Tk", "WoodburyMatrices", "ZipFile", "Zlib"])
```

In the amount of time it will save you, Jeff could probably fix 2 codegen bugs and rewrite our module-loading logic :smile:.
