### PR TITLE
Added tests for sparsevec

### DIFF
--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -904,6 +904,8 @@ A = sprandbool(5,5,0.2)
 # test sparsevec
 A = sparse(ones(5,5))
 @test all(full(sparsevec(A)) .== ones(25))
+@test all(full(sparsevec([1:5;],1)) .== ones(5))
+@test_throws ArgumentError sparsevec([1:5;], [1:4;])
 
 #test sparse
 @test sparse(A) == A


### PR DESCRIPTION
Covering untested lines for sparsevec called with a single number for the value or with mismatched index and value vectors.
