### PR TITLE
Fix unsafe SubArray logical indexing

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -63,7 +63,8 @@ end
 # For S4, J[1] corresponds to I[2], because of the slice along
 # dimension 1 in S2
 
-@generated function slice_unsafe{T,NP,IndTypes}(A::AbstractArray{T,NP}, J::IndTypes)
+slice_unsafe(A::AbstractArray, J) = _slice_unsafe(A, to_indexes(J...))
+@generated function _slice_unsafe{T,NP,IndTypes}(A::AbstractArray{T,NP}, J::IndTypes)
     N = 0
     sizeexprs = Array(Any, 0)
     Jp = J.parameters
@@ -86,14 +87,15 @@ end
 
 # Conventional style (drop trailing singleton dimensions, keep any
 # other singletons by converting them to ranges, e.g., 3:3)
-sub(A::AbstractArray, I::ViewIndex...) = _sub(A, to_indexes(I...))
-sub(A::AbstractArray, I::Tuple{Vararg{ViewIndex}}) = _sub(A, to_indexes(I...))
+sub(A::AbstractArray, I::ViewIndex...) = _sub(A, I)
+sub(A::AbstractArray, I::Tuple{Vararg{ViewIndex}}) = _sub(A, I)
 function _sub(A, I)
     checkbounds(A, I...)
     sub_unsafe(A, I)
 end
 
-@generated function sub_unsafe{T,NP,IndTypes}(A::AbstractArray{T,NP}, J::IndTypes)
+sub_unsafe(A::AbstractArray, J) = _sub_unsafe(A, to_indexes(J...))
+@generated function _sub_unsafe{T,NP,IndTypes}(A::AbstractArray{T,NP}, J::IndTypes)
     sizeexprs = Array(Any, 0)
     Itypes = Array(Any, 0)
     Iexprs = Array(Any, 0)
@@ -129,7 +131,7 @@ end
 
 # Constructing from another SubArray
 # This "pops" the old SubArray and creates a more compact one
-@generated function slice_unsafe{T,NV,PV,IV,PLD,IndTypes}(V::SubArray{T,NV,PV,IV,PLD}, J::IndTypes)
+@generated function _slice_unsafe{T,NV,PV,IV,PLD,IndTypes}(V::SubArray{T,NV,PV,IV,PLD}, J::IndTypes)
     N = 0
     sizeexprs = Array(Any, 0)
     indexexprs = Array(Any, 0)
@@ -220,7 +222,7 @@ end
     end
 end
 
-@generated function sub_unsafe{T,NV,PV,IV,PLD,IndTypes}(V::SubArray{T,NV,PV,IV,PLD}, J::IndTypes)
+@generated function _sub_unsafe{T,NV,PV,IV,PLD,IndTypes}(V::SubArray{T,NV,PV,IV,PLD}, J::IndTypes)
     Jp = J.parameters
     IVp = IV.parameters
     N = length(Jp)

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -402,9 +402,11 @@ sA = sub(A, 1:2:3, 1:3:5, 1:2:8)
 # sub logical indexing #4763
 A = sub([1:10;], 5:8)
 @test A[A.<7] == [5, 6]
+@test Base.unsafe_getindex(A, A.<7) == [5, 6]
 B = reshape(1:16, 4, 4)
 sB = sub(B, 2:3, 2:3)
 @test sB[sB.>8] == [10, 11]
+@test Base.unsafe_getindex(sB, sB.>8) == [10, 11]
 
 # slice
 A = reshape(1:120, 3, 5, 8)


### PR DESCRIPTION
(Followup to #12289).  I hadn't inserted `to_index` back into the unsafe calls, so it failed on unsafe logical indexing — as a segfault, since it's unsafe.  Whoops!
