### PR TITLE
Use type inference to determine the call signature for method completion.

### DIFF
--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -33,7 +33,15 @@ module CompletionFoo
     test3(x::AbstractArray{Int}, y::Int) = pass
     test3(x::AbstractArray{Float64}, y::Float64) = pass
 
+    test4(x::AbstractString, y::AbstractString) = pass
+    test4(x::AbstractString, y::Regex) = pass
+
+    test5(x::Array{Bool,1}) = pass
+    test5(x::BitArray{1}) = pass
+    test5(x::Float64) = pass
+
     array = [1, 1]
+    varfloat = 0.1
 end
 
 function temp_pkg_dir(fn::Function)
@@ -186,7 +194,7 @@ c, r, res = test_complete(s)
 @test r == 1:3
 @test s[r] == "max"
 
-# Test completion of methods with input args
+# Test completion of methods with input concrete args and args where typeinference determine their type
 s = "CompletionFoo.test(1,1, "
 c, r, res = test_complete(s)
 @test !res
@@ -239,23 +247,53 @@ for (T, arg) in [(ASCIIString,"\")\""),(Char, "')'")]
     @test s[r] == "CompletionFoo.test2"
 end
 
-# This cannot find the correct method due to the backticks expands to a macro in the parser.
-# Then the function argument is an expression which is not handled by current method completion logic.
 s = "(1, CompletionFoo.test2(`)`,"
 c, r, res = test_complete(s)
-@test length(c) == 3
+@test c[1] == string(methods(CompletionFoo.test2, Tuple{Cmd})[1])
+@test length(c) == 1
 
-s = "CompletionFoo.test3([1.,2.],"
+s = "CompletionFoo.test3([1, 2] + CompletionFoo.varfloat,"
 c, r, res = test_complete(s)
 @test !res
-@test length(c) == 2
+@test c[1] == string(methods(CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})[1])
+@test length(c) == 1
 
 s = "CompletionFoo.test3([1.,2.], 1.,"
 c, r, res = test_complete(s)
 @test !res
 @test c[1] == string(methods(CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})[1])
 @test r == 1:19
+@test length(c) == 1
 @test s[r] == "CompletionFoo.test3"
+
+s = "CompletionFoo.test4(\"e\",r\" \","
+c, r, res = test_complete(s)
+@test !res
+@test c[1] == string(methods(CompletionFoo.test4, Tuple{ASCIIString, Regex})[1])
+@test r == 1:19
+@test length(c) == 1
+@test s[r] == "CompletionFoo.test4"
+
+s = "CompletionFoo.test5(push!(Base.split(\"\",' '),\"\",\"\").==\"\","
+c, r, res = test_complete(s)
+@test !res
+@test length(c) == 1
+@test c[1] == string(methods(CompletionFoo.test5, Tuple{BitArray{1}})[1])
+
+########## Test where the current inference logic fails ########
+# Fails due to inferrence fails to determine a concrete type from the map
+# But it returns AbstractArray{T,N} and hence is able to remove test5(x::Float64) from the suggestions
+s = "CompletionFoo.test5(map(x-> x==\"\",push!(Base.split(\"\",' '),\"\",\"\")),"
+c, r, res = test_complete(s)
+@test !res
+@test length(c) == 2
+
+# equivalent to above but due to the time macro the completion fails to find the concrete type
+s = "CompletionFoo.test3(@time([1, 2] + CompletionFoo.varfloat),"
+c, r, res = test_complete(s)
+@test !res
+@test length(c) == 2
+#################################################################
 
 # Test completion in multi-line comments
 s = "#=\n\\alpha"


### PR DESCRIPTION
This pull implement method completion using type inference to determine the input types for a function call, Second case in #6338. This means the method completion suggestion removes the methods not appropriate for the function call, see:

```
julia> dot([1],<tab>
dot(x::AbstractArray{T,1}, y::AbstractArray{T,1}) at linalg/generic.jl:280
julia> dot(max(1,1),<tab>
dot(x::Number, y::Number) at linalg/generic.jl:279
```

~~The only thing I do not like about the implementation, is the need for eval an expression of the arguments into an anonymous function, see line: https://github.com/JuliaLang/julia/blob/1940b8f223c4383a0a7f4e8c17bd4c782c449a70/base/REPLCompletions.jl#L273. I do only let type inference work its magic on the anonymous function so the anonymous function is never called, so it might be ok? This might not be necessary if I could create the `LambdaStaticData` manually for the anonymous function, anyone know how this could be done?~~
It only analyse function arguments that is a call or is lowered to a call. Hence this do not work when the arguments is an expression. Example the time macro return an expression. I have also added this as a test case in https://github.com/dhoegh/julia/blob/603d16c7742fed2b10106402ec7284cf0e7c1f6e/test/replcompletions.jl#L292.
cc @blakejohnson could you review this, you reviewed similar additions in #9676?

~~Further work on this pull includes~~
- ~~Make tests~~
