### PR TITLE
Fixed handling of backslash literal in substitution string

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -246,7 +246,7 @@ function _replace(io, repl_s::SubstitutionString, str, r, re)
             next_i = nextind(repl, i)
             next_i > e && replace_err(repl)
             if repl[next_i] == SUB_CHAR
-                write(io, SUB_CHAR, repl[next_i])
+                write(io, SUB_CHAR)
                 i = nextind(repl, next_i)
             elseif isnumber(repl[next_i])
                 group = parse(Int, repl[next_i])

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -45,5 +45,5 @@ let m = match(r"(?<a>.)(.)(?<b>.)", "xyz")
 end
 
 # Backcapture reference in substitution string
-@test replace("abcde", r"(..)(?P<byname>d)", s"\g<byname>xy\1") == "adxybce"
+@test replace("abcde", r"(..)(?P<byname>d)", s"\g<byname>xy\\\1") == "adxy\\bce"
 @test_throws ErrorException replace("a", r"(?P<x>)", s"\g<y>")


### PR DESCRIPTION
Before, `replace("", r"", s"\\")` was incorrectly returning`"\\\\"` (two backslashes) instead of `"\\"` (one backslash). 
