### PR TITLE
Silence ptr->int conversion warning in dump.c

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -1458,8 +1458,8 @@ void jl_save_system_image_to_stream(ios_t *f)
 
     // record reinitialization functions
     for (i = 0; i < reinit_list.len; i += 2) {
-        write_int32(f, (int)reinit_list.items[i]);
-        write_int32(f, (int)reinit_list.items[i+1]);
+        write_int32(f, (int)((uintptr_t) reinit_list.items[i]));
+        write_int32(f, (int)((uintptr_t) reinit_list.items[i+1]));
     }
     write_int32(f, -1);
 


### PR DESCRIPTION
I'm not entirely confident that this _isn't_ warning us about a potential problem that needs a different fix, but FWIW this suppresses these longstanding warnings:

```
dump.c: In function ‘jl_save_system_image_to_stream’:
dump.c:1461:24: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
         write_int32(f, (int)reinit_list.items[i]);
                        ^
dump.c:1462:24: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
         write_int32(f, (int)reinit_list.items[i+1]);
                        ^
```

on my system. CC @vtjnash.
