### PR TITLE
make A[:] = x::Number fall back to fill!

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -349,6 +349,9 @@ function unsafe_setindex!{T}(A::Array{T}, X::Array{T}, ::Colon)
     return A
 end
 
+setindex!{T}(A::Array{T}, x::Number, c::Colon) = unsafe_setindex!(A, x, c)
+unsafe_setindex!{T}(A::Array{T}, x::Number, ::Colon) = fill!(A, x)
+
 # efficiently grow an array
 
 function _growat!(a::Vector, i::Integer, delta::Integer)


### PR DESCRIPTION
@mbauman mentioned this in https://groups.google.com/forum/#!topic/julia-users/ub08AnpIutw

`A[:]` previously fell back to the AbstractArray function.

Before there was a performance difference:

```
julia> @time fill!(A, 0.);
  0.007387 seconds (4 allocations: 160 bytes)

julia> @time A[:] = 0.
  0.010574 seconds (5 allocations: 176 bytes)
```
