### PR TITLE
test: add basic dlload tests

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -119,7 +119,7 @@ static uv_lib_t *jl_load_dynamic_library_(const char *modname, unsigned flags, i
             uv_dlclose(handle);
     }
 /*
-    this branch permutes all base paths in DL_LOAD_PATH with all extensions
+    this branch permutes all base paths in DL_LOAD_PATH with all DL extensions
     note: skip when !jl_base_module to avoid UndefVarError(:DL_LOAD_PATH)
 */
     else if (jl_base_module != NULL) {
@@ -154,7 +154,7 @@ static uv_lib_t *jl_load_dynamic_library_(const char *modname, unsigned flags, i
     }
 
 /*
-    now fall back and look in default library paths, for all extensions
+    now fall back and use default dlopen (system library paths) vs. all DL extensions
 */
     for(i=0; i < N_EXTENSIONS; i++) {
         ext = extensions[i];

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -30,7 +30,7 @@ function choosetests(choices = [])
         "replutil", "sets", "test", "goto", "llvmcall", "grisu",
         "nullable", "meta", "profile", "libgit2", "docs", "markdown",
         "base64", "parser", "serialize", "functors", "char", "misc",
-        "enums", "cmdlineargs", "i18n"
+        "enums", "cmdlineargs", "i18n", "dlload"
     ]
 
     if Base.USE_GPL_LIBS

--- a/test/dlload.jl
+++ b/test/dlload.jl
@@ -1,0 +1,47 @@
+import Base.Libdl: dlopen, dlclose, dlext
+
+macro good(arg)
+    return quote
+        hdl = $(arg)
+        @test hdl != Ptr{Void}(0)
+        dlclose(hdl)
+    end
+end
+
+# test failures
+#non-existent path
+@test_throws ErrorException dlopen("/long/and/winding/road/to/nowhere.$dlext")
+@test_throws ErrorException dlopen("./fakedl.$dlext")
+@test_throws ErrorException dlopen(abspath("./fakedl.$dlext"))
+
+# test search behavior
+# case 1: libjulia handle
+@good dlopen("")
+
+# case 2: relative and absolute paths
+@good dlopen("./libccalltest.$dlext")
+@good dlopen("./libccalltest")
+@good dlopen(abspath("./libccalltest.$dlext"))
+@good dlopen(abspath("./libccalltest"))
+
+# case 3: unqualified names present in DL_LOAD_PATH
+
+push!(Libdl.DL_LOAD_PATH, "$(pwd())")
+@good dlopen("libccalltest.$dlext")
+@good dlopen("libccalltest")
+
+# variant: /path/tmpdir/libccalltest (extension-free) findable in DL_LOAD_PATH
+#          before the (usable) ./libccalltest
+# set up fake paths
+tmpdir = mktempdir()
+write(open("$tmpdir/libccalltest", "w"), "foo")
+
+# path with dlopen-able file first
+push!(Libdl.DL_LOAD_PATH, "./", tmpdir)
+@good dlopen("libccalltest")
+empty!(Libdl.DL_LOAD_PATH)
+# path with un-dlopen-able file first
+# TODO: this order should also work
+push!(Libdl.DL_LOAD_PATH, tmpdir, "./")
+#@good dlopen("libccalltest")
+empty!(Libdl.DL_LOAD_PATH)


### PR DESCRIPTION
Add some tests for the current `dlopen`/`jl_load_dynamic_library` behaviors as a baseline (ref https://github.com/JuliaLang/julia/pull/11488#issuecomment-108020747). Obviously dl loading is heavily tested by the whole system, but the intent here is to be explicit about the search help we provide on top of the system `dlopen`.

The final test is slightly convoluted and intentionally commented out right now as it [currently fails](https://github.com/JuliaLang/julia/pull/11488#issuecomment-108020444).
