### PR TITLE
Make checkbounds more consistent & easier to extend

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -5278,6 +5278,15 @@ doc"""
     checkbounds(array, indexes...)
 
 Throw an error if the specified indexes are not in bounds for the given array.
+Subtypes of `AbstractArray` should specialize this method if they need to
+provide custom bounds checking behaviors.
+
+    checkbounds(::Type{Bool}, dimlength::Integer, index)
+
+Return a `Bool` describing if the given index is within the bounds of the given
+dimension length. Custom types that would like to behave as indices for all
+arrays can extend this method in order to provide a specialized bounds checking
+implementation.
 """
 checkbounds
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -238,9 +238,9 @@ function test_in_bounds(::Type{TestAbstractArray})
     dims = tuple(rand(2:5, n)...)
     len = prod(dims)
     for i in 1:len
-        @test Base.in_bounds(dims, i) == true
+        @test checkbounds(Bool, dims, i) == true
     end
-    @test Base.in_bounds(dims, len + 1) == false
+    @test checkbounds(Bool, dims, len + 1) == false
 end
 
 type UnimplementedFastArray{T, N} <: AbstractArray{T, N} end


### PR DESCRIPTION
- ~~Remove index types from all `checkbounds` methods to make it easier for custom arrays to extend `checkbounds` without ambiguities.~~
- ~~Provide a nicer name for custom array types to extend and override if they want to provide an optimized `in_bounds` check for the dimension that they are indexing into (which simply returns true or false without throwing errors).~~

~~The `in_bounds` name already existed in base with only one use and the same meaning.  This simply uses it more consistently and in a way that makes it easier to extend.  It remains un-exported, and un-documented for now.~~
- Remove index types from `checkbounds(A::AbstractArray, I...)` to make it easier for custom arrays to extend `checkbounds` without ambiguities.
- Rename the internal `_checkbounds(sz::Integer, I)` to `checkbounds(::Type{Bool}, sz::Integer, I)` in order to provide a nicer name for custom array types to extend and override if they want to provide an optimized bounds check for the dimension that they are indexing into (which simply returns true or false without throwing errors).
- The internal `in_bounds` is folded into `checkbounds(::Type{Bool}, …)`.

Worked through in collaboration with @davidagold for a NullableArrays use-case, similar to how DataArrays currently works (c.f. https://github.com/JuliaStats/DataArrays.jl/blob/e7172be39310728acc4ded16a988eae603b69787/src/indexing.jl#L103-L113).
