### PR TITLE
Implement binding docs.

### DIFF
--- a/test/docs.jl
+++ b/test/docs.jl
@@ -20,7 +20,7 @@ end
 @doc ("I am a macro";)  :@ModuleMacroDoc.m
 
 @test (@doc ModuleMacroDoc)    == "I am a module"
-@test (@doc ModuleMacroDoc.@m) == ["I am a macro"]
+@test (@doc ModuleMacroDoc.@m) == "I am a macro"
 
 # General tests for docstrings.
 
@@ -129,17 +129,12 @@ let IT = DocsTest.IT
     @test typedoc.fields[:y] == doc"IT.y"
 end
 
-let TA = DocsTest.TA
-    @test meta(DocsTest)[TA] == doc"TA"
-end
+@test @doc(DocsTest.TA) == doc"TA"
 
-let mac = getfield(DocsTest, symbol("@mac"))
-    funcdoc = meta(DocsTest)[mac]
-    @test funcdoc.main == doc"@mac"
-end
+@test @doc(DocsTest.@mac) == doc"@mac"
 
-@test meta(DocsTest)[:G] == doc"G"
-@test meta(DocsTest)[:K] == doc"K"
+@test @doc(DocsTest.G) == doc"G"
+@test @doc(DocsTest.K) == doc"K"
 
 @test @doc(DocsTest.t(::AbstractString)) == doc"t-1"
 @test @doc(DocsTest.t(::Int, ::Any)) == doc"t-2"


### PR DESCRIPTION
This splits out the bindings-related commits from #12088, which are needed to avoid documenting the values of constants rather than the constants themselves, ie.

```
julia> "a"
       a = 1

julia> "b"
       b = 1

julia> Main.__META__
ObjectIdDict with 2 entries:
  1                        => Base.Markdown.MD(Any[Base.Markdow…
  #= circular reference =# => Base.Markdown.MD(Any[Base.…
```

cc @one-more-minute: I'm not quite sure about the lines https://github.com/JuliaLang/julia/pull/12088/files#diff-5a9ad42cbc2e070b47b9d63118501e2fR330 and https://github.com/JuliaLang/julia/pull/12088/files#diff-5a9ad42cbc2e070b47b9d63118501e2fR296 where `@var` syntax is supported. What's the intention behind that?
