### PR TITLE
Fix Linux grow! function called by mmap

### DIFF
--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -57,9 +57,9 @@ grow!(::Anonymous,o::Integer,l::Integer) = return
 function grow!(io::IO, offset::Integer, len::Integer)
     pos = position(io)
     filelen = filesize(io)
-    if filelen < offset + len
-        write(io, Base.zeros(UInt8,(offset + len) - filelen))
-        flush(io)
+    failure = ccall(:ftruncate, Int16, (Int, Int), fd(io), offset+len)
+    if failure!=0
+        error("Failed to grow file to the size requested")
     end
     seek(io, pos)
     return


### PR DESCRIPTION
The grow! function now makes a C call to truncate() rather than writing an array of zeros in order to grow a file.  Allocating the array of zeros was prohibiting growing files larger than the amount of RAM available.
