### PR TITLE
Explain the usage of `[av skip]` tag.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Julia's documentation is stored in the `doc` directory, and like everything else
 - Search for the function you want to change
 - Make your changes
 - Exit Zen mode
-- Provide a title, and optionally a longer description of your change
+- Provide a title with the tag `[av skip]` included, e.g. `[av skip] document foo.jl bahaviour` (this is used in order to prevent the AppVeyor job queue from growing to large because of trivial edits) and optionally a longer description of your change
 - Submit your change
 
 Julia's documentation is built with [Sphinx](http://sphinx-doc.org/contents.html), which supports (and Julia's docs rely heavily on) [ReST directives](http://docutils.sourceforge.net/docs/ref/rst/directives.html). To build the documentation locally, run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Julia's documentation is stored in the `doc` directory, and like everything else
 - Make your changes
 - Exit Zen mode
 - Provide a title
-- Provide a longer description of your change with the tag `[av skip]` included at the bottom (this is used in order to prevent the AppVeyor job queue from growing to large because of documentation edits)
+- Provide a longer description of your change with the tag `[av skip]` included at the bottom (this is used in order to prevent the AppVeyor job queue from growing too large because of documentation edits)
 - Submit your change
 
 Julia's documentation is built with [Sphinx](http://sphinx-doc.org/contents.html), which supports (and Julia's docs rely heavily on) [ReST directives](http://docutils.sourceforge.net/docs/ref/rst/directives.html). To build the documentation locally, run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,8 @@ Julia's documentation is stored in the `doc` directory, and like everything else
 - Search for the function you want to change
 - Make your changes
 - Exit Zen mode
-- Provide a title with the tag `[av skip]` included, e.g. `[av skip] document foo.jl bahaviour` (this is used in order to prevent the AppVeyor job queue from growing to large because of trivial edits) and optionally a longer description of your change
+- Provide a title
+- Provide a longer description of your change with the tag `[av skip]` included at the bottom (this is used in order to prevent the AppVeyor job queue from growing to large because of documentation edits)
 - Submit your change
 
 Julia's documentation is built with [Sphinx](http://sphinx-doc.org/contents.html), which supports (and Julia's docs rely heavily on) [ReST directives](http://docutils.sourceforge.net/docs/ref/rst/directives.html). To build the documentation locally, run


### PR DESCRIPTION
Related to trivial edits on documentation source files. Mentioned in https://github.com/JuliaLang/julia/pull/11766#issuecomment-113630198.
