### PR TITLE
make win32 julia-debug build work again

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -386,10 +386,6 @@ else
   SHLIB_EXT = so
 endif
 
-
-# if not absolute, then relative to the directory of the julia executable
-JCPPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.$(SHLIB_EXT)\""
-
 # On Windows, we want shared library files to end up in $(build_bindir), instead of $(build_libdir)
 ifeq ($(OS),WINNT)
 build_shlibdir = $(build_bindir)
@@ -913,9 +909,11 @@ endif
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(2)))))
 
 JULIA_BUILD_MODE = release
+JULIA_LIBSUFFIX=
 ifeq (,$(findstring release,$(MAKECMDGOALS)))
 ifneq (,$(findstring debug,$(MAKECMDGOALS)))
 JULIA_BUILD_MODE = debug
+JULIA_LIBSUFFIX=-debug
 endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,6 +44,10 @@ DOBJS = $(SRCS:%=$(BUILDDIR)/%.dbg.obj)
 DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
 
+# if not absolute, then relative to the directory of the julia executable
+SHIPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.$(SHLIB_EXT)\""
+DEBUGFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys-debug.$(SHLIB_EXT)\""
+
 ifeq ($(JULIAGC),MARKSWEEP)
 SRCS += gc
 endif

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -350,7 +350,6 @@ static Function *jlgetnthfieldchecked_func;
 static Function *resetstkoflw_func;
 #endif
 static Function *diff_gc_total_bytes_func;
-static Function *show_execution_point_func;
 
 static std::vector<Type *> two_pvalue_llvmt;
 static std::vector<Type *> three_pvalue_llvmt;

--- a/src/dump.c
+++ b/src/dump.c
@@ -213,11 +213,6 @@ static int jl_load_sysimg_so()
         return -1;
 
     int imaging_mode = jl_generating_output();
-#ifdef _OS_WINDOWS_
-    //XXX: the windows linker forces our system image to be
-    //     linked against only one dll, I picked libjulia-release
-    if (jl_is_debugbuild()) imaging_mode = 1;
-#endif
     // in --build mode only use sysimg data, not precompiled native code
     if (!imaging_mode && jl_options.use_precompiled==JL_OPTIONS_USE_PRECOMPILED_YES) {
         sysimg_gvars = (jl_value_t***)jl_dlsym(jl_sysimg_handle, "jl_sysimg_gvars");
@@ -1542,13 +1537,7 @@ DLLEXPORT void jl_preload_sysimg_so(const char *fname)
     }
 
     // Get handle to sys.so
-#ifdef _OS_WINDOWS_
-    if (!jl_is_debugbuild()) {
-#endif
-        jl_sysimg_handle = (uv_lib_t*)jl_load_dynamic_library_e(fname_shlib, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
-#ifdef _OS_WINDOWS_
-    }
-#endif
+    jl_sysimg_handle = (uv_lib_t*)jl_load_dynamic_library_e(fname_shlib, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
 
     // set cpu target if unspecified by user and available from sysimg
     // otherwise default to native.

--- a/src/init.c
+++ b/src/init.c
@@ -83,7 +83,7 @@ DLLEXPORT void jlbacktrace();
 DLLEXPORT void gdbbacktrace();
 DLLEXPORT void gdblookup(ptrint_t ip);
 
-static const char system_image_path[256] = JL_SYSTEM_IMAGE_PATH;
+static const char system_image_path[256] = "\0" JL_SYSTEM_IMAGE_PATH;
 
 jl_options_t jl_options = { 0,    // quiet
                             NULL, // julia_home
@@ -92,7 +92,7 @@ jl_options_t jl_options = { 0,    // quiet
                             NULL, // print
                             NULL, // postboot
                             NULL, // load
-                            system_image_path, // image_file
+                            &system_image_path[1], // image_file
                             NULL, // cpu_taget ("native", "core2", etc...)
                             0,    // nprocs
                             NULL, // machinefile

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -30,10 +30,6 @@
 #define WHOLE_ARCHIVE
 #include "../src/julia.h"
 
-#ifndef JL_SYSTEM_IMAGE_PATH
-#error "JL_SYSTEM_IMAGE_PATH not defined!"
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
this makes two copies of sys.dll, linked against both libjulia and libjulia-debug, so that the user can pick the right one. loading the wrong one will probably cause a segfault pretty quickly.

breadcrumb: these copies of sys.dll were built independently, so the cache search path in #8745 will also need to be updated to be split based on some function of the debugbuild flag, sys.so name/location, or the Main.uid value.
