### PR TITLE
merge 2 versions (for GMP 5 & 6) of rand(::UnitRange{BigInt})

### DIFF
--- a/base/random.jl
+++ b/base/random.jl
@@ -593,10 +593,11 @@ for (T, U) in [(UInt8, UInt32), (UInt16, UInt32),
 end
 
 struct RangeGeneratorBigInt <: RangeGenerator
-    a::BigInt             # first
-    m::BigInt             # range length - 1
-    nlimbs::Int           # number of limbs in generated BigInt's
-    mask::Limb            # applied to the highest limb
+    a::BigInt         # first
+    m::BigInt         # range length - 1
+    nlimbs::Int       # number of limbs in generated BigInt's (z ∈ [0, m])
+    nlimbsmax::Int    # max number of limbs for z+a
+    mask::Limb        # applied to the highest limb
 end
 
 
@@ -607,7 +608,8 @@ function RangeGenerator(r::UnitRange{BigInt})
     nlimbs, highbits = divrem(nd, 8*sizeof(Limb))
     highbits > 0 && (nlimbs += 1)
     mask = highbits == 0 ? ~zero(Limb) : one(Limb)<<highbits - one(Limb)
-    return RangeGeneratorBigInt(first(r), m, nlimbs, mask)
+    nlimbsmax = max(nlimbs, abs(last(r).size), abs(first(r).size))
+    return RangeGeneratorBigInt(first(r), m, nlimbs, nlimbsmax, mask)
 end
 
 
@@ -638,7 +640,7 @@ function rand{T<:Integer, U<:Unsigned}(rng::AbstractRNG, g::RangeGeneratorInt{T,
 end
 
 function rand(rng::AbstractRNG, g::RangeGeneratorBigInt)
-    x = MPZ.realloc2(g.nlimbs*8*sizeof(Limb))
+    x = MPZ.realloc2(g.nlimbsmax*8*sizeof(Limb))
     limbs = unsafe_wrap(Array, x.d, g.nlimbs)
     while true
         rand!(rng, limbs)


### PR DESCRIPTION
I saw the error caused by incompatible GMP versions (run time vs compile time) reported few times on the lists, but technically the versions need to agree only for `rand(::UnitRange{BigInt})`, so this PR proposes to remove this constraint.
That said I'm not sure if different versions of GMP could reveal other installation problems, so I kept a warning, please comment on this point.
The second commit optimizes slightly the pre-allocation of the random BigInt in some cases (the speed gains are very modest). This is not related to GMP versions, and I could as well make another PR for that.
