### PR TITLE
tweak pmap tests, move topology tests out of conditional exec

### DIFF
--- a/test/topology.jl
+++ b/test/topology.jl
@@ -1,7 +1,6 @@
 include("testdefs.jl")
 addprocs(4; topology="master_slave")
-v=remotecall_fetch(2, ()->remotecall_fetch(3,myid))
-@test isa(v, Exception)
+@test_throws RemoteException remotecall_fetch(2, ()->remotecall_fetch(3,myid))
 
 function test_worker_counts()
     # check if the nprocs/nworkers/workers are the same on the remaining workers
@@ -26,9 +25,12 @@ end
 
 remove_workers_and_test()
 
-# a hack just to test the "custom" topology.
 # connect even pids to other even pids, odd to odd.
-function Base.launch(manager::Base.LocalManager, params::Dict, launched::Array, c::Condition)
+type TopoTestManager <: ClusterManager
+    np::Integer
+end
+
+function Base.launch(manager::TopoTestManager, params::Dict, launched::Array, c::Condition)
     dir = params[:dir]
     exename = params[:exename]
     exeflags = params[:exeflags]
@@ -46,8 +48,9 @@ function Base.launch(manager::Base.LocalManager, params::Dict, launched::Array, 
 
     notify(c)
 end
+
 const map_pid_ident=Dict()
-function Base.manage(manager::Base.LocalManager, id::Integer, config::WorkerConfig, op::Symbol)
+function Base.manage(manager::TopoTestManager, id::Integer, config::WorkerConfig, op::Symbol)
     if op == :register
         map_pid_ident[id] = get(config.ident)
     elseif op == :interrupt
@@ -55,7 +58,7 @@ function Base.manage(manager::Base.LocalManager, id::Integer, config::WorkerConf
     end
 end
 
-addprocs(8; topology="custom")
+addprocs(TopoTestManager(8); topology="custom")
 
 while true
     if any(x->get(map_pid_ident, x, 0)==0, workers())
@@ -72,8 +75,7 @@ for p1 in workers()
         if (iseven(i1) && iseven(i2)) || (isodd(i1) && isodd(i2))
             @test p2 == remotecall_fetch(p1, p->remotecall_fetch(p,myid), p2)
         else
-            v1 = remotecall_fetch(p1, p->remotecall_fetch(p,myid), p2)
-            @test isa(v1, Exception)
+            @test_throws RemoteException remotecall_fetch(p1, p->remotecall_fetch(p,myid), p2)
         end
     end
 end


### PR DESCRIPTION
This PR 
- enables the  topology tests in mainline CI. Previously was a conditional execution under JULIA_TEST_FULL.
- tweaks `pmap` tests.

@tkelman : the changes result in an additional 8 temporary workers.We can try this for a few days and can revert in case we see OOM messages again.     
