### PR TITLE
Make the constructors of Array and SharedArray consistent

### DIFF
--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -24,6 +24,17 @@ type SharedArray{T,N} <: DenseArray{T,N}
     SharedArray(d,p,r,sn) = new(d,p,r,sn)
 end
 
+call{T,N}(::Type{SharedArray{T}}, d::NTuple{N,Int}; kwargs...) =
+    SharedArray(T, d; kwargs...)
+call{T}(::Type{SharedArray{T}}, d::Integer...; kwargs...) =
+    SharedArray(T, d; kwargs...)
+call{T}(::Type{SharedArray{T}}, m::Integer; kwargs...) =
+    SharedArray(T, m; kwargs...)
+call{T}(::Type{SharedArray{T}}, m::Integer, n::Integer; kwargs...) =
+    SharedArray(T, m, n; kwargs...)
+call{T}(::Type{SharedArray{T}}, m::Integer, n::Integer, o::Integer; kwargs...) =
+    SharedArray(T, m, n, o; kwargs...)
+
 function SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
     N = length(dims)
 

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -179,6 +179,20 @@ end
 
 ### Utility functions
 
+# construct PR #13514
+S = SharedArray{Int}((1,2,3))
+@test size(S) == (1,2,3)
+@test typeof(S) <: SharedArray{Int}
+S = SharedArray{Int}(2)
+@test size(S) == (2,)
+@test typeof(S) <: SharedArray{Int}
+S = SharedArray{Int}(1,2)
+@test size(S) == (1,2)
+@test typeof(S) <: SharedArray{Int}
+S = SharedArray{Int}(1,2,3)
+@test size(S) == (1,2,3)
+@test typeof(S) <: SharedArray{Int}
+
 # reshape
 
 d = Base.shmem_fill(1.0, (10,10,10))


### PR DESCRIPTION
While Array supports these kind of constructors: Array{Int}(100), SharedArray does not have.
