### PR TITLE
Fix building with MCJIT LLVM

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -62,7 +62,6 @@ static inline void add_named_global(GlobalValue *gv, void *addr)
         }
     }
 #endif
-    addComdat(gv);
     sys::DynamicLibrary::AddSymbol(name, addr);
 
 #else // USE_MCJIT


### PR DESCRIPTION
The backport included a call to a function that did not exist on 0.3.

I'm using this to build the Fedora package.

CC: @tkelman
