### PR TITLE
Avoid unnecessary conversions of nullables.

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -8,6 +8,8 @@ Nullable() = Nullable{Union{}}()
 
 eltype{T}(::Type{Nullable{T}}) = T
 
+convert{T}(::Type{Nullable{T}}, x::Nullable{T}) = x
+
 function convert{T}(::Type{Nullable{T}}, x::Nullable)
     return isnull(x) ? Nullable{T}() : Nullable{T}(convert(T, get(x)))
 end


### PR DESCRIPTION
There's currently an unnecessary conversion that happens between nullables of the same type. Adding this def sped up some code I was working by 2x.

Here's a contrived benchmark

``` julia
type Thing
    x::Nullable{Int}
end

function f()
    a = Thing(1)
    b = Thing(2)
    for _ in 1:100000000
        a.x = b.x
    end
end

f()
@time f()
```

Before this PR: `0.409873 seconds (155 allocations: 10.543 KB)`
After this PR: `0.070780 seconds (155 allocations: 10.543 KB)`
