### PR TITLE
Disallow documenting string literals

### DIFF
--- a/test/docs.jl
+++ b/test/docs.jl
@@ -264,6 +264,9 @@ end
 @test docstrings_equal(@doc(BareModule.A), doc"A")
 @test docstrings_equal(@doc(BareModule.T), doc"T")
 
+@test_throws ErrorException @doc("...", "error")
+@test_throws ErrorException @doc("...", @time 0)
+
 # test that when no docs exist, they fallback to
 # the docs for the typeof(value)
 let d1 = @doc(DocsTest.val)


### PR DESCRIPTION
This fixes #12737 by throwing an error when trying to document unbound string literals. String-valued variables can still be documented though.

Also improves error reporting for invalid doc expressions and adds tests.
