### PR TITLE
Remove exception catching for __init__ functions, add InitError exception type

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -40,6 +40,11 @@ type LoadError <: Exception
     error
 end
 
+type InitError <: Exception
+    mod::Symbol
+    error
+end
+
 type MethodError <: Exception
     f
     args

--- a/base/base.jl
+++ b/base/base.jl
@@ -34,17 +34,6 @@ type KeyError <: Exception
     key
 end
 
-type LoadError <: Exception
-    file::AbstractString
-    line::Int
-    error
-end
-
-type InitError <: Exception
-    mod::Symbol
-    error
-end
-
 type MethodError <: Exception
     f
     args
@@ -62,6 +51,21 @@ type AssertionError <: Exception
 
     AssertionError() = new("")
     AssertionError(msg) = new(msg)
+end
+
+#Generic wrapping of arbitrary exceptions
+#Subtypes should put the exception in an 'error' field
+abstract WrappedException <: Exception
+
+type LoadError <: WrappedException
+    file::AbstractString
+    line::Int
+    error
+end
+
+type InitError <: WrappedException
+    mod::Symbol
+    error
 end
 
 ccall(:jl_get_system_hooks, Void, ())

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -13649,6 +13649,16 @@ LoadError
 doc"""
 ```rst
 ::
+           InitError(mod::Symbol, error)
+
+An error occurred when running a module's `__init__` function. The actual error thrown is available in the `.error` field.
+```
+"""
+InitError
+
+doc"""
+```rst
+::
            vec(Array) -> Vector
 
 Vectorize an array using column-major convention.

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -164,6 +164,7 @@ export
     InvalidStateException,
     KeyError,
     LoadError,
+    InitError,
     MethodError,
     NullException,
     ParseError,

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -145,7 +145,7 @@ function show(io::IO, ex::PrecompilableError)
     end
 end
 precompilableerror(ex::PrecompilableError, c) = ex.isprecompilable == c
-precompilableerror(ex::LoadError, c) = precompilableerror(ex.error, c)
+precompilableerror(ex::Union{LoadError,InitError}, c) = precompilableerror(ex.error, c)
 precompilableerror(ex, c) = false
 
 # put at the top of a file to force it to be precompiled (true), or

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -145,7 +145,7 @@ function show(io::IO, ex::PrecompilableError)
     end
 end
 precompilableerror(ex::PrecompilableError, c) = ex.isprecompilable == c
-precompilableerror(ex::Union{LoadError,InitError}, c) = precompilableerror(ex.error, c)
+precompilableerror(ex::WrappedException, c) = precompilableerror(ex.error, c)
 precompilableerror(ex, c) = false
 
 # put at the top of a file to force it to be precompiled (true), or

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -93,6 +93,13 @@ function showerror(io::IO, ex::LoadError, bt; backtrace=true)
 end
 showerror(io::IO, ex::LoadError) = showerror(io, ex, [])
 
+function showerror(io::IO, ex::InitError, bt; backtrace=true)
+    print(io, "InitError: ")
+    showerror(io, ex.error, bt, backtrace=backtrace)
+    print(io, "\nduring initialization of module $(ex.mod)")
+end
+showerror(io::IO, ex::InitError) = showerror(io, ex, [])
+
 function showerror(io::IO, ex::DomainError, bt; backtrace=true)
     print(io, "DomainError:")
     for b in bt

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -619,6 +619,8 @@ built-in :exc:`Exception`\ s listed below all interrupt the normal flow of contr
 +------------------------------+
 | :exc:`InexactError`          |
 +------------------------------+
+| :exc:`InitError`             |
++------------------------------+
 | :exc:`InterruptException`    |
 +------------------------------+
 | :exc:`InvalidStateException` |

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -55,6 +55,7 @@ jl_datatype_t *jl_argumenterror_type;
 jl_datatype_t *jl_typeerror_type;
 jl_datatype_t *jl_methoderror_type;
 jl_datatype_t *jl_loaderror_type;
+jl_datatype_t *jl_initerror_type;
 jl_datatype_t *jl_undefvarerror_type;
 jl_datatype_t *jl_ref_type;
 jl_datatype_t *jl_pointer_type;

--- a/src/init.c
+++ b/src/init.c
@@ -734,6 +734,7 @@ DLLEXPORT void jl_get_system_hooks(void)
     jl_typeerror_type = (jl_datatype_t*)basemod("TypeError");
     jl_methoderror_type = (jl_datatype_t*)basemod("MethodError");
     jl_loaderror_type = (jl_datatype_t*)basemod("LoadError");
+    jl_initerror_type = (jl_datatype_t*)basemod("InitError");
     jl_complex_type = (jl_datatype_t*)basemod("Complex");
 }
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -393,6 +393,7 @@ extern DLLEXPORT jl_datatype_t *jl_utf8_string_type;
 extern DLLEXPORT jl_datatype_t *jl_errorexception_type;
 extern DLLEXPORT jl_datatype_t *jl_argumenterror_type;
 extern DLLEXPORT jl_datatype_t *jl_loaderror_type;
+extern DLLEXPORT jl_datatype_t *jl_initerror_type;
 extern DLLEXPORT jl_datatype_t *jl_typeerror_type;
 extern DLLEXPORT jl_datatype_t *jl_methoderror_type;
 extern DLLEXPORT jl_datatype_t *jl_undefvarerror_type;

--- a/src/module.c
+++ b/src/module.c
@@ -542,9 +542,14 @@ void jl_module_run_initializer(jl_module_t *m)
         jl_apply(f, NULL, 0);
     }
     JL_CATCH {
-        jl_printf(JL_STDERR, "WARNING: error initializing module %s:\n", m->name->name);
-        jl_static_show(JL_STDERR, jl_exception_in_transit);
-        jl_printf(JL_STDERR, "\n");
+        if (jl_initerror_type == NULL) {
+            jl_rethrow();
+        }
+        else {
+            jl_rethrow_other(jl_new_struct(jl_initerror_type, m->name,
+                                           jl_exception_in_transit));
+            jl_printf(JL_STDERR, "\n");
+        }
     }
 }
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -141,6 +141,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
         jl_typeerror_type = NULL;
         jl_methoderror_type = NULL;
         jl_loaderror_type = NULL;
+        jl_initerror_type = NULL;
         jl_current_task->tls = jl_nothing; // may contain an entry for :SOURCE_FILE that is not valid in the new base
     }
     // export all modules from Main
@@ -205,12 +206,18 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
     arraylist_push(&module_stack, newm);
 
     if (outermost == NULL || jl_current_module == jl_main_module) {
-        size_t i, l=module_stack.len;
-        for(i = stackidx; i < l; i++) {
-            jl_module_load_time_initialize((jl_module_t*)module_stack.items[i]);
+        JL_TRY {
+            size_t i, l=module_stack.len;
+            for(i = stackidx; i < l; i++) {
+                jl_module_load_time_initialize((jl_module_t*)module_stack.items[i]);
+            }
+            assert(module_stack.len == l);
+            module_stack.len = stackidx;
         }
-        assert(module_stack.len == l);
-        module_stack.len = stackidx;
+        JL_CATCH {
+            module_stack.len = stackidx;
+            jl_rethrow();
+        }
     }
 
     return (jl_value_t*)newm;
@@ -585,8 +592,13 @@ jl_value_t *jl_parse_eval_all(const char *fname, size_t len)
             jl_rethrow();
         }
         else {
-            jl_rethrow_other(jl_new_struct(jl_loaderror_type, fn, ln,
-                                           jl_exception_in_transit));
+            if(jl_typeis(jl_exception_in_transit, jl_initerror_type)) {
+                jl_rethrow();
+            }
+            else {
+                jl_rethrow_other(jl_new_struct(jl_loaderror_type, fn, ln,
+                                               jl_exception_in_transit));
+            }
         }
     }
     jl_stop_parsing();

--- a/test/core.jl
+++ b/test/core.jl
@@ -672,6 +672,14 @@ end
 @test names(Module(:anonymous), true, true) != [:anonymous]
 @test names(Module(:anonymous, false), true, true) == [:anonymous]
 
+# exception from __init__()
+@test_throws InitError include_string(
+    """
+    module TestInitError
+        __init__() = error()
+    end
+    """)
+
 # issue #7307
 function test7307(a, ret)
     try


### PR DESCRIPTION
This PR is to continue the discussion from #12505 with a concrete implementation candidate. Sometime later this week I am interested to try running the package evaluator to see what level of breakage it causes due to people not bothering to fix warnings.

@JeffBezanson @StefanKarpinski @vtjnash 
