### PR TITLE
default to new container-based Travis infrastructure in Pkg.generate's .travis.yml

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -162,6 +162,7 @@ end
 function travis(pkg::AbstractString; force::Bool=false)
     genfile(pkg,".travis.yml",force) do io
         print(io, """
+        # Documentation: http://docs.travis-ci.com/user/languages/julia/
         language: julia
         os:
           - linux


### PR DESCRIPTION
This enables the new container-based Travis infrastructure, see http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade

Pros: More RAM / CPU on travis, faster startup of tests.

This only affects new packages - in case that package needs `sudo` on travis it can be enabled again with `sudo: true`.

I have updated all my packages' testing to use `sudo: false` in the last weeks, works nicely.
