### PR TITLE
Fix broadcasting for empty sparse matrices

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -700,7 +700,8 @@ function gen_broadcast_body_sparse(f::Function, is_first_sparse::Bool)
         colptr1 = A_1.colptr; rowval1 = A_1.rowval; nzval1 = A_1.nzval
         colptr2 = A_2.colptr; rowval2 = A_2.rowval; nzval2 = A_2.nzval
 
-        nnzB = nnz(A_1) * div(B.n, A_1.n) * div(B.m, A_1.m)  +
+        nnzB = isempty(B) ? 0 :
+               nnz(A_1) * div(B.n, A_1.n) * div(B.m, A_1.m)  +
                nnz(A_2) * div(B.n, A_2.n) * div(B.m, A_2.m)
         if length(rowvalB) < nnzB
             resize!(rowvalB, nnzB)
@@ -860,7 +861,8 @@ function gen_broadcast_body_zpreserving(f::Function, is_first_sparse::Bool)
         Base.Broadcast.check_broadcast_shape(size(B), $A1)
         Base.Broadcast.check_broadcast_shape(size(B), $A2)
 
-        nnzB = nnz($A1) * div(B.n, ($A1).n) * div(B.m, ($A1).m)
+        nnzB = isempty(B) ? 0 :
+               nnz($A1) * div(B.n, ($A1).n) * div(B.m, ($A1).m)
         if length(B.rowval) < nnzB
             resize!(B.rowval, nnzB)
         end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -700,9 +700,8 @@ function gen_broadcast_body_sparse(f::Function, is_first_sparse::Bool)
         colptr1 = A_1.colptr; rowval1 = A_1.rowval; nzval1 = A_1.nzval
         colptr2 = A_2.colptr; rowval2 = A_2.rowval; nzval2 = A_2.nzval
 
-        nnzB = isempty(B) ? 0 :
-               nnz(A_1) * div(B.n, A_1.n) * div(B.m, A_1.m)  +
-               nnz(A_2) * div(B.n, A_2.n) * div(B.m, A_2.m)
+        nnzB = isempty(B) ? 0 : (nnz(A_1) * div(B.n, A_1.n) * div(B.m, A_1.m)  +
+                                 nnz(A_2) * div(B.n, A_2.n) * div(B.m, A_2.m))
         if length(rowvalB) < nnzB
             resize!(rowvalB, nnzB)
         end

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -877,6 +877,14 @@ let  A = sprand(10,10,0.3), B = sprand(10,10,0.3), CF = rand(10,10), AF = full(A
     @test BF[:,1] .^ A == BF[:,1] .^ AF
 end
 
+# test broadcasting for empty matrices
+@test spzeros(0,0)  + spzeros(0,0)  == zeros(0,0)
+@test spzeros(0,0)  * spzeros(0,0)  == zeros(0,0)
+@test spzeros(1,0) .+ spzeros(2,1)  == zeros(2,0)
+@test spzeros(1,0) .* spzeros(2,1)  == zeros(2,0)
+@test spzeros(1,2) .+ spzeros(0,1)  == zeros(0,2)
+@test spzeros(1,2) .* spzeros(0,1)  == zeros(0,2)
+
 # test throws
 A = sprandbool(5,5,0.2)
 @test_throws ArgumentError reinterpret(Complex128,A,(5,5))


### PR DESCRIPTION
For sparse empty broadcast result matrices, add special case to avoid dividing by zero when calculating the number of nonzeros.

Fixes issue reported on the mailing list: https://groups.google.com/forum/#!topic/julia-dev/s7jVxhEYC4M

Hold off merging for a few minutes and I'll write some tests as well.
