### PR TITLE
LibGit2: tests & improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
     - cd .. && mv julia julia2
     - cp /tmp/julia/lib/julia/sys.ji local.ji && /tmp/julia/bin/julia -J local.ji -e 'true' && /tmp/julia/bin/julia-debug -J local.ji -e 'true' && rm local.ji
     - /tmp/julia/bin/julia -e 'versioninfo()'
-    - export JULIA_CPU_CORES=2 && cd /tmp/julia/share/julia/test && /tmp/julia/bin/julia --check-bounds=yes runtests.jl all && /tmp/julia/bin/julia --check-bounds=yes runtests.jl pkg
+    - export JULIA_CPU_CORES=2 && cd /tmp/julia/share/julia/test && /tmp/julia/bin/julia --check-bounds=yes runtests.jl all && /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online pkg
     - cd - && mv julia2 julia
     - sudo dmesg
     - echo "Ready for packaging..."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,4 +49,4 @@ build_script:
 test_script:
   - usr\bin\julia -e "versioninfo()"
   - copy usr\lib\julia\sys.ji local.ji && usr\bin\julia -J local.ji -e "true" && del local.ji
-  - cd test && ..\usr\bin\julia runtests.jl all && ..\usr\bin\julia runtests.jl pkg
+  - cd test && ..\usr\bin\julia runtests.jl all && ..\usr\bin\julia runtests.jl libgit2-online pkg

--- a/base/libgit2.jl
+++ b/base/libgit2.jl
@@ -9,6 +9,7 @@ export with, GitRepo, GitConfig
 const GITHUB_REGEX =
     r"^(?:git@|git://|https://(?:[\w\.\+\-]+@)?)github.com[:/](([^/].+)/(.+?))(?:\.git)?$"i
 
+include("libgit2/utils.jl")
 include("libgit2/consts.jl")
 include("libgit2/types.jl")
 include("libgit2/error.jl")
@@ -30,7 +31,6 @@ include("libgit2/rebase.jl")
 include("libgit2/status.jl")
 include("libgit2/tree.jl")
 include("libgit2/callbacks.jl")
-include("libgit2/utils.jl")
 
 immutable State
     head::Oid
@@ -141,17 +141,18 @@ function set_remote_url(path::AbstractString, url::AbstractString; remote::Abstr
 end
 
 """ git fetch [<url>|<repository>] [<refspecs>]"""
-function fetch{T<:AbstractString}(repo::GitRepo;
+function fetch{T<:AbstractString, P<:AbstractPayload}(repo::GitRepo;
                                   remote::AbstractString="origin",
                                   remoteurl::AbstractString="",
-                                  refspecs::Vector{T}=AbstractString[])
+                                  refspecs::Vector{T}=AbstractString[],
+                                  payload::Nullable{P}=Nullable{AbstractPayload}())
     rmt = if isempty(remoteurl)
         get(GitRemote, repo, remote)
     else
         GitRemoteAnon(repo, remoteurl)
     end
     try
-        fo = FetchOptions(callbacks=RemoteCallbacks(credentials=credentials_cb()))
+        fo = FetchOptions(callbacks=RemoteCallbacks(credentials_cb(), payload))
         fetch(rmt, refspecs, msg="from $(url(rmt))", options = fo)
     catch err
         warn("fetch: $err")
@@ -161,19 +162,20 @@ function fetch{T<:AbstractString}(repo::GitRepo;
 end
 
 """ git push [<url>|<repository>] [<refspecs>]"""
-function push{T<:AbstractString}(repo::GitRepo;
+function push{T<:AbstractString, P<:AbstractPayload}(repo::GitRepo;
               remote::AbstractString="origin",
               remoteurl::AbstractString="",
               refspecs::Vector{T}=AbstractString[],
-              force::Bool=false)
+              force::Bool=false,
+              payload::Nullable{P}=Nullable{AbstractPayload}())
     rmt = if isempty(remoteurl)
         get(GitRemote, repo, remote)
     else
         GitRemoteAnon(repo, remoteurl)
     end
     try
-        po = PushOptions(callbacks=RemoteCallbacks(credentials=credentials_cb()))
-        push(rmt, refspecs, force=force, options=po)
+        push_opts=PushOptions(callbacks=RemoteCallbacks(credentials_cb(), payload))
+        push(rmt, refspecs, force=force, options=push_opts)
     finally
         finalize(rmt)
     end
@@ -232,13 +234,15 @@ function branch!(repo::GitRepo, branch_name::AbstractString,
             end
         end
 
-        # checout selected branch
-        with(peel(GitTree, branch_ref)) do btree
-            checkout_tree(repo, btree)
-        end
+        if set_head
+            # checkout selected branch
+            with(peel(GitTree, branch_ref)) do btree
+                checkout_tree(repo, btree)
+            end
 
-        # switch head to the branch
-        set_head && head!(repo, branch_ref)
+            # switch head to the branch
+            head!(repo, branch_ref)
+        end
     finally
         finalize(branch_ref)
     end
@@ -289,17 +293,20 @@ function checkout!(repo::GitRepo, commit::AbstractString = "";
 end
 
 """ git clone [-b <branch>] [--bare] <url> <dir> """
-function clone(repo_url::AbstractString, repo_path::AbstractString;
+function clone{P<:AbstractPayload}(repo_url::AbstractString, repo_path::AbstractString;
                branch::AbstractString="",
                isbare::Bool = false,
-               remote_cb::Ptr{Void} = C_NULL)
-    # setup colne options
+               remote_cb::Ptr{Void} = C_NULL,
+               payload::Nullable{P}=Nullable{AbstractPayload}())
+    # setup clone options
+    fetch_opts=FetchOptions(callbacks = RemoteCallbacks(credentials_cb(), payload))
     clone_opts = CloneOptions(
-                    bare = Int32(isbare),
-                    checkout_branch = isempty(branch) ? Cstring_NULL :
-                                      convert(Cstring, pointer(branch)),
-                    remote_cb = remote_cb
-                )
+                bare = Int32(isbare),
+                checkout_branch = isempty(branch) ? Cstring_NULL :
+                                  convert(Cstring, pointer(branch)),
+                fetch_opts=fetch_opts,
+                remote_cb = remote_cb
+            )
     return clone(repo_url, repo_path, clone_opts)
 end
 
@@ -357,7 +364,8 @@ function merge!(repo::GitRepo;
                 committish::AbstractString = "",
                 branch::AbstractString = "",
                 fastforward::Bool = false,
-                options = MergeOptions())
+                merge_opts::MergeOptions = MergeOptions(),
+                checkout_opts::CheckoutOptions = CheckoutOptions())
     # merge into head branch
     with(head(repo)) do head_ref
         upst_anns = if !isempty(committish) # merge committish into HEAD
@@ -383,7 +391,7 @@ function merge!(repo::GitRepo;
         end
 
         try
-            merge!(repo, upst_anns, fastforward, options)
+            merge!(repo, upst_anns, fastforward, merge_opts, checkout_opts=checkout_opts)
         finally
             for ann in upst_anns
                 finalize(ann)

--- a/base/libgit2.jl
+++ b/base/libgit2.jl
@@ -301,7 +301,7 @@ function clone{P<:AbstractPayload}(repo_url::AbstractString, repo_path::Abstract
     # setup clone options
     fetch_opts=FetchOptions(callbacks = RemoteCallbacks(credentials_cb(), payload))
     clone_opts = CloneOptions(
-                bare = Int32(isbare),
+                bare = Cint(isbare),
                 checkout_branch = isempty(branch) ? Cstring_NULL :
                                   convert(Cstring, pointer(branch)),
                 fetch_opts=fetch_opts,

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -1,14 +1,7 @@
-function prompt(msg::AbstractString; default::AbstractString="", password::Bool=false)
-    msg = length(default) > 0 ? msg*" [$default]:" : msg*":"
-    uinput = if password
-        bytestring(ccall(:getpass, Cstring, (Cstring,), msg))
-    else
-        print(msg)
-        chomp(readline(STDIN))
-    end
-    length(uinput) == 0 ? default : uinput
-end
+"""Mirror callback function
 
+Function sets `+refs/*:refs/*` refspecs and `mirror` flag for remote reference.
+"""
 function mirror_callback(remote::Ptr{Ptr{Void}}, repo_ptr::Ptr{Void},
                          name::Cstring, url::Cstring, payload::Ptr{Void})
     # Create the remote with a mirroring url
@@ -29,20 +22,45 @@ function mirror_callback(remote::Ptr{Ptr{Void}}, repo_ptr::Ptr{Void},
     return Cint(0)
 end
 
+"""Credentials callback function
+
+Function provides different credential acquisition functionality w.r.t. a connection protocol.
+If payload is provided then `payload_ptr` should contain `LibGit2.AbstractPayload` object.
+
+For `LibGit2.Consts.CREDTYPE_USERPASS_PLAINTEXT` type, if payload contains fields: `user` & `pass` they are used to create authentication credentials.
+In addition, if payload has field `used` it can be set to `true` to indicate that payload was used and abort callback with error. This behavior is required to avoid repeated authentication calls with incorrect credentials.
+"""
 function credentials_callback(cred::Ptr{Ptr{Void}}, url_ptr::Cstring,
                               username_ptr::Cstring,
-                              allowed_types::Cuint, payload::Ptr{Void})
+                              allowed_types::Cuint, payload_ptr::Ptr{Void})
     err = 1
     url = bytestring(url_ptr)
 
     if isset(allowed_types, Cuint(Consts.CREDTYPE_USERPASS_PLAINTEXT))
-        # use keyboard-interactive prompt
-        username = prompt("Username for '$url'")
-        pass     = prompt("Password for '$url'", password=true)
+        username = password = ""
+        if payload_ptr != C_NULL
+            payload = unsafe_pointer_to_objref(payload_ptr)
+            if isa(payload, AbstractPayload)
+                username = isdefined(payload, :user) ? getfield(payload, :user) : ""
+                password = isdefined(payload, :pass) ? getfield(payload, :pass) : ""
+                if isdefined(payload, :used)
+                    getfield(payload, :used) && return Cint(-1)
+                    setfield!(payload, :used, true)
+                end
+            end
+        end
+        if isempty(username)
+            username = prompt("Username for '$url'")
+        end
+        if isempty(password)
+            password = prompt("Password for '$username@$url'", password=true)
+        end
+
+        length(username) == 0 && length(password) == 0 && return Cint(-1)
 
         err = ccall((:git_cred_userpass_plaintext_new, :libgit2), Cint,
                      (Ptr{Ptr{Void}}, Cstring, Cstring),
-                     cred, username, pass)
+                     cred, username, password)
         err == 0 && return Cint(0)
     elseif isset(allowed_types, Cuint(Consts.CREDTYPE_SSH_KEY)) && err > 0
         # use ssh-agent
@@ -91,6 +109,9 @@ function fetchhead_foreach_callback(ref_name::Cstring, remote_url::Cstring,
     return Cint(0)
 end
 
+"C function pointer for `mirror_callback`"
 mirror_cb() = cfunction(mirror_callback, Cint, (Ptr{Ptr{Void}}, Ptr{Void}, Cstring, Cstring, Ptr{Void}))
+"C function pointer for `credentials_callback`"
 credentials_cb() = cfunction(credentials_callback, Cint, (Ptr{Ptr{Void}}, Cstring, Cstring, Cuint, Ptr{Void}))
+"C function pointer for `fetchhead_foreach_callback`"
 fetchhead_foreach_cb() = cfunction(fetchhead_foreach_callback, Cint, (Cstring, Cstring, Ptr{Oid}, Cuint, Ptr{Void}))

--- a/base/libgit2/consts.jl
+++ b/base/libgit2/consts.jl
@@ -242,11 +242,11 @@ module Consts
                                 SUBMODULE_IGNORE_DIRTY        = 3,  # only dirty if HEAD moved
                                 SUBMODULE_IGNORE_ALL          = 4)  # never dirty
 
-    """
+    doc"""
 Option flags for `GitRepo`.
 
 * REPOSITORY_OPEN_NO_SEARCH - Only open the repository if it can be immediately found in the `path`.  Do not walk up from the `path` looking at parent directories.
-* REPOSITORY_OPEN_CROSS_FS - Unless this flag is set, open will not continue searching across filesystem boundaries. (E.g. Searching in a user's home directory "/home/user/source/" will not return "/.git/" as the found repo if "/" is a different filesystem than "/home".)
+* REPOSITORY_OPEN_CROSS_FS - Unless this flag is set, open will not continue searching across filesystem boundaries. (E.g. Searching in a user's home directory `/home/user/source/` will not return `/.git/` as the found repo if `/` is a different filesystem than `/home`.)
 * REPOSITORY_OPEN_BARE - Open repository as a bare repo regardless of core.bare config, and defer loading config file for faster setup.
     """
     @enum(GIT_REPOSITORY_OPEN, REPOSITORY_OPEN_DEFAULT   = 0,
@@ -271,7 +271,7 @@ Option flags for `GitRepo`.
                         CREDTYPE_USERNAME           = Cuint(1 << 5),
                         CREDTYPE_SSH_MEMORY         = Cuint(1 << 6))
 
-    """
+    doc"""
 Priority level of a config file.
 
 These priority levels correspond to the natural escalation logic (from higher to lower) when searching for config entries in git.

--- a/base/libgit2/consts.jl
+++ b/base/libgit2/consts.jl
@@ -263,4 +263,12 @@ module Consts
                         CREDTYPE_SSH_INTERACTIVE    = Cuint(1 << 4),
                         CREDTYPE_USERNAME           = Cuint(1 << 5),
                         CREDTYPE_SSH_MEMORY         = Cuint(1 << 6))
+
+    @enum(GIT_CONFIG, CONFIG_LEVEL_DEFAULT = 0,
+                      CONFIG_LEVEL_SYSTEM  = 1, # System-wide configuration file; /etc/gitconfig on Linux systems
+                      CONFIG_LEVEL_XDG     = 2, # XDG compatible configuration file; typically ~/.config/git/config
+                      CONFIG_LEVEL_GLOBAL  = 3, # User-specific configuration file (also called Global configuration file); typically ~/.gitconfig
+                      CONFIG_LEVEL_LOCAL   = 4, # Repository specific configuration file; $WORK_DIR/.git/config on non-bare repos
+                      CONFIG_LEVEL_APP     = 5, # Application specific configuration file; freely defined by applications
+                      CONFIG_HIGHEST_LEVEL =-1) # Represents the highest level available config file (i.e. the most specific config file available that actually is loaded)
 end

--- a/base/libgit2/consts.jl
+++ b/base/libgit2/consts.jl
@@ -242,10 +242,17 @@ module Consts
                                 SUBMODULE_IGNORE_DIRTY        = 3,  # only dirty if HEAD moved
                                 SUBMODULE_IGNORE_ALL          = 4)  # never dirty
 
-    @enum(GIT_REPOSITORY_OPEN, REPOSITORY_OPEN_DEFAULT   = 0,    # default value
-                               REPOSITORY_OPEN_NO_SEARCH = 1<<0, # only open the repository if it can be immediately found
-                               REPOSITORY_OPEN_CROSS_FS  = 1<<1, # open will not continue searching across FS boundaries
-                               REPOSITORY_OPEN_BARE      = 1<<2) # open repository as a bare repo
+    """
+Option flags for `GitRepo`.
+
+* REPOSITORY_OPEN_NO_SEARCH - Only open the repository if it can be immediately found in the `path`.  Do not walk up from the `path` looking at parent directories.
+* REPOSITORY_OPEN_CROSS_FS - Unless this flag is set, open will not continue searching across filesystem boundaries. (E.g. Searching in a user's home directory "/home/user/source/" will not return "/.git/" as the found repo if "/" is a different filesystem than "/home".)
+* REPOSITORY_OPEN_BARE - Open repository as a bare repo regardless of core.bare config, and defer loading config file for faster setup.
+    """
+    @enum(GIT_REPOSITORY_OPEN, REPOSITORY_OPEN_DEFAULT   = 0,
+                               REPOSITORY_OPEN_NO_SEARCH = 1<<0,
+                               REPOSITORY_OPEN_CROSS_FS  = 1<<1,
+                               REPOSITORY_OPEN_BARE      = 1<<2)
 
     @enum(GIT_BRANCH, BRANCH_LOCAL = 1, BRANCH_REMOTE = 2)
 
@@ -264,11 +271,24 @@ module Consts
                         CREDTYPE_USERNAME           = Cuint(1 << 5),
                         CREDTYPE_SSH_MEMORY         = Cuint(1 << 6))
 
+    """
+Priority level of a config file.
+
+These priority levels correspond to the natural escalation logic (from higher to lower) when searching for config entries in git.
+
+* CONFIG_LEVEL_DEFAULT - Open the global, XDG and system configuration files if any available.
+* CONFIG_LEVEL_SYSTEM - System-wide configuration file; /etc/gitconfig on Linux systems
+* CONFIG_LEVEL_XDG - XDG compatible configuration file; typically ~/.config/git/config
+* CONFIG_LEVEL_GLOBAL - User-specific configuration file (also called Global configuration file); typically ~/.gitconfig
+* CONFIG_LEVEL_LOCAL - Repository specific configuration file; \$WORK_DIR/.git/config on non-bare repos
+* CONFIG_LEVEL_APP - Application specific configuration file; freely defined by applications
+* CONFIG_HIGHEST_LEVEL - Represents the highest level available config file (i.e. the most specific config file available that actually is loaded)
+    """
     @enum(GIT_CONFIG, CONFIG_LEVEL_DEFAULT = 0,
-                      CONFIG_LEVEL_SYSTEM  = 1, # System-wide configuration file; /etc/gitconfig on Linux systems
-                      CONFIG_LEVEL_XDG     = 2, # XDG compatible configuration file; typically ~/.config/git/config
-                      CONFIG_LEVEL_GLOBAL  = 3, # User-specific configuration file (also called Global configuration file); typically ~/.gitconfig
-                      CONFIG_LEVEL_LOCAL   = 4, # Repository specific configuration file; $WORK_DIR/.git/config on non-bare repos
-                      CONFIG_LEVEL_APP     = 5, # Application specific configuration file; freely defined by applications
-                      CONFIG_HIGHEST_LEVEL =-1) # Represents the highest level available config file (i.e. the most specific config file available that actually is loaded)
+                      CONFIG_LEVEL_SYSTEM  = 1,
+                      CONFIG_LEVEL_XDG     = 2,
+                      CONFIG_LEVEL_GLOBAL  = 3,
+                      CONFIG_LEVEL_LOCAL   = 4,
+                      CONFIG_LEVEL_APP     = 5,
+                      CONFIG_HIGHEST_LEVEL =-1)
 end

--- a/base/libgit2/index.jl
+++ b/base/libgit2/index.jl
@@ -81,6 +81,7 @@ function add!{T<:AbstractString}(repo::GitRepo, files::T...;
         add!(idx, files..., flags = flags)
         write!(idx)
     end
+    return
 end
 
 function update!{T<:AbstractString}(repo::GitRepo, files::T...)
@@ -88,6 +89,7 @@ function update!{T<:AbstractString}(repo::GitRepo, files::T...)
         update!(idx, files...)
         write!(idx)
     end
+    return
 end
 
 function remove!{T<:AbstractString}(repo::GitRepo, files::T...)
@@ -95,12 +97,14 @@ function remove!{T<:AbstractString}(repo::GitRepo, files::T...)
         remove!(idx, files...)
         write!(idx)
     end
+    return
 end
 
 function read!(repo::GitRepo, force::Bool = false)
     with(GitIndex, repo) do idx
         read!(idx, force)
     end
+    return
 end
 
 function Base.count(idx::GitIndex)

--- a/base/libgit2/remote.jl
+++ b/base/libgit2/remote.jl
@@ -38,6 +38,28 @@ function url(rmt::GitRemote)
     return  bytestring(url_ptr)
 end
 
+function fetch_refspecs(rmt::GitRemote)
+    sa_ref = Ref{StrArrayStruct}()
+    try
+        @check ccall((:git_remote_get_fetch_refspecs, :libgit2), Cint,
+                      (Ptr{LibGit2.StrArrayStruct}, Ptr{Void}), sa_ref, rmt.ptr)
+        convert(Vector{AbstractString}, sa_ref[])
+    finally
+        finalize(sa_ref[])
+    end
+end
+
+function push_refspecs(rmt::GitRemote)
+    sa_ref = Ref{StrArrayStruct}()
+    try
+        @check ccall((:git_remote_get_push_refspecs, :libgit2), Cint,
+                      (Ptr{LibGit2.StrArrayStruct}, Ptr{Void}), sa_ref, rmt.ptr)
+        convert(Vector{AbstractString}, sa_ref[])
+    finally
+        finalize(sa_ref[])
+    end
+end
+
 function fetch{T<:AbstractString}(rmt::GitRemote, refspecs::Vector{T};
                options::FetchOptions = FetchOptions(),
                msg::AbstractString="")

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -52,6 +52,10 @@ end
 
 "Abstract payload type for callback functions"
 abstract AbstractPayload
+user(p::AbstractPayload) = throw(AssertionError("Function 'user' is not implemented for type $(typeof(p))"))
+password(p::AbstractPayload) = throw(AssertionError("Function 'password' is not implemented for type $(typeof(p))"))
+isused(p::AbstractPayload) = throw(AssertionError("Function 'isused' is not implemented for type $(typeof(p))"))
+setused!(p::AbstractPayload,v::Bool) = throw(AssertionError("Function 'setused!' is not implemented for type $(typeof(p))"))
 
 immutable CheckoutOptions
     version::Cuint
@@ -530,3 +534,7 @@ type UserPasswordCredentials <: AbstractPayload
     used::Bool
     UserPasswordCredentials(u::AbstractString,p::AbstractString) = new(u,p,false)
 end
+user(p::UserPasswordCredentials) = p.user
+password(p::UserPasswordCredentials) = p.pass
+isused(p::UserPasswordCredentials) = p.used
+setused!(p::UserPasswordCredentials, val::Bool) = (p.used = val)

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -8,3 +8,14 @@ function version()
 end
 
 isset(val::Integer, flag::Integer) = (val & flag == flag)
+
+function prompt(msg::AbstractString; default::AbstractString="", password::Bool=false)
+    msg = length(default) > 0 ? msg*" [$default]:" : msg*":"
+    uinput = if password
+        bytestring(ccall(:getpass, Cstring, (Cstring,), msg))
+    else
+        print(msg)
+        chomp(readline(STDIN))
+    end
+    length(uinput) == 0 ? default : uinput
+end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -651,7 +651,7 @@ function tag(pkg::AbstractString, ver::Union{Symbol,VersionNumber}, force::Bool=
                 existing = VersionNumber[keys(Read.available(pkg))...]
                 ancestors = filter(v->LibGit2.is_ancestor_of(avail[v].sha1, commit, repo), existing)
             else
-                tags = filter(t->startswith(t,"v"), Pkg.LibGit2.tag_list(repo))
+                tags = filter(t->startswith(t,"v"), LibGit2.tag_list(repo))
                 filter!(tag->ismatch(Base.VERSION_REGEX,tag), tags)
                 existing = VersionNumber[tags...]
                 filter!(tags) do tag

--- a/test/libgit2-online.jl
+++ b/test/libgit2-online.jl
@@ -1,0 +1,59 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
+@testset "libgit2-online" begin
+
+#########
+# Setup #
+#########
+
+function temp_dir(fn::Function, remove_tmp_dir::Bool=true)
+    tmpdir = joinpath(tempdir(),randstring())
+    @test !isdir(tmpdir)
+    try
+        mkdir(tmpdir)
+        @test isdir(tmpdir)
+        fn(tmpdir)
+    finally
+        remove_tmp_dir && rm(tmpdir, recursive=true)
+    end
+end
+
+#########
+# TESTS #
+#########
+# init & clone
+temp_dir() do dir
+    repo_url = "github.com/JuliaLang/Example.jl"
+    https_prefix = "https://"
+    ssh_prefix = "git@"
+    @testset "Cloning repository" begin
+        @testset "with 'https' protocol" begin
+            repo_path = joinpath(dir, "Example1")
+            repo = LibGit2.clone(https_prefix*repo_url, repo_path)
+            try
+                @test isdir(repo_path)
+                @test isdir(joinpath(repo_path, ".git"))
+            finally
+                finalize(repo)
+            end
+        end
+        @testset "with incorrect url" begin
+            repo_path = joinpath(dir, "Example2")
+            # credential are required because github try authenticate on uknown repo
+            x = Nullable(LibGit2.UserPasswordCredentials("X","X"))
+            @test_throws LibGit2.Error.GitError LibGit2.clone(https_prefix*repo_url*randstring(10), repo_path, payload=x)
+        end
+
+        try
+            @testset "with 'ssh' protocol (by default is not supported)" begin
+                repo_path = joinpath(dir, "Example3")
+                @test_throws LibGit2.Error.GitError LibGit2.clone(ssh_prefix*repo_url, repo_path)
+            end
+        catch ex
+            # but we cloned succesfully, so check that repo was created
+            ex.fail == 1 && @test isdir(joinpath(path, ".git"))
+        end
+    end
+end
+
+end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1,21 +1,50 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-# check that libgit2 has been installed correctly
+@testset "libgit2" begin
 
 const LIBGIT2_VER = v"0.23.0"
 
-function check_version()
-    v = LibGit2.version()
-    if v.major == LIBGIT2_VER.major && v.minor >= LIBGIT2_VER.minor
-        return true
-    else
-        return false
+#########
+# Setup #
+#########
+
+function temp_dir(fn::Function, remove_tmp_dir::Bool=true)
+    tmpdir = joinpath(tempdir(),randstring())
+    @test !isdir(tmpdir)
+    try
+        mkdir(tmpdir)
+        @test isdir(tmpdir)
+        fn(tmpdir)
+    finally
+        remove_tmp_dir && rm(tmpdir, recursive=true)
     end
 end
-@test check_version()
 
-# strarray
-begin
+
+#########
+# TESTS #
+#########
+
+@testset "Check library verison" begin
+    v = LibGit2.version()
+    @test  v.major == LIBGIT2_VER.major && v.minor >= LIBGIT2_VER.minor
+end
+
+@testset "OID" begin
+    z = LibGit2.Oid()
+    r = rand(LibGit2.Oid)
+    @test LibGit2.iszero(z)
+    @test z == zero(LibGit2.Oid)
+    rs = string(r)
+    rr = LibGit2.raw(r)
+    @test r == LibGit2.Oid(rr)
+    @test r == LibGit2.Oid(rs)
+    @test r == LibGit2.Oid(pointer(rr))
+    for i in 11:length(rr); rr[i] = 0; end
+    @test LibGit2.Oid(rr) == LibGit2.Oid(rs[1:20])
+end
+
+@testset "StrArrayStruct" begin
     p1 = "XXX"
     p2 = "YYY"
     sa1 = LibGit2.StrArrayStruct(p1)
@@ -41,206 +70,333 @@ begin
     end
 end
 
-function credentials!(cfg::LibGit2.GitConfig, usr="Test User", usr_email="Test@User.com")
-    git_user = LibGit2.get(cfg, "user.name", usr)
-    usr==git_user && LibGit2.set!(cfg, "user.name", usr)
-    git_user_email = LibGit2.get(cfg, "user.email", usr_email)
-    usr_email==git_user_email && LibGit2.set!(cfg, "user.email", usr_email)
+@testset "Signature" begin
+    sig = LibGit2.Signature("AAA", "AAA@BBB.COM", round(time(), 0), 0)
+    git_sig = convert(LibGit2.GitSignature, sig)
+    sig2 = LibGit2.Signature(git_sig)
+    finalize(git_sig)
+    @test sig.name == sig2.name
+    @test sig.email == sig2.email
+    @test sig.time == sig2.time
 end
 
-#TODO: tests need 'user.name' & 'user.email' in config ???
-LibGit2.with(LibGit2.GitConfig) do cfg
-    credentials!(cfg)
-end
-
-function temp_dir(fn::Function, remove_tmp_dir::Bool=true)
-    tmpdir = joinpath(tempdir(),randstring())
-    @test !isdir(tmpdir)
-    try
-        mkdir(tmpdir)
-        @test isdir(tmpdir)
-        fn(tmpdir)
-    finally
-        remove_tmp_dir && rm(tmpdir, recursive=true)
-    end
-end
-
-# clone bare
 temp_dir() do dir
+
+    # test parameters
     repo_url = "https://github.com/JuliaLang/Example.jl"
-    repo_path = joinpath(dir, "Example.Bare")
-    repo = LibGit2.clone(repo_url, repo_path, isbare = true, remote_cb = LibGit2.mirror_cb())
-    finalize(repo)
-    @test isdir(repo_path)
-    @test isfile(joinpath(repo_path, LibGit2.Consts.HEAD_FILE))
-end
+    ssh_prefix = "git@"
+    cache_repo = joinpath(dir, "Example")
+    test_repo = joinpath(dir, "Example.Test")
+    test_sig = LibGit2.Signature("TEST", "TEST@TEST.COM", round(time(), 0), 0)
+    test_file = "testfile"
+    config_file = "testconfig"
+    commit_msg1 = randstring(10)
+    commit_msg2 = randstring(10)
+    commit_oid1 = LibGit2.Oid()
+    commit_oid2 = LibGit2.Oid()
+    test_branch = "test_branch"
+    tag1 = "tag1"
+    tag2 = "tag2"
 
-# clone
-temp_dir() do dir
-    url = "https://github.com/JuliaLang/Example.jl"
-    path = joinpath(dir, "Example")
-    repo = LibGit2.clone(url, path)
-    finalize(repo)
-    @test isdir(path)
-    @test isdir(joinpath(path, ".git"))
-end
+    @testset "Configuration" begin
+        cfg = LibGit2.GitConfig(joinpath(dir, config_file), LibGit2.Consts.CONFIG_LEVEL_APP)
+        try
+            @test_throws LibGit2.Error.GitError LibGit2.get(AbstractString, cfg, "tmp.str")
+            @test isempty(LibGit2.get(cfg, "tmp.str", "")) == true
 
-# init
-temp_dir() do dir
-    path = joinpath(dir, "Example")
-    repo = LibGit2.init(path)
+            LibGit2.set!(cfg, "tmp.str", "AAAA")
+            LibGit2.set!(cfg, "tmp.int32", Int32(1))
+            LibGit2.set!(cfg, "tmp.int64", Int64(1))
+            LibGit2.set!(cfg, "tmp.bool", true)
 
-    @test isdir(path)
-    @test isdir(joinpath(path, ".git"))
-
-    branch = "upstream"
-    url = "https://github.com/JuliaLang/julia.git"
-    remote = LibGit2.GitRemote(repo, branch, url)
-    finalize(remote)
-
-    config = joinpath(path, ".git", "config")
-    lines = split(open(readall, config, "r"), "\n")
-    @test any(map(x->x == "[remote \"upstream\"]", lines))
-
-    remote = LibGit2.get(LibGit2.GitRemote, repo, branch)
-    @test LibGit2.url(remote) == url
-
-    finalize(repo)
-end
-
-# fetch
-temp_dir() do dir_cache
-    # create cache
-    url = "https://github.com/JuliaLang/Example.jl"
-    path_cache = joinpath(dir_cache, "Example.Bare")
-    repo = LibGit2.clone(url, path_cache, isbare = true, remote_cb = LibGit2.mirror_cb())
-    LibGit2.with(LibGit2.GitConfig, repo) do cfg
-        credentials!(cfg)
-    end
-    finalize(repo)
-
-    # fetch
-    temp_dir() do dir
-        # clone repo
-        path = joinpath(dir, "Example")
-        repo = LibGit2.clone(path_cache, path)
-        LibGit2.with(LibGit2.GitConfig, repo) do cfg
-            credentials!(cfg)
-        end
-
-        LibGit2.fetch(repo)
-        refs1 = parse(Int, readchomp(pipeline(`find $(joinpath(path, ".git/refs"))`,`wc -l`)))
-
-        LibGit2.fetch(repo, remoteurl=path_cache, refspecs =["+refs/*:refs/remotes/cache/*"])
-        refs2 = parse(Int, readchomp(pipeline(`find $(joinpath(path, ".git/refs"))`,`wc -l`)))
-
-        finalize(repo)
-        @test refs1 > 0
-        @test refs2 > 0
-        @test refs2 > refs1
-    end
-
-    # signature
-    temp_dir() do dir
-        path = joinpath(dir, "Example")
-        LibGit2.with(LibGit2.clone(path_cache, path)) do repo
-            oid = "129eb39c8e0817c616296d1ac5f2cd1cf4f8b312"
-            c = LibGit2.get(LibGit2.GitCommit, repo, oid)
-            auth = LibGit2.author(c)
-            cmtr = LibGit2.committer(c)
-            cmsg = LibGit2.message(c)
-            @test isa(auth, LibGit2.Signature)
-            @test length(auth.name) > 0
-            @test isa(cmtr, LibGit2.Signature)
-            @test length(cmtr.email) > 0
-            @test length(cmsg) > 0
-
-            sig = LibGit2.Signature("AAA", "AAA@BBB.COM", round(time(), 0), 0)
-            git_sig = convert(LibGit2.GitSignature, sig)
-            sig2 = LibGit2.Signature(git_sig)
-            finalize(git_sig)
-            @test sig.name == sig2.name
-            @test sig.email == sig2.email
-            @test sig.time == sig2.time
+            @test LibGit2.get(cfg, "tmp.str", "") == "AAAA"
+            @test LibGit2.get(cfg, "tmp.int32", Int32(0)) == Int32(1)
+            @test LibGit2.get(cfg, "tmp.int64", Int64(0)) == Int64(1)
+            @test LibGit2.get(cfg, "tmp.bool", false) == true
+        finally
+            finalize(cfg)
         end
     end
 
-    # revwalk
-    temp_dir() do dir
-        path = joinpath(dir, "Example")
-        repo = LibGit2.clone(path_cache, path)
-        LibGit2.with(LibGit2.GitConfig, repo) do cfg
-            credentials!(cfg)
-        end
-        oids = LibGit2.with(LibGit2.GitRevWalker(repo)) do walker
-            LibGit2.map((oid,repo)->string(oid), walker, by = LibGit2.Consts.SORT_TIME)
-        end
-        @test length(oids) > 0
-        finalize(repo)
+    @testset "Initializing repository" begin
+        @testset "with remote branch" begin
+            repo = LibGit2.init(cache_repo)
+            try
+                @test isdir(cache_repo)
+                @test isdir(joinpath(cache_repo, ".git"))
 
-        LibGit2.with(LibGit2.GitRepo, path) do repo
-            oid = LibGit2.Oid(oids[end])
-            oids = LibGit2.with(LibGit2.GitRevWalker(repo)) do walker
-                LibGit2.map((oid,repo)->(oid,repo), walker, oid=oid, by=LibGit2.Consts.SORT_TIME)
+                # set a remote branch
+                branch = "upstream"
+                LibGit2.GitRemote(repo, branch, repo_url) |> finalize
+
+                config = joinpath(cache_repo, ".git", "config")
+                lines = split(open(readall, config, "r"), "\n")
+                @test any(map(x->x == "[remote \"upstream\"]", lines))
+
+                remote = LibGit2.get(LibGit2.GitRemote, repo, branch)
+                @test LibGit2.url(remote) == repo_url
+                finalize(remote)
+            finally
+                finalize(repo)
             end
-            @test length(oids) > 0
+        end
+
+        @testset "bare" begin
+            path = joinpath(dir, "Example.Bare")
+            repo = LibGit2.init(path, Cuint(1))
+            try
+                @test isdir(path)
+                @test isfile(joinpath(path, LibGit2.Consts.HEAD_FILE))
+            finally
+                finalize(repo)
+            end
         end
     end
 
-    # transact
-    temp_dir() do dir
-        # clone repo
-        path = joinpath(dir, "Example")
-        LibGit2.with(LibGit2.clone(path_cache, path)) do repo
-            LibGit2.with(LibGit2.GitConfig, repo) do cfg
-                credentials!(cfg)
+    @testset "Cloning repository" begin
+
+        @testset "bare" begin
+            repo_path = joinpath(dir, "Example.Bare1")
+            repo = LibGit2.clone(cache_repo, repo_path, isbare = true)
+            try
+                @test isdir(repo_path)
+                @test isfile(joinpath(repo_path, LibGit2.Consts.HEAD_FILE))
+            finally
+                finalize(repo)
             end
-            cp(joinpath(path, "REQUIRE"), joinpath(path, "CCC"))
-            cp(joinpath(path, "REQUIRE"), joinpath(path, "AAA"))
+        end
+        @testset "bare with remote callback" begin
+            repo_path = joinpath(dir, "Example.Bare2")
+            repo = LibGit2.clone(cache_repo, repo_path, isbare = true, remote_cb = LibGit2.mirror_cb())
+            try
+                @test isdir(repo_path)
+                @test isfile(joinpath(repo_path, LibGit2.Consts.HEAD_FILE))
+                rmt = LibGit2.get(LibGit2.GitRemote, repo, "origin")
+                try
+                    @test LibGit2.fetch_refspecs(rmt)[1] == "+refs/*:refs/*"
+                finally
+                    finalize(rmt)
+                end
+            finally
+                finalize(repo)
+            end
+        end
+        @testset "normal" begin
+            repo = LibGit2.clone(cache_repo, test_repo, remote_cb = LibGit2.mirror_cb())
+            try
+                @test isdir(test_repo)
+                @test isdir(joinpath(test_repo, ".git"))
+            finally
+                finalize(repo)
+            end
+        end
+    end
+
+    @testset "Update cache repository" begin
+
+        @testset "with commits" begin
+            repo = LibGit2.GitRepo(cache_repo)
+            repo_file = open(joinpath(cache_repo,test_file), "a")
+            try
+                # create commits
+                println(repo_file, commit_msg1)
+                flush(repo_file)
+                LibGit2.add!(repo, test_file)
+                @test LibGit2.iszero(commit_oid1)
+                commit_oid1 = LibGit2.commit(repo, commit_msg1; author=test_sig, committer=test_sig)
+                @test !LibGit2.iszero(commit_oid1)
+
+                println(repo_file, randstring(10))
+                flush(repo_file)
+                LibGit2.add!(repo, test_file)
+                LibGit2.commit(repo, randstring(10); author=test_sig, committer=test_sig)
+
+                println(repo_file, commit_msg2)
+                flush(repo_file)
+                LibGit2.add!(repo, test_file)
+                @test LibGit2.iszero(commit_oid2)
+                commit_oid2 = LibGit2.commit(repo, commit_msg2; author=test_sig, committer=test_sig)
+                @test !LibGit2.iszero(commit_oid2)
+
+                # lookup commits
+                cmt = LibGit2.get(LibGit2.GitCommit, repo, commit_oid1)
+                try
+                    @test commit_oid1 == LibGit2.Oid(cmt)
+                    auth = LibGit2.author(cmt)
+                    @test isa(auth, LibGit2.Signature)
+                    @test auth.name == test_sig.name
+                    @test auth.time == test_sig.time
+                    @test auth.email == test_sig.email
+                    cmtr = LibGit2.committer(cmt)
+                    @test isa(cmtr, LibGit2.Signature)
+                    @test cmtr.name == test_sig.name
+                    @test cmtr.time == test_sig.time
+                    @test cmtr.email == test_sig.email
+                    @test LibGit2.message(cmt) == commit_msg1
+                finally
+                    finalize(cmt)
+                end
+            finally
+                finalize(repo)
+                close(repo_file)
+            end
+        end
+
+        @testset "with branch" begin
+            repo = LibGit2.GitRepo(cache_repo)
+            try
+                brnch = LibGit2.branch(repo)
+                @test brnch == "master"
+
+                LibGit2.branch!(repo, test_branch, string(commit_oid1), set_head=false)
+
+                branches = map(b->LibGit2.shortname(b[1]), LibGit2.GitBranchIter(repo))
+                @test "master" in branches
+                @test test_branch in branches
+            finally
+                finalize(repo)
+            end
+        end
+
+        @testset "with default configuration" begin
+            repo = LibGit2.GitRepo(cache_repo)
+            try
+                try
+                    LibGit2.Signature(repo)
+                catch ex
+                    # these test configure repo with new signature
+                    # in case when global one does not exsist
+                    @test isa(ex, LibGit2.Error.GitError) == true
+
+                    cfg = LibGit2.GitConfig(repo)
+                    LibGit2.set!(cfg, "user.name", "AAAA")
+                    LibGit2.set!(cfg, "user.email", "BBBB@BBBB.COM")
+                    sig = LibGit2.Signature(repo)
+                    @test sig.name == "AAAA"
+                    @test sig.email == "BBBB@BBBB.COM"
+                end
+            finally
+                finalize(repo)
+            end
+        end
+
+
+        @testset "with tags" begin
+            repo = LibGit2.GitRepo(cache_repo)
+            try
+                tags = LibGit2.tag_list(repo)
+                @test length(tags) == 0
+
+                tag_oid1 = LibGit2.tag_create(repo, tag1, commit_oid1, sig=test_sig)
+                @test !LibGit2.iszero(tag_oid1)
+                tags = LibGit2.tag_list(repo)
+                @test length(tags) == 1
+                @test tag1 in tags
+
+                tag_oid2 = LibGit2.tag_create(repo, tag2, commit_oid2)
+                @test !LibGit2.iszero(tag_oid2)
+                tags = LibGit2.tag_list(repo)
+                @test length(tags) == 2
+                @test tag2 in tags
+
+                LibGit2.tag_delete(repo, tag1)
+                tags = LibGit2.tag_list(repo)
+                @test length(tags) == 1
+                @test tag2 ∈ tags
+                @test tag1 ∉ tags
+            finally
+                finalize(repo)
+            end
+        end
+    end
+
+    @testset "Fetch from cache repository" begin
+        repo = LibGit2.GitRepo(test_repo)
+        try
+            # fetch changes
+            @test LibGit2.fetch(repo) == 0
+            @test !isfile(joinpath(test_repo, test_file))
+
+            # ff merge them
+            @test LibGit2.merge!(repo, fastforward=true)
+
+            # because there was not any file we need to reset branch
+            head_oid = LibGit2.head_oid(repo)
+            LibGit2.reset!(repo, head_oid, LibGit2.Consts.RESET_HARD)
+            @test isfile(joinpath(test_repo, test_file))
+        finally
+            finalize(repo)
+        end
+    end
+
+    @testset "Examine test repository" begin
+        @testset "files" begin
+            @test readall(joinpath(test_repo, test_file)) == readall(joinpath(cache_repo, test_file))
+        end
+
+        @testset "tags & branches" begin
+            repo = LibGit2.GitRepo(test_repo)
+            try
+                # all tag in place
+                tags = LibGit2.tag_list(repo)
+                @test length(tags) == 1
+                @test tag2 in tags
+
+                # all tag in place
+                branches = map(b->LibGit2.shortname(b[1]), LibGit2.GitBranchIter(repo))
+                @test "master" in branches
+                @test test_branch in branches
+            finally
+                finalize(repo)
+            end
+        end
+
+        @testset "commits with revwalk" begin
+            repo = LibGit2.GitRepo(test_repo)
+            cache = LibGit2.GitRepo(cache_repo)
+            try
+                oids = LibGit2.with(LibGit2.GitRevWalker(repo)) do walker
+                    LibGit2.map((oid,repo)->(oid,repo), walker, oid=commit_oid1, by=LibGit2.Consts.SORT_TIME)
+                end
+                @test length(oids) == 1
+
+                test_oids = LibGit2.with(LibGit2.GitRevWalker(repo)) do walker
+                    LibGit2.map((oid,repo)->string(oid), walker, by = LibGit2.Consts.SORT_TIME)
+                end
+                cache_oids = LibGit2.with(LibGit2.GitRevWalker(cache)) do walker
+                    LibGit2.map((oid,repo)->string(oid), walker, by = LibGit2.Consts.SORT_TIME)
+                end
+                @testloop for i in eachindex(oids)
+                    @test cache_oids[i] == test_oids[i]
+                end
+            finally
+                finalize(repo)
+                finalize(cache)
+            end
+        end
+    end
+
+    @testset "Transact test repository" begin
+        repo = LibGit2.GitRepo(test_repo)
+        try
+            cp(joinpath(test_repo, test_file), joinpath(test_repo, "CCC"))
+            cp(joinpath(test_repo, test_file), joinpath(test_repo, "AAA"))
             LibGit2.add!(repo, "AAA")
-            @test_throws ErrorException LibGit2.transact(repo) do repo
-                mv(joinpath(path, "REQUIRE"), joinpath(path, "BBB"))
-                LibGit2.add!(repo, "BBB")
-                oid = LibGit2.commit(repo, "test commit")
+            @test_throws ErrorException LibGit2.transact(repo) do trepo
+                mv(joinpath(test_repo, test_file), joinpath(test_repo, "BBB"))
+                LibGit2.add!(trepo, "BBB")
+                oid = LibGit2.commit(trepo, "test commit"; author=test_sig, committer=test_sig)
                 error("Force recovery")
             end
-            @test isfile(joinpath(path, "AAA"))
-            @test isfile(joinpath(path, "CCC"))
-            @test !isfile(joinpath(path, "BBB"))
-            @test isfile(joinpath(path, "REQUIRE"))
+            @test isfile(joinpath(test_repo, "AAA"))
+            @test isfile(joinpath(test_repo, "CCC"))
+            @test !isfile(joinpath(test_repo, "BBB"))
+            @test isfile(joinpath(test_repo, test_file))
+        finally
+            finalize(repo)
         end
     end
 
-    # branch
-    temp_dir() do dir
-        path = joinpath(dir, "Example")
-        LibGit2.with(LibGit2.clone(path_cache, path)) do repo
-            LibGit2.with(LibGit2.GitConfig, repo) do cfg
-                credentials!(cfg)
-            end
-            brnch = LibGit2.branch(repo)
-            @test brnch == "master"
-
-            brnch_name = "test"
-            LibGit2.branch!(repo, brnch_name)
-            brnch = LibGit2.branch(repo)
-            @test brnch == brnch_name
-        end
-    end
 end
 
-# Oid
-begin
-    z = LibGit2.Oid()
-    r = rand(LibGit2.Oid)
-    @test LibGit2.iszero(z)
-    @test z == zero(LibGit2.Oid)
-    rs = string(r)
-    rr = LibGit2.raw(r)
-    @test r == LibGit2.Oid(rr)
-    @test r == LibGit2.Oid(rs)
-    @test r == LibGit2.Oid(pointer(rr))
-    for i in 11:length(rr); rr[i] = 0; end
-    @test LibGit2.Oid(rr) == LibGit2.Oid(rs[1:20])
 end
-

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -232,7 +232,7 @@ end
 
 # issue #13374
 temp_pkg_dir() do
-    Pkg.generate("Foo", "MIT")
+    Pkg.generate("Foo", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
     Pkg.tag("Foo")
     Pkg.tag("Foo")
 end


### PR DESCRIPTION
PR provides following:
- more tests for `LibGit2` module (separated online part)
- `AbstractPayload` type for various callback payloads
- Credential callback can handle payload parameter (i.e. credentials)
- Payload support to high level functions: `clone`, `fetch`, `push`
- Some additional functions for remote references which are required for tests
- Function which generates for github credentials from git global config and 2FA token (if available)
