### PR TITLE
Fix several bugs in reverse(::UTF8String), add full coverage tests

### DIFF
--- a/test/unicode/utf8.jl
+++ b/test/unicode/utf8.jl
@@ -11,6 +11,7 @@ let ch = 0x10000
     end
 end
 
+
 let str = UTF8String(b"this is a test\xed\x80")
     @test next(str, 15) == ('\ufffd', 16)
     @test_throws BoundsError getindex(str, 0:3)
@@ -24,3 +25,13 @@ let str = UTF8String(b"this is a test\xed\x80")
     @test s8 == "This is a sill"
     @test convert(UTF8String, b"this is a test\xed\x80\x80") == "this is a test\ud000"
 end
+
+## Reverse of UTF8String
+@test reverse(UTF8String("")) == ""
+@test reverse(UTF8String("a")) == "a"
+@test reverse(UTF8String("abc")) == "cba"
+@test reverse(UTF8String("xyz\uff\u800\uffff\U10ffff")) == "\U10ffff\uffff\u800\uffzyx"
+for str in (b"xyz\xc1", b"xyz\xd0", b"xyz\xe0", b"xyz\xed\x80", b"xyz\xf0", b"xyz\xf0\x80",  b"xyz\xf0\x80\x80")
+    @test_throws UnicodeError reverse(UTF8String(str))
+end
+


### PR DESCRIPTION
`reverse` on a `UTF8String` used the C function `u8_reverse`, which I discovered in testing has several bugs.
1. It doesn't detect running off the end of the string when there is a char > 0x80
2. It picks up garbage bytes depending on the lead character
3. It is not portable to any machine that requires alignment.

I have rewritten it in Julia, and added tests that fully cover the function.
I wanted to remove `u8_reverse` from `src/support/utf8.c`, however that function is used by `flisp` for the `string.reverse` function, even though that function is apparently never used anywhere in any of the .scm code I have found in Base.
I wonder if the unused string functions in flisp, that are depending on broken C code, can simply be removed and save some space.
