### PR TITLE
Let constructors for structured matrices take Range inputs`

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -12,8 +12,8 @@ type Bidiagonal{T} <: AbstractMatrix{T}
         new(dv, ev, isupper)
     end
 end
-Bidiagonal{T}(dv::AbstractVector{T}, ev::AbstractVector{T}, isupper::Bool) = Bidiagonal{T}(dv, ev, isupper)
-Bidiagonal{T}(dv::AbstractVector{T}, ev::AbstractVector{T}) = throw(ArgumentError("did you want an upper or lower Bidiagonal? Try again with an additional true (upper) or false (lower) argument."))
+Bidiagonal{T}(dv::AbstractVector{T}, ev::AbstractVector{T}, isupper::Bool) = Bidiagonal{T}(collect(dv), collect(ev), isupper)
+Bidiagonal(dv::AbstractVector, ev::AbstractVector) = throw(ArgumentError("did you want an upper or lower Bidiagonal? Try again with an additional true (upper) or false (lower) argument."))
 
 #Convert from BLAS uplo flag to boolean internal
 Bidiagonal(dv::AbstractVector, ev::AbstractVector, uplo::Char) = begin
@@ -24,7 +24,7 @@ Bidiagonal(dv::AbstractVector, ev::AbstractVector, uplo::Char) = begin
     else
         throw(ArgumentError("Bidiagonal uplo argument must be upper 'U' or lower 'L', got $(repr(uplo))"))
     end
-    Bidiagonal(copy(dv), copy(ev), isupper)
+    Bidiagonal(collect(dv), collect(ev), isupper)
 end
 function Bidiagonal{Td,Te}(dv::AbstractVector{Td}, ev::AbstractVector{Te}, isupper::Bool)
     T = promote_type(Td,Te)

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -6,6 +6,7 @@ immutable Diagonal{T} <: AbstractMatrix{T}
     diag::Vector{T}
 end
 Diagonal(A::AbstractMatrix) = Diagonal(diag(A))
+Diagonal(V::AbstractVector) = Diagonal(collect(V))
 
 convert{T}(::Type{Diagonal{T}}, D::Diagonal{T}) = D
 convert{T}(::Type{Diagonal{T}}, D::Diagonal) = Diagonal{T}(convert(Vector{T}, D.diag))

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -16,7 +16,7 @@ end
 
 SymTridiagonal{T}(dv::Vector{T}, ev::Vector{T}) = SymTridiagonal{T}(dv, ev)
 
-function SymTridiagonal{Td,Te}(dv::Vector{Td}, ev::Vector{Te})
+function SymTridiagonal{Td,Te}(dv::AbstractVector{Td}, ev::AbstractVector{Te})
     T = promote_type(Td,Te)
     SymTridiagonal(convert(Vector{T}, dv), convert(Vector{T}, ev))
 end
@@ -271,6 +271,8 @@ immutable Tridiagonal{T} <: AbstractMatrix{T}
     du::Vector{T}    # sup-diagonal
     du2::Vector{T}   # supsup-diagonal for pivoting
 end
+
+# Basic constructor takes in three dense vectors of same type
 function Tridiagonal{T}(dl::Vector{T}, d::Vector{T}, du::Vector{T})
     n = length(d)
     if (length(dl) != n-1 || length(du) != n-1)
@@ -278,8 +280,21 @@ function Tridiagonal{T}(dl::Vector{T}, d::Vector{T}, du::Vector{T})
     end
     Tridiagonal(dl, d, du, zeros(T,n-2))
 end
-function Tridiagonal{Tl, Td, Tu}(dl::Vector{Tl}, d::Vector{Td}, du::Vector{Tu})
+
+# Construct from diagonals of any abstract vector, any eltype
+function Tridiagonal{Tl, Td, Tu}(dl::AbstractVector{Tl}, d::AbstractVector{Td}, du::AbstractVector{Tu})
     Tridiagonal(map(v->convert(Vector{promote_type(Tl,Td,Tu)}, v), (dl, d, du))...)
+end
+
+# Provide a constructor Tridiagonal(A) similar to the triangulars, diagonal, symmetric
+"""
+    Tridiagonal(A)
+
+returns a `Tridiagonal` array based on (abstract) matrix `A`, using its lower diagonal,
+diagonal, and upper diagonal.
+"""
+function Tridiagonal(A::AbstractMatrix)
+    return Tridiagonal(diag(A,-1), diag(A), diag(A,+1))
 end
 
 size(M::Tridiagonal) = (length(M.d), length(M.d))

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -184,6 +184,9 @@ let A = Bidiagonal([1,2,3], [0,0], true)
     @test isdiag(A)
 end
 
+# test construct from range
+@test Bidiagonal(1:3, 1:2, true) == [1 1 0; 0 2 2; 0 0 3]
+
 #test promote_rule
 A = Bidiagonal(ones(Float32,10),ones(Float32,9),true)
 B = rand(Float64,10,10)

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -214,3 +214,6 @@ let d = randn(n), D = Diagonal(d)
     @test inv(D) ≈ inv(full(D))
 end
 @test_throws SingularException inv(Diagonal(zeros(n)))
+
+# allow construct from range
+@test Diagonal(linspace(1,3,3)) == Diagonal([1.,2.,3.])

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -400,3 +400,11 @@ SymTridiagonal([1, 2], [0])^3 == [1 0; 0 8]
 #test convert for SymTridiagonal
 @test convert(SymTridiagonal{Float64},SymTridiagonal(ones(Float32,5),ones(Float32,4))) == SymTridiagonal(ones(Float64,5),ones(Float64,4))
 @test convert(AbstractMatrix{Float64},SymTridiagonal(ones(Float32,5),ones(Float32,4))) == SymTridiagonal(ones(Float64,5),ones(Float64,4))
+
+# Test constructors from matrix
+@test SymTridiagonal([1 2 3; 2 5 6; 0 6 9]) == [1 2 0; 2 5 6; 0 6 9]
+@test Tridiagonal([1 2 3; 4 5 6; 7 8 9]) == [1 2 0; 4 5 6; 0 8 9]
+
+# Test constructors with range and other abstract vectors
+@test SymTridiagonal(1:3, 1:2) == [1 1 0; 1 2 2; 0 2 3]
+@test Tridiagonal(4:5, 1:3, 1:2) == [1 1 0; 4 2 2; 0 5 3]


### PR DESCRIPTION
Super trivial matter, but you can't do `Diagonal(1:3)` even though you can do `diagm(1:3)`. Structured matrices like `Tridiagonal`, `Bidiagonal`, `Diagonal` take vectors as inputs, and there's no reason why they shouldn't take `AbstractVector`. In some cases the method template was just overly restrictive, in some just a `collect` was needed. Also most can take a matrix as input, e.g. `SymTridiagonal(A)`, but  `Tridiagonal(A)` was missing, so I added one, plus a docstring. Associated tests added; everything passes.
