### PR TITLE
Don't overload * for linearindexing type computations

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -94,10 +94,14 @@ ndims(R::CartesianRange) = length(R.start)
     :($meta; CartesianRange(CartesianIndex{$N}($(startargs...)), CartesianIndex{$N}($(stopargs...))))
 end
 
-@generated function eachindex{S,T,M,N}(::LinearSlow, A::AbstractArray{S,M}, B::AbstractArray{T,N})
-    K = max(M,N)
+@generated function eachindex(::LinearSlow, A::AbstractArray, B::AbstractArray...)
+    K = max(ndims(A), map(ndims, B)...)
     startargs = fill(1, K)
-    stopargs = [:(max(size(A,$i),size(B,$i))) for i=1:K]
+    stopargs = Array(Expr, K)
+    for i = 1:K
+        Bargs = [:(size(B[$j],$i)) for j = 1:length(B)]
+        stopargs[i] = :(max(size(A,$i),$(Bargs...)))
+    end
     meta = Expr(:meta, :inline)
     :($meta; CartesianRange(CartesianIndex{$K}($(startargs...)), CartesianIndex{$K}($(stopargs...))))
 end

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -31,7 +31,7 @@ Basic functions
 
    Returns the number of elements in A
 
-.. function:: eachindex(A)
+.. function:: eachindex(A...)
 
    Creates an iterable object for visiting each index of an AbstractArray ``A`` in an efficient manner. For array types that have opted into fast linear indexing (like ``Array``), this is simply the range ``1:length(A)``. For other array types, this returns a specialized Cartesian range to efficiently index into the array with indices specified for every dimension. Example for a sparse 2-d array::
 
@@ -58,6 +58,13 @@ Basic functions
     A[iter] = 0.4864987874354343
     (iter.I_1,iter.I_2) = (2,3)
     A[iter] = 0.8090413606455655
+
+If you supply more than one ``AbstractArray`` argument, ``eachindex``
+will create an iterable object that is fast for all arguments (a
+``UnitRange`` if all inputs have fast linear indexing, a
+CartesianRange otherwise).  If the arrays have different sizes and/or
+dimensionalities, ``eachindex`` returns an interable that spans the
+largest range along each dimension.
 
 .. function:: Base.linearindexing(A)
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1105,6 +1105,12 @@ R = CartesianRange((0,3))
 R = CartesianRange((3,0))
 @test done(R, start(R)) == true
 
+@test eachindex(Base.LinearSlow(),zeros(3),zeros(2,2),zeros(2,2,2),zeros(2,2)) == CartesianRange((3,2,2))
+@test eachindex(Base.LinearFast(),zeros(3),zeros(2,2),zeros(2,2,2),zeros(2,2)) == 1:8
+@test eachindex(zeros(3),sub(zeros(3,3),1:2,1:2),zeros(2,2,2),zeros(2,2)) == CartesianRange((3,2,2))
+@test eachindex(zeros(3),zeros(2,2),zeros(2,2,2),zeros(2,2)) == 1:8
+
+
 #rotates
 
 a = [1 0 0; 0 0 0]


### PR DESCRIPTION
Addresses concerns raised in https://github.com/JuliaLang/julia/commit/429713502b3b3e59d96e20326bc89a491ca5570e#commitcomment-11513102.

This also generalizes `eachindex(A, B, C...)`. Includes documentation and tests :smile:.
