### PR TITLE
Docsystem refactoring

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -160,6 +160,11 @@ function doc(b::Binding)
 
                 `$(b.mod === Main ? b.var : join((b.mod, b.var),'.'))` is $(isgeneric(v) ? "a generic" : "an anonymous") `Function`.
                 """), functionsummary(v))
+            elseif isa(v,DataType)
+                d = catdoc(Markdown.parse("""
+                No documentation found.
+
+                """), typesummary(v))
             else
                 T = typeof(v)
                 d = catdoc(Markdown.parse("""
@@ -234,37 +239,6 @@ function doc!(f::Function, sig::ANY, data, source)
     fd.source[sig] = source
 end
 
-doc(f::Function) = doc(f, Tuple)
-
-function doc(f::Function, sig::Type)
-    isgeneric(f) && isempty(methods(f,sig)) && return nothing
-    results, funcdocs = [], []
-    for mod in modules
-        if (haskey(meta(mod), f) && isa(meta(mod)[f], FuncDoc))
-            fd = meta(mod)[f]
-            push!(funcdocs, fd)
-            for msig in fd.order
-                # try to find specific matching method signatures
-                if sig <: msig
-                    push!(results, (msig, fd.meta[msig]))
-                end
-            end
-        end
-    end
-    # if all method signatures are Union{} ( ⊥ ), concat all docstrings
-    if isempty(results)
-        for fd in funcdocs
-            append!(results, [fd.meta[msig] for msig in reverse(fd.order)])
-        end
-    else
-        sort!(results, lt = (a, b) -> type_morespecific(first(a), first(b)))
-        results = [last(r) for r in results]
-    end
-    catdoc(results...)
-end
-doc(f::Function,args::Any...) = doc(f, Tuple{args...})
-
-
 """
 `catdoc(xs...)`: Combine the documentation metadata `xs` into a single meta object.
 """
@@ -317,32 +291,39 @@ function doc!(T::DataType, sig::ANY, data, source)
     td.meta[sig] = data
 end
 
-function doc(T::DataType)
-    docs = []
-    for mod in modules
-        if haskey(meta(mod), T)
-            Td = meta(mod)[T]
-            if isa(Td, TypeDoc)
-                if length(docs) == 0 && Td.main !== nothing
-                    push!(docs, Td.main)
+function doc(obj::Base.Callable, sig::Type = Union)
+    isgeneric(obj) && sig !== Union && isempty(methods(obj, sig)) && return nothing
+    results, groups = [], []
+    for m in modules
+        if haskey(meta(m), obj)
+            docs = meta(m)[obj]
+            if isa(docs, FuncDoc) || isa(docs, TypeDoc)
+                push!(groups, docs)
+                for msig in docs.order
+                    if sig <: msig
+                        push!(results, (msig, docs.meta[msig]))
+                    end
                 end
-                for m in Td.order
-                    push!(docs, Td.meta[m])
+                if isempty(results) && docs.main !== nothing
+                    push!(results, (Union{}, docs.main))
                 end
-            elseif length(docs) == 0
-                return Td
+            else
+                push!(results, (Union{}, docs))
             end
         end
     end
-    if isempty(docs)
-        catdoc(Markdown.parse("""
-        No documentation found.
-
-        """), typesummary(T))
-    else
-        catdoc(docs...)
+    # If all method signatures are Union{} ( ⊥ ), concat all docstrings.
+    if isempty(results)
+        for group in groups
+            append!(results, [group.meta[s] for s in reverse(group.order)])
+        end
+     else
+        sort!(results, lt = (a, b) -> type_morespecific(first(a), first(b)))
+        results = map(last, results)
     end
+    catdoc(results...)
 end
+doc(f::Base.Callable, args::Any...) = doc(f, Tuple{args...})
 
 function typesummary(T::DataType)
     parts = [


### PR DESCRIPTION
**Minor docsystem refactoring.**

Combines the `doc(::Function)` and `doc(::DataType)` methods since they were nearly identical.

Enables searching for docstrings attached to specific constructors in the same manner as is currently allowed for normal methods. Prior to this it resulted in a no method error.

Fixes #12701 where splatted method docs were shadowing others. Although not the original cause of the issue, with the change to storing signatures as `Tuple{...}` (in #12835) this meant that `f(x...)` was stored as `Tuple{Vararg{Any}}` which is equal to `Tuple`. Since the default value of `sig` was `Tuple` not all matching docs were returned in the example provided in #12701.

**Simplify `@repl` implementation.**

Enable `apropos` search via help mode by passing a string or regex:

```
help?> "foo"
help?> r"foo"
```

This shouldn't interfere with any docstring lookup since we don't encourage documenting specific strings or regex objects. Docs for `@r_str` can still be found by either using an empty regex `r""` or `@r_str` directly.

Enable specifying method signatures using

```
help?> f(::Float64, ::Int)
```

as well as the current behaviour

```
help?> f(x, y)
```

where `x` and `y` are already defined. This is quite useful when you don't have an instance of the required type. Prior to this an error was thrown in `gen_call_with_extracted_types` when using the `::` syntax.

Tests are failing with

```
    From worker 3:       * backtrace            Test Failed
    From worker 3:    Expression: (code_loc(b1[4]))[1] == (code_loc(b2[4]))[1] == :test_throw_commoning
    From worker 3:     Evaluated: test_throw_commoning == ??? == test_throw_commoning
    From worker 2:   in  30.63 seconds
```

`julia/test$ make docs` does pass for me locally though.
