### PR TITLE
Fix exported names from gc.c to have jl_gc_ prefix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -409,6 +409,21 @@ Deprecated or removed
 
   * `start_timer` and `stop_timer` are replaced by `Timer` and `close`.
 
+  * The following internal julia C functions have been renamed, in order to prevent
+    potential naming conflicts with C libraries: ([#11741])
+
+    * `gc_wb*` -> `jl_gc_wb*`
+
+    * `gc_queue_root` -> `jl_gc_queue_root`
+
+    * `allocobj` -> `jl_gc_allocobj`
+
+    * `alloc_[0-3]w` -> `jl_gc_alloc_*w`
+
+    * `diff_gc_total_bytes` -> `jl_gc_diff_total_bytes`
+
+    * `sync_gc_total_bytes` -> `jl_gc_sync_total_bytes`
+
 Julia v0.3.0 Release Notes
 ==========================
 
@@ -1462,3 +1477,4 @@ Too numerous to mention.
 [#11347]: https://github.com/JuliaLang/julia/issues/11347
 [#11379]: https://github.com/JuliaLang/julia/issues/11379
 [#11432]: https://github.com/JuliaLang/julia/issues/11432
+[#11741]: https://github.com/JuliaLang/julia/issues/11741

--- a/doc/devdocs/object.rst
+++ b/doc/devdocs/object.rst
@@ -72,7 +72,7 @@ The mutability property of a value can be queried for with::
 
 If the object being stored is a :c:type:`jl_value_t`, the Julia garbage collector must be notified also::
 
-    void gc_wb(jl_value_t *parent, jl_value_t *ptr);
+    void jl_gc_wb(jl_value_t *parent, jl_value_t *ptr);
 
 However, the :ref:`man-embedding` section of the manual is also required reading at this point,
 
@@ -163,7 +163,7 @@ Internal to Julia, storage is typically allocated by :c:func:`newstruct` (or :fu
 And at the lowest level, memory is getting allocated by a call to the garbage collector (in ``gc.c``),
 then tagged with its type::
 
-    jl_value_t *allocobj(size_t nbytes);
+    jl_value_t *jl_gc_allocobj(size_t nbytes);
     void jl_set_typeof(jl_value_t *v, jl_datatype_t *type);
 
 .. sidebar:: :ref:`man-singleton-types`

--- a/doc/manual/embedding.rst
+++ b/doc/manual/embedding.rst
@@ -194,11 +194,12 @@ Manipulating the Garbage Collector
 
 There are some functions to control the GC. In normal use cases, these should not be necessary.
 
-========================= ==============================================================================
-``void jl_gc_collect()``   Force a GC run
-``void jl_gc_enable(0)``   Disable the GC
-``void jl_gc_enable(1)``   Enable the GC
-========================= ==============================================================================
+======================= =====================================================
+``jl_gc_collect()``      Force a GC run
+``jl_gc_enable(0)``      Disable the GC, return previous state as int
+``jl_gc_enable(1)``      Enable the GC,  return previous state as int
+``jl_gc_is_enabled()``   Return current state as int
+======================= =====================================================
 
 Working with Arrays
 ========================

--- a/doc/manual/embedding.rst
+++ b/doc/manual/embedding.rst
@@ -172,11 +172,11 @@ Several Julia values can be pushed at once using the ``JL_GC_PUSH2`` , ``JL_GC_P
     // Do something with args (e.g. call jl_... functions)
     JL_GC_POP();
 
-The garbage collector also operates under the assumption that it is aware of every old-generation object pointing to a young-generation one. Any time a pointer is updated breaking that assumption, it must be signaled to the collector with the ``gc_wb`` (write barrier) function like so::
+The garbage collector also operates under the assumption that it is aware of every old-generation object pointing to a young-generation one. Any time a pointer is updated breaking that assumption, it must be signaled to the collector with the ``jl_gc_wb`` (write barrier) function like so::
 
     jl_value_t *parent = some_old_value, *child = some_young_value;
     ((some_specific_type*)parent)->field = child;
-    gc_wb(parent, child);
+    jl_gc_wb(parent, child);
 
 It is in general impossible to predict which values will be old at runtime, so the write barrier must be inserted after all explicit stores. One notable exception is if the ``parent`` object was just allocated and garbage collection was not run since then. Remember that most ``jl_...`` functions can sometimes invoke garbage collection.
 
@@ -186,7 +186,7 @@ The write barrier is also necessary for arrays of pointers when updating their d
     void **data = (void**)jl_array_data(some_array);
     jl_value_t *some_value = ...;
     data[0] = some_value;
-    gc_wb(some_array, some_value);
+    jl_gc_wb(some_array, some_value);
 
 
 Manipulating the Garbage Collector
@@ -196,8 +196,8 @@ There are some functions to control the GC. In normal use cases, these should no
 
 ========================= ==============================================================================
 ``void jl_gc_collect()``   Force a GC run
-``void jl_gc_disable()``   Disable the GC
-``void jl_gc_enable()``    Enable the GC
+``void jl_gc_enable(0)``   Disable the GC
+``void jl_gc_enable(1)``   Enable the GC
 ========================= ==============================================================================
 
 Working with Arrays

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -257,7 +257,7 @@ void jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
     size_t offs = jl_field_offset(st,i);
     if (jl_field_isptr(st,i)) {
         *(jl_value_t**)((char*)v + offs) = rhs;
-        if (rhs != NULL) gc_wb(v, rhs);
+        if (rhs != NULL) jl_gc_wb(v, rhs);
     }
     else {
         jl_assign_bits((char*)v + offs, rhs);
@@ -315,7 +315,7 @@ DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type)
 DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t fptr, jl_value_t *env,
                                         jl_lambda_info_t *linfo)
 {
-    jl_function_t *f = (jl_function_t*)alloc_3w(); assert(NWORDS(sizeof(jl_function_t))==3);
+    jl_function_t *f = (jl_function_t*)jl_gc_alloc_3w(); assert(NWORDS(sizeof(jl_function_t))==3);
     jl_set_typeof(f, jl_function_type);
     f->fptr = (fptr!=NULL ? fptr : linfo->fptr);
     f->env = env;
@@ -445,7 +445,7 @@ jl_sym_t *jl_symbol(const char *str)
     if (*pnode == NULL) {
         *pnode = mk_symbol(str);
         if (parent != NULL)
-            gc_wb(parent, *pnode);
+            jl_gc_wb(parent, *pnode);
     }
     return *pnode;
 }
@@ -594,11 +594,11 @@ jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
         tn = t->name;
     // init before possibly calling jl_new_typename
     t->super = super;
-    if (super != NULL) gc_wb(t, t->super);
+    if (super != NULL) jl_gc_wb(t, t->super);
     t->parameters = parameters;
-    gc_wb(t, t->parameters);
+    jl_gc_wb(t, t->parameters);
     t->types = ftypes;
-    if (ftypes != NULL) gc_wb(t, t->types);
+    if (ftypes != NULL) jl_gc_wb(t, t->types);
     t->abstract = abstract;
     t->mutabl = mutabl;
     t->pointerfree = 0;
@@ -616,14 +616,14 @@ jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
         else
             tn = jl_new_typename((jl_sym_t*)name);
         t->name = tn;
-        gc_wb(t, t->name);
+        jl_gc_wb(t, t->name);
     }
     t->name->names = fnames;
-    gc_wb(t->name, t->name->names);
+    jl_gc_wb(t->name, t->name->names);
 
     if (t->name->primary == NULL) {
         t->name->primary = (jl_value_t*)t;
-        gc_wb(t->name, t);
+        jl_gc_wb(t->name, t);
     }
 
     if (abstract || jl_svec_len(parameters) > 0) {
@@ -668,7 +668,7 @@ jl_value_t *jl_box##nb(jl_datatype_t *t, int##nb##_t x)        \
 {                                                              \
     assert(jl_isbits(t));                                      \
     assert(jl_datatype_size(t) == sizeof(x));                  \
-    jl_value_t *v = (jl_value_t*)alloc_##nw##w();              \
+    jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w();              \
     jl_set_typeof(v, t);                                       \
     *(int##nb##_t*)jl_data_ptr(v) = x;                         \
     return v;                                                  \
@@ -706,7 +706,7 @@ UNBOX_FUNC(gensym, ssize_t)
 #define BOX_FUNC(typ,c_type,pfx,nw)               \
 jl_value_t *pfx##_##typ(c_type x)                 \
 {                                                 \
-    jl_value_t *v = (jl_value_t*)alloc_##nw##w(); \
+    jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w(); \
     jl_set_typeof(v, jl_##typ##_type);            \
     *(c_type*)jl_data_ptr(v) = x;                 \
     return v;                                     \
@@ -728,7 +728,7 @@ jl_value_t *jl_box_##typ(c_type x)                      \
     c_type idx = x+NBOX_C/2;                            \
     if ((u##c_type)idx < (u##c_type)NBOX_C)             \
         return boxed_##typ##_cache[idx];                \
-    jl_value_t *v = (jl_value_t*)alloc_##nw##w();       \
+    jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w();       \
     jl_set_typeof(v, jl_##typ##_type);                  \
     *(c_type*)jl_data_ptr(v) = x;                       \
     return v;                                           \
@@ -739,7 +739,7 @@ jl_value_t *jl_box_##typ(c_type x)                 \
 {                                                  \
     if (x < NBOX_C)                                \
         return boxed_##typ##_cache[x];             \
-    jl_value_t *v = (jl_value_t*)alloc_##nw##w();  \
+    jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w();  \
     jl_set_typeof(v, jl_##typ##_type);             \
     *(c_type*)jl_data_ptr(v) = x;                  \
     return v;                                      \
@@ -833,7 +833,7 @@ jl_expr_t *jl_exprn(jl_sym_t *head, size_t n)
 {
     jl_array_t *ar = n==0 ? (jl_array_t*)jl_an_empty_cell : jl_alloc_cell_1d(n);
     JL_GC_PUSH1(&ar);
-    jl_expr_t *ex = (jl_expr_t*)alloc_3w(); assert(NWORDS(sizeof(jl_expr_t))==3);
+    jl_expr_t *ex = (jl_expr_t*)jl_gc_alloc_3w(); assert(NWORDS(sizeof(jl_expr_t))==3);
     jl_set_typeof(ex, jl_expr_type);
     ex->head = head;
     ex->args = ar;
@@ -850,7 +850,7 @@ JL_CALLABLE(jl_f_new_expr)
     JL_GC_PUSH1(&ar);
     for(size_t i=0; i < nargs-1; i++)
         jl_cellset(ar, i, args[i+1]);
-    jl_expr_t *ex = (jl_expr_t*)alloc_3w(); assert(NWORDS(sizeof(jl_expr_t))==3);
+    jl_expr_t *ex = (jl_expr_t*)jl_gc_alloc_3w(); assert(NWORDS(sizeof(jl_expr_t))==3);
     jl_set_typeof(ex, jl_expr_type);
     ex->head = (jl_sym_t*)args[0];
     ex->args = ar;

--- a/src/ast.c
+++ b/src/ast.c
@@ -770,7 +770,7 @@ static jl_value_t *copy_ast(jl_value_t *expr, jl_svec_t *sp, int do_sp)
         // of a top-level thunk that gets type inferred.
         li->def = li;
         li->ast = jl_prepare_ast(li, li->sparams);
-        gc_wb(li, li->ast);
+        jl_gc_wb(li, li->ast);
         JL_GC_POP();
         return (jl_value_t*)li;
     }
@@ -821,7 +821,7 @@ DLLEXPORT jl_value_t *jl_copy_ast(jl_value_t *expr)
         ne = jl_exprn(e->head, l);
         if (l == 0) {
             ne->args = jl_alloc_cell_1d(0);
-            gc_wb(ne, ne->args);
+            jl_gc_wb(ne, ne->args);
         }
         else {
             for(i=0; i < l; i++) {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -938,7 +938,7 @@ void jl_trampoline_compile_function(jl_function_t *f, int always_infer, jl_tuple
         if (!jl_in_inference) {
             if (!jl_is_expr(f->linfo->ast)) {
                 f->linfo->ast = jl_uncompress_ast(f->linfo, f->linfo->ast);
-                gc_wb(f->linfo, f->linfo->ast);
+                jl_gc_wb(f->linfo, f->linfo->ast);
             }
             if (always_infer || jl_eval_with_compiler_p(jl_lam_body((jl_expr_t*)f->linfo->ast),1,f->linfo->module)) {
                 jl_type_infer(f->linfo, sig, f->linfo);
@@ -952,7 +952,7 @@ void jl_trampoline_compile_function(jl_function_t *f, int always_infer, jl_tuple
     jl_generate_fptr(f);
     if (jl_boot_file_loaded && jl_is_expr(f->linfo->ast)) {
         f->linfo->ast = jl_compress_ast(f->linfo, f->linfo->ast);
-        gc_wb(f->linfo, f->linfo->ast);
+        jl_gc_wb(f->linfo, f->linfo->ast);
     }
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -355,9 +355,9 @@ static std::vector<Type *> three_pvalue_llvmt;
 
 static std::map<jl_fptr_t, Function*> builtin_func_map;
 
-extern "C" DLLEXPORT void gc_wb_slow(jl_value_t* parent, jl_value_t* ptr)
+extern "C" DLLEXPORT void jl_gc_wb_slow(jl_value_t* parent, jl_value_t* ptr)
 {
-    gc_wb(parent, ptr);
+    jl_gc_wb(parent, ptr);
 }
 
 // --- code generation ---
@@ -1229,7 +1229,7 @@ static logdata_t mallocData;
 static void mallocVisitLine(std::string filename, int line)
 {
     if (filename == "" || filename == "none" || filename == "no file") {
-        sync_gc_total_bytes();
+        jl_gc_sync_total_bytes();
         return;
     }
     logdata_t::iterator it = mallocData.find(filename);
@@ -1273,7 +1273,7 @@ extern "C" DLLEXPORT void jl_clear_malloc_data(void)
             }
         }
     }
-    sync_gc_total_bytes();
+    jl_gc_sync_total_bytes();
 }
 
 extern "C" void jl_write_malloc_log(void)
@@ -1749,7 +1749,7 @@ static void jl_add_linfo_root(jl_lambda_info_t *li, jl_value_t *val)
     li = li->def;
     if (li->roots == NULL) {
         li->roots = jl_alloc_cell_1d(1);
-        gc_wb(li, li->roots);
+        jl_gc_wb(li, li->roots);
         jl_cellset(li->roots, 0, val);
     }
     else {
@@ -4966,9 +4966,9 @@ extern "C" void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig)
 
 extern "C" DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v)
 {
-    jl_value_t *box = (jl_value_t*)alloc_1w();
+    jl_value_t *box = (jl_value_t*)jl_gc_alloc_1w();
     jl_set_typeof(box, jl_box_any_type);
-    // if (v) gc_wb(box, v); // write block not needed: box was just allocated
+    // if (v) jl_gc_wb(box, v); // write block not needed: box was just allocated
     box->fieldptr[0] = v;
     return box;
 }
@@ -5341,16 +5341,16 @@ static void init_julia_llvm_env(Module *m)
 #ifdef JL_GC_MARKSWEEP
     queuerootfun = Function::Create(FunctionType::get(T_void, args_1ptr, false),
                                     Function::ExternalLinkage,
-                                    "gc_queue_root", m);
-    add_named_global(queuerootfun, (void*)&gc_queue_root);
+                                    "jl_gc_queue_root", m);
+    add_named_global(queuerootfun, (void*)&jl_gc_queue_root);
 
     std::vector<Type *> wbargs(0);
     wbargs.push_back(jl_pvalue_llvmt);
     wbargs.push_back(jl_pvalue_llvmt);
     wbfunc = Function::Create(FunctionType::get(T_void, wbargs, false),
                               Function::ExternalLinkage,
-                              "gc_wb_slow", m);
-    add_named_global(wbfunc, (void*)&gc_wb_slow);
+                              "jl_gc_wb_slow", m);
+    add_named_global(wbfunc, (void*)&jl_gc_wb_slow);
 #endif
 
     std::vector<Type *> exp_args(0);
@@ -5489,27 +5489,27 @@ static void init_julia_llvm_env(Module *m)
     jlallocobj_func =
         Function::Create(FunctionType::get(jl_pvalue_llvmt, aoargs, false),
                          Function::ExternalLinkage,
-                         "allocobj", m);
-    add_named_global(jlallocobj_func, (void*)&allocobj);
+                         "jl_gc_allocobj", m);
+    add_named_global(jlallocobj_func, (void*)&jl_gc_allocobj);
 
     std::vector<Type*> empty_args(0);
     jlalloc1w_func =
         Function::Create(FunctionType::get(jl_pvalue_llvmt, empty_args, false),
                          Function::ExternalLinkage,
-                         "alloc_1w", m);
-    add_named_global(jlalloc1w_func, (void*)&alloc_1w);
+                         "jl_gc_alloc_1w", m);
+    add_named_global(jlalloc1w_func, (void*)&jl_gc_alloc_1w);
 
     jlalloc2w_func =
         Function::Create(FunctionType::get(jl_pvalue_llvmt, empty_args, false),
                          Function::ExternalLinkage,
-                         "alloc_2w", m);
-    add_named_global(jlalloc2w_func, (void*)&alloc_2w);
+                         "jl_gc_alloc_2w", m);
+    add_named_global(jlalloc2w_func, (void*)&jl_gc_alloc_2w);
 
     jlalloc3w_func =
         Function::Create(FunctionType::get(jl_pvalue_llvmt, empty_args, false),
                          Function::ExternalLinkage,
-                         "alloc_3w", m);
-    add_named_global(jlalloc3w_func, (void*)&alloc_3w);
+                         "jl_gc_alloc_3w", m);
+    add_named_global(jlalloc3w_func, (void*)&jl_gc_alloc_3w);
 
     std::vector<Type*> atargs(0);
     atargs.push_back(T_size);
@@ -5550,8 +5550,8 @@ static void init_julia_llvm_env(Module *m)
     diff_gc_total_bytes_func =
         Function::Create(FunctionType::get(T_int64, false),
                          Function::ExternalLinkage,
-                         "diff_gc_total_bytes", m);
-    add_named_global(diff_gc_total_bytes_func, (void*)*diff_gc_total_bytes);
+                         "jl_gc_diff_total_bytes", m);
+    add_named_global(diff_gc_total_bytes_func, (void*)*jl_gc_diff_total_bytes);
 
     std::vector<Type *> execpoint_args(0);
     execpoint_args.push_back(T_pint8);

--- a/src/gc.c
+++ b/src/gc.c
@@ -785,21 +785,21 @@ static inline int maybe_collect(void)
 
 // preserved values
 
-int jl_gc_n_preserved_values(void)
+DLLEXPORT int jl_gc_n_preserved_values(void)
 {
     FOR_CURRENT_HEAP
         return preserved_values.len;
     END
 }
 
-void jl_gc_preserve(jl_value_t *v)
+DLLEXPORT void jl_gc_preserve(jl_value_t *v)
 {
     FOR_CURRENT_HEAP
         arraylist_push(&preserved_values, (void*)v);
     END
 }
 
-void jl_gc_unpreserve(void)
+DLLEXPORT void jl_gc_unpreserve(void)
 {
     FOR_CURRENT_HEAP
         (void)arraylist_pop(&preserved_values);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -152,7 +152,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
             jl_lambda_info_t *li = (jl_lambda_info_t*)e;
             if (jl_boot_file_loaded && li->ast && jl_is_expr(li->ast)) {
                 li->ast = jl_compress_ast(li, li->ast);
-                gc_wb(li, li->ast);
+                jl_gc_wb(li, li->ast);
             }
             return (jl_value_t*)jl_new_closure(NULL, (jl_value_t*)jl_emptysvec, li);
         }
@@ -192,7 +192,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
                     JL_GC_PUSHARGS(ar, na*2);
                     for(int i=0; i < na; i++) {
                         ar[i*2+1] = eval(args[i+1], locals, nl, ngensym);
-                        gc_wb(ex->args, ar[i*2+1]);
+                        jl_gc_wb(ex->args, ar[i*2+1]);
                     }
                     if (na != nreq) {
                         jl_error("wrong number of arguments");
@@ -350,7 +350,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         temp = b->value;
         check_can_assign_type(b);
         b->value = (jl_value_t*)dt;
-        gc_wb_binding(b, dt);
+        jl_gc_wb_binding(b, dt);
         super = eval(args[2], locals, nl, ngensym);
         jl_set_datatype_super(dt, super);
         b->value = temp;
@@ -380,7 +380,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         temp = b->value;
         check_can_assign_type(b);
         b->value = (jl_value_t*)dt;
-        gc_wb_binding(b, dt);
+        jl_gc_wb_binding(b, dt);
         super = eval(args[3], locals, nl, ngensym);
         jl_set_datatype_super(dt, super);
         b->value = temp;
@@ -409,13 +409,13 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         // temporarily assign so binding is available for field types
         check_can_assign_type(b);
         b->value = (jl_value_t*)dt;
-        gc_wb_binding(b,dt);
+        jl_gc_wb_binding(b,dt);
 
         JL_TRY {
             // operations that can fail
             inside_typedef = 1;
             dt->types = (jl_svec_t*)eval(args[4], locals, nl, ngensym);
-            gc_wb(dt, dt->types);
+            jl_gc_wb(dt, dt->types);
             inside_typedef = 0;
             for(size_t i=0; i < jl_svec_len(dt->types); i++) {
                 jl_value_t *elt = jl_svecref(dt->types, i);
@@ -435,7 +435,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         jl_compute_field_offsets(dt);
         if (para == (jl_value_t*)jl_emptysvec && jl_is_datatype_singleton(dt)) {
             dt->instance = newstruct(dt);
-            gc_wb(dt, dt->instance);
+            jl_gc_wb(dt, dt->instance);
         }
 
         b->value = temp;
@@ -459,7 +459,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
             f->linfo && f->linfo->ast && jl_is_expr(f->linfo->ast)) {
             jl_lambda_info_t *li = f->linfo;
             li->ast = jl_compress_ast(li, li->ast);
-            gc_wb(li, li->ast);
+            jl_gc_wb(li, li->ast);
             li->name = nm;
         }
         jl_set_global(jl_current_module, nm, (jl_value_t*)f);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -275,7 +275,7 @@ jl_value_t *jl_type_union_v(jl_value_t **ts, size_t n)
     JL_GC_PUSH1(&types);
     jl_uniontype_t *tu = (jl_uniontype_t*)newobj((jl_value_t*)jl_uniontype_type,NWORDS(sizeof(jl_uniontype_t)));
     tu->types = types;
-    gc_wb(tu, types);
+    jl_gc_wb(tu, types);
     JL_GC_POP();
     return (jl_value_t*)tu;
 }
@@ -1922,7 +1922,7 @@ static void cache_insert_type(jl_value_t *type, ssize_t insert_at, int ordered)
             ((jl_datatype_t*)type)->name->cache = nc;
         else
             ((jl_datatype_t*)type)->name->linearcache = nc;
-        gc_wb(((jl_datatype_t*)type)->name, nc);
+        jl_gc_wb(((jl_datatype_t*)type)->name, nc);
         cache = nc;
         n = jl_svec_len(nc);
     }
@@ -2026,10 +2026,10 @@ static jl_value_t *inst_datatype(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **i
     top.prev = stack;
     stack = &top;
     ndt->name = tn;
-    gc_wb(ndt, ndt->name);
+    jl_gc_wb(ndt, ndt->name);
     ndt->super = jl_any_type;
     ndt->parameters = p;
-    gc_wb(ndt, ndt->parameters);
+    jl_gc_wb(ndt, ndt->parameters);
     ndt->types = istuple ? p : jl_emptysvec; // to be filled in below
     ndt->mutabl = dt->mutabl;
     ndt->abstract = dt->abstract;
@@ -2048,13 +2048,13 @@ static jl_value_t *inst_datatype(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **i
         ndt->super = jl_any_type;
     else
         ndt->super = (jl_datatype_t*)inst_type_w_((jl_value_t*)dt->super, env,n,stack, 1);
-    gc_wb(ndt, ndt->super);
+    jl_gc_wb(ndt, ndt->super);
     ftypes = dt->types;
     if (ftypes != NULL) {
         if (!istuple) {
             // recursively instantiate the types of the fields
             ndt->types = inst_all(ftypes, env, n, stack, 1);
-            gc_wb(ndt, ndt->types);
+            jl_gc_wb(ndt, ndt->types);
         }
         if (!isabstract) {
             if (jl_svec_len(ftypes) == 0) {
@@ -2067,7 +2067,7 @@ static jl_value_t *inst_datatype(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **i
             }
             if (jl_is_datatype_singleton(ndt)) {
                 ndt->instance = newstruct(ndt);
-                gc_wb(ndt, ndt->instance);
+                jl_gc_wb(ndt, ndt->instance);
             }
         }
         else {
@@ -2286,9 +2286,9 @@ void jl_reinstantiate_inner_types(jl_datatype_t *t)
         env[i*2+1] = env[i*2];
     }
     t->super = (jl_datatype_t*)inst_type_w_((jl_value_t*)t->super, env, n, &top, 1);
-    gc_wb(t, t->super);
+    jl_gc_wb(t, t->super);
     t->types = inst_all(t->types, env, n, &top, 1);
-    gc_wb(t, t->types);
+    jl_gc_wb(t, t->types);
 }
 
 // subtype comparison

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -2,8 +2,6 @@
   global:
     __asan*;
     __stack_chk_guard;
-    alloc_*w;
-    allocobj;
     asprintf;
     bitvector_*;
     clock_now;
@@ -32,8 +30,6 @@
     uv_*;
     add_library_mapping;
     utf8proc_*;
-    gc_queue_root;
-    gc_wb_slow;
     jlbacktrace;
     _IO_stdin_used;
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -550,9 +550,9 @@ int64_t jl_gc_diff_total_bytes(void);
 void jl_gc_sync_total_bytes(void);
 
 DLLEXPORT void jl_gc_collect(int);
-void jl_gc_preserve(jl_value_t *v);
-void jl_gc_unpreserve(void);
-int jl_gc_n_preserved_values(void);
+DLLEXPORT void jl_gc_preserve(jl_value_t *v);
+DLLEXPORT void jl_gc_unpreserve(void);
+DLLEXPORT int jl_gc_n_preserved_values(void);
 
 DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f);
 DLLEXPORT void jl_finalize(jl_value_t *o);
@@ -645,8 +645,8 @@ int64_t jl_gc_diff_total_bytes(void);
 
 #endif
 
-void *jl_gc_managed_malloc(size_t sz);
-void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz, int isaligned, jl_value_t* owner);
+DLLEXPORT void *jl_gc_managed_malloc(size_t sz);
+DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz, int isaligned, jl_value_t* owner);
 
 // object accessors -----------------------------------------------------------
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -18,15 +18,15 @@ STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
     jl_value_t *jv = NULL;
     switch (nfields) {
     case 0:
-        jv = (jl_value_t*)alloc_0w(); break;
+        jv = (jl_value_t*)jl_gc_alloc_0w(); break;
     case 1:
-        jv = (jl_value_t*)alloc_1w(); break;
+        jv = (jl_value_t*)jl_gc_alloc_1w(); break;
     case 2:
-        jv = (jl_value_t*)alloc_2w(); break;
+        jv = (jl_value_t*)jl_gc_alloc_2w(); break;
     case 3:
-        jv = (jl_value_t*)alloc_3w(); break;
+        jv = (jl_value_t*)jl_gc_alloc_3w(); break;
     default:
-        jv = (jl_value_t*)allocobj(nfields * sizeof(void*));
+        jv = (jl_value_t*)jl_gc_allocobj(nfields * sizeof(void*));
     }
     jl_set_typeof(jv, type);
     return jv;
@@ -34,7 +34,7 @@ STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
 
 STATIC_INLINE jl_value_t *newstruct(jl_datatype_t *type)
 {
-    jl_value_t *jv = (jl_value_t*)allocobj(type->size);
+    jl_value_t *jv = (jl_value_t*)jl_gc_allocobj(type->size);
     jl_set_typeof(jv, type);
     return jv;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -19,7 +19,7 @@ jl_module_t *jl_current_module=NULL;
 
 jl_module_t *jl_new_module(jl_sym_t *name)
 {
-    jl_module_t *m = (jl_module_t*)allocobj(sizeof(jl_module_t));
+    jl_module_t *m = (jl_module_t*)jl_gc_allocobj(sizeof(jl_module_t));
     jl_set_typeof(m, jl_module_type);
     JL_GC_PUSH1(&m);
     assert(jl_is_symbol(name));
@@ -46,7 +46,7 @@ DLLEXPORT jl_value_t *jl_f_new_module(jl_sym_t *name, uint8_t std_imports)
     jl_module_t *m = jl_new_module(name);
     JL_GC_PUSH1(&m);
     m->parent = jl_main_module;
-    gc_wb(m, m->parent);
+    jl_gc_wb(m, m->parent);
     if (std_imports) jl_add_standard_imports(m);
     JL_GC_POP();
     return (jl_value_t*)m;
@@ -102,7 +102,7 @@ DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var)
     b = new_binding(var);
     b->owner = m;
     *bp = b;
-    gc_wb_buf(m, b);
+    jl_gc_wb_buf(m, b);
     return *bp;
 }
 
@@ -145,7 +145,7 @@ DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *
     b = new_binding(var);
     b->owner = m;
     *bp = b;
-    gc_wb_buf(m, b);
+    jl_gc_wb_buf(m, b);
     return *bp;
 }
 
@@ -292,7 +292,7 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
             nb->owner = b->owner;
             nb->imported = (explici!=0);
             *bp = nb;
-            gc_wb_buf(to, nb);
+            jl_gc_wb_buf(to, nb);
         }
     }
 }
@@ -361,7 +361,7 @@ void jl_module_export(jl_module_t *from, jl_sym_t *s)
         // don't yet know who the owner is
         b->owner = NULL;
         *bp = b;
-        gc_wb_buf(from, b);
+        jl_gc_wb_buf(from, b);
     }
     assert(*bp != HT_NOTFOUND);
     (*bp)->exportp = 1;
@@ -399,7 +399,7 @@ void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
     jl_binding_t *bp = jl_get_binding_wr(m, var);
     if (!bp->constp) {
         bp->value = val;
-        gc_wb(m, val);
+        jl_gc_wb(m, val);
     }
 }
 
@@ -409,7 +409,7 @@ void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
     if (!bp->constp) {
         bp->value = val;
         bp->constp = 1;
-        gc_wb(m, val);
+        jl_gc_wb(m, val);
     }
 }
 
@@ -432,7 +432,7 @@ DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
         }
     }
     b->value = rhs;
-    gc_wb_binding(b, rhs);
+    jl_gc_wb_binding(b, rhs);
 }
 
 DLLEXPORT void jl_declare_constant(jl_binding_t *b)

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -23,9 +23,9 @@ DLLEXPORT jl_svec_t *jl_svec(size_t n, ...)
 jl_svec_t *jl_svec1(void *a)
 {
 #ifdef OVERLAP_SVEC_LEN
-    jl_svec_t *v = (jl_svec_t*)alloc_1w();
+    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_1w();
 #else
-    jl_svec_t *v = (jl_svec_t*)alloc_2w();
+    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_2w();
 #endif
     jl_set_typeof(v, jl_simplevector_type);
     jl_svec_set_len_unsafe(v, 1);
@@ -36,9 +36,9 @@ jl_svec_t *jl_svec1(void *a)
 jl_svec_t *jl_svec2(void *a, void *b)
 {
 #ifdef OVERLAP_SVEC_LEN
-    jl_svec_t *v = (jl_svec_t*)alloc_2w();
+    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_2w();
 #else
-    jl_svec_t *v = (jl_svec_t*)alloc_3w();
+    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_3w();
 #endif
     jl_set_typeof(v, jl_simplevector_type);
     jl_svec_set_len_unsafe(v, 2);

--- a/src/table.c
+++ b/src/table.c
@@ -23,7 +23,7 @@ void jl_idtable_rehash(jl_array_t **pa, size_t newsz)
     for(i=0; i < sz; i+=2) {
         if (ol[i+1] != NULL) {
             (*jl_table_lookup_bp(pa, ol[i])) = ol[i+1];
-            gc_wb(*pa, ol[i+1]);
+            jl_gc_wb(*pa, ol[i+1]);
              // it is however necessary here because allocation
             // can (and will) occur in a recursive call inside table_lookup_bp
         }
@@ -49,7 +49,7 @@ static void **jl_table_lookup_bp(jl_array_t **pa, void *key)
     do {
         if (tab[index+1] == NULL) {
             tab[index] = key;
-            gc_wb(a, key);
+            jl_gc_wb(a, key);
             return &tab[index+1];
         }
 
@@ -118,7 +118,7 @@ jl_array_t *jl_eqtable_put(jl_array_t *h, void *key, void *val)
 {
     void **bp = jl_table_lookup_bp(&h, key);
     *bp = val;
-    gc_wb(h, val);
+    jl_gc_wb(h, val);
     return h;
 }
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -117,7 +117,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
     jl_module_t *newm = jl_new_module(name);
     newm->parent = parent_module;
     b->value = (jl_value_t*)newm;
-    gc_wb_binding(b, newm);
+    jl_gc_wb_binding(b, newm);
 
     if (parent_module == jl_main_module && name == jl_symbol("Base")) {
         // pick up Base module during bootstrap
@@ -635,7 +635,7 @@ void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super)
         jl_errorf("invalid subtyping in definition of %s",tt->name->name->name);
     }
     tt->super = (jl_datatype_t*)super;
-    gc_wb(tt, tt->super);
+    jl_gc_wb(tt, tt->super);
     if (jl_svec_len(tt->parameters) > 0) {
         tt->name->cache = jl_emptysvec;
         tt->name->linearcache = jl_emptysvec;
@@ -691,7 +691,7 @@ DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name, jl_value_t **bp, j
     if (*bp == NULL) {
         gf = (jl_value_t*)jl_new_generic_function(name);
         *bp = gf;
-        if (bp_owner) gc_wb(bp_owner, gf);
+        if (bp_owner) jl_gc_wb(bp_owner, gf);
     }
     return gf;
 }
@@ -740,7 +740,7 @@ DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_value_t 
                 // edit args, insert type first
                 if (!jl_is_expr(f->linfo->ast)) {
                     f->linfo->ast = jl_uncompress_ast(f->linfo, f->linfo->ast);
-                    gc_wb(f->linfo, f->linfo->ast);
+                    jl_gc_wb(f->linfo, f->linfo->ast);
                 }
                 jl_array_t *al = jl_lam_args((jl_expr_t*)f->linfo->ast);
                 if (jl_array_len(al) == 0) {
@@ -799,7 +799,7 @@ DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_value_t 
     if (*bp == NULL) {
         gf = (jl_value_t*)jl_new_generic_function(name);
         *bp = gf;
-        if (bp_owner) gc_wb(bp_owner, gf);
+        if (bp_owner) jl_gc_wb(bp_owner, gf);
     }
     assert(jl_is_function(f));
     assert(jl_is_tuple_type(argtypes));
@@ -810,7 +810,7 @@ DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_value_t 
         f->linfo && f->linfo->ast && jl_is_expr(f->linfo->ast)) {
         jl_lambda_info_t *li = f->linfo;
         li->ast = jl_compress_ast(li, li->ast);
-        gc_wb(li, li->ast);
+        jl_gc_wb(li, li->ast);
     }
     JL_GC_POP();
     return gf;


### PR DESCRIPTION
Changed exported names in `gc.c` to have the `jl_gc_` prefix to prevent name collisions when julia is linked with other code.

`gc_wb*` -> `jl_gc_wb*`
`gc_queue_root` -> `jl_gc_queue_root`
`allocobj` -> `jl_gc_allocobj`
`alloc_[0-4]w` -> `jl_gc_alloc_*w`
`diff_gc_total_bytes` -> `jl_gc_diff_total_bytes`
`sync_gc_total_bytes` -> `jl_gc_sync_total_bytes`
