### PR TITLE
combine .o and .ji by default, add output options to control it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
 script:
     - make check-whitespace || exit 1
     - make $BUILDOPTS -C base version_git.jl.phony
-    - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
+    - make $BUILDOPTS NO_GIT=1 JULIA_SYSIMG_BUILD_FLAGS="--output-ji ../usr/lib/julia/sys.ji" prefix=/tmp/julia install | moreutils/ts -s "%.s"
     - if [ `uname` = "Darwin" ]; then
         for name in spqr umfpack colamd cholmod amd suitesparse_wrapper; do
             install -pm755 usr/lib/lib${name}*.dylib* /tmp/julia/lib/julia/;

--- a/Make.inc
+++ b/Make.inc
@@ -374,9 +374,26 @@ LD := link
 endif #USEMSVC
 RANLIB := $(CROSS_COMPILE)ranlib
 
+# file extensions
+ifeq ($(OS), WINNT)
+  SHLIB_EXT = dll
+  SHELL_EXT = bat
+else ifeq ($(OS), Darwin)
+  SHLIB_EXT = dylib
+  SHELL_EXT = sh
+else
+  SHLIB_EXT = so
+  SHELL_EXT = sh
+endif
+
 
 # if not absolute, then relative to the directory of the julia executable
+# on windows, use .ji by default
+ifeq ($(OS),WINNT)
 JCPPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.ji\""
+else
+JCPPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.$(SHLIB_EXT)\""
+endif
 
 # On Windows, we want shared library files to end up in $(build_bindir), instead of $(build_libdir)
 ifeq ($(OS),WINNT)
@@ -679,18 +696,6 @@ else ifeq ($(OS), Darwin)
 else
   RPATH = -Wl,-rpath,'$$ORIGIN/$(build_private_libdir_rel)' -Wl,-rpath,'$$ORIGIN/$(build_libdir_rel)' -Wl,-z,origin
   RPATH_ORIGIN = -Wl,-rpath,'$$ORIGIN' -Wl,-z,origin
-endif
-
-# file extensions
-ifeq ($(OS), WINNT)
-  SHLIB_EXT = dll
-  SHELL_EXT = bat
-else ifeq ($(OS), Darwin)
-  SHLIB_EXT = dylib
-  SHELL_EXT = sh
-else
-  SHLIB_EXT = so
-  SHELL_EXT = sh
 endif
 
 # --whole-archive

--- a/base/client.jl
+++ b/base/client.jl
@@ -227,10 +227,11 @@ let reqarg = Set(UTF8String["--home",          "-H",
                             "--startup-file",
                             "--compile",
                             "--check-bounds",
-                            "--dump-bitcode",
                             "--depwarn",
                             "--inline",
-                            "--build",        "-b",
+                            "--output-o",
+                            "--output-ji",
+                            "--output-bc",
                             "--bind-to"])
     global process_options
     function process_options(opts::JLOptions, args::Vector{UTF8String})

--- a/base/options.jl
+++ b/base/options.jl
@@ -5,7 +5,6 @@ immutable JLOptions
     quiet::Int8
     julia_home::Ptr{UInt8}
     julia_bin::Ptr{UInt8}
-    build_path::Ptr{UInt8}
     eval::Ptr{UInt8}
     print::Ptr{UInt8}
     postboot::Ptr{UInt8}
@@ -23,13 +22,15 @@ immutable JLOptions
     malloc_log::Int8
     opt_level::Int8
     check_bounds::Int8
-    dumpbitcode::Int8
     depwarn::Int8
     can_inline::Int8
     fast_math::Int8
     worker::Int8
-    bindto::Ptr{UInt8}
     handle_signals::Int8
+    bindto::Ptr{UInt8}
+    outputbc::Ptr{UInt8}
+    outputo::Ptr{UInt8}
+    outputji::Ptr{UInt8}
 end
 
 JLOptions() = unsafe_load(cglobal(:jl_options, JLOptions))

--- a/src/ast.c
+++ b/src/ast.c
@@ -140,7 +140,7 @@ void jl_init_frontend(void)
 
     // Enable / disable syntax deprecation warnings
     // Disable in imaging mode to avoid i/o errors (#10727)
-    if (jl_options.build_path != NULL)
+    if (jl_generating_output())
         jl_parse_depwarn(0);
     else
         jl_parse_depwarn((int)jl_options.depwarn);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -75,7 +75,7 @@ static inline void add_named_global(GlobalValue *gv, void *addr)
 #ifdef _OS_WINDOWS_
     std::string imp_name;
     // setting DLLEXPORT correctly only matters when building a binary
-    if (jl_options.build_path != NULL) {
+    if (jl_generating_output()) {
         // add the __declspec(dllimport) attribute
         gv->setDLLStorageClass(GlobalValue::DLLImportStorageClass);
         // this will cause llvm to rename it, so we do the same
@@ -97,7 +97,7 @@ static inline void add_named_global(GlobalValue *gv, void *addr)
 
 #ifdef _OS_WINDOWS_
     // setting DLLEXPORT correctly only matters when building a binary
-    if (jl_options.build_path != NULL) {
+    if (jl_generating_output()) {
         if (gv->getLinkage() == GlobalValue::ExternalLinkage)
             gv->setLinkage(GlobalValue::DLLImportLinkage);
 #ifdef _P64

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5683,7 +5683,7 @@ extern "C" void jl_init_codegen(void)
 #if defined(_CPU_PPC_) || defined(_CPU_PPC64_)
     imaging_mode = true; // LLVM seems to JIT bad TOC tables for the optimizations we attempt in non-imaging_mode
 #else
-    imaging_mode = jl_options.build_path != NULL;
+    imaging_mode = jl_generating_output();
 #endif
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR <= 3

--- a/src/dump.c
+++ b/src/dump.c
@@ -201,20 +201,16 @@ DLLEXPORT int jl_running_on_valgrind()
     return RUNNING_ON_VALGRIND;
 }
 
-static void jl_load_sysimg_so()
+static int jl_load_sysimg_so()
 {
 #ifndef _OS_WINDOWS_
     Dl_info dlinfo;
 #endif
     // attempt to load the pre-compiled sysimage from jl_sysimg_handle
-    // if this succeeds, sysimg_gvars will be a valid array
-    // otherwise, it will be NULL
-    if (jl_sysimg_handle == 0) {
-        sysimg_gvars = 0;
-        return;
-    }
+    if (jl_sysimg_handle == 0)
+        return -1;
 
-    int imaging_mode = jl_options.build_path != NULL;
+    int imaging_mode = jl_generating_output();
 #ifdef _OS_WINDOWS_
     //XXX: the windows linker forces our system image to be
     //     linked against only one dll, I picked libjulia-release
@@ -261,7 +257,9 @@ static void jl_load_sysimg_so()
     if (sysimg_data) {
         size_t len = *(size_t*)jl_dlsym(jl_sysimg_handle, "jl_system_image_size");
         jl_restore_system_image_data(sysimg_data, len);
+        return 0;
     }
+    return -1;
 }
 
 static jl_value_t *jl_deserialize_gv(ios_t *s, jl_value_t *v)
@@ -1503,8 +1501,11 @@ DLLEXPORT void jl_preload_sysimg_so(const char *fname)
     char *fname_shlib = (char*)alloca(strlen(fname)+1);
     strcpy(fname_shlib, fname);
     char *fname_shlib_dot = strrchr(fname_shlib, '.');
-    if (fname_shlib_dot != NULL)
+    if (fname_shlib_dot != NULL) {
+        if (!strcmp(fname_shlib_dot, ".ji"))
+            return;  // .ji extension => load .ji file only
         *fname_shlib_dot = 0;
+    }
 
     // Get handle to sys.so
 #ifdef _OS_WINDOWS_
@@ -1603,19 +1604,21 @@ DLLEXPORT void jl_restore_system_image(const char *fname)
     char *dot = (char*) strrchr(fname, '.');
     int is_ji = (dot && !strcmp(dot, ".ji"));
 
-    jl_load_sysimg_so();
     if (!is_ji) {
-        if (sysimg_gvars == 0)
+        int err = jl_load_sysimg_so();
+        if (err != 0) {
+            if (jl_sysimg_handle == 0)
+                jl_errorf("System image file \"%s\" not found\n", fname);
+            jl_errorf("Library \"%s\" does not contain a valid system image\n", fname);
+        }
+    }
+    else {
+        ios_t f;
+        if (ios_file(&f, fname, 1, 0, 0, 0) == NULL)
             jl_errorf("System image file \"%s\" not found\n", fname);
-        return;
+        jl_restore_system_image_from_stream(&f);
+        ios_close(&f);
     }
-
-    ios_t f;
-    if (ios_file(&f, fname, 1, 0, 0, 0) == NULL) {
-        jl_errorf("System image file \"%s\" not found\n", fname);
-    }
-    jl_restore_system_image_from_stream(&f);
-    ios_close(&f);
 }
 
 DLLEXPORT void jl_restore_system_image_data(const char *buf, size_t len)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1534,7 +1534,6 @@ typedef struct {
     int8_t quiet;
     const char *julia_home;
     const char *julia_bin;
-    const char *build_path;
     const char *eval;
     const char *print;
     const char *postboot;
@@ -1552,16 +1551,20 @@ typedef struct {
     int8_t malloc_log;
     int8_t opt_level;
     int8_t check_bounds;
-    int8_t dumpbitcode;
     int8_t depwarn;
     int8_t can_inline;
     int8_t fast_math;
     int8_t worker;
-    const char *bindto;
     int8_t handle_signals;
+    const char *bindto;
+    const char *outputbc;
+    const char *outputo;
+    const char *outputji;
 } jl_options_t;
 
 extern DLLEXPORT jl_options_t jl_options;
+
+DLLEXPORT int jl_generating_output();
 
 // Settings for code_coverage and malloc_log
 // NOTE: if these numbers change, test/cmdlineargs.jl will have to be updated
@@ -1577,9 +1580,6 @@ extern DLLEXPORT jl_options_t jl_options;
 #define JL_OPTIONS_COMPILE_OFF 0
 #define JL_OPTIONS_COMPILE_ON  1
 #define JL_OPTIONS_COMPILE_ALL 2
-
-#define JL_OPTIONS_DUMPBITCODE_ON 1
-#define JL_OPTIONS_DUMPBITCODE_OFF 2
 
 #define JL_OPTIONS_COLOR_ON 1
 #define JL_OPTIONS_COLOR_OFF 2

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -75,7 +75,7 @@ jl_array_t *jl_module_init_order = NULL;
 // load time init procedure: in build mode, only record order
 void jl_module_load_time_initialize(jl_module_t *m)
 {
-    int build_mode = (jl_options.build_path != NULL);
+    int build_mode = jl_generating_output();
     if (build_mode) {
         if (jl_module_init_order == NULL)
             jl_module_init_order = jl_alloc_cell_1d(0);
@@ -111,7 +111,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
     jl_module_t *parent_module = jl_current_module;
     jl_binding_t *b = jl_get_binding_wr(parent_module, name);
     jl_declare_constant(b);
-    if (b->value != NULL && jl_options.build_path == NULL) {
+    if (b->value != NULL && !jl_generating_output()) {
         jl_printf(JL_STDERR, "Warning: replacing module %s\n", name->name);
     }
     jl_module_t *newm = jl_new_module(name);

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -86,8 +86,9 @@ static const char opts[]  =
     " --depwarn={yes|no}        Enable or disable syntax and method deprecation warnings\n\n"
 
     // compiler output options
-    " --build name              Generate a system image with the given name (without extension)\n"
-    " --dump-bitcode={yes|no}   Dump bitcode for the system image\n\n"
+    " --output-o name           Generate an object file (including system image data)\n"
+    " --output-ji name          Generate a system image data file (.ji)\n"
+    " --output-bc name          Generate LLVM bitcode (.bc)\n\n"
 
     // instrumentation options
     " --code-coverage={none|user|all}, --code-coverage\n"
@@ -106,13 +107,15 @@ void parse_opts(int *argcp, char ***argvp)
            opt_code_coverage,
            opt_track_allocation,
            opt_check_bounds,
-           opt_dump_bitcode,
+           opt_output_bc,
            opt_depwarn,
            opt_inline,
            opt_math_mode,
            opt_worker,
            opt_bind_to,
-           opt_handle_signals
+           opt_handle_signals,
+           opt_output_o,
+           opt_output_ji
     };
     static char* shortopts = "+vhqFfH:e:E:P:L:J:C:ip:Ob:";
     static struct option longopts[] = {
@@ -141,13 +144,14 @@ void parse_opts(int *argcp, char ***argvp)
         { "track-allocation",optional_argument, 0, opt_track_allocation },
         { "optimize",        no_argument,       0, 'O' },
         { "check-bounds",    required_argument, 0, opt_check_bounds },
-        { "dump-bitcode",    required_argument, 0, opt_dump_bitcode },
+        { "output-bc",       required_argument, 0, opt_output_bc },
+        { "output-o",        required_argument, 0, opt_output_o },
+        { "output-ji",       required_argument, 0, opt_output_ji },
         { "depwarn",         required_argument, 0, opt_depwarn },
         { "inline",          required_argument, 0, opt_inline },
         { "math-mode",       required_argument, 0, opt_math_mode },
         { "handle-signals",  required_argument, 0, opt_handle_signals },
         // hidden command line options
-        { "build",           required_argument, 0, 'b' },
         { "worker",          no_argument,       0, opt_worker },
         { "bind-to",         required_argument, 0, opt_bind_to },
         { "lisp",            no_argument,       &lisp_prompt, 1 },
@@ -307,11 +311,17 @@ void parse_opts(int *argcp, char ***argvp)
             else
                 jl_errorf("julia: invalid argument to --check-bounds={yes|no} (%s)\n", optarg);
             break;
-        case opt_dump_bitcode:
-            if (!strcmp(optarg,"yes"))
-                jl_options.dumpbitcode = JL_OPTIONS_DUMPBITCODE_ON;
-            else if (!strcmp(optarg,"no"))
-                jl_options.dumpbitcode = JL_OPTIONS_DUMPBITCODE_OFF;
+        case opt_output_bc:
+            jl_options.outputbc = optarg;
+            if (!imagepathspecified) jl_options.image_file = NULL;
+            break;
+        case opt_output_o:
+            jl_options.outputo = optarg;
+            if (!imagepathspecified) jl_options.image_file = NULL;
+            break;
+        case opt_output_ji:
+            jl_options.outputji = optarg;
+            if (!imagepathspecified) jl_options.image_file = NULL;
             break;
         case opt_depwarn:
             if (!strcmp(optarg,"yes"))
@@ -339,11 +349,6 @@ void parse_opts(int *argcp, char ***argvp)
                 jl_options.fast_math = JL_OPTIONS_FAST_MATH_DEFAULT;
             else
                 jl_errorf("julia: invalid argument to --math-mode (%s)\n", optarg);
-            break;
-        case 'b': // build
-            jl_options.build_path = strdup(optarg);
-            if (!imagepathspecified)
-                jl_options.image_file = NULL;
             break;
         case opt_worker:
             jl_options.worker = 1;


### PR DESCRIPTION
This switches us to generating a .o with system image data included by default. It adds the following options:
- `--output-o` Write a .o.
- `--output-ji` Write a .ji file
- `--output-bc` Write LLVM bitcode.

`--build` and `--dump-bitcode` are replaced by these.
