### PR TITLE
Return the exception thrown in @test_throws.

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -8,8 +8,9 @@ abstract Result
 type Success <: Result
     expr
     resultexpr
+    res
+    Success(expr, resultexpr=nothing, res=nothing) = new(expr, resultexpr, res)
 end
-Success(expr) = Success(expr, nothing)
 type Failure <: Result
     expr
     resultexpr
@@ -21,7 +22,7 @@ type Error <: Result
     backtrace
 end
 
-default_handler(r::Success) = nothing
+default_handler(r::Success) = r.res
 function default_handler(r::Failure)
     if r.resultexpr != nothing
         error("test failed: $(r.resultexpr)\n in expression: $(r.expr)")
@@ -63,10 +64,10 @@ function do_test_throws(body, qex, bt, extype)
             @test_throws without an exception type is deprecated;
             Use `@test_throws $(typeof(err)) $(qex)` instead.
             """, bt = bt)
-            Success(qex)
+            Success(qex, nothing, err)
         else
             if isa(err, extype)
-                Success(qex)
+                Success(qex, nothing, err)
             else
                 if isa(err,Type)
                     Failure(qex, "the type $err was thrown instead of an instance of $extype")

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -13236,6 +13236,7 @@ golden
 
    Test that the expression \"ex\" throws an exception of type
    \"extype\" and calls the current handler to handle the result.
+   The default handler returns the exception if it is of the expected type.
 
 "),
 

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -53,6 +53,7 @@ Another macro is provided to check if the given expression throws an exception o
 :func:`@test_throws`::
 
   julia> @test_throws ErrorException error("An error")
+  ErrorException("An error")
 
   julia> @test_throws BoundsError error("An error")
   ERROR: test failed: error("An error")
@@ -61,6 +62,7 @@ Another macro is provided to check if the given expression throws an exception o
    in do_test_throws at test.jl:55
 
   julia> @test_throws DomainError throw(DomainError())
+  DomainError()
 
   julia> @test_throws DomainError throw(EOFError())
   ERROR: test failed: throw(EOFError())
@@ -138,6 +140,7 @@ Macros
 .. function:: @test_throws(extype, ex)
 
    Test that the expression ``ex`` throws an exception of type ``extype`` and calls the current handler to handle the result.
+   The default handler returns the exception if it is of the expected type.
 
 .. function:: @test_approx_eq(a, b)
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -34,13 +34,11 @@ let res = assert(true)
     @test res === nothing
 end
 let
-    try
+    ex = @test_throws AssertionError begin
         assert(false)
         error("unexpected")
-    catch ex
-        @test isa(ex, AssertionError)
-        @test isempty(ex.msg)
     end
+    @test isempty(ex.msg)
 end
 
 # test @assert macro
@@ -50,53 +48,44 @@ end
 @test_throws AssertionError (@assert false "this is a test" "another test")
 @test_throws AssertionError (@assert false :a)
 let
-    try
+    ex = @test_throws AssertionError begin
         @assert 1 == 2
         error("unexpected")
-    catch ex
-        @test isa(ex, AssertionError)
-        @test contains(ex.msg, "1 == 2")
     end
+    @test contains(ex.msg, "1 == 2")
 end
 # test @assert message
 let
-    try
+    ex = @test_throws AssertionError begin
         @assert 1 == 2 "this is a test"
         error("unexpected")
-    catch ex
-        @test isa(ex, AssertionError)
-        @test ex.msg == "this is a test"
     end
+    @test ex.msg == "this is a test"
 end
 # @assert only uses the first message string
 let
-    try
+    ex = @test_throws AssertionError begin
         @assert 1 == 2 "this is a test" "this is another test"
         error("unexpected")
-    catch ex
-        @test isa(ex, AssertionError)
-        @test ex.msg == "this is a test"
     end
+    @test ex.msg == "this is a test"
 end
 # @assert calls string() on second argument
 let
-    try
+    ex = @test_throws AssertionError begin
         @assert 1 == 2 :random_object
         error("unexpected")
-    catch ex
-        @test isa(ex, AssertionError)
-        @test !contains(ex.msg,  "1 == 2")
-        @test contains(ex.msg, "random_object")
     end
+    @test !contains(ex.msg,  "1 == 2")
+    @test contains(ex.msg, "random_object")
 end
 # if the second argument is an expression, c
 let deepthought(x, y) = 42
-    try
-        @assert 1 == 2 string("the answer to the ultimate question: ", deepthought(6,9))
-    catch ex
-        @test isa(ex, AssertionError)
-        @test ex.msg == "the answer to the ultimate question: 42"
+    ex = @test_throws AssertionError begin
+        @assert 1 == 2 string("the answer to the ultimate question: ",
+                              deepthought(6, 9))
     end
+    @test ex.msg == "the answer to the ultimate question: 42"
 end
 
 let # test the process title functions, issue #9957


### PR DESCRIPTION
Added the return value and use `test/misc.jl` as an example of the new feature.

Fix #11981
