### PR TITLE
Vectorize `@ inbounds for x in A ...`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -265,7 +265,7 @@ collect(itr) = collect(eltype(itr), itr)
 ## Iteration ##
 start(A::Array) = 1
 next(a::Array,i) = (a[i],i+1)
-done(a::Array,i) = (i > length(a))
+done(a::Array,i) = i == length(a)+1
 
 ## Indexing: getindex ##
 


### PR DESCRIPTION
This would previously have been an infinite loop if `length(A) == typemax(Int)` so the loop vectorizer couldn't compute a trip count. Ref https://github.com/JuliaLang/julia/pull/13860#issuecomment-153490708
