### PR TITLE
Speed up addition and subtraction between SparseMatrixCSC and UniformScaling

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2835,3 +2835,37 @@ function Base.centralize_sumabs2!{S,Tv,Ti}(R::AbstractArray{S}, A::SparseMatrixC
     end
     return R
 end
+
+## Unitform matrix arithmetic
+
+function (+)(A::SparseMatrixCSC, J::UniformScaling)
+    n = LinAlg.chksquare(A)
+    i, j, nz = findnz(A)
+    for k = 1:n
+        push!(i, k)
+        push!(j, k)
+        push!(nz, J.λ)
+    end
+    return sparse(i, j, nz)
+end
+
+function (-)(A::SparseMatrixCSC, J::UniformScaling)
+    n = LinAlg.chksquare(A)
+    i, j, nz = findnz(A)
+    for k = 1:n
+        push!(i, k)
+        push!(j, k)
+        push!(nz, -J.λ)
+    end
+    return sparse(i, j, nz)
+end
+function (-)(J::UniformScaling, A::SparseMatrixCSC)
+    n = LinAlg.chksquare(A)
+    i, j, nz = findnz(A)
+    for k = 1:n
+        push!(i, k)
+        push!(j, k)
+        push!(nz, -J.λ)
+    end
+    return sparse(i, j, -nz)
+end

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1006,3 +1006,10 @@ A1[2:5,1] = 1
 nonzeros(A1)[2:5]=0
 @test A1==A2
 @test sparse([1,1,0])!=sparse([0,1,1])
+
+# UniformScaling
+A = sprandn(10,10,0.5)
+@test A + I == full(A) + I
+@test I + A == I + full(A)
+@test A - I == full(A) - I
+@test I - A == I - full(A)


### PR DESCRIPTION
It used to use a generic fallback which was extremely slow. For that reason, I've also restricted the generic fallback to `StridedMatrix`.
