### PR TITLE
RFC: Define `length` methods for various iterators, using `Inf` as length for infinite iterators

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -28,6 +28,7 @@ export
     AbstractSparseVector,
     AbstractVector,
     AbstractVecOrMat,
+    AlephNull,
     Array,
     Associative,
     Bidiagonal,
@@ -198,6 +199,7 @@ export
     catalan,
     φ, golden,
     I,
+    ℵ₀,
 
 # Operators
     !,

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -23,11 +23,11 @@ min(x::Integer, ::AlephNull) = x
 min(::AlephNull, x::Integer) = x
 min(::AlephNull, ::AlephNull) = AlephNull()
 
-max(x::Integer, ::AlephNull) = AlephNull()
+max(::Integer, ::AlephNull) = AlephNull()
 max(::AlephNull, ::Integer) = AlephNull()
 max(::AlephNull, ::AlephNull) = AlephNull()
 
-+(x::Integer, ::AlephNull) = AlephNull()
++(::Integer, ::AlephNull) = AlephNull()
 +(::AlephNull, ::Integer) = AlephNull()
 +(::AlephNull, ::AlephNull) = AlephNull()
 

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -1,5 +1,38 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+# For unbounded length iterators
+immutable AlephNull <: Number
+end
+
+show(io::IO, ::AlephNull) = print(io, "ℵ₀")
+const ℵ₀ = AlephNull()
+
+==(::Integer,::AlephNull) = false
+==(::AlephNull,::Integer) = false
+==(::AlephNull,::AlephNull) = true
+
+<(::Integer,::AlephNull) = true
+<(::AlephNull,::Integer) = false
+<(::AlephNull,::AlephNull) = false
+
+<=(::Integer,::AlephNull) = true
+<=(::AlephNull,::Integer) = false
+<=(::AlephNull,::AlephNull) = true
+
+min(x::Integer, ::AlephNull) = x
+min(::AlephNull, x::Integer) = x
+min(::AlephNull, ::AlephNull) = AlephNull()
+
+max(x::Integer, ::AlephNull) = AlephNull()
+max(::AlephNull, ::Integer) = AlephNull()
+max(::AlephNull, ::AlephNull) = AlephNull()
+
++(x::Integer, ::AlephNull) = AlephNull()
++(::AlephNull, ::Integer) = AlephNull()
++(::AlephNull, ::AlephNull) = AlephNull()
+
+-(::AlephNull, ::Integer) = AlephNull()
+
 isempty(itr) = done(itr, start(itr))
 
 # enumerate
@@ -120,7 +153,7 @@ countfrom(start::Number)               = Count(start, one(start))
 countfrom()                            = Count(1, 1)
 
 eltype{S}(it::Count{S}) = S
-length(it::Count) = Inf
+length(it::Count) = AlephNull()
 
 start(it::Count) = it.start
 next(it::Count, state) = (state, state + it.step)
@@ -184,7 +217,7 @@ end
 cycle(xs) = Cycle(xs)
 
 eltype(it::Cycle) = eltype(it.xs)
-length(it::Cycle) = Inf
+length(it::Cycle) = AlephNull()
 
 function start(it::Cycle)
     s = start(it.xs)
@@ -209,7 +242,7 @@ immutable Repeated{O}
 end
 repeated(x) = Repeated(x)
 eltype{O}(r::Repeated{O}) = O
-length(x::Repeated) = Inf
+length(x::Repeated) = AlephNull()
 
 start(it::Repeated) = nothing
 next(it::Repeated, state) = (it.x, nothing)

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -120,6 +120,7 @@ countfrom(start::Number)               = Count(start, one(start))
 countfrom()                            = Count(1, 1)
 
 eltype{S}(it::Count{S}) = S
+length(it::Count) = Inf
 
 start(it::Count) = it.start
 next(it::Count, state) = (state, state + it.step)
@@ -134,6 +135,7 @@ end
 take(xs, n::Int) = Take(xs, n)
 
 eltype(it::Take) = eltype(it.xs)
+length(it::Take) = min(length(it.xs), it.n)
 
 start(it::Take) = (it.n, start(it.xs))
 
@@ -157,6 +159,7 @@ end
 drop(xs, n::Int) = Drop(xs, n)
 
 eltype(it::Drop) = eltype(it.xs)
+length(it::Drop) = max(length(it.xs)-it.n, 0)
 
 function start(it::Drop)
     xs_state = start(it.xs)
@@ -181,6 +184,7 @@ end
 cycle(xs) = Cycle(xs)
 
 eltype(it::Cycle) = eltype(it.xs)
+length(it::Cycle) = Inf
 
 function start(it::Cycle)
     s = start(it.xs)
@@ -205,6 +209,8 @@ immutable Repeated{O}
 end
 repeated(x) = Repeated(x)
 eltype{O}(r::Repeated{O}) = O
+length(x::Repeated) = Inf
+
 start(it::Repeated) = nothing
 next(it::Repeated, state) = (it.x, nothing)
 done(it::Repeated, state) = false

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -122,6 +122,20 @@ General Collections
 
    For ordered, indexable collections, the maximum index ``i`` for which ``getindex(collection, i)`` is valid. For unordered collections, the number of elements.
 
+   If the collection is infinite (e.g. :func:`repeated`), then the function returns ``ℵ₀``, an instance of the singleton type :obj:`AlephNull`.
+
+.. function:: AlephNull()
+
+   A singleton type with instance ``ℵ₀`` representing the cardinality of the set of natural numbers. Its main purpose is to provide a well-defined :func:`length` of infinite iterators, and its use outside this context is discouraged.
+
+   .. doctest::
+
+      julia> length(repeated(1))
+      ℵ₀
+
+      julia> min(ℵ₀,5)
+      5
+
 .. function:: endof(collection) -> Integer
 
    Returns the last index of the collection.

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -48,8 +48,10 @@ let b = IOBuffer("1\n2\n3\n"), a = []
         push!(a, (i,x))
     end
     @test a == [(1,"1\n"),(2,"2\n"),(3,"3\n")]
-    @test length(enumerate(eachline(b))) == 3
 end
+@test length(enumerate(1:3)) == 3
+@test length(repeated(0)) == ℵ₀
+
 
 # zip eachline (issue #7369)
 let zeb     = IOBuffer("1\n2\n3\n4\n5\n"),
@@ -83,8 +85,8 @@ let i = 0
         i <= 10 || break
     end
 end
-@test length(countfrom(0,2)) == Inf
-@test length(countfrom(0)) == Inf
+@test length(countfrom(0,2)) == ℵ₀
+@test length(countfrom(0)) == ℵ₀
 
 # take
 # ----
@@ -124,7 +126,7 @@ end
 
 @test length(drop(1:10,5)) == 5
 @test length(drop(1:10,15)) == 0
-@test length(drop(countfrom(0),5)) == Inf
+@test length(drop(countfrom(0),5)) == ℵ₀
 
 
 # cycle
@@ -138,7 +140,7 @@ let i = 0
     end
 end
 
-@test length(cycle(0:3)) == Inf
+@test length(cycle(0:3)) == ℵ₀
 
 # repeated
 # --------
@@ -158,5 +160,5 @@ let i = 0
     end
 end
 
-@test length(repeated(1)) == Inf
+@test length(repeated(1)) == ℵ₀
 @test length(repeated(1,10)) == 10

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -48,6 +48,7 @@ let b = IOBuffer("1\n2\n3\n"), a = []
         push!(a, (i,x))
     end
     @test a == [(1,"1\n"),(2,"2\n"),(3,"3\n")]
+    @test length(enumerate(eachline(b))) == 3
 end
 
 # zip eachline (issue #7369)
@@ -58,6 +59,9 @@ let zeb     = IOBuffer("1\n2\n3\n4\n5\n"),
         push!(res, (parse(Int,strip(number)), letter))
     end
     @test res == [(1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')]
+    @test length(zip(letters, 1:10)) == 5
+    @test length(zip(letters, countfrom(1))) == 5
+    @test length(zip(letters, 1:3)) == 3
 end
 
 # rest
@@ -66,6 +70,8 @@ let s = "hello"
     _, st = next(s, start(s))
     @test collect(rest(s, st)) == ['e','l','l','o']
 end
+
+
 
 # countfrom
 # ---------
@@ -77,6 +83,8 @@ let i = 0
         i <= 10 || break
     end
 end
+@test length(countfrom(0,2)) == Inf
+@test length(countfrom(0)) == Inf
 
 # take
 # ----
@@ -99,6 +107,10 @@ let i = 0
     @test i == 10
 end
 
+@test length(take(1:10,5)) == 5
+@test length(take(1:10,15)) == 10
+@test length(take(countfrom(1),5)) == 5
+
 # drop
 # ----
 
@@ -110,6 +122,11 @@ let i = 0
     @test i == 4
 end
 
+@test length(drop(1:10,5)) == 5
+@test length(drop(1:10,15)) == 0
+@test length(drop(countfrom(0),5)) == Inf
+
+
 # cycle
 # -----
 
@@ -120,6 +137,8 @@ let i = 0
         i <= 10 || break
     end
 end
+
+@test length(cycle(0:3)) == Inf
 
 # repeated
 # --------
@@ -138,3 +157,6 @@ let i = 0
         i <= 10 || break
     end
 end
+
+@test length(repeated(1)) == Inf
+@test length(repeated(1,10)) == 10


### PR DESCRIPTION
See JuliaLang/Iterators.jl#42 for some discussion.
