### PR TITLE
Fix upper/lower bug in cholfact! for non-BlasFloats

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,8 @@ Deprecated or removed
   * The method `A_ldiv_B!(SparseMatrixCSC, StrideVecOrMat)` has been deprecated in favor
     of versions that require the matrix to in factored form ([#13496]).
 
+  * Deprecate `chol(A,Val{:U/:L})` in favor of `chol(A)` ([#13680]).
+
 Julia v0.4.0 Release Notes
 ==========================
 

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -125,7 +125,7 @@ function cholfact!(A::StridedMatrix, uplo::Symbol, ::Type{Val{false}})
     if uplo == :U
         Cholesky(chol!(A, UpperTriangular).data, 'U')
     else
-        Cholesky(chol!(A, UpperTriangular).data, 'U')
+        Cholesky(chol!(A, LowerTriangular).data, 'L')
     end
 end
 cholfact!(A::StridedMatrix, uplo::Symbol, ::Type{Val{true}}; tol = 0.0) = throw(ArgumentError("generic pivoted Cholesky fectorization is not implemented yet"))

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -67,6 +67,8 @@ for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
     @test_approx_eq full(lapd) apd
     l = lapd[:L]
     @test_approx_eq l*l' apd
+    @test triu(capd.factors) ≈ lapd[:U]
+    @test tril(lapd.factors) ≈ capd[:L]
 
     #pivoted upper Cholesky
     if eltya != BigFloat


### PR DESCRIPTION
The `cholfact!` methods for upper and lower used to be one method definition with a `Union{Type{Val{:U}},Type{Val{:L}}}` argument, so one of the methods had escaped code coverage.
