### PR TITLE
change open(cmds::AbstractCmd,...), eachline(cmd::AbstractCmd, ...) t…

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -456,10 +456,10 @@ spawn(cmds::AbstractCmd, args...; chain::Nullable{ProcessChain}=Nullable{Process
 function eachline(cmd::AbstractCmd, stdin)
     stdout = Pipe()
     processes = spawn(cmd, (stdin,stdout,STDERR))
-    close(stdout.in)
+    !isa(cmds, Cmd) || close(stdout.in)
     out = stdout.out
     # implicitly close after reading lines, since we opened
-    return EachLine(out, ()->close(out))
+    return EachLine(out, ()->close(stdout))
 end
 eachline(cmd::AbstractCmd) = eachline(cmd, DevNull)
 
@@ -469,12 +469,12 @@ function open(cmds::AbstractCmd, mode::AbstractString="r", other::AsyncStream=De
         in = other
         out = io = Pipe()
         processes = spawn(cmds, (in,out,STDERR))
-        close(out.in)
+        !isa(cmds, Cmd) || close(out.in)
     elseif mode == "w"
         in = io = Pipe()
         out = other
         processes = spawn(cmds, (in,out,STDERR))
-        close(in.out)
+        !isa(cmds, Cmd) || close(in.out)
     else
         throw(ArgumentError("mode must be \"r\" or \"w\", not \"$mode\""))
     end


### PR DESCRIPTION
In order to use the abstract implementation of open and eachline for user defined implementations of AbstractCmd it is required that the one can write to the opened pipe object.

In my case i am implementing a SSHCmd and SSHProcess object that can be used as if they were normal commands created with back quotes. As such all output from the process is written to the pipe, which fails if it is closed beforehand (which is ok if Cmd is used since the process writes directly to the pipe i guess).
