### PR TITLE
Fix USE_GPL_LIBS=1 #13060: Changed Makefile and base/docs/helpdb.jl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,9 @@ JL_LIBS = julia julia-debug
 # private libraries, that are installed in $(prefix)/lib/julia
 JL_PRIVATE_LIBS = suitesparse_wrapper Rmath
 ifeq ($(USE_SYSTEM_FFTW),0)
+ifeq ($(USE_GPL_LIBS), 1)
 JL_PRIVATE_LIBS += fftw3 fftw3f fftw3_threads fftw3f_threads
+endif
 endif
 ifeq ($(USE_SYSTEM_PCRE),0)
 JL_PRIVATE_LIBS += pcre

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -557,6 +557,7 @@ Run the function `f` using the `handler` as the handler.
 """
 Test.with_handler
 
+if USE_GPL_LIBS
 # Base.FFTW
 
 doc"""
@@ -616,6 +617,220 @@ correspond to :func:`r2r` and :func:`r2r!`, respectively.
 ```
 """
 FFTW.plan_r2r
+
+doc"""
+```rst
+..  plan_bfft!(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
+
+Same as :func:`plan_bfft`, but operates in-place on ``A``.
+```
+"""
+plan_bfft!
+
+doc"""
+```rst
+..  plan_irfft(A, d [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
+
+Pre-plan an optimized inverse real-input FFT, similar to :func:`plan_rfft`
+except for :func:`irfft` and :func:`brfft`, respectively.  The first
+three arguments have the same meaning as for :func:`irfft`.
+```
+"""
+plan_irfft
+
+doc"""
+```rst
+..  plan_rfft(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
+
+Pre-plan an optimized real-input FFT, similar to :func:`plan_fft`
+except for :func:`rfft` instead of :func:`fft`.  The first two
+arguments, and the size of the transformed result, are the same as
+for :func:`rfft`.
+```
+"""
+plan_rfft
+
+doc"""
+```rst
+..  plan_fft(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
+
+Pre-plan an optimized FFT along given dimensions (``dims``) of arrays
+matching the shape and type of ``A``.  (The first two arguments have
+the same meaning as for :func:`fft`.)  Returns an object ``P`` which
+represents the linear operator computed by the FFT, and which contains
+all of the information needed to compute ``fft(A, dims)`` quickly.
+
+To apply ``P`` to an array ``A``, use ``P * A``; in general, the
+syntax for applying plans is much like that of matrices.  (A plan
+can only be applied to arrays of the same size as the ``A`` for
+which the plan was created.)  You can also apply a plan with a
+preallocated output array ``Â`` by calling ``A_mul_B!(Â, plan,
+A)``.  You can compute the inverse-transform plan by ``inv(P)`` and
+apply the inverse plan with ``P \ Â`` (the inverse plan is cached
+and reused for subsequent calls to ``inv`` or ``\``), and apply the
+inverse plan to a pre-allocated output array ``A`` with
+``A_ldiv_B!(A, P, Â)``.
+
+The ``flags`` argument is a bitwise-or of FFTW planner flags, defaulting
+to ``FFTW.ESTIMATE``.  e.g. passing ``FFTW.MEASURE`` or ``FFTW.PATIENT``
+will instead spend several seconds (or more) benchmarking different
+possible FFT algorithms and picking the fastest one; see the FFTW manual
+for more information on planner flags.  The optional ``timelimit`` argument
+specifies a rough upper bound on the allowed planning time, in seconds.
+Passing ``FFTW.MEASURE`` or ``FFTW.PATIENT`` may cause the input array ``A``
+to be overwritten with zeros during plan creation.
+
+:func:`plan_fft!` is the same as :func:`plan_fft` but creates a plan
+that operates in-place on its argument (which must be an array of
+complex floating-point numbers).  :func:`plan_ifft` and so on
+are similar but produce plans that perform the equivalent of
+the inverse transforms :func:`ifft` and so on.
+```
+"""
+plan_fft
+
+doc"""
+```rst
+..  plan_bfft(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
+
+Same as :func:`plan_fft`, but produces a plan that performs an unnormalized
+backwards transform :func:`bfft`.
+```
+"""
+plan_bfft
+
+doc"""
+```rst
+..  plan_fft!(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
+
+Same as :func:`plan_fft`, but operates in-place on ``A``.
+```
+"""
+plan_fft!
+
+doc"""
+```rst
+..  plan_ifft(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
+
+Same as :func:`plan_fft`, but produces a plan that performs inverse transforms
+:func:`ifft`.
+```
+"""
+plan_ifft
+
+doc"""
+```rst
+..  plan_brfft(A, d [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
+
+Pre-plan an optimized real-input unnormalized transform, similar to
+:func:`plan_rfft` except for :func:`brfft` instead of :func:`rfft`.
+The first two arguments and the size of the transformed result, are
+the same as for :func:`brfft`.
+```
+"""
+plan_brfft
+
+doc"""
+```rst
+..  plan_ifft!(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
+
+Same as :func:`plan_ifft`, but operates in-place on ``A``.
+```
+"""
+plan_ifft!
+
+doc"""
+```rst
+..  dct(A [, dims])
+
+Performs a multidimensional type-II discrete cosine transform (DCT)
+of the array ``A``, using the unitary normalization of the DCT.
+The optional ``dims`` argument specifies an iterable subset of
+dimensions (e.g. an integer, range, tuple, or array) to transform
+along.  Most efficient if the size of ``A`` along the transformed
+dimensions is a product of small primes; see :func:`nextprod`.  See
+also :func:`plan_dct` for even greater efficiency.
+```
+"""
+dct
+
+doc"""
+```rst
+..  idct(A [, dims])
+
+Computes the multidimensional inverse discrete cosine transform (DCT)
+of the array ``A`` (technically, a type-III DCT with the unitary
+normalization).
+The optional ``dims`` argument specifies an iterable subset of
+dimensions (e.g. an integer, range, tuple, or array) to transform
+along.  Most efficient if the size of ``A`` along the transformed
+dimensions is a product of small primes; see :func:`nextprod`.  See
+also :func:`plan_idct` for even greater efficiency.
+```
+"""
+idct
+
+doc"""
+```rst
+..  dct!(A [, dims])
+
+Same as :func:`dct!`, except that it operates in-place
+on ``A``, which must be an array of real or complex floating-point
+values.
+```
+"""
+dct!
+
+doc"""
+```rst
+..  idct!(A [, dims])
+
+Same as :func:`idct!`, but operates in-place on ``A``.
+```
+"""
+idct!
+
+doc"""
+```rst
+..  plan_dct!(A [, dims [, flags [, timelimit]]])
+
+Same as :func:`plan_dct`, but operates in-place on ``A``.
+```
+"""
+plan_dct!
+
+doc"""
+```rst
+..  plan_idct(A [, dims [, flags [, timelimit]]])
+
+Pre-plan an optimized inverse discrete cosine transform (DCT), similar to
+:func:`plan_fft` except producing a function that computes :func:`idct`.
+The first two arguments have the same meaning as for :func:`idct`.
+```
+"""
+plan_idct
+
+doc"""
+```rst
+..  plan_dct(A [, dims [, flags [, timelimit]]])
+
+Pre-plan an optimized discrete cosine transform (DCT), similar to
+:func:`plan_fft` except producing a function that computes :func:`dct`.
+The first two arguments have the same meaning as for :func:`dct`.
+```
+"""
+plan_dct
+
+doc"""
+```rst
+..  plan_idct!(A [, dims [, flags [, timelimit]]])
+
+Same as :func:`plan_idct`, but operates in-place on ``A``.
+```
+"""
+plan_idct!
+
+end
 
 # Base.Profile
 
@@ -964,15 +1179,6 @@ Compute a type that contains the intersection of `T` and `S`. Usually this will 
 typeintersect
 
 doc"""
-```rst
-..  plan_bfft!(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
-
-Same as :func:`plan_bfft`, but operates in-place on ``A``.
-```
-"""
-plan_bfft!
-
-doc"""
     pointer(array [, index])
 
 Get the native address of an array or string element. Be careful to ensure that a julia reference to `a` exists as long as this pointer will be used. This function is "unsafe" like `unsafe_convert`.
@@ -994,17 +1200,6 @@ doc"""
 Test whether a floating point number is not a number (NaN)
 """
 isnan
-
-doc"""
-```rst
-..  plan_irfft(A, d [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
-
-Pre-plan an optimized inverse real-input FFT, similar to :func:`plan_rfft`
-except for :func:`irfft` and :func:`brfft`, respectively.  The first
-three arguments have the same meaning as for :func:`irfft`.
-```
-"""
-plan_irfft
 
 doc"""
 ```rst
@@ -3813,21 +4008,6 @@ remotecall_wait
 
 doc"""
 ```rst
-..  dct(A [, dims])
-
-Performs a multidimensional type-II discrete cosine transform (DCT)
-of the array ``A``, using the unitary normalization of the DCT.
-The optional ``dims`` argument specifies an iterable subset of
-dimensions (e.g. an integer, range, tuple, or array) to transform
-along.  Most efficient if the size of ``A`` along the transformed
-dimensions is a product of small primes; see :func:`nextprod`.  See
-also :func:`plan_dct` for even greater efficiency.
-```
-"""
-dct
-
-doc"""
-```rst
 ..  append!(collection, collection2) -> collection.
 
 Add the elements of ``collection2`` to the end of ``collection``.
@@ -5424,22 +5604,6 @@ Like uperm but gets the permissions of the group owning the file
 gperm
 
 doc"""
-```rst
-..  idct(A [, dims])
-
-Computes the multidimensional inverse discrete cosine transform (DCT)
-of the array ``A`` (technically, a type-III DCT with the unitary
-normalization).
-The optional ``dims`` argument specifies an iterable subset of
-dimensions (e.g. an integer, range, tuple, or array) to transform
-along.  Most efficient if the size of ``A`` along the transformed
-dimensions is a product of small primes; see :func:`nextprod`.  See
-also :func:`plan_idct` for even greater efficiency.
-```
-"""
-idct
-
-doc"""
     nb_available(stream)
 
 Returns the number of bytes available for reading before a read from this stream or buffer will block.
@@ -6004,17 +6168,6 @@ Tests whether a character is alphanumeric, or whether this is true for all eleme
 isalnum
 
 doc"""
-```rst
-..  dct!(A [, dims])
-
-Same as :func:`dct!`, except that it operates in-place
-on ``A``, which must be an array of real or complex floating-point
-values.
-```
-"""
-dct!
-
-doc"""
     @sprintf("%Fmt", args...)
 
 Return `@printf` formatted output as string.
@@ -6495,15 +6648,6 @@ ntuple
 
 doc"""
 ```rst
-..  idct!(A [, dims])
-
-Same as :func:`idct!`, but operates in-place on ``A``.
-```
-"""
-idct!
-
-doc"""
-```rst
 ..  Ac_rdiv_Bc(a,b)
 
 Matrix operator A\ :sup:`H` / B\ :sup:`H`
@@ -6922,15 +7066,6 @@ Create an IOBuffer, which may optionally operate on a pre-existing array. If the
 IOBuffer(data=?)
 
 doc"""
-```rst
-..  plan_dct!(A [, dims [, flags [, timelimit]]])
-
-Same as :func:`plan_dct`, but operates in-place on ``A``.
-```
-"""
-plan_dct!
-
-doc"""
     findmax(itr) -> (x, index)
 
 Returns the maximum element and its index.
@@ -7110,18 +7245,6 @@ doc"""
 Read a series of values of the given type from a stream, in canonical binary representation. `dims` is either a tuple or a series of integer arguments specifying the size of `Array` to return.
 """
 read(stream, t, dims)
-
-doc"""
-```rst
-..  plan_rfft(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
-
-Pre-plan an optimized real-input FFT, similar to :func:`plan_fft`
-except for :func:`rfft` instead of :func:`fft`.  The first two
-arguments, and the size of the transformed result, are the same as
-for :func:`rfft`.
-```
-"""
-plan_rfft
 
 doc"""
     @timev
@@ -8767,45 +8890,6 @@ TypeError
 
 doc"""
 ```rst
-..  plan_fft(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
-
-Pre-plan an optimized FFT along given dimensions (``dims``) of arrays
-matching the shape and type of ``A``.  (The first two arguments have
-the same meaning as for :func:`fft`.)  Returns an object ``P`` which
-represents the linear operator computed by the FFT, and which contains
-all of the information needed to compute ``fft(A, dims)`` quickly.
-
-To apply ``P`` to an array ``A``, use ``P * A``; in general, the
-syntax for applying plans is much like that of matrices.  (A plan
-can only be applied to arrays of the same size as the ``A`` for
-which the plan was created.)  You can also apply a plan with a
-preallocated output array ``Â`` by calling ``A_mul_B!(Â, plan,
-A)``.  You can compute the inverse-transform plan by ``inv(P)`` and
-apply the inverse plan with ``P \ Â`` (the inverse plan is cached
-and reused for subsequent calls to ``inv`` or ``\``), and apply the
-inverse plan to a pre-allocated output array ``A`` with
-``A_ldiv_B!(A, P, Â)``.
-
-The ``flags`` argument is a bitwise-or of FFTW planner flags, defaulting
-to ``FFTW.ESTIMATE``.  e.g. passing ``FFTW.MEASURE`` or ``FFTW.PATIENT``
-will instead spend several seconds (or more) benchmarking different
-possible FFT algorithms and picking the fastest one; see the FFTW manual
-for more information on planner flags.  The optional ``timelimit`` argument
-specifies a rough upper bound on the allowed planning time, in seconds.
-Passing ``FFTW.MEASURE`` or ``FFTW.PATIENT`` may cause the input array ``A``
-to be overwritten with zeros during plan creation.
-
-:func:`plan_fft!` is the same as :func:`plan_fft` but creates a plan
-that operates in-place on its argument (which must be an array of
-complex floating-point numbers).  :func:`plan_ifft` and so on
-are similar but produce plans that perform the equivalent of
-the inverse transforms :func:`ifft` and so on.
-```
-"""
-plan_fft
-
-doc"""
-```rst
 ..  A_rdiv_Bt(a,b)
 
 Matrix operator A / B\ :sup:`T`
@@ -9031,16 +9115,6 @@ doc"""
 Get the vector of processes that have mapped the shared array
 """
 procs(::SharedArray)
-
-doc"""
-```rst
-..  plan_bfft(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
-
-Same as :func:`plan_fft`, but produces a plan that performs an unnormalized
-backwards transform :func:`bfft`.
-```
-"""
-plan_bfft
 
 doc"""
     mod(x, y)
@@ -10025,17 +10099,6 @@ Create an ASCII string from the address of a C (0-terminated) string encoded in 
 ascii(::Ptr{UInt8},?)
 
 doc"""
-```rst
-..  plan_idct(A [, dims [, flags [, timelimit]]])
-
-Pre-plan an optimized inverse discrete cosine transform (DCT), similar to
-:func:`plan_fft` except producing a function that computes :func:`idct`.
-The first two arguments have the same meaning as for :func:`idct`.
-```
-"""
-plan_idct
-
-doc"""
     maxabs(itr)
 
 Compute the maximum absolute value of a collection of values.
@@ -10143,15 +10206,6 @@ doc"""
 Create a `RandomDevice` RNG object. Two such objects will always generate different streams of random numbers.
 """
 RandomDevice
-
-doc"""
-```rst
-..  plan_fft!(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
-
-Same as :func:`plan_fft`, but operates in-place on ``A``.
-```
-"""
-plan_fft!
 
 doc"""
     fma(x, y, z)
@@ -10789,16 +10843,6 @@ Determine whether predicate `p` returns `true` for any elements of `itr`.
 any(p,itr)
 
 doc"""
-```rst
-..  plan_ifft(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
-
-Same as :func:`plan_fft`, but produces a plan that performs inverse transforms
-:func:`ifft`.
-```
-"""
-plan_ifft
-
-doc"""
     cosc(x)
 
 Compute $\cos(\pi x) / x - \sin(\pi x) / (\pi x^2)$ if $x \neq 0$, and $0$
@@ -11075,18 +11119,6 @@ k]``.)
 eigfact(A,B)
 
 doc"""
-```rst
-..  plan_brfft(A, d [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
-
-Pre-plan an optimized real-input unnormalized transform, similar to
-:func:`plan_rfft` except for :func:`brfft` instead of :func:`rfft`.
-The first two arguments and the size of the transformed result, are
-the same as for :func:`brfft`.
-```
-"""
-plan_brfft
-
-doc"""
     rowvals(A)
 
 Return a vector of the row indices of `A`, and any modifications to the returned vector will mutate `A` as well. Given the internal storage format of sparse matrices, providing access to how the row indices are stored internally can be useful in conjuction with iterating over structural nonzero values. See `nonzeros(A)` and `nzrange(A, col)`.
@@ -11318,17 +11350,6 @@ doc"""
 Return `x` if `lo <= x <= hi`. If `x < lo`, return `lo`. If `x > hi`, return `hi`. Arguments are promoted to a common type. Operates elementwise over `x` if it is an array.
 """
 clamp
-
-doc"""
-```rst
-..  plan_dct(A [, dims [, flags [, timelimit]]])
-
-Pre-plan an optimized discrete cosine transform (DCT), similar to
-:func:`plan_fft` except producing a function that computes :func:`dct`.
-The first two arguments have the same meaning as for :func:`dct`.
-```
-"""
-plan_dct
 
 doc"""
     cscd(x)
@@ -11629,15 +11650,6 @@ filter
 
 doc"""
 ```rst
-..  plan_idct!(A [, dims [, flags [, timelimit]]])
-
-Same as :func:`plan_idct`, but operates in-place on ``A``.
-```
-"""
-plan_idct!
-
-doc"""
-```rst
 ..  randperm([rng,] n)
 
 Construct a random permutation of length ``n``. The optional ``rng`` argument
@@ -11652,15 +11664,6 @@ doc"""
 Seek a stream to its end.
 """
 seekend
-
-doc"""
-```rst
-..  plan_ifft!(A [, dims]; flags=FFTW.ESTIMATE;  timelimit=Inf)
-
-Same as :func:`plan_ifft`, but operates in-place on ``A``.
-```
-"""
-plan_ifft!
 
 doc"""
     DivideError()


### PR DESCRIPTION
Makefile: Add FFTW libs to JL_PRIVATE_LIBS only when USE_GPL_LIBS is 1.
helpdb.jl: Add docstrings for FFTW API only when USE_GPL_LIBS is true.

Build with `make USE_GPL_LIBS=1` passes with these changes.
