### PR TITLE
RFC: document vagrant setup for windows build

### DIFF
--- a/README.windows.md
+++ b/README.windows.md
@@ -236,6 +236,15 @@ Finally, the build and install process for Julia:
 
 If you are building for 64-bit windows, the steps are essentially the same. Just replace i686 in XC_HOST with x86_64. (note: on Mac, wine only runs in 32-bit mode)
 
+## Using a Windows VM
+
+[Vagrant](http://www.vagrantup.com/downloads) can also be used with a Windows
+guest VM via the `Vagrantfile` in [contrib/windows](contrib/windows/Vagrantfile),
+just run `vagrant up` from that folder. To build with Cygwin instead of MSYS2,
+replace `config.vm.provision :shell, :inline => $script_msys2` (near the end
+of the file) with `config.vm.provision :shell, :inline => $script_cygwin`.
+
+
 ## Windows Build Debugging
 
 ### GDB hangs with cygwin mintty

--- a/contrib/windows/Vagrantfile
+++ b/contrib/windows/Vagrantfile
@@ -1,0 +1,80 @@
+# Vagrantfile for building Windows Julia via MSYS2 or Cygwin
+
+$script_msys2 = <<SCRIPT
+# change the following to 32 for 32 bit Julia
+$bits = "64"
+$arch = "x86_$bits".Replace("x86_32", "i686")
+# change the date in the following for future msys2 releases
+$msys2tarball = "msys2-base-$arch-20150512.tar"
+
+# these environment variables need to be set, or Julia gets confused
+[Environment]::SetEnvironmentVariable("HOMEDRIVE", "C:")
+[Environment]::SetEnvironmentVariable("HOMEPATH", "\\Users\\vagrant")
+
+# install chocolatey, cmake, and python2
+iex ((new-object net.webclient).DownloadString("https://chocolatey.org/install.ps1"))
+choco install -y cmake
+choco install -y python2
+
+# pacman is picky, reinstall msys2 from scratch
+foreach ($dir in @("etc", "usr", "var")) {
+  if (Test-Path "C:\\msys$bits\\$dir") {
+    rm -Recurse -Force C:\\msys$bits\\$dir
+  }
+}
+mkdir -Force C:\\msys$bits | Out-Null
+(new-object net.webclient).DownloadFile(
+  "https://chocolatey.org/7za.exe",
+  "C:\\msys$bits\\7za.exe")
+(new-object net.webclient).DownloadFile(
+  "http://sourceforge.net/projects/msys2/files/Base/$arch/$msys2tarball.xz",
+  "C:\\msys$bits\\$msys2tarball.xz")
+cd C:\\
+& "msys$bits\\7za.exe" x -y msys$bits\\$msys2tarball.xz
+& "msys$bits\\7za.exe" x -y $msys2tarball | Out-Null
+rm $msys2tarball, msys$bits\\$msys2tarball.xz, msys$bits\\7za.exe
+
+& "C:\\msys$bits\\usr\\bin\\sh" -lc "pacman --noconfirm --force --needed -Sy \\
+  bash pacman pacman-mirrors msys2-runtime"
+& "C:\\msys$bits\\usr\\bin\\sh" -lc "pacman --noconfirm -Syu && \\
+  pacman --noconfirm -S diffutils git m4 make patch tar p7zip msys/openssh"
+& "C:\\msys$bits\\usr\\bin\\sh" -lc "if ! [ -e julia$bits ]; then
+  git clone git://github.com/JuliaLang/julia.git julia$bits; fi && cd julia$bits && git pull && \\
+  if ! [ -e usr/$arch-w64-mingw32 ]; then contrib/windows/get_toolchain.sh $bits; fi && \\
+  export PATH=`$PWD/usr/$arch-w64-mingw32/sys-root/mingw/bin:`$PATH:/c/tools/python2 && \\
+  echo 'override CMAKE=/c/Program\\ Files\\ \\(x86\\)/CMake/bin/cmake' > Make.user && \\
+  make cleanall && make -j2 testall && make win-extras binary-dist"
+SCRIPT
+
+$script_cygwin = <<SCRIPT
+# change the following to 32 for 32 bit Julia
+$bits = "64"
+$arch = "x86_$bits".Replace("x86_32", "i686")
+$setup = "setup-$arch.exe".Replace("i686", "x86")
+
+mkdir -Force C:\\cygwin$bits | Out-Null
+(new-object net.webclient).DownloadFile(
+  "http://cygwin.com/$setup", "C:\\cygwin$bits\\$setup")
+foreach ($pkg in @("git,make,curl,patch,python,gcc-g++,m4,cmake,p7zip",
+    "mingw64-$arch-gcc-g++,mingw64-$arch-gcc-fortran")) {
+  & "C:\\cygwin$bits\\$setup" -q -n -R C:\\cygwin$bits -l C:\\cygwin$bits\\packages `
+    -s http://mirrors.mit.edu/cygwin -g -P $pkg | Where-Object `
+    -FilterScript {$_ -notlike "Installing file *"} | Write-Output
+}
+[Environment]::SetEnvironmentVariable("HOMEDRIVE", "C:")
+[Environment]::SetEnvironmentVariable("HOMEPATH", "\\Users\\vagrant")
+& "C:\\cygwin$bits\\bin\\sh" -lc "if ! [ -e julia$bits ]; then git clone \\
+  git://github.com/JuliaLang/julia.git julia$bits; fi && cd julia$bits && git pull && \\
+  echo 'XC_HOST = $arch-w64-mingw32' > Make.user && make cleanall && \\
+  make -j2 testall && make win-extras binary-dist"
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "kensykora/windows_2012_r2_standard"
+  config.vm.provider :virtualbox do |vb|
+    # Use VBoxManage to customize the VM. For example to change memory:
+    vb.memory = 2048
+  end
+  # change the following to $script_cygwin to build with Cygwin instead of MSYS2
+  config.vm.provision :shell, :inline => $script_msys2
+end


### PR DESCRIPTION
A few people have asked about this, including @vtjnash and @ViralBShah. This Vagrant box seems to download and work just fine for me without having to do any extra work aside from `vagrant up`, though I'm going to let the provisioning script run and see if it all works correctly. Will remove WIP if it does.

Also note if you view the rich diff there's a bug (reported, hopefully will be fixed before too long) with github's markdown rendering where they aren't displaying the lines that start with `[Environment]`. If we don't have that as a test case in the Julia Markdown parser, it should be.
