### PR TITLE
Adds custom testset type API

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -479,13 +479,13 @@ macro testset(args...)
     length(args) > 0 || error("No arguments to @testset")
 
     tests = args[end]
-    # if we're at the top level we'll default to DefaultTestSet. Otherwise
-    # default to the type of the parent testset
 
     desc, testsettype, options = parse_testset_args(args[1:end-1])
     if desc == nothing
         desc = "test set"
     end
+    # if we're at the top level we'll default to DefaultTestSet. Otherwise
+    # default to the type of the parent testset
     if testsettype == nothing
         testsettype = :(get_testset_depth() == 0 ? DefaultTestSet : typeof(get_testset()))
     end
@@ -542,11 +542,11 @@ macro testloop(args...)
     if desc == nothing
         # No description provided. Generate from the loop variable names
         v = loopvars[1].args[1]
-        desc = Expr(:string,"$v = ",v) # first variable
+        desc = Expr(:string,"$v = ", esc(v)) # first variable
         for l = loopvars[2:end]
             v = l.args[1]
             push!(desc.args,", $v = ")
-            push!(desc.args,v)
+            push!(desc.args, esc(v))
         end
     end
 
@@ -609,19 +609,18 @@ end
 """
     get_testset()
 
-Retrieve the active test set from the task's local storage and the options used
-to create it. If no test set is active, use the fallback default test set.
+Retrieve the active test set from the task's local storage. If no
+test set is active, use the fallback default test set.
 """
 function get_testset()
     testsets = get(task_local_storage(), :__BASETESTNEXT__, AbstractTestSet[])
-    return length(testsets) == 0 ? (fallback_testset) : testsets[end]
+    return length(testsets) == 0 ? fallback_testset : testsets[end]
 end
 
 """
-    push_testset(ts::AbstractTestSet[, options::Dict])
+    push_testset(ts::AbstractTestSet)
 
-Adds the test set to the task_local_storage, as well as the options used to
-create it.
+Adds the test set to the task_local_storage.
 """
 function push_testset(ts::AbstractTestSet)
     testsets = get(task_local_storage(), :__BASETESTNEXT__, AbstractTestSet[])
@@ -632,8 +631,8 @@ end
 """
     pop_testset()
 
-Pops the last test set added to the task_local_storage along with the options
-used to create it. If there are no active test sets, returns the default test set.
+Pops the last test set added to the task_local_storage. If there are no
+active test sets, returns the default test set.
 """
 function pop_testset()
     testsets = get(task_local_storage(), :__BASETESTNEXT__, AbstractTestSet[])

--- a/base/test.jl
+++ b/base/test.jl
@@ -468,12 +468,19 @@ end
 #-----------------------------------------------------------------------
 
 """
-    @testset "description" begin ... end
-    @testset begin ... end
+    @testset [CustomTestSet] [option=val  ...] ["description"] begin ... end
 
 Starts a new test set. The test results will be recorded, and if there
-are any `Fail`s or `Error`s, an exception will be thrown only at the end,
-along with a summary of the test results.
+are any `Fail`s or `Error`s, an exception will be thrown at the end of the
+top-level (non-nested) test set, along with a summary of the test results.
+
+Any custom testset type (subtype of `AbstractTestSet`) can be given and it will
+also be used for any nested `@testset` or `@testloop` invocations. The given
+options are only applied to the test set where they are given. The default test
+set type does not take any options.
+
+By default the `@testset` macro will return the testset object itself, though
+this behavior can be customized in other testset types.
 """
 macro testset(args...)
     length(args) > 0 || error("No arguments to @testset")
@@ -511,12 +518,20 @@ end
 
 
 """
-    @testloop "description \$v" for v in (...) ... end
-    @testloop for x in (...), y in (...) ... end
+    @testloop [CustomTestSet] [option=val  ...] ["description \$v"] for v in (...) ... end
+    @testloop [CustomTestSet] [option=val  ...] ["description \$v, \$w"] for v in (...), w in (...) ... end
 
-Starts a new test set for each iteration of the loop. The description
-string accepts interpolation from the loop indices. If no description
-is provided, one is constructed based on the variables.
+Starts a new test set for each iteration of the loop. The description string
+accepts interpolation from the loop indices. If no description is provided, one
+is constructed based on the variables.
+
+Any custom testset type (subtype of `AbstractTestSet`) can be given and it will
+also be used for any nested `@testset` or `@testloop` invocations. The given
+options are only applied to the test sets where they are given. The default test
+set type does not take any options.
+
+By default the `@testset` macro will return a list of the testset objects used
+in each iteration, though this behavior can be customized in other testset types.
 """
 macro testloop(args...)
     length(args) > 0 || error("no arguments to @testloop")
@@ -632,7 +647,7 @@ end
     pop_testset()
 
 Pops the last test set added to the task_local_storage. If there are no
-active test sets, returns the default test set.
+active test sets, returns the fallback default test set.
 """
 function pop_testset()
     testsets = get(task_local_storage(), :__BASETESTNEXT__, AbstractTestSet[])

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -125,12 +125,16 @@ test set will then throw a ``TestSetException``.
 
    By default the ``@testset`` macro will return the testset object itself, though this behavior can be customized in other testset types.
 
-.. function:: @testloop [CustomTestSet] [option=val  ...] ["description \$v"] for v in (...) ... end
-              @testloop [CustomTestSet] [option=val  ...] ["description \$v, \$w"] for v in (...), w in (...) ... end
+.. function:: @testloop [CustomTestSet] [option=val  ...] ["description $v"] for v in (...) ... end
+              @testloop [CustomTestSet] [option=val  ...] ["description $v, $w"] for v in (...), w in (...) ... end
 
    .. Docstring generated from Julia source
 
    Starts a new test set for each iteration of the loop. The description string accepts interpolation from the loop indices. If no description is provided, one is constructed based on the variables.
+
+   Any custom testset type (subtype of ``AbstractTestSet``\ ) can be given and it will also be used for any nested ``@testset`` or ``@testloop`` invocations. The given options are only applied to the test sets where they are given. The default test set type does not take any options.
+
+   The ``@testloop`` macro collects and returns a list of the return values of the ``finish`` method, which by default will return a list of the testset objects used in each iteration.
 
 We can put our tests for the ``foo(x)`` function in a test set::
 

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -115,16 +115,18 @@ and at the end of the test set a summary will be printed. If any of
 the tests failed, or could not be evaluated due to an error, the
 test set will then throw a ``TestSetException``.
 
-
-.. function:: @testset "description" begin ... end
-              @testset begin ... end
+.. function:: @testset [CustomTestSet] [option=val  ...] ["description"] begin ... end
 
    .. Docstring generated from Julia source
 
-   Starts a new test set. The test results will be recorded, and if there are any ``Fail``\ s or ``Error``\ s, an exception will be thrown only at the end, along with a summary of the test results.
+   Starts a new test set. If no custom testset type is given it defaults to creating a ``DefaultTestSet``\ . ``DefaultTestSet`` records all the results and, and if there are any ``Fail``\ s or ``Error``\ s, throws an exception at the end of the top-level (non-nested) test set, along with a summary of the test results.
 
-.. function:: @testloop "description $v" for v in (...) ... end
-              @testloop for x in (...), y in (...) ... end
+   Any custom testset type (subtype of ``AbstractTestSet``\ ) can be given and it will also be used for any nested ``@testset`` or ``@testloop`` invocations. The given options are only applied to the test set where they are given. The default test set type does not take any options.
+
+   By default the ``@testset`` macro will return the testset object itself, though this behavior can be customized in other testset types.
+
+.. function:: @testloop [CustomTestSet] [option=val  ...] ["description \$v"] for v in (...) ... end
+              @testloop [CustomTestSet] [option=val  ...] ["description \$v, \$w"] for v in (...), w in (...) ... end
 
    .. Docstring generated from Julia source
 
@@ -244,3 +246,77 @@ writing new tests.
 
    Test two floating point numbers ``a`` and ``b`` for equality taking in account a margin of tolerance given by ``tol``\ .
 
+Creating Custom ``AbstractTestSet`` Types
+-----------------------------------------
+
+Packages can create their own ``AbstractTestSet`` subtypes by implementing the
+``record`` and ``finish`` methods. The subtype should have a one-argument
+constructor taking a description string, with any options passed in as keyword
+arguments.
+
+.. function:: record(ts::AbstractTestSet, res::Result)
+
+   .. Docstring generated from Julia source
+
+   Record a result to a testset. This function is called by the ``@testset`` infrastructure each time a contained ``@test`` macro completes, and is given the test result (which could be an ``Error``\ ). This will also be called with an ``Error`` if an exception is thrown inside the test block but outside of a ``@test`` context.
+
+.. function:: finish(ts::AbstractTestSet)
+
+   .. Docstring generated from Julia source
+
+   Do any final processing necessary for the given testset. This is called by the ``@testset`` infrastructure after a test block executes. One common use for this function is to record the testset to the parent's results list, using ``get_testset``\ .
+
+``Base.Test`` takes responsibility for maintaining a stack of nested testsets as
+they are executed, but any result accumulation is the responsibility of the
+``AbstractTestSet`` subtype. You can access this stack with the ``get_testset`` and
+``get_testset_depth`` methods. Note that these functions are not exported.
+
+.. function:: get_testset()
+
+   .. Docstring generated from Julia source
+
+   Retrieve the active test set from the task's local storage. If no test set is active, use the fallback default test set.
+
+.. function:: get_testset_depth()
+
+   .. Docstring generated from Julia source
+
+   Returns the number of active test sets, not including the defaut test set
+
+``Base.Test`` also makes sure that nested ``@testset`` invocations use the same
+``AbstractTestSet`` subtype as their parent unless it is set explicitly. It does
+not propagate any properties of the testset option inheritance behavior can be
+implemented by packages using the stack infrastructure that ``Base.Test``
+provides.
+
+Defining a basic ``AbstractTestSet`` subtype might look like::
+
+    import Base.Test: record, finish
+    using Base.Test: AbstractTestSet, Result, Pass, Fail, Error
+    using Base.Test: get_testset_depth, get_testset
+    immutable CustomTestSet <: Base.Test.AbstractTestSet
+        description::AbstractString
+        foo::Int
+        results::Vector
+        # constructor takes a description string and options keyword arguments
+        CustomTestSet(desc; foo=1) = new(desc, foo, [])
+    end
+
+    record(ts::CustomTestSet, child::AbstractTestSet) = push!(ts.results, child)
+    record(ts::CustomTestSet, res::Result) = push!(ts.results, res)
+    function finish(ts::CustomTestSet)
+        # just record if we're not the top-level parent
+        if get_testset_depth() > 0
+            record(get_testset(), ts)
+        end
+        ts
+    end
+
+And using that testset looks like::
+
+    @testset CustomTestSet foo=4 "custom testset inner 2" begin
+        # this testset should inherit the type, but not the argument.
+        @testset "custom testset inner" begin
+            @test true
+        end
+    end

--- a/test/test.jl
+++ b/test/test.jl
@@ -127,8 +127,9 @@ end
 redirect_stdout(OLD_STDOUT)
 
 # import the methods needed for defining our own testset type
-import Base.Test: record, finish, get_testset_depth, get_testset
-import Base.Test: AbstractTestSet, Result, Pass, Fail, Error
+import Base.Test: record, finish
+using Base.Test: get_testset_depth, get_testset
+using Base.Test: AbstractTestSet, Result, Pass, Fail, Error
 immutable CustomTestSet <: Base.Test.AbstractTestSet
     description::AbstractString
     foo::Int

--- a/test/test.jl
+++ b/test/test.jl
@@ -83,7 +83,7 @@ try
         end
         # should add 3 errors and 3 passing tests
         @testloop for i in 1:6
-            i % 2 == 0 || error("error outside of test")
+            iseven(i) || error("error outside of test")
             @test true # only gets run if the above passed
         end
     end
@@ -92,7 +92,6 @@ end
     redirect_stdout(OLD_STDOUT)
     error("No exception was thrown!")
 catch ex
-    redirect_stdout(OLD_STDOUT)
 
     @test isa(ex, Test.TestSetException)
     @test ex.pass  == 24
@@ -110,3 +109,19 @@ end
 
 # Test @test_approx_eq_eps
 # TODO
+
+ts = @testset "@testset should return the testset" begin
+    @test true
+end
+@test typeof(ts) == Base.Test.DefaultTestSet
+@test typeof(ts.results[1]) == Base.Test.Pass
+
+tss = @testloop "@testloop should return an array of testsets: $i" for i in 1:3
+    @test true
+end
+@test length(tss) == 3
+@test typeof(tss[1]) == Base.Test.DefaultTestSet
+@test typeof(tss[1].results[1]) == Base.Test.Pass
+
+
+redirect_stdout(OLD_STDOUT)


### PR DESCRIPTION
This PR creates an API for packages to create their own `AbstractTestSet`
subtypes. `Base.Test` takes responsibility for maintaining the stack of
nested testsets as they are executed, but any result accumulation is the
responsibility of the `AbstractTestSet` subtype. `Base.Test` also makes
sure that nested `@testset` invocations use the same `AbstractTestSet`
subtype as their parent unless it is set explicitly, but it does not
propogate any properties of the testset. If a package wants to inherit
properties from a parent it is responsible for implementing that (which
should be pretty easy using the stack infrastructure that `Base.Test`
provides). Propagating the options would have required more complexity,
and maintaining an option stack, and it's not clear that it's the right
behavior for all the subtypes.

Defining a basic `AbstractTestSet` subtype looks like:

``` julia
import Base.Test: record, finish, get_testset_depth, get_testset
import Base.Test: AbstractTestSet, Result, Pass, Fail, Error
immutable CustomTestSet <: Base.Test.AbstractTestSet
    description::AbstractString
    foo::Int
    results::Vector
    # constructor takes a description string and options keyword arguments
    CustomTestSet(desc; foo=1) = new(desc, foo, [])
end

record(ts::CustomTestSet, child::AbstractTestSet) = push!(ts.results, child)
record(ts::CustomTestSet, res::Result) = push!(ts.results, res)
function finish(ts::CustomTestSet)
    # just record if we're not the top-level parent
    if get_testset_depth() > 0
        record(get_testset(), ts)
    end
    ts
end
```

And using that testset looks like

``` julia
@testset CustomTestSet foo=4 "custom testset inner 2" begin
    # this testset should inherit the type, but not the argument.
    @testset "custom testset inner" begin
        @test true
    end
end
```

It also includes some other small changes:
- Makes `finish(::DefaultTestType)` return the testset object so it gets
  returned from the `@testset` macro
- now `@testloop` returns an Array of testsets (or whatever is returned from
  the `finish` method of each invocation in the loop)

Still TODO:
- [x] Add docs on how to create your own testset
- [x] Update docstrings for `@testset` and `@testloop` to document return values
- [x] Decide on what should be exported. Currently the methods you want to
  import to create your own `AbstractTestSet` are not exported

@IainNZ
