### PR TITLE
convert more Union(...) to Union{...} instances that escaped #11432

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -611,7 +611,7 @@ type SharedMemSpec
     create :: Bool
 end
 export mmap_array
-function mmap_array{T,N}(::Type{T}, dims::NTuple{N,Integer}, s::Union(IO,SharedMemSpec), offset::FileOffset)
+function mmap_array{T,N}(::Type{T}, dims::NTuple{N,Integer}, s::Union{IO,SharedMemSpec}, offset::FileOffset)
     depwarn("`mmap_array` is deprecated, use `Mmap.mmap(io, Array{T,N}, dims, offset)` instead to return an mmapped-array", :mmap_array)
     if isa(s,SharedMemSpec)
         a = Mmap.Anonymous(s.name, s.readonly, s.create)

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -46,12 +46,12 @@ for f in (:fft, :bfft, :ifft)
     @eval begin
         $f{T<:Real}(x::AbstractArray{T}, region=1:ndims(x)) = $f(complexfloat(x), region)
         $pf{T<:Real}(x::AbstractArray{T}, region; kws...) = $pf(complexfloat(x), region; kws...)
-        $f{T<:Union(Integer,Rational)}(x::AbstractArray{Complex{T}}, region=1:ndims(x)) = $f(complexfloat(x), region)
-        $pf{T<:Union(Integer,Rational)}(x::AbstractArray{Complex{T}}, region; kws...) = $pf(complexfloat(x), region; kws...)
+        $f{T<:Union{Integer,Rational}}(x::AbstractArray{Complex{T}}, region=1:ndims(x)) = $f(complexfloat(x), region)
+        $pf{T<:Union{Integer,Rational}}(x::AbstractArray{Complex{T}}, region; kws...) = $pf(complexfloat(x), region; kws...)
     end
 end
-rfft{T<:Union(Integer,Rational)}(x::AbstractArray{T}, region=1:ndims(x)) = rfft(float(x), region)
-plan_rfft{T<:Union(Integer,Rational)}(x::AbstractArray{T}, region; kws...) = plan_rfft(float(x), region; kws...)
+rfft{T<:Union{Integer,Rational}}(x::AbstractArray{T}, region=1:ndims(x)) = rfft(float(x), region)
+plan_rfft{T<:Union{Integer,Rational}}(x::AbstractArray{T}, region; kws...) = plan_rfft(float(x), region; kws...)
 
 # only require implementation to provide *(::Plan{T}, ::Array{T})
 *{T}(p::Plan{T}, x::AbstractArray) = p * copy!(Array(T, size(x)), x)
@@ -138,7 +138,7 @@ end
 for f in (:brfft, :irfft)
     @eval begin
         $f{T<:Real}(x::AbstractArray{T}, d::Integer, region=1:ndims(x)) = $f(complexfloat(x), d, region)
-        $f{T<:Union(Integer,Rational)}(x::AbstractArray{Complex{T}}, d::Integer, region=1:ndims(x)) = $f(complexfloat(x), d, region)
+        $f{T<:Union{Integer,Rational}}(x::AbstractArray{Complex{T}}, d::Integer, region=1:ndims(x)) = $f(complexfloat(x), d, region)
     end
 end
 

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -2614,7 +2614,7 @@ rol
 doc"""
 ```rst
 ::
-           Mmap.mmap(io::Union(IOStream,AbstractString,Mmap.AnonymousMmap)[, type::Type{Array{T,N}}, dims, offset]; grow::Bool=true, shared::Bool=true)
+           Mmap.mmap(io::Union{IOStream,AbstractString,Mmap.AnonymousMmap}[, type::Type{Array{T,N}}, dims, offset]; grow::Bool=true, shared::Bool=true)
            Mmap.mmap(type::Type{Array{T,N}}, dims)
 
 Create an ``Array`` whose values are linked to a file, using memory-mapping. This provides a convenient way of working with data too large to fit in the computer's memory.

--- a/base/fft/FFTW.jl
+++ b/base/fft/FFTW.jl
@@ -61,13 +61,13 @@ end
 
 # FFTW floating-point types:
 
-typealias fftwNumber Union(Float64,Float32,Complex128,Complex64)
-typealias fftwReal Union(Float64,Float32)
-typealias fftwComplex Union(Complex128,Complex64)
-typealias fftwDouble Union(Float64,Complex128)
-typealias fftwSingle Union(Float32,Complex64)
-typealias fftwTypeDouble Union(Type{Float64},Type{Complex128})
-typealias fftwTypeSingle Union(Type{Float32},Type{Complex64})
+typealias fftwNumber Union{Float64,Float32,Complex128,Complex64}
+typealias fftwReal Union{Float64,Float32}
+typealias fftwComplex Union{Complex128,Complex64}
+typealias fftwDouble Union{Float64,Complex128}
+typealias fftwSingle Union{Float32,Complex64}
+typealias fftwTypeDouble Union{Type{Float64},Type{Complex128}}
+typealias fftwTypeSingle Union{Type{Float32},Type{Complex64}}
 
 # For ESTIMATE plans, FFTW allows one to pass NULL for the array pointer,
 # since it is not written to.  Hence, it is convenient to create an

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -176,4 +176,4 @@ const ≈ = isapprox
 # default tolerance arguments
 rtoldefault{T<:AbstractFloat}(::Type{T}) = sqrt(eps(T))
 rtoldefault{T<:Real}(::Type{T}) = 0
-rtoldefault{T<:Number,S<:Number}(x::Union(T,Type{T}), y::Union(S,Type{S})) = rtoldefault(promote_type(real(T),real(S)))
+rtoldefault{T<:Number,S<:Number}(x::Union{T,Type{T}}, y::Union{S,Type{S}}) = rtoldefault(promote_type(real(T),real(S)))

--- a/base/poll.jl
+++ b/base/poll.jl
@@ -172,12 +172,12 @@ function close(t::FDWatcher)
     close(t.watcher, r, w)
 end
 
-function uvfinalize(uv::Union(FileMonitor, PollingFileWatcher))
+function uvfinalize(uv::Union{FileMonitor, PollingFileWatcher})
     disassociate_julia_struct(uv)
     close(uv)
 end
 
-function close(t::Union(FileMonitor, PollingFileWatcher))
+function close(t::Union{FileMonitor, PollingFileWatcher})
     if t.handle != C_NULL
         ccall(:jl_close_uv, Void, (Ptr{Void},), t.handle)
         t.handle = C_NULL

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -195,7 +195,7 @@ immutable InsertionSortAlg <: Algorithm end
 immutable QuickSortAlg     <: Algorithm end
 immutable MergeSortAlg     <: Algorithm end
 
-immutable PartialQuickSort{T <: Union(Int,OrdinalRange)} <: Algorithm
+immutable PartialQuickSort{T <: Union{Int,OrdinalRange}} <: Algorithm
     k::T
 end
 
@@ -406,11 +406,11 @@ sort(v::AbstractVector; kws...) = sort!(copy(v); kws...)
 
 ## selectperm: the permutation to sort the first k elements of an array ##
 
-selectperm(v::AbstractVector, k::Union(Integer,OrdinalRange); kwargs...) =
+selectperm(v::AbstractVector, k::Union{Integer,OrdinalRange}; kwargs...) =
     selectperm!(Vector{eltype(k)}(length(v)), v, k; kwargs..., initialized=false)
 
 function selectperm!{I<:Integer}(ix::AbstractVector{I}, v::AbstractVector,
-                                 k::Union(Int, OrdinalRange);
+                                 k::Union{Int, OrdinalRange};
                                  lt::Function=isless,
                                  by::Function=identity,
                                  rev::Bool=false,

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -1145,7 +1145,7 @@ Memory-mapped I/O
 
    Create an ``IO``-like object for creating zeroed-out mmapped-memory that is not tied to a file for use in ``Mmap.mmap``. Used by ``SharedArray`` for creating shared memory arrays.
 
-.. function:: Mmap.mmap(io::Union(IOStream,AbstractString,Mmap.AnonymousMmap)[, type::Type{Array{T,N}}, dims, offset]; grow::Bool=true, shared::Bool=true)
+.. function:: Mmap.mmap(io::Union{IOStream,AbstractString,Mmap.AnonymousMmap}[, type::Type{Array{T,N}}, dims, offset]; grow::Bool=true, shared::Bool=true)
 
    ::
               Mmap.mmap(type::Type{Array{T,N}}, dims)
@@ -1201,7 +1201,7 @@ Memory-mapped I/O
 .. function:: Mmap.mmap(io, BitArray, [dims, offset])
 
    ::
-              Mmap.mmap(io::Union(IOStream,AbstractString,Mmap.AnonymousMmap)[, type::Type{Array{T,N}}, dims, offset]; grow::Bool=true, shared::Bool=true)
+              Mmap.mmap(io::Union{IOStream,AbstractString,Mmap.AnonymousMmap}[, type::Type{Array{T,N}}, dims, offset]; grow::Bool=true, shared::Bool=true)
               Mmap.mmap(type::Type{Array{T,N}}, dims)
 
    Create an ``Array`` whose values are linked to a file, using memory-mapping. This provides a convenient way of working with data too large to fit in the computer's memory.

--- a/test/core.jl
+++ b/test/core.jl
@@ -2989,7 +2989,7 @@ f11715(x) = (x === Tuple{Any})
 
 # part of #11597
 # make sure invalid, partly-constructed types don't end up in the cache
-abstract C11597{T<:Union(Void, Int)}
+abstract C11597{T<:Union{Void, Int}}
 type D11597{T} <: C11597{T} d::T end
 @test_throws TypeError D11597(1.0)
 @test_throws TypeError repr(D11597(1.0))

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -63,7 +63,7 @@ immutable IT
 end
 
 "TA"
-typealias TA Union(T, IT)
+typealias TA Union{T, IT}
 
 "@mac"
 macro mac() end

--- a/test/unicode/utf32.jl
+++ b/test/unicode/utf32.jl
@@ -75,7 +75,7 @@ tstcvt(str4_UTF8,str4_UTF16,str4_UTF32)
 # Test invalid sequences
 
 strval(::Type{UTF8String}, dat) = dat
-strval(::Union(Type{UTF16String},Type{UTF32String}), dat) = UTF8String(dat)
+strval(::Union{Type{UTF16String},Type{UTF32String}}, dat) = UTF8String(dat)
 
 byt = 0x0
 for T in (UTF8String, UTF16String, UTF32String)


### PR DESCRIPTION
This just cleans up more usages of `Union(...)` that have crept in since #11432 (or were never fixed).
