### PR TITLE
Fix read!(s::IO, a::Vector{UInt8}) to return a

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -129,6 +129,7 @@ function read!(s::IO, a::Vector{UInt8})
     for i in 1:length(a)
         a[i] = read(s, UInt8)
     end
+    return a
 end
 
 function read!{T}(s::IO, a::Array{T})

--- a/test/core.jl
+++ b/test/core.jl
@@ -3416,3 +3416,8 @@ end
 end
 @test f13432b(true) == true
 @test f13432b(false) == false
+
+#13433, read!(::IO, a::Vector{UInt8}) should return a
+type IO13433 <: IO end
+Base.read(::IO13433, ::Type{UInt8}) = 0x01
+@test read!(IO13433(), Array(UInt8, 4)) == [0x01, 0x01, 0x01, 0x01]


### PR DESCRIPTION
lost in #12839 

This was causing failures in ZipFile.jl, ref https://github.com/fhs/ZipFile.jl/pull/20#issuecomment-145197741 and https://github.com/JuliaLang/julia/pull/13357#issuecomment-145170312
