### PR TITLE
RFC: add `foreach` function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,9 @@ Library improvements
       appropriate. The `sparsevec` function returns a one-dimensional sparse
       vector instead of a one-column sparse matrix. ([#13440])
 
+  * New `foreach` function for calling a function on every element of a collection when
+    the results are not needed.
+
 Deprecated or removed
 ---------------------
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1137,6 +1137,16 @@ end
 
 ## iteration utilities ##
 
+doc"""
+    foreach(f, c...) -> Void
+
+Call function `f` on each element of iterable `c`.
+For multiple iterable arguments, `f` is called elementwise.
+"""
+foreach(f) = (f(); nothing)
+foreach(f, itr) = (for x in itr; f(x); end; nothing)
+foreach(f, itrs...) = (for z in zip(itrs...); f(z...); end; nothing)
+
 # generic map on any iterator
 function map(f, iters...)
     result = []

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1142,6 +1142,8 @@ doc"""
 
 Call function `f` on each element of iterable `c`.
 For multiple iterable arguments, `f` is called elementwise.
+`foreach` should be used instead of `map` when the results of `f` are not
+needed, for example in `foreach(println, array)`.
 """
 foreach(f) = (f(); nothing)
 foreach(f, itr) = (for x in itr; f(x); end; nothing)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -753,6 +753,7 @@ export
     filter,
     foldl,
     foldr,
+    foreach,
     get,
     get!,
     getindex,

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -138,3 +138,16 @@ let i = 0
         i <= 10 || break
     end
 end
+
+# foreach
+let
+    a = []
+    foreach(()->push!(a,0))
+    @test a == [0]
+    a = []
+    foreach(x->push!(a,x), [1,5,10])
+    @test a == [1,5,10]
+    a = []
+    foreach((args...)->push!(a,args), [2,4,6], [10,20,30])
+    @test a == [(2,10),(4,20),(6,30)]
+end


### PR DESCRIPTION
A few times I have seen `map` used with a function called only for side effects, for example `map(println, x)`. This returns a noisy and unnecessary array of nothings. I think we should have a `foreach` function (ala Scheme) for cases like this.
