### PR TITLE
Remove out of date paragraph about narrower types being promoted.

### DIFF
--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -231,12 +231,6 @@ modern computers. In applications where overflow is possible, explicit checking
 for wraparound produced by overflow is essential; otherwise, the ``BigInt`` type
 in :ref:`man-arbitrary-precision-arithmetic` is recommended instead.
 
-To minimize the practical impact of this overflow, integer addition,
-subtraction, multiplication, and exponentiation operands are promoted
-to ``Int`` or ``UInt`` from narrower integer types.  (However,
-divisions, remainders, and bitwise operations do not promote narrower
-types.)
-
 Division errors
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes #12482
