### PR TITLE
added empty [] definition for remoteref

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1653,6 +1653,7 @@ function terminate_all_workers()
     end
 end
 
+getindex(r::RemoteRef) = fetch(r)
 function getindex(r::RemoteRef, args...)
     if r.where == myid()
         return getindex(fetch(r), args...)

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -18,11 +18,13 @@ rr=RemoteRef()
 a = rand(5,5)
 put!(rr, a)
 @test rr[2,3] == a[2,3]
+@test rr[] == a
 
 rr=RemoteRef(workers()[1])
 a = rand(5,5)
 put!(rr, a)
 @test rr[1,5] == a[1,5]
+@test rr[] == a
 
 dims = (20,20,20)
 


### PR DESCRIPTION
If the value stored in a `RemoteRef` is an array, currently `rr[]` returns the first element of the array. This changes `rr[]` to be equivalent to `fetch(rr)`. Useful in situations where references are created to share data across processes, and `rr[]` is visually nicer to look at compared to a `fetch(rr)` everywhere.
