### PR TITLE
Replace a :: with .. doctest:: in the types.rst

### DIFF
--- a/doc/devdocs/types.rst
+++ b/doc/devdocs/types.rst
@@ -242,7 +242,8 @@ bound :obj:`TypeVar` objects with a hash (``#T`` instead of ``T``):
    julia> jl_(x) = ccall(:jl_, Void, (Any,), x)
    jl_ (generic function with 1 method)
 
-::
+.. doctest::
+
    julia> jl_(start(methods(candid)))
    Method(sig=Tuple{Array{＃T<:Any, N<:Any}, ＃T<:Any}, va=false, isstaged=false, tvars=＃T<:Any, func=＃<function>, invokes=nothing, next=nothing)
 


### PR DESCRIPTION
Previous I think it's better to merge the two code blocks into a single.
