### PR TITLE
Fix #11436: print nested operators with parens

### DIFF
--- a/test/show.jl
+++ b/test/show.jl
@@ -256,3 +256,8 @@ end
 @test repr(:(@m x y))    == ":(@m x y)"
 @test string(:(@m x y))  ==   "@m x y"
 @test string(:(@m x y;)) == "begin \n    @m x y\nend"
+
+# issue #11436
+@test_repr "1 => 2 => 3"
+@test_repr "1 => (2 => 3)"
+@test_repr "(1 => 2) => 3"


### PR DESCRIPTION
CC @fcard.

It does introduce parentheses in a few un-necessary places (e.g., `a && b && c`), but it's simply because we don't track operator associativity.  Semantically, `(a && b) && c` behaves the same as `a && (b && c)`, but they are parsed differently.  This is how we print the `call`ed operators, too — see `a & b & c`.

I'll merge on CI.
