### PR TITLE
Improve error message for dup'd type field names.

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -935,6 +935,8 @@
                      (default-inner-ctors name field-names field-types (null? params) locs)
                      defs))
           (min-initialized (min (ctors-min-initialized defs) (length fields))))
+     (let ((dups (has-dups field-names)))
+        (if dups (error (string "duplicate field name: \"" (car dups) "\" is not unique"))))
      (for-each (lambda (v)
                  (if (not (symbol? v))
                      (error (string "field name \"" (deparse v) "\" is not a symbol"))))


### PR DESCRIPTION
before:

```
julia> type Foo
       f1
       f1
       end
ERROR: syntax: function argument names not unique
```

after:

```
julia> type Foo
       f1
       f1
       end
ERROR: syntax: duplicate field name: "f1" is not unique
```
