### PR TITLE
Update range display with range defn

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -14,14 +14,17 @@ function writemime(io::IO, ::MIME"text/plain", f::Function)
 end
 
 # writemime for ranges, e.g.
-#  3-element UnitRange{Int64,Int}
+#  3-element UnitRange{Int64} 1:3,
 #   1,2,3
 # or for more elements than fit on screen:
 #   1.0,2.0,3.0,…,6.0,7.0,8.0
+# or for zero elements:
+#   0-element UnitRange{Int64} 3:1
 function writemime(io::IO, ::MIME"text/plain", r::Range)
-    print(io, summary(r))
+    print(io, summary(r), " ")
+    show(io, r)
     if !isempty(r)
-        println(io, ":")
+        println(io, ",")
         with_output_limit(()->print_range(io, r))
     end
 end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -553,13 +553,14 @@ end
 # stringmime/writemime should display the range or linspace nicely
 # to test print_range in range.jl
 replstr(x) = stringmime("text/plain", x)
-@test replstr(1:4) == "4-element UnitRange{$Int}:\n 1,2,3,4"
-@test replstr(linspace(1,5,7)) == "7-element LinSpace{Float64}:\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"
-@test replstr(0:100.) == "101-element FloatRange{Float64}:\n 0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,…,94.0,95.0,96.0,97.0,98.0,99.0,100.0"
+@test replstr(1:4) == "4-element UnitRange{$Int} 1:4,\n 1,2,3,4"
+@test replstr(2:1) == "0-element UnitRange{$Int} 2:1"
+@test replstr(linspace(1,5,7)) == "7-element LinSpace{Float64} linspace(1.0,5.0,7),\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"
+@test replstr(0:100.) == "101-element FloatRange{Float64} 0.0:1.0:100.0,\n 0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,…,94.0,95.0,96.0,97.0,98.0,99.0,100.0"
 # next is to test a very large range, which should be fast because print_range
 # only examines spacing of the left and right edges of the range, sufficient
 # to cover the designated screen size.
-@test replstr(0:10^9) == "1000000001-element UnitRange{$Int}:\n 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,…,999999998,999999999,1000000000"
+@test replstr(0:10^9) == "1000000001-element UnitRange{$Int} 0:1000000000,\n 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,…,999999998,999999999,1000000000"
 
 # Issue 11049 and related
 @test promote(linspace(0f0, 1f0, 3), linspace(0., 5., 2)) ===


### PR DESCRIPTION
Suggestion by @rfourquet to include definition of `Range` in its repl display #13966. The recently added behavior was to show the elements in one line of text #13615. Suggestion was to also include the definition, like in 0.4. Looks like this:

```
julia> 1:3
3-element UnitRange{Int64} 1:3,
 1,2,3

julia> linspace(1,3,3)
3-element LinSpace{Float64} linspace(1.0,3.0,3),
 1.0,2.0,3.0

julia> 3:2
0-element UnitRange{Int64} 3:2
```

The alternatives to are to go back to 0.4 where `linspace(1,3,3)` just returns `linspace(1.0,2.0,3)` (which was complained about in user forum), or to just have `linspace` produce an actual array. But an array wouldn't address how to display things like `3:2` (e.g. clearly showing 0 elements), plus some of the complaints had to do with `linspace` not being consistent with `logspace` and not having a nice REPL display. My belief is that people will complain less about `linspace` if they can see its contents displayed, which we are trying to do here. In two lines of output, you see how your `Range` is defined (even if empty) and what it looks like.
