### PR TITLE
micro: change LIBBLAS to use LIBBLASNAME

### DIFF
--- a/test/perf/micro/Makefile
+++ b/test/perf/micro/Makefile
@@ -18,7 +18,7 @@ endif
 #Which BLAS library am I using?
 ifeq ($(USE_SYSTEM_BLAS), 0)
 BLASDIR=$(JULIAHOME)/deps/build/openblas/
-LIBBLAS=$(BLASDIR)libopenblas64_.a
+LIBBLAS=$(BLASDIR)$(LIBBLASNAME).a
 endif
 
 FFLAGS=-fexternal-blas
@@ -53,11 +53,11 @@ perf.h: $(JULIAHOME)/deps/Versions.make
 	echo '#include "$(RMATHDIR)/src/randmtzig.c"' >> $@
 
 bin/perf%: perf.c perf.h
-	$(CC) -std=c99 -O$* $< -o $@  -I$(DSFMTDIR) -L$(BLASDIR) $(LIBBLAS) -L$(LIBMDIR) $(LIBM) $(CFLAGS) -lpthread
+	$(CC) -std=c99 -O$* $< -o $@  -I$(DSFMTDIR) $(LIBBLAS) -L$(LIBMDIR) $(LIBM) $(CFLAGS) -lpthread
 
 bin/fperf%: perf.f90
 	mkdir -p mods/$@ #Modules for each binary go in separate directories
-	$(FC) $(FFLAGS) -Jmods/$@ -O$* $< -o $@ -L$(BLASDIR) $(LIBBLAS) -L$(LIBMDIR) $(LIBM) -lpthread
+	$(FC) $(FFLAGS) -Jmods/$@ -O$* $< -o $@ $(LIBBLAS) -L$(LIBMDIR) $(LIBM) -lpthread
 
 benchmarks/c.csv: \
 	benchmarks/c0.csv \


### PR DESCRIPTION
Also get rid of -L$(BLASDIR), which is not necessary when statically
linking

Ref: 7dcc01be36a854bf95915f1cdf157df7c722ea68
