### PR TITLE
Remove unnecessary checkbounds from default Travis

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -177,7 +177,7 @@ function travis(pkg::AbstractString; force::Bool=false)
         # uncomment the following lines to override the default test script
         #script:
         #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-        #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("$pkg"); Pkg.test("$pkg"; coverage=true)'
+        #  - julia -e 'Pkg.clone(pwd()); Pkg.build("$pkg"); Pkg.test("$pkg"; coverage=true)'
         """)
     end
 end


### PR DESCRIPTION
`Pkg.test` executes Julia with this flag set if called with `coverage=true`. Placing the `--checkbounds` where it was was simply enabling bounds checking in the `Pkg.clone`, `Pkg.build` commands, which isn't what was intended.
