### PR TITLE
RFC: add cleandeps keyword argument to Pkg.rm

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -19,7 +19,7 @@ dir(path...) = Dir.path(path...)
 init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRANCH) = Dir.init(meta,branch)
 
 edit() = cd(Entry.edit)
-rm(pkg::AbstractString) = cd(Entry.rm,pkg)
+rm(pkg::AbstractString; cleandeps=true) = cd(Entry.rm, pkg; cleandeps=cleandeps)
 add(pkg::AbstractString, vers::VersionNumber...) = cd(Entry.add,pkg,vers...)
 
 available() = cd(Entry.available)

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -72,11 +72,12 @@ function add(pkg::AbstractString, vers::VersionSet)
 end
 add(pkg::AbstractString, vers::VersionNumber...) = add(pkg,VersionSet(vers...))
 
-function rm(pkg::AbstractString)
-    edit(Reqs.rm,pkg) && return
+function rm(pkg::AbstractString; cleandeps=true)
+    edit(Reqs.rm,pkg) && return (cleandeps ? Write.cleandeps(pkg) : nothing)
     ispath(pkg) || return info("Nothing to be done")
     info("Removing $pkg (unregistered)")
     Write.remove(pkg)
+    return (cleandeps ? Write.cleandeps(pkg) : nothing)
 end
 
 available() = sort!(ASCIIString[keys(Read.available())...], by=lowercase)

--- a/base/pkg/write.jl
+++ b/base/pkg/write.jl
@@ -52,8 +52,8 @@ end
 
 function cleandeps(pkg::AbstractString)
     if isdir(".trash/$pkg/deps")
-        info("Cleaning .trash/$pkg/deps")
-        Git.run(`clean -qdfx deps`; dir=".trash/$pkg")
+        info("Cleaning ignored files in .trash/$pkg/deps")
+        Git.run(`clean -qdfX deps`; dir=".trash/$pkg")
     end
 end
 

--- a/base/pkg/write.jl
+++ b/base/pkg/write.jl
@@ -50,4 +50,11 @@ function remove(pkg::AbstractString)
     mv(pkg, ".trash/$pkg")
 end
 
+function cleandeps(pkg::AbstractString)
+    if isdir(".trash/$pkg/deps")
+        info("Cleaning .trash/$pkg/deps")
+        Git.run(`clean -qdfx deps`; dir=".trash/$pkg")
+    end
+end
+
 end # module

--- a/doc/stdlib/pkg.rst
+++ b/doc/stdlib/pkg.rst
@@ -46,7 +46,7 @@ to use them, you'll need to prefix each function call with an explicit ``Pkg.``,
 .. function:: rm(pkg; cleandeps=true)
 
    Remove all requirement entries for ``pkg`` from ``Pkg.dir("REQUIRE")`` and call ``Pkg.resolve()``.
-   If the keyword argument ``cleandeps`` is true, then ``git clean -qdfx deps`` is run in ``.trash/$pkg``
+   If the keyword argument ``cleandeps`` is true, then ``git clean -qdfX deps`` is run in ``.trash/$pkg``
    to clean build artifacts.
 
 .. function:: clone(url, [pkg])

--- a/doc/stdlib/pkg.rst
+++ b/doc/stdlib/pkg.rst
@@ -43,9 +43,11 @@ to use them, you'll need to prefix each function call with an explicit ``Pkg.``,
    Add a requirement entry for ``pkg`` to ``Pkg.dir("REQUIRE")`` and call ``Pkg.resolve()``.
    If ``vers`` are given, they must be ``VersionNumber`` objects and they specify acceptable version intervals for ``pkg``.
 
-.. function:: rm(pkg)
+.. function:: rm(pkg; cleandeps=true)
 
    Remove all requirement entries for ``pkg`` from ``Pkg.dir("REQUIRE")`` and call ``Pkg.resolve()``.
+   If the keyword argument ``cleandeps`` is true, then ``git clean -qdfx deps`` is run in ``.trash/$pkg``
+   to clean build artifacts.
 
 .. function:: clone(url, [pkg])
 


### PR DESCRIPTION
~~and rename current Pkg.rm to Pkg.subtract~~ original commit db0cb23643c4b029846542b289da03240253428a was replaced

should fix #7054, probably a simpler alternative to #11262

I can't really think of a situation where I call `Pkg.rm` and really strongly want to keep that package around in `.trash`. If I did this correctly it still does dependency resolution in a way that moves no-longer-required packages to `.trash`, but actually deletes the specific package you asked to remove when you call `Pkg.rm`.
