### PR TITLE
document that second argument to hash is UInt

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -6603,7 +6603,7 @@ Compute the cosecant of `x`, where `x` is in radians
 csc
 
 doc"""
-    hash(x[, h])
+    hash(x[, h::UInt])
 
 Compute an integer hash code such that `isequal(x,y)` implies `hash(x)==hash(y)`. The optional second argument `h` is a hash code to be mixed with the result.
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -306,7 +306,7 @@ All Objects
 
    Get a unique integer id for ``x``\ . ``object_id(x)==object_id(y)`` if and only if ``is(x,y)``\ .
 
-.. function:: hash(x[, h])
+.. function:: hash(x[, h::UInt])
 
    .. Docstring generated from Julia source
 
@@ -1384,4 +1384,3 @@ Internals
    .. Docstring generated from Julia source
 
    Compile the given function ``f`` for the argument tuple (of types) ``args``\ , but do not execute it.
-


### PR DESCRIPTION
I was confused while trying to implement my own `hash` function when things like `hash(sum,1)` failed. This would have helped. I'm not up on the doc changes, so sorry if this is not the correct way to add this information.
