### PR TITLE
Fix newly added backtrace test

### DIFF
--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -21,7 +21,7 @@ using Base.Test
 
 function get_bt_frame(functionname, bt)
     for i = 1:length(bt)
-        lkup = ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), bt[i], true)
+        lkup = ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), bt[i]-1, true)
         # find the function frame
         lkup[1] == functionname && (return lkup)
     end


### PR DESCRIPTION
For any given frame the PC will be after the instruction that actually executed. In some cases, this PC can be past the end of the function boundary (or at least be not covered by line information). Thus, one should always pass the address-1 to jl_lookup_code_address (see show_backtrace in base for example). @ihnorton 
