### PR TITLE
Fix generic_matvecmul! for cases where zero(eltype(C)) is not defined.

### DIFF
--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -132,3 +132,14 @@ let A = [1+2im 3+4im; 5+6im 7+8im], B = [2+7im 4+1im; 3+8im 6+5im]
         end
     end
 end
+
+# Issue 11978
+A = Array(Matrix{Float64}, 2, 2)
+A[1,1] = eye(3)
+A[1,2] = eye(3,2)
+A[2,1] = eye(2,3)
+A[2,2] = eye(2)
+b = Array(Vector{Float64}, 2)
+b[1] = ones(3)
+b[2] = ones(2)
+@test A*b == Vector{Float64}[[2,2,1], [2,2]]


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#225.

Fix type instability in generic_matmatmul! when addition changes the element type, e.g. for Bool.

With these changes the return array element type is only used when the arrays are empty. We therefore get the right type for

``` jl
julia> big(randn(2,0))*big(randn(0,0))
2x0 Array{Base.MPFR.BigFloat,2}
```

and

``` jl
julia> big(randn(2,0))*big(randn(0))
2-element Array{Base.MPFR.BigFloat,1}:
 0.000000000000000000000000000000000000000000000000000000000000000000000000000000
 0.000000000000000000000000000000000000000000000000000000000000000000000000000000
```

and can now also do

``` jl
julia> fill(eye(2), (2,2))*fill(eye(2), 2)
2-element Array{Array{Float64,2},1}:
 2x2 Array{Float64,2}:
 2.0  0.0
 0.0  2.0
 2x2 Array{Float64,2}:
 2.0  0.0
 0.0  2.0
```

but we have to throw an error when multiplying empty matrices with element types that don't support `zero`. We can probably live with that for a while.
