### PR TITLE
package docs: s/INSTALLED/REQUIRE/

### DIFF
--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -143,7 +143,7 @@ same operating system and environment.
 
 :func:`Pkg.add` does the following within the package root directory:
 
-1. Adds the name of the package to ``INSTALLED``.
+1. Adds the name of the package to ``REQUIRE``.
 2. Downloads the package to ``.cache``, then copies the package to the package root directory.
 3. Recursively performs step 2 against all the packages listed in the package's ``REQUIRE`` file.
 4. Runs :func:`Pkg.build`


### PR DESCRIPTION
this is the only mention of all-caps `INSTALLED` currently in the repo
[av skip]
