### PR TITLE
Make info & warn colors configurable via ENV

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -19,11 +19,23 @@ const text_colors = AnyDict(
 )
 
 have_color = false
+default_color_warn = :red
+default_color_info = :blue
 @unix_only default_color_answer = text_colors[:bold]
 @unix_only default_color_input = text_colors[:bold]
 @windows_only default_color_answer = text_colors[:normal]
 @windows_only default_color_input = text_colors[:normal]
 color_normal = text_colors[:normal]
+
+function warn_color()
+    c = symbol(get(ENV, "JULIA_WARN_COLOR", ""))
+    haskey(text_colors, c) ? c : default_color_warn
+end
+
+function info_color()
+    c = symbol(get(ENV, "JULIA_INFO_COLOR", ""))
+    haskey(text_colors, c) ? c : default_color_info
+end
 
 function answer_color()
     c = symbol(get(ENV, "JULIA_ANSWER_COLOR", ""))

--- a/base/util.jl
+++ b/base/util.jl
@@ -329,7 +329,7 @@ println_with_color(color::Symbol, msg::AbstractString...) =
 ## warnings and messages ##
 
 function info(io::IO, msg...; prefix="INFO: ")
-    println_with_color(:blue, io, prefix, chomp(string(msg...)))
+    println_with_color(info_color(), io, prefix, chomp(string(msg...)))
 end
 info(msg...; prefix="INFO: ") = info(STDERR, msg..., prefix=prefix)
 
@@ -351,7 +351,7 @@ function warn(io::IO, msg...;
         (key in have_warned) && return
         push!(have_warned, key)
     end
-    print_with_color(:red, io, prefix, str)
+    print_with_color(warn_color(), io, prefix, str)
     if bt !== nothing
         show_backtrace(io, bt)
     end

--- a/doc/manual/interacting-with-julia.rst
+++ b/doc/manual/interacting-with-julia.rst
@@ -229,3 +229,26 @@ and get a list of LaTeX matches as well::
     \hbar             \hermitconjmatrix  \hkswarow          \hookrightarrow    \hspace
 
 A full list of tab-completions can be found in the :ref:`man-unicode-input` section of the manual.
+
+
+Customizing Colors
+~~~~~~~~~~~~~~~~~~
+
+The colors used by Julia and the REPL can be customized, as well. To change the color of the Julia
+prompt you can add something like the following to your ``juliarc.jl`` file::
+
+    Base.active_repl.prompt_color = Base.text_colors[:cyan]
+
+The available color keys in ``Base.text_colors`` are ``:black``, ``:red``, ``:green``, ``:yellow``,
+``:blue``, ``:magenta``, ``:cyan``, ``:white``, ``:normal``, and ``:bold``. Similarly, you can
+change the colors for the help and shell prompts and input and answer text by setting the
+appropriate member of ``Base.active_repl`` (respectively, ``help_color``, ``shell_color``,
+``input_color``, and ``answer_color``). For the latter two, be sure that the ``envcolors`` member
+is also set to false.
+
+You can also customize the color used to render warning and informational messages by
+setting the appropriate environment variable. For instance, to render warning messages in yellow and
+informational messages in cyan you can add the following to your ``juliarc.jl`` file::
+
+    ENV["JULIA_WARN_COLOR"] = :yellow
+    ENV["JULIA_INFO_COLOR"] = :cyan


### PR DESCRIPTION
Attempts to address #12753.

This is a modest change to allow setting the color for ~~`error`,~~ `info` and `warn` via `ENV`.

EDIT: Playing with error color is probably a bridge too far. My patch for error colors didn't seem to be working right, anyway.

~~One open question: do any changes need to be made in `REPL.jl` to keep things consistent?~~
