### PR TITLE
RFC: Add match! function for in-place matching

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -857,6 +857,7 @@ export
     lpad,
     lstrip,
     match,
+    match!,
     matchall,
     ndigits,
     nextind,

--- a/doc/stdlib/strings.rst
+++ b/doc/stdlib/strings.rst
@@ -135,6 +135,11 @@
 
    Search for the first match of the regular expression ``r`` in ``s`` and return a RegexMatch object containing the match, or nothing if the match failed. The matching substring can be retrieved by accessing ``m.match`` and the captured sequences can be retrieved by accessing ``m.captures`` The optional ``idx`` argument specifies an index at which to start the search.
 
+.. function:: match!(m::RegexMatch, s::AbstractString[, idx::Integer[, addopts]])
+
+    Like ``match``, but accepts a pre-allocated match object instead of a regular expression. ``m`` will be modified in-place to hold the results of the match. Returns ```true`` if a match was found; ``false`` otherwise. A pre-allocated match object compatible with a 
+    regular expression ``re`` can be obtained via ``RegexMatch(re)``.
+
 .. function:: eachmatch(r::Regex, s::AbstractString[, overlap::Bool=false])
 
    Search for all matches of a the regular expression ``r`` in ``s`` and return a iterator over the matches. If overlap is true, the matching sequences are allowed to overlap indices in the original string, otherwise they must be from distinct character ranges.
@@ -409,5 +414,3 @@
    depending on whether ``Cwchar_t`` is 32 or 16 bits, respectively.
    The synonym ``WString`` for ``UTF32String`` or ``UTF16String``
    is also provided.
-
-

--- a/doc/stdlib/strings.rst
+++ b/doc/stdlib/strings.rst
@@ -137,8 +137,7 @@
 
 .. function:: match!(m::RegexMatch, s::AbstractString[, idx::Integer[, addopts]])
 
-    Like ``match``, but accepts a pre-allocated match object instead of a regular expression. ``m`` will be modified in-place to hold the results of the match. Returns ```true`` if a match was found; ``false`` otherwise. A pre-allocated match object compatible with a 
-    regular expression ``re`` can be obtained via ``RegexMatch(re)``.
+    Like ``match``, but accepts a pre-allocated match object instead of a regular expression. ``m`` will be modified in-place to hold the results of the match. Returns ```true`` if a match was found; ``false`` otherwise. A pre-allocated match object compatible with a regular expression ``re`` can be obtained via ``RegexMatch(re)``.
 
 .. function:: eachmatch(r::Regex, s::AbstractString[, overlap::Bool=false])
 

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -44,6 +44,19 @@ let m = match(r"(?<a>.)(.)(?<b>.)", "xyz")
     @test sprint(show, m) == "RegexMatch(\"xyz\", a=\"x\", 2=\"y\", b=\"z\")"
 end
 
+# In-place matching
+let
+    r = r"a(.)(.)"
+    m = RegexMatch(r)
+    s = "babca"
+    match!(m, s)
+    @test (m[1], m[2]) == ("b", "c")
+    r2 = r"a(.)"
+    m = RegexMatch(r2)
+    m.regex = r
+    @test_throws ArgumentError match!(m, s)
+end
+
 # Backcapture reference in substitution string
 @test replace("abcde", r"(..)(?P<byname>d)", s"\g<byname>xy\\\1") == "adxy\\bce"
 @test_throws ErrorException replace("a", r"(?P<x>)", s"\g<y>")


### PR DESCRIPTION
This is to speed up inner loops that keep calling `match` with the same regex. Here's a benchmark for a hypothetical use case of collecting all letters that occur 1 or 2 characters after 'a' in a document:

``` julia
s=readall("CONTRIBUTING.md"); 

function in_place(s;N=1000)
    r=r"a(.)(.)"
    for i=1:N
        offset = 1
        while true
            m = match(r, s, offset)
            m==nothing && break
            offset = m.offset + length(m.match)
        end
    end
end

function with_match(s;N=1000)
    r=r"a(.)(.)"
    m = RegexMatch(r)
    for i=1:N
        offset = 1
        while true
            Base.match!(m, s, offset) || break
            offset = m.offset + length(m.match)
        end
    end
end

function with_matchall(s;N=1000)
    r=r"a(.)(.)"
    for i=1:N
        matches = matchall(r, s)  # Note this API doesn't let you get the capture groups, but forms a reasonable baseline
    end
end

@time with_match(s);
 515.801 milliseconds (6253 k allocations: 251 MB, 23.24% gc time)


@time inplace(s);
 263.869 milliseconds (3137 k allocations: 85766 KB, 14.53% gc time)


@time with_matchall(s);
 272.747 milliseconds (5404 k allocations: 110 MB, 20.30% gc time)
```
