### PR TITLE
Remove 0-size and variable size array members

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -182,7 +182,8 @@ int jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err)
         }
     }
     if (err)
-        jl_errorf("type %s has no field %s", t->name->name->name, fld->name);
+        jl_errorf("type %s has no field %s", jl_symbol_name(t->name->name),
+                  jl_symbol_name(fld));
     return -1;
 }
 
@@ -370,7 +371,7 @@ static uptrint_t hash_symbol(const char *str, size_t len)
 
 static size_t symbol_nbytes(size_t len)
 {
-    return (sizeof_jl_taggedvalue_t+sizeof(jl_sym_t)+len+1+7)&-8;
+    return (sizeof_jl_taggedvalue_t + sizeof(jl_sym_t) + len + 1 + 7) & -8;
 }
 
 static jl_sym_t *mk_symbol(const char *str, size_t len)
@@ -387,20 +388,20 @@ static jl_sym_t *mk_symbol(const char *str, size_t len)
     }
 
 #ifdef MEMDEBUG
-    sym = (jl_sym_t*)&((jl_taggedvalue_t*)malloc(nb))->value;
+    sym = (jl_sym_t*)jl_valueof(malloc(nb));
 #else
     if (sym_pool == NULL || pool_ptr+nb > sym_pool+SYM_POOL_SIZE) {
         sym_pool = (char*)malloc(SYM_POOL_SIZE);
         pool_ptr = sym_pool;
     }
-    sym = (jl_sym_t*)&((jl_taggedvalue_t*)pool_ptr)->value;
+    sym = (jl_sym_t*)jl_valueof(pool_ptr);
     pool_ptr += nb;
 #endif
     jl_set_typeof(sym, jl_sym_type);
     sym->left = sym->right = NULL;
     sym->hash = hash_symbol(str, len);
-    memcpy(&sym->name[0], str, len);
-    sym->name[len] = 0;
+    memcpy(jl_symbol_name(sym), str, len);
+    jl_symbol_name(sym)[len] = 0;
     return sym;
 }
 
@@ -414,8 +415,8 @@ static jl_sym_t **symtab_lookup(jl_sym_t **ptree, const char *str, size_t len, j
     while (*ptree != NULL) {
         x = (int)(h-(*ptree)->hash);
         if (x == 0) {
-            x = strncmp(str, (*ptree)->name, len);
-            if (x == 0 && (*ptree)->name[len] == 0)
+            x = strncmp(str, jl_symbol_name(*ptree), len);
+            if (x == 0 && jl_symbol_name(*ptree)[len] == 0)
                 return ptree;
         }
         if (parent != NULL) *parent = *ptree;
@@ -600,11 +601,11 @@ jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
     if (!jl_boot_file_loaded && jl_is_symbol(name)) {
         // hack to avoid making two versions of basic types needed
         // during bootstrapping
-        if (!strcmp(((jl_sym_t*)name)->name, "Int32"))
+        if (!strcmp(jl_symbol_name((jl_sym_t*)name), "Int32"))
             t = jl_int32_type;
-        else if (!strcmp(((jl_sym_t*)name)->name, "Int64"))
+        else if (!strcmp(jl_symbol_name((jl_sym_t*)name), "Int64"))
             t = jl_int64_type;
-        else if (!strcmp(((jl_sym_t*)name)->name, "Bool"))
+        else if (!strcmp(jl_symbol_name((jl_sym_t*)name), "Bool"))
             t = jl_bool_type;
     }
     if (t == NULL)
@@ -850,7 +851,7 @@ DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v)
     jl_value_t *box = (jl_value_t*)jl_gc_alloc_1w();
     jl_set_typeof(box, jl_box_any_type);
     // if (v) jl_gc_wb(box, v); // write block not needed: box was just allocated
-    box->fieldptr[0] = v;
+    *(jl_value_t**)box = v;
     return box;
 }
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -451,7 +451,7 @@ static value_t julia_to_list2(jl_value_t *a, jl_value_t *b)
 static value_t julia_to_scm_(jl_value_t *v)
 {
     if (jl_is_symbol(v))
-        return symbol(((jl_sym_t*)v)->name);
+        return symbol(jl_symbol_name((jl_sym_t*)v));
     if (jl_is_gensym(v)) {
         size_t idx = ((jl_gensym_t*)v)->id;
         size_t i;

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -357,7 +357,7 @@ static native_sym_arg_t interpret_symbol_arg(jl_value_t *arg, jl_codectx_t *ctx,
             ptr = jl_fieldref(ptr,0);
         }
         if (jl_is_symbol(ptr))
-            f_name = ((jl_sym_t*)ptr)->name;
+            f_name = jl_symbol_name((jl_sym_t*)ptr);
         else if (jl_is_byte_string(ptr))
             f_name = jl_string_data(ptr);
         if (f_name != NULL) {
@@ -374,13 +374,13 @@ static native_sym_arg_t interpret_symbol_arg(jl_value_t *arg, jl_codectx_t *ctx,
             jl_value_t *t0 = jl_fieldref(ptr,0);
             jl_value_t *t1 = jl_fieldref(ptr,1);
             if (jl_is_symbol(t0))
-                f_name = ((jl_sym_t*)t0)->name;
+                f_name = jl_symbol_name((jl_sym_t*)t0);
             else if (jl_is_byte_string(t0))
                 f_name = jl_string_data(t0);
             else
                 JL_TYPECHKS(fname, symbol, t0);
             if (jl_is_symbol(t1))
-                f_lib = ((jl_sym_t*)t1)->name;
+                f_lib = jl_symbol_name((jl_sym_t*)t1);
             else if (jl_is_byte_string(t1))
                 f_lib = jl_string_data(t1);
             else
@@ -891,7 +891,7 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
                                                          jl_undefvarerror_type)
                                             && jl_is_symbol(args[2])) {
                     std::string msg = "ccall return type undefined: " +
-                                      std::string(((jl_sym_t*)args[2])->name);
+                                      std::string(jl_symbol_name((jl_sym_t*)args[2]));
                     emit_error(msg.c_str(), ctx);
                     JL_GC_POP();
                     return jl_cgval_t();

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -708,11 +708,17 @@ typedef struct {
 } jl_codectx_t;
 
 typedef struct {
+    int64_t isref;
+    Function *f;
+} cFunction_t;
+
+typedef struct {
     size_t len;
-    struct {
-        int64_t isref;
-        Function *f;
-    } data[];
+    // cFunction_t data[];
+    cFunction_t *data()
+    {
+        return (cFunction_t*)((char*)this + sizeof(*this));
+    }
 } cFunctionList_t;
 
 static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool boxed=true,
@@ -876,7 +882,7 @@ static void alloc_local(jl_sym_t *s, jl_codectx_t *ctx)
         return;
     }
     // CreateAlloca is OK here because alloc_local is only called during prologue setup
-    Value *lv = builder.CreateAlloca(vtype, 0, s->name);
+    Value *lv = builder.CreateAlloca(vtype, 0, jl_symbol_name(s));
     vi.value = mark_julia_slot(lv, jt);
     vi.value.isimmutable &= vi.isSA; // slot is not immutable if there are multiple assignments
     assert(vi.value.isboxed == false);
@@ -961,7 +967,7 @@ static Function *to_function(jl_lambda_info_t *li)
         }
         JL_SIGATOMIC_END();
         JL_UNLOCK(codegen)
-        jl_rethrow_with_add("error compiling %s", li->name->name);
+        jl_rethrow_with_add("error compiling %s", jl_symbol_name(li->name));
     }
     assert(f != NULL);
 #ifdef JL_DEBUG_BUILD
@@ -985,9 +991,9 @@ static Function *to_function(jl_lambda_info_t *li)
     }
     //n_compile++;
     // print out the function's LLVM code
-    //jl_static_show(JL_STDERR, (jl_value_t*)li);
-    //jl_printf(JL_STDERR, "%s:%d\n",
-    //           ((jl_sym_t*)li->file)->name, li->line);
+    // jl_static_show(JL_STDERR, (jl_value_t*)li);
+    // jl_printf(JL_STDERR, "%s:%d\n",
+    //           jl_symbol_name((jl_sym_t*)li->file), li->line);
     //f->dump();
     //if (verifyFunction(*f,PrintMessageAction)) {
     //    f->dump();
@@ -1075,7 +1081,7 @@ extern "C" void jl_generate_fptr(jl_function_t *f)
                 size_t i;
                 cFunctionList_t *list = (cFunctionList_t*)li->cFunctionList;
                 for (i = 0; i < list->len; i++) {
-                    list->data[i].f = mover.CloneFunction(list->data[i].f);
+                    list->data()[i].f = mover.CloneFunction(list->data()[i].f);
                 }
             }
             jl_finalize_module(m);
@@ -1099,13 +1105,13 @@ extern "C" void jl_generate_fptr(jl_function_t *f)
             cFunctionList_t *list = (cFunctionList_t*)li->cFunctionList;
             for (i = 0; i < list->len; i++) {
 #ifdef USE_MCJIT
-                (void)jl_ExecutionEngine->getFunctionAddress(list->data[i].f->getName());
+                (void)jl_ExecutionEngine->getFunctionAddress(list->data()[i].f->getName());
 #else
-                (void)jl_ExecutionEngine->getPointerToFunction(list->data[i].f);
+                (void)jl_ExecutionEngine->getPointerToFunction(list->data()[i].f);
 #endif
 #ifndef KEEP_BODIES
                 if (!imaging_mode) {
-                    list->data[i].f->deleteBody();
+                    list->data()[i].f->deleteBody();
                 }
 #endif
             }
@@ -1194,19 +1200,20 @@ static Function *jl_cfunction_object(jl_function_t *f, jl_value_t *rt, jl_tuplet
         jl_lambda_info_t *li = ff->linfo;
         if (!jl_types_equal((jl_value_t*)li->specTypes, sigt)) {
             jl_errorf("cfunction: type signature of %s does not match specification",
-                      li->name->name);
+                      jl_symbol_name(li->name));
         }
         jl_value_t *astrt = jl_ast_rettype(li, li->ast);
         if (rt != NULL) {
             if (astrt == (jl_value_t*)jl_bottom_type) {
                 if (rt != (jl_value_t*)jl_void_type) {
                     // a function that doesn't return can be passed to C as void
-                    jl_errorf("cfunction: %s does not return", li->name->name);
+                    jl_errorf("cfunction: %s does not return",
+                              jl_symbol_name(li->name));
                 }
             }
             else if (!jl_subtype(astrt, rt, 0)) {
                 jl_errorf("cfunction: return type of %s does not match",
-                          li->name->name);
+                          jl_symbol_name(li->name));
             }
         }
         JL_GC_POP(); // kill list: sigt
@@ -1641,7 +1648,8 @@ extern "C" void jl_write_malloc_log(void)
 static void show_source_loc(JL_STREAM *out, jl_codectx_t *ctx)
 {
     if (ctx == NULL) return;
-    jl_printf(out, "in %s at %s", ctx->linfo->name->name, ctx->linfo->file->name);
+    jl_printf(out, "in %s at %s", jl_symbol_name(ctx->linfo->name),
+              jl_symbol_name(ctx->linfo->file));
 }
 
 extern "C" void jl_binding_deprecation_warning(jl_binding_t *b);
@@ -3856,7 +3864,7 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
         return ghostValue(jl_void_type);  // will change as new metadata gets added
     }
     else {
-        if (!strcmp(head->name, "$"))
+        if (!strcmp(jl_symbol_name(head), "$"))
             jl_error("syntax: prefix \"$\" in non-quoted expression");
         if (jl_is_toplevel_only_expr(expr) &&
             ctx->linfo->name == anonymous_sym && ctx->vars.empty() &&
@@ -3878,7 +3886,8 @@ static jl_cgval_t emit_expr(jl_value_t *expr, jl_codectx_t *ctx, bool isboxed, b
             }
             else {
                 jl_errorf("unsupported or misplaced expression \"%s\" in function %s",
-                          head->name, ctx->linfo->name->name);
+                          jl_symbol_name(head),
+                          jl_symbol_name(ctx->linfo->name));
             }
         }
     }
@@ -3989,8 +3998,8 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     if (list != NULL) {
         size_t i;
         for (i = 0; i < list->len; i++) {
-            if (list->data[i].isref == isref) {
-                return list->data[i].f;
+            if (list->data()[i].isref == isref) {
+                return list->data()[i].f;
             }
         }
     }
@@ -4026,11 +4035,12 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
 
     jl_compile_linfo(lam);
     if (!lam->functionObject) {
-        jl_errorf("error compiling %s while creating cfunction", lam->name->name);
+        jl_errorf("error compiling %s while creating cfunction",
+                  jl_symbol_name(lam->name));
     }
 
     std::stringstream funcName;
-    funcName << "jlcapi_" << lam->name->name << "_" << globalUnique++;
+    funcName << "jlcapi_" << jl_symbol_name(lam->name) << "_" << globalUnique++;
 
     // Backup the info for the nested compile
     JL_SIGATOMIC_BEGIN(); // no errors expected beyond this point
@@ -4075,12 +4085,12 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
 
     // Save the Function object reference
     int len = (list ? list->len : 0) + 1;
-    cFunctionList_t *list2 = (cFunctionList_t*)realloc(list, sizeof(*list)+sizeof(list->data[0])*len);
+    cFunctionList_t *list2 = (cFunctionList_t*)realloc(list, sizeof(cFunctionList_t)+sizeof(list->data()[0])*len);
     if (!list2)
         jl_throw(jl_memory_exception);
     list2->len = len;
-    list2->data[len-1].isref = isref;
-    list2->data[len-1].f = cw;
+    list2->data()[len-1].isref = isref;
+    list2->data()[len-1].f = cw;
     lam->cFunctionList = list2;
 
     // See whether this function is specsig or jlcall
@@ -4383,7 +4393,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
     ctx.ast = ast;
     ctx.sp = sparams;
     ctx.linfo = lam;
-    ctx.funcName = lam->name->name;
+    ctx.funcName = jl_symbol_name(lam->name);
     ctx.vaName = NULL;
     ctx.vaStack = false;
     ctx.boundsCheck.push_back(true);
@@ -4504,7 +4514,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
 
     std::stringstream funcName;
     // try to avoid conflicts in the global symbol table
-    funcName << "julia_" << lam->name->name;
+    funcName << "julia_" << jl_symbol_name(lam->name);
 
     Module *m;
 #ifdef USE_MCJIT
@@ -4605,12 +4615,12 @@ static Function *emit_function(jl_lambda_info_t *lam)
     bool do_malloc_log = jl_options.malloc_log  == JL_LOG_ALL || (jl_options.malloc_log    == JL_LOG_USER && in_user_code);
     jl_value_t *stmt = skip_meta(stmts);
     std::string filename = "no file";
-    char *dbgFuncName = lam->name->name;
+    char *dbgFuncName = jl_symbol_name(lam->name);
     int lno = -1;
     // look for initial (line num filename [funcname]) node, [funcname] for kwarg methods.
     if (jl_is_linenode(stmt)) {
         lno = jl_linenode_line(stmt);
-        filename = jl_linenode_file(stmt)->name;
+        filename = jl_symbol_name(jl_linenode_file(stmt));
     }
     else if (jl_is_expr(stmt) && ((jl_expr_t*)stmt)->head == line_sym &&
              jl_array_dim0(((jl_expr_t*)stmt)->args) > 0) {
@@ -4620,11 +4630,11 @@ static Function *emit_function(jl_lambda_info_t *lam)
         if (jl_array_dim0(((jl_expr_t*)stmt)->args) > 1) {
             a1 = jl_exprarg(stmt,1);
             if (jl_is_symbol(a1))
-                filename = ((jl_sym_t*)a1)->name;
+                filename = jl_symbol_name((jl_sym_t*)a1);
             if (jl_array_dim0(((jl_expr_t*)stmt)->args) > 2) {
                 a1 = jl_exprarg(stmt,2);
                 if (jl_is_symbol(a1))
-                    dbgFuncName = ((jl_sym_t*)a1)->name;
+                    dbgFuncName = jl_symbol_name((jl_sym_t*)a1);
             }
         }
     }
@@ -4644,8 +4654,8 @@ static Function *emit_function(jl_lambda_info_t *lam)
     BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", f);
     builder.SetInsertPoint(b0);
 
-    //jl_printf(JL_STDERR, "\n*** compiling %s at %s:%d\n\n",
-    //           lam->name->name, filename.c_str(), lno);
+    // jl_printf(JL_STDERR, "\n*** compiling %s at %s:%d\n\n",
+    //           jl_symbol_name(lam->name), filename.c_str(), lno);
 
     DebugLoc noDbg;
     ctx.debug_enabled = true;
@@ -4731,7 +4741,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
 #ifdef LLVM38
             varinfo.dinfo = ctx.dbuilder->createParameterVariable(
                 SP,                                 // Scope (current function will be fill in later)
-                argname->name,                      // Variable name
+                jl_symbol_name(argname),            // Variable name
                 ctx.sret + i + 1,                                // Argument number (1-based)
                 topfile,                            // File
                 toplineno == -1 ? 0 : toplineno,  // Line
@@ -4741,7 +4751,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
             varinfo.dinfo = ctx.dbuilder->createLocalVariable(
                 llvm::dwarf::DW_TAG_arg_variable,    // Tag
                 SP,         // Scope (current function will be fill in later)
-                argname->name,    // Variable name
+                jl_symbol_name(argname),    // Variable name
                 topfile,                    // File
                 toplineno == -1 ? 0 : toplineno,             // Line (for now, use lineno of the function)
                 julia_type_to_di(varinfo.value.typ, ctx.dbuilder,false), // Variable type
@@ -4754,7 +4764,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
 #ifdef LLVM38
             ctx.vars[ctx.vaName].dinfo = ctx.dbuilder->createParameterVariable(
                 SP,                     // Scope (current function will be fill in later)
-                ctx.vaName->name,       // Variable name
+                jl_symbol_name(ctx.vaName),        // Variable name
                 ctx.sret + nreq + 1,               // Argument number (1-based)
                 topfile,                    // File
                 toplineno == -1 ? 0 : toplineno,             // Line (for now, use lineno of the function)
@@ -4763,8 +4773,8 @@ static Function *emit_function(jl_lambda_info_t *lam)
             ctx.vars[ctx.vaName].dinfo = ctx.dbuilder->createLocalVariable(
                 llvm::dwarf::DW_TAG_arg_variable,   // Tag
                 SP,                                 // Scope (current function will be fill in later)
-                ctx.vaName->name,                   // Variable name
-                topfile,                             // File
+                jl_symbol_name(ctx.vaName),         // Variable name
+                topfile,                            // File
                 toplineno == -1 ? 0 : toplineno,  // Line (for now, use lineno of the function)
                 julia_type_to_di(ctx.vars[ctx.vaName].value.typ, ctx.dbuilder, false),      // Variable type
                 false,                  // May be optimized out
@@ -4784,7 +4794,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                 llvm::dwarf::DW_TAG_auto_variable,    // Tag
 #endif
                 SP,                     // Scope (current function will be fill in later)
-                s->name,                // Variable name
+                jl_symbol_name(s),       // Variable name
                 topfile,                 // File
                 toplineno == -1 ? 0 : toplineno, // Line (for now, use lineno of the function)
                 julia_type_to_di(varinfo.value.typ, ctx.dbuilder, false), // Variable type
@@ -4808,7 +4818,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                 llvm::dwarf::DW_TAG_auto_variable,    // Tag
 #endif
                 SP,                     // Scope (current function will be filled in later)
-                vname->name,            // Variable name
+                jl_symbol_name(vname),   // Variable name
                 topfile,                 // File
                 toplineno == -1 ? 0 : toplineno, // Line (for now, use lineno of the function)
                 julia_type_to_di(varinfo.value.typ, ctx.dbuilder, false), // Variable type
@@ -4935,7 +4945,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
             jl_varinfo_t &varinfo = ctx.vars[vname];
             if (!varinfo.value.isghost) {
                 varinfo.memloc = builder.CreatePointerCast(
-                        emit_nthptr_addr(envArg, i + offsetof(jl_svec_t,data) / sizeof(void*)),
+                        emit_nthptr_addr(envArg, i + sizeof(jl_svec_t) / sizeof(void*)),
                         T_ppjlvalue);
             }
         }
@@ -5183,7 +5193,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                     }
                 }
             }
-            assert(file->name);
+            assert(jl_symbol_name(file));
 
 #           ifdef LLVM37
             DIFile *dfil = NULL;
@@ -5192,7 +5202,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
 #           endif
 
             // If the string is not empty
-            if (*file->name != '\0') {
+            if (*jl_symbol_name(file) != '\0') {
 #               ifdef LLVM37
                 std::map<jl_sym_t *, DIFile *>::iterator it = filescopes.find(file);
 #               else
@@ -5202,9 +5212,11 @@ static Function *emit_function(jl_lambda_info_t *lam)
                     dfil = it->second;
                 } else {
 #                   ifdef LLVM37
-                    dfil = (DIFile*)dbuilder.createFile(file->name, ".");
+                    dfil = (DIFile*)dbuilder.createFile(jl_symbol_name(file),
+                                                        ".");
 #                   else
-                    dfil = (MDNode*)dbuilder.createFile(file->name, ".");
+                    dfil = (MDNode*)dbuilder.createFile(jl_symbol_name(file),
+                                                        ".");
 #                   endif
                 }
             }
@@ -5363,7 +5375,7 @@ extern "C" void jl_fptr_to_llvm(void *fptr, jl_lambda_info_t *lam, int specsig)
     }
     else {
         // this assigns a function pointer (from loading the system image), to the function object
-        std::string funcName = lam->name->name;
+        std::string funcName = jl_symbol_name(lam->name);
         funcName = "julia_" + funcName;
         if (specsig) { // assumes !va
             std::vector<Type*> fsig(0);
@@ -5482,8 +5494,8 @@ static void init_julia_llvm_env(Module *m)
         "jl_value_t",
         julia_h,
         71, // At the time of this writing. Not sure if it's worth it to keep this in sync
-        sizeof(jl_value_t)*8,
-        __alignof__(jl_value_t)*8,
+        0 * 8, // sizeof(jl_value_t) * 8,
+        __alignof__(void*) * 8, // __alignof__(jl_value_t) * 8,
         0, // Flags
 #ifdef LLVM37
         nullptr,    // Derived from

--- a/src/gc.c
+++ b/src/gc.c
@@ -43,8 +43,6 @@ JL_DEFINE_MUTEX(finalizers)
 #define GC_QUEUED 2 // if it is reachable it will be marked as old
 #define GC_MARKED_NOESC (GC_MARKED | GC_QUEUED) // reachable and young
 
-#define jl_valueof(v) (&((jl_taggedvalue_t*)(v))->value)
-
 // This struct must be kept in sync with the Julia type of the same name in base/util.jl
 typedef struct {
     int64_t     allocd;
@@ -1664,8 +1662,9 @@ static int push_root(jl_value_t *v, int d, int bits)
     // some values have special representations
     if (vt == (jl_value_t*)jl_simplevector_type) {
         size_t l = jl_svec_len(v);
-        MARK(v, bits = gc_setmark(v, l*sizeof(void*) + sizeof(jl_svec_t), GC_MARKED_NOESC));
-        jl_value_t **data = ((jl_svec_t*)v)->data;
+        MARK(v, bits = gc_setmark(v, l * sizeof(void*) +
+                                  sizeof(jl_svec_t), GC_MARKED_NOESC));
+        jl_value_t **data = jl_svec_data(v);
         nptr += l;
         for(size_t i=0; i < l; i++) {
             jl_value_t *elt = data[i];

--- a/src/gf.c
+++ b/src/gf.c
@@ -230,7 +230,8 @@ static jl_function_t *jl_method_table_assoc_exact_by_type(jl_methtable_t *mt, jl
         ml = mt->cache;
  mt_assoc_bt_lkup:
     while (ml != (void*)jl_nothing) {
-        if (cache_match_by_type(jl_svec_data(types->parameters), jl_datatype_nfields(types),
+        if (cache_match_by_type(jl_svec_data(types->parameters),
+                                jl_datatype_nfields(types),
                                 ml->sig, ml->va)) {
             return ml->func;
         }
@@ -729,7 +730,7 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tupletype_t *type,
             if (jl_svec_len(sparams) > 0) {
                 lastdeclt = (jl_value_t*)
                     jl_instantiate_type_with((jl_value_t*)lastdeclt,
-                                             sparams->data,
+                                             jl_svec_data(sparams),
                                              jl_svec_len(sparams)/2);
             }
             jl_svecset(limited, i, lastdeclt);
@@ -916,7 +917,7 @@ static jl_value_t *lookup_match(jl_value_t *a, jl_value_t *b, jl_svec_t **penv,
     }
     if (n != l) {
         jl_svec_t *en = jl_alloc_svec_uninit(n);
-        memcpy(en->data, ee, n*sizeof(void*));
+        memcpy(jl_svec_data(en), ee, n*sizeof(void*));
         *penv = en;
     }
     JL_GC_POP();
@@ -1171,7 +1172,7 @@ static void check_ambiguous(jl_methlist_t *ml, jl_tupletype_t *type,
                 goto done_chk_amb;  // ok, intersection is covered
             l = l->next;
         }
-        n = fname->name;
+        n = jl_symbol_name(fname);
         s = JL_STDERR;
         jl_printf(s, "WARNING: New definition \n    %s", n);
         jl_static_show_func_sig(s, (jl_value_t*)type);
@@ -1216,11 +1217,14 @@ jl_methlist_t *jl_method_list_insert(jl_methlist_t **pml, jl_tupletype_t *type,
                 (l->func->linfo->module != method->linfo->module)) {
                 jl_module_t *newmod = method->linfo->module;
                 JL_STREAM *s = JL_STDERR;
-                jl_printf(s, "WARNING: Method definition %s", method->linfo->name->name);
+                jl_printf(s, "WARNING: Method definition %s",
+                          jl_symbol_name(method->linfo->name));
                 jl_static_show_func_sig(s, (jl_value_t*)type);
-                jl_printf(s, " in module %s", l->func->linfo->module->name->name);
+                jl_printf(s, " in module %s",
+                          jl_symbol_name(l->func->linfo->module->name));
                 print_func_loc(s, l->func->linfo);
-                jl_printf(s, " overwritten in module %s", newmod->name->name);
+                jl_printf(s, " overwritten in module %s",
+                          jl_symbol_name(newmod->name));
                 print_func_loc(s, method->linfo);
                 jl_printf(s, ".\n");
             }
@@ -2030,7 +2034,7 @@ void print_func_loc(JL_STREAM *s, jl_lambda_info_t *li)
 {
     long lno = li->line;
     if (lno > 0) {
-        char *fname = ((jl_sym_t*)li->file)->name;
+        char *fname = jl_symbol_name((jl_sym_t*)li->file);
         jl_printf(s, " at %s:%ld", fname, lno);
     }
 }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -102,7 +102,8 @@ static int equiv_type(jl_datatype_t *dta, jl_datatype_t *dtb)
 static void check_can_assign_type(jl_binding_t *b)
 {
     if (b->constp && b->value != NULL && !jl_is_datatype(b->value))
-        jl_errorf("invalid redefinition of constant %s", b->name->name);
+        jl_errorf("invalid redefinition of constant %s",
+                  jl_symbol_name(b->name));
 }
 
 static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ngensym)
@@ -371,11 +372,12 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
         assert(jl_is_svec(para));
         vnb  = eval(args[2], locals, nl, ngensym);
         if (!jl_is_long(vnb))
-            jl_errorf("invalid declaration of bits type %s", ((jl_sym_t*)name)->name);
+            jl_errorf("invalid declaration of bits type %s",
+                      jl_symbol_name((jl_sym_t*)name));
         ssize_t nb = jl_unbox_long(vnb);
         if (nb < 1 || nb>=(1<<23) || (nb&7) != 0)
             jl_errorf("invalid number of bits in type %s",
-                      ((jl_sym_t*)name)->name);
+                      jl_symbol_name((jl_sym_t*)name));
         dt = jl_new_bitstype(name, jl_any_type, (jl_svec_t*)para, nb);
         jl_binding_t *b = jl_get_binding_wr(jl_current_module, (jl_sym_t*)name);
         temp = b->value;
@@ -421,7 +423,9 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
             for(size_t i=0; i < jl_svec_len(dt->types); i++) {
                 jl_value_t *elt = jl_svecref(dt->types, i);
                 if (!jl_is_type(elt) && !jl_is_typevar(elt))
-                    jl_type_error_rt(dt->name->name->name, "type definition", (jl_value_t*)jl_type_type, elt);
+                    jl_type_error_rt(jl_symbol_name(dt->name->name),
+                                     "type definition",
+                                     (jl_value_t*)jl_type_type, elt);
             }
             super = eval(args[3], locals, nl, ngensym);
             jl_set_datatype_super(dt, super);
@@ -496,7 +500,7 @@ static jl_value_t *eval(jl_value_t *e, jl_value_t **locals, size_t nl, size_t ng
     else if (ex->head == inert_sym) {
         return args[0];
     }
-    jl_errorf("unsupported or misplaced expression %s", ex->head->name);
+    jl_errorf("unsupported or misplaced expression %s", jl_symbol_name(ex->head));
     return (jl_value_t*)jl_nothing;
 }
 

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -82,7 +82,7 @@ DLLEXPORT const char *jl_typename_str(jl_value_t *v)
 {
     if (!jl_is_datatype(v))
         return NULL;
-    return ((jl_datatype_t*)v)->name->name->name;
+    return jl_symbol_name(((jl_datatype_t*)v)->name->name);
 }
 
 // get the name of typeof(v) as a string
@@ -304,16 +304,19 @@ DLLEXPORT const char *jl_git_commit(void)
 }
 
 // Create function versions of some useful macros
-#undef jl_astaggedvalue
-DLLEXPORT jl_taggedvalue_t *jl_astaggedvalue(jl_value_t *v)
+DLLEXPORT jl_taggedvalue_t *(jl_astaggedvalue)(jl_value_t *v)
 {
-    return jl_astaggedvalue__MACRO(v);
+    return jl_astaggedvalue(v);
 }
 
-#undef jl_typeof
-DLLEXPORT jl_value_t *jl_typeof(jl_value_t *v)
+DLLEXPORT jl_value_t *(jl_valueof)(jl_taggedvalue_t *v)
 {
-    return jl_typeof__MACRO(v);
+    return jl_valueof(v);
+}
+
+DLLEXPORT jl_value_t *(jl_typeof)(jl_value_t *v)
+{
+    return jl_typeof(v);
 }
 
 #ifdef __cplusplus

--- a/src/module.c
+++ b/src/module.c
@@ -94,7 +94,7 @@ DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var)
         else if ((*bp)->owner != m) {
             // TODO: change this to an error soon
             jl_printf(JL_STDERR,
-                       "WARNING: imported binding for %s overwritten in module %s\n", var->name, m->name->name);
+                      "WARNING: imported binding for %s overwritten in module %s\n", jl_symbol_name(var), jl_symbol_name(m->name));
         }
         else {
             return *bp;
@@ -127,7 +127,8 @@ DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *
         if (opmod != NULL && jl_defines_or_exports_p(opmod, var)) {
             jl_printf(JL_STDERR,
                       "WARNING: module %s should explicitly import %s from %s\n",
-                      m->name->name, var->name, jl_base_module->name->name);
+                      jl_symbol_name(m->name), jl_symbol_name(var),
+                      jl_symbol_name(jl_base_module->name));
             jl_module_import(m, opmod, var);
         }
     }
@@ -139,10 +140,10 @@ DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *
         if (b->owner != m && b->owner != NULL) {
             jl_binding_t *b2 = jl_get_binding(b->owner, var);
             if (b2 == NULL)
-                jl_errorf("invalid method definition: imported function %s.%s does not exist", b->owner->name->name, var->name);
+                jl_errorf("invalid method definition: imported function %s.%s does not exist", jl_symbol_name(b->owner->name), jl_symbol_name(var));
             if (!b->imported && (b2->value==NULL || jl_is_function(b2->value))) {
                 if (b2->value && !jl_is_gf(b2->value)) {
-                    jl_errorf("error in method definition: %s.%s cannot be extended", b->owner->name->name, var->name);
+                    jl_errorf("error in method definition: %s.%s cannot be extended", jl_symbol_name(b->owner->name), jl_symbol_name(var));
                 }
                 else {
                     if (jl_base_module && m->std_imports && b->owner == jl_base_module) {
@@ -150,11 +151,14 @@ DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *
                         if (opmod != NULL && jl_defines_or_exports_p(opmod, var)) {
                             jl_printf(JL_STDERR,
                                       "WARNING: module %s should explicitly import %s from %s\n",
-                                      m->name->name, var->name, b->owner->name->name);
+                                      jl_symbol_name(m->name),
+                                      jl_symbol_name(var),
+                                      jl_symbol_name(b->owner->name));
                             return b2;
                         }
                     }
-                    jl_errorf("error in method definition: function %s.%s must be explicitly imported to be extended", b->owner->name->name, var->name);
+                    jl_errorf("error in method definition: function %s.%s must be explicitly imported to be extended", jl_symbol_name(b->owner->name),
+                              jl_symbol_name(var));
                 }
             }
             return b2;
@@ -205,7 +209,9 @@ static jl_binding_t *jl_get_binding_(jl_module_t *m, jl_sym_t *var, modstack_t *
                     !(tempb->constp && tempb->value && b->constp && b->value == tempb->value)) {
                     jl_printf(JL_STDERR,
                               "WARNING: both %s and %s export \"%s\"; uses of it in module %s must be qualified\n",
-                              owner->name->name, imp->name->name, var->name, m->name->name);
+                              jl_symbol_name(owner->name),
+                              jl_symbol_name(imp->name), jl_symbol_name(var),
+                              jl_symbol_name(m->name));
                     // mark this binding resolved, to avoid repeating the warning
                     (void)jl_get_binding_wr(m, var);
                     return NULL;
@@ -284,7 +290,8 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
     if (b == NULL) {
         jl_printf(JL_STDERR,
                   "WARNING: could not import %s.%s into %s\n",
-                  from->name->name, s->name, to->name->name);
+                  jl_symbol_name(from->name), jl_symbol_name(s),
+                  jl_symbol_name(to->name));
     }
     else {
         jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&to->bindings, s);
@@ -307,7 +314,8 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
                 }
                 jl_printf(JL_STDERR,
                           "WARNING: ignoring conflicting import of %s.%s into %s\n",
-                          from->name->name, s->name, to->name->name);
+                          jl_symbol_name(from->name), jl_symbol_name(s),
+                          jl_symbol_name(to->name));
             }
             else if (bto->constp || bto->value) {
                 // conflict with name owned by destination module
@@ -318,7 +326,8 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
                 }
                 jl_printf(JL_STDERR,
                           "WARNING: import of %s.%s into %s conflicts with an existing identifier; ignored.\n",
-                          from->name->name, s->name, to->name->name);
+                          jl_symbol_name(from->name), jl_symbol_name(s),
+                          jl_symbol_name(to->name));
             }
             else {
                 bto->owner = b->owner;
@@ -383,7 +392,8 @@ void jl_module_using(jl_module_t *to, jl_module_t *from)
                     !eq_bindings(jl_get_binding(to,var), b)) {
                     jl_printf(JL_STDERR,
                               "WARNING: using %s.%s in module %s conflicts with an existing identifier.\n",
-                              from->name->name, var->name, to->name->name);
+                              jl_symbol_name(from->name), jl_symbol_name(var),
+                              jl_symbol_name(to->name));
                 }
             }
         }
@@ -488,14 +498,15 @@ void jl_binding_deprecation_warning(jl_binding_t *b)
         if (jl_options.depwarn != JL_OPTIONS_DEPWARN_ERROR)
             jl_printf(JL_STDERR, "WARNING: ");
         if (b->owner)
-            jl_printf(JL_STDERR, "%s.%s is deprecated", b->owner->name->name, b->name->name);
+            jl_printf(JL_STDERR, "%s.%s is deprecated",
+                      jl_symbol_name(b->owner->name), jl_symbol_name(b->name));
         else
-            jl_printf(JL_STDERR, "%s is deprecated", b->name->name);
+            jl_printf(JL_STDERR, "%s is deprecated", jl_symbol_name(b->name));
         jl_value_t *v = b->value;
         if (v && (jl_is_type(v) || (jl_is_function(v) && jl_is_gf(v)))) {
             jl_printf(JL_STDERR, ", use ");
-            if (b->owner && strcmp(b->owner->name->name, "Base") == 0 &&
-                strcmp(b->name->name, "Uint") == 0) {
+            if (b->owner && strcmp(jl_symbol_name(b->owner->name), "Base") == 0 &&
+                strcmp(jl_symbol_name(b->name), "Uint") == 0) {
                 // TODO: Suggesting type b->value is wrong for typealiases.
                 // Uncommon in Base, hardcoded here for now, see #13221
                 jl_printf(JL_STDERR, "UInt");
@@ -512,9 +523,11 @@ void jl_binding_deprecation_warning(jl_binding_t *b)
 
         if (jl_options.depwarn == JL_OPTIONS_DEPWARN_ERROR) {
             if (b->owner)
-                jl_errorf("deprecated binding: %s.%s", b->owner->name->name, b->name->name);
+                jl_errorf("deprecated binding: %s.%s",
+                          jl_symbol_name(b->owner->name),
+                          jl_symbol_name(b->name));
             else
-                jl_errorf("deprecated binding: %s", b->name->name);
+                jl_errorf("deprecated binding: %s", jl_symbol_name(b->name));
         }
     }
 }
@@ -525,9 +538,11 @@ DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
         if (!jl_egal(rhs, b->value)) {
             if (jl_typeof(rhs) != jl_typeof(b->value) ||
                 jl_is_type(rhs) || jl_is_function(rhs) || jl_is_module(rhs)) {
-                jl_errorf("invalid redefinition of constant %s", b->name->name);
+                jl_errorf("invalid redefinition of constant %s",
+                          jl_symbol_name(b->name));
             }
-            jl_printf(JL_STDERR,"WARNING: redefining constant %s\n",b->name->name);
+            jl_printf(JL_STDERR, "WARNING: redefining constant %s\n",
+                      jl_symbol_name(b->name));
         }
     }
     b->value = rhs;
@@ -538,7 +553,7 @@ DLLEXPORT void jl_declare_constant(jl_binding_t *b)
 {
     if (b->value != NULL && !b->constp) {
         jl_errorf("cannot declare %s constant; it already has a value",
-                  b->name->name);
+                  jl_symbol_name(b->name));
     }
     b->constp = 1;
 }


### PR DESCRIPTION
For some reason, the `llvm-config` from LLVM 3.7 adds `-pedantic` to cflags and cxxflags. This causes a huge amount of compiler warnings (mainly because of `JL_DATA_TYPE`). I couldn't find out why did LLVM starts doing this or how to workaround it in general so I decided to fix most of the warnings....

This PR doesn't completely fix all the `-Wpedantic` warnings (the ones that are not fixed is anonymous structs which we use for bitsfields in a union. This turns out to be valid C11 but not valid C++ yet...).

This could break embedding. In particular,
1. `jl_value_t` is only a declaration now. Direct use of `jl_value_t` instead of `jl_value_t*` shouldn't be necessary.
2. Types with variable array members do no have such member anymore. The address of the variable length array is calculated directly with pointer arithmetics instead. Notes about how each of them should be updated,
   1. `jl_value_t::fieldptr`
      
      We already have `jl_data_ptr` and this macro should be used instead.
   2. `jl_sym_t::data`
      
      Use `jl_symbol_name`, which is also the name of the exported function.
   3. `jl_taggedvalue_t::value`
      
      (not actually a flexible array member but was serving a similar purpose). I doubt any embedding code manipulate `jl_taggedvalue_t` directly but `jl_valueof` is provided as a convenient way to access the value pointer.
   4. `jl_svec_t::data`
      
      We already have `jl_svec_data` and this macro should be used instead.
   5. `jl_datatype_t::fields`
      
      This shouldn't be accessed directly since https://github.com/JuliaLang/julia/pull/13147. `jl_datatype_fields` macro is also added to get the address of the fields in the rare case it is needed.
3. If any code was relying on `JL_DATA_TYPE` in a non-gc allocated `struct` to provide necessary alignment, it needs to find another way to do it. (define its own zero length array member, use the alignment attributes etc.)
4. The presence of `jl_valueof` macro and function could be used as a compile time and runtime check to detect this change.

@vtjnash Ref https://github.com/JuliaLang/julia/pull/13787
@tkelman This should make the code more MSVC compatible but it's also possible that I break something without realizing it....
