### PR TITLE
Have parallel test record coverage

### DIFF
--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -3,7 +3,15 @@
 # Run the parallel test outside of the main driver, since it runs off its own
 # set of workers.
 
-cmd = `$(Base.julia_cmd()) --check-bounds=yes --depwarn=error parallel_exec.jl`
+inline_flag = Base.JLOptions().can_inline == 1 ? "" : "--inline=no"
+cov_flag = ""
+if Base.JLOptions().code_coverage == 1
+    cov_flag = "--code-coverage=user"
+elseif Base.JLOptions().code_coverage == 2
+    cov_flag = "--code-coverage=all"
+end
+
+cmd = `$(Base.julia_cmd()) $inline_flag $cov_flag --check-bounds=yes --depwarn=error parallel_exec.jl`
 
 (strm, proc) = open(cmd)
 cmdout = readall(strm)


### PR DESCRIPTION
Currently, the tests for `sharedarray.jl` aren't recording `.cov` information and we have artificially lowered coverage stats! Boo, hiss. The reason is that `parallel_exec.jl` wasn't being spawned with the inlining and code-cov flags. I've added a pass-through for those flags in case the test is part of a coverage run.
