### PR TITLE
additional tests for take/drop iterators

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -518,6 +518,10 @@ IteratorSize(::Type{<:Count}) = IsInfinite()
 struct Take{I}
     xs::I
     n::Int
+    function Take(xs, n)
+        n < 0 && throw(ArgumentError("Take length must be nonnegative"))
+        return new(xs, n)
+    end
 end
 
 """
@@ -574,6 +578,10 @@ end
 struct Drop{I}
     xs::I
     n::Int
+    function Drop(xs, n)
+        n < 0 && throw(ArgumentError("Drop length must be nonnegative"))
+        return new(xs, n)
+    end
 end
 
 """

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -518,9 +518,9 @@ IteratorSize(::Type{<:Count}) = IsInfinite()
 struct Take{I}
     xs::I
     n::Int
-    function Take(xs, n)
+    function Take(xs::I, n::Integer) where {I}
         n < 0 && throw(ArgumentError("Take length must be nonnegative"))
-        return new(xs, n)
+        return new{I}(xs, n)
     end
 end
 
@@ -578,9 +578,9 @@ end
 struct Drop{I}
     xs::I
     n::Int
-    function Drop(xs, n)
+    function Drop(xs::I, n::Integer) where {I}
         n < 0 && throw(ArgumentError("Drop length must be nonnegative"))
-        return new(xs, n)
+        return new{I}(xs, n)
     end
 end
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -84,7 +84,7 @@ end
 # take
 # ----
 let t = take(0:2:8, 10), i = 0
-    @test length(collect(t)) == 5
+    @test length(collect(t)) == 5 == length(t)
 
     for j = t
         @test j == i*2
@@ -101,6 +101,8 @@ let i = 0
     @test i == 10
 end
 
+@test isempty(take(0:2:8, 0))
+@test_throws ArgumentError take(0:2:8, -1)
 @test length(take(1:3,typemax(Int))) == 3
 @test length(take(countfrom(1),3)) == 3
 @test length(take(1:6,3)) == 3
@@ -115,6 +117,9 @@ let i = 0
     @test i == 4
 end
 
+@test isempty(drop(0:2:10, 100))
+@test isempty(collect(drop(0:2:10, 100)))
+@test_throws ArgumentError drop(0:2:8, -1)
 @test length(drop(1:3,typemax(Int))) == 0
 @test Base.IteratorSize(drop(countfrom(1),3)) == Base.IsInfinite()
 @test_throws MethodError length(drop(countfrom(1), 3))


### PR DESCRIPTION
This adds a `length` method for the `Take` and `Drop` iterators.  I also added a check that the specified length is nonnegative, and a couple of corresponding tests in the test suite.

Note that #12009 is implicated by the added `length` method, if the underlying iterator is missing `length`.
