### PR TITLE
Always use emit_allocobj to emit heap allocation

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -654,9 +654,7 @@ static jl_cgval_t emit_pointerref(jl_value_t *e, jl_value_t *i, jl_codectx_t *ct
         }
         assert(jl_is_datatype(ety));
         uint64_t size = jl_datatype_size(ety);
-        Value *strct =
-            builder.CreateCall(prepare_call(jlallocobj_func),
-                               ConstantInt::get(T_size, size));
+        Value *strct = emit_allocobj(size);
         builder.CreateStore(literal_pointer_val((jl_value_t*)ety),
                             emit_typeptr_addr(strct));
         im1 = builder.CreateMul(im1, ConstantInt::get(T_size,


### PR DESCRIPTION
Mainly for consistency and to make optimizing the allocation in codegen easier.

@vtjnash 
