### PR TITLE
Fix a scoping bug in Pkg.Read

### DIFF
--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -77,8 +77,8 @@ function isfixed(pkg::AbstractString, prepo::LibGit2.GitRepo, avail::Dict=availa
     else
         false
     end
+    res = true
     try
-        res = true
         for (ver,info) in avail
             if cache_has_head && LibGit2.iscommit(info.sha1, crepo)
                 if LibGit2.is_ancestor_of(head, info.sha1, crepo)

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -112,6 +112,12 @@ temp_pkg_dir() do
         @test err.msg == "Example – 2147483647.0.0 is not a registered version"
     end
 
+    # PR #13572, handling of versions with untagged detached heads
+    LibGit2.with(LibGit2.GitRepo, Pkg.dir("Example")) do repo
+        LibGit2.checkout!(repo, "72f09c7d0099793378c645929a9961155faae6d2")
+    end
+    @test Pkg.installed()["Example"] > v"0.0.0"
+
     Pkg.rm("Example")
     @test isempty(Pkg.installed())
 end


### PR DESCRIPTION
Should make JuliaStats/StatsBase.jl#139 pass tests on Travis

It is kind of questionable that [this line](https://github.com/JuliaLang/julia/blob/6aa15b859e1b114061439fa6640173d2978fed3d/base/pkg/read.jl#L186) catches all exceptions. That made this bug much harder to track down than it should have been.
