### PR TITLE
Add writemime tests for markdown.

### DIFF
--- a/base/markdown/render/rst.jl
+++ b/base/markdown/render/rst.jl
@@ -41,6 +41,14 @@ function rst(io::IO, list::List)
     end
 end
 
+function rst(io::IO, q::BlockQuote)
+    s = sprint(buf -> plain(buf, q.content))
+    for line in split(rstrip(s), "\n")
+        println(io, "    ", line)
+    end
+    println(io)
+end
+
 function rst(io::IO, md::HorizontalRule)
     println(io, "–" ^ 5)
 end

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -125,6 +125,82 @@ Some **bolded**
 """
 @test latex(book) == "\\section{Title}\nSome discussion\n\\begin{quote}\nA quote\n\\end{quote}\n\\subsection{Section \\emph{important}}\nSome \\textbf{bolded}\n\\begin{itemize}\n\\item list1\n\\item list2\n\\end{itemize}\n"
 
+# writemime output
+
+let out =
+    """
+    # Title
+
+    Some discussion
+
+    > A quote
+
+
+    ## Section *important*
+
+    Some **bolded**
+
+      * list1
+      * list2
+    """
+    @test sprint(io -> writemime(io, "text/plain", book)) == out
+    @test sprint(io -> writemime(io, "text/markdown", book)) == out
+end
+let out =
+    """
+    <div class="markdown"><h1>Title</h1>
+    <p>Some discussion</p>
+    <blockquote>
+    <p>A quote</p>
+    </blockquote>
+    <h2>Section <em>important</em></h2>
+    <p>Some <strong>bolded</strong></p>
+    <ul>
+    <li>list1</li>
+    <li>list2</li>
+    </ul>
+    </div>"""
+    @test sprint(io -> writemime(io, "text/html", book)) == out
+end
+let out =
+    """
+    \\section{Title}
+    Some discussion
+    \\begin{quote}
+    A quote
+    \\end{quote}
+    \\subsection{Section \\emph{important}}
+    Some \\textbf{bolded}
+    \\begin{itemize}
+    \\item list1
+    \\item list2
+    \\end{itemize}
+    """
+    @test sprint(io -> writemime(io, "text/latex", book)) == out
+end
+let out =
+    """
+    Title
+    *****
+
+
+    Some discussion
+
+        A quote
+
+
+    Section *important*
+    ===================
+
+
+    Some **bolded**
+
+      * list1
+      * list2
+    """
+    @test sprint(io -> writemime(io, "text/rst", book)) == out
+end
+
 # Interpolation / Custom types
 
 type Reference


### PR DESCRIPTION
As @tkelman pointed out the `writemime` methods for `Markdown.MD` aren't actually tested. Only the internal `plain`, `html`, `latex` and `rst` are.

Also adds missing blockquote rendering for `rst`.
