### PR TITLE
Require gnu11 on icc. Use static_assert only with c11 or on gcc 4.6+

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -328,7 +328,7 @@ $(error Address Sanitizer only supported with clang. Try setting SANITIZE=0)
 endif
 CC  = icc
 CXX = icpc
-JCFLAGS = -std=gnu99 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -fp-model precise -fp-model except -no-ftz
+JCFLAGS = -std=gnu11 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -fp-model precise -fp-model except -no-ftz
 JCPPFLAGS =
 JCXXFLAGS = -pipe $(fPIC) -fno-rtti
 DEBUGFLAGS = -O0 -g -DJL_DEBUG_BUILD -fstack-protector-all

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -27,8 +27,23 @@
 #include <io.h>
 #define write _write
 #endif
-#if defined(_COMPILER_MICROSOFT_) && !defined(_Static_assert)
-#define _Static_assert static_assert
+
+#ifndef static_assert
+#  ifdef __cplusplus
+#    if __cplusplus < 201103L
+#      define static_assert(...)
+#    endif
+#  else
+#    define static_assert(...)
+// Remove the following gcc special handling when we officially requires
+// gcc 4.7 (for c++11) and -std=gnu11
+#    ifdef __GNUC__
+#      if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#        undef static_assert
+#        define static_assert _Static_assert
+#      endif
+#    endif
+#  endif
 #endif
 
 #ifdef __cplusplus
@@ -364,7 +379,7 @@ DLLEXPORT void jl_uv_writecb(uv_write_t *req, int status)
 static void jl_write(uv_stream_t *stream, const char *str, size_t n)
 {
     assert(stream);
-    _Static_assert(offsetof(uv_stream_t,type) == offsetof(ios_t,bm) &&
+    static_assert(offsetof(uv_stream_t,type) == offsetof(ios_t,bm) &&
         sizeof(((uv_stream_t*)0)->type) == sizeof(((ios_t*)0)->bm),
 	   "UV and ios layout mismatch");
 


### PR DESCRIPTION
See #12881 and https://github.com/JuliaLang/julia/commit/a96afe2f1d65a4e9d20a65d8fbab20b66069495b#commitcomment-12870463 for more detail.

`static_assert` is a [`c11`](http://en.cppreference.com/w/c/error/static_assert) / [`c++11`](http://en.cppreference.com/w/cpp/language/static_assert) feature so the easiest way to solve this is to require c11. This [should be fine](https://github.com/JuliaLang/julia/issues/12881#issuecomment-136504051) on all supported compilers but would make it impossible to compile on gcc < 4.6. It would be nice to not break those compilers until we switch to a llvm version that requires c++11.

This patch basically make sure `jl_uv.c` can be compiled no matter if it is in c11 mode (with some special code for gcc to make sure we have static assert on gcc without requiring c11). This also requires gnu11 on icc.

Fix #12881

@mschauer if you can verify that this fixes the build issue on gcc 4.4.
@kshyatt If you could verify this fixes the icc build issue as well.
