### PR TITLE
Remove unnecessary `Tuple`s from doc signatures.

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -107,8 +107,8 @@ function signature(expr::Expr)
         sig = :(Union{Tuple{}})
         for arg in expr.args[2:end]
             isexpr(arg, :parameters) && continue
-            if isa(arg,Expr) && arg.head === :kw # optional arg
-                push!(sig.args, :(Tuple{$(sig.args[end].args...)}))
+            if isexpr(arg, :kw) # optional arg
+                push!(sig.args, :(Tuple{$(sig.args[end].args[2:end]...)}))
             end
             push!(sig.args[end].args, argtype(arg))
         end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -104,6 +104,9 @@ type FieldDocs
     three
 end
 
+"h/0-3"
+h(x = 1, y = 2, z = 3) = x + y + z
+
 end
 
 import Base.Docs: meta
@@ -135,6 +138,12 @@ end
 let g = DocsTest.g
     funcdoc = meta(DocsTest)[g]
     @test docstrings_equal(funcdoc.meta[Union{}], doc"g")
+end
+
+let h = DocsTest.h
+    funcdoc = meta(DocsTest)[h]
+    sig = Union{Tuple{}, Tuple{Any}, Tuple{Any, Any}, Tuple{Any, Any, Any}}
+    @test docstrings_equal(funcdoc.meta[sig], doc"h/0-3")
 end
 
 let AT = DocsTest.AT


### PR DESCRIPTION
Additional `Tuple`s were being prepended to signatures of docstrings with optional arguments.

Before:

```
julia> "..." f(x = 1, y = 2) = x
f (generic function with 3 methods)

julia> Main.__META__[f].order
1-element Array{Type{T},1}:
 Union{Tuple{Tuple,Any},Tuple{Tuple,Tuple,Any,Any},Tuple{}}
```

After:

```
julia> "..."  f(x = 1, y = 2) = x
f (generic function with 3 methods)

julia> Main.__META__[f].order
1-element Array{Type{T},1}:
 Union{Tuple{Any,Any},Tuple{Any},Tuple{}}
```
