### PR TITLE
Place parseint @test inside loop

### DIFF
--- a/test/perf/micro/perf.jl
+++ b/test/perf/micro/perf.jl
@@ -19,8 +19,8 @@ function parseintperf(t)
         n = rand(UInt32)
         s = hex(n)
         m = UInt32(parse(Int64,s,16))
+        @test m == n
     end
-    @test m == n
     return n
 end
 


### PR DESCRIPTION
It really should be inside the loop, when you compare to the slow matlab implementation. 

Here's the performance impact for me:

```
with @test outside loop: julia,parse_int,0.320313,30.821464,0.350194,0.419335
 with @test inside loop: julia,parse_int,2.012968,32.083471,2.292076,1.140998
```
