### PR TITLE
Stopgap for Vararg widening

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -65,9 +65,9 @@ end
     T.parameters[1]
 end
 
-isvarargtype(t::ANY) = isa(t,DataType)&&is((t::DataType).name,Vararg.name)
+isvarargtype(t::ANY) = isa(t,DataType)&&is((t::DataType).name,Vararg.name) || isa(t,TypeVar) && isvarargtype(t.ub)
 isvatuple(t::DataType) = (n = length(t.parameters); n > 0 && isvarargtype(t.parameters[n]))
-unwrapva(t::ANY) = isvarargtype(t) ? t.parameters[1] : t
+unwrapva(t::ANY) = isvarargtype(t) ? (isa(t,TypeVar) ? unwrapva(t.ub) : t.parameters[1]) : t
 
 @generated function tuple_type_tail{T<:Tuple}(::Type{T})
     if isvatuple(T) && length(T.parameters) == 1

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -315,7 +315,7 @@ const getfield_tfunc = function (A, s0, name)
         i::Int = A[2]
         nf = s.types.length
         if isvatuple(s) && i >= nf
-            return s.types[nf].parameters[1], false
+            return unwrapva(s.types[nf]), false
         end
         if i < 1 || i > nf
             return Bottom, true


### PR DESCRIPTION
This is a not-very-good fix for the following problem. It turns out that
since Vararg is a type (which I would argue is a bad idea), it can get
widened into a `<:Vararg` type var. This is not handled correctly and
can cause inference to crash. This patch does not fix the fact that we
could potentially encouter something like `Tuple{<:Any}` which could
come from `Tuple{Vararg{T}}`.

A small repro :

``` julia
abstract A{T}
@noinline f(x,y) = ()
function hh(x :: A{A{A{A{A{Int}}}}}) # enough for type_too_complex
    y :: Tuple{Vararg{typeof(x)}} = (x,) # apply_type(Vararg, too_complex) => TypeVar(_,Vararg)
    f(y[1], # fool getfield logic : Tuple{_<:Vararg}[1] => Vararg
      1) # make it crash by construction of the signature Tuple{Vararg,Int}
end
code_typed(hh,(Any,))
```

I would argue that `Vararg` as a type has to go away, since being handled as a special case everywhere it breaks some obvious rules like :

``` julia
Vararg{Int} <: Vararg{Integer} # false
Tuple{Vararg{Int}} <: Tuple{Vararg{Integer}} # true
```

My vote is for Vararg to be a syntactic-only construct that can never be materialized outside of a tuple type. It would be a property of the tuple type alone.

cc @JeffBezanson 
