### PR TITLE
cache dependency mtimes and check equality, not mtime(dep) <= mtime(cache)

### DIFF
--- a/test/compile.jl
+++ b/test/compile.jl
@@ -47,7 +47,7 @@ try
         deps = Base.cache_dependencies(cachefile)
         @test sort(deps[1]) == map(s -> (s, Base.module_uuid(eval(s))),
                                    [:Base,:Core,:Main])
-        @test sort(deps[2]) == [Foo_file,joinpath(dir,"bar.jl"),joinpath(dir,"foo.jl")]
+        @test map(x -> x[1], sort(deps[2])) == [Foo_file,joinpath(dir,"bar.jl"),joinpath(dir,"foo.jl")]
     end
 
     Baz_file = joinpath(dir, "Baz.jl")


### PR DESCRIPTION
As discussed in #12458, it is a good idea to store the timestamp of the dependency files in the `.ji` file, so that we can check staleness by comparing that the dependency timestamp is _equal_ to the cached value, not just that the dependency is older than the cachefile (ala `make`).  This has two advantages:
- Correctness: if you replace a dependency with an _older_ version of the file, you still want to recompile.
- Clock-skew: this should greatly reduce the problems arising from clock-skew if you are manually copying files back and forth over the network (cc @tkelman).

Of course, we may _still_ want to use a hash or checksum at some point, but this is a free-of-cost thing that we can do _now_.
