### PR TITLE
Initialize finalizer_list_marked

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2547,6 +2547,7 @@ void jl_gc_init(void)
     jl_mk_thread_heap();
 
     arraylist_new(&finalizer_list, 0);
+    arraylist_new(&finalizer_list_marked, 0);
     arraylist_new(&to_finalize, 0);
 
     collect_interval = default_collect_interval;


### PR DESCRIPTION
Noticed this when I was checking https://github.com/JuliaLang/julia/issues/11814.

This doesn't cause a crash because `arraylist_grow` thinks the `items == NULL != &_space[0]` is a `malloc`'d array and called `realloc` on it (which is allowed).

The implementation seems to be robust against this but this IMHO should be fixed.

Note that this does **not** fix #11814 
