### PR TITLE
Improve generated debug info to avoid assertion in SROA

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -345,8 +345,13 @@ static DIType *julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxe
 static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed = false)
 #endif
 {
-    if (jl_is_abstracttype(jt) || !jl_is_datatype(jt) || !jl_isbits(jt) || isboxed)
+    if (isboxed)
         return jl_pvalue_dillvmt;
+    if (jl_is_abstracttype(jt) || jl_is_uniontype(jt) || jl_is_array_type(jt))
+        return jl_pvalue_dillvmt;
+    if (jl_is_typector(jt) || jl_is_typevar(jt))
+        return jl_pvalue_dillvmt;
+    assert(jl_is_datatype(jt));
     jl_datatype_t *jdt = (jl_datatype_t*)jt;
     if (jdt->ditype != NULL) {
 #ifdef LLVM37
@@ -356,17 +361,45 @@ static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed
 #endif
     }
     if (jl_is_bitstype(jt)) {
+        uint64_t SizeInBits = jdt == jl_bool_type ? 1 : 8*jdt->size;
     #ifdef LLVM37
-        llvm::DIType *t = dbuilder->createBasicType(jdt->name->name->name,jdt->size,jdt->alignment,llvm::dwarf::DW_ATE_unsigned);
+        llvm::DIType *t = dbuilder->createBasicType(jdt->name->name->name,SizeInBits,8*jdt->alignment,llvm::dwarf::DW_ATE_unsigned);
         jdt->ditype = t;
         return t;
     #else
-        DIType t = dbuilder->createBasicType(jdt->name->name->name,jdt->size,jdt->alignment,llvm::dwarf::DW_ATE_unsigned);
+        DIType t = dbuilder->createBasicType(jdt->name->name->name,SizeInBits,8*jdt->alignment,llvm::dwarf::DW_ATE_unsigned);
         MDNode *M = t;
         jdt->ditype = M;
         return t;
     #endif
     }
+    #ifdef LLVM37
+    else if (jl_is_tuple_type(jt) || jl_is_structtype(jt)) {
+        jl_datatype_t *jst = (jl_datatype_t*)jt;
+        size_t ntypes = jl_datatype_nfields(jst);
+        llvm::DICompositeType *ct = dbuilder->createStructType(
+            NULL,                       // Scope
+            jdt->name->name->name,      // Name
+            NULL,                       // File
+            0,                          // LineNumber
+            8*jdt->size,                // SizeInBits
+            8*jdt->alignment,           // AlignmentInBits
+            0,                          // Flags
+            NULL,                       // DerivedFrom
+            DINodeArray(),              // Elements
+            dwarf::DW_LANG_Julia        // RuntimeLanguage
+            );
+        jdt->ditype = ct;
+        std::vector<llvm::Metadata*> Elements;
+        for(unsigned i = 0; i < ntypes; i++)
+            Elements.push_back(julia_type_to_di(jl_svecref(jst->types,i),dbuilder,false));
+        dbuilder->replaceArrays(ct, dbuilder->getOrCreateArray(ArrayRef<Metadata*>(Elements)));
+        return ct;
+    } else {
+        jdt->ditype = dbuilder->createTypedef(jl_pvalue_dillvmt, jdt->name->name->name, NULL, 0, NULL);
+        return (llvm::DIType*)jdt->ditype;
+    }
+    #endif
     // TODO: Fixme
     return jl_pvalue_dillvmt;
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4507,7 +4507,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                 topfile,                            // File
                 toplineno == -1 ? 0 : toplineno,  // Line
                 // Variable type
-                julia_type_to_di(varinfo.value.typ,ctx.dbuilder,specsig));
+                julia_type_to_di(varinfo.value.typ,ctx.dbuilder,false));
 #else
             varinfo.dinfo = ctx.dbuilder->createLocalVariable(
                 llvm::dwarf::DW_TAG_arg_variable,    // Tag
@@ -4515,7 +4515,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                 argname->name,    // Variable name
                 topfile,                    // File
                 toplineno == -1 ? 0 : toplineno,             // Line (for now, use lineno of the function)
-                julia_type_to_di(varinfo.value.typ, ctx.dbuilder, specsig), // Variable type
+                julia_type_to_di(varinfo.value.typ, ctx.dbuilder,false), // Variable type
                 false,                  // May be optimized out
                 0,                      // Flags (TODO: Do we need any)
                 ctx.sret + i + 1);                   // Argument number (1-based)
@@ -4558,7 +4558,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                 s->name,                // Variable name
                 topfile,                 // File
                 toplineno == -1 ? 0 : toplineno, // Line (for now, use lineno of the function)
-                julia_type_to_di(varinfo.value.typ, ctx.dbuilder, specsig), // Variable type
+                julia_type_to_di(varinfo.value.typ, ctx.dbuilder, false), // Variable type
                 false,                  // May be optimized out
                 0                       // Flags (TODO: Do we need any)
 #ifndef LLVM38
@@ -4582,7 +4582,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                 vname->name,            // Variable name
                 topfile,                 // File
                 toplineno == -1 ? 0 : toplineno, // Line (for now, use lineno of the function)
-                julia_type_to_di(varinfo.value.typ, ctx.dbuilder, specsig), // Variable type
+                julia_type_to_di(varinfo.value.typ, ctx.dbuilder, false), // Variable type
                 false,                  // May be optimized out
                 0                       // Flags (TODO: Do we need any)
 #ifndef LLVM38
@@ -4616,7 +4616,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                 SmallVector<int64_t, 9> addr;
                 addr.push_back(llvm::dwarf::DW_OP_plus);
                 addr.push_back(i * sizeof(void*));
-                //addr.push_back(llvm::dwarf::DW_OP_deref);
+                addr.push_back(llvm::dwarf::DW_OP_deref);
 #ifdef LLVM37
                 ctx.dbuilder->insertDbgValueIntrinsic(argArray, 0, ctx.vars[s].dinfo,
                 ctx.dbuilder->createExpression(addr),
@@ -5879,7 +5879,6 @@ static void init_julia_llvm_env(Module *m)
     FPM->add(createInstructionCombiningPass());  // Clean up after loop vectorizer
 #endif
     //FPM->add(createCFGSimplificationPass());     // Merge & remove BBs
-
     FPM->doInitialization();
 }
 


### PR DESCRIPTION
This is a very simple start on emitting more thorough debug info. I was planning (and still am) to work on this as part of a larger push to improve our generated debug info, but at the moment SROA is crashing on 3.7 (#13754), because our debug info is not quite valid. Interestingly, I can still see a crash if I run the system image that results from this through bugpoint, the optimizer still crashes, so we might be hitting another LLVM bug here. Bootstrap goes through fine with this though.
