### PR TITLE
strip all MD markup when calling docsearch on `Markdown.MD` object

### DIFF
--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -337,21 +337,34 @@ function docsearch(haystack::FuncDoc, needle)
     false
 end
 
-## Recursive Markdown search
-docsearch(haystack::Markdown.BlockQuote, needle) = docsearch(haystack.content, needle)
-docsearch(haystack::Markdown.Bold, needle) = docsearch(haystack.text, needle)
-docsearch(haystack::Markdown.Code, needle) = docsearch(haystack.code, needle)
-docsearch(haystack::Markdown.Header, needle) = docsearch(haystack.text, needle)
-docsearch(haystack::Markdown.HorizontalRule, needle) = false
-docsearch(haystack::Markdown.Image, needle) = docsearch(haystack.alt, needle)
-docsearch(haystack::Markdown.Italic, needle) = docsearch(haystack.text, needle)
-docsearch(haystack::Markdown.LaTeX, needle) = docsearch(haystack.formula, needle)
-docsearch(haystack::Markdown.LineBreak, needle) = false
-docsearch(haystack::Markdown.Link, needle) = docsearch(haystack.text, needle) # URL too?
-docsearch(haystack::Markdown.List, needle) = docsearch(haystack.items, needle)
-docsearch(haystack::Markdown.MD, needle) = docsearch(haystack.content, needle)
-docsearch(haystack::Markdown.Paragraph, needle) = docsearch(haystack.content, needle)
-docsearch(haystack::Markdown.Table, needle) = docsearch(haystack.rows, needle)
+## Markdown search simply strips all markup and searches plain text version
+docsearch(haystack::Markdown.MD, needle) =
+    docsearch(stripmd(haystack.content), needle)
+
+"""
+    stripmd(x)
+
+Strip all Markdown markup from x, leaving the result in plain text. Used
+internally by apropos to make docstrings containing more than one markdown
+element searchable.
+"""
+stripmd(x::AbstractString) = x  # base case
+stripmd(x::Vector) = string(map(stripmd, x)...)
+stripmd(x::Markdown.BlockQuote) = "$(stripmd(x.content))"
+stripmd(x::Markdown.Bold) = "$(stripmd(x.text))"
+stripmd(x::Markdown.Code) = "$(stripmd(x.code))"
+stripmd{N}(x::Markdown.Header{N}) = stripmd(x.text)
+stripmd(x::Markdown.HorizontalRule) = " "
+stripmd(x::Markdown.Image) = "$(stripmd(x.alt)) $(x.url)"
+stripmd(x::Markdown.Italic) = "$(stripmd(x.text))"
+stripmd(x::Markdown.LaTeX) = "$(x.formula)"
+stripmd(x::Markdown.LineBreak) = " "
+stripmd(x::Markdown.Link) = "$(stripmd(x.text)) $(x.url)"
+stripmd(x::Markdown.List) = join(map(stripmd, x.items), " ")
+stripmd(x::Markdown.MD) = join(map(stripmd, x.content), " ")
+stripmd(x::Markdown.Paragraph) = stripmd(x.content)
+stripmd(x::Markdown.Table) =
+    join([join(map(stripmd, r), " ") for r in x.rows], " ")
 
 # Apropos searches through all available documentation for some string or regex
 """


### PR DESCRIPTION
Instead of recursing through the elements inside a `Markdown.MD` object and searching them independently, this PR now strips all markup from the MD and searches all the plain text contents.

This means that we can now do things like this:

```
julia> """
       This *would* **not** have worked `before`

       > but now it *does*
       """
       foo(x, y) = x+y
foo (generic function with 1 method)

julia> apropos("but now it does")
foo

julia> apropos(r"would not.+before")
foo
```
