### PR TITLE
changed runtests.jl default test to test default runtests.jl changed

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -130,8 +130,13 @@ function tests(pkg::AbstractString; force::Bool=false)
         using $pkg
         using Base.Test
 
-        # write your own tests here
-        @test 1 == 1
+        function still_using_default_tests()
+            testtext = readall(Base.source_path())
+            testtext = testtext[max(1, findfirst(testtext, '\\n')):end]
+            hash(testtext) & 67108863 == 61878686
+        end
+
+        @test !still_using_default_tests()
         """)
     end
 end


### PR DESCRIPTION
This changed the default test file made by `Pkg.generate` to a failing test that tests that changes have been made to the default runtests.jl.

This is a serious suggestion, but a slightly less than serious implementation.
