### PR TITLE
RFC: Dyadic mapslices with broadcasting

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -2101,6 +2101,13 @@ Transform the given dimensions of array `A` using function `f`. `f` is called on
 mapslices
 
 doc"""
+    mapranked(f, A, r, [B, s])
+
+Transform the leading subarrays or slices of rank (number of dimensions) `r` respective `s` of the arrays `A` and `B` using the two-argument function `f`. For example, if `r` is 2 and `A` is 4-dimensional and `s` is 1 and `B` is 3-dimensional, then `f` is called on `(A[:,:,i,j], B[:, i,j])` for all `i` and `j`. The results are concatenated along the remaining dimensions. If the dimensions of the arrays of `A`-slices or rank `r` and `B`-slices of rank `s` disagree, the function broadcasts these arrays to a common size by expanding singleton dimensions. If `B` and `s` are omitted, call `f` on the `r`-slices of `A`.
+"""
+mapranked
+
+doc"""
     spdiagm(B, d[, m, n])
 
 Construct a sparse diagonal matrix. `B` is a tuple of vectors containing the diagonals and `d` is a tuple containing the positions of the diagonals. In the case the input contains only one diagonaly, `B` can be a vector (instead of a tuple) and `d` can be the diagonal position (instead of a tuple), defaulting to 0 (diagonal). Optionally, `m` and `n` specify the size of the resulting sparse matrix.

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -548,6 +548,7 @@ export
     linspace,
     logspace,
     mapslices,
+    mapranked,
     max,
     maxabs,
     maxabs!,

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -696,6 +696,30 @@ let
     @test size(n1) == (6,1,4) && size(n2) == (6,3,1)  && size(n3) == (2,6,1)
 end
 
+# mapranked
+let
+
+    local a, b
+
+    b = mapranked((x,y) -> sum(x)+sum(y), ones(2,3,4), 1, ones(2,3,4),1)
+    @test size(b) === (3,4)
+    @test all(b.== 4)
+    b = mapranked((x,y) -> sum(x)+sum(y), ones(2,3,4), 2, ones(2,3,4),2)
+    @test size(b) === (4,)
+    @test all(b.==12)
+    a = rand(5,5)
+    @test mapranked(x-> maximum(-x), a, 0) == -a
+    @test mapranked(x-> maximum(-x), a, 1) == vec(maximum(-a,1))
+
+    b = rand(5)
+    @test mapranked(*,reverse(b)',0,b,0) == b*reverse(b)'
+    @test mapranked(*,reverse(b),0,b',0) == reverse(b)*b'
+
+    # other types than Number
+    @test mapranked((x,y)-> prod(x)*prod(y), ["1" "2"; "3" "4"], 1, ["a" "b"; "c" "d"], 1) == ["13ac", "24bd"]
+    @test mapranked(prod,["1"],1) == ["1"]
+
+end
 
 # single multidimensional index
 let


### PR DESCRIPTION
An open issue is to make `mapslices` accept two inputs and allow broadcasting. See #10928, #5140. There are aspects of the interface of mapslices which make straight generalization difficult.  The result of the provided function applied to the slices is arranged along the unsliced dimensions, so for example

```
julia> mapslices(mean, rand(3,3), 2)
3x1 Array{Float64,2}:
 0.648857
 0.560829
 0.256913

julia> mapslices(mean, rand(3,3), 1)
1x5 Array{Float64,2}:
 0.518943  0.615732  0.471542  0.475519  0.557684
```

Further the result of `f` has to fit dimensionally into the slices, so that the resulting array has the same number of dimensions as the original.  This behaviour does not generalize well to two arguments (what should the shape of `mapslices(f, A, Adims, B, Bdims)` be?).

The function `mapranked(f, A, r, B, s)` here follows APL and J and applies `f` only to the leading subarrays of given rank:  For example, if r is 2 and A is 4-dimensional and s is 1 and B is 3-dimensional, then f is called on  (A[:,:,i,j], B[:, i,j]) for all i and j. The results are concatenated along the remaining dimensions. The function broadcasts the arguments to a common size by expanding singleton dimensions. This more restrictive API makes the function conceptually much simpler. While it is meant to generalize `mapslices` to the dyadic case, to prevent confusion it should perhaps have a different name. Here I went with `mapranked` following the notion of changing the rank of a function/verb in APL (other suggestions?).

Some usage:

```
# Matrix from vector of vectors
mapranked(identity,[rand(5) for i in 1:10],0)

# Punnett square
cross(a,b) = string(a[1],b[1],a[2],b[2])
mapranked(cross, ["RA", "Ra", "rA", "ra"]',0,["RA", "Ra", "rA", "ra"],0 )

# Kronecker array
A = rand(3,3)
kron(A,A)[(2-1)*3+2,(2-1)*3+2] ==  mapranked(*, A, 0, A, 2)[2,2,2,2]

# selfclassify and memoize
v = rand(1:4, 10)
A = mapranked(.==, v, 1, unique(v), 0)

f(x) = begin sleep(.2*length(x)); x.*x end # time consuming computation ^^
sum(A.*f(unique(v))',2) # == f(v)
```

Ping @andreasnoack 
