### PR TITLE
Fix dangling pointer in libuv close callback

### DIFF
--- a/base/poll.jl
+++ b/base/poll.jl
@@ -180,7 +180,6 @@ end
 function close(t::Union{FileMonitor, PollingFileWatcher})
     if t.handle != C_NULL
         ccall(:jl_close_uv, Void, (Ptr{Void},), t.handle)
-        t.handle = C_NULL
     end
 end
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -887,3 +887,38 @@ let n = tempname()
     close(io); close(w)
     rm(n)
 end
+
+#issue #12992
+function test_12992()
+    pfw = PollingFileWatcher(@__FILE__, 0.01)
+    close(pfw)
+    pfw = PollingFileWatcher(@__FILE__, 0.01)
+    close(pfw)
+    pfw = PollingFileWatcher(@__FILE__, 0.01)
+    close(pfw)
+    gc()
+    gc()
+end
+
+# Make sure multiple close is fine
+function test2_12992()
+    pfw = PollingFileWatcher(@__FILE__, 0.01)
+    close(pfw)
+    close(pfw)
+    pfw = PollingFileWatcher(@__FILE__, 0.01)
+    close(pfw)
+    close(pfw)
+    pfw = PollingFileWatcher(@__FILE__, 0.01)
+    close(pfw)
+    close(pfw)
+    gc()
+    gc()
+end
+
+test_12992()
+test_12992()
+test_12992()
+
+test2_12992()
+test2_12992()
+test2_12992()


### PR DESCRIPTION
Fix #12992

Calling `close` multiple times seems fine too.

@vtjnash 
