### PR TITLE
Allow pkg-config to fallback to system libraries

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -200,8 +200,8 @@ BUILD_LLDB := 0
 # Path to cmake (override in Make.user if needed)
 CMAKE ?= cmake
 
-# Point pkg-config to only look at our libraries
-export PKG_CONFIG_LIBDIR = $(JULIAHOME)/usr/lib/pkgconfig
+# Point pkg-config to prefer our libraries
+export PKG_CONFIG_PATH = $(JULIAHOME)/usr/lib/pkgconfig
 
 # Figure out OS and architecture
 BUILD_OS := $(shell uname)


### PR DESCRIPTION
Fixes #13472

Setting PKG_CONFIG_LIBDIR to only look at our libraries means that `libgit2` won't find `libcurl`. Due to `libgit2#2555` this means it will build without proxy support. By instead setting PKG_CONFIG_PATH we allow our libraries to take precedence, but don't disable inclusion of system libraries as a fallback.

However I'm not on a Mac and can't check that this wouldn't reintroduce https://github.com/JuliaLang/julia/issues/12514, so if someone could check that that would be awesome :)
