### PR TITLE
Performance improvements for sparse triu!, tril!, dropzeros!, droptol! 

### DIFF
--- a/base/sparse/csparse.jl
+++ b/base/sparse/csparse.jl
@@ -358,9 +358,19 @@ function fkeep!{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, f, other)
     A
 end
 
-droptol!(A::SparseMatrixCSC, tol) = fkeep!(A, (i,j,x,other)->abs(x)>other, tol)
-dropzeros!(A::SparseMatrixCSC) = fkeep!(A, (i,j,x,other)->x!=0, nothing)
-triu!(A::SparseMatrixCSC) = fkeep!(A, (i,j,x,other)->(j>=i), nothing)
+
+immutable DropTolFun <: Func{4} end
+call(::DropTolFun, i,j,x,other) = abs(x)>other
+immutable DropZerosFun <: Func{4} end
+call(::DropZerosFun, i,j,x,other) = x!=0
+immutable TriuFun <: Func{4} end
+call(::TriuFun, i,j,x,other) = j>=i
+immutable TrilFun <: Func{4} end
+call(::TrilFun, i,j,x,other) = i>=j
+
+droptol!(A::SparseMatrixCSC, tol) = fkeep!(A, DropTolFun(), tol)
+dropzeros!(A::SparseMatrixCSC) = fkeep!(A, DropZerosFun(), nothing)
+triu!(A::SparseMatrixCSC) = fkeep!(A, TriuFun(), nothing)
 triu(A::SparseMatrixCSC) = triu!(copy(A))
-tril!(A::SparseMatrixCSC) = fkeep!(A, (i,j,x,other)->(i>=j), nothing)
+tril!(A::SparseMatrixCSC) = fkeep!(A, TrilFun(), nothing)
 tril(A::SparseMatrixCSC) = tril!(copy(A))


### PR DESCRIPTION
This changes the anonymous functions used in the calls to `fkeep!` made by `droptol!`, `dropzeros!`, `triu!` and `tril!` to instead use functors.

Performance differences below are with this benchmark:

``` julia
A = sprand(10^5, 10^5, 0.001)
B = copy(A)

import Base.droptol!
import Base.dropzeros!

B = copy(A);
@time droptol!(B, 0.1);

B = copy(A);
@time dropzeros!(B);

B = copy(A);
@time triu!(B);

B = copy(A);
@time tril!(B);
```
## Master

``` julia
 605.263 milliseconds (49914 k allocations: 762 MB, 7.72% gc time)
 422.887 milliseconds (29908 k allocations: 456 MB, 8.26% gc time)
 376.937 milliseconds (29908 k allocations: 456 MB, 9.14% gc time)
 374.099 milliseconds (29908 k allocations: 456 MB, 9.38% gc time)
```
## PR

``` julia
  32.674 milliseconds (4 allocations: 144 bytes)
  31.266 milliseconds (4 allocations: 144 bytes)
  26.735 milliseconds (38 allocations: 2416 bytes)
  27.053 milliseconds (38 allocations: 2416 bytes)
```
