### PR TITLE
add muladd(x,y,z)=x*y+z fallback

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -24,7 +24,7 @@ export sin, cos, tan, sinh, cosh, tanh, asin, acos, atan,
 
 import Base: log, exp, sin, cos, tan, sinh, cosh, tanh, asin,
              acos, atan, asinh, acosh, atanh, sqrt, log2, log10,
-             max, min, minmax, ^, exp2,
+             max, min, minmax, ^, exp2, muladd,
              exp10, expm1, log1p,
              sign_mask, exponent_mask, exponent_one, exponent_half,
              significand_mask, significand_bits, exponent_bits, exponent_bias
@@ -378,6 +378,9 @@ function mod2pi(x::Int64)
   fx == x || throw(ArgumentError("Int64 argument to mod2pi is too large: $x"))
   mod2pi(fx)
 end
+
+# generic fallback; for number types, promotion.jl does promotion
+muladd(x,y,z) = x*y+z
 
 # More special functions
 include("special/trig.jl")

--- a/test/math.jl
+++ b/test/math.jl
@@ -681,3 +681,8 @@ end
 @test_throws DomainError 2 ^ -2
 @test_throws DomainError (-2)^(2.2)
 @test_throws DomainError (-2.0)^(2.2)
+
+# issue #13748
+let A = [1 2; 3 4]; B = [5 6; 7 8]; C = [9 10; 11 12]
+    @test muladd(A,B,C) == A*B + C
+end


### PR DESCRIPTION
 (fixes #13748)

Note that I kept the `Number`-specific fallbacks in `promotion.jl`, in addition to the fallback, because I think it is sensible to do promotion on number types.  e.g. `muladd(x,y,z)` should do _all_ the operations in `BigFloat` precision if _any_ of the operands are `BigFloat`, at least for `Number` operands.
