### PR TITLE
Fix a hang in type inference after workspace()

### DIFF
--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -211,7 +211,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
 // - later, it refers to either old Base or new Base
 DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m)
 {
-    while (m != jl_main_module) {
+    while (m != m->parent) {
         if (m->istopmod)
             return m;
         m = m->parent;


### PR DESCRIPTION
The test case to reproduce is:

``` julia
julia> f(x) = x+1;

julia> workspace()

julia> LastMain.f(2)
```

The problem is that `LastMain` is its own parent, but it isn't `jl_main_module`, and `istopmod` is apparently false, so this was evidently an infinite loop. I'm not sure if this is the right fix, but I can build Julia with it after `make clean`, and the code above no longer hangs. Ref #11274, cc @vtjnash

I will also try to add a test for this.
