### PR TITLE
possibly fix a libuv assertion failure on shutdown

### DIFF
--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -153,7 +153,8 @@ DLLEXPORT void jl_close_uv(uv_handle_t *handle)
          * b) In case the stream is already closed, in which case uv_close would
          *    cause an assertion failure.
          */
-        uv_shutdown(req, (uv_stream_t*)handle, &jl_uv_shutdownCallback);
+        if (((uv_stream_t*)handle)->io_watcher.fd >= 0)
+            uv_shutdown(req, (uv_stream_t*)handle, &jl_uv_shutdownCallback);
     }
     else if (handle->type == UV_FILE) {
         uv_fs_t req;


### PR DESCRIPTION
On Keno's branch kf/stderrpipe (#11919) I reliably see this assertion failure:

```
jeff@gurren:~/src/julia/test$ ../julia runtests.jl file examples
    From worker 2:       * file                 in   9.90 seconds
julia: src/unix/stream.c:1166: int uv_shutdown(uv_shutdown_t *, uv_stream_t *, uv_shutdown_cb): Assertion `((stream)->io_watcher.fd) >= 0' failed.

signal (6): Aborted
gsignal at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
abort at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
unknown function (ip: 0x7f5a200f9b86)
unknown function (ip: 0x7f5a200f9c32)
julia: src/unix/stream.c:1166: int uv_shutdown(uv_shutdown_t *, uv_stream_t *, uv_shutdown_cb): Assertion `((stream)->io_watcher.fd) >= 0' failed.

signal (6): Aborted
unknown function (ip: 0x7f5a20862deb)
jl_close_uv at /home/jeff/src/julia/usr/bin/../lib/libjulia.so (unknown line)
jl_atexit_hook at /home/jeff/src/julia/usr/bin/../lib/libjulia.so (unknown line)
jl_exit at /home/jeff/src/julia/usr/bin/../lib/libjulia.so (unknown line)
exit at client.jl:39
gsignal at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
abort at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
unknown function (ip: 0x7f86420d0b86)
unknown function (ip: 0x7f86420d0c32)
unknown function (ip: 0x7f8642839deb)
jl_close_uv at /home/jeff/src/julia/usr/bin/../lib/libjulia.so (unknown line)
jl_atexit_hook at /home/jeff/src/julia/usr/bin/../lib/libjulia.so (unknown line)
jl_exit at /home/jeff/src/julia/usr/bin/../lib/libjulia.so (unknown line)
exit at client.jl:39
    From worker 3:       * examples             in  19.12 seconds
    SUCCESS
```

This change makes it go away. cc @vtjnash 
