### PR TITLE
Clean up Schur

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -1838,20 +1838,6 @@ Update `collection`, removing elements for which `function` is `false`. For asso
 filter!
 
 doc"""
-    schurfact(A) -> Schur
-
-Computes the Schur factorization of the matrix `A`. The (quasi) triangular Schur factor can be obtained from the `Schur` object `F` with either `F[:Schur]` or `F[:T]` and the unitary/orthogonal Schur vectors can be obtained with `F[:vectors]` or `F[:Z]` such that `A=F[:vectors]*F[:Schur]*F[:vectors]'`. The eigenvalues of `A` can be obtained with `F[:values]`.
-"""
-schurfact(A)
-
-doc"""
-    schurfact(A, B) -> GeneralizedSchur
-
-Computes the Generalized Schur (or QZ) factorization of the matrices `A` and `B`. The (quasi) triangular Schur factors can be obtained from the `Schur` object `F` with `F[:S]` and `F[:T]`, the left unitary/orthogonal Schur vectors can be obtained with `F[:left]` or `F[:Q]` and the right unitary/orthogonal Schur vectors can be obtained with `F[:right]` or `F[:Z]` such that `A=F[:left]*F[:S]*F[:right]'` and `B=F[:left]*F[:T]*F[:right]'`. The generalized eigenvalues of `A` and `B` can be obtained with `F[:alpha]./F[:beta]`.
-"""
-schurfact(A, B)
-
-doc"""
     base64decode(string)
 
 Decodes the base64-encoded `string` and returns a `Vector{UInt8}` of the decoded bytes.
@@ -2092,24 +2078,6 @@ doc"""
 Reseed the random number generator. If a `seed` is provided, the RNG will give a reproducible sequence of numbers, otherwise Julia will get entropy from the system. For `MersenneTwister`, the `seed` may be a non-negative integer, a vector of `UInt32` integers or a filename, in which case the seed is read from a file. `RandomDevice` does not support seeding.
 """
 srand
-
-doc"""
-```rst
-..  schur(A) -> Schur[:T], Schur[:Z], Schur[:values]
-
-See :func:`schurfact`
-```
-"""
-schur(A)
-
-doc"""
-```rst
-..  schur(A,B) -> GeneralizedSchur[:S], GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
-
-See :func:`schurfact`
-```
-"""
-schur(A,B)
 
 doc"""
     isexecutable(path) -> Bool
@@ -3067,42 +3035,6 @@ doc"""
 Accepts a connection on the given server and returns a connection to the client. An uninitialized client stream may be provided, in which case it will be used instead of creating a new stream.
 """
 accept
-
-doc"""
-```rst
-..  ordschur(Q, T, select) -> Schur
-
-Reorders the Schur factorization of a real matrix ``A=Q*T*Q'`` according to the logical array ``select`` returning a Schur object ``F``. The selected eigenvalues appear in the leading diagonal of ``F[:Schur]`` and the the corresponding leading columns of ``F[:vectors]`` form an orthonormal basis of the corresponding right invariant subspace. A complex conjugate pair of eigenvalues must be either both included or excluded via ``select``.
-```
-"""
-ordschur(Q, T, select)
-
-doc"""
-```rst
-..  ordschur(S, select) -> Schur
-
-Reorders the Schur factorization ``S`` of type ``Schur``.
-```
-"""
-ordschur(S::Schur, select)
-
-doc"""
-```rst
-..  ordschur(S, T, Q, Z, select) -> GeneralizedSchur
-
-Reorders the Generalized Schur factorization of a matrix ``(A, B) = (Q*S*Z^{H}, Q*T*Z^{H})`` according to the logical array ``select`` and returns a GeneralizedSchur object ``GS``.  The selected eigenvalues appear in the leading diagonal of both ``(GS[:S], GS[:T])`` and the left and right unitary/orthogonal Schur vectors are also reordered such that ``(A, B) = GS[:Q]*(GS[:S], GS[:T])*GS[:Z]^{H}`` still holds and the generalized eigenvalues of ``A`` and ``B`` can still be obtained with ``GS[:alpha]./GS[:beta]``.
-```
-"""
-ordschur(S, T, Q, Z)
-
-doc"""
-```rst
-..  ordschur(GS, select) -> GeneralizedSchur
-
-Reorders the Generalized Schur factorization of a Generalized Schur object.  See :func:`ordschur`.
-```
-"""
-ordschur(GS::GeneralizedSchur, select)
 
 doc"""
     triu!(M)
@@ -6009,42 +5941,6 @@ sin
 
 doc"""
 ```rst
-..  ordschur!(Q, T, select) -> Schur
-
-Reorders the Schur factorization of a real matrix ``A=Q*T*Q'``, overwriting ``Q`` and ``T`` in the process. See :func:`ordschur`
-```
-"""
-ordschur!(Q,T,select)
-
-doc"""
-```rst
-..  ordschur!(S, select) -> Schur
-
-Reorders the Schur factorization ``S`` of type ``Schur``, overwriting ``S`` in the process. See :func:`ordschur`
-```
-"""
-ordschur!(S,select)
-
-doc"""
-```rst
-..  ordschur!(S, T, Q, Z, select) -> GeneralizedSchur
-
-Reorders the Generalized Schur factorization of a matrix by overwriting the matrices ``(S, T, Q, Z)`` in the process.  See :func:`ordschur`.
-```
-"""
-ordschur!(S,T,Q,Z,select)
-
-doc"""
-```rst
-..  ordschur!(GS, select) -> GeneralizedSchur
-
-Reorders the Generalized Schur factorization of a Generalized Schur object by overwriting the object with the new factorization.  See :func:`ordschur`.
-```
-"""
-ordschur!(::LinAlg.GeneralizedSchur,select)
-
-doc"""
-```rst
 ..  Base.compilecache(module::ByteString)
 
 Creates a precompiled cache file for module (see help for ``require``) and all of its dependencies. This can be used to reduce package load times. Cache files are stored in ``LOAD_CACHE_PATH[1]``, which defaults to ``~/.julia/lib/VERSION``. See :ref:`Module initialization and precompilation <man-modules-initialization-precompilation>` for important notes.
@@ -6673,15 +6569,6 @@ ERROR: ArgumentError: indices must be unique and sorted
 ```
 """
 deleteat!(collection, itr)
-
-doc"""
-```rst
-..  schurfact!(A)
-
-Computes the Schur factorization of ``A``, overwriting ``A`` in the process. See :func:`schurfact`
-```
-"""
-schurfact!
 
 doc"""
     read(stream, type)

--- a/base/linalg/schur.jl
+++ b/base/linalg/schur.jl
@@ -9,7 +9,18 @@ immutable Schur{Ty<:BlasFloat, S<:AbstractMatrix} <: Factorization{Ty}
 end
 Schur{Ty}(T::AbstractMatrix{Ty}, Z::AbstractMatrix{Ty}, values::Vector) = Schur{Ty, typeof(T)}(T, Z, values)
 
+doc"""
+    schurfact!(A::StridedMatrix) -> F::Schur
+
+Same as `schurfact` but uses the input argument as workspace.
+"""
 schurfact!{T<:BlasFloat}(A::StridedMatrix{T}) = Schur(LinAlg.LAPACK.gees!('V', A)...)
+
+doc"""
+    schurfact(A::StridedMatrix) -> F::Schur
+
+Computes the Schur factorization of the matrix `A`. The (quasi) triangular Schur factor can be obtained from the `Schur` object `F` with either `F[:Schur]` or `F[:T]` and the orthogonal/unitary Schur vectors can be obtained with `F[:vectors]` or `F[:Z]` such that `A = F[:vectors]*F[:Schur]*F[:vectors]'`. The eigenvalues of `A` can be obtained with `F[:values]`.
+"""
 schurfact{T<:BlasFloat}(A::StridedMatrix{T}) = schurfact!(copy(A))
 function schurfact{T}(A::StridedMatrix{T})
     S = promote_type(Float32, typeof(one(T)/norm(one(T))))
@@ -28,15 +39,50 @@ function getindex(F::Schur, d::Symbol)
     end
 end
 
+doc"""
+    schur(A::StridedMatrix) -> T::Matrix, Z::Matrix, λ::Vector
+
+Computes the Schur factorization of the matrix `A`. The methods return the (quasi) triangular Schur factor `T` and the orthogonal/unitary Schur vectors `Z` such that `A = Z*T*Z'`. The eigenvalues of `A` are returned in the vector `λ`.
+
+See `schurfact`
+"""
 function schur(A::StridedMatrix)
     SchurF = schurfact(A)
     SchurF[:T], SchurF[:Z], SchurF[:values]
 end
 
-ordschur!{Ty<:BlasFloat}(Q::StridedMatrix{Ty}, T::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) = Schur(LinAlg.LAPACK.trsen!(convert(Vector{BlasInt}, select), T , Q)...)
-ordschur{Ty<:BlasFloat}(Q::StridedMatrix{Ty}, T::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) = ordschur!(copy(Q), copy(T), select)
-ordschur!{Ty<:BlasFloat}(schur::Schur{Ty}, select::Union{Vector{Bool},BitVector}) = (res=ordschur!(schur.Z, schur.T, select); schur[:values][:]=res[:values]; res)
-ordschur{Ty<:BlasFloat}(schur::Schur{Ty}, select::Union{Vector{Bool},BitVector}) = ordschur(schur.Z, schur.T, select)
+doc"""
+    ordschur!(F::Schur, select::Union{Vector{Bool},BitVector}) -> F::Schur
+
+Same as `ordschur` but overwrites the factorization `F`.
+"""
+function ordschur!{Ty<:BlasFloat}(schur::Schur{Ty}, select::Union{Vector{Bool},BitVector})
+    _, _, vals = ordschur!(schur.T, schur.Z, select)
+    schur[:values][:] = vals
+    return schur
+end
+
+doc"""
+    ordschur(F::Schur, select::Union{Vector{Bool},BitVector}) -> F::Schur
+
+Reorders the Schur factorization `F` of a matrix `A = Z*T*Z'` according to the logical array `select` returning the reordered factorization `F` object. The selected eigenvalues appear in the leading diagonal of `F[:Schur]` and the the corresponding leading columns of `F[:vectors]` form an orthogonal/unitary basis of the corresponding right invariant subspace. In the real case, a complex conjugate pair of eigenvalues must be either both included or both excluded via `select`.
+
+"""
+ordschur{Ty<:BlasFloat}(schur::Schur{Ty}, select::Union{Vector{Bool},BitVector}) = Schur(ordschur(schur.T, schur.Z, select)...)
+
+doc"""
+    ordschur!(T::StridedMatrix, Z::StridedMatrix, select::Union{Vector{Bool},BitVector}) -> T::StridedMatrix, Z::StridedMatrix, λ::Vector
+
+Same as `ordschur` but overwrites the input arguments.
+"""
+ordschur!{Ty<:BlasFloat}(T::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) = LinAlg.LAPACK.trsen!(convert(Vector{BlasInt}, select), T, Z)
+
+doc"""
+    ordschur(T::StridedMatrix, Z::StridedMatrix, select::Union{Vector{Bool},BitVector}) -> T::StridedMatrix, Z::StridedMatrix, λ::Vector
+
+Reorders the Schur factorization of a real matrix `A = Z*T*Z'` according to the logical array `select` returning the reordered matrices `T` and `Z` as well as the vector of eigenvalues `λ`. The selected eigenvalues appear in the leading diagonal of `T` and the the corresponding leading columns of `Z` form an orthogonal/unitary basis of the corresponding right invariant subspace. In the real case, a complex conjugate pair of eigenvalues must be either both included or both excluded via `select`.
+"""
+ordschur{Ty<:BlasFloat}(T::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) = ordschur!(copy(T), copy(Z), select)
 
 immutable GeneralizedSchur{Ty<:BlasFloat, M<:AbstractMatrix} <: Factorization{Ty}
     S::M
@@ -49,17 +95,57 @@ immutable GeneralizedSchur{Ty<:BlasFloat, M<:AbstractMatrix} <: Factorization{Ty
 end
 GeneralizedSchur{Ty}(S::AbstractMatrix{Ty}, T::AbstractMatrix{Ty}, alpha::Vector, beta::Vector{Ty}, Q::AbstractMatrix{Ty}, Z::AbstractMatrix{Ty}) = GeneralizedSchur{Ty, typeof(S)}(S, T, alpha, beta, Q, Z)
 
+doc"""
+    schurfact!(A::StridedMatrix, B::StridedMatrix) -> F::GeneralizedSchur
+
+Same as `schurfact` but uses the input matrices `A` and `B` as workspace.
+"""
 schurfact!{T<:BlasFloat}(A::StridedMatrix{T}, B::StridedMatrix{T}) = GeneralizedSchur(LinAlg.LAPACK.gges!('V', 'V', A, B)...)
+
+doc"""
+    schurfact(A::StridedMatrix, B::StridedMatrix) -> F::GeneralizedSchur
+
+Computes the Generalized Schur (or QZ) factorization of the matrices `A` and `B`. The (quasi) triangular Schur factors can be obtained from the `Schur` object `F` with `F[:S]` and `F[:T]`, the left unitary/orthogonal Schur vectors can be obtained with `F[:left]` or `F[:Q]` and the right unitary/orthogonal Schur vectors can be obtained with `F[:right]` or `F[:Z]` such that `A=F[:left]*F[:S]*F[:right]'` and `B=F[:left]*F[:T]*F[:right]'`. The generalized eigenvalues of `A` and `B` can be obtained with `F[:alpha]./F[:beta]`.
+"""
 schurfact{T<:BlasFloat}(A::StridedMatrix{T},B::StridedMatrix{T}) = schurfact!(copy(A),copy(B))
 function schurfact{TA,TB}(A::StridedMatrix{TA}, B::StridedMatrix{TB})
     S = promote_type(Float32, typeof(one(TA)/norm(one(TA))), TB)
     return schurfact!(copy_oftype(A, S), copy_oftype(B, S))
 end
 
-ordschur!{Ty<:BlasFloat}(S::StridedMatrix{Ty}, T::StridedMatrix{Ty}, Q::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) = GeneralizedSchur(LinAlg.LAPACK.tgsen!(convert(Vector{BlasInt}, select), S, T, Q, Z)...)
-ordschur{Ty<:BlasFloat}(S::StridedMatrix{Ty}, T::StridedMatrix{Ty}, Q::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) = ordschur!(copy(S), copy(T), copy(Q), copy(Z), select)
-ordschur!{Ty<:BlasFloat}(gschur::GeneralizedSchur{Ty}, select::Union{Vector{Bool},BitVector}) = (res=ordschur!(gschur.S, gschur.T, gschur.Q, gschur.Z, select); gschur[:alpha][:]=res[:alpha]; gschur[:beta][:]=res[:beta]; res)
-ordschur{Ty<:BlasFloat}(gschur::GeneralizedSchur{Ty}, select::Union{Vector{Bool},BitVector}) = ordschur(gschur.S, gschur.T, gschur.Q, gschur.Z, select)
+doc"""
+    ordschur!(F::GeneralizedSchur, select::Union{Vector{Bool},BitVector}) -> F::GeneralizedSchur
+
+Same as `ordschur` but overwrites the factorization `F`.
+"""
+function ordschur!{Ty<:BlasFloat}(gschur::GeneralizedSchur{Ty}, select::Union{Vector{Bool},BitVector})
+    _, _, α, β, _, _ = ordschur!(gschur.S, gschur.T, gschur.Q, gschur.Z, select)
+    gschur[:alpha][:] = α
+    gschur[:beta][:] = β
+    return gschur
+end
+
+doc"""
+    ordschur(F::GeneralizedSchur, select::Union{Vector{Bool},BitVector}) -> F::GeneralizedSchur
+
+Reorders the Generalized Schur factorization `F` of a matrix pair `(A, B) = (Q*S*Z^{H}, Q*T*Z^{H})` according to the logical array `select` and returns a GeneralizedSchur object `F`.  The selected eigenvalues appear in the leading diagonal of both `F[:S]` and F[:T]`, and the left and right orthogonal/unitary Schur vectors are also reordered such that `(A, B) = F[:Q]*(F[:S], F[:T])*F[:Z]^{H}` still holds and the generalized eigenvalues of `A` and `B` can still be obtained with `F[:alpha]./F[:beta]`.
+"""
+ordschur{Ty<:BlasFloat}(gschur::GeneralizedSchur{Ty}, select::Union{Vector{Bool},BitVector}) = GeneralizedSchur(ordschur(gschur.S, gschur.T, gschur.Q, gschur.Z, select)...)
+
+doc"""
+    ordschur!(S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, select) -> S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, α::Vector, β::Vector
+
+Same as `ordschur` but overwrites the factorization the input arguments.
+"""
+ordschur!{Ty<:BlasFloat}(S::StridedMatrix{Ty}, T::StridedMatrix{Ty}, Q::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) = LinAlg.LAPACK.tgsen!(convert(Vector{BlasInt}, select), S, T, Q, Z)
+
+doc"""
+    ordschur(S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, select) -> S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, α::Vector, β::Vector
+
+Reorders the Generalized Schur factorization of a matrix pair `(A, B) = (Q*S*Z', Q*T*Z')` according to the logical array `select` and returns the matrices `S`, `T`, `Q`, `Z` and vectors `α` and `β`.  The selected eigenvalues appear in the leading diagonal of both `S` and `T`, and the left and right unitary/orthogonal Schur vectors are also reordered such that `(A, B) = Q*(S, T)*Z'` still holds and the generalized eigenvalues of `A` and `B` can still be obtained with `α./β`.
+"""
+ordschur{Ty<:BlasFloat}(S::StridedMatrix{Ty}, T::StridedMatrix{Ty}, Q::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) =
+    ordschur!(copy(S), copy(T), copy(Q), copy(Z), select)
 
 function getindex(F::GeneralizedSchur, d::Symbol)
     if d == :S
@@ -81,9 +167,14 @@ function getindex(F::GeneralizedSchur, d::Symbol)
     end
 end
 
+doc"""
+    schur(A::StridedMatrix, B::StridedMatrix) -> S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, α::Vector, β::Vector
+
+See `schurfact`
+"""
 function schur(A::StridedMatrix, B::StridedMatrix)
     SchurF = schurfact(A, B)
-    SchurF[:S], SchurF[:T], SchurF[:Q], SchurF[:Z]
+    SchurF[:S], SchurF[:T], SchurF[:Q], SchurF[:Z], SchurF[:alpha], SchurF[:beta]
 end
 
 full(F::Schur) = (F.Z * F.T) * F.Z'

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -237,7 +237,7 @@ General I/O
 
    .. Docstring generated from Julia source
 
-   Write an arbitrary value to a stream in an opaque format, such that it can be read back by ``deserialize``\ . The read-back value will be as identical as possible to the original. In general, this process will not work if the reading and writing are done by different versions of Julia, or an instance of Julia with a different system image.
+   Write an arbitrary value to a stream in an opaque format, such that it can be read back by ``deserialize``\ . The read-back value will be as identical as possible to the original. In general, this process will not work if the reading and writing are done by different versions of Julia, or an instance of Julia with a different system image. ``Ptr`` values are serialized as all-zero bit patterns (``NULL``\ ).
 
 .. function:: deserialize(stream)
 

--- a/doc/stdlib/linalg.rst
+++ b/doc/stdlib/linalg.rst
@@ -392,83 +392,93 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    ``hessfact!`` is the same as :func:`hessfact`, but saves space by overwriting the input ``A``, instead of creating a copy.
 
-.. function:: schurfact(A) -> Schur
+.. function:: schurfact(A::StridedMatrix) -> F::Schur
 
    .. Docstring generated from Julia source
 
-   Computes the Schur factorization of the matrix ``A``\ . The (quasi) triangular Schur factor can be obtained from the ``Schur`` object ``F`` with either ``F[:Schur]`` or ``F[:T]`` and the unitary/orthogonal Schur vectors can be obtained with ``F[:vectors]`` or ``F[:Z]`` such that ``A=F[:vectors]*F[:Schur]*F[:vectors]'``\ . The eigenvalues of ``A`` can be obtained with ``F[:values]``\ .
+   Computes the Schur factorization of the matrix ``A``\ . The (quasi) triangular Schur factor can be obtained from the ``Schur`` object ``F`` with either ``F[:Schur]`` or ``F[:T]`` and the orthogonal/unitary Schur vectors can be obtained with ``F[:vectors]`` or ``F[:Z]`` such that ``A = F[:vectors]*F[:Schur]*F[:vectors]'``\ . The eigenvalues of ``A`` can be obtained with ``F[:values]``\ .
 
-.. function:: schurfact!(A)
-
-   .. Docstring generated from Julia source
-
-   Computes the Schur factorization of ``A``, overwriting ``A`` in the process. See :func:`schurfact`
-
-.. function:: schur(A) -> Schur[:T], Schur[:Z], Schur[:values]
+.. function:: schurfact!(A::StridedMatrix) -> F::Schur
 
    .. Docstring generated from Julia source
 
-   See :func:`schurfact`
+   Same as ``schurfact`` but uses the input argument as workspace.
 
-.. function:: ordschur(Q, T, select) -> Schur
-
-   .. Docstring generated from Julia source
-
-   Reorders the Schur factorization of a real matrix ``A=Q*T*Q'`` according to the logical array ``select`` returning a Schur object ``F``. The selected eigenvalues appear in the leading diagonal of ``F[:Schur]`` and the the corresponding leading columns of ``F[:vectors]`` form an orthonormal basis of the corresponding right invariant subspace. A complex conjugate pair of eigenvalues must be either both included or excluded via ``select``.
-
-.. function:: ordschur!(Q, T, select) -> Schur
+.. function:: schur(A::StridedMatrix) -> T::Matrix, Z::Matrix, λ::Vector
 
    .. Docstring generated from Julia source
 
-   Reorders the Schur factorization of a real matrix ``A=Q*T*Q'``, overwriting ``Q`` and ``T`` in the process. See :func:`ordschur`
+   Computes the Schur factorization of the matrix ``A``\ . The methods returns the (quasi) triangular Schur factor ``T`` and the orthogonal/unitary Schur vectors ``Z`` such that ``A = Z*T*Z'``\ . The eigenvalues of ``A`` are returned in the vector ``λ``\ .
 
-.. function:: ordschur(S, select) -> Schur
+   See ``schurfact``
 
-   .. Docstring generated from Julia source
-
-   Reorders the Schur factorization ``S`` of type ``Schur``.
-
-.. function:: ordschur!(S, select) -> Schur
+.. function:: ordschur(F::Schur, select::Union{Vector{Bool},BitVector}) -> F::Schur
 
    .. Docstring generated from Julia source
 
-   Reorders the Schur factorization ``S`` of type ``Schur``, overwriting ``S`` in the process. See :func:`ordschur`
+   Reorders the Schur factorization ``F`` of a matrix ``A = Z*T*Z'`` according to the logical array ``select`` returning the reordered factorization ``F`` object. The selected eigenvalues appear in the leading diagonal of ``F[:Schur]`` and the the corresponding leading columns of ``F[:vectors]`` form an orthogonal/unitary basis of the corresponding right invariant subspace. In the real case, a complex conjugate pair of eigenvalues must be either both included or excluded via ``select``\ .
 
-.. function:: schurfact(A, B) -> GeneralizedSchur
+.. function:: ordschur!(F::Schur, select::Union{Vector{Bool},BitVector}) -> F::Schur
+
+   .. Docstring generated from Julia source
+
+   Same as ``ordschur`` but overwrites the factorization ``F``\ .
+
+.. function:: ordschur(T::StridedMatrix, Z::StridedMatrix, select::Union{Vector{Bool},BitVector}) -> T::StridedMatrix, Z::StridedMatrix, λ::Vector
+
+   .. Docstring generated from Julia source
+
+   ..  ordschur(T::StridedMatrix, Z::StridedMatrix, select::Union{Vector{Bool},BitVector}) -> T::StridedMatrix, Z::StridedMatrix, λ::Vector
+
+   Reorders the Schur factorization of a real matrix ``A = Z*T*Z'`` according to the logical array ``select`` returning the reordered matrices ``T`` and ``Z`` as well as the vector of eigenvalues ``λ``\ . The selected eigenvalues appear in the leading diagonal of ``T`` and the the corresponding leading columns of ``Z`` form an orthogonal/unitary basis of the corresponding right invariant subspace. In the real case, a complex conjugate pair of eigenvalues must be either both included or excluded via ``select``\ .
+
+.. function:: ordschur!(T::StridedMatrix, Z::StridedMatrix, select::Union{Vector{Bool},BitVector}) -> T::StridedMatrix, Z::StridedMatrix, λ::Vector
+
+   .. Docstring generated from Julia source
+
+   Same as ``ordschur`` but overwrites the input arguments.
+
+.. function:: schurfact(A::StridedMatrix, B::StridedMatrix) -> F::GeneralizedSchur
 
    .. Docstring generated from Julia source
 
    Computes the Generalized Schur (or QZ) factorization of the matrices ``A`` and ``B``\ . The (quasi) triangular Schur factors can be obtained from the ``Schur`` object ``F`` with ``F[:S]`` and ``F[:T]``\ , the left unitary/orthogonal Schur vectors can be obtained with ``F[:left]`` or ``F[:Q]`` and the right unitary/orthogonal Schur vectors can be obtained with ``F[:right]`` or ``F[:Z]`` such that ``A=F[:left]*F[:S]*F[:right]'`` and ``B=F[:left]*F[:T]*F[:right]'``\ . The generalized eigenvalues of ``A`` and ``B`` can be obtained with ``F[:alpha]./F[:beta]``\ .
 
-.. function:: schur(A,B) -> GeneralizedSchur[:S], GeneralizedSchur[:T], GeneralizedSchur[:Q], GeneralizedSchur[:Z]
+.. function:: schurfact!(A::StridedMatrix, B::StridedMatrix) -> F::GeneralizedSchur
 
    .. Docstring generated from Julia source
 
-   See :func:`schurfact`
+   Same as ``schurfact`` but uses the input matrices ``A`` and ``B`` as workspace.
 
-.. function:: ordschur(S, T, Q, Z, select) -> GeneralizedSchur
-
-   .. Docstring generated from Julia source
-
-   Reorders the Generalized Schur factorization of a matrix ``(A, B) = (Q*S*Z^{H}, Q*T*Z^{H})`` according to the logical array ``select`` and returns a GeneralizedSchur object ``GS``.  The selected eigenvalues appear in the leading diagonal of both ``(GS[:S], GS[:T])`` and the left and right unitary/orthogonal Schur vectors are also reordered such that ``(A, B) = GS[:Q]*(GS[:S], GS[:T])*GS[:Z]^{H}`` still holds and the generalized eigenvalues of ``A`` and ``B`` can still be obtained with ``GS[:alpha]./GS[:beta]``.
-
-.. function:: ordschur!(S, T, Q, Z, select) -> GeneralizedSchur
+.. function:: ordschur(F::GeneralizedSchur, select::Union{Vector{Bool},BitVector}) -> F::GeneralizedSchur
 
    .. Docstring generated from Julia source
 
-   Reorders the Generalized Schur factorization of a matrix by overwriting the matrices ``(S, T, Q, Z)`` in the process.  See :func:`ordschur`.
+   Reorders the Generalized Schur factorization ``F`` of a matrix pair ``(A, B) = (Q*S*Z^{H}, Q*T*Z^{H})`` according to the logical array ``select`` and returns a GeneralizedSchur object ``F``\ .  The selected eigenvalues appear in the leading diagonal of both ``F[:S]`` and F[:T]``, and the left and right orthogonal/unitary Schur vectors are also reordered such that `(A, B) = F[:Q]*(F[:S], F[:T])*F[:Z]^{H}`` still holds and the generalized eigenvalues of ``A`` and ``B`` can still be obtained with ``F[:alpha]./F[:beta]``\ .
 
-.. function:: ordschur(GS, select) -> GeneralizedSchur
-
-   .. Docstring generated from Julia source
-
-   Reorders the Generalized Schur factorization of a Generalized Schur object.  See :func:`ordschur`.
-
-.. function:: ordschur!(GS, select) -> GeneralizedSchur
+.. function:: ordschur!(F::GeneralizedSchur, select::Union{Vector{Bool},BitVector}) -> F::GeneralizedSchur
 
    .. Docstring generated from Julia source
 
-   Reorders the Generalized Schur factorization of a Generalized Schur object by overwriting the object with the new factorization.  See :func:`ordschur`.
+   Same as ``ordschur`` but overwrites the factorization ``F``\ .
+
+.. function:: ordschur(S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, select) -> S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, α::Vector, β::Vector
+
+   .. Docstring generated from Julia source
+
+   Reorders the Generalized Schur factorization of a matrix pair ``(A, B) = (Q*S*Z^{H}, Q*T*Z^{H})`` according to the logical array ``select`` and returns the matrices ``S``\ , ``T``\ , ``Q``\ , ``Z`` and vectors ``α`` and ``β``\ .  The selected eigenvalues appear in the leading diagonal of both ``S`` and ``T``\ , and the left and right unitary/orthogonal Schur vectors are also reordered such that ``(A, B) = Q*(S, T)*Z^{H}`` still holds and the generalized eigenvalues of ``A`` and ``B`` can still be obtained with ``α./β``\ .
+
+.. function:: ordschur!(S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, select) -> S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, α::Vector, β::Vector
+
+   .. Docstring generated from Julia source
+
+   Same as ``ordschur`` but overwrites the factorization the input arguments.
+
+.. function:: schur(A::StridedMatrix, B::StridedMatrix) -> S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, α::Vector, β::Vector
+
+   .. Docstring generated from Julia source
+
+   See ``schurfact``
 
 .. function:: svdfact(A, [thin=true]) -> SVD
 
@@ -733,8 +743,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 
    For more information, see [issue8859]_, [B96]_, [S84]_, [KY88]_.
 
-   .. [issue8859] Issue 8859, "Fix least squares",
-      https://github.com/JuliaLang/julia/pull/8859
+   .. [issue8859] Issue 8859, "Fix least squares", https://github.com/JuliaLang/julia/pull/8859
    .. [B96] Åke Björck, "Numerical Methods for Least Squares Problems",
       SIAM Press, Philadelphia, 1996, "Other Titles in Applied Mathematics", Vol. 51.
       `doi:10.1137/1.9781611971484 <http://epubs.siam.org/doi/book/10.1137/1.9781611971484>`_

--- a/test/linalg/schur.jl
+++ b/test/linalg/schur.jl
@@ -43,8 +43,8 @@ debug && println("Reorder Schur")
     sum(select) != 0 && @test_approx_eq S[:values][find(select)] O[:values][1:sum(select)]
     @test_approx_eq O[:vectors]*O[:Schur]*O[:vectors]' ordschura
     @test_throws KeyError f[:A]
-    Snew = Base.LinAlg.Schur(copy(S.T),copy(S.Z),copy(S.values))
-    SchurNew = ordschur!(Snew,select)
+    Snew = Base.LinAlg.Schur(copy(S.T), copy(S.Z), copy(S.values))
+    SchurNew = ordschur!(Snew, select)
     @test O[:vectors] ≈ SchurNew[:vectors]
     @test O[:Schur] ≈ SchurNew[:Schur]
 
@@ -72,8 +72,8 @@ debug && println("Reorder Generalized Schur")
     # Make sure that we have sorted it correctly
     @test_approx_eq NS[:values][find(select)] S[:values][1:m]
 
-    Snew = Base.LinAlg.GeneralizedSchur(copy(NS.S),copy(NS.T),copy(NS.alpha),copy(NS.beta),copy(NS.Q),copy(NS.Z))
-    SchurNew = ordschur!(Snew,select)
+    Snew = Base.LinAlg.GeneralizedSchur(copy(NS.S), copy(NS.T), copy(NS.alpha), copy(NS.beta), copy(NS.Q), copy(NS.Z))
+    SchurNew = ordschur!(Snew, select)
     @test S[:Q] ≈ SchurNew[:Q]
     @test S[:S] ≈ SchurNew[:S]
     @test S[:T] ≈ SchurNew[:T]


### PR DESCRIPTION
This is a fix of JuliaLang/LinearAlgebra.jl#267 as well as a general cleanup in all the Schur methods. As noted in the other issue, this is technically breaking `ordschur`, but practically I don't think it is. I've searched through all github repositories using `ordschur` and none of them is using the version I'm changing here.

@spencerlyon2 I think it has mainly been economists who have been using `ordschur`. Do you think this change will have fatal consequences for any code bases that you know of? I would expect most users of `ordschur` to use the `ordschur(Schur)` mehod and not the `ordschur(`T,Z)` method and if that is the case this change won't affect anyone.

It would be great if someone could look through the doc strings.
