### PR TITLE
Another libgit2 patch for old openssl

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1904,7 +1904,8 @@ endif
 endif
 
 $(LIBGIT2_SRC_DIR)/build/Makefile: $(LIBGIT2_SRC_DIR)/CMakeLists.txt
-	cd $(LIBGIT2_SRC_DIR) && patch -p1 -f < ../libgit2_oldcmake.patch || true
+	-cd $(LIBGIT2_SRC_DIR) && patch -p1 -f < ../libgit2_oldcmake.patch
+	-cd $(LIBGIT2_SRC_DIR) && patch -p1 -f < ../libgit2_oldssl.patch
 	mkdir -p $(LIBGIT2_SRC_DIR)/build
 	cd $(LIBGIT2_SRC_DIR)/build/ && \
 	$(CMAKE) .. $(LIBGIT2_OPTS)

--- a/deps/libgit2_oldssl.patch
+++ b/deps/libgit2_oldssl.patch
@@ -1,0 +1,14 @@
+diff --git a/src/openssl_stream.c b/src/openssl_stream.c
+index 958252e..4df7c6b 100644
+--- a/src/openssl_stream.c
++++ b/src/openssl_stream.c
+@@ -324,7 +324,9 @@ int openssl_connect(git_stream *stream)
+ 
+ 	SSL_set_bio(st->ssl, bio, bio);
+ 	/* specify the host in case SNI is needed */
++#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
+ 	SSL_set_tlsext_host_name(st->ssl, st->host);
++#endif
+ 
+ 	if ((ret = SSL_connect(st->ssl)) <= 0)
+ 		return ssl_set_error(st->ssl, ret);


### PR DESCRIPTION
Fixing more breakage that I caused on the generic Linux nightly buildbots by bumping libgit2. To be merged here and submitted upstream if
http://buildbot.e.ip.saba.us:8010/builders/package_tarball32/builds/1012
and
http://buildbot.e.ip.saba.us:8010/builders/package_tarball64/builds/993
both pass.
