### PR TITLE
Prevent flisp from triggering the Darwin C library's overflow check

### DIFF
--- a/src/flisp/flisp.c
+++ b/src/flisp/flisp.c
@@ -267,7 +267,7 @@ static symbol_t *mk_symbol(const char *str)
     symbol_t *sym;
     size_t len = strlen(str);
 
-    sym = (symbol_t*)malloc((sizeof(symbol_t)-sizeof(void*)+len+1+7)&-8);
+    sym = (symbol_t*)malloc((offsetof(symbol_t,name)+len+1+7)&-8);
     CHECK_ALIGN8(sym);
     sym->left = sym->right = NULL;
     sym->flags = 0;

--- a/src/flisp/flisp.h
+++ b/src/flisp/flisp.h
@@ -38,10 +38,7 @@ typedef struct _symbol_t {
     // below fields are private
     struct _symbol_t *left;
     struct _symbol_t *right;
-    union {
-        char name[1];
-        void *_pad;    // ensure field aligned to pointer size
-    };
+    char name[] __attribute__((aligned(sizeof(void*))));
 } symbol_t;
 
 typedef struct {


### PR DESCRIPTION
If name is declared as char[1], anything else is considered an overflow
causing a runtime abort. This does the same thing, but with a char[].

cc @JeffBezanson
cc @tkelman for MSVC concerns
