### PR TITLE
fix nextpow2 for 8, 16, and 32bit integers

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -130,7 +130,7 @@ function powermod{T}(b::Integer, p::Integer, m::T)
 end
 
 # smallest power of 2 >= x
-nextpow2(x::Unsigned) = one(x)<<((sizeof(x)<<3)-leading_zeros(x-1))
+nextpow2(x::Unsigned) = one(x)<<((sizeof(x)<<3)-leading_zeros(x-one(x)))
 nextpow2(x::Integer) = reinterpret(typeof(x),x < 0 ? -nextpow2(unsigned(-x)) : nextpow2(unsigned(x)))
 
 prevpow2(x::Unsigned) = (one(x)>>(x==0)) << ((sizeof(x)<<3)-leading_zeros(x)-1)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2232,6 +2232,10 @@ for i = -100:100
     @test nextpow2(i) == nextpow2(big(i))
     @test prevpow2(i) == prevpow2(big(i))
 end
+for T in (Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64)
+    @test nextpow2(T(42)) === T(64)
+    @test prevpow2(T(42)) === T(32)
+end
 
 @test nextpow(2,1) == 1
 @test prevpow(2,1) == 1


### PR DESCRIPTION
I've found the following strange behavior:

```
julia> nextpow2(Int32(42))
0

julia> nextpow2(UInt32(42))
0x00000000
```

The `nextpow2` doesn't work for integers less than 64 bits.
This pull request will fix that.
