### PR TITLE
Add more tests for UTF-16 and UTF-32 to improve unit test coverage

### DIFF
--- a/base/unicode/utf16.jl
+++ b/base/unicode/utf16.jl
@@ -120,8 +120,8 @@ function convert(::Type{UTF16String}, str::AbstractString)
             buf[out += 1] = UInt16(c)
         else
             # output surrogate pair
-            buf[out += 1] = UInt16(0xd7c0 + (ch >>> 10))
-            buf[out += 1] = UInt16(0xdc00 + (ch & 0x3ff))
+            buf[out += 1] = UInt16(0xd7c0 + (c >>> 10))
+            buf[out += 1] = UInt16(0xdc00 + (c & 0x3ff))
         end
     end
     @inbounds buf[out + 1] = 0 # NULL termination

--- a/base/unicode/utf32.jl
+++ b/base/unicode/utf32.jl
@@ -159,8 +159,6 @@ function convert(::Type{UTF16String}, str::UTF32String)
     return encode_to_utf16(dat, len + num4byte)
 end
 
-convert(::Type{UTF32String}, c::Char)             = UTF32String(Char[c, Char(0)])
-
 function convert(::Type{UTF32String}, str::ASCIIString)
     dat = str.data
     @inbounds return fast_utf_copy(UTF32String, Char, length(dat), dat, true)


### PR DESCRIPTION
This also fixes two minor issues, one was a duplicate copy of a method, the other a problem that showed up after I had to change to use an `AbstractString` with `Char` instead of a `Vector{UInt32}`.
