### PR TITLE
RemoteRefs parameterized on remote store type

### DIFF
--- a/test/examples.jl
+++ b/test/examples.jl
@@ -56,6 +56,7 @@ pid = length(w_set) > 0 ? w_set[1] : myid()
 
 remotecall_fetch(pid, f->(include(f); nothing), dc_path)
 dc=RemoteRef(()->DictChannel(), pid)
+@test typeof(dc) == RemoteRef{DictChannel}
 
 @test isready(dc) == false
 put!(dc, 1, 2)

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -15,11 +15,13 @@ id_other = filter(x -> x != id_me, procs())[rand(1:(nprocs()-1))]
 @fetch begin myid() end
 
 rr=RemoteRef()
+@test typeof(rr) == RemoteRef{Channel{Any}}
 a = rand(5,5)
 put!(rr, a)
 @test rr[2,3] == a[2,3]
 
 rr=RemoteRef(workers()[1])
+@test typeof(rr) == RemoteRef{Channel{Any}}
 a = rand(5,5)
 put!(rr, a)
 @test rr[1,5] == a[1,5]


### PR DESCRIPTION
Realized that https://github.com/JuliaLang/julia/pull/12385#issuecomment-126941910 would require `RemoteRef` to be parametric on the remote store type. Will enable `put!`, `take!`, etc to be dispatched based on the backing store.  
