### PR TITLE
Fix incorrect module selection in `Binding` objects.

### DIFF
--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -2,43 +2,25 @@
 
 export @var
 
-moduleusings(mod) = ccall(:jl_module_usings, Any, (Any,), mod)
-
-function findsource(mod::Module, var::Symbol, seen = Set{Module}())
-    mod in seen && return
-    var in names(mod, true) && return mod
-    push!(seen, mod)
-    sources = filter(m -> m ≠ nothing && m ∉ seen,
-                     map(n -> findsource(n, var, seen),
-                         moduleusings(mod)))
-    isempty(sources) ? nothing : collect(sources)[1]
-end
-
 immutable Binding
     mod::Module
     var::Symbol
-
-    function Binding(mod::Module, var::Symbol)
-        mod′ = findsource(mod, var)
-        mod′ == nothing && error("$mod.$var not found.")
-        new(mod′, var)
-    end
+    Binding(m, v) = new(Base.which_module(m, v), v)
 end
 
 function splitexpr(x::Expr)
-    isexpr(x, :macrocall) && return splitexpr(x.args[1])
-    isexpr(x, :.)         && return (x.args[1], x.args[2].args[1])
+    isexpr(x, :macrocall) ? splitexpr(x.args[1]) :
+    isexpr(x, :.)         ? (esc(x.args[1]), x.args[2]) :
     error("Invalid @var syntax `$x`.")
 end
-splitexpr(s::Symbol) = (module_name(current_module()), s)
+splitexpr(s::Symbol) = :(current_module()), quot(s)
 splitexpr(other)     = error("Invalid @var syntax `$other`.")
 
 isvar(x) = isexpr(x, :macrocall, :.)
 isvar(::Symbol) = true
 
 macro var(x)
-    mod, var = splitexpr(x)
-    :(Binding($(esc(mod)), $(quot(var))))
+    :(Binding($(splitexpr(x)...)))
 end
 
 Base.show(io::IO, x::Binding) = print(io, "$(x.mod).$(x.var)")


### PR DESCRIPTION
`findsource` didn't always find the correct module and was much too easy to confuse with imported symbols - see #12700 for an example.

This replaces `findsource` with a call to `which_module` and should work properly in all cases.

`doc/genstdlib.jl` has been run with no noticeable change in generated output.

Also added comprehensive tests for Bindings.

Closes #12700.
