### PR TITLE
Change open(cmd) to return Process instead of Tuple

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1324,5 +1324,18 @@ end
 
 # END 0.6 deprecations
 
+# BEGIN 0.7 deprecations
+
+# 12807
+start(::Union{Process, ProcessChain}) = 1
+done(::Union{Process, ProcessChain}, i::Int) = (i == 3)
+next(p::Union{Process, ProcessChain}, i::Int) = (getindex(p, i), i + 1)
+@noinline function getindex(p::Union{Process, ProcessChain}, i::Int)
+    depwarn("open(cmd) now returns only a Process<:IO object", :getindex)
+    return i == 1 ? getfield(p, p.openstream) : p
+end
+
+# END 0.7 deprecations
+
 # BEGIN 1.0 deprecations
 # END 1.0 deprecations

--- a/base/distributed/cluster.jl
+++ b/base/distributed/cluster.jl
@@ -525,8 +525,8 @@ function launch_additional(np::Integer, cmd::Cmd)
     addresses = Vector{Any}(np)
 
     for i in 1:np
-        io, pobj = open(pipeline(detach(cmd), stderr=STDERR), "r")
-        io_objs[i] = io
+        io = open(detach(cmd))
+        io_objs[i] = io.out
     end
 
     for (i,io) in enumerate(io_objs)

--- a/base/distributed/managers.jl
+++ b/base/distributed/managers.jl
@@ -202,10 +202,10 @@ function launch_on_machine(manager::SSHManager, machine, cnt, params, launched, 
     # detach launches the command in a new process group, allowing it to outlive
     # the initial julia process (Ctrl-C and teardown methods are handled through messages)
     # for the launched processes.
-    io, pobj = open(pipeline(detach(cmd), stderr=STDERR), "r")
+    io = open(detach(cmd))
 
     wconfig = WorkerConfig()
-    wconfig.io = io
+    wconfig.io = io.out
     wconfig.host = host
     wconfig.tunnel = params[:tunnel]
     wconfig.sshflags = sshflags
@@ -321,12 +321,11 @@ function launch(manager::LocalManager, params::Dict, launched::Array, c::Conditi
     bind_to = manager.restrict ? `127.0.0.1` : `$(LPROC.bind_addr)`
 
     for i in 1:manager.np
-        io, pobj = open(pipeline(detach(
-                setenv(`$(julia_cmd(exename)) $exeflags --bind-to $bind_to --worker $(cluster_cookie())`, dir=dir)),
-            stderr=STDERR), "r")
+        cmd = `$(julia_cmd(exename)) $exeflags --bind-to $bind_to --worker $(cluster_cookie())`
+        io = open(detach(setenv(cmd, dir=dir)))
         wconfig = WorkerConfig()
-        wconfig.process = pobj
-        wconfig.io = io
+        wconfig.process = io
+        wconfig.io = io.out
         wconfig.enable_threaded_blas = params[:enable_threaded_blas]
         push!(launched, wconfig)
     end

--- a/examples/clustermanager/simple/UnixDomainCM.jl
+++ b/examples/clustermanager/simple/UnixDomainCM.jl
@@ -13,10 +13,10 @@ function launch(manager::UnixDomainCM, params::Dict, launched::Array, c::Conditi
         sockname = tempname()
         try
             cmd = `$(params[:exename]) --startup-file=no $(@__FILE__) udwrkr $sockname $cookie`
-            io, pobj = open(cmd, "r")
+            pobj = open(cmd)
 
             wconfig = WorkerConfig()
-            wconfig.userdata = Dict(:sockname=>sockname, :io=>io, :process=>pobj)
+            wconfig.userdata = Dict(:sockname=>sockname, :io=>pobj.out, :process=>pobj)
             push!(launched, wconfig)
             notify(c)
         catch e

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -1307,11 +1307,11 @@ function Base.launch(manager::ErrorSimulator, params::Dict, launched::Array, c::
     else
         error("Unknown mode")
     end
-    io, pobj = open(pipeline(detach(setenv(cmd, dir=dir)); stderr=STDERR), "r")
+    io = open(detach(setenv(cmd, dir=dir)))
 
     wconfig = WorkerConfig()
-    wconfig.process = pobj
-    wconfig.io = io
+    wconfig.process = io
+    wconfig.io = io.out
     push!(launched, wconfig)
     notify(c)
 end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -242,26 +242,26 @@ let fname = tempname()
     function thrash(handle::Ptr{Void})
         # Kill the memory, but write a nice low value in the libuv type field to
         # trigger the right code path
-        ccall(:memset,Ptr{Void},(Ptr{Void},Cint,Csize_t),handle,0xee,3*sizeof(Ptr{Void}))
-        unsafe_store!(convert(Ptr{Cint},handle+2*sizeof(Ptr{Void})),15)
+        ccall(:memset, Ptr{Void}, (Ptr{Void}, Cint, Csize_t), handle, 0xee, 3 * sizeof(Ptr{Void}))
+        unsafe_store!(convert(Ptr{Cint}, handle + 2 * sizeof(Ptr{Void})), 15)
         nothing
     end
     OLD_STDERR = STDERR
-    redirect_stderr(open("$(escape_string(fname))","w"))
+    redirect_stderr(open("$(escape_string(fname))", "w"))
     # Usually this would be done by GC. Do it manually, to make the failure
     # case more reliable.
     oldhandle = OLD_STDERR.handle
     OLD_STDERR.status = Base.StatusClosing
     OLD_STDERR.handle = C_NULL
-    ccall(:uv_close,Void,(Ptr{Void},Ptr{Void}),oldhandle,cfunction(thrash,Void,(Ptr{Void},)))
+    ccall(:uv_close, Void, (Ptr{Void}, Ptr{Void}), oldhandle, cfunction(thrash, Void, (Ptr{Void},)))
     sleep(1)
     import Base.zzzInvalidIdentifier
     """
     try
-        (in,p) = open(pipeline(`$exename --startup-file=no`, stderr=STDERR), "w")
-        write(in,cmd)
-        close(in)
-        wait(p)
+        io = open(pipeline(`$exename --startup-file=no`, stderr=STDERR), "w")
+        write(io, cmd)
+        close(io)
+        wait(io)
     catch
         error("IOStream redirect failed. Child stderr was \n$(readstring(fname))\n")
     finally


### PR DESCRIPTION
fixes #9659 by changing open(Cmd) to only return a Process, and defining close(Process) to mean `close(Process.in) && close(Process.out)`. this is a breaking change, since i know of no way to sanely provide a deprecation for this (I would prefer not to define iteration over a Process object as returning the old tuple of (io, process))
