### PR TITLE
Fix infinite loop in windows memory manager

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -969,6 +969,8 @@ public:
   virtual uint8_t *getGOTBase() const { return JMM->getGOTBase(); }
   virtual uint8_t *startFunctionBody(const Function *F,
                                      uintptr_t &ActualSize) {
+      if (ActualSize == 0)
+          ActualSize += 64;
       ActualSize += 48;
       uint8_t *mem = JMM->startFunctionBody(F,ActualSize);
       ActualSize -= 48;


### PR DESCRIPTION
I'll do more testing on various commit later (haven't actually even tested this compiles yet). Currently debugging with the most reliable failure from https://github.com/JuliaLang/julia/pull/11569#issuecomment-110168040.

When it fails, this function is called with `ActualSize == 0` and somehow `JMM->startFunctionBody` returns exactly the same size as requested. This breaks the retry logic which is doubling the size every time (because doubling a `0` is getting no where...)

@tkelman Would be nice if you can do a few tests locally.

@Keno @vtjnash ~~I didn't run blame but~~ would be nice if you could check if this makes sense.

Close #7942
