### PR TITLE
tweak memory printing in @time

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -89,19 +89,16 @@ function toc()
 end
 
 # print elapsed time, return expression value
-const _mem_units = ["bytes", "KB", "MB", "GB", "TB", "PB"]
+const _mem_units = ["byte", "KB", "MB", "GB", "TB", "PB"]
 const _cnt_units = ["", " k", " M", " G", " T", " P"]
 function prettyprint_getunits(value, numunits, factor)
-    c1 = factor
-    c2 = c1 * c1
-    if value <= c1*100 ; return (value, 1) ; end
-    unit = 2
-    while value > c2*100 && (unit < numunits)
-        c1 = c2
-        c2 *= factor
-        unit += 1
+    if value == 0 || value == 1
+        return (value, 1)
     end
-    return div(value+(c1>>>1),c1), unit
+    unit = ceil(Int, log(value) / log(factor))
+    unit = min(numunits, unit)
+    number = value/factor^(unit-1)
+    return number, unit
 end
 
 const _sec_units = ["nanoseconds ", "microseconds", "milliseconds", "seconds     "]
@@ -139,7 +136,16 @@ function time_print(elapsedtime, bytes, gctime, allocs)
     if bytes != 0 || allocs != 0
         bytes, mb = prettyprint_getunits(bytes, length(_mem_units), Int64(1024))
         allocs, ma = prettyprint_getunits(allocs, length(_cnt_units), Int64(1000))
-        @printf(" (%d%s allocation%s: %d %s", allocs, _cnt_units[ma], allocs==1 ? "" : "s", bytes, _mem_units[mb])
+        if ma == 1
+            @printf(" (%d%s allocation%s: ", allocs, _cnt_units[ma], allocs==1 ? "" : "s")
+        else
+            @printf(" (%.2f%s allocations: ", allocs, _cnt_units[ma])
+        end
+        if mb == 1
+            @printf("%d %s%s", bytes, _mem_units[mb], bytes==1 ? "" : "s")
+        else
+            @printf("%.3f %s", bytes, _mem_units[mb])
+        end
         if gctime > 0
             @printf(", %.2f%% gc time", 100*gctime/elapsedtime)
         end


### PR DESCRIPTION
Since today is bike shed day I decided to tweak this that has been annoying me for a while in the memory reporting of `@time`.

In short, this changes so that instead of reporting `12345 k` allocations we switch to the new unit and report `12.35 M`. Same for the allocation size.

This script is used to compare the way master and this PR prints some memory allocations.

``` julia
bytes = [1, 2, 48345, 10^8]
allocs = [1, 42350000, 999, 1234560]
for (b, a) in zip(bytes, allocs)
    Base.time_print(UInt64(2), b, 1, a)
end
```
#### Master

``` julia
2 nanoseconds  (1 allocation: 1 bytes, 50.00% gc time)
2 nanoseconds  (42350 k allocations: 2 bytes, 50.00% gc time)
2 nanoseconds  (999 allocations: 48345 bytes, 50.00% gc time)
2 nanoseconds  (1235 k allocations: 97656 KB, 50.00% gc time)
```
#### PR

``` julia
2 nanoseconds  (1 allocation: 1 byte, 50.00% gc time)
2 nanoseconds  (42.35 M allocations: 2 bytes, 50.00% gc time)
2 nanoseconds  (999 allocations: 47.21 KB, 50.00% gc time)
2 nanoseconds  (1.23 M allocations: 95.37 MB, 50.00% gc time)
```
