### PR TITLE
Fix regression in `atrepl`

### DIFF
--- a/test/docs.jl
+++ b/test/docs.jl
@@ -411,6 +411,13 @@ f12593_2() = 1
 # test that macro documentation works
 @test (Docs.@repl @assert) !== nothing
 
+@test (Docs.@repl 0) !== nothing
+
+let t = @doc(DocsTest.t(::Int, ::Int))
+    @test docstrings_equal(Docs.@repl(DocsTest.t(0, 0)), t)
+    @test docstrings_equal(Docs.@repl(DocsTest.t(::Int, ::Int)), t)
+end
+
 # Issue #13467.
 @test (Docs.@repl @r_str) !== nothing
 


### PR DESCRIPTION
Docs attached to numbers weren't being found. (ref https://groups.google.com/d/msg/julia-users/D7QE9oFj91Y/D5f4HKC2AgAJ)

Finding docs for specific methods using the syntax

```
help?> f(::Int)
```

wasn't being recognised due to changes in how `gen_call_with_extracted_types` generated an error when it failed. (Previously the error was thrown by the function, but is now returned as an `:(error("..."))` expression.)
