### PR TITLE
Make bitfields unsigned to suppress GCC warnings

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -278,8 +278,8 @@ typedef struct _jl_lambda_info_t {
     // hidden fields:
     // flag telling if inference is running on this function
     // used to avoid infinite recursion
-    int8_t inInference : 1;
-    int8_t inCompile : 1;
+    uint8_t inInference : 1;
+    uint8_t inCompile : 1;
     jl_fptr_t fptr;             // jlcall entry point
     void *functionObject;       // jlcall llvm Function
     void *cFunctionList;        // c callable llvm Functions


### PR DESCRIPTION
Signed single bit bitfield is either `0` or `-1` rather than `0` or `1`. GCC 5.2 is not happy about the implicit type conversion when assigning `1` to it....
