### PR TITLE
give more context to error when parsing REQUIRE files

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -16,13 +16,13 @@ macro recover(ex)
 end
 
 function edit(f::Function, pkg::AbstractString, args...)
-    r = Reqs.read("REQUIRE")
-    reqs = Reqs.parse(r)
+    r = Reqs.read("REQUIRE", pkg=pkg)
+    reqs = Reqs.parse(r, pkg=pkg)
     avail = Read.available()
     !haskey(avail,pkg) && !haskey(reqs,pkg) && return false
     rʹ = f(r,pkg,args...)
     rʹ == r && return false
-    reqsʹ = Reqs.parse(rʹ)
+    reqsʹ = Reqs.parse(rʹ,pkg=pkg)
     reqsʹ != reqs && resolve(reqsʹ,avail)
     Reqs.write("REQUIRE",rʹ)
     info("Package database updated")
@@ -34,9 +34,9 @@ function edit()
     editor !== nothing ||
         error("set the EDITOR environment variable to an edit command")
     editor = Base.shell_split(editor)
-    reqs = Reqs.parse("REQUIRE")
+    reqs = Reqs.parse("REQUIRE", pkg=pkg)
     run(`$editor REQUIRE`)
-    reqsʹ = Reqs.parse("REQUIRE")
+    reqsʹ = Reqs.parse("REQUIRE", pkg=pkg)
     reqs == reqsʹ && return info("Nothing to be done")
     info("Computing changes...")
     resolve(reqsʹ)
@@ -106,7 +106,7 @@ end
 
 function status(io::IO; pkgname::AbstractString = "")
     showpkg(pkg) = (pkgname == "") ? (true) : (pkg == pkgname)
-    reqs = Reqs.parse("REQUIRE")
+    reqs = Reqs.parse("REQUIRE", pkg=pkgname)
     instd = Read.installed()
     required = sort!(collect(keys(reqs)))
     if !isempty(required)
@@ -159,7 +159,7 @@ function clone(url::AbstractString, pkg::AbstractString)
     end
     info("Computing changes...")
     if !edit(Reqs.add, pkg)
-        isempty(Reqs.parse("$pkg/REQUIRE")) && return
+        isempty(Reqs.parse("$pkg/REQUIRE", pkg=pkg)) && return
         resolve()
     end
 end
@@ -303,7 +303,7 @@ function update(branch::AbstractString)
         end
     end
     info("Computing changes...")
-    resolve(Reqs.parse("REQUIRE"), avail, instd, fixed, free)
+    resolve(Reqs.parse("REQUIRE", pkg=pkg), avail, instd, fixed, free)
     # Don't use instd here since it may have changed
     updatehook(sort!(collect(keys(installed()))))
 end
@@ -706,10 +706,10 @@ end
 function test!(pkg::AbstractString, errs::Vector{AbstractString}, notests::Vector{AbstractString}; coverage::Bool=false)
     reqs_path = abspath(pkg,"test","REQUIRE")
     if isfile(reqs_path)
-        tests_require = Reqs.parse(reqs_path)
+        tests_require = Reqs.parse(reqs_path, pkg=pkg)
         if (!isempty(tests_require))
             info("Computing test dependencies for $pkg...")
-            resolve(merge(Reqs.parse("REQUIRE"), tests_require))
+            resolve(merge(Reqs.parse("REQUIRE",pkg=pkg), tests_require))
         end
     end
     test_path = abspath(pkg,"test","runtests.jl")

--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -130,10 +130,10 @@ function requires_path(pkg::AbstractString, avail::Dict=available(pkg))
 end
 
 requires_list(pkg::AbstractString, avail::Dict=available(pkg)) =
-    collect(keys(Reqs.parse(requires_path(pkg,avail))))
+    collect(keys(Reqs.parse(requires_path(pkg,avail),pkg=pkg)))
 
 requires_dict(pkg::AbstractString, avail::Dict=available(pkg)) =
-    Reqs.parse(requires_path(pkg,avail))
+    Reqs.parse(requires_path(pkg,avail),pkg=pkg)
 
 function installed(avail::Dict=available())
     pkgs = Dict{ByteString,Tuple{VersionNumber,Bool}}()


### PR DESCRIPTION
before:

``` julia
julia> Pkg.update()
INFO: Updating METADATA...
ERROR: invalid requires entry for julia: julia 0.3 - 0.5
 in error at ./error.jl:21
 in call at pkg/reqs.jl:29
 in read at pkg/reqs.jl:61
 in open at ./iostream.jl:114
 in parse at ./pkg/reqs.jl:101
 in requires_dict at pkg/read.jl:135
 in fixed at ./pkg/read.jl:154
 in update at ./pkg/entry.jl:289
 in anonymous at pkg/dir.jl:31
 in cd at ./file.jl:22
 in cd at pkg/dir.jl:31
 in update at ./pkg.jl:45
```

with this change:

``` julia
julia> Pkg.update()
INFO: Updating METADATA...
ERROR: parsing REQUIRE entry for package "NumericExtensions"
invalid requires entry for julia: julia 0.3 - 0.5
 in error at ./error.jl:21
 in call at pkg/reqs.jl:29
 in read at pkg/reqs.jl:61
 in open at ./iostream.jl:114
 in parse at ./pkg/reqs.jl:101
 in requires_dict at pkg/read.jl:135
 in fixed at ./pkg/read.jl:154
 in update at ./pkg/entry.jl:289
 in anonymous at pkg/dir.jl:31
 in cd at ./file.jl:22
 in cd at pkg/dir.jl:31
 in update at ./pkg.jl:45
```

closes #12395
