### PR TITLE
Ensure that some parameters are actually types in inference

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -174,7 +174,7 @@ add_tfunc(arraylen, 1, 1, x->Int)
 #                                     a.parameters[1] : Any))
 #add_tfunc(arrayset, 3, IInf, (a,v,i...)->a)
 add_tfunc(arraysize, 2, 2, (a,d)->Int)
-add_tfunc(pointerref, 2, 2, (a,i)->(isa(a,DataType) && a<:Ptr ? a.parameters[1] : Any))
+add_tfunc(pointerref, 2, 2, (a,i)->(isa(a,DataType) && a<:Ptr && isa(a.parameters[1],DataType) ? a.parameters[1] : Any))
 add_tfunc(pointerset, 3, 3, (a,v,i)->a)
 
 const typeof_tfunc = function (t)
@@ -487,7 +487,7 @@ function builtin_tfunction(f::ANY, args::ANY, argtype::ANY)
             return Bottom
         end
         a = argtypes[1]
-        return (isa(a,DataType) && a<:Array ?
+        return (isa(a,DataType) && a<:Array && isa(a.parameters[1],Type) ?
                 a.parameters[1] : Any)
     elseif is(f,Expr)
         if length(argtypes) < 1 && !isva

--- a/test/core.jl
+++ b/test/core.jl
@@ -3207,3 +3207,7 @@ end
 # don't allow Vararg{} in Tuple{} type constructor in non-trailing position
 @test_throws TypeError Tuple{Vararg{Int32},Int64,Float64}
 @test_throws TypeError Tuple{Int64,Vararg{Int32},Float64}
+
+# issue #12551 (make sure these don't throw in inference)
+Base.return_types(unsafe_load, (Ptr{nothing},))
+Base.return_types(getindex, (Vector{nothing},))


### PR DESCRIPTION
Fixes errors in type inference for such cases as:

``` julia
julia> unsafe_load(Ptr{nothing}(0))
ERROR: TypeError: subtype: expected Type{T}, got Void
 in tchanged at ./inference.jl:1184
 in typeinf_uncached at ./inference.jl:1641
 in typeinf at ./inference.jl:1340
 in typeinf at ./inference.jl:1290
 in abstract_call_gf at ./inference.jl:726
 in abstract_call at ./inference.jl:883
 in abstract_eval_call at ./inference.jl:935
 in abstract_eval at ./inference.jl:962
 in typeinf_uncached at ./inference.jl:1623
 in typeinf at ./inference.jl:1340
 in typeinf_ext at ./inference.jl:1284

julia> Array{nothing}(1)[1]
ERROR: TypeError: subtype: expected Type{T}, got Void
 in tchanged at ./inference.jl:1184
 in typeinf_uncached at ./inference.jl:1641
 in typeinf at ./inference.jl:1340
 in typeinf_ext at ./inference.jl:1284
```

although it turns out that `Array{nothing}(1)` is now actually constructable, which is a bit weird.

For some reason type inference was trying to infer the `Ptr{nothing}` case in my code, although I'm not sure why. With this fix my tests pass. Not sure if I should also be considering TypeVars here?
