### PR TITLE
Profile JIT events with OProfile

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -59,6 +59,9 @@ $(warning "The julia make variable USE_MKL has been renamed to USE_INTEL_MKL")
 USE_INTEL_MKL := 1
 endif
 
+# Set to 1 to enable profiling with OProfile
+USE_OPROFILE_JITEVENTS ?= 0
+
 # libc++ is standard on OS X 10.9, but not for earlier releases
 USE_LIBCPP := 0
 
@@ -837,6 +840,11 @@ endif
 # Intel VTune Amplifier
 ifeq ($(USE_INTEL_JITEVENTS), 1)
 JCPPFLAGS += -DJL_USE_INTEL_JITEVENTS
+endif
+
+# OProfile
+ifeq ($(USE_OPROFILE_JITEVENTS), 1)
+JCPPFLAGS += -DJL_USE_OPROFILE_JITEVENTS
 endif
 
 # Intel libraries

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -424,6 +424,10 @@ else
 LLVM_FLAGS += --disable-threads
 endif # USE_INTEL_JITEVENTS
 
+ifeq ($(USE_OPROFILE_JITEVENTS), 1)
+LLVM_FLAGS += --with-oprofile=/usr/
+endif # USE_OPROFILE_JITEVENTS
+
 ifeq ($(BUILD_LLDB),1)
 ifeq ($(USECLANG),1)
 LLVM_FLAGS += --enable-cxx11

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6043,6 +6043,12 @@ extern "C" void jl_init_codegen(void)
             JITEventListener::createIntelJITEventListener());
 #endif // JL_USE_INTEL_JITEVENTS
 
+#ifdef JL_USE_OPROFILE_JITEVENTS
+    if (jl_using_oprofile_jitevents)
+        jl_ExecutionEngine->RegisterJITEventListener(
+            JITEventListener::createOProfileJITEventListener());
+#endif // JL_USE_OPROFILE_JITEVENTS
+
     BOX_F(int8,int8);  UBOX_F(uint8,uint8);
     BOX_F(int16,int16); UBOX_F(uint16,uint16);
     BOX_F(int32,int32); UBOX_F(uint32,uint32);

--- a/src/init.c
+++ b/src/init.c
@@ -346,6 +346,10 @@ void init_stdio()
 char jl_using_intel_jitevents; // Non-zero if running under Intel VTune Amplifier
 #endif
 
+#ifdef JL_USE_OPROFILE_JITEVENTS
+char jl_using_oprofile_jitevents = 0; // Non-zero if running under OProfile
+#endif
+
 int isabspath(const char *in)
 {
 #ifdef _OS_WINDOWS_
@@ -517,6 +521,13 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     const char *jit_profiling = getenv("ENABLE_JITPROFILING");
     if (jit_profiling && atoi(jit_profiling)) {
         jl_using_intel_jitevents = 1;
+    }
+#endif
+
+#if defined(JL_USE_OPROFILE_JITEVENTS)
+    const char *jit_profiling = getenv("ENABLE_JITPROFILING");
+    if (jit_profiling && atoi(jit_profiling)) {
+        jl_using_oprofile_jitevents = 1;
     }
 #endif
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -120,6 +120,9 @@ extern jl_array_t *jl_module_init_order;
 #ifdef JL_USE_INTEL_JITEVENTS
 extern char jl_using_intel_jitevents;
 #endif
+#ifdef JL_USE_OPROFILE_JITEVENTS
+extern char jl_using_oprofile_jitevents;
+#endif
 extern size_t jl_arr_xtralloc_limit;
 
 void jl_init_types(void);


### PR DESCRIPTION
This assumes that OProfile is installed in /usr.  Adjust deps/Makefile
if it is installed elsewhere (the line '--with-oprofile=/usr').

In the current default version of LLVM (3.3), the check to see if
the execution is being profiled only looks for the older style of
running OProfile. (It checks if the 'oprofiled' daemon is running.)
The check is in
llvm-3.3/lib/ExecutionEngine/OProfileJIT/OProfileWrapper.cpp

This is fixed to recognize 'operf' in newer versions of LLVM.
