### PR TITLE
Avoid overflow in generic_vecnorm()

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -109,12 +109,12 @@ function generic_vecnorm2(x)
     s = start(x)
     (v, s) = next(x, s)
     T = typeof(maxabs)
-    scale::promote_type(Float64, T) = 1/maxabs
-    y = norm(v)*scale
+    scale::promote_type(Float64, T) = maxabs
+    y = norm(v)/scale
     sum::promote_type(Float64, T) = y*y
     while !done(x, s)
         (v, s) = next(x, s)
-        y = norm(v)*scale
+        y = norm(v)/scale
         sum += y*y
     end
     return convert(T, maxabs * sqrt(sum))
@@ -130,11 +130,11 @@ function generic_vecnormp(x, p)
         (v, s) = next(x, s)
         T = typeof(maxabs)
         spp::promote_type(Float64, T) = p
-        scale::promote_type(Float64, T) = 1/maxabs
-        ssum::promote_type(Float64, T) = (norm(v)*scale)^spp
+        scale::promote_type(Float64, T) = maxabs
+        ssum::promote_type(Float64, T) = (norm(v)/scale)^spp
         while !done(x, s)
             (v, s) = next(x, s)
-            ssum += (norm(v)*scale)^spp
+            ssum += (norm(v)/scale)^spp
         end
         return convert(T, maxabs * ssum^inv(spp))
     else # -1 ≤ p ≤ 1, no need for rescaling

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -106,3 +106,7 @@ b = randn(Base.LinAlg.SCAL_CUTOFF) # make sure we try BLAS path
 @test isequal(scale(Float64[1.0], big(2.0)im), Complex{BigFloat}[2.0im])
 @test isequal(scale(BigFloat[1.0], 2.0im),     Complex{BigFloat}[2.0im])
 @test isequal(scale(BigFloat[1.0], 2.0f0im),   Complex{BigFloat}[2.0im])
+
+# Issue #11788
+@test_approx_eq norm([2.4e-322, 4.4e-323]) 2.47e-322
+@test_approx_eq norm([2.4e-322, 4.4e-323], 3) 2.4e-322


### PR DESCRIPTION
No need to take the inverse too early. Fixes JuliaLang/LinearAlgebra.jl#222.

I've kept the existing type promotion code, although I'm not sure how it works.
