### PR TITLE
qualify location of libccalltest

### DIFF
--- a/test/libdl.jl
+++ b/test/libdl.jl
@@ -20,6 +20,8 @@ end
 @test_throws ArgumentError Libdl.dlsym(C_NULL, :foo)
 @test_throws ArgumentError Libdl.dlsym_e(C_NULL, :foo)
 
+cd(dirname(@__FILE__)) do
+
 # @test !isempty(Libdl.find_library(["libccalltest"], [dirname(@__FILE__)]))
 
 # dlopen should be able to handle absolute and relative paths, with and without dlext
@@ -161,4 +163,6 @@ let dl = C_NULL
     finally
         Libdl.dlclose(dl)
     end
+end
+
 end

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 using Base.LineEdit
+isdefined(:TestHelpers) || include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
 using TestHelpers
 
 a_foo = 0

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # REPL tests
+isdefined(:TestHelpers) || include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
 using TestHelpers
 import Base: REPL, LineEdit
 


### PR DESCRIPTION
fixes `Base.runtests("ccall")` when run from a different directory, since the `cd` in `test/runtests.jl` was removed by #8745

Either the cd needs to go back or we can merge this pr:

```
     * ccall               exception on 1: ERROR: LoadError: error compiling anonymous: could not load library './libccalltest'
./libccalltest: cannot open shared object file: No such file or directory
 in include at ./boot.jl:254
 in include_from_node1 at ./loading.jl:187
 in runtests at /home/tkelman/Julia/julia-4b757af634/share/julia/test/testdefs.jl:197
 in anonymous at /home/tkelman/Julia/julia-4b757af634/share/julia/test/runtests.jl:14
 in anonymous at multi.jl:623
 in run_work_thunk at multi.jl:584
 in remotecall_fetch at multi.jl:657
 in remotecall_fetch at multi.jl:672
 in anonymous at task.jl:1392
while loading /home/tkelman/Julia/julia-4b757af634/share/julia/test/ccall.jl, in expression starting on line 5
ERROR: LoadError: LoadError: error compiling anonymous: could not load library './libccalltest'
./libccalltest: cannot open shared object file: No such file or directory
 in include at ./boot.jl:254
 in include_from_node1 at ./loading.jl:187
 in runtests at /home/tkelman/Julia/julia-4b757af634/share/julia/test/testdefs.jl:197
 in anonymous at /home/tkelman/Julia/julia-4b757af634/share/julia/test/runtests.jl:14
 in anonymous at multi.jl:623
 in run_work_thunk at multi.jl:584
 in remotecall_fetch at multi.jl:657
 in remotecall_fetch at multi.jl:672
 in anonymous at task.jl:1392
while loading /home/tkelman/Julia/julia-4b757af634/share/julia/test/ccall.jl, in expression starting on line 5
while loading /home/tkelman/Julia/julia-4b757af634/share/julia/test/runtests.jl, in expression starting on line 14
ERROR: A test has failed. Please submit a bug report (https://github.com/JuliaLang/julia/issues)
including error messages above and the output of versioninfo():
Julia Version 0.4.0-dev+6075
Commit 4b757af (2015-07-19 00:53 UTC)
Platform Info:
  System: Linux (x86_64-unknown-linux-gnu)
  CPU: Intel(R) Core(TM)2 Duo CPU     E8400  @ 3.00GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Penryn)
  LAPACK: libopenblas
  LIBM: libopenlibm
  LLVM: libLLVM-3.3

 in error at ./error.jl:21
 in runtests at interactiveutil.jl:406
 in runtests at interactiveutil.jl:395
```
