### PR TITLE
Make InetAddr immutable

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -233,7 +233,7 @@ macro ip_str(str)
     return parseip(str)
 end
 
-type InetAddr
+immutable InetAddr
     host::IPAddr
     port::UInt16
 
@@ -726,7 +726,7 @@ function listenany(default_port)
             return (addr.port,sock)
         end
         close(sock)
-        addr.port += 1
+        addr = InetAddr(addr.host, addr.port + 1)
         if addr.port==default_port
             error("no ports available")
         end

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -233,8 +233,8 @@ macro ip_str(str)
     return parseip(str)
 end
 
-immutable InetAddr
-    host::IPAddr
+immutable InetAddr{T<:IPAddr}
+    host::T
     port::UInt16
 
     function InetAddr(host, port::Integer)
@@ -245,6 +245,7 @@ immutable InetAddr
     end
 end
 
+InetAddr(ip::IPAddr, port) = InetAddr{typeof(ip)}(ip, port)
 
 ## SOCKETS ##
 

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -236,13 +236,6 @@ end
 immutable InetAddr{T<:IPAddr}
     host::T
     port::UInt16
-
-    function InetAddr(host, port::Integer)
-        if !(0 <= port <= typemax(UInt16))
-            throw(ArgumentError("port out of range, must be 0 ≤ port ≤ 65535, got $port"))
-        end
-        new(host,UInt16(port))
-    end
 end
 
 InetAddr(ip::IPAddr, port) = InetAddr{typeof(ip)}(ip, port)

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -47,8 +47,8 @@ let inet = Base.InetAddr(IPv4(127,0,0,1), 1024)
     @test inet.port == 1024
 end
 # test InetAddr invalid port
-@test_throws ArgumentError Base.InetAddr(IPv4(127,0,0,1), -1)
-@test_throws ArgumentError Base.InetAddr(IPv4(127,0,0,1), typemax(UInt16)+1)
+@test_throws InexactError Base.InetAddr(IPv4(127,0,0,1), -1)
+@test_throws InexactError Base.InetAddr(IPv4(127,0,0,1), typemax(UInt16)+1)
 
 # isless and comparisons
 @test ip"1.2.3.4" < ip"1.2.3.7" < ip"2.3.4.5"


### PR DESCRIPTION
`InetAddr` appears to predate immutable types, but I think it makes sense to treat it as a value. In particular, this makes it behave intuitively when used as a key in a dict.

I also had a go at parametrising the IP type – let me know if there was a reason that wasn't done before.
