### PR TITLE
Fix sign(0) for complex number and add documentation

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -107,7 +107,6 @@ abs(z::Complex)  = hypot(real(z), imag(z))
 abs2(z::Complex) = real(z)*real(z) + imag(z)*imag(z)
 inv(z::Complex)  = conj(z)/abs2(z)
 inv{T<:Integer}(z::Complex{T}) = inv(float(z))
-sign(z::Complex) = z/abs(z)
 
 -(z::Complex) = Complex(-real(z), -imag(z))
 +(z::Complex, w::Complex) = Complex(real(z) + real(w), imag(z) + imag(w))

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -15178,8 +15178,7 @@ doc"""
 ```rst
 ::
            sign(x)
-
-Return ``+1`` if ``x`` is positive, ``0`` if ``x == 0``, and ``-1`` if ``x`` is negative.
+Return zero if ``x==0`` and :math:`x/|x|` otherwise (i.e., ±1 for real ``x``).
 ```
 """
 sign

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -179,7 +179,7 @@ ComplexTypes = Union{Complex64, Complex128}
     abs2_fast{T<:ComplexTypes}(x::T) = real(x)*real(x) + imag(x)*imag(x)
     conj_fast{T<:ComplexTypes}(x::T) = T(real(x), -imag(x))
     inv_fast{T<:ComplexTypes}(x::T) = conj(x) / abs2(x)
-    sign_fast{T<:ComplexTypes}(x::T) = x / abs(x)
+    sign_fast{T<:ComplexTypes}(x::T) = x == 0 ? float(zero(x)) : x/abs(x)
 
     add_fast{T<:ComplexTypes}(x::T, y::T) =
         T(real(x)+real(y), imag(x)+imag(y))

--- a/base/number.jl
+++ b/base/number.jl
@@ -22,6 +22,7 @@ last(x::Number) = x
 divrem(x,y) = (div(x,y),rem(x,y))
 fldmod(x,y) = (fld(x,y),mod(x,y))
 signbit(x::Real) = x < 0
+sign(x::Number) = x == 0? float(zero(x)) : x/abs(x)
 sign(x::Real) = ifelse(x < 0, oftype(x,-1), ifelse(x > 0, one(x), x))
 sign(x::Unsigned) = ifelse(x > 0, one(x), x)
 abs(x::Real) = ifelse(signbit(x), -x, x)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -733,6 +733,26 @@ end
 @test log10(10+0im) === 1.0 + 0.0im
 @test log2(2+0im) === 1.0 + 0.0im
 
+# sign
+for T in (Float32, Float64)
+    z = Complex{T}(1)
+    @test typeof(sign(z)) == typeof(z)
+    z = Complex{T}(0)
+    @test typeof(sign(z)) == typeof(z)
+end
+for T in (Int32, Int64)
+    z = Complex{T}(1)
+    @test typeof(sign(z)) == typeof(float(z))
+    z = Complex{T}(0)
+    @test typeof(sign(z)) == typeof(float(z))
+end
+
+@test sign(0 + 0im) == 0
+@test sign(2 + 0im) == 1
+@test sign(-2 + 0im) == -1
+@test sign(1 + im) ≈ (1 + im) / sqrt(2)
+@test sign(1 - im) ≈ (1 - im) / sqrt(2)
+
 # cis
 @test_approx_eq cis(0.0+1.0im) 0.367879441171442321595523770161460867445811131031767834507836+0.0im
 @test_approx_eq cis(1.0+0.0im) 0.54030230586813971740093660744297660373231042061+0.84147098480789650665250232163029899962256306079im


### PR DESCRIPTION
Fix issue #12599

EDIT: Fix inconsistency in `sign(0)`, add tests and documentation for `sign(x::Complex)`.
