### PR TITLE
julia-paren-indent skips blanks after paren

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -356,9 +356,9 @@ This variable has a moderate effect on indent performance if set too
 high.")
 
 (defun julia-paren-indent ()
-  "Return the column position of the first non-blank character
-after the innermost containing paren before point. Returns nil if
-we're not within nested parens."
+  "Return the column of the text following the innermost
+containing paren before point, so we can align succeeding code
+with it. Returns nil if we're not within nested parens."
   (save-excursion
     (let ((min-pos (max (- (point) julia-max-paren-lookback)
                         (point-min)))
@@ -513,7 +513,7 @@ end"
 end"))
 
   (ert-deftest julia--test-indent-paren ()
-    "We should indent to line up with open parens."
+    "We should indent to line up with the text after an open paren."
     (julia--should-indent
      "
 foobar(bar,
@@ -521,6 +521,17 @@ baz)"
      "
 foobar(bar,
        baz)"))
+
+  (ert-deftest julia--test-indent-paren-space ()
+    "We should indent to line up with the text after an open
+paren, even if there are additional spaces."
+    (julia--should-indent
+     "
+foobar( bar,
+baz )"
+     "
+foobar( bar,
+        baz )"))
 
   (ert-deftest julia--test-indent-equals ()
     "We should increase indent on a trailing =."

--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -356,8 +356,9 @@ This variable has a moderate effect on indent performance if set too
 high.")
 
 (defun julia-paren-indent ()
-  "Return the column position of the innermost containing paren
-before point. Returns nil if we're not within nested parens."
+  "Return the column position of the first non-blank character
+after the innermost containing paren before point. Returns nil if
+we're not within nested parens."
   (save-excursion
     (let ((min-pos (max (- (point) julia-max-paren-lookback)
                         (point-min)))
@@ -375,7 +376,10 @@ before point. Returns nil if we're not within nested parens."
         (julia--safe-backward-char))
 
       (if (plusp open-count)
-          (+ (current-column) 2)
+          (progn (forward-char 2)
+                 (while (looking-at (rx blank))
+                   (forward-char))
+                 (current-column))
         nil))))
 
 (defun julia-indent-line ()


### PR DESCRIPTION
Some coders prefer to put some space inside their parentheses in some circumstances, e.g.,

```
foo( bar,
     baz,
     quux )
```

rather than

```
foo(bar,
    baz,
    quux)
```

julia-mode has been indenting the first example as

```
foo( bar,
    baz,
    quux )
```

which is ugly.

This patch indents both the first and second examples nicely by looking for blank space after the open paren. As before, If a line ends with a paren, the next line will begin one column to the right of it.

Note that the original docstring was incorrect, as julia-paren-indent was always returning the column position _after_ the innermost containing paren before point. So this is a smaller change than the docstring change would indicate.
