### PR TITLE
new compile-all algorithm

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -250,8 +250,9 @@ end
 
 # builtins
 
-pow_fast{T<:FloatTypes}(x::T, y::Integer) =
-    box(T, Base.powi_llvm(unbox(T,x), unbox(Int32,Int32(y))))
+pow_fast{T<:FloatTypes}(x::T, y::Integer) = pow_fast(x, Int32(y))
+pow_fast{T<:FloatTypes}(x::T, y::Int32) =
+    box(T, Base.powi_llvm(unbox(T,x), unbox(Int32,y)))
 
 # TODO: Change sqrt_llvm intrinsic to avoid nan checking; add nan
 # checking to sqrt in math.jl; remove sqrt_llvm_fast intrinsic

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1979,8 +1979,8 @@ function type_annotate(ast::Expr, states::Array{Any,1}, sv::ANY, rettype::ANY, a
     ast.args[2][3] = sv.gensym_types
 
     for (li::LambdaStaticData) in closures
-        if !li.inferred
-            a = li.ast
+        if !li.inferred && (isa(li.ast, Expr) || isdefined(li, :capt))
+            a = li.ast::Expr
             # pass on declarations of captured vars
             for vi in a.args[2][2]::Array{Any,1}
                 if (vi[3]&4)==0

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -135,7 +135,13 @@ end
 
 tt_cons(t::ANY, tup::ANY) = (@_pure_meta; Tuple{t, (isa(tup, Type) ? tup.parameters : tup)...})
 
-code_lowered(f, t::ANY) = map(m->uncompressed_ast(m.func.code), methods(f, t))
+function code_lowered(f, t::ANY=Tuple)
+    if !isa(f, Function) || isgeneric(f)
+        return map(m->uncompressed_ast(m.func.code), methods(f, t))
+    else
+        return Any[uncompressed_ast(f.code)]
+    end
+end
 function methods(f::Function,t::ANY)
     if !isgeneric(f)
         throw(ArgumentError("argument is not a generic function"))
@@ -223,18 +229,18 @@ function _dump_function(f, t::ANY, native, wrapper, strip_ir_metadata, dump_modu
     return str
 end
 
-code_llvm(io::IO, f::Function, types::ANY, strip_ir_metadata=true, dump_module=false) =
+code_llvm(io::IO, f::Function, types::ANY=Tuple, strip_ir_metadata=true, dump_module=false) =
     print(io, _dump_function(f, types, false, false, strip_ir_metadata, dump_module))
-code_llvm(f::ANY, types::ANY) = code_llvm(STDOUT, f, types)
-code_llvm_raw(f::ANY, types::ANY) = code_llvm(STDOUT, f, types, false)
-code_llvm(io::IO, f::ANY, t::ANY, args...) =
+code_llvm(f::ANY, types::ANY=Tuple) = code_llvm(STDOUT, f, types)
+code_llvm_raw(f::ANY, types::ANY=Tuple) = code_llvm(STDOUT, f, types, false)
+code_llvm(io::IO, f::ANY, t::ANY=Tuple, args...) =
     code_llvm(io, call,
               tt_cons(isa(f, Type) ? Type{f} : typeof(f), t), args...)
 
-code_native(io::IO, f::Function, types::ANY) =
+code_native(io::IO, f::Function, types::ANY=Tuple) =
     print(io, _dump_function(f, types, true, false, false, false))
-code_native(f::ANY, types::ANY) = code_native(STDOUT, f, types)
-code_native(io::IO, f::ANY, t::ANY) =
+code_native(f::ANY, types::ANY=Tuple) = code_native(STDOUT, f, types)
+code_native(io::IO, f::ANY, t::ANY=Tuple) =
     code_native(io, call, tt_cons(isa(f, Type) ? Type{f} : typeof(f), t))
 
 # give a decent error message if we try to instantiate a staged function on non-leaf types
@@ -247,7 +253,7 @@ function func_for_method_checked(m, types)
     linfo::LambdaStaticData
 end
 
-function code_typed(f::Function, types::ANY; optimize=true)
+function code_typed(f::Function, types::ANY=Tuple; optimize=true)
     types = to_tuple_type(types)
     asts = []
     for x in _methods(f,types,-1)
@@ -268,12 +274,12 @@ function code_typed(f::Function, types::ANY; optimize=true)
     asts
 end
 
-function code_typed(f, t::ANY; optimize=true)
+function code_typed(f, t::ANY=Tuple; optimize=true)
     code_typed(call, tt_cons(isa(f, Type) ? Type{f} : typeof(f), t),
                optimize=optimize)
 end
 
-function return_types(f::Function, types::ANY)
+function return_types(f::Function, types::ANY=Tuple)
     types = to_tuple_type(types)
     rt = []
     for x in _methods(f,types,-1)
@@ -284,7 +290,7 @@ function return_types(f::Function, types::ANY)
     rt
 end
 
-function return_types(f, t::ANY)
+function return_types(f, t::ANY=Tuple)
     return_types(call, tt_cons(isa(f, Type) ? Type{f} : typeof(f), t))
 end
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -335,6 +335,28 @@ jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams, jl_mod
     return li;
 }
 
+jl_lambda_info_t *jl_copy_lambda_info(jl_lambda_info_t *linfo)
+{
+    jl_lambda_info_t *new_linfo =
+        jl_new_lambda_info(linfo->ast, linfo->sparams, linfo->module);
+    new_linfo->tfunc = linfo->tfunc;
+    new_linfo->name = linfo->name;
+    new_linfo->roots = linfo->roots;
+    new_linfo->specTypes = linfo->specTypes;
+    new_linfo->unspecialized = linfo->unspecialized;
+    new_linfo->specializations = linfo->specializations;
+    new_linfo->def = linfo->def;
+    new_linfo->capt = linfo->capt;
+    new_linfo->file = linfo->file;
+    new_linfo->line = linfo->line;
+    new_linfo->fptr = linfo->fptr;
+    new_linfo->functionObject = linfo->functionObject;
+    new_linfo->specFunctionObject = linfo->specFunctionObject;
+    new_linfo->functionID = linfo->functionID;
+    new_linfo->specFunctionID = linfo->specFunctionID;
+    return new_linfo;
+}
+
 // symbols --------------------------------------------------------------------
 
 static jl_sym_t *symtab = NULL;

--- a/src/ast.c
+++ b/src/ast.c
@@ -800,13 +800,20 @@ static jl_value_t *copy_ast(jl_value_t *expr, jl_svec_t *sp, int do_sp)
     }
     else if (jl_is_lambda_info(expr)) {
         jl_lambda_info_t *li = (jl_lambda_info_t*)expr;
-        /*
-        if (sp == jl_empty_svec && li->ast &&
-            jl_array_len(jl_lam_capt((jl_expr_t*)li->ast)) == 0)
+        if (sp == jl_emptysvec && li->ast &&
+            (jl_is_expr(li->ast) ? jl_array_len(jl_lam_capt((jl_expr_t*)li->ast)) == 0 : li->capt == NULL)) {
+            // share the inner function if the outer function has no sparams to insert
+            if (!li->specTypes) {
+                // if the decl values haven't been evaluated yet (or alternately already compiled by jl_trampoline), do so now
+                li->ast = jl_prepare_ast(li, li->sparams);
+                jl_gc_wb(li, li->ast);
+                if (jl_array_len(jl_lam_staticparams((jl_expr_t*)li->ast)) == 0)
+                    // mark this as compilable; otherwise, will need to make an (un)specialized version of
+                    // to handle all of the static parameters before compiling
+                    li->specTypes = jl_anytuple_type; // no gc_wb needed
+            }
             return expr;
-        */
-        // TODO: avoid if above condition is true and decls have already
-        // been evaluated.
+        }
         JL_GC_PUSH1(&li);
         li = jl_add_static_parameters(li, sp, li->specTypes);
         // inner lambda does not need the "def" link. it leads to excess object

--- a/src/ast.c
+++ b/src/ast.c
@@ -808,7 +808,7 @@ static jl_value_t *copy_ast(jl_value_t *expr, jl_svec_t *sp, int do_sp)
         // TODO: avoid if above condition is true and decls have already
         // been evaluated.
         JL_GC_PUSH1(&li);
-        li = jl_add_static_parameters(li, sp);
+        li = jl_add_static_parameters(li, sp, li->specTypes);
         // inner lambda does not need the "def" link. it leads to excess object
         // retention, for example pointing to the original uncompressed AST
         // of a top-level thunk that gets type inferred.

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1001,10 +1001,6 @@ void jl_trampoline_compile_function(jl_function_t *f, int always_infer, jl_tuple
         }
     }
     jl_compile(f);
-    // this assertion is probably not correct; the fptr could have been assigned
-    // by a recursive invocation from inference above.
-    //assert(f->fptr == &jl_trampoline);
-    jl_generate_fptr(f);
     if (jl_boot_file_loaded && jl_is_expr(f->linfo->ast)) {
         f->linfo->ast = jl_compress_ast(f->linfo, f->linfo->ast);
         jl_gc_wb(f->linfo, f->linfo->ast);
@@ -1016,6 +1012,7 @@ JL_CALLABLE(jl_trampoline)
     assert(jl_is_func(F));
     jl_function_t *f = (jl_function_t*)F;
     jl_trampoline_compile_function(f, 0, f->linfo->specTypes ? f->linfo->specTypes : jl_anytuple_type);
+    jl_generate_fptr(f);
     return jl_apply(f, args, nargs);
 }
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -975,10 +975,10 @@ static int jl_eval_inner_with_compiler(jl_expr_t *e, jl_module_t *m)
     return 0;
 }
 
-void jl_trampoline_compile_linfo(jl_lambda_info_t *linfo, int always_infer, jl_tupletype_t *sig)
+void jl_trampoline_compile_linfo(jl_lambda_info_t *linfo, int always_infer)
 {
     assert(linfo);
-    assert(sig);
+    assert(linfo->specTypes);
     // to run inference on all thunks. slows down loading files.
     // NOTE: if this call to inference is removed, type_annotate in inference.jl
     // needs to be updated to infer inner functions.
@@ -996,7 +996,7 @@ void jl_trampoline_compile_linfo(jl_lambda_info_t *linfo, int always_infer, jl_t
                 // inference on the whole thing to propagate types into the inner
                 // functions. caused issue #12794
                 jl_eval_inner_with_compiler(jl_lam_body((jl_expr_t*)linfo->ast), linfo->module)) {
-                jl_type_infer(linfo, sig, linfo);
+                jl_type_infer(linfo, linfo->specTypes, linfo);
             }
         }
     }
@@ -1011,7 +1011,8 @@ JL_CALLABLE(jl_trampoline)
 {
     assert(jl_is_func(F));
     jl_function_t *f = (jl_function_t*)F;
-    jl_trampoline_compile_linfo(f->linfo, 0, f->linfo->specTypes ? f->linfo->specTypes : jl_anytuple_type);
+    if (!f->linfo->specTypes) f->linfo->specTypes = jl_anytuple_type; // no gc_wb needed
+    jl_trampoline_compile_linfo(f->linfo, 0);
     jl_generate_fptr(f);
     return jl_apply(f, args, nargs);
 }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -975,35 +975,35 @@ static int jl_eval_inner_with_compiler(jl_expr_t *e, jl_module_t *m)
     return 0;
 }
 
-void jl_trampoline_compile_function(jl_function_t *f, int always_infer, jl_tupletype_t *sig)
+void jl_trampoline_compile_linfo(jl_lambda_info_t *linfo, int always_infer, jl_tupletype_t *sig)
 {
+    assert(linfo);
     assert(sig);
-    assert(f->linfo != NULL);
     // to run inference on all thunks. slows down loading files.
     // NOTE: if this call to inference is removed, type_annotate in inference.jl
     // needs to be updated to infer inner functions.
-    if (f->linfo->inferred == 0) {
+    if (linfo->inferred == 0) {
         if (!jl_in_inference) {
-            if (!jl_is_expr(f->linfo->ast)) {
-                f->linfo->ast = jl_uncompress_ast(f->linfo, f->linfo->ast);
-                jl_gc_wb(f->linfo, f->linfo->ast);
+            if (!jl_is_expr(linfo->ast)) {
+                linfo->ast = jl_uncompress_ast(linfo, linfo->ast);
+                jl_gc_wb(linfo, linfo->ast);
             }
-            assert(jl_is_expr(f->linfo->ast));
+            assert(jl_is_expr(linfo->ast));
             if (always_infer ||
-                jl_eval_with_compiler_p((jl_expr_t*)f->linfo->ast, jl_lam_body((jl_expr_t*)f->linfo->ast), 1, f->linfo->module) ||
+                jl_eval_with_compiler_p((jl_expr_t*)linfo->ast, jl_lam_body((jl_expr_t*)linfo->ast), 1, linfo->module) ||
                 // if this function doesn't need to be compiled, but contains inner
                 // functions that do and that capture variables, we need to run
                 // inference on the whole thing to propagate types into the inner
                 // functions. caused issue #12794
-                jl_eval_inner_with_compiler(jl_lam_body((jl_expr_t*)f->linfo->ast), f->linfo->module)) {
-                jl_type_infer(f->linfo, sig, f->linfo);
+                jl_eval_inner_with_compiler(jl_lam_body((jl_expr_t*)linfo->ast), linfo->module)) {
+                jl_type_infer(linfo, sig, linfo);
             }
         }
     }
-    jl_compile(f);
-    if (jl_boot_file_loaded && jl_is_expr(f->linfo->ast)) {
-        f->linfo->ast = jl_compress_ast(f->linfo, f->linfo->ast);
-        jl_gc_wb(f->linfo, f->linfo->ast);
+    jl_compile_linfo(linfo);
+    if (jl_boot_file_loaded && jl_is_expr(linfo->ast)) {
+        linfo->ast = jl_compress_ast(linfo, linfo->ast);
+        jl_gc_wb(linfo, linfo->ast);
     }
 }
 
@@ -1011,7 +1011,7 @@ JL_CALLABLE(jl_trampoline)
 {
     assert(jl_is_func(F));
     jl_function_t *f = (jl_function_t*)F;
-    jl_trampoline_compile_function(f, 0, f->linfo->specTypes ? f->linfo->specTypes : jl_anytuple_type);
+    jl_trampoline_compile_linfo(f->linfo, 0, f->linfo->specTypes ? f->linfo->specTypes : jl_anytuple_type);
     jl_generate_fptr(f);
     return jl_apply(f, args, nargs);
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1286,44 +1286,73 @@ extern int jl_get_llvmf_info(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
 extern "C" DLLEXPORT
 void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper)
 {
-    jl_function_t *sf = f;
-    if (tt != NULL) {
-        if (!jl_is_function(f) || !jl_is_gf(f)) {
-            return NULL;
-        }
-        sf = jl_get_specialization(f, tt);
+    if (!jl_is_function(f)) {
+        return NULL;
     }
-    if (sf == NULL || sf->linfo == NULL) {
-        sf = jl_method_lookup_by_type(jl_gf_mtable(f), tt, 0, 0);
-        if (sf == jl_bottom_func) {
-            return NULL;
+    jl_lambda_info_t *linfo = f->linfo;
+    JL_GC_PUSH1(&linfo);
+    if (jl_is_gf(f)) {
+        if (tt != NULL) {
+            jl_function_t *sf = jl_get_specialization(f, tt);
+            linfo = (sf == NULL ? NULL : sf->linfo);
+            if (linfo == NULL) {
+                sf = jl_method_lookup_by_type(jl_gf_mtable(f), tt, 0, 0);
+                if (sf == jl_bottom_func || sf == NULL) {
+                    JL_GC_POP();
+                    return NULL;
+                }
+                linfo = sf->linfo;
+            }
         }
-        jl_printf(JL_STDERR,
-                  "WARNING: Returned code may not match what actually runs.\n");
+        if (linfo && !linfo->specTypes) {
+            jl_printf(JL_STDERR,
+                      "WARNING: Returned code may not match what actually runs.\n");
+            if (linfo->unspecialized) {
+                linfo = linfo->unspecialized->linfo;
+            }
+            else {
+                // linfo can't be compiled directly,
+                // but we can compile a throw-away copy
+                // by leaking a bit of memory
+                // (since the compiled code is not usable)
+                linfo = jl_copy_lambda_info(linfo);
+                linfo->specTypes = tt;
+            }
+        }
     }
-    if (sf->linfo->specFunctionObject != NULL) {
+    else if (linfo && !linfo->specTypes) {
+        // anonymous function: compile directly
+        linfo->specTypes = jl_anytuple_type; // no gc_wb needed
+    }
+    if (linfo == NULL) {
+        JL_GC_POP();
+        return NULL;
+    }
+
+    if (linfo->specFunctionObject != NULL) {
         // found in the system image: force a recompile
-        Function *llvmf = (Function*)sf->linfo->specFunctionObject;
+        Function *llvmf = (Function*)linfo->specFunctionObject;
         if (llvmf->isDeclaration()) {
-            sf->linfo->specFunctionObject = NULL;
-            sf->linfo->functionObject = NULL;
+            linfo->specFunctionObject = NULL;
+            linfo->functionObject = NULL;
         }
     }
-    if (sf->linfo->functionObject != NULL) {
+    if (linfo->functionObject != NULL) {
         // found in the system image: force a recompile
-        Function *llvmf = (Function*)sf->linfo->functionObject;
+        Function *llvmf = (Function*)linfo->functionObject;
         if (llvmf->isDeclaration()) {
-            sf->linfo->specFunctionObject = NULL;
-            sf->linfo->functionObject = NULL;
+            linfo->specFunctionObject = NULL;
+            linfo->functionObject = NULL;
         }
     }
-    if (sf->linfo->functionObject == NULL && sf->linfo->specFunctionObject == NULL) {
-        jl_compile_linfo(sf->linfo);
+    if (linfo->functionObject == NULL && linfo->specFunctionObject == NULL) {
+        jl_compile_linfo(linfo);
     }
-    if (!getwrapper && sf->linfo->specFunctionObject != NULL)
-        return (Function*)sf->linfo->specFunctionObject;
+    JL_GC_POP();
+    if (!getwrapper && linfo->specFunctionObject != NULL)
+        return (Function*)linfo->specFunctionObject;
     else
-        return (Function*)sf->linfo->functionObject;
+        return (Function*)linfo->functionObject;
 }
 
 Function* CloneFunctionToModule(Function *F, Module *destModule)
@@ -4355,6 +4384,9 @@ static Function *emit_function(jl_lambda_info_t *lam)
     size_t captvinfoslen = jl_array_dim0(captvinfos);
     size_t nreq = largslen;
     int va = 0;
+
+    if ((jl_array_len(jl_lam_staticparams(ast)) == 0) != (jl_svec_len(sparams) == 0)) // TODO: more accurate check
+        jl_error("wrong number of static-parameters on LambdaStaticData");
 
     assert(lam->specTypes); // this could happen if the user tries to compile a generic-function
                             // without specializing (or unspecializing) it first

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4355,8 +4355,13 @@ static Function *emit_function(jl_lambda_info_t *lam)
     size_t captvinfoslen = jl_array_dim0(captvinfos);
     size_t nreq = largslen;
     int va = 0;
-    if (!lam->specTypes)
-        lam->specTypes = jl_anytuple_type;
+
+    assert(lam->specTypes); // this could happen if the user tries to compile a generic-function
+                            // without specializing (or unspecializing) it first
+                            // compiling this would cause all specializations to inherit
+                            // this code and could create an broken compile / function cache
+                            // if the method has static parameters
+
     if (nreq > 0 && jl_is_rest_arg(jl_cellref(largs,nreq-1))) {
         nreq--;
         va = 1;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1120,9 +1120,8 @@ extern "C" void jl_generate_fptr(jl_function_t *f)
     f->fptr = li->fptr;
 }
 
-extern "C" void jl_compile(jl_function_t *f)
+extern "C" void jl_compile_linfo(jl_lambda_info_t *li)
 {
-    jl_lambda_info_t *li = f->linfo;
     if (li->functionObject == NULL) {
         // objective: assign li->functionObject
         li->inCompile = 1;
@@ -1319,7 +1318,7 @@ void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper)
         }
     }
     if (sf->linfo->functionObject == NULL && sf->linfo->specFunctionObject == NULL) {
-        jl_compile(sf);
+        jl_compile_linfo(sf->linfo);
     }
     if (!getwrapper && sf->linfo->specFunctionObject != NULL)
         return (Function*)sf->linfo->specFunctionObject;
@@ -3988,7 +3987,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     if (fargt.size() + sret != fargt_sig.size())
         jl_error("va_arg syntax not allowed for cfunction argument list");
 
-    jl_compile(ff);
+    jl_compile_linfo(lam);
     if (!lam->functionObject) {
         jl_errorf("error compiling %s while creating cfunction", lam->name->name);
     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -1499,6 +1499,7 @@ void jl_trampoline_compile_linfo(jl_lambda_info_t *linfo, int always_infer);
 static void parameters_to_closureenv(jl_value_t *ast, jl_svec_t *tvars)
 {
     jl_array_t *closed = jl_lam_capt((jl_expr_t*)ast);
+    jl_array_t *splist = jl_lam_staticparams((jl_expr_t*)ast);
     jl_value_t **tvs;
     int tvarslen;
     if (jl_is_typevar(tvars)) {
@@ -1509,55 +1510,75 @@ static void parameters_to_closureenv(jl_value_t *ast, jl_svec_t *tvars)
         tvs = jl_svec_data(tvars);
         tvarslen = jl_svec_len(tvars);
     }
-    if (jl_in_vinfo_array(closed, ((jl_tvar_t*)tvs[0])->name))
-        return;
-    size_t i;
+
+    size_t i, j;
     jl_array_t *vi=NULL;
     JL_GC_PUSH1(&vi);
     for(i=0; i < tvarslen; i++) {
+        jl_sym_t *sp = ((jl_tvar_t*)tvs[i])->name;
+        int found = 0;
+        // add this item to closed
+        assert(!jl_in_vinfo_array(closed, sp));
         vi = jl_alloc_cell_1d(3);
-        jl_cellset(vi, 0, ((jl_tvar_t*)tvs[i])->name);
+        jl_cellset(vi, 0, sp);
         jl_cellset(vi, 1, jl_any_type);
         jl_cellset(vi, 2, jl_box_long(1));
         jl_cell_1d_push(closed, (jl_value_t*)vi);
+        // delete this item from the list of static parameters
+        for (j = 0; j < jl_array_len(splist); j++) {
+            if (jl_cellref(splist, j) == (jl_value_t*)sp) {
+                jl_cellset(splist, j, jl_cellref(splist, jl_array_len(splist) - 1));
+                jl_array_del_end(splist, 1);
+                found = 1;
+                break;
+            }
+        }
+        assert(found);
     }
-
-    // clear the AST.args[2][4] list of sparams
-    jl_array_t *splist = jl_lam_staticparams((jl_expr_t*)ast);
-    assert(jl_array_len(splist) == tvarslen);
-    jl_array_del_end(splist, jl_array_len(splist));
 
     JL_GC_POP();
 }
 
-static void all_p2c(jl_value_t *ast, jl_svec_t *tvars)
+// modifies ast to replace any lambda info with an unspecialized version
+// that removes tvars from the sparams. instead adds these static parameter
+// names to end of closure env; the compile assumes they are there.
+// the method cache will fill them in when it constructs closures
+// for new "specializations".
+static jl_value_t *all_p2c(jl_value_t *ast, jl_svec_t *tvars)
 {
+    if (tvars == jl_emptysvec)
+        return ast;
     if (jl_is_lambda_info(ast)) {
         jl_lambda_info_t *li = (jl_lambda_info_t*)ast;
-        li->ast = jl_prepare_ast(li, jl_emptysvec);
-        jl_gc_wb(li, li->ast);
-        parameters_to_closureenv(li->ast, tvars);
-        all_p2c(li->ast, tvars);
+        // use linfo->unspecialized to store the modified ast
+        jl_function_t *unspec = li->unspecialized;
+        if (unspec)
+            return (jl_value_t*)unspec->linfo;
+        unspec = jl_new_closure(NULL, NULL, li);
+        JL_GC_PUSH1(&unspec);
+        unspec->linfo = jl_add_static_parameters(li, jl_emptysvec, NULL); // copy linfo
+        jl_gc_wb(unspec, unspec->linfo);
+        unspec->linfo->ast = jl_prepare_ast(unspec->linfo, jl_emptysvec); // copy ast
+        jl_gc_wb(unspec->linfo, unspec->linfo->ast);
+        parameters_to_closureenv(unspec->linfo->ast, tvars); // move sparams to closure env
+        unspec->linfo->ast = all_p2c(unspec->linfo->ast, tvars);
+        jl_gc_wb(unspec, unspec->linfo->ast);
+        if (jl_array_len(jl_lam_staticparams((jl_expr_t*)unspec->linfo->ast)) == 0)
+            // mark this as compilable; otherwise, would need to make an unspecialized version of
+            // this unspecialized function to handle all of the static parameters
+            unspec->linfo->specTypes = jl_anytuple_type; // no gc_wb needed
+        li->unspecialized = unspec; // record result for reuse
+        jl_gc_wb(li, unspec);
+        JL_GC_POP();
+        return (jl_value_t*)unspec->linfo;
     }
     else if (jl_is_expr(ast)) {
         jl_expr_t *e = (jl_expr_t*)ast;
-        for(size_t i=0; i < jl_array_len(e->args); i++)
-            all_p2c(jl_exprarg(e,i), tvars);
+        jl_array_t *a = e->args;
+        for(size_t i=0; i < jl_array_len(a); i++)
+            jl_cellset(a, i, all_p2c(jl_cellref(a, i), tvars));
     }
-}
-
-static void precompile_linfo(jl_lambda_info_t *linfo, jl_tupletype_t *sig, jl_svec_t *tvars)
-{
-    assert(sig);
-    linfo->specTypes = sig;
-    jl_gc_wb(linfo, sig);
-    if (tvars != jl_emptysvec) {
-        // add static parameter names to end of closure env; compile
-        // assuming they are there. method cache will fill them in when
-        // it constructs closures for new "specializations".
-        all_p2c((jl_value_t*)linfo, tvars);
-    }
-    jl_trampoline_compile_linfo(linfo, 1);
+    return ast;
 }
 
 static int tupletype_any_bottom(jl_value_t *sig)
@@ -1665,8 +1686,11 @@ static void _compile_all_deq(jl_array_t *found)
                 unspec->env = NULL;
             meth->func->linfo->unspecialized = unspec;
             jl_gc_wb(meth->func->linfo, unspec);
+            unspec->linfo = (jl_lambda_info_t*)all_p2c((jl_value_t*)unspec->linfo, meth->tvars);
+            jl_gc_wb(unspec, unspec->linfo);
         }
-        precompile_linfo(unspec->linfo, meth->sig, meth->tvars);
+        jl_trampoline_compile_linfo(unspec->linfo, 1);
+        assert(unspec->linfo->functionID > 0);
         meth->func->linfo->functionID = -1; // indicate that this method doesn't need a functionID
     }
     jl_printf(JL_STDERR, "\n");
@@ -2037,7 +2061,11 @@ void jl_add_method(jl_function_t *gf, jl_tupletype_t *types, jl_function_t *meth
         meth->linfo->name = n;
     }
     if (isstaged && tvars != jl_emptysvec) {
-        all_p2c((jl_value_t*)meth->linfo, tvars);
+        // copy meth before modifying meth->linfo
+        meth = jl_new_closure(NULL, meth->env, meth->linfo);
+        // copy linfo and move static parameters to closure where jl_instantiate_staged expects to put them
+        meth->linfo = (jl_lambda_info_t*)all_p2c((jl_value_t*)meth->linfo, tvars);
+        jl_gc_wb(meth, meth->linfo);
     }
     (void)jl_method_table_insert(jl_gf_mtable(gf), types, meth, tvars, isstaged);
     JL_GC_POP();

--- a/src/gf.c
+++ b/src/gf.c
@@ -303,16 +303,17 @@ jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t *sp, j
     JL_GC_PUSH1(&sp);
     if (jl_svec_len(l->sparams) > 0)
         sp = jl_svec_append(sp, l->sparams);
-    jl_lambda_info_t *nli = jl_new_lambda_info(l->ast, sp, l->module);
-    nli->name = l->name;
-    nli->fptr = l->fptr;
-    nli->functionObject = l->functionObject;
-    nli->specFunctionObject = l->specFunctionObject;
-    nli->functionID = l->functionID;
-    nli->specFunctionID = l->specFunctionID;
-    nli->file = l->file;
-    nli->line = l->line;
-    nli->def  = l->def;
+    jl_lambda_info_t *nli = jl_copy_lambda_info(l);
+    nli->sparams = sp; // no gc_wb needed
+    nli->tfunc = jl_nothing;
+    nli->capt = NULL;
+    nli->specializations = NULL;
+    nli->unspecialized = NULL;
+    nli->fptr = jl_trampoline;
+    nli->functionObject = NULL;
+    nli->specFunctionObject = NULL;
+    nli->functionID = 0; // make sure this marked as needing to be compiled
+    nli->specFunctionID = 0;
     nli->specTypes = types;
     if (types) jl_gc_wb(nli, types);
     JL_GC_POP();
@@ -801,23 +802,18 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tupletype_t *type,
         }
         newmeth = jl_instantiate_method(method, sparams, type);
     }
-    /*
-      if "method" itself can ever be compiled, for example for use as
-      an unspecialized method (see below), then newmeth->fptr might point
-      to some slow compiled code instead of jl_trampoline, meaning our
-      type-inferred code would never get compiled. this can be fixed with
-      the commented-out snippet below.
 
-      NOTE: this is now needed when we start with a system image compiled
-      with --compile=all.
-    */
-    /*
+    /* "method" itself should never get compiled,
+      for example, if an unspecialized method is needed,
+      the slow compiled code should be associated with
+      method->linfo->unspecialized, not method */
     assert(!(newmeth->linfo && newmeth->linfo->ast) ||
-           newmeth->fptr == &jl_trampoline);
-    */
-    if (newmeth->linfo && newmeth->linfo->ast && newmeth->fptr != &jl_trampoline) {
-        newmeth->fptr = &jl_trampoline;
-    }
+           (newmeth->fptr == &jl_trampoline &&
+            newmeth->linfo->fptr == &jl_trampoline &&
+            newmeth->linfo->functionObject == NULL &&
+            newmeth->linfo->specFunctionObject == NULL &&
+            newmeth->linfo->functionID == 0 &&
+            newmeth->linfo->specFunctionID == 0));
 
     (void)jl_method_cache_insert(mt, type, newmeth);
 
@@ -1511,6 +1507,12 @@ static void parameters_to_closureenv(jl_value_t *ast, jl_svec_t *tvars)
         jl_cellset(vi, 2, jl_box_long(1));
         jl_cell_1d_push(closed, (jl_value_t*)vi);
     }
+
+    // clear the AST.args[2][4] list of sparams
+    jl_array_t *splist = jl_lam_staticparams((jl_expr_t*)ast);
+    assert(jl_array_len(splist) == tvarslen);
+    jl_array_del_end(splist, jl_array_len(splist));
+
     JL_GC_POP();
 }
 
@@ -1595,6 +1597,7 @@ static void _compile_all_deq(jl_array_t *found)
             if (spec && !jl_has_typevars((jl_value_t*)meth->sig)) {
                 // replace unspecialized func with specialized version
                 // if there are no bound type vars (e.g. `call{K,V}(Dict{K,V})` vs `call(Dict)`)
+                // that might cause a different method to match at runtime
                 meth->func = spec;
                 jl_gc_wb(meth, spec);
                 continue;
@@ -1635,7 +1638,6 @@ static void _compile_all_deq(jl_array_t *found)
                     complete = 0;
                 }
                 if (complete) {
-                    //meth->func->fptr = (jl_fptr_t)1; // invalidate fptr: meth should be unused now
                     meth->func->linfo->functionID = -1; // indicate that this method doesn't need a functionID
                     continue;
                 }
@@ -1651,7 +1653,6 @@ static void _compile_all_deq(jl_array_t *found)
             jl_gc_wb(meth->func->linfo, unspec);
         }
         precompile_linfo(unspec->linfo, meth->sig, meth->tvars);
-        //meth->func->fptr = (jl_fptr_t)1; // invalidate fptr: meth should be unused now -- but isn't because staged functions corrupt the function lookup
         meth->func->linfo->functionID = -1; // indicate that this method doesn't need a functionID
     }
     jl_printf(JL_STDERR, "\n");
@@ -1695,7 +1696,7 @@ static void _compile_all_enq(jl_value_t *v, htable_t *h, jl_array_t *found, jl_f
                 return;
             }
             jl_methlist_t *meth = (jl_methlist_t*)v;
-            int use_mtable = (meth->func->linfo && !meth->func->linfo->specTypes);
+            int use_mtable = (meth->func->linfo && !meth->func->linfo->specTypes) && !(meth->isstaged);
             _compile_all_enq((jl_value_t*)meth->invokes, h, found, in_gf);
             _compile_all_enq((jl_value_t*)meth->next, h, found, in_gf);
             _compile_all_enq((jl_value_t*)meth->func, h, found, in_gf);
@@ -1707,16 +1708,9 @@ static void _compile_all_enq(jl_value_t *v, htable_t *h, jl_array_t *found, jl_f
         else if (jl_is_lambda_info(v)) {
             jl_lambda_info_t *li = (jl_lambda_info_t*)v;
             // if in_gf and !specTypes, the lambda will be compiled from the method table
-            if (!in_gf && !li->specTypes) {
-                // anonymous function: compile via unspecialized
-                jl_function_t *func = li->unspecialized;
-                if (func == NULL) {
-                    func = jl_new_closure(li->fptr, (jl_value_t*)jl_emptysvec, li);
-                    li->unspecialized = func;
-                    jl_gc_wb(li, func);
-                    if (!func->linfo->specTypes) func->linfo->specTypes = jl_anytuple_type; // no gc_wb needed
-                }
-                li = func->linfo;
+            if (!in_gf && !li->specTypes && li->unspecialized) {
+                // naked lambda from a gf: compile via unspecialized
+                li = li->unspecialized->linfo;
             }
             if (li->specTypes && li->fptr == jl_trampoline && !li->functionID) {
                 jl_cell_1d_push(found, (jl_value_t*)li);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1546,6 +1546,16 @@ static void precompile_unspecialized(jl_function_t *func, jl_tupletype_t *sig, j
     jl_trampoline_compile_function(func, 1, sig);
 }
 
+static int tupletype_any_bottom(jl_value_t *sig) {
+    jl_svec_t *types = ((jl_tupletype_t*)sig)->types;
+    size_t i, l = jl_svec_len(types);
+    for (i = 0; i < l; i++) {
+        if (jl_svecref(types, i) == jl_bottom_type)
+            return 1;
+    }
+    return 0;
+}
+
 void jl_compile_all_defs(jl_function_t *gf)
 {
     assert(jl_is_gf(gf));
@@ -1557,9 +1567,49 @@ void jl_compile_all_defs(jl_function_t *gf)
     JL_GC_PUSH1(&func);
     while (m != (void*)jl_nothing) {
         if (jl_is_leaf_type((jl_value_t*)m->sig)) {
+            // usually can create a specialized version of the function,
+            // if the signature is already a leaftype
             if (jl_get_specialization(gf, m->sig)) {
                 m = m->next;
                 continue;
+            }
+        }
+        if (jl_is_typevar(m->tvars)) {
+            // f{T<:Union{...}}(...) is a common pattern
+            // and expanding the Union may give a leaf function
+            jl_tvar_t *tv = (jl_tvar_t*)m->tvars;
+            if (jl_is_uniontype(tv->ub)) {
+                int complete = 1; // keep track of whether all possible signatures have been cached (and thus whether it can skip trying to compile the unspecialized function)
+                // TODO: remove the "complete" check once runtime-intrinsics are fully active
+                jl_uniontype_t *ub = (jl_uniontype_t*)tv->ub;
+                size_t i, l = jl_svec_len(ub->types);
+                for (i = 0; i < l + 1; i++) { // add Union{} to the end of the list, since T<:Union{} is always a valid option
+                    jl_value_t *ty = (i == l ? jl_bottom_type : jl_svecref(ub->types, i));
+                    if (i == l || jl_is_leaf_type(ty)) {
+                        jl_value_t *env[2] = {(jl_value_t*)tv, ty};
+                        jl_value_t *sig;
+                        JL_TRY {
+                            sig = (jl_value_t*)
+                                jl_instantiate_type_with((jl_value_t*)m->sig, env, 1);
+                        }
+                        JL_CATCH {
+                            continue; // sigh, we found an invalid type signature. should we warn the user?
+                        }
+                        if (sig == jl_bottom_type || tupletype_any_bottom(sig)) {
+                            continue; // signature wouldn't be callable / is invalid -- skip it
+                        }
+                        if (jl_is_leaf_type(sig)) {
+                            if (jl_get_specialization(gf, (jl_tupletype_t*)sig)) {
+                                if (!jl_has_typevars((jl_value_t*)sig)) continue;
+                            }
+                        }
+                    }
+                    complete = 0;
+                }
+                if (complete) {
+                    m = m->next;
+                    continue;
+                }
             }
         }
         func = m->func->linfo->unspecialized;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1484,7 +1484,7 @@ jl_function_t *jl_get_specialization(jl_function_t *f, jl_tupletype_t *types)
     if (sf->linfo->functionObject == NULL) {
         if (sf->fptr != &jl_trampoline)
             goto not_found;
-        jl_compile(sf);
+        jl_compile_linfo(sf->linfo);
     }
     JL_GC_POP();
     return sf;
@@ -1493,7 +1493,7 @@ jl_function_t *jl_get_specialization(jl_function_t *f, jl_tupletype_t *types)
     return NULL;
 }
 
-void jl_trampoline_compile_function(jl_function_t *f, int always_infer, jl_tupletype_t *sig);
+void jl_trampoline_compile_linfo(jl_lambda_info_t *linfo, int always_infer, jl_tupletype_t *sig);
 
 static void parameters_to_closureenv(jl_value_t *ast, jl_svec_t *tvars)
 {
@@ -1539,21 +1539,18 @@ static void all_p2c(jl_value_t *ast, jl_svec_t *tvars)
     }
 }
 
-static void precompile_unspecialized(jl_function_t *func, jl_tupletype_t *sig, jl_svec_t *tvars)
+static void precompile_linfo(jl_lambda_info_t *linfo, jl_tupletype_t *sig, jl_svec_t *tvars)
 {
     assert(sig);
-    func->linfo->specTypes = sig;
-    jl_gc_wb(func->linfo, sig);
+    linfo->specTypes = sig;
+    jl_gc_wb(linfo, sig);
     if (tvars != jl_emptysvec) {
         // add static parameter names to end of closure env; compile
         // assuming they are there. method cache will fill them in when
         // it constructs closures for new "specializations".
-        all_p2c((jl_value_t*)func->linfo, tvars);
+        all_p2c((jl_value_t*)linfo, tvars);
     }
-    //func->fptr = (jl_fptr_t)jl_apply_unspecialized; // we might enter type-inference for this function
-    //assert(func->linfo->unspecialized);
-    jl_trampoline_compile_function(func, 1, sig);
-    //func->fptr = func->linfo->fptr;
+    jl_trampoline_compile_linfo(linfo, 1, sig);
 }
 
 static int tupletype_any_bottom(jl_value_t *sig)
@@ -1585,17 +1582,19 @@ static void _compile_all_deq(jl_array_t *found)
     jl_printf(JL_STDERR, "found %d uncompiled methods for compile-all\n", (int)(found_l / 2));
     for (found_i = 0; found_i < found_l; found_i += 2) {
         dbg_print_progress(JL_STDERR, found_i + 2, found_l);
-        jl_function_t *func = (jl_function_t*)jl_cellref(found, found_i);
-        jl_methlist_t *meth = (jl_methlist_t*)jl_cellref(found, found_i + 1);
+        jl_value_t *thunk = jl_cellref(found, found_i);
 
-        if (!meth) {
-            // anonymous function
-            jl_lambda_info_t *li = func->linfo;
-            precompile_unspecialized(func, li->specTypes, jl_emptysvec);
+        if (jl_is_lambda_info(thunk)) {
+            // anonymous or specialized function
+            jl_lambda_info_t *li = (jl_lambda_info_t*)thunk;
+            assert(!jl_cellref(found, found_i + 1));
+            precompile_linfo(li, li->specTypes, jl_emptysvec);
             assert(li->functionID > 0);
             continue;
         }
 
+        jl_function_t *func = (jl_function_t*)thunk;
+        jl_methlist_t *meth = (jl_methlist_t*)jl_cellref(found, found_i + 1);
         assert(!func->linfo);
 
         if (jl_is_leaf_type((jl_value_t*)meth->sig)) {
@@ -1645,7 +1644,7 @@ static void _compile_all_deq(jl_array_t *found)
                     complete = 0;
                 }
                 if (complete) {
-                    meth->func->fptr = (jl_fptr_t)1; // invalidate fptr: meth should be unused now
+                    //meth->func->fptr = (jl_fptr_t)1; // invalidate fptr: meth should be unused now
                     meth->func->linfo->functionID = -1; // indicate that this method doesn't need a functionID
                     continue;
                 }
@@ -1661,7 +1660,7 @@ static void _compile_all_deq(jl_array_t *found)
             jl_gc_wb(meth->func->linfo, unspec);
             if (!unspec->linfo->specTypes) unspec->linfo->specTypes = meth->sig; // no gc_wb needed
         }
-        precompile_unspecialized(unspec, meth->sig, meth->tvars);
+        precompile_linfo(unspec->linfo, meth->sig, meth->tvars);
         //meth->func->fptr = (jl_fptr_t)1; // invalidate fptr: meth should be unused now -- but isn't because staged functions corrupt the function lookup
         meth->func->linfo->functionID = -1; // indicate that this method doesn't need a functionID
     }
@@ -1678,31 +1677,13 @@ static void _compile_all_enq(jl_value_t *v, htable_t *h, jl_array_t *found, jl_f
         if (jl_is_gf(v)) {
             jl_function_t *gf = (jl_function_t*)v;
             _compile_all_enq(gf->env, h, found, gf);
-            // fast return and skip linfo, it is supposed to be null
+            // fast return and skip linfo, it is supposed to be null here
             return;
         }
         else if (jl_is_function(v)) {
             jl_function_t *f = (jl_function_t*)v;
-            jl_array_t *specs = f->linfo ? f->linfo->specializations : NULL;
             _compile_all_enq(f->env, h, found, 0);
             _compile_all_enq((jl_value_t*)f->linfo, h, found, in_gf);
-            if (specs) {
-                size_t i, l = jl_array_len(specs);
-                ptrhash_put(h, specs, specs);
-                for (i = 0; i < l; i++) {
-                    jl_lambda_info_t *li = (jl_lambda_info_t*)jl_cellref(specs, i);
-                    if (li->fptr == jl_trampoline && !li->functionID) {
-                        jl_cell_1d_push(found, (jl_value_t*)jl_reinstantiate_method(f, li));
-                        jl_cell_1d_push(found, (jl_value_t*)NULL);
-                    }
-                    assert(li->specTypes);
-                    _compile_all_enq((jl_value_t*)li, h, found, 0);
-                }
-            }
-            if (f->linfo && f->linfo->specTypes && f->fptr == jl_trampoline && !f->linfo->functionID) {
-                jl_cell_1d_push(found, (jl_value_t*)f);
-                jl_cell_1d_push(found, (jl_value_t*)NULL);
-            }
             return;
         }
         else if (jl_is_mtable(v)) {
@@ -1735,11 +1716,9 @@ static void _compile_all_enq(jl_value_t *v, htable_t *h, jl_array_t *found, jl_f
         }
         else if (jl_is_lambda_info(v)) {
             jl_lambda_info_t *li = (jl_lambda_info_t*)v;
-            if (in_gf || li->specTypes) {
-                // hopefully this lambda will be compiled from the right place: that place is not here.
-                // XXX: can end up here from Module->constant_table[x]->LambdaStaticData->specialized[x]->LambdaStaticData
-            }
-            else {
+            // if in_gf and !specTypes, the lambda will be compiled from the method table
+            if (!in_gf && !li->specTypes) {
+                // anonymous function: compile via unspecialized
                 jl_function_t *func = li->unspecialized;
                 if (func == NULL) {
                     func = jl_new_closure(li->fptr, (jl_value_t*)jl_emptysvec, li);
@@ -1747,6 +1726,11 @@ static void _compile_all_enq(jl_value_t *v, htable_t *h, jl_array_t *found, jl_f
                     jl_gc_wb(li, func);
                     if (!func->linfo->specTypes) func->linfo->specTypes = jl_anytuple_type; // no gc_wb needed
                 }
+                li = func->linfo;
+            }
+            if (li->specTypes && li->fptr == jl_trampoline && !li->functionID) {
+                jl_cell_1d_push(found, (jl_value_t*)li);
+                jl_cell_1d_push(found, (jl_value_t*)NULL);
             }
         }
         else if (jl_is_array(v)) {

--- a/src/julia.h
+++ b/src/julia.h
@@ -1247,7 +1247,7 @@ DLLEXPORT const char *jl_lookup_soname(const char *pfx, size_t n);
 #endif
 
 // compiler
-void jl_compile(jl_function_t *f);
+void jl_compile_linfo(jl_lambda_info_t *li);
 DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v);
 DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex);
 DLLEXPORT jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex, int delay_warn);

--- a/src/julia.h
+++ b/src/julia.h
@@ -198,7 +198,7 @@ typedef struct _jl_lambda_info_t {
     // array of all lambda infos with code generated from this one
     jl_array_t *specializations;
     struct _jl_module_t *module;
-    struct _jl_lambda_info_t *def;  // original this is specialized from
+    struct _jl_lambda_info_t *def;  // original this is specialized from, for consolidating codegen roots
     jl_value_t *capt;  // captured var info
     jl_sym_t *file;
     int32_t line;

--- a/src/julia.h
+++ b/src/julia.h
@@ -192,7 +192,7 @@ typedef struct _jl_lambda_info_t {
     jl_value_t *tfunc;
     jl_sym_t *name;  // for error reporting
     jl_array_t *roots;  // pointers in generated code
-    jl_tupletype_t *specTypes;  // argument types this is specialized for
+    jl_tupletype_t *specTypes;  // argument types this will be compiled for
     // a slower-but-works version of this function as a fallback
     struct _jl_function_t *unspecialized;
     // array of all lambda infos with code generated from this one

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -147,7 +147,7 @@ void jl_dump_objfile(char *fname, int jit_model, const char *sysimg_data, size_t
 int32_t jl_get_llvm_gv(jl_value_t *p);
 void jl_idtable_rehash(jl_array_t **pa, size_t newsz);
 
-jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t *sp);
+jl_lambda_info_t *jl_add_static_parameters(jl_lambda_info_t *l, jl_svec_t *sp, jl_tupletype_t *types);
 jl_function_t *jl_get_specialization(jl_function_t *f, jl_tupletype_t *types);
 jl_function_t *jl_module_get_initializer(jl_module_t *m);
 void jl_generate_fptr(jl_function_t *f);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -118,6 +118,7 @@ void jl_compute_field_offsets(jl_datatype_t *st);
 jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, size_t *dims,
                                              int isunboxed, int elsz);
 DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v);
+jl_lambda_info_t *jl_copy_lambda_info(jl_lambda_info_t *linfo);
 extern jl_array_t *jl_module_init_order;
 
 #ifdef JL_USE_INTEL_JITEVENTS

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -699,23 +699,6 @@ DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name, jl_value_t **bp, j
     return gf;
 }
 
-static jl_lambda_info_t *jl_copy_lambda_info(jl_lambda_info_t *linfo)
-{
-    jl_lambda_info_t *new_linfo =
-        jl_new_lambda_info(linfo->ast, linfo->sparams, linfo->module);
-    new_linfo->tfunc = linfo->tfunc;
-    new_linfo->name = linfo->name;
-    new_linfo->roots = linfo->roots;
-    new_linfo->specTypes = linfo->specTypes;
-    new_linfo->unspecialized = linfo->unspecialized;
-    new_linfo->specializations = linfo->specializations;
-    new_linfo->def = linfo->def;
-    new_linfo->capt = linfo->capt;
-    new_linfo->file = linfo->file;
-    new_linfo->line = linfo->line;
-    return new_linfo;
-}
-
 DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_value_t *bp_owner,
                                     jl_binding_t *bnd,
                                     jl_svec_t *argdata, jl_function_t *f, jl_value_t *isstaged,


### PR DESCRIPTION
this further develops the `--compile=all` mode such that it is able to run Julia (sans generated functions and eval) without linking against llvm.
