### PR TITLE
add empty BitVector constructor

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -32,6 +32,8 @@ BitArray(dims::Int...) = BitArray(dims)
 typealias BitVector BitArray{1}
 typealias BitMatrix BitArray{2}
 
+call(::Type{BitVector}) = BitArray{1}(0)
+
 ## utility functions ##
 
 length(B::BitArray) = B.len

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -28,6 +28,9 @@ let t0 = time()
     end
 end
 
+# empty bitvector
+@test BitVector() == BitVector(0)
+
 # vectors size
 v1 = 260
 # matrices size


### PR DESCRIPTION
`Vector{Int}()` creates an empty vector. So why not `BitVector()`?
