### PR TITLE
Only visit module parent when it is not NULL

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1567,7 +1567,9 @@ NOINLINE static int gc_mark_module(jl_module_t *m, int d)
         refyoung |= gc_push_root(m->constant_table, d);
     }
 
-    refyoung |= gc_push_root(m->parent, d);
+    if (m->parent) {
+        refyoung |= gc_push_root(m->parent, d);
+    }
 
     return refyoung;
 }


### PR DESCRIPTION
This can happen during bootstrap.

@carnaval 

This is the first bug discovered with https://github.com/JuliaLang/julia/pull/11358 . (Sadly?) Not a very interesting one...
