### PR TITLE
ignore __precompile__(true) except within require (fixes #12623)

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -14633,7 +14633,8 @@ doc"""
            __precompile__(isprecompilable::Bool=true)
 
 Specify whether the file calling this function is precompilable.  If
-``isprecompilable`` is ``true``, then ``__precompile__`` throws an exception
+``isprecompilable`` is ``true``, then ``__precompile__`` throws an
+exception when the file is loaded by ``using``/``import``/``require``
 *unless* the file is being precompiled, and in a module file it causes
 the module to be automatically precompiled when it is imported.
 Typically, ``__precompile__()`` should occur before the ``module``

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -148,10 +148,12 @@ precompilableerror(ex::PrecompilableError, c) = ex.isprecompilable == c
 precompilableerror(ex::LoadError, c) = precompilableerror(ex.error, c)
 precompilableerror(ex, c) = false
 
-# put at the top of a file to force it to be precompiled (true), or
-# to be prevent it from being precompiled (false).
+# Call __precompile__ at the top of a file to force it to be precompiled (true), or
+# to be prevent it from being precompiled (false).  __precompile__(true) is
+# ignored except within "require" call.
 function __precompile__(isprecompilable::Bool=true)
-    if myid() == 1 && isprecompilable != (0 != ccall(:jl_generating_output, Cint, ()))
+    if myid() == 1 && isprecompilable != (0 != ccall(:jl_generating_output, Cint, ())) &&
+        !(isprecompilable && toplevel_load::Bool)
         throw(PrecompilableError(isprecompilable))
     end
 end

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -24,10 +24,8 @@ try
               """)
     end
 
-    if myid() == 1
-        @test_throws Base.PrecompilableError __precompile__(true)
-        @test_throws LoadError include(Foo_file) # from __precompile__(true)
-    end
+    # Issue #12623
+    @test __precompile__(true) === nothing
 
     Base.require(Foo_module)
     cachefile = joinpath(dir, "$Foo_module.ji")


### PR DESCRIPTION
As discussed in #12623, this makes `__precompile__(true)` a no-op except in the context of a `require` statement.

cc: @jakebolewski
