### PR TITLE
Add patch to set PCRE2 stack size dynamically

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -747,6 +747,7 @@ pcre2-$(PCRE_VER)/configure: pcre2-$(PCRE_VER).tar.bz2
 pcre2-$(PCRE_VER)/config.status: pcre2-$(PCRE_VER)/configure
 	cd pcre2-$(PCRE_VER) && \
 	./configure $(CONFIGURE_COMMON) --enable-jit --includedir=$(build_includedir)
+	patch -p0 pcre2-10.10/RunTest < pcre2_RunTest.patch
 	touch -c $@
 $(PCRE_SRC_TARGET): pcre2-$(PCRE_VER)/config.status
 	$(MAKE) -C pcre2-$(PCRE_VER) $(LIBTOOL_CCLD)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -743,11 +743,11 @@ pcre2-$(PCRE_VER).tar.bz2:
 pcre2-$(PCRE_VER)/configure: pcre2-$(PCRE_VER).tar.bz2
 	$(JLCHECKSUM) $<
 	$(TAR) jxf $<
+	patch -p0 pcre2-$(PCRE_VER)/RunTest < pcre2_RunTest.patch
 	touch -c $@
 pcre2-$(PCRE_VER)/config.status: pcre2-$(PCRE_VER)/configure
 	cd pcre2-$(PCRE_VER) && \
 	./configure $(CONFIGURE_COMMON) --enable-jit --includedir=$(build_includedir)
-	patch -p0 pcre2-10.10/RunTest < pcre2_RunTest.patch
 	touch -c $@
 $(PCRE_SRC_TARGET): pcre2-$(PCRE_VER)/config.status
 	$(MAKE) -C pcre2-$(PCRE_VER) $(LIBTOOL_CCLD)

--- a/deps/pcre2_RunTest.patch
+++ b/deps/pcre2_RunTest.patch
@@ -1,0 +1,11 @@
+290c290,297
+<   test2stack="-S 16"
+---
+>   # Attempt to auto-detect the maximum stack size:
+>   MAX_STACK=$(( $(ulimit -H -s)/1024 ))
+> 
+>   # if that fails, default to 16MB
+>   if [ "$MAX_STACK" -eq 0 ]; then
+>     MAX_STACK=16
+>   fi
+>   test2stack="-S $MAX_STACK"


### PR DESCRIPTION
It limits itself to 16MB by default, which isn't enough on my mac mini, causing the test to segfault.  Fixes #11668.
