### PR TITLE
Deal with some race conditions in mkpath

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -47,7 +47,17 @@ function mkpath(path::AbstractString, mode::Unsigned=0o777)
     dir = dirname(path)
     (path == dir || isdir(path)) && return
     mkpath(dir, mode)
-    mkdir(path, mode)
+    try
+        mkdir(path, mode)
+    # If there is a problem with making the directory, but the directory
+    # does in fact exist, then ignore the error. Else re-throw it.
+    catch err
+        if isa(err, SystemError) && isdir(path)
+            return
+        else
+            rethrow()
+        end
+    end
 end
 
 mkdir(path::AbstractString, mode::Signed) = throw(ArgumentError("mode must be an unsigned integer; try 0o$mode"))


### PR DESCRIPTION
From my commit message:
Although mkpath checks to see which parent directories need to be
created, there is a race condition from the time of that check and the
actual creation of directories. In the event another process creates one
of those directories during that time, this commit will suppress the
mkdir error due to the file already existing. Addresses issue #13094.

Additionally:
As mentioned on the issue thread, it's impossible to prevent all race conditions in this situation, but I think this is a reasonable place to stop. If some other process creates one of the intended directories, then great, no error should occur. On the other hand, if the other process _deletes_ one of the directories, then an error is a good thing in my opinion.
