### PR TITLE
correct limit flag effect in show_nd

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1143,7 +1143,7 @@ function show_nd(io::IO, a::AbstractArray, limit, print_matrix, label_slices)
     nd = ndims(a)-2
     for I in CartesianRange(tail)
         idxs = I.I
-        if limit
+        if !limit
             for i = 1:nd
                 ii = idxs[i]
                 if size(a,i+2) > 10


### PR DESCRIPTION
I noticed that running `whos()` on large n-d arrays was very slow in 0.4, and I tracked it down to the `show` call that produces the rightmost part after the colon. For n-d arrays this is eventually calling `show_nd`, and inside there the conditional that starts `if limit` appears to be backward. 

Even with this fix, a limited `show`-ing large n-d arrays is way too slow. In principle one should be able to peek at the first few and last few entries for the truncated data display, but I don't have the understanding of the code base to do that, and it looks like that whole section of code is due for a refactoring.
