### PR TITLE
add missing eachindex method for indexable collections: SimpleVector, Tuple, and Number

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -219,6 +219,7 @@ start(v::SimpleVector) = 1
 next(v::SimpleVector,i) = (v[i],i+1)
 done(v::SimpleVector,i) = (i > v.length)
 isempty(v::SimpleVector) = (v.length == 0)
+eachindex(v::SimpleVector) = 1:length(v)
 
 function ==(v1::SimpleVector, v2::SimpleVector)
     length(v1)==length(v2) || return false

--- a/base/number.jl
+++ b/base/number.jl
@@ -18,6 +18,7 @@ getindex(x::Number, I::Real...) = getindex(x, to_indexes(I...)...)
 unsafe_getindex(x::Real, i::Real) = x
 first(x::Number) = x
 last(x::Number) = x
+eachindex(x::Number) = 1
 
 divrem(x,y) = (div(x,y),rem(x,y))
 fldmod(x,y) = (fld(x,y),mod(x,y))

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -9,6 +9,7 @@ getindex(t::Tuple, i::Int) = getfield(t, i)
 getindex(t::Tuple, i::Real) = getfield(t, convert(Int, i))
 getindex(t::Tuple, r::AbstractArray) = tuple([t[ri] for ri in r]...)
 getindex(t::Tuple, b::AbstractArray{Bool}) = getindex(t,find(b))
+eachindex(t::Tuple) = 1:length(t)
 
 ## iterating ##
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -3259,3 +3259,5 @@ code_typed(A12612.f2, Tuple{})
 @test_throws ArgumentError gensym("x"^10_000_000)
 @test symbol("x") === symbol("x")
 @test split(string(gensym("abc")),'#')[3] == "abc"
+
+@test DataType.types[eachindex(DataType.types)] == DataType.types

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2522,3 +2522,6 @@ end
 # issue #12536
 @test Rational{Int16}(1,2) === Rational(Int16(1),Int16(2))
 @test Rational{Int16}(500000,1000000) === Rational(Int16(1),Int16(2))
+
+@test collect(1.7) == [1.7]
+@test collect(eachindex(1.7)) == [1]

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -135,3 +135,5 @@ foo(x, y, z) = x + y + z
 
 @test @inferred(ntuple(Base.Abs2Fun(), Val{2})) == (1, 4)
 @test @inferred(ntuple(Base.Abs2Fun(), Val{6})) == (1, 4, 9, 16, 25, 36)
+
+@test eachindex((7,1,4)) == 1:3


### PR DESCRIPTION
This adds a few missing `eachindex` methods for indexable collections that I noticed in #12788.

I think the principle is that any iterable collection that implements `getindex` should implement `eachindex`, to enable the writing of generic code for such indexable collections.  That includes `SimpleVector` (used for low-level stuff like `DataType.types`), `Tuple`, and `Number` (since numbers are indexable collections in Julia, primarily to make it easy to write generic code that works for both vectors and scalars).
