### PR TITLE
WIP/RFC: Sweet Holy Traits

### DIFF
--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -41,6 +41,11 @@ include("int.jl")
 include("operators.jl")
 include("pointer.jl")
 
+# # traits
+getindex(A::Array, i1::Real) = arrayref(A, to_index(i1))
+include("traits.jl")
+#include("traits-bootstrap-tests.jl")
+
 # core array operations
 include("abstractarray.jl")
 typealias StridedArray{T,N,A<:DenseArray,I<:Tuple{Vararg{RangeIndex}}} DenseArray{T,N}

--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -41,10 +41,10 @@ include("int.jl")
 include("operators.jl")
 include("pointer.jl")
 
-# # traits
+#  traits
 getindex(A::Array, i1::Real) = arrayref(A, to_index(i1))
 include("traits.jl")
-#include("traits-bootstrap-tests.jl")
+include("traits-bootstrap-tests.jl")
 
 # core array operations
 include("abstractarray.jl")

--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -44,7 +44,7 @@ include("pointer.jl")
 #  traits
 getindex(A::Array, i1::Real) = arrayref(A, to_index(i1))
 include("traits.jl")
-include("traits-bootstrap-tests.jl")
+#include("traits-bootstrap-tests.jl")
 
 # core array operations
 include("abstractarray.jl")

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -3958,17 +3958,6 @@ Multiply elements of an array over the given dimensions.
 prod(A, dims)
 
 doc"""
-    Base.linearindexing(A)
-
-`linearindexing` defines how an AbstractArray most efficiently accesses its elements. If `Base.linearindexing(A)` returns `Base.LinearFast()`, this means that linear indexing with only one index is an efficient operation. If it instead returns `Base.LinearSlow()` (by default), this means that the array intrinsically accesses its elements with indices specified for every dimension. Since converting a linear index to multiple indexing subscripts is typically very expensive, this provides a traits-based mechanism to enable efficient generic code for all array types.
-
-An abstract array subtype `MyArray` that wishes to opt into fast linear indexing behaviors should define `linearindexing` in the type-domain:
-
-    Base.linearindexing{T<:MyArray}(::Type{T}) = Base.LinearFast()
-"""
-Base.linearindexing
-
-doc"""
     isqrt(n)
 
 Integer square root: the largest integer `m` such that `m*m <= n`.

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -3958,6 +3958,17 @@ Multiply elements of an array over the given dimensions.
 prod(A, dims)
 
 doc"""
+    Base.linearindexing(A)
+
+`linearindexing` defines how an AbstractArray most efficiently accesses its elements. If `Base.linearindexing(A)` returns `Base.LinearFast()`, this means that linear indexing with only one index is an efficient operation. If it instead returns `Base.LinearSlow()` (by default), this means that the array intrinsically accesses its elements with indices specified for every dimension. Since converting a linear index to multiple indexing subscripts is typically very expensive, this provides a traits-based mechanism to enable efficient generic code for all array types.
+
+An abstract array subtype `MyArray` that wishes to opt into fast linear indexing behaviors should define `linearindexing` in the type-domain:
+
+    Base.linearindexing{T<:MyArray}(::Type{T}) = Base.LinearFast()
+"""
+Base.linearindexing
+
+doc"""
     isqrt(n)
 
 Integer square root: the largest integer `m` such that `m*m <= n`.

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -131,6 +131,23 @@ export
     WString,
     Zip,
 
+# Traits and related functions
+    IsAnything,
+    IsNothing,
+    IsCallable,
+    IsBits,
+    Isimmutable,
+    IsLeafType,
+    IsContiguous,
+    HasFastLinearIndex,
+    Not,
+    Trait,
+    istrait,
+    trait,
+    @traitdef,
+    @traitimpl,
+    @traitfn,
+
 # Ccall types
     Cchar,
     Cdouble,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -49,6 +49,10 @@ include("pointer.jl")
 include("refpointer.jl")
 include("functors.jl")
 
+# traits
+include("traits.jl")
+#include("traits-bootstrap-tests.jl")
+
 # array structures
 include("abstractarray.jl")
 include("subarray.jl")

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -15,7 +15,7 @@ eval(m,x) = Core.eval(m,x)
 
 include("exports.jl")
 
-if true
+if false
     # simple print definitions for debugging. enable these if something
     # goes wrong during bootstrap before printing code is available.
     show(x::ANY) = ccall(:jl_static_show, Void, (Ptr{Void}, Any),
@@ -51,7 +51,7 @@ include("functors.jl")
 
 # traits
 include("traits.jl")
-include("traits-bootstrap-tests.jl")
+#include("traits-bootstrap-tests.jl") # also activate the printing above
 
 # array structures
 include("abstractarray.jl")

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -15,7 +15,7 @@ eval(m,x) = Core.eval(m,x)
 
 include("exports.jl")
 
-if false
+if true
     # simple print definitions for debugging. enable these if something
     # goes wrong during bootstrap before printing code is available.
     show(x::ANY) = ccall(:jl_static_show, Void, (Ptr{Void}, Any),
@@ -51,7 +51,7 @@ include("functors.jl")
 
 # traits
 include("traits.jl")
-#include("traits-bootstrap-tests.jl")
+include("traits-bootstrap-tests.jl")
 
 # array structures
 include("abstractarray.jl")

--- a/base/traits-bootstrap-tests.jl
+++ b/base/traits-bootstrap-tests.jl
@@ -1,0 +1,94 @@
+# Tests which can be run during bootstrap.  Essentially the same as in test/traits.jl
+
+println("--------------------trait-----------------")
+println("Running traits tests:")
+### tests
+@traitdef Tr{X}
+@traitimpl Tr{Int}
+@traitfn ff985{X; Tr{X}}(x::X) = x
+a = ff985(5)
+# println("Running traitfn:")
+# println(ff985(5))
+
+## run tests
+
+macro assert_(ex)
+    :($(esc(ex)) ? $(nothing) : (print("------------- Error in:  "); println($(esc(ex)))) )
+end
+
+@traitdef Tr1{X}
+@assert_ trait(Tr1{Int})==Not{Tr1{Int}}
+@assert_ !istrait(Tr1{Int})
+@traitimpl Tr1{Integer}
+@assert_ trait(Tr1{Int})==Tr1{Int}
+@assert_ istrait(Tr1{Int})
+@assert_ trait(Tr1{Bool})==Tr1{Bool}
+
+# Logic.  trait(Tr) returns the same trait Tr if it is fulfilled and
+# Not{Tr} otherwise.  This is a bit confusing.
+@assert_ trait(Tr1{AbstractString})==Not{Tr1{AbstractString}}
+@assert_ istrait(Tr1{AbstractString})==false
+@assert_ trait(Not{Tr1{AbstractString}})==Not{Tr1{AbstractString}}
+@assert_ istrait(Not{Tr1{AbstractString}})==true
+@assert_ trait(Not{Not{Tr1{AbstractString}}})==Not{Tr1{AbstractString}}
+@assert_ istrait(Not{Not{Tr1{AbstractString}}})==false
+@assert_ trait(Not{Not{Not{Tr1{AbstractString}}}})==Not{Tr1{AbstractString}}
+@assert_ istrait(Not{Not{Not{Tr1{AbstractString}}}})==true
+
+@assert_ trait(Not{Tr1{Integer}})==Tr1{Integer}
+@assert_ istrait(Not{Tr1{Integer}})==false
+@assert_ trait(Not{Not{Tr1{Integer}}})==Tr1{Integer}
+@assert_ istrait(Not{Not{Tr1{Integer}}})==true
+@assert_ trait(Not{Not{Not{Tr1{Integer}}}})==Tr1{Integer}
+@assert_ istrait(Not{Not{Not{Tr1{Integer}}}})==false
+
+@traitdef Tr2{X,Y}
+@assert_ trait(Tr2{Int,AbstractFloat})==Not{Tr2{Int,AbstractFloat}}
+@traitimpl Tr2{Integer, Float64}
+@assert_ trait(Tr2{Int, Float64})==Tr2{Int, Float64}
+@assert_ trait(Tr2{Int, Float32})==Not{Tr2{Int, Float32}}
+
+# trait functions
+@traitfn f985{X; Tr1{X}}(x::X) = 1  # def 1
+@traitfn f985{X; !Tr1{X}}(x::X) = 2
+@assert_ f985(5)==1
+@assert_ f985(5.)==2
+
+
+@traitfn f985{X,Y; Tr2{X,Y}}(x::X,y::Y,z) = 1
+@assert_ f985(5,5., "a")==1
+@traitfn f985{X,Y; !Tr2{X,Y}}(x::X,y::Y,z) = 2
+@assert_ f985(5,5, "a")==2
+# This will overwrite the definition def1 above
+@traitfn f985{X; !Tr2{X,X}}(x::X) = 10
+@traitfn f985{X; Tr2{X,X}}(x::X) = 100
+@assert_ f985(5)==10
+@assert_ f985(5.)==10
+@traitimpl Tr2{Integer, Integer}
+@assert_ f985(5.)==10
+println("This fails on the first round of coreimg.jl:")
+@assert_ f985(5)==10
+println("end of failure")
+# need to update method cache to make above right:
+@traitfn f985{X; Tr2{X,X}}(x::X) = 100
+@assert_ f985(5)==100
+@assert_ f985(5.)==10
+
+# VarArg
+@traitfn g{X; Tr1{X}}(x::X, y...) = y
+@assert_ g(5, 7, 8)==((7,8),)
+### @assert_ g(5.0, 7, 8)==((7,8),) # hangs because of https://github.com/JuliaLang/julia/issues/13183
+## With macros
+@traitfn @generated ggg{X; Tr1{X}}(x::X) = ( x<:Array ? :(x[1]+1) : :(x))
+#@traitfn @generated ggg{X; Tr1{X}}(x::X) = ( println(x); x<:Array ? :(x[1]+1) : :(x))
+@assert_ ggg(5)==5
+@traitimpl Tr1{AbstractArray}
+a = Array(Any,1) # Array(Int,1) does not work yet!?
+a[1] = 5
+@assert_ ggg(a)==6
+
+# traitfn with Type
+@traitfn ggt{X; Tr1{X}}(::Type{X}, y) = (X,y)
+@assert_ ggt(Array, 5)==(Array, 5)
+
+println("Traits tests done")

--- a/base/traits-bootstrap-tests.jl
+++ b/base/traits-bootstrap-tests.jl
@@ -91,4 +91,8 @@ a[1] = 5
 @traitfn ggt{X; Tr1{X}}(::Type{X}, y) = (X,y)
 @assert_ ggt(Array, 5)==(Array, 5)
 
+# traitfn with ::X
+@traitfn gg27{X; Tr1{X}}(::X) = X
+@assert_ gg27(a)==Array{Int,1}
+
 println("Traits tests done")

--- a/base/traits.jl
+++ b/base/traits.jl
@@ -1,0 +1,291 @@
+# This just adds a few convenience functions & macros around Holy Traits.
+
+export istrait, trait, @traitdef, @traitimpl, @traitfn, Not, Trait
+const curmod = module_name(current_module())
+
+"""
+All Traits are subtypes of abstract type Trait.  (SUPER is not used
+here but in Traits.jl)
+"""
+abstract Trait{SUPER}
+# a concrete Trait will look like
+# immutable Tr1{X,Y} <: Trait end
+# where X and Y are the types involved in the trait.
+
+"""
+The set of all types not belonging to a trait is encoded by wrapping
+it with Not{}, e.g.  Not{Tr1{X,Y}}
+"""
+abstract Not{T<:Trait} <: Trait
+
+# Helper to strip an even number of Not{}s off: Not{Not{T}}->T
+stripNot{T<:Trait}(::Type{T}) = T
+stripNot{T<:Trait}(::Type{Not{T}}) = Not{T}
+stripNot{T<:Trait}(::Type{Not{Not{T}}}) = stripNot(T)
+
+"""
+A trait is defined as full filled if this function is the identity function for that trait.
+Otherwise it returns the trait wrapped in `Not`.
+
+Example:
+```
+trait(IsBits{Int}) # returns IsBits{Int}
+trait(IsBits{Array}) # returns Not{IsBits{Array}}
+```
+
+Instead of using `@traitimpl` one can define a method for `trait` to
+implement a trait.  If this uses `@generated` functions it will be
+in-lined away.  For example the `IsBits` trait is defined by:
+```
+@traitdef IsBits{X}
+@generated trait{X}(::Type{IsBits{X}}) =
+    isbits(X) ? :(IsBits{X}) : :(Not{IsBits{X}})
+```
+"""
+trait{T<:Trait}(::Type{T}) = Not{T}
+trait{T<:Trait}(::Type{Not{T}}) = trait(T)
+
+## Under the hood, a trait is then implemented for specific types by
+## defining:
+#   trait(::Type{Tr1{Int,Float64}}) = Tr1{Int,Float64}
+# or
+#   trait{I<:Integer,F<:AbstractFloat}(::Type{Tr1{I,F}}) = Tr1{I,F}
+
+"""
+This function checks whether a trait is fulfilled by a specific
+set of types.
+```
+istrait(Tr1{Int,Float64}) => return true or false
+```
+"""
+istrait(::Any) = error("Argument is not a Trait.")
+istrait{T<:Trait}(tr::Type{T}) = trait(tr)==stripNot(tr) ? true : false # Problem, this can run into issue #265
+                                                                        # thus is redefine when traits are defined
+"""
+Used to define a trait.  Traits, like types, are camel cased.
+Often they start with `Is` or `Has`.
+
+Examples:
+```
+@traitdef IsFast{X}
+@traitdef IsSlow{X,Y}
+```
+"""
+macro traitdef(tr)
+    :(immutable $(esc(tr)) <: Trait end)
+end
+
+# # helper as not available during bootstrap:
+# function _dec(x::Unsigned, pad::Int, neg::Bool)
+#     i = neg + max(pad,ndigits0z(x))
+#     a = Array(UInt8,i)
+#     while i > neg
+#         a[i] = '0'+rem(x,10)
+#         x = oftype(x,div(x,10))
+#         i -= 1
+#     end
+#     if neg; a[1]='-'; end
+#     ASCIIString(a)
+# end
+
+# A helper function to insert several args into an expression as this
+# does not work early in bootstrap:
+# :(T{$(ar...)})
+#
+# Use instead:
+# tmp = :(T{})
+# addtoargs!(tmp, ar)
+function addtoargs!(e::Expr, ar::Array{Any,1})
+    n1 = arraylen(e.args)
+    n2 = arraylen(ar)
+    tmp = Array(Any,n1+n2)
+    for i=1:n1
+        tmp[i] = e.args[i]
+    end
+    for i=n1+1:n1+n2
+        tmp[i] = ar[i-n1]
+    end
+    e.args = tmp
+    return e
+end
+getindex(A::Array, i1::Real) = arrayref(A, to_index(i1))
+
+# TODO: do this more generally?
+const syms = (:X1,:X2,:X3,:X4,:X5,:X6,:X7,:X8,:X9,:X10,:X11,:X12,:X13,:X14,
+              :X15,:X16,:X17,:X18,:X19,:X20,:X21,:X22,:X23,:X24,:X25,:X26,
+              :X27,:X28,:X29,:X30,:X31,:X32,:X33,:X34,:X35,:X36,:X37,:X38,
+              :X39,:X40,:X41,:X42,:X43,:X44,:X45,:X46,:X47,:X48,:X49,:X50,
+              :X51,:X52,:X53,:X54,:X55,:X56,:X57,:X58,:X59,:X60,:X61,:X62,
+              :X63,:X64,:X65,:X66,:X67,:X68,:X69,:X70,:X71,:X72,:X73,:X74,
+              :X75,:X76,:X77,:X78,:X79,:X80,:X81,:X82,:X83,:X84,:X85,:X86,
+              :X87,:X88,:X89,:X90,:X91,:X92,:X93,:X94,:X95,:X96,:X97,:X98,:X99,:X100)
+
+"""
+Used to add a type or type-tuple to a trait.  By default a type does
+not belong to a trait.
+
+Example:
+```
+@traitdef IsFast{X}
+@traitimpl IsFast{Array{Int,1}}
+```
+"""
+macro traitimpl(tr)
+    # makes
+    # trait{X1<:Int,X2<:Float64}(::Type{Tr1{X1,X2}}) = Tr1{X1,X2}
+    n = arraylen(tr.args)-1
+    typs = [tr.args[i] for i=2:n+1]
+    trname = esc(tr.args[1])
+    curly = Array(Any,n)
+    paras = Array(Any,n)
+    for i=1:n
+        ty = typs[i]
+        v = syms[i]
+        curly[i] = Expr(:(<:), esc(v), esc(ty))  #:($v<:$ty)
+        paras[i] = esc(v)
+    end
+    # some shenanigans needed for bootstrap:
+    # arg = :(::Type{$trname{$(paras...)}})
+    tmp = :($trname{})
+    addtoargs!(tmp, paras)
+    arg = :(::Type{$tmp})
+    # fnhead = :($curmod.trait{$(curly...)}($arg))
+    tmp = :($curmod.trait{})
+    addtoargs!(tmp, curly)
+    fnhead = :($tmp($arg))
+    # isfnhead = :($curmod.istrait{$(curly...)}($arg))
+    tmp = :($curmod.istrait{})
+    addtoargs!(tmp, curly)
+    isfnhead = :($tmp($arg))
+    # tmp = $trname{$(paras...)}
+    tmp = :($trname{})
+    addtoargs!(tmp, paras)
+    quote
+        $fnhead = $tmp
+        $isfnhead = true # Add the istrait definition as otherwise
+                         # method-caching can be an issue.
+    end
+end
+
+"""
+Defines a function dispatching on a trait:
+```
+@traitfn f{X,Y;  Tr1{X,Y}}(x::X,y::Y) = ...
+@traitfn f{X,Y; !Tr1{X,Y}}(x::X,y::Y) = ... # which is just sugar for:
+@traitfn f{X,Y; Not{Tr1{X,Y}}}(x::X,y::Y) = ...
+```
+"""
+macro traitfn(tfn)
+    # Need
+    # f{X,Y}(x::X,Y::Y) = f(trait(Tr1{X,Y}), x, y)
+    # f(::False, x, y)= ...
+    if tfn.head==:macrocall
+        # if it is
+        # @traitfn @generated f{X,Y;  Tr1{X,Y}}(x::X,y::Y) = ...
+        hasmac = true
+        mac = tfn.args[1]
+        tfn = tfn.args[2]
+    else
+        hasmac = false
+    end
+    fhead = tfn.args[1]
+    fbody = tfn.args[2]
+    fname = fhead.args[1].args[1]
+    args = [fhead.args[i] for i=2:arraylen(fhead.args)]
+    typs = [fhead.args[1].args[i] for i=3:arraylen(fhead.args[1].args)]
+    trait = fhead.args[1].args[2].args[1]
+    if isnegated(trait)
+        trait = trait.args[2]
+        val = :(::Type{$curmod.Not{$trait}})
+    else
+        val = :(::Type{$trait})
+    end
+
+    # The wrapper function:
+    # fwrap = $fname{$(typs...)}($(args...)) = (@_inline_meta(); $fname($curmod.trait($trait), $(striparg(args)...)))
+    #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    #              tmp1                                                  tmp2
+    tmp1 = :($fname{})
+    addtoargs!(tmp1, typs)
+    tmp1 = :($tmp1())
+    addtoargs!(tmp1, args)
+    tmp2 = :($fname($curmod.trait($trait)))
+    addtoargs!(tmp2, striparg(args))
+    fwrap = :($tmp1 = ($curmod.@_inline_meta(); $tmp2))
+
+    # The function containing the logic
+    if !hasmac
+        # fn = :($fname{$(typs...)}($val, $(args...)) = (@_inline_meta(); $fbody))
+        #        ^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^
+        #           tmp1                   tmp2
+        tmp1 = :($fname{})
+        addtoargs!(tmp1, typs)
+        tmp2 = :($tmp1($val,))
+        addtoargs!(tmp2, args)
+        fn = :($tmp2 = ($curmod.@_inline_meta(); $fbody))
+    else
+        # during bootstrap it's just on possible to insert that darned
+        # macrocall any simpler than this:
+           fn = :(@dummy function $fname{}($val)
+                   $curmod.@_inline_meta()
+                   $fbody
+               end)
+        fn.args[1] = mac
+        addtoargs!(fn.args[2].args[1].args[1], typs)
+        addtoargs!(fn.args[2].args[1], args)
+    end
+    esc(quote
+        $fwrap
+        $fn
+    end)
+end
+
+######
+## Helpers
+######
+
+# true if :(!(Tr{x}))
+isnegated(t::Expr) = t.head==:call
+
+# [:(x::X)] -> [:x]
+striparg{T}(args::Array{T,1}) = [striparg(args[i]) for i=1:arraylen(args)]
+striparg(a::Symbol) = a
+striparg(a::Expr) = a.args[1]
+
+####
+# Some trait definitions
+####
+export IsAnything, IsNothing, IsCallable
+
+"Trait which contains all types"
+@traitdef IsAnything{X}
+trait{X}(::Type{IsAnything{X}}) = IsAnything{X}
+"Trait which contains no types"
+typealias IsNothing{X} Not{IsAnything{X}}
+
+#"Trait of all callable objects"
+@traitdef IsCallable{X}
+@generated function trait{X}(::Type{IsCallable{X}})
+    if X==Function ||  length(methods(call, (X,Vararg)))>0
+        return IsCallable{X}
+    else
+        return Not{IsCallable{X}}
+    end
+end
+
+# # from reflection.jl (need to be moved elsewhere because they don't bootstrap here)
+# "Trait of all isbits-types"
+# @traitdef IsBits{X}
+# @generated trait{X}(::Type{IsBits{X}}) =
+#     isbits(X) ? :(IsBits{X}) : :(Not{IsBits{X}})
+
+# "Trait of all immutable types"
+# @traitdef IsImmutable{X}
+# @generated trait{X}(::Type{IsImmutable{X}}) =
+#     X.mutable ? :(Not{IsImmutable{X}}) : :(IsImmutable{X})
+
+# "Trait of all leaf types types"
+# @traitdef IsLeafType{X}
+# @generated trait{X}(::Type{IsLeafType{X}}) =
+#     X.mutable ? :(Not{IsLeafType{X}}) : :(IsLeafType{X})
+

--- a/base/traits.jl
+++ b/base/traits.jl
@@ -210,7 +210,7 @@ macro traitfn(tfn)
     tmp1 = :($tmp1())
     addtoargs!(tmp1, args)
     tmp2 = :($fname($curmod.trait($trait)))
-    addtoargs!(tmp2, striparg(args))
+    addtoargs!(tmp2, stripType(striparg(args)))
     fwrap = :($tmp1 = ($curmod.@_inline_meta(); $tmp2))
 
     # The function containing the logic
@@ -252,6 +252,11 @@ striparg{T}(args::Array{T,1}) = [striparg(args[i]) for i=1:arraylen(args)]
 striparg(a::Symbol) = a
 striparg(a::Expr) = a.args[1]
 
+# :(Type{X}) -> X, X->X
+stripType{T}(args::Array{T,1}) = [stripType(args[i]) for i=1:arraylen(args)]
+stripType(a::Symbol) = a
+stripType(a::Expr) = (a.head==:curly && a.args[1]==:Type) ? a.args[2] : a
+
 ####
 # Some trait definitions
 ####
@@ -273,19 +278,20 @@ typealias IsNothing{X} Not{IsAnything{X}}
     end
 end
 
-# # from reflection.jl (need to be moved elsewhere because they don't bootstrap here)
 # "Trait of all isbits-types"
 # @traitdef IsBits{X}
-# @generated trait{X}(::Type{IsBits{X}}) =
+# @generated function trait{X}(::Type{IsBits{X}})
 #     isbits(X) ? :(IsBits{X}) : :(Not{IsBits{X}})
+# end
 
 # "Trait of all immutable types"
 # @traitdef IsImmutable{X}
-# @generated trait{X}(::Type{IsImmutable{X}}) =
+# @generated function trait{X}(::Type{IsImmutable{X}})
 #     X.mutable ? :(Not{IsImmutable{X}}) : :(IsImmutable{X})
+# end
 
 # "Trait of all leaf types types"
 # @traitdef IsLeafType{X}
-# @generated trait{X}(::Type{IsLeafType{X}}) =
+# @generated function trait{X}(::Type{IsLeafType{X}})
 #     X.mutable ? :(Not{IsLeafType{X}}) : :(IsLeafType{X})
-
+# end

--- a/base/traits.jl
+++ b/base/traits.jl
@@ -278,20 +278,20 @@ typealias IsNothing{X} Not{IsAnything{X}}
     end
 end
 
-# "Trait of all isbits-types"
-# @traitdef IsBits{X}
-# @generated function trait{X}(::Type{IsBits{X}})
-#     isbits(X) ? :(IsBits{X}) : :(Not{IsBits{X}})
-# end
+"Trait of all isbits-types"
+@traitdef IsBits{X}
+@generated function trait{X}(::Type{IsBits{X}})
+    isbits(X) ? :(IsBits{X}) : :(Not{IsBits{X}})
+end
 
-# "Trait of all immutable types"
-# @traitdef IsImmutable{X}
-# @generated function trait{X}(::Type{IsImmutable{X}})
-#     X.mutable ? :(Not{IsImmutable{X}}) : :(IsImmutable{X})
-# end
+"Trait of all immutable types"
+@traitdef IsImmutable{X}
+@generated function trait{X}(::Type{IsImmutable{X}})
+    X.mutable ? :(Not{IsImmutable{X}}) : :(IsImmutable{X})
+end
 
-# "Trait of all leaf types types"
-# @traitdef IsLeafType{X}
-# @generated function trait{X}(::Type{IsLeafType{X}})
-#     X.mutable ? :(Not{IsLeafType{X}}) : :(IsLeafType{X})
-# end
+"Trait of all leaf types types"
+@traitdef IsLeafType{X}
+@generated function trait{X}(::Type{IsLeafType{X}})
+    X.mutable ? :(Not{IsLeafType{X}}) : :(IsLeafType{X})
+end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -32,7 +32,7 @@ function choosetests(choices = [])
         "nullable", "meta", "profile", "libgit2", "docs", "markdown",
         "base64", "serialize", "functors", "misc",
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
-        "intset", "floatfuncs", "compile"
+        "intset", "floatfuncs", "compile", "traits"
     ]
 
     if Base.USE_GPL_LIBS

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -85,6 +85,10 @@ a[1] = 5
 @traitfn ggt{X; Tr1{X}}(::Type{X}, y) = (X,y)
 @test ggt(Array, 5)==(Array, 5)
 
+# traitfn with ::X
+@traitfn gg27{X; Tr1{X}}(::X) = X
+@test gg27([1])==Array{Int,1}
+
 ######
 # Other tests
 #####

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -72,6 +72,19 @@ using Base.Test
 @traitfn g{X; !Tr1{X}}(x::X, y...) = 99
 @test g(5.0, 7, 8)==99
 
+## With macros
+@traitfn @generated ggg{X; Tr1{X}}(x::X) = ( x<:Array ? :(x[1]+1) : :(x))
+#@traitfn @generated ggg{X; Tr1{X}}(x::X) = ( println(x); x<:Array ? :(x[1]+1) : :(x))
+@test ggg(5)==5
+@traitimpl Tr1{AbstractArray}
+a = Array(Any,1) # Array(Int,1) does not work yet!?
+a[1] = 5
+@test ggg(a)==6
+
+# traitfn with Type
+@traitfn ggt{X; Tr1{X}}(::Type{X}, y) = (X,y)
+@test ggt(Array, 5)==(Array, 5)
+
 ######
 # Other tests
 #####

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,0 +1,105 @@
+module TraitTests
+using Base.Test
+
+# @test_throws MethodError trait(4)
+@test_throws ErrorException istrait(4)
+
+# definition & adding
+@traitdef Tr1{X}
+@test trait(Tr1{Int})==Not{Tr1{Int}}
+@test !istrait(Tr1{Int})
+@traitimpl Tr1{Integer}
+@test trait(Tr1{Int})==Tr1{Int}
+@test istrait(Tr1{Int})
+@test trait(Tr1{Bool})==Tr1{Bool}
+@test trait(Tr1{AbstractString})==Not{Tr1{AbstractString}}
+@test !istrait(Tr1{AbstractString})
+
+# Logic.  trait(Tr) returns the same trait Tr if it is fulfilled and
+# Not{Tr} otherwise.  This is a bit confusing.
+@test trait(Tr1{AbstractString})==Not{Tr1{AbstractString}}
+@test istrait(Tr1{AbstractString})==false
+@test trait(Not{Tr1{AbstractString}})==Not{Tr1{AbstractString}}
+@test istrait(Not{Tr1{AbstractString}})==true
+@test trait(Not{Not{Tr1{AbstractString}}})==Not{Tr1{AbstractString}}
+@test istrait(Not{Not{Tr1{AbstractString}}})==false
+@test trait(Not{Not{Not{Tr1{AbstractString}}}})==Not{Tr1{AbstractString}}
+@test istrait(Not{Not{Not{Tr1{AbstractString}}}})==true
+
+@test trait(Not{Tr1{Integer}})==Tr1{Integer}
+@test istrait(Not{Tr1{Integer}})==false
+@test trait(Not{Not{Tr1{Integer}}})==Tr1{Integer}
+@test istrait(Not{Not{Tr1{Integer}}})==true
+@test trait(Not{Not{Not{Tr1{Integer}}}})==Tr1{Integer}
+@test istrait(Not{Not{Not{Tr1{Integer}}}})==false
+
+
+@traitdef Tr2{X,Y}
+@test trait(Tr2{Int,AbstractFloat})==Not{Tr2{Int,AbstractFloat}}
+@traitimpl Tr2{Integer, Float64}
+@test trait(Tr2{Int, Float64})==Tr2{Int, Float64}
+@test trait(Tr2{Int, Float32})==Not{Tr2{Int, Float32}}
+
+# trait functions
+@traitfn f{X; Tr1{X}}(x::X) = 1  # def 1
+@traitfn f{X; !Tr1{X}}(x::X) = 2
+@test f(5)==1
+@test f(5.)==2
+
+@traitfn f{X,Y; Tr2{X,Y}}(x::X,y::Y,z) = 1
+@test f(5,5., "a")==1
+@test_throws MethodError f(5,5, "a")==2
+@traitfn f{X,Y; !Tr2{X,Y}}(x::X,y::Y,z) = 2
+@test f(5,5, "a")==2
+
+# This will overwrite the definition def1 above
+@traitfn f{X; !Tr2{X,X}}(x::X) = 10
+@traitfn f{X; Tr2{X,X}}(x::X) = 100
+@test f(5)==10
+@test f(5.)==10
+@traitimpl Tr2{Integer, Integer}
+@test f(5.)==10
+@test !(f(5)==100)
+# need to update method cache:
+@traitfn f{X; Tr2{X,X}}(x::X) = 100
+@test f(5)==100
+@test f(5.)==10
+
+# VarArg
+@traitfn g{X; Tr1{X}}(x::X, y...) = y
+@test g(5, 7, 8)==((7,8),)
+# @test g(5.0, 7, 8)==((7,8),) # hangs because of https://github.com/JuliaLang/julia/issues/13183
+@traitfn g{X; !Tr1{X}}(x::X, y...) = 99
+@test g(5.0, 7, 8)==99
+
+######
+# Other tests
+#####
+@test istrait(IsAnything{Any})
+@test istrait(IsAnything{Union{}})
+@test istrait(IsAnything{Int})
+
+@test !istrait(IsNothing{Any})
+@test !istrait(IsNothing{Union{}})
+@test !istrait(IsNothing{Int})
+
+@test !istrait(IsCallable{Float64})
+@test istrait(IsCallable{Function})
+
+## TODO: activate once these are done
+# @test istrait(IsBits{Int})
+# @test !istrait(IsBits{Vector{Int}})
+
+# @test istrait(IsImmutable{Float64})
+# @test !istrait(IsImmutable{Vector{Int}})
+
+# if VERSION>v"0.4-" # use @generated functions
+#     @test istrait(IsContiguous{SubArray{Int64,1,Array{Int64,1},Tuple{UnitRange{Int64}},1}})
+#     @test !istrait(IsContiguous{SubArray{Int64,1,Array{Int64,1},Tuple{StepRange{Int64,Int64}},1}})
+
+#     @test istrait(IsFastLinearIndex{Vector})
+#     @test !istrait(IsFastLinearIndex{AbstractArray})
+
+#     @test istrait(IsCallable{Base.AddFun})
+# end
+end


### PR DESCRIPTION
This PR implements macro-sugar for Holy Traits (HT).  This is [SimpleTraits.jl](https://github.com/mauro3/SimpleTraits.jl) ported to Base (so to check it out, cloning SimpleTraits will be faster than building this PR).

The idea behind this PR is to make HT easier to use.  An added benefit is that this marks them, so they could be easily updated once a more proper trait system is in place.  (I suspect that the semantics of a trait-system-to-be will be a superset of HT, so the migration should be reasonably easy.)  At the moment only the linear-indexing HT is in Base, but judging by the chat on julia-issues this may change (e.g. JuliaLang/LinearAlgebra.jl#255, JuliaLang/LinearAlgebra.jl#186, ...), thus a more structured approach may make sense.

The readme of [SimpleTraits.jl](https://github.com/mauro3/SimpleTraits.jl) gives an overview of the functionality.  The short is:

``` julia
@traitdef LinearFastTr{X}
@traitimpl LinearFastTr{Array}
@traitimpl LinearFastTr{Range}
@traitfn f1{X<:AbstractArray;  LinearFastTr{X}}(a::X) = 1
@traitfn f1{X<:AbstractArray; !LinearFastTr{X}}(a::X) = 2
f1(1:3)      # -> 1
f1([1,2])    # -> 1
f1(speye(2)) # -> 2
```

which is quite a bit shorter and more readable than the manual implementation (as done for `LinearIndexing` in Base):

``` julia
# the trait
abstract LinearIndexing
immutable LinearFast <: LinearIndexing end
immutable LinearSlow <: LinearIndexing end

# the trait-implementation
linearindexing(A::AbstractArray) = linearindexing(typeof(A))
linearindexing{T<:AbstractArray}(::Type{T}) = LinearSlow()
linearindexing{T<:Array}(::Type{T}) = LinearFast()
linearindexing{T<:Range}(::Type{T}) = LinearFast()

# a traitfunction
@inline f2(A::AbstractArray) = f2(linearindexing(A), A)
f2(::LinearFast, A::AbstractArray) = 1
f2(::LinearSlow, A::AbstractArray) = 2

# use it
f2(1:3)      # -> 1
f2([1,2])    # -> 1
f2(speye(2)) # -> 2
```

For testing and illustrating, I've implemented some HT usages in Base (which should be purged again).  The next step would be to refactor the `LinearIndexing` HT (the only HT currently used in Base, as far as I know).  However, before embarking on that reasonably big task, I have this question: _Does this PR have any chance of being merged?_ (Any other comments are of course welcome too!)

Other things to consider:
- function/macro names?
- should the HT-interface be exported?
# TODO
- [ ] refactor `LinearIndexing` trait
- [ ] add documentation
- [ ] move to earlier in the bootstrap?
- [ ] add doc-capability to traitfn after JuliaLang/julia#13006

Remove:
- [ ] example HTs
- [ ] bootstrap tests
