### PR TITLE
Revert "use constant meta symbol"

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -10,7 +10,7 @@ export doc
 
 const modules = Module[]
 
-const META′ = :__META__
+const META′ = gensym("META")
 
 @eval meta(mod) = mod.$META′
 


### PR DESCRIPTION
This reverts commit 4fc9bb63deed183d3124581445f1f3522a04dc47.

ref https://github.com/JuliaLang/julia/commit/4fc9bb63deed183d3124581445f1f3522a04dc47#commitcomment-12099162

let's see if this fixes the appveyor bootstrap freeze - having trouble reproducing that locally, not sure why
