### PR TITLE
mandelperf: allocate mandelbrot array and sum only as check

### DIFF
--- a/test/perf/micro/Makefile
+++ b/test/perf/micro/Makefile
@@ -140,3 +140,5 @@ clean:
 	@rm -rf perf.h bin/perf* bin/fperf* benchmarks/*.csv benchmarks.csv mods *~ octave-core perf.log gopath/*
 
 .PHONY: all perf clean
+
+.PRECIOUS: bin/perf0 bin/perf1 bin/perf2 bin/perf3


### PR DESCRIPTION
This is what all the other benchmarks do, and therefore what the C version should do as a fairer comparison. Java and C, etc. should follow the same pattern as well.

cc: @tanmaykm 
