### PR TITLE
prevent pkg-config from finding unrelated system libraries

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -160,6 +160,9 @@ BUILD_LLDB = 0
 # Path to cmake (override in Make.user if needed)
 CMAKE ?= cmake
 
+# Point pkg-config to only look at our libraries
+export PKG_CONFIG_LIBDIR = $(JULIAHOME)/usr/lib/pkgconfig
+
 # Figure out OS and architecture
 BUILD_OS := $(shell uname)
 


### PR DESCRIPTION
fix #12514
