### PR TITLE
uuid4 function should accept rng

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -1166,8 +1166,8 @@ immutable UUID
 end
 UUID(u::AbstractString) = convert(UUID, u)
 
-function uuid4()
-    u = rand(UInt128)
+function uuid4(rng::AbstractRNG=GLOBAL_RNG)
+    u = rand(rng, UInt128)
     u &= 0xffffffffffff0fff3fffffffffffffff
     u |= 0x00000000000040008000000000000000
     UUID(u)

--- a/test/random.jl
+++ b/test/random.jl
@@ -210,6 +210,7 @@ import Base.Random: uuid4, UUID
 # UUID
 a = uuid4()
 @test a == UUID(string(a)) == UUID(utf16(string(a))) == UUID(utf32(string(a)))
+@test uuid4(MersenneTwister()) == uuid4(MersenneTwister())
 @test_throws ArgumentError UUID("550e8400e29b-41d4-a716-446655440000")
 @test_throws ArgumentError UUID("550e8400e29b-41d4-a716-44665544000098")
 @test_throws ArgumentError UUID("z50e8400-e29b-41d4-a716-446655440000")


### PR DESCRIPTION
As described in  JuliaLang/IJulia.jl#336, and consistent with the behavior of our other random-number functions, `uuid4()` should take an optional `rng` argument.

(As a separate issue, we should discuss documenting these UUID functions etc.)
