### PR TITLE
RFC: General 1-norm estimation for some functions of sparse matrices 

### DIFF
--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -518,12 +518,11 @@ function cond(A::SparseMatrixCSC, p::Real=2)
     end
 end
 
-function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = 2)
+function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A))))
     maxiter = 5
     # Check the input
     n = max(size(A)...)
     F = factorize(A)
-    t = min(t,n)
     if t <= 0
         throw(ArgumentError("number of blocks must be a positive integer"))
     end
@@ -532,10 +531,13 @@ function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = 2)
     end
     ind = Array(Int64, n)
     ind_hist = Array(Int64, maxiter * t)
-    S = zeros(T, n, t)
+
+    Ti = T <: Real ? typeof(float(zero(T))) : typeof(float(complex(zero(T))))
+
+    S = zeros(Ti, n, t)
 
     # Generate the block matrix
-    X = Array(T, n, t)
+    X = Array(Ti, n, t)
     X[1:n,1] = 1
     for j = 2:t
         repeated = true
@@ -585,39 +587,41 @@ function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = 2)
         S_old = copy(S)
         for j = 1:t
             for i = 1:n
-                S[i,j] = Y[i,j]==0?1:sign(Y[i,j])
+                S[i,j] = Y[i,j]==0?one(Y[i,j]):sign(Y[i,j])
             end
         end
 
-        # Check wether cols of S are parallel to cols of S or S_old
-        for j = 1:t
-            done = false
-            while ~done
-                repeated = false
-                if j > 1
-                    saux = S[1:n,j]' * S[1:n,1:j-1]
-                    for i = 1:j-1
-                        if abs(saux[i]) == n
-                            repeated = true
-                            break
+        if T <: Real
+            # Check wether cols of S are parallel to cols of S or S_old
+            for j = 1:t
+                done = false
+                while ~done
+                    repeated = false
+                    if j > 1
+                        saux = S[1:n,j]' * S[1:n,1:j-1]
+                        for i = 1:j-1
+                            if abs(saux[i]) == n
+                                repeated = true
+                                break
+                            end
                         end
                     end
-                end
-                if ~repeated
-                    saux2 = S[1:n,j]' * S_old[1:n,1:t]
-                    for i = 1:t
-                        if abs(saux2[i]) == n
-                            repeated = true
-                            break
+                    if ~repeated
+                        saux2 = S[1:n,j]' * S_old[1:n,1:t]
+                        for i = 1:t
+                            if abs(saux2[i]) == n
+                                repeated = true
+                                break
+                            end
                         end
                     end
-                end
-                if repeated
-                    for i = 1:n
-                        S[i,j] = rand()>=0.5?1:-1
+                    if repeated
+                        for i = 1:n
+                            S[i,j] = rand()>=0.5?1:-1
+                        end
+                    else
+                        done = true
                     end
-                else
-                    done = true
                 end
             end
         end

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1077,5 +1077,16 @@ Ar = sprandn(20,20,.5)
 @test_throws ArgumentError cond(A,2)
 @test_throws ArgumentError cond(A,3)
 
+# test sparse matrix normestinv
+Ac = sprandn(20,20,.5) + im* sprandn(20,20,.5)
+Aci = ceil(Int64,100*sprand(20,20,.5))+ im*ceil(Int64,sprand(20,20,.5))
+Ar = sprandn(20,20,.5)
+Ari = ceil(Int64,100*Ar)
+@test_approx_eq_eps Base.SparseMatrix.normestinv(Ac,3) norm(inv(full(Ac)),1) 1e-4
+@test_approx_eq_eps Base.SparseMatrix.normestinv(Aci,3) norm(inv(full(Aci)),1) 1e-4
+@test_approx_eq_eps Base.SparseMatrix.normestinv(Ar) norm(inv(full(Ar)),1) 1e-4
+@test_throws ArgumentError Base.SparseMatrix.normestinv(Ac,0)
+@test_throws ArgumentError Base.SparseMatrix.normestinv(Ac,21)
+
 @test_throws ErrorException transpose(sub(sprandn(10, 10, 0.3), 1:4, 1:4))
 @test_throws ErrorException ctranspose(sub(sprandn(10, 10, 0.3), 1:4, 1:4))


### PR DESCRIPTION
@mfasi @tkelman 

Here is what I had in mind for a more general `normest` routine.  At the moment there is something wrong with `Ac_ldiv_B!` that I don't quite understand (something about the types keeps this from compiling).

This attempt of a general `normest` is also not type stable (the `pre` routine in particular mucks that up) but that is probably fixable by replacing it with an object instead of a function.

I also put `normest` in a separate file just to make it easier to test it while I play with it.  This pull request is really just meant to bring attention to the idea and discuss the proper way to do it.

EDIT:

This is motivated by the usefulness of such a generic function for the fast and accurate computation of `f(A)*v` without explicitly computing `f(A)`, which is especially attractive when `A` is sparse but `f(A)` may not be. The one interesting case where this can be applied is `expm`, but potentially others as well, such as `logm`, `sqrtm` (see below).

_Computing the Action of the Matrix Exponential, with an Application to Exponential Integrators_, Awad H. Al-Mohy and Nicholas J. Higham, SIAM Journal on Scientific Computing 2011 33:2, 488-511. ([preprint](http://eprints.ma.man.ac.uk/1426/))

_Computing f(A)b for Matrix Functions f_, Philip I. Davies and Nicholas J. Higham. Lecture Notes in Computational Science and Engineering Volume 47, 2005, pp 15-24 ([preprint](http://eprints.ma.man.ac.uk/96/))

_Estimating the condition number of f(A)b_, Edvin Deadman. Numerical Algorithms December 2014 ([article](http://rd.springer.com/article/10.1007%2Fs11075-014-9947-4))

_An Improved Schur--Padé Algorithm for Fractional Powers of a Matrix and their Fréchet Derivatives_, Nicholas J Higham, Lijing Lin, SIAM. J. Matrix Anal. & Appl. 32 1056 2013. ([preprint](http://eprints.ma.man.ac.uk/2021/01/hili13.pdf))
