### PR TITLE
Move code_typed and return_types out of inference

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -3269,44 +3269,6 @@ function replace_getfield!(ast, e::ANY, tupname, vals, sv, i0)
     end
 end
 
-function code_typed(f, types::ANY; optimize=true)
-    types = to_tuple_type(types)
-    code_typed(call, Tuple{isa(f,Type)?Type{f}:typeof(f), types.parameters...}, optimize=optimize)
-end
-function code_typed(f::Function, types::ANY; optimize=true)
-    types = to_tuple_type(types)
-    asts = []
-    for x in _methods(f,types,-1)
-        linfo = func_for_method(x[3],types,x[2])
-        if optimize
-            (tree, ty) = typeinf(linfo, x[1], x[2], linfo, true, true)
-        else
-            (tree, ty) = typeinf_uncached(linfo, x[1], x[2], optimize=false)
-        end
-        if !isa(tree,Expr)
-            push!(asts, ccall(:jl_uncompress_ast, Any, (Any,Any), linfo, tree))
-        else
-            push!(asts, tree)
-        end
-    end
-    asts
-end
-
-function return_types(f, types::ANY)
-    types = to_tuple_type(types)
-    return_types(call, Tuple{isa(f,Type)?Type{f}:typeof(f), types.parameters...})
-end
-function return_types(f::Function, types::ANY)
-    types = to_tuple_type(types)
-    rt = []
-    for x in _methods(f,types,-1)
-        linfo = func_for_method(x[3],types,x[2])
-        (tree, ty) = typeinf(linfo, x[1], x[2])
-        push!(rt, ty)
-    end
-    rt
-end
-
 #tfunc(f,t) = methods(f,t)[1].func.code.tfunc
 
 ccall(:jl_set_typeinf_func, Void, (Any,), typeinf_ext)


### PR DESCRIPTION
I'm still not sure what exactly is the reason for #11590 but this seems to fix it, as well as the error when inspecting `code_typed` I mentioned in that issue https://github.com/JuliaLang/julia/issues/11590#issuecomment-109493465

IMHO, these methods (including other `code_*`'s) doesn't really belong to `Core.Inference` and can probably be moved into a different file (`interactiveutil.jl`?). (Leave them here for now since I don't want to change everything at the same time....)

Fix #11590

@mbauman 
