### PR TITLE
Update julia-mode.el for UInt -> Uint.

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -207,7 +207,7 @@ This function provides equivalent functionality, but makes no efforts to optimis
 (defconst julia-builtin-types-regex
   (julia--regexp-opt
    '("Number" "Real" "BigInt" "Integer"
-     "UInt" "UInt8" "UInt16" "UInt32" "UInt64" "UInt128"
+     "Uint" "Uint8" "Uint16" "Uint32" "Uint64" "Uint128"
      "Int" "Int8" "Int16" "Int32" "Int64" "Int128"
      "BigFloat" "FloatingPoint" "Float16" "Float32" "Float64"
      "Complex128" "Complex64"


### PR DESCRIPTION
Update `julia-mode` for Emacs so that the newly renamed Uint type is highlighted instead of the old UInt name (differing by capitalization of letter i).

Please update this on melpa as well, thanks!
