### PR TITLE
Allow inference of super even if has TypeVars

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -278,7 +278,7 @@ const getfield_tfunc = function (A, s0, name)
         end
         if isType(s0)
             sp = s0.parameters[1]
-            if isa(sp,DataType) && !any(x->isa(x,TypeVar), sp.parameters)
+            if isa(sp,DataType)
                 # TODO
                 #if fld === :parameters
                 #    return Type{sp.parameters}, true

--- a/test/core.jl
+++ b/test/core.jl
@@ -3211,3 +3211,22 @@ end
 # issue #12551 (make sure these don't throw in inference)
 Base.return_types(unsafe_load, (Ptr{nothing},))
 Base.return_types(getindex, (Vector{nothing},))
+
+# issue #12636
+module MyColors
+
+abstract Paint{T}
+immutable RGB{T<:FloatingPoint} <: Paint{T}
+    r::T
+    g::T
+    b::T
+end
+
+myeltype{T}(::Type{Paint{T}}) = T
+myeltype{P<:Paint}(::Type{P}) = myeltype(super(P))
+myeltype(::Type{Any}) = Any
+
+end
+
+@test @inferred(MyColors.myeltype(MyColors.RGB{Float32})) == Float32
+@test @inferred(MyColors.myeltype(MyColors.RGB)) == Any


### PR DESCRIPTION
This fixes #12636. If acceptable and it doesn't cause problems for packages, I'd like to propose to backport the same fix to julia-0.3.
