### PR TITLE
Fix compiler warning about incompatible pointer types.

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -325,7 +325,7 @@ DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t fptr, jl_value_t *env,
     return f;
 }
 
-DLLEXPORT jl_fptr_t *jl_linfo_fptr(jl_lambda_info_t *linfo)
+DLLEXPORT jl_fptr_t jl_linfo_fptr(jl_lambda_info_t *linfo)
 {
     return linfo->fptr;
 }


### PR DESCRIPTION
`jl_fptr_t` is already a function pointer. https://github.com/JuliaLang/julia/commit/a9ae0adce6c90dd8bb84befef21291af3938a0c4 @JeffBezanson 
