### PR TITLE
Don't throw an error when reflecting on multiple methods 

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -3,7 +3,7 @@
 # parameters limiting potentially-infinite types
 const MAX_TYPEUNION_LEN = 3
 const MAX_TYPE_DEPTH = 7
-const MAX_TUPLETYPE_LEN  = 8
+const MAX_TUPLETYPE_LEN = 8
 const MAX_TUPLE_DEPTH = 4
 
 immutable NotFound


### PR DESCRIPTION
with an abstract type if any of those methods are staged

cc @andreasnoack 
