### PR TITLE
Fix c(transpose) of Matrix{Vector}.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -384,6 +384,9 @@ function copy_transpose!{R,S}(B::AbstractVecOrMat{R}, ir_dest::Range{Int}, jr_de
 end
 
 zero{T}(x::AbstractArray{T}) = fill!(similar(x), zero(T))
+zero{A<:AbstractArray}(::Type{A}) = error(
+"it is not possible to construct zero of an AbstractArray without providing dimension
+arguments. Try calling zero on an instance of AbstractArray.")
 
 ## iteration support for arrays by iterating over `eachindex` in the array ##
 # Allows fast iteration by default for both LinearFast and LinearSlow arrays

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -404,11 +404,19 @@ function ccopy!(B, A)
 end
 
 function transpose(A::StridedMatrix)
-    B = similar(A, size(A, 2), size(A, 1))
+    if length(A) != 0
+        B = similar(A, typeof(transpose(A[1])), size(A, 2), size(A, 1))
+    else
+        B = similar(A, typeof(transpose(zero(eltype(A)))), size(A, 2), size(A, 1))
+    end
     transpose!(B, A)
 end
 function ctranspose(A::StridedMatrix)
-    B = similar(A, size(A, 2), size(A, 1))
+    if length(A) != 0
+        B = similar(A, typeof(ctranspose(A[1])), size(A, 2), size(A, 1))
+    else
+        B = similar(A, typeof(ctranspose(zero(eltype(A)))), size(A, 2), size(A, 1))
+    end
     ctranspose!(B, A)
 end
 ctranspose{T<:Real}(A::StridedVecOrMat{T}) = transpose(A)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1200,6 +1200,11 @@ ctranspose!(b,a)
 a = zeros(Complex,1,5)
 ctranspose!(a,b)
 @test a == ones(Complex,1,5)
+a = fill([1,1im], 2, 2)
+@test a' == fill([1,1im]', 2, 2)
+@test a.' == fill([1,1im].', 2, 2)
+@test permutedims(a, (2,1)) == a
+@test_throws ErrorException zero(Vector{Float64})
 
 # flipdim
 a = rand(5,3)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1310,7 +1310,7 @@ end
 @test isa(b4208(),b4208)
 
 # make sure convert_default error isn't swallowed by typeof()
-convert_default_should_fail_here() = similar([1],typeof(zero(typeof(rand(2,2)))))
+convert_default_should_fail_here() = similar([1],typeof(one(typeof(rand(2,2)))))
 @test_throws MethodError convert_default_should_fail_here()
 
 # issue #4343

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -255,10 +255,10 @@ end
 @test var(sparse(Int[])) === NaN
 
 for f in (sum, prod, minimum, maximum, var)
-    @test isequal(f(spzeros(0, 1), 1), f(Array(Int, 0, 1), 1))
-    @test isequal(f(spzeros(0, 1), 2), f(Array(Int, 0, 1), 2))
-    @test isequal(f(spzeros(0, 1), (1, 2)), f(Array(Int, 0, 1), (1, 2)))
-    @test isequal(f(spzeros(0, 1), 3), f(Array(Int, 0, 1), 3))
+    @test isequal(f(spzeros(0, 1), 1), f(Array(Float64, 0, 1), 1))
+    @test isequal(f(spzeros(0, 1), 2), f(Array(Float64, 0, 1), 2))
+    @test isequal(f(spzeros(0, 1), (1, 2)), f(Array(Float64, 0, 1), (1, 2)))
+    @test isequal(f(spzeros(0, 1), 3), f(Array(Float64, 0, 1), 3))
 end
 
 # spdiagm


### PR DESCRIPTION
When allocating the return array, it is necessary to specify the element type as it might change due to recursive definition of `(c)transpose`.

To improve the type inference for `(c)transpose(Matrix{Vector})`, I've added an error method for `zero(Type{AbstractArray})` such the inferred type is `Union{}` instead of `DataType`.

Update: @stevengj Defining `zero` as an error for `Type{AbstractMatrix}` went agasinst the logic of the initialization of reductions along dimension which you authored. I don't think any behavior is changed, but please take a look.

@simonster I had to change some tests of reductions on empty arrays that you wrote. It used to be the case that `minimum` and `maximum` of empty arrays were empty, but with my changes they are `typemax` and `typemin` respectively. Have we discussed this before? I think, I like the the new behavior and would be surprised if anyone relied on getting an empty result for `maximum`/`minimum`.
