### PR TITLE
support multiple topologies

### DIFF
--- a/base/managers.jl
+++ b/base/managers.jl
@@ -36,7 +36,7 @@ end
 
 function check_addprocs_args(kwargs)
     for keyname in kwargs
-        !(keyname[1] in [:dir, :exename, :exeflags]) && throw(ArgumentError("Invalid keyword argument $(keyname[1])"))
+        !(keyname[1] in [:dir, :exename, :exeflags, :topology]) && throw(ArgumentError("Invalid keyword argument $(keyname[1])"))
     end
 end
 

--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -755,7 +755,22 @@ implementation simply executes an ``exit()`` call on the specified remote worker
 ``examples/clustermanager/simple`` is an example that shows a simple implementation using unix domain sockets for cluster setup
 
 
+Specifying network topology (Experimental)
+-------------------------------------------
 
+Keyword argument ``topology`` to ``addprocs`` is used to specify how the workers must
+be connected to each other:
+    - ``:all_to_all`` : is the default, where all workers are connected to each other.
+
+    - ``:master_slave`` : only the driver process, i.e. pid 1 has connections to the workers.
+
+    - ``:custom`` : the ``launch`` method of the cluster manager specifes the connection topology.
+      Fields ``ident`` and ``connect_idents`` in ``WorkerConfig`` are used to specify the  same.
+      ``connect_idents`` is a list of ``ClusterManager`` provided identifiers to workers that worker
+      with identified by ``ident`` must connect to.
+
+Currently sending a message between unconnected workers results in an error. This behaviour, as also the
+functionality and interface should be considered experimental in nature and may change in future releases.
 
 .. rubric:: Footnotes
 

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -323,6 +323,24 @@ if Bool(parse(Int,(get(ENV, "JULIA_TESTFULL", "0"))))
 
     print("\n\nPassed all pmap tests that print errors.\n")
 
+    # Topology tests need to run externally since
+    # a given cluster at any time can only support a single topology and the
+    # current session is already running in parallel under the default
+    # topology.
+    # They also print errors to screen
+    print("\n\nTopology tests. \n")
+
+    script = joinpath(dirname(@__FILE__), "topology.jl")
+    cmd = `$(joinpath(JULIA_HOME,Base.julia_exename())) $script`
+
+    (strm, proc) = open(cmd)
+    wait(proc)
+    if !success(proc) && ccall(:jl_running_on_valgrind,Cint,()) == 0
+        println(readall(strm))
+        error("Topology tests failed : $cmd")
+    end
+
+
 @unix_only begin
     function test_n_remove_pids(new_pids)
         for p in new_pids

--- a/test/topology.jl
+++ b/test/topology.jl
@@ -1,0 +1,81 @@
+include("testdefs.jl")
+addprocs(4; topology="master_slave")
+v=remotecall_fetch(2, ()->remotecall_fetch(3,myid))
+@test isa(v, Exception)
+
+function test_worker_counts()
+    # check if the nprocs/nworkers/workers are the same on the remaining workers
+    np=nprocs()
+    nw=nworkers()
+    ws=sort(workers())
+
+    for p in workers()
+        @test (true, true, true) == remotecall_fetch(p, (x,y,z)->(x==nprocs(), y==nworkers(), z==sort(workers())), np, nw, ws)
+    end
+end
+
+function remove_workers_and_test()
+    while nworkers() > 0
+        @test :ok == rmprocs(workers()[1]; waitfor=2.0)
+        test_worker_counts()
+        if nworkers() == nprocs()
+            break
+        end
+    end
+end
+
+remove_workers_and_test()
+
+# a hack just to test the "custom" topology.
+# connect even pids to other even pids, odd to odd.
+function Base.launch(manager::Base.LocalManager, params::Dict, launched::Array, c::Condition)
+    dir = params[:dir]
+    exename = params[:exename]
+    exeflags = params[:exeflags]
+
+    for i in 1:manager.np
+        io, pobj = open(detach(
+            setenv(`$(Base.julia_cmd(exename)) $exeflags --bind-to $(Base.LPROC.bind_addr) --worker`, dir=dir)), "r")
+        wconfig = WorkerConfig()
+        wconfig.process = pobj
+        wconfig.io = io
+        wconfig.ident = i
+        wconfig.connect_idents = collect(i+2:2:manager.np)
+        push!(launched, wconfig)
+    end
+
+    notify(c)
+end
+const map_pid_ident=Dict()
+function Base.manage(manager::Base.LocalManager, id::Integer, config::WorkerConfig, op::Symbol)
+    if op == :register
+        map_pid_ident[id] = get(config.ident)
+    elseif op == :interrupt
+        kill(get(config.process), 2)
+    end
+end
+
+addprocs(8; topology="custom")
+
+while true
+    if any(x->get(map_pid_ident, x, 0)==0, workers())
+        yield()
+    else
+        break
+    end
+end
+
+for p1 in workers()
+    for p2 in workers()
+        i1 = map_pid_ident[p1]
+        i2 = map_pid_ident[p2]
+        if (iseven(i1) && iseven(i2)) || (isodd(i1) && isodd(i2))
+            @test p2 == remotecall_fetch(p1, p->remotecall_fetch(p,myid), p2)
+        else
+            v1 = remotecall_fetch(p1, p->remotecall_fetch(p,myid), p2)
+            @test isa(v1, Exception)
+        end
+    end
+end
+
+remove_workers_and_test()


### PR DESCRIPTION
edit : current iteration : https://github.com/JuliaLang/julia/pull/11665#issuecomment-125201449

Currently all workers are connected to all other workers. However, a large number of use cases require connections between the master and workers only, and the we can optimize the total number of TCP connections for such cases, especially with hundreds of workers.

This PR provides a means of supporting multiple connection topologies in the future. Currently ALL_TO_ALL and MASTER_SLAVE are supported.

Default is MASTER_SLAVE, which is a BREAKING change for programs that expect all to all connections.

With `all_to_all`, `@time addprocs(8)` takes around 1.7 seconds.
With `master_slave`, `@time addprocs(8)` takes around 0.8 seconds.
- program arg `-I` or `--interconnect` specifies the interconnect type to be setup by `addprocs`
- valid options are `all_to_all`, `master_slave` and `custom`. Default is `master_slave`
- `custom` indicates that the cluster manager is responsible for the connection topology and it will provide the list of workers that a worker must connect with. Currently unsupported.
- the master continues to be connected to all workers.
- We cannot have a mix of workers with some connected via all_to_all and the rest in master_slave mode.

While currently we cannot send requests between nodes that are not connected to each other, we can build on this to  implement routing mechanisms that will efficiently transport messages via intermediate, mutually connected nodes. Especially required for broadcast type of requests. 

edit : standardized on the term "topology" in place of  "interconnect".
