### PR TITLE
Deprecate utf16_is_*, utf16_get_supplementary, is_utf8_*, add @unexportedwarning macro, add tests

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -577,6 +577,25 @@ function utf16_get_supplementary(lead::UInt16, trail::UInt16)
     Base.get_supplementary(lead, trail)
 end
 
+function is_utf8_start(byte::UInt8)
+    depwarn("""
+            Base.is_utf8_start(c::UInt8) was undocumented and unexported,
+            and has been removed.  Use !Base.is_valid_continuation(c) instead,
+            however it is also undocumented and unexported, and may change in the future.
+            """,
+            symbol("is_utf8_start"))
+    !Base.is_valid_continuation(byte)
+end
+function is_utf8_continuation(byte::UInt8)
+    depwarn("""
+            Base.is_utf8_continuation(c::UInt8) was undocumented and unexported,
+            and has been removed.  Use Base.is_valid_continuation(c) instead,
+            however it is also undocumented and unexported, and may change in the future.
+            """,
+            symbol("is_utf8_continuation"))
+    Base.is_valid_continuation(byte)
+end
+
 # 11280, mmap
 
 export msync

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -527,10 +527,6 @@ function start_timer(t, d, r)
     error("start_timer is deprecated. Use Timer(callback, delay, repeat) instead.")
 end
 
-# 11551
-@deprecate utf16_is_surrogate(chr::UInt16) Base.is_surrogate_codeunit(chr)
-@deprecate utf16_get_supplementary(lead::UInt16, trail::UInt16) Base.get_supplementary(lead, trail)
-
 const UnionType = Union
 export UnionType
 
@@ -542,6 +538,44 @@ macro math_const(sym, val, def)
 end
 
 export MathConst, @math_const
+
+# 11551
+function utf16_is_surrogate(chr::UInt16)
+    depwarn("""
+            Base.utf16_is_surrogate was undocumented and unexported,
+            and has been removed.  Use Base.is_surrogate_codeunit(chr::Unsigned) instead,
+            however it is also undocumented and unexported, and may change in the future.
+            """,
+            symbol("utf16_is_surrogate"))
+    Base.is_surrogate_codeunit(chr)
+end
+function utf16_is_lead(chr::UInt16)
+    depwarn("""
+            Base.utf16_is_lead was undocumented and unexported,
+            and has been removed.  Use Base.is_surrogate_lead(chr::Unsigned) instead,
+            however is is also undocumented and unexported, and may change in the future.
+            """,
+            symbol("utf16_is_lead"))
+    Base.is_surrogate_lead(chr)
+end
+function utf16_is_trail(chr::UInt16)
+    depwarn("""
+            Base.utf16_is_trail was undocumented and unexported,
+            and has been removed.  Use Base.is_surrogate_trail(chr::Unsigned) instead,
+            however it is also undocumented and unexported, and may change in the future.
+            """,
+            symbol("utf16_is_trail"))
+    Base.is_surrogate_trail(chr)
+end
+function utf16_get_supplementary(lead::UInt16, trail::UInt16)
+    depwarn("""
+            Base.utf16_get_supplementary was undocumented and unexported,
+            and has been removed.  Use Base.get_supplementary(lead::Unsigned, trail::Unsigned) instead,
+            however it is also undocumented and unexported, and may change in the future.
+            """,
+            symbol("utf16_get_supplementary"))
+    Base.get_supplementary(lead, trail)
+end
 
 # 11280, mmap
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -540,61 +540,53 @@ end
 export MathConst, @math_const
 
 # 11551
-function utf16_is_surrogate(chr::UInt16)
-    depwarn("""
-            Base.utf16_is_surrogate was undocumented and unexported,
-            and has been removed.  Use Base.is_surrogate_codeunit(chr::Unsigned) instead,
-            however it is also undocumented and unexported, and may change in the future.
-            """,
-            symbol("utf16_is_surrogate"))
-    Base.is_surrogate_codeunit(chr)
-end
-function utf16_is_lead(chr::UInt16)
-    depwarn("""
-            Base.utf16_is_lead was undocumented and unexported,
-            and has been removed.  Use Base.is_surrogate_lead(chr::Unsigned) instead,
-            however is is also undocumented and unexported, and may change in the future.
-            """,
-            symbol("utf16_is_lead"))
-    Base.is_surrogate_lead(chr)
-end
-function utf16_is_trail(chr::UInt16)
-    depwarn("""
-            Base.utf16_is_trail was undocumented and unexported,
-            and has been removed.  Use Base.is_surrogate_trail(chr::Unsigned) instead,
-            however it is also undocumented and unexported, and may change in the future.
-            """,
-            symbol("utf16_is_trail"))
-    Base.is_surrogate_trail(chr)
-end
-function utf16_get_supplementary(lead::UInt16, trail::UInt16)
-    depwarn("""
-            Base.utf16_get_supplementary was undocumented and unexported,
-            and has been removed.  Use Base.get_supplementary(lead::Unsigned, trail::Unsigned) instead,
-            however it is also undocumented and unexported, and may change in the future.
-            """,
-            symbol("utf16_get_supplementary"))
-    Base.get_supplementary(lead, trail)
+
+macro unexportedwarn(old, new)
+    meta = Expr(:meta, :noinline)
+    if isa(old,Symbol)
+        oldname = Expr(:quote, old)
+        newname = Expr(:quote, new)
+        Expr(:toplevel,
+                :(function $old(args...)
+                $meta
+                depwarn(string("Base.", $oldname, " was undocumented and unexported,\n",
+                "and has been removed.  Use ", $newname, " instead,\n",
+                "however it is also undocumented and unexported, and may change in the future."),
+                $oldname)
+                $new(args...)
+                end))
+    elseif isa(old,Expr) && old.head == :call
+        oldcall = sprint(io->show_unquoted(io,old))
+        newcall = sprint(io->show_unquoted(io,new))
+        oldsym = if isa(old.args[1],Symbol)
+            old.args[1]
+        elseif isa(old.args[1],Expr) && old.args[1].head == :curly
+            old.args[1].args[1]
+        else
+            error("invalid usage of @unexportedwarn")
+        end
+        oldname = Expr(:quote, oldsym)
+        Expr(:toplevel,
+            :($(esc(old)) = begin
+                  $meta
+                  depwarn(string("Base.", $oldcall, " was undocumented and unexported,\n",
+                         "and has been removed.  Use ", $newcall, " instead,\n",
+                         "however it is also undocumented and unexported, and may change in the future."),
+                         $oldname)
+                  $(esc(new))
+              end))
+    else
+        error("invalid usage of @unexportedwarn")
+    end
 end
 
-function is_utf8_start(byte::UInt8)
-    depwarn("""
-            Base.is_utf8_start(c::UInt8) was undocumented and unexported,
-            and has been removed.  Use !Base.is_valid_continuation(c) instead,
-            however it is also undocumented and unexported, and may change in the future.
-            """,
-            symbol("is_utf8_start"))
-    !Base.is_valid_continuation(byte)
-end
-function is_utf8_continuation(byte::UInt8)
-    depwarn("""
-            Base.is_utf8_continuation(c::UInt8) was undocumented and unexported,
-            and has been removed.  Use Base.is_valid_continuation(c) instead,
-            however it is also undocumented and unexported, and may change in the future.
-            """,
-            symbol("is_utf8_continuation"))
-    Base.is_valid_continuation(byte)
-end
+@unexportedwarn utf16_is_surrogate(ch::Uint16) Base.is_surrogate_codeunit(ch)
+@unexportedwarn utf16_is_lead(ch::UInt16)      Base.is_surrogate_lead(ch)
+@unexportedwarn utf16_is_trail(ch::UInt16)     Base.is_surrogate_trail(ch)
+@unexportedwarn utf16_get_supplementary(lead::UInt16, trail::UInt16) Base.get_supplementary(lead, trail)
+
+@unexportedwarn is_utf8_start(ch::UInt8)         !Base.is_valid_continuation(ch)
+@unexportedwarn is_utf8_continuation(ch::UInt8)  Base.is_valid_continuation(ch)
 
 # 11280, mmap
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -527,6 +527,10 @@ function start_timer(t, d, r)
     error("start_timer is deprecated. Use Timer(callback, delay, repeat) instead.")
 end
 
+# 11551
+@deprecate utf16_is_surrogate(chr::UInt16) Base.is_surrogate_codeunit(chr)
+@deprecate utf16_get_supplementary(lead::UInt16, trail::UInt16) Base.get_supplementary(lead, trail)
+
 const UnionType = Union
 export UnionType
 

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -21,7 +21,7 @@ function choosetests(choices = [])
         "arrayops", "tuple", "subarray", "reduce", "reducedim", "random",
         "abstractarray", "intfuncs", "simdloop", "blas", "sparse",
         "bitarray", "copy", "math", "fastmath", "functional",
-        "operators", "path", "ccall", "parse", "loading",
+        "operators", "path", "ccall", "parse", "loading", "deprecated",
         "bigint", "sorting", "statistics", "spawn", "backtrace",
         "priorityqueue", "file", "mmap", "version", "resolve",
         "pollfd", "mpfr", "broadcast", "complex", "socket",

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,19 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+if (Base.JLOptions()).depwarn > 1
+    @test_throws ErrorException Base.utf16_is_surrogate(0xdc00)
+    @test_throws ErrorException Base.utf16_is_lead(0xd800)
+    @test_throws ErrorException Base.utf16_is_trail(0xdc00)
+    @test_throws ErrorException Base.utf16_get_supplementary(0xd800, 0xdc00)
+else
+    olderr = STDERR
+    try
+        rd, wr = redirect_stderr()
+        @test Base.utf16_is_surrogate(0xdc00) == true
+        @test Base.utf16_is_lead(0xd800) == true
+        @test Base.utf16_is_trail(0xdc00) == true
+        @test Base.utf16_get_supplementary(0xd800, 0xdc00) == 0x10000
+    finally
+        redirect_stderr(olderr)
+    end
+end

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -5,14 +5,18 @@ if (Base.JLOptions()).depwarn > 1
     @test_throws ErrorException Base.utf16_is_lead(0xd800)
     @test_throws ErrorException Base.utf16_is_trail(0xdc00)
     @test_throws ErrorException Base.utf16_get_supplementary(0xd800, 0xdc00)
+    @test_throws ErrorException Base.is_utf8_start(0x40)
+    @test_throws ErrorException Base.is_utf8_continuation(0x90)
 else
     olderr = STDERR
     try
         rd, wr = redirect_stderr()
-        @test Base.utf16_is_surrogate(0xdc00) == true
-        @test Base.utf16_is_lead(0xd800) == true
-        @test Base.utf16_is_trail(0xdc00) == true
+        @test Base.utf16_is_surrogate(0xdc00)
+        @test Base.utf16_is_lead(0xd800)
+        @test Base.utf16_is_trail(0xdc00)
         @test Base.utf16_get_supplementary(0xd800, 0xdc00) == 0x10000
+        @test Base.is_utf8_start(0x40)
+        @test Base.is_utf8_continuation(0x90)
     finally
         redirect_stderr(olderr)
     end


### PR DESCRIPTION
Although these were undocumented, unexported functions internal to the utf16.jl code, they got used in the JSON package.
(I will also submit a PR to fix JSON)
