### PR TITLE
Misc linalg tests

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -282,8 +282,6 @@ function rcswap!{T<:Number}(i::Integer, j::Integer, X::StridedMatrix{T})
     end
 end
 
-expm(x::Number) = exp(x)
-
 function logm(A::StridedMatrix)
     # If possible, use diagonalization
     if ishermitian(A)
@@ -537,4 +535,3 @@ function lyap{T<:BlasFloat}(A::StridedMatrix{T},C::StridedMatrix{T})
 end
 lyap{T<:Integer}(A::StridedMatrix{T},C::StridedMatrix{T}) = lyap(float(A), float(C))
 lyap{T<:Number}(a::T, c::T) = -c/(2a)
-

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -27,6 +27,61 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
     apd  = a'*a                  # symmetric positive-definite
     ε = εa = eps(abs(float(one(eltya))))
 
+    @inferred cholfact(apd)
+    @inferred chol(apd)
+    capd  = factorize(apd)
+    r     = capd[:U]
+    κ     = cond(apd, 1) #condition number
+
+    #getindex
+    @test_throws KeyError capd[:Z]
+
+    #Test error bound on reconstruction of matrix: LAWNS 14, Lemma 2.1
+    E = abs(apd - r'*r)
+    for i=1:n, j=1:n
+        @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
+    end
+    E = abs(apd - full(capd))
+    for i=1:n, j=1:n
+        @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
+    end
+    @test_approx_eq apd * inv(capd) eye(n)
+    @test abs((det(capd) - det(apd))/det(capd)) <= ε*κ*n # Ad hoc, but statistically verified, revisit
+    @test_approx_eq @inferred(logdet(capd)) log(det(capd)) # logdet is less likely to overflow
+
+    apos = apd[1,1]            # test chol(x::Number), needs x>0
+    @test_approx_eq cholfact(apos).factors √apos
+    @test_throws ArgumentError chol(-one(eltya))
+
+    # test chol of 2x2 Strang matrix
+    S = convert(AbstractMatrix{eltya},full(SymTridiagonal([2,2],[-1])))
+    U = Bidiagonal([2,sqrt(eltya(3))],[-1],true) / sqrt(eltya(2))
+    @test_approx_eq full(chol(S)) full(U)
+
+    #lower Cholesky factor
+    lapd = cholfact(apd, :L)
+    @test_approx_eq full(lapd) apd
+    l = lapd[:L]
+    @test_approx_eq l*l' apd
+
+    #pivoted upper Cholesky
+    if eltya != BigFloat
+        cpapd = cholfact(apd, :U, Val{true})
+        @test rank(cpapd) == n
+        @test all(diff(diag(real(cpapd.factors))).<=0.) # diagonal should be non-increasing
+        if isreal(apd)
+            @test_approx_eq apd * inv(cpapd) eye(n)
+        end
+        @test full(cpapd) ≈ apd
+        #getindex
+        @test_throws KeyError cpapd[:Z]
+
+        @test size(cpapd) == size(apd)
+        @test full(copy(cpapd)) ≈ apd
+        @test det(cpapd) ≈ det(apd)
+        @test cpapd[:P]*cpapd[:L]*cpapd[:U]*cpapd[:P]' ≈ apd
+    end
+
     for eltyb in (Float32, Float64, Complex64, Complex128, Int)
         b = eltyb == Int ? rand(1:5, n, 2) : convert(Matrix{eltyb}, eltyb <: Complex ? complex(breal, bimg) : breal)
         εb = eps(abs(float(one(eltyb))))
@@ -34,66 +89,28 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
 
 debug && println("\ntype of a: ", eltya, " type of b: ", eltyb, "\n")
 
-debug && println("(Automatic) upper Cholesky factor")
-
-        @inferred cholfact(apd)
-        @inferred chol(apd)
-        capd  = factorize(apd)
-        r     = capd[:U]
-        κ     = cond(apd, 1) #condition number
-
-        #getindex
-        @test_throws KeyError capd[:Z]
-
-        #Test error bound on reconstruction of matrix: LAWNS 14, Lemma 2.1
-        E = abs(apd - r'*r)
-        for i=1:n, j=1:n
-            @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
-        end
-        E = abs(apd - full(capd))
-        for i=1:n, j=1:n
-            @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))
-        end
-
         #Test error bound on linear solver: LAWNS 14, Theorem 2.1
         #This is a surprisingly loose bound...
         x = capd\b
         @test norm(x-apd\b,1)/norm(x,1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
         @test norm(apd*x-b,1)/norm(b,1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
 
-        @test_approx_eq apd * inv(capd) eye(n)
         @test norm(a*(capd\(a'*b)) - b,1)/norm(b,1) <= ε*κ*n # Ad hoc, revisit
-        @test abs((det(capd) - det(apd))/det(capd)) <= ε*κ*n # Ad hoc, but statistically verified, revisit
-        @test_approx_eq @inferred(logdet(capd)) log(det(capd)) # logdet is less likely to overflow
 
-        apos = apd[1,1]            # test chol(x::Number), needs x>0
-        @test_approx_eq cholfact(apos).factors √apos
-        @test_throws ArgumentError chol(-one(eltya))
-
-        # test chol of 2x2 Strang matrix
-        S = convert(AbstractMatrix{eltya},full(SymTridiagonal([2,2],[-1])))
-        U = Bidiagonal([2,sqrt(eltya(3))],[-1],true) / sqrt(eltya(2))
-        @test_approx_eq full(chol(S)) full(U)
-
-debug && println("lower Cholesky factor")
-        lapd = cholfact(apd, :L)
-        @test_approx_eq full(lapd) apd
-        l = lapd[:L]
-        @test_approx_eq l*l' apd
+        if eltya != BigFloat && eltyb != BigFloat
+            @test norm(apd * (lapd\b) - b)/norm(b) <= ε*κ*n
+            @test norm(apd * (lapd\b[1:n]) - b[1:n])/norm(b[1:n]) <= ε*κ*n
+        end
 
 debug && println("pivoted Choleksy decomposition")
         if eltya != BigFloat && eltyb != BigFloat # Note! Need to implement pivoted cholesky decomposition in julia
-            cpapd = cholfact(apd, :U, Val{true})
-            @test rank(cpapd) == n
-            @test all(diff(diag(real(cpapd.factors))).<=0.) # diagonal should be non-increasing
-            @test norm(apd * (cpapd\b) - b)/norm(b) <= ε*κ*n # Ad hoc, revisit
-            if isreal(apd)
-                @test_approx_eq apd * inv(cpapd) eye(n)
-            end
-            @test_approx_eq full(cpapd) apd
 
-            #getindex
-            @test_throws KeyError cpapd[:Z]
+            @test norm(apd * (cpapd\b) - b)/norm(b) <= ε*κ*n # Ad hoc, revisit
+            @test norm(apd * (cpapd\b[1:n]) - b[1:n])/norm(b[1:n]) <= ε*κ*n
+
+            lpapd = cholfact(apd, :L, Val{true})
+            @test norm(apd * (lpapd\b) - b)/norm(b) <= ε*κ*n # Ad hoc, revisit
+            @test norm(apd * (lpapd\b[1:n]) - b[1:n])/norm(b[1:n]) <= ε*κ*n
         end
     end
 end

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -37,6 +37,10 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
     @test_throws KeyError capd[:Z]
 
     #Test error bound on reconstruction of matrix: LAWNS 14, Lemma 2.1
+
+    #these tests were failing on 64-bit linux when inside the inner loop
+    #for eltya = Complex64 and eltyb = Int. The E[i,j] had NaN32 elements
+    #but only with srand(1234321) set before the loops.
     E = abs(apd - r'*r)
     for i=1:n, j=1:n
         @test E[i,j] <= (n+1)ε/(1-(n+1)ε)*real(sqrt(apd[i,i]*apd[j,j]))

--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -360,9 +360,6 @@ for elty in (Float32, Float64, Complex64, Complex128)
                                              [4.000000000000000  -1.414213562373094  -1.414213562373095
                                               -1.414213562373095   4.999999999999996  -0.000000000000000
                                               0  -0.000000000000002   3.000000000000000])
-    @test_throws KeyError hessfact(A1)[:Z]
-    @test_approx_eq full(hessfact(A1)) A1
-    @test_approx_eq full(Base.LinAlg.HessenbergQ(hessfact(A1))) full(hessfact(A1)[:Q])
 end
 
 for elty in (Float64, Complex{Float64})

--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -69,6 +69,8 @@ debug && println("Test pinv")
     @test_approx_eq a[:,1:n1]*pinva15*a[:,1:n1] a[:,1:n1]
     @test_approx_eq pinva15*a[:,1:n1]*pinva15 pinva15
 
+    @test size(pinv(ones(eltya,0,0))) == (0,0)
+
 debug && println("Lyapunov/Sylvester")
     let
         x = lyap(a, a2)
@@ -99,6 +101,26 @@ debug && println("Powers")
         @test a^t ≈ a^2
         @test eye(eltya,n,n)^r ≈ eye(a)
     end
+
+debug && println("Factorize")
+    d = rand(eltya,n)
+    e = rand(eltya,n-1)
+    e2 = rand(eltya,n-1)
+    f = rand(eltya,n-2)
+    A = diagm(d)
+    @test factorize(A) == Diagonal(d)
+    A += diagm(e,-1)
+    @test factorize(A) == Bidiagonal(d,e,false)
+    A += diagm(f,-2)
+    @test factorize(A) == LowerTriangular(A)
+    if eltya <: Real
+        A = diagm(d) + diagm(e,1) + diagm(e,-1)
+        @test full(factorize(A)) ≈ full(factorize(SymTridiagonal(d,e)))
+    end
+    A = diagm(d) + diagm(e,1) + diagm(e2,-1)
+    @test full(factorize(A)) ≈ full(factorize(Tridiagonal(e2,d,e)))
+    A = diagm(d) + diagm(e,1) + diagm(f,2)
+    @test factorize(A) == UpperTriangular(A)
 end # for eltya
 
 # test triu/tril bounds checking
@@ -118,6 +140,7 @@ for elty in (Int32, Int64, Float32, Float64, Complex64, Complex128)
         g = convert(Vector{elty}, complex(ones(3), ones(3)))
     end
     @test_approx_eq gradient(x) g
+    @test gradient(ones(elty,1)) == zeros(elty,1)
 end
 
 # Tests norms
@@ -476,3 +499,8 @@ for elty in [Float32,Float64,Complex64,Complex128]
     @test logm(a) ≈ log(a)
     @test lyap(one(elty),a) == -a/2
 end
+
+# stride1
+a = rand(10)
+b = slice(a,2:2:10)
+@test Base.LinAlg.stride1(b) == 2

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -143,3 +143,17 @@ b = Array(Vector{Float64}, 2)
 b[1] = ones(3)
 b[2] = ones(2)
 @test A*b == Vector{Float64}[[2,2,1], [2,2]]
+
+@test_throws ArgumentError Base.LinAlg.copytri!(ones(10,10),'Z')
+for elty in [Float32,Float64,Complex128,Complex64]
+    @test_throws DimensionMismatch Base.LinAlg.gemv!(ones(elty,10),'N',rand(elty,10,10),ones(elty,11))
+    @test_throws DimensionMismatch Base.LinAlg.gemv!(ones(elty,11),'N',rand(elty,10,10),ones(elty,10))
+    @test Base.LinAlg.gemv!(ones(elty,0),'N',rand(elty,0,0),rand(elty,0)) == ones(elty,0)
+
+    @test Base.LinAlg.gemm_wrapper('N','N',eye(elty,10,10),eye(elty,10,10)) == eye(elty,10,10)
+    @test_throws DimensionMismatch Base.LinAlg.gemm_wrapper!(eye(elty,10,10),'N','N',eye(elty,10,11),eye(elty,10,10))
+    @test_throws DimensionMismatch Base.LinAlg.gemm_wrapper!(eye(elty,10,10),'N','N',eye(elty,0,0),eye(elty,0,0))
+
+    A = rand(elty,3,3)
+    @test Base.LinAlg.matmul3x3('T','N',A,eye(elty,3)) == A.'
+end

--- a/test/linalg/qr.jl
+++ b/test/linalg/qr.jl
@@ -32,6 +32,11 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         εb = eps(abs(float(one(eltyb))))
         ε = max(εa,εb)
 
+        α = rand(eltyb)
+        aα = fill(α,1,1)
+        @test qrfact(α)[:Q]*qrfact(α)[:R] ≈ qrfact(aα)[:Q]*qrfact(aα)[:R]
+
+
 debug && println("\ntype of a: ", eltya, " type of b: ", eltyb, "\n")
 debug && println("QR decomposition (without pivoting)")
         for i = 1:2
@@ -57,6 +62,7 @@ debug && println("Thin QR decomposition (without pivoting)")
                 @test_approx_eq_eps q*b[1:n1] full(q)*b[1:n1] 100ε
                 @test_approx_eq_eps q*b full(q, thin=false)*b 100ε
                 @test_throws DimensionMismatch q*b[1:n1 + 1]
+                @test_throws DimensionMismatch b[1:n1 + 1]*q'
 
 debug && println("(Automatic) Fat (pivoted) QR decomposition") # Pivoting is only implemented for BlasFloats
                 if eltya <: BlasFloat
@@ -71,8 +77,11 @@ debug && println("(Automatic) Fat (pivoted) QR decomposition") # Pivoting is onl
                 @test_approx_eq q*full(q, thin=false)' eye(n1)
                 @test_approx_eq q*r isa(qrpa,QRPivoted) ? a[1:n1,p] : a[1:n1,:]
                 @test_approx_eq isa(qrpa, QRPivoted) ? q*r[:,invperm(p)] : q*r a[1:n1,:]
+                @test_approx_eq isa(qrpa, QRPivoted) ? q*r*qrpa[:P].' : q*r a[1:n1,:]
                 @test_approx_eq_eps a[1:n1,:]*(qrpa\b[1:n1]) b[1:n1] 5000ε
                 @test_approx_eq full(qrpa) a[1:5,:]
+                @test_throws DimensionMismatch q*b[1:n1 + 1]
+                @test_throws DimensionMismatch b[1:n1 + 1]*q'
 
 debug && println("(Automatic) Thin (pivoted) QR decomposition") # Pivoting is only implemented for BlasFloats
                 qrpa  = factorize(a[:,1:n1])
@@ -84,6 +93,8 @@ debug && println("(Automatic) Thin (pivoted) QR decomposition") # Pivoting is on
                 @test_approx_eq q*r isa(qrpa, QRPivoted) ? a[:,p] : a[:,1:n1]
                 @test_approx_eq isa(qrpa, QRPivoted) ? q*r[:,invperm(p)] : q*r a[:,1:n1]
                 @test_approx_eq full(qrpa) a[:,1:5]
+                @test_throws DimensionMismatch q*b[1:n1 + 1]
+                @test_throws DimensionMismatch b[1:n1 + 1]*q'
             end
         end
 
@@ -104,8 +115,17 @@ debug && println("Matmul with QR factorizations")
             @test_approx_eq A_mul_Bc!(full(q,thin=false),q) eye(n)
             @test_throws DimensionMismatch A_mul_Bc!(eye(eltya,n+1),q)
             @test_throws BoundsError size(q,-1)
-
             @test_throws DimensionMismatch q * eye(Int8,n+4)
+        end
+
+debug && println("Hessenberg")
+        if eltya != BigFloat
+            hA = hessfact(a)
+            @test size(hA[:Q],1) == size(a,1)
+            @test size(hA[:Q],2) == size(a,2)
+            @test_throws KeyError hA[:Z]
+            @test_approx_eq full(hA) a
+            @test_approx_eq full(Base.LinAlg.HessenbergQ(hA)) full(hA[:Q])
         end
     end
 end


### PR DESCRIPTION
We had two `expm(x::Number)` methods defined.

I moved some `Hessenberg` tests out of `dense.jl` to `qr.jl` which is a more natural place for them.

I added tests for `cholesky.jl` and `matmul.jl`.
