### PR TITLE
don't make a copy on the stack when creating a new symbol (fixes #12569)

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -1238,10 +1238,11 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
             len = read_uint8(s);
         else
             len = read_int32(s);
-        char *name = (char*)alloca(len+1);
+        char *name = (char*) (len >= 256 ? malloc(len+1) : alloca(len+1));
         ios_read(s, name, len);
         name[len] = '\0';
         jl_value_t *sym = (jl_value_t*)jl_symbol(name);
+        if (len >= 256) free(name);
         if (usetable)
             arraylist_push(&backref_list, sym);
         return sym;

--- a/test/core.jl
+++ b/test/core.jl
@@ -3253,3 +3253,9 @@ code_typed(A12612.f1, Tuple{})
 code_typed(A12612.f2, Tuple{})
 @test_throws ErrorException A12612.f1()
 @test_throws ErrorException A12612.f2()
+
+# issue #12569
+@test_throws ArgumentError symbol("x"^10_000_000)
+@test_throws ArgumentError gensym("x"^10_000_000)
+@test symbol("x") === symbol("x")
+@test split(string(gensym("abc")),'#')[3] == "abc"


### PR DESCRIPTION
This avoids making a copy in `jl_symbol_n`, which was only happening to guarantee that we add a NUL terminator to the string (which was probably there already).  Instead, it just passes the string length around as needed.  (Fixes #12569.)
