### PR TITLE
fixed #13379: `transact` slowdown due to unnecessary file addition

### DIFF
--- a/base/libgit2.jl
+++ b/base/libgit2.jl
@@ -444,12 +444,8 @@ function snapshot(repo::GitRepo)
     index = with(GitIndex, repo) do idx; write_tree!(idx) end
     work = try
         with(GitIndex, repo) do idx
-            content = readdir(path(repo))
-            if length(content) > 1
-                files = [utf8(bytestring(c))::UTF8String for c in content]
-                push!(files, utf8("."))
-
-                add!(idx, files...)
+            if length(readdir(path(repo))) > 1
+                add!(idx, utf8("."))
                 write!(idx)
             end
             write_tree!(idx)


### PR DESCRIPTION
Originally, there were two git commands which saved altered content of repository: 

> git add -A
> git add .

Mistakenly, I explicitly added all  files in repo directory which reduced performance of operations that use this function. Apparently, it was sufficient to pass current dir `.` which is root of the repository to stash all changes in repo index.
