### PR TITLE
Type docs

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -352,6 +352,8 @@ end
 
 copy(o::ObjectIdDict) = ObjectIdDict(o)
 
+get!(o::ObjectIdDict, key, default) = (o[key] = get(o, key, default))
+
 # SerializationState type needed as soon as ObjectIdDict is available
 
 type SerializationState{I<:IO}

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -135,7 +135,7 @@ function field_meta (def)
     for l in def.args[3].args
         if isdoc(l)
             doc = mdify(l)
-        elseif doc != nothing && isexpr(l, Symbol, Expr)
+        elseif doc != nothing && isexpr(l, Symbol, :(::))
             meta[namify(l)] = doc
             doc = nothing
         end

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -73,12 +73,18 @@ function trackmethod(def)
 end
 
 type FuncDoc
+    main
     order::Vector{Method}
     meta::Dict{Method, Any}
     source::Dict{Method, Any}
 end
 
-FuncDoc() = FuncDoc([], Dict(), Dict())
+FuncDoc() = FuncDoc(nothing, [], Dict(), Dict())
+
+function doc!(f::Function, data)
+    fd = get!(meta(), f, FuncDoc())
+    fd.main = data
+end
 
 function doc!(f::Function, m::Method, data, source)
     fd = get!(meta(), f, FuncDoc())
@@ -93,6 +99,7 @@ function doc(f::Function)
     for mod in modules
         if haskey(mod.META, f)
             fd = mod.META[f]
+            length(docs) == 0 && fd.main != nothing && push!(docs, fd.main)
             if isa(fd, FuncDoc)
                 for m in fd.order
                     push!(docs, fd.meta[m])

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -19,7 +19,7 @@ end
 @doc ("I am a macro";)  ModuleMacroDoc.@m
 
 @test (@doc ModuleMacroDoc)    == "I am a module"
-@test (@doc ModuleMacroDoc.@m) == "I am a macro"
+@test (@doc ModuleMacroDoc.@m) == ["I am a macro"]
 
 # apropos function testing
 


### PR DESCRIPTION
``` julia
julia> "This is a type"
       type Foo
           "`x` repesents the Fooness of the Foo"
           x::Int
           "`y` is magical"
           y
       end

help?> Foo
search: Foo floor ifloor pointer_from_objref OverflowError RoundFromZero

  This is a type

help?> Foo.x
  x repesents the Fooness of the Foo

help?> Foo.y
  y is magical
```

Kinda neat that we can do this without any more parser changes, I think.
