### PR TITLE
wait for peer connection in send_msg

### DIFF
--- a/base/precompile.jl
+++ b/base/precompile.jl
@@ -497,20 +497,18 @@ precompile(Base.start_worker, (Base.TTY,))
 precompile(Base.process_messages, (Base.TCPSocket, Base.TCPSocket))
 precompile(Base.process_messages, (Base.TCPSocket, Base.TCPSocket, Void))
 precompile(Base.process_tcp_streams, (Base.TCPSocket, Base.TCPSocket, Void))
-
 precompile(Base.message_handler_loop, (Base.TCPSocket, Base.TCPSocket, Void))
-
 precompile(Base.connect_to_peer, (Base.LocalManager, Int64, Base.WorkerConfig))
 precompile(Base.connect, (Base.LocalManager, Int64, Base.WorkerConfig))
 precompile(Base.connect_w2w, (Int64, Base.WorkerConfig))
-
 precompile(Base.connect_to_worker, (UTF8String, Int64))
-
 precompile(Base.addprocs, (Base.LocalManager, ))
 precompile(Base.addprocs, (Int, ))
 precompile(Base.setup_launched_worker, (Base.LocalManager, Dict, Base.WorkerConfig, Array{Int,1}))
 precompile(Base.create_worker, (Base.LocalManager, Dict, Base.WorkerConfig))
 precompile(Base.launch, (Base.LocalManager, Dict, Array{Base.WorkerConfig, 1}, Base.Condition))
+precompile(Base.set_valid_processes, (Array{Int, 1}, ))
+
 
 # Speed up repl help
 if Base.USE_GPL_LIBS


### PR DESCRIPTION
Prior to merging https://github.com/JuliaLang/julia/pull/11503, `worker_from_id` used to wait for a peer to connect if required. Merging https://github.com/JuliaLang/julia/pull/11503 necessitated a check to ensure that all connections were setup before `addprocs` returned.

The wait, if required, has been reinstated in this PR in `send_msg`. This makes it possible for `addprocs` to return to the caller sooner, while the connections are are being setup in the background, without waiting for setup completion.

cc: @JeffBezanson 
