### PR TITLE
Handle Dates-array arithmetic with promote_op

### DIFF
--- a/base/functors.jl
+++ b/base/functors.jl
@@ -58,6 +58,9 @@ call(::DotMulFun, x, y) = x .* y
 immutable RDivFun <: Func{2} end
 call(::RDivFun, x, y) = x / y
 
+immutable DotRDivFun <: Func{2} end
+call(::DotRDivFun, x, y) = x ./ y
+
 immutable LDivFun <: Func{2} end
 call(::LDivFun, x, y) = x \ y
 


### PR DESCRIPTION
This fixes the ambiguity warnings triggered by #12115. It also introduces a new abstract type, `AbstractScalar` and makes use of it in defining operations.

CC @GordStephen, @quinnj.
