### PR TITLE
Fix segment violation with negative size argument to NTuple{N,T}

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -963,6 +963,8 @@ DLLEXPORT double jl_unbox_float64(jl_value_t *v);
 DLLEXPORT void *jl_unbox_voidpointer(jl_value_t *v);
 DLLEXPORT ssize_t jl_unbox_gensym(jl_value_t *v);
 
+DLLEXPORT int jl_get_size(jl_value_t *val, size_t *pnt);
+
 #ifdef _P64
 #define jl_box_long(x)   jl_box_int64(x)
 #define jl_box_ulong(x)  jl_box_uint64(x)

--- a/test/core.jl
+++ b/test/core.jl
@@ -3082,6 +3082,14 @@ catch err
     @test err.got == 0x1
 end
 
+# 11996
+try
+    @eval NTuple{-1, Int}
+catch err
+    @test isa(err, ErrorException)
+    @test err.msg == "size or dimension is negative: -1"
+end
+
 try
     @eval Union{Int, 1}
 catch err


### PR DESCRIPTION
This fixes one of the problems I discovered with the way values are handled in the type system.

~~This is a different fix for the issue in #11967.
Instead of making using an `Unsigned` value (or anything not strictly of `Int` type)
be an error, this allows any `Integer` or `Unsigned` type that is <= `size_t` to be used,
which conceptually seems to be what you'd want.~~

~~Note: the code is more verbose than I would have liked, I couldn't find any way of simply asking if
a parameter was an `Integer` type, as opposed to checking each specific concrete type.~~
