### PR TITLE
Remove restriction from _trsen wrappers

### DIFF
--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -3889,7 +3889,9 @@ for (trexc, trsen, tgsen, elty) in
             @lapackerror
             T, Q
         end
-        function trsen!(select::StridedVector{BlasInt}, T::StridedMatrix{$elty}, Q::StridedMatrix{$elty})
+        trsen!(select::StridedVector{BlasInt}, T::StridedMatrix{$elty}, Q::StridedMatrix{$elty}) =
+            trsen!('N', 'V', select, T, Q)
+        function trsen!(compq::Char, job::Char, select::StridedVector{BlasInt}, T::StridedMatrix{$elty}, Q::StridedMatrix{$elty})
 # *     .. Scalar Arguments ..
 #       CHARACTER          COMPQ, JOB
 #       INTEGER            INFO, LDQ, LDT, LIWORK, LWORK, M, N
@@ -3920,7 +3922,7 @@ for (trexc, trsen, tgsen, elty) in
                     Ptr{$elty}, Ptr{$elty}, Ptr{BlasInt}, Ptr{Void}, Ptr{Void},
                     Ptr{$elty}, Ptr{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt},
                     Ptr{BlasInt}),
-                    &'N', &'V', select, &n,
+                    &compq, &job, select, &n,
                     T, &ldt, Q, &ldq,
                     wr, wi, &m, C_NULL, C_NULL,
                     work, &lwork, iwork, &liwork,
@@ -4035,7 +4037,9 @@ for (trexc, trsen, tgsen, elty) in
             @lapackerror
             T, Q
         end
-        function trsen!(select::StridedVector{BlasInt}, T::StridedMatrix{$elty}, Q::StridedMatrix{$elty})
+        trsen!(select::StridedVector{BlasInt}, T::StridedMatrix{$elty}, Q::StridedMatrix{$elty}) =
+            trsen!('N', 'V', select, T, Q)
+        function trsen!(compq::Char, job::Char, select::StridedVector{BlasInt}, T::StridedMatrix{$elty}, Q::StridedMatrix{$elty})
 # *     .. Scalar Arguments ..
 #       CHARACTER          COMPQ, JOB
 #       INTEGER            INFO, LDQ, LDT, LWORK, M, N
@@ -4062,7 +4066,7 @@ for (trexc, trsen, tgsen, elty) in
                     Ptr{$elty}, Ptr{BlasInt}, Ptr{Void}, Ptr{Void},
                     Ptr{$elty}, Ptr{BlasInt},
                     Ptr{BlasInt}),
-                    &'N', &'V', select, &n,
+                    &compq, &job, select, &n,
                     T, &ldt, Q, &ldq,
                     w, &m, C_NULL, C_NULL,
                     work, &lwork,

--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -460,6 +460,20 @@ for elty in (Float32, Float64, Complex64, Complex128)
     for c in ('V', 'N')
         A = convert(Matrix{elty}, [7 2 2 1; 1 5 2 0; 0 3 9 4; 1 1 1 4])
         T,Q,d = schur(A)
+        Base.LinAlg.LAPACK.trsen!('N',c,Array{LinAlg.BlasInt}([0,1,0,0]),T,Q)
+        @test d[1] ≈ T[2,2]
+        @test d[2] ≈ T[1,1]
+        if (c == 'V')
+            @test  Q * T * Q' ≈ A
+        end
+    end
+end
+
+#trexc and trsen
+for elty in (Float32, Float64, Complex64, Complex128)
+    for c in ('V', 'N')
+        A = convert(Matrix{elty}, [7 2 2 1; 1 5 2 0; 0 3 9 4; 1 1 1 4])
+        T,Q,d = schur(A)
         Base.LinAlg.LAPACK.trexc!(c,LinAlg.BlasInt(1),LinAlg.BlasInt(2),T,Q)
         @test d[1] ≈ T[2,2]
         @test d[2] ≈ T[1,1]


### PR DESCRIPTION
As pointed out in [#12659](https://github.com/JuliaLang/julia/pull/12659#discussion_r37488504), options supported by LAPACK should not be restricted. This commit fixes the issue for the `_trsen` family.
