### PR TITLE
Expand the expression before checking :calls in gen_call_with_extracted_types

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -236,11 +236,11 @@ function gen_call_with_extracted_types(fcn, ex0)
         return Expr(:call, fcn, esc(args[1]),
                     Expr(:call, :typesof, map(esc, args[2:end])...))
     end
-    if isa(ex0, Expr) && ex0.head == :call
-        return Expr(:call, fcn, esc(ex0.args[1]),
-                    Expr(:call, :typesof, map(esc, ex0.args[2:end])...))
-    end
     ex = expand(ex0)
+    if isa(ex, Expr) && ex.head == :call
+        return Expr(:call, fcn, esc(ex.args[1]),
+                    Expr(:call, :typesof, map(esc, ex.args[2:end])...))
+    end
     exret = Expr(:call, :error, "expression is not a function call or symbol")
     if !isa(ex, Expr)
         # do nothing -> error


### PR DESCRIPTION
This fixes expression like `@which x'x`. Right now we get the wrong result

``` jl
julia> @which x'x
*{T,S}(A::AbstractArray{T,2}, B::Union{DenseArray{S,2},SubArray{S,2,A<:DenseArray{T,N},I<:Tuple{Vararg{Union{Int64,Range{Int64},Colon}}},LD}}) at linalg/matmul.jl:112
```

and with this change we get

``` jl
julia> @which x'x
Ac_mul_B{T<:Union{Float64,Float32}}(A::Union{SubArray{T<:Union{Float64,Float32},2,A<:DenseArray{T,N},I<:Tuple{Vararg{Union{Colon,Range{Int64},Int64}}},LD},DenseArray{T<:Union{Float64,Float32},2}}, B::Union{SubArray{T<:Union{Float64,Float32},2,A<:DenseArray{T,N},I<:Tuple{Vararg{Union{Colon,Range{Int64},Int64}}},LD},DenseArray{T<:Union{Float64,Float32},2}}) at linalg/matmul.jl:159
```

but I really don't know if the change has unforeseen consequences.
