### PR TITLE
Fix behaviour of scale! for triangular matrices (fixes #12903)

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -330,20 +330,6 @@ end
 scale!(A::Union{UpperTriangular,LowerTriangular},c::Number) = scale!(A,A,c)
 scale!(c::Number, A::Union{UpperTriangular,LowerTriangular}) = scale!(A,c)
 
-for (t1, t2) in ([:UnitLowerTriangular, :LowerTriangular],
-                 [:UnitUpperTriangular, :UpperTriangular])
-    for (type1, type2) in ([:Real, :Complex], [:Any, :Number])
-        @eval begin
-            function scale{T<:$(type1),S<:$(type2)}(A::$(t1){T}, c::S)
-                D = $(t2)(Array(promote_type(T,S), size(A)...));
-                scale!(D,A,c);
-                return D
-            end
-            scale{T<:$(type1),S<:$(type2)}(c::S, A::$(t1){T}) = scale(A, c)
-        end
-    end
-end
-
 # Binary operations
 +(A::UpperTriangular, B::UpperTriangular) = UpperTriangular(A.data + B.data)
 +(A::LowerTriangular, B::LowerTriangular) = LowerTriangular(A.data + B.data)

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -313,6 +313,7 @@ function scale!{T<:Union{UpperTriangular, UnitUpperTriangular}}(A::UpperTriangul
             @inbounds A[i,j] = c * B[i,j]
         end
     end
+    return A
 end
 function scale!{T<:Union{LowerTriangular, UnitLowerTriangular}}(A::LowerTriangular, B::T, c::Number)
     n = chksquare(B)
@@ -324,20 +325,21 @@ function scale!{T<:Union{LowerTriangular, UnitLowerTriangular}}(A::LowerTriangul
             @inbounds A[i,j] = c * B[i,j]
         end
     end
+    return A
 end
+scale!(A::Union{UpperTriangular,LowerTriangular},c::Number) = scale!(A,A,c)
+scale!(c::Number, A::Union{UpperTriangular,LowerTriangular}) = scale!(A,c)
 
 for (t1, t2) in ([:UnitLowerTriangular, :LowerTriangular],
                  [:UnitUpperTriangular, :UpperTriangular])
-    @eval begin
-        function scale!{T,S<:Number}(A::$(t1){T}, c::S)
-            D = $(t2)(Array(promote_type(T,S), size(A)...));
-            scale!(D,A,c);
-            return D
-        end
-        function scale!{T,S<:Number}(A::$(t2){T}, c::S)
-            D = $(t2)(Array(promote_type(T,S), size(A)...));
-            scale!(D,A,c);
-            return D
+    for (type1, type2) in ([:Real, :Complex], [:Any, :Number])
+        @eval begin
+            function scale{T<:$(type1),S<:$(type2)}(A::$(t1){T}, c::S)
+                D = $(t2)(Array(promote_type(T,S), size(A)...));
+                scale!(D,A,c);
+                return D
+            end
+            scale{T<:$(type1),S<:$(type2)}(c::S, A::$(t1){T}) = scale(A, c)
         end
     end
 end

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -133,14 +133,13 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         @test B == A1.'
 
         # scale
-        if elty1 == Int
-            cr = 2
-        else
-            cr = 0.5
-        end
-        ci = cr * im
-
         if (t1 == UpperTriangular || t1 == LowerTriangular)
+            if elty1 == Int
+                cr = 2
+            else
+                cr = 0.5
+            end
+            ci = cr * im
             if elty1 <: Real
                 A1tmp = copy(A1)
                 scale!(A1tmp,cr)
@@ -150,12 +149,11 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
                 scale!(A1tmp,ci)
                 @test A1tmp == ci*A1
             end
+            @test scale(A1,cr) == cr*A1
+            @test scale(cr,A1) == cr*A1
+            @test scale(A1,ci) == ci*A1
+            @test scale(ci,A1) == ci*A1
         end
-
-        @test scale(A1,cr) == cr*A1
-        @test scale(cr,A1) == cr*A1
-        @test scale(A1,ci) == ci*A1
-        @test scale(ci,A1) == ci*A1
 
         # Binary operations
         @test A1*0.5 == full(A1)*0.5

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -124,17 +124,40 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         # Unary operations
         @test full(-A1) == -full(A1)
 
-        # Binary operations
+        # copy
         B = similar(A1)
         copy!(B,A1)
         @test B == A1
         B = similar(A1.')
         copy!(B, A1.')
         @test B == A1.'
-        @test scale(A1,0.5) == 0.5*A1
-        @test scale(A1,0.5im) == 0.5im*A1
-        @test scale(A1.',0.5) == 0.5*A1.'
-        @test scale(A1.',0.5im) == 0.5im*A1.'
+
+        # scale
+        if elty1 == Int
+            cr = 2
+        else
+            cr = 0.5
+        end
+        ci = cr * im
+
+        if (t1 == UpperTriangular || t1 == LowerTriangular)
+            if elty1 <: Real
+                A1tmp = copy(A1)
+                scale!(A1tmp,cr)
+                @test A1tmp == cr*A1
+            else
+                A1tmp = copy(A1)
+                scale!(A1tmp,ci)
+                @test A1tmp == ci*A1
+            end
+        end
+
+        @test scale(A1,cr) == cr*A1
+        @test scale(cr,A1) == cr*A1
+        @test scale(A1,ci) == ci*A1
+        @test scale(ci,A1) == ci*A1
+
+        # Binary operations
         @test A1*0.5 == full(A1)*0.5
         @test 0.5*A1 == 0.5*full(A1)
         @test A1/0.5 == full(A1)/0.5


### PR DESCRIPTION
Make `scale!` modify input matrix for `UpperTriangular` and `LowerTriangular`, remove `scale!` method for `UnitUpperTriangular` and `UnitLowerTriangular`. 

[would close JuliaLang/LinearAlgebra.jl#244] 
