### PR TITLE
Fix #11659, problems with tab characters not counted correctly

### DIFF
--- a/test/repl.jl
+++ b/test/repl.jl
@@ -174,6 +174,32 @@ function AddCustomMode(repl)
     foobar_mode, search_prompt
 end
 
+# Note: since the \t character matters for the REPL file history,
+# it is important not to have the """ code reindent this line,
+# possibly converting \t to spaces.
+fakehistory = """
+# time: 2014-06-30 17:32:49 EDT
+# mode: julia
+\tshell
+# time: 2014-06-30 17:32:59 EDT
+# mode: shell
+\tll
+# time: 2014-06-30 17:32:49 EDT
+# mode: julia
+\t1 + 1
+# time: 2014-06-30 17:35:39 EDT
+# mode: foobar
+\tbarfoo
+# time: 2014-06-30 18:44:29 EDT
+# mode: shell
+\tls
+# time: 2014-06-30 19:44:29 EDT
+# mode: foobar
+\tls
+# time: 2014-06-30 20:44:29 EDT
+# mode: julia
+\t2 + 2"""
+
 # Test various history related issues
 begin
     stdin_write, stdout_read, stdout_read, repl = fake_repl()
@@ -191,29 +217,6 @@ begin
     hp = REPL.REPLHistoryProvider(Dict{Symbol,Any}(:julia => repl_mode,
                                                    :shell => shell_mode,
                                                    :help  => help_mode))
-    fakehistory =
-    """
-    # time: 2014-06-30 17:32:49 EDT
-    # mode: julia
-    \tshell
-    # time: 2014-06-30 17:32:59 EDT
-    # mode: shell
-    \tll
-    # time: 2014-06-30 17:32:49 EDT
-    # mode: julia
-    \t1 + 1
-    # time: 2014-06-30 17:35:39 EDT
-    # mode: foobar
-    \tbarfoo
-    # time: 2014-06-30 18:44:29 EDT
-    # mode: shell
-    \tls
-    # time: 2014-06-30 19:44:29 EDT
-    # mode: foobar
-    \tls
-    # time: 2014-06-30 20:44:29 EDT
-    # mode: julia
-    \t2 + 2"""
 
     REPL.hist_from_file(hp, IOBuffer(fakehistory))
     REPL.history_reset_state(hp)

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -234,3 +234,19 @@ print_joined(myio, "", "", 1)
 @test_throws ArgumentError print_unescaped(IOBuffer(), string('\\',"xZ"))
 @test_throws ArgumentError print_unescaped(IOBuffer(), string('\\',"777"))
 
+# 11659
+# The indentation code was not correctly counting tab stops
+@test Base.indentation("      \t") == (8, true)
+@test Base.indentation("  \tfoob") == (8, false)
+@test Base.indentation(" \t \t")   == (16, true)
+
+@test Base.unindent("\tfoo",0) == "\tfoo"
+@test Base.unindent("\tfoo",4) == "    foo"
+@test Base.unindent("    \tfoo",4) == "    foo"
+@test Base.unindent("\t\n    \tfoo",4) == "    \n    foo"
+@test Base.unindent("\tfoo\tbar",4) == "    foo     bar"
+@test Base.unindent("\n\tfoo",4) == "\n    foo"
+@test Base.unindent("\n    \tfoo",4) == "\n    foo"
+@test Base.unindent("\n\t\n    \tfoo",4) == "\n    \n    foo"
+@test Base.unindent("\n\tfoo\tbar",4) == "\n    foo     bar"
+


### PR DESCRIPTION
This fixes issues with tabs not being counted correctly (they were counted as a fixed with of 8 spaces,
instead of moving over to the next tab stop), in the `Base.indentation` and `Base.unindent` functions,
which are used to copy/paste text in `REPL.jl` and `LineEdit.jl`.
This also allows code to set the tab width (`Base.tab_indentation_width`).
This also adds unit tests so that the functions should be completely covered.
