### PR TITLE
export isidentifier function for embedded Julia

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -378,6 +378,7 @@ export
     isapprox,
     iseven,
     isfinite,
+    isidentifier,
     isinf,
     isinteger,
     isnan,


### PR DESCRIPTION
the isidentifier function  can be used to judge a string whether is valid identifier. when embedded Julia  we need to know variable name in other language is valid in Julia or not. so please export isidentifier.
