### PR TITLE
Vector{String} .* String

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -48,6 +48,8 @@ sizeof(s::AbstractString) = error("type $(typeof(s)) has no canonical binary rep
 eltype{T<:AbstractString}(::Type{T}) = Char
 
 (*)(s1::AbstractString, ss::AbstractString...) = string(s1, ss...)
+(.*){T<:AbstractString}(v::Vector{T},s::AbstractString) = [i*s for i in v]
+(.*){T<:AbstractString}(s::AbstractString,v::Vector{T}) = [s*i for i in v]
 
 length(s::DirectIndexString) = endof(s)
 function length(s::AbstractString)

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -484,3 +484,9 @@ foobaz(ch) = reinterpret(Char, typemax(UInt32))
 @test_throws UnicodeError map(foomap, utf16(str))
 @test_throws UnicodeError map(foobar, utf16(str))
 @test_throws UnicodeError map(foobaz, utf16(str))
+
+@test "a".*["b","c"] == ["ab","ac"]
+@test ["b","c"].*"a" == ["ba","ca"]
+@test utf8("a").*["b","c"] == ["ab","ac"]
+@test "a".*map(utf8,["b","c"]) == ["ab","ac"]
+@test ["a","b"].*["c","d"]' == ["ac" "ad"; "bc" "bd"]


### PR DESCRIPTION
unless (or until) \* and ^ notation for strings is completely removed, it would be nice if one could multiply scalars with vectors.

see https://github.com/JuliaLang/julia/issues/13053 and https://groups.google.com/forum/#!topic/julia-users/Z6fTmdeuEkI
