### PR TITLE
Bug fixes, better error messages, and tests for Tridiag, Bidiag, and BLAS

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -61,9 +61,9 @@ promote_rule{T,S}(::Type{Matrix{T}}, ::Type{Bidiagonal{S}})=Matrix{promote_type(
 
 #Converting from Bidiagonal to Tridiagonal
 Tridiagonal{T}(M::Bidiagonal{T}) = convert(Tridiagonal{T}, M)
-function convert{T}(::Type{Tridiagonal{T}}, A::Bidiagonal{T})
+function convert{T}(::Type{Tridiagonal{T}}, A::Bidiagonal)
     z = zeros(T, size(A)[1]-1)
-    A.isupper ? Tridiagonal(z, A.dv, A.ev) : Tridiagonal(A.ev, A.dv, z)
+    A.isupper ? Tridiagonal(z, convert(Vector{T},A.dv), convert(Vector{T},A.ev)) : Tridiagonal(convert(Vector{T},A.ev), convert(Vector{T},A.dv), z)
 end
 promote_rule{T,S}(::Type{Tridiagonal{T}}, ::Type{Bidiagonal{S}})=Tridiagonal{promote_type(T,S)}
 

--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -70,6 +70,10 @@ function convert(::Type{SymTridiagonal}, A::Tridiagonal)
     SymTridiagonal(A.d, A.dl)
 end
 
+function convert(::Type{Tridiagonal}, A::SymTridiagonal)
+    Tridiagonal(copy(A.ev), A.dv, A.ev)
+end
+
 function convert(::Type{Diagonal}, A::AbstractTriangular)
     if full(A) != diagm(diag(A))
         throw(ArgumentError("matrix cannot be represented as Diagonal"))

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -176,3 +176,10 @@ let A = Bidiagonal([1,2,3], [0,0], true)
     @test istril(A)
     @test isdiag(A)
 end
+
+#test promote_rule
+A = Bidiagonal(ones(Float32,10),ones(Float32,9),true)
+B = rand(Float64,10,10)
+C = Tridiagonal(rand(Float64,9),rand(Float64,10),rand(Float64,9))
+@test promote(B,A) == (B,convert(Matrix{Float64},full(A)))
+@test promote(C,A) == (C,Tridiagonal(zeros(Float64,9),convert(Vector{Float64},A.dv),convert(Vector{Float64},A.ev)))


### PR DESCRIPTION
Some of the code in `tridiag.jl` was obviated by `special.jl`. I checked that it was not called and removed it. I added a missing convert method to `special.jl`. Hopefully this gets `tridiag.jl` to 100% coverage!

BLAS gets a bunch more tests and more verbose error messages. I split some of them up for coverage purposes.

The `convert` method from `Bidiagonal` to `Tridiagonal` was broken. I fixed it and added tests for `promote_rule` and now `Bidiag` has all methods tested too!
