### PR TITLE
Check ninitialized on type redefinition

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -93,6 +93,7 @@ static int equiv_type(jl_datatype_t *dta, jl_datatype_t *dtb)
             dta->abstract == dtb->abstract &&
             dta->mutabl == dtb->mutabl &&
             dta->size == dtb->size &&
+            dta->ninitialized == dtb->ninitialized &&
             jl_egal((jl_value_t*)dta->super, (jl_value_t*)dtb->super) &&
             jl_egal((jl_value_t*)dta->name->names, (jl_value_t*)dtb->name->names) &&
             jl_egal((jl_value_t*)dta->parameters, (jl_value_t*)dtb->parameters));

--- a/test/core.jl
+++ b/test/core.jl
@@ -3155,3 +3155,13 @@ immutable MyType8010_ghost
 end
 @test_throws TypeError MyType8010([3.0;4.0])
 @test_throws TypeError MyType8010_ghost([3.0;4.0])
+
+# don't allow redefining types if ninitialized changes
+immutable NInitializedTestType
+    a
+end
+
+@test_throws ErrorException @eval immutable NInitializedTestType
+    a
+    NInitializedTestType() = new()
+end


### PR DESCRIPTION
Otherwise previously generated code may not have checks for fields that can now be uninitialized in the redefined type.
