### PR TITLE
Remove references to GPL methods in markdown/docs

### DIFF
--- a/base/precompile.jl
+++ b/base/precompile.jl
@@ -501,8 +501,6 @@ precompile(Base.set_valid_processes, (Array{Int, 1}, ))
 
 
 # Speed up repl help
-if Base.USE_GPL_LIBS
-    sprint(Markdown.term, @doc fft)
-    sprint(Docs.repl_search, "fft")
-    sprint(Docs.repl_corrections, "fft")
-end
+sprint(Markdown.term, @doc mean)
+sprint(Docs.repl_search, "mean")
+sprint(Docs.repl_corrections, "meen")

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -213,24 +213,20 @@ end
 
 ref(x) = Reference(x)
 
-if Base.USE_GPL_LIBS
-
-ref(fft)
+ref(mean)
 
 writemime(io::IO, m::MIME"text/plain", r::Reference) =
     print(io, "$(r.ref) (see Julia docs)")
 
-fft_ref = md"Behaves like $(ref(fft))"
-@test plain(fft_ref) == "Behaves like fft (see Julia docs)\n"
-@test html(fft_ref) == "<p>Behaves like fft &#40;see Julia docs&#41;</p>\n"
+mean_ref = md"Behaves like $(ref(mean))"
+@test plain(mean_ref) == "Behaves like mean (see Julia docs)\n"
+@test html(mean_ref) == "<p>Behaves like mean &#40;see Julia docs&#41;</p>\n"
 
 writemime(io::IO, m::MIME"text/html", r::Reference) =
     Markdown.withtag(io, :a, :href=>"test") do
         Markdown.htmlesc(io, Markdown.plaininline(r))
     end
-@test html(fft_ref) == "<p>Behaves like <a href=\"test\">fft &#40;see Julia docs&#41;</a></p>\n"
-
-end # USE_GPL_LIBS
+@test html(mean_ref) == "<p>Behaves like <a href=\"test\">mean &#40;see Julia docs&#41;</a></p>\n"
 
 @test md"""
 ````julia


### PR DESCRIPTION
_Note: It's still used in [documenting fft](https://github.com/JuliaLang/julia/blob/master/base/docs/basedocs.jl#L493-L521), I think that was missed in  (https://github.com/JuliaLang/julia/commit/fb15f5a9697b6aa91554744d45a21e4f7215e87d, #13118) ?_
