### PR TITLE
Tiny correction to the documentation

### DIFF
--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -278,7 +278,7 @@ Rationals can be easily converted to floating-point numbers:
 
 Conversion from rational to floating-point respects the following
 identity for any integral values of ``a`` and ``b``, with the exception
-of the case ``a == 0`` and ``b == 0``:
+of the case ``a = 0`` and ``b = 0``:
 
 .. doctest::
 


### PR DESCRIPTION
A correction to the documentation on [complex and rational numbers](http://julia.readthedocs.org/en/latest/manual/complex-and-rational-numbers/#man-complex-and-rational-numbers):

Presently, the documentation reads:

> Conversion from rational to floating-point respects the following identity for any integral values of `a` and `b`, with the exception of the case `a == 0` and `b == 0`

A correction is proposed to change `a == 0` to `a = 0` and `b == 0` to `b = 0`. 

The reasoning behind this is that `a == 0` is not a 'case' per se, it is a test of equality. There is no such case as 'is a equal to zero?', only a case 'in which a is equal to zero'. For this reason, single equality signs would be more appropriate.
