### PR TITLE
RFC: clean up timer API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -289,7 +289,7 @@ Library improvements
 
     * You can now tab-complete Emoji characters via their [short names](http://www.emoji-cheat-sheet.com/), using `\:name:<tab>` ([#10709]).
 
-    * The `gc_enable` and `gc_disable` functions now return the previous GC state.
+    * `gc_enable` subsumes `gc_disable`, and also returns the previous GC state.
 
     * `assert`, `@assert` now throws an `AssertionError` exception type ([#9734]).
 
@@ -398,6 +398,8 @@ Deprecated or removed
     of type `Vector{UInt8}`, `Vector{UInt16}`, `Vector{UInt32}`, and `Vector{Char}` ([#11241]).
 
   * Instead of `utf32(64,123,...)` use `utf32(UInt32[64,123,...])` ([#11379]).
+
+  * `start_timer` and `stop_timer` are replaced by `Timer` and `close`.
 
 Julia v0.3.0 Release Notes
 ==========================

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -517,3 +517,13 @@ end
 
 @deprecate gc_enable() gc_enable(true)
 @deprecate gc_disable() gc_enable(false)
+
+@deprecate stop_timer close
+
+function Timer(f::Function)
+    error("Timer(f) is deprecated. Use Timer(f, delay, repeat) instead.")
+end
+
+function start_timer(t, d, r)
+    error("start_timer is deprecated. Use Timer(callback, delay, repeat) instead.")
+end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1177,8 +1177,6 @@ export
     serialize,
     skip,
     skipchars,
-    start_timer,
-    stop_timer,
     takebuf_array,
     takebuf_string,
     truncate,

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1533,15 +1533,14 @@ function timedwait(testcb::Function, secs::Float64; pollint::Float64=0.1)
         catch e
             put!(done, :error)
         finally
-            isready(done) && stop_timer(aw)
+            isready(done) && close(aw)
         end
     end
 
     if !testcb()
-        t = Timer(timercb)
-        start_timer(t, pollint, pollint)
+        t = Timer(timercb, pollint, pollint)
         ret = fetch(done)
-        stop_timer(t)
+        close(t)
     else
         ret = :ok
     end

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -926,21 +926,20 @@ Errors
 Events
 ------
 
-.. function:: Timer(f::Function)
+.. function:: Timer(callback::Function, delay, repeat=0)
 
-   Create a timer to call the given callback function. The callback
-   is passed one argument, the timer object itself. The timer can be
-   started and stopped with ``start_timer`` and ``stop_timer``.
-
-.. function:: start_timer(t::Timer, delay, repeat)
-
-   Start invoking the callback for a ``Timer`` after the specified initial
-   delay, and then repeating with the given interval. Times are in seconds.
+   Create a timer to call the given callback function.
+   The callback is passed one argument, the timer object itself.
+   The callback will be invoked after the specified initial delay,
+   and then repeating with the given ``repeat`` interval.
    If ``repeat`` is ``0``, the timer is only triggered once.
+   Times are in seconds.
+   A timer is stopped and has its resources freed by calling ``close`` on it.
 
-.. function:: stop_timer(t::Timer)
+.. function:: Timer(delay, repeat=0)
 
-   Stop invoking the callback for a timer.
+   Create a timer that wakes up tasks waiting for it (by calling ``wait`` on
+   the timer object) at a specified interval.
 
 Reflection
 ----------

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -68,6 +68,7 @@ enum CALLBACK_TYPE { CB_PTR, CB_INT32, CB_UINT32, CB_INT64, CB_UINT64 };
     XX(connectcb) \
     XX(connectioncb) \
     XX(asynccb) \
+    XX(timercb) \
     XX(getaddrinfo) \
     XX(pollcb) \
     XX(fspollcb) \
@@ -228,6 +229,11 @@ DLLEXPORT void jl_uv_getaddrinfocb(uv_getaddrinfo_t *req,int status, struct addr
 DLLEXPORT void jl_uv_asynccb(uv_handle_t *handle)
 {
     JULIA_CB(asynccb,handle->data,0);
+}
+
+DLLEXPORT void jl_uv_timercb(uv_handle_t *handle)
+{
+    JULIA_CB(timercb,handle->data,0);
 }
 
 DLLEXPORT void jl_uv_pollcb(uv_poll_t *handle, int status, int events)


### PR DESCRIPTION
This fixes the following problems:
- start_timer and stop_timer were ugly, and are now removed.
- Timer resources were never fully freed because Timers were never closed, only "stopped". It wasn't clear whether a stopped timer was done for good, or would be restarted.
- We were calling user callbacks directly from libuv callbacks, meaning they could not block.

The new API is
- `Timer(callback, timeout, repeat=0)` creates _and starts_ a timer that calls a callback repeatedly.
- `close(timer)` stops and fully shuts down a timer. If a timer is set not to repeat, it closes itself after firing once.
- `Timer(timeout, repeat=0)` creates a timer that periodically wakes up whoever calls `wait` on it. This is used to implement `sleep` in 1 line.

~~This PR also removes `SingleAsyncWork` because it's not used anywhere and is redundant with `@schedule`.~~

Developed with @vtjnash.
