### PR TITLE
fix parametric type definitions for RemoteRef and AbstractChannel

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-abstract AbstractChannel{T}
+abstract AbstractChannel
 
-type Channel{T} <: AbstractChannel{T}
+type Channel{T} <: AbstractChannel
     cond_take::Condition    # waiting for data to become available
     cond_put::Condition     # waiting for a writeable slot
     state::Symbol

--- a/base/multi.jl
+++ b/base/multi.jl
@@ -465,7 +465,7 @@ end
 
 const client_refs = WeakKeyDict()
 
-type RemoteRef{RemoteStore}
+type RemoteRef{T<:AbstractChannel}
     where::Int
     whence::Int
     id::Int


### PR DESCRIPTION
I believe these should be the correct definitions. 
