### PR TITLE
@select macro fixes

### DIFF
--- a/doc/manual/parallel-computing.rst
+++ b/doc/manual/parallel-computing.rst
@@ -484,11 +484,8 @@ Consider this simple example which times out if a computation takes too long::
         end
 
         @select begin
-            if output_channel |> value
-                println("Calculation produced $value")
-            elseif timeout_channel
-                println("Timed out waiting for computation")
-            end
+            output_channel |> value => println("Calculation produced $value")
+            timeout_channel         => println("Timed out waiting for computation")
         end
     end
 

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -30,13 +30,10 @@ function select_block_test(t1, t2, t3, t4)
     end
 
     @select begin
-        if c1 |> x
-            "Got $x from c1"
-        elseif c2
-            "Got a message from c2"
-        elseif c3 <| :write_test
-            "Wrote to c3"
-        elseif task |> z
+        c1 |> x           => "Got $x from c1"
+        c2                =>  "Got a message from c2"
+        c3 <| :write_test => "Wrote to c3"
+        task |> z         => begin
             "Task finished with $z"
         end
     end
@@ -59,13 +56,9 @@ function select_nonblock_test(test)
     end
 
     @select begin
-        if c |> x
-            "Got $x from c"
-        elseif c2 <| 1
-            "Wrote to c2"
-        else
-            "Default case"
-        end
+        c |> x => "Got $x from c"
+        c2 <| 1 => "Wrote to c2"
+        _ => "Default case"
     end
 end
 


### PR DESCRIPTION
General:
Syntax change from if/else to =>

Blocking:
1. moved evaluation of body expression to original parent task.

Non Blocking:
1. Throw an error if more than one default case
2. Always check default case last regardless of written position
3. Allow resulting expression to be anything (previously it had to
evaluate to a valid rvalue)
