### PR TITLE
Fix printing of bitstype definition

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -596,6 +596,10 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         show_block(io, args[1] ? :type : :immutable, args[2], args[3], indent)
         print(io, "end")
 
+    elseif is(head, :bitstype) && nargs == 2
+        print(io, "bitstype ")
+        show_list(io, args, ' ', indent)
+
     # empty return (i.e. "function f() return end")
     elseif is(head, :return) && nargs == 1 && is(args[1], nothing)
         print(io, head)

--- a/test/show.jl
+++ b/test/show.jl
@@ -263,3 +263,9 @@ end
 @test_repr "1 => 2 => 3"
 @test_repr "1 => (2 => 3)"
 @test_repr "(1 => 2) => 3"
+
+# pr 12008
+@test_repr "bitstype A B"
+@test_repr "bitstype 100 B"
+@test repr(:(bitstype A B)) == ":(bitstype A B)"
+@test repr(:(bitstype 100 B)) == ":(bitstype 100 B)"


### PR DESCRIPTION
Before

``` julia
julia> :(bitstype 100 B)
:($(Expr(:bitstype, 100, :B)))
```

After

``` julia
julia> :(bitstype 100 B)
:(bitstype 100 B)
```
