### PR TITLE
Use tbaa_immut for getfield of immutable types

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1361,7 +1361,7 @@ static jl_cgval_t emit_getfield_knownidx(const jl_cgval_t &strct, unsigned idx, 
             LLVM37_param(cast<PointerType>(strct.V->getType()->getScalarType())->getElementType())
             strct.V, 0, idx);
         assert(!jt->mutabl);
-        return typed_load(addr, NULL, jfty, ctx, NULL);
+        return typed_load(addr, NULL, jfty, ctx, tbaa_immut);
     }
     else {
         assert(strct.V->getType()->isVectorTy());


### PR DESCRIPTION
This fixes a vectorization regression in [this script](https://github.com/yuyichao/explore/blob/3805e1694be12efad8eda621baf25f1a16f167dc/julia/simd_complex/test.jl)

LLVM refuses to vectorize it on the current master because it cannot prove that the array doesn't alias the fields of `factor::Complex64`. (see `test-0.4.ll` and `test-master.ll` in the same directory for the raw llvmir including tbaa info)

@simonster @vtjnash 
