### PR TITLE
Fix throwing of Pkg errors, add error-condition tests and fixes

### DIFF
--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -28,15 +28,7 @@ function cd(f::Function, args...; kws...)
         !haskey(ENV,"JULIA_PKGDIR") ? init() :
             throw(PkgError("Package metadata directory $metadata_dir doesn't exist; run Pkg.init() to initialize it."))
     end
-    try
-        Base.cd(()->f(args...; kws...), dir)
-    catch err
-        if isa(err, PkgError)
-            print_with_color(:red, "ERROR: $(err.msg)")
-        else
-            throw(err)
-        end
-    end
+    Base.cd(()->f(args...; kws...), dir)
 end
 
 function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRANCH)

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -308,9 +308,9 @@ pin(pkg::AbstractString) = pin(pkg, "")
 
 function pin(pkg::AbstractString, ver::VersionNumber)
     ispath(pkg,".git") || throw(PkgError("$pkg is not a git repo"))
-    Read.isinstalled(pkg) || throw(PkgError("$pkg cannot be pinned – not an installed package".tmp))
+    Read.isinstalled(pkg) || throw(PkgError("$pkg cannot be pinned – not an installed package"))
     avail = Read.available(pkg)
-    isempty(avail) && throw(PkgError("$pkg cannot be pinned – not a registered package".tmp))
+    isempty(avail) && throw(PkgError("$pkg cannot be pinned – not a registered package"))
     haskey(avail,ver) || throw(PkgError("$pkg – $ver is not a registered version"))
     pin(pkg, avail[ver].sha1)
 end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -475,7 +475,7 @@ function resolve(
     for pkg in keys(reqs)
         if !haskey(deps,pkg)
             if "julia" in conflicts[pkg]
-                throw(PkgError("$pkg can't be installed because it has no versions that support ", VERSION, " of julia. " *
+                throw(PkgError("$pkg can't be installed because it has no versions that support $VERSION of julia. " *
                    "You may need to update METADATA by running `Pkg.update()`"))
             else
                 sconflicts = join(conflicts[pkg], ", ", " and ")

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -39,6 +39,7 @@ eval(Expr(:function, Expr(:call, :test_inline_2),
 
 try
     eval(:(test_inline_1()))
+    error("unexpected")
 catch err
     lkup = get_bt_frame(:test_inline_1, catch_backtrace())
     if is(lkup, nothing)
@@ -51,6 +52,7 @@ catch err
 end
 try
     eval(:(test_inline_2()))
+    error("unexpected")
 catch err
     lkup = get_bt_frame(:test_inline_2, catch_backtrace())
     if is(lkup, nothing)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -94,6 +94,7 @@ let deepthought(x, y) = 42
     try
         @assert 1 == 2 string("the answer to the ultimate question: ",
                               deepthought(6, 9))
+        error("unexpected")
     catch ex
         @test isa(ex, AssertionError)
         @test ex.msg == "the answer to the ultimate question: 42"

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -383,6 +383,7 @@ try
             @async error(i)
         end
     end
+    error("unexpected")
 catch ex
     @test typeof(ex) == CompositeException
     @test length(ex) == 5
@@ -394,6 +395,7 @@ end
 
 try
     remotecall_fetch(()->throw(ErrorException("foobar")), id_other)
+    error("unexpected")
 catch ex
     @test typeof(ex) == RemoteException
     @test typeof(ex.captured) == CapturedException

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -1,128 +1,128 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 function temp_pkg_dir(fn::Function)
-  # Used in tests below to setup and teardown a sandboxed package directory
-  const tmpdir = ENV["JULIA_PKGDIR"] = joinpath(tempdir(),randstring())
-  @test !isdir(Pkg.dir())
-  try
-    Pkg.init()
-    @test isdir(Pkg.dir())
-    Pkg.resolve()
+    # Used in tests below to setup and teardown a sandboxed package directory
+    const tmpdir = ENV["JULIA_PKGDIR"] = joinpath(tempdir(),randstring())
+    @test !isdir(Pkg.dir())
+    try
+        Pkg.init()
+        @test isdir(Pkg.dir())
+        Pkg.resolve()
 
-    fn()
-  finally
-    rm(tmpdir, recursive=true)
-  end
+        fn()
+    finally
+        rm(tmpdir, recursive=true)
+    end
 end
 
 
 # Test basic operations: adding or removing a package, status, free
 #Also test for the existence of REQUIRE and META_Branch
 temp_pkg_dir() do
-  @test isfile(joinpath(Pkg.dir(),"REQUIRE"))
-  @test isfile(joinpath(Pkg.dir(),"META_BRANCH"))
-  @test isempty(Pkg.installed())
-  Pkg.add("Example")
-  @test [keys(Pkg.installed())...] == ["Example"]
-  iob = IOBuffer()
-  Pkg.checkout("Example")
-  Pkg.status("Example", iob)
-  str = chomp(takebuf_string(iob))
-  @test startswith(str, " - Example")
-  @test endswith(str, "master")
-  Pkg.free("Example")
-  Pkg.status("Example", iob)
-  str = chomp(takebuf_string(iob))
-  @test endswith(str, string(Pkg.installed("Example")))
-  Pkg.checkout("Example")
-  Pkg.free(("Example",))
-  Pkg.status("Example", iob)
-  str = chomp(takebuf_string(iob))
-  @test endswith(str, string(Pkg.installed("Example")))
-  Pkg.rm("Example")
-  @test isempty(Pkg.installed())
-  @test !isempty(Pkg.available("Example"))
-  @test Pkg.available("IDoNotExist") === nothing
-  Pkg.clone("https://github.com/JuliaLang/Example.jl.git")
-  @test [keys(Pkg.installed())...] == ["Example"]
-  Pkg.status("Example", iob)
-  str = chomp(takebuf_string(iob))
-  @test startswith(str, " - Example")
-  @test endswith(str, "master")
-  Pkg.free("Example")
-  Pkg.status("Example", iob)
-  str = chomp(takebuf_string(iob))
-  @test endswith(str, string(Pkg.installed("Example")))
-  Pkg.checkout("Example")
-  Pkg.free(("Example",))
-  Pkg.status("Example", iob)
-  str = chomp(takebuf_string(iob))
-  @test endswith(str, string(Pkg.installed("Example")))
-  Pkg.rm("Example")
-  @test isempty(Pkg.installed())
+    @test isfile(joinpath(Pkg.dir(),"REQUIRE"))
+    @test isfile(joinpath(Pkg.dir(),"META_BRANCH"))
+    @test isempty(Pkg.installed())
+    Pkg.add("Example")
+    @test [keys(Pkg.installed())...] == ["Example"]
+    iob = IOBuffer()
+    Pkg.checkout("Example")
+    Pkg.status("Example", iob)
+    str = chomp(takebuf_string(iob))
+    @test startswith(str, " - Example")
+    @test endswith(str, "master")
+    Pkg.free("Example")
+    Pkg.status("Example", iob)
+    str = chomp(takebuf_string(iob))
+    @test endswith(str, string(Pkg.installed("Example")))
+    Pkg.checkout("Example")
+    Pkg.free(("Example",))
+    Pkg.status("Example", iob)
+    str = chomp(takebuf_string(iob))
+    @test endswith(str, string(Pkg.installed("Example")))
+    Pkg.rm("Example")
+    @test isempty(Pkg.installed())
+    @test !isempty(Pkg.available("Example"))
+    @test Pkg.available("IDoNotExist") === nothing
+    Pkg.clone("https://github.com/JuliaLang/Example.jl.git")
+    @test [keys(Pkg.installed())...] == ["Example"]
+    Pkg.status("Example", iob)
+    str = chomp(takebuf_string(iob))
+    @test startswith(str, " - Example")
+    @test endswith(str, "master")
+    Pkg.free("Example")
+    Pkg.status("Example", iob)
+    str = chomp(takebuf_string(iob))
+    @test endswith(str, string(Pkg.installed("Example")))
+    Pkg.checkout("Example")
+    Pkg.free(("Example",))
+    Pkg.status("Example", iob)
+    str = chomp(takebuf_string(iob))
+    @test endswith(str, string(Pkg.installed("Example")))
+    Pkg.rm("Example")
+    @test isempty(Pkg.installed())
 end
 
 # testing a package with test dependencies causes them to be installed for the duration of the test
 temp_pkg_dir() do
-  Pkg.generate("PackageWithTestDependencies", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
-  @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
-  @test readall(Pkg.dir("PackageWithTestDependencies","REQUIRE")) == "julia $(Pkg.Generate.versionfloor(VERSION))\n"
+    Pkg.generate("PackageWithTestDependencies", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
+    @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
+    @test readall(Pkg.dir("PackageWithTestDependencies","REQUIRE")) == "julia $(Pkg.Generate.versionfloor(VERSION))\n"
 
-  isdir(Pkg.dir("PackageWithTestDependencies","test")) || mkdir(Pkg.dir("PackageWithTestDependencies","test"))
-  open(Pkg.dir("PackageWithTestDependencies","test","REQUIRE"),"w") do f
-    println(f,"Example")
-  end
+    isdir(Pkg.dir("PackageWithTestDependencies","test")) || mkdir(Pkg.dir("PackageWithTestDependencies","test"))
+    open(Pkg.dir("PackageWithTestDependencies","test","REQUIRE"),"w") do f
+        println(f,"Example")
+    end
 
-  open(Pkg.dir("PackageWithTestDependencies","test","runtests.jl"),"w") do f
-    println(f,"using Base.Test")
-    println(f,"@test haskey(Pkg.installed(), \"Example\")")
-  end
+    open(Pkg.dir("PackageWithTestDependencies","test","runtests.jl"),"w") do f
+        println(f,"using Base.Test")
+        println(f,"@test haskey(Pkg.installed(), \"Example\")")
+    end
 
-  Pkg.resolve()
-  @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
+    Pkg.resolve()
+    @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
 
-  Pkg.test("PackageWithTestDependencies")
+    Pkg.test("PackageWithTestDependencies")
 
-  @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
+    @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
 end
 
 # testing a package with no runtests.jl errors
 temp_pkg_dir() do
-  Pkg.generate("PackageWithNoTests", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
+    Pkg.generate("PackageWithNoTests", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
 
-  if isfile(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
-    rm(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
-  end
+    if isfile(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
+        rm(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
+    end
 
-  try
-    Pkg.test("PackageWithNoTests")
-  catch err
-    @test err.msg == "PackageWithNoTests did not provide a test/runtests.jl file"
-  end
+    try
+        Pkg.test("PackageWithNoTests")
+    catch err
+        @test err.msg == "PackageWithNoTests did not provide a test/runtests.jl file"
+    end
 end
 
 # testing a package with failing tests errors
 temp_pkg_dir() do
-  Pkg.generate("PackageWithFailingTests", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
+    Pkg.generate("PackageWithFailingTests", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
 
-  isdir(Pkg.dir("PackageWithFailingTests","test")) || mkdir(Pkg.dir("PackageWithFailingTests","test"))
-  open(Pkg.dir("PackageWithFailingTests", "test", "runtests.jl"),"w") do f
-    println(f,"using Base.Test")
-    println(f,"@test false")
-  end
+    isdir(Pkg.dir("PackageWithFailingTests","test")) || mkdir(Pkg.dir("PackageWithFailingTests","test"))
+    open(Pkg.dir("PackageWithFailingTests", "test", "runtests.jl"),"w") do f
+        println(f,"using Base.Test")
+        println(f,"@test false")
+    end
 
-  try
-    Pkg.test("PackageWithFailingTests")
-  catch err
-    @test err.msg == "PackageWithFailingTests had test errors"
-  end
+    try
+        Pkg.test("PackageWithFailingTests")
+    catch err
+        @test err.msg == "PackageWithFailingTests had test errors"
+    end
 end
 
 # Testing with code-coverage
 temp_pkg_dir() do
-  Pkg.generate("PackageWithCodeCoverage", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
+    Pkg.generate("PackageWithCodeCoverage", "MIT", config=Dict("user.name"=>"Julia Test", "user.email"=>"test@julialang.org"))
 
-  src = """
+    src = """
 module PackageWithCodeCoverage
 
 export f1, f2, f3, untested
@@ -135,34 +135,34 @@ end
 untested(x) = 7
 
 end"""
-  linetested = [false, false, false, false, true, true, false, true, false, false]
-  open(Pkg.dir("PackageWithCodeCoverage", "src", "PackageWithCodeCoverage.jl"), "w") do f
-      println(f, src)
-  end
-  isdir(Pkg.dir("PackageWithCodeCoverage","test")) || mkdir(Pkg.dir("PackageWithCodeCoverage","test"))
-  open(Pkg.dir("PackageWithCodeCoverage", "test", "runtests.jl"),"w") do f
-    println(f,"using PackageWithCodeCoverage, Base.Test")
-    println(f,"@test f2(2) == 4")
-    println(f,"@test f3(5) == 15")
-  end
+    linetested = [false, false, false, false, true, true, false, true, false, false]
+    open(Pkg.dir("PackageWithCodeCoverage", "src", "PackageWithCodeCoverage.jl"), "w") do f
+        println(f, src)
+    end
+    isdir(Pkg.dir("PackageWithCodeCoverage","test")) || mkdir(Pkg.dir("PackageWithCodeCoverage","test"))
+    open(Pkg.dir("PackageWithCodeCoverage", "test", "runtests.jl"),"w") do f
+        println(f,"using PackageWithCodeCoverage, Base.Test")
+        println(f,"@test f2(2) == 4")
+        println(f,"@test f3(5) == 15")
+    end
 
-  Pkg.test("PackageWithCodeCoverage")
-  covdir = Pkg.dir("PackageWithCodeCoverage","src")
-  covfiles = filter!(x -> contains(x, "PackageWithCodeCoverage.jl") && contains(x,".cov"), readdir(covdir))
-  @test isempty(covfiles)
-  Pkg.test("PackageWithCodeCoverage", coverage=true)
-  covfiles = filter!(x -> contains(x, "PackageWithCodeCoverage.jl") && contains(x,".cov"), readdir(covdir))
-  @test !isempty(covfiles)
-  for file in covfiles
-      @test isfile(joinpath(covdir,file))
-      covstr = readall(joinpath(covdir,file))
-      srclines = split(src, '\n')
-      covlines = split(covstr, '\n')
-      for i = 1:length(linetested)
-          covline = (linetested[i] ? "        1 " : "        - ")*srclines[i]
-          @test covlines[i] == covline
-      end
-  end
+    Pkg.test("PackageWithCodeCoverage")
+    covdir = Pkg.dir("PackageWithCodeCoverage","src")
+    covfiles = filter!(x -> contains(x, "PackageWithCodeCoverage.jl") && contains(x,".cov"), readdir(covdir))
+    @test isempty(covfiles)
+    Pkg.test("PackageWithCodeCoverage", coverage=true)
+    covfiles = filter!(x -> contains(x, "PackageWithCodeCoverage.jl") && contains(x,".cov"), readdir(covdir))
+    @test !isempty(covfiles)
+    for file in covfiles
+        @test isfile(joinpath(covdir,file))
+        covstr = readall(joinpath(covdir,file))
+        srclines = split(src, '\n')
+        covlines = split(covstr, '\n')
+        for i = 1:length(linetested)
+            covline = (linetested[i] ? "        1 " : "        - ")*srclines[i]
+            @test covlines[i] == covline
+        end
+    end
 end
 
 # issue #13373

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -37,16 +37,16 @@ module CompletionFoo
 end
 
 function temp_pkg_dir(fn::Function)
-  # Used in tests below to setup and teardown a sandboxed package directory
-  const tmpdir = ENV["JULIA_PKGDIR"] = joinpath(tempdir(),randstring())
-  @test !isdir(Pkg.dir())
-  try
-    mkpath(Pkg.dir())
-    @test isdir(Pkg.dir())
-    fn()
-  finally
-    rm(tmpdir, recursive=true)
-  end
+    # Used in tests below to setup and teardown a sandboxed package directory
+    const tmpdir = ENV["JULIA_PKGDIR"] = joinpath(tempdir(),randstring())
+    @test !isdir(Pkg.dir())
+    try
+        mkpath(Pkg.dir())
+        @test isdir(Pkg.dir())
+        fn()
+    finally
+        rm(tmpdir, recursive=true)
+    end
 end
 
 test_complete(s) = completions(s,endof(s))

--- a/test/unicode/utf32.jl
+++ b/test/unicode/utf32.jl
@@ -163,7 +163,7 @@ for T in (UTF8String, UTF16String, UTF32String)
         # Lead followed by non-continuation character > 0xbf
         @test_throws UnicodeError convert(T, strval(T, UInt8[byt,0x80,0x80,0xc0]))
     end
-    catch exp ;
+    catch exp
         println("Error checking $T: $byt")
         throw(exp)
     end


### PR DESCRIPTION
First two commits are #13419, I'll rebase them out after that's merged. The bug with the extraneous `.tmp` is also present in 0.3 (and 0.2), so apparently no one has hit these error conditions and reported anything about it over the past 2 years.
