### PR TITLE
Define svdvals(::SVD)

### DIFF
--- a/base/linalg/svd.jl
+++ b/base/linalg/svd.jl
@@ -51,6 +51,7 @@ function svdvals{T}(A::AbstractMatrix{T})
     svdvals!(copy_oftype(A, S))
 end
 svdvals(x::Number) = abs(x)
+svdvals{T, Tr}(S::SVD{T, Tr}) = (S[:S])::Vector{Tr}
 
 # SVD least squares
 function A_ldiv_B!{T<:BlasFloat}(A::SVD{T}, B::StridedVecOrMat{T})

--- a/test/linalg/svd.jl
+++ b/test/linalg/svd.jl
@@ -29,6 +29,7 @@ debug && println("\ntype of a: ", eltya, "\n")
 
 debug && println("singular value decomposition")
     usv = svdfact(a)
+    @test usv[:S] === svdvals(usv)
     @test_approx_eq usv[:U]*scale(usv[:S],usv[:Vt]) a
     @test_approx_eq full(usv) a
     @test_approx_eq usv[:Vt]' usv[:V]


### PR DESCRIPTION
This method includes a type assertion to avoid the unfortunate type
instability of getindex(::SVD), which arises since :S is a vector while
:U, :V are matrices.
