### PR TITLE
fix #13309: return correct real value from var, varm, etc of complex arrays

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -6354,7 +6354,7 @@ minimum(A,dims)
 doc"""
     var(v[, region])
 
-Compute the sample variance of a vector or array `v`, optionally along dimensions in `region`. The algorithm will return an estimator of the generative distribution's variance under the assumption that each entry of `v` is an IID drawn from that generative distribution. This computation is equivalent to calculating `sum((v - mean(v)).^2) / (length(v) - 1)`. Note: Julia does not ignore `NaN` values in the computation. For applications requiring the handling of missing data, the `DataArray` package is recommended.
+Compute the sample variance of a vector or array `v`, optionally along dimensions in `region`. The algorithm will return an estimator of the generative distribution's variance under the assumption that each entry of `v` is an IID drawn from that generative distribution. This computation is equivalent to calculating `sumabs2(v - mean(v)) / (length(v) - 1)`. Note: Julia does not ignore `NaN` values in the computation. For applications requiring the handling of missing data, the `DataArray` package is recommended.
 """
 var
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1587,7 +1587,7 @@ Statistics
 
    .. Docstring generated from Julia source
 
-   Compute the sample variance of a vector or array ``v``\ , optionally along dimensions in ``region``\ . The algorithm will return an estimator of the generative distribution's variance under the assumption that each entry of ``v`` is an IID drawn from that generative distribution. This computation is equivalent to calculating ``sum((v - mean(v)).^2) / (length(v) - 1)``\ . Note: Julia does not ignore ``NaN`` values in the computation. For applications requiring the handling of missing data, the ``DataArray`` package is recommended.
+   Compute the sample variance of a vector or array ``v``\ , optionally along dimensions in ``region``\ . The algorithm will return an estimator of the generative distribution's variance under the assumption that each entry of ``v`` is an IID drawn from that generative distribution. This computation is equivalent to calculating ``sumabs2(v - mean(v)) / (length(v) - 1)``\ . Note: Julia does not ignore ``NaN`` values in the computation. For applications requiring the handling of missing data, the ``DataArray`` package is recommended.
 
 .. function:: varm(v, m)
 

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -310,3 +310,20 @@ end
 @test_throws ArgumentError histrange([1, 10], 0)
 @test_throws ArgumentError histrange([1, 10], -1)
 @test_throws ArgumentError histrange(Float64[],-1)
+
+# variance of complex arrays (#13309)
+let z = rand(Complex128, 10)
+    @test var(z) ≈ invoke(var, (Any,), z) ≈ cov(z) ≈ var(z,1)[1] ≈ sumabs2(z - mean(z))/9
+    @test isa(var(z), Float64)
+    @test isa(invoke(var, (Any,), z), Float64)
+    @test isa(cov(z), Float64)
+    @test isa(var(z,1), Vector{Float64})
+    @test varm(z, 0.0) ≈ invoke(varm, (Any,Float64), z, 0.0) ≈ sumabs2(z)/9
+    @test isa(varm(z, 0.0), Float64)
+    @test isa(invoke(varm, (Any,Float64), z, 0.0), Float64)
+    @test cor(z) === 1.0
+end
+let v = varm([1.0+2.0im], 0; corrected = false)
+    @test v ≈ 5
+    @test isa(v, Float64)
+end


### PR DESCRIPTION
This fixes issue #13309:
- `var(iterable)` and `varm(iterable, mean)` were giving the wrong values for complex arrays
- `var(z)` and `varm(z,mean)`, `cov(z)` etc. were giving the correct values, but were suboptimal because they often  returned a complex result even though the variance is (by definition) purely real
- `varm` was type unstable (sometimes returning real, sometimes returning complex results, depending on the length of the complex array)
- `cor(z)` was going to a lot of effort just to return 1.  Also, there seems no point in returning a complex or floating-point 1 when `one(real(T))` will do for an array of `T`.
