### PR TITLE
Added tests for methodshow functions

### DIFF
--- a/test/show.jl
+++ b/test/show.jl
@@ -303,6 +303,15 @@ function f13127()
 end
 @test f13127() == "f"
 
+#test methodshow.jl functions
+@test Base.inbase(Base)
+@test Base.inbase(LinAlg)
+
+@test contains(sprint(io -> writemime(io,"text/plain",methods(Base.inbase))),"inbase(m::Module)")
+@test contains(sprint(io -> writemime(io,"text/html",methods(Base.inbase))),"inbase(m::<b>Module</b>)")
+
+@test contains(Base.url(methods(eigs).defs),"https://github.com/JuliaLang/julia/tree/$(Base.GIT_VERSION_INFO.commit)/base/linalg/arnoldi.jl#L")
+
 # print_matrix should be able to handle small and large objects easily, test by
 # calling writemime. This also indirectly tests print_matrix_row, which
 # is used repeatedly by print_matrix.


### PR DESCRIPTION
`inbase`, `url` and `writemime` didn’t have any tests.
