### PR TITLE
Fix url(::Method) for no-git builds

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -100,7 +100,12 @@ function url(m::Method)
     line = m.func.code.line
     line <= 0 || ismatch(r"In\[[0-9]+\]", file) && return ""
     if inbase(M)
-        return "https://github.com/JuliaLang/julia/tree/$(Base.GIT_VERSION_INFO.commit)/base/$file#L$line"
+        if isempty(Base.GIT_VERSION_INFO.commit)
+            # this url will only work if we're on a tagged release
+            return "https://github.com/JuliaLang/julia/tree/v$VERSION/base/$file#L$line"
+        else
+            return "https://github.com/JuliaLang/julia/tree/$(Base.GIT_VERSION_INFO.commit)/base/$file#L$line"
+        end
     else
         try
             d = dirname(file)

--- a/test/show.jl
+++ b/test/show.jl
@@ -317,7 +317,11 @@ end
 @test contains(sprint(io -> writemime(io,"text/plain",methods(Base.inbase))),"inbase(m::Module)")
 @test contains(sprint(io -> writemime(io,"text/html",methods(Base.inbase))),"inbase(m::<b>Module</b>)")
 
-@test contains(Base.url(methods(eigs).defs),"https://github.com/JuliaLang/julia/tree/$(Base.GIT_VERSION_INFO.commit)/base/linalg/arnoldi.jl#L")
+if isempty(Base.GIT_VERSION_INFO.commit)
+    @test contains(Base.url(methods(eigs).defs),"https://github.com/JuliaLang/julia/tree/v$VERSION/base/linalg/arnoldi.jl#L")
+else
+    @test contains(Base.url(methods(eigs).defs),"https://github.com/JuliaLang/julia/tree/$(Base.GIT_VERSION_INFO.commit)/base/linalg/arnoldi.jl#L")
+end
 
 # print_matrix should be able to handle small and large objects easily, test by
 # calling writemime. This also indirectly tests print_matrix_row, which


### PR DESCRIPTION
noticed in #13933 that this method gives broken links in a `NO_GIT` build

might be able to come up with better options for builds of prereleases?
