### PR TITLE
RFC: execute `finally` block after `break` from try..finally in a loop (ref #12806)

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -757,25 +757,6 @@ let a = []
     @test a[1] == 1
 end
 
-function test1784()
-    let catchb = false, catchc = false, catchr = false
-    for i in 1:3
-        try
-            throw("try err")
-        catch e
-            i == 1 && break
-            i == 2 && continue
-            i == 3 && return
-        finally
-            i == 1 && (catchb = true; continue)
-            i == 2 && (catchc = true; continue)
-            i == 3 && (catchr = true; return (catchb, catchc, catchr))
-      end
-      end
-    end
-end
-@test test1784() == (true,true,true)
-
 # issue #12806
 let x = 0, y = 0, z = 0
     for i=1:2
@@ -784,7 +765,7 @@ let x = 0, y = 0, z = 0
         finally
             x = 11
         end
-    
+
         try
             i==2 && throw()
         catch
@@ -802,6 +783,25 @@ let x = 0, y = 0, z = 0
     @test y == 12
     @test z == 13
 end
+
+function test12806()
+    let catchb = false, catchc = false, catchr = false
+    for i in 1:3
+        try
+            throw("try err")
+        catch e
+            i == 1 && break
+            i == 2 && continue
+            i == 3 && return
+        finally
+            i == 1 && (catchb = true; continue)
+            i == 2 && (catchc = true; continue)
+            i == 3 && (catchr = true; return (catchb, catchc, catchr))
+      end
+      end
+    end
+end
+@test test12806() == (true,true,true)
 
 # chained and multiple assignment behavior (issue #2913)
 let

--- a/test/core.jl
+++ b/test/core.jl
@@ -745,6 +745,30 @@ let a = []
     @test length(a) == 1
 end
 
+# issue #1784
+let a = []
+    try
+        return 5
+        3
+    finally
+        push!(a, 1)
+    end
+    @test x == 5
+    @test a[1] == 1
+end
+
+# issue #12806
+let x = 0
+    for i=1:10
+        try
+            break
+        finally
+            x = 11
+        end
+    end
+    @test x == 11
+end
+
 # chained and multiple assignment behavior (issue #2913)
 let
     local x, a, b, c, d, e

--- a/test/core.jl
+++ b/test/core.jl
@@ -757,16 +757,50 @@ let a = []
     @test a[1] == 1
 end
 
-# issue #12806
-let x = 0
-    for i=1:10
+function test1784()
+    let catchb = false, catchc = false, catchr = false
+    for i in 1:3
         try
-            break
+            throw("try err")
+        catch e
+            i == 1 && break
+            i == 2 && continue
+            i == 3 && return
+        finally
+            i == 1 && (catchb = true; continue)
+            i == 2 && (catchc = true; continue)
+            i == 3 && (catchr = true; return (catchb, catchc, catchr))
+      end
+      end
+    end
+end
+@test test1784() == (true,true,true)
+
+# issue #12806
+let x = 0, y = 0, z = 0
+    for i=1:2
+        try
+            i==1 && continue
         finally
             x = 11
         end
+    
+        try
+            i==2 && throw()
+        catch
+            break
+        finally
+            y = 12
+        end
+    end
+    for i=1:2
+        try i==1 && break
+        finally z = 13
+        end
     end
     @test x == 11
+    @test y == 12
+    @test z == 13
 end
 
 # chained and multiple assignment behavior (issue #2913)


### PR DESCRIPTION
Replace `break` and `continue` statements inside of a `try` block with a labeled `break` to the `finally` handler, followed by a conditional unlabeled `break`, which will then be the intended loop-exit. Fixes #12806; new tests added from reworked examples there and in #1784.

I'd like some feedback on one consequence. Given the following example:

```
for i in 1:2
try
    break
catch
finally
    println("fin $1")
    i == 1 && continue
end
end
```

On master, the loop just exits -- the `finally` block is not executed (i.e., #12806).
With this patch, it is possible to `continue` after `break`ing to the `finally` block:

```
fin 1
fin 2
```

(without the `continue`, we only hit finally once, as  expected)
