### PR TITLE
WIP: add macroexpand shortcut REPL

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -780,6 +780,15 @@ function setup_interface(repl::LineEditREPL; hascolor = repl.hascolor, extra_rep
                 edit_insert(s, '?')
             end
         end,
+        '§' => function (s,o...)
+            if !isempty(s)
+                try
+                    line = parse(LineEdit.input_string(s))
+                    LineEdit.edit_clear(s)
+                    LineEdit.edit_insert(s,string(macroexpand(line)))
+                end
+            end
+        end,
 
         # Bracketed Paste Mode
         "\e[200~" => (s,o...)->begin


### PR DESCRIPTION
I think it would be nice to have a shortcut Key that runs macroexpand on the code currently inserted into the REPL. This came up in this thread on the user-mailing list https://groups.google.com/forum/#!topic/julia-users/TE64KJVcLFY. The code proposed here does exactly this, enter some code that calls a macro and hit "§" afterwards and the expanded code will show up. 

Some questions:
- Which keyboard shortcut should this actually use, "§" is just a placeholder so far
- would this rather belong into `extra_repl_keymap` as a user extension? I just didn't find how to hook into these. 
- It would be nice if the generated lines would always be excutable which is currently not the case when local macro variables are generated, any ideas how to fix this?
