### PR TITLE
Add keys(::Array) and values(::Array)

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -981,3 +981,18 @@ end
 symdiff(a) = a
 symdiff(a, b) = union(setdiff(a,b), setdiff(b,a))
 symdiff(a, b, rest...) = symdiff(a, symdiff(b, rest...))
+
+# Lightweight wrapper type for values(::Array)
+immutable ArrayIterator{T,N}
+    array::Array{T,N}
+end
+start(ai::ArrayIterator) = start(ai.array)
+next(ai::ArrayIterator,k) = next(ai.array,k)
+done(ai::ArrayIterator,k) = done(ai.array,k)
+
+length(v::ArrayIterator) = length(v.array)
+isempty(v::ArrayIterator) = isempty(v.array)
+eltype{T,N}(::Type{ArrayIterator{T,N}}) = T
+
+keys(x::Array) = CartesianRange(size(x))
+values(x::Array) = ArrayIterator(x)

--- a/base/array.jl
+++ b/base/array.jl
@@ -982,17 +982,6 @@ symdiff(a) = a
 symdiff(a, b) = union(setdiff(a,b), setdiff(b,a))
 symdiff(a, b, rest...) = symdiff(a, symdiff(b, rest...))
 
-# Lightweight wrapper type for values(::Array)
-immutable ArrayIterator{T,N}
-    array::Array{T,N}
-end
-start(ai::ArrayIterator) = start(ai.array)
-next(ai::ArrayIterator,k) = next(ai.array,k)
-done(ai::ArrayIterator,k) = done(ai.array,k)
-
-length(v::ArrayIterator) = length(v.array)
-isempty(v::ArrayIterator) = isempty(v.array)
-eltype{T,N}(::Type{ArrayIterator{T,N}}) = T
-
-keys(x::Array) = CartesianRange(size(x))
-values(x::Array) = ArrayIterator(x)
+# keys and values
+keys(  x::Array) = CartesianRange(size(x))
+values(x::Array) = x

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1239,3 +1239,16 @@ module RetTypeDecl
     @test @inferred(m.*[m,m]) == [m2,m2]
     @test @inferred([m,m].*m) == [m2,m2]
 end
+
+# keys(::Array) and values(::Array)
+A = rand(4,2,3)
+@test length(keys(A)) == length(values(A)) == 4 * 2 * 3
+@test eltype(typeof(keys(A))) === Base.IteratorsMD.CartesianIndex{3}
+@test eltype(typeof(values(A))) === Float64
+
+seen = falses(size(A))
+for (index,(I,v)) in enumerate(zip(keys(A),values(A)))
+    @test A[I] === A[index] === v
+    seen[I] = true
+end
+@test all(seen)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1244,6 +1244,7 @@ end
 A = rand(4,2,3)
 @test length(keys(A)) == length(values(A)) == 4 * 2 * 3
 @test eltype(typeof(keys(A))) === Base.IteratorsMD.CartesianIndex{3}
+@test values(A) === A
 @test eltype(typeof(values(A))) === Float64
 
 seen = falses(size(A))


### PR DESCRIPTION
This PR adds methods for `keys` and `values` for `Array`s. The `keys` implementation is merely a `CartesianRange`, while the `values` implementation uses a new lightweight wrapper around the `Array`. I did it this way because just using `values(d::Array) = d` means you could change the contents of `d` by what is returned from `values`, while `values(d::Array) = copy(d)` seemed wasteful. This could potentially be widened to `AbstractArray`, but this doesn't seem like the right way to do it for something like a sparse matrix, for example. 
