### PR TITLE
Exceed reader limits

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -467,8 +467,7 @@ end
 function readbytes(cmd::AbstractCmd, stdin::AsyncStream=DevNull)
     (out,pc) = open(cmd, "r", stdin)
     !success(pc) && pipeline_error(pc)
-    wait_close(out)
-    return takebuf_array(out.buffer)
+    return readbytes(out)
 end
 
 function readall(cmd::AbstractCmd, stdin::AsyncStream=DevNull)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -402,6 +402,7 @@ function _uv_hook_readcb(stream::AsyncStream, nread::Int, base::Ptr{Void}, len::
             # close function won't work and libuv will fail with an assertion failure
             ccall(:jl_forceclose_uv,Void,(Ptr{Void},),stream.handle)
             notify_error(stream.readnotify, UVError("readcb",nread))
+            notify_error(stream.closenotify, UVError("readcb",nread))
         else
             if isa(stream,TTY)
                 stream.status = StatusEOF

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -662,6 +662,14 @@ function stop_reading(stream::AsyncStream)
     end
 end
 
+function readbytes(stream::AsyncStream)
+    while isopen(stream)
+        start_reading(stream)
+        stream_wait(stream, stream.readnotify)
+    end
+    return takebuf_array(stream.buffer)
+end
+
 function readall(stream::AsyncStream)
     while isopen(stream)
         start_reading(stream)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -663,8 +663,10 @@ function stop_reading(stream::AsyncStream)
 end
 
 function readall(stream::AsyncStream)
-    start_reading(stream)
-    wait_close(stream)
+    while isopen(stream)
+        start_reading(stream)
+        stream_wait(stream, stream.readnotify)
+    end
     return takebuf_string(stream.buffer)
 end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -671,11 +671,7 @@ function readbytes(stream::AsyncStream)
 end
 
 function readall(stream::AsyncStream)
-    while isopen(stream)
-        start_reading(stream)
-        stream_wait(stream, stream.readnotify)
-    end
-    return takebuf_string(stream.buffer)
+    return bytestring(readbytes(stream))
 end
 
 function read!{T}(s::AsyncStream, a::Array{T})

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -266,9 +266,9 @@ Base.wait_readnb(master,1)
 write(master,"1\nquit()\n")
 
 wait(p)
+output = bytestring(readavailable(master))
 
 ccall(:close,Cint,(Cint,),fds)
-output = readall(master)
 if ccall(:jl_running_on_valgrind,Cint,()) == 0
     @test output == "julia> 1\r\nquit()\r\n1\r\n\r\njulia> "
 end


### PR DESCRIPTION
Possible fix for #10282, #10655.

This introduces `readbytes(cmd::AsyncStream)`. Is it bad form to introduce new methods in a bugfix?

No tests. Sorry.
