### PR TITLE
Avoid introducing local variable (and GC frame store) in `unsafe_setindex!`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -303,7 +303,10 @@ end
 setindex!{T}(A::Array{T}, x, i1::Real) = arrayset(A, convert(T,x)::T, to_index(i1))
 setindex!{T}(A::Array{T}, x, i1::Real, i2::Real, I::Real...) = arrayset(A, convert(T,x)::T, to_index(i1), to_index(i2), to_indexes(I...)...)
 
-unsafe_setindex!{T}(A::Array{T}, x, i1::Real, I::Real...) = @inbounds return arrayset(A, convert(T,x)::T, to_index(i1), to_indexes(I...)...)
+# Type inference is confused by `@inbounds return ...` and introduces a
+# !ispointerfree local variable and a GC frame
+unsafe_setindex!{T}(A::Array{T}, x, i1::Real, I::Real...) =
+    (@inbounds arrayset(A, convert(T,x)::T, to_index(i1), to_indexes(I...)...); A)
 
 # These are redundant with the abstract fallbacks but needed for bootstrap
 function setindex!(A::Array, x, I::AbstractVector{Int})


### PR DESCRIPTION
This is a workaround to avoid the generation of a GC frame store when `unsafe_setindex!` is called directly.

The problem seems to be that the type inference is not able to figure out the exit point of `@inbounds return ...`. (Or more precisely, the second return is never reachable and the result is not used anyway....)

``` julia
julia> Base.code_typed(Base.unsafe_setindex!, Tuple{Matrix{Float64}, Float64, Int})
1-element Array{Any,1}:
 :($(Expr(:lambda, Any[:A,:x,:i1,:(I::Real...)], Any[Any[Any[:A,Array{Float64,2},0],Any[:x,Float64,0],Any[:i1,Int64,0],Any[:I,Tuple{},0]],Any[],Any[],Any[:T]], :(begin  # array.jl, line 306:
        $(Expr(:boundscheck, false))
        return (Base.arrayset)(A::Array{Float64,2},x::Float64,i1::Int64)::Array{Float64,2}
        return $(Expr(:boundscheck, :(Base.pop)))
    end::Array{Float64,2}))))
```

The code above generates a pointer local variable and disables SIMD. There are many fixes/optimizations that we can do to avoid the store in the loop at multiple levels but I think this workaround should be the safest to backport to 0.4 with minimum side effect _(**not** necessarily 0.4.0)_.

This is an alternative solution to what's in https://github.com/JuliaLang/julia/pull/13459.
It seems that `A[:] = 0.` still generates one allocation while `fill!` doesn't so #13459 might still be good to have (or we should find why is `A[:] = 0.` allocate and fix that in general). (edit: It's the splatting panelty, see https://github.com/JuliaLang/julia/pull/13461#issuecomment-145694521)

``` julia
julia> @time fill!(A, 0.);
  0.008700 seconds (4 allocations: 160 bytes)

julia> @time A[:] = 0.;
  0.008251 seconds (5 allocations: 176 bytes)
```
