### PR TITLE
WIP: Eliminate backtrace display when testing __precompile__()

### DIFF
--- a/test/compile.jl
+++ b/test/compile.jl
@@ -2,6 +2,7 @@
 
 using Base.Test
 
+olderr = STDERR
 dir = mktempdir()
 insert!(LOAD_PATH, 1, dir)
 insert!(Base.LOAD_CACHE_PATH, 1, dir)
@@ -32,8 +33,15 @@ try
 
     # use _require_from_serialized to ensure that the test fails if
     # the module doesn't load from the image:
-    println(STDERR, "\nNOTE: The following 'replacing module' warning indicates normal operation:")
-    @test nothing !== Base._require_from_serialized(myid(), Foo_module, true)
+    try
+        rd, wr = redirect_stderr()
+        @test nothing !== Base._require_from_serialized(myid(), Foo_module, true)
+        sleep(5)
+        redirect_stderr(olderr)
+    catch exc
+        redirect_stderr(olderr)
+        rethow(exc)
+    end
 
     let Foo = eval(Main, Foo_module)
         @test Foo.foo(17) == 18
@@ -57,8 +65,14 @@ try
               end
               """)
     end
-    println(STDERR, "\nNOTE: The following 'LoadError: __precompile__(false)' indicates normal operation")
-    @test_throws ErrorException Base.compilecache("Baz") # from __precompile__(false)
+    try
+        rd, wr = redirect_stderr()
+        Base.compilecache("Baz") # from __precompile__(false)
+    catch exc
+        redirect_stderr(olderr)
+        isa(exc, ErrorException) || rethrow(exc)
+        search(exc.msg, "__precompile__(false)") == 0 && rethrow(exc)
+    end
 
     # Issue #12720
     FooBar_file = joinpath(dir, "FooBar.jl")
@@ -79,9 +93,18 @@ try
               end
               """)
     end
-    println(STDERR, "\nNOTE: The following 'LoadError: break me' indicates normal operation")
-    @test_throws ErrorException Base.require(:FooBar)
+    try
+        rd, wr = redirect_stderr()
+        Base.require(:FooBar)
+    catch exc
+        redirect_stderr(olderr)
+        isa(exc, ErrorException) || rethrow(exc)
+        search(exc.msg, "ERROR: LoadError: break me") == 0 && rethrow(exc)
+    end
 finally
+    if STDERR != olderr
+        redirect_stderr(olderr)
+    end
     splice!(Base.LOAD_CACHE_PATH, 1)
     splice!(LOAD_PATH, 1)
     rm(dir, recursive=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 include("choosetests.jl")
+include("testdefs.jl")
+
 tests, net_on = choosetests(ARGS)
 tests = unique(tests)
 
@@ -11,21 +13,20 @@ if compile_test
 end
 
 cd(dirname(@__FILE__)) do
-    n = 1
-    if net_on
-        n = min(8, CPU_CORES, length(tests))
-        n > 1 && addprocs(n; exeflags=`--check-bounds=yes --depwarn=error`)
-        blas_set_num_threads(1)
-    end
-
-    @everywhere include("testdefs.jl")
-
-    reduce(propagate_errors, nothing, pmap(runtests, tests; err_retry=false, err_stop=true))
+    n = net_on ? min(8, CPU_CORES, length(tests)) : 1
 
     if compile_test
         n > 1 && print("\tFrom worker 1:\t")
         runtests("compile")
     end
+
+    if net_on
+        n > 1 && addprocs(n; exeflags=`--check-bounds=yes --depwarn=error`)
+        @everywhere include("testdefs.jl")
+        blas_set_num_threads(1)
+    end
+
+    reduce(propagate_errors, nothing, pmap(runtests, tests; err_retry=false, err_stop=true))
 
     @unix_only n > 1 && rmprocs(workers(), waitfor=5.0)
     println("    \033[32;1mSUCCESS\033[0m")


### PR DESCRIPTION
This just cleans up the output of unit test in compile.jl.
