### PR TITLE
RFC: prettify single line throws/returns and add more descriptive errors for linalg

### DIFF
--- a/base/linalg/bunchkaufman.jl
+++ b/base/linalg/bunchkaufman.jl
@@ -14,7 +14,9 @@ end
 BunchKaufman{T}(LD::AbstractMatrix{T}, ipiv::Vector{BlasInt}, uplo::Char, symmetric::Bool) = BunchKaufman{T,typeof(LD)}(LD, ipiv, uplo, symmetric)
 
 function bkfact!{T<:BlasReal}(A::StridedMatrix{T}, uplo::Symbol=:U, symmetric::Bool=issym(A))
-    symmetric || throw(ArgumentError("Bunch-Kaufman decomposition is only valid for symmetric matrices"))
+    if !symmetric
+        throw(ArgumentError("Bunch-Kaufman decomposition is only valid for symmetric matrices"))
+    end
     LD, ipiv = LAPACK.sytrf!(char_uplo(uplo) , A)
     BunchKaufman(LD, ipiv, char_uplo(uplo), symmetric)
 end

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -85,7 +85,9 @@ function chol{T}(A::AbstractMatrix{T}, uplo::Union(Type{Val{:L}}, Type{Val{:U}})
 end
 function chol!(x::Number, uplo)
     rx = real(x)
-    rx == abs(x) || throw(DomainError())
+    if rx != abs(x)
+        throw(DomainError("x must be positive semidefinite"))
+    end
     rxr = sqrt(rx)
     convert(promote_type(typeof(x), typeof(rxr)), rxr)
 end

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -56,7 +56,9 @@ function mapreduce_seq_impl{T<:BlasComplex}(::Abs2Fun, ::AddFun, a::Union(Array{
 end
 
 function norm{T<:BlasFloat, TI<:Integer}(x::StridedVector{T}, rx::Union(UnitRange{TI},Range{TI}))
-    (minimum(rx) < 1 || maximum(rx) > length(x)) && throw(BoundsError())
+    if minimum(rx) < 1 || maximum(rx) > length(x)
+        throw(BoundsError())
+    end
     BLAS.nrm2(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx))
 end
 
@@ -168,8 +170,9 @@ kron(a::Vector, b::Matrix)=kron(reshape(a,length(a),1),b)
 ^(A::Matrix, p::Integer) = p < 0 ? inv(A^-p) : Base.power_by_squaring(A,p)
 
 function ^(A::Matrix, p::Number)
-    isinteger(p) && return A^Integer(real(p))
-
+    if isinteger(p)
+        return A^Integer(real(p))
+    end
     chksquare(A)
     v, X = eig(A)
     any(v.<0) && (v = complex(v))
@@ -276,7 +279,9 @@ function rcswap!{T<:Number}(i::Integer, j::Integer, X::StridedMatrix{T})
 end
 
 function sqrtm{T<:Real}(A::StridedMatrix{T})
-    issym(A) && return sqrtm(Symmetric(A))
+    if issym(A)
+        return sqrtm(Symmetric(A))
+    end
     n = chksquare(A)
     SchurF = schurfact(complex(A))
     R = full(sqrtm(UpperTriangular(SchurF[:T])))
@@ -284,7 +289,9 @@ function sqrtm{T<:Real}(A::StridedMatrix{T})
     all(imag(retmat) .== 0) ? real(retmat) : retmat
 end
 function sqrtm{T<:Complex}(A::StridedMatrix{T})
-    ishermitian(A) && return sqrtm(Hermitian(A))
+    if ishermitian(A)
+        return sqrtm(Hermitian(A))
+    end
     n = chksquare(A)
     SchurF = schurfact(A)
     R = full(sqrtm(UpperTriangular(SchurF[:T])))

--- a/base/linalg/givens.jl
+++ b/base/linalg/givens.jl
@@ -221,13 +221,17 @@ function givensAlgorithm{T<:FloatingPoint}(f::Complex{T}, g::Complex{T})
 end
 
 function givens{T}(f::T, g::T, i1::Integer, i2::Integer)
-    i1 < i2 || throw(ArgumentError("second index must be larger than the first"))
+    if i1 >= i2
+        throw(ArgumentError("second index must be larger than the first"))
+    end
     c, s, r = givensAlgorithm(f, g)
     Givens(i1, i2, convert(T, c), convert(T, s)), r
 end
 
 function givens{T}(A::AbstractMatrix{T}, i1::Integer, i2::Integer, col::Integer)
-    i1 < i2 || throw(ArgumentError("second index must be larger than the first"))
+    if i1 >= i2
+        throw(ArgumentError("second index must be larger than the first"))
+    end
     c, s, r = givensAlgorithm(A[i1,col], A[i2,col])
     Givens(i1, i2, convert(T, c), convert(T, s)), r
 end
@@ -237,7 +241,9 @@ getindex(G::Givens, i::Integer, j::Integer) = i == j ? (i == G.i1 || i == G.i2 ?
 A_mul_B!(G1::Givens, G2::Givens) = error("Operation not supported. Consider *")
 function A_mul_B!(G::Givens, A::AbstractMatrix)
     m, n = size(A)
-    G.i2 <= m || throw(DimensionMismatch("column indices for rotation are outside the matrix"))
+    if G.i2 > m
+        throw(DimensionMismatch("column indices for rotation are outside the matrix"))
+    end
     @inbounds @simd for i = 1:n
         tmp = G.c*A[G.i1,i] + G.s*A[G.i2,i]
         A[G.i2,i] = G.c*A[G.i2,i] - conj(G.s)*A[G.i1,i]
@@ -247,7 +253,9 @@ function A_mul_B!(G::Givens, A::AbstractMatrix)
 end
 function A_mul_Bc!(A::AbstractMatrix, G::Givens)
     m, n = size(A)
-    G.i2 <= n || throw(DimensionMismatch("column indices for rotation are outside the matrix"))
+    if G.i2 > n
+        throw(DimensionMismatch("column indices for rotation are outside the matrix"))
+    end
     @inbounds @simd for i = 1:m
         tmp = G.c*A[i,G.i1] + conj(G.s)*A[i,G.i2]
         A[i,G.i2] = G.c*A[i,G.i2] - G.s*A[i,G.i1]

--- a/base/linalg/ldlt.jl
+++ b/base/linalg/ldlt.jl
@@ -34,7 +34,9 @@ factorize(S::SymTridiagonal) = ldltfact(S)
 
 function A_ldiv_B!{T}(S::LDLt{T,SymTridiagonal{T}}, B::AbstractVecOrMat{T})
     n, nrhs = size(B, 1), size(B, 2)
-    size(S,1) == n || throw(DimensionMismatch())
+    if size(S,1) != n
+        throw(DimensionMismatch("Matrix has dimensions $(size(S)) but right hand side has first dimension $n"))
+    end
     d = S.data.dv
     l = S.data.ev
     @inbounds begin

--- a/base/linalg/schur.jl
+++ b/base/linalg/schur.jl
@@ -17,10 +17,15 @@ function schurfact{T}(A::StridedMatrix{T})
 end
 
 function getindex(F::Schur, d::Symbol)
-    (d == :T || d == :Schur) && return F.T
-    (d == :Z || d == :vectors) && return F.Z
-    d == :values && return F.values
-    throw(KeyError(d))
+    if d == :T || d == :Schur
+        return F.T
+    elseif d == :Z || d == :vectors
+        return F.Z
+    elseif d == :values
+        return F.values
+    else
+        throw(KeyError(d))
+    end
 end
 
 function schur(A::StridedMatrix)
@@ -57,14 +62,23 @@ ordschur!{Ty<:BlasFloat}(gschur::GeneralizedSchur{Ty}, select::Union(Vector{Bool
 ordschur{Ty<:BlasFloat}(gschur::GeneralizedSchur{Ty}, select::Union(Vector{Bool},BitVector)) = ordschur(gschur.S, gschur.T, gschur.Q, gschur.Z, select)
 
 function getindex(F::GeneralizedSchur, d::Symbol)
-    d == :S && return F.S
-    d == :T && return F.T
-    d == :alpha && return F.alpha
-    d == :beta && return F.beta
-    d == :values && return F.alpha./F.beta
-    (d == :Q || d == :left) && return F.Q
-    (d == :Z || d == :right) && return F.Z
-    throw(KeyError(d))
+    if d == :S
+        return F.S
+    elseif d == :T
+        return F.T
+    elseif d == :alpha
+        return F.alpha
+    elseif d == :beta
+        return F.beta
+    elseif d == :values
+        return F.alpha./F.beta
+    elseif d == :Q || d == :left
+        return F.Q
+    elseif d == :Z || d == :right
+        return F.Z
+    else
+        throw(KeyError(d))
+    end
 end
 
 function schur(A::StridedMatrix, B::StridedMatrix)

--- a/base/linalg/svd.jl
+++ b/base/linalg/svd.jl
@@ -31,11 +31,17 @@ function svd(A::Union(Number, AbstractArray); thin::Bool=true)
 end
 
 function getindex(F::SVD, d::Symbol)
-    d == :U && return F.U
-    d == :S && return F.S
-    d == :Vt && return F.Vt
-    d == :V && return F.Vt'
-    throw(KeyError(d))
+    if d == :U
+        return F.U
+    elseif d == :S
+        return F.S
+    elseif d == :Vt
+        return F.Vt
+    elseif d == :V
+        return F.Vt'
+    else
+        throw(KeyError(d))
+    end
 end
 
 svdvals!{T<:BlasFloat}(A::StridedMatrix{T}) = any([size(A)...].==0) ? zeros(T, 0) : LAPACK.gesdd!('N', A)[2]
@@ -85,21 +91,26 @@ function svd(A::AbstractMatrix, B::AbstractMatrix)
 end
 
 function getindex{T}(obj::GeneralizedSVD{T}, d::Symbol)
-    d == :U && return obj.U
-    d == :V && return obj.V
-    d == :Q && return obj.Q
-    (d == :alpha || d == :a) && return obj.a
-    (d == :beta || d == :b) && return obj.b
-    (d == :vals || d == :S) && return obj.a[1:obj.k + obj.l] ./ obj.b[1:obj.k + obj.l]
-    if d == :D1
+    if d == :U
+        return obj.U
+    elseif d == :V
+        return obj.V
+    elseif d == :Q
+        return obj.Q
+    elseif d == :alpha || d == :a
+        return obj.a
+    elseif d == :beta || d == :b
+        return obj.b
+    elseif d == :vals || d == :S
+        return obj.a[1:obj.k + obj.l] ./ obj.b[1:obj.k + obj.l]
+    elseif d == :D1
         m = size(obj.U, 1)
         if m - obj.k - obj.l >= 0
             return [eye(T, obj.k) zeros(T, obj.k, obj.l); zeros(T, obj.l, obj.k) diagm(obj.a[obj.k + 1:obj.k + obj.l]); zeros(T, m - obj.k - obj.l, obj.k + obj.l)]
         else
             return [eye(T, m, obj.k) [zeros(T, obj.k, m - obj.k); diagm(obj.a[obj.k + 1:m])] zeros(T, m, obj.k + obj.l - m)]
         end
-    end
-    if d == :D2
+    elseif d == :D2
         m = size(obj.U, 1)
         p = size(obj.V, 1)
         if m - obj.k - obj.l >= 0
@@ -107,13 +118,14 @@ function getindex{T}(obj::GeneralizedSVD{T}, d::Symbol)
         else
             return [zeros(T, p, obj.k) [diagm(obj.b[obj.k + 1:m]); zeros(T, obj.k + p - m, m - obj.k)] [zeros(T, m - obj.k, obj.k + obj.l - m); eye(T, obj.k + p - m, obj.k + obj.l - m)]]
         end
-    end
-    d == :R && return obj.R
-    if d == :R0
+    elseif d == :R
+        return obj.R
+    elseif d == :R0
         n = size(obj.Q, 1)
         return [zeros(T, obj.k + obj.l, n - obj.k - obj.l) obj.R]
+    else
+        throw(KeyError(d))
     end
-    throw(KeyError(d))
 end
 
 function svdvals!{T<:BlasFloat}(A::StridedMatrix{T}, B::StridedMatrix{T})

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -23,8 +23,12 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular, :UnitUpperTr
         convert{T,S}(::Type{Matrix}, A::$t{T,S}) = convert(Matrix{T}, A)
 
         function similar{T,S,Tnew}(A::$t{T,S}, ::Type{Tnew}, dims::Dims)
-            dims[1] == dims[2] || throw(ArgumentError("Triangular matrix must be square"))
-            length(dims) == 2 || throw(ArgumentError("Triangular matrix must have two dimensions"))
+            if dims[1] != dims[2]
+                throw(ArgumentError("Triangular matrix must be square"))
+            end
+            if length(dims) != 2
+                throw(ArgumentError("Triangular matrix must have two dimensions"))
+            end
             B = similar(A.data, Tnew, dims)
             return $t(B)
         end
@@ -226,9 +230,9 @@ for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
         # Condition numbers
         function cond{T<:BlasFloat,S}(A::$t{T,S}, p::Real=2)
             chksquare(A)
-            if p==1
+            if p == 1
                 return inv(LAPACK.trcon!('O', $uploc, $isunitc, A.data))
-            elseif p==Inf
+            elseif p == Inf
                 return inv(LAPACK.trcon!('I', $uploc, $isunitc, A.data))
             else #use fallback
                 return cond(full(A), p)
@@ -315,7 +319,9 @@ end
 ## Generic triangular multiplication
 function A_mul_B!(A::UpperTriangular, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
-    m == size(A, 1) || throw(DimensionMismatch("left and right hand side does not fit"))
+    if m != size(A, 1)
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for j = 1:n
         for i = 1:m
             Bij = A.data[i,i]*B[i,j]
@@ -329,7 +335,9 @@ function A_mul_B!(A::UpperTriangular, B::StridedVecOrMat)
 end
 function A_mul_B!(A::UnitUpperTriangular, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
-    m == size(A, 1) || throw(DimensionMismatch("left and right hand side does not fit"))
+    if m != size(A, 1)
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for j = 1:n
         for i = 1:m
             Bij = B[i,j]
@@ -344,7 +352,9 @@ end
 
 function A_mul_B!(A::LowerTriangular, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
-    m == size(A, 1) || throw(DimensionMismatch("left and right hand side does not fit"))
+    if m != size(A, 1)
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for j = 1:n
         for i = m:-1:1
             Bij = A.data[i,i]*B[i,j]
@@ -358,7 +368,9 @@ function A_mul_B!(A::LowerTriangular, B::StridedVecOrMat)
 end
 function A_mul_B!(A::UnitLowerTriangular, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
-    m == size(A, 1) || throw(DimensionMismatch("left and right hand side does not fit"))
+    if m != size(A, 1)
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for j = 1:n
         for i = m:-1:1
             Bij = B[i,j]
@@ -373,7 +385,9 @@ end
 
 function Ac_mul_B!(A::UpperTriangular, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
-    m == size(A, 1) || throw(DimensionMismatch("left and right hand side does not fit"))
+    if m != size(A, 1)
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for j = 1:n
         for i = m:-1:1
             Bij = A.data[i,i]*B[i,j]
@@ -387,7 +401,9 @@ function Ac_mul_B!(A::UpperTriangular, B::StridedVecOrMat)
 end
 function Ac_mul_B!(A::UnitUpperTriangular, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
-    m == size(A, 1) || throw(DimensionMismatch("left and right hand side does not fit"))
+    if m != size(A, 1)
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for j = 1:n
         for i = m:-1:1
             Bij = B[i,j]
@@ -402,7 +418,9 @@ end
 
 function Ac_mul_B!(A::LowerTriangular, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
-    m == size(A, 1) || throw(DimensionMismatch("left and right hand side does not fit"))
+    if m != size(A, 1)
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for j = 1:n
         for i = 1:m
             Bij = A.data[i,i]*B[i,j]
@@ -416,7 +434,9 @@ function Ac_mul_B!(A::LowerTriangular, B::StridedVecOrMat)
 end
 function Ac_mul_B!(A::UnitLowerTriangular, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
-    m == size(A, 1) || throw(DimensionMismatch("left and right hand side does not fit"))
+    if m != size(A, 1)
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for j = 1:n
         for i = 1:m
             Bij = B[i,j]
@@ -431,7 +451,9 @@ end
 
 function A_mul_B!(A::StridedMatrix, B::UpperTriangular)
     m, n = size(A)
-    size(B, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(B, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = n:-1:1
             Aij = A[i,j]*B[j,j]
@@ -445,7 +467,9 @@ function A_mul_B!(A::StridedMatrix, B::UpperTriangular)
 end
 function A_mul_B!(A::StridedMatrix, B::UnitUpperTriangular)
     m, n = size(A)
-    size(B, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(B, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = n:-1:1
             Aij = A[i,j]
@@ -460,7 +484,9 @@ end
 
 function A_mul_B!(A::StridedMatrix, B::LowerTriangular)
     m, n = size(A)
-    size(B, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(B, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = 1:n
             Aij = A[i,j]*B[j,j]
@@ -474,7 +500,9 @@ function A_mul_B!(A::StridedMatrix, B::LowerTriangular)
 end
 function A_mul_B!(A::StridedMatrix, B::UnitLowerTriangular)
     m, n = size(A)
-    size(B, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(B, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = 1:n
             Aij = A[i,j]
@@ -489,7 +517,9 @@ end
 
 function A_mul_Bc!(A::StridedMatrix, B::UpperTriangular)
     m, n = size(A)
-    size(B, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(B, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = 1:n
             Aij = A[i,j]*B[j,j]
@@ -503,7 +533,9 @@ function A_mul_Bc!(A::StridedMatrix, B::UpperTriangular)
 end
 function A_mul_Bc!(A::StridedMatrix, B::UnitUpperTriangular)
     m, n = size(A)
-    size(B, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(B, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = 1:n
             Aij = A[i,j]
@@ -518,7 +550,9 @@ end
 
 function A_mul_Bc!(A::StridedMatrix, B::LowerTriangular)
     m, n = size(A)
-    size(B, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(B, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = n:-1:1
             Aij = A[i,j]*B[j,j]
@@ -532,7 +566,9 @@ function A_mul_Bc!(A::StridedMatrix, B::LowerTriangular)
 end
 function A_mul_Bc!(A::StridedMatrix, B::UnitLowerTriangular)
     m, n = size(A)
-    size(B, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(B, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = n:-1:1
             Aij = A[i,j]
@@ -548,7 +584,9 @@ end
 #Generic solver using naive substitution
 function naivesub!(A::UpperTriangular, b::AbstractVector, x::AbstractVector=b)
     n = size(A, 2)
-    n == length(b) == length(x) || throw(DimensionMismatch())
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("Second dimension of A, $n, length of x, $(length(x)), and length of b, $(length(b)) must be equal"))
+    end
     for j = n:-1:1
         xj = b[j]
         for k = j+1:1:n
@@ -565,7 +603,9 @@ function naivesub!(A::UpperTriangular, b::AbstractVector, x::AbstractVector=b)
 end
 function naivesub!(A::UnitUpperTriangular, b::AbstractVector, x::AbstractVector=b)
     n = size(A, 2)
-    n == length(b) == length(x) || throw(DimensionMismatch())
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("Second dimension of A, $n, length of x, $(length(x)), and length of b, $(length(b)) must be equal"))
+    end
     for j = n:-1:1
         xj = b[j]
         for k = j+1:1:n
@@ -577,7 +617,9 @@ function naivesub!(A::UnitUpperTriangular, b::AbstractVector, x::AbstractVector=
 end
 function naivesub!(A::LowerTriangular, b::AbstractVector, x::AbstractVector=b)
     n = size(A, 2)
-    n == length(b) == length(x) || throw(DimensionMismatch())
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("Second dimension of A, $n, length of x, $(length(x)), and length of b, $(length(b)) must be equal"))
+    end
     for j = 1:n
         xj = b[j]
         for k = 1:j-1
@@ -594,7 +636,9 @@ function naivesub!(A::LowerTriangular, b::AbstractVector, x::AbstractVector=b)
 end
 function naivesub!(A::UnitLowerTriangular, b::AbstractVector, x::AbstractVector=b)
     n = size(A, 2)
-    n == length(b) == length(x) || throw(DimensionMismatch())
+    if !(n == length(b) == length(x))
+        throw(DimensionMismatch("Second dimension of A, $n, length of x, $(length(x)), and length of b, $(length(b)) must be equal"))
+    end
     for j = 1:n
         xj = b[j]
         for k = 1:j-1
@@ -607,7 +651,9 @@ end
 
 function A_rdiv_B!(A::StridedMatrix, B::UpperTriangular)
     m, n = size(A)
-    size(A, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(A, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = 1:n
             Aij = A[i,j]
@@ -621,7 +667,9 @@ function A_rdiv_B!(A::StridedMatrix, B::UpperTriangular)
 end
 function A_rdiv_B!(A::StridedMatrix, B::UnitUpperTriangular)
     m, n = size(A)
-    size(A, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(A, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = 1:n
             Aij = A[i,j]
@@ -636,7 +684,9 @@ end
 
 function A_rdiv_B!(A::StridedMatrix, B::LowerTriangular)
     m, n = size(A)
-    size(A, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(A, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = n:-1:1
             Aij = A[i,j]
@@ -650,7 +700,9 @@ function A_rdiv_B!(A::StridedMatrix, B::LowerTriangular)
 end
 function A_rdiv_B!(A::StridedMatrix, B::UnitLowerTriangular)
     m, n = size(A)
-    size(A, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(A, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = n:-1:1
             Aij = A[i,j]
@@ -665,7 +717,9 @@ end
 
 function A_rdiv_Bc!(A::StridedMatrix, B::UpperTriangular)
     m, n = size(A)
-    size(A, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(A, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = n:-1:1
             Aij = A[i,j]
@@ -679,7 +733,9 @@ function A_rdiv_Bc!(A::StridedMatrix, B::UpperTriangular)
 end
 function A_rdiv_Bc!(A::StridedMatrix, B::UnitUpperTriangular)
     m, n = size(A)
-    size(A, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(A, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = n:-1:1
             Aij = A[i,j]
@@ -694,7 +750,9 @@ end
 
 function A_rdiv_Bc!(A::StridedMatrix, B::LowerTriangular)
     m, n = size(A)
-    size(A, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(A, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = 1:n
             Aij = A[i,j]
@@ -708,7 +766,9 @@ function A_rdiv_Bc!(A::StridedMatrix, B::LowerTriangular)
 end
 function A_rdiv_Bc!(A::StridedMatrix, B::UnitLowerTriangular)
     m, n = size(A)
-    size(A, 1) == n || throw(DimensionMismatch("left and right hand side does not fit"))
+    if size(A, 1) != n
+        throw(DimensionMismatch("left and right hand side does not fit"))
+    end
     for i = 1:m
         for j = 1:n
             Aij = A[i,j]
@@ -869,8 +929,11 @@ sqrtm(A::UnitLowerTriangular) = sqrtm(A.').'
 eigvals(A::AbstractTriangular) = diag(A)
 function eigvecs{T}(A::AbstractTriangular{T})
     TT = promote_type(T, Float32)
-    TT <: BlasFloat && return eigvecs(convert(AbstractMatrix{TT}, A))
-    throw(ArgumentError("eigvecs type $(typeof(A)) not supported. Please submit a pull request."))
+    if TT <: BlasFloat
+        return eigvecs(convert(AbstractMatrix{TT}, A))
+    else
+        throw(ArgumentError("eigvecs type $(typeof(A)) not supported. Please submit a pull request."))
+    end
 end
 det{T}(A::UnitUpperTriangular{T}) = one(T)*one(T)
 det{T}(A::UnitLowerTriangular{T}) = one(T)*one(T)
@@ -887,4 +950,3 @@ for func in (:svd, :svdfact, :svdfact!, :svdvals)
 end
 
 factorize(A::AbstractTriangular) = A
-

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -53,7 +53,15 @@ ctranspose(M::SymTridiagonal) = conj(M)
 
 function diag{T}(M::SymTridiagonal{T}, n::Integer=0)
     absn = abs(n)
-    absn==0 ? M.dv : absn==1 ? M.ev : absn<size(M,1) ? zeros(T,size(M,1)-absn) : throw(BoundsError())
+    if absn == 0
+        return M.dv
+    elseif absn==1
+        return M.ev
+    elseif absn<size(M,1)
+        return zeros(T,size(M,1)-absn)
+    else
+        throw(BoundsError("$n-th diagonal of a $(size(M)) matrix doesn't exist!"))
+    end
 end
 
 +(A::SymTridiagonal, B::SymTridiagonal) = SymTridiagonal(A.dv+B.dv, A.ev+B.ev)
@@ -65,8 +73,12 @@ end
 
 function A_mul_B!(C::StridedVecOrMat, S::SymTridiagonal, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
-    m == size(S, 1) == size(C, 1) || throw(DimensionMismatch())
-    n == size(C, 2) || throw(DimensionMismatch())
+    if !(m == size(S, 1) == size(C, 1))
+        throw(DimensionMismatch("A has first dimension $(size(A,1)), B has $(size(B,1)), C has $(size(C,1)) but all must match"))
+    end
+    if n != size(C, 2)
+        throw(DimensionMismatch("Second dimension of B, $n, doesn't match second dimension of C, $(size(C,2))"))
+    end
 
     α = S.dv
     β = S.ev
@@ -166,7 +178,9 @@ end
 function det_usmani{T}(a::Vector{T}, b::Vector{T}, c::Vector{T})
     n = length(b)
     θa = one(T)
-    n==0 && return θa
+    if n == 0
+        return θa
+    end
     θb = b[1]
     for i=2:n
         θb, θa = b[i]*θb-a[i-1]*c[i-1]*θa, θb
@@ -178,8 +192,18 @@ inv(A::SymTridiagonal) = inv_usmani(A.ev, A.dv, A.ev)
 det(A::SymTridiagonal) = det_usmani(A.ev, A.dv, A.ev)
 
 function getindex{T}(A::SymTridiagonal{T}, i::Integer, j::Integer)
-    (1<=i<=size(A,2) && 1<=j<=size(A,2)) || throw(BoundsError())
-    i==j ? A.dv[i] : i==j+1 ? A.ev[j] : i+1==j ? A.ev[i] : zero(T)
+    if !(1 <= i <= size(A,2) && 1 <= j <= size(A,2))
+        throw(BoundsError("(i,j) = ($i,$j) not within matrix of size $(size(A))"))
+    end
+    if i == j
+        return A.dv[i]
+    elseif i == j + 1
+        return A.ev[j]
+    elseif i + 1 == j
+        return A.ev[i]
+    else
+        return zero(T)
+    end
 end
 
 ## Tridiagonal matrices ##
@@ -201,7 +225,15 @@ function Tridiagonal{Tl, Td, Tu}(dl::Vector{Tl}, d::Vector{Td}, du::Vector{Tu})
 end
 
 size(M::Tridiagonal) = (length(M.d), length(M.d))
-size(M::Tridiagonal, d::Integer) = d<1 ? throw(ArgumentError("dimension d must be ≥ 1, got $d")) : (d<=2 ? length(M.d) : 1)
+function size(M::Tridiagonal, d::Integer)
+    if d < 1
+        throw(ArgumentError("dimension d must be ≥ 1, got $d"))
+    elseif d <= 2
+        return length(M.d)
+    else
+        return 1
+    end
+end
 
 full{T}(M::Tridiagonal{T}) = convert(Matrix{T}, M)
 function convert{T}(::Type{Matrix{T}}, M::Tridiagonal{T})
@@ -243,8 +275,18 @@ ctranspose(M::Tridiagonal) = conj(transpose(M))
 
 diag{T}(M::Tridiagonal{T}, n::Integer=0) = n==0 ? M.d : n==-1 ? M.dl : n==1 ? M.du : abs(n)<size(M,1) ? zeros(T,size(M,1)-abs(n)) : throw(BoundsError())
 function getindex{T}(A::Tridiagonal{T}, i::Integer, j::Integer)
-    (1<=i<=size(A,2) && 1<=j<=size(A,2)) || throw(BoundsError())
-    i==j ? A.d[i] : i==j+1 ? A.dl[j] : i+1==j ? A.du[i] : zero(T)
+    if !(1 <= i <= size(A,2) && 1 <= j <= size(A,2))
+        throw(BoundsError("(i,j) = ($i,$j) not within matrix of size $(size(A))"))
+    end
+    if i == j
+        return A.d[i]
+    elseif i == j + 1
+        return A.dl[j]
+    elseif i + 1 == j
+        return A.du[i]
+    else
+        return zero(T)
+    end
 end
 
 ###################
@@ -279,8 +321,14 @@ convert{T}(::Type{SymTridiagonal{T}}, M::Tridiagonal) = M.dl==M.du ? (SymTridiag
 convert{T}(::Type{SymTridiagonal{T}},M::SymTridiagonal) = SymTridiagonal(convert(Vector{T}, M.dv), convert(Vector{T}, M.ev))
 
 function A_mul_B!(C::AbstractVecOrMat, A::Tridiagonal, B::AbstractVecOrMat)
-    size(C,1) == size(B,1) == (nA = size(A,1)) || throw(DimensionMismatch())
-    size(C,2) == (nB = size(B,2)) || throw(DimensionMismatch())
+    nA = size(A,1)
+    nB = size(B,2)
+    if !(size(C,1) == size(B,1) == nA)
+        throw(DimensionMismatch("A has first dimension $nA, B has $(size(B,1)), C has $(size(C,1)) but all must match"))
+    end
+    if size(C,2) != nB
+        throw(DimensionMismatch("A has second dimension $nA, B has $(size(B,2)), C has $(size(C,2)) but all must match"))
+    end
     l = A.dl
     d = A.d
     u = A.du


### PR DESCRIPTION
This series of commits removes many likes like
`n == nA || throw(DimensionMismatch())`
both so that we can more easily see if the error throwing is tested for in coverage runs, and so that the source is easier to read (some of these functions had five nested ternary operators in them). I also added many more verbose errors for `DimensionMismatch` and `BoundsError` so that the user can see, for instance, that the first dimensions of input matrices didn't match and what those dimensions were.
