### PR TITLE
ENH: enabled user keyword arg for Pkg.generate

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -63,8 +63,9 @@ publish() = cd(Entry.publish,Dir.getmetabranch())
 build() = cd(Entry.build)
 build(pkgs::AbstractString...) = cd(Entry.build,[pkgs...])
 
-generate(pkg::AbstractString, license::AbstractString; force::Bool=false, authors::Union{AbstractString,Array} = [], config::Dict=Dict()) =
-    cd(Generate.package,pkg,license,force=force,authors=authors,config=config)
+generate(pkg::AbstractString, license::AbstractString; force::Bool=false,
+         authors::Union{AbstractString,Array} = [], user=Generate.github_user(), config::Dict=Dict()) =
+    cd(Generate.package,pkg,license,force=force,authors=authors,user=user,config=config)
 
 
 test(;coverage::Bool=false) = cd(Entry.test; coverage=coverage)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -117,6 +117,16 @@ temp_pkg_dir() do
   end
 end
 
+# testing a package with `user` keyword argument set
+temp_pkg_dir() do
+  Pkg.generate("PackageNewUser", "MIT";
+               config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"),
+               user="newuser")
+  url = Pkg.Git.readchomp(`config --get remote.origin.url`, dir=Pkg.dir("PackageNewUser"))
+  @test split(url, '/')[4] == "newuser"
+end
+
+
 # Testing with code-coverage
 temp_pkg_dir() do
   Pkg.generate("PackageWithCodeCoverage", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))


### PR DESCRIPTION
We have this keyword arg in `Pkg.Generate.generate`, I thought we'd expose it
at the level we suggest users call
