### PR TITLE
Check for :meta expressions more thoroughly, and improve indexing performance

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -119,45 +119,58 @@ function pushmeta!(ex::Expr, sym::Symbol, args::Any...)
     else
         tag = Expr(sym, args...)
     end
-
-    if ex.head == :function
+    found, metaex = findmeta(ex)
+    if found
+        push!(metaex.args, tag)
+    else
         body::Expr = ex.args[2]
-        if !isempty(body.args) && isa(body.args[1], Expr) && (body.args[1]::Expr).head == :meta
-            push!((body.args[1]::Expr).args, tag)
-        elseif isempty(body.args)
-            push!(body.args, Expr(:meta, tag))
-            push!(body.args, nothing)
-        else
-            unshift!(body.args, Expr(:meta, tag))
-        end
-    elseif (ex.head == :(=) && typeof(ex.args[1]) == Expr && ex.args[1].head == :call)
-        ex = Expr(:function, ex.args[1], Expr(:block, Expr(:meta, tag), ex.args[2]))
-#     else
-#         ex = Expr(:withmeta, ex, sym)
+        unshift!(body.args, Expr(:meta, tag))
     end
     ex
 end
 
 function popmeta!(body::Expr, sym::Symbol)
-    if isa(body.args[1],Expr) && (body.args[1]::Expr).head === :meta
-        metaargs = (body.args[1]::Expr).args
-        for i = 1:length(metaargs)
-            if (isa(metaargs[i], Symbol) && metaargs[i] == sym) ||
-               (isa(metaargs[i], Expr) && metaargs[i].head == sym)
-                if length(metaargs) == 1
-                    shift!(body.args)        # get rid of :meta Expr
-                else
-                    deleteat!(metaargs, i)   # delete this portion of the metadata
-                end
+    body.head == :block || return false, []
+    found, metaex = findmeta_block(body)
+    if !found
+        return false, []
+    end
+    metaargs = metaex.args
+    for i = 1:length(metaargs)
+        if isa(metaargs[i], Symbol) && (metaargs[i]::Symbol) == sym
+            deleteat!(metaargs, i)
+            return true, []
+        elseif isa(metaargs[i], Expr) && (metaargs[i]::Expr).head == sym
+            ret = (metaargs[i]::Expr).args
+            deleteat!(metaargs, i)
+            return true, ret
+        end
+    end
+    false, []
+end
+popmeta!(arg, sym) = (false, [])
 
-                if isa(metaargs[i], Symbol)
-                    return (true, [])
-                elseif isa(metaargs[i], Expr)
-                    return (true, metaargs[i].args)
+function findmeta(ex::Expr)
+    if ex.head == :function || (ex.head == :(=) && typeof(ex.args[1]) == Expr && ex.args[1].head == :call)
+        body::Expr = ex.args[2]
+        body.head == :block || error(body, " is not a block expression")
+        return findmeta_block(ex)
+    end
+    error(ex, " is not a function expression")
+end
+
+function findmeta_block(ex::Expr)
+    for a in ex.args
+        if isa(a, Expr)
+            if (a::Expr).head == :meta
+                return true, a::Expr
+            elseif (a::Expr).head == :block
+                found, exb = findmeta_block(a)
+                if found
+                    return found, exb
                 end
             end
         end
     end
-    return (false, [])
+    return false, Expr(:block)
 end
-popmeta!(arg, sym) = (false, [])

--- a/doc/devdocs/meta.rst
+++ b/doc/devdocs/meta.rst
@@ -10,8 +10,8 @@ that a given block of code has special properties: you might always
 want to inline it, or you might want to turn on special compiler
 optimization passes.  Starting with version 0.4, julia has a
 convention that these instructions can be placed inside a ``:meta``
-expression, which must be the first expression in the body of a
-function.
+expression, which is typically (but not necessarily) the first
+expression in the body of a function.
 
 ``:meta`` expressions are created with macros. As an example, consider
 the implementation of the ``@inline`` macro::

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -66,6 +66,29 @@ body.args = ast.args[3].args
 @test popmeta!(body, :test) == (true, [42])
 @test popmeta!(body, :nonexistent) == (false, [])
 
+metaex = Expr(:meta, :foo)
+ex1 = quote
+    $metaex
+    x*x+1
+end
+metaex = Expr(:meta, :foo)
+ex2 = quote
+    y = x
+    $metaex
+    y*y+1
+end
+metaex = Expr(:block, Expr(:meta, :foo))
+ex3 = quote
+    y = x
+    $metaex
+    x*x+1
+end
+
+@test popmeta!(ex1, :foo)[1]
+@test popmeta!(ex2, :foo)[1]
+@test popmeta!(ex3, :foo)[1]
+@test !(popmeta!(:(x*x+1), :foo)[1])
+
 end
 
 


### PR DESCRIPTION
This addresses #11595, and fixes most of our current problems with indexing performance. Sadly, it still doesn't recover the full performance compared to https://github.com/JuliaLang/julia/issues/5117#issuecomment-109215640. With this PR (running on a different machine, but the times relative to the first should be pretty comparable):

``` jl
julia> include("/tmp/mykern.jl")
follow up: mykern( 2:(siz - 3), s, a, x, y )
  16.097 milliseconds (6 allocations: 192 bytes)
follow up: mykern( 2:(siz - 3), s1, a, x1, y1 )
  99.089 milliseconds (29670 allocations: 1216 KB)
follow up: mykern( 3:(siz - 2), s2, a, x2, y2 )
  44.005 milliseconds (6 allocations: 192 bytes)
  41.978 milliseconds (6 allocations: 192 bytes)
  41.984 milliseconds (6 allocations: 192 bytes)
```

which is a big improvement over the nearly thousand-fold penalty observed in https://github.com/JuliaLang/julia/issues/5117#issuecomment-109206457.

If we want SubArrays to have indexing performance nearly equivalent to Arrays, we probably have to go back to not doing bounds checking :frowning:.
