### PR TITLE
RFC: remove the export for Base.require

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1095,7 +1095,6 @@ export
     include,
     include_string,
     reload,
-    require,
 
 # RTS internals
     finalizer,

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # NOTE: worker processes cannot add more workers, only the client process can.
-require("testdefs.jl")
+using Base.Test
 
 if nworkers() < 3
     remotecall_fetch(1, () -> addprocs(3 - nworkers()))


### PR DESCRIPTION
this is in preparation for also removing `require(::String)` during the incremental compilation work (#8745). otherwise it is confusing to the system whether or not it should be using precompiled versions to satisfy this function.

based on a quick grep of my local packages, they should generally have been doing one of (a) not calling require at all (b) using `import X` instead or (c) using conditional modules or (d) using import followed by a relative `using` statement.

also, it's nice to actually be eliminating one of the include/require/using/import set.
