### PR TITLE
Reductions shouldn't overflow for LinearSlow arrays

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -36,10 +36,10 @@ function mapfoldl_impl(f, op, v0, itr, i)
     # Unroll the while loop once; if v0 is known, the call to op may
     # be evaluated at compile time
     if done(itr, i)
-        return v0
+        return r_promote(op, v0)
     else
         (x, i) = next(itr, i)
-        v = op(v0, f(x))
+        v = op(r_promote(op, v0), f(x))
         while !done(itr, i)
             (x, i) = next(itr, i)
             v = op(v, f(x))
@@ -71,10 +71,10 @@ function mapfoldr_impl(f, op, v0, itr, i::Integer)
     # Unroll the while loop once; if v0 is known, the call to op may
     # be evaluated at compile time
     if i == 0
-        return v0
+        return r_promote(op, v0)
     else
         x = itr[i]
-        v  = op(f(x), v0)
+        v  = op(f(x), r_promote(op, v0))
         while i > 1
             x = itr[i -= 1]
             v = op(f(x), v)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -271,6 +271,14 @@ end
 @test sum(collect(map(UInt8,0:255))) == 32640
 @test sum(collect(map(UInt8,254:255))) == 509
 
+A = reshape(map(UInt8, 101:109), (3,3))
+@test @inferred(sum(A)) == 945
+@test @inferred(sum(sub(A, 1:3, 1:3))) == 945
+
+A = reshape(map(UInt8, 1:100), (10,10))
+@test @inferred(sum(A)) == 5050
+@test @inferred(sum(sub(A, 1:10, 1:10))) == 5050
+
 # issue #11618
 @test sum([-0.0]) === -0.0
 @test sum([-0.0, -0.0]) === -0.0


### PR DESCRIPTION
Talk about embarrassing:

``` jl
julia> A = reshape(map(UInt8, 101:109), (3,3))
3x3 Array{UInt8,2}:                                                                                                                                                                                                                                                            
 0x65  0x68  0x6b                                                                                                                                                                                                                                                              
 0x66  0x69  0x6c                                                                                                                                                                                                                                                              
 0x67  0x6a  0x6d                                                                                                                                                                                                                                                              

julia> sum(A)
0x00000000000003b1                                                                                                                                                                                                                                                             

julia> sum(sub(A, 1:3, 1:3))
0xb1
```

I can't believe no one (first and foremost, myself) has caught this; we've had it since #8420 was merged. As someone who has been writing/prodding at related code for quite a while, I am ashamed.
