### PR TITLE
RFC: always add .jl to non-absolute paths in find_in_path

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -7,14 +7,13 @@
 function find_in_path(name::AbstractString, wd = pwd())
     isabspath(name) && return name
     if wd === nothing; wd = pwd(); end
-    isfile(joinpath(wd,name)) && return joinpath(wd,name)
     base = name
     if endswith(name,".jl")
         base = name[1:end-3]
     else
         name = string(base,".jl")
-        isfile(joinpath(wd,name)) && return joinpath(wd,name)
     end
+    isfile(joinpath(wd,name)) && return joinpath(wd,name)
     for prefix in [Pkg.dir(); LOAD_PATH]
         path = joinpath(prefix, name)
         isfile(path) && return abspath(path)


### PR DESCRIPTION
Possible fix for #12340.

Discussion sought on how to handle absolute paths. My instinct was to leave absolute paths alone, but it also seems slightly odd to add .jl to `a/b` but not to `/a/b`. However, this function is only used by `require`, so I'm not sure names with slashes are ever passed to it at all, in which case we could remove that code.
