### PR TITLE
for dl handles, remove the half-hearted indirection through libuv

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -43,10 +43,7 @@ dlopen_e(s::AbstractString, flags::Integer = RTLD_LAZY | RTLD_DEEPBIND) =
     ccall(:jl_load_dynamic_library_e, Ptr{Void}, (Cstring,UInt32), s, flags)
 
 function dlclose(p::Ptr)
-    if p != C_NULL
-        ccall(:uv_dlclose,Void,(Ptr{Void},),p)
-        Libc.free(p)
-    end
+    0 == ccall(:jl_dlclose, Cint, (Ptr{Void},), p)
 end
 
 function find_library(libnames::Vector, extrapaths::Vector=ASCIIString[])

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -378,7 +378,7 @@ static DIType julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxed
 
 // --- emitting pointers directly into code ---
 
-static Value *literal_static_pointer_val(void *p, Type *t)
+static Value *literal_static_pointer_val(const void *p, Type *t)
 {
     // this function will emit a static pointer into the generated code
     // the generated code will only be valid during the current session,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -997,7 +997,7 @@ static Function *to_function(jl_lambda_info_t *li)
     JL_SIGATOMIC_END();
     if (dump_compiles_stream != NULL) {
         uint64_t this_time = jl_hrtime();
-        jl_printf(dump_compiles_stream, "%llu\t\"", (unsigned long long)(this_time-last_time));
+        jl_printf(dump_compiles_stream, "%" PRIu64 "\t\"", this_time - last_time);
         jl_static_show(dump_compiles_stream, (jl_value_t*)li);
         jl_printf(dump_compiles_stream, "\"\n");
         last_time = this_time;

--- a/src/dump.c
+++ b/src/dump.c
@@ -206,7 +206,7 @@ extern void jl_cpuid(int32_t CPUInfo[4], int32_t InfoType);
 #endif
 
 extern int globalUnique;
-uv_lib_t *jl_sysimg_handle = NULL;
+void *jl_sysimg_handle = NULL;
 uint64_t jl_sysimage_base = 0;
 #ifdef _OS_WINDOWS_
 #include <dbghelp.h>
@@ -254,7 +254,7 @@ static int jl_load_sysimg_so()
 #endif
 
 #ifdef _OS_WINDOWS_
-        jl_sysimage_base = (intptr_t)jl_sysimg_handle->handle;
+        jl_sysimage_base = (intptr_t)jl_sysimg_handle;
 #else
         if (dladdr((void*)sysimg_gvars, &dlinfo) != 0) {
             jl_sysimage_base = (intptr_t)dlinfo.dli_fbase;
@@ -1838,7 +1838,7 @@ DLLEXPORT void jl_preload_sysimg_so(const char *fname)
     }
 
     // Get handle to sys.so
-    jl_sysimg_handle = (uv_lib_t*)jl_load_dynamic_library_e(fname_shlib, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
+    jl_sysimg_handle = jl_load_dynamic_library_e(fname_shlib, JL_RTLD_DEFAULT | JL_RTLD_GLOBAL);
 
     // set cpu target if unspecified by user and available from sysimg
     // otherwise default to native.

--- a/src/julia.h
+++ b/src/julia.h
@@ -1233,13 +1233,14 @@ enum JL_RTLD_CONSTANT {
 };
 #define JL_RTLD_DEFAULT (JL_RTLD_LAZY | JL_RTLD_DEEPBIND)
 
-typedef void *jl_uv_libhandle; // uv_lib_t* (avoid uv.h dependency)
+typedef void *jl_uv_libhandle; // compatible with dlopen (void*) / LoadLibrary (HMODULE)
 DLLEXPORT jl_uv_libhandle jl_load_dynamic_library(const char *fname, unsigned flags);
 DLLEXPORT jl_uv_libhandle jl_load_dynamic_library_e(const char *fname, unsigned flags);
+DLLEXPORT jl_uv_libhandle jl_dlopen(const char *filename, unsigned flags);
+DLLEXPORT int jl_dlclose(jl_uv_libhandle handle);
 DLLEXPORT void *jl_dlsym_e(jl_uv_libhandle handle, const char *symbol);
 DLLEXPORT void *jl_dlsym(jl_uv_libhandle handle, const char *symbol);
-DLLEXPORT int jl_uv_dlopen(const char *filename, jl_uv_libhandle lib, unsigned flags);
-char *jl_dlfind_win32(const char *name);
+const char *jl_dlfind_win32(const char *name);
 DLLEXPORT int add_library_mapping(char *lib, void *hnd);
 
 #if defined(__linux__) || defined(__FreeBSD__)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -204,18 +204,18 @@ static inline char *jl_copy_str(char **to, const char *from)
 DLLEXPORT uint64_t jl_hrtime(void);
 
 // libuv stuff:
-DLLEXPORT extern uv_lib_t *jl_dl_handle;
-DLLEXPORT extern uv_lib_t *jl_RTLD_DEFAULT_handle;
+DLLEXPORT extern void *jl_dl_handle;
+DLLEXPORT extern void *jl_RTLD_DEFAULT_handle;
 #if defined(_OS_WINDOWS_)
-DLLEXPORT extern uv_lib_t *jl_exe_handle;
-extern uv_lib_t *jl_ntdll_handle;
-extern uv_lib_t *jl_kernel32_handle;
-extern uv_lib_t *jl_crtdll_handle;
-extern uv_lib_t *jl_winsock_handle;
+DLLEXPORT extern void *jl_exe_handle;
+extern void *jl_ntdll_handle;
+extern void *jl_kernel32_handle;
+extern void *jl_crtdll_handle;
+extern void *jl_winsock_handle;
 #endif
 
-uv_lib_t *jl_get_library(char *f_lib);
-DLLEXPORT void *jl_load_and_lookup(char *f_lib, char *f_name, uv_lib_t **hnd);
+void *jl_get_library(const char *f_lib);
+DLLEXPORT void *jl_load_and_lookup(const char *f_lib, const char *f_name, void **hnd);
 
 
 // libuv wrappers:

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -335,7 +335,8 @@ DLLEXPORT void jl_profile_stop_timer(void)
 void jl_install_default_signal_handlers(void)
 {
     ULONG StackSizeInBytes = sig_stack_size;
-    if (uv_dlsym(jl_kernel32_handle, "SetThreadStackGuarantee", (void**)&pSetThreadStackGuarantee) || !pSetThreadStackGuarantee(&StackSizeInBytes))
+    pSetThreadStackGuarantee = jl_dlsym_e(jl_kernel32_handle, "SetThreadStackGuarantee");
+    if (!pSetThreadStackGuarantee || !pSetThreadStackGuarantee(&StackSizeInBytes))
         pSetThreadStackGuarantee = NULL;
     if (signal(SIGFPE, (void (__cdecl *)(int))crt_sig_handler) == SIG_ERR) {
         jl_error("fatal error: Couldn't set SIGFPE");


### PR DESCRIPTION
we were already bypassing libuv for linux dlopen, this just removes the extra little bit of memory for the indirection and the complication of trying to malloc/free it and adds a statement that Julia's Libdl handles are exactly the same as the OS handle.

---

the only problem I know this will cause is for BinDeps, where it tried to be clever and do a direct ccall to a function that will no longer exist (https://github.com/JuliaLang/BinDeps.jl/blob/e35913637c1c30149bcc7bdba5bd5ebede711efa/src/dependencies.jl#L510-L519l)
