### PR TITLE
read multi-byte integers in one shot

### DIFF
--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -165,6 +165,14 @@ function read(s::IOStream, ::Type{UInt8})
     b % UInt8
 end
 
+for (fname, U, S) in (("jl_ios_get_uint16", :UInt16, :Int16),
+                      ("jl_ios_get_uint32", :UInt32, :Int32),
+                      ("jl_ios_get_uint64", :UInt64, :Int64))
+    @eval function read{T<:Union{$U,$S}}(s::IOStream, ::Type{T})
+        ccall($fname, $U, (Ptr{Void},), s.ios) % T
+    end
+end
+
 function read!{T}(s::IOStream, a::Array{T})
     if isbits(T)
         nb = length(a)*sizeof(T)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -165,11 +165,11 @@ function read(s::IOStream, ::Type{UInt8})
     b % UInt8
 end
 
-for (fname, U, S) in (("jl_ios_get_uint16", :UInt16, :Int16),
-                      ("jl_ios_get_uint32", :UInt32, :Int32),
-                      ("jl_ios_get_uint64", :UInt64, :Int64))
+for (U, S) in ((:UInt16, :Int16),
+               (:UInt32, :Int32),
+               (:UInt64, :Int64))
     @eval function read{T<:Union{$U,$S}}(s::IOStream, ::Type{T})
-        ccall($fname, $U, (Ptr{Void},), s.ios) % T
+        ccall(:jl_ios_get_nbytes, UInt64, (Ptr{Void}, Csize_t), s.ios, sizeof(T)) % T
     end
 end
 

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -290,6 +290,49 @@ DLLEXPORT jl_value_t *jl_typeof(jl_value_t *v) {
     return jl_typeof__MACRO(v);
 }
 
+static void NORETURN throw_eof_error(void)
+{
+    jl_datatype_t* eof_error = (jl_datatype_t*)jl_get_global(jl_base_module, jl_symbol("EOFError"));
+    assert(eof_error != NULL);
+    jl_exceptionf(eof_error, "");
+}
+
+DLLEXPORT uint16_t jl_ios_get_uint16(ios_t *s)
+{
+    uint8_t buf[2];
+    size_t ret = ios_readall(s, (char*)buf, 2);
+    if (ret < 2)
+        throw_eof_error();
+    uint16_t x = 0;
+    for (int i = 0; i < 2; i++)
+        x |= (uint16_t)buf[i] << (i << 3);
+    return x;
+}
+
+DLLEXPORT uint32_t jl_ios_get_uint32(ios_t *s)
+{
+    uint8_t buf[4];
+    size_t ret = ios_readall(s, (char*)buf, 4);
+    if (ret < 4)
+        throw_eof_error();
+    uint32_t x = 0;
+    for (int i = 0; i < 4; i++)
+        x |= (uint32_t)buf[i] << (i << 3);
+    return x;
+}
+
+DLLEXPORT uint64_t jl_ios_get_uint64(ios_t *s)
+{
+    uint8_t buf[8];
+    size_t ret = ios_readall(s, (char*)buf, 8);
+    if (ret < 8)
+        throw_eof_error();
+    uint64_t x = 0;
+    for (int i = 0; i < 8; i++)
+        x |= (uint64_t)buf[i] << (i << 3);
+    return x;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This pull request improves the performance of reading multi-byte integers.
The performance gain is especially large for 64-bit integers.

```
Before                      After
------                      -----
UInt16                      UInt16
  83.915 milliseconds         70.105 milliseconds
Int16                       Int16
  77.856 milliseconds         70.525 milliseconds
UInt32                      UInt32
 169.842 milliseconds         69.058 milliseconds
Int32                       Int32
 175.813 milliseconds         77.217 milliseconds
UInt64                      UInt64
 325.072 milliseconds         83.050 milliseconds
Int64                       Int64
 313.216 milliseconds         84.966 milliseconds
```

Benchmark script:

``` julia
function bench{T}(::Type{T}, n)
    f = open(string("tmp", T), "w+")
    x = 12345
    for i in 1:n
        write(f, T(x))
    end
    @time for _ in 1:5
        seekstart(f)
        for i in 1:n
            @assert read(f, T) == x
        end
    end
    close(f)
end

let
    n = 1_000_000
    for T in [UInt16, Int16, UInt32, Int32, UInt64, Int64]
        println(T)
        bench(T, n)
    end
end
```

This is because the original code calls the `ios_getc` function for each reading byte, but the proposed code calls only one function (`jl_ios_get_uint(16|32|64)`) based on the required number of bytes.
https://github.com/JuliaLang/julia/blob/d88dd21e0d5722377bb4fe59e7330d35bae48081/base/io.jl#L109-L115
https://github.com/JuliaLang/julia/blob/d88dd21e0d5722377bb4fe59e7330d35bae48081/base/iostream.jl#L160-L166
