### PR TITLE
Make it possible again to read STDERR without calling `cat`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -207,16 +207,17 @@ const MemoryError = OutOfMemoryError
 #9295
 @deprecate push!(t::Associative, key, v)  setindex!(t, v, key)
 
-@deprecate (|>)(src::AbstractCmd,    dest::AbstractCmd)    pipe(src, dest)
-@deprecate (.>)(src::AbstractCmd,    dest::AbstractCmd)    pipe(src, stderr=dest)
-@deprecate (|>)(src::Redirectable,   dest::AbstractCmd)    pipe(src, dest)
-@deprecate (|>)(src::AbstractCmd,    dest::Redirectable)   pipe(src, dest)
-@deprecate (.>)(src::AbstractCmd,    dest::Redirectable)   pipe(src, stderr=dest)
-@deprecate (|>)(src::AbstractCmd,    dest::AbstractString) pipe(src, dest)
-@deprecate (|>)(src::AbstractString, dest::AbstractCmd)    pipe(src, dest)
-@deprecate (.>)(src::AbstractCmd,    dest::AbstractString) pipe(src, stderr=dest)
-@deprecate (>>)(src::AbstractCmd,    dest::AbstractString) pipe(src, stdout=dest, append=true)
-@deprecate (.>>)(src::AbstractCmd,   dest::AbstractString) pipe(src, stderr=dest, append=true)
+@deprecate (|>)(src::AbstractCmd,    dest::AbstractCmd)    pipeline(src, dest)
+@deprecate (.>)(src::AbstractCmd,    dest::AbstractCmd)    pipeline(src, stderr=dest)
+@deprecate (|>)(src::Redirectable,   dest::AbstractCmd)    pipeline(src, dest)
+@deprecate (|>)(src::AbstractCmd,    dest::Redirectable)   pipeline(src, dest)
+@deprecate (.>)(src::AbstractCmd,    dest::Redirectable)   pipeline(src, stderr=dest)
+@deprecate (|>)(src::AbstractCmd,    dest::AbstractString) pipeline(src, dest)
+@deprecate (|>)(src::AbstractString, dest::AbstractCmd)    pipeline(src, dest)
+@deprecate (.>)(src::AbstractCmd,    dest::AbstractString) pipeline(src, stderr=dest)
+@deprecate (>>)(src::AbstractCmd,    dest::AbstractString) pipeline(src, stdout=dest, append=true)
+@deprecate (.>>)(src::AbstractCmd,   dest::AbstractString) pipeline(src, stderr=dest, append=true)
+@deprecate pipe pipeline
 
 # 10314
 @deprecate filter!(r::Regex, d::Dict) filter!((k,v)->ismatch(r,k), d)

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -3548,9 +3548,9 @@ doc"""
 Connect to the host ``host`` on port ``port``
 
 ::
-           connect(path) -> Pipe
+           connect(path) -> PipeEndpoint
 
-Connect to the Named Pipe/Domain Socket at ``path``
+Connect to the Named Pipe / Domain Socket at ``path``
 
 ::
            connect(manager::FooManager, pid::Int, config::WorkerConfig) -> (instrm::AsyncStream, outstrm::AsyncStream)
@@ -12163,7 +12163,7 @@ To listen on all interfaces pass ``IPv4(0)`` or ``IPv6(0)`` as appropriate.
 ::
            listen(path) -> PipeServer
 
-Listens on/Creates a Named Pipe/Domain Socket
+Create and listen on a Named Pipe / Domain Socket
 ```
 """
 listen

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1161,7 +1161,7 @@ export
     ntoh,
     open,
     pipeline,
-    Pipe,
+    PipeEndpoint,
     PipeBuffer,
     poll_fd,
     poll_file,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1161,6 +1161,7 @@ export
     ntoh,
     open,
     pipe,
+    Pipe,
     PipeBuffer,
     poll_fd,
     poll_file,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1160,7 +1160,7 @@ export
     nb_available,
     ntoh,
     open,
-    pipe,
+    pipeline,
     Pipe,
     PipeBuffer,
     poll_fd,

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -87,7 +87,7 @@ end
         global _clipboardcmd
         _clipboardcmd !== nothing && return _clipboardcmd
         for cmd in (:xclip, :xsel)
-            success(pipe(`which $cmd`, DevNull)) && return _clipboardcmd = cmd
+            success(pipeline(`which $cmd`, DevNull)) && return _clipboardcmd = cmd
         end
         error("no clipboard command found, please install xsel or xclip")
     end
@@ -165,7 +165,7 @@ function versioninfo(io::IO=STDOUT, verbose::Bool=false)
     println(io,             "  WORD_SIZE: ", Sys.WORD_SIZE)
     if verbose
         lsb = ""
-        @linux_only try lsb = readchomp(pipe(`lsb_release -ds`, stderr=DevNull)) end
+        @linux_only try lsb = readchomp(pipeline(`lsb_release -ds`, stderr=DevNull)) end
         @windows_only try lsb = strip(readall(`$(ENV["COMSPEC"]) /c ver`)) end
         if lsb != ""
             println(io,     "           ", lsb)
@@ -343,7 +343,7 @@ downloadcmd = nothing
     global downloadcmd
     if downloadcmd === nothing
         for checkcmd in (:curl, :wget, :fetch)
-            if success(pipe(`which $checkcmd`, DevNull))
+            if success(pipeline(`which $checkcmd`, DevNull))
                 downloadcmd = checkcmd
                 break
             end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -55,7 +55,7 @@ function add(pkg::AbstractString, vers::VersionSet)
                 outdated = :yes
             else
                 try
-                    run(pipe(Git.cmd(`fetch -q --all`, dir="METADATA"),stdout=DevNull,stderr=DevNull))
+                    run(pipeline(Git.cmd(`fetch -q --all`, dir="METADATA"),stdout=DevNull,stderr=DevNull))
                     outdated = Git.success(`diff --quiet origin/$branch`, dir="METADATA") ?
                         (:no) : (:yes)
                 end

--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -11,7 +11,7 @@ github_user() = readchomp(ignorestatus(`git config --global --get github.user`))
 function git_contributors(dir::AbstractString, n::Int=typemax(Int))
     contrib = Dict()
     tty = @windows? "CON:" : "/dev/tty"
-    for line in eachline(pipe(tty, Git.cmd(`shortlog -nes`, dir=dir)))
+    for line in eachline(pipeline(tty, Git.cmd(`shortlog -nes`, dir=dir)))
         m = match(r"\s*(\d+)\s+(.+?)\s+\<(.+?)\>\s*$", line)
         m === nothing && continue
         commits, name, email = m.captures

--- a/base/pkg/git.jl
+++ b/base/pkg/git.jl
@@ -21,7 +21,7 @@ function git(d)
 end
 
 cmd(args::Cmd; dir="") = `$(git(dir)) $args`
-run(args::Cmd; dir="", out=STDOUT) = Base.run(pipe(cmd(args,dir=dir), out))
+run(args::Cmd; dir="", out=STDOUT) = Base.run(pipeline(cmd(args,dir=dir), out))
 readall(args::Cmd; dir="") = Base.readall(cmd(args,dir=dir))
 readchomp(args::Cmd; dir="") = Base.readchomp(cmd(args,dir=dir))
 

--- a/base/process.jl
+++ b/base/process.jl
@@ -311,7 +311,9 @@ macro setup_stdio()
         in,out,err = stdios
         if isa(stdios[1], Pipe)
             if stdios[1].handle == C_NULL
-                error("pipes passed to spawn must be initialized")
+                in = box(Ptr{Void},Intrinsics.jl_alloca(_sizeof_uv_named_pipe))
+                link_pipe(in,false,stdios[1],true)
+                close_in = true
             end
         elseif isa(stdios[1], FileRedirect)
             in = FS.open(stdios[1].filename, JL_O_RDONLY)
@@ -321,7 +323,9 @@ macro setup_stdio()
         end
         if isa(stdios[2], Pipe)
             if stdios[2].handle == C_NULL
-                error("pipes passed to spawn must be initialized")
+                out = box(Ptr{Void},Intrinsics.jl_alloca(_sizeof_uv_named_pipe))
+                link_pipe(stdios[2],true,out,false)
+                close_out = true
             end
         elseif isa(stdios[2], FileRedirect)
             out = FS.open(stdios[2].filename, JL_O_WRONLY | JL_O_CREAT | (stdios[2].append?JL_O_APPEND:JL_O_TRUNC), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)
@@ -331,7 +335,9 @@ macro setup_stdio()
         end
         if isa(stdios[3], Pipe)
             if stdios[3].handle == C_NULL
-                error("pipes passed to spawn must be initialized")
+                err = box(Ptr{Void},Intrinsics.jl_alloca(_sizeof_uv_named_pipe))
+                link_pipe(stdios[3],true,err,false)
+                close_err = true
             end
         elseif isa(stdios[3], FileRedirect)
             err = FS.open(stdios[3].filename, JL_O_WRONLY | JL_O_CREAT | (stdios[3].append?JL_O_APPEND:JL_O_TRUNC), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)
@@ -345,9 +351,9 @@ end
 macro cleanup_stdio()
     esc(
     quote
-        close_in && close(in)
-        close_out && close(out)
-        close_err && close(err)
+        close_in && (isa(in,Ptr) ? close_pipe_sync(in) : close(in))
+        close_out && (isa(out,Ptr) ? close_pipe_sync(out) : close(out))
+        close_err && (isa(err,Ptr) ? close_pipe_sync(err) : close(err))
     end)
 end
 

--- a/base/process.jl
+++ b/base/process.jl
@@ -50,7 +50,7 @@ function show(io::IO, cmd::Cmd)
 end
 
 function show(io::IO, cmds::Union{OrCmds,ErrOrCmds})
-    print(io, "pipe(")
+    print(io, "pipeline(")
     show(io, cmds.a)
     print(io, ", ")
     print(io, isa(cmds, ErrOrCmds) ? "stderr=" : "stdout=")
@@ -100,7 +100,7 @@ type CmdRedirect <: AbstractCmd
 end
 
 function show(io::IO, cr::CmdRedirect)
-    print(io, "pipe(")
+    print(io, "pipeline(")
     show(io, cr.cmd)
     print(io, ", ")
     if cr.stream_no == STDOUT_NO
@@ -149,7 +149,7 @@ redir_err(src::AbstractCmd, dest::AbstractString) = CmdRedirect(src, FileRedirec
 redir_out_append(src::AbstractCmd, dest::AbstractString) = CmdRedirect(src, FileRedirect(dest, true), STDOUT_NO)
 redir_err_append(src::AbstractCmd, dest::AbstractString) = CmdRedirect(src, FileRedirect(dest, true), STDERR_NO)
 
-function pipe(cmd::AbstractCmd; stdin=nothing, stdout=nothing, stderr=nothing, append::Bool=false)
+function pipeline(cmd::AbstractCmd; stdin=nothing, stdout=nothing, stderr=nothing, append::Bool=false)
     if append && stdout === nothing && stderr === nothing
         error("append set to true, but no output redirections specified")
     end
@@ -165,10 +165,10 @@ function pipe(cmd::AbstractCmd; stdin=nothing, stdout=nothing, stderr=nothing, a
     return cmd
 end
 
-pipe(cmd::AbstractCmd, dest) = pipe(cmd, stdout=dest)
-pipe(src::Union{Redirectable,AbstractString}, cmd::AbstractCmd) = pipe(cmd, stdin=src)
+pipeline(cmd::AbstractCmd, dest) = pipeline(cmd, stdout=dest)
+pipeline(src::Union{Redirectable,AbstractString}, cmd::AbstractCmd) = pipeline(cmd, stdin=src)
 
-pipe(a, b, c, d...) = pipe(pipe(a,b), c, d...)
+pipeline(a, b, c, d...) = pipeline(pipeline(a,b), c, d...)
 
 typealias RawOrBoxedHandle Union{UVHandle,AsyncStream,Redirectable,IOStream}
 typealias StdIOSet NTuple{3,RawOrBoxedHandle}

--- a/base/random.jl
+++ b/base/random.jl
@@ -142,7 +142,7 @@ function make_seed()
         seed = reinterpret(UInt64, time())
         seed = hash(seed, UInt64(getpid()))
         try
-        seed = hash(seed, parse(UInt64, readall(pipe(`ifconfig`, `sha1sum`))[1:40], 16))
+        seed = hash(seed, parse(UInt64, readall(pipeline(`ifconfig`, `sha1sum`))[1:40], 16))
         end
         return make_seed(seed)
     end

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -343,7 +343,12 @@ _jl_sockaddr_set_port(ptr::Ptr{Void},port::UInt16) =
     ccall(:jl_sockaddr_set_port,Void,(Ptr{Void},UInt16),ptr,port)
 
 accept(server::TCPServer) = accept(server, TCPSocket())
-accept(server::PipeServer) = accept(server, Pipe())
+
+# Libuv will internally reset the readable and writable flags on
+# this pipe after it has successfully accepted the connection, to
+# remember that before that this is an invalid pipe
+accept(server::PipeServer) = accept(server, init_pipe!(Pipe();
+    readable=false, writable=false, julia_only=true))
 
 ##
 

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -347,7 +347,7 @@ accept(server::TCPServer) = accept(server, TCPSocket())
 # Libuv will internally reset the readable and writable flags on
 # this pipe after it has successfully accepted the connection, to
 # remember that before that this is an invalid pipe
-accept(server::PipeServer) = accept(server, init_pipe!(Pipe();
+accept(server::PipeServer) = accept(server, init_pipe!(PipeEndpoint();
     readable=false, writable=false, julia_only=true))
 
 ##
@@ -393,7 +393,7 @@ function UDPSocket()
     this
 end
 
-function uvfinalize(uv::Union{TTY,Pipe,PipeServer,TCPServer,TCPSocket,UDPSocket})
+function uvfinalize(uv::Union{TTY,PipeEndpoint,PipeServer,TCPServer,TCPSocket,UDPSocket})
     if (uv.status != StatusUninit && uv.status != StatusInit)
         close(uv)
     end

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -440,8 +440,7 @@ General I/O
    ::
               redirect_stdout(stream)
 
-   Replace STDOUT by stream for all C and julia level output to STDOUT. Note that ``stream`` must be a TTY, a Pipe or a
-   TcpSocket.
+   Replace STDOUT by stream for all C and julia level output to STDOUT. Note that ``stream`` must be a TTY, a PipeEndpoint, or a TcpSocket.
 
 .. function:: redirect_stdout(stream)
 
@@ -456,8 +455,7 @@ General I/O
    ::
               redirect_stdout(stream)
 
-   Replace STDOUT by stream for all C and julia level output to STDOUT. Note that ``stream`` must be a TTY, a Pipe or a
-   TcpSocket.
+   Replace STDOUT by stream for all C and julia level output to STDOUT. Note that ``stream`` must be a TTY, a PipeEndpoint, or a TcpSocket.
 
 .. function:: redirect_stderr([stream])
 
@@ -1264,9 +1262,9 @@ Network I/O
    Connect to the host ``host`` on port ``port``
 
    ::
-              connect(path) -> Pipe
+              connect(path) -> PipeEndpoint
 
-   Connect to the Named Pipe/Domain Socket at ``path``
+   Connect to the Named Pipe / Domain Socket at ``path``
 
    ::
               connect(manager::FooManager, pid::Int, config::WorkerConfig) -> (instrm::AsyncStream, outstrm::AsyncStream)
@@ -1277,7 +1275,7 @@ Network I/O
     must ensure that messages are delivered and received completely and in order. ``Base.connect(manager::ClusterManager.....)``
     sets up TCP/IP socket connections in-between workers.
 
-.. function:: connect(path) -> Pipe
+.. function:: connect(path) -> PipeEndpoint
 
    ::
               connect([host],port) -> TcpSocket
@@ -1285,9 +1283,9 @@ Network I/O
    Connect to the host ``host`` on port ``port``
 
    ::
-              connect(path) -> Pipe
+              connect(path) -> PipeEndpoint
 
-   Connect to the Named Pipe/Domain Socket at ``path``
+   Connect to the Named Pipe / Domain Socket at ``path``
 
    ::
               connect(manager::FooManager, pid::Int, config::WorkerConfig) -> (instrm::AsyncStream, outstrm::AsyncStream)
@@ -1306,7 +1304,7 @@ Network I/O
    ::
               listen(path) -> PipeServer
 
-   Listens on/Creates a Named Pipe/Domain Socket
+   Create and listens on a Named Pipe / Domain Socket
 
 .. function:: listen(path) -> PipeServer
 
@@ -1319,7 +1317,7 @@ Network I/O
    ::
               listen(path) -> PipeServer
 
-   Listens on/Creates a Named Pipe/Domain Socket
+   Create and listens on a Named Pipe / Domain Socket
 
 .. function:: getaddrinfo(host)
 

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -755,9 +755,9 @@ Cluster Manager Interface
    Connect to the host ``host`` on port ``port``
 
    ::
-              connect(path) -> Pipe
+              connect(path) -> PipeEndpoint
 
-   Connect to the Named Pipe/Domain Socket at ``path``
+   Connect to the Named Pipe / Domain Socket at ``path``
 
    ::
               connect(manager::FooManager, pid::Int, config::WorkerConfig) -> (instrm::AsyncStream, outstrm::AsyncStream)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -9,9 +9,9 @@ function fake_repl()
     # Use pipes so we can easily do blocking reads
     # In the future if we want we can add a test that the right object
     # gets displayed by intercepting the display
-    stdin_read,stdin_write = (Base.Pipe(C_NULL), Base.Pipe(C_NULL))
-    stdout_read,stdout_write = (Base.Pipe(C_NULL), Base.Pipe(C_NULL))
-    stderr_read,stderr_write = (Base.Pipe(C_NULL), Base.Pipe(C_NULL))
+    stdin_read,stdin_write = (Base.PipeEndpoint(), Base.PipeEndpoint())
+    stdout_read,stdout_write = (Base.PipeEndpoint(), Base.PipeEndpoint())
+    stderr_read,stderr_write = (Base.PipeEndpoint(), Base.PipeEndpoint())
     Base.link_pipe(stdin_read,true,stdin_write,true)
     Base.link_pipe(stdout_read,true,stdout_write,true)
     Base.link_pipe(stderr_read,true,stderr_write,true)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -174,6 +174,9 @@ if valgrind_off
     # If --trace-children=yes is passed to valgrind, we will get a
     # valgrind banner here, not "Hello World\n".
     @test readall(pipe(`$exename -f -e 'println(STDERR,"Hello World")'`, stderr=`cat`)) == "Hello World\n"
+    p = Pipe()
+    run(pipe(`$exename -f -e 'println(STDERR,"Hello World")'`, stderr = p))
+    @test readall(p) == "Hello World\n"
 end
 
 # issue #6310

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -169,14 +169,15 @@ unmark(sock)
 close(sock)
 
 # issue #4535
-exename = joinpath(JULIA_HOME, Base.julia_exename())
+exename = Base.julia_cmd()
 if valgrind_off
     # If --trace-children=yes is passed to valgrind, we will get a
     # valgrind banner here, not "Hello World\n".
     @test readall(pipeline(`$exename -f -e 'println(STDERR,"Hello World")'`, stderr=`cat`)) == "Hello World\n"
-    p = Pipe()
-    run(pipeline(`$exename -f -e 'println(STDERR,"Hello World")'`, stderr = p))
-    @test readall(p) == "Hello World\n"
+    out = PipeEndpoint()
+    proc = spawn(pipeline(`$exename -f -e 'println(STDERR,"Hello World")'`, stderr = out))
+    @test readall(out) == "Hello World\n"
+    @test success(proc)
 end
 
 # issue #6310

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -247,7 +247,6 @@ let bad = "bad\0name"
 end
 
 # issue #8529
-@test_throws ErrorException run(pipeline(Base.Pipe(C_NULL), `cat`))
 let fname = tempname()
     open(fname, "w") do f
         println(f, "test")

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -155,7 +155,7 @@ else
     for encoding in ["UTF-32LE", "UTF-16BE", "UTF-16LE", "UTF-8"]
         output_path = joinpath(unicodedir, encoding*".unicode")
         f = Base.FS.open(output_path,Base.JL_O_WRONLY|Base.JL_O_CREAT,Base.S_IRUSR | Base.S_IWUSR | Base.S_IRGRP | Base.S_IROTH)
-        run(pipe(`iconv -f $primary_encoding -t $encoding $primary_path`, f))
+        run(pipeline(`iconv -f $primary_encoding -t $encoding $primary_path`, f))
         Base.FS.close(f)
     end
 


### PR DESCRIPTION
Merge the Pipe() and Pipe(C_NULL) constructors having the former just
call the latter and delaying initialization to the place where it is
actually needed. Now passing an empty Pipe to spawn will once again
initialize it with the appropriate pipe end. Fixes #11824.
