### PR TITLE
Circumvent type-instability of deepcopy

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -5,7 +5,7 @@
 # Note: deepcopy_internal(::Any, ::ObjectIdDict) is
 #       only exposed for specialization by libraries
 
-deepcopy(x) = deepcopy_internal(x, ObjectIdDict())
+deepcopy(x) = deepcopy_internal(x, ObjectIdDict())::typeof(x)
 
 deepcopy_internal(x::Union{Symbol,LambdaInfo,TopNode,GlobalRef,DataType,Union,Task},
                   stackdict::ObjectIdDict) = x

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -281,8 +281,8 @@ convert{TS,TA,N}(::Type{SharedArray{TS,N}}, A::Array{TA,N}) = (S = SharedArray(T
 
 function deepcopy_internal(S::SharedArray, stackdict::ObjectIdDict)
     haskey(stackdict, S) && return stackdict[S]
-    # Note: copy can be used here because SharedArrays are restricted to isbits types
-    R = copy(S)
+    R = SharedArray(eltype(S), size(S); pids = S.pids)
+    copy!(sdata(R), sdata(S))
     stackdict[S] = R
     return R
 end

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -50,7 +50,7 @@ end
 
 # test behavior of shallow and deep copying
 let a = Any[[1]], q = QuoteNode([1])
-    ca = copy(a); dca = deepcopy(a)
+    ca = copy(a); dca = @inferred(deepcopy(a))
     @test ca !== a
     @test ca[1] === a[1]
     @test dca !== a

--- a/test/parallel_exec.jl
+++ b/test/parallel_exec.jl
@@ -401,6 +401,15 @@ pids_d = procs(d)
 remotecall_fetch(setindex!, pids_d[findfirst(id->(id != myid()), pids_d)], d, 1.0, 1:10)
 @test ds != d
 @test s != d
+copy!(d, s)
+@everywhere setid!(A) = A[localindexes(A)] = myid()
+@sync for p in procs(ds)
+    @async remotecall_wait(setid!, p, ds)
+end
+@test d == s
+@test ds != s
+@test first(ds) == first(procs(ds))
+@test last(ds)  ==  last(procs(ds))
 
 
 # SharedArray as an array
@@ -841,4 +850,3 @@ end
 v15406 = remotecall_wait(() -> 1, id_other)
 fetch(v15406)
 remotecall_wait(t -> fetch(t), id_other, v15406)
-


### PR DESCRIPTION
Due to the use of the `ObjectIdDict`, `deepcopy` is type-unstable. Obviously this dict is important for avoiding cycles, so it seems the best solution is to prevent the type-instability from propagating.

Ref https://github.com/timholy/Images.jl/issues/356
