### PR TITLE
Fix comment for emit_function.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3812,7 +3812,7 @@ static Function *gen_jlcall_wrapper(jl_lambda_info_t *lam, jl_expr_t *ast, Funct
     return w;
 }
 
-// cstyle = compile with c-callable signature, not jlcall
+// Compile to LLVM IR, using a specialized signature if applicable.
 static Function *emit_function(jl_lambda_info_t *lam)
 {
     // step 1. unpack AST and allocate codegen context for this function


### PR DESCRIPTION
The `cstyle` flag disappeared, but the comment remains.   Suggestions for a better replacement comment appreciated, as the function is arguably one of the more important ones for beginners to understand. :-)
