### PR TITLE
test that max() can take 4 or more array arguments (bug #13144)

### DIFF
--- a/test/operators.jl
+++ b/test/operators.jl
@@ -47,3 +47,10 @@ p = 1=>:foo
 @test 1 .== 1
 @test 1 .< 2
 @test 1 .<= 2
+
+# issue #13144: max() with 4 or more array arguments
+let xs = [[i:i+4;] for i in 1:10]
+    for n in 2:10
+        @test max(xs[1:n]...) == [n:n+4;]
+    end
+end


### PR DESCRIPTION
see #13144 
