### PR TITLE
Fix bugs with using pointer on a SubString, add tests of pointer

### DIFF
--- a/base/unicode/utf32.jl
+++ b/base/unicode/utf32.jl
@@ -11,7 +11,6 @@ sizeof(s::UTF32String) = sizeof(s.data) - sizeof(Char)
 
 const empty_utf32 = UTF32String(UInt32[0])
 
-utf32(x) = convert(UTF32String, x)
 convert(::Type{UTF32String}, c::Char) = UTF32String(Char[c, Char(0)])
 convert(::Type{UTF32String}, s::UTF32String) = s
 
@@ -186,8 +185,6 @@ end
 convert(::Type{Vector{Char}}, str::UTF32String) = str.data
 convert(::Type{Array{Char}},  str::UTF32String) = str.data
 
-reverse(s::UTF32String) = UTF32String(reverse!(copy(s.data), 1, length(s)))
-
 unsafe_convert{T<:Union{Int32,UInt32,Char}}(::Type{Ptr{T}}, s::UTF32String) =
     convert(Ptr{T}, pointer(s))
 
@@ -272,9 +269,11 @@ end
 
 # pointer conversions of ASCII/UTF8/UTF16/UTF32 strings:
 pointer(x::Union{ByteString,UTF16String,UTF32String}) = pointer(x.data)
-pointer{T<:ByteString}(x::SubString{T}) = pointer(x.string.data) + x.offset
 pointer(x::ByteString, i::Integer) = pointer(x.data)+(i-1)
-pointer{T<:ByteString}(x::SubString{T}, i::Integer) = pointer(x.string.data) + x.offset + (i-1)
 pointer(x::Union{UTF16String,UTF32String}, i::Integer) = pointer(x)+(i-1)*sizeof(eltype(x.data))
-pointer{T<:Union{UTF16String,UTF32String}}(x::SubString{T}) = pointer(x.string.data) + x.offset*sizeof(eltype(x.data))
-pointer{T<:Union{UTF16String,UTF32String}}(x::SubString{T}, i::Integer) = pointer(x.string.data) + (x.offset + (i-1))*sizeof(eltype(x.data))
+
+# pointer conversions of SubString of ASCII/UTF8/UTF16/UTF32:
+pointer{T<:ByteString}(x::SubString{T}) = pointer(x.string.data) + x.offset
+pointer{T<:ByteString}(x::SubString{T}, i::Integer) = pointer(x.string.data) + x.offset + (i-1)
+pointer{T<:Union{UTF16String,UTF32String}}(x::SubString{T}) = pointer(x.string.data) + x.offset*sizeof(eltype(x.string.data))
+pointer{T<:Union{UTF16String,UTF32String}}(x::SubString{T}, i::Integer) = pointer(x.string.data) + (x.offset + (i-1))*sizeof(eltype(x.string.data))

--- a/test/unicode/utf32.jl
+++ b/test/unicode/utf32.jl
@@ -208,3 +208,62 @@ end
 
 @test isvalid(UTF32String, Char['d','\uff','\u7ff','\u7fff','\U7ffff'])
 @test reverse(utf32("abcd \uff\u7ff\u7fff\U7ffff")) == utf32("\U7ffff\u7fff\u7ff\uff dcba")
+
+# Test pointer() functions
+let str = "this "
+    u8  = utf8(str)
+    u16 = utf16(str)
+    u32 = utf32(str)
+    pa  = pointer(str)
+    p8  = pointer(u8)
+    p16 = pointer(u16)
+    p32 = pointer(u32)
+    @test typeof(pa) == Ptr{UInt8}
+    @test unsafe_load(pa,1) == 0x74
+    @test typeof(p8) == Ptr{UInt8}
+    @test unsafe_load(p8,1) == 0x74
+    @test typeof(p16) == Ptr{UInt16}
+    @test unsafe_load(p16,1) == 0x0074
+    @test typeof(p32) == Ptr{Char}
+    @test unsafe_load(p32,1) == 't'
+    pa  = pointer(str, 2)
+    p8  = pointer(u8,  2)
+    p16 = pointer(u16, 2)
+    p32 = pointer(u32, 2)
+    @test typeof(pa) == Ptr{UInt8}
+    @test unsafe_load(pa,1) == 0x68
+    @test typeof(p8) == Ptr{UInt8}
+    @test unsafe_load(p8,1) == 0x68
+    @test typeof(p16) == Ptr{UInt16}
+    @test unsafe_load(p16,1) == 0x0068
+    @test typeof(p32) == Ptr{Char}
+    @test unsafe_load(p32,1) == 'h'
+    sa  = SubString{ASCIIString}(str, 3, 5)
+    s8  = SubString{UTF8String}(u8,   3, 5)
+    s16 = SubString{UTF16String}(u16, 3, 5)
+    s32 = SubString{UTF32String}(u32, 3, 5)
+    pa  = pointer(sa)
+    p8  = pointer(s8)
+    p16 = pointer(s16)
+    p32 = pointer(s32)
+    @test typeof(pa) == Ptr{UInt8}
+    @test unsafe_load(pa,1) == 0x69
+    @test typeof(p8) == Ptr{UInt8}
+    @test unsafe_load(p8,1) == 0x69
+    @test typeof(p16) == Ptr{UInt16}
+    @test unsafe_load(p16,1) == 0x0069
+    @test typeof(p32) == Ptr{Char}
+    @test unsafe_load(p32,1) == 'i'
+    pa  = pointer(sa, 2)
+    p8  = pointer(s8,  2)
+    p16 = pointer(s16, 2)
+    p32 = pointer(s32, 2)
+    @test typeof(pa) == Ptr{UInt8}
+    @test unsafe_load(pa,1) == 0x73
+    @test typeof(p8) == Ptr{UInt8}
+    @test unsafe_load(p8,1) == 0x73
+    @test typeof(p16) == Ptr{UInt16}
+    @test unsafe_load(p16,1) == 0x0073
+    @test typeof(p32) == Ptr{Char}
+    @test unsafe_load(p32,1) == 's'
+end


### PR DESCRIPTION
The code had `x.data` instead of `x.string.data` in a few places.
Since there were no unit tests for those functions, the bugs had not been discovered previously.
