### PR TITLE
checks dir in order to prevent exception loss

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -197,7 +197,7 @@ function clone(url::AbstractString, pkg::AbstractString)
             LibGit2.set_remote_url(repo, url)
         end
     catch
-        Base.rm(pkg, recursive=true)
+        isdir(pkg) && Base.rm(pkg, recursive=true)
         rethrow()
     end
     info("Computing changes...")


### PR DESCRIPTION
Checks if folder was created before deleting. This should solve exception inhibition caused by `rm` exception. It's related to #13390 error report.
