### PR TITLE
Some static compilation tweaks

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -332,7 +332,7 @@ function init_load_path()
     end
     push!(LOAD_PATH,abspath(JULIA_HOME,"..","local","share","julia","site",vers))
     push!(LOAD_PATH,abspath(JULIA_HOME,"..","share","julia","site",vers))
-    push!(LOAD_CACHE_PATH,abspath(homedir(),".julia",".libs"))
+    push!(LOAD_CACHE_PATH,abspath(homedir(),".julia","libs",vers))
     push!(LOAD_CACHE_PATH,abspath(JULIA_HOME,"..","usr","lib","julia")) #TODO: fixme
 end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -634,3 +634,32 @@ end
 
 @deprecate mmap_bitarray{N}(::Type{Bool}, dims::NTuple{N,Integer}, s::IOStream, offset::FileOffset=position(s)) mmap(s, BitArray, dims, offset)
 @deprecate mmap_bitarray{N}(dims::NTuple{N,Integer}, s::IOStream, offset=position(s)) mmap(s, BitArray, dims, offset)
+
+function require(mod::AbstractString)
+    depwarn("`require` is deprecated, use `using` or `import` instead", :require)
+    require(symbol(require_filename(mod)))
+end
+function require(f::AbstractString, fs::AbstractString...)
+    require(f)
+    for fn in fs
+        require(fn)
+    end
+end
+export require
+function require_filename(name::AbstractString)
+    # This function can be deleted when the deprecation for `require`
+    # is deleted.
+    # While we could also strip off the absolute path, the user may be
+    # deliberately directing to a different file than what got
+    # cached. So this takes a conservative approach.
+    if endswith(name, ".jl")
+        tmp = name[1:end-3]
+        for prefix in LOAD_CACHE_PATH
+            path = joinpath(prefix, tmp*".ji")
+            if isfile(path)
+                return tmp
+            end
+        end
+    end
+    name
+end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -245,7 +245,7 @@ evalfile(path::AbstractString, args::Vector) = evalfile(path, UTF8String[args...
 function create_expr_cache(m::Expr, name)
     cachepath = LOAD_CACHE_PATH[1]
     if !isdir(cachepath)
-        mkdir(cachepath)
+        mkpath(cachepath)
     end
     cachefile = abspath(cachepath, name*".ji")
     code_object = """

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -229,6 +229,7 @@ function base_include(content::Nullable{ByteString}, path::AbstractString, relat
         end
     end
 end
+base_include(content::AbstractString, path::AbstractString, relative_to=nothing) = base_include(Nullable{ByteString}(content), path, relative_to)
 base_include(path::AbstractString, relative_to=nothing) = base_include(Nullable{ByteString}(), path, relative_to)
 include_string(txt::AbstractString, fname::AbstractString="none") = base_include(Nullable{ByteString}(bytestring(txt)), bytestring(fname))
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -61,9 +61,8 @@ function _require_from_serialized(node::Int, path_to_try::ByteString)
         if _include_from_serialized(content)
             others = filter(x -> x != myid(), procs())
             refs = Any[ @spawnat p _include_from_serialized(content) for p in others]
-            successes = Any[ fetch(ref) for ref in refs ]
             for (id, ref) in zip(others, refs)
-                if fetch(ref)
+                if !fetch(ref)
                     warn("node state is inconsistent: node $id failed to load serialized cache from :node $node:$path_to_try.")
                 end
             end


### PR DESCRIPTION
Note this is against #8745. @vtjnash, I made small commits so you can cherry-pick as you wish. I haven't yet changed the `.libs` path, but intend to do so.

The Images tests are working for me. I've been trying this against my own internal code tree, and it works astonishingly well---I've only had to made one restructuring, splitting a file that contained two toplevel modules into two files.

Not all is perfect, of course. Currently, the roadblock is a segfault that can be reproduced with the following sequence:

```
Pkg.add("Interpolations")
Pkg.checkout("Interpolations", "teh/moretypes")  # not sure this is necessary, but it's what I'm using
Base.require(:Interpolations, true)
```

restart julia

```
using Interpolations
A = rand(10);
itp = interpolate(A, BSpline(Constant), OnCell);
itp[1]  # Segfault
```

I will dig into this myself, but I have to take a break for a bit.
