### PR TITLE
Speed up replace

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -296,10 +296,8 @@ function write_sub{T}(to::AbstractIOBuffer, a::AbstractArray{T}, offs, nel)
         ensureroom(to, Int(nb))
         ptr = (to.append ? to.size+1 : to.ptr)
         written = min(nb, length(to.data) - ptr + 1)
-        copy!(to.data, ptr,
-              pointer_to_array(convert(Ptr{UInt8},pointer(a)), sizeof(a)), # reinterpret(UInt8,a) but without setting the shared data property on a
-              1 + (offs - 1) * sizeof(T),
-              written)
+        unsafe_copy!(pointer(to.data, ptr),
+            convert(Ptr{UInt8}, pointer(a, offs)), nb)
         to.size = max(to.size, ptr - 1 + written)
         if !to.append to.ptr += written end
     else

--- a/base/string.jl
+++ b/base/string.jl
@@ -1334,7 +1334,10 @@ function _rsplit{T<:AbstractString,U<:Array}(str::T, splitter, limit::Integer, k
 end
 #rsplit(str::AbstractString) = rsplit(str, _default_delims, 0, false)
 
-function replace(str::ByteString, pattern, repl::Function, limit::Integer)
+_replacement(repl, str, j, k) = repl
+_replacement(repl::Function, str, j, k) = repl(SubString(str, j, k))
+
+function replace(str::ByteString, pattern, repl, limit::Integer)
     n = 1
     e = endof(str)
     i = a = start(str)
@@ -1343,8 +1346,8 @@ function replace(str::ByteString, pattern, repl::Function, limit::Integer)
     out = IOBuffer()
     while j != 0
         if i == a || i <= k
-            write(out, SubString(str,i,prevind(str,j)))
-            write(out, string(repl(SubString(str,j,k))))
+            write_sub(out, str.data, i, j-i)
+            write(out, _replacement(repl, str, j, k))
         end
         if k<j
             i = j
@@ -1363,8 +1366,7 @@ function replace(str::ByteString, pattern, repl::Function, limit::Integer)
     write(out, SubString(str,i))
     takebuf_string(out)
 end
-replace(s::AbstractString, pat, f::Function, n::Integer) = replace(bytestring(s), pat, f, n)
-replace(s::AbstractString, pat, r, n::Integer) = replace(s, pat, x->r, n)
+replace(s::AbstractString, pat, f, n::Integer) = replace(bytestring(s), pat, f, n)
 replace(s::AbstractString, pat, r) = replace(s, pat, r, 0)
 
 function print_joined(io, strings, delim, last)


### PR DESCRIPTION
Before:

``` julia
s=readall("CONTRIBUTING.md")
@time replace(s,"a","b")
535.033 microseconds (5537 allocations: 218 KB)
```

After:

``` julia
@time replace(s,"a","b")
90.240 microseconds (16 allocations: 33600 bytes)
```
