### PR TITLE
Better support for documenting expressions with macros

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -205,7 +205,7 @@ end
 
 doc(f, ::Method) = doc(f)
 
-# Modules
+# Modules
 
 function doc(m::Module)
     md = invoke(doc, Tuple{Any}, m)
@@ -231,7 +231,8 @@ function unblock(ex)
     isexpr(ex, :block) || return ex
     exs = filter(ex->!isexpr(ex, :line), ex.args)
     length(exs) == 1 || return ex
-    return exs[1]
+    # Recursive unblock'ing for macro expansion
+    return unblock(exs[1])
 end
 
 uncurly(ex) = isexpr(ex, :curly) ? ex.args[1] : ex
@@ -287,14 +288,29 @@ end
 fexpr(ex) = isexpr(ex, :function, :(=)) && isexpr(ex.args[1], :call)
 
 function docm(meta, def)
+    # Quote, Unblock and Macroexpand
+    # * Always do macro expansion unless it's a quote (for consistency)
+    # * Unblock before checking for Expr(:quote) to support `->` syntax
+    # * Unblock after macro expansion to recognize structures of
+    #   the generated AST
     def′ = unblock(def)
+    if !isexpr(def′, :quote)
+        def = macroexpand(def)
+        def′ = unblock(def)
+    elseif length(def′.args) == 1 && isexpr(def′.args[1], :macrocall)
+        # Special case for documenting macros after definition with
+        # `@doc "<doc string>" :@macro` or
+        # `@doc "<doc string>" :(str_macro"")` syntax.
+        #
+        # Allow more general macrocall for now unless it causes confusion.
+        return objdoc(meta, namify(def′.args[1]))
+    end
     isexpr(def′, :macro) && return namedoc(meta, def, symbol("@", namify(def′)))
     isexpr(def′, :type) && return typedoc(meta, def, namify(def′.args[2]))
     isexpr(def′, :bitstype) && return namedoc(meta, def, def′.args[2])
     isexpr(def′, :abstract) && return namedoc(meta, def, namify(def′))
     isexpr(def′, :module) && return namedoc(meta, def, def′.args[2])
     fexpr(def′) && return funcdoc(meta, def)
-    isexpr(def′, :macrocall) && (def = namify(def′))
     return objdoc(meta, def)
 end
 
@@ -369,7 +385,7 @@ documented, as opposed to the whole function. Method docs are
 concatenated together in the order they were defined to provide docs
 for the function.
 """
-@doc
+:@Base.DocBootstrap.doc
 
 "`doc(obj)`: Get the doc metadata for `obj`."
 doc

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -370,6 +370,19 @@ The `->` is not required if the object is on the same line, e.g.
 
     @doc "foo" foo
 
+# Documenting objects after they are defined
+You can document an object after its definition by
+
+    @doc "foo" function_to_doc
+    @doc "bar" TypeToDoc
+
+For functions, this currently only support documenting the whole function
+Instead of a specific method. See Functions & Methods section below
+
+For macros, the syntax is `@doc "macro doc" :(@Module.macro)` or
+`@doc "macro doc" :(string_macro"")` for string macros. Without the quote `:()`
+the expansion of the macro will be documented.
+
 # Retrieving Documentation
 You can retrieve docs for functions, macros and other objects as
 follows:

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -296,7 +296,7 @@ allocated. Returns the value of the expression. For example:
       2+2
     end
 """
-@time
+:@time
 
 doc"""
 Construct a regex, such as `r"^[a-z]*$"`. The regex also accepts

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -6,7 +6,8 @@ abstract C74685 <: AbstractArray
 
 macro macro_doctest() end
 @doc "Helps test if macros can be documented with `@doc \"...\" -> @...`." ->
-@macro_doctest
+:@macro_doctest
+
 @test (@doc @macro_doctest) != nothing
 
 # issue #11548
@@ -16,7 +17,7 @@ macro m() end
 end
 
 @doc ("I am a module";) ModuleMacroDoc
-@doc ("I am a macro";)  ModuleMacroDoc.@m
+@doc ("I am a macro";)  :@ModuleMacroDoc.m
 
 @test (@doc ModuleMacroDoc)    == "I am a module"
 @test (@doc ModuleMacroDoc.@m) == ["I am a macro"]
@@ -193,3 +194,33 @@ end
 
 @test meta(DocsTest)[:G] == doc"G"
 @test meta(DocsTest)[:K] == doc"K"
+
+# issue 11993
+# Check if we are documenting the expansion of the macro
+macro m1_11993()
+end
+
+macro m2_11993()
+    symbol("@m1_11993")
+end
+
+@doc "This should document @m1... since its the result of expansion" @m2_11993
+@test (@doc @m1_11993) !== nothing
+@test (@doc @m2_11993) === nothing
+
+@doc "Now @m2... should be documented" :@m2_11993
+@test (@doc @m2_11993) !== nothing
+
+"Document inline function"
+@inline f1_11993() = nothing
+
+@test (@doc f1_11993) !== nothing
+
+f1_11993()
+
+@doc "Document inline function with old syntax" ->
+@inline f2_11993() = nothing
+
+@test (@doc f2_11993) !== nothing
+
+f2_11993()


### PR DESCRIPTION
Fix #11993 (not sure if this is the best way though)
- Update:
  
  See below for the current behavior https://github.com/JuliaLang/julia/pull/12000#issuecomment-118404697 and examples of it https://github.com/JuliaLang/julia/pull/12000#issuecomment-118410489
  
  It still uses `macroexpand` in a `macro`.

Original post:
1. Disallow documenting macro with
   
   ```
   "<doc>"
   @macro
   ```
   
   syntax since it can be ambiguous with expanding and using the macro (which might have side effects)
2. Expand the macro if the expression to be documented is a macro call in order to document the correct object.

Issues
1. This is calling `macroexpand` in a macro. Not sure if this is the best thing to do but I couldn't come up with a better way to do what I want.
2. ~~Both `"" @m` and~~ `""<\n>@m` ~~are~~ is parsed as
   
   ``` julia
   quote
       ""
       @id
   end
   ```
   
   ~~The former should probably be reallowed,~~(edit: fixed) ~~the latter~~ this should probably not have the `block` (although I couldn't figure out if I can reset the input stream)
