### PR TITLE
Fix #11904 and also fix #11874

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -265,7 +265,7 @@ static Value *emit_unbox(Type *to, Value *x, jl_value_t *jt)
         return UndefValue::get(to);
     }
     if (ty != jl_pvalue_llvmt) {
-        if (to->isAggregateType()) {
+        if (ty->isPointerTy() && to->isAggregateType()) {
             x = builder.CreateLoad(x); // something stack allocated
             ty = x->getType();
         }

--- a/test/core.jl
+++ b/test/core.jl
@@ -3033,3 +3033,30 @@ f11858(Any[Foo11858, Bar11858, g11858])
 @test g11858(1) == 1.0
 @test Foo11858(1).x == 1.0
 @test Bar11858(1).x == 1.0
+
+# issue 11904
+@noinline throw_error() = error()
+foo11904(x::Int) = x
+@inline function foo11904{S}(x::Nullable{S})
+    if isbits(S)
+        Nullable(foo11904(x.value), x.isnull)
+    else
+        throw_error()
+    end
+end
+
+@test !foo11904(Nullable(1)).isnull
+
+# issue 11874
+immutable Foo11874
+   x::Int
+end
+
+function bar11874(x)
+   y::Foo11874
+   y=x
+end
+
+Base.convert(::Type{Foo11874},x::Int) = float(x)
+
+@test_throws TypeError bar11874(1)


### PR DESCRIPTION
When in branches that type inference knows are dead, type information
can be inaccurate and codegen basically just needs to bail out as fast
as possible.
