### PR TITLE
Improve apropos searching of markdown

### DIFF
--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -318,21 +318,8 @@ function docsearch(haystack::FuncDoc, needle)
     false
 end
 
-## Recursive Markdown search
-docsearch(haystack::Markdown.BlockQuote, needle) = docsearch(haystack.content, needle)
-docsearch(haystack::Markdown.Bold, needle) = docsearch(haystack.text, needle)
-docsearch(haystack::Markdown.Code, needle) = docsearch(haystack.code, needle)
-docsearch(haystack::Markdown.Header, needle) = docsearch(haystack.text, needle)
-docsearch(haystack::Markdown.HorizontalRule, needle) = false
-docsearch(haystack::Markdown.Image, needle) = docsearch(haystack.alt, needle)
-docsearch(haystack::Markdown.Italic, needle) = docsearch(haystack.text, needle)
-docsearch(haystack::Markdown.LaTeX, needle) = docsearch(haystack.formula, needle)
-docsearch(haystack::Markdown.LineBreak, needle) = false
-docsearch(haystack::Markdown.Link, needle) = docsearch(haystack.text, needle) # URL too?
-docsearch(haystack::Markdown.List, needle) = docsearch(haystack.items, needle)
-docsearch(haystack::Markdown.MD, needle) = docsearch(haystack.content, needle)
-docsearch(haystack::Markdown.Paragraph, needle) = docsearch(haystack.content, needle)
-docsearch(haystack::Markdown.Table, needle) = docsearch(haystack.rows, needle)
+## Markdown: simply search the plaintext
+docsearch(haystack::Markdown.MD, needle) = docsearch(sprint(writemime, MIME"text/plain"(), haystack), needle)
 
 # Apropos searches through all available documentation for some string or regex
 """


### PR DESCRIPTION
Search the entire plaintext markdown wholistically (instead of searching each markdown element independently). Before, `docsearch(md"*foo* bar", r"foo.*bar")` would return false; it now properly returns true.

This does have significant overhead -- it is about 50x slower than the current implementation -- but it still searches the entire standard library on my wimpy laptop in less than 0.5 seconds after compilation. This does get slightly worse as more packages are imported, but I am not aware of any packages that even come close to defining as many docstrings as there are in the standard library.

As a bonus, the implementation is much simpler, too.
