### PR TITLE
RELBUILDROOT does not need to have cygpath_w called on it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ $(build_private_libdir)/inference.ji: $(build_private_libdir)/inference0.ji
 	$(call spawn,$(JULIA_EXECUTABLE)) -C $(JULIA_CPU_TARGET) --output-ji $(call cygpath_w,$@) -f \
 		-J $(call cygpath_w,$<) coreimg.jl)
 
-RELBUILDROOT := $(call cygpath_w,$(shell $(JULIAHOME)/contrib/relative_path.sh "$(JULIAHOME)/base" "$(BUILDROOT)/base/"))
+RELBUILDROOT := $(shell $(JULIAHOME)/contrib/relative_path.sh "$(JULIAHOME)/base" "$(BUILDROOT)/base/")
 COMMA:=,
 define sysimg_builder
 $$(build_private_libdir)/sys$1.o: $$(build_private_libdir)/inference.ji $$(JULIAHOME)/VERSION $$(BASE_SRCS)


### PR DESCRIPTION
fixes a cygwin warning from #12463 due to `cygpath -w`

~~I think this should be okay but wouldn't mind opinions from @staticfloat or @nalimilan~~

former commit was cf94c24a1f30c8d4be50e1be138bc2be8e235d46, being replaced with simpler solution
