### PR TITLE
RFC: Update Windows build toolchain and instructions

### DIFF
--- a/README.windows.md
+++ b/README.windows.md
@@ -55,9 +55,11 @@ or edit `%USERPROFILE%\.gitconfig` and add/edit the lines:
 
 ### MSYS2 provides a robust MSYS experience.
 
-1. Install [CMake](http://www.cmake.org/download/).
+1. Install [Python 2.x](http://www.python.org/download/releases). Do **not** install Python 3.
 
-2. Install and configure [MSYS2](https://msys2.github.io), a minimal POSIX-like environment for Windows.
+2. Install [CMake](http://www.cmake.org/download/).
+
+3. Install and configure [MSYS2](https://msys2.github.io), a minimal POSIX-like environment for Windows.
 
   1. Download and run the latest installer for the [32-bit](http://sourceforge.net/projects/msys2/files/Base/i686/) or [64-bit](http://sourceforge.net/projects/msys2/files/Base/x86_64/) distribution. The installer will have a name like `msys2-i686-yyyymmdd.exe` or `msys2-x86_64-yyyymmdd.exe`.
 
@@ -71,12 +73,23 @@ or edit `%USERPROFILE%\.gitconfig` and add/edit the lines:
 
      ```
     pacman -Syu           #Update package database and full system upgrade
-    pacman -S diffutils git m4 make patch tar python2 p7zip msys/openssh
+    pacman -S diffutils git m4 make patch tar p7zip msys/openssh
 ```
 
-  4. Configuration of MSYS2 is complete. Now `exit` the MSYS2 shell.
+  4. Configure your MSYS2 shell so Python is visible on the path:
 
-3. Build Julia and its dependencies from source.
+     ```
+    echo "export PATH=/usr/local/bin:/usr/bin:/opt/bin:/C/Python27" >> ~/.bashrc
+```
+
+     *N.B.* The `export` clobbers whatever `$PATH` is already defined. This is suggested to avoid path-masking. If you use MSYS2 for purposes other than building Julia, you may prefer to append rather than clobber.
+
+     *N.B.* All of the path separators are unix-style. In MSYS2, `/C/` means the root of your `C:\` drive. Replace `/C/Python27` with the location where you installed Python.
+
+
+  5. Configuration of MSYS2 is complete. Now `exit` the MSYS2 shell.
+
+4. Build Julia and its dependencies from source.
   1. Open a new MSYS2 shell and clone the Julia sources
      ```
     git clone https://github.com/JuliaLang/julia.git
@@ -108,7 +121,7 @@ or edit `%USERPROFILE%\.gitconfig` and add/edit the lines:
     make -j 4   # Adjust the number of cores (4) to match your build environment.
 ```
 
-4. Setup Package Development Environment
+5. Setup Package Development Environment
   1. The `Pkg` module in Base provides many convenient tools for [developing and publishing packages](http://docs.julialang.org/en/latest/manual/packages/).
   One of the packages added through pacman above was `openssh`, which will allow secure access to GitHub APIs.
   Follow GitHub's [guide](https://help.github.com/articles/generating-ssh-keys) to setting up SSH keys to ensure your local machine can communicate with GitHub effectively.

--- a/README.windows.md
+++ b/README.windows.md
@@ -25,11 +25,9 @@ Both the 32-bit and 64-bit versions are supported.
 The 32-bit (i686) binary will run on either a 32-bit and 64-bit operating system.
 The 64-bit (x86_64) binary will only run on 64-bit Windows and will otherwise refuse to launch.
 
-1. Download and install [7-Zip](http://www.7-zip.org/download.html). Install the full program, not just the command line version.
+1. [Download](http://julialang.org/downloads) the latest version of Julia. Extract the binary to a reasonable destination folder, e.g. `C:\julia`.
 
-2. [Download](http://julialang.org/downloads) the latest version of Julia. Extract the binary to a reasonable destination folder, e.g. `C:\julia`.
-
-3. Double-click the file `julia.bat` to launch Julia.
+2. Double-click the `julia` shortcut to launch Julia.
 
 # Line endings
 
@@ -56,80 +54,48 @@ or edit `%USERPROFILE%\.gitconfig` and add/edit the lines:
 ## Compiling with MinGW/MSYS2
 
 ### MSYS2 provides a robust MSYS experience.
-### The instructions in this section were tested with the latest versions of all packages specified as of 2014-02-28.
 
-1. Install [7-Zip](http://www.7-zip.org/download.html).
+1. Install [CMake](http://www.cmake.org/download/).
 
-2. Install [Python 2.x](http://www.python.org/download/releases). Do **not** install Python 3.
+2. Install and configure [MSYS2](https://msys2.github.io), a minimal POSIX-like environment for Windows.
 
-3. Install [CMake](http://www.cmake.org/download/).
+  1. Download and run the latest installer for the [32-bit](http://sourceforge.net/projects/msys2/files/Base/i686/) or [64-bit](http://sourceforge.net/projects/msys2/files/Base/x86_64/) distribution. The installer will have a name like `msys2-i686-yyyymmdd.exe` or `msys2-x86_64-yyyymmdd.exe`.
 
-4. Install [MinGW-builds](http://sourceforge.net/projects/mingwbuilds/), a Windows port of GCC, as follows. Do **not** use the regular MinGW distribution.
-  1. Download the [MinGW-builds installer](http://downloads.sourceforge.net/project/mingwbuilds/mingw-builds-install/mingw-builds-install.exe).
-  2. Run the installer. When prompted, choose:
-    - Version: the most recent version (these instructions were tested with 4.8.1)
-    - Architecture: `x32` or `x64` as appropriate and desired.
-    - Threads: `win32` (not posix)
-    - Exception: `sjlj` (for x32) or `seh` (for x64). Do not choose dwarf2.
-    - Build revision: most recent available (tested with 5)
-  3. Do **not** install to a directory with spaces in the name. You will have to change the default installation path, for example,
-    - `C:\mingw-builds\x64-4.8.1-win32-seh-rev5` for 64 bits
-    - `C:\mingw-builds\x32-4.8.1-win32-sjlj-rev5` for 32 bits
-
-5. Install and configure [MSYS2](http://sourceforge.net/projects/msys2), a minimal POSIX-like environment for Windows.
-
-  1. Download the latest base [32-bit](http://sourceforge.net/projects/msys2/files/Base/i686/) or [64-bit](http://sourceforge.net/projects/msys2/files/Base/x86_64/) distribution, consistent with the architecture you chose for MinGW-builds. The archive will have a name like `msys2-base-x86_64-yyyymmdd.tar.xz` and these instructions were tested with `msys2-base-x86_64-20140216.tar.xz`.
-
-  2. Using [7-Zip](http://www.7-zip.org/download.html), extract the archive to any convenient directory.
-    - *N.B.* Some versions of this archive contain zero-byte files that clash with existing files. If prompted, choose **not** to overwrite existing files.
-    - You may need to extract the tarball in a separate step. This will create an `msys32` or `msys64` directory, according to the architecture you chose.
-    - Move the `msys32` or `msys64` directory into your MinGW-builds directory, which is `C:\mingw-builds` if you followed the suggestions in step 3. We will omit the "32" or "64" in the steps below and refer to this as "the msys directory".
-
-  3. Double-click `msys2_shell.bat` in the msys directory. This will initialize MSYS2. The shell will tell you to `exit` and restart the shell. For now, ignore it.
-
-  4. Update MSYS2 and install packages required to build julia, using the `pacman` package manager included in MSYS2:
+  2. Double-click `msys2_shell.bat` in the installed msys directory. Initialize the MSYS2 base system using the `pacman` package manager included in MSYS2:
 
      ```
-    pacman-key --init     #Download keys
+    pacman --needed -Sy bash pacman pacman-mirrors msys2-runtime
+```
+
+  3. Exit and restart MSYS2, then install packages required to build julia:
+
+     ```
     pacman -Syu           #Update package database and full system upgrade
-```
-    Now `exit` the MSYS2 shell and restart it,  *even if you already restarted it above*. This is necessary in case the system upgrade updated the main MSYS2 libs. Reopen the MSYS2 shell and continue with:
-
-    ```
-    pacman -S diffutils git m4 make patch tar msys/openssh
+    pacman -S diffutils git m4 make patch tar python2 p7zip msys/openssh
 ```
 
-  5. Configure your MSYS2 shell for convenience:
+  4. Configuration of MSYS2 is complete. Now `exit` the MSYS2 shell.
 
+3. Build Julia and its dependencies from source.
+  1. Open a new MSYS2 shell and clone the Julia sources
      ```
-    echo "mount C:/Python27 /python" >> ~/.bashrc
-    # uncomment ONE of the following two lines
-    #echo "mount C:/mingw-builds/x64-4.8.1-win32-seh-rev5/mingw64 /mingw" >> ~/.bashrc
-    #echo "mount C:/mingw-builds/x32-4.8.1-win32-sjlj-rev5/mingw32 /mingw" >> ~/.bashrc
-    echo "export PATH=/usr/local/bin:/usr/bin:/opt/bin:/mingw/bin:/python" >> ~/.bashrc
-```
-
-     *N.B.* The `export` clobbers whatever `$PATH` is already defined. This is suggested to avoid path-masking. If you use MSYS2 for purposes other than building Julia, you may prefer to append rather than clobber.
-
-     *N.B.* All of the path-separators in the mount commands are unix-style.
-
-
-  6. Configuration of the toolchain is complete. Now `exit` the MSYS2 shell.
-
-6. Build Julia and its dependencies from source.
-  1. Relaunch the MSYS2 shell and type
-
-     ```
-    . ~/.bashrc  # Some versions of MSYS2 do not run this automatically
-```
-
-     Ignore any warnings you see from `mount` about `/mingw` and `/python` not existing.
-
-  2. Get the Julia sources
-    ```
     git clone https://github.com/JuliaLang/julia.git
     cd julia
 ```
+
+  2. Run the following script to download the correct versions of the MinGW-w64 compilers
+     ```
+    contrib/windows/get_toolchain.sh 32  # for 32 bit Julia
+    # or
+    contrib/windows/get_toolchain.sh 64  # for 64 bit Julia
+```
+     Then follow the printed instructions by running either
+     ```
+    export PATH=$PWD/usr/i686-w64-mingw32/sys-root/mingw/bin:$PATH  # for 32 bit Julia
+    # or
+    export PATH=$PWD/usr/x86_64-w64-mingw32/sys-root/mingw/bin:$PATH  # for 64 bit Julia
+```
+     to add the downloaded MinGW-w64 compilers to your path (temporarily, only needed during the shell session when you build Julia).
 
   3. Specify the location where you installed CMake
 
@@ -138,15 +104,16 @@ or edit `%USERPROFILE%\.gitconfig` and add/edit the lines:
 ```
 
   4. Start the build
-    ```
+     ```
     make -j 4   # Adjust the number of cores (4) to match your build environment.
 ```
-7. Setup Package Development Environment
+
+4. Setup Package Development Environment
   1. The `Pkg` module in Base provides many convenient tools for [developing and publishing packages](http://docs.julialang.org/en/latest/manual/packages/).
   One of the packages added through pacman above was `openssh`, which will allow secure access to GitHub APIs.
   Follow GitHub's [guide](https://help.github.com/articles/generating-ssh-keys) to setting up SSH keys to ensure your local machine can communicate with GitHub effectively.
 
-  5. In case of the issues with building packages (i.e. ICU fails to build with the following error message ```error compiling xp_parse: error compiling xp_make_parser: could not load module libexpat-1: %```) run ```make win-extras``` and then copy everything from the ```dist-extras``` folder into ```usr/bin```.
+  2. In case of the issues with building packages (i.e. ICU fails to build with the following error message ```error compiling xp_parse: error compiling xp_make_parser: could not load module libexpat-1: %```) run ```make win-extras``` and then copy everything from the ```dist-extras``` folder into ```usr/bin```.
 
 ## Cygwin-to-MinGW cross compiling
 
@@ -208,69 +175,40 @@ Julia can be also compiled from source in [Cygwin](http://www.cygwin.com), using
 
 If you prefer to cross-compile, the following steps should get you started.
 
-### Ubuntu and Mac Dependencies (these steps will work for almost any linux platform)
+For maximum compatibility with packages that use [WinRPM.jl](https://github.com/JuliaLang/WinRPM.jl) for binary dependencies on Windows, it is recommended that you use OpenSUSE 13.1 for cross-compiling a Windows build of Julia. If you use a different Linux distribution or OS X, install [Vagrant](http://www.vagrantup.com/downloads) and use the following `Vagrantfile`:
+```
+# Vagrantfile for MinGW-w64 cross-compilation of Julia
 
-First, you will need to ensure your system has the required dependencies. We need wine (>=1.7.5),
-a system compiler, and some downloaders.
+$script = <<SCRIPT
+# Change the following to i686-w64-mingw32 for 32 bit Julia:
+export XC_HOST=x86_64-w64-mingw32
+# Change the following to 32 for 32 bit Julia:
+export BITS=64
+zypper addrepo http://download.opensuse.org/repositories/windows:mingw:win$BITS/openSUSE_13.1/windows:mingw:win$BITS.repo
+zypper --gpg-auto-import-keys refresh
+zypper -n install --no-recommends git make cmake tar wine which curl \
+    python python-xml patch gcc-c++ m4 p7zip.i586 libxml2-tools
+zypper -n install mingw$BITS-cross-gcc-c++ mingw$BITS-cross-gcc-fortran \
+    mingw$BITS-libstdc++6 mingw$BITS-libgfortran3 mingw$BITS-libssp0
+# opensuse packages the mingw runtime dlls under sys-root/mingw/bin, not /usr/lib64/gcc
+cp /usr/$XC_HOST/sys-root/mingw/bin/*.dll /usr/lib*/gcc/$XC_HOST/*/
+git clone git://github.com/JuliaLang/julia.git julia
+cd julia
+make -j4 win-extras julia-ui-release
+export WINEDEBUG=-all # suppress wine fixme's
+# this last step may need to be run interactively
+make -j4 binary-dist
+SCRIPT
 
-On Ubuntu:
-
-    apt-add-repository ppa:ubuntu-wine/ppa
-    apt-get upate
-    apt-get install wine1.7 subversion cvs gcc wget p7zip-full
-
-
-On Mac: Install XCode, XCode command line tools, X11 (now [XQuartz](http://xquartz.macosforge.org/)),
-and [MacPorts](http://www.macports.org/install.php) or [Homebrew](http://mxcl.github.io/homebrew/).
-Then run ```port install wine wget``` or ```brew install wine wget```, as appropriate.
-
-On Both:
-
-Unfortunately, the version of gcc installed by Ubuntu targets pthreads.
-On Mac, the situation is similar: the version in MacPorts is very old and Homebrew does not have it.
-So first we need to get a cross-compile version of gcc.
-Most binary packages appear to not include gfortran, so we will need to compile it from source (or ask @vtjnash to send you a tgz of his build).
-This is typically quite a bit of work, so we will use [this script](http://sourceforge.net/projects/mingw-w64-dgn/) to make it easy.
-
-1. `svn checkout svn checkout svn://svn.code.sf.net/p/mingw-w64-dgn/code/trunk mingw-w64-dgn-code`
-2. `cd mingw-w64-dgn`
-3. edit `rebuild_cross.sh` and make the following two changes:
-  a. uncomment `export MAKE_OPT="-j 2"`, if appropriate for your machine
-  b. add `fortran` to the end of `--enable-languages=c,c++,objc,obj-c++`
-5. `bash update_source.sh`
-4. `bash rebuild_cross.sh`
-5. `mv cross ~/cross-w64`
-6. `export PATH=$HOME/cross-w64/bin:$PATH` # NOTE: it is important that you remember to always do this before using make in the following steps!, you can put this line in your .profile to make it easy
-
-Then we can essentially just repeat these steps for the 32-bit compiler, reusing some of the work:
-
-7. `cd ..`
-8. `cp -a mingw-w64-dgn mingw-w32-dgn`
-9. `cd mingw-w32-dgn`
-10. `rm -r cross build`
-11. `bash rebuild_cross.sh 32r`
-12. `mv cross ~/cross-w32`
-13. `export PATH=$HOME/cross-w32/bin:$PATH` # NOTE: it is important that you remember to always do this before using make in the following steps!, you can put this line in your .profile to make it easy
-
-Note: for systems that support rpm-based package managers, the OpenSUSE build service appears to contain a fully up-to-date versions of the necessary dependencies.
-
-### Arch Linux Dependencies
-
-1. Install the following packages from the official Arch repository:
-`sudo pacman -S cloog gcc-ada libmpc p7zip ppl subversion zlib`
-2. The rest of the prerequisites consist of the mingw-w64 packages, which are available in the AUR Arch repository. They must be installed exactly in the order they are given or else their installation will fail. The `yaourt` package manager is used for illustration purposes; you may instead follow the [Arch instructions for installing packages from AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages) or may use your preferred package manager. To start with, install `mingw-w64-binutils` via the command
-`yaourt -S mingw-w64-binutils`
-3. `yaourt -S mingw-w64-headers-svn`
-4. `yaourt -S mingw-w64-headers-bootstrap`
-5. `yaourt -S mingw-w64-gcc-base`
-6. `yaourt -S mingw-w64-crt-svn`
-7. Remove `mingw-w64-headers-bootstrap` without removing its dependent mingw-w64 installed packages by using the command
-`yaourt -Rdd mingw-w64-headers-bootstrap`
-8. `yaourt -S mingw-w64-winpthreads`
-9. Remove `mingw-w64-gcc-base` without removing its installed mingw-w64 dependencies:
-`yaourt -Rdd mingw-w64-gcc-base`
-10. Complete the installation of the required `mingw-w64` packages:
-`yaourt -S mingw-w64-gcc`
+Vagrant.configure("2") do |config|
+  config.vm.box = "chef/opensuse-13.1"
+  config.vm.provider :virtualbox do |vb|
+    # Use VBoxManage to customize the VM. For example to change memory:
+    vb.memory = 2048
+  end
+  config.vm.provision :shell, :inline => $script
+end
+```
 
 ### Cross-building Julia
 
@@ -281,7 +219,7 @@ Finally, the build and install process for Julia:
 3. `make`
 4. `make win-extras` (Necessary before running `make binary-dist`p)
 5. `make binary-dist`
-6. move the julia-* directory / zip file to the target machine
+6. move the julia-*.exe installer to the target machine
 
 If you are building for 64-bit windows, the steps are essentially the same. Just replace i686 in XC_HOST with x86_64. (note: on Mac, wine only runs in 32-bit mode)
 

--- a/contrib/windows/get_toolchain.sh
+++ b/contrib/windows/get_toolchain.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+# download mingw-w64 compilers from opensuse build service, usage:
+# ./get_toolchain.sh 64
+# (or ./get_toolchain.sh 32)
+# depends on curl, xmllint, gunzip, sort -V, sha256sum, and p7zip
+
+# Run in top-level Julia directory
+cd `dirname "$0"`/../..
+# Stop on error
+set -e
+bits=$1
+
+case $bits in
+  32)
+    host=i686-w64-mingw32
+    exc=sjlj
+    ;;
+  64)
+    host=x86_64-w64-mingw32
+    exc=seh
+    ;;
+  *)
+    echo 'error: run script either as `./get_toolchain.sh 32` or `./get_toolchain.sh 64`' >&2
+    exit 1
+    ;;
+esac
+echo "Downloading $host toolchain, check $PWD/get_toolchain.log for full output"
+contrib/windows/winrpm.sh http://download.opensuse.org/repositories/windows:/mingw:/win$bits/openSUSE_13.1 \
+  "mingw$bits-gcc mingw$bits-gcc-c++ mingw$bits-gcc-fortran \
+   mingw$bits-libssp0 mingw$bits-libstdc++6 mingw$bits-libgfortran3" > get_toolchain.log
+
+mingwdir=usr/$host/sys-root/mingw
+chmod +x $mingwdir/bin/* $mingwdir/$host/bin/* $mingwdir/libexec/gcc/$host/*/*
+mkdir -p usr/bin
+for i in gcc_s_$exc-1 ssp-0 stdc++-6 gfortran-3 quadmath-0; do
+  cp $mingwdir/bin/lib$i.dll usr/bin
+done
+$mingwdir/bin/g++ --version
+# copy around binutils and make a junction for includes
+cp $mingwdir/$host/bin/* $mingwdir/bin
+case $(uname) in
+  CYGWIN*)
+    mklink="cmd /C mklink /J"
+    # treat these like cross-compilers if we're running from cygwin
+    for i in gcc g++ gfortran; do
+      mv $mingwdir/bin/$i.exe $mingwdir/bin/$host-$i.exe
+    done
+    ;;
+  *)
+    mklink="cmd //C mklink //J"
+    ;;
+esac
+if ! [ -e $mingwdir/$host/include ]; then
+  $mklink $(cygpath -w $mingwdir/$host/include) $(cygpath -w $mingwdir/include)
+fi
+echo "Toolchain successfully downloaded to $PWD/$mingwdir"
+echo "Add toolchain to your path by running \`export PATH=$PWD/$mingwdir/bin:\$PATH\`"

--- a/contrib/windows/winrpm.sh
+++ b/contrib/windows/winrpm.sh
@@ -8,9 +8,13 @@
 set -e
 url=$1
 toinstall=$2
-# run in dist-extras
-mkdir -p $(dirname "$0")/../../dist-extras
-cd $(dirname "$0")/../../dist-extras
+
+for i in curl xmllint gunzip sort sha256sum 7z; do
+  if [ -z "$(which $i 2>/dev/null)" ]; then
+    echo "error: this script requires having $i installed" >&2
+    exit 1
+  fi
+done
 
 # there is a curl --retry flag but it wasn't working here for some reason
 retry_curl() {
@@ -18,7 +22,7 @@ retry_curl() {
     curl -fLsS $1 && return
     #sleep 2
   done
-  echo "failed to download $1" >&2
+  echo "error: failed to download $1" >&2
   exit 1
 }
 
@@ -75,17 +79,69 @@ rpm_select() {
     [@ver='$maxver'][@rel='$maxrel']][1]" -
 }
 
+for i in $toinstall; do
+  # fail if no available candidates for requested packages
+  if [ -z "$(rpm_select $i)" ]; then
+    exit 1
+  fi
+done
+
+# outputs package and dll names, e.g. mingw64(zlib1.dll)
+rpm_requires() {
+  for i in $(rpm_select $1 | \
+      $xp "/package/format/requires/entry/@name" - 2>/dev/null); do
+    eval $i
+    echo $name
+  done
+}
+
+# outputs package name, warns if multiple providers with different names
+rpm_provides() {
+  providers=$(echo $primary | $xp "//*[$loc'package'][./*[$loc'format'] \
+    /*[$loc'provides']/*[$loc'entry'][@name='$1']]/*[$loc'name']" - | \
+    sed -e 's|<name>||g' -e 's|</name>|\n|g' | sort -u)
+  if [ $(echo $providers | wc -w) -gt 1 ]; then
+    echo "warning: found multiple providers $providers for $1, adding all" >&2
+  fi
+  echo $providers
+}
+
+newpkgs=$toinstall
+allrequires=""
+while [ -n "$newpkgs" ]; do
+  newrequires=""
+  for i in $newpkgs; do
+    for j in $(rpm_requires $i); do
+      # leading and trailing spaces to ensure word match
+      case " $allrequires $newrequires " in
+        *" $j "*) # already on list
+          ;;
+        *)
+          newrequires="$newrequires $j";;
+      esac
+    done
+  done
+  allrequires="$allrequires $newrequires"
+  newpkgs=""
+  for i in $newrequires; do
+    provides="$(rpm_provides $i)"
+    case " $toinstall $newpkgs " in
+      *" $provides "*) # already on list
+        ;;
+      *)
+        newpkgs="$newpkgs $provides";;
+    esac
+  done
+  toinstall="$toinstall $newpkgs"
+done
+
 mkdir -p noarch
 for i in $toinstall; do
   pkgi=$(rpm_select $i)
-  # fail if no available candidates for requested packages
-  if [ -z "$pkgi" ]; then
-    exit 1
-  fi
   checksum=$(echo $pkgi | $xp "/package/checksum/text()" -)
   eval $(echo $pkgi | $xp "/package/location/@href" -)
   echo "downloading $href"
-  ../deps/jldownload $href $url/$href
+  $(dirname "$0")/../../deps/jldownload $href $url/$href
   echo "$checksum *$href" | sha256sum -c
   7z x -y $href
   cpiofile=$(basename $href | sed 's/.rpm$/.cpio/')

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1857,7 +1857,7 @@ $(VIRTUALENV_SOURCE): virtualenv-$(VIRTUALENV_VER).tar.gz
 $(VIRTUALENV_TARGET): $(VIRTUALENV_SOURCE)
 	"$(shell ./find_python2)" $< $@
 ifeq ($(BUILD_OS), WINNT)
-	[ -e $@/Scripts ] && ! [ -e $@/bin ] && cmd //C mklink //J $@\\bin $@\\Scripts
+	-[ -e $@/Scripts ] && ! [ -e $@/bin ] && cmd //C mklink //J $@\\bin $@\\Scripts
 endif
 	touch -c $@
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -697,6 +697,9 @@ UV_MFLAGS += LDFLAGS="$(LDFLAGS) $(CLDFLAGS) -v"
 ifneq ($(UV_CFLAGS),)
 UV_MFLAGS += CFLAGS="$(UV_CFLAGS)"
 endif
+ifneq ($(VERBOSE), 0)
+UV_MFLAGS += V=1
+endif
 ifneq ($(USEMSVC), 1)
 UV_FLAGS = $(UV_MFLAGS)
 else
@@ -785,6 +788,9 @@ $(eval $(call git-external,openlibm,OPENLIBM,Makefile,libopenlibm.$(SHLIB_EXT)))
 OPENLIBM_OBJ_TARGET = $(build_shlibdir)/libopenlibm.$(SHLIB_EXT) $(build_libdir)/libopenlibm.a
 OPENLIBM_OBJ_SOURCE = $(OPENLIBM_SRC_DIR)/libopenlibm.$(SHLIB_EXT)
 OPENLIBM_FLAGS = ARCH="$(ARCH)" CC="$(CC)" FC="$(FC)" AR="$(AR)" OS="$(OS)" USECLANG=$(USECLANG) USEGCC=$(USEGCC)
+ifeq (CYGWIN,$(findstring CYGWIN,$(BUILD_OS)))
+OPENLIBM_FLAGS += OPENLIBM_HOME="$(call cygpath_w,$(abspath $(OPENLIBM_SRC_DIR)))"
+endif
 
 $(OPENLIBM_OBJ_SOURCE): $(OPENLIBM_SRC_DIR)/Makefile
 	$(MAKE) -C $(OPENLIBM_SRC_DIR) $(OPENLIBM_FLAGS) $(MAKE_COMMON)


### PR DESCRIPTION
This uses the opensuse toolchain, to maximize compatibility with WinRPM packages. Ref previous related issues and discussion in #10490 #11285 and #11682.

I haven't gotten this toolchain to fully work in Cygwin yet, since it's a native windows compiler executable and not cygwin-hosted so it doesn't understand Cygwin paths, symlinks, etc. If we're lucky, a future cygwin mingw-w64 package update might restore ABI compatibility with opensuse. We'll need to figure out something to do about the buildbots, which are currently cygwin-based. Maybe we could transition or augment them with MSYS2 and/or opensuse cross-compile.

I'd greatly appreciate people testing this, especially from a clean environment (pristine VM or fresh separate install of msys2, no pre-existing junk on the path, etc) to verify that it works as I'm describing for other people too.

I'll be adding another commit shortly that replaces the cross-compiling section of README.windows.md with a much simpler set of Docker+opensuse instructions.
