### PR TITLE
Implement reuseaddr for UDPSocket

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -423,7 +423,7 @@ _bind(sock::UDPSocket, host::IPv4, port::UInt16, flags::UInt32 = UInt32(0)) = cc
 _bind(sock::UDPSocket, host::IPv6, port::UInt16, flags::UInt32 = UInt32(0)) = ccall(:jl_udp_bind6, Int32, (Ptr{Void}, UInt16, Ptr{UInt128}, UInt32),
             sock.handle, hton(port), Ref(hton(host.host)), flags)
 
-function bind(sock::Union{TCPServer, UDPSocket}, host::IPAddr, port::Integer; ipv6only = false, reuseaddr = false)
+function bind(sock::Union{TCPServer, UDPSocket}, host::IPAddr, port::Integer; ipv6only = false, reuseaddr = false, kws...)
     if sock.status != StatusInit
         error("$(typeof(sock)) is not initialized")
     end
@@ -444,6 +444,7 @@ function bind(sock::Union{TCPServer, UDPSocket}, host::IPAddr, port::Integer; ip
         end
     end
     sock.status = StatusOpen
+    isa(sock, UDPSocket) && setopt(sock; kws...)
     true
 end
 

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -238,3 +238,20 @@ begin
     close(csock)
     close(sock)
 end
+
+# Local-machine multicast
+
+let
+    function create_socket()
+        s = UDPSocket()
+        bind(s, ip"0.0.0.0", 2000, reuseaddr = true, enable_broadcast = true)
+        s
+    end
+    a, b, c = [create_socket() for i = 1:3]
+    @sync begin
+        recvs = [@async @test bytestring(recv(s)) == "hello" for s in (a, b)]
+        send(c, ip"255.255.255.255", 2000, "hello")
+        map(wait, recvs)
+    end
+    [close(s) for s in [a, b, c]]
+end


### PR DESCRIPTION
This patch implements UDP address reuse via the [appropriate libuv flag](http://docs.libuv.org/en/v1.x/udp.html). Happy to bike shed the name of the option; I originally went with `reuse` but wasn't sure if that was specific enough.
