### PR TITLE
Allow empty `baremodule`'s to be documented.

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -471,8 +471,7 @@ function moddoc(meta, def, name)
         def = unblock(def)
         block = def.args[3].args
         if !def.args[1]
-            isempty(block) && error("empty baremodules are not documentable.")
-            insert!(block, 2, :(import Base: call, @doc))
+            unshift!(block, :(import Base: call, @doc))
         end
         push!(block, docex)
         esc(Expr(:toplevel, def))

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -853,7 +853,7 @@ jl_value_t *jl_box_bool(int8_t x)
 
 jl_expr_t *jl_exprn(jl_sym_t *head, size_t n)
 {
-    jl_array_t *ar = n==0 ? (jl_array_t*)jl_an_empty_cell : jl_alloc_cell_1d(n);
+    jl_array_t *ar = jl_alloc_cell_1d(n);
     JL_GC_PUSH1(&ar);
     jl_expr_t *ex = (jl_expr_t*)jl_gc_alloc_3w(); assert(NWORDS(sizeof(jl_expr_t))==3);
     jl_set_typeof(ex, jl_expr_type);

--- a/src/ast.c
+++ b/src/ast.c
@@ -377,9 +377,6 @@ static jl_value_t *scm_to_julia_(value_t e, int eo)
                 sym = quote_sym;
             }
             jl_expr_t *ex = jl_exprn(sym, n);
-            // allocate a fresh args array for empty exprs passed to macros
-            if (eo && n == 0)
-                ex->args = jl_alloc_cell_1d(0);
             for(i=0; i < n; i++) {
                 assert(iscons(e));
                 jl_cellset(ex->args, i, scm_to_julia_(car_(e),eo));

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -264,6 +264,13 @@ end
 @test docstrings_equal(@doc(BareModule.A), doc"A")
 @test docstrings_equal(@doc(BareModule.T), doc"T")
 
+# Test that empty baremodules can be documented #13109
+"EmptyBareModule"
+baremodule EmptyBareModule
+end
+
+@test docstrings_equal(@doc(EmptyBareModule), doc"EmptyBareModule")
+
 # test that when no docs exist, they fallback to
 # the docs for the typeof(value)
 let d1 = @doc(DocsTest.val)


### PR DESCRIPTION
This used to cause a segfault as the global `jl_an_empty_cell` was mutated to contain the contents of `Expr(:toplevel, def)`.  Mutating the contents of `Expr.args` should not clobber runtime globals.

ref #13067 
