### PR TITLE
Add missing markdown render methods.

### DIFF
--- a/base/markdown/render/plain.jl
+++ b/base/markdown/render/plain.jl
@@ -38,6 +38,14 @@ function plain(io::IO, list::List)
     end
 end
 
+function plain(io::IO, q::BlockQuote)
+    s = sprint(buf -> plain(buf, q.content))
+    for line in split(rstrip(s), "\n")
+        println(io, isempty(line) ? ">" : "> ", line)
+    end
+    println(io)
+end
+
 function plain(io::IO, md::HorizontalRule)
     println(io, "–" ^ 3)
 end
@@ -55,6 +63,8 @@ function plaininline(io::IO, md...)
 end
 
 plaininline(io::IO, md::Vector) = !isempty(md) && plaininline(io, md...)
+
+plaininline(io::IO, link::Link) = plaininline(io, "[", link.text, "](", link.url, ")")
 
 plaininline(io::IO, md::Image) = plaininline(io, "![", md.alt, "](", md.url, ")")
 

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -61,6 +61,15 @@ foo
 
 ---
 World""" |> plain == "Hello\n\n–––\n\nWorld\n"
+@test md"[*a*](b)" |> plain == "[*a*](b)\n"
+@test md"""
+> foo
+>
+>   * bar
+>
+> ```
+> baz
+> ```""" |> plain == """> foo\n>\n>   * bar\n>\n> ```\n> baz\n> ```\n\n"""
 
 # HTML output
 


### PR DESCRIPTION
Markdown plain text rendering was missing for `BlockQuote` and `Link` types.
