### PR TITLE
RFC: Allow any index type in nonscalar indexing

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -498,9 +498,6 @@ _unsafe_getindex{T}(::LinearSlow, A::AbstractArray{T,0}) = (@_inline_meta; getin
 _unsafe_getindex(::LinearSlow, A::AbstractVector) = (@_inline_meta; unsafe_getindex(A, 1))
 _unsafe_getindex(l::LinearSlow, A::AbstractArray) = (@_inline_meta; _unsafe_getindex(l, A, 1))
 
-_getindex(::LinearIndexing, A::AbstractArray, I...) = error("indexing $(typeof(A)) with types $(typeof(I)) is not supported")
-_unsafe_getindex(::LinearIndexing, A::AbstractArray, I...) = (@_inline_meta; getindex(A, I...))
-
 ## LinearFast Scalar indexing
 _getindex(::LinearFast, A::AbstractArray, I::Int) = error("indexing not defined for ", typeof(A))
 function _getindex(::LinearFast, A::AbstractArray, I::Real...)
@@ -599,9 +596,6 @@ _unsafe_setindex!(::LinearFast, A::AbstractArray, v) = (@_inline_meta; unsafe_se
 _unsafe_setindex!{T}(::LinearSlow, A::AbstractArray{T,0}, v) = (@_inline_meta; setindex!(A, v))
 _unsafe_setindex!(::LinearSlow, A::AbstractVector, v) = (@_inline_meta; unsafe_setindex!(A, v, 1))
 _unsafe_setindex!(l::LinearSlow, A::AbstractArray, v) = (@_inline_meta; _unsafe_setindex!(l, A, v, 1))
-
-_setindex!(::LinearIndexing, A::AbstractArray, v, I...) = error("indexing $(typeof(A)) with types $(typeof(I)) is not supported")
-_unsafe_setindex!(::LinearIndexing, A::AbstractArray, v, I...) = (@_inline_meta; setindex!(A, v, I...))
 
 ## LinearFast Scalar indexing
 _setindex!(::LinearFast, A::AbstractArray, v, I::Int) = error("indexed assignment not defined for ", typeof(A))

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -494,7 +494,7 @@ _getindex{T}(::LinearSlow, A::AbstractArray{T,0}) = error("indexing not defined 
 _getindex(::LinearSlow, A::AbstractVector) = (@_inline_meta; getindex(A, 1))
 _getindex(l::LinearSlow, A::AbstractArray) = (@_inline_meta; _getindex(l, A, 1))
 _unsafe_getindex(::LinearFast, A::AbstractArray) = (@_inline_meta; unsafe_getindex(A, 1))
-_unsafe_getindex{T}(::LinearSlow, A::AbstractArray{T,0}) = error("indexing not defined for ", typeof(A))
+_unsafe_getindex{T}(::LinearSlow, A::AbstractArray{T,0}) = (@_inline_meta; getindex(A))
 _unsafe_getindex(::LinearSlow, A::AbstractVector) = (@_inline_meta; unsafe_getindex(A, 1))
 _unsafe_getindex(l::LinearSlow, A::AbstractArray) = (@_inline_meta; _unsafe_getindex(l, A, 1))
 
@@ -596,7 +596,7 @@ _setindex!{T}(::LinearSlow, A::AbstractArray{T,0}, v) = error("indexing not defi
 _setindex!(::LinearSlow, A::AbstractVector, v) = (@_inline_meta; setindex!(A, v, 1))
 _setindex!(l::LinearSlow, A::AbstractArray, v) = (@_inline_meta; _setindex!(l, A, v, 1))
 _unsafe_setindex!(::LinearFast, A::AbstractArray, v) = (@_inline_meta; unsafe_setindex!(A, v, 1))
-_unsafe_setindex!{T}(::LinearSlow, A::AbstractArray{T,0}, v) = error("indexing not defined for ", typeof(A))
+_unsafe_setindex!{T}(::LinearSlow, A::AbstractArray{T,0}, v) = (@_inline_meta; setindex!(A, v))
 _unsafe_setindex!(::LinearSlow, A::AbstractVector, v) = (@_inline_meta; unsafe_setindex!(A, v, 1))
 _unsafe_setindex!(l::LinearSlow, A::AbstractArray, v) = (@_inline_meta; _unsafe_setindex!(l, A, v, 1))
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -441,24 +441,6 @@ end
 end
 
 # 10458
-to_index_nodep(i::Real) = convert(Int,i)::Int
-
-@noinline function to_index(i::Real)
-    depwarn("indexing with non Integer Reals is deprecated", :to_index)
-    to_index_nodep(i)
-end
-
-to_index{T<:Integer}(A::AbstractArray{T}) = A
-@noinline function to_index{T<:Real}(A::AbstractArray{T})
-    depwarn("indexing with non Integer AbstractArrays is deprecated", :to_index)
-    Int[to_index_nodep(x) for x in A]
-end
-
-@noinline function to_index(I::Tuple)
-    depwarn("to_index(I::Tuple) is deprecated, use to_indexes(I...) instead.", :to_index)
-    to_indexes(I...)
-end
-
 @deprecate getindex(c::Char, I::Real...) getindex(c, map(Int, I)...)
 @deprecate getindex(s::AbstractString, x::Real) getindex(s, Int(x))
 @deprecate checkbounds(s::AbstractString, i::Real) checkbounds(s, Int(i))

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -309,14 +309,9 @@ function setindex_shape_check{T}(X::AbstractArray{T,2}, i, j)
 end
 setindex_shape_check(X, I...) = nothing # Non-arrays broadcast to all idxs
 
-# convert to a supported index type (Array, Colon, or Int)
+# convert to a supported scalar index type (Int)
 to_index(i::Int) = i
 to_index(i::Integer) = convert(Int,i)::Int
-to_index(c::Colon) = c
-to_index(I::AbstractArray{Bool}) = find(I)
-to_index(A::AbstractArray) = A
-to_index{T<:AbstractArray}(A::AbstractArray{T}) = throw(ArgumentError("invalid index: $A"))
-to_index(A::AbstractArray{Colon}) = throw(ArgumentError("invalid index: $A"))
 to_index(i) = throw(ArgumentError("invalid index: $i"))
 
 to_indexes() = ()

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -36,8 +36,8 @@ parentindexes(a::AbstractArray) = ntuple(i->1:size(a,i), ndims(a))
 
 ## SubArray creation
 # Drops singleton dimensions (those indexed with a scalar)
-slice(A::AbstractArray, I::ViewIndex...) = _slice(A, to_indexes(I...))
-slice(A::AbstractArray, I::Tuple{Vararg{ViewIndex}}) = _slice(A, to_indexes(I...))
+slice(A::AbstractArray, I::ViewIndex...) = _slice(A, to_nonscalar_indexes(I...))
+slice(A::AbstractArray, I::Tuple{Vararg{ViewIndex}}) = _slice(A, to_nonscalar_indexes(I...))
 function _slice(A, I)
     checkbounds(A, I...)
     slice_unsafe(A, I)
@@ -60,7 +60,7 @@ end
 # For S4, J[1] corresponds to I[2], because of the slice along
 # dimension 1 in S2
 
-slice_unsafe(A::AbstractArray, J) = _slice_unsafe(A, to_indexes(J...))
+slice_unsafe(A::AbstractArray, J) = _slice_unsafe(A, to_nonscalar_indexes(J...))
 @generated function _slice_unsafe{T,NP,IndTypes}(A::AbstractArray{T,NP}, J::IndTypes)
     N = 0
     sizeexprs = Array(Any, 0)
@@ -91,7 +91,7 @@ function _sub(A, I)
     sub_unsafe(A, I)
 end
 
-sub_unsafe(A::AbstractArray, J) = _sub_unsafe(A, to_indexes(J...))
+sub_unsafe(A::AbstractArray, J) = _sub_unsafe(A, to_nonscalar_indexes(J...))
 @generated function _sub_unsafe{T,NP,IndTypes}(A::AbstractArray{T,NP}, J::IndTypes)
     sizeexprs = Array(Any, 0)
     Itypes = Array(Any, 0)
@@ -345,8 +345,10 @@ end
     length(I.parameters) == LD ? (:(LinearFast())) : (:(LinearSlow()))
 end
 
-getindex(::Colon, i) = to_index(i)
-unsafe_getindex(v::Colon, i) = to_index(i)
+getindex(::Colon, i::Real) = to_index(i)
+unsafe_getindex(v::Colon, i::Real) = to_index(i)
+getindex(::Colon, i) = to_nonscalar_index(i)
+unsafe_getindex(v::Colon, i) = to_nonscalar_index(i)
 
 step(::Colon) = 1
 first(::Colon) = 1


### PR DESCRIPTION
I'm posting this to point an arrow towards where I think the array indexing fallbacks will go.  I'm seeking a discussion on what deserves to be changed before 0.4 is branched.

Here's what this enables:

``` jl
immutable SymInt{T} <: AbstractArray{T,2}
    a::Vector{T}
    b::Vector{T}
    c::Vector{T}
end
Base.size(A::SymInt) = (3, length(A.a))
Base.getindex(A::SymInt, f::Union{Symbol, Int}, i::Int) = getfield(A, f)[i]
Base.checkbounds(A::SymInt, I...) = true # punt

julia> A = SymInt([1,2,3,4],[11,12,13,14],[21,22,23,24])
3x4 SymInt{Int64}:
  1   2   3   4
 11  12  13  14
 21  22  23  24

julia> A[[:c,:a,:b],[3,2,1]]
3x3 Array{Int64,2}:
 23  22  21
  3   2   1
 13  12  11

julia> A[:a, :]
1x4 Array{Int64,2}:
 1  2  3  4

julia> A[:, 2]
3-element Array{Int64,1}:
  2
 12
 22
```

Here's what I think should occur before 0.4 branches:
- This sits atop #11895.  If we can't find a good name for `in_bounds`, we can at least make it easier to extend checkbounds for a custom type, even if it's still undocumented for custom array types to provide custom index-in-bounds checks.
- I think we should un-deprecate float indexing

Here's why the rest of this might need to wait, but if folks are gung-ho I can work to mitigate some of these concerns:
- It adds some crazy powerful functionality that isn't tested (but I can add tests like the above)
- It changes the behavior of `to_index`, which, while not documented or exported, does get used outside of base.
- It uses more generated functions to express dispatch on "at least one vararg is <: X".
- It extends what it means to be an AbstractArray to a more nebulous area.
