### PR TITLE
fix length for zips with cycles

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -210,3 +210,11 @@ next(it::Repeated, state) = (it.x, nothing)
 done(it::Repeated, state) = false
 
 repeated(x, n::Int) = take(repeated(x), n)
+
+# Zips with infinite length components
+
+length{I<:Union{Cycle,Repeated},Z<:AbstractZipIterator}(z::Zip{I,Z}) = length(z.z)
+length{I1<:Union{Cycle,Repeated},I2<:Union{Cycle,Repeated}}(z::Zip2{I1,I2}) = length(z.b) # inherit behaviour, error
+length{I1,I2<:Union{Cycle,Repeated}}(z::Zip2{I1,I2}) = length(z.a)
+length{I1<:Union{Cycle,Repeated},I2}(z::Zip2{I1,I2}) = length(z.b)
+

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -2,6 +2,7 @@
 
 isempty(itr) = done(itr, start(itr))
 
+
 # enumerate
 
 immutable Enumerate{I}
@@ -211,10 +212,14 @@ done(it::Repeated, state) = false
 
 repeated(x, n::Int) = take(repeated(x), n)
 
-# Zips with infinite length components
+# Infinite-length Iterators
 
-length{I<:Union{Cycle,Repeated},Z<:AbstractZipIterator}(z::Zip{I,Z}) = length(z.z)
-length{I1<:Union{Cycle,Repeated},I2<:Union{Cycle,Repeated}}(z::Zip2{I1,I2}) = length(z.b) # inherit behaviour, error
-length{I1,I2<:Union{Cycle,Repeated}}(z::Zip2{I1,I2}) = length(z.a)
-length{I1<:Union{Cycle,Repeated},I2}(z::Zip2{I1,I2}) = length(z.b)
+typealias InfiniteIterator Union{Cycle,Repeated,Count} # TODO: we should do this with traits once we have #13222
+
+# Zips with infinite-length components
+
+length{I<:InfiniteIterator,Z<:AbstractZipIterator}(z::Zip{I,Z}) = length(z.z)
+length{I1<:InfiniteIterator,I2<:InfiniteIterator}(z::Zip2{I1,I2}) = length(z.b) # inherit behaviour, error
+length{I1,I2<:InfiniteIterator}(z::Zip2{I1,I2}) = length(z.a)
+length{I1<:InfiniteIterator,I2}(z::Zip2{I1,I2}) = length(z.b)
 

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -121,6 +121,9 @@ let i = 0
     end
 end
 
+@test length(zip(cycle(1:3), 1:7)) == 7
+@test length(zip(cycle(1:3), 1:7, cycle(1:3))) == 7
+
 # repeated
 # --------
 


### PR DESCRIPTION
This fixes a small issue with Zips containing infinite components which prevented constructions like

```
[i for i in zip(1:10, cycle(1:2))]
```
