### PR TITLE
UTF32String: change the code unit to UInt32 instead of Char.

### DIFF
--- a/base/unicode/types.jl
+++ b/base/unicode/types.jl
@@ -19,16 +19,16 @@ end
 # \throws     UnicodeError
 
 immutable UTF32String <: DirectIndexString
-    data::Vector{Char} # includes 32-bit NULL termination after string chars
+    data::Vector{UInt32} # includes 32-bit NULL termination after string chars
 
-    function UTF32String(data::Vector{Char})
-        if length(data) < 1 || data[end] != Char(0)
+    function UTF32String(data::Vector{UInt32})
+        if length(data) < 1 || data[end] != 0
             throw(UnicodeError(UTF_ERR_NULL_32_TERMINATE, 0, 0))
         end
         new(data)
     end
 end
-UTF32String(data::Vector{UInt32}) = UTF32String(reinterpret(Char, data))
+UTF32String(data::Vector{Char}) = UTF32String(reinterpret(UInt32, data))
 
 isvalid{T<:Union{ASCIIString,UTF8String,UTF16String,UTF32String}}(str::T) = isvalid(T, str.data)
 isvalid{T<:Union{ASCIIString,UTF8String,UTF16String,UTF32String}}(::Type{T}, str::T) = isvalid(T, str.data)

--- a/base/unicode/utf16.jl
+++ b/base/unicode/utf16.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 # Quickly copy and set trailing \0
-@inline function fast_utf_copy{S <: Union{UTF16String, UTF32String}, T <: Union{UInt16, Char}}(
+@inline function fast_utf_copy{S <: Union{UTF16String, UTF32String}, T <: Union{UInt16, UInt32}}(
 			      ::Type{S}, ::Type{T}, len, dat, flag::Bool=false)
      S(setindex!(copy!(Vector{T}(len+1), 1, dat, 1, flag ? len : len+1), 0, len+1))
 end

--- a/test/unicode/utf32.jl
+++ b/test/unicode/utf32.jl
@@ -176,7 +176,7 @@ w = wstring(u8)
 @test u8 == WString(w.data)
 
 # 12268
-for (fun, S, T) in ((utf16, UInt16, UTF16String), (utf32, Char, UTF32String))
+for (fun, S, T) in ((utf16, UInt16, UTF16String), (utf32, UInt32, UTF32String))
     # AbstractString
     str = "abcd\0\uff\u7ff\u7fff\U7ffff"
     tst = SubString(convert(T,str),4)
@@ -187,7 +187,7 @@ for (fun, S, T) in ((utf16, UInt16, UTF16String), (utf32, Char, UTF32String))
     cmpx = (S == UInt16 ? cmp16 : cmpch)
     @test typeof(tst) == SubString{T}
     @test convert(T, tst) == str[4:end]
-    S != Char && @test convert(Vector{Char}, x) == cmp
+    S != UInt32 && @test convert(Vector{Char}, x) == cmp
     # Vector{T} / Array{T}
     @test convert(Vector{S}, x) == cmpx
     @test convert(Array{S}, x) == cmpx
@@ -224,7 +224,7 @@ let str = "this "
     @test unsafe_load(p8,1) == 0x74
     @test typeof(p16) == Ptr{UInt16}
     @test unsafe_load(p16,1) == 0x0074
-    @test typeof(p32) == Ptr{Char}
+    @test typeof(p32) == Ptr{UInt32}
     @test unsafe_load(p32,1) == 't'
     pa  = pointer(str, 2)
     p8  = pointer(u8,  2)
@@ -236,7 +236,7 @@ let str = "this "
     @test unsafe_load(p8,1) == 0x68
     @test typeof(p16) == Ptr{UInt16}
     @test unsafe_load(p16,1) == 0x0068
-    @test typeof(p32) == Ptr{Char}
+    @test typeof(p32) == Ptr{UInt32}
     @test unsafe_load(p32,1) == 'h'
     sa  = SubString{ASCIIString}(str, 3, 5)
     s8  = SubString{UTF8String}(u8,   3, 5)
@@ -252,7 +252,7 @@ let str = "this "
     @test unsafe_load(p8,1) == 0x69
     @test typeof(p16) == Ptr{UInt16}
     @test unsafe_load(p16,1) == 0x0069
-    @test typeof(p32) == Ptr{Char}
+    @test typeof(p32) == Ptr{UInt32}
     @test unsafe_load(p32,1) == 'i'
     pa  = pointer(sa, 2)
     p8  = pointer(s8,  2)
@@ -264,6 +264,6 @@ let str = "this "
     @test unsafe_load(p8,1) == 0x73
     @test typeof(p16) == Ptr{UInt16}
     @test unsafe_load(p16,1) == 0x0073
-    @test typeof(p32) == Ptr{Char}
+    @test typeof(p32) == Ptr{UInt32}
     @test unsafe_load(p32,1) == 's'
 end


### PR DESCRIPTION
These are conceptually different things: the fact that Char happens
to have the same in-memory representation as a UInt32 is incidental.
