### PR TITLE
Follow up changes for InitError

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -53,19 +53,24 @@ _gmp_clear_func = C_NULL
 _mpfr_clear_func = C_NULL
 
 function __init__()
-    if gmp_version().major != GMP_VERSION.major || gmp_bits_per_limb() != GMP_BITS_PER_LIMB
-        error(string("The dynamically loaded GMP library (version $(gmp_version()) with __gmp_bits_per_limb == $(gmp_bits_per_limb()))\n",
-                     "does not correspond to the compile time version (version $GMP_VERSION with __gmp_bits_per_limb == $GMP_BITS_PER_LIMB).\n",
-                     "Please rebuild Julia."))
-    end
+    try
+        if gmp_version().major != GMP_VERSION.major || gmp_bits_per_limb() != GMP_BITS_PER_LIMB
+            error(string("The dynamically loaded GMP library (version $(gmp_version()) with __gmp_bits_per_limb == $(gmp_bits_per_limb()))\n",
+                         "does not correspond to the compile time version (version $GMP_VERSION with __gmp_bits_per_limb == $GMP_BITS_PER_LIMB).\n",
+                         "Please rebuild Julia."))
+        end
 
-    global _gmp_clear_func = cglobal((:__gmpz_clear, :libgmp))
-    global _mpfr_clear_func = cglobal((:mpfr_clear, :libmpfr))
-    ccall((:__gmp_set_memory_functions, :libgmp), Void,
-          (Ptr{Void},Ptr{Void},Ptr{Void}),
-          cglobal(:jl_gc_counted_malloc),
-          cglobal(:jl_gc_counted_realloc_with_old_size),
-          cglobal(:jl_gc_counted_free))
+        global _gmp_clear_func = cglobal((:__gmpz_clear, :libgmp))
+        global _mpfr_clear_func = cglobal((:mpfr_clear, :libmpfr))
+        ccall((:__gmp_set_memory_functions, :libgmp), Void,
+              (Ptr{Void},Ptr{Void},Ptr{Void}),
+              cglobal(:jl_gc_counted_malloc),
+              cglobal(:jl_gc_counted_realloc_with_old_size),
+              cglobal(:jl_gc_counted_free))
+    catch ex
+        Base.showerror_nostdio(ex,
+            "WARNING: Error during initialization of module GMP")
+    end
 end
 
 widen(::Type{Int128})  = BigInt

--- a/base/linalg.jl
+++ b/base/linalg.jl
@@ -236,9 +236,14 @@ include("linalg/arpack.jl")
 include("linalg/arnoldi.jl")
 
 function __init__()
-    Base.check_blas()
-    if Base.blas_vendor() == :mkl
-        ccall((:MKL_Set_Interface_Layer, Base.libblas_name), Void, (Cint,), USE_BLAS64 ? 1 : 0)
+    try
+        Base.check_blas()
+        if Base.blas_vendor() == :mkl
+            ccall((:MKL_Set_Interface_Layer, Base.libblas_name), Void, (Cint,), USE_BLAS64 ? 1 : 0)
+        end
+    catch ex
+        Base.showerror_nostdio(ex,
+            "WARNING: Error during initialization of module LinAlg")
     end
 end
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -30,9 +30,14 @@ import Base.GMP: ClongMax, CulongMax, CdoubleMax
 import Base.Math.lgamma_r
 
 function __init__()
-    # set exponent to full range by default
-    set_emin!(get_emin_min())
-    set_emax!(get_emax_max())
+    try
+        # set exponent to full range by default
+        set_emin!(get_emin_min())
+        set_emax!(get_emax_max())
+    catch ex
+        Base.showerror_nostdio(ex,
+            "WARNING: Error during initialization of module MPFR")
+    end
 end
 
 const ROUNDING_MODE = Cint[0]

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -12,15 +12,20 @@ global JIT_STACK = C_NULL
 global MATCH_CONTEXT = C_NULL
 
 function __init__()
-    JIT_STACK_START_SIZE = 32768
-    JIT_STACK_MAX_SIZE = 1048576
-    global JIT_STACK = ccall((:pcre2_jit_stack_create_8, PCRE_LIB), Ptr{Void},
-                             (Cint, Cint, Ptr{Void}),
-                             JIT_STACK_START_SIZE, JIT_STACK_MAX_SIZE, C_NULL)
-    global MATCH_CONTEXT = ccall((:pcre2_match_context_create_8, PCRE_LIB),
-                                 Ptr{Void}, (Ptr{Void},), C_NULL)
-    ccall((:pcre2_jit_stack_assign_8, PCRE_LIB), Void,
-          (Ptr{Void}, Ptr{Void}, Ptr{Void}), MATCH_CONTEXT, C_NULL, JIT_STACK)
+    try
+        JIT_STACK_START_SIZE = 32768
+        JIT_STACK_MAX_SIZE = 1048576
+        global JIT_STACK = ccall((:pcre2_jit_stack_create_8, PCRE_LIB), Ptr{Void},
+                                 (Cint, Cint, Ptr{Void}),
+                                 JIT_STACK_START_SIZE, JIT_STACK_MAX_SIZE, C_NULL)
+        global MATCH_CONTEXT = ccall((:pcre2_match_context_create_8, PCRE_LIB),
+                                     Ptr{Void}, (Ptr{Void},), C_NULL)
+        ccall((:pcre2_jit_stack_assign_8, PCRE_LIB), Void,
+              (Ptr{Void}, Ptr{Void}, Ptr{Void}), MATCH_CONTEXT, C_NULL, JIT_STACK)
+    catch ex
+        Base.showerror_nostdio(ex,
+            "WARNING: Error during initialization of module PCRE")
+    end
 end
 
 # supported options for different use cases

--- a/base/random.jl
+++ b/base/random.jl
@@ -128,7 +128,14 @@ randjump(r::MersenneTwister, jumps::Integer) = randjump(r, jumps, dSFMT.JPOLY1e2
 
 ## initialization
 
-__init__() = srand()
+function __init__()
+    try
+        srand()
+    catch ex
+        Base.showerror_nostdio(ex,
+            "WARNING: Error during initialization of module Random")
+    end
+end
 
 
 ## make_seed()

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -591,13 +591,8 @@ jl_value_t *jl_parse_eval_all(const char *fname, size_t len)
             jl_rethrow();
         }
         else {
-            if(jl_typeis(jl_exception_in_transit, jl_initerror_type)) {
-                jl_rethrow();
-            }
-            else {
-                jl_rethrow_other(jl_new_struct(jl_loaderror_type, fn, ln,
-                                               jl_exception_in_transit));
-            }
+            jl_rethrow_other(jl_new_struct(jl_loaderror_type, fn, ln,
+                                           jl_exception_in_transit));
         }
     }
     jl_stop_parsing();

--- a/test/core.jl
+++ b/test/core.jl
@@ -673,7 +673,7 @@ end
 @test names(Module(:anonymous, false), true, true) == [:anonymous]
 
 # exception from __init__()
-let t =
+let didthrow =
     try
         include_string(
             """
@@ -687,7 +687,7 @@ let t =
         @test isa(ex.error, InitError)
         true
     end
-    @test t
+    @test didthrow
 end
 
 # issue #7307

--- a/test/core.jl
+++ b/test/core.jl
@@ -673,12 +673,22 @@ end
 @test names(Module(:anonymous, false), true, true) == [:anonymous]
 
 # exception from __init__()
-@test_throws InitError include_string(
-    """
-    module TestInitError
-        __init__() = error()
+let t =
+    try
+        include_string(
+            """
+            module TestInitError
+                __init__() = error()
+            end
+            """)
+        false
+    catch ex
+        @test isa(ex, LoadError)
+        @test isa(ex.error, InitError)
+        true
     end
-    """)
+    @test t
+end
 
 # issue #7307
 function test7307(a, ret)


### PR DESCRIPTION
Per the comments in #12576, this no longer escapes `InitError`s from being wrapped in `LoadError`s.

I also wrapped all the Base submodule `__init__` functions that use external libraries in `try` ... `catch` so they don't throw but I'm not sure if it's the best approach to take.
