### PR TITLE
Add tril and triu for special matrices

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -109,6 +109,44 @@ ctranspose(M::Bidiagonal) = Bidiagonal(conj(M.dv), conj(M.ev), !M.isupper)
 istriu(M::Bidiagonal) = M.isupper || all(M.ev .== 0)
 istril(M::Bidiagonal) = !M.isupper || all(M.ev .== 0)
 
+function tril(M::Bidiagonal, k::Integer=0)
+    n = length(M.dv)
+    if abs(k) > n
+        throw(ArgumentError("requested diagonal, $k, out of bounds in matrix of size ($n,$n)"))
+    elseif M.isupper && k < 0
+        return Bidiagonal(zeros(M.dv),zeros(M.ev),M.isupper)
+    elseif k < -1
+        return Bidiagonal(zeros(M.dv),zeros(M.ev),M.isupper)
+    elseif !M.isupper && k == 0
+        return M
+    elseif M.isupper && k == 0
+        return Bidiagonal(M.dv,zeros(M.ev),M.isupper)
+    elseif !M.isupper && k == -1
+        return Bidiagonal(zeros(M.dv),M.ev,M.isupper)
+    elseif k > 0
+        return M
+    end
+end
+
+function triu(M::Bidiagonal, k::Integer=0)
+    n = length(M.dv)
+    if abs(k) > n
+        throw(ArgumentError("requested diagonal, $k, out of bounds in matrix of size ($n,$n)"))
+    elseif !M.isupper && k > 0
+        return Bidiagonal(zeros(M.dv),zeros(M.ev),M.isupper)
+    elseif k > 1
+        return Bidiagonal(zeros(M.dv),zeros(M.ev),M.isupper)
+    elseif M.isupper && k == 0
+        return M
+    elseif !M.isupper && k == 0
+        return Bidiagonal(M.dv,zeros(M.ev),M.isupper)
+    elseif M.isupper && k == 1
+        return Bidiagonal(zeros(M.dv),M.ev,M.isupper)
+    elseif k < 0
+        return M
+    end
+end
+
 function diag{T}(M::Bidiagonal{T}, n::Integer=0)
     if n==0
         return M.dv
@@ -249,4 +287,3 @@ function eigvecs{T}(M::Bidiagonal{T})
     Q #Actually Triangular
 end
 eigfact(M::Bidiagonal) = Eigen(eigvals(M), eigvecs(M))
-

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -55,8 +55,8 @@ isposdef(D::Diagonal) = all(D.diag .> 0)
 
 factorize(D::Diagonal) = D
 
-tril!(D::Diagonal,i::Integer) = i == 0 ? D : zeros(D)
-triu!(D::Diagonal,i::Integer) = i == 0 ? D : zeros(D)
+tril(D::Diagonal,i::Integer=0) = i == 0 ? D : zeros(D)
+triu(D::Diagonal,i::Integer=0) = i == 0 ? D : zeros(D)
 
 ==(Da::Diagonal, Db::Diagonal) = Da.diag == Db.diag
 -(A::Diagonal)=Diagonal(-A.diag)

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -56,6 +56,12 @@ end
 ctranspose(A::Hermitian) = A
 trace(A::Hermitian) = real(trace(A.data))
 
+#tril/triu
+tril(A::Hermitian,k::Integer=0) = tril(A.data,k)
+triu(A::Hermitian,k::Integer=0) = triu(A.data,k)
+tril(A::Symmetric,k::Integer=0) = tril(A.data,k)
+triu(A::Symmetric,k::Integer=0) = triu(A.data,k)
+
 ## Matvec
 A_mul_B!{T<:BlasFloat,S<:StridedMatrix}(y::StridedVector{T}, A::Symmetric{T,S}, x::StridedVector{T}) = BLAS.symv!(A.uplo, one(T), A.data, x, zero(T), y)
 A_mul_B!{T<:BlasComplex,S<:StridedMatrix}(y::StridedVector{T}, A::Hermitian{T,S}, x::StridedVector{T}) = BLAS.hemv!(A.uplo, one(T), A.data, x, zero(T), y)

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -146,6 +146,66 @@ istril(A::UnitLowerTriangular) = true
 istriu(A::UpperTriangular) = true
 istriu(A::UnitUpperTriangular) = true
 
+function tril(A::UpperTriangular,k::Integer=0)
+    n = size(A,1)
+    if abs(k) > n
+        throw(ArgumentError("requested diagonal, $k, out of bounds in matrix of size ($n,$n)"))
+    elseif k < 0
+        return UpperTriangular(zeros(A.data))
+    elseif k == 0
+        return UpperTriangular(diagm(diag(A)))
+    else
+        return UpperTriangular(triu(tril(A.data,k)))
+    end
+end
+
+triu(A::UpperTriangular,k::Integer=0) = UpperTriangular(triu(triu(A.data),k))
+
+function tril(A::UnitUpperTriangular,k::Integer=0)
+    n = size(A,1)
+    if abs(k) > n
+        throw(ArgumentError("requested diagonal, $k, out of bounds in matrix of size ($n,$n)"))
+    elseif k < 0
+        return UnitUpperTriangular(zeros(A.data))
+    elseif k == 0
+        return UnitUpperTriangular(eye(A))
+    else
+        return UnitUpperTriangular(triu(tril(A.data,k)))
+    end
+end
+
+triu(A::UnitUpperTriangular,k::Integer=0) = UnitUpperTriangular(triu(triu(A.data),k))
+
+function triu(A::LowerTriangular,k::Integer=0)
+    n = size(A,1)
+    if abs(k) > n
+        throw(ArgumentError("requested diagonal, $k, out of bounds in matrix of size ($n,$n)"))
+    elseif k > 0
+        return LowerTriangular(zeros(A.data))
+    elseif k == 0
+        return LowerTriangular(diagm(diag(A)))
+    else
+        return LowerTriangular(tril(triu(A.data,k)))
+    end
+end
+
+tril(A::LowerTriangular,k::Integer=0) = LowerTriangular(tril(tril(A.data),k))
+
+function triu(A::UnitLowerTriangular,k::Integer=0)
+    n = size(A,1)
+    if abs(k) > n
+        throw(ArgumentError("requested diagonal, $k, out of bounds in matrix of size ($n,$n)"))
+    elseif k > 0
+        return UnitLowerTriangular(zeros(A.data))
+    elseif k == 0
+        return UnitLowerTriangular(eye(A))
+    else
+        return UnitLowerTriangular(tril(triu(A.data,k)))
+    end
+end
+
+tril(A::UnitLowerTriangular,k::Integer=0) = UnitLowerTriangular(tril(tril(A.data),k))
+
 transpose{T,S}(A::LowerTriangular{T,S}) = UpperTriangular{T, S}(transpose(A.data))
 transpose{T,S}(A::UnitLowerTriangular{T,S}) = UnitUpperTriangular{T, S}(transpose(A.data))
 transpose{T,S}(A::UpperTriangular{T,S}) = LowerTriangular{T, S}(transpose(A.data))

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -144,6 +144,41 @@ eigmin(A::SymTridiagonal) = eigvals(A, 1:1)[1]
 eigvecs(A::SymTridiagonal) = eigfact(A)[:vectors]
 eigvecs{T<:BlasFloat,Eigenvalue<:Real}(A::SymTridiagonal{T}, eigvals::Vector{Eigenvalue}) = LAPACK.stein!(A.dv, A.ev, eigvals)
 
+#tril and triu
+
+istriu(M::SymTridiagonal) = all(M.ev .== 0)
+istril(M::SymTridiagonal) = all(M.ev .== 0)
+
+function tril(M::SymTridiagonal, k::Integer=0)
+    n = length(M.dv)
+    if abs(k) > n
+        throw(ArgumentError("requested diagonal, $k, out of bounds in matrix of size ($n,$n)"))
+    elseif k < -1
+        return SymTridiagonal(zeros(M.dv),zeros(M.ev))
+    elseif k == -1
+        return Tridiagonal(M.ev,zeros(M.dv),zeros(M.ev))
+    elseif k == 0
+        return Tridiagonal(M.ev,M.dv,zeros(M.ev))
+    elseif k >= 1
+        return M
+    end
+end
+
+function triu(M::SymTridiagonal, k::Integer=0)
+    n = length(M.dv)
+    if abs(k) > n
+        throw(ArgumentError("requested diagonal, $k, out of bounds in matrix of size ($n,$n)"))
+    elseif k > 1
+        return SymTridiagonal(zeros(M.dv),zeros(M.ev))
+    elseif k == 1
+        return Tridiagonal(zeros(M.ev),zeros(M.dv),M.ev)
+    elseif k == 0
+        return Tridiagonal(zeros(M.ev),M.dv,M.ev)
+    elseif k <= -1
+        return M
+    end
+end
+
 ###################
 # Generic methods #
 ###################
@@ -316,6 +351,41 @@ function getindex{T}(A::Tridiagonal{T}, i::Integer, j::Integer)
         return A.du[i]
     else
         return zero(T)
+    end
+end
+
+#tril and triu
+
+istriu(M::Tridiagonal) = all(M.ev .== 0)
+istril(M::Tridiagonal) = all(M.ev .== 0)
+
+function tril(M::Tridiagonal, k::Integer=0)
+    n = length(M.d)
+    if abs(k) > n
+        throw(ArgumentError("requested diagonal, $k, out of bounds in matrix of size ($n,$n)"))
+    elseif k < -1
+        return Tridiagonal(zeros(M.dl),zeros(M.d),zeros(M.du))
+    elseif k == -1
+        return Tridiagonal(M.dl,zeros(M.d),zeros(M.du))
+    elseif k == 0
+        return Tridiagonal(M.dl,M.d,zeros(M.du))
+    elseif k >= 1
+        return M
+    end
+end
+
+function triu(M::Tridiagonal, k::Integer=0)
+    n = length(M.d)
+    if abs(k) > n
+        throw(ArgumentError("requested diagonal, $k, out of bounds in matrix of size ($n,$n)"))
+    elseif k > 1
+        return Tridiagonal(zeros(M.dl),zeros(M.d),zeros(M.du))
+    elseif k == 1
+        return Tridiagonal(zeros(M.dl),zeros(M.d),M.du)
+    elseif k == 0
+        return Tridiagonal(zeros(M.dl),M.d,M.du)
+    elseif k <= -1
+        return M
     end
 end
 

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -42,6 +42,28 @@ for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
             @test func(func(T)) == T
         end
 
+        debug && println("triu and tril")
+        @test tril(Bidiagonal(dv,ev,'U'),-1) == Bidiagonal(zeros(dv),zeros(ev),'U')
+        @test tril(Bidiagonal(dv,ev,'L'),-1) == Bidiagonal(zeros(dv),ev,'L')
+        @test tril(Bidiagonal(dv,ev,'U'),-2) == Bidiagonal(zeros(dv),zeros(ev),'U')
+        @test tril(Bidiagonal(dv,ev,'L'),-2) == Bidiagonal(zeros(dv),zeros(ev),'L')
+        @test tril(Bidiagonal(dv,ev,'U'),1)  == Bidiagonal(dv,ev,'U')
+        @test tril(Bidiagonal(dv,ev,'L'),1)  == Bidiagonal(dv,ev,'L')
+        @test tril(Bidiagonal(dv,ev,'U'))    == Bidiagonal(dv,zeros(ev),'U')
+        @test tril(Bidiagonal(dv,ev,'L'))    == Bidiagonal(dv,ev,'L')
+        @test_throws ArgumentError tril(Bidiagonal(dv,ev,'U'),n+1)
+
+        @test triu(Bidiagonal(dv,ev,'L'),1)  == Bidiagonal(zeros(dv),zeros(ev),'L')
+        @test triu(Bidiagonal(dv,ev,'U'),1)  == Bidiagonal(zeros(dv),ev,'U')
+        @test triu(Bidiagonal(dv,ev,'U'),2)  == Bidiagonal(zeros(dv),zeros(ev),'U')
+        @test triu(Bidiagonal(dv,ev,'L'),2)  == Bidiagonal(zeros(dv),zeros(ev),'L')
+        @test triu(Bidiagonal(dv,ev,'U'),-1) == Bidiagonal(dv,ev,'U')
+        @test triu(Bidiagonal(dv,ev,'L'),-1) == Bidiagonal(dv,ev,'L')
+        @test triu(Bidiagonal(dv,ev,'L'))    == Bidiagonal(dv,zeros(ev),'L')
+        @test triu(Bidiagonal(dv,ev,'U'))    == Bidiagonal(dv,ev,'U')
+        @test_throws ArgumentError triu(Bidiagonal(dv,ev,'U'),n+1)
+
+
         debug && println("Linear solver")
         Tfull = full(T)
         condT = cond(map(Complex128,Tfull))

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -84,10 +84,10 @@ for relty in (Float32, Float64, BigFloat), elty in (relty, Complex{relty})
     @test_approx_eq D/D2 Diagonal(D.diag./D2.diag)
 
     # test triu/tril
-    @test triu!(copy(D),1) == zeros(D)
-    @test triu!(copy(D),0) == D
-    @test tril!(copy(D),1) == zeros(D)
-    @test tril!(copy(D),0) == D
+    @test triu(D,1) == zeros(D)
+    @test triu(D,0) == D
+    @test tril(D,1) == zeros(D)
+    @test tril(D,0) == D
 
     # factorize
     @test factorize(D) == D

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -59,6 +59,12 @@ let n=10
         @test ctranspose(Symmetric(asym)) == Symmetric(conj(asym))
         @test ctranspose(Hermitian(asym)) == asym
 
+        #tril/triu
+        @test triu(Symmetric(asym),1) == triu(asym,1)
+        @test tril(Symmetric(asym),1) == tril(asym,1)
+        @test triu(Hermitian(asym),1) == triu(asym,1)
+        @test tril(Hermitian(asym),1) == tril(asym,1)
+
         eltya == BigFloat && continue # Revisit when implemented in julia
         d, v = eig(asym)
         @test_approx_eq asym*v[:,1] d[1]*v[:,1]

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -85,6 +85,25 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
             @test !istril(A1)
         end
 
+        #tril/triu
+        if uplo1 == :L
+            @test tril(A1)    == A1
+            @test tril(A1,-1) == t1(tril(full(A1),-1))
+            @test tril(A1,1)  == t1(tril(tril(full(A1),1)))
+            @test_throws ArgumentError tril(A1,n+1)
+            @test triu(A1)    == t1(diagm(diag(A1)))
+            @test triu(A1,-1) == t1(tril(triu(A1.data,-1)))
+            @test_throws ArgumentError triu(A1,n+1)
+        else
+            @test triu(A1)    == A1
+            @test triu(A1,1)  == t1(triu(full(A1),1))
+            @test triu(A1,-1) == t1(triu(triu(full(A1),-1)))
+            @test_throws ArgumentError triu(A1,n+1)
+            @test tril(A1)    == t1(diagm(diag(A1)))
+            @test tril(A1,1)  == t1(triu(tril(A1.data,1)))
+            @test_throws ArgumentError tril(A1,n+1)
+        end
+
         # factorize
         @test factorize(A1) == A1
 

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -115,6 +115,25 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
 
     # issue #1490
     @test_approx_eq_eps det(ones(elty, 3,3)) zero(elty) 3*eps(real(one(elty)))
+
+    #tril/triu
+    @test_throws ArgumentError tril(SymTridiagonal(d,dl),n+1)
+    @test_throws ArgumentError tril(Tridiagonal(dl,d,du),n+1)
+    @test tril(SymTridiagonal(d,dl))    == Tridiagonal(dl,d,zeros(dl))
+    @test tril(SymTridiagonal(d,dl),1)  == Tridiagonal(dl,d,dl)
+    @test tril(SymTridiagonal(d,dl),-1) == Tridiagonal(dl,zeros(d),zeros(dl))
+    @test tril(Tridiagonal(dl,d,du))    == Tridiagonal(dl,d,zeros(du))
+    @test tril(Tridiagonal(dl,d,du),1)  == Tridiagonal(dl,d,du)
+    @test tril(Tridiagonal(dl,d,du),-1) == Tridiagonal(dl,zeros(d),zeros(du))
+
+    @test_throws ArgumentError triu(SymTridiagonal(d,dl),n+1)
+    @test_throws ArgumentError triu(Tridiagonal(dl,d,du),n+1)
+    @test triu(SymTridiagonal(d,dl))    == Tridiagonal(zeros(dl),d,dl)
+    @test triu(SymTridiagonal(d,dl),-1) == Tridiagonal(dl,d,dl)
+    @test triu(SymTridiagonal(d,dl),1)  == Tridiagonal(zeros(dl),zeros(d),dl)
+    @test triu(Tridiagonal(dl,d,du))    == Tridiagonal(zeros(dl),d,du)
+    @test triu(Tridiagonal(dl,d,du),-1) == Tridiagonal(dl,d,du)
+    @test triu(Tridiagonal(dl,d,du),1)  == Tridiagonal(zeros(dl),zeros(d),du)
     end
 end
 


### PR DESCRIPTION
As discussed in JuliaLang/LinearAlgebra.jl#161, `Diagonal`, `Bidiagonal`, `Tridiagonal`, `SymTridiagonal`, `UpperTriangular`, `LowerTriangular`, `UnitUpperTriangular`, `UnitLowerTriangular`, `Symmetric`, and `Hermitian` types didn't have `tril` or `triu` defined. `Diagonal` had `tril!` and `triu!` but the `!` was incorrect since the underlying matrix wasn't modified.

I also added tests.
