### PR TITLE
Expanded error messages and added tests to LAPACK

### DIFF
--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -1977,11 +1977,11 @@ end
 
 ## (PT) positive-definite, symmetric, tri-diagonal matrices
 ## Direct solvers for general tridiagonal and symmetric positive-definite tridiagonal
-for (ptsv, pttrf, pttrs, elty, relty) in
-    ((:dptsv_,:dpttrf_,:dpttrs_,:Float64,:Float64),
-     (:sptsv_,:spttrf_,:spttrs_,:Float32,:Float32),
-     (:zptsv_,:zpttrf_,:zpttrs_,:Complex128,:Float64),
-     (:cptsv_,:cpttrf_,:cpttrs_,:Complex64,:Float32))
+for (ptsv, pttrf, elty, relty) in
+    ((:dptsv_,:dpttrf_,:Float64,:Float64),
+     (:sptsv_,:spttrf_,:Float32,:Float32),
+     (:zptsv_,:zpttrf_,:Complex128,:Float64),
+     (:cptsv_,:cpttrf_,:Complex64,:Float32))
     @eval begin
         #       SUBROUTINE DPTSV( N, NRHS, D, E, B, LDB, INFO )
         #       .. Scalar Arguments ..

--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -1,7 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 using Base.Test
-using Base.LAPACK.bdsqr!
 
 let # syevr
     srand(123)
@@ -38,14 +37,14 @@ let # xbdsqr
     for elty in (Float32, Float64)
         d, e = convert(Vector{elty}, randn(n)), convert(Vector{elty}, randn(n - 1))
         U, Vt, C = eye(elty, n), eye(elty, n), eye(elty, n)
-        s, _ = bdsqr!('U', copy(d), copy(e), Vt, U, C)
+        s, _ = LAPACK.bdsqr!('U', copy(d), copy(e), Vt, U, C)
         @test_approx_eq full(Bidiagonal(d, e, true)) U*Diagonal(s)*Vt
 
-        @test_throws ArgumentError bdsqr!('A', d, e, Vt, U, C)
-        @test_throws DimensionMismatch bdsqr!('U', d, [e; 1], Vt, U, C)
-        @test_throws DimensionMismatch bdsqr!('U', d, e, Vt[1:end - 1, :], U, C)
-        @test_throws DimensionMismatch bdsqr!('U', d, e, Vt, U[:,1:end - 1], C)
-        @test_throws DimensionMismatch bdsqr!('U', d, e, Vt, U, C[1:end - 1, :])
+        @test_throws ArgumentError LAPACK.bdsqr!('A', d, e, Vt, U, C)
+        @test_throws DimensionMismatch LAPACK.bdsqr!('U', d, [e; 1], Vt, U, C)
+        @test_throws DimensionMismatch LAPACK.bdsqr!('U', d, e, Vt[1:end - 1, :], U, C)
+        @test_throws DimensionMismatch LAPACK.bdsqr!('U', d, e, Vt, U[:,1:end - 1], C)
+        @test_throws DimensionMismatch LAPACK.bdsqr!('U', d, e, Vt, U, C[1:end - 1, :])
     end
 end
 


### PR DESCRIPTION
Many of the LAPACK error messages would have been hidden under coverage runs and/or were not very informative. I've expanded them with more information if thrown and rewritten them to be more coverage-friendly. I added tests for a few methods: `posv`, `ptsv`, `pttrf`, `pttrs`, `trtri` and `sytri`. There was an extra `pttrs` keyword floating around in a definition which I removed as well.
