### PR TITLE
Inhibit finalizers during codegen

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -628,6 +628,7 @@ static Function *to_function(jl_lambda_info_t *li)
     DebugLoc olddl = builder.getCurrentDebugLocation();
     bool last_n_c = nested_compile;
     nested_compile = true;
+    jl_gc_inhibit_finalizers(nested_compile);
     Function *f = NULL;
     JL_TRY {
         f = emit_function(li);
@@ -647,6 +648,7 @@ static Function *to_function(jl_lambda_info_t *li)
     }
     assert(f != NULL);
     nested_compile = last_n_c;
+    jl_gc_inhibit_finalizers(nested_compile);
 #ifdef JL_DEBUG_BUILD
 #ifdef LLVM35
     llvm::raw_fd_ostream out(1,false);

--- a/src/gc.c
+++ b/src/gc.c
@@ -257,6 +257,7 @@ extern "C" {
 #endif
 
 int jl_in_gc; // referenced from switchto task.c
+static int jl_gc_finalizers_inhibited; // don't run finalizers during codegen #11956
 
 // malloc wrappers, aligned allocation
 
@@ -342,6 +343,16 @@ static void run_finalizers(void)
         run_finalizer((jl_value_t*)o, (jl_value_t*)f);
     }
     JL_GC_POP();
+}
+
+void jl_gc_inhibit_finalizers(int state)
+{
+    if (jl_gc_finalizers_inhibited && !state && !jl_in_gc) {
+        jl_in_gc = 1;
+        run_finalizers();
+        jl_in_gc = 0;
+    }
+    jl_gc_finalizers_inhibited = state;
 }
 
 static void schedule_all_finalizers(arraylist_t* flist)
@@ -2142,7 +2153,9 @@ void jl_gc_collect(int full)
 #if defined(GC_FINAL_STATS) || defined(GC_TIME)
             finalize_time = jl_hrtime();
 #endif
-            run_finalizers();
+            if (!jl_gc_finalizers_inhibited) {
+                run_finalizers();
+            }
 #if defined(GC_FINAL_STATS) || defined(GC_TIME)
             finalize_time = jl_hrtime() - finalize_time;
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -43,6 +43,7 @@ STATIC_INLINE jl_value_t *newstruct(jl_datatype_t *type)
 // MSVC miscalculates sizeof(jl_taggedvalue_t) because
 // empty structs are a GNU extension
 #define sizeof_jl_taggedvalue_t (sizeof(void*))
+void jl_gc_inhibit_finalizers(int state);
 
 #ifdef GC_DEBUG_ENV
 void gc_debug_print_status();


### PR DESCRIPTION
Might close #11956, if I followed @carnaval's idea correctly. Will see if this helps at all with #11818 or #7942.
