### PR TITLE
Revert parsing change

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -852,7 +852,7 @@
         (error (string "unexpected " t)))
     ;; TODO: ? should probably not be listed here except for the syntax hack in osutils.jl
     (cond ((and (operator? t) (not (memq t '(: |'| ?))) (not (syntactic-unary-op? t))
-                (not (invalid-identifier-name? t)))
+		(not (invalid-identifier-name? t)))
            (let* ((op  (take-token s))
                   (nch (peek-char (ts:port s))))
              (if (and (or (eq? op '-) (eq? op '+))
@@ -870,14 +870,19 @@
                  (let ((next (peek-token s)))
                    (cond ((or (closing-token? next) (newline? next) (eq? next '=))
                           op)  ; return operator by itself, as in (+)
-                         ((or (eqv? next #\{)   ;; +{T}(x::T) or +(x)
-                              (eqv? next #\( ))
+                         ((or (eqv? next #\{)  ;; this case is +{T}(x::T) = ...
+			      (and (not (memq op unary-ops))
+				   (eqv? next #\( )))
                           (ts:put-back! s op)
                           (parse-factor s))
-                         ((not (memq op unary-ops))
-                          (error (string "\"" op "\" is not a unary operator")))
+			 ((not (memq op unary-ops))
+			  (error (string "\"" op "\" is not a unary operator")))
                          (else
-                          (list 'call op (parse-unary s))))))))
+                          (let ((arg (parse-unary s)))
+                            (if (and (pair? arg)
+                                     (eq? (car arg) 'tuple))
+                                (list* 'call op (cdr arg))
+                                (list  'call op arg)))))))))
           (else
            (parse-juxtapose (parse-factor s) s)))))
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -290,7 +290,3 @@ parse("""
 # issue #12626
 @test parse("a .÷ 1") == Expr(:call, :.÷, :a, 1)
 @test parse("a .÷= 1") == Expr(:.÷=, :a, 1)
-
-# issue #12755
-@test string(parse(string(:((+)((1,2)))))) == "+((1,2))"
-@test string(parse(string(:((~)((1,2)))))) == "~((1,2))"

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -290,3 +290,6 @@ parse("""
 # issue #12626
 @test parse("a .÷ 1") == Expr(:call, :.÷, :a, 1)
 @test parse("a .÷= 1") == Expr(:.÷=, :a, 1)
+
+# issue #12771
+@test -(3)^2 == -9


### PR DESCRIPTION
56360a7ee1ebc6028ce16f352749843bee48cf76 does something which makes logical sense but which breaks common mathematical notation. See discussion in #12771.
