### PR TITLE
correct parsing of FFTW version for recent MKL

### DIFF
--- a/base/fft/FFTW.jl
+++ b/base/fft/FFTW.jl
@@ -20,7 +20,7 @@ export export_wisdom, import_wisdom, import_system_wisdom, forget_wisdom,
 const libfftw = Base.libfftw_name
 const libfftwf = Base.libfftwf_name
 
-const version = convert(VersionNumber, split(bytestring(cglobal((:fftw_version,Base.DFT.FFTW.libfftw), UInt8)), "-")[2])
+const version = convert(VersionNumber, split(bytestring(cglobal((:fftw_version,Base.DFT.FFTW.libfftw), UInt8)), ['-', ' '])[2])
 
 ## Direction of FFT
 


### PR DESCRIPTION
ICC 15.0.3 with MKL reports FFTW version as follows: "FFTW 3.2 wrappers to MKL". So little fix to make Julia compile under ICC.
