### PR TITLE
Remove definition for static_assert in C++ mode

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -337,7 +337,7 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
                     return temp;
                 }
                 jl_value_t *scmv = NULL, *temp = NULL;
-                JL_GC_PUSH(&scmv);
+                JL_GC_PUSH1(&scmv);
                 if (sym == label_sym) {
                     scmv = scm_to_julia_(car_(e),0);
                     temp = jl_new_struct(jl_labelnode_type, scmv);

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -29,11 +29,7 @@
 #endif
 
 #ifndef static_assert
-#  ifdef __cplusplus
-#    if __cplusplus < 201103L
-#      define static_assert(...)
-#    endif
-#  else
+#  ifndef __cplusplus
 #    define static_assert(...)
 // Remove the following gcc special handling when we officially requires
 // gcc 4.7 (for c++11) and -std=gnu11

--- a/src/julia.h
+++ b/src/julia.h
@@ -860,7 +860,6 @@ int jl_is_type(jl_value_t *v);
 DLLEXPORT int jl_is_leaf_type(jl_value_t *v);
 DLLEXPORT int jl_has_typevars(jl_value_t *v);
 DLLEXPORT int jl_subtype(jl_value_t *a, jl_value_t *b, int ta);
-int jl_type_morespecific(jl_value_t *a, jl_value_t *b);
 DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b);
 DLLEXPORT jl_value_t *jl_type_union(jl_svec_t *types);
 jl_value_t *jl_type_union_v(jl_value_t **ts, size_t n);


### PR DESCRIPTION
MSVC didn't like macroizing a keyword

ref https://github.com/JuliaLang/julia/pull/12895#issuecomment-137304864 @yuyichao
