### PR TITLE
change for i in 1:length(a) to i in eachindex(a) (continuing #10858)

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -48,7 +48,7 @@ function complete_symbol(sym, ffunc)
             # We're now looking for a type
             fields = fieldnames(t)
             found = false
-            for i in 1:length(fields)
+            for i in eachindex(fields)
                 s == fields[i] || continue
                 t = t.types[i]
                 Base.isstructtype(t) || return UTF8String[]

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -10,7 +10,7 @@ typealias RangeIndex Union{Int, Range{Int}, UnitRange{Int}, Colon}
 ## Basic functions ##
 
 vect() = Array(Any, 0)
-vect{T}(X::T...) = T[ X[i] for i=1:length(X) ]
+vect{T}(X::T...) = T[ X[i] for i in eachindex(X) ]
 
 const _oldstyle_array_vcat_ = true
 
@@ -44,7 +44,7 @@ if _oldstyle_array_vcat_
 else
     function vect(X...)
         T = promote_typeof(X...)
-        #T[ X[i] for i=1:length(X) ]
+        #T[ X[i] for i in eachindex(X) ]
         # TODO: this is currently much faster. should figure out why. not clear.
         copy!(Array(T,length(X)), X)
     end
@@ -703,8 +703,8 @@ hcat() = Array(Any, 0)
 ## cat: special cases
 hcat{T}(X::T...)         = T[ X[j] for i=1, j=1:length(X) ]
 hcat{T<:Number}(X::T...) = T[ X[j] for i=1, j=1:length(X) ]
-vcat{T}(X::T...)         = T[ X[i] for i=1:length(X) ]
-vcat{T<:Number}(X::T...) = T[ X[i] for i=1:length(X) ]
+vcat{T}(X::T...)         = T[ X[i] for i in eachindex(X) ]
+vcat{T<:Number}(X::T...) = T[ X[i] for i in eachindex(X) ]
 
 function vcat(X::Number...)
     T = promote_typeof(X...)
@@ -723,7 +723,7 @@ function vcat{T}(V::AbstractVector{T}...)
     end
     a = similar(full(V[1]), n)
     pos = 1
-    for k=1:length(V)
+    for k in eachindex(V)
         Vk = V[k]
         p1 = pos+length(Vk)-1
         a[pos:p1] = Vk
@@ -800,12 +800,12 @@ function cat_t(catdims, typeC::Type, X...)
     ndimsC = max(maximum(ndimsX), maximum(catdims))
     catsizes = zeros(Int,(nargs,length(catdims)))
     dims2cat = zeros(Int,ndimsC)
-    for k = 1:length(catdims)
+    for k in eachindex(catdims)
         dims2cat[catdims[k]]=k
     end
 
     dimsC = Int[d <= ndimsX[1] ? size(X[1],d) : 1 for d=1:ndimsC]
-    for k = 1:length(catdims)
+    for k in eachindex(catdims)
         catsizes[1,k] = dimsC[catdims[k]]
     end
     for i = 2:nargs
@@ -832,7 +832,7 @@ function cat_t(catdims, typeC::Type, X...)
         cat_one = [ dims2cat[d] == 0 ? (1:dimsC[d]) : (offsets[dims2cat[d]]+(1:catsizes[i,dims2cat[d]]))
                    for d=1:ndimsC ]
         C[cat_one...] = X[i]
-        for k = 1:length(catdims)
+        for k in eachindex(catdims)
             offsets[k] += catsizes[i,k]
         end
     end
@@ -1291,7 +1291,7 @@ end
 ## 1 argument
 map!{F}(f::F, A::AbstractArray) = map!(f, A, A)
 function map!{F}(f::F, dest::AbstractArray, A::AbstractArray)
-    for i = 1:length(A)
+    for i in eachindex(A)
         dest[i] = f(A[i])
     end
     return dest
@@ -1328,7 +1328,7 @@ end
 
 ## 2 argument
 function map!{F}(f::F, dest::AbstractArray, A::AbstractArray, B::AbstractArray)
-    for i = 1:length(A)
+    for i in eachindex(A)
         dest[i] = f(A[i], B[i])
     end
     return dest

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -19,7 +19,7 @@ _sub(t::Tuple, ::Tuple{}) = t
 _sub(t::Tuple, s::Tuple) = _sub(tail(t), tail(s))
 
 function squeeze(A::AbstractArray, dims::Dims)
-    for i in 1:length(dims)
+    for i in eachindex(dims)
         1 <= dims[i] <= ndims(A) || throw(ArgumentError("squeezed dims must be in range 1:ndims(A)"))
         size(A, dims[i]) == 1 || throw(ArgumentError("squeezed dims must all be size 1"))
         for j = 1:i-1
@@ -144,7 +144,7 @@ function cumsum_kbn{T<:AbstractFloat}(A::AbstractArray{T}, axis::Integer=1)
     B = similar(A)
     C = similar(A)
 
-    for i = 1:length(A)
+    for i in eachindex(A)
         if div(i-1, axis_stride) % axis_size == 0
             B[i] = A[i]
             C[i] = zero(T)
@@ -167,7 +167,7 @@ end
 
 function ipermutedims(A::AbstractArray,perm)
     iperm = Array(Int,length(perm))
-    for i = 1:length(perm)
+    for i in eachindex(perm)
         iperm[perm[i]] = i
     end
     return permutedims(A,iperm)

--- a/base/array.jl
+++ b/base/array.jl
@@ -33,7 +33,7 @@ function call{P<:Ptr,T}(::Type{Ref{P}}, a::Array{T}) # Ref{P<:Ptr}(a::Array)
     else
         ptrs = Array(P, length(a)+1)
         roots = Array(Any, length(a))
-        for i = 1:length(a)
+        for i in eachindex(a)
             root = cconvert(P, a[i])
             ptrs[i] = unsafe_convert(P, root)::P
             roots[i] = root
@@ -163,7 +163,7 @@ similar{T}(a::Array{T,2}, S)          = Array(S, size(a,1), size(a,2))
 # T[x...] constructs Array{T,1}
 function getindex(T::Type, vals...)
     a = Array(T,length(vals))
-    @inbounds for i = 1:length(vals)
+    @inbounds for i in eachindex(vals)
         a[i] = vals[i]
     end
     return a
@@ -171,7 +171,7 @@ end
 
 function getindex(::Type{Any}, vals::ANY...)
     a = Array(Any,length(vals))
-    @inbounds for i = 1:length(vals)
+    @inbounds for i in eachindex(vals)
         a[i] = vals[i]
     end
     return a
@@ -680,7 +680,7 @@ function hcat{T}(V::Vector{T}...)
             throw(DimensionMismatch("vectors must have same lengths"))
         end
     end
-    [ V[j][i]::T for i=1:length(V[1]), j=1:length(V) ]
+    [ V[j][i]::T for i in eachindex(V[1]), j in eachindex(V) ]
 end
 
 
@@ -750,7 +750,7 @@ function find(testf::Function, A::AbstractArray)
     # use a dynamic-length array to store the indexes, then copy to a non-padded
     # array for the return
     tmpI = Array(Int, 0)
-    for i = 1:length(A)
+    for i in eachindex(A)
         if testf(A[i])
             push!(tmpI, i)
         end
@@ -764,7 +764,7 @@ function find(A::StridedArray)
     nnzA = countnz(A)
     I = similar(A, Int, nnzA)
     count = 1
-    for i=1:length(A)
+    for i in eachindex(A)
         if A[i] != 0
             I[count] = i
             count += 1
@@ -860,7 +860,7 @@ function findin(a, b::UnitRange)
     ind = Array(Int, 0)
     f = first(b)
     l = last(b)
-    for i = 1:length(a)
+    for i in eachindex(a)
         if f <= a[i] <= l
             push!(ind, i)
         end
@@ -871,7 +871,7 @@ end
 function findin(a, b)
     ind = Array(Int, 0)
     bset = Set(b)
-    @inbounds for i = 1:length(a)
+    @inbounds for i in eachindex(a)
         a[i] in bset && push!(ind, i)
     end
     ind
@@ -907,7 +907,7 @@ filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 
 function filter!(f, a::Vector)
     insrt = 1
-    for curr = 1:length(a)
+    for curr in eachindex(a)
         if f(a[curr])
             a[insrt] = a[curr]
             insrt += 1
@@ -919,7 +919,7 @@ end
 
 function filter(f, a::Vector)
     r = Array(eltype(a), 0)
-    for i = 1:length(a)
+    for i in eachindex(a)
         if f(a[i])
             push!(r, a[i])
         end
@@ -934,7 +934,7 @@ function intersect(v1, vs...)
     ret = Array(eltype(v1),0)
     for v_elem in v1
         inall = true
-        for i = 1:length(vs)
+        for i in eachindex(vs)
             if !in(v_elem, vs[i])
                 inall=false; break
             end

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -398,7 +398,7 @@ function ctransposeblock!(B::StridedMatrix,A::StridedMatrix,m::Int,n::Int,offset
     return B
 end
 function ccopy!(B, A)
-    for i = 1:length(A)
+    for i in eachindex(A)
         B[i] = ctranspose(A[i])
     end
 end
@@ -480,7 +480,7 @@ for (f, op) = ((:cummin, :min), (:cummax, :max))
 
         B = similar(A)
 
-        for i = 1:length(A)
+        for i in eachindex(A)
             if div(i-1, axis_stride) % axis_size == 0
                B[i] = A[i]
             else

--- a/base/ascii.jl
+++ b/base/ascii.jl
@@ -63,7 +63,7 @@ end
 
 function uppercase(s::ASCIIString)
     d = s.data
-    for i = 1:length(d)
+    for i in eachindex(d)
         if 'a' <= Char(d[i]) <= 'z'
             td = copy(d)
             for j = i:length(td)
@@ -78,7 +78,7 @@ function uppercase(s::ASCIIString)
 end
 function lowercase(s::ASCIIString)
     d = s.data
-    for i = 1:length(d)
+    for i in eachindex(d)
         if 'A' <= Char(d[i]) <= 'Z'
             td = copy(d)
             for j = i:length(td)

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -208,7 +208,7 @@ function lreplace!(ex::Expr, r::LReplace)
             return ex
         end
     end
-    for i in 1:length(ex.args)
+    for i in eachindex(ex.args)
         ex.args[i] = lreplace!(ex.args[i], r)
     end
     ex
@@ -255,7 +255,7 @@ exprresolve_conditional(arg) = false, false
 
 exprresolve(arg) = arg
 function exprresolve(ex::Expr)
-    for i = 1:length(ex.args)
+    for i in eachindex(ex.args)
         ex.args[i] = exprresolve(ex.args[i])
     end
     # Handle simple arithmetic

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -171,17 +171,17 @@ format(dt::TimeType,f::AbstractString;locale::AbstractString="english") = format
 # vectorized
 DateTime{T<:AbstractString}(y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = DateTime(y,DateFormat(format,locale))
 function DateTime{T<:AbstractString}(y::AbstractArray{T},df::DateFormat=ISODateTimeFormat)
-    return reshape(DateTime[DateTime(parse(y[i],df)...) for i in 1:length(y)], size(y))
+    return reshape(DateTime[DateTime(parse(y[i],df)...) for i in eachindex(y)], size(y))
 end
 Date{T<:AbstractString}(y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = Date(y,DateFormat(format,locale))
 function Date{T<:AbstractString}(y::AbstractArray{T},df::DateFormat=ISODateFormat)
-    return reshape(Date[Date(parse(y[i],df)...) for i in 1:length(y)], size(y))
+    return reshape(Date[Date(parse(y[i],df)...) for i in eachindex(y)], size(y))
 end
 
 format{T<:TimeType}(y::AbstractArray{T},format::AbstractString;locale::AbstractString="english") = Dates.format(y,DateFormat(format,locale))
 function format(y::AbstractArray{Date},df::DateFormat=ISODateFormat)
-    return reshape([Dates.format(y[i],df) for i in 1:length(y)], size(y))
+    return reshape([Dates.format(y[i],df) for i in eachindex(y)], size(y))
 end
 function format(y::AbstractArray{DateTime},df::DateFormat=ISODateTimeFormat)
-    return reshape([Dates.format(y[i],df) for i in 1:length(y)], size(y))
+    return reshape([Dates.format(y[i],df) for i in eachindex(y)], size(y))
 end

--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -64,7 +64,7 @@ for (op,Ty,Tz) in ((:.*,Real,:P),
     @eval begin
         function ($op){P<:Period}(X::StridedArray{P},y::$Ty)
             Z = similar(X, $Tz)
-            for i = 1:length(X)
+            for i in eachindex(X)
                 @inbounds Z[i] = ($op_)(X[i],y)
             end
             return Z
@@ -206,7 +206,7 @@ for op in (:.+, :.-)
     @eval begin
         function ($op){P<:GeneralPeriod}(X::StridedArray{P},y::GeneralPeriod)
             Z = similar(X, CompoundPeriod)
-            for i = 1:length(X)
+            for i in eachindex(X)
                 @inbounds Z[i] = ($op_)(X[i],y)
             end
             return Z
@@ -258,7 +258,7 @@ end
 
 # FixedPeriod conversions and promotion rules
 const fixedperiod_conversions = [(Week,7),(Day,24),(Hour,60),(Minute,60),(Second,1000),(Millisecond,1)]
-for i = 1:length(fixedperiod_conversions)
+for i in eachindex(fixedperiod_conversions)
     (T,n) = fixedperiod_conversions[i]
     N = 1
     for j = i-1:-1:1 # less-precise periods

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -60,7 +60,7 @@ function _deepcopy_array_t(x, T, stackdict::ObjectIdDict)
     end
     dest = similar(x)
     stackdict[x] = dest
-    for i=1:length(x)
+    for i in eachindex(x)
         if isdefined(x,i)
             arrayset(dest, deepcopy_internal(x[i], stackdict), i)
         end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -730,7 +730,7 @@ export RopeString
 
 function complement!(s::IntSet)
     depwarn("complement IntSets are deprecated", :complement!);
-    for n = 1:length(s.bits)
+    for n in eachindex(s.bits)
         s.bits[n] = ~s.bits[n]
     end
     s.fill1s = !s.fill1s

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -4602,7 +4602,7 @@ subtypes
 doc"""
     digits(n, [base], [pad])
 
-Returns an array of the digits of `n` in the given base, optionally padded with zeros to a specified size. More significant digits are at higher indexes, such that `n == sum([digits[k]*base^(k-1) for k=1:length(digits)])`.
+Returns an array of the digits of `n` in the given base, optionally padded with zeros to a specified size. More significant digits are at higher indexes, such that `n == sum([digits[k]*base^(k-1) for k in eachindex(digits)])`.
 """
 digits
 

--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -191,7 +191,7 @@ function levsort(search, candidates)
     scores = map(cand -> (levenshtein(search, cand), -fuzzyscore(search, cand)), candidates)
     candidates = candidates[sortperm(scores)]
     i = 0
-    for i = 1:length(candidates)
+    for i in eachindex(candidates)
         levenshtein(search, candidates[i]) > 3 && break
     end
     return candidates[1:i]
@@ -230,7 +230,7 @@ printmatches(args...; cols = Base.tty_size()[2]) = printmatches(STDOUT, args...,
 function print_joined_cols(io::IO, ss, delim = "", last = delim; cols = Base.tty_size()[2])
     i = 0
     total = 0
-    for i = 1:length(ss)
+    for i in eachindex(ss)
         total += length(ss[i])
         total + max(i-2,0)*length(delim) + (i>1?1:0)*length(last) > cols && (i-=1; break)
     end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -151,7 +151,7 @@ function length_checked_equal(args...)
     n
 end
 
-map(f::Function, a::Array{Any,1}) = Any[ f(a[i]) for i=1:length(a) ]
+map(f::Function, a::Array{Any,1}) = Any[ f(a[i]) for i in 1:length(a) ]
 
 function precompile(f::ANY, args::Tuple)
     if isa(f,DataType)
@@ -219,16 +219,17 @@ start(v::SimpleVector) = 1
 next(v::SimpleVector,i) = (v[i],i+1)
 done(v::SimpleVector,i) = (i > v.length)
 isempty(v::SimpleVector) = (v.length == 0)
+eachindex(v::SimpleVector) = 1:length(v)
 
 function ==(v1::SimpleVector, v2::SimpleVector)
     length(v1)==length(v2) || return false
-    for i = 1:length(v1)
+    for i in eachindex(v1)
         v1[i] == v2[i] || return false
     end
     return true
 end
 
-map(f, v::SimpleVector) = Any[ f(v[i]) for i = 1:length(v) ]
+map(f, v::SimpleVector) = Any[ f(v[i]) for i in eachindex(v) ]
 
 getindex(v::SimpleVector, I::AbstractArray) = svec(Any[ v[i] for i in I ]...)
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -136,7 +136,7 @@ function popmeta!(body::Expr, sym::Symbol)
         return false, []
     end
     metaargs = metaex.args
-    for i = 1:length(metaargs)
+    for i in eachindex(metaargs)
         if isa(metaargs[i], Symbol) && (metaargs[i]::Symbol) == sym
             deleteat!(metaargs, i)
             return true, []

--- a/base/fft/FFTW.jl
+++ b/base/fft/FFTW.jl
@@ -441,7 +441,7 @@ function fix_kinds(region, kinds)
     else
         kinds = Int32[kinds...]
     end
-    for i = 1:length(kinds)
+    for i in eachindex(kinds)
         if kinds[i] < 0 || kinds[i] > 10
             throw(ArgumentError("invalid transform kind"))
         end

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -69,7 +69,7 @@ round{T<:Integer}(::Type{T}, x::AbstractFloat, r::RoundingMode) = trunc(T,round(
 for f in (:trunc,:floor,:ceil,:round)
     @eval begin
         function ($f){T,R}(::Type{T}, x::AbstractArray{R,1})
-            [ ($f)(T, x[i])::T for i = 1:length(x) ]
+            [ ($f)(T, x[i])::T for i in eachindex(x) ]
         end
         function ($f){T,R}(::Type{T}, x::AbstractArray{R,2})
             [ ($f)(T, x[i,j])::T for i = 1:size(x,1), j = 1:size(x,2) ]
@@ -78,7 +78,7 @@ for f in (:trunc,:floor,:ceil,:round)
             reshape([ ($f)(T, x[i])::T for i in eachindex(x) ], size(x))
         end
         function ($f){R}(x::AbstractArray{R,1}, digits::Integer, base::Integer=10)
-            [ ($f)(x[i], digits, base) for i = 1:length(x) ]
+            [ ($f)(x[i], digits, base) for i in eachindex(x) ]
         end
         function ($f){R}(x::AbstractArray{R,2}, digits::Integer, base::Integer=10)
             [ ($f)(x[i,j], digits, base) for i = 1:size(x,1), j = 1:size(x,2) ]
@@ -90,7 +90,7 @@ for f in (:trunc,:floor,:ceil,:round)
 end
 
 function round{R}(x::AbstractArray{R,1}, r::RoundingMode)
-    [ round(x[i], r) for i = 1:length(x) ]
+    [ round(x[i], r) for i in eachindex(x) ]
 end
 function round{R}(x::AbstractArray{R,2}, r::RoundingMode)
     [ round(x[i,j], r) for i = 1:size(x,1), j = 1:size(x,2) ]
@@ -100,7 +100,7 @@ function round(x::AbstractArray, r::RoundingMode)
 end
 
 function round{T,R}(::Type{T}, x::AbstractArray{R,1}, r::RoundingMode)
-    [ round(T, x[i], r)::T for i = 1:length(x) ]
+    [ round(T, x[i], r)::T for i in eachindex(x) ]
 end
 function round{T,R}(::Type{T}, x::AbstractArray{R,2}, r::RoundingMode)
     [ round(T, x[i,j], r)::T for i = 1:size(x,1), j = 1:size(x,2) ]

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -318,7 +318,7 @@ end
 
 function digits!{T<:Integer}(a::AbstractArray{T,1}, n::Integer, base::T=10)
     2 <= base || throw(ArgumentError("base must be ≥ 2, got $base"))
-    for i = 1:length(a)
+    for i in eachindex(a)
         a[i] = rem(n, base)
         n = div(n, base)
     end

--- a/base/linalg/bitarray.jl
+++ b/base/linalg/bitarray.jl
@@ -187,7 +187,7 @@ function findmax(a::BitArray)
     m, mi = false, 1
     ti = 1
     ac = a.chunks
-    for i=1:length(ac)
+    for i in eachindex(ac)
         @inbounds k = trailing_zeros(ac[i])
         ti += k
         k==64 || return (true, ti)

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -99,7 +99,7 @@ function A_ldiv_B!{T}(D::Diagonal{T}, v::AbstractVector{T})
     if length(v) != length(D.diag)
         throw(DimensionMismatch("diagonal matrix is $(length(D.diag)) by $(length(D.diag)) but right hand side has $(length(v)) rows"))
     end
-    for i=1:length(D.diag)
+    for i in eachindex(D.diag)
         d = D.diag[i]
         if d == zero(T)
             throw(SingularException(i))
@@ -112,7 +112,7 @@ function A_ldiv_B!{T}(D::Diagonal{T}, V::AbstractMatrix{T})
     if size(V,1) != length(D.diag)
         throw(DimensionMismatch("diagonal matrix is $(length(D.diag)) by $(length(D.diag)) but right hand side has $(size(V,1)) rows"))
     end
-    for i=1:length(D.diag)
+    for i in eachindex(D.diag)
         d = D.diag[i]
         if d == zero(T)
             throw(SingularException(i))
@@ -165,7 +165,7 @@ end
 
 function inv{T}(D::Diagonal{T})
     Di = similar(D.diag)
-    for i = 1:length(D.diag)
+    for i in eachindex(D.diag)
         if D.diag[i] == zero(T)
             throw(SingularException(i))
         end
@@ -176,7 +176,7 @@ end
 
 function pinv{T}(D::Diagonal{T})
     Di = similar(D.diag)
-    for i = 1:length(D.diag)
+    for i in eachindex(D.diag)
         isfinite(inv(D.diag[i])) ? Di[i]=inv(D.diag[i]) : Di[i]=zero(T)
     end
     Diagonal(Di)
@@ -184,7 +184,7 @@ end
 function pinv{T}(D::Diagonal{T}, tol::Real)
     Di = similar(D.diag)
     if( length(D.diag) != 0 ) maxabsD = maximum(abs(D.diag)) end
-    for i = 1:length(D.diag)
+    for i in eachindex(D.diag)
         if( abs(D.diag[i]) > tol*maxabsD && isfinite(inv(D.diag[i])) )
             Di[i]=inv(D.diag[i])
         else
@@ -207,9 +207,9 @@ function svd{T<:Number}(D::Diagonal{T})
     S   = abs(D.diag)
     piv = sortperm(S, rev = true)
     U   = full(Diagonal(D.diag ./ S))
-    Up  = hcat([U[:,i] for i = 1:length(D.diag)][piv]...)
+    Up  = hcat([U[:,i] for i in eachindex(D.diag)][piv]...)
     V   = eye(D)
-    Vp  = hcat([V[:,i] for i = 1:length(D.diag)][piv]...)
+    Vp  = hcat([V[:,i] for i in eachindex(D.diag)][piv]...)
     return (Up, S[piv], Vp)
 end
 function svdfact(D::Diagonal)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -16,7 +16,7 @@ scale{R<:Real}(s::Complex, X::AbstractArray{R}) = scale(X, s)
 # For better performance when input and output are the same array
 # See https://github.com/JuliaLang/julia/issues/8415#issuecomment-56608729
 function generic_scale!(X::AbstractArray, s::Number)
-    for i = 1:length(X)
+    for i in eachindex(X)
         @inbounds X[i] *= s
     end
     X
@@ -26,7 +26,7 @@ function generic_scale!(C::AbstractArray, X::AbstractArray, s::Number)
     if length(C) != length(X)
         throw(DimensionMismatch("first array has length $(length(C)) which does not match the length of the second, $(length(X))."))
     end
-    for i = 1:length(X)
+    for i in eachindex(X)
         @inbounds C[i] = X[i]*s
     end
     C
@@ -450,7 +450,7 @@ function axpy!{Ti<:Integer,Tj<:Integer}(alpha, x::AbstractArray, rx::AbstractArr
     elseif length(rx) != length(ry)
         throw(ArgumentError("rx has length $(length(rx)), but ry has length $(length(ry))"))
     end
-    for i = 1:length(rx)
+    for i in eachindex(rx)
         @inbounds y[ry[i]] += alpha * x[rx[i]]
     end
     y

--- a/base/linalg/givens.jl
+++ b/base/linalg/givens.jl
@@ -268,13 +268,13 @@ function A_mul_B!(G::Givens, R::Rotation)
     return R
 end
 function A_mul_B!(R::Rotation, A::AbstractMatrix)
-    @inbounds for i = 1:length(R.rotations)
+    @inbounds for i in eachindex(R.rotations)
         A_mul_B!(R.rotations[i], A)
     end
     return A
 end
 function A_mul_Bc!(A::AbstractMatrix, R::Rotation)
-    @inbounds for i = 1:length(R.rotations)
+    @inbounds for i in eachindex(R.rotations)
         A_mul_Bc!(A, R.rotations[i])
     end
     return A

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -107,7 +107,7 @@ size(A::LU,n) = size(A.factors,n)
 
 function ipiv2perm{T}(v::AbstractVector{T}, maxi::Integer)
     p = T[1:maxi;]
-    @inbounds for i in 1:length(v)
+    @inbounds for i in eachindex(v)
         p[i], p[v[i]] = p[v[i]], p[i]
     end
     return p

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -168,7 +168,7 @@ eigvals!{T<:BlasComplex,S<:StridedMatrix}(A::Hermitian{T,S}, B::Hermitian{T,S}) 
 
 function svdvals!{T<:Real,S}(A::Union{Hermitian{T,S}, Symmetric{T,S}, Hermitian{Complex{T},S}}) #  the union is the same as RealHermSymComplexHerm, but right now parametric typealiases are broken
     vals = eigvals!(A)
-    for i = 1:length(vals)
+    for i in eachindex(vals)
         vals[i] = abs(vals[i])
     end
     return sort!(vals, rev = true)

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -294,7 +294,7 @@ end
 full{T}(M::Tridiagonal{T}) = convert(Matrix{T}, M)
 function convert{T}(::Type{Matrix{T}}, M::Tridiagonal{T})
     A = zeros(T, size(M))
-    for i = 1:length(M.d)
+    for i in eachindex(M.d)
         A[i,i] = M.d[i]
     end
     for i = 1:length(M.d)-1

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -35,7 +35,7 @@ function arg_decl_parts(m::Method)
     e = uncompressed_ast(li)
     argnames = e.args[1]
     s = symbol("?")
-    decls = [argtype_decl(get(argnames,i,s), m.sig.parameters[i]) for i=1:length(m.sig.parameters)]
+    decls = [argtype_decl(get(argnames,i,s), m.sig.parameters[i]) for i in eachindex(m.sig.parameters)]
     return tv, decls, li.file, li.line
 end
 

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -116,7 +116,7 @@ type WorkerConfig
 
     function WorkerConfig()
         wc = new()
-        for n in 1:length(WorkerConfig.types)
+        for n in eachindex(WorkerConfig.types)
             T = eltype(fieldtype(WorkerConfig, n))
             setfield!(wc, n, Nullable{T}())
         end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -34,6 +34,7 @@ length{N}(::Type{CartesianIndex{N}})=N
 
 # indexing
 getindex(index::CartesianIndex, i::Integer) = index.I[i]
+eachindex(index::CartesianIndex) = 1:length(index)
 
 # arithmetic, min/max
 for op in (:+, :-, :min, :max)
@@ -80,7 +81,7 @@ end
     startargs = fill(1, K)
     stopargs = Array(Expr, K)
     for i = 1:K
-        Bargs = [:(size(B[$j],$i)) for j = 1:length(B)]
+        Bargs = [:(size(B[$j],$i)) for j in eachindex(B)]
         stopargs[i] = :(max(size(A,$i),$(Bargs...)))
     end
     meta = Expr(:meta, :inline)
@@ -351,7 +352,7 @@ function cartindex_exprs(indexes, syms)
     exprs = Any[]
     for (i,ind) in enumerate(indexes)
         if ind <: CartesianIndex
-            for j = 1:length(ind)
+            for j in 1:length(ind)
                 push!(exprs, :($syms[$i][$j]))
             end
         else
@@ -777,7 +778,7 @@ for (V, PT, BT) in [((:N,), BitArray, BitArray), ((:T,:N), Array, StridedArray)]
             length(perm) == N || throw(ArgumentError("expected permutation of size $N, but length(perm)=$(length(perm))"))
             isperm(perm) || throw(ArgumentError("input is not a permutation"))
             dimsP = size(P)
-            for i = 1:length(perm)
+            for i in eachindex(perm)
                 dimsP[i] == dimsB[perm[i]] || throw(DimensionMismatch("destination tensor of incorrect size"))
             end
 

--- a/base/number.jl
+++ b/base/number.jl
@@ -10,6 +10,7 @@ eltype{T<:Number}(::Type{T}) = T
 ndims(x::Number) = 0
 ndims{T<:Number}(::Type{T}) = 0
 length(x::Number) = 1
+eachindex(x::Number) = 1
 endof(x::Number) = 1
 getindex(x::Number) = x
 getindex(x::Number, i::Integer) = i == 1 ? x : throw(BoundsError())

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -220,7 +220,7 @@ function promote_shape(a::Dims, b::Dims)
     if length(a) < length(b)
         return promote_shape(b, a)
     end
-    for i=1:length(b)
+    for i in eachindex(b)
         if a[i] != b[i]
             throw(DimensionMismatch("dimensions must match"))
         end
@@ -371,7 +371,7 @@ end
 macro vectorize_1arg(S,f)
     S = esc(S); f = esc(f); T = esc(:T)
     quote
-        ($f){$T<:$S}(x::AbstractArray{$T,1}) = [ ($f)(x[i]) for i=1:length(x) ]
+        ($f){$T<:$S}(x::AbstractArray{$T,1}) = [ ($f)(x[i]) for i in eachindex(x) ]
         ($f){$T<:$S}(x::AbstractArray{$T,2}) =
             [ ($f)(x[i,j]) for i=1:size(x,1), j=1:size(x,2) ]
         ($f){$T<:$S}(x::AbstractArray{$T}) =

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -257,7 +257,7 @@ function print_flat(io::IO, lilist::Vector{LineInfo}, n::Vector{Int}, combine::B
         wfunc = floor(Integer,3*ntext/5)
     end
     println(io, lpad("Count", wcounts, " "), " ", rpad("File", wfile, " "), " ", rpad("Function", wfunc, " "), " ", lpad("Line", wline, " "))
-    for i = 1:length(n)
+    for i in eachindex(n)
         li = lilist[i]
         println(io, lpad(string(n[i]), wcounts, " "), " ", rpad(truncto(li.file, wfile), wfile, " "), " ", rpad(truncto(li.func, wfunc), wfunc, " "), " ", lpad(string(li.line), wline, " "))
     end
@@ -301,7 +301,7 @@ function tree_format(lilist::Vector{LineInfo}, counts::Vector{Int}, level::Int, 
         nindent -= ndigits(nextra)+2
         showextra = true
     end
-    for i = 1:length(lilist)
+    for i in eachindex(lilist)
         li = lilist[i]
         if li != UNKNOWN
             base = " "^nindent
@@ -343,7 +343,7 @@ function tree{T<:Unsigned}(io::IO, bt::Vector{Vector{T}}, counts::Vector{Int}, l
     if combine
         # Combine based on the line information
         d = Dict{LineInfo,Vector{Int}}()
-        for i = 1:length(bt)
+        for i in eachindex(bt)
             ip = bt[i][level+1]
             key = lidict[ip]
             indx = Base.ht_keyindex(d, key)
@@ -368,7 +368,7 @@ function tree{T<:Unsigned}(io::IO, bt::Vector{Vector{T}}, counts::Vector{Int}, l
     else
         # Combine based on the instruction pointer
         d = Dict{T,Vector{Int}}()
-        for i = 1:length(bt)
+        for i in eachindex(bt)
             key = bt[i][level+1]
             indx = Base.ht_keyindex(d, key)
             if indx == -1
@@ -401,7 +401,7 @@ function tree{T<:Unsigned}(io::IO, bt::Vector{Vector{T}}, counts::Vector{Int}, l
     strs = tree_format(lilist, n, level, cols)
     # Recurse to the next level
     len = Int[length(x) for x in bt]
-    for i = 1:length(lilist)
+    for i in eachindex(lilist)
         if !isempty(strs[i])
             println(io, strs[i])
         end
@@ -465,7 +465,7 @@ end
 # Order alphabetically (file, function) and then by line number
 function liperm(lilist::Vector{LineInfo})
     comb = Array(ByteString, length(lilist))
-    for i = 1:length(lilist)
+    for i in eachindex(lilist)
         li = lilist[i]
         if li != UNKNOWN
             comb[i] = @sprintf("%s:%s:%06d", li.file, li.func, li.line)

--- a/base/quadgk.jl
+++ b/base/quadgk.jl
@@ -169,10 +169,10 @@ end
 # all the integration-segment endpoints
 function quadgk(f, a, b, c...; kws...)
     T = promote_type(typeof(float(a)), typeof(b))
-    for i in 1:length(c)
+    for i in eachindex(c)
         T = promote_type(T, typeof(c[i]))
     end
-    cT = T[ c[i] for i in 1:length(c) ]
+    cT = T[ c[i] for i in eachindex(c) ]
     quadgk(f, convert(T, a), convert(T, b), cT...; kws...)
 end
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -397,7 +397,7 @@ end
 
 function count(pred, a::AbstractArray)
     n = 0
-    for i = 1:length(a)
+    for i in eachindex(a)
         @inbounds if pred(a[i])
             n += 1
         end

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -100,7 +100,7 @@ function show(io::IO, m::RegexMatch)
     idx_to_capture_name = PCRE.capture_names(m.regex.regex)
     if !isempty(m.captures)
         print(io, ", ")
-        for i = 1:length(m.captures)
+        for i in eachindex(m.captures)
             # If the capture group is named, show the name.
             # Otherwise show its index.
             capture_name = get(idx_to_capture_name, i, i)

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -366,7 +366,7 @@ function process_backtrace(process_func::Function, top_function::Symbol, t, set)
     lastfile = ""; lastline = -11; lastname = symbol("#")
     local fname, file, line
     count = 0
-    for i = 1:length(t)
+    for i in eachindex(t)
         lkup = ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), t[i]-1, true)
         if lkup === nothing
             continue

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -123,7 +123,7 @@ end
 function serialize(s::SerializationState, v::SimpleVector)
     writetag(s.io, SIMPLEVECTOR_TAG)
     write(s.io, Int32(length(v)))
-    for i = 1:length(v)
+    for i in eachindex(v)
         serialize(s.io, v[i])
     end
 end
@@ -180,7 +180,7 @@ function serialize(s::SerializationState, a::Array)
     if isbits(elty)
         serialize_array_data(s.io, a)
     else
-        for i = 1:length(a)
+        for i in eachindex(a)
             if isdefined(a, i)
                 serialize(s, a[i])
             else
@@ -595,7 +595,7 @@ function deserialize_array(s::SerializationState)
     end
     A = Array(elty, dims)
     deserialize_cycle(s, A)
-    for i = 1:length(A)
+    for i in eachindex(A)
         tag = Int32(read(s.io, UInt8)::UInt8)
         if tag != UNDEFREF_TAG
             A[i] = handle_deserialize(s, tag)

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -55,7 +55,7 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
         end
 
         # Wait till all the workers have mapped the segment
-        for i in 1:length(refs)
+        for i in eachindex(refs)
             wait(refs[i])
         end
 
@@ -138,7 +138,7 @@ function SharedArray{T,N}(filename::AbstractString, ::Type{T}, dims::NTuple{N,In
     end
 
     # Wait till all the workers have mapped the segment
-    for i in 1:length(refs)
+    for i in eachindex(refs)
         wait(refs[i])
     end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1004,7 +1004,7 @@ function print_matrix_row(io::IO,
     X::AbstractVecOrMat, A::Vector,
     i::Integer, cols::AbstractVector, sep::AbstractString
 )
-    for k = 1:length(A)
+    for k in eachindex(A)
         j = cols[k]
         if isassigned(X,i,j)
             x = X[i,j]
@@ -1024,7 +1024,7 @@ end
 function print_matrix_vdots(io::IO,
     vdots::AbstractString, A::Vector, sep::AbstractString, M::Integer, m::Integer
 )
-    for k = 1:length(A)
+    for k in eachindex(A)
         w = A[k][1] + A[k][2]
         if k % M == m
             l = repeat(" ", max(0, A[k][1]-length(vdots)))

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -417,7 +417,7 @@ function selectperm!{I<:Integer}(ix::AbstractVector{I}, v::AbstractVector,
                                  order::Ordering=Forward,
                                  initialized::Bool=false)
     if !initialized
-        @inbounds for i = 1:length(ix)
+        @inbounds for i in eachindex(ix)
             ix[i] = i
         end
     end

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -830,10 +830,10 @@ end
 function convert{Tv<:VTypes}(::Type{Sparse}, A::SparseMatrixCSC{Tv,SuiteSparse_long}, stype::Integer)
     o = allocate_sparse(A.m, A.n, length(A.nzval), true, true, stype, Tv)
     s = unsafe_load(o.p)
-    for i = 1:length(A.colptr)
+    for i in eachindex(A.colptr)
         unsafe_store!(s.p, A.colptr[i] - 1, i)
     end
-    for i = 1:length(A.rowval)
+    for i in eachindex(A.rowval)
         unsafe_store!(s.i, A.rowval[i] - 1, i)
     end
     unsafe_copy!(s.x, pointer(A.nzval), length(A.nzval))
@@ -987,7 +987,7 @@ function sparse(F::Factor)
     p = get_perm(F)
     if p != [1:s.n;]
         pinv = Array(Int, length(p))
-        for k = 1:length(p)
+        for k in eachindex(p)
             pinv[p[k]] = k
         end
         A = A[pinv,pinv]
@@ -1115,7 +1115,7 @@ function getLd!(S::SparseMatrixCSC)
     d = Array(eltype(S), size(S, 1))
     fill!(d, 0)
     col = 1
-    for k = 1:length(S.nzval)
+    for k in eachindex(S.nzval)
         while k >= S.colptr[col+1]
             col += 1
         end

--- a/base/sparse/csparse.jl
+++ b/base/sparse/csparse.jl
@@ -111,7 +111,7 @@ function sparse{Tv,Ti<:Integer}(I::AbstractVector{Ti},
     RpT = cumsum(Wj[1:(ncol+1)])
 
     # Transpose
-    @simd for i=1:length(RpT); @inbounds Wj[i] = RpT[i]; end
+    @simd for i in eachindex(RpT); @inbounds Wj[i] = RpT[i]; end
     @inbounds for j = 1:nrow
         p1 = Rp[j]
         p2 = p1 + Rnz[j] - 1

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -6,14 +6,14 @@ import Base.LinAlg: chksquare
 
 # Convert from 1-based to 0-based indices
 function decrement!{T<:Integer}(A::AbstractArray{T})
-    for i in 1:length(A) A[i] -= one(T) end
+    for i in eachindex(A) A[i] -= one(T) end
     A
 end
 decrement{T<:Integer}(A::AbstractArray{T}) = decrement!(copy(A))
 
 # Convert from 0-based to 1-based indices
 function increment!{T<:Integer}(A::AbstractArray{T})
-    for i in 1:length(A) A[i] += one(T) end
+    for i in eachindex(A) A[i] += one(T) end
     A
 end
 increment{T<:Integer}(A::AbstractArray{T}) = increment!(copy(A))
@@ -477,7 +477,7 @@ function norm(A::SparseMatrixCSC,p::Real=2)
             throw(ArgumentError("2-norm not yet implemented for sparse matrices. Try norm(full(A)) or norm(A, p) where p=1 or Inf."))
         elseif p==Inf
             rowSum = zeros(Tsum,m)
-            for i=1:length(A.nzval)
+            for i in eachindex(A.nzval)
                 rowSum[A.rowval[i]] += abs(A.nzval[i])
             end
             return convert(Tnorm, maximum(rowSum))
@@ -526,13 +526,13 @@ function normestinv{T}(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A)
     S = zeros(T <: Real ? Int : Ti, n, t)
 
     function _rand_pm1!(v)
-      for i = 1:length(v)
+      for i in eachindex(v)
           v[i] = rand()<0.5?1:-1
       end
     end
 
     function _any_abs_eq(v,n::Int)
-        for i = 1:length(v)
+        for i in eachindex(v)
             if abs(v[i])==n
                 return true
             end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -564,7 +564,7 @@ for op in (:-, :log1p, :expm1)
             B = similar(A)
             nzvalB = B.nzval
             nzvalA = A.nzval
-            @simd for i=1:length(nzvalB)
+            @simd for i in eachindex(nzvalB)
                 @inbounds nzvalB[i] = ($op)(nzvalA[i])
             end
             return B
@@ -585,7 +585,7 @@ for op in (:abs, :abs2)
             B = similar(A)
             nzvalB = B.nzval
             nzvalA = A.nzval
-            @simd for i=1:length(nzvalB)
+            @simd for i in eachindex(nzvalB)
                 @inbounds nzvalB[i] = ($op)(nzvalA[i])
             end
             return B
@@ -595,7 +595,7 @@ end
 
 function conj!(A::SparseMatrixCSC)
     nzvalA = A.nzval
-    @simd for i=1:length(nzvalA)
+    @simd for i in eachindex(nzvalA)
         @inbounds nzvalA[i] = conj(nzvalA[i])
     end
     return A
@@ -2714,7 +2714,7 @@ end
 function rot180(A::SparseMatrixCSC)
     I,J,V = findnz(A)
     m,n = size(A)
-    for i=1:length(I)
+    for i in eachindex(I)
         I[i] = m - I[i] + 1
         J[i] = n - J[i] + 1
     end
@@ -2725,7 +2725,7 @@ function rotr90(A::SparseMatrixCSC)
     I,J,V = findnz(A)
     m,n = size(A)
     #old col inds are new row inds
-    for i=1:length(I)
+    for i in eachindex(I)
         I[i] = m - I[i] + 1
     end
     return sparse(J, I, V, n, m)
@@ -2735,7 +2735,7 @@ function rotl90(A::SparseMatrixCSC)
     I,J,V = findnz(A)
     m,n = size(A)
     #old row inds are new col inds
-    for i=1:length(J)
+    for i in eachindex(J)
         J[i] = n - J[i] + 1
     end
     return sparse(J, I, V, n, m)

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -336,21 +336,21 @@ A_ldiv_B!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::Matrix{T}) = solve(lu, b, UMFPACK_A
 function A_ldiv_B!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::Vector{Tb})
     r = solve(lu, [convert(Tlu,real(be)) for be in b], UMFPACK_A)
     i = solve(lu, [convert(Tlu,imag(be)) for be in b], UMFPACK_A)
-    Tb[r[k]+im*i[k] for k = 1:length(r)]
+    Tb[r[k]+im*i[k] for k in eachindex(r)]
 end
 
 Ac_ldiv_B!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::VecOrMat{T}) = solve(lu, b, UMFPACK_At)
 function Ac_ldiv_B!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::Vector{Tb})
     r = solve(lu, [convert(Float64,real(be)) for be in b], UMFPACK_At)
     i = solve(lu, [convert(Float64,imag(be)) for be in b], UMFPACK_At)
-    Tb[r[k]+im*i[k] for k = 1:length(r)]
+    Tb[r[k]+im*i[k] for k in eachindex(r)]
 end
 
 At_ldiv_B!{T<:UMFVTypes}(lu::UmfpackLU{T}, b::VecOrMat{T}) = solve(lu, b, UMFPACK_Aat)
 function At_ldiv_B!{Tb<:Complex}(lu::UmfpackLU{Float64}, b::Vector{Tb})
     r = solve(lu, [convert(Float64,real(be)) for be in b], UMFPACK_Aat)
     i = solve(lu, [convert(Float64,imag(be)) for be in b], UMFPACK_Aat)
-    Tb[r[k]+im*i[k] for k = 1:length(r)]
+    Tb[r[k]+im*i[k] for k in eachindex(r)]
 end
 
 function getindex(lu::UmfpackLU, d::Symbol)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -65,7 +65,7 @@ slice_unsafe(A::AbstractArray, J) = _slice_unsafe(A, to_indexes(J...))
     N = 0
     sizeexprs = Array(Any, 0)
     Jp = J.parameters
-    for Jindex = 1:length(Jp)
+    for Jindex in eachindex(Jp)
         j = Jp[Jindex]
         if !(j <: Real)
             N += 1
@@ -101,7 +101,7 @@ sub_unsafe(A::AbstractArray, J) = _sub_unsafe(A, to_indexes(J...))
     while N > 0 && Jp[N] <: Real
         N -= 1
     end
-    for Jindex = 1:length(Jp)
+    for Jindex in eachindex(Jp)
         j = Jp[Jindex]
         if Jindex <= N
             push!(sizeexprs, dimsizeexpr(j, Jindex, length(Jp), :A, :J))
@@ -150,7 +150,7 @@ end
     LD, die_next_vector, jprev, isLDdone = 0, false, Void, false  # for linear indexing inference
     Jindex = 0
     IVp = IV.parameters
-    for IVindex = 1:length(IVp)
+    for IVindex in eachindex(IVp)
         iv = IVp[IVindex]
         if iv <: Real
             push!(indexexprs, :(V.indexes[$IVindex]))
@@ -233,7 +233,7 @@ end
     preexprs = Array(Any, 0)
     LD, die_next_vector, jprev, isLDdone = 0, false, Void, false
     Jindex = 0
-    for IVindex = 1:length(IVp)
+    for IVindex in eachindex(IVp)
         iv = IVp[IVindex]
         if iv <: Real
             push!(indexexprs, :(V.indexes[$IVindex]))
@@ -361,7 +361,7 @@ in(::Int, ::Colon) = true
     strideexprs[1] = 1
     i = 1
     Vdim = 1
-    for i = 1:length(Ip)
+    for i in eachindex(Ip)
         if Ip[i] != Int
             strideexprs[Vdim+1] = copy(strideexprs[Vdim])
             strideexprs[Vdim] = :(step(V.indexes[$i])*$(strideexprs[Vdim]))
@@ -420,7 +420,7 @@ first_index(V::SubArray) = first_index(V.parent, V.indexes)
 function first_index(P::AbstractArray, indexes::Tuple)
     f = 1
     s = 1
-    for i = 1:length(indexes)
+    for i in eachindex(indexes)
         f += (first(indexes[i])-1)*s
         s *= size(P, i)
     end
@@ -500,7 +500,7 @@ pointer(V::SubArray, i::Int) = pointer(V, ind2sub(size(V), i))
 function pointer{T,N,P<:Array,I<:Tuple{Vararg{RangeIndex}}}(V::SubArray{T,N,P,I}, is::Tuple{Vararg{Int}})
     index = first_index(V)
     strds = strides(V)
-    for d = 1:length(is)
+    for d in eachindex(is)
         index += (is[d]-1)*strds[d]
     end
     return pointer(V.parent, index)

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -113,7 +113,7 @@ function cpu_info()
     count = Array(Int32,1)
     uv_error("uv_cpu_info",ccall(:uv_cpu_info, Int32, (Ptr{Ptr{UV_cpu_info_t}}, Ptr{Int32}), UVcpus, count))
     cpus = Array(CPUinfo,count[1])
-    for i = 1:length(cpus)
+    for i in eachindex(cpus)
         cpus[i] = CPUinfo(unsafe_load(UVcpus[1],i))
     end
     ccall(:uv_free_cpu_info, Void, (Ptr{UV_cpu_info_t}, Int32), UVcpus[1], count[1])

--- a/base/test.jl
+++ b/base/test.jl
@@ -81,10 +81,10 @@ end
 
 macro test(ex)
     if typeof(ex) == Expr && ex.head == :comparison
-        syms = [gensym() for i = 1:length(ex.args)]
+        syms = [gensym() for i in eachindex(ex.args)]
         func_block = Expr(:block)
         # insert assignment into a block
-        func_block.args = [:($(syms[i]) = $(esc(ex.args[i]))) for i = 1:length(ex.args)]
+        func_block.args = [:($(syms[i]) = $(esc(ex.args[i]))) for i in eachindex(ex.args)]
         # finish the block with a return
         push!(func_block.args, Expr(:return, :(Expr(:comparison, $(syms...)), $(Expr(:comparison, syms...)))))
         :(do_test(()->($func_block), $(Expr(:quote,ex))))
@@ -124,7 +124,7 @@ function test_approx_eq(va, vb, Eps, astr, bstr)
               "\n  ", bstr, " (length $(length(vb))) = ", vb)
     end
     diff = real(zero(eltype(va)))
-    for i = 1:length(va)
+    for i in eachindex(va)
         xa = va[i]; xb = vb[i]
         if isfinite(xa) && isfinite(xb)
             diff = max(diff, abs(xa-xb))

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -15,6 +15,7 @@ getindex(t::Tuple, b::AbstractArray{Bool}) = getindex(t,find(b))
 start(t::Tuple) = 1
 done(t::Tuple, i::Int) = (length(t) < i)
 next(t::Tuple, i::Int) = (t[i], i+1)
+eachindex(t::Tuple) = 1:length(t)
 
 # this allows partial evaluation of bounded sequences of next() calls on tuples,
 # while reducing to plain next() for arbitrary iterables.
@@ -75,7 +76,7 @@ function isequal(t1::Tuple, t2::Tuple)
     if length(t1) != length(t2)
         return false
     end
-    for i = 1:length(t1)
+    for i in eachindex(t1)
         if !isequal(t1[i], t2[i])
             return false
         end
@@ -87,7 +88,7 @@ function ==(t1::Tuple, t2::Tuple)
     if length(t1) != length(t2)
         return false
     end
-    for i = 1:length(t1)
+    for i in eachindex(t1)
         if !(t1[i] == t2[i])
             return false
         end

--- a/base/unicode/utf32.jl
+++ b/base/unicode/utf32.jl
@@ -210,7 +210,7 @@ function convert(T::Type{UTF32String}, bytes::AbstractArray{UInt8})
 end
 
 function isvalid(::Type{UTF32String}, str::Union{Vector{UInt32}, Vector{Char}})
-    for i=1:length(str)
+    for i in eachindex(str)
         @inbounds if !isvalid(Char, UInt32(str[i])) ; return false ; end
     end
     return true

--- a/base/unicode/utf8.jl
+++ b/base/unicode/utf8.jl
@@ -41,7 +41,7 @@ end
 function length(s::UTF8String)
     d = s.data
     cnum = 0
-    for i = 1:length(d)
+    for i in eachindex(d)
         @inbounds cnum += !is_valid_continuation(d[i])
     end
     cnum


### PR DESCRIPTION
Continuing the changes made in #10858 and #8432, this changes `for i = 1:length(a)` to `for i in eachindex(a)` throughout Base, and adds missing `eachindex` methods for `Number` and `Tuple` types (which are required for generic code).

There should be no performance penalty to this, since in most cases `eachindex(a)` inlines to `1:length(a)` anyway.   But since using `eachindex(a)` in loops is now the preferred style, it seemed best to do it consistently in Base, both to establish the habit and to catch any problems.
