### PR TITLE
Gcframe codegen cleanup

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1161,7 +1161,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     }
 
     // save argument depth until after we're done emitting arguments
-    int last_depth = ctx->argDepth;
+    int last_depth = ctx->gc.argDepth;
 
     // number of parameters to the c function
     bool needStackRestore = false;
@@ -1322,7 +1322,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                                                      Intrinsic::stackrestore),
                            stacksave);
     }
-    ctx->argDepth = last_depth;
+    ctx->gc.argDepth = last_depth;
     if (0) { // Enable this to turn on SSPREQ (-fstack-protector) on the function containing this ccall
         ctx->f->addFnAttr(Attribute::StackProtectReq);
     }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1876,7 +1876,7 @@ static Value *emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, j
             return mark_julia_type(strct,ty);
         }
         Value *f1 = NULL;
-        int fieldStart = ctx->argDepth;
+        int fieldStart = ctx->gc.argDepth;
         bool needroots = false;
         for (size_t i = 1;i < nargs;i++) {
             if (might_need_root(args[i])) {
@@ -1903,7 +1903,7 @@ static Value *emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, j
             if (!jl_subtype(expr_type(args[1],ctx), jl_field_type(sty,0), 0))
                 emit_typecheck(f1, jl_field_type(sty,0), "new", ctx);
             emit_setfield(sty, strct, 0, f1, ctx, false, false);
-            ctx->argDepth = fieldStart;
+            ctx->gc.argDepth = fieldStart;
             if (nf > 1 && needroots)
                 make_gcroot(strct, ctx);
         }
@@ -1935,7 +1935,7 @@ static Value *emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, j
                 need_wb = true;
             emit_setfield(sty, strct, i-1, rhs, ctx, false, need_wb);
         }
-        ctx->argDepth = fieldStart;
+        ctx->gc.argDepth = fieldStart;
         return strct;
     }
     else {

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -601,7 +601,7 @@ static Value *emit_runtime_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t
     Value *preffunc =
         jl_Module->getOrInsertFunction("jl_pointerref",
                                        FunctionType::get(jl_pvalue_llvmt, two_pvalue_llvmt, false));
-    int ldepth = ctx->argDepth;
+    int ldepth = ctx->gc.argDepth;
     Value *parg = emit_boxed_rooted(e, ctx);
     Value *iarg = boxed(emit_expr(i, ctx), ctx);
 #ifdef LLVM37
@@ -609,7 +609,7 @@ static Value *emit_runtime_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t
 #else
     Value *ret = builder.CreateCall2(prepare_call(preffunc), parg, iarg);
 #endif
-    ctx->argDepth = ldepth;
+    ctx->gc.argDepth = ldepth;
     return ret;
 }
 
@@ -661,7 +661,7 @@ static Value *emit_runtime_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *
     Value *psetfunc =
         jl_Module->getOrInsertFunction("jl_pointerset",
                                        FunctionType::get(T_void, three_pvalue_llvmt, false));
-    int ldepth = ctx->argDepth;
+    int ldepth = ctx->gc.argDepth;
     Value *parg = emit_boxed_rooted(e, ctx);
     Value *iarg = emit_boxed_rooted(i, ctx);
     Value *xarg = boxed(emit_expr(x, ctx), ctx);
@@ -670,7 +670,7 @@ static Value *emit_runtime_pointerset(jl_value_t *e, jl_value_t *x, jl_value_t *
 #else
     builder.CreateCall3(prepare_call(psetfunc), parg, xarg, iarg);
 #endif
-    ctx->argDepth = ldepth;
+    ctx->gc.argDepth = ldepth;
     return parg;
 }
 
@@ -880,7 +880,7 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         Type *llt1 = julia_type_to_llvm(t1);
         jl_value_t *t2 = expr_type(args[3], ctx);
         Type *llt2 = julia_type_to_llvm(t2);
-        int argStart = ctx->argDepth;
+        int argStart = ctx->gc.argDepth;
         Value *ifelse_result;
         if (llt1 == jl_pvalue_llvmt && llt2 == jl_pvalue_llvmt) {
             Value *arg1 = emit_expr(args[3], ctx, false);
@@ -903,7 +903,7 @@ static Value *emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
                                                  arg1,
                                                  boxed(emit_expr(args[2],ctx,false), ctx, expr_type(args[2],ctx)));
         }
-        ctx->argDepth = argStart;
+        ctx->gc.argDepth = argStart;
         return ifelse_result;
     }
     default: ;


### PR DESCRIPTION
This is the clean up only part of https://github.com/JuliaLang/julia/pull/11508.

The main purpose of these commits is to split out some common functions and also the structure that stores the relevant information for generating gc frame. It also removes a few duplicated entries in the structure.

I left individual commits as is to make it easier to review.

I've already rebased #11508 on this. but I'll squash and clean up a little before I push it out.

@carnaval 
