### PR TITLE
Fix two issues on LLVM-SVN

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -328,7 +328,7 @@ static Value *julia_to_native(Type *ty, jl_value_t *jt, Value *jv,
         return boxed(jv,ctx);
     }
 
-    if (!tojulia && julia_type_to_llvm(aty)->isAggregateType()) {
+    if (!tojulia && vt != jl_pvalue_llvmt && julia_type_to_llvm(aty)->isAggregateType()) {
         // this value is expected to be a pointer in the julia codegen,
         // so it needs to be extracted first if not tojulia
         vt = vt->getContainedType(0);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1011,7 +1011,6 @@ void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper)
         return (Function*)sf->linfo->functionObject;
 }
 
-#ifndef USE_MCJIT
 Function* CloneFunctionToModule(Function *F, Module *destModule)
 {
     ValueToValueMapTy VMap;
@@ -1031,17 +1030,9 @@ Function* CloneFunctionToModule(Function *F, Module *destModule)
     llvm::CloneFunctionInto(NewF, F, VMap, true, Returns, "", NULL, NULL);
     return NewF;
 }
-#else
-Function* CloneFunctionToModule(Function *F, Module *destModule)
-{
-    FunctionMover mover(destModule, F->getParent());
-    Function* f2 = mover.CloneFunction(F);
-    return f2;
-}
-#endif
 
 extern "C" DLLEXPORT
-const jl_value_t *jl_dump_function_ir(void *f, bool strip_ir_metadata)
+const jl_value_t *jl_dump_function_ir(void *f, bool strip_ir_metadata, bool dump_module)
 {
     std::string code;
     llvm::raw_string_ostream stream(code);
@@ -1085,7 +1076,10 @@ const jl_value_t *jl_dump_function_ir(void *f, bool strip_ir_metadata)
                 }
             }
         }
-        m->print(stream, NULL);
+        if (dump_module)
+            m->print(stream, NULL);
+        else
+            f2->print(stream);
         f2->eraseFromParent();
         delete m;
     }


### PR DESCRIPTION
- The reflection test was failing because FunctionMover was used in an unsupported way
- Also make generation of a module optional, as it's nice to have code_llvm as small as possible
- Cxx.jl's usage of LLVM call resulted in an assertion in julia (not related to Cxx.jl itself but due to llvmcall's argument translation). Put a workaround in for that, until that gets cleaned up properly.

@vtjnash 
