### PR TITLE
Vectorize matlab parseint to improve performance

### DIFF
--- a/test/perf/micro/perf.m
+++ b/test/perf/micro/perf.m
@@ -90,12 +90,10 @@ end
 %% parse int %%
 
 function n = parseintperf(t)
-    for i = 1:t
-        n = randi([0,2^32-1],1,'uint32');
-        s = dec2hex(n);
-        m = hex2dec(s);
-        assert(m == n);
-    end
+    n = randi([0,2^32-1],t,1,'uint32');
+    s = dec2hex(n);
+    m = hex2dec(s);
+    assert(m == n);
 end
 
 %% matmul and transpose %%


### PR DESCRIPTION
I realize that all other parseint tests are written using loops, so I am not sure my edit is appropriate. But if this PR is not accepted, then I think you should add comments in the code to explain why it is written as it is, because it really stands out in the performance comparison table for matlab. It might also be a good idea to have a link to a document explaining the philosophy of each test.

Another option which would keep the loop, but still make it faster would be to use sprintf/scanf instead of dec2hex:

``` matlab
function n = parseintperf(t)
for i = 1:t
    n = randi([0,2^32-1],1,'uint32');
    s = sprintf('%08x',n);
    m = sscanf(s,'%8x');
    assert(m == n);
end
end
```

Performance Comparisons

dec2hex/hex2dec with loop: matlab,parse_int,214.96379052
**dec2hex/hex2dec no loop: matlab,parse_int,2.49963863**
sprintf/scanf with loop: matlab,parse_int,67.90164638
`
