### PR TITLE
Avoid overflow in p norms

### DIFF
--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -121,3 +121,6 @@ for elty in [Float32,Float64,Complex64,Complex128]
 end
 
 @test qr(big([0 1; 0 0]))[2] == [0 1; 0 0]
+
+@test norm([2.4e-322, 4.4e-323]) ≈ 2.47e-322
+@test norm([2.4e-322, 4.4e-323], 3) ≈ 2.4e-322


### PR DESCRIPTION
Use division instead of multiplication with reciprocal when scaling elements in vecnorm methods. This fixes JuliaLang/LinearAlgebra.jl#222 and supersedes JuliaLang/julia#11789. The logic used here is a little different from the other `generic_vecnorm`s. I try to use the element type of the array when the input is an `AbstractVector{T<:Number}` and for general iterables I have to require that they are non-empty.

cc: @stevengj 
