### PR TITLE
Fix Windows Git path issues

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -83,7 +83,6 @@ Julia's build process uses the following external tools:
 Julia bundles the following external programs and libraries on some platforms:
 
 - [7-Zip](http://www.7-zip.org/license.txt)
-- [BUSYBOX](https://github.com/rmyorston/busybox-w32/blob/master/LICENSE)
 - [GIT](http://git-scm.com/about/free-and-open-source)
 - [ZLIB](http://zlib.net/zlib_license.html)
 - [LIBEXPAT](http://expat.cvs.sourceforge.net/viewvc/expat/expat/README)

--- a/Makefile
+++ b/Makefile
@@ -465,10 +465,8 @@ ifeq ($(OS), WINNT)
 		cp 7z.exe 7z.dll libexpat-1.dll zlib1.dll libgfortran-3.dll libquadmath-0.dll libstdc++-6.dll libgcc_s_s*-1.dll libssp-0.dll $(bindir) && \
 	    mkdir $(DESTDIR)$(prefix)/Git && \
 	    7z x PortableGit.7z -o"$(DESTDIR)$(prefix)/Git" && \
-	    echo "[core] eol = lf" >> "$(DESTDIR)$(prefix)/Git/etc/gitconfig" && \
-	    sed -i "s/\bautocrlf = true$$/autocrlf = input/" "$(DESTDIR)$(prefix)/Git/etc/gitconfig" && \
-	    cp busybox.exe $(DESTDIR)$(prefix)/Git/bin/echo.exe && \
-	    cp busybox.exe $(DESTDIR)$(prefix)/Git/bin/printf.exe )
+	    echo "[core] eol = lf" >> "$(DESTDIR)$(prefix)"/Git/mingw*/etc/gitconfig && \
+	    sed -i "s/\bautocrlf = true$$/autocrlf = input/" "$(DESTDIR)$(prefix)"/Git/mingw*/etc/gitconfig )
 	cd $(DESTDIR)$(bindir) && rm -f llvm* llc.exe lli.exe opt.exe LTO.dll bugpoint.exe macho-dump.exe
 
 	# create file listing for uninstall. note: must have Windows path separators and line endings.
@@ -612,9 +610,7 @@ endif
 	cd $(JULIAHOME)/dist-extras && \
 	$(JLDOWNLOAD) http://downloads.sourceforge.net/sevenzip/7z920_extra.7z && \
 	$(JLDOWNLOAD) https://unsis.googlecode.com/files/nsis-2.46.5-Unicode-setup.exe && \
-	$(JLDOWNLOAD) busybox.exe http://frippery.org/files/busybox/busybox-w32-FRP-1-g9eb16cb.exe && \
 	chmod a+x 7z.exe && \
 	chmod a+x 7z.dll && \
 	$(call spawn,./7z.exe) x -y -onsis nsis-2.46.5-Unicode-setup.exe && \
-	chmod a+x ./nsis/makensis.exe && \
-	chmod a+x busybox.exe
+	chmod a+x ./nsis/makensis.exe

--- a/contrib/windows/juliarc.jl
+++ b/contrib/windows/juliarc.jl
@@ -1,6 +1,4 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-let user_data_dir
-    ENV["PATH"] = JULIA_HOME*";"*joinpath(JULIA_HOME,"..","Git","bin")*";"*ENV["PATH"]
-    #haskey(ENV,"JULIA_EDITOR") || (ENV["JULIA_EDITOR"] = "start") #start is not a program, so this doesn't work
-end
+ENV["PATH"] = JULIA_HOME*";"*joinpath(JULIA_HOME,"..","Git","bin")*";"*
+    joinpath(JULIA_HOME,"..","Git","usr","bin")*";"*ENV["PATH"]

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -106,7 +106,7 @@ if ! [ -e julia-installer.exe ]; then
   echo "Extracting $f"
   $SEVENZIP x -y $f >> get-deps.log
 fi
-for i in bin/*.dll Git/bin/msys-1.0.dll Git/bin/msys-perl5_8.dll Git/bin/*.exe; do
+for i in bin/*.dll Git/usr/bin/*.dll Git/usr/bin/*.exe; do
   $SEVENZIP e -y julia-installer.exe "\$_OUTDIR/$i" \
     -ousr\\`dirname $i | sed -e 's|/julia||' -e 's|/|\\\\|g'` >> get-deps.log
 done
@@ -179,8 +179,6 @@ if [ -z "`which make 2>/dev/null`" ]; then
   fi
   $SEVENZIP x -y `basename $f.lzma` >> get-deps.log
   tar -xf `basename $f`
-  # msysgit has an ancient version of touch that fails with `touch -c nonexistent`
-  cp usr/Git/bin/echo.exe bin/touch.exe
   export PATH=$PWD/bin:$PATH
 fi
 


### PR DESCRIPTION
from upgrade to Git 2.x (#13494), causing failure of spawn test on appveyor

also remove busybox since Git 2.x makes it unnecessary

edit: to be backported along with 09c9a195add174e1f7f141703caf8a74fed6f1d6
