### PR TITLE
dense: Use BLAS.iamax for vecnormInf when applicable

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -8,6 +8,7 @@ const SCAL_CUTOFF = 2048
 const DOT_CUTOFF = 128
 const ASUM_CUTOFF = 32
 const NRM2_CUTOFF = 32
+const IAMAX_CUTOFF = 8
 
 function scale!{T<:BlasFloat}(X::Array{T}, s::T)
     if length(X) < SCAL_CUTOFF
@@ -67,6 +68,13 @@ vecnorm1{T<:BlasReal}(x::Union{Array{T},StridedVector{T}}) =
 
 vecnorm2{T<:BlasFloat}(x::Union{Array{T},StridedVector{T}}) =
     length(x) < NRM2_CUTOFF ? generic_vecnorm2(x) : BLAS.nrm2(x)
+
+function vecnormInf{T<:BlasFloat}(x::Union{Array{T}, StridedVector{T}})
+    if length(x) < IAMAX_CUTOFF
+        return generic_vecnormInf(x)
+    end
+    @inbounds return abs(x[BLAS.iamax(x)])
+end
 
 function triu!(M::AbstractMatrix, k::Integer)
     m, n = size(M)


### PR DESCRIPTION
When recently profiling an algorithm (a solver for sparse time-independent complex ODEs) which should be entirely dominated by sparse-dense multiplication, I was surprised to see that `norm(vec, Inf)` was much slower than expected. For tasks like this that are quite amenable to optimization in terms of SIMD and ILP, my first reaction is usually to look whether BLAS offers a well-tuned implementation.

And indeed, `vecnormInf` can be easily implemented in terms of `iamax`. Other than for the 1- and 2-norms, this was not done so far, however (perhaps because it is slight less obvious than those?). 

A quick ad-hoc benchmark (take the results for very small vectors with a grain of salt, as BenchmarkLite might not measure the short timings very accurately):

``` julia
using BenchmarkLite

type InfNorm{Method, T} <: Proc end

type Generic{T} end
Base.string{T}(::InfNorm{Generic{T}, T}) = string("generic-", lowercase("$T"))
calc{T}(::Generic{T}, a) = Base.LinAlg.generic_vecnormInf(a)

type Blas{T} end
Base.string{T}(::InfNorm{Blas{T}, T}) = string("blas-", lowercase("$T"))
calc{T}(::Blas{T}, a) = @inbounds abs(a[BLAS.iamax(a)])

Base.length(p::InfNorm, n::Int) = n
Base.isvalid(p::InfNorm, n::Int) = (n > 0)
Base.start{M, T}(p::InfNorm{M, T}, n::Int) = rand(T, n)
Base.run{Op}(p::InfNorm{Op}, n, s) = calc(Op(), s)
Base.done(p::InfNorm, n, s) = nothing

procs = Proc[]
for T in [Float32, Float64, Complex64, Complex128]
    push!(procs, InfNorm{Generic{T}, T}())
    push!(procs, InfNorm{Blas{T}, T}())
end

cfgs = round(Int64, 2 .^ (1:2.5:30))
rtable = run(procs, cfgs, duration=5.0)
show(rtable, unit=:usec)
```

On an i7-4980HQ @ 2.80GHz (2015 MacBook Pro) and using Julia 0.4 from the official OS X binaries (i.e. OpenBLAS), this yields:

```
config    |  generic-float32  blas-float32  generic-float64  blas-float64  generic-complex{float32}  blas-complex{float32}  generic-complex{float64}  blas-complex{float64}
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2         |           0.0040        0.0070           0.0046        0.0069                    0.0218                 0.0158                    0.0221                 0.0161
11        |           0.0169        0.0098           0.0170        0.0112                    0.0995                 0.0198                    0.1150                 0.0242
64        |           0.0940        0.0191           0.0890        0.0278                    0.6042                 0.0625                    0.6345                 0.0694
362       |           0.4792        0.0685           0.4779        0.1056                    3.8517                 0.1878                    4.3298                 0.2349
2048      |           2.5700        0.3338           2.6027        0.4429                   32.5925                 1.0535                   33.3559                 2.1284
11585     |          14.6106        1.4790          14.7761        3.4367                  207.9688                 5.4690                  209.4380                12.9941
65536     |          82.1400        8.4149          83.2801       23.2338                 1181.9106                36.7312                 1190.6121                47.4018
370728    |         467.1537       84.1836         467.9886      113.4118                 6762.7792               301.0620                 6821.8013               246.0305
2097152   |        2656.9854      607.3485        2770.9644      868.4505                38030.0249              1338.2240                39202.6030              3429.3851
11863283  |       15331.6844     3063.2022       15871.0272     6647.2698               217814.6080              9671.0280               222938.8073             25235.8199
67108864  |       91625.5585    21238.6639       97534.3364    56076.1892              1232270.7262             72410.9445              1250452.9735            158077.2765
379625062 |      520812.2763   114426.7778      554825.7703   308552.0588              6915791.0150            430399.1465              7141003.7490            678496.8453
```

Note how much slower the pure Julia implementation of the complex case is even for small vectors.

In this PR, I'm using a cutoff of 8 as a compromise between the real and complex cases. The exact value is probably rather inconsequential, though.
