### PR TITLE
RFC: Speed up sorting along a dimension of an array (fixes part of #9832)

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -761,6 +761,23 @@ let
     @test issorted(as[1,:])
     @test issorted(as[2,:])
     @test issorted(as[3,:])
+
+    local b = rand(21,21,2)
+
+    bs = sort(b, 1)
+    for i in 1:21
+        @test issorted(bs[:,i,1])
+        @test issorted(bs[:,i,2])
+    end
+
+    bs = sort(b, 2)
+    for i in 1:21
+        @test issorted(bs[i,:,1])
+        @test issorted(bs[i,:,2])
+    end
+
+    bs = sort(b, 3)
+    @test all(bs[:,:,1] .<= bs[:,:,2])
 end
 
 # fill


### PR DESCRIPTION
- Sorts 1D array slices along the specified dimension
- n-D case uses `CartesianRanges`
- Also adds (and uses) iteration over components of a `CartesianIndex`

Before:

``` julia
julia> a=rand(Int64,30000000,2);

julia> @time sort(a,2);
 45.318352 seconds (600.35 M allocations: 22.369 GB, 4.56% gc time)
```

After:

``` julia
julia> a=rand(Int64,30000000,2);

julia> @time sort(a,2);
  3.586818 seconds (120.20 M allocations: 5.374 GB, 5.80% gc time)
```

Notes:
1. ~~The "before" time is already 10x faster than the time reported in #9832.  It's not clear to me when this happened.~~  This is because the array size is 10x smaller.  Whoops.  Numbers updated to match those in #9832.
2. Because `slice` doesn't actually work directly with `CartesianIndex`es (at least in the way that I needed), I also added methods for iterating over a `CartesianIndex`, so that I could splat it inside of a call to `slice`.  But I'm unsure if this is desirable--perhaps it wasn't there to discourage users from splatting?  (Cc: @mbauman @timholy)
3. Most of the functionality is in `sortdim!(...)`, which is unexported. `sort(a, dim; kws...)` calls `sort!(a, dim; kws...)` (new), which calls `sortdim!`.  
   
   Defining a new function isn't strictly necessary, but "sorting" vs "sorting along a dimension" seem different enough to me that I'd like to suggest deprecating `sort(a, dim)` for `sortdim(a, dim)` (in a future PR).  Thoughts?
