### PR TITLE
Fix some show methods after workspace()

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -81,7 +81,14 @@ end
 
 show(io::IO, mt::MethodTable) = show_method_table(io, mt)
 
-inbase(m::Module) = m == Base ? true : m == Main ? false : inbase(module_parent(m))
+function inbase(m::Module)
+    if m == Base
+        true
+    else
+        parent = module_parent(m)
+        parent === m ? false : inbase(parent)
+    end
+end
 fileurl(file) = let f = find_source_file(file); f === nothing ? "" : "file://"*f; end
 function url(m::Method)
     M = m.func.code.module

--- a/base/show.jl
+++ b/base/show.jl
@@ -56,14 +56,16 @@ end
 
 # Check if a particular symbol is exported from a standard library module
 function is_exported_from_stdlib(name::Symbol, mod::Module)
-    parent = module_parent(mod)
-    if parent !== Main && isdefined(mod, name) && isdefined(parent, name) &&
-            getfield(mod, name) === getfield(parent, name)
-        is_exported_from_stdlib(name, module_parent(mod))
-    else
-        (mod === Base && name in names(Base)) ||
-            (mod === Core && name in names(Core))
+    if (mod === Base && name in names(Base)) ||
+       (mod === Core && name in names(Core))
+        return true
     end
+    parent = module_parent(mod)
+    if parent !== mod && isdefined(mod, name) && isdefined(parent, name) &&
+       getfield(mod, name) === getfield(parent, name)
+        return is_exported_from_stdlib(name, parent)
+    end
+    return false
 end
 
 function show(io::IO, f::Function)

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -1226,7 +1226,7 @@ Reflection
 
    .. Docstring generated from Julia source
 
-   Get a module's enclosing ``Module``\ . ``Main`` is its own parent.
+   Get a module's enclosing ``Module``\ . ``Main`` is its own parent, as is ``LastMain`` after ``workspace()``\ .
 
 .. function:: current_module() -> Module
 

--- a/test/workspace.jl
+++ b/test/workspace.jl
@@ -1,11 +1,17 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-# Issue #11948
 script = """
+# Issue #11948
 f(x) = x+1
 workspace()
 @assert !isdefined(:f)
 LastMain.f(2)
+
+# PR #12990
+io = IOBuffer()
+show(io, Pair)
+@assert takebuf_string(io) == "Pair{A,B}"
+@assert !Base.inbase(LastMain)
 """
 exename = joinpath(JULIA_HOME, Base.julia_exename())
 run(`$exename -f -e $script`)


### PR DESCRIPTION
Main is not the only module whose parent is itself. LastMain is also its own parent. Previously these gave stack overflows:

``` julia
julia> f() = 1;

julia> workspace()

julia> Pair
Error showing value of type DataType:
ERROR: StackOverflowError:

julia> Base.url(LastMain.f.env.defs)
ERROR: StackOverflowError:
```
