### PR TITLE
__precompile__(isprecompilable) function for automated opt-in to module precompilation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,13 +28,19 @@ New language features
   * The syntax `function foo end` can be used to introduce a generic function without
     yet adding any methods ([#8283]).
 
-  * Incremental compilation of modules: `Base.compile(module::Symbol)` imports the named module,
-    but instead of loading it into the current session saves the result of compiling it in
+  * Incremental precompilation of modules: call ``__precompile__()`` at the top of a
+    module file to automatically precompile it when it is imported ([#12491]), or manually
+    run `Base.compile(modulename)`. The resulting precompiled `.ji` file is saved in
     `~/.julia/lib/v0.4` ([#8745]).
 
-      * See manual section on `Module initialization and precompilation` (under `Modules`) for details and errata.
+      * See manual section on `Module initialization and precompilation` (under `Modules`) for details and errata.  In particular, to be safely precompilable a module may need an `__init__` function to separate code that must be executed at runtime rather than precompile-time.  Modules that are *not* precompilable should call `__precompile__(false)`.
 
-      * New option `--output-incremental={yes|no}` added to invoke the equivalent of ``Base.compile`` from the command line.
+      * The precompiled `.ji` file includes a list of dependencies (modules and files that
+        were imported/included at precompile-time), and the module is automatically recompiled
+        upon `import` when any of its dependencies have changed.  Explicit dependencies
+        on other files can be declared with `include_dependency(path)` ([#12458]).
+
+      * New option `--output-incremental={yes|no}` added to invoke the equivalent of ``Base.compilecache`` from the command line.
 
   * The syntax `new{parameters...}(...)` can be used in constructors to specify parameters for
     the type to be constructed ([#8135]).
@@ -1557,3 +1563,5 @@ Too numerous to mention.
 [#12137]: https://github.com/JuliaLang/julia/issues/12137
 [#12162]: https://github.com/JuliaLang/julia/issues/12162
 [#12393]: https://github.com/JuliaLang/julia/issues/12393
+[#12458]: https://github.com/JuliaLang/julia/issues/12458
+[#12491]: https://github.com/JuliaLang/julia/issues/12491

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -8472,12 +8472,12 @@ whos
 doc"""
 ```rst
 ::
-           compile(module::Symbol)
+           Base.compilecache(module::Symbol)
 
 Creates a precompiled cache file for module (see help for ``require``) and all of its dependencies. This can be used to reduce package load times. Cache files are stored in LOAD_CACHE_PATH[1], which defaults to `~/.julia/lib/VERSION`. See the manual section `Module initialization and precompilation` (under `Modules`) for important notes.
 ```
 """
-compile
+compilecache
 
 doc"""
 ```rst
@@ -14578,6 +14578,26 @@ used via `include`.   It has no effect outside of compilation.
 ```
 """
 include_dependency
+
+doc"""
+```rst
+::
+           __precompile__(isprecompilable::Bool=true)
+
+Specify whether the file calling this function is precompilable.  If
+``isprecompilable`` is ``true``, then ``__precompile__`` throws an exception
+*unless* the file is being precompiled, and in a module file it causes
+the module to be automatically precompiled when it is imported.
+Typically, ``__precompile__()`` should occur before the ``module``
+declaration in the file, or better yet ``VERSION >= v"0.4" &&
+__precompile__()`` in order to be backward-compatible with Julia 0.3.
+
+If a module or file is *not* safely precompilable, it should call
+``__precompile__(false)`` in order to throw an error if Julia attempts
+to precompile it.
+```
+"""
+__precompile__
 
 doc"""
 ```rst

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1101,6 +1101,7 @@ export
     workspace,
 
 # loading source files
+    __precompile__,
     evalfile,
     include,
     include_string,

--- a/src/dump.c
+++ b/src/dump.c
@@ -1657,7 +1657,7 @@ static void jl_reinit_item(ios_t *f, jl_value_t *v, int how) {
                         jl_errorf("invalid redefinition of constant %s", mod->name->name); // this also throws
                     }
                     if (jl_generating_output() && jl_options.incremental) {
-                        jl_errorf("cannot replace module %s during incremental compile", mod->name->name);
+                        jl_errorf("cannot replace module %s during incremental precompile", mod->name->name);
                     }
                     jl_printf(JL_STDERR, "WARNING: replacing module %s\n", mod->name->name);
                 }


### PR DESCRIPTION
This addresses #12462 by adding a new function `__precompile__(isprecompilable::Bool=true)`:
- If a file calls `__precompile__()` (typically at the top of the file before the `module` statement), then it will be automatically precompiled when it is imported for the first time (and thereafter will be automatically recompiled thanks to #12458).  Technically, `__precompile__(true)` throws an exception if the file is included in a non-precompile Julia process.
- If a file calls `__precompile__(false)`, then it will throw an exception during precompilation.  This way, if a module is known to be unsafe to precompile, you can prevent the user from precompiling it accidentally (e.g. by importing it into another module that is being compiled).
- Backwards compatibility with 0.3 is easy: just use `VERSION >= v"0.4-" && __precompile__()`.  We should also put `__precompile__` into Compat for completeness, but it is nice to be able to put `__precompile__()` _before_ the `module ... end` in order to prevent the module from being parsed or `eval`-ed (even partially) when we are detecting precompilability.
- `Base.compile(mod)` (which should now be rarely needed by users) is renamed to `Base.compilecache(mod)` to better describe its function.

Thanks to @ScottPJones for his suggestion.  This turned out to be much cleaner than the `#pragma` approach in #12475, with no loss of functionality.
