### PR TITLE
Make scale(Array,Number) fall back to *. Fixes #12912.

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -2,16 +2,8 @@
 
 ## linalg.jl: Some generic Linear Algebra definitions
 
-scale(X::AbstractArray, s::Number) = scale!(copy(X), s)
-scale(s::Number, X::AbstractArray) = scale!(copy(X), s)
-
-function scale{R<:Real,S<:Complex}(X::AbstractArray{R}, s::S)
-    Y = Array(promote_type(R,S), size(X))
-    copy!(Y, X)
-    scale!(Y, s)
-end
-
-scale{R<:Real}(s::Complex, X::AbstractArray{R}) = scale(X, s)
+scale(X::AbstractArray, s::Number) = X*s
+scale(s::Number, X::AbstractArray) = s*X
 
 # For better performance when input and output are the same array
 # See https://github.com/JuliaLang/julia/issues/8415#issuecomment-56608729

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -69,6 +69,7 @@ a = reshape([1.:6;], (2,3))
 @test scale([1.; 2.], a) == a.*[1; 2]
 @test scale(a, [1; 2; 3]) == a.*[1 2 3]
 @test scale([1; 2], a) == a.*[1; 2]
+@test scale(eye(Int, 2), 0.5) == 0.5*eye(2)
 @test_throws DimensionMismatch scale(a, ones(2))
 @test_throws DimensionMismatch scale(ones(3), a)
 


### PR DESCRIPTION
...and the same for `scale(Array,Matrix)`.
