### PR TITLE
fix the document about the return value of `a[i] = x`

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -10692,7 +10692,7 @@ Store values from array `X` within some subset of `A` as specified by `inds`.
 
     setindex!(collection, value, key...)
 
-Store the given value at the given key or index within a collection. The syntax `a[i,j,...] = x` is converted by the compiler to `setindex!(a, x, i, j, ...)`.
+Store the given value at the given key or index within a collection. The syntax `a[i,j,...] = x` is converted by the compiler to `(setindex!(a, x, i, j, ...); x)`.
 """
 setindex!
 


### PR DESCRIPTION
`a[i] = x` behaves more like `(setindex!(a, x, i); x)` rather than `setindex!(a, x, i)`.
This is related to a question I asked in [julia-users](https://groups.google.com/forum/#!searchin/julia-users/setindex!/julia-users/pNSHodLgFC4/J1QgHe_dAgAJ).
