### PR TITLE
Raise an explicit error when building with -march=i386

### DIFF
--- a/src/ia_misc.h
+++ b/src/ia_misc.h
@@ -7,6 +7,10 @@
 #include <immintrin.h>
 #include "support/dtypes.h"
 
+#if defined(__i386__) && defined(__GNUC__) && !defined(__SSE2__)
+#error Julia can only be built for architectures above Pentium 4. Pass -march=pentium4, or set MARCH=pentium4 and ensure that -march is not passed separately with an older architecture.
+#endif
+
 #if defined(__i386__)
 
 STATIC_INLINE unsigned long long rdtsc(void)


### PR DESCRIPTION
Better than failing with an obscure error in cases where, despite
MARCH=pentium4 being set, other flags include -march=386 or similar.
This check should work with both gcc and clang, and be skipped with
other compilers.

Closes https://github.com/JuliaLang/julia/issues/13862.
