### PR TITLE
Made DateFormat Extensible

### DIFF
--- a/base/dates/adjusters.jl
+++ b/base/dates/adjusters.jl
@@ -39,6 +39,7 @@ function lastdayofyear(dt::Date)
     y,m,d = yearmonthday(dt)
     return Date(UTD(value(dt)+daysinyear(y)-dayofyear(y,m,d)))
 end
+lastdayofyear(dt::DateTime) = DateTime(lastdayofyear(Date(dt)))
 
 @vectorize_1arg TimeType firstdayofyear
 @vectorize_1arg TimeType lastdayofyear

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -99,7 +99,7 @@ function DateFormat(f::AbstractString,locale::AbstractString="english")
         last_offset = m.offset + width
     end
 
-    tran = last_offset > endof(f) ? r"$" : f[last_offset:end]
+    tran = last_offset > endof(f) ? r"(?=\s|$)" : f[last_offset:end]
     if !isempty(params)
         slot = tran == "" ? FixedWidthSlot(params...) : DelimitedSlot(params..., tran)
         push!(slots,slot)
@@ -137,7 +137,7 @@ end
 getslot(x,slot,locale,cursor) = (cursor+slot.width, slotparse(slot,x[cursor:(cursor+slot.width-1)], locale))
 
 function parse(x::AbstractString,df::DateFormat)
-    x = strip(replace(x, r"#.*$", ""))
+    x = strip(x)
     startswith(x, df.prefix) && (x = replace(x, df.prefix, "", 1))
     isempty(x) && throw(ArgumentError("Cannot parse empty format string"))
     if isa(df.slots[1], DelimitedSlot) && first(search(x,df.slots[1].transition)) == 0

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -59,19 +59,27 @@ abstract DayOfWeekSlot
 
 # Slot rules translate letters into types. Note that
 # list of rules can be extended.
-const SLOT_RULE = Dict{Char,Type}(
-    'y' => Year,
-    'm' => Month,
-    'u' => Month,
-    'U' => Month,
-    'e' => DayOfWeekSlot,
-    'E' => DayOfWeekSlot,
-    'd' => Day,
-    'H' => Hour,
-    'M' => Minute,
-    'S' => Second,
-    's' => Millisecond,
-)
+immutable SlotRule
+    rules::Array{Type}
+end
+const SLOT_RULE = SlotRule(Array{Type}(256))
+
+getindex(collection::SlotRule, key::Char) = collection.rules[Int(key)]
+setindex!(collection::SlotRule, value::Type, key::Char) = collection.rules[Int(key)] = value
+keys(c::SlotRule) = map(Char, filter(el -> isdefined(c.rules, el), eachindex(c.rules)))
+
+SLOT_RULE['y'] = Year
+SLOT_RULE['m'] = Month
+SLOT_RULE['u'] = Month
+SLOT_RULE['U'] = Month
+SLOT_RULE['e'] = DayOfWeekSlot
+SLOT_RULE['E'] = DayOfWeekSlot
+SLOT_RULE['d'] = Day
+SLOT_RULE['H'] = Hour
+SLOT_RULE['M'] = Minute
+SLOT_RULE['S'] = Second
+SLOT_RULE['s'] = Millisecond
+
 duplicates(slots) = any(map(x->count(y->x.parser==y.parser,slots),slots) .> 1)
 
 function DateFormat(f::AbstractString,locale::AbstractString="english")

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -51,7 +51,7 @@ end
 
 immutable DateFormat
     slots::Array{Slot,1}
-    prefix # optional transition from the start of a string to the 1st slot
+    prefix::AbstractString # optional transition from the start of a string to the 1st slot
     locale::AbstractString
 end
 
@@ -138,7 +138,7 @@ getslot(x,slot,locale,cursor) = (cursor+slot.width, slotparse(slot,x[cursor:(cur
 
 function parse(x::AbstractString,df::DateFormat)
     x = strip(replace(x, r"#.*$", ""))
-    x = replace(x,df.prefix,"")
+    startswith(x, df.prefix) && (x = replace(x, df.prefix, "", 1))
     isempty(x) && throw(ArgumentError("Cannot parse empty format string"))
     if isa(df.slots[1], DelimitedSlot) && first(search(x,df.slots[1].transition)) == 0
         throw(ArgumentError("Delimiter mismatch. Couldn't find first delimiter, \"$(df.slots[1].transition)\", in date string"))
@@ -175,7 +175,7 @@ end
 slotformat(slot::Slot{Millisecond},dt,locale) = rpad(string(millisecond(dt)/1000.0)[3:end], slot.width, "0")
 
 function format(dt::TimeType,df::DateFormat)
-    f = ""
+    f = df.prefix
     for slot in df.slots
         f *= slotformat(slot,dt,df.locale)
         if isa(slot, DelimitedSlot)

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -62,24 +62,42 @@ immutable DayOfWeekSlot <: AbstractTime end
 
 duplicates(slots) = any(map(x->count(y->x.period==y.period,slots),slots) .> 1)
 
+# Dicts are not constant to allow for extensibility.
+SLOT_TYPE = Dict(
+    'y' => Year,
+    'm' => Month,
+    'u' => Month,
+    'U' => Month,
+    'E' => DayOfWeekSlot,
+    'e' => DayOfWeekSlot,
+    'd' => Day,
+    'H' => Hour,
+    'M' => Minute,
+    'S' => Second,
+    's' => Millisecond,
+)
+
+SLOT_OPTION = Dict(
+    'e' => 1,
+    'E' => 2,
+    'u' => 1,
+    'U' => 2,
+)
+
 function DateFormat(f::AbstractString,locale::AbstractString="english")
     slots = Slot[]
     trans = []
-    begtran = match(r"^.*?(?=[ymuUdHMSsEe])",f).match
-    ss = split(f,r"^.*?(?=[ymuUdHMSsEe])")
-    s = split(begtran == "" ? ss[1] : ss[2],r"[^ymuUdHMSsEe]+|(?<=([ymuUdHMSsEe])(?!\1))")
+    ids = join(keys(SLOT_TYPE), "")
+    begtran, format = match(Regex("(^[^$ids]*)(.*)"), f).captures
+    s = split(format, Regex("[^$ids]+|(?<=([$ids])(?!\\1))"))
     for (i,k) in enumerate(s)
         k == "" && break
         tran = i >= endof(s) ? r"$" : match(Regex("(?<=$(s[i])).*(?=$(s[i+1]))"),f).match
         slot = tran == "" ? FixedWidthSlot : DelimitedSlot
         width = length(k)
-        typ = 'E' in k ? DayOfWeekSlot : 'e' in k ? DayOfWeekSlot :
-              'y' in k ? Year : 'm' in k ? Month :
-              'u' in k ? Month : 'U' in k ? Month :
-              'd' in k ? Day : 'H' in k ? Hour :
-              'M' in k ? Minute : 'S' in k ? Second : Millisecond
-        option = 'E' in k ? 2 : 'e' in k ? 1 :
-                 'U' in k ? 2 : 'u' in k ? 1 : 0
+        c = k[1]
+        typ = SLOT_TYPE[c]
+        option = get(SLOT_OPTION, c, 0)
         push!(slots,slot(i,typ,width,option,locale))
         push!(trans,tran)
     end
@@ -117,13 +135,14 @@ function parse(x::AbstractString,df::DateFormat)
     isempty(x) && throw(ArgumentError("Cannot parse empty format string"))
     (typeof(df.slots[1]) <: DelimitedSlot && first(search(x,df.trans[1])) == 0) && throw(ArgumentError("Delimiter mismatch. Couldn't find first delimiter, \"$(df.trans[1])\", in date string"))
     periods = Period[]
+    extra = []
     cursor = 1
     for slot in df.slots
         cursor, pe = getslot(x,slot,df,cursor)
-        pe !== nothing && push!(periods,pe)
+        pe != nothing && (isa(pe,Period) ? push!(periods,pe) : push!(extra,pe))
         cursor > endof(x) && break
     end
-    return sort!(periods,rev=true,lt=periodisless)
+    return vcat(sort!(periods,rev=true,lt=periodisless), extra)
 end
 
 slotformat(slot::Slot{Year},dt) = lpad(string(value(slot.period(dt))),slot.width,"0")[(end-slot.width+1):end]

--- a/test/dates/adjusters.jl
+++ b/test/dates/adjusters.jl
@@ -183,6 +183,17 @@ end
 @test Dates.lastdayofquarter(Dates.DateTime(2014,8,2)) == Dates.DateTime(2014,9,30)
 @test Dates.lastdayofquarter(Dates.DateTime(2014,12,2)) == Dates.DateTime(2014,12,31)
 
+first = Dates.Date(2014,1,1)
+last = Dates.Date(2014,12,31)
+for i = 0:364
+    dt = first + Dates.Day(i)
+
+    @test Dates.firstdayofyear(dt) == first
+    @test Dates.firstdayofyear(DateTime(dt)) == DateTime(first)
+
+    @test Dates.lastdayofyear(dt) == last
+    @test Dates.lastdayofyear(DateTime(dt)) == DateTime(last)
+end
 
 # Adjusters
 # Adjuster Constructors

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -176,6 +176,10 @@ gg = "Jan-1996-15"
 f = "uuu-yyyy-dd"
 @test Dates.DateTime(gg,f) == dt
 @test Dates.format(dt,f) == gg
+hh = "1996#1#15"
+f = "yyyy#m#d"
+@test Dates.DateTime(hh,f) == dt
+@test Dates.format(dt,f) == hh
 
 # test prefix.
 s = "/1996/1/15"

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -177,6 +177,13 @@ f = "uuu-yyyy-dd"
 @test Dates.DateTime(gg,f) == dt
 @test Dates.format(dt,f) == gg
 
+# test prefix.
+s = "/1996/1/15"
+f = "/yyyy/m/d"
+@test Dates.DateTime(s,f) == dt
+@test Dates.format(dt,f) == s
+@test Dates.DateTime("1996/1/15",f) == dt
+
 # from Jiahao
 @test Dates.Date("2009年12月01日","yyyy年mm月dd日") == Dates.Date(2009,12,1)
 @test Dates.format(Dates.Date(2009,12,1),"yyyy年mm月dd日") == "2009年12月01日"


### PR DESCRIPTION
When I was working on [TimeZones.jl](https://github.com/quinnj/TimeZones.jl) I found out that the DateFormat code was written in such a way that made it difficult to extend. As a [temporary solution in TimeZones.jl](https://github.com/quinnj/TimeZones.jl/blob/v0.0.1/src/timezones/io.jl) I overwrote some of the `Base.Dates` methods such that I could include support for new slot letters 'Z' and 'z'.

The following pull request mades the `Base.Dates` implementation of `DateFormat` easier for the TimeZones.jl package to extend and additionally fixes some minor bugs.
