### PR TITLE
RFC: Run each test in separate julia process to save memory

### DIFF
--- a/test/char.jl
+++ b/test/char.jl
@@ -1,7 +1,6 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
 #tests for /base/char.jl
-
 @test typemin(Char) == 0
 @test ndims(Char) == 0
 @test getindex('a', 1) == 'a'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,13 +14,35 @@ cd(dirname(@__FILE__)) do
     n = 1
     if net_on
         n = min(8, CPU_CORES, length(tests))
-        n > 1 && addprocs(n; exeflags=`--check-bounds=yes --depwarn=error`)
-        blas_set_num_threads(1)
+        # n > 1 && addprocs(n; exeflags=`--check-bounds=yes --depwarn=error`)
+        # blas_set_num_threads(1)
     end
 
     @everywhere include("testdefs.jl")
 
-    reduce(propagate_errors, nothing, pmap(runtests, tests; err_retry=false, err_stop=true))
+    # reduce(propagate_errors, nothing, pmap(runtests, tests; err_retry=false, err_stop=true))
+    tr = Int[]
+    m = 0
+    while !isempty(tests)
+        if m < n
+            testi = shift!(tests)
+            m += 1
+            @schedule begin
+                push!(tr, !runtests(testi))
+                m -= 1
+                return nothing
+            end
+        else
+            sleep(0.5)
+        end
+        sleep(0.1)
+    end
+    while m > 0
+        wait()
+    end
+    if sum(tr) > 0
+        error("total number of errors was $(sum(tr))")
+    end
 
     if compile_test
         n > 1 && print("\tFrom worker 1:\t")

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -3,20 +3,12 @@
 using Base.Test
 
 function runtests(name)
+    exename = joinpath(JULIA_HOME, Base.julia_exename())
+    testcmd = "using Base.Test; blas_set_num_threads(1); include(\"$name.jl\") " # use space to add single quotes when printed in shell
+    tt = @elapsed (r = success(pipeline(`$exename --check-bounds=yes --depwarn=error -e $testcmd`, stderr=STDERR)))
     @printf("     \033[1m*\033[0m \033[31m%-21s\033[0m", name)
-    tt = @elapsed include("$name.jl")
     @printf(" in %6.2f seconds\n", tt)
-    nothing
-end
-
-function propagate_errors(a,b)
-    if isa(a,Exception)
-        rethrow(a)
-    end
-    if isa(b,Exception)
-        rethrow(b)
-    end
-    nothing
+    return r
 end
 
 # looking in . messes things up badly


### PR DESCRIPTION
This is an attempt to fix #11553. Instead of running all tests in the same `CPU_CORES` processes where the memory consumption accumulates as the tests run, I here run each test in a separate julia process launched as a task such that at most `CPU_CORES` processes are running simultanously. E.g. `linalg/traingular.jl` causes the julia binary to grow to over 500mb so just shutting down that process saves a lot of memory.

I haven't used tasks much so this might not be the right implementation, even if the idea is right. Also, the printing is a complete mess right now. Anyone knows how to ensure that the printing is pretty?
