### PR TITLE
Rounding out some tests in linalg

### DIFF
--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -6,8 +6,6 @@
 convert{T}(::Type{Bidiagonal}, A::Diagonal{T})=Bidiagonal(A.diag, zeros(T, size(A.diag,1)-1), true)
 convert{T}(::Type{SymTridiagonal}, A::Diagonal{T})=SymTridiagonal(A.diag, zeros(T, size(A.diag,1)-1))
 convert{T}(::Type{Tridiagonal}, A::Diagonal{T})=Tridiagonal(zeros(T, size(A.diag,1)-1), A.diag, zeros(T, size(A.diag,1)-1))
-convert(::Type{UpperTriangular}, A::Diagonal) = UpperTriangular(full(A), :L)
-convert(::Type{LowerTriangular}, A::Diagonal) = LowerTriangular(full(A), :L)
 convert(::Type{LowerTriangular}, A::Bidiagonal) = !A.isupper ? LowerTriangular(full(A)) : throw(ArgumentError("Bidiagonal matrix must have lower off diagonal to be converted to LowerTriangular"))
 convert(::Type{UpperTriangular}, A::Bidiagonal) = A.isupper ? UpperTriangular(full(A)) : throw(ArgumentError("Bidiagonal matrix must have upper off diagonal to be converted to UpperTriangular"))
 convert(::Type{Matrix}, D::Diagonal) = diagm(D.diag)
@@ -148,4 +146,3 @@ end
 A_mul_Bc!(A::AbstractTriangular, B::QRCompactWYQ) = A_mul_Bc!(full!(A),B)
 A_mul_Bc!(A::AbstractTriangular, B::QRPackedQ) = A_mul_Bc!(full!(A),B)
 A_mul_Bc(A::AbstractTriangular, B::Union{QRCompactWYQ,QRPackedQ}) = A_mul_Bc(full(A), B)
-

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -114,6 +114,14 @@ debug && println("Fat LU")
     end
 end
 
+# test conversion routine
+a = Tridiagonal(rand(9),rand(10),rand(9))
+fa = full(a)
+falu = lufact(fa)
+alu = lufact(a)
+falu = convert(typeof(falu),alu)
+@test full(alu) == fa
+
 # Test rational matrices
 ## Integrate in general tests when more linear algebra is implemented in julia
 a = convert(Matrix{Rational{BigInt}}, rand(1:10//1,n,n))/n

--- a/test/linalg/special.jl
+++ b/test/linalg/special.jl
@@ -64,6 +64,7 @@ let a=[1.0:n;]
    @test full(convert(Bidiagonal, A)) == full(A)
    A = LowerTriangular(Tridiagonal(ones(n-1), [1.0:n;], zeros(n-1)))
    @test full(convert(Bidiagonal, A)) == full(A)
+   @test_throws ArgumentError convert(SymTridiagonal,A)
 
    A = LowerTriangular(full(Diagonal(a))) #morally Diagonal
    for newtype in [Diagonal, Bidiagonal, SymTridiagonal, LowerTriangular, Matrix]
@@ -102,4 +103,17 @@ let a=[1.0:n;]
        @test_approx_eq full(B - convert(Spectype,A)) full(B - A)
        @test_approx_eq full(convert(Spectype,A) - B) full(A - B)
    end
+end
+
+#Triangular Types and QR
+for typ in [UpperTriangular,LowerTriangular,Base.LinAlg.UnitUpperTriangular,Base.LinAlg.UnitLowerTriangular]
+    a = rand(n,n)
+    atri = typ(a)
+    b = rand(n,n)
+    qrb = qrfact(b,Val{true})
+    @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ full(atri) * qrb[:Q]'
+    @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ full(atri) * qrb[:Q]'
+    qrb = qrfact(b,Val{false})
+    @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ full(atri) * qrb[:Q]'
+    @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ full(atri) * qrb[:Q]'
 end

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -21,8 +21,11 @@ let A1 = randn(4,4) + im*randn(4,4)
 end
 
 let A1 = randn(4,4)
+    A3 = A1 * A1'
     A4 = A1 + A1.'
     @test expm(A4) ≈ expm(Symmetric(A4))
+    @test logm(A3) ≈ logm(Symmetric(A3))
+    @test logm(A3) ≈ logm(Hermitian(A3))
 end
 
 let n=10
@@ -156,6 +159,12 @@ let n=10
                 @test Hermitian(convert(Matrix{typ},asym)) == convert(Hermitian{typ,Matrix{typ}},Hermitian(asym))
             end
         end
+
+        #unsafe_getindex
+        if eltya <: Real
+            @test Symmetric(asym)[1:2,1:2] == asym[1:2,1:2]
+        end
+        @test Hermitian(asym)[1:2,1:2] == asym[1:2,1:2]
     end
 end
 


### PR DESCRIPTION
I found some extraneous `convert`s in `special.jl` - these are handled in `diagonal.jl`. I added tests for `blas` and `lu` and `symmetric`. 
