### PR TITLE
Expose ninitialized to Julia

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3098,7 +3098,7 @@ extern void jl_init_int32_int64_cache(void);
 void jl_init_types(void)
 {
     // create base objects
-    jl_datatype_type = jl_new_uninitialized_datatype(9);
+    jl_datatype_type = jl_new_uninitialized_datatype(10);
     jl_set_typeof(jl_datatype_type, jl_datatype_type);
     jl_typename_type = jl_new_uninitialized_datatype(7);
     jl_sym_type = jl_new_uninitialized_datatype(0);
@@ -3117,7 +3117,7 @@ void jl_init_types(void)
     jl_datatype_type->name->primary = (jl_value_t*)jl_datatype_type;
     jl_datatype_type->super = jl_type_type;
     jl_datatype_type->parameters = jl_emptysvec;
-    jl_datatype_type->name->names = jl_svec(9, jl_symbol("name"),
+    jl_datatype_type->name->names = jl_svec(10, jl_symbol("name"),
                                             jl_symbol("super"),
                                             jl_symbol("parameters"),
                                             jl_symbol("types"),
@@ -3125,12 +3125,13 @@ void jl_init_types(void)
                                             jl_symbol("size"),
                                             jl_symbol("abstract"),
                                             jl_symbol("mutable"),
-                                            jl_symbol("pointerfree"));
-    jl_datatype_type->types = jl_svec(9, jl_typename_type, jl_type_type,
+                                            jl_symbol("pointerfree"),
+                                            jl_symbol("ninitialized"));
+    jl_datatype_type->types = jl_svec(10, jl_typename_type, jl_type_type,
                                       jl_simplevector_type, jl_simplevector_type,
                                       jl_any_type,
                                       jl_any_type, // size
-                                      jl_any_type, jl_any_type, jl_any_type);
+                                      jl_any_type, jl_any_type, jl_any_type, jl_any_type);
     jl_datatype_type->instance = NULL;
     jl_datatype_type->uid = jl_assign_type_uid();
     jl_datatype_type->struct_decl = NULL;
@@ -3444,6 +3445,7 @@ void jl_init_types(void)
     jl_svecset(jl_datatype_type->types, 6, (jl_value_t*)jl_bool_type);
     jl_svecset(jl_datatype_type->types, 7, (jl_value_t*)jl_bool_type);
     jl_svecset(jl_datatype_type->types, 8, (jl_value_t*)jl_bool_type);
+    jl_svecset(jl_datatype_type->types, 9, jl_int32_type);
     jl_svecset(jl_function_type->types, 0, pointer_void);
     jl_svecset(jl_tvar_type->types, 3, (jl_value_t*)jl_bool_type);
     jl_svecset(jl_simplevector_type->types, 0, jl_long_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -279,9 +279,9 @@ typedef struct _jl_datatype_t {
     uint8_t abstract;
     uint8_t mutabl;
     uint8_t pointerfree;
+    int32_t ninitialized;
     // hidden fields:
     uint32_t nfields;
-    int32_t ninitialized;
     uint32_t alignment : 31;  // strictest alignment over all fields
     uint32_t haspadding : 1;  // has internal undefined bytes
     uint32_t uid;


### PR DESCRIPTION
I'd like this for JLD2 since it tells me whether I can store non-pointerfree immutable fields inline or if I should store them by reference (or maybe store an extra defined bit). I tried to expose it originally in #8827 but it broke bootstrap for some unknown reason. It doesn't seem like that's a problem anymore.
