### PR TITLE
Include LLVM libs in make install if using shared source-build llvm library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,10 @@ endif
 ifeq ($(USE_SYSTEM_SUITESPARSE),0)
 JL_PRIVATE_LIBS += amd camd ccolamd cholmod colamd umfpack spqr suitesparseconfig
 endif
+ifeq ($(USE_SYSTEM_LLVM),0)
 ifeq ($(USE_LLVM_SHLIB),1)
 JL_PRIVATE_LIBS += LLVM
+endif
 endif
 ifeq ($(OS),Darwin)
 ifeq ($(USE_SYSTEM_BLAS),1)

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,9 @@ endif
 ifeq ($(USE_SYSTEM_SUITESPARSE),0)
 JL_PRIVATE_LIBS += amd camd ccolamd cholmod colamd umfpack spqr suitesparseconfig
 endif
+ifeq ($(LLVM_VER),svn)
+JL_PRIVATE_LIBS += LLVM
+endif
 ifeq ($(OS),Darwin)
 ifeq ($(USE_SYSTEM_BLAS),1)
 ifeq ($(USE_SYSTEM_LAPACK),0)

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ endif
 ifeq ($(USE_SYSTEM_SUITESPARSE),0)
 JL_PRIVATE_LIBS += amd camd ccolamd cholmod colamd umfpack spqr suitesparseconfig
 endif
-ifeq ($(LLVM_VER),svn)
+ifeq ($(USE_LLVM_SHLIB),1)
 JL_PRIVATE_LIBS += LLVM
 endif
 ifeq ($(OS),Darwin)


### PR DESCRIPTION
The llvm libraries are not included in the distribution by default.  If building llvm-svn, this is probably not correct.  This PR changes the Makefile to add LLVM to JL_PRIVATE_LIBS when building llvm-svn causing them to be copied as part of install.
