### PR TITLE
Add more coverage for UTF8String

### DIFF
--- a/test/unicode/utf8.jl
+++ b/test/unicode/utf8.jl
@@ -24,13 +24,3 @@ let str = UTF8String(b"this is a test\xed\x80")
     @test s8 == "This is a sill"
     @test convert(UTF8String, b"this is a test\xed\x80\x80") == "this is a test\ud000"
 end
-
-# Test undocumented, unexported function, used in a registered package
-@test Base.is_utf8_start(0x65)
-
-# Test undocumented, unexported function, used in a registered package
-@test Base.utf8sizeof('a') == 1
-@test Base.utf8sizeof('\uff') == 2
-@test Base.utf8sizeof('\uffff') == 3
-@test Base.utf8sizeof('\U1f596') == 4
-@test Base.utf8sizeof(Char(0x110000)) == 3

--- a/test/unicode/utf8.jl
+++ b/test/unicode/utf8.jl
@@ -10,3 +10,27 @@ let ch = 0x10000
         end
     end
 end
+
+let str = UTF8String(b"this is a test\xed\x80")
+    @test next(str, 15) == ('\ufffd', 16)
+    @test_throws BoundsError getindex(str, 0:3)
+    @test_throws BoundsError getindex(str, 17:18)
+    @test_throws BoundsError getindex(str, 2:17)
+    @test_throws UnicodeError getindex(str, 16:17)
+    @test string(Char(0x110000)) == "\ufffd"
+    sa = SubString{ASCIIString}("This is a silly test", 1, 14)
+    s8 = convert(SubString{UTF8String}, sa)
+    @test typeof(s8) == SubString{UTF8String}
+    @test s8 == "This is a sill"
+    @test convert(UTF8String, b"this is a test\xed\x80\x80") == "this is a test\ud000"
+end
+
+# Test undocumented, unexported function, used in a registered package
+@test Base.is_utf8_start(0x65)
+
+# Test undocumented, unexported function, used in a registered package
+@test Base.utf8sizeof('a') == 1
+@test Base.utf8sizeof('\uff') == 2
+@test Base.utf8sizeof('\uffff') == 3
+@test Base.utf8sizeof('\U1f596') == 4
+@test Base.utf8sizeof(Char(0x110000)) == 3


### PR DESCRIPTION
This should give almost 100% coverage of `unicode/utf8.jl`, there is still one line with `reverse` that looks like the C code `u8_reverse` is broken that I'll need to address in a subsequent PR.
