### PR TITLE
add support for `enumerate` with starting index

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -19,6 +19,25 @@ done(e::Enumerate, state) = done(e.itr, state[2])
 
 eltype{I}(::Type{Enumerate{I}}) = Tuple{Int, eltype(I)}
 
+
+immutable EnumerateFrom{I}
+    itr::I
+    start::Int
+end
+
+enumerate(itr, start) = EnumerateFrom(itr, start)
+
+length(e::EnumerateFrom) = length(e.itr) - (e.start - 1)
+start(e::EnumerateFrom) = (e.start, Base.start(e.itr))
+function next(e::EnumerateFrom, state)
+    n = next(e.itr, state[2])
+    (state[1],n[1]), (state[1]+1,n[2])
+end
+done(e::EnumerateFrom, state) = done(e.itr, state[2])
+
+eltype{I}(::Type{EnumerateFrom{I}}) = Tuple{Int, eltype(I)}
+
+
 # zip
 
 abstract AbstractZipIterator


### PR DESCRIPTION
Often, I want to subsets of an array. But, if I need to update an element, I must translate the enumerated index. For example:

``` julia
xs = [10, 20, 30, 40]
for (i, x) in enumerate(xs[2:end])
    if x > 20
        xs[i+1] = -x
    end
end
```

I'd like to be able to specify where the enumeration should start. For example:

``` julia
xs = [10, 20, 30, 40]
for (i, x) in enumerate(xs[2:end], 2)
    if x > 20
        xs[i] = -x
    end
end
```

This matches the [style I have grown used to in Python](https://docs.python.org/2/library/functions.html#enumerate). I add this support to the base by creating an `EnumerateFrom` type. I think this is more appropriate than modifying the original `Enumerate` type.
