### PR TITLE
Do not suppress errors and warnings from pre-compilation process.

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -33,18 +33,18 @@ function edit(file::AbstractString, line::Integer)
     end
     const no_line_msg = "Unknown editor: no line number information passed.\nThe method is defined at line $line."
     if startswith(name, "emacs") || name == "gedit"
-        spawn(`$command +$line $file`)
+        spawn(pipeline(`$command +$line $file`, stderr=STDERR))
     elseif name == "vi" || name == "vim" || name == "nvim" || name == "mvim" || name == "nano"
         run(`$command +$line $file`)
     elseif name == "textmate" || name == "mate" || name == "kate"
-        spawn(`$command $file -l $line`)
+        spawn(pipeline(`$command $file -l $line`, stderr=STDERR))
     elseif startswith(name, "subl") || name == "atom"
-        spawn(`$command $file:$line`)
+        spawn(pipeline(`$command $file:$line`, stderr=STDERR))
     elseif OS_NAME == :Windows && (name == "start" || name == "open")
-        spawn(`cmd /c start /b $file`)
+        spawn(pipeline(`cmd /c start /b $file`, stderr=STDERR))
         println(no_line_msg)
     elseif OS_NAME == :Darwin && (name == "start" || name == "open")
-        spawn(`open -t $file`)
+        spawn(pipeline(`open -t $file`, stderr=STDERR))
         println(no_line_msg)
     else
         run(`$command $file`)
@@ -79,7 +79,7 @@ less(file, line::Integer) = error("could not find source file for function")
 
 @osx_only begin
     function clipboard(x)
-        open(`pbcopy`, "w") do io
+        open(pipeline(`pbcopy`, stderr=STDERR), "w") do io
             print(io, x)
         end
     end
@@ -101,7 +101,7 @@ end
         cmd = c == :xsel  ? `xsel --nodetach --input --clipboard` :
               c == :xclip ? `xclip -quiet -in -selection clipboard` :
             error("unexpected clipboard command: $c")
-        open(cmd, "w") do io
+        open(pipeline(cmd, stderr=STDERR), "w") do io
             print(io, x)
         end
     end
@@ -110,7 +110,7 @@ end
         cmd = c == :xsel  ? `xsel --nodetach --output --clipboard` :
               c == :xclip ? `xclip -quiet -out -selection clipboard` :
             error("unexpected clipboard command: $c")
-        readall(cmd)
+        readall(pipeline(cmd, stderr=STDERR))
     end
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -421,11 +421,12 @@ function create_expr_cache(input::AbstractString, output::AbstractString)
             eval(Main, deserialize(STDIN))
         end
         """
-    io, pobj = open(detach(`$(julia_cmd())
-                           --output-ji $output --output-incremental=yes
-                           --startup-file=no --history-file=no
-                           --color=$(have_color ? "yes" : "no")
-                           --eval $code_object`), "w", STDOUT)
+    io, pobj = open(pipeline(detach(`$(julia_cmd())
+                                    --output-ji $output --output-incremental=yes
+                                    --startup-file=no --history-file=no
+                                    --color=$(have_color ? "yes" : "no")
+                                    --eval $code_object`), stderr=STDERR),
+                    "w", STDOUT)
     try
         serialize(io, quote
                   empty!(Base.LOAD_PATH)

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -1306,7 +1306,7 @@ function launch_additional(np::Integer, cmd::Cmd)
     addresses = cell(np)
 
     for i in 1:np
-        io, pobj = open(detach(cmd), "r")
+        io, pobj = open(pipeline(detach(cmd), stderr=STDERR), "r")
         io_objs[i] = io
     end
 

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -542,11 +542,11 @@ function build!(pkgs::Vector, errs::Dict, seen::Set=Set())
             end
         end
     """
-    io, pobj = open(detach(`$(Base.julia_cmd())
-                           --compilecache=$(Bool(Base.JLOptions().use_compilecache) ? "yes" : "no")
-                           --history-file=no
-                           --color=$(Base.have_color ? "yes" : "no")
-                           --eval $code`), "w", STDOUT)
+    io, pobj = open(pipeline(detach(`$(Base.julia_cmd())
+                                    --compilecache=$(Bool(Base.JLOptions().use_compilecache) ? "yes" : "no")
+                                    --history-file=no
+                                    --color=$(Base.have_color ? "yes" : "no")
+                                    --eval $code`), stderr=STDERR), "w", STDOUT)
     try
         build!(pkgs, io, seen)
         close(io)


### PR DESCRIPTION
Fix breakage caused by https://github.com/JuliaLang/julia/commit/cf5f23adafb4f9d1eca2ff0cdea80398ee34f799 (c.c. @JeffBezanson )

Similar to https://github.com/JuliaLang/julia/commit/2b36acd6015f10a59c44d93b1250f81b35c5bb26 (c.c. @vtjnash )

I'm totally not convinced that suppressing the stderr by default is the right thing to do but we definitely shouldn't swallow the errors and (dep)warnings from package precompilation.
