### PR TITLE
Fix up type inference and other issues for the new DFT API

### DIFF
--- a/base/dft.jl
+++ b/base/dft.jl
@@ -87,7 +87,8 @@ type ScaledPlan{T,P,N} <: Plan{T}
     pinv::Plan
     ScaledPlan(p, scale) = new(p, scale)
 end
-ScaledPlan{P<:Plan,N<:Number}(p::P, scale::N) = ScaledPlan{eltype(P),P,N}(p, scale)
+call{T,P,N}(::Type{ScaledPlan{T}}, p::P, scale::N) = ScaledPlan{T,P,N}(p, scale)
+ScaledPlan{T}(p::Plan{T}, scale::Number) = ScaledPlan{T}(p, scale)
 ScaledPlan(p::ScaledPlan, α::Number) = ScaledPlan(p.p, p.scale * α)
 
 size(p::ScaledPlan) = size(p.p)
@@ -105,7 +106,7 @@ summary(p::ScaledPlan) = string(p.scale, " * ", summary(p.p))
 *(p::Plan, I::UniformScaling) = ScaledPlan(p, I.λ)
 
 # Normalization for ifft, given unscaled bfft, is 1/prod(dimensions)
-normalization(T, sz, region) = one(T) / prod([sz...][[region...]])
+normalization(T, sz, region) = (one(T) / prod([sz...][[region...]]))::T
 normalization(X, region) = normalization(real(eltype(X)), size(X), region)
 
 plan_ifft(x::AbstractArray, region; kws...) =

--- a/test/fft.jl
+++ b/test/fft.jl
@@ -309,7 +309,7 @@ for x in (randn(10),randn(10,12))
     @inferred rfft(x)
     @inferred brfft(x,18)
     @inferred brfft(y,10)
-    for f in (fft,plan_fft,bfft,plan_bfft,fft_)
+    for f in (fft,plan_fft,bfft,plan_bfft,fft_,ifft,plan_ifft)
         @inferred f(x)
         @inferred f(z)
     end

--- a/test/fft.jl
+++ b/test/fft.jl
@@ -309,9 +309,14 @@ for x in (randn(10),randn(10,12))
     @inferred rfft(x)
     @inferred brfft(x,18)
     @inferred brfft(y,10)
-    for f in (fft,plan_fft,bfft,plan_bfft,fft_,ifft,plan_ifft)
-        @inferred f(x)
+    for f in (plan_bfft!, plan_fft!, plan_ifft!,
+              plan_bfft, plan_fft, plan_ifft,
+              fft, bfft, fft_, ifft)
         @inferred f(z)
+    end
+    for f in (plan_bfft, plan_fft, plan_ifft,
+              plan_rfft, fft, bfft, fft_, ifft)
+        @inferred f(x)
     end
     # note: inference doesn't work for plan_fft_ since the
     #       algorithm steps are included in the CTPlan type

--- a/test/fft.jl
+++ b/test/fft.jl
@@ -295,6 +295,13 @@ for T in (Complex64, Complex128)
     end
 end
 
+let
+    plan32 = plan_fft([1.0:2048.0;])
+    plan64 = plan_fft([1f0:2048f0;])
+    FFTW.flops(plan32)
+    FFTW.flops(plan64)
+end
+
 # issue #9772
 for x in (randn(10),randn(10,12))
     z = complex(x)


### PR DESCRIPTION
The type instability/inference issue is mentioned in https://github.com/JuliaLang/julia/pull/12087#issuecomment-120135449 and https://github.com/JuliaLang/julia/pull/12087#issuecomment-120166974.

The code can probably be cleaned up a little to make the type inference more effective without the type assertion but the current version should be good enough.

This also fixes a deprecation warning for `int64`.

Close #9772

CC. @stevengj 
