### PR TITLE
Modified heuristic for getindex on sparse matrices

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1375,10 +1375,12 @@ function getindex_I_sorted{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, 
     # Similar to getindex_general but without the transpose trick.
     (m, n) = size(A)
 
-    nI = length(I)
-    avgM = div(nnz(A),n)
+    nI   = length(I)
+    nzA  = nnz(A)
+    avgM = div(nzA,n)
     # heuristics based on experiments
-    alg = ((nI - avgM) > 2^8) ? 1 :
+    alg = ((m > nzA) && (m > nI)) ? 0 :
+          ((nI - avgM) > 2^8) ? 1 :
           ((avgM - nI) > 2^10) ? 0 : 2
 
     (alg == 0) ? getindex_I_sorted_bsearch_A(A, I, J) :

--- a/test/perf/sparse/getindex_skinny.jl
+++ b/test/perf/sparse/getindex_skinny.jl
@@ -1,0 +1,41 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+# Test getindex for skinny sparse matrix
+function sparse_getindex_skinny_perf()
+
+    seed = 1
+    srand(seed)
+
+    # matsize = (size(A,1), nnz(A))
+    matsize = [
+        (2^12,1  ),
+        (2^12,2^6),
+        (2^18,1  ),
+        (2^18,2^9)]
+    # indsize = (length(I), number of repetitions)
+    indsize = [
+        (1,   2^12),
+        (2^8, 2^8 ),
+        (2^16,2^4 )]
+
+    c = 0 # counter
+    for (m,nz) in matsize
+        A = sprand(m,1,nz/m)
+        for (n,p) in indsize
+            c += 1
+            I = rand(1:m,n)
+            @timeit indexing(A,I,p) "sparse_getindex_skinny$c" ""
+        end
+    end
+
+end
+
+function indexing(A,I,p)
+
+    J = [1]
+    for k = 1:p
+        A[I,J]
+    end
+    nothing
+
+end

--- a/test/perf/sparse/perf.jl
+++ b/test/perf/sparse/perf.jl
@@ -6,5 +6,8 @@ include("../perfutil.jl")
 include("getindex.jl")
 sparse_getindex_perf()
 
+include("getindex_skinny.jl")
+sparse_getindex_skinny_perf()
+
 include("fem.jl")
 fem_perf()


### PR DESCRIPTION
getindex(A::SparseMatrixCSC, I::AbstractVector, J::AbstractVector)
- modified heuristic for skinny sparse matrices to reduce memory footprint
- added performance test for skinny  sparse matrices

The modification takes into account that both `Base.SparseMatrix.getindex_I_sorted_bsearch_I(A,I,J)` and `Base.SparseMatrix.getindex_I_sorted_linear(A,I,J)` allocate a dense vector of size `m = size(A,1)` as cache. `Base.SparseMatrix.getindex_I_sorted_bsearch_A(A,I,J)` does not allocate a dense vector. I introduce an upper bound for the cache making the assumption that the algorithm shouldn't require more storage than the input or output. A quick estimate for the input is the storage for all non-zero entries of the sparse matrix A, `nzA = nnz(A)`, and the length of the index vector I, `nI = length(I)`. A rough estimate for the output is `length(I) * length(J)`. I default to the algorithm with a small memory footprint `Base.SparseMatrix.getindex_I_sorted_bsearch_A(A,I,J)` if `m > nzA && m > nI`. Otherwise, the standard heuristic is applied.

Note that for most square matrices, `nnz(A) >= size(A,1)` (`nnz(A) == size(A,1)` for diagonal matrices) and, therefore, the standard heuristic is applied. The modification is only active for skinny matrices.

The modification reduces the memory footprint and, at the same time, reduces the runtime significantly for 9 of 12 of my skinny matrix test examples. For all other matrix test examples the runtime is the same as prior to my modification.
