### PR TITLE
Fix string formatting

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #if defined(_OS_WINDOWS_)
 #include <malloc.h>
 #else
@@ -1335,34 +1336,35 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
         n += jl_printf(out, "#<intrinsic function %d>", *(uint32_t*)jl_data_ptr(v));
     }
     else if (jl_is_int64(v)) {
-        n += jl_printf(out, "%lld", jl_unbox_int64(v));
+        n += jl_printf(out, "%" PRId64, jl_unbox_int64(v));
     }
     else if (jl_is_int32(v)) {
-        n += jl_printf(out, "%d", jl_unbox_int32(v));
+        n += jl_printf(out, "%" PRId32, jl_unbox_int32(v));
     }
     else if (jl_typeis(v,jl_int16_type)) {
-        n += jl_printf(out, "%hd", jl_unbox_int16(v));
+        n += jl_printf(out, "%" PRId16, jl_unbox_int16(v));
     }
     else if (jl_typeis(v,jl_int8_type)) {
-        n += jl_printf(out, "%hhd", jl_unbox_int8(v));
+        n += jl_printf(out, "%" PRId8, jl_unbox_int8(v));
     }
     else if (jl_is_uint64(v)) {
-        n += jl_printf(out, "0x%016llx", jl_unbox_uint64(v));
+        n += jl_printf(out, "0x%016" PRIx64, jl_unbox_uint64(v));
     }
     else if (jl_is_uint32(v)) {
-        n += jl_printf(out, "0x%08x", jl_unbox_uint32(v));
+        n += jl_printf(out, "0x%08" PRIx32, jl_unbox_uint32(v));
     }
     else if (jl_typeis(v,jl_uint16_type)) {
-        n += jl_printf(out, "0x%04hx", jl_unbox_uint16(v));
+        n += jl_printf(out, "0x%04" PRIx16, jl_unbox_uint16(v));
     }
     else if (jl_typeis(v,jl_uint8_type)) {
-        n += jl_printf(out, "0x%02hhx", jl_unbox_uint8(v));
+        n += jl_printf(out, "0x%02" PRIx8, jl_unbox_uint8(v));
     }
     else if (jl_is_cpointer(v)) {
 #ifdef _P64
-        n += jl_printf(out, "0x%016llx", jl_unbox_voidpointer(v));
+        n += jl_printf(out, "0x%016" PRIx64,
+                       (int64_t)jl_unbox_voidpointer(v));
 #else
-        n += jl_printf(out, "0x%08x", jl_unbox_voidpointer(v));
+        n += jl_printf(out, "0x%08" PRIx32, (int32_t)jl_unbox_voidpointer(v));
 #endif
     }
     else if (jl_is_float32(v)) {
@@ -1409,7 +1411,8 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
         n += jl_printf(out, ":%s", ((jl_sym_t*)v)->name);
     }
     else if (jl_is_gensym(v)) {
-        n += jl_printf(out, "GenSym(%d)", ((jl_gensym_t*)v)->id);
+        n += jl_printf(out, "GenSym(%" PRIuPTR ")",
+                       (uintptr_t)((jl_gensym_t*)v)->id);
     }
     else if (jl_is_symbolnode(v)) {
         n += jl_printf(out, "%s::", jl_symbolnode_sym(v)->name);
@@ -1420,10 +1423,10 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
         n += jl_printf(out, ".%s", jl_globalref_name(v)->name);
     }
     else if (jl_is_labelnode(v)) {
-        n += jl_printf(out, "%d:", jl_labelnode_label(v));
+        n += jl_printf(out, "%" PRIuPTR ":", jl_labelnode_label(v));
     }
     else if (jl_is_gotonode(v)) {
-        n += jl_printf(out, "goto %d", jl_gotonode_label(v));
+        n += jl_printf(out, "goto %" PRIuPTR, jl_gotonode_label(v));
     }
     else if (jl_is_quotenode(v)) {
         jl_value_t *qv = jl_fieldref(v,0);
@@ -1442,7 +1445,7 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
         n += jl_printf(out, ")");
     }
     else if (jl_is_linenode(v)) {
-        n += jl_printf(out, "# line %d", jl_linenode_line(v));
+        n += jl_printf(out, "# line %" PRIuPTR, jl_linenode_line(v));
     }
     else if (jl_is_expr(v)) {
         jl_expr_t *e = (jl_expr_t*)v;
@@ -1508,14 +1511,14 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
             char *data = (char*)jl_data_ptr(v);
             n += jl_printf(out, "0x");
             for(int i=nb-1; i >= 0; --i)
-                n += jl_printf(out, "%02hhx", data[i]);
+                n += jl_printf(out, "%02" PRIx8, data[i]);
         }
         else {
             jl_value_t *fldval=NULL;
             JL_GC_PUSH1(&fldval);
             for (size_t i = 0; i < tlen; i++) {
                 if (!istuple) {
-                    n += jl_printf(out, ((jl_sym_t*)jl_svecref(t->name->names, i))->name);
+                    n += jl_printf(out, "%s", ((jl_sym_t*)jl_svecref(t->name->names, i))->name);
                     //jl_fielddesc_t f = t->fields[i];
                     n += jl_printf(out, "=");
                 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5812,7 +5812,8 @@ extern "C" void jl_init_codegen(void)
     jl_ExecutionEngine = eb.create(jl_TargetMachine);
     //jl_printf(JL_STDERR,"%s\n",jl_ExecutionEngine->getDataLayout()->getStringRepresentation().c_str());
     if (!jl_ExecutionEngine) {
-        jl_printf(JL_STDERR, "Critical error initializing llvm: ", ErrorStr.c_str());
+        jl_printf(JL_STDERR, "Critical error initializing llvm: %s\n",
+                  ErrorStr.c_str());
         exit(1);
     }
 #ifdef LLVM35

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -130,7 +130,7 @@ static void create_PRUNTIME_FUNCTION(uint8_t *Code, size_t Size, StringRef fnnam
 #endif
             static int warned = 0;
             if (!warned) {
-                jl_printf(JL_STDERR, "WARNING: failed to insert module info for backtrace: %d\n", GetLastError());
+                jl_printf(JL_STDERR, "WARNING: failed to insert module info for backtrace: %lu\n", GetLastError());
                 warned = 1;
             }
         }
@@ -143,7 +143,7 @@ static void create_PRUNTIME_FUNCTION(uint8_t *Code, size_t Size, StringRef fnnam
             name[len-1] = 0;
             if (!SymAddSymbol(GetCurrentProcess(), (ULONG64)Section, name,
                         (DWORD64)Code, (DWORD)Size, 0)) {
-                jl_printf(JL_STDERR, "WARNING: failed to insert function name %s into debug info: %d\n", name, GetLastError());
+                jl_printf(JL_STDERR, "WARNING: failed to insert function name %s into debug info: %lu\n", name, GetLastError());
             }
         }
         jl_in_stackwalk = 0;
@@ -152,7 +152,7 @@ static void create_PRUNTIME_FUNCTION(uint8_t *Code, size_t Size, StringRef fnnam
     if (!RtlAddFunctionTable(tbl, 1, (DWORD64)Section)) {
         static int warned = 0;
         if (!warned) {
-            jl_printf(JL_STDERR, "WARNING: failed to insert function stack unwind info: %d\n", GetLastError());
+            jl_printf(JL_STDERR, "WARNING: failed to insert function stack unwind info: %lu\n", GetLastError());
             warned = 1;
         }
     }

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -324,7 +324,8 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
     OwningPtr<MCDisassembler> DisAsm(TheTarget->createMCDisassembler(*STI));
 #endif
     if (!DisAsm) {
-        jl_printf(JL_STDERR, "error: no disassembler for target", TripleName.c_str(), "\n");
+        jl_printf(JL_STDERR, "error: no disassembler for target %s\n",
+                  TripleName.c_str());
         return;
     }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -18,6 +18,7 @@
 #include <strings.h>
 #endif
 #include <assert.h>
+#include <inttypes.h>
 #include "julia.h"
 #include "julia_internal.h"
 #ifndef _OS_WINDOWS_
@@ -496,8 +497,8 @@ static void add_lostval_parent(jl_value_t* parent)
 #define verify_val(v) do {                                              \
         if (lostval == (jl_value_t*)(v) && (v) != 0) {                  \
             jl_printf(JL_STDOUT,                                        \
-                      "Found lostval 0x%lx at %s:%d oftype: ",          \
-                      (uintptr_t)(lostval), __FILE__, __LINE__);        \
+                      "Found lostval %p at %s:%d oftype: ",             \
+                      (void*)(lostval), __FILE__, __LINE__);            \
             jl_static_show(JL_STDOUT, jl_typeof(v));                    \
             jl_printf(JL_STDOUT, "\n");                                 \
         }                                                               \
@@ -506,9 +507,9 @@ static void add_lostval_parent(jl_value_t* parent)
 
 #define verify_parent(ty, obj, slot, args...) do {                      \
         if (*(jl_value_t**)(slot) == lostval && (obj) != lostval) {     \
-            jl_printf(JL_STDOUT, "Found parent %s 0x%lx at %s:%d\n",    \
-                      ty, (uintptr_t)(obj), __FILE__, __LINE__);        \
-            jl_printf(JL_STDOUT, "\tloc 0x%lx : ", (uintptr_t)(slot));  \
+            jl_printf(JL_STDOUT, "Found parent %s %p at %s:%d\n",       \
+                      (void*)(ty), (void*)(obj), __FILE__, __LINE__);   \
+            jl_printf(JL_STDOUT, "\tloc %p : ", (void*)(slot));         \
             jl_printf(JL_STDOUT, args);                                 \
             jl_printf(JL_STDOUT, "\n");                                 \
             jl_printf(JL_STDOUT, "\ttype: ");                           \
@@ -1432,7 +1433,8 @@ static void grow_mark_stack(void)
     size_t offset = mark_stack - mark_stack_base;
     mark_stack_base = (jl_value_t**)realloc(mark_stack_base, newsz*sizeof(void*));
     if (mark_stack_base == NULL) {
-        jl_printf(JL_STDERR, "Could'nt grow mark stack to : %d\n", newsz);
+        jl_printf(JL_STDERR, "Couldn't grow mark stack to : %" PRIuPTR "\n",
+                  (uintptr_t)newsz);
         exit(1);
     }
     mark_stack = mark_stack_base + offset;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1764,7 +1764,7 @@ void print_func_loc(JL_STREAM *s, jl_lambda_info_t *li)
     long lno = li->line;
     if (lno > 0) {
         char *fname = ((jl_sym_t*)li->file)->name;
-        jl_printf(s, " at %s:%d", fname, lno);
+        jl_printf(s, " at %s:%ld", fname, lno);
     }
 }
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1490,9 +1490,19 @@ typedef struct {
     uv_file file;
 } jl_uv_file_t;
 
-DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...);
-DLLEXPORT int jl_vprintf(uv_stream_t *s, const char *format, va_list args);
-DLLEXPORT void jl_safe_printf(const char *str, ...);
+#ifdef __GNUC__
+#define _JL_FORMAT_ATTR(type, str, arg) \
+    __attribute__((format(type, str, arg)))
+#else
+#define _JL_FORMAT_ATTR(type, str, arg)
+#endif
+
+DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...)
+    _JL_FORMAT_ATTR(printf, 2, 3);
+DLLEXPORT int jl_vprintf(uv_stream_t *s, const char *format, va_list args)
+    _JL_FORMAT_ATTR(printf, 2, 0);
+DLLEXPORT void jl_safe_printf(const char *str, ...)
+    _JL_FORMAT_ATTR(printf, 1, 2);
 
 extern DLLEXPORT JL_STREAM *JL_STDIN;
 extern DLLEXPORT JL_STREAM *JL_STDOUT;

--- a/src/task.c
+++ b/src/task.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <errno.h>
+#include <inttypes.h>
 #include "julia.h"
 #include "julia_internal.h"
 
@@ -754,11 +755,12 @@ DLLEXPORT void gdblookup(ptrint_t ip)
     frame_info_from_ip(&func_name, &line_num, &file_name, ip, 0);
     if (func_name != NULL) {
         if (line_num == ip)
-            jl_safe_printf("unknown function (ip: %d)\n", line_num);
+            jl_safe_printf("unknown function (ip: %p)\n", (void*)ip);
         else if (line_num == -1)
             jl_safe_printf("%s at %s (unknown line)\n", func_name, file_name);
         else
-            jl_safe_printf("%s at %s:%d\n", func_name, file_name, line_num);
+            jl_safe_printf("%s at %s:%" PRIuPTR "\n", func_name, file_name,
+                           (uintptr_t)line_num);
     }
 }
 


### PR DESCRIPTION
Updated:
1. Print address in hex instead of decimal
2. Use the `format` function attribute in GCC to verify that the format string is used correctly.
3. Fix a number of incorrect usage found with `format` attribute.

Original post:
The problem of the output before
1. It print the address as a signed integer and it's annoy to convert that into hex and to match the output of all other tools.
2. It truncate the output to 32bit (because of `%d`) on 64bit system.

Printing of the backtrace with this PR is attached (don't worry about where the segfault happens, it's done with `kill -SEGV`).

Will merge after the CI passes (or fail due to known reason.)

```
signal (11): 段错误
syscall at /usr/lib/libc.so.6 (unknown line)
uv__epoll_wait at /home/yuyichao/projects/julia/hex-address/deps/libuv/src/unix/linux-syscalls.c:316
uv__io_poll at /home/yuyichao/projects/julia/hex-address/deps/libuv/src/unix/linux-core.c:202
uv_run at /home/yuyichao/projects/julia/hex-address/deps/libuv/src/unix/core.c:295
process_events at ./stream.jl:599
wait at ./task.jl:299
wait at ./task.jl:225
wait_readnb at ./stream.jl:341
eof at ./stream.jl:49
match_input at ./LineEdit.jl:751
jl_apply_generic at /home/yuyichao/projects/julia/hex-address/src/gf.c:1652
match_input at ./LineEdit.jl:751
jl_apply_generic at /home/yuyichao/projects/julia/hex-address/src/gf.c:1652
prompt! at ./LineEdit.jl:1575
run_interface at ./LineEdit.jl:1549
unknown function (ip: 0x7ffff4115a60)
jl_apply_generic at /home/yuyichao/projects/julia/hex-address/src/gf.c:1652
run_frontend at ./REPL.jl:841
run_repl at ./REPL.jl:166
jl_apply_generic at /home/yuyichao/projects/julia/hex-address/src/gf.c:1652
_start at ./client.jl:446
unknown function (ip: 0x7ffff4130159)
jl_apply_generic at /home/yuyichao/projects/julia/hex-address/src/gf.c:1652
unknown function (ip: 0x401a17)
unknown function (ip: 0x40160f)
__libc_start_main at /usr/lib/libc.so.6 (unknown line)
unknown function (ip: 0x401669)
unknown function (ip: 0x0)
```
