### PR TITLE
Release 0.4: make `https` protocol as default one for a new packages

### DIFF
--- a/base/pkg/generate.jl
+++ b/base/pkg/generate.jl
@@ -41,7 +41,7 @@ function package(
     isnew = !ispath(pkg)
     try
         if isnew
-            url = isempty(user) ? "" : "git://github.com/$user/$pkg.jl.git"
+            url = isempty(user) ? "" : "https://github.com/$user/$pkg.jl.git"
             Generate.init(pkg,url,config=config)
         else
             Git.dirty(dir=pkg) && error("$pkg is dirty – commit or stash your changes")


### PR DESCRIPTION
Start a gradual transition to a new `https`-only package manager ([METADATA/3601](https://github.com/JuliaLang/METADATA.jl/pull/3601)).
