### PR TITLE
Ensure SubArray's unsafe_getindex doesn't check bounds

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -533,9 +533,9 @@ getindex(V::SubArray, I::Int...) = (@_inline_meta; checkbounds(V, I...); unsafe_
     if ni == 1 && length(IV.parameters) == LD  # linear indexing
         meta = Expr(:meta, :inline)
         if iscontiguous(V)
-            return :($meta; V.parent[V.first_index + I[1] - 1])
+            return :($meta; unsafe_getindex(V.parent, V.first_index + I[1] - 1))
         end
-        return :($meta; V.parent[V.first_index + V.stride1*(I[1]-1)])
+        return :($meta; unsafe_getindex(V.parent, V.first_index + V.stride1*(I[1]-1)))
     end
     Isyms = [:(I[$d]) for d = 1:ni]
     exhead, idxs = index_generate(ndims(P), IV, :V, Isyms)
@@ -550,9 +550,9 @@ setindex!(V::SubArray, v, I::Int...) = (@_inline_meta; checkbounds(V, I...); uns
     if ni == 1 && length(IV.parameters) == LD  # linear indexing
         meta = Expr(:meta, :inline)
         if iscontiguous(V)
-            return :($meta; V.parent[V.first_index + I[1] - 1] = v)
+            return :($meta; unsafe_setindex!(V.parent, v, V.first_index + I[1] - 1))
         end
-        return :($meta; V.parent[V.first_index + V.stride1*(I[1]-1)] = v)
+        return :($meta; unsafe_setindex!(V.parent, v, V.first_index + V.stride1*(I[1]-1)))
     end
     Isyms = [:(I[$d]) for d = 1:ni]
     exhead, idxs = index_generate(ndims(P), IV, :V, Isyms)


### PR DESCRIPTION
This resolves the core issue behind the regressions in SubArray's performance as reported in #5117.  Unfortunately, without #7799, the surface syntax isn't very nice since it's a ton of unsafe_ function calls.

Using the test case from https://github.com/JuliaLang/julia/issues/5117#issuecomment-109206457 :
- Julia pre-10525 (benchmark as written, with `@inbounds`)

```
follow up: mykern( 2:(siz - 3), s, a, x, y )
   9.484 milliseconds (157 allocations: 10893 bytes)
follow up: mykern( 2:(siz - 3), s1, a, x1, y1 )
  68.632 milliseconds (16353 allocations: 718 KB)
follow up: mykern( 3:(siz - 2), s2, a, x2, y2 )
  16.753 milliseconds (6 allocations: 192 bytes)
  15.493 milliseconds (6 allocations: 192 bytes)
  17.036 milliseconds (6 allocations: 192 bytes)
```
- This branch (benchmark rewritten to use `unsafe_getindex`/`unsafe_setindex!`):

```
follow up: mykern( 2:(siz - 3), s, a, x, y )
  10.046 milliseconds (158 allocations: 11469 bytes)
follow up: mykern( 2:(siz - 3), s1, a, x1, y1 )
  70.425 milliseconds (19097 allocations: 827 KB)
follow up: mykern( 3:(siz - 2), s2, a, x2, y2 )
  14.263 milliseconds (6 allocations: 192 bytes)
  16.470 milliseconds (6 allocations: 192 bytes)
  16.711 milliseconds (6 allocations: 192 bytes)
```
