### PR TITLE
automatic recompilation of stale cache files

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -14567,6 +14567,21 @@ include
 doc"""
 ```rst
 ::
+           include_dependency(path::AbstractString)
+
+In a module, declare that the file specified by `path` (relative or
+absolute) is a dependency for precompilation; that is, the
+module will need to be recompiled if this file changes.
+
+This is only needed if your module depends on a file that is not
+used via `include`.   It has no effect outside of compilation.
+```
+"""
+include_dependency
+
+doc"""
+```rst
+::
            randn!([rng], A::Array{Float64,N})
 
 Fill the array A with normally-distributed (mean 0, standard deviation 1) random numbers. Also see the rand function.

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1104,6 +1104,7 @@ export
     evalfile,
     include,
     include_string,
+    include_dependency,
 
 # RTS internals
     finalizer,

--- a/src/dump.c
+++ b/src/dump.c
@@ -132,46 +132,48 @@ static jl_array_t *datatype_list=NULL; // (only used in MODE_SYSTEM_IMAGE)
 #define write_int8(s, n) write_uint8(s, n)
 #define read_int8(s) read_uint8(s)
 
+/* read and write in network (bigendian) order: */
+
 static void write_int32(ios_t *s, int32_t i)
 {
-    write_uint8(s, i       & 0xff);
-    write_uint8(s, (i>> 8) & 0xff);
-    write_uint8(s, (i>>16) & 0xff);
     write_uint8(s, (i>>24) & 0xff);
+    write_uint8(s, (i>>16) & 0xff);
+    write_uint8(s, (i>> 8) & 0xff);
+    write_uint8(s, i       & 0xff);
 }
 
 static int32_t read_int32(ios_t *s)
 {
-    int b0 = read_uint8(s);
-    int b1 = read_uint8(s);
-    int b2 = read_uint8(s);
     int b3 = read_uint8(s);
+    int b2 = read_uint8(s);
+    int b1 = read_uint8(s);
+    int b0 = read_uint8(s);
     return b0 | (b1<<8) | (b2<<16) | (b3<<24);
 }
 
 static void write_uint64(ios_t *s, uint64_t i)
 {
-    write_int32(s, i       & 0xffffffff);
     write_int32(s, (i>>32) & 0xffffffff);
+    write_int32(s, i       & 0xffffffff);
 }
 
 static uint64_t read_uint64(ios_t *s)
 {
-    uint64_t b0 = (uint32_t)read_int32(s);
     uint64_t b1 = (uint32_t)read_int32(s);
+    uint64_t b0 = (uint32_t)read_int32(s);
     return b0 | (b1<<32);
 }
 
 static void write_uint16(ios_t *s, uint16_t i)
 {
-    write_uint8(s, i       & 0xff);
     write_uint8(s, (i>> 8) & 0xff);
+    write_uint8(s, i       & 0xff);
 }
 
 static uint16_t read_uint16(ios_t *s)
 {
-    int b0 = read_uint8(s);
     int b1 = read_uint8(s);
+    int b0 = read_uint8(s);
     return b0 | (b1<<8);
 }
 
@@ -950,7 +952,7 @@ void jl_serialize_mod_list(ios_t *s)
 }
 
 // "magic" string and version header of .ji file
-static const int JI_FORMAT_VERSION = 0;
+static const int JI_FORMAT_VERSION = 1;
 static const char JI_MAGIC[] = "\373jli\r\n\032\n"; // based on PNG signature
 static const uint16_t BOM = 0xFEFF; // byte-order marker
 static void jl_serialize_header(ios_t *s)
@@ -966,6 +968,52 @@ static void jl_serialize_header(ios_t *s)
     const char *branch = jl_git_branch(), *commit = jl_git_commit();
     ios_write(s, branch, strlen(branch)+1);
     ios_write(s, commit, strlen(commit)+1);
+}
+
+// serialize the global _require_dependencies array of pathnames that
+// are include depenencies
+void jl_serialize_dependency_list(ios_t *s)
+{
+    size_t total_size = 0;
+    static jl_array_t *deps = NULL;
+    if (!deps)
+        deps = (jl_array_t*)jl_get_global(jl_base_module, jl_symbol("_require_dependencies"));
+    if (deps) {
+        // sort!(deps) so that we can easily eliminate duplicates
+        static jl_value_t *sort_func = NULL;
+        if (!sort_func)
+            sort_func = jl_get_global(jl_base_module, jl_symbol("sort!"));
+        jl_apply((jl_function_t*)sort_func, (jl_value_t**)&deps, 1);
+
+        size_t l = jl_array_len(deps);
+        jl_value_t *prev = NULL;
+        for (size_t i=0; i < l; i++) {
+            jl_value_t *dep = jl_cellref(deps, i);
+            size_t slen = jl_string_len(dep);
+            if (!prev || memcmp(jl_string_data(dep), jl_string_data(prev), slen)) {
+                total_size += 4 + slen;
+            }
+            prev = dep;
+        }
+        total_size += 4;
+    }
+    // write the total size so that we can quickly seek past all of the
+    // dependencies if we don't need them
+    write_uint64(s, total_size);
+    if (deps) {
+        size_t l = jl_array_len(deps);
+        jl_value_t *prev = NULL;
+        for (size_t i=0; i < l; i++) {
+            jl_value_t *dep = jl_cellref(deps, i);
+            size_t slen = jl_string_len(dep);
+            if (!prev || memcmp(jl_string_data(dep), jl_string_data(prev), slen)) {
+                write_int32(s, slen);
+                ios_write(s, jl_string_data(dep), slen);
+            }
+            prev = dep;
+        }
+        write_int32(s, 0); // terminator, for ease of reading
+    }
 }
 
 // --- deserialize ---
@@ -1553,7 +1601,7 @@ static int readstr_verify(ios_t *s, const char *str)
     return 1;
 }
 
-static int jl_deserialize_header(ios_t *s)
+DLLEXPORT int jl_deserialize_verify_header(ios_t *s)
 {
     uint16_t bom;
     return (readstr_verify(s, JI_MAGIC) &&
@@ -1936,6 +1984,7 @@ DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist)
     serializer_worklist = worklist;
     jl_serialize_header(&f);
     jl_serialize_mod_list(&f); // this can throw, keep it early (before any actual initialization)
+    jl_serialize_dependency_list(&f);
 
     JL_SIGATOMIC_BEGIN();
     arraylist_new(&reinit_list, 0);
@@ -1976,11 +2025,13 @@ static jl_array_t *_jl_restore_incremental(ios_t *f)
         ios_close(f);
         return NULL;
     }
-    if (!jl_deserialize_header(f) ||
+    if (!jl_deserialize_verify_header(f) ||
         !jl_deserialize_verify_mod_list(f)) {
         ios_close(f);
         return NULL;
     }
+    size_t deplen = read_uint64(f);
+    ios_skip(f, deplen); // skip past the dependency list
     JL_SIGATOMIC_BEGIN();
     arraylist_new(&backref_list, 4000);
     arraylist_push(&backref_list, jl_main_module);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1130,6 +1130,7 @@ DLLEXPORT int julia_trampoline(int argc, const char *argv[], int (*pmain)(int ac
 DLLEXPORT void jl_atexit_hook(int status);
 DLLEXPORT void NORETURN jl_exit(int status);
 
+DLLEXPORT int jl_deserialize_verify_header(ios_t *s);
 DLLEXPORT void jl_preload_sysimg_so(const char *fname);
 DLLEXPORT ios_t *jl_create_system_image(void);
 DLLEXPORT void jl_save_system_image(const char *fname);

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -13,29 +13,37 @@ try
         print(f, """
               module $Foo_module
               @doc "foo function" foo(x) = x + 1
+              include_dependency("foo.jl")
               module Bar
               @doc "bar function" bar(x) = x + 2
+              include_dependency("bar.jl")
               end
               end
               """)
     end
 
-    Base.compile(Foo_module)
+    cachefile = Base.compile(Foo_module)
 
     # use _require_from_serialized to ensure that the test fails if
     # the module doesn't load from the image:
     @test nothing !== Base._require_from_serialized(myid(), Foo_module, true)
+
+    let Foo = eval(Main, Foo_module)
+        @test Foo.foo(17) == 18
+        @test Foo.Bar.bar(17) == 19
+
+        # issue #12284:
+        @test stringmime("text/plain", Base.Docs.doc(Foo.foo)) == "foo function\n"
+        @test stringmime("text/plain", Base.Docs.doc(Foo.Bar.bar)) == "bar function\n"
+
+        deps = Base.cache_dependencies(cachefile)
+        @test sort(deps[1]) == map(s -> (s, Base.module_uuid(eval(s))),
+                                   [:Base,:Core,:Main])
+        @test sort(deps[2]) == [file,joinpath(dir,"bar.jl"),joinpath(dir,"foo.jl")]
+    end
+
 finally
     splice!(Base.LOAD_CACHE_PATH, 1)
     splice!(LOAD_PATH, 1)
     rm(dir, recursive=true)
-end
-
-let Foo = eval(Main, Foo_module)
-    @test Foo.foo(17) == 18
-    @test Foo.Bar.bar(17) == 19
-
-    # issue #12284:
-    @test stringmime("text/plain", Base.Docs.doc(Foo.foo)) == "foo function\n"
-    @test stringmime("text/plain", Base.Docs.doc(Foo.Bar.bar)) == "bar function\n"
 end


### PR DESCRIPTION
This fixes #12259 by automating the recompilation of stale cache files whenever you `require` a module (e.g. by `using`) and a stale cache file is found.  Currently, staleness is judged by timestamps; other mechanisms like checksums are left to future PRs.

For example, here is a typical session after I had done `Base.compile(:PyPlot)` and then updated a file in Compat:

```
julia> using PyPlot
INFO: Recompiling stale cache file /Users/stevenj/.julia/lib/v0.4/Compat.ji for module Compat.
INFO: Recompiling stale cache file /Users/stevenj/.julia/lib/v0.4/LaTeXStrings.ji for module LaTeXStrings.
INFO: Recompiling stale cache file /Users/stevenj/.julia/lib/v0.4/PyPlot.ji for module PyPlot.
INFO: Recompiling stale cache file /Users/stevenj/.julia/lib/v0.4/PyCall.ji for module PyCall.
INFO: Recompiling stale cache file /Users/stevenj/.julia/lib/v0.4/Color.ji for module Color.
INFO: Recompiling stale cache file /Users/stevenj/.julia/lib/v0.4/FixedPointNumbers.ji for module FixedPointNumbers.
```

This patch supersedes #12445.

Like #12445, it adds a list of the dependency files to the `.ji` file, with a new `include_dependency(path)` function to manually supply non-`include` dependencies for a module.

(Also as discussed in #12445, I changed the serialization metadata to use bigendian rather than littleendian storage, for ease of reading back in via `ntoh`.)

Once #12448 lands, it will be easy to add other information about the dependencies (e.g. checksums) if that is judged necessary in the future, but I think it is better to develop that incrementally.  (Merging a hash/checksum algorithm is a nontrivial task that is best left to a separate PR.)

Note that you still have to manually `Base.compile` a module at least once—this PR only automates the _recompilation_ of the image.  A separate PR can implement a `@cacheable` tag (or whatever) to allow modules to opt-in for automatic initial compilation.
