### PR TITLE
Missing docs between functions

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -3779,6 +3779,13 @@ Example for a sparse 2-d array:
     A[iter] = 0.4864987874354343
     (iter.I_1,iter.I_2) = (2,3)
     A[iter] = 0.8090413606455655
+
+If you supply more than one ``AbstractArray`` argument, ``eachindex``
+will create an iterable object that is fast for all arguments (a
+``UnitRange`` if all inputs have fast linear indexing, a
+CartesianRange otherwise).  If the arrays have different sizes and/or
+dimensionalities, ``eachindex`` returns an iterable that spans the
+largest range along each dimension.
 """
 eachindex
 
@@ -9633,6 +9640,8 @@ doc"""
 ..  bkfact(A) -> BunchKaufman
 
 Compute the Bunch-Kaufman [Bunch1977]_ factorization of a real symmetric or complex Hermitian matrix ``A`` and return a ``BunchKaufman`` object. The following functions are available for ``BunchKaufman`` objects: ``size``, ``\``, ``inv``, ``issym``, ``ishermitian``.
+
+.. [Bunch1977] J R Bunch and L Kaufman, Some stable methods for calculating inertia and solving symmetric linear systems, Mathematics of Computation 31:137 (1977), 163-179. `url <http://www.ams.org/journals/mcom/1977-31-137/S0025-5718-1977-0428694-0>`_.
 ```
 """
 bkfact

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -77,12 +77,7 @@ Basic functions
        (iter.I_1,iter.I_2) = (2,3)
        A[iter] = 0.8090413606455655
 
-If you supply more than one ``AbstractArray`` argument, ``eachindex``
-will create an iterable object that is fast for all arguments (a
-``UnitRange`` if all inputs have fast linear indexing, a
-CartesianRange otherwise).  If the arrays have different sizes and/or
-dimensionalities, ``eachindex`` returns an interable that spans the
-largest range along each dimension.
+   If you supply more than one ``AbstractArray`` argument, ``eachindex`` will create an iterable object that is fast for all arguments (a ``UnitRange`` if all inputs have fast linear indexing, a CartesianRange otherwise).  If the arrays have different sizes and/or dimensionalities, ``eachindex`` returns an iterable that spans the largest range along each dimension.
 
 .. function:: Base.linearindexing(A)
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -251,7 +251,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    Compute the Bunch-Kaufman [Bunch1977]_ factorization of a real symmetric or complex Hermitian matrix ``A`` and return a ``BunchKaufman`` object. The following functions are available for ``BunchKaufman`` objects: ``size``, ``\``, ``inv``, ``issym``, ``ishermitian``.
 
-.. [Bunch1977] J R Bunch and L Kaufman, Some stable methods for calculating inertia and solving symmetric linear systems, Mathematics of Computation 31:137 (1977), 163-179. `url <http://www.ams.org/journals/mcom/1977-31-137/S0025-5718-1977-0428694-0>`_.
+   .. [Bunch1977] J R Bunch and L Kaufman, Some stable methods for calculating inertia and solving symmetric linear systems, Mathematics of Computation 31:137 (1977), 163-179. `url <http://www.ams.org/journals/mcom/1977-31-137/S0025-5718-1977-0428694-0>`_.
 
 .. function:: bkfact!(A) -> BunchKaufman
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -2072,9 +2072,9 @@ multi-threading. Use ``FFTW.set_num_threads(np)`` to use ``np`` threads.
 
    Compute the cross-correlation of two vectors.
 
-The following functions are defined within the ``Base.FFTW`` module.
-
 .. currentmodule:: Base.FFTW
+
+The following functions are defined within the ``Base.FFTW`` module.
 
 .. function:: r2r(A, kind [, dims])
 


### PR DESCRIPTION
- Optionally warn about document between functions in `genstdlib.jl`
- Fix missing docs in `helpdb.jl`. (Include and) close #12956.
