### PR TITLE
Fix use of one deprecation in another deprecation

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -330,12 +330,12 @@ for (f,t) in ((:int,    Int), (:int8,   Int8), (:int16,  Int16), (:int32,  Int32
               (:int64,  Int64), (:int128, Int128), (:uint,   UInt), (:uint8,  UInt8),
               (:uint16, UInt16), (:uint32, UInt32), (:uint64, UInt64), (:uint128,UInt128))
     @eval begin
-        @deprecate ($f){S<:AbstractString}(a::AbstractArray{S}) [parseint($t,s) for s in a]
+        @deprecate ($f){S<:AbstractString}(a::AbstractArray{S}) [parse($t,s) for s in a]
     end
 end
 for (f,t) in ((:float32, Float32), (:float64, Float64))
     @eval begin
-        @deprecate ($f){S<:AbstractString}(a::AbstractArray{S}) [parsefloat($t,s) for s in a]
+        @deprecate ($f){S<:AbstractString}(a::AbstractArray{S}) [parse($t,s) for s in a]
     end
 end
 


### PR DESCRIPTION
Combined with bad backtraces for deprecations, this made for some moderately infuriating error messages.
