### PR TITLE
add --precompiled option to control whether precompiled code is used

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -232,7 +232,8 @@ let reqarg = Set(UTF8String["--home",          "-H",
                             "--output-o",
                             "--output-ji",
                             "--output-bc",
-                            "--bind-to"])
+                            "--bind-to",
+                            "--precompiled"])
     global process_options
     function process_options(opts::JLOptions, args::Vector{UTF8String})
         if !isempty(args)

--- a/base/options.jl
+++ b/base/options.jl
@@ -27,6 +27,7 @@ immutable JLOptions
     fast_math::Int8
     worker::Int8
     handle_signals::Int8
+    use_precompiled::Int8
     bindto::Ptr{UInt8}
     outputbc::Ptr{UInt8}
     outputo::Ptr{UInt8}

--- a/src/dump.c
+++ b/src/dump.c
@@ -217,7 +217,7 @@ static int jl_load_sysimg_so()
     if (jl_is_debugbuild()) imaging_mode = 1;
 #endif
     // in --build mode only use sysimg data, not precompiled native code
-    if (!imaging_mode) {
+    if (!imaging_mode && jl_options.use_precompiled==JL_OPTIONS_USE_PRECOMPILED_YES) {
         sysimg_gvars = (jl_value_t***)jl_dlsym(jl_sysimg_handle, "jl_sysimg_gvars");
         globalUnique = *(size_t*)jl_dlsym(jl_sysimg_handle, "jl_globalUnique");
         const char *cpu_target = (const char*)jl_dlsym(jl_sysimg_handle, "jl_sysimg_cpu_target");

--- a/src/init.c
+++ b/src/init.c
@@ -111,6 +111,7 @@ jl_options_t jl_options = { 0,    // quiet
                             JL_OPTIONS_FAST_MATH_DEFAULT,
                             0,    // worker
                             JL_OPTIONS_HANDLE_SIGNALS_ON,
+                            JL_OPTIONS_USE_PRECOMPILED_YES,
                             NULL, // bindto
                             NULL, // outputbc
                             NULL, // outputo

--- a/src/julia.h
+++ b/src/julia.h
@@ -1512,6 +1512,7 @@ typedef struct {
     int8_t fast_math;
     int8_t worker;
     int8_t handle_signals;
+    int8_t use_precompiled;
     const char *bindto;
     const char *outputbc;
     const char *outputo;
@@ -1552,6 +1553,9 @@ DLLEXPORT int jl_generating_output();
 
 #define JL_OPTIONS_HANDLE_SIGNALS_ON 1
 #define JL_OPTIONS_HANDLE_SIGNALS_OFF 0
+
+#define JL_OPTIONS_USE_PRECOMPILED_YES 1
+#define JL_OPTIONS_USE_PRECOMPILED_NO 0
 
 // Version information
 #include "julia_version.h"

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -218,7 +218,7 @@ void parse_opts(int *argcp, char ***argvp)
                 jl_options.use_precompiled = JL_OPTIONS_USE_PRECOMPILED_NO;
             else
                 jl_errorf("julia: invalid argument to --precompiled={yes|no} (%s)\n", optarg);
-            break;            
+            break;
         case 'C': // cpu-target
             jl_options.cpu_target = strdup(optarg);
             break;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -50,6 +50,7 @@ static const char opts[]  =
 
     // startup options
     " -J, --sysimage <file>     Start up with the given system image file\n"
+    " --precompiled={yes|no}    Use precompiled code from system image if available\n"
     " -H, --home <dir>          Set location of julia executable\n"
     " --startup-file={yes|no}   Load ~/.juliarc.jl\n"
     " -f, --no-startup          Don't load ~/.juliarc (deprecated, use --startup-file=no)\n"
@@ -115,7 +116,8 @@ void parse_opts(int *argcp, char ***argvp)
            opt_bind_to,
            opt_handle_signals,
            opt_output_o,
-           opt_output_ji
+           opt_output_ji,
+           opt_use_precompiled
     };
     static char* shortopts = "+vhqFfH:e:E:P:L:J:C:ip:Ob:";
     static struct option longopts[] = {
@@ -131,6 +133,7 @@ void parse_opts(int *argcp, char ***argvp)
         { "post-boot",       required_argument, 0, 'P' },
         { "load",            required_argument, 0, 'L' },
         { "sysimage",        required_argument, 0, 'J' },
+        { "precompiled",     required_argument, 0, opt_use_precompiled },
         { "cpu-target",      required_argument, 0, 'C' },
         { "procs",           required_argument, 0, 'p' },
         { "machinefile",     required_argument, 0, opt_machinefile },
@@ -208,6 +211,14 @@ void parse_opts(int *argcp, char ***argvp)
             jl_options.image_file = strdup(optarg);
             imagepathspecified = 1;
             break;
+        case opt_use_precompiled:
+            if (!strcmp(optarg,"yes"))
+                jl_options.use_precompiled = JL_OPTIONS_USE_PRECOMPILED_YES;
+            else if (!strcmp(optarg,"no"))
+                jl_options.use_precompiled = JL_OPTIONS_USE_PRECOMPILED_NO;
+            else
+                jl_errorf("julia: invalid argument to --precompiled={yes|no} (%s)\n", optarg);
+            break;            
         case 'C': // cpu-target
             jl_options.cpu_target = strdup(optarg);
             break;


### PR DESCRIPTION
Ideally, we would do some extra work on windows here to pass `LOAD_LIBRARY_AS_DATAFILE` to LoadLibraryEx.
