### PR TITLE
define getindex on regex matches to return captures.

### DIFF
--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -697,6 +697,16 @@ use destructuring syntax to bind them to local variables::
     julia> first, second, third = m.captures; first
     "a"
 
+Captures can also be accessed by indexing the :obj:`RegexMatch` object
+with the number or name of the capture group::
+
+    julia> m=match(r"(?P<hour>\d+):(?P<minute>\d+)","12:45")
+    RegexMatch("12:45", hour="12", minute="45")
+    julia> m[:minute]
+    "45"
+    julia> m[2]
+    "45"
+
 You can modify the behavior of regular expressions by some combination
 of the flags ``i``, ``m``, ``s``, and ``x`` after the closing double
 quote mark. These flags have the same meaning as they do in Perl, as

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -37,3 +37,7 @@ show(buf, r"")
 # regex match / search string must be a ByteString
 @test_throws ArgumentError match(r"test", utf32("this is a test"))
 @test_throws ArgumentError search(utf32("this is a test"), r"test")
+
+# Named subpatterns
+m = match(r"(?<a>.)(.)(?<b>.)", "xyz")
+@test (m["a"], m[2], m["b"]) == ("x", "y", "z")

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -41,3 +41,4 @@ show(buf, r"")
 # Named subpatterns
 m = match(r"(?<a>.)(.)(?<b>.)", "xyz")
 @test (m[:a], m[2], m["b"]) == ("x", "y", "z")
+@test sprint(show, m) == "RegexMatch(\"xyz\", a=\"x\", 2=\"y\", b=\"z\")"

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -40,4 +40,4 @@ show(buf, r"")
 
 # Named subpatterns
 m = match(r"(?<a>.)(.)(?<b>.)", "xyz")
-@test (m["a"], m[2], m["b"]) == ("x", "y", "z")
+@test (m[:a], m[2], m["b"]) == ("x", "y", "z")


### PR DESCRIPTION
Two non-breaking changes to regular expressions related to named capture groups:
- Showing a match object on the REPL will display the name of a named capture group instead of its index
- `getindex` on a match object returns the captured substring. The index can either be an integer, in which case it indicates the position of the capture group in the original regex, or a string, in which case it corresponds to the name of a capture group. 

This introduces no additional overhead to `match`, since the mapping between capture group names and indices is only computed once, when the regular expression is first compiled. This should address @StefanKarpinski's concern about constructing a `Dict` for every `RegexMatch` object.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/julialang/julia/11566)

<!-- Reviewable:end -->
