### PR TITLE
WIP: Add specialized methods for determinant of small matrices

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -528,8 +528,48 @@ function det{T}(A::AbstractMatrix{T})
         S = typeof((one(T)*zero(T) + zero(T))/one(T))
         return convert(S, det(UpperTriangular(A)))
     end
+    if T <: Union{Real, Complex}
+        n = chksquare(A)
+        n == 1 && return A[1]
+        n == 2 && return det2x2(A)
+        n == 3 && return det3x3(A)
+        n == 4 && return det4x4(A)
+    end
     return det(lufact(A))
 end
+
+function det2x2(A)
+    @inbounds d = A[1,1]*A[2,2] - A[1,2]*A[2,1]
+    d
+end
+
+function det3x3(A)
+    @inbounds begin
+        d = A[1,1] * (A[2,2]*A[3,3] - A[2,3]*A[3,2]) -
+            A[1,2] * (A[2,1]*A[3,3] - A[2,3]*A[3,1]) +
+            A[1,3] * (A[2,1]*A[3,2] - A[2,2]*A[3,1])
+    end
+    d
+end
+
+function det4x4(A)
+    @inbounds begin
+    d = A[13] * A[10]  * A[7]  * A[4]  - A[9] * A[14] * A[7]  * A[4]   -
+        A[13] * A[6]   * A[11] * A[4]  + A[5] * A[14] * A[11] * A[4]   +
+        A[9]  * A[6]   * A[15] * A[4]  - A[5] * A[10] * A[15] * A[4]   -
+        A[13] * A[10]  * A[3]  * A[8]  + A[9] * A[14] * A[3]  * A[8]   +
+        A[13] * A[2]   * A[11] * A[8]  - A[1] * A[14] * A[11] * A[8]   -
+        A[9]  * A[2]   * A[15] * A[8]  + A[1] * A[10] * A[15] * A[8]   +
+        A[13] * A[6]   * A[3]  * A[12] - A[5] * A[14] * A[3]  * A[12]  -
+        A[13] * A[2]   * A[7]  * A[12] + A[1] * A[14] * A[7]  * A[12]  +
+        A[5]  * A[2]   * A[15] * A[12] - A[1] * A[6]  * A[15] * A[12]  -
+        A[9]  * A[6]   * A[3]  * A[16] + A[5] * A[10] * A[3]  * A[16]  +
+        A[9]  * A[2]   * A[7]  * A[16] - A[1] * A[10] * A[7]  * A[16]  -
+        A[5]  * A[2]   * A[11] * A[16] + A[1] * A[6]  * A[11] * A[16]
+    end
+    d
+end
+
 det(x::Number) = x
 
 logdet(A::AbstractMatrix) = logdet(lufact(A))

--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -438,3 +438,13 @@ for elty in (Float32, Float64, Complex64, Complex128)
     # symmetric, indefinite
     @test_approx_eq inv(convert(Matrix{elty}, [1. 2; 2 1])) convert(Matrix{elty}, [-1. 2; 2 -1]/3)
 end
+
+# Test specialized determinants for n = 1,2,3,4
+let
+    for n = 1:4
+        for T in [Float32, Float64, Complex64, Complex128]
+            A = rand(T, n,n)
+            @test_approx_eq det(A) det(lufact(A))
+        end
+    end
+end


### PR DESCRIPTION
We currently have specialized methods for 2x2 and 3x3 matrices when it comes to matrix multiplication. This is because the overhead in calling BLAS is significant in these cases. There is currently no such optimization for determinants. This PR implements specialized methods for 2x2, 3x3, 4x4 matrices. 

The motivation for this is that I noticed in my finite element code that calculating the determinant of the Jacobian matrix took a significant time of the full analysis.

The following benchmark shows the difference between master and PR:

``` julia
function f(N, n)
    A = rand(n,n)
    @time for i = 1:N
        det(A)
    end
end
```

Note, these times are from the branch in #12460. On current master the timings are about 25x slower.
### #12460

``` julia
f(10^5, 2);
#  0.029382 seconds (600.00 k allocations: 32.043 MB, 19.62% gc time)
f(10^5, 3);
#0.031129 seconds (600.00 k allocations: 38.147 MB, 9.52% gc time)
f(10^5, 4);
#0.031129 seconds (600.00 k allocations: 38.147 MB, 9.52% gc time)
```
### PR

``` julia
f(10^5, 2);
#0.001552 seconds
f(10^5, 3);
#0.001898 seconds
f(10^5, 4);
#0.003764 seconds
```

Does anyone know if these "naive" formulas are much more sensitive to catastrophic cancellation than the ones from the factorization?

For the record, I took these formulas from one of @SimonDanisch packages.
