### PR TITLE
Remove some signatures for chksquare and make the ... version type stable

### DIFF
--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -166,14 +166,14 @@ else
 end
 
 # Check that stride of matrix/vector is 1
-function chkstride1(A::StridedVecOrMat...)
+function chkstride1(A...)
     for a in A
         stride(a,1)== 1 || error("matrix does not have contiguous columns")
     end
 end
 
 # Check that matrix is square
-function chksquare(A::AbstractMatrix)
+function chksquare(A)
     m,n = size(A)
     m == n || throw(DimensionMismatch("matrix is not square"))
     m
@@ -185,7 +185,7 @@ function chksquare(A...)
         size(a,1)==size(a,2) || throw(DimensionMismatch("matrix is not square: dimensions are $(size(a))"))
         push!(sizes, size(a,1))
     end
-    length(A)==1 ? sizes[1] : sizes
+    return sizes
 end
 
 # Check that upper/lower (for special matrices) is correctly specified


### PR DESCRIPTION
As pointed out by @KristofferC in #12452, there is a type stability problem with `chksquare(Factorizations)`. E.g.

``` jl
julia> Base.return_types(LinAlg.chksquare, (LinAlg.LU,))
1-element Array{Any,1}:
 Union{Array{Int64,1},Int64}
```

This is fixed by these changes.
