### PR TITLE
Improve apply_type inference for complicated types

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -451,10 +451,11 @@ const apply_type_tfunc = function (A, args...)
         appl = headtype
         uncertain = true
     end
+    !uncertain && return Type{appl}
     if type_too_complex(appl,0)
         return Type{TypeVar(:_,headtype)}
     end
-    uncertain && !isa(appl,TypeVar) ? Type{TypeVar(:_,appl)} : Type{appl}
+    !isa(appl,TypeVar) ? Type{TypeVar(:_,appl)} : Type{appl}
 end
 add_tfunc(apply_type, 1, IInf, apply_type_tfunc)
 


### PR DESCRIPTION
The motivating example here is:

```
julia> T = Cxx.CppValue{Cxx.CxxQualType{Cxx.CppTemplate{Cxx.CppBaseType{:A},Tuple{Cxx.CxxQualType{Cxx.CppBaseType{:B},(false,false,false)}}},(false,false,false)}}
Cxx.CppValue{Cxx.CxxQualType{Cxx.CppTemplate{Cxx.CppBaseType{:A},Tuple{Cxx.CxxQualType{Cxx.CppBaseType{:B},(false,false,false)}}},(false,false,false)},N}

julia> @eval baz() = ($T){4}
```

Without this patch it infers it as `Type{<:Cxx.CppValue{Cxx.CxxQualType{Cxx.CppTemplate{Cxx.CppBaseType{:A},Tuple{Cxx.CxxQualType{Cxx.CppBaseType{:B},(false,false,false)}}},(false,false,false)},N}}`, which seems pretty sad given how simple the expression is. @JeffBezanson Does this look reasonable?
