### PR TITLE
Throw an error when `call` is not a generic function

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -889,7 +889,10 @@ function abstract_call(f, fargs, argtypes::Vector{Any}, vtypes, sv::StaticVarInf
         # TODO: call() case
         return Any
     end
-    if !isa(f,Function) && !isa(f,IntrinsicFunction) && _iisdefined(:call)
+    if !isa(f,Function) && !isa(f,IntrinsicFunction)
+        if !_iisdefined(:call)
+            return Any
+        end
         call_func = _ieval(:call)
         if isa(call_func,Function)
             return abstract_call(call_func, e.args,

--- a/src/gf.c
+++ b/src/gf.c
@@ -1611,6 +1611,7 @@ static void show_call(jl_value_t *F, jl_value_t **args, uint32_t nargs)
 
 JL_CALLABLE(jl_apply_generic)
 {
+    assert(jl_is_gf(F));
     jl_methtable_t *mt = jl_gf_mtable(F);
 #ifdef JL_GF_PROFILE
     mt->ncalls++;

--- a/src/module.c
+++ b/src/module.c
@@ -552,7 +552,7 @@ jl_function_t *jl_module_call_func(jl_module_t *m)
 {
     if (m->call_func == NULL) {
         jl_function_t *cf = (jl_function_t*)jl_get_global(m, call_sym);
-        if (cf == NULL || !jl_is_function(cf))
+        if (cf == NULL || !jl_is_function(cf) || !jl_is_gf(cf))
             cf = jl_bottom_func;
         m->call_func = cf;
     }

--- a/test/core.jl
+++ b/test/core.jl
@@ -3230,3 +3230,18 @@ end
 
 @test @inferred(MyColors.myeltype(MyColors.RGB{Float32})) == Float32
 @test @inferred(MyColors.myeltype(MyColors.RGB)) == Any
+
+# issue #12612 (handle the case when `call` is not defined)
+Main.eval(:(type Foo12612 end))
+
+baremodule A12612
+import Main: Foo12612
+f1() = Foo12612()
+f2() = Main.Foo12612()
+end
+
+## Don't panic in type inference if call is not defined
+code_typed(A12612.f1, Tuple{})
+code_typed(A12612.f2, Tuple{})
+@test_throws ErrorException A12612.f1()
+@test_throws ErrorException A12612.f2()


### PR DESCRIPTION
The error message is mirroring the one a few lines above for the definitely not function case.

Fix #12612

@mbauman
