### PR TITLE
Adding declarations to llvmcall

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -503,9 +503,12 @@ keywords[:ccall] = doc"""
 
 keywords[:llvmcall] = doc"""
       llvmcall(IR::String, ReturnType, (ArgumentType1, ...), ArgumentValue1, ...)
+      llvmcall((declarations::String, IR::String), ReturnType, (ArgumentType1, ...), ArgumentValue1, ...)
 
   Call LLVM IR string in the first argument. Similar to an LLVM function `define`
   block, arguments are available as consecutive unnamed SSA variables (%0, %1, etc.).
+
+  The optional declarations string contains external functions declarations that are necessary for llvm to compile the IR string. Multiple declarations can be passed in by separating them with line breaks.
 
   Note that the argument type tuple must be a literal tuple, and not a tuple-valued variable or expression.
 

--- a/doc/stdlib/c.rst
+++ b/doc/stdlib/c.rst
@@ -254,10 +254,13 @@
 ****************
 
 .. function:: llvmcall(IR::String, ReturnType, (ArgumentType1, ...), ArgumentValue1, ...)
+              llvmcall((declarations::String, IR::String), ReturnType, (ArgumentType1, ...), ArgumentValue1, ...)
 
    .. Docstring generated from Julia source
 
    Call LLVM IR string in the first argument. Similar to an LLVM function ``define`` block, arguments are available as consecutive unnamed SSA variables (%0, %1, etc.).
+
+   The optional declarations string contains external functions declarations that are necessary for llvm to compile the IR string. Multiple declarations can be passed in by separating them with line breaks.
 
    Note that the argument type tuple must be a literal tuple, and not a tuple-valued variable or expression.
 

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -477,9 +477,9 @@ static jl_cgval_t emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ct
 static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 {
     JL_NARGSV(llvmcall, 3)
-    jl_value_t *rt = NULL, *at = NULL, *ir = NULL;
+    jl_value_t *rt = NULL, *at = NULL, *ir = NULL, *decl = NULL;
     jl_svec_t *stt = NULL;
-    JL_GC_PUSH4(&ir, &rt, &at, &stt);
+    JL_GC_PUSH5(&ir, &rt, &at, &stt, &decl);
     {
     JL_TRY {
         at  = jl_interpret_toplevel_expr_in(ctx->module, args[3],
@@ -514,7 +514,6 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
     if (ir == NULL) {
         jl_error("Cannot statically evaluate first argument to llvmcall");
     }
-    jl_value_t *decl = NULL;
     if (jl_is_tuple(ir)) {
         // if the IR is a tuple, we expect (declarations, ir)
         if (jl_nfields(ir) != 2)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1,6 +1,10 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
+#include "support/hashing.h"
 
 // --- the ccall, cglobal, and llvm intrinsics ---
+
+// keep track of llvmcall declarations
+static std::set<u_int64_t> llvmcallDecls;
 
 static std::map<std::string, GlobalVariable*> libMapGV;
 static std::map<std::string, GlobalVariable*> symMapGV;
@@ -510,10 +514,20 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
     if (ir == NULL) {
         jl_error("Cannot statically evaluate first argument to llvmcall");
     }
+    jl_value_t *decl = NULL;
+    if (jl_is_tuple(ir)) {
+        // if the IR is a tuple, we expect (declarations, ir)
+        if (jl_nfields(ir) != 2)
+            jl_error("Tuple as first argument to llvmcall must have exactly two children");
+        decl = jl_fieldref(ir,0);
+        ir = jl_fieldref(ir,1);
+        if (!jl_is_byte_string(decl))
+            jl_error("Declarations passed to llvmcall must be a string");
+    }
     bool isString = jl_is_byte_string(ir);
     bool isPtr = jl_is_cpointer(ir);
     if (!isString && !isPtr) {
-        jl_error("First argument to llvmcall must be a string or pointer to an LLVM Function");
+        jl_error("IR passed to llvmcall must be a string or pointer to an LLVM Function");
     }
 
     JL_TYPECHK(llvmcall, type, rt);
@@ -600,6 +614,14 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
         llvm::raw_string_ostream rtypename(rstring);
         rettype->print(rtypename);
 
+        if (decl != NULL) {
+            char *declstr = jl_string_data(decl);
+            u_int64_t declhash = memhash(declstr, strlen(declstr));
+            if (llvmcallDecls.count(declhash) == 0) {
+                ir_stream << "; Declarations\n" << declstr << "\n";
+                llvmcallDecls.insert(declhash);
+            }
+        }
         ir_stream << "; Number of arguments: " << nargt << "\n"
         << "define "<<rtypename.str()<<" @\"" << ir_name << "\"("<<argstream.str()<<") {\n"
         << jl_string_data(ir) << "\n}";

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -617,7 +617,20 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
             char *declstr = jl_string_data(decl);
             u_int64_t declhash = memhash(declstr, strlen(declstr));
             if (llvmcallDecls.count(declhash) == 0) {
-                ir_stream << "; Declarations\n" << declstr << "\n";
+                // Find name of declaration
+                char *declcopy = (char*) malloc(strlen(declstr) + 1);
+                strcpy(declcopy, declstr);
+                // Find '@'
+                char *declname = (char*) strchr(declcopy, '@') + 1;
+                // Insert null byte at the end of the function name
+                ((char*) strchr(declname, '('))[0] = 0;
+
+                // Check if declaration already present in module
+                if(jl_Module->getNamedValue(declname) == NULL) {
+                    ir_stream << "; Declarations\n" << declstr << "\n";
+                }
+
+                free(declcopy);
                 llvmcallDecls.insert(declhash);
             }
         }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4508,6 +4508,8 @@ static Function *emit_function(jl_lambda_info_t *lam)
         m = new Module(funcName.str(), jl_LLVMContext);
         jl_setup_module(m);
     }
+    // clear the list of llvmcall declarations as we'll be using a clean module
+    llvmcallDecls.clear();
 #else
     m = jl_Module;
 #endif

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -70,11 +70,17 @@ end
         Int32(1), Int32(2))) == 3
 
 # Test whether declarations work properly
+# These tests only work properly for llvm 3.5+
+if convert(VersionNumber, Base.libllvm_version) > v"3.5-"
+
 function undeclared_ceil(x::Float64)
     llvmcall("""%2 = call double @llvm.ceil.f64(double %0)
         ret double %2""", Float64, Tuple{Float64}, x)
 end
 @test_throws ErrorException undeclared_ceil(4.2)
+
+end
+
 # KNOWN ISSUE: although the llvmcall in undeclare_ceil did error(), the LLVM
 # module contains the generated IR referencing the ceil intrinsic. At some
 # point, a declaration for that intrinsic is added, breaking any future
@@ -87,6 +93,7 @@ function declared_floor(x::Float64)
     Float64, Tuple{Float64}, x)
 end
 @test_approx_eq declared_floor(4.2) 4.
+
 function doubly_declared_floor(x::Float64)
     llvmcall(
         ("""declare double @llvm.floor.f64(double)""",

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -116,3 +116,27 @@ function doubly_declared2_trunc(x::Float64)
     a + b
 end
 @test_approx_eq doubly_declared2_trunc(4.2) 8.
+
+# Test for single line
+function declared_ceil(x::Float64)
+    llvmcall(
+        ("declare double @llvm.ceil.f64(double)",
+         """%2 = call double @llvm.ceil.f64(double %0)
+            ret double %2"""),
+    Float64, Tuple{Float64}, x)
+end
+
+@test_approx_eq declared_ceil(4.2) 5.0
+
+# Test for multiple lines
+function ceilfloor(x::Float64)
+    llvmcall(
+        ("""declare double @llvm.ceil.f64(double)
+            declare double @llvm.floor.f64(double)""",
+         """%2 = call double @llvm.ceil.f64(double %0)
+            %3 = call double @llvm.floor.f64(double %2)
+            ret double %3"""),
+    Float64, Tuple{Float64}, x)
+end
+
+@test_approx_eq ceilfloor(7.4) 8.0

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -70,7 +70,10 @@ end
         Int32(1), Int32(2))) == 3
 
 # Test whether declarations work properly
-# These tests only work properly for llvm 3.5+
+# This test only work properly for llvm 3.5+
+# On llvm <3.5+ even though the the compilation fails on the first try,
+# llvm still adds the intrinsice declaration to the module and subsequent calls
+# are succesfull.
 if convert(VersionNumber, Base.libllvm_version) > v"3.5-"
 
 function undeclared_ceil(x::Float64)
@@ -81,10 +84,6 @@ end
 
 end
 
-# KNOWN ISSUE: although the llvmcall in undeclare_ceil did error(), the LLVM
-# module contains the generated IR referencing the ceil intrinsic. At some
-# point, a declaration for that intrinsic is added, breaking any future
-# llvmcall((conflicting declaration, ...), ...). Not an issue in LLVM 3.5+.
 function declared_floor(x::Float64)
     llvmcall(
         ("""declare double @llvm.floor.f64(double)""",
@@ -102,6 +101,7 @@ function doubly_declared_floor(x::Float64)
     Float64, Tuple{Float64}, x+1)-1
 end
 @test_approx_eq doubly_declared_floor(4.2) 4.
+
 function doubly_declared2_trunc(x::Float64)
     a = llvmcall(
         ("""declare double @llvm.trunc.f64(double)""",

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -72,7 +72,7 @@ end
 # Test whether declarations work properly
 function undeclared_ceil(x::Float64)
     llvmcall("""%2 = call double @llvm.ceil.f64(double %0)
-        ret double %2""", Float64, (Float64,), x)
+        ret double %2""", Float64, Tuple{Float64}, x)
 end
 @test_throws ErrorException undeclared_ceil(4.2)
 # KNOWN ISSUE: although the llvmcall in undeclare_ceil did error(), the LLVM
@@ -84,7 +84,7 @@ function declared_floor(x::Float64)
         ("""declare double @llvm.floor.f64(double)""",
          """%2 = call double @llvm.floor.f64(double %0)
             ret double %2"""),
-    Float64, (Float64,), x)
+    Float64, Tuple{Float64}, x)
 end
 @test_approx_eq declared_floor(4.2) 4.
 function doubly_declared_floor(x::Float64)
@@ -92,7 +92,7 @@ function doubly_declared_floor(x::Float64)
         ("""declare double @llvm.floor.f64(double)""",
          """%2 = call double @llvm.floor.f64(double %0)
             ret double %2"""),
-    Float64, (Float64,), x+1)-1
+    Float64, Tuple{Float64}, x+1)-1
 end
 @test_approx_eq doubly_declared_floor(4.2) 4.
 function doubly_declared2_trunc(x::Float64)
@@ -100,12 +100,12 @@ function doubly_declared2_trunc(x::Float64)
         ("""declare double @llvm.trunc.f64(double)""",
          """%2 = call double @llvm.trunc.f64(double %0)
             ret double %2"""),
-    Float64, (Float64,), x)
+    Float64, Tuple{Float64}, x)
     b = llvmcall(
         ("""declare double @llvm.trunc.f64(double)""",
          """%2 = call double @llvm.trunc.f64(double %0)
             ret double %2"""),
-    Float64, (Float64,), x+1)-1
+    Float64, Tuple{Float64}, x+1)-1
     a + b
 end
 @test_approx_eq doubly_declared2_trunc(4.2) 8.


### PR DESCRIPTION
Rebased from #8740 via #11516 in response to #11603 

This allows to hook up llvm intrinsics via llvmcall. This is necessary for the CUDA backend work and several people expressed that they have other usages in mind. 

Ping @ihnorton @tkelman 
## Overview

This extension of llvmcall allows to pass declarations of intrinsics to llvmcall. As an example see:

``` julia
function ceil(x::Float64)
    llvmcall(
        ("declare double @llvm.ceil.f64(double)",
         """%2 = call double @llvm.ceil.f64(double %0)
            ret double %2"""),
    Float64, Tuple{Float64}, x)
end

function ceilfloor(x::Float64)
    llvmcall(
        ("""declare double @llvm.ceil.f64(double)
            declare double @llvm.floor.f64(double)""",
         """%2 = call double @llvm.ceil.f64(double %0)
            %3 = call double @llvm.floor.f64(double %2)
            ret double %3"""),
    Float64, Tuple{Float64}, x)
end
```
