### PR TITLE
better cmdline option error handling (fixes #12679)

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -207,110 +207,77 @@ function init_bind_addr()
     LPROC.bind_port = UInt16(bind_port)
 end
 
-# NOTE: This set of required arguments need to be kept in sync with the required arguments defined in ui/repl.c
-let reqarg = Set(UTF8String["--home",          "-H",
-                            "--eval",          "-e",
-                            "--print",         "-E",
-                            "--post-boot",     "-P",
-                            "--load",          "-L",
-                            "--sysimage",      "-J",
-                            "--cpu-target",    "-C",
-                            "--procs",         "-p",
-                            "--machinefile",
-                            "--color",
-                            "--history-file",
-                            "--startup-file",
-                            "--compile",
-                            "--check-bounds",
-                            "--depwarn",
-                            "--inline",
-                            "--output-o",
-                            "--output-ji",
-                            "--output-bc",
-                            "--bind-to",
-                            "--precompiled"])
-    global process_options
-    function process_options(opts::JLOptions, args::Vector{UTF8String})
-        if !isempty(args)
-            arg = first(args)
-            if !isempty(arg) && arg[1] == '-' && in(arg, reqarg)
-                println(STDERR, "julia: option `$arg` is missing an argument")
-                exit(1)
-            end
-            idxs = find(x -> x == "--", args)
-            if length(idxs) > 1
-                println(STDERR, "julia: redundant option terminator `--`")
-                exit(1)
-            end
-            deleteat!(ARGS, idxs)
+function process_options(opts::JLOptions, args::Vector{UTF8String})
+    if !isempty(args)
+        arg = first(args)
+        idxs = find(x -> x == "--", args)
+        if length(idxs) > 1
+            println(STDERR, "julia: redundant option terminator `--`")
+            exit(1)
         end
-        repl                  = true
-        startup               = (opts.startupfile != 2)
-        history_file          = (opts.historyfile != 0)
-        quiet                 = (opts.quiet != 0)
-        color_set             = (opts.color != 0)
-        global have_color     = (opts.color == 1)
-        global is_interactive = (opts.isinteractive != 0)
-        while true
-            # load ~/.juliarc file
-            startup && load_juliarc()
+        deleteat!(ARGS, idxs)
+    end
+    repl                  = true
+    startup               = (opts.startupfile != 2)
+    history_file          = (opts.historyfile != 0)
+    quiet                 = (opts.quiet != 0)
+    color_set             = (opts.color != 0)
+    global have_color     = (opts.color == 1)
+    global is_interactive = (opts.isinteractive != 0)
+    while true
+        # load ~/.juliarc file
+        startup && load_juliarc()
 
-            # startup worker
-            if opts.worker != 0
-                start_worker() # does not return
+        # startup worker
+        if opts.worker != 0
+            start_worker() # does not return
+        end
+        # add processors
+        if opts.nprocs > 0
+            addprocs(opts.nprocs)
+        end
+        # load processes from machine file
+        if opts.machinefile != C_NULL
+            addprocs(load_machine_file(bytestring(opts.machinefile)))
+        end
+        # load file immediately on all processors
+        if opts.load != C_NULL
+            @sync for p in procs()
+                @async remotecall_fetch(p, include, bytestring(opts.load))
             end
-            # add processors
-            if opts.nprocs > 0
-                addprocs(opts.nprocs)
-            end
-            # load processes from machine file
-            if opts.machinefile != C_NULL
-                addprocs(load_machine_file(bytestring(opts.machinefile)))
-            end
-            # load file immediately on all processors
-            if opts.load != C_NULL
-                @sync for p in procs()
-                    @async remotecall_fetch(p, include, bytestring(opts.load))
-                end
-            end
-            # eval expression
-            if opts.eval != C_NULL
-                repl = false
-                eval(Main, parse_input_line(bytestring(opts.eval)))
-                break
-            end
-            # eval expression and show result
-            if opts.print != C_NULL
-                repl = false
-                show(eval(Main, parse_input_line(bytestring(opts.print))))
-                println()
-                break
-            end
-            # eval expression but don't disable interactive mode
-            if opts.postboot != C_NULL
-                eval(Main, parse_input_line(bytestring(opts.postboot)))
-            end
-            # load file
-            if !isempty(args)
-                if !isempty(args[1]) && args[1][1] != '-'
-                    # program
-                    repl = false
-                    # remove filename from ARGS
-                    shift!(ARGS)
-                    if !is_interactive
-                        ccall(:jl_exit_on_sigint, Void, (Cint,), 1)
-                    end
-                    include(args[1])
-                else
-                    println(STDERR, "julia: unknown option `$(args[1])`")
-                    exit(1)
-                end
-            end
+        end
+        # eval expression
+        if opts.eval != C_NULL
+            repl = false
+            eval(Main, parse_input_line(bytestring(opts.eval)))
             break
         end
-        repl |= is_interactive
-        return (quiet,repl,startup,color_set,history_file)
+        # eval expression and show result
+        if opts.print != C_NULL
+            repl = false
+            show(eval(Main, parse_input_line(bytestring(opts.print))))
+            println()
+            break
+        end
+        # eval expression but don't disable interactive mode
+        if opts.postboot != C_NULL
+            eval(Main, parse_input_line(bytestring(opts.postboot)))
+        end
+        # load file
+        if !isempty(args) && !isempty(args[1])
+            # program
+            repl = false
+            # remove filename from ARGS
+            shift!(ARGS)
+            if !is_interactive
+                ccall(:jl_exit_on_sigint, Void, (Cint,), 1)
+            end
+            include(args[1])
+        end
+        break
     end
+    repl |= is_interactive
+    return (quiet,repl,startup,color_set,history_file)
 end
 
 const roottask = current_task()

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -193,4 +193,9 @@ let exename = `$(joinpath(JULIA_HOME, Base.julia_exename())) --precompiled=yes`
     # issue #10562
     @test readchomp(`$exename -e 'println(ARGS);' ''`) == "UTF8String[\"\"]"
 
+    # issue #12679
+    @test readchomp(pipeline(ignorestatus(`$exename -f --compile=yes -foo`),stderr=`cat`)) == "ERROR: unknown option `-o`"
+    @test readchomp(pipeline(ignorestatus(`$exename -f -p`),stderr=`cat`)) == "ERROR: option `-p/--procs` is missing an argument"
+    @test readchomp(pipeline(ignorestatus(`$exename -f --inline`),stderr=`cat`)) == "ERROR: option `--inline` is missing an argument"
+    @test readchomp(pipeline(ignorestatus(`$exename -f -e "@show ARGS" -now -- julia RUN.jl`),stderr=`cat`)) == "ERROR: unknown option `-n`"
 end


### PR DESCRIPTION
Moves all the cmdline option error handling code from `client.jl` to `repl.c`. Fixes #12679.

Before:

```
$ ./julia --compile=yes -foo
julia: unknown option `--compile=yes`
```

After:

```
$ ./julia --compile=yes -foo
ERROR: unknown option `-o`
```

Easier to read with the `?w=1` flag: https://github.com/JuliaLang/julia/commit/dff1c901bbb3ac00a48612213b4536584fb2f2af?w=1
