### PR TITLE
Fix #13008, error in sparse for row/col inds larger than matrix

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -3509,7 +3509,7 @@ A_rdiv_Bc
 doc"""
     sparse(I,J,V,[m,n,combine])
 
-Create a sparse matrix `S` of dimensions `m x n` such that `S[I[k], J[k]] = V[k]`. The `combine` function is used to combine duplicates. If `m` and `n` are not specified, they are set to `max(I)` and `max(J)` respectively. If the `combine` function is not supplied, duplicates are added by default.
+Create a sparse matrix `S` of dimensions `m x n` such that `S[I[k], J[k]] = V[k]`. The `combine` function is used to combine duplicates. If `m` and `n` are not specified, they are set to `maximum(I)` and `maximum(J)` respectively. If the `combine` function is not supplied, duplicates are added by default. All elements of `I` must satisfy `1 <= I[k] <= m`, and all elements of `J` must satisfy `1 <= J[k] <= n`.
 """
 sparse(I, J, V, m=?, n=?, combine=?)
 

--- a/base/sparse/csparse.jl
+++ b/base/sparse/csparse.jl
@@ -35,8 +35,11 @@ function sparse{Tv,Ti<:Integer}(I::AbstractVector{Ti},
     Rnz[1] = 1
     nz = 0
     for k=1:N
+        iind = I[k]
+        iind > 0 || throw(ArgumentError("all I index values must be > 0"))
+        iind <= nrow || throw(ArgumentError("all I index values must be ≤ the number of rows"))
         if V[k] != 0
-            Rnz[I[k]+1] += 1
+            Rnz[iind+1] += 1
             nz += 1
         end
     end
@@ -52,9 +55,7 @@ function sparse{Tv,Ti<:Integer}(I::AbstractVector{Ti},
     @inbounds for k=1:N
         iind = I[k]
         jind = J[k]
-        iind > 0 || throw(ArgumentError("all I index values must be > 0"))
         jind > 0 || throw(ArgumentError("all J index values must be > 0"))
-        iind <= nrow || throw(ArgumentError("all I index values must be ≤ the number of rows"))
         jind <= ncol || throw(ArgumentError("all J index values must be ≤ the number of columns"))
         p = Wj[iind]
         Vk = V[k]

--- a/base/sparse/csparse.jl
+++ b/base/sparse/csparse.jl
@@ -18,12 +18,12 @@ function sparse{Tv,Ti<:Integer}(I::AbstractVector{Ti},
                                 nrow::Integer, ncol::Integer,
                                 combine::Union{Function,Base.Func})
 
-    if length(I) == 0;
-        return spzeros(eltype(V), Ti, nrow,ncol)
-    end
     N = length(I)
     if N != length(J) || N != length(V)
         throw(ArgumentError("triplet I,J,V vectors must be the same length"))
+    end
+    if N == 0
+        return spzeros(eltype(V), Ti, nrow, ncol)
     end
 
     # Work array

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -863,7 +863,7 @@ Sparse matrices support much of the same set of operations as dense matrices. Th
 
    .. Docstring generated from Julia source
 
-   Create a sparse matrix ``S`` of dimensions ``m x n`` such that ``S[I[k], J[k]] = V[k]``\ . The ``combine`` function is used to combine duplicates. If ``m`` and ``n`` are not specified, they are set to ``max(I)`` and ``max(J)`` respectively. If the ``combine`` function is not supplied, duplicates are added by default.
+   Create a sparse matrix ``S`` of dimensions ``m x n`` such that ``S[I[k], J[k]] = V[k]``\ . The ``combine`` function is used to combine duplicates. If ``m`` and ``n`` are not specified, they are set to ``maximum(I)`` and ``maximum(J)`` respectively. If the ``combine`` function is not supplied, duplicates are added by default. All elements of ``I`` must satisfy ``1 <= I[k] <= m``\ , and all elements of ``J`` must satisfy ``1 <= J[k] <= n``\ .
 
 .. function:: sparsevec(I, V, [m, combine])
 

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1098,3 +1098,6 @@ A = sprand(10,10,0.2)
 p = randperm(10)
 q = randperm(10)
 @test Base.SparseMatrix.csc_permute(A, invperm(p), q) == full(A)[p, q]
+
+# issue #13008
+@test_throws ArgumentError sparse(collect(1:100), collect(1:100), fill(5,100), 5, 5)

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -1101,3 +1101,4 @@ q = randperm(10)
 
 # issue #13008
 @test_throws ArgumentError sparse(collect(1:100), collect(1:100), fill(5,100), 5, 5)
+@test_throws ArgumentError sparse(Int[], collect(1:5), collect(1:5))


### PR DESCRIPTION
Error was already there but the earlier preallocation loop was hitting a `BoundsError` instead of the specific error message for this condition.
