### PR TITLE
minor fixes to exception processing and testing

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -340,14 +340,17 @@ function show_backtrace(io::IO, t, set=1:typemax(Int))
     # we may not declare :eval_user_input
     # directly so that we get a compile error
     # in case its name changes in the future
-    process_entry(lastname, lastfile, lastline, n) = show_trace_entry(io, lastname, lastfile, lastline, n)
+    show_backtrace(io,
+                    try
+                        symbol(string(eval_user_input))
+                    catch
+                        :(:) #for when client.jl is not yet defined
+                    end, t, set)
+end
 
-    process_backtrace(process_entry,
-                        try
-                            symbol(string(eval_user_input))
-                        catch
-                            :(:) #for when client.jl is not yet defined
-                        end, t, set)
+function show_backtrace(io::IO, top_function::Symbol, t, set)
+    process_entry(lastname, lastfile, lastline, n) = show_trace_entry(io, lastname, lastfile, lastline, n)
+    process_backtrace(process_entry, top_function, t, set)
 end
 
 # process the backtrace, up to (but not including) top_function

--- a/base/task.jl
+++ b/base/task.jl
@@ -8,6 +8,7 @@ Task(f) = Task(()->f())
 function show(io::IO, t::Task)
     print(io, "Task ($(t.state)) @0x$(hex(convert(UInt, pointer_from_objref(t)), WORD_SIZE>>2))")
     if t.state == :failed
+        println(io)
         show(io, CapturedException(t.result, t.backtrace))
     end
 end

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -287,21 +287,21 @@ try
         end
     end
 catch ex
-    @test isa(ex, CompositeException)
+    @test typeof(ex) == CompositeException
     @test length(ex) == 5
-    @test isa(ex.exceptions[1], CapturedException)
-    @test isa(ex.exceptions[1].ex, ErrorException)
+    @test typeof(ex.exceptions[1]) == CapturedException
+    @test typeof(ex.exceptions[1].ex) == ErrorException
     errors = map(x->x.ex.msg, ex.exceptions)
     @test collect(1:5) == sort(map(x->parse(Int, x), errors))
 end
 
 try
     remotecall_fetch(id_other, ()->throw(ErrorException("foobar")))
-catch e
-    @test isa(e, RemoteException)
-    @test isa(e.captured, CapturedException)
-    @test isa(e.captured.ex, ErrorException)
-    @test e.captured.ex.msg == "foobar"
+catch ex
+    @test typeof(ex) == RemoteException
+    @test typeof(ex.captured) == CapturedException
+    @test typeof(ex.captured.ex) == ErrorException
+    @test ex.captured.ex.msg == "foobar"
 end
 
 # The below block of tests are usually run only on local development systems, since:


### PR DESCRIPTION
- restores  `show_backtrace(io::IO, top_function::Symbol, t, set)`
- changes `@test` exception type testing from `isa` to `typeof` to better capture cause of test failure.  
