### PR TITLE
Fix #12066: LinearSlow zero dimensional indexing

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -428,10 +428,17 @@ function unsafe_getindex(A::AbstractArray, I...)
     _unsafe_getindex(linearindexing(A), A, I...)
 end
 ## Internal defitions
+# 0-dimensional indexing is defined to prevent ambiguities. LinearFast is easy:
 _getindex(::LinearFast, A::AbstractArray) = (@_inline_meta; getindex(A, 1))
-_getindex(::LinearSlow, A::AbstractArray) = (@_inline_meta; _getindex(A, 1))
+# But LinearSlow must take into account the dimensionality of the array:
+_getindex{T}(::LinearSlow, A::AbstractArray{T,0}) = error("indexing not defined for ", typeof(A))
+_getindex(::LinearSlow, A::AbstractVector) = (@_inline_meta; getindex(A, 1))
+_getindex(l::LinearSlow, A::AbstractArray) = (@_inline_meta; _getindex(l, A, 1))
 _unsafe_getindex(::LinearFast, A::AbstractArray) = (@_inline_meta; unsafe_getindex(A, 1))
-_unsafe_getindex(::LinearSlow, A::AbstractArray) = (@_inline_meta; _unsafe_getindex(A, 1))
+_unsafe_getindex{T}(::LinearSlow, A::AbstractArray{T,0}) = error("indexing not defined for ", typeof(A))
+_unsafe_getindex(::LinearSlow, A::AbstractVector) = (@_inline_meta; unsafe_getindex(A, 1))
+_unsafe_getindex(l::LinearSlow, A::AbstractArray) = (@_inline_meta; _unsafe_getindex(l, A, 1))
+
 _getindex(::LinearIndexing, A::AbstractArray, I...) = error("indexing $(typeof(A)) with types $(typeof(I)) is not supported")
 _unsafe_getindex(::LinearIndexing, A::AbstractArray, I...) = error("indexing $(typeof(A)) with types $(typeof(I)) is not supported")
 
@@ -521,9 +528,13 @@ function unsafe_setindex!(A::AbstractArray, v, I...)
 end
 ## Internal defitions
 _setindex!(::LinearFast, A::AbstractArray, v) = (@_inline_meta; setindex!(A, v, 1))
-_setindex!(::LinearSlow, A::AbstractArray, v) = (@_inline_meta; _setindex!(A, v, 1))
+_setindex!{T}(::LinearSlow, A::AbstractArray{T,0}, v) = error("indexing not defined for ", typeof(A))
+_setindex!(::LinearSlow, A::AbstractVector, v) = (@_inline_meta; setindex!(A, v, 1))
+_setindex!(l::LinearSlow, A::AbstractArray, v) = (@_inline_meta; _setindex!(l, A, v, 1))
 _unsafe_setindex!(::LinearFast, A::AbstractArray, v) = (@_inline_meta; unsafe_setindex!(A, v, 1))
-_unsafe_setindex!(::LinearSlow, A::AbstractArray, v) = (@_inline_meta; _unsafe_setindex!(A, v, 1))
+_unsafe_setindex!{T}(::LinearSlow, A::AbstractArray{T,0}, v) = error("indexing not defined for ", typeof(A))
+_unsafe_setindex!(::LinearSlow, A::AbstractVector, v) = (@_inline_meta; unsafe_setindex!(A, v, 1))
+_unsafe_setindex!(l::LinearSlow, A::AbstractArray, v) = (@_inline_meta; _unsafe_setindex!(l, A, v, 1))
 _setindex!(::LinearIndexing, A::AbstractArray, v, I...) = error("indexing $(typeof(A)) with types $(typeof(I)) is not supported")
 _unsafe_setindex!(::LinearIndexing, A::AbstractArray, v, I...) = error("indexing $(typeof(A)) with types $(typeof(I)) is not supported")
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -113,6 +113,8 @@ function test_scalar_indexing{T}(::Type{T}, shape)
             end
         end
     end
+    # Test zero-dimensional accesses
+    @test A[] == B[] == A[1] == B[1] == 1
     # Test multidimensional scalar indexed assignment
     C = T(Int, shape)
     i=0
@@ -159,6 +161,10 @@ function test_scalar_indexing{T}(::Type{T}, shape)
         end
     end
     @test C == B == A
+    # Test zero-dimensional setindex
+    A[] = 0; B[] = 0
+    @test A[] == B[] == 0
+    @test A == B
 end
 
 function test_vector_indexing{T}(::Type{T}, shape)


### PR DESCRIPTION
The goal of the internal _getindex/_unsafe_getindex/_setindex!/_unsafe_setindex! is to compute the indexes required in order to call the "canonical" indexing method. We must manually define zero-dimensional methods to preven ambiguities, but the definitions there are tricky for LinearSlow:
- If the array is zero-dimensional, it should be an error (as this meant that the user didn't define their required method)
- If the array is one-dimensional, it should call the real (non-underscored) method as this is the canonical indexing method
- If the array is multi-dimensional, it should stay within the underscored functions until it has resolved the indices to the proper dimensionality.  The simplest way to do this is just to punt: `_getindex(LinearSlow(), A, 1)`.

(This is good to merge once CI passes — I'm just a little gunshy from pushing to master)
