### PR TITLE
Tweaks to tests (mmap robustness, don't use at-test_throw return type)

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -3109,15 +3109,25 @@ Base.convert(::Type{Foo11874},x::Int) = float(x)
 
 # issue #9233
 let
-    err = @test_throws TypeError NTuple{Int, 1}
-    @test err.func == :NTuple
-    @test err.expected == Int
-    @test err.got == Int
+    try
+        NTuple{Int, 1}
+        @test false
+    catch err
+        @test isa(err, TypeError)
+        @test err.func == :NTuple
+        @test err.expected == Int
+        @test err.got == Int
+    end
 
-    err = @test_throws TypeError NTuple{0x1, Int}
-    @test err.func == :NTuple
-    @test err.expected == Int
-    @test err.got == 0x1
+    try
+        NTuple{0x1, Int}
+        @test false
+    catch err
+        @test isa(err, TypeError)
+        @test err.func == :NTuple
+        @test err.expected == Int
+        @test err.got == 0x1
+    end
 end
 
 # 11996

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -34,11 +34,13 @@ let res = assert(true)
     @test res === nothing
 end
 let
-    ex = @test_throws AssertionError begin
+    try
         assert(false)
         error("unexpected")
+    catch ex
+        @test isa(ex, AssertionError)
+        @test isempty(ex.msg)
     end
-    @test isempty(ex.msg)
 end
 
 # test @assert macro
@@ -48,44 +50,54 @@ end
 @test_throws AssertionError (@assert false "this is a test" "another test")
 @test_throws AssertionError (@assert false :a)
 let
-    ex = @test_throws AssertionError begin
+    try
         @assert 1 == 2
         error("unexpected")
+    catch ex
+        @test isa(ex, AssertionError)
+        @test contains(ex.msg, "1 == 2")
     end
-    @test contains(ex.msg, "1 == 2")
 end
 # test @assert message
 let
-    ex = @test_throws AssertionError begin
+    try
         @assert 1 == 2 "this is a test"
         error("unexpected")
+    catch ex
+        @test isa(ex, AssertionError)
+        @test ex.msg == "this is a test"
     end
-    @test ex.msg == "this is a test"
 end
 # @assert only uses the first message string
 let
-    ex = @test_throws AssertionError begin
+    try
         @assert 1 == 2 "this is a test" "this is another test"
         error("unexpected")
+    catch ex
+        @test isa(ex, AssertionError)
+        @test ex.msg == "this is a test"
     end
-    @test ex.msg == "this is a test"
 end
 # @assert calls string() on second argument
 let
-    ex = @test_throws AssertionError begin
+    try
         @assert 1 == 2 :random_object
         error("unexpected")
+    catch ex
+        @test isa(ex, AssertionError)
+        @test !contains(ex.msg,  "1 == 2")
+        @test contains(ex.msg, "random_object")
     end
-    @test !contains(ex.msg,  "1 == 2")
-    @test contains(ex.msg, "random_object")
 end
 # if the second argument is an expression, c
 let deepthought(x, y) = 42
-    ex = @test_throws AssertionError begin
+    try
         @assert 1 == 2 string("the answer to the ultimate question: ",
                               deepthought(6, 9))
+    catch ex
+        @test isa(ex, AssertionError)
+        @test ex.msg == "the answer to the ultimate question: 42"
     end
-    @test ex.msg == "the answer to the ultimate question: 42"
 end
 
 let # test the process title functions, issue #9957


### PR DESCRIPTION
- First commit by @quinnj robustifies the mmap tests, which avoided an issue on Windows.
- Second commit modifies some tests to use `try`-`catch` instead of relying on `@test_throws` to return the thrown exception.

Both these came out of https://github.com/JuliaLang/julia/pull/13062 (the first is cherry picked, the second manually extracted).

Ping: @tkelman @StefanKarpinski 
