### PR TITLE
Reserve 4 bits for GC and clean up write barrier functions.

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -973,7 +973,7 @@ static Value *emit_typeof(Value *p)
         tt = builder.CreateLoad(emit_typeptr_addr(tt), false);
         tt = builder.CreateIntToPtr(builder.CreateAnd(
                     builder.CreatePtrToInt(tt, T_size),
-                    ConstantInt::get(T_size,~(uptrint_t)3)),
+                    ConstantInt::get(T_size,~(uptrint_t)15)),
                 jl_pvalue_llvmt);
         return tt;
     }

--- a/src/gc.c
+++ b/src/gc.c
@@ -74,7 +74,7 @@ typedef struct _buff_t {
         uintptr_t header;
         struct _buff_t *next;
         uptrint_t flags;
-        jl_value_t *type;
+        jl_value_t *type; // 16-bytes aligned
         struct {
             uintptr_t gc_bits:2;
             uintptr_t pooled:1;


### PR DESCRIPTION
1. Changes the mask for gc bits **in the tag** from 2 bits to 4 bits, leaving two more bits for the GC to use.
   
   Edit: This relies on what the tag **points to** is 16 bytes aligned, the address of the tag doesn't need to be aligned.
   
   Our allocation for any object bigger than 4 bytes on 32bit or non-singleton on 64bit (i.e. all types) is 16 bytes aligned. Since we already suffer a little bit dealing with this in the GC, we might as well take advantage of it.
2. Clean up the write barrier function.
   
   This should make the logic more clear and make it easier to move the GC bits around.

cc. @carnaval 
