### PR TITLE
Improve countlines() performance

### DIFF
--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -243,7 +243,7 @@ General I/O
 
 .. function:: countlines(io,[eol::Char])
 
-   Read io until the end of the stream/file and count the number of non-empty lines. To specify a file pass the filename as the first
+   Read ``io`` until the end of the stream/file and count the number of lines. To specify a file pass the filename as the first
    argument. EOL markers other than '\\n' are supported by passing them as the second argument.
 
 .. function:: PipeBuffer()

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -1,5 +1,20 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+# countlines
+@test countlines(IOBuffer("\n")) == 1
+@test countlines(IOBuffer("\n"),'\r') == 0
+@test countlines(IOBuffer("\n\n\n\n\n\n\n\n\n\n")) == 10
+@test countlines(IOBuffer("\n \n \n \n \n \n \n \n \n \n")) == 10
+@test countlines(IOBuffer("\r\n \r\n \r\n \r\n \r\n")) == 5
+file = tempname()
+open(file,"w") do f
+    write(f,"Spiffy header\nspectacular first row\neven better 2nd row\nalmost done\n")
+end
+@test countlines(file) == 4
+@test countlines(file,'\r') == 0
+@test countlines(file,'\n') == 4
+rm(file)
+
 isequaldlm(m1, m2, t) = isequal(m1, m2) && (eltype(m1) == eltype(m2) == t)
 
 @test isequaldlm(readdlm(IOBuffer("1\t2\n3\t4\n5\t6\n")), [1. 2; 3 4; 5 6], Float64)


### PR DESCRIPTION
| Size of File | Base.countlines | new countlines |
| --- | --- | --- |
| 10MB | 11.3 milliseconds | 7.3 milliseconds |
| 100MB | 102 milliseconds | 62.5 milliseconds |
| 1GB | 928 milliseconds | 598 milliseconds |
| 21GB | 31 seconds | 26 seconds |

The first 3 files were auto-generated from random characters + newlines. The 21GB file is from @jiahao's test file from the readdlm issue.

Also added previously missing tests
