### PR TITLE
Fix a libuv assertion after redirect_*(::IOStream)

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1041,13 +1041,12 @@ for (x,writable,unix_fd,c_symbol) in ((:STDIN,false,0,:jl_uv_stdin),(:STDOUT,tru
                 dup(_fd(stream),  RawFD($unix_fd)) )
             $x = stream
         end
-        function ($f)(handle::AsyncStream)
+        function ($f)(handle::Union{AsyncStream,IOStream})
             $(_f)(handle)
             unsafe_store!(cglobal($(Expr(:quote,c_symbol)),Ptr{Void}),
                 handle.handle)
             handle
         end
-        ($f)(handle::IOStream) = ($_f)(handle)
         function ($f)()
             read,write = (Pipe(C_NULL), Pipe(C_NULL))
             link_pipe(read,$(writable),write,$(!writable))

--- a/src/init.c
+++ b/src/init.c
@@ -583,9 +583,11 @@ DLLEXPORT void jl_atexit_hook()
     uv_walk(loop, jl_uv_exitcleanup_walk, &queue);
     // close stdout and stderr last, since we like being
     // able to show stuff (incl. printf's)
-    if (JL_STDOUT != (void*) STDOUT_FILENO)
+    if (JL_STDOUT != (void*) STDOUT_FILENO &&
+        ((uv_handle_t*)JL_STDOUT)->type < UV_HANDLE_TYPE_MAX)
         jl_uv_exitcleanup_add((uv_handle_t*)JL_STDOUT, &queue);
-    if (JL_STDERR != (void*) STDERR_FILENO)
+    if (JL_STDERR != (void*) STDERR_FILENO &&
+        ((uv_handle_t*)JL_STDERR)->type < UV_HANDLE_TYPE_MAX)
         jl_uv_exitcleanup_add((uv_handle_t*)JL_STDERR, &queue);
     //uv_unref((uv_handle_t*)JL_STDOUT);
     //uv_unref((uv_handle_t*)JL_STDERR);

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -351,6 +351,9 @@ DLLEXPORT void jl_uv_writecb(uv_write_t *req, int status)
 static void jl_write(uv_stream_t *stream, const char *str, size_t n)
 {
     assert(stream);
+    _Static_assert(offsetof(uv_stream_t,type) == offsetof(ios_t,bm) &&
+        sizeof(((uv_stream_t*)0)->type) == sizeof(((ios_t*)0)->bm),
+	   "UV and ios layout mismatch");
 
     uv_file fd = 0;
 

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -226,7 +226,10 @@ sleep(1)
 import Base.zzzInvalidIdentifier
 """
 try
-    run(`$exename -f -e $cmd`)
+    (out,in,p) = readandwrite(`$exename -f`)
+    write(in,cmd)
+    close(in)
+    wait(p)
 catch
     error("IOStream redirect failed. Child stderr was \n$(readall(fname))")
 end


### PR DESCRIPTION
When passing an IOStream to redirect_*, there was still a reference
to the libuv side stream, which would be used to print errors, etc. However,
since the julia side is now unreferenced, it would be gc'ed and its finalizer
would take the libuv side with it, leaving the C side pointer pointing to free'd
memory. Fix this by recording the IOStream as the new JL_STD* stream on the C
side as well.

This is the 0.4 version of #12143.
