### PR TITLE
Implement 2d-indexing in mandelperf for matlab

### DIFF
--- a/test/perf/micro/perf.m
+++ b/test/perf/micro/perf.m
@@ -119,14 +119,14 @@ function n = mandel(z)
 end
 
 function M = mandelperf(ignore)
-  M = zeros(length(-2.0:.1:0.5), length(-1:.1:1));
-  count = 1;
-  for r = -2:0.1:0.5
-    for i = -1:.1:1
-      M(count) = mandel(complex(r,i));
-      count = count + 1;
+    x=-2.0:.1:0.5;
+    y=-1:.1:1;
+    M=zeros(length(y),length(x));
+    for r=1:size(M,1) 
+        for c=1:size(M,2)
+           M(r,c) = mandel(x(c)+y(r)*i);
+        end
     end
-  end
 end
 
 %% numeric vector quicksort %%


### PR DESCRIPTION
A faster version of mandelperf for matlab implemented using 2d-indexing as planned (see #13673), and avoiding calls to meshgrid (see #13742).

**Performance impact:**
BEFORE: matlab,mandel,19.46211369
AFTER: matlab,mandel,7.37917273
