### PR TITLE
use === for comparison to nothing

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -341,7 +341,7 @@ function hist_from_file(hp, file)
             error(invalid_history_message, repr(line[1]), " at line ", countlines)
         while !isempty(line)
             m = match(r"^#\s*(\w+)\s*:\s*(.*?)\s*$", line)
-            m == nothing && break
+            m === nothing && break
             if m.captures[1] == "mode"
                 mode = symbol(m.captures[2])
             end
@@ -387,7 +387,7 @@ function add_history(hist::REPLHistoryProvider, s)
         mode == hist.modes[end] && str == hist.history[end] && return
     push!(hist.modes, mode)
     push!(hist.history, str)
-    hist.history_file == nothing && return
+    hist.history_file === nothing && return
     entry = """
     # time: $(Libc.strftime("%Y-%m-%d %H:%M:%S %Z", time()))
     # mode: $mode

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1014,9 +1014,9 @@ function (.^){T<:Number}(B::BitArray, x::T)
         catch err
             uerr = err
         end
-        if zerr == nothing && uerr == nothing
+        if zerr === nothing && uerr === nothing
             t = promote_type(typeof(z), typeof(u))
-        elseif zerr == nothing
+        elseif zerr === nothing
             t = typeof(z)
         else
             t = typeof(u)
@@ -1024,13 +1024,13 @@ function (.^){T<:Number}(B::BitArray, x::T)
         F = Array(t, size(B))
         for i = 1:length(B)
             if B[i]
-                if uerr == nothing
+                if uerr === nothing
                     F[i] = u
                 else
                     throw(uerr)
                 end
             else
-                if zerr == nothing
+                if zerr === nothing
                     F[i] = z
                 else
                     throw(zerr)

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -245,7 +245,7 @@ function readdlm_string(sbuff::ByteString, dlm::Char, T::Type, eol::Char, auto::
 
     skipblanks = get(optsd, :skipblanks, true)
 
-    offset_handler = (dims == nothing) ? DLMOffsets(sbuff) : DLMStore(T, dims, has_header, sbuff, auto, eol)
+    offset_handler = (dims === nothing) ? DLMOffsets(sbuff) : DLMStore(T, dims, has_header, sbuff, auto, eol)
 
     for retry in 1:2
         try
@@ -259,7 +259,7 @@ function readdlm_string(sbuff::ByteString, dlm::Char, T::Type, eol::Char, auto::
             else
                 rethrow(ex)
             end
-            offset_handler = (dims == nothing) ? DLMOffsets(sbuff) : DLMStore(T, dims, has_header, sbuff, auto, eol)
+            offset_handler = (dims === nothing) ? DLMOffsets(sbuff) : DLMStore(T, dims, has_header, sbuff, auto, eol)
         end
     end
 

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -120,7 +120,7 @@ function parse(x::AbstractString,df::DateFormat)
     cursor = 1
     for slot in df.slots
         cursor, pe = getslot(x,slot,df,cursor)
-        pe != nothing && push!(periods,pe)
+        pe !== nothing && push!(periods,pe)
         cursor > endof(x) && break
     end
     return sort!(periods,rev=true,lt=periodisless)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -52,7 +52,7 @@ showdict(t::Associative; kw...) = showdict(STDOUT, t; kw...)
 function showdict{K,V}(io::IO, t::Associative{K,V}; limit::Bool = false, compact = false,
                        sz=(s = tty_size(); (s[1]-3, s[2])))
     shown_set = get(task_local_storage(), :SHOWNSET, nothing)
-    if shown_set == nothing
+    if shown_set === nothing
         shown_set = ObjectIdDict()
         task_local_storage(:SHOWNSET, shown_set)
     end

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -103,7 +103,7 @@ function doc(f::Function)
     for mod in modules
         if haskey(meta(mod), f)
             fd = meta(mod)[f]
-            length(docs) == 0 && fd.main != nothing && push!(docs, fd.main)
+            length(docs) == 0 && fd.main !== nothing && push!(docs, fd.main)
             if isa(fd, FuncDoc)
                 for m in fd.order
                     push!(docs, fd.meta[m])
@@ -139,7 +139,7 @@ function field_meta(def)
     for l in def.args[3].args
         if isdoc(l)
             doc = mdify(l)
-        elseif doc != nothing && isexpr(l, Symbol, :(::))
+        elseif doc !== nothing && isexpr(l, Symbol, :(::))
             meta[namify(l)] = doc
             doc = nothing
         end
@@ -175,7 +175,7 @@ function doc(f::DataType)
         if haskey(meta(mod), f)
             fd = meta(mod)[f]
             if isa(fd, TypeDoc)
-                length(docs) == 0 && fd.main != nothing && push!(docs, fd.main)
+                length(docs) == 0 && fd.main !== nothing && push!(docs, fd.main)
                 for m in fd.order
                     push!(docs, fd.meta[m])
                 end
@@ -209,7 +209,7 @@ doc(f, ::Method) = doc(f)
 
 function doc(m::Module)
     md = invoke(doc, Tuple{Any}, m)
-    md == nothing || return md
+    md === nothing || return md
     readme = Pkg.dir(string(m), "README.md")
     if isfile(readme)
         return Markdown.parse_file(readme)

--- a/base/env.jl
+++ b/base/env.jl
@@ -95,16 +95,16 @@ push!(::EnvHash, k::AbstractString, v) = setindex!(ENV, v, k)
 
 @unix_only begin
 start(::EnvHash) = 0
-done(::EnvHash, i) = (ccall(:jl_environ, Any, (Int32,), i) == nothing)
+done(::EnvHash, i) = (ccall(:jl_environ, Any, (Int32,), i) === nothing)
 
 function next(::EnvHash, i)
     env = ccall(:jl_environ, Any, (Int32,), i)
-    if env == nothing
+    if env === nothing
         throw(BoundsError())
     end
     env::ByteString
     m = match(r"^(.*?)=(.*)$"s, env)
-    if m == nothing
+    if m === nothing
         error("malformed environment entry: $env")
     end
     (Pair{ByteString,ByteString}(m.captures[1], m.captures[2]), i+1)
@@ -128,7 +128,7 @@ function next(hash::EnvHash, block::Tuple{Ptr{UInt16},Ptr{UInt16}})
     unsafe_copy!(pointer(buf), pos, len)
     env = utf8(UTF16String(buf))
     m = match(r"^(=?[^=]+)=(.*)$"s, env)
-    if m == nothing
+    if m === nothing
         error("malformed environment entry: $env")
     end
     (Pair{ByteString,ByteString}(m.captures[1], m.captures[2]), (pos+len*2, blk))
@@ -155,12 +155,12 @@ function withenv{T<:AbstractString}(f::Function, keyvals::Pair{T}...)
     old = Dict{T,Any}()
     for (key,val) in keyvals
         old[key] = get(ENV,key,nothing)
-        val != nothing ? (ENV[key]=val) : _unsetenv(key)
+        val !== nothing ? (ENV[key]=val) : _unsetenv(key)
     end
     try f()
     finally
         for (key,val) in old
-            val != nothing ? (ENV[key]=val) : _unsetenv(key)
+            val !== nothing ? (ENV[key]=val) : _unsetenv(key)
         end
     end
 end

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -24,7 +24,7 @@ function edit(file::AbstractString, line::Integer)
     issrc = length(file)>2 && file[end-2:end] == ".jl"
     if issrc
         f = find_source_file(file)
-        f != nothing && (file = f)
+        f !== nothing && (file = f)
     end
     const no_line_msg = "Unknown editor: no line number information passed.\nThe method is defined at line $line."
     if startswith(edname, "emacs") || edname == "gedit"
@@ -293,7 +293,7 @@ function methodswith(t::Type, f::Function, showparents::Bool=false, meths = Meth
         return meths
     end
     d = f.env.defs
-    while d != nothing
+    while d !== nothing
         if any(x -> (type_close_enough(x, t) ||
                      (showparents ? (t <: x && (!isa(x,TypeVar) || x.ub != Any)) :
                       (isa(x,TypeVar) && x.ub != Any && t == x.ub)) &&

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -133,6 +133,6 @@ log(::Irrational{:e}, x) = log(x)
 # align along = for nice Array printing
 function alignment(x::Irrational)
     m = match(r"^(.*?)(=.*)$", sprint(showcompact_lim, x))
-    m == nothing ? (length(sprint(showcompact_lim, x)), 0) :
+    m === nothing ? (length(sprint(showcompact_lim, x)), 0) :
     (length(m.captures[1]), length(m.captures[2]))
 end

--- a/base/latex_symbols.jl
+++ b/base/latex_symbols.jl
@@ -17,9 +17,9 @@ for c in child_nodes(root(xdoc))
         latex = nothing
         for el in ("AMS", "IEEE", "mathlatex", "latex")
             latex = find_element(ce, el)
-            latex != nothing && break
+            latex !== nothing && break
         end
-        if latex != nothing
+        if latex !== nothing
             L = strip(content(latex))
             id = attribute(ce, "id")
             U = string(map(s -> Char(parse(Int, s, 16)),

--- a/base/linalg/arnoldi.jl
+++ b/base/linalg/arnoldi.jl
@@ -59,7 +59,7 @@ function eigs(A, B;
         which=:LM
     end
 
-    if sigma != nothing && !iscmplx && isa(sigma,Complex)
+    if sigma !== nothing && !iscmplx && isa(sigma,Complex)
         throw(ArgumentError("complex shifts for real problems are not yet supported"))
     end
     sigma = isshift ? convert(T,sigma) : zero(T)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -36,7 +36,7 @@ end
 function find_source_file(file)
     (isabspath(file) || isfile(file)) && return file
     file2 = find_in_path(file)
-    file2 != nothing && return file2
+    file2 !== nothing && return file2
     file2 = joinpath(JULIA_HOME, DATAROOTDIR, "julia", "base", file)
     isfile(file2) ? file2 : nothing
 end
@@ -68,9 +68,9 @@ function _require_from_serialized(node::Int, path_to_try::ByteString, toplevel_l
             content = remotecall_fetch(node, open, readbytes, path_to_try)
         end
         restored = _include_from_serialized(content)
-        if restored != nothing
+        if restored !== nothing
             others = filter(x -> x != myid(), procs())
-            refs = Any[ @spawnat p (nothing != _include_from_serialized(content)) for p in others]
+            refs = Any[ @spawnat p (nothing !== _include_from_serialized(content)) for p in others]
             for (id, ref) in zip(others, refs)
                 if !fetch(ref)
                     warn("node state is inconsistent: node $id failed to load cache from $path_to_try")
@@ -91,7 +91,7 @@ function _require_from_serialized(node::Int, mod::Symbol, toplevel_load::Bool)
     paths = @fetchfrom node find_all_in_cache_path(mod)
     for path_to_try in paths
         restored = _require_from_serialized(node, path_to_try, toplevel_load)
-        if restored == nothing
+        if restored === nothing
             warn("deserialization checks failed while attempting to load cache from $path_to_try")
         else
             return restored
@@ -120,7 +120,7 @@ function require(mod::Symbol)
     try
         toplevel_load = false
         restored = _require_from_serialized(1, mod, last)
-        if restored != nothing
+        if restored !== nothing
             for M in restored
                 if isdefined(M, :__META__)
                     push!(Base.Docs.modules, M)
@@ -131,7 +131,7 @@ function require(mod::Symbol)
         if JLOptions().incremental != 0
             # spawn off a new incremental compile task from node 1 for recursive `require` calls
             cachefile = compile(mod)
-            if nothing == _require_from_serialized(1, cachefile, last)
+            if nothing === _require_from_serialized(1, cachefile, last)
                 warn("require failed to create a precompiled cache file")
             end
             return
@@ -189,7 +189,7 @@ macro __FILE__() source_path() end
 
 function include_from_node1(path::AbstractString)
     prev = source_path(nothing)
-    path = (prev == nothing) ? abspath(path) : joinpath(dirname(prev),path)
+    path = (prev === nothing) ? abspath(path) : joinpath(dirname(prev),path)
     tls = task_local_storage()
     tls[:SOURCE_PATH] = path
     local result
@@ -203,7 +203,7 @@ function include_from_node1(path::AbstractString)
             result = include_string(remotecall_fetch(1, readall, path), path)
         end
     finally
-        if prev == nothing
+        if prev === nothing
             delete!(tls, :SOURCE_PATH)
         else
             tls[:SOURCE_PATH] = prev

--- a/base/markdown/Common/block.jl
+++ b/base/markdown/Common/block.jl
@@ -168,7 +168,7 @@ function list(stream::IO, block::MD)
     withstream(stream) do
         eatindent(stream) || return false
         b = startswith(stream, num_or_bullets)
-        (b == nothing || b == "") && return false
+        (b === nothing || b == "") && return false
         ordered = !(b[1] in bullets)
         if ordered
             b = b[end - 1] == '.' ? r"^\d+\. " : r"^\d+\) "

--- a/base/markdown/Common/inline.jl
+++ b/base/markdown/Common/inline.jl
@@ -11,7 +11,7 @@ end
 @trigger '*' ->
 function asterisk_italic(stream::IO, md::MD)
     result = parse_inline_wrapper(stream, "*")
-    return result == nothing ? nothing : Italic(parseinline(result, md))
+    return result === nothing ? nothing : Italic(parseinline(result, md))
 end
 
 type Bold
@@ -21,7 +21,7 @@ end
 @trigger '*' ->
 function asterisk_bold(stream::IO, md::MD)
     result = parse_inline_wrapper(stream, "**")
-    return result == nothing ? nothing : Bold(parseinline(result, md))
+    return result === nothing ? nothing : Bold(parseinline(result, md))
 end
 
 # ––––
@@ -31,7 +31,7 @@ end
 @trigger '`' ->
 function inline_code(stream::IO, md::MD)
     result = parse_inline_wrapper(stream, "`"; rep=true)
-    return result == nothing ? nothing : Code(result)
+    return result === nothing ? nothing : Code(result)
 end
 
 # ––––––––––––––

--- a/base/markdown/GitHub/table.jl
+++ b/base/markdown/GitHub/table.jl
@@ -43,14 +43,14 @@ function github_table(stream::IO, md::MD)
         rows = []
         cols = 0
         align = nothing
-        while (row = parserow(stream)) != nothing
+        while (row = parserow(stream)) !== nothing
             if length(rows) == 0
                 row[1] == "" && return false
                 cols = length(row)
             end
-            if align == nothing && length(rows) == 1 # Must have a --- row
+            if align === nothing && length(rows) == 1 # Must have a --- row
                 align = parsealign(row)
-                (align == nothing || length(align) != cols) && return false
+                (align === nothing || length(align) != cols) && return false
             else
                 push!(rows, map(x -> parseinline(x, md), rowlength!(row, cols)))
             end

--- a/base/markdown/IPython/IPython.jl
+++ b/base/markdown/IPython/IPython.jl
@@ -7,7 +7,7 @@ end
 @trigger '$' ->
 function tex(stream::IO, md::MD)
     result = parse_inline_wrapper(stream, "\$", rep = true)
-    return result == nothing ? nothing : LaTeX(result)
+    return result === nothing ? nothing : LaTeX(result)
 end
 
 function blocktex(stream::IO, md::MD)

--- a/base/markdown/parse/parse.jl
+++ b/base/markdown/parse/parse.jl
@@ -53,7 +53,7 @@ function parseinline(stream::IO, md::MD, config::Config)
     while !eof(stream)
         char = peek(stream)
         if haskey(config.inner, char) &&
-                (inner = parseinline(stream, md, config.inner[char])) != nothing
+                (inner = parseinline(stream, md, config.inner[char])) !== nothing
             c = takebuf_string(buffer)
             !isempty(c) && push!(content, c)
             buffer = IOBuffer()

--- a/base/markdown/parse/util.jl
+++ b/base/markdown/parse/util.jl
@@ -101,7 +101,7 @@ function startswith(stream::IO, r::Regex; eat = true, padding = false)
     line = chomp(readline(stream))
     seek(stream, start)
     m = match(r, line)
-    m == nothing && return ""
+    m === nothing && return ""
     eat && @dotimes length(m.match) read(stream, Char)
     return m.match
 end

--- a/base/markdown/render/html.jl
+++ b/base/markdown/render/html.jl
@@ -13,7 +13,7 @@ function withtag(f, io::IO, tag, attrs...)
         htmlesc(io, value)
         print(io, "\"")
     end
-    f == nothing && return print(io, " />")
+    f === nothing && return print(io, " />")
 
     print(io, ">")
     f()

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -82,7 +82,7 @@ end
 show(io::IO, mt::MethodTable) = show_method_table(io, mt)
 
 inbase(m::Module) = m == Base ? true : m == Main ? false : inbase(module_parent(m))
-fileurl(file) = let f = find_source_file(file); f == nothing ? "" : "file://"*f; end
+fileurl(file) = let f = find_source_file(file); f === nothing ? "" : "file://"*f; end
 function url(m::Method)
     M = m.func.code.module
     (m.func.code.file == :null || m.func.code.file == :string) && return ""

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1045,7 +1045,7 @@ end
 
 function parse_connection_info(str)
     m = match(r"^julia_worker:(\d+)#(.*)", str)
-    if m != nothing
+    if m !== nothing
         (m.captures[2], parse(Int16, m.captures[1]))
     else
         ("", Int16(-1))
@@ -1414,7 +1414,7 @@ function pmap(f, lsts...; err_retry=true, err_stop=false, pids = workers())
         for (pididx, wpid) in enumerate(pids)
             @async begin
                 tasklet = getnext_tasklet()
-                while (tasklet != nothing)
+                while (tasklet !== nothing)
                     (idx, fvals) = tasklet
                     busy_workers[pididx] = true
                     try

--- a/base/path.jl
+++ b/base/path.jl
@@ -32,7 +32,7 @@ isdirpath(path::AbstractString) = ismatch(path_directory_re, splitdrive(path)[2]
 function splitdir(path::ByteString)
     a, b = splitdrive(path)
     m = match(path_dir_splitter,b)
-    m == nothing && return (a,b)
+    m === nothing && return (a,b)
     a = string(a, isempty(m.captures[1]) ? m.captures[2][1] : m.captures[1])
     a, bytestring(m.captures[3])
 end
@@ -44,14 +44,14 @@ basename(path::AbstractString) = splitdir(path)[2]
 function splitext(path::AbstractString)
     a, b = splitdrive(path)
     m = match(path_ext_splitter, b)
-    m == nothing && return (path,"")
+    m === nothing && return (path,"")
     a*m.captures[1], bytestring(m.captures[2])
 end
 
 function pathsep(paths::AbstractString...)
     for path in paths
         m = match(path_separator_re, path)
-        m != nothing && return m.match[1]
+        m !== nothing && return m.match[1]
     end
     return path_separator
 end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -31,7 +31,7 @@ end
 
 function edit()
     editor = get(ENV,"VISUAL",get(ENV,"EDITOR",nothing))
-    editor != nothing ||
+    editor !== nothing ||
         error("set the EDITOR environment variable to an edit command")
     editor = Base.shell_split(editor)
     reqs = Reqs.parse("REQUIRE")
@@ -173,7 +173,7 @@ function clone(url_or_pkg::AbstractString)
     else
         url = url_or_pkg
         m = match(r"(?:^|[/\\])(\w+?)(?:\.jl)?(?:\.git)?$", url)
-        m != nothing || error("can't determine package name from URL: $url")
+        m !== nothing || error("can't determine package name from URL: $url")
         pkg = m.captures[1]
     end
     clone(url,pkg)
@@ -313,7 +313,7 @@ function pull_request(dir::AbstractString, commit::AbstractString="", url::Abstr
         Git.readchomp(`rev-parse --verify $commit`, dir=dir)
     isempty(url) && (url = Git.readchomp(`config remote.origin.url`, dir=dir))
     m = match(Git.GITHUB_REGEX, url)
-    m == nothing && error("not a GitHub repo URL, can't make a pull request: $url")
+    m === nothing && error("not a GitHub repo URL, can't make a pull request: $url")
     owner, repo = m.captures[2:3]
     user = GitHub.user()
     info("Forking $owner/$repo to $user")
@@ -346,7 +346,7 @@ function publish(branch::AbstractString)
     for line in eachline(Git.cmd(cmd, dir="METADATA"))
         path = chomp(line)
         m = match(r"^(.+?)/versions/([^/]+)/sha1$", path)
-        m != nothing && ismatch(Base.VERSION_REGEX, m.captures[2]) || continue
+        m !== nothing && ismatch(Base.VERSION_REGEX, m.captures[2]) || continue
         pkg, ver = m.captures; ver = convert(VersionNumber,ver)
         sha1 = readchomp(joinpath("METADATA",path))
         if Git.success(`cat-file -e origin/$branch:$path`, dir="METADATA")
@@ -443,7 +443,7 @@ function resolve(
             if ver1 === nothing
                 info("Installing $pkg v$ver2")
                 Write.install(pkg, Read.sha1(pkg,ver2))
-            elseif ver2 == nothing
+            elseif ver2 === nothing
                 info("Removing $pkg v$ver1")
                 Write.remove(pkg)
             else
@@ -455,10 +455,10 @@ function resolve(
         end
     catch
         for (pkg,(ver1,ver2)) in reverse!(changed)
-            if ver1 == nothing
+            if ver1 === nothing
                 info("Rolling back install of $pkg")
                 @recover Write.remove(pkg)
-            elseif ver2 == nothing
+            elseif ver2 === nothing
                 info("Rolling back deleted $pkg to v$ver1")
                 @recover Write.install(pkg, Read.sha1(pkg,ver1))
             else
@@ -469,7 +469,7 @@ function resolve(
         rethrow()
     end
     # re/build all updated/installed packages
-    build(map(x->x[1],filter(x->x[2][2]!=nothing,changes)))
+    build(map(x->x[1], filter(x -> x[2][2] !== nothing, changes)))
 end
 
 function write_tag_metadata(pkg::AbstractString, ver::VersionNumber, commit::AbstractString, force::Bool=false)

--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -13,7 +13,7 @@ function git_contributors(dir::AbstractString, n::Int=typemax(Int))
     tty = @windows? "CON:" : "/dev/tty"
     for line in eachline(pipe(tty, Git.cmd(`shortlog -nes`, dir=dir)))
         m = match(r"\s*(\d+)\s+(.+?)\s+\<(.+?)\>\s*$", line)
-        m == nothing && continue
+        m === nothing && continue
         commits, name, email = m.captures
         if haskey(contrib,email)
             contrib[email][1] += parse(Int,commits)

--- a/base/pkg/git.jl
+++ b/base/pkg/git.jl
@@ -111,14 +111,14 @@ const GITHUB_REGEX =
 function set_remote_url(url::AbstractString; remote::AbstractString="origin", dir="")
     run(`config remote.$remote.url $url`, dir=dir)
     m = match(GITHUB_REGEX,url)
-    m == nothing && return
+    m === nothing && return
     push = "git@github.com:$(m.captures[1]).git"
     push != url && run(`config remote.$remote.pushurl $push`, dir=dir)
 end
 
 function normalize_url(url::AbstractString)
     m = match(GITHUB_REGEX,url)
-    m == nothing ? url : "git://github.com/$(m.captures[1]).git"
+    m === nothing ? url : "git://github.com/$(m.captures[1]).git"
 end
 
 end # module

--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -169,7 +169,7 @@ end
 function issue_url(pkg::AbstractString)
     ispath(pkg,".git") || return ""
     m = match(Git.GITHUB_REGEX, url(pkg))
-    m == nothing && return ""
+    m === nothing && return ""
     return "https://github.com/" * m.captures[1] * "/issues"
 end
 

--- a/base/pkg/resolve/interface.jl
+++ b/base/pkg/resolve/interface.jl
@@ -302,7 +302,7 @@ function enforce_optimality!(sol::Vector{Int}, interface::Interface)
             # dependency of another package
             for (p1,d) in prevdeps[p0]
                 vs = get(d, sol[p1], nothing)
-                if vs == nothing
+                if vs === nothing
                     continue
                 end
                 vn = pvers[p0][s0+1]

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -276,7 +276,7 @@ function gen_d(flags::ASCIIString, width::Int, precision::Int, c::Char)
         end
     end
     # print space padding
-    if padding != nothing && !('-' in flags)
+    if padding !== nothing && !('-' in flags)
         push!(blk.args, pad(width-precision, padding, ' '))
     end
     # print sign
@@ -297,7 +297,7 @@ function gen_d(flags::ASCIIString, width::Int, precision::Int, c::Char)
     # print integer
     push!(blk.args, :(write(out, pointer(DIGITS), pt)))
     # print padding
-    if padding != nothing && '-' in flags
+    if padding !== nothing && '-' in flags
         push!(blk.args, pad(width-precision, padding, ' '))
     end
     # return arg, expr
@@ -339,7 +339,7 @@ function gen_f(flags::ASCIIString, width::Int, precision::Int, c::Char)
         end
     end
     # print space padding
-    if padding != nothing && !('-' in flags) && !('0' in flags)
+    if padding !== nothing && !('-' in flags) && !('0' in flags)
         push!(blk.args, pad(width-1, padding, ' '))
     end
     # print sign
@@ -347,7 +347,7 @@ function gen_f(flags::ASCIIString, width::Int, precision::Int, c::Char)
     ' ' in flags ? push!(blk.args, :(write(out, neg?'-':' '))) :
                    push!(blk.args, :(neg && write(out, '-')))
     # print zero padding
-    if padding != nothing && !('-' in flags) && '0' in flags
+    if padding !== nothing && !('-' in flags) && '0' in flags
         push!(blk.args, pad(width-1, padding, '0'))
     end
     # print digits
@@ -359,7 +359,7 @@ function gen_f(flags::ASCIIString, width::Int, precision::Int, c::Char)
         '#' in flags && push!(blk.args, :(write(out, '.')))
     end
     # print space padding
-    if padding != nothing && '-' in flags
+    if padding !== nothing && '-' in flags
         push!(blk.args, pad(width-1, padding, ' '))
     end
     # return arg, expr
@@ -427,7 +427,7 @@ function gen_e(flags::ASCIIString, width::Int, precision::Int, c::Char)
         end
     end
     # print space padding
-    if padding != nothing && !('-' in flags) && !('0' in flags)
+    if padding !== nothing && !('-' in flags) && !('0' in flags)
         push!(blk.args, pad(width, padding, ' '))
     end
     # print sign
@@ -435,7 +435,7 @@ function gen_e(flags::ASCIIString, width::Int, precision::Int, c::Char)
     ' ' in flags ? push!(blk.args, :(write(out, neg?'-':' '))) :
                     push!(blk.args, :(neg && write(out, '-')))
     # print zero padding
-    if padding != nothing && !('-' in flags) && '0' in flags
+    if padding !== nothing && !('-' in flags) && '0' in flags
         push!(blk.args, pad(width, padding, '0'))
     end
     # print digits
@@ -453,7 +453,7 @@ function gen_e(flags::ASCIIString, width::Int, precision::Int, c::Char)
     end
     push!(blk.args, :(print_exp_e(out, exp)))
     # print space padding
-    if padding != nothing && '-' in flags
+    if padding !== nothing && '-' in flags
         push!(blk.args, pad(width, padding, ' '))
     end
     # return arg, expr
@@ -521,7 +521,7 @@ function gen_a(flags::ASCIIString, width::Int, precision::Int, c::Char)
         end
     end
     # print space padding
-    if padding != nothing && !('-' in flags) && !('0' in flags)
+    if padding !== nothing && !('-' in flags) && !('0' in flags)
         push!(blk.args, pad(width, padding, ' '))
     end
     # print sign
@@ -533,7 +533,7 @@ function gen_a(flags::ASCIIString, width::Int, precision::Int, c::Char)
         push!(blk.args, :(write(out, $ch)))
     end
     # print zero padding
-    if padding != nothing && !('-' in flags) && '0' in flags
+    if padding !== nothing && !('-' in flags) && '0' in flags
         push!(blk.args, pad(width, padding, '0'))
     end
     # print digits
@@ -561,7 +561,7 @@ function gen_a(flags::ASCIIString, width::Int, precision::Int, c::Char)
     end
     push!(blk.args, :(print_exp_a(out, exp)))
     # print space padding
-    if padding != nothing && '-' in flags
+    if padding !== nothing && '-' in flags
         push!(blk.args, pad(width, padding, ' '))
     end
     # return arg, expr

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -26,11 +26,11 @@ end
 function init(; n::Union{Void,Integer} = nothing, delay::Union{Void,Float64} = nothing)
     n_cur = ccall(:jl_profile_maxlen_data, Csize_t, ())
     delay_cur = ccall(:jl_profile_delay_nsec, UInt64, ())/10^9
-    if n == nothing && delay == nothing
+    if n === nothing && delay === nothing
         return Int(n_cur), delay_cur
     end
-    nnew = (n == nothing) ? n_cur : n
-    delaynew = (delay == nothing) ? delay_cur : delay
+    nnew = (n === nothing) ? n_cur : n
+    delaynew = (delay === nothing) ? delay_cur : delay
     init(nnew, delaynew)
 end
 
@@ -69,11 +69,11 @@ function getdict(data::Vector{UInt})
 end
 
 function callers(funcname::ByteString, bt::Vector{UInt}, lidict; filename = nothing, linerange = nothing)
-    if filename == nothing && linerange == nothing
+    if filename === nothing && linerange === nothing
         return callersf(li -> li.func == funcname, bt, lidict)
     end
-    filename == nothing && throw(ArgumentError("if supplying linerange, you must also supply the filename"))
-    if linerange == nothing
+    filename === nothing && throw(ArgumentError("if supplying linerange, you must also supply the filename"))
+    if linerange === nothing
         return callersf(li -> li.func == funcname && li.file == filename, bt, lidict)
     else
         return callersf(li -> li.func == funcname && li.file == filename && in(li.line, linerange), bt, lidict)

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -306,7 +306,7 @@ end
 compile(itr::RegexMatchIterator) = (compile(itr.regex); itr)
 eltype(::Type{RegexMatchIterator}) = RegexMatch
 start(itr::RegexMatchIterator) = match(itr.regex, itr.string, 1, UInt32(0))
-done(itr::RegexMatchIterator, prev_match) = (prev_match == nothing)
+done(itr::RegexMatchIterator, prev_match) = (prev_match === nothing)
 
 # Assumes prev_match is not nothing
 function next(itr::RegexMatchIterator, prev_match)

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -367,7 +367,7 @@ function shm_mmap_array(T, dims, shm_seg_name, mode)
         rethrow(e)
 
     finally
-        if s != nothing
+        if s !== nothing
             close(s)
         end
     end

--- a/base/show.jl
+++ b/base/show.jl
@@ -13,7 +13,7 @@ function show_default(io::IO, x::ANY)
     if nf != 0 || t.size==0
         recorded = false
         shown_set = get(task_local_storage(), :SHOWNSET, nothing)
-        if shown_set == nothing
+        if shown_set === nothing
             shown_set = ObjectIdDict()
             task_local_storage(:SHOWNSET, shown_set)
         end
@@ -952,17 +952,17 @@ alignment(x::Number) = (length(sprint(showcompact_lim, x)), 0)
 alignment(x::Integer) = (length(sprint(showcompact_lim, x)), 0)
 function alignment(x::Real)
     m = match(r"^(.*?)((?:[\.eE].*)?)$", sprint(showcompact_lim, x))
-    m == nothing ? (length(sprint(showcompact_lim, x)), 0) :
+    m === nothing ? (length(sprint(showcompact_lim, x)), 0) :
                    (length(m.captures[1]), length(m.captures[2]))
 end
 function alignment(x::Complex)
     m = match(r"^(.*[\+\-])(.*)$", sprint(showcompact_lim, x))
-    m == nothing ? (length(sprint(showcompact_lim, x)), 0) :
+    m === nothing ? (length(sprint(showcompact_lim, x)), 0) :
                    (length(m.captures[1]), length(m.captures[2]))
 end
 function alignment(x::Rational)
     m = match(r"^(.*?/)(/.*)$", sprint(showcompact_lim, x))
-    m == nothing ? (length(sprint(showcompact_lim, x)), 0) :
+    m === nothing ? (length(sprint(showcompact_lim, x)), 0) :
                    (length(m.captures[1]), length(m.captures[2]))
 end
 

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -41,7 +41,7 @@ function var(iterable; corrected::Bool=true, mean=nothing)
     end
     count = 1
     value, state = next(iterable, state)
-    if mean == nothing
+    if mean === nothing
         # Use Welford algorithm as seen in (among other places)
         # Knuth's TAOCP, Vol 2, page 232, 3rd edition.
         M = value / 1
@@ -160,14 +160,14 @@ varm{T}(A::AbstractArray{T}, m::AbstractArray, region; corrected::Bool=true) =
 
 function var{T}(A::AbstractArray{T}; corrected::Bool=true, mean=nothing)
     convert(momenttype(T), mean == 0 ? varzm(A; corrected=corrected) :
-                           mean == nothing ? varm(A, Base.mean(A); corrected=corrected) :
+                           mean === nothing ? varm(A, Base.mean(A); corrected=corrected) :
                            isa(mean, Number) ? varm(A, mean::Number; corrected=corrected) :
                            throw(ArgumentError("invalid value of mean, $(mean)::$(typeof(mean))")))::momenttype(T)
 end
 
 function var(A::AbstractArray, region; corrected::Bool=true, mean=nothing)
     mean == 0 ? varzm(A, region; corrected=corrected) :
-    mean == nothing ? varm(A, Base.mean(A, region), region; corrected=corrected) :
+    mean === nothing ? varm(A, Base.mean(A, region), region; corrected=corrected) :
     isa(mean, AbstractArray) ? varm(A, mean::AbstractArray, region; corrected=corrected) :
     throw(ArgumentError("invalid value of mean, $(mean)::$(typeof(mean))"))
 end
@@ -285,21 +285,21 @@ covm(x::AbstractVecOrMat, xmean, y::AbstractVecOrMat, ymean; vardim::Int=1, corr
 
 function cov(x::AbstractVector; corrected::Bool=true, mean=nothing)
     mean == 0 ? covzm(x; corrected=corrected) :
-    mean == nothing ? covm(x, Base.mean(x); corrected=corrected) :
+    mean === nothing ? covm(x, Base.mean(x); corrected=corrected) :
     isa(mean, Number) ? covm(x, mean; corrected=corrected) :
     throw(ArgumentError("invalid value of mean, $(mean)::$(typeof(mean))"))
 end
 
 function cov(x::AbstractMatrix; vardim::Int=1, corrected::Bool=true, mean=nothing)
     mean == 0 ? covzm(x; vardim=vardim, corrected=corrected) :
-    mean == nothing ? covm(x, _vmean(x, vardim); vardim=vardim, corrected=corrected) :
+    mean === nothing ? covm(x, _vmean(x, vardim); vardim=vardim, corrected=corrected) :
     isa(mean, AbstractArray) ? covm(x, mean; vardim=vardim, corrected=corrected) :
     throw(ArgumentError("invalid value of mean, $(mean)::$(typeof(mean))"))
 end
 
 function cov(x::AbstractVector, y::AbstractVector; corrected::Bool=true, mean=nothing)
     mean == 0 ? covzm(x, y; corrected=corrected) :
-    mean == nothing ? covm(x, Base.mean(x), y, Base.mean(y); corrected=corrected) :
+    mean === nothing ? covm(x, Base.mean(x), y, Base.mean(y); corrected=corrected) :
     isa(mean, (Number,Number)) ? covm(x, mean[1], y, mean[2]; corrected=corrected) :
     throw(ArgumentError("invalid value of mean, $(mean)::$(typeof(mean))"))
 end
@@ -307,7 +307,7 @@ end
 function cov(x::AbstractVecOrMat, y::AbstractVecOrMat; vardim::Int=1, corrected::Bool=true, mean=nothing)
     if mean == 0
         covzm(x, y; vardim=vardim, corrected=corrected)
-    elseif mean == nothing
+    elseif mean === nothing
         covm(x, _vmean(x, vardim), y, _vmean(y, vardim); vardim=vardim, corrected=corrected)
     elseif isa(mean, (Any,Any))
         covm(x, mean[1], y, mean[2]; vardim=vardim, corrected=corrected)
@@ -421,21 +421,21 @@ corm(x::AbstractVecOrMat, xmean, y::AbstractVecOrMat, ymean; vardim::Int=1) =
 
 function cor(x::AbstractVector; mean=nothing)
     mean == 0 ? corzm(x) :
-    mean == nothing ? corm(x, Base.mean(x)) :
+    mean === nothing ? corm(x, Base.mean(x)) :
     isa(mean, Number) ? corm(x, mean) :
     throw(ArgumentError("invalid value of mean, $(mean)::$(typeof(mean))"))
 end
 
 function cor(x::AbstractMatrix; vardim::Int=1, mean=nothing)
     mean == 0 ? corzm(x; vardim=vardim) :
-    mean == nothing ? corm(x, _vmean(x, vardim); vardim=vardim) :
+    mean === nothing ? corm(x, _vmean(x, vardim); vardim=vardim) :
     isa(mean, AbstractArray) ? corm(x, mean; vardim=vardim) :
     throw(ArgumentError("invalid value of mean, $(mean)::$(typeof(mean))"))
 end
 
 function cor(x::AbstractVector, y::AbstractVector; mean=nothing)
     mean == 0 ? corzm(x, y) :
-    mean == nothing ? corm(x, Base.mean(x), y, Base.mean(y)) :
+    mean === nothing ? corm(x, Base.mean(x), y, Base.mean(y)) :
     isa(mean, (Number,Number)) ? corm(x, mean[1], y, mean[2]) :
     throw(ArgumentError("invalid value of mean, $(mean)::$(typeof(mean))"))
 end
@@ -443,7 +443,7 @@ end
 function cor(x::AbstractVecOrMat, y::AbstractVecOrMat; vardim::Int=1, mean=nothing)
     if mean == 0
         corzm(x, y; vardim=vardim)
-    elseif mean == nothing
+    elseif mean === nothing
         corm(x, _vmean(x, vardim), y, _vmean(y, vardim); vardim=vardim)
     elseif isa(mean, (Any,Any))
         corm(x, mean[1], y, mean[2]; vardim=vardim)

--- a/base/test.jl
+++ b/base/test.jl
@@ -24,7 +24,7 @@ end
 
 default_handler(r::Success) = r.res
 function default_handler(r::Failure)
-    if r.resultexpr != nothing
+    if r.resultexpr !== nothing
         error("test failed: $(r.resultexpr)\n in expression: $(r.expr)")
     else
         error("test failed in expression: $(r.expr)")
@@ -57,9 +57,9 @@ end
 function do_test_throws(body, qex, bt, extype)
     handler()(try
         body()
-        Failure(qex, "$qex did not throw $(extype == nothing ? "anything" : extype)")
+        Failure(qex, "$qex did not throw $(extype === nothing ? "anything" : extype)")
     catch err
-        if extype == nothing
+        if extype === nothing
             Base.warn("""
             @test_throws without an exception type is deprecated;
             Use `@test_throws $(typeof(err)) $(qex)` instead.
@@ -193,7 +193,7 @@ function test_approx_eq_modphase{S<:Real,T<:Real}(
 
     m, n = size(a)
     @test n==size(b, 2) && m==size(b, 1)
-    err==nothing && (err=m^3*(eps(S)+eps(T)))
+    err === nothing && (err=m^3*(eps(S)+eps(T)))
     for i=1:n
         v1, v2 = a[:, i], b[:, i]
         @test_approx_eq_eps min(abs(norm(v1-v2)), abs(norm(v1+v2))) 0.0 err

--- a/base/version.jl
+++ b/base/version.jl
@@ -83,16 +83,16 @@ end
 
 VersionNumber(v::AbstractString) = begin
     m = match(VERSION_REGEX, v)
-    m == nothing && throw(ArgumentError("invalid version string: $v"))
+    m === nothing && throw(ArgumentError("invalid version string: $v"))
     major, minor, patch, minus, prerl, plus, build = m.captures
     major = parse(Int, major)
-    minor = minor != nothing ? parse(Int, minor) : 0
-    patch = patch != nothing ? parse(Int, patch) : 0
-    if prerl != nothing && !isempty(prerl) && prerl[1] == '-'
+    minor = minor !== nothing ? parse(Int, minor) : 0
+    patch = patch !== nothing ? parse(Int, patch) : 0
+    if prerl !== nothing && !isempty(prerl) && prerl[1] == '-'
         prerl = prerl[2:end] # strip leading '-'
     end
-    prerl = prerl != nothing ? split_idents(prerl) : minus == "-" ? ("",) : ()
-    build = build != nothing ? split_idents(build) : plus  == "+" ? ("",) : ()
+    prerl = prerl !== nothing ? split_idents(prerl) : minus == "-" ? ("",) : ()
+    build = build !== nothing ? split_idents(build) : plus  == "+" ? ("",) : ()
     VersionNumber(major, minor, patch, prerl, build)
 end
 


### PR DESCRIPTION
Just a little code cleanup & (probably very minor) performance enhancement.  As mentioned by @yuyichao in [#12302 (comment)](https://github.com/JuliaLang/julia/pull/12302#discussion_r36056483), it can be slightly more efficient to use `===` when comparing objects to `nothing`.

This is always safe because there is only a single `nothing` object in Julia, and I guess it avoids a runtime type lookup and method dispatch when the type of the object being compared to is not known (which will often be the case if you are comparing to `nothing`).  (Compare `code_llvm(foo, (Any,))` for `foo(x) = x == nothing` vs. `===`.)

(In many instances, it may make no difference since the type being compared to is probably inferred as `Union(Void, SomeConcreteType)`, but it can't hurt.)
