### PR TITLE
fix #12552 (norm should return NaN for NaN inputs)

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -74,7 +74,8 @@ function generic_vecnormMinusInf(x)
     minabs = norm(v)
     while !done(x, s)
         (v, s) = next(x, s)
-        minabs = Base.scalarmin(minabs, norm(v))
+        vnorm = norm(v)
+        minabs = ifelse(isnan(minabs) | (minabs < vnorm), minabs, vnorm)
     end
     return float(minabs)
 end
@@ -85,7 +86,8 @@ function generic_vecnormInf(x)
     maxabs = norm(v)
     while !done(x, s)
         (v, s) = next(x, s)
-        maxabs = Base.scalarmax(maxabs, norm(v))
+        vnorm = norm(v)
+        maxabs = ifelse(isnan(maxabs) | (maxabs > vnorm), maxabs, vnorm)
     end
     return float(maxabs)
 end

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -401,6 +401,7 @@ function -(x::BigFloat)
 end
 
 function sqrt(x::BigFloat)
+    isnan(x) && return x
     z = BigFloat()
     ccall((:mpfr_sqrt, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Int32), &z, &x, ROUNDING_MODE[end])
     if isnan(z)

--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -127,6 +127,14 @@ for elty in (Float32, Float64, BigFloat, Complex{Float32}, Complex{Float64}, Com
     @test_approx_eq norm(xs, 3) cbrt(5)
     @test_approx_eq norm(xs, Inf) 1
 
+    # Issue #12552:
+    if real(elty) <: AbstractFloat
+        for p in [-Inf,-1,1,2,3,Inf]
+            @test isnan(norm(elty[0,NaN],p))
+            @test isnan(norm(elty[NaN,0],p))
+        end
+    end
+
     ## Number
     norm(x[1:1]) === norm(x[1], -Inf)
     norm(x[1:1]) === norm(x[1], 0)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -861,3 +861,5 @@ let b = IOBuffer()
     seekstart(b)
     @test deserialize(b) == x
 end
+
+@test isnan(sqrt(BigFloat(NaN)))


### PR DESCRIPTION
This is a minimal fix for JuliaLang/LinearAlgebra.jl#236 that does not require a decision on JuliaLang/julia#7866.

In the infinity norms, we don't have to worry about signed zeros because we are taking absolute values.  So, it is optimal anyway just to inline our own `max` and `min` functions that ignore the sign bit, and once we are doing that we can treat NaN however we want for these functions.

In doing so, I noticed and fixed a bug that `sqrt(big(NaN))` was throwing a `DomainError` rather than returning NaN.
