### PR TITLE
Deprecate IntSet complement and stored zeros

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -736,3 +736,14 @@ write(io::IO, s::RopeString) = (write(io, s.head); write(io, s.tail))
 sizeof(s::RopeString) = sizeof(s.head) + sizeof(s.tail)
 
 export RopeString
+
+function complement!(s::IntSet)
+    depwarn("complement IntSets are deprecated", :complement!);
+    for n = 1:length(s.bits)
+        s.bits[n] = ~s.bits[n]
+    end
+    s.fill1s = !s.fill1s
+    s
+end
+complement(s::IntSet) = complement!(copy(s))
+export complement, complement!

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -747,8 +747,6 @@ export
     any!,
     any,
     collect,
-    complement!,
-    complement,
     contains,
     count,
     delete!,

--- a/base/intset.jl
+++ b/base/intset.jl
@@ -55,8 +55,12 @@ function push!(s::IntSet, n::Integer)
             lim = Int(n + div(n,2))
             sizehint!(s, lim)
         end
-    elseif n < 0
-        throw(ArgumentError("IntSet elements cannot be negative"))
+    elseif n <= 0
+        if n < 0
+            throw(ArgumentError("IntSet elements cannot be negative"))
+        else
+            depwarn("storing zero in IntSets is deprecated", :push!)
+        end
     end
     s.bits[n>>5 + 1] |= (UInt32(1)<<(n&31))
     return s
@@ -78,8 +82,12 @@ function pop!(s::IntSet, n::Integer, deflt)
             return deflt
         end
     end
-    if n < 0
-        return deflt
+    if n <= 0
+        if n < 0
+            return deflt
+        else
+            depwarn("stored zeros in IntSet is deprecated", :pop!)
+        end
     end
     mask = UInt32(1)<<(n&31)
     idx = n>>5 + 1
@@ -147,12 +155,15 @@ function in(n::Integer, s::IntSet)
     if n >= s.limit
         # max IntSet length is typemax(Int), so highest possible element is
         # typemax(Int)-1
-        s.fill1s && n >= 0 && n < typemax(Int)
-    elseif n < 0
-        return false
-    else
-        (s.bits[n>>5 + 1] & (UInt32(1)<<(n&31))) != 0
+        return s.fill1s && n >= 0 && n < typemax(Int)
+    elseif n <= 0
+        if n < 0
+            return false
+        else
+            depwarn("stored zeros in IntSet is deprecated", :in)
+        end
     end
+    (s.bits[n>>5 + 1] & (UInt32(1)<<(n&31))) != 0
 end
 
 start(s::IntSet) = Int64(0)

--- a/base/intset.jl
+++ b/base/intset.jl
@@ -78,6 +78,9 @@ function pop!(s::IntSet, n::Integer, deflt)
             return deflt
         end
     end
+    if n < 0
+        return deflt
+    end
     mask = UInt32(1)<<(n&31)
     idx = n>>5 + 1
     b = s.bits[idx]

--- a/base/intset.jl
+++ b/base/intset.jl
@@ -236,16 +236,6 @@ intersect(s1::IntSet, s2::IntSet) =
     (s1.limit >= s2.limit ? intersect!(copy(s1), s2) : intersect!(copy(s2), s1))
 intersect(s1::IntSet, ss::IntSet...) = intersect(s1, intersect(ss...))
 
-function complement!(s::IntSet)
-    for n = 1:length(s.bits)
-        s.bits[n] = ~s.bits[n]
-    end
-    s.fill1s = !s.fill1s
-    s
-end
-
-complement(s::IntSet) = complement!(copy(s))
-
 function symdiff!(s::IntSet, s2::IntSet)
     if s2.limit > s.limit
         sizehint!(s, s2.limit)

--- a/test/intset.jl
+++ b/test/intset.jl
@@ -26,6 +26,7 @@ s = IntSet([0,1,10,20,200,300,1000,10000,10002])
 @test first(s) == 0
 @test length(s) == 9
 @test pop!(s) == 10002
+@test_throws KeyError pop!(s, -1)
 @test length(s) == 8
 @test shift!(s) == 0
 @test length(s) == 7

--- a/test/intset.jl
+++ b/test/intset.jl
@@ -19,7 +19,6 @@ data_out = collect(s)
 # show
 @test sprint(show, IntSet()) == "IntSet([])"
 @test sprint(show, IntSet([1,2,3])) == "IntSet([1, 2, 3])"
-@test contains(sprint(show, complement(IntSet())), "...,")
 
 
 s = IntSet([0,1,10,20,200,300,1000,10000,10002])
@@ -38,7 +37,6 @@ s = IntSet([0,1,10,20,200,300,1000,10000,10002])
 t = copy(s)
 sizehint!(t, 20000) #check that hash does not depend on size of internal Array{UInt32, 1}
 @test hash(s) == hash(t)
-@test hash(complement(s)) == hash(complement(t))
 
 @test setdiff(IntSet([1, 2, 3, 4]), IntSet([2, 4, 5, 6])) == IntSet([1, 3])
 @test symdiff(IntSet([1, 2, 3, 4]), IntSet([2, 4, 5, 6])) == IntSet([1, 3, 5, 6])
@@ -63,21 +61,6 @@ s = IntSet(255)
 # for b in s; b; end
 
 i = IntSet([1, 2, 3])
-j = complement(i)
-
-for n in (0, 4, 171)
-    @test n in j
-end
-
-@test j.limit == 256
-@test length(j) == typemax(Int) - 3
-push!(j, 257)
-@test length(j) == typemax(Int) - 3
-
-pop!(j, 171)
-@test !(171 in j)
-@test length(j) == typemax(Int) - 4
-@test complement(j) == IntSet([1, 2, 3, 171])
 
 union!(i, [1, 2])
 @test length(i) == 3
@@ -96,7 +79,6 @@ empty!(i)
 
 i = IntSet(1:6)
 @test symdiff!(i, IntSet([6, 513])) == IntSet([1:5; 513])
-@test length(symdiff!(i, complement(i))) == typemax(Int)
 
 i = IntSet([1, 2, 3])
 k = IntSet([4, 5])
@@ -104,15 +86,7 @@ copy!(k, i)
 @test k == i
 @test !(k === i)
 
-union!(i, complement(i))
-copy!(k, i)
-@test k == i
-@test !(k === i)
-
 # unions
-l = union!(i, complement(i))
-@test length(l) == typemax(Int)
-
 i = IntSet([1, 2, 3])
 j = union(i)
 @test j == i
@@ -138,16 +112,8 @@ push!(j, 257)
 push!(j, 2, 3, 17)
 @test intersect(i, j) == IntSet([2, 3])
 
-k = complement(j)
-@test intersect(i, k) == IntSet([1])
-
-l = IntSet([1, 3])
-@test intersect(i, k, l) == IntSet([1])
-
-
 ## equality
 i = IntSet([1, 2, 3])
-@test !(i == complement(i))
 j = IntSet([1, 2, 4])
 @test i != j
 

--- a/test/intset.jl
+++ b/test/intset.jl
@@ -21,16 +21,16 @@ data_out = collect(s)
 @test sprint(show, IntSet([1,2,3])) == "IntSet([1, 2, 3])"
 
 
-s = IntSet([0,1,10,20,200,300,1000,10000,10002])
+s = IntSet([1,2,10,20,200,300,1000,10000,10002])
 @test last(s) == 10002
-@test first(s) == 0
+@test first(s) == 1
 @test length(s) == 9
 @test pop!(s) == 10002
 @test_throws KeyError pop!(s, -1)
 @test length(s) == 8
-@test shift!(s) == 0
+@test shift!(s) == 1
 @test length(s) == 7
-@test !in(0,s)
+@test !in(1,s)
 @test !in(10002,s)
 @test in(10000,s)
 @test_throws ArgumentError first(IntSet())
@@ -53,7 +53,7 @@ s = IntSet(255)
 
 # issue #7851
 @test_throws ArgumentError IntSet(-1)
-@test !(-1 in IntSet(0:10))
+@test !(-1 in IntSet(1:10))
 
 # # issue #8570
 # This requires 2^29 bytes of storage, which is too much for a simple test


### PR DESCRIPTION
As discussed in https://github.com/JuliaLang/julia/pull/10065#issuecomment-123369017, this deprecates `complement`, `complement!`, and the ability to explicitly store and test for zero in `IntSet`, paving the way for a much simpler and more straightforward `IndexSet` in 0.5.  This _doesn't_ do the rename.  I figure that can happen when we start changing the internals.

Also fixes a bug in `pop!`.

~~(Temporarily without the stored zeros deprecation to try and determine if that was the trigger for the intermittent CI failures)~~
