### PR TITLE
RFC: use an `instances` function for enums

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -94,12 +94,10 @@ macro enum(T,syms...)
         end
         Base.typemin(x::Type{$(esc(typename))}) = $(esc(typename))($lo)
         Base.typemax(x::Type{$(esc(typename))}) = $(esc(typename))($hi)
-        Base.length(x::Type{$(esc(typename))}) = $(length(vals))
-        Base.start(::Type{$(esc(typename))}) = 1
-        Base.next(x::Type{$(esc(typename))},s) = ($(esc(typename))($values[s]),s+1)
-        Base.done(x::Type{$(esc(typename))},s) = s > $(length(values))
-        Base.names(x::Type{$(esc(typename))}) = [$(map(x->Expr(:quote, (x[1])), vals)...)]
         Base.isless(x::$(esc(typename)), y::$(esc(typename))) = isless(x.val, y.val)
+        let insts = ntuple(i->$(esc(typename))($values[i]), $(length(vals)))
+            Base.instances(::Type{$(esc(typename))}) = insts
+        end
         function Base.print(io::IO,x::$(esc(typename)))
             for (sym, i) in $vals
                 if i == x.val

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1046,6 +1046,7 @@ export
     promote_rule,
     promote_type,
     subtypes,
+    instances,
     super,
     typeintersect,
     typejoin,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -81,6 +81,9 @@ end
 type_alignment(x::DataType) = ccall(:jl_get_alignment,Csize_t,(Any,),x)
 field_offset(x::DataType,idx) = ccall(:jl_get_field_offset,Csize_t,(Any,Int32),x,idx)
 
+# return all instances, for types that can be enumerated
+function instances end
+
 # subtypes
 function _subtypes(m::Module, x::DataType, sts=Set(), visited=Set())
     push!(visited, m)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -482,6 +482,11 @@ Types
       julia> f(apple)
       "I'm a FRUIT with value: 1"
 
+.. function:: instances(T::Type)
+
+   Return a collection of all instances of the given type, if applicable.
+   Mostly used for enumerated types (see ``@enum``).
+
 Generic Functions
 -----------------
 

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -27,13 +27,6 @@ using Base.Test
 @test Fruit(0x00) == apple
 @test Fruit(big(0)) == apple
 @test_throws MethodError Fruit(0.0)
-@test start(Fruit) == 1
-@test next(Fruit,1) == (apple,2)
-@test next(Fruit,2) == (orange,3)
-@test next(Fruit,3) == (kiwi,4)
-@test !done(Fruit,3)
-@test done(Fruit,4)
-@test length(Fruit) == 3
 @test typemin(Fruit) == apple
 @test typemax(Fruit) == kiwi
 @test convert(Fruit,0) == apple
@@ -49,7 +42,7 @@ using Base.Test
 @test convert(Bool,apple) == false
 @test convert(Bool,orange) == true
 @test_throws InexactError convert(Bool,kiwi)
-@test names(Fruit) == [:apple, :orange, :kiwi]
+@test instances(Fruit) == (apple, orange, kiwi)
 
 f(x::Fruit) = "hey, I'm a Fruit"
 @test f(apple) == "hey, I'm a Fruit"
@@ -59,12 +52,12 @@ d = Dict(apple=>"apple",orange=>"orange",kiwi=>"kiwi")
 @test d[orange] == "orange"
 @test d[kiwi] == "kiwi"
 vals = [apple,orange,kiwi]
-for (i,enum) in enumerate(Fruit)
+for (i,enum) in enumerate(instances(Fruit))
     @test enum == vals[i]
 end
 
 @enum(QualityofFrenchFood, ReallyGood)
-@test length(QualityofFrenchFood) == 1
+@test length(instances(QualityofFrenchFood)) == 1
 @test typeof(ReallyGood) <: QualityofFrenchFood <: Enum
 @test Int(ReallyGood) == 0
 
@@ -95,7 +88,7 @@ end
 @enum Test3 _one_Test3=0x01 _two_Test3=0x02 _three_Test3=0x03
 @test typeof(_one_Test3.val) <: UInt8
 @test _one_Test3.val === 0x01
-@test length(Test3) == 3
+@test length(instances(Test3)) == 3
 
 @enum Test4 _one_Test4=0x01 _two_Test4=0x0002 _three_Test4=0x03
 @test _one_Test4.val === 0x0001


### PR DESCRIPTION
...instead of making the types iterable. I prefer this approach, since there is much less confusion between values and types. In passing, it also fixes #10693 (though not the underlying cause).
