### PR TITLE
Added definition for tuple conversion no-op as a fix for #11765

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -95,6 +95,7 @@ tail(x::Tuple) = argtail(x...)
 
 convert{T<:Tuple{Any,Vararg{Any}}}(::Type{T}, x::Tuple{Any, Vararg{Any}}) =
     tuple(convert(tuple_type_head(T),x[1]), convert(tuple_type_tail(T), tail(x))...)
+convert{T<:Tuple{Any,Vararg{Any}}}(::Type{T}, x::T) = x
 
 oftype(x,c) = convert(typeof(x),c)
 


### PR DESCRIPTION
This PR ensures that conversions of tuples to tuples of the same type results in a no-op (it previously didn't; see  #11765).
