### PR TITLE
Extend mktemp to support file suffixes.

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -6114,9 +6114,9 @@ See also: :func:`extrema` that returns ``(minimum(x), maximum(x))``
 minmax
 
 doc"""
-    mktemp([parent=tempdir()])
+    mktemp([parent=tempdir()]; suffix="")
 
-Returns `(path, io)`, where `path` is the path of a new temporary file in `parent` and `io` is an open file object for this path.
+Returns `(path, io)`, where `path` is the path of a new temporary file in `parent` (with suffix `suffix`) and `io` is an open file object for this path.
 """
 mktemp(?)
 

--- a/base/file.jl
+++ b/base/file.jl
@@ -228,10 +228,11 @@ end
 function mktemp(parent=tempdir(); suffix="")
     filename = tempname(parent, UInt32(0))
     if length(suffix) > 0
-        if !endswith(filename, ".TMP")
+        fnlen = length(filename)
+        if fnlen < 4 || lowercase(filename[fnlen-3:end]) != ".tmp"
             error("mktemp failed: invalid result by GetTempFileName")
         end
-        new_filename = filename[1:length(filename)-4] * suffix
+        new_filename = filename[1:fnlen-4] * suffix
         # NOTE: new_filename is not guaranteed to exist,
         #       but at least then mv will error out.
         mv(filename, new_filename)

--- a/base/file.jl
+++ b/base/file.jl
@@ -233,7 +233,7 @@ function mktemp(parent=tempdir(); suffix="")
             error("mktemp failed: invalid result by GetTempFileName")
         end
         new_filename = filename[1:fnlen-4] * suffix
-        # NOTE: new_filename is not guaranteed to exist,
+        # NOTE: new_filename is not guaranteed to be nonexistent,
         #       but at least then mv will error out.
         mv(filename, new_filename)
         filename = new_filename

--- a/base/file.jl
+++ b/base/file.jl
@@ -190,11 +190,7 @@ tempdir() = dirname(tempname())
 # Create and return the name of a temporary file along with an IOStream
 function mktemp(parent=tempdir(); suffix="")
     b = joinpath(parent, "tmpXXXXXX$suffix")
-    if length(suffix) > 0
-        p = ccall(:mkstemps, Int32, (Ptr{UInt8}, Cint), b, length(suffix))
-    else
-        p = ccall(:mkstemp, Int32, (Ptr{UInt8},), b)
-    end
+    p = ccall(:mkstemps, Int32, (Ptr{UInt8}, Cint), b, length(suffix))
     systemerror(:mktemp, p == -1)
     return (b, fdio(p, true))
 end

--- a/base/file.jl
+++ b/base/file.jl
@@ -226,7 +226,17 @@ function tempname(temppath::AbstractString,uunique::UInt32)
     return utf8(UTF16String(tname))
 end
 function mktemp(parent=tempdir(); suffix="")
-    filename = tempname(parent, UInt32(0)) * suffix
+    filename = tempname(parent, UInt32(0))
+    if length(suffix) > 0
+        if !endswith(filename, ".TMP")
+            error("mktemp failed: invalid result by GetTempFileName")
+        end
+        new_filename = filename[1:length(filename)-4] * suffix
+        # NOTE: new_filename is not guaranteed to exist,
+        #       but at least then mv will error out.
+        mv(filename, new_filename)
+        filename = new_filename
+    end
     return (filename, Base.open(filename, "r+"))
 end
 function mktempdir(parent=tempdir())

--- a/test/file.jl
+++ b/test/file.jl
@@ -219,6 +219,12 @@ close(f)
 @test readall(p) == "Here is some text"
 rm(p)
 
+(p, f) = mktemp(suffix=".foo")
+close(f)
+@test isfile(p) == true
+@test endswith(p, ".foo") == true
+rm(p)
+
 let
     tmp_path = mktemp() do p, io
         @test isfile(p)

--- a/test/file.jl
+++ b/test/file.jl
@@ -219,11 +219,10 @@ close(f)
 @test readall(p) == "Here is some text"
 rm(p)
 
-(p, f) = mktemp(suffix=".foo")
-close(f)
-@test isfile(p) == true
-@test endswith(p, ".foo") == true
-rm(p)
+mktemp(suffix=".foo") do p, f
+    @test isfile(p) == true
+    @test endswith(p, ".foo") == true
+end
 
 let
     tmp_path = mktemp() do p, io


### PR DESCRIPTION
This PR extends `mktemp` to support file suffixes using the `mkstemps` function:

```
mktemp(suffix=".txt")
("/tmp/tmprFezJ1.txt",IOStream(<fd 15>))
```

Additionally, I've also changed the ccall signature from `Ptr{UInt8}` to `Cstring`. My understanding is that `Cstring` is meant to be used when a string is NULL-terminated, and according to [this document](https://www.mkssoftware.com/docs/man3/mkstemp.3.asp) the template parameter to `mkstemp` and others is supposed to be terminated as such.
Am I reading this correctly? If so, I think other functions (`tempnam`, `mktempdir`) might need adjusting too.
