### PR TITLE
make apply_type error messages more understandable

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -86,7 +86,7 @@ end
 
 function show(io::IO, x::DataType)
     show(io, x.name)
-    if (length(x.parameters) > 0 || x.name === Tuple.name) && x !== Tuple
+    if (length(x.parameters) > 0 || x.name === Tuple.name) && x !== x.name.primary
         print(io, '{')
         n = length(x.parameters)
         for i = 1:n

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1004,7 +1004,9 @@ JL_CALLABLE(jl_f_instantiate_type)
         for(size_t i=1; i < nargs; i++) {
             jl_value_t* ty = args[i];
             if ((!jl_is_type(ty) && !jl_is_typevar(ty)) || jl_is_vararg_type(ty)) {
-                jl_type_error_rt("apply_type", "parameter of Union",
+                char pstr[32];
+                snprintf(pstr, sizeof(pstr), "parameter %d", (int)i);
+                jl_type_error_rt("Union{...} expression", pstr,
                                  (jl_value_t*)jl_type_type, args[i]);
             }
         }
@@ -1013,13 +1015,15 @@ JL_CALLABLE(jl_f_instantiate_type)
         for(size_t i=1; i < nargs; i++) {
             jl_value_t* ty = args[i];
             if (jl_is_vararg_type(ty) && i != nargs-1) {
-                jl_type_error_rt("apply_type", "parameter of Tuple",
+                char pstr[32];
+                snprintf(pstr, sizeof(pstr), "parameter %d", (int)i);
+                jl_type_error_rt("Tuple{...} expression", pstr,
                                  (jl_value_t*)jl_type_type, args[i]);
             }
         }
     }
-    else if (!jl_is_datatype(args[0])) {
-        JL_TYPECHK(instantiate_type, typector, args[0]);
+    else if (!jl_is_datatype(args[0]) && !jl_is_typector(args[0])) {
+        jl_type_error("Type{...} expression", (jl_value_t*)jl_type_type, args[0]);
     }
     return jl_apply_type_(args[0], &args[1], nargs-1);
 }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -7,6 +7,7 @@
   . builtin type definitions
 */
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <assert.h>
 #ifdef _OS_WINDOWS_
@@ -1689,7 +1690,7 @@ jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n)
     jl_datatype_t *stprimary = NULL;
     if (jl_is_typector(tc)) {
         tp = ((jl_typector_t*)tc)->parameters;
-        tname = "alias";
+        tname = "typealias";
     }
     else {
         assert(jl_is_datatype(tc));
@@ -1700,10 +1701,9 @@ jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n)
     for(i=0; i < n; i++) {
         jl_value_t *pi = params[i];
         if (!valid_type_param(pi)) {
-            jl_type_error_rt("apply_type", tname,
-                             jl_subtype(pi, (jl_value_t*)jl_number_type, 1) ?
-                             (jl_value_t*)jl_long_type : (jl_value_t*)jl_type_type,
-                             pi);
+            char pstr[32];
+            snprintf(pstr, sizeof(pstr), "parameter %d", (int)i+1);
+            jl_type_error_rt(tname, pstr, tc, pi);
         }
     }
     if (tc == (jl_value_t*)jl_ntuple_type && (n == 1 || n == 2)) {
@@ -1712,7 +1712,7 @@ jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n)
             if (!jl_get_size(params[0], &nt)) {
                 // Only allow Int or TypeVar as the first parameter to
                 // NTuple. issue #9233
-                jl_type_error_rt("apply_type", "first parameter of NTuple",
+                jl_type_error_rt("NTuple{T, N} expression", "first parameter of NTuple",
                                  (jl_value_t*)jl_long_type, params[0]);
             }
             return jl_tupletype_fill(nt, (n==2) ? params[1] :

--- a/test/core.jl
+++ b/test/core.jl
@@ -3069,14 +3069,14 @@ Base.convert(::Type{Foo11874},x::Int) = float(x)
 @test_throws TypeError bar11874(1)
 
 # issue #9233
-let
+let func = Symbol("NTuple{T, N} expression")
     err = @test_throws TypeError NTuple{Int, 1}
-    @test err.func == :apply_type
+    @test err.func == func
     @test err.expected == Int
     @test err.got == Int
 
     err = @test_throws TypeError NTuple{0x1, Int}
-    @test err.func == :apply_type
+    @test err.func == func
     @test err.expected == Int
     @test err.got == 0x1
 end


### PR DESCRIPTION
the current `apply_type` error message assumes the user knows that `Type{...}` expressions translate into calls to apply_type. This change is intended to make the error messages both more informative (more specific to the error) and more easily comprehended to those uninitiated with the bowels of the julia src code.
