### PR TITLE
Renaming Catalan's constant so Catalan numbers can be defined more na…

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -203,7 +203,6 @@ export
     π, pi,
     e, eu,
     γ, eulergamma,
-    catalan,
     φ, golden,
     I,
 

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -101,11 +101,10 @@ big(x::Irrational) = convert(BigFloat,x)
 
 ## specific irriational mathematical constants
 
-@irrational π        3.14159265358979323846  pi
-@irrational e        2.71828182845904523536  exp(big(1))
-@irrational γ        0.57721566490153286061  euler
-@irrational catalan  0.91596559417721901505  catalan
-@irrational φ        1.61803398874989484820  (1+sqrt(big(5)))/2
+@irrational π  3.14159265358979323846  pi
+@irrational e  2.71828182845904523536  exp(big(1))
+@irrational γ  0.57721566490153286061  euler
+@irrational φ  1.61803398874989484820  (1+sqrt(big(5)))/2
 
 # aliases
 const pi = π

--- a/contrib/julia.xml
+++ b/contrib/julia.xml
@@ -319,7 +319,6 @@
       <item> eu </item>
       <item> γ </item>
       <item> eulergamma </item>
-      <item> catalan </item>
       <item> φ </item>
       <item> golden </item>
     </list>

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -181,10 +181,6 @@ General Number Functions and Constants
 
    The constant e
 
-.. data:: catalan
-
-   Catalan's constant
-
 .. data:: γ
           eulergamma
 

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -110,7 +110,7 @@ end
 for T in [Float32,Float64]
     for v in [sqrt(big(2.0)),-big(1.0)/big(3.0),nextfloat(big(1.0)),
               prevfloat(big(1.0)),nextfloat(big(0.0)),prevfloat(big(0.0)),
-              pi,e,eulergamma,catalan,golden,
+              pi,e,eulergamma,golden,
               typemax(Int64),typemax(UInt64),typemax(Int128),typemax(UInt128),0xa2f30f6001bb2ec6]
         pn = T(v,RoundNearest)
         @test pn == convert(T,BigFloat(v))


### PR DESCRIPTION
…turally.

This is just an idea to float so the `catalan` function in `Combinatorics.jl` won't be in conflict with the constant `Base.catalan`.  I just renamed `catalan` -> `catalan_const`.  Any comments are welcome!
