### PR TITLE
inlining lambdas

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1490,8 +1490,8 @@ function typeinf_uncached(linfo::LambdaStaticData, atypes::ANY, sparams::SimpleV
         for i=laty+1:la
             s[1][args[i]] = VarState(lastatype,false)
         end
-    else
-        @assert la == 0
+    elseif la != 0
+        return ((), Bottom, false) # wrong number of arguments
     end
 
     # types of closed vars
@@ -1804,7 +1804,9 @@ function eval_annotate(e::ANY, vtypes::ANY, sv::StaticVarInfo, decls, clo, undef
         argtypes = Tuple{[abstract_eval(a, vtypes, sv) for a in fargs]...}
         # recur inside inner functions once we have all types
         tr,ty = typeinf(called, argtypes, called.sparams, called, false, true)
-        called.ast = tr
+        if tr !== ()
+            called.ast = tr
+        end
     end
     return e
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -2180,6 +2180,21 @@ f9520c(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, args...) = 46
 @test invoke(f9520c, (Any, Any, Any, Any, Any, Any), 1, 2, 3, 4, 5, 6) == 46
 @test invoke(f9520c, (Any, Any, Any, Any, Any, Any, Any), 1, 2, 3, 4, 5, 6, 7) == 46
 
+call_lambda1() = (()->x)(1)
+call_lambda2() = ((x)->x)()
+call_lambda3() = ((x)->x)(1,2)
+call_lambda4() = ((x,y...)->x)()
+@test (try call_lambda1(); false; catch e; (e::ErrorException).msg; end) == "wrong number of arguments"
+@test (try call_lambda2(); false; catch e; (e::ErrorException).msg; end) == "wrong number of arguments"
+@test (try call_lambda3(); false; catch e; (e::ErrorException).msg; end) == "wrong number of arguments"
+@test (try call_lambda4(); false; catch e; (e::ErrorException).msg; end) == "too few arguments"
+call_lambda5() = ((x...)->x)()
+call_lambda6() = ((x...)->x)(1)
+call_lambda7() = ((x...)->x)(1,2)
+@test call_lambda5() == ()
+@test call_lambda6() == (1,)
+@test call_lambda7() == (1,2)
+
 # jl_new_bits testing
 let x = [1,2,3]
     @test ccall(:jl_new_bits, Any, (Any,Ptr{Void},), Int, x) === 1


### PR DESCRIPTION
this enables inference to inline lambdas and thunks, just like it was already able to do for generic functions

(hint: diff is more clear if you add `?w=1` to the link)
