### PR TITLE
Don't use _mapreduce for countnz

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -393,16 +393,8 @@ end
 
 function count(pred, itr)
     n = 0
-    for x in itr
-        pred(x) && (n += 1)
-    end
-    return n
-end
-
-function count(pred, A::AbstractArray)
-    n = 0
-    @inbounds for a in A
-        pred(a) && (n += 1)
+    @inbounds for x in itr
+        n += pred(x)
     end
     return n
 end


### PR DESCRIPTION
This was a surprising bottleneck in some of my code. Before I got

``` jl
julia> x = map(Float64, bitrand(10^8));

julia> @time countnz(x);
 0.458802 seconds (5 allocations: 176 bytes)

julia> @time countnz(x);
 0.505234 seconds (5 allocations: 176 bytes)
```

and with this change

``` jl
julia> x = map(Float64, bitrand(10^8));

julia> @time countnz(x);
  0.104807 seconds (3.82 k allocations: 201.454 KB)

julia> @time countnz(x);
  0.064269 seconds (5 allocations: 176 bytes)
```
