### PR TITLE
More tests for LU and SVD

### DIFF
--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -210,6 +210,7 @@ function logdet{T<:Complex,S}(A::LU{T,S})
 end
 
 inv!{T<:BlasFloat,S<:StridedMatrix}(A::LU{T,S}) = @assertnonsingular LAPACK.getri!(A.factors, A.ipiv) A.info
+inv{T<:BlasFloat,S<:StridedMatrix}(A::LU{T,S}) = inv!(LU(copy(A.factors), copy(A.ipiv), copy(A.info)))
 
 cond{T<:BlasFloat,S<:StridedMatrix}(A::LU{T,S}, p::Number) = inv(LAPACK.gecon!(p == 1 ? '1' : 'I', A.factors, norm((A[:L]*A[:U])[A[:p],:], p)))
 cond(A::LU, p::Number) = norm(A[:L]*A[:U],p)*norm(inv(A),p)

--- a/test/linalg/svd.jl
+++ b/test/linalg/svd.jl
@@ -44,8 +44,11 @@ debug && println("Generalized svd")
     @test_approx_eq gsvd[:V]*gsvd[:D2]*gsvd[:R]*gsvd[:Q]' a_svd
     @test_approx_eq usv[:Vt]' usv[:V]
     @test_throws KeyError usv[:Z]
+    @test_throws KeyError gsvd[:Z]
+    @test_approx_eq gsvd[:vals] svdvals(a,a_svd)
     α = eltya == Int ? -1 : rand(eltya)
     β = svdfact(α)
     @test β[:S] == [abs(α)]
     @test svdvals(α) == abs(α)
+
 end


### PR DESCRIPTION
The `inv!` method for `LU`s was never called. `inv` was falling back to the method in `factorize.jl`. I added a `inv` method in `lu.jl` and now it uses the specialized LAPACK call. I fleshed out the tests for `lu` and `svd` in general, too.
