### PR TITLE
Use an ObjectIdDict for holding staged function cache

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -598,7 +598,7 @@ const limit_tuple_type_n = function (t, lim::Int)
     return t
 end
 
-let stagedcache=Dict{Any,Any}()
+let stagedcache=ObjectIdDict()
     global func_for_method
     function func_for_method(m::Method, tt, env)
         if !m.isstaged


### PR DESCRIPTION
If we use a Dict, we compile `==` for staged function method signature types, which is not so great. Since we only run staged functions on leaf types I think this should be okay.

I benchmarked this with the SubArray tests and they were slightly (~5%) but significantly faster (p = 0.014) comparing 3 runs each with and without the change.
