### PR TITLE
RFC: turn on precompiled dll support on windows (wip)

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -70,12 +70,7 @@ jl_options_t jl_options = { 0,    // quiet
                             JL_OPTIONS_FAST_MATH_DEFAULT,
                             0,    // worker
                             JL_OPTIONS_HANDLE_SIGNALS_ON,
-#ifdef _OS_WINDOWS_
-// TODO remove this when using LLVM 3.5+
-                            JL_OPTIONS_USE_PRECOMPILED_NO,
-#else
                             JL_OPTIONS_USE_PRECOMPILED_YES,
-#endif
                             NULL, // bindto
                             NULL, // outputbc
                             NULL, // outputo


### PR DESCRIPTION
I believe this patch should suffice to allow turning on precompiled dll support on windows. If there is interest in getting this into v0.4, I'll start work on writing the relevant Makefile rules. Otherwise, I'll finish this after the jn/makefile_o branch merges into master. (although I may need some help with the AppVeyor updates to add support for llvm 3.6).
