### PR TITLE
Faster matlab parseintperf

### DIFF
--- a/test/perf/micro/perf.m
+++ b/test/perf/micro/perf.m
@@ -92,8 +92,8 @@ end
 function n = parseintperf(t)
     for i = 1:t
         n = randi([0,2^32-1],1,'uint32');
-        s = dec2hex(n);
-        m = hex2dec(s);
+        s = sprintf('%08X',n);
+        m = sscanf(s,'%X');
         assert(m == n);
     end
 end


### PR DESCRIPTION
sprintf/sscanf are much faster than dec2hex/hex2dec which have lots of input checking.

**performance impact: 5.6x** 

**Before:** matlab,parse_int,224.24132012
**After:** matlab,parse_int,40.78281241
