### PR TITLE
mega codegen restructuring

### DIFF
--- a/examples/clustermanager/simple/UnixDomainCM.jl
+++ b/examples/clustermanager/simple/UnixDomainCM.jl
@@ -47,10 +47,9 @@ function connect(manager::UnixDomainCM, pid::Int, config::WorkerConfig)
             end
             return (sock, sock)
         catch e
-            if (time() - t) > 10.0
+            if (time() - t) > 30.0
                 rethrow(e)
             else
-                gc()
                 sleep(0.1)
             end
         end

--- a/src/abi_llvm.cpp
+++ b/src/abi_llvm.cpp
@@ -47,7 +47,7 @@ bool use_sret(AbiState *state,jl_value_t *ty)
     return false;
 }
 
-void needPassByRef(AbiState *state,jl_value_t *ty, bool *byRef, bool *inReg, bool *byRefAttr)
+void needPassByRef(AbiState *state,jl_value_t *ty, bool *byRef, bool *inReg)
 {
     return;
 }

--- a/src/abi_win32.cpp
+++ b/src/abi_win32.cpp
@@ -50,14 +50,14 @@ bool use_sret(AbiState *state, jl_value_t *ty)
     return true;
 }
 
-void needPassByRef(AbiState *state, jl_value_t *ty, bool *byRef, bool *inReg, bool *byRefAttr)
+void needPassByRef(AbiState *state, jl_value_t *ty, bool *byRef, bool *inReg)
 {
     if (!jl_is_datatype(ty) || jl_is_abstracttype(ty) || jl_is_cpointer_type(ty) || jl_is_array_type(ty))
         return;
     size_t size = jl_datatype_size(ty);
     if (size <= 8)
         return;
-    *byRefAttr = *byRef = true;
+    *byRef = true;
 }
 
 Type *preferred_llvm_type(jl_value_t *ty, bool isret)

--- a/src/abi_win64.cpp
+++ b/src/abi_win64.cpp
@@ -54,13 +54,13 @@ bool use_sret(AbiState *state, jl_value_t *ty)
     return true;
 }
 
-void needPassByRef(AbiState *state, jl_value_t *ty, bool *byRef, bool *inReg, bool *byRefAttr)
+void needPassByRef(AbiState *state, jl_value_t *ty, bool *byRef, bool *inReg)
 {
     if(!jl_is_datatype(ty) || jl_is_abstracttype(ty) || jl_is_cpointer_type(ty) || jl_is_array_type(ty))
         return;
     size_t size = jl_datatype_size(ty);
     if (size > 8)
-        *byRefAttr = *byRef = true;
+        *byRef = true;
 }
 
 Type *preferred_llvm_type(jl_value_t *ty, bool isret)

--- a/src/abi_x86.cpp
+++ b/src/abi_x86.cpp
@@ -66,14 +66,14 @@ bool use_sret(AbiState *state, jl_value_t *ty)
     return true;
 }
 
-void needPassByRef(AbiState *state, jl_value_t *ty, bool *byRef, bool *inReg, bool *byRefAttr)
+void needPassByRef(AbiState *state, jl_value_t *ty, bool *byRef, bool *inReg)
 {
     if (!jl_is_datatype(ty) || jl_is_abstracttype(ty) || jl_is_cpointer_type(ty) || jl_is_array_type(ty))
         return;
     size_t size = jl_datatype_size(ty);
     if (is_complex64(ty) || is_complex128(ty) || (jl_is_bitstype(ty) && size <= 8))
         return;
-    *byRefAttr = *byRef = true;
+    *byRef = true;
 }
 
 Type *preferred_llvm_type(jl_value_t *ty, bool isret)

--- a/src/abi_x86_64.cpp
+++ b/src/abi_x86_64.cpp
@@ -157,11 +157,11 @@ bool use_sret(AbiState *state,jl_value_t *ty)
     return sret;
 }
 
-void needPassByRef(AbiState *state, jl_value_t *ty, bool *byRef, bool *inReg, bool *byRefAttr)
+void needPassByRef(AbiState *state, jl_value_t *ty, bool *byRef, bool *inReg)
 {
     Classification cl = classify(ty);
     if (cl.isMemory) {
-        *byRefAttr = *byRef = true;
+        *byRef = true;
         return;
     }
 
@@ -182,7 +182,7 @@ void needPassByRef(AbiState *state, jl_value_t *ty, bool *byRef, bool *inReg, bo
     else if (jl_is_structtype(ty)) {
         // spill to memory even though we would ordinarily pass
         // it in registers
-        *byRefAttr = *byRef = true;
+        *byRef = true;
     }
 }
 

--- a/src/abi_x86_64.cpp
+++ b/src/abi_x86_64.cpp
@@ -177,7 +177,6 @@ void needPassByRef(AbiState *state, jl_value_t *ty, bool *byRef, bool *inReg)
     if (wanted.int_regs <= state->int_regs && wanted.sse_regs <= state->sse_regs) {
         state->int_regs -= wanted.int_regs;
         state->sse_regs -= wanted.sse_regs;
-        *inReg = true;
     }
     else if (jl_is_structtype(ty)) {
         // spill to memory even though we would ordinarily pass

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -252,6 +252,9 @@ Value *llvm_type_rewrite(Value *v, Type *from_type, Type *target_type,
         bool issigned, /* determines whether an integer value should be zero or sign extended */
         jl_codectx_t *ctx)
 {
+    if (v->getType() == T_void)
+        return UndefValue::get(target_type); // convert undef (unreachable) -> undef (target_type)
+
     if (byref) {
         if (tojulia) {
             Type *ptarget_type = PointerType::get(target_type, 0);
@@ -334,7 +337,7 @@ static Value *julia_to_native(Type *to, jl_value_t *jlto, const jl_cgval_t &jvin
     if (addressOf) {
         if (!jl_is_cpointer_type(jlto)) {
             emit_error("ccall: & on argument was not matched by Ptr{T} argument type", ctx);
-            return UndefValue::get(to); // the only "safe" thing to emit here is the expected struct
+            return UndefValue::get(T_void);
         }
         ety = jl_tparam0(jlto);
         if (jlto == (jl_value_t*)jl_voidpointer_type)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -248,7 +248,7 @@ static Value *runtime_sym_lookup(PointerType *funcptype, char *f_lib, char *f_na
 
 Value *llvm_type_rewrite(Value *v, Type *from_type, Type *target_type,
         bool tojulia, /* only matters if byref is set (declares the direction of the byref attribute) */
-        bool byref, /* only applies to arguments, set false for return values */
+        bool byref, /* only applies to arguments, set false for return values -- effectively the same as jl_cgval_t.ispointer */
         bool issigned, /* determines whether an integer value should be zero or sign extended */
         jl_codectx_t *ctx)
 {
@@ -426,7 +426,7 @@ static Value *julia_to_native(Type *to, jl_value_t *jlto, const jl_cgval_t &jvin
     if (addressOf)
         to = to->getContainedType(0);
     Value *slot = emit_static_alloca(to, ctx);
-    if (!jvinfo.isboxed)
+    if (!jvinfo.ispointer)
         builder.CreateStore(emit_unbox(to, jvinfo, jlto), slot);
     else
         builder.CreateMemCpy(slot, builder.CreateBitCast(jvinfo.V, T_pint8), (uint64_t)jl_datatype_size(jlto), (uint64_t)((jl_datatype_t*)jlto)->alignment);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -461,8 +461,7 @@ static native_sym_arg_t interpret_symbol_arg(jl_value_t *arg, jl_codectx_t *ctx,
                                "cglobal: first argument not a pointer or valid constant expression",
                                ctx);
         }
-        arg1.typ = (jl_value_t*)jl_voidpointer_type;
-        arg1.isboxed = false;
+        arg1 = remark_julia_type(arg1, (jl_value_t*)jl_voidpointer_type);
         jl_ptr = emit_unbox(T_size, arg1, (jl_value_t*)jl_voidpointer_type);
     }
 

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -247,7 +247,7 @@ static Value *runtime_sym_lookup(PointerType *funcptype, char *f_lib, char *f_na
 #endif
 
 Value *llvm_type_rewrite(Value *v, Type *from_type, Type *target_type, bool tojulia, bool byref, bool issigned, jl_codectx_t *ctx)
-{
+{ // TODO: XXX this function is broken.
     Type *ptarget_type = PointerType::get(target_type, 0);
 
     if (tojulia) {
@@ -315,113 +315,89 @@ Value *llvm_type_rewrite(Value *v, Type *from_type, Type *target_type, bool toju
 // --- argument passing and scratch space utilities ---
 
 // Emit code to convert argument to form expected by C ABI
-// ty = desired LLVM type
-// jt = Julia type of formal argument
-// jv = value of actual argument
-// aty = Julia inferred type of actual argument
-static Value *julia_to_native(Type *ty, jl_value_t *jt, Value *jv,
-                              jl_value_t *aty, bool addressOf,
-                              bool byRef, bool inReg,
-                              bool needCopy, bool tojulia,
-                              int argn, jl_codectx_t *ctx,
+// to = desired LLVM type
+// jlto = Julia type of formal argument
+// jvinfo = value of actual argument
+static Value *julia_to_native(Type *to, jl_value_t *jlto, const jl_cgval_t &jvinfo,
+                              bool addressOf, bool byRef, bool inReg, bool needCopy,
+                              bool tojulia, int argn, jl_codectx_t *ctx,
                               bool *needStackRestore)
 {
-    Type *vt = jv->getType();
-
     // We're passing Any
-    if (ty == jl_pvalue_llvmt) {
-        return boxed(jv,ctx);
+    if (to == jl_pvalue_llvmt) {
+        return boxed(jvinfo, ctx);
     }
-
-    if (!tojulia && vt != jl_pvalue_llvmt && julia_type_to_llvm(aty)->isAggregateType()) {
-        // this value is expected to be a pointer in the julia codegen,
-        // so it needs to be extracted first if not tojulia
-        vt = vt->getContainedType(0);
-    }
-
-    if (ty == vt && !addressOf && !byRef) {
-        return jv;
-    }
-
-    if (vt != jl_pvalue_llvmt) {
-        // argument value is unboxed
-        if (vt != jv->getType())
-            jv = builder.CreateLoad(jv); // something stack allocated
-        if (addressOf || (byRef && inReg)) {
-            if (ty->isPointerTy() && ty->getContainedType(0) == vt) {
-                // pass the address of an alloca'd thing, not a box
-                // since those are immutable.
-                Value *slot = emit_static_alloca(vt, ctx);
-                builder.CreateStore(jv, slot);
-                return builder.CreateBitCast(slot, ty);
-            }
-        }
-        else if ((vt->isIntegerTy() && ty->isIntegerTy()) ||
-                 (vt->isFloatingPointTy() && ty->isFloatingPointTy()) ||
-                 (vt->isPointerTy() && ty->isPointerTy())) {
-            if (vt->getPrimitiveSizeInBits() ==
-                ty->getPrimitiveSizeInBits()) {
-                if (!byRef) {
-                    return builder.CreateBitCast(jv, ty);
-                }
-                else {
-                    Value *mem = emit_static_alloca(ty, ctx);
-                    builder.CreateStore(jv,builder.CreateBitCast(mem,vt->getPointerTo()));
-                    return mem;
-                }
-            }
-        }
-        else if (vt->isStructTy()) {
-            if (byRef) {
-                Value *mem = emit_static_alloca(vt, ctx);
-                builder.CreateStore(jv, mem);
-                return mem;
-            }
-            else {
-                return jv;
-            }
-        }
-
-        emit_error("ccall: argument type did not match declaration", ctx);
-    }
-
-    // argument value is boxed (jl_value_t*)
-    if (jl_is_tuple(jt)) {
+    if (jl_is_tuple(jlto)) {
         emit_error("ccall: unimplemented: boxed tuple argument type", ctx);
-        return jv; // TODO: this is wrong
+        return UndefValue::get(to);
     }
-    if (jl_is_cpointer_type(jt) && addressOf) {
-        assert(ty->isPointerTy());
-        jl_value_t *ety = jl_tparam0(jt);
-        if (aty != ety && ety != (jl_value_t*)jl_any_type && jt != (jl_value_t*)jl_voidpointer_type) {
+
+    jl_value_t *ety = jlto;
+    if (addressOf) {
+        if (!jl_is_cpointer_type(jlto)) {
+            emit_error("ccall: & on argument was not matched by Ptr{T} argument type", ctx);
+            return UndefValue::get(to); // the only "safe" thing to emit here is the expected struct
+        }
+        ety = jl_tparam0(jlto);
+        if (jlto == (jl_value_t*)jl_voidpointer_type)
+            ety = jvinfo.typ; // skip the type-check
+    }
+    if (addressOf || byRef)
+        assert(to->isPointerTy());
+    if (jvinfo.typ != ety || ety == (jl_value_t*)jl_any_type) {
+        if (!addressOf && jlto == (jl_value_t*)jl_voidpointer_type) {
+            // allow a bit more flexibility for what can be passed to (void*)
+            if (!jl_is_cpointer_type(jvinfo.typ)) {
+                // emit a typecheck, if not statically known to be correct
+                std::stringstream msg;
+                msg << "ccall argument ";
+                msg << argn;
+                emit_cpointercheck(jvinfo, msg.str(), ctx);
+            }
+        }
+        else {
+            // emit a typecheck, if not statically known to be correct
             std::stringstream msg;
             msg << "ccall argument ";
             msg << argn;
-            emit_typecheck(jv, ety, msg.str(), ctx);
+            emit_typecheck(jvinfo, ety, msg.str(), ctx);
         }
-        if (jl_is_mutable_datatype(ety)) {
-            // no copy, just reference the data field
-            return builder.CreateBitCast(jv, ty);
-        }
-        else if (jl_is_immutable_datatype(ety) && jt != (jl_value_t*)jl_voidpointer_type) {
-            // yes copy
-            Value *nbytes;
-            if (jl_is_leaf_type(ety))
-                nbytes = ConstantInt::get(T_int32, jl_datatype_size(ety));
-            else
-                nbytes = tbaa_decorate(tbaa_datatype, builder.CreateLoad(
-                                builder.CreateGEP(builder.CreatePointerCast(emit_typeof(jv), T_pint32),
-                                    ConstantInt::get(T_size, offsetof(jl_datatype_t,size)/sizeof(int32_t))),
-                                false));
-            *needStackRestore = true;
-            AllocaInst *ai = builder.CreateAlloca(T_int8, nbytes);
-            ai->setAlignment(16);
-            builder.CreateMemCpy(ai, builder.CreateBitCast(jv, T_pint8), nbytes, sizeof(void*)); // minimum gc-alignment in julia is pointer size
-            return builder.CreateBitCast(ai, ty);
+    }
+
+    if (!addressOf && !byRef)
+        return emit_unbox(to, jvinfo, jlto);
+
+    if (addressOf && jvinfo.isboxed) {
+        if (!jl_is_abstracttype(ety)) {
+            if (jl_is_mutable_datatype(ety)) {
+                // no copy, just reference the data field
+                return builder.CreateBitCast(jvinfo.V, to);
+            }
+            else if (jl_is_immutable_datatype(ety) && jlto != (jl_value_t*)jl_voidpointer_type) {
+                // yes copy
+                Value *nbytes;
+                AllocaInst *ai;
+                if (jl_is_leaf_type(ety)) {
+                    int nb = jl_datatype_size(ety);
+                    nbytes = ConstantInt::get(T_int32, nb);
+                    ai = emit_static_alloca(T_int8, nb, ctx);
+                }
+                else {
+                    nbytes = tbaa_decorate(tbaa_datatype, builder.CreateLoad(
+                                    builder.CreateGEP(builder.CreatePointerCast(emit_typeof(jvinfo), T_pint32),
+                                        ConstantInt::get(T_size, offsetof(jl_datatype_t,size)/sizeof(int32_t))),
+                                    false));
+                    ai = builder.CreateAlloca(T_int8, nbytes);
+                    *needStackRestore = true;
+                }
+                ai->setAlignment(16);
+                builder.CreateMemCpy(ai, builder.CreateBitCast(jvinfo.V, T_pint8), nbytes, sizeof(void*)); // minimum gc-alignment in julia is pointer size
+                return builder.CreateBitCast(ai, to);
+            }
         }
         // emit maybe copy
         *needStackRestore = true;
-        Value *jvt = emit_typeof(jv);
+        Value *jvt = emit_typeof(jvinfo);
         BasicBlock *mutableBB = BasicBlock::Create(getGlobalContext(),"is-mutable",ctx->f);
         BasicBlock *immutableBB = BasicBlock::Create(getGlobalContext(),"is-immutable",ctx->f);
         BasicBlock *afterBB = BasicBlock::Create(getGlobalContext(),"after",ctx->f);
@@ -433,7 +409,7 @@ static Value *julia_to_native(Type *ty, jl_value_t *jt, Value *jv,
                 T_int1);
         builder.CreateCondBr(ismutable, mutableBB, immutableBB);
         builder.SetInsertPoint(mutableBB);
-        Value *p1 = builder.CreatePointerCast(jv, ty);
+        Value *p1 = builder.CreatePointerCast(jvinfo.V, to);
         builder.CreateBr(afterBB);
         builder.SetInsertPoint(immutableBB);
         Value *nbytes = tbaa_decorate(tbaa_datatype, builder.CreateLoad(
@@ -442,38 +418,24 @@ static Value *julia_to_native(Type *ty, jl_value_t *jt, Value *jv,
                     false));
         AllocaInst *ai = builder.CreateAlloca(T_int8, nbytes);
         ai->setAlignment(16);
-        builder.CreateMemCpy(ai, builder.CreatePointerCast(jv, T_pint8), nbytes, sizeof(void*)); // minimum gc-alignment in julia is pointer size
-        Value *p2 = builder.CreatePointerCast(ai, ty);
+        builder.CreateMemCpy(ai, builder.CreatePointerCast(jvinfo.V, T_pint8), nbytes, sizeof(void*)); // minimum gc-alignment in julia is pointer size
+        Value *p2 = builder.CreatePointerCast(ai, to);
         builder.CreateBr(afterBB);
         builder.SetInsertPoint(afterBB);
-        PHINode *p = builder.CreatePHI(ty, 2);
+        PHINode *p = builder.CreatePHI(to, 2);
         p->addIncoming(p1, mutableBB);
         p->addIncoming(p2, immutableBB);
         return p;
     }
-    if (addressOf)
-        jl_error("ccall: unexpected & on argument"); // the only "safe" thing to emit here is the expected struct
-    assert(jl_is_datatype(jt));
-    if (aty != jt) {
-        std::stringstream msg;
-        msg << "ccall argument ";
-        msg << argn;
-        emit_typecheck(jv, jt, msg.str(), ctx);
-    }
-    Value *pjv = builder.CreatePointerCast(jv, PointerType::get(ty,0));
-    if (byRef) {
-        if (!needCopy) {
-            return pjv;
-        }
-        else {
-            Value *mem = emit_static_alloca(ty, ctx);
-            builder.CreateMemCpy(mem, pjv, (uint64_t)jl_datatype_size(jt), (uint64_t)((jl_datatype_t*)jt)->alignment);
-            return mem;
-        }
-    }
-    else {
-        return pjv; // lazy load by llvm_type_rewrite
-    }
+
+    // pass the address of an alloca'd thing, not a box
+    // since those are immutable.
+    Value *slot = emit_static_alloca(to->getContainedType(0), ctx);
+    if (!jvinfo.isboxed)
+        builder.CreateStore(emit_unbox(to->getContainedType(0), jvinfo, jlto), slot);
+    else
+        builder.CreateMemCpy(slot, builder.CreateBitCast(jvinfo.V, T_pint8), (uint64_t)jl_datatype_size(jlto), (uint64_t)((jl_datatype_t*)jlto)->alignment);
+    return slot;
 }
 
 typedef struct {
@@ -492,7 +454,7 @@ static native_sym_arg_t interpret_symbol_arg(jl_value_t *arg, jl_codectx_t *ctx,
     ptr = static_eval(arg, ctx, true);
     if (ptr == NULL) {
         jl_value_t *ptr_ty = expr_type(arg, ctx);
-        Value *arg1 = emit_unboxed(arg, ctx);
+        jl_cgval_t arg1 = emit_unboxed(arg, ctx);
         if (!jl_is_cpointer_type(ptr_ty)) {
             emit_cpointercheck(arg1,
                                !strcmp(fname,"ccall") ?
@@ -500,6 +462,8 @@ static native_sym_arg_t interpret_symbol_arg(jl_value_t *arg, jl_codectx_t *ctx,
                                "cglobal: first argument not a pointer or valid constant expression",
                                ctx);
         }
+        arg1.typ = (jl_value_t*)jl_voidpointer_type;
+        arg1.isboxed = false;
         jl_ptr = emit_unbox(T_size, arg1, (jl_value_t*)jl_voidpointer_type);
     }
 
@@ -559,7 +523,7 @@ typedef AttributeSet attr_type;
 
 // --- code generator for cglobal ---
 
-static Value *emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
+static jl_cgval_t emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 {
     JL_NARGS(cglobal, 1, 2);
     jl_value_t *rt=NULL;
@@ -625,7 +589,7 @@ static Value *emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 }
 
 // llvmcall(ir, (rettypes...), (argtypes...), args...)
-static Value *emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
+static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 {
     JL_NARGSV(llvmcall, 3)
     jl_value_t *rt = NULL, *at = NULL, *ir = NULL;
@@ -704,27 +668,23 @@ static Value *emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             jl_error("Missing arguments to llvmcall!");
         }
         jl_value_t *argi = args[4+i];
-        Value *arg;
+        jl_cgval_t arg;
         bool needroot = false;
         if (t == jl_pvalue_llvmt || !jl_isbits(tti)) {
             arg = emit_expr(argi, ctx, true);
-            if (t == jl_pvalue_llvmt && arg->getType() != jl_pvalue_llvmt) {
-                arg = boxed(arg, ctx);
+            if (t == jl_pvalue_llvmt && !arg.isboxed) {
                 needroot = true;
             }
         }
         else {
             arg = emit_unboxed(argi, ctx);
-            if (jl_is_bitstype(expr_type(argi, ctx))) {
-                arg = emit_unbox(t, arg, tti);
-            }
         }
 
+        Value *v = julia_to_native(t, tti, arg, false, false, false, false, false, i, ctx, NULL);
         // make sure args are rooted
         if (t == jl_pvalue_llvmt && (needroot || might_need_root(argi))) {
-            make_gcroot(arg, ctx);
+            make_gcroot(v, ctx);
         }
-        Value *v = julia_to_native(t, tti, arg, expr_type(argi, ctx), false, false, false, false, false, i, ctx, NULL);
         bool issigned = jl_signed_type && jl_subtype(tti, (jl_value_t*)jl_signed_type, 0);
         argvals[i] = llvm_type_rewrite(v, t, t, false, false, issigned, ctx);
     }
@@ -832,18 +792,17 @@ static Value *emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 
 // --- code generator for ccall itself ---
 
-int try_to_determine_bitstype_nbits(jl_value_t *targ, jl_codectx_t *ctx);
-
-static Value *mark_or_box_ccall_result(Value *result, jl_value_t *rt_expr, jl_value_t *rt, bool static_rt, jl_codectx_t *ctx)
+static jl_cgval_t mark_or_box_ccall_result(Value *result, jl_value_t *rt_expr, jl_value_t *rt, bool static_rt, jl_codectx_t *ctx)
 {
-    if (!static_rt && rt != (jl_value_t*)jl_any_type) {
-        // box if type was not statically known
-        int nbits = try_to_determine_bitstype_nbits(rt_expr, ctx);
-        return allocate_box_dynamic(emit_expr(rt_expr, ctx),
-                                    ConstantInt::get(T_size, nbits/8),
-                                    result);
+    if (!static_rt) {
+        // box if concrete type was not statically known
+        assert(rt == (jl_value_t*)jl_voidpointer_type);
+        Value *runtime_bt = boxed(emit_expr(rt_expr, ctx), ctx);
+        int nb = sizeof(void*);
+        return mark_julia_type(
+                init_bits_value(emit_allocobj(nb), runtime_bt, result),
+                (jl_value_t*)jl_pointer_type);
     }
-
     return mark_julia_type(result, rt);
 }
 
@@ -983,7 +942,7 @@ static std::string generate_func_sig(Type **lrt, Type **prt, int &sret,
 
 
 // ccall(pointer, rettype, (argtypes...), args...)
-static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
+static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
 {
     JL_NARGSV(ccall, 3);
     jl_value_t *rt=NULL, *at=NULL;
@@ -1000,9 +959,9 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     bool isVa = false;
 
     if (f_name == NULL && fptr == NULL && jl_ptr == NULL) {
-        JL_GC_POP();
         emit_error("ccall: null function pointer", ctx);
-        return literal_pointer_val(jl_nothing);
+        JL_GC_POP();
+        return jl_cgval_t();
     }
 
     jl_value_t *rtt_ = expr_type(args[2], ctx);
@@ -1026,12 +985,13 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                 else if (jl_subtype(jl_tparam0(rtt_), (jl_value_t*)jl_array_type, 0)) {
                     // `Array` used as return type just returns a julia object reference
                     rt = (jl_value_t*)jl_any_type;
+                    static_rt = true;
                 }
             }
             if (rt == NULL) {
                 emit_error("error interpreting ccall return type", ctx);
                 JL_GC_POP();
-                return UndefValue::get(T_void);
+                return jl_cgval_t();
             }
         }
     }
@@ -1058,9 +1018,9 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     JL_TYPECHK(ccall, type, rt);
     Type *lrt = julia_struct_to_llvm(rt);
     if (lrt == NULL) {
-        JL_GC_POP();
         emit_error("ccall: return type doesn't correspond to a C type", ctx);
-        return literal_pointer_val(jl_nothing);
+        JL_GC_POP();
+        return jl_cgval_t();
     }
 
     {
@@ -1073,7 +1033,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             //jl_rethrow_with_add("error interpreting ccall argument tuple");
             emit_error("error interpreting ccall argument tuple", ctx);
             JL_GC_POP();
-            return UndefValue::get(lrt);
+            return jl_cgval_t();
         }
     }
 
@@ -1112,7 +1072,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         if (jl_is_cpointer_type(tti) && jl_is_typevar(jl_tparam0(tti))) {
             JL_GC_POP();
             emit_error("ccall: argument type Ptr should have an element type, Ptr{T}",ctx);
-            return literal_pointer_val(jl_nothing);
+            return jl_cgval_t();
         }
         if (jl_is_vararg_type(tti))
             isVa = true;
@@ -1131,9 +1091,9 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         assert(nargt==1);
         jl_value_t *argi = args[4];
         assert(!(jl_is_expr(argi) && ((jl_expr_t*)argi)->head == amp_sym));
-        Value *ary = emit_expr(argi, ctx);
+        jl_cgval_t ary = emit_expr(argi, ctx);
         JL_GC_POP();
-        return mark_or_box_ccall_result(builder.CreateBitCast(emit_arrayptr(ary),lrt),
+        return mark_or_box_ccall_result(builder.CreateBitCast(emit_arrayptr(boxed(ary, ctx)),lrt),
                                         args[2], rt, static_rt, ctx);
     }
     if (fptr == (void *) &jl_value_ptr ||
@@ -1157,13 +1117,13 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         if (addressOf)
             largty = jl_pvalue_llvmt;
         else
-            largty = julia_struct_to_llvm(jl_svecref(tt, 0));
+            largty = julia_struct_to_llvm(tti);
         if (largty == jl_pvalue_llvmt) {
             ary = boxed(emit_expr(argi, ctx),ctx);
         }
         else {
             assert(!addressOf);
-            ary = emit_unbox(largty, emit_unboxed(argi, ctx), jl_svecref(tt, 0));
+            ary = emit_unbox(largty, emit_unboxed(argi, ctx), tti);
         }
         JL_GC_POP();
         return mark_or_box_ccall_result(builder.CreateBitCast(ary, lrt),
@@ -1178,7 +1138,8 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
         if (jl_is_type_type(ty) && !jl_is_typevar(jl_tparam0(ty))) {
             int isleaf = jl_is_leaf_type(jl_tparam0(ty));
             JL_GC_POP();
-            return ConstantInt::get(T_int32, isleaf);
+            return mark_or_box_ccall_result(ConstantInt::get(T_int32, isleaf),
+                    args[2], rt, static_rt, ctx);
         }
     }
     if (fptr == (void*)&jl_function_ptr ||
@@ -1246,7 +1207,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     if (!err_msg.empty()) {
         JL_GC_POP();
         emit_error(err_msg,ctx);
-        return literal_pointer_val(jl_nothing);
+        return jl_cgval_t();
     }
 
     // emit arguments
@@ -1257,16 +1218,17 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     // First, if the ABI requires us to provide the space for the return
     // argument, allocate the box and store that as the first argument type
     if (sret) {
-        result = emit_new_struct(rt,1,NULL,ctx); // TODO: is it valid to be creating an incomplete type this way?
-        assert(result != NULL && "Type was not concrete");
-        if (!result->getType()->isPointerTy()) {
+        jl_cgval_t sret_val = emit_new_struct(rt,1,NULL,ctx); // TODO: is it valid to be creating an incomplete type this way?
+        assert(sret_val.typ != NULL && "Type was not concrete");
+        if (!sret_val.ispointer) {
             Value *mem = emit_static_alloca(lrt, ctx);
-            builder.CreateStore(result, mem);
+            builder.CreateStore(sret_val.V, mem);
             result = mem;
             argvals[0] = result;
         }
         else {
             // XXX: result needs a GC root here if result->getType() == jl_pvalue_llvmt
+            result = sret_val.V;
             argvals[0] = builder.CreateBitCast(result, fargt_sig[0]);
         }
     }
@@ -1309,59 +1271,39 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             jargty = jl_svecref(tt,ai);
         }
 
-        Value *arg;
+        jl_cgval_t arg;
         bool needroot = false;
         if (jl_is_abstract_ref_type(jargty)) {
             if (addressOf)
                 emit_error("ccall: & on a Ref{T} argument is invalid", ctx);
             arg = emit_unboxed((jl_value_t*)argi, ctx);
-            if (arg->getType() == jl_pvalue_llvmt) {
+            if (!jl_is_cpointer_type(arg.typ)) {
                 emit_cpointercheck(arg, "ccall: argument to Ref{T} is not a pointer", ctx);
-                arg = emit_unbox(largty, arg, (jl_value_t*)jl_voidpointer_type);
+                arg.typ = (jl_value_t*)jl_voidpointer_type;
+                arg.isboxed = false;
             }
-            if (arg->getType() != T_pint8)
-                arg = builder.CreatePointerCast(arg, T_pint8);
             jargty = (jl_value_t*)jl_voidpointer_type;
         }
         else if (largty == jl_pvalue_llvmt || largty->isStructTy()) {
             arg = emit_expr(argi, ctx, true);
-            if (largty == jl_pvalue_llvmt && arg->getType() != jl_pvalue_llvmt) {
-                arg = boxed(arg,ctx);
+            if (largty == jl_pvalue_llvmt && !arg.isboxed) {
                 needroot = true;
             }
         }
         else {
             arg = emit_unboxed(argi, ctx);
-            if (jl_is_bitstype(expr_type(argi, ctx))) {
-                Type *at = arg->getType();
-                Type *totype = addressOf ? largty->getContainedType(0) : largty;
-                if (at != jl_pvalue_llvmt && at != totype &&
-                    !(at->isPointerTy() && jargty==(jl_value_t*)jl_voidpointer_type)) {
-                    emit_type_error(arg, jargty, "ccall", ctx);
-                    arg = UndefValue::get(totype);
-                }
-                else {
-                    arg = emit_unbox(totype, arg, jargty);
-                }
-            }
         }
 
+        Value *v = julia_to_native(largty, jargty, arg, addressOf, byRefList[ai], inRegList[ai],
+                    need_private_copy(jargty, byRefList[ai]), false, ai + 1, ctx, &needStackRestore);
         // make sure args are rooted
         if (largty == jl_pvalue_llvmt && (needroot || might_need_root(argi))) {
-            make_gcroot(arg, ctx);
+            make_gcroot(v, ctx);
         }
-
-        bool nSR=false;
         bool issigned = jl_signed_type && jl_subtype(jargty, (jl_value_t*)jl_signed_type, 0);
-        assert(byRefList.size() == inRegList.size() && byRefIndex < byRefList.size());
-        bool byRef = byRefList[byRefIndex];
-        bool inReg = inRegList[byRefIndex];
-        argvals[ai + sret] = llvm_type_rewrite(
-                julia_to_native(largty, jargty, arg, expr_type(argi, ctx), addressOf, byRef, inReg,
-                    need_private_copy(jargty, byRef), false, ai + 1, ctx, &nSR),
-                largty, ai + sret < fargt_sig.size() ? fargt_sig[ai + sret] : fargt_vasig,
-                false, byRef, issigned, ctx);
-        needStackRestore |= nSR;
+        argvals[ai + sret] = llvm_type_rewrite(v, largty,
+                ai + sret < fargt_sig.size() ? fargt_sig[ai + sret] : fargt_vasig,
+                false, byRefList[ai], issigned, ctx);
     }
 
 
@@ -1404,7 +1346,7 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                     msg << f_lib;
                 }
                 emit_error(msg.str(), ctx);
-                return literal_pointer_val(jl_nothing);
+                return jl_cgval_t();
             }
             // since we aren't saving this code, there's no sense in
             // putting anything complicated here: just JIT the function address
@@ -1451,17 +1393,17 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     // type because the ABI required us to pass a pointer (sret),
     // then we do not need to do this.
     if (!sret) {
-        if (lrt == T_void)
-            result = literal_pointer_val((jl_value_t*)jl_nothing);
+        if (type_is_ghost(lrt))
+            return ghostValue(rt);
         else if (lrt->isStructTy()) {
             //fprintf(stderr, "ccall rt: %s -> %s\n", f_name, ((jl_tag_type_t*)rt)->name->name->name);
             assert(jl_is_structtype(rt));
-            Value *newst = emit_new_struct(rt,1,NULL,ctx);
-            assert(newst != NULL && "Type was not concrete");
-            assert(newst->getType()->isPointerTy());
+            jl_cgval_t newst = emit_new_struct(rt,1,NULL,ctx);
+            assert(newst.typ != NULL && "Type was not concrete");
+            assert(newst.ispointer);
             // julia gc is aligned 16, otherwise use default alignment for alloca pointers
-            builder.CreateAlignedStore(result, builder.CreateBitCast(newst, prt->getPointerTo()), newst->getType()==jl_pvalue_llvmt ? 16 : 0);
-            result = newst;
+            builder.CreateAlignedStore(result, builder.CreateBitCast(newst.V, prt->getPointerTo()), newst.V->getType() == jl_pvalue_llvmt ? 16 : 0);
+            result = newst.V;
         }
         else {
             if (prt->getPrimitiveSizeInBits() == lrt->getPrimitiveSizeInBits()) {

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -281,7 +281,7 @@ Value *llvm_type_rewrite(Value *v, Type *from_type, Type *target_type,
     }
 
     // simple integer and float widening & conversion cases
-    if (from_type->isPrimitiveType() && target_type->getPrimitiveSizeInBits() == from_type->getPrimitiveSizeInBits()) {
+    if (from_type->getPrimitiveSizeInBits() > 0 && target_type->getPrimitiveSizeInBits() == from_type->getPrimitiveSizeInBits()) {
         return builder.CreateBitCast(v, target_type);
     }
     if (target_type->isFloatingPointTy() && from_type->isFloatingPointTy()) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1748,6 +1748,8 @@ static jl_value_t *static_constant_instance(Constant *constant, jl_value_t *jt)
     ConstantInt *cint = dyn_cast<ConstantInt>(constant);
     if (cint != NULL) {
         assert(jl_is_datatype(jt));
+        if (jt == (jl_value_t*)jl_bool_type)
+            return cint->isZero() ? jl_false : jl_true;
         return jl_new_bits(jt,
             const_cast<uint64_t *>(cint->getValue().getRawData()));
     }
@@ -1774,8 +1776,6 @@ static jl_value_t *static_constant_instance(Constant *constant, jl_value_t *jt)
         }
     }
 
-    assert(jl_is_tuple_type(jt));
-
     size_t nargs = 0;
     ConstantStruct *cst = NULL;
     ConstantVector *cvec = NULL;
@@ -1790,6 +1790,8 @@ static jl_value_t *static_constant_instance(Constant *constant, jl_value_t *jt)
         return NULL;
     else
         assert(false && "Cannot process this type of constant");
+
+    assert(jl_is_tuple_type(jt));
 
     jl_value_t **tupleargs;
     JL_GC_PUSHARGS(tupleargs, nargs);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -658,7 +658,8 @@ static Value *julia_binding_gv(jl_binding_t *b)
 
 static Type *julia_struct_to_llvm(jl_value_t *jt);
 
-static Type *julia_type_to_llvm(jl_value_t *jt)
+extern "C" {
+DLLEXPORT Type *julia_type_to_llvm(jl_value_t *jt)
 {
     // this function converts a Julia Type into the equivalent LLVM type
     if (jt == (jl_value_t*)jl_bool_type) return T_int1;
@@ -697,6 +698,7 @@ static Type *julia_type_to_llvm(jl_value_t *jt)
         return julia_struct_to_llvm(jt);
     }
     return jl_pvalue_llvmt;
+}
 }
 
 static Type *julia_struct_to_llvm(jl_value_t *jt)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -18,7 +18,7 @@ template<class T>
 static T* addComdat(T *G) { return G; }
 #endif
 
-static Value *tbaa_decorate(MDNode* md, Instruction* load_or_store)
+static Instruction *tbaa_decorate(MDNode* md, Instruction* load_or_store)
 {
     load_or_store->setMetadata( llvm::LLVMContext::MD_tbaa, md );
     return load_or_store;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1585,6 +1585,9 @@ static jl_value_t *static_constant_instance(Constant *constant, jl_value_t *jt)
 {
     assert(constant != NULL);
 
+    if (isa<UndefValue>(constant))
+	return NULL;
+
     ConstantInt *cint = dyn_cast<ConstantInt>(constant);
     if (cint != NULL) {
         assert(jl_is_datatype(jt));

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -656,15 +656,9 @@ static Value *julia_binding_gv(jl_binding_t *b)
 
 // --- mapping between julia and llvm types ---
 
-static bool type_is_ghost(Type *ty)
-{
-    return (ty == T_void || ty->isEmptyTy());
-}
-
 static Type *julia_struct_to_llvm(jl_value_t *jt);
 
-extern "C" {
-DLLEXPORT Type *julia_type_to_llvm(jl_value_t *jt)
+static Type *julia_type_to_llvm(jl_value_t *jt)
 {
     // this function converts a Julia Type into the equivalent LLVM type
     if (jt == (jl_value_t*)jl_bool_type) return T_int1;
@@ -704,7 +698,6 @@ DLLEXPORT Type *julia_type_to_llvm(jl_value_t *jt)
     }
     return jl_pvalue_llvmt;
 }
-}
 
 static Type *julia_struct_to_llvm(jl_value_t *jt)
 {
@@ -739,7 +732,7 @@ static Type *julia_struct_to_llvm(jl_value_t *jt)
                 if (lasttype != NULL && lasttype != lty)
                     isvector = false;
                 lasttype = lty;
-                if (lty == T_void || lty->isEmptyTy())
+                if (type_is_ghost(lty))
                     lty = NoopType;
                 latypes.push_back(lty);
             }
@@ -747,7 +740,7 @@ static Type *julia_struct_to_llvm(jl_value_t *jt)
                 structdecl->setBody(latypes);
             }
             else {
-                if (isvector && lasttype != T_int1 && lasttype != T_void) {
+                if (isvector && lasttype != T_int1 && !type_is_ghost(lasttype)) {
                     // TODO: currently we get LLVM assertion failures for other vector sizes
                     bool validVectorSize = (ntypes == 2 || ntypes == 4 || ntypes == 6);
                     if (0 && lasttype->isSingleValueType() && !lasttype->isVectorTy() && validVectorSize) // currently disabled due to load/store alignment issues
@@ -763,37 +756,6 @@ static Type *julia_struct_to_llvm(jl_value_t *jt)
         return (Type*)jst->struct_decl;
     }
     return julia_type_to_llvm(jt);
-}
-
-// NOTE: llvm cannot express all julia types (for example unsigned),
-// so this is an approximation. it's only correct if the associated LLVM
-// value is not tagged with our value name hack.
-// boxed(v) below gets the correct type.
-static jl_value_t *llvm_type_to_julia(Type *t, bool throw_error)
-{
-    if (t == T_int1)  return (jl_value_t*)jl_bool_type;
-    if (t == T_int8)  return (jl_value_t*)jl_int8_type;
-    if (t == T_int16) return (jl_value_t*)jl_int16_type;
-    if (t == T_int32) return (jl_value_t*)jl_int32_type;
-    if (t == T_int64) return (jl_value_t*)jl_int64_type;
-    if (t == T_float32) return (jl_value_t*)jl_float32_type;
-    if (t == T_float64) return (jl_value_t*)jl_float64_type;
-    if (t == T_void) return (jl_value_t*)jl_void_type;
-    if (t->isEmptyTy()) return (jl_value_t*)jl_void_type;
-    if (t == jl_pvalue_llvmt)
-        return (jl_value_t*)jl_any_type;
-    if (t->isPointerTy()) {
-        jl_value_t *elty = llvm_type_to_julia(t->getContainedType(0),
-                                              throw_error);
-        if (elty != NULL) {
-            return (jl_value_t*)jl_apply_type((jl_value_t*)jl_pointer_type,
-                                              jl_svec1(elty));
-        }
-    }
-    if (throw_error) {
-        jl_error("cannot convert type to a julia type");
-    }
-    return NULL;
 }
 
 static bool is_datatype_all_pointers(jl_datatype_t *dt)
@@ -819,114 +781,6 @@ static bool is_tupletype_homogeneous(jl_svec_t *t)
         }
     }
     return true;
-}
-
-// --- scheme for tagging llvm values with julia types using metadata ---
-
-static std::map<int, jl_value_t*> typeIdToType;
-extern "C" {
-    jl_array_t *typeToTypeId;
-}
-static int cur_type_id = 1;
-
-static int jl_type_to_typeid(jl_value_t *t)
-{
-    jl_value_t *idx = jl_eqtable_get(typeToTypeId, t, NULL);
-    if (idx == NULL) {
-        int mine = cur_type_id++;
-        if (mine > 65025)
-            jl_error("internal compiler error: too many bits types");
-        JL_GC_PUSH1(&idx);
-        idx = jl_box_long(mine);
-        typeToTypeId = jl_eqtable_put(typeToTypeId, t, idx);
-        typeIdToType[mine] = t;
-        JL_GC_POP();
-        return mine;
-    }
-    return jl_unbox_long(idx);
-}
-
-static jl_value_t *jl_typeid_to_type(int i)
-{
-    std::map<int, jl_value_t*>::iterator it = typeIdToType.find(i);
-    if (it == typeIdToType.end()) {
-        jl_error("internal compiler error: invalid type id");
-    }
-    return (*it).second;
-}
-
-static bool has_julia_type(Value *v)
-{
-    Instruction *inst = (dyn_cast<Instruction>(v));
-    return (inst != NULL) &&
-            (inst->getMetadata("julia_type")!=NULL);
-}
-
-static jl_value_t *julia_type_of_without_metadata(Value *v, bool err=true)
-{
-    if (dyn_cast<AllocaInst>(v) != NULL ||
-        dyn_cast<GetElementPtrInst>(v) != NULL) {
-        // an alloca always has llvm type pointer
-        return llvm_type_to_julia(v->getType()->getContainedType(0), err);
-    }
-    return llvm_type_to_julia(v->getType(), err);
-}
-
-static jl_value_t *julia_type_of(Value *v)
-{
-    MDNode *mdn;
-    assert(v != NULL);
-    if (dyn_cast<Instruction>(v) == NULL ||
-        (mdn = ((Instruction*)v)->getMetadata("julia_type")) == NULL) {
-        return julia_type_of_without_metadata(v, true);
-    }
-#ifdef LLVM36
-    MDString *md = dyn_cast<MDString>(mdn->getOperand(0).get());
-#else
-    MDString *md = (MDString*)mdn->getOperand(0);
-#endif
-    assert(md != NULL);
-    const unsigned char *vts = (const unsigned char*)md->getString().data();
-    int idx = (vts[0]-1) + (vts[1]-1)*255;
-    return jl_typeid_to_type(idx);
-}
-
-static Value *NoOpInst(Value *v)
-{
-    v = SelectInst::Create(ConstantInt::get(T_int1,1), v, v);
-    builder.Insert((Instruction*)v);
-    return v;
-}
-
-static Value *mark_julia_type(Value *v, jl_value_t *jt)
-{
-    if (jt == (jl_value_t*)jl_any_type || v->getType()==jl_pvalue_llvmt)
-        return v;
-    if (has_julia_type(v)) {
-        if (julia_type_of(v) == jt)
-            return v;
-        v = NoOpInst(v);
-    }
-    else if (julia_type_of_without_metadata(v,false) == jt) {
-        return v;
-    }
-    if (dyn_cast<Instruction>(v) == NULL)
-        v = NoOpInst(v);
-    assert(dyn_cast<Instruction>(v));
-    char name[3];
-    int idx = jl_type_to_typeid(jt);
-    // store idx as base-255 to avoid NUL
-    name[0] = (idx%255)+1;
-    name[1] = (idx/255)+1;
-    name[2] = '\0';
-    MDString *md = MDString::get(jl_LLVMContext, name);
-#ifdef LLVM36
-    MDNode *mdn = MDNode::get(jl_LLVMContext, ArrayRef<Metadata*>(md));
-#else
-    MDNode *mdn = MDNode::get(jl_LLVMContext, ArrayRef<Value*>(md));
-#endif
-    ((Instruction*)v)->setMetadata("julia_type", mdn);
-    return v;
 }
 
 // --- generating various field accessors ---
@@ -969,37 +823,48 @@ static Value *emit_typeptr_addr(Value *p)
    return emit_nthptr_addr(p, -offset);
 }
 
-static Value *emit_typeof(Value *p)
+static Value *emit_typeof(Value *tt)
 {
     // given p, a jl_value_t*, compute its type tag
-    if (p->getType() == jl_pvalue_llvmt) {
-        Value *tt = builder.CreateBitCast(p, jl_ppvalue_llvmt);
-        tt = builder.CreateLoad(emit_typeptr_addr(tt), false);
-        tt = builder.CreateIntToPtr(builder.CreateAnd(
-                    builder.CreatePtrToInt(tt, T_size),
-                    ConstantInt::get(T_size,~(uptrint_t)15)),
-                jl_pvalue_llvmt);
-        return tt;
+    assert(tt->getType() == jl_pvalue_llvmt);
+    tt = builder.CreateLoad(emit_typeptr_addr(tt), false);
+    tt = builder.CreateIntToPtr(builder.CreateAnd(
+                builder.CreatePtrToInt(tt, T_size),
+                ConstantInt::get(T_size,~(uptrint_t)15)),
+            jl_pvalue_llvmt);
+    return tt;
+}
+static Value *emit_typeof(const jl_cgval_t &p)
+{
+    // given p, compute its type
+    if (p.isboxed && !jl_is_leaf_type(p.typ)) {
+        return emit_typeof(p.V);
     }
-    return literal_pointer_val(julia_type_of(p));
+    jl_value_t *aty = p.typ;
+    if (jl_is_type_type(aty)) // convert Int::Type{Int} ==> typeof(Int) ==> DataType
+                              // but convert 1::Type{1} ==> typeof(1) ==> Int
+        aty = (jl_value_t*)jl_typeof(jl_tparam0(aty));
+    return literal_pointer_val(aty);
 }
 
-static Value *emit_datatype_types(Value *dt)
+static Value *emit_datatype_types(const jl_cgval_t &dt)
 {
+    assert(dt.isboxed);
     return builder.
         CreateLoad(builder.
                    CreateBitCast(builder.
-                                 CreateGEP(builder.CreateBitCast(dt, T_pint8),
+                                 CreateGEP(builder.CreateBitCast(dt.V, T_pint8),
                                            ConstantInt::get(T_size, offsetof(jl_datatype_t, types))),
                                  jl_ppvalue_llvmt));
 }
 
-static Value *emit_datatype_nfields(Value *dt)
+static Value *emit_datatype_nfields(const jl_cgval_t &dt)
 {
+    assert(dt.isboxed);
     Value *nf = builder.
         CreateLoad(builder.
                    CreateBitCast(builder.
-                                 CreateGEP(builder.CreateBitCast(dt, T_pint8),
+                                 CreateGEP(builder.CreateBitCast(dt.V, T_pint8),
                                            ConstantInt::get(T_size, offsetof(jl_datatype_t, nfields))),
                                  T_pint32));
 #ifdef _P64
@@ -1009,8 +874,6 @@ static Value *emit_datatype_nfields(Value *dt)
 }
 
 // --- generating various error checks ---
-
-static jl_value_t *llvm_type_to_julia(Type *t, bool err=true);
 
 static void just_emit_error(const std::string &txt, jl_codectx_t *ctx)
 {
@@ -1082,9 +945,9 @@ static void null_pointer_check(Value *v, jl_codectx_t *ctx)
                            prepare_global(jlundeferr_var), ctx);
 }
 
-static Value *boxed(Value *v, jl_codectx_t *ctx, jl_value_t *jt=NULL);
+static Value *boxed(const jl_cgval_t &v, jl_codectx_t *ctx, jl_value_t *jt=NULL);
 
-static void emit_type_error(Value *x, jl_value_t *type, const std::string &msg,
+static void emit_type_error(const jl_cgval_t &x, jl_value_t *type, const std::string &msg,
                             jl_codectx_t *ctx)
 {
     Value *zeros[2] = { ConstantInt::get(T_int32, 0),
@@ -1106,18 +969,19 @@ static void emit_type_error(Value *x, jl_value_t *type, const std::string &msg,
 #endif
 }
 
-static void emit_typecheck(Value *x, jl_value_t *type, const std::string &msg,
+static void emit_typecheck(const jl_cgval_t &x, jl_value_t *type, const std::string &msg,
                            jl_codectx_t *ctx)
 {
     Value *istype;
     if (jl_is_type_type(type) || !jl_is_leaf_type(type)) {
+        Value *vx = boxed(x, ctx, type);
         istype = builder.
             CreateICmpNE(
 #ifdef LLVM37
-                builder.CreateCall(prepare_call(jlsubtype_func), { x, literal_pointer_val(type),
+                builder.CreateCall(prepare_call(jlsubtype_func), { vx, literal_pointer_val(type),
                                              ConstantInt::get(T_int32,1) }),
 #else
-                builder.CreateCall3(prepare_call(jlsubtype_func), x, literal_pointer_val(type),
+                builder.CreateCall3(prepare_call(jlsubtype_func), vx, literal_pointer_val(type),
                                              ConstantInt::get(T_int32,1)),
 #endif
                          ConstantInt::get(T_int32,0));
@@ -1138,7 +1002,7 @@ static void emit_typecheck(Value *x, jl_value_t *type, const std::string &msg,
 }
 
 #define CHECK_BOUNDS 1
-static Value *emit_bounds_check(Value *a, jl_value_t *ty, Value *i, Value *len, jl_codectx_t *ctx)
+static Value *emit_bounds_check(const jl_cgval_t &ainfo, jl_value_t *ty, Value *i, Value *len, jl_codectx_t *ctx)
 {
     Value *im1 = builder.CreateSub(i, ConstantInt::get(T_size, 1));
 #if CHECK_BOUNDS==1
@@ -1150,15 +1014,26 @@ static Value *emit_bounds_check(Value *a, jl_value_t *ty, Value *i, Value *len, 
         BasicBlock *passBB = BasicBlock::Create(getGlobalContext(),"pass");
         builder.CreateCondBr(ok, passBB, failBB);
         builder.SetInsertPoint(failBB);
-        if (ty == (jl_value_t*)jl_any_type) {
+        if (!ty) { // jl_value_t** tuple (e.g. the vararg)
 #ifdef LLVM37
-            builder.CreateCall(prepare_call(jlvboundserror_func), { a, len, i });
+            builder.CreateCall(prepare_call(jlvboundserror_func), { ainfo.V, len, i });
 #else
-            builder.CreateCall3(prepare_call(jlvboundserror_func), a, len, i);
+            builder.CreateCall3(prepare_call(jlvboundserror_func), ainfo.V, len, i);
 #endif
         }
-        else if (ty && a->getType() != jl_pvalue_llvmt) {
-            if (!a->getType()->isPtrOrPtrVectorTy()) {
+        else if (ainfo.isboxed) { // jl_datatype_t or boxed jl_value_t
+#ifdef LLVM37
+            builder.CreateCall(prepare_call(jlboundserror_func), { ainfo.V, i });
+#else
+            builder.CreateCall2(prepare_call(jlboundserror_func), ainfo.V, i);
+#endif
+        }
+        else { // unboxed jl_value_t*
+            Value *a = ainfo.V;
+            if (ainfo.isghost) {
+                a = Constant::getNullValue(T_pint8);
+            }
+            else if (!ainfo.ispointer) {
                 // CreateAlloca is OK here since we are on an error branch
                 Value *tempSpace = builder.CreateAlloca(a->getType());
                 builder.CreateStore(a, tempSpace);
@@ -1176,13 +1051,6 @@ static Value *emit_bounds_check(Value *a, jl_value_t *ty, Value *i, Value *len, 
                                 i);
 #endif
         }
-        else {
-#ifdef LLVM37
-            builder.CreateCall(prepare_call(jlboundserror_func), { a, i });
-#else
-            builder.CreateCall2(prepare_call(jlboundserror_func), a, i);
-#endif
-        }
         builder.CreateUnreachable();
         ctx->f->getBasicBlockList().push_back(passBB);
         builder.SetInsertPoint(passBB);
@@ -1193,30 +1061,14 @@ static Value *emit_bounds_check(Value *a, jl_value_t *ty, Value *i, Value *len, 
 
 // --- loading and storing ---
 
-static AllocaInst *emit_static_alloca(Type *lty, jl_codectx_t *ctx) {
-    return new AllocaInst(lty, "", /*InsertBefore=*/ctx->gc.gcframe);
-}
+static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt);
 
-static Value *emit_reg2mem(Value *v, jl_codectx_t *ctx) {
-    // eagerly put this back onto the stack
-    // llvm mem2reg pass will remove this if unneeded
-    if (v->getType()->isAggregateType() && !type_is_ghost(v->getType())) {
-        Value *loc = emit_static_alloca(v->getType(), ctx);
-        builder.CreateStore(v, loc);
-        return loc;
-    }
-    return v;
-}
-
-
-static Value *ghostValue(jl_value_t *ty);
-
-static Value *typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
+static jl_cgval_t typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
                          jl_codectx_t *ctx, MDNode* tbaa, size_t alignment = 0)
 {
     Type *elty = julia_type_to_llvm(jltype);
     assert(elty != NULL);
-    if (elty == T_void)
+    if (type_is_ghost(elty))
         return ghostValue(jltype);
     bool isbool=false;
     if (elty == T_int1) {
@@ -1251,30 +1103,29 @@ static Value *typed_load(Value *ptr, Value *idx_0based, jl_value_t *jltype,
         elt = emit_reg2mem(elt, ctx);
     //}
     if (isbool)
-        return builder.CreateTrunc(elt, T_int1);
+        return mark_julia_type(builder.CreateTrunc(elt, T_int1), jltype);
     return mark_julia_type(elt, jltype);
 }
 
-static Value *emit_unbox(Type *to, Value *x, jl_value_t *jt);
-
-static void typed_store(Value *ptr, Value *idx_0based, Value *rhs,
+static void typed_store(Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
                         jl_value_t *jltype, jl_codectx_t *ctx, MDNode* tbaa,
                         Value* parent,  // for the write barrier, NULL if no barrier needed
                         size_t alignment = 0)
 {
     Type *elty = julia_type_to_llvm(jltype);
     assert(elty != NULL);
-    if (elty == T_void)
+    if (type_is_ghost(elty))
         return;
     if (elty == T_int1) {
         elty = T_int8;
     }
+    Value *r;
     if (jl_isbits(jltype) && ((jl_datatype_t*)jltype)->size > 0) {
-        rhs = emit_unbox(elty, rhs, jltype);
+        r = emit_unbox(elty, rhs, jltype);
     }
     else {
-        rhs = boxed(rhs,ctx);
-        if (parent != NULL) emit_write_barrier(ctx, parent, rhs);
+        r = boxed(rhs, ctx, jltype);
+        if (parent != NULL) emit_write_barrier(ctx, parent, r);
     }
     Value *data;
     if (ptr->getType()->getContainedType(0) != elty)
@@ -1283,7 +1134,7 @@ static void typed_store(Value *ptr, Value *idx_0based, Value *rhs,
         data = ptr;
     if (data->getType()->getContainedType(0)->isVectorTy() && !alignment)
         alignment = ((jl_datatype_t*)jltype)->alignment; // prevent llvm from assuming 32 byte alignment of vectors
-    Instruction *store = builder.CreateAlignedStore(rhs, builder.CreateGEP(data, idx_0based), alignment);
+    Instruction *store = builder.CreateAlignedStore(r, builder.CreateGEP(data, idx_0based), alignment);
     if (tbaa)
         tbaa_decorate(tbaa, store);
 }
@@ -1359,7 +1210,7 @@ static jl_value_t *expr_type(jl_value_t *e, jl_codectx_t *ctx)
             else {
                 std::map<jl_sym_t*,jl_varinfo_t>::iterator it = ctx->vars.find((jl_sym_t*)e);
                 if (it != ctx->vars.end())
-                    return (*it).second.declType;
+                    return (*it).second.value.typ;
                 return (jl_value_t*)jl_any_type;
             }
         }
@@ -1379,7 +1230,6 @@ type_of_constant:
 
 // --- accessing the representations of built-in data types ---
 
-static Value *allocate_box_dynamic(Value *jlty, Value *nb, Value *v);
 static void jl_add_linfo_root(jl_lambda_info_t *li, jl_value_t *val);
 
 static Value *data_pointer(Value *x)
@@ -1387,45 +1237,47 @@ static Value *data_pointer(Value *x)
     return builder.CreateBitCast(x, jl_ppvalue_llvmt);
 }
 
-static Value *emit_getfield_unknownidx(Value *strct, Value *idx, jl_datatype_t *stt, jl_codectx_t *ctx)
+static bool emit_getfield_unknownidx(jl_cgval_t *ret, const jl_cgval_t &strct, Value *idx, jl_datatype_t *stt, jl_codectx_t *ctx)
 {
-    Type *llvm_st = strct->getType();
     size_t nfields = jl_datatype_nfields(stt);
-    if (llvm_st == jl_pvalue_llvmt || llvm_st->isPointerTy()) { // boxed or stack
+    if (strct.ispointer) { // boxed or stack
         if (is_datatype_all_pointers(stt)) {
             idx = emit_bounds_check(strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
             Value *fld = tbaa_decorate(tbaa_user, builder.CreateLoad(
                         builder.CreateGEP(
-                            builder.CreateBitCast(strct, jl_ppvalue_llvmt),
+                            builder.CreateBitCast(strct.V, jl_ppvalue_llvmt),
                             idx)));
             if ((unsigned)stt->ninitialized != nfields)
                 null_pointer_check(fld, ctx);
-            return fld;
+            *ret = mark_julia_type(fld, jl_any_type);
+            return true;
         }
         else if (is_tupletype_homogeneous(stt->types)) {
             assert(nfields > 0); // nf == 0 trapped by all_pointers case
             jl_value_t *jt = jl_field_type(stt, 0);
             idx = emit_bounds_check(strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
-            Value *ptr = data_pointer(strct);
-            return typed_load(ptr, idx, jt, ctx, stt->mutabl ? tbaa_user : tbaa_immut);
+            Value *ptr = data_pointer(strct.V);
+            *ret = typed_load(ptr, idx, jt, ctx, stt->mutabl ? tbaa_user : tbaa_immut);
+            return true;
         }
-        else if (llvm_st == jl_pvalue_llvmt) {
+        else if (strct.isboxed) {
             idx = builder.CreateSub(idx, ConstantInt::get(T_size, 1));
 #ifdef LLVM37
-            Value *fld = builder.CreateCall(prepare_call(jlgetnthfieldchecked_func), { strct, idx });
+            Value *fld = builder.CreateCall(prepare_call(jlgetnthfieldchecked_func), { strct.V, idx });
 #else
-            Value *fld = builder.CreateCall2(prepare_call(jlgetnthfieldchecked_func), strct, idx);
+            Value *fld = builder.CreateCall2(prepare_call(jlgetnthfieldchecked_func), strct.V, idx);
 #endif
-            return fld;
+            *ret = mark_julia_type(fld, jl_any_type);
+            return true;
         }
     }
     else if (is_tupletype_homogeneous(stt->types)) {
         assert(jl_isbits(stt));
         if (nfields == 0) {
-            // TODO: pass correct thing to emit_bounds_check ?
-            idx = emit_bounds_check(tbaa_decorate(tbaa_const, builder.CreateLoad(prepare_global(jlemptysvec_var))),
+            idx = emit_bounds_check(ghostValue(stt),
                                     (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
-            return UndefValue::get(jl_pvalue_llvmt);
+            *ret = jl_cgval_t();
+            return true;
         }
         assert(!jl_field_isptr(stt, 0));
         jl_value_t *jt = jl_field_type(stt,0);
@@ -1433,45 +1285,46 @@ static Value *emit_getfield_unknownidx(Value *strct, Value *idx, jl_datatype_t *
             // add root for types not cached
             jl_add_linfo_root(ctx->linfo, (jl_value_t*)stt);
         }
-        // TODO: pass correct thing to emit_bounds_check ?
         Value *idx0 = emit_bounds_check(strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), ctx);
-        if (type_is_ghost(llvm_st)) {
-            return mark_julia_type(UndefValue::get(NoopType), jt);
+        if (strct.isghost) {
+            *ret = ghostValue(jt);
+            return true;
         }
         // llvm::VectorType
         if (sizeof(void*) != sizeof(int))
-            idx0 = builder.CreateTrunc(idx0, T_int32); // llvm3.3 requires this
-        Value *fld = builder.CreateExtractElement(strct, idx0);
+            idx0 = builder.CreateTrunc(idx0, T_int32); // llvm3.3 requires this, harmless elsewhere
+        Value *fld = builder.CreateExtractElement(strct.V, idx0);
         if (jt == (jl_value_t*)jl_bool_type) {
             fld = builder.CreateTrunc(fld, T_int1);
         }
-        return mark_julia_type(fld, jt);
+        *ret = mark_julia_type(fld, jt);
+        return true;
     }
-    return NULL;
+    return false;
 }
 
-static Value *emit_getfield_knownidx(Value *strct, unsigned idx, jl_datatype_t *jt, jl_codectx_t *ctx)
+static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, jl_datatype_t *jt, jl_codectx_t *ctx)
 {
     jl_value_t *jfty = jl_field_type(jt,idx);
     Type *elty = julia_type_to_llvm(jfty);
     assert(elty != NULL);
     if (jfty == jl_bottom_type) {
         raise_exception_unless(ConstantInt::get(T_int1,0), prepare_global(jlundeferr_var), ctx);
-        return UndefValue::get(jl_pvalue_llvmt);
+        return jl_cgval_t(); // unreachable
     }
-    if (elty == T_void)
+    if (type_is_ghost(elty))
         return ghostValue(jfty);
     Value *fldv = NULL;
-    if (strct->getType() == jl_pvalue_llvmt) {
+    if (strct.isboxed) {
         Value *addr =
-            builder.CreateGEP(builder.CreateBitCast(strct, T_pint8),
+            builder.CreateGEP(builder.CreateBitCast(strct.V, T_pint8),
                               ConstantInt::get(T_size, jl_field_offset(jt,idx)));
-        MDNode *tbaa = jt->mutabl ? tbaa_user : tbaa_immut;
+        MDNode *tbaa = strct.isimmutable ? tbaa_immut : tbaa_user;
         if (jl_field_isptr(jt,idx)) {
             Value *fldv = tbaa_decorate(tbaa, builder.CreateLoad(builder.CreateBitCast(addr,jl_ppvalue_llvmt)));
             if (idx >= (unsigned)jt->ninitialized)
                 null_pointer_check(fldv, ctx);
-            return fldv;
+            return mark_julia_type(fldv, jfty);
         }
         else {
             int align = jl_field_offset(jt,idx);
@@ -1483,20 +1336,16 @@ static Value *emit_getfield_knownidx(Value *strct, unsigned idx, jl_datatype_t *
             return typed_load(addr, ConstantInt::get(T_size, 0), jfty, ctx, tbaa, align);
         }
     }
-    else if (strct->getType()->isPointerTy()) { // something stack allocated
-#       ifdef LLVM37
+    else if (strct.ispointer) { // something stack allocated
         Value *addr = builder.CreateConstInBoundsGEP2_32(
-            cast<PointerType>(strct->getType()->getScalarType())->getElementType(),
-            strct, 0, idx);
-#       else
-        Value *addr = builder.CreateConstInBoundsGEP2_32(strct, 0, idx);
-#       endif
+            LLVM37_param(cast<PointerType>(strct.V->getType()->getScalarType())->getElementType())
+            strct.V, 0, idx);
         assert(!jt->mutabl);
         return typed_load(addr, NULL, jfty, ctx, NULL);
     }
     else {
-        assert(strct->getType()->isVectorTy());
-        fldv = builder.CreateExtractElement(strct, ConstantInt::get(T_int32, idx));
+        assert(strct.V->getType()->isVectorTy());
+        fldv = builder.CreateExtractElement(strct.V, ConstantInt::get(T_int32, idx));
         if (jfty == (jl_value_t*)jl_bool_type) {
             fldv = builder.CreateTrunc(fldv, T_int1);
         }
@@ -1518,8 +1367,10 @@ static Value *emit_n_varargs(jl_codectx_t *ctx)
 #endif
 }
 
-static Value *emit_arraysize(Value *t, Value *dim)
+static Value *emit_arraysize(const jl_cgval_t &tinfo, Value *dim)
 {
+    assert(tinfo.isboxed);
+    Value *t = tinfo.V;
     int o = offsetof(jl_array_t, nrows)/sizeof(void*) - 1;
     return emit_nthptr_recast(t, builder.CreateAdd(dim,
                                                    ConstantInt::get(dim->getType(), o)),
@@ -1541,9 +1392,9 @@ static jl_arrayvar_t *arrayvar_for(jl_value_t *ex, jl_codectx_t *ctx)
     return NULL;
 }
 
-static Value *emit_arraysize(Value *t, int dim)
+static Value *emit_arraysize(const jl_cgval_t &tinfo, int dim)
 {
-    return emit_arraysize(t, ConstantInt::get(T_int32, dim));
+    return emit_arraysize(tinfo, ConstantInt::get(T_int32, dim));
 }
 
 static Value *emit_arraylen_prim(Value *t, jl_value_t *ty)
@@ -1578,12 +1429,13 @@ static Value *emit_arraylen_prim(Value *t, jl_value_t *ty)
 #endif
 }
 
-static Value *emit_arraylen(Value *t, jl_value_t *ex, jl_codectx_t *ctx)
+static Value *emit_arraylen(const jl_cgval_t &tinfo, jl_value_t *ex, jl_codectx_t *ctx)
 {
+    assert(tinfo.isboxed);
     jl_arrayvar_t *av = arrayvar_for(ex, ctx);
     if (av!=NULL)
         return builder.CreateLoad(av->len);
-    return emit_arraylen_prim(t, expr_type(ex,ctx));
+    return emit_arraylen_prim(tinfo.V, expr_type(ex,ctx));
 }
 
 static Value *emit_arrayptr(Value *t)
@@ -1598,45 +1450,53 @@ static Value *emit_arrayptr(Value *t)
     return tbaa_decorate(tbaa_arrayptr, builder.CreateLoad(addr, false));
 }
 
-static Value *emit_arrayptr(Value *t, jl_value_t *ex, jl_codectx_t *ctx)
+static Value *emit_arrayptr(const jl_cgval_t &tinfo, jl_value_t *ex, jl_codectx_t *ctx)
 {
+    assert(tinfo.isboxed);
+    Value *t = tinfo.V;
     jl_arrayvar_t *av = arrayvar_for(ex, ctx);
     if (av!=NULL)
         return builder.CreateLoad(av->dataptr);
     return emit_arrayptr(t);
 }
 
-static Value *emit_arraysize(Value *t, jl_value_t *ex, int dim, jl_codectx_t *ctx)
+static Value *emit_arraysize(const jl_cgval_t &tinfo, jl_value_t *ex, int dim, jl_codectx_t *ctx)
 {
     jl_arrayvar_t *av = arrayvar_for(ex, ctx);
     if (av != NULL && dim <= (int)av->sizes.size())
         return builder.CreateLoad(av->sizes[dim-1]);
-    return emit_arraysize(t, dim);
+    return emit_arraysize(tinfo, dim);
 }
 
-static Value *emit_arrayflags(Value *t, jl_codectx_t *ctx)
+static Value *emit_arrayflags(const jl_cgval_t &tinfo, jl_codectx_t *ctx)
 {
+    assert(tinfo.isboxed);
+    Value *t = tinfo.V;
     Value *addr = builder.CreateStructGEP(
 #ifdef LLVM37
                             nullptr,
 #endif
-                            builder.CreateBitCast(t,jl_parray_llvmt), 2);
-    return builder.CreateLoad(addr); // TODO tbaa
+                            builder.CreateBitCast(t, jl_parray_llvmt), 2);
+    return builder.CreateLoad(addr); // TODO: tbaa
 }
 
-static void assign_arrayvar(jl_arrayvar_t &av, Value *ar)
+static void assign_arrayvar(jl_arrayvar_t &av, const jl_cgval_t &ainfo)
 {
+    assert(ainfo.isboxed);
+    Value *ar = ainfo.V;
     tbaa_decorate(tbaa_arrayptr,builder.CreateStore(builder.CreateBitCast(emit_arrayptr(ar),
                                                     av.dataptr->getType()->getContainedType(0)),
                                                     av.dataptr));
     builder.CreateStore(emit_arraylen_prim(ar, av.ty), av.len);
     for(size_t i=0; i < av.sizes.size(); i++)
-        builder.CreateStore(emit_arraysize(ar,i+1), av.sizes[i]);
+        builder.CreateStore(emit_arraysize(ainfo,i+1), av.sizes[i]);
 }
 
-static Value *emit_array_nd_index(Value *a, jl_value_t *ex, size_t nd, jl_value_t **args,
+static Value *emit_array_nd_index(const jl_cgval_t &ainfo, jl_value_t *ex, size_t nd, jl_value_t **args,
                                   size_t nidxs, jl_codectx_t *ctx)
 {
+    assert(ainfo.isboxed);
+    Value *a = ainfo.V;
     Value *i = ConstantInt::get(T_size, 0);
     Value *stride = ConstantInt::get(T_size, 1);
 #if CHECK_BOUNDS==1
@@ -1658,7 +1518,7 @@ static Value *emit_array_nd_index(Value *a, jl_value_t *ex, size_t nd, jl_value_
         i = builder.CreateAdd(i, builder.CreateMul(ii, stride));
         if (k < nidxs-1) {
             Value *d =
-                k >= nd ? ConstantInt::get(T_size, 1) : emit_arraysize(a, ex, k+1, ctx);
+                k >= nd ? ConstantInt::get(T_size, 1) : emit_arraysize(ainfo, ex, k+1, ctx);
 #if CHECK_BOUNDS==1
             if (bc) {
                 BasicBlock *okBB = BasicBlock::Create(getGlobalContext(), "ib");
@@ -1673,7 +1533,7 @@ static Value *emit_array_nd_index(Value *a, jl_value_t *ex, size_t nd, jl_value_
     }
 #if CHECK_BOUNDS==1
     if (bc) {
-        Value *alen = emit_arraylen(a, ex, ctx);
+        Value *alen = emit_arraylen(ainfo, ex, ctx);
         // if !(i < alen) goto error
         builder.CreateCondBr(builder.CreateICmpULT(i, alen), endBB, failBB);
 
@@ -1699,34 +1559,14 @@ static Value *emit_array_nd_index(Value *a, jl_value_t *ex, size_t nd, jl_value_
     return i;
 }
 
-// --- propagate julia type from value a to b. returns b. ---
-
-static Value *tpropagate(Value *a, Value *b)
-{
-    if (has_julia_type(a))
-        return mark_julia_type(b, julia_type_of(a));
-    return b;
-}
-
 // --- boxing ---
 
-static Value *init_bits_value(Value *newv, Value *jt, Type *t, Value *v)
+static Value* emit_allocobj(size_t static_size);
+static Value *init_bits_value(Value *newv, Value *jt, Value *v)
 {
     builder.CreateStore(jt, builder.CreateBitCast(emit_typeptr_addr(newv), jl_ppvalue_llvmt));
-    builder.CreateAlignedStore(v, builder.CreateBitCast(data_pointer(newv), PointerType::get(t,0)), 16); // Julia's gc-alignment is 16-bytes
+    builder.CreateAlignedStore(v, builder.CreateBitCast(data_pointer(newv), PointerType::get(v->getType(),0)), 16); // Julia's gc-alignment is 16-bytes
     return newv;
-}
-
-// allocate a box where the type might not be known at compile time
-static Value *allocate_box_dynamic(Value *jlty, Value *nb, Value *v)
-{
-    // TODO: allocate on the stack if !envescapes
-    if (v->getType()->isPointerTy()) {
-        v = builder.CreatePtrToInt(v, T_size);
-    }
-    Value *newv = builder.CreateCall(prepare_call(jlallocobj_func), nb);
-    // TODO: make sure this is rooted. I think it is.
-    return init_bits_value(newv, jlty, v->getType(), v);
 }
 
 static jl_value_t *static_void_instance(jl_value_t *jt)
@@ -1820,43 +1660,41 @@ static Value *call_with_unsigned(Function *ufunc, Value *v)
 // this is used to wrap values for generic contexts, where a
 // dynamically-typed value is required (e.g. argument to unknown function).
 // if it's already a pointer it's left alone.
-static Value *boxed(Value *v, jl_codectx_t *ctx, jl_value_t *jt)
+static Value *boxed(const jl_cgval_t &vinfo, jl_codectx_t *ctx, jl_value_t *jt)
 {
-    Type *t = (v == NULL) ? NULL : v->getType();
-
     if (jt == NULL) {
-        jt = julia_type_of(v);
+        jt = vinfo.typ;
     }
     else if (jt != jl_bottom_type && !jl_is_leaf_type(jt)) {
         // we can get a sharper type from julia_type_of than expr_type in some
         // cases, due to ccall's compile-time evaluations of types. see issue #5752
-        jl_value_t *jt2 = julia_type_of(v);
-        if (jl_subtype(jt2, jt, 0))
+        jl_value_t *jt2 = vinfo.typ;
+        if (jt2 && jl_subtype(jt2, jt, 0))
             jt = jt2;
     }
-    if (jt == jl_bottom_type)
+    if (jt == jl_bottom_type || jt == NULL) {
+        // We have an undef value on a (hopefully) dead branch
         return UndefValue::get(jl_pvalue_llvmt);
-    UndefValue *uv = NULL;
-    if (v == NULL || (uv = dyn_cast<UndefValue>(v)) != 0 || t == NoopType) {
-        if (uv != NULL && jl_is_datatype(jt)) {
-            jl_datatype_t *jb = (jl_datatype_t*)jt;
-            // We have an undef value on a hopefully dead branch
-            if (jl_isbits(jb) && jb->size != 0)
-                return UndefValue::get(jl_pvalue_llvmt);
-        }
+    }
+    if (vinfo.isghost) {
         jl_value_t *s = static_void_instance(jt);
+        assert(s);
         return literal_pointer_val(s);
     }
-    if (t == jl_pvalue_llvmt)
-        return v;
+    Type *t = julia_type_to_llvm(vinfo.typ);
+    assert(!type_is_ghost(t)); // should have been handled by isghost above!
+
+    if (vinfo.isboxed)
+        return vinfo.V;
+
+    Value *v = vinfo.V;
+    if (vinfo.ispointer) {
+        v = builder.CreateLoad(builder.CreatePointerCast(v, t->getPointerTo()));
+    }
     if (t == T_int1) return julia_bool(v);
-    if (t == T_void || t->isEmptyTy()) {
-        jl_value_t *s = static_void_instance(jt);
-        return literal_pointer_val(s);
-    }
     Constant *c = NULL;
     if ((c = dyn_cast<Constant>(v)) != NULL) {
-        jl_value_t *s = static_constant_instance(c,jt);
+        jl_value_t *s = static_constant_instance(c, jt);
         if (s) {
             jl_add_linfo_root(ctx->linfo, s);
             return literal_pointer_val(s);
@@ -1871,23 +1709,7 @@ static Value *boxed(Value *v, jl_codectx_t *ctx, jl_value_t *jt)
     if (jb == jl_int64_type) return call_with_signed(box_int64_func, v);
     if (jb == jl_float32_type) return builder.CreateCall(prepare_call(box_float32_func), v);
     //if (jb == jl_float64_type) return builder.CreateCall(box_float64_func, v);
-    if (jb == jl_float64_type) {
-        // manually inline alloc & init of Float64 box. cheap, I know.
-#ifdef _P64
-        Value *newv = builder.CreateCall(prepare_call(jlalloc1w_func)
-#ifdef LLVM37
-            , {}
-#endif
-        );
-#else
-        Value *newv = builder.CreateCall(prepare_call(jlalloc2w_func)
-#ifdef LLVM37
-            , {}
-#endif
-        );
-#endif
-        return init_bits_value(newv, literal_pointer_val(jt), t, v);
-    }
+    // for Float64, fall through to generic case below, to inline alloc & init of Float64 box. cheap, I know.
     if (jb == jl_uint8_type)  return call_with_unsigned(box_uint8_func, v);
     if (jb == jl_uint16_type) return call_with_unsigned(box_uint16_func, v);
     if (jb == jl_uint32_type) return call_with_unsigned(box_uint32_func, v);
@@ -1912,18 +1734,14 @@ static Value *boxed(Value *v, jl_codectx_t *ctx, jl_value_t *jt)
         return literal_pointer_val(jb->instance);
     }
 
-    Type *llvmt = julia_type_to_llvm(jt);
-    if (llvmt->isAggregateType() && v->getType()->isPointerTy()) {
-        v = builder.CreateLoad(v);
-    }
-    return allocate_box_dynamic(literal_pointer_val(jt), ConstantInt::get(T_size, jl_datatype_size(jt)), v);
+    return init_bits_value(emit_allocobj(jl_datatype_size(jt)), literal_pointer_val(jt), v);
 }
 
-static void emit_cpointercheck(Value *x, const std::string &msg,
+static void emit_cpointercheck(const jl_cgval_t &x, const std::string &msg,
                                jl_codectx_t *ctx)
 {
     Value *t = emit_typeof(x);
-    emit_typecheck(t, (jl_value_t*)jl_datatype_type, msg, ctx);
+    emit_typecheck(mark_julia_type(t, jl_any_type), (jl_value_t*)jl_datatype_type, msg, ctx);
 
     Value *istype =
         builder.CreateICmpEQ(emit_nthptr(t, (ssize_t)(offsetof(jl_datatype_t,name)/sizeof(char*)), tbaa_datatype),
@@ -2008,38 +1826,38 @@ static void emit_checked_write_barrier(jl_codectx_t *ctx, Value *parent, Value *
     builder.SetInsertPoint(cont);
 }
 
-static Value *emit_setfield(jl_datatype_t *sty, Value *strct, size_t idx0,
-                            Value *rhs, jl_codectx_t *ctx, bool checked, bool wb)
+static void emit_setfield(jl_datatype_t *sty, const jl_cgval_t &strct, size_t idx0,
+                            const jl_cgval_t &rhs, jl_codectx_t *ctx, bool checked, bool wb)
 {
     if (sty->mutabl || !checked) {
+        assert(strct.ispointer);
         Value *addr =
-            builder.CreateGEP(builder.CreateBitCast(strct, T_pint8),
+            builder.CreateGEP(builder.CreateBitCast(strct.V, T_pint8),
                               ConstantInt::get(T_size, jl_field_offset(sty,idx0)));
         jl_value_t *jfty = jl_svecref(sty->types, idx0);
         if (sty->fields[idx0].isptr) {
-            rhs = boxed(rhs, ctx);
-            builder.CreateStore(rhs,
+            Value *r = boxed(rhs, ctx);
+            builder.CreateStore(r,
                                 builder.CreateBitCast(addr, jl_ppvalue_llvmt));
-            if (wb) emit_checked_write_barrier(ctx, strct, rhs);
+            if (wb) emit_checked_write_barrier(ctx, strct.V, r);
         }
         else {
-            int align = jl_field_offset(sty,idx0);
+            int align = jl_field_offset(sty, idx0);
             if (align & 1) align = 1;
             else if (align & 2) align = 2;
             else if (align & 4) align = 4;
             else if (align & 8) align = 8;
             else align = 16;
-            typed_store(addr, ConstantInt::get(T_size, 0), rhs, jfty, ctx, sty->mutabl ? tbaa_user : tbaa_immut, strct, align);
+            typed_store(addr, ConstantInt::get(T_size, 0), rhs, jfty, ctx, sty->mutabl ? tbaa_user : tbaa_immut, strct.V, align);
         }
     }
     else {
         // TODO: better error
         emit_error("type is immutable", ctx);
     }
-    return strct;
 }
 
-static Value *emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, jl_codectx_t *ctx)
+static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, jl_codectx_t *ctx)
 {
     assert(jl_is_datatype(ty));
     assert(jl_is_leaf_type(ty));
@@ -2055,11 +1873,11 @@ static Value *emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, j
             for (size_t i=0; i < na; i++) {
                 jl_value_t *jtype = jl_svecref(sty->types,i);
                 Type *fty = julia_type_to_llvm(jtype);
-                Value *fval = emit_unboxed(args[i+1], ctx);
-                if (!jl_subtype(expr_type(args[i+1],ctx), jtype, 0))
-                    emit_typecheck(fval, jtype, "new", ctx);
+                jl_cgval_t fval_info = emit_unboxed(args[i+1], ctx);
+                if (!jl_subtype(fval_info.typ, jtype, 0))
+                    emit_typecheck(fval_info, jtype, "new", ctx);
                 if (!type_is_ghost(fty)) {
-                    fval = emit_unbox(fty, fval, jtype);
+                    Value *fval = emit_unbox(fty, fval_info, jtype);
                     if (fty == T_int1)
                         fval = builder.CreateZExt(fval, T_int8);
                     if (lt->isVectorTy())
@@ -2086,19 +1904,21 @@ static Value *emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, j
             // a couple store instructions. avoids initializing
             // the first field to NULL, and sometimes the GC root
             // for the new struct.
-            Value *fval = emit_expr(args[1],ctx);
-            f1 = boxed(fval,ctx);
+            jl_cgval_t fval_info = emit_expr(args[1],ctx);
+            f1 = boxed(fval_info, ctx);
             j++;
-            if (might_need_root(args[1]) || fval->getType() != jl_pvalue_llvmt)
+            if (might_need_root(args[1]) || !fval_info.isboxed)
                 make_gcroot(f1, ctx);
         }
         Value *strct = emit_allocobj(sty->size);
+        jl_cgval_t strctinfo = mark_julia_type(strct, ty);
         builder.CreateStore(literal_pointer_val((jl_value_t*)ty),
                             emit_typeptr_addr(strct));
         if (f1) {
+            jl_cgval_t f1info = mark_julia_type(f1, jl_any_type);
             if (!jl_subtype(expr_type(args[1],ctx), jl_field_type(sty,0), 0))
-                emit_typecheck(f1, jl_field_type(sty,0), "new", ctx);
-            emit_setfield(sty, strct, 0, f1, ctx, false, false);
+                emit_typecheck(f1info, jl_field_type(sty,0), "new", ctx);
+            emit_setfield(sty, strctinfo, 0, f1info, ctx, false, false);
             ctx->gc.argDepth = fieldStart;
             if (nf > 1 && needroots)
                 make_gcroot(strct, ctx);
@@ -2108,13 +1928,18 @@ static Value *emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, j
         }
         for(size_t i=j; i < nf; i++) {
             if (sty->fields[i].isptr) {
-                emit_setfield(sty, strct, i, V_null, ctx, false, false);
+                builder.CreateStore(
+                        V_null,
+                        builder.CreatePointerCast(
+                            builder.CreateGEP(builder.CreateBitCast(strct, T_pint8),
+                                ConstantInt::get(T_size, jl_field_offset(sty,i))),
+                            jl_ppvalue_llvmt));
             }
         }
         bool need_wb = false;
         for(size_t i=j+1; i < nargs; i++) {
-            Value *rhs = emit_expr(args[i],ctx);
-            if (sty->fields[i-1].isptr && rhs->getType() != jl_pvalue_llvmt) {
+            jl_cgval_t rhs = emit_expr(args[i],ctx);
+            if (sty->fields[i-1].isptr && !rhs.isboxed) {
                 if (!needroots) {
                     // if this struct element needs boxing and we haven't rooted
                     // the struct, root it now.
@@ -2123,19 +1948,24 @@ static Value *emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **args, j
                 }
                 need_wb = true;
             }
-            if (rhs->getType() == jl_pvalue_llvmt) {
+            if (rhs.isboxed) {
                 if (!jl_subtype(expr_type(args[i],ctx), jl_svecref(sty->types,i-1), 0))
                     emit_typecheck(rhs, jl_svecref(sty->types,i-1), "new", ctx);
             }
             if (!need_wb && might_need_root(args[i]))
                 need_wb = true;
-            emit_setfield(sty, strct, i-1, rhs, ctx, false, need_wb);
+            emit_setfield(sty, strctinfo, i-1, rhs, ctx, false, need_wb);
         }
         ctx->gc.argDepth = fieldStart;
-        return strct;
+        return strctinfo;
+    }
+    else if (!sty->mutabl) {
+        // 0 fields, ghost
+        return ghostValue(sty);
     }
     else {
         // 0 fields, singleton
-        return literal_pointer_val(jl_new_struct_uninit((jl_datatype_t*)ty));
+        assert(sty->instance != NULL);
+        return mark_julia_type(literal_pointer_val(sty->instance), sty);
     }
 }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1564,8 +1564,8 @@ static Value *emit_array_nd_index(const jl_cgval_t &ainfo, jl_value_t *ex, size_
 static Value* emit_allocobj(size_t static_size);
 static Value *init_bits_value(Value *newv, Value *jt, Value *v)
 {
-    builder.CreateStore(jt, builder.CreateBitCast(emit_typeptr_addr(newv), jl_ppvalue_llvmt));
-    builder.CreateAlignedStore(v, builder.CreateBitCast(data_pointer(newv), PointerType::get(v->getType(),0)), 16); // Julia's gc-alignment is 16-bytes
+    builder.CreateStore(jt, emit_typeptr_addr(newv));
+    builder.CreateAlignedStore(v, builder.CreateBitCast(newv, PointerType::get(v->getType(),0)), sizeof(void*)); // min alignment in julia's gc is pointer-aligned
     return newv;
 }
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1960,8 +1960,13 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
         return strctinfo;
     }
     else if (!sty->mutabl) {
-        // 0 fields, ghost
-        return ghostValue(sty);
+        // 0 fields, ghost or bitstype
+        if (sty->size == 0)
+            return ghostValue(sty);
+        if (nargs >= 2)
+            return emit_unboxed(args[1], ctx);  // do side effects
+        Type *lt = julia_type_to_llvm(ty);
+        return mark_julia_type(UndefValue::get(lt), ty);
     }
     else {
         // 0 fields, singleton

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -394,7 +394,7 @@ struct jl_cgval_t {
         isboxed(V && V->getType() == jl_pvalue_llvmt),
         isghost(false),
         ispointer(this->isboxed),
-        isimmutable(this->isboxed && jl_is_immutable(typ)),
+        isimmutable(this->isboxed && jl_is_immutable_datatype(typ)),
         needsgcroot(this->isboxed)
     {
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -388,7 +388,7 @@ struct jl_cgval_t {
     //bool isarg; // derived from an argument
     bool needsgcroot; // this value needs a gcroot
     jl_cgval_t(Value *V, jl_value_t *typ) : // general constructor (with pointer type auto-detect)
-        V(V), // V is allowed to be NULL in a jl_varinfo_t context, but not during codegen
+        V(V), // V is allowed to be NULL in a jl_varinfo_t context, but not during codegen contexts
         typ(typ),
         //T(julia_type_to_llvm(typ)),
         isboxed(V && V->getType() == jl_pvalue_llvmt),

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -261,7 +261,9 @@ DICompositeType jl_di_func_sig;
 static Value *V_null;
 static Type *NoopType;
 static Value *literal_pointer_val(jl_value_t *p);
-static Type *julia_type_to_llvm(jl_value_t *jt);
+extern "C" {
+DLLEXPORT Type *julia_type_to_llvm(jl_value_t *jt);
+}
 static bool type_is_ghost(Type *ty)
 {
     return (ty == T_void || ty->isEmptyTy());

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2159,9 +2159,9 @@ static bool emit_known_call(jl_cgval_t *ret, jl_value_t *ff,
         jl_cgval_t v2 = emit_unboxed(args[2], ctx); // unrooted!
         // FIXME: v.typ is roughly equiv. to expr_type, but with typeof(T) == Type{T} instead of DataType in a few cases
         if (v1.typ == (jl_value_t*)jl_datatype_type)
-            v1.typ = expr_type(args[1], ctx);
+            v1 = remark_julia_type(v1, expr_type(args[1], ctx)); // patch up typ if necessary
         if (v2.typ == (jl_value_t*)jl_datatype_type)
-            v2.typ = expr_type(args[2], ctx);
+            v2 = remark_julia_type(v2, expr_type(args[2], ctx)); // patch up typ if necessary
         // emit comparison test
         Value *ans = emit_f_is(v1, v2, ctx);
         ctx->gc.argDepth = last_depth;
@@ -2486,7 +2486,7 @@ static bool emit_known_call(jl_cgval_t *ret, jl_value_t *ff,
             *ret = emit_getfield(args[1],
                                  (jl_sym_t*)jl_fieldref(args[2],0), ctx);
             if (ret->typ == (jl_value_t*)jl_any_type) // improve the type, if known from the expr
-                ret->typ = expr_type(expr, ctx);
+                *ret = remark_julia_type(*ret, expr_type(expr, ctx));
             JL_GC_POP();
             return true;
         }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3247,7 +3247,7 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
         if (!valuepos) return jl_cgval_t(); // value not used, no point in doing codegen for it
         ssize_t idx = ((jl_gensym_t*)expr)->id;
         assert(idx >= 0);
-        assert(ctx->gensym_assigned.at(idx));
+        //assert(ctx->gensym_assigned.at(idx));
         jl_cgval_t val = ctx->gensym_SAvalues.at(idx); // at this point, gensym_SAvalues[idx] actually contains the SAvalue
         return val;
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2058,7 +2058,7 @@ static Value *emit_f_is(const jl_cgval_t &arg1, const jl_cgval_t &arg2, jl_codec
     if (!sub1 && !sub2) // types are disjoint (exhaustive test)
         return ConstantInt::get(T_int1, 0);
 
-    bool isbits = isleaf && isteq && jl_is_bitstype(rt1);
+    bool isbits = isleaf && isteq && jl_isbits(rt1);
     if (isbits) { // whether this type is unique'd by value
         return emit_bits_compare(arg1, arg2, ctx);
     }
@@ -2081,7 +2081,7 @@ static Value *emit_f_is(const jl_cgval_t &arg1, const jl_cgval_t &arg2, jl_codec
     if (arg2.isboxed && arg2.needsgcroot)
         make_gcroot(arg2.V, ctx);
     Value *varg1 = boxed(arg1, ctx);
-    if (!arg1.isboxed && arg1.needsgcroot)
+    if (!arg1.isboxed)
         make_gcroot(varg1, ctx);
     Value *varg2 = boxed(arg2, ctx); // unrooted!
 #ifdef LLVM37

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3469,9 +3469,18 @@ static void allocate_gc_frame(size_t n_roots, BasicBlock *b0, jl_codectx_t *ctx)
     gc->maxDepth = 0;
 
     gc->gcframe = builder.CreateAlloca(jl_pvalue_llvmt, ConstantInt::get(T_int32, 0));
+#ifdef JL_DEBUG_BUILD
+    gc->gcframe->setName("gcrootframe");
+#endif
     gc->first_gcframe_inst = BasicBlock::iterator(gc->gcframe);
     gc->argSlot = builder.CreateConstGEP1_32(gc->gcframe, 2);
+#ifdef JL_DEBUG_BUILD
+    gc->argSlot->setName("locals");
+#endif
     gc->tempSlot = (GetElementPtrInst*)builder.CreateConstGEP1_32(gc->gcframe, 2);
+#ifdef JL_DEBUG_BUILD
+    gc->tempSlot->setName("temproots");
+#endif
     gc->last_gcframe_inst = BasicBlock::iterator((Instruction*)gc->tempSlot);
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1793,7 +1793,7 @@ static jl_cgval_t emit_boxed_rooted(jl_value_t *e, jl_codectx_t *ctx) // TODO: m
     if (!v.isboxed) {
         Value *vbox = boxed(v, ctx);
         make_gcroot(vbox, ctx);
-        v = mark_julia_type(vbox, v.typ);
+        v = jl_cgval_t(vbox, v.typ); // bypass normal auto-unbox behavior for isghost
     }
     else if (might_need_root(e)) { // TODO: v.needsroot
         make_gcroot(v.V, ctx);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1859,7 +1859,7 @@ static Value *emit_lambda_closure(jl_value_t *expr, jl_codectx_t *ctx)
             val = builder.CreateLoad(vari.memloc, vari.isVolatile);
         }
         else {
-            assert(!vari.isAssigned); // make sure there wasn't an inference / codegen error earlier
+            assert(!vari.isAssigned || vari.value.isghost); // make sure there wasn't an inference / codegen error earlier
             val = boxed(vari.value, ctx);
             if (!vari.value.isghost)
                 make_gcroot(val, ctx);
@@ -3053,7 +3053,7 @@ static jl_cgval_t emit_var(jl_sym_t *sym, jl_value_t *ty, jl_codectx_t *ctx, boo
             return v;
         }
     }
-    else if (vi.isVolatile) {
+    else if (vi.isVolatile && !vi.value.isghost) {
         // copy value to a non-volatile location
         assert(vi.value.ispointer);
         Type *T = julia_type_to_llvm(vi.value.typ)->getPointerTo();
@@ -3139,7 +3139,7 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
     // it's a local variable or closure variable
     jl_varinfo_t &vi = ctx->vars[s];
     if (!vi.memloc && !vi.hasGCRoot && vi.used
-            && !vi.isArgument && !is_stable_expr(r, ctx)) {
+            && !vi.isArgument && !is_stable_expr(r, ctx) && !vi.value.isghost) {
         Instruction *newroot = cast<Instruction>(emit_local_slot(ctx->gc.argSpaceSize++, ctx));
         newroot->removeFromParent(); // move it to the gc frame basic block so it can be reused as needed
         newroot->insertAfter(ctx->gc.last_gcframe_inst);
@@ -4508,6 +4508,10 @@ static Function *emit_function(jl_lambda_info_t *lam)
     for(i=0; i < largslen; i++) {
         jl_sym_t *s = jl_decl_var(jl_cellref(largs,i));
         jl_varinfo_t &varinfo = ctx.vars[s];
+        if (varinfo.value.isghost) {
+            // no need to explicitly load/store a ghost value
+            continue;
+        }
         if (store_unboxed_p(s, &ctx)) {
             if (varinfo.isAssigned) // otherwise, just leave it in the input register
                 alloc_local(s, &ctx);
@@ -4523,6 +4527,10 @@ static Function *emit_function(jl_lambda_info_t *lam)
         jl_varinfo_t &vi = ctx.vars[s];
         if (vi.isArgument)
             continue;
+        if (vi.value.isghost && !vi.usedUndef) {
+            // no need to explicitly load/store a ghost value
+            continue;
+        }
         if (store_unboxed_p(s, &ctx)) {
             alloc_local(s, &ctx);
         }
@@ -4571,6 +4579,10 @@ static Function *emit_function(jl_lambda_info_t *lam)
         jl_sym_t *s = jl_decl_var(jl_cellref(largs,i));
         jl_varinfo_t &varinfo = ctx.vars[s];
         assert(!varinfo.memloc); // arguments shouldn't also be in the closure env
+        if (varinfo.value.isghost) {
+            // no need to explicitly load/store a ghost value
+            continue;
+        }
         if (store_unboxed_p(s, &ctx)) {
             varinfo.hasGCRoot = true;
         }
@@ -4584,7 +4596,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
         jl_sym_t *s = (jl_sym_t*)jl_cellref(jl_cellref(vinfos,i),0);
         jl_varinfo_t &varinfo = ctx.vars[s];
         if (varinfo.memloc || varinfo.isArgument)
-            continue;
+            continue; // gc root already created
         if (store_unboxed_p(s, &ctx)) {
             varinfo.hasGCRoot = true;
         }
@@ -4704,6 +4716,9 @@ static Function *emit_function(jl_lambda_info_t *lam)
             jl_value_t *inst = static_void_instance(vi.value.typ);
             assert(inst);
             builder.CreateStore(builder.CreateCall(prepare_call(jlbox_func), literal_pointer_val(inst)), lv);
+        }
+        else {
+            assert(vi.memloc == NULL);
         }
     }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2742,7 +2742,6 @@ static jl_cgval_t emit_call_function_object(jl_function_t *f, Value *theF, Value
             else {
                 assert(at == et);
                 argvals[idx] = emit_unbox(et, emit_unboxed(args[i+1], ctx), jt);
-                assert(dyn_cast<UndefValue>(argvals[idx]) == 0);
             }
             idx++;
         }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3736,10 +3736,10 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     Type *prt = NULL;
     int sret = 0;
     std::string err_msg = generate_func_sig(&crt, &prt, sret, fargt, fargt_sig, fargt_vasig, inRegList, byRefList, attrs,
-                                            ((isref&1) ? (jl_value_t*)jl_any_type : jlrettype), argt->parameters);
+                                            ((isref&1) ? (jl_value_t*)jl_any_type : jlrettype), argt->parameters, nargs);
     if (!err_msg.empty())
         jl_error(err_msg.c_str());
-    if (fargt.size() != fargt_sig.size())
+    if (fargt.size() + sret != fargt_sig.size())
         jl_error("va_arg syntax not allowed for cfunction argument list");
 
     jl_compile(ff);
@@ -3835,7 +3835,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
         else {
             // undo whatever we might have done to this poor argument
             bool issigned = jl_signed_type && jl_subtype(jargty, (jl_value_t*)jl_signed_type, 0);
-            val = llvm_type_rewrite(val, val->getType(), fargt[i+sret], true, byRefList[i], issigned, &ctx);
+            val = llvm_type_rewrite(val, val->getType(), fargt[i], true, byRefList[i], issigned, &ctx);
         }
 
         // figure out how to repack this type

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3084,10 +3084,10 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
             }
             else {
                 slot = emit_unboxed(r, ctx);
-                if (!slot.isboxed && slot.ispointer) { // emit a copy. TODO: elid this copy if unnecessary
+                if (slot.ispointer) { // emit a copy of boxed isbits values. TODO: elid this copy if unnecessary
                     slot = mark_julia_type(
-                            emit_unbox(julia_type_to_llvm(slot.typ), slot, slot.typ),
-                            slot.typ);
+                            emit_unbox(julia_type_to_llvm(declType), slot, declType),
+                            declType);
                 }
             }
         }
@@ -3179,10 +3179,10 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
         }
         else {
             // SSA variable w/o gcroot, just track the value info
-            if (!rval_info.isboxed && rval_info.ispointer) { // emit a copy. TODO: elid this copy if unnecessary
+            if (store_unboxed_p(vi.value.typ) && rval_info.ispointer) { // emit a copy of boxed isbits values. TODO: elid this copy if unnecessary
                 rval_info = mark_julia_type(
-                        emit_unbox(julia_type_to_llvm(rval_info.typ), rval_info, rval_info.typ),
-                        rval_info.typ);
+                        emit_unbox(julia_type_to_llvm(vi.value.typ), rval_info, vi.value.typ),
+                        vi.value.typ);
             }
             vi.value = rval_info;
         }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2021,8 +2021,8 @@ static Value *emit_bits_compare(const jl_cgval_t &arg1, const jl_cgval_t &arg2, 
             for(unsigned i=0; i < l; i++) {
                 jl_value_t *fldty = jl_svecref(types, i);
                 Value *subAns, *fld1, *fld2;
-                fld1 = builder.CreateConstGEP2_32(varg1, 0, i);
-                fld2 = builder.CreateConstGEP2_32(varg2, 0, i);
+                fld1 = builder.CreateConstGEP2_32(LLVM37_param(at) varg1, 0, i);
+                fld2 = builder.CreateConstGEP2_32(LLVM37_param(at) varg2, 0, i);
                 if (type_is_ghost(fld1->getType()))
                     continue;
                 subAns = emit_bits_compare(mark_julia_slot(fld1, fldty), mark_julia_slot(fld2, fldty), ctx);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2008,13 +2008,13 @@ static Value *emit_bits_compare(const jl_cgval_t &arg1, const jl_cgval_t &arg2, 
             return builder.CreateICmpEQ(answer, ConstantInt::get(T_int32, 0));
         }
         else {
-            at = at->getPointerTo();
+            Type *atp = at->getPointerTo();
             Value *varg1 = arg1.V;
-            if (varg1->getType() != at)
-                builder.CreatePointerCast(varg1, at);
+            if (varg1->getType() != atp)
+                builder.CreatePointerCast(varg1, atp);
             Value *varg2 = arg2.V;
-            if (varg2->getType() != at)
-                builder.CreatePointerCast(varg2, at);
+            if (varg2->getType() != atp)
+                builder.CreatePointerCast(varg2, atp);
             jl_svec_t *types = ((jl_datatype_t*)arg1.typ)->types;
             Value *answer = ConstantInt::get(T_int1, 1);
             size_t l = jl_svec_len(types);
@@ -4366,7 +4366,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                 topfile,                            // File
                 ctx.lineno == -1 ? 0 : ctx.lineno,  // Line
                 // Variable type
-                julia_type_to_di(varinfo.declType,ctx.dbuilder,specsig));
+                julia_type_to_di(varinfo.value.typ,ctx.dbuilder,specsig));
 #else
             varinfo.dinfo = ctx.dbuilder->createLocalVariable(
                 llvm::dwarf::DW_TAG_arg_variable,    // Tag

--- a/src/gc.c
+++ b/src/gc.c
@@ -1816,7 +1816,6 @@ double clock_now(void);
 #endif
 
 extern jl_module_t *jl_old_base_module;
-extern jl_array_t *typeToTypeId;
 extern jl_array_t *jl_module_init_order;
 
 static int inc_count = 0;
@@ -1837,7 +1836,6 @@ static void pre_mark(void)
     if (jl_an_empty_cell) gc_push_root(jl_an_empty_cell, 0);
     gc_push_root(jl_exception_in_transit, 0);
     gc_push_root(jl_task_arg_in_transit, 0);
-    gc_push_root(typeToTypeId, 0);
     if (jl_module_init_order != NULL)
         gc_push_root(jl_module_init_order, 0);
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -263,6 +263,7 @@ static jl_cgval_t ghostValue(jl_value_t *ty);
 // emit code to unpack a raw value from a box into registers
 static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt)
 {
+    assert(to != jl_pvalue_llvmt);
     // TODO: fully validate that x.typ == jt?
     if (x.isghost) {
         if (type_is_ghost(to)) {

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -273,10 +273,15 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt)
     }
     if (!x.isboxed) { // already unboxed, but sometimes need conversion
         Value *unboxed;
-        if (x.ispointer)
-            return builder.CreateLoad(builder.CreatePointerCast(x.V, to->getPointerTo()));
-        else
+        if (x.ispointer) {
+            if (jt == (jl_value_t*)jl_bool_type && to != T_int1)
+                return builder.CreateZExt(builder.CreateLoad(builder.CreatePointerCast(x.V, T_int1->getPointerTo())), to);
+            else
+                return builder.CreateLoad(builder.CreatePointerCast(x.V, to->getPointerTo()));
+        }
+        else {
             unboxed = x.V;
+        }
         Type *ty = unboxed->getType();
         // bools are stored internally as int8 (for now)
         if (ty == T_int1 && to == T_int8)

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -406,7 +406,7 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
         if (bt && jl_is_bitstype(bt)) {
             // always fixed size
             nb = jl_datatype_size(bt);
-            llvmt = julia_type_to_llvm(bt);
+            llvmt = staticeval_bitstype(bt);
             alignment = ((jl_datatype_t*)bt)->alignment;
         }
         else {
@@ -417,7 +417,7 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
                 return jl_cgval_t();
             }
             nb = jl_datatype_size(v.typ);
-            llvmt = julia_type_to_llvm(v.typ);
+            llvmt = staticeval_bitstype(v.typ);
             alignment = ((jl_datatype_t*)v.typ)->alignment;
         }
         Value *runtime_bt = boxed(emit_expr(targ, ctx), ctx);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -388,7 +388,7 @@ int get_bitstype_nbits(jl_value_t *bt)
 static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx)
 {
     // Examine the first argument //
-    jl_value_t *bt = staticeval_bitstype(targ, nullptr, ctx);
+    jl_value_t *bt = staticeval_bitstype(targ, NULL, ctx);
 
     // Examine the second argument //
     jl_cgval_t v = emit_unboxed(x, ctx);
@@ -428,7 +428,7 @@ static jl_cgval_t generic_box(jl_value_t *targ, jl_value_t *x, jl_codectx_t *ctx
     Value *vx;
     if (v.ispointer) {
         // TODO: validate the size and type of the pointer contents
-        if (v.isimmutable) { // wrong type, but can lazy load this later as needed
+        if (v.isimmutable && !v.needsgcroot) { // wrong type, but can lazy load this later as needed
             v.typ = bt;
             v.isboxed = false;
             return v;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -968,6 +968,9 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
         jl_value_t *newtyp = xinfo.typ;
         // TODO: compare the type validity of x,y,z before emitting the intrinsic
         Value *r = emit_untyped_intrinsic(f, x, y, z, nargs, ctx, (jl_datatype_t**)&newtyp);
+        if (newtyp == xinfo.typ && r->getType() != x->getType())
+            // cast back to the exact original type (float vs. int) before remarking as a julia type
+            r = builder.CreateBitCast(r, x->getType());
         return mark_julia_type(r, newtyp);
     }
     }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -268,6 +268,7 @@ static Value *emit_unbox(Type *to, const jl_cgval_t &x, jl_value_t *jt)
         if (type_is_ghost(to)) {
             return NULL;
         }
+        //emit_error("emit_unbox: a type mismatch error in occurred during codegen", ctx);
         return UndefValue::get(to); // type mismatch error
     }
     if (!x.isboxed) { // already unboxed, but sometimes need conversion

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -31,6 +31,7 @@
     add_library_mapping;
     utf8proc_*;
     jlbacktrace;
+    julia_type_to_llvm;
     _IO_stdin_used;
     __ZN4llvm23createLowerSimdLoopPassEv;
 

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -73,7 +73,7 @@ b = unsafe_load(ccall((:cfptest, libccalltest), Ptr{Complex64}, (Ptr{Complex64},
 
 # Tests for native Julia data types
 @test_throws MethodError ccall((:cptest, libccalltest), Ptr{Complex{Int}}, (Ptr{Complex{Int}},), cf32)
-@test_throws ErrorException ccall((:cptest, libccalltest), Ptr{Complex{Int}}, (Complex{Int},), &cf32) #compile-time error
+@test_throws MethodError ccall((:cptest, libccalltest), Ptr{Complex{Int}}, (Complex{Int},), &cf32)
 
 # Tests for various sized data types (ByVal)
 type Struct1

--- a/test/core.jl
+++ b/test/core.jl
@@ -3225,6 +3225,13 @@ let x = Array(Empty12394,1), y = [Empty12394()]
     @test_throws UndefRefError y==x
 end
 
+module TestConstStructCreate
+const x = (1,2)
+const y = (x,(3,4))
+f() = (x,y,(5,6))
+@test f() == ((1,2),((1,2),(3,4)),(5,6))
+end
+
 # object_id of haspadding field
 immutable HasPadding
     x::Bool

--- a/test/core.jl
+++ b/test/core.jl
@@ -3232,6 +3232,11 @@ f() = (x,y,(5,6))
 end
 @test TestRecursiveConstGlobalStructCtor.f() == ((1,2),((1,2),(3,4)),(5,6))
 
+const const_array_int1 = Array{Int}
+const const_array_int2 = Array{Int}
+test_eq_array_int() = is(const_array_int1, const_array_int2)
+@test test_eq_array_int()
+
 # object_id of haspadding field
 immutable HasPadding
     x::Bool

--- a/test/core.jl
+++ b/test/core.jl
@@ -3347,3 +3347,13 @@ foo12967(x, ::TupleType12967) = 2
 
 # issue #13083
 @test Void() === nothing
+
+# issue discovered in #11973
+for j = 1:1
+    x = try
+        error()
+        2
+    catch
+        continue
+    end
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -3225,12 +3225,12 @@ let x = Array(Empty12394,1), y = [Empty12394()]
     @test_throws UndefRefError y==x
 end
 
-module TestConstStructCreate
+module TestRecursiveConstGlobalStructCtor
 const x = (1,2)
 const y = (x,(3,4))
 f() = (x,y,(5,6))
-@test f() == ((1,2),((1,2),(3,4)),(5,6))
 end
+@test TestRecursiveConstGlobalStructCtor.f() == ((1,2),((1,2),(3,4)),(5,6))
 
 # object_id of haspadding field
 immutable HasPadding

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -38,12 +38,13 @@ include(joinpath(dir, "queens.jl"))
 # cluster manager example through a new Julia session.
 @unix_only begin
     script = joinpath(dir, "clustermanager/simple/test_simple.jl")
-    cmd = `$(joinpath(JULIA_HOME,Base.julia_exename())) $script`
+    cmd = `$(Base.julia_cmd()) $script`
 
     (strm, proc) = open(cmd)
+    errors = readall(strm)
     wait(proc)
     if !success(proc) && ccall(:jl_running_on_valgrind,Cint,()) == 0
-        println(readall(strm))
+        println(errors);
         error("UnixDomainCM failed test, cmd : $cmd")
     end
 end


### PR DESCRIPTION
this rewrite of codegen is intended to help make it much more obvious to new users (and old) of how type information is flowing through the codegen system.

the key changes are that raw llvm `Value*` objects are almost never allowed (although they can be created with `boxed()` or `emit_unbox()`) and that all Intrinsics are now fully typed. in the longer term, it should be feasible to do a lot of new optimizations through this data structure :). also, when llvm removes `PointerType->getElementType()` in the next release, this should also provide a straightforward path to handling the resulting codegen upgrade necessity.

i know this is huge, but I hope this will provide a basis for adding more advanced & flexible codegen features in the future with much lower impact. I also feel that this has been needed for a long time, as the codegen system has been organically growing with support for so many new unboxed type representations.

TODO before merging:
- [x] cleanup commit history (i don't think i want to flatten it entirely into one commit, but the breakdown right now is pretty pointless)
- [x] get signoff from @carnaval
- [x] get signoff from @Keno
- [x] get signoff from @JeffBezanson 
- [x] check / cleanup any MCJIT and LLVM37 issues

TODO after merging:
- continue to reduce codegen dependence on expr_type
- remove distinction between emit_boxed / emit_unboxed
- add more argument type validation to Intrinsics so that invalid usage results in emitting an explicit error rather than potentially triggering an llvm assertion
- track alignment information more explicitly
- track allocation (gcroot) information in the jl_cgval_t representation
- write docs for codegen – this is probably a good time to sit down and write a solid description of this system for other devs
- ~~document that many Intrinsics eval their arguments at compile-time~~ remove all Intrinsics
