### PR TITLE
Add scale, scale! and copy! for triangular matrices

### DIFF
--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -125,6 +125,16 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         @test full(-A1) == -full(A1)
 
         # Binary operations
+        B = similar(A1)
+        copy!(B,A1)
+        @test B == A1
+        B = similar(A1.')
+        copy!(B, A1.')
+        @test B == A1.'
+        @test scale(A1,0.5) == 0.5*A1
+        @test scale(A1,0.5im) == 0.5im*A1
+        @test scale(A1.',0.5) == 0.5*A1.'
+        @test scale(A1.',0.5im) == 0.5im*A1.'
         @test A1*0.5 == full(A1)*0.5
         @test 0.5*A1 == 0.5*full(A1)
         @test A1/0.5 == full(A1)/0.5


### PR DESCRIPTION
Add the methods `scale!` and `copy!` for triangular matrices. This addition is motivated by a few improvements suggested by @stevengj in  #12584.

I tried to add the `scale` and `copy` methods as well. Not sure I did something reasonable there, as somewhere along the line I started listening to the compilation warnings without really understanding what was going on.
