### PR TITLE
cleanups of some isempty calls from #13821

### DIFF
--- a/base/libgit2/remote.jl
+++ b/base/libgit2/remote.jl
@@ -78,7 +78,7 @@ end
 function push{T<:AbstractString}(rmt::GitRemote, refspecs::Vector{T};
                                  force::Bool = false,
                                  options::PushOptions = PushOptions())
-    no_refs = (isempty(refspecs))
+    no_refs = isempty(refspecs)
     !no_refs && (sa = StrArrayStruct(refspecs...))
     try
         @check ccall((:git_remote_push, :libgit2), Cint,

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -1154,7 +1154,7 @@ function _printf(macroname, io, fmt, args)
 end
 
 macro printf(args...)
-    !isempty(args) || throw(ArgumentError("@printf: called with no arguments"))
+    isempty(args) && throw(ArgumentError("@printf: called with no arguments"))
     if isa(args[1], AbstractString) || is_str_expr(args[1])
         _printf("@printf", :STDOUT, args[1], args[2:end])
     else
@@ -1165,7 +1165,7 @@ macro printf(args...)
 end
 
 macro sprintf(args...)
-    !isempty(args) || throw(ArgumentError("@sprintf: called with zero arguments"))
+    isempty(args) && throw(ArgumentError("@sprintf: called with zero arguments"))
     isa(args[1], AbstractString) || is_str_expr(args[1]) ||
         throw(ArgumentError("@sprintf: first argument must be a format string"))
     letexpr = _printf("@sprintf", :(IOBuffer()), args[1], args[2:end])

--- a/base/test.jl
+++ b/base/test.jl
@@ -505,7 +505,7 @@ By default the `@testset` macro will return the testset object itself, though
 this behavior can be customized in other testset types.
 """
 macro testset(args...)
-    !isempty(args) || error("No arguments to @testset")
+    isempty(args) && error("No arguments to @testset")
 
     tests = args[end]
 
@@ -557,7 +557,7 @@ The `@testloop` macro collects and returns a list of the return values of the
 in each iteration.
 """
 macro testloop(args...)
-    !isempty(args) || error("no arguments to @testloop")
+    isempty(args) && error("no arguments to @testloop")
 
     testloop = args[end]
     isa(testloop,Expr) && testloop.head == :for || error("Unexpected argument to @testloop")


### PR DESCRIPTION
Removes a couple awkward double-negatives pointed out by @IainNZ in #13821, and removes some extraneous parens.
