### PR TITLE
WIP: Address #12074 - Date array operations

### DIFF
--- a/base/dates/arithmetic.jl
+++ b/base/dates/arithmetic.jl
@@ -68,5 +68,10 @@ end
 
 (.+){T<:TimeType}(x::AbstractArray{T}, y::Period) = reshape(T[i + y for i in x], size(x))
 (.-){T<:TimeType}(x::AbstractArray{T}, y::Period) = reshape(T[i - y for i in x], size(x))
-(.+){T<:TimeType}(y::Period, x::AbstractArray{T}) = x .+ y
-(.-){T<:TimeType}(y::Period, x::AbstractArray{T}) = x .- y
+(.+)(y::Period, x::AbstractArray{TimeType}) = x .+ y
+(.-)(y::Period, x::AbstractArray{TimeType}) = x .- y
+
+(.-){T<:TimeType}(x::AbstractArray{T}, y::T) = reshape(Period[i - y for i in x], size(x))
+(.-){T<:TimeType}(y::T, x::AbstractArray{T}) = -(x .- y)
+
+(-){T<:TimeType}(x::AbstractArray{T}, y::AbstractArray{T}) = reshape(Period[x[i] - y[i] for i in eachindex(x, y)], promote_shape(size(x),size(y)))

--- a/base/dates/arithmetic.jl
+++ b/base/dates/arithmetic.jl
@@ -68,10 +68,13 @@ end
 
 (.+){T<:TimeType}(x::AbstractArray{T}, y::Period) = reshape(T[i + y for i in x], size(x))
 (.-){T<:TimeType}(x::AbstractArray{T}, y::Period) = reshape(T[i - y for i in x], size(x))
-(.+)(y::Period, x::AbstractArray{TimeType}) = x .+ y
-(.-)(y::Period, x::AbstractArray{TimeType}) = x .- y
+(.+){T<:TimeType}(y::Period, x::AbstractArray{T}) = x .+ y
+(.-){T<:TimeType}(y::Period, x::AbstractArray{T}) = x .- y
 
 (.-){T<:TimeType}(x::AbstractArray{T}, y::T) = reshape(Period[i - y for i in x], size(x))
 (.-){T<:TimeType}(y::T, x::AbstractArray{T}) = -(x .- y)
 
+(-){T<:TimeType}(x::Range{T}, y::Range{T}) = collect(x) - collect(y)
+(-){T<:TimeType}(x::AbstractArray{T}, y::Range{T}) = y - collect(x)
+(-){T<:TimeType}(x::Range{T}, y::AbstractArray{T}) = collect(x) - y
 (-){T<:TimeType}(x::AbstractArray{T}, y::AbstractArray{T}) = reshape(Period[x[i] - y[i] for i in eachindex(x, y)], promote_shape(size(x),size(y)))

--- a/test/dates/arithmetic.jl
+++ b/test/dates/arithmetic.jl
@@ -330,3 +330,18 @@ dt2 = dt + Dates.Year(1)
 @test Dates.minute(dt2) == 30
 @test Dates.second(dt2) == 45
 @test Dates.millisecond(dt2) == 500
+
+t1 = [Date(2009,1,1) Date(2009,1,2) Date(2009,1,3); Date(2009,2,1) Date(2009,2,2) Date(2009,2,3)]
+t2 = [Date(2009,1,2) Date(2009,2,2) Date(2010,1,3); Date(2010,2,1) Date(2009,3,2) Date(2009,2,4)]
+t3 = [DateTime(2009,1,1), DateTime(2009,1,2), DateTime(2009,1,3)]
+t4 = [DateTime(2009,1,1,0,0,1), DateTime(2009,1,2,0,1), DateTime(2009,1,3,1)]
+
+# TimeType, Array{TimeType}
+@test Date(2010,1,1) .- t1 == [Day(365) Day(364) Day(363); Day(334) Day(333) Day(332)]
+@test t1 .- Date(2010,1,1) == [Day(-365) Day(-364) Day(-363); Day(-334) Day(-333) Day(-332)]
+@test DateTime(2009,1,1) .- t3 == [Millisecond(0), Millisecond(-86400000), Millisecond(-172800000)]
+@test t3 .- DateTime(2009,1,1) == [Millisecond(0), Millisecond(86400000), Millisecond(172800000)]
+
+# Array{TimeType}, Array{TimeType}
+@test t2 - t1 == [Day(1) Day(31) Day(365); Day(365) Day(28) Day(1)]
+@test t4 - t3 == [Millisecond(1000), Millisecond(60000), Millisecond(3600000)]

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -288,3 +288,58 @@ emptyperiod = ((y + d) - d) - y
 @test 8d - s == 1w + 23h + 59mi + 59s
 @test h + 3mi == 63mi
 @test y - m == 11m
+
+pa = [1y 1m 1w 1d; 1h 1mi 1s 1ms]
+cpa = [1y+1s 1m+1s 1w+1s 1d+1s; 1h+1s 1mi+1s 2m+1s 1s+1ms]
+
+@test 1y .+ pa == [2y 1y+1m 1y+1w 1y+1d; 1y+1h 1y+1mi 1y+1s 1y+1ms]
+@test (1y+1m) .+ pa == [2y+1m 1y+2m 1y+1m+1w 1y+1m+1d; 1y+1m+1h 1y+1m+1mi 1y+1m+1s 1y+1m+1ms]
+@test pa .+ 1y == [2y 1y+1m 1y+1w 1y+1d; 1y+1h 1y+1mi 1y+1s 1y+1ms]
+@test pa .+ (1y+1m) == [2y+1m 1y+2m 1y+1m+1w 1y+1m+1d; 1y+1m+1h 1y+1m+1mi 1y+1m+1s 1y+1m+1ms]
+
+@test 1y .+ cpa == [2y+1s 1y+1m+1s 1y+1w+1s 1y+1d+1s; 1y+1h+1s 1y+1mi+1s 1y+2m+1s 1y+1ms+1s]
+@test (1y+1m) .+ cpa == [2y+1m+1s 1y+2m+1s 1y+1m+1w+1s 1y+1m+1d+1s; 1y+1m+1h+1s 1y+1m+1mi+1s 1y+3m+1s 1y+1m+1s+1ms]
+@test cpa .+ 1y == [2y+1s 1y+1m+1s 1y+1w+1s 1y+1d+1s; 1y+1h+1s 1y+1mi+1s 1y+2m+1s 1y+1ms+1s]
+@test cpa .+ (1y+1m) == [2y+1m+1s 1y+2m+1s 1y+1m+1w+1s 1y+1m+1d+1s; 1y+1m+1h+1s 1y+1m+1mi+1s 1y+3m+1s 1y+1m+1s+1ms]
+
+@test 1y + pa == [2y 1y+1m 1y+1w 1y+1d; 1y+1h 1y+1mi 1y+1s 1y+1ms]
+@test (1y+1m) + pa == [2y+1m 1y+2m 1y+1m+1w 1y+1m+1d; 1y+1m+1h 1y+1m+1mi 1y+1m+1s 1y+1m+1ms]
+@test pa + 1y == [2y 1y+1m 1y+1w 1y+1d; 1y+1h 1y+1mi 1y+1s 1y+1ms]
+@test pa + (1y+1m) == [2y+1m 1y+2m 1y+1m+1w 1y+1m+1d; 1y+1m+1h 1y+1m+1mi 1y+1m+1s 1y+1m+1ms]
+
+@test 1y + cpa == [2y+1s 1y+1m+1s 1y+1w+1s 1y+1d+1s; 1y+1h+1s 1y+1mi+1s 1y+2m+1s 1y+1ms+1s]
+@test (1y+1m) + cpa == [2y+1m+1s 1y+2m+1s 1y+1m+1w+1s 1y+1m+1d+1s; 1y+1m+1h+1s 1y+1m+1mi+1s 1y+3m+1s 1y+1m+1s+1ms]
+@test cpa + 1y == [2y+1s 1y+1m+1s 1y+1w+1s 1y+1d+1s; 1y+1h+1s 1y+1mi+1s 1y+2m+1s 1y+1ms+1s]
+@test cpa + (1y+1m) == [2y+1m+1s 1y+2m+1s 1y+1m+1w+1s 1y+1m+1d+1s; 1y+1m+1h+1s 1y+1m+1mi+1s 1y+3m+1s 1y+1m+1s+1ms]
+
+@test 1y .- pa == [0y 1y-1m 1y-1w 1y-1d; 1y-1h 1y-1mi 1y-1s 1y-1ms]
+@test (1y+1m) .- pa == [1m 1y 1y+1m-1w 1y+1m-1d; 1y+1m-1h 1y+1m-1mi 1y+1m-1s 1y+1m-1ms]
+@test pa .- (1y+1m) == [-1m -1y -1y-1m+1w -1y-1m+1d; -1y-1m+1h -1y-1m+1mi -1y-1m+1s -1y-1m+1ms]
+@test pa .- 1y == [0y 1m-1y -1y+1w -1y+1d; -1y+1h -1y+1mi -1y+1s -1y+1ms]
+
+@test 1y .- cpa == [-1s 1y-1m-1s 1y-1w-1s 1y-1d-1s; 1y-1h-1s 1y-1mi-1s 1y-2m-1s 1y-1ms-1s]
+@test (1y+1m) .- cpa == [1m-1s 1y-1s 1y+1m-1w-1s 1y+1m-1d-1s; 1y+1m-1h-1s 1y+1m-1mi-1s 1y-1m-1s 1y+1m-1s-1ms]
+@test cpa .- 1y == [1s -1y+1m+1s -1y+1w+1s -1y+1d+1s; -1y+1h+1s -1y+1mi+1s -1y+2m+1s -1y+1ms+1s]
+@test cpa .- (1y+1m) == [-1m+1s -1y+1s -1y-1m+1w+1s -1y-1m+1d+1s; -1y-1m+1h+1s -1y-1m+1mi+1s -1y+1m+1s -1y+-1m+1s+1ms]
+
+@test 1y - pa == [0y 1y-1m 1y-1w 1y-1d; 1y-1h 1y-1mi 1y-1s 1y-1ms]
+@test (1y+1m) - pa == [1m 1y 1y+1m-1w 1y+1m-1d; 1y+1m-1h 1y+1m-1mi 1y+1m-1s 1y+1m-1ms]
+@test pa - (1y+1m) == [-1m -1y -1y-1m+1w -1y-1m+1d; -1y-1m+1h -1y-1m+1mi -1y-1m+1s -1y-1m+1ms]
+@test pa - 1y == [0y 1m-1y -1y+1w -1y+1d; -1y+1h -1y+1mi -1y+1s -1y+1ms]
+
+@test 1y - cpa == [-1s 1y-1m-1s 1y-1w-1s 1y-1d-1s; 1y-1h-1s 1y-1mi-1s 1y-2m-1s 1y-1ms-1s]
+@test (1y+1m) - cpa == [1m-1s 1y-1s 1y+1m-1w-1s 1y+1m-1d-1s; 1y+1m-1h-1s 1y+1m-1mi-1s 1y-1m-1s 1y+1m-1s-1ms]
+@test cpa - 1y == [1s -1y+1m+1s -1y+1w+1s -1y+1d+1s; -1y+1h+1s -1y+1mi+1s -1y+2m+1s -1y+1ms+1s]
+@test cpa - (1y+1m) == [-1m+1s -1y+1s -1y-1m+1w+1s -1y-1m+1d+1s; -1y-1m+1h+1s -1y-1m+1mi+1s -1y+1m+1s -1y+-1m+1s+1ms]
+
+@test [1y 1m; 1w 1d] + [1h 1mi; 1s 1ms] == [1y+1h 1m+1mi; 1w+1s 1d+1ms]
+@test [1y 1m; 1w 1d] - [1h 1mi; 1s 1ms] == [1y-1h 1m-1mi; 1w-1s 1d-1ms]
+
+@test [1y+1s 1m+1s; 1w+1s 1d+1s] + [1h 1mi; 1s 1ms] == [1y+1h+1s 1m+1mi+1s; 1w+2s 1d+1s+1ms]
+@test [1y+1s 1m+1s; 1w+1s 1d+1s] - [1h 1mi; 1s 1ms] == [1y-1h+1s 1m-1mi+1s; 1w 1d+1s-1ms]
+
+@test [1y 1m; 1w 1d] + [1h+1s 1mi+1s; 1m+1s 1s+1ms] == [1y+1h+1s 1m+1mi+1s; 1w+1m+1s 1d+1s+1ms]
+@test [1y 1m; 1w 1d] - [1h+1s 1mi+1s; 1m+1s 1s+1ms] == [1y-1h-1s 1m-1mi-1s; 1w-1m-1s 1d-1s-1ms]
+
+@test [1y+1s 1m+1s; 1w+1s 1d+1s] + [1y+1h 1y+1mi; 1y+1s 1y+1ms] == [2y+1h+1s 1y+1m+1mi+1s; 1y+1w+2s 1y+1d+1s+1ms]
+@test [1y+1s 1m+1s; 1w+1s 1d+1s] - [1y+1h 1y+1mi; 1y+1s 1y+1ms] == [1s-1h 1m+1s-1y-1mi; 1w-1y 1d+1s-1y-1ms]


### PR DESCRIPTION
A first step at improving functionality consistency among array operations involving `TimeType` and `Period`/`CompoundPeriod` (as per https://github.com/JuliaLang/julia/issues/12074). For now I've just implemented subtraction between `TimeType` arrays and scalars.

~~Unfortunately, defining~~

``` julia
(-){T<:TimeType}(x::AbstractArray{T}, y::AbstractArray{T})
```

~~raises ambiguous definition errors with both https://github.com/JuliaLang/julia/blob/master/base/arraymath.jl#L71 and https://github.com/JuliaLang/julia/blob/master/base/arraymath.jl#L80. Any suggestions to avoid that?~~
Edit: Fixed below
