### PR TITLE
RFC: Have each process write its own unique .cov file for coverage statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.dylib
 *.dSYM
 *.jl.cov
+*.jl.*.cov
 *.jl.mem
 *.ji
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1291,9 +1291,11 @@ void write_log_data(logdata_t logData, const char *extension)
     }
 }
 
+extern "C" int jl_getpid();
 extern "C" void jl_write_coverage_data(void)
 {
-    write_log_data(coverageData, ".cov");
+    std::string outf = "." + std::to_string(jl_getpid()) + ".cov";
+    write_log_data(coverageData, outf.c_str());
 }
 
 // Memory allocation log (malloc_log)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1294,7 +1294,9 @@ void write_log_data(logdata_t logData, const char *extension)
 extern "C" int jl_getpid();
 extern "C" void jl_write_coverage_data(void)
 {
-    std::string outf = "." + std::to_string(jl_getpid()) + ".cov";
+    std::ostringstream stm;
+    stm << jl_getpid();
+    std::string outf = "." + stm.str() + ".cov";
     write_log_data(coverageData, outf.c_str());
 }
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -126,15 +126,20 @@ end"""
   end
 
   Pkg.test("PackageWithCodeCoverage")
-  covfile = Pkg.dir("PackageWithCodeCoverage","src","PackageWithCodeCoverage.jl.cov")
-  @test !isfile(covfile)
+  covdir = Pkg.dir("PackageWithCodeCoverage","src")
+  covfiles = filter!(x -> contains(x, "PackageWithCodeCoverage.jl") && contains(x,".cov"), readdir(covdir))
+  @test isempty(covfiles)
   Pkg.test("PackageWithCodeCoverage", coverage=true)
-  @test isfile(covfile)
-  covstr = readall(covfile)
-  srclines = split(src, '\n')
-  covlines = split(covstr, '\n')
-  for i = 1:length(linetested)
-      covline = (linetested[i] ? "        1 " : "        - ")*srclines[i]
-      @test covlines[i] == covline
+  covfiles = filter!(x -> contains(x, "PackageWithCodeCoverage.jl") && contains(x,".cov"), readdir(covdir))
+  @test !isempty(covfiles)
+  for file in covfiles
+      @test isfile(joinpath(covdir,file))
+      covstr = readall(joinpath(covdir,file))
+      srclines = split(src, '\n')
+      covlines = split(covstr, '\n')
+      for i = 1:length(linetested)
+          covline = (linetested[i] ? "        1 " : "        - ")*srclines[i]
+          @test covlines[i] == covline
+      end
   end
 end


### PR DESCRIPTION
Right now, files from multiple processes (e.g. for `parallel` and `multi` tests) are overwriting each other and throwing our statistics off. This PR changes the behaviour so that when `--code-coverage={user/all}` is passed, each process will write its own file of the format `{filename}.{pid}.cov`. I've already tested this with `Coverage.jl` and `CoverageBase.jl` and have submitted PRs to handle the change to those two packages. 
