### PR TITLE
Only allow Int or TypeVar as the first parameter of NTuple

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -147,7 +147,7 @@ copy(S::SparseMatrixCSC) =
 
 similar(S::SparseMatrixCSC, Tv::Type=eltype(S))   = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), Array(Tv, length(S.nzval)))
 similar{Tv,Ti,TvNew,TiNew}(S::SparseMatrixCSC{Tv,Ti}, ::Type{TvNew}, ::Type{TiNew}) = SparseMatrixCSC(S.m, S.n, convert(Array{TiNew},S.colptr), convert(Array{TiNew}, S.rowval), Array(TvNew, length(S.nzval)))
-similar{Tv}(S::SparseMatrixCSC, ::Type{Tv}, d::NTuple{Integer}) = spzeros(Tv, d...)
+similar{Tv, N}(S::SparseMatrixCSC, ::Type{Tv}, d::NTuple{N, Integer}) = spzeros(Tv, d...)
 
 function convert{Tv,Ti,TvS,TiS}(::Type{SparseMatrixCSC{Tv,Ti}}, S::SparseMatrixCSC{TvS,TiS})
     if Tv == TvS && Ti == TiS

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -981,8 +981,10 @@ JL_CALLABLE(jl_f_instantiate_type)
     if (args[0] == (jl_value_t*)jl_uniontype_type) {
         size_t i;
         for(i=1; i < nargs; i++) {
-            if (!jl_is_type(args[i]) && !jl_is_typevar(args[i]))
-                jl_error("invalid union type");
+            if (!jl_is_type(args[i]) && !jl_is_typevar(args[i])) {
+                jl_type_error_rt("apply_type", "parameter of Union",
+                                 (jl_value_t*)jl_type_type, args[i]);
+            }
         }
     }
     else if (!jl_is_datatype(args[0])) {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1686,11 +1686,18 @@ jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n)
                              pi);
         }
     }
-    if (tc == (jl_value_t*)jl_ntuple_type && (n==1||n==2) &&
-        jl_is_long(params[0])) {
-        size_t nt = jl_unbox_long(params[0]);
-        return (jl_value_t*)jl_tupletype_fill(nt, (n==2) ? params[1] :
-                                              (jl_value_t*)jl_any_type);
+    if (tc == (jl_value_t*)jl_ntuple_type && (n == 1 || n == 2)) {
+        if (jl_is_long(params[0])) {
+            size_t nt = jl_unbox_long(params[0]);
+            return jl_tupletype_fill(nt, (n==2) ? params[1] :
+                                     (jl_value_t*)jl_any_type);
+        }
+        else if (!jl_is_typevar(params[0])) {
+            // Only allow integer or TypeVar as the first parameter to
+            // NTuple. issue #9233
+            jl_type_error_rt("apply_type", "first parameter of NTuple",
+                             (jl_value_t*)jl_long_type, params[0]);
+        }
     }
     size_t ntp = jl_svec_len(tp);
     if (n > ntp)

--- a/test/core.jl
+++ b/test/core.jl
@@ -3060,3 +3060,24 @@ end
 Base.convert(::Type{Foo11874},x::Int) = float(x)
 
 @test_throws TypeError bar11874(1)
+
+# issue 9233
+try
+    # Seems to be evaluated and throw an error at compile time if not
+    # using `@eval`
+    @eval NTuple{Int, 1}
+catch err
+    @test isa(err, TypeError)
+    @test err.func == :apply_type
+    @test err.expected == Int
+    @test err.got == Int
+end
+
+try
+    @eval NTuple{0x1, Int}
+catch err
+    @test isa(err, TypeError)
+    @test err.func == :apply_type
+    @test err.expected == Int
+    @test err.got == 0x1
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -3081,3 +3081,12 @@ catch err
     @test err.expected == Int
     @test err.got == 0x1
 end
+
+try
+    @eval Union{Int, 1}
+catch err
+    @test isa(err, TypeError)
+    @test err.func == :apply_type
+    @test err.expected == Type
+    @test err.got == 1
+end


### PR DESCRIPTION
Update: Also throw a `TypeError` instead of an `ErrorException` for invalid `Union`.

In the long term, it would be nice to replace this with a more general mechanism (edit: to force certain type parameters to be a value of certain type) but this seems to be the single most confusing one (especially because of the order of the parameters).

Fix #11967 (ok, it is not really a fix but at least it won't silently ignore the error)
