### PR TITLE
Add a system sync() to start_worker() for aggressive SGE buffering

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -980,6 +980,7 @@ function start_worker(out::IO)
     print(out, LPROC.bind_addr)
     print(out, '\n')
     flush(out)
+    ccall((:sync, "libc"), Void, ())   # necessary for SGE, which redirects and buffers stdout
     # close STDIN; workers will not use it
     #close(STDIN)
 


### PR DESCRIPTION
As reported [here](https://groups.google.com/forum/#!topic/julia-dev/Ms9pTNGoIvA), on a very large SGE cluster, the i/o buffering for stdout/stderr can be so aggressive that the (port,worker-ip) is never flushed to file---the very file that the master uses to find out what worker machines to connect to.  Thus, the workers time-out and the connection cannot be established.  Effectively, `addprocs_sge()` doesn't work on such a cluster. 

The only solution I could get working is to include a sync() in the workers, after the flush(), to ensure stdout---which is redirected by SGE to a file---is actually flushed.  
