### PR TITLE
Documenting Modules

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -337,6 +337,13 @@ function typedoc(meta, def, def′)
     end
 end
 
+function moddoc(meta, def, name)
+    docex = :(@doc $meta $name)
+    def == nothing && return :(eval($name, $(quot(docex)))) |> esc
+    push!(unblock(def).args[3].args, docex)
+    return esc(Expr(:toplevel, def))
+end
+
 function objdoc(meta, def)
     quote
         @init
@@ -373,7 +380,7 @@ function docm(meta, def, define = true)
     isexpr(def′, :abstract)    ? namedoc(meta, def, namify(def′)) :
     isexpr(def′, :bitstype)    ? namedoc(meta, def, def′.args[2]) :
     isexpr(def′, :typealias)   ?  vardoc(meta, def, namify(def′)) :
-    isexpr(def′, :module)      ? namedoc(meta, def, def′.args[2]) :
+    isexpr(def′, :module)      ?  moddoc(meta, def, def′.args[2]) :
     isexpr(def′, :(=), :const,
                  :global)      ?  vardoc(meta, def, namify(def′)) :
     isvar(def′)                ? objdoc(meta, def′) :

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -1,13 +1,11 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-module Docs
-
 """
 The Docs module provides the `@doc` macro which can be used to set and retrieve
 documentation metadata for Julia objects. Please see docs for the `@doc` macro for more
 info.
 """
-Docs
+module Docs
 
 """
 # Documentation

--- a/base/docs/bootstrap.jl
+++ b/base/docs/bootstrap.jl
@@ -19,7 +19,7 @@ setexpand!(f) = global _expand_ = f
 
 setexpand!() do str, obj
     global docs = List((ccall(:jl_get_current_module, Any, ()), str, obj), docs)
-    return esc(obj)
+    return esc(Expr(:toplevel, obj))
 end
 
 """


### PR DESCRIPTION
There seems to be some issue preventing this from working:

``` julia
julia> "foo"
       module Foo
       end

(type-error table.foldl table ())
unexpected error: #0 (table.keys ())
#1 (toplevel-expr-globals
 (module #t Foo
     (block (= (call eval x) (block (line 2 none)
                    (call (|.| (top Core) (inert eval)) Foo
                          x)))
        (= (call eval m x) (block (line 2 none)
                      (call (|.| (top Core) (inert eval))
                        m x)))
        (macrocall @doc #<julia: "foo"> Foo))))
ERROR: syntax: malformed expression
```

Parsing and evaling the above input reproduces the error, but oddly, parsing, macroexpanding and evaling does not. Obviously this is blocking module documentation.
