### PR TITLE
Fix #12515.

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -254,7 +254,7 @@ end
 
 function funcdoc(meta, def, def′, name)
     f = esc(name)
-    m = :(which($f, $(esc(signature(def′)))))
+    m = :(methods($f, $(esc(signature(def′))))[1])
     quote
         @init
         $(esc(def))

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -171,3 +171,16 @@ let fd = meta(I11798)[I11798.read]
     @test fd.order[1] == which(I11798.read, Tuple{Any})
     @test fd.meta[fd.order[1]] == doc"read"
 end
+
+module I12515
+
+immutable EmptyType{T} end
+
+"A new method"
+Base.collect{T}(::Type{EmptyType{T}}) = "borked"
+
+end
+
+let fd = meta(I12515)[Base.collect]
+    @test fd.order[1].sig == Tuple{Type{I12515.EmptyType{TypeVar(:T, Any, true)}}}
+end


### PR DESCRIPTION
Fix based on https://github.com/JuliaLang/julia/issues/12515#issuecomment-129011960. Is the result of `methods(f, sig)` sorted in some kind of best-to-worst order of how well they match? If it's not maybe it's best to iterate over all the candidates and compare the signatures manually.
