### PR TITLE
Fix #11698. Only call cholmod_start when CHOLMOD module is initialized

### DIFF
--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -42,16 +42,26 @@ const common_postorder = (1:4) + cholmod_com_offsets[17]
 ## macro to generate the name of the C function according to the integer type
 macro cholmod_name(nm,typ) string("cholmod_", eval(typ) == SuiteSparse_long ? "l_" : "", nm) end
 
-for Ti in IndexTypes
-    @eval begin
-        function common(::Type{$Ti})
-            a = fill(0xff, common_size)
-            @isok ccall((@cholmod_name "start" $Ti
-                , :libcholmod), Cint, (Ptr{UInt8},), a)
-            set_print_level(a, 0) # no printing from CHOLMOD by default
-            a
-        end
-    end
+function start(a::Vector{UInt8})
+    @isok ccall((@cholmod_name("start", SuiteSparse_long), :libcholmod),
+        Cint, (Ptr{UInt8},), a)
+end
+
+function finish(a::Vector{UInt8})
+    @isok ccall((@cholmod_name("finish", SuiteSparse_long), :libcholmod),
+        Cint, (Ptr{UInt8},), a)
+end
+
+function defaults(a::Vector{UInt8})
+    @isok ccall((@cholmod_name("defaults", SuiteSparse_long), :libcholmod),
+        Cint, (Ptr{UInt8},), a)
+end
+
+function common()
+    global cmn
+    defaults(cmn)
+    set_print_level(cmn, 0) # no printing from CHOLMOD by default
+    cmn
 end
 
 const version_array = Array(Cint, 3)
@@ -63,6 +73,7 @@ end
 const version = VersionNumber(version_array...)
 
 function __init__()
+    ### Check if the linked library is compatible with the Julia code
     if Libdl.dlsym(Libdl.dlopen("libcholmod"), :cholmod_version) == C_NULL
         warn("""
 
@@ -122,6 +133,10 @@ function __init__()
              the correct versions of all dependencies.
          """)
     end
+
+    ### Initiate CHOLMOD
+    global const cmn = fill(0xff, common_size)
+    start(cmn)
 end
 
 function set_print_level(cm::Array{UInt8}, lev::Integer)
@@ -154,13 +169,13 @@ type Dense{T<:VTypes} <: DenseMatrix{T}
 end
 
 # Sparse
-immutable C_Sparse{Tv<:VTypes,Ti<:ITypes}
+immutable C_Sparse{Tv<:VTypes}
     nrow::Csize_t
     ncol::Csize_t
     nzmax::Csize_t
-    p::Ptr{Ti}
-    i::Ptr{Ti}
-    nz::Ptr{Ti}
+    p::Ptr{SuiteSparse_long}
+    i::Ptr{SuiteSparse_long}
+    nz::Ptr{SuiteSparse_long}
     x::Ptr{Tv}
     z::Ptr{Void}
     stype::Cint
@@ -191,43 +206,44 @@ immutable C_SparseVoid
     packed::Cint
 end
 
-type Sparse{Tv<:VTypes,Ti<:ITypes} <: AbstractSparseMatrix{Tv,Ti}
-    p::Ptr{C_Sparse{Tv,Ti}}
-    function Sparse(ptr::Ptr{C_Sparse{Tv,Ti}})
-        if ptr == C_NULL
+type Sparse{Tv<:VTypes} <: AbstractSparseMatrix{Tv,SuiteSparse_long}
+    p::Ptr{C_Sparse{Tv}}
+    common::Vector{UInt8}
+    function Sparse(p::Ptr{C_Sparse{Tv}})
+        if p == C_NULL
             throw(ArgumentError("sparse matrix construction failed for unknown reasons. Please submit a bug report."))
         end
-        new(ptr)
+        new(p)
     end
 end
-Sparse{Tv<:VTypes,Ti<:ITypes}(p::Ptr{C_Sparse{Tv,Ti}}) = Sparse{Tv,Ti}(p)
+Sparse{Tv<:VTypes}(p::Ptr{C_Sparse{Tv}}) = Sparse{Tv}(p)
 
 # Factor
 
 if version >= v"2.1.0" # CHOLMOD version 2.1.0 or later
-    immutable C_Factor{Tv<:VTypes,Ti<:ITypes}
+    immutable C_Factor{Tv<:VTypes}
         n::Csize_t
         minor::Csize_t
-        Perm::Ptr{Ti}
-        ColCount::Ptr{Ti}
-        IPerm::Ptr{Ti}        # this pointer was added in verison 2.1.0
+        Perm::Ptr{SuiteSparse_long}
+        ColCount::Ptr{SuiteSparse_long}
+        IPerm::Ptr{SuiteSparse_long}        # this pointer was added in verison 2.1.0
         nzmax::Csize_t
-        p::Ptr{Ti}
-        i::Ptr{Ti}
+        p::Ptr{SuiteSparse_long}
+        i::Ptr{SuiteSparse_long}
         x::Ptr{Tv}
         z::Ptr{Void}
-        nz::Ptr{Ti}
-        next::Ptr{Ti}
-        prev::Ptr{Ti}
+        nz::Ptr{SuiteSparse_long}
+        next::Ptr{SuiteSparse_long}
+        prev::Ptr{SuiteSparse_long}
         nsuper::Csize_t
         ssize::Csize_t
         xsize::Csize_t
         maxcsize::Csize_t
         maxesize::Csize_t
-        super::Ptr{Ti}
-        pi::Ptr{Ti}
-        px::Ptr{Ti}
-        s::Ptr{Ti}
+        super::Ptr{SuiteSparse_long}
+        pi::Ptr{SuiteSparse_long}
+        px::Ptr{SuiteSparse_long}
+        s::Ptr{SuiteSparse_long}
         ordering::Cint
         is_ll::Cint
         is_super::Cint
@@ -237,28 +253,28 @@ if version >= v"2.1.0" # CHOLMOD version 2.1.0 or later
         dtype::Cint
     end
 else
-    immutable C_Factor{Tv<:VTypes,Ti<:ITypes}
+    immutable C_Factor{Tv<:VTypes}
         n::Csize_t
         minor::Csize_t
-        Perm::Ptr{Ti}
-        ColCount::Ptr{Ti}
+        Perm::Ptr{SuiteSparse_long}
+        ColCount::Ptr{SuiteSparse_long}
         nzmax::Csize_t
-        p::Ptr{Ti}
-        i::Ptr{Ti}
+        p::Ptr{SuiteSparse_long}
+        i::Ptr{SuiteSparse_long}
         x::Ptr{Tv}
         z::Ptr{Void}
-        nz::Ptr{Ti}
-        next::Ptr{Ti}
-        prev::Ptr{Ti}
+        nz::Ptr{SuiteSparse_long}
+        next::Ptr{SuiteSparse_long}
+        prev::Ptr{SuiteSparse_long}
         nsuper::Csize_t
         ssize::Csize_t
         xsize::Csize_t
         maxcsize::Csize_t
         maxesize::Csize_t
-        super::Ptr{Ti}
-        pi::Ptr{Ti}
-        px::Ptr{Ti}
-        s::Ptr{Ti}
+        super::Ptr{SuiteSparse_long}
+        pi::Ptr{SuiteSparse_long}
+        px::Ptr{SuiteSparse_long}
+        s::Ptr{SuiteSparse_long}
         ordering::Cint
         is_ll::Cint
         is_super::Cint
@@ -269,15 +285,15 @@ else
     end
 end
 
-type Factor{Tv,Ti} <: Factorization{Tv}
-    p::Ptr{C_Factor{Tv,Ti}}
+type Factor{Tv} <: Factorization{Tv}
+    p::Ptr{C_Factor{Tv}}
 end
 
 # FactorComponent, for encoding particular factors from a factorization
-type FactorComponent{Tv,Ti,S} <: AbstractMatrix{Tv}
-    F::Factor{Tv,Ti}
+type FactorComponent{Tv,S} <: AbstractMatrix{Tv}
+    F::Factor{Tv}
 
-    function FactorComponent(F::Factor{Tv,Ti})
+    function FactorComponent(F::Factor{Tv})
         s = unsafe_load(F.p)
         if s.is_ll != 0
             S == :L || S == :U || S == :PtL || S == :UP || throw(CHOLMODException(string(S, " not supported for sparse LLt matrices; try :L, :U, :PtL, or :UP")))
@@ -289,8 +305,8 @@ type FactorComponent{Tv,Ti,S} <: AbstractMatrix{Tv}
         new(F)
     end
 end
-function FactorComponent{Tv,Ti}(F::Factor{Tv,Ti}, sym::Symbol)
-    FactorComponent{Tv,Ti,sym}(F)
+function FactorComponent{Tv}(F::Factor{Tv}, sym::Symbol)
+    FactorComponent{Tv,sym}(F)
 end
 
 Factor(FC::FactorComponent) = Factor(FC.F)
@@ -307,24 +323,24 @@ Factor(FC::FactorComponent) = Factor(FC.F)
 function allocate_dense(nrow::Integer, ncol::Integer, d::Integer, ::Type{Float64})
     d = Dense(ccall((:cholmod_l_allocate_dense, :libcholmod), Ptr{C_Dense{Float64}},
         (Csize_t, Csize_t, Csize_t, Cint, Ptr{Void}),
-        nrow, ncol, d, REAL, common(SuiteSparse_long)))
+        nrow, ncol, d, REAL, common()))
     finalizer(d, free!)
     d
 end
 function allocate_dense(nrow::Integer, ncol::Integer, d::Integer, ::Type{Complex{Float64}})
     d = Dense(ccall((:cholmod_l_allocate_dense, :libcholmod), Ptr{C_Dense{Complex{Float64}}},
         (Csize_t, Csize_t, Csize_t, Cint, Ptr{Void}),
-        nrow, ncol, d, COMPLEX, common(SuiteSparse_long)))
+        nrow, ncol, d, COMPLEX, common()))
     finalizer(d, free!)
     d
 end
 
-free_dense!{T}(p::Ptr{C_Dense{T}}) = ccall((:cholmod_l_free_dense, :libcholmod), Cint, (Ref{Ptr{C_Dense{T}}}, Ptr{Void}), p, common(Cint))
+free_dense!{T}(p::Ptr{C_Dense{T}}) = ccall((:cholmod_l_free_dense, :libcholmod), Cint, (Ref{Ptr{C_Dense{T}}}, Ptr{Void}), p, common())
 
 function zeros{T<:VTypes}(m::Integer, n::Integer, ::Type{T})
     d = Dense(ccall((:cholmod_l_zeros, :libcholmod), Ptr{C_Dense{T}},
         (Csize_t, Csize_t, Cint, Ptr{UInt8}),
-         m, n, xtyp(T), common(SuiteSparse_long)))
+         m, n, xtyp(T), common()))
     finalizer(d, free!)
     d
 end
@@ -333,7 +349,7 @@ zeros(m::Integer, n::Integer) = zeros(m, n, Float64)
 function ones{T<:VTypes}(m::Integer, n::Integer, ::Type{T})
     d = Dense(ccall((:cholmod_l_ones, :libcholmod), Ptr{C_Dense{T}},
         (Csize_t, Csize_t, Cint, Ptr{UInt8}),
-         m, n, xtyp(T), common(SuiteSparse_long)))
+         m, n, xtyp(T), common()))
     finalizer(d, free!)
     d
 end
@@ -342,7 +358,7 @@ ones(m::Integer, n::Integer) = ones(m, n, Float64)
 function eye{T<:VTypes}(m::Integer, n::Integer, ::Type{T})
     d = Dense(ccall((:cholmod_l_eye, :libcholmod), Ptr{C_Dense{T}},
         (Csize_t, Csize_t, Cint, Ptr{UInt8}),
-         m, n, xtyp(T), common(SuiteSparse_long)))
+         m, n, xtyp(T), common()))
     finalizer(d, free!)
     d
 end
@@ -352,7 +368,7 @@ eye(n::Integer) = eye(n, n, Float64)
 function copy_dense{Tv<:VTypes}(A::Dense{Tv})
     d = Dense(ccall((:cholmod_l_copy_dense, :libcholmod), Ptr{C_Dense{Tv}},
         (Ptr{C_Dense{Tv}}, Ptr{UInt8}),
-         A.p, common(SuiteSparse_long)))
+         A.p, common()))
     finalizer(d, free!)
     d
 end
@@ -369,353 +385,368 @@ function norm_dense{Tv<:VTypes}(D::Dense{Tv}, p::Integer)
     end
     ccall((:cholmod_l_norm_dense, :libcholmod), Cdouble,
         (Ptr{C_Dense{Tv}}, Cint, Ptr{UInt8}),
-          D.p, p, common(SuiteSparse_long))
+          D.p, p, common())
 end
 
 ### cholmod_check.h ###
 function check_dense{T<:VTypes}(A::Dense{T})
     ccall((:cholmod_l_check_dense, :libcholmod), Cint,
           (Ptr{C_Dense{T}}, Ptr{UInt8}),
-          A.p, common(SuiteSparse_long))!=0
+          A.p, common())!=0
 end
 
-# Non-Dense wrappers (which all depend on IType)
-for Ti in IndexTypes
-    @eval begin
-        ### cholmod_core.h ###
-        function allocate_sparse(nrow::Integer, ncol::Integer, nzmax::Integer, sorted::Bool, packed::Bool, stype::Integer, ::Type{Float64}, ::Type{$Ti})
-            s = Sparse(ccall((@cholmod_name("allocate_sparse", $Ti), :libcholmod), Ptr{C_Sparse{Float64,$Ti}},
-                    (Csize_t, Csize_t, Csize_t, Cint,
-                        Cint, Cint, Cint, Ptr{Void}),
-                    nrow, ncol, nzmax, sorted,
-                        packed, stype, REAL, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
-        function allocate_sparse(nrow::Integer, ncol::Integer, nzmax::Integer, sorted::Bool, packed::Bool, stype::Integer, ::Type{Complex{Float64}}, ::Type{$Ti})
-            s = Sparse(ccall((@cholmod_name("allocate_sparse", $Ti), :libcholmod), Ptr{C_Sparse{Complex{Float64},$Ti}},
-                    (Csize_t, Csize_t, Csize_t, Cint,
-                        Cint, Cint, Cint, Ptr{Void}),
-                    nrow, ncol, nzmax, sorted,
-                        packed, stype, COMPLEX, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
-        function free_sparse!{Tv<:VTypes}(ptr::Ptr{C_Sparse{Tv,$Ti}})
-            @isok ccall((@cholmod_name("free_sparse", $Ti), :libcholmod), Cint,
-                    (Ptr{Ptr{C_Sparse{Tv,$Ti}}}, Ptr{UInt8}),
-                        &ptr, common($Ti))
-        end
+# Non-Dense wrappers
+### cholmod_core.h ###
+function allocate_sparse(nrow::Integer, ncol::Integer, nzmax::Integer, sorted::Bool, packed::Bool, stype::Integer, ::Type{Float64})
+    s = Sparse(ccall((@cholmod_name("allocate_sparse", SuiteSparse_long), :libcholmod), Ptr{C_Sparse{Float64}},
+            (Csize_t, Csize_t, Csize_t, Cint,
+                Cint, Cint, Cint, Ptr{Void}),
+            nrow, ncol, nzmax, sorted,
+                packed, stype, REAL, common()))
+    finalizer(s, free!)
+    s
+end
+function allocate_sparse(nrow::Integer, ncol::Integer, nzmax::Integer, sorted::Bool, packed::Bool, stype::Integer, ::Type{Complex{Float64}})
+    s = Sparse(ccall((@cholmod_name("allocate_sparse", SuiteSparse_long), :libcholmod),
+            Ptr{C_Sparse{Complex{Float64}}},
+                (Csize_t, Csize_t, Csize_t, Cint,
+                 Cint, Cint, Cint, Ptr{Void}),
+                nrow, ncol, nzmax, sorted,
+                packed, stype, COMPLEX, common()))
+    finalizer(s, free!)
+    s
+end
+function free_sparse!{Tv<:VTypes}(ptr::Ptr{C_Sparse{Tv}})
+    @isok ccall((@cholmod_name("free_sparse", SuiteSparse_long), :libcholmod), Cint,
+            (Ptr{Ptr{C_Sparse{Tv}}}, Ptr{UInt8}),
+                &ptr, common())
+end
 
-        function free_sparse!(ptr::Ptr{C_SparseVoid})
-            @isok ccall((@cholmod_name("free_sparse", $Ti), :libcholmod), Cint,
-                    (Ptr{Ptr{C_SparseVoid}}, Ptr{UInt8}),
-                        &ptr, common($Ti))
-        end
+function free_sparse!(ptr::Ptr{C_SparseVoid})
+    @isok ccall((@cholmod_name("free_sparse", SuiteSparse_long), :libcholmod), Cint,
+            (Ptr{Ptr{C_SparseVoid}}, Ptr{UInt8}),
+                &ptr, common())
+end
 
-        function free_factor!{Tv<:VTypes}(ptr::Ptr{C_Factor{Tv,$Ti}})
-            @isok ccall((@cholmod_name("free_factor", $Ti), :libcholmod), Cint,
-                    (Ptr{Ptr{C_Factor{Tv,$Ti}}}, Ptr{Void}),
-                        &ptr, common($Ti))
-        end
+function free_factor!{Tv<:VTypes}(ptr::Ptr{C_Factor{Tv}})
+    @isok ccall((@cholmod_name("free_factor", SuiteSparse_long), :libcholmod), Cint,
+            (Ptr{Ptr{C_Factor{Tv}}}, Ptr{Void}),
+                &ptr, common())
+end
 
-        function aat{Tv<:VRealTypes}(A::Sparse{Tv,$Ti}, fset::Vector{$Ti}, mode::Integer)
-            s = Sparse(ccall((@cholmod_name("aat", $Ti), :libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Ptr{C_Sparse{Tv,$Ti}}, Ptr{$Ti}, Csize_t, Cint, Ptr{UInt8}),
-                        A.p, fset, length(fset), mode, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
+function aat{Tv<:VRealTypes}(A::Sparse{Tv}, fset::Vector{SuiteSparse_long}, mode::Integer)
+    s = Sparse(ccall((@cholmod_name("aat", SuiteSparse_long), :libcholmod),
+        Ptr{C_Sparse{Tv}},
+            (Ptr{C_Sparse{Tv}}, Ptr{SuiteSparse_long}, Csize_t, Cint, Ptr{UInt8}),
+                A.p, fset, length(fset), mode, common()))
+    finalizer(s, free!)
+    s
+end
 
-        function sparse_to_dense{Tv<:VTypes}(A::Sparse{Tv,$Ti})
-            d = Dense(ccall((@cholmod_name("sparse_to_dense", $Ti),:libcholmod), Ptr{C_Dense{Tv}},
-                    (Ptr{C_Sparse{Tv,$Ti}}, Ptr{UInt8}),
-                        A.p, common($Ti)))
-            finalizer(d, free!)
-            d
-        end
-        function dense_to_sparse{Tv<:VTypes}(D::Dense{Tv}, ::Type{$Ti})
-            s = Sparse(ccall((@cholmod_name("dense_to_sparse", $Ti),:libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Ptr{C_Dense{Tv}}, Cint, Ptr{UInt8}),
-                        D.p, true, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
+function sparse_to_dense{Tv<:VTypes}(A::Sparse{Tv})
+    d = Dense(ccall((@cholmod_name("sparse_to_dense", SuiteSparse_long),:libcholmod),
+        Ptr{C_Dense{Tv}},
+            (Ptr{C_Sparse{Tv}}, Ptr{UInt8}),
+                A.p, common()))
+    finalizer(d, free!)
+    d
+end
+function dense_to_sparse{Tv<:VTypes}(D::Dense{Tv}, ::Type{SuiteSparse_long})
+    s = Sparse(ccall((@cholmod_name("dense_to_sparse", SuiteSparse_long),:libcholmod),
+        Ptr{C_Sparse{Tv}},
+            (Ptr{C_Dense{Tv}}, Cint, Ptr{UInt8}),
+                D.p, true, common()))
+    finalizer(s, free!)
+    s
+end
 
-        function factor_to_sparse!{Tv<:VTypes}(F::Factor{Tv,$Ti})
-            ss = unsafe_load(F.p)
-            ss.xtype > PATTERN || throw(CHOLMODException("only numeric factors are supported"))
-            s = Sparse(ccall((@cholmod_name("factor_to_sparse", $Ti),:libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Ptr{C_Factor{Tv,$Ti}}, Ptr{UInt8}),
-                        F.p, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
+function factor_to_sparse!{Tv<:VTypes}(F::Factor{Tv})
+    ss = unsafe_load(F.p)
+    ss.xtype > PATTERN || throw(CHOLMODException("only numeric factors are supported"))
+    s = Sparse(ccall((@cholmod_name("factor_to_sparse", SuiteSparse_long),:libcholmod),
+        Ptr{C_Sparse{Tv}},
+            (Ptr{C_Factor{Tv}}, Ptr{UInt8}),
+                F.p, common()))
+    finalizer(s, free!)
+    s
+end
 
-        function change_factor!{Tv<:VTypes}(::Type{Float64}, to_ll::Bool, to_super::Bool, to_packed::Bool, to_monotonic::Bool, F::Factor{Tv,$Ti})
-            @isok ccall((@cholmod_name("change_factor", $Ti),:libcholmod), Cint,
-                    (Cint, Cint, Cint, Cint, Cint, Ptr{C_Factor{Tv,$Ti}}, Ptr{UInt8}),
-                        REAL, to_ll, to_super, to_packed, to_monotonic, F.p, common($Ti))
-            Factor{Float64,$Ti}(F.p)
-        end
+function change_factor!{Tv<:VTypes}(::Type{Float64}, to_ll::Bool, to_super::Bool, to_packed::Bool, to_monotonic::Bool, F::Factor{Tv})
+    @isok ccall((@cholmod_name("change_factor", SuiteSparse_long),:libcholmod), Cint,
+            (Cint, Cint, Cint, Cint, Cint, Ptr{C_Factor{Tv}}, Ptr{UInt8}),
+                REAL, to_ll, to_super, to_packed, to_monotonic, F.p, common())
+    Factor{Float64}(F.p)
+end
 
-        function change_factor!{Tv<:VTypes}(::Type{Complex{Float64}}, to_ll::Bool, to_super::Bool, to_packed::Bool, to_monotonic::Bool, F::Factor{Tv,$Ti})
-            @isok ccall((@cholmod_name("change_factor", $Ti),:libcholmod), Cint,
-                    (Cint, Cint, Cint, Cint, Cint, Ptr{C_Factor{Tv,$Ti}}, Ptr{UInt8}),
-                        COMPLEX, to_ll, to_super, to_packed, to_monotonic, F.p, common($Ti))
-            Factor{Complex{Float64},$Ti}(F.p)
-        end
+function change_factor!{Tv<:VTypes}(::Type{Complex{Float64}}, to_ll::Bool, to_super::Bool, to_packed::Bool, to_monotonic::Bool, F::Factor{Tv})
+    @isok ccall((@cholmod_name("change_factor", SuiteSparse_long),:libcholmod), Cint,
+            (Cint, Cint, Cint, Cint, Cint, Ptr{C_Factor{Tv}}, Ptr{UInt8}),
+                COMPLEX, to_ll, to_super, to_packed, to_monotonic, F.p, common())
+    Factor{Complex{Float64}}(F.p)
+end
 
-        function check_sparse{Tv<:VTypes}(A::Sparse{Tv,$Ti})
-            ccall((@cholmod_name("check_sparse", $Ti),:libcholmod), Cint,
-                  (Ptr{C_Sparse{Tv,$Ti}}, Ptr{UInt8}),
-                  A.p, common($Ti))!=0
-        end
+function check_sparse{Tv<:VTypes}(A::Sparse{Tv})
+    ccall((@cholmod_name("check_sparse", SuiteSparse_long),:libcholmod), Cint,
+          (Ptr{C_Sparse{Tv}}, Ptr{UInt8}),
+          A.p, common())!=0
+end
 
-        function check_factor{Tv<:VTypes}(F::Factor{Tv,$Ti})
-            ccall((@cholmod_name("check_factor", $Ti),:libcholmod), Cint,
-                  (Ptr{C_Factor{Tv,$Ti}}, Ptr{UInt8}),
-                  F.p, common($Ti))!=0
-        end
+function check_factor{Tv<:VTypes}(F::Factor{Tv})
+    ccall((@cholmod_name("check_factor", SuiteSparse_long),:libcholmod), Cint,
+          (Ptr{C_Factor{Tv}}, Ptr{UInt8}),
+          F.p, common())!=0
+end
 
-        function nnz{Tv<:VTypes}(A::Sparse{Tv,$Ti})
-            ccall((@cholmod_name("nnz", $Ti),:libcholmod), Int,
-                    (Ptr{C_Sparse{Tv,$Ti}}, Ptr{UInt8}),
-                        A.p, common($Ti))
-        end
+function nnz{Tv<:VTypes}(A::Sparse{Tv})
+    ccall((@cholmod_name("nnz", SuiteSparse_long),:libcholmod), Int,
+            (Ptr{C_Sparse{Tv}}, Ptr{UInt8}),
+                A.p, common())
+end
 
-        function speye{Tv<:VTypes}(m::Integer, n::Integer, ::Type{Tv})
-            s = Sparse(ccall((@cholmod_name("speye", $Ti), :libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Csize_t, Csize_t, Cint, Ptr{UInt8}),
-                        m, n, xtyp(Tv), common($Ti)))
-            finalizer(s, free!)
-            s
-        end
+function speye{Tv<:VTypes}(m::Integer, n::Integer, ::Type{Tv})
+    s = Sparse(ccall((@cholmod_name("speye", SuiteSparse_long), :libcholmod),
+        Ptr{C_Sparse{Tv}},
+            (Csize_t, Csize_t, Cint, Ptr{UInt8}),
+                m, n, xtyp(Tv), common()))
+    finalizer(s, free!)
+    s
+end
 
-        function spzeros{Tv<:VTypes}(m::Integer, n::Integer, nzmax::Integer, ::Type{Tv})
-            s = Sparse(ccall((@cholmod_name("spzeros", $Ti), :libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Csize_t, Csize_t, Csize_t, Cint, Ptr{UInt8}),
-                        m, n, nzmax, xtyp(Tv), common($Ti)))
-            finalizer(s, free!)
-            s
-        end
+function spzeros{Tv<:VTypes}(m::Integer, n::Integer, nzmax::Integer, ::Type{Tv})
+    s = Sparse(ccall((@cholmod_name("spzeros", SuiteSparse_long), :libcholmod),
+        Ptr{C_Sparse{Tv}},
+            (Csize_t, Csize_t, Csize_t, Cint, Ptr{UInt8}),
+             m, n, nzmax, xtyp(Tv), common()))
+    finalizer(s, free!)
+    s
+end
 
-        function transpose_{Tv<:VTypes}(A::Sparse{Tv,$Ti}, values::Integer)
-            s = Sparse(ccall((@cholmod_name("transpose", $Ti),:libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Ptr{C_Sparse{Tv,$Ti}}, Cint, Ptr{UInt8}),
-                        A.p, values, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
+function transpose_{Tv<:VTypes}(A::Sparse{Tv}, values::Integer)
+    s = Sparse(ccall((@cholmod_name("transpose", SuiteSparse_long),:libcholmod),
+        Ptr{C_Sparse{Tv}},
+            (Ptr{C_Sparse{Tv}}, Cint, Ptr{UInt8}),
+                A.p, values, common()))
+    finalizer(s, free!)
+    s
+end
 
-        function copy_factor{Tv<:VTypes}(F::Factor{Tv,$Ti})
-            f = Factor(ccall((@cholmod_name("copy_factor", $Ti),:libcholmod), Ptr{C_Factor{Tv,$Ti}},
-                    (Ptr{C_Factor{Tv,$Ti}}, Ptr{UInt8}),
-                        F.p, common($Ti)))
-            finalizer(f, free!)
-            f
-        end
-        function copy_sparse{Tv<:VTypes}(A::Sparse{Tv,$Ti})
-            s = Sparse(ccall((@cholmod_name("copy_sparse", $Ti),:libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Ptr{C_Sparse{Tv,$Ti}}, Ptr{UInt8}),
-                        A.p, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
-        function copy{Tv<:VRealTypes}(A::Sparse{Tv,$Ti}, stype::Integer, mode::Integer)
-            s = Sparse(ccall((@cholmod_name("copy", $Ti),:libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Ptr{C_Sparse{Tv,$Ti}}, Cint, Cint, Ptr{UInt8}),
-                        A.p, stype, mode, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
+function copy_factor{Tv<:VTypes}(F::Factor{Tv})
+    f = Factor(ccall((@cholmod_name("copy_factor", SuiteSparse_long),:libcholmod),
+        Ptr{C_Factor{Tv}},
+            (Ptr{C_Factor{Tv}}, Ptr{UInt8}),
+                F.p, common()))
+    finalizer(f, free!)
+    f
+end
+function copy_sparse{Tv<:VTypes}(A::Sparse{Tv})
+    s = Sparse(ccall((@cholmod_name("copy_sparse", SuiteSparse_long),:libcholmod),
+        Ptr{C_Sparse{Tv}},
+            (Ptr{C_Sparse{Tv}}, Ptr{UInt8}),
+                A.p, common()))
+    finalizer(s, free!)
+    s
+end
+function copy{Tv<:VRealTypes}(A::Sparse{Tv}, stype::Integer, mode::Integer)
+    s = Sparse(ccall((@cholmod_name("copy", SuiteSparse_long),:libcholmod),
+        Ptr{C_Sparse{Tv}},
+            (Ptr{C_Sparse{Tv}}, Cint, Cint, Ptr{UInt8}),
+                A.p, stype, mode, common()))
+    finalizer(s, free!)
+    s
+end
 
-        ### cholmod_check.h ###
-        function print_sparse{Tv<:VTypes}(A::Sparse{Tv,$Ti}, name::ASCIIString)
-            cm = common($Ti)
-            set_print_level(cm, 3)
-            @isok ccall((@cholmod_name("print_sparse", $Ti),:libcholmod), Cint,
-                    (Ptr{C_Sparse{Tv,$Ti}}, Ptr{UInt8}, Ptr{UInt8}),
-                         A.p, name, cm)
-            nothing
-        end
-        function print_factor{Tv<:VTypes}(F::Factor{Tv,$Ti}, name::ASCIIString)
-            cm = common($Ti)
-            set_print_level(cm, 3)
-            @isok ccall((@cholmod_name("print_factor", $Ti),:libcholmod), Cint,
-                    (Ptr{C_Factor{Tv,$Ti}}, Ptr{UInt8}, Ptr{UInt8}),
-                        F.p, name, cm)
-            nothing
-        end
+### cholmod_check.h ###
+function print_sparse{Tv<:VTypes}(A::Sparse{Tv}, name::ASCIIString)
+    cm = common()
+    set_print_level(cm, 3)
+    @isok ccall((@cholmod_name("print_sparse", SuiteSparse_long),:libcholmod), Cint,
+            (Ptr{C_Sparse{Tv}}, Ptr{UInt8}, Ptr{UInt8}),
+                 A.p, name, cm)
+    nothing
+end
+function print_factor{Tv<:VTypes}(F::Factor{Tv}, name::ASCIIString)
+    cm = common()
+    set_print_level(cm, 3)
+    @isok ccall((@cholmod_name("print_factor", SuiteSparse_long),:libcholmod), Cint,
+            (Ptr{C_Factor{Tv}}, Ptr{UInt8}, Ptr{UInt8}),
+                F.p, name, cm)
+    nothing
+end
 
-        ### cholmod_matrixops.h ###
-        function ssmult{Tv<:VRealTypes}(A::Sparse{Tv,$Ti}, B::Sparse{Tv,$Ti}, stype::Integer, values::Bool, sorted::Bool)
-            lA = unsafe_load(A.p)
-            lB = unsafe_load(B.p)
-            if lA.ncol != lB.nrow
-                throw(DimensionMismatch("inner matrix dimensions do not fit"))
-            end
-            s = Sparse(ccall((@cholmod_name("ssmult", $Ti),:libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Ptr{C_Sparse{Tv,$Ti}}, Ptr{C_Sparse{Tv,$Ti}}, Cint, Cint, Cint, Ptr{UInt8}),
-                        A.p, B.p, stype, values, sorted, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
+### cholmod_matrixops.h ###
+function ssmult{Tv<:VRealTypes}(A::Sparse{Tv}, B::Sparse{Tv}, stype::Integer, values::Bool, sorted::Bool)
+    lA = unsafe_load(A.p)
+    lB = unsafe_load(B.p)
+    if lA.ncol != lB.nrow
+        throw(DimensionMismatch("inner matrix dimensions do not fit"))
+    end
+    s = Sparse(ccall((@cholmod_name("ssmult", SuiteSparse_long),:libcholmod),
+        Ptr{C_Sparse{Tv}},
+            (Ptr{C_Sparse{Tv}}, Ptr{C_Sparse{Tv}}, Cint, Cint,
+                Cint, Ptr{UInt8}),
+             A.p, B.p, stype, values,
+                sorted, common()))
+    finalizer(s, free!)
+    s
+end
 
-        function norm_sparse{Tv<:VTypes}(A::Sparse{Tv,$Ti}, norm::Integer)
-            if norm != 0 && norm != 1
-                throw(ArgumentError("norm argument must be either 0 or 1"))
-            end
-            ccall((@cholmod_name("norm_sparse", $Ti), :libcholmod), Cdouble,
-                    (Ptr{C_Sparse{Tv,$Ti}}, Cint, Ptr{UInt8}),
-                        A.p, norm, common($Ti))
-        end
+function norm_sparse{Tv<:VTypes}(A::Sparse{Tv}, norm::Integer)
+    if norm != 0 && norm != 1
+        throw(ArgumentError("norm argument must be either 0 or 1"))
+    end
+    ccall((@cholmod_name("norm_sparse", SuiteSparse_long), :libcholmod), Cdouble,
+            (Ptr{C_Sparse{Tv}}, Cint, Ptr{UInt8}),
+                A.p, norm, common())
+end
 
-        function horzcat{Tv<:VRealTypes}(A::Sparse{Tv,$Ti}, B::Sparse{Tv,$Ti}, values::Bool)
-            s = Sparse(ccall((@cholmod_name("horzcat", $Ti), :libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Ptr{C_Sparse{Tv,$Ti}}, Ptr{C_Sparse{Tv,$Ti}}, Cint, Ptr{UInt8}),
-                        A.p, B.p, values, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
+function horzcat{Tv<:VRealTypes}(A::Sparse{Tv}, B::Sparse{Tv}, values::Bool)
+    s = Sparse(ccall((@cholmod_name("horzcat", SuiteSparse_long), :libcholmod),
+        Ptr{C_Sparse{Tv}},
+            (Ptr{C_Sparse{Tv}}, Ptr{C_Sparse{Tv}}, Cint, Ptr{UInt8}),
+             A.p, B.p, values, common()))
+    finalizer(s, free!)
+    s
+end
 
-        function scale!{Tv<:VRealTypes}(S::Dense{Tv}, scale::Integer, A::Sparse{Tv,$Ti})
-            sS = unsafe_load(S.p)
-            sA = unsafe_load(A.p)
-            sS.ncol == 1 || sS.nrow == 1 || throw(DimensionMismatch("first argument must be a vector"))
-            if scale == SCALAR && sS.nrow != 1
-                throw(DimensionMismatch("scaling argument must have length one"))
-            elseif scale == ROW && sS.nrow*sS.ncol != sA.nrow
-                throw(DimensionMismatch("scaling vector has length $(sS.nrow*sS.ncol), but matrix has $(sA.nrow) rows."))
-            elseif scale == COL && sS.nrow*sS.ncol != sA.ncol
-                throw(DimensionMismatch("scaling vector has length $(sS.nrow*sS.ncol), but matrix has $(sA.ncol) columns"))
-            elseif scale == SYM
-                if sA.nrow != sA.ncol
-                    throw(DimensionMismatch("matrix must be square"))
-                elseif sS.nrow*sS.ncol != sA.nrow
-                    throw(DimensionMismatch("scaling vector has length $(sS.nrow*sS.ncol), but matrix has $(sA.ncol) columns and rows"))
-                end
-            end
+function scale!{Tv<:VRealTypes}(S::Dense{Tv}, scale::Integer, A::Sparse{Tv})
+    sS = unsafe_load(S.p)
+    sA = unsafe_load(A.p)
+    sS.ncol == 1 || sS.nrow == 1 || throw(DimensionMismatch("first argument must be a vector"))
+    if scale == SCALAR && sS.nrow != 1
+        throw(DimensionMismatch("scaling argument must have length one"))
+    elseif scale == ROW && sS.nrow*sS.ncol != sA.nrow
+        throw(DimensionMismatch("scaling vector has length $(sS.nrow*sS.ncol), but matrix has $(sA.nrow) rows."))
+    elseif scale == COL && sS.nrow*sS.ncol != sA.ncol
+        throw(DimensionMismatch("scaling vector has length $(sS.nrow*sS.ncol), but matrix has $(sA.ncol) columns"))
+    elseif scale == SYM
+        if sA.nrow != sA.ncol
+            throw(DimensionMismatch("matrix must be square"))
+        elseif sS.nrow*sS.ncol != sA.nrow
+            throw(DimensionMismatch("scaling vector has length $(sS.nrow*sS.ncol), but matrix has $(sA.ncol) columns and rows"))
+        end
+    end
 
-            sA = unsafe_load(A.p)
-            @isok ccall((@cholmod_name("scale",$Ti),:libcholmod), Cint,
-                    (Ptr{C_Dense{Tv}}, Cint, Ptr{C_Sparse{Tv,$Ti}}, Ptr{UInt8}),
-                        S.p, scale, A.p, common($Ti))
-            A
-        end
+    sA = unsafe_load(A.p)
+    @isok ccall((@cholmod_name("scale",SuiteSparse_long),:libcholmod), Cint,
+            (Ptr{C_Dense{Tv}}, Cint, Ptr{C_Sparse{Tv}}, Ptr{UInt8}),
+                S.p, scale, A.p, common())
+    A
+end
 
-        function sdmult!{Tv<:VTypes}(A::Sparse{Tv,$Ti}, transpose::Bool, α::Number, β::Number, X::Dense{Tv}, Y::Dense{Tv})
-            m, n = size(A)
-            nc = transpose ? m : n
-            nr = transpose ? n : m
-            if nc != size(X, 1)
-                throw(DimensionMismatch("incompatible dimensions, $nc and $(size(X,1))"))
-            end
-            @isok ccall((@cholmod_name("sdmult", $Ti),:libcholmod), Cint,
-                    (Ptr{C_Sparse{Tv,$Ti}}, Cint,
-                     Ref{Complex128}, Ref{Complex128},
-                     Ptr{C_Dense{Tv}}, Ptr{C_Dense{Tv}}, Ptr{UInt8}),
-                        A.p, transpose, α, β, X.p, Y.p, common($Ti))
-            Y
-        end
+function sdmult!{Tv<:VTypes}(A::Sparse{Tv}, transpose::Bool, α::Number, β::Number, X::Dense{Tv}, Y::Dense{Tv})
+    m, n = size(A)
+    nc = transpose ? m : n
+    nr = transpose ? n : m
+    if nc != size(X, 1)
+        throw(DimensionMismatch("incompatible dimensions, $nc and $(size(X,1))"))
+    end
+    @isok ccall((@cholmod_name("sdmult", SuiteSparse_long),:libcholmod), Cint,
+            (Ptr{C_Sparse{Tv}}, Cint,
+             Ref{Complex128}, Ref{Complex128},
+             Ptr{C_Dense{Tv}}, Ptr{C_Dense{Tv}}, Ptr{UInt8}),
+                A.p, transpose, α, β, X.p, Y.p, common())
+    Y
+end
 
-        function vertcat{Tv<:VRealTypes}(A::Sparse{Tv,$Ti}, B::Sparse{Tv,$Ti}, values::Bool)
-            s = Sparse(ccall((@cholmod_name("vertcat", $Ti), :libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Ptr{C_Sparse{Tv,$Ti}}, Ptr{C_Sparse{Tv,$Ti}}, Cint, Ptr{UInt8}),
-                        A.p, B.p, values, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
+function vertcat{Tv<:VRealTypes}(A::Sparse{Tv}, B::Sparse{Tv}, values::Bool)
+    s = Sparse(ccall((@cholmod_name("vertcat", SuiteSparse_long), :libcholmod), Ptr{C_Sparse{Tv}},
+            (Ptr{C_Sparse{Tv}}, Ptr{C_Sparse{Tv}}, Cint, Ptr{UInt8}),
+                A.p, B.p, values, common()))
+    finalizer(s, free!)
+    s
+end
 
-        function symmetry{Tv<:VTypes}(A::Sparse{Tv,$Ti}, option::Integer)
-            xmatched = Array($Ti, 1)
-            pmatched = Array($Ti, 1)
-            nzoffdiag = Array($Ti, 1)
-            nzdiag = Array($Ti, 1)
-            rv = ccall((@cholmod_name("symmetry", $Ti), :libcholmod), Cint,
-                    (Ptr{C_Sparse{Tv,$Ti}}, Cint, Ptr{$Ti}, Ptr{$Ti},
-                        Ptr{$Ti}, Ptr{$Ti}, Ptr{UInt8}),
-                            A.p, option, xmatched, pmatched,
-                                nzoffdiag, nzdiag, common($Ti))
-            rv, xmatched[1], pmatched[1], nzoffdiag[1], nzdiag[1]
-        end
+function symmetry{Tv<:VTypes}(A::Sparse{Tv}, option::Integer)
+    xmatched = Array(SuiteSparse_long, 1)
+    pmatched = Array(SuiteSparse_long, 1)
+    nzoffdiag = Array(SuiteSparse_long, 1)
+    nzdiag = Array(SuiteSparse_long, 1)
+    rv = ccall((@cholmod_name("symmetry", SuiteSparse_long), :libcholmod), Cint,
+            (Ptr{C_Sparse{Tv}}, Cint, Ptr{SuiteSparse_long}, Ptr{SuiteSparse_long},
+                Ptr{SuiteSparse_long}, Ptr{SuiteSparse_long}, Ptr{UInt8}),
+                    A.p, option, xmatched, pmatched,
+                        nzoffdiag, nzdiag, common())
+    rv, xmatched[1], pmatched[1], nzoffdiag[1], nzdiag[1]
+end
 
-        # cholmod_cholesky.h
-        # For analyze, analyze_p, and factorize_p!, the Common argument must be
-        # supplied in order to control if the factorization is LLt or LDLt
-        function analyze{Tv<:VTypes}(A::Sparse{Tv,$Ti}, cmmn::Vector{UInt8})
-            f = Factor(ccall((@cholmod_name("analyze", $Ti),:libcholmod), Ptr{C_Factor{Tv,$Ti}},
-                    (Ptr{C_Sparse{Tv,$Ti}}, Ptr{UInt8}),
-                        A.p, cmmn))
-            finalizer(f, free!)
-            f
-        end
-        function analyze_p{Tv<:VTypes}(A::Sparse{Tv,$Ti}, perm::Vector{$Ti},
-                                       cmmn::Vector{UInt8})
-            length(perm) != size(A,1) && throw(BoundsError())
-            f = Factor(ccall((@cholmod_name("analyze_p", $Ti),:libcholmod), Ptr{C_Factor{Tv,$Ti}},
-                             (Ptr{C_Sparse{Tv,$Ti}}, Ptr{$Ti}, Ptr{$Ti}, Csize_t, Ptr{UInt8}),
-                             A.p, perm, C_NULL, 0, cmmn))
-            finalizer(f, free!)
-            f
-        end
-        function factorize!{Tv<:VTypes}(A::Sparse{Tv,$Ti}, F::Factor{Tv,$Ti}, cmmn::Vector{UInt8})
-            @isok ccall((@cholmod_name("factorize", $Ti),:libcholmod), Cint,
-                    (Ptr{C_Sparse{Tv,$Ti}}, Ptr{C_Factor{Tv,$Ti}}, Ptr{UInt8}),
-                        A.p, F.p, cmmn)
-            F
-        end
-        function factorize_p!{Tv<:VTypes}(A::Sparse{Tv,$Ti}, β::Real, F::Factor{Tv,$Ti}, cmmn::Vector{UInt8})
-            # note that β is passed as a complex number (double beta[2]),
-            # but the CHOLMOD manual says that only beta[0] (real part) is used
-            @isok ccall((@cholmod_name("factorize_p", $Ti),:libcholmod), Cint,
-                    (Ptr{C_Sparse{Tv,$Ti}}, Ref{Complex128}, Ptr{$Ti}, Csize_t,
-                        Ptr{C_Factor{Tv,$Ti}}, Ptr{UInt8}),
-                        A.p, β, C_NULL, 0, F.p, cmmn)
-            F
-        end
+# cholmod_cholesky.h
+# For analyze, analyze_p, and factorize_p!, the Common argument must be
+# supplied in order to control if the factorization is LLt or LDLt
+function analyze{Tv<:VTypes}(A::Sparse{Tv}, cmmn::Vector{UInt8})
+    f = Factor(ccall((@cholmod_name("analyze", SuiteSparse_long),:libcholmod),
+        Ptr{C_Factor{Tv}},
+            (Ptr{C_Sparse{Tv}}, Ptr{UInt8}),
+                A.p, cmmn))
+    finalizer(f, free!)
+    f
+end
+function analyze_p{Tv<:VTypes}(A::Sparse{Tv}, perm::Vector{SuiteSparse_long},
+    cmmn::Vector{UInt8})
+    length(perm) != size(A,1) && throw(BoundsError())
+    f = Factor(ccall((@cholmod_name("analyze_p", SuiteSparse_long),:libcholmod),
+        Ptr{C_Factor{Tv}},
+            (Ptr{C_Sparse{Tv}}, Ptr{SuiteSparse_long}, Ptr{SuiteSparse_long}, Csize_t, Ptr{UInt8}),
+                A.p, perm, C_NULL, 0, cmmn))
+    finalizer(f, free!)
+    f
+end
+function factorize!{Tv<:VTypes}(A::Sparse{Tv}, F::Factor{Tv}, cmmn::Vector{UInt8})
+    @isok ccall((@cholmod_name("factorize", SuiteSparse_long),:libcholmod), Cint,
+        (Ptr{C_Sparse{Tv}}, Ptr{C_Factor{Tv}}, Ptr{UInt8}),
+            A.p, F.p, cmmn)
+    F
+end
+function factorize_p!{Tv<:VTypes}(A::Sparse{Tv}, β::Real, F::Factor{Tv}, cmmn::Vector{UInt8})
+    # note that β is passed as a complex number (double beta[2]),
+    # but the CHOLMOD manual says that only beta[0] (real part) is used
+    @isok ccall((@cholmod_name("factorize_p", SuiteSparse_long),:libcholmod), Cint,
+        (Ptr{C_Sparse{Tv}}, Ref{Complex128}, Ptr{SuiteSparse_long}, Csize_t,
+         Ptr{C_Factor{Tv}}, Ptr{UInt8}),
+            A.p, β, C_NULL, 0, F.p, cmmn)
+    F
+end
 
-        function solve{Tv<:VTypes}(sys::Integer, F::Factor{Tv,$Ti}, B::Dense{Tv})
-            if size(F,1) != size(B,1)
-                throw(DimensionMismatch("LHS and RHS should have the same number of rows. LHS has $(size(F,1)) rows, but RHS has $(size(B,1)) rows."))
-            end
-            d = Dense(ccall((@cholmod_name("solve", $Ti),:libcholmod), Ptr{C_Dense{Tv}},
-                    (Cint, Ptr{C_Factor{Tv,$Ti}}, Ptr{C_Dense{Tv}}, Ptr{UInt8}),
-                        sys, F.p, B.p, common($Ti)))
-            finalizer(d, free!)
-            d
-        end
+function solve{Tv<:VTypes}(sys::Integer, F::Factor{Tv}, B::Dense{Tv})
+    if size(F,1) != size(B,1)
+        throw(DimensionMismatch("LHS and RHS should have the same number of rows. LHS has $(size(F,1)) rows, but RHS has $(size(B,1)) rows."))
+    end
+    d = Dense(ccall((@cholmod_name("solve", SuiteSparse_long),:libcholmod), Ptr{C_Dense{Tv}},
+            (Cint, Ptr{C_Factor{Tv}}, Ptr{C_Dense{Tv}}, Ptr{UInt8}),
+                sys, F.p, B.p, common()))
+    finalizer(d, free!)
+    d
+end
 
-        function spsolve{Tv<:VTypes}(sys::Integer, F::Factor{Tv,$Ti}, B::Sparse{Tv,$Ti})
-            if size(F,1) != size(B,1)
-                throw(DimensionMismatch("LHS and RHS should have the same number of rows. LHS has $(size(F,1)) rows, but RHS has $(size(B,1)) rows."))
-            end
-            s = Sparse(ccall((@cholmod_name("spsolve", $Ti),:libcholmod), Ptr{C_Sparse{Tv,$Ti}},
-                    (Cint, Ptr{C_Factor{Tv,$Ti}}, Ptr{C_Sparse{Tv,$Ti}}, Ptr{UInt8}),
-                        sys, F.p, B.p, common($Ti)))
-            finalizer(s, free!)
-            s
-        end
+function spsolve{Tv<:VTypes}(sys::Integer, F::Factor{Tv}, B::Sparse{Tv})
+    if size(F,1) != size(B,1)
+        throw(DimensionMismatch("LHS and RHS should have the same number of rows. LHS has $(size(F,1)) rows, but RHS has $(size(B,1)) rows."))
+    end
+    s = Sparse(ccall((@cholmod_name("spsolve", SuiteSparse_long),:libcholmod),
+        Ptr{C_Sparse{Tv}},
+            (Cint, Ptr{C_Factor{Tv}}, Ptr{C_Sparse{Tv}}, Ptr{UInt8}),
+                sys, F.p, B.p, common()))
+    finalizer(s, free!)
+    s
+end
 
-        # Autodetects the types
-        function read_sparse(file::Libc.FILE, ::Type{$Ti})
-            ptr = ccall((@cholmod_name("read_sparse", $Ti), :libcholmod), Ptr{C_SparseVoid},
-                (Ptr{Void}, Ptr{UInt8}),
-                    file.ptr, common($Ti))
-            if ptr == C_NULL
-                throw(ArgumentError("sparse matrix construction failed. Check that input file is valid."))
-            end
-            s = Sparse(ptr)
-            finalizer(s, free!)
-            s
-        end
+# Autodetects the types
+function read_sparse(file::Libc.FILE, ::Type{SuiteSparse_long})
+    ptr = ccall((@cholmod_name("read_sparse", SuiteSparse_long), :libcholmod),
+        Ptr{C_SparseVoid},
+            (Ptr{Void}, Ptr{UInt8}),
+                file.ptr, common())
+    if ptr == C_NULL
+        throw(ArgumentError("sparse matrix construction failed. Check that input file is valid."))
+    end
+    s = Sparse(ptr)
+    finalizer(s, free!)
+    s
+end
 
-        function read_sparse(file::IO, T)
-            cfile = Libc.FILE(file)
-            try return read_sparse(cfile, T)
-            finally close(cfile)
-            end
-        end
+function read_sparse(file::IO, T)
+    cfile = Libc.FILE(file)
+    try return read_sparse(cfile, T)
+    finally close(cfile)
     end
 end
 
@@ -740,7 +771,7 @@ end
 Dense(A::Sparse) = sparse_to_dense(A)
 
 # This constructior assumes zero based colptr and rowval
-function Sparse{Tv<:VTypes,Ti<:ITypes}(m::Integer, n::Integer, colptr::Vector{Ti}, rowval::Vector{Ti}, nzval::Vector{Tv}, stype)
+function Sparse{Tv<:VTypes}(m::Integer, n::Integer, colptr::Vector{SuiteSparse_long}, rowval::Vector{SuiteSparse_long}, nzval::Vector{Tv}, stype)
 
     # check if columns are sorted
     iss = true
@@ -751,7 +782,7 @@ function Sparse{Tv<:VTypes,Ti<:ITypes}(m::Integer, n::Integer, colptr::Vector{Ti
         end
     end
 
-    o = allocate_sparse(m, n, length(nzval), iss, true, stype, Tv, Ti)
+    o = allocate_sparse(m, n, length(nzval), iss, true, stype, Tv)
     s = unsafe_load(o.p)
 
     unsafe_copy!(s.p, pointer(colptr), length(colptr))
@@ -763,7 +794,7 @@ function Sparse{Tv<:VTypes,Ti<:ITypes}(m::Integer, n::Integer, colptr::Vector{Ti
     return o
 
 end
-function Sparse{Tv<:VTypes,Ti<:ITypes}(m::Integer, n::Integer, colptr::Vector{Ti}, rowval::Vector{Ti}, nzval::Vector{Tv})
+function Sparse{Tv<:VTypes}(m::Integer, n::Integer, colptr::Vector{SuiteSparse_long}, rowval::Vector{SuiteSparse_long}, nzval::Vector{Tv})
     o = Sparse(m, n, colptr, rowval, nzval, 0)
 
     # check if array is symmetric and change stype if it is
@@ -773,8 +804,8 @@ function Sparse{Tv<:VTypes,Ti<:ITypes}(m::Integer, n::Integer, colptr::Vector{Ti
     o
 end
 
-function Sparse{Tv<:VTypes,Ti<:ITypes}(A::SparseMatrixCSC{Tv,Ti}, stype::Integer)
-    o = allocate_sparse(A.m, A.n, length(A.nzval), true, true, stype, Tv, Ti)
+function Sparse{Tv<:VTypes}(A::SparseMatrixCSC{Tv,SuiteSparse_long}, stype::Integer)
+    o = allocate_sparse(A.m, A.n, length(A.nzval), true, true, stype, Tv)
     s = unsafe_load(o.p)
     for i = 1:length(A.colptr)
         unsafe_store!(s.p, A.colptr[i] - 1, i)
@@ -788,7 +819,7 @@ function Sparse{Tv<:VTypes,Ti<:ITypes}(A::SparseMatrixCSC{Tv,Ti}, stype::Integer
 
     return o
 end
-function Sparse{Tv<:VTypes,Ti<:ITypes}(A::SparseMatrixCSC{Tv,Ti})
+function Sparse{Tv<:VTypes}(A::SparseMatrixCSC{Tv,SuiteSparse_long})
     o = Sparse(A, 0)
     # check if array is symmetric and change stype if it is
     if ishermitian(o)
@@ -797,8 +828,8 @@ function Sparse{Tv<:VTypes,Ti<:ITypes}(A::SparseMatrixCSC{Tv,Ti})
     o
 end
 
-Sparse{Ti<:ITypes}(A::Symmetric{Float64,SparseMatrixCSC{Float64,Ti}}) = Sparse(A.data, A.uplo == 'L' ? -1 : 1)
-Sparse{Tv<:VTypes,Ti<:ITypes}(A::Hermitian{Tv,SparseMatrixCSC{Tv,Ti}}) = Sparse(A.data, A.uplo == 'L' ? -1 : 1)
+Sparse(A::Symmetric{Float64,SparseMatrixCSC{Float64,SuiteSparse_long}}) = Sparse(A.data, A.uplo == 'L' ? -1 : 1)
+Sparse{Tv<:VTypes}(A::Hermitian{Tv,SparseMatrixCSC{Tv,SuiteSparse_long}}) = Sparse(A.data, A.uplo == 'L' ? -1 : 1)
 
 # Useful when reading in files, but not type stable
 function Sparse(p::Ptr{C_SparseVoid})
@@ -811,13 +842,12 @@ function Sparse(p::Ptr{C_SparseVoid})
 
     # Check integer type
     if s.itype == INT
-        Ti = Cint
+        free_sparse!(p)
+        throw(CHOLMODException("the value of itype was $s.itype. Only integer type of $SuiteSparse_long is supported."))
     elseif s.itype == INTLONG
         free_sparse!(p)
         throw(CHOLMODException("the value of itype was $s.itype. This combination of integer types shouldn't happen. Please submit a bug report."))
-    elseif s.itype == LONG
-        Ti = SuiteSparse_long
-    else
+    elseif s.itype != LONG # must be s.itype == LONG
         free_sparse!(p)
         throw(CHOLMODException("illegal value of itype: $s.itype"))
     end
@@ -842,12 +872,11 @@ function Sparse(p::Ptr{C_SparseVoid})
         throw(CHOLMODException("illegal value of xtype: $s.xtype"))
     end
 
-    return Sparse(convert(Ptr{C_Sparse{Tv,Ti}}, p))
+    return Sparse(convert(Ptr{C_Sparse{Tv}}, p))
 
 end
 
-# default is Cint which is probably sufficient when converted from dense matrix
-Sparse(A::Dense) = dense_to_sparse(A, Cint)
+Sparse(A::Dense) = dense_to_sparse(A, SuiteSparse_long)
 Sparse(L::Factor) = factor_to_sparse!(copy(L))
 function Sparse(filename::ByteString)
     open(filename) do f
@@ -879,40 +908,40 @@ function convert{T}(::Type{Vector{T}}, D::Dense{T})
 end
 convert{T}(::Type{Vector}, D::Dense{T}) = convert(Vector{T}, D)
 
-function convert{Tv,Ti}(::Type{SparseMatrixCSC{Tv,Ti}}, A::Sparse{Tv,Ti})
+function convert{Tv}(::Type{SparseMatrixCSC{Tv,SuiteSparse_long}}, A::Sparse{Tv})
     s = unsafe_load(A.p)
     if s.stype != 0
         throw(ArgumentError("matrix has stype != 0. Convert to matrix with stype == 0 before converting to SparseMatrixCSC"))
     end
     return SparseMatrixCSC(s.nrow, s.ncol, increment(pointer_to_array(s.p, (s.ncol + 1,), false)), increment(pointer_to_array(s.i, (s.nzmax,), false)), copy(pointer_to_array(s.x, (s.nzmax,), false)))
 end
-function convert{Ti<:ITypes}(::Type{Symmetric{Float64,SparseMatrixCSC{Float64,Ti}}}, A::Sparse{Float64,Ti})
+function convert(::Type{Symmetric{Float64,SparseMatrixCSC{Float64,SuiteSparse_long}}}, A::Sparse{Float64})
     s = unsafe_load(A.p)
     if !issym(A)
         throw(ArgumentError("matrix is not symmetric"))
     end
     return Symmetric(SparseMatrixCSC(s.nrow, s.ncol, increment(pointer_to_array(s.p, (s.ncol + 1,), false)), increment(pointer_to_array(s.i, (s.nzmax,), false)), copy(pointer_to_array(s.x, (s.nzmax,), false))), s.stype > 0 ? :U : :L)
 end
-function convert{Tv<:VTypes,Ti<:ITypes}(::Type{Hermitian{Tv,SparseMatrixCSC{Tv,Ti}}}, A::Sparse{Tv,Ti})
+function convert{Tv<:VTypes}(::Type{Hermitian{Tv,SparseMatrixCSC{Tv,SuiteSparse_long}}}, A::Sparse{Tv})
     s = unsafe_load(A.p)
     if !ishermitian(A)
         throw(ArgumentError("matrix is not Hermitian"))
     end
     return Hermitian(SparseMatrixCSC(s.nrow, s.ncol, increment(pointer_to_array(s.p, (s.ncol + 1,), false)), increment(pointer_to_array(s.i, (s.nzmax,), false)), copy(pointer_to_array(s.x, (s.nzmax,), false))), s.stype > 0 ? :U : :L)
 end
-function sparse{Ti}(A::Sparse{Float64,Ti}) # Notice! Cannot be type stable because of stype
+function sparse(A::Sparse{Float64}) # Notice! Cannot be type stable because of stype
     s = unsafe_load(A.p)
     if s.stype == 0
-        return convert(SparseMatrixCSC{Float64,Ti}, A)
+        return convert(SparseMatrixCSC{Float64,SuiteSparse_long}, A)
     end
-    return convert(Symmetric{Float64,SparseMatrixCSC{Float64,Ti}}, A)
+    return convert(Symmetric{Float64,SparseMatrixCSC{Float64,SuiteSparse_long}}, A)
 end
-function sparse{Ti}(A::Sparse{Complex{Float64},Ti}) # Notice! Cannot be type stable because of stype
+function sparse(A::Sparse{Complex{Float64}}) # Notice! Cannot be type stable because of stype
     s = unsafe_load(A.p)
     if s.stype == 0
-        return convert(SparseMatrixCSC{Complex{Float64},Ti}, A)
+        return convert(SparseMatrixCSC{Complex{Float64},SuiteSparse_long}, A)
     end
-    return convert(Hermitian{Complex{Float64},SparseMatrixCSC{Complex{Float64},Ti}}, A)
+    return convert(Hermitian{Complex{Float64},SparseMatrixCSC{Complex{Float64},SuiteSparse_long}}, A)
 end
 function sparse(F::Factor)
     s = unsafe_load(F.p)
@@ -938,13 +967,13 @@ end
 
 sparse(D::Dense)    = sparse(Sparse(D))
 
-function sparse{Tv,Ti}(FC::FactorComponent{Tv,Ti,:L})
+function sparse{Tv}(FC::FactorComponent{Tv,:L})
     F = Factor(FC)
     s = unsafe_load(F.p)
     s.is_ll != 0 || throw(CHOLMODException("sparse: supported only for :LD on LDLt factorizations"))
     sparse(Sparse(F))
 end
-sparse{Tv,Ti}(FC::FactorComponent{Tv,Ti,:LD}) = sparse(Sparse(Factor(FC)))
+sparse{Tv}(FC::FactorComponent{Tv,:LD}) = sparse(Sparse(Factor(FC)))
 
 # Calculate the offset into the stype field of the cholmod_sparse_struct and
 # change the value
@@ -1017,15 +1046,15 @@ linearindexing(::Dense) = LinearFast()
 size(FC::FactorComponent, i::Integer) = size(FC.F, i)
 size(FC::FactorComponent) = size(FC.F)
 
-ctranspose{Tv,Ti}(FC::FactorComponent{Tv,Ti,:L}) = FactorComponent{Tv,Ti,:U}(FC.F)
-ctranspose{Tv,Ti}(FC::FactorComponent{Tv,Ti,:U}) = FactorComponent{Tv,Ti,:L}(FC.F)
-ctranspose{Tv,Ti}(FC::FactorComponent{Tv,Ti,:PtL}) = FactorComponent{Tv,Ti,:UP}(FC.F)
-ctranspose{Tv,Ti}(FC::FactorComponent{Tv,Ti,:UP}) = FactorComponent{Tv,Ti,:PtL}(FC.F)
-ctranspose{Tv,Ti}(FC::FactorComponent{Tv,Ti,:D}) = FC
-ctranspose{Tv,Ti}(FC::FactorComponent{Tv,Ti,:LD}) = FactorComponent{Tv,Ti,:DU}(FC.F)
-ctranspose{Tv,Ti}(FC::FactorComponent{Tv,Ti,:DU}) = FactorComponent{Tv,Ti,:LD}(FC.F)
-ctranspose{Tv,Ti}(FC::FactorComponent{Tv,Ti,:PtLD}) = FactorComponent{Tv,Ti,:DUP}(FC.F)
-ctranspose{Tv,Ti}(FC::FactorComponent{Tv,Ti,:DUP}) = FactorComponent{Tv,Ti,:PtLD}(FC.F)
+ctranspose{Tv}(FC::FactorComponent{Tv,:L}) = FactorComponent{Tv,:U}(FC.F)
+ctranspose{Tv}(FC::FactorComponent{Tv,:U}) = FactorComponent{Tv,:L}(FC.F)
+ctranspose{Tv}(FC::FactorComponent{Tv,:PtL}) = FactorComponent{Tv,:UP}(FC.F)
+ctranspose{Tv}(FC::FactorComponent{Tv,:UP}) = FactorComponent{Tv,:PtL}(FC.F)
+ctranspose{Tv}(FC::FactorComponent{Tv,:D}) = FC
+ctranspose{Tv}(FC::FactorComponent{Tv,:LD}) = FactorComponent{Tv,:DU}(FC.F)
+ctranspose{Tv}(FC::FactorComponent{Tv,:DU}) = FactorComponent{Tv,:LD}(FC.F)
+ctranspose{Tv}(FC::FactorComponent{Tv,:PtLD}) = FactorComponent{Tv,:DUP}(FC.F)
+ctranspose{Tv}(FC::FactorComponent{Tv,:DUP}) = FactorComponent{Tv,:PtLD}(FC.F)
 
 function getindex(A::Dense, i::Integer)
     s = unsafe_load(A.p)
@@ -1073,8 +1102,8 @@ end
 (*)(A::Sparse, B::Dense) = sdmult!(A, false, 1., 0., B, zeros(size(A, 1), size(B, 2)))
 (*)(A::Sparse, B::VecOrMat) = (*)(A, Dense(B))
 
-function A_mul_Bc{Tv<:VRealTypes,Ti<:ITypes}(A::Sparse{Tv,Ti}, B::Sparse{Tv,Ti})
-    cm = common(Ti)
+function A_mul_Bc{Tv<:VRealTypes}(A::Sparse{Tv}, B::Sparse{Tv})
+    cm = common()
 
     if !is(A,B)
         aa1 = transpose_(B, 2)
@@ -1088,9 +1117,9 @@ function A_mul_Bc{Tv<:VRealTypes,Ti<:ITypes}(A::Sparse{Tv,Ti}, B::Sparse{Tv,Ti})
     s = unsafe_load(A.p)
     if s.stype != 0
         aa1 = copy(A, 0, 1)
-        return aat(aa1, Ti[0:s.ncol-1;], 1)
+        return aat(aa1, SuiteSparse_long[0:s.ncol-1;], 1)
     else
-        return aat(A, Ti[0:s.ncol-1;], 1)
+        return aat(A, SuiteSparse_long[0:s.ncol-1;], 1)
     end
 end
 
@@ -1109,11 +1138,9 @@ Ac_mul_B(A::Sparse, B::VecOrMat) =  Ac_mul_B(A, Dense(B))
 
 ## Factorization methods
 
-function fact_{Tv<:VTypes,Ti<:ITypes,Ti2<:Integer}(A::Sparse{Tv,Ti}, cm::Array{UInt8};
-                                          shift::Real=0.0,
-                                          perm::AbstractVector{Ti2}=Int[],
-                                          postorder::Bool=true,
-                                          userperm_only::Bool=true)
+function fact_{Tv<:VTypes}(A::Sparse{Tv}, cm::Array{UInt8};
+    shift::Real=0.0, perm::AbstractVector{SuiteSparse_long}=SuiteSparse_long[],
+    postorder::Bool=true, userperm_only::Bool=true)
     sA = unsafe_load(A.p)
     sA.stype == 0 && throw(ArgumentError("sparse matrix is not symmetric/Hermitian"))
 
@@ -1127,7 +1154,7 @@ function fact_{Tv<:VTypes,Ti<:ITypes,Ti2<:Integer}(A::Sparse{Tv,Ti}, cm::Array{U
         if userperm_only # use perm even if it is worse than AMD
             cm[common_nmethods] = reinterpret(UInt8, [one(Cint)])
         end
-        F = analyze_p(A, Ti[p-1 for p in perm], cm)
+        F = analyze_p(A, SuiteSparse_long[p-1 for p in perm], cm)
     end
 
     factorize_p!(A, shift, F, cm)
@@ -1135,7 +1162,7 @@ function fact_{Tv<:VTypes,Ti<:ITypes,Ti2<:Integer}(A::Sparse{Tv,Ti}, cm::Array{U
 end
 
 function cholfact(A::Sparse; kws...)
-    cm = common(indtype(A))
+    cm = common()
 
     # Hack! makes it a llt
     cm[common_final_ll] = reinterpret(UInt8, [one(Cint)])
@@ -1147,7 +1174,7 @@ function cholfact(A::Sparse; kws...)
 end
 
 function ldltfact(A::Sparse; kws...)
-    cm = common(indtype(A))
+    cm = common()
 
     # Hack! makes it a ldlt
     cm[common_final_ll] = reinterpret(UInt8, [zero(Cint)])
@@ -1165,13 +1192,13 @@ end
 for f in (:cholfact, :ldltfact)
     @eval begin
         $f(A::SparseMatrixCSC; kws...) = $f(Sparse(A); kws...)
-        $f{Ti}(A::Symmetric{Float64,SparseMatrixCSC{Float64,Ti}}; kws...) = $f(Sparse(A); kws...)
-        $f{Ti}(A::Hermitian{Complex{Float64},SparseMatrixCSC{Complex{Float64},Ti}}; kws...) = $f(Sparse(A); kws...)
+        $f(A::Symmetric{Float64,SparseMatrixCSC{Float64,SuiteSparse_long}}; kws...) = $f(Sparse(A); kws...)
+        $f(A::Hermitian{Complex{Float64},SparseMatrixCSC{Complex{Float64},SuiteSparse_long}}; kws...) = $f(Sparse(A); kws...)
     end
 end
 
-function update!{Tv<:VTypes,Ti<:ITypes}(F::Factor{Tv,Ti}, A::Sparse{Tv,Ti}; shift::Real=0.0)
-    cm = common(Ti)
+function update!{Tv<:VTypes}(F::Factor{Tv}, A::Sparse{Tv}; shift::Real=0.0)
+    cm = common()
     s = unsafe_load(F.p)
     if s.is_ll!=0
         cm[common_final_ll] = reinterpret(UInt8, [one(Cint)]) # Hack! makes it a llt
@@ -1185,36 +1212,36 @@ update!{T<:VTypes}(F::Factor{T}, A::SparseMatrixCSC{T}; kws...) = update!(F, Spa
 for (T, f) in ((:Dense, :solve), (:Sparse, :spsolve))
     @eval begin
         # Solve Lx = b and L'x=b where A = L*L'
-        function (\){T,Ti}(L::FactorComponent{T,Ti,:L}, B::$T)
+        function (\){T}(L::FactorComponent{T,:L}, B::$T)
             ($f)(CHOLMOD_L, Factor(L), B)
         end
-        function (\){T,Ti}(L::FactorComponent{T,Ti,:U}, B::$T)
+        function (\){T}(L::FactorComponent{T,:U}, B::$T)
             ($f)(CHOLMOD_Lt, Factor(L), B)
         end
         # Solve PLx = b and L'P'x=b where A = P*L*L'*P'
-        function (\){T,Ti}(L::FactorComponent{T,Ti,:PtL}, B::$T)
+        function (\){T}(L::FactorComponent{T,:PtL}, B::$T)
             F = Factor(L)
             ($f)(CHOLMOD_L, F, ($f)(CHOLMOD_P, F, B))  # Confusingly, CHOLMOD_P solves P'x = b
         end
-        function (\){T,Ti}(L::FactorComponent{T,Ti,:UP}, B::$T)
+        function (\){T}(L::FactorComponent{T,:UP}, B::$T)
             F = Factor(L)
             ($f)(CHOLMOD_Pt, F, ($f)(CHOLMOD_Lt, F, B))
         end
         # Solve various equations for A = L*D*L' and A = P*L*D*L'*P'
-        function (\){T,Ti}(L::FactorComponent{T,Ti,:D}, B::$T)
+        function (\){T}(L::FactorComponent{T,:D}, B::$T)
             ($f)(CHOLMOD_D, Factor(L), B)
         end
-        function (\){T,Ti}(L::FactorComponent{T,Ti,:LD}, B::$T)
+        function (\){T}(L::FactorComponent{T,:LD}, B::$T)
             ($f)(CHOLMOD_LD, Factor(L), B)
         end
-        function (\){T,Ti}(L::FactorComponent{T,Ti,:DU}, B::$T)
+        function (\){T}(L::FactorComponent{T,:DU}, B::$T)
             ($f)(CHOLMOD_DLt, Factor(L), B)
         end
-        function (\){T,Ti}(L::FactorComponent{T,Ti,:PtLD}, B::$T)
+        function (\){T}(L::FactorComponent{T,:PtLD}, B::$T)
             F = Factor(L)
             ($f)(CHOLMOD_LD, F, ($f)(CHOLMOD_P, F, B))
         end
-        function (\){T,Ti}(L::FactorComponent{T,Ti,:DUP}, B::$T)
+        function (\){T}(L::FactorComponent{T,:DUP}, B::$T)
             F = Factor(L)
             ($f)(CHOLMOD_Pt, F, ($f)(CHOLMOD_DLt, F, B))
         end
@@ -1275,7 +1302,7 @@ function diag{Tv}(F::Factor{Tv})
     res
 end
 
-function logdet{Tv<:VTypes,Ti<:ITypes}(F::Factor{Tv,Ti})
+function logdet{Tv<:VTypes}(F::Factor{Tv})
     f = unsafe_load(F.p)
     res = zero(Tv)
     for d in diag(F) res += log(abs(d)) end
@@ -1284,7 +1311,7 @@ end
 
 det(L::Factor) = exp(logdet(L))
 
-function isposdef{Tv<:VTypes,Ti}(A::SparseMatrixCSC{Tv,Ti})
+function isposdef{Tv<:VTypes}(A::SparseMatrixCSC{Tv,SuiteSparse_long})
     if !ishermitian(A)
         return false
     end

--- a/base/sparse/spqr.jl
+++ b/base/sparse/spqr.jl
@@ -45,23 +45,23 @@ import Base.SparseMatrix.CHOLMOD: convert, free!
 
 
 
-immutable C_Factorization{Tv<:VTypes,Ti<:ITypes}
+immutable C_Factorization{Tv<:VTypes}
     xtype::Cint
     factors::Ptr{Tv}
 end
 
-type Factorization{Tv<:VTypes,Ti<:ITypes} <: Base.LinAlg.Factorization{Tv}
+type Factorization{Tv<:VTypes} <: Base.LinAlg.Factorization{Tv}
     m::Int
     n::Int
-    p::Ptr{C_Factorization{Tv,Ti}}
-    function Factorization(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv,Ti}})
+    p::Ptr{C_Factorization{Tv}}
+    function Factorization(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}})
         if p == C_NULL
             throw(ArgumentError("factorization failed for unknown reasons. Please submit a bug report."))
         end
         new(m, n, p)
     end
 end
-Factorization{Tv<:VTypes,Ti<:ITypes}(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv,Ti}}) = Factorization{Tv,Ti}(m, n, p)
+Factorization{Tv<:VTypes}(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) = Factorization{Tv}(m, n, p)
 
 size(F::Factorization) = (F.m, F.n)
 function size(F::Factorization, i::Integer)
@@ -76,37 +76,37 @@ function size(F::Factorization, i::Integer)
     return 1
 end
 
-function free!{Tv<:VTypes,Ti<:ITypes}(F::Factorization{Tv,Ti})
+function free!{Tv<:VTypes}(F::Factorization{Tv})
     ccall((:SuiteSparseQR_C_free, :libspqr), Cint,
-        (Ptr{Ptr{C_Factorization{Tv,Ti}}}, Ptr{Void}),
-            &F.p, common(Ti)) == 1
+        (Ptr{Ptr{C_Factorization{Tv}}}, Ptr{Void}),
+            &F.p, common()) == 1
 end
 
-function backslash{Tv<:VTypes,Ti<:ITypes}(ordering::Integer, tol::Real, A::Sparse{Tv,Ti}, B::Dense{Tv})
+function backslash{Tv<:VTypes}(ordering::Integer, tol::Real, A::Sparse{Tv}, B::Dense{Tv})
     m, n  = size(A)
     if m != size(B, 1)
         throw(DimensionMismatch("left hand side and right hand side must have same number of rows"))
     end
     d = Dense(ccall((:SuiteSparseQR_C_backslash, :libspqr), Ptr{C_Dense{Tv}},
-        (Cint, Cdouble, Ptr{C_Sparse{Tv,Ti}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
-            ordering, tol, A.p, B.p, common(Ti)))
+        (Cint, Cdouble, Ptr{C_Sparse{Tv}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
+            ordering, tol, A.p, B.p, common()))
     finalizer(d, free!)
     d
 end
 
-function factorize{Tv<:VTypes,Ti<:ITypes}(ordering::Integer, tol::Real, A::Sparse{Tv,Ti})
+function factorize{Tv<:VTypes}(ordering::Integer, tol::Real, A::Sparse{Tv})
     s = unsafe_load(A.p)
     if s.stype != 0
         throw(ArgumentError("stype must be zero"))
     end
-    f = Factorization(size(A)..., ccall((:SuiteSparseQR_C_factorize, :libspqr), Ptr{C_Factorization{Tv,Ti}},
-        (Cint, Cdouble, Ptr{Sparse{Tv,Ti}}, Ptr{Void}),
-            ordering, tol, A.p, common(Ti)))
+    f = Factorization(size(A)..., ccall((:SuiteSparseQR_C_factorize, :libspqr), Ptr{C_Factorization{Tv}},
+        (Cint, Cdouble, Ptr{Sparse{Tv}}, Ptr{Void}),
+            ordering, tol, A.p, common()))
     finalizer(f, free!)
     f
 end
 
-function solve{Tv<:VTypes,Ti<:ITypes}(system::Integer, QR::Factorization{Tv,Ti}, B::Dense{Tv})
+function solve{Tv<:VTypes}(system::Integer, QR::Factorization{Tv}, B::Dense{Tv})
     m, n = size(QR)
     mB = size(B, 1)
     if (system == RX_EQUALS_B || system == RETX_EQUALS_B) && m != mB
@@ -115,13 +115,13 @@ function solve{Tv<:VTypes,Ti<:ITypes}(system::Integer, QR::Factorization{Tv,Ti},
         throw(DimensionMismatch("number of columns in factorized matrix must equal number of rows in right hand side"))
     end
     d = Dense(ccall((:SuiteSparseQR_C_solve, :libspqr), Ptr{C_Dense{Tv}},
-        (Cint, Ptr{C_Factorization{Tv,Ti}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
-            system, QR.p, B.p, common(Ti)))
+        (Cint, Ptr{C_Factorization{Tv}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
+            system, QR.p, B.p, common()))
     finalizer(d, free!)
     d
 end
 
-function qmult{Tv<:VTypes,Ti<:ITypes}(method::Integer, QR::Factorization{Tv,Ti}, X::Dense{Tv})
+function qmult{Tv<:VTypes}(method::Integer, QR::Factorization{Tv}, X::Dense{Tv})
     mQR, nQR = size(QR)
     mX, nX = size(X)
     if (method == QTX || method == QX) && mQR != mX
@@ -130,8 +130,8 @@ function qmult{Tv<:VTypes,Ti<:ITypes}(method::Integer, QR::Factorization{Tv,Ti},
         throw(DimensionMismatch("Q matrix size $mQR and dense matrix has $nX columns"))
     end
     d = Dense(ccall((:SuiteSparseQR_C_qmult, :libspqr), Ptr{C_Dense{Tv}},
-            (Cint, Ptr{C_Factorization{Tv,Ti}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
-                method, QR.p, X.p, common(Ti)))
+            (Cint, Ptr{C_Factorization{Tv}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
+                method, QR.p, X.p, common()))
     finalizer(d, free!)
     d
 end

--- a/test/sparsedir/cholmod.jl
+++ b/test/sparsedir/cholmod.jl
@@ -37,59 +37,64 @@ using Base.SparseMatrix.CHOLMOD
 ## rcond     9.5e-06
 
 A = CHOLMOD.Sparse(48, 48,
-            Int32[0,1,2,3,6,9,12,15,18,20,25,30,34,36,39,43,47,52,58,62,67,71,77,84,90,93,95,
-                  98,103,106,110,115,119,123,130,136,142,146,150,155,161,167,174,182,189,197,
-                  207,215,224], # zero-based column pointers
-            Int32[0,1,2,1,2,3,0,2,4,0,1,5,0,4,6,1,3,7,2,8,1,3,7,8,9,0,4,6,8,10,5,6,7,11,6,12,
-                  7,11,13,8,10,13,14,9,13,14,15,8,10,12,14,16,7,11,12,13,16,17,0,12,16,18,1,
-                  5,13,15,19,2,4,14,20,3,13,15,19,20,21,2,4,12,16,18,20,22,1,5,17,18,19,23,0,
-                  5,24,1,25,2,3,26,2,3,25,26,27,4,24,28,0,5,24,29,6,11,24,28,30,7,25,27,31,8,
-                  9,26,32,8,9,25,27,31,32,33,10,24,28,30,32,34,6,11,29,30,31,35,12,17,30,36,
-                  13,31,35,37,14,15,32,34,38,14,15,33,37,38,39,16,32,34,36,38,40,12,17,31,35,
-                  36,37,41,12,16,17,18,23,36,40,42,13,14,15,19,37,39,43,13,14,15,20,21,38,43,
-                  44,13,14,15,20,21,37,39,43,44,45,12,16,17,22,36,40,42,46,12,16,17,18,23,41,
-                  42,46,47],
-                 [2.83226851852e6,1.63544753086e6,1.72436728395e6,-2.0e6,-2.08333333333e6,
-                  1.00333333333e9,1.0e6, -2.77777777778e6,1.0675e9,2.08333333333e6,
-                  5.55555555555e6,1.53533333333e9,-3333.33333333,-1.0e6,2.83226851852e6,
-                  -6666.66666667,2.0e6,1.63544753086e6,-1.68e6,1.72436728395e6,-2.0e6,4.0e8,2.0e6,
-                  -2.08333333333e6,1.00333333333e9,1.0e6,2.0e8,-1.0e6,-2.77777777778e6,1.0675e9,
-                  -2.0e6,2.08333333333e6,5.55555555555e6,1.53533333333e9,-2.8e6,2.8360994695e6,
-                  -30864.1975309,-5.55555555555e6,1.76741074446e6,-15432.0987654,2.77777777778e6,
-                  517922.131816,3.89003806848e6,-3.33333333333e6,4.29857058902e6,-2.6349902747e6,
-                  1.97572063531e9,-2.77777777778e6,3.33333333333e8,-2.14928529451e6,
-                  2.77777777778e6,1.52734651547e9,5.55555555555e6,6.66666666667e8,2.35916180402e6,
-                  -5.55555555555e6,-1.09779731332e8,1.56411143711e9,-2.8e6,-3333.33333333,1.0e6,
-                  2.83226851852e6,-30864.1975309,-5.55555555555e6,-6666.66666667,-2.0e6,
-                  1.63544753086e6,-15432.0987654,2.77777777778e6,-1.68e6,1.72436728395e6,
-                  -3.33333333333e6,2.0e6,4.0e8,-2.0e6,-2.08333333333e6,1.00333333333e9,
-                  -2.77777777778e6,3.33333333333e8,-1.0e6,2.0e8,1.0e6,2.77777777778e6,1.0675e9,
-                  5.55555555555e6,6.66666666667e8,-2.0e6,2.08333333333e6,-5.55555555555e6,
-                  1.53533333333e9,-28935.1851852,-2.08333333333e6,60879.6296296,-1.59791666667e6,
-                  3.37291666667e6,-28935.1851852,2.08333333333e6,2.41171296296e6,-2.08333333333e6,
-                  1.0e8,-2.5e6,-416666.666667,1.5e9,-833333.333333,1.25e6,5.01833333333e8,
-                  2.08333333333e6,1.0e8,416666.666667,5.025e8,-28935.1851852,-2.08333333333e6,
-                  -4166.66666667,-1.25e6,3.98587962963e6,-1.59791666667e6,-8333.33333333,2.5e6,
-                  3.41149691358e6,-28935.1851852,2.08333333333e6,-2.355e6,2.43100308642e6,
-                  -2.08333333333e6,1.0e8,-2.5e6,5.0e8,2.5e6,-416666.666667,1.50416666667e9,
-                  -833333.333333,1.25e6,2.5e8,-1.25e6,-3.47222222222e6,1.33516666667e9,
-                  2.08333333333e6,1.0e8,-2.5e6,416666.666667,6.94444444444e6,2.16916666667e9,
-                  -28935.1851852,-2.08333333333e6,-3.925e6,3.98587962963e6,-1.59791666667e6,
-                  -38580.2469136,-6.94444444444e6,3.41149691358e6,-28935.1851852,2.08333333333e6,
-                  -19290.1234568,3.47222222222e6,2.43100308642e6,-2.08333333333e6,1.0e8,
-                  -4.16666666667e6,2.5e6,-416666.666667,1.50416666667e9,-833333.333333,
-                  -3.47222222222e6,4.16666666667e8,-1.25e6,3.47222222222e6,1.33516666667e9,
-                  2.08333333333e6,1.0e8,6.94444444445e6,8.33333333333e8,416666.666667,
-                  -6.94444444445e6,2.16916666667e9,-3830.95098171,1.14928529451e6,-275828.470683,
-                  -28935.1851852,-2.08333333333e6,-4166.66666667,1.25e6,64710.5806113,
-                  -131963.213599,-517922.131816,-2.29857058902e6,-1.59791666667e6,-8333.33333333,
-                  -2.5e6,3.50487988027e6,-517922.131816,-2.16567078453e6,551656.941366,
-                  -28935.1851852,2.08333333333e6,-2.355e6,517922.131816,4.57738374749e6,
-                  2.29857058902e6,-551656.941367,4.8619365099e8,-2.08333333333e6,1.0e8,2.5e6,
-                  5.0e8,-4.79857058902e6,134990.2747,2.47238730198e9,-1.14928529451e6,
-                  2.29724661236e8,-5.57173510779e7,-833333.333333,-1.25e6,2.5e8,2.39928529451e6,
-                  9.61679848804e8,275828.470683,-5.57173510779e7,1.09411960038e7,2.08333333333e6,
-                  1.0e8,-2.5e6,140838.195984,-1.09779731332e8,5.31278103775e8], 1)
+    CHOLMOD.SuiteSparse_long[0,1,2,3,6,9,12,15,18,20,25,30,34,36,39,43,47,52,58,
+    62,67,71,77,84,90,93,95,98,103,106,110,115,119,123,130,136,142,146,150,155,
+    161,167,174,182,189,197,207,215,224], # zero-based column pointers
+    CHOLMOD.SuiteSparse_long[0,1,2,1,2,3,0,2,4,0,1,5,0,4,6,1,3,7,2,8,1,3,7,8,9,
+    0,4,6,8,10,5,6,7,11,6,12,7,11,13,8,10,13,14,9,13,14,15,8,10,12,14,16,7,11,
+    12,13,16,17,0,12,16,18,1,5,13,15,19,2,4,14,20,3,13,15,19,20,21,2,4,12,16,18,
+    20,22,1,5,17,18,19,23,0,5,24,1,25,2,3,26,2,3,25,26,27,4,24,28,0,5,24,29,6,
+    11,24,28,30,7,25,27,31,8,9,26,32,8,9,25,27,31,32,33,10,24,28,30,32,34,6,11,
+    29,30,31,35,12,17,30,36,13,31,35,37,14,15,32,34,38,14,15,33,37,38,39,16,32,
+    34,36,38,40,12,17,31,35,36,37,41,12,16,17,18,23,36,40,42,13,14,15,19,37,39,
+    43,13,14,15,20,21,38,43,44,13,14,15,20,21,37,39,43,44,45,12,16,17,22,36,40,
+    42,46,12,16,17,18,23,41,42,46,47],
+    [2.83226851852e6,1.63544753086e6,1.72436728395e6,-2.0e6,-2.08333333333e6,
+    1.00333333333e9,1.0e6,-2.77777777778e6,1.0675e9,2.08333333333e6,
+    5.55555555555e6,1.53533333333e9,-3333.33333333,-1.0e6,2.83226851852e6,
+    -6666.66666667,2.0e6,1.63544753086e6,-1.68e6,1.72436728395e6,-2.0e6,4.0e8,
+    2.0e6,-2.08333333333e6,1.00333333333e9,1.0e6,2.0e8,-1.0e6,-2.77777777778e6,
+    1.0675e9,-2.0e6,2.08333333333e6,5.55555555555e6,1.53533333333e9,-2.8e6,
+    2.8360994695e6,-30864.1975309,-5.55555555555e6,1.76741074446e6,
+    -15432.0987654,2.77777777778e6,517922.131816,3.89003806848e6,
+    -3.33333333333e6,4.29857058902e6,-2.6349902747e6,1.97572063531e9,
+    -2.77777777778e6,3.33333333333e8,-2.14928529451e6,2.77777777778e6,
+    1.52734651547e9,5.55555555555e6,6.66666666667e8,2.35916180402e6,
+    -5.55555555555e6,-1.09779731332e8,1.56411143711e9,-2.8e6,-3333.33333333,
+    1.0e6,2.83226851852e6,-30864.1975309,-5.55555555555e6,-6666.66666667,
+    -2.0e6,1.63544753086e6,-15432.0987654,2.77777777778e6,-1.68e6,
+    1.72436728395e6,-3.33333333333e6,2.0e6,4.0e8,-2.0e6,-2.08333333333e6,
+    1.00333333333e9,-2.77777777778e6,3.33333333333e8,-1.0e6,2.0e8,1.0e6,
+    2.77777777778e6,1.0675e9,5.55555555555e6,6.66666666667e8,-2.0e6,
+    2.08333333333e6,-5.55555555555e6,1.53533333333e9,-28935.1851852,
+    -2.08333333333e6,60879.6296296,-1.59791666667e6,3.37291666667e6,
+    -28935.1851852,2.08333333333e6,2.41171296296e6,-2.08333333333e6,
+    1.0e8,-2.5e6,-416666.666667,1.5e9,-833333.333333,1.25e6,5.01833333333e8,
+    2.08333333333e6,1.0e8,416666.666667,5.025e8,-28935.1851852,
+    -2.08333333333e6,-4166.66666667,-1.25e6,3.98587962963e6,-1.59791666667e6,
+    -8333.33333333,2.5e6,3.41149691358e6,-28935.1851852,2.08333333333e6,
+    -2.355e6,2.43100308642e6,-2.08333333333e6,1.0e8,-2.5e6,5.0e8,2.5e6,
+    -416666.666667,1.50416666667e9,-833333.333333,1.25e6,2.5e8,-1.25e6,
+    -3.47222222222e6,1.33516666667e9,2.08333333333e6,1.0e8,-2.5e6,
+    416666.666667,6.94444444444e6,2.16916666667e9,-28935.1851852,
+    -2.08333333333e6,-3.925e6,3.98587962963e6,-1.59791666667e6,
+    -38580.2469136,-6.94444444444e6,3.41149691358e6,-28935.1851852,
+    2.08333333333e6,-19290.1234568,3.47222222222e6,2.43100308642e6,
+    -2.08333333333e6,1.0e8,-4.16666666667e6,2.5e6,-416666.666667,
+    1.50416666667e9,-833333.333333,-3.47222222222e6,4.16666666667e8,
+    -1.25e6,3.47222222222e6,1.33516666667e9,2.08333333333e6,1.0e8,
+    6.94444444445e6,8.33333333333e8,416666.666667,-6.94444444445e6,
+    2.16916666667e9,-3830.95098171,1.14928529451e6,-275828.470683,
+    -28935.1851852,-2.08333333333e6,-4166.66666667,1.25e6,64710.5806113,
+    -131963.213599,-517922.131816,-2.29857058902e6,-1.59791666667e6,
+    -8333.33333333,-2.5e6,3.50487988027e6,-517922.131816,-2.16567078453e6,
+    551656.941366,-28935.1851852,2.08333333333e6,-2.355e6,517922.131816,
+    4.57738374749e6,2.29857058902e6,-551656.941367,4.8619365099e8,
+    -2.08333333333e6,1.0e8,2.5e6,5.0e8,-4.79857058902e6,134990.2747,
+    2.47238730198e9,-1.14928529451e6,2.29724661236e8,-5.57173510779e7,
+    -833333.333333,-1.25e6,2.5e8,2.39928529451e6,9.61679848804e8,275828.470683,
+    -5.57173510779e7,1.09411960038e7,2.08333333333e6,1.0e8,-2.5e6,
+    140838.195984,-1.09779731332e8,5.31278103775e8], 1)
 @test_approx_eq CHOLMOD.norm_sparse(A, 0) 3.570948074697437e9
 @test_approx_eq CHOLMOD.norm_sparse(A, 1) 3.570948074697437e9
 @test_throws ArgumentError CHOLMOD.norm_sparse(A, 2)
@@ -113,21 +118,21 @@ x = chma\B
 
 #lp_afiro example
 afiro = CHOLMOD.Sparse(27, 51,
-            Int32[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,23,25,27,29,33,37,
-                  41,45,47,49,51,53,55,57,59,63,65,67,69,71,75,79,83,87,89,91,93,95,97,
-                  99,101,102],
-            Int32[2,3,6,7,8,9,12,13,16,17,18,19,20,21,22,23,24,25,26,0,1,2,23,0,3,0,21,
-                  1,25,4,5,6,24,4,5,7,24,4,5,8,24,4,5,9,24,6,20,7,20,8,20,9,20,3,4,4,22,
-                  5,26,10,11,12,21,10,13,10,23,10,20,11,25,14,15,16,22,14,15,17,22,14,
-                  15,18,22,14,15,19,22,16,20,17,20,18,20,19,20,13,15,15,24,14,26,15],
-                     [1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,
-                      -1.0,-1.06,1.0,0.301,1.0,-1.0,1.0,-1.0,1.0,1.0,-1.0,-1.06,1.0,0.301,-1.0,
-                      -1.06,1.0,0.313,-1.0,-0.96,1.0,0.313,-1.0,-0.86,1.0,0.326,-1.0,2.364,-1.0,
-                      2.386,-1.0,2.408,-1.0,2.429,1.4,1.0,1.0,-1.0,1.0,1.0,-1.0,-0.43,1.0,0.109,
-                      1.0,-1.0,1.0,-1.0,1.0,-1.0,1.0,1.0,-0.43,1.0,1.0,0.109,-0.43,1.0,1.0,0.108,
-                      -0.39,1.0,1.0,0.108,-0.37,1.0,1.0,0.107,-1.0,2.191,-1.0,2.219,-1.0,2.249,
-                      -1.0,2.279,1.4,-1.0,1.0,-1.0,1.0,1.0,1.0], 0)
-afiro2 = CHOLMOD.aat(afiro, Int32[0:50;], Int32(1))
+    CHOLMOD.SuiteSparse_long[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,
+    23,25,27,29,33,37,41,45,47,49,51,53,55,57,59,63,65,67,69,71,75,79,83,87,89,
+    91,93,95,97,99,101,102],
+    CHOLMOD.SuiteSparse_long[2,3,6,7,8,9,12,13,16,17,18,19,20,21,22,23,24,25,26,
+    0,1,2,23,0,3,0,21,1,25,4,5,6,24,4,5,7,24,4,5,8,24,4,5,9,24,6,20,7,20,8,20,9,
+    20,3,4,4,22,5,26,10,11,12,21,10,13,10,23,10,20,11,25,14,15,16,22,14,15,17,
+    22,14,15,18,22,14,15,19,22,16,20,17,20,18,20,19,20,13,15,15,24,14,26,15],
+    [1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,
+    1.0,-1.0,-1.06,1.0,0.301,1.0,-1.0,1.0,-1.0,1.0,1.0,-1.0,-1.06,1.0,0.301,
+    -1.0,-1.06,1.0,0.313,-1.0,-0.96,1.0,0.313,-1.0,-0.86,1.0,0.326,-1.0,2.364,
+    -1.0,2.386,-1.0,2.408,-1.0,2.429,1.4,1.0,1.0,-1.0,1.0,1.0,-1.0,-0.43,1.0,
+    0.109,1.0,-1.0,1.0,-1.0,1.0,-1.0,1.0,1.0,-0.43,1.0,1.0,0.109,-0.43,1.0,1.0,
+    0.108,-0.39,1.0,1.0,0.108,-0.37,1.0,1.0,0.107,-1.0,2.191,-1.0,2.219,-1.0,
+    2.249,-1.0,2.279,1.4,-1.0,1.0,-1.0,1.0,1.0,1.0], 0)
+afiro2 = CHOLMOD.aat(afiro, CHOLMOD.SuiteSparse_long[0:50;], CHOLMOD.SuiteSparse_long(1))
 CHOLMOD.change_stype!(afiro2, -1)
 chmaf = cholfact(afiro2)
 y = afiro'*ones(size(afiro,1))
@@ -185,10 +190,6 @@ ACSC = sprandn(10, 10, 0.3) + I
 @test ishermitian(Sparse(Hermitian(complex(ACSC), :L)))
 @test ishermitian(Sparse(Hermitian(complex(ACSC), :U)))
 
-# test Sparse constructor for c_Sparse{Tv,Ti} input( and Sparse*Sparse)
-B = CHOLMOD.Sparse(SparseMatrixCSC{Float64,Int32}(sprandn(48, 48, 0.1))) # A has Int32 indices
-@test_approx_eq A*B sparse(A)*sparse(B)
-
 # test Sparse constructor for c_SparseVoid (and read_sparse)
 let testfile = joinpath(tempdir(), "tmp.mtx")
     try
@@ -217,14 +218,14 @@ let testfile = joinpath(tempdir(), "tmp.mtx")
 end
 
 # test that Sparse(Ptr) constructor throws the right places
-@test_throws ArgumentError CHOLMOD.Sparse(convert(Ptr{CHOLMOD.C_Sparse{Float64,CHOLMOD.SuiteSparse_long}}, C_NULL))
+@test_throws ArgumentError CHOLMOD.Sparse(convert(Ptr{CHOLMOD.C_Sparse{Float64}}, C_NULL))
 @test_throws ArgumentError CHOLMOD.Sparse(convert(Ptr{CHOLMOD.C_SparseVoid}, C_NULL))
 
 ## The struct pointer must be constructed by the library constructor and then modified afterwards to checks that the method throws
 ### illegal dtype (for now but should be supported at some point)
 p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(CHOLMOD.SuiteSparse_long))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 puint = convert(Ptr{Uint32}, p)
 unsafe_store!(puint, CHOLMOD.SINGLE, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) + 4)
 @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
@@ -232,7 +233,7 @@ unsafe_store!(puint, CHOLMOD.SINGLE, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Pt
 ### illegal dtype
 p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(CHOLMOD.SuiteSparse_long))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 puint = convert(Ptr{Uint32}, p)
 unsafe_store!(puint, 5, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) + 4)
 @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
@@ -240,7 +241,7 @@ unsafe_store!(puint, 5, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) 
 ### illegal xtype
 p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(CHOLMOD.SuiteSparse_long))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 puint = convert(Ptr{Uint32}, p)
 unsafe_store!(puint, 3, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) + 3)
 @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
@@ -248,7 +249,7 @@ unsafe_store!(puint, 3, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) 
 ### illegal itype
 p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(CHOLMOD.SuiteSparse_long))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 puint = convert(Ptr{Uint32}, p)
 unsafe_store!(puint, CHOLMOD.INTLONG, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) + 2)
 @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
@@ -256,18 +257,10 @@ unsafe_store!(puint, CHOLMOD.INTLONG, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(P
 ### illegal itype
 p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(CHOLMOD.SuiteSparse_long))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 puint = convert(Ptr{Uint32}, p)
 unsafe_store!(puint,  5, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) + 2)
 @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
-
-# test that Sparse(Ptr) works for SuiteSparse_long (on 64 bit systems)
-if CHOLMOD.SuiteSparse_long == Int64
-    p = ccall((:cholmod_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
-        (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-        1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(Int32))
-    @test isa(CHOLMOD.Sparse(p), CHOLMOD.Sparse{Float64,Int32})
-end
 
 # Test Dense wrappers (only Float64 supported a present)
 
@@ -311,9 +304,9 @@ end
 
 # Test Sparse and Factor
 ## test free_sparse!
-p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_Sparse{Float64,Cint}},
+p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_Sparse{Float64}},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(Int))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 @test CHOLMOD.free_sparse!(p)
 
 for elty in (Float64, Complex{Float64})
@@ -376,7 +369,7 @@ for elty in (Float64, Complex{Float64})
     tmp = IOBuffer()
     show(tmp, F)
     @test tmp.size > 0
-    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty, CHOLMOD.SuiteSparse_long})
+    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty})
     @test_approx_eq F\CHOLMOD.Sparse(sparse(ones(elty, 5))) A1pd\ones(5)
     @test_throws DimensionMismatch F\CHOLMOD.Dense(ones(elty, 4))
     @test_throws DimensionMismatch F\CHOLMOD.Sparse(sparse(ones(elty, 4)))
@@ -420,15 +413,15 @@ for elty in (Float64, Complex{Float64})
     @test_throws ArgumentError size(F, 0)
 
     F = cholfact(A1pdSparse, shift=2)
-    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty, CHOLMOD.SuiteSparse_long})
+    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty})
     @test_approx_eq CHOLMOD.Sparse(CHOLMOD.update!(copy(F), A1pd, shift=2.0)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
 
     F = ldltfact(A1pd)
-    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty, CHOLMOD.SuiteSparse_long})
+    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty})
     @test_approx_eq CHOLMOD.Sparse(CHOLMOD.update!(copy(F), A1pd)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
 
     F = ldltfact(A1pdSparse, shift=2)
-    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty, CHOLMOD.SuiteSparse_long})
+    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty})
     @test_approx_eq CHOLMOD.Sparse(CHOLMOD.update!(copy(F), A1pd, shift=2.0)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
 
     @test isa(CHOLMOD.factor_to_sparse!(F), CHOLMOD.Sparse)

--- a/test/sparsedir/spqr.jl
+++ b/test/sparsedir/spqr.jl
@@ -29,7 +29,7 @@ for eltyA in (Float64, Complex{Float64})
         if eltyA == eltyB # promotions not defined for unexported methods
             @test qrfact(sparse(eye(eltyA, 5)))\ones(eltyA, 5) == ones(5)
             @test_throws ArgumentError SPQR.factorize(SPQR.ORDERING_DEFAULT, SPQR.DEFAULT_TOL, CHOLMOD.Sparse(sparse(eye(eltyA, 5))))
-            @test_throws ArgumentError SPQR.Factorization(1, 1, convert(Ptr{SPQR.C_Factorization{eltyA, CHOLMOD.SuiteSparse_long}}, C_NULL))
+            @test_throws ArgumentError SPQR.Factorization(1, 1, convert(Ptr{SPQR.C_Factorization{eltyA}}, C_NULL))
             F = qrfact(A)
             @test size(F) == (m,n)
             @test size(F, 1) == m


### PR DESCRIPTION
This avoids the memory leak. In consequence, introduce global `cholmod_common` array and restrict all
methods to `SuiteSparse_long` and remove the integer type parameter in CHOLMOD and SPQR types.

I don't think it is allowed to mix 32 and 64 bit integers in the same CHOLMOD session and since we only can have one CHOLMOD session we'll have to decide on a size on startup. Right now I've chosen `SuiteSparse_long`.

There is a second commit that uses gc tracked allocation functions in SuiteSparse. This makes the gc aware of the memory consumption of the objects allocated by the libraries in SuiteSparse. I couldn't find a `calloc` version of the gc tracked allocators and I don't know if this will be a problem. It appears to work fine.
