### PR TITLE
RFC: Add cygwin mintty to windows binary distribution.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -88,3 +88,4 @@ Julia bundles the following external programs and libraries on some platforms:
 - [ZLIB](http://zlib.net/zlib_license.html)
 - [LIBEXPAT](http://expat.cvs.sourceforge.net/viewvc/expat/expat/README)
 - [CYGWIN](https://cygwin.com/licensing.html)
+- [MINTTY](https://github.com/mintty/mintty/blob/master/LICENSE)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -87,3 +87,4 @@ Julia bundles the following external programs and libraries on some platforms:
 - [GIT](http://git-scm.com/about/free-and-open-source)
 - [ZLIB](http://zlib.net/zlib_license.html)
 - [LIBEXPAT](http://expat.cvs.sourceforge.net/viewvc/expat/expat/README)
+- [CYGWIN](https://cygwin.com/licensing.html)

--- a/Makefile
+++ b/Makefile
@@ -419,13 +419,16 @@ endif
 
 ifeq ($(OS), WINNT)
 	[ ! -d dist-extras ] || ( cd dist-extras && \
-		cp 7z.exe 7z.dll libexpat-1.dll zlib1.dll libgfortran-3.dll libquadmath-0.dll libstdc++-6.dll libgcc_s_s*-1.dll libssp-0.dll $(bindir) && \
+	    cp 7z.exe 7z.dll libexpat-1.dll zlib1.dll libgfortran-3.dll libquadmath-0.dll libstdc++-6.dll libgcc_s_s*-1.dll libssp-0.dll $(bindir) && \
 	    mkdir $(DESTDIR)$(prefix)/Git && \
 	    7z x PortableGit.7z -o"$(DESTDIR)$(prefix)/Git" && \
 	    echo "[core] eol = lf" >> "$(DESTDIR)$(prefix)/Git/etc/gitconfig" && \
 	    sed -i "s/\bautocrlf = true$$/autocrlf = input/" "$(DESTDIR)$(prefix)/Git/etc/gitconfig" && \
 	    cp busybox.exe $(DESTDIR)$(prefix)/Git/bin/echo.exe && \
-	    cp busybox.exe $(DESTDIR)$(prefix)/Git/bin/printf.exe )
+	    cp busybox.exe $(DESTDIR)$(prefix)/Git/bin/printf.exe && \
+            mkdir -p $(DESTDIR)$(prefix)/mintty/usr/bin	&& \
+	    cd cygwin/usr/bin && \
+            cp mintty.exe stty.exe env.exe cygwin-console-helper.exe cygwin1.dll cygintl-8.dll cygiconv-2.dll cyggcc_s-1.dll $(DESTDIR)$(prefix)/mintty/usr/bin/ )
 	cd $(DESTDIR)$(bindir) && rm -f llvm* llc.exe lli.exe opt.exe LTO.dll bugpoint.exe macho-dump.exe
 
 	# create file listing for uninstall. note: must have Windows path separators and line endings.
@@ -569,3 +572,6 @@ endif
 	chmod a+x ./nsis/makensis.exe && \
 	chmod a+x busybox.exe && \
 	$(JLDOWNLOAD) PortableGit.7z https://github.com/msysgit/msysgit/releases/download/Git-1.9.5-preview20141217/PortableGit-1.9.5-preview20141217.7z
+	cd dist-extras && \
+	../contrib/windows/cygwin.sh
+

--- a/Makefile
+++ b/Makefile
@@ -426,9 +426,9 @@ ifeq ($(OS), WINNT)
 	    sed -i "s/\bautocrlf = true$$/autocrlf = input/" "$(DESTDIR)$(prefix)/Git/etc/gitconfig" && \
 	    cp busybox.exe $(DESTDIR)$(prefix)/Git/bin/echo.exe && \
 	    cp busybox.exe $(DESTDIR)$(prefix)/Git/bin/printf.exe && \
-            mkdir -p $(DESTDIR)$(prefix)/mintty/usr/bin	&& \
+            mkdir -p $(DESTDIR)$(prefix)/usr/bin	&& \
 	    cd cygwin/usr/bin && \
-            cp mintty.exe stty.exe env.exe cygwin-console-helper.exe cygwin1.dll cygintl-8.dll cygiconv-2.dll cyggcc_s-1.dll $(DESTDIR)$(prefix)/mintty/usr/bin/ )
+            cp mintty.exe stty.exe env.exe cygwin-console-helper.exe cygwin1.dll cygintl-8.dll cygiconv-2.dll cyggcc_s-1.dll $(DESTDIR)$(prefix)/usr/bin/ )
 	cd $(DESTDIR)$(bindir) && rm -f llvm* llc.exe lli.exe opt.exe LTO.dll bugpoint.exe macho-dump.exe
 
 	# create file listing for uninstall. note: must have Windows path separators and line endings.

--- a/contrib/windows/build-installer.nsi
+++ b/contrib/windows/build-installer.nsi
@@ -29,7 +29,7 @@ FunctionEnd
 Function createDesktopLink
   ${NSD_GetState} $Checkbox $0
   ${If} $0 <> 0
-    CreateShortcut "$DESKTOP\julia.lnk" "$INSTDIR\mintty\usr\bin\env.exe" "HOME=%HOMEDRIVE%%HOMEPATH% $INSTDIR\mintty\usr\bin\mintty.exe -h error -i $INSTDIR\bin\julia.exe $INSTDIR\bin\julia.exe" "$INSTDIR\bin\julia.exe" 0 SW_SHOWNORMAL "" "The Julia REPL"
+    CreateShortcut "$DESKTOP\julia.lnk" "$INSTDIR\usr\bin\env.exe" "HOME=%HOMEDRIVE%%HOMEPATH% $INSTDIR\usr\bin\mintty.exe -h error -i $INSTDIR\bin\julia.exe $INSTDIR\bin\julia.exe" "$INSTDIR\bin\julia.exe" 0 SW_SHOWNORMAL "" "The Julia REPL"
   ${EndIf}
 FunctionEnd
 
@@ -69,7 +69,7 @@ Section "Dummy Section" SecDummy
     SetOutPath $INSTDIR
     File /a /r "julia-${Commit}\*"
     WriteUninstaller "$INSTDIR\Uninstall.exe"
-    CreateShortcut "$INSTDIR\julia.lnk" "$INSTDIR\mintty\usr\bin\env.exe" "HOME=%HOMEDRIVE%%HOMEPATH% $INSTDIR\mintty\usr\bin\mintty.exe -h error -i $INSTDIR\bin\julia.exe $INSTDIR\bin\julia.exe" "$INSTDIR\bin\julia.exe" 0 SW_SHOWNORMAL "" "The Julia REPL"
+    CreateShortcut "$INSTDIR\julia.lnk" "$INSTDIR\usr\bin\env.exe" "HOME=%HOMEDRIVE%%HOMEPATH% $INSTDIR\usr\bin\mintty.exe -h error -i $INSTDIR\bin\julia.exe $INSTDIR\bin\julia.exe" "$INSTDIR\bin\julia.exe" 0 SW_SHOWNORMAL "" "The Julia REPL"
 
     # ARP entries
     WriteRegStr HKCU "${ARP}" \
@@ -148,7 +148,7 @@ SectionEnd
 # Helper function to create Start Menu folder and shortcuts
 Function AddToStartMenu
     CreateDirectory "$SMPROGRAMS\${JuliaStartMenuFolder}"
-    CreateShortcut "$SMPROGRAMS\${JuliaStartMenuFolder}\julia.lnk" "$INSTDIR\mintty\usr\bin\env.exe" "HOME=%HOMEDRIVE%%HOMEPATH% $INSTDIR\mintty\usr\bin\mintty.exe -h error -i $INSTDIR\bin\julia.exe $INSTDIR\bin\julia.exe" "$INSTDIR\bin\julia.exe" 0 SW_SHOWNORMAL "" "The Julia REPL"    
+    CreateShortcut "$SMPROGRAMS\${JuliaStartMenuFolder}\julia.lnk" "$INSTDIR\usr\bin\env.exe" "HOME=%HOMEDRIVE%%HOMEPATH% $INSTDIR\usr\bin\mintty.exe -h error -i $INSTDIR\bin\julia.exe $INSTDIR\bin\julia.exe" "$INSTDIR\bin\julia.exe" 0 SW_SHOWNORMAL "" "The Julia REPL"    
     CreateShortcut "$SMPROGRAMS\${JuliaStartMenuFolder}\Uninstall.lnk" "$instdir\Uninstall.exe"
 FunctionEnd
 

--- a/contrib/windows/build-installer.nsi
+++ b/contrib/windows/build-installer.nsi
@@ -29,7 +29,7 @@ FunctionEnd
 Function createDesktopLink
   ${NSD_GetState} $Checkbox $0
   ${If} $0 <> 0
-    CreateShortCut "$DESKTOP\julia.lnk" "$INSTDIR\bin\julia.exe"
+    CreateShortcut "$DESKTOP\julia.lnk" "$INSTDIR\mintty\usr\bin\env.exe" "HOME=%HOMEDRIVE%%HOMEPATH% $INSTDIR\mintty\usr\bin\mintty.exe -h error -i $INSTDIR\bin\julia.exe $INSTDIR\bin\julia.exe" "$INSTDIR\bin\julia.exe" 0 SW_SHOWNORMAL "" "The Julia REPL"
   ${EndIf}
 FunctionEnd
 
@@ -69,7 +69,7 @@ Section "Dummy Section" SecDummy
     SetOutPath $INSTDIR
     File /a /r "julia-${Commit}\*"
     WriteUninstaller "$INSTDIR\Uninstall.exe"
-    CreateShortcut "$INSTDIR\julia.lnk" "$INSTDIR\bin\julia.exe"
+    CreateShortcut "$INSTDIR\julia.lnk" "$INSTDIR\mintty\usr\bin\env.exe" "HOME=%HOMEDRIVE%%HOMEPATH% $INSTDIR\mintty\usr\bin\mintty.exe -h error -i $INSTDIR\bin\julia.exe $INSTDIR\bin\julia.exe" "$INSTDIR\bin\julia.exe" 0 SW_SHOWNORMAL "" "The Julia REPL"
 
     # ARP entries
     WriteRegStr HKCU "${ARP}" \
@@ -148,7 +148,7 @@ SectionEnd
 # Helper function to create Start Menu folder and shortcuts
 Function AddToStartMenu
     CreateDirectory "$SMPROGRAMS\${JuliaStartMenuFolder}"
-    CreateShortcut "$SMPROGRAMS\${JuliaStartMenuFolder}\julia.lnk" "$INSTDIR\julia.lnk" "" "" "" "" "" "The Julia Language"
+    CreateShortcut "$SMPROGRAMS\${JuliaStartMenuFolder}\julia.lnk" "$INSTDIR\mintty\usr\bin\env.exe" "HOME=%HOMEDRIVE%%HOMEPATH% $INSTDIR\mintty\usr\bin\mintty.exe -h error -i $INSTDIR\bin\julia.exe $INSTDIR\bin\julia.exe" "$INSTDIR\bin\julia.exe" 0 SW_SHOWNORMAL "" "The Julia REPL"    
     CreateShortcut "$SMPROGRAMS\${JuliaStartMenuFolder}\Uninstall.lnk" "$instdir\Uninstall.exe"
 FunctionEnd
 

--- a/contrib/windows/cygwin.sh
+++ b/contrib/windows/cygwin.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+set -e
+mirror=http://mirrors.mit.edu/cygwin
+platform=x86
+packages="mintty cygwin coreutils libintl8 libiconv2 libgcc1"
+local_path=./cygwin
+
+# make place to put downloads
+mkdir -p $local_path
+
+# get setup.ini
+curl $mirror/$platform/setup.bz2 -o $local_path/setup.ini.bz2
+bunzip2 -f $local_path/setup.ini.bz2
+
+# get and unpack packages
+for package in $packages
+do
+    # determine the relative URL
+    url=$(awk "BEGIN {RS = \"@ \"} ; \$1 == \"$package\" { print \$0 }" \
+          $local_path/setup.ini | awk '$1 == "install:" { print $2 }' - | \
+          head -1)
+
+    # determine the local filename
+    filename=${url##*/}
+
+    # download the file
+    curl $mirror/$url -o $local_path/$filename
+
+    # unpack it
+    tar xf $local_path/$filename --directory $local_path
+done

--- a/contrib/windows/juliarc.jl
+++ b/contrib/windows/juliarc.jl
@@ -1,6 +1,11 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 let user_data_dir
+    try
+        run(`stty`)
+    catch
+        ENV["PATH"] = joinpath(JULIA_HOME,"..","mintty","usr","bin")*";"*ENV["PATH"]
+    end
     ENV["PATH"] = JULIA_HOME*";"*joinpath(JULIA_HOME,"..","Git","bin")*";"*ENV["PATH"]
     #haskey(ENV,"JULIA_EDITOR") || (ENV["JULIA_EDITOR"] = "start") #start is not a program, so this doesn't work
 end

--- a/contrib/windows/juliarc.jl
+++ b/contrib/windows/juliarc.jl
@@ -1,11 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 let user_data_dir
-    try
-        run(`stty`)
-    catch
-        ENV["PATH"] = joinpath(JULIA_HOME,"..","mintty","usr","bin")*";"*ENV["PATH"]
-    end
-    ENV["PATH"] = JULIA_HOME*";"*joinpath(JULIA_HOME,"..","Git","bin")*";"*ENV["PATH"]
+    ENV["PATH"] = JULIA_HOME*";"*joinpath(JULIA_HOME,"..","Git","bin")*";"*ENV["PATH"]*";"*joinpath(JULIA_HOME,"..","usr","bin")
     #haskey(ENV,"JULIA_EDITOR") || (ENV["JULIA_EDITOR"] = "start") #start is not a program, so this doesn't work
 end


### PR DESCRIPTION
Addresses #7267.
- [x] Add automated download of cygwin bits to the `win-extras` target.
- [x] Copy the right bits to the staging area.
- [x] Create the julia shortcut that wraps `mintty`.
- [ ] Verify that common workflows still work.

The `contrib/windows/cygwin.sh` script is minimally functional but could be robustified and possibly generalized ala `winrpm.sh`.

~~The copy step is written but I haven't tested it yet, as my environment is currently set up such that the `binary-dist` target is barfing before it gets to the new stuff.~~

~~The shortcuts are getting generated but they don't work unless the working directory is `mintty/usr/bin` as julia is looking for `stty` on the path. We need a workaround.~~
