### PR TITLE
Use llvm-dsymutil on recent-enough LLVM

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -678,7 +678,13 @@ ifeq ($(OS), Darwin)
   INSTALL_NAME_ID_DIR = @rpath/
   INSTALL_NAME_CMD = install_name_tool -id $(INSTALL_NAME_ID_DIR)
   INSTALL_NAME_CHANGE_CMD = install_name_tool -change
-ifeq ($(shell test `dsymutil -v | cut -d\- -f2 | cut -d. -f1` -gt 102 && echo yes), yes)
+  LLVM_MAJOR = $(shell echo $(LLVM_VER) | cut -d. -f1)
+  LLVM_MINOR = $(shell echo $(LLVM_VER) | cut -d. -f2)
+ifeq ($(LLVM_VER),svn)
+  DSYMUTIL = $(build_bindir)/llvm-dsymutil
+else ifeq ($(shell test (($(LLVM_MAJOR) -gt 3) -o (($(LLVM_MAJOR -eq 3) -a ($(LLVM_MINOR) -gt 7))))))
+  DSYMUTIL = $(build_bindir)/llvm-dsymutil
+else ifeq ($(shell test `dsymutil -v | cut -d\- -f2 | cut -d. -f1` -gt 102 && echo yes), yes)
   DSYMUTIL = dsymutil
 else
   DSYMUTIL = true -ignore


### PR DESCRIPTION
Darwin's dsymutil has bugs that can make it annoying to debug julia on OS X. LLVM ships with its own version of dsymutil, which for LLVM >= 3.8 is mature enough to be usable and more stable. On those versions of LLVM, prefer llvm-dsymutil over the system one.
