### PR TITLE
RFC: Use Julia hypot instead of libm hypot.

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -103,7 +103,7 @@ end
 ## generic functions of complex numbers ##
 
 conj(z::Complex) = Complex(real(z),-imag(z))
-abs(z::Complex)  = hypot(real(z), imag(z))
+@inline abs(z::Complex)  = hypot(real(z), imag(z))
 abs2(z::Complex) = real(z)*real(z) + imag(z)*imag(z)
 inv(z::Complex)  = conj(z)/abs2(z)
 inv{T<:Integer}(z::Complex{T}) = inv(float(z))

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -179,7 +179,7 @@ function vecnorm(itr, p::Real=2)
         vecnormp(itr,p)
     end
 end
-vecnorm(x::Number, p::Real=2) = p == 0 ? real(x==0 ? zero(x) : one(x)) : abs(x)
+@inline vecnorm(x::Number, p::Real=2) = ifelse(p == 0, convert(typeof(abs(zero(x))), x == zero(x) ? 0 : 1), abs(x))
 
 norm(x::AbstractVector, p::Real=2) = vecnorm(x, p)
 
@@ -233,8 +233,7 @@ function norm{T}(A::AbstractMatrix{T}, p::Real=2)
     end
 end
 
-norm(x::Number, p::Real=2) =
-    p == 0 ? convert(typeof(real(x)), ifelse(x != 0, 1, 0)) : abs(x)
+@inline norm(x::Number, p::Real=2) = vecnorm(x, p)
 
 function vecdot(x::AbstractVector, y::AbstractVector)
     lx = length(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -146,15 +146,17 @@ sqrt(x::Float32) = box(Float32,sqrt_llvm(unbox(Float32,x)))
 sqrt(x::Real) = sqrt(float(x))
 @vectorize_1arg Number sqrt
 
-hypot(x::Real, y::Real) = hypot(promote(float(x), float(y))...)
-function hypot{T<:AbstractFloat}(x::T, y::T)
+@inline hypot(x::Real, y::Real) = hypot(promote(float(x), float(y))...)
+@inline function hypot{T<:AbstractFloat}(x::T, y::T)
     x = abs(x)
     y = abs(y)
     if x < y
         x, y = y, x
     end
-    if x == 0
+    if x == zero(x)
         r = y/one(x)
+    elseif x < sqrt(realmax(x))
+        return sqrt(x*x + y*y)
     else
         r = y/x
         if isnan(r)
@@ -163,19 +165,15 @@ function hypot{T<:AbstractFloat}(x::T, y::T)
             return r
         end
     end
-    x * sqrt(one(r)+r*r)
+    x*sqrt(one(r) + r*r)
 end
+@vectorize_2arg Number hypot
 
 atan2(y::Real, x::Real) = atan2(promote(float(y),float(x))...)
 atan2{T<:AbstractFloat}(y::T, x::T) = Base.no_op_err("atan2", T)
-
-for f in (:atan2, :hypot)
-    @eval begin
-        ($f)(y::Float64, x::Float64) = ccall(($(string(f)),libm), Float64, (Float64, Float64,), y, x)
-        ($f)(y::Float32, x::Float32) = ccall(($(string(f,"f")),libm), Float32, (Float32, Float32), y, x)
-        @vectorize_2arg Number $f
-    end
-end
+atan2(y::Float64, x::Float64) = ccall((:atan2,libm), Float64, (Float64, Float64,), y, x)
+atan2(y::Float32, x::Float32) = ccall((:atan2f,libm), Float32, (Float32, Float32), y, x)
+@vectorize_2arg Number atan2
 
 max{T<:AbstractFloat}(x::T, y::T) = ifelse((y > x) | (signbit(y) < signbit(x)),
                                     ifelse(isnan(y), x, y), ifelse(isnan(x), y, x))


### PR DESCRIPTION
Only scale in hypot when necessary.

Make use abs(Complex) is inlined.

Our own `hypot` appears to be almost double as fast as the `libm` version, but we might not be careful enough about underflow.

A main motivation for this is to make it easier for the compiler to optimize expressions with `abs(Complex)`. With these changes we don't call out to libm and all components are inlined.
