### PR TITLE
Make `@deprecate_binding` work with `--depwarn` cmdline flags

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -482,10 +482,12 @@ DLLEXPORT int jl_is_binding_deprecated(jl_module_t *m, jl_sym_t *var)
 void jl_binding_deprecation_warning(jl_binding_t *b)
 {
     if (b->deprecated && jl_options.depwarn) {
+        if (jl_options.depwarn != JL_OPTIONS_DEPWARN_ERROR)
+            jl_printf(JL_STDERR, "WARNING: ");
         if (b->owner)
-            jl_printf(JL_STDERR, "WARNING: %s.%s is deprecated", b->owner->name->name, b->name->name);
+            jl_printf(JL_STDERR, "%s.%s is deprecated", b->owner->name->name, b->name->name);
         else
-            jl_printf(JL_STDERR, "WARNING: %s is deprecated", b->name->name);
+            jl_printf(JL_STDERR, "%s is deprecated", b->name->name);
         jl_value_t *v = b->value;
         if (v && (jl_is_type(v) || (jl_is_function(v) && jl_is_gf(v)))) {
             jl_printf(JL_STDERR, ", use ");
@@ -493,6 +495,12 @@ void jl_binding_deprecation_warning(jl_binding_t *b)
             jl_printf(JL_STDERR, " instead");
         }
         jl_printf(JL_STDERR, ".\n");
+        if (jl_options.depwarn == JL_OPTIONS_DEPWARN_ERROR) {
+            if (b->owner)
+                jl_errorf("deprecated binding: %s.%s", b->owner->name->name, b->name->name);
+            else
+                jl_errorf("deprecated binding: %s", b->name->name);
+        }
     }
 }
 

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -152,7 +152,7 @@ let exename = `$(joinpath(JULIA_HOME, Base.julia_exename())) --precompiled=yes`
         foo()
     " --depwarn=error`)
 
-    # test deprecated bindings
+    # test deprecated bindings, #13269
     let code = """
         module Foo
             import Base: @deprecate_binding
@@ -166,6 +166,7 @@ let exename = `$(joinpath(JULIA_HOME, Base.julia_exename())) --precompiled=yes`
 
         @test !success(`$exename -E "$code" --depwarn=error`)
 
+        # FIXME these should also be run on windows once the bug causing them to hang gets fixed
         @unix_only let out  = Pipe(),
                        proc = spawn(pipeline(`$exename -E "$code" --depwarn=yes`, stderr=out))
 


### PR DESCRIPTION
Adds tests for `--depwarn` and `@deprecate_binding`. 

cc @tkelman 
