### PR TITLE
WIP: Fix MSVC build of threading code

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2425,7 +2425,7 @@ void jl_print_gc_stats(JL_STREAM *s)
 struct _jl_thread_heap_t *jl_mk_thread_heap(void)
 {
 #ifdef JULIA_ENABLE_THREADING
-    jl_thread_heap = malloc(sizeof(jl_thread_heap_t)); // FIXME - should be cache-aligned malloc
+    jl_thread_heap = (jl_thread_heap_t*) malloc(sizeof(jl_thread_heap_t)); // FIXME - should be cache-aligned malloc
 #endif
     FOR_CURRENT_HEAP
         const int* szc = sizeclasses;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1481,9 +1481,9 @@ typedef struct {
 } jl_thread_task_state_t;
 
 extern JL_THREAD_EXPORT jl_task_t * volatile jl_current_task;
-extern JL_THREAD_EXPORT jl_task_t *jl_root_task;
+extern JL_THREAD jl_task_t *jl_root_task;
 extern JL_THREAD_EXPORT jl_value_t *jl_exception_in_transit;
-extern JL_THREAD_EXPORT jl_value_t * volatile jl_task_arg_in_transit;
+extern JL_THREAD jl_value_t * volatile jl_task_arg_in_transit;
 
 DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize);
 DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg);

--- a/src/julia.h
+++ b/src/julia.h
@@ -61,12 +61,17 @@ extern "C" {
 #ifndef JULIA_ENABLE_THREADING
 // Definition for compiling non-thread-safe Julia.
 #  define JL_THREAD
-#elif !defined(_OS_WINDOWS_)
+#elif !defined(_COMPILER_MICROSOFT_)
 // Definition for compiling Julia on platforms with GCC __thread.
 #  define JL_THREAD __thread
 #else
 // Definition for compiling Julia on Windows
 #  define JL_THREAD __declspec(thread)
+#endif
+#ifdef _COMPILER_MICROSOFT_
+#define JL_THREAD_EXPORT JL_THREAD
+#else
+#define JL_THREAD_EXPORT DLLEXPORT JL_THREAD
 #endif
 
 DLLEXPORT int16_t jl_threadid(void);
@@ -87,7 +92,7 @@ DLLEXPORT void jl_threading_profile(void);
 #  define JL_ATOMIC_FETCH_AND_ADD(a,b)                                    \
        _InterlockedExchangeAdd((volatile LONG *)&(a), (b))
 #  define JL_ATOMIC_COMPARE_AND_SWAP(a,b,c)                               \
-       _InterlockedCompareExchange64(&(a), (c), (b))
+       _InterlockedCompareExchange64((volatile LONG64 *)&(a), (c), (b))
 #  define JL_ATOMIC_TEST_AND_SET(a)                                       \
        _InterlockedExchange64(&(a), 1)
 #  define JL_ATOMIC_RELEASE(a)                                            \
@@ -575,7 +580,7 @@ typedef struct _jl_gcframe_t {
 // jl_value_t *x=NULL, *y=NULL; JL_GC_PUSH2(&x, &y);
 // x = f(); y = g(); foo(x, y)
 
-extern DLLEXPORT JL_THREAD jl_gcframe_t *jl_pgcstack;
+extern JL_THREAD_EXPORT jl_gcframe_t *jl_pgcstack;
 
 #define JL_GC_PUSH1(arg1)                                                 \
   void *__gc_stkf[] = {(void*)3, jl_pgcstack, arg1};                      \
@@ -1475,10 +1480,10 @@ typedef struct {
     jl_value_t * volatile *ptask_arg_in_transit;
 } jl_thread_task_state_t;
 
-extern DLLEXPORT JL_THREAD jl_task_t * volatile jl_current_task;
-extern DLLEXPORT JL_THREAD jl_task_t *jl_root_task;
-extern DLLEXPORT JL_THREAD jl_value_t *jl_exception_in_transit;
-extern DLLEXPORT JL_THREAD jl_value_t * volatile jl_task_arg_in_transit;
+extern JL_THREAD_EXPORT jl_task_t * volatile jl_current_task;
+extern JL_THREAD_EXPORT jl_task_t *jl_root_task;
+extern JL_THREAD_EXPORT jl_value_t *jl_exception_in_transit;
+extern JL_THREAD_EXPORT jl_value_t * volatile jl_task_arg_in_transit;
 
 DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize);
 DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg);

--- a/src/task.c
+++ b/src/task.c
@@ -138,10 +138,10 @@ static jl_sym_t *runnable_sym;
 
 extern size_t jl_page_size;
 jl_datatype_t *jl_task_type;
-DLLEXPORT JL_THREAD jl_task_t * volatile jl_current_task;
+JL_THREAD_EXPORT jl_task_t * volatile jl_current_task;
 JL_THREAD jl_task_t *jl_root_task;
-DLLEXPORT JL_THREAD jl_value_t *jl_exception_in_transit;
-DLLEXPORT JL_THREAD jl_gcframe_t *jl_pgcstack = NULL;
+JL_THREAD_EXPORT jl_value_t *jl_exception_in_transit;
+JL_THREAD_EXPORT jl_gcframe_t *jl_pgcstack = NULL;
 
 #ifdef COPY_STACKS
 static JL_THREAD jl_jmp_buf * volatile jl_jmp_target;

--- a/src/threading.c
+++ b/src/threading.c
@@ -21,6 +21,8 @@ TODO:
 #ifndef _MSC_VER
 #include <unistd.h>
 #include <sched.h>
+#else
+#define sleep(x) Sleep(1000*x)
 #endif
 
 #include "julia.h"


### PR DESCRIPTION
Not sure if this code actually works on Windows (LLVM 3.7.0 crashes at the start of bootstrap with a `Relocation type not implemented yet!
UNREACHABLE executed at /home/Tony/julia/deps/srccache/llvm-3.7.0/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp:230!`), but at least we can check whether it builds. Some of the `!defined(_OS_WINDOWS_)` in here should maybe actually be `!defined(_COMPILER_MICROSOFT_)`, but we can sort that out when newer LLVM and the threading code are closer to being enabled by default.
