### PR TITLE
Move the last RST only doc to julia

### DIFF
--- a/base/docs/bootstrap.jl
+++ b/base/docs/bootstrap.jl
@@ -19,10 +19,21 @@ _expand_ = nothing
 
 setexpand!(f) = global _expand_ = f
 
-setexpand!() do str, obj
+function __bootexpand(str, obj)
     global docs = List((ccall(:jl_get_current_module, Any, ()), str, obj), docs)
-    (isa(obj, Expr) && obj.head == :call) ? nothing : esc(Expr(:toplevel, obj))
+    (isa(obj, Expr) && obj.head == :call) && return nothing
+    (isa(obj, Expr) && obj.head == :module) && return esc(Expr(:toplevel, obj))
+    esc(obj)
 end
+
+function __bootexpand(expr::Expr)
+    if expr.head !== :->
+        throw(ArgumentError("Wrong argument to @doc"))
+    end
+    __bootexpand(expr.args...)
+end
+
+setexpand!(__bootexpand)
 
 """
     DocBootstrap :: Module

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -167,25 +167,36 @@ strerror(e::Integer) = bytestring(ccall(:strerror, Ptr{UInt8}, (Int32,), e))
 strerror() = strerror(errno())
 
 @windows_only begin
-GetLastError() = ccall(:GetLastError,stdcall,UInt32,())
-function FormatMessage(e=GetLastError())
-    const FORMAT_MESSAGE_ALLOCATE_BUFFER = UInt32(0x100)
-    const FORMAT_MESSAGE_FROM_SYSTEM = UInt32(0x1000)
-    const FORMAT_MESSAGE_IGNORE_INSERTS = UInt32(0x200)
-    const FORMAT_MESSAGE_MAX_WIDTH_MASK = UInt32(0xFF)
-    lpMsgBuf = Array(Ptr{UInt16})
-    lpMsgBuf[1] = 0
-    len = ccall(:FormatMessageW,stdcall,UInt32,(Cint, Ptr{Void}, Cint, Cint, Ptr{Ptr{UInt16}}, Cint, Ptr{Void}),
-        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
-        C_NULL, e, 0, lpMsgBuf, 0, C_NULL)
-    p = lpMsgBuf[1]
-    len == 0 && return utf8("")
-    len = len + 1
-    buf = Array(UInt16, len)
-    unsafe_copy!(pointer(buf), p, len)
-    ccall(:LocalFree,stdcall,Ptr{Void},(Ptr{Void},),p)
-    return utf8(UTF16String(buf))
-end
+    @doc """
+        GetLastError()
+
+    Call the Win32 `GetLastError` function [only available on Windows].
+    """ ->
+    GetLastError() = ccall(:GetLastError,stdcall,UInt32,())
+
+    @doc """
+        FormatMessage(n=GetLastError())
+
+    Convert a Win32 system call error code to a descriptive string [only available on Windows].
+    """ ->
+    function FormatMessage(e=GetLastError())
+        const FORMAT_MESSAGE_ALLOCATE_BUFFER = UInt32(0x100)
+        const FORMAT_MESSAGE_FROM_SYSTEM = UInt32(0x1000)
+        const FORMAT_MESSAGE_IGNORE_INSERTS = UInt32(0x200)
+        const FORMAT_MESSAGE_MAX_WIDTH_MASK = UInt32(0xFF)
+        lpMsgBuf = Array(Ptr{UInt16})
+        lpMsgBuf[1] = 0
+        len = ccall(:FormatMessageW,stdcall,UInt32,(Cint, Ptr{Void}, Cint, Cint, Ptr{Ptr{UInt16}}, Cint, Ptr{Void}),
+                    FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
+                    C_NULL, e, 0, lpMsgBuf, 0, C_NULL)
+        p = lpMsgBuf[1]
+        len == 0 && return utf8("")
+        len = len + 1
+        buf = Array(UInt16, len)
+        unsafe_copy!(pointer(buf), p, len)
+        ccall(:LocalFree,stdcall,Ptr{Void},(Ptr{Void},),p)
+        return utf8(UTF16String(buf))
+    end
 end
 
 ## Memory related ##

--- a/doc/stdlib/libc.rst
+++ b/doc/stdlib/libc.rst
@@ -46,9 +46,13 @@
 
 .. function:: GetLastError()
 
+   .. Docstring generated from Julia source
+
    Call the Win32 ``GetLastError`` function [only available on Windows].
 
 .. function:: FormatMessage(n=GetLastError())
+
+   .. Docstring generated from Julia source
 
    Convert a Win32 system call error code to a descriptive string [only available on Windows].
 


### PR DESCRIPTION
- Move the doc for the windows only `Libc.GetLastError` and `Libc.FormatMessage` functions to julia
- Fix the bootstrap `@doc` to support non-toplevel doc and the `->` syntax.
