### PR TITLE
fix regex serialization

### DIFF
--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -71,7 +71,7 @@ function DateFormat(f::AbstractString,locale::AbstractString="english")
     for (i,k) in enumerate(s)
         k == "" && break
         tran = i >= endof(s) ? r"$" : match(Regex("(?<=$(s[i])).*(?=$(s[i+1]))"),f).match
-        slot = tran == "" || tran == r"$" ? FixedWidthSlot : DelimitedSlot
+        slot = tran == "" ? FixedWidthSlot : DelimitedSlot
         width = length(k)
         typ = 'E' in k ? DayOfWeekSlot : 'e' in k ? DayOfWeekSlot :
               'y' in k ? Year : 'm' in k ? Month :

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -249,3 +249,18 @@ function eachmatch(re::Regex, str::AbstractString, ovr::Bool=false)
 end
 
 eachmatch(re::Regex, str::AbstractString) = RegexMatchIterator(re,str)
+
+## comparison ##
+
+function ==(a::Regex, b::Regex)
+    a.pattern == b.pattern && a.compile_options == b.compile_options && a.match_options == b.match_options
+end
+
+## hash ##
+const hashre_seed = UInt === UInt64 ? 0x67e195eb8555e72d : 0xe32373e4
+function hash(r::Regex, h::UInt)
+    h += hashre_seed
+    h = hash(r.pattern, h)
+    h = hash(r.compile_options, h)
+    h = hash(r.match_options, h)
+end

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -209,7 +209,8 @@ end
 function serialize(s::SerializationState, r::Regex)
     serialize_type(s, typeof(r))
     serialize(s, r.pattern)
-    serialize(s, r.options)
+    serialize(s, r.compile_options)
+    serialize(s, r.match_options)
 end
 
 function serialize(s::SerializationState, n::BigInt)
@@ -706,8 +707,9 @@ deserialize(s::SerializationState, ::Type{BigInt}) = get(GMP.tryparse_internal(B
 
 function deserialize(s::SerializationState, t::Type{Regex})
     pattern = deserialize(s)
-    options = deserialize(s)
-    Regex(pattern, options)
+    compile_options = deserialize(s)
+    match_options = deserialize(s)
+    Regex(pattern, compile_options, match_options)
 end
 
 end

--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -292,3 +292,12 @@ create_serialization_stream() do s
     @test length(b) == 5
     @test isa(b,Vector{Any})
 end
+
+# Regex
+create_serialization_stream() do s
+    r1 = r"a?b.*"
+    serialize(s, r1)
+    seekstart(s)
+    r2 = deserialize(s)
+    @test r1 == r2
+end


### PR DESCRIPTION
This should fix serialization of `Regex` types broken by recent changes.
Also added a test, and comparison methods (required for the test).
