### PR TITLE
Add *.jl.*.cov to generated .gitignore after #12022

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -233,6 +233,7 @@ function gitignore(pkg::AbstractString; force::Bool=false)
     genfile(pkg,".gitignore",force) do io
         print(io, """
         *.jl.cov
+        *.jl.*.cov
         *.jl.mem
         """)
     end


### PR DESCRIPTION
Gets rid of this stuff after #12022:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

    MMA.jl.26400.cov
    utils.jl.26400.cov
    ../test/runtests.jl.26400.cov
```
