### PR TITLE
WIP: Implement 'at-docsyntax' [skip ci].

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1343,7 +1343,9 @@ export
     @text_str,
     @html_str,
     @doc,
+    @docsyntax,
     @doc_str,
+    @doc_markdown,
 
     # output
     @show,

--- a/base/markdown/Markdown.jl
+++ b/base/markdown/Markdown.jl
@@ -21,7 +21,7 @@ include("render/latex.jl")
 
 include("render/terminal/render.jl")
 
-export readme, license, @md_str, @doc_str
+export readme, license, @md_str, @doc_markdown
 
 parse(markdown::String; flavor = julia) = parse(IOBuffer(markdown), flavor = flavor)
 parse_file(file::String; flavor = julia) = parse(readall(file), flavor = flavor)
@@ -51,8 +51,8 @@ macro md_str(s, t...)
     mdexpr(s, t...)
 end
 
-macro doc_str(s, t...)
-    docexpr(s, t...)
+macro doc_markdown(s, t...)
+    :(parse($(esc(s))))
 end
 
 function Base.display(d::Base.REPL.REPLDisplay, md::Vector{MD})


### PR DESCRIPTION
A rough WIP sketch of the `@docsyntax` idea @one-more-minute mentioned in #11970.

`@docsyntax` defines a module constant called `__DOCSYNTAX__` that stores that module's format.

`@doc` then transforms all docstrings into calls to the format specific macro, which can be handled however the macro author chooses.

`doc"..."` is now only for avoiding interpolation. The markdown parsing is handled by the `@doc_markdown` macro.

``` jl
module T

@docsyntax rst

macro doc_rst(text)
    text
end

"..."
f(x) = x

end
```
