### PR TITLE
Fix error in type summaries

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -326,7 +326,7 @@ end
 doc(f::Base.Callable, args::Any...) = doc(f, Tuple{args...})
 
 function typesummary(T::DataType)
-    parts = [
+    parts = UTF8String[
     """
     **Summary:**
     ```julia

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -318,6 +318,9 @@ end
 
 @test isdefined(MacroGenerated, :_g)
 
+# Issue #13385.
+@test @doc(I) !== nothing
+
 # Issue #12700.
 @test @doc(DocsTest.@m) == doc"Inner.@m"
 


### PR DESCRIPTION
Types with fields containing unicode characters would throw an error since the initial type of the `parts` vector would be ASCII instead of utf8. Fixes #13385.
