### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/flisp/flisp.c
+++ b/src/flisp/flisp.c
@@ -2248,7 +2248,7 @@ value_t fl_map1(value_t *args, u_int32_t nargs)
     if (!iscons(args[1])) return NIL;
     value_t v;
     uint32_t first, last, argSP = args-Stack;
-    assert(argSP >= 0 && argSP < N_STACK);
+    assert(args >= Stack && argSP < N_STACK);
     if (nargs == 2) {
         if (SP+4 > N_STACK) grow_stack();
         PUSH(Stack[argSP]);

--- a/test/ccalltest.c
+++ b/test/ccalltest.c
@@ -31,7 +31,7 @@ testUcharX(unsigned char x) {
 
 #define xstr(s) str(s)
 #define str(s) #s
-volatile int (*fptr)(unsigned char x);
+int (*volatile fptr)(unsigned char x);
 volatile int a;
 volatile int b;
 
@@ -348,7 +348,7 @@ int main() {
     fprintf(stderr,"all of the following should be 1 except xs[259] = 0\n");
     a = 3;
     b = 259;
-    fptr = (volatile int (*)(unsigned char x))&testUcharX;
+    fptr = (int (*)(unsigned char x))&testUcharX;
     if ((((size_t)fptr)&((size_t)1)) == 1) fptr = NULL;
     fprintf(stderr,"compiled with: '%s'\nxs[3] = %d\nxs[259] = %d\ntestUcharX(3) = %d\ntestUcharX(%d) = %d\nfptr(3) = %d\nfptr(259) = %d\n",
            xstr(CC), xs[a], xs[b], testUcharX(a), b, testUcharX((unsigned char)b), fptr(a), fptr(b));


### PR DESCRIPTION
Fix two compiler warnings.
1. In `ccalltest`, the `volatile` variable pointing to a function that returns integer is incorrectly declare as a variable pointing to a function that returns `volatile` integer.
   The compiler gives a warning and I'm 90% sure I've got it right but I'm not a expert on these `const`/`volatile` modifiers and please tell me if I got it wrong.
2. A underflow check in flisp is no-op. It can probably be removed since the second check should cover it but it's probably better to make it explicit in the source code.

@JeffBezanson maybe the second one should be cherry-picked back to femtolisp if it wasn't fixed there already?
