### PR TITLE
Fix documentation of isexecutable

### DIFF
--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -248,7 +248,7 @@
 
    .. Docstring generated from Julia source
 
-   Returns ``true`` if the current user has permission to execute ``path``\ , ``false`` otherwise.
+   Returns ``true`` if ``path`` is executable, ``false`` otherwise.
 
 .. function:: isfifo(path) -> Bool
 


### PR DESCRIPTION
That function doesn't take the current user
into account, but just checks whether +x is
set for anyone (`(st.mode & 0o111) > 0`).

See https://github.com/JuliaLang/julia/blob/2d821670d2516cd38b51710b07b3eb18f191cd1b/base/stat.jl#L80
