### PR TITLE
[RFC] - use let blocks for testsets

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -458,12 +458,13 @@ end
 #-----------------------------------------------------------------------
 
 """
-    @testset "description" begin ... end
-    @testset begin ... end
+    @testset "description" let ... end
+    @testset let ... end
 
 Starts a new test set. The test results will be recorded, and if there
 are any `Fail`s or `Error`s, an exception will be thrown only at the end,
-along with a summary of the test results.
+along with a summary of the test results. Wrapping your test in a `let` block
+creates a new scope that isolates your tests from other test sets.
 """
 macro testset(args...)
     # Parse arguments to do determine if any options passed in

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -116,12 +116,12 @@ the tests failed, or could not be evaluated due to an error, the
 test set will then throw a ``TestSetException``.
 
 
-.. function:: @testset "description" begin ... end
-              @testset begin ... end
+.. function:: @testset "description" let ... end
+              @testset let ... end
 
    .. Docstring generated from Julia source
 
-   Starts a new test set. The test results will be recorded, and if there are any ``Fail``\ s or ``Error``\ s, an exception will be thrown only at the end, along with a summary of the test results.
+   Starts a new test set. The test results will be recorded, and if there are any ``Fail``\ s or ``Error``\ s, an exception will be thrown only at the end, along with a summary of the test results. Wrapping your test in a ``let`` block creates a new scope that isolates your tests from other test sets.
 
 .. function:: @testloop "description $v" for v in (...) ... end
               @testloop for x in (...), y in (...) ... end
@@ -132,7 +132,7 @@ test set will then throw a ``TestSetException``.
 
 We can put our tests for the ``foo(x)`` function in a test set::
 
-    julia> @testset "Foo Tests" begin
+    julia> @testset "Foo Tests" let
                @test foo("a")   == 1
                @test foo("ab")  == 4
                @test foo("abc") == 9
@@ -142,8 +142,8 @@ We can put our tests for the ``foo(x)`` function in a test set::
 
 Test sets can all also be nested::
 
-    julia> @testset "Foo Tests" begin
-               @testset "Animals" begin
+    julia> @testset "Foo Tests" let
+               @testset "Animals" let
                    @test foo("cat") == 9
                    @test foo("dog") == foo("cat")
                end
@@ -159,16 +159,16 @@ In the event that a nested test set has no failures, as happened here,
 it will be hidden in the summary. If we do have a test failure, only
 the details for the failed test sets will be shown::
 
-    julia> @testset "Foo Tests" begin
-               @testset "Animals" begin
-                   @testset "Felines" begin
+    julia> @testset "Foo Tests" let
+               @testset "Animals" let
+                   @testset "Felines" let
                        @test foo("cat") == 9
                    end
-                   @testset "Canines" begin
+                   @testset "Canines" let
                        @test foo("dog") == 9
                    end
                end
-               @testset "Arrays" begin
+               @testset "Arrays" let
                    @test foo(zeros(2)) == 4
                    @test foo(ones(4)) == 15
                end

--- a/test/test.jl
+++ b/test/test.jl
@@ -26,46 +26,46 @@ OLD_STDOUT = STDOUT
 catch_out = IOStream("")
 rd, wr = redirect_stdout()
 
-@testset "no errors" begin
+@testset "no errors" let
     @test true
     @test 1 == 1
 end
 
 try
 
-@testset "outer" begin
-    @testset "inner1" begin
+@testset "outer" let
+    @testset "inner1" let
         @test true
         @test false
         @test 1 == 1
         @test 2 == :foo
         @test 3 == 3
-        @testset "d" begin
+        @testset "d" let
             @test 4 == 4
         end
-        @testset begin
+        @testset let
             @test :blank != :notblank
         end
     end
-    @testset "inner1" begin
+    @testset "inner1" let
         @test 1 == 1
         @test 2 == 2
         @test 3 == :bar
         @test 4 == 4
         @test_throws ErrorException 1+1
         @test_throws ErrorException error()
-        @testset "errrrr" begin
+        @testset "errrrr" let
             @test "not bool"
             @test error()
         end
     end
 
-    @testset "loop with desc" begin
+    @testset "loop with desc" let
         @testloop "loop1 $T" for T in (Float32, Float64)
             @test 1 == T(1)
         end
     end
-    @testset "loops without desc" begin
+    @testset "loops without desc" let
         @testloop for T in (Float32, Float64)
             @test 1 == T(1)
         end
@@ -74,7 +74,7 @@ try
         end
     end
     srand(123)
-    @testset "some loops fail" begin
+    @testset "some loops fail" let
         @testloop for i in 1:5
             @test i <= rand(1:10)
         end


### PR DESCRIPTION
It seems like in most cases it's better to use `let` blocks instead of `begin`
when defining test sets so that the testset runs in its own scope block.
This way folks are less likely to have unexpected behavior from variables
leaking between tests. This doesn't make any code changes to the test system,
but just changes the documentation and usage in the tests.

Are there any downsides to using `let` blocks (assuming you don't _want_
to share variables between tests)?
