### PR TITLE
DateTime conversion issues with Int32 on 32-bit

### DIFF
--- a/base/dates/conversions.jl
+++ b/base/dates/conversions.jl
@@ -14,7 +14,7 @@ Base.convert{R<:Real}(::Type{R},x::Date)     = convert(R,value(x))
 ### External Conversions
 const UNIXEPOCH = value(DateTime(1970)) #Rata Die milliseconds for 1970-01-01T00:00:00
 function unix2datetime(x)
-    rata = UNIXEPOCH + round(Int64,1000*x)
+    rata = UNIXEPOCH + round(Int64, Int64(1000) * x)
     return DateTime(UTM(rata))
 end
 # Returns unix seconds since 1970-01-01T00:00:00
@@ -32,7 +32,7 @@ datetime2rata(dt::DateTime) = days(dt)
 # Julian conversions
 const JULIANEPOCH = value(DateTime(-4713,11,24,12))
 function julian2datetime(f)
-    rata = JULIANEPOCH + round(Int64,86400000*f)
+    rata = JULIANEPOCH + round(Int64, Int64(86400000) * f)
     return DateTime(UTM(rata))
 end
 # Returns # of julian days since -4713-11-24T12:00:00

--- a/test/dates/conversions.jl
+++ b/test/dates/conversions.jl
@@ -71,3 +71,12 @@ end
 @test Dates.Year(3) < Dates.Month(37)
 @test_throws InexactError convert(Dates.Year, Dates.Month(37))
 @test_throws InexactError Dates.Month(Dates.Year(typemax(Int64)))
+
+# Ensure that conversion of 32-bit integers work
+let dt = DateTime(1915,1,1,12)
+    unix = Int32(Dates.datetime2unix(dt))
+    julian = Int32(Dates.datetime2julian(dt))
+
+    @test Dates.unix2datetime(unix) == dt
+    @test Dates.julian2datetime(julian) == dt
+end


### PR DESCRIPTION
Dates functions `unix2datetime` and `julian2datetime` have issues on 32-bit systems due to the use integer literals.

Here is a brief example of the issue which can be used on 64-bit systems:

``` julia
julia> import Base.Dates: UNIXEPOCH, UTM

julia> function unix2datetime32(x)
           rata = UNIXEPOCH + round(Int64, Int32(1000) * x)
           return DateTime(UTM(rata))
       end
unix2datetime32 (generic function with 1 method)

julia> v = Int64(Dates.datetime2unix(DateTime(1915,1,1,12)))
-1735646400

julia> unix2datetime32(Int64(v))
1915-01-01T12:00:00

julia> unix2datetime32(Int32(v))
1969-12-26T10:46:27.584
```
