### PR TITLE
LinAlg testing strikes again

### DIFF
--- a/base/linalg/svd.jl
+++ b/base/linalg/svd.jl
@@ -53,7 +53,7 @@ end
 svdvals(x::Number) = [abs(x)]
 
 # SVD least squares
-function \{T<:BlasFloat}(A::SVD{T}, B::StridedVecOrMat{T})
+function A_ldiv_B!{T<:BlasFloat}(A::SVD{T}, B::StridedVecOrMat{T})
     n = length(A.S)
     Sinv = zeros(T, n)
     k = length(find(A.S .> eps(real(float(one(T))))*maximum(A.S)))

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -74,7 +74,7 @@ end
 function A_mul_B!(C::StridedVecOrMat, S::SymTridiagonal, B::StridedVecOrMat)
     m, n = size(B, 1), size(B, 2)
     if !(m == size(S, 1) == size(C, 1))
-        throw(DimensionMismatch("A has first dimension $(size(A,1)), B has $(size(B,1)), C has $(size(C,1)) but all must match"))
+        throw(DimensionMismatch("A has first dimension $(size(S,1)), B has $(size(B,1)), C has $(size(C,1)) but all must match"))
     end
     if n != size(C, 2)
         throw(DimensionMismatch("Second dimension of B, $n, doesn't match second dimension of C, $(size(C,2))"))
@@ -107,7 +107,7 @@ eigfact{T}(A::SymTridiagonal{T}) = (S = promote_type(Float32, typeof(zero(T)/nor
 eigfact!{T<:BlasReal}(A::SymTridiagonal{T}, irange::UnitRange) = Eigen(LAPACK.stegr!('V', 'I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)...)
 eigfact{T}(A::SymTridiagonal{T}, irange::UnitRange) = (S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigfact!(S != T ? convert(SymTridiagonal{S}, A) : copy(A), irange))
 
-eigfact!{T<:BlasReal}(A::SymTridiagonal{T}, vl::Real, vu::Real) = Eigen(LAPACK.stegr!('V', A.dv, A.ev, convert(T, vl), convert(T, vu), 0, 0)...)
+eigfact!{T<:BlasReal}(A::SymTridiagonal{T}, vl::Real, vu::Real) = Eigen(LAPACK.stegr!('V', 'V', A.dv, A.ev, vl, vu, 0, 0)...)
 eigfact{T}(A::SymTridiagonal{T}, vl::Real, vu::Real) = (S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigfact!(S != T ? convert(SymTridiagonal{S}, A) : copy(A), vl, vu))
 
 eigvals!{T<:BlasReal}(A::SymTridiagonal{T}) = LAPACK.stev!('N', A.dv, A.ev)[1]

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -61,6 +61,12 @@ let
         @test_approx_eq_eps apd*v[:,1] d[1]*bpd*v[:,1] testtol
         @test norm(v) > testtol # eigenvectors cannot be null vectors
 
+        @test_throws ArgumentError eigs(rand(elty,2,2))
+        @test_throws ArgumentError eigs(a, nev=-1)
+        @test_throws ArgumentError eigs(a, which=:Z)
+        @test_throws ArgumentError eigs(a, which=:BE)
+        @test_throws DimensionMismatch eigs(a, v0=zeros(elty,n+2))
+        @test_throws ArgumentError eigs(a, v0=zeros(Int,n))
     end
 end
 
@@ -164,6 +170,9 @@ let # svds test
     @test_approx_eq S3[1] [34.0, 6.0]
     S4 = svds(B, nsv=2)
     @test_approx_eq S4[2] [34.0, 6.0]
+
+    @test_throws ArgumentError svds(A,nsv=0)
+    @test_throws ArgumentError svds(A,nsv=20)
 end
 
 debug && println("complex svds")
@@ -184,4 +193,7 @@ let # complex svds test
     s1_right = abs(S1[3][:,1:2])
     s2_right = abs(S2[3][:,1:2])
     @test_approx_eq s1_right s2_right
+
+    @test_throws ArgumentError svds(A,nsv=0)
+    @test_throws ArgumentError svds(A,nsv=20)
 end

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -30,6 +30,13 @@ for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
         @test_approx_eq_eps D\U DM\U 2n^3*eps(relty)*(elty<:Complex ? 2:1)
         @test_approx_eq_eps A_ldiv_B!(D,copy(v)) DM\v 2n^2*eps(relty)*(elty<:Complex ? 2:1)
         @test_approx_eq_eps A_ldiv_B!(D,copy(U)) DM\U 2n^3*eps(relty)*(elty<:Complex ? 2:1)
+        @test_throws DimensionMismatch A_ldiv_B!(D, ones(elty, n + 1))
+        b = rand(elty,n,n)
+        b = sparse(b)
+        @test_approx_eq A_ldiv_B!(D,copy(b)) full(D)\full(b)
+        b = rand(elty,n+1,n+1)
+        b = sparse(b)
+        @test_throws DimensionMismatch A_ldiv_B!(D,copy(b))
     end
 
     debug && println("Simple unary functions")
@@ -150,4 +157,9 @@ let d = randn(n), D = Diagonal(d)
     @test_throws BoundsError (D[n+1,n+1] = 0)
     @test_throws BoundsError D[n,n+1]
     @test_throws BoundsError (D[n,n+1] = 0)
+end
+
+# inv
+let d = randn(n), D = Diagonal(d)
+    @test_approx_eq inv(D) inv(full(D))
 end

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -72,6 +72,18 @@ let n = 12 #Size of matrix problem to test
             w, iblock, isplit = LAPACK.stebz!('V', 'B', -infinity, infinity, 0, 0, zero, a, b)
             evecs = LAPACK.stein!(a, b, w, iblock, isplit)
             test_approx_eq_vecs(v, evecs)
+
+            debug && println("stegr! call with index range")
+            F = eigfact(SymTridiagonal(a, b),1:2)
+            fF = eigfact(Symmetric(full(SymTridiagonal(a, b))),1:2)
+            @test_approx_eq F[:vectors] fF[:vectors]
+            @test_approx_eq F[:values] fF[:values]
+
+            debug && println("stegr! call with value range")
+            F = eigfact(SymTridiagonal(a, b),0.0,1.0)
+            fF = eigfact(Symmetric(full(SymTridiagonal(a, b))),0.0,1.0)
+            @test_approx_eq F[:vectors] fF[:vectors]
+            @test_approx_eq F[:values] fF[:values]
         end
 
         debug && println("Binary operations")
@@ -92,6 +104,10 @@ let n = 12 #Size of matrix problem to test
         @test_approx_eq full(α*A) α*full(A)
         @test_approx_eq full(A*α) full(A)*α
         @test_approx_eq full(A/α) full(A)/α
+
+        @test_throws DimensionMismatch A_mul_B!(zeros(elty,n,n),B,ones(elty,n+1,n))
+        @test_throws DimensionMismatch A_mul_B!(zeros(elty,n+1,n),B,ones(elty,n,n))
+        @test_throws DimensionMismatch A_mul_B!(zeros(elty,n,n+1),B,ones(elty,n,n))
     end
 
     debug && println("Tridiagonal matrices")

--- a/test/linalg1.jl
+++ b/test/linalg1.jl
@@ -230,6 +230,8 @@ debug && println("singular value decomposition")
         @test_approx_eq full(usv) a
         @test_approx_eq usv[:Vt]' usv[:V]
         @test_throws KeyError usv[:Z]
+        b = rand(eltya,n)
+        @test_approx_eq usv\b a\b
     end
 
 debug && println("Generalized svd")

--- a/test/linalg4.jl
+++ b/test/linalg4.jl
@@ -135,3 +135,11 @@ A = rand(5,7)
 @test_throws(BoundsError,triu(A,-6))
 @test_throws(BoundsError,tril(A,8))
 @test_throws(BoundsError,tril(A,-6))
+
+# test generic axpy
+x = ['a','b','c','d','e']
+y = ['a','b','c','d','e']
+α = 'f'
+@test_throws DimensionMismatch Base.LinAlg.axpy!(α,x,['g'])
+@test_throws BoundsError Base.LinAlg.axpy!(α,x,collect(-1:5),y,collect(1:7))
+@test_throws BoundsError Base.LinAlg.axpy!(α,x,collect(1:7),y,collect(1:7))


### PR DESCRIPTION
As part of a pre-JuliaCon push to get all the linalg files into the yellow (>80% coverage), I've added tests for:
- `base/linalg/tridiag.jl` - there was also a bug here in an error throwing message, which I fixed - this bug was introduced by me, during https://github.com/JuliaLang/julia/commit/bbc47a84fa2f5359cd078e820ae53dd9ec68c870. Sorry, everyone!
- `base/linalg/generic.jl` - the `axpy!` method wasn't tested
- `base/linalg/arnoldi.jl` - almost all the error throwing messages weren't tested
- `base/linalg/svd.jl` - the `\` linear solver wasn't getting "name resolved" (? is that the right term?) correctly, but changing it to `A_ldiv_B!` allows us to call the method correctly
- `base/linalg/diagonal.jl` - `inv` and `A_ldiv_B` where `B` isn't a `StridedMatrix` weren't tested
