### PR TITLE
Only call cholmod_start when CHOLMOD module is initiazed to avoid memory leaks

### DIFF
--- a/base/sparse/spqr.jl
+++ b/base/sparse/spqr.jl
@@ -45,23 +45,23 @@ import Base.SparseMatrix.CHOLMOD: convert, free!
 
 
 
-immutable C_Factorization{Tv<:VTypes,Ti<:ITypes}
+immutable C_Factorization{Tv<:VTypes}
     xtype::Cint
     factors::Ptr{Tv}
 end
 
-type Factorization{Tv<:VTypes,Ti<:ITypes} <: Base.LinAlg.Factorization{Tv}
+type Factorization{Tv<:VTypes} <: Base.LinAlg.Factorization{Tv}
     m::Int
     n::Int
-    p::Ptr{C_Factorization{Tv,Ti}}
-    function Factorization(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv,Ti}})
+    p::Ptr{C_Factorization{Tv}}
+    function Factorization(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}})
         if p == C_NULL
             throw(ArgumentError("factorization failed for unknown reasons. Please submit a bug report."))
         end
         new(m, n, p)
     end
 end
-Factorization{Tv<:VTypes,Ti<:ITypes}(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv,Ti}}) = Factorization{Tv,Ti}(m, n, p)
+Factorization{Tv<:VTypes}(m::Integer, n::Integer, p::Ptr{C_Factorization{Tv}}) = Factorization{Tv}(m, n, p)
 
 size(F::Factorization) = (F.m, F.n)
 function size(F::Factorization, i::Integer)
@@ -76,37 +76,37 @@ function size(F::Factorization, i::Integer)
     return 1
 end
 
-function free!{Tv<:VTypes,Ti<:ITypes}(F::Factorization{Tv,Ti})
+function free!{Tv<:VTypes}(F::Factorization{Tv})
     ccall((:SuiteSparseQR_C_free, :libspqr), Cint,
-        (Ptr{Ptr{C_Factorization{Tv,Ti}}}, Ptr{Void}),
-            &F.p, common(Ti)) == 1
+        (Ptr{Ptr{C_Factorization{Tv}}}, Ptr{Void}),
+            &F.p, common()) == 1
 end
 
-function backslash{Tv<:VTypes,Ti<:ITypes}(ordering::Integer, tol::Real, A::Sparse{Tv,Ti}, B::Dense{Tv})
+function backslash{Tv<:VTypes}(ordering::Integer, tol::Real, A::Sparse{Tv}, B::Dense{Tv})
     m, n  = size(A)
     if m != size(B, 1)
         throw(DimensionMismatch("left hand side and right hand side must have same number of rows"))
     end
     d = Dense(ccall((:SuiteSparseQR_C_backslash, :libspqr), Ptr{C_Dense{Tv}},
-        (Cint, Cdouble, Ptr{C_Sparse{Tv,Ti}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
-            ordering, tol, A.p, B.p, common(Ti)))
+        (Cint, Cdouble, Ptr{C_Sparse{Tv}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
+            ordering, tol, A.p, B.p, common()))
     finalizer(d, free!)
     d
 end
 
-function factorize{Tv<:VTypes,Ti<:ITypes}(ordering::Integer, tol::Real, A::Sparse{Tv,Ti})
+function factorize{Tv<:VTypes}(ordering::Integer, tol::Real, A::Sparse{Tv})
     s = unsafe_load(A.p)
     if s.stype != 0
         throw(ArgumentError("stype must be zero"))
     end
-    f = Factorization(size(A)..., ccall((:SuiteSparseQR_C_factorize, :libspqr), Ptr{C_Factorization{Tv,Ti}},
-        (Cint, Cdouble, Ptr{Sparse{Tv,Ti}}, Ptr{Void}),
-            ordering, tol, A.p, common(Ti)))
+    f = Factorization(size(A)..., ccall((:SuiteSparseQR_C_factorize, :libspqr), Ptr{C_Factorization{Tv}},
+        (Cint, Cdouble, Ptr{Sparse{Tv}}, Ptr{Void}),
+            ordering, tol, A.p, common()))
     finalizer(f, free!)
     f
 end
 
-function solve{Tv<:VTypes,Ti<:ITypes}(system::Integer, QR::Factorization{Tv,Ti}, B::Dense{Tv})
+function solve{Tv<:VTypes}(system::Integer, QR::Factorization{Tv}, B::Dense{Tv})
     m, n = size(QR)
     mB = size(B, 1)
     if (system == RX_EQUALS_B || system == RETX_EQUALS_B) && m != mB
@@ -115,13 +115,13 @@ function solve{Tv<:VTypes,Ti<:ITypes}(system::Integer, QR::Factorization{Tv,Ti},
         throw(DimensionMismatch("number of columns in factorized matrix must equal number of rows in right hand side"))
     end
     d = Dense(ccall((:SuiteSparseQR_C_solve, :libspqr), Ptr{C_Dense{Tv}},
-        (Cint, Ptr{C_Factorization{Tv,Ti}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
-            system, QR.p, B.p, common(Ti)))
+        (Cint, Ptr{C_Factorization{Tv}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
+            system, QR.p, B.p, common()))
     finalizer(d, free!)
     d
 end
 
-function qmult{Tv<:VTypes,Ti<:ITypes}(method::Integer, QR::Factorization{Tv,Ti}, X::Dense{Tv})
+function qmult{Tv<:VTypes}(method::Integer, QR::Factorization{Tv}, X::Dense{Tv})
     mQR, nQR = size(QR)
     mX, nX = size(X)
     if (method == QTX || method == QX) && mQR != mX
@@ -130,8 +130,8 @@ function qmult{Tv<:VTypes,Ti<:ITypes}(method::Integer, QR::Factorization{Tv,Ti},
         throw(DimensionMismatch("Q matrix size $mQR and dense matrix has $nX columns"))
     end
     d = Dense(ccall((:SuiteSparseQR_C_qmult, :libspqr), Ptr{C_Dense{Tv}},
-            (Cint, Ptr{C_Factorization{Tv,Ti}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
-                method, QR.p, X.p, common(Ti)))
+            (Cint, Ptr{C_Factorization{Tv}}, Ptr{C_Dense{Tv}}, Ptr{Void}),
+                method, QR.p, X.p, common()))
     finalizer(d, free!)
     d
 end

--- a/test/sparsedir/cholmod.jl
+++ b/test/sparsedir/cholmod.jl
@@ -37,59 +37,64 @@ using Base.SparseMatrix.CHOLMOD
 ## rcond     9.5e-06
 
 A = CHOLMOD.Sparse(48, 48,
-            Int32[0,1,2,3,6,9,12,15,18,20,25,30,34,36,39,43,47,52,58,62,67,71,77,84,90,93,95,
-                  98,103,106,110,115,119,123,130,136,142,146,150,155,161,167,174,182,189,197,
-                  207,215,224], # zero-based column pointers
-            Int32[0,1,2,1,2,3,0,2,4,0,1,5,0,4,6,1,3,7,2,8,1,3,7,8,9,0,4,6,8,10,5,6,7,11,6,12,
-                  7,11,13,8,10,13,14,9,13,14,15,8,10,12,14,16,7,11,12,13,16,17,0,12,16,18,1,
-                  5,13,15,19,2,4,14,20,3,13,15,19,20,21,2,4,12,16,18,20,22,1,5,17,18,19,23,0,
-                  5,24,1,25,2,3,26,2,3,25,26,27,4,24,28,0,5,24,29,6,11,24,28,30,7,25,27,31,8,
-                  9,26,32,8,9,25,27,31,32,33,10,24,28,30,32,34,6,11,29,30,31,35,12,17,30,36,
-                  13,31,35,37,14,15,32,34,38,14,15,33,37,38,39,16,32,34,36,38,40,12,17,31,35,
-                  36,37,41,12,16,17,18,23,36,40,42,13,14,15,19,37,39,43,13,14,15,20,21,38,43,
-                  44,13,14,15,20,21,37,39,43,44,45,12,16,17,22,36,40,42,46,12,16,17,18,23,41,
-                  42,46,47],
-                 [2.83226851852e6,1.63544753086e6,1.72436728395e6,-2.0e6,-2.08333333333e6,
-                  1.00333333333e9,1.0e6, -2.77777777778e6,1.0675e9,2.08333333333e6,
-                  5.55555555555e6,1.53533333333e9,-3333.33333333,-1.0e6,2.83226851852e6,
-                  -6666.66666667,2.0e6,1.63544753086e6,-1.68e6,1.72436728395e6,-2.0e6,4.0e8,2.0e6,
-                  -2.08333333333e6,1.00333333333e9,1.0e6,2.0e8,-1.0e6,-2.77777777778e6,1.0675e9,
-                  -2.0e6,2.08333333333e6,5.55555555555e6,1.53533333333e9,-2.8e6,2.8360994695e6,
-                  -30864.1975309,-5.55555555555e6,1.76741074446e6,-15432.0987654,2.77777777778e6,
-                  517922.131816,3.89003806848e6,-3.33333333333e6,4.29857058902e6,-2.6349902747e6,
-                  1.97572063531e9,-2.77777777778e6,3.33333333333e8,-2.14928529451e6,
-                  2.77777777778e6,1.52734651547e9,5.55555555555e6,6.66666666667e8,2.35916180402e6,
-                  -5.55555555555e6,-1.09779731332e8,1.56411143711e9,-2.8e6,-3333.33333333,1.0e6,
-                  2.83226851852e6,-30864.1975309,-5.55555555555e6,-6666.66666667,-2.0e6,
-                  1.63544753086e6,-15432.0987654,2.77777777778e6,-1.68e6,1.72436728395e6,
-                  -3.33333333333e6,2.0e6,4.0e8,-2.0e6,-2.08333333333e6,1.00333333333e9,
-                  -2.77777777778e6,3.33333333333e8,-1.0e6,2.0e8,1.0e6,2.77777777778e6,1.0675e9,
-                  5.55555555555e6,6.66666666667e8,-2.0e6,2.08333333333e6,-5.55555555555e6,
-                  1.53533333333e9,-28935.1851852,-2.08333333333e6,60879.6296296,-1.59791666667e6,
-                  3.37291666667e6,-28935.1851852,2.08333333333e6,2.41171296296e6,-2.08333333333e6,
-                  1.0e8,-2.5e6,-416666.666667,1.5e9,-833333.333333,1.25e6,5.01833333333e8,
-                  2.08333333333e6,1.0e8,416666.666667,5.025e8,-28935.1851852,-2.08333333333e6,
-                  -4166.66666667,-1.25e6,3.98587962963e6,-1.59791666667e6,-8333.33333333,2.5e6,
-                  3.41149691358e6,-28935.1851852,2.08333333333e6,-2.355e6,2.43100308642e6,
-                  -2.08333333333e6,1.0e8,-2.5e6,5.0e8,2.5e6,-416666.666667,1.50416666667e9,
-                  -833333.333333,1.25e6,2.5e8,-1.25e6,-3.47222222222e6,1.33516666667e9,
-                  2.08333333333e6,1.0e8,-2.5e6,416666.666667,6.94444444444e6,2.16916666667e9,
-                  -28935.1851852,-2.08333333333e6,-3.925e6,3.98587962963e6,-1.59791666667e6,
-                  -38580.2469136,-6.94444444444e6,3.41149691358e6,-28935.1851852,2.08333333333e6,
-                  -19290.1234568,3.47222222222e6,2.43100308642e6,-2.08333333333e6,1.0e8,
-                  -4.16666666667e6,2.5e6,-416666.666667,1.50416666667e9,-833333.333333,
-                  -3.47222222222e6,4.16666666667e8,-1.25e6,3.47222222222e6,1.33516666667e9,
-                  2.08333333333e6,1.0e8,6.94444444445e6,8.33333333333e8,416666.666667,
-                  -6.94444444445e6,2.16916666667e9,-3830.95098171,1.14928529451e6,-275828.470683,
-                  -28935.1851852,-2.08333333333e6,-4166.66666667,1.25e6,64710.5806113,
-                  -131963.213599,-517922.131816,-2.29857058902e6,-1.59791666667e6,-8333.33333333,
-                  -2.5e6,3.50487988027e6,-517922.131816,-2.16567078453e6,551656.941366,
-                  -28935.1851852,2.08333333333e6,-2.355e6,517922.131816,4.57738374749e6,
-                  2.29857058902e6,-551656.941367,4.8619365099e8,-2.08333333333e6,1.0e8,2.5e6,
-                  5.0e8,-4.79857058902e6,134990.2747,2.47238730198e9,-1.14928529451e6,
-                  2.29724661236e8,-5.57173510779e7,-833333.333333,-1.25e6,2.5e8,2.39928529451e6,
-                  9.61679848804e8,275828.470683,-5.57173510779e7,1.09411960038e7,2.08333333333e6,
-                  1.0e8,-2.5e6,140838.195984,-1.09779731332e8,5.31278103775e8], 1)
+    CHOLMOD.SuiteSparse_long[0,1,2,3,6,9,12,15,18,20,25,30,34,36,39,43,47,52,58,
+    62,67,71,77,84,90,93,95,98,103,106,110,115,119,123,130,136,142,146,150,155,
+    161,167,174,182,189,197,207,215,224], # zero-based column pointers
+    CHOLMOD.SuiteSparse_long[0,1,2,1,2,3,0,2,4,0,1,5,0,4,6,1,3,7,2,8,1,3,7,8,9,
+    0,4,6,8,10,5,6,7,11,6,12,7,11,13,8,10,13,14,9,13,14,15,8,10,12,14,16,7,11,
+    12,13,16,17,0,12,16,18,1,5,13,15,19,2,4,14,20,3,13,15,19,20,21,2,4,12,16,18,
+    20,22,1,5,17,18,19,23,0,5,24,1,25,2,3,26,2,3,25,26,27,4,24,28,0,5,24,29,6,
+    11,24,28,30,7,25,27,31,8,9,26,32,8,9,25,27,31,32,33,10,24,28,30,32,34,6,11,
+    29,30,31,35,12,17,30,36,13,31,35,37,14,15,32,34,38,14,15,33,37,38,39,16,32,
+    34,36,38,40,12,17,31,35,36,37,41,12,16,17,18,23,36,40,42,13,14,15,19,37,39,
+    43,13,14,15,20,21,38,43,44,13,14,15,20,21,37,39,43,44,45,12,16,17,22,36,40,
+    42,46,12,16,17,18,23,41,42,46,47],
+    [2.83226851852e6,1.63544753086e6,1.72436728395e6,-2.0e6,-2.08333333333e6,
+    1.00333333333e9,1.0e6,-2.77777777778e6,1.0675e9,2.08333333333e6,
+    5.55555555555e6,1.53533333333e9,-3333.33333333,-1.0e6,2.83226851852e6,
+    -6666.66666667,2.0e6,1.63544753086e6,-1.68e6,1.72436728395e6,-2.0e6,4.0e8,
+    2.0e6,-2.08333333333e6,1.00333333333e9,1.0e6,2.0e8,-1.0e6,-2.77777777778e6,
+    1.0675e9,-2.0e6,2.08333333333e6,5.55555555555e6,1.53533333333e9,-2.8e6,
+    2.8360994695e6,-30864.1975309,-5.55555555555e6,1.76741074446e6,
+    -15432.0987654,2.77777777778e6,517922.131816,3.89003806848e6,
+    -3.33333333333e6,4.29857058902e6,-2.6349902747e6,1.97572063531e9,
+    -2.77777777778e6,3.33333333333e8,-2.14928529451e6,2.77777777778e6,
+    1.52734651547e9,5.55555555555e6,6.66666666667e8,2.35916180402e6,
+    -5.55555555555e6,-1.09779731332e8,1.56411143711e9,-2.8e6,-3333.33333333,
+    1.0e6,2.83226851852e6,-30864.1975309,-5.55555555555e6,-6666.66666667,
+    -2.0e6,1.63544753086e6,-15432.0987654,2.77777777778e6,-1.68e6,
+    1.72436728395e6,-3.33333333333e6,2.0e6,4.0e8,-2.0e6,-2.08333333333e6,
+    1.00333333333e9,-2.77777777778e6,3.33333333333e8,-1.0e6,2.0e8,1.0e6,
+    2.77777777778e6,1.0675e9,5.55555555555e6,6.66666666667e8,-2.0e6,
+    2.08333333333e6,-5.55555555555e6,1.53533333333e9,-28935.1851852,
+    -2.08333333333e6,60879.6296296,-1.59791666667e6,3.37291666667e6,
+    -28935.1851852,2.08333333333e6,2.41171296296e6,-2.08333333333e6,
+    1.0e8,-2.5e6,-416666.666667,1.5e9,-833333.333333,1.25e6,5.01833333333e8,
+    2.08333333333e6,1.0e8,416666.666667,5.025e8,-28935.1851852,
+    -2.08333333333e6,-4166.66666667,-1.25e6,3.98587962963e6,-1.59791666667e6,
+    -8333.33333333,2.5e6,3.41149691358e6,-28935.1851852,2.08333333333e6,
+    -2.355e6,2.43100308642e6,-2.08333333333e6,1.0e8,-2.5e6,5.0e8,2.5e6,
+    -416666.666667,1.50416666667e9,-833333.333333,1.25e6,2.5e8,-1.25e6,
+    -3.47222222222e6,1.33516666667e9,2.08333333333e6,1.0e8,-2.5e6,
+    416666.666667,6.94444444444e6,2.16916666667e9,-28935.1851852,
+    -2.08333333333e6,-3.925e6,3.98587962963e6,-1.59791666667e6,
+    -38580.2469136,-6.94444444444e6,3.41149691358e6,-28935.1851852,
+    2.08333333333e6,-19290.1234568,3.47222222222e6,2.43100308642e6,
+    -2.08333333333e6,1.0e8,-4.16666666667e6,2.5e6,-416666.666667,
+    1.50416666667e9,-833333.333333,-3.47222222222e6,4.16666666667e8,
+    -1.25e6,3.47222222222e6,1.33516666667e9,2.08333333333e6,1.0e8,
+    6.94444444445e6,8.33333333333e8,416666.666667,-6.94444444445e6,
+    2.16916666667e9,-3830.95098171,1.14928529451e6,-275828.470683,
+    -28935.1851852,-2.08333333333e6,-4166.66666667,1.25e6,64710.5806113,
+    -131963.213599,-517922.131816,-2.29857058902e6,-1.59791666667e6,
+    -8333.33333333,-2.5e6,3.50487988027e6,-517922.131816,-2.16567078453e6,
+    551656.941366,-28935.1851852,2.08333333333e6,-2.355e6,517922.131816,
+    4.57738374749e6,2.29857058902e6,-551656.941367,4.8619365099e8,
+    -2.08333333333e6,1.0e8,2.5e6,5.0e8,-4.79857058902e6,134990.2747,
+    2.47238730198e9,-1.14928529451e6,2.29724661236e8,-5.57173510779e7,
+    -833333.333333,-1.25e6,2.5e8,2.39928529451e6,9.61679848804e8,275828.470683,
+    -5.57173510779e7,1.09411960038e7,2.08333333333e6,1.0e8,-2.5e6,
+    140838.195984,-1.09779731332e8,5.31278103775e8], 1)
 @test_approx_eq CHOLMOD.norm_sparse(A, 0) 3.570948074697437e9
 @test_approx_eq CHOLMOD.norm_sparse(A, 1) 3.570948074697437e9
 @test_throws ArgumentError CHOLMOD.norm_sparse(A, 2)
@@ -113,21 +118,21 @@ x = chma\B
 
 #lp_afiro example
 afiro = CHOLMOD.Sparse(27, 51,
-            Int32[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,23,25,27,29,33,37,
-                  41,45,47,49,51,53,55,57,59,63,65,67,69,71,75,79,83,87,89,91,93,95,97,
-                  99,101,102],
-            Int32[2,3,6,7,8,9,12,13,16,17,18,19,20,21,22,23,24,25,26,0,1,2,23,0,3,0,21,
-                  1,25,4,5,6,24,4,5,7,24,4,5,8,24,4,5,9,24,6,20,7,20,8,20,9,20,3,4,4,22,
-                  5,26,10,11,12,21,10,13,10,23,10,20,11,25,14,15,16,22,14,15,17,22,14,
-                  15,18,22,14,15,19,22,16,20,17,20,18,20,19,20,13,15,15,24,14,26,15],
-                     [1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,
-                      -1.0,-1.06,1.0,0.301,1.0,-1.0,1.0,-1.0,1.0,1.0,-1.0,-1.06,1.0,0.301,-1.0,
-                      -1.06,1.0,0.313,-1.0,-0.96,1.0,0.313,-1.0,-0.86,1.0,0.326,-1.0,2.364,-1.0,
-                      2.386,-1.0,2.408,-1.0,2.429,1.4,1.0,1.0,-1.0,1.0,1.0,-1.0,-0.43,1.0,0.109,
-                      1.0,-1.0,1.0,-1.0,1.0,-1.0,1.0,1.0,-0.43,1.0,1.0,0.109,-0.43,1.0,1.0,0.108,
-                      -0.39,1.0,1.0,0.108,-0.37,1.0,1.0,0.107,-1.0,2.191,-1.0,2.219,-1.0,2.249,
-                      -1.0,2.279,1.4,-1.0,1.0,-1.0,1.0,1.0,1.0], 0)
-afiro2 = CHOLMOD.aat(afiro, Int32[0:50;], Int32(1))
+    CHOLMOD.SuiteSparse_long[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,
+    23,25,27,29,33,37,41,45,47,49,51,53,55,57,59,63,65,67,69,71,75,79,83,87,89,
+    91,93,95,97,99,101,102],
+    CHOLMOD.SuiteSparse_long[2,3,6,7,8,9,12,13,16,17,18,19,20,21,22,23,24,25,26,
+    0,1,2,23,0,3,0,21,1,25,4,5,6,24,4,5,7,24,4,5,8,24,4,5,9,24,6,20,7,20,8,20,9,
+    20,3,4,4,22,5,26,10,11,12,21,10,13,10,23,10,20,11,25,14,15,16,22,14,15,17,
+    22,14,15,18,22,14,15,19,22,16,20,17,20,18,20,19,20,13,15,15,24,14,26,15],
+    [1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,
+    1.0,-1.0,-1.06,1.0,0.301,1.0,-1.0,1.0,-1.0,1.0,1.0,-1.0,-1.06,1.0,0.301,
+    -1.0,-1.06,1.0,0.313,-1.0,-0.96,1.0,0.313,-1.0,-0.86,1.0,0.326,-1.0,2.364,
+    -1.0,2.386,-1.0,2.408,-1.0,2.429,1.4,1.0,1.0,-1.0,1.0,1.0,-1.0,-0.43,1.0,
+    0.109,1.0,-1.0,1.0,-1.0,1.0,-1.0,1.0,1.0,-0.43,1.0,1.0,0.109,-0.43,1.0,1.0,
+    0.108,-0.39,1.0,1.0,0.108,-0.37,1.0,1.0,0.107,-1.0,2.191,-1.0,2.219,-1.0,
+    2.249,-1.0,2.279,1.4,-1.0,1.0,-1.0,1.0,1.0,1.0], 0)
+afiro2 = CHOLMOD.aat(afiro, CHOLMOD.SuiteSparse_long[0:50;], CHOLMOD.SuiteSparse_long(1))
 CHOLMOD.change_stype!(afiro2, -1)
 chmaf = cholfact(afiro2)
 y = afiro'*ones(size(afiro,1))
@@ -185,10 +190,6 @@ ACSC = sprandn(10, 10, 0.3) + I
 @test ishermitian(Sparse(Hermitian(complex(ACSC), :L)))
 @test ishermitian(Sparse(Hermitian(complex(ACSC), :U)))
 
-# test Sparse constructor for c_Sparse{Tv,Ti} input( and Sparse*Sparse)
-B = CHOLMOD.Sparse(SparseMatrixCSC{Float64,Int32}(sprandn(48, 48, 0.1))) # A has Int32 indices
-@test_approx_eq A*B sparse(A)*sparse(B)
-
 # test Sparse constructor for c_SparseVoid (and read_sparse)
 let testfile = joinpath(tempdir(), "tmp.mtx")
     try
@@ -217,14 +218,14 @@ let testfile = joinpath(tempdir(), "tmp.mtx")
 end
 
 # test that Sparse(Ptr) constructor throws the right places
-@test_throws ArgumentError CHOLMOD.Sparse(convert(Ptr{CHOLMOD.C_Sparse{Float64,CHOLMOD.SuiteSparse_long}}, C_NULL))
+@test_throws ArgumentError CHOLMOD.Sparse(convert(Ptr{CHOLMOD.C_Sparse{Float64}}, C_NULL))
 @test_throws ArgumentError CHOLMOD.Sparse(convert(Ptr{CHOLMOD.C_SparseVoid}, C_NULL))
 
 ## The struct pointer must be constructed by the library constructor and then modified afterwards to checks that the method throws
 ### illegal dtype (for now but should be supported at some point)
 p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(CHOLMOD.SuiteSparse_long))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 puint = convert(Ptr{Uint32}, p)
 unsafe_store!(puint, CHOLMOD.SINGLE, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) + 4)
 @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
@@ -232,7 +233,7 @@ unsafe_store!(puint, CHOLMOD.SINGLE, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Pt
 ### illegal dtype
 p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(CHOLMOD.SuiteSparse_long))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 puint = convert(Ptr{Uint32}, p)
 unsafe_store!(puint, 5, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) + 4)
 @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
@@ -240,7 +241,7 @@ unsafe_store!(puint, 5, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) 
 ### illegal xtype
 p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(CHOLMOD.SuiteSparse_long))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 puint = convert(Ptr{Uint32}, p)
 unsafe_store!(puint, 3, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) + 3)
 @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
@@ -248,7 +249,7 @@ unsafe_store!(puint, 3, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) 
 ### illegal itype
 p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(CHOLMOD.SuiteSparse_long))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 puint = convert(Ptr{Uint32}, p)
 unsafe_store!(puint, CHOLMOD.INTLONG, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) + 2)
 @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
@@ -256,18 +257,10 @@ unsafe_store!(puint, CHOLMOD.INTLONG, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(P
 ### illegal itype
 p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(CHOLMOD.SuiteSparse_long))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 puint = convert(Ptr{Uint32}, p)
 unsafe_store!(puint,  5, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4) + 2)
 @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
-
-# test that Sparse(Ptr) works for SuiteSparse_long (on 64 bit systems)
-if CHOLMOD.SuiteSparse_long == Int64
-    p = ccall((:cholmod_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_SparseVoid},
-        (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-        1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(Int32))
-    @test isa(CHOLMOD.Sparse(p), CHOLMOD.Sparse{Float64,Int32})
-end
 
 # Test Dense wrappers (only Float64 supported a present)
 
@@ -311,9 +304,9 @@ end
 
 # Test Sparse and Factor
 ## test free_sparse!
-p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_Sparse{Float64,Cint}},
+p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_Sparse{Float64}},
     (Csize_t, Csize_t, Csize_t, Cint, Cint, Cint, Cint, Ptr{Void}),
-    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common(Int))
+    1, 1, 1, true, true, 0, CHOLMOD.REAL, CHOLMOD.common())
 @test CHOLMOD.free_sparse!(p)
 
 for elty in (Float64, Complex{Float64})
@@ -376,7 +369,7 @@ for elty in (Float64, Complex{Float64})
     tmp = IOBuffer()
     show(tmp, F)
     @test tmp.size > 0
-    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty, CHOLMOD.SuiteSparse_long})
+    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty})
     @test_approx_eq F\CHOLMOD.Sparse(sparse(ones(elty, 5))) A1pd\ones(5)
     @test_throws DimensionMismatch F\CHOLMOD.Dense(ones(elty, 4))
     @test_throws DimensionMismatch F\CHOLMOD.Sparse(sparse(ones(elty, 4)))
@@ -393,21 +386,29 @@ for elty in (Float64, Complex{Float64})
     @test isposdef(A1pd)
     @test !isposdef(A1)
     @test !isposdef(A1 + A1' |> t -> t - 2eigmax(full(t))*I)
+
     if elty <: Real
         @test CHOLMOD.issym(Sparse(A1pd, 0))
         @test CHOLMOD.Sparse(cholfact(Symmetric(A1pd, :L))) == CHOLMOD.Sparse(cholfact(A1pd))
-        @test CHOLMOD.Sparse(cholfact(Symmetric(A1pd, :L), shift=2)) == CHOLMOD.Sparse(cholfact(A1pd, shift=2))
+        F1 = CHOLMOD.Sparse(cholfact(Symmetric(A1pd, :L), shift=2))
+        F2 = CHOLMOD.Sparse(cholfact(A1pd, shift=2))
+        @test F1 == F2
         @test CHOLMOD.Sparse(ldltfact(Symmetric(A1pd, :L))) == CHOLMOD.Sparse(ldltfact(A1pd))
-        @test CHOLMOD.Sparse(ldltfact(Symmetric(A1pd, :L), shift=2)) == CHOLMOD.Sparse(ldltfact(A1pd, shift=2))
+        F1 = CHOLMOD.Sparse(ldltfact(Symmetric(A1pd, :L), shift=2))
+        F2 = CHOLMOD.Sparse(ldltfact(A1pd, shift=2))
+        @test F1 == F2
     else
         @test !CHOLMOD.issym(Sparse(A1pd, 0))
         @test CHOLMOD.ishermitian(Sparse(A1pd, 0))
         @test CHOLMOD.Sparse(cholfact(Hermitian(A1pd, :L))) == CHOLMOD.Sparse(cholfact(A1pd))
-        @test CHOLMOD.Sparse(cholfact(Hermitian(A1pd, :L), shift=2)) == CHOLMOD.Sparse(cholfact(A1pd, shift=2))
+        F1 = CHOLMOD.Sparse(cholfact(Hermitian(A1pd, :L), shift=2))
+        F2 = CHOLMOD.Sparse(cholfact(A1pd, shift=2))
+        @test F1 == F2
         @test CHOLMOD.Sparse(ldltfact(Hermitian(A1pd, :L))) == CHOLMOD.Sparse(ldltfact(A1pd))
-        @test CHOLMOD.Sparse(ldltfact(Hermitian(A1pd, :L), shift=2)) == CHOLMOD.Sparse(ldltfact(A1pd, shift=2))
+        F1 = CHOLMOD.Sparse(ldltfact(Hermitian(A1pd, :L), shift=2))
+        F2 = CHOLMOD.Sparse(ldltfact(A1pd, shift=2))
+        @test F1 == F2
     end
-
 
     ### update!
     F = cholfact(A1pd)
@@ -420,15 +421,15 @@ for elty in (Float64, Complex{Float64})
     @test_throws ArgumentError size(F, 0)
 
     F = cholfact(A1pdSparse, shift=2)
-    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty, CHOLMOD.SuiteSparse_long})
+    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty})
     @test_approx_eq CHOLMOD.Sparse(CHOLMOD.update!(copy(F), A1pd, shift=2.0)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
 
     F = ldltfact(A1pd)
-    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty, CHOLMOD.SuiteSparse_long})
+    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty})
     @test_approx_eq CHOLMOD.Sparse(CHOLMOD.update!(copy(F), A1pd)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
 
     F = ldltfact(A1pdSparse, shift=2)
-    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty, CHOLMOD.SuiteSparse_long})
+    @test isa(CHOLMOD.Sparse(F), CHOLMOD.Sparse{elty})
     @test_approx_eq CHOLMOD.Sparse(CHOLMOD.update!(copy(F), A1pd, shift=2.0)) CHOLMOD.Sparse(F) # surprisingly, this can cause small ulp size changes so we cannot test exact equality
 
     @test isa(CHOLMOD.factor_to_sparse!(F), CHOLMOD.Sparse)
@@ -469,7 +470,6 @@ for elty in (Float64, Complex{Float64})
 
     @test CHOLMOD.Sparse(CHOLMOD.Dense(A1Sparse)) == A1Sparse
 end
-
 
 Af = float([4 12 -16; 12 37 -43; -16 -43 98])
 As = sparse(Af)

--- a/test/sparsedir/spqr.jl
+++ b/test/sparsedir/spqr.jl
@@ -29,7 +29,7 @@ for eltyA in (Float64, Complex{Float64})
         if eltyA == eltyB # promotions not defined for unexported methods
             @test qrfact(sparse(eye(eltyA, 5)))\ones(eltyA, 5) == ones(5)
             @test_throws ArgumentError SPQR.factorize(SPQR.ORDERING_DEFAULT, SPQR.DEFAULT_TOL, CHOLMOD.Sparse(sparse(eye(eltyA, 5))))
-            @test_throws ArgumentError SPQR.Factorization(1, 1, convert(Ptr{SPQR.C_Factorization{eltyA, CHOLMOD.SuiteSparse_long}}, C_NULL))
+            @test_throws ArgumentError SPQR.Factorization(1, 1, convert(Ptr{SPQR.C_Factorization{eltyA}}, C_NULL))
             F = qrfact(A)
             @test size(F) == (m,n)
             @test size(F, 1) == m


### PR DESCRIPTION
In consequence, introduce global common array and restrict all method to SuiteSparse_long.

Adjust CHOLMOD tests

Reopening this PR to get some AppVeyor builds to monitor the test error.
