### PR TITLE
WIP: ccall using libuv's threadpool

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1324,10 +1324,13 @@ export
     pointer_to_array,
     pointer_to_string,
     reenable_sigint,
+    threadcall,
     unsafe_copy!,
     unsafe_load,
     unsafe_pointer_to_objref,
     unsafe_store!,
+    # ccall in threadpool
+    @wrapper,
 
 # nullable types
     isnull,

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -306,6 +306,8 @@ DLLEXPORT int jl_fs_write(int handle, const char *data, size_t len, int64_t offs
     return ret;
 }
 
+
+
 DLLEXPORT int jl_fs_read(int handle, char *data, size_t len)
 {
     uv_fs_t req;
@@ -770,6 +772,55 @@ DLLEXPORT int jl_tty_set_mode(uv_tty_t *handle, int mode)
 {
     if (handle->type != UV_TTY) return 0;
     return uv_tty_set_mode(handle, mode);
+}
+
+typedef int (* work_cb_t)(void *, void *);
+typedef void (* notify_cb_t)(int);
+struct work_baton {
+    uv_work_t req;
+    work_cb_t work_func;
+    void *    work_args;
+    void *    work_retval;
+    notify_cb_t notify_func;
+    pid_t     tid;
+    int       notify_idx;
+};
+
+#ifdef _OS_LINUX_
+#include <sys/syscall.h>
+#endif
+
+void jl_work_wrapper(uv_work_t *req) {
+    struct work_baton *baton = (struct work_baton*) req->data;
+#ifdef _OS_LINUX_
+    baton->tid = syscall(SYS_gettid);
+#else
+    baton->tid = 0;
+#endif
+    printf("job(%d) started\n", baton->tid);
+    baton->work_func(baton->work_args, baton->work_retval);
+}
+
+void jl_work_notifier(uv_work_t *req, int status) {
+    struct work_baton *baton = (struct work_baton*) req->data;
+    printf("Finished(%d). Status: %d\n", baton->tid, status);
+    baton->notify_func(baton->notify_idx);
+    free(baton);
+}
+
+DLLEXPORT int jl_queue_work(void * work_func, void * work_args, void * work_retval, void * notify_func, int notify_idx)
+{
+    struct work_baton *baton = (struct work_baton*) malloc(sizeof(struct work_baton));
+    baton->req.data = (void*) baton;
+    baton->work_func = work_func;
+    baton->work_args = work_args;
+    baton->work_retval = work_retval;
+    baton->notify_func = notify_func;
+    baton->notify_idx = notify_idx;
+
+    uv_queue_work(jl_io_loop, &baton->req, jl_work_wrapper, jl_work_notifier);
+
+    return 0;
 }
 
 #ifndef _OS_WINDOWS_


### PR DESCRIPTION
Develops on ideas discussed in #12455 . @StefanKarpinski your work was really useful. 

You need to export env variable UV_THREADPOOL_SIZE to set libuv's threadpool size before starting julia.  Default is 4.

Works for `sleep` with integer arguments

```
c_sleep = @wrapper sleep Cuint Cuint
@sync begin
    for i in 1:10
        @async threadcall(c_sleep, i)
    end
end
```

Barfs on string arguments 

```
julia> c_printf = @wrapper printf Cuint Cstring Cuint
Base.CFunction{2}(Ptr{Void} @0x00007fdc41bc8290,UInt32,(Cstring,UInt32))

julia> @sync begin
           for i in 1:10
               @async threadcall(c_printf, "Hello from %d\n", i)
           end
       end
ERROR: MethodError(convert,(Cstring,"Hello from %d\n"))
 in threadcall at util.jl:434
 in anonymous at task.jl:446

...and 9 other exceptions.

 in sync_end at ./task.jl:412
 in anonymous at task.jl:421
```
