### PR TITLE
Don't bail out in the binary-dist target, if openblas is not compiled with dynamic arch support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,9 +386,11 @@ dist:
 
 binary-dist: distclean
 ifeq ($(USE_SYSTEM_BLAS),0)
+ifeq ($(ISX86),1)
 ifneq ($(OPENBLAS_DYNAMIC_ARCH),1)
 	@echo OpenBLAS must be rebuilt with OPENBLAS_DYNAMIC_ARCH=1 to use binary-dist target
 	@false
+endif
 endif
 endif
 ifneq ($(prefix),$(abspath julia-$(JULIA_COMMIT)))


### PR DESCRIPTION
This is not available on ARM, and in any case, it seems ok to
just print a warning.
