### PR TITLE
RFC: Implement @__LINE__ macro

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,7 @@ New language features
     Default continues to be of length 1 ([#12385]).
     See http://docs.julialang.org/en/latest/manual/parallel-computing/#remoterefs-and-abstractchannels for details.
 
+  * `@__LINE__` special macro now available to reflect invocation source line number ([#12727]).
 
 Language changes
 ----------------

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -2,6 +2,8 @@
 
 # Base.LinAlg.BLAS
 
+import .Docs: keywords
+
 doc"""
     ger!(alpha, x, y, A)
 
@@ -9537,12 +9539,20 @@ Returns an iterator over substrings of `s` that correspond to the extended graph
 """
 graphemes
 
-doc"""
+keywords[symbol("@__FILE__")] = doc"""
+
     @__FILE__() -> AbstractString
 
-`@__FILE__` expands to a string with the absolute path and file name of the script being run. Returns `nothing` if run from a REPL or an empty string if evaluated by `julia -e <expr>`.
+`@__FILE__` expands to a string with the absolute path and file name of the script being run.
+Returns `"none"` if run from a REPL or command-line context.
 """
-:@__FILE__
+
+keywords[symbol("@__LINE__")] = doc"""
+
+    @__LINE__() -> Int
+
+`@__LINE__` expands to the line number of the call-site.
+"""
 
 doc"""
     charwidth(c)

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2039,14 +2039,17 @@
            (with-space-sensitive
             (let* ((head (parse-unary-prefix s))
                    (t    (peek-token s)))
-              (if (ts:space? s)
+              (cond
+                 ((eqv? head '__LINE__) (input-port-line (ts:port s)))
+                 ((ts:space? s)
                   `(macrocall ,(macroify-name head)
-                              ,@(parse-space-separated-exprs s))
-                  (let ((call (parse-call-chain s head #t)))
-                    (if (and (pair? call) (eq? (car call) 'call))
+                              ,@(parse-space-separated-exprs s)))
+                 (else
+                   (let ((call (parse-call-chain s head #t)))
+                      (if (and (pair? call) (eq? (car call) 'call))
                         `(macrocall ,(macroify-name (cadr call)) ,@(cddr call))
                         `(macrocall ,(macroify-name call)
-                                    ,@(parse-space-separated-exprs s))))))))
+                                    ,@(parse-space-separated-exprs s)))))))))
 
           ;; command syntax
           ((eqv? t #\`)

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -2,6 +2,8 @@
 
 using Base.Test
 
+@test @__LINE__ == 5
+
 include("test_sourcepath.jl")
 thefname = "the fname!//\\&\0\1*"
 @test include_string("include_string_test() = @__FILE__", thefname)() == Base.source_path()


### PR DESCRIPTION
(upated) Implements `__LINE__` and `__FILE__` magic macros returning the line number (integer) and filename (as string) for a given call location.

Fixes #8066

~~_This is what happens when you force the riff-raff to learn a little scheme._~~
