### PR TITLE
WIP: make which(str) return the path to the command

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -176,7 +176,7 @@ function which(cmd::AbstractString)
         if isfile(cmd)
             return Nullable(utf8(cmd))
         end
-    else
+    elseif haskey(ENV, "PATH")
         # find `cmd` from the PATH
         for path in split(ENV["PATH"], ':')
             cmd_path = joinpath(path, cmd)

--- a/base/file.jl
+++ b/base/file.jl
@@ -168,6 +168,25 @@ function mktempdir(parent=tempdir())
     systemerror(:mktempdir, p == C_NULL)
     return bytestring(p)
 end
+
+# Find and return the path to a command.
+function which(cmd::AbstractString)
+    if !isempty(dirname(cmd))
+        # `cmd` seems to be a relative path
+        if isfile(cmd)
+            return Nullable(utf8(cmd))
+        end
+    else
+        # find `cmd` from the PATH
+        for path in split(ENV["PATH"], ':')
+            cmd_path = joinpath(path, cmd)
+            if isfile(cmd_path)
+                return Nullable(utf8(cmd_path))
+            end
+        end
+    end
+    return Nullable{UTF8String}()
+end
 end
 
 @windows_only begin

--- a/test/file.jl
+++ b/test/file.jl
@@ -36,6 +36,10 @@ end
     cd(pwd_)
 end
 
+# which (TODO: tests for Windows)
+@unix_only @test !isnull(which("ls"))
+@unix_only @test isfile(get(which("ls")))
+@unix_only @test isnull(which("abracadabra"))
 
 #######################################################################
 # This section tests some of the features of the stat-based file info #

--- a/test/file.jl
+++ b/test/file.jl
@@ -39,7 +39,7 @@ end
 # which (TODO: tests for Windows)
 @unix_only @test !isnull(which("ls"))
 @unix_only @test isfile(get(which("ls")))
-@unix_only @test isnull(which("abracadabra"))
+@unix_only @test isnull(which("WhayXUbWtIo50h0"))
 
 #######################################################################
 # This section tests some of the features of the stat-based file info #


### PR DESCRIPTION
This will make `which(cmd::AbstractString)` return the path to the command string:

``` julia
julia> which("ls")
Nullable("/bin/ls")
```

This method is useful to find the location of a command and to check if a command exists or not.
The same function is available in the `shutil` module on Python3 (https://docs.python.org/dev/library/shutil.html#shutil.which).

Before going into the details, I'd like to know whether you like it or not.
- [ ] Is this method approved?
- [ ] Is returning a `Nullable` good?
- [ ] Support Windows.
- [ ] Write document.
