### PR TITLE
fixed bug and added test for generic vecnorm of array of arrays

### DIFF
--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -124,3 +124,10 @@ end
 
 @test norm([2.4e-322, 4.4e-323]) ≈ 2.47e-322
 @test norm([2.4e-322, 4.4e-323], 3) ≈ 2.4e-322
+
+# test generic vecnorm for arrays of arrays
+let x = Vector{Int}[[1,2], [3,4]]
+    @test norm(x) ≈ sqrt(30)
+    @test norm(x, 1) ≈ sqrt(5) + 5
+    @test norm(x, 3) ≈ cbrt(sqrt(125)+125)
+end


### PR DESCRIPTION
As discussed in #12571, that PR inadvertently broke `norm` for arrays of arrays  — `norm` should work on any iterable where a `norm` function is defined for the elements.

This fixes the bug add adds a test.  It also speeds things up slightly for complex numbers, where `abs2(abs(x)/one(x))` can be replaced by `abs2(x)`.

@andreasnoack, I don't quite understand why you were dividing by `one(x)` (which is not defined for an arbitrary Banach space) in the first place. Was it to avoid overflow for squaring integers?  That could be fixed by an appropriate call to `float`.  Does this fix look okay to you?
