### PR TITLE
In docs, consider expressions like `x.y` to be names (fix #11548)

### DIFF
--- a/base/docs.jl
+++ b/base/docs.jl
@@ -150,7 +150,7 @@ end
 
 uncurly(ex) = isexpr(ex, :curly) ? ex.args[1] : ex
 
-namify(ex::Expr) = namify(ex.args[1])
+namify(ex::Expr) = isexpr(ex, :.)? ex : namify(ex.args[1])
 namify(sy::Symbol) = sy
 
 function mdify(ex)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -8,3 +8,15 @@ macro macro_doctest() end
 @doc "Helps test if macros can be documented with `@doc \"...\" -> @...`." ->
 @macro_doctest
 @test (@doc @macro_doctest) != nothing
+
+# issue #11548
+
+module ModuleMacroDoc
+macro m() end
+end
+
+@doc ("I am a module";) ModuleMacroDoc
+@doc ("I am a macro";)  ModuleMacroDoc.@m
+
+@test (@doc ModuleMacroDoc)    == "I am a module"
+@test (@doc ModuleMacroDoc.@m) == "I am a macro"


### PR DESCRIPTION
Q: Is there a possibility that forms like `macro M.m() end` will ever be valid? Because this code will break then :P Should I prepare for that or is it not necessary?
