### PR TITLE
Add option to disable / ignore incremental module precompilation

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -28,6 +28,7 @@ immutable JLOptions
     worker::Int8
     handle_signals::Int8
     use_precompiled::Int8
+    use_compilecache::Int8
     bindto::Ptr{UInt8}
     outputbc::Ptr{UInt8}
     outputo::Ptr{UInt8}
@@ -36,3 +37,17 @@ immutable JLOptions
 end
 
 JLOptions() = unsafe_load(cglobal(:jl_options, JLOptions))
+
+function show(io::IO, opt::JLOptions)
+    println(io, "JLOptions(")
+    fields = fieldnames(opt)
+    nfields = length(fields)
+    for (i,f) in enumerate(fieldnames(opt))
+        v = getfield(opt,f)
+        if isa(v, Ptr{UInt8})
+            v = v != C_NULL ? bytestring(v) : ""
+        end
+        println(io, "  ", f, " = ", repr(v), i < nfields ? "," : "")
+    end
+    print(io,")")
+end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -543,6 +543,7 @@ function build!(pkgs::Vector, errs::Dict, seen::Set=Set())
         end
     """
     io, pobj = open(detach(`$(Base.julia_cmd())
+                           --compilecache=$(Bool(Base.JLOptions().use_compilecache) ? "yes" : "no")
                            --history-file=no
                            --color=$(Base.have_color ? "yes" : "no")
                            --eval $code`), "w", STDOUT)

--- a/doc/manual/getting-started.rst
+++ b/doc/manual/getting-started.rst
@@ -112,6 +112,7 @@ those available for the ``perl`` and ``ruby`` programs::
 
      -J, --sysimage <file>     Start up with the given system image file
      --precompiled={yes|no}    Use precompiled code from system image if available
+     --compilecache={yes|no}   Enable/disable incremental precompilation of modules\n"
      -H, --home <dir>          Set location of julia executable
      --startup-file={yes|no}   Load ~/.juliarc.jl
      -f, --no-startup          Don't load ~/.juliarc (deprecated, use --startup-file=no)

--- a/doc/manual/modules.rst
+++ b/doc/manual/modules.rst
@@ -419,3 +419,9 @@ A few other points to be aware of:
 
 4. WeakRef objects and finalizers are not currently handled properly by the serializer
    (this will be fixed in an upcoming release).
+
+It is sometimes helpful during module development to turn off incremental precompilation.
+The command line flag ``--compilecache={yes|no}`` enables you to toggle module precompilation on and off.
+When Julia is started with ``--compilecache=no`` the serialized modules in the compile cache are ignored when loading modules and module dependencies.
+``Base.compilecache()`` can still be called manually and it will respect ``__precompile__()`` directives for the module.
+The state of this command line flag is passed to ``Pkg.build()`` to disable automatic precompilation triggering when installing, updating, and explicitly building packages.

--- a/src/init.c
+++ b/src/init.c
@@ -76,6 +76,7 @@ jl_options_t jl_options = { 0,    // quiet
 #else
                             JL_OPTIONS_USE_PRECOMPILED_YES,
 #endif
+                            JL_OPTIONS_USE_COMPILECACHE_YES,
                             NULL, // bindto
                             NULL, // outputbc
                             NULL, // outputo

--- a/src/julia.h
+++ b/src/julia.h
@@ -1572,6 +1572,7 @@ typedef struct {
     int8_t worker;
     int8_t handle_signals;
     int8_t use_precompiled;
+    int8_t use_compilecache;
     const char *bindto;
     const char *outputbc;
     const char *outputo;
@@ -1620,6 +1621,9 @@ DLLEXPORT int jl_generating_output(void);
 
 #define JL_OPTIONS_USE_PRECOMPILED_YES 1
 #define JL_OPTIONS_USE_PRECOMPILED_NO 0
+
+#define JL_OPTIONS_USE_COMPILECACHE_YES 1
+#define JL_OPTIONS_USE_COMPILECACHE_NO 0
 
 // Version information
 #include <julia_version.h>

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -232,4 +232,10 @@ let exename = `$(joinpath(JULIA_HOME, Base.julia_exename())) --precompiled=yes`
     @test readchomp(pipeline(ignorestatus(`$exename -f -p`),stderr=`cat`)) == "ERROR: option `-p/--procs` is missing an argument"
     @test readchomp(pipeline(ignorestatus(`$exename -f --inline`),stderr=`cat`)) == "ERROR: option `--inline` is missing an argument"
     @test readchomp(pipeline(ignorestatus(`$exename -f -e "@show ARGS" -now -- julia RUN.jl`),stderr=`cat`)) == "ERROR: unknown option `-n`"
+
+    # --compilecache={yes|no}
+    @test readchomp(`$exename -E "Bool(Base.JLOptions().use_compilecache)"`) == "true"
+    @test readchomp(`$exename --compilecache=yes -E "Bool(Base.JLOptions().use_compilecache)"`) == "true"
+    @test readchomp(`$exename --compilecache=no -E "Bool(Base.JLOptions().use_compilecache)"`) == "false"
+    @test !success(`$exename --compilecache=foo -e "exit(0)"`)
 end

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -47,6 +47,7 @@ static const char opts[]  =
     // startup options
     " -J, --sysimage <file>     Start up with the given system image file\n"
     " --precompiled={yes|no}    Use precompiled code from system image if available\n"
+    " --compilecache={yes|no}   Enable/disable incremental precompilation of modules\n"
     " -H, --home <dir>          Set location of julia executable\n"
     " --startup-file={yes|no}   Load ~/.juliarc.jl\n"
     " -f, --no-startup          Don't load ~/.juliarc (deprecated, use --startup-file=no)\n"
@@ -115,6 +116,7 @@ void parse_opts(int *argcp, char ***argvp)
            opt_output_o,
            opt_output_ji,
            opt_use_precompiled,
+           opt_use_compilecache,
            opt_incremental
     };
     static char* shortopts = "+vhqFfH:e:E:P:L:J:C:ip:O";
@@ -132,6 +134,7 @@ void parse_opts(int *argcp, char ***argvp)
         { "load",            required_argument, 0, 'L' },
         { "sysimage",        required_argument, 0, 'J' },
         { "precompiled",     required_argument, 0, opt_use_precompiled },
+        { "compilecache",    required_argument, 0, opt_use_compilecache },
         { "cpu-target",      required_argument, 0, 'C' },
         { "procs",           required_argument, 0, 'p' },
         { "machinefile",     required_argument, 0, opt_machinefile },
@@ -230,6 +233,14 @@ void parse_opts(int *argcp, char ***argvp)
                 jl_options.use_precompiled = JL_OPTIONS_USE_PRECOMPILED_NO;
             else
                 jl_errorf("julia: invalid argument to --precompiled={yes|no} (%s)", optarg);
+            break;
+        case opt_use_compilecache:
+            if (!strcmp(optarg,"yes"))
+                jl_options.use_compilecache = JL_OPTIONS_USE_COMPILECACHE_YES;
+            else if (!strcmp(optarg,"no"))
+                jl_options.use_compilecache = JL_OPTIONS_USE_COMPILECACHE_NO;
+            else
+                jl_errorf("julia: invalid argument to --compilecache={yes|no} (%s)", optarg);
             break;
         case 'C': // cpu-target
             jl_options.cpu_target = strdup(optarg);


### PR DESCRIPTION
This is useful for debugging as well as for package development where aggressive precompilation can sometimes be a problem when making incremental changes.

related issues: #13693, #13684

closes #13474
