### PR TITLE
WIP: Move some documentation to sparse files

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -981,13 +981,6 @@ Calling `Ref(array[, index])` is generally preferable to this function.
 pointer
 
 doc"""
-    countnz(A)
-
-Counts the number of nonzero values in array A (dense or sparse). Note that this is not a constant-time operation. For sparse matrices, one should usually use `nnz`, which returns the number of stored values.
-"""
-countnz
-
-doc"""
     isnan(f) -> Bool
 
 Test whether a floating point number is not a number (NaN)
@@ -1327,13 +1320,6 @@ doc"""
 Read all lines as an array.
 """
 readlines
-
-doc"""
-    findnz(A)
-
-Return a tuple `(I, J, V)` where `I` and `J` are the row and column indexes of the non-zero values in matrix `A`, and `V` is a vector of the non-zero values.
-"""
-findnz
 
 doc"""
     RemoteRef()
@@ -1718,25 +1704,6 @@ doc"""
 Compute the inverse cosine of `x`, where the output is in radians
 """
 acos
-
-doc"""
-    nzrange(A, col)
-
-Return the range of indices to the structural nonzero values of a sparse matrix column. In conjunction with `nonzeros(A)` and `rowvals(A)`, this allows for convenient iterating over a sparse matrix :
-
-    A = sparse(I,J,V)
-    rows = rowvals(A)
-    vals = nonzeros(A)
-    m, n = size(A)
-    for i = 1:n
-       for j in nzrange(A, i)
-          row = rows[j]
-          val = vals[j]
-          # perform sparse wizardry...
-       end
-    end
-"""
-nzrange
 
 doc"""
     ispath(path) -> Bool
@@ -3147,13 +3114,6 @@ doc"""
 Get a hexadecimal string of the binary representation of a floating point number
 """
 num2hex
-
-doc"""
-    speye(type,m[,n])
-
-Create a sparse identity matrix of specified type of size `m x m`. In case `n` is supplied, create a sparse identity matrix of size `m x n`.
-"""
-speye
 
 doc"""
 ```rst
@@ -5087,13 +5047,6 @@ for the transformed real array.)
 irfft
 
 doc"""
-    nnz(A)
-
-Returns the number of stored (filled) elements in a sparse matrix.
-"""
-nnz
-
-doc"""
 ```rst
 ::
 
@@ -5133,12 +5086,6 @@ Construct a real symmetric tridiagonal matrix from the diagonal and upper diagon
 """
 SymTridiagonal
 
-doc"""
-    spzeros(m,n)
-
-Create a sparse matrix of size `m x n`. This sparse matrix will not contain any nonzero values. No storage will be allocated for nonzero values during construction.
-"""
-spzeros
 
 doc"""
     colon(start, [step], stop)
@@ -11253,13 +11200,6 @@ the same as for :func:`brfft`.
 ```
 """
 plan_brfft
-
-doc"""
-    rowvals(A)
-
-Return a vector of the row indices of `A`, and any modifications to the returned vector will mutate `A` as well. Given the internal storage format of sparse matrices, providing access to how the row indices are stored internally can be useful in conjuction with iterating over structural nonzero values. See `nonzeros(A)` and `nzrange(A, col)`.
-"""
-rowvals
 
 doc"""
     mkdir(path, [mode])

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -589,7 +589,7 @@ Indexing, Assignment, and Concatenation
 
        setindex!(collection, value, key...)
 
-   Store the given value at the given key or index within a collection. The syntax ``a[i,j,...] = x`` is converted by the compiler to ``setindex!(a, x, i, j, ...)``\ .
+   Store the given value at the given key or index within a collection. The syntax ``a[i,j,...] = x`` is converted by the compiler to ``(setindex!(a, x, i, j, ...); x)``\ .
 
 .. function:: broadcast_getindex(A, inds...)
 
@@ -1026,7 +1026,13 @@ Indexing, Assignment, and Concatenation
 
        checkbounds(array, indexes...)
 
-   Throw an error if the specified indexes are not in bounds for the given array.
+   Throw an error if the specified indexes are not in bounds for the given array. Subtypes of ``AbstractArray`` should specialize this method if they need to provide custom bounds checking behaviors.
+
+   .. code-block:: julia
+
+       checkbounds(::Type{Bool}, dimlength::Integer, index)
+
+   Return a ``Bool`` describing if the given index is within the bounds of the given dimension length. Custom types that would like to behave as indices for all arrays can extend this method in order to provide a specialized bounds checking implementation.
 
 .. function:: randsubseq(A, p) -> Vector
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -45,7 +45,7 @@ Getting Around
 
        atexit(f)
 
-   Register a zero-argument function to be called at exit.
+   Register a zero-argument function ``f()`` to be called at process exit. ``atexit()`` hooks are called in last in first out (LIFO) order and run before object finalizers.
 
 .. function:: atreplinit(f)
 
@@ -70,9 +70,11 @@ Getting Around
    .. Docstring generated from Julia source
    .. code-block:: julia
 
-       whos([Module,] [pattern::Regex])
+       whos([io,] [Module,] [pattern::Regex])
 
    Print information about exported global variables in a module, optionally restricted to those matching ``pattern``\ .
+
+   The memory consumption estimate is an approximate lower bound on the size of the internal structure of the object.
 
 .. function:: edit(file::AbstractString, [line])
 

--- a/doc/stdlib/collections.rst
+++ b/doc/stdlib/collections.rst
@@ -1345,7 +1345,7 @@ Indexable Collections
 
        setindex!(collection, value, key...)
 
-   Store the given value at the given key or index within a collection. The syntax ``a[i,j,...] = x`` is converted by the compiler to ``setindex!(a, x, i, j, ...)``\ .
+   Store the given value at the given key or index within a collection. The syntax ``a[i,j,...] = x`` is converted by the compiler to ``(setindex!(a, x, i, j, ...); x)``\ .
 
 Fully implemented by:
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -1438,9 +1438,9 @@ Network I/O
 
    .. code-block:: julia
 
-       connect(path) -> Pipe
+       connect(path) -> PipeEndpoint
 
-   Connect to the Named Pipe/Domain Socket at ``path``
+   Connect to the Named Pipe / Domain Socket at ``path``
 
    .. code-block:: julia
 
@@ -1459,9 +1459,9 @@ Network I/O
 
    .. code-block:: julia
 
-       connect(path) -> Pipe
+       connect(path) -> PipeEndpoint
 
-   Connect to the Named Pipe/Domain Socket at ``path``
+   Connect to the Named Pipe / Domain Socket at ``path``
 
    .. code-block:: julia
 
@@ -1482,7 +1482,7 @@ Network I/O
 
        listen(path) -> PipeServer
 
-   Listens on/Creates a Named Pipe/Domain Socket
+   Create and listen on a Named Pipe / Domain Socket
 
 .. function:: listen(path) -> PipeServer
 
@@ -1497,7 +1497,7 @@ Network I/O
 
        listen(path) -> PipeServer
 
-   Listens on/Creates a Named Pipe/Domain Socket
+   Create and listen on a Named Pipe / Domain Socket
 
 .. function:: getaddrinfo(host)
 

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -258,6 +258,9 @@ General Parallel Computing Support
 
     Equivalent to ``addprocs(CPU_CORES)``
 
+    Note that workers do not run a `.juliarc.jl` startup script, nor do they synchronize their global state
+   (such as global variables, new method definitions, and loaded modules) with any of the other running processes.
+
    ::
 
               addprocs(machines; tunnel=false, sshflags=``, max_parallel=10, exeflags=``) -> List of process identifiers
@@ -326,6 +329,9 @@ General Parallel Computing Support
               addprocs() -> List of process identifiers
 
     Equivalent to ``addprocs(CPU_CORES)``
+
+    Note that workers do not run a `.juliarc.jl` startup script, nor do they synchronize their global state
+   (such as global variables, new method definitions, and loaded modules) with any of the other running processes.
 
    ::
 
@@ -396,6 +402,9 @@ General Parallel Computing Support
 
     Equivalent to ``addprocs(CPU_CORES)``
 
+    Note that workers do not run a `.juliarc.jl` startup script, nor do they synchronize their global state
+   (such as global variables, new method definitions, and loaded modules) with any of the other running processes.
+
    ::
 
               addprocs(machines; tunnel=false, sshflags=``, max_parallel=10, exeflags=``) -> List of process identifiers
@@ -464,6 +473,9 @@ General Parallel Computing Support
               addprocs() -> List of process identifiers
 
     Equivalent to ``addprocs(CPU_CORES)``
+
+    Note that workers do not run a `.juliarc.jl` startup script, nor do they synchronize their global state
+   (such as global variables, new method definitions, and loaded modules) with any of the other running processes.
 
    ::
 
@@ -1013,9 +1025,9 @@ Cluster Manager Interface
 
    .. code-block:: julia
 
-       connect(path) -> Pipe
+       connect(path) -> PipeEndpoint
 
-   Connect to the Named Pipe/Domain Socket at ``path``
+   Connect to the Named Pipe / Domain Socket at ``path``
 
    .. code-block:: julia
 


### PR DESCRIPTION
So this is my mini attempt of moving some of the documentation from helpdb.jl to source files. I started small with a few methods in `sparsematrix.jl`. The reason for starting small is that I don't know if I do it right or if this is desired at this point.

Questions:
- The fact that nothing changed in the .rst files from my changes means I did it right?
- Why was unrelated changes updated in the manual when I ran `genstdlib.jl`. Is it because people have added things to `helpdb.jl` without rerunning the manual builder?

@one-more-minute @MichaelHatherly 
