### PR TITLE
RFC: only warn once for a use of a deprecated binding

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -509,6 +509,7 @@ void jl_binding_deprecation_warning(jl_binding_t *b)
             else
                 jl_errorf("deprecated binding: %s", b->name->name);
         }
+        b->deprecated = 0;
     }
 }
 


### PR DESCRIPTION
RFC: only warn once for a use of a deprecated binding
