### PR TITLE
Fix inlinedAt debug locations

### DIFF
--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -34,6 +34,7 @@ eval(Expr(:function, Expr(:call, :test_inline_1),
 # different-file inline
 eval(Expr(:function, Expr(:call, :test_inline_2),
                      Expr(:block, LineNumberNode(symbol("backtrace.jl"), 99),
+                     LineNumberNode(symbol("foobar.jl"), 666),
                      LineNumberNode(symbol("/foo/bar/baz.jl"), 111),
                      Expr(:call, :throw, "foo"))))
 
@@ -74,6 +75,7 @@ loc = functionloc(f12977)
 @test endswith(loc[1], "backtrace.jl")
 @test loc[2] == linenum
 
+# issue #922: SimplifyCFG pass merges throws
 code_loc(p, skipC=true) = ccall(:jl_lookup_code_address, Any, (Ptr{Void},Cint), p, skipC)
 
 @noinline function test_throw_commoning(x)


### PR DESCRIPTION
This restores correct(*) inlined code location annotations from #12544. After 35c5234a, `ctx.lineno` cannot be used to indicate the function starting location, so hold this in a local variable instead.

*([still need](https://github.com/JuliaLang/julia/issues/1334#issuecomment-127648525) a way to handle nested inlines for the full solution)
