### PR TITLE
fix #13360 by removing localtime_r from julia.h

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -1498,10 +1498,6 @@ DLLEXPORT int jl_tcp_bind(uv_tcp_t *handle, uint16_t port, uint32_t host, unsign
 
 DLLEXPORT int jl_sizeof_ios_t(void);
 
-#ifdef _OS_WINDOWS_
-DLLEXPORT struct tm* localtime_r(const time_t *t, struct tm *tm);
-#endif
-
 DLLEXPORT jl_array_t *jl_takebuf_array(ios_t *s);
 DLLEXPORT jl_value_t *jl_takebuf_string(ios_t *s);
 DLLEXPORT void *jl_takebuf_raw(ios_t *s);


### PR DESCRIPTION
Not really public api for embedders, as long as it's exported from libjulia (which it is, in `jl_uv.c`). Now that struct return from ccall works we could maybe refactor the `Libc.TmStruct` constructor and get rid of the `localtime_r` wrapper entirely from `jl_uv.c`, but hopefully this is good enough to avoid a conflict with recent LLVM.
