### PR TITLE
improve interaction of task switches and finally blocks (#12485)

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -292,6 +292,7 @@ static void ctx_switch(jl_task_t *t, jl_jmp_buf *where)
     */
     //JL_SIGATOMIC_BEGIN();
     if (!jl_setjmp(jl_current_task->ctx, 0)) {
+        bt_size = 0;  // backtraces don't survive task switches, see e.g. issue #12485
 #ifdef COPY_STACKS
         jl_task_t *lastt = jl_current_task;
         save_stack(lastt);


### PR DESCRIPTION
This does two things intended to improve the state of affairs in issue #12485:
- Save the exception to be rethrown around the code in a finally block
- Set bt_size=0 on task switch. Since we don't remember which task the backtrace came from, it must be associated with the current task or else not exist.

Behavior with this change:

```
julia> t = @schedule try
              while true; sleep(1); end
              catch e
              isa(e,InterruptException) || rethrow(e)
              end
Task (waiting) @0x00007fb118dc6590

julia> try
              error("You will never see me")
              catch e
              rethrow(e)
              finally
              Base.throwto(t,InterruptException())
              end
ERROR: You will never see me
```

We give the correct exception, but the backtrace is lost on task switch since nobody saved it and we don't save it automatically. Basically, somebody has to call `catch_backtrace` between catching and the next throw or task switch. This doesn't interfere with task backtraces, since `task_done_hook` now calls `catch_backtrace`. I think this will make things less confusing; seeing no backtrace tells you that it was lost, and is better than a backtrace from some random different place.
