### PR TITLE
Make cov and cor similar to mean and var by removing keyword arguments.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@ Library improvements
   * The functions `remotecall`, `remotecall_fetch`, and `remotecall_wait` now have the
     function argument as the first argument to allow for do-block syntax ([#13338]).
 
+  * `cov` and `cor` don't use keyword arguments anymore and are therefore now type stable ([#13465]).
+
 Deprecated or removed
 ---------------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -842,3 +842,13 @@ for f in (:remotecall, :remotecall_fetch, :remotecall_wait)
         @deprecate ($f)(id::Integer, f::Function, args...)        ($f)(f, id::Integer, args...)
     end
 end
+
+@deprecate cov(x::AbstractVector; corrected=true, mean=nothing) covm(x, mean, corrected)
+@deprecate cov(X::AbstractMatrix; vardim=1, corrected=true, mean=nothing) covm(X, mean, vardim, corrected)
+@deprecate cov(x::AbstractVector, y::AbstractVector; corrected=true, mean=nothing) covm(x, mean[1], y, mean[2], corrected)
+@deprecate cov(X::AbstractVecOrMat, Y::AbstractVecOrMat; vardim=1, corrected=true, mean=nothing) covm(X, mean[1], Y, mean[2], vardim, corrected)
+
+@deprecate cor(x::AbstractVector; mean=nothing) corm(x, mean)
+@deprecate cor(X::AbstractMatrix; vardim=1, mean=nothing) corm(X, mean, vardim)
+@deprecate cor(x::AbstractVector, y::AbstractVector; mean=nothing) corm(x, mean[1], y, mean[2])
+@deprecate cor(X::AbstractVecOrMat, Y::AbstractVecOrMat; vardim=1, mean=nothing) corm(X, mean[1], Y, mean[2], vardim)

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -1141,15 +1141,6 @@ Get the precision of a floating point number, as defined by the effective number
 precision
 
 doc"""
-    cor(v1[, v2][, vardim=1, mean=nothing])
-
-Compute the Pearson correlation between the vector(s) in `v1` and `v2`.
-
-Users can use the keyword argument `vardim` to specify the variable dimension, and `mean` to supply pre-computed mean values.
-"""
-cor
-
-doc"""
     partitions(n)
 
 Generate all integer arrays that sum to `n`. Because the number of partitions can be very large, this function returns an iterator object. Use `collect(partitions(n))` to get an array of all partitions. The number of partitions to generate can be efficiently computed using `length(partitions(n))`.
@@ -9002,23 +8993,6 @@ doc"""
 The process was stopped by a terminal interrupt (CTRL+C).
 """
 InterruptException
-
-doc"""
-    cov(v1[, v2][, vardim=1, corrected=true, mean=nothing])
-
-Compute the Pearson covariance between the vector(s) in `v1` and `v2`. Here, `v1` and `v2` can be either vectors or matrices.
-
-This function accepts three keyword arguments:
-
-- `vardim`: the dimension of variables. When `vardim = 1`, variables are considered in columns while observations in rows; when `vardim = 2`, variables are in rows while observations in columns. By default, it is set to `1`.
-- `corrected`: whether to apply Bessel's correction (divide by `n-1` instead of `n`). By default, it is set to `true`.
-- `mean`: allow users to supply mean values that are known. By default, it is set to `nothing`, which indicates that the mean(s) are unknown, and the function will compute the mean. Users can use `mean=0` to indicate that the input data are centered, and hence there's no need to subtract the mean.
-
-The size of the result depends on the size of `v1` and `v2`. When both `v1` and `v2` are vectors, it returns the covariance between them as a scalar. When either one is a matrix, it returns a covariance matrix of size `(n1, n2)`, where `n1` and `n2` are the numbers of slices in `v1` and `v2`, which depend on the setting of `vardim`.
-
-Note: `v2` can be omitted, which indicates `v2 = v1`.
-"""
-cov
 
 doc"""
     den(x)

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -1691,29 +1691,53 @@ Statistics
 
    Like ``quantile``\ , but overwrites the input vector.
 
-.. function:: cov(v1[, v2][, vardim=1, corrected=true, mean=nothing])
+.. function:: cov(x[, corrected=true])
 
    .. Docstring generated from Julia source
 
-   Compute the Pearson covariance between the vector(s) in ``v1`` and ``v2``\ . Here, ``v1`` and ``v2`` can be either vectors or matrices.
+   Compute the variance of the vector ``x``\ . If ``corrected`` is ``true`` (the default) then the sum is scaled with ``n-1`` wheares the sum is scaled with ``n`` if ``corrected`` is ``false`` where ``n = length(x)``\ .
 
-   This function accepts three keyword arguments:
-
-   * ``vardim``\ : the dimension of variables. When ``vardim = 1``\ , variables are considered in columns while observations in rows; when ``vardim = 2``\ , variables are in rows while observations in columns. By default, it is set to ``1``\ .
-   * ``corrected``\ : whether to apply Bessel's correction (divide by ``n-1`` instead of ``n``\ ). By default, it is set to ``true``\ .
-   * ``mean``\ : allow users to supply mean values that are known. By default, it is set to ``nothing``\ , which indicates that the mean(s) are unknown, and the function will compute the mean. Users can use ``mean=0`` to indicate that the input data are centered, and hence there's no need to subtract the mean.
-
-   The size of the result depends on the size of ``v1`` and ``v2``\ . When both ``v1`` and ``v2`` are vectors, it returns the covariance between them as a scalar. When either one is a matrix, it returns a covariance matrix of size ``(n1, n2)``\ , where ``n1`` and ``n2`` are the numbers of slices in ``v1`` and ``v2``\ , which depend on the setting of ``vardim``\ .
-
-   Note: ``v2`` can be omitted, which indicates ``v2 = v1``\ .
-
-.. function:: cor(v1[, v2][, vardim=1, mean=nothing])
+.. function:: cov(X[, vardim=1, corrected=true])
 
    .. Docstring generated from Julia source
 
-   Compute the Pearson correlation between the vector(s) in ``v1`` and ``v2``\ .
+   Compute the covariance matrix of the matrix ``X`` along the dimension ``vardim``\ . If ``corrected`` is ``true`` (the default) then the sum is scaled with ``n-1`` wheares the sum is scaled with ``n`` if ``corrected`` is ``false`` where ``n = size(X, vardim)``\ .
 
-   Users can use the keyword argument ``vardim`` to specify the variable dimension, and ``mean`` to supply pre-computed mean values.
+.. function:: cov(x, y[, corrected=true])
+
+   .. Docstring generated from Julia source
+
+   Compute the covariance between the vectors ``x`` and ``y``\ . If ``corrected`` is ``true`` (the default) then the sum is scaled with ``n-1`` wheares the sum is scaled with ``n`` if ``corrected`` is ``false`` where ``n = length(x) = length(y)``\ .
+
+.. function:: cov(X, Y[, vardim=1, corrected=true])
+
+   .. Docstring generated from Julia source
+
+   Compute the covariance between the vectors or matrices ``X`` and ``Y`` along the dimension ``vardim``\ . If ``corrected`` is ``true`` (the default) then the sum is scaled with ``n-1`` wheares the sum is scaled with ``n`` if ``corrected`` is ``false`` where ``n = size(X, vardim) = size(Y, vardim)``\ .
+
+.. function:: cor(x)
+
+   .. Docstring generated from Julia source
+
+   Return the number one.
+
+.. function:: cor(X[, vardim=1])
+
+   .. Docstring generated from Julia source
+
+   Compute the Pearson correlation matrix of the matrix ``X`` along the dimension ``vardim``\ .
+
+.. function:: cor(x, y)
+
+   .. Docstring generated from Julia source
+
+   Compute the Pearson correlation between the vectors ``x`` and ``y``\ .
+
+.. function:: cor(X, Y[, vardim=1])
+
+   .. Docstring generated from Julia source
+
+   Compute the Pearson correlation between the vectors or matrices ``X`` and ``Y`` along the dimension ``vardim``\ .
 
 Signal Processing
 -----------------

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -415,7 +415,7 @@ f12593_2() = 1
 @test (Docs.@repl @r_str) !== nothing
 
 # Simple tests for apropos:
-@test contains(sprint(apropos, "pearson"), "cov")
+@test contains(sprint(apropos, "pearson"), "cor")
 @test contains(sprint(apropos, r"ind(exes|ices)"), "eachindex")
 @test contains(sprint(apropos, "print"), "Profile.print")
 

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -178,35 +178,41 @@ for vd in [1, 2], zm in [true, false], cr in [true, false]
         y1 = vec(Y[1,:])
     end
 
-    c = zm ? cov(x1; mean=0, corrected=cr) :
-             cov(x1; corrected=cr)
+    c = zm ? Base.covm(x1, 0, cr) :
+             cov(x1, cr)
     @test isa(c, Float64)
     @test_approx_eq c Cxx[1,1]
+    @inferred cov(x1, cr)
 
-    C = zm ? cov(X; vardim=vd, mean=0, corrected=cr) :
-             cov(X; vardim=vd, corrected=cr)
+    C = zm ? Base.covm(X, 0, vd, cr) :
+             cov(X, vd, cr)
     @test size(C) == (k, k)
     @test_approx_eq C Cxx
+    @inferred cov(X, vd, cr)
 
-    c = zm ? cov(x1, y1; mean=0, corrected=cr) :
-             cov(x1, y1; corrected=cr)
+    c = zm ? Base.covm(x1, 0, y1, 0, cr) :
+             cov(x1, y1, cr)
     @test isa(c, Float64)
     @test_approx_eq c Cxy[1,1]
+    @inferred cov(x1, y1, cr)
 
-    C = zm ? cov(x1, Y; vardim=vd, mean=0, corrected=cr) :
-             cov(x1, Y; vardim=vd, corrected=cr)
+    C = zm ? Base.covm(x1, 0, Y, 0, vd, cr) :
+             cov(x1, Y, vd, cr)
     @test size(C) == (1, k)
     @test_approx_eq C Cxy[1,:]
+    @inferred cov(x1, Y, vd, cr)
 
-    C = zm ? cov(X, y1; vardim=vd, mean=0, corrected=cr) :
-             cov(X, y1; vardim=vd, corrected=cr)
+    C = zm ? Base.covm(X, 0, y1, 0, vd, cr) :
+             cov(X, y1, vd, cr)
     @test size(C) == (k, 1)
     @test_approx_eq C Cxy[:,1]
+    @inferred cov(X, y1, vd, cr)
 
-    C = zm ? cov(X, Y; vardim=vd, mean=0, corrected=cr) :
-             cov(X, Y; vardim=vd, corrected=cr)
+    C = zm ? Base.covm(X, 0, Y, 0, vd, cr) :
+             cov(X, Y, vd, cr)
     @test size(C) == (k, k)
     @test_approx_eq C Cxy
+    @inferred cov(X, Y, vd, cr)
 end
 
 # test correlation
@@ -245,29 +251,35 @@ for vd in [1, 2], zm in [true, false]
         y1 = vec(Y[1,:])
     end
 
-    c = zm ? cor(x1; mean=0) : cor(x1)
+    c = zm ? Base.corm(x1, 0) : cor(x1)
     @test isa(c, Float64)
     @test_approx_eq c Cxx[1,1]
+    @inferred cor(x1)
 
-    C = zm ? cor(X; vardim=vd, mean=0) : cor(X; vardim=vd)
+    C = zm ? Base.corm(X, 0, vd) : cor(X, vd)
     @test size(C) == (k, k)
     @test_approx_eq C Cxx
+    @inferred cor(X, vd)
 
-    c = zm ? cor(x1, y1; mean=0) : cor(x1, y1)
+    c = zm ? Base.corm(x1, 0, y1, 0) : cor(x1, y1)
     @test isa(c, Float64)
     @test_approx_eq c Cxy[1,1]
+    @inferred cor(x1, y1)
 
-    C = zm ? cor(x1, Y; vardim=vd, mean=0) : cor(x1, Y; vardim=vd)
+    C = zm ? Base.corm(x1, 0, Y, 0, vd) : cor(x1, Y, vd)
     @test size(C) == (1, k)
     @test_approx_eq C Cxy[1,:]
+    @inferred cor(x1, Y, vd)
 
-    C = zm ? cor(X, y1; vardim=vd, mean=0) : cor(X, y1; vardim=vd)
+    C = zm ? Base.corm(X, 0, y1, 0, vd) : cor(X, y1, vd)
     @test size(C) == (k, 1)
     @test_approx_eq C Cxy[:,1]
+    @inferred cor(X, y1, vd)
 
-    C = zm ? cor(X, Y; vardim=vd, mean=0) : cor(X, Y; vardim=vd)
+    C = zm ? Base.corm(X, 0, Y, 0, vd) : cor(X, Y, vd)
     @test size(C) == (k, k)
     @test_approx_eq C Cxy
+    @inferred cor(X, Y, vd)
 end
 
 


### PR DESCRIPTION
This fixes #13081 and the type instability that motivated that issue.

I think it is actually quite rare that users would like to provide a precalculated mean and when they do, they would like maximum performance which they wouldn't get from a keyword argument function anyway. Since precalculated means are rare, I have also chosen not to export `covm` and `corm`.

It is probably more likely that someone would like the uncorrected version of the covariance, but it is not hard to get without the keyword argument.

The dimension keyword is simply too inconsistent with what we are doing for `mean`, `var`, `sum` etc.

I've also moved the documentation to the method definitions and split it out on the individual methods.
