### PR TITLE
Ensure the backtrace is shown even if we can't show method candidates

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -205,7 +205,11 @@ function showerror(io::IO, ex::MethodError)
         print(io, "This may have arisen from a call to the constructor $construct_type(...),",
                   "\nsince type constructors fall back to convert methods.")
     end
-    show_method_candidates(io, ex)
+    try
+        show_method_candidates(io, ex)
+    catch
+        warn("Unable to show method candidates")
+    end
 end
 
 #Show an error by directly calling jl_printf.


### PR DESCRIPTION
This is a bandaid for #13306 until the deeper cause is discovered.
