### PR TITLE
WIP: unpack TypeVars before subtyping with Union

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -81,7 +81,7 @@ end
 
 isvarargtype(t::ANY) = isa(t,DataType)&&is((t::DataType).name,Vararg.name)
 isvatuple(t::DataType) = (n = length(t.parameters); n > 0 && isvarargtype(t.parameters[n]))
-unwrapva(t::ANY) = isvarargtype(t) ? t.parameters[1] : t
+unwrapva(t::ANY) = isa(t,TypeVar) ? unwrapva(t.ub) : (isvarargtype(t) ? t.parameters[1] : t)
 
 @generated function tuple_type_tail{T<:Tuple}(::Type{T})
     if isvatuple(T) && length(T.parameters) == 1

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1120,12 +1120,12 @@ function type_too_complex(t::ANY, d)
     if d > MAX_TYPE_DEPTH
         return true
     end
-    if isa(t,Union)
+    if isa(t,TypeVar)
+        return type_too_complex(t.lb,d+1) || type_too_complex(t.ub,d+1)
+    elseif isa(t,Union)
         p = t.types
     elseif isa(t,DataType)
         p = t.parameters
-    elseif isa(t,TypeVar)
-        return type_too_complex(t.lb,d+1) || type_too_complex(t.ub,d+1)
     else
         return false
     end

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2358,6 +2358,24 @@ static int jl_subtype_le(jl_value_t *a, jl_value_t *b, int ta, int invariant)
         return 1;
     }
 
+    if (jl_is_typevar(a)) {
+        if (jl_is_typevar(b)) {
+            return
+                jl_subtype_le((jl_value_t*)((jl_tvar_t*)a)->ub,
+                              (jl_value_t*)((jl_tvar_t*)b)->ub, 0, 0) &&
+                jl_subtype_le((jl_value_t*)((jl_tvar_t*)b)->lb,
+                              (jl_value_t*)((jl_tvar_t*)a)->lb, 0, 0);
+        }
+        if (invariant) {
+            return 0;
+        }
+        return jl_subtype_le((jl_value_t*)((jl_tvar_t*)a)->ub, b, 0, 0);
+    }
+    if (jl_is_typevar(b)) {
+        return jl_subtype_le(a, (jl_value_t*)((jl_tvar_t*)b)->ub, 0, 0) &&
+            jl_subtype_le((jl_value_t*)((jl_tvar_t*)b)->lb, a, 0, 0);
+    }
+
     size_t i;
     if (!ta && jl_is_uniontype(a)) {
         jl_svec_t *ap = ((jl_uniontype_t*)a)->types;
@@ -2477,23 +2495,6 @@ static int jl_subtype_le(jl_value_t *a, jl_value_t *b, int ta, int invariant)
         return 0;
     }
 
-    if (jl_is_typevar(a)) {
-        if (jl_is_typevar(b)) {
-            return
-                jl_subtype_le((jl_value_t*)((jl_tvar_t*)a)->ub,
-                              (jl_value_t*)((jl_tvar_t*)b)->ub, 0, 0) &&
-                jl_subtype_le((jl_value_t*)((jl_tvar_t*)b)->lb,
-                              (jl_value_t*)((jl_tvar_t*)a)->lb, 0, 0);
-        }
-        if (invariant) {
-            return 0;
-        }
-        return jl_subtype_le((jl_value_t*)((jl_tvar_t*)a)->ub, b, 0, 0);
-    }
-    if (jl_is_typevar(b)) {
-        return jl_subtype_le(a, (jl_value_t*)((jl_tvar_t*)b)->ub, 0, 0) &&
-            jl_subtype_le((jl_value_t*)((jl_tvar_t*)b)->lb, a, 0, 0);
-    }
     if ((jl_datatype_t*)a == jl_any_type) return 0;
 
     return jl_egal(a, b);

--- a/test/core.jl
+++ b/test/core.jl
@@ -30,6 +30,8 @@ isnot(x,y) = !is(x,y)
 @test !(Type{Bottom} <: Type{Int32})
 @test !(Vector{Float64} <: Vector{Union{Float64,Float32}})
 testintersect(Vector{Float64}, Vector{Union{Float64,Float32}}, Bottom)
+@test TypeVar(:T,Int,true) <: Int
+@test TypeVar(:T,Union(Int,Float64),true) <: Union(Int,Float64)
 
 @test !isa(Array,Type{Any})
 @test Type{Complex} <: DataType


### PR DESCRIPTION
Someday this will fix #11803 and #11015, but as it stands this exposes an error in inference than can be triggered by `make test-replutil`.
