### PR TITLE
Define AArch64 as "not x86"

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -591,14 +591,9 @@ ISX86:=1
 else ifeq ($(ARCH),x86_64)
 BINARY:=64
 ISX86:=1
-else ifneq (,$(findstring arm,$(ARCH)))
-ISX86:=0
-else ifneq (,$(findstring powerpc,$(ARCH)))
-ISX86:=0
-else ifneq (,$(findstring ppc,$(ARCH)))
-ISX86:=0
 else
-$(error "unknown word-size for arch: $(ARCH)")
+# For all other architectures (ARM, PPC, AArch64, etc.)
+ISX86:=0
 endif
 
 # If we are running on ARM, set certain options automatically


### PR DESCRIPTION
Originally posted by @pao in #10791

[pao: fix my own username :D]
