### PR TITLE
Improve enums printing

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -92,7 +92,16 @@ macro enum(T,syms...)
                 end
             end
         end
-        Base.show(io::IO,x::$(esc(typename))) = print(io, x, "::", $(esc(typename)))
+        function Base.show(io::IO,x::$(esc(typename)))
+            print(io, x, "::", $(esc(typename)), " = ", Int(x))
+        end
+        Base.showcompact(io::IO,x::$(esc(typename))) = print(io, x)
+        function Base.writemime(io::IO,::MIME"text/plain",::Type{$(esc(typename))})
+            print(io, "Enum ", $(esc(typename)), ":")
+            for (sym, i) in $vals
+                print(io, "\n", sym, " = ", i)
+            end
+        end
     end
     if isa(T,Symbol)
         for (sym,i) in vals

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -152,8 +152,10 @@ end
 # test for unique Enum values
 @test_throws ArgumentError eval(:(@enum(Test14, _zero_Test14, _one_Test14, _two_Test14=0)))
 
-@test repr(apple) == "apple::"*string(Fruit)
+@test repr(apple) == "apple::$(string(Fruit)) = 0"
 @test string(apple) == "apple"
+
+@test reprmime("text/plain", Fruit) == "Enum $(string(Fruit)):\napple = 0\norange = 1\nkiwi = 2"
 
 @enum LogLevel DEBUG INFO WARN ERROR CRITICAL
 @test DEBUG < CRITICAL


### PR DESCRIPTION
Print list of members and associated values when showing enum type,
as well as value and enum type when printing member.

Fixes https://github.com/JuliaLang/julia/issues/13138. Most of the credit is due to @KristofferC.

This gives:

``` julia
julia> @enum FRUIT apple=1 banana=10

julia> apple
apple = 1, a member of enum FRUIT

julia> FRUIT
Enum with 2 member values:
apple = 1
banana = 10
```

I must say that despite having read several issues, I still don't really understand the whole story with `show`, `showcompact` and `writemime`.
