### PR TITLE
RFC: Bring back apropos

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1082,6 +1082,7 @@ export
     symbol,
 
 # help and reflection
+    apropos,
     current_module,
     edit,
     code_typed,

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -156,6 +156,12 @@ Getting Around
 
    This is only needed if your module depends on a file that is not used via ``include``\ . It has no effect outside of compilation.
 
+.. function:: apropos(string)
+
+   .. Docstring generated from Julia source
+
+   Search through all documention for a string, ignoring case.
+
 .. function:: which(f, types)
 
    .. Docstring generated from Julia source

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -269,3 +269,8 @@ f12593_2() = 1
 
 # test that macro documentation works
 @test (Docs.@repl @assert) !== nothing
+
+# Simple tests for apropos:
+@test contains(sprint(apropos, "pearson"), "cov")
+@test contains(sprint(apropos, r"ind(exes|ices)"), "eachindex")
+@test contains(sprint(apropos, "print"), "Profile.print")

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -21,7 +21,7 @@ srand(123)
 @test α + UniformScaling(1.0) == UniformScaling(1.0) + α
 @test α - UniformScaling(1.0) == -(UniformScaling(1.0) - α)
 @test copy(UniformScaling(one(Float64))) == UniformScaling(one(Float64))
-@test sprint(show,UniformScaling(one(Float32))) == "Base.LinAlg.UniformScaling{Float32}\n1.0*I"
+@test sprint(show,UniformScaling(one(Float32))) == "UniformScaling{Float32}\n1.0*I"
 
 λ = complex(randn(),randn())
 J = UniformScaling(λ)


### PR DESCRIPTION
This adds a very simple documentation search in order to bring back apropos:

``` jl
julia> apropos("pearson")
cov
cor

julia> apropos("combine")
Base.Docs.catdoc
muladd
ldltfact
sparsevec
sparse
Base.include_from_node1
cholfact
graphemes
Base.Profile.print
bfft

julia> import DataFrames

julia> apropos(r"\bNA\b")
DataFrames.complete_cases
DataFrames.nonunique
DataFrames.complete_cases!
StatsBase.describe
DataFrames.AbstractDataFrame
join
```

I've also updated the display of functions to include module names when they're not exported from Base.  This is important in cases like `Profile.print`, where it would currently just write `print`.

One downside here is that it cannot search across multiple markdown elements.  But this is the simplest solution that I saw to get something basic working… and it works quite well in most simple cases.  On the plus side, this way is extremely fast.
