### PR TITLE
Let workspace() call load_juliarc()

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -386,7 +386,7 @@ function workspace()
               :(const Base = $(Expr(:quote, b))),
               :(const LastMain = $(Expr(:quote, last)))))
     empty!(package_locks)
-    load_juliarc()
+    JLOptions().startupfile != 2 && load_juliarc()
     nothing
 end
 

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -386,6 +386,7 @@ function workspace()
               :(const Base = $(Expr(:quote, b))),
               :(const LastMain = $(Expr(:quote, last)))))
     empty!(package_locks)
+    load_juliarc()
     nothing
 end
 


### PR DESCRIPTION
When exploring some possibilities to optimize my workflow (see [this thread on julia-users](https://groups.google.com/forum/#!topic/julia-users/XuF9wxeXsZE)) I ran into problems because `~/.juliarc.jl` wasn't loaded when I ran `workspace()`. This PR mitigates that.

If there is a reason not to do this, it's no big deal for me - I can always do `workspace(); Base.load_juliarc()` manually - but I think it feels both intuitive and useful that the startup script is run in every workspace, and not just the first in each session.
