### PR TITLE
Add some debugging tip for using GDB on Windows

### DIFF
--- a/README.windows.md
+++ b/README.windows.md
@@ -240,7 +240,15 @@ If you are building for 64-bit windows, the steps are essentially the same. Just
 
 ### GDB hangs with cygwin mintty
 
-- run gdb under the windows console (cmd) instead. gdb [does not function properly](https://www.cygwin.com/ml/cygwin/2009-02/msg00531.html) under mintty with non-cygwin applications.
+- Run gdb under the windows console (cmd) instead. gdb [does not function properly](https://www.cygwin.com/ml/cygwin/2009-02/msg00531.html) under mintty with non-cygwin applications. You can use `cmd /c start` to start the windows console from mintty if necessary.
+
+### GDB not attaching to the right process
+
+- Use the PID from the windows task manager or `WINPID` from the `ps` command instead of the PID from unix style command line tools (e.g. `pgrep`). You may need to add the PID column if it is not shown by default in the windows task manager.
+
+### GDB not showing the right backtrace
+
+- When attaching to the julia process, GDB may not be attaching to the right thread. Use `info threads` command to show all the threads and `thread <threadno>` to switch threads.
 
 ### Build process is slow/eats memory/hangs my computer
 


### PR DESCRIPTION
These are some tips that I find useful when debugging #7942.

They might be obvious for windows users but I found them very confusing at first.

@vtjnash Since I notice that you mentioned the issue with attaching to the wrong thread in the comment of #7942 
