### PR TITLE
Move docsystem to end of sysimg.jl

### DIFF
--- a/base/docs/bootstrap.jl
+++ b/base/docs/bootstrap.jl
@@ -19,7 +19,7 @@ setexpand!(f) = global _expand_ = f
 
 setexpand!() do str, obj
     global docs = List((ccall(:jl_get_current_module, Any, ()), str, obj), docs)
-    return esc(Expr(:toplevel, obj))
+    (isa(obj, Expr) && obj.head == :call) ? nothing : esc(Expr(:toplevel, obj))
 end
 
 """

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -234,13 +234,6 @@ include("REPLCompletions.jl")
 include("REPL.jl")
 include("client.jl")
 
-# Documentation
-
-include("markdown/Markdown.jl")
-include("docs/Docs.jl")
-using .Docs
-using .Markdown
-
 # misc useful functions & macros
 include("util.jl")
 
@@ -291,6 +284,13 @@ importall .Profile
 # dates
 include("Dates.jl")
 import .Dates: Date, DateTime, now
+
+# Documentation
+
+include("markdown/Markdown.jl")
+include("docs/Docs.jl")
+using .Docs
+using .Markdown
 
 # deprecated functions
 include("deprecated.jl")


### PR DESCRIPTION
Fixes #13274. Having the docsystem defined last should avoid the inconsistencies in available doc syntax in different parts of `Base`.
