### PR TITLE
Fix Profiler segfault on Darwin

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -954,6 +954,15 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
         jl_options.load = abspath(jl_options.load);
 }
 
+#ifdef _OS_DARWIN_
+void attach_exception_port()
+{
+    kern_return_t ret;
+    ret = thread_set_exception_ports(mach_thread_self(),EXC_MASK_BAD_ACCESS,segv_port,EXCEPTION_DEFAULT,MACHINE_THREAD_STATE);
+    HANDLE_MACH_ERROR("thread_set_exception_ports",ret);
+}
+#endif
+
 void _julia_init(JL_IMAGE_SEARCH rel)
 {
     libsupport_init();
@@ -1123,8 +1132,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     }
     pthread_attr_destroy(&attr);
 
-    ret = thread_set_exception_ports(mach_thread_self(),EXC_MASK_BAD_ACCESS,segv_port,EXCEPTION_DEFAULT,MACHINE_THREAD_STATE);
-    HANDLE_MACH_ERROR("thread_set_exception_ports",ret);
+    attach_exception_port();
 #else // defined(_OS_DARWIN_)
     stack_t ss;
     ss.ss_flags = 0;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -154,6 +154,9 @@ DLLEXPORT size_t rec_backtrace_ctx(ptrint_t *data, size_t maxsize, bt_context_t 
 size_t rec_backtrace_ctx_dwarf(ptrint_t *data, size_t maxsize, bt_context_t ctx);
 #endif
 DLLEXPORT void jl_raise_debugger(void);
+#ifdef _OS_DARWIN_
+DLLEXPORT void attach_exception_port(void);
+#endif
 
 // timers
 // Returns time in nanosec

--- a/src/profile.c
+++ b/src/profile.c
@@ -169,6 +169,7 @@ void *mach_profile_listener(void *arg)
 {
     (void)arg;
     int max_size = 512;
+    attach_exception_port();
     mach_profiler_thread = mach_thread_self();
     mig_reply_error_t *bufRequest = (mig_reply_error_t *) malloc(max_size);
     while (1) {


### PR DESCRIPTION
We frequently find ourselves in the presence of invalid unwind information,
which can cause the profiler to try to access invalid memory. It is possible
to probe before whether the memory is accessible, but the easier solution is
just to catch the SEGV and recover. This used to work originally, but in
12d363a1c678fabec61b215b8ecc5e6b7a17cc65, I switched exception handling
to be thread-local to be able to debug the exception handler. Unfortunately,
since the profiler runs on a different thread, it was no longer covered by
this protection. Rectify that.
