### PR TITLE
Make |> wellbehaved with regard to splatting

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -1538,8 +1538,9 @@ cconvert
 
 doc"""
     |>(x, f)
+    |>(x, y, ..., f)
 
-Applies a function to the preceding argument. This allows for easy function chaining.
+Applies a function to the preceding argument(s). This allows for easy function chaining.
 
 ```jldoctest
 julia> [1:5;] |> x->x.^2 |> sum |> inv

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -196,6 +196,8 @@ copy(x::Union{Symbol,Number,AbstractString,Function,Tuple,LambdaStaticData,
 
 # function pipelining
 |>(x, f) = f(x)
+|>(x, y, f) = f(x, y)
+|>(args...) = args[end](args[1:end-1]...)
 
 # array shape rules
 

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -48,6 +48,8 @@ p = 1=>:foo
 @test 1 .< 2
 @test 1 .<= 2
 
+@test minmax(2,1)... |> tuple == (1,2) # test splicing in combination with pipelining
+
 # issue #13144: max() with 4 or more array arguments
 let xs = [[i:i+4;] for i in 1:10]
     for n in 2:10


### PR DESCRIPTION
Defines `|>(x,..,z, f) == f(x,...,z)`. This would make the chaining operator `|>` work nicely with splatted arguments. 

Example: 

```
    minmax(2,1)... |> tuple == (1,2)
```

This small change is nonbreaking, motivated by 

 http://stackoverflow.com/questions/32276896/how-to-use-the-pipe-operator-with-tuples-and-anonymous-functions-in-julia/32284433#32284433 
