### PR TITLE
improve the performance of reverse!

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -658,8 +658,13 @@ reverseind(a::AbstractVector, i::Integer) = length(a) + 1 - i
 reverse(v::StridedVector) = (n=length(v); [ v[n-i+1] for i=1:n ])
 reverse(v::StridedVector, s, n=length(v)) = reverse!(copy(v), s, n)
 function reverse!(v::StridedVector, s=1, n=length(v))
+    if !(1 ≤ s ≤ endof(v))
+        throw(BoundsError(v, s))
+    elseif !(1 ≤ n ≤ endof(v))
+        throw(BoundsError(v, n))
+    end
     r = n
-    for i=s:div(s+n-1,2)
+    @inbounds for i in s:div(s+n-1, 2)
         v[i], v[r] = v[r], v[i]
         r -= 1
     end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -824,9 +824,12 @@ end
 @test reverse(1:10,1,4) == [4,3,2,1,5,6,7,8,9,10]
 @test reverse(1:10,3,6) == [1,2,6,5,4,3,7,8,9,10]
 @test reverse(1:10,6,10) == [1,2,3,4,5,10,9,8,7,6]
+@test reverse!([1:10;]) == [10,9,8,7,6,5,4,3,2,1]
 @test reverse!([1:10;],1,4) == [4,3,2,1,5,6,7,8,9,10]
 @test reverse!([1:10;],3,6) == [1,2,6,5,4,3,7,8,9,10]
 @test reverse!([1:10;],6,10) == [1,2,3,4,5,10,9,8,7,6]
+@test_throws BoundsError reverse!([1:10;], 11)
+@test_throws BoundsError reverse!([1:10;], 1, 11)
 
 # flipdim
 @test isequal(flipdim([2,3,1], 1), [1,3,2])


### PR DESCRIPTION
Minor performance improvement (~1.3-2.8 times) of the `reverse!` method for vector types.

Benchmark script:

``` julia
let
    k = 100

    n = 2^8
    x = collect(1:n)
    reverse!(x)
    @time for i in 1:k; reverse!(x); end

    n = 2^16
    x = collect(1:n)
    @time for i in 1:k; reverse!(x); end

    n = 2^24
    x = collect(1:n)
    @time for i in 1:k; reverse!(x); end
end
```

Before:

```
  27.221 microseconds
   8.411 milliseconds
   1.906 seconds     
```

After:

```
   9.591 microseconds
   3.093 milliseconds
   1.492 seconds     
```
