### PR TITLE
Test exact equality for most matrix functions applied to scalars

### DIFF
--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -450,9 +450,9 @@ end
 # test ops on Numbers
 for elty in [Float32,Float64,Complex64,Complex128]
     a = rand(elty)
-    @test_approx_eq expm(a) exp(a)
+    @test expm(a) == exp(a)
     @test isposdef(one(elty))
-    @test_approx_eq sqrtm(a) sqrt(a)
-    @test_approx_eq logm(a) log(a)
-    @test_approx_eq lyap(one(elty),a) -a/2
+    @test sqrtm(a) == sqrt(a)
+    @test logm(a) ≈ log(a)
+    @test lyap(one(elty),a) == -a/2
 end

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -117,5 +117,5 @@ for elty in [Float32,Float64,Complex64,Complex128]
     @test cond(a)          == one(elty)
     @test issym(a)
     @test ishermitian(one(elty))
-    @test_approx_eq det(a) a
+    @test det(a) == a
 end


### PR DESCRIPTION
ref #12637, only exception is logm since real(log(complex(x))) is not always
exactly equal to log(x)
