### PR TITLE
Control worker startup timeout via an env variable

### DIFF
--- a/base/managers.jl
+++ b/base/managers.jl
@@ -99,7 +99,9 @@ function launch_on_machine(manager::SSHManager, machine, cnt, params, launched, 
     host = machine_def[1]
 
     # Build up the ssh command
-    cmd = `cd $dir && $exename $exeflags` # launch julia
+    tval = haskey(ENV, "JULIA_WORKER_TIMEOUT") ? `export JULIA_WORKER_TIMEOUT=$(ENV["JULIA_WORKER_TIMEOUT"]);` : ``
+
+    cmd = `cd $dir && $tval $exename $exeflags` # launch julia
     cmd = `sh -l -c $(shell_escape(cmd))` # shell to launch under
     cmd = `ssh -T -a -x -o ClearAllForwardings=yes -n $sshflags $host $(shell_escape(cmd))` # use ssh to remote launch
 

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -991,7 +991,7 @@ function start_worker(out::IO)
         # To prevent hanging processes on remote machines, newly launched workers exit if the
         # master process does not connect in time.
         # TODO : Make timeout configurable.
-        check_master_connect(60.0)
+        check_master_connect(parse(Float64, get(ENV, "JULIA_WORKER_TIMEOUT", "60.0")))
         while true; wait(); end
     catch err
         print(STDERR, "unhandled exception on $(myid()): $(err)\nexiting.\n")

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -158,6 +158,13 @@ General Parallel Computing Support
 
    ``exeflags`` :  additional flags passed to the worker processes.
 
+   Environment variables :
+
+   If the master process fails to establish a connection with a newly launched worker within 60.0 seconds,
+   the worker treats it a fatal situation and terminates. This timeout can be controlled via environment
+   variable ``JULIA_WORKER_TIMEOUT``. The value of ``JULIA_WORKER_TIMEOUT`` on the master process, specifies
+   the number of seconds a newly launched worker waits for connection establishment.
+
 
 .. function:: addprocs(manager::ClusterManager; kwargs...) -> List of process identifiers
 
@@ -165,6 +172,10 @@ General Parallel Computing Support
 
    For example Beowulf clusters are  supported via a custom cluster manager implemented
    in  package ``ClusterManagers``.
+
+   The number of seconds a newly launched worker waits for connection establishment from the master can be
+   specified via variable ``JULIA_WORKER_TIMEOUT`` in the worker process's environment. Relevant only when
+   using TCP/IP as transport.
 
 
 .. function:: nprocs()


### PR DESCRIPTION
Currently, worker processes wait upto 60.0 seconds for the master process to connect upon launch, and terminate if the master fails to do so.  It has been noticed that this is not sufficient in certain cases.

This PR makes this timeout configurable via env variable `JWORKER_TIMEOUT` . Default value continue to be 60.0 seconds. Custom cluster managers  can specify this in the worker's env while launching a worker. For SSHManager,  `JWORKER_TIMEOUT` is picked up from master process's  env, if defined.

The alternative to using an env variable was to have it specified as a julia exe option, which I wanted to avoid.

cc @andreasnoack 
