### PR TITLE
Fix [ind,find][min,max] for LinearFast AbstractArrays (fixes #13888)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -401,6 +401,7 @@ next(A::AbstractArray,i) = (@_inline_meta(); (idx, s) = next(i[1], i[2]); (A[idx
 done(A::AbstractArray,i) = done(i[1], i[2])
 
 iterstate(i) = i
+iterstate(i::Tuple{UnitRange{Int},Int}) = i[2]
 
 # eachindex iterates over all indices. LinearSlow definitions are later.
 eachindex(A::AbstractArray) = (@_inline_meta(); eachindex(linearindexing(A), A))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1290,6 +1290,7 @@ Base.setindex!(A::LinSlowMatrix, v, i::Integer, j::Integer) = A.data[i,j] = v
 
 A = rand(3,5)
 B = LinSlowMatrix(A)
+S = sub(A, :, :)
 
 @test A == B
 @test B == A
@@ -1299,51 +1300,61 @@ B = LinSlowMatrix(A)
 for (a,b) in zip(A, B)
     @test a == b
 end
+for (a,s) in zip(A, S)
+    @test a == s
+end
 
 C = copy(B)
 @test A == C
 @test B == C
 
-@test vec(A) == vec(B)
-@test minimum(A) == minimum(B)
-@test maximum(A) == maximum(B)
+@test vec(A) == vec(B) == vec(S)
+@test minimum(A) == minimum(B) == minimum(S)
+@test maximum(A) == maximum(B) == maximum(S)
 
 a, ai = findmin(A)
 b, bi = findmin(B)
-@test a == b
-@test ai == bi
+s, si = findmin(S)
+@test a == b == s
+@test ai == bi == si
 
 a, ai = findmax(A)
 b, bi = findmax(B)
-@test a == b
-@test ai == bi
+s, si = findmax(S)
+@test a == b == s
+@test ai == bi == si
 
 fill!(B, 2)
 @test all(x->x==2, B)
 
-i,j = findn(B)
 iall = (1:size(A,1)).*ones(Int,size(A,2))'
 jall = ones(Int,size(A,1)).*(1:size(A,2))'
+i,j = findn(B)
+@test vec(i) == vec(iall)
+@test vec(j) == vec(jall)
+fill!(S, 2)
+i,j = findn(S)
 @test vec(i) == vec(iall)
 @test vec(j) == vec(jall)
 
 copy!(B, A)
+copy!(S, A)
 
-@test cat(1, A, B) == cat(1, A, A)
-@test cat(2, A, B) == cat(2, A, A)
+@test cat(1, A, B, S) == cat(1, A, A, A)
+@test cat(2, A, B, S) == cat(2, A, A, A)
 
-@test cumsum(A, 1) == cumsum(B, 1)
-@test cumsum(A, 2) == cumsum(B, 2)
+@test cumsum(A, 1) == cumsum(B, 1) == cumsum(S, 1)
+@test cumsum(A, 2) == cumsum(B, 2) == cumsum(S, 2)
 
-@test mapslices(v->sort(v), A, 1) == mapslices(v->sort(v), B, 1)
-@test mapslices(v->sort(v), A, 2) == mapslices(v->sort(v), B, 2)
+@test mapslices(v->sort(v), A, 1) == mapslices(v->sort(v), B, 1) == mapslices(v->sort(v), S, 1)
+@test mapslices(v->sort(v), A, 2) == mapslices(v->sort(v), B, 2) == mapslices(v->sort(v), S, 2)
 
-@test flipdim(A, 1) == flipdim(B, 1)
-@test flipdim(A, 2) == flipdim(B, 2)
+@test flipdim(A, 1) == flipdim(B, 1) == flipdim(S, 2)
+@test flipdim(A, 2) == flipdim(B, 2) == flipdim(S, 2)
 
-@test A + 1 == B + 1
-@test 2*A == 2*B
-@test A/3 == B/3
+@test A + 1 == B + 1 == S + 1
+@test 2*A == 2*B == 2*S
+@test A/3 == B/3 == S/3
 
 # issue #13250
 x13250 = zeros(3)


### PR DESCRIPTION
Turns out the problem wasn't a broken implementation, it was a missing one. I'd forgotten that `Array`s used a separate iterator-state type (`Int`) from all other `LinearFast` `AbstractArray`s (which use `Tuple{UnitRange{Int}, Int}`).
