### PR TITLE
Add Julia routines for setting/getting "subnormals are zero" mode.

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -915,6 +915,8 @@ export
     get_rounding,
     set_rounding,
     with_rounding,
+    get_zero_subnormals,
+    set_zero_subnormals,
 
 # statistics
     cor,

--- a/base/rounding.jl
+++ b/base/rounding.jl
@@ -6,7 +6,8 @@ include("fenv_constants.jl")
 export
     RoundingMode, RoundNearest, RoundToZero, RoundUp, RoundDown, RoundFromZero,
     RoundNearestTiesAway, RoundNearestTiesUp,
-    get_rounding, set_rounding, with_rounding
+    get_rounding, set_rounding, with_rounding,
+    get_zero_subnormals, set_zero_subnormals
 
 ## rounding modes ##
 immutable RoundingMode{T} end
@@ -84,5 +85,8 @@ function _convert_rounding{T<:FloatingPoint}(::Type{T},x::Real,r::RoundingMode{:
         y < x ? nextfloat(y) : y
     end
 end
+
+set_zero_subnormals(yes::Bool) = ccall(:jl_set_zero_subnormals,Int32,(Int8,),yes)==0
+get_zero_subnormals() = ccall(:jl_get_zero_subnormals,Int32,())!=0
 
 end #module

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -310,6 +310,25 @@ General Number Functions and Constants
 
    See ``get_rounding`` for available rounding modes.
 
+.. function:: get_zero_subnormals() -> Bool
+
+   Returns ``false`` if operations on subnormal floating-point values
+   ("denormals") obey rules for IEEE arithmetic, and ``true`` if they
+   might be converted to zeros.
+
+.. function:: set_zero_subnormals(yes::Bool) -> Bool
+
+   If ``yes`` is ``false``, subsequent floating-point operations follow
+   rules for IEEE arithmetic on subnormal values ("denormals").
+   Otherwise, floating-point operations are permitted (but not required)
+   to convert subnormal inputs or outputs to zero.  Returns ``true``
+   unless ``yes==true`` but the hardware does not support zeroing of
+   subnormal numbers.
+
+   ``set_zero_subnormals(true)`` can speed up some computations on
+   some hardware. However, it can break identities such as
+   ``(x-y==0) == (x==y)``.
+
 Integers
 ~~~~~~~~
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -354,8 +354,10 @@ end
 @test_approx_eq quadgk(cos, 0,0.7,1, norm=abs)[1] sin(1)
 
 # Ensure subnormal flags functions don't segfault
-@test any(ccall("jl_zero_subnormals", UInt8, (UInt8,), 1) .== [0x00 0x01])
-@test any(ccall("jl_zero_subnormals", UInt8, (UInt8,), 0) .== [0x00 0x01])
+@test any(set_zero_subnormals(true) .== [false,true])
+@test any(get_zero_subnormals() .== [false,true])
+@test set_zero_subnormals(false)
+@test !get_zero_subnormals()
 
 # useful test functions for relative error
 err(z, x) = abs(z - x) / abs(x)


### PR DESCRIPTION
This PR lets users more easily elect to treat subnormal numbers as zeros, which speeds up some programs on some x86 processors.  Previously, doing such required `ccall`.   The patch also lets users check the current treatment.  See issue #12132 for discussion.  [Here](https://gist.github.com/ArchRobison/00e666bea128f1862f37) is a demo program, which also demonstrates the "inject some noise" trick for avoiding subnormals.

The patch removes the undocumented routine `jl_zero_subnormals` and replaces it with `jl_set_zero_subnormals`.  I renamed it because the semantics changed to make it similar to the Linux `fesetround` interface.

The implementation caches the result of CPUID inspection since CPUID is a serializing (slow) instruction.

~~I'll write the user documentation as a separate PR once we've agreed that this PR is the right way to go.~~
