### PR TITLE
Attempt to get 100% coverage for unicode functions

### DIFF
--- a/test/unicode.jl
+++ b/test/unicode.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 include("unicode/UnicodeError.jl")
+include("unicode/types.jl")
 include("unicode/checkstring.jl")
 include("unicode/utf8.jl")
 include("unicode/utf16.jl")

--- a/test/unicode.jl
+++ b/test/unicode.jl
@@ -1,5 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
+include("unicode/UnicodeError.jl")
 include("unicode/checkstring.jl")
 include("unicode/utf8.jl")
 include("unicode/utf16.jl")

--- a/test/unicode/UnicodeError.jl
+++ b/test/unicode/UnicodeError.jl
@@ -1,0 +1,7 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+let io = IOBuffer()
+    show(io, UnicodeError(Base.UTF_ERR_SHORT, 1, 10))
+    check = "UnicodeError: invalid UTF-8 sequence starting at index 1 (0xa) missing one or more continuation bytes)"
+    @test takebuf_string(io) == check
+end

--- a/test/unicode/types.jl
+++ b/test/unicode/types.jl
@@ -1,0 +1,11 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+nullstring16 = UInt16[]
+badstring16  = Uint16[0x0065]
+@test_throws UnicodeError UTF16String(nullstring16)
+@test_throws UnicodeError UTF16String(badstring16)
+
+nullstring32 = UInt32[]
+badstring32  = Uint32['a']
+@test_throws UnicodeError UTF32String(nullstring32)
+@test_throws UnicodeError UTF32String(badstring32)

--- a/test/unicode/utf16.jl
+++ b/test/unicode/utf16.jl
@@ -12,3 +12,12 @@ u16 = utf16(u8)
 @test u8 == utf16(pointer(u16)) == utf16(convert(Ptr{Int16}, pointer(u16)))
 @test_throws UnicodeError utf16(utf32(Char(0x120000)))
 @test_throws UnicodeError utf16(UInt8[1,2,3])
+
+# Add tests for full coverage
+@test convert(UTF16String, "test") == "test"
+@test convert(UTF16String, u16) == u16
+@test convert(UTF16String, UInt16[[0x65, 0x66] [0x67, 0x68]]) == "efgh"
+@test convert(UTF16String, Int16[[0x65, 0x66] [0x67, 0x68]]) == "efgh"
+@test map(lowercase, utf16("TEST\U1f596")) == "test\U1f596"
+@test typeof(Base.unsafe_convert(Ptr{UInt16}, utf16("test"))) == Ptr{UInt16}
+

--- a/test/unicode/utf8proc.jl
+++ b/test/unicode/utf8proc.jl
@@ -257,3 +257,36 @@ end
 @test length("\0w") == length("\0α") == 2
 @test strwidth("\0w") == strwidth("\0α") == 1
 @test normalize_string("\0W", casefold=true) == "\0w"
+
+# Make sure AbstractString case is covered (for utf8proc_map)
+@test normalize_string(utf32("\u006e\u0303"), :NFC) == "\u00f1"
+
+@test_throws ArgumentError normalize_string("\u006e\u0303", compose=false, compat=true)
+@test_throws ArgumentError normalize_string("\u006e\u0303", compose=false, stripmark=true)
+
+# Make sure fastplus is called for coverage
+@test lowercase('A') == 'a'
+@test uppercase('a') == 'A'
+
+@test is_assigned_char('A')
+
+# Get full coverage of isspace function
+@test isspace(' ')
+@test isspace('\t')
+@test isspace('\r')
+@test isspace('\u85')
+@test isspace('\ua0')
+@test !isspace('\ufffd')
+@test !isspace('\U10ffff')
+
+# Get full coverage of grapheme iterator functions
+let str = "This is a test"
+    g = graphemes(str)
+    h = hash(str)
+    @test hash(g) == h
+    @test convert(UTF16String, g) == str
+    io = IOBuffer()
+    show(io, g)
+    check = "length-14 GraphemeIterator{ASCIIString} for \"$str\""
+    @test takebuf_string(io) == check
+end


### PR DESCRIPTION
This should get 100% coverage for a number of files (`UnicodeError`, `types`, `utf8proc`, `utf16`) in `base/unicode`.
(remaining ones are `checkstring.jl`, `utf8.jl`, and `utf32.jl`, for another PR)
