### PR TITLE
Check if argument is NULL in jl_f_apply. Fix #11772

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -465,8 +465,15 @@ JL_CALLABLE(jl_f_apply)
         }
         else {
             size_t al = jl_array_len(args[i]);
-            for(j=0; j < al; j++)
-                newargs[n++] = jl_cellref(args[i], j);
+            for (j = 0;j < al;j++) {
+                jl_value_t *arg = jl_cellref(args[i], j);
+                // apply with array splatting may have embedded NULL value
+                // #11772
+                if (__unlikely(arg == NULL)) {
+                    jl_throw(jl_undefref_exception);
+                }
+                newargs[n++] = arg;
+            }
         }
     }
     jl_value_t *result = jl_apply(f, newargs, n);

--- a/test/core.jl
+++ b/test/core.jl
@@ -2972,3 +2972,6 @@ abstract C11597{T<:Union(Void, Int)}
 type D11597{T} <: C11597{T} d::T end
 @test_throws TypeError D11597(1.0)
 @test_throws TypeError repr(D11597(1.0))
+
+# issue #11772
+@test_throws UndefRefError (cell(5)...)


### PR DESCRIPTION
AFAICT, this can only happen in `apply`. I did a rough search and other places all looks ok for me.

The optimization in `codegen` is probably fine as well since it's directly forwarding the input parameters.

~~P.S. The `onstack` logic looks weird for me. It seems that the index calculation is wrong.~~

Fix #11772
