### PR TITLE
Fix permute! for non-mutable index vectors

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -142,7 +142,7 @@ function permute!!{T<:Integer}(a, p::AbstractVector{T})
     a
 end
 
-permute!(a, p::AbstractVector) = permute!!(a, copy(p))
+permute!(a, p::AbstractVector) = permute!!(a, copy!(similar(p), p))
 
 function ipermute!!{T<:Integer}(a, p::AbstractVector{T})
     count = 0
@@ -167,7 +167,7 @@ function ipermute!!{T<:Integer}(a, p::AbstractVector{T})
     a
 end
 
-ipermute!(a, p::AbstractVector) = ipermute!!(a, copy(p))
+ipermute!(a, p::AbstractVector) = ipermute!!(a, copy!(similar(p), p))
 
 immutable Combinations{T}
     a::T

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -24,6 +24,11 @@ push!(p, 1)
 a = randcycle(10)
 @test ipermute!(permute!([1:10;], a),a) == [1:10;]
 
+# PR 12785
+let a = 2:-1:1
+    @test ipermute!(permute!([1, 2], a), a) == [1, 2]
+end
+
 @test collect(combinations("abc",3)) == Any[['a','b','c']]
 @test collect(combinations("abc",2)) == Any[['a','b'],['a','c'],['b','c']]
 @test collect(combinations("abc",1)) == Any[['a'],['b'],['c']]


### PR DESCRIPTION
Before `permute!([1,2], 2:-1:1)` was failing since `copy(::StepRange)` doesn't return a mutable vector, as combinatorics.jl:145 implicitly assumed. 
