### PR TITLE
RFC: deprecate `cartesianmap`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -515,6 +515,8 @@ Deprecated or removed
 
   * `require(::AbstractString)` and `reload` (see news about addition of `compile`)
 
+  * `cartesianmap` is deprecated in favor of iterating over a `CartesianRange`
+
 Julia v0.3.0 Release Notes
 ==========================
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1118,57 +1118,6 @@ end
 
 ## iteration utilities ##
 
-# slow, but useful
-function cartesianmap(body, t::Tuple{Vararg{Int}}, it...)
-    idx = length(t)-length(it)
-    if idx == 1
-        for i = 1:t[1]
-            body(i, it...)
-        end
-    elseif idx == 2
-        for j = 1:t[2]
-            for i = 1:t[1]
-                body(i, j, it...)
-            end
-        end
-    elseif idx > 1
-        for j = 1:t[idx]
-            for i = 1:t[idx-1]
-                cartesianmap(body, t, i, j, it...)
-            end
-        end
-    else
-        throw(ArgumentError("cartesianmap length(t) - length(it) ≤ 0"))
-    end
-end
-
-cartesianmap(body, t::Tuple{}) = (body(); nothing)
-
-function cartesianmap(body, t::Tuple{Int,})
-    for i = 1:t[1]
-        body(i)
-    end
-end
-
-function cartesianmap(body, t::Tuple{Int,Int})
-    for j = 1:t[2]
-        for i = 1:t[1]
-            body(i,j)
-        end
-    end
-end
-
-function cartesianmap(body, t::Tuple{Int,Int,Int})
-    for k = 1:t[3]
-        for j = 1:t[2]
-            for i = 1:t[1]
-                body(i,j,k)
-            end
-        end
-    end
-end
-
-##
 # generic map on any iterator
 function map(f, iters...)
     result = []
@@ -1242,13 +1191,14 @@ function mapslices(f, A::AbstractArray, dims::AbstractVector)
     R[ridx...] = r1
 
     first = true
-    cartesianmap(itershape) do idxs...
+    nidx = length(otherdims)
+    for I in CartesianRange(itershape)
         if first
             first = false
         else
-            ia = [idxs...]
-            idx[otherdims] = ia
-            ridx[otherdims] = ia
+            for i in 1:nidx
+                idx[otherdims[i]] = ridx[otherdims[i]] = I.I[i]
+            end
             R[ridx...] = f(reshape(A[idx...], Asliceshape))
         end
     end

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -550,19 +550,6 @@ end
 
 writedlm{T}(io::IO, a::AbstractArray{T,0}, dlm; opts...) = writedlm(io, reshape(a,1), dlm; opts...)
 
-#=
-function writedlm_ndarray(io::IO, a::AbstractArray, dlm; opts...)
-    tail = size(a)[3:end]
-    function print_slice(idxs...)
-        writedlm(io, sub(a, 1:size(a,1), 1:size(a,2), idxs...), dlm; opts...)
-        if idxs != tail
-            print(io, "\n")
-        end
-    end
-    cartesianmap(print_slice, tail)
-end
-=#
-
 function writedlm(io::IO, itr, dlm; opts...)
     optsd = val_opts(opts)
     quotes = get(optsd, :quotes, true)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -32,6 +32,7 @@ macro deprecate(old,new)
                   $(esc(new))(args...)
               end))
     elseif isa(old,Expr) && old.head == :call
+        remove_linenums!(new)
         oldcall = sprint(io->show_unquoted(io,old))
         newcall = sprint(io->show_unquoted(io,new))
         oldsym = if isa(old.args[1],Symbol)
@@ -53,6 +54,15 @@ macro deprecate(old,new)
     else
         error("invalid usage of @deprecate")
     end
+end
+
+remove_linenums!(ex) = ex
+function remove_linenums!(ex::Expr)
+    filter!(x->!((isa(x,Expr) && is(x.head,:line)) || isa(x,LineNumberNode)), ex.args)
+    for subex in ex.args
+        remove_linenums!(subex)
+    end
+    ex
 end
 
 function depwarn(msg, funcsym)
@@ -782,3 +792,5 @@ function Regex(pattern::AbstractString, options::Integer)
             "use string flags instead: Regex(\"$pattern\", \"$flags\").", :Regex)
     Regex(pattern, flags)
 end
+
+@deprecate cartesianmap(f, dims) for idx in CartesianRange(dims); f(idx.I...); end

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -5561,26 +5561,6 @@ doc"""
 svdfact!
 
 doc"""
-```rst
-::
-
-           cartesianmap(f, dims)
-
-Given a ``dims`` tuple of integers ``(m, n, ...)``, call ``f`` on all combinations of
-integers in the ranges ``1:m``, ``1:n``, etc.
-
-.. doctest::
-
-   julia> cartesianmap(println, (2,2))
-   11
-   21
-   12
-   22
-```
-"""
-cartesianmap
-
-doc"""
     hist2d(M, e1, e2) -> (edge1, edge2, counts)
 
 Compute a "2d histogram" of a set of N points specified by N-by-2 matrix `M`. Arguments `e1` and `e2` are bins for each dimension, specified either as integer bin counts or vectors of bin edges. The result is a tuple of `edge1` (the bin edges used in the first dimension), `edge2` (the bin edges used in the second dimension), and `counts`, a histogram matrix of size `(length(edge1)-1, length(edge2)-1)`. Note: Julia does not ignore `NaN` values in the computation.

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -499,7 +499,6 @@ export
     broadcast_function,
     broadcast_getindex,
     broadcast_setindex!,
-    cartesianmap,
     cat,
     cell,
     checkbounds,

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -148,8 +148,9 @@ function write{T,N,A<:Array}(s::IOStream, a::SubArray{T,N,A})
     if N<=1
         return write(s, pointer(a, 1), colsz)
     else
-        cartesianmap((idxs...)->write(s, pointer(a, idxs), colsz),
-                     tuple(1, size(a)[2:end]...))
+        for idxs in CartesianRange((1, size(a)[2:end]...))
+            write(s, pointer(a, idxs.I), colsz)
+        end
         return colsz*trailingsize(a,2)
     end
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -1132,7 +1132,8 @@ function show_nd(io::IO, a::AbstractArray, limit, print_matrix, label_slices)
     end
     tail = size(a)[3:end]
     nd = ndims(a)-2
-    function print_slice(idxs...)
+    for I in CartesianRange(tail)
+        idxs = I.I
         if limit
             for i = 1:nd
                 ii = idxs[i]
@@ -1141,15 +1142,15 @@ function show_nd(io::IO, a::AbstractArray, limit, print_matrix, label_slices)
                         for j=i+1:nd
                             szj = size(a,j+2)
                             if szj>10 && 3 < idxs[j] <= szj-3
-                                return
+                                @goto skip
                             end
                         end
                         #println(io, idxs)
                         print(io, "...\n\n")
-                        return
+                        @goto skip
                     end
                     if 3 < ii <= size(a,i+2)-3
-                        return
+                        @goto skip
                     end
                 end
             end
@@ -1162,8 +1163,8 @@ function show_nd(io::IO, a::AbstractArray, limit, print_matrix, label_slices)
         slice = sub(a, 1:size(a,1), 1:size(a,2), idxs...)
         print_matrix(io, slice)
         print(io, idxs == tail ? "" : "\n\n")
+        @label skip
     end
-    cartesianmap(print_slice, tail)
 end
 
 function whos(m::Module, pattern::Regex)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -43,7 +43,9 @@ Base.convert{T,N  }(::Type{TSlow     }, X::AbstractArray{T,N}) = convert(TSlow{T
 Base.convert{T,N,_}(::Type{TSlow{T  }}, X::AbstractArray{_,N}) = convert(TSlow{T,N}, X)
 Base.convert{T,N  }(::Type{TSlow{T,N}}, X::AbstractArray     ) = begin
     A = TSlow(T, size(X))
-    cartesianmap((I...)->(A[I...] = X[I...]), size(X))
+    for I in CartesianRange(size(X))
+        A[I.I...] = X[I.I...]
+    end
     A
 end
 
@@ -371,17 +373,6 @@ function test_ind2sub(::Type{TestAbstractArray})
     end
 end
 
-function test_cartesianmap(::Type{TestAbstractArray})
-    f(x, y, z, B::Array) = push!(B, (x, y, z))
-    B = NTuple{3, Int}[]
-    cartesianmap(f, (3, 3, 3, 1), B)
-    @test B == NTuple{3, Int}[(1,1,1), (2,1,1), (3,1,1), (1,2,1), (2,2,1), (3,2,1),
-        (1,3,1), (2,3,1), (3,3,1), (1,1,2), (2,1,2), (3,1,2), (1,2,2), (2,2,2),
-        (3,2,2), (1,3,2), (2,3,2), (3,3,2), (1,1,3), (2,1,3), (3,1,3), (1,2,3),
-        (2,2,3), (3,2,3), (1,3,3), (2,3,3), (3,3,3)]
-    @test_throws ArgumentError cartesianmap(f, (1,), B)
-end
-
 type GenericIterator{N} end
 Base.start{N}(::GenericIterator{N}) = 1
 Base.next{N}(::GenericIterator{N}, i) = (i, i + 1)
@@ -479,7 +470,6 @@ test_setindex!_internals(TestAbstractArray)
 test_get(TestAbstractArray)
 test_cat(TestAbstractArray)
 test_ind2sub(TestAbstractArray)
-test_cartesianmap(TestAbstractArray)
 test_map(TestAbstractArray)
 test_map_promote(TestAbstractArray)
 test_UInt_indexing(TestAbstractArray)


### PR DESCRIPTION
This function is redundant with `CartesianRange`, and is also a performance trap. We could eventually fix the performance, but I think there are enough other problems with this function. It's not really a `map`, but more like a `cartesian_foreach`, so it's misnamed plus its behavior is a bit odd. I think in the future we will want to use product iterators and/or CartesianRange instead.

It's a bit awkward that CartesianRange provides a CartesianIndex instead of a tuple. I'm not sure what to do about that, but it seems OK for now.
