### PR TITLE
improve vectorized float()/complex() for homogeneous arrays of numbers

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -730,18 +730,15 @@ big{T<:Integer}(z::Complex{T}) = Complex{BigInt}(z)
 
 ## Array operations on complex numbers ##
 
-complex{T<:Complex}(x::AbstractArray{T}) = x
+complex{T<:Complex}(A::AbstractArray{T}) = A
 
-complex{T<:Union{Integer64,Float64,Float32,Float16}}(x::AbstractArray{T}) =
-    convert(AbstractArray{typeof(complex(zero(T)))}, x)
+complex{T<:Number}(A::AbstractArray{T}) =
+    convert(AbstractArray{typeof(complex(zero(T)))}, A)
 
-function complex(A::AbstractArray)
-    cnv(x) = convert(Complex,x)
-    map_promote(cnv, A)
-end
+complex(A::AbstractArray) = map_promote(Complex,A)
 
-big{T<:Integer,N}(x::AbstractArray{Complex{T},N}) = convert(AbstractArray{Complex{BigInt},N}, x)
-big{T<:FloatingPoint,N}(x::AbstractArray{Complex{T},N}) = convert(AbstractArray{Complex{BigFloat},N}, x)
+big{T<:Integer,N}(A::AbstractArray{Complex{T},N}) = convert(AbstractArray{Complex{BigInt},N}, A)
+big{T<:FloatingPoint,N}(A::AbstractArray{Complex{T},N}) = convert(AbstractArray{Complex{BigFloat},N}, A)
 
 ## promotion to complex ##
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -732,10 +732,12 @@ big{T<:Integer}(z::Complex{T}) = Complex{BigInt}(z)
 
 complex{T<:Complex}(A::AbstractArray{T}) = A
 
-complex{T<:Number}(A::AbstractArray{T}) =
+function complex{T}(A::AbstractArray{T})
+    if !isleaftype(T)
+        error("`complex` not defined on abstractly-typed arrays; please convert to a more specific type")
+    end
     convert(AbstractArray{typeof(complex(zero(T)))}, A)
-
-complex(A::AbstractArray) = map_promote(Complex,A)
+end
 
 big{T<:Integer,N}(A::AbstractArray{Complex{T},N}) = convert(AbstractArray{Complex{BigInt},N}, A)
 big{T<:FloatingPoint,N}(A::AbstractArray{Complex{T},N}) = convert(AbstractArray{Complex{BigFloat},N}, A)

--- a/base/float.jl
+++ b/base/float.jl
@@ -453,14 +453,13 @@ exponent_bias{T<:FloatingPoint}(::Type{T}) = Int(exponent_one(T) >> significand_
 
 ## Array operations on floating point numbers ##
 
-float{T<:FloatingPoint}(x::AbstractArray{T}) = x
+float{T<:FloatingPoint}(A::AbstractArray{T}) = A
 
-float{T<:Integer64}(x::AbstractArray{T}) = convert(AbstractArray{typeof(float(zero(T)))}, x)
+float{T<:Number}(A::AbstractArray{T}) =
+    convert(AbstractArray{typeof(float(zero(T)))}, A)
 
-function float(A::AbstractArray)
-    cnv(x) = convert(FloatingPoint,x)
-    map_promote(cnv, A)
-end
+float(A::AbstractArray) =
+    map_promote(FloatingPoint, A)
 
 for fn in (:float,:big)
     @eval begin

--- a/base/float.jl
+++ b/base/float.jl
@@ -455,11 +455,12 @@ exponent_bias{T<:FloatingPoint}(::Type{T}) = Int(exponent_one(T) >> significand_
 
 float{T<:FloatingPoint}(A::AbstractArray{T}) = A
 
-float{T<:Number}(A::AbstractArray{T}) =
+function float{T}(A::AbstractArray{T})
+    if !isleaftype(T)
+        error("`float` not defined on abstractly-typed arrays; please convert to a more specific type")
+    end
     convert(AbstractArray{typeof(float(zero(T)))}, A)
-
-float(A::AbstractArray) =
-    map_promote(FloatingPoint, A)
+end
 
 for fn in (:float,:big)
     @eval begin


### PR DESCRIPTION
Use the `convert(::AbstractArray{T}, x)` function instead of falling
back to `map_promote`.  This solves the issue like picking the return
type for the empty array case for <: Number.  In the general case, where
the conversion is potentially undefined, fall back to the generic
`map_promote`.

"fixes" the empty array `Bool[]` case #11658
