### PR TITLE
More verbose Pkg.update() for checked out packages

### DIFF
--- a/base/libgit2.jl
+++ b/base/libgit2.jl
@@ -70,7 +70,8 @@ function iscommit(id::AbstractString, repo::GitRepo)
 end
 
 """ git diff-index HEAD [-- <path>]"""
-isdirty(repo::GitRepo, paths::AbstractString=""; cached::Bool=false) = isdiff(repo, Consts.HEAD_FILE, paths, cached=cached)
+isdirty(repo::GitRepo, paths::AbstractString=""; cached::Bool=false) =
+    isdiff(repo, Consts.HEAD_FILE, paths, cached=cached)
 
 """ git diff-index <treeish> [-- <path>]"""
 function isdiff(repo::GitRepo, treeish::AbstractString, paths::AbstractString=""; cached::Bool=false)
@@ -186,8 +187,6 @@ function branch(repo::GitRepo)
     head_ref = head(repo)
     try
         branch(head_ref)
-    catch
-        ""
     finally
         finalize(head_ref)
     end


### PR DESCRIPTION
I just ran into a situation where this behavior would have been nice. 

I changed the skip packages output to warnings to make them more visible.

Updated version of #11875
