### PR TITLE
[documentation] STRUCTURE and RECORD are not standard in Fortran

### DIFF
--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -471,7 +471,7 @@ can be called via the following Julia code::
 Struct Type correspondences
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Composite types, aka ``struct`` in C or ``STRUCTURE`` / ``RECORD`` in Fortran),
+Composite types, aka ``struct`` in C or ``TYPE`` in Fortran),
 can be mirrored in Julia by creating a ``type`` or ``immutable``
 definition with the same field layout.
 


### PR DESCRIPTION
But `type` is. This confused me at first read of the documentation.

See https://gcc.gnu.org/onlinedocs/gfortran/STRUCTURE-and-RECORD.html
