### PR TITLE
RFC: Create local gc frame for `throw`

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2798,6 +2798,10 @@ function inlining_pass(e::Expr, sv, ast)
         elseif is_known_call(e, Core.Intrinsics.llvmcall, sv)
             i0 = 5
             isccall = false
+        elseif is_known_call(e, Core.throw, sv)
+            # Do not inline throw (or it's arguments). They should not be
+            # in the hot path and they can cause code inflation
+            return (e, ())
         else
             i0 = 1
             isccall = false

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -521,13 +521,12 @@ struct jl_gcinfo_t {
     int argDepth;
     int maxDepth;
     int argSpaceOffs;
+    Instruction *gcframe; /* This should always be the first instruction to
+                           * create the GC frame */
 #ifdef JL_GC_MARKSWEEP
-    Instruction *gcframe;
-    Instruction *argSpaceInits;
     StoreInst *storeFrameSize;
 #endif
-    BasicBlock::iterator first_gcframe_inst;
-    BasicBlock::iterator last_gcframe_inst;
+    Instruction *last_gcframe_inst;
     std::vector<Instruction*> gc_frame_pops;
 };
 
@@ -3448,8 +3447,7 @@ static void allocate_gc_frame(size_t n_roots, BasicBlock *b0, jl_codectx_t *ctx)
     // in finalize_gc_frame.
     // (Add back first_gcframe_inst if this is not true anymore)
     gc->gcframe = (Instruction*)builder.CreateAlloca(
-        jl_pvalue_llvmt, ConstantInt::get(T_int32,n_roots + 2));
-    gc->first_gcframe_inst = BasicBlock::iterator(gc->gcframe);
+        jl_pvalue_llvmt, ConstantInt::get(T_int32, n_roots + 2));
     gc->argTemp = (Instruction*)builder.CreateConstGEP1_32(gc->gcframe, 2);
     gc->storeFrameSize =
         builder.CreateStore(ConstantInt::get(T_size, n_roots<<1),
@@ -3457,13 +3455,12 @@ static void allocate_gc_frame(size_t n_roots, BasicBlock *b0, jl_codectx_t *ctx)
     builder.CreateStore(builder.CreateLoad(prepare_global(jlpgcstack_var), false),
                         builder.CreateBitCast(builder.CreateConstGEP1_32(gc->gcframe, 1), PointerType::get(jl_ppvalue_llvmt,0)));
     Instruction *linst = builder.CreateStore(gc->gcframe, prepare_global(jlpgcstack_var), false);
-    gc->argSpaceInits = &b0->back();
 #else
     // gc->gcframe is assumed to be the first instruction creating the gc frame
     // in finalize_gc_frame
     gc->argTemp = builder.CreateAlloca(jl_pvalue_llvmt,
                                        ConstantInt::get(T_int32, n_roots));
-    gc->first_gcframe_inst = BasicBlock::iterator(gc->argTemp);
+    gc->gcframe = gc->argTemp;
     Instruction *linst = gc->argTemp;
 #endif
     // initialize local variable stack roots to null
@@ -3471,19 +3468,20 @@ static void allocate_gc_frame(size_t n_roots, BasicBlock *b0, jl_codectx_t *ctx)
         Value *varSlot = emit_local_slot(i, ctx);
         linst = builder.CreateStore(V_null, varSlot);
     }
-    gc->last_gcframe_inst = BasicBlock::iterator(linst);
+    gc->last_gcframe_inst = linst;
 }
 
 static void clear_gc_frame(jl_gcinfo_t *gc)
 {
     // replace instruction uses with Undef first to avoid LLVM assertion failures
-    BasicBlock::iterator bbi = gc->first_gcframe_inst;
+    BasicBlock::iterator bbi(gc->gcframe);
+    BasicBlock::iterator last_gcframe_inst(gc->last_gcframe_inst);
     while (1) {
         Instruction &iii = *bbi;
         Type *ty = iii.getType();
         if (ty != T_void)
             iii.replaceAllUsesWith(UndefValue::get(ty));
-        if (bbi == gc->last_gcframe_inst) break;
+        if (bbi == last_gcframe_inst) break;
         bbi++;
     }
     for (size_t i=0; i < gc->gc_frame_pops.size(); i++) {
@@ -3501,9 +3499,9 @@ static void clear_gc_frame(jl_gcinfo_t *gc)
     // Remove GC frame creation
     // (instructions from gc->gcframe to gc->last_gcframe_inst)
     BasicBlock::InstListType &il = gc->gcframe->getParent()->getInstList();
-    il.erase(gc->first_gcframe_inst, gc->last_gcframe_inst);
+    il.erase(BasicBlock::iterator(gc->gcframe), last_gcframe_inst);
     // erase() erases up *to* the end point; erase last inst too
-    il.erase(gc->last_gcframe_inst);
+    il.erase(last_gcframe_inst);
     // Remove GC pops
     // (4 instructions from each element in the gc->gc_frame_pops)
     for (size_t i=0; i < gc->gc_frame_pops.size(); i++) {
@@ -3534,6 +3532,7 @@ static void finalize_gc_frame(jl_codectx_t *ctx)
                                                       gc->maxDepth + 2)));
         ReplaceInstWithInst(gc->gcframe->getParent()->getInstList(), bbi,
                             newgcframe);
+        gc->gcframe = newgcframe;
 
         BasicBlock::iterator bbi2(gc->storeFrameSize);
         StoreInst *newFrameSize =
@@ -3542,9 +3541,10 @@ static void finalize_gc_frame(jl_codectx_t *ctx)
                           gc->storeFrameSize->getPointerOperand());
         ReplaceInstWithInst(gc->storeFrameSize->getParent()->getInstList(), bbi2,
                             newFrameSize);
+        gc->storeFrameSize = newFrameSize;
 
-        BasicBlock::InstListType &instList = gc->argSpaceInits->getParent()->getInstList();
-        Instruction *after = gc->argSpaceInits;
+        Instruction *after = gc->last_gcframe_inst;
+        BasicBlock::InstListType &instList = after->getParent()->getInstList();
 
         // Initialize the slots for temporary variables to NULL
         for (int i = 0;i < gc->maxDepth;i++) {
@@ -3553,6 +3553,7 @@ static void finalize_gc_frame(jl_codectx_t *ctx)
             after = new StoreInst(V_null, argTempi);
             instList.insertAfter(argTempi, after);
         }
+        gc->last_gcframe_inst = after;
     }
 #else
     if (gc->maxDepth != 0) {


### PR DESCRIPTION
This PR inplements the idea proposed by @carnaval in https://github.com/JuliaLang/julia/pull/11284#issuecomment-102457067 to create a local gc frame for throwing errors.

TL;DR
I think this idea can be slightly generalized and combine with #11284 to get the best performance for (not) throwing errors.

Benchmark:
The script used to benchmark can be found [here](https://github.com/yuyichao/explore/blob/883615adf791337db2a5484b3815b3cc3a9b5bd8/julia/throw_error/throw_error.jl).

Timing output on current master ([Full output with llvm ir](https://gist.github.com/yuyichao/a4647d0f9b9aab63ea6e))

``` julia
f0
   1.428 seconds
f1
   1.462 seconds
f2
   1.592 seconds
getindex
   1.747 seconds
```

Timing output with this PR ([Full output with llvm ir](https://gist.github.com/yuyichao/4cd0bf9570ef4b9c3c7f))

``` julia
f0
   1.388 seconds
f1
   1.466 seconds
f2
   1.535 seconds
getindex
   1.478 seconds
```

(Relaxant number is the timing for `f2` and `getindex`)

As shown in the benchmark, creating a local gc frame (if there isn't a global one yet) can boost the performance for complex functions but a #11284 style transformation can still be useful especally for simple functions.

Currently this PR only has a special case for throw, which is easy because the control flow terminates here and no rooted variables can be leaked. It is probably possible to generalize this to other blocks that doesn't have too complicated control flow (or at least when calling functions that does not return). In that case, it can probably be used together with #11284 for the best performance.
