### PR TITLE
Throw a parser error to disambiguate numeric literals followed by .(op)

### DIFF
--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -114,7 +114,7 @@ function eupd_wrapper(T, n::Integer, sym::Bool, cmplx::Bool, bmat::ASCIIString,
 
     dmap = x->abs(x)
     if iparam[7] == 3 # shift-and-invert
-        dmap = x->abs(1./(x-sigma))
+        dmap = x->abs(1 ./ (x-sigma))
     elseif which == "LR" || which == "LA" || which == "BE"
         dmap = x->real(x)
     elseif which == "SR" || which == "SA"

--- a/base/range.jl
+++ b/base/range.jl
@@ -244,7 +244,7 @@ function show(io::IO, r::LinSpace)
     print(io, ')')
 end
 
-logspace(start::Real, stop::Real, n::Integer=50) = 10.^linspace(start, stop, n)
+logspace(start::Real, stop::Real, n::Integer=50) = 10 .^ linspace(start, stop, n)
 
 ## interface implementations
 

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -497,7 +497,7 @@ function quantile!(v::AbstractVector, q::AbstractVector)
     i = find(index .> lo)
     r = float(v[lo])
     h = (index.-lo)[i]
-    r[i] = (1.-h).*r[i] + h.*v[hi[i]]
+    r[i] = (1 .- h).*r[i] + h.*v[hi[i]]
     return r
 end
 quantile(v::AbstractVector, q::AbstractVector) = quantile!(copy(v),q)

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -280,7 +280,7 @@
     (if (eqv? (peek-char port) #\.)
         (begin (read-char port)
                (if (dot-opchar? (peek-char port))
-                   (io.ungetc port #\.)
+                   (error "add disambiguating space between numeric literal and infix dot operator")
                    (begin (write-char #\. str)
                           (read-digs #f)
                           (if (eq? pred char-hex?)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -14,22 +14,22 @@ b = a+a
 @test length((1,)) == 1
 @test length((1,2)) == 2
 
-@test isequal(1.+[1,2,3], [2,3,4])
-@test isequal([1,2,3].+1, [2,3,4])
-@test isequal(1.-[1,2,3], [0,-1,-2])
-@test isequal([1,2,3].-1, [0,1,2])
+@test isequal(1 .+ [1,2,3], [2,3,4])
+@test isequal([1,2,3] .+ 1, [2,3,4])
+@test isequal(1 .- [1,2,3], [0,-1,-2])
+@test isequal([1,2,3] .- 1, [0,1,2])
 
-@test isequal(5*[1,2,3], [5,10,15])
-@test isequal([1,2,3]*5, [5,10,15])
-@test isequal(1./[1,2,5], [1.0,0.5,0.2])
-@test isequal([1,2,3]/5, [0.2,0.4,0.6])
+@test isequal(5 * [1,2,3], [5,10,15])
+@test isequal([1,2,3] * 5, [5,10,15])
+@test isequal(1 ./ [1,2,5], [1.0,0.5,0.2])
+@test isequal([1,2,3] / 5, [0.2,0.4,0.6])
 
-@test isequal(1.<<[1,2,5], [2,4,32])
-@test isequal(128.>>[1,2,5], [64,32,4])
-@test isequal(2.>>1, 1)
-@test isequal(1.<<1, 2)
-@test isequal([1,2,5].<<[1,2,5], [2,8,160])
-@test isequal([10,20,50].>>[1,2,5], [5,5,1])
+@test isequal(1 .<< [1,2,5], [2,4,32])
+@test isequal(128 .>> [1,2,5], [64,32,4])
+@test isequal(2 .>> 1, 1)
+@test isequal(1 .<< 1, 2)
+@test isequal([1,2,5] .<< [1,2,5], [2,8,160])
+@test isequal([10,20,50] .>> [1,2,5], [5,5,1])
 
 
 a = ones(2,2)
@@ -792,7 +792,7 @@ for idx in Any[1, 2, 5, 9, 10, 1:0, 2:1, 1:1, 2:2, 1:2, 2:4, 9:8, 10:9, 9:9, 10:
 end
 a = [1:10;]
 @test deleteat!(a, 11:10) == [1:10;]
-@test deleteat!(a, [1,3,5,7:10...]) == [2,4,6]
+@test deleteat!(a, [1,3,5,(7:10)...]) == [2,4,6]
 @test_throws BoundsError deleteat!(a, 13)
 @test_throws BoundsError deleteat!(a, [1,13])
 @test_throws ArgumentError deleteat!(a, [5,3])
@@ -813,8 +813,8 @@ end
 @test isequal([1,2,3], [a for (a,b) in enumerate(2:4)])
 @test isequal([2,3,4], [b for (a,b) in enumerate(2:4)])
 
-@test_throws DomainError (10.^[-1])[1] == 0.1
-@test (10.^[-1.])[1] == 0.1
+@test_throws DomainError (10 .^ [-1])[1] == 0.1
+@test (10 .^ [-1.])[1] == 0.1
 
 # reverse
 @test reverse([2,3,1]) == [1,3,2]

--- a/test/linalg2.jl
+++ b/test/linalg2.jl
@@ -256,7 +256,7 @@ for elty in (Float32, Float64, BigFloat, Complex{Float32}, Complex{Float64}, Com
 
         # Against vectorized versions
         @test_approx_eq norm(x,-Inf) minimum(abs(x))
-        @test_approx_eq norm(x,-1) inv(sum(1./abs(x)))
+        @test_approx_eq norm(x,-1) inv(sum(1 ./ abs(x)))
         @test_approx_eq norm(x,0) sum(x .!= 0)
         @test_approx_eq norm(x,1) sum(abs(x))
         @test_approx_eq norm(x) sqrt(sum(abs2(x)))
@@ -388,7 +388,7 @@ T = LowerTriangular(randn(3,3))
 ## Issue related tests
 # issue #1447
 let
-    A = [1.+0.im 0; 0 1]
+    A = [1.0+0.0im 0; 0 1]
     B = pinv(A)
     for i = 1:4
         @test_approx_eq A[i] B[i]

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -2,9 +2,9 @@
 
 # issue #9684
 let
-    for (ex1, ex2) in [("5.≠x", "5.!=x"),
-                       ("5.≥x", "5.>=x"),
-                       ("5.≤x", "5.<=x")]
+    for (ex1, ex2) in [("5 .≠ x", "5 .!= x"),
+                       ("5 .≥ x", "5 .>= x"),
+                       ("5 .≤ x", "5 .<= x")]
         ex1 = parse(ex1); ex2 = parse(ex2)
         @test ex1.head === :comparison && (ex1.head === ex2.head)
         @test ex1.args[1] === 5 && ex2.args[1] === 5


### PR DESCRIPTION
This _breaking_ change throws a parser error asking the user to
disambiguate the parsing of a numeric literal and dot operator with no
whitespace in between.  We are consistent in how this is handled (always
favor the operator in parsing with no disambiguating whitespace), but
there was popular support that this should be special cased as it it
quite hard to track these subtle syntax errors down.

Closes #10920
