### PR TITLE
time in seconds: print times as 1.234 if ≥ 1 or 1.234/10^p if < 1.

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -112,13 +112,7 @@ function padded_nonzero_print(value,str)
 end
 
 function time_print(elapsedtime, bytes, gctime, allocs)
-    seconds = elapsedtime/1e9
-    if 1 <= round(seconds,3)
-        @printf("%.3f seconds", seconds)
-    else
-        power = -floor(log10(seconds))
-        @printf("%.3f/10^%d seconds", seconds*10^power, power)
-    end
+    @printf("%.6f seconds", elapsedtime/1e9)
     if bytes != 0 || allocs != 0
         bytes, mb = prettyprint_getunits(bytes, length(_mem_units), Int64(1024))
         allocs, ma = prettyprint_getunits(allocs, length(_cnt_units), Int64(1000))

--- a/base/util.jl
+++ b/base/util.jl
@@ -112,7 +112,7 @@ function padded_nonzero_print(value,str)
 end
 
 function time_print(elapsedtime, bytes, gctime, allocs)
-    @printf("%.6f seconds", elapsedtime/1e9)
+    @printf("%10.6f seconds", elapsedtime/1e9)
     if bytes != 0 || allocs != 0
         bytes, mb = prettyprint_getunits(bytes, length(_mem_units), Int64(1024))
         allocs, ma = prettyprint_getunits(allocs, length(_cnt_units), Int64(1000))


### PR DESCRIPTION
Printing times with different units is often confusing since one doesn't notice the units. When timing something, you generally want to compare across different measurements. Having them in common units (seconds) makes this easier.
