### PR TITLE
<<, >>, >>>: make core bit shift operators take Int as second arg.

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1177,28 +1177,23 @@ end
 
 reverse(v::BitVector) = reverse!(copy(v))
 
-function (<<)(B::BitVector, i::Int64)
+function (<<)(B::BitVector, i::Int)
     n = length(B)
     i == 0 && return copy(B)
     A = falses(n)
     i < n && copy_chunks!(A.chunks, 1, B.chunks, i+1, n-i)
     return A
 end
-(<<)(B::BitVector, i::Int32) = B << Int64(i)
-(<<)(B::BitVector, i::Integer) = B << Int64(i)
 
-function (>>>)(B::BitVector, i::Int64)
+function (>>>)(B::BitVector, i::Int)
     n = length(B)
     i == 0 && return copy(B)
     A = falses(n)
     i < n && copy_chunks!(A.chunks, i+1, B.chunks, 1, n-i)
     return A
 end
-(>>>)(B::BitVector, i::Int32) = B >>> Int64(i)
-(>>>)(B::BitVector, i::Integer) = B >>> Int64(i)
 
-(>>)(B::BitVector, i::Int32) = B >>> i
-(>>)(B::BitVector, i::Integer) = B >>> i
+(>>)(B::BitVector, i::Int) = B >>> i
 
 function rol!(dest::BitVector, src::BitVector, i::Integer)
     length(dest) == length(src) || throw(ArgumentError("destination and source should be of same size"))

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -334,7 +334,7 @@ for (fJ, fC) in ((:-, :neg), (:~, :com))
     end
 end
 
-function <<(x::BigInt, c::Int32)
+function <<(x::BigInt, c::Int)
     c < 0 && throw(DomainError())
     c == 0 && return x
     z = BigInt()
@@ -342,7 +342,7 @@ function <<(x::BigInt, c::Int32)
     return z
 end
 
-function >>(x::BigInt, c::Int32)
+function >>(x::BigInt, c::Int)
     c < 0 && throw(DomainError())
     c == 0 && return x
     z = BigInt()
@@ -350,7 +350,7 @@ function >>(x::BigInt, c::Int32)
     return z
 end
 
->>>(x::BigInt, c::Int32) = x >> c
+>>>(x::BigInt, c::Int) = x >> c
 
 trailing_zeros(x::BigInt) = Int(ccall((:__gmpz_scan1, :libgmp), Culong, (Ptr{BigInt}, Culong), &x, 0))
 trailing_ones(x::BigInt) = Int(ccall((:__gmpz_scan0, :libgmp), Culong, (Ptr{BigInt}, Culong), &x, 0))

--- a/base/int.jl
+++ b/base/int.jl
@@ -96,13 +96,13 @@ for T in IntTypes
         (|)(x::$T, y::$T) = box($T, or_int(unbox($T,x),unbox($T,y)))
         ($)(x::$T, y::$T) = box($T,xor_int(unbox($T,x),unbox($T,y)))
 
-        <<(x::$T,  y::Int32) = box($T, shl_int(unbox($T,x),unbox(Int32,y)))
-        >>>(x::$T, y::Int32) = box($T,lshr_int(unbox($T,x),unbox(Int32,y)))
+        <<(x::$T,  y::Int) = box($T, shl_int(unbox($T,x),unbox(Int,y)))
+        >>>(x::$T, y::Int) = box($T,lshr_int(unbox($T,x),unbox(Int,y)))
     end
     if issubtype(T,Unsigned)
-        @eval >>(x::$T, y::Int32) = box($T,lshr_int(unbox($T,x),unbox(Int32,y)))
+        @eval >>(x::$T, y::Int) = box($T,lshr_int(unbox($T,x),unbox(Int,y)))
     else
-        @eval >>(x::$T, y::Int32) = box($T,ashr_int(unbox($T,x),unbox(Int32,y)))
+        @eval >>(x::$T, y::Int) = box($T,ashr_int(unbox($T,x),unbox(Int,y)))
     end
 end
 
@@ -348,8 +348,8 @@ typemin(::Type{UInt64}) = UInt64(0)
 typemax(::Type{UInt64}) = 0xffffffffffffffff
 @eval typemin(::Type{UInt128}) = $(UInt128(0))
 @eval typemax(::Type{UInt128}) = $(box(UInt128,unbox(Int128,convert(Int128,-1))))
-@eval typemin(::Type{Int128} ) = $(convert(Int128,1)<<Int32(127))
-@eval typemax(::Type{Int128} ) = $(box(Int128,unbox(UInt128,typemax(UInt128)>>Int32(1))))
+@eval typemin(::Type{Int128} ) = $(convert(Int128,1)<<127)
+@eval typemax(::Type{Int128} ) = $(box(Int128,unbox(UInt128,typemax(UInt128)>>1)))
 
 widen(::Type{Int8}) = Int
 widen(::Type{Int16}) = Int
@@ -373,7 +373,7 @@ widemul(x::Number,y::Bool) = x*y
 
 ## wide multiplication, Int128 multiply and divide ##
 
-if WORD_SIZE==32
+if WORD_SIZE == 32
     function widemul(u::Int64, v::Int64)
         local u0::UInt64, v0::UInt64, w0::UInt64
         local u1::Int64, v1::Int64, w1::UInt64, w2::Int64, t::UInt64
@@ -434,12 +434,12 @@ if WORD_SIZE==32
 
     mod(x::Int128, y::Int128) = Int128(mod(BigInt(x),BigInt(y)))
 
-    << (x::Int128,  y::Int32) = y == 0 ? x : box(Int128,shl_int(unbox(Int128,x),unbox(Int32,y)))
-    << (x::UInt128, y::Int32) = y == 0 ? x : box(UInt128,shl_int(unbox(UInt128,x),unbox(Int32,y)))
-    >> (x::Int128,  y::Int32) = y == 0 ? x : box(Int128,ashr_int(unbox(Int128,x),unbox(Int32,y)))
-    >> (x::UInt128, y::Int32) = y == 0 ? x : box(UInt128,lshr_int(unbox(UInt128,x),unbox(Int32,y)))
-    >>>(x::Int128,  y::Int32) = y == 0 ? x : box(Int128,lshr_int(unbox(Int128,x),unbox(Int32,y)))
-    >>>(x::UInt128, y::Int32) = y == 0 ? x : box(UInt128,lshr_int(unbox(UInt128,x),unbox(Int32,y)))
+    << (x::Int128,  y::Int) = y == 0 ? x : box(Int128,shl_int(unbox(Int128,x),unbox(Int,y)))
+    << (x::UInt128, y::Int) = y == 0 ? x : box(UInt128,shl_int(unbox(UInt128,x),unbox(Int,y)))
+    >> (x::Int128,  y::Int) = y == 0 ? x : box(Int128,ashr_int(unbox(Int128,x),unbox(Int,y)))
+    >> (x::UInt128, y::Int) = y == 0 ? x : box(UInt128,lshr_int(unbox(UInt128,x),unbox(Int,y)))
+    >>>(x::Int128,  y::Int) = y == 0 ? x : box(Int128,lshr_int(unbox(Int128,x),unbox(Int,y)))
+    >>>(x::UInt128, y::Int) = y == 0 ? x : box(UInt128,lshr_int(unbox(UInt128,x),unbox(Int,y)))
 else
     *(x::Int128,  y::Int128)  = box(Int128,mul_int(unbox(Int128,x),unbox(Int128,y)))
     *(x::UInt128, y::UInt128) = box(UInt128,mul_int(unbox(UInt128,x),unbox(UInt128,y)))
@@ -491,13 +491,13 @@ for T in (Int8,UInt8)
 end
 
 if WORD_SIZE == 32
-for T in (Int64,UInt64)
-    @eval function checked_mul(x::$T, y::$T)
-        xy = Int128(x)*Int128(y)
-        (typemin($T) <= xy <= typemax($T)) || throw(OverflowError())
-        return xy % $T
+    for T in (Int64,UInt64)
+        @eval function checked_mul(x::$T, y::$T)
+            xy = Int128(x)*Int128(y)
+            (typemin($T) <= xy <= typemax($T)) || throw(OverflowError())
+            return xy % $T
+        end
     end
-end
 else
     checked_mul(x::Int64, y::Int64)   = box(Int64,checked_smul(unbox(Int64,x),unbox(Int64,y)))
     checked_mul(x::UInt64, y::UInt64) = box(UInt64,checked_umul(unbox(UInt64,x),unbox(UInt64,y)))

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -108,13 +108,13 @@ end
 const .≤ = .<=
 const .≠ = .!=
 
-# core << >> and >>> takes Int32 as second arg
-<<(x,y::Int32)    = no_op_err("<<", typeof(x))
->>(x,y::Int32)    = no_op_err(">>", typeof(x))
->>>(x,y::Int32)   = no_op_err(">>>", typeof(x))
-<<(x,y::Integer)  = x << convert(Int32,y)
->>(x,y::Integer)  = x >> convert(Int32,y)
->>>(x,y::Integer) = x >>> convert(Int32,y)
+# core << >> and >>> takes Int as second arg
+<<(x,y::Int)  = no_op_err("<<", typeof(x))
+>>(x,y::Int)  = no_op_err(">>", typeof(x))
+>>>(x,y::Int) = no_op_err(">>>", typeof(x))
+<<(x,y::Integer)  = x << convert(Int,y)
+>>(x,y::Integer)  = x >> convert(Int,y)
+>>>(x,y::Integer) = x >>> convert(Int,y)
 
 # fallback div, fld, and cld implementations
 # NOTE: C89 fmod() and x87 FPREM implicitly provide truncating float division,


### PR DESCRIPTION
Conversion to Int32 was making the code generation for these pretty
unfortunate, this makes it better.

Before:

```
julia> @code_llvm 123 << 7

define i64 @"julia_<<_21019"(i64, i64) {
top:
  %sext = shl i64 %1, 32
  %2 = ashr exact i64 %sext, 32
  %3 = icmp eq i64 %2, %1
  br i1 %3, label %pass, label %fail

fail:                                             ; preds = %top
  %4 = load %jl_value_t** @jl_inexact_exception, align 8
  call void @jl_throw_with_superfluous_argument(%jl_value_t* %4, i32 115)
  unreachable

pass:                                             ; preds = %top
  %5 = trunc i64 %1 to i32
  %6 = icmp ugt i32 %5, 63
  %7 = and i64 %1, 4294967295
  %8 = shl i64 %0, %7
  %9 = select i1 %6, i64 0, i64 %8
  ret i64 %9
}
```

After:

```
julia> @code_llvm 123 << 7

define i64 @"julia_<<_21040"(i64, i64) {
top:
  %2 = icmp ugt i64 %1, 63
  %3 = shl i64 %0, %1
  %4 = select i1 %2, i64 0, i64 %3
  ret i64 %4
}
```
