### PR TITLE
Fix documenting bitstypes

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -515,7 +515,7 @@ function docm(meta, def, define = true)
     isexpr(def′, :type)        ? typedoc(meta, def, def′) :
     isexpr(def′, :macro)       ?  vardoc(meta, def, symbol('@',namify(def′))) :
     isexpr(def′, :abstract)    ? namedoc(meta, def, namify(def′)) :
-    isexpr(def′, :bitstype)    ? namedoc(meta, def, def′.args[2]) :
+    isexpr(def′, :bitstype)    ? namedoc(meta, def, namify(def′.args[2])) :
     isexpr(def′, :typealias)   ?  vardoc(meta, def, namify(def′)) :
     isexpr(def′, :module)      ?  moddoc(meta, def, def′.args[2]) :
     isexpr(def′, :(=), :const,

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -54,6 +54,9 @@ abstract AT
 "BT"
 bitstype 8 BT
 
+"BT2"
+bitstype 8 BT2 <: Integer
+
 "T"
 type T <: AT
     "T.x"
@@ -173,6 +176,8 @@ end
 let BT = DocsTest.BT
     @test meta(DocsTest)[BT] == doc"BT"
 end
+
+@test meta(DocsTest)[DocsTest.BT2] == doc"BT2"
 
 let T = DocsTest.T
     typedoc = meta(DocsTest)[T]


### PR DESCRIPTION
Documenting `bitstype`s that used `<:` syntax, ie.

``` julia
"..."
bitstype 8 T <: S
```

was unsupported.
