### PR TITLE
== for sparse matrices

### DIFF
--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -968,3 +968,28 @@ A[3,1] = 2
 A.nzval[2] = 0.0
 @test ishermitian(A) == true
 @test issym(A) == true
+
+# equality ==
+A1 = speye(10)
+A2 = speye(10)
+nonzeros(A1)[end]=0
+@test A1!=A2
+nonzeros(A1)[end]=1
+@test A1==A2
+A1[1:4,end] = 1
+@test A1!=A2
+nonzeros(A1)[end-4:end-1]=0
+@test A1==A2
+A2[1:4,end-1] = 1
+@test A1!=A2
+nonzeros(A2)[end-5:end-2]=0
+@test A1==A2
+A2[2:3,1] = 1
+@test A1!=A2
+nonzeros(A2)[2:3]=0
+@test A1==A2
+A1[2:5,1] = 1
+@test A1!=A2
+nonzeros(A1)[2:5]=0
+@test A1==A2
+@test sparse([1,1,0])!=sparse([0,1,1])


### PR DESCRIPTION
Currently `==` for sparse matrices falls back to the `AbstractArray` definition which iterates over all indices and thus is slow. This PR only looks at the actual entries and is much faster.  Works also with stored zeros.
