### PR TITLE
fix #12241, running tests from outside test/

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,8 @@
 
 include("choosetests.jl")
 tests, net_on = choosetests(ARGS)
-let n = 1
+cd(dirname(@__FILE__)) do
+    n = 1
     if net_on
         n = min(8, CPU_CORES, length(tests))
         n > 1 && addprocs(n; exeflags=`--check-bounds=yes --depwarn=error`)
@@ -11,7 +12,7 @@ let n = 1
 
     @everywhere include("testdefs.jl")
 
-    reduce(propagate_errors, nothing, pmap(test->runtests(test), tests; err_retry=false, err_stop=true))
+    reduce(propagate_errors, nothing, pmap(runtests, tests; err_retry=false, err_stop=true))
 
     @unix_only n > 1 && rmprocs(workers(), waitfor=5.0)
     println("    \033[32;1mSUCCESS\033[0m")


### PR DESCRIPTION
put back `cd` that was removed in #8745
