### PR TITLE
expanded package development docs

### DIFF
--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -570,11 +570,38 @@ going to have to do a *force push*:
   indicates that this should replace the ``fixbar`` branch found at
   ``myfork``.
 
-
 Creating a new Package
 ----------------------
 
-Guidelines for Naming a Package
+REQUIRE speaks for itself
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You should have a ``REQUIRE`` file in your package repository, with a bare minimum directive of what Julia
+version you expect your users to be running for the package to work. Putting a floor on what Julia
+version your package supports is done by simply adding ``julia 0.x`` in this file. While this line is
+partly informational, it also has the consequence of whether ``Pkg.update()`` will update code found
+in ``.julia`` version directories. It will not update code found in version directories beneath the
+floor of what's specified in your ``REQUIRE``.
+
+As the development version ``0.y`` matures, you may find yourself using it more frequently, and wanting your
+package to support it. Be warned, the development branch of Julia is the land of breakage, and you can expect
+things to break. When you go about fixing whatever broke your package in the development ``0.y`` branch, you
+will likely find that you just broke your package on the stable version.
+
+There is a mechanism found in the `Compat <https://github.com/JuliaLang/Compat.jl>`_ package that will enable
+you to support both the stable version and breaking changes found in the development version. Should you decide
+to use this solution, you will need to add ``Compat`` to your ``REQUIRE`` file. In this case, you will still
+have ``julia 0.x`` in your ``REQUIRE``. The ``x`` is the floor version of what your package supports.
+
+It is not recommended that you abandon support for the current version ``0.x`` but if you choose to do so, you
+can add ``julia 0.y-`` to your ``REQUIRE``. The ``-`` at the end of the version number means you support
+pre-release versions of that specific version from the very first commit. Just remember to change the
+``julia 0.y-`` to ``julia 0.y`` in your ``REQUIRE`` file once ``0.y`` is officially released. If you don't
+edit the dash cruft you are suggesting that you support both the development and stable versions of the same
+version number! That would be madness.  See the `Requirements Specification <#man-package-requirements>`_
+for the full format of ``REQUIRE``.
+
+Guidelines for naming a package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Package names should be sensible to most Julia users, *even to those who are
@@ -624,8 +651,9 @@ not domain experts*.
 Generating the package
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Suppose you want to create a new Julia package called ``FooBar``.
-To get started, do :func:`Pkg.generate(pkg,license) <Pkg.generate>` where ``pkg`` is the new package name and ``license`` is the name of a license that the package generator knows about::
+Suppose you want to create a new Julia package called ``FooBar``.  To get started, do
+:func:`Pkg.generate(pkg,license) <Pkg.generate>` where ``pkg`` is the new package name and ``license`` is the
+name of a license that the package generator knows about::
 
     julia> Pkg.generate("FooBar","MIT")
     INFO: Initializing FooBar repo: /Users/stefan/.julia/v0.4/FooBar
@@ -637,7 +665,8 @@ To get started, do :func:`Pkg.generate(pkg,license) <Pkg.generate>` where ``pkg`
     INFO: Generating .travis.yml
     INFO: Committing FooBar generated files
 
-This creates the directory ``~/.julia/v0.4/FooBar``, initializes it as a git repository, generates a bunch of files that all packages should have, and commits them to the repository::
+This creates the directory ``~/.julia/v0.4/FooBar``, initializes it as a git repository, generates a bunch of files
+that all packages should have, and commits them to the repository::
 
     $ cd ~/.julia/v0.4/FooBar && git show --stat
 
@@ -661,21 +690,23 @@ This creates the directory ``~/.julia/v0.4/FooBar``, initializes it as a git rep
      test/runtests.jl |  5 +++++
      5 files changed, 51 insertions(+)
 
-At the moment, the package manager knows about the MIT "Expat" License, indicated by ``"MIT"``, the Simplified BSD License, indicated by ``"BSD"``, and version 2.0 of the Apache Software License, indicated by ``"ASL"``.
-If you want to use a different license, you can ask us to add it to the package generator, or just pick one of these three and then modify the ``~/.julia/v0.4/PACKAGE/LICENSE.md`` file after it has been generated.
+At the moment, the package manager knows about the MIT "Expat" License, indicated by ``"MIT"``, the Simplified BSD License,
+indicated by ``"BSD"``, and version 2.0 of the Apache Software License, indicated by ``"ASL"``.  If you want to use a
+different license, you can ask us to add it to the package generator, or just pick one of these three and then modify the
+``~/.julia/v0.4/PACKAGE/LICENSE.md`` file after it has been generated.
 
-If you created a GitHub account and configured git to know about it, :func:`Pkg.generate` will set an appropriate origin URL for you.
-It will also automatically generate a ``.travis.yml`` file for using the `Travis <https://travis-ci.org>`_ automated testing service.
-You will have to enable testing on the Travis website for your package repository, but once you've done that, it will already have working tests.
-Of course, all the default testing does is verify that ``using FooBar`` in Julia works.
+If you created a GitHub account and configured git to know about it, :func:`Pkg.generate` will set an appropriate origin URL
+for you.  It will also automatically generate a ``.travis.yml`` file for using the `Travis <https://travis-ci.org>`_ automated
+testing service.  You will have to enable testing on the Travis website for your package repository, but once you've done that,
+it will already have working tests.  Of course, all the default testing does is verify that ``using FooBar`` in Julia works.
 
 Making Your Package Available
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once you've made some commits and you're happy with how ``FooBar`` is working, you may want to get some other people to try it out.
-First you'll need to create the remote repository and push your code to it;
-we don't yet automatically do this for you, but we will in the future and it's not too hard to figure out [3]_.
-Once you've done this, letting people try out your code is as simple as sending them the URL of the published repo – in this case::
+Once you've made some commits and you're happy with how ``FooBar`` is working, you may want to get some other people to try
+it out.  First you'll need to create the remote repository and push your code to it; we don't yet automatically do this for you,
+but we will in the future and it's not too hard to figure out [3]_.  Once you've done this, letting people try out your code is
+as simple as sending them the URL of the published repo – in this case::
 
     git://github.com/StefanKarpinski/FooBar.jl.git
 
@@ -687,10 +718,11 @@ People you send this URL to can use :func:`Pkg.clone` to install the package and
 
 .. [3] Installing and using GitHub's `"hub" tool <https://github.com/github/hub>`_ is highly recommended. It allows you to do things like run ``hub create`` in the package repo and have it automatically created via GitHub's API.
 
-Publishing Your Package
-~~~~~~~~~~~~~~~~~~~~~~~
+Tagging and Publishing Your Package
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once you've decided that ``FooBar`` is ready to be registered as an official package, you can add it to your local copy of ``METADATA`` using :func:`Pkg.register`::
+Once you've decided that ``FooBar`` is ready to be registered as an official package, you can add it to your local copy
+of ``METADATA`` using :func:`Pkg.register`::
 
     julia> Pkg.register("FooBar")
     INFO: Registering FooBar at git://github.com/StefanKarpinski/FooBar.jl.git
@@ -714,10 +746,9 @@ This creates a commit in the ``~/.julia/v0.4/METADATA`` repo::
     @@ -0,0 +1 @@
     +git://github.com/StefanKarpinski/FooBar.jl.git
 
-This commit is only locally visible, however.  In order to make it visible to
-the world, you need to merge your local ``METADATA`` upstream into the official
-repo.  The :func:`Pkg.publish` command will fork the ``METADATA`` repository on
-GitHub, push your changes to your fork, and open a pull request::
+This commit is only locally visible, however.  To make it visible to the Julia community, you need to merge your
+local ``METADATA`` upstream into the official repo.  The :func:`Pkg.publish` command will fork the ``METADATA`` repository
+on GitHub, push your changes to your fork, and open a pull request::
 
     julia> Pkg.publish()
     INFO: Validating METADATA
@@ -745,13 +776,59 @@ GitHub, push your changes to your fork, and open a pull request::
     <https://help.github.com/articles/creating-a-pull-request>`_.
     See: :ref:`man-manual-publish` below.
 
-Once the package URL for ``FooBar`` is registered in the official ``METADATA`` repo, people know where to clone the package from, but there still aren't any registered versions available.
-This means that :func:`Pkg.add("FooBar") <Pkg.add>` won't work yet since it only installs official versions.
-:func:`Pkg.clone("FooBar") <Pkg.clone>` without having to specify a URL for it.
-Moreover, when they run :func:`Pkg.update`, they will get the latest version of ``FooBar`` that you've pushed to the repo.
-This is a good way to have people test out your packages as you work on them, before they're ready for an official release.
+Once the package URL for ``FooBar`` is registered in the official ``METADATA`` repo, people know where
+to clone the package from, but there still aren't any registered versions available. You can tag and
+register it with the :func:`Pkg.tag` command::
 
-.. _man-manual-publish:
+    julia> Pkg.tag("FooBar")
+    INFO: Tagging FooBar v0.0.1
+    INFO: Committing METADATA for FooBar
+
+This tags ``v0.0.1`` in the ``FooBar`` repo::
+
+    $ cd ~/.julia/v0.4/FooBar && git tag
+    v0.0.1
+
+It also creates a new version entry in your local ``METADATA`` repo for ``FooBar``::
+
+    $ cd ~/.julia/v0.4/FooBar && git show
+    commit de77ee4dc0689b12c5e8b574aef7f70e8b311b0e
+    Author: Stefan Karpinski <stefan@karpinski.org>
+    Date:   Wed Oct 16 23:06:18 2013 -0400
+
+        Tag FooBar v0.0.1
+
+    diff --git a/FooBar/versions/0.0.1/sha1 b/FooBar/versions/0.0.1/sha1
+    new file mode 100644
+    index 0000000..c1cb1c1
+    --- /dev/null
+    +++ b/FooBar/versions/0.0.1/sha1
+    @@ -0,0 +1 @@
+    +84b8e266dae6de30ab9703150b3bf771ec7b6285
+
+The :func:`Pkg.tag` command takes an optional second argument that is either an explicit version number object
+like ``v"0.0.1"`` or one of the symbols ``:patch``, ``:minor`` or ``:major``.  These increment the patch, minor
+or major version number of your package intelligently.
+
+Adding a tagged version of your package will expedite the official registration into METADATA.jl by collaborators. It is
+strongly recommended that you complete this process, regardless if your package is completely ready for an official release.
+
+As a general rule, packages should be tagged ``0.0.1`` first. Since Julia itself hasn't achieved ``1.0`` status, it's best to
+be conservative in your package's tagged versions.
+
+As with :func:`Pkg.register`, these changes to ``METADATA`` aren't available to anyone else until they've been included upstream.
+Again, use the :func:`Pkg.publish` command, which first makes sure that individual package repos have been tagged, pushes them
+if they haven't already been, and then opens a pull request to ``METADATA``::
+
+    julia> Pkg.publish()
+    INFO: Validating METADATA
+    INFO: Pushing FooBar permanent tags: v0.0.1
+    INFO: Submitting METADATA changes
+    INFO: Forking JuliaLang/METADATA.jl to StefanKarpinski
+    INFO: Pushing changes as branch pull-request/3ef4f5c4
+    INFO: To create a pull-request open:
+
+      https://github.com/StefanKarpinski/METADATA.jl/compare/pull-request/3ef4f5c4
 
 Publishing METADATA manually
 ============================
@@ -782,60 +859,6 @@ your github username)::
 4. If all of that works, then go back to the GitHub page for your
 fork, and click the "pull request" link.
 
-
-Tagging Package Versions
-------------------------
-
-Once you are ready to make an official version your package---or release a new version of an established package---you can tag and register it with the :func:`Pkg.tag` command::
-
-    julia> Pkg.tag("FooBar")
-    INFO: Tagging FooBar v0.0.1
-    INFO: Committing METADATA for FooBar
-
-This tags ``v0.0.1`` in the ``FooBar`` repo::
-
-    $ cd ~/.julia/v0.4/FooBar && git tag
-    v0.0.1
-
-It also creates a new version entry in your local ``METADATA`` repo for ``FooBar``::
-
-    $ cd ~/.julia/v0.4/FooBar && git show
-    commit de77ee4dc0689b12c5e8b574aef7f70e8b311b0e
-    Author: Stefan Karpinski <stefan@karpinski.org>
-    Date:   Wed Oct 16 23:06:18 2013 -0400
-
-        Tag FooBar v0.0.1
-
-    diff --git a/FooBar/versions/0.0.1/sha1 b/FooBar/versions/0.0.1/sha1
-    new file mode 100644
-    index 0000000..c1cb1c1
-    --- /dev/null
-    +++ b/FooBar/versions/0.0.1/sha1
-    @@ -0,0 +1 @@
-    +84b8e266dae6de30ab9703150b3bf771ec7b6285
-
-If there is a ``REQUIRE`` file in your package repo, it will be copied into the appropriate spot in ``METADATA`` when you tag a version.
-Package developers should make sure that the ``REQUIRE`` file in their package correctly reflects the requirements of their package, which will automatically flow into the official metadata if you're using :func:`Pkg.tag`.
-See the `Requirements Specification <#man-package-requirements>`_ for the full format of ``REQUIRE``.
-
-The :func:`Pkg.tag` command takes an optional second argument that is either an explicit version number object like ``v"0.0.1"`` or one of the symbols ``:patch``, ``:minor`` or ``:major``.
-These increment the patch, minor or major version number of your package intelligently.
-
-As with :func:`Pkg.register`, these changes to ``METADATA`` aren't
-available to anyone else until they've been included upstream.  Again,
-use the :func:`Pkg.publish` command, which first makes sure that
-individual package repos have been tagged, pushes them if they haven't
-already been, and then opens a pull request to ``METADATA``::
-
-    julia> Pkg.publish()
-    INFO: Validating METADATA
-    INFO: Pushing FooBar permanent tags: v0.0.1
-    INFO: Submitting METADATA changes
-    INFO: Forking JuliaLang/METADATA.jl to StefanKarpinski
-    INFO: Pushing changes as branch pull-request/3ef4f5c4
-    INFO: To create a pull-request open:
-
-      https://github.com/StefanKarpinski/METADATA.jl/compare/pull-request/3ef4f5c4
 
 Fixing Package Requirements
 ---------------------------

--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -593,13 +593,18 @@ you to support both the stable version and breaking changes found in the develop
 to use this solution, you will need to add ``Compat`` to your ``REQUIRE`` file. In this case, you will still
 have ``julia 0.x`` in your ``REQUIRE``. The ``x`` is the floor version of what your package supports.
 
-It is not recommended that you abandon support for the current version ``0.x`` but if you choose to do so, you
-can add ``julia 0.y-`` to your ``REQUIRE``. The ``-`` at the end of the version number means you support
-pre-release versions of that specific version from the very first commit. Just remember to change the
-``julia 0.y-`` to ``julia 0.y`` in your ``REQUIRE`` file once ``0.y`` is officially released. If you don't
-edit the dash cruft you are suggesting that you support both the development and stable versions of the same
-version number! That would be madness.  See the `Requirements Specification <#man-package-requirements>`_
-for the full format of ``REQUIRE``.
+You might also have no interest in supporting the development version of Julia. Just as you can add a floor
+to the version you expect your users to be on, you can set an upper bound. In this case, you would put
+``julia 0.x 0.y-`` in your ``REQUIRE`` file.  The ``-`` at the end of the version number means pre-release
+versions of that specific version from the very first commit. By setting it as the ceiling, you mean the code
+supports everything up to but not including the ceiling version.
+
+Another scenario is that you are writing the bulk of the code for your package with Julia ``0.y`` and do
+not want to support the current stable version of Julia. If you choose to do this, simply add ``julia 0.y-``
+to your ``REQUIRE``. Just remember to change the ``julia 0.y-`` to ``julia 0.y`` in your ``REQUIRE`` file once
+``0.y`` is officially released. If you don't edit the dash cruft you are suggesting that you support both the
+development and stable versions of the same version number! That would be madness.  See the
+`Requirements Specification <#man-package-requirements>`_ for the full format of ``REQUIRE``.
 
 Guidelines for naming a package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- makes mention earlier on the importance of a `REQUIRE` file and the preference of `v0.3` over `v0.3-`.
- combines tagging and publishing to emphasize importance of tagging.
- some more package naming guidelines for creative names.

To keep track of editorial input, here is a list:
- [x] remove _Creative names are cool_ section (or maybe reword it?) or not
- [ ] ~~enforce 92 char limit per line~~
