### PR TITLE
WIP/RFC: stack scrubbing

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -1,5 +1,30 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
 
+// Find the memory block in the pool that owns the byte pointed to by p.
+// For end of object pointer (which is always the case for pointer to a
+// singleton object), this usually returns the same pointer which points to
+// the next object but it can also return NULL if the pointer is pointing to
+// the end of the page.
+DLLEXPORT jl_taggedvalue_t *jl_gc_find_taggedvalue_pool(char *p,
+                                                        size_t *osize_p)
+{
+    region_t *r = find_region(p, 1);
+    if (!r)
+        return NULL;
+    char *page_begin = GC_PAGE_DATA(p) + GC_PAGE_OFFSET;
+    if (p < page_begin)
+        return NULL;
+    size_t ofs = p - page_begin;
+    int pg_idx = PAGE_INDEX(r, p);
+    gcpage_t *pagemeta = &r->meta[pg_idx];
+    int osize = pagemeta->osize;
+    if (osize == 0)
+        return NULL;
+    if (osize_p)
+        *osize_p = osize;
+    return (jl_taggedvalue_t*)((char*)p - (ofs % osize));
+}
+
 #ifdef GC_DEBUG_ENV
 #include <inttypes.h>
 #include <stdio.h>

--- a/src/gc.c
+++ b/src/gc.c
@@ -260,9 +260,19 @@ static gcpage_t *page_metadata(void *data);
 static void pre_mark(void);
 static void post_mark(arraylist_t *list, int dryrun);
 static region_t *find_region(void *ptr, int maybe);
+jl_taggedvalue_t *jl_gc_find_taggedvalue_pool(char *p, size_t *osize_p);
+
 #define PAGE_INDEX(region, data)              \
     ((GC_PAGE_DATA((data) - GC_PAGE_OFFSET) - \
       &(region)->pages[0][0])/GC_PAGE_SZ)
+
+NOINLINE static uintptr_t gc_get_stack_ptr()
+{
+    void *dummy = NULL;
+    // The mask is to suppress the compiler warning about returning
+    // address of local variable
+    return (uintptr_t)&dummy & ~(uintptr_t)15;
+}
 
 #include "gc-debug.c"
 
@@ -1975,6 +1985,7 @@ void jl_gc_collect(int full)
 {
     if (!is_gc_enabled) return;
     if (jl_in_gc) return;
+    char *stack_hi = (char*)gc_get_stack_ptr();
     gc_debug_print();
     JL_SIGATOMIC_BEGIN();
     jl_in_gc = 1;
@@ -2076,6 +2087,7 @@ void jl_gc_collect(int full)
 #endif
             estimate_freed = live_bytes - scanned_bytes - perm_scanned_bytes + actual_allocd;
 
+            gc_scrub(stack_hi);
             gc_verify();
 
 #if defined(MEMPROFILE)


### PR DESCRIPTION
This is a rewrite of @carnaval 's previous work in #10725. The main differences are,
1. (As suggested by Oscar) Instead of messing with stack data, we fill the dead object that might be referenced by the stack with garbage (`0xff` ATM) so that we won't have any data corruption.
2. Split out the logic for conservative pool scan (i.e. figure out if a pointer might be refering a GC object in the pool)
   
   This function is useful for a number of other things including conservative stack scan (either for GC root #11714, or for pinning https://github.com/JuliaLang/julia/issues/11714#issuecomment-112153682), ccall sanitizer https://github.com/JuliaLang/julia/issues/12173 and gc debugging in general.
