### PR TITLE
WIP: Reintroduce random BigFloats removed in 1a8885b

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -49,6 +49,23 @@ type BigInt <: Integer
     end
 end
 
+type GMPRandState
+    seed_alloc::Cint
+    seed_size::Cint
+    seed_d::Ptr{Void}
+    alg::Cint
+    alg_data::Ptr{Void}
+
+    function GMPRandState()
+        randstate = new(zero(Cint), zero(Cint), C_NULL, zero(Cint), C_NULL)
+        # The default algorithm in GMP is currently MersenneTwister
+        ccall((:__gmp_randinit_default, :libgmp), Void, (Ptr{GMPRandState},),
+          &randstate)
+        finalizer(randstate, randclear)
+        randstate
+    end
+end
+
 _gmp_clear_func = C_NULL
 _mpfr_clear_func = C_NULL
 
@@ -552,5 +569,27 @@ Base.checked_abs(x::BigInt) = abs(x)
 Base.checked_add(a::BigInt, b::BigInt) = a + b
 Base.checked_sub(a::BigInt, b::BigInt) = a - b
 Base.checked_mul(a::BigInt, b::BigInt) = a * b
+
+
+## GMPRandState
+
+function GMPRandState(seed::UInt64)
+    randstate = GMPRandState()
+    ccall((:__gmp_randseed_ui, :libgmp), Void, (Ptr{GMPRandState}, Culong),
+      &randstate, seed)
+    randstate
+end
+
+function GMPRandState(seed::BigInt)
+    randstate = GMPRandState()
+    ccall((:__gmp_randseed, :libgmp), Void, (Ptr{GMPRandState}, Ptr{BigInt}),
+      &randstate, &seed)
+    randstate
+end
+
+
+function randclear(x::GMPRandState)
+    ccall((:__gmp_randclear, :libgmp), Void, (Ptr{GMPRandState},), &x)
+end
 
 end # module

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -22,7 +22,7 @@ import
 
 import Base.Rounding: rounding_raw, setrounding_raw
 
-import Base.GMP: ClongMax, CulongMax, CdoubleMax
+import Base.GMP: ClongMax, CulongMax, CdoubleMax, GMPRandState
 
 import Base.Math.lgamma_r
 
@@ -879,5 +879,14 @@ get_emin_max() = ccall((:mpfr_get_emin_max, :libmpfr), Clong, ())
 
 set_emax!(x) = ccall((:mpfr_set_emax, :libmpfr), Void, (Clong,), x)
 set_emin!(x) = ccall((:mpfr_set_emin, :libmpfr), Void, (Clong,), x)
+
+
+function urandomb(randstate::GMPRandState)
+    z = BigFloat()
+    ccall((:mpfr_urandomb,:libmpfr), Int32,
+          (Ptr{BigFloat}, Ptr{GMPRandState}),
+           &z, &randstate)
+    z
+end
 
 end #module


### PR DESCRIPTION
These would be the bare bones changes needed to reintroduce sampling of random floats to address #13948 (Tests and docs if interest, then.) 

This does not yet intent to link the `BigFloat`-number generator with the global number generator. This can be done similar to #4845, but I think linking those is not strictly necessary. 

 This order of dependencies (`GMPRandState` in gmp.jl, `mpfr_urandomb`-wrapper in mpfr.jl depending on `GMPRandState` and finally `BigFloatRNG` in random.jl depending on both of them) corresponds with the order in sysimg.jl. Would that mean that the problem 1a8885b does not appear?
