### PR TITLE
Store module reference for plain docs

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -344,7 +344,7 @@ namify(sy::Symbol) = sy
 
 function mdify(ex)
     if isexpr(ex, AbstractString, :string)
-        :(Markdown.parse($(esc(ex))))
+        :(Markdown.doc_str($(esc(ex)), @__FILE__, current_module()))
     else
         esc(ex)
     end

--- a/base/markdown/Markdown.jl
+++ b/base/markdown/Markdown.jl
@@ -51,6 +51,7 @@ macro md_str(s, t...)
 end
 
 doc_str(md, file, mod) = (md.meta[:path] = file; md.meta[:module] = mod; md)
+doc_str(md::AbstractString, file, mod) = doc_str(parse(md), file, mod)
 
 macro doc_str(s, t...)
     :(doc_str($(mdexpr(s, t...)), @__FILE__, current_module()))

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -130,6 +130,10 @@ end
 
 @test meta(DocsTest)[DocsTest] == doc"DocsTest"
 
+# Check that plain docstrings store a module reference.
+# https://github.com/JuliaLang/julia/pull/13017#issuecomment-138618663
+@test meta(DocsTest)[DocsTest].meta[:module] == DocsTest
+
 let f = DocsTest.f
     funcdoc = meta(DocsTest)[f]
     @test funcdoc.main == nothing


### PR DESCRIPTION
Without a reference to the module `genstdlib.jl` was not able to find inline docs correctly.

See: https://github.com/JuliaLang/julia/pull/13017#issuecomment-138618663

@jakebolewski, could you check that this works properly now for you? It fixed the issue for me I think.
