### PR TITLE
Report an exception but allow to continue operation

### DIFF
--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -183,7 +183,8 @@ function installed(avail::Dict=available())
             ver = installed_version(pkg, prepo, ap)
             fixed = isfixed(pkg, prepo, ap)
             pkgs[pkg] = (ver, fixed)
-        catch
+        catch e
+            warn("Unable to determine package $pkg version. Error: $e")
             pkgs[pkg] = (typemin(VersionNumber), true)
         finally
             finalize(prepo)


### PR DESCRIPTION
`installed` used in many places around Pkg. So instead of failing function report any exception and continue with a default value. This is a temporary fix. This behavior is expected to change as soon as comprehensive collection of exceptions will be introduced in Pkg that will allow gracefully handle such errors at a caller function. Related to #13589.
