### PR TITLE
Return error from `at-doc` if `macroexpand` fails.

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -541,6 +541,7 @@ function docm(meta, def, define = true)
     isvar(def′)                ? objdoc(meta, def′) :
     isexpr(def′, :tuple)       ? multidoc(meta, def′.args) :
     __doc__!(meta, def′)       ? esc(def′) :
+    isexpr(def′, :error)       ? esc(def′) :
 
     # All other expressions are undocumentable and should be handled on a case-by-case basis
     # with `@__doc__`. Unbound string literals are also undocumentable since they cannot be

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -471,6 +471,9 @@ end
 @test docstrings_equal(Docs.doc(I13068.A.foo, Tuple{Float64}), doc"foo from B")
 @test Docs.doc(I13068.A.foo, Tuple{Char}) === nothing
 
+# Issue #13905.
+@test macroexpand(:(@doc "" f() = @x)) == Expr(:error, UndefVarError(symbol("@x")))
+
 # Undocumented DataType Summaries.
 
 module Undocumented


### PR DESCRIPTION
When `macroexpand` fails due to an undefined macro in the expression return the resulting error rather than the more generic and misleading "invalid doc expression..." error message.

Fixes #13905.
