### PR TITLE
Fix access to undefined reference in showarray(::SparseMatrixCSC)

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -52,7 +52,11 @@ function Base.showarray(io::IO, S::SparseMatrixCSC;
     for col = 1:S.n, k = S.colptr[col] : (S.colptr[col+1]-1)
         if k < half_screen_rows || k > nnz(S)-half_screen_rows
             print(io, sep, '[', rpad(S.rowval[k], pad), ", ", lpad(col, pad), "]  =  ")
-            showcompact(io, S.nzval[k])
+            if isassigned(S.nzval, k)
+                showcompact(io, S.nzval[k])
+            else
+                print(io, Base.undef_ref_str)
+            end
         elseif k == half_screen_rows
             print(io, sep, '\u22ee')
         end

--- a/test/show.jl
+++ b/test/show.jl
@@ -281,3 +281,15 @@ try
 finally
     redirect_stdout(oldout)
 end
+
+# issue #12960
+type T12960 end
+let
+    A = speye(3)
+    B = similar(A, T12960)
+    @test sprint(show, B)  == "\n\t[1, 1]  =  #undef\n\t[2, 2]  =  #undef\n\t[3, 3]  =  #undef"
+    @test sprint(print, B) == "\n\t[1, 1]  =  #undef\n\t[2, 2]  =  #undef\n\t[3, 3]  =  #undef"
+    B[1,2] = T12960()
+    @test sprint(show, B)  == "\n\t[1, 1]  =  #undef\n\t[1, 2]  =  T12960()\n\t[2, 2]  =  #undef\n\t[3, 3]  =  #undef"
+    @test sprint(print, B) == "\n\t[1, 1]  =  #undef\n\t[1, 2]  =  T12960()\n\t[2, 2]  =  #undef\n\t[3, 3]  =  #undef"
+end


### PR DESCRIPTION
Reported in #12960.

Before:

``` jl
julia> ype Foo end

julia> A = speye(3)
julia> @show similar(A, Foo)
...
ERROR: UndefRefError: access to undefined reference
 [inlined code] from sparse/sparsematrix.jl:55
 in __showarray#296__ at no file:0
 in showarray at no file
 in showall at show.jl:1249
 in repr at strings/io.jl:48
```

After:

``` jl
julia> type Foo end

julia> A = speye(3);

julia> @show similar(A, Foo);
similar(A,Foo) =
    [1, 1]  =  #undef
    [2, 2]  =  #undef
    [3, 3]  =  #undef
```
