### PR TITLE
fix regression #13028. add missing check for valid nrows

### DIFF
--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -208,7 +208,7 @@ function result{T}(dlmstore::DLMStore{T})
     cells = dlmstore.data
     sbuff = dlmstore.sbuff
 
-    if (lastcol < ncols) || (lastrow < nrows)
+    if (nrows > 0) && ((lastcol < ncols) || (lastrow < nrows))
         while lastrow <= nrows
             (lastcol == ncols) && (lastcol = 0; lastrow += 1)
             for cidx in (lastcol+1):ncols

--- a/test/readdlm.jl
+++ b/test/readdlm.jl
@@ -218,3 +218,10 @@ end
     reshape(Any[1,2000.1,Float64(22222222222222222222222222222222222222),true,0x3,false,10e6,-10.34], 2, 4), Any)
 
 @test isequaldlm(readcsv(IOBuffer("-9223355253176920979,9223355253176920979"), Int64), Int64[-9223355253176920979  9223355253176920979], Int64)
+
+# fix #13028
+for data in ["A B C", "A B C\n"]
+    data,hdr = readdlm(IOBuffer(data), header=true)
+    @test hdr == AbstractString["A" "B" "C"]
+    @test data == Array(Float64, 0, 3)
+end


### PR DESCRIPTION
Fixes parsing files with header but with no data.

Bug got introduced with https://github.com/JuliaLang/julia/commit/9e2050d9765bcb7855c12d268ff8333cdd3771af
