### PR TITLE
Minor documentation cleanups

### DIFF
--- a/base/dft.jl
+++ b/base/dft.jl
@@ -91,12 +91,12 @@ To apply ``P`` to an array ``A``, use ``P * A``; in general, the
 syntax for applying plans is much like that of matrices.  (A plan
 can only be applied to arrays of the same size as the ``A`` for
 which the plan was created.)  You can also apply a plan with a
-preallocated output array ``Â`` by calling ``A_mul_B!(Â, plan,
+preallocated output array ``Ã‚`` by calling ``A_mul_B!(Ã‚, plan,
 A)``.  You can compute the inverse-transform plan by ``inv(P)`` and
-apply the inverse plan with ``P \ Â`` (the inverse plan is cached
+apply the inverse plan with ``P \ Ã‚`` (the inverse plan is cached
 and reused for subsequent calls to ``inv`` or ``\``), and apply the
 inverse plan to a pre-allocated output array ``A`` with
-``A_ldiv_B!(A, P, Â)``.
+``A_ldiv_B!(A, P, Ã‚)``.
 
 The ``flags`` argument is a bitwise-or of FFTW planner flags, defaulting
 to ``FFTW.ESTIMATE``.  e.g. passing ``FFTW.MEASURE`` or ``FFTW.PATIENT``

--- a/base/dft.jl
+++ b/base/dft.jl
@@ -395,7 +395,7 @@ fftshift(x,dim)
 ifftshift(x) = circshift(x, div([size(x)...],-2))
 
 doc"""
-    ifftshift(x)
+    ifftshift(x, [dim])
 
 Undoes the effect of `fftshift`.
 """
@@ -406,13 +406,6 @@ function ifftshift(x,dim)
     s[dim] = -div(size(x,dim),2)
     circshift(x, s)
 end
-
-doc"""
-    ifftshift(x, [dim])
-
-Undoes the effect of `fftshift`.
-"""
-ifftshift
 
 ##############################################################################
 

--- a/doc/genstdlib.jl
+++ b/doc/genstdlib.jl
@@ -53,7 +53,7 @@ function add_all_docs_mod(m::Module)
     try
         add_all_docs_meta(m,Docs.meta(m))
     end
-    for name in names(m)
+    for name in names(m, true)
         try
             sub_m = getfield(m,name)
             isa(sub_m, Module) || continue

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -107,7 +107,14 @@ General I/O
 
    .. Docstring generated from Julia source
 
-   Write the canonical binary representation of a value to the given stream.
+   Write the canonical binary representation of a value to the given stream. Returns the number of bytes written into the stream.
+
+   You can write multiple values with the same :func:``write`` call. i.e. the following are equivalent:
+
+   .. code-block:: julia
+
+       write(stream, x, y...)
+       write(stream, x) + write(stream, y...)
 
 .. function:: read(stream, type)
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -1479,12 +1479,6 @@ Usually a function has 4 methods defined, one each for ``Float64``,
 
    Computes the least norm solution of ``A * X = B`` by finding the full ``QR`` factorization of ``A``\ , then dividing-and-conquering the problem. ``B`` is overwritten with the solution ``X``\ . Singular values below ``rcond`` will be treated as zero. Returns the solution in ``B`` and the effective rank of ``A`` in ``rnk``\ .
 
-.. function:: gelsy!(A, B, rcond) -> (B, rnk)
-
-   .. Docstring generated from Julia source
-
-   Computes the least norm solution of ``A * X = B`` by finding the full ``QR`` factorization of ``A``\ , then dividing-and-conquering the problem. ``B`` is overwritten with the solution ``X``\ . Singular values below ``rcond`` will be treated as zero. Returns the solution in ``B`` and the effective rank of ``A`` in ``rnk``\ .
-
 .. function:: gglse!(A, c, B, d) -> (X,res)
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
This is a bit of a documentation cleanup grab-bag, but it's a bunch of small things.

The encoding of plan_fft was some strange hybrid between some latin extended set and unicode… which made me realize that it wasn't finding any of the docstrings in Base.DFT.

So this now lets `genstdlib` look into unexported modules, since some bindings end up getting exported from base but live in a module that isn't itself exported…

Which ended up throwing a warning that the `ifftshift` docstring wasn't getting matched properly. 
