### PR TITLE
Add UTF encoding validity functions

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -87,6 +87,7 @@ include("osutils.jl")
 # strings & printing
 include("utferror.jl")
 include("utftypes.jl")
+include("utfcheck.jl")
 include("char.jl")
 include("ascii.jl")
 include("utf8.jl")

--- a/base/utfcheck.jl
+++ b/base/utfcheck.jl
@@ -1,0 +1,229 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+## Functions to check validity of UTF-8, UTF-16, and UTF-32 encoded strings,
+#  and also to return information necessary to convert to other encodings
+
+is_surrogate_lead(c::Unsigned) = ((c & ~0x003ff) == 0xd800)
+is_surrogate_trail(c::Unsigned) = ((c & ~0x003ff) == 0xdc00)
+is_surrogate_codeunit(c::Unsigned) = ((c & ~0x007ff) == 0xd800)
+is_valid_continuation(c) = ((c & 0xc0) == 0x80)
+
+## Return flags for check_string function
+
+const UTF_LONG = 1              ##< Long encodings are present
+const UTF_LATIN1 = 2            ##< characters in range 0x80-0xFF present
+const UTF_UNICODE2 = 4          ##< characters in range 0x100-0x7ff present
+const UTF_UNICODE3 = 8          ##< characters in range 0x800-0xd7ff, 0xe000-0xffff
+const UTF_UNICODE4 = 16         ##< non-BMP characters present
+const UTF_SURROGATE = 32        ##< surrogate pairs present
+
+## Get a UTF-8 continuation byte, give error if invalid, return updated character value
+@inline function get_continuation(ch::UInt32, byt::UInt8, pos)
+    !is_valid_continuation(byt) && throw(UnicodeError(UTF_ERR_CONT, pos, byt))
+    (ch << 6) | (byt & 0x3f)
+end
+
+"
+Validates and calculates number of characters in a UTF-8,UTF-16 or UTF-32 encoded vector/string
+
+Warning: this function does not check the bounds of the start or end positions
+Use `checkstring` to make sure the bounds are checked
+
+### Input Arguments:
+* `dat`    UTF-8 (`Vector{UInt8}`), UTF-16 (`Vector{UInt16}`) or UTF-32 (`Vector{UInt32}`, `AbstractString`) encoded string
+
+### Optional Input Arguments:
+* `pos`    start position (defaults to `start(dat)`)
+* `endpos` end position   (defaults to `endof(dat)`)
+
+### Keyword Arguments:
+* `accept_long_null`  = `true`  # Modified UTF-8 (`\\0` represented as `b\"\\xc0\\x80\"`)
+* `accept_surrogates` = `true`  # `CESU-8`
+* `accept_long_char`  = `false` # Accept arbitrary long encodings
+
+### Returns:
+* (total characters, flags, 4-byte, 3-byte, 2-byte)
+
+### Throws:
+* `UnicodeError`
+"
+function unsafe_checkstring end
+
+function unsafe_checkstring(dat::Vector{UInt8},
+                      pos = start(dat),
+                      endpos = endof(dat)
+                      ;
+                      accept_long_null  = true,
+                      accept_surrogates = true,
+                      accept_long_char  = false)
+    local byt::UInt8, ch::UInt32, surr::UInt32
+    flags::UInt = 0
+    totalchar = num2byte = num3byte = num4byte = 0
+    @inbounds while pos <= endpos
+        ch, pos = next(dat, pos)
+        totalchar += 1
+        if ch > 0x7f
+            # Check UTF-8 encoding
+            if ch < 0xe0
+                # 2-byte UTF-8 sequence (i.e. characters 0x80-0x7ff)
+                (pos > endpos) && throw(UnicodeError(UTF_ERR_SHORT, pos, ch))
+                byt, pos = next(dat, pos)
+                ch = get_continuation(ch & 0x3f, byt, pos)
+                if ch > 0x7f
+                    num2byte += 1
+                    flags |= (ch > 0xff) ? UTF_UNICODE2 : UTF_LATIN1
+                elseif accept_long_char
+                    flags |= UTF_LONG
+                elseif (ch == 0) && accept_long_null
+                    flags |= UTF_LONG
+                else
+                    throw(UnicodeError(UTF_ERR_LONG, pos, ch))
+                end
+             elseif ch < 0xf0
+                # 3-byte UTF-8 sequence (i.e. characters 0x800-0xffff)
+                (pos + 1 > endpos) && throw(UnicodeError(UTF_ERR_SHORT, pos, ch))
+                byt, pos = next(dat, pos)
+                ch = get_continuation(ch & 0x0f, byt, pos)
+                byt, pos = next(dat, pos)
+                ch = get_continuation(ch, byt, pos)
+                # check for surrogate pairs, make sure correct
+                if is_surrogate_codeunit(ch)
+                    !is_surrogate_lead(ch) && throw(UnicodeError(UTF_ERR_NOT_LEAD, pos-2, ch))
+                    # next character *must* be a trailing surrogate character
+                    (pos + 2 > endpos) && throw(UnicodeError(UTF_ERR_MISSING_SURROGATE, pos-2, ch))
+                    byt, pos = next(dat, pos)
+                    (byt != 0xed) && throw(UnicodeError(UTF_ERR_NOT_TRAIL, pos, byt))
+                    byt, pos = next(dat, pos)
+                    surr = get_continuation(0x0000d, byt, pos)
+                    byt, pos = next(dat, pos)
+                    surr = get_continuation(surr, byt, pos)
+                    !is_surrogate_trail(surr) && throw(UnicodeError(UTF_ERR_NOT_TRAIL, pos-2, surr))
+                    !accept_surrogates && throw(UnicodeError(UTF_ERR_SURROGATE, pos-2, surr))
+                    flags |= UTF_SURROGATE
+                    num4byte += 1
+                elseif ch > 0x07ff
+                    num3byte += 1
+                elseif accept_long_char
+                    flags |= UTF_LONG
+                    num2byte += 1
+                else
+                    throw(UnicodeError(UTF_ERR_LONG, pos-2, ch))
+                end
+            elseif ch < 0xf5
+                # 4-byte UTF-8 sequence (i.e. characters > 0xffff)
+                (pos + 2 > endpos) && throw(UnicodeError(UTF_ERR_SHORT, pos, ch))
+                byt, pos = next(dat, pos)
+                ch = get_continuation(ch & 0x07, byt, pos)
+                byt, pos = next(dat, pos)
+                ch = get_continuation(ch, byt, pos)
+                byt, pos = next(dat, pos)
+                ch = get_continuation(ch, byt, pos)
+                if ch > 0x10ffff
+                    throw(UnicodeError(UTF_ERR_INVALID, pos-3, ch))
+                elseif ch > 0xffff
+                    num4byte += 1
+                elseif is_surrogate_codeunit(ch)
+                    throw(UnicodeError(UTF_ERR_SURROGATE, pos-3, ch))
+                elseif accept_long_char
+                    # This is an overly long encoded character
+                    flags |= UTF_LONG
+                    if ch > 0x7ff
+                        num3byte += 1
+                    elseif ch > 0x7f
+                        num2byte += 1
+                    end
+                else
+                    throw(UnicodeError(UTF_ERR_LONG, pos-2, ch))
+                end
+            else
+                throw(UnicodeError(UTF_ERR_INVALID, pos, ch))
+            end
+        end
+    end
+    num3byte != 0 && (flags |= UTF_UNICODE3)
+    num4byte != 0 && (flags |= UTF_UNICODE4)
+    return totalchar, flags, num4byte, num3byte, num2byte
+end
+
+function unsafe_checkstring{T <: Union{Vector{UInt16}, Vector{UInt32}, AbstractString}}(
+                      dat::T,
+                      pos = start(dat),
+                      endpos = endof(dat)
+                      ;
+                      accept_long_null  = true,
+                      accept_surrogates = true,
+                      accept_long_char  = false)
+    local ch::UInt32
+    flags::UInt = 0
+    totalchar = num2byte = num3byte = num4byte = 0
+    @inbounds while pos <= endpos
+        ch, pos = next(dat, pos)
+        totalchar += 1
+        if ch > 0x7f
+            if ch < 0x100
+                num2byte += 1
+                flags |= UTF_LATIN1
+            elseif ch < 0x800
+                num2byte += 1
+                flags |= UTF_UNICODE2
+            elseif ch > 0x0ffff
+                (ch > 0x10ffff) && throw(UnicodeError(UTF_ERR_INVALID, pos, ch))
+                num4byte += 1
+            elseif !is_surrogate_codeunit(ch)
+                num3byte += 1
+            elseif is_surrogate_lead(ch)
+                pos > endpos && throw(UnicodeError(UTF_ERR_MISSING_SURROGATE, pos, ch))
+                # next character *must* be a trailing surrogate character
+                ch, pos = next(dat, pos)
+                !is_surrogate_trail(ch) && throw(UnicodeError(UTF_ERR_NOT_TRAIL, pos, ch))
+                num4byte += 1
+                if T != Vector{UInt16}
+                    !accept_surrogates && throw(UnicodeError(UTF_ERR_SURROGATE, pos, ch))
+                    flags |= UTF_SURROGATE
+                end
+            else
+                throw(UnicodeError(UTF_ERR_NOT_LEAD, pos, ch))
+            end
+        end
+    end
+    num3byte != 0 && (flags |= UTF_UNICODE3)
+    num4byte != 0 && (flags |= UTF_UNICODE4)
+    return totalchar, flags, num4byte, num3byte, num2byte
+end
+
+"
+Validates and calculates number of characters in a UTF-8,UTF-16 or UTF-32 encoded vector/string
+
+This function checks the bounds of the start and end positions
+Use `unsafe_checkstring` to avoid that overhead if the bounds have already been checked
+
+### Input Arguments:
+* `dat`    UTF-8 (`Vector{UInt8}`), UTF-16 (`Vector{UInt16}`) or UTF-32 (`Vector{UInt32}`, `AbstractString`) encoded string
+
+### Optional Input Arguments:
+* `startpos` start position (defaults to `start(dat)`)
+* `endpos`   end position   (defaults to `endof(dat)`)
+
+### Keyword Arguments:
+* `accept_long_null`  = `true`  # Modified UTF-8 (`\\0` represented as `b\"\\xc0\\x80\"`)
+* `accept_surrogates` = `true`  # `CESU-8`
+* `accept_long_char`  = `false` # Accept arbitrary long encodings
+
+### Returns:
+* (total characters, flags, 4-byte, 3-byte, 2-byte)
+
+### Throws:
+* `UnicodeError`
+"
+function checkstring end
+
+# No need to check bounds if using defaults
+checkstring(dat; kwargs...) = unsafe_checkstring(dat, start(dat), endof(dat); kwargs...)
+
+# Make sure that beginning and end positions are bounds checked
+function checkstring(dat, startpos, endpos = endof(dat); kwargs...)
+    checkbounds(dat,startpos)
+    checkbounds(dat,endpos)
+    endpos < startpos && throw(ArgumentError("End position ($endpos) is less than start position ($startpos)"))
+    unsafe_checkstring(dat, startpos, endpos; kwargs...)
+end

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1732,3 +1732,163 @@ d = UTF32String(c)
 c[1] = 'A'
 @test d=="A"
 
+# 11575
+# Test invalid sequences
+
+byt = 0x0 # Needs to be defined outside the try block!
+try
+    # Continuation byte not after lead
+    for byt in 0x80:0xbf
+        @test_throws UnicodeError Base.checkstring(UInt8[byt])
+    end
+
+    # Test lead bytes
+    for byt in 0xc0:0xff
+        # Single lead byte at end of string
+        @test_throws UnicodeError Base.checkstring(UInt8[byt])
+        # Lead followed by non-continuation character < 0x80
+        @test_throws UnicodeError Base.checkstring(UInt8[byt,0])
+        # Lead followed by non-continuation character > 0xbf
+        @test_throws UnicodeError Base.checkstring(UInt8[byt,0xc0])
+    end
+
+    # Test overlong 2-byte
+    for byt in 0x81:0xbf
+        @test_throws UnicodeError Base.checkstring(UInt8[0xc0,byt])
+    end
+    for byt in 0x80:0xbf
+        @test_throws UnicodeError Base.checkstring(UInt8[0xc1,byt])
+    end
+
+    # Test overlong 3-byte
+    for byt in 0x80:0x9f
+        @test_throws UnicodeError Base.checkstring(UInt8[0xe0,byt,0x80])
+    end
+
+    # Test overlong 4-byte
+    for byt in 0x80:0x8f
+        @test_throws UnicodeError Base.checkstring(UInt8[0xef,byt,0x80,0x80])
+    end
+
+    # Test 4-byte > 0x10ffff
+    for byt in 0x90:0xbf
+        @test_throws UnicodeError Base.checkstring(UInt8[0xf4,byt,0x80,0x80])
+    end
+    for byt in 0xf5:0xf7
+        @test_throws UnicodeError Base.checkstring(UInt8[byt,0x80,0x80,0x80])
+    end
+
+    # Test 5-byte
+    for byt in 0xf8:0xfb
+        @test_throws UnicodeError Base.checkstring(UInt8[byt,0x80,0x80,0x80,0x80])
+    end
+
+    # Test 6-byte
+    for byt in 0xfc:0xfd
+        @test_throws UnicodeError Base.checkstring(UInt8[byt,0x80,0x80,0x80,0x80,0x80])
+    end
+
+    # Test 7-byte
+    @test_throws UnicodeError Base.checkstring(UInt8[0xfe,0x80,0x80,0x80,0x80,0x80,0x80])
+
+    # Three and above byte sequences
+    for byt in 0xe0:0xef
+        # Lead followed by only 1 continuation byte
+        @test_throws UnicodeError Base.checkstring(UInt8[byt,0x80])
+        # Lead ended by non-continuation character < 0x80
+        @test_throws UnicodeError Base.checkstring(UInt8[byt,0x80,0])
+        # Lead ended by non-continuation character > 0xbf
+        @test_throws UnicodeError Base.checkstring(UInt8[byt,0x80,0xc0])
+    end
+
+    # 3-byte encoded surrogate character(s)
+    # Single surrogate
+    @test_throws UnicodeError Base.checkstring(UInt8[0xed,0xa0,0x80])
+    # Not followed by surrogate
+    @test_throws UnicodeError Base.checkstring(UInt8[0xed,0xa0,0x80,0xed,0x80,0x80])
+    # Trailing surrogate first
+    @test_throws UnicodeError Base.checkstring(UInt8[0xed,0xb0,0x80,0xed,0xb0,0x80])
+    # Followed by lead surrogate
+    @test_throws UnicodeError Base.checkstring(UInt8[0xed,0xa0,0x80,0xed,0xa0,0x80])
+
+    # Four byte sequences
+    for byt in 0xf0:0xf4
+        # Lead followed by only 2 continuation bytes
+        @test_throws UnicodeError Base.checkstring(UInt8[byt,0x80,0x80])
+        # Lead followed by non-continuation character < 0x80
+        @test_throws UnicodeError Base.checkstring(UInt8[byt,0x80,0x80,0])
+        # Lead followed by non-continuation character > 0xbf
+        @test_throws UnicodeError Base.checkstring(UInt8[byt,0x80,0x80,0xc0])
+    end
+catch exp;
+    println("Error testing checkstring: $byt, $exp")
+    throw(exp)
+end
+
+# Surrogates
+@test_throws UnicodeError Base.checkstring(UInt16[0xd800])
+@test_throws UnicodeError Base.checkstring(UInt16[0xdc00])
+@test_throws UnicodeError Base.checkstring(UInt16[0xdc00,0xd800])
+
+# Surrogates in UTF-32
+@test_throws UnicodeError Base.checkstring(UInt32[0xd800])
+@test_throws UnicodeError Base.checkstring(UInt32[0xdc00])
+@test_throws UnicodeError Base.checkstring(UInt32[0xdc00,0xd800])
+
+# Characters > 0x10ffff
+@test_throws UnicodeError Base.checkstring(UInt32[0x110000])
+
+# Test valid sequences
+for (seq, res) in (
+    (UInt8[0x0],                (1,0,0,0,0)),   # Nul byte, beginning of ASCII range
+    (UInt8[0x7f],               (1,0,0,0,0)),   # End of ASCII range
+    (UInt8[0xc0,0x80],          (1,1,0,0,0)),   # Long encoded Nul byte (Modified UTF-8, Java)
+    (UInt8[0xc2,0x80],          (1,2,0,0,1)),   # \u80, beginning of Latin1 range
+    (UInt8[0xc3,0xbf],          (1,2,0,0,1)),   # \uff, end of Latin1 range
+    (UInt8[0xc4,0x80],          (1,4,0,0,1)),   # \u100, beginning of non-Latin1 2-byte range
+    (UInt8[0xdf,0xbf],          (1,4,0,0,1)),   # \u7ff, end of non-Latin1 2-byte range
+    (UInt8[0xe0,0xa0,0x80],     (1,8,0,1,0)),   # \u800, beginning of 3-byte range
+    (UInt8[0xed,0x9f,0xbf],     (1,8,0,1,0)),   # \ud7ff, end of first part of 3-byte range
+    (UInt8[0xee,0x80,0x80],     (1,8,0,1,0)),   # \ue000, beginning of second part of 3-byte range
+    (UInt8[0xef,0xbf,0xbf],     (1,8,0,1,0)),   # \uffff, end of 3-byte range
+    (UInt8[0xf0,0x90,0x80,0x80],(1,16,1,0,0)),  # \U10000, beginning of 4-byte range
+    (UInt8[0xf4,0x8f,0xbf,0xbf],(1,16,1,0,0)),  # \U10ffff, end of 4-byte range
+    (UInt8[0xed,0xa0,0x80,0xed,0xb0,0x80], (1,0x30,1,0,0)), # Overlong \U10000, (CESU-8)
+    (UInt8[0xed,0xaf,0xbf,0xed,0xbf,0xbf], (1,0x30,1,0,0)), # Overlong \U10ffff, (CESU-8)
+    (UInt16[0x0000],            (1,0,0,0,0)),   # Nul byte, beginning of ASCII range
+    (UInt16[0x007f],            (1,0,0,0,0)),   # End of ASCII range
+    (UInt16[0x0080],            (1,2,0,0,1)),   # Beginning of Latin1 range
+    (UInt16[0x00ff],            (1,2,0,0,1)),   # End of Latin1 range
+    (UInt16[0x0100],            (1,4,0,0,1)),   # Beginning of non-Latin1 2-byte range
+    (UInt16[0x07ff],            (1,4,0,0,1)),   # End of non-Latin1 2-byte range
+    (UInt16[0x0800],            (1,8,0,1,0)),   # Beginning of 3-byte range
+    (UInt16[0xd7ff],            (1,8,0,1,0)),   # End of first part of 3-byte range
+    (UInt16[0xe000],            (1,8,0,1,0)),   # Beginning of second part of 3-byte range
+    (UInt16[0xffff],            (1,8,0,1,0)),   # End of 3-byte range
+    (UInt16[0xd800,0xdc00],     (1,16,1,0,0)),  # \U10000, beginning of 4-byte range
+    (UInt16[0xdbff,0xdfff],     (1,16,1,0,0)),  # \U10ffff, end of 4-byte range
+    (UInt32[0x0000],            (1,0,0,0,0)),   # Nul byte, beginning of ASCII range
+    (UInt32[0x007f],            (1,0,0,0,0)),   # End of ASCII range
+    (UInt32[0x0080],            (1,2,0,0,1)),   # Beginning of Latin1 range
+    (UInt32[0x00ff],            (1,2,0,0,1)),   # End of Latin1 range
+    (UInt32[0x0100],            (1,4,0,0,1)),   # Beginning of non-Latin1 2-byte range
+    (UInt32[0x07ff],            (1,4,0,0,1)),   # End of non-Latin1 2-byte range
+    (UInt32[0x0800],            (1,8,0,1,0)),   # Beginning of 3-byte range
+    (UInt32[0xd7ff],            (1,8,0,1,0)),   # End of first part of 3-byte range
+    (UInt32[0xe000],            (1,8,0,1,0)),   # Beginning of second part of 3-byte range
+    (UInt32[0xffff],            (1,8,0,1,0)),   # End of 3-byte range
+    (UInt32[0x10000],           (1,16,1,0,0)),  # \U10000, beginning of 4-byte range
+    (UInt32[0x10ffff],          (1,16,1,0,0)),  # \U10ffff, end of 4-byte range
+    (UInt32[0xd800,0xdc00],     (1,0x30,1,0,0)),# Overlong \U10000, (CESU-8)
+    (UInt32[0xdbff,0xdfff],     (1,0x30,1,0,0)))# Overlong \U10ffff, (CESU-8)
+    @test Base.checkstring(seq) == res
+end
+
+# Test bounds checking
+@test_throws BoundsError Base.checkstring(b"abcdef", -10)
+@test_throws BoundsError Base.checkstring(b"abcdef", 0)
+@test_throws BoundsError Base.checkstring(b"abcdef", 7)
+@test_throws BoundsError Base.checkstring(b"abcdef", 3, -10)
+@test_throws BoundsError Base.checkstring(b"abcdef", 3, 0)
+@test_throws BoundsError Base.checkstring(b"abcdef", 3, 7)
+@test_throws ArgumentError Base.checkstring(b"abcdef", 3, 1)


### PR DESCRIPTION
This introduces the `Base.check_string` function, with methods for handling UTF-8, UTF-16, and UTF-32 as vectors of `UInt8`, `UInt16`, and `UInt32`, respectively, as well as an `AbstractString` version that operates on Unicode characters (making sure that they are all valid code points, `0 <= ch < 0xd800`, `0xe000 <= ch < 0x10ffff`).
There are options to accept or not accept things like `Modified UTF-8` encoding, or `CESU-8` encoding,
or "overly long" encodings.  (See `utfcheck.jl` for documentation)
These methods either throw a `UnicodeError`, with information about which character was invalid, and
its position in the input, or they return a tuple, of the number of logical characters in the string, a bit flag to indicate what types of data were found (i.e. all ASCII, all Latin1, surrogates present, overlong characters present, etc.), the number of characters that would take 2 bytes to encode in UTF-8, the number that would take 3 bytes, and the number that would take 4 bytes.
This information is designed to be useful for future conversion routines, because they allow one to calculate the exact size needed to represent a valid string in UTF-8, UTF-16, or UTF-32, and also
indicate whether an optimized "widening" or "narrowing" conversion can be done.
