### PR TITLE
Travis uses containers now

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -166,6 +166,7 @@ function travis(pkg::AbstractString; force::Bool=false)
         print(io, """
         # Documentation: http://docs.travis-ci.com/user/languages/julia/
         language: julia
+        sudo: false
         os:
           - linux
           - osx


### PR DESCRIPTION
Stumbled across this on my latest push:
http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade

At least for https://github.com/mauro3/Traits.jl `sudo: false` works.  But I'm not sure whether this can be generally recommended.
