### PR TITLE
Remove specialized sort! method for PartialQuickSort{Int} (fixes #12833)

### DIFF
--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -346,3 +346,6 @@ Base.isless(x :: Twain, y :: Twain) = x.a < y.a
 let x = Twain(2,3), y = Twain(2,4)
     @test (min(x,y), max(x,y)) == (x,y) == minmax(x,y)
 end
+
+# issue #12833 - type stability of sort
+@test Base.return_types(sort, (Vector{Int},)) == [Vector{Int}]


### PR DESCRIPTION
There were two `sort` methods for `PartialQuickSort`, depending
on whether it was parameterized by an `Int` (representing the
last index needing to be sorted) or a `Range`.  The version
parameterized by an `Int` has one less comparison per branch,
but it causes inference to fail to infer the return type of
`sort`/`sort!` under many circumstances.  Removing this version 
of `sort!` and only providing the generic function restores proper 
type inference.

If there's an underlying bug that is fixed, this can be reverted
(although the test should remain.)
