### PR TITLE
Add more SubString conversions, fix #13023

### DIFF
--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -75,8 +75,10 @@ nextind(s::SubString, i::Integer) = nextind(s.string, i+s.offset)-s.offset
 prevind(s::SubString, i::Integer) = prevind(s.string, i+s.offset)-s.offset
 
 convert{T<:AbstractString}(::Type{SubString{T}}, s::T) = SubString(s, 1, endof(s))
+convert{T<:AbstractString}(S::Type{SubString{T}}, s::AbstractString) = convert(S, convert(T, s))
+convert{T<:AbstractString}(::Type{SubString}, x::T) = convert(SubString{T}, x)
 
-bytestring{T <: ByteString}(p::SubString{T}) = bytestring(p.string.data[1+p.offset:p.offset+nextind(p, p.endof)-1])
+bytestring{T<:ByteString}(p::SubString{T}) = bytestring(p.string.data[1+p.offset:p.offset+nextind(p, p.endof)-1])
 
 function getindex(s::AbstractString, r::UnitRange{Int})
     if first(r) < 1 || endof(s) < last(r)
@@ -121,6 +123,8 @@ reverse(s::AbstractString) = RevString(s)
 reverse(s::RevString) = s.string
 
 isascii(s::RevString{ASCIIString}) = true
+
+Base.convert{T<:AbstractString}(::Type{RevString{T}}, x::SubString{RevString{T}}) = RevString(reverse(bytestring(x)))
 
 ## reverse an index i so that reverse(s)[i] == s[reverseind(s,i)]
 

--- a/test/strings/types.jl
+++ b/test/strings/types.jl
@@ -187,6 +187,27 @@ for T in (ASCIIString, UTF8String, UTF16String, UTF32String)
     end
 end
 
+# SubString conversions, issue #13023
+for fromT in (ASCIIString, UTF8String, UTF16String, UTF32String)
+    fstr = convert(fromT, "foo bar")
+    for toT in (ASCIIString, UTF8String, UTF16String, UTF32String)
+        sstr = convert(SubString{toT}, fstr)
+        @test fstr == sstr
+        @test typeof(sstr) == SubString{toT}
+        tstr = convert(fromT, sstr)
+        @test fstr == tstr
+        @test typeof(tstr) == fromT
+        ustr = convert(SubString{fromT}, sstr)
+        @test sstr == tstr == ustr
+        @test typeof(ustr) == SubString{fromT}
+    end
+    sstr = convert(SubString, fstr)
+    @test typeof(sstr) == SubString{fromT}
+    tstr = convert(fromT, sstr)
+    @test fstr == tstr
+    @test typeof(fstr) == typeof(tstr)
+end
+
 ## Repeat strings ##
 
 # issue #7764


### PR DESCRIPTION
@stevengj can you review? The `RevString` `convert` was needed for the tests to pass, I'm not sure its correct/I'm missing something deeper here.
