### PR TITLE
adds try...catch in testset and reports errors instead of bailing

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -555,7 +555,13 @@ macro testloop(args...)
     blk = quote
         $ts = DefaultTestSet($(esc(desc)))
         add_testset($ts)
-        $(esc(tests))
+        try
+            $(esc(tests))
+        catch err
+            # something in the test block threw an error. Count that as an
+            # error in this test set
+            record($ts, Error(:nontest_error, :(), err, catch_backtrace()))
+        end
         pop_testset()
         finish($ts)
     end

--- a/test/test.jl
+++ b/test/test.jl
@@ -81,6 +81,11 @@ try
         @testloop for i in 1:5
             @test i <= rand(1:10)
         end
+        # should add 3 errors and 3 passing tests
+        @testloop for i in 1:6
+            i % 2 == 0 || error("error outside of test")
+            @test true # only gets run if the above passed
+        end
     end
 end
     # These lines shouldn't be called
@@ -90,9 +95,9 @@ catch ex
     redirect_stdout(OLD_STDOUT)
 
     @test isa(ex, Test.TestSetException)
-    @test ex.pass  == 21
+    @test ex.pass  == 24
     @test ex.fail  == 5
-    @test ex.error == 3
+    @test ex.error == 6
 end
 
 # Test @test_approx_eq

--- a/test/test.jl
+++ b/test/test.jl
@@ -58,6 +58,9 @@ try
             @test "not bool"
             @test error()
         end
+
+        error("exceptions in testsets should be caught")
+        @test 1 == 1 # this test will not be run
     end
 
     @testset "loop with desc" begin
@@ -89,7 +92,7 @@ catch ex
     @test isa(ex, Test.TestSetException)
     @test ex.pass  == 21
     @test ex.fail  == 5
-    @test ex.error == 2
+    @test ex.error == 3
 end
 
 # Test @test_approx_eq


### PR DESCRIPTION
Based on discussion with @IainNZ and @StefanKarpinski, this PR now wraps the whole `@testset` expression in a `try...catch` block, and reports exceptions as errors in the summary. Previously only exceptions thrown inside a `@test` expression were caught and reported.

Note that now the testset expression is evaluated in a new scope block because of the `try...catch`, which keeps tests more isolated from each other.

One (maybe) odd thing here is that errors are counted in the `Total` column, so it doesn't match the number of `@test*` expressions exactly. If your code is throwing uncaught exceptions though, you probably don't care what the exact number is, so I don't think it's a big deal.
