### PR TITLE
Backport some LLVM API changes (+ related functionality) to 0.4

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -583,36 +583,33 @@ ifneq ($(LLVM_LLDB_TAR),)
 	mkdir -p llvm-$(LLVM_VER)/tools/lldb && \
 	$(TAR) -C llvm-$(LLVM_VER)/tools/lldb --strip-components 1 -xf $(LLVM_LLDB_TAR)
 endif # LLVM_LLDB_TAR
-else
-ifeq ($(BUILD_LLVM_CLANG),1)
-	([ ! -d llvm-$(LLVM_VER)/tools/clang ] && \
-		git clone $(LLVM_GIT_URL_CLANG) llvm-$(LLVM_VER)/tools/clang  ) || \
-		(cd llvm-$(LLVM_VER)/tools/clang  && \
-		git pull --ff-only)
-endif # BUILD_LLVM_CLANG
-ifeq ($(BUILD_LLDB),1)
-	([ ! -d llvm-$(LLVM_VER)/tools/lldb ] && \
-		git clone $(LLVM_GIT_URL_LLDB) llvm-$(LLVM_VER)/tools/lldb  ) || \
-		(cd llvm-$(LLVM_VER)/tools/lldb  && \
-		git pull --ff-only)
-endif # BUILD_LLDB
-endif # LLVM_VER
-ifeq ($(LLVM_VER),svn)
+else # LLVM_VER
 ifeq ($(BUILD_LLVM_CLANG),1)
 	([ ! -d llvm-$(LLVM_VER)/tools/clang ] && \
 		git clone $(LLVM_GIT_URL_CLANG) llvm-$(LLVM_VER)/tools/clang  ) || \
 		(cd llvm-$(LLVM_VER)/tools/clang  && \
 		git pull --ff-only)
 	([ ! -d llvm-$(LLVM_VER)/projects/compiler-rt ] && \
-		git clone $(LLVM_GIT_URL_COMPILER_RT) llvm-$(LLVM_VER)/projects/compiler-rt  ) || \
-		(cd llvm-$(LLVM_VER)/projects/compiler-rt  && \
-		git pull --ff-only)
-ifneq ($(LLVM_CLANG_VER),)
-	(cd llvm-$(LLVM_VER) && \
-		git checkout $(LLVM_GIT_VER))
-endif # LLVM_CLANG_VER
+                git clone $(LLVM_GIT_URL_COMPILER_RT) llvm-$(LLVM_VER)/projects/compiler-rt  ) || \
+                (cd llvm-$(LLVM_VER)/projects/compiler-rt  && \
+                git pull --ff-only)
+ifneq ($(LLVM_GIT_VER_CLANG),)
+	(cd llvm-$(LLVM_VER)/tools/clang && \
+		git checkout $(LLVM_GIT_VER_CLANG))
+endif # LLVM_GIT_VER_CLANG
 endif # BUILD_LLVM_CLANG
+ifeq ($(BUILD_LLDB),1)
+	([ ! -d llvm-$(LLVM_VER)/tools/lldb ] && \
+		git clone $(LLVM_GIT_URL_LLDB) llvm-$(LLVM_VER)/tools/lldb  ) || \
+		(cd llvm-$(LLVM_VER)/tools/lldb  && \
+		git pull --ff-only)
+ifneq ($(LLVM_GIT_VER_LLDB),)
+	(cd $(LLVM_VER)/tools/lldb && \
+		git checkout $(LLVM_GIT_VER_LLDB))
+endif # LLVM_GIT_VER_CLANG
+endif # BUILD_LLDB
 endif # LLVM_VER
+	touch -c $@
 
 # Apply version-specific LLVM patches
 ifeq ($(LLVM_VER),3.3)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -463,7 +463,11 @@ static void jl_dump_shadow(char *fname, int jit_model, const char *sysimg_data, 
         CodeGenOpt::Aggressive // -O3
         ));
 
+#ifdef LLVM38
+    legacy::PassManager PM;
+#else
     PassManager PM;
+#endif
     if (!dump_as_bc) {
 #ifndef LLVM37
         PM.add(new TargetLibraryInfo(Triple(TM->getTargetTriple())));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4243,7 +4243,9 @@ static Function *emit_function(jl_lambda_info_t *lam)
                     continue;
                 ditypes.push_back(julia_type_to_di(jl_tparam(lam->specTypes,i),ctx.dbuilder,false));
             }
-#ifdef LLVM36
+#ifdef LLVM38
+            subrty = ctx.dbuilder->createSubroutineType(ctx.dbuilder->getOrCreateTypeArray(ditypes));
+#elif defined(LLVM36)
             subrty = ctx.dbuilder->createSubroutineType(topfile,ctx.dbuilder->getOrCreateTypeArray(ditypes));
 #else
             subrty = ctx.dbuilder->createSubroutineType(topfile,ctx.dbuilder->getOrCreateArray(ditypes));
@@ -5029,7 +5031,10 @@ static void init_julia_llvm_env(Module *m)
     // Third argument (length(argv))
     diargs.push_back(julia_type_to_di((jl_value_t*)jl_int32_type,&dbuilder,false));
 
-#ifdef LLVM36
+#ifdef LLVM38
+    jl_di_func_sig = dbuilder.createSubroutineType(
+        dbuilder.getOrCreateTypeArray(diargs));
+#elif defined(LLVM36)
     jl_di_func_sig = dbuilder.createSubroutineType(julia_h,
         dbuilder.getOrCreateTypeArray(diargs));
 #else

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5636,6 +5636,50 @@ static void init_julia_llvm_env(Module *m)
     FPM->doInitialization();
 }
 
+// Helper to figure out what features to set for the LLVM target
+// If the user specifies native ( or does not specify ) we default
+// using the API provided by LLVM
+static inline SmallVector<std::string,10> getTargetFeatures() {
+  StringMap<bool> HostFeatures;
+  if( !strcmp(jl_options.cpu_target,"native") )
+  {
+    // On earlier versions of LLVM this is empty
+    llvm::sys::getHostCPUFeatures(HostFeatures);
+  }
+
+  // Platform specific overides follow
+#if defined(_CPU_X86_64_) || defined(_CPU_X86_)
+#ifndef USE_MCJIT
+    // Temporarily disable Haswell BMI2 features due to LLVM bug.
+  HostFeatures["bmi2"] = false;
+  HostFeatures["avx2"] = false;
+#endif
+#ifdef V128_BUG
+  HostFeatures["avx"] = false;
+#endif
+#endif
+
+  // Figure out if we know the cpu_target
+  std::string cpu = strcmp(jl_options.cpu_target,"native") ? jl_options.cpu_target : sys::getHostCPUName();
+  if (cpu.empty() || cpu == "generic") {
+    jl_printf(JL_STDERR, "WARNING: unable to determine host cpu name.\n");
+#ifdef _CPU_ARM_
+    // Check if this is required when you have read the features directly from the processor
+    // the processors that don't have VFP are old and (hopefully) rare. this affects the platform calling convention.
+    HostFeatures["vfp2"] = true;
+#endif
+  }
+
+  SmallVector<std::string,10> attr;
+  for( StringMap<bool>::const_iterator it = HostFeatures.begin(); it != HostFeatures.end(); it++  )
+  {
+    std::string att = it->getValue() ? it->getKey().str() :
+                      std::string("-") + it->getKey().str();
+    attr.append( 1, att );
+  }
+  return attr;
+}
+
 extern "C" void jl_init_codegen(void)
 {
 #if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
@@ -5701,19 +5745,7 @@ extern "C" void jl_init_codegen(void)
 #ifdef USE_MCJIT
     jl_mcjmm = new SectionMemoryManager();
 #endif
-    const char *mattr[] = {
-#if defined(_CPU_X86_64_) || defined(_CPU_X86_)
-#ifndef USE_MCJIT
-        // Temporarily disable Haswell BMI2 features due to LLVM bug.
-        "-bmi2", "-avx2",
-#endif
-#ifdef V128_BUG
-        "-avx",
-#endif
-#endif
-        "", // padding to make sure this isn't an empty array (ref #11817)
-    };
-    SmallVector<std::string, 4> MAttrs(mattr, mattr+sizeof(mattr)/sizeof(mattr[0]));
+
 #ifdef LLVM36
     EngineBuilder eb(std::move(std::unique_ptr<Module>(engine_module)));
 #else
@@ -5747,17 +5779,12 @@ extern "C" void jl_init_codegen(void)
 #endif
 #endif
     std::string TheCPU = strcmp(jl_options.cpu_target,"native") ? jl_options.cpu_target : sys::getHostCPUName();
-    if (TheCPU.empty() || TheCPU == "generic") {
-        jl_printf(JL_STDERR, "WARNING: unable to determine host cpu name.\n");
-#ifdef _CPU_ARM_
-        MAttrs.append(1, "+vfp2"); // the processors that don't have VFP are old and (hopefully) rare. this affects the platform calling convention.
-#endif
-    }
+    SmallVector<std::string, 10>  targetFeatures = getTargetFeatures( );
     TargetMachine *targetMachine = eb.selectTarget(
             TheTriple,
             "",
             TheCPU,
-            MAttrs);
+            targetFeatures);
     assert(targetMachine && "Failed to select target machine -"
                             " Is the LLVM backend for this CPU enabled?");
     jl_TargetMachine = targetMachine->getTarget().createTargetMachine(


### PR DESCRIPTION
This is a backported version of some of the more recent LLVM 3.8 API changes, as well as the initialization bug found by @mdcfrancis. With this people should be able to build Cxx.jl against 0.4(.1 when that's released).
