### PR TITLE
Move docs bootstrapping earlier in build.

### DIFF
--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -17,6 +17,9 @@ print(x::ANY) = show(x)
 println(x::ANY) = ccall(:jl_, Void, (Any,), x) # includes a newline
 print(a::ANY...) = for x=a; print(x); end
 
+# Doc macro shim.
+macro doc(str, def) Expr(:escape, def) end
+
 ## Load essential files and libraries
 include("essentials.jl")
 include("reflection.jl")
@@ -45,9 +48,6 @@ typealias StridedVector{T,A<:DenseArray,I<:Tuple{Vararg{RangeIndex}}}  DenseArra
 typealias StridedMatrix{T,A<:DenseArray,I<:Tuple{Vararg{RangeIndex}}}  DenseArray{T,2}
 typealias StridedVecOrMat{T} Union{StridedVector{T}, StridedMatrix{T}}
 include("array.jl")
-
-# Doc macro shim
-macro doc(ex) esc(ex.args[2]) end
 
 #TODO: eliminate Dict from inference
 include("hashing.jl")

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -263,11 +263,11 @@ function funcdoc(meta, def, def′, name)
     end
 end
 
-function typedoc(meta, def, name)
+function typedoc(meta, def, def′, name)
     quote
         @init
         $(esc(def))
-        doc!($(esc(name)), $(mdify(meta)), $(field_meta(unblock(def))))
+        doc!($(esc(name)), $(mdify(meta)), $(field_meta(unblock(def′))))
         nothing
     end
 end
@@ -304,15 +304,14 @@ function docm(meta, def, define = true)
 
     fexpr(def′)                && return funcdoc(meta, def, def′, namify(def′))
     isexpr(def′, :call)        && return funcdoc(meta, nothing, def′, namify(def′))
-    isexpr(def′, :type)        && return typedoc(meta, def, namify(def′.args[2]))
+    isexpr(def′, :type)        && return typedoc(meta, def, def′, namify(def′.args[2]))
     isexpr(def′, :macro)       && return namedoc(meta, def, symbol("@", namify(def′)))
     isexpr(def′, :abstract)    && return namedoc(meta, def, namify(def′))
     isexpr(def′, :bitstype)    && return namedoc(meta, def, def′.args[2])
     isexpr(def′, :module)      && return namedoc(meta, def, def′.args[2])
     isexpr(def′, :(=), :const) && return namedoc(meta, def, namify(def′))
 
-    isexpr(def′, :macrocall) && (def = namify(def′))
-    return objdoc(meta, def)
+    objdoc(meta, def′)
 end
 
 function docm(ex)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -28,6 +28,8 @@ end
 
 ## Load essential files and libraries
 include("essentials.jl")
+include("docs/bootstrap.jl")
+using .DocBootstrap
 include("base.jl")
 include("reflection.jl")
 include("build_h.jl")
@@ -55,9 +57,6 @@ include("functors.jl")
 include("abstractarray.jl")
 include("subarray.jl")
 include("array.jl")
-
-include("docs/bootstrap.jl")
-using .DocBootstrap
 
 # numeric operations
 include("hashing.jl")

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2083,7 +2083,7 @@
                 ((closing-token? t) #f)
                 ((newline? t) (take-token s) (loop (peek-token s)))
                 (else #t))))
-        `(macrocall (|.| Base (quote @doc)) ,ex ,(production s))
+        `(macrocall @doc ,ex ,(production s))
         ex)))
 
 ; --- main entry point ---


### PR DESCRIPTION
This moves the docstring bootstrapping to a little earlier on by not relying on an `Array`
for storage. It'll allow more of `Base` to be documented inline once that starts happening.

~~The second commit is just an example to show that it does indeed work and it can be removed first
if this does get merged.~~ (Edit: second commit now removed.)
