### PR TITLE
Fix reflection macros when using splatting

### DIFF
--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -190,3 +190,6 @@ let
 end
 
 @test_throws ArgumentError which(is, Tuple{Int, Int})
+
+# issue #13264
+@test isa((@which vcat(1...)), Method)


### PR DESCRIPTION
...by fixing the splatting branch of `gen_call_with_extracted_types`. The branch to handle splatting was added in https://github.com/JuliaLang/julia/commit/9e525744cf9de28cf248292b54f7aa07071b923b but I think it was shadowed by the branch in line 115 from the same commit because the splatting branch was broken and nobody has noticed.

This fixes #13264
