### PR TITLE
Deprecate getindex/checkbounds methods for non Integer Real indices for Chars and Strings

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -19,7 +19,6 @@ endof(c::Char) = 1
 getindex(c::Char) = c
 getindex(c::Char, i::Integer) = i == 1 ? c : throw(BoundsError())
 getindex(c::Char, I::Integer...) = all(EqX(1), I) ? c : throw(BoundsError())
-getindex(c::Char, I::Real...) = getindex(c, to_indexes(I...)...)
 first(c::Char) = c
 last(c::Char) = c
 eltype(::Type{Char}) = Char

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -439,6 +439,10 @@ end
     to_indexes(I...)
 end
 
+@deprecate getindex(c::Char, I::Real...) getindex(c, map(Int, I)...)
+@deprecate getindex(s::AbstractString, x::Real) getindex(s, Int(x))
+@deprecate checkbounds(s::AbstractString, i::Real) checkbounds(s, Int(i))
+
 @noinline function float_isvalid{T<:Union{Float32,Float64}}(s::AbstractString, out::Array{T,1})
     tf = tryparse(T, s)
     isnull(tf) || (out[1] = get(tf))

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -36,7 +36,6 @@ start(s::AbstractString) = 1
 done(s::AbstractString,i) = (i > endof(s))
 getindex(s::AbstractString, i::Int) = next(s,i)[1]
 getindex(s::AbstractString, i::Integer) = s[Int(i)]
-getindex(s::AbstractString, x::Real) = s[to_index(x)]
 getindex{T<:Integer}(s::AbstractString, r::UnitRange{T}) = s[Int(first(r)):Int(last(r))]
 # TODO: handle other ranges with stride ±1 specially?
 getindex(s::AbstractString, v::AbstractVector) =
@@ -150,9 +149,10 @@ function nextind(s::AbstractString, i::Integer)
 end
 
 checkbounds(s::AbstractString, i::Integer) = start(s) <= i <= endof(s) || throw(BoundsError(s, i))
-checkbounds(s::AbstractString, i::Real) = checkbounds(s, to_index(i))
 checkbounds{T<:Integer}(s::AbstractString, r::Range{T}) = isempty(r) || (minimum(r) >= start(s) && maximum(r) <= endof(s)) || throw(BoundsError(s, r))
+# The following will end up using a deprecated checkbounds, when T is not Integer
 checkbounds{T<:Real}(s::AbstractString, I::AbstractArray{T}) = all(i -> checkbounds(s, i), I)
+checkbounds{T<:Integer}(s::AbstractString, I::AbstractArray{T}) = all(i -> checkbounds(s, i), I)
 
 ind2chr(s::DirectIndexString, i::Integer) = begin checkbounds(s,i); i end
 chr2ind(s::DirectIndexString, i::Integer) = begin checkbounds(s,i); i end


### PR DESCRIPTION
These functions depended on a version of `to_index`, which has been deprecated.
I tried to add tests for these methods, because they showed up as not being covered,
however I was told not to, because they give a deprecation warning.
This now gives a better error to the user, giving a work-around, and also giving the method that they called that doesn't work any longer, and eliminates the coverage holes in `strings/basic.jl` and `char.jl`
