### PR TITLE
add functors SubFun, DivFun, and PowFun

### DIFF
--- a/base/functors.jl
+++ b/base/functors.jl
@@ -37,8 +37,17 @@ call(::OrFun, x, y) = x | y
 immutable AddFun <: Func{2} end
 call(::AddFun, x, y) = x + y
 
+immutable SubFun <: Func{2} end
+call(::SubFun, x, y) = x - y
+
 immutable MulFun <: Func{2} end
 call(::MulFun, x, y) = x * y
+
+immutable DivFun <: Func{2} end
+call(::DivFun, x, y) = x / y
+
+immutable PowFun <: Func{2} end
+call(::PowFun, x, y) = x ^ y
 
 immutable MaxFun <: Func{2} end
 call(::MaxFun, x, y) = scalarmax(x,y)
@@ -121,7 +130,10 @@ function specialized_unary(f::Function)
 end
 function specialized_binary(f::Function)
     is(f, +) ? AddFun() :
+    is(f, -) ? SubFun() :
     is(f, *) ? MulFun() :
+    is(f, /) ? DivFun() :
+    is(f, ^) ? PowFun() :
     is(f, &) ? AndFun() :
     is(f, |) ? OrFun()  :
     UnspecializedFun{2}(f)

--- a/base/functors.jl
+++ b/base/functors.jl
@@ -43,8 +43,14 @@ call(::SubFun, x, y) = x - y
 immutable MulFun <: Func{2} end
 call(::MulFun, x, y) = x * y
 
-immutable DivFun <: Func{2} end
-call(::DivFun, x, y) = x / y
+immutable RDivFun <: Func{2} end
+call(::RDivFun, x, y) = x / y
+
+immutable LDivFun <: Func{2} end
+call(::LDivFun, x, y) = x \ y
+
+immutable IDivFun <: Func{2} end
+call(::IDivFun, x, y) = div(x, y)
 
 immutable PowFun <: Func{2} end
 call(::PowFun, x, y) = x ^ y
@@ -132,10 +138,12 @@ function specialized_binary(f::Function)
     is(f, +) ? AddFun() :
     is(f, -) ? SubFun() :
     is(f, *) ? MulFun() :
-    is(f, /) ? DivFun() :
+    is(f, /) ? RDivFun() :
+    is(f, \) ? LDivFun() :
     is(f, ^) ? PowFun() :
     is(f, &) ? AndFun() :
     is(f, |) ? OrFun()  :
+    is(f, div) ? IDivFun() :
     UnspecializedFun{2}(f)
 end
 

--- a/test/functors.jl
+++ b/test/functors.jl
@@ -6,7 +6,7 @@ for op in (identity, abs, abs2, exp, log)
     @test Base.specialized_unary(op)(3) == Base.specialized_unary(x->op(x))(3) == op(3)
     @test Base.specialized_unary(op)(-5+im) == Base.specialized_unary(x->op(x))(-5+im) == op(-5+im)
 end
-for op in (+, *, &, |)
+for op in (+, -, *, /, ^, &, |)
     @test Base.specialized_binary(op)(2,10) == Base.specialized_binary((x,y)->op(x,y))(2,10) == op(2,10)
 end
 

--- a/test/functors.jl
+++ b/test/functors.jl
@@ -6,7 +6,7 @@ for op in (identity, abs, abs2, exp, log)
     @test Base.specialized_unary(op)(3) == Base.specialized_unary(x->op(x))(3) == op(3)
     @test Base.specialized_unary(op)(-5+im) == Base.specialized_unary(x->op(x))(-5+im) == op(-5+im)
 end
-for op in (+, -, *, /, ^, &, |)
+for op in (+, -, *, /, \, div, ^, &, |)
     @test Base.specialized_binary(op)(2,10) == Base.specialized_binary((x,y)->op(x,y))(2,10) == op(2,10)
 end
 


### PR DESCRIPTION
Several basic functors (subtraction, division, and power) are currently missing (which should be an oversight). This PR adds them.

These functors will be useful in the Sparse module. Since this is a very quick-fix, I make a quick PR for this, instead of putting these small changes to the SparseVector PR (which might take a relatively long time to get merged).
