### PR TITLE
make creation of .ji files atomic

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -2014,9 +2014,10 @@ DLLEXPORT jl_value_t *jl_uncompress_ast(jl_lambda_info_t *li, jl_value_t *data)
 
 DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist)
 {
+    char *tmpfname = strcat(strcpy((char *) alloca(strlen(fname)+8), fname), ".XXXXXX");
     ios_t f;
-    if (ios_file(&f, fname, 1, 1, 1, 1) == NULL) {
-        jl_printf(JL_STDERR, "Cannot open cache file \"%s\" for writing.\n", fname);
+    if (ios_mkstemp(&f, tmpfname) == NULL) {
+        jl_printf(JL_STDERR, "Cannot open cache file \"%s\" for writing.\n", tmpfname);
         return 1;
     }
     serializer_worklist = worklist;
@@ -2050,6 +2051,11 @@ DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist)
     arraylist_free(&reinit_list);
     ios_close(&f);
     JL_SIGATOMIC_END();
+
+    if (jl_fs_rename(tmpfname, fname) < 0) {
+        jl_printf(JL_STDERR, "Cannot write cache file \"%s\".\n", fname);
+        return 1;
+    }
 
     return 0;
 }

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -257,7 +257,7 @@ DLLEXPORT int jl_fs_unlink(char *path)
     return ret;
 }
 
-DLLEXPORT int jl_fs_rename(char *src_path, char *dst_path)
+DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path)
 {
     uv_fs_t req;
     JL_SIGATOMIC_BEGIN();
@@ -796,6 +796,7 @@ DLLEXPORT HANDLE jl_uv_handle(uv_stream_t *handle)
     }
 }
 #endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -209,6 +209,9 @@ extern uv_lib_t *jl_crtdll_handle;
 extern uv_lib_t *jl_winsock_handle;
 #endif
 
+// libuv wrappers:
+DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path);
+
 #if defined(_CPU_X86_) || defined(_CPU_X86_64_)
 #define HAVE_CPUID
 #endif

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -888,6 +888,35 @@ ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int tru
     return NULL;
 }
 
+// Portable ios analogue of mkstemp: modifies fname to replace
+// trailing XXXX's with unique ID and returns the file handle s
+// for writing and reading.
+ios_t *ios_mkstemp(ios_t *s, char *fname)
+{
+    int fd;
+    // would be better to use a libuv function once it exists (see libuv/libuv#322)
+#ifdef _OS_WINDOWS_
+    size_t wlen = MultiByteToWideChar(CP_UTF8, 0, fname, -1, NULL, 0);
+    if (!wlen) goto open_file_err;
+    wchar_t *fname_w = (wchar_t*)alloca(wlen*sizeof(wchar_t));
+    if (!MultiByteToWideChar(CP_UTF8, 0, fname, -1, fname_w, wlen) ||
+        !_wmktemp(fname_w) ||
+        !WideCharToMultiByte(CP_UTF8, 0, fname_w, -1, fname, strlen(fname)+1,
+                             NULL, NULL))
+        goto open_file_err;
+    fd = _wopen(fname_w, O_CREAT|O_TRUNC|O_RDWR | O_BINARY | O_NOINHERIT, _S_IREAD | _S_IWRITE);
+#else
+    fd = mkstemp(fname);
+#endif
+    ios_fd(s, fd, 1, 1);
+    if (fd == -1)
+        goto open_file_err;
+    return s;
+open_file_err:
+    s->fd = -1;
+    return NULL;
+}
+
 ios_t *ios_mem(ios_t *s, size_t initsize)
 {
     _ios_init(s);

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -100,6 +100,7 @@ DLLEXPORT size_t ios_readprep(ios_t *from, size_t n);
 /* stream creation */
 DLLEXPORT
 ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc);
+DLLEXPORT ios_t *ios_mkstemp(ios_t *f, char *fname);
 DLLEXPORT ios_t *ios_mem(ios_t *s, size_t initsize);
 ios_t *ios_str(ios_t *s, char *str);
 ios_t *ios_static_buffer(ios_t *s, char *buf, size_t sz);


### PR DESCRIPTION
This makes the creation of the `.ji` files more atomic, by first serializing to a temporary file and then atomically renaming this to the `.ji` file.

In general, this is the best practice for creating files anyway, and should help to avoid `.ji` corruption and similar race conditions when multiple `julia` processes are present.  (It may help with #12381, at least to eliminate crashes.)
