### PR TITLE
Better error message for `methods` on non-generic functions

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -125,7 +125,13 @@ end
 tt_cons(t::ANY, tup::ANY) = Tuple{t, (isa(tup, Type) ? tup.parameters : tup)...}
 
 code_lowered(f, t::ANY) = map(m->uncompressed_ast(m.func.code), methods(f, t))
-methods(f::Function,t::ANY) = (t=to_tuple_type(t); Any[m[3] for m in _methods(f,t,-1)])
+function methods(f::Function,t::ANY)
+    if !isgeneric(f)
+        throw(ArgumentError("argument is not a generic function"))
+    end
+    t = to_tuple_type(t)
+    Any[m[3] for m in _methods(f,t,-1)]
+end
 methods(f::ANY,t::ANY) = methods(call, tt_cons(isa(f,Type) ? Type{f} : typeof(f), t))
 function _methods(f::ANY,t::ANY,lim)
     if isa(t,Type)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -189,3 +189,5 @@ let
     @test TestMod7648==@which foo7648
     @test TestMod7648.TestModSub9475==@which a9475
 end
+
+@test_throws ArgumentError which(is, Tuple{Int, Int})


### PR DESCRIPTION
Throw an informative error when methods(f::Function, t) is called with non-generic function

Ref: [julia-dev](https://groups.google.com/forum/#!topic/julia-dev/LF7jo1QjWvA)
