### PR TITLE
make rad2deg/deg2rad adapt to the correct precision

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -91,10 +91,10 @@ macro evalpoly(z, p...)
       end)
 end
 
-rad2deg(z::Real) = oftype(z, 57.29577951308232*z)
-deg2rad(z::Real) = oftype(z, 0.017453292519943295*z)
-rad2deg(z::Integer) = rad2deg(float(z))
-deg2rad(z::Integer) = deg2rad(float(z))
+rad2deg(z::AbstractFloat) = z * (180 / oftype(z, pi))
+deg2rad(z::AbstractFloat) = z * (oftype(z, pi) / 180)
+rad2deg(z::Real) = rad2deg(float(z))
+deg2rad(z::Real) = deg2rad(float(z))
 @vectorize_1arg Real rad2deg
 @vectorize_1arg Real deg2rad
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -12,10 +12,10 @@ export
 
 import
     Base: (*), +, -, /, <, <=, ==, >, >=, ^, besselj, besselj0, besselj1, bessely,
-        bessely0, bessely1, ceil, cmp, convert, copysign, deg2rad, div,
+        bessely0, bessely1, ceil, cmp, convert, copysign, div,
         exp, exp2, exponent, factorial, floor, fma, hypot, isinteger,
         isfinite, isinf, isnan, ldexp, log, log2, log10, max, min, mod, modf,
-        nextfloat, prevfloat, promote_rule, rad2deg, rem, round, show,
+        nextfloat, prevfloat, promote_rule, rem, round, show,
         showcompact, sum, sqrt, string, print, trunc, precision, exp10, expm1,
         gamma, lgamma, digamma, erf, erfc, zeta, eta, log1p, airyai,
         eps, signbit, sin, cos, tan, sec, csc, cot, acos, asin, atan,
@@ -411,9 +411,6 @@ function sqrt(x::BigFloat)
 end
 
 sqrt(x::BigInt) = sqrt(BigFloat(x))
-
-rad2deg(z::BigFloat) = 180/big(pi)*z
-deg2rad(z::BigFloat) = big(pi)/180*z
 
 function ^(x::BigFloat, y::BigFloat)
     z = BigFloat()


### PR DESCRIPTION
As discussed in #12817, the `rad2deg` and `deg2rad` functions can be made precision-agnostic with no loss of speed (thanks to constant folding), and actually with less code (since a special version in mpfr.jl is no longer needed).
