### PR TITLE
Avoid branch in get(Nullable, default_value)

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -27,7 +27,13 @@ end
 
 get(x::Nullable) = x.isnull ? throw(NullException()) : x.value
 
-get{T}(x::Nullable{T}, y) = x.isnull ? convert(T, y) : x.value
+@inline function get{T}(x::Nullable{T}, y)
+    if isbits(T)
+        ifelse(x.isnull, convert(T, y), x.value)
+    else
+        x.isnull ? convert(T, y) : x.value
+    end
+end
 
 isnull(x::Nullable) = x.isnull
 


### PR DESCRIPTION
This uses a combination of `isbits` type-checking, `ifelse` branch removal and the `@inline` annotation to make it possible for loops that call `get` on `Nullable` objects to be SIMD optimized.

One example given the current `NullableArrays` code:

``` jl
using NullableArrays

A = rand(Float64, 5_000);
X = NullableArray(A);

function f(X::NullableArray)
    res = 0.0
    @simd for i in 1:length(X)
        @inbounds res += get(X[i], NaN)
    end
    return res
end

@code_llvm(f(X))
```

Before this change:

```

define double @julia_f_21641(%jl_value_t*) {
L:
  %1 = alloca [3 x %jl_value_t*], align 8
  %.sub = getelementptr inbounds [3 x %jl_value_t*]* %1, i64 0, i64 0
  %2 = getelementptr [3 x %jl_value_t*]* %1, i64 0, i64 2
  store %jl_value_t* inttoptr (i64 2 to %jl_value_t*), %jl_value_t** %.sub, align 8
  %3 = load %jl_value_t*** @jl_pgcstack, align 8
  %4 = getelementptr [3 x %jl_value_t*]* %1, i64 0, i64 1
  %.c = bitcast %jl_value_t** %3 to %jl_value_t*
  store %jl_value_t* %.c, %jl_value_t** %4, align 8
  store %jl_value_t** %.sub, %jl_value_t*** @jl_pgcstack, align 8
  store %jl_value_t* null, %jl_value_t** %2, align 8
  %5 = getelementptr inbounds %jl_value_t* %0, i64 0, i32 0
  %6 = load %jl_value_t** %5, align 8
  %7 = getelementptr inbounds %jl_value_t* %6, i64 1
  %8 = bitcast %jl_value_t* %7 to i64*
  %9 = load i64* %8, align 8
  %10 = icmp sgt i64 %9, 0
  %11 = select i1 %10, i64 %9, i64 0
  %12 = getelementptr inbounds %jl_value_t* %0, i64 1, i32 0
  %13 = call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %11, i64 1)
  %14 = extractvalue { i64, i1 } %13, 1
  br i1 %14, label %fail, label %pass

fail:                                             ; preds = %L
  %15 = load %jl_value_t** @jl_overflow_exception, align 8
  call void @jl_throw_with_superfluous_argument(%jl_value_t* %15, i32 67)
  unreachable

pass:                                             ; preds = %L
  %16 = extractvalue { i64, i1 } %13, 0
  %17 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %16, i64 1)
  %18 = extractvalue { i64, i1 } %17, 1
  br i1 %18, label %fail1, label %pass2

fail1:                                            ; preds = %pass
  %19 = load %jl_value_t** @jl_overflow_exception, align 8
  call void @jl_throw_with_superfluous_argument(%jl_value_t* %19, i32 67)
  unreachable

pass2:                                            ; preds = %pass
  %20 = extractvalue { i64, i1 } %17, 0
  %21 = icmp slt i64 %20, 1
  br i1 %21, label %L25, label %if3

if3:                                              ; preds = %pass2
  %22 = load %jl_value_t** %12, align 8
  %23 = bitcast %jl_value_t* %22 to i8**
  %24 = load i8** %23, align 8
  br label %L5

L5:                                               ; preds = %L19, %if3
  %"##i#6384.0" = phi i64 [ 0, %if3 ], [ %36, %L19 ]
  %res.1 = phi double [ 0.000000e+00, %if3 ], [ %35, %L19 ]
  %25 = getelementptr i8* %24, i64 %"##i#6384.0"
  %26 = load i8* %25, align 1
  %27 = and i8 %26, 1
  %28 = icmp eq i8 %27, 0
  br i1 %28, label %L18, label %L19

L18:                                              ; preds = %L5
  %29 = load %jl_value_t** %5, align 8
  %30 = bitcast %jl_value_t* %29 to i8**
  %31 = load i8** %30, align 8
  %32 = bitcast i8* %31 to double*
  %33 = getelementptr double* %32, i64 %"##i#6384.0"
  %34 = load double* %33, align 8
  br label %L19

L19:                                              ; preds = %L18, %L5
  %_var1.0 = phi double [ %34, %L18 ], [ 0x7FF8000000000000, %L5 ]
  %35 = fadd fast double %res.1, %_var1.0
  %36 = add i64 %"##i#6384.0", 1
  %exitcond = icmp eq i64 %36, %20
  br i1 %exitcond, label %L25, label %L5

L25:                                              ; preds = %L19, %pass2
  %res.3 = phi double [ 0.000000e+00, %pass2 ], [ %35, %L19 ]
  %37 = load %jl_value_t** %4, align 8
  %38 = getelementptr inbounds %jl_value_t* %37, i64 0, i32 0
  store %jl_value_t** %38, %jl_value_t*** @jl_pgcstack, align 8
  ret double %res.3
}
```

```

define double @julia_f_21663(%jl_value_t*) {
L:
  %1 = alloca [3 x %jl_value_t*], align 8
  %.sub = getelementptr inbounds [3 x %jl_value_t*]* %1, i64 0, i64 0
  %2 = getelementptr [3 x %jl_value_t*]* %1, i64 0, i64 2
  store %jl_value_t* inttoptr (i64 2 to %jl_value_t*), %jl_value_t** %.sub, align 8
  %3 = load %jl_value_t*** @jl_pgcstack, align 8
  %4 = getelementptr [3 x %jl_value_t*]* %1, i64 0, i64 1
  %.c = bitcast %jl_value_t** %3 to %jl_value_t*
  store %jl_value_t* %.c, %jl_value_t** %4, align 8
  store %jl_value_t** %.sub, %jl_value_t*** @jl_pgcstack, align 8
  store %jl_value_t* null, %jl_value_t** %2, align 8
  %5 = getelementptr inbounds %jl_value_t* %0, i64 0, i32 0
  %6 = load %jl_value_t** %5, align 8
  %7 = getelementptr inbounds %jl_value_t* %6, i64 1
  %8 = bitcast %jl_value_t* %7 to i64*
  %9 = load i64* %8, align 8
  %10 = icmp sgt i64 %9, 0
  %11 = select i1 %10, i64 %9, i64 0
  %12 = getelementptr inbounds %jl_value_t* %0, i64 1, i32 0
  %13 = call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 %11, i64 1)
  %14 = extractvalue { i64, i1 } %13, 1
  br i1 %14, label %fail, label %pass

fail:                                             ; preds = %L
  %15 = load %jl_value_t** @jl_overflow_exception, align 8
  call void @jl_throw_with_superfluous_argument(%jl_value_t* %15, i32 67)
  unreachable

pass:                                             ; preds = %L
  %16 = extractvalue { i64, i1 } %13, 0
  %17 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %16, i64 1)
  %18 = extractvalue { i64, i1 } %17, 1
  br i1 %18, label %fail1, label %pass2

fail1:                                            ; preds = %pass
  %19 = load %jl_value_t** @jl_overflow_exception, align 8
  call void @jl_throw_with_superfluous_argument(%jl_value_t* %19, i32 67)
  unreachable

pass2:                                            ; preds = %pass
  %20 = extractvalue { i64, i1 } %17, 0
  %21 = icmp slt i64 %20, 1
  br i1 %21, label %L31, label %if3

if3:                                              ; preds = %pass2
  %22 = load %jl_value_t** %12, align 8
  %23 = bitcast %jl_value_t* %22 to i8**
  %24 = load i8** %23, align 8
  %25 = load %jl_value_t** %5, align 8
  %26 = bitcast %jl_value_t* %25 to i8**
  %27 = load i8** %26, align 8
  %28 = bitcast i8* %27 to double*
  %n.mod.vf = urem i64 %20, 12
  %cmp.zero = icmp eq i64 %20, %n.mod.vf
  br i1 %cmp.zero, label %middle.block, label %vector.ph

vector.ph:                                        ; preds = %if3
  %n.vec = sub i64 %20, %n.mod.vf
  br label %vector.body

vector.body:                                      ; preds = %vector.body, %vector.ph
  %index = phi i64 [ 0, %vector.ph ], [ %index.next, %vector.body ]
  %vec.phi = phi <4 x double> [ zeroinitializer, %vector.ph ], [ %50, %vector.body ]
  %vec.phi36 = phi <4 x double> [ zeroinitializer, %vector.ph ], [ %51, %vector.body ]
  %vec.phi37 = phi <4 x double> [ zeroinitializer, %vector.ph ], [ %52, %vector.body ]
  %29 = getelementptr i8* %24, i64 %index
  %30 = bitcast i8* %29 to <4 x i8>*
  %wide.load = load <4 x i8>* %30, align 1
  %.sum = add i64 %index, 4
  %31 = getelementptr i8* %24, i64 %.sum
  %32 = bitcast i8* %31 to <4 x i8>*
  %wide.load38 = load <4 x i8>* %32, align 1
  %.sum51 = add i64 %index, 8
  %33 = getelementptr i8* %24, i64 %.sum51
  %34 = bitcast i8* %33 to <4 x i8>*
  %wide.load39 = load <4 x i8>* %34, align 1
  %35 = getelementptr double* %28, i64 %index
  %36 = bitcast double* %35 to <4 x double>*
  %wide.load40 = load <4 x double>* %36, align 8
  %37 = getelementptr double* %28, i64 %.sum
  %38 = bitcast double* %37 to <4 x double>*
  %wide.load41 = load <4 x double>* %38, align 8
  %39 = getelementptr double* %28, i64 %.sum51
  %40 = bitcast double* %39 to <4 x double>*
  %wide.load42 = load <4 x double>* %40, align 8
  %41 = and <4 x i8> %wide.load, <i8 1, i8 1, i8 1, i8 1>
  %42 = and <4 x i8> %wide.load38, <i8 1, i8 1, i8 1, i8 1>
  %43 = and <4 x i8> %wide.load39, <i8 1, i8 1, i8 1, i8 1>
  %44 = icmp eq <4 x i8> %41, zeroinitializer
  %45 = icmp eq <4 x i8> %42, zeroinitializer
  %46 = icmp eq <4 x i8> %43, zeroinitializer
  %47 = select <4 x i1> %44, <4 x double> %wide.load40, <4 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000, double 0x7FF8000000000000, double 0x7FF8000000000000>
  %48 = select <4 x i1> %45, <4 x double> %wide.load41, <4 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000, double 0x7FF8000000000000, double 0x7FF8000000000000>
  %49 = select <4 x i1> %46, <4 x double> %wide.load42, <4 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000, double 0x7FF8000000000000, double 0x7FF8000000000000>
  %50 = fadd <4 x double> %vec.phi, %47
  %51 = fadd <4 x double> %vec.phi36, %48
  %52 = fadd <4 x double> %vec.phi37, %49
  %index.next = add i64 %index, 12
  %53 = icmp eq i64 %index.next, %n.vec
  br i1 %53, label %middle.block, label %vector.body

middle.block:                                     ; preds = %vector.body, %if3
  %resume.val = phi i64 [ 0, %if3 ], [ %n.vec, %vector.body ]
  %rdx.vec.exit.phi = phi <4 x double> [ zeroinitializer, %if3 ], [ %50, %vector.body ]
  %rdx.vec.exit.phi45 = phi <4 x double> [ zeroinitializer, %if3 ], [ %51, %vector.body ]
  %rdx.vec.exit.phi46 = phi <4 x double> [ zeroinitializer, %if3 ], [ %52, %vector.body ]
  %bin.rdx = fadd <4 x double> %rdx.vec.exit.phi45, %rdx.vec.exit.phi
  %bin.rdx47 = fadd <4 x double> %rdx.vec.exit.phi46, %bin.rdx
  %rdx.shuf = shufflevector <4 x double> %bin.rdx47, <4 x double> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
  %bin.rdx48 = fadd <4 x double> %bin.rdx47, %rdx.shuf
  %rdx.shuf49 = shufflevector <4 x double> %bin.rdx48, <4 x double> undef, <4 x i32> <i32 1, i32 undef, i32 undef, i32 undef>
  %bin.rdx50 = fadd <4 x double> %bin.rdx48, %rdx.shuf49
  %54 = extractelement <4 x double> %bin.rdx50, i32 0
  %cmp.n = icmp eq i64 %20, %resume.val
  br i1 %cmp.n, label %L31, label %L5

L5:                                               ; preds = %L5, %middle.block
  %"##i#6384.0" = phi i64 [ %63, %L5 ], [ %resume.val, %middle.block ]
  %res.1 = phi double [ %62, %L5 ], [ %54, %middle.block ]
  %55 = getelementptr i8* %24, i64 %"##i#6384.0"
  %56 = load i8* %55, align 1
  %57 = getelementptr double* %28, i64 %"##i#6384.0"
  %58 = load double* %57, align 8
  %59 = and i8 %56, 1
  %60 = icmp eq i8 %59, 0
  %61 = select i1 %60, double %58, double 0x7FF8000000000000
  %62 = fadd fast double %res.1, %61
  %63 = add i64 %"##i#6384.0", 1
  %exitcond = icmp eq i64 %63, %20
  br i1 %exitcond, label %L31, label %L5

L31:                                              ; preds = %L5, %middle.block, %pass2
  %res.3 = phi double [ 0.000000e+00, %pass2 ], [ %62, %L5 ], [ %54, %middle.block ]
  %64 = load %jl_value_t** %4, align 8
  %65 = getelementptr inbounds %jl_value_t* %64, i64 0, i32 0
  store %jl_value_t** %65, %jl_value_t*** @jl_pgcstack, align 8
  ret double %res.3
}
```
