### PR TITLE
Disable FastISel on ARM

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5998,7 +5998,8 @@ extern "C" void jl_init_codegen(void)
             );
     delete targetMachine;
     assert(jl_TargetMachine);
-#ifdef USE_MCJIT
+#if defined(USE_MCJIT) && !defined(_CPU_ARM_)
+    // FastISel seems to be buggy for ARM. Ref #13321
     jl_TargetMachine->setFastISel(true);
 #endif
 #if defined(LLVM38)


### PR DESCRIPTION
FastISel seems to be selecting the wrong instructions on ARM https://github.com/JuliaLang/julia/issues/13321#issuecomment-143393963 . Both @vtjnash and I have been able to reproduce this and have both bisected to the commit that introduce FastISel as the cause of the SegFault.

@vtjnash and @ViralBShah have got it working on llvm-svn or a different CPU but I think it's safe to say that FastISel is not very reliable on ARM yet. Therefore, this patch simply disable FastISel for all ARM cpus instead of conditionally do that depending on the ARM cpu model and/or LLVM version. We can always re-enable this when we have more tests.

Fix #13321 
