### PR TITLE
Fixes Pkg.submit(): GitHub no longer stores OAuth tokens

### DIFF
--- a/base/pkg/github.jl
+++ b/base/pkg/github.jl
@@ -66,7 +66,8 @@ function token(user::AbstractString=user())
         tok = strip(readchomp(tokfile))
         !isempty(tok) && return tok
     end
-    status, header, content = curl("https://api.github.com/authorizations",AUTH_DATA,`-u $user`)
+    params = merge(AUTH_DATA, ["fingerprint" => randstring(40)])
+    status, header, content = curl("https://api.github.com/authorizations",params,`-u $user`)
     tfa = false
 
     # Check for two-factor authentication
@@ -75,33 +76,12 @@ function token(user::AbstractString=user())
         info("Two-factor authentication in use.  Enter auth code.  (You may have to re-enter your password.)")
         print(STDERR, "Authentication code: ")
         code = readline(STDIN) |> chomp
-        status, header, content = curl("https://api.github.com/authorizations",AUTH_DATA,`-H "X-GitHub-OTP: $code" -u $user`)
+        status, header, content = curl("https://api.github.com/authorizations",params,`-H "X-GitHub-OTP: $code" -u $user`)
     end
 
     if status == 422
         error_code = json().parse(content)["errors"][1]["code"]
-        if error_code == "already_exists"
-            if tfa
-                info("Retrieving existing GitHub token. (You may have to re-enter your password twice more.)")
-                status, header, content = curl("https://api.github.com/authorizations",AUTH_DATA,`-u $user`)
-                status != 401 && throw(PkgError("$status: $(json().parse(content)["message"])"))
-                print(STDERR, "New authentication code: ")
-                code = readline(STDIN) |> chomp
-                status, header, content = curl("https://api.github.com/authorizations",`-H "X-GitHub-OTP: $code" -u $user`)
-            else
-                info("Retrieving existing GitHub token. (You may have to re-enter your password.)")
-                status, header, content = curl("https://api.github.com/authorizations", `-u $user`)
-            end
-            (status >= 400) && throw(PkgError("$status: $(json().parse(content)["message"])"))
-            for entry in json().parse(content)
-                if entry["note"] == AUTH_NOTE
-                    tok = entry["token"]
-                    break
-                end
-            end
-        else
-            throw(PkgError("GitHub returned validation error (422): $error_code: $(json().parse(content)["message"])"))
-        end
+        throw(PkgError("GitHub returned validation error (422): $error_code: $(json().parse(content)["message"])"))
     else
         (status != 401 && status != 403) || throw(PkgError("$status: $(json().parse(content)["message"])"))
         tok = json().parse(content)["token"]


### PR DESCRIPTION
`Pkg.submit()` currently fails if a user has previously created a GitHub Julia Package Manager OAuth token but no longer has the token stored locally. While previously it was possible to refetch the token from GitHub, this is no longer supported: https://developer.github.com/changes/2014-12-08-removing-authorizations-token/

This PR changes the github.jl code to always create a new token (with a different fingerprint) if a local token is not found.
