### PR TITLE
New convert method for non-Nullables to Nullables

### DIFF
--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -10,6 +10,8 @@ eltype{T}(::Type{Nullable{T}}) = T
 
 convert{T}(::Type{Nullable{T}}, x::Nullable{T}) = x
 
+convert{T}(t::Type{Nullable{T}}, x::Any) = convert(t, convert(T, x))
+
 function convert{T}(::Type{Nullable{T}}, x::Nullable)
     return isnull(x) ? Nullable{T}() : Nullable{T}(convert(T, get(x)))
 end

--- a/test/nullable.jl
+++ b/test/nullable.jl
@@ -266,7 +266,16 @@ end
 # issue #9462
 for T in types
     @test isa(convert(Nullable{Number}, Nullable(one(T))), Nullable{Number})
+    @test isa(convert(Nullable{Number}, one(T)), Nullable{Number})
+    @test isa(convert(Nullable{T}, one(T)), Nullable{T})
     @test isa(convert(Nullable{Any}, Nullable(one(T))), Nullable{Any})
+    @test isa(convert(Nullable{Any}, one(T)), Nullable{Any})
+
+    # one(T) is convertible to every type in types
+    # let's test that with Nullables
+    for S in types
+        @test isa(convert(Nullable{T}, one(S)), Nullable{T})
+    end
 end
 
 @test isnull(convert(Nullable, nothing))


### PR DESCRIPTION
This PR defines `convert{T}(t::Type{Nullable{T}}, x::Any) = convert(t, convert(T, x))`

This resolves the apparent inconsistency that currently exists where you can do `setindex!([1 2 3], 5.0, 1)` and `setindex!(Nullable{Int64}[1 2 3], 5, 1)` but not `setindex!(Nullable{Int64}[1 2 3], 5.0, 1)`.
