### PR TITLE
Refactor names of BigFloat precision functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,16 @@ Library improvements
 Deprecated or removed
 ---------------------
 
+  * The following function names have been simplified and unified ([#13232]):
+
+    * `get_bigfloat_precision`  -> `precision(BigFloat)`
+    * `set_bigfloat_precision`  -> `setprecision`
+    * `with_bigfloat_precision` -> `setprecision`
+
+    * `get_rounding`            -> `rounding`
+    * `set_rounding`            -> `setrounding`
+    * `with_rounding`           -> `setrounding`
+
   * The method `A_ldiv_B!(SparseMatrixCSC, StrideVecOrMat)` has been deprecated
     in favor of versions that require the matrix to be in factored form
     ([#13496]).
@@ -987,7 +997,7 @@ Deprecated or removed
 
   * The `Stat` type is renamed `StatStruct` ([#4670]).
 
-  * `set_rounding`, `get_rounding` and `with_rounding` now take an additional
+  * `setrounding`, `rounding` and `setrounding` now take an additional
     argument specifying the floating point type to which they apply. The old
     behaviour and `[get/set/with]_bigfloat_rounding` functions are deprecated ([#5007]).
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -843,6 +843,15 @@ for f in (:remotecall, :remotecall_fetch, :remotecall_wait)
     end
 end
 
+# 13232
+@deprecate with_bigfloat_precision setprecision
+@deprecate set_bigfloat_precision(prec) setprecision(prec)
+@deprecate get_bigfloat_precision() precision(BigFloat)
+
+@deprecate set_rounding setrounding
+@deprecate with_rounding setrounding
+@deprecate get_rounding rounding
+
 #13465
 @deprecate cov(x::AbstractVector; corrected=true, mean=Base.mean(x)) covm(x, mean, corrected)
 @deprecate cov(X::AbstractMatrix; vardim=1, corrected=true, mean=Base.mean(X, vardim)) covm(X, mean, vardim, corrected)

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -1238,20 +1238,6 @@ For matrices or vectors $A$ and $B$, calculates $Aᴴ / B$
 """
 Ac_rdiv_B
 
-doc"""
-```rst
-..  set_rounding(T, mode)
-
-Set the rounding mode of floating point type ``T``, controlling the
-rounding of basic arithmetic functions (:func:`+`, :func:`-`, :func:`*`,
-:func:`/` and :func:`sqrt`) and type conversion.
-
-Note that this may affect other types, for instance changing the rounding
-mode of ``Float64`` will change the rounding mode of ``Float32``. See
-``get_rounding`` for available modes
-```
-"""
-set_rounding
 
 doc"""
     linspace(start, stop, n=100)
@@ -1700,7 +1686,7 @@ julia> Float32(1/3, RoundUp)
 0.33333334f0
 ```
 
-See `get_rounding` for available rounding modes.
+See `rounding` for available rounding modes.
 """
 Float32
 
@@ -3122,7 +3108,7 @@ doc"""
 ..  round([T,] x, [digits, [base]], [r::RoundingMode])
 
 ``round(x)`` rounds ``x`` to an integer value according to the default
-rounding mode (see :func:`get_rounding`), returning a value of the same type as
+rounding mode (see :func:`rounding`), returning a value of the same type as
 ``x``. By default (:obj:`RoundNearest`), this will round to the nearest
 integer, with ties (fractional values of 0.5) being rounded to the even
 integer.
@@ -3854,7 +3840,7 @@ julia> Float64(pi, RoundUp)
 3.1415926535897936
 ```
 
-See `get_rounding` for available rounding modes.
+See `rounding` for available rounding modes.
 """
 Float64
 
@@ -6222,7 +6208,7 @@ isreadonly
 
 doc"""
 ```rst
-..  get_rounding(T)
+..  rounding(T)
 
 Get the current floating point rounding mode for type ``T``, controlling
 the rounding of basic arithmetic functions (:func:`+`, :func:`-`,
@@ -6232,7 +6218,7 @@ Valid modes are ``RoundNearest``, ``RoundToZero``, ``RoundUp``,
 ``RoundDown``, and ``RoundFromZero`` (``BigFloat`` only).
 ```
 """
-get_rounding
+rounding
 
 doc"""
 ```rst
@@ -6447,18 +6433,33 @@ Like `broadcast_function`, but for `broadcast!`.
 broadcast!_function
 
 doc"""
-    with_rounding(f::Function, T, mode)
+```rst
+..  setrounding(T, mode)
+
+Set the rounding mode of floating point type ``T``, controlling the
+rounding of basic arithmetic functions (:func:`+`, :func:`-`, :func:`*`,
+:func:`/` and :func:`sqrt`) and type conversion.
+
+Note that this may affect other types, for instance changing the rounding
+mode of ``Float64`` will change the rounding mode of ``Float32``. See
+``rounding`` for available modes
+```
+"""
+setrounding(T, mode)
+
+doc"""
+    setrounding(f::Function, T, mode)
 
 Change the rounding mode of floating point type `T` for the duration of `f`. It is logically equivalent to:
 
-    old = get_rounding(T)
-    set_rounding(T, mode)
+    old = rounding(T)
+    setrounding(T, mode)
     f()
-    set_rounding(T, old)
+    setrounding(T, old)
 
-See `get_rounding` for available rounding modes.
+See `rounding` for available rounding modes.
 """
-with_rounding
+setrounding(f::Function, T, mode)
 
 doc"""
     sleep(seconds)
@@ -7808,11 +7809,11 @@ Join path components into a full path. If some argument is an absolute path, the
 joinpath
 
 doc"""
-    get_bigfloat_precision()
+    precision(BigFloat)
 
 Get the precision (in bits) currently used for `BigFloat` arithmetic.
 """
-get_bigfloat_precision
+precision(::Type{BigFloat})
 
 doc"""
     homedir() -> AbstractString
@@ -8441,16 +8442,16 @@ Compute $e^x$.
 exp
 
 doc"""
-    with_bigfloat_precision(f::Function,precision::Integer)
+    setprecision(f::Function, precision::Integer)
 
 Change the `BigFloat` arithmetic precision (in bits) for the duration of `f`. It is logically equivalent to:
 
-    old = get_bigfloat_precision()
-    set_bigfloat_precision(precision)
+    old = precision(BigFloat)
+    setprecision(BigFloat, precision)
     f()
-    set_bigfloat_precision(old)
+    setprecision(BigFloat, old)
 """
-with_bigfloat_precision
+setprecision
 
 doc"""
     searchindex(string, substring, [start])
@@ -9527,11 +9528,11 @@ Test whether a vector is in sorted order. The `by`, `lt` and `rev` keywords modi
 issorted
 
 doc"""
-    set_bigfloat_precision(x::Int64)
+    setprecision(x::Int64)
 
 Set the precision (in bits) to be used to `BigFloat` arithmetic.
 """
-set_bigfloat_precision
+setprecision
 
 doc"""
     isbits(T)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -912,12 +912,9 @@ export
 
 # bigfloat & precision
     precision,
-    get_bigfloat_precision,
-    set_bigfloat_precision,
-    with_bigfloat_precision,
-    get_rounding,
-    set_rounding,
-    with_rounding,
+    rounding,
+    setprecision,
+    setrounding,
     get_zero_subnormals,
     set_zero_subnormals,
 

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -205,5 +205,5 @@ end
 # This is necessary at least on 32-bit Intel Linux, since fma_llvm may
 # have called glibc, and some broken glibc fma implementations don't
 # properly restore the rounding mode
-Rounding.set_rounding_raw(Float32, Rounding.JL_FE_TONEAREST)
-Rounding.set_rounding_raw(Float64, Rounding.JL_FE_TONEAREST)
+Rounding.setrounding_raw(Float32, Rounding.JL_FE_TONEAREST)
+Rounding.setrounding_raw(Float64, Rounding.JL_FE_TONEAREST)

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -34,10 +34,10 @@ end
 <(x::Float32, y::Irrational) = x <= Float32(y,RoundDown)
 <(x::Irrational, y::Float16) = Float32(x,RoundUp) <= y
 <(x::Float16, y::Irrational) = x <= Float32(y,RoundDown)
-<(x::Irrational, y::BigFloat) = with_bigfloat_precision(precision(y)+32) do
+<(x::Irrational, y::BigFloat) = setprecision(precision(y)+32) do
     big(x) < y
 end
-<(x::BigFloat, y::Irrational) = with_bigfloat_precision(precision(x)+32) do
+<(x::BigFloat, y::Irrational) = setprecision(precision(x)+32) do
     x < big(y)
 end
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -4,10 +4,7 @@ module MPFR
 
 export
     BigFloat,
-    get_bigfloat_precision,
-    set_bigfloat_precision,
-    with_bigfloat_precision,
-    bigfloat_str,
+    setprecision,
     big_str
 
 import
@@ -20,10 +17,10 @@ import
         gamma, lgamma, digamma, erf, erfc, zeta, eta, log1p, airyai,
         eps, signbit, sin, cos, tan, sec, csc, cot, acos, asin, atan,
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, atan2,
-        cbrt, typemax, typemin, unsafe_trunc, realmin, realmax, get_rounding,
-        set_rounding, maxintfloat, widen, significand, frexp, tryparse
+        cbrt, typemax, typemin, unsafe_trunc, realmin, realmax, rounding,
+        setrounding, maxintfloat, widen, significand, frexp, tryparse
 
-import Base.Rounding: get_rounding_raw, set_rounding_raw
+import Base.Rounding: rounding_raw, setrounding_raw
 
 import Base.GMP: ClongMax, CulongMax, CdoubleMax
 
@@ -51,7 +48,7 @@ type BigFloat <: AbstractFloat
     exp::Clong
     d::Ptr{Culong}
     function BigFloat()
-        N = get_bigfloat_precision()
+        N = precision(BigFloat)
         z = new(zero(Clong), zero(Cint), zero(Clong), C_NULL)
         ccall((:mpfr_init2,:libmpfr), Void, (Ptr{BigFloat}, Clong), &z, N)
         finalizer(z, Base.GMP._mpfr_clear_func)
@@ -681,20 +678,33 @@ cmp(x::CdoubleMax, y::BigFloat) = -cmp(y,x)
 
 signbit(x::BigFloat) = ccall((:mpfr_signbit, :libmpfr), Int32, (Ptr{BigFloat},), &x) != 0
 
-function precision(x::BigFloat)
+function precision(x::BigFloat)  # precision of an object of type BigFloat
     return ccall((:mpfr_get_prec, :libmpfr), Clong, (Ptr{BigFloat},), &x)
 end
 
-get_bigfloat_precision() = DEFAULT_PRECISION[end]
-function set_bigfloat_precision(x::Int)
-    if x < 2
+precision(::Type{BigFloat}) = DEFAULT_PRECISION[end]  # precision of the type BigFloat itself
+
+doc"""
+    setprecision(T, precision)
+
+Set precision of type `T`.
+"""
+function setprecision(::Type{BigFloat}, precision::Int)
+    if precision < 2
         throw(DomainError())
     end
-    DEFAULT_PRECISION[end] = x
+    DEFAULT_PRECISION[end] = precision
 end
 
+doc"""
+    setprecision(precision)
+
+Set the precision of `BigFloat`
+"""
+setprecision(precision::Int) = setprecision(BigFloat, precision)
+
 maxintfloat(x::BigFloat) = BigFloat(2)^precision(x)
-maxintfloat(::Type{BigFloat}) = BigFloat(2)^get_bigfloat_precision()
+maxintfloat(::Type{BigFloat}) = BigFloat(2)^precision(BigFloat)
 
 to_mpfr(::RoundingMode{:Nearest}) = Cint(0)
 to_mpfr(::RoundingMode{:ToZero}) = Cint(1)
@@ -719,10 +729,11 @@ function from_mpfr(c::Integer)
     RoundingMode(c)
 end
 
-get_rounding_raw(::Type{BigFloat}) = ROUNDING_MODE[end]
-set_rounding_raw(::Type{BigFloat},i::Integer) = ROUNDING_MODE[end] = i
-get_rounding(::Type{BigFloat}) = from_mpfr(get_rounding_raw(BigFloat))
-set_rounding(::Type{BigFloat},r::RoundingMode) = set_rounding_raw(BigFloat,to_mpfr(r))
+rounding_raw(::Type{BigFloat}) = ROUNDING_MODE[end]
+setrounding_raw(::Type{BigFloat},i::Integer) = ROUNDING_MODE[end] = i
+
+rounding(::Type{BigFloat}) = from_mpfr(rounding_raw(BigFloat))
+setrounding(::Type{BigFloat},r::RoundingMode) = setrounding_raw(BigFloat,to_mpfr(r))
 
 function copysign(x::BigFloat, y::BigFloat)
     z = BigFloat()
@@ -813,15 +824,29 @@ eps(::Type{BigFloat}) = nextfloat(BigFloat(1)) - BigFloat(1)
 realmin(::Type{BigFloat}) = nextfloat(zero(BigFloat))
 realmax(::Type{BigFloat}) = prevfloat(BigFloat(Inf))
 
-function with_bigfloat_precision(f::Function, precision::Integer)
-    old_precision = get_bigfloat_precision()
-    set_bigfloat_precision(precision)
+doc"""
+    setprecision(f::Function, T, precision)
+
+Set the precision of the type `T` for the duration of the function `f`.
+Often used as `setprecision(T, precision) do ... end`
+"""
+function setprecision{T}(f::Function, ::Type{T}, prec::Integer)
+    old_prec = precision(T)
+    setprecision(T, prec)
     try
         return f()
     finally
-        set_bigfloat_precision(old_precision)
+        setprecision(T, old_prec)
     end
 end
+
+doc"""
+    setprecision(f::Function, precision::Integer)
+
+Set the `BigFloat` precision for the duration of the function `f`.
+Often used as `setprecision(precision) do ... end`
+"""
+setprecision(f::Function, precision::Integer) = setprecision(f, BigFloat, precision)
 
 function string(x::BigFloat)
     # In general, the number of decimal places needed to read back the number exactly

--- a/base/quadgk.jl
+++ b/base/quadgk.jl
@@ -79,7 +79,7 @@ function evalrule(f, a,b, x,w,gw, nrm)
     return Segment(a, b, Ik, E)
 end
 
-rulekey(::Type{BigFloat}, n) = (BigFloat, get_bigfloat_precision(), n)
+rulekey(::Type{BigFloat}, n) = (BigFloat, precision(BigFloat), n)
 rulekey(T,n) = (T,n)
 
 # Internal routine: integrate f over the union of the open intervals

--- a/contrib/BBEditTextWrangler-julia.plist
+++ b/contrib/BBEditTextWrangler-julia.plist
@@ -477,9 +477,6 @@
               <string>gensym</string>
               <string>get</string>
               <string>get!</string>
-              <string>get_bigfloat_precision</string>
-              <string>get_bigfloat_rounding</string>
-              <string>get_rounding</string>
               <string>getaddrinfo</string>
               <string>gethostname</string>
               <string>getindex</string>
@@ -901,6 +898,7 @@
               <string>rotl90</string>
               <string>rotr90</string>
               <string>round</string>
+              <string>rounding</string>
               <string>rpad</string>
               <string>rref</string>
               <string>rsearch</string>
@@ -930,14 +928,13 @@
               <string>select!</string>
               <string>send</string>
               <string>serialize</string>
-              <string>set_bigfloat_precision</string>
-              <string>set_bigfloat_rounding</string>
-              <string>set_rounding</string>
               <string>setdiff</string>
               <string>setdiff!</string>
               <string>setenv</string>
               <string>setfield</string>
               <string>setindex!</string>
+              <string>setprecision</string>
+              <string>setrounding</string>
               <string>shift!</string>
               <string>show</string>
               <string>showall</string>
@@ -1103,9 +1100,6 @@
               <string>whos</string>
               <string>widemul</string>
               <string>widen</string>
-              <string>with_bigfloat_precision</string>
-              <string>with_bigfloat_rounding</string>
-              <string>with_rounding</string>
               <string>workers</string>
               <string>workspace</string>
               <string>write</string>

--- a/doc/manual/integers-and-floating-point-numbers.rst
+++ b/doc/manual/integers-and-floating-point-numbers.rst
@@ -512,7 +512,7 @@ presented in the `IEEE 754 standard <https://en.wikipedia.org/wiki/IEEE_754-2008
     julia> 1.1 + 0.1
     1.2000000000000002
 
-    julia> with_rounding(Float64,RoundDown) do
+    julia> setrounding(Float64,RoundDown) do
            1.1 + 0.1
            end
     1.2
@@ -619,26 +619,25 @@ However, type promotion between the primitive types above and
 
 The default precision (in number of bits of the significand) and
 rounding mode of :class:`BigFloat` operations can be changed globally
-by calling :func:`set_bigfloat_precision` and
-:func:`set_rounding`, and all further calculations will take
+by calling :func:`setprecision` and
+:func:`setrounding`, and all further calculations will take
 these changes in account.  Alternatively, the precision or the
 rounding can be changed only within the execution of a particular
-block of code by :func:`with_bigfloat_precision` or
-:func:`with_rounding`:
+block of code by using the same functions with a `do` block:
 
 .. doctest::
 
-    julia> with_rounding(BigFloat,RoundUp) do
+    julia> setrounding(BigFloat, RoundUp) do
            BigFloat(1) + parse(BigFloat, "0.1")
            end
     1.100000000000000000000000000000000000000000000000000000000000000000000000000003
 
-    julia> with_rounding(BigFloat,RoundDown) do
+    julia> setrounding(BigFloat, RoundDown) do
            BigFloat(1) + parse(BigFloat, "0.1")
            end
     1.099999999999999999999999999999999999999999999999999999999999999999999999999986
 
-    julia> with_bigfloat_precision(40) do
+    julia> setprecision(40) do
            BigFloat(1) + parse(BigFloat, "0.1")
            end
     1.1000000000004
@@ -778,4 +777,3 @@ Examples:
 
     julia> one(BigFloat)
     1.000000000000000000000000000000000000000000000000000000000000000000000000000000
-

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -892,7 +892,7 @@ Mathematical Functions
    .. Docstring generated from Julia source
 
    ``round(x)`` rounds ``x`` to an integer value according to the default
-   rounding mode (see :func:`get_rounding`), returning a value of the same type as
+   rounding mode (see :func:`rounding`), returning a value of the same type as
    ``x``. By default (:obj:`RoundNearest`), this will round to the nearest
    integer, with ties (fractional values of 0.5) being rounded to the even
    integer.

--- a/doc/stdlib/numbers.rst
+++ b/doc/stdlib/numbers.rst
@@ -293,7 +293,7 @@ General Number Functions and Constants
        julia> Float32(1/3, RoundUp)
        0.33333334f0
 
-   See ``get_rounding`` for available rounding modes.
+   See ``rounding`` for available rounding modes.
 
 .. function:: Float64(x [, mode::RoundingMode])
 
@@ -309,7 +309,7 @@ General Number Functions and Constants
        julia> Float64(pi, RoundUp)
        3.1415926535897936
 
-   See ``get_rounding`` for available rounding modes.
+   See ``rounding`` for available rounding modes.
 
 .. function:: BigInt(x)
 
@@ -344,7 +344,7 @@ General Number Functions and Constants
       julia> big"2.1"
       2.099999999999999999999999999999999999999999999999999999999999999999999999999986
 
-.. function:: get_rounding(T)
+.. function:: rounding(T)
 
    .. Docstring generated from Julia source
 
@@ -355,7 +355,7 @@ General Number Functions and Constants
    Valid modes are ``RoundNearest``, ``RoundToZero``, ``RoundUp``,
    ``RoundDown``, and ``RoundFromZero`` (``BigFloat`` only).
 
-.. function:: set_rounding(T, mode)
+.. function:: setrounding(T, mode)
 
    .. Docstring generated from Julia source
 
@@ -365,9 +365,9 @@ General Number Functions and Constants
 
    Note that this may affect other types, for instance changing the rounding
    mode of ``Float64`` will change the rounding mode of ``Float32``. See
-   ``get_rounding`` for available modes
+   ``rounding`` for available modes
 
-.. function:: with_rounding(f::Function, T, mode)
+.. function:: setrounding(f::Function, T, mode)
 
    .. Docstring generated from Julia source
 
@@ -375,12 +375,12 @@ General Number Functions and Constants
 
    .. code-block:: julia
 
-       old = get_rounding(T)
-       set_rounding(T, mode)
+       old = rounding(T)
+       setrounding(T, mode)
        f()
-       set_rounding(T, old)
+       setrounding(T, old)
 
-   See ``get_rounding`` for available rounding modes.
+   See ``rounding`` for available rounding modes.
 
 .. function:: get_zero_subnormals() -> Bool
 
@@ -537,30 +537,23 @@ The ``BigFloat`` type implements arbitrary-precision floating-point arithmetic u
 
    Get the precision of a floating point number, as defined by the effective number of bits in the mantissa.
 
-.. function:: get_bigfloat_precision()
+.. function:: precision(BigFloat)
 
    .. Docstring generated from Julia source
 
    Get the precision (in bits) currently used for ``BigFloat`` arithmetic.
 
-.. function:: set_bigfloat_precision(x::Int64)
+.. function:: setprecision(x::Int64)
 
    .. Docstring generated from Julia source
 
    Set the precision (in bits) to be used to ``BigFloat`` arithmetic.
 
-.. function:: with_bigfloat_precision(f::Function,precision::Integer)
+.. function:: setprecision(f::Function, precision::Integer)
 
    .. Docstring generated from Julia source
 
-   Change the ``BigFloat`` arithmetic precision (in bits) for the duration of ``f``\ . It is logically equivalent to:
-
-   .. code-block:: julia
-
-       old = get_bigfloat_precision()
-       set_bigfloat_precision(precision)
-       f()
-       set_bigfloat_precision(old)
+   Set the ``BigFloat`` precision for the duration of the function ``f``\ . Often used as ``setprecision(precision) do ... end``
 
 .. _random-numbers:
 

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -140,7 +140,7 @@ nHilbert = 50
 H = Rational{BigInt}[1//(i+j-1) for i = 1:nHilbert,j = 1:nHilbert]
 Hinv = Rational{BigInt}[(-1)^(i+j)*(i+j-1)*binomial(nHilbert+i-1,nHilbert-j)*binomial(nHilbert+j-1,nHilbert-i)*binomial(i+j-2,i-1)^2 for i = big(1):nHilbert,j=big(1):nHilbert]
 @test inv(H) == Hinv
-with_bigfloat_precision(2^10) do
+setprecision(2^10) do
     @test norm(Array{Float64}(inv(float(H)) - float(Hinv))) < 1e-100
 end
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -647,7 +647,7 @@ end
 for n = 0:28
     @test log(2,2^n) == n
 end
-with_bigfloat_precision(10_000) do
+setprecision(10_000) do
     @test log(2,big(2)^100) == 100
     @test log(2,big(2)^200) == 200
     @test log(2,big(2)^300) == 300

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -2,7 +2,7 @@
 
 import Base.MPFR
 # constructors
-with_bigfloat_precision(53) do
+setprecision(53) do
     x = BigFloat()
     x = BigFloat(12)
 end
@@ -90,16 +90,16 @@ z = BigFloat(30)
 @test !(y <= z)
 
 # rounding modes
-with_bigfloat_precision(4) do
+setprecision(4) do
     # default mode is round to nearest
-    down, up =  with_rounding(BigFloat,RoundNearest) do
+    down, up =  setrounding(BigFloat,RoundNearest) do
         parse(BigFloat,"0.0938"), parse(BigFloat,"0.102")
     end
-    with_rounding(BigFloat,RoundDown) do
+    setrounding(BigFloat,RoundDown) do
         @test BigFloat(0.1) == down
         @test BigFloat(0.1) != up
     end
-    with_rounding(BigFloat,RoundUp) do
+    setrounding(BigFloat,RoundUp) do
         @test BigFloat(0.1) != down
         @test BigFloat(0.1) == up
     end
@@ -188,14 +188,14 @@ prevfloat(y)
 @test_throws DomainError sqrt(BigFloat(-1))
 
 # precision
-old_precision = get_bigfloat_precision()
+old_precision = precision(BigFloat)
 x = BigFloat(0)
 @test precision(x) == old_precision
-set_bigfloat_precision(256)
+setprecision(256)
 x = BigFloat(0)
 @test precision(x) == 256
-set_bigfloat_precision(old_precision)
-z = with_bigfloat_precision(240) do
+setprecision(old_precision)
+z = setprecision(240) do
     z = x + 20
     return z
 end
@@ -203,14 +203,14 @@ end
 @test precision(z) == 240
 x = BigFloat(12)
 @test precision(x) == old_precision
-@test_throws DomainError set_bigfloat_precision(1)
+@test_throws DomainError setprecision(1)
 
 # isinteger
 @test isinteger(BigFloat(12))
 @test !isinteger(BigFloat(12.12))
 
 # nextfloat / prevfloat
-with_bigfloat_precision(53) do
+setprecision(53) do
     x = BigFloat(12.12)
     @test BigFloat(nextfloat(12.12)) == nextfloat(x)
     @test BigFloat(prevfloat(12.12)) == prevfloat(x)
@@ -274,7 +274,7 @@ y = modf(x)
 @test (isnan(y[1]), isinf(y[2])) == (true, true)
 
 # rem
-with_bigfloat_precision(53) do
+setprecision(53) do
     x = BigFloat(2)
     y = BigFloat(1.67)
     @test rem(x,y) == rem(2, 1.67)
@@ -310,13 +310,13 @@ big_array = ones(BigFloat, 100)
 # promotion
 # the array converts everyone to the DEFAULT_PRECISION!
 x = BigFloat(12)
-y = with_bigfloat_precision(60) do
+y = setprecision(60) do
     BigFloat(42)
 end
 @test [x,y] == [BigFloat(12), BigFloat(42)]
 
 # log / log2 / log10
-with_bigfloat_precision(53) do
+setprecision(53) do
 x = BigFloat(42)
     @test log(x) == log(42)
     @test isinf(log(BigFloat(0)))
@@ -330,7 +330,7 @@ x = BigFloat(42)
 end
 
 # exp / exp2 / exp10
-with_bigfloat_precision(53) do
+setprecision(53) do
     x = BigFloat(10)
     @test exp(x) == exp(10)
     @test exp2(x) == 1024
@@ -353,7 +353,7 @@ y = BigFloat(42)
 
 # round
 x = BigFloat(42.42)
-y = with_bigfloat_precision(256) do
+y = setprecision(256) do
     parse(BigFloat,"9223372036854775809.2324")
 end
 z = parse(BigInt,"9223372036854775809")
@@ -369,20 +369,20 @@ z = parse(BigInt,"9223372036854775809")
 
 # string representation
 str = "1.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000012"
-with_bigfloat_precision(406) do
+setprecision(406) do
     @test string(nextfloat(BigFloat(1))) == str
 end
-with_bigfloat_precision(21) do
+setprecision(21) do
     @test string(zero(BigFloat)) == "0.0000000"
     @test string(parse(BigFloat, "0.1")) == "1.0000002e-01"
     @test string(parse(BigFloat, "-9.9")) == "-9.9000015"
 end
-with_bigfloat_precision(40) do
+setprecision(40) do
     @test string(zero(BigFloat)) == "0.0000000000000"
     @test string(parse(BigFloat, "0.1")) == "1.0000000000002e-01"
     @test string(parse(BigFloat, "-9.9")) == "-9.8999999999942"
 end
-with_bigfloat_precision(123) do
+setprecision(123) do
     @test string(zero(BigFloat)) == "0.00000000000000000000000000000000000000"
     @test string(parse(BigFloat, "0.1")) == "9.99999999999999999999999999999999999953e-02"
     @test string(parse(BigFloat, "-9.9")) == "-9.8999999999999999999999999999999999997"
@@ -402,7 +402,7 @@ x = realmax(BigFloat)
 @test isinf(nextfloat(x))
 
 # factorial
-with_bigfloat_precision(256) do
+setprecision(256) do
     x = BigFloat(42)
     @test factorial(x) == factorial(BigInt(42))
     x = BigFloat(10)
@@ -412,7 +412,7 @@ with_bigfloat_precision(256) do
 end
 
 # bessel functions
-with_bigfloat_precision(53) do
+setprecision(53) do
     @test_approx_eq besselj(4, BigFloat(2)) besselj(4, 2.)
     @test_approx_eq besselj0(BigFloat(2))  besselj0(2.)
     @test_approx_eq besselj1(BigFloat(2))  besselj1(2.)
@@ -422,7 +422,7 @@ with_bigfloat_precision(53) do
 end
 
 # trigonometric functions
-with_bigfloat_precision(53) do
+setprecision(53) do
     for f in (:sin,:cos,:tan,:sec,:csc,:cot,:acos,:asin,:atan,
             :cosh,:sinh,:tanh,:sech,:csch,:coth,:asinh),
         j in (-1., -0.5, -0.25, .25, .5, 1.)
@@ -452,12 +452,12 @@ end
 @test hypot(BigFloat(3), BigFloat(4)) == 5
 
 # atan2
-with_bigfloat_precision(53) do
+setprecision(53) do
     @test atan2(12,2) == atan2(BigFloat(12), BigFloat(2))
 end
 
 # ldexp
-with_bigfloat_precision(53) do
+setprecision(53) do
     @test ldexp(BigFloat(24.5), 72) == ldexp(24.5, 72)
     @test ldexp(BigFloat(24.5), Int16(72)) == ldexp(24.5, 72)
     @test ldexp(BigFloat(24.5), -72) == ldexp(24.5, -72)

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -18,7 +18,7 @@ d = prevfloat(1.)
 @test b - a === c
 
 # RoundToZero
-with_rounding(Float64,RoundToZero) do
+setrounding(Float64,RoundToZero) do
     @test a + b === d
     @test - a - b === -d
     @test a - b === -c
@@ -32,7 +32,7 @@ end
 @test b - a == c
 
 # RoundUp
-with_rounding(Float64,RoundUp) do
+setrounding(Float64,RoundUp) do
     @test a + b === 1.
     @test - a - b === -d
     @test a - b === -c
@@ -40,7 +40,7 @@ with_rounding(Float64,RoundUp) do
 end
 
 # RoundDown
-with_rounding(Float64,RoundDown) do
+setrounding(Float64,RoundDown) do
     @test a + b === d
     @test - a - b === -1.
     @test a - b === -c
@@ -61,7 +61,7 @@ d32 = prevfloat(1.0f0)
 @test b32 - a32 === c32
 
 # RoundToZero
-with_rounding(Float32,RoundToZero) do
+setrounding(Float32,RoundToZero) do
     @test a32 + b32 === d32
     @test - a32 - b32 === -d32
     @test a32 - b32 === -c32
@@ -75,7 +75,7 @@ end
 @test b32 - a32 == c32
 
 # RoundUp
-with_rounding(Float32,RoundUp) do
+setrounding(Float32,RoundUp) do
     @test a32 + b32 === 1.0f0
     @test - a32 - b32 === -d32
     @test a32 - b32 === -c32
@@ -83,7 +83,7 @@ with_rounding(Float32,RoundUp) do
 end
 
 # RoundDown
-with_rounding(Float32,RoundDown) do
+setrounding(Float32,RoundDown) do
     @test a32 + b32 === d32
     @test - a32 - b32 === -1.0f0
     @test a32 - b32 === -c32
@@ -96,11 +96,11 @@ for v = [sqrt(2),-1/3,nextfloat(1.0),prevfloat(1.0),nextfloat(-1.0),
     pn = Float32(v,RoundNearest)
     @test pn == convert(Float32,v)
     pz = Float32(v,RoundToZero)
-    @test pz == with_rounding(()->convert(Float32,v), Float64, RoundToZero)
+    @test pz == setrounding(()->convert(Float32,v), Float64, RoundToZero)
     pd = Float32(v,RoundDown)
-    @test pd == with_rounding(()->convert(Float32,v), Float64, RoundDown)
+    @test pd == setrounding(()->convert(Float32,v), Float64, RoundDown)
     pu = Float32(v,RoundUp)
-    @test pu == with_rounding(()->convert(Float32,v), Float64, RoundUp)
+    @test pu == setrounding(()->convert(Float32,v), Float64, RoundUp)
 
     @test pn == pd || pn == pu
     @test v > 0 ? pz == pd : pz == pu
@@ -115,11 +115,11 @@ for T in [Float32,Float64]
         pn = T(v,RoundNearest)
         @test pn == convert(T,BigFloat(v))
         pz = T(v,RoundToZero)
-        @test pz == with_rounding(()->convert(T,BigFloat(v)), BigFloat, RoundToZero)
+        @test pz == setrounding(()->convert(T,BigFloat(v)), BigFloat, RoundToZero)
         pd = T(v,RoundDown)
-        @test pd == with_rounding(()->convert(T,BigFloat(v)), BigFloat, RoundDown)
+        @test pd == setrounding(()->convert(T,BigFloat(v)), BigFloat, RoundDown)
         pu = T(v,RoundUp)
-        @test pu == with_rounding(()->convert(T,BigFloat(v)), BigFloat, RoundUp)
+        @test pu == setrounding(()->convert(T,BigFloat(v)), BigFloat, RoundUp)
 
         @test pn == pd || pn == pu
         @test v > 0 ? pz == pd : pz == pu


### PR DESCRIPTION
This reduces the number of exported names from `Base` by 3  and makes them more flexible to be used with other types with different precisions.
Fixes #13225.

Changes:
- `get_bigfloat_precision()` -> `precision(BigFloat)`
- `set_bigfloat_precision(prec)` -> `setprecision(BigFloat, prec)` and `setprecision(prec)`
- `with_bigfloat_precision(f, prec)` -> `setprecision(f, BigFloat, prec)` and `setprecision(f, prec)`

The idea of reusing `setprecision` instead of `with_bigfloat_precision` is due to @simonbyrne 

Also, for consistency,
- `with_rounding(f, T, rounding_mode)` -> `setrounding(f, T, rounding_mode)`
- `set_rounding(T, rounding_mode)` -> `setrounding(T, rounding_mode)`
- `get_rounding(T)` -> `rounding(T)`
