### PR TITLE
Use Base's getindex in eval_user_input hack

### DIFF
--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -57,7 +57,7 @@ function eval_user_input(ast::ANY, backend::REPLBackend)
                 ans = backend.ans
                 # note: value wrapped in a non-syntax value to avoid evaluating
                 # possibly-invalid syntax (issue #6763).
-                eval(Main, :(ans = $(Any[ans])[1]))
+                eval(Main, :(ans = $(getindex)($(Any[ans]), 1)))
                 backend.in_eval = true
                 value = eval(Main, ast)
                 backend.in_eval = false


### PR DESCRIPTION
To avoid breakage when getindex is overwritten in Main
