### PR TITLE
Fix type instability in sparse for Int32

### DIFF
--- a/base/sparse/csparse.jl
+++ b/base/sparse/csparse.jl
@@ -19,7 +19,7 @@ function sparse{Tv,Ti<:Integer}(I::AbstractVector{Ti},
                                 combine::Union{Function,Base.Func})
 
     if length(I) == 0;
-        return spzeros(eltype(V),nrow,ncol)
+        return spzeros(eltype(V), Ti, nrow,ncol)
     end
     N = length(I)
     if N != length(J) || N != length(V)
@@ -86,7 +86,7 @@ function sparse{Tv,Ti<:Integer}(I::AbstractVector{Ti},
                     Ri[pdest] = j
                     Rx[pdest] = Rx[p]
                 end
-                pdest += 1
+                pdest += one(Ti)
             end
         end
 


### PR DESCRIPTION
Fixes #12963 

Before:

``` julia
julia> @time A = sparse(r,c,v,N,N)
  3.676528 seconds (65.99 M allocations: 1.300 GB, 2.11% gc time)
```

After:

``` julia
julia> @time A = sparse(r,c,v,N,N)
  1.498092 seconds (23 allocations: 324.249 MB)
```

Fixed:
~~The returnvalue is still not correctly inferred though:~~

``` julia
julia> @code_warntype sparse(r,c,v,N,N); 
Variables:
  I::Array{Int32,1}
  J::Array{Int32,1}
  V::Array{Float32,1}
  m::Int64
  n::Int64

Body:
  begin  # sparse/sparsematrix.jl, line 320:
      return (Base.SparseMatrix.sparse)(I::Array{Int32,1},J::Array{Int32,1},V::Array{Float32,1},m::Int64,n::Int64,$(Expr(:new, :((top(getfield))(Base,:AddFun)::Type{Base.AddFun}))))::Union{Base.SparseMatrix.SparseMatrixCSC{Float32,Int32},Base.SparseMatrix.SparseMatrixCSC{Float32,Int64}}
  end::Union{Base.SparseMatrix.SparseMatrixCSC{Float32,Int32},Base.SparseMatrix.SparseMatrixCSC{Float32,Int64}}
```
