### PR TITLE
Fix commit string.

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -210,6 +210,7 @@ function banner(io::IO = STDOUT)
         commit_string = ""
     else
         days = Int(floor((ccall(:clock_now, Float64, ()) - GIT_VERSION_INFO.fork_master_timestamp) / (60 * 60 * 24)))
+        days = max(0, days)
         unit = days == 1 ? "day" : "days"
         distance = GIT_VERSION_INFO.fork_master_distance
         commit = GIT_VERSION_INFO.commit_short


### PR DESCRIPTION
Reference:
- https://groups.google.com/forum/#!topic/julia-users/LAkV4FhRD4U

`Commit d092dd0 (-1 days old master)`

should be: `Commit d092dd0 (0 days old master)`

[av skip]
