### PR TITLE
[release-0.4] bump version of embedded git for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -553,7 +553,8 @@ ifneq (,$(filter $(ARCH), i386 i486 i586 i686))
 	7z x -y 7z920.exe 7z.exe 7z.dll && \
 	../contrib/windows/winrpm.sh http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_13.1 \
 	"mingw32-libgfortran3 mingw32-libquadmath0 mingw32-libstdc++6 mingw32-libgcc_s_sjlj1 mingw32-libssp0 mingw32-libexpat1 mingw32-zlib1" && \
-	cp usr/i686-w64-mingw32/sys-root/mingw/bin/*.dll .
+	cp usr/i686-w64-mingw32/sys-root/mingw/bin/*.dll . && \
+	$(JLDOWNLOAD) PortableGit.7z https://github.com/git-for-windows/git/releases/download/v2.6.1.windows.1/PortableGit-2.6.1-32-bit.7z.exe
 else ifeq ($(ARCH),x86_64)
 	cd dist-extras && \
 	$(JLDOWNLOAD) 7z920-x64.msi http://downloads.sourceforge.net/sevenzip/7z920-x64.msi && \
@@ -562,7 +563,8 @@ else ifeq ($(ARCH),x86_64)
 	mv _7z.exe 7z.exe && \
 	../contrib/windows/winrpm.sh http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_13.1 \
 	"mingw64-libgfortran3 mingw64-libquadmath0 mingw64-libstdc++6 mingw64-libgcc_s_seh1 mingw64-libssp0 mingw64-libexpat1 mingw64-zlib1" && \
-	cp usr/x86_64-w64-mingw32/sys-root/mingw/bin/*.dll .
+	cp usr/x86_64-w64-mingw32/sys-root/mingw/bin/*.dll . && \
+	$(JLDOWNLOAD) PortableGit.7z https://github.com/git-for-windows/git/releases/download/v2.6.1.windows.1/PortableGit-2.6.1-64-bit.7z.exe
 else
 	$(error no win-extras target for ARCH=$(ARCH))
 endif
@@ -574,5 +576,4 @@ endif
 	chmod a+x 7z.dll && \
 	$(call spawn,./7z.exe) x -y -onsis nsis-2.46.5-Unicode-setup.exe && \
 	chmod a+x ./nsis/makensis.exe && \
-	chmod a+x busybox.exe && \
-	$(JLDOWNLOAD) PortableGit.7z https://github.com/msysgit/msysgit/releases/download/Git-1.9.5-preview20141217/PortableGit-1.9.5-preview20141217.7z
+	chmod a+x busybox.exe


### PR DESCRIPTION
This will optimize overall performance of `Pkg` module on windows.
Also, for some reason I´m unable to skip firewall using `https insteadOf git` workaround on current git version that ships with julia for windows. With this update, everything works fine and now I´m able to use julia at work.

I would recommend some more testing on this before merging. I was unable to run `make binary-dist`, but `make win-extras` worked fine, and `7z x PortableGit.7z` also worked.

I also tested the current Julia rc with the new Git folder, and it runs smoothly. I did this on win7 and win10, both 64bit.

I also noticed the unpacked Git folder is smaller (old was 260MB, new is 190MB).
