### PR TITLE
Add coverage in more places for unicode/*.jl

### DIFF
--- a/base/unicode/checkstring.jl
+++ b/base/unicode/checkstring.jl
@@ -19,7 +19,9 @@ const UTF_SURROGATE = 32        ##< surrogate pairs present
 
 ## Get a UTF-8 continuation byte, give error if invalid, return updated character value
 @inline function get_continuation(ch::UInt32, byt::UInt8, pos)
-    !is_valid_continuation(byt) && throw(UnicodeError(UTF_ERR_CONT, pos, byt))
+    if !is_valid_continuation(byt)
+        throw(UnicodeError(UTF_ERR_CONT, pos, byt))
+    end
     (ch << 6) | (byt & 0x3f)
 end
 

--- a/base/unicode/utf16.jl
+++ b/base/unicode/utf16.jl
@@ -267,8 +267,6 @@ function convert(T::Type{UTF16String}, bytes::AbstractArray{UInt8})
     UTF16String(d)
 end
 
-convert(::Type{UTF16String}, str::UTF16String)    = str
-
 utf16(x) = convert(UTF16String, x)
 utf16(p::Ptr{UInt16}, len::Integer) = utf16(pointer_to_array(p, len))
 utf16(p::Ptr{Int16}, len::Integer) = utf16(convert(Ptr{UInt16}, p), len)

--- a/test/unicode/checkstring.jl
+++ b/test/unicode/checkstring.jl
@@ -88,6 +88,15 @@ try
         # Lead followed by non-continuation character > 0xbf
         @test_throws UnicodeError Base.checkstring(UInt8[byt,0x80,0x80,0xc0])
     end
+
+    # Long encoding of 0x01
+    @test_throws UnicodeError utf8(b"\xf0\x80\x80\x80")
+    # Test ends of long encoded surrogates
+    @test_throws UnicodeError utf8(b"\xf0\x8d\xa0\x80")
+    @test_throws UnicodeError utf8(b"\xf0\x8d\xbf\xbf")
+    @test_throws UnicodeError Base.checkstring(b"\xf0\x80\x80\x80")
+    @test Base.checkstring(b"\xc0\x81"; accept_long_char=true) == (1,0x1,0,0,0)
+    @test Base.checkstring(b"\xf0\x80\x80\x80"; accept_long_char=true) == (1,0x1,0,0,0)
 catch exp;
     println("Error testing checkstring: $byt, $exp")
     throw(exp)
@@ -105,6 +114,9 @@ end
 
 # Characters > 0x10ffff
 @test_throws UnicodeError Base.checkstring(UInt32[0x110000])
+
+# Test starting and different position
+@test Base.checkstring(UInt32[0x110000, 0x1f596], 2) == (1,0x10,1,0,0)
 
 # Test valid sequences
 for (seq, res) in (

--- a/test/unicode/types.jl
+++ b/test/unicode/types.jl
@@ -1,11 +1,11 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 nullstring16 = UInt16[]
-badstring16  = Uint16[0x0065]
+badstring16  = UInt16[0x0065]
 @test_throws UnicodeError UTF16String(nullstring16)
 @test_throws UnicodeError UTF16String(badstring16)
 
 nullstring32 = UInt32[]
-badstring32  = Uint32['a']
+badstring32  = UInt32['a']
 @test_throws UnicodeError UTF32String(nullstring32)
 @test_throws UnicodeError UTF32String(badstring32)

--- a/test/unicode/utf32.jl
+++ b/test/unicode/utf32.jl
@@ -267,3 +267,5 @@ let str = ascii("this ")
     @test typeof(p32) == Ptr{UInt32}
     @test unsafe_load(p32,1) == 's'
 end
+
+@test isvalid(Char['f','o','o','b','a','r'])

--- a/test/unicode/utf8.jl
+++ b/test/unicode/utf8.jl
@@ -35,3 +35,5 @@ for str in (b"xyz\xc1", b"xyz\xd0", b"xyz\xe0", b"xyz\xed\x80", b"xyz\xf0", b"xy
     @test_throws UnicodeError reverse(UTF8String(str))
 end
 
+## Specifically check UTF-8 string whose lead byte is same as a surrogate
+@test convert(UTF8String,b"\xed\x9f\xbf") == "\ud7ff"


### PR DESCRIPTION
Added test for uncovered line in utf32.jl
Changed Uint to UInt in types.jl
Removed a duplicate convert method in utf16.jl
Add test to cover converting a long utf8 sequence in utf8.jl
Changed a method in checkstring.jl for better coverage
Added more tests for checkstring.jl, test accept_long_char option
