### PR TITLE
inbounds and hoist field loading for dense * sparse

### DIFF
--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -94,8 +94,10 @@ function (*){TX,TvA,TiA}(X::StridedMatrix{TX}, A::SparseMatrixCSC{TvA,TiA})
     mX, nX = size(X)
     nX == A.m || throw(DimensionMismatch())
     Y = zeros(promote_type(TX,TvA), mX, A.n)
-    for multivec_row=1:mX, col = 1:A.n, k=A.colptr[col]:(A.colptr[col+1]-1)
-        Y[multivec_row, col] += X[multivec_row, A.rowval[k]] * A.nzval[k]
+    rowval = A.rowval
+    nzval = A.nzval
+    @inbounds for multivec_row=1:mX, col = 1:A.n, k=A.colptr[col]:(A.colptr[col+1]-1)
+        Y[multivec_row, col] += X[multivec_row, rowval[k]] * nzval[k]
     end
     Y
 end


### PR DESCRIPTION
I keep looking for low hanging fruits...

Before:

``` julia
julia> A = rand(300,300)

julia> B = sprand(300,10^5,0.01);

julia> @time A * B;
#  1.469583 seconds (6 allocations: 228.882 MB, 0.09% gc time)
```

After:

``` julia
julia> A = rand(300,300)

julia> B = sprand(300,10^5,0.01);

julia> @time A * B;
#  0.925440 seconds (6 allocations: 228.882 MB, 1.12% gc time)
```
