### PR TITLE
Replace sizeof(jl_tagged_value_t) with sizeof(void*) for MSVC

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -380,7 +380,7 @@ static jl_sym_t *mk_symbol(const char *str)
 #endif
     jl_sym_t *sym;
     size_t len = strlen(str);
-    size_t nb = (sizeof(jl_taggedvalue_t)+sizeof(jl_sym_t)+len+1+7)&-8;
+    size_t nb = (sizeof_jl_taggedvalue_t+sizeof(jl_sym_t)+len+1+7)&-8;
 
     if (nb >= SYM_POOL_SIZE) {
         jl_exceptionf(jl_argumenterror_type, "Symbol length exceeds maximum length");

--- a/src/gc.c
+++ b/src/gc.c
@@ -213,7 +213,7 @@ typedef buff_t gcval_t;
 
 #define GC_PAGE_LG2 14 // log2(size of a page)
 #define GC_PAGE_SZ (1 << GC_PAGE_LG2) // 16k
-#define GC_PAGE_OFFSET (16 - (sizeof(jl_taggedvalue_t) % 16))
+#define GC_PAGE_OFFSET (16 - (sizeof_jl_taggedvalue_t % 16))
 
 // pool page metadata
 typedef struct _gcpage_t {
@@ -631,7 +631,7 @@ static inline int gc_setmark_pool(void *o, int mark_mode)
 static inline int gc_setmark(jl_value_t *v, int sz, int mark_mode)
 {
     jl_taggedvalue_t *o = jl_astaggedvalue(v);
-    sz += sizeof(jl_taggedvalue_t);
+    sz += sizeof_jl_taggedvalue_t;
 #ifdef MEMDEBUG
     return gc_setmark_big(o, mark_mode);
 #endif
@@ -2438,7 +2438,7 @@ void *reallocb(void *b, size_t sz)
 
 DLLEXPORT jl_value_t *allocobj(size_t sz)
 {
-    size_t allocsz = sz + sizeof(jl_taggedvalue_t);
+    size_t allocsz = sz + sizeof_jl_taggedvalue_t;
     if (allocsz < sz) // overflow in adding offs, size was "negative"
         jl_throw(jl_memory_exception);
 #ifdef MEMDEBUG
@@ -2452,7 +2452,7 @@ DLLEXPORT jl_value_t *allocobj(size_t sz)
 
 DLLEXPORT jl_value_t *alloc_0w(void)
 {
-    const int sz = sizeof(jl_taggedvalue_t);
+    const int sz = sizeof_jl_taggedvalue_t;
 #ifdef MEMDEBUG
     return jl_valueof(alloc_big(sz));
 #endif
@@ -2461,7 +2461,7 @@ DLLEXPORT jl_value_t *alloc_0w(void)
 
 DLLEXPORT jl_value_t *alloc_1w(void)
 {
-    const int sz = LLT_ALIGN(sizeof(jl_taggedvalue_t) + sizeof(void*), 16);
+    const int sz = LLT_ALIGN(sizeof_jl_taggedvalue_t + sizeof(void*), 16);
 #ifdef MEMDEBUG
     return jl_valueof(alloc_big(sz));
 #endif
@@ -2470,7 +2470,7 @@ DLLEXPORT jl_value_t *alloc_1w(void)
 
 DLLEXPORT jl_value_t *alloc_2w(void)
 {
-    const int sz = LLT_ALIGN(sizeof(jl_taggedvalue_t) + sizeof(void*) * 2, 16);
+    const int sz = LLT_ALIGN(sizeof_jl_taggedvalue_t + sizeof(void*) * 2, 16);
 #ifdef MEMDEBUG
     return jl_valueof(alloc_big(sz));
 #endif
@@ -2479,7 +2479,7 @@ DLLEXPORT jl_value_t *alloc_2w(void)
 
 DLLEXPORT jl_value_t *alloc_3w(void)
 {
-    const int sz = LLT_ALIGN(sizeof(jl_taggedvalue_t) + sizeof(void*) * 3, 16);
+    const int sz = LLT_ALIGN(sizeof_jl_taggedvalue_t + sizeof(void*) * 3, 16);
 #ifdef MEMDEBUG
     return jl_valueof(alloc_big(sz));
 #endif
@@ -2681,7 +2681,7 @@ static void big_obj_stats(void)
 #else //JL_GC_MARKSWEEP
 DLLEXPORT jl_value_t *allocobj(size_t sz)
 {
-    size_t allocsz = sz + sizeof(jl_taggedvalue_t);
+    size_t allocsz = sz + sizeof_jl_taggedvalue_t;
     if (allocsz < sz)  // overflow in adding offs, size was "negative"
         jl_throw(jl_memory_exception);
     allocd_bytes += allocsz;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -40,6 +40,9 @@ STATIC_INLINE jl_value_t *newstruct(jl_datatype_t *type)
 }
 
 #define GC_MAX_SZCLASS (2032-sizeof(void*))
+// MSVC miscalculates sizeof(jl_taggedvalue_t) because
+// empty structs are a GNU extension
+#define sizeof_jl_taggedvalue_t (sizeof(void*))
 
 int jl_assign_type_uid(void);
 jl_value_t *jl_cache_type_(jl_datatype_t *type);


### PR DESCRIPTION
This (along with [one small int128 patch](https://gist.github.com/0afb86e5ece491b220a6), not included with this PR) results in a successful MSVC-built julia repl, see discussion at https://github.com/JuliaLang/julia/commit/8b8b26193093ae2a0663b3b0d83341719826fcad#commitcomment-11018031

MSVC was getting a different answer for `sizeof(jl_taggedvalue_t)` because there are some GNU extension tricks that make the current "types as C structs" arrangement work.

Amazingly all the linalg tests pass (`ccall`ing into a mingw-built openblas dll), there's a failure in numbers that's likely due to missing int128 intrinsics, and ~~I still need to run the rest of the tests to get an idea what other failures there are~~ [several other failures](https://gist.github.com/tkelman/8ebc5330426331555676) to look into. See https://github.com/JuliaLang/julia/pull/7761#issue-38915926 for instructions on how to build with MSVC - it currently downloads mingw-built dependency dll's from a nightly julia binary, but leveraging #11754 should eventually be able to make the build process less hacky, including building as many deps as possible with MSVC to make things msys and mingw-independent.

Should probably open an MSVC support tracking issue after this gets merged, to figure out how to manage any MSVC-only changes in base, get an MSVC-built Julia to properly identify itself as such, etc.
