### PR TITLE
[release-0.3] backports for 0.3.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ before_install:
         sudo add-apt-repository ppa:staticfloat/julia-deps -y;
         sudo apt-get update -qq -y;
         sudo apt-get install patchelf gfortran llvm-3.3-dev libsuitesparse-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libdouble-conversion-dev libopenlibm-dev librmath-dev libmpfr-dev -y;
+        git config --global user.name "Travis Buildbot";
+        git config --global user.email "travis@buildbot.example.org";
       elif [ `uname` = "Darwin" ]; then
         brew tap staticfloat/julia;
         brew rm --force $(brew deps julia);

--- a/Make.inc
+++ b/Make.inc
@@ -490,9 +490,17 @@ else
 PCRE_CONFIG = $(build_bindir)/pcre-config
 endif
 
-# Use 64-bit libraries by default on 64-bit architectures
+# Use ILP64 BLAS interface when building openblas from source on 64-bit architectures
 ifeq ($(BINARY), 64)
+ifeq ($(USE_SYSTEM_BLAS), 1)
+ifeq ($(USE_INTEL_MKL), 1)
 USE_BLAS64 ?= 1
+else # non MKL system blas is most likely LP64
+USE_BLAS64 ?= 0
+endif
+else
+USE_BLAS64 ?= 1
+endif
 endif
 
 ifeq ($(USE_SYSTEM_BLAS), 1)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -104,7 +104,6 @@ abs(z::Complex)  = hypot(real(z), imag(z))
 abs2(z::Complex) = real(z)*real(z) + imag(z)*imag(z)
 inv(z::Complex)  = conj(z)/abs2(z)
 inv{T<:Integer}(z::Complex{T}) = inv(float(z))
-sign(z::Complex) = z/abs(z)
 
 -(z::Complex) = Complex(-real(z), -imag(z))
 +(z::Complex, w::Complex) = Complex(real(z) + real(w), imag(z) + imag(w))

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -59,7 +59,8 @@ function generic_vecnormMinusInf(x)
     minabs = abs(v)
     while !done(x, s)
         (v, s) = next(x, s)
-        minabs = Base.scalarmin(minabs, abs(v))
+        vnorm = norm(v)
+        minabs = ifelse(isnan(minabs) | (minabs < vnorm), minabs, vnorm)
     end
     return float(minabs)
 end
@@ -70,7 +71,8 @@ function generic_vecnormInf(x)
     maxabs = abs(v)
     while !done(x, s)
         (v, s) = next(x, s)
-        maxabs = Base.scalarmax(maxabs, abs(v))
+        vnorm = norm(v)
+        maxabs = ifelse(isnan(maxabs) | (maxabs > vnorm), maxabs, vnorm)
     end
     return float(maxabs)
 end

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -282,6 +282,7 @@ function -(x::BigFloat)
 end
 
 function sqrt(x::BigFloat)
+    isnan(x) && return x
     z = BigFloat()
     ccall((:mpfr_sqrt, :libmpfr), Int32, (Ptr{BigFloat}, Ptr{BigFloat}, Int32), &z, &x, ROUNDING_MODE[end])
     if isnan(z)

--- a/base/number.jl
+++ b/base/number.jl
@@ -20,6 +20,7 @@ last(x::Number) = x
 
 divrem(x,y) = (div(x,y),rem(x,y))
 signbit(x::Real) = x < 0
+sign(x::Number) = x == 0? float(zero(x)) : x/abs(x)
 sign(x::Real) = ifelse(x < 0, oftype(x,-1), ifelse(x > 0, one(x), x))
 abs(x::Real) = ifelse(signbit(x), -x, x)
 abs2(x::Real) = x*x

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -225,9 +225,9 @@ pin(pkg::String) = pin(pkg,Git.head(dir=pkg))
 
 function pin(pkg::String, ver::VersionNumber)
     ispath(pkg,".git") || error("$pkg is not a git repo")
-    Read.isinstalled(pkg) || error("$pkg cannot be pinned – not an installed package".tmp)
+    Read.isinstalled(pkg) || error("$pkg cannot be pinned – not an installed package")
     avail = Read.available(pkg)
-    isempty(avail) && error("$pkg cannot be pinned – not a registered package".tmp)
+    isempty(avail) && error("$pkg cannot be pinned – not a registered package")
     haskey(avail,ver) || error("$pkg – $ver is not a registered version")
     pin(pkg,avail[ver].sha1)
 end

--- a/contrib/windows/msys_build.sh
+++ b/contrib/windows/msys_build.sh
@@ -53,6 +53,7 @@ if [ "$ARCH" = x86_64 ]; then
   archsuffix=64
   exc=seh
   echo "override MARCH = x86-64" >> Make.user
+  echo 'USE_BLAS64 = 1' >> Make.user
 else
   bits=32
   archsuffix=86

--- a/doc/helpdb.jl
+++ b/doc/helpdb.jl
@@ -7834,8 +7834,8 @@ popdisplay(d::Display)
 
 ("Base","sign","sign(x)
 
-   Return \"+1\" if \"x\" is positive, \"0\" if \"x == 0\", and \"-1\"
-   if \"x\" is negative.
+   Return zero if \"x==0\" and x/|x| otherwise (i.e., ±1 for real
+   \"x\").
 
 "),
 

--- a/doc/stdlib/math.rst
+++ b/doc/stdlib/math.rst
@@ -706,7 +706,7 @@ Mathematical Functions
 
 .. function:: sign(x)
 
-   Return ``+1`` if ``x`` is positive, ``0`` if ``x == 0``, and ``-1`` if ``x`` is negative.
+   Return zero if ``x==0`` and :math:`x/|x|` otherwise (i.e., ±1 for real ``x``).
 
 .. function:: signbit(x)
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -426,15 +426,19 @@ static uptrint_t hash_symbol(const char *str, size_t len)
 
 #define SYM_POOL_SIZE 524288
 
-static jl_sym_t *mk_symbol(const char *str)
+static size_t symbol_nbytes(size_t len)
+{
+    return (sizeof(jl_sym_t)+len+1+7)&-8;
+}
+
+static jl_sym_t *mk_symbol(const char *str, size_t len)
 {
 #ifndef MEMDEBUG
     static char *sym_pool = NULL;
     static char *pool_ptr = NULL;
 #endif
     jl_sym_t *sym;
-    size_t len = strlen(str);
-    size_t nb = (sizeof(jl_sym_t)+len+1+7)&-8;
+    size_t nb = symbol_nbytes(len);
 
     if (nb >= SYM_POOL_SIZE) {
         jl_error("Symbol length exceeds maximum length");
@@ -453,7 +457,8 @@ static jl_sym_t *mk_symbol(const char *str)
     sym->type = (jl_value_t*)jl_sym_type;
     sym->left = sym->right = NULL;
     sym->hash = hash_symbol(str, len);
-    strcpy(&sym->name[0], str);
+    memcpy(&sym->name[0], str, len);
+    sym->name[len] = 0;
     return sym;
 }
 
@@ -468,17 +473,17 @@ static void unmark_symbols_(jl_sym_t *root)
 
 void jl_unmark_symbols(void) { unmark_symbols_(symtab); }
 
-static jl_sym_t **symtab_lookup(jl_sym_t **ptree, const char *str)
+static jl_sym_t **symtab_lookup(jl_sym_t **ptree, const char *str, size_t len)
 {
     int x;
-    uptrint_t h = hash_symbol(str, strlen(str));
+    uptrint_t h = hash_symbol(str, len);
 
     // Tree nodes sorted by major key of (int(hash)) and minor key o (str).
     while (*ptree != NULL) {
         x = (int)(h-(*ptree)->hash);
         if (x == 0) {
-            x = strcmp(str, (*ptree)->name);
-            if (x == 0)
+            x = strncmp(str, (*ptree)->name, len);
+            if (x == 0 && (*ptree)->name[len] == 0)
                 return ptree;
         }
         if (x < 0)
@@ -489,27 +494,31 @@ static jl_sym_t **symtab_lookup(jl_sym_t **ptree, const char *str)
     return ptree;
 }
 
-jl_sym_t *jl_symbol(const char *str)
+static jl_sym_t *_jl_symbol(const char *str, size_t len)
 {
     jl_sym_t **pnode;
 
-    pnode = symtab_lookup(&symtab, str);
+    pnode = symtab_lookup(&symtab, str, len);
     if (*pnode == NULL)
-        *pnode = mk_symbol(str);
+        *pnode = mk_symbol(str, len);
     return *pnode;
+}
+
+jl_sym_t *jl_symbol(const char *str)
+{
+    return _jl_symbol(str, strlen(str));
 }
 
 jl_sym_t *jl_symbol_lookup(const char *str)
 {
-    return *symtab_lookup(&symtab, str);
+    return *symtab_lookup(&symtab, str, strlen(str));
 }
 
 DLLEXPORT jl_sym_t *jl_symbol_n(const char *str, int32_t len)
 {
-    char *name = (char*)alloca(len+1);
-    memcpy(name, str, len);
-    name[len] = '\0';
-    return jl_symbol(name);
+    if (memchr(str, 0, len))
+        jl_error("Symbol name may not contain \\0");
+    return _jl_symbol(str, len);
 }
 
 DLLEXPORT jl_sym_t *jl_get_root_symbol() { return symtab; }
@@ -531,14 +540,21 @@ DLLEXPORT jl_sym_t *jl_gensym(void)
 DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len)
 {
     static char gs_name[14];
-    char *name = (char*)alloca(sizeof(gs_name)+len+3);
+    if (symbol_nbytes(len) >= SYM_POOL_SIZE)
+        jl_error("Symbol length exceeds maximum");
+    if (memchr(str, 0, len))
+        jl_error("Symbol name may not contain \\0");
+    char *name = (char*) (len >= 256 ? malloc(sizeof(gs_name)+len+3) :
+                          alloca(sizeof(gs_name)+len+3));
     char *n;
     name[0] = '#'; name[1] = '#'; name[2+len] = '#';
     memcpy(name+2, str, len);
     n = uint2str(gs_name, sizeof(gs_name), gs_ctr, 10);
     memcpy(name+3+len, n, sizeof(gs_name)-(n-gs_name));
     gs_ctr++;
-    return jl_symbol(name);
+    jl_sym_t *sym = _jl_symbol(name, len+3+sizeof(gs_name)-(n-gs_name)-1);
+    if (len >= 256) free(name);
+    return sym;
 }
 
 // allocating types -----------------------------------------------------------

--- a/src/dump.c
+++ b/src/dump.c
@@ -738,10 +738,11 @@ static jl_value_t *jl_deserialize_value_internal(ios_t *s)
             len = read_uint8(s);
         else
             len = read_int32(s);
-        char *name = (char*)alloca(len+1);
+        char *name = (char*) (len >= 256 ? malloc(len+1) : alloca(len+1));
         ios_read(s, name, len);
         name[len] = '\0';
         jl_value_t *sym = (jl_value_t*)jl_symbol(name);
+        if (len >= 256) free(name);
         if (usetable)
             ptrhash_put(&backref_table, (void*)(ptrint_t)pos, sym);
         return sym;

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -729,6 +729,26 @@ end
 @test log10(10+0im) === 1.0 + 0.0im
 @test log2(2+0im) === 1.0 + 0.0im
 
+# sign
+for T in (Float32, Float64)
+    z = convert(Complex{T}, 1)
+    @test typeof(sign(z)) == typeof(z)
+    z = convert(Complex{T}, 0)
+    @test typeof(sign(z)) == typeof(z)
+end
+for T in (Int32, Int64)
+    z = convert(Complex{T}, 1)
+    @test typeof(sign(z)) == typeof(float(z))
+    z = convert(Complex{T}, 0)
+    @test typeof(sign(z)) == typeof(float(z))
+end
+
+@test sign(0 + 0im) == 0
+@test sign(2 + 0im) == 1
+@test sign(-2 + 0im) == -1
+@test_approx_eq sign(1 + im) ((1 + im) / sqrt(2))
+@test_approx_eq sign(1 - im) ((1 - im) / sqrt(2))
+
 # cis
 @test_approx_eq cis(0.0+1.0im) 0.367879441171442321595523770161460867445811131031767834507836+0.0im
 @test_approx_eq cis(1.0+0.0im) 0.54030230586813971740093660744297660373231042061+0.84147098480789650665250232163029899962256306079im

--- a/test/core.jl
+++ b/test/core.jl
@@ -1904,3 +1904,16 @@ end
 
 # issue #11772
 @test_throws UndefRefError zip(cell(5)...)
+
+# don't allow Vararg{} in Union{} type constructor
+@test_throws TypeError Union{Int,Vararg{Int}}
+
+# don't allow Vararg{} in Tuple{} type constructor in non-trailing position
+@test_throws TypeError Tuple{Vararg{Int32},Int64,Float64}
+@test_throws TypeError Tuple{Int64,Vararg{Int32},Float64}
+
+# issue #12569
+@test_throws ErrorException symbol("x"^10_000_000)
+@test_throws ErrorException gensym("x"^10_000_000)
+@test symbol("x") === symbol("x")
+@test split(string(gensym("abc")),'#')[3] == "abc"

--- a/test/linalg2.jl
+++ b/test/linalg2.jl
@@ -315,6 +315,14 @@ for elty in (Float32, Float64, BigFloat, Complex{Float32}, Complex{Float64}, Com
     @test_approx_eq norm(xs, 3) cbrt(5)
     @test_approx_eq norm(xs, Inf) 1
 
+    # Issue #12552:
+    if elty <: FloatingPoint || elty <: Complex
+        for p in [-Inf,-1,1,2,3,Inf]
+            @test isnan(norm(elty[0,NaN],p))
+            @test isnan(norm(elty[NaN,0],p))
+        end
+    end
+
     ## Number
     norm(x[1:1]) === norm(x[1], -Inf)
     norm(x[1:1]) === norm(x[1], 0)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -797,3 +797,13 @@ i3 = itrunc(f)
 err(z, x) = abs(z - x) / abs(x)
 @test 1e-60 > err(eta(BigFloat("1.005")), BigFloat("0.693945708117842473436705502427198307157819636785324430166786"))
 @test 1e-60 > err(exp(eta(big(1.0))), 2.0)
+
+# serialization (issue #12386)
+let b = IOBuffer()
+    x = 2.1*big(pi)
+    serialize(b, x)
+    seekstart(b)
+    @test deserialize(b) == x
+end
+
+@test isnan(sqrt(BigFloat(NaN)))

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -1,79 +1,79 @@
 function temp_pkg_dir(fn::Function)
-  # Used in tests below to setup and teardown a sandboxed package directory
-  const tmpdir = ENV["JULIA_PKGDIR"] = joinpath(tempdir(),randstring())
-  @test !isdir(Pkg.dir())
-  try
-    Pkg.init()
-    @test isdir(Pkg.dir())
-    Pkg.resolve()
+    # Used in tests below to setup and teardown a sandboxed package directory
+    const tmpdir = ENV["JULIA_PKGDIR"] = joinpath(tempdir(),randstring())
+    @test !isdir(Pkg.dir())
+    try
+        Pkg.init()
+        @test isdir(Pkg.dir())
+        Pkg.resolve()
 
-    fn()
-  finally
-    rm(tmpdir, recursive=true)
-  end
+        fn()
+    finally
+        rm(tmpdir, recursive=true)
+    end
 end
 
 # Test adding a removing a package
 temp_pkg_dir() do
-  @test isempty(Pkg.installed())
-  Pkg.add("Example")
-  @test [keys(Pkg.installed())...] == ["Example"]
-  Pkg.rm("Example")
-  @test isempty(Pkg.installed())
+    @test isempty(Pkg.installed())
+    Pkg.add("Example")
+    @test [keys(Pkg.installed())...] == ["Example"]
+    Pkg.rm("Example")
+    @test isempty(Pkg.installed())
 end
 
 # testing a package with test dependencies causes them to be installed for the duration of the test
 temp_pkg_dir() do
-  Pkg.generate("PackageWithTestDependencies", "MIT", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
-  @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
+    Pkg.generate("PackageWithTestDependencies", "MIT", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
+    @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
 
-  isdir(Pkg.dir("PackageWithTestDependencies","test")) || mkdir(Pkg.dir("PackageWithTestDependencies","test"))
-  open(Pkg.dir("PackageWithTestDependencies","test","REQUIRE"),"w") do f
-    println(f,"Example")
-  end
+    isdir(Pkg.dir("PackageWithTestDependencies","test")) || mkdir(Pkg.dir("PackageWithTestDependencies","test"))
+    open(Pkg.dir("PackageWithTestDependencies","test","REQUIRE"),"w") do f
+        println(f,"Example")
+    end
 
-  open(Pkg.dir("PackageWithTestDependencies","test","runtests.jl"),"w") do f
-    println(f,"using Base.Test")
-    println(f,"@test haskey(Pkg.installed(), \"Example\")")
-  end
+    open(Pkg.dir("PackageWithTestDependencies","test","runtests.jl"),"w") do f
+        println(f,"using Base.Test")
+        println(f,"@test haskey(Pkg.installed(), \"Example\")")
+    end
 
-  Pkg.resolve()
-  @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
+    Pkg.resolve()
+    @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
 
-  Pkg.test("PackageWithTestDependencies")
+    Pkg.test("PackageWithTestDependencies")
 
-  @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
+    @test [keys(Pkg.installed())...] == ["PackageWithTestDependencies"]
 end
 
 # testing a package with no runtests.jl errors
 temp_pkg_dir() do
-  Pkg.generate("PackageWithNoTests", "MIT", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
+    Pkg.generate("PackageWithNoTests", "MIT", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
 
-  if isfile(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
-    rm(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
-  end
+    if isfile(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
+        rm(Pkg.dir("PackageWithNoTests", "test", "runtests.jl"))
+    end
 
-  try
-    Pkg.test("PackageWithNoTests")
-  catch err
-    @test err.msg == "PackageWithNoTests did not provide a test/runtests.jl file"
-  end
+    try
+        Pkg.test("PackageWithNoTests")
+    catch err
+        @test err.msg == "PackageWithNoTests did not provide a test/runtests.jl file"
+    end
 end
 
 # testing a package with failing tests errors
 temp_pkg_dir() do
-  Pkg.generate("PackageWithFailingTests", "MIT", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
+    Pkg.generate("PackageWithFailingTests", "MIT", config=["user.name"=>"Julia Test", "user.email"=>"test@julialang.org"])
 
-  isdir(Pkg.dir("PackageWithFailingTests","test")) || mkdir(Pkg.dir("PackageWithFailingTests","test"))
-  open(Pkg.dir("PackageWithFailingTests", "test", "runtests.jl"),"w") do f
-    println(f,"using Base.Test")
-    println(f,"@test false")
-  end
+    isdir(Pkg.dir("PackageWithFailingTests","test")) || mkdir(Pkg.dir("PackageWithFailingTests","test"))
+    open(Pkg.dir("PackageWithFailingTests", "test", "runtests.jl"),"w") do f
+        println(f,"using Base.Test")
+        println(f,"@test false")
+    end
 
-  try
-    Pkg.test("PackageWithFailingTests")
-  catch err
-    @test err.msg == "PackageWithFailingTests had test errors"
-  end
+    try
+        Pkg.test("PackageWithFailingTests")
+    catch err
+        @test err.msg == "PackageWithFailingTests had test errors"
+    end
 end
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: http://julialang.org/license
+
 function temp_pkg_dir(fn::Function)
     # Used in tests below to setup and teardown a sandboxed package directory
     const tmpdir = ENV["JULIA_PKGDIR"] = joinpath(tempdir(),randstring())
@@ -20,6 +22,36 @@ temp_pkg_dir() do
     @test [keys(Pkg.installed())...] == ["Example"]
     Pkg.rm("Example")
     @test isempty(Pkg.installed())
+
+    # adding a package with unsatisfiable julia version requirements (REPL.jl) errors
+    try
+        Pkg.add("REPL")
+        error("unexpected")
+    catch err
+        @test err.msg == "REPL can't be installed because " *
+            "it has no versions that support $VERSION of julia. You may " *
+            "need to update METADATA by running `Pkg.update()`"
+    end
+
+    # trying to add, check availability, or pin a nonexistent package errors
+    try
+        Pkg.add("NonexistentPackage")
+        error("unexpected")
+    catch err
+        @test err.msg == "unknown package NonexistentPackage"
+    end
+    try
+        Pkg.available("NonexistentPackage")
+        error("unexpected")
+    catch err
+        @test err.msg == "NonexistentPackage is not a package (not registered or installed)"
+    end
+    try
+        Pkg.pin("NonexistentPackage", v"1.0.0")
+        error("unexpected")
+    catch err
+        @test err.msg == "NonexistentPackage is not a git repo"
+    end
 end
 
 # testing a package with test dependencies causes them to be installed for the duration of the test
@@ -55,6 +87,7 @@ temp_pkg_dir() do
 
     try
         Pkg.test("PackageWithNoTests")
+        error("unexpected")
     catch err
         @test err.msg == "PackageWithNoTests did not provide a test/runtests.jl file"
     end
@@ -72,8 +105,15 @@ temp_pkg_dir() do
 
     try
         Pkg.test("PackageWithFailingTests")
+        error("unexpected")
     catch err
         @test err.msg == "PackageWithFailingTests had test errors"
     end
 end
 
+# issue #13374
+temp_pkg_dir() do
+    Pkg.generate("Foo", "MIT")
+    Pkg.tag("Foo")
+    Pkg.tag("Foo")
+end


### PR DESCRIPTION
Been a while since 0.3.11, we had a bunch of 0.4.0 release candidates to worry about. Since there are a few commits already on release-0.3 that haven't been released, and a few more tagged for "backport pending 0.3," figured we should probably do one last tag. I'll build test binaries from this branch and run PkgEval to compare with 0.3.11, make sure there are no regressions at least in automatically tested code. If anyone identifies any regression between 0.3.x and 0.3.12 at any point in the future we can put out an 0.3.13 to fix it if we need to.

Please do check my backporting work. The only PR with the "backport pending 0.3" label that isn't yet included here is #12645, cc @timholy and see my recent comment there. I did just remove that label from #12934 and #12607 due to cherry-picking conflicts, but could be convinced otherwise if someone feels strongly.
