### PR TITLE
Fix #11549 (top level after paren-indented line)

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -452,13 +452,10 @@ with it. Returns nil if we're not within nested parens."
       (save-excursion
         (beginning-of-line)
         (forward-to-indentation 0)
-        (let ((endtok (julia-at-keyword julia-block-end-keywords)))
-          (ignore-errors (+ (julia-last-open-block (- (point) julia-max-block-lookback))
-                            (if endtok (- julia-indent-offset) 0)))))
-      ;; Otherwise, use the same indentation as previous line.
-      (save-excursion (forward-line -1)
-                      (current-indentation))
-      0))
+        (let ((endtok (julia-at-keyword julia-block-end-keywords))
+              (last-open-block (julia-last-open-block (- (point) julia-max-block-lookback))))
+          (max 0 (+ (or last-open-block 0)
+                    (if endtok (- julia-indent-offset) 0)))))))
     ;; Point is now at the beginning of indentation, restore it
     ;; to its original position (relative to indentation).
     (when (>= point-offset 0)
@@ -621,6 +618,16 @@ c"))
 (1)"
      "
 (1)"))
+
+  (ert-deftest julia--test-top-level-following-paren-indent ()
+    "`At the top level, a previous line indented due to parens should not affect indentation."
+    (julia--should-indent
+     "y1 = f(x,
+       z)
+y2 = g(x)"
+     "y1 = f(x,
+       z)
+y2 = g(x)"))
 
   (defun julia--run-tests ()
     (interactive)


### PR DESCRIPTION
The last-resort case of `julia-indent-line`, which indents to the same level as the previous line, does the wrong thing when we're at the top level (so the "indent according to the block level" rule fails) and the previous line is indented funny due to, for example, being inside a parenthesized expression.

This change removes that case, so the most general case is always to indent according to the block level. Perhaps this breaks some other desired behavior, but if so, someone should write a test for it and we can restore it!

See issue #11549 (one instance of which is now a test) for an example that used to break and is now indented correctly.

Fix #11549
