### PR TITLE
Make `Base.argtype_decl` more explicit.

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -12,11 +12,11 @@ function argtype_decl(n, t) # -> (argname, argtype)
         s = s[1:i-1]
     end
     if t === Any && !isempty(s)
-        return s, ""
+        return s, "Any"
     end
     if isvarargtype(t)
         if t.parameters[1] === Any
-            return string(s, "..."), ""
+            return string(s, "..."), "Any"
         else
             return s, string(t.parameters[1], "...")
         end


### PR DESCRIPTION
Make `Base.argtype_decl` more explicit when the type of the arguments is `Any`.

Ref: https://github.com/JuliaLang/julia/commit/8d10edf59cd79339d471115e5461fc44546167ec#commitcomment-12024427
