### PR TITLE
+/- interop for the Triangular types

### DIFF
--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -141,6 +141,24 @@ for op in (:+, :-)
             end
         end
     end
+
+    for matrixtype1 in (:Diagonal,)
+        for (matrixtype2,matrixtype3) in ((:UpperTriangular,:UpperTriangular),
+                                          (:UnitUpperTriangular,:UpperTriangular),
+                                          (:LowerTriangular,:LowerTriangular),
+                                          (:UnitLowerTriangular,:LowerTriangular))
+            @eval begin
+                ($op)(A::($matrixtype1), B::($matrixtype2)) = ($op)(convert(($matrixtype3), A), B)
+                ($op)(A::($matrixtype2), B::($matrixtype1)) = ($op)(A, convert(($matrixtype3), B))
+            end
+        end
+    end
+    for matrixtype in (:SymTridiagonal,:Tridiagonal,:Bidiagonal,:Matrix)
+        @eval begin
+            ($op)(A::AbstractTriangular, B::($matrixtype)) = ($op)(full(A), B)
+            ($op)(A::($matrixtype), B::AbstractTriangular) = ($op)(A, full(B))
+        end
+    end
 end
 
 A_mul_Bc!(A::AbstractTriangular, B::QRCompactWYQ) = A_mul_Bc!(full!(A),B)

--- a/test/linalg/special.jl
+++ b/test/linalg/special.jl
@@ -103,6 +103,17 @@ let a=[1.0:n;]
        @test_approx_eq full(B - convert(Spectype,A)) full(B - A)
        @test_approx_eq full(convert(Spectype,A) - B) full(A - B)
    end
+
+   C = rand(n,n)
+   for TriType in [Base.LinAlg.UnitLowerTriangular, Base.LinAlg.UnitUpperTriangular, UpperTriangular, LowerTriangular]
+       D = TriType(C)
+       for Spectype in [Diagonal, Bidiagonal, Tridiagonal, Matrix]
+           @test full(D + convert(Spectype,A)) ≈ full(D + A)
+           @test full(convert(Spectype,A) + D) ≈ full(A + D)
+           @test full(D - convert(Spectype,A)) ≈ full(D - A)
+           @test full(convert(Spectype,A) - D) ≈ full(A - D)
+       end
+   end
 end
 
 #Triangular Types and QR


### PR DESCRIPTION
`Diagonal` didn't have interop `+` or `-` methods with a bunch of the `AbstractTriangular` types.

They didn't have `+` or `-` with a bunch of the special matrix types.

Added tests too.

For `Diagonal + AbstractTriangular` I tried to be conservative and keep the types "in house" as triangular. I can change that if it's preferred.
