### PR TITLE
Remove unused rethrow.

### DIFF
--- a/base/pkg/resolve.jl
+++ b/base/pkg/resolve.jl
@@ -36,7 +36,6 @@ function resolve(reqs::Requires, deps::Dict{ByteString,Dict{VersionNumber,Availa
                 end
                 error(msg)
             end
-            rethrow(err)
         end
 
         # verify solution (debug code) and enforce its optimality


### PR DESCRIPTION
This line is out of reach:
- https://coveralls.io/builds/2869755/source?filename=base%2Fpkg%2Fresolve.jl#L39

``` julia
julia> function foo()
           try
               throw(UnsatError)
           catch err
               error("Exiting from foo...")
               rethrow(err)    # never runs
           end
       end
foo (generic function with 1 method)

julia> foo()
ERROR: Exiting from foo...
 in foo at none:5
```
