### PR TITLE
re-add big(z::Complex) method

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -725,6 +725,9 @@ float{T<:FloatingPoint}(z::Complex{T}) = z
 float(z::Complex) = Complex(float(real(z)), float(imag(z)))
 @vectorize_1arg Complex float
 
+big{T<:FloatingPoint}(z::Complex{T}) = Complex{BigFloat}(z)
+big{T<:Integer}(z::Complex{T}) = Complex{BigInt}(z)
+
 ## Array operations on complex numbers ##
 
 complex{T<:Complex}(x::AbstractArray{T}) = x
@@ -737,6 +740,7 @@ function complex(A::AbstractArray)
     map_promote(cnv, A)
 end
 
+big{T<:Integer,N}(x::AbstractArray{Complex{T},N}) = convert(AbstractArray{Complex{BigInt},N}, x)
 big{T<:FloatingPoint,N}(x::AbstractArray{Complex{T},N}) = convert(AbstractArray{Complex{BigFloat},N}, x)
 
 ## promotion to complex ##

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -80,6 +80,9 @@ end
 convert(::Type{Rational}, x::Float64) = convert(Rational{Int64}, x)
 convert(::Type{Rational}, x::Float32) = convert(Rational{Int}, x)
 
+big{T<:Integer}(z::Complex{Rational{T}}) = Complex{Rational{BigInt}}(z)
+big{T<:Integer,N}(x::AbstractArray{Complex{Rational{T}},N}) = convert(AbstractArray{Complex{Rational{BigInt}},N}, x)
+
 promote_rule{T<:Integer,S<:Integer}(::Type{Rational{T}}, ::Type{S}) = Rational{promote_type(T,S)}
 promote_rule{T<:Integer,S<:Integer}(::Type{Rational{T}}, ::Type{Rational{S}}) = Rational{promote_type(T,S)}
 promote_rule{T<:Integer,S<:FloatingPoint}(::Type{Rational{T}}, ::Type{S}) = promote_type(T,S)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2481,3 +2481,10 @@ for T in (Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128)
     @test_throws InexactError T(big(typemax(T))+1)
     @test_throws InexactError T(big(typemin(T))-1)
 end
+
+for (d,B) in ((4//2+1im,Rational{BigInt}),(3.0+1im,BigFloat),(2+1im,BigInt))
+    @test typeof(big(d)) == Complex{B}
+    @test big(d) == d
+    @test typeof(big([d])) == Vector{Complex{B}}
+    @test big([d]) == [d]
+end


### PR DESCRIPTION
`big(z::Complex)` seems to have been deleted without explanation, apparently in #8253?   Analogous to `float(z::Complex)`, this is a perfectly useful and sensible method to have (and is not sensible to omit given our other `big` methods).

Also added some missing `big` methods for arrays: we had `big(::Array{Complex{FloatingPoint}})`, but for some reason were missing `big(::Array{Complex{Real}})` for other `Real` types.

cc: @rfourquet
