### PR TITLE
Fix type intersection of NTuple's

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -927,10 +927,18 @@ static jl_value_t *jl_type_intersect(jl_value_t *a, jl_value_t *b,
     if (jl_is_tuple_type(b)) {
         return jl_type_intersect(b, a, penv,eqc,var);
     }
-    if (jl_is_ntuple_type(a) && jl_is_type_type(b)) {
-        jl_value_t *temp = a;
-        a = b;
-        b = temp;
+    if (jl_is_ntuple_type(a)) {
+        if (jl_is_ntuple_type(b)) {
+            jl_value_t *tag = intersect_tag((jl_datatype_t*)a,
+                                            (jl_datatype_t*)b, penv, eqc, var);
+            // The length parameter must be a TypeVar
+            return tag == jl_bottom_type ? jl_typeof(jl_emptytuple) : tag;
+        }
+        else if (jl_is_type_type(b)) {
+            jl_value_t *temp = a;
+            a = b;
+            b = temp;
+        }
     }
     // tag
     if (!jl_is_datatype(a) || !jl_is_datatype(b))


### PR DESCRIPTION
The type intersection of `NTuple{N, Int}` and `NTuple{N, Float64}` should be `Tuple{}`

This also give a ambiguity warning with the following function definitions

``` julia
julia> f{N}(::NTuple{N, Int}) = 1
f (generic function with 1 method)

julia> f{N}(::NTuple{N, Float64}) = 2
Warning: New definition 
    f(NTuple{#N<:Any, Float64}) at none:1
is ambiguous with: 
    f(NTuple{#N<:Any, Int64}) at none:1.
To fix, define 
    f(Tuple{})
before the new definition.
f (generic function with 2 methods)
```
