### PR TITLE
Restore 'line handling for kwarg specializations

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -338,6 +338,9 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams, jl_mod
         if (jl_is_linenode(body1)) {
             li->file = (jl_sym_t*)jl_fieldref(body1, 0);
             li->line = jl_unbox_long(jl_fieldref(body1, 1));
+        } else if (jl_is_expr(body1) && ((jl_expr_t*)body1)->head == line_sym) {
+            li->file = (jl_sym_t*)jl_exprarg(body1, 1);
+            li->line = jl_unbox_long(jl_exprarg(body1, 0));
         }
     }
     li->module = ctx;

--- a/src/ast.c
+++ b/src/ast.c
@@ -327,6 +327,9 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
             e = cdr_(e);
             if (!eo) {
                 if (sym == line_sym && n==2) {
+                    // NOTE: n==3 case exists: '(line, linenum, filename, funcname) passes
+                    //       the original name through to keyword-arg specializations.
+                    //       See 'line handling in julia-syntax.scm:keywords-method-def-expr
                     jl_value_t *filename = NULL, *linenum = NULL;
                     JL_GC_PUSH2(&filename, &linenum);
                     filename = scm_to_julia_(car_(cdr_(e)),0);

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-# note: when modifying this file, update TESTLINE below or the inline test will fail!
-
 bt = backtrace()
 have_backtrace = false
 for l in bt
@@ -67,3 +65,9 @@ catch err
 end
 
 end # module
+
+#issue 12977: line numbers for kwarg methods.
+linenum = @__LINE__; f12977(; args...) = ()
+loc = functionloc(f12977)
+@test endswith(loc[1], "backtrace.jl")
+@test loc[2] == linenum


### PR DESCRIPTION
'(line, linenum, filename, funcname) is used to pass
the original name through to keyword-arg specializations.
See 'line handling in julia-syntax.scm:keywords-method-def-expr

fixes #12971
fixes #12977
