### PR TITLE
Bump MAX_TYPE_DEPTH again

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2,7 +2,7 @@
 
 # parameters limiting potentially-infinite types
 const MAX_TYPEUNION_LEN = 3
-const MAX_TYPE_DEPTH = 5
+const MAX_TYPE_DEPTH = 7
 const MAX_TUPLETYPE_LEN  = 8
 const MAX_TUPLE_DEPTH = 4
 


### PR DESCRIPTION
This is needed to fix the performance problem noted in https://github.com/tlycken/Interpolations.jl/pull/79.

This seems to be within the noise in terms of effect on compilation time; I've posted a [gist](https://gist.github.com/timholy/304686c2d8e7dd5e71ca) for anyone who wants to see individual test times. (Look first at the file called "Test times.") EDIT: Total change was 2.5%. It looked like it was having an effect on the linalg times, but when I re-ran the branch on just the linalg tests, that concern evaporated. So I suspect the differences were mostly due to noise & perhaps the fact that this server is running other stuff.

I limited to 4 cores because otherwise the total time is dominated by waiting for the SubArray tests to finish.
