### PR TITLE
Delete usage of inference in SubArray code

### DIFF
--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -214,7 +214,14 @@ function runtests(A::Array, I...)
     ldc = Base.subarray_linearindexing_dim(typeof(A), typeof(I))
     ld == ldc || err_li(I, ld, ldc)
     # sub
-    S = sub(A, I...)
+    local S
+    try
+        S = @inferred(sub(A, I...))
+    catch err
+        @show typeof(A)
+        @show I
+        rethrow(err)
+    end
     getLD(S) == ldc || err_li(S, ldc)
     if Base.iscontiguous(S)
         @test S.stride1 == 1
@@ -223,7 +230,13 @@ function runtests(A::Array, I...)
     test_cartesian(S, C)
     test_mixed(S, C)
     # slice
-    S = slice(A, I...)
+    try
+        S = @inferred(slice(A, I...))
+    catch err
+        @show typeof(A)
+        @show I
+        rethrow(err)
+    end
     getLD(S) == ldc || err_li(S, ldc)
     test_linear(S, C)
     test_cartesian(S, C)
@@ -258,7 +271,7 @@ function runtests(A::SubArray, I...)
     # sub
     local S
     try
-        S = sub(A, I...)
+        S = @inferred(sub(A, I...))
     catch err
         @show typeof(A)
         @show A.indexes
@@ -272,7 +285,7 @@ function runtests(A::SubArray, I...)
     test_mixed(S, C)
     # slice
     try
-        S = slice(A, I...)
+        S = @inferred(slice(A, I...))
     catch err
         @show typeof(A)
         @show A.indexes

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -156,8 +156,8 @@ end
 function test_linear(A, B)
     length(A) == length(B) || error("length mismatch")
     isgood = true
-    for (iA, iB) in zip(1:length(A), 1:length(B))
-        if A[iA] != B[iB]
+    for i = 1:length(A)
+        if A[i] != B[i]
             isgood = false
             break
         end


### PR DESCRIPTION
It was [recently noticed](https://github.com/JuliaLang/julia/pull/12292#issuecomment-124322950) that the subarray code called `Base.return_types` from a `@generated` function, and that this is a no-no. This PR eliminates that call.

There are a few interesting things to discuss here:
- For reasons I haven't yet pinned down, inference and dispatch seem to fail on `merge_indexes`. I suspect it has to do with the constructs like `V.indexes[2:end]`. As a bandaid, I added a type annotation to its output.
- The first commit, adding `@inferrable` to the sub and slice tests, seems to work fine in our standard tests. However, if you run with `JULIA_TESTFULL` it seems to be an effective way of uncovering some lurking bug:

``` sh
$ JULIA_TESTFULL=1 ./julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "help()" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.4.0-dev+6409 (2015-07-30 15:23 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit eb2f341* (0 days old master)
|__/                   |  x86_64-linux-gnu

shell> cd test
/home/tim/src/julia/test

julia> using Base.Test

julia> include("subarray.jl")  # now wait a LOONG time
typeof(A) = SubArray{Int64,3,Array{Int64,3},Tuple{Array{Int64,1},StepRange{Int64,Int64},Array{Int64,1}},0}
A.indexes = ([8,4,6,12,5,7],13:-2:1,[8,4,6,12,5,7])
I = (2:5,1:2:5,1:2:5)
ERROR: LoadError: SYSTEM: show(lasterr) caused an error
```

EDIT: I should add that if you try that supposedly-failing test directly, it works fine:

``` jl
julia> B = reshape(1:13^3, 13, 13, 13);

julia> A = sub(B, [8,4,6,12,5,7], 13:-2:1, [8,4,6,12,5,7]);

julia> S = sub(A, 2:5, 1:2:5, 1:2:5)
4x3x3 SubArray{Int64,3,Array{Int64,3},Tuple{Array{Int64,1},StepRange{Int64,Int64},Array{Int64,1}},0}:
[:, :, 1] =
 1343  1291  1239
 1345  1293  1241
 1351  1299  1247
 1344  1292  1240

[:, :, 2] =
 1005  953  901
 1007  955  903
 1013  961  909
 1006  954  902

[:, :, 3] =
 836  784  732
 838  786  734
 844  792  740
 837  785  733

julia> S == A[2:5,1:2:5, 1:2:5]
true
```

Because it's history-dependent, it suggests a "deep" bug.

Not sure what to do about that. I could test what happens if we drop the first commit and just do the second. It would be nice, of course, to ensure that these operations remain inferrable.

CC @carnaval, @jakebolewski, @JeffBezanson.
