### PR TITLE
Allow built-in commands in shell mode for Windows

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -75,11 +75,11 @@ function repl_cmd(cmd, out)
         @windows_only begin
             cmdbuf = IOBuffer()
             if lowercase(shell[1]) == "cmd"
-                print_cmdshell_escaped(cmdbuf, cmd.exec...)
+                print_shell_escaped(cmdbuf, cmd.exec..., mode=:cmd)
                 cmd.exec = ["cmd"; "/s /c \"$(bytestring(cmdbuf))\""]
                 cmd.verbatimargument = true
             elseif lowercase(shell[1]) == "powershell"
-                print_powershell_escaped(cmdbuf, cmd.exec...)
+                print_shell_escaped(cmdbuf, cmd.exec..., mode=:powershell)
                 cmd.exec = ["powershell"; "-command"; "$(bytestring(cmdbuf))"]
             end
         end

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -188,7 +188,8 @@ DLLEXPORT int jl_spawn(char *name, char **argv, uv_loop_t *loop,
                        uv_handle_type stdin_type, uv_pipe_t *stdin_pipe,
                        uv_handle_type stdout_type, uv_pipe_t *stdout_pipe,
                        uv_handle_type stderr_type, uv_pipe_t *stderr_pipe,
-                       int detach, char **env, char *cwd, uv_exit_cb cb)
+                       int detach, int verbatimargument, char **env, char *cwd,
+                       uv_exit_cb cb)
 {
     uv_process_options_t opts;
     uv_stdio_container_t stdio[3];
@@ -204,6 +205,8 @@ DLLEXPORT int jl_spawn(char *name, char **argv, uv_loop_t *loop,
     opts.args = argv;
     if (detach)
         opts.flags |= UV_PROCESS_DETACHED;
+    if (verbatimargument)
+        opts.flags |= UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
     opts.stdio = stdio;
     opts.stdio_count = 3;
     stdio[0].type = stdin_type;


### PR DESCRIPTION
This was originally part of #7108 by @quinnj  but appears to have fallen between the cracks. It allows using built-in dos commands from the Julia shell-mode. `edit()` already works the same way.
