### PR TITLE
fix newline parsing in markdown paragraphs

### DIFF
--- a/base/markdown/Common/block.jl
+++ b/base/markdown/Common/block.jl
@@ -15,11 +15,14 @@ function paragraph(stream::IO, md::MD)
     p = Paragraph()
     push!(md, p)
     skipwhitespace(stream)
+    prev_char = '\n'
     while !eof(stream)
         char = read(stream, Char)
         if char == '\n' || char == '\r'
             char == '\r' && peek(stream) == '\n' && read(stream, Char)
-            if blankline(stream) || parse(stream, md, breaking = true)
+            if prev_char == '\\'
+                write(buffer, '\n')
+            elseif blankline(stream) || parse(stream, md, breaking = true)
                 break
             else
                 write(buffer, ' ')
@@ -27,6 +30,7 @@ function paragraph(stream::IO, md::MD)
         else
             write(buffer, char)
         end
+        prev_char = char
     end
     p.content = parseinline(seek(buffer, 0), md)
     return true

--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -104,6 +104,10 @@ function terminline(io::IO, md::Italic)
     with_output_format(:underline, terminline, io, md.text)
 end
 
+function terminline(io::IO, md::LineBreak)
+    println(io)
+end
+
 function terminline(io::IO, md::Image)
     print(io, "(Image: $(md.alt))")
 end

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 using Base.Markdown
-import Base.Markdown: MD, Paragraph, Header, Italic, Bold, plain, term, html, Table, Code, LaTeX
+import Base.Markdown: MD, Paragraph, Header, Italic, Bold, LineBreak, plain, term, html, Table, Code, LaTeX
 import Base: writemime
 
 # Basics
@@ -10,6 +10,10 @@ import Base: writemime
 
 @test md"foo" == MD(Paragraph("foo"))
 @test md"foo *bar* baz" == MD(Paragraph(["foo ", Italic("bar"), " baz"]))
+@test md"""foo
+bar""" == MD(Paragraph(["foo bar"]))
+@test md"""foo\
+bar""" == MD(Paragraph(["foo", LineBreak(), "bar"]))
 
 @test md"#no title" == MD(Paragraph(["#no title"]))
 @test md"# title" == MD(Header{1}("title"))


### PR DESCRIPTION
@jakebolewski @one-more-minute 

as described in http://spec.commonmark.org/0.21/#hard-line-breaks
