### PR TITLE
Inline Latex in docs for A_mul_Bt etc.

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -1041,7 +1041,7 @@ Base.(:(//))
 doc"""
     At_mul_B(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᵀ B`
+For matrices or vectors $A$ and $B$, calculates $Aᵀ⋅B$
 """
 At_mul_B
 
@@ -1360,7 +1360,7 @@ airybiprime
 doc"""
     Ac_rdiv_B(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᴴ / B`
+For matrices or vectors $A$ and $B$, calculates $Aᴴ / B$
 """
 Ac_rdiv_B
 
@@ -2528,7 +2528,7 @@ redisplay
 doc"""
     A_mul_Bc(A, B)
 
-For matrices or vectors `A` and `B`, calculates `A Bᴴ`
+For matrices or vectors $A$ and $B$, calculates $A⋅Bᴴ$
 """
 A_mul_Bc
 
@@ -2662,7 +2662,7 @@ watch_file
 doc"""
     At_rdiv_Bt(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᵀ / Bᵀ`
+For matrices or vectors $A$ and $B$, calculates $Aᵀ / Bᵀ$
 """
 At_rdiv_Bt
 
@@ -2676,7 +2676,7 @@ isinteractive
 doc"""
     At_mul_Bt(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᵀ Bᵀ`
+For matrices or vectors $A$ and $B$, calculates $Aᵀ⋅Bᵀ$
 """
 At_mul_Bt
 
@@ -3429,7 +3429,7 @@ Mmap.Anonymous
 doc"""
     A_rdiv_Bc(A, B)
 
-For matrices or vectors `A` and `B`, calculates `A / Bᴴ`
+For matrices or vectors $A$ and $B$, calculates $A / Bᴴ$
 """
 A_rdiv_Bc
 
@@ -6457,8 +6457,8 @@ doc"""
     A_mul_B!(Y, A, B) -> Y
 
 
-Calculates the matrix-matrix or matrix-vector product `A * B` and stores the
-result in `Y`, overwriting the existing value of `Y`.
+Calculates the matrix-matrix or matrix-vector product $A⋅B$ and stores the
+result in $Y$, overwriting the existing value of $Y$.
 
 ```jldoctest
 julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; A_mul_B!(B, A, B);
@@ -6490,7 +6490,7 @@ idct!
 doc"""
     Ac_rdiv_Bc(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᴴ \ Bᴴ`
+For matrices or vectors $A$ and $B$, calculates $Aᴴ / Bᴴ$
 
 """
 Ac_rdiv_Bc
@@ -8789,7 +8789,7 @@ plan_fft
 doc"""
     A_rdiv_Bt(A, B)
 
-For matrices or vectors `A` and `B`, calculates `A / Bᵀ`
+For matrices or vectors $A$ and $B$, calculates $A / Bᵀ$
 """
 A_rdiv_Bt
 
@@ -9549,7 +9549,7 @@ issubnormal
 doc"""
     Ac_ldiv_B(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᴴ \ B`
+For matrices or vectors $A$ and $B$, calculates $Aᴴ$ \ $B$
 """
 Ac_ldiv_B
 
@@ -9807,7 +9807,7 @@ nprocs
 doc"""
     Ac_mul_B(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᴴ B`
+For matrices or vectors $A$ and $B$, calculates $Aᴴ⋅B$
 """
 Ac_mul_B
 
@@ -9823,7 +9823,7 @@ qrfact!
 doc"""
     At_rdiv_B(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᵀ / B`
+For matrices or vectors $A$ and $B$, calculates $Aᵀ / B$
 """
 At_rdiv_B
 
@@ -10072,7 +10072,7 @@ convert
 doc"""
     A_ldiv_Bt(A, B)
 
-For matrices or vectors `A` and `B`, calculates `A \ Bᵀ`
+For matrices or vectors $A$ and $B$, calculates $A$ \ $Bᵀ$
 """
 A_ldiv_Bt
 
@@ -10154,7 +10154,7 @@ eigvals
 doc"""
     A_ldiv_Bc(A, B)
 
-For matrices or vectors `A` and `B`, calculates `A \ Bᴴ`
+For matrices or vectors $A$ and $B$, calculates $A$ \ $Bᴴ$
 """
 A_ldiv_Bc
 
@@ -10786,14 +10786,14 @@ getkey
 doc"""
     At_ldiv_Bt(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᵀ \ Bᵀ`
+For matrices or vectors $A$ and $B$, calculates $Aᵀ$ \ $Bᵀ$
 """
 At_ldiv_Bt
 
 doc"""
     Ac_mul_Bc(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᴴ Bᴴ`
+For matrices or vectors $A$ and $B$, calculates $Aᴴ Bᴴ$
 """
 Ac_mul_Bc
 
@@ -10852,7 +10852,7 @@ sprand
 doc"""
     A_mul_Bt(A, B)
 
-For matrices or vectors `A` and `B`, calculates `A Bᵀ`
+For matrices or vectors $A$ and $B$, calculates $A⋅Bᵀ$
 """
 A_mul_Bt
 
@@ -11388,7 +11388,7 @@ union!
 doc"""
     At_ldiv_B(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᵀ \ B`
+For matrices or vectors $A$ and $B$, calculates $Aᵀ$ \ $B$
 """
 At_ldiv_B
 
@@ -11649,7 +11649,7 @@ ror
 doc"""
     Ac_ldiv_Bc(A, B)
 
-For matrices or vectors `A` and `B`, calculates `Aᴴ \ Bᴴ`
+For matrices or vectors $A$ and $B$, calculates $Aᴴ$ \ $Bᴴ$
 """
 Ac_ldiv_Bc
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -413,19 +413,19 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``A \ Bᴴ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`A` \\ :math:`Bᴴ`
 
 .. function:: A_ldiv_Bt(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``A \ Bᵀ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`A` \\ :math:`Bᵀ`
 
 .. function:: A_mul_B!(Y, A, B) -> Y
 
    .. Docstring generated from Julia source
 
-   Calculates the matrix-matrix or matrix-vector product ``A * B`` and stores the result in ``Y``\ , overwriting the existing value of ``Y``\ .
+   Calculates the matrix-matrix or matrix-vector product :math:`A⋅B` and stores the result in :math:`Y`\ , overwriting the existing value of :math:`Y`\ .
 
    .. doctest::
 
@@ -440,97 +440,97 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``A Bᴴ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`A⋅Bᴴ`
 
 .. function:: A_mul_Bt(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``A Bᵀ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`A⋅Bᵀ`
 
 .. function:: A_rdiv_Bc(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``A / Bᴴ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`A / Bᴴ`
 
 .. function:: A_rdiv_Bt(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``A / Bᵀ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`A / Bᵀ`
 
 .. function:: Ac_ldiv_B(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᴴ \ B``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᴴ` \\ :math:`B`
 
 .. function:: Ac_ldiv_Bc(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᴴ \ Bᴴ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᴴ` \\ :math:`Bᴴ`
 
 .. function:: Ac_mul_B(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᴴ B``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᴴ⋅B`
 
 .. function:: Ac_mul_Bc(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᴴ Bᴴ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᴴ Bᴴ`
 
 .. function:: Ac_rdiv_B(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᴴ / B``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᴴ / B`
 
 .. function:: Ac_rdiv_Bc(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᴴ \ Bᴴ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᴴ / Bᴴ`
 
 .. function:: At_ldiv_B(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᵀ \ B``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᵀ` \\ :math:`B`
 
 .. function:: At_ldiv_Bt(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᵀ \ Bᵀ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᵀ` \\ :math:`Bᵀ`
 
 .. function:: At_mul_B(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᵀ B``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᵀ⋅B`
 
 .. function:: At_mul_Bt(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᵀ Bᵀ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᵀ⋅Bᵀ`
 
 .. function:: At_rdiv_B(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᵀ / B``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᵀ / B`
 
 .. function:: At_rdiv_Bt(A, B)
 
    .. Docstring generated from Julia source
 
-   For matrices or vectors ``A`` and ``B``\ , calculates ``Aᵀ / Bᵀ``
+   For matrices or vectors :math:`A` and :math:`B`\ , calculates :math:`Aᵀ / Bᵀ`
 
 Mathematical Functions
 ----------------------


### PR DESCRIPTION
Replace `A B` with inline Latex `$A \cdot B$` in the docs for `A_mul_Bt` etc.

Follows on from JuliaLang/julia#13108 and makes sure that the docs look good in the REPL, the PDF manual and the online manual.
