### PR TITLE
add "#pragma compile [true]" for opt-in to automatic compilation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@ New language features
     but instead of loading it into the current session saves the result of compiling it in
     `~/.julia/lib/v0.4` ([#8745]).
 
+      * Put `#pragma compilable` at the top of your module file to automatically compile it when it is imported ([#12475]).
+
       * See manual section on `Module initialization and precompilation` (under `Modules`) for details and errata.
 
       * New option `--output-incremental={yes|no}` added to invoke the equivalent of ``Base.compile`` from the command line.
@@ -1557,3 +1559,4 @@ Too numerous to mention.
 [#12137]: https://github.com/JuliaLang/julia/issues/12137
 [#12162]: https://github.com/JuliaLang/julia/issues/12162
 [#12393]: https://github.com/JuliaLang/julia/issues/12393
+[#12475]: https://github.com/JuliaLang/julia/issues/12475

--- a/doc/manual/modules.rst
+++ b/doc/manual/modules.rst
@@ -264,7 +264,15 @@ To create a custom system image that can be used to start julia with the -J opti
 recompile Julia after modifying the file ``base/userimg.jl`` to require the desired modules.
 
 To create an incremental precompiled module file,
-call ``Base.compile(modulename::Symbol)``.
+you can call ``Base.compile(modulename::Symbol)``.  Alternatively, if you
+put ``#pragma compile`` at the top of your module file (before any
+non-comment code), then the module will be automatically compiled the
+first time it is imported.   Compiling a module also recursively compiles
+any modules that are imported therein.   If you know that it is *not*
+safe to compile your module, you should put ``#pragma compile false``
+at the top of its file, which cause ``Base.compile`` to throw an error
+(and thereby prevent the module from being imported any other compiled
+module).
 The resulting cache files will be stored in ``Base.LOAD_CACHE_PATH[1]``.
 
 In order to make your module work with precompilation,

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -11,6 +11,8 @@ try
 
     open(file, "w") do f
         print(f, """
+              # Auto-compile this module:
+               # pragma compile
               module $Foo_module
               @doc "foo function" foo(x) = x + 1
               include_dependency("foo.jl")
@@ -22,7 +24,9 @@ try
               """)
     end
 
-    cachefile = Base.compile(Foo_module)
+    # make sure the "#pragma compile" causes Foo to be compiled
+    cachefile = Base.autocompile_on_node1(Foo_module, file)
+    @test nothing !== cachefile
 
     # use _require_from_serialized to ensure that the test fails if
     # the module doesn't load from the image:
@@ -41,7 +45,6 @@ try
                                    [:Base,:Core,:Main])
         @test sort(deps[2]) == [file,joinpath(dir,"bar.jl"),joinpath(dir,"foo.jl")]
     end
-
 finally
     splice!(Base.LOAD_CACHE_PATH, 1)
     splice!(LOAD_PATH, 1)


### PR DESCRIPTION
This PR implements automatic opt-in to compilation for modules, as discussed in #12462.   In particular:
- If the module `Foo`'s file `Foo.jl` starts with `#pragma compile [ true]` (before any non-comment code), then `require(:Foo)` (hence `import` or `using`) will automatically invoke `Base.compile(:Foo)`. 
- The default is not to compile, i.e. opt-in.  Any other default would be unsafe, and Julia is a safe language by default.  (You can still manually call `Base.compile`, however.)
- If you explicitly put `#pragma compile false` at the top of the module, then `Base.compile` will throw an error for that module.  (Since `Base.compile` is recursive, this will also throw an error if you attempt to compile a module that requires a non-compilable module.)

(In the future, it might be nice to implement compilation of modules that depend on non-compilable modules, but this is new functionality and should be a separate PR.)

Probably better to merge this after #12448 (`.ji` magic header) and #12458 (automated recompilation).
