### PR TITLE
Make function argument the first in remotecallX and remote_do to ease the use  of do block syntax.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,27 @@
+Julia v0.5.0 Release Notes
+==========================
+
+New language features
+---------------------
+
+Language changes
+----------------
+
+Command line option changes
+---------------------------
+
+Compiler/Runtime improvements
+-----------------------------
+
+Library improvements
+--------------------
+
+Deprecated or removed
+---------------------
+
+  * The function `remotecall`, `remotecall_fetch`, and `remotecall_wait` now have the
+    the function argument as the first argument to allow for do-block syntax. [#13338]
+
 Julia v0.4.0 Release Notes
 ==========================
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -243,7 +243,7 @@ function process_options(opts::JLOptions, args::Vector{UTF8String})
         # load file immediately on all processors
         if opts.load != C_NULL
             @sync for p in procs()
-                @async remotecall_fetch(p, include, bytestring(opts.load))
+                @async remotecall_fetch(include, p, bytestring(opts.load))
             end
         end
         # eval expression

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -834,3 +834,11 @@ end
 # 12839
 const AsyncStream = IO
 deprecate(:AsyncStream)
+
+for f in (:remotecall, :remotecall_fetch, :remotecall_wait)
+    @eval begin
+        @deprecate ($f)(w::LocalProcess, f::Function, args...)    ($f)(f, w::LocalProcess, args...)
+        @deprecate ($f)(w::Worker, f::Function, args...)          ($f)(f, w::Worker, args...)
+        @deprecate ($f)(id::Integer, f::Function, args...)        ($f)(f, id::Integer, args...)
+    end
+end

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -3609,7 +3609,7 @@ Returns the index of the current worker into the `pids` vector, i.e., the list o
 indexpids
 
 doc"""
-    remotecall_wait(id, func, args...)
+    remotecall_wait(func, id, args...)
 
 Perform `wait(remotecall(...))` in one message.
 """
@@ -6259,7 +6259,7 @@ Search for the first occurrence of the given characters within the given string.
 search
 
 doc"""
-    remotecall_fetch(id, func, args...)
+    remotecall_fetch(func, id, args...)
 
 Perform `fetch(remotecall(...))` in one message. Any remote exceptions are captured in a `RemoteException` and thrown.
 """
@@ -7370,7 +7370,7 @@ Determine whether a `RemoteRef` has a value stored to it. Note that this functio
 If the argument `RemoteRef` is owned by a different node, this call will block to wait for the answer. It is recommended to wait for `r` in a separate task instead, or to use a local `RemoteRef` as a proxy:
 
     rr = RemoteRef()
-    @async put!(rr, remotecall_fetch(p, long_computation))
+    @async put!(rr, remotecall_fetch(long_computation, p))
     isready(rr)  # will not block
 """
 isready
@@ -9490,7 +9490,7 @@ Read all available data on the stream, blocking the task only if no data is avai
 readavailable
 
 doc"""
-    remotecall(id, func, args...)
+    remotecall(func, id, args...)
 
 Call a function asynchronously on the given arguments on the specified process. Returns a `RemoteRef`.
 """

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -30,7 +30,7 @@ function find_in_node_path(name, srcpath, node::Int=1)
     if myid() == node
         find_in_path(name, srcpath)
     else
-        remotecall_fetch(node, find_in_path, name, srcpath)
+        remotecall_fetch(find_in_path, node, name, srcpath)
     end
 end
 
@@ -67,7 +67,7 @@ function _require_from_serialized(node::Int, mod::Symbol, path_to_try::ByteStrin
         if node == myid()
             content = open(readbytes, path_to_try)
         else
-            content = remotecall_fetch(node, open, readbytes, path_to_try)
+            content = remotecall_fetch(open, node, readbytes, path_to_try)
         end
         restored = _include_from_serialized(content)
         if restored !== nothing
@@ -83,7 +83,7 @@ function _require_from_serialized(node::Int, mod::Symbol, path_to_try::ByteStrin
         myid() == 1 && recompile_stale(mod, path_to_try)
         restored = ccall(:jl_restore_incremental, Any, (Ptr{UInt8},), path_to_try)
     else
-        content = remotecall_fetch(node, open, readbytes, path_to_try)
+        content = remotecall_fetch(open, node, readbytes, path_to_try)
         restored = _include_from_serialized(content)
     end
     # otherwise, continue search
@@ -304,7 +304,7 @@ function include_from_node1(_path::AbstractString)
             result = Core.include(path)
             nprocs()>1 && sleep(0.005)
         else
-            result = include_string(remotecall_fetch(1, readall, path), path)
+            result = include_string(remotecall_fetch(readall, 1, path), path)
         end
     finally
         if prev === nothing

--- a/base/managers.jl
+++ b/base/managers.jl
@@ -357,7 +357,7 @@ function connect_to_worker(host::AbstractString, bind_addr::AbstractString, port
 end
 
 function kill(manager::ClusterManager, pid::Int, config::WorkerConfig)
-    remote_do(pid, exit) # For TCP based transports this will result in a close of the socket
+    remote_do(exit, pid) # For TCP based transports this will result in a close of the socket
                        # at our end, which will result in a cleanup of the worker.
     nothing
 end

--- a/base/require.jl
+++ b/base/require.jl
@@ -23,7 +23,7 @@ function find_in_path(name::AbstractString)
 end
 
 find_in_node1_path(name) = myid()==1 ?
-    find_in_path(name) : remotecall_fetch(1, find_in_path, name)
+    find_in_path(name) : remotecall_fetch(find_in_path, 1, name)
 
 # Store list of files and their load time
 package_list = (ByteString=>Float64)[]
@@ -94,7 +94,7 @@ function include_from_node1(path::AbstractString)
             result = Core.include(path)
             nprocs()>1 && sleep(0.005)
         else
-            result = include_string(remotecall_fetch(1, readall, path), path)
+            result = include_string(remotecall_fetch(readall, 1, path), path)
         end
     finally
         if prev == nothing

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -44,14 +44,17 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
         else
             # The shared array is created on a remote machine....
             shmmem_create_pid = pids[1]
-            remotecall_fetch(pids[1], () -> begin shm_mmap_array(T, dims, shm_seg_name, JL_O_CREAT | JL_O_RDWR); nothing end)
+            remotecall_fetch(pids[1]) do
+                shm_mmap_array(T, dims, shm_seg_name, JL_O_CREAT | JL_O_RDWR)
+                nothing
+            end
         end
 
         func_mapshmem = () -> shm_mmap_array(T, dims, shm_seg_name, JL_O_RDWR)
 
         refs = Array(RemoteRef, length(pids))
         for (i, p) in enumerate(pids)
-            refs[i] = remotecall(p, func_mapshmem)
+            refs[i] = remotecall(func_mapshmem, p)
         end
 
         # Wait till all the workers have mapped the segment
@@ -64,7 +67,7 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
             if onlocalhost
                 rc = shm_unlink(shm_seg_name)
             else
-                rc = remotecall_fetch(shmmem_create_pid, shm_unlink, shm_seg_name)
+                rc = remotecall_fetch(shm_unlink, shmmem_create_pid, shm_seg_name)
             end
             systemerror("Error unlinking shmem segment " * shm_seg_name, rc != 0)
         end
@@ -85,14 +88,14 @@ function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
         if isa(init, Function)
             @sync begin
                 for p in pids
-                    @async remotecall_wait(p, init, S)
+                    @async remotecall_wait(init, p, S)
                 end
             end
         end
 
     finally
         if shm_seg_name != ""
-            remotecall_fetch(shmmem_create_pid, shm_unlink, shm_seg_name)
+            remotecall_fetch(shm_unlink, shmmem_create_pid, shm_seg_name)
         end
     end
     S
@@ -108,7 +111,7 @@ function SharedArray{T,N}(filename::AbstractString, ::Type{T}, dims::NTuple{N,In
     pids, onlocalhost = shared_pids(pids)
 
     # If not supplied, determine the appropriate mode
-    have_file = onlocalhost ? isfile(filename) : remotecall_fetch(pids[1], isfile, filename)
+    have_file = onlocalhost ? isfile(filename) : remotecall_fetch(isfile, pids[1], filename)
     if mode == nothing
         mode = have_file ? "r+" : "w+"
     end
@@ -127,14 +130,20 @@ function SharedArray{T,N}(filename::AbstractString, ::Type{T}, dims::NTuple{N,In
     local s
     if onlocalhost
         s = func_mmap(mode)
-        refs[1] = remotecall(pids[1], () -> func_mmap(workermode))
+        refs[1] = remotecall(pids[1]) do
+            func_mmap(workermode)
+        end
     else
-        refs[1] = remotecall_wait(pids[1], () -> func_mmap(mode))
+        refs[1] = remotecall_wait(pids[1]) do
+            func_mmap(mode)
+        end
     end
 
     # Populate the rest of the workers
     for i = 2:length(pids)
-        refs[i] = remotecall(pids[i], () -> func_mmap(workermode))
+        refs[i] = remotecall(pids[i]) do
+            func_mmap(workermode)
+        end
     end
 
     # Wait till all the workers have mapped the segment
@@ -157,7 +166,7 @@ function SharedArray{T,N}(filename::AbstractString, ::Type{T}, dims::NTuple{N,In
     if isa(init, Function)
         @sync begin
             for p in pids
-                @async remotecall_wait(p, init, S)
+                @async remotecall_wait(init, p, S)
             end
         end
     end
@@ -175,7 +184,9 @@ function reshape{T,N}(a::SharedArray{T}, dims::NTuple{N,Int})
     (length(a) != prod(dims)) && throw(DimensionMismatch("dimensions must be consistent with array size"))
     refs = Array(RemoteRef, length(a.pids))
     for (i, p) in enumerate(a.pids)
-        refs[i] = remotecall(p, (r,d)->reshape(fetch(r),d), a.refs[i], dims)
+        refs[i] = remotecall(p, a.refs[i], dims) do r,d
+            reshape(fetch(r),d)
+        end
     end
 
     A = SharedArray{T,N}(dims, a.pids, refs, a.segname)
@@ -288,7 +299,7 @@ function fill!(S::SharedArray, v)
     vT = convert(eltype(S), v)
     f = S->fill!(S.loc_subarr_1d, vT)
     @sync for p in procs(S)
-        @async remotecall_wait(p, f, S)
+        @async remotecall_wait(f, p, S)
     end
     return S
 end
@@ -296,7 +307,7 @@ end
 function rand!{T}(S::SharedArray{T})
     f = S->map!(x->rand(T), S.loc_subarr_1d)
     @sync for p in procs(S)
-        @async remotecall_wait(p, f, S)
+        @async remotecall_wait(f, p, S)
     end
     return S
 end
@@ -304,7 +315,7 @@ end
 function randn!(S::SharedArray)
     f = S->map!(x->randn(), S.loc_subarr_1d)
     @sync for p in procs(S)
-        @async remotecall_wait(p, f, S)
+        @async remotecall_wait(f, p, S)
     end
     return S
 end

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -264,7 +264,7 @@ General Parallel Computing Support
    If ``err_retry`` is ``true``, it retries a failed application of ``f`` on a different worker.
    If ``err_stop`` is ``true``, it takes precedence over the value of ``err_retry`` and ``pmap`` stops execution on the first error.
 
-.. function:: remotecall(id, func, args...)
+.. function:: remotecall(func, id, args...)
 
    .. Docstring generated from Julia source
 
@@ -296,13 +296,13 @@ General Parallel Computing Support
      * ``RemoteRef``\ : Wait for and get the value of a remote reference. If the remote value is an exception, throws a ``RemoteException`` which captures the remote exception and backtrace.
      * ``Channel`` : Wait for and get the first available item from the channel.
 
-.. function:: remotecall_wait(id, func, args...)
+.. function:: remotecall_wait(func, id, args...)
 
    .. Docstring generated from Julia source
 
    Perform ``wait(remotecall(...))`` in one message.
 
-.. function:: remotecall_fetch(id, func, args...)
+.. function:: remotecall_fetch(func, id, args...)
 
    .. Docstring generated from Julia source
 
@@ -343,7 +343,7 @@ General Parallel Computing Support
    .. code-block:: julia
 
        rr = RemoteRef()
-       @async put!(rr, remotecall_fetch(p, long_computation))
+       @async put!(rr, remotecall_fetch(long_computation, p))
        isready(rr)  # will not block
 
 .. function:: close(Channel)

--- a/examples/clustermanager/simple/test_simple.jl
+++ b/examples/clustermanager/simple/test_simple.jl
@@ -5,7 +5,7 @@ include(cmanpath)
 
 npids = addprocs(UnixDomainCM(2))
 assert(length(npids) == 2)
-test_pids = [remotecall_fetch(x, myid) for x in npids]
+test_pids = [remotecall_fetch(myid, x) for x in npids]
 assert(npids == test_pids)
 rmprocs(npids; waitfor=1.0)
 

--- a/examples/hpl.jl
+++ b/examples/hpl.jl
@@ -251,15 +251,15 @@ function hpl_par2(A::Matrix, b::Vector)
     for i = 1:nB
         #println("C=$(convert(Array, C))") #####
         ##panel factorization
-        panel_p = remotecall_fetch(C.pmap[i], panel_factor_par2, C, i, n)
+        panel_p = remotecall_fetch(panel_factor_par2, C.pmap[i], C, i, n)
 
         ## Apply permutation from pivoting
         for j = (i+1):nB
-           depend[i,j] = remotecall(C.pmap[j], permute, C, i, j, panel_p, n, false)
+           depend[i,j] = remotecall(permute, C.pmap[j], C, i, j, panel_p, n, false)
         end
         ## Special case for last column
         if i == nB
-           depend[nB,nB] = remotecall(C.pmap[nB], permute, C, i, nB+1, panel_p, n, true)
+           depend[nB,nB] = remotecall(permute, C.pmap[nB], C, i, nB+1, panel_p, n, true)
         end
 
         ##Trailing updates
@@ -276,13 +276,13 @@ function hpl_par2(A::Matrix, b::Vector)
 
         for j=(i+1):nB
             dep = depend[i,j]
-            depend[j,i] = remotecall(C.pmap[j], trailing_update_par2, C, L_II, C_KI, i, j, n, false, dep)
+            depend[j,i] = remotecall(trailing_update_par2, C.pmap[j], C, L_II, C_KI, i, j, n, false, dep)
         end
 
         ## Special case for last column
         if i == nB
             dep = depend[nB,nB]
-            remotecall_fetch(C.pmap[nB], trailing_update_par2, C, L_II, C_KI, i, nB+1, n, true, dep)
+            remotecall_fetch(trailing_update_par2, C.pmap[nB], C, L_II, C_KI, i, nB+1, n, true, dep)
         else
             #enforce dependencies for nonspecial case
             for j=(i+1):nB

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -55,7 +55,10 @@ include(dc_path)
 w_set=filter!(x->x != myid(), workers())
 pid = length(w_set) > 0 ? w_set[1] : myid()
 
-remotecall_fetch(pid, f->(include(f); nothing), dc_path)
+remotecall_fetch(pid, dc_path) do f
+    include(f)
+    nothing
+end
 dc=RemoteRef(()->DictChannel(), pid)
 @test typeof(dc) == RemoteRef{DictChannel}
 

--- a/test/netload/memtest.jl
+++ b/test/netload/memtest.jl
@@ -54,7 +54,7 @@ end
 
 function mtest_remotecall_fetch()
     for i in 1:10^5
-        remotecall_fetch(1, myid)
+        remotecall_fetch(myid, 1)
     end
     gc()
 end

--- a/test/topology.jl
+++ b/test/topology.jl
@@ -2,7 +2,7 @@
 
 include("testdefs.jl")
 addprocs(4; topology="master_slave")
-@test_throws RemoteException remotecall_fetch(2, ()->remotecall_fetch(3,myid))
+@test_throws RemoteException remotecall_fetch(()->remotecall_fetch(3,myid), 2)
 
 function test_worker_counts()
     # check if the nprocs/nworkers/workers are the same on the remaining workers
@@ -11,7 +11,9 @@ function test_worker_counts()
     ws=sort(workers())
 
     for p in workers()
-        @test (true, true, true) == remotecall_fetch(p, (x,y,z)->(x==nprocs(), y==nworkers(), z==sort(workers())), np, nw, ws)
+        @test (true, true, true) == remotecall_fetch(p, np, nw, ws) for (x,y,z)
+            (x==nprocs(), y==nworkers(), z==sort(workers()))
+        end
     end
 end
 
@@ -75,9 +77,9 @@ for p1 in workers()
         i1 = map_pid_ident[p1]
         i2 = map_pid_ident[p2]
         if (iseven(i1) && iseven(i2)) || (isodd(i1) && isodd(i2))
-            @test p2 == remotecall_fetch(p1, p->remotecall_fetch(p,myid), p2)
+            @test p2 == remotecall_fetch(p->remotecall_fetch(p,myid), p1, p2)
         else
-            @test_throws RemoteException remotecall_fetch(p1, p->remotecall_fetch(p,myid), p2)
+            @test_throws RemoteException remotecall_fetch(p->remotecall_fetch(p,myid), p1, p2)
         end
     end
 end


### PR DESCRIPTION
...such that we can write

``` jl
julia> remotecall_fetch(1,2) do x
       x+x
       end
4
```
