### PR TITLE
Have import look in pkg dir before working directory

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -4,13 +4,11 @@
 
 function find_in_path(name::AbstractString)
     isabspath(name) && return name
-    isfile(name) && return abspath(name)
     base = name
     if endswith(name,".jl")
         base = name[1:end-3]
     else
         name = string(base,".jl")
-        isfile(name) && return abspath(name)
     end
     for prefix in [Pkg.dir(); LOAD_PATH]
         path = joinpath(prefix, name)
@@ -19,6 +17,11 @@ function find_in_path(name::AbstractString)
         isfile(path) && return abspath(path)
         path = joinpath(prefix, name, "src", name)
         isfile(path) && return abspath(path)
+    end
+    isfile(name) && return abspath(name)
+    if base != name
+        name = string(base,".jl")
+        isfile(name) && return abspath(name)
     end
     return nothing
 end


### PR DESCRIPTION
Currently `import Foo` will first look in the working directory for an appropriately named file before trying to load a package called `Foo`. This PR reverses that precedence. I don't know if that's the optimal solution, or what the all the consequences might be, but I hope I can provoke some thought about this.

There are various problems that the current behavior can cause. All of them are not obvious failures, and can be difficult, especially for new users to debug. Here's an example:
1. Make a named `Markdown.jl`
2. Have it `import Markdown`
3. Run `julia Markdown.jl`
4. Julia hangs forever.

This is especially egregious on case-insensitive file systems, where the file might be named `markdown.jl`, or if `import Markdown` doesn't appear directly in that file, but something it imports. Furthermore, it's easy to break working code just by accidentally introducing files named the wrong things (e.g. `images.jl`, `distributions.jl`) in the same working directory. Once more command line tools are written in Julia, this behavior could be a security risk as well, at least as long as there's no way to disable it.

Our current behavior is similar to Python's, but I don't think this is a Python feature that's worth emulating. It has been raised before as a python issue ([a decade ago](https://bugs.python.org/issue946373)), but dismissed because it would break too many things to change.

It also comes up periodically here as well, for example: #9079
