### PR TITLE
Improve parse_eval_all line number reporting

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -15,6 +15,7 @@ extern "C" {
 #endif
 
 extern int jl_lineno;
+extern const char *jl_filename;
 
 static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ngensym);
 static jl_value_t *eval_body(jl_array_t *stmts, jl_value_t **locals, size_t nl, size_t ngensym,
@@ -159,6 +160,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         }
         if (jl_is_linenode(e)) {
             jl_lineno = jl_linenode_line(e);
+            jl_filename = jl_linenode_file(e)->name;
         }
         if (jl_is_newvarnode(e)) {
             jl_value_t *var = jl_fieldref(e,0);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -555,11 +555,12 @@ jl_value_t *jl_parse_eval_all(const char *fname, size_t len)
 {
     //jl_printf(JL_STDERR, "***** loading %s\n", fname);
     int last_lineno = jl_lineno;
+    int top_lineno = -1;
     const char *last_filename = jl_filename;
     jl_lineno = 0;
     jl_filename = fname;
-    jl_value_t *fn=NULL, *ln=NULL, *form=NULL, *result=jl_nothing;
-    JL_GC_PUSH4(&fn, &ln, &form, &result);
+    jl_value_t *fn=NULL, *ln=NULL, *form=NULL, *nest_exc=NULL, *result=jl_nothing;
+    JL_GC_PUSH5(&fn, &ln, &form, &result, &nest_exc);
     JL_TRY {
         // handle syntax error
         while (1) {
@@ -574,22 +575,38 @@ jl_value_t *jl_parse_eval_all(const char *fname, size_t len)
                     jl_interpret_toplevel_expr(form);
                 }
             }
+            top_lineno = jl_lineno; // jl_parse_next sets lineno.
             result = jl_toplevel_eval_flex(form, 1);
         }
     }
     JL_CATCH {
         jl_stop_parsing();
-        fn = jl_pchar_to_string(fname, len);
-        ln = jl_box_long(jl_lineno);
-        jl_lineno = last_lineno;
-        jl_filename = last_filename;
+
         if (jl_loaderror_type == NULL) {
+            // reset line and filename before throwing
+            jl_lineno = last_lineno;
+            jl_filename = last_filename;
             jl_rethrow();
         }
-        else {
-            jl_rethrow_other(jl_new_struct(jl_loaderror_type, fn, ln,
-                                           jl_exception_in_transit));
+
+        fn = jl_pchar_to_string(jl_filename, strlen(jl_filename));
+        ln = jl_box_long(jl_lineno);
+        nest_exc = jl_new_struct(jl_loaderror_type, fn, ln,
+                                 jl_exception_in_transit);
+
+        if ((strcmp(jl_filename, fname) == 0) &&
+                              jl_lineno == top_lineno) {
+            jl_lineno = last_lineno;
+            jl_filename = last_filename;
+            jl_rethrow_other(nest_exc);
         }
+
+        jl_lineno = last_lineno;
+        jl_filename = last_filename;
+        fn = jl_pchar_to_string(fname, len);
+        ln = jl_box_long(top_lineno);
+        jl_rethrow_other(jl_new_struct(jl_loaderror_type, fn, ln,
+                                       nest_exc));
     }
     jl_stop_parsing();
     jl_lineno = last_lineno;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -173,7 +173,7 @@ let exename = `$(joinpath(JULIA_HOME, Base.julia_exename())) --precompiled=yes`
             wait(proc)
             close(out.in)
             @test success(proc)
-            @test readchomp(out) == "WARNING: Foo.Deprecated is deprecated.\n  likely near no file:5"
+            @test readchomp(out) == "WARNING: Foo.Deprecated is deprecated.\n  likely near none:5"
         end
 
         @unix_only let out  = Pipe(),

--- a/test/core.jl
+++ b/test/core.jl
@@ -704,7 +704,7 @@ let didthrow =
         false
     catch ex
         @test isa(ex, LoadError)
-        @test isa(ex.error, InitError)
+        @test isa(ex.error.error, InitError)
         true
     end
     @test didthrow


### PR DESCRIPTION
Wraps a `LoadError` thrown by `jl_parse_eval_all` with the original top-level line/file from the parser.

Ref: https://github.com/JuliaOpt/JuMP.jl/issues/7 where we have a macro expansion that will throw `UndefVarError`:

```
using JuMP
m = Model()
@setObjective(m, Max, z)
```

before:

```
ERROR: LoadError: UndefVarError: z not defined
 in include at ./boot.jl:260
 in include_from_node1 at ./loading.jl:304
while loading /cmn/julia/dummy.jl, in expression starting on line 584
```

after:

```
julia> include("dummy.jl")
ERROR: LoadError: LoadError: UndefVarError: z not defined
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
while loading /home/isaiah/.julia/v0.5/JuMP/src/macros.jl, in expression starting on line 584
while loading /cmn/julia/dummy.jl, in expression starting on line 3
```
