### PR TITLE
maybe fix julia-debug on windows

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -203,6 +203,25 @@ jl_uv_libhandle jl_load_dynamic_library(const char *modname, unsigned flags)
     return (jl_uv_libhandle) jl_load_dynamic_library_(modname, flags, 1);
 }
 
+jl_uv_libhandle jl_load_library_as_datafile_e(const char *filename, unsigned flags)
+{
+#ifdef _OS_WINDOWS_
+    WCHAR filename_w[32768];
+    if (!uv_utf8_to_utf16(filename, filename_w, ARRAY_SIZE(filename_w)))
+        return NULL;
+    uv_lib_t *lib = (uv_lib_t*)malloc(sizeof(uv_lib_t));
+    lib->errmsg = NULL;
+    lib->handle = LoadLibraryExW(filename_w, NULL, LOAD_WITH_ALTERED_SEARCH_PATH | LOAD_LIBRARY_AS_DATAFILE);
+    if (lib->handle == NULL) {
+        free(lib);
+        return NULL;
+    }
+    return lib;
+#else
+    return jl_load_dynamic_library_e(filename, flags);
+#endif
+}
+
 void *jl_dlsym_e(jl_uv_libhandle handle, const char *symbol)
 {
     void *ptr;

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -207,7 +207,7 @@ jl_uv_libhandle jl_load_library_as_datafile_e(const char *filename, unsigned fla
 {
 #ifdef _OS_WINDOWS_
     WCHAR filename_w[32768];
-    if (!uv_utf8_to_utf16(filename, filename_w, ARRAY_SIZE(filename_w)))
+    if (!uv_utf8_to_utf16(filename, filename_w, 32768))
         return NULL;
     uv_lib_t *lib = (uv_lib_t*)malloc(sizeof(uv_lib_t));
     lib->errmsg = NULL;

--- a/src/dump.c
+++ b/src/dump.c
@@ -1542,13 +1542,16 @@ DLLEXPORT void jl_preload_sysimg_so(const char *fname)
     }
 
     // Get handle to sys.so
+    int windows = 0;
 #ifdef _OS_WINDOWS_
-    if (!jl_is_debugbuild()) {
+    windows = 1;
 #endif
-        jl_sysimg_handle = (uv_lib_t*)jl_load_dynamic_library_e(fname_shlib, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
-#ifdef _OS_WINDOWS_
+    if (windows && (jl_is_debugbuild() || jl_options.use_precompiled==JL_OPTIONS_USE_PRECOMPILED_NO)) {
+        jl_sysimg_handle = (uv_lib_t*)jl_load_library_as_datafile_e(fname_shlib, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
     }
-#endif
+    else {
+        jl_sysimg_handle = (uv_lib_t*)jl_load_dynamic_library_e(fname_shlib, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
+    }
 
     // set cpu target if unspecified by user and available from sysimg
     // otherwise default to native.

--- a/src/julia.h
+++ b/src/julia.h
@@ -1178,6 +1178,7 @@ enum JL_RTLD_CONSTANT {
 typedef void *jl_uv_libhandle; // uv_lib_t* (avoid uv.h dependency)
 DLLEXPORT jl_uv_libhandle jl_load_dynamic_library(const char *fname, unsigned flags);
 DLLEXPORT jl_uv_libhandle jl_load_dynamic_library_e(const char *fname, unsigned flags);
+jl_uv_libhandle jl_load_library_as_datafile_e(const char *filename, unsigned flags);
 DLLEXPORT void *jl_dlsym_e(jl_uv_libhandle handle, const char *symbol);
 DLLEXPORT void *jl_dlsym(jl_uv_libhandle handle, const char *symbol);
 DLLEXPORT int jl_uv_dlopen(const char *filename, jl_uv_libhandle lib, unsigned flags);


### PR DESCRIPTION
... by loading sys.dll but ignoring the code in it. cc @tkelman 

I haven't tried this yet on windows.
