### PR TITLE
WIP: Add specialized methods for inverses of small matrices

### DIFF
--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -438,3 +438,16 @@ for elty in (Float32, Float64, Complex64, Complex128)
     # symmetric, indefinite
     @test_approx_eq inv(convert(Matrix{elty}, [1. 2; 2 1])) convert(Matrix{elty}, [-1. 2; 2 -1]/3)
 end
+
+# Test specialized inverses for n = 1,2,3
+let
+    for n = 1:3
+        for T in [Float32, Float64, Complex64, Complex128]
+            A = rand(T, n,n)
+            @test_approx_eq inv(A) inv(lufact(A))
+            if n > 1
+                @test_throws Base.LinAlg.SingularException inv(ones(T, n, n))
+            end
+        end
+    end
+end


### PR DESCRIPTION
Same as #12452 but for inverses

The following benchmark shows the difference between master and PR (using #12452):

``` julia
function f(N, n)
    A = rand(n, n)
    @time for i = 1:N
        inv(A)
    end
end
```
### Master

``` julia
f(10^5, 2)
#  0.094840 seconds (800.00 k allocations: 48.828 MB, 5.10% gc time) 
f(10^5, 3)
#  0.124090 seconds (800.00 k allocations: 59.509 MB, 4.77% gc time)
```
### PR

``` julia
f(10^5, 2);
#0.009085 seconds (100.00 k allocations: 9.155 MB)
f(10^5, 3);
#0.012562 seconds (100.00 k allocations: 13.733 MB)
```
