### PR TITLE
Add checked_abs() methods for unsigned ints and BigInt

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -548,6 +548,7 @@ isprime(x::BigInt, reps=25) = ccall((:__gmpz_probab_prime_p,:libgmp), Cint, (Ptr
 prevpow2(x::BigInt) = x.size < 0 ? -prevpow2(-x) : (x <= 2 ? x : one(BigInt) << (ndigits(x, 2)-1))
 nextpow2(x::BigInt) = x.size < 0 ? -nextpow2(-x) : (x <= 2 ? x : one(BigInt) << ndigits(x-1, 2))
 
+Base.checked_abs(x::BigInt) = abs(x)
 Base.checked_add(a::BigInt, b::BigInt) = a + b
 Base.checked_sub(a::BigInt, b::BigInt) = a - b
 Base.checked_mul(a::BigInt, b::BigInt) = a * b

--- a/base/int.jl
+++ b/base/int.jl
@@ -57,17 +57,27 @@ typemin(typeof(x))`, `abs(x) == x`, not `-x` as might be expected.
 abs(x::Signed) = flipsign(x,x)
 
 """
+    Base.checked_abs(x)
+
+The absolute value of `x`, with overflow error trapping where applicable.
+For types for which no overflow can happen during `abs`, this is equivalent
+to `abs(x)`.
+"""
+function checked_abs end
+
+"""
     Base.checked_abs(x::Signed)
 
-The absolute value of `x`, with signed integer overflow error trapping.
-`checked_abs` will throw an `OverflowError` when `x == typemin(typeof(x))`.
-Otherwise `checked_abs` behaves as `abs`, though the overflow protection may
-impose a perceptible performance penalty.
+For signed integers, throws an `OverflowError` when `x == typemin(typeof(x))`.
+Otherwise, behaves as `abs`, though the overflow protection may impose a perceptible
+performance penalty.
 """
 function checked_abs{T<:Signed}(x::T)
     x == typemin(T) && throw(OverflowError())
     abs(x)
 end
+
+checked_abs(x::Unsigned) = abs(x)
 
 ~(n::Integer) = -n-1
 

--- a/test/int.jl
+++ b/test/int.jl
@@ -143,6 +143,12 @@ for T in SItypes
     @test_throws OverflowError checked_abs(typemin(T))
 end
 
+for T in UItypes
+    @test checked_abs(one(T)) == one(T)
+end
+
+@test checked_abs(BigInt(-1)) == BigInt(1)
+
 # Checked operations on UInt128 are currently broken
 # FIXME: #4905
 


### PR DESCRIPTION
This is consistent with other checked_\* methods and allows
writing more generic code.

CC: @MichaeLeroy 
