### PR TITLE
Implement walkdir. fixes #8814

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1298,6 +1298,7 @@ export
     tempname,
     touch,
     uperm,
+    walkdir,
 
 # external processes ## TODO: whittle down these exports.
     detach,

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -28,6 +28,25 @@
 
    Returns the files and directories in the directory ``dir`` (or the current working directory if not given).
 
+.. function:: walkdir(dir; topdown=true, follow_symlinks=false, onerror=throw)
+
+   .. Docstring generated from Julia source
+
+   The walkdir method return an iterator that walks the directory tree of a directory. The iterator returns a tuple containing ``(rootpath, dirs, files)``\ . The directory tree can be traversed top-down or bottom-up. If walkdir encounters a SystemError it will raise the error. A custom error handling function can be provided through ``onerror`` keyword argument, the function is called with a SystemError as argument.
+
+   .. code-block:: julia
+
+       for (root, dirs, files) in walkdir(".")
+           println("Directories in $root")
+           for dir in dirs
+               println(joinpath(root, dir)) # path to directories
+           end
+           println("Files in $root")
+           for file in files
+               println(joinpath(root, file)) # path to files
+           end
+       end
+
 .. function:: mkdir(path, [mode])
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
This implements a `walkdir` function equivalent to Python's `os.walk`. I have added test for the function and it's keyword arguments. Please correct the docs, as I am not a native speaker. My only remaining question is whether `walkdir` should do as `os.walk` and swallow errors as default.
Fixes #8814
