### PR TITLE
More type-inference friendly FFTWPlan constructors

### DIFF
--- a/test/fft.jl
+++ b/test/fft.jl
@@ -312,11 +312,17 @@ for x in (randn(10),randn(10,12))
     for f in (plan_bfft!, plan_fft!, plan_ifft!,
               plan_bfft, plan_fft, plan_ifft,
               fft, bfft, fft_, ifft)
-        @inferred f(z)
+        p = @inferred f(z)
+        if isa(p, FFTW.Plan)
+            @inferred FFTW.plan_inv(p)
+        end
     end
     for f in (plan_bfft, plan_fft, plan_ifft,
               plan_rfft, fft, bfft, fft_, ifft)
-        @inferred f(x)
+        p = @inferred f(x)
+        if isa(p, FFTW.Plan)
+            @inferred FFTW.plan_inv(p)
+        end
     end
     # note: inference doesn't work for plan_fft_ since the
     #       algorithm steps are included in the CTPlan type


### PR DESCRIPTION
- Remove type assertions
- More tests for type stability of the plan functions

This cuts down allocation by ~10%. Performance doesn't change too much but the main purpose of this is to make them type stable without type assertions.

**The one place in this patch that isn't reorganizing the code and adding tests is [here](https://github.com/JuliaLang/julia/commit/b9b5ce19987262f2439d3cda1c5ea93419fc4685#diff-4049a0d6669adf642c8bf9c21a8874c7L650)**. The copied `X` doesn't seem to be used before and judging from the context I think that shouldn't be the case.

Possible future improvements (personally not affected):
- `plan_r2r*` is still not type stable. One possible way to solve this (if necessary) is to remove the `kinds` from the type parameter and store it in the type value. This can also remove some unnecessary codegen since the parameter is only used in `plan_inv`
- Remove type stability caused by `FakeArray` and replace it with a wrapper that has some conditional logic in it's `pointer` method.

cc. @stevengj 
