### PR TITLE
replace length(x) == 0 with isempty(x), similarly for !isempty

### DIFF
--- a/base/LineEdit.jl
+++ b/base/LineEdit.jl
@@ -70,7 +70,7 @@ input_string(s::PromptState) = bytestring(s.input_buffer)
 input_string_newlines(s::PromptState) = count(c->(c == '\n'), input_string(s))
 function input_string_newlines_aftercursor(s::PromptState)
     str = input_string(s)
-    length(str) == 0 && return 0
+    isempty(str) && return 0
     rest = str[nextind(str, position(s.input_buffer)):end]
     return count(c->(c == '\n'), rest)
 end
@@ -143,7 +143,7 @@ end
 complete_line(s::MIState) = complete_line(s.mode_state[s.current_mode], s.key_repeats)
 function complete_line(s::PromptState, repeats)
     completions, partial, should_complete = complete_line(s.p.complete, s)
-    if length(completions) == 0
+    if isempty(completions)
         beep(terminal(s))
     elseif !should_complete
         # should_complete is false for cases where we only want to show
@@ -156,7 +156,7 @@ function complete_line(s::PromptState, repeats)
         edit_replace(s, position(s.input_buffer), prev_pos, completions[1])
     else
         p = common_prefix(completions)
-        if length(p) > 0 && p != partial
+        if !isempty(p) && p != partial
             # All possible completions share the same prefix, so we might as
             # well complete that
             prev_pos = position(s.input_buffer)

--- a/base/REPL.jl
+++ b/base/REPL.jl
@@ -385,7 +385,7 @@ function add_history(hist::REPLHistoryProvider, s)
     str = rstrip(bytestring(s.input_buffer))
     isempty(strip(str)) && return
     mode = mode_idx(hist, LineEdit.mode(s))
-    length(hist.history) > 0 &&
+    !isempty(hist.history) &&
         mode == hist.modes[end] && str == hist.history[end] && return
     push!(hist.modes, mode)
     push!(hist.history, str)
@@ -507,7 +507,7 @@ function history_move_prefix(s::LineEdit.PrefixSearchState,
         if (idx == max_idx) || (startswith(hist.history[idx], prefix) && (hist.history[idx] != cur_response || hist.modes[idx] != LineEdit.mode(s)))
             m = history_move(s, hist, idx)
             if m == :ok
-                if length(prefix) == 0
+                if isempty(prefix)
                     # on empty prefix search, move cursor to the end
                     LineEdit.move_input_end(s)
                 else

--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -122,7 +122,7 @@ function complete_path(path::AbstractString, pos)
     end
     local files
     try
-        if length(dir) == 0
+        if isempty(dir)
             files = readdir()
         elseif isdir(dir)
             files = readdir(dir)
@@ -146,7 +146,7 @@ function complete_path(path::AbstractString, pos)
     # The pos - endof(prefix) + 1 is correct due to `endof(prefix)-endof(prefix)==0`,
     # hence we need to add one to get the first index. This is also correct when considering
     # pos, because pos is the `endof` a larger string which `endswith(path)==true`.
-    return matches, startpos:pos, length(matches) > 0
+    return matches, startpos:pos, !isempty(matches)
 end
 
 # Determines whether method_complete should be tried. It should only be done if

--- a/base/ascii.jl
+++ b/base/ascii.jl
@@ -45,7 +45,7 @@ function string(c::ASCIIString...)
 end
 
 function ucfirst(s::ASCIIString)
-    if length(s) > 0 && 'a' <= s[1] <= 'z'
+    if !isempty(s) && 'a' <= s[1] <= 'z'
         t = ASCIIString(copy(s.data))
         t.data[1] -= 32
         return t
@@ -53,7 +53,7 @@ function ucfirst(s::ASCIIString)
     return s
 end
 function lcfirst(s::ASCIIString)
-    if length(s) > 0 && 'A' <= s[1] <= 'Z'
+    if !isempty(s) && 'A' <= s[1] <= 'Z'
         t = ASCIIString(copy(s.data))
         t.data[1] += 32
         return t

--- a/base/base64.jl
+++ b/base/base64.jl
@@ -179,7 +179,7 @@ type Base64DecodePipe <: IO
 end
 
 function read(b::Base64DecodePipe, t::Type{UInt8})
-    if length(b.cache) > 0
+    if !isempty(b.cache)
         return shift!(b.cache)
     else
         empty!(b.encvec)
@@ -193,7 +193,7 @@ function read(b::Base64DecodePipe, t::Type{UInt8})
     end
 end
 
-eof(b::Base64DecodePipe) = length(b.cache) == 0 && eof(b.io)
+eof(b::Base64DecodePipe) = isempty(b.cache) && eof(b.io)
 close(b::Base64DecodePipe) = nothing
 
 # Decodes a base64-encoded string

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -224,7 +224,7 @@ similar(B::BitArray, T::Type, dims::Dims) = Array(T, dims)
 
 function fill!(B::BitArray, x)
     y = convert(Bool, x)
-    length(B) == 0 && return B
+    isempty(B) && return B
     Bc = B.chunks
     if !y
         fill!(Bc, 0)
@@ -1488,7 +1488,7 @@ sum(A::BitArray, region) = reducedim(AddFun(), A, region)
 sum(B::BitArray) = countnz(B)
 
 function all(B::BitArray)
-    length(B) == 0 && return true
+    isempty(B) && return true
     Bc = B.chunks
     @inbounds begin
         for i = 1:length(Bc)-1
@@ -1500,7 +1500,7 @@ function all(B::BitArray)
 end
 
 function any(B::BitArray)
-    length(B) == 0 && return false
+    isempty(B) && return false
     Bc = B.chunks
     @inbounds begin
         for i = 1:length(Bc)
@@ -1533,7 +1533,7 @@ map!(f::Function, dest::BitArray, A::BitArray, B::BitArray) = map!(specialized_b
 # iterates bit-by-bit.
 function map!(f::BitFunctorUnary, dest::BitArray, A::BitArray)
     size(A) == size(dest) || throw(DimensionMismatch("sizes of dest and A must match"))
-    length(A) == 0 && return dest
+    isempty(A) && return dest
     for i=1:length(A.chunks)-1
         dest.chunks[i] = f(A.chunks[i])
     end
@@ -1542,7 +1542,7 @@ function map!(f::BitFunctorUnary, dest::BitArray, A::BitArray)
 end
 function map!(f::BitFunctorBinary, dest::BitArray, A::BitArray, B::BitArray)
     size(A) == size(B) == size(dest) || throw(DimensionMismatch("sizes of dest, A, and B must all match"))
-    length(A) == 0 && return dest
+    isempty(A) && return dest
     for i=1:length(A.chunks)-1
         dest.chunks[i] = f(A.chunks[i], B.chunks[i])
     end

--- a/base/client.jl
+++ b/base/client.jl
@@ -347,7 +347,7 @@ function init_parallel()
     global PGRP
     global LPROC
     LPROC.id = 1
-    assert(length(PGRP.workers) == 0)
+    assert(isempty(PGRP.workers))
     register_worker(LPROC)
 end
 

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -221,7 +221,7 @@ permutations(a) = Permutations(a)
 start(p::Permutations) = [1:length(p.a);]
 function next(p::Permutations, s)
     perm = [p.a[si] for si in s]
-    if length(p.a) == 0
+    if isempty(p.a)
         # special case to generate 1 result for len==0
         return (perm,[1])
     end
@@ -456,7 +456,7 @@ end
 # vector b of length n describing the first index b[i] that belongs to partition i
 # integer n
 
-done(p::FixedSetPartitions, s) = length(s[1]) == 0 || s[1][1] > 1
+done(p::FixedSetPartitions, s) = isempty(s[1]) || s[1][1] > 1
 next(p::FixedSetPartitions, s) = nextfixedsetpartition(p.s,p.m, s...)
 
 function nextfixedsetpartition(s::AbstractVector, m, a, b, n)

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -112,7 +112,7 @@ function localize_vars(expr, esca)
 end
 
 function pushmeta!(ex::Expr, sym::Symbol, args::Any...)
-    if length(args) == 0
+    if isempty(args)
         tag = sym
     else
         tag = Expr(sym, args...)

--- a/base/fft/FFTW.jl
+++ b/base/fft/FFTW.jl
@@ -430,7 +430,7 @@ function fix_kinds(region, kinds)
         if length(kinds) > length(region)
             throw(ArgumentError("too many transform kinds"))
         else
-            if length(kinds) == 0
+            if isempty(kinds)
                 throw(ArgumentError("must supply a transform kind"))
             end
             k = Array(Int32, length(region))

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -222,7 +222,7 @@ function limit_type_depth(t::ANY, d::Int, cov::Bool, vars)
         end
     elseif isa(t,DataType)
         P = t.parameters
-        length(P) == 0 && return t
+        isempty(P) && return t
         if d > MAX_TYPE_DEPTH
             R = t.name.primary
         else
@@ -297,7 +297,7 @@ const getfield_tfunc = function (A, s0, name)
         for i=1:length(snames)
             if is(snames[i],fld)
                 R = s.types[i]
-                if length(s.parameters) == 0
+                if isempty(s.parameters)
                     return R, true
                 else
                     typ = limit_type_depth(R, 0, true,
@@ -2328,7 +2328,7 @@ function inlineable(f::ANY, e::Expr, atype::ANY, sv::StaticVarInfo, enclosing_as
             methfunc = f
         end
 
-        if length(methfunc.env) > 0
+        if !isempty(methfunc.env)
             # can't inline something with an env
             return NF
         end
@@ -2866,7 +2866,7 @@ function inlining_pass(e::Expr, sv, ast)
             end
             if isa(res[2],Array)
                 res2 = res[2]::Array{Any,1}
-                if length(res2) > 0
+                if !isempty(res2)
                     prepend!(stmts,res2)
                     if !has_stmts
                         for stmt in res2

--- a/base/libgit2.jl
+++ b/base/libgit2.jl
@@ -370,7 +370,7 @@ function merge!(repo::GitRepo;
             if committish == Consts.FETCH_HEAD # merge FETCH_HEAD
                 fheads = fetchheads(repo)
                 filter!(fh->fh.ismerge, fheads)
-                if length(fheads) == 0
+                if isempty(fheads)
                     throw(Error.GitError(Error.Merge,Error.ERROR,
                                    "There is no fetch reference for this branch."))
                 end

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -54,7 +54,7 @@ function credentials_callback(cred::Ptr{Ptr{Void}}, url_ptr::Cstring,
             userpass = prompt("Password for '$username@$url'", password=true)
         end
 
-        length(username) == 0 && length(userpass) == 0 && return Cint(-1)
+        isempty(username) && isempty(userpass) && return Cint(-1)
 
         err = ccall((:git_cred_userpass_plaintext_new, :libgit2), Cint,
                      (Ptr{Ptr{Void}}, Cstring, Cstring),

--- a/base/libgit2/commit.jl
+++ b/base/libgit2/commit.jl
@@ -58,7 +58,7 @@ function commit(repo::GitRepo, msg::AbstractString;
     end
 
     # Retrieve parents from HEAD
-    if length(parent_ids) == 0
+    if isempty(parent_ids)
         try # if throws then HEAD not found -> empty repo
             push!(parent_ids, Oid(repo, refname))
         end

--- a/base/libgit2/remote.jl
+++ b/base/libgit2/remote.jl
@@ -64,7 +64,7 @@ function fetch{T<:AbstractString}(rmt::GitRemote, refspecs::Vector{T};
                options::FetchOptions = FetchOptions(),
                msg::AbstractString="")
     msg = "libgit2.fetch: $msg"
-    no_refs = (length(refspecs) == 0)
+    no_refs = isempty(refspecs)
     !no_refs && (sa = StrArrayStruct(refspecs...))
     try
         @check ccall((:git_remote_fetch, :libgit2), Cint,
@@ -78,7 +78,7 @@ end
 function push{T<:AbstractString}(rmt::GitRemote, refspecs::Vector{T};
                                  force::Bool = false,
                                  options::PushOptions = PushOptions())
-    no_refs = (length(refspecs) == 0)
+    no_refs = (isempty(refspecs))
     !no_refs && (sa = StrArrayStruct(refspecs...))
     try
         @check ccall((:git_remote_push, :libgit2), Cint,

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -10,12 +10,12 @@ end
 isset(val::Integer, flag::Integer) = (val & flag == flag)
 
 function prompt(msg::AbstractString; default::AbstractString="", password::Bool=false)
-    msg = length(default) > 0 ? msg*" [$default]:" : msg*":"
+    msg = !isempty(default) ? msg*" [$default]:" : msg*":"
     uinput = if password
         bytestring(ccall(:getpass, Cstring, (Cstring,), msg))
     else
         print(msg)
         chomp(readline(STDIN))
     end
-    length(uinput) == 0 ? default : uinput
+    isempty(uinput) ? default : uinput
 end

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -187,7 +187,7 @@ function pinv{T}(D::Diagonal{T})
 end
 function pinv{T}(D::Diagonal{T}, tol::Real)
     Di = similar(D.diag)
-    if( length(D.diag) != 0 ) maxabsD = maximum(abs(D.diag)) end
+    if( !isempty(D.diag) ) maxabsD = maximum(abs(D.diag)) end
     for i = 1:length(D.diag)
         if( abs(D.diag[i]) > tol*maxabsD && isfinite(inv(D.diag[i])) )
             Di[i]=inv(D.diag[i])

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -593,7 +593,7 @@ Normalize the vector `v` with respect to the `p`-norm.
 """
 function normalize(v::AbstractVector, p::Real = 2)
     nrm = norm(v, p)
-    if length(v) > 0
+    if !isempty(v)
         vv = copy_oftype(v, typeof(v[1]/nrm))
         return __normalize!(vv, nrm)
     else

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -510,7 +510,7 @@ function generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVe
         if tA == 'N'
             if tB == 'N'
                 for i = 1:mA, j = 1:nB
-                    if length(A) == 0 || length(B) == 0
+                    if isempty(A) || isempty(B)
                         Ctmp = zero(R)
                     else
                         Ctmp = zero(A[i, 1]*B[1, j] + A[i, 1]*B[1, j])
@@ -522,7 +522,7 @@ function generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVe
                 end
             elseif tB == 'T'
                 for i = 1:mA, j = 1:nB
-                    if length(A) == 0 || length(B) == 0
+                    if isempty(A) || isempty(B)
                         Ctmp = zero(R)
                     else
                         Ctmp = zero(A[i, 1]*B[j, 1] + A[i, 1]*B[j, 1])
@@ -534,7 +534,7 @@ function generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVe
                 end
             else
                 for i = 1:mA, j = 1:nB
-                    if length(A) == 0 || length(B) == 0
+                    if isempty(A) || isempty(B)
                         Ctmp = zero(R)
                     else
                         Ctmp = zero(A[i, 1]*B[j, 1] + A[i, 1]*B[j, 1])
@@ -548,7 +548,7 @@ function generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVe
         elseif tA == 'T'
             if tB == 'N'
                 for i = 1:mA, j = 1:nB
-                    if length(A) == 0 || length(B) == 0
+                    if isempty(A) || isempty(B)
                         Ctmp = zero(R)
                     else
                         Ctmp = zero(A[1, i]*B[1, j] + A[1, i]*B[1, j])
@@ -560,7 +560,7 @@ function generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVe
                 end
             elseif tB == 'T'
                 for i = 1:mA, j = 1:nB
-                    if length(A) == 0 || length(B) == 0
+                    if isempty(A) || isempty(B)
                         Ctmp = zero(R)
                     else
                         Ctmp = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
@@ -572,7 +572,7 @@ function generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVe
                 end
             else
                 for i = 1:mA, j = 1:nB
-                    if length(A) == 0 || length(B) == 0
+                    if isempty(A) || isempty(B)
                         Ctmp = zero(R)
                     else
                         Ctmp = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
@@ -586,7 +586,7 @@ function generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVe
         else
             if tB == 'N'
                 for i = 1:mA, j = 1:nB
-                    if length(A) == 0 || length(B) == 0
+                    if isempty(A) || isempty(B)
                         Ctmp = zero(R)
                     else
                         Ctmp = zero(A[1, i]*B[1, j] + A[1, i]*B[1, j])
@@ -598,7 +598,7 @@ function generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVe
                 end
             elseif tB == 'T'
                 for i = 1:mA, j = 1:nB
-                    if length(A) == 0 || length(B) == 0
+                    if isempty(A) || isempty(B)
                         Ctmp = zero(R)
                     else
                         Ctmp = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
@@ -610,7 +610,7 @@ function generic_matmatmul!{T,S,R}(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVe
                 end
             else
                 for i = 1:mA, j = 1:nB
-                    if length(A) == 0 || length(B) == 0
+                    if isempty(A) || isempty(B)
                         Ctmp = zero(R)
                     else
                         Ctmp = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])

--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -126,7 +126,7 @@ Computes the polar decomposition of a vector.
 """
 function qr(v::AbstractVector)
     nrm = norm(v)
-    if length(v) > 0
+    if !isempty(v)
         vv = copy_oftype(v, typeof(v[1]/nrm))
         return __normalize!(vv, nrm), nrm
     else

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -41,7 +41,7 @@ function show_sexpr(io::IO, ex::Expr, indent::Int)
         print(io, ex.head === :block ? ",\n"*" "^inner : ", ")
         show_sexpr(io, arg, inner)
     end
-    if length(ex.args) == 0; print(io, ",)")
+    if isempty(ex.args); print(io, ",)")
     else print(io, (ex.head === :block ? "\n"*" "^indent : ""), ')')
     end
 end

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1136,13 +1136,13 @@ function addprocs_locked(manager::ClusterManager; kwargs...)
 
     @sync begin
         while true
-            if length(launched) == 0
+            if isempty(launched)
                 istaskdone(t_launch) && break
                 @schedule (sleep(1); notify(launch_ntfy))
                 wait(launch_ntfy)
             end
 
-            if (length(launched) > 0)
+            if !isempty(launched)
                 wconfig = shift!(launched)
                 let wconfig=wconfig
                     @async setup_launched_worker(manager, wconfig, launched_q)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -640,7 +640,7 @@ end
 @generated function unsafe_setindex!(B::BitArray, X::BitArray, I0::UnitRange{Int}, I::Union{Int,UnitRange{Int}}...)
     N = length(I)
     quote
-        length(X) == 0 && return B
+        isempty(X) && return B
         f0 = first(I0)
         l0 = length(I0)
 
@@ -674,7 +674,7 @@ end
         f0 = first(I0)
         l0 = length(I0)
         l0 == 0 && return B
-        @nexprs $N d->(length(I[d]) == 0 && return B)
+        @nexprs $N d->(isempty(I[d]) && return B)
 
         gap_lst_1 = 0
         @nexprs $N d->(gap_lst_{d+1} = length(I[d]))

--- a/base/process.jl
+++ b/base/process.jl
@@ -564,7 +564,7 @@ function pipeline_error(procs::ProcessChain)
             push!(failed, p)
         end
     end
-    length(failed) == 0 && return nothing
+    isempty(failed) && return nothing
     length(failed) == 1 && pipeline_error(failed[1])
     msg = "failed processes:"
     for proc in failed

--- a/base/random.jl
+++ b/base/random.jl
@@ -596,7 +596,7 @@ rand(rng::AbstractRNG, r::AbstractArray, dims::Int...) = rand(rng, r, dims)
 ## random BitArrays (AbstractRNG)
 
 function rand!(rng::AbstractRNG, B::BitArray)
-    length(B) == 0 && return B
+    isempty(B) && return B
     Bc = B.chunks
     rand!(rng, Bc)
     Bc[end] &= Base._msk_end(B)

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -337,7 +337,7 @@ function show_method_candidates(io::IO, ex::MethodError)
         end
     end
 
-    if length(lines) != 0 # Display up to three closest candidates
+    if !isempty(lines) # Display up to three closest candidates
         Base.with_output_color(:normal, io) do io
             println(io)
             print(io, "Closest candidates are:")

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -147,7 +147,7 @@ end
 
 function serialize_array_data(s::IO, a)
     elty = eltype(a)
-    if elty === Bool && length(a)>0
+    if elty === Bool && !isempty(a)
         last = a[1]
         count = 1
         for i = 2:length(a)
@@ -364,7 +364,7 @@ function serialize_type_data(s, t)
     serialize(s, tname)
     mod = t.name.module
     serialize(s, mod)
-    if length(t.parameters) > 0
+    if !isempty(t.parameters)
         if isdefined(mod,tname) && is(t,getfield(mod,tname))
             serialize(s, svec())
         else
@@ -639,7 +639,7 @@ function deserialize_datatype(s::SerializationState)
     name = deserialize(s)::Symbol
     mod = deserialize(s)::Module
     ty = getfield(mod,name)
-    if length(ty.parameters) == 0
+    if isempty(ty.parameters)
         t = ty
     else
         params = deserialize(s)

--- a/base/show.jl
+++ b/base/show.jl
@@ -103,7 +103,7 @@ end
 
 function show(io::IO, x::DataType)
     show(io, x.name)
-    if (length(x.parameters) > 0 || x.name === Tuple.name) && x !== Tuple
+    if (!isempty(x.parameters) || x.name === Tuple.name) && x !== Tuple
         print(io, '{')
         n = length(x.parameters)
         for i = 1:n
@@ -187,7 +187,7 @@ function show_delim_array(io::IO, itr::AbstractArray, op, delim, cl, delim_one, 
                 multiline = false
             else
                 x = itr[i]
-                multiline = isa(x,AbstractArray) && ndims(x)>1 && length(x)>0
+                multiline = isa(x,AbstractArray) && ndims(x)>1 && !isempty(x)
                 newline && multiline && println(io)
                 if !isbits(x) && is(x, itr)
                     print(io, "#= circular reference =#")
@@ -227,7 +227,7 @@ function show_delim_array(io::IO, itr, op, delim, cl, delim_one, compact=false, 
     if !done(itr,state)
         while true
             x, state = next(itr,state)
-            multiline = isa(x,AbstractArray) && ndims(x)>1 && length(x)>0
+            multiline = isa(x,AbstractArray) && ndims(x)>1 && !isempty(x)
             newline && multiline && println(io)
             if !isbits(x) && is(x, itr)
                 print(io, "#= circular reference =#")
@@ -903,7 +903,7 @@ function dumptype(io::IO, x, n::Int, indent)
                          any(map(tt -> string(x.name) == typargs(tt), t.body.types)))
                         targs = join(t.parameters, ",")
                         println(io, indent, "  ", s,
-                                length(t.parameters) > 0 ? "{$targs}" : "",
+                                !isempty(t.parameters) ? "{$targs}" : "",
                                 " = ", t)
                     end
                 elseif isa(t, Union)
@@ -1195,7 +1195,7 @@ end
 summary(x) = string(typeof(x)) # e.g. Int64
 
 # sizes such as 0-dimensional, 4-dimensional, 2x3
-dims2string(d) = length(d) == 0 ? "0-dimensional" :
+dims2string(d) = isempty(d) ? "0-dimensional" :
                  length(d) == 1 ? "$(d[1])-element" :
                  join(map(string,d), 'x')
 
@@ -1399,7 +1399,7 @@ print_bit_chunk(c::UInt64, l::Integer) = print_bit_chunk(STDOUT, c, l)
 print_bit_chunk(c::UInt64) = print_bit_chunk(STDOUT, c)
 
 function bitshow(io::IO, B::BitArray)
-    length(B) == 0 && return
+    isempty(B) && return
     Bc = B.chunks
     for i = 1:length(Bc)-1
         print_bit_chunk(io, Bc[i])

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -143,7 +143,7 @@ function parseipv4(str)
     i = 1
     ret = 0
     for f in fields
-        if length(f) == 0
+        if isempty(f)
             throw(ArgumentError("empty field in IPv4 address"))
         end
         if f[1] == '0'

--- a/base/sparse/csparse.jl
+++ b/base/sparse/csparse.jl
@@ -242,7 +242,7 @@ function etree{Tv,Ti}(A::SparseMatrixCSC{Tv,Ti}, postorder::Bool)
     for j in 1:n
         if (parent[j] != 0) continue end # skip j if it is not a root
         push!(stack, j)                  # place j on the stack
-        while (length(stack) > 0)        # while (stack is not empty)
+        while (!isempty(stack))        # while (stack is not empty)
             p = stack[end]               # p = top of stack
             i = head[p]                  # i = youngest child of p
             if (i == 0)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -278,7 +278,7 @@ function sparse_IJ_sorted!{Ti<:Integer}(I::AbstractVector{Ti}, J::AbstractVector
 
     m = m < 0 ? 0 : m
     n = n < 0 ? 0 : n
-    if length(V) == 0; return spzeros(eltype(V),Ti,m,n); end
+    if isempty(V); return spzeros(eltype(V),Ti,m,n); end
 
     cols = zeros(Ti, n+1)
     cols[1] = 1  # For cumsum purposes
@@ -320,7 +320,7 @@ end
 
 ## sparse() can take its inputs in unsorted order (the parent method is now in csparse.jl)
 
-dimlub(I) = length(I)==0 ? 0 : Int(maximum(I)) #least upper bound on required sparse matrix dimension
+dimlub(I) = isempty(I) ? 0 : Int(maximum(I)) #least upper bound on required sparse matrix dimension
 
 sparse(I,J,v::Number) = sparse(I, J, fill(v,length(I)), dimlub(I), dimlub(J), AddFun())
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -31,14 +31,18 @@ end
 showerror(io::IO, ce::CapturedException) = showerror(io, ce.ex, ce.processed_bt, backtrace=true)
 
 type CompositeException <: Exception
-    exceptions::Array
+    exceptions::Vector{Any}
     CompositeException() = new(Any[])
 end
 length(c::CompositeException) = length(c.exceptions)
 push!(c::CompositeException, ex) = push!(c.exceptions, ex)
+isempty(c::CompositeException) = isempty(c.exceptions)
+start(c::CompositeException) = start(c.exceptions)
+next(c::CompositeException, state) = next(c.exceptions, state)
+done(c::CompositeException, state) = done(c.exceptions, state)
 
 function showerror(io::IO, ex::CompositeException)
-    if length(ex) > 0
+    if !isempty(ex)
         showerror(io, ex.exceptions[1])
         remaining = length(ex) - 1
         if remaining > 0
@@ -405,7 +409,7 @@ function sync_end()
         end
     end
 
-    if length(c_ex) > 0
+    if !isempty(c_ex)
         throw(c_ex)
     end
     nothing

--- a/base/test.jl
+++ b/base/test.jl
@@ -405,7 +405,7 @@ function get_alignment(ts::DefaultTestSet, depth::Int)
     !ts.anynonpass && return ts_width
     # Return the maximum of this width and the minimum width
     # for all children (if they exist)
-    length(ts.results) == 0 && return ts_width
+    isempty(ts.results) && return ts_width
     child_widths = map(t->get_alignment(t, depth+1), ts.results)
     return max(ts_width, maximum(child_widths))
 end
@@ -505,7 +505,7 @@ By default the `@testset` macro will return the testset object itself, though
 this behavior can be customized in other testset types.
 """
 macro testset(args...)
-    length(args) > 0 || error("No arguments to @testset")
+    !isempty(args) || error("No arguments to @testset")
 
     tests = args[end]
 
@@ -557,7 +557,7 @@ The `@testloop` macro collects and returns a list of the return values of the
 in each iteration.
 """
 macro testloop(args...)
-    length(args) > 0 || error("no arguments to @testloop")
+    !isempty(args) || error("no arguments to @testloop")
 
     testloop = args[end]
     isa(testloop,Expr) && testloop.head == :for || error("Unexpected argument to @testloop")
@@ -652,7 +652,7 @@ test set is active, use the fallback default test set.
 """
 function get_testset()
     testsets = get(task_local_storage(), :__BASETESTNEXT__, AbstractTestSet[])
-    return length(testsets) == 0 ? fallback_testset : testsets[end]
+    return isempty(testsets) ? fallback_testset : testsets[end]
 end
 
 """
@@ -674,7 +674,7 @@ active test sets, returns the fallback default test set.
 """
 function pop_testset()
     testsets = get(task_local_storage(), :__BASETESTNEXT__, AbstractTestSet[])
-    ret = length(testsets) == 0 ? fallback_testset : pop!(testsets)
+    ret = isempty(testsets) ? fallback_testset : pop!(testsets)
     setindex!(task_local_storage(), testsets, :__BASETESTNEXT__)
     return ret
 end


### PR DESCRIPTION
I noticed that in some places we were doing `length(string) > 0` to check whether it was not empty, which is O(n), whereas `!isempty(string)` is O(1).  (It probably wasn't being done in performance-critical cases, but it bugged me every time I saw it.)

Rather than find the places where `length(x)` is being compared to `0` specifically for strings, it was a lot easier to just globally search and replace this with `isempty(x)` or `!isempty(x)` everywhere.   It certainly shouldn't _hurt_ performance, and seemed like better style to use `isempty` to check for empty collections.
