### PR TITLE
implement pure function annotations

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -117,15 +117,6 @@ linearindexing(A::AbstractArray, B::AbstractArray...) = linearindexing(linearind
 linearindexing(::LinearFast, ::LinearFast) = LinearFast()
 linearindexing(::LinearIndexing, ::LinearIndexing) = LinearSlow()
 
-# The real @inline macro is not available this early in the bootstrap, so this
-# internal macro splices the meta Expr directly into the function body.
-macro _inline_meta()
-    Expr(:meta, :inline)
-end
-macro _noinline_meta()
-    Expr(:meta, :noinline)
-end
-
 ## Bounds checking ##
 @generated function trailingsize{T,N,n}(A::AbstractArray{T,N}, ::Type{Val{n}})
     n > N && return 1

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -14,6 +14,9 @@ end
 macro _noinline_meta()
     Expr(:meta, :noinline)
 end
+macro _pure_meta()
+    Expr(:meta, :pure)
+end
 
 
 # constructors for Core types in boot.jl
@@ -74,7 +77,8 @@ macro generated(f)
 end
 
 
-@generated function tuple_type_head{T<:Tuple}(::Type{T})
+function tuple_type_head{T<:Tuple}(::Type{T})
+    @_pure_meta
     T.parameters[1]
 end
 
@@ -82,7 +86,8 @@ isvarargtype(t::ANY) = isa(t,DataType)&&is((t::DataType).name,Vararg.name)
 isvatuple(t::DataType) = (n = length(t.parameters); n > 0 && isvarargtype(t.parameters[n]))
 unwrapva(t::ANY) = isvarargtype(t) ? t.parameters[1] : t
 
-@generated function tuple_type_tail{T<:Tuple}(::Type{T})
+function tuple_type_tail{T<:Tuple}(::Type{T})
+    @_pure_meta
     if isvatuple(T) && length(T.parameters) == 1
         return T
     end

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -67,18 +67,16 @@ macro eval(x)
 end
 
 macro inline(ex)
-    esc(_inline(ex))
+    esc(isa(ex, Expr) ? pushmeta!(ex, :inline) : ex)
 end
-
-_inline(ex::Expr) = pushmeta!(ex, :inline)
-_inline(arg) = arg
 
 macro noinline(ex)
-    esc(_noinline(ex))
+    esc(isa(ex, Expr) ? pushmeta!(ex, :noinline) : ex)
 end
 
-_noinline(ex::Expr) = pushmeta!(ex, :noinline)
-_noinline(arg) = arg
+macro pure(ex)
+    esc(isa(ex, Expr) ? pushmeta!(ex, :pure) : ex)
+end
 
 ## some macro utilities ##
 

--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -45,7 +45,8 @@ immutable Zip{I, Z<:AbstractZipIterator} <: AbstractZipIterator
 end
 zip(a, b, c...) = Zip(a, zip(b, c...))
 length(z::Zip) = min(length(z.a), length(z.z))
-@generated function tuple_type_cons{S,T<:Tuple}(::Type{S}, ::Type{T})
+function tuple_type_cons{S,T<:Tuple}(::Type{S}, ::Type{T})
+    @_pure_meta
     Tuple{S, T.parameters...}
 end
 eltype{I,Z}(::Type{Zip{I,Z}}) = tuple_type_cons(eltype(I), eltype(Z))

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -71,16 +71,16 @@ isconst(m::Module, s::Symbol) =
 object_id(x::ANY) = ccall(:jl_object_id, UInt, (Any,), x)
 
 # type predicates
-isimmutable(x::ANY) = (isa(x,Tuple) || !typeof(x).mutable)
-isstructtype(t::DataType) = nfields(t) != 0 || (t.size==0 && !t.abstract)
-isstructtype(x) = false
-isbits(t::DataType) = !t.mutable & t.pointerfree & isleaftype(t)
-isbits(t::Type) = false
-isbits(x) = isbits(typeof(x))
-isleaftype(t::ANY) = ccall(:jl_is_leaf_type, Int32, (Any,), t) != 0
+isimmutable(x::ANY) = (@_pure_meta; (isa(x,Tuple) || !typeof(x).mutable))
+isstructtype(t::DataType) = (@_pure_meta; nfields(t) != 0 || (t.size==0 && !t.abstract))
+isstructtype(x) = (@_pure_meta; false)
+isbits(t::DataType) = (@_pure_meta; !t.mutable & t.pointerfree & isleaftype(t))
+isbits(t::Type) = (@_pure_meta; false)
+isbits(x) = (@_pure_meta; isbits(typeof(x)))
+isleaftype(t::ANY) = (@_pure_meta; ccall(:jl_is_leaf_type, Int32, (Any,), t) != 0)
 
-typeintersect(a::ANY,b::ANY) = ccall(:jl_type_intersection, Any, (Any,Any), a, b)
-typeseq(a::ANY,b::ANY) = a<:b && b<:a
+typeintersect(a::ANY,b::ANY) = (@_pure_meta; ccall(:jl_type_intersection, Any, (Any,Any), a, b))
+typeseq(a::ANY,b::ANY) = (@_pure_meta; a<:b && b<:a)
 
 function fieldoffsets(x::DataType)
     offsets = Array(Int, nfields(x))
@@ -88,8 +88,8 @@ function fieldoffsets(x::DataType)
     offsets
 end
 
-type_alignment(x::DataType) = ccall(:jl_get_alignment,Csize_t,(Any,),x)
-field_offset(x::DataType,idx) = ccall(:jl_get_field_offset,Csize_t,(Any,Int32),x,idx)
+type_alignment(x::DataType) = (@_pure_meta; ccall(:jl_get_alignment,Csize_t,(Any,),x))
+field_offset(x::DataType,idx) = (@_pure_meta; ccall(:jl_get_field_offset,Csize_t,(Any,Int32),x,idx))
 
 # return all instances, for types that can be enumerated
 function instances end
@@ -114,11 +114,12 @@ subtypes(m::Module, x::DataType) = sort(collect(_subtypes(m, x)), by=string)
 subtypes(x::DataType) = subtypes(Main, x)
 
 # function reflection
-isgeneric(f::ANY) = (isa(f,Function) && isa(f.env,MethodTable))
+isgeneric(f::ANY) = (@_pure_meta; (isa(f,Function) && isa(f.env,MethodTable)))
 
 function_name(f::Function) = isgeneric(f) ? f.env.name : (:anonymous)
 
 function to_tuple_type(t::ANY)
+    @_pure_meta
     if isa(t,Tuple) || isa(t,AbstractArray) || isa(t,SimpleVector)
         t = Tuple{t...}
     end
@@ -132,7 +133,7 @@ function to_tuple_type(t::ANY)
     t
 end
 
-tt_cons(t::ANY, tup::ANY) = Tuple{t, (isa(tup, Type) ? tup.parameters : tup)...}
+tt_cons(t::ANY, tup::ANY) = (@_pure_meta; Tuple{t, (isa(tup, Type) ? tup.parameters : tup)...})
 
 code_lowered(f, t::ANY) = map(m->uncompressed_ast(m.func.code), methods(f, t))
 function methods(f::Function,t::ANY)

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -100,7 +100,7 @@ jl_sym_t *compositetype_sym; jl_sym_t *type_goto_sym;
 jl_sym_t *global_sym; jl_sym_t *tuple_sym;
 jl_sym_t *dot_sym;    jl_sym_t *newvar_sym;
 jl_sym_t *boundscheck_sym; jl_sym_t *copyast_sym;
-jl_sym_t *fastmath_sym;
+jl_sym_t *fastmath_sym; jl_sym_t *pure_sym;
 jl_sym_t *simdloop_sym; jl_sym_t *meta_sym;
 jl_sym_t *arrow_sym;  jl_sym_t *inert_sym;
 jl_sym_t *vararg_sym;
@@ -339,8 +339,12 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams, jl_mod
     li->ast = ast;
     li->file = null_sym;
     li->line = 0;
+    li->pure = 0;
     if (ast != NULL && jl_is_expr(ast)) {
-        jl_value_t *body1 = skip_meta(jl_lam_body((jl_expr_t*)ast)->args);
+        jl_array_t *body = jl_lam_body((jl_expr_t*)ast)->args;
+        if (has_meta(body, pure_sym))
+            li->pure = 1;
+        jl_value_t *body1 = skip_meta(body);
         if (jl_is_linenode(body1)) {
             li->file = jl_linenode_file(body1);
             li->line = jl_linenode_line(body1);
@@ -361,7 +365,6 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams, jl_mod
     li->specFunctionID = 0;
     li->specTypes = NULL;
     li->inferred = 0;
-    li->pure = 0;
     li->inInference = 0;
     li->inCompile = 0;
     li->unspecialized = NULL;

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -361,6 +361,7 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams, jl_mod
     li->specFunctionID = 0;
     li->specTypes = NULL;
     li->inferred = 0;
+    li->pure = 0;
     li->inInference = 0;
     li->inCompile = 0;
     li->unspecialized = NULL;

--- a/src/ast.c
+++ b/src/ast.c
@@ -1008,6 +1008,22 @@ jl_value_t *skip_meta(jl_array_t *body)
     return body1;
 }
 
+int has_meta(jl_array_t *body, jl_sym_t *sym)
+{
+    size_t i, l = jl_array_len(body);
+    for (i = 0; i < l; i++) {
+        jl_expr_t *stmt = (jl_expr_t*)jl_cellref(body, i);
+        if (jl_is_expr((jl_value_t*)stmt) && stmt->head == meta_sym) {
+            size_t i, l = jl_array_len(stmt->args);
+            for (i = 0; i < l; i++)
+                if (jl_cellref(stmt->args, i) == (jl_value_t*)sym)
+                    return 1;
+        }
+    }
+    return 0;
+}
+
+
 int jl_in_vinfo_array(jl_array_t *a, jl_sym_t *v)
 {
     size_t i, l=jl_array_len(a);

--- a/src/dump.c
+++ b/src/dump.c
@@ -822,6 +822,7 @@ static void jl_serialize_value_(ios_t *s, jl_value_t *v)
         jl_serialize_value(s, (jl_value_t*)li->specTypes);
         jl_serialize_value(s, (jl_value_t*)li->specializations);
         write_int8(s, li->inferred);
+        write_int8(s, li->pure);
         jl_serialize_value(s, (jl_value_t*)li->file);
         write_int32(s, li->line);
         jl_serialize_value(s, (jl_value_t*)li->module);
@@ -1366,6 +1367,7 @@ static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t 
         li->specializations = (jl_array_t*)jl_deserialize_value(s, (jl_value_t**)&li->specializations);
         if (li->specializations) jl_gc_wb(li, li->specializations);
         li->inferred = read_int8(s);
+        li->pure = read_int8(s);
         li->file = (jl_sym_t*)jl_deserialize_value(s, NULL);
         jl_gc_wb(li, li->file);
         li->line = read_int32(s);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -493,6 +493,9 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
     else if (ex->head == meta_sym) {
         return (jl_value_t*)jl_nothing;
     }
+    else if (ex->head == inert_sym) {
+        return args[0];
+    }
     jl_errorf("unsupported or misplaced expression %s", ex->head->name);
     return (jl_value_t*)jl_nothing;
 }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3573,6 +3573,7 @@ void jl_init_types(void)
     newvar_sym = jl_symbol("newvar");
     copyast_sym = jl_symbol("copyast");
     simdloop_sym = jl_symbol("simdloop");
+    pure_sym = jl_symbol("pure");
     meta_sym = jl_symbol("meta");
     arrow_sym = jl_symbol("->");
     dots_sym = jl_symbol("...");

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3420,7 +3420,7 @@ void jl_init_types(void)
     jl_lambda_info_type =
         jl_new_datatype(jl_symbol("LambdaStaticData"),
                         jl_any_type, jl_emptysvec,
-                        jl_svec(14, jl_symbol("ast"), jl_symbol("sparams"),
+                        jl_svec(15, jl_symbol("ast"), jl_symbol("sparams"),
                                 jl_symbol("tfunc"), jl_symbol("name"),
                                 jl_symbol("roots"),
                                 /* jl_symbol("specTypes"),
@@ -3430,15 +3430,16 @@ void jl_init_types(void)
                                 jl_symbol("module"), jl_symbol("def"),
                                 jl_symbol("capt"),
                                 jl_symbol("file"), jl_symbol("line"),
-                                jl_symbol("inferred")),
-                        jl_svec(14, jl_any_type, jl_simplevector_type,
+                                jl_symbol("inferred"),
+                                jl_symbol("pure")),
+                        jl_svec(15, jl_any_type, jl_simplevector_type,
                                 jl_any_type, jl_sym_type,
                                 jl_any_type, jl_any_type,
                                 jl_any_type, jl_array_any_type,
                                 jl_module_type, jl_any_type,
                                 jl_any_type,
                                 jl_sym_type, jl_int32_type,
-                                jl_bool_type),
+                                jl_bool_type, jl_bool_type),
                         0, 1, 4);
 
     jl_box_type =

--- a/src/julia.h
+++ b/src/julia.h
@@ -203,6 +203,7 @@ typedef struct _jl_lambda_info_t {
     jl_sym_t *file;
     int32_t line;
     int8_t inferred;
+    int8_t pure;
 
     // hidden fields:
     // flag telling if inference is running on this function

--- a/src/julia.h
+++ b/src/julia.h
@@ -493,7 +493,7 @@ extern jl_sym_t *abstracttype_sym; extern jl_sym_t *bitstype_sym;
 extern jl_sym_t *compositetype_sym; extern jl_sym_t *type_goto_sym;
 extern jl_sym_t *global_sym;  extern jl_sym_t *tuple_sym;
 extern jl_sym_t *boundscheck_sym; extern jl_sym_t *copyast_sym;
-extern jl_sym_t *fastmath_sym;
+extern jl_sym_t *fastmath_sym; extern jl_sym_t *pure_sym;
 extern jl_sym_t *simdloop_sym; extern jl_sym_t *meta_sym;
 extern jl_sym_t *arrow_sym; extern jl_sym_t *inert_sym;
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -155,6 +155,7 @@ void jl_generate_fptr(jl_function_t *f);
 void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig);
 
 jl_value_t* skip_meta(jl_array_t *body);
+int has_meta(jl_array_t *body, jl_sym_t *sym);
 
 // backtraces
 #ifdef _OS_WINDOWS_


### PR DESCRIPTION
this implements a `@pure` annotation for functions. if a pure function can be run at compile-time, it will be, so use sparingly (and don't try to make it solve the halting problem). however, it provides a less codegen-heavy alternative to several `@generated` functions that were in base (since the optimization now becomes optional / compile-time, rather than mandatory / runtime).

future work: the current implementation neglects to make use of this information to improve `effect_free` or to auto-compute this information using `effect_free`. both of those optimizations should be simple and beneficial.
