### PR TITLE
WIP/help please: Restore with_handler, deprecated

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -718,4 +718,21 @@ function test_approx_eq_modphase{S<:Real,T<:Real}(
     end
 end
 
+#-----------------------------------------------------------------------
+# Deprecated support for old with_handler functionality
+# Supports the old handler functionality with a test set
+immutable DeprecatedTestSet <: AbstractTestSet
+    handler
+end
+record(ts::DeprecatedTestSet, t) = ts.handler(t)
+finish(ts::DeprecatedTestSet) = nothing
+
+function with_handler(f::Function, handler)
+    ts = DeprecatedTestSet(handler)
+    add_testset(ts)
+    f()
+    pop_testset()
+    finish(ts)
+end
+
 end # module

--- a/test/test.jl
+++ b/test/test.jl
@@ -110,3 +110,28 @@ end
 
 # Test @test_approx_eq_eps
 # TODO
+
+# Test with_handler
+successflag = false
+failureflag = false
+errorflag = false
+test_handler(r::Test.Pass) = !successflag
+test_handler(r::Test.Fail) = !failureflag
+test_handler(r::Test.Error) = !errorflag
+
+Test.with_handler(test_handler) do
+    @test true
+    @test successflag
+    @test !failureflag
+    @test !errorflag
+    successflag = false
+    @test false
+    @test !successflag
+    @test failureflag
+    @test !errorflag
+    failureflag = false
+    @test error("throw error")
+    @test !successflag
+    @test !failureflag
+    @test errorflag
+end


### PR DESCRIPTION
Need help with
- Deprecating this function
- The fact that I changed the names of the result types
- The fact that I changed the internal fields of the result types

Regarding the second and third points, heres an example that worries me:
https://github.com/tlycken/Interpolations.jl/blob/7646fe923f4c9e04e23cff2f26222917cbe9b4cb/test/scaling/nointerp.jl

The handler stuff will now work again with this PR, but it was relying on internal fields of the results, that have changed. Should I also add deprecated types for the old types and in the `record` function translate from the new types to the old types?
