### PR TITLE
Fix MSVC build

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -28,6 +28,10 @@
 #endif
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // manipulating mark bits
 
 #define GC_CLEAN 0 // freshly allocated
@@ -251,10 +255,6 @@ static void pre_mark(void);
 static void post_mark(arraylist_t *list, int dryrun);
 
 #include "gc-debug.c"
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 int jl_in_gc; // referenced from switchto task.c
 

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -27,6 +27,9 @@
 #include <io.h>
 #define write _write
 #endif
+#if defined(_COMPILER_MICROSOFT_) && !defined(_Static_assert)
+#define _Static_assert static_assert
+#endif
 
 #ifdef __cplusplus
 #include <cstring>


### PR DESCRIPTION
various complaints about unknown `void *` size in pointer arithmetic (ref https://github.com/JuliaLang/julia/commit/d81f6d2fcaa1ec77402e1e9526886441944ebf24#commitcomment-12240818),
inconsistent linkage in gc functions due to moving the `extern "C"` in #11358,
and different spelling of `_Static_assert` from #12144

Also need to replace the sysimg patch in #12056 with https://gist.github.com/bb6b600056bf2bbeb42a once this gets merged.
