### PR TITLE
Even more tests for linear algebra special matrices

### DIFF
--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -28,6 +28,8 @@ for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
     if relty != BigFloat
         @test_approx_eq_eps D\v DM\v 2n^2*eps(relty)*(elty<:Complex ? 2:1)
         @test_approx_eq_eps D\U DM\U 2n^3*eps(relty)*(elty<:Complex ? 2:1)
+        @test_approx_eq_eps A_ldiv_B!(D,copy(v)) DM\v 2n^2*eps(relty)*(elty<:Complex ? 2:1)
+        @test_approx_eq_eps A_ldiv_B!(D,copy(U)) DM\U 2n^3*eps(relty)*(elty<:Complex ? 2:1)
     end
 
     debug && println("Simple unary functions")

--- a/test/linalg/givens.jl
+++ b/test/linalg/givens.jl
@@ -29,6 +29,11 @@ for elty in (Float32, Float64, Complex64, Complex128)
             @test_throws ErrorException transpose(R)
         end
     end
+    @test_throws ArgumentError givens(A, 3, 2, 2)
+    @test_throws ArgumentError givens(one(elty),zero(elty),3,2)
+    G, _ = givens(one(elty),zero(elty),11,12)
+    @test_throws DimensionMismatch A_mul_B!(G, A)
+    @test_throws DimensionMismatch A_mul_Bc!(A,G)
     @test_approx_eq abs(A) abs(hessfact(Ac)[:H])
     @test_approx_eq norm(R*eye(elty, 10)) one(elty)
 

--- a/test/linalg3.jl
+++ b/test/linalg3.jl
@@ -246,6 +246,13 @@ b = randn(Base.LinAlg.SCAL_CUTOFF) # make sure we try BLAS path
 # issue #6450
 @test dot(Any[1.0,2.0], Any[3.5,4.5]) === 12.5
 
+@test_throws DimensionMismatch dot([1.0,2.0,3.0], 1:2, [3.5,4.5,5.5], 1:3)
+@test_throws BoundsError dot([1.0,2.0,3.0], 1:4, [3.5,4.5,5.5], 1:4)
+@test_throws BoundsError dot([1.0,2.0,3.0], 1:3, [3.5,4.5,5.5], 2:4)
+@test_throws DimensionMismatch dot(Complex128[1.0,2.0,3.0], 1:2, Complex128[3.5,4.5,5.5], 1:3)
+@test_throws BoundsError dot(Complex128[1.0,2.0,3.0], 1:4, Complex128[3.5,4.5,5.5], 1:4)
+@test_throws BoundsError dot(Complex128[1.0,2.0,3.0], 1:3, Complex128[3.5,4.5,5.5], 2:4)
+
 # issue #7181
 A = [ 1  5  9
       2  6 10


### PR DESCRIPTION
The `A_ldiv_B` methods for `Diagonal`s still needed tests. `Givens` needed a bunch of error throwing tests, as did `dot` for ranges.
