### PR TITLE
Change windows file description property of julia.exe

### DIFF
--- a/contrib/windows/julia.rc
+++ b/contrib/windows/julia.rc
@@ -14,7 +14,7 @@ BEGIN
     BLOCK "040904E4"
     BEGIN
       VALUE "CompanyName", "JuliaLang"
-      VALUE "FileDescription", "The Julia Programming Language"
+      VALUE "FileDescription", "Julia Programming Language"
       VALUE "FileVersion", JLVER_STR
       VALUE "InternalName", "julia"
       VALUE "LegalCopyright", "MIT Licensed"


### PR DESCRIPTION
The file description property is used in Task Manager as the main App name. No other windows software I know of starts with a "The" in Task Manager. This PR is mainly to make it easier to find the julia process in Task Manager, i.e. people will sort by name and then the process should show up starting with the "julia" term.

@tkelman 
