### PR TITLE
Reinstate Array indexing for arbitrary dimensions

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -289,8 +289,8 @@ done(a::Array,i) = (i > length(a))
 
 ## Indexing: getindex ##
 
-getindex(A::Array, i1::Int) = arrayref(A, i1)
-unsafe_getindex(A::Array, i1::Int) = @inbounds return arrayref(A, i1)
+getindex(A::Array, i::Int, I::Int...) = arrayref(A, i, I...)
+unsafe_getindex(A::Array, i::Int, I::Int...) = @inbounds return arrayref(A, i, I...)
 
 # Faster contiguous indexing using copy! for UnitRange and Colon
 getindex(A::Array, I::UnitRange{Int}) = (checkbounds(A, I); unsafe_getindex(A, I))
@@ -318,7 +318,8 @@ function getindex{T<:Real}(A::Array, I::Range{T})
 end
 
 ## Indexing: setindex! ##
-setindex!{T}(A::Array{T}, x, i0::Real) = arrayset(A, convert(T,x), to_index(i0))
+setindex!{T}(A::Array{T}, x, i::Int, I::Int...) = arrayset(A, convert(T,x), i, I...)
+unsafe_setindex!{T}(A::Array{T}, x, i::Int, I::Int...) = @inbounds return arrayset(A, convert(T,x), i, I...)
 
 # These are redundant with the abstract fallbacks but needed for bootstrap
 function setindex!(A::Array, x, I::AbstractVector{Int})

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -138,7 +138,7 @@ function append_any(xs...)
 end
 
 # simple Array{Any} operations needed for bootstrap
-setindex!(A::Array{Any}, x::ANY, i::Real) = arrayset(A, x, to_index(i))
+setindex!(A::Array{Any}, x::ANY, i::Int) = arrayset(A, x, i)
 
 function length_checked_equal(args...)
     n = length(args[1])

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -297,7 +297,6 @@ _checksize(A::AbstractArray, dim, I::AbstractVector{Bool}) = size(A, dim) == sum
 _checksize(A::AbstractArray, dim, ::Colon) = true
 _checksize(A::AbstractArray, dim, ::Real) = size(A, dim) == 1
 
-@inline unsafe_setindex!{T}(v::Array{T}, x::T, ind::Int) = (@inbounds v[ind] = x; v)
 @inline unsafe_setindex!(v::BitArray, x::Bool, ind::Int) = (Base.unsafe_bitsetindex!(v.chunks, x, ind); v)
 @inline unsafe_setindex!(v::BitArray, x, ind::Real) = (Base.unsafe_bitsetindex!(v.chunks, convert(Bool, x), to_index(ind)); v)
 


### PR DESCRIPTION
While this fixes some instances of the performance regressions, it covers up the root cause that will still exist for other array types.  I'd like to fix the root cause, which is easier to find without this commit, but I can do that locally.
