### PR TITLE
Fix Emacs 23 error.

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -278,14 +278,15 @@ Based on `python-syntax-stringify'."
         (put-text-property string-start-pos (1+ string-start-pos)
                            'syntax-table (string-to-syntax "|"))))))
 
-(defconst julia-syntax-propertize-function
-  (syntax-propertize-rules
-   ("\"\"\""
-    (0 (ignore (julia-stringify-triple-quote))))
-   (julia-char-regex
-    (1 "\"") ; Treat ' as a string delimiter.
-    (2 ".") ; Don't highlight anything between.
-    (3 "\"")))) ; Treat the last " in """ as a string delimiter.
+(unless (< emacs-major-version 24)
+  (defconst julia-syntax-propertize-function
+    (syntax-propertize-rules
+     ("\"\"\""
+      (0 (ignore (julia-stringify-triple-quote))))
+     (julia-char-regex
+      (1 "\"") ; Treat ' as a string delimiter.
+      (2 ".") ; Don't highlight anything between.
+      (3 "\""))))) ; Treat the last " in """ as a string delimiter.
 
 (defun julia-in-comment ()
   "Return non-nil if point is inside a comment.


### PR DESCRIPTION
This constant is only used in Emacs 24+, and `syntax-propertize-rules`
is not defined in Emacs 23.

Fixes the issue seen by @simonp0420 [here](https://github.com/JuliaLang/julia/commit/6c76548878fccc68a90c87dfda618224fe1bf0b5).
