### PR TITLE
Add back try/catch blocks around staged functions

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -686,7 +686,11 @@ function abstract_call_gf(f, fargs, argtype, e)
     end
     for (m::SimpleVector) in x
         local linfo
-        linfo = func_for_method(m[3],argtype,m[2])
+        linfo = try
+            func_for_method(m[3],argtype,m[2])
+        catch
+            NF
+        end
         if linfo === NF
             rettype = Any
             break
@@ -748,7 +752,11 @@ function invoke_tfunc(f, types, argtype)
     end
     (ti, env) = ccall(:jl_match_method, Any, (Any, Any, Any),
                       argtype, meth.sig, meth.tvars)::SimpleVector
-    linfo = func_for_method(meth, types, env)
+    linfo = try
+        func_for_method(meth, types, env)
+    catch
+        NF
+    end
     if linfo === NF
         return Any
     end
@@ -2165,7 +2173,11 @@ function inlineable(f::ANY, e::Expr, atype::ANY, sv::StaticVarInfo, enclosing_as
     meth = meth[1]::SimpleVector
 
     local linfo
-    linfo = func_for_method(meth[3],atype,meth[2])
+    linfo = try
+        func_for_method(meth[3],atype,meth[2])
+    catch
+        NF
+    end
     if linfo === NF
         return NF
     end

--- a/src/dump.c
+++ b/src/dump.c
@@ -1989,6 +1989,7 @@ DLLEXPORT jl_value_t *jl_compress_ast(jl_lambda_info_t *li, jl_value_t *ast)
 DLLEXPORT jl_value_t *jl_uncompress_ast(jl_lambda_info_t *li, jl_value_t *data)
 {
     JL_SIGATOMIC_BEGIN();
+    assert(jl_is_array(data));
     DUMP_MODES last_mode = mode;
     mode = MODE_AST;
     jl_array_t *bytes = (jl_array_t*)data;

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -135,3 +135,19 @@ f10502() = ()
 end
 @test f11982(Float32) == "Float32"
 @test f11982(Int32) == "Int32"
+
+# @generated functions that throw (shouldn't segfault or throw)
+module TestGeneratedThrow
+    using Base.Test
+
+    @generated function bar(x)
+        error("I'm not happy with type $x")
+    end
+
+    foo() = (bar(rand() > 0.5 ? 1 : 1.0); error("foo"))
+    function __init__()
+        code_typed(foo,(); optimize = false)
+        @test isa(Core.Inference.inference_stack,Core.Inference.EmptyCallStack)
+        cfunction(foo,Void,())
+    end
+end


### PR DESCRIPTION
Otherwise an exception inside a staged function will cause
corrupted inference state, which can lead to segfaults (add a test
to demonstrate this). @carnaval 
