### PR TITLE
RFC: Added documentation and tests for Pkg.setprotocol

### DIFF
--- a/base/pkg.jl
+++ b/base/pkg.jl
@@ -56,6 +56,11 @@ test(pkgs::AbstractString...; coverage::Bool=false) = cd(Entry.test,AbstractStri
 
 dependents(packagename::AbstractString) = Reqs.dependents(packagename)
 
+doc"""
+    setprotocol!(proto)
+
+Set the protocol used to access GitHub-hosted packages.  Defaults to 'https', with a blank `proto` delegating the choice to the package developer.
+"""
 setprotocol!(proto::AbstractString) = Cache.setprotocol!(proto)
 
 

--- a/doc/manual/packages.rst
+++ b/doc/manual/packages.rst
@@ -130,9 +130,11 @@ Once again, this is equivalent to editing the ``REQUIRE`` file to remove the lin
 While :func:`Pkg.add` and :func:`Pkg.rm` are convenient for adding and removing requirements for a single package, when you want to add or remove multiple packages, you can call :func:`Pkg.edit` to manually change the contents of ``REQUIRE`` and then update your packages accordingly.
 :func:`Pkg.edit` does not roll back the contents of ``REQUIRE`` if :func:`Pkg.resolve` fails – rather, you have to run :func:`Pkg.edit` again to fix the files contents yourself.
 
-Because the package manager uses git internally to manage the package git repositories, users may run into protocol issues (if behind a firewall, for example), when running :func:`Pkg.add`. The following command can be run from the command line to tell git to use 'https' instead of the 'git' protocol when cloning repositories::
+Because the package manager uses git internally to manage the package git repositories, users may run into protocol issues (if behind a firewall, for example), when running :func:`Pkg.add`. By default, all GitHub-hosted packages wil be accessed via 'https'; this default can be modified by calling :func:`Pkg.setprotocol!`.  The following command can be run from the command line in order to tell git to use 'https' instead of the 'git' protocol when cloning all repositories, wherever they are hosted::
 
     git config --global url."https://".insteadOf git://
+
+However, this change will be system-wide and thus the use of :func:`Pkg.setprotocol!` is preferable.
 
 Offline Installation of Packages
 --------------------------------

--- a/doc/stdlib/pkg.rst
+++ b/doc/stdlib/pkg.rst
@@ -63,6 +63,12 @@ Functions for package development (e.g. ``tag``, ``publish``, etc.) have been mo
 
    If ``pkg`` has a URL registered in ``Pkg.dir("METADATA")``\ , clone it from that URL on the default branch. The package does not need to have any registered versions.
 
+.. function:: setprotocol!(proto)
+
+   .. Docstring generated from Julia source
+
+   Set the protocol used to access GitHub-hosted packages.  Defaults to 'https', with a blank ``proto`` delegating the choice to the package developer.
+
 .. function:: available() -> Vector{ASCIIString}
 
    .. Docstring generated from Julia source


### PR DESCRIPTION
As a followup to #11312, I have added documentation and a test for Pkg.setprotocol!()

The test is performed by setting the protocol to "notarealprotocol" before testing Pkg.add(), and trapping the error.  This seems the most straightforward way to see what is actually being passed to Git.

The protocol is then manually reset to "https" in order to continue testing Pkg,add().
