### PR TITLE
Workaround incorrect Uint deprecation message

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -160,6 +160,7 @@ end
 
 @deprecate_binding String AbstractString
 
+# 13221 - when removing Uint deprecation, remove hack in jl_binding_deprecation_warning
 @deprecate_binding Uint    UInt
 @deprecate_binding Uint8   UInt8
 @deprecate_binding Uint16  UInt16

--- a/src/module.c
+++ b/src/module.c
@@ -489,7 +489,15 @@ void jl_binding_deprecation_warning(jl_binding_t *b)
         jl_value_t *v = b->value;
         if (v && (jl_is_type(v) || (jl_is_function(v) && jl_is_gf(v)))) {
             jl_printf(JL_STDERR, ", use ");
-            jl_static_show(JL_STDERR, v);
+            if (b->owner && strcmp(b->owner->name->name, "Base") == 0 &&
+                strcmp(b->name->name, "Uint") == 0) {
+                // TODO: Suggesting type b->value is wrong for typealiases.
+                // Uncommon in Base, hardcoded here for now, see #13221
+                jl_printf(JL_STDERR, "UInt");
+            }
+            else {
+                jl_static_show(JL_STDERR, v);
+            }
             jl_printf(JL_STDERR, " instead");
         }
         jl_printf(JL_STDERR, ".\n");


### PR DESCRIPTION
The Uint deprecation warning suggested a system dependent type (UInt64 or UInt32) rather than UInt, due to this being a type alias.  Hardcode a warning message for this rather common type, pending a more powerful deprecation warning system.

See #13221.  I hope this is what Jeff had in mind as a quick patch for 0.4... it's pretty disgusting :-)

Fixes https://github.com/JuliaLang/julia/issues/13221
