### PR TITLE
RFC: change array promotion rule so at most one array (of 2) is converted

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -260,7 +260,12 @@ convert{T,n}(::Type{Array{T,n}}, x::Array{T,n}) = x
 convert{T,n,S}(::Type{Array{T}}, x::Array{S,n}) = convert(Array{T,n}, x)
 convert{T,n,S}(::Type{Array{T,n}}, x::Array{S,n}) = copy!(similar(x,T), x)
 
-promote_rule{T,n,S}(::Type{Array{T,n}}, ::Type{Array{S,n}}) = Array{promote_type(T,S),n}
+# don't change both arrays
+promote_rule{T,n,S}(a::Type{Array{T,n}}, b::Type{Array{S,n}}) = el_same(promote_type(T,S), a, b)
+el_same{T,n}(::Type{T}, ::Type{Array{T,n}}, ::Type{Array{T,n}}) = Array{T,n}
+el_same{T,S,n}(::Type{T}, ::Type{Array{T,n}}, ::Type{Array{S,n}}) = Array{T,n}
+el_same{T,S,n}(::Type{T}, ::Type{Array{S,n}}, ::Type{Array{T,n}}) = Array{T,n}
+el_same(::Type, a, b) = typejoin(a, b)
 
 function collect{T}(::Type{T}, itr)
     if applicable(length, itr)


### PR DESCRIPTION
Currently we have this:

```
julia> a = Vector{Int}[[1]];  # vector of Int vectors

julia> b = Vector{Float64}[[2.0]];  # vector of Float64 vectors

julia> [a;b]
2-element Array{Array{Float64,1},1}:
 [1.0]
 [2.0]
```

So the array elements were promoted to the common type `Vector{Float64}`. So far so good. However with less-related types, this happens:

```
julia> c = Vector{Char}[['a']];  # vector of Char vectors

julia> [a;c]
2-element Array{Array{Any,1},1}:
 Any[1]  
 Any['a']
```

In this case the common type is `Vector{Any}`, which works but is probably not what you want, since it  converts every array inside to an inefficient representation.

In my proposed change, promoting array types only promotes the element type if one argument array would remain unchanged. Given an int array and a float array you can get two float arrays, but given two very different arrays we just move to an abstract array type:

```
julia> [a;c]
2-element Array{Array{T,1},1}:
 [1]  
 ['a']
```

I discovered this while testing the new behavior of `[a, b]`. In that case the promotion behavior was more obviously strange, since you're expecting to get an array of just `a` and `b`, so any change to the types of `a` and `b` is more surprising.
