### PR TITLE
Revert "make RTLD_LOCAL the default for dlopen on both Mac and Linux …

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -50,7 +50,7 @@ DLLEXPORT int jl_uv_dlopen(const char *filename, jl_uv_libhandle lib_, unsigned 
     dlerror(); /* Reset error status. */
     lib->handle = dlopen(filename,
                          (flags & JL_RTLD_NOW ? RTLD_NOW : RTLD_LAZY)
-                         | (flags & JL_RTLD_GLOBAL ? RTLD_GLOBAL : RTLD_LOCAL)
+                         | JL_RTLD(flags, GLOBAL) | JL_RTLD(flags, LOCAL)
 #ifdef RTLD_NODELETE
                          | JL_RTLD(flags, NODELETE)
 #endif


### PR DESCRIPTION
Fixes #11689
