### PR TITLE
Bugfix in vcat.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -738,7 +738,7 @@ function hcat(X::Number...)
 end
 
 function vcat{T}(V::AbstractVector{T}...)
-    n = 0
+    n::Int = 0
     for Vk in V
         n += length(Vk)
     end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -452,6 +452,12 @@ function test_vcat_depwarn(::Type{TestAbstractArray})
     end
 end
 
+# Issue 13315
+function test_13315(::Type{TestAbstractArray})
+    U = UInt(1):UInt(2)
+    @test [U;[U;]] == [UInt(1), UInt(2), UInt(1), UInt(2)]
+end
+
 #----- run tests -------------------------------------------------------------#
 
 for T in (T24Linear, TSlow), shape in ((24,), (2, 12), (2,3,4), (1,2,3,4), (4,3,2,1))
@@ -471,3 +477,4 @@ test_map(TestAbstractArray)
 test_map_promote(TestAbstractArray)
 test_UInt_indexing(TestAbstractArray)
 test_vcat_depwarn(TestAbstractArray)
+test_13315(TestAbstractArray)


### PR DESCRIPTION
This pull request fixes a concatenation failure.

```
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.5.0-dev+376 (2015-09-25 02:50 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit d233ef3* (0 days old master)
|__/                   |  x86_64-linux-gnu

julia> U = UInt(1):UInt(2); [U;[U;]]
ERROR: MethodError: `similar` has no method matching similar(::UnitRange{UInt64}, ::UInt64, ::Tuple{UInt64})
Closest candidates are:
  similar(::Range{T}, ::Type{T}, ::Tuple{Vararg{Integer}})
  similar(::AbstractArray{T,N}, ::Any)
  similar(::AbstractArray{T,N}, ::Any, ::Int64...)
  ...
 in similar at abstractarray.jl:202
 in vcat at abstractarray.jl:745
```

It is not a regression from 0.3; the same thing happens there.
