### PR TITLE
Change doublequotes to triple(double)quotes

### DIFF
--- a/base/unicode/checkstring.jl
+++ b/base/unicode/checkstring.jl
@@ -23,7 +23,7 @@ const UTF_SURROGATE = 32        ##< surrogate pairs present
     (ch << 6) | (byt & 0x3f)
 end
 
-"
+"""
 Validates and calculates number of characters in a UTF-8,UTF-16 or UTF-32 encoded vector/string
 
 Warning: this function does not check the bounds of the start or end positions
@@ -46,7 +46,7 @@ Use `checkstring` to make sure the bounds are checked
 
 ### Throws:
 * `UnicodeError`
-"
+"""
 function unsafe_checkstring end
 
 function unsafe_checkstring(dat::Vector{UInt8},
@@ -191,7 +191,7 @@ function unsafe_checkstring{T <: Union{Vector{UInt16}, Vector{UInt32}, AbstractS
     return totalchar, flags, num4byte, num3byte, num2byte
 end
 
-"
+"""
 Validates and calculates number of characters in a UTF-8,UTF-16 or UTF-32 encoded vector/string
 
 This function checks the bounds of the start and end positions
@@ -214,7 +214,7 @@ Use `unsafe_checkstring` to avoid that overhead if the bounds have already been 
 
 ### Throws:
 * `UnicodeError`
-"
+"""
 function checkstring end
 
 # No need to check bounds if using defaults

--- a/base/unicode/utf16.jl
+++ b/base/unicode/utf16.jl
@@ -101,7 +101,7 @@ function isvalid(::Type{UTF16String}, data::AbstractArray{UInt16})
     return i > n || !is_surrogate_codeunit(data[i])
 end
 
-"
+"""
 Converts an `AbstractString` to a `UTF16String`
 
 ### Returns:
@@ -109,7 +109,7 @@ Converts an `AbstractString` to a `UTF16String`
 
 ### Throws:
 *   `UnicodeError`
-"
+"""
 function convert(::Type{UTF16String}, str::AbstractString)
     len, flags, num4byte = unsafe_checkstring(str)
     buf = Vector{UInt16}(len+num4byte+1)
@@ -128,7 +128,7 @@ function convert(::Type{UTF16String}, str::AbstractString)
     UTF16String(buf)
 end
 
-"
+"""
 Converts a `UTF8String` to a `UTF16String`
 
 ### Returns:
@@ -136,7 +136,7 @@ Converts a `UTF8String` to a `UTF16String`
 
 ### Throws:
 *   `UnicodeError`
-"
+"""
 function convert(::Type{UTF16String}, str::UTF8String)
     dat = str.data
     # handle zero length string quickly
@@ -174,7 +174,7 @@ function convert(::Type{UTF16String}, str::UTF8String)
     UTF16String(buf)
 end
 
-"
+"""
 Converts a `UTF16String` to a `UTF8String`
 
 ### Returns:
@@ -182,7 +182,7 @@ Converts a `UTF16String` to a `UTF8String`
 
 ### Throws:
 *   `UnicodeError`
-"
+"""
 function convert(::Type{UTF8String}, str::UTF16String)
     dat = str.data
     len = sizeof(dat) >>> 1
@@ -194,7 +194,7 @@ function convert(::Type{UTF8String}, str::UTF16String)
     return encode_to_utf8(UInt16, dat, len + num2byte + num3byte*2 + num4byte*3)
 end
 
-"
+"""
 Converts an already validated UTF-32 encoded vector of `UInt32` to a `UTF16String`
 
 ### Input Arguments:
@@ -203,7 +203,7 @@ Converts an already validated UTF-32 encoded vector of `UInt32` to a `UTF16Strin
 
 ### Returns:
 *   `::UTF16String`
-"
+"""
 function encode_to_utf16(dat, len)
     buf = Vector{UInt16}(len)
     @inbounds buf[len] = 0 # NULL termination

--- a/base/unicode/utf32.jl
+++ b/base/unicode/utf32.jl
@@ -15,7 +15,7 @@ utf32(x) = convert(UTF32String, x)
 convert(::Type{UTF32String}, c::Char) = UTF32String(Char[c, Char(0)])
 convert(::Type{UTF32String}, s::UTF32String) = s
 
-"
+"""
 Converts an `AbstractString` to a `UTF32String`
 
 ### Returns:
@@ -23,7 +23,7 @@ Converts an `AbstractString` to a `UTF32String`
 
 ### Throws:
 *   `UnicodeError`
-"
+"""
 function convert(::Type{UTF32String}, str::AbstractString)
     len, flags = unsafe_checkstring(str)
     buf = Vector{Char}(len+1)
@@ -33,7 +33,7 @@ function convert(::Type{UTF32String}, str::AbstractString)
     UTF32String(buf)
 end
 
-"
+"""
 Converts a `UTF32String` to a `UTF8String`
 
 ### Returns:
@@ -41,7 +41,7 @@ Converts a `UTF32String` to a `UTF8String`
 
 ### Throws:
 *   `UnicodeError`
-"
+"""
 function convert(::Type{UTF8String},  str::UTF32String)
     dat = reinterpret(UInt32, str.data)
     len = sizeof(dat) >>> 2
@@ -53,7 +53,7 @@ function convert(::Type{UTF8String},  str::UTF32String)
     return encode_to_utf8(UInt32, dat, len + num2byte + num3byte*2 + num4byte*3)
 end
 
-"
+"""
 Converts a `UTF8String` to a `UTF32String`
 
 ### Returns:
@@ -61,7 +61,7 @@ Converts a `UTF8String` to a `UTF32String`
 
 ### Throws:
 *   `UnicodeError`
-"
+"""
 function convert(::Type{UTF32String}, str::UTF8String)
     dat = str.data
     # handle zero length string quickly
@@ -107,7 +107,7 @@ function convert(::Type{UTF32String}, str::UTF8String)
     UTF32String(buf)
 end
 
-"
+"""
 Converts a `UTF16String` to `UTF32String`
 
 ### Returns:
@@ -115,7 +115,7 @@ Converts a `UTF16String` to `UTF32String`
 
 ### Throws:
 *   `UnicodeError`
-"
+"""
 function convert(::Type{UTF32String}, str::UTF16String)
     dat = str.data
     len = sizeof(dat)
@@ -138,7 +138,7 @@ function convert(::Type{UTF32String}, str::UTF16String)
     UTF32String(buf)
 end
 
-"
+"""
 Converts a `UTF32String` to `UTF16String`
 
 ### Returns:
@@ -146,7 +146,7 @@ Converts a `UTF32String` to `UTF16String`
 
 ### Throws:
 *   `UnicodeError`
-"
+"""
 function convert(::Type{UTF16String}, str::UTF32String)
     dat = reinterpret(UInt32, str.data)
     len = sizeof(dat)


### PR DESCRIPTION
Simply change documentation strings in `utf16.jl` and `utf32.jl` to use triplequotes, since that capability has been added in the parser.
