### PR TITLE
disallow 'global x' when x exists in outer scope

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -127,6 +127,9 @@ Language changes
   * Triple-quoted strings no longer treat tabs as 8 spaces. Instead, the
     longest common prefix of spaces and tabs is removed.
 
+  * `global x` in a nested scope is now a syntax error if `x` is local
+    to the enclosing scope ([#7264]/[#11985]).
+
 Command line option changes
 ---------------------------
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3229,7 +3229,12 @@ So far only the second case can actually occur.
                    (mark-label endl))
                ))
 
-            ((global) #f)  ; remove global declarations
+            ((global) ; remove global declarations
+             (let ((vname (cadr e)))
+               (if (var-info-for vname vi)
+                   ; issue #7264
+                   (error (string "`global " vname "`: " vname " is local variable in the enclosing scope"))
+                   #f)))
             ((implicit-global) #f)
             ((local!) #f)
             ((jlgensym) #f)


### PR DESCRIPTION
"fixes" #7264
before:

```
julia> let
         z = 4
              let
                  global z = 10
              end
         end
10
julia> z
ERROR: UndefVarError: z not defined
```

after:

```
let
       z = 4
       let
           global z = 10
       end
end
ERROR: syntax: variable "z" declared local in enclosing scope
```

I guess ideally this ought to work, but at least giving an error makes the problem obvious immediately.

Alternatively, if someone can suggest how to pass the annotation through I'll try to implement that.(~~...remember the variable and emit a a lambda when compiling the assignment block?~~ edit: ick, nevermind. that would be order-dependent)
