### PR TITLE
Fix deprecation warning on LLVM 3.7

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -330,7 +330,7 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
 #else
     MCContext Ctx(*MAI, *MRI, MOFI.get(), &SrcMgr);
 #endif
-#ifdef LLVM38
+#ifdef LLVM37
     MOFI->InitMCObjectFileInfo(TheTriple, Reloc::Default, CodeModel::Default, Ctx);
 #else
     MOFI->InitMCObjectFileInfo(TripleName, Reloc::Default, CodeModel::Default, Ctx);


### PR DESCRIPTION
I don't know how to check but apparently it is included/backported to LLVM 3.7 since I'm seeing this warning on LLVM 3.7.
