### PR TITLE
Throw remote errors locally, and do not print them on remote worker. 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -141,6 +141,15 @@ Language changes
   * The default `importall Base.Operators` is deprecated, and relying on it
     will give a warning ([#8113]).
 
+  * `remotecall_fetch` and `fetch` now rethrow any uncaught remote exception locally as a
+    `RemoteException`. Previously they would return the remote exception object.
+    The worker pid, remote exception and remote backtrace are available in the
+    thrown `RemoteException`.
+
+  * If any of the enclosed async operations in a `@sync` block throw exceptions, they
+    are now collected in a `CompositeException` and the `CompositeException` thrown.
+
+
 Command line option changes
 ---------------------------
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -156,6 +156,8 @@ export
 # Exceptions
     ArgumentError,
     DimensionMismatch,
+    CapturedException,
+    CompositeException,
     EOFError,
     ErrorException,
     InvalidStateException,
@@ -165,6 +167,7 @@ export
     NullException,
     ParseError,
     ProcessExitedException,
+    RemoteException,
     SystemError,
     TypeError,
     AssertionError,

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -612,20 +612,31 @@ function wait_empty(rv::RemoteValue)
 end
 
 ## core messages: do, call, fetch, wait, ref, put! ##
+type RemoteException <: Exception
+    pid::Int
+    captured::CapturedException
+end
 
-function run_work_thunk(thunk)
+RemoteException(captured) = RemoteException(myid(), captured)
+function show(io::IO, re::RemoteException)
+    (re.pid != myid()) && print(io, "On worker ", re.pid, ":\n")
+    show(io, re.captured)
+end
+
+
+function run_work_thunk(thunk, print_error)
     local result
     try
         result = thunk()
     catch err
-        print(STDERR, "exception on ", myid(), ": ")
-        display_error(err,catch_backtrace())
-        result = err
+        ce = CapturedException(err, catch_backtrace())
+        result = RemoteException(ce)
+        print_error && print(STDERR, ce)
     end
     result
 end
 function run_work_thunk(rv::RemoteValue, thunk)
-    put!(rv, run_work_thunk(thunk))
+    put!(rv, run_work_thunk(thunk, false))
     nothing
 end
 
@@ -689,7 +700,8 @@ remotecall(id::Integer, f, args...) = remotecall(worker_from_id(id), f, args...)
 
 # faster version of fetch(remotecall(...))
 function remotecall_fetch(w::LocalProcess, f, args...)
-    run_work_thunk(local_remotecall_thunk(f,args))
+    v=run_work_thunk(local_remotecall_thunk(f,args), false)
+    isa(v, RemoteException) ? throw(v) : v
 end
 
 function remotecall_fetch(w::Worker, f, args...)
@@ -701,7 +713,7 @@ function remotecall_fetch(w::Worker, f, args...)
     send_msg(w, CallMsg{:call_fetch}(f, args, oid))
     v = wait_full(rv)
     delete!(PGRP.refs, oid)
-    v
+    isa(v, RemoteException) ? throw(v) : v
 end
 
 remotecall_fetch(id::Integer, f, args...) =
@@ -877,7 +889,7 @@ end
 handle_msg(msg::CallMsg{:call}, r_stream, w_stream) = schedule_call(msg.response_oid, ()->msg.f(msg.args...))
 function handle_msg(msg::CallMsg{:call_fetch}, r_stream, w_stream)
     @schedule begin
-        v = run_work_thunk(()->msg.f(msg.args...))
+        v = run_work_thunk(()->msg.f(msg.args...), false)
         deliver_result(w_stream, :call_fetch, msg.response_oid, v)
     end
 end
@@ -889,7 +901,7 @@ function handle_msg(msg::CallWaitMsg, r_stream, w_stream)
     end
 end
 
-handle_msg(msg::RemoteDoMsg, r_stream, w_stream) = @schedule run_work_thunk(()->msg.f(msg.args...))
+handle_msg(msg::RemoteDoMsg, r_stream, w_stream) = @schedule run_work_thunk(()->msg.f(msg.args...), true)
 
 handle_msg(msg::ResultMsg, r_stream, w_stream) = put!(lookup_ref(msg.response_oid), msg.value)
 
@@ -1321,7 +1333,7 @@ macro everywhere(ex)
     quote
         @sync begin
             for w in PGRP.workers
-                @async remotecall_fetch(w.id, ()->(eval(Main,$(Expr(:quote,ex))); nothing))
+                @async remotecall_fetch(w, ()->(eval(Main,$(Expr(:quote,ex))); nothing))
             end
         end
     end
@@ -1392,12 +1404,7 @@ function pmap(f, lsts...; err_retry=true, err_stop=false, pids = workers())
                     (idx, fvals) = tasklet
                     busy_workers[pididx] = true
                     try
-                        result = remotecall_fetch(wpid, f, fvals...)
-                        if isa(result, Exception)
-                            ((wpid == myid()) ? rethrow(result) : throw(result))
-                        else
-                            results[idx] = result
-                        end
+                        results[idx] = remotecall_fetch(wpid, f, fvals...)
                     catch ex
                         if err_retry
                             push!(retryqueue, (idx,fvals, ex))

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -607,6 +607,8 @@ built-in :exc:`Exception`\ s listed below all interrupt the normal flow of contr
 +------------------------------+
 | :exc:`BoundsError`           |
 +------------------------------+
+| :exc:`CompositeException`    |
++------------------------------+
 | :exc:`DivideError`           |
 +------------------------------+
 | :exc:`DomainError`           |
@@ -628,6 +630,8 @@ built-in :exc:`Exception`\ s listed below all interrupt the normal flow of contr
 | :exc:`OutOfMemoryError`      |
 +------------------------------+
 | :exc:`ReadOnlyMemoryError`   |
++------------------------------+
+| :exc:`RemoteException`       |
 +------------------------------+
 | :exc:`MethodError`           |
 +------------------------------+

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -261,7 +261,8 @@ General Parallel Computing Support
 
    Waits and fetches a value from ``x`` depending on the type of ``x``. Does not remove the item fetched:
 
-   * ``RemoteRef``: Wait for and get the value of a remote reference.
+   * ``RemoteRef``: Wait for and get the value of a remote reference. If the remote value is an exception,
+                    throws a ``RemoteException`` which captures the remote exception and backtrace.
 
    * ``Channel`` : Wait for and get the first available item from the channel.
 
@@ -271,7 +272,8 @@ General Parallel Computing Support
 
 .. function:: remotecall_fetch(id, func, args...)
 
-   Perform ``fetch(remotecall(...))`` in one message.
+   Perform ``fetch(remotecall(...))`` in one message. Any remote exceptions are captured in a ``RemoteException``
+   and thrown.
 
 .. function:: put!(RemoteRef, value)
 
@@ -327,13 +329,14 @@ General Parallel Computing Support
 
 .. function:: @spawn
 
-   Execute an expression on an automatically-chosen process, returning a
+   Creates a closure around an expression and runs it on an automatically-chosen process, returning a
    ``RemoteRef`` to the result.
 
 .. function:: @spawnat
 
-   Accepts two arguments, ``p`` and an expression, and runs the expression
-   asynchronously on process ``p``, returning a ``RemoteRef`` to the result.
+   Accepts two arguments, ``p`` and an expression. A closure is created around
+   the expression and run asynchronously on process ``p``. Returns a ``RemoteRef``
+   to the result.
 
 .. function:: @fetch
 
@@ -345,13 +348,14 @@ General Parallel Computing Support
 
 .. function:: @async
 
-   Schedule an expression to run on the local machine, also adding it to the
-   set of items that the nearest enclosing ``@sync`` waits for.
+   Wraps an expression in a closure and schedules it to run on the local machine. Also
+   adds it to the set of items that the nearest enclosing ``@sync`` waits for.
 
 .. function:: @sync
 
    Wait until all dynamically-enclosed uses of ``@async``, ``@spawn``,
-   ``@spawnat`` and ``@parallel`` are complete.
+   ``@spawnat`` and ``@parallel`` are complete. All exceptions thrown by
+   enclosed async operations are collected and thrown as a ``CompositeException``.
 
 .. function:: @parallel
 
@@ -373,6 +377,11 @@ General Parallel Computing Support
         @sync @parallel for var = range
             body
         end
+
+.. function:: @everywhere
+
+    Execute an expression on all processes. Errors on any of the processes are
+    collected into a `CompositeException` and thrown.
 
 Shared Arrays (Experimental, UNIX-only feature)
 -----------------------------------------------

--- a/src/julia.h
+++ b/src/julia.h
@@ -1316,6 +1316,7 @@ typedef struct _jl_task_t {
     jl_value_t *donenotify;
     jl_value_t *result;
     jl_value_t *exception;
+    jl_value_t *backtrace;
     jl_function_t *start;
     jl_jmp_buf ctx;
 #ifndef COPY_STACKS

--- a/src/task.c
+++ b/src/task.c
@@ -837,6 +837,7 @@ DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
     t->result = jl_nothing;
     t->donenotify = jl_nothing;
     t->exception = jl_nothing;
+    t->backtrace = jl_nothing;
     // there is no active exception handler available on this stack yet
     t->eh = NULL;
     t->gcstack = NULL;
@@ -890,7 +891,7 @@ void jl_init_tasks(void)
     jl_task_type = jl_new_datatype(jl_symbol("Task"),
                                    jl_any_type,
                                    jl_emptysvec,
-                                   jl_svec(9,
+                                   jl_svec(10,
                                             jl_symbol("parent"),
                                             jl_symbol("last"),
                                             jl_symbol("storage"),
@@ -899,12 +900,14 @@ void jl_init_tasks(void)
                                             jl_symbol("donenotify"),
                                             jl_symbol("result"),
                                             jl_symbol("exception"),
+                                            jl_symbol("backtrace"),
                                             jl_symbol("code")),
-                                   jl_svec(9,
+                                   jl_svec(10,
                                             jl_any_type, jl_any_type,
                                             jl_any_type, jl_sym_type,
                                             jl_any_type, jl_any_type,
-                                            jl_any_type, jl_any_type, jl_function_type),
+                                            jl_any_type, jl_any_type,
+                                            jl_any_type, jl_function_type),
                                    0, 1, 0);
     jl_svecset(jl_task_type->types, 0, (jl_value_t*)jl_task_type);
 
@@ -938,6 +941,7 @@ void jl_init_root_task(void *stack, size_t ssize)
     jl_current_task->result = NULL;
     jl_current_task->donenotify = NULL;
     jl_current_task->exception = NULL;
+    jl_current_task->backtrace = NULL;
     jl_current_task->eh = NULL;
     jl_current_task->gcstack = NULL;
 

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -277,51 +277,78 @@ function test_iteration(in_c, out_c)
 end
 
 test_iteration(Channel(10), Channel(10))
+# make sure exceptions propagate when waiting on Tasks
+@test_throws CompositeException (@sync (@async error("oops")))
+try
+    @sync begin
+        for i in 1:5
+            @async error(i)
+        end
+    end
+catch ex
+    @test isa(ex, CompositeException)
+    @test length(ex) == 5
+    @test isa(ex.exceptions[1], CapturedException)
+    @test isa(ex.exceptions[1].ex, ErrorException)
+    errors = map(x->x.ex.msg, ex.exceptions)
+    @test collect(1:5) == sort(map(x->parse(Int, x), errors))
+end
+
+
+try
+    remotecall_fetch(id_other, ()->throw(ErrorException("foobar")))
+catch e
+    @test isa(e, RemoteException)
+    @test isa(e.captured, CapturedException)
+    @test isa(e.captured.ex, ErrorException)
+    @test e.captured.ex.msg == "foobar"
+end
+
+# pmap tests
+# needs at least 4 processors dedicated to the below tests
+nprocs() < 5 && remotecall_fetch(1, ()->addprocs(5-nprocs()))
+s = "a"*"bcdefghijklmnopqrstuvwxyz"^100;
+ups = "A"*"BCDEFGHIJKLMNOPQRSTUVWXYZ"^100;
+@test ups == bytestring(UInt8[UInt8(c) for c in pmap(x->uppercase(x), s)])
+@test ups == bytestring(UInt8[UInt8(c) for c in pmap(x->uppercase(Char(x)), s.data)])
+
+DoFullTest = Bool(parse(Int,(get(ENV, "JULIA_TESTFULL", "0"))))
+
+# retry, on error exit
+res = pmap(x->(x=='a') ? error("EXPECTED TEST ERROR. TO BE IGNORED.") : uppercase(x), s; err_retry=true, err_stop=true);
+# Commenting out the below test for now since it depends on how the workers are scheduled on presumably already
+# overloaded systems in CI.
+#@test (length(res) < length(ups))
+@test isa(res[1], Exception)
+
+# no retry, on error exit
+res = pmap(x->(x=='a') ? error("EXPECTED TEST ERROR. TO BE IGNORED.") : uppercase(x), s; err_retry=false, err_stop=true);
+#@test (length(res) < length(ups))
+@test isa(res[1], Exception)
+
+# retry, on error continue
+res = pmap(x->iseven(myid()) ? error("EXPECTED TEST ERROR. TO BE IGNORED.") : uppercase(x), s; err_retry=true, err_stop=false);
+@test length(res) == length(ups)
+@test ups == bytestring(UInt8[UInt8(c) for c in res])
+
+# no retry, on error continue
+res = pmap(x->(x=='a') ? error("EXPECTED TEST ERROR. TO BE IGNORED.") : uppercase(x), s; err_retry=false, err_stop=false);
+@test length(res) == length(ups)
+@test isa(res[1], Exception)
+
 
 # The below block of tests are usually run only on local development systems, since:
+# - tests which print errors
 # - addprocs tests are memory intensive
 # - ssh addprocs requires sshd to be running locally with passwordless login enabled.
-# - includes some tests that print errors
 # The test block is enabled by defining env JULIA_TESTFULL=1
 
-if Bool(parse(Int,(get(ENV, "JULIA_TESTFULL", "0"))))
-    print("\n\nTesting correct error handling in pmap call. Please ignore printed errors when specified.\n")
+if DoFullTest
+    println("Testing exception printing on remote worker from a `remote_do` call")
+    println("Please ensure the remote error and backtrace is displayed on screen")
 
-    # make sure exceptions propagate when waiting on Tasks
-    @test_throws ErrorException (@sync (@async error("oops")))
-
-    # pmap tests
-    # needs at least 4 processors (which are being created above for the @parallel tests)
-    s = "a"*"bcdefghijklmnopqrstuvwxyz"^100;
-    ups = "A"*"BCDEFGHIJKLMNOPQRSTUVWXYZ"^100;
-    @test ups == bytestring(UInt8[UInt8(c) for c in pmap(x->uppercase(x), s)])
-    @test ups == bytestring(UInt8[UInt8(c) for c in pmap(x->uppercase(Char(x)), s.data)])
-
-    pmappids = remotecall_fetch(1, () -> addprocs(4))
-
-    # retry, on error exit
-    res = pmap(x->(x=='a') ? error("EXPECTED TEST ERROR. TO BE IGNORED.") : uppercase(x), s; err_retry=true, err_stop=true, pids=pmappids);
-    @test (length(res) < length(ups))
-    @test isa(res[1], Exception)
-
-    # no retry, on error exit
-    res = pmap(x->(x=='a') ? error("EXPECTED TEST ERROR. TO BE IGNORED.") : uppercase(x), s; err_retry=false, err_stop=true, pids=pmappids);
-    @test (length(res) < length(ups))
-    @test isa(res[1], Exception)
-
-    # retry, on error continue
-    res = pmap(x->iseven(myid()) ? error("EXPECTED TEST ERROR. TO BE IGNORED.") : uppercase(x), s; err_retry=true, err_stop=false, pids=pmappids);
-    @test length(res) == length(ups)
-    @test ups == bytestring(UInt8[UInt8(c) for c in res])
-
-    # no retry, on error continue
-    res = pmap(x->(x=='a') ? error("EXPECTED TEST ERROR. TO BE IGNORED.") : uppercase(x), s; err_retry=false, err_stop=false, pids=pmappids);
-    @test length(res) == length(ups)
-    @test isa(res[1], Exception)
-
-    remotecall_fetch(1, p->rmprocs(p), pmappids)
-
-    print("\n\nPassed all pmap tests that print errors.\n")
+    Base.remote_do(id_other, ()->throw(ErrorException("TESTING EXCEPTION ON REMOTE DO. PLEASE IGNORE")))
+    sleep(0.5)  # Give some time for the above error to be printed
 
 @unix_only begin
     function test_n_remove_pids(new_pids)


### PR DESCRIPTION
Currently, the `remotecall` functions print any exceptions on the remote worker and return an exception object to the calling process.

This PR changes the behaviour to not print on the remote worker and send back a `RemoteException` which wraps the actual exception and remote call stack. This is thrown on the calling process.

I felt the need for this change in behavior in some recent work where a remote exception needed to be handled at the caller but not printed on the remote worker.

Unexported function `remote_do` continues to print to STDERR similar to unhandled task exceptions being printed.

This would be a breaking change for code that was handling remote exceptions as a return value from `remotecall_fetch` 
