### PR TITLE
add navailable()/capacity(RemoteRef{Channel})

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -107,7 +107,10 @@ The maximal number of elements the channel can store.
 """
 capacity(c::Channel) = c.sz_max
 
-function n_avail(c::Channel)
+"""
+The number of elements currently in the channel.
+"""
+function navailable(c::Channel)
     if c.put_pos >= c.take_pos
         return c.put_pos - c.take_pos
     else
@@ -115,7 +118,7 @@ function n_avail(c::Channel)
     end
 end
 
-show(io::IO, c::Channel) = print(io, "$(typeof(c))(capacity:$(capacity(c)), sz_curr:$(n_avail(c)))")
+show(io::IO, c::Channel) = print(io, "$(typeof(c))(capacity:$(capacity(c)), navailable:$(navailable(c)))")
 
 start{T}(c::Channel{T}) = Ref{Nullable{T}}()
 function done(c::Channel, state::Ref)

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -102,6 +102,11 @@ end
 
 eltype{T}(::Type{Channel{T}}) = T
 
+"""
+The maximal number of elements the channel can store.
+"""
+capacity(c::Channel) = c.sz_max
+
 function n_avail(c::Channel)
     if c.put_pos >= c.take_pos
         return c.put_pos - c.take_pos
@@ -110,7 +115,7 @@ function n_avail(c::Channel)
     end
 end
 
-show(io::IO, c::Channel) = print(io, "$(typeof(c))(sz_max:$(c.sz_max),sz_curr:$(n_avail(c)))")
+show(io::IO, c::Channel) = print(io, "$(typeof(c))(capacity:$(capacity(c)), sz_curr:$(n_avail(c)))")
 
 start{T}(c::Channel{T}) = Ref{Nullable{T}}()
 function done(c::Channel, state::Ref)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1209,6 +1209,7 @@ export
 
 # multiprocessing
     addprocs,
+    capacity,
     ClusterManager,
     fetch,
     init_worker,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1218,6 +1218,7 @@ export
     launch,
     manage,
     myid,
+    navailable,
     nprocs,
     nworkers,
     pmap,

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -16,17 +16,33 @@ id_other = filter(x -> x != id_me, procs())[rand(1:(nprocs()-1))]
 
 rr=RemoteRef()
 @test typeof(rr) == RemoteRef{Channel{Any}}
+@test !isready(rr)
+@test navailable(rr) == 0
+@test capacity(rr) > 0
 a = rand(5,5)
 put!(rr, a)
+@test isready(rr)
+@test navailable(rr) == 1
 @test rr[2,3] == a[2,3]
 @test rr[] == a
+take!(rr)
+@test !isready(rr)
+@test navailable(rr) == 0
 
 rr=RemoteRef(workers()[1])
 @test typeof(rr) == RemoteRef{Channel{Any}}
+@test !isready(rr)
+@test navailable(rr) == 0
+@test capacity(rr) > 0
 a = rand(5,5)
 put!(rr, a)
+@test isready(rr)
+@test navailable(rr) == 1
 @test rr[1,5] == a[1,5]
 @test rr[] == a
+take!(rr)
+@test !isready(rr)
+@test navailable(rr) == 0
 
 dims = (20,20,20)
 


### PR DESCRIPTION
Make current number of elements in the `Channel` and its capacity available via `RemoteRef`.
Should be important for dynamically balancing the channel's usage in some applications.
