### PR TITLE
Optionally log compilation

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -753,6 +753,15 @@ static void maybe_alloc_arrayvar(jl_sym_t *s, jl_codectx_t *ctx)
     }
 }
 
+// Snooping on which functions are being compiled, and how long it takes
+JL_STREAM *dump_compiles_stream = NULL;
+uint64_t last_time = 0;
+extern "C" DLLEXPORT
+void jl_dump_compiles(void *s)
+{
+    dump_compiles_stream = (JL_STREAM*)s;
+}
+
 // --- entry point ---
 //static int n_emit=0;
 static Function *emit_function(jl_lambda_info_t *lam);
@@ -764,6 +773,8 @@ static Function *to_function(jl_lambda_info_t *li)
     BasicBlock *old = nested_compile ? builder.GetInsertBlock() : NULL;
     DebugLoc olddl = builder.getCurrentDebugLocation();
     bool last_n_c = nested_compile;
+    if (!nested_compile && dump_compiles_stream != NULL)
+        last_time = jl_hrtime();
     nested_compile = true;
     jl_gc_inhibit_finalizers(nested_compile);
     Function *f = NULL;
@@ -817,6 +828,13 @@ static Function *to_function(jl_lambda_info_t *li)
     nested_compile = last_n_c;
     jl_gc_inhibit_finalizers(nested_compile);
     JL_SIGATOMIC_END();
+    if (dump_compiles_stream != NULL) {
+        uint64_t this_time = jl_hrtime();
+        jl_printf(dump_compiles_stream, "%lu\t\"", this_time-last_time);
+        jl_static_show(dump_compiles_stream, (jl_value_t*)li);
+        jl_printf(dump_compiles_stream, "\"\n");
+        last_time = this_time;
+    }
     return f;
 }
 


### PR DESCRIPTION
This patch is used by SnoopCompile (https://github.com/JuliaLang/METADATA.jl/pull/3416) to log compilation steps. @ihnorton pointed out that it seems safe for base, so I'm putting it up for consideration.

One potentially-interesting application of this is profiling the compiler---I've noticed that some functions _seem_ to take 30-50x longer than others to compile. I haven't dug deeply enough to figure out whether this is noise or signal.
