### PR TITLE
Remove OVERLAP_SVEC_LEN

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -971,17 +971,10 @@ static Value *emit_typeof(Value *p)
     if (p->getType() == jl_pvalue_llvmt) {
         Value *tt = builder.CreateBitCast(p, jl_ppvalue_llvmt);
         tt = builder.CreateLoad(emit_typeptr_addr(tt), false);
-#ifdef OVERLAP_SVEC_LEN
-        tt = builder.CreateIntToPtr(builder.CreateAnd(
-                    builder.CreatePtrToInt(tt, T_int64),
-                    ConstantInt::get(T_int64,0x000ffffffffffffe)),
-                jl_pvalue_llvmt);
-#else
         tt = builder.CreateIntToPtr(builder.CreateAnd(
                     builder.CreatePtrToInt(tt, T_size),
                     ConstantInt::get(T_size,~(uptrint_t)3)),
                 jl_pvalue_llvmt);
-#endif
         return tt;
     }
     return literal_pointer_val(julia_type_of(p));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1705,11 +1705,7 @@ static Value *emit_lambda_closure(jl_value_t *expr, jl_codectx_t *ctx)
         jl_varinfo_t &vari = ctx->vars[s];
         if (vari.closureidx != -1) {
             int idx = vari.closureidx;
-#ifdef OVERLAP_SVEC_LEN
-            val = emit_nthptr((Value*)ctx->envArg, idx, tbaa_sveclen);
-#else
             val = emit_nthptr((Value*)ctx->envArg, idx+1, tbaa_sveclen);
-#endif
         }
         else {
             Value *l = vari.memvalue;
@@ -2807,17 +2803,9 @@ static Value *var_binding_pointer(jl_sym_t *s, jl_binding_t **pbnd,
         int idx = vi.closureidx;
         assert(((Value*)ctx->envArg)->getType() == jl_pvalue_llvmt);
         if (isBoxed(s, ctx)) {
-#ifdef OVERLAP_SVEC_LEN
-            return builder.CreatePointerCast(emit_nthptr((Value*)ctx->envArg, idx, tbaa_sveclen), jl_ppvalue_llvmt);
-#else
             return builder.CreatePointerCast(emit_nthptr((Value*)ctx->envArg, idx+1, tbaa_sveclen), jl_ppvalue_llvmt);
-#endif
         }
-#ifdef OVERLAP_SVEC_LEN
-        return emit_nthptr_addr((Value*)ctx->envArg, idx);
-#else
         return emit_nthptr_addr((Value*)ctx->envArg, idx+1);
-#endif
     }
     Value *l = vi.memvalue;
     if (l == NULL) return NULL;

--- a/src/julia.h
+++ b/src/julia.h
@@ -93,14 +93,6 @@ typedef struct {
         uintptr_t type_bits;
         struct {
             uintptr_t gc_bits:2;
-#ifdef OVERLAP_SVEC_LEN
-#ifdef _P64
-            uintptr_t unmarked:50;
-#else
-#error OVERLAP_SVEC_LEN requires 64-bit pointers
-#endif
-            uintptr_t length:12;
-#endif
         };
     };
     jl_value_t value;
@@ -133,9 +125,7 @@ typedef struct _jl_gensym_t {
 
 typedef struct {
     JL_DATA_TYPE
-#ifndef OVERLAP_SVEC_LEN
     size_t length;
-#endif
     jl_value_t *data[];
 } jl_svec_t;
 

--- a/src/options.h
+++ b/src/options.h
@@ -8,12 +8,6 @@
 
 // object layout options ------------------------------------------------------
 
-#ifdef _P64
-// a risky way to save 8 bytes per tuple, by storing the length in the
-// top bits of the type tag. only possible on 64-bit.
-//#define OVERLAP_TUPLE_LEN
-#endif
-
 // if this is not defined, only individual dimension sizes are
 // stored and not total length, to save space.
 #define STORE_ARRAY_LEN

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -22,11 +22,7 @@ DLLEXPORT jl_svec_t *jl_svec(size_t n, ...)
 
 jl_svec_t *jl_svec1(void *a)
 {
-#ifdef OVERLAP_SVEC_LEN
-    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_1w();
-#else
     jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_2w();
-#endif
     jl_set_typeof(v, jl_simplevector_type);
     jl_svec_set_len_unsafe(v, 1);
     jl_svecset(v, 0, a);
@@ -35,11 +31,7 @@ jl_svec_t *jl_svec1(void *a)
 
 jl_svec_t *jl_svec2(void *a, void *b)
 {
-#ifdef OVERLAP_SVEC_LEN
-    jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_2w();
-#else
     jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_3w();
-#endif
     jl_set_typeof(v, jl_simplevector_type);
     jl_svec_set_len_unsafe(v, 2);
     jl_svecset(v, 0, a);
@@ -50,11 +42,7 @@ jl_svec_t *jl_svec2(void *a, void *b)
 jl_svec_t *jl_alloc_svec_uninit(size_t n)
 {
     if (n == 0) return jl_emptysvec;
-#ifdef OVERLAP_TUPLE_LEN
-    jl_svec_t *jv = (jl_svec_t*)newobj((jl_value_t*)jl_simplevector_type, n);
-#else
     jl_svec_t *jv = (jl_svec_t*)newobj((jl_value_t*)jl_simplevector_type, n+1);
-#endif
     jl_svec_set_len_unsafe(jv, n);
     return jv;
 }


### PR DESCRIPTION
Apparently no one have ever tried it after #10380 because it has been [broken since then](https://github.com/JuliaLang/julia/commit/afd4eb038dcd9fa3e512509f4c332a9e7763ba59#diff-14033cdee5c961b2b50b8326f262067aR51).

I think we also don't need this risky saving anymore since we don't use `SimpleVector` all over the place anymore and only for certain internal stuff.
