### PR TITLE
Enable operator-sensitive extension of element-type promotion

### DIFF
--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -57,8 +57,13 @@ promote_array_type{S<:Integer}(F, ::Type{S}, ::Type{Bool}) = S
 .^(X::AbstractArray, y::Number      ) =
     reshape([ x ^ y for x in X ], size(X))
 
-for f in (:+, :-, :div, :mod, :&, :|, :$)
-    F = GenericNFunc{f,2}()
+for (f,F) in ((:+,   AddFun()),
+              (:-,   SubFun()),
+              (:div, IDivFun()),
+              (:mod, ModFun()),
+              (:&,   AndFun()),
+              (:|,   OrFun()),
+              (:$,   XorFun()))
     @eval begin
         function ($f){S,T}(A::Range{S}, B::Range{T})
             F = similar(A, promote_op($F,S,T), promote_shape(size(A),size(B)))
@@ -96,8 +101,18 @@ for f in (:+, :-, :div, :mod, :&, :|, :$)
         end
     end
 end
-for f in (:.+, :.-, :.*, :.%, :.<<, :.>>, :div, :mod, :rem, :&, :|, :$)
-    F = GenericNFunc{f,2}()
+for (f,F) in ((:.+,  DotAddFun()),
+          (:.-,  DotSubFun()),
+          (:.*,  DotMulFun()),
+          (:.%,  DotRemFun()),
+          (:.<<, DotLSFun()),
+          (:.>>, DotRSFun()),
+          (:div, IDivFun()),
+          (:mod, ModFun()),
+          (:rem, RemFun()),
+          (:&,   AndFun()),
+          (:|,   OrFun()),
+          (:$,   XorFun()))
     @eval begin
         function ($f){T}(A::Number, B::AbstractArray{T})
             F = similar(B, promote_array_type($F,typeof(A),T))

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -38,10 +38,10 @@ end
 
 ## Binary arithmetic operators ##
 
-promote_array_type{Scalar, Arry}(::Type{Scalar}, ::Type{Arry}) = promote_type(Scalar, Arry)
-promote_array_type{S<:Real, A<:FloatingPoint}(::Type{S}, ::Type{A}) = A
-promote_array_type{S<:Integer, A<:Integer}(::Type{S}, ::Type{A}) = A
-promote_array_type{S<:Integer}(::Type{S}, ::Type{Bool}) = S
+promote_array_type{Scalar, Arry}(F, ::Type{Scalar}, ::Type{Arry}) = promote_op(F, Scalar, Arry)
+promote_array_type{S<:Real, A<:FloatingPoint}(F, ::Type{S}, ::Type{A}) = A
+promote_array_type{S<:Integer, A<:Integer}(F, ::Type{S}, ::Type{A}) = A
+promote_array_type{S<:Integer}(F, ::Type{S}, ::Type{Bool}) = S
 
 # Handle operations that return different types
 ./(x::Number, Y::AbstractArray) =
@@ -58,9 +58,10 @@ promote_array_type{S<:Integer}(::Type{S}, ::Type{Bool}) = S
     reshape([ x ^ y for x in X ], size(X))
 
 for f in (:+, :-, :div, :mod, :&, :|, :$)
+    F = GenericNFunc{f,2}()
     @eval begin
         function ($f){S,T}(A::Range{S}, B::Range{T})
-            F = similar(A, promote_type(S,T), promote_shape(size(A),size(B)))
+            F = similar(A, promote_op($F,S,T), promote_shape(size(A),size(B)))
             i = 1
             for (a,b) in zip(A,B)
                 @inbounds F[i] = ($f)(a, b)
@@ -69,7 +70,7 @@ for f in (:+, :-, :div, :mod, :&, :|, :$)
             return F
         end
         function ($f){S,T}(A::AbstractArray{S}, B::Range{T})
-            F = similar(A, promote_type(S,T), promote_shape(size(A),size(B)))
+            F = similar(A, promote_op($F,S,T), promote_shape(size(A),size(B)))
             i = 1
             for b in B
                 @inbounds F[i] = ($f)(A[i], b)
@@ -78,7 +79,7 @@ for f in (:+, :-, :div, :mod, :&, :|, :$)
             return F
         end
         function ($f){S,T}(A::Range{S}, B::AbstractArray{T})
-            F = similar(B, promote_type(S,T), promote_shape(size(A),size(B)))
+            F = similar(B, promote_op($F,S,T), promote_shape(size(A),size(B)))
             i = 1
             for a in A
                 @inbounds F[i] = ($f)(a, B[i])
@@ -87,7 +88,7 @@ for f in (:+, :-, :div, :mod, :&, :|, :$)
             return F
         end
         function ($f){S,T}(A::AbstractArray{S}, B::AbstractArray{T})
-            F = similar(A, promote_type(S,T), promote_shape(size(A),size(B)))
+            F = similar(A, promote_op($F,S,T), promote_shape(size(A),size(B)))
             for i in eachindex(A,B)
                 @inbounds F[i] = ($f)(A[i], B[i])
             end
@@ -96,16 +97,17 @@ for f in (:+, :-, :div, :mod, :&, :|, :$)
     end
 end
 for f in (:.+, :.-, :.*, :.%, :.<<, :.>>, :div, :mod, :rem, :&, :|, :$)
+    F = GenericNFunc{f,2}()
     @eval begin
         function ($f){T}(A::Number, B::AbstractArray{T})
-            F = similar(B, promote_array_type(typeof(A),T))
+            F = similar(B, promote_array_type($F,typeof(A),T))
             for i in eachindex(B)
                 @inbounds F[i] = ($f)(A, B[i])
             end
             return F
         end
         function ($f){T}(A::AbstractArray{T}, B::Number)
-            F = similar(A, promote_array_type(typeof(B),T))
+            F = similar(A, promote_array_type($F,typeof(B),T))
             for i in eachindex(A)
                 @inbounds F[i] = ($f)(A[i], B)
             end

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -855,12 +855,12 @@ for f in (:+, :-)
         return r
     end
 end
-for f in (:.+, :.-)
-    fq = Expr(:quote, f)
+for (f,F) in ((:.+, DotAddFun()),
+              (:.-, DotSubFun()))
     for (arg1, arg2, T, fargs) in ((:(B::BitArray), :(x::Bool)    , Int                                   , :(b, x)),
-                                   (:(B::BitArray), :(x::Number)  , :(promote_array_type(GenericNFunc{$fq,2}(),typeof(x), Bool)), :(b, x)),
+                                   (:(B::BitArray), :(x::Number)  , :(promote_array_type($F, typeof(x), Bool)), :(b, x)),
                                    (:(x::Bool)    , :(B::BitArray), Int                                   , :(x, b)),
-                                   (:(x::Number)  , :(B::BitArray), :(promote_array_type(GenericNFunc{$fq,2}(),typeof(x), Bool)), :(x, b)))
+                                   (:(x::Number)  , :(B::BitArray), :(promote_array_type($F, typeof(x), Bool)), :(x, b)))
         @eval function ($f)($arg1, $arg2)
             r = Array($T, size(B))
             bi = start(B)
@@ -899,7 +899,7 @@ function div(x::Bool, B::BitArray)
 end
 function div(x::Number, B::BitArray)
     all(B) || throw(DivideError())
-    pt = promote_array_type(GenericNFunc{:div,2}(),typeof(x), Bool)
+    pt = promote_array_type(IDivFun(), typeof(x), Bool)
     y = div(x, true)
     reshape(pt[ y for i = 1:length(B) ], size(B))
 end
@@ -920,13 +920,13 @@ function mod(x::Bool, B::BitArray)
 end
 function mod(x::Number, B::BitArray)
     all(B) || throw(DivideError())
-    pt = promote_array_type(GenericNFunc{:mod,2}(), typeof(x), Bool)
+    pt = promote_array_type(ModFun(), typeof(x), Bool)
     y = mod(x, true)
     reshape(pt[ y for i = 1:length(B) ], size(B))
 end
 
-for f in (:div, :mod)
-    F = GenericNFunc{f,2}()
+for (f,F) in ((:div, IDivFun()),
+              (:mod, ModFun()))
     @eval begin
         function ($f)(B::BitArray, x::Number)
             F = Array(promote_array_type($F, typeof(x), Bool), size(B))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -747,7 +747,7 @@ big{T<:FloatingPoint,N}(A::AbstractArray{Complex{T},N}) = convert(AbstractArray{
 
 ## promotion to complex ##
 
-promote_array_type{S<:Union{Complex, Real}, AT<:FloatingPoint}(::Type{S}, ::Type{Complex{AT}}) = Complex{AT}
+promote_array_type{S<:Union{Complex, Real}, AT<:FloatingPoint}(F, ::Type{S}, ::Type{Complex{AT}}) = Complex{AT}
 
 function complex{S<:Real,T<:Real}(A::Array{S}, B::Array{T})
     if size(A) != size(B); throw(DimensionMismatch()); end

--- a/base/functors.jl
+++ b/base/functors.jl
@@ -67,6 +67,11 @@ call(::LessFun, x, y) = x < y
 immutable MoreFun <: Func{2} end
 call(::MoreFun, x, y) = x > y
 
+immutable GenericNFunc{F,N} <: Func{N} end
+@generated function call{F}(::GenericNFunc{F,2}, x, y)
+    :($F(x, y))
+end
+
 # a fallback unspecialized function object that allows code using
 # function objects to not care whether they were able to specialize on
 # the function value or not

--- a/base/functors.jl
+++ b/base/functors.jl
@@ -34,14 +34,26 @@ call(::AndFun, x, y) = x & y
 immutable OrFun <: Func{2} end
 call(::OrFun, x, y) = x | y
 
+immutable XorFun <: Func{2} end
+call(::XorFun, x, y) = x $ y
+
 immutable AddFun <: Func{2} end
 call(::AddFun, x, y) = x + y
+
+immutable DotAddFun <: Func{2} end
+call(::DotAddFun, x, y) = x .+ y
 
 immutable SubFun <: Func{2} end
 call(::SubFun, x, y) = x - y
 
+immutable DotSubFun <: Func{2} end
+call(::DotSubFun, x, y) = x .- y
+
 immutable MulFun <: Func{2} end
 call(::MulFun, x, y) = x * y
+
+immutable DotMulFun <: Func{2} end
+call(::DotMulFun, x, y) = x .* y
 
 immutable RDivFun <: Func{2} end
 call(::RDivFun, x, y) = x / y
@@ -51,6 +63,15 @@ call(::LDivFun, x, y) = x \ y
 
 immutable IDivFun <: Func{2} end
 call(::IDivFun, x, y) = div(x, y)
+
+immutable ModFun <: Func{2} end
+call(::ModFun, x, y) = mod(x, y)
+
+immutable RemFun <: Func{2} end
+call(::RemFun, x, y) = rem(x, y)
+
+immutable DotRemFun <: Func{2} end
+call(::RemFun, x, y) = x .% y
 
 immutable PowFun <: Func{2} end
 call(::PowFun, x, y) = x ^ y
@@ -67,10 +88,11 @@ call(::LessFun, x, y) = x < y
 immutable MoreFun <: Func{2} end
 call(::MoreFun, x, y) = x > y
 
-immutable GenericNFunc{F,N} <: Func{N} end
-@generated function call{F}(::GenericNFunc{F,2}, x, y)
-    :($F(x, y))
-end
+immutable DotLSFun <: Func{2} end
+call(::DotLSFun, x, y) = x .<< y
+
+immutable DotRSFun <: Func{2} end
+call(::DotRSFun, x, y) = x .>> y
 
 # a fallback unspecialized function object that allows code using
 # function objects to not care whether they were able to specialize on

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -199,6 +199,13 @@ checked_add(x::Integer, y::Integer) = checked_add(promote(x,y)...)
 checked_sub(x::Integer, y::Integer) = checked_sub(promote(x,y)...)
 checked_mul(x::Integer, y::Integer) = checked_mul(promote(x,y)...)
 
+@generated function promote_op{R,S}(F, ::Type{R}, ::Type{S})
+    ret = Base.return_types(F(), Tuple{R,S})
+    length(ret) == 1 || error("Strange result from Base.return_types: ", ret)
+    T = ret[1]
+    :($T)
+end
+
 ## catch-alls to prevent infinite recursion when definitions are missing ##
 
 no_op_err(name, T) = error(name," not defined for ",T)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -199,12 +199,11 @@ checked_add(x::Integer, y::Integer) = checked_add(promote(x,y)...)
 checked_sub(x::Integer, y::Integer) = checked_sub(promote(x,y)...)
 checked_mul(x::Integer, y::Integer) = checked_mul(promote(x,y)...)
 
-@generated function promote_op{R,S}(F, ::Type{R}, ::Type{S})
-    ret = Base.return_types(F(), Tuple{R,S})
-    length(ret) == 1 || error("Strange result from Base.return_types: ", ret)
-    T = ret[1]
-    :($T)
-end
+# "Promotion" that takes a Functor into account. You can override this
+# as needed. For example, if you need to provide a custom result type
+# for the multiplication of two types,
+#   promote_op{R<:MyType,S<:MyType}(::GenericNFunc{:*,2}, ::Type{R}, ::Type{S}) = MyType{multype(R,S)}
+promote_op{R,S}(::Any, ::Type{R}, ::Type{S}) = promote_type(R, S)
 
 ## catch-alls to prevent infinite recursion when definitions are missing ##
 

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -202,7 +202,7 @@ checked_mul(x::Integer, y::Integer) = checked_mul(promote(x,y)...)
 # "Promotion" that takes a Functor into account. You can override this
 # as needed. For example, if you need to provide a custom result type
 # for the multiplication of two types,
-#   promote_op{R<:MyType,S<:MyType}(::GenericNFunc{:*,2}, ::Type{R}, ::Type{S}) = MyType{multype(R,S)}
+#   promote_op{R<:MyType,S<:MyType}(::MulFun, ::Type{R}, ::Type{S}) = MyType{multype(R,S)}
 promote_op{R,S}(::Any, ::Type{R}, ::Type{S}) = promote_type(R, S)
 
 ## catch-alls to prevent infinite recursion when definitions are missing ##

--- a/doc/devdocs/promote-op.rst
+++ b/doc/devdocs/promote-op.rst
@@ -1,0 +1,34 @@
+.. currentmodule:: Base
+
+.. _devdocs-promote-op:
+
+Operator-sensitive promotion
+============================
+
+In certain cases, the :ref:`simple rules for promotion
+<man-promotion-rules>` may not be sufficient. For example, consider a
+type that can represent an object with physical units, here restricted
+to a single unit like "meter"::
+
+    immutable MeterUnits{T,P} <: Number
+        val::T
+    end
+    MeterUnits{T}(val::T, pow::Int) = MeterUnits{T,pow}(val)
+
+    m  = MeterUnits(1.0, 1)   # 1.0 meter, i.e. units of length
+    m2 = MeterUnits(1.0, 2)   # 1.0 meter^2, i.e. units of area
+
+Now let's define the operations ``+`` and ``*`` for these objects:
+``m+m`` should have the type of ``m`` but ``m*m`` should have the type
+of ``m2``.  When the result type depends on the operation, and not
+just the input types, ``promote_rule`` will be inadequate.
+
+Fortunately, it's possible to provide such definitions via ``promote_op``::
+
+    Base.promote_op{R,S}(::Base.GenericNFunc{:+,2}, ::Type{MeterUnits{R,1}}, ::Type{MeterUnits{S,1}}) = MeterUnits{promote_type(R,S),1}
+    Base.promote_op{R,S}(::Base.GenericNFunc{:*,2}, ::Type{MeterUnits{R,1}}, ::Type{MeterUnits{S,1}}) = MeterUnits{promote_type(R,S),2}
+    Base.promote_op{R,S}(::Base.GenericNFunc{:.*,2}, ::Type{MeterUnits{R,1}}, ::Type{MeterUnits{S,1}}) = MeterUnits{promote_type(R,S),2}
+
+The first one defines the promotion rule for ``+``, and the second one
+for ``*``.  A ``GenericNFunc`` is a `functor <https://github.com/JuliaLang/julia/blob/master/base/functors.jl>`_;
+the second parameter ``2`` means that it takes two arguments.

--- a/doc/devdocs/promote-op.rst
+++ b/doc/devdocs/promote-op.rst
@@ -25,10 +25,14 @@ just the input types, ``promote_rule`` will be inadequate.
 
 Fortunately, it's possible to provide such definitions via ``promote_op``::
 
-    Base.promote_op{R,S}(::Base.GenericNFunc{:+,2}, ::Type{MeterUnits{R,1}}, ::Type{MeterUnits{S,1}}) = MeterUnits{promote_type(R,S),1}
-    Base.promote_op{R,S}(::Base.GenericNFunc{:*,2}, ::Type{MeterUnits{R,1}}, ::Type{MeterUnits{S,1}}) = MeterUnits{promote_type(R,S),2}
-    Base.promote_op{R,S}(::Base.GenericNFunc{:.*,2}, ::Type{MeterUnits{R,1}}, ::Type{MeterUnits{S,1}}) = MeterUnits{promote_type(R,S),2}
+    Base.promote_op{R,S}(::Base.AddFun, ::Type{MeterUnits{R,1}}, ::Type{MeterUnits{S,1}}) = MeterUnits{promote_type(R,S),1}
+    Base.promote_op{R,S}(::Base.MulFun, ::Type{MeterUnits{R,1}}, ::Type{MeterUnits{S,1}}) = MeterUnits{promote_type(R,S),2}
+    Base.promote_op{R,S}(::Base.DotMulFun, ::Type{MeterUnits{R,1}}, ::Type{MeterUnits{S,1}}) = MeterUnits{promote_type(R,S),2}
 
 The first one defines the promotion rule for ``+``, and the second one
-for ``*``.  A ``GenericNFunc`` is a `functor <https://github.com/JuliaLang/julia/blob/master/base/functors.jl>`_;
-the second parameter ``2`` means that it takes two arguments.
+for ``*``.  ``AddFun``, ``MulFun``, and ``DotMulFun`` are "functor
+types" defined in `functor.jl
+<https://github.com/JuliaLang/julia/blob/master/base/functors.jl>`_.
+
+It's worth noting that as julia's internal representation of functions
+evolves, this interface may change in a future version of Julia.

--- a/doc/manual/conversion-and-promotion.rst
+++ b/doc/manual/conversion-and-promotion.rst
@@ -276,6 +276,9 @@ the the catch-all method definitions given in
     *(x::Number, y::Number) = *(promote(x,y)...)
     /(x::Number, y::Number) = /(promote(x,y)...)
 
+In certain cases, the result type also depends on the operator; how to
+handle such scenarios is described :ref:`elsewhere <devdocs-promote-op>`.
+
 These method definitions say that in the absence of more specific rules
 for adding, subtracting, multiplying and dividing pairs of numeric
 values, promote the values to a common type and then try again. That's
@@ -308,6 +311,8 @@ For most user-defined types, it is better practice to require
 programmers to supply the expected types to constructor functions
 explicitly, but sometimes, especially for numeric problems, it can be
 convenient to do promotion automatically.
+
+.. _man-promotion-rules:
 
 Defining Promotion Rules
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This fixes the long-standing #8027, providing much better generic fallbacks for elementwise operations involving arrays and array/scalar operations. The proximal motivation for tackling this was to fix the ambiguity warnings triggered by #12115, but this will also (given suitable type-stability improvements to SIUnits) finally allow `eltype([1Meter]+1Meter) == typeof(1Meter)` and `eltype([1Meter]*(1Meter)) == typeof(1Meter^2)`. In some ways this turns out to be the (much easier) companion of #10525, defining operations that involve arrays in terms of operations defined for scalars. I think it will allow cleanup of a certain amount of torturous code.

I had forgotten why we had `promote_array_type`; to save any reviewers the trouble, it turns out to be because we've decided that `eltype([1.0f0]+1.0) == Float32` (i.e., the eltype of the Array wins, when working with `Real` numbers). This rule obviously doesn't work for more generic types, but the exception does make sense so I've kept it.

If this meets with approval, I'll see about applying it to #12115.
