### PR TITLE
fix #12375 (fix scaling of isapprox)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -311,6 +311,8 @@ Library improvements
 
     * The `MathConst` type has been renamed `Irrational` ([#11922]).
 
+    * `isapprox` now has simpler and more sensible default tolerances ([#12393]).
+
   * Random numbers
 
     * Streamlined random number generation APIs [#8246].
@@ -1554,3 +1556,4 @@ Too numerous to mention.
 [#12087]: https://github.com/JuliaLang/julia/issues/12087
 [#12137]: https://github.com/JuliaLang/julia/issues/12137
 [#12162]: https://github.com/JuliaLang/julia/issues/12162
+[#12393]: https://github.com/JuliaLang/julia/issues/12393

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -417,17 +417,11 @@ Mathematical Operators
 Mathematical Functions
 ----------------------
 
-.. function:: isapprox(x::Number, y::Number; rtol::Real=cbrt(maxeps), atol::Real=sqrt(maxeps))
+.. function:: isapprox(x::Number, y::Number; rtol::Real=sqrt(eps), atol::Real=0)
 
-   Inexact equality comparison - behaves slightly different depending on types of input args:
+   Inexact equality comparison: ``true`` if ``abs(x-y) <= atol + rtol*max(abs(x), abs(y))``.  The default ``atol`` is zero and the default ``rtol`` depends on the types of ``x`` and ``y``.
 
-   * For ``AbstractFloat`` numbers, ``isapprox`` returns ``true`` if ``abs(x-y) <= atol + rtol*max(abs(x), abs(y))``.
-
-   * For ``Integer`` and ``Rational`` numbers, ``isapprox`` returns ``true`` if ``abs(x-y) <= atol``. The `rtol` argument is ignored. If one of ``x`` and ``y`` is ``AbstractFloat``, the other is promoted, and the method above is called instead.
-
-   * For ``Complex`` numbers, the distance in the complex plane is compared, using the same criterion as above.
-
-   For default tolerance arguments, ``maxeps = max(eps(abs(x)), eps(abs(y)))``.
+   For real or complex floating-point values, ``rtol`` defaults to ``sqrt(eps(typeof(real(x-y))))``.  This corresponds to requiring equality of about half of the significand digits.   For other types, ``rtol`` defaults to zero.
 
 .. function:: sin(x)
 

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -138,18 +138,22 @@ for T in (Complex64, Complex128, Complex{BigFloat})
     half = (1+1im)/T(2)
     third = (1-1im)/T(3)
 
+    # some of these functions promote their result to double
+    # precision, but we want to check equality at precision T
+    rtol = Base.rtoldefault(real(T))
+
     for f in (:+, :-, :abs, :abs2, :conj, :inv, :sign,
               :acos, :acosh, :asin, :asinh, :atan, :atanh, :cos,
               :cosh, :exp10, :exp2, :exp, :expm1, :log10, :log1p,
               :log2, :log, :sin, :sinh, :sqrt, :tan, :tanh)
-        @test isapprox((@eval @fastmath $f($half)), (@eval $f($half)))
-        @test isapprox((@eval @fastmath $f($third)), (@eval $f($third)))
+        @test isapprox((@eval @fastmath $f($half)), (@eval $f($half)), rtol=rtol)
+        @test isapprox((@eval @fastmath $f($third)), (@eval $f($third)), rtol=rtol)
     end
     for f in (:+, :-, :*, :/, :(==), :!=, :^)
         @test isapprox((@eval @fastmath $f($half, $third)),
-                       (@eval $f($half, $third)))
+                       (@eval $f($half, $third)), rtol=rtol)
         @test isapprox((@eval @fastmath $f($third, $half)),
-                       (@eval $f($third, $half)))
+                       (@eval $f($third, $half)), rtol=rtol)
     end
 end
 

--- a/test/floatapprox.jl
+++ b/test/floatapprox.jl
@@ -43,3 +43,6 @@
 # Notably missing from this test suite at the moment
 # * Tests for other magnitudes of numbers - very small, very big, and combinations of small and big
 # * Tests for various odd combinations of types, e.g. isapprox(x::Integer, y::Rational)
+
+# issue #12375:
+@test !isapprox(1e17, 1)


### PR DESCRIPTION
As discussed in #12375, `isapprox(x,y)` had default tolerances that were dimensionally incorrect: if you multiply both `x` and `y` by 10, the relative tolerance should be unchanged while the absolute tolerance should multiply by 10.  The new implementation fixes this issue, and is also greatly simplified:
- The default relative tolerance is `sqrt(eps(T))` where `T` comes from promoting `x` and `y`, for floating-point types, or zero for other types.
- The default absolute tolerance is zero.  (Nonzero absolute tolerances must come from external information that sets an overall scale.)
- It now works for any `Number` type that defines `real(T)` to get the corresponding real type, along with `abs` and `isfinite` and `-`.
