### PR TITLE
eval build.jl files in a separate Julia process for Pkg.build

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -725,22 +725,66 @@ function warnbanner(msg...; label="[ WARNING ]", prefix="")
     warn(prefix="", "="^cols)
 end
 
-function build!(pkgs::Vector, errs::Dict, seen::Set=Set())
+function build!(pkgs::Vector, buildstream::IO, seen::Set)
     for pkg in pkgs
         pkg == "julia" && continue
         pkg in seen && continue
-        build!(Read.requires_list(pkg),errs,push!(seen,pkg))
+        build!(Read.requires_list(pkg),buildstream,push!(seen,pkg))
         Read.isinstalled(pkg) || throw(PkgError("$pkg is not an installed package"))
         path = abspath(pkg,"deps","build.jl")
         isfile(path) || continue
-        info("Building $pkg")
-        cd(dirname(path)) do
-            try evalfile(path)
-            catch err
-                warnbanner(err, label="[ ERROR: $pkg ]")
+        println(buildstream, path) # send to build process for evalfile
+        flush(buildstream)
+    end
+end
+
+function build!(pkgs::Vector, errs::Dict, seen::Set=Set())
+    # To isolate the build from the running Julia process, we
+    # execute the build.jl files in a separate process that
+    # is sitting there waiting for paths to evaluate.   Errors
+    # are serialized to errfile for later retrieval into errs[pkg]
+    errfile = tempname()
+    close(open(errfile, "w")) # create empty file
+    code = """
+        open("$(escape_string(errfile))", "a") do f
+            for path_ in eachline(STDIN)
+                path = chomp(path_)
+                pkg = basename(dirname(dirname(path)))
+                try
+                    info("Building \$pkg")
+                    cd(dirname(path)) do
+                        evalfile(path)
+                    end
+                catch err
+                    Base.Pkg.Entry.warnbanner(err, label="[ ERROR: \$pkg ]")
+                    serialize(f, pkg)
+                    serialize(f, err)
+                end
+            end
+        end
+    """
+    io, pobj = open(detach(`$(Base.julia_cmd())
+                           --history-file=no
+                           --color=$(Base.have_color ? "yes" : "no")
+                           --eval $code`), "w", STDOUT)
+    try
+        build!(pkgs, io, seen)
+        close(io)
+        wait(pobj)
+        success(pobj) || error("Build process failed.")
+        open(errfile, "r") do f
+            while !eof(f)
+                pkg = deserialize(f)
+                err = deserialize(f)
                 errs[pkg] = err
             end
         end
+    catch
+        kill(pobj)
+        close(io)
+        rethrow()
+    finally
+        isfile(errfile) && Base.rm(errfile)
     end
 end
 


### PR DESCRIPTION
This fixes #13458.

It supersedes #13499, which spawned a separate process for each `build.jl` file.  Instead, as requested by @tkelman (since launching `julia` is slow on Windows), my new version spawns a single Julia process which evals all the `build.jl` files.  This should suffice to fix the problems described in #13458 — it isolates the build from the running Julia process, and since packages are built in dependency order it should be okay that their builds share a process.
