### PR TITLE
Remove guarantee of at-test_throw return type.

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -525,7 +525,7 @@ Collections.isheap
 doc"""
     @test_throws(extype, ex)
 
-Test that the expression `ex` throws an exception of type `extype` and calls the current handler to handle the result. The default handler returns the exception if it is of the expected type.
+Test that the expression `ex` throws an exception of type `extype` and calls the current handler to handle the result.
 """
 :(Test.@test_throws)
 

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -158,7 +158,7 @@ Macros
 
    .. Docstring generated from Julia source
 
-   Test that the expression ``ex`` throws an exception of type ``extype`` and calls the current handler to handle the result. The default handler returns the exception if it is of the expected type.
+   Test that the expression ``ex`` throws an exception of type ``extype`` and calls the current handler to handle the result.
 
 .. function:: @test_approx_eq(a, b)
 


### PR DESCRIPTION
In preparation for new test system. Partial revert of #11984. Follows from discussion in https://github.com/JuliaLang/julia/pull/13090.
