### PR TITLE
Fix bug in elementary reflector calculation when the norm of the vector was zero.

### DIFF
--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -119,3 +119,5 @@ for elty in [Float32,Float64,Complex64,Complex128]
     @test ishermitian(one(elty))
     @test det(a) == a
 end
+
+@test qr(big([0 1; 0 0]))[2] == [0 1; 0 0]


### PR DESCRIPTION
Change name and signature of reflector methods.

Some cleanup of `A_ldiv_B!(QR,Matrix)`

There wasn't a check for if the norm of the vector for which the reflector was calculated was zero which could result `NaN`s for very sparse matrices. I've therefore added fix.

I've also changed the signtaure and name of reflector function. The versions for left and right side were almost identical so they are now merged. I've checked the packages in `METADATA.jl` and no packages are using these functions.

Finally, the update of the matrix with the reflector has been factorored out in a function.
