### PR TITLE
Make show(io, ::UnicodeError) output start with UnicodeError:

### DIFF
--- a/base/unicode/UnicodeError.jl
+++ b/base/unicode/UnicodeError.jl
@@ -27,4 +27,5 @@ type UnicodeError <: Exception
     errchr::UInt32              ##< Invalid character
 end
 
-show(io::IO, exc::UnicodeError) = print(io, replace(replace(exc.errmsg,"<<1>>",string(exc.errpos)),"<<2>>",hex(exc.errchr)))
+show(io::IO, exc::UnicodeError) = print(io, replace(replace(string("UnicodeError: ",exc.errmsg),
+    "<<1>>",string(exc.errpos)),"<<2>>",hex(exc.errchr)))

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -643,6 +643,8 @@ built-in :exc:`Exception`\ s listed below all interrupt the normal flow of contr
 +------------------------------+
 | :exc:`UndefVarError`         |
 +------------------------------+
+| :exc:`UnicodeError`          |
++------------------------------+
 
 
 For example, the :func:`sqrt` function throws a :exc:`DomainError` if applied to a


### PR DESCRIPTION
looks like we do this for most other Exception types

ref #11573
