### PR TITLE
Documented abs overflow behavior, added checked_abs for overflow prot…

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -44,7 +44,32 @@ copysign(x::Signed, y::Float64) = copysign(x, reinterpret(Int64,y))
 copysign(x::Signed, y::Real)    = copysign(x, -oftype(x,signbit(y)))
 
 abs(x::Unsigned) = x
+
+"""
+    abs(x::Signed)
+
+The absolute value of x.  When `abs` is applied to signed integers,
+overflow may occur, resulting in the return of a negative value.  This
+overflow occurs only when `abs` is applied to the minimum
+representable value of a signed integer.  That is when `x ==
+typemin(typeof(x))`, `abs(x) == x`, not `-x` as might be expected.
+
+"""
 abs(x::Signed) = flipsign(x,x)
+
+"""
+    checked_abs(x::Signed)
+
+The absolute value of x, with signed integer overflow error trapping.
+`checked_abs` will throw an `OverflowError` when `x ==
+typemin(typeof(x))`.  Otherwise `checked_abs` behaves as `abs`, though
+the overflow protection may impose a perceptible performance penalty.
+
+"""
+function checked_abs{T<:Signed}(x::T)
+    x == typemin(T) && throw(OverflowError())
+    abs(x)
+end
 
 ~(n::Integer) = -n-1
 

--- a/test/int.jl
+++ b/test/int.jl
@@ -158,5 +158,3 @@ end
 #@test_throws OverflowError checked_mul(UInt128(2)^127, UInt128(2))
 @test checked_mul(UInt128(2)^127, UInt128(2)) === UInt128(0)
 # broken
-
-    

--- a/test/int.jl
+++ b/test/int.jl
@@ -125,7 +125,7 @@ end
 
 # checked operations
 
-import Base: checked_add, checked_sub, checked_mul
+import Base: checked_add, checked_sub, checked_mul, checked_abs
 @test checked_sub(UInt(4), UInt(3)) === UInt(1)
 @test_throws OverflowError checked_sub(UInt(5), UInt(6))
 @test checked_mul(UInt(4), UInt(3)) === UInt(12)
@@ -136,6 +136,11 @@ if WORD_SIZE == 32
     @test_throws OverflowError checked_mul(UInt(2)^30, UInt(2)^2)
 else
     @test_throws OverflowError checked_mul(UInt(2)^62, UInt(2)^2)
+end
+
+for T in SItypes
+    @test checked_abs(-one(T)) == one(T)
+    @test_throws OverflowError checked_abs(typemin(T))
 end
 
 # Checked operations on UInt128 are currently broken
@@ -153,3 +158,5 @@ end
 #@test_throws OverflowError checked_mul(UInt128(2)^127, UInt128(2))
 @test checked_mul(UInt128(2)^127, UInt128(2)) === UInt128(0)
 # broken
+
+    


### PR DESCRIPTION
…ection
## Summary

This PR is to address, in part, #13549.  It adds documentation to the signed integer version of `abs` that explains its overflow behavior.  It also adds an overflow trapped version of this function, `Base.checked_abs`.  As yet unaddressed is the addition of an _Integer overflow_ entry to Julia's FAQ.
## `abs` Documentation

With this change, the documentation for `abs` reads:

```
julia> @doc abs
  abs(x::Signed)

  The absolute value of x.  When abs is applied to signed integers, overflow may occur, resulting in the
  return of a negative value.  This overflow occurs only when abs is applied to the minimum representable
  value of a signed integer.  That is when x == typemin(typeof(x)), abs(x) == x, not -x as might be
  expected.

  abs(x)

  Absolute value of x
```

It is interesting that the added signed integer specific `abs` documentation is printed prior to the already existing generic documentation.  As far as I can tell, such presentation is a result of the design of the documentation system, which presents documentation in order of descending specificity,
## `Base.checked_abs`

This function's documentation tells most of the story:

```
julia> @doc Base.checked_abs
  checked_abs(x::Signed)

  The absolute value of x, with signed integer overflow error trapping. checked_abs will throw an
  OverflowError when x == typemin(typeof(x)).  Otherwise checked_abs behaves as abs, though the overflow
  protection may impose a perceptible performance penalty.
```

 I chose to implement this function only for Signed types, rather than (trivially) making it more generic.  I did so, because it struck me as a sort of false advertising to provide this function for other types when it useful only for Signed types.  That said, I have no strong feelings against making it more generic.
