### PR TITLE
[WIP,RFC] implement single precision Bessel functions in pure julia

### DIFF
--- a/base/special/j0f.jl
+++ b/base/special/j0f.jl
@@ -1,0 +1,324 @@
+# e_j0f.c -- float version of e_j0.c.
+# Conversion to float by Ian Lance Taylor, Cygnus Support, ian@cygnus.com.
+
+# ====================================================
+# Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+#
+# Developed at SunPro, a Sun Microsystems, Inc. business.
+# Permission to use, copy, modify, and distribute this
+# software is freely granted, provided that this notice
+# is preserved.
+# ====================================================
+
+module J0F
+
+import Base.Math: libm, @evalpoly
+
+sin_unchecked(x::Float32) = ccall((:sinf, libm), Float32, (Float32,), x)
+cos_unchecked(x::Float32) = ccall((:cosf, libm), Float32, (Float32,), x)
+log_unchecked(x::Float32) = ccall((:logf, libm), Float32, (Float32,), x)
+
+# The asymptotic expansions of pzero is
+#     1 - 9 / 128 s^2 + 11025 / 98304 s^4 - ..., where s = 1 / x.
+# For x >= 2, We approximate pzero by
+#     pzero(x) = 1 + R / S
+# where  R = pR0 + pR1 * s^2 + pR2 * s^4 + ... + pR5 * s^10
+#     S = 1 + pS0 * s^2 + ... + pS4 * s^10
+# and
+#     |pzero(x) - 1 - R / S| <= 2^-60.26
+const pR8 = (0.0000000000f00, # 0x00000000
+             -7.0312500000f-02, # 0xbd900000
+             -8.0816707611f+00, # 0xc1014e86
+             -2.5706311035f+02, # 0xc3808814
+             -2.4852163086f+03, # 0xc51b5376
+             -5.2530439453f+03, # 0xc5a4285a
+             )::NTuple{6,Float32}
+const pS8 = (1.1653436279f+02, # 0x42e91198
+             3.8337448730f+03, # 0x456f9beb
+             4.0597855469f+04, # 0x471e95db
+             1.1675296875f+05, # 0x47e4087c
+             4.7627726562f+04, # 0x473a0bba
+             )::NTuple{5,Float32}
+# for x in [8, 4.5454] = 1 / [0.125, 0.22001]
+const pR5 = (-1.1412546255f-11, # 0xad48c58a
+             -7.0312492549f-02, # 0xbd8fffff
+             -4.1596107483f+00, # 0xc0851b88
+             -6.7674766541f+01, # 0xc287597b
+             -3.3123129272f+02, # 0xc3a59d9b
+             -3.4643338013f+02, # 0xc3ad3779
+             )::NTuple{6,Float32}
+const pS5 = (6.0753936768f+01, # 0x42730408
+             1.0512523193f+03, # 0x44836813
+             5.9789707031f+03, # 0x45bad7c4
+             9.6254453125f+03, # 0x461665c8
+             2.4060581055f+03, # 0x451660ee
+             )::NTuple{5,Float32}
+# for x in [4.547, 2.8571] = 1 / [0.2199, 0.35001]
+const pR3 = (-2.5470459075f-09, # 0xb12f081b
+             -7.0311963558f-02, # 0xbd8fffb8
+             -2.4090321064f+00, # 0xc01a2d95
+             -2.1965976715f+01, # 0xc1afba52
+             -5.8079170227f+01, # 0xc2685112
+             -3.1447946548f+01, # 0xc1fb9565
+             )::NTuple{6,Float32}
+const pS3 = (3.5856033325f+01, # 0x420f6c94
+             3.6151397705f+02, # 0x43b4c1ca
+             1.1936077881f+03, # 0x44953373
+             1.1279968262f+03, # 0x448cffe6
+             1.7358093262f+02, # 0x432d94b8
+             )::NTuple{5,Float32}
+# for x in [2.8570, 2] = 1 / [0.3499, 0.5]
+const pR2 = (-8.8753431271f-08, # 0xb3be98b7
+             -7.0303097367f-02, # 0xbd8ffb12
+             -1.4507384300f+00, # 0xbfb9b1cc
+             -7.6356959343f+00, # 0xc0f4579f
+             -1.1193166733f+01, # 0xc1331736
+             -3.2336456776f+00, # 0xc04ef40d
+             )::NTuple{6,Float32}
+const pS2 = (2.2220300674f+01, # 0x41b1c32d
+             1.3620678711f+02, # 0x430834f0
+             2.7047027588f+02, # 0x43873c32
+             1.5387539673f+02, # 0x4319e01a
+             1.4657617569f+01, # 0x416a859a
+             )::NTuple{5,Float32}
+
+# Note: This function is only called for ix>=0x40000000 (see below)
+function pzerof(x::Float32)
+    ix = reinterpret(UInt32, x) & 0x7fffffff
+    # @assert ix >= 0x40000000 && ix <= 0x48000000
+    z = 1f0 / (x * x)
+    if ix >= 0x41000000
+        p = pR8
+        q = pS8
+    elseif ix >= 0x409173eb
+        p = pR5
+        q = pS5
+    elseif ix >= 0x4036d917
+        p = pR3
+        q = pS3
+    else
+        p = pR2
+        q = pS2
+    end
+    r = @evalpoly(z, p[1], p[2], p[3], p[4], p[5], p[6])
+    s = @evalpoly(z, 1f0, q[1], q[2], q[3], q[4], q[5])
+    1f0 + r / s
+end
+
+# For x >= 8, the asymptotic expansions of qzero is
+#    -1 / 8 s + 75 / 1024 s^3 - ..., where s = 1 / x.
+# We approximate pzero by
+#    qzero(x) = s * (-1.25 + R / S)
+# where  R = qR0 + qR1 * s^2 + qR2 * s^4 + ... + qR5 * s^10
+#    S = 1 + qS0 * s^2 + ... + qS5 * s^12
+# and
+#    |qzero(x) / s + 1.25 - R / S| <= 2^(-61.22)
+# for x in [inf, 8] = 1 / [0, 0.125]
+const qR8 = (0.0000000000f+00, # 0x00000000
+             7.3242187500f-02, # 0x3d960000
+             1.1768206596f+01, # 0x413c4a93
+             5.5767340088f+02, # 0x440b6b19
+             8.8591972656f+03, # 0x460a6cca
+             3.7014625000f+04, # 0x471096a0
+             )::NTuple{6,Float32}
+const qS8 = (1.6377603149f+02, # 0x4323c6aa
+             8.0983447266f+03, # 0x45fd12c2
+             1.4253829688f+05, # 0x480b3293
+             8.0330925000f+05, # 0x49441ed4
+             8.4050156250f+05, # 0x494d3359
+             -3.4389928125f+05, # 0xc8a7eb69
+             )::NTuple{6,Float32}
+# for x in [8, 4.5454] = 1 / [0.125, 0.22001]
+const qR5 = (1.8408595828f-11, # 0x2da1ec79
+             7.3242180049f-02, # 0x3d95ffff
+             5.8356351852f+00, # 0x40babd86
+             1.3511157227f+02, # 0x43071c90
+             1.0272437744f+03, # 0x448067cd
+             1.9899779053f+03, # 0x44f8bf4b
+             )::NTuple{6,Float32}
+const qS5 = (8.2776611328f+01, # 0x42a58da0
+             2.0778142090f+03, # 0x4501dd07
+             1.8847289062f+04, # 0x46933e94
+             5.6751113281f+04, # 0x475daf1d
+             3.5976753906f+04, # 0x470c88c1
+             -5.3543427734f+03, # 0xc5a752be
+             )::NTuple{6,Float32}
+# for x in [4.547, 2.8571] = 1 / [0.2199, 0.35001]
+const qR3 = (4.3774099900f-09, # 0x3196681b
+             7.3241114616f-02, # 0x3d95ff70
+             3.3442313671f+00, # 0x405607e3
+             4.2621845245f+01, # 0x422a7cc5
+             1.7080809021f+02, # 0x432acedf
+             1.6673394775f+02, # 0x4326bbe4
+             )::NTuple{6,Float32}
+const qS3 = (4.8758872986f+01, # 0x42430916
+             7.0968920898f+02, # 0x44316c1c
+             3.7041481934f+03, # 0x4567825f
+             6.4604252930f+03, # 0x45c9e367
+             2.5163337402f+03, # 0x451d4557
+             -1.4924745178f+02, # 0xc3153f59
+             )::NTuple{6,Float32}
+# for x in [2.8570, 2] = 1 / [0.3499, 0.5]
+const qR2 = (1.5044444979f-07, # 0x342189db
+             7.3223426938f-02, # 0x3d95f62a
+             1.9981917143f+00, # 0x3fffc4bf
+             1.4495602608f+01, # 0x4167edfd
+             3.1666231155f+01, # 0x41fd5471
+             1.6252708435f+01, # 0x4182058c
+             )::NTuple{6,Float32}
+const qS2 = (3.0365585327f+01, # 0x41f2ecb8
+             2.6934811401f+02, # 0x4386ac8f
+             8.4478375244f+02, # 0x44533229
+             8.8293585205f+02, # 0x445cbbe5
+             2.1266638184f+02, # 0x4354aa98
+             -5.3109550476f+00, # 0xc0a9f358
+             )::NTuple{6,Float32}
+
+# Note: This function is only called for ix >= 0x40000000 (see below)
+function qzerof(x::Float32)
+    ix = reinterpret(UInt32, x) & 0x7fffffff
+    z = 1f0 / (x * x)
+    # @assert ix >= 0x40000000 && ix <= 0x48000000
+    if ix >= 0x41000000
+        p = qR8
+        q = qS8
+    elseif ix >= 0x409173eb
+        p = qR5
+        q = qS5
+    elseif ix >= 0x4036d917
+        p = qR3
+        q = qS3
+    else
+        p = qR2
+        q = qS2
+    end
+    r = @evalpoly(z, p[1], p[2], p[3], p[4], p[5], p[6])
+    s = @evalpoly(z, 1f0, q[1], q[2], q[3], q[4], q[5], q[6])
+    (-0.125f0 + r / s) / x
+end
+
+const huge = 1f30
+const invsqrtpi = 5.6418961287f-01 # 0x3f106ebb
+const tpi = 6.3661974669f01 # 0x3f22f983
+# R0 / S0 on [0, 2.00]
+const R02 =  1.5625000000f-02 # 0x3c800000
+const R03 = -1.8997929874f-04 # 0xb947352e
+const R04 =  1.8295404516f-06 # 0x35f58e88
+const R05 = -4.6183270541f-09 # 0xb19eaf3c
+const S01 =  1.5619102865f-02 # 0x3c7fe744
+const S02 =  1.1692678527f-04 # 0x38f53697
+const S03 =  5.1354652442f-07 # 0x3509daa6
+const S04 =  1.1661400734f-09 # 0x30a045e8
+
+function ieee754_j0f(x::Float32)
+    x = abs(x)
+    ix::UInt32 = reinterpret(UInt32, x)
+    ix >= 0x7f800000 && return 1f0 / (x * x)
+    if ix >= 0x40000000 # |x| >= 2.0
+        s = sin_unchecked(x)
+        c = cos_unchecked(x)
+        ss = s - c
+        cc = s + c
+        if ix < 0x7f000000 # make sure x + x not overflow
+            z = -cos_unchecked(x + x)
+            if s * c < 0f0
+                cc = z / ss
+            else
+                ss = z / cc
+            end
+        end
+        # j0(x) = 1 / √π * (P(0, x) * cc - Q(0, x) * ss) / sqrt(x)
+        # y0(x) = 1 / √π * (P(0, x) * ss + Q(0, x) * cc) / sqrt(x)
+        if ix > 0x58000000 # |x| > 2^49
+            z = invsqrtpi * cc / sqrt(x)
+        else
+            u = pzerof(x)
+            v = qzerof(x)
+            z = invsqrtpi * (u * cc - v * ss) / sqrt(x)
+        end
+        return z
+    end
+    z = x * x
+    if ix < 0x3b000000 # |x| < 2^-9
+        if huge + x > 1f0 # raise inexact if x != 0
+            if ix < 0x39800000 # |x| < 2^-12
+                return 1f0
+            else
+                return muladd(z, -0.25f0, 1f0)
+            end
+        end
+    end
+    r = z * @evalpoly(z, R02, R03, R04, R05)
+    s = @evalpoly(z, 1f0, S01, S02, S03, S04)
+    r /= s
+    if ix < 0x3F800000 # |x| < 1.00
+        muladd(z, -0.25f0 + r, 1f0)
+    else
+        u = 0.5f0 * x
+        muladd(1f0 + u, 1f0 - u, z * r)
+    end
+end
+
+const u00 = -7.3804296553f-02 # 0xbd9726b5
+const u01 =  1.7666645348f-01 # 0x3e34e80d
+const u02 = -1.3818567619f-02 # 0xbc626746
+const u03 =  3.4745343146f-04 # 0x39b62a69
+const u04 = -3.8140706238f-06 # 0xb67ff53c
+const u05 =  1.9559013964f-08 # 0x32a802ba
+const u06 = -3.9820518410f-11 # 0xae2f21eb
+const v01 =  1.2730483897f-02 # 0x3c509385
+const v02 =  7.6006865129f-05 # 0x389f65e0
+const v03 =  2.5915085189f-07 # 0x348b216c
+const v04 =  4.4111031494f-10 # 0x2ff280c2
+
+function ieee754_y0f(x::Float32)
+    ix = reinterpret(UInt32, x) & 0x7fffffff
+    # y0(NaN) is NaN, y0(-Inf) is NaN, y0(Inf) is 0
+    ix >= 0x7f800000 && return 1f0 / (x + x * x)
+    ix == 0 && return -Inf32
+    # use (x < 0) so that llvm can infer that x >= 0 afterwards
+    # somehow llvm cannot remove the bounds check on sqrt with `x <= 0f0`....
+    x < 0 && return NaN32
+    if ix >= 0x40000000 # |x| >= 2.0
+        # y0(x) = sqrt(2 / (π * x)) * (p0(x) * sin(x0) + q0(x) * cos(x0))
+        # where x0 = x - π / 4
+        #      Better formula:
+        #              cos(x0) = cos(x)cos(π / 4) + sin(x)sin(π / 4)
+        #                      =  1/√2 * (sin(x) + cos(x))
+        #              sin(x0) = sin(x)cos(3π / 4) - cos(x)sin(3π / 4)
+        #                      =  1/√2 * (sin(x) - cos(x))
+        # To avoid cancellation, use
+        #              sin(x) ± cos(x) = -cos(2x) / (sin(x) ∓ cos(x))
+        # to compute the worse one.
+        s = sin_unchecked(x)
+        c = cos_unchecked(x)
+        ss = s - c
+        cc = s + c
+        # j0(x) = 1 / √π * (P(0, x) * cc - Q(0, x) * ss) / sqrt(x)
+        # y0(x) = 1 / √π * (P(0, x) * ss + Q(0, x) * cc) / sqrt(x)
+        if ix < 0x7f000000 # make sure x + x not overflow
+            z = -cos_unchecked(x + x)
+            if s * c < 0f0
+                cc = z / ss
+            else
+                ss = z / cc
+            end
+        end
+        if ix > 0x58000000 # |x| > 2^49
+            z = (invsqrtpi * ss) / sqrt(x)
+        else
+            u = pzerof(x)
+            v = qzerof(x)
+            z = invsqrtpi * (u * ss + v * cc) / sqrt(x)
+        end
+        return z
+    end
+    if ix <= 0x39000000 # x < 2^-13
+        return muladd(tpi, log_unchecked(x), u00)
+    end
+    z = x * x
+    u = @evalpoly(z, u00, u01, u02, u03, u04, u05, u06)
+    v = @evalpoly(z, 1f0, v01, v02, v03, v04)
+    muladd(tpi, ieee754_j0f(x) * log_unchecked(x), u / v)
+end
+end

--- a/base/special/j1f.jl
+++ b/base/special/j1f.jl
@@ -1,0 +1,308 @@
+# e_j1f.c -- float version of e_j1.c.
+# Conversion to float by Ian Lance Taylor, Cygnus Support, ian@cygnus.com.
+
+# ====================================================
+# Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+#
+# Developed at SunPro, a Sun Microsystems, Inc. business.
+# Permission to use, copy, modify, and distribute this
+# software is freely granted, provided that this notice
+# is preserved.
+# ====================================================
+
+module J1F
+
+import Base.Math: libm, @evalpoly
+
+sin_unchecked(x::Float32) = ccall((:sinf, libm), Float32, (Float32,), x)
+cos_unchecked(x::Float32) = ccall((:cosf, libm), Float32, (Float32,), x)
+log_unchecked(x::Float32) = ccall((:logf, libm), Float32, (Float32,), x)
+
+# For x >= 8, the asymptotic expansions of pone is
+#     1 + 15 / 128 s^2 - 4725 / 2^15 s^4 - ..., where s = 1/x.
+# We approximate pone by
+#     pone(x) = 1 + R / S
+# where  R = pr0 + pr1 * s^2 + pr2 * s^4 + ... + pr5 * s^10
+#     S = 1 + ps0 * s^2 + ... + ps4 * s^10
+# and
+#     |pone(x) - 1 - R / S| <= 2^-60.06
+
+# for x in [inf, 8] = 1 / [0, 0.125]
+const pr8 = (0.0000000000f+00, # 0x00000000
+             1.1718750000f-01, # 0x3df00000
+             1.3239480972f+01, # 0x4153d4ea
+             4.1205184937f+02, # 0x43ce06a3
+             3.8747453613f+03, # 0x45722bed
+             7.9144794922f+03, # 0x45f753d6
+             )::NTuple{6,Float32}
+const ps8 = (1.1420736694f+02, # 0x42e46a2c
+             3.6509309082f+03, # 0x45642ee5
+             3.6956207031f+04, # 0x47105c35
+             9.7602796875f+04, # 0x47bea166
+             3.0804271484f+04, # 0x46f0a88b
+             )::NTuple{5,Float32}
+# for x in [8, 4.5454] = 1 / [0.125, 0.22001]
+const pr5 = (1.3199052094f-11, # 0x2d68333f
+             1.1718749255f-01, # 0x3defffff
+             6.8027510643f+00, # 0x40d9b023
+             1.0830818176f+02, # 0x42d89dca
+             5.1763616943f+02, # 0x440168b7
+             5.2871520996f+02, # 0x44042dc6
+             )::NTuple{6,Float32}
+const ps5 = (5.9280597687f+01, # 0x426d1f55
+             9.9140142822f+02, # 0x4477d9b1
+             5.3532670898f+03, # 0x45a74a23
+             7.8446904297f+03, # 0x45f52586
+             1.5040468750f+03, # 0x44bc0180
+             )::NTuple{5,Float32}
+const pr3 = (3.0250391081f-09, # 0x314fe10d
+             1.1718686670f-01, # 0x3defffab
+             3.9329774380f+00, # 0x407bb5e7
+             3.5119403839f+01, # 0x420c7a45
+             9.1055007935f+01, # 0x42b61c2a
+             4.8559066772f+01, # 0x42423c7c
+             )::NTuple{6,Float32}
+const ps3 = (3.4791309357f+01, # 0x420b2a4d
+             3.3676245117f+02, # 0x43a86198
+             1.0468714600f+03, # 0x4482dbe3
+             8.9081134033f+02, # 0x445eb3ed
+             1.0378793335f+02, # 0x42cf936c
+             )::NTuple{5,Float32}
+# for x in [2.8570, 2] = 1 / [0.3499, 0.5]
+const pr2 = (1.0771083225f-07, # 0x33e74ea8
+             1.1717621982f-01, # 0x3deffa16
+             2.3685150146f+00, # 0x401795c0
+             1.2242610931f+01, # 0x4143e1bc
+             1.7693971634f+01, # 0x418d8d41
+             5.0735230446f+00, # 0x40a25a4d
+             )::NTuple{6,Float32}
+const ps2 = (2.1436485291f+01, # 0x41ab7dec
+             1.2529022980f+02, # 0x42fa9499
+             2.3227647400f+02, # 0x436846c7
+             1.1767937469f+02, # 0x42eb5bd7
+             8.3646392822f+00, # 0x4105d590
+             )::NTuple{5,Float32}
+
+function ponef(x::Float32)
+    ix = reinterpret(UInt32, x) & 0x7fffffff
+    z = 1f0 / (x * x)
+    if ix >= 0x41000000
+        p = pr8
+        q = ps8
+    elseif ix >= 0x409173eb
+        p = pr5
+        q = ps5
+    elseif ix >= 0x4036d917
+        p = pr3
+        q = ps3
+    else
+        p = pr2
+        q = ps2
+    end
+    r = @evalpoly(z, p[1], p[2], p[3], p[4], p[5], p[6])
+    s = @evalpoly(z, 1f0, q[1], q[2], q[3], q[4], q[5])
+    1f0 + r / s
+end
+
+# For x >= 8, the asymptotic expansions of qone is
+#     3 / 8 s - 105 / 1024 s^3 - ..., where s = 1 / x.
+# We approximate pone by
+#     qone(x) = s * (0.375 + R / S)
+# where R = qr1 * s^2 + qr2 * s^4 + ... + qr5 * s^10
+#     S = 1 + qs1 * s^2 + ... + qs6 * s^12
+# and
+#     |qone(x) / s - 0.375 - R / S| <= 2^-61.13
+
+# for x in [inf, 8] = 1 / [0, 0.125]
+const qr8 = (0.0000000000f+00, # 0x00000000
+             -1.0253906250f-01, # 0xbdd20000
+             -1.6271753311f+01, # 0xc1822c8d
+             -7.5960174561f+02, # 0xc43de683
+             -1.1849806641f+04, # 0xc639273a
+             -4.8438511719f+04, # 0xc73d3683
+             )::NTuple{6,Float32}
+const qs8 = (1.6139537048f+02, # 0x43216537
+             7.8253862305f+03, # 0x45f48b17
+             1.3387534375f+05, # 0x4802bcd6
+             7.1965775000f+05, # 0x492fb29c
+             6.6660125000f+05, # 0x4922be94
+             -2.9449025000f+05, # 0xc88fcb48
+             )::NTuple{6,Float32}
+# for x in [8, 4.5454] = 1 / [0.125, 0.22001]
+const qr5 = (-2.0897993405f-11, # 0xadb7d219
+             -1.0253904760f-01, # 0xbdd1fffe
+             -8.0564479828f+00, # 0xc100e736
+             -1.8366960144f+02, # 0xc337ab6b
+             -1.3731937256f+03, # 0xc4aba633
+             -2.6124443359f+03, # 0xc523471c
+             )::NTuple{6,Float32}
+const qs5 = (8.1276550293f+01, # 0x42a28d98
+             1.9917987061f+03, # 0x44f8f98f
+             1.7468484375f+04, # 0x468878f8
+             4.9851425781f+04, # 0x4742bb6d
+             2.7948074219f+04, # 0x46da5826
+             -4.7191835938f+03, # 0xc5937978
+             )::NTuple{6,Float32}
+const qr3 = (-5.0783124372f-09, # 0xb1ae7d4f
+             -1.0253783315f-01, # 0xbdd1ff5b
+             -4.6101160049f+00, # 0xc0938612
+             -5.7847221375f+01, # 0xc267638e
+             -2.2824453735f+02, # 0xc3643e9a
+             -2.1921012878f+02, # 0xc35b35cb
+             )::NTuple{6,Float32}
+const qs3 = (4.7665153503f+01, # 0x423ea91e
+             6.7386511230f+02, # 0x4428775e
+             3.3801528320f+03, # 0x45534272
+             5.5477290039f+03, # 0x45ad5dd5
+             1.9031191406f+03, # 0x44ede3d0
+             -1.3520118713f+02, # 0xc3073381
+             )::NTuple{6,Float32}
+# for x in [2.8570, 2] = 1 / [0.3499, 0.5]
+const qr2 = (-1.7838172539f-07, # 0xb43f8932
+             -1.0251704603f-01, # 0xbdd1f475
+             -2.7522056103f+00, # 0xc0302423
+             -1.9663616180f+01, # 0xc19d4f16
+             -4.2325313568f+01, # 0xc2294d1f
+             -2.1371921539f+01, # 0xc1aaf9b2
+             )::NTuple{6,Float32}
+const qs2 = (2.9533363342f+01, # 0x41ec4454
+             2.5298155212f+02, # 0x437cfb47
+             7.5750280762f+02, # 0x443d602e
+             7.3939318848f+02, # 0x4438d92a
+             1.5594900513f+02, # 0x431bf2f2
+             -4.9594988823f+00, # 0xc09eb437
+             )::NTuple{6,Float32}
+
+function qonef(x::Float32)
+    ix = reinterpret(UInt32, x) & 0x7fffffff
+    z = 1f0 / (x * x)
+    if ix >= 0x41000000
+        p = qr8
+        q = qs8
+    elseif ix >= 0x409173eb
+        p = qr5
+        q = qs5
+    elseif ix >= 0x4036d917
+        p = qr3
+        q = qs3
+    else
+        p = qr2
+        q = qs2
+    end
+    r = @evalpoly(z, p[1], p[2], p[3], p[4], p[5], p[6])
+    s = @evalpoly(z, 1f0, q[1], q[2], q[3], q[4], q[5], q[6])
+    (0.375f0 + r / s) / x
+end
+
+const huge = 1f30
+const invsqrtpi = 5.6418961287f-01 # 0x3f106ebb
+const tpi = 6.3661974669f-01 # 0x3f22f983
+# R0 / S0 on [0, 2]
+const r00 = -6.2500000000f-02 # 0xbd800000
+const r01 =  1.4070566976f-03 # 0x3ab86cfd
+const r02 = -1.5995563444f-05 # 0xb7862e36
+const r03 =  4.9672799207f-08 # 0x335557d2
+const s01 =  1.9153760746f-02 # 0x3c9ce859
+const s02 =  1.8594678841f-04 # 0x3942fab6
+const s03 =  1.1771846857f-06 # 0x359dffc2
+const s04 =  5.0463624390f-09 # 0x31ad6446
+const s05 =  1.2354227016f-11 # 0x2d59567e
+
+function ieee754_j1f(x::Float32)
+    hx = reinterpret(UInt32, x)
+    ix::UInt32 = hx & 0x7fffffff
+    ix >= 0x7f800000 && return 1f0 / x
+    y = abs(x)
+    if ix >= 0x40000000 # |x| >= 2.0
+        s = sin_unchecked(y)
+        c = cos_unchecked(y)
+        ss = -s - c
+        cc = s - c
+        if ix < 0x7f000000 # make sure y + y not overflow
+            z = cos_unchecked(y + y)
+            if s * c > 0f0
+                cc = z / ss
+            else
+                ss = z / cc
+            end
+        end
+        # j1(x) = 1 / √π * (P(1, x) * cc - Q(1, x) * ss) / sqrt(x)
+        # y1(x) = 1 / √π * (P(1, x) * ss + Q(1, x) * cc) / sqrt(x)
+        if ix > 0x58000000
+            z = (invsqrtpi * cc) / sqrt(y) # |x| > 2^49
+        else
+            u = ponef(y)
+            v = qonef(y)
+            z = invsqrtpi * (u * cc - v * ss) / sqrt(y)
+        end
+        return hx & 0x8000000 != 0 ? -z : z
+    end
+    if ix < 0x39000000 # |x| < 2^-13
+        huge + x > 1f0 && return 0.5f0 * x # inexact if x != 0 necessary
+    end
+    z = x * x
+    r = z * @evalpoly(z, r00, r01, r02, r03)
+    s = @evalpoly(z, 1f0, s01, s02, s03, s04, s05)
+    r *= x
+    x * 0.5f0 + r / s
+end
+
+const U0 = (-1.9605709612f-01, # 0xbe48c331
+            5.0443872809f-02, # 0x3d4e9e3c
+            -1.9125689287f-03, # 0xbafaaf2a
+            2.3525259166f-05, # 0x37c5581c
+            -9.1909917899f-08, # 0xb3c56003
+            )::NTuple{5,Float32}
+const V0 = (1.9916731864f-02, # 0x3ca3286a
+            2.0255257550f-04, # 0x3954644b
+            1.3560879779f-06, # 0x35b602d4
+            6.2274145840f-09, # 0x31d5f8eb
+            1.6655924903f-11, # 0x2d9281cf
+            )::NTuple{5,Float32}
+
+function ieee754_y1f(x::Float32)
+    ix = reinterpret(UInt32, x) & 0x7fffffff
+    ix >= 0x7f800000 && return 1f0 / (x + x * x)
+    ix == 0 && return -Inf32
+    # use (x < 0) so that llvm can infer that x >= 0 afterwards
+    # somehow llvm cannot remove the bounds check on sqrt with `x <= 0f0`....
+    x < 0f0 && return NaN32
+    if ix >= 0x40000000 # |x| >= 2.0
+        s = sin_unchecked(x)
+        c = cos_unchecked(x)
+        ss = -s - c
+        cc = s - c
+        if ix < 0x7f000000 # make sure x + x not overflow
+            z = cos_unchecked(x + x)
+            if s * c > 0f0
+                cc = z / ss
+            else
+                ss = z / cc
+            end
+        end
+        # y1(x) = sqrt(2 / (π*x)) * (p1(x) * sin(x0) + q1(x) * cos(x0))
+        # where x0 = x - 3π / 4
+        #      Better formula:
+        #              cos(x0) = cos(x)cos(3π / 4) + sin(x)sin(3π / 4)
+        #                      = 1 / √2 * (sin(x) - cos(x))
+        #              sin(x0) = sin(x)cos(3π / 4) - cos(x)sin(3π / 4)
+        #                      = -1/√2 * (cos(x) + sin(x))
+        # To avoid cancellation, use
+        #              sin(x) ± cos(x) = -cos(2x) / (sin(x) ∓ cos(x))
+        # to compute the worse one.
+        if ix > 0x58000000
+            z = (invsqrtpi * ss) / sqrt(x) # |x| > 2^49
+        else
+            u = ponef(x)
+            v = qonef(x)
+            z = invsqrtpi * (u * ss + v * cc) / sqrt(x)
+        end
+        return z;
+    end
+    ix <= 0x33000000 && return -tpi / x # x < 2^-25
+    z = x * x
+    u = @evalpoly(z, U0[1], U0[2], U0[3], U0[4], U0[5])
+    v = @evalpoly(z, 1f0, V0[1], V0[2], V0[3], V0[4], V0[5])
+    muladd(tpi, muladd(ieee754_j1f(x), log_unchecked(x), -1f0 / x), x * (u / v))
+end
+end

--- a/base/special/jnf.jl
+++ b/base/special/jnf.jl
@@ -1,0 +1,181 @@
+# e_jnf.c -- float version of e_jn.c.
+# Conversion to float by Ian Lance Taylor, Cygnus Support, ian@cygnus.com.
+
+# ====================================================
+# Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+#
+# Developed at SunPro, a Sun Microsystems, Inc. business.
+# Permission to use, copy, modify, and distribute this
+# software is freely granted, provided that this notice
+# is preserved.
+# ====================================================
+
+module JNF
+
+import Base.Math: libm, J0F, J1F
+
+log_unchecked(x::Float32) = ccall((:logf, libm), Float32, (Float32,), x)
+
+function ieee754_jnf(n::Int32, x::Float32)
+    # J(-n,x) = (-1)^n * J(n, x), J(n, -x) = (-1)^n * J(n, x)
+    # Thus, J(-n,x) = J(n,-x)
+    hx = reinterpret(UInt32, x)
+    ix = 0x7fffffff & hx
+    # if J(n, NaN) is NaN
+    ix > 0x7f800000 && return x + x
+    if n < 0
+        n = -n
+        x = -x
+        hx = hx $ 0x80000000
+    end
+    n == 0 && return J0F.ieee754_j0f(x)
+    n == 1 && return J1F.ieee754_j1f(x)
+    sgn = (n & 1) & (hx >> 31) # even n -- 0, odd n -- sign(x)
+    x = abs(x)
+    if ix == 0 || ix >= 0x7f800000 # if x is 0 or inf
+        b = 0f0
+    elseif n <= x
+        # Safe to use J(n + 1, x) = 2n / x * J(n, x) - J(n - 1, x)
+        a = J0F.ieee754_j0f(x)
+        b = J1F.ieee754_j1f(x)
+        for i in Int32(1):(n - Int32(1))
+            a, b = b, b * ((i + i) / x) - a # avoid underflow
+        end
+    else
+        if ix < 0x30800000 # x < 2^-29
+            # x is tiny, return the first Taylor expansion of J(n, x)
+            # J(n, x) = 1 / n! * (x / 2)^n  - ...
+            if (n > 33) # underflow
+                b = 0f0
+            else
+                temp = x * 0.5f0
+                b = temp
+                a = 1f0
+                for i in Int32(2):n
+                    a *= i # a = n!
+                    b *= temp # b = (x / 2)^n
+                end
+                b = b / a
+            end
+        else
+            # use backward recurrence */
+            #                      x      x^2      x^2
+            #  J(n,x)/J(n-1,x) =  ----   ------   ------   .....
+            #                      2n  - 2(n+1) - 2(n+2)
+            #
+            #                      1      1        1
+            #  (for large x)   =  ----  ------   ------   .....
+            #                      2n   2(n+1)   2(n+2)
+            #                      -- - ------ - ------ -
+            #                       x     x         x
+            #
+            # Let w = 2n/x and h=2/x, then the above quotient
+            # is equal to the continued fraction:
+            #                  1
+            #      = -----------------------
+            #                     1
+            #         w - -----------------
+            #                        1
+            #              w+h - ---------
+            #                     w+2h - ...
+            #
+            # To determine how many terms needed, let
+            # Q(0) = w, Q(1) = w(w + h) - 1,
+            # Q(k) = (w + k * h) * Q(k - 1) - Q(k - 2),
+            # When Q(k) > 1e4        good for single
+            # When Q(k) > 1e9        good for double
+            # When Q(k) > 1e17       good for quadruple
+            # determine k
+            w = (n + n) / x
+            h = 2f0 / x
+            q0 = w
+            z = w + h
+            q1 = w * z - 1f0
+            k::Int32 = 1
+            while q1 < 1f9
+                k += Int32(1)
+                z += h
+                q1, q0 = z * q1 - q0, q1
+            end
+            m = n + n
+            t = 0f0
+            for i in (Int32(2) * (n + k)):-Int32(2):m
+                 t = 1f0 / (i / x - t)
+            end
+            a = t
+            b = 1f0
+            # estimate log((2 / x)^n * n!) = n * log(2 / x) + n * ln(n)
+            # Hence, if n * (log(2n / x)) > ...
+            # single 8.8722839355e+01
+            # double 7.09782712893383973096e+02
+            # long double 1.1356523406294143949491931077970765006170e+04
+            # then recurrent value may overflow and the result is
+            # likely underflow to zero
+            v = 2f0 / x
+            tmp = n * log_unchecked(abs(v * n))
+            di = Float32(2n - 2)
+            if tmp < 8.8721679688f+01
+                for i in (n - Int32(1)):-Int32(1):Int32(1)
+                    temp = b
+                    b *= di
+                    b = b / x - a
+                    a = temp
+                    di -= 2f0
+                end
+            else
+                for i in (n - Int32(1)):-Int32(1):Int32(1)
+                    temp = b
+                    b *= di
+                    b = b/x - a
+                    a = temp
+                    di -= 2f0
+                    # scale b to avoid spurious overflow
+                    if b > 1f10
+                        a /= b
+                        t /= b
+                        b = 1f0
+                    end
+                end
+            end
+            z = J0F.ieee754_j0f(x)
+            w = J1F.ieee754_j1f(x)
+            if abs(z) >= abs(w)
+                b = t * z / b
+            else
+                b = t * w / a
+            end
+        end
+    end
+    if sgn == 1
+        return -b
+    else
+        return b
+    end
+end
+
+function ieee754_ynf(n::Int32, x::Float32)
+    hx = reinterpret(UInt32, x)
+    ix = 0x7fffffff & hx
+    ix > 0x7f800000 && return x + x
+    ix == 0 && return -Inf32
+    (hx & 0x80000000 != 0) && return NaN32
+    sign::Int32 = 1
+    if n < 0
+        n = -n
+        sign = 1 - ((n & 1) << 1)
+    end
+    n == 0 && return J0F.ieee754_y0f(x)
+    n == 1 && return sign * J1F.ieee754_y1f(x)
+    ix == 0x7f800000 && return 0f0
+    a = J0F.ieee754_y0f(x)
+    b = J1F.ieee754_y1f(x)
+    # quit if b is -Inf
+    for i in Int32(1):(n - Int32(1))
+        b === -Inf32 && break
+        temp = b
+        b = ((i + i) / x) * b - a
+        a = temp
+    end
+    sign > 0 ? b : -b
+end
+end


### PR DESCRIPTION
The master version of openlibm removes some non-standard libm functions that are used by julia. This is an attempt to make the julia test suite pass by implementing the missing ones in julia. (side note: I still don't really see the problem of including some useful non-standard function in openlibm).

When testing locally, the only function-not-found error I had is for bessel functions and so I translated their implementation from C and made this PR _just for fun_....

The three added files are almost direct translation of the c code (including a bug fix https://github.com/freebsd/freebsd/commit/0563b7a42b5b5f9ab2af93daf62bfed48fb84e55). I kept the original license header although I'm not sure what exactly should I do about them. There are probably still a lot of improvement to make it compile better with julia. (get rid of some bitcast to integer, use `fma` when possible etc).

No additional test coverage and no benchmark yet. The performance of `jnf` and `ynf` are affected by https://github.com/JuliaLang/julia/issues/13864.

@ViralBShah 
