### PR TITLE
Remove forced gc() from RemoteRef constructor

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -417,12 +417,6 @@ type RemoteRef
     function RemoteRef(pid::Integer)
         rr = RemoteRef(pid, myid(), REQ_ID)
         REQ_ID += 1
-        if mod(REQ_ID,200) == 0
-            # force gc after making a lot of refs since they take up
-            # space on the machine where they're stored, yet the client
-            # is responsible for freeing them.
-            gc()
-        end
         rr
     end
 


### PR DESCRIPTION
Reasons:
- it was anyway buggy since the check did not consider `REQ_ID` being incremented in `next_id` which is used for temporary local oids in `remotecall_wait` and `remotecall_fetch`
- the background task will cleanup when the refs are finalized. User code can explicitly call gc() if required.
- makes @carnaval happy
