### PR TITLE
Stop preventing indexing with Numbers

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -409,20 +409,6 @@ function push!(A)
     A
 end
 
-# 10458
-to_index_nodep(i::Real) = convert(Int,i)::Int
-
-function to_index(i::Real)
-    depwarn("indexing with non Integer Reals is deprecated", :to_index)
-    to_index_nodep(i)
-end
-
-to_index{T<:Integer}(A::AbstractArray{T}) = A
-function to_index{T<:Real}(A::AbstractArray{T})
-    depwarn("indexing with non Integer AbstractArrays is deprecated", :to_index)
-    Int[to_index_nodep(x) for x in A]
-end
-
 function to_index(I::Tuple)
     depwarn("to_index(I::Tuple) is deprecated, use to_indexes(I...) instead.", :to_index)
     to_indexes(I...)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -306,6 +306,7 @@ setindex_shape_check(X, I::Int...) = nothing # Non-arrays broadcast to all idxs
 # convert to a supported index type (Array, Colon, or Int)
 to_index(i::Int) = i
 to_index(i::Integer) = convert(Int,i)::Int
+to_index(x::Number) = x
 to_index(c::Colon) = c
 to_index(I::AbstractArray{Bool}) = find(I)
 to_index(A::AbstractArray) = A


### PR DESCRIPTION
This change permits `AbstractArray` types to perform vector indexing with any type of `Number`. For Interpolations, this enables `B = A[linspace(1,10,1001), linspace(1,15,201)]` to work (well, it will after https://github.com/tlycken/Interpolations.jl/pull/54 gets merged...).

CC @mbauman, @jakebolewski (ref #10458)
