### PR TITLE
fix perf reg in creating a remoteref on a different worker

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -488,7 +488,10 @@ end
 
 RemoteRef(w::LocalProcess) = RemoteRef(w.id)
 RemoteRef(w::Worker) = RemoteRef(w.id)
-RemoteRef(pid::Integer=myid()) = RemoteRef(def_rv_channel, pid)
+function RemoteRef(pid::Integer=myid())
+    rrid = next_rrid_tuple()
+    RemoteRef{Channel{Any}}(pid, rrid[1], rrid[2])
+end
 
 function RemoteRef(f::Function, pid::Integer=myid())
     remotecall_fetch(pid, (f, rrid) -> begin


### PR DESCRIPTION
This PR avoids a network call when a RemoteRef is created on a remote worker, to the actual time of access. This used to be the implementation earlier and this regression had crept in during the Channel changes.

This PR fixes the same.
