### PR TITLE
runtime versions of Intrinsics.reinterpret

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -266,6 +266,7 @@ EXE :=
 endif
 
 JULIAGC := MARKSWEEP
+JULIACODEGEN := LLVM
 USE_COPY_STACKS := 1
 
 # flag for disabling assertions

--- a/base/c.jl
+++ b/base/c.jl
@@ -2,7 +2,7 @@
 
 # definitions related to C interface
 
-import Core.Intrinsics: cglobal, box, unbox
+import Core.Intrinsics: cglobal, box
 
 const OS_NAME = ccall(:jl_get_OS_NAME, Any, ())
 
@@ -58,10 +58,10 @@ else
     bitstype 32 Cwstring
 end
 
-convert{T<:Union{Int8,UInt8}}(::Type{Cstring}, p::Ptr{T}) = box(Cstring, unbox(Ptr{T}, p))
-convert(::Type{Cwstring}, p::Ptr{Cwchar_t}) = box(Cwstring, unbox(Ptr{Cwchar_t}, p))
-convert{T<:Union{Int8,UInt8}}(::Type{Ptr{T}}, p::Cstring) = box(Ptr{T}, unbox(Cstring, p))
-convert(::Type{Ptr{Cwchar_t}}, p::Cwstring) = box(Ptr{Cwchar_t}, unbox(Cwstring, p))
+convert{T<:Union{Int8,UInt8}}(::Type{Cstring}, p::Ptr{T}) = box(Cstring, p)
+convert(::Type{Cwstring}, p::Ptr{Cwchar_t}) = box(Cwstring, p)
+convert{T<:Union{Int8,UInt8}}(::Type{Ptr{T}}, p::Cstring) = box(Ptr{T}, p)
+convert(::Type{Ptr{Cwchar_t}}, p::Cwstring) = box(Ptr{Cwchar_t}, p)
 
 # here, not in pointer.jl, to avoid bootstrapping problems in coreimg.jl
 pointer_to_string(p::Cstring, own::Bool=false) = pointer_to_string(convert(Ptr{UInt8}, p), own)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -903,6 +903,9 @@ function abstract_call(f, fargs, argtypes::Vector{Any}, vtypes, sv::StaticVarInf
         end
     end
     rt = builtin_tfunction(f, fargs, Tuple{argtypes...}, vtypes, sv)
+    if isa(rt, TypeVar)
+        rt = rt.ub
+    end
     #print("=> ", rt, "\n")
     return rt
 end
@@ -1324,14 +1327,14 @@ function typeinf(linfo::LambdaStaticData,atypes::ANY,sparams::SimpleVector, def,
                     break
                 end
                 if isa(code,Type)
-                    curtype = code
+                    curtype = code::Type
                     # sometimes just a return type is stored here. if a full AST
                     # is not needed, we can return it.
                     if !needtree
                         return (nothing, code)
                     end
                 else
-                    curtype = ccall(:jl_ast_rettype, Any, (Any,Any), def, code)
+                    curtype = ccall(:jl_ast_rettype, Any, (Any,Any), def, code)::Type
                     return (code, curtype)
                 end
             end
@@ -1344,7 +1347,7 @@ function typeinf(linfo::LambdaStaticData,atypes::ANY,sparams::SimpleVector, def,
 
     (fulltree, result, rec) = typeinf_uncached(linfo, atypes, sparams, def, curtype, cop, true)
     if fulltree === ()
-        return (fulltree,result)
+        return (fulltree, result::Type)
     end
 
     if !redo
@@ -1373,7 +1376,7 @@ function typeinf(linfo::LambdaStaticData,atypes::ANY,sparams::SimpleVector, def,
         def.tfunc[tfunc_idx+1] = rec
     end
 
-    return (fulltree, result)
+    return (fulltree, result::Type)
 end
 
 typeinf_uncached(linfo, atypes::ANY, sparams::ANY; optimize=true) =
@@ -1487,14 +1490,21 @@ function typeinf_uncached(linfo::LambdaStaticData, atypes::ANY, sparams::SimpleV
             lastatype = lastatype.parameters[1]
             laty -= 1
         end
+        if isa(lastatype, TypeVar)
+            lastatype = lastatype.ub
+        end
         if laty > la
             laty = la
         end
         for i=1:laty
-            s[1][args[i]] = VarState(atypes.parameters[i],false)
+            atyp = atypes.parameters[i]
+            if isa(atyp, TypeVar)
+                atyp = atyp.ub
+            end
+            s[1][args[i]] = VarState(atyp, false)
         end
         for i=laty+1:la
-            s[1][args[i]] = VarState(lastatype,false)
+            s[1][args[i]] = VarState(lastatype, false)
         end
     elseif la != 0
         return ((), Bottom, false) # wrong number of arguments

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -5,7 +5,7 @@
 const C_NULL = box(Ptr{Void}, 0)
 
 # pointer to integer
-convert{T<:Union{Int,UInt}}(::Type{T}, x::Ptr) = box(T, unbox(Ptr,x))
+convert{T<:Union{Int,UInt}}(::Type{T}, x::Ptr) = box(T, unbox(Ptr{Void},x))
 convert{T<:Integer}(::Type{T}, x::Ptr) = convert(T,convert(UInt, x))
 
 # integer to pointer
@@ -14,7 +14,7 @@ convert{T}(::Type{Ptr{T}}, x::Int) = box(Ptr{T},unbox(Int,Int(x)))
 
 # pointer to pointer
 convert{T}(::Type{Ptr{T}}, p::Ptr{T}) = p
-convert{T}(::Type{Ptr{T}}, p::Ptr) = box(Ptr{T}, unbox(Ptr,p))
+convert{T}(::Type{Ptr{T}}, p::Ptr) = box(Ptr{T}, unbox(Ptr{Void},p))
 
 # object to pointer (when used with ccall)
 unsafe_convert(::Type{Ptr{UInt8}}, x::Symbol) = ccall(:jl_symbol_name, Ptr{UInt8}, (Any,), x)

--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -1,10 +1,14 @@
+// This file is a part of Julia. License is MIT: http://julialang.org/license
+
 #include "llvm-version.h"
 #include <llvm/ADT/APInt.h>
 #include <llvm/ADT/APFloat.h>
 #include <llvm/Support/MathExtras.h>
 
-#define DLLEXPORT
-extern "C" DLLEXPORT void jl_error(const char *str);
+extern "C" {
+#include "APInt-C.h"
+DLLEXPORT void jl_error(const char *str);
+}
 
 using namespace llvm;
 

--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -1,0 +1,486 @@
+#include "llvm-version.h"
+#include <llvm/ADT/APInt.h>
+#include <llvm/ADT/APFloat.h>
+#include <llvm/Support/MathExtras.h>
+
+#define DLLEXPORT
+extern "C" DLLEXPORT void jl_error(const char *str);
+
+using namespace llvm;
+
+/* create "APInt s" from "integerPart *ps" */
+#define CREATE(s) \
+    APInt s; \
+    if ((numbits % integerPartWidth) != 0) { \
+        /* use LLT_ALIGN to round the memory area up to the nearest integerPart-sized chunk */ \
+        unsigned nbytes = RoundUpToAlignment(numbits, integerPartWidth) / host_char_bit; \
+        integerPart *data_a64 = (integerPart*)alloca(nbytes); \
+        /* TODO: this memcpy assumes little-endian,
+         * for big-endian, need to align the copy to the other end */ \
+        memcpy(data_a64, p##s, RoundUpToAlignment(numbits, host_char_bit) / host_char_bit); \
+        s = APInt(numbits, makeArrayRef(data_a64, nbytes / sizeof(integerPart))); \
+    } \
+    else { \
+        s = APInt(numbits, makeArrayRef(p##s, numbits / integerPartWidth)); \
+    }
+
+/* assign to "integerPart *pr" from "APInt a" */
+#define ASSIGN(r, a) \
+    if (numbits <= 8) \
+        *(uint8_t*)p##r = a.getZExtValue(); \
+    else if (numbits <= 16) \
+        *(uint16_t*)p##r = a.getZExtValue(); \
+    else if (numbits <= 32) \
+        *(uint32_t*)p##r = a.getZExtValue(); \
+    else if (numbits <= 64) \
+        *(uint64_t*)p##r = a.getZExtValue(); \
+    else \
+        memcpy(p##r, a.getRawData(), RoundUpToAlignment(numbits, host_char_bit) / host_char_bit); \
+
+extern "C" DLLEXPORT
+void LLVMNeg(unsigned numbits, integerPart *pa, integerPart *pr) {
+    APInt z(numbits, 0);
+    CREATE(a)
+    z -= a;
+    ASSIGN(r, z)
+}
+
+extern "C" DLLEXPORT
+void LLVMAdd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a += b;
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+void LLVMSub(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a -= b;
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+void LLVMMul(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a *= b;
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+void LLVMSDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a = a.sdiv(b);
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+void LLVMUDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a = a.udiv(b);
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+void LLVMSRem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a = a.srem(b);
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+void LLVMURem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a = a.urem(b);
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+int LLVMICmpEQ(unsigned numbits, integerPart *pa, integerPart *pb) {
+    CREATE(a)
+    CREATE(b)
+    return a.eq(b);
+}
+
+extern "C" DLLEXPORT
+int LLVMICmpNE(unsigned numbits, integerPart *pa, integerPart *pb) {
+    CREATE(a)
+    CREATE(b)
+    return a.ne(b);
+}
+
+extern "C" DLLEXPORT
+int LLVMICmpSLT(unsigned numbits, integerPart *pa, integerPart *pb) {
+    CREATE(a)
+    CREATE(b)
+    return a.slt(b);
+}
+
+extern "C" DLLEXPORT
+int LLVMICmpULT(unsigned numbits, integerPart *pa, integerPart *pb) {
+    CREATE(a)
+    CREATE(b)
+    return a.ult(b);
+}
+
+extern "C" DLLEXPORT
+int LLVMICmpSLE(unsigned numbits, integerPart *pa, integerPart *pb) {
+    CREATE(a)
+    CREATE(b)
+    return a.sle(b);
+}
+
+extern "C" DLLEXPORT
+int LLVMICmpULE(unsigned numbits, integerPart *pa, integerPart *pb) {
+    CREATE(a)
+    CREATE(b)
+    return a.ule(b);
+}
+
+extern "C" DLLEXPORT
+void LLVMAnd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a &= b;
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+void LLVMOr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a |= b;
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+void LLVMXor(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a ^= b;
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+void LLVMShl(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a = a.shl(b);
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+void LLVMLShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a = a.lshr(b);
+    ASSIGN(r, a)
+}
+extern "C" DLLEXPORT
+void LLVMAShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    a = a.ashr(b);
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+void LLVMFlipAllBits(unsigned numbits, integerPart *pa, integerPart *pr) {
+    CREATE(a)
+    a.flipAllBits();
+    ASSIGN(r, a)
+}
+
+extern "C" DLLEXPORT
+int LLVMAdd_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    bool Overflow;
+    a = a.uadd_ov(b, Overflow);
+    ASSIGN(r, a)
+    return Overflow;
+}
+
+extern "C" DLLEXPORT
+int LLVMAdd_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    bool Overflow;
+    a = a.sadd_ov(b, Overflow);
+    ASSIGN(r, a)
+    return Overflow;
+}
+
+extern "C" DLLEXPORT
+int LLVMSub_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    bool Overflow;
+    a = a.usub_ov(b, Overflow);
+    ASSIGN(r, a)
+    return Overflow;
+}
+
+extern "C" DLLEXPORT
+int LLVMSub_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    bool Overflow;
+    a = a.ssub_ov(b, Overflow);
+    ASSIGN(r, a)
+    return Overflow;
+}
+
+extern "C" DLLEXPORT
+int LLVMMul_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    bool Overflow;
+    a = a.smul_ov(b, Overflow);
+    ASSIGN(r, a)
+    return Overflow;
+}
+
+extern "C" DLLEXPORT
+int LLVMMul_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    bool Overflow;
+    a = a.umul_ov(b, Overflow);
+    ASSIGN(r, a)
+    return Overflow;
+}
+
+extern "C" DLLEXPORT
+void LLVMByteSwap(unsigned numbits, integerPart *pa, integerPart *pr) {
+    CREATE(a)
+    a = a.byteSwap();
+    ASSIGN(r, a)
+}
+
+void LLVMFPtoInt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr, bool isSigned, bool *isExact) {
+    double Val;
+    if (numbits == 32)
+        Val = *(float*)pa;
+    else if (numbits == 64)
+        Val = *(double*)pa;
+    else
+        jl_error("FPtoSI: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
+    unsigned onumbytes = RoundUpToAlignment(onumbits, host_char_bit) / host_char_bit;
+    if (onumbits <= 64) { // fast-path, if possible
+        if (isSigned) {
+            int64_t ia = Val;
+            memcpy(pr, &ia, onumbytes); // TODO: assumes little-endian
+            if (isExact) {
+                // check whether the conversion was lossless
+                int64_t ia2 = ia < 0 ? -1 : 0;
+                memcpy(&ia2, pr, onumbytes);
+                *isExact = (Val == (double)ia2 && ia == ia2);
+            }
+        }
+        else {
+            uint64_t ia = Val;
+            memcpy(pr, &ia, onumbytes); // TODO: assumes little-endian
+            if (isExact) {
+                // check whether the conversion was lossless
+                uint64_t ia2 = 0;
+                memcpy(&ia2, pr, onumbytes);
+                *isExact = (Val == (double)ia2 && ia == ia2);
+            }
+        }
+    }
+    else {
+        APFloat a(Val);
+        bool isVeryExact;
+        APFloat::roundingMode rounding_mode = APFloat::rmNearestTiesToEven;
+        unsigned nbytes = RoundUpToAlignment(onumbits, integerPartWidth) / host_char_bit;
+        integerPart *parts = (integerPart*)alloca(nbytes);
+        APFloat::opStatus status = a.convertToInteger(parts, onumbits, isSigned, rounding_mode, &isVeryExact);
+        memcpy(pr, parts, onumbytes);
+        if (isExact)
+            *isExact = (status == APFloat::opOK);
+    }
+}
+
+extern "C" DLLEXPORT
+void LLVMFPtoSI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+    LLVMFPtoInt(numbits, pa, onumbits, pr, true, NULL);
+}
+
+extern "C" DLLEXPORT
+void LLVMFPtoUI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+    LLVMFPtoInt(numbits, pa, onumbits, pr, false, NULL);
+}
+
+extern "C" DLLEXPORT
+int LLVMFPtoSI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+    bool isExact;
+    LLVMFPtoInt(numbits, pa, onumbits, pr, true, &isExact);
+    return isExact;
+}
+
+extern "C" DLLEXPORT
+int LLVMFPtoUI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+    bool isExact;
+    LLVMFPtoInt(numbits, pa, onumbits, pr, false, &isExact);
+    return isExact;
+}
+
+extern "C" DLLEXPORT
+void LLVMSItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+    CREATE(a)
+    double val = a.roundToDouble(true);
+    if (onumbits == 32)
+        *(float*)pr = val;
+    else if (onumbits == 64)
+        *(double*)pr = val;
+    else
+        jl_error("SItoFP: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
+}
+
+extern "C" DLLEXPORT
+void LLVMUItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+    CREATE(a)
+    double val = a.roundToDouble(false);
+    if (onumbits == 32)
+        *(float*)pr = val;
+    else if (onumbits == 64)
+        *(double*)pr = val;
+    else
+        jl_error("UItoFP: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
+}
+
+extern "C" DLLEXPORT
+void LLVMSExt(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+    assert(inumbits < onumbits);
+    unsigned inumbytes = RoundUpToAlignment(inumbits, host_char_bit) / host_char_bit;
+    unsigned onumbytes = RoundUpToAlignment(onumbits, host_char_bit) / host_char_bit;
+    int bits = (0 - inumbits) % host_char_bit;
+    int signbit = (inumbits - 1) % host_char_bit;
+    int sign = ((unsigned char*)pa)[inumbytes - 1] & (1 << signbit) ? -1 : 0;
+    // copy over the input bytes
+    memcpy(pr, pa, inumbytes);
+    if (bits) {
+        // sign-extend the partial byte
+        ((signed char*)pr)[inumbytes - 1] = ((signed char*)pa)[inumbytes - 1] << bits >> bits;
+    }
+    // sign-extend the rest of the bytes
+    memset((char*)pr + inumbytes, sign, onumbytes - inumbytes);
+}
+
+extern "C" DLLEXPORT
+void LLVMZExt(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+    assert(inumbits < onumbits);
+    unsigned inumbytes = RoundUpToAlignment(inumbits, host_char_bit) / host_char_bit;
+    unsigned onumbytes = RoundUpToAlignment(onumbits, host_char_bit) / host_char_bit;
+    int bits = (0 - inumbits) % host_char_bit;
+    // copy over the input bytes
+    memcpy(pr, pa, inumbytes);
+    if (bits) {
+        // zero the remaining bits of the partial byte
+        ((unsigned char*)pr)[inumbytes - 1] = ((unsigned char*)pa)[inumbytes - 1] << bits >> bits;
+    }
+    // zero-extend the rest of the bytes
+    memset((char*)pr + inumbytes, 0, onumbytes - inumbytes);
+}
+
+extern "C" DLLEXPORT
+void LLVMTrunc(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+    assert(inumbits > onumbits);
+    unsigned onumbytes = RoundUpToAlignment(onumbits, host_char_bit) / host_char_bit;
+    memcpy(pr, pa, onumbytes);
+}
+
+extern "C" DLLEXPORT
+unsigned countTrailingZeros_8(uint8_t Val) {
+#ifdef LLVM35
+    return countTrailingZeros(Val);
+#else
+    return CountTrailingZeros_32(Val);
+#endif
+}
+
+extern "C" DLLEXPORT
+unsigned countTrailingZeros_16(uint16_t Val) {
+#ifdef LLVM35
+    return countTrailingZeros(Val);
+#else
+    return CountTrailingZeros_32(Val);
+#endif
+}
+
+extern "C" DLLEXPORT
+unsigned countTrailingZeros_32(uint32_t Val) {
+#ifdef LLVM35
+    return countTrailingZeros(Val);
+#else
+    return CountTrailingZeros_32(Val);
+#endif
+}
+
+extern "C" DLLEXPORT
+unsigned countTrailingZeros_64(uint64_t Val) {
+#ifdef LLVM35
+    return countTrailingZeros(Val);
+#else
+    return CountTrailingZeros_64(Val);
+#endif
+}
+
+extern "C" DLLEXPORT
+void jl_LLVMSMod(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    CREATE(a)
+    CREATE(b)
+    APInt r = a.srem(b);
+    if (a.isNegative() != b.isNegative()) {
+        r = (b + r).srem(b);
+    }
+    ASSIGN(r, r)
+}
+
+extern "C" DLLEXPORT
+void jl_LLVMFlipSign(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
+    unsigned numbytes = RoundUpToAlignment(numbits, host_char_bit) / host_char_bit;
+    int signbit = (numbits - 1) % host_char_bit;
+    int sign = ((unsigned char*)pa)[numbytes - 1] & (1 << signbit) ? -1 : 0;
+    if (sign)
+        LLVMNeg(numbits, pa, pr);
+    else
+        memcpy(pr, pa,  numbytes);
+}
+
+extern "C" DLLEXPORT
+unsigned LLVMCountPopulation(unsigned numbits, integerPart *pa) {
+    CREATE(a)
+    return a.countPopulation();
+}
+
+extern "C" DLLEXPORT
+unsigned LLVMCountTrailingOnes(unsigned numbits, integerPart *pa) {
+    CREATE(a)
+    return a.countTrailingOnes();
+}
+
+extern "C" DLLEXPORT
+unsigned LLVMCountTrailingZeros(unsigned numbits, integerPart *pa) {
+    CREATE(a)
+    return a.countTrailingZeros();
+}
+
+extern "C" DLLEXPORT
+unsigned LLVMCountLeadingOnes(unsigned numbits, integerPart *pa) {
+    CREATE(a)
+    return a.countLeadingOnes();
+}
+
+extern "C" DLLEXPORT
+unsigned LLVMCountLeadingZeros(unsigned numbits, integerPart *pa) {
+    CREATE(a)
+    return a.countLeadingZeros();
+}

--- a/src/APInt-C.h
+++ b/src/APInt-C.h
@@ -1,3 +1,4 @@
+// This file is a part of Julia. License is MIT: http://julialang.org/license
 
 #ifndef APINT_C_H
 #define APINT_C_H
@@ -5,70 +6,76 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#include "dtypes.h"
+
+#ifdef LLVM_VERSION_MAJOR
+using llvm::integerPart;
+#else
 typedef void integerPart;
+#endif
 
-void LLVMNeg(unsigned numbits, integerPart *pa, integerPart *pr);
-void LLVMByteSwap(unsigned numbits, integerPart *pa, integerPart *pr);
+DLLEXPORT void LLVMNeg(unsigned numbits, integerPart *pa, integerPart *pr);
+DLLEXPORT void LLVMByteSwap(unsigned numbits, integerPart *pa, integerPart *pr);
 
-void LLVMAdd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMSub(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMMul(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMSDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMUDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMSRem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMURem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMAdd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMSub(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMMul(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMSDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMUDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMSRem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMURem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 
-void LLVMAnd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMOr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMXor(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMShl(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMLShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMAShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void LLVMFlipAllBits(unsigned numbits, integerPart *pa, integerPart *pr);
+DLLEXPORT void LLVMAnd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMOr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMXor(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMShl(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMLShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMAShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void LLVMFlipAllBits(unsigned numbits, integerPart *pa, integerPart *pr);
 
-int LLVMICmpEQ(unsigned numbits, integerPart *pa, integerPart *pr);
-int LLVMICmpNE(unsigned numbits, integerPart *pa, integerPart *pb);
-int LLVMICmpSLT(unsigned numbits, integerPart *pa, integerPart *pb);
-int LLVMICmpULT(unsigned numbits, integerPart *pa, integerPart *pb);
-int LLVMICmpSLE(unsigned numbits, integerPart *pa, integerPart *pb);
-int LLVMICmpULE(unsigned numbits, integerPart *pa, integerPart *pb);
+DLLEXPORT int LLVMICmpEQ(unsigned numbits, integerPart *pa, integerPart *pr);
+DLLEXPORT int LLVMICmpNE(unsigned numbits, integerPart *pa, integerPart *pb);
+DLLEXPORT int LLVMICmpSLT(unsigned numbits, integerPart *pa, integerPart *pb);
+DLLEXPORT int LLVMICmpULT(unsigned numbits, integerPart *pa, integerPart *pb);
+DLLEXPORT int LLVMICmpSLE(unsigned numbits, integerPart *pa, integerPart *pb);
+DLLEXPORT int LLVMICmpULE(unsigned numbits, integerPart *pa, integerPart *pb);
 
-int LLVMAdd_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-int LLVMAdd_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-int LLVMSub_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-int LLVMSub_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-int LLVMMul_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-int LLVMMul_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT int LLVMAdd_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT int LLVMAdd_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT int LLVMSub_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT int LLVMSub_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT int LLVMMul_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT int LLVMMul_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 
-unsigned LLVMCountPopulation(unsigned numbits, integerPart *pa);
-unsigned LLVMCountTrailingOnes(unsigned numbits, integerPart *pa);
-unsigned LLVMCountTrailingZeros(unsigned numbits, integerPart *pa);
-unsigned LLVMCountLeadingOnes(unsigned numbits, integerPart *pa);
-unsigned LLVMCountLeadingZeros(unsigned numbits, integerPart *pa);
+DLLEXPORT unsigned LLVMCountPopulation(unsigned numbits, integerPart *pa);
+DLLEXPORT unsigned LLVMCountTrailingOnes(unsigned numbits, integerPart *pa);
+DLLEXPORT unsigned LLVMCountTrailingZeros(unsigned numbits, integerPart *pa);
+DLLEXPORT unsigned LLVMCountLeadingOnes(unsigned numbits, integerPart *pa);
+DLLEXPORT unsigned LLVMCountLeadingZeros(unsigned numbits, integerPart *pa);
 
-void LLVMFPtoSI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-void LLVMFPtoUI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-void LLVMSItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-void LLVMUItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-void LLVMSExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-void LLVMZExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-void LLVMTrunc(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+DLLEXPORT void LLVMFPtoSI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+DLLEXPORT void LLVMFPtoUI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+DLLEXPORT void LLVMSItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+DLLEXPORT void LLVMUItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+DLLEXPORT void LLVMSExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+DLLEXPORT void LLVMZExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+DLLEXPORT void LLVMTrunc(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
 
-int LLVMFPtoSI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-int LLVMFPtoUI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+DLLEXPORT int LLVMFPtoSI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+DLLEXPORT int LLVMFPtoUI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
 
-void jl_LLVMSMod(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-void jl_LLVMFlipSign(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void jl_LLVMSMod(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+DLLEXPORT void jl_LLVMFlipSign(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 
-unsigned countTrailingZeros_8(uint8_t Val);
-unsigned countTrailingZeros_16(uint16_t Val);
-unsigned countTrailingZeros_32(uint32_t Val);
-unsigned countTrailingZeros_64(uint64_t Val);
+DLLEXPORT unsigned countTrailingZeros_8(uint8_t Val);
+DLLEXPORT unsigned countTrailingZeros_16(uint16_t Val);
+DLLEXPORT unsigned countTrailingZeros_32(uint32_t Val);
+DLLEXPORT unsigned countTrailingZeros_64(uint64_t Val);
 
-uint8_t getSwappedBytes_8(uint8_t Value); // no-op
-uint16_t getSwappedBytes_16(uint16_t Value);
-uint32_t getSwappedBytes_32(uint32_t Value);
-uint64_t getSwappedBytes_64(uint64_t Value);
+//uint8_t getSwappedBytes_8(uint8_t Value); // no-op
+//uint16_t getSwappedBytes_16(uint16_t Value);
+//uint32_t getSwappedBytes_32(uint32_t Value);
+//uint64_t getSwappedBytes_64(uint64_t Value);
 
 
 #ifdef __cplusplus

--- a/src/APInt-C.h
+++ b/src/APInt-C.h
@@ -1,0 +1,78 @@
+
+#ifndef APINT_C_H
+#define APINT_C_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef void integerPart;
+
+void LLVMNeg(unsigned numbits, integerPart *pa, integerPart *pr);
+void LLVMByteSwap(unsigned numbits, integerPart *pa, integerPart *pr);
+
+void LLVMAdd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMSub(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMMul(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMSDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMUDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMSRem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMURem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+
+void LLVMAnd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMOr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMXor(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMShl(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMLShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMAShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void LLVMFlipAllBits(unsigned numbits, integerPart *pa, integerPart *pr);
+
+int LLVMICmpEQ(unsigned numbits, integerPart *pa, integerPart *pr);
+int LLVMICmpNE(unsigned numbits, integerPart *pa, integerPart *pb);
+int LLVMICmpSLT(unsigned numbits, integerPart *pa, integerPart *pb);
+int LLVMICmpULT(unsigned numbits, integerPart *pa, integerPart *pb);
+int LLVMICmpSLE(unsigned numbits, integerPart *pa, integerPart *pb);
+int LLVMICmpULE(unsigned numbits, integerPart *pa, integerPart *pb);
+
+int LLVMAdd_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+int LLVMAdd_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+int LLVMSub_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+int LLVMSub_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+int LLVMMul_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+int LLVMMul_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+
+unsigned LLVMCountPopulation(unsigned numbits, integerPart *pa);
+unsigned LLVMCountTrailingOnes(unsigned numbits, integerPart *pa);
+unsigned LLVMCountTrailingZeros(unsigned numbits, integerPart *pa);
+unsigned LLVMCountLeadingOnes(unsigned numbits, integerPart *pa);
+unsigned LLVMCountLeadingZeros(unsigned numbits, integerPart *pa);
+
+void LLVMFPtoSI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+void LLVMFPtoUI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+void LLVMSItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+void LLVMUItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+void LLVMSExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+void LLVMZExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+void LLVMTrunc(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+
+int LLVMFPtoSI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+int LLVMFPtoUI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+
+void jl_LLVMSMod(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+void jl_LLVMFlipSign(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+
+unsigned countTrailingZeros_8(uint8_t Val);
+unsigned countTrailingZeros_16(uint16_t Val);
+unsigned countTrailingZeros_32(uint32_t Val);
+unsigned countTrailingZeros_64(uint64_t Val);
+
+uint8_t getSwappedBytes_8(uint8_t Value); // no-op
+uint16_t getSwappedBytes_16(uint16_t Value);
+uint32_t getSwappedBytes_32(uint32_t Value);
+uint64_t getSwappedBytes_64(uint64_t Value);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ override CPPFLAGS += $(JCPPFLAGS)
 SRCS := \
 	jltypes gf ast builtins module codegen disasm debuginfo interpreter \
 	alloc dlload sys init task array dump toplevel jl_uv jlapi signal-handling \
-	llvm-simdloop simplevector
+	llvm-simdloop simplevector APInt-C runtime_intrinsics
 ifeq ($(JULIAGC),MARKSWEEP)
 SRCS += gc
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,16 +11,6 @@ override CFLAGS += $(JCFLAGS)
 override CXXFLAGS += $(JCXXFLAGS)
 override CPPFLAGS += $(JCPPFLAGS)
 
-SRCS := \
-	jltypes gf ast builtins module codegen disasm debuginfo interpreter \
-	alloc dlload sys init task array dump toplevel jl_uv jlapi signal-handling \
-	llvm-simdloop simplevector APInt-C runtime_intrinsics
-ifeq ($(JULIAGC),MARKSWEEP)
-SRCS += gc
-endif
-
-HEADERS := $(addprefix $(SRCDIR)/,julia.h julia_internal.h options.h) $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(LIBUV_INC)/uv.h
-
 # -I BUILDDIR comes before -I SRCDIR so that the user can override <options.h> on a per-build-directory basis
 #  for gcc/clang, suggested content is:
 #  #include_next <options.h>
@@ -28,17 +18,37 @@ HEADERS := $(addprefix $(SRCDIR)/,julia.h julia_internal.h options.h) $(BUILDDIR
 FLAGS := \
 	-D_GNU_SOURCE -I$(BUILDDIR) -I$(SRCDIR) \
 	-I$(SRCDIR)/flisp -I$(SRCDIR)/support \
-	-I$(shell $(LLVM_CONFIG_HOST) --includedir) \
 	-I$(LIBUV_INC) -I$(build_includedir) -DLIBRARY_EXPORTS \
 	-I$(JULIAHOME)/deps/valgrind
 ifneq ($(USEMSVC), 1)
 FLAGS += -Wall -Wno-strict-aliasing -fno-omit-frame-pointer -fvisibility=hidden -fno-common
 endif
 
+
+SRCS := \
+	jltypes gf ast builtins module interpreter \
+	alloc dlload sys init task array dump toplevel jl_uv jlapi signal-handling \
+	simplevector APInt-C runtime_intrinsics runtime_ccall
+ifeq ($(JULIAGC),MARKSWEEP)
+SRCS += gc
+endif
+
+ifeq ($(JULIACODEGEN),LLVM)
+SRCS += codegen disasm debuginfo llvm-simdloop
+FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --includedir)
+LLVM_LIBS := all
+else
+SRCS += anticodegen
+LLVM_LIBS := support
+endif
+
+HEADERS := $(addprefix $(SRCDIR)/,julia.h julia_internal.h options.h) $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(LIBUV_INC)/uv.h
+
 # In LLVM < 3.4, --ldflags includes both options and libraries, so use it both before and after --libs
 # In LLVM >= 3.4, --ldflags has only options, and --system-libs has the libraries.
-LLVMLINK := $(shell $(LLVM_CONFIG_HOST) --ldflags) $(shell $(LLVM_CONFIG_HOST) --libs) $(shell $(LLVM_CONFIG_HOST) --ldflags) $(shell $(LLVM_CONFIG_HOST) --system-libs 2> /dev/null)
-ifeq ($(USE_LLVM_SHLIB),1)
+ifneq ($(USE_LLVM_SHLIB),1)
+LLVMLINK := $(shell $(LLVM_CONFIG_HOST) --ldflags) $(shell $(LLVM_CONFIG_HOST) --libs $(LLVM_LIBS)) $(shell $(LLVM_CONFIG_HOST) --ldflags) $(shell $(LLVM_CONFIG_HOST) --system-libs 2> /dev/null)
+else
 ifeq ($(LLVM_USE_CMAKE),1)
 LLVMLINK := $(shell $(LLVM_CONFIG_HOST) --ldflags) -lLLVM
 else
@@ -102,7 +112,8 @@ $(BUILDDIR)/julia_flisp.boot: $(addprefix $(SRCDIR)/,jlfrontend.scm \
 		$(call cygpath_w,$(SRCDIR)/mk_julia_flisp_boot.scm) $(call cygpath_w,$(dir $<)) $(notdir $<) $(call cygpath_w,$@))
 
 $(BUILDDIR)/ast.o $(BUILDDIR)/ast.dbg.obj: $(BUILDDIR)/julia_flisp.boot.inc $(SRCDIR)/flisp/*.h
-$(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: $(addprefix $(SRCDIR)/,intrinsics.cpp cgutils.cpp ccall.cpp abi_*.cpp)
+$(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: $(addprefix $(SRCDIR)/,intrinsics.cpp intrinsics.h cgutils.cpp ccall.cpp abi_*.cpp)
+$(BUILDDIR)/anticodegen.o $(BUILDDIR)/anticodegen.dbg.obj: $(SRCDIR)/intrinsics.h
 $(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/table.c
 $(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc-debug.c
 $(BUILDDIR)/signal-handling.o $(BUILDDIR)/signal-handling.dbg.obj: $(addprefix $(SRCDIR)/,signals-*.c)

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -159,25 +159,6 @@ jl_value_t *jl_new_bits(jl_value_t *bt, void *data)
     return jl_new_bits_internal(bt, data, &len);
 }
 
-// run time version of pointerref intrinsic (warning: i is not rooted)
-DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i)
-{
-    JL_TYPECHK(pointerref, pointer, p);
-    JL_TYPECHK(pointerref, long, i);
-    jl_value_t *ety = jl_tparam0(jl_typeof(p));
-    if (ety == (jl_value_t*)jl_any_type) {
-        jl_value_t **pp = (jl_value_t**)(jl_unbox_long(p) + (jl_unbox_long(i)-1)*sizeof(void*));
-        return *pp;
-    }
-    else {
-        if (!jl_is_datatype(ety))
-            jl_error("pointerref: invalid pointer");
-        size_t nb = LLT_ALIGN(jl_datatype_size(ety), ((jl_datatype_t*)ety)->alignment);
-        char *pp = (char*)jl_unbox_long(p) + (jl_unbox_long(i)-1)*nb;
-        return jl_new_bits(ety, pp);
-    }
-}
-
 void jl_assign_bits(void *dest, jl_value_t *bits)
 {
     size_t nb = jl_datatype_size(jl_typeof(bits));
@@ -189,27 +170,6 @@ void jl_assign_bits(void *dest, jl_value_t *bits)
     case  8: *(int64_t*)dest   = *(int64_t*)jl_data_ptr(bits);   break;
     case 16: *(bits128_t*)dest = *(bits128_t*)jl_data_ptr(bits); break;
     default: memcpy(dest, jl_data_ptr(bits), nb);
-    }
-}
-
-// run time version of pointerset intrinsic (warning: x is not gc-rooted)
-DLLEXPORT void jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i)
-{
-    JL_TYPECHK(pointerset, pointer, p);
-    JL_TYPECHK(pointerset, long, i);
-    jl_value_t *ety = jl_tparam0(jl_typeof(p));
-    if (ety == (jl_value_t*)jl_any_type) {
-        jl_value_t **pp = (jl_value_t**)(jl_unbox_long(p) + (jl_unbox_long(i)-1)*sizeof(void*));
-        *pp = x;
-    }
-    else {
-        if (!jl_is_datatype(ety))
-            jl_error("pointerset: invalid pointer");
-        size_t nb = LLT_ALIGN(jl_datatype_size(ety), ((jl_datatype_t*)ety)->alignment);
-        char *pp = (char*)jl_unbox_long(p) + (jl_unbox_long(i)-1)*nb;
-        if (jl_typeof(x) != ety)
-            jl_error("pointerset: type mismatch in assign");
-        jl_assign_bits(pp, x);
     }
 }
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -819,6 +819,15 @@ jl_value_t *jl_box_bool(int8_t x)
     return jl_false;
 }
 
+DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v)
+{
+    jl_value_t *box = (jl_value_t*)jl_gc_alloc_1w();
+    jl_set_typeof(box, jl_box_any_type);
+    // if (v) jl_gc_wb(box, v); // write block not needed: box was just allocated
+    box->fieldptr[0] = v;
+    return box;
+}
+
 // Expr constructor for internal use ------------------------------------------
 
 jl_expr_t *jl_exprn(jl_sym_t *head, size_t n)

--- a/src/anticodegen.c
+++ b/src/anticodegen.c
@@ -1,0 +1,50 @@
+#include "julia.h"
+#include "julia_internal.h"
+
+#include "intrinsics.h"
+
+int globalUnique = 0;
+
+#define UNAVAILABLE { jl_errorf("%s: not available in this build of Julia", __func__); }
+
+void jl_dump_bitcode(char *fname, const char *sysimg_data, size_t sysimg_len) UNAVAILABLE
+void jl_dump_objfile(char *fname, int jit_model, const char *sysimg_data, size_t sysimg_len) UNAVAILABLE
+int32_t jl_get_llvm_gv(jl_value_t *p) UNAVAILABLE
+void jl_write_malloc_log(void) UNAVAILABLE
+void jl_write_coverage_data(void) UNAVAILABLE
+void jl_generate_fptr(jl_function_t *f) {
+    jl_lambda_info_t *li = f->linfo;
+    if (li->fptr == &jl_trampoline) UNAVAILABLE
+    f->fptr = li->fptr;
+}
+
+DLLEXPORT void jl_clear_malloc_data(void) UNAVAILABLE
+DLLEXPORT void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name) UNAVAILABLE
+DLLEXPORT void *jl_function_ptr(jl_function_t *f, jl_value_t *rt, jl_value_t *argt) UNAVAILABLE
+DLLEXPORT const jl_value_t *jl_dump_function_asm(void *f, int raw_mc) UNAVAILABLE
+DLLEXPORT const jl_value_t *jl_dump_function_ir(void *f, uint8_t strip_ir_metadata, uint8_t dump_module) UNAVAILABLE
+
+void jl_init_codegen(void) { }
+void jl_compile(jl_function_t *f) { }
+void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig)
+{
+    if (!specsig)
+        lam->fptr = (jl_fptr_t)fptr;
+}
+void jl_getFunctionInfo(char **name, char **filename, size_t *line,
+                        char **inlinedat_file, size_t *inlinedat_line,
+                        size_t pointer, int *fromC, int skipC, int skipInline)
+{
+    *name = NULL;
+    *line = -1;
+    *filename = NULL;
+    *inlinedat_file = NULL;
+    *inlinedat_line = -1;
+    *fromC = 0;
+}
+
+jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
+                           jl_value_t *sp, jl_expr_t *ast, int sparams, int allow_alloc)
+{
+    return NULL;
+}

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1400,12 +1400,14 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v,
             n += jl_printf(out, "%s", jl_gf_name(v)->name);
         }
         else {
-            n += jl_printf(out, "#<function>");
+            n += jl_printf(out, "#<function ");
+            n += jl_static_show_x(out, (jl_value_t*)((jl_function_t*)v)->linfo, depth);
+            n += jl_printf(out, ">");
         }
     }
     else if (vt == jl_intrinsic_type) {
-        n += jl_printf(out, "#<intrinsic function %d>",
-                       *(uint32_t*)jl_data_ptr(v));
+        int f = *(uint32_t*)jl_data_ptr(v);
+        n += jl_printf(out, "#<intrinsic #%d %s>", f, jl_intrinsic_name(f));
     }
     else if (vt == jl_int64_type) {
         n += jl_printf(out, "%" PRId64, *(int64_t*)v);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1,126 +1,6 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
 
-// --- the ccall intrinsic ---
-
-// --- library symbol lookup ---
-
-// map from "libX" to full soname "libX.so.ver"
-#if defined(__linux__) || defined(__FreeBSD__)
-static std::map<std::string, std::string> sonameMap;
-static bool got_sonames = false;
-
-extern "C" DLLEXPORT void jl_read_sonames(void)
-{
-    char *line=NULL;
-    size_t sz=0;
-#if defined(__linux__)
-    FILE *ldc = popen("/sbin/ldconfig -p", "r");
-#else
-    FILE *ldc = popen("/sbin/ldconfig -r", "r");
-#endif
-
-    while (!feof(ldc)) {
-        ssize_t n = getline(&line, &sz, ldc);
-        if (n == -1)
-            break;
-        if (n > 2 && isspace((unsigned char)line[0])) {
-#ifdef __linux__
-            int i = 0;
-            while (isspace((unsigned char)line[++i])) ;
-            char *name = &line[i];
-            char *dot = strstr(name, ".so");
-            i = 0;
-#else
-            char *name = strstr(line, ":-l");
-            if (name == NULL) continue;
-            strncpy(name, "lib", 3);
-            char *dot = strchr(name, '.');
-#endif
-
-            if (NULL == dot)
-                continue;
-
-#ifdef __linux__
-            // Detect if this entry is for the current architecture
-            while (!isspace((unsigned char)dot[++i])) ;
-            while (isspace((unsigned char)dot[++i])) ;
-            int j = i;
-            while (!isspace((unsigned char)dot[++j])) ;
-            char *arch = strstr(dot+i,"x86-64");
-            if (arch != NULL && arch < dot + j) {
-#ifdef _P32
-                continue;
-#endif
-            }
-            else {
-#ifdef _P64
-                continue;
-#endif
-            }
-#endif // __linux__
-
-            char *abslibpath = strrchr(line, ' ');
-            if (dot != NULL && abslibpath != NULL) {
-                std::string pfx(name, dot - name);
-                // Do not include ' ' in front and '\n' at the end
-                std::string soname(abslibpath+1, line+n-(abslibpath+1)-1);
-                sonameMap[pfx] = soname;
-            }
-        }
-    }
-
-    free(line);
-    pclose(ldc);
-}
-
-extern "C" DLLEXPORT const char *jl_lookup_soname(const char *pfx, size_t n)
-{
-    if (!got_sonames) {
-        jl_read_sonames();
-        got_sonames = true;
-    }
-    std::string str(pfx, n);
-    if (sonameMap.find(str) != sonameMap.end()) {
-        return sonameMap[str].c_str();
-    }
-    return NULL;
-}
-#endif
-
-// map from user-specified lib names to handles
-static std::map<std::string, uv_lib_t*> libMap;
-
-static uv_lib_t *get_library(char *lib)
-{
-    uv_lib_t *hnd;
-#ifdef _OS_WINDOWS_
-    if ((intptr_t)lib == 1)
-        return jl_exe_handle;
-    if ((intptr_t)lib == 2)
-        return jl_dl_handle;
-#endif
-    if (lib == NULL)
-        return jl_RTLD_DEFAULT_handle;
-    hnd = libMap[lib];
-    if (hnd != NULL)
-        return hnd;
-    hnd = (uv_lib_t *) jl_load_dynamic_library(lib, JL_RTLD_DEFAULT);
-    if (hnd != NULL)
-        libMap[lib] = hnd;
-    return hnd;
-}
-
-extern "C" DLLEXPORT
-void *jl_load_and_lookup(char *f_lib, char *f_name, uv_lib_t **hnd)
-{
-    uv_lib_t *handle = *hnd;
-    if (!handle)
-        *hnd = handle = get_library(f_lib);
-    void *ptr = jl_dlsym_e(handle, f_name);
-    if (!ptr)
-        jl_errorf("symbol \"%s\" could not be found: %s", f_name, uv_dlerror(handle));
-    return ptr;
-}
+// --- the ccall, cglobal, and llvm intrinsics ---
 
 static std::map<std::string, GlobalVariable*> libMapGV;
 static std::map<std::string, GlobalVariable*> symMapGV;
@@ -161,7 +41,7 @@ static Value *runtime_sym_lookup(PointerType *funcptype, char *f_lib, char *f_na
                false, GlobalVariable::PrivateLinkage,
                initnul, f_lib);
             libMapGV[f_lib] = libptrgv;
-            libsym = get_library(f_lib);
+            libsym = jl_get_library(f_lib);
             assert(libsym != NULL);
 #ifdef USE_MCJIT
             jl_llvm_to_jl_value[libptrgv] = libsym;
@@ -565,7 +445,7 @@ static jl_cgval_t emit_cglobal(jl_value_t **args, size_t nargs, jl_codectx_t *ct
             res = runtime_sym_lookup((PointerType*)lrt, sym.f_lib, sym.f_name, ctx);
         }
         else {
-            void *symaddr = jl_dlsym_e(get_library(sym.f_lib), sym.f_name);
+            void *symaddr = jl_dlsym_e(jl_get_library(sym.f_lib), sym.f_name);
             if (symaddr == NULL) {
                 std::stringstream msg;
                 msg << "cglobal: could not find symbol ";
@@ -1370,7 +1250,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
             llvmf = runtime_sym_lookup(funcptype, f_lib, f_name, ctx);
         }
         else {
-            void *symaddr = jl_dlsym_e(get_library(f_lib), f_name);
+            void *symaddr = jl_dlsym_e(jl_get_library(f_lib), f_name);
             if (symaddr == NULL) {
                 JL_GC_POP();
                 std::stringstream msg;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -871,24 +871,22 @@ static Value *emit_typeof(const jl_cgval_t &p)
     return literal_pointer_val(aty);
 }
 
-static Value *emit_datatype_types(const jl_cgval_t &dt)
+static Value *emit_datatype_types(Value *dt)
 {
-    assert(dt.isboxed);
     return builder.
         CreateLoad(builder.
                    CreateBitCast(builder.
-                                 CreateGEP(builder.CreateBitCast(dt.V, T_pint8),
+                                 CreateGEP(builder.CreateBitCast(dt, T_pint8),
                                            ConstantInt::get(T_size, offsetof(jl_datatype_t, types))),
                                  T_ppjlvalue));
 }
 
-static Value *emit_datatype_nfields(const jl_cgval_t &dt)
+static Value *emit_datatype_nfields(Value *dt)
 {
-    assert(dt.isboxed);
     Value *nf = builder.
         CreateLoad(builder.
                    CreateBitCast(builder.
-                                 CreateGEP(builder.CreateBitCast(dt.V, T_pint8),
+                                 CreateGEP(builder.CreateBitCast(dt, T_pint8),
                                            ConstantInt::get(T_size, offsetof(jl_datatype_t, nfields))),
                                  T_pint32));
 #ifdef _P64
@@ -896,6 +894,45 @@ static Value *emit_datatype_nfields(const jl_cgval_t &dt)
 #endif
     return nf;
 }
+
+static Value *emit_datatype_size(Value *dt)
+{
+    Value *size = builder.
+        CreateLoad(builder.
+                   CreateBitCast(builder.
+                                 CreateGEP(builder.CreateBitCast(dt, T_pint8),
+                                           ConstantInt::get(T_size, offsetof(jl_datatype_t, size))),
+                                 T_pint32));
+    return size;
+}
+
+static Value *emit_datatype_mutabl(Value *dt)
+{
+    Value *mutabl = builder.
+        CreateLoad(builder.CreateGEP(builder.CreateBitCast(dt, T_pint8),
+                                     ConstantInt::get(T_size, offsetof(jl_datatype_t, mutabl))));
+    return builder.CreateTrunc(mutabl, T_int1);
+}
+
+static Value *emit_datatype_abstract(Value *dt)
+{
+    Value *abstract = builder.
+        CreateLoad(builder.CreateGEP(builder.CreateBitCast(dt, T_pint8),
+                                     ConstantInt::get(T_size, offsetof(jl_datatype_t, abstract))));
+    return builder.CreateTrunc(abstract, T_int1);
+}
+
+static Value *emit_datatype_isbitstype(Value *dt)
+{
+    Value *immut = builder.CreateXor(emit_datatype_mutabl(dt), ConstantInt::get(T_int1, -1));
+    Value *nofields = builder.CreateICmpEQ(emit_datatype_nfields(dt), ConstantInt::get(T_size, 0));
+    Value *isbitstype = builder.CreateAnd(immut, builder.CreateAnd(nofields,
+            builder.CreateXor(builder.CreateAnd(emit_datatype_abstract(dt),
+                    builder.CreateICmpSGT(emit_datatype_size(dt), ConstantInt::get(T_int32, 0))),
+                ConstantInt::get(T_int1, -1))));
+    return isbitstype;
+}
+
 
 // --- generating various error checks ---
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -658,17 +658,6 @@ extern "C" {
     int globalUnique = 0;
 }
 
-extern "C" DLLEXPORT
-jl_value_t *jl_get_cpu_name(void)
-{
-#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR < 5
-    std::string HostCPUName = llvm::sys::getHostCPUName();
-#else
-    StringRef HostCPUName = llvm::sys::getHostCPUName();
-#endif
-    return jl_pchar_to_string(HostCPUName.data(), HostCPUName.size());
-}
-
 static void emit_write_barrier(jl_codectx_t*, Value*, Value*);
 
 #include "cgutils.cpp"
@@ -5206,15 +5195,6 @@ extern "C" void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig)
             }
         }
     }
-}
-
-extern "C" DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v)
-{
-    jl_value_t *box = (jl_value_t*)jl_gc_alloc_1w();
-    jl_set_typeof(box, jl_box_any_type);
-    // if (v) jl_gc_wb(box, v); // write block not needed: box was just allocated
-    box->fieldptr[0] = v;
-    return box;
 }
 
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 3 && SYSTEM_LLVM

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6121,6 +6121,7 @@ extern "C" void jl_init_codegen(void)
                               "jl_box32", (void*)&jl_box32, m);
     box64_func = boxfunc_llvm(ft2arg(T_pjlvalue, T_pjlvalue, T_int64),
                               "jl_box64", (void*)&jl_box64, m);
+    jl_init_intrinsic_functions_codegen(m);
 }
 
 // for debugging from gdb

--- a/src/dump.c
+++ b/src/dump.c
@@ -1942,6 +1942,7 @@ DLLEXPORT jl_value_t *jl_ast_rettype(jl_lambda_info_t *li, jl_value_t *ast)
 {
     if (jl_is_expr(ast))
         return jl_lam_body((jl_expr_t*)ast)->etype;
+    assert(jl_is_array(ast));
     JL_SIGATOMIC_BEGIN();
     DUMP_MODES last_mode = mode;
     mode = MODE_AST;

--- a/src/dump.c
+++ b/src/dump.c
@@ -78,6 +78,7 @@ static jl_fptr_t id_to_fptrs[] = {
   jl_f_instantiate_type, jl_f_kwcall, jl_trampoline,
   jl_f_methodexists, jl_f_applicable, jl_f_invoke,
   jl_apply_generic, jl_unprotect_stack, jl_f_sizeof, jl_f_new_expr,
+  jl_f_intrinsic_call,
   NULL };
 
 // pointers to non-AST-ish objects in a compressed tree

--- a/src/init.c
+++ b/src/init.c
@@ -604,7 +604,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 
     jl_gc_enable(1);
 
-    if (jl_options.image_file) {
+    if (jl_options.image_file && (!jl_generating_output() || jl_options.incremental)) {
         jl_array_t *temp = jl_module_init_order;
         JL_GC_PUSH1(&temp);
         jl_module_init_order = NULL;

--- a/src/init.c
+++ b/src/init.c
@@ -627,15 +627,29 @@ void jl_compile_all(void);
 
 static void julia_save()
 {
+    if (!jl_generating_output())
+        return;
+
     if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_ALL)
         jl_compile_all();
 
-    if (jl_options.incremental) {
-        jl_array_t *worklist = jl_module_init_order;
-        if (!worklist) {
-            jl_printf(JL_STDERR, "WARNING: incremental output requested, but no modules defined during run\n");
-            return;
+    if (!jl_module_init_order) {
+        jl_printf(JL_STDERR, "WARNING: --output requested, but no modules defined during run\n");
+        return;
+    }
+
+    jl_array_t *worklist = jl_module_init_order;
+    JL_GC_PUSH1(&worklist);
+    jl_module_init_order = jl_alloc_cell_1d(0);
+    int i, l = jl_array_len(worklist);
+    for (i = 0; i < l; i++) {
+        jl_value_t *m = jl_arrayref(worklist, i);
+        if (jl_module_get_initializer((jl_module_t*)m)) {
+            jl_cell_1d_push(jl_module_init_order, m);
         }
+    }
+
+    if (jl_options.incremental) {
         if (jl_options.outputji)
             if (jl_save_incremental(jl_options.outputji, worklist))
                 jl_exit(1);
@@ -668,6 +682,7 @@ static void julia_save()
         if (jl_options.outputo)
             jl_dump_objfile((char*)jl_options.outputo, 0, (const char*)s->buf, s->size);
     }
+    JL_GC_POP();
 }
 
 jl_function_t *jl_typeinf_func=NULL;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -920,7 +920,7 @@ static jl_cgval_t emit_intrinsic(intrinsic f, jl_value_t **args, size_t nargs,
     case ccall: return emit_ccall(args, nargs, ctx);
     case cglobal: return emit_cglobal(args, nargs, ctx);
     case llvmcall: return emit_llvmcall(args, nargs, ctx);
-#if 0
+#if 0 // this section enables runtime-intrinsics (e.g. for testing), and disables their llvm counterparts
     default:
         int ldepth = ctx->gc.argDepth;
         Value *r;

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -1,0 +1,207 @@
+// This file is a part of Julia. License is MIT: http://julialang.org/license
+
+#define INTRINSICS \
+    /*  wrap and unwrap */ \
+    ALIAS(box, reinterpret) \
+    ALIAS(unbox, reinterpret) \
+    /*  arithmetic */ \
+    ADD_I(neg_int, 1) \
+    ADD_I(add_int, 2) \
+    ADD_I(sub_int, 2) \
+    ADD_I(mul_int, 2) \
+    ADD_I(sdiv_int, 2) \
+    ADD_I(udiv_int, 2) \
+    ADD_I(srem_int, 2) \
+    ADD_I(urem_int, 2) \
+    ADD_I(smod_int, 2) \
+    ADD_I(neg_float, 1) \
+    ADD_I(add_float, 2) \
+    ADD_I(sub_float, 2) \
+    ADD_I(mul_float, 2) \
+    ADD_I(div_float, 2) \
+    ADD_I(rem_float, 2) \
+    ADD_I(fma_float, 3) \
+    ADD_I(muladd_float, 3) \
+    /*  fast arithmetic */ \
+    ALIAS(neg_float_fast, neg_float) \
+    ALIAS(add_float_fast, add_float) \
+    ALIAS(sub_float_fast, sub_float) \
+    ALIAS(mul_float_fast, mul_float) \
+    ALIAS(div_float_fast, div_float) \
+    ALIAS(rem_float_fast, rem_float) \
+    /*  same-type comparisons */ \
+    ADD_I(eq_int, 2) \
+    ADD_I(ne_int, 2) \
+    ADD_I(slt_int, 2) \
+    ADD_I(ult_int, 2) \
+    ADD_I(sle_int, 2) \
+    ADD_I(ule_int, 2) \
+    ADD_I(eq_float, 2) \
+    ADD_I(ne_float, 2) \
+    ADD_I(lt_float, 2) \
+    ADD_I(le_float, 2) \
+    ALIAS(eq_float_fast, eq_float) \
+    ALIAS(ne_float_fast, ne_float) \
+    ALIAS(lt_float_fast, lt_float) \
+    ALIAS(le_float_fast, le_float) \
+    ADD_I(fpiseq, 2) \
+    ADD_I(fpislt, 2) \
+    /*  bitwise operators */ \
+    ADD_I(and_int, 2) \
+    ADD_I(or_int, 2) \
+    ADD_I(xor_int, 2) \
+    ADD_I(not_int, 1) \
+    ADD_I(shl_int, 2) \
+    ADD_I(lshr_int, 2) \
+    ADD_I(ashr_int, 2) \
+    ADD_I(bswap_int, 1) \
+    ADD_I(ctpop_int, 1) \
+    ADD_I(ctlz_int, 1) \
+    ADD_I(cttz_int, 1) \
+    /*  conversion */ \
+    ADD_I(sext_int, 2) \
+    ADD_I(zext_int, 2) \
+    ADD_I(trunc_int, 2) \
+    ADD_I(fptoui, 2) \
+    ADD_I(fptosi, 2) \
+    ADD_I(uitofp, 2) \
+    ADD_I(sitofp, 2) \
+    ADD_I(fptrunc, 2) \
+    ADD_I(fpext, 2) \
+    /*  checked conversion */ \
+    ADD_I(checked_fptosi, 2) \
+    ADD_I(checked_fptoui, 2) \
+    ADD_I(checked_trunc_sint, 2) \
+    ADD_I(checked_trunc_uint, 2) \
+    ADD_I(check_top_bit, 1) \
+    /*  checked arithmetic */ \
+    ADD_I(checked_sadd, 2) \
+    ADD_I(checked_uadd, 2) \
+    ADD_I(checked_ssub, 2) \
+    ADD_I(checked_usub, 2) \
+    ADD_I(checked_smul, 2) \
+    ADD_I(checked_umul, 2) \
+    ADD_I(nan_dom_err, 2) \
+    /*  functions */ \
+    ADD_I(abs_float, 1) \
+    ADD_I(copysign_float, 2) \
+    ADD_I(flipsign_int, 2) \
+    ADD_I(select_value, 3) \
+    ADD_I(ceil_llvm, 1) \
+    ADD_I(floor_llvm, 1) \
+    ADD_I(trunc_llvm, 1) \
+    ADD_I(rint_llvm, 1) \
+    ADD_I(sqrt_llvm, 1) \
+    ADD_I(powi_llvm, 2) \
+    ALIAS(sqrt_llvm_fast, sqrt_llvm) \
+    /*  pointer access */ \
+    ADD_I(pointerref, 2) \
+    ADD_I(pointerset, 3) \
+    /* c interface */ \
+    ALIAS(ccall, ccall) \
+    ALIAS(cglobal, cglobal) \
+    ALIAS(llvmcall, llvmcall) \
+    /*  hidden intrinsics */ \
+    ADD_HIDDEN(fptoui_auto, 1) \
+    ADD_HIDDEN(fptosi_auto, 1)
+
+enum intrinsic {
+#define ADD_I(func, nargs) func,
+#define ADD_HIDDEN ADD_I
+#define ALIAS ADD_I
+    INTRINSICS
+#undef ADD_I
+#undef ADD_HIDDEN
+#undef ALIAS
+    num_intrinsics,
+    reinterpret = box
+};
+
+#ifdef __cplusplus
+extern "C"
+#endif
+const char* jl_intrinsic_name(int f)
+{
+    switch ((enum intrinsic)f) {
+    default: return "invalid";
+#define ADD_I(func, nargs) case func: return #func;
+#define ADD_HIDDEN ADD_I
+#define ALIAS ADD_I
+    INTRINSICS
+#undef ADD_I
+#undef ADD_HIDDEN
+#undef ALIAS
+    }
+}
+
+static void* runtime_fp[num_intrinsics];
+static unsigned intrinsic_nargs[num_intrinsics];
+
+typedef jl_value_t *(*intrinsic_call_1_arg)(jl_value_t*);
+typedef jl_value_t *(*intrinsic_call_2_arg)(jl_value_t*, jl_value_t*);
+typedef jl_value_t *(*intrinsic_call_3_arg)(jl_value_t*, jl_value_t*, jl_value_t*);
+#define jl_is_intrinsic(v)       jl_typeis(v,jl_intrinsic_type)
+
+#ifdef __cplusplus
+extern "C"
+#endif
+JL_CALLABLE(jl_f_intrinsic_call)
+{
+    JL_NARGSV(intrinsic_call, 1);
+    JL_TYPECHK(intrinsic_call, intrinsic, args[0]);
+    enum intrinsic f = (enum intrinsic)*(uint32_t*)jl_data_ptr(args[0]);
+    if (f == fptoui && nargs == 1)
+        f = fptoui_auto;
+    if (f == fptosi && nargs == 1)
+        f = fptosi_auto;
+    unsigned fargs = intrinsic_nargs[f];
+    JL_NARGS(intrinsic_call, 1 + fargs, 1 + fargs);
+    switch (fargs) {
+        case 1:
+            return ((intrinsic_call_1_arg)runtime_fp[f])(args[1]);
+        case 2:
+            return ((intrinsic_call_2_arg)runtime_fp[f])(args[1], args[2]);
+        case 3:
+            return ((intrinsic_call_3_arg)runtime_fp[f])(args[1], args[2], args[3]);
+        default:
+            assert(0 && "unexpected number of arguments to an intrinsic function");
+    }
+    abort();
+}
+
+static void add_intrinsic_properties(enum intrinsic f, unsigned nargs, void *pfunc)
+{
+    intrinsic_nargs[f] = nargs;
+    runtime_fp[f] = pfunc;
+}
+
+static void add_intrinsic(jl_module_t *inm, const char *name, enum intrinsic f)
+{
+    jl_value_t *i = jl_box32(jl_intrinsic_type, (int32_t)f);
+    jl_sym_t *sym = jl_symbol(name);
+    jl_set_const(inm, sym, i);
+    jl_module_export(inm, sym);
+}
+
+
+#ifdef __cplusplus
+extern "C"
+#endif
+void jl_init_intrinsic_functions()
+{
+    jl_module_t *inm = jl_new_module(jl_symbol("Intrinsics"));
+    inm->parent = jl_core_module;
+    jl_set_const(jl_core_module, jl_symbol("Intrinsics"), (jl_value_t*)inm);
+
+#define ADD_I(name, nargs) add_intrinsic(inm, #name, name); add_intrinsic_properties(name, nargs, (void*)&jl_##name);
+#define ADD_HIDDEN(name, nargs) add_intrinsic_properties(name, nargs, (void*)&jl_##name);
+#define ALIAS(alias, base) add_intrinsic(inm, #alias, alias); add_intrinsic_properties(alias, intrinsic_nargs[base], runtime_fp[base]);
+    ADD_HIDDEN(reinterpret, 2);
+    INTRINSICS
+#undef ADD_I
+#undef ADD_HIDDEN
+#undef ALIAS
+
+    jl_set_const(inm, jl_symbol("intrinsic_call"),
+            (jl_value_t*)jl_new_closure(jl_f_intrinsic_call, (jl_value_t*)jl_symbol("intrinsic_call"), NULL));
+}

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -116,6 +116,7 @@ jl_value_t *jl_nth_slot_type(jl_tupletype_t *sig, size_t i);
 void jl_compute_field_offsets(jl_datatype_t *st);
 jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, size_t *dims,
                                              int isunboxed, int elsz);
+DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v);
 extern jl_array_t *jl_module_init_order;
 
 #ifdef JL_USE_INTEL_JITEVENTS
@@ -144,10 +145,6 @@ void jl_dump_bitcode(char *fname, const char *sysimg_data, size_t sysimg_len);
 void jl_dump_objfile(char *fname, int jit_model, const char *sysimg_data, size_t sysimg_len);
 int32_t jl_get_llvm_gv(jl_value_t *p);
 void jl_idtable_rehash(jl_array_t **pa, size_t newsz);
-
-#ifdef _OS_LINUX_
-DLLEXPORT void jl_read_sonames(void);
-#endif
 
 jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t *sp);
 jl_function_t *jl_get_specialization(jl_function_t *f, jl_tupletype_t *types);
@@ -214,6 +211,10 @@ extern uv_lib_t *jl_crtdll_handle;
 extern uv_lib_t *jl_winsock_handle;
 #endif
 
+uv_lib_t *jl_get_library(char *f_lib);
+DLLEXPORT void *jl_load_and_lookup(char *f_lib, char *f_name, uv_lib_t **hnd);
+
+
 // libuv wrappers:
 DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path);
 
@@ -226,6 +227,7 @@ extern DLLEXPORT jl_value_t *jl_segv_exception;
 #endif
 
 // Runtime intrinsics //
+const char* jl_intrinsic_name(int f);
 
 DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v);
 DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -224,6 +224,98 @@ DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path);
 extern DLLEXPORT jl_value_t *jl_segv_exception;
 #endif
 
+// Runtime intrinsics //
+
+DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v);
+DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i);
+DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i);
+
+DLLEXPORT jl_value_t *jl_neg_int(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_add_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_sub_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_mul_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_sdiv_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_udiv_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_srem_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_urem_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_smod_int(jl_value_t *a, jl_value_t *b);
+
+DLLEXPORT jl_value_t *jl_neg_float(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_add_float(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_sub_float(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_mul_float(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_div_float(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_rem_float(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_fma_float(jl_value_t *a, jl_value_t *b, jl_value_t *c);
+DLLEXPORT jl_value_t *jl_muladd_float(jl_value_t *a, jl_value_t *b, jl_value_t *c);
+
+DLLEXPORT jl_value_t *jl_eq_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_ne_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_slt_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_ult_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_sle_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_ule_int(jl_value_t *a, jl_value_t *b);
+
+DLLEXPORT jl_value_t *jl_eq_float(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_ne_float(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_lt_float(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_le_float(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_fpiseq(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_fpislt(jl_value_t *a, jl_value_t *b);
+
+DLLEXPORT jl_value_t *jl_not_int(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_and_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_or_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_xor_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_shl_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_lshr_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_ashr_int(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_bswap_int(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_ctpop_int(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_ctlz_int(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_cttz_int(jl_value_t *a);
+
+DLLEXPORT jl_value_t *jl_sext_int(jl_value_t *ty, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_zext_int(jl_value_t *ty, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_trunc_int(jl_value_t *ty, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_sitofp(jl_value_t *ty, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_uitofp(jl_value_t *ty, jl_value_t *a);
+
+DLLEXPORT jl_value_t *jl_fptoui(jl_value_t *ty, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_fptosi(jl_value_t *ty, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_fptrunc(jl_value_t *ty, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_fpext(jl_value_t *ty, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_fptoui_auto(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_fptosi_auto(jl_value_t *a);
+
+DLLEXPORT jl_value_t *jl_checked_fptoui(jl_value_t *ty, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_checked_fptosi(jl_value_t *ty, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_checked_trunc_sint(jl_value_t *ty, jl_value_t *a);
+DLLEXPORT jl_value_t *jl_checked_trunc_uint(jl_value_t *ty, jl_value_t *a);
+
+DLLEXPORT jl_value_t *jl_check_top_bit(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_checked_sadd(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_checked_uadd(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_checked_ssub(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_checked_usub(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_checked_smul(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_checked_umul(jl_value_t *a, jl_value_t *b);
+
+DLLEXPORT jl_value_t *jl_nan_dom_err(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_ceil_llvm(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_floor_llvm(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_trunc_llvm(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_rint_llvm(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_sqrt_llvm(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_powi_llvm(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_abs_float(jl_value_t *a);
+DLLEXPORT jl_value_t *jl_copysign_float(jl_value_t *a, jl_value_t *b);
+DLLEXPORT jl_value_t *jl_flipsign_int(jl_value_t *a, jl_value_t *b);
+
+DLLEXPORT jl_value_t *jl_select_value(jl_value_t *isfalse, jl_value_t *a, jl_value_t *b);
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -75,6 +75,7 @@ JL_CALLABLE(jl_apply_generic);
 JL_CALLABLE(jl_unprotect_stack);
 JL_CALLABLE(jl_f_no_function);
 JL_CALLABLE(jl_f_tuple);
+JL_CALLABLE(jl_f_intrinsic_call);
 extern jl_function_t *jl_unprotect_stack_func;
 extern jl_function_t *jl_bottom_func;
 void jl_install_default_signal_handlers(void);

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -1,0 +1,140 @@
+// This file is a part of Julia. License is MIT: http://julialang.org/license
+
+#include <map>
+#include <string>
+#include "julia.h"
+#include "julia_internal.h"
+
+// --- library symbol lookup ---
+
+// map from "libX" to full soname "libX.so.ver"
+#if defined(__linux__) || defined(__FreeBSD__)
+static std::map<std::string, std::string> sonameMap;
+static bool got_sonames = false;
+
+static void jl_read_sonames(void)
+{
+    char *line=NULL;
+    size_t sz=0;
+#if defined(__linux__)
+    FILE *ldc = popen("/sbin/ldconfig -p", "r");
+#else
+    FILE *ldc = popen("/sbin/ldconfig -r", "r");
+#endif
+
+    while (!feof(ldc)) {
+        ssize_t n = getline(&line, &sz, ldc);
+        if (n == -1)
+            break;
+        if (n > 2 && isspace((unsigned char)line[0])) {
+#ifdef __linux__
+            int i = 0;
+            while (isspace((unsigned char)line[++i])) ;
+            char *name = &line[i];
+            char *dot = strstr(name, ".so");
+            i = 0;
+#else
+            char *name = strstr(line, ":-l");
+            if (name == NULL) continue;
+            strncpy(name, "lib", 3);
+            char *dot = strchr(name, '.');
+#endif
+
+            if (NULL == dot)
+                continue;
+
+#ifdef __linux__
+            // Detect if this entry is for the current architecture
+            while (!isspace((unsigned char)dot[++i])) ;
+            while (isspace((unsigned char)dot[++i])) ;
+            int j = i;
+            while (!isspace((unsigned char)dot[++j])) ;
+            char *arch = strstr(dot+i,"x86-64");
+            if (arch != NULL && arch < dot + j) {
+#ifdef _P32
+                continue;
+#endif
+            }
+            else {
+#ifdef _P64
+                continue;
+#endif
+            }
+#endif // __linux__
+
+            char *abslibpath = strrchr(line, ' ');
+            if (dot != NULL && abslibpath != NULL) {
+                std::string pfx(name, dot - name);
+                // Do not include ' ' in front and '\n' at the end
+                std::string soname(abslibpath+1, line+n-(abslibpath+1)-1);
+                sonameMap[pfx] = soname;
+            }
+        }
+    }
+
+    free(line);
+    pclose(ldc);
+}
+
+extern "C" DLLEXPORT const char *jl_lookup_soname(const char *pfx, size_t n)
+{
+    if (!got_sonames) {
+        jl_read_sonames();
+        got_sonames = true;
+    }
+    std::string str(pfx, n);
+    if (sonameMap.find(str) != sonameMap.end()) {
+        return sonameMap[str].c_str();
+    }
+    return NULL;
+}
+#endif
+
+// map from user-specified lib names to handles
+static std::map<std::string, uv_lib_t*> libMap;
+
+extern "C"
+uv_lib_t *jl_get_library(char *f_lib)
+{
+    uv_lib_t *hnd;
+#ifdef _OS_WINDOWS_
+    if ((intptr_t)f_lib == 1)
+        return jl_exe_handle;
+    if ((intptr_t)f_lib == 2)
+        return jl_dl_handle;
+#endif
+    if (f_lib == NULL)
+        return jl_RTLD_DEFAULT_handle;
+    hnd = libMap[f_lib];
+    if (hnd != NULL)
+        return hnd;
+    hnd = (uv_lib_t *) jl_load_dynamic_library(f_lib, JL_RTLD_DEFAULT);
+    if (hnd != NULL)
+        libMap[f_lib] = hnd;
+    return hnd;
+}
+
+extern "C" DLLEXPORT
+void *jl_load_and_lookup(char *f_lib, char *f_name, uv_lib_t **hnd)
+{
+    uv_lib_t *handle = *hnd;
+    if (!handle)
+        *hnd = handle = jl_get_library(f_lib);
+    void *ptr = jl_dlsym_e(handle, f_name);
+    if (!ptr)
+        jl_errorf("symbol \"%s\" could not be found: %s", f_name, uv_dlerror(handle));
+    return ptr;
+}
+
+// miscellany
+#include <llvm/Support/Host.h>
+extern "C" DLLEXPORT
+jl_value_t *jl_get_cpu_name(void)
+{
+#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR < 5
+    std::string HostCPUName = llvm::sys::getHostCPUName();
+#else
+    StringRef HostCPUName = llvm::sys::getHostCPUName();
+#endif
+    return jl_pchar_to_string(HostCPUName.data(), HostCPUName.size());
+}

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <string>
+#include <cstdio>
 #include "julia.h"
 #include "julia_internal.h"
 

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1,5 +1,5 @@
 // This file is a part of Julia. License is MIT: http://julialang.org/license
-//
+
 // This is in implementation of the Julia intrinsic functions against boxed types
 // excluding the c interface (ccall, cglobal, llvmcall)
 //

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1,0 +1,930 @@
+// This file is a part of Julia. License is MIT: http://julialang.org/license
+//
+// This is in implementation of the Julia intrinsic functions against boxed types
+// excluding the c interface (ccall, cglobal, llvmcall)
+//
+// this file assumes a little-endian processor, although that isn't too hard to fix
+// it also assumes two's complement negative numbers, which might be a bit harder to fix
+//
+// TODO: add half-float support
+
+#include "julia.h"
+#include "julia_internal.h"
+#include "APInt-C.h"
+const unsigned int host_char_bit = 8;
+
+// run time version of box/unbox intrinsic
+DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v)
+{
+    JL_TYPECHK(reinterpret, datatype, ty);
+    if (!jl_is_leaf_type(ty) || !jl_is_bitstype(ty))
+        jl_error("reinterpret: target type not a leaf bitstype");
+    if (!jl_is_bitstype(jl_typeof(v)))
+        jl_error("reinterpret: value not a bitstype");
+    if (jl_datatype_size(jl_typeof(v)) != jl_datatype_size(ty))
+        jl_error("reinterpret: argument size does not match size of target type");
+    if (ty == jl_typeof(v))
+        return v;
+    if (ty == (jl_value_t*)jl_bool_type)
+        return *(uint8_t*)jl_data_ptr(v) & 1 ? jl_true : jl_false;
+    return jl_new_bits(ty, jl_data_ptr(v));
+}
+
+// run time version of pointerref intrinsic (warning: i is not rooted)
+DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i)
+{
+    JL_TYPECHK(pointerref, pointer, p);
+    JL_TYPECHK(pointerref, long, i);
+    jl_value_t *ety = jl_tparam0(jl_typeof(p));
+    if (ety == (jl_value_t*)jl_any_type) {
+        jl_value_t **pp = (jl_value_t**)(jl_unbox_long(p) + (jl_unbox_long(i)-1)*sizeof(void*));
+        return *pp;
+    }
+    else {
+        if (!jl_is_datatype(ety))
+            jl_error("pointerref: invalid pointer");
+        size_t nb = LLT_ALIGN(jl_datatype_size(ety), ((jl_datatype_t*)ety)->alignment);
+        char *pp = (char*)jl_unbox_long(p) + (jl_unbox_long(i)-1)*nb;
+        return jl_new_bits(ety, pp);
+    }
+}
+
+// run time version of pointerset intrinsic (warning: x is not gc-rooted)
+DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i)
+{
+    JL_TYPECHK(pointerset, pointer, p);
+    JL_TYPECHK(pointerset, long, i);
+    jl_value_t *ety = jl_tparam0(jl_typeof(p));
+    if (ety == (jl_value_t*)jl_any_type) {
+        jl_value_t **pp = (jl_value_t**)(jl_unbox_long(p) + (jl_unbox_long(i)-1)*sizeof(void*));
+        *pp = x;
+    }
+    else {
+        if (!jl_is_datatype(ety))
+            jl_error("pointerset: invalid pointer");
+        size_t nb = LLT_ALIGN(jl_datatype_size(ety), ((jl_datatype_t*)ety)->alignment);
+        char *pp = (char*)jl_unbox_long(p) + (jl_unbox_long(i)-1)*nb;
+        if (jl_typeof(x) != ety)
+            jl_error("pointerset: type mismatch in assign");
+        jl_assign_bits(pp, x);
+    }
+    return p;
+}
+
+
+static inline unsigned int next_power_of_two(unsigned int val) {
+  /* this function taken from libuv src/unix/core.c */
+  val -= 1;
+  val |= val >> 1;
+  val |= val >> 2;
+  val |= val >> 4;
+  val |= val >> 8;
+  val |= val >> 16;
+  val += 1;
+  return val;
+}
+
+static inline char signbitbyte(void *a, unsigned bytes) {
+    // sign bit of an signed number of n bytes, as a byte
+    return signbit(((signed char*)a)[bytes-1]) ? ~0 : 0;
+}
+
+static inline char usignbitbyte(void *a, unsigned bytes) {
+    // sign bit of an unsigned number
+    return 0;
+}
+
+static inline unsigned select_by_size(unsigned sz)
+{
+    /* choose the right sized function specialization */
+    switch (sz) {
+    default: return 0;
+    case  1: return 1;
+    case  2: return 2;
+    case  4: return 3;
+    case  8: return 4;
+    case 16: return 5;
+    }
+}
+
+#define SELECTOR_FUNC(intrinsic) \
+    typedef intrinsic##_t select_##intrinsic##_t[6]; \
+    static inline intrinsic##_t select_##intrinsic(unsigned sz, select_##intrinsic##_t list) \
+    { \
+        return list[select_by_size(sz)] ?: list[0]; \
+    }
+
+#define fp_select(a, func) \
+    sizeof(a) == sizeof(float) ? func##f((float)a) : func(a)
+#define fp_select2(a, b, func) \
+    sizeof(a) == sizeof(float) ? func##f(a, b) : func(a, b)
+
+// fast-function generators //
+
+// integer input
+// OP::Function macro(input)
+// name::unique string
+// nbits::number of bits
+// c_type::c_type corresponding to nbits
+#define un_iintrinsic_ctype(OP, name, nbits, c_type) \
+static inline void jl_##name##nbits(unsigned runtime_nbits, void *pa, void *pr) \
+{ \
+    c_type a = *(c_type*)pa; \
+    *(c_type*)pr = OP(a); \
+}
+
+// integer input, unsigned output
+// OP::Function macro(input)
+// name::unique string
+// nbits::number of bits
+// c_type::c_type corresponding to nbits
+#define uu_iintrinsic_ctype(OP, name, nbits, c_type) \
+static inline unsigned jl_##name##nbits(unsigned runtime_nbits, void *pa) \
+{ \
+    c_type a = *(c_type*)pa; \
+    return OP(a); \
+}
+
+// floating point
+// OP::Function macro(output pointer, input)
+// name::unique string
+// nbits::number of bits in the *input*
+// c_type::c_type corresponding to nbits
+#define un_fintrinsic_ctype(OP, name, c_type) \
+static inline void name(unsigned osize, void *pa, void *pr) \
+{ \
+    c_type a = *(c_type*)pa; \
+    OP((c_type*)pr, a); \
+}
+
+// float or integer inputs
+// OP::Function macro(inputa, inputb)
+// name::unique string
+// nbits::number of bits
+// c_type::c_type corresponding to nbits
+#define bi_intrinsic_ctype(OP, name, nbits, c_type) \
+static void jl_##name##nbits(unsigned runtime_nbits, void *pa, void *pb, void *pr) \
+{ \
+    c_type a = *(c_type*)pa; \
+    c_type b = *(c_type*)pb; \
+    *(c_type*)pr = (c_type)OP(a, b); \
+}
+
+// float or integer inputs, bool output
+// OP::Function macro(inputa, inputb)
+// name::unique string
+// nbits::number of bits
+// c_type::c_type corresponding to nbits
+#define bool_intrinsic_ctype(OP, name, nbits, c_type) \
+static int jl_##name##nbits(unsigned runtime_nbits, void *pa, void *pb) \
+{ \
+    c_type a = *(c_type*)pa; \
+    c_type b = *(c_type*)pb; \
+    return OP(a, b); \
+}
+
+// integer inputs, with precondition test
+// OP::Function macro(inputa, inputb)
+// name::unique string
+// nbits::number of bits
+// c_type::c_type corresponding to nbits
+#define checked_intrinsic_ctype(CHECK_OP, OP, name, nbits, c_type) \
+static int jl_##name##nbits(unsigned runtime_nbits, void *pa, void *pb, void *pr) \
+{ \
+    c_type a = *(c_type*)pa; \
+    c_type b = *(c_type*)pb; \
+    if (CHECK_OP(a, b)) \
+        return 1; \
+    *(c_type*)pr = (c_type)OP(a, b); \
+    return 0; \
+}
+
+// float inputs
+// OP::Function macro(inputa, inputb, inputc)
+// name::unique string
+// nbits::number of bits
+// c_type::c_type corresponding to nbits
+#define ter_intrinsic_ctype(OP, name, nbits, c_type) \
+static void jl_##name##nbits(unsigned runtime_nbits, void *pa, void *pb, void *pc, void *pr) \
+{ \
+    c_type a = *(c_type*)pa; \
+    c_type b = *(c_type*)pb; \
+    c_type c = *(c_type*)pc; \
+    *(c_type*)pr = (c_type)OP(a, b, c); \
+}
+
+
+// unary operator generator //
+
+typedef void (*intrinsic_1_t)(unsigned, void*, void*);
+SELECTOR_FUNC(intrinsic_1)
+#define un_iintrinsic(name, u) \
+DLLEXPORT jl_value_t *jl_##name(jl_value_t *a) \
+{ \
+    return jl_iintrinsic_1(jl_typeof(a), a, #name, u##signbitbyte, jl_intrinsiclambda_ty1, name##_list); \
+}
+#define un_iintrinsic_fast(LLVMOP, OP, name, u) \
+un_iintrinsic_ctype(OP, name, 8, u##int##8_t) \
+un_iintrinsic_ctype(OP, name, 16, u##int##16_t) \
+un_iintrinsic_ctype(OP, name, 32, u##int##32_t) \
+un_iintrinsic_ctype(OP, name, 64, u##int##64_t) \
+static select_intrinsic_1_t name##_list = { \
+    LLVMOP, \
+    jl_##name##8, \
+    jl_##name##16, \
+    jl_##name##32, \
+    jl_##name##64, \
+}; \
+un_iintrinsic(name, u)
+#define un_iintrinsic_slow(LLVMOP, name, u) \
+static select_intrinsic_1_t name##_list = { \
+    LLVMOP \
+}; \
+un_iintrinsic(name, u)
+
+typedef unsigned (*intrinsic_u1_t)(unsigned, void*);
+SELECTOR_FUNC(intrinsic_u1)
+#define uu_iintrinsic(name, u) \
+DLLEXPORT jl_value_t *jl_##name(jl_value_t *a) \
+{ \
+    return jl_iintrinsic_1(jl_typeof(a), a, #name, u##signbitbyte, jl_intrinsiclambda_u1, name##_list); \
+}
+#define uu_iintrinsic_fast(LLVMOP, OP, name, u) \
+uu_iintrinsic_ctype(OP, name, 8, u##int##8_t) \
+uu_iintrinsic_ctype(OP, name, 16, u##int##16_t) \
+uu_iintrinsic_ctype(OP, name, 32, u##int##32_t) \
+uu_iintrinsic_ctype(OP, name, 64, u##int##64_t) \
+static select_intrinsic_u1_t name##_list = { \
+    LLVMOP, \
+    jl_##name##8, \
+    jl_##name##16, \
+    jl_##name##32, \
+    jl_##name##64, \
+}; \
+uu_iintrinsic(name, u)
+#define uu_iintrinsic_slow(LLVMOP, name, u) \
+static select_intrinsic_u1_t name##_list = { \
+    LLVMOP \
+}; \
+uu_iintrinsic(name, u)
+
+static inline jl_value_t *jl_iintrinsic_1(jl_value_t *ty, jl_value_t *a, const char *name, char (*getsign)(void*, unsigned),
+        jl_value_t* (*lambda1)(jl_value_t*, void*, unsigned, unsigned, void*), void *list)
+{
+    if (!jl_is_bitstype(jl_typeof(a)))
+        jl_errorf("%s: value is not a bitstype", name);
+    if (!jl_is_bitstype(ty))
+        jl_errorf("%s: type is not a bitstype", name);
+    void *pa = jl_data_ptr(a);
+    unsigned isize = jl_datatype_size(jl_typeof(a));
+    unsigned isize2 = next_power_of_two(isize);
+    unsigned osize = jl_datatype_size(ty);
+    unsigned osize2 = next_power_of_two(osize);
+    if (isize2 > osize2)
+        osize2 = isize2;
+    if (osize2 > isize || isize2 > isize) {
+        /* if needed, round type up to a real c-type and set/clear the unused bits */
+        void *pa2;
+        pa2 = alloca(osize2);
+        /* TODO: this memcpy assumes little-endian,
+         * for big-endian, need to align the copy to the other end */ \
+        memcpy(pa2, pa, isize);
+        memset(pa2 + isize, getsign(pa, isize), osize2 - isize);
+        pa = pa2;
+    }
+    jl_value_t *newv = lambda1(ty, pa, osize, osize2, list);
+    if (ty == (jl_value_t*)jl_bool_type)
+        return *(uint8_t*)jl_data_ptr(newv) & 1 ? jl_true : jl_false;
+    return newv;
+}
+
+static inline jl_value_t *jl_intrinsiclambda_ty1(jl_value_t *ty, void *pa, unsigned osize, unsigned osize2, void *voidlist)
+{
+    jl_value_t *newv = newstruct((jl_datatype_t*)ty);
+    intrinsic_1_t op = select_intrinsic_1(osize2, (intrinsic_1_t*)voidlist);
+    op(osize * host_char_bit, pa, jl_data_ptr(newv));
+    return newv;
+}
+
+static inline jl_value_t *jl_intrinsiclambda_u1(jl_value_t *ty, void *pa, unsigned osize, unsigned osize2, void *voidlist)
+{
+    jl_value_t *newv = newstruct((jl_datatype_t*)ty);
+    intrinsic_u1_t op = select_intrinsic_u1(osize2, (intrinsic_u1_t*)voidlist);
+    unsigned cnt = op(osize * host_char_bit, pa);
+    // TODO: the following memset/memcpy assumes little-endian
+    // for big-endian, need to copy from the other end of cnt
+    if (osize > sizeof(unsigned)) {
+        // perform zext, if needed
+        memset((char*)jl_data_ptr(newv) + sizeof(unsigned), 0, osize - sizeof(unsigned));
+        osize = sizeof(unsigned);
+    }
+    memcpy(jl_data_ptr(newv), &cnt, osize);
+    return newv;
+}
+
+// conversion operator
+
+typedef void (*intrinsic_cvt_t)(unsigned, void*, unsigned, void*);
+typedef unsigned (*intrinsic_cvt_check_t)(unsigned, unsigned, void*);
+#define cvt_iintrinsic_checked(LLVMOP, check_op, name) \
+DLLEXPORT jl_value_t *jl_##name(jl_value_t *ty, jl_value_t *a) \
+{ \
+    return jl_intrinsic_cvt(ty, a, #name, LLVMOP, check_op); \
+}
+#define cvt_iintrinsic(LLVMOP, name) \
+    cvt_iintrinsic_checked(LLVMOP, NULL, name) \
+
+static inline jl_value_t *jl_intrinsic_cvt(jl_value_t *ty, jl_value_t *a, const char *name, intrinsic_cvt_t op, intrinsic_cvt_check_t check_op)
+{
+    jl_value_t *aty = jl_typeof(a);
+    if (!jl_is_bitstype(aty))
+        jl_errorf("%s: value is not a bitstype", name);
+    if (!jl_is_bitstype(ty))
+        jl_errorf("%s: type is not a bitstype", name);
+    void *pa = jl_data_ptr(a);
+    unsigned isize = jl_datatype_size(aty);
+    unsigned osize = jl_datatype_size(ty);
+    if (check_op && check_op(isize, osize, pa))
+        jl_throw(jl_inexact_exception);
+    jl_value_t *newv = newstruct((jl_datatype_t*)ty);
+    op(aty == (jl_value_t*)jl_bool_type ? 1 : isize * host_char_bit, pa,
+            osize * host_char_bit, jl_data_ptr(newv));
+    if (ty == (jl_value_t*)jl_bool_type)
+        return *(uint8_t*)jl_data_ptr(newv) & 1 ? jl_true : jl_false;
+    return newv;
+}
+
+// floating point
+
+#define un_fintrinsic_withtype(OP, name) \
+un_fintrinsic_ctype(OP, jl_##name##32, float) \
+un_fintrinsic_ctype(OP, jl_##name##64, double) \
+DLLEXPORT jl_value_t *jl_##name(jl_value_t *ty, jl_value_t *a) \
+{ \
+    return jl_fintrinsic_1(ty, a, #name, jl_##name##32, jl_##name##64); \
+}
+
+#define un_fintrinsic(OP, name) \
+un_fintrinsic_withtype(OP, name##_withtype) \
+DLLEXPORT jl_value_t *jl_##name(jl_value_t *a) \
+{ \
+    return jl_##name##_withtype(jl_typeof(a), a); \
+}
+
+typedef void (fintrinsic_op1)(unsigned, void*, void*);
+
+static inline jl_value_t *jl_fintrinsic_1(jl_value_t *ty, jl_value_t *a, const char *name, fintrinsic_op1 *floatop, fintrinsic_op1 *doubleop)
+{
+    if (!jl_is_bitstype(jl_typeof(a)))
+        jl_errorf("%s: value is not a bitstype", name);
+    if (!jl_is_bitstype(ty))
+        jl_errorf("%s: type is not a bitstype", name);
+    jl_value_t *newv = newstruct((jl_datatype_t*)ty);
+    void *pa = jl_data_ptr(a), *pr = jl_data_ptr(newv);
+    unsigned sz = jl_datatype_size(jl_typeof(a));
+    unsigned sz2 = jl_datatype_size(ty);
+    switch (sz) {
+    /* choose the right size c-type operation based on the input */
+    case 4:
+        floatop(sz2 * host_char_bit, pa, pr);
+        break;
+    case 8:
+        doubleop(sz2 * host_char_bit, pa, pr);
+        break;
+    default:
+        jl_errorf("%s: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64", name);
+    }
+    return newv;
+}
+
+// binary operator generator //
+
+// integer
+
+typedef void (*intrinsic_2_t)(unsigned, void*, void*, void*);
+SELECTOR_FUNC(intrinsic_2)
+#define bi_iintrinsic(name, u, cvtb) \
+DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+{ \
+    return jl_iintrinsic_2(a, b, #name, u##signbitbyte, jl_intrinsiclambda_2, name##_list, cvtb); \
+}
+#define bi_iintrinsic_cnvtb_fast(LLVMOP, OP, name, u, cvtb) \
+bi_intrinsic_ctype(OP, name, 8, u##int##8_t) \
+bi_intrinsic_ctype(OP, name, 16, u##int##16_t) \
+bi_intrinsic_ctype(OP, name, 32, u##int##32_t) \
+bi_intrinsic_ctype(OP, name, 64, u##int##64_t) \
+static select_intrinsic_2_t name##_list = { \
+    LLVMOP, \
+    jl_##name##8, \
+    jl_##name##16, \
+    jl_##name##32, \
+    jl_##name##64, \
+}; \
+bi_iintrinsic(name, u, cvtb)
+#define bi_iintrinsic_fast(LLVMOP, OP, name, u) \
+    bi_iintrinsic_cnvtb_fast(LLVMOP, OP, name, u, 0)
+
+typedef int (*intrinsic_cmp_t)(unsigned, void*, void*);
+SELECTOR_FUNC(intrinsic_cmp)
+#define cmp_iintrinsic(name, u) \
+DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+{ \
+    return jl_iintrinsic_2(a, b, #name, u##signbitbyte, jl_intrinsiclambda_cmp, name##_list, 0); \
+}
+#define bool_iintrinsic_fast(LLVMOP, OP, name, u) \
+bool_intrinsic_ctype(OP, name, 8, u##int##8_t) \
+bool_intrinsic_ctype(OP, name, 16, u##int##16_t) \
+bool_intrinsic_ctype(OP, name, 32, u##int##32_t) \
+bool_intrinsic_ctype(OP, name, 64, u##int##64_t) \
+static select_intrinsic_cmp_t name##_list = { \
+    LLVMOP, \
+    jl_##name##8, \
+    jl_##name##16, \
+    jl_##name##32, \
+    jl_##name##64, \
+}; \
+cmp_iintrinsic(name, u)
+
+typedef int (*intrinsic_checked_t)(unsigned, void*, void*, void*);
+SELECTOR_FUNC(intrinsic_checked)
+#define checked_iintrinsic(name, u) \
+DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+{ \
+    return jl_iintrinsic_2(a, b, #name, u##signbitbyte, jl_intrinsiclambda_checked, name##_list, 0); \
+}
+#define checked_iintrinsic_fast(LLVMOP, CHECK_OP, OP, name, u) \
+checked_intrinsic_ctype(CHECK_OP, OP, name, 8, u##int##8_t) \
+checked_intrinsic_ctype(CHECK_OP, OP, name, 16, u##int##16_t) \
+checked_intrinsic_ctype(CHECK_OP, OP, name, 32, u##int##32_t) \
+checked_intrinsic_ctype(CHECK_OP, OP, name, 64, u##int##64_t) \
+static select_intrinsic_checked_t name##_list = { \
+    LLVMOP, \
+    jl_##name##8, \
+    jl_##name##16, \
+    jl_##name##32, \
+    jl_##name##64, \
+}; \
+checked_iintrinsic(name, u)
+#define checked_iintrinsic_slow(LLVMOP, name, u) \
+static select_intrinsic_checked_t name##_list = { \
+    LLVMOP \
+}; \
+checked_iintrinsic(name, u)
+
+static inline jl_value_t *jl_iintrinsic_2(jl_value_t *a, jl_value_t *b, const char *name, char (*getsign)(void*, unsigned),
+        jl_value_t* (*lambda2)(jl_value_t*, void*, void*, unsigned, unsigned, void*),
+        void *list, int cvtb)
+{
+    jl_value_t *ty = jl_typeof(a);
+    jl_value_t *tyb = jl_typeof(b);
+    if (tyb != ty) {
+        if (!cvtb)
+            jl_errorf("%s: types of a and b must match", name);
+        if (!jl_is_bitstype(tyb))
+            jl_errorf("%s: b is not a bitstypes", name);
+    }
+    if (!jl_is_bitstype(ty))
+        jl_errorf("%s: a is not a bitstypes", name);
+    void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b);
+    unsigned sz = jl_datatype_size(ty);
+    unsigned sz2 = next_power_of_two(sz);
+    unsigned szb = jl_datatype_size(tyb);
+    if (sz2 > sz) {
+        /* round type up to the appropriate c-type and set/clear the unused bits */
+        void *pa2 = alloca(sz2);
+        memcpy(pa2, pa, sz);
+        memset((char*)pa2 + sz, getsign(pa, sz), sz2 - sz);
+        pa = pa2;
+    }
+    if (sz2 > szb) {
+        /* round type up to the appropriate c-type and set/clear/truncate the unused bits */
+        void *pb2 = alloca(sz2);
+        memcpy(pb2, pb, szb);
+        memset((char*)pb2 + szb, getsign(pb, sz), sz2 - szb);
+        pb = pb2;
+    }
+    jl_value_t *newv = lambda2(ty, pa, pb, sz, sz2, list);
+    return newv;
+}
+
+static inline jl_value_t *jl_intrinsiclambda_2(jl_value_t *ty, void *pa, void *pb, unsigned sz, unsigned sz2, void *voidlist)
+{
+    jl_value_t *newv = newstruct((jl_datatype_t*)ty);
+    intrinsic_2_t op = select_intrinsic_2(sz2, (intrinsic_2_t*)voidlist);
+    op(sz * host_char_bit, pa, pb, jl_data_ptr(newv));
+    if (ty == (jl_value_t*)jl_bool_type)
+        return *(uint8_t*)jl_data_ptr(newv) & 1 ? jl_true : jl_false;
+    return newv;
+}
+
+static inline jl_value_t *jl_intrinsiclambda_cmp(jl_value_t *ty, void *pa, void *pb, unsigned sz, unsigned sz2, void *voidlist)
+{
+    intrinsic_cmp_t op = select_intrinsic_cmp(sz2, (intrinsic_cmp_t*)voidlist);
+    int cmp = op(sz * host_char_bit, pa, pb);
+    return cmp ? jl_true : jl_false;
+}
+
+static inline jl_value_t *jl_intrinsiclambda_checked(jl_value_t *ty, void *pa, void *pb, unsigned sz, unsigned sz2, void *voidlist)
+{
+    jl_value_t *newv = newstruct((jl_datatype_t*)ty);
+    intrinsic_checked_t op = select_intrinsic_checked(sz2, (intrinsic_checked_t*)voidlist);
+    int ovflw = op(sz * host_char_bit, pa, pb, jl_data_ptr(newv));
+    if (ovflw)
+        jl_throw(jl_overflow_exception);
+    if (ty == (jl_value_t*)jl_bool_type)
+        return *(uint8_t*)jl_data_ptr(newv) & 1 ? jl_true : jl_false;
+    return newv;
+}
+
+// floating point
+
+#define bi_fintrinsic(OP, name) \
+    bi_intrinsic_ctype(OP, name, 32, float) \
+    bi_intrinsic_ctype(OP, name, 64, double) \
+DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+{ \
+    jl_value_t *ty = jl_typeof(a); \
+    if (jl_typeof(b) != ty) \
+        jl_error(#name ": types of a and b must match"); \
+    if (!jl_is_bitstype(ty)) \
+        jl_error(#name ": values are not bitstypes"); \
+    jl_value_t *newv = newstruct((jl_datatype_t*)ty); \
+    void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b), *pr = jl_data_ptr(newv); \
+    int sz = jl_datatype_size(ty); \
+    switch (sz) { \
+    /* choose the right size c-type operation */ \
+    case 4: \
+        jl_##name##32(32, pa, pb, pr); \
+        break; \
+    case 8: \
+        jl_##name##64(64, pa, pb, pr); \
+        break; \
+    default: \
+        jl_error(#name ": runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64"); \
+    } \
+    return newv; \
+}
+
+#define bool_fintrinsic(OP, name) \
+    bool_intrinsic_ctype(OP, name, 32, float) \
+    bool_intrinsic_ctype(OP, name, 64, double) \
+DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+{ \
+    jl_value_t *ty = jl_typeof(a); \
+    if (jl_typeof(b) != ty) \
+        jl_error(#name ": types of a and b must match"); \
+    if (!jl_is_bitstype(ty)) \
+        jl_error(#name ": values are not bitstypes"); \
+    void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b); \
+    int sz = jl_datatype_size(ty); \
+    int cmp; \
+    switch (sz) { \
+    /* choose the right size c-type operation */ \
+    case 4: \
+        cmp = jl_##name##32(32, pa, pb); \
+        break; \
+    case 8: \
+        cmp = jl_##name##64(64, pa, pb); \
+        break; \
+    default: \
+        jl_error(#name ": runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64"); \
+    } \
+    return cmp ? jl_true : jl_false; \
+}
+
+#define ter_fintrinsic(OP, name) \
+    ter_intrinsic_ctype(OP, name, 32, float) \
+    ter_intrinsic_ctype(OP, name, 64, double) \
+DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b, jl_value_t *c) \
+{ \
+    jl_value_t *ty = jl_typeof(a); \
+    if (jl_typeof(b) != ty || jl_typeof(c) != ty) \
+        jl_error(#name ": types of a, b, and c must match"); \
+    if (!jl_is_bitstype(ty)) \
+        jl_error(#name ": values are not bitstypes"); \
+    jl_value_t *newv = newstruct((jl_datatype_t*)ty); \
+    void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b), *pc = jl_data_ptr(c), *pr = jl_data_ptr(newv); \
+    int sz = jl_datatype_size(ty); \
+    switch (sz) { \
+    /* choose the right size c-type operation */ \
+    case 4: \
+        jl_##name##32(32, pa, pb, pc, pr); \
+        break; \
+    case 8: \
+        jl_##name##64(64, pa, pb, pc, pr); \
+        break; \
+    default: \
+        jl_error(#name ": runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64"); \
+    } \
+    return newv; \
+}
+
+// arithmetic
+#define neg(a) -a
+#define neg_float(pr, a) *pr = -a
+un_iintrinsic_fast(LLVMNeg, neg, neg_int, u)
+#define add(a,b) a + b
+bi_iintrinsic_fast(LLVMAdd, add, add_int, u)
+#define sub(a,b) a - b
+bi_iintrinsic_fast(LLVMSub, sub, sub_int, u)
+#define mul(a,b) a * b
+bi_iintrinsic_fast(LLVMMul, mul, mul_int, u)
+#define div(a,b) a / b
+bi_iintrinsic_fast(LLVMSDiv, div, sdiv_int,  )
+bi_iintrinsic_fast(LLVMUDiv, div, udiv_int, u)
+#define rem(a,b) a % b
+bi_iintrinsic_fast(LLVMSRem, rem, srem_int,  )
+bi_iintrinsic_fast(LLVMURem, rem, urem_int, u)
+#define smod(a,b) ((a < 0) == (b < 0)) ? a % b : (b + (a % b)) % b
+bi_iintrinsic_fast(jl_LLVMSMod, smod, smod_int,  )
+#define frem(a, b) \
+    fp_select2(a, b, fmod)
+
+un_fintrinsic(neg_float,neg_float)
+bi_fintrinsic(add,add_float)
+bi_fintrinsic(sub,sub_float)
+bi_fintrinsic(mul,mul_float)
+bi_fintrinsic(div,div_float)
+bi_fintrinsic(frem,rem_float)
+
+// ternary operators //
+#define fma(a, b, c) \
+    sizeof(a) == sizeof(float) ? fmaf(a, b, c) : fma(a, b, c)
+#define muladd(a, b, c) a * b + c
+ter_fintrinsic(fma,fma_float)
+ter_fintrinsic(muladd,muladd_float)
+
+// same-type comparisons
+#define eq(a,b) a == b
+bool_iintrinsic_fast(LLVMICmpEQ, eq, eq_int, u)
+#define ne(a,b) a != b
+bool_iintrinsic_fast(LLVMICmpNE, ne, ne_int, u)
+#define lt(a,b) a < b
+bool_iintrinsic_fast(LLVMICmpSLT, lt, slt_int,  )
+bool_iintrinsic_fast(LLVMICmpULT, lt, ult_int, u)
+#define le(a,b) a <= b
+bool_iintrinsic_fast(LLVMICmpSLE, le, sle_int,  )
+bool_iintrinsic_fast(LLVMICmpULE, le, ule_int, u)
+
+typedef union {
+    float f;
+    int32_t d;
+    uint32_t ud;
+} bits32;
+typedef union {
+    double f;
+    int64_t d;
+    uint64_t ud;
+} bits64;
+
+#define fpiseq_n(c_type, nbits) \
+static inline int fpiseq##nbits(c_type a, c_type b) { \
+    bits##nbits ua, ub; \
+    ua.f = a; \
+    ub.f = b; \
+    return (isnan(a) && isnan(b)) || ua.d == ub.d; \
+}
+fpiseq_n(float, 32)
+fpiseq_n(double, 64)
+#define fpiseq(a,b) \
+    sizeof(a) == sizeof(float) ? fpiseq32(a, b) : fpiseq64(a, b)
+
+#define fpislt_n(c_type, nbits) \
+static inline int fpislt##nbits(c_type a, c_type b) { \
+    bits##nbits ua, ub; \
+    ua.f = a; \
+    ub.f = b; \
+    if (!isnan(a) && isnan(b)) \
+        return 1; \
+    if (isnan(a) || isnan(b)) \
+        return 0; \
+    if (ua.d >= 0 && ua.d < ub.d) \
+        return 1; \
+    if (ua.d < 0 && ua.ud > ub.ud) \
+        return 1; \
+    return 0; \
+}
+fpislt_n(float, 32)
+fpislt_n(double, 64)
+#define fpislt(a, b) \
+    sizeof(a) == sizeof(float) ? fpislt32(a, b) : fpislt64(a, b)
+
+bool_fintrinsic(eq,eq_float)
+bool_fintrinsic(ne,ne_float)
+bool_fintrinsic(lt,lt_float)
+bool_fintrinsic(le,le_float)
+bool_fintrinsic(fpiseq,fpiseq)
+bool_fintrinsic(fpislt,fpislt)
+
+// bitwise operators
+#define and(a,b) a & b
+bi_iintrinsic_fast(LLVMAnd, and, and_int, u)
+#define or(a,b) a | b
+bi_iintrinsic_fast(LLVMOr, or, or_int, u)
+#define xor(a,b) a ^ b
+bi_iintrinsic_fast(LLVMXor, xor, xor_int, u)
+#define shl(a,b) b >= 8 * sizeof(a) ? 0 : a << b
+bi_iintrinsic_cnvtb_fast(LLVMShl, shl, shl_int, u, 1)
+#define lshr(a,b) (b >= 8 * sizeof(a)) ? 0 : a >> b
+bi_iintrinsic_cnvtb_fast(LLVMLShr, lshr, lshr_int, u, 1)
+#define ashr(a,b) \
+        /* if ((signed)a > 0) [in two's complement] ? ... : ...) */ \
+        (a >> (host_char_bit * sizeof(a) - 1)) ? ~(b >= 8 * sizeof(a) ? 0 : (~a) >> b) : (b >= 8 * sizeof(a) ? 0 : a >> b)
+bi_iintrinsic_cnvtb_fast(LLVMAShr, ashr, ashr_int, u, 1)
+//#define bswap(a) __builtin_bswap(a)
+//un_iintrinsic_fast(LLVMByteSwap, bswap, bswap_int, u)
+un_iintrinsic_slow(LLVMByteSwap, bswap_int, u)
+//#define ctpop(a) __builtin_ctpop(a)
+//uu_iintrinsic_fast(LLVMCountPopulation, ctpop, ctpop_int, u)
+uu_iintrinsic_slow(LLVMCountPopulation, ctpop_int, u)
+//#define ctlz(a) __builtin_ctlz(a)
+//uu_iintrinsic_fast(LLVMCountLeadingZeros, ctlz_int, u)
+uu_iintrinsic_slow(LLVMCountLeadingZeros, ctlz_int, u)
+//#define cttz(a) __builtin_cttz(a)
+//uu_iintrinsic_fast(LLVMCountTrailingZeros, cttz, cttz_int, u)
+uu_iintrinsic_slow(LLVMCountTrailingZeros, cttz_int, u)
+#define not(a) ~a
+un_iintrinsic_fast(LLVMFlipAllBits, not, not_int, u)
+
+// conversions
+cvt_iintrinsic(LLVMTrunc, trunc_int)
+cvt_iintrinsic(LLVMSExt, sext_int)
+cvt_iintrinsic(LLVMZExt, zext_int)
+cvt_iintrinsic(LLVMSItoFP, sitofp)
+cvt_iintrinsic(LLVMUItoFP, uitofp)
+cvt_iintrinsic(LLVMFPtoSI, fptosi)
+cvt_iintrinsic(LLVMFPtoUI, fptoui)
+
+#define fpcvt(pr, a) \
+        if (osize == 32) \
+            *(float*)pr = a; \
+        else if (osize == 64) \
+            *(double*)pr = a; \
+        else \
+            jl_error("fptrunc/fpext: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
+un_fintrinsic_withtype(fpcvt,fptrunc)
+un_fintrinsic_withtype(fpcvt,fpext)
+
+DLLEXPORT jl_value_t *jl_fptoui_auto(jl_value_t *a)
+{
+    jl_datatype_t *ty;
+    switch (jl_datatype_size(jl_typeof(a))) {
+        case 4:
+            ty = jl_uint32_type;
+            break;
+        case 8:
+            ty = jl_uint64_type;
+            break;
+        default:
+            jl_error("fptoui: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
+    }
+    return jl_fptoui((jl_value_t*)ty, a);
+}
+DLLEXPORT jl_value_t *jl_fptosi_auto(jl_value_t *a)
+{
+    jl_datatype_t *ty;
+    switch (jl_datatype_size(jl_typeof(a))) {
+        case 4:
+            ty = jl_int32_type;
+            break;
+        case 8:
+            ty = jl_int64_type;
+            break;
+        default:
+            jl_error("fptoui: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
+    }
+    return jl_fptosi((jl_value_t*)ty, a);
+}
+
+// checked conversion
+static inline int all_eq(char *p, char n, char v)
+{
+    // computes p[0:n] == v
+    while (n--)
+        if (*p++ != v)
+            return 0;
+    return 1;
+}
+static unsigned check_trunc_sint(unsigned isize, unsigned osize, void *pa)
+{
+    return !all_eq((char*)pa + osize, isize - osize, signbitbyte(pa, isize)); // TODO: assumes little-endian
+}
+cvt_iintrinsic_checked(LLVMTrunc, check_trunc_sint, checked_trunc_sint)
+static unsigned check_trunc_uint(unsigned isize, unsigned osize, void *pa)
+{
+    return !all_eq((char*)pa + osize, isize - osize, 0); // TODO: assumes little-endian
+}
+cvt_iintrinsic_checked(LLVMTrunc, check_trunc_uint, checked_trunc_uint)
+
+#define checked_fptosi(pr, a) \
+        if (!LLVMFPtoSI_exact(sizeof(a) * host_char_bit, pa, osize, pr)) \
+            jl_throw(jl_inexact_exception);
+un_fintrinsic_withtype(checked_fptosi, checked_fptosi)
+#define checked_fptoui(pr, a) \
+        if (!LLVMFPtoUI_exact(sizeof(a) * host_char_bit, pa, osize, pr)) \
+            jl_throw(jl_inexact_exception);
+un_fintrinsic_withtype(checked_fptoui, checked_fptoui)
+
+DLLEXPORT jl_value_t *jl_check_top_bit(jl_value_t *a)
+{
+    jl_value_t *ty = jl_typeof(a);
+    if (!jl_is_bitstype(ty))
+        jl_error("check_top_bit: value is not a bitstype");
+    if (signbitbyte(jl_data_ptr(a), jl_datatype_size(ty)))
+        jl_throw(jl_inexact_exception);
+    return a;
+}
+
+// checked arithmetic
+#define check_sadd(a,b) \
+        /* this test is a reduction of (b > 0) ? (a + b >= typemin(a)) : (a + b < typemin(a)) ==> overflow */ \
+        (b > 0) == (a >= (((typeof(a))1) << (8 * sizeof(a) - 1)) - b)
+checked_iintrinsic_fast(LLVMAdd_sov, check_sadd, add, checked_sadd,  )
+#define check_uadd(a,b) \
+        /* this test checks for (a + b) > typemax(a) ==> overflow */ \
+        a >= -b
+checked_iintrinsic_fast(LLVMAdd_uov, check_uadd, add, checked_uadd, u)
+#define check_ssub(a,b) check_sadd(a,-b)
+checked_iintrinsic_fast(LLVMSub_sov, check_ssub, sub, checked_ssub,  )
+#define check_usub(a,b) \
+        /* this test checks for (a - b) < 0 ==> overflow */ \
+        a < b
+checked_iintrinsic_fast(LLVMSub_uov, check_usub, sub, checked_usub, u)
+checked_iintrinsic_slow(LLVMMul_sov, checked_smul,  )
+checked_iintrinsic_slow(LLVMMul_uov, checked_umul, u)
+
+DLLEXPORT jl_value_t *jl_nan_dom_err(jl_value_t *a, jl_value_t *b)
+{
+    jl_value_t *ty = jl_typeof(a);
+    if (jl_typeof(b) != ty)
+        jl_error("nan_dom_err: types of a and b must match");
+    if (!jl_is_bitstype(ty))
+        jl_error("nan_dom_err: values are not bitstypes");
+    switch (jl_datatype_size(ty)) {
+        case 4:
+            if (isnan(*(float*)a) && !isnan(*(float*)b))
+                jl_throw(jl_domain_exception);
+            break;
+        case 8:
+            if (isnan(*(double*)a) && !isnan(*(double*)b))
+                jl_throw(jl_domain_exception);
+            break;
+        default:
+            jl_error("nan_dom_err: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
+    }
+    return a;
+}
+
+// functions
+#define flipsign(a, b) \
+        (b >= 0) ? a : -a
+bi_iintrinsic_fast(jl_LLVMFlipSign, flipsign, flipsign_int,  )
+#define abs_float(pr, a) *pr = fp_select(a, fabs)
+#define ceil_float(pr, a) *pr = fp_select(a, ceil)
+#define floor_float(pr, a) *pr = fp_select(a, floor)
+#define trunc_float(pr, a) *pr = fp_select(a, trunc)
+#define rint_float(pr, a) *pr = fp_select(a, rint)
+#define sqrt_float(pr, a) \
+        if (a < 0) \
+            jl_throw(jl_domain_exception); \
+        *pr = fp_select(a, sqrt)
+#define copysign_float(a, b) \
+        fp_select2(a, b, copysign)
+
+un_fintrinsic(abs_float,abs_float)
+bi_fintrinsic(copysign_float,copysign_float)
+un_fintrinsic(ceil_float,ceil_llvm)
+un_fintrinsic(floor_float,floor_llvm)
+un_fintrinsic(trunc_float,trunc_llvm)
+un_fintrinsic(rint_float,rint_llvm)
+un_fintrinsic(sqrt_float,sqrt_llvm)
+
+DLLEXPORT jl_value_t *jl_powi_llvm(jl_value_t *a, jl_value_t *b)
+{
+    jl_value_t *ty = jl_typeof(a);
+    if (!jl_is_bitstype(ty))
+        jl_error("powi_llvm: a is not a bitstype");
+    if (!jl_is_bitstype(jl_typeof(b)) || jl_datatype_size(jl_typeof(b)) != 4)
+        jl_error("powi_llvm: b is not a 32-bit bitstype");
+    jl_value_t *newv = newstruct((jl_datatype_t*)ty);
+    void *pa = jl_data_ptr(a), *pr = jl_data_ptr(newv);
+    int sz = jl_datatype_size(ty);
+    switch (sz) {
+    /* choose the right size c-type operation */
+    case 4:
+        *(float*)pr = powf(*(float*)pa, (float)jl_unbox_int32(b));
+        break;
+    case 8:
+        *(double*)pr = pow(*(double*)pa, (double)jl_unbox_int32(b));
+        break;
+    default:
+        jl_error("powi_llvm: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
+    }
+    return newv;
+}
+
+DLLEXPORT jl_value_t *jl_select_value(jl_value_t *isfalse, jl_value_t *a, jl_value_t *b)
+{
+    JL_TYPECHK(isfalse, bool, isfalse);
+    return (isfalse == jl_false ? b : a);
+}

--- a/src/sys.c
+++ b/src/sys.c
@@ -540,14 +540,12 @@ DLLEXPORT int32_t jl_set_zero_subnormals(int8_t isZero)
 DLLEXPORT void jl_native_alignment(uint_t *int8align, uint_t *int16align, uint_t *int32align,
                                    uint_t *int64align, uint_t *float32align, uint_t *float64align)
 {
-    LLVMTargetDataRef tgtdata = LLVMCreateTargetData("");
-    *int8align = LLVMPreferredAlignmentOfType(tgtdata, LLVMInt8Type());
-    *int16align = LLVMPreferredAlignmentOfType(tgtdata, LLVMInt16Type());
-    *int32align = LLVMPreferredAlignmentOfType(tgtdata, LLVMInt32Type());
-    *int64align = LLVMPreferredAlignmentOfType(tgtdata, LLVMInt64Type());
-    *float32align = LLVMPreferredAlignmentOfType(tgtdata, LLVMFloatType());
-    *float64align = LLVMPreferredAlignmentOfType(tgtdata, LLVMDoubleType());
-    LLVMDisposeTargetData(tgtdata);
+    *int8align = __alignof(uint8_t);
+    *int16align = __alignof(uint16_t);
+    *int32align = __alignof(uint32_t);
+    *int64align = __alignof(uint64_t);
+    *float32align = __alignof(float);
+    *float64align = __alignof(double);
 }
 
 DLLEXPORT jl_value_t *jl_is_char_signed()

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2353,6 +2353,12 @@ end
 # issue #7508
 @test_throws ErrorException reinterpret(Int, 0x01)
 
+# issue #12832
+@test_throws ErrorException reinterpret(Float64, Complex{Int64}(1))
+@test_throws ErrorException reinterpret(Float64, Complex64(1))
+@test_throws ErrorException reinterpret(Complex64, Float64(1))
+@test_throws ErrorException reinterpret(Int32, false)
+
 # issue #41
 ndigf(n) = Float64(log(Float32(n)))
 @test Float64(log(Float32(256))) == ndigf(256) == 5.545177459716797


### PR DESCRIPTION
this implements runtime versions of all of the julia intrinsics (so that functions that use them don't need to be compiled to be run). it additionally includes a `Core.Intrinsics.intrinsic_call` invoke point for calling any of these runtime intrinsics. and it adds the name of the intrinsic to `jl_` printing.

additionally, It implements full error checking for the reinterpret/box/unbox intrinsic (fixes #12832), falling back to the the runtime version when necessary.

finally, it re-organizes some of the julia codegen architecture so that it is possible to link a version of libjulia that does not include a copy of LLVM (although I don't recommend trying, since the runtime currently can't get very far without the JIT).

~~(marked as wip simply because I'm still working on this branch, not because it couldn't be merged)~~
