### PR TITLE
RFC: remove default `importall Base.Operators`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -138,6 +138,9 @@ Language changes
   * `global x` in a nested scope is now a syntax error if `x` is local
     to the enclosing scope ([#7264]/[#11985]).
 
+  * The default `importall Base.Operators` is deprecated, and relying on it
+    will give a warning ([#8113]).
+
 Command line option changes
 ---------------------------
 
@@ -1420,6 +1423,7 @@ Too numerous to mention.
 [#7992]: https://github.com/JuliaLang/julia/issues/7992
 [#8011]: https://github.com/JuliaLang/julia/issues/8011
 [#8089]: https://github.com/JuliaLang/julia/issues/8089
+[#8113]: https://github.com/JuliaLang/julia/issues/8113
 [#8135]: https://github.com/JuliaLang/julia/issues/8135
 [#8152]: https://github.com/JuliaLang/julia/issues/8152
 [#8246]: https://github.com/JuliaLang/julia/issues/8246
@@ -1535,4 +1539,6 @@ Too numerous to mention.
 [#11922]: https://github.com/JuliaLang/julia/issues/11922
 [#11985]: https://github.com/JuliaLang/julia/issues/11985
 [#12031]: https://github.com/JuliaLang/julia/issues/12031
+[#12034]: https://github.com/JuliaLang/julia/issues/12034
 [#12087]: https://github.com/JuliaLang/julia/issues/12087
+[#12137]: https://github.com/JuliaLang/julia/issues/12137

--- a/base/Dates.jl
+++ b/base/Dates.jl
@@ -2,6 +2,8 @@
 
 module Dates
 
+importall ..Base.Operators
+
 include("dates/types.jl")
 include("dates/periods.jl")
 include("dates/accessors.jl")

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -17,7 +17,8 @@ import Base:
     Display,
     display,
     writemime,
-    AnyDict
+    AnyDict,
+    ==
 
 import ..LineEdit:
     CompletionProvider,

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -6,8 +6,7 @@ using ..Cartesian
 import Base.promote_eltype
 import Base.@get!
 import Base.num_bit_chunks, Base._msk_end, Base.unsafe_bitgetindex
-import Base.(.+), Base.(.-), Base.(.*), Base.(./), Base.(.\), Base.(.//)
-import Base.(.==), Base.(.<), Base.(.!=), Base.(.<=)
+import Base: .+, .-, .*, ./, .\, .//, .==, .<, .!=, .<=, .%, .<<, .>>, .^
 export broadcast, broadcast!, broadcast_function, broadcast!_function, bitbroadcast
 export broadcast_getindex, broadcast_setindex!
 

--- a/base/grisu.jl
+++ b/base/grisu.jl
@@ -2,6 +2,8 @@
 
 module Grisu
 
+importall ..Base.Operators
+
 export print_shortest
 export DIGITS, grisu
 

--- a/base/grisu/bignums.jl
+++ b/base/grisu/bignums.jl
@@ -30,6 +30,8 @@
 
 module Bignums
 
+import Base: ==, <
+
 export Bignum
 
 const kMaxSignificantBits = 3584

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -3,6 +3,7 @@
 module LinAlg
 
 importall Base
+importall ..Base.Operators
 import Base: USE_BLAS64, size, copy, copy_transpose!, power_by_squaring,
              print_matrix, transpose!, unsafe_getindex, unsafe_setindex!
 

--- a/base/markdown/Markdown.jl
+++ b/base/markdown/Markdown.jl
@@ -2,7 +2,7 @@
 
 module Markdown
 
-import Base: writemime
+import Base: writemime, ==
 
 typealias String AbstractString
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -4,6 +4,7 @@
 module IteratorsMD
 
 import Base: eltype, length, start, done, next, last, getindex, setindex!, linearindexing, min, max, eachindex, ndims
+importall ..Base.Operators
 import Base: simd_outer_range, simd_inner_length, simd_index, @generated
 import Base: @nref, @ncall, @nif, @nexprs, LinearFast, LinearSlow, to_index
 

--- a/base/pkg/reqs.jl
+++ b/base/pkg/reqs.jl
@@ -2,6 +2,8 @@
 
 module Reqs
 
+import Base: ==
+
 using ..Types
 
 # representing lines of REQUIRE files

--- a/base/pkg/resolve/fieldvalue.jl
+++ b/base/pkg/resolve/fieldvalue.jl
@@ -3,6 +3,7 @@
 module FieldValues
 
 using ...VersionWeights
+importall .....Base.Operators
 
 export FieldValue, Field, validmax, secondmax
 

--- a/base/pkg/resolve/versionweight.jl
+++ b/base/pkg/resolve/versionweight.jl
@@ -2,6 +2,8 @@
 
 module VersionWeights
 
+importall ....Base.Operators
+
 export VersionWeight
 
 immutable HierarchicalValue{T}

--- a/base/pkg/types.jl
+++ b/base/pkg/types.jl
@@ -3,7 +3,7 @@
 module Types
 
 export VersionInterval, VersionSet, Requires, Available, Fixed, merge_requires!, satisfies
-import Base: show, isempty, in, intersect, hash, deepcopy_internal
+import Base: show, isempty, in, intersect, hash, deepcopy_internal, ==
 
 immutable VersionInterval
     lower::VersionNumber

--- a/base/sparse.jl
+++ b/base/sparse.jl
@@ -7,6 +7,7 @@ using Base.Sort: Forward
 using Base.LinAlg: AbstractTriangular
 
 importall Base
+importall ..Base.Operators
 importall Base.LinAlg
 import Base.promote_eltype
 import Base.@get!

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -3,7 +3,7 @@
 module CHOLMOD
 
 import Base: (*), convert, copy, eltype, getindex, show, showarray, size,
-             linearindexing, LinearFast, LinearSlow
+             linearindexing, LinearFast, LinearSlow, ctranspose
 
 import Base.LinAlg: (\), A_mul_Bc, A_mul_Bt, Ac_ldiv_B, Ac_mul_B, At_ldiv_B, At_mul_B,
                  cholfact, det, diag, ishermitian, isposdef,

--- a/base/sparse/spqr.jl
+++ b/base/sparse/spqr.jl
@@ -2,6 +2,8 @@
 
 module SPQR
 
+import Base: \
+
 # ordering options */
 const ORDERING_FIXED   = Int32(0)
 const ORDERING_NATURAL = Int32(1)

--- a/doc/manual/modules.rst
+++ b/doc/manual/modules.rst
@@ -160,13 +160,12 @@ contain ``using Base``, since this is needed in the vast majority of cases.
 Default top-level definitions and bare modules
 ----------------------------------------------
 
-In addition to ``using Base``, all operators are explicitly imported,
-since one typically wants to extend operators rather than creating entirely
-new definitions of them. A module also automatically contains a definition
-of the ``eval`` function, which evaluates expressions within the context of
-that module.
+In addition to ``using Base``, modules also perform ``import Base.call`` by
+default, to facilitate adding constructors to new types.
+A new module also automatically contains a definition of the ``eval`` function,
+which evaluates expressions within the context of that module.
 
-If these ``Base`` definitions are not wanted, modules can be defined using the
+If these default definitions are not wanted, modules can be defined using the
 keyword ``baremodule`` instead (note: ``Core`` is still imported, as per above).
 In terms of ``baremodule``, a standard ``module`` looks like this::
 
@@ -174,7 +173,7 @@ In terms of ``baremodule``, a standard ``module`` looks like this::
 
     using Base
 
-    importall Base.Operators
+    import Base.call
 
     eval(x) = Core.eval(Mod, x)
     eval(m,x) = Core.eval(m, x)

--- a/examples/modint.jl
+++ b/examples/modint.jl
@@ -3,6 +3,8 @@
 module ModInts
 export ModInt
 
+import Base: +, -, *
+
 immutable ModInt{n} <: Integer
     k::Int
     ModInt(k) = new(mod(k,n))

--- a/src/dump.c
+++ b/src/dump.c
@@ -540,6 +540,7 @@ static void jl_serialize_module(ios_t *s, jl_module_t *m)
     }
     jl_serialize_value(s, m->constant_table);
     write_uint8(s, m->istopmod);
+    write_uint8(s, m->std_imports);
     write_uint64(s, m->uuid);
 }
 
@@ -1336,6 +1337,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         m->constant_table = (jl_array_t*)jl_deserialize_value(s, (jl_value_t**)&m->constant_table);
         if (m->constant_table != NULL) jl_gc_wb(m, m->constant_table);
         m->istopmod = read_uint8(s);
+        m->std_imports = read_uint8(s);
         m->uuid = read_uint64(s);
         return (jl_value_t*)m;
     }

--- a/src/julia.h
+++ b/src/julia.h
@@ -312,6 +312,7 @@ typedef struct _jl_module_t {
     jl_array_t *constant_table;
     jl_function_t *call_func;  // cached lookup of `call` within this module
     uint8_t istopmod;
+    uint8_t std_imports;  // only for temporarily deprecating `importall Base.Operators`
     uint64_t uuid;
 } jl_module_t;
 

--- a/src/module.c
+++ b/src/module.c
@@ -28,6 +28,7 @@ jl_module_t *jl_new_module(jl_sym_t *name)
     m->constant_table = NULL;
     m->call_func = NULL;
     m->istopmod = 0;
+    m->std_imports = 0;
     m->uuid = uv_now(uv_default_loop());
     htable_new(&m->bindings, 0);
     arraylist_new(&m->usings, 0);
@@ -120,6 +121,16 @@ DLLEXPORT jl_module_t *jl_get_module_of_binding(jl_module_t *m, jl_sym_t *var)
 // and overwriting.
 DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *var)
 {
+    if (jl_base_module && m->std_imports && !jl_binding_resolved_p(m,var)) {
+        jl_module_t *opmod = (jl_module_t*)jl_get_global(jl_base_module, jl_symbol("Operators"));
+        if (opmod != NULL && jl_defines_or_exports_p(opmod, var)) {
+            jl_printf(JL_STDERR,
+                      "WARNING: module %s should explicitly import %s from %s\n",
+                      m->name->name, var->name, jl_base_module->name->name);
+            jl_module_import(m, opmod, var);
+        }
+    }
+
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
     jl_binding_t *b = *bp;
 
@@ -133,6 +144,15 @@ DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *
                     jl_errorf("error in method definition: %s.%s cannot be extended", b->owner->name->name, var->name);
                 }
                 else {
+                    if (jl_base_module && b->owner == jl_base_module) {
+                        jl_module_t *opmod = (jl_module_t*)jl_get_global(jl_base_module, jl_symbol("Operators"));
+                        if (opmod != NULL && jl_defines_or_exports_p(opmod, var)) {
+                            jl_printf(JL_STDERR,
+                                      "WARNING: module %s should explicitly import %s from %s\n",
+                                      m->name->name, var->name, b->owner->name->name);
+                            return b2;
+                        }
+                    }
                     jl_errorf("error in method definition: function %s.%s must be explicitly imported to be extended", b->owner->name->name, var->name);
                 }
             }

--- a/src/module.c
+++ b/src/module.c
@@ -144,7 +144,7 @@ DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *
                     jl_errorf("error in method definition: %s.%s cannot be extended", b->owner->name->name, var->name);
                 }
                 else {
-                    if (jl_base_module && b->owner == jl_base_module) {
+                    if (jl_base_module && m->std_imports && b->owner == jl_base_module) {
                         jl_module_t *opmod = (jl_module_t*)jl_get_global(jl_base_module, jl_symbol("Operators"));
                         if (opmod != NULL && jl_defines_or_exports_p(opmod, var)) {
                             jl_printf(JL_STDERR,

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -40,10 +40,8 @@ void jl_add_standard_imports(jl_module_t *m)
     assert(jl_base_module != NULL);
     // using Base
     jl_module_using(m, jl_base_module);
-    // importall Base.Operators
-    jl_module_t *opmod = (jl_module_t*)jl_get_global(jl_base_module, jl_symbol("Operators"));
-    if (opmod != NULL)
-        jl_module_importall(m, opmod);
+    // import Base.call
+    jl_module_import(m, jl_base_module, jl_symbol("call"));
 }
 
 jl_module_t *jl_new_main_module(void)

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -42,6 +42,7 @@ void jl_add_standard_imports(jl_module_t *m)
     jl_module_using(m, jl_base_module);
     // import Base.call
     jl_module_import(m, jl_base_module, jl_symbol("call"));
+    m->std_imports = 1;
 }
 
 jl_module_t *jl_new_main_module(void)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1726,6 +1726,7 @@ test5536(a::Union{Real, AbstractArray}) = "Non-splatting"
 @test_throws LoadError include_string("#= #= #= =# =# =")
 
 # issue #6142
+import Base: +
 type A6142 <: AbstractMatrix{Float64}; end
 +{TJ}(x::A6142, y::UniformScaling{TJ}) = "UniformScaling method called"
 +(x::A6142, y::AbstractArray) = "AbstractArray method called"

--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -104,6 +104,7 @@ end
 size(Phi::CPM)=(size(Phi.kraus,1)^2,size(Phi.kraus,3)^2)
 issym(Phi::CPM)=false
 ishermitian(Phi::CPM)=false
+import Base: *
 function *{T<:Base.LinAlg.BlasFloat}(Phi::CPM{T},rho::Vector{T})
     rho=reshape(rho,(size(Phi.kraus,3),size(Phi.kraus,3)))
     rho2=zeros(T,(size(Phi.kraus,1),size(Phi.kraus,1)))


### PR DESCRIPTION
Here is what this might look like. It's not so bad, and I was pleasantly surprised to see that several submodules of Base already explicitly imported the operators they extend, which is a good sign. However life is very very hard without a default import of `Base.call`, so I think we're stuck with that for now. Still an improvement over importing the 73 identifiers in Base.Operators though.

ref #8113
