### PR TITLE
Add reload(::Module) - now you can tab-complete the module name

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -195,6 +195,7 @@ function reload(name::AbstractString)
         require(symbol(require_modname(name)))
     end
 end
+reload(name::Module) = reload(string(name))
 
 # require always works in Main scope and loads files from node 1
 toplevel_load = true


### PR DESCRIPTION
With this, you can tab-complete the module name when you want to `reload` it, instead of typing its full name as a string. It makes interactive development a bit nicer. 
