### PR TITLE
Fix sharedarray indexing regression

### DIFF
--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -280,9 +280,9 @@ end
 convert(::Type{Array}, S::SharedArray) = S.s
 
 # pass through getindex and setindex! - unlike DArrays, these always work on the complete array
-getindex(S::SharedArray, I::Real) = getindex(S.s, I)
+getindex(S::SharedArray, i::Real) = getindex(S.s, i)
 
-setindex!(S::SharedArray, x, I::Real) = setindex!(S.s, x, I)
+setindex!(S::SharedArray, x, i::Real) = setindex!(S.s, x, i)
 
 function fill!(S::SharedArray, v)
     vT = convert(eltype(S), v)
@@ -334,10 +334,10 @@ function shmem_randn(dims; kwargs...)
 end
 shmem_randn(I::Int...; kwargs...) = shmem_randn(I; kwargs...)
 
-similar(S::SharedArray, T, dims::Dims) = SharedArray(T, dims; pids=procs(S))
-similar(S::SharedArray, T) = similar(S, T, size(S))
-similar(S::SharedArray, dims::Dims) = similar(S, eltype(S), dims)
-similar(S::SharedArray) = similar(S, eltype(S), size(S))
+similar(S::SharedArray, T, dims::Dims) = similar(S.s, T, dims)
+similar(S::SharedArray, T) = similar(S.s, T, size(S))
+similar(S::SharedArray, dims::Dims) = similar(S.s, eltype(S), dims)
+similar(S::SharedArray) = similar(S.s, eltype(S), size(S))
 
 map(f, S::SharedArray) = (S2 = similar(S); S2[:] = S[:]; map!(f, S2); S2)
 

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -97,6 +97,9 @@ for p in procs(d)
     @test d[idxl] == p
 end
 
+d = SharedArray(Float64, (2,3))
+@test isa(d[:,2], Vector{Float64})
+
 ### SharedArrays from a file
 
 # Mapping an existing file
@@ -183,10 +186,10 @@ d = Base.shmem_rand(dims)
 s = copy(sdata(d))
 ds = deepcopy(d)
 @test ds == d
-pids_ds = procs(ds)
-remotecall_fetch(pids_ds[findfirst(id->(id != myid()), pids_ds)], setindex!, ds, 1.0, 1:10)
+pids_d = procs(d)
+remotecall_fetch(pids_d[findfirst(id->(id != myid()), pids_d)], setindex!, d, 1.0, 1:10)
 @test ds != d
-@test s == d
+@test s != d
 
 
 # SharedArray as an array


### PR DESCRIPTION
#12560 got rid of pass-through `getindex`/`setindex` definitions for `SharedArray`. This causes   `getindex(::SharedArray, ...)` to always create new shared arrays and thus quickly running out of open file handles. Instead, normal arrays should be returned. This PR reintroduces the old behavior.

To trigger the problem in current master:

``` jl
d = SharedArray(Float64, (2,3))
for x in 1:100000
    @show x
    d[:,2]
end
```

I think this is a blocker for 0.4, as SharedArrays are totally unusable in the current state.
cc @timholy @amitmurthy 
