### PR TITLE
Support loss of .ji in lib

### DIFF
--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -23,17 +23,17 @@ end
 
 function osxInitDir()
     if imagePath()[end-1:end] == "ji"
-        return return match(r"(.*)(/julia/sys.ji)",imagePath()).captures[1];
+        return match(r"(.*)(/julia/sys.ji)",imagePath()).captures[1];
     else
-       return match(r"(.*)(/julia/sys.dylib)",imagePath()).captures[1];
+        return match(r"(.*)(/julia/sys.dylib)",imagePath()).captures[1];
     end
 end
 
 function linuxInitDir()
     if imagePath()[end-1:end] == "ji"
-        return return match(r"(.*)(/julia/sys.ji)",imagePath()).captures[1];
+        return match(r"(.*)(/julia/sys.ji)",imagePath()).captures[1];
     else
-       return match(r"(.*)(/julia/sys.so)",imagePath()).captures[1];
+        return match(r"(.*)(/julia/sys.so)",imagePath()).captures[1];
     end
 end
 

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -21,20 +21,9 @@ function includeDir()
     joinpath(match(r"(.*)(bin)",JULIA_HOME).captures[1],"include","julia");
 end
 
-function osxInitDir()
-    if imagePath()[end-1:end] == "ji"
-        return match(r"(.*)(/julia/sys.ji)",imagePath()).captures[1];
-    else
-        return match(r"(.*)(/julia/sys.dylib)",imagePath()).captures[1];
-    end
-end
-
-function linuxInitDir()
-    if imagePath()[end-1:end] == "ji"
-        return match(r"(.*)(/julia/sys.ji)",imagePath()).captures[1];
-    else
-        return match(r"(.*)(/julia/sys.so)",imagePath()).captures[1];
-    end
+function unixInitDir()
+    filePart = split(imagePath(),"/")[end]
+    return match(Regex("(.*)(/julia/$filePart)"),imagePath()).captures[1];
 end
 
 function windowsInitDir()
@@ -46,8 +35,7 @@ function windowsInitDir()
 end
 
 function initDir()
-    @osx_only return osxInitDir();
-    @linux_only return linuxInitDir();
+    @unix_only return unixInitDir();
     @windows_only return windowInitDir();
 end
 

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -21,9 +21,34 @@ function includeDir()
     joinpath(match(r"(.*)(bin)",JULIA_HOME).captures[1],"include","julia");
 end
 
+function osxInitDir()
+    if imagePath()[end-1:end] == "ji"
+        return return match(r"(.*)(/julia/sys.ji)",imagePath()).captures[1];
+    else
+       return match(r"(.*)(/julia/sys.dylib)",imagePath()).captures[1];
+    end
+end
+
+function linuxInitDir()
+    if imagePath()[end-1:end] == "ji"
+        return return match(r"(.*)(/julia/sys.ji)",imagePath()).captures[1];
+    else
+       return match(r"(.*)(/julia/sys.so)",imagePath()).captures[1];
+    end
+end
+
+function windowsInitDir()
+    if imagePath()[end-1:end] == "ji"
+        return match(r"(.*)(\\julia\\sys.ji)",imagePath()).captures[1];
+    else
+        return match(r"(.*)(\\julia\\sys.dll)",imagePath()).captures[1];
+    end
+end
+
 function initDir()
-    @unix_only return match(r"(.*)(/julia/sys.ji)",imagePath()).captures[1];
-    @windows_only return match(r"(.*)(\\julia\\sys.ji)",imagePath()).captures[1];
+    @osx_only return osxInitDir();
+    @linux_only return linuxInitDir();
+    @windows_only return windowInitDir();
 end
 
 function ldflags()


### PR DESCRIPTION
A fix in julia-config that doesn't assume that sys.ji must exist.  Backward compatible 
