### PR TITLE
Define gc counted allocator functions with libc API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
     - make $BUILDOPTS -C base version_git.jl.phony
     - make $BUILDOPTS NO_GIT=1 JULIA_SYSIMG_BUILD_FLAGS="--output-ji ../usr/lib/julia/sys.ji" prefix=/tmp/julia install | moreutils/ts -s "%.s"
     - if [ `uname` = "Darwin" ]; then
-        for name in spqr umfpack colamd cholmod amd suitesparse_wrapper; do
+        for name in suitesparseconfig spqr umfpack colamd cholmod amd suitesparse_wrapper; do
             install -pm755 usr/lib/lib${name}*.dylib* /tmp/julia/lib/julia/;
         done;
       fi

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -25,14 +25,16 @@ default:
 	mkdir -p $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib
 	cd $(JULIAHOME)/deps/SuiteSparse-SYSTEM/lib && \
 	rm -f $(build_libdir)/lib{amd,cholmod,colamd,spqr,umfpack}.$(SHLIB_EXT)
-	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libamd.a $(SS_LIB)/libsuitesparseconfig.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libamd.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libsuitesparseconfig.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libsuitesparseconfig.$(SHLIB_EXT) $(build_libdir)/libsuitesparseconfig.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libamd.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libamd.$(SHLIB_EXT) $(LDFLAGS) -L$(build_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
 	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(build_libdir)/libamd.$(SHLIB_EXT)
-	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcolamd.a $(SS_LIB)/libsuitesparseconfig.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libcolamd.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS)
+	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcolamd.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libcolamd.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
 	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(build_libdir)/libcolamd.$(SHLIB_EXT)
-	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcholmod.a $(SS_LIB)/libsuitesparseconfig.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_libdir) -lcolamd -lccolamd -lcamd -lamd $(RPATH_ORIGIN)
+	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcholmod.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_libdir) -lsuitesparseconfig -lcolamd -lccolamd -lcamd -lamd $(RPATH_ORIGIN)
 	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(build_libdir)/libcholmod.$(SHLIB_EXT)
-	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(SS_LIB)/libumfpack.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libumfpack.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_libdir) -lcolamd -lccolamd -lcamd -lamd -lcholmod $(RPATH_ORIGIN)
+	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libumfpack.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libumfpack.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_libdir) -lsuitesparseconfig -lcolamd -lccolamd -lcamd -lamd -lcholmod $(RPATH_ORIGIN)
 	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(build_libdir)/libumfpack.$(SHLIB_EXT)
-	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(SS_LIB)/libspqr.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libspqr.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_libdir) -lcolamd -lccolamd -lcamd -lamd -lcholmod $(RPATH_ORIGIN)
+	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libspqr.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libspqr.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_libdir) -lsuitesparseconfig -lcolamd -lccolamd -lcamd -lamd -lcholmod $(RPATH_ORIGIN)
 	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(build_libdir)/libspqr.$(SHLIB_EXT)
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -2690,6 +2690,17 @@ DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
     return b;
 }
 
+DLLEXPORT void *jl_gc_counted_calloc(size_t nm, size_t sz)
+{
+    maybe_collect();
+    allocd_bytes += nm*sz;
+    gc_num.malloc++;
+    void *b = calloc(nm, sz);
+    if (b == NULL)
+        jl_throw(jl_memory_exception);
+    return b;
+}
+
 DLLEXPORT void jl_gc_counted_free(void *p, size_t sz)
 {
     free(p);
@@ -2710,6 +2721,38 @@ DLLEXPORT void *jl_gc_counted_realloc_with_old_size(void *p, size_t old, size_t 
     if (b == NULL)
         jl_throw(jl_memory_exception);
     return b;
+}
+
+DLLEXPORT void *jl_malloc(size_t sz)
+{
+    int64_t *p = (int64_t *)jl_gc_counted_malloc(sz + 16);
+    p[0] = sz;
+    return (void *)(p + 2);
+}
+
+DLLEXPORT void *jl_calloc(size_t nm, size_t sz)
+{
+    int64_t *p;
+    size_t nmsz = nm*sz;
+    p = (int64_t *)jl_gc_counted_calloc(nmsz + 16, 1);
+    p[0] = nmsz;
+    return (void *)(p + 2);
+}
+
+DLLEXPORT void jl_free(void *p)
+{
+    int64_t *pp = (int64_t *)p - 2;
+    size_t sz = pp[0];
+    jl_gc_counted_free(pp, sz + 16);
+}
+
+DLLEXPORT void *jl_realloc(void *p, size_t sz)
+{
+    int64_t *pp = (int64_t *)p - 2;
+    size_t szold = pp[0];
+    int64_t *pnew = (int64_t *)jl_gc_counted_realloc_with_old_size(pp, szold + 16, sz + 16);
+    pnew[0] = sz;
+    return (void *)(pnew + 2);
 }
 
 DLLEXPORT void *jl_gc_managed_malloc(size_t sz)


### PR DESCRIPTION
...and use them in CHOLMOD wrappers. This makes the memory consumption from SuiteSparse visible to our GC. Right now SuiteSparse object looks tiny to the GC even though they are huge and in consequence much memory is left allocated when it could be freed.

In particular, I'd like comments on the `gc.c` part of this as I haven't touched that part of the code base before.
