### PR TITLE
fix tracking of serialization state for Function types and Expr

### DIFF
--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -224,7 +224,7 @@ function serialize(s::SerializationState, n::BigFloat)
 end
 
 function serialize(s::SerializationState, ex::Expr)
-    serialize_cycle(s, e) && return
+    serialize_cycle(s, ex) && return
     l = length(ex.args)
     if l <= 255
         writetag(s.io, EXPR_TAG)
@@ -265,8 +265,6 @@ function serialize(s::SerializationState, m::Module)
 end
 
 function serialize(s::SerializationState, f::Function)
-    serialize_cycle(s, f) && return
-    writetag(s.io, FUNCTION_TAG)
     name = false
     if isgeneric(f)
         name = f.env.name
@@ -275,6 +273,7 @@ function serialize(s::SerializationState, f::Function)
     end
     if isa(name,Symbol)
         if isdefined(Base,name) && is(f,getfield(Base,name))
+            writetag(s.io, FUNCTION_TAG)
             write(s.io, UInt8(0))
             serialize(s, name)
             return
@@ -288,18 +287,23 @@ function serialize(s::SerializationState, f::Function)
         if mod !== ()
             if isdefined(mod,name) && is(f,getfield(mod,name))
                 # toplevel named func
+                writetag(s.io, FUNCTION_TAG)
                 write(s.io, UInt8(2))
                 serialize(s, mod)
                 serialize(s, name)
                 return
             end
         end
+        serialize_cycle(s, f) && return
+        writetag(s.io, FUNCTION_TAG)
         write(s.io, UInt8(3))
         serialize(s, f.env)
     else
+        serialize_cycle(s, f) && return
+        writetag(s.io, FUNCTION_TAG)
+        write(s.io, UInt8(1))
         linfo = f.code
         @assert isa(linfo,LambdaStaticData)
-        write(s.io, UInt8(1))
         serialize(s, linfo)
         serialize(s, f.env)
     end
@@ -520,17 +524,18 @@ function deserialize(s::SerializationState, ::Type{Function})
             f = getfield(mod,name)::Function
         end
     elseif b==3
-        env = deserialize(s)
-        f = ccall(:jl_new_gf_internal, Any, (Any,), env)::Function
-    else
-        linfo = deserialize(s)
-        f = ccall(:jl_new_closure, Any, (Ptr{Void}, Ptr{Void}, Any), C_NULL, C_NULL, linfo)::Function
+        f = ccall(:jl_new_gf_internal, Any, (Any,), nothing)::Function
         deserialize_cycle(s, f)
         f.env = deserialize(s)
-        return f
+    else
+        f = ccall(:jl_new_closure, Any, (Ptr{Void}, Ptr{Void}, Any),
+                  cglobal(:jl_trampoline), C_NULL, nothing)::Function
+        deserialize_cycle(s, f)
+        f.code = li = deserialize(s)
+        f.fptr = ccall(:jl_linfo_fptr, Ptr{Void}, (Any,), li)
+        f.env = deserialize(s)
     end
 
-    deserialize_cycle(s, f)
     return f
 end
 

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -529,7 +529,7 @@ function deserialize(s::SerializationState, ::Type{Function})
         f.env = deserialize(s)
         return f
     end
-    
+
     deserialize_cycle(s, f)
     return f
 end

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -325,6 +325,11 @@ DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t fptr, jl_value_t *env,
     return f;
 }
 
+DLLEXPORT jl_fptr_t *jl_linfo_fptr(jl_lambda_info_t *linfo)
+{
+    return linfo->fptr;
+}
+
 DLLEXPORT
 jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams, jl_module_t *ctx)
 {

--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -280,16 +280,34 @@ create_serialization_stream() do s
 end
 
 # cycles
+module CycleFoo
+    echo(x)=x
+end
 create_serialization_stream() do s
-    A = Any[1,2,3,4,5]
+    echo(x) = x
+    afunc = (x)->x
+    A = Any[1,2,3,abs,abs,afunc,afunc,echo,echo,CycleFoo.echo,CycleFoo.echo,4,5]
     A[3] = A
     serialize(s, A)
     seekstart(s)
     b = deserialize(s)
     @test b[3] === b
     @test b[1] == 1
-    @test b[5] == 5
-    @test length(b) == 5
+    @test b[4] === abs
+    @test b[5] === b[4]
+    @test b[5](-1) == 1
+
+    @test b[6] === b[7]
+    @test b[6]("Hello") == "Hello"
+
+    @test b[8] === b[9]
+    @test b[8]("World") == "World"
+
+    @test b[10] === b[11]
+    @test b[10]("foobar") == "foobar"
+
+    @test b[end] == 5
+    @test length(b) == length(A)
     @test isa(b,Vector{Any})
 end
 


### PR DESCRIPTION
While `serialize_cycle` was being called for all `Function` types, `deserialize_cycle` was not. This causes a mismatch in deserializing state.

Closes https://github.com/JuliaLang/julia/issues/12848

@JeffBezanson - I am not really familiar with the ser/deser codebase. Can you review this?
