### PR TITLE
Fix handling of trailing spaces in REPL shell mode

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -473,8 +473,17 @@ function shell_completions(string, pos)
     arg = args.args[end].args[end]
     if all(s -> isa(s, AbstractString), args.args[end].args)
         # Treat this as a path
+
+        # As Base.shell_parse throws away trailing spaces (unless they are escaped),
+        # we need to special case here.
+        # If the last char was a space, but shell_parse ignored it search on "".
+        ignore_last_word = arg != " " && scs[end] == ' '
+        prefix = ignore_last_word ? "" : join(args.args[end].args)
+
         # Also try looking into the env path if the user wants to complete the first argument
-        return complete_path(join(args.args[end].args), pos, use_envpath=length(args.args) < 2)
+        use_envpath = !ignore_last_word && length(args.args) < 2
+
+        return complete_path(prefix, pos, use_envpath=use_envpath)
     elseif isexpr(arg, :escape) && (isexpr(arg.args[1], :incomplete) || isexpr(arg.args[1], :error))
         r = first(last_parse):prevind(last_parse, last(last_parse))
         partial = scs[r]

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -431,6 +431,28 @@ c, r, res = test_scomplete(s)
     @test r == 6:7
     @test s[r] == "Pk"
 
+    # Pressing tab after having entered "/tmp " should not
+    # attempt to complete "/tmp" but rather work on the current
+    # working directory again.
+
+    let
+        file = joinpath(path, "repl completions")
+        s = "/tmp "
+        c,r = test_scomplete(s)
+        @test r == 6:5
+    end
+
+    # Test completing paths with an escaped trailing space
+    let
+        file = joinpath(tempdir(), "repl completions")
+        touch(file)
+        s = string(tempdir(), "/repl\\ ")
+        c,r = test_scomplete(s)
+        @test ["repl\\ completions"] == c
+        @test s[r] == "repl\\ "
+        rm(file)
+    end
+
     # Tests homedir expansion
     let
         path = homedir()


### PR DESCRIPTION
As Base.shell_parse throws away trailing spaces (unless they
are escaped) we need to special case that for completions
in REPL shell mode.

Prior to this any trailing spaces were ignored for completions,
which led to problems as we tried to complete the word before
the space.

For example in case of `"ls /tmp "` (note the trailing space)
hitting tab would have made us try to complete `tmp`. Also
because the offsets are wrong in that case, the input value
would have changed to `"ls /ttmp/"` (note the double tt, the
trailing space is gone).

This also adds a regression test for completing paths with spaces
in them as I was afraid to break that.
