### PR TITLE
Deprecate old Regex constructor method (fixes #11593)

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -766,3 +766,19 @@ end
 
 const FloatingPoint = AbstractFloat
 export FloatingPoint
+
+# 11447
+
+function Regex(pattern::AbstractString, options::Integer)
+    flags = string([opt & options != 0? flag : ""
+        for (opt,flag) in [
+            (PCRE.CASELESS,  "i"),
+            (PCRE.MULTILINE, "m"),
+            (PCRE.DOTALL,    "s"),
+            (PCRE.EXTENDED,  "x")
+        ]
+    ]...)
+    depwarn("Constructing regexes with integer flags is deprecated, "*
+            "use string flags instead: Regex(\"$pattern\", \"$flags\").", :Regex)
+    Regex(pattern, flags)
+end


### PR DESCRIPTION
Is there a way to test this without throwing warnings? Seems like a lot noise to be added by such a small change.

It's not possible to replicate the old method, so I decided to be a little creative in order to generate a more useful warning.
