### PR TITLE
Test for gensyms in staged functions

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -3758,3 +3758,15 @@ module I13229
     end
     @test z == 10
 end
+
+# issue #12474
+@generated function f12474(::Any)
+    :(for i in 1
+      end)
+end
+let
+    ast12474 = code_typed(f12474, Tuple{Float64})
+    for (_, vartype) in ast12474[1].args[2][1]
+        @test isleaftype(vartype)
+    end
+end


### PR DESCRIPTION
This fixes the name collision in #12474 by prefixing the generated symbols in a staged function by `#staged`. This is probably not the most elegant way to fix this but it is the most robust and minimum change I can come up with. (Without passing more informations between julia/c/flisp and without relying on where in the staged function AST the name may collide)

Fix #12474

maybe @JeffBezanson ?
