### PR TITLE
Fix issue #13106 by adding TargetTransformInfoWrapperPass to pass list.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -35,6 +35,7 @@
 #include <llvm/Analysis/Passes.h>
 #include <llvm/Bitcode/ReaderWriter.h>
 #ifdef LLVM37
+#include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Analysis/TargetLibraryInfo.h>
 #else
 #include <llvm/Target/TargetLibraryInfo.h>
@@ -5752,7 +5753,9 @@ static void init_julia_llvm_env(Module *m)
     FPM->add(llvm::createMemorySanitizerPass(true));
 #   endif
 #endif
-#ifndef LLVM37
+#ifdef LLVM37
+    FPM->add(createTargetTransformInfoWrapperPass(jl_TargetMachine->getTargetIRAnalysis()));
+#else
     jl_TargetMachine->addAnalysisPasses(*FPM);
 #endif
 #ifdef LLVM38


### PR DESCRIPTION
This PR fixes issue #13106.

LLVM 3.7 seems to introduce the pass normally via function `addPassesToGenerateCode`, which is called by `addPassesToEmitMC`, which are both defined in `lib/CodeGen/LLVMTargetMachine.cpp`.  If LLVM >=3.7 ever becomes our default version of LLVM, we should study that code more closely to see if we should be calling it instead of just inserting `createTargetTransformInfoWrapperPass` into the pass list.
