### PR TITLE
Only allow $ as prefix operator in export and import and do not look across newlines

### DIFF
--- a/test/parser.jl
+++ b/test/parser.jl
@@ -1,5 +1,21 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+function parseall(str)
+    pos = start(str)
+    exs = []
+    while !done(str, pos)
+        ex, pos = parse(str, pos)
+        push!(exs, ex)
+    end
+    if length(exs) == 0
+        throw(ParseError("end of input"))
+    elseif length(exs) == 1
+        return exs[1]
+    else
+        return Expr(:block, exs...)
+    end
+end
+
 # issue #9684
 let
     for (ex1, ex2) in [("5.≠x", "5.!=x"),
@@ -120,3 +136,9 @@ macro test999_str(args...); args; end
 @test parse("using \$a: \$b, \$c.\$d") ==
     Expr(:toplevel, Expr(:using, Expr(:$, :a), Expr(:$, :b)),
          Expr(:using, Expr(:$, :a), Expr(:$, :c), Expr(:$, :d)))
+
+# fix pr #11338
+@test parseall("using \$\na") == Expr(:block, Expr(:using, :$), :a)
+@test parseall("using \$,\na") == Expr(:toplevel, Expr(:using, :$),
+                                       Expr(:using, :a))
+@test parseall("using &\na") == Expr(:block, Expr(:using, :&), :a)


### PR DESCRIPTION
Fix up #11338

@JeffBezanson The test cases added should work now.

Another difference caused by this PR is that `using &a` will be parsed as `(:call :* (:using :&), :a)` instead of a parse error now. This is the same behavior before #11338, has always been the case for `using -a`, and will be caught by further lowering so it shouldn't be a problem. (Although `expand` doesn't complain about it and I'm not sure how to add a test for that...)
