### PR TITLE
Faster SparseCSC and UniformScaling addition and subtraction

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -2847,36 +2847,8 @@ function Base.centralize_sumabs2!{S,Tv,Ti}(R::AbstractArray{S}, A::SparseMatrixC
     return R
 end
 
-## Unitform matrix arithmetic
+## Uniform matrix arithmetic
 
-function (+)(A::SparseMatrixCSC, J::UniformScaling)
-    n = LinAlg.chksquare(A)
-    i, j, nz = findnz(A)
-    for k = 1:n
-        push!(i, k)
-        push!(j, k)
-        push!(nz, J.λ)
-    end
-    return sparse(i, j, nz)
-end
-
-function (-)(A::SparseMatrixCSC, J::UniformScaling)
-    n = LinAlg.chksquare(A)
-    i, j, nz = findnz(A)
-    for k = 1:n
-        push!(i, k)
-        push!(j, k)
-        push!(nz, -J.λ)
-    end
-    return sparse(i, j, nz)
-end
-function (-)(J::UniformScaling, A::SparseMatrixCSC)
-    n = LinAlg.chksquare(A)
-    i, j, nz = findnz(A)
-    for k = 1:n
-        push!(i, k)
-        push!(j, k)
-        push!(nz, -J.λ)
-    end
-    return sparse(i, j, -nz)
-end
+(+)(A::SparseMatrixCSC, J::UniformScaling) = A + J.λ * speye(A)
+(-)(A::SparseMatrixCSC, J::UniformScaling) = A - J.λ * speye(A)
+(-)(J::UniformScaling, A::SparseMatrixCSC) = J.λ * speye(A) - A


### PR DESCRIPTION
This pull requests improves on the SparseMatrixCSC +- UniformScaling code, as mentioned at the bottom of #12030. Thanks to @andreasnoack for encouraging my first pull request!

For a 1_000_000 random square matrix with nnz = 100_000_000, the times on my i5 were after #12030 were:

``` julia
@time B = A + 20I;
#  12.496 seconds      (1113 k allocations: 5903 MB, 1.07% gc time)
```

now:

``` julia
@time C = A + 20I;
#  490.157 milliseconds (205 k allocations: 1603 MB)
```
