### PR TITLE
<<, >>, >>>: use intrinsics for more mixed-type shift operations.

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -104,6 +104,18 @@ for T in IntTypes
     else
         @eval >>(x::$T, y::Int) = box($T,ashr_int(unbox($T,x),unbox(Int,y)))
     end
+    for S in IntTypes
+        (S === Int128 || S === UInt128) && continue
+        @eval begin
+            <<(x::$T,  y::$S) = box($T, shl_int(unbox($T,x),unbox($S,y)))
+            >>>(x::$T, y::$S) = box($T,lshr_int(unbox($T,x),unbox($S,y)))
+        end
+        if issubtype(T,Unsigned)
+            @eval >>(x::$T, y::$S) = box($T,lshr_int(unbox($T,x),unbox($S,y)))
+        else
+            @eval >>(x::$T, y::$S) = box($T,ashr_int(unbox($T,x),unbox($S,y)))
+        end
+    end
 end
 
 bswap(x::Int8)    = x

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -112,9 +112,9 @@ const .≠ = .!=
 <<(x,y::Int)  = no_op_err("<<", typeof(x))
 >>(x,y::Int)  = no_op_err(">>", typeof(x))
 >>>(x,y::Int) = no_op_err(">>>", typeof(x))
-<<(x,y::Integer)  = x << convert(Int,y)
->>(x,y::Integer)  = x >> convert(Int,y)
->>>(x,y::Integer) = x >>> convert(Int,y)
+<<(x,y::Integer)  = typemax(Int) < y ? zero(x) : x <<  (y % Int)
+>>(x,y::Integer)  = typemax(Int) < y ? zero(x) : x >>  (y % Int)
+>>>(x,y::Integer) = typemax(Int) < y ? zero(x) : x >>> (y % Int)
 
 # fallback div, fld, and cld implementations
 # NOTE: C89 fmod() and x87 FPREM implicitly provide truncating float division,


### PR DESCRIPTION
LLVM isn't able to eliminate the additional checks done by fallbacks
for the mixed-type bitshift operations, so this change just calls
the intrinsics directly, which minimizes the amount of work done.
The fallback now avoids conversion checking as well and just returns
zero if the second argument is too large to fit in an Int.
