### PR TITLE
Fix #13223, linear indexing of sparse matrices

### DIFF
--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -468,9 +468,14 @@ function getindex{Tv}(A::SparseMatrixCSC{Tv}, I::AbstractVector)
         row,col = ind2sub(szA, I[i])
         for r in colptrA[col]:(colptrA[col+1]-1)
             @inbounds if rowvalA[r] == row
-                rowvalB[idxB] = i
-                nzvalB[idxB] = nzvalA[r]
-                idxB += 1
+                if idxB <= nnzB
+                    rowvalB[idxB] = i
+                    nzvalB[idxB] = nzvalA[r]
+                    idxB += 1
+                else # this can happen if there are repeated indices in I
+                    push!(rowvalB, i)
+                    push!(nzvalB, nzvalA[r])
+                end
                 break
             end
         end

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -336,6 +336,57 @@ let S = sprand(4, 8, 0.5)
     end
 end
 
+let r = [1,10], S = sparse(r, r, r)
+    Sf = full(S)
+    @assert isa(Sf, Matrix{Int})
+
+    inds = [1,1,1,1,1,1]
+    v = S[inds]
+    @test isa(v, SparseVector{Int,Int})
+    @test length(v) == length(inds)
+    @test full(v) == Sf[inds]
+
+    inds = [2,2,2,2,2,2]
+    v = S[inds]
+    @test isa(v, SparseVector{Int,Int})
+    @test length(v) == length(inds)
+    @test full(v) == Sf[inds]
+
+    # get a single column
+    for j = 1:size(S,2)
+        col = S[:, j]
+        @test isa(col, SparseVector{Int,Int})
+        @test length(col) == size(S,1)
+        @test full(col) == Sf[:,j]
+    end
+
+    # Get a reshaped vector
+    v = S[:]
+    @test isa(v, SparseVector{Int,Int})
+    @test length(v) == length(S)
+    @test full(v) == Sf[:]
+
+    # Get a linear subset
+    for i=0:length(S)
+        v = S[1:i]
+        @test isa(v, SparseVector{Int,Int})
+        @test length(v) == i
+        @test full(v) == Sf[1:i]
+    end
+    for i=1:length(S)+1
+        v = S[i:end]
+        @test isa(v, SparseVector{Int,Int})
+        @test length(v) == length(S) - i + 1
+        @test full(v) == Sf[i:end]
+    end
+    for i=0:div(length(S),2)
+        v = S[1+i:end-i]
+        @test isa(v, SparseVector{Int,Int})
+        @test length(v) == length(S) - 2i
+        @test full(v) == Sf[1+i:end-i]
+    end
+end
+
 ## math
 
 ### Data

--- a/test/sparsedir/sparsevector.jl
+++ b/test/sparsedir/sparsevector.jl
@@ -328,6 +328,12 @@ let S = sprand(4, 8, 0.5)
         @test length(v) == length(S) - i + 1
         @test full(v) == Sf[i:end]
     end
+    for i=0:div(length(S),2)
+        v = S[1+i:end-i]
+        @test isa(v, SparseVector{Float64,Int})
+        @test length(v) == length(S) - 2i
+        @test full(v) == Sf[1+i:end-i]
+    end
 end
 
 ## math


### PR DESCRIPTION
make `getindex(A::SparseMatrixCSC, I::AbstractArray)` faster by allocating
at most the number of nonzeros in `A`, and add a specialized implementation
for `getindex(A::SparseMatrixCSC, I::UnitRange)`

before:

```
 _/ |\__'_|_|_|\__'_|  |  Commit 7a4d817* (0 days old master)
|__/                   |  x86_64-linux-gnu
julia> r=[1;10000]
2-element Array{Int64,1}:
     1
 10000
julia> A=sparse(r,r,r)
10000x10000 sparse matrix with 2 Int64 entries:
        [1    ,     1]  =  1
        [10000, 10000]  =  10000
julia> @time A[:]
  1.839530 seconds (40.10 k allocations: 1.492 GB, 0.16% gc time)
Sparse vector of length 100000000, with 2 Int64 nonzero entries:
  [1        ]  =  1
  [100000000]  =  10000
```

after:

```
 _/ |\__'_|_|_|\__'_|  |  tk/fix13223/f0f5938* (fork: 1 commits, 0 days)
|__/                   |  x86_64-linux-gnu
julia> r=[1;10000]
2-element Array{Int64,1}:
     1
 10000
julia> A=sparse(r,r,r)
10000x10000 sparse matrix with 2 Int64 entries:
        [1    ,     1]  =  1
        [10000, 10000]  =  10000
julia> @time A[:]
  0.028696 seconds (58.86 k allocations: 2.627 MB)
Sparse vector of length 100000000, with 2 Int64 nonzero entries:
  [1        ]  =  1
  [100000000]  =  10000
julia> @time A[:]
  0.000020 seconds (7 allocations: 352 bytes)
Sparse vector of length 100000000, with 2 Int64 nonzero entries:
  [1        ]  =  1
  [100000000]  =  10000
```
