### PR TITLE
make sure Pkg.build process uses same paths as parent process

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -519,6 +519,12 @@ function build!(pkgs::Vector, errs::Dict, seen::Set=Set())
     errfile = tempname()
     close(open(errfile, "w")) # create empty file
     code = """
+        empty!(Base.LOAD_PATH)
+        append!(Base.LOAD_PATH, $(repr(Base.LOAD_PATH)))
+        empty!(Base.LOAD_CACHE_PATH)
+        append!(Base.LOAD_CACHE_PATH, $(repr(Base.LOAD_CACHE_PATH)))
+        empty!(Base.DL_LOAD_PATH)
+        append!(Base.DL_LOAD_PATH, $(repr(Base.DL_LOAD_PATH)))
         open("$(escape_string(errfile))", "a") do f
             for path_ in eachline(STDIN)
                 path = chomp(path_)


### PR DESCRIPTION
I just noticed this oversight in #13506, compared to what `create_expr_cache` does in `base/loading.jl`.

I'm not sure if this is related to some of the problems people have seen in #13506.
