### PR TITLE
Add test for scale(::AbstractTriangular{Int64},::Float64)

### DIFF
--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -149,11 +149,13 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
                 scale!(A1tmp,ci)
                 @test A1tmp == ci*A1
             end
-            @test scale(A1,cr) == cr*A1
-            @test scale(cr,A1) == cr*A1
-            @test scale(A1,ci) == ci*A1
-            @test scale(ci,A1) == ci*A1
         end
+
+        @test scale(A1,0.5) == 0.5*A1
+        @test scale(0.5,A1) == 0.5*A1
+        @test scale(A1,0.5im) == 0.5im*A1
+        @test scale(0.5im,A1) == 0.5im*A1
+
 
         # Binary operations
         @test A1*0.5 == full(A1)*0.5


### PR DESCRIPTION
Now that `scale(A,x)` falls back to `*` (#12912) rather than `scale!`, these tests do not need to be restricted any more.
