### PR TITLE
Improve build with sanitizer enabled.

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -397,6 +397,10 @@ ifeq (exists, $(shell [ -e $(JULIAHOME)/Make.user ] && echo exists ))
 include $(JULIAHOME)/Make.user
 endif
 
+# Special case fortran LDFLAGS, because they generally might be quite different
+# if C/C++ are built with Clang
+FORTRAN_LDFLAGS := $(LDFLAGS)
+
 ifeq ($(SANITIZE),1)
 ifeq ($(SANITIZE_MEMORY),1)
 SANITIZE_OPTS = -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer
@@ -837,10 +841,11 @@ endif
 
 # Custom libcxx
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
-LDFLAGS += -L$(build_libdir) -lc++abi
 CXXLDFLAGS += -L$(build_libdir) -lc++abi -stdlib=libc++ -lc++
 CPPFLAGS += -I$(build_includedir)/c++/v1
+ifeq ($(OS), Linux)
 CUSTOM_LD_LIBRARY_PATH = LD_LIBRARY_PATH="$(build_libdir)"
+endif # Linux
 ifeq ($(USEICC),1)
 CXXFLAGS += -cxxlib-nostd -static-intel
 CLDFLAGS += -static-intel

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -24,7 +24,7 @@ include $(JULIAHOME)/Make.inc
 
 ## Some shared configuration options ##
 
-CONFIGURE_COMMON = --prefix=$(abspath $(build_prefix)) --build=$(BUILD_MACHINE) --libdir=$(abspath $(build_libdir)) $(CUSTOM_LD_LIBRARY_PATH)
+CONFIGURE_COMMON = --prefix=$(abspath $(build_prefix)) --build=$(BUILD_MACHINE) --libdir=$(abspath $(build_libdir))
 ifneq ($(XC_HOST),)
 CONFIGURE_COMMON += --host=$(XC_HOST)
 endif
@@ -33,7 +33,7 @@ ifneq ($(USEMSVC), 1)
 CONFIGURE_COMMON += LDFLAGS="$(LDFLAGS) -Wl,--stack,8388608"
 endif
 endif
-CONFIGURE_COMMON += F77="$(FC)" CC="$(CC) $(DEPS_CFLAGS)" CXX="$(CXX) $(DEPS_CXXFLAGS)"
+CONFIGURE_COMMON += F77="$(FC)" CC="$(CC) $(DEPS_CFLAGS)" CXX="$(CXX) $(DEPS_CXXFLAGS) $(CXXLDFLAGS)" CPPFLAGS="$(CPPFLAGS)"
 
 CMAKE_CC_ARG = $(CC_ARG) $(DEPS_CFLAGS)
 CMAKE_CXX_ARG = $(CXX_ARG) $(DEPS_CXXFLAGS)
@@ -99,7 +99,8 @@ endif
 ifeq ($(OS), Linux)
 ifeq ($(USE_SYSTEM_PATCHELF), 0)
 STAGE1_DEPS += patchelf
-PATCHELF=$(build_bindir)/patchelf
+PATCHELF_TARGET=$(build_bindir)/patchelf
+PATCHELF=$(CUSTOM_LD_LIBRARY_PATH) $(PATCHELF_TARGET)
 else
 PATCHELF=patchelf
 endif
@@ -439,7 +440,7 @@ endif # LLVM_CXXFLAGS
 LLVM_MFLAGS += $(LLVM_CC)
 
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
-LLVM_LDFLAGS += -Wl,-R$(build_libdir) -lc++ -lc++abi
+LLVM_LDFLAGS += -Wl,-R$(build_libdir) $(CXXLDFLAGS)
 ifeq ($(USEICC),1)
 LLVM_LDFLAGS += -no_cpprt
 endif # USEICC
@@ -1281,7 +1282,7 @@ ARPACK_MFLAGS = F77="$(FC)" MPIF77="$(FC)"
 ARPACK_FFLAGS += $(FFLAGS) $(JFFLAGS)
 ARPACK_FLAGS = --with-blas="$(LIBBLAS)" --with-lapack="$(LIBLAPACK)" --disable-mpi --enable-shared FFLAGS="$(ARPACK_FFLAGS)" CFLAGS="$(CFLAGS) $(ARPACK_CFLAGS)"
 ifneq ($(OS),WINNT)
-ARPACK_FLAGS += LDFLAGS="$(LDFLAGS) -Wl,-rpath,'$(build_libdir)'"
+ARPACK_FLAGS += LDFLAGS="$(FORTRAN_LDFLAGS) -Wl,-rpath,'$(build_libdir)'"
 endif
 
 # ARPACK-NG upstream keeps changing their download filenames
@@ -1329,7 +1330,7 @@ ifeq ($(OS), Linux)
 endif
 	touch -c $@
 ifneq ($(PATCHELF),patchelf)
-$(ARPACK_OBJ_TARGET): $(PATCHELF)
+$(ARPACK_OBJ_TARGET): $(PATCHELF_TARGET)
 endif
 
 clean-arpack:
@@ -1442,8 +1443,8 @@ endif
 	touch -c $@
 
 ifneq ($(PATCHELF),patchelf)
-$(FFTW_DOUBLE_OBJ_TARGET): $(PATCHELF)
-$(FFTW_SINGLE_OBJ_TARGET): $(PATCHELF)
+$(FFTW_DOUBLE_OBJ_TARGET): $(PATCHELF_TARGET)
+$(FFTW_SINGLE_OBJ_TARGET): $(PATCHELF_TARGET)
 endif
 
 clean-fftw: clean-fftw-single clean-fftw-double
@@ -1644,6 +1645,7 @@ libunwind-$(UNWIND_VER)/configure: libunwind-$(UNWIND_VER).tar.gz
 	$(JLCHECKSUM) $<
 	$(TAR) xfz $<
 	cd libunwind-$(UNWIND_VER) && patch -p1 < ../libunwind.patch
+	cd libunwind-$(UNWIND_VER) && patch -p1 < ../libunwind-sanitizer.patch
 	touch -c $@
 libunwind-$(UNWIND_VER)/config.status: libunwind-$(UNWIND_VER)/configure
 	cd libunwind-$(UNWIND_VER) && \

--- a/deps/libunwind-sanitizer.patch
+++ b/deps/libunwind-sanitizer.patch
@@ -1,0 +1,63 @@
+diff -r '--exclude=*.o' '--exclude=Makefile' '--exclude=*.m4' '--exclude=configure' '--exclude=tests' '--exclude=*.lo' '--exclude=*.la' '--exclude=*.pc' '--exclude=.deps' '--exclude=.libs' '--exclude=.dirstamp' '--exclude=config.log' '--exclude=config.status' '--exclude=common.tex' '--exclude=test-driver' '--exclude=*~' '--exclude=libunwind.h' '--exclude=libunwind-common.h' '--exclude=stamp-h1' '--exclude=libtool' '--exclude=config.h' '--exclude=*.cache' '--exclude=Makefile.in' libunwind/include/config.h.in libunwind-1.1/include/config.h.in
+176,178d175
+< /* Define to 1 if your C compiler doesn't accept -c and -o together. */
+< #undef NO_MINUS_C_MINUS_O
+< 
+diff -r '--exclude=*.o' '--exclude=Makefile' '--exclude=*.m4' '--exclude=configure' '--exclude=tests' '--exclude=*.lo' '--exclude=*.la' '--exclude=*.pc' '--exclude=.deps' '--exclude=.libs' '--exclude=.dirstamp' '--exclude=config.log' '--exclude=config.status' '--exclude=common.tex' '--exclude=test-driver' '--exclude=*~' '--exclude=libunwind.h' '--exclude=libunwind-common.h' '--exclude=stamp-h1' '--exclude=libtool' '--exclude=config.h' '--exclude=*.cache' '--exclude=Makefile.in' libunwind/include/dwarf_i.h libunwind-1.1/include/dwarf_i.h
+11a12,18
+> #if defined(__has_feature)
+> #  if __has_feature(memory_sanitizer)
+> extern void __msan_unpoison(const volatile void *a, size_t size);
+> #    define UNPOISON(val) __msan_unpoison(val,sizeof(*val))
+> #  endif
+> #endif
+> 
+51a59
+>   UNPOISON(val);
+62a71
+>   UNPOISON(val);
+73a83
+>   UNPOISON(val);
+84a95
+>   UNPOISON(val);
+95a107
+>   UNPOISON(val);
+106a119
+>   UNPOISON(val);
+117a131
+>   UNPOISON(val);
+128a143
+>   UNPOISON(val);
+diff -r '--exclude=*.o' '--exclude=Makefile' '--exclude=*.m4' '--exclude=configure' '--exclude=tests' '--exclude=*.lo' '--exclude=*.la' '--exclude=*.pc' '--exclude=.deps' '--exclude=.libs' '--exclude=.dirstamp' '--exclude=config.log' '--exclude=config.status' '--exclude=common.tex' '--exclude=test-driver' '--exclude=*~' '--exclude=libunwind.h' '--exclude=libunwind-common.h' '--exclude=stamp-h1' '--exclude=libtool' '--exclude=config.h' '--exclude=*.cache' '--exclude=Makefile.in' libunwind/include/libunwind-x86_64.h libunwind-1.1/include/libunwind-x86_64.h
+129c129,135
+< #define unw_tdep_getcontext		UNW_ARCH_OBJ(getcontext)
+---
+> #define unw_tdep_getcontext UNW_ARCH_OBJ(getcontext)
+> #if defined(__has_feature)
+> #  if __has_feature(memory_sanitizer)
+> #    undef unw_tdep_getcontext
+> #    define unw_tdep_getcontext UNW_ARCH_OBJ(getcontext_interceptor)
+> #  endif
+> #endif
+Only in libunwind-1.1/include/tdep: libunwind_i.h
+diff -r '--exclude=*.o' '--exclude=Makefile' '--exclude=*.m4' '--exclude=configure' '--exclude=tests' '--exclude=*.lo' '--exclude=*.la' '--exclude=*.pc' '--exclude=.deps' '--exclude=.libs' '--exclude=.dirstamp' '--exclude=config.log' '--exclude=config.status' '--exclude=common.tex' '--exclude=test-driver' '--exclude=*~' '--exclude=libunwind.h' '--exclude=libunwind-common.h' '--exclude=stamp-h1' '--exclude=libtool' '--exclude=config.h' '--exclude=*.cache' '--exclude=Makefile.in' libunwind/src/Makefile.am libunwind-1.1/src/Makefile.am
+299c299,300
+< 	x86_64/Lstash_frame.c x86_64/Lstep.c x86_64/Ltrace.c x86_64/getcontext.S
+---
+> 	x86_64/Lstash_frame.c x86_64/Lstep.c x86_64/Ltrace.c x86_64/getcontext.S \
+>   x86_64/getcontext_interceptor.S
+Only in libunwind-1.1/src/x86_64: getcontext_interceptor.S
+diff -r '--exclude=*.o' '--exclude=Makefile' '--exclude=*.m4' '--exclude=configure' '--exclude=tests' '--exclude=*.lo' '--exclude=*.la' '--exclude=*.pc' '--exclude=.deps' '--exclude=.libs' '--exclude=.dirstamp' '--exclude=config.log' '--exclude=config.status' '--exclude=common.tex' '--exclude=test-driver' '--exclude=*~' '--exclude=libunwind.h' '--exclude=libunwind-common.h' '--exclude=stamp-h1' '--exclude=libtool' '--exclude=config.h' '--exclude=*.cache' '--exclude=Makefile.in' libunwind/src/x86_64/Ginit.c libunwind-1.1/src/x86_64/Ginit.c
+36a37,42
+> #if defined(__has_feature)
+> #  if __has_feature(memory_sanitizer)
+> void __msan_unpoison(void *, size_t);
+> #  endif
+> #endif
+> 
+173a180,184
+> 	#if defined(__has_feature)
+> 	#  if __has_feature(memory_sanitizer)
+> 				__msan_unpoison(val, sizeof(unw_word_t));
+> 	#  endif
+> 	#endif


### PR DESCRIPTION
Do not set LD_LIBRARY_PATH on every configure command, because some
of them use awk, which uses gmp, which can be a problem, but do set
of them use awk, which uses gmp, which can be a problem, but do set
it on PATCHELF directly if we're building it. Also special case
FORTRAN LDFLAGS for dependencies, which use gfortran for linking
(in particular ARPACK) and do not include sanitizer flags there.

Also add a patch that makes libunwind sanitizer compatible.
