### PR TITLE
RFC: better ntuple implementation without `@generated`

### DIFF
--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -29,9 +29,9 @@ include("options.jl")
 typealias Cint Int32
 typealias Csize_t UInt
 include("promotion.jl")
+include("expr.jl")
 include("tuple.jl")
 include("range.jl")
-include("expr.jl")
 include("error.jl")
 
 # core numeric operations & types

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -403,8 +403,6 @@ end
 
 @deprecate with_env(f::Function, key::AbstractString, val) withenv(f, key=>val)
 
-@deprecate ntuple(n::Integer, f::Function) ntuple(f, n)
-
 # 0.4 discontinued functions
 
 @noinline function subtypetree(x::DataType, level=-1)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -458,6 +458,9 @@ const apply_type_tfunc = function (A, args...)
 end
 add_tfunc(apply_type, 1, IInf, apply_type_tfunc)
 
+## external tfunc additions ##
+add_tfunc(ntuple, 2, 2, _ntuple_tfunc)
+
 function tuple_tfunc(argtype::ANY)
     if isa(argtype,DataType) && argtype.name === Tuple.name
         p = map(x->(isType(x) && !isa(x.parameters[1],TypeVar) ? typeof(x.parameters[1]) : x),

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -35,9 +35,9 @@ include("options.jl")
 
 # core operations & types
 include("promotion.jl")
+include("expr.jl")
 include("tuple.jl")
 include("range.jl")
-include("expr.jl")
 include("error.jl")
 
 # core numeric operations & types

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -145,12 +145,14 @@ foo(x, y, z) = x + y + z
 @test any((true,true,false)) === true
 @test any((true,true,true)) === true
 
-@test @inferred(ntuple(Base.Abs2Fun(), Val{0})) == ()
-@test @inferred(ntuple(Base.Abs2Fun(), Val{2})) == (1, 4)
-@test @inferred(ntuple(Base.Abs2Fun(), Val{3})) == (1, 4, 9)
-@test @inferred(ntuple(Base.Abs2Fun(), Val{4})) == (1, 4, 9, 16)
-@test @inferred(ntuple(Base.Abs2Fun(), Val{5})) == (1, 4, 9, 16, 25)
-@test @inferred(ntuple(Base.Abs2Fun(), Val{6})) == (1, 4, 9, 16, 25, 36)
+ntuple_val{T}(x, ::Type{Val{T}}) = ntuple(x, T)
+@test @inferred(ntuple_val(Base.Abs2Fun(), Val{0})) == ()
+@test @inferred(ntuple_val(Base.Abs2Fun(), Val{2})) == (1, 4)
+@test @inferred(ntuple_val(Base.Abs2Fun(), Val{3})) == (1, 4, 9)
+@test @inferred(ntuple_val(Base.Abs2Fun(), Val{4})) == (1, 4, 9, 16)
+@test @inferred(ntuple_val(Base.Abs2Fun(), Val{5})) == (1, 4, 9, 16, 25)
+@test @inferred(ntuple_val(Base.Abs2Fun(), Val{6})) == (1, 4, 9, 16, 25, 36)
 
 # issue #12854
-@test_throws TypeError ntuple(identity, Val{1:2})
+@test_throws TypeError ntuple(identity, Val{1})
+@test_throws TypeError ntuple_val(identity, Val{1:2})


### PR DESCRIPTION
instead of requiring `Val` to force constant propagation through dispatch, this allows type-inference to directly reason about the higher-level functionality of `ntuple`.

this is an example of one mechanism that could be used for avoiding needing a `@generated` function (and, as a bonus, a usage of `Val` in this case). this is not to pick on ntuple (added by @timholy in ae0ce5f4), but to open a larger discussion about having more efficient code generation and runtime behaviors though more direct coupling.

ping @JeffBezanson @carnaval who I think might already have ideas for evolving this
