### PR TITLE
fail to load modules if precompilation fails

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -626,7 +626,8 @@ static void julia_save()
             return;
         }
         if (jl_options.outputji)
-            jl_save_incremental(jl_options.outputji, worklist);
+            if (jl_save_incremental(jl_options.outputji, worklist))
+                jl_exit(1);
         if (jl_options.outputbc)
             jl_printf(JL_STDERR, "WARNING: incremental output to a .bc file is not implemented\n");
         if (jl_options.outputo)

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -59,6 +59,28 @@ try
     end
     println(STDERR, "\nNOTE: The following 'LoadError: __precompile__(false)' indicates normal operation")
     @test_throws ErrorException Base.compilecache("Baz") # from __precompile__(false)
+
+    # Issue #12720
+    FooBar_file = joinpath(dir, "FooBar.jl")
+    open(FooBar_file, "w") do f
+        print(f, """
+              __precompile__(true)
+              module FooBar
+              end
+              """)
+    end
+    Base.compilecache("FooBar")
+    sleep(2)
+    open(FooBar_file, "w") do f
+        print(f, """
+              __precompile__(true)
+              module FooBar
+              error("break me")
+              end
+              """)
+    end
+    println(STDERR, "\nNOTE: The following 'LoadError: break me' indicates normal operation")
+    @test_throws ErrorException require(:FooBar)
 finally
     splice!(Base.LOAD_CACHE_PATH, 1)
     splice!(LOAD_PATH, 1)


### PR DESCRIPTION
This fixes #12720: if precompilation fails for any reason, we should fail to load the module, even if an otherwise-valid (but stale) `.ji` file exists.
