### PR TITLE
define jl_value_t* in llvmcall to be i8**

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -60,9 +60,9 @@ pointer_to_string(p::Ptr{UInt8}, own::Bool=false) =
     pointer_to_string(p, ccall(:strlen, Csize_t, (Ptr{UInt8},), p), own)
 
 # convert a raw Ptr to an object reference, and vice-versa
-unsafe_pointer_to_objref(x::Ptr) = ccall(:jl_value_ptr, Any, (Ptr{Void},), x)
-pointer_from_objref(x::ANY) = ccall(:jl_value_ptr, Ptr{Void}, (Any,), x)
-data_pointer_from_objref(x::ANY) = pointer_from_objref(x)::Ptr{Void}
+unsafe_pointer_to_objref(x::Ptr) = llvmcall("%2 = bitcast i8* %0 to i8**\nret i8** %2", Any, Type{Ptr{Void}}, convert(Ptr{Void}, x))
+pointer_from_objref(x::ANY) = llvmcall("%2 = bitcast i8** %0 to i8*\nret i8* %2", Ptr{Void}, Type{Any}, x)
+data_pointer_from_objref(x::ANY) = pointer_from_objref(x)
 
 eltype{T}(::Type{Ptr{T}}) = T
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -778,10 +778,6 @@ DLLEXPORT void *jl_array_ptr(jl_array_t *a)
 {
     return a->data;
 }
-DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a)
-{
-    return a;
-}
 
 // printing -------------------------------------------------------------------
 

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -37,7 +37,8 @@ end
 @test ccall_echo_func(124, Ref{Int}, Any) === 124
 @test ccall_echo_load(422, Ptr{Any}, Ref{Any}) === 422
 @test ccall_echo_load([383], Ptr{Int}, Ref{Int}) === 383
-@test ccall_echo_load(Ref([144,172],2), Ptr{Int}, Ref{Int}) === 172
+@test_throws MethodError ccall_echo_load(Base.Ref(Any[821, 241], 2), Ptr{Int}, Ref{Int}) === 271
+@test ccall_echo_load(Ref(Int[144, 172], 2), Ptr{Int}, Ref{Int}) === 172
 # @test ccall_echo_load(Ref([8],1,1), Ptr{Int}, Ref{Int}) === 8
 
 # Tests for passing and returning structs


### PR DESCRIPTION
when calling the llvm parser, it will unique any type definition, making it impossible to use `jl_value_t*`.
avoid that by defining `jl_value_t*` to be handled as `i8**`

@Keno I realize this will probably break Cxx.jl, since there you are emitting `Function*` objects directly, but this seemed to be necessary to make it possible to pass `Any` to an llvmcall as a string.
