### PR TITLE
Create SharedArray from disk file

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1247,6 +1247,7 @@ export
 # shared arrays
     sdata,
     indexpids,
+    localindexes,
 
 # paths and file names
     abspath,

--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -111,7 +111,7 @@ function mmap{T,N}(io::IO,
 
     file_desc = gethandle(io)
     # platform-specific mmapping
-     @unix_only begin
+    @unix_only begin
         prot, flags, iswrite = settings(file_desc, shared)
         iswrite && grow && grow!(io, offset, len)
         # mmap the file

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -117,6 +117,7 @@ function SharedArray{T,N}(filename::AbstractString, ::Type{T}, dims::NTuple{N,In
     # Ensure the file will be readable
     mode in ("r", "r+", "w+", "a+") || throw(ArgumentError("mode must be readable, but $mode is not"))
     init==false || mode in ("r+", "w+", "a+") || throw(ArgumentError("cannot initialize unwritable array (mode = $mode)"))
+    mode == "r" && !isfile(filename) && throw(ArgumentError("file $filename does not exist, but mode $mode cannot create it"))
 
     # Create the file if it doesn't exist, map it if it does
     refs = Array(RemoteRef, length(pids))

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -102,7 +102,7 @@ SharedArray(T, I::Int...; kwargs...) = SharedArray(T, I; kwargs...)
 
 # Create a SharedArray from a disk file
 function SharedArray{T,N}(filename::AbstractString, ::Type{T}, dims::NTuple{N,Int}, offset::Integer=0; mode=nothing, init=false, pids::Vector{Int}=Int[])
-    isabspath(filename) || error("$filename is not an absolute path; try abspath(filename)?")
+    isabspath(filename) || throw(ArgumentError("$filename is not an absolute path; try abspath(filename)?"))
     isbits(T) || throw(ArgumentError("type of SharedArray elements must be bits types, got $(T)"))
 
     pids, onlocalhost = shared_pids(pids)
@@ -115,8 +115,8 @@ function SharedArray{T,N}(filename::AbstractString, ::Type{T}, dims::NTuple{N,In
     workermode = mode == "w+" ? "r+" : mode  # workers don't truncate!
 
     # Ensure the file will be readable
-    mode in ("r", "r+", "w+", "a+") || error("mode must be readable, but I got $mode")
-    init==false || mode in ("r+", "w+", "a+") || error("cannot initialize array unless it is writable")
+    mode in ("r", "r+", "w+", "a+") || throw(ArgumentError("mode must be readable, but $mode is not"))
+    init==false || mode in ("r+", "w+", "a+") || throw(ArgumentError("cannot initialize unwritable array (mode = $mode)"))
 
     # Create the file if it doesn't exist, map it if it does
     refs = Array(RemoteRef, length(pids))

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -127,12 +127,7 @@ end
 @test_throws ArgumentError SharedArray(fn, Int, sz, mode="w")
 
 # Error for file doesn't exist, but not allowed to create
-@windows_only begin
-    @test_throws ArgumentError SharedArray(tempname(), Int, sz, mode="r")
-end
-@unix_only begin
-    @test_throws SystemError   SharedArray(tempname(), Int, sz, mode="r")
-end
+@test_throws ArgumentError SharedArray(tempname(), Int, sz, mode="r")
 
 # Creating a new file
 fn2 = tempname()

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -42,7 +42,18 @@ end
 
 # TODO : Need a similar test of shmem cleanup for OSX
 
-# SharedArray tests
+##### SharedArray tests
+
+function check_pids_all(S::SharedArray)
+    pidtested = falses(size(S))
+    for p in procs(S)
+        idxes_in_p = remotecall_fetch(p, D -> parentindexes(D.loc_subarr_1d)[1], S)
+        @test all(sdata(S)[idxes_in_p] .== p)
+        pidtested[idxes_in_p] = true
+    end
+    @test all(pidtested)
+end
+
 d = Base.shmem_rand(1:100, dims)
 a = convert(Array, d)
 
@@ -85,6 +96,66 @@ for p in procs(d)
     @test d[idxf] == p
     @test d[idxl] == p
 end
+
+### SharedArrays from a file
+
+# Mapping an existing file
+fn = tempname()
+open(fn, "w") do io
+    write(io, 1:30)
+end
+sz = (6,5)
+Atrue = reshape(1:30, sz)
+
+S = SharedArray(fn, Int, sz)
+@test S == Atrue
+@test length(procs(S)) > 1
+@sync begin
+    for p in procs(S)
+        @async remotecall_wait(p, D->fill!(D.loc_subarr_1d, myid()), S)
+    end
+end
+check_pids_all(S)
+
+filedata = similar(Atrue)
+open(fn, "r") do io
+    read!(io, filedata)
+end
+@test filedata == sdata(S)
+
+# Error for write-only files
+@test_throws ErrorException SharedArray(fn, Int, sz, mode="w")
+
+# Error for file doesn't exist, but not allowed to create
+@test_throws SystemError SharedArray(tempname(), Int, sz, mode="r")
+
+# Creating a new file
+fn2 = tempname()
+S = SharedArray(fn2, Int, sz, init=D->D[localindexes(D)] = myid())
+@test S == filedata
+filedata2 = similar(Atrue)
+open(fn2, "r") do io
+    read!(io, filedata2)
+end
+@test filedata == filedata2
+
+# Appending to a file
+fn3 = tempname()
+open(fn3, "w") do io
+    write(io, ones(UInt8, 4))
+end
+S = SharedArray(fn3, UInt8, sz, 4, mode="a+", init=D->D[localindexes(D)]=0x02)
+len = prod(sz)+4
+@test filesize(fn3) == len
+filedata = Array(UInt8, len)
+open(fn3, "r") do io
+    read!(io, filedata)
+end
+@test all(filedata[1:4] .== 0x01)
+@test all(filedata[5:end] .== 0x02)
+
+
+### Utility functions
 
 # reshape
 

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -124,10 +124,15 @@ end
 @test filedata == sdata(S)
 
 # Error for write-only files
-@test_throws ErrorException SharedArray(fn, Int, sz, mode="w")
+@test_throws ArgumentError SharedArray(fn, Int, sz, mode="w")
 
 # Error for file doesn't exist, but not allowed to create
-@test_throws SystemError SharedArray(tempname(), Int, sz, mode="r")
+@windows_only begin
+    @test_throws ArgumentError SharedArray(tempname(), Int, sz, mode="r")
+end
+@unix_only begin
+    @test_throws SystemError   SharedArray(tempname(), Int, sz, mode="r")
+end
 
 # Creating a new file
 fn2 = tempname()


### PR DESCRIPTION
The third commit here allows you to share data from a pre-existing disk file (or a newly-created one) across all workers.

The first commit is just a cleanup (and net code deletion): it leverages #10525 for indexing, and makes all fields of a SharedArray concrete (I think the important ones were already). The second is #12423 without the documentation changes (because docs can always be added later, and we're in a bit of doc-paralysis at the moment). That commit should still be good even after this merges.

CC @amitmurthy
