### PR TITLE
Remove string.reverse from flisp and u8_reverse from utf8.c

### DIFF
--- a/src/flisp/string.c
+++ b/src/flisp/string.c
@@ -73,17 +73,6 @@ value_t fl_string_width(value_t *args, u_int32_t nargs)
     return size_wrap(u8_strwidth(s));
 }
 
-value_t fl_string_reverse(value_t *args, u_int32_t nargs)
-{
-    argcount("string.reverse", nargs, 1);
-    if (!fl_isstring(args[0]))
-        type_error("string.reverse", "string", args[0]);
-    size_t len = cv_len((cvalue_t*)ptr(args[0]));
-    value_t ns = cvalue_string(len);
-    u8_reverse((char*)cvalue_data(ns), (char*)cvalue_data(args[0]), len);
-    return ns;
-}
-
 value_t fl_string_encode(value_t *args, u_int32_t nargs)
 {
     argcount("string.encode", nargs, 1);
@@ -416,7 +405,6 @@ static builtinspec_t stringfunc_info[] = {
     { "string.char", fl_string_char },
     { "string.inc", fl_string_inc },
     { "string.dec", fl_string_dec },
-    { "string.reverse", fl_string_reverse },
     { "string.encode", fl_string_encode },
     { "string.decode", fl_string_decode },
     { "string.isutf8", fl_string_isutf8 },

--- a/src/support/utf8.c
+++ b/src/support/utf8.c
@@ -489,24 +489,6 @@ size_t u8_escape(char *buf, size_t sz, const char *src, size_t *pi, size_t end,
     return (buf-start);
 }
 
-char *u8_strchr(const char *s, uint32_t ch, size_t *charn)
-{
-    size_t i = 0, lasti=0;
-    uint32_t c;
-
-    *charn = 0;
-    while (s[i]) {
-        c = u8_nextchar(s, &i);
-        if (c == ch) {
-            /* it's const for us, but not necessarily the caller */
-            return (char*)&s[lasti];
-        }
-        lasti = i;
-        (*charn)++;
-    }
-    return NULL;
-}
-
 char *u8_memchr(const char *s, uint32_t ch, size_t sz, size_t *charn)
 {
     size_t i = 0, lasti=0;
@@ -673,47 +655,6 @@ chkutf8:
     }
     return 2;   // Valid UTF-8
 }
-
-int u8_reverse(char *dest, char *src, size_t len)
-{
-    size_t si=0, di=len;
-    unsigned char c;
-
-    dest[di] = '\0';
-    while (si < len) {
-        c = (unsigned char)src[si];
-        if ((~c) & 0x80) {
-            di--;
-            dest[di] = c;
-            si++;
-        }
-        else {
-            switch (c>>4) {
-            case 0xC:
-            case 0xD:
-                di -= 2;
-                *((int16_t*)&dest[di]) = *((int16_t*)&src[si]);
-                si += 2;
-                break;
-            case 0xE:
-                di -= 3;
-                dest[di] = src[si];
-                *((int16_t*)&dest[di+1]) = *((int16_t*)&src[si+1]);
-                si += 3;
-                break;
-            case 0xF:
-                di -= 4;
-                *((int32_t*)&dest[di]) = *((int32_t*)&src[si]);
-                si += 4;
-                break;
-            default:
-                return 1;
-            }
-        }
-    }
-    return 0;
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/support/utf8.h
+++ b/src/support/utf8.h
@@ -85,10 +85,6 @@ size_t u8_escape(char *buf, size_t sz, const char *src, size_t *pi, size_t end,
 int octal_digit(char c);
 int hex_digit(char c);
 
-/* return a pointer to the first occurrence of ch in s, or NULL if not
-   found. character index of found character returned in *charn. */
-char *u8_strchr(const char *s, uint32_t ch, size_t *charn);
-
 /* same as the above, but searches a buffer of a given size instead of
    a NUL-terminated string. */
 char *u8_memchr(const char *s, uint32_t ch, size_t sz, size_t *charn);
@@ -108,10 +104,6 @@ size_t u8_printf(const char *fmt, ...);
 
 /* determine whether a sequence of bytes is valid UTF-8. length is in bytes */
 DLLEXPORT int u8_isvalid(const char *str, size_t length);
-
-/* reverse a UTF-8 string. len is length in bytes. dest and src must both
-   be allocated to at least len+1 bytes. returns 1 for error, 0 otherwise */
-DLLEXPORT int u8_reverse(char *dest, char *src, size_t len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The flisp `string.reverse` does not appear to be used anywhere (at least, not in JuliaLang/julia), and depends on the function `u8_reverse` that has the potential of access violations if there is invalid data at the end of a string.
Removing it will eliminate the problem, and save a small amount of space.
