### PR TITLE
Peformance improvements in docs/utils.jl

### DIFF
--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -282,16 +282,16 @@ const builtins = ["abstract", "baremodule", "begin", "bitstype", "break",
 
 moduleusings(mod) = ccall(:jl_module_usings, Any, (Any,), mod)
 
-isvalid(name::AbstractString) = !ismatch(r"#", name)
+is_valid_name(name::AbstractString) = !ismatch(r"#", name)
 
 function accessible(mod::Module)
     result = ByteString[]
-    append!(result, filter(isvalid, map(string, names(mod, true, true))))
+    append!(result, filter(is_valid_name, map(string, names(mod, true, true))))
     for inner_mod in moduleusings(mod), sym in names(inner_mod)
         name = string(sym)
-        if isvalid(name); push!(result, name) end
+        if is_valid_name(name); push!(result, name) end
     end
-    return append!(result, filter(isvalid, map(string, builtins)))
+    return append!(result, filter(is_valid_name, map(string, builtins)))
 end
 
 completions(name) = fuzzysort(name, accessible(current_module()))


### PR DESCRIPTION
Some performance improvements in docutils. I also made a type `ScorePair` to be able to sort 2-tuples - depending on a lexicographic `isless` for tuples feels too pythonic (as there are [multiple ways](https://en.wikipedia.org/wiki/Total_order#Orders_on_the_Cartesian_product_of_totally_ordered_sets) to define an ordening on tuples).

In numbers:

Before:

```
julia> @time Base.Docs.completions(:foo)
  0.036103 seconds (247.24 k allocations: 7.603 MB, 27.98% gc time)
1551-element Array{Any,1}:
 "floor"                 
 "ifloor"                
 "pointer_from_objref"   
...
```

After:

```
julia> @time Base.Docs.completions(:foo)
  0.008606 seconds (36.98 k allocations: 2.219 MB)
1551-element Array{ByteString,1}:
 "floor"                   
 "ifloor"                  
 "pointer_from_objref"     
...
```
