### PR TITLE
use color in precompilation output if parent process is using color

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -336,6 +336,7 @@ function create_expr_cache(input::AbstractString, output::AbstractString)
     io, pobj = open(detach(`$(julia_cmd())
                            --output-ji $output --output-incremental=yes
                            --startup-file=no --history-file=no
+                           --color=$(have_color ? "yes" : "no")
                            --eval $code_object`), "w", STDOUT)
     try
         serialize(io, quote


### PR DESCRIPTION
This uses the `--have-color` option so that the precompilation child processes can use color.
