### PR TITLE
Prototype package bundling

### DIFF
--- a/base/defaultpkg.jl
+++ b/base/defaultpkg.jl
@@ -1,0 +1,28 @@
+let
+    pkgs = ["JSON"]
+
+    JULIA_HOME = ccall(:jl_get_julia_home, Any, ())
+
+    dir = joinpath(JULIA_HOME, "..", "..", "usr", "share", "julia", "site")
+
+    !isdir(dir) && mkdir(dir)
+
+    dir′ = get(ENV, "JULIA_PKGDIR", false)
+    ENV["JULIA_PKGDIR"] = dir
+
+    !isdir(joinpath(dir, "v0.4", "METADATA")) && Pkg.init()
+
+    Pkg.update()
+
+    for pkg in pkgs
+        if Pkg.installed(pkg) == nothing
+            println("Adding $pkg.jl")
+            Pkg.add(pkg)
+        end
+        @eval using $(symbol(pkg))
+    end
+
+    dir′ == false ? delete!(ENV, "JULIA_PKGDIR") : (ENV["JULIA_PKGDIR"] = dir′)
+
+    "JSON" in pkgs && @eval export json
+end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -318,6 +318,10 @@ include("precompile.jl")
 
 include = include_from_node1
 
+reinit_stdio()
+
+include("defaultpkg.jl")
+
 end # baremodule Base
 
 using Base


### PR DESCRIPTION
Sorry if you got a blank email, I pressed enter by accident.

``` julia
Mikes-MBP:julia mike$ julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "help()" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.4.0-dev+5925 (2015-07-11 18:47 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 17bebe5* (0 days old master)
|__/                   |  x86_64-apple-darwin14.4.0

julia> json
json (generic function with 2 methods)

julia> 
```

In short, the idea here is to be able to specify packages to include in the Base build. This means we can make e.g. JSON functionality available by default without having it in Base proper, as I have here.

This also means that we can strip packages out of Base without degrading the user experience. e.g. we can put Markdown.jl and the Doc system into their own respective repos, but still have (legible) docstrings available at the REPL by default.

This is very much a work in progress, but hopefully the people who know more about this stuff than I do can help shape it into something usable.
