### PR TITLE
Generalize Base.simd_index

### DIFF
--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -46,8 +46,8 @@ simd_outer_range(r) = 0:0
 # Get trip count for inner loop.
 simd_inner_length(r,j::Int) = length(r)
 
-# Construct user-level index from original range, outer loop index j, and inner loop index i.
-simd_index(r,j::Int,i) = first(r)+i*step(r)
+# Construct user-level element from original range, outer loop index j, and inner loop index i.
+@inline simd_index(r,j::Int,i) = Base.unsafe_getindex(r,i+1)
 
 # Compile Expr x in context of @simd.
 function compile(x)

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -125,3 +125,15 @@ crng = CartesianRange(CartesianIndex{0}(),
                       CartesianIndex{0}())
 indexes = simd_cartesian_range!(Array(eltype(crng), 0), crng)
 @test indexes == collect(crng)
+
+# @simd with array as "range"
+# issue #13869
+function simd_sum_over_array(a)
+    s = zero(eltype(a))
+    @inbounds @simd for x in a
+        s += x
+    end
+    s
+end
+@test 2001000 == simd_sum_over_array(collect(1:2000))
+@test 2001000 == simd_sum_over_array(Float32[i+j*500 for i=1:500, j=0:3])


### PR DESCRIPTION
This patch fixes #13869 by generalizing the definition of `Base.simd_index`.  When the iteration space for the `@simd` loop is a `Range{T}`, the definition is equivalent to the old definition after inlining and algebraic simplification of `(i+1)-1`.  The "unsafe" indexing is actually safe here as long as `length(r)` is correct, because `i` is always in the interval `0:length(r)-1`.
