### PR TITLE
Fix #13344 compiling issues in disasm.cpp

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -313,7 +313,11 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
 #else
     MCContext Ctx(*MAI, *MRI, MOFI.get(), &SrcMgr);
 #endif
+#ifdef LLVM38
+    MOFI->InitMCObjectFileInfo(TheTriple, Reloc::Default, CodeModel::Default, Ctx);
+#else
     MOFI->InitMCObjectFileInfo(TripleName, Reloc::Default, CodeModel::Default, Ctx);
+#endif
 
     // Set up Subtarget and Disassembler
 #ifdef LLVM35


### PR DESCRIPTION
This fixes an issue where the API has changed, and instead of a StringRef, a Triple is needed.
