### PR TITLE
Even MORE throwing tests for BLAS

### DIFF
--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -89,11 +89,13 @@ let n=10
             @test_approx_eq Hermitian(asym) * a asym * a
             @test_approx_eq a * Hermitian(asym) a * asym
             @test_approx_eq Hermitian(asym) * Hermitian(asym) asym*asym
+            @test_throws DimensionMismatch Hermitian(asym) * ones(eltya,n+1)
         end
         if eltya <: Real && eltya != Int
             @test_approx_eq Symmetric(asym) * Symmetric(asym) asym*asym
             @test_approx_eq Symmetric(asym) * a asym * a
             @test_approx_eq a * Symmetric(asym) a * asym
+            @test_throws DimensionMismatch Symmetric(asym) * ones(eltya,n+1)
         end
 
         # solver

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -171,6 +171,7 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
                     @test_throws DimensionMismatch eye(n+1)*A2'
                     @test_throws DimensionMismatch A2'*eye(n+1)
                     @test_throws DimensionMismatch A2*eye(n+1)
+                    @test_throws DimensionMismatch A2*ones(n+1)
                 end
             end
         end


### PR DESCRIPTION
I prettied up my old tests in `test/blas.jl` so that you can now set the dimension (to match other linalg tests in Julia). `BLAS.tsrv` wasn't tested at all, neither was `BLAS.copy`. `trmv`, `symv`, and `hemv` needed tests for mismatched matrix-vector dimensions.
