### PR TITLE
Remove two make options that are not used

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -356,7 +356,6 @@ JCXXFLAGS += -std=c++11
 endif
 
 JFFLAGS = -O2 $(fPIC)
-JF2CFLAGS = -ff2c -fno-second-underscore
 ifneq ($(USEMSVC),1)
 CPP = $(CC) -E
 AR := $(CROSS_COMPILE)ar
@@ -377,13 +376,10 @@ RANLIB := $(CROSS_COMPILE)ranlib
 # file extensions
 ifeq ($(OS), WINNT)
   SHLIB_EXT = dll
-  SHELL_EXT = bat
 else ifeq ($(OS), Darwin)
   SHLIB_EXT = dylib
-  SHELL_EXT = sh
 else
   SHLIB_EXT = so
-  SHELL_EXT = sh
 endif
 
 


### PR DESCRIPTION
These are two make variables that seems to be unused. They are not set in https://github.com/JuliaLang/julia/pull/11754 and it seems fine. Please comment if they are implicitly used by some dependencies in certain configuration.
