### PR TITLE
WIP: Fix skipped docstrings in types.

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -187,7 +187,8 @@ catdoc(xs...) = vcat(xs...)
 # Type Documentation
 
 isdoc(x) = isexpr(x, :string, AbstractString) ||
-    (isexpr(x, :macrocall) && endswith(string(x.args[1]), "_str"))
+    (isexpr(x, :macrocall) && x.args[1] == symbol("@doc_str")) ||
+    (isexpr(x, :call) && x.args[1] == Expr(:., Base.Markdown, QuoteNode(:doc_str)))
 
 dict_expr(d) = :(Dict($([:($(Expr(:quote, f)) => $d) for (f, d) in d]...)))
 

--- a/base/markdown/Markdown.jl
+++ b/base/markdown/Markdown.jl
@@ -52,8 +52,10 @@ macro md_str(s, t...)
     mdexpr(s, t...)
 end
 
+doc_str(md, file, mod) = (md.meta[:path] = file; md.meta[:module] = mod; md)
+
 macro doc_str(s, t...)
-    docexpr(s, t...)
+    :(doc_str($(mdexpr(s, t...)), @__FILE__, current_module()))
 end
 
 function Base.display(d::Base.REPL.REPLDisplay, md::Vector{MD})

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -95,6 +95,15 @@ t(::Int, ::Any)
 "t-3"
 t{S <: Integer}(::S)
 
+"FieldDocs"
+type FieldDocs
+    "one"
+    one
+    doc"two"
+    two
+    three
+end
+
 end
 
 import Base.Docs: meta
@@ -156,6 +165,11 @@ end
 @test @doc(DocsTest.t(::AbstractString)) == doc"t-1"
 @test @doc(DocsTest.t(::Int, ::Any)) == doc"t-2"
 @test @doc(DocsTest.t{S <: Integer}(::S)) == doc"t-3"
+
+let fields = meta(DocsTest)[DocsTest.FieldDocs].fields
+    @test haskey(fields, :one) && fields[:one] == doc"one"
+    @test haskey(fields, :two) && fields[:two] == doc"two"
+end
 
 # issue 11993
 # Check if we are documenting the expansion of the macro


### PR DESCRIPTION
cc @one-more-minute 

`doc"..."` gets skipped when documenting type fields since `macroexpand`converts `@doc_str`s into `let` blocks which `isdoc` doesn't recognise as docstrings.

This fixes that by keeping around the unexpanded version and passing that to `typedoc`. Some other ways to do this instead might be to
- have `doc""` return something like `:(Markdown.doc_str("...", current_module(), @__FILE__))` which would be easier to match against in `isdoc` instead of a `let` block.
- have `doc""` just return an unescaped string. That would mean losing the interpolation/latex feature which is quite nice to have.

This also updates `isdoc` to match the definition used in the parser, ie. https://github.com/JuliaLang/julia/blob/72c344c472bfd55fcda36aa30585c8f185389cdd/src/julia-parser.scm#L2072-L2076 rather than matching any string macro.
