### PR TITLE
Add support for editing directories

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -1335,11 +1335,11 @@ Get the value type of an associative collection type. Behaves similarly to `elty
 valtype
 
 doc"""
-    edit(file::AbstractString, [line])
+    edit(path::AbstractString, [line])
 
-Edit a file optionally providing a line number to edit at. Returns to the julia prompt when you quit the editor.
+Edit a file or directory optionally providing a line number to edit the file at. Returns to the julia prompt when you quit the editor.
 """
-edit(file::AbstractString, line=?)
+edit(path::AbstractString, line=?)
 
 doc"""
     edit(function, [types])

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -23,33 +23,33 @@ function editor()
     return args
 end
 
-function edit(file::AbstractString, line::Integer=0)
+function edit(path::AbstractString, line::Integer=0)
     command = editor()
     name = basename(first(command))
-    issrc = length(file)>2 && file[end-2:end] == ".jl"
+    issrc = length(path)>2 && path[end-2:end] == ".jl"
     if issrc
-        f = find_source_file(file)
-        f !== nothing && (file = f)
+        f = find_source_file(path)
+        f !== nothing && (path = f)
     end
     background = true
     line_unsupported = false
     if startswith(name, "emacs") || name == "gedit"
-        cmd = line != 0 ? `$command +$line $file` : `$command $file`
+        cmd = line != 0 ? `$command +$line $path` : `$command $path`
     elseif name == "vi" || name == "vim" || name == "nvim" || name == "mvim" || name == "nano"
-        cmd = line != 0 ? `$command +$line $file` : `$command $file`
+        cmd = line != 0 ? `$command +$line $path` : `$command $path`
         background = false
     elseif name == "textmate" || name == "mate" || name == "kate"
-        cmd = line != 0 ? `$command $file -l $line` : `$command $file`
+        cmd = line != 0 ? `$command $path -l $line` : `$command $path`
     elseif startswith(name, "subl") || name == "atom"
-        cmd = line != 0 ? `$command $file:$line` : `$command $file`
+        cmd = line != 0 ? `$command $path:$line` : `$command $path`
     elseif OS_NAME == :Windows && (name == "start" || name == "open")
-        cmd = `cmd /c start /b $file`
+        cmd = `cmd /c start /b $path`
         line_unsupported = true
     elseif OS_NAME == :Darwin && (name == "start" || name == "open")
-        cmd = `open -t $file`
+        cmd = `open -t $path`
         line_unsupported = true
     else
-        cmd = `$command $file`
+        cmd = `$command $path`
         background = false
         line_unsupported = true
     end

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -23,7 +23,7 @@ function editor()
     return args
 end
 
-function edit(file::AbstractString, line::Integer)
+function edit(file::AbstractString, line::Integer=0)
     command = editor()
     name = basename(first(command))
     issrc = length(file)>2 && file[end-2:end] == ".jl"
@@ -34,14 +34,14 @@ function edit(file::AbstractString, line::Integer)
     background = true
     line_unsupported = false
     if startswith(name, "emacs") || name == "gedit"
-        cmd = `$command +$line $file`
+        cmd = line != 0 ? `$command +$line $file` : `$command $file`
     elseif name == "vi" || name == "vim" || name == "nvim" || name == "mvim" || name == "nano"
-        cmd = `$command +$line $file`
+        cmd = line != 0 ? `$command +$line $file` : `$command $file`
         background = false
     elseif name == "textmate" || name == "mate" || name == "kate"
-        cmd = `$command $file -l $line`
+        cmd = line != 0 ? `$command $file -l $line` : `$command $file`
     elseif startswith(name, "subl") || name == "atom"
-        cmd = `$command $file:$line`
+        cmd = line != 0 ? `$command $file:$line` : `$command $file`
     elseif OS_NAME == :Windows && (name == "start" || name == "open")
         cmd = `cmd /c start /b $file`
         line_unsupported = true
@@ -59,7 +59,7 @@ function edit(file::AbstractString, line::Integer)
     else
         run(cmd)
     end
-    line_unsupported && println("Unknown editor: no line number information passed.\nThe method is defined at line $line.")
+    line != 0 && line_unsupported && println("Unknown editor: no line number information passed.\nThe method is defined at line $line.")
 
     nothing
 end
@@ -69,7 +69,6 @@ function edit(m::Method)
     edit(string(file), line)
 end
 
-edit(file::AbstractString) = edit(file, 1)
 edit(f)          = edit(functionloc(f)...)
 edit(f, t::ANY)  = edit(functionloc(f,t)...)
 edit(file, line::Integer) = error("could not find source file for function")

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -64,11 +64,11 @@ Getting Around
 
    Compute the amount of memory used by all unique objects reachable from the argument. Keyword argument ``exclude`` specifies a type of objects to exclude from the traversal.
 
-.. function:: edit(file::AbstractString, [line])
+.. function:: edit(path::AbstractString, [line])
 
    .. Docstring generated from Julia source
 
-   Edit a file optionally providing a line number to edit at. Returns to the julia prompt when you quit the editor.
+   Edit a file or directory optionally providing a line number to edit the file at. Returns to the julia prompt when you quit the editor.
 
 .. function:: edit(function, [types])
 


### PR DESCRIPTION
I wanted to be able to more easily edit packages. By adding directory support to `edit` you can now do things like `edit(Pkg.dir("TimeZones"))` to open an entire directory in your preferred editor.

The change required me to optionally add in arguments for line numbers. This was required by sublime to work correctly and I think it makes sense not to include them for other editors as well. I'll note that editors such as nano and TextEdit don't support opening directories but fail gracefully.
