### PR TITLE
Update README link from Ubuntu Raring to Ubuntu (not a specific version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ The following distributions include julia, but the versions may be out of date d
   * Git package for openSUSE: [OBS page](https://build.opensuse.org/package/show/science/julia-unstable), [1 Click Install](http://software.opensuse.org/download.html?project=science&package=julia-unstable)
 * [NixOS](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/julia)
 * Ubuntu
-  * [Ubuntu 15.10 (Wily Werewolf)](http://packages.ubuntu.com/wily/julia)
+  * [Ubuntu](http://packages.ubuntu.com/search?keywords=julia)
   * [Nightly builds PPA](https://launchpad.net/~staticfloat/+archive/julianightlies) (depends on the [julia-deps PPA](https://launchpad.net/~staticfloat/+archive/julia-deps/))
 * [OS X Homebrew Tap](https://github.com/staticfloat/homebrew-julia/)
 

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ The following distributions include julia, but the versions may be out of date d
   * Git package for openSUSE: [OBS page](https://build.opensuse.org/package/show/science/julia-unstable), [1 Click Install](http://software.opensuse.org/download.html?project=science&package=julia-unstable)
 * [NixOS](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/julia)
 * Ubuntu
-  * [Ubuntu 13.04 (Raring Ringtail)](http://packages.ubuntu.com/raring/julia)
+  * [Ubuntu 15.10 (Wily Werewolf)](http://packages.ubuntu.com/wily/julia)
   * [Nightly builds PPA](https://launchpad.net/~staticfloat/+archive/julianightlies) (depends on the [julia-deps PPA](https://launchpad.net/~staticfloat/+archive/julia-deps/))
 * [OS X Homebrew Tap](https://github.com/staticfloat/homebrew-julia/)
 


### PR DESCRIPTION
Links for older Ubuntu version point to Julia 0.2. Thought about linking to current stable version, but I guess link might disappear in January 2016.. This one will be valid longer, but Wily isn't strictly released until October..
