### PR TITLE
Improve prime sieve performance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -319,6 +319,12 @@ Library improvements
 
     * `isapprox` now has simpler and more sensible default tolerances ([#12393]).
 
+  * Numbers
+
+    * `primes` is now faster and has been extended to generate the primes in a user defined closed interval ([#12025]).
+
+    * The function `primesmask` which generates a prime sieve for a user defined closed interval is now exported ([#12025]).
+
   * Random numbers
 
     * Streamlined random number generation APIs [#8246].

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -2947,12 +2947,22 @@ isapprox
 doc"""
 ```rst
 ::
-           primes(n)
+           primes([lo,] hi)
 
-Returns a collection of the prime numbers <= ``n``.
+Returns a collection of the prime numbers (from ``lo``, if specified) up to ``hi``.
 ```
 """
 primes
+
+doc"""
+```rst
+::
+           primesmask([lo,] hi)
+
+Returns a prime sieve, as a ``BitArray``, of the positive integers (from ``lo``, if specified) up to ``hi``. Useful when working with either primes or composite numbers.
+```
+"""
+primesmask
 
 doc"""
 ```rst

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -415,6 +415,7 @@ export
     prevpow2,
     prevprod,
     primes,
+    primesmask,
     rad2deg,
     rationalize,
     real,

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -445,9 +445,9 @@ Integers
    	julia> isprime(big(3))
    	true
 
-.. function:: primes(n)
+.. function:: primes([lo,] hi)
 
-   Returns a collection of the prime numbers <= ``n``.
+.. function:: primesmask([lo,] hi)
 
 .. function:: isodd(x::Integer) -> Bool
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1978,7 +1978,7 @@ for f in (trunc, round, floor, ceil)
 
 # primes
 
-@test Base.primes(10000) == [
+@test primes(10000) == primes(2, 10000) == [
     2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
     73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151,
     157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233,
@@ -2080,6 +2080,11 @@ for f in (trunc, round, floor, ceil)
     9851, 9857, 9859, 9871, 9883, 9887, 9901, 9907, 9923, 9929, 9931, 9941,
     9949, 9967, 9973 ]
 
+for n = 100:100:1000
+    @test primes(n, 10n) == primes(10n)[length(primes(n))+1:end]
+    @test primesmask(n, 10n) == primesmask(10n)[n:end]
+end
+
 for T in [Int,BigInt], n = [1:1000;1000000]
     n = convert(T,n)
     f = factor(n)
@@ -2087,9 +2092,10 @@ for T in [Int,BigInt], n = [1:1000;1000000]
     prime = n!=1 && length(f)==1 && get(f,n,0)==1
     @test isprime(n) == prime
 
-    s = Base.primesmask(n)
+    s = primesmask(n)
     for k = 1:n
         @test s[k] == isprime(k)
+        @test s[k] == primesmask(k, k)[1]
     end
 end
 


### PR DESCRIPTION
This PR changes the algorithm used in `primesmask` from a Sieve of Atkin to a Sieve of Eratosthenes, based on the ~~idea~~ redesign proposed by @VicDrastik in #11594.

The main ideas used are
- ~~Most integers are composite, so it is better to set all flags to false initially, then invert for possible primes~~
- ~~Except for 2, 3 all primes are of the from 6k ± 1~~
- Implement a 30 wheel sieve. This sieve stores a flag for each number of the form 30k + p where p is one of `[7, 11, 13, 17, 19, 23, 29, 31]` (all primes greater than 5 are of this form).
- Cross-off multiples of p of the above form, starting from p².
- Use the wheel sieve `_primesmask` (not exported) to construct `primesmask` and to find primes.

Additionally, the function `primesmask` is now exported and both this function and `primes` are extended in order to generate all the primes between two integers.

As a follow-up, it would be worth trying to write a general segmented version (perhaps a mix between this and the ideas of @ironman353 in #11594 or this http://primesieve.org/segmented_sieve.html).

I apologize to @Ismael-VC who was also working on this in #11927 (his approach was to fix the current implementation of the Sieve of Atkin, but this should be even faster as suggested in #11594).

Finally, this PR addresses the initial issue on #11594 but that turned out to be a discussion on how to improve the whole support for primes. Maybe that one should be separated into smaller issues and grouped into a master issue.

CC @danaj @aiorla @StefanKarpinski 
