### PR TITLE
Added some tests for linalg methods on numbers

### DIFF
--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -446,3 +446,13 @@ for elty in (Float32, Float64, Complex64, Complex128)
     # symmetric, indefinite
     @test_approx_eq inv(convert(Matrix{elty}, [1. 2; 2 1])) convert(Matrix{elty}, [-1. 2; 2 -1]/3)
 end
+
+# test ops on Numbers
+for elty in [Float32,Float64,Complex64,Complex128]
+    a = rand(elty)
+    @test_approx_eq expm(a) exp(a)
+    @test isposdef(one(elty))
+    @test_approx_eq sqrtm(a) sqrt(a)
+    @test_approx_eq logm(a) log(a)
+    @test_approx_eq lyap(one(elty),a) -a/2
+end

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -106,3 +106,16 @@ b = randn(Base.LinAlg.SCAL_CUTOFF) # make sure we try BLAS path
 @test isequal(scale(Float64[1.0], big(2.0)im), Complex{BigFloat}[2.0im])
 @test isequal(scale(BigFloat[1.0], 2.0im),     Complex{BigFloat}[2.0im])
 @test isequal(scale(BigFloat[1.0], 2.0f0im),   Complex{BigFloat}[2.0im])
+
+# test ops on Numbers
+for elty in [Float32,Float64,Complex64,Complex128]
+    a = rand(elty)
+    @test trace(a)         == a
+    @test rank(zero(elty)) == 0
+    @test rank(one(elty))  == 1
+    @test !isfinite(cond(zero(elty)))
+    @test cond(a)          == one(elty)
+    @test issym(a)
+    @test ishermitian(one(elty))
+    @test_approx_eq det(a) a
+end


### PR DESCRIPTION
A bunch of methods in `generic` and `dense` for `Number`s weren't tested. Now they will have tests.
