### PR TITLE
Update control-flow.rst

### DIFF
--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -136,7 +136,7 @@ So, we could have defined the ``test`` function above as
              else
                relation = "greater than"
              end
-             println("x is ", relation, " than y.")
+             println("x is ", relation, " y.")
            end
     test (generic function with 1 method)
 
@@ -153,7 +153,7 @@ the above function results in a runtime error
              elseif x == y
                relation = "equal to"
              end
-             println("x is ", relation, " than y.")
+             println("x is ", relation, " y.")
            end
     test (generic function with 1 method)
 


### PR DESCRIPTION
typos fixed regarding the `println` statement while comparing x and y values.
