### PR TITLE
Enable fast ISel for MCJIT

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5859,6 +5859,9 @@ extern "C" void jl_init_codegen(void)
             );
     delete targetMachine;
     assert(jl_TargetMachine);
+#ifdef USE_MCJIT
+    jl_TargetMachine->setFastISel(true);
+#endif
 #if defined(LLVM38)
     engine_module->setDataLayout(jl_TargetMachine->createDataLayout());
 #elif defined(LLVM36) && !defined(LLVM37)


### PR DESCRIPTION
This starts the long march back to acceptable codegen performance. By enabling fast-isel, I see about a 10-20% improvement in overall execution time when running the test suite. Also from what I've been told, generated code performance isn't significantly worse than
with the regular regalloc, though this is something we should benchmark at some point.
