### PR TITLE
Fix #13261, isvatuple MethodError in inference

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -783,6 +783,8 @@ function precise_container_types(args, types, vtypes, sv)
             if any(isvarargtype, result[i])
                 return nothing
             end
+        elseif ti === Union{}
+            return nothing
         elseif ti<:Tuple && (i==n || !isvatuple(ti))
             result[i] = ti.parameters
         elseif ti<:AbstractArray && i==n
@@ -2813,7 +2815,7 @@ function inlining_pass(e::Expr, sv, ast)
                     newargs[i-3] = aarg.args[2:end]
                 elseif isa(aarg, Tuple)
                     newargs[i-3] = Any[ QuoteNode(x) for x in aarg ]
-                elseif (t<:Tuple) && !isvatuple(t) && effect_free(aarg,sv,true)
+                elseif (t<:Tuple) && t !== Union{} && !isvatuple(t) && effect_free(aarg,sv,true)
                     # apply(f,t::(x,y)) => f(t[1],t[2])
                     tp = t.parameters
                     newargs[i-3] = Any[ mk_getfield(aarg,j,tp[j]) for j=1:length(tp) ]

--- a/test/core.jl
+++ b/test/core.jl
@@ -3390,3 +3390,8 @@ f8932(a::Vec3_8932, b::Vec3_8932) = Vec3_8932(a.x % b.x, a.y % b.y, a.z % b.z)
 a8932 = Vec3_8932(1,1,1)
 b8932 = Vec3_8932(2,2,2)
 @test f8932(a8932, b8932) == Vec3_8932(1.0, 1.0, 1.0)
+
+# issue #13261
+f13261() = (x = (error("oops"),); +(x...))
+g13261() = f13261()
+@test_throws ErrorException g13261()


### PR DESCRIPTION
Not sure if https://github.com/JuliaLang/julia/blob/3b189b9a4e0ebd2578ae3df0ffd29b8d5d1f35bd/base/inference.jl#L786 needs a similar check (or possibly other uses of `<:` in inference).
