### PR TITLE
Improve sparse triplet constructor error messages

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -219,13 +219,24 @@ sparsevec(I::AbstractVector, V, m::Integer) = sparsevec(I, V, m, AddFun())
 
 sparsevec(I::AbstractVector, V) = sparsevec(I, V, maximum(I), AddFun())
 
-function sparsevec(I::AbstractVector, V, m::Integer, combine::Union{Function,Func})
+function sparsevec(I::AbstractVector, V, m::Integer, combine::Union{Function,Base.Func})
     nI = length(I)
-    if isa(V, Number); V = fill(V, nI); end
+    if isa(V, Number)
+        V = fill(V, nI)
+    end
+    if nI != length(V)
+        throw(ArgumentError("index and value vectors must be the same length"))
+    end
     p = sortperm(I)
     @inbounds I = I[p]
-    (nI==0 || m >= I[end]) || throw(DimensionMismatch("indices cannot be larger than length of vector"))
-    (nI==0 || I[1] > 0) || throw(BoundsError())
+    if nI > 0
+        if I[1] <= 0
+            throw(ArgumentError("I index values must be ≥ 0"))
+        end
+        if I[end] > m
+            throw(ArgumentError("all I index values must be ≤ length(sparsevec)"))
+        end
+    end
     V = V[p]
     sparse_IJ_sorted!(I, ones(eltype(I), nI), V, m, 1, combine)
 end

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -281,7 +281,7 @@ mfe22 = eye(Float64, 2)
 @test reinterpret(Int64, sfe22) == reinterpret(Int64, mfe22)
 
 # issue #5190
-@test_throws DimensionMismatch sparsevec([3,5,7],[0.1,0.0,3.2],4)
+@test_throws ArgumentError sparsevec([3,5,7],[0.1,0.0,3.2],4)
 
 # issue #5169
 @test nnz(sparse([1,1],[1,2],[0.0,-0.0])) == 0
@@ -589,17 +589,17 @@ let A = Array(Int,0,0), S = sparse(A)
 end
 
 # issue #8225
-@test_throws BoundsError sparse([0],[-1],[1.0],2,2)
+@test_throws ArgumentError sparse([0],[-1],[1.0],2,2)
 
 # issue #8363
-@test_throws BoundsError sparsevec(Dict(-1=>1,1=>2))
+@test_throws ArgumentError sparsevec(Dict(-1=>1,1=>2))
 
 # issue #8976
 @test conj(sparse([1im])) == sparse(conj([1im]))
 @test conj!(sparse([1im])) == sparse(conj!([1im]))
 
 # issue #9525
-@test_throws BoundsError sparse([3], [5], 1.0, 3, 3)
+@test_throws ArgumentError sparse([3], [5], 1.0, 3, 3)
 
 #findn
 b = findn( speye(4) )
@@ -1013,3 +1013,7 @@ A = sprandn(10,10,0.5)
 @test I + A == I + full(A)
 @test A - I == full(A) - I
 @test I - A == I - full(A)
+
+# Test error path if triplet vectors are not all the same length (#12177)
+@test_throws ArgumentError sparse([1,2,3], [1,2], [1,2,3], 3, 3)
+@test_throws ArgumentError sparse([1,2,3], [1,2,3], [1,2], 3, 3)


### PR DESCRIPTION
Makes sparse matrix triplet constructor error messages more consistent and gives them better context to the source of the problem.
