### PR TITLE
Add missing three-parameter methods for A[tc]_mul_B!(::Triangular)

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -441,12 +441,17 @@ scale!(c::Number, A::Union{UpperTriangular,LowerTriangular}) = scale!(A,c)
 A_mul_B!(A::Tridiagonal, B::AbstractTriangular) = A*full!(B)
 A_mul_B!(C::AbstractMatrix, A::AbstractTriangular, B::Tridiagonal) = A_mul_B!(C, full(A), B)
 A_mul_B!(C::AbstractMatrix, A::Tridiagonal, B::AbstractTriangular) = A_mul_B!(C, A, full(B))
-A_mul_B!(C::AbstractVector, A::AbstractTriangular, B::AbstractVector) = A_mul_B!(A, copy!(C, B))
-A_mul_B!(C::AbstractMatrix, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, copy!(C, B))
-A_mul_B!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, copy!(C, B))
 A_mul_Bt!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, transpose!(C, B))
 A_mul_Bc!(C::AbstractMatrix, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, adjoint!(C, B))
 A_mul_Bc!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, adjoint!(C, B))
+# The three methods are neceesary to avoid ambiguities with definitions in matmul.jl
+for f in (:A_mul_B!, :Ac_mul_B!, :At_mul_B!)
+    @eval begin
+        ($f)(C::AbstractVector  , A::AbstractTriangular, B::AbstractVector)   = ($f)(A, copy!(C, B))
+        ($f)(C::AbstractMatrix  , A::AbstractTriangular, B::AbstractVecOrMat) = ($f)(A, copy!(C, B))
+        ($f)(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = ($f)(A, copy!(C, B))
+    end
+end
 
 for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
                             (:UnitLowerTriangular, 'L', 'U'),

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -342,9 +342,11 @@ for elty1 in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloa
             @test B'A1' ≈ B'full(A1)'
 
             if eltyB == elty1
-                @test A_mul_B!(zeros(B),A1,B) ≈ A1*B
+                @test A_mul_B!(zeros(B),A1,B)  ≈ A1*B
                 @test A_mul_Bc!(zeros(B),A1,B) ≈ A1*B'
                 @test A_mul_Bt!(zeros(B),A1,B) ≈ A1*B.'
+                @test Ac_mul_B!(zeros(B),A1,B) ≈ A1'*B
+                @test At_mul_B!(zeros(B),A1,B) ≈ A1.'*B
             end
             #error handling
             @test_throws DimensionMismatch Base.LinAlg.A_mul_B!(A1, ones(eltyB,n+1))


### PR DESCRIPTION
These methods are needed for compatibility with ordinary dense matrices,
which have the three-parameter forms.
