### PR TITLE
Don't run resolve in Pkg.test unless test/REQUIRE exists

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -730,7 +730,7 @@ function test!(pkg::AbstractString, errs::Vector{AbstractString}, notests::Vecto
     else
         push!(notests,pkg)
     end
-    resolve()
+    isfile(reqs_path) && resolve()
 end
 
 function test(pkgs::Vector{AbstractString}; coverage::Bool=false)


### PR DESCRIPTION
Should make Pkg.test faster for packages without any test-only dependencies

ref #12348
