### PR TITLE
New doc syntax

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,9 +25,8 @@ New language features
     specialize. The quoted expression it returns forms the body of the specialized
     method which is then called at run time ([#7311]).
 
-  * (Also with syntax todo) Documentation system for functions, methods, types
-    and macros in packages and user code ([#8791]). Type `?@doc` at the repl
-    to see the current syntax and more information.
+  * [Documentation system](http://docs.julialang.org/en/latest/manual/documentation/)
+    for functions, methods, types and macros in packages and user code ([#8791]).
 
   * The syntax `function foo end` can be used to introduce a generic function without
     yet adding any methods ([#8283]).

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -223,53 +223,66 @@ Base.DocBootstrap.setexpand!(docm)
 # Names are resolved relative to the DocBootstrap module, so
 # inject the ones we need there.
 
-eval(Base.DocBootstrap, :(import ..Docs: @init, doc!, doc, newmethod, def_dict))
+eval(Base.DocBootstrap,
+     :(import ..Docs: @init, doc!, doc, newmethod, def_dict, @doc_str))
 
 # Metametadata
 
-@doc """
-  The Docs module provides the `@doc` macro which can be used
-  to set and retreive documentation metadata for Julia objects.
-  Please see docs for the `@doc` macro for more info.
-  """ Docs
+"""
+The Docs module provides the `@doc` macro which can be used
+to set and retreive documentation metadata for Julia objects.
+Please see docs for the `@doc` macro for more info.
+"""
+Docs
 
-@doc """
-  # Documentation
-  The `@doc` macro can be used to both set and retrieve documentation /
-  metadata. By default, documentation is written as Markdown, but any
-  object can be placed before the arrow. For example:
+"""
+# Documentation
 
-      @doc \"""
-        # The Foo Function
-        `foo(x)`: Foo the living hell out of `x`.
-      \""" ->
-      function foo() ...
+Functions, methods and types can be documented by placing a string before the
+definition:
 
-  The `->` is not required if the object is on the same line, e.g.
+    \"""
+    # The Foo Function
+    `foo(x)`: Foo the living hell out of `x`.
+    \"""
+    foo(x) = ...
 
-      @doc "foo" foo
+The `@doc` macro can be used directly to both set and retrieve documentation /
+metadata. By default, documentation is written as Markdown, but any object can
+be placed before the arrow. For example:
 
-  # Retrieving Documentation
-  You can retrieve docs for functions, macros and other objects as
-  follows:
+    @doc "blah" ->
+    function foo() ...
 
-      @doc foo
-      @doc @time
-      @doc md""
+The `->` is not required if the object is on the same line, e.g.
 
-  # Functions & Methods
-  Placing documentation before a method definition (e.g. `function foo()
-  ...` or `foo() = ...`) will cause that specific method to be
-  documented, as opposed to the whole function. Method docs are
-  concatenated together in the order they were defined to provide docs
-  for the function.
-  """ @doc
+    @doc "foo" foo
 
-@doc "`doc(obj)`: Get the doc metadata for `obj`." doc
+# Retrieving Documentation
+You can retrieve docs for functions, macros and other objects as
+follows:
 
-@doc """
-  `catdoc(xs...)`: Combine the documentation metadata `xs` into a single meta object.
-  """ catdoc
+    @doc foo
+    @doc @time
+    @doc md""
+
+# Functions & Methods
+Placing documentation before a method definition (e.g. `function foo()
+...` or `foo() = ...`) will cause that specific method to be
+documented, as opposed to the whole function. Method docs are
+concatenated together in the order they were defined to provide docs
+for the function.
+"""
+@doc
+
+"`doc(obj)`: Get the doc metadata for `obj`."
+doc
+
+"""
+`catdoc(xs...)`: Combine the documentation metadata `xs` into a single meta
+object.
+"""
+catdoc
 
 # Text / HTML objects
 
@@ -279,7 +292,7 @@ export HTML, @html_str
 
 export HTML, Text
 
-@doc """
+"""
 `HTML(s)`: Create an object that renders `s` as html.
 
     HTML("<div>foo</div>")
@@ -289,7 +302,7 @@ You can also use a stream for large amounts of data:
     HTML() do io
       println(io, "<div>foo</div>")
     end
-""" ->
+"""
 type HTML{T}
     content::T
 end
@@ -320,7 +333,7 @@ end
 
 export Text, @text_str
 
-@doc """
+"""
 `Text(s)`: Create an object that renders `s` as plain text.
 
     Text("foo")
@@ -330,7 +343,7 @@ You can also use a stream for large amounts of data:
     Text() do io
       println(io, "foo")
     end
-""" ->
+"""
 type Text{T}
     content::T
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -369,3 +369,8 @@ combine files in packages that are broken into multiple source
 files.
 """
 include_from_node1
+
+"""
+0 (zero; BrE: `/ˈzɪərəʊ/` or AmE: `/ˈziːroʊ/`) is both a number and the numerical digit used to represent that number in numerals. It fulfills a central role in mathematics as the additive identity of the integers, real numbers, and many other algebraic structures. As a digit, 0 is used as a placeholder in place value systems. Names for the number 0 in English include zero, nought or (US) naught (`/ˈnɔːt/`), nil, or — in contexts where at least one adjacent digit distinguishes it from the letter "O" — oh or o (`/ˈoʊ/`). Informal or slang terms for zero include zilch and zip. Ought and aught (/ˈɔːt/), as well as cipher, have also been used historically.
+"""
+0

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -353,15 +353,16 @@ if Base.USE_GPL_LIBS
 
 end # USE_GPL_LIBS
 
-@doc doc"""
-      include("file.jl")
+"""
+    include("file.jl")
 
-  Evaluate the contents of a source file in the current context.
-  During including, a task-local include path is set to the directory
-  containing the file. Nested calls to `include` will search
-  relative to that path. All paths refer to files on node 1 when
-  running in parallel, and files will be fetched from node 1. This
-  function is typically used to load source interactively, or to
-  combine files in packages that are broken into multiple source
-  files.
-  """ include_from_node1
+Evaluate the contents of a source file in the current context.
+During including, a task-local include path is set to the directory
+containing the file. Nested calls to `include` will search
+relative to that path. All paths refer to files on node 1 when
+running in parallel, and files will be fetched from node 1. This
+function is typically used to load source interactively, or to
+combine files in packages that are broken into multiple source
+files.
+"""
+include_from_node1

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -286,70 +286,73 @@ keywords[:immutable] = doc"""
   See `type` and the manual for more information.
   """
 
-@doc doc"""
-  Executes an expression, printing the time it took to
-  execute and the total number of bytes its execution caused to be
-  allocated. Returns the value of the expression. For example:
+"""
+Executes an expression, printing the time it took to
+execute and the total number of bytes its execution caused to be
+allocated. Returns the value of the expression. For example:
 
-      @time begin
-        sleep(1)
-        2+2
-      end
-  """ @time
+    @time begin
+      sleep(1)
+      2+2
+    end
+"""
+@time
 
-@doc doc"""
-  Construct a regex, such as `r"^[a-z]*$"`. The regex also accepts
-  one or more flags, listed after the ending quote, to change its
-  behaviour:
+doc"""
+Construct a regex, such as `r"^[a-z]*$"`. The regex also accepts
+one or more flags, listed after the ending quote, to change its
+behaviour:
 
-    • `i` enables case-insensitive matching
-    • `m` treats the `^` and `$` tokens as matching the start and
-      and end of individual lines, as opposed to the whole string.
-    • `s` allows the `.` modifier to match newlines.
-    • `x` enables "comment mode": whitespace is enabled except when
-      escaped with `\`, and `#` is treated as starting a comment.
+  • `i` enables case-insensitive matching
+  • `m` treats the `^` and `$` tokens as matching the start and
+    and end of individual lines, as opposed to the whole string.
+  • `s` allows the `.` modifier to match newlines.
+  • `x` enables "comment mode": whitespace is enabled except when
+    escaped with `\`, and `#` is treated as starting a comment.
 
-  For example, this regex has all three flags enabled:
+For example, this regex has all three flags enabled:
 
-      julia> match(r"a+.*b+.*?d$"ism, "Goodbye,\nOh, angry,\nBad world\n")
-      RegexMatch("angry,\nBad world")
-  """ r""
+    julia> match(r"a+.*b+.*?d$"ism, "Goodbye,\nOh, angry,\nBad world\n")
+    RegexMatch("angry,\nBad world")
+"""
+r""
 
-@doc doc"""
-      push!(collection, items...) → collection
+"""
+    push!(collection, items...) → collection
 
-  Insert `items` at the end of `collection`.
+Insert `items` at the end of `collection`.
 
-      push!([1,2,3], 4) == [1,2,3,4]
-  """ push!
+    push!([1,2,3], 4) == [1,2,3,4]
+"""
+push!
 
 if Base.USE_GPL_LIBS
 
 @doc doc"""
-      fft(A[, dims])
+    fft(A[, dims])
 
-  Performs a multidimensional FFT of the array `A`.  The optional
-  `dims` argument specifies an iterable subset of dimensions (e.g.
-  an integer, range, tuple, or array) to transform along.  Most
-  efficient if the size of `A` along the transformed dimensions is
-  a product of small primes; see `nextprod()`.  See also
-  `plan_fft()` for even greater efficiency.
+Performs a multidimensional FFT of the array `A`.  The optional
+`dims` argument specifies an iterable subset of dimensions (e.g.
+an integer, range, tuple, or array) to transform along.  Most
+efficient if the size of `A` along the transformed dimensions is
+a product of small primes; see `nextprod()`.  See also
+`plan_fft()` for even greater efficiency.
 
-  A one-dimensional FFT computes the one-dimensional discrete Fourier
-  transform (DFT) as defined by
+A one-dimensional FFT computes the one-dimensional discrete Fourier
+transform (DFT) as defined by
 
-  $$\operatorname{DFT}(A)[k] =
-    \sum_{n=1}^{\operatorname{length}(A)}
-    \exp\left(-i\frac{2\pi
-    (n-1)(k-1)}{\operatorname{length}(A)} \right) A[n].$$
+$$\operatorname{DFT}(A)[k] =
+  \sum_{n=1}^{\operatorname{length}(A)}
+  \exp\left(-i\frac{2\pi
+  (n-1)(k-1)}{\operatorname{length}(A)} \right) A[n].$$
 
-  A multidimensional FFT simply performs this operation along each
-  transformed dimension of `A`.
+A multidimensional FFT simply performs this operation along each
+transformed dimension of `A`.
 
-  Higher performance is usually possible with multi-threading. Use
-  `FFTW.set_num_threads(np)` to use `np` threads, if you have `np`
-  processors.
-  """ fft
+Higher performance is usually possible with multi-threading. Use
+`FFTW.set_num_threads(np)` to use `np` threads, if you have `np`
+processors.
+""" fft
 
 end # USE_GPL_LIBS
 

--- a/base/docs/bootstrap.jl
+++ b/base/docs/bootstrap.jl
@@ -12,8 +12,8 @@ macro doc (args...)
   _expand_(args...)
 end
 
-setexpand!() do ex
-  str, obj = ex.args[1], ex.args[2]
+setexpand!() do str, obj
+  # str, obj = ex.args[1], ex.args[2]
   push!(docs, (current_module(), str, obj))
   return esc(obj)
 end

--- a/doc/manual/documentation.rst
+++ b/doc/manual/documentation.rst
@@ -9,11 +9,11 @@ other objects easily, either via the built-in documentation system in Julia 0.4
 or the `Docile.jl <http://github.com/MichaelHatherly/Docile.jl>`_ package in
 Julia 0.3.
 
+In 0.4:
+
 .. doctest::
 
-    VERSION < v"0.4-" && using Docile
-
-    @doc doc"Tells you if there are too foo items in the array." ->
+    "Tells you if there are too foo items in the array."
     foo(xs::Array) = ...
 
 Documentation is interpreted as `Markdown <http://en.wikipedia.org/wiki/Markdown>`_,
@@ -21,12 +21,12 @@ so you can use indentation and code fences to delimit code examples from text.
 
 .. doctest::
 
-    @doc doc"""
-      The `@bar` macro will probably make your code 2x faster or something. Use
-      it like this:
+    """
+    The `@bar` macro will probably make your code 2x faster or something. Use
+    it like this:
 
-          @bar buy_drink_for("Jiahao")
-      """ ->
+        @bar buy_drink_for("Jiahao")
+    """
     macro bar(ex) ...
 
 Documentation is very free-form; there are no set formatting
@@ -65,17 +65,15 @@ example:
 
 .. doctest::
 
-    @doc doc"""
-      Multiplication operator. `x*y*z*...` calls this function with multiple
-      arguments, i.e. `*(x,y,z...)`.
-      """ ->
+    """
+    Multiplication operator. `x*y*z*...` calls this function with multiple
+    arguments, i.e. `*(x,y,z...)`.
+    """
     function *(x, y)
       # ... [implementation sold seperately] ...
     end
 
-    @doc doc"""
-      When applied to strings, concatenates them.
-      """ ->
+    "When applied to strings, concatenates them."
     function *(x::String, y::String)
       # ... [insert secret sauce here] ...
     end
@@ -144,15 +142,3 @@ references) without cluttering the basic syntax.
 In principle, the Markdown parser itself can also be arbitrarily
 extended by packages, or an entirely custom flavour of Markdown can be
 used, but this should generally be unnecessary.
-
-Other Notes
------------
-
-Julia 0.4 will introduce the more convenient syntax
-
-.. doctest::
-
-    "..."
-    f(x) = ...
-
-but this is not yet implemented.

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1959,7 +1959,7 @@
   (let* ((isstr (eqv? (peek-token s) #\"))
 	 (ex    (production s)))
     (if (and (or isstr (any-string-literal? ex))
-	     (not (eof-object? (peek-token s))))
+	     (not (closing-token? (peek-token s))))
 	`(macrocall (|.| Base (quote @doc)) ,ex ,(production s))
 	ex)))
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1985,4 +1985,4 @@
          (if (eof-object? (peek-token s))
              (eof-object)
              ((if (null? production) parse-stmts (car production))
-	      s)))))
+	            s)))))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1940,6 +1940,13 @@
                               (quote ,(macroify-name (cadr (caddr e))))))
         (else (error (string "invalid macro use \"@(" (deparse e) ")\"" )))))
 
+(define (parse-docstring s production)
+  (if (eqv? (peek-token s) #\")
+    (begin
+      (take-token s)
+      `(macrocall (|.| Base (quote @doc)) ,(parse-string-literal s #t) ,(production s)))
+    (production s)))
+
 ; --- main entry point ---
 
 ;; can optionally specify which grammar production to parse.
@@ -1961,5 +1968,4 @@
                (begin (take-token s) (skip-loop (peek-token s)))))
          (if (eof-object? (peek-token s))
              (eof-object)
-             ((if (null? production) parse-stmts (car production))
-              s)))))
+             (parse-docstring s (if (null? production) parse-stmts (car production)))))))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -700,12 +700,14 @@
 
 ; the principal non-terminals follow, in increasing precedence order
 
-(define (parse-block s) (parse-Nary s parse-eq '(#\newline #\;) 'block
-                                    '(end else elseif catch finally) #t))
+(define (parse-block s (down parse-eq))
+  (parse-Nary s down '(#\newline #\;) 'block
+	      '(end else elseif catch finally) #t))
 
 ;; ";" at the top level produces a sequence of top level expressions
 (define (parse-stmts s)
-  (let ((ex (parse-Nary s parse-eq '(#\;) 'toplevel '(#\newline) #t)))
+  (let ((ex (parse-Nary s (lambda (s) (parse-docstring s parse-eq))
+			'(#\;) 'toplevel '(#\newline) #t)))
     ;; check for unparsed junk after an expression
     (let ((t (peek-token s)))
       (if (not (or (eof-object? t) (eqv? t #\newline) (eq? t #f)))
@@ -1243,7 +1245,7 @@
            `(const ,assgn))))
     ((module baremodule)
      (let* ((name (parse-unary-prefix s))
-            (body (parse-block s)))
+            (body (parse-block s (lambda (s) (parse-docstring s parse-eq)))))
        (expect-end s)
        (list 'module (eq? word 'module) name
              (if (eq? word 'module)
@@ -1940,12 +1942,26 @@
                               (quote ,(macroify-name (cadr (caddr e))))))
         (else (error (string "invalid macro use \"@(" (deparse e) ")\"" )))))
 
+(define (simple-string-literal? e)
+  (or (string? e)
+      (and (pair? e)
+	   (memq (car e) '(triple_quoted_string single_quoted_string)))))
+
+(define (any-string-literal? e)
+  (or (simple-string-literal? e)
+      (and (length= e 3) (eq? (car e) 'macrocall)
+	   (simple-string-literal? (caddr e))
+	   (let ((mname (string (cadr e))))
+	     (equal? (string.sub mname (string.dec mname (length mname) 4))
+		     "_str")))))
+
 (define (parse-docstring s production)
-  (if (eqv? (peek-token s) #\")
-    (begin
-      (take-token s)
-      `(macrocall (|.| Base (quote @doc)) ,(parse-string-literal s #t) ,(production s)))
-    (production s)))
+  (let* ((isstr (eqv? (peek-token s) #\"))
+	 (ex    (production s)))
+    (if (and (or isstr (any-string-literal? ex))
+	     (not (eof-object? (peek-token s))))
+	`(macrocall (|.| Base (quote @doc)) ,ex ,(production s))
+	ex)))
 
 ; --- main entry point ---
 
@@ -1968,4 +1984,5 @@
                (begin (take-token s) (skip-loop (peek-token s)))))
          (if (eof-object? (peek-token s))
              (eof-object)
-             (parse-docstring s (if (null? production) parse-stmts (car production)))))))
+             ((if (null? production) parse-stmts (car production))
+	      s)))))


### PR DESCRIPTION
I'm sure this implementation is far from acceptable (aesthetically and as far as the tests are concerned) but hopefully the core idea is sound. I've used the new syntax for the `include` doc string for illustration, and as you can easily verify from `Base.DocBootstrap.docs` the plain docstrings we already have are successfully stored, even before the doc system itself is in place (although we don't process these just yet).

(@Keno @ViralBShah apologies that this is four hours late)
