### PR TITLE
Avoid that type inference runs each time a message is sent by wrapping args in a Vector

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -140,14 +140,14 @@ function flush_gc_msgs(w::Worker)
     msgs = copy(w.add_msgs)
     if !isempty(msgs)
         empty!(w.add_msgs)
-        remote_do(w, add_clients, msgs...)
+        remote_do(w, add_clients, msgs)
     end
 
     msgs = copy(w.del_msgs)
     if !isempty(msgs)
         empty!(w.del_msgs)
         #print("sending delete of $msgs\n")
-        remote_do(w, del_clients, msgs...)
+        remote_do(w, del_clients, msgs)
     end
 end
 
@@ -471,7 +471,7 @@ function del_client(pg, id, client)
     nothing
 end
 
-function del_clients(pairs::Tuple{Any,Any}...)
+function del_clients(pairs::Vector)
     for p in pairs
         del_client(p[1], p[2])
     end
@@ -507,7 +507,7 @@ function add_client(id, client)
     nothing
 end
 
-function add_clients(pairs::Tuple{Any,Any}...)
+function add_clients(pairs::Vector)
     for p in pairs
         add_client(p[1], p[2])
     end


### PR DESCRIPTION
When generating many `RemoteRef`s, the number of sent arguments would vary which then caused inference to be run repeatedly when I ran my parallel code. @carnaval suggested wrapping the arguments in a `Vector` to avoid this.
