### PR TITLE
Fix problem with bitstype when N doesn't fit in 32-bits

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -371,7 +371,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         vnb  = eval(args[2], locals, nl, ngensym);
         if (!jl_is_long(vnb))
             jl_errorf("invalid declaration of bits type %s", ((jl_sym_t*)name)->name);
-        int32_t nb = jl_unbox_long(vnb);
+        ssize_t nb = jl_unbox_long(vnb);
         if (nb < 1 || nb>=(1<<23) || (nb&7) != 0)
             jl_errorf("invalid number of bits in type %s",
                       ((jl_sym_t*)name)->name);

--- a/test/core.jl
+++ b/test/core.jl
@@ -3106,3 +3106,8 @@ end
 const DATE12003 = DateTime(1917,1,1)
 failure12003(dt=DATE12003) = Dates.year(dt)
 @test isa(failure12003(), Integer)
+
+# #12023 Test error checking in bitstype
+@test_throws ErrorException bitstype 0 SPJa12023
+@test_throws ErrorException bitstype 4294967312 SPJb12023
+@test_throws ErrorException bitstype -4294967280 SPJc12023


### PR DESCRIPTION
The code in `src/interpreter.c` for handling bitstype definitions had a bug on 64-bit platforms, because it used `jl_is_long` and `jl_unbox_long` but stored the value in an `int32` variable.
For example, without this PR, definitions such as these don't get errors.

``` julia
julia> bitstype -4294967280 t
julia> bitstype 68719476752 y
```

~~(Note: I'm trying to add test cases to test/core.jl, however, I need to figure out what sort of error is thrown, it just prints out ERROR:...)~~
