### PR TITLE
Deprecate chol(A, Val{:U/:L}) and move documentation to method definitions

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -858,3 +858,8 @@ end
 
 #13496
 @deprecate A_ldiv_B!(A::SparseMatrixCSC, B::StridedVecOrMat) A_ldiv_B!(factorize(A), B)
+
+@deprecate chol(A::Number, ::Type{Val{:U}})         chol(A)
+@deprecate chol(A::AbstractMatrix, ::Type{Val{:U}}) chol(A)
+@deprecate chol(A::Number, ::Type{Val{:L}})         ctranspose(chol(A))
+@deprecate chol(A::AbstractMatrix, ::Type{Val{:L}}) ctranspose(chol(A))

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -5735,13 +5735,6 @@ as ``v0``. In general, this cannot be used with empty collections
 foldr(op, itr)
 
 doc"""
-    chol(A, [LU]) -> F
-
-Compute the Cholesky factorization of a symmetric positive definite matrix `A` and return the matrix `F`. If `LU` is `Val{:U}` (Upper), `F` is of type `UpperTriangular` and `A = F'*F`. If `LU` is `Val{:L}` (Lower), `F` is of type `LowerTriangular` and `A = F*F'`. `LU` defaults to `Val{:U}`.
-"""
-chol
-
-doc"""
     ParseError(msg)
 
 The expression passed to the `parse` function could not be interpreted as a valid Julia expression.

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -111,11 +111,17 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    ``lufact!`` is the same as :func:`lufact`, but saves space by overwriting the input ``A``, instead of creating a copy.  For sparse ``A`` the ``nzval`` field is not overwritten but the index fields, ``colptr`` and ``rowval`` are decremented in place, converting from 1-based indices to 0-based indices.
 
-.. function:: chol(A, [LU]) -> F
+.. function:: chol(A::AbstractMatrix) -> U
 
    .. Docstring generated from Julia source
 
-   Compute the Cholesky factorization of a symmetric positive definite matrix ``A`` and return the matrix ``F``\ . If ``LU`` is ``Val{:U}`` (Upper), ``F`` is of type ``UpperTriangular`` and ``A = F'*F``\ . If ``LU`` is ``Val{:L}`` (Lower), ``F`` is of type ``LowerTriangular`` and ``A = F*F'``\ . ``LU`` defaults to ``Val{:U}``\ .
+   Compute the Cholesky factorization of a positive definite matrix ``A`` and return the UpperTriangular matrix ``U`` such that ``A = U'U``\ .
+
+.. function:: chol(x::Number) -> y
+
+   .. Docstring generated from Julia source
+
+   Compute the square root of a non-negative number ``x``\ .
 
 .. function:: cholfact(A, [LU=:U[,pivot=Val{false}]][;tol=-1.0]) -> Cholesky
 

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -125,8 +125,8 @@ begin
     # Cholesky factor of Matrix with non-commutative elements, here 2x2-matrices
 
     X = Matrix{Float64}[0.1*rand(2,2) for i in 1:3, j = 1:3]
-    L = full(Base.LinAlg.chol!(X*X', Val{:L}))
-    U = full(Base.LinAlg.chol!(X*X', Val{:U}))
+    L = full(Base.LinAlg.chol!(X*X', LowerTriangular))
+    U = full(Base.LinAlg.chol!(X*X', UpperTriangular))
     XX = full(X*X')
 
     @test sum(sum(norm, L*L' - XX)) < eps()
@@ -141,7 +141,6 @@ for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
         A = randn(5,5)
     end
     A = convert(Matrix{elty}, A'A)
-    for ul in (:U, :L)
-        @test_approx_eq full(cholfact(A, ul)[ul]) full(invoke(Base.LinAlg.chol!, Tuple{AbstractMatrix, Type{Val{ul}}},copy(A), Val{ul}))
-    end
+    @test_approx_eq full(cholfact(A)[:L]) full(invoke(Base.LinAlg.chol!, Tuple{AbstractMatrix, Type{LowerTriangular}}, copy(A), LowerTriangular))
+    @test_approx_eq full(cholfact(A)[:U]) full(invoke(Base.LinAlg.chol!, Tuple{AbstractMatrix, Type{UpperTriangular}}, copy(A), UpperTriangular))
 end

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -22,7 +22,7 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
                         (UnitLowerTriangular, :L))
 
         # Construct test matrix
-        A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't, Val{uplo1})))
+        A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't) |> t -> uplo1 == :U ? t : ctranspose(t)))
 
         debug && println("elty1: $elty1, A1: $t1")
 
@@ -243,7 +243,7 @@ for elty1 in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
 
                 debug && println("elty1: $elty1, A1: $t1, elty2: $elty2")
 
-                A2 = t2(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t-> chol(t't, Val{uplo2})))
+                A2 = t2(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't) |> t -> uplo2 == :U ? t : ctranspose(t)))
 
                 # Convert
                 if elty1 <: Real && !(elty2 <: Integer)


### PR DESCRIPTION
It was resently brought up on the [mailing list](https://groups.google.com/forum/#!topic/julia-users/mGV-V-FYzrA) that the syntax for getting the lower triangular version of the Cholesky, `chol(A, Val{:L})`, is "ugly and confusing".

In 0.3 the syntax was `chol(A,:L)` which is simpler, but because the `Triangular` type was split into `LowerTriangular` and `UpperTriangular`, it was necessary to introduce two different method signatures for creating the `Lower` and the `Upper` version of the Cholesky factor. This let to https://github.com/JuliaLang/LinearAlgebra.jl/issues/268.

In this PR I follow the idea from 3. in JuliaLang/LinearAlgebra.jl#268 and remove the second argument from `chol`. The reason for this is that the `Lower` and the `Upper` versions are in fact the exact same factorization, `A=◣*◥`, and the only difference is if the lower or the upper part is used for storage. Therefore, it is only a matter of transposing the result to get the other version and if this is done as part of a multiplication of solve, then this is essensially free.
