### PR TITLE
Fix macro summary display

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -148,18 +148,18 @@ function doc(b::Binding)
         v = getfield(b.mod,b.var)
         d = doc(v)
         if d === nothing
-            if isa(v,Function)
-                d = catdoc(Markdown.parse("""
-                No documentation found.
-
-                `$(b.mod === Main ? b.var : join((b.mod, b.var),'.'))` is $(isgeneric(v) ? "a generic" : "an anonymous") `Function`.
-                """), functionsummary(v))
-            elseif startswith(string(b.var),'@')
+            if startswith(string(b.var),'@')
                 # check to see if the binding var is a macro
                 d = catdoc(Markdown.parse("""
                 No documentation found.
 
                 """), macrosummary(b.var, v))
+            elseif isa(v,Function)
+                d = catdoc(Markdown.parse("""
+                No documentation found.
+
+                `$(b.mod === Main ? b.var : join((b.mod, b.var),'.'))` is $(isgeneric(v) ? "a generic" : "an anonymous") `Function`.
+                """), functionsummary(v))
             else
                 T = typeof(v)
                 d = catdoc(Markdown.parse("""

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -241,9 +241,13 @@ end
 @doc "This should document @m1... since its the result of expansion" @m2_11993
 @test (@doc @m1_11993) !== nothing
 let d = (@doc @m2_11993)
-    io = IOBuffer()
-    writemime(io, MIME"text/markdown"(), d)
-    @test startswith(takebuf_string(io),"No documentation found")
+    @test docstrings_equal(d, doc"""
+    No documentation found.
+
+    ```julia
+    @m2_11993()
+    ```
+    """)
 end
 
 @doc "Now @m2... should be documented" :@m2_11993


### PR DESCRIPTION
Macros were being listed as anonymous functions in docs summary.

cc @jakebolewski 
