### PR TITLE
Fix static dispatch bug

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1090,7 +1090,7 @@ JL_CALLABLE(jl_f_invoke)
     else {
         jl_check_type_tuple(args[1], jl_gf_name(args[0]), "invoke");
     }
-    if (!jl_tuple_subtype(&args[2], nargs-2, (jl_datatype_t*)argtypes, 1))
+    if (!jl_tuple_subtype(&args[2], nargs-2, (jl_datatype_t*)argtypes, NULL, 1))
         jl_error("invoke: argument type error");
     jl_value_t *res = jl_gf_invoke((jl_function_t*)args[0],
                                    (jl_tupletype_t*)argtypes, &args[2], nargs-2);
@@ -1412,10 +1412,10 @@ size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
 #endif
     }
     else if (jl_is_float32(v)) {
-        n += jl_printf(out, "%g", jl_unbox_float32(v));
+        n += jl_printf(out, "%#g", jl_unbox_float32(v));
     }
     else if (jl_is_float64(v)) {
-        n += jl_printf(out, "%g", jl_unbox_float64(v));
+        n += jl_printf(out, "%#g", jl_unbox_float64(v));
     }
     else if (v == jl_true) {
         n += jl_printf(out, "true");

--- a/src/julia.h
+++ b/src/julia.h
@@ -857,6 +857,7 @@ DLLEXPORT uptrint_t jl_object_id(jl_value_t *v);
 int jl_is_type(jl_value_t *v);
 DLLEXPORT int jl_is_leaf_type(jl_value_t *v);
 DLLEXPORT int jl_has_typevars(jl_value_t *v);
+int jl_subtype_le(jl_value_t *a, jl_value_t *b, jl_value_t* envb, int ta, int invariant);
 DLLEXPORT int jl_subtype(jl_value_t *a, jl_value_t *b, int ta);
 int jl_type_morespecific(jl_value_t *a, jl_value_t *b);
 DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -98,7 +98,7 @@ DLLEXPORT void jl_uv_associate_julia_struct(uv_handle_t *handle, jl_value_t *dat
 DLLEXPORT int jl_uv_fs_result(uv_fs_t *f);
 
 
-int jl_tuple_subtype(jl_value_t **child, size_t cl, jl_datatype_t *pdt, int ta);
+int jl_tuple_subtype(jl_value_t **child, size_t cl, jl_datatype_t *pdt, jl_value_t *envpdt, int ta);
 
 int jl_subtype_invariant(jl_value_t *a, jl_value_t *b, int ta);
 jl_value_t *jl_type_match(jl_value_t *a, jl_value_t *b);

--- a/test/core.jl
+++ b/test/core.jl
@@ -3211,3 +3211,20 @@ end
 # issue #12551 (make sure these don't throw in inference)
 Base.return_types(unsafe_load, (Ptr{nothing},))
 Base.return_types(getindex, (Vector{nothing},))
+
+# dispatch bug
+abstract AKoala{T}
+type KKoala{T} <: AKoala{T}
+end
+typealias ZKoala{J<:Number} KKoala{J}
+FKoala{T}(::AKoala{T},::AKoala{T}) = 1
+FKoala(::AKoala,::AKoala) = 2
+FKoala{T}(::KKoala{T},::KKoala{T}) = 3
+Koala_abs_sig1 = Tuple{ZKoala,KKoala{Int}}
+Koala_abs_sig2 = Tuple{ZKoala,ZKoala}
+Koala_conc_sig = Tuple{KKoala{Float64},KKoala{Int}}
+@test Koala_conc_sig <: Koala_abs_sig1
+@test Koala_conc_sig <: Koala_abs_sig2
+Koala_conc_matches = Set(map(m->m[3],Base._methods(FKoala, Koala_conc_sig, -1)))
+@show Koala_conc_matches <= Set(map(m->m[3],Base._methods(FKoala, Koala_abs_sig1, -1)))
+@show Koala_conc_matches <= Set(map(m->m[3],Base._methods(FKoala, Koala_abs_sig2, -1)))


### PR DESCRIPTION
In some conditions (see test) it was possible for the compile time dispatch search to stop too early. The intersection was overapproximated and the guard check for this could forget about the static type environment.

The failure mode for this bug is something like :

``` julia
vcat(::Vector{T},::Vector{T}) = ...
vcat(::Vector,::Vector) = ...
```

(it is more complicated to trigger actually since intersection gets it right in that case but this is the idea)
when compile time method dispatch for the signature e.g.  `{Vector{J<:Number},Vector{Int}}` where J is some unbound type var, the intersection+matching for method (1) might return :

`{Vector{J<:Number},Vector{Int}} with env T=Int` which is an over-approximation but the guard check uses subtype_le that has no notion of typevar constraints/boundness so will return true because `{Vector{<:Number},Vector{Int}}<:{Vector{<:Any},Vector{<:Any}}`

To fix this I added an env parameter to subtype to make it a bit more aware of the environment.

This does not fix another problem where `{Vector{<:Number},Vector{<:Number}}` would have the intersection answer :
`{Vector{_<:Number},Vector{_<:Number}} with env T=_<:Number`

In that case the proper fix would be to have the new subtyping algorithm to be able to distinguish `∃T<Number∃T'<Number{Vector{T},Vector{T'}}` and `∃T<Number,{Vector{T},Vector{T}}`

as a bandaid I just conservatively assume no exact match if there are several occurences of matching typevars on the rhs.

Note that this instance of the bug can probably be fixed by improving intersection but I think the test should still be robust when intersection is wrong.

@JeffBezanson 
