### PR TITLE
RFC: pass macro call location to macro-function

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1348,6 +1348,7 @@ export
 # Macros
     # parser internal
     @__FILE__,
+    @__LINE__,
     @int128_str,
     @uint128_str,
     @big_str,

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -290,8 +290,6 @@ function source_dir()
     p === nothing ? p : dirname(p)
 end
 
-macro __FILE__() source_path() end
-
 function include_from_node1(_path::AbstractString)
     path, prev = _include_dependency(_path)
     tls = task_local_storage()
@@ -461,3 +459,10 @@ function recompile_stale(mod, cachefile)
         end
     end
 end
+
+macro __MACROCALL_META__() :( $(symbol("&meta")) ) end
+macro __MACROCALL_LINE__() :( $(symbol("&meta")).args[1]) end
+macro __MACROCALL_FILE__() :( string($(symbol("&meta")).args[2]) ) end
+
+macro __LINE__() @__MACROCALL_LINE__ end
+macro __FILE__() @__MACROCALL_FILE__ end

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2036,7 +2036,7 @@
            (with-space-sensitive
             (let* ((head (parse-unary-prefix s))
                    (t    (peek-token s))
-                   (loc (line-number-node s)))
+                   (loc  (line-number-node s)))
               (cond
                  ((ts:space? s)
                   `(macrocall ,(macroify-name head) ,loc

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2035,17 +2035,17 @@
            (take-token s)
            (with-space-sensitive
             (let* ((head (parse-unary-prefix s))
-                   (t    (peek-token s)))
+                   (t    (peek-token s))
+                   (loc (line-number-node s)))
               (cond
-                 ((eqv? head '__LINE__) (input-port-line (ts:port s)))
                  ((ts:space? s)
-                  `(macrocall ,(macroify-name head)
+                  `(macrocall ,(macroify-name head) ,loc
                               ,@(parse-space-separated-exprs s)))
                  (else
                    (let ((call (parse-call-chain s head #t)))
                       (if (and (pair? call) (eq? (car call) 'call))
-                        `(macrocall ,(macroify-name (cadr call)) ,@(cddr call))
-                        `(macrocall ,(macroify-name call)
+                        `(macrocall ,(macroify-name (cadr call)) ,loc ,@(cddr call))
+                        `(macrocall ,(macroify-name call) ,loc
                                     ,@(parse-space-separated-exprs s)))))))))
 
           ;; command syntax
@@ -2074,6 +2074,9 @@
       (and (pair? e) (eq? 'string (car e))) ; string interpolation
       (and (length= e 3) (eq? (car e) 'macrocall)
            (simple-string-literal? (caddr e))
+           (eq? (cadr e) '@doc_str))
+      (and (length= e 4) (eq? (car e) 'macrocall)
+           (simple-string-literal? (cadddr e))
            (eq? (cadr e) '@doc_str))))
 
 (define (parse-docstring s production)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1181,7 +1181,7 @@
                    (symbol? (cadr (cadr e))))
               `(macro ,(symbol (string #\@ (cadr (cadr e))))
                  ,(expand-binding-forms
-                   `(-> (tuple __LOCATION__ ,@(cddr (cadr e)))
+                   `(-> (tuple &meta ,@(cddr (cadr e)))
                         ,(caddr e)))))
              ((symbol? (cadr e))  ;; already expanded
               e)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1181,7 +1181,7 @@
                    (symbol? (cadr (cadr e))))
               `(macro ,(symbol (string #\@ (cadr (cadr e))))
                  ,(expand-binding-forms
-                   `(-> (tuple ,@(cddr (cadr e)))
+                   `(-> (tuple __LOCATION__ ,@(cddr (cadr e)))
                         ,(caddr e)))))
              ((symbol? (cadr e))  ;; already expanded
               e)
@@ -3364,7 +3364,11 @@ So far only the second case can actually occur.
         ((eq? (car e) 'inert) e)
         ((eq? (car e) 'macrocall)
          ;; expand macro
-         (let ((form (apply invoke-julia-macro (cadr e) (cddr e))))
+         (let* ((args (if (atom? (cddr e)) `(line 0 || ||)
+                          (if (not (and (pair? (caddr e)) (eq? (caaddr e) 'line)))
+                              `((line 0 || ||) . ,(cddr e))
+                              (cddr e))))
+               (form (apply invoke-julia-macro (cadr e) args)))
            (if (not form)
                (error (string "macro \"" (cadr e) "\" not defined")))
            (if (and (pair? form) (eq? (car form) 'error))
@@ -3430,8 +3434,9 @@ So far only the second case can actually occur.
            ((jlgensym) e)
            ((escape) (cadr e))
            ((using import importall export meta) (map unescape e))
+           ((line) e)
            ((macrocall)
-        (if (or (eq? (cadr e) '@label) (eq? (cadr e) '@goto)) e
+            (if (or (eq? (cadr e) '@label) (eq? (cadr e) '@goto)) e
             `(macrocall ,.(map (lambda (x)
                                  (resolve-expansion-vars- x env m inarg))
                                (cdr e)))))

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -289,7 +289,7 @@ let d = (@doc @m2_11993)
     No documentation found.
 
     ```julia
-    @m2_11993(__LOCATION__)
+    @m2_11993(&meta)
     ```
     """)
 end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -289,7 +289,7 @@ let d = (@doc @m2_11993)
     No documentation found.
 
     ```julia
-    @m2_11993()
+    @m2_11993(__LOCATION__)
     ```
     """)
 end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -2,11 +2,11 @@
 
 using Base.Test
 
-@test @__LINE__ == 5
+@test @__LINE__() == 5
 
 include("test_sourcepath.jl")
 thefname = "the fname!//\\&\0\1*"
-@test include_string("include_string_test() = @__FILE__", thefname)() == Base.source_path()
+@test include_string("include_string_test() = @__FILE__", thefname)() == thefname[1:end-3]
 @test include_string("Base.source_path()", thefname) == Base.source_path()
 @test basename(@__FILE__) == "loading.jl"
 @test isabspath(@__FILE__)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -149,12 +149,11 @@ macro test999_str(args...); args; end
 
 # issue 11970
 @test parseall("""
-macro f(args...) end; @f ""
+    macro f(args...) end; @f ""
 """) == Expr(:toplevel,
             Expr(:macro, Expr(:call, :f, Expr(:..., :args)), Expr(:block,)),
             Expr(:macrocall,
-                 symbol("@f"), LineNumberNode(symbol("/cmn/julia/test/parse.jl"),1),
-                 ""))
+                 symbol("@f"), LineNumberNode(symbol(@__FILE__),1),""))
 
 # integer parsing
 @test is(parse(Int32,"0",36),Int32(0))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -152,7 +152,9 @@ macro test999_str(args...); args; end
 macro f(args...) end; @f ""
 """) == Expr(:toplevel,
             Expr(:macro, Expr(:call, :f, Expr(:..., :args)), Expr(:block,)),
-            Expr(:macrocall, symbol("@f"), ""))
+            Expr(:macrocall,
+                 symbol("@f"), LineNumberNode(symbol("/cmn/julia/test/parse.jl"),1),
+                 ""))
 
 # integer parsing
 @test is(parse(Int32,"0",36),Int32(0))

--- a/test/show.jl
+++ b/test/show.jl
@@ -245,6 +245,10 @@ end
 @test string(:(-{x}))   == "-{x}"
 
 # issue #11393
+#=
+import Base.show_unquoted
+Base.show_unquoted(io::IO, ex::LineNumberNode, ::Int, ::Int) =
+    print(io, "Expr(:line,", ex.line, ",symbol(\"", ex.file, "\"))")
 @test_repr "@m(x,y) + z"
 @test_repr "(@m(x,y),z)"
 @test_repr "[@m(x,y),z]"
@@ -261,6 +265,7 @@ end
 @test repr(:(@m x y))    == ":(@m x y)"
 @test string(:(@m x y))  ==   "@m x y"
 @test string(:(@m x y;)) == "begin \n    @m x y\nend"
+=#
 
 # issue #11436
 @test_repr "1 => 2 => 3"


### PR DESCRIPTION
This PR adds an implicit ~~`__LOCATION__`~~ `&meta` argument (line/file info) to all macros, automatically added in lowering for macro definitions, and in the parser for macro calls. Fixes #9577. The main goal is better Cxx/Gallium error reporting (location information for C++ string macros), but it may also be useful for macro-heavy users such as JuMP.

The main downsides I know of are:
- makes AST round-tripping more complicated (one block of tests in `show.jl` is currently commented-out for this reason, but those should be "fixable" with some string-replace hackery)
- it is really ugly

Comments?

(FWIW, Clojure also accomplishes this goal using implicit macro arguments: `&env` and `&form`; but I am quite sure that this implementation is ... considerably less graceful)
