### PR TITLE
Try to fix memory leak in depwarn

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -79,6 +79,7 @@
 #endif
 
 #include "julia.h"
+#include "julia_internal.h"
 
 using namespace llvm;
 
@@ -203,9 +204,6 @@ const char *SymbolLookup(void *DisInfo,
     return NULL;
 }
 
-extern "C" void jl_getFunctionInfo
-  (const char **name, size_t *line, const char **filename, uintptr_t pointer,
-   int *fromC, int skipC);
 int OpInfoLookup(void *DisInfo, uint64_t PC,
                  uint64_t Offset, uint64_t Size,
                  int TagType, void *TagBuf)
@@ -229,11 +227,12 @@ int OpInfoLookup(void *DisInfo, uint64_t PC,
     default: return 0;          // Cannot handle input address size
     }
     int skipC = 0;
-    const char *name;
+    char *name;
     size_t line;
-    const char *filename;
+    char *filename;
     int fromC;
     jl_getFunctionInfo(&name, &line, &filename, pointer, &fromC, skipC);
+    free(filename);
     if (!name)
         return 0;               // Did not find symbolic information
     // Describe the symbol

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -176,6 +176,23 @@ DLLEXPORT void jl_raise_debugger(void);
 #ifdef _OS_DARWIN_
 DLLEXPORT void attach_exception_port(void);
 #endif
+// Set *name and *filename to either NULL or malloc'd string
+void jl_getFunctionInfo(char **name, size_t *line, char **filename,
+                        uintptr_t pointer, int *fromC, int skipC);
+
+// *to is NULL or malloc'd pointer, from is allowed to be NULL
+static inline char *jl_copy_str(char **to, const char *from)
+{
+    if (!from) {
+        free(*to);
+        *to = NULL;
+        return NULL;
+    }
+    size_t len = strlen(from) + 1;
+    *to = (char*)realloc(*to, len);
+    memcpy(*to, from, len);
+    return *to;
+}
 
 // timers
 // Returns time in nanosec


### PR DESCRIPTION
Most of the leak is caused by [not freeing a `DIContext`](https://github.com/JuliaLang/julia/pull/12433/files#diff-d4b80bf89e46982070f234dd7cc344a9R801) but there's also a lot of small leaks because of the inconsistency when dealing with strings.

Valgrind shows some other leaks as well but those are much smaller and is possibly best solved by using the smart pointers in c++0x when we move to llvm 37.

Ref #12427 

@tkelman I only tested locally on llvm36. Can you try if this improves the memory consumption? The time is spent on retriving debug info (include 30% on getting the backtrace itself.) so this patch doesn't help with it too much.
