### PR TITLE
Tests and a bugfix for statistics

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -177,7 +177,15 @@ varm(iterable, m::Number; corrected::Bool=true) =
 
 ## variances over ranges
 
-varm(v::Range, m::Number) = var(v)
+function varm(v::Range, m::Number)
+    f = first(v) - m
+    s = step(v)
+    l = length(v)
+    if l == 0 || l == 1
+           return NaN
+    end
+    return f^2 * l / (l - 1) + f * s * l + s^2 * l * (2 * l - 1) / 6
+end
 
 function var(v::Range)
     s = step(v)

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+using Base.Test
+
 # middle
 
 @test middle(3) === 3.0
@@ -43,6 +45,8 @@ end
 @test median!([1 2; 3 4]) == 2.5
 
 # mean
+@test_throws ArgumentError mean(())
+@test mean((1,2,3)) === 2.
 @test mean([0]) === 0.
 @test mean([1.]) === 1.
 @test mean([1.,3]) == 2.
@@ -96,6 +100,9 @@ end
 @test_approx_eq var([1], 1; mean=[2], corrected=false) [1.0]
 
 @test var(1:8) == 6.
+@test varm(1:8,1) == varm(collect(1:8),1)
+@test isnan(var(1:1))
+@test isnan(var(1:-1))
 
 @test_approx_eq varm([1,2,3], 2) 1.
 @test_approx_eq var([1,2,3]) 1.
@@ -108,6 +115,7 @@ end
 @test_approx_eq var((1,2,3); corrected=false) 2.0/3
 @test_approx_eq var((1,2,3); mean=0) 7.
 @test_approx_eq var((1,2,3); mean=0, corrected=false) 14.0/3
+@test_throws ArgumentError var((1,2,3); mean=())
 
 @test_approx_eq var([1 2 3 4 5; 6 7 8 9 10], 2) [2.5 2.5]'
 @test_approx_eq var([1 2 3 4 5; 6 7 8 9 10], 2; corrected=false) [2.0 2.0]'
@@ -300,4 +308,4 @@ end
 
 @test_throws ArgumentError histrange([1, 10], 0)
 @test_throws ArgumentError histrange([1, 10], -1)
-
+@test_throws ArgumentError histrange(Float64[],-1)


### PR DESCRIPTION
The `mean` for iterables wasn't tested. A bunch of error-throwing paths in various functions weren't tested.

And we found that `varm` for `Range`s was broken!
