### PR TITLE
Make `replace` use `print` instead of `write`

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -173,9 +173,9 @@ function _rsplit{T<:AbstractString,U<:Array}(str::T, splitter, limit::Integer, k
 end
 #rsplit(str::AbstractString) = rsplit(str, _default_delims, 0, false)
 
-_replace(io, repl, str, r, pattern) = write(io, repl)
+_replace(io, repl, str, r, pattern) = print(io, repl)
 _replace(io, repl::Function, str, r, pattern) =
-    write(io, repl(SubString(str, first(r), last(r))))
+    print(io, repl(SubString(str, first(r), last(r))))
 
 function replace(str::ByteString, pattern, repl, limit::Integer)
     n = 1

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -205,6 +205,9 @@ end
 
 @test replace("foo", "oo", uppercase) == "fOO"
 
+# Issue 13332
+@test replace("abc", 'b', 2.1) == "a2.1c"
+
 # chomp/chop
 @test chomp("foo\n") == "foo"
 @test chop("foob") == "foo"


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/13332 by using `print` instead of `write` to print the replacement string to the output buffer. 
