### PR TITLE
Improve Unicode related error messages

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -165,6 +165,7 @@ export
     SystemError,
     TypeError,
     AssertionError,
+    UnicodeError,
 
 # Global constants and variables
     ARGS,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -84,6 +84,8 @@ include("iterator.jl")
 include("osutils.jl")
 
 # strings & printing
+include("utferror.jl")
+include("utftypes.jl")
 include("char.jl")
 include("ascii.jl")
 include("utf8.jl")

--- a/base/utf8.jl
+++ b/base/utf8.jl
@@ -72,7 +72,7 @@ function next(s::UTF8String, i::Int)
         end
         if 0 < j && i <= j+utf8_trailing[d[j]+1] <= length(d)
             # b is a continuation byte of a valid UTF-8 character
-            throw(ArgumentError("invalid UTF-8 character index"))
+            throw(UnicodeError(UTF_ERR_CONT, i, d[j]))
         end
         # move past 1 byte in case the data is actually Latin-1
         return '\ufffd', i+1
@@ -198,7 +198,7 @@ function reverse(s::UTF8String)
     out = similar(s.data)
     if ccall(:u8_reverse, Cint, (Ptr{UInt8}, Ptr{UInt8}, Csize_t),
              out, s.data, length(out)) == 1
-        throw(ArgumentError("invalid UTF-8 data"))
+        throw(UnicodeError(UTF_ERR_INVALID_8,0,0))
     end
     UTF8String(out)
 end
@@ -212,7 +212,7 @@ write(io::IO, s::UTF8String) = write(io, s.data)
 utf8(x) = convert(UTF8String, x)
 convert(::Type{UTF8String}, s::UTF8String) = s
 convert(::Type{UTF8String}, s::ASCIIString) = UTF8String(s.data)
-convert(::Type{UTF8String}, a::Array{UInt8,1}) = isvalid(UTF8String, a) ? UTF8String(a) : throw(ArgumentError("invalid UTF-8 sequence"))
+convert(::Type{UTF8String}, a::Array{UInt8,1}) = isvalid(UTF8String, a) ? UTF8String(a) : throw(UnicodeError(UTF_ERR_INVALID_8))
 function convert(::Type{UTF8String}, a::Array{UInt8,1}, invalids_as::AbstractString)
     l = length(a)
     idx = 1

--- a/base/utferror.jl
+++ b/base/utferror.jl
@@ -1,0 +1,30 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+##\brief      Error messages for Unicode / UTF support
+
+const UTF_ERR_SHORT             = "invalid UTF-8 sequence starting at index <<1>> (0x<<2>>) missing one or more continuation bytes)"
+const UTF_ERR_CONT              = "invalid UTF-8 sequence starting at index <<1>> (0x<<2>> is not a continuation byte)"
+const UTF_ERR_LONG              = "invalid UTF-8 sequence, overlong encoding starting at index <<1>> (0x<<2>>)"
+const UTF_ERR_NOT_LEAD          = "not a leading Unicode surrogate code unit at index <<1>> (0x<<2>>)"
+const UTF_ERR_NOT_TRAIL         = "not a trailing Unicode surrogate code unit at index <<1>> (0x<<2>>)"
+const UTF_ERR_NOT_SURROGATE     = "not a valid Unicode surrogate code unit at index <<1>> (0x<<2>>"
+const UTF_ERR_MISSING_SURROGATE = "missing trailing Unicode surrogate code unit after index <<1>> (0x<<2>>)"
+const UTF_ERR_INVALID           = "invalid Unicode character starting at index <<1>> (0x<<2>> > 0x10ffff)"
+const UTF_ERR_SURROGATE         = "surrogate encoding not allowed in UTF-8 or UTF-32, at index <<1>> (0x<<2>>)"
+const UTF_ERR_NULL_16_TERMINATE = "UTF16String data must be NULL-terminated"
+const UTF_ERR_NULL_32_TERMINATE = "UTF32String data must be NULL-terminated"
+const UTF_ERR_ODD_BYTES_16      = "UTF16String can't have odd number of bytes <<1>>"
+const UTF_ERR_ODD_BYTES_32      = "UTF32String must have multiple of 4 bytes <<1>>"
+const UTF_ERR_INVALID_CHAR      = "invalid Unicode character (0x<<2>> > 0x10ffff)"
+const UTF_ERR_INVALID_8         = "invalid UTF-8 data"
+const UTF_ERR_INVALID_16        = "invalid UTF-16 data"
+const UTF_ERR_INVALID_INDEX     = "invalid character index"
+const UTF_ERR_MAP_CHAR          = "map(f,s::AbstractString) requires f to return Char; try map(f,collect(s)) or a comprehension instead"
+
+type UnicodeError <: Exception
+    errmsg::AbstractString      ##< A UTF_ERR_ message
+    errpos::Int32               ##< Position of invalid character
+    errchr::UInt32              ##< Invalid character
+end
+
+show(io::IO, exc::UnicodeError) = print(io, replace(replace(exc.errmsg,"<<1>>",string(exc.errpos)),"<<2>>",hex(exc.errchr)))

--- a/base/utftypes.jl
+++ b/base/utftypes.jl
@@ -1,0 +1,34 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+##\brief      Base UTF16String type, has 16-bit NULL termination word after data, native byte order
+#
+# \throws     UnicodeError
+
+immutable UTF16String <: AbstractString
+    data::Vector{UInt16} # includes 16-bit NULL termination after string chars
+    function UTF16String(data::Vector{UInt16})
+        if length(data) < 1 || data[end] != 0
+            throw(UnicodeError(UTF_ERR_NULL_16_TERMINATE, 0, 0))
+        end
+        new(data)
+    end
+end
+
+##\brief      Base UTF32String type, has 32-bit NULL termination word after data, native byte order
+#
+# \throws     UnicodeError
+
+immutable UTF32String <: DirectIndexString
+    data::Vector{Char} # includes 32-bit NULL termination after string chars
+
+    function UTF32String(data::Vector{Char})
+        if length(data) < 1 || data[end] != Char(0)
+            throw(UnicodeError(UTF_ERR_NULL_32_TERMINATE, 0, 0))
+        end
+        new(data)
+    end
+end
+UTF32String(data::Vector{UInt32}) = UTF32String(reinterpret(Char, data))
+
+isvalid{T<:Union(ASCIIString,UTF8String,UTF16String,UTF32String)}(str::T) = isvalid(T, str.data)
+isvalid{T<:Union(ASCIIString,UTF8String,UTF16String,UTF32String)}(::Type{T}, str::T) = isvalid(T, str.data)

--- a/test/unicode.jl
+++ b/test/unicode.jl
@@ -10,7 +10,8 @@ u16 = utf16(u8)
 @test collect(u8) == collect(u16)
 @test u8 == utf16(u16.data[1:end-1]) == utf16(copy!(Array(UInt8, 18), 1, reinterpret(UInt8, u16.data), 1, 18))
 @test u8 == utf16(pointer(u16)) == utf16(convert(Ptr{Int16}, pointer(u16)))
-@test_throws ArgumentError utf16(utf32(Char(0x120000)))
+@test_throws UnicodeError utf16(utf32(Char(0x120000)))
+@test_throws UnicodeError utf16(UInt8[1,2,3])
 
 # UTF32
 u32 = utf32(u8)
@@ -21,6 +22,7 @@ u32 = utf32(u8)
 @test collect(u8) == collect(u32)
 @test u8 == utf32(u32.data[1:end-1]) == utf32(copy!(Array(UInt8, 20), 1, reinterpret(UInt8, u32.data), 1, 20))
 @test u8 == utf32(pointer(u32)) == utf32(convert(Ptr{Int32}, pointer(u32)))
+@test_throws UnicodeError utf32(UInt8[1,2,3])
 
 # Wstring
 w = wstring(u8)


### PR DESCRIPTION
This improves the error messages for the Unicode support, in `utf8.jl`, `utf16.jl`, and `utf32.jl`
They will save the position in the string where the error occurred, as well as the character or code unit that caused the error, and the `show` method for the `UnicodeError` exception type displays that extra information.
