### PR TITLE
Always run doc/genstdlib.jl after bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,10 @@ julia-sysimg-release : julia-inference julia-ui-release
 julia-sysimg-debug : julia-inference julia-ui-debug
 	@$(MAKE) $(QUIET_MAKE) $(build_private_libdir)/sys-debug.$(SHLIB_EXT) JULIA_BUILD_MODE=debug
 
-julia-debug julia-release : julia-% : julia-ui-% julia-sysimg-% julia-symlink julia-libccalltest
+julia-genstdlib : julia-sysimg-$(JULIA_BUILD_MODE)
+	@$(JULIA_EXECUTABLE) doc/genstdlib.jl
+
+julia-debug julia-release : julia-% : julia-ui-% julia-sysimg-% julia-symlink julia-libccalltest julia-genstdlib
 
 debug release : % : julia-%
 


### PR DESCRIPTION
Should make it more noticeable when doc changes need to be committed to the generated parts of the RST, and add maybe 10ish seconds to CI time.
