### PR TITLE
Allow `Base.File`s to be mmapped

### DIFF
--- a/base/fs.jl
+++ b/base/fs.jl
@@ -275,7 +275,7 @@ function position(f::File)
     ret
 end
 
-fd(f::File) = RawFD(f.handle)
+fd(f::File) = f.handle
 stat(f::File) = stat(fd(f))
 
 end

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -282,3 +282,22 @@ n = similar(m, (2,2))
 n = similar(m, 12)
 @test length(n) == 12
 @test size(n) == (12,)
+
+# Test Base.File; ref #12286
+t = "Hello World".data
+file = tempname()
+s = open(file, "w") do f
+    write(f, "Hello World\n")
+end
+f = Base.FS.open(file,Base.JL_O_RDWR)
+m = Mmap.mmap(f, Vector{UInt8})
+@test m[1:11] == t
+@test length(m) == 12
+
+m2 = Mmap.mmap(f, Vector{UInt8}, (20,))
+@test m2[1:11] == t
+@test length(m2) == 20
+finalize(m); finalize(m2)
+gc()
+@test filesize(file) == 20
+rm(file)


### PR DESCRIPTION
Ref: #12286

I don't think there's anything controversial here, but I'm interested to see if windows is ok on this.

cc: @jiahao 
