### PR TITLE
add det(Symmetric) and method= to expm(Matrix)

### DIFF
--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -55,6 +55,7 @@ function transpose(A::Hermitian)
 end
 ctranspose(A::Hermitian) = A
 trace(A::Hermitian) = real(trace(A.data))
+det(A::HermOrSym) = det(full(A))
 
 #tril/triu
 function tril(A::Hermitian, k::Integer=0)

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -13,10 +13,10 @@ end
 # Hermitian matrix exponential/log/det
 let A1 = randn(4,4) + im*randn(4,4)
     A2 = A1 + A1'
-    @test expm(A2) ≈ expm(Hermitian(A2))
+    @test expm(A2, method=:higham) ≈ expm(Hermitian(A2))
     @test logm(A2) ≈ logm(Hermitian(A2))
     A3 = A1 * A1' # posdef
-    @test expm(A3) ≈ expm(Hermitian(A3))
+    @test expm(A3, method=:higham) ≈ expm(Hermitian(A3))
     @test logm(A3) ≈ logm(Hermitian(A3))
     @test det(A2) ≈ det(Hermitian(A2))
     @test det(A3) ≈ det(Hermitian(A3))
@@ -30,7 +30,7 @@ let A1 = randn(4,4)
     @test det(A3) ≈ det(Hermitian(A3))
     @test det(A3) ≈ det(Symmetric(A3))
     @test det(A4) ≈ det(Hermitian(A4))
-    @test expm(A4) ≈ expm(Symmetric(A4))
+    @test expm(A4, method=:higham) ≈ expm(Symmetric(A4))
     @test logm(A3) ≈ logm(Symmetric(A3))
     @test logm(A3) ≈ logm(Hermitian(A3))
 end

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -18,6 +18,9 @@ let A1 = randn(4,4) + im*randn(4,4)
     A3 = A1 * A1' # posdef
     @test expm(A3, method=:higham) ≈ expm(Hermitian(A3))
     @test logm(A3) ≈ logm(Hermitian(A3))
+    A4 = (A2 - trace(A2)/size(A2,1)*eye(A2)) # tr(A4) == 0 => det(expm(A4)) == 1
+    @test expm(A4, method=:higham) ≈ expm(Hermitian(A4))
+    @test logm(A4) ≈ logm(Hermitian(A4))
     @test det(A2) ≈ det(Hermitian(A2))
     @test det(A3) ≈ det(Hermitian(A3))
     @test det(A4) ≈ det(Hermitian(A4))
@@ -33,6 +36,10 @@ let A1 = randn(4,4)
     @test expm(A4, method=:higham) ≈ expm(Symmetric(A4))
     @test logm(A3) ≈ logm(Symmetric(A3))
     @test logm(A3) ≈ logm(Hermitian(A3))
+    A5 = (A4 - trace(A4)/size(A4,1)*eye(A4)) # tr(A5) == 0 => det(expm(A5)) == 1
+    @assert isapprox(trace(A5), 0.0, atol=1E-10)
+    @test expm(A5, method=:higham) ≈ expm(Symmetric(A5))
+    @test det(expm(Symmetric(A5))) ≈ 1.0
 end
 
 let n=10

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -10,7 +10,7 @@ for σ in map(Hermitian, Any[ eye(2), [0 1; 1 0], [0 -im; im 0], [1 0; 0 -1] ])
     @test ishermitian(σ)
 end
 
-# Hermitian matrix exponential/log
+# Hermitian matrix exponential/log/det
 let A1 = randn(4,4) + im*randn(4,4)
     A2 = A1 + A1'
     @test expm(A2) ≈ expm(Hermitian(A2))
@@ -18,11 +18,18 @@ let A1 = randn(4,4) + im*randn(4,4)
     A3 = A1 * A1' # posdef
     @test expm(A3) ≈ expm(Hermitian(A3))
     @test logm(A3) ≈ logm(Hermitian(A3))
+    @test det(A2) ≈ det(Hermitian(A2))
+    @test det(A3) ≈ det(Hermitian(A3))
+    @test det(A4) ≈ det(Hermitian(A4))
 end
 
+# Symmetric matrix exponential/log/det
 let A1 = randn(4,4)
     A3 = A1 * A1'
     A4 = A1 + A1.'
+    @test det(A3) ≈ det(Hermitian(A3))
+    @test det(A3) ≈ det(Symmetric(A3))
+    @test det(A4) ≈ det(Hermitian(A4))
     @test expm(A4) ≈ expm(Symmetric(A4))
     @test logm(A3) ≈ logm(Symmetric(A3))
     @test logm(A3) ≈ logm(Hermitian(A3))


### PR DESCRIPTION
- There was no `det(Symmetric)` (see JuliaLang/LinearAlgebra.jl#252). Now it just falls back to the dense case, don't know if there's better solution.
- Added keyword argument `method=:auto/:higham` to `expm(AbstractMatrix)` to avoid switching to `Symmetric` branch if the dense matrix is symmetric. Otherwise, tests for exponential of symmetric matrix are essentially comparing `expm(Symmetric)` to itself. Also, given many numerical stability problems of `expm()`, it would be convenient to have several numerical methods to choose from.
