### PR TITLE
Allow indexing SubArray with any AbstractVector

### DIFF
--- a/test/perf/array/indexing.jl
+++ b/test/perf/array/indexing.jl
@@ -169,6 +169,6 @@ function makearrays{T}(::Type{T}, sz)
     B = reshape(convert(Vector{T}, [1:prod(outersz);]), outersz)
     Asub = sub(B, 1:sz[1], 2:sz[2]+1)
     Bit = trues(sz)
-    (A, AS, AF, AS, ASS, AF, Asub, Bit,)
+    (A, AF, AS, ASS, Asub, Bit,)
 end
 

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -308,10 +308,9 @@ runviews{T}(SB::AbstractArray{T,0}, indexN, indexNN, indexNNN) = nothing
 testfull = Bool(parse(Int,(get(ENV, "JULIA_TESTFULL", "0"))))
 
 ### Views from Arrays ###
-
-index5 = (2, :, 2:5, 1:2:5, [4,1,5])  # all work with at least size 5
-index25 = (8, :, 2:11, 12:3:22, [4,1,5,9])
-index125 = (113, :, 85:121, 2:15:92, [99,14,103])
+index5 = (2, :, 2:5, 1:2:5, [4,1,5], sub(1:5,[2,1,5]))  # all work with at least size 5
+index25 = (8, :, 2:11, 12:3:22, [4,1,5,9], sub(1:25,[13,22,24]))
+index125 = (113, :, 85:121, 2:15:92, [99,14,103], sub(1:125,[66,18,59]))
 
 if testfull
     let A = reshape(1:5*7*11, 11, 7, 5)
@@ -347,7 +346,9 @@ if !testfull
                      (6,3:7,3:7),
                      (13:-2:1,:,:),
                      ([8,4,6,12,5,7],:,3:7),
-                     (6,6,[8,4,6,12,5,7]))
+                     (6,6,[8,4,6,12,5,7]),
+                     (1,:,sub(1:13,[9,12,4,13,1])),
+                     (sub(1:13,[9,12,4,13,1]),2:6,4))
             runtests(B, oind...)
             sliceB = slice(B, oind)
             runviews(sliceB, index5, index25, index125)


### PR DESCRIPTION
This was much simpler than I had feared it might.  Given that one of the aims of 0.5 is to always return SubArray views upon indexing, folks in 0.4 will likely start using `sub` and `slice` a whole lot more.  And they would likely run into the fact that they couldn't index a subarray by another subarray.  This fixes that.

One downside here is that since the full testsuite runs over exponential combinations of index types, this doubles the time required for `JULIA_TESTFULL=1 make -C test subarray` to 70 minutes on my wimpy laptop.

Cc @timholy 
