### PR TITLE
Fix bugs & add tests for triangular matrices

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -362,7 +362,7 @@ scale!(c::Number, A::Union{UpperTriangular,LowerTriangular}) = scale!(A,c)
 
 A_mul_B!(A::Tridiagonal, B::AbstractTriangular) = A*full!(B)
 A_mul_B!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, copy!(C, B))
-A_mul_Bc!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_Bc!(A, copy!(C, B))
+A_mul_Bc!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, ctranspose!(C, B))
 
 for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
                             (:UnitLowerTriangular, 'L', 'U'),
@@ -1022,7 +1022,7 @@ end
 ### Right division with triangle to the right hence lhs cannot be transposed. Quotients.
 for (f, g) in ((:/, :A_rdiv_B!), (:A_rdiv_Bc, :A_rdiv_Bc!), (:A_rdiv_Bt, :A_rdiv_Bt!))
     @eval begin
-        function ($f){TA,TB,S}(A::StridedVecOrMat{TA}, B::Union{UnitUpperTriangular{TB,S},UnitLowerTriangular{TB,S}})
+        function ($f){TA,TB,S}(A::StridedVecOrMat{TA}, B::Union{UpperTriangular{TB,S},LowerTriangular{TB,S}})
             TAB = typeof((zero(TA)*zero(TB) + zero(TA)*zero(TB))/one(TA))
             ($g)(copy_oftype(A, TAB), convert(AbstractArray{TAB}, B))
         end

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -134,6 +134,11 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         copy!(B, A1.')
         @test B == A1.'
 
+        #expm/logm
+        if (elty1 == Float64 || elty1 == Complex128) && (t1 == UpperTriangular || t1 == LowerTriangular)
+            @test expm(full(logm(A1))) ≈ full(A1)
+        end
+
         # scale
         if (t1 == UpperTriangular || t1 == LowerTriangular)
             unitt = istriu(A1) ? UnitUpperTriangular : UnitLowerTriangular
@@ -282,6 +287,10 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
             @test_approx_eq B[:,1]'A1' B[:,1]'full(A1)'
             @test_approx_eq B'A1' B'full(A1)'
 
+            if eltyB == elty1
+                @test_approx_eq A_mul_B!(zeros(B),A1,B) A1*B
+                @test_approx_eq A_mul_Bc!(zeros(B),A1,B) A1*B'
+            end
             #error handling
             @test_throws DimensionMismatch Base.LinAlg.A_mul_B!(A1, ones(eltyB,n+1))
             @test_throws DimensionMismatch Base.LinAlg.A_mul_B!(ones(eltyB,n+1,n+1), A1)
@@ -305,6 +314,7 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
 
             # Error bounds
             elty1 != BigFloat && errorbounds(A1, A1\B, B)
+
         end
     end
 end


### PR DESCRIPTION
`A_mul_Bc!` would fail immediately because the appropriate method didn't exist. I did something ugly to make it work - if people have a nicer suggestion, I'll be happy to change it. `BLAS.trmm!` doesn't support this specific op.

I also removed a dupe that means that `rdiv` now actually works for `Upper/LowerTriangular`s.

I added tests for `logm` and the methods I bugfixed above.
