### PR TITLE
Throw nicer message when module can't be found

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -402,6 +402,8 @@ function recompile_stale(mod, cachefile)
     cachestat = stat(cachefile)
     if iswritable(cachestat) && stale_cachefile(cachefile)
         info("Recompiling stale cache file $cachefile for module $mod.")
-        create_expr_cache(find_in_path(string(mod)), cachefile)
+        path = find_in_path(string(mod))
+        path === nothing && error("module $mod not found")
+        create_expr_cache(path, cachefile)
     end
 end


### PR DESCRIPTION
Formerly this gave

```
MethodError: `create_expr_cache` has no method matching create_expr_cache(::Void, ::UTF8String)
```

Now it gives

```
SystemError: module FooBar not found: No such file or directory
```

CC @stevengj 
