### PR TITLE
Remove JL_GC_MARKSWEEP option

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -799,7 +799,6 @@ void jl_init_box_caches(void)
     }
 }
 
-#ifdef JL_GC_MARKSWEEP
 void jl_mark_box_caches(void)
 {
     int64_t i;
@@ -818,7 +817,6 @@ void jl_mark_box_caches(void)
         jl_gc_setmark(boxed_gensym_cache[i]);
     }
 }
-#endif
 
 jl_value_t *jl_box_bool(int8_t x)
 {

--- a/src/ast.c
+++ b/src/ast.c
@@ -197,9 +197,7 @@ static jl_value_t *full_list_of_lists(value_t e, int expronly)
 
 static jl_value_t *scm_to_julia(value_t e, int expronly)
 {
-#ifdef JL_GC_MARKSWEEP
     int en = jl_gc_enable(0);
-#endif
     jl_value_t *v;
     JL_TRY {
         v = scm_to_julia_(e, expronly);
@@ -210,9 +208,7 @@ static jl_value_t *scm_to_julia(value_t e, int expronly)
         jl_cellset(ex->args, 0, jl_cstr_to_string("invalid AST"));
         v = (jl_value_t*)ex;
     }
-#ifdef JL_GC_MARKSWEEP
     jl_gc_enable(en);
-#endif
     return v;
 }
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -188,9 +188,7 @@ void jl_enter_handler(jl_handler_t *eh)
 {
     JL_SIGATOMIC_BEGIN();
     eh->prev = jl_current_task->eh;
-#ifdef JL_GC_MARKSWEEP
     eh->gcstack = jl_pgcstack;
-#endif
     jl_current_task->eh = eh;
     // TODO: this should really go after setjmp(). see comment in
     // ctx_switch in task.c.

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -715,12 +715,10 @@ static Value *emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             }
         }
 
-#ifdef JL_GC_MARKSWEEP
         // make sure args are rooted
         if (t == jl_pvalue_llvmt && (needroot || might_need_root(argi))) {
             make_gcroot(arg, ctx);
         }
-#endif
         Value *v = julia_to_native(t, tti, arg, expr_type(argi, ctx), false, false, false, false, false, i, ctx, NULL);
         bool issigned = jl_signed_type && jl_subtype(tti, (jl_value_t*)jl_signed_type, 0);
         argvals[i] = llvm_type_rewrite(v, t, t, false, false, issigned, ctx);
@@ -1298,12 +1296,10 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             }
         }
 
-#ifdef JL_GC_MARKSWEEP
         // make sure args are rooted
         if (largty == jl_pvalue_llvmt && (needroot || might_need_root(argi))) {
             make_gcroot(arg, ctx);
         }
-#endif
 
         bool nSR=false;
         bool issigned = jl_signed_type && jl_subtype(jargty, (jl_value_t*)jl_signed_type, 0);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1874,7 +1874,6 @@ static Value* emit_allocobj(size_t static_size)
 // if ptr is NULL this emits a write barrier _back_
 static void emit_write_barrier(jl_codectx_t* ctx, Value *parent, Value *ptr)
 {
-#ifdef JL_GC_MARKSWEEP
     Value* parenttag = builder.CreateBitCast(emit_typeptr_addr(parent), T_psize);
     Value* parent_type = builder.CreateLoad(parenttag);
     Value* parent_mark_bits = builder.CreateAnd(parent_type, 1);
@@ -1897,12 +1896,10 @@ static void emit_write_barrier(jl_codectx_t* ctx, Value *parent, Value *ptr)
     builder.CreateBr(cont);
     ctx->f->getBasicBlockList().push_back(cont);
     builder.SetInsertPoint(cont);
-#endif
 }
 
 static void emit_checked_write_barrier(jl_codectx_t *ctx, Value *parent, Value *ptr)
 {
-#ifdef JL_GC_MARKSWEEP
     BasicBlock *cont;
     Value *not_null = builder.CreateICmpNE(ptr, V_null);
     BasicBlock *if_not_null = BasicBlock::Create(getGlobalContext(), "wb_not_null", ctx->f);
@@ -1913,7 +1910,6 @@ static void emit_checked_write_barrier(jl_codectx_t *ctx, Value *parent, Value *
     builder.CreateBr(cont);
     ctx->f->getBasicBlockList().push_back(cont);
     builder.SetInsertPoint(cont);
-#endif
 }
 
 static Value *emit_setfield(jl_datatype_t *sty, Value *strct, size_t idx0,

--- a/src/dump.c
+++ b/src/dump.c
@@ -1524,9 +1524,7 @@ DLLEXPORT void jl_preload_sysimg_so(const char *fname)
 
 void jl_restore_system_image_from_stream(ios_t *f)
 {
-#ifdef JL_GC_MARKSWEEP
     int en = jl_gc_enable(0);
-#endif
     DUMP_MODES last_mode = mode;
     mode = MODE_SYSTEM_IMAGE;
     arraylist_new(&backref_list, 250000);
@@ -1592,9 +1590,7 @@ void jl_restore_system_image_from_stream(ios_t *f)
     //jl_printf(JL_STDERR, "backref_list.len = %d\n", backref_list.len);
     arraylist_free(&backref_list);
 
-#ifdef JL_GC_MARKSWEEP
     jl_gc_enable(en);
-#endif
     mode = last_mode;
     jl_update_all_fptrs();
 }

--- a/src/init.c
+++ b/src/init.c
@@ -544,7 +544,7 @@ static struct uv_shutdown_queue_item *next_shutdown_queue_item(struct uv_shutdow
 
 DLLEXPORT void jl_atexit_hook()
 {
-#if defined(JL_GC_MARKSWEEP) && defined(GC_FINAL_STATS)
+#if defined(GC_FINAL_STATS)
     jl_print_gc_stats(JL_STDERR);
 #endif
     if (jl_options.code_coverage)
@@ -1067,10 +1067,8 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     }
 #endif
 
-#ifdef JL_GC_MARKSWEEP
     jl_gc_init();
     jl_gc_enable(0);
-#endif
     jl_init_frontend();
     jl_init_types();
     jl_init_tasks();
@@ -1140,9 +1138,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     if (jl_options.handle_signals == JL_OPTIONS_HANDLE_SIGNALS_ON)
         jl_install_default_signal_handlers();
 
-#ifdef JL_GC_MARKSWEEP
     jl_gc_enable(1);
-#endif
 
     if (jl_options.image_file)
         jl_init_restored_modules();

--- a/src/julia.h
+++ b/src/julia.h
@@ -491,7 +491,6 @@ extern jl_sym_t *arrow_sym; extern jl_sym_t *inert_sym;
 
 // gc -------------------------------------------------------------------------
 
-#ifdef JL_GC_MARKSWEEP
 typedef struct _jl_gcframe_t {
     size_t nroots;
     struct _jl_gcframe_t *prev;
@@ -606,44 +605,6 @@ static inline void jl_gc_wb_back(void *ptr) // ptr isa jl_value_t*
         jl_gc_queue_root((jl_value_t*)ptr);
     }
 }
-
-#else // No Garbage Collection
-
-#define JL_GC_PUSH(...) ;
-#define JL_GC_PUSH1(...) ;
-#define JL_GC_PUSH2(...) ;
-#define JL_GC_PUSH3(...) ;
-#define JL_GC_PUSH4(...) ;
-#define JL_GC_PUSH5(...) ;
-#define JL_GC_PUSHARGS(rts_var,n) rts_var = ((jl_value_t**)alloca((n)*sizeof(jl_value_t*)));
-#define JL_GC_POP()
-
-#define jl_gc_preserve(v) ((void)(v))
-#define jl_gc_unpreserve()
-#define jl_gc_n_preserved_values() (0)
-
-#define allocb(nb)    malloc(nb)
-DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz);
-STATIC_INLINE jl_value_t *jl_gc_alloc_1w() { return jl_gc_allocobj(1*sizeof(void*)); }
-STATIC_INLINE jl_value_t *jl_gc_alloc_2w() { return jl_gc_allocobj(2*sizeof(void*)); }
-STATIC_INLINE jl_value_t *jl_gc_alloc_3w() { return jl_gc_allocobj(3*sizeof(void*)); }
-
-DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f);
-
-int64_t jl_gc_diff_total_bytes(void);
-#define jl_gc_sync_total_bytes()
-#define jl_gc_collect(arg);
-#define jl_gc_enable(on) (0)
-#define jl_gc_is_enabled() (0)
-#define jl_gc_track_malloced_array(a)
-#define jl_gc_count_allocd(sz)
-
-#define jl_gc_wb_binding(bnd, val)
-#define jl_gc_wb(parent, ptr)
-#define jl_gc_wb_buf(parent, bufptr)
-#define jl_gc_wb_back(ptr)
-
-#endif
 
 DLLEXPORT void *jl_gc_managed_malloc(size_t sz);
 DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz, int isaligned, jl_value_t* owner);
@@ -1337,9 +1298,7 @@ void jl_install_default_signal_handlers(void);
 // info describing an exception handler
 typedef struct _jl_handler_t {
     jl_jmp_buf eh_ctx;
-#ifdef JL_GC_MARKSWEEP
     jl_gcframe_t *gcstack;
-#endif
     struct _jl_handler_t *prev;
 } jl_handler_t;
 
@@ -1364,10 +1323,8 @@ typedef struct _jl_task_t {
 
     // current exception handler
     jl_handler_t *eh;
-#ifdef JL_GC_MARKSWEEP
     // saved gc stack top for context switches
     jl_gcframe_t *gcstack;
-#endif
     // current module, or NULL if this task has not set one
     jl_module_t *current_module;
 } jl_task_t;
@@ -1387,9 +1344,7 @@ STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
 {
     JL_SIGATOMIC_BEGIN();
     jl_current_task->eh = eh->prev;
-#ifdef JL_GC_MARKSWEEP
     jl_pgcstack = eh->gcstack;
-#endif
     JL_SIGATOMIC_END();
 }
 
@@ -1521,7 +1476,7 @@ DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v);
 DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type);
 DLLEXPORT void jlbacktrace(void);
 
-#if defined(GC_FINAL_STATS) && defined(JL_GC_MARKSWEEP)
+#if defined(GC_FINAL_STATS)
 void jl_print_gc_stats(JL_STREAM *s);
 #endif
 

--- a/src/options.h
+++ b/src/options.h
@@ -35,9 +35,6 @@
 
 // GC options -----------------------------------------------------------------
 
-// only one GC is supported at this time
-#define JL_GC_MARKSWEEP
-
 // debugging options
 
 // with MEMDEBUG, every object is allocated explicitly with malloc, and

--- a/src/task.c
+++ b/src/task.c
@@ -147,9 +147,7 @@ jl_datatype_t *jl_task_type;
 DLLEXPORT JL_THREAD jl_task_t * volatile jl_current_task;
 JL_THREAD jl_task_t *jl_root_task;
 DLLEXPORT JL_THREAD jl_value_t *jl_exception_in_transit;
-#ifdef JL_GC_MARKSWEEP
 DLLEXPORT JL_THREAD jl_gcframe_t *jl_pgcstack = NULL;
-#endif
 
 #ifdef COPY_STACKS
 static JL_THREAD jl_jmp_buf * volatile jl_jmp_target;
@@ -302,10 +300,8 @@ static void ctx_switch(jl_task_t *t, jl_jmp_buf *where)
 #endif
 
         // set up global state for new task
-#ifdef JL_GC_MARKSWEEP
         jl_current_task->gcstack = jl_pgcstack;
         jl_pgcstack = t->gcstack;
-#endif
 
         // restore task's current module, looking at parent tasks
         // if it hasn't set one.
@@ -843,9 +839,7 @@ DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
     t->exception = jl_nothing;
     // there is no active exception handler available on this stack yet
     t->eh = NULL;
-#ifdef JL_GC_MARKSWEEP
     t->gcstack = NULL;
-#endif
     t->stkbuf = NULL;
 
 #ifdef COPY_STACKS
@@ -945,9 +939,7 @@ void jl_init_root_task(void *stack, size_t ssize)
     jl_current_task->donenotify = NULL;
     jl_current_task->exception = NULL;
     jl_current_task->eh = NULL;
-#ifdef JL_GC_MARKSWEEP
     jl_current_task->gcstack = NULL;
-#endif
 
     jl_root_task = jl_current_task;
 


### PR DESCRIPTION
1. We don't really need it
2. It doesn't compile anymore and I don't think we should try to keep it

@vtjnash @carnaval 
