### PR TITLE
Use call overload in FFTW.plan_*

### DIFF
--- a/base/fftw.jl
+++ b/base/fftw.jl
@@ -343,6 +343,21 @@ end
 
 call(w::ScaleWrap, Z) = scale!(w.w(Z), w.nrm)
 
+immutable PlanWrapR{Ti, To, Nd, P}
+    p::P
+    osize::NTuple{Nd, Int}
+end
+
+call{Ti, To, Nd, P}(::Type{PlanWrapR{Ti, To, Nd}}, p::P, osize) =
+    PlanWrapR{Ti, To, Nd, P}(p, (osize...))
+
+function call{Ti, To}(w::PlanWrapR{Ti, To}, Z::StridedArray{Ti})
+    assert_applicable(w.p, Z)
+    W = Array(To, w.osize...)
+    execute(w.p.plan, Z, W)
+    return W
+end
+
 # low-level Plan creation (for internal use in FFTW module)
 
 for (Tr,Tc,fftw,lib) in ((:Float64,:Complex128,"fftw",libfftw),
@@ -588,12 +603,7 @@ for (Tr,Tc) in ((:Float32,:Complex64),(:Float64,:Complex128))
             osize[d1] = osize[d1]>>1 + 1
             Y = Array($Tc, osize...)
             p = Plan(X, Y, region, flags, tlim)
-            return Z::StridedArray{$Tr} -> begin
-                assert_applicable(p, Z)
-                W = Array($Tc, osize...)
-                execute(p.plan, Z, W)
-                return W
-            end
+            return PlanWrapR{$Tr, $Tc, ndims(X)}(p, osize)
         end
 
         # FFTW currently doesn't support PRESERVE_INPUT for
@@ -644,12 +654,7 @@ for (Tr,Tc) in ((:Float32,:Complex64),(:Float64,:Complex128))
             osize[region] = d
             Y = Array($Tr, osize...)
             p = Plan(X, Y, region, flags | PRESERVE_INPUT, tlim)
-            return Z::StridedArray{$Tc} -> begin
-                assert_applicable(p, Z)
-                W = Array($Tr, osize...)
-                execute(p.plan, Z, W)
-                return W
-            end
+            return PlanWrapR{$Tc, $Tr, ndims(X)}(p, osize)
         end
 
         function plan_brfft(X::StridedArray{$Tc}, d::Integer, region,

--- a/base/fftw.jl
+++ b/base/fftw.jl
@@ -294,6 +294,16 @@ function fix_kinds(region, kinds)
     return kinds
 end
 
+immutable Identity
+end
+
+@inline call(::Identity, x) = x
+
+immutable ToReal
+end
+
+@inline call(::ToReal, x) = real(x)
+
 # low-level Plan creation (for internal use in FFTW module)
 
 for (Tr,Tc,fftw,lib) in ((:Float64,:Complex128,"fftw",libfftw),
@@ -697,19 +707,19 @@ rfft(x::Real, dims) = dims[1] == 1 ? x : throw(BoundsError())
 irfft(x::Number, d::Integer, dims) = d == 1 && dims[1] == 1 ? real(x) : throw(BoundsError())
 brfft(x::Number, d::Integer, dims) = d == 1 && dims[1] == 1 ? real(x) : throw(BoundsError())
 
-plan_fft(x::Number) = x -> x
-plan_ifft(x::Number) = x -> x
-plan_bfft(x::Number) = x -> x
-plan_rfft(x::Real) = x -> x
-plan_irfft(x::Number, d::Integer) = (irfft(x,d); x -> real(x))
-plan_brfft(x::Number, d::Integer) = (brfft(x,d); x -> real(x))
+plan_fft(x::Number) = Identity()
+plan_ifft(x::Number) = Identity()
+plan_bfft(x::Number) = Identity()
+plan_rfft(x::Real) = Identity()
+plan_irfft(x::Number, d::Integer) = (irfft(x,d); ToReal())
+plan_brfft(x::Number, d::Integer) = (brfft(x,d); ToReal())
 
-plan_fft(x::Number, dims) = (fft(x,dims); x -> x)
-plan_ifft(x::Number, dims) = (ifft(x,dims); x -> x)
-plan_bfft(x::Number, dims) = (bfft(x,dims); x -> x)
-plan_rfft(x::Real, dims) = (rfft(x,dims); x -> x)
-plan_irfft(x::Number, d::Integer, dims) = (irfft(x,d,dims); x -> real(x))
-plan_brfft(x::Number, d::Integer, dims) = (brfft(x,d,dims); x -> real(x))
+plan_fft(x::Number, dims) = (fft(x,dims); Identity())
+plan_ifft(x::Number, dims) = (ifft(x,dims); Identity())
+plan_bfft(x::Number, dims) = (bfft(x,dims); Identity())
+plan_rfft(x::Real, dims) = (rfft(x,dims); Identity())
+plan_irfft(x::Number, d::Integer, dims) = (irfft(x,d,dims); ToReal())
+plan_brfft(x::Number, d::Integer, dims) = (brfft(x,d,dims); ToReal())
 
 plan_fft(x::Number, dims, flags) = plan_fft(x, dims)
 plan_ifft(x::Number, dims, flags) = plan_ifft(x, dims)


### PR DESCRIPTION
I'm aware of https://github.com/JuliaLang/julia/pull/6193. However, I think it is still useful to get this into 0.4 for following reasons.
1. This PR does not break the API
2. The API in the PR does not conflict with the one in #6193 (the commits themselves might)
3. Unless we're going to fix the anonymous function performance issue, this PR has a non-negligible performance improvment.
   
   I have a time propagator which uses FFT to transform between position and momentum space and this PR boost the performance by 23% (2.6s to 2.0s) and reduce the allocation number by 10x and size by 130M (2720 k -> 300k times, 440M -> 310M). These are numbers that includes the time spend for other calculations. (cleaner benchmark: https://github.com/JuliaLang/julia/pull/11994#issuecomment-118193390)

A few other notes about this PR:
1. I breaks the PR into several commits mainly because the nature of this PR means there's a lot of code movement and having separate commits makes it easier to write, test and review.
2. Is [this](https://github.com/JuliaLang/julia/blob/8ad0c1ca37271bdae8e4ad209774b3489cef770d/base/fftw.jl#L768) missing a `assert_applicable`?

@stevengj 
