### PR TITLE
edit command breaks for EDITOR path containing spaces

### DIFF
--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -271,3 +271,25 @@ let fname = tempname()
     @test success(pipeline(`cat $fname`, `$exename -e $code`))
     rm(fname)
 end
+
+let cmd = AbstractString[]
+    # Ensure that quoting works
+    @test Base.shell_split("foo bar baz") == ["foo", "bar", "baz"]
+    @test Base.shell_split("foo\\ bar baz") == ["foo bar", "baz"]
+    @test Base.shell_split("'foo bar' baz") == ["foo bar", "baz"]
+    @test Base.shell_split("\"foo bar\" baz") == ["foo bar", "baz"]
+
+    # "Over quoted"
+    @test Base.shell_split("'foo\\ bar' baz") == ["foo\\ bar", "baz"]
+    @test Base.shell_split("\"foo\\ bar\" baz") == ["foo\\ bar", "baz"]
+
+    # Ensure that shell_split handles quoted spaces
+    cmd = ["/Volumes/External HD/program", "-a"]
+    @test Base.shell_split("/Volumes/External\\ HD/program -a") == cmd
+    @test Base.shell_split("'/Volumes/External HD/program' -a") == cmd
+    @test Base.shell_split("\"/Volumes/External HD/program\" -a") == cmd
+
+    # Backticks should automatically quote where necessary
+    cmd = ["foo bar", "baz"]
+    @test string(`$cmd`) == "`'foo bar' baz`"
+end


### PR DESCRIPTION
I noticed when using the `edit` function in Julia that I was getting this message:

``` julia
julia> edit(edit, (String,))
Unknown editor: no line number information passed.
The method is defined at line 56.
```

After doing some digging I noticed that my default editor Sublime is supported by the `edit` function but something else was going on. My editor is set using the environmental variable EDITOR and looks like this:

``` bash
$ echo $EDITOR
/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl
```

In Julia the path includes the backslash but is not recognized as a path:

``` julia
julia> ENV["EDITOR"]
"/Applications/Sublime\\ Text.app/Contents/SharedSupport/bin/subl"

julia> ispath(ENV["EDITOR"])
false
```

Since the `ispath` function doesn't recognize this string as a path the `edit` function will not recognize the editor as "subl" and state that line number support is not available. Note that if I set the EDITOR to not include the backslash `ispath` will pass but will cause the spawn call to fail:

``` julia
julia> ENV["EDITOR"] = "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
"/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"

julia> ispath(ENV["EDITOR"])
true

julia> edit(edit, (String,))
ERROR: could not spawn `/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl /usr/local/Cellar/julia/HEAD/bin/../share/julia/base/interactiveutil.jl:56`: no such file or directory (ENOENT)
 in _jl_spawn at process.jl:255
 in anonymous at process.jl:408
 in setup_stdio at process.jl:396
 in spawn at process.jl:407
 in edit at interactiveutil.jl:37
 in edit at interactiveutil.jl:58
```

I have updated the code to use `shell_split` earlier which strips the backslash and makes it easier to find the editor name. Another improvement is allowing the if the user includes flags in their EDITOR (such as ".../subl -w") we can still determine the editor name.

I believe that this pull request fixes the issue in #11305 and is an improvement over the pull request #11329.
