### PR TITLE
tbaa_gcframe

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -61,7 +61,7 @@ static Value *stringConstPtr(const std::string &txt)
                                     ssno.str());
             gv->setUnnamedAddr(true);
             pooledval->second = gv;
-            jl_ExecutionEngine->addGlobalMapping(gv, (void*)pooledtxt.data());
+            jl_ExecutionEngine->addGlobalMapping(gv, (void*)(uintptr_t)pooledtxt.data());
         }
 
         GlobalVariable *v = prepare_global(pooledval->second);


### PR DESCRIPTION
Add `tbaa_gcframe` and use it to decorate all stores and loads to/from the GC frame.
This doesn't rely on the the codegen rewrite so it should be easily back ported (probably after 0.4.0).

This is also yet another way to fix the performance issue in https://github.com/JuliaLang/julia/pull/13459 and https://github.com/JuliaLang/julia/pull/13461 .

Close #13301 (Load from gc frame is still bad but it doesn't prevent vectorization anymore)

@vtjnash @simonster .

@carnaval , you also mentioned this during JuliaCon.
