### PR TITLE
Fix building with LLVM 3.8

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -492,7 +492,11 @@ static void jl_dump_shadow(char *fname, int jit_model, const char *sysimg_data, 
 #ifdef LLVM37
     // Reset the target triple to make sure it matches the new target machine
     clone->setTargetTriple(TM->getTargetTriple().str());
+#ifdef LLVM38
+    clone->setDataLayout(TM->createDataLayout());
+#else
     clone->setDataLayout(TM->getDataLayout()->getStringRepresentation());
+#endif
 #endif
 
     // add metadata information

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5545,7 +5545,9 @@ extern "C" void jl_init_codegen(void)
             );
     delete targetMachine;
     assert(jl_TargetMachine);
-#if defined(LLVM36) && !defined(LLVM37)
+#if defined(LLVM38)
+    engine_module->setDataLayout(jl_TargetMachine->createDataLayout());
+#elif defined(LLVM36) && !defined(LLVM37)
     engine_module->setDataLayout(jl_TargetMachine->getSubtargetImpl()->getDataLayout());
 #elif defined(LLVM35) && !defined(LLVM37)
     engine_module->setDataLayout(jl_TargetMachine->getDataLayout());

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -2,6 +2,10 @@
 
 #include <llvm/Config/llvm-config.h>
 
+#if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 8
+#define LLVM38 1
+#endif
+
 #if defined(LLVM_VERSION_MAJOR) && LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 7
 #define LLVM37 1
 #endif


### PR DESCRIPTION
This PR fixes breakage brought on by recent changes to LLVM that renamed `getDataLayout()`
as `createDataLayout()`. 

[Note for interpreting following discussion: original PR mistakenly targeted 3.7]
