### PR TITLE
RFC: Implement complex(::Type)

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -37,6 +37,9 @@ reim(z) = (real(z), imag(z))
 real{T<:Real}(::Type{T}) = T
 real{T<:Real}(::Type{Complex{T}}) = T
 
+complex{T<:Real}(::Type{T}) = Complex{T}
+complex{T<:Real}(::Type{Complex{T}}) = Complex{T}
+
 isreal(x::Real) = true
 isreal(z::Complex) = imag(z) == 0
 isimag(z::Number) = real(z) == 0

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -2,6 +2,13 @@
 
 @test reim(2 + 3im) == (2, 3)
 
+for T in (Int64, Float64)
+    @test real(T) == T
+    @test real(Complex{T}) == T
+    @test complex(T) == Complex{T}
+    @test complex(Complex{T}) == Complex{T}
+end
+
 # Basic arithmetic
 for T in (Float16, Float32, Float64, BigFloat)
     t = true


### PR DESCRIPTION
Currently there is a method `real(::Type)` that converts a type to its "real" part:

```
julia> real(Float64)
Float64

julia> real(Complex128)
Float64
```

This pull request adds a similar method `complex(::Type)` that behaves as follows:

```
julia> complex(Float64)
Complex{Float64}

julia> complex(Complex128)
Complex{Float64}
```

This is much more clear than writing `Complex{real(T)}`, which was necessary to get this behavior before.
