### PR TITLE
WIP: resolve all globals to GlobalRef very early

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1549,9 +1549,8 @@ NOINLINE static int gc_mark_module(jl_module_t *m, int d)
                 verify_parent2("module", m, &b->value, "binding(%s)", b->name->name);
                 refyoung |= gc_push_root(b->value, d);
             }
-            if (b->type != (jl_value_t*)jl_any_type) {
-                refyoung |= gc_push_root(b->type, d);
-            }
+            if (b->globalref != NULL)
+                refyoung |= gc_push_root(b->globalref, d);
         }
     }
     // this is only necessary because bindings for "using" modules

--- a/src/gf.c
+++ b/src/gf.c
@@ -895,7 +895,7 @@ DLLEXPORT jl_function_t *jl_instantiate_staged(jl_methlist_t *m, jl_tupletype_t 
         oldast = (jl_expr_t*)jl_uncompress_ast(m->func->linfo, m->func->linfo->ast);
     assert(oldast->head == lambda_sym);
     ex = jl_exprn(arrow_sym, 2);
-    jl_array_t *oldargnames = (jl_array_t*)jl_cellref(oldast->args,0);
+    jl_array_t *oldargnames = jl_lam_args(oldast);
     jl_expr_t *argnames = jl_exprn(tuple_sym, jl_array_len(oldargnames));
     jl_cellset(ex->args, 0, argnames);
     for (size_t i = 0; i < jl_array_len(oldargnames); ++i) {
@@ -921,6 +921,21 @@ DLLEXPORT jl_function_t *jl_instantiate_staged(jl_methlist_t *m, jl_tupletype_t 
     jl_cellset(linenode->args, 0, jl_box_long(m->func->linfo->line));
     jl_cellset(linenode->args, 1, m->func->linfo->file);
     jl_cellset(body->args, 1, jl_apply(func, jl_svec_data(tt->parameters), jl_nparams(tt)));
+    if (m->tvars != jl_emptysvec) {
+        // mark this function as having the same static parameters as the generator
+        size_t nsp = jl_is_typevar(m->tvars) ? 1 : jl_svec_len(m->tvars);
+        oldast = jl_exprn(jl_symbol("with-static-parameters"), nsp+1);
+        jl_exprarg(oldast,0) = (jl_value_t*)ex;
+        // (with-static-parameters func_expr sp_1 sp_2 ...)
+        if (jl_is_typevar(m->tvars)) {
+            jl_exprarg(oldast,1) = (jl_value_t*)((jl_tvar_t*)m->tvars)->name;
+        }
+        else {
+            for(size_t i=0; i < nsp; i++)
+                jl_exprarg(oldast,i+1) = (jl_value_t*)((jl_tvar_t*)jl_svecref(m->tvars,i))->name;
+        }
+        ex = oldast;
+    }
     func = (jl_function_t*)jl_toplevel_eval_in(m->func->linfo->module, (jl_value_t*)ex);
     func->linfo->name = m->func->linfo->name;
     JL_GC_POP();

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3033,6 +3033,10 @@ So far only the second case can actually occur.
               `(call (lambda ,vs ,(caddr (cadr e)) ,(cadddr (cadr e)))
                      ,@vs)
               env captvars sp))))
+	((with-static-parameters)
+	 ;; (with-static-parameters func_expr sp_1 sp_2 ...)
+	 (analyze-vars (cadr e) env captvars
+		       (delete-duplicates (append sp (cddr e)))))
         ((method)
          (let ((vi (var-info-for (method-expr-name e) env)))
            (if vi

--- a/src/julia.h
+++ b/src/julia.h
@@ -307,7 +307,7 @@ typedef struct {
     // not first-class
     jl_sym_t *name;
     jl_value_t *value;
-    jl_value_t *type;
+    jl_value_t *globalref;  // cached GlobalRef for this binding
     struct _jl_module_t *owner;  // for individual imported bindings
     unsigned constp:1;
     unsigned exportp:1;
@@ -1040,6 +1040,7 @@ DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name);
 // get binding for reading
 DLLEXPORT jl_binding_t *jl_get_binding(jl_module_t *m, jl_sym_t *var);
 DLLEXPORT jl_binding_t *jl_get_binding_or_error(jl_module_t *m, jl_sym_t *var);
+DLLEXPORT jl_value_t *jl_module_globalref(jl_module_t *m, jl_sym_t *var);
 // get binding for assignment
 DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var);
 DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *var);


### PR DESCRIPTION
Replace the resolve_globals pass in inlining by using a GlobalRef for every global.

Handles most of #10403.

As expected, this makes the AST data a bit bigger than necessary. Next steps are to unique GlobalRefs for efficiency, and better support them in `show` so ASTs are easier to read.
