### PR TITLE
Drop extraneous line and add tests for matmul

### DIFF
--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -211,8 +211,6 @@ function copytri!(A::StridedMatrix, uplo::Char, conjugate::Bool=false)
         for i = 1:(n-1), j = (i+1):n
             A[i,j] = conjugate ? conj(A[j,i]) : A[j,i]
         end
-    else
-        throw(ArgumentError("second argument must be 'U' or 'L'"))
     end
     A
 end


### PR DESCRIPTION
`copytri` was checking the `uplo` argument twice.

Added more tests for a bunch of error throwing/misc methods.
