### PR TITLE
doc: fix outdated output msg in the assert example [av skip]

### DIFF
--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -535,7 +535,7 @@ Building an advanced macro
 Here is a simplified definition of Julia's :obj:`@assert` macro::
 
     macro assert(ex)
-        return :($ex ? nothing : error("Assertion failed: ", $(string(ex))))
+        return :( $ex ? nothing : throw(AssertionError($(string(ex)))) )
     end
 
 This macro can be used like this:
@@ -545,13 +545,13 @@ This macro can be used like this:
     julia> @assert 1==1.0
 
     julia> @assert 1==0
-    ERROR: Assertion failed: 1 == 0
+    ERROR: AssertionError: 1 == 0
 
 In place of the written syntax, the macro call is expanded at parse time to
 its returned result. This is equivalent to writing::
 
-    1==1.0 ? nothing : error("Assertion failed: ", "1==1.0")
-    1==0 ? nothing : error("Assertion failed: ", "1==0")
+    1==1.0 ? nothing : throw(AssertionError("1==1.0"))
+    1==0 ? nothing : throw(AssertionError("1==0"))
 
 That is, in the first call, the expression ``:(1==1.0)`` is spliced into
 the test condition slot, while the value of ``string(:(1==1.0))`` is
@@ -572,8 +572,8 @@ ellipses following the last argument::
 
     macro assert(ex, msgs...)
         msg_body = isempty(msgs) ? ex : msgs[1]
-        msg = string("assertion failed: ", msg_body)
-        return :($ex ? nothing : error($msg))
+        msg = string(msg_body)
+        return :($ex ? nothing : throw(AssertionError($msg)))
     end
 
 Now :obj:`@assert` has two modes of operation, depending upon the number of

--- a/doc/manual/metaprogramming.rst
+++ b/doc/manual/metaprogramming.rst
@@ -545,7 +545,7 @@ This macro can be used like this:
     julia> @assert 1==1.0
 
     julia> @assert 1==0
-    ERROR: AssertionError: 1 == 0
+    ERROR: Assertion failed: 1 == 0
 
 In place of the written syntax, the macro call is expanded at parse time to
 its returned result. This is equivalent to writing::


### PR DESCRIPTION
This is a minor fix:

```
macro assert(ex)
    return :($ex ? nothing : error("Assertion failed: ", $(string(ex))))
end
```

gives me

```
julia> @assert 1==0
ERROR: Assertion failed: 1 == 0
```

but the current documentation says

```
julia> @assert 1==0
ERROR: AssertionError: 1 == 0
```

which could be confusing for beginners like me. :)
