### PR TITLE
fix a libuv assertion failure that can happen after doing a redirect_stderr

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -938,13 +938,12 @@ for (x,writable,unix_fd,c_symbol) in ((:STDIN,false,0,:jl_uv_stdin),(:STDOUT,tru
                 dup(_fd(stream),  RawFD($unix_fd)) )
             $x = stream
         end
-        function ($f)(handle::AsyncStream)
+        function ($f)(handle::Union(AsyncStream,IOStream))
             $(_f)(handle)
             unsafe_store!(cglobal($(Expr(:quote,c_symbol)),Ptr{Void}),
                 handle.handle)
             handle
         end
-        ($f)(handle::IOStream) = ($_f)(handle)
         function ($f)()
             read,write = (Pipe(C_NULL), Pipe(C_NULL))
             link_pipe(read,$(writable),write,$(!writable))

--- a/src/init.c
+++ b/src/init.c
@@ -459,8 +459,10 @@ DLLEXPORT void uv_atexit_hook()
     uv_walk(loop, jl_uv_exitcleanup_walk, &queue);
     // close stdout and stderr last, since we like being
     // able to show stuff (incl. printf's)
-    jl_uv_exitcleanup_add((uv_handle_t*)jl_uv_stdout, &queue);
-    jl_uv_exitcleanup_add((uv_handle_t*)jl_uv_stderr, &queue);
+    if (((uv_handle_t*)jl_uv_stdout)->type < UV_HANDLE_TYPE_MAX)
+        jl_uv_exitcleanup_add((uv_handle_t*)jl_uv_stdout, &queue);
+    if (((uv_handle_t*)jl_uv_stderr)->type < UV_HANDLE_TYPE_MAX)
+        jl_uv_exitcleanup_add((uv_handle_t*)jl_uv_stderr, &queue);
     //uv_unref((uv_handle_t*)jl_uv_stdout);
     //uv_unref((uv_handle_t*)jl_uv_stderr);
     struct uv_shutdown_queue_item *item = queue.first;


### PR DESCRIPTION
`redirect_stderr` unreferenced the old value of `STDERR`, but the C jl_uv_stderr variable still pointed to the old object, which could then be clobbered by the finalizer. The fix is to also change the jl_uv_stderr variable to the new i/o object.

There may not be another official 0.3 release, but it's still handy to have this fix in place.
