### PR TITLE
fix #11876 (backport)

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -401,7 +401,6 @@ function _start()
         end
     catch err
         display_error(err,catch_backtrace())
-        println()
         exit(1)
     end
     if is_interactive


### PR DESCRIPTION
don't print an extra newline to stdout when exiting with an error
when we quit on EPIPE this caused us to throw another error

(cherry picked from 34ec37d949b899fb4a3adc01aec3c78dbeb1acfc)

**Note that this is a PR against release-0.3.**
