### PR TITLE
RFC: add "++" operator

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -532,7 +532,9 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         # unary operator (i.e. "!z")
         elseif isa(func,Symbol) && func in uni_ops && length(func_args) == 1
             show_unquoted(io, func, indent)
-            if isa(func_args[1], Expr) || length(func_args) > 1
+            #for safety, always wrap a call on an operator in parens
+            arg_is_op = func_args[1] in union(uni_ops, expr_infix_any)
+            if arg_is_op || isa(func_args[1], Expr)
                 show_enclosed_list(io, '(', func_args, ",", ')', indent, func_prec)
             else
                 show_unquoted(io, func_args[1])

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -14,7 +14,7 @@
 ;; infix "in" goes here
 (define prec-pipe        '(|\|>| |<\|| =>))
 (define prec-colon       '(: |..|))
-(define prec-plus        '(+ - ⊕ ⊖ ⊞ ⊟ |.+| |.-| |\|| ∪ ∨ $ ⊔ ± ∓ ∔ ∸ ≂ ≏ ⊎ ⊻ ⊽ ⋎ ⋓ ⧺ ⧻ ⨈ ⨢ ⨣ ⨤ ⨥ ⨦ ⨧ ⨨ ⨩ ⨪ ⨫ ⨬ ⨭ ⨮ ⨹ ⨺ ⩁ ⩂ ⩅ ⩊ ⩌ ⩏ ⩐ ⩒ ⩔ ⩖ ⩗ ⩛ ⩝ ⩡ ⩢ ⩣))
+(define prec-plus        '(+ - ⊕ ⊖ ⊞ ⊟ |.+| |.-| |++| |\|| ∪ ∨ $ ⊔ ± ∓ ∔ ∸ ≂ ≏ ⊎ ⊻ ⊽ ⋎ ⋓ ⧺ ⧻ ⨈ ⨢ ⨣ ⨤ ⨥ ⨦ ⨧ ⨨ ⨩ ⨪ ⨫ ⨬ ⨭ ⨮ ⨹ ⨺ ⩁ ⩂ ⩅ ⩊ ⩌ ⩏ ⩐ ⩒ ⩔ ⩖ ⩗ ⩛ ⩝ ⩡ ⩢ ⩣))
 (define prec-bitshift    '(<< >> >>> |.<<| |.>>| |.>>>|))
 (define prec-times       '(* / |./| ÷ % ⋅ ∘ × |.%| |.*| |\\| |.\\| & ∩ ∧ ⊗ ⊘ ⊙ ⊚ ⊛ ⊠ ⊡ ⊓ ∗ ∙ ∤ ⅋ ≀ ⊼ ⋄ ⋆ ⋇ ⋉ ⋊ ⋋ ⋌ ⋏ ⋒ ⟑ ⦸ ⦼ ⦾ ⦿ ⧶ ⧷ ⨇ ⨰ ⨱ ⨲ ⨳ ⨴ ⨵ ⨶ ⨷ ⨸ ⨻ ⨼ ⨽ ⩀ ⩃ ⩄ ⩋ ⩍ ⩎ ⩑ ⩓ ⩕ ⩘ ⩚ ⩜ ⩞ ⩟ ⩠ ⫛ ⊍))
 (define prec-rational    '(// .//))
@@ -754,7 +754,7 @@
 
 ;; parse left to right, combining chains of a certain operator into 1 call
 ;; e.g. a+b+c => (call + a b c)
-(define (parse-with-chains s down ops chain-op)
+(define (parse-with-chains s down ops chain-ops)
   (let loop ((ex (down s)))
     (let* ((t   (peek-token s))
            (spc (ts:space? s)))
@@ -767,17 +767,17 @@
                    ;; here we have "x -y"
                    (ts:put-back! s t)
                    ex)
-                  ((eq? t chain-op)
+                  ((memq t chain-ops)
                    (loop (list* 'call t ex
                                 (parse-chain s down t))))
                   (else
                    (loop (list 'call t ex (down s))))))))))
 
-(define (parse-expr s) (parse-with-chains s parse-shift is-prec-plus? '+))
+(define (parse-expr s) (parse-with-chains s parse-shift is-prec-plus? '(+ ++)))
 
 (define (parse-shift s) (parse-LtoR s parse-term is-prec-bitshift?))
 
-(define (parse-term s) (parse-with-chains s parse-rational is-prec-times? '*))
+(define (parse-term s) (parse-with-chains s parse-rational is-prec-times? '(*)))
 
 (define (parse-rational s) (parse-LtoR s parse-unary is-prec-rational?))
 


### PR DESCRIPTION
I was quite surprised issue #11030 reach 160+ comments and no one had created a PR for introducing `++`, as it seemed to have very broad support. It was a pleasant surprise how easy it was to add. Serious thanks to @mbauman for providing the hint to get this functionality that an outsider like me would otherwise have no idea about.

~~Speaking of being an outsider, I tried to be as non-controversial as possible, by just replicating the current `*` concat method and not allowing any other generic use. I was motivated to make this PR because I really liked the idea of a generic sequence concat operator but others can work out the details for that.~~

This will break code if anyone was doing something like `x++1` (as `x + (+1)`) which is pretty unlikely but possible.

I guess the long-term plan would be to decide if `++` should be added to 0.4, and then if so, the whole debacle of deprecating `*` would be discussed/argued/executed in 0.5-dev? I'm looking forward to watching the comments with my popcorn...
