### PR TITLE
Deprecate colon{T<:AbstractFloat}(::T, ::T)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -423,7 +423,7 @@ map(::Type{Unsigned}, a::Array) = map!(Unsigned, similar(a,typeof(Unsigned(one(e
 ## range conversions ##
 
 map{T<:Real}(::Type{T}, r::StepRange) = T(r.start):T(r.step):T(last(r))
-map{T<:Real}(::Type{T}, r::UnitRange) = T(r.start):T(last(r))
+map{T<:Real}(::Type{T}, r::UnitRange) = UnitRange(T(r.start), T(last(r)))
 map{T<:AbstractFloat}(::Type{T}, r::FloatRange) = FloatRange(T(r.start), T(r.step), r.len, T(r.divisor))
 function map{T<:AbstractFloat}(::Type{T}, r::LinSpace)
     new_len = T(r.len)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -782,3 +782,5 @@ function Regex(pattern::AbstractString, options::Integer)
             "use string flags instead: Regex(\"$pattern\", \"$flags\").", :Regex)
     Regex(pattern, flags)
 end
+
+@deprecate colon{T<:AbstractFloat}(a::T, b::T) colon(a, one(a), b)

--- a/base/float.jl
+++ b/base/float.jl
@@ -467,7 +467,7 @@ end
 for fn in (:float,:big)
     @eval begin
         $fn(r::StepRange) = $fn(r.start):$fn(r.step):$fn(last(r))
-        $fn(r::UnitRange) = $fn(r.start):$fn(last(r))
+        $fn(r::UnitRange) = UnitRange($fn(r.start), $fn(last(r)))
         $fn(r::FloatRange) = FloatRange($fn(r.start), $fn(r.step), r.len, $fn(r.divisor))
         function $fn(r::LinSpace)
             new_len = $fn(r.len)

--- a/base/range.jl
+++ b/base/range.jl
@@ -159,8 +159,6 @@ function colon{T<:AbstractFloat}(start::T, step::T, stop::T)
     FloatRange{T}(start, step, floor(r)+1, one(step))
 end
 
-colon{T<:AbstractFloat}(a::T, b::T) = colon(a, one(a), b)
-
 colon{T<:Real}(a::T, b::AbstractFloat, c::T) = colon(promote(a,b,c)...)
 colon{T<:AbstractFloat}(a::T, b::AbstractFloat, c::T) = colon(promote(a,b,c)...)
 colon{T<:AbstractFloat}(a::T, b::Real, c::T) = colon(promote(a,b,c)...)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -119,7 +119,7 @@ for (sz,T) in allsizes[2:end]
         @check_bit_operation setindex!(b1, x, j) T
     end
 
-    y = rand(0.0:1.0)
+    y = rand(0.0:1:1.0)
     @check_bit_operation setindex!(b1, y, 100) T
 
     for j in [1, 63, 64, 65, 127, 128, 129, 191, 192, 193, l-1]
@@ -144,7 +144,7 @@ for (sz,T) in allsizes[2:end]
     b2 = bitrand(100)
     @check_bit_operation setindex!(b1, b2, 1:100) T
 
-    y = rand(0.0:1.0)
+    y = rand(0.0:1:1.0)
     @check_bit_operation setindex!(b1, y, 1:100) T
 
     t1 = find(bitrand(l))
@@ -153,7 +153,7 @@ for (sz,T) in allsizes[2:end]
     b2 = bitrand(length(t1))
     @check_bit_operation setindex!(b1, b2, t1) T
 
-    y = rand(0.0:1.0)
+    y = rand(0.0:1:1.0)
     @check_bit_operation setindex!(b1, y, t1) T
 end
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -775,7 +775,7 @@ end
 @test round(Complex(1.125, 0.875), 2) == Complex(1.12, 0.88)
 @test round(Complex(1.5, 0.5), RoundDown, RoundUp) == Complex(1.0, 1.0)
 @test round([1:5;] + im) == [1:5;] + im
-@test round([1:5;] + 0.5im) == [1.0:5.0;]
+@test round([1:5;] + 0.5im) == [1.0:1:5.0;]
 
 # float #8291
 @test float(Complex(1, 2)) == Complex(1.0, 2.0)

--- a/test/core.jl
+++ b/test/core.jl
@@ -2057,7 +2057,7 @@ end
 c99991{T}(::Type{T},x::T) = 0
 c99991{T}(::Type{UnitRange{T}},x::FloatRange{T}) = 1
 c99991{T}(::Type{UnitRange{T}},x::Range{T}) = 2
-@test c99991(UnitRange{Float64}, 1.0:2.0) == 1
+@test c99991(UnitRange{Float64}, 1.0:1:2.0) == 1
 @test c99991(UnitRange{Int}, 1:2) == 2
 
 # issue #8798

--- a/test/dsp.jl
+++ b/test/dsp.jl
@@ -6,16 +6,16 @@ x = [1., 1., 0., 1., 1., 0., 0., 0.]
 @test filt(b, 1., x)  == [1., 3., 5., 8., 7., 5., 7., 4.]
 @test filt(b, [1., -0.5], x)  == [1., 3.5, 6.75, 11.375, 12.6875, 11.34375, 12.671875, 10.3359375]
 # With ranges
-@test filt(b, 1., 1.0:10.0) == [1., 4., 10., 20., 30., 40., 50., 60., 70., 80.]
-@test filt(1.:4., 1., 1.0:10.0) == [1., 4., 10., 20., 30., 40., 50., 60., 70., 80.]
+@test filt(b, 1., 1.0:1:10.0) == [1., 4., 10., 20., 30., 40., 50., 60., 70., 80.]
+@test filt(1.:1:4., 1., 1.0:1:10.0) == [1., 4., 10., 20., 30., 40., 50., 60., 70., 80.]
 # Across an array is the same as channel-by-channel
-@test filt(b, 1., [x 1.0:8.0]) == [filt(b, 1., x) filt(b, 1., 1.0:8.0)]
-@test filt(b, [1., -0.5], [x 1.0:8.0]) == [filt(b, [1., -0.5], x) filt(b, [1., -0.5], 1.0:8.0)]
+@test filt(b, 1., [x 1.0:1:8.0]) == [filt(b, 1., x) filt(b, 1., 1.0:1:8.0)]
+@test filt(b, [1., -0.5], [x 1.0:1:8.0]) == [filt(b, [1., -0.5], x) filt(b, [1., -0.5], 1.0:1:8.0)]
 si = zeros(3)
-@test filt(b, 1., [x 1.0:8.0], si) == [filt(b, 1., x, si) filt(b, 1., 1.0:8.0, si)]
+@test filt(b, 1., [x 1.0:1:8.0], si) == [filt(b, 1., x, si) filt(b, 1., 1.0:1:8.0, si)]
 @test si == zeros(3) # Will likely fail if/when arrayviews are implemented
 si = [zeros(3) ones(3)]
-@test filt(b, 1., [x 1.0:8.0], si) == [filt(b, 1., x, zeros(3)) filt(b, 1., 1.0:8.0, ones(3))]
+@test filt(b, 1., [x 1.0:1:8.0], si) == [filt(b, 1., x, zeros(3)) filt(b, 1., 1.0:1:8.0, ones(3))]
 # With initial conditions: a lowpass 5-pole butterworth filter with W_n = 0.25,
 # and a stable initial filter condition matched to the initial value
 b = [0.003279216306360201,0.016396081531801006,0.03279216306360201,0.03279216306360201,0.016396081531801006,0.003279216306360201]

--- a/test/fft.jl
+++ b/test/fft.jl
@@ -296,8 +296,8 @@ for T in (Complex64, Complex128)
 end
 
 let
-    plan32 = plan_fft([1.0:2048.0;])
-    plan64 = plan_fft([1f0:2048f0;])
+    plan32 = plan_fft([1.0:1:2048.0;])
+    plan64 = plan_fft([1f0:1:2048f0;])
     FFTW.flops(plan32)
     FFTW.flops(plan64)
 end

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -62,7 +62,7 @@ y = ['a','b','c','d','e']
 
 
 # 2-argument version of scale
-a = reshape([1.:6;], (2,3))
+a = reshape([1.:1:6;], (2,3))
 @test scale(a, 5.) == a*5
 @test scale(5., a) == a*5
 @test scale(a, [1.; 2.; 3.]) == a.*[1 2 3]

--- a/test/linalg/special.jl
+++ b/test/linalg/special.jl
@@ -7,7 +7,7 @@ n= 10 #Size of matrix to test
 srand(1)
 
 debug && println("Test interconversion between special matrix types")
-let a=[1.0:n;]
+let a=Float64[1:n;]
    A=Diagonal(a)
    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, LowerTriangular, UpperTriangular, Matrix]
        debug && println("newtype is $(newtype)")
@@ -20,7 +20,7 @@ let a=[1.0:n;]
 
    for isupper in (true, false)
        debug && println("isupper is $(isupper)")
-       A=Bidiagonal(a, [1.0:n-1;], isupper)
+       A=Bidiagonal(a, Float64[1:n-1;], isupper)
        for newtype in [Bidiagonal, Tridiagonal, isupper ? UpperTriangular : LowerTriangular, Matrix]
            debug && println("newtype is $(newtype)")
            @test full(convert(newtype, A)) == full(A)
@@ -35,7 +35,7 @@ let a=[1.0:n;]
        end
    end
 
-   A = SymTridiagonal(a, [1.0:n-1;])
+   A = SymTridiagonal(a, [1.0:1:n-1;])
    for newtype in [Tridiagonal, Matrix]
        @test full(convert(newtype, A)) == full(A)
    end
@@ -45,24 +45,24 @@ let a=[1.0:n;]
    A = SymTridiagonal(a, zeros(n-1))
    @test full(convert(Bidiagonal,A)) == full(A)
 
-   A = Tridiagonal(zeros(n-1), [1.0:n;], zeros(n-1)) #morally Diagonal
+   A = Tridiagonal(zeros(n-1), [1.0:1:n;], zeros(n-1)) #morally Diagonal
    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Matrix]
        @test full(convert(newtype, A)) == full(A)
    end
-   A = Tridiagonal(ones(n-1), [1.0:n;], ones(n-1)) #not morally Diagonal
+   A = Tridiagonal(ones(n-1), [1.0:1:n;], ones(n-1)) #not morally Diagonal
    for newtype in [SymTridiagonal, Matrix]
        @test full(convert(newtype, A)) == full(A)
    end
    for newtype in [Diagonal, Bidiagonal]
        @test_throws ArgumentError convert(newtype,A)
    end
-   A = Tridiagonal(zeros(n-1), [1.0:n;], ones(n-1)) #not morally Diagonal
+   A = Tridiagonal(zeros(n-1), [1.0:1:n;], ones(n-1)) #not morally Diagonal
    @test full(convert(Bidiagonal, A)) == full(A)
-   A = UpperTriangular(Tridiagonal(zeros(n-1), [1.0:n;], ones(n-1)))
+   A = UpperTriangular(Tridiagonal(zeros(n-1), [1.0:1:n;], ones(n-1)))
    @test full(convert(Bidiagonal, A)) == full(A)
-   A = Tridiagonal(ones(n-1), [1.0:n;], zeros(n-1)) #not morally Diagonal
+   A = Tridiagonal(ones(n-1), [1.0:1:n;], zeros(n-1)) #not morally Diagonal
    @test full(convert(Bidiagonal, A)) == full(A)
-   A = LowerTriangular(Tridiagonal(ones(n-1), [1.0:n;], zeros(n-1)))
+   A = LowerTriangular(Tridiagonal(ones(n-1), [1.0:1:n;], zeros(n-1)))
    @test full(convert(Bidiagonal, A)) == full(A)
 
    A = LowerTriangular(full(Diagonal(a))) #morally Diagonal
@@ -84,7 +84,7 @@ let a=[1.0:n;]
 end
 
 # Binary ops among special types
-let a=[1.0:n;]
+let a=[1.0:1:n;]
    A=Diagonal(a)
    Spectypes = [Diagonal, Bidiagonal, Tridiagonal, Matrix]
    for (idx, type1) in enumerate(Spectypes)

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -152,14 +152,14 @@ let n=10
 end
 
 #Issue #7647: test xsyevr, xheevr, xstevr drivers
-for Mi7647 in (Symmetric(diagm(1.0:3.0)),
-               Hermitian(diagm(1.0:3.0)),
-               Hermitian(diagm(complex(1.0:3.0))),
-               SymTridiagonal([1.0:3.0;], zeros(2)))
+for Mi7647 in (Symmetric(diagm([1.0:1:3.0;])),
+               Hermitian(diagm([1.0:1:3.0;])),
+               Hermitian(diagm(complex([1.0:1:3.0;]))),
+               SymTridiagonal([1.0:1:3.0;], zeros(2)))
     debug && println("Eigenvalues in interval for $(typeof(Mi7647))")
     @test eigmin(Mi7647)  == eigvals(Mi7647, 0.5, 1.5)[1] == 1.0
     @test eigmax(Mi7647)  == eigvals(Mi7647, 2.5, 3.5)[1] == 3.0
-    @test eigvals(Mi7647) == eigvals(Mi7647, 0.5, 3.5) == [1.0:3.0;]
+    @test eigvals(Mi7647) == eigvals(Mi7647, 0.5, 3.5) == [1.0:1:3.0;]
 end
 
 #Issue #7933

--- a/test/random.jl
+++ b/test/random.jl
@@ -58,7 +58,11 @@ randn!(MersenneTwister(42), A)
 
 for T in (Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128, BigInt,
           Float16, Float32, Float64, Rational{Int})
-    r = rand(convert(T, 97):convert(T, 122))
+    if T <: Integer
+        r = rand(UnitRange{T}(97, 122))
+    else
+        r = rand(convert(T, 97) : one(T) : convert(T, 122))
+    end
     @test typeof(r) == T
     @test 97 <= r <= 122
     r = rand(convert(T, 97):convert(T,2):convert(T, 122),2)[1]

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -10,7 +10,7 @@
 @test length(2.:.2:1.) == 0
 
 @test length(1:0) == 0
-@test length(0.0:-0.5) == 0
+@test length(0.0:1:-0.5) == 0
 @test length(1:2:0) == 0
 L32 = linspace(Int32(1), Int32(4), 4)
 L64 = linspace(Int64(1), Int64(4), 4)
@@ -132,7 +132,7 @@ r = (-4*Int64(maxintfloat(is(Int,Int32) ? Float32 : Float64))):5
 @test (3.0 in r)
 
 @test !(1 in 1:0)
-@test !(1.0 in 1.0:0.0)
+@test !(1.0 in 1.0:1:0.0)
 
 # indexing range with empty range (#4309)
 @test (3:6)[5:4] == 7:6
@@ -230,9 +230,9 @@ end
 
 # operations with scalars
 @test (1:3) - 2 == -1:1
-@test (1:3) - 0.25 == 1-0.25:3-0.25
+@test (1:3) - 0.25 == (1-0.25):1:(3-0.25)
 @test (1:3) + 2 == 3:5
-@test (1:3) + 0.25 == 1+0.25:3+0.25
+@test (1:3) + 0.25 == (1+0.25):1:(3+0.25)
 @test (1:2:6) + 1 == 2:2:6
 @test (1:2:6) + 0.3 == 1+0.3:2:5+0.3
 @test (1:2:6) - 1 == 0:2:4
@@ -349,7 +349,7 @@ for T = (Float32, Float64)
             @test [linspace(a,-b,0);] == []
             @test [linspace(a,-b,2);] == [a,-b]
             @test [linspace(a,-b,3);] == [a,(a-b)/2,-b]
-            for c = maxintfloat(T)-3:maxintfloat(T)
+            for c = (maxintfloat(T)-3):1:(maxintfloat(T))
                 s = linspace(-a,b,c)
                 @test first(s) == -a
                 @test last(s) == b
@@ -388,7 +388,7 @@ let
 end
 
 # issue #2959
-@test 1.0:1.5 == 1.0:1.0:1.5 == 1.0:1.0
+@test 1.0:1:1.5 == 1.0:1.0:1.5 == 1.0:1:1.0
 #@test 1.0:(.3-.1)/.1 == 1.0:2.0
 
 let r = typemin(Int64):2:typemax(Int64), s = typemax(Int64):-2:typemin(Int64)
@@ -451,7 +451,7 @@ r7484 = 0.1:0.1:1
 @test [reverse(r7484);] == reverse([r7484;])
 
 # issue #7387
-for r in (0:1, 0.0:1.0)
+for r in (0:1, 0.0:1:1.0)
     @test r+im == [r;]+im
     @test r-im == [r;]-im
     @test r*im == [r;]*im
@@ -515,7 +515,7 @@ end
 @test promote(0:1:1, 2:5) === (0:1:1, 2:1:5)
 @test convert(StepRange{Int128,Int128}, 0:5) === Int128(0):Int128(1):Int128(5)
 @test convert(StepRange, 0:5) === 0:1:5
-@test convert(StepRange{Int128,Int128}, 0.:5) === Int128(0):Int128(1):Int128(5)
+@test convert(StepRange{Int128,Int128}, 0.:1:5) === Int128(0):Int128(1):Int128(5)
 
 @test promote(0f0:inv(3f0):1f0, 0.:2.:5.) === (0:1/3:1, 0.:2.:5.)
 @test convert(FloatRange{Float64}, 0:1/3:1) === 0:1/3:1
@@ -632,10 +632,10 @@ end
 @test_throws DimensionMismatch (1:5) .* (1:6)
 @test_throws DimensionMismatch (1:5) ./ (1:6)
 
-@test_throws DimensionMismatch (1.:5.) + (1.:6.)
-@test_throws DimensionMismatch (1.:5.) - (1.:6.)
-@test_throws DimensionMismatch (1.:5.) .* (1.:6.)
-@test_throws DimensionMismatch (1.:5.) ./ (1.:6.)
+@test_throws DimensionMismatch (1.:1:5.) + (1.:1:6.)
+@test_throws DimensionMismatch (1.:1:5.) - (1.:1:6.)
+@test_throws DimensionMismatch (1.:1:5.) .* (1.:1:6.)
+@test_throws DimensionMismatch (1.:1:5.) ./ (1.:1:6.)
 
 function test_range_sum_diff(r1, r2, r_sum, r_diff)
     @test r1 + r2 == r_sum
@@ -650,14 +650,14 @@ function test_range_sum_diff(r1, r2, r_sum, r_diff)
 end
 
 test_range_sum_diff(1:5, 0:2:8, 1:3:13, 1:-1:-3)
-test_range_sum_diff(1.:5., 0.:2.:8., 1.:3.:13., 1.:-1.:-3.)
+test_range_sum_diff(1.:1:5., 0.:2.:8., 1.:3.:13., 1.:-1.:-3.)
 test_range_sum_diff(linspace(1.,5.,5), linspace(0.,-4.,5),
                     linspace(1.,1.,5), linspace(1.,9.,5))
 
 test_range_sum_diff(1:5, 0.:2.:8., 1.:3.:13., 1.:-1.:-3.)
 test_range_sum_diff(1:5, linspace(0, 8, 5),
                     linspace(1, 13, 5), linspace(1, -3, 5))
-test_range_sum_diff(1.:5., linspace(0, 8, 5),
+test_range_sum_diff(1.:1:5., linspace(0, 8, 5),
                     linspace(1, 13, 5), linspace(1, -3, 5))
 
 # Issue #12388

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -284,12 +284,12 @@ end
 @test hist([1 2 3 4;1 2 3 4]) == (0.0:2.0:4.0, [2 2 0 0; 0 0 2 2])
 
 @test midpoints(1.0:1.0:10.0) == 1.5:1.0:9.5
-@test midpoints(1:10) == 1.5:9.5
+@test midpoints(1:10) == 1.5:1:9.5
 @test midpoints(Float64[1.0:1.0:10.0;]) == Float64[1.5:1.0:9.5;]
 
 @test quantile([1,2,3,4],0.5) == 2.5
 @test quantile([1., 3],[.25,.5,.75])[2] == median([1., 3])
-@test quantile([0.:100.;],[.1,.2,.3,.4,.5,.6,.7,.8,.9])[1] == 10.0
+@test quantile([0.:1:100.;],[.1,.2,.3,.4,.5,.6,.7,.8,.9])[1] == 10.0
 
 # test invalid hist nbins argument (#9999)
 @test_throws ArgumentError hist(Int[], -1)


### PR DESCRIPTION
Since a bike shed is only as good as the code that goes along with it, I spent a flight implementing #12624. A few comments:
- This wasn't used anywhere in Base itself (probably unsurprising)
- Of the handful of uses in the tests, _only one_ "in the wild" (i.e. not in `test/ranges.jl`) had an endpoint `a:b` that didn't exactly convert to an integer (most were something like `1.0:n`)
- Most of the uses were for essentially a shorter way to write `convert(Vector{Float64}, 1:n)`
- The deprecation doesn't have the most useful warning, but that can be changed if this actually gets any support
- The natural extension of this is to disallow things like `1//2 : 3//2`, but one step at a time
- I hope I did this without changing any behavior, but there might be a change in behavior in the `map` method

After this, I have to say that this usage seems more and more like a crufty MATLAB-ism (like @yuyichao mentioned in #12624, probably because they don't have "real" integers), and the 2 character fix (`a:b` to `a:1:b`) seems like a win in clarity for users that aren't already familiar with what this is supposed to mean. But I also don't have too much code that uses this, so I'm not the best judge of whether this is actually used and embraced in the larger community.
