### PR TITLE
Widen setindex_shape_check method signature

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -252,7 +252,7 @@ end
 # for permutations that leave array elements in the same linear order.
 # those are the permutations that preserve the order of the non-singleton
 # dimensions.
-function setindex_shape_check(X::AbstractArray, I::Int...)
+function setindex_shape_check(X::AbstractArray, I...)
     li = ndims(X)
     lj = length(I)
     i = j = 1
@@ -289,16 +289,16 @@ end
 setindex_shape_check(X::AbstractArray) =
     (length(X)==1 || throw_setindex_mismatch(X,()))
 
-setindex_shape_check(X::AbstractArray, i::Int) =
+setindex_shape_check(X::AbstractArray, i) =
     (length(X)==i || throw_setindex_mismatch(X, (i,)))
 
-setindex_shape_check{T}(X::AbstractArray{T,1}, i::Int) =
+setindex_shape_check{T}(X::AbstractArray{T,1}, i) =
     (length(X)==i || throw_setindex_mismatch(X, (i,)))
 
-setindex_shape_check{T}(X::AbstractArray{T,1}, i::Int, j::Int) =
+setindex_shape_check{T}(X::AbstractArray{T,1}, i, j) =
     (length(X)==i*j || throw_setindex_mismatch(X, (i,j)))
 
-function setindex_shape_check{T}(X::AbstractArray{T,2}, i::Int, j::Int)
+function setindex_shape_check{T}(X::AbstractArray{T,2}, i, j)
     if length(X) != i*j
         throw_setindex_mismatch(X, (i,j))
     end
@@ -307,7 +307,7 @@ function setindex_shape_check{T}(X::AbstractArray{T,2}, i::Int, j::Int)
         throw_setindex_mismatch(X, (i,j))
     end
 end
-setindex_shape_check(X, I::Int...) = nothing # Non-arrays broadcast to all idxs
+setindex_shape_check(X, I...) = nothing # Non-arrays broadcast to all idxs
 
 # convert to a supported index type (Array, Colon, or Int)
 to_index(i::Int) = i

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1340,3 +1340,10 @@ copy!(B, A)
 @test A + 1 == B + 1
 @test 2*A == 2*B
 @test A/3 == B/3
+
+# issue #13250
+x13250 = zeros(3)
+x13250[UInt(1):UInt(2)] = 1.0
+@test x13250[1] == 1.0
+@test x13250[2] == 1.0
+@test x13250[3] == 0.0


### PR DESCRIPTION
This removes the restriction on setindex_shape_check that the index lengths
must all be Int, allowing data structures to return non-Int lengths (e.g.,
`UInt(1):UInt(2)` or `big(1):big(2)`).  Fixes #13250.
