### PR TITLE
Prefer the parent module when serializing functions (fixes #13452)

### DIFF
--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -281,6 +281,8 @@ function serialize(s::SerializationState, f::Function)
         mod = ()
         if isa(f.env,Symbol)
             mod = Core
+        elseif isdefined(f.env, :module) && isa(f.env.module, Module)
+            mod = f.env.module
         elseif !is(f.env.defs, ())
             mod = f.env.defs.func.code.module
         end

--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -319,3 +319,26 @@ create_serialization_stream() do s
     r2 = deserialize(s)
     @test r1 == r2
 end
+
+# issue #13452
+module Test13452
+using Base.Test
+
+module Shell
+export foo
+foo(x) = error("Instances must implement foo")
+end
+
+module Instance1
+using ..Shell
+Shell.foo(x::Int) = "This is an Int"
+end
+
+using .Shell, .Instance1
+io = IOBuffer()
+serialize(io, foo)
+str = takebuf_string(io)
+@test isempty(search(str, "Instance1"))
+@test !isempty(search(str, "Shell"))
+
+end  # module Test13452


### PR DESCRIPTION
I've verified that this works on `0.4.0-rc4`, so @JuliaBackports.
