### PR TITLE
Allow LLVM to figure out the target features (from kf/gallium under VM)

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5715,6 +5715,50 @@ static void init_julia_llvm_env(Module *m)
     FPM->doInitialization();
 }
 
+// Helper to figure out what features to set for the LLVM target
+// If the user specifies native ( or does not specify ) we default
+// using the API provided by LLVM
+static inline SmallVector<std::string,10> getTargetFeatures() {
+  StringMap<bool> HostFeatures;
+  if( !strcmp(jl_options.cpu_target,"native") )
+  {
+    // On earlier versions of LLVM this is empty
+    llvm::sys::getHostCPUFeatures(HostFeatures);
+  }
+
+  // Platform specific overides follow
+#if defined(_CPU_X86_64_) || defined(_CPU_X86_)
+#ifndef USE_MCJIT
+    // Temporarily disable Haswell BMI2 features due to LLVM bug.
+  HostFeatures["bmi2"] = false;
+  HostFeatures["avx2"] = false;
+#endif
+#ifdef V128_BUG
+  HostFeatures["avx"] = false;
+#endif
+#endif
+
+  // Figure out if we know the cpu_target
+  std::string cpu = strcmp(jl_options.cpu_target,"native") ? jl_options.cpu_target : sys::getHostCPUName();
+  if (cpu.empty() || cpu == "generic") {
+    jl_printf(JL_STDERR, "WARNING: unable to determine host cpu name.\n");
+#ifdef _CPU_ARM_
+    // Check if this is required when you have read the features directly from the processor
+    // the processors that don't have VFP are old and (hopefully) rare. this affects the platform calling convention.
+    HostFeatures["vfp2"] = true;
+#endif
+  }
+
+  SmallVector<std::string,10> attr;
+  for( StringMap<bool>::const_iterator it = HostFeatures.begin(); it != HostFeatures.end(); it++  )
+  {
+    std::cerr << it->getKey().str() << std::endl;
+    std::string att =it->getValue()?it->getKey().str():std::string("-") + it->getKey().str();
+    attr.append( 1, att );
+  }
+  return attr;
+}
+
 extern "C" void jl_init_codegen(void)
 {
 #if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
@@ -5780,19 +5824,7 @@ extern "C" void jl_init_codegen(void)
 #ifdef USE_MCJIT
     jl_mcjmm = new SectionMemoryManager();
 #endif
-    const char *mattr[] = {
-#if defined(_CPU_X86_64_) || defined(_CPU_X86_)
-#ifndef USE_MCJIT
-        // Temporarily disable Haswell BMI2 features due to LLVM bug.
-        "-bmi2", "-avx2",
-#endif
-#ifdef V128_BUG
-        "-avx",
-#endif
-#endif
-        "", // padding to make sure this isn't an empty array (ref #11817)
-    };
-    SmallVector<std::string, 4> MAttrs(mattr, mattr+sizeof(mattr)/sizeof(mattr[0]));
+
 #ifdef LLVM36
     EngineBuilder eb(std::move(std::unique_ptr<Module>(engine_module)));
 #else
@@ -5826,17 +5858,12 @@ extern "C" void jl_init_codegen(void)
 #endif
 #endif
     std::string TheCPU = strcmp(jl_options.cpu_target,"native") ? jl_options.cpu_target : sys::getHostCPUName();
-    if (TheCPU.empty() || TheCPU == "generic") {
-        jl_printf(JL_STDERR, "WARNING: unable to determine host cpu name.\n");
-#ifdef _CPU_ARM_
-        MAttrs.append(1, "+vfp2"); // the processors that don't have VFP are old and (hopefully) rare. this affects the platform calling convention.
-#endif
-    }
+    SmallVector<std::string, 10>  targetFeatures = getTargetFeatures( );
     TargetMachine *targetMachine = eb.selectTarget(
             TheTriple,
             "",
             TheCPU,
-            MAttrs);
+            targetFeatures);
     assert(targetMachine && "Failed to select target machine -"
                             " Is the LLVM backend for this CPU enabled?");
     jl_TargetMachine = targetMachine->getTarget().createTargetMachine(

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5752,7 +5752,6 @@ static inline SmallVector<std::string,10> getTargetFeatures() {
   SmallVector<std::string,10> attr;
   for( StringMap<bool>::const_iterator it = HostFeatures.begin(); it != HostFeatures.end(); it++  )
   {
-    std::cerr << it->getKey().str() << std::endl;
     std::string att =it->getValue()?it->getKey().str():std::string("-") + it->getKey().str();
     attr.append( 1, att );
   }


### PR DESCRIPTION
Migrated the target features to a helper function which queries LLVM for the features the CPU supports. 

https://github.com/JuliaLang/julia/issues/13121

This could be due to overwriting the cpu type to selectTarget at line 5865 (codegen.cpp) - on my CPU this is passed i7.
