### PR TITLE
Fix algorithms that assume linear indexing

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -827,32 +827,36 @@ function findmax(a)
     if isempty(a)
         throw(ArgumentError("collection must be non-empty"))
     end
-    m = a[1]
-    mi = 1
-    for i=2:length(a)
-        ai = a[i]
+    i = start(a)
+    mi = i
+    m, i = next(a, i)
+    while !done(a, i)
+        iold = i
+        ai, i = next(a, i)
         if ai > m || m!=m
             m = ai
-            mi = i
+            mi = iold
         end
     end
-    return (m, mi)
+    return (m, iterstate(mi))
 end
 
 function findmin(a)
     if isempty(a)
         throw(ArgumentError("collection must be non-empty"))
     end
-    m = a[1]
-    mi = 1
-    for i=2:length(a)
-        ai = a[i]
+    i = start(a)
+    mi = i
+    m, i = next(a, i)
+    while !done(a, i)
+        iold = i
+        ai, i = next(a, i)
         if ai < m || m!=m
             m = ai
-            mi = i
+            mi = iold
         end
     end
-    return (m, mi)
+    return (m, iterstate(mi))
 end
 
 indmax(a) = findmax(a)[2]

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -3,7 +3,7 @@
 ### Multidimensional iterators
 module IteratorsMD
 
-import Base: eltype, length, start, done, next, last, getindex, setindex!, linearindexing, min, max, eachindex, ndims
+import Base: eltype, length, start, done, next, last, getindex, setindex!, linearindexing, min, max, eachindex, ndims, iterstate
 importall ..Base.Operators
 import Base: simd_outer_range, simd_inner_length, simd_index, @generated
 import Base: @nref, @ncall, @nif, @nexprs, LinearFast, LinearSlow, to_index
@@ -58,6 +58,8 @@ immutable CartesianRange{I<:CartesianIndex}
     start::I
     stop::I
 end
+
+iterstate{CR<:CartesianRange,CI<:CartesianIndex}(i::Tuple{CR,CI}) = i[2]
 
 @generated function CartesianRange{N}(I::CartesianIndex{N})
     startargs = fill(1, N)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -59,7 +59,7 @@ immutable CartesianRange{I<:CartesianIndex}
     stop::I
 end
 
-iterstate{CR<:CartesianRange,CI<:CartesianIndex}(i::Tuple{CR,CI}) = i[2]
+iterstate{CR<:CartesianRange,CI<:CartesianIndex}(i::Tuple{CR,CI}) = Base._sub2ind(i[1].stop.I, i[2].I)
 
 @generated function CartesianRange{N}(I::CartesianIndex{N})
     startargs = fill(1, N)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1017,7 +1017,7 @@ function _mapreducezeros(f, op, T::Type, nzeros::Int, v0)
     v
 end
 
-function Base._mapreduce{T}(f, op, A::SparseMatrixCSC{T})
+function Base._mapreduce{T}(f, op, ::Base.LinearSlow, A::SparseMatrixCSC{T})
     z = nnz(A)
     n = length(A)
     if z == 0


### PR DESCRIPTION
I wrote an `AbstractArray` type that throws an error for linear indexing, and in the course of kicking the tires discovered a number of places where we assume linear indexing (but shouldn't). This PR fixes those places I've found so far.

This could probably be backported to 0.4, with one risky exception which I'll highlight below. Please discuss.

For fun: my new `AbstractArray` type indexes each dimension from `-n:n`. By overloading `eachindex`, I was able to get surprisingly good results. From the remaining problems, unquestionably the most important next step is to define `eachindex(A, d)` with default value `1:size(A,d)`. I am likely to play around with this in the near future.
