### PR TITLE
Allow setindex! in zero part of Triangular matrices...

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -23,11 +23,11 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular, :UnitUpperTr
         convert{T,S}(::Type{Matrix}, A::$t{T,S}) = convert(Matrix{T}, A)
 
         function similar{T,S,Tnew}(A::$t{T,S}, ::Type{Tnew}, dims::Dims)
-            if dims[1] != dims[2]
-                throw(ArgumentError("Triangular matrix must be square"))
-            end
             if length(dims) != 2
                 throw(ArgumentError("Triangular matrix must have two dimensions"))
+            end
+            if dims[1] != dims[2]
+                throw(ArgumentError("Triangular matrix must be square"))
             end
             B = similar(A.data, Tnew, dims)
             return $t(B)
@@ -119,33 +119,41 @@ getindex{T,S}(A::UpperTriangular{T,S}, i::Integer, j::Integer) = i <= j ? A.data
 
 function setindex!(A::UpperTriangular, x, i::Integer, j::Integer)
     if i > j
-        throw(BoundsError(A,(i,j)))
+        x == 0 || throw(ArgumentError("cannot set index in the lower triangular part ($i, $j) of an UpperTriangular matrix to a nonzero value ($x)"))
+    else
+        A.data[i,j] = x
     end
-    A.data[i,j] = x
     return A
 end
 
 function setindex!(A::UnitUpperTriangular, x, i::Integer, j::Integer)
-    if i >= j
-        throw(BoundsError(A,(i,j)))
+    if i > j
+        x == 0 || throw(ArgumentError("cannot set index in the lower triangular part ($i, $j) of a UnitUpperTriangular matrix to a nonzero value ($x)"))
+    elseif i == j
+        x == 1 || throw(ArgumentError("cannot set index on the diagonal ($i, $j) of a UnitUpperTriangular matrix to a non-unit value ($x)"))
+    else
+        A.data[i,j] = x
     end
-    A.data[i,j] = x
     return A
 end
 
 function setindex!(A::LowerTriangular, x, i::Integer, j::Integer)
     if i < j
-        throw(BoundsError(A,(i,j)))
+        x == 0 || throw(ArgumentError("cannot set index in the upper triangular part ($i, $j) of a LowerTriangular matrix to a nonzero value ($x)"))
+    else
+        A.data[i,j] = x
     end
-    A.data[i,j] = x
     return A
 end
 
 function setindex!(A::UnitLowerTriangular, x, i::Integer, j::Integer)
-    if i <= j
-        throw(BoundsError(A,(i,j)))
+    if i < j
+        x == 0 || throw(ArgumentError("cannot set index in the upper triangular part ($i, $j) of a UnitLowerTriangular matrix to a nonzero value ($x)"))
+    elseif i == j
+        x == 1 || throw(ArgumentError("cannot set diagonal index ($i, $j) of a UnitLowerTriangular matrix to a non-unit value ($x)"))
+    else
+        A.data[i,j] = x
     end
-    A.data[i,j] = x
     return A
 end
 

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -59,15 +59,23 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
         for i = 1:size(A1, 1)
             for j = 1:size(A1, 2)
                 if uplo1 == :U
-                    if i > j || (i == j && t1 == UnitUpperTriangular)
-                        @test_throws BoundsError A1c[i,j] = 0
+                    if i > j
+                        A1c[i,j] = 0
+                        @test_throws ArgumentError A1c[i,j] = 1
+                    elseif i == j && t1 == UnitUpperTriangular
+                        A1c[i,j] = 1
+                        @test_throws ArgumentError A1c[i,j] = 0
                     else
                         A1c[i,j] = 0
                         @test A1c[i,j] == 0
                     end
                 else
-                    if i < j || (i == j && t1 == UnitLowerTriangular)
-                        @test_throws BoundsError A1c[i,j] = 0
+                    if i < j
+                        A1c[i,j] = 0
+                        @test_throws ArgumentError A1c[i,j] = 1
+                    elseif i == j && t1 == UnitLowerTriangular
+                        A1c[i,j] = 1
+                        @test_throws ArgumentError A1c[i,j] = 0
                     else
                         A1c[i,j] = 0
                         @test A1c[i,j] == 0


### PR DESCRIPTION
as long as the value is zero. The error message is similar to that of setindex for Diagonal matrices.  And similarly for setting the diagonal of UnitTriangular types to one.

Prompted by [this SO question](http://stackoverflow.com/a/33027927/176071).  We may want to also think about what a similar triangular matrix is… but that's a bigger question.
