### PR TITLE
Improve IOBuffer read performance

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -81,12 +81,14 @@ function read_sub{T}(from::AbstractIOBuffer, a::AbstractArray{T}, offs, nel)
 end
 
 @inline function read(from::AbstractIOBuffer, ::Type{UInt8})
+    ptr = from.ptr
+    size = from.size
     from.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
-    if from.ptr > from.size
+    if ptr > size
         throw(EOFError())
     end
-    @inbounds byte = from.data[from.ptr]
-    from.ptr += 1
+    @inbounds byte = from.data[ptr]
+    from.ptr = ptr + 1
     return byte
 end
 

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -80,12 +80,12 @@ function read_sub{T}(from::AbstractIOBuffer, a::AbstractArray{T}, offs, nel)
     return a
 end
 
-function read(from::AbstractIOBuffer, ::Type{UInt8})
+@inline function read(from::AbstractIOBuffer, ::Type{UInt8})
     from.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
     if from.ptr > from.size
         throw(EOFError())
     end
-    byte = from.data[from.ptr]
+    @inbounds byte = from.data[from.ptr]
     from.ptr += 1
     return byte
 end


### PR DESCRIPTION
The first commit here inlines `read` for IOBuffer bytes and adds `@inbounds`, since we should already be checking for EOF above.

The second commit restructures the code so that LLVM can do a better job of hoisting loads out of loops as suggested by @carnaval, but turns out only to be needed if Julia is running without `-O`.
##### My benchmark:

``` julia
using Benchmarks
io = IOBuffer(randstring(10^8));
f(io) = (seek(io, 0); x = 0; while !eof(io); x += read(io, UInt8); end)
@benchmark f(io)
```
##### Baseline:

```
Average elapsed time: 293.620 ms
  95% CI for average: [268.775 ms, 318.466 ms]
```

(insignificantly different with `julia -O`)
##### With 51ff6070cb8a5ca05b742b579b93184005beecd5:

```
Average elapsed time: 195.870 ms
  95% CI for average: [190.746 ms, 200.993 ms]
```
##### With 51ff6070cb8a5ca05b742b579b93184005beecd5, `julia -O`:

```
Average elapsed time: 66.866 ms
  95% CI for average: [64.272 ms, 69.460 ms]
```
##### With d98ea9558ae3580b31190073f5a3f12aea1930f1:

```
Average elapsed time: 70.925 ms
  95% CI for average: [68.119 ms, 73.730 ms]
```

(does not change generated code or timings for `julia -O`)

cc @jiahao 
