### PR TITLE
Fix Linux grow! function called by mmap

### DIFF
--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -58,8 +58,8 @@ function grow!(io::IO, offset::Integer, len::Integer)
     pos = position(io)
     filelen = filesize(io)
     if filelen < offset + len
-        write(io, Base.zeros(UInt8,(offset + len) - filelen))
-        flush(io)
+        failure = ccall(:ftruncate, Cint, (Cint, Coff_t), fd(io), offset+len)
+        Base.systemerror(:ftruncate, failure != 0)
     end
     seek(io, pos)
     return


### PR DESCRIPTION
The grow! function now makes a C call to truncate() rather than writing an array of zeros in order to grow a file. Allocating the array of zeros was prohibiting growing files larger than the amount of RAM available. (updated from previous pull request https://github.com/JuliaLang/julia/pull/13025)
