### PR TITLE
Fix promotion and type stability for sparse factorizations

### DIFF
--- a/base/linalg/factorization.jl
+++ b/base/linalg/factorization.jl
@@ -22,15 +22,15 @@ convert{T}(::Type{Factorization{T}}, F::Factorization{T}) = F
 inv{T}(F::Factorization{T}) = A_ldiv_B!(F, eye(T, size(F,1)))
 function \{TF<:Number,TB<:Number,N}(F::Factorization{TF}, B::AbstractArray{TB,N})
     TFB = typeof(one(TF)/one(TB))
-    A_ldiv_B!(convert(Factorization{TFB}, F), TB == TFB ? copy(B) : convert(AbstractArray{TFB,N}, B))
+    A_ldiv_B!(convert(Factorization{TFB}, F), copy_oftype(B, TFB))
 end
 
 function Ac_ldiv_B{TF<:Number,TB<:Number,N}(F::Factorization{TF}, B::AbstractArray{TB,N})
     TFB = typeof(one(TF)/one(TB))
-    Ac_ldiv_B!(convert(Factorization{TFB}, F), TB == TFB ? copy(B) : convert(AbstractArray{TFB,N}, B))
+    Ac_ldiv_B!(convert(Factorization{TFB}, F), copy_oftype(B, TFB))
 end
 
 function At_ldiv_B{TF<:Number,TB<:Number,N}(F::Factorization{TF}, B::AbstractArray{TB,N})
     TFB = typeof(one(TF)/one(TB))
-    At_ldiv_B!(convert(Factorization{TFB}, F), TB == TFB ? copy(B) : convert(AbstractArray{TFB,N}, B))
+    At_ldiv_B!(convert(Factorization{TFB}, F), copy_oftype(B, TFB))
 end

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -535,7 +535,6 @@ function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = 2)
     S = zeros(T, n, t)
 
     # Generate the block matrix
-    h = zeros(real(T), n)
     X = Array(T, n, t)
     X[1:n,1] = 1
     for j = 2:t
@@ -625,7 +624,8 @@ function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = 2)
 
         # Use the conjugate transpose
         Z = F' \ S
-        h_max = 0
+        h_max = zero(real(eltype(Z)))
+        h = zeros(real(eltype(Z)), n)
         h_ind = 0
         for i = 1:n
             h[i] = norm(Z[i,1:t], Inf)
@@ -640,7 +640,7 @@ function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = 2)
         end
         p = sortperm(h, rev=true)
         h = h[p]
-        ind = ind[p]
+        permute!(ind, p)
         if t > 1
             addcounter = t
             elemcounter = 0

--- a/base/sparse/spqr.jl
+++ b/base/sparse/spqr.jl
@@ -144,5 +144,6 @@ function (\){T}(F::Factorization{T}, B::StridedVecOrMat{T})
     QtB = qmult(QTX, F, Dense(B))
     convert(typeof(B), solve(RETX_EQUALS_B, F, QtB))
 end
+(\){T,S}(F::Factorization{T}, B::StridedVecOrMat{S}) = F\convert(AbstractArray{T}, B)
 
 end # module

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -113,6 +113,7 @@ function lufact{Tv<:UMFVTypes,Ti<:UMFITypes}(S::SparseMatrixCSC{Tv,Ti})
     finalizer(res, umfpack_free_symbolic)
     umfpack_numeric!(res)
 end
+lufact(A::SparseMatrixCSC) = lufact(float(A))
 
 function show(io::IO, f::UmfpackLU)
     println(io, "UMFPACK LU Factorization of a $(f.m)-by-$(f.n) sparse matrix")

--- a/test/sparsedir/cholmod.jl
+++ b/test/sparsedir/cholmod.jl
@@ -593,3 +593,7 @@ sparse(cholfact(sparse(Float64[ 10 1 1 1; 1 10 0 0; 1 0 10 0; 1 0 0 10]))); gc()
 
 # Issue 11747 - Wrong show method defined for FactorComponent
 Base.writemime(IOBuffer(), MIME"text/plain"(), cholfact(sparse(Float64[ 10 1 1 1; 1 10 0 0; 1 0 10 0; 1 0 0 10]))[:L])
+
+# Element promotion and type inference
+@inferred cholfact(As)\ones(Int, size(As, 1))
+@inferred ldltfact(As)\ones(Int, size(As, 1))

--- a/test/sparsedir/spqr.jl
+++ b/test/sparsedir/spqr.jl
@@ -9,18 +9,21 @@ m, n = 100, 10
 nn = 100
 
 for eltyA in (Float64, Complex{Float64})
-    for eltyB in (Float64, Complex{Float64})
+    for eltyB in (Int, Float64, Complex{Float64})
         if eltyA <: Real
             A = sparse([1:n; rand(1:m, nn - n)], [1:n; rand(1:n, nn - n)], randn(nn), m, n)
         else
             A = sparse([1:n; rand(1:m, nn - n)], [1:n; rand(1:n, nn - n)], complex(randn(nn), randn(nn)), m, n)
         end
-        if eltyB <: Real
+        if eltyB == Int
+            B = rand(1:10, m, 2)
+        elseif eltyB <: Real
             B = randn(m, 2)
         else
             B = complex(randn(m, 2), randn(m, 2))
         end
 
+        @inferred A\B
         @test_approx_eq A\B[:,1] full(A)\B[:,1]
         @test_approx_eq A\B full(A)\B
         @test_throws DimensionMismatch A\B[1:m-1,:]

--- a/test/sparsedir/umfpack.jl
+++ b/test/sparsedir/umfpack.jl
@@ -33,6 +33,9 @@ for Tv in (Float64, Complex128)
         @test_approx_eq x float([1:5;])
 
         @test norm(A'*x-b,1) < eps(1e4)
+
+        # Element promotion and type inference
+        @inferred lua\ones(Int, size(A, 2))
     end
 end
 


### PR DESCRIPTION
Element type promotion was not working correctly for the sparse factorizations. In some places errors were thrown and in some places the return types were not uniquely determined from the input types. This pr should fix some of these problems.
