### PR TITLE
fix UnitRange's stop field for release-0.3

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -62,9 +62,16 @@ immutable UnitRange{T<:Real} <: OrdinalRange{T,Int}
     start::T
     stop::T
 
-    UnitRange(start, stop) = new(start, ifelse(stop >= start, stop, start-1))
+    UnitRange(start, stop) = new(start, unitrange_last(start,stop))
 end
 UnitRange{T<:Real}(start::T, stop::T) = UnitRange{T}(start, stop)
+
+unitrange_last(::Bool, stop::Bool) = stop
+unitrange_last{T<:Integer}(start::T, stop::T) =
+    ifelse(stop >= start, stop, convert(T,start-one(stop-start)))
+unitrange_last{T}(start::T, stop::T) =
+    ifelse(stop >= start, convert(T,start+floor(stop-start)),
+                          convert(T,start-one(stop-start)))
 
 colon(a::Real, b::Real) = colon(promote(a,b)...)
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -383,3 +383,7 @@ end
 @test eltype(0:1//3:10) <: Rational
 @test (0:1//3:10)[1] == 0
 @test (0:1//3:10)[2] == 1//3
+
+# issue #12534
+@test length([1:10//3]) == 3
+@test [1:10//3] == Rational[1:3]


### PR DESCRIPTION
backport from 0.4.0 of unitrange_last, fixes #12534
added tests
