### PR TITLE
Fix dump(io) and xdump(io), add tests

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -891,6 +891,7 @@ xdump(fn::Function, io::IO, args...) = throw(ArgumentError("invalid arguments to
 xdump(fn::Function, args...) = xdump(fn, STDOUT::IO, args...)
 xdump(io::IO, args...) = xdump(xdump, io, args...)
 xdump(args...) = with_output_limit(()->xdump(xdump, STDOUT::IO, args...), true)
+xdump(arg::IO) = xdump(xdump, STDOUT::IO, arg)
 
 # Here are methods specifically for dump:
 dump(io::IO, x, n::Int) = dump(io, x, n, "")
@@ -900,6 +901,7 @@ dump(io::IO, x::AbstractString, n::Int, indent) =
                 show(io, x); println(io))
 dump(io::IO, x, n::Int, indent) = xdump(dump, io, x, n, indent)
 dump(io::IO, args...) = throw(ArgumentError("invalid arguments to dump"))
+dump(arg::IO) = xdump(dump, STDOUT::IO, arg)
 dump(args...) = with_output_limit(()->dump(STDOUT::IO, args...), true)
 
 function dump(io::IO, x::Dict, n::Int, indent)

--- a/test/show.jl
+++ b/test/show.jl
@@ -269,3 +269,12 @@ end
 @test_repr "bitstype 100 B"
 @test repr(:(bitstype A B)) == ":(bitstype A B)"
 @test repr(:(bitstype 100 B)) == ":(bitstype 100 B)"
+
+oldout = STDOUT
+try
+    rd, wr = redirect_stdout()
+    @test dump(STDERR) == nothing
+    @test xdump(STDERR) == nothing
+finally
+    redirect_stdout(oldout)
+end


### PR DESCRIPTION
This fixes a bug I ran across when trying to debug some issues with output.
dump and xdump were both defined with (x)dump(args...) and (x)dump(io::IO, args...),
so that (x)dump of a single argument of type <: IO would get an error.
Fixed by adding two methods: (x)dump(arg::IO) = xdump((x)dump,STDOUT::IO,arg)
