### PR TITLE
Alias `run-julia` to `inferior-julia` in julia-mode.el

### DIFF
--- a/contrib/julia-mode.el
+++ b/contrib/julia-mode.el
@@ -3240,6 +3240,10 @@ y2 = g(x)"))
 
 (add-hook 'inferior-julia-mode-hook 'inferior-julia--initialize)
 
+;;;###autoload
+(defalias 'run-julia #'inferior-julia
+  "Run an inferior instance of `julia' inside Emacs.")
+
 (provide 'julia-mode)
 
 ;; Local Variables:


### PR DESCRIPTION
It's a common Emacs naming convention to name the function that starts an inferior process `run-<programname>`. For example:
- `run-prolog`
- `run-python`
- `run-octave`
- `run-scheme`
- `run-sage`

I've aliased a similar command, `run-julia` to adhere to this naming scheme.
