### PR TITLE
propagate errors on wait(::RemoteRef) and remotecall_wait

### DIFF
--- a/base/multi.jl
+++ b/base/multi.jl
@@ -749,8 +749,9 @@ function remotecall_wait(f, w::Worker, args...)
     rv.waitingfor = w.id
     rr = RemoteRef(w)
     send_msg(w, CallWaitMsg(f, args, rr2id(rr), prid))
-    wait(rv)
+    v = fetch(rv.c)
     delete!(PGRP.refs, prid)
+    isa(v, RemoteException) && throw(v)
     rr
 end
 
@@ -783,8 +784,18 @@ function call_on_owner(f, rr::RemoteRef, args...)
     end
 end
 
-wait_ref(rid, args...) = (wait(lookup_ref(rid).c, args...); nothing)
-wait(r::RemoteRef, args...) = (call_on_owner(wait_ref, r, args...); r)
+function wait_ref(rid, callee, args...)
+    v = fetch_ref(rid, args...)
+    if isa(v, RemoteException)
+        if myid() == callee
+            throw(v)
+        else
+            return v
+        end
+    end
+    nothing
+end
+wait(r::RemoteRef, args...) = (call_on_owner(wait_ref, r, myid(), args...); r)
 
 fetch_ref(rid, args...) = fetch(lookup_ref(rid).c, args...)
 fetch(r::RemoteRef, args...) = call_on_owner(fetch_ref, r, args...)
@@ -796,8 +807,12 @@ put_ref(rid, args...) = put!(lookup_ref(rid), args...)
 put!(rr::RemoteRef, args...) = (call_on_owner(put_ref, rr, args...); rr)
 
 take!(rv::RemoteValue, args...) = take!(rv.c, args...)
-take_ref(rid, args...) = take!(lookup_ref(rid), args...)
-take!(rr::RemoteRef, args...) = call_on_owner(take_ref, rr, args...)
+function take_ref(rid, callee, args...)
+    v=take!(lookup_ref(rid), args...)
+    isa(v, RemoteException) && (myid() == callee) && throw(v)
+    v
+end
+take!(rr::RemoteRef, args...) = call_on_owner(take_ref, rr, myid(), args...)
 
 close_ref(rid) = (close(lookup_ref(rid).c); nothing)
 close(rr::RemoteRef) = call_on_owner(close_ref, rr)
@@ -805,10 +820,10 @@ close(rr::RemoteRef) = call_on_owner(close_ref, rr)
 
 function deliver_result(sock::IO, msg, oid, value)
     #print("$(myid()) sending result $oid\n")
-    if is(msg,:call_fetch)
+    if is(msg,:call_fetch) || isa(value, RemoteException)
         val = value
     else
-        val = oid
+        val = :OK
     end
     try
         send_msg_now(sock, ResultMsg(oid, val))
@@ -903,7 +918,7 @@ end
 function handle_msg(msg::CallWaitMsg, r_stream, w_stream)
     @schedule begin
         rv = schedule_call(msg.response_oid, ()->msg.f(msg.args...))
-        deliver_result(w_stream, :call_wait, msg.notify_oid, wait(rv))
+        deliver_result(w_stream, :call_wait, msg.notify_oid, fetch(rv.c))
     end
 end
 


### PR DESCRIPTION
closes #13730 

With this patch and `julia -p 1`:

```
julia> t = 0.0
0.0

julia> @sync @parallel for i=1:10
           t.nonexistent
       end
ERROR: On worker 2:
type Float64 has no field nonexistent
 [inlined code] from none:2
 in anonymous at no file:0
 in anonymous at multi.jl:1348
 in anonymous at multi.jl:899
 in run_work_thunk at multi.jl:651
 in run_work_thunk at multi.jl:660
 in anonymous at task.jl:54
 in remotecall_fetch at multi.jl:737
 [inlined code] from multi.jl:373
 in call_on_owner at multi.jl:783
 in wait at multi.jl:791
 in sync_end at ./task.jl:396

julia> pmap(x->t.nonexistent, [0,1,2])
1-element Array{Any,1}:
 RemoteException(2,CapturedException(UndefVarError(:t),Any[(:anonymous,:none,1,symbol(""),-1,1),(:anonymous,symbol("multi.jl"),902,symbol(""),-1,1),(:run_work_thunk,symbol("multi.jl"),651,symbol(""),-1,1),(:anonymous,symbol("multi.jl"),902,symbol("task.jl"),59,1)]))

julia> pmap(x->t.nonexistent, [0,1,2]; err_stop=true)
1-element Array{Any,1}:
 RemoteException(2,CapturedException(UndefVarError(:t),Any[(:anonymous,:none,1,symbol(""),-1,1),(:anonymous,symbol("multi.jl"),902,symbol(""),-1,1),(:run_work_thunk,symbol("multi.jl"),651,symbol(""),-1,1),(:anonymous,symbol("multi.jl"),902,symbol("task.jl"),59,1)]))
```

`@parallel` prints an error.

`pmap` returns the exception objects as before.
