### PR TITLE
accept ∈ as a synonym for 'in' inside for loops and comprehensions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ Julia v0.5.0 Release Notes
 New language features
 ---------------------
 
+  * `x ∈ X` is now a synonym for `x in X` in `for` loops and comprehensions,
+    as it already was in comparisons ([#13824]).
+
 Language changes
 ----------------
 
@@ -1589,6 +1592,7 @@ Too numerous to mention.
 [#7917]: https://github.com/JuliaLang/julia/issues/7917
 [#7992]: https://github.com/JuliaLang/julia/issues/7992
 [#8011]: https://github.com/JuliaLang/julia/issues/8011
+[#8036]: https://github.com/JuliaLang/julia/issues/8036
 [#8089]: https://github.com/JuliaLang/julia/issues/8089
 [#8113]: https://github.com/JuliaLang/julia/issues/8113
 [#8135]: https://github.com/JuliaLang/julia/issues/8135
@@ -1736,6 +1740,8 @@ Too numerous to mention.
 [#13465]: https://github.com/JuliaLang/julia/issues/13465
 [#13496]: https://github.com/JuliaLang/julia/issues/13496
 [#13480]: https://github.com/JuliaLang/julia/issues/13480
+[#13496]: https://github.com/JuliaLang/julia/issues/13496
 [#13542]: https://github.com/JuliaLang/julia/issues/13542
 [#13680]: https://github.com/JuliaLang/julia/issues/13680
 [#13681]: https://github.com/JuliaLang/julia/issues/13681
+[#13824]: https://github.com/JuliaLang/julia/issues/13824

--- a/doc/manual/control-flow.rst
+++ b/doc/manual/control-flow.rst
@@ -483,8 +483,8 @@ See :ref:`man-variables-and-scoping` for a detailed
 explanation of variable scope and how it works in Julia.
 
 In general, the ``for`` loop construct can iterate over any container.
-In these cases, the alternative (but fully equivalent) keyword ``in`` is
-typically used instead of ``=``, since it makes the code read more
+In these cases, the alternative (but fully equivalent) keyword ``in``
+or `∈` is typically used instead of ``=``, since it makes the code read more
 clearly:
 
 .. doctest::
@@ -496,7 +496,7 @@ clearly:
     4
     0
 
-    julia> for s in ["foo","bar","baz"]
+    julia> for s ∈ ["foo","bar","baz"]
              println(s)
            end
     foo

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1414,7 +1414,8 @@
                       r)
                      ((eq? r ':)
                       r)
-                     ((and (length= r 4) (eq? (car r) 'comparison) (eq? (caddr r) 'in))
+                     ((and (length= r 4) (eq? (car r) 'comparison)
+                           (or (eq? (caddr r) 'in) (eq? (caddr r) '∈)))
                       `(= ,(cadr r) ,(cadddr r)))
                      (else
                       (error "invalid iteration specification")))))

--- a/test/core.jl
+++ b/test/core.jl
@@ -3485,6 +3485,15 @@ end
 @test foo13855(Base.AddFun())() == Base.AddFun()
 @test foo13855(Base.MulFun())() == Base.MulFun()
 
+# issue #8487
+@test [x for x in 1:3] == [x for x ∈ 1:3] == [x for x = 1:3]
+let A = Array(Int, 4,3)
+    for i ∈ 1:size(A,1), j ∈ 1:size(A,2)
+        A[i,j] = 17*i + 51*j
+    end
+    @test A == [17*i + 51*j for i ∈ 1:size(A,1), j ∈ 1:size(A,2)]
+end
+
 # check if finalizers for the old gen can be triggered manually
 # issue #13986
 let


### PR DESCRIPTION
As discussed in #8487, it's a bit odd and confusing that we allow `x ∈ X` as synonym for `x in X` comparisons, but we don't allow `for x ∈ X` as a synonym for `for x in X`.

This patch changes the parser to allow `∈` as a synonym for `in` in `for` loops and comprehensions.

(This should be backwards compatible: even existing code that works with ASTs is not affected, because both `for x ∈ X` and `for x in X` are parsed as `for x = X`.)
