### PR TITLE
Don't convert Symmetric to full for expm()

### DIFF
--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -176,12 +176,12 @@ end
 
 #Matrix-valued functions
 function expm(A::Symmetric)
-    F = eigfact(full(A))
+    F = eigfact(A)
     return Symmetric((F.vectors * Diagonal(exp(F.values))) * F.vectors')
 end
 function expm{T}(A::Hermitian{T})
     n = chksquare(A)
-    F = eigfact(full(A))
+    F = eigfact(A)
     retmat = (F.vectors * Diagonal(exp(F.values))) * F.vectors'
     if T <: Real
         return real(Hermitian(retmat))
@@ -198,7 +198,7 @@ for (funm, func) in ([:logm,:log], [:sqrtm,:sqrt])
     @eval begin
 
         function ($funm)(A::Symmetric)
-            F = eigfact(full(A))
+            F = eigfact(A)
             if isposdef(F)
                 retmat = (F.vectors * Diagonal(($func)(F.values))) * F.vectors'
             else


### PR DESCRIPTION
It looks like the conversion of `Symmetric` into `full()` before `eigfact()` is unnecessary.
It doesn't speed up the things, but at least reduces the memory footprint.

``` julia
function f(t::Int, m::Int=100, n::Int=100)
         for i in 1:t
           mtx = randn(m, n)
           sy = Symmetric(mtx+mtx')
           expsy = expm(sy)
         end
       end
```

Before 

``` julia
@time f(1000)
#  3.839750 seconds (52.79 k allocations: 720.854 MB, 0.52% gc time)
#  3.623629 seconds (47.00 k allocations: 720.612 MB, 0.49% gc time)
#  3.606365 seconds (47.00 k allocations: 720.612 MB, 0.49% gc time)
```

After

``` julia
@time f(1000)
#3.573506 seconds (44.00 k allocations: 644.165 MB, 0.34% gc time)
#3.634259 seconds (44.00 k allocations: 644.165 MB, 0.35% gc time)
#3.586167 seconds (44.00 k allocations: 644.165 MB, 0.34% gc time)
```
