### PR TITLE
REPLCompletions: Allow dirs in PATH that can't be read

### DIFF
--- a/base/REPLCompletions.jl
+++ b/base/REPLCompletions.jl
@@ -161,7 +161,18 @@ function complete_path(path::AbstractString, pos; use_envpath=false)
                 continue
             end
 
-            local filesinpath = readdir(pathdir)
+            local filesinpath
+            try
+                filesinpath = readdir(pathdir)
+            catch e
+                # Bash allows dirs in PATH that can't be read, so we should as well.
+                if isa(e, SystemError)
+                    continue
+                else
+                    # We only handle SystemErrors here
+                    rethrow(e)
+                end
+            end
 
             for file in filesinpath
                 # In a perfect world, we would filter on whether the file is executable

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -451,16 +451,24 @@ c, r, res = test_scomplete(s)
     let
         oldpath = ENV["PATH"]
         path = tempdir()
-        ENV["PATH"] = path
+        # PATH can also contain folders which we aren't actually allowed to read.
+        unreadable = joinpath(tempdir(), "replcompletion-unreadable")
+        ENV["PATH"] = string(path, ":", unreadable)
+
         file = joinpath(path, "tmp-executable")
         touch(file)
         chmod(file, 0o755)
+        mkdir(unreadable)
+        chmod(unreadable, 0o000)
+
         s = "tmp-execu"
         c,r = test_scomplete(s)
         @test "tmp-executable" in c
         @test r == 1:9
         @test s[r] == "tmp-execu"
+
         rm(file)
+        rm(unreadable)
         ENV["PATH"] = oldpath
     end
 


### PR DESCRIPTION
As bash allows this (without complaining), we should as
well support that.
