### PR TITLE
RFC: allow serializing pointers. fixes #13122

### DIFF
--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -102,8 +102,6 @@ end
 serialize(s::SerializationState, x::Bool) = x ? writetag(s.io, TRUE_TAG) :
                                                 writetag(s.io, FALSE_TAG)
 
-serialize(s::SerializationState, ::Ptr) = error("cannot serialize a pointer")
-
 serialize(s::SerializationState, ::Tuple{}) = writetag(s.io, EMPTYTUPLE_TAG)
 
 function serialize(s::SerializationState, t::Tuple)
@@ -646,8 +644,6 @@ function deserialize_datatype(s::SerializationState)
     end
     deserialize(s, t)
 end
-
-deserialize{T}(s::SerializationState, ::Type{Ptr{T}}) = convert(Ptr{T}, 0)
 
 function deserialize(s::SerializationState, ::Type{Task})
     t = Task(()->nothing)

--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -39,7 +39,9 @@ end
 
 # Ptr
 create_serialization_stream() do s
-    @test_throws ErrorException serialize(s, C_NULL)
+    serialize(s, C_NULL)
+    seekstart(s)
+    @test deserialize(s) === C_NULL
 end
 
 # Integer


### PR DESCRIPTION
I think this error is too much of a slap on the wrist, and we should just SUASTFD (shut up and send the fancy data). There are cases where a pointer can be sent through no fault of the user, and the error is too brittle.
