### PR TITLE
Hide multiple spaces when rendering markdown.

### DIFF
--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -28,7 +28,6 @@ function term(io::IO, md::BlockQuote, columns)
     for line in split(rstrip(s), "\n")
         println(io, " "^margin, "|", line)
     end
-    println(io)
 end
 
 function term(io::IO, md::List, columns)
@@ -93,7 +92,7 @@ function terminline(io::IO, content::Vector)
 end
 
 function terminline(io::IO, md::AbstractString)
-    print(io, md)
+    print(io, replace(md, r"[\s\t\n]+", " "))
 end
 
 function terminline(io::IO, md::Bold)
@@ -109,7 +108,7 @@ function terminline(io::IO, md::LineBreak)
 end
 
 function terminline(io::IO, md::Image)
-    print(io, "(Image: $(md.alt))")
+    terminline(io, "(Image: $(md.alt))")
 end
 
 function terminline(io::IO, md::Link)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -75,6 +75,20 @@ World""" |> plain == "Hello\n\n–––\n\nWorld\n"
 > baz
 > ```""" |> plain == """> foo\n>\n>   * bar\n>\n> ```\n> baz\n> ```\n\n"""
 
+# Terminal (markdown) output
+
+# multiple whitespace is ignored
+@test sprint(term, md"a  b") == "  a b\n"
+@test sprint(term, md"- a
+        not code") == "    •  a not code\n"
+@test sprint(term, md"[x](https://julialang.org)") == "  x\n"
+@test sprint(term, md"![x](https://julialang.org)") == "  (Image: x)\n"
+
+# enumeration is normalized
+@test sprint(term, md"""
+    1. a
+    3. b""") == "    1. a\n    2. b\n"
+
 # HTML output
 
 @test md"foo *bar* baz" |> html == "<p>foo <em>bar</em> baz</p>\n"


### PR DESCRIPTION
fix #13789.
