### PR TITLE
print memory usage and a truncated version of the object in whos()

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -6506,13 +6506,6 @@ Reorders the Generalized Schur factorization of a Generalized Schur object by ov
 ordschur!
 
 doc"""
-    whos([Module,] [pattern::Regex])
-
-Print information about exported global variables in a module, optionally restricted to those matching `pattern`.
-"""
-whos
-
-doc"""
 ```rst
 ::
 

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -412,6 +412,14 @@ end
 
 # testing
 
+
+doc"""
+    whos([io,] [Module,] [pattern::Regex])
+
+Print information about exported global variables in a module, optionally restricted to those matching `pattern`.
+
+The memory consumption estimate is an approximate lower bound on the size of the internal structure of the object.
+"""
 function whos(io::IO=STDOUT, m::Module=current_module(), pattern::Regex=r"")
     maxline = tty_size()[2]
     line = zeros(UInt8, maxline)
@@ -457,15 +465,17 @@ end
 whos(m::Module, pat::Regex=r"") = whos(STDOUT, m, pat)
 whos(pat::Regex) = whos(STDOUT, current_module(), pat)
 
-# summarysize is an estimate of the size of the object
-# as if all iterables were allocated inline
-# in general, this forms a conservative lower bound
-# on the memory "controlled" by the object
-# if recurse is true, then simply reachable memory
-# should also be included, otherwise, only
-# directly used memory should be included
-# you should never ignore recurse in cases where recursion is possible
+"""
+    summarysize(obj, recurse) => Int
 
+summarysize is an estimate of the size of the object
+as if all iterables were allocated inline
+in general, this forms a conservative lower bound
+n the memory "controlled" by the object
+if recurse is true, then simply reachable memory
+should also be included, otherwise, only
+directly used memory should be included
+you should never ignore recurse in cases where recursion is possible"""
 summarysize(obj::ANY, recurse::Bool) = try convert(Int, sizeof(obj)); catch; Core.sizeof(obj); end
 
 # these three cases override the exception that would be thrown by Core.sizeof

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -409,3 +409,242 @@ function runtests(tests = ["all"], numcores = ceil(Int,CPU_CORES/2))
               "including error messages above and the output of versioninfo():\n$(readall(buf))")
     end
 end
+
+# testing
+
+function whos(io::IO=STDOUT, m::Module=current_module(), pattern::Regex=r"")
+    maxline = tty_size()[2]
+    line = zeros(UInt8, maxline)
+    head = PipeBuffer(maxline + 1)
+    for v in sort!(names(m))
+        s = string(v)
+        if isdefined(m, v) && ismatch(pattern, s)
+            value = getfield(m, v)
+            bytes = summarysize(value, true)
+            @printf head "%30s " s
+            if bytes < 10_000
+                @printf(head, "%6d bytes  ", bytes)
+            else
+                @printf(head, "%6d KB     ", bytes ÷ (1024))
+            end
+            print(head, summary(value))
+            print(head, " : ")
+            show(head, value)
+
+            newline = search(head, UInt8('\n')) - 1
+            if newline < 0
+                newline = nb_available(head)
+            end
+            if newline > maxline
+                newline = maxline - 1 # make space for ...
+            end
+            line = resize!(line, newline)
+            line = read!(head, line)
+
+            write(io, line)
+            if nb_available(head) > 0 # more to read? replace with ...
+                print(io, '\u2026') # hdots
+            end
+            println(io)
+            seekend(head) # skip the rest of the text
+        end
+    end
+end
+whos(m::Module, pat::Regex=r"") = whos(STDOUT, m, pat)
+whos(pat::Regex) = whos(STDOUT, current_module(), pat)
+
+# summarysize is an estimate of the size of the object
+# as if all iterables were allocated inline
+# in general, this forms a conservative lower bound
+# on the memory "controlled" by the object
+# if recurse is true, then simply reachable memory
+# should also be included, otherwise, only
+# directly used memory should be included
+# you should never ignore recurse in cases where recursion is possible
+
+summarysize(obj::ANY, recurse::Bool) = try convert(Int, sizeof(obj)); catch; Core.sizeof(obj); end
+
+# these three cases override the exception that would be thrown by Core.sizeof
+summarysize(obj::Symbol, recurse::Bool) = 0
+summarysize(obj::DataType, recurse::Bool) = 0
+function summarysize(obj::Module, recurse::Bool)
+    size::Int = sizeof(obj)
+    if recurse
+        for binding in names(obj, true)
+            if isdefined(obj, binding)
+                value = getfield(obj, binding)
+                if (value !== obj) # skip the self-recursive definition
+                    recurseok = !isa(value, Module) || module_parent(value) === obj
+                    size += summarysize(value, recurseok)::Int # recurse on anything that isn't a module
+                end
+            end
+        end
+    end
+    return size
+end
+
+function summarysize(obj::Task, recurse::Bool)
+    size::Int = sizeof(obj)
+    if recurse
+        size += summarysize(obj.code, true)::Int
+        size += summarysize(obj.storage, true)::Int
+
+        size += summarysize(obj.backtrace, false)::Int
+        size += summarysize(obj.donenotify, false)::Int
+        size += summarysize(obj.exception, false)::Int
+        size += summarysize(obj.result, false)::Int
+    end
+    return size
+end
+
+function summarysize(obj::SimpleVector, recurse::Bool)
+    size::Int = sizeof(obj)
+    if recurse
+        for val in obj
+            if val !== obj
+                size += summarysize(val, false)::Int
+            end
+        end
+    end
+    return size
+end
+
+function summarysize(obj::Tuple, recurse::Bool)
+    size::Int = sizeof(obj)
+    if recurse
+        for val in obj
+            if val !== obj && !isbits(val)
+                size += summarysize(val, recurse)::Int
+            end
+        end
+    end
+    return size
+end
+
+function summarysize(obj::Array, recurse::Bool)
+    size::Int = sizeof(obj)
+    if recurse && !isbits(eltype(obj))
+        for i in 1:length(obj)
+            if isdefined(obj, i) && (val = obj[i]) !== obj
+                size += summarysize(val, false)::Int
+            end
+        end
+    end
+    return size
+end
+
+function summarysize(obj::AbstractArray, recurse::Bool)
+    size::Int = sizeof(obj)
+    if recurse && !isbits(eltype(obj))
+        for val in obj
+            if val !== obj
+                size += summarysize(val, false)::Int
+            end
+        end
+    end
+    return size
+end
+
+function summarysize(obj::Associative, recurse::Bool)
+    size::Int = sizeof(obj)
+    if recurse
+        for (key, val) in obj
+            if key !== obj
+                size += summarysize(key, false)::Int
+            end
+            if val !== obj
+                size += summarysize(val, false)::Int
+            end
+        end
+    end
+    return size
+end
+
+function summarysize(obj::Dict, recurse::Bool)
+    size::Int = sizeof(obj)
+    size += summarysize(obj.keys, recurse)::Int
+    size += summarysize(obj.vals, recurse)::Int
+    size += summarysize(obj.slots, recurse)::Int
+    return size
+end
+
+summarysize(obj::Set, recurse::Bool) =
+    sizeof(obj) + summarysize(obj.dict, recurse)
+
+function summarysize(obj::Function, recurse::Bool)
+    size::Int = sizeof(obj)
+    size += summarysize(obj.env, recurse)::Int
+    if isdefined(obj, :code)
+        size += summarysize(obj.code, recurse)::Int
+    end
+    return size
+end
+
+function summarysize(obj::MethodTable, recurse::Bool)
+    size::Int = sizeof(obj)
+    size += summarysize(obj.defs, recurse)::Int
+    size += summarysize(obj.cache, recurse)::Int
+    size += summarysize(obj.cache_arg1, recurse)::Int
+    size += summarysize(obj.cache_targ, recurse)::Int
+    if isdefined(obj, :kwsorter)
+        size += summarysize(obj.kwsorter, recurse)::Int
+    end
+    return size
+end
+
+function summarysize(obj::Method, recurse::Bool)
+    size::Int = sizeof(obj)
+    size += summarysize(obj.func, recurse)::Int
+    size += summarysize(obj.next, recurse)::Int
+    return size
+end
+
+function summarysize(obj::LambdaStaticData, recurse::Bool)
+    size::Int = sizeof(obj)
+    size += summarysize(obj.ast, true)::Int # always include the AST
+    size += summarysize(obj.sparams, true)::Int
+    if isdefined(obj, :roots)
+        size += summarysize(obj.roots, recurse)::Int
+    end
+    if isdefined(obj, :capt)
+        size += summarysize(obj.capt, false)::Int
+    end
+    return size
+end
+
+function summarysize(obj::Expr, recurse::Bool)
+    size::Int = sizeof(obj) + sizeof(obj.args)
+    if recurse
+        for arg in obj.args
+            size += summarysize(arg, isa(arg, Expr))::Int
+        end
+    end
+    return size
+end
+
+function summarysize(obj::Box, recurse::Bool)
+    size::Int = sizeof(obj)
+    # ignore the recurse parameter for Box,
+    # even though it could in theory recurse
+    # since it is an internal construct
+    # used by codegen with very limited usage
+    if isdefined(obj, :contents)
+        if obj.contents !== obj
+            size += summarysize(obj.contents, false)::Int
+        end
+    end
+    return size
+end
+
+function summarysize(obj::Ref, recurse::Bool)
+    size::Int = sizeof(obj)
+    if recurse && !isbits(eltype(obj))
+        try
+            val = obj[]
+            if val !== obj
+                size += summarysize(val, false)::Int
+            end
+        end
+    end
+    return size
+end

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -486,7 +486,9 @@ end
 function summarysize(obj::Task, recurse::Bool)
     size::Int = sizeof(obj)
     if recurse
-        size += summarysize(obj.code, true)::Int
+        if isdefined(obj, :code)
+            size += summarysize(obj.code, true)::Int
+        end
         size += summarysize(obj.storage, true)::Int
 
         size += summarysize(obj.backtrace, false)::Int

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -420,16 +420,20 @@ function whos(io::IO=STDOUT, m::Module=current_module(), pattern::Regex=r"")
         s = string(v)
         if isdefined(m, v) && ismatch(pattern, s)
             value = getfield(m, v)
-            bytes = summarysize(value, true)
             @printf head "%30s " s
-            if bytes < 10_000
-                @printf(head, "%6d bytes  ", bytes)
-            else
-                @printf(head, "%6d KB     ", bytes ÷ (1024))
+            try
+                bytes = summarysize(value, true)
+                if bytes < 10_000
+                    @printf(head, "%6d bytes  ", bytes)
+                else
+                    @printf(head, "%6d KB     ", bytes ÷ (1024))
+                end
+                print(head, summary(value))
+                print(head, " : ")
+                show(head, value)
+            catch e
+                print(head, "#=ERROR: unable to show value=#")
             end
-            print(head, summary(value))
-            print(head, " : ")
-            show(head, value)
 
             newline = search(head, UInt8('\n')) - 1
             if newline < 0

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -343,7 +343,8 @@ readbytes(io::AbstractIOBuffer, nb) = read!(io, Array(UInt8, min(nb, nb_availabl
 function search(buf::IOBuffer, delim::UInt8)
     p = pointer(buf.data, buf.ptr)
     q = ccall(:memchr,Ptr{UInt8},(Ptr{UInt8},Int32,Csize_t),p,delim,nb_available(buf))
-    nb = (q == C_NULL ? 0 : q-p+1)
+    nb::Int = (q == C_NULL ? 0 : q-p+1)
+    return nb
 end
 
 function search(buf::AbstractIOBuffer, delim::UInt8)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1166,18 +1166,6 @@ function show_nd(io::IO, a::AbstractArray, limit, print_matrix, label_slices)
     cartesianmap(print_slice, tail)
 end
 
-function whos(m::Module, pattern::Regex)
-    for v in sort(names(m))
-        s = string(v)
-        if isdefined(m,v) && ismatch(pattern, s)
-            println(rpad(s, 30), summary(eval(m,v)))
-        end
-    end
-end
-whos() = whos(r"")
-whos(m::Module) = whos(m, r"")
-whos(pat::Regex) = whos(current_module(), pat)
-
 # global flag for limiting output
 # TODO: this should be replaced with a better mechanism. currently it is only
 # for internal use in showing arrays.

--- a/src/task.c
+++ b/src/task.c
@@ -930,13 +930,13 @@ void jl_init_root_task(void *stack, size_t ssize)
     jl_current_task->current_module = jl_current_module;
     jl_current_task->last = jl_current_task;
     jl_current_task->tls = NULL;
-    jl_current_task->consumers = NULL;
+    jl_current_task->consumers = jl_nothing;
     jl_current_task->state = runnable_sym;
     jl_current_task->start = NULL;
-    jl_current_task->result = NULL;
-    jl_current_task->donenotify = NULL;
-    jl_current_task->exception = NULL;
-    jl_current_task->backtrace = NULL;
+    jl_current_task->result = jl_nothing;
+    jl_current_task->donenotify = jl_nothing;
+    jl_current_task->exception = jl_nothing;
+    jl_current_task->backtrace = jl_nothing;
     jl_current_task->eh = NULL;
     jl_current_task->gcstack = NULL;
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -161,11 +161,10 @@ v11801, t11801 = @timed sin(1)
 
 import Base.summarysize
 @test summarysize(Core, true) > summarysize(Core.Inference, true) > summarysize(Core, false) == summarysize(Core.Inference, false) == Core.sizeof(Core)
-@test summarysize(Main, true) > 10_000*summarysize(Main, false) > 10_000*sizeof(Int)
+@test summarysize(Base, true) > 10_000*summarysize(Base, false) > 10_000*sizeof(Int)
 @test 0 == summarysize(Int, true) == summarysize(Int, false) == summarysize(DataType, true) == summarysize(Ptr, true) == summarysize(Any, true)
 @test sprint(whos, Main, r"^$") == ""
 let v = sprint(whos, Main)
-    @test contains(v, " KB     Module : Main")
     @test contains(v, " KB     Module : Base")
     @test contains(v, " KB     Module : Core")
     @test contains(v, "  0 bytes  DataType : NoMethodHasThisType")

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -156,3 +156,21 @@ v11801, t11801 = @timed sin(1)
 @test isa(t11801,Real) && t11801 >= 0
 
 @test names(current_module(), true) == names_before_timing
+
+# interactive utilities
+
+import Base.summarysize
+@test summarysize(Core, true) > summarysize(Core.Inference, true) > summarysize(Core, false) == summarysize(Core.Inference, false) == Core.sizeof(Core)
+@test summarysize(Main, true) > 10_000*summarysize(Main, false) > 10_000*sizeof(Int)
+@test 0 == summarysize(Int, true) == summarysize(Int, false) == summarysize(DataType, true) == summarysize(Ptr, true) == summarysize(Any, true)
+@test sprint(whos, Main, r"^$") == ""
+let v = sprint(whos, Main)
+    @test contains(v, " KB     Module : Main")
+    @test contains(v, " KB     Module : Base")
+    @test contains(v, " KB     Module : Core")
+    @test contains(v, "  0 bytes  DataType : NoMethodHasThisType")
+    @test contains(v, "\u2026\n")
+    @test match(r".\u2026$"m, v) !== nothing
+    @test match(r"\u2026."m, v) === nothing
+    @test !contains(v, "Core.Inference")
+end

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -183,7 +183,7 @@ m = Mmap.mmap(file,Vector{UInt8},2,6)
 @test m[1] == "W".data[1]
 @test m[2] == "o".data[1]
 @test_throws BoundsError m[3]
-finalize(m); gc()
+finalize(m); m = nothing; gc()
 
 s = open(file, "w")
 write(s, [0xffffffffffffffff,
@@ -242,6 +242,7 @@ A4 = Mmap.mmap(s, Matrix{Int}, (m,150), convert(FileOffset,(2+150*m)*sizeof(Int)
 @test A[:, 151:end] == A4
 close(s)
 finalize(A2); finalize(A3); finalize(A4)
+A2 = A3 = A4 = nothing
 gc()
 rm(fname)
 


### PR DESCRIPTION
this avoids the issues and complications of the previous attempts at this by explicitly defining minimally-recursive byte ownership relationships, rather than recursing over all fields and guessing too much. the general heuristic here is that if something could (in theory) form a recursive tree, then it doesn't exclusively "own" that memory, so it doesn't need to get counted. Only when an object is effectively just an indirection (by construction), did I add some rules to try to incorporate more of the fields. In practice, I think this makes the results pretty much as good as they possibly can be.

example output:

```
julia> whos()
                    @code_llvm    335 bytes  Function : (anonymous function)
                @code_llvm_raw    339 bytes  Function : (anonymous function)
                 @code_lowered    338 bytes  Function : (anonymous function)
                  @code_native    337 bytes  Function : (anonymous function)
                   @code_typed    336 bytes  Function : (anonymous function)
                @code_warntype    339 bytes  Function : (anonymous function)
                         @edit    330 bytes  Function : (anonymous function)
                         @less    330 bytes  Function : (anonymous function)
                        @which    331 bytes  Function : (anonymous function)
                    ArrayViews    137 KB     Module : ArrayViews
                          Base  30951 KB     Module : Base
                         Cairo    144 KB     Module : Cairo
                         Color    322 KB     Module : Color
                        Compat     39 KB     Module : Compat
                          Core   2620 KB     Module : Core
                    DataArrays    512 KB     Module : DataArrays
                    DataFrames    888 KB     Module : DataFrames
                        Docile    268 KB     Module : Docile
             FixedPointNumbers     30 KB     Module : FixedPointNumbers
                          GZip    284 KB     Module : GZip
                      Graphics     61 KB     Module : Graphics
                           Gtk   3307 KB     Module : Gtk
                        Images    879 KB     Module : Images
                          Main  42168 KB     Module : Main
                      Reexport   3110 bytes  Module : Reexport
             SortingAlgorithms     22 KB     Module : SortingAlgorithms
                     StatsBase    360 KB     Module : StatsBase
                     StatsFuns    352 KB     Module : StatsFuns
                             a     24 bytes  3-element Array{Int64,1} : [1,2,3]
                           ans    406 KB     Function : summarysize
                             b     16 bytes  1-element Array{Any,1} : Any[2]
                             c     64 bytes  2x2 Array{Any,2} : Any[2 3…
                     clipboard    831 bytes  Function : clipboard
                 code_warntype   1980 bytes  Function : code_warntype
                             d    322 bytes  Dict{Any,Any} with 2 entries : Dict{Any,Any}("b"=>:B,"a"=>:a)
                      download   1849 bytes  Function : download
                   downloadcmd      0 bytes  Void : nothing
                             e    256 bytes  Dict{Int64,Char} with 2 entries : Dict(2=>'3',1=>'2')
                          edit   6241 bytes  Function : edit
                             f    123 KB     Function : +
                             g    212 bytes  Function : (anonymous function)
 gen_call_with_extracted_types   3005 bytes  Function : gen_call_with_extracted_types
                             h      8 bytes  UInt64 : 0x0000000000000000
                             i     48 bytes  Base.AbstractIOBuffer{Array{UInt8,1}} : IOBuffer(data=UInt8[...], readable=true, writabl…
                          less   1992 bytes  Function : less
                   methodswith   4074 bytes  Function : methodswith
                      runtests   1688 bytes  Function : runtests
                   summarysize    406 KB     Function : summarysize
             type_close_enough    656 bytes  Function : type_close_enough
                       typesof    465 bytes  Function : typesof
                   versioninfo   4238 bytes  Function : versioninfo
                          whos     17 KB     Function : whos
                     workspace    809 bytes  Function : workspace

julia> bigtask = let a = rand(100_000_00)
         Task(()->a)
       end
Task (runnable) @0x00000001122a0010

julia> Base.summarysize(bigtask, true)
80_000_299
```
