### PR TITLE
relax Int to Integer in similar and getindex for ranges (fix #13738 )

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -189,13 +189,14 @@ end
 ## Constructors ##
 
 # default arguments to similar()
-similar{T}(a::AbstractArray{T})               = similar(a, T, size(a))
-similar(   a::AbstractArray, T)               = similar(a, T, size(a))
-similar{T}(a::AbstractArray{T}, dims::Dims)   = similar(a, T, dims)
-similar{T}(a::AbstractArray{T}, dims::Int...) = similar(a, T, dims)
-similar(   a::AbstractArray, T, dims::Int...) = similar(a, T, dims)
+similar{T}(a::AbstractArray{T})                          = similar(a, T, size(a))
+similar(   a::AbstractArray, T::Type)                    = similar(a, T, size(a))
+similar{T}(a::AbstractArray{T}, dims::DimsInteger)       = similar(a, T, dims)
+similar{T}(a::AbstractArray{T}, dims::Integer...)        = similar(a, T, dims)
+similar(   a::AbstractArray, T::Type, dims::Integer...)  = similar(a, T, dims)
 # similar creates an Array by default
-similar(   a::AbstractArray, T, dims::Dims)   = Array(T, dims)
+similar(   a::AbstractArray, T::Type, dims::DimsInteger) = Array(T, dims...)
+similar(   a::AbstractArray, T::Type, dims::Dims)        = Array(T, dims)
 
 function reshape(a::AbstractArray, dims::Dims)
     if prod(dims) != length(a)

--- a/base/range.jl
+++ b/base/range.jl
@@ -3,6 +3,7 @@
 ## 1-dimensional ranges ##
 
 typealias Dims Tuple{Vararg{Int}}
+typealias DimsInteger Tuple{Vararg{Integer}}
 
 abstract Range{T} <: AbstractArray{T,1}
 
@@ -301,9 +302,6 @@ logspace(start::Real, stop::Real, n::Integer=50) = 10.^linspace(start, stop, n)
 
 ## interface implementations
 
-similar(r::Range, T::Type, dims::Tuple{Vararg{Integer}}) = Array(T, dims...)
-similar(r::Range, T::Type, dims::Dims) = Array(T, dims)
-
 size(r::Range) = (length(r),)
 
 isempty(r::StepRange) =
@@ -415,20 +413,20 @@ unsafe_getindex{T}(r::LinSpace{T}, i::Integer) = convert(T, ((r.len-i)*r.start +
 getindex(r::Range, ::Colon) = copy(r)
 unsafe_getindex(r::Range, ::Colon) = copy(r)
 
-getindex(r::UnitRange, s::UnitRange{Int}) = (checkbounds(r, s); unsafe_getindex(r, s))
-function unsafe_getindex(r::UnitRange, s::UnitRange{Int})
+getindex{T<:Integer}(r::UnitRange, s::UnitRange{T}) = (checkbounds(r, s); unsafe_getindex(r, s))
+function unsafe_getindex{T<:Integer}(r::UnitRange, s::UnitRange{T})
     st = oftype(r.start, r.start + s.start-1)
     range(st, length(s))
 end
 
-getindex(r::UnitRange, s::StepRange{Int}) = (checkbounds(r, s); unsafe_getindex(r, s))
-function unsafe_getindex(r::UnitRange, s::StepRange{Int})
+getindex{T<:Integer}(r::UnitRange, s::StepRange{T}) = (checkbounds(r, s); unsafe_getindex(r, s))
+function unsafe_getindex{T<:Integer}(r::UnitRange, s::StepRange{T})
     st = oftype(r.start, r.start + s.start-1)
     range(st, step(s), length(s))
 end
 
-getindex(r::StepRange, s::Range{Int}) = (checkbounds(r, s); unsafe_getindex(r, s))
-function unsafe_getindex(r::StepRange, s::Range{Int})
+getindex{T<:Integer}(r::StepRange, s::Range{T}) = (checkbounds(r, s); unsafe_getindex(r, s))
+function unsafe_getindex{T<:Integer}(r::StepRange, s::Range{T})
     st = oftype(r.start, r.start + (first(s)-1)*step(r))
     range(st, step(r)*step(s), length(s))
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -1056,7 +1056,7 @@ function print_matrix_row(io::IO,
 )
     for k = 1:length(A)
         j = cols[k]
-        if isassigned(X,i,j)
+        if isassigned(X,Int(i),Int(j)) # isassigned accepts only `Int` indices
             x = X[i,j]
             a = alignment(x)
             sx = sprint(showcompact_lim, x)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -675,3 +675,12 @@ test_range_sum_diff(1.:5., linspace(0, 8, 5),
 let r = 0x02:0x05
     @test r[2:3] == 0x03:0x04
 end
+
+# Issue #13738
+for r in (big(1):big(2), UInt128(1):UInt128(2), 0x1:0x2)
+    rr = r[r]
+    @test typeof(rr) == typeof(r)
+    @test r[r] == r
+    # these calls to similar must not throw:
+    @test size(similar(r, size(r))) == size(similar(r, length(r)))
+end


### PR DESCRIPTION
This is a minimal fix to the error triggered by:

> r = UInt(1):UInt(2); r[r];

r[r] should produce a range (or at least an array).

The error first comes from the fact that similar(h, size(h)) selects
similar(a::AbstractArray, T) because T (meant to be a Type) is
unconstrained, and size(h) doesn't match the dims::Dims argument of
other methods.

This patch therefore relaxes Dims to DimsInteger for similar, and
constrains T. Also, r[r] should probably be a UnitRange equal to r,
like for UnitRange{Int}; the getindex methods for ranges are updated
accordingly.

Note: if this fix is deemed correct, please suggest alternative names for `DimsInteger`.
