### PR TITLE
Add test for #11948

### DIFF
--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -30,7 +30,7 @@ function choosetests(choices = [])
         "replutil", "sets", "test", "goto", "llvmcall", "grisu",
         "nullable", "meta", "profile", "libgit2", "docs", "markdown",
         "base64", "parser", "serialize", "functors", "char", "misc",
-        "enums", "cmdlineargs", "i18n"
+        "enums", "cmdlineargs", "i18n", "workspace"
     ]
 
     if Base.USE_GPL_LIBS

--- a/test/workspace.jl
+++ b/test/workspace.jl
@@ -1,0 +1,9 @@
+# Issue #11948
+script = """
+f(x) = x+1
+workspace()
+@assert !isdefined(:f)
+LastMain.f(2)
+"""
+exename = joinpath(JULIA_HOME, Base.julia_exename())
+run(`$exename -f -e $script`)


### PR DESCRIPTION
Runs in a separate process, because running `workspace()` in the middle of the tests seemed like a recipe for non-deterministic bugs
