### PR TITLE
Quote shell command correctly for Posix shells

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -91,8 +91,8 @@ include("iobuffer.jl")
 include("string.jl")
 include("unicode.jl")
 include("parse.jl")
-include("shell.jl")
 include("regex.jl")
+include("shell.jl")
 include("base64.jl")
 importall .Base64
 

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -328,6 +328,18 @@ end
 # Backticks should automatically quote where necessary
 let cmd = ["foo bar", "baz"]
     @test string(`$cmd`) == "`'foo bar' baz`"
+
+    # Test various difficult strings, and test multiple quoting levels
+    strs = ByteString["", "asdf", "'", "\"", "\\", " ", "\$",
+                      "a\"bc\"d", "'012'3", " a ", "\n", "\\n", "\t",
+                      "echo hello", " \${LANG}", "\"println(ARGS)\""]
+    for level in 1:3
+        cmd = Cmd(strs)
+        quoted = Base.shell_escape(cmd)
+        strs2 = Base.shell_split(quoted)
+        @test strs2 == strs
+        strs = ByteString[Base.shell_escape(str) for str in strs]
+    end
 end
 
 @test Base.shell_split("\"\\\\\"") == ["\\"]


### PR DESCRIPTION
The quoting is now safe for Posix sh-like shells.

The algorithm tries several ways to quote words (via single or double quotes or backslashes), and then uses a scoring method to choose the "best" result. The current scoring chooses the shortest string, and adds additional penalties for backslashes.
