### PR TITLE
improve docs for A_mul_B!

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -6086,14 +6086,14 @@ values
 doc"""
     A_mul_B!(Y, A, B) -> Y
 
-
 Calculates the matrix-matrix or matrix-vector product $A⋅B$ and stores the
-result in $Y$, overwriting the existing value of $Y$.
+result in `Y`, overwriting the existing value of `Y`. Note that `Y` must not
+be aliased with either `A` or `B`.
 
 ```jldoctest
-julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; A_mul_B!(B, A, B);
+julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; Y = similar(B); A_mul_B!(Y, A, B);
 
-julia> B
+julia> Y
 2x2 Array{Float64,2}:
  3.0  3.0
  7.0  7.0

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -425,13 +425,13 @@ Mathematical Operators
 
    .. Docstring generated from Julia source
 
-   Calculates the matrix-matrix or matrix-vector product :math:`A⋅B` and stores the result in :math:`Y`\ , overwriting the existing value of :math:`Y`\ .
+   Calculates the matrix-matrix or matrix-vector product :math:`A⋅B` and stores the result in ``Y``\ , overwriting the existing value of ``Y``\ . Note that ``Y`` must not be aliased with either ``A`` or ``B``\ .
 
    .. doctest::
 
-       julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; A_mul_B!(B, A, B);
+       julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; Y = similar(B); A_mul_B!(Y, A, B);
 
-       julia> B
+       julia> Y
        2x2 Array{Float64,2}:
         3.0  3.0
         7.0  7.0


### PR DESCRIPTION
The docs for in place matrix multiplication updated an aliased matrix which does not work in the general case.

I also noticed when I looked at the online docs that the `\cdot` in the `A \cdot B` is not visible for me. Same for anyone else?

![image](https://cloud.githubusercontent.com/assets/1282691/10351620/cacd3174-6d4a-11e5-96de-7c6ee2750730.png)

Fixes JuliaLang/LinearAlgebra.jl#264
