### PR TITLE
Register JIT frames with the correct unwinder when linking LLVM dylib

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,6 +28,7 @@ endif
 LLVMLINK = $(call exec,$(LLVM_CONFIG) --ldflags) $(call exec,$(LLVM_CONFIG) --libs) $(call exec,$(LLVM_CONFIG) --ldflags) $(call exec,$(LLVM_CONFIG) --system-libs 2> /dev/null)
 ifeq ($(USE_LLVM_SHLIB),1)
 LLVMLINK = $(call exec,$(LLVM_CONFIG) --ldflags) -lLLVM-$(call exec,$(LLVM_CONFIG) --version)
+FLAGS += -DLLVM_SHLIB
 endif
 
 COMMON_LIBS = -L$(build_shlibdir) -L$(build_libdir) $(LIBUV) $(LIBUTF8PROC) $(NO_WHOLE_ARCHIVE) $(LLVMLINK) $(OSLIBS)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -269,6 +269,10 @@ static GlobalVariable *jldll_var;
 extern JITMemoryManager* createJITMemoryManagerWin();
 #endif
 #endif //_OS_WINDOWS_
+#if defined(_OS_DARWIN_) && defined(LLVM37) && defined(LLVM_SHLIB)
+#define CUSTOM_MEMORY_MANAGER 1
+extern RTDyldMemoryManager* createRTDyldMemoryManagerOSX();
+#endif
 
 // important functions
 static Function *jlnew_func;
@@ -5623,6 +5627,8 @@ extern "C" void jl_init_codegen(void)
     eb  .setEngineKind(EngineKind::JIT)
 #if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_) && !defined(USE_MCJIT)
         .setJITMemoryManager(createJITMemoryManagerWin())
+#elif defined(CUSTOM_MEMORY_MANAGER)
+        .setMCJITMemoryManager(std::move(std::unique_ptr<RTDyldMemoryManager>{createRTDyldMemoryManagerOSX()}))
 #endif
         .setTargetOptions(options)
         .setRelocationModel(Reloc::PIC_)


### PR DESCRIPTION
Since we provide our custom unwinder in libjulia, LLVM had trouble finding it,
falling back to the system unwinder, so our custom unwinder did not know about
JIT frames. Fix this by creating a memory manager that calls the registration
functions in the same shared library as the unwinder, thus making sure we get
the right symbol.
