### PR TITLE
Fix wrong `merge` example output.

### DIFF
--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -685,20 +685,20 @@ Given a dictionary ``D``, the syntax ``D[x]`` returns the value of key ``x`` (if
 
      julia> b = Dict(utf8("baz") => 17, utf8("bar") => 4711)
      Dict{UTF8String,Int64} with 2 entries:
+       "bar" => 4711
        "baz" => 17
-       "qux" => 4711
 
      julia> merge(a, b)
-     Dict{ASCIIString,Float64} with 3 entries:
+     Dict{UTF8String,Float64} with 3 entries:
        "bar" => 4711.0
        "baz" => 17.0
        "foo" => 0.0
 
      julia> merge(b, a)
-     Dict{UTF8String,Int64} with 3 entries:
-       "bar" => 42
-       "baz" => 17
-       "foo" => 0
+     Dict{UTF8String,Float64} with 3 entries:
+       "bar" => 42.0
+       "baz" => 17.0
+       "foo" => 0.0
 
 .. function:: merge!(collection, others...)
 


### PR DESCRIPTION
I'm sorry, this happened because I tested in `0.3.9`.

I wish JuliaBox also had an option for the development kernel, lately I've been using it exclusively since I'm stuck with an old Mac and Julia `0.2.1` and in my work I tend to use a lot of computers so it's easier for me to use JuliaBox than to configure all of the computers to my tastes, Im also getting used to use the web interface only for the same reasons, still it's no excuse.

[av skip]
