### PR TITLE
Add BigFloat constructors with precision and rounding mode

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -138,33 +138,6 @@ function BigFloat(x, precision::Integer, rounding_mode::RoundingMode)
     end
 end
 
-doc"""
-    big(x, precision)
-
-Create a `BigFloat` representation of `x` with given precision (number of bits in
-the fractional part).
-"""
-big(x, precision::Integer) = BigFloat(x, precision)
-
-function big(x::AbstractString, precision::Integer)
-    with_bigfloat_precision(precision) do
-        parse(BigFloat, x)
-    end
-end
-
-doc"""
-    big(x, precision, rounding_mode)
-
-Create a `BigFloat` representation of `x` with given precision (number of bits in
-the fractional part) and given rounding mode.
-"""
-function big(x, precision::Integer, rounding_mode::RoundingMode)
-    with_rounding(BigFloat, rounding_mode) do
-        big(x, precision)
-    end
-end
-
-big(x, rounding_mode::RoundingMode) = big(x, get_bigfloat_precision(), rounding_mode)
 
 convert(::Type{Rational}, x::BigFloat) = convert(Rational{BigInt}, x)
 convert(::Type{AbstractFloat}, x::BigInt) = BigFloat(x)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -165,6 +165,7 @@ function big(x, precision::Integer, rounding_mode::RoundingMode)
     end
 end
 
+big(x, rounding_mode::RoundingMode) = big(x, get_bigfloat_precision(), rounding_mode)
 
 convert(::Type{Rational}, x::BigFloat) = convert(Rational{BigInt}, x)
 convert(::Type{AbstractFloat}, x::BigInt) = BigFloat(x)
@@ -875,7 +876,12 @@ function prevfloat(x::BigFloat)
     return z
 end
 
-eps(::Type{BigFloat}) = nextfloat(BigFloat(1)) - BigFloat(1)
+function eps(x::BigFloat)
+    with_bigfloat_precision(precision(x)) do
+        nextfloat(x) - x
+    end
+end
+eps(::Type{BigFloat}) = eps(BigFloat(1))
 
 realmin(::Type{BigFloat}) = nextfloat(zero(BigFloat))
 realmax(::Type{BigFloat}) = prevfloat(BigFloat(Inf))
@@ -923,6 +929,5 @@ set_emax!(x) = ccall((:mpfr_set_emax, :libmpfr), Void, (Clong,), x)
 set_emin!(x) = ccall((:mpfr_set_emin, :libmpfr), Void, (Clong,), x)
 
 convert(::Type{BigFloat}, x::BigFloat) = BigFloat(x)  # gives error if moved earlier
-
 
 end #module

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -915,7 +915,10 @@ function string(x::BigFloat)
         buf = Array(UInt8, lng + 1)
         lng = ccall((:mpfr_snprintf,:libmpfr), Int32, (Ptr{UInt8}, Culong, Ptr{UInt8}, Ptr{BigFloat}...), buf, lng + 1, "%.Re", &x)
     end
-    return bytestring(pointer(buf), (1 <= x < 10 || -10 < x <= -1 || x == 0) ? lng - 4 : lng)
+
+    repr = bytestring(pointer(buf), (1 <= x < 10 || -10 < x <= -1 || x == 0) ? lng - 4 : lng)
+    return repr == "inf" ? "Inf" : repr
+
 end
 
 print(io::IO, b::BigFloat) = print(io, string(b))

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -877,11 +877,19 @@ function prevfloat(x::BigFloat)
 end
 
 function eps(x::BigFloat)
-    with_bigfloat_precision(Int(precision(x))) do
+    distance = with_bigfloat_precision(Int(precision(x))) do
         nextfloat(x) - x
     end
+
+    if distance == BigFloat(0.0)
+        throw(ArgumentError("eps not defined for tiny numbers"))
+    end
+
+    return distance
 end
+
 eps(::Type{BigFloat}) = eps(BigFloat(1))
+
 
 realmin(::Type{BigFloat}) = nextfloat(zero(BigFloat))
 realmax(::Type{BigFloat}) = prevfloat(BigFloat(Inf))

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -877,7 +877,7 @@ function prevfloat(x::BigFloat)
 end
 
 function eps(x::BigFloat)
-    with_bigfloat_precision(precision(x)) do
+    with_bigfloat_precision(Int(precision(x))) do
         nextfloat(x) - x
     end
 end

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -863,3 +863,24 @@ let b = IOBuffer()
 end
 
 @test isnan(sqrt(BigFloat(NaN)))
+
+# test constructors and `big` with additional precision and rounding mode:
+
+for prec in (10, 100, 1000)
+    set_bigfloat_precision(prec)
+
+    a = big("3.1", RoundDown)
+    b = big("3.1", RoundUp)
+
+    @test b - a == eps(a)
+end
+
+set_bigfloat_precision(100)
+a = BigFloat(3.1)
+set_bigfloat_precision(1000)
+b = BigFloat(3.1, 100)
+@test a == b
+
+a = big("3.1", 10, RoundDown)
+b = big("3.1", 10, RoundUp)
+@test b - a == eps(a)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -881,6 +881,5 @@ set_bigfloat_precision(1000)
 b = BigFloat(3.1, 100)
 @test a == b
 
-a = big("3.1", 10, RoundDown)
-b = big("3.1", 10, RoundUp)
-@test b - a == eps(a)
+
+@test_throws ArgumentError eps(nextfloat(BigFloat(0.0)))

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -867,12 +867,15 @@ end
 # test constructors and `big` with additional precision and rounding mode:
 
 for prec in (10, 100, 1000)
-    set_bigfloat_precision(prec)
+    for val in (pi, eu)
 
-    a = big("3.1", RoundDown)
-    b = big("3.1", RoundUp)
+        @show prec, val
 
-    @test b - a == eps(a)
+        a = BigFloat(val, prec, RoundDown)
+        b = BigFloat(val, prec, RoundUp)
+
+        @test b - a == BigFloat(eps(a), prec)
+    end
 end
 
 set_bigfloat_precision(100)


### PR DESCRIPTION
This adds new constructors for `BigFloat` of the form

```
BigFloat(x, precision)
BigFloat(x, precision, rounding_mode)
```

It also _changes_ the behaviour of `eps`, `prevfloat` and `nextfloat` acting on `BigFloat`s so that they are calculated _using the precision of `x` itself_. Note that this is one of the ambiguities forced on us by the fact that the precision is not a parameter of the `BigFloat` type; c.f. #10040
