### PR TITLE
Avoid unnecessary overflow checking in non-Int Ranges iterating and indexing

### DIFF
--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -183,6 +183,12 @@ let s = 0
     end
     @test s == 256
 
+    s = 0
+    for i = typemin(UInt8):one(UInt8):typemax(UInt8)
+        s += 1
+    end
+    @test s == 256
+
     # loops past typemax(Int)
     n = 0
     s = Int128(0)


### PR DESCRIPTION
This basically makes the schematics of iterating through `UnitRange` identical with iterating though over a `StepRange` of the same `eltype` with step size `1`.

With this PR. (Note that this is running on my laptop instead of the faster machine I usually do benchmarks on so the overall performance is lower).

```
julia> function f{T}(n::T)
           s = zero(T)
           for i in one(T):one(T):n
               s += i
           end
           s
       end
f (generic function with 1 method)

julia> @benchmark f(Int32(1000))
================ Benchmark Results ========================
     Time per evaluation: 9.24 ns [9.12 ns, 9.36 ns]

julia> @benchmark f(Int(1000))
================ Benchmark Results ========================
     Time per evaluation: 16.87 ns [16.65 ns, 17.09 ns]
```

Fix #13864
