### PR TITLE
fix range bugs for matrix multiply/solve

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -262,7 +262,7 @@ function naivesub!{T}(A::Bidiagonal{T}, b::AbstractVector, x::AbstractVector = b
     x
 end
 
-function \{T,S}(A::Bidiagonal{T}, B::AbstractVecOrMat{S})
+function \{T,S}(A::Bidiagonal{T}, B::StridedVecOrMat{S})
     TS = typeof(zero(T)*zero(S) + zero(T)*zero(S))
     TS == S ? A_ldiv_B!(A, copy(B)) : A_ldiv_B!(A, convert(AbstractArray{TS}, B))
 end

--- a/base/range.jl
+++ b/base/range.jl
@@ -633,6 +633,10 @@ end
 ./(r::FloatRange, x::Real)   = FloatRange(r.start/x, r.step/x, r.len, r.divisor)
 ./(r::LinSpace, x::Real)     = LinSpace(r.start / x, r.stop / x, r.len, r.divisor)
 
+# Matrix multiplication/solve on ranges, A*r should treat r as collected vector
+*{T}(A::AbstractArray{T, 2}, r::Range) = A*collect(r)
+\{T}(A::AbstractArray{T, 2}, r::Range) = A\collect(r)
+
 promote_rule{T1,T2}(::Type{UnitRange{T1}},::Type{UnitRange{T2}}) =
     UnitRange{promote_type(T1,T2)}
 convert{T}(::Type{UnitRange{T}}, r::UnitRange{T}) = r

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -244,6 +244,11 @@ end
 @test all(([1:5;] - (1:5)) .== 0)
 @test all(((1:5) - [1:5;]) .== 0)
 
+# matrix multiplication between matrix and range, e.g. A*r
+@test [1 2 3;]*(1:3) == [14]
+# and a matrix solve A\r
+@test [1 0; 0 1]\linspace(1,2,2) ≈ [1., 2.]
+
 # tricky floating-point ranges
 
 @test [0.1:0.1:0.3;]   == [linspace(0.1,0.3,3);]     == [1:3;]./10


### PR DESCRIPTION
This is a combined bug fix and workaround for ranges not behaving properly when pre-multiplied by a matrix. In the [user forum](https://groups.google.com/d/msg/julia-users/fVXAF0RP2MM/knKTy8oIBgAJ) an error was reported for `A*r` where `A` is a matrix and `r` is a range, which should just like a vector. The fix is to define matrix multiplication by a `Range` as including a `collect` first.

A second problem is that `A\r` can fail, with the workaround also being to do a `collect` on `r`. I call this a workaround as opposed to a bug fix, because the problem may come from intricacies of `convert`, and not necessarily a failure to `collect`, as `A\r` doesn't fail universally but only for some/most combinations of types for `A` and `r`. I didn't trace down far enough to figure that out, and someone more knowledgeable might know whether there is a deeper bug lurking somewhere. Nevertheless this PR seems to work and pass all tests including the added ones.

Finally, I left the definitions very broad here with `AbstractArray`. I would appreciate advice if these should be something more specific such as `AbstractMatrix` or such. My thinking was that the details on types get figured out by matmul.jl so there's no need to deal with it beforehand, but I'm not sure if this could potentially slow things down.
