### PR TITLE
added print_range for Range objects, to show the elements of the Rang…

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -244,6 +244,59 @@ function show(io::IO, r::LinSpace)
     print(io, ')')
 end
 
+"""
+`print_range(io, r)` prints out a nice looking range r in terms of its elements
+as if it were `collect(r)`, dependent on the size of the
+terminal, and taking into account whether compact numbers should be shown.
+It figures out the width in characters of each element, and if they
+end up too wide, it shows the first and last elements separated by a
+horizontal elipsis. Typical output will look like `1.0,2.0,3.0,…,4.0,5.0,6.0`.
+
+`print_range(io, r, sz, pre, sep, post, hdots)` uses optional
+parameters `sz` for the (rows,cols) of the screen,
+`pre` and `post` characters for each printed row, `sep` separator string between
+printed elements, `hdots` string for the horizontal ellipsis.
+"""
+function print_range(io::IO, r::Range,
+                     sz::Tuple{Integer, Integer} = (s = tty_size(); (s[1]-4, s[2])),
+                     pre::AbstractString = " ",
+                     sep::AbstractString = ",",
+                     post::AbstractString = "",
+                     hdots::AbstractString = ",\u2026,") # horiz ellipsis
+    # This function borrows from print_matrix() in show.jl
+    # and should be called by writemime (replutil.jl) and by display()
+    screenheight, screenwidth = sz
+    screenwidth -= length(pre) + length(post)
+    postsp = ""
+    sepsize = length(sep)
+    m = 1 # treat the range as a one-row matrix
+    n = length(r)
+    # Figure out spacing alignments for r, but only need to examine the
+    # left and right edge columns, as many as could conceivably fit on the
+    # screen, with the middle columns summarized by horz, vert, or diag ellipsis
+    maxpossiblecols = div(screenwidth, 1+sepsize) # assume each element is at least 1 char + 1 separator
+    colsr = n <= maxpossiblecols ? (1:n) : [1:div(maxpossiblecols,2)+1; (n-div(maxpossiblecols,2)):n]
+    rowmatrix = r[colsr]' # treat the range as a one-row matrix for print_matrix_row
+    A = alignment(rowmatrix,1:m,1:length(rowmatrix),screenwidth,screenwidth,sepsize) # how much space range takes
+    if n <= length(A) # cols fit screen, so print out all elements
+        print(io, pre) # put in pre chars
+        print_matrix_row(io,rowmatrix,A,1,1:n,sep) # the entire range
+        print(io, post) # add the post characters
+    else # cols don't fit so put horiz ellipsis in the middle
+        # how many chars left after dividing width of screen in half
+        # and accounting for the horiz ellipsis
+        c = div(screenwidth-length(hdots)+1,2)+1 # chars remaining for each side of rowmatrix
+        alignR = reverse(alignment(rowmatrix,1:m,length(rowmatrix):-1:1,c,c,sepsize)) # which cols of rowmatrix to put on the right
+        c = screenwidth - sum(map(sum,alignR)) - (length(alignR)-1)*sepsize - length(hdots)
+        alignL = alignment(rowmatrix,1:m,1:length(rowmatrix),c,c,sepsize) # which cols of rowmatrix to put on the left
+        print(io, pre)   # put in pre chars
+        print_matrix_row(io, rowmatrix,alignL,1,1:length(alignL),sep) # left part of range
+        print(io, hdots) # horizontal ellipsis
+        print_matrix_row(io, rowmatrix,alignR,1,length(rowmatrix)-length(alignR)+1:length(rowmatrix),sep) # right part of range
+        print(io, post)  # post chars
+    end
+end
+
 logspace(start::Real, stop::Real, n::Integer=50) = 10.^linspace(start, stop, n)
 
 ## interface implementations

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -13,15 +13,24 @@ function writemime(io::IO, ::MIME"text/plain", f::Function)
     end
 end
 
+# writemime for ranges, e.g.
+#  3-element UnitRange{Int64,Int}
+#   1,2,3
+# or for more elements than fit on screen:
+#   1.0,2.0,3.0,…,6.0,7.0,8.0
+function writemime(io::IO, ::MIME"text/plain", r::Range)
+    print(io, summary(r))
+    if !isempty(r)
+        println(io, ":")
+        with_output_limit(()->print_range(io, r))
+    end
+end
+
 function writemime(io::IO, ::MIME"text/plain", v::AbstractVector)
-    if isa(v, Range)
-        show(io, v)
-    else
-        print(io, summary(v))
-        if !isempty(v)
-            println(io, ":")
-            with_output_limit(()->print_matrix(io, v))
-        end
+    print(io, summary(v))
+    if !isempty(v)
+        println(io, ":")
+        with_output_limit(()->print_matrix(io, v))
     end
 end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -972,14 +972,21 @@ dump(io::IO, x::DataType) = dump(io, x, 5, "")
 dump(io::IO, x::TypeVar, n::Int, indent) = println(io, x.name)
 
 
+"""
+`alignment(X)` returns a tuple (left,right) showing how many characters are
+needed on either side of an alignment feature such as a decimal point.
+"""
 alignment(x::Any) = (0, length(sprint(showcompact_lim, x)))
 alignment(x::Number) = (length(sprint(showcompact_lim, x)), 0)
+"`alignment(42)` yields (2,0)"
 alignment(x::Integer) = (length(sprint(showcompact_lim, x)), 0)
+"`alignment(4.23)` yields (1,3) for `4` and `.23`"
 function alignment(x::Real)
     m = match(r"^(.*?)((?:[\.eE].*)?)$", sprint(showcompact_lim, x))
     m === nothing ? (length(sprint(showcompact_lim, x)), 0) :
                    (length(m.captures[1]), length(m.captures[2]))
 end
+"`alignment(1 + 10im)` yields (3,5) for `1 +` and `_10im` (plus sign on left, space on right)"
 function alignment(x::Complex)
     m = match(r"^(.*[\+\-])(.*)$", sprint(showcompact_lim, x))
     m === nothing ? (length(sprint(showcompact_lim, x)), 0) :
@@ -994,26 +1001,37 @@ end
 const undef_ref_str = "#undef"
 const undef_ref_alignment = (3,3)
 
+"""
+`alignment(X, rows, cols, cols_if_complete, cols_otherwise, sep)` returns the
+alignment for specified parts of array `X`, returning the (left,right) info.
+It will look in X's `rows`, `cols` (both lists of indices)
+and figure out what's needed to be fully aligned, for example looking all
+the way down a column and finding out the maximum size of each element.
+Parameter `sep::Integer` is number of spaces to put between elements.
+`cols_if_complete` and `cols_otherwise` indicate screen width to use.
+Alignment is reported as a vector of (left,right) tuples, one for each
+column going across the screen.
+"""
 function alignment(
     X::AbstractVecOrMat,
     rows::AbstractVector, cols::AbstractVector,
     cols_if_complete::Integer, cols_otherwise::Integer, sep::Integer
 )
     a = Tuple{Int, Int}[]
-    for j in cols
+    for j in cols # need to go down each column one at a time
         l = r = 0
-        for i in rows
+        for i in rows # plumb down and see what largest element sizes are
             if isassigned(X,i,j)
                 aij = alignment(X[i,j])
             else
                 aij = undef_ref_alignment
             end
-            l = max(l, aij[1])
-            r = max(r, aij[2])
+            l = max(l, aij[1]) # left characters
+            r = max(r, aij[2]) # right characters
         end
-        push!(a, (l, r))
+        push!(a, (l, r)) # one tuple per column of X, pruned to screen width
         if length(a) > 1 && sum(map(sum,a)) + sep*length(a) >= cols_if_complete
-            pop!(a)
+            pop!(a) # remove this latest tuple if we're already beyond screen width
             break
         end
     end
@@ -1025,6 +1043,13 @@ function alignment(
     return a
 end
 
+"""
+`print_matrix_row(io, X, A, i, cols, sep)` produces the aligned output for
+a single matrix row X[i, cols] where the desired list of columns is given.
+The corresponding alignment A is used, and the separation between elements
+is specified as string sep.
+`print_matrix_row` will also respect compact output for elements.
+"""
 function print_matrix_row(io::IO,
     X::AbstractVecOrMat, A::Vector,
     i::Integer, cols::AbstractVector, sep::AbstractString
@@ -1039,13 +1064,18 @@ function print_matrix_row(io::IO,
             a = undef_ref_alignment
             sx = undef_ref_str
         end
-        l = repeat(" ", A[k][1]-a[1])
+        l = repeat(" ", A[k][1]-a[1]) # pad on left and right as needed
         r = repeat(" ", A[k][2]-a[2])
         print(io, l, sx, r)
         if k < length(A); print(io, sep); end
     end
 end
 
+"""
+`print_matrix_vdots` is used to show a series of vertical ellipsis instead
+of a bunch of rows for long matrices. Not only is the string vdots shown
+but it also repeated every M elements if desired.
+"""
 function print_matrix_vdots(io::IO,
     vdots::AbstractString, A::Vector, sep::AbstractString, M::Integer, m::Integer
 )
@@ -1161,15 +1191,20 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
     end
 end
 
-summary(x) = string(typeof(x))
+"`summary(x)` a string of type information, e.g. `Int64`"
+summary(x) = string(typeof(x)) # e.g. Int64
 
+# sizes such as 0-dimensional, 4-dimensional, 2x3
 dims2string(d) = length(d) == 0 ? "0-dimensional" :
                  length(d) == 1 ? "$(d[1])-element" :
                  join(map(string,d), 'x')
 
+# anything array-like gets summarized e.g. 10-element Array{Int64,1}
+"`summary(A)` for array is a string of size and type info, e.g. `10-element Array{Int64,1}`"
 summary(a::AbstractArray) =
     string(dims2string(size(a)), " ", typeof(a))
 
+# n-dimensional arrays
 function show_nd(io::IO, a::AbstractArray, limit, print_matrix, label_slices)
     if isempty(a)
         return
@@ -1216,6 +1251,9 @@ end
 # for internal use in showing arrays.
 _limit_output = false
 
+"""
+`print_matrix_repr(io, X)` prints matrix X with opening and closing square brackets.
+"""
 function print_matrix_repr(io, X::AbstractArray)
     compact, prefix = array_eltype_show_how(X)
     prefix *= "["
@@ -1282,7 +1320,7 @@ end
 
 show(io::IO, X::AbstractArray) = showarray(io, X, header=_limit_output, repr=!_limit_output)
 
-function with_output_limit(thk, lim=true)
+function with_output_limit(thk, lim=true) # thk is usually show()
     global _limit_output
     last = _limit_output
     _limit_output = lim

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -544,6 +544,17 @@ for x in r
 end
 @test i == 7
 
+# stringmime/writemime should display the range or linspace nicely
+# to test print_range in range.jl
+replstr(x) = stringmime("text/plain", x)
+@test replstr(1:4) == "4-element UnitRange{$Int}:\n 1,2,3,4"
+@test replstr(linspace(1,5,7)) == "7-element LinSpace{Float64}:\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"
+@test replstr(0:100.) == "101-element FloatRange{Float64}:\n 0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,…,94.0,95.0,96.0,97.0,98.0,99.0,100.0"
+# next is to test a very large range, which should be fast because print_range
+# only examines spacing of the left and right edges of the range, sufficient
+# to cover the designated screen size.
+@test replstr(0:10^9) == "1000000001-element UnitRange{$Int}:\n 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,…,999999998,999999999,1000000000"
+
 # Issue 11049 and related
 @test promote(linspace(0f0, 1f0, 3), linspace(0., 5., 2)) ===
     (linspace(0., 1., 3), linspace(0., 5., 2))


### PR DESCRIPTION
This is the result of a [user's forum discussion about ranges](https://groups.google.com/forum/#!searchin/julia-users/nicer/julia-users/qPqgJS-usrU/Hu40_tOlDQAJ). People were unhappy that `0:5` or `linspace(1,10,7)` does not return a vector, as they wanted. I believe it is sensible for these to be `range` objects (rather than being converted via `collect`), but the REPL display could be modified to show what the `range` actually looks like. The user probably wants to see some confirmation of what they were thinking, and seeing the definition doesn't help.

The proposed solution is to give REPL output like this:

```
julia> 0:4
5-element UnitRange{Int64}:
 0,1,2,3,4

julia> 0:100
101-element UnitRange{Int64}:
 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,…,89,90,91,92,93,94,95,96,97,98,99,100

julia> linspace(0,2.5,4)
4-element LinSpace{Float64}:
 0.0,0.833333,1.66667,2.5
```

This is accomplished by overloading writemime (replutil.jl) to respond to `range` objects, adding a `print_range` method (range.jl) and appropriate unit tests (test/ranges.jl). This affects `display()`, but the user can still use `show(1:5)` to return the definition `1:5`. The `print_range` method is based on the existing `print_matrix_row`, and so it uses knowledge of screen size to make everything fit in one row, with horizontal dots (ellipsis) where appropriate.

Additional edits were made to show.jl, where I added a bunch of comments. I had to learn how `print_matrix` works, and the comments are meant to save time for someone like me, as the code is a bit opaque. There were absolutely no changes to execution of show.jl.

A few notes. I decided not to add brackets around the range. Perhaps square brackets would be appropriate, but I felt they were not needed, as a range is not exactly an array. Also, the range is printed as a single row to save vertical screen space. I thought this was acceptable because tuples are also printed across, despite acting somewhat like 1-d arrays, which are kind of "vertical." I would appreciate feedback if there are disagreements about these choices, or about the whole idea of modifying the REPL.

Take 1 was #13524
Take 2 was #13534  Fixed test to allow for 32- or 64-bit systems; changed pull request to base from master. Had a problem with docstrings due to a bug elsewhere #12737. Got stuck with git.
This is take 3: Waited for fix #13602, restored docstring to intended version, verified that everything works now and passes tests. 
