### PR TITLE
New way to display a range in REPL

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -13,15 +13,24 @@ function writemime(io::IO, ::MIME"text/plain", f::Function)
     end
 end
 
+# writemime for ranges, e.g.
+#  3-element UnitRange{Int64,Int}
+#   1,2,3
+# or for more elements than fit on screen:
+#   1.0,2.0,3.0,…,6.0,7.0,8.0
+function writemime(io::IO, ::MIME"text/plain", r::Union{Range, LinSpace})
+    print(io, summary(r))
+    if !isempty(r)
+        println(io, ":")
+        with_output_limit(()->print_range(io, r))
+    end
+end
+
 function writemime(io::IO, ::MIME"text/plain", v::AbstractVector)
-    if isa(v, Range)
-        show(io, v)
-    else
-        print(io, summary(v))
-        if !isempty(v)
-            println(io, ":")
-            with_output_limit(()->print_matrix(io, v))
-        end
+    print(io, summary(v))
+    if !isempty(v)
+        println(io, ":")
+        with_output_limit(()->print_matrix(io, v))
     end
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -544,6 +544,12 @@ for x in r
 end
 @test i == 7
 
+# writemime should display the range or linspace nicely
+replstr(x) = sprint((io,x) -> writemime(io,MIME("text/plain"),x), x)
+@test replstr(1:4) == "4-element UnitRange{Int64}:\n 1,2,3,4"
+@test replstr(linspace(1,5,7)) == "7-element LinSpace{Float64}:\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"
+@test replstr(0:100.) == "101-element FloatRange{Float64}:\n 0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,…,94.0,95.0,96.0,97.0,98.0,99.0,100.0"
+
 # Issue 11049 and related
 @test promote(linspace(0f0, 1f0, 3), linspace(0., 5., 2)) ===
     (linspace(0., 1., 3), linspace(0., 5., 2))


### PR DESCRIPTION
This is the result of a [user's forum discussion about ranges](https://groups.google.com/forum/#!searchin/julia-users/nicer/julia-users/qPqgJS-usrU/Hu40_tOlDQAJ). People were unhappy that `0:5` or `linspace(1,10,7)` does not return a vector, as they wanted. I believe it is sensible for these to be `range` objects (rather than being converted via `collect`), but the REPL display could be modified to show what the `range` actually looks like. The user probably wants to see some confirmation of what they were thinking, and seeing the definition doesn't help.

The proposed solution is to give REPL output more like this:

```
julia> 0:4
5-element UnitRange{Int64}:
 0,1,2,3,4

julia> 0:100
101-element UnitRange{Int64}:
 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,…,89,90,91,92,93,94,95,96,97,98,99,100

julia> linspace(0,2.5,4)
4-element LinSpace{Float64}:
 0.0,0.833333,1.66667,2.5
```

This is accomplished my overloading writemime (replutil.jl) to respond to `range` objects, adding a `print_range` method (range.jl) and appropriate unit tests (test/ranges.jl). This affects `display()`, but the user can still use `show(1:5)` to return the definition `1:5`. The `print_range` method is based on the existing `print_matrix_row`, and so it uses knowledge of screen size to make everything fit in one row, with horizontal dots (ellipsis) where appropriate.

Additional edits were made to show.jl, where I added a bunch of comments. I had to learn how `print_matrix` works, and the comments are meant to save time for someone like me, as the code is a bit opaque. There were absolutely no changes to execution of show.jl.

A few notes. I decided not to add brackets around the range. Perhaps square brackets would be appropriate, but I felt they were not needed, as a range is not exactly an array. Also, the range is printed as a single row to save vertical screen space. I thought this was acceptable because tuples are also printed across, despite acting somewhat like 1-d arrays, which are kind of "vertical." I would appreciate feedback if there are disagreements about these choices, or about the whole idea of modifying the REPL.
