### PR TITLE
export isidentifier for embedded julia

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -378,6 +378,7 @@ export
     isapprox,
     iseven,
     isfinite,
+    isidentifier,
     isinf,
     isinteger,
     isnan,

--- a/base/show.jl
+++ b/base/show.jl
@@ -331,7 +331,7 @@ end
 """
     isidentifier(s) -> Bool
 
-Returns whether symbol contianis charaters that is parsed as a valid identifier in Julia code.
+Returns whether symbol contains characters that are parsed as a valid identifier in Julia code.
 
 Internally Julia allows any sequence of characters in a `Symbol` (exept`\0`s),
 and macros automatically use variable names containing `#` in order to

--- a/base/show.jl
+++ b/base/show.jl
@@ -311,6 +311,11 @@ const expr_parens = Dict(:tuple=>('(',')'), :vcat=>('[',']'), :cell1d=>("Any[","
 
 is_id_start_char(c::Char) = ccall(:jl_id_start_char, Cint, (UInt32,), c) != 0
 is_id_char(c::Char) = ccall(:jl_id_char, Cint, (UInt32,), c) != 0
+"""
+    isidentifier(s) -> Bool
+
+Returns whether the string s is valid identifier.
+"""
 function isidentifier(s::AbstractString)
     i = start(s)
     done(s, i) && return false
@@ -322,6 +327,19 @@ function isidentifier(s::AbstractString)
     end
     return true
 end
+
+"""
+    isidentifier(s) -> Bool
+
+Returns whether symbol contianis charaters that is parsed as a valid identifier in Julia code.
+
+Internally Julia allows any sequence of characters in a `Symbol` (exept`\0`s),
+and macros automatically use variable names containing `#` in order to
+avoid naming collision with the surrounding code. In order for the parser to
+recognize a variable, it uses a limited set of characters (greatly extended by Unicode).
+`isidentifier()` makes it possible to query the parser directly whether a symbol contains
+valid characters.
+"""
 isidentifier(s::Symbol) = isidentifier(string(s))
 
 isoperator(s::Symbol) = ccall(:jl_is_operator, Cint, (Cstring,), s) != 0

--- a/test/show.jl
+++ b/test/show.jl
@@ -302,3 +302,13 @@ function f13127()
     takebuf_string(buf)
 end
 @test f13127() == "f"
+
+# isidentifier
+@test isidentifier("x")==true
+@test isidentifier("x1")==true
+@test isidentifier("x.1")==false
+@test isidentifier("1x")==false
+@test isidentifier(symbol("x"))==true
+@test isidentifier(symbol("x1"))==true
+@test isidentifier(symbol("x.1"))==false
+@test isidentifier(symbol("1x"))==false


### PR DESCRIPTION
the isidentifier function can be used to judge a string whether is valid identifier. when embedded Julia we need to know variable name in other language is valid in Julia or not. so please export isidentifier.
