### PR TITLE
Wrapper to annotate the MIME type of some data

### DIFF
--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -205,11 +205,22 @@ for mime in ["application/atom+xml", "application/ecmascript",
     global istextmime(::MIME{Symbol(mime)}) = true
 end
 
-immutable MIMEData{mime}
-    data::Vector{UInt8}
+"""
+    MIMEData{mime<:MIME}(data)
+
+A wrapper around `data` that causes [`show`](@ref)` to [`write`](@ref) it as
+raw data of the given [`MIME`](@ref) type.
+
+That is, when `show(io, mime, d)` is called on `d::MIMEData{mime}`, it simply
+calls `write(io, d)`.
+"""
+struct MIMEData{mime<:MIME}
+    data
 end
-writemime{mime <: MIME}(io::IO,::MIME"text/plain",data::MIMEData{MIME"text/plain"}) = write(io,data.data)
-writemime{mime <: MIME}(io::IO,::mime,data::MIMEData{mime}) = write(io,data.data)
+MIMEData(::MIME{mime}, data) where {mime} = MIMEData{MIME{mime}}(data)
+MIMEData(mime::AbstractString, data) = MIMEData{MIME{Symbol(mime)}}(data)
+show(io::IO, ::MIME"text/plain", data::MIMEData{MIME"text/plain"}) = write(io, data.data)
+show(io::IO, ::MIME{mime}, data::MIMEData{MIME{mime}}) where {mime} = write(io, data.data)
 
 ###########################################################################
 # We have an abstract AbstractDisplay class that can be subclassed in order to

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -206,13 +206,21 @@ for mime in ["application/atom+xml", "application/ecmascript",
 end
 
 """
-    MIMEData{mime<:MIME}(data)
+    struct MIMEData{mime<:MIME}
+        data
+    end
+
+    MIMEData(mime::Union{MIME,AbstractString}, data)
 
 A wrapper around `data` that causes [`show`](@ref)` to [`write`](@ref) it as
 raw data of the given [`MIME`](@ref) type.
 
 That is, when `show(io, mime, d)` is called on `d::MIMEData{mime}`, it simply
-calls `write(io, d)`.
+calls `write(io, d.data)`.
+
+Can be constructed with `MIMEData(mime, data)` where `mime` is either a MIME
+type (an instance of `MIME`) or a string such as `"text/plain"` (which gets
+converted to a `MIME` instance).
 """
 struct MIMEData{mime<:MIME}
     data

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -205,6 +205,12 @@ for mime in ["application/atom+xml", "application/ecmascript",
     global istextmime(::MIME{Symbol(mime)}) = true
 end
 
+immutable MIMEData{mime}
+    data::Vector{UInt8}
+end
+writemime{mime <: MIME}(io::IO,::MIME"text/plain",data::MIMEData{MIME"text/plain"}) = write(io,data.data)
+writemime{mime <: MIME}(io::IO,::mime,data::MIMEData{mime}) = write(io,data.data)
+
 ###########################################################################
 # We have an abstract AbstractDisplay class that can be subclassed in order to
 # define new rich-display output devices.  A typical subclass should


### PR DESCRIPTION
I frequently find myself in the situation, where I have some data (say `image/png`), that I just want to have show up properly in the REPL without having to create a whole extra type for it. I don't think we currently have something like that. I would propose something like this (name to be bikeshedded), unless there already exists something better. cc @stevengj 

Example usage:
<img width="500" alt="screen shot 2015-09-21 at 11 32 05 am" src="https://cloud.githubusercontent.com/assets/1291671/9996303/6c00613c-6054-11e5-8d91-7eac2f7df518.png">
