### PR TITLE
Fixing types conflict in pollardfactors!

### DIFF
--- a/base/primes.jl
+++ b/base/primes.jl
@@ -99,7 +99,7 @@ function factor{T<:Integer}(n::T)
             isprime(n) && (h[n] = 1; return h)
         end
     end
-    widemul(n-1,n-1) <= typemax(n) ? pollardfactors!(n, h) : pollardfactors!(widen(n), h)
+    T <: BigInt || widemul(n-1,n-1) <= typemax(n) ? pollardfactors!(n, h) : pollardfactors!(widen(n), h)
 end
 
 function pollardfactors!{T<:Integer,K<:Integer}(n::T, h::Dict{K,Int})

--- a/base/primes.jl
+++ b/base/primes.jl
@@ -99,12 +99,12 @@ function factor{T<:Integer}(n::T)
             isprime(n) && (h[n] = 1; return h)
         end
     end
-    pollardfactors!(n, h)
+    widemul(n-1,n-1) <= typemax(n) ? pollardfactors!(n, h) : pollardfactors!(widen(n), h)
 end
 
-function pollardfactors!{T<:Integer}(n::T, h::Dict{T,Int})
+function pollardfactors!{T<:Integer,K<:Integer}(n::T, h::Dict{K,Int})
     while true
-        local c::T = rand(1:(n-1)), G::T = 1, r::T = 1, y::T = rand(0:(n-1)), m::T = 1900
+        local c::T = rand(1:(n-1)), G::T = 1, r::K = 1, y::T = rand(0:(n-1)), m::K = 1900
         local ys::T, q::T = 1, x::T
         while c == n - 2
             c = rand(1:(n-1))
@@ -112,17 +112,17 @@ function pollardfactors!{T<:Integer}(n::T, h::Dict{T,Int})
         while G == 1
             x = y
             for i in 1:r
-                y = widemul(y,y)%n
-                y = (widen(y)+widen(c))%n
+                y = (y*y)%n
+                y = (y+c)%n
             end
-            local k::T = 0
+            local k::K = 0
             G = 1
             while k < r && G == 1
                 for i in 1:(m>(r-k)?(r-k):m)
                     ys = y
-                    y = widemul(y,y)%n
-                    y = (widen(y)+widen(c))%n
-                    q = widemul(q,x>y?x-y:y-x)%n
+                    y = (y*y)%n
+                    y = (y+c)%n
+                    q = (q*(x>y?x-y:y-x))%n
                 end
                 G = gcd(q,n)
                 k = k + m
@@ -131,8 +131,8 @@ function pollardfactors!{T<:Integer}(n::T, h::Dict{T,Int})
         end
         G == n && (G = 1)
         while G == 1
-            ys = widemul(ys,ys)%n
-            ys = (widen(ys)+widen(c))%n
+            ys = (ys*ys)%n
+            ys = (ys+c)%n
             G = gcd(x>ys?x-ys:ys-x,n)
         end
         if G != n

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2119,6 +2119,9 @@ end
 @test factor((big(2)^31-1)^2) == Dict(big(2^31-1) => 2)
 @test factor((big(2)^31-1)*(big(2)^17-1)) == Dict(big(2^31-1) => 1, big(2^17-1) => 1)
 
+# fast factorization of Int128 (#11477)
+@test factor((Int128(2)^39-7)^2) == Dict(Int128(2)^39-7 => 2)
+
 # large shift amounts
 @test Int32(-1)>>31 == -1
 @test Int32(-1)>>32 == -1


### PR DESCRIPTION
Reading this [thread](https://groups.google.com/forum/#!topic/julia-users/-c5Xqa1CA3w) from julia-users I realized that my modification #11189 had something wrong, the improvement was only x8 and linux `factor` was +x1000. After reviewing the algorithm and not finding any error I used `profile` and I realized that an enormous portion of the time pollardfactors! was spent foolishly converting Int128 <-> BigInt...
Now we have something like a x1000 improvement respect the old version in Int128 (the most problematic type).
(I'm actually embarrassed for not having profiled the code before... :disappointed:)

----- EDIT
I had to fix not to check typemax when T is a BigInteger. (That's what happens when you don't test...)
