### PR TITLE
Add eachindex() for AbstractString and Associative

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -192,6 +192,7 @@ in(k, v::KeyIterator) = !is(get(v.dict, k, secret_table_token),
                             secret_table_token)
 
 keys(a::Associative) = KeyIterator(a)
+eachindex(a::Associative) = KeyIterator(a)
 values(a::Associative) = ValueIterator(a)
 
 function copy(a::Associative)

--- a/base/string.jl
+++ b/base/string.jl
@@ -181,6 +181,17 @@ function chr2ind(s::AbstractString, i::Integer)
     end
 end
 
+immutable EachStringIndex{T<:AbstractString}
+    s::T
+end
+eachindex(s::AbstractString) = EachStringIndex(s)
+
+length(e::EachStringIndex) = length(e.s)
+start(e::EachStringIndex) = start(e.s)
+next(e::EachStringIndex, state) = (state, nextind(e.s, state))
+done(e::EachStringIndex, state) = done(e.s, state)
+eltype(e::EachStringIndex) = Int
+
 typealias Chars Union{Char,AbstractVector{Char},Set{Char}}
 
 function search(s::AbstractString, c::Chars, i::Integer)

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -33,7 +33,9 @@ Basic functions
 
 .. function:: eachindex(A...)
 
-   Creates an iterable object for visiting each index of an AbstractArray ``A`` in an efficient manner. For array types that have opted into fast linear indexing (like ``Array``), this is simply the range ``1:length(A)``. For other array types, this returns a specialized Cartesian range to efficiently index into the array with indices specified for every dimension. Example for a sparse 2-d array::
+   Creates an iterable object for visiting each index of an AbstractArray ``A`` in an efficient manner. For array types that have opted into fast linear indexing (like ``Array``), this is simply the range ``1:length(A)``. For other array types, this returns a specialized Cartesian range to efficiently index into the array with indices specified for every dimension. For other iterables, including strings and dictionaries, this returns an iterator object supporting arbitrary index types (e.g. unevenly spaced or non-integer indices).
+
+   Example for a sparse 2-d array::
 
     julia> A = sprand(2, 3, 0.5)
     2x3 sparse matrix with 4 Float64 entries:

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -333,3 +333,8 @@ let d = Dict{Int,Int}()
     end
     @test length(d) == 1
 end
+
+# iteration
+d = Dict('a'=>1, 'b'=>1, 'c'=> 3)
+@test [d[k] for k in keys(d)] == [d[k] for k in eachindex(d)] ==
+      [v for (k, v) in d] == [d[x[1]] for (i, x) in enumerate(d)]

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1892,3 +1892,8 @@ end
 @test_throws BoundsError Base.checkstring(b"abcdef", 3, 0)
 @test_throws BoundsError Base.checkstring(b"abcdef", 3, 7)
 @test_throws ArgumentError Base.checkstring(b"abcdef", 3, 1)
+
+# iteration
+@test [c for c in "ḟøøƀäṙ"] == ['ḟ', 'ø', 'ø', 'ƀ', 'ä', 'ṙ']
+@test [i for i in eachindex("ḟøøƀäṙ")] == [1, 4, 6, 8, 10, 12]
+@test [x for x in enumerate("ḟøøƀäṙ")] == [(1, 'ḟ'), (2, 'ø'), (3, 'ø'), (4, 'ƀ'), (5, 'ä'), (6, 'ṙ')]


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/11649 which was only about strings, but in the end I didn't see the point in restricting this to strings: it could be useful for any other type which would use unevenly spaced or non-integer indices. Actually, it's very similar to `Enumerate`, but returning the actual indices which can be passed to `getindex` (while `Enumerate` returns the element number), and of course not returning the value.

The potential issue with this very general approach is that I'm using `next` instead of `nextind`, which is wasteful since we don't use the value. We could restore `nextind`, which is currently deprecated for non-strings, if we want to keep this general approach. But in my tests using `nex` or `nextind` doesn't make any difference  for strings (see below).

Either way, it's not very efficient. Calling `eachindex` and indexing the string is about twice slower as iterating over it directly for a `UTF8String`. Indeed, it appears that `next` is not inlined in either case. Is that expected?

Another funny result is that with an `ASCIIString`, using `nextind` in `eachindex` is actually _faster_ than iterating over the string. This is because `next` is inlined in that case, but not when iterating. I'm not sure why, but this seems to indicate something is wrong in the standard behavior.

``` julia
julia> function f(s)
           [c for c in s]
       end
f (generic function with 1 method)

julia> function g(s)
           [s[i] for i in eachindex(s)]
       end
g (generic function with 1 method)

julia> s = "some string but quite long to make the test interesting €"
"some string but quite long to make the test interesting €"

julia> f(s); g(s);

julia> @time for i in 1:10000000; f(s); end
   7.724 seconds      (10000 k allocations: 3204 MB, 1.48% gc time)

julia> @time for i in 1:10000000; g(s); end
  15.677 seconds      (20000 k allocations: 3357 MB, 1.21% gc time)
```

And with `nextind`:

``` julia
julia> Base.next(e::EachIndex, state) = (state, nextind(e.itr, state))
next (generic function with 60 methods)

julia> function g(s)
           [s[i] for i in eachindex(s)]
       end
g (generic function with 1 method)

julia> g(s);

julia> @time for i in 1:10000000; g(s); end
  16.803 seconds      (20000 k allocations: 3357 MB, 1.13% gc time)
```
