### PR TITLE
`pmap()` cleanup. Fixes #12908.

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -23,11 +23,23 @@ eltype{I}(::Type{Enumerate{I}}) = Tuple{Int, eltype(I)}
 
 abstract AbstractZipIterator
 
+immutable Zip1{I} <: AbstractZipIterator
+    i::I
+end
+zip(a) = Zip1(a)
+length(z::Zip1) = length(z.i)
+eltype{I}(::Type{Zip1{I}}) = Tuple{eltype(I)}
+start(z::Zip1) = start(z.i)
+function next(z::Zip1, st)
+    n = next(z.i,st)
+    return (tuple(n[1]), n[2])
+end
+done(z::Zip1, st) = done(z.i,st)
+
 immutable Zip2{I1, I2} <: AbstractZipIterator
     a::I1
     b::I2
 end
-zip(a) = a
 zip(a, b) = Zip2(a, b)
 length(z::Zip2) = min(length(z.a), length(z.b))
 eltype{I1,I2}(::Type{Zip2{I1,I2}}) = Tuple{eltype(I1), eltype(I2)}

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1389,11 +1389,11 @@ function pmap(f, lsts...; err_retry=0, err_stop=true, pids = workers())
     state = start(tasks)
     abort_tasks() = state = nothing
 
-    function next_task() 
+    function next_task()
 
         if state != nothing && !done(tasks, state)
             ((idx, args), state) = next(tasks, state)
-            return (idx, args, 0)
+            return (idx, length(lsts) > 1 ? args : tuple(args), 0)
         elseif !isempty(retryqueue)
             return shift!(retryqueue)
         end

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1393,7 +1393,7 @@ function pmap(f, lsts...; err_retry=0, err_stop=true, pids = workers())
 
         if state != nothing && !done(tasks, state)
             ((idx, args), state) = next(tasks, state)
-            return (idx, length(lsts) > 1 ? args : tuple(args), 0)
+            return (idx, args, 0)
         elseif !isempty(retryqueue)
             return shift!(retryqueue)
         end


### PR DESCRIPTION
Interface
- Rethrow worker exception unless `err_stop == false` (fix #12908).
- Change err_retry from bool to int number of retries.
- Set defaults to `err_retry=0`, err_stop=true to match `map()`

Implementation
- Use `enumerate(zip(lsts...))` in place of `getnextidx()`,
  `states`, `nxtvals` etc to simplify iteration logic.
- Use `finally` to clear `busy_workers` flag.
