### PR TITLE
Update range display with range defn

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -35,33 +35,19 @@ a shorthand (e.g., `1:3`), or (2) as full constructor (e.g., `LinSpace{Int64}(..
 `rangelist` [`true`] selects whether the contents should be shown.
 If the range is empty, then at minimum the shorthand definition is shown.
 """
-function writemime(io::IO, ::MIME"text/plain", r::Range;
-    rangeverbose = true, rangeinfo = 1, rangelist = true)
-    if rangeverbose                      # at minimum show type, e.g.
-        print(io, summary(r))            #   5-element LinSpace{Float64}
-        if rangeinfo == 1 ||             # default is to print shorthand, e.g.
-          (rangeinfo == 0 && isempty(r))
-            print(io, " ")               #   1:3
-            if typeof(r) <: LinSpace
-                show(io, r)
-            else # FloatRange or OrdinalRange should be wrapped in parens
-                print(io, "(")
-                show(io,r)
-                print(io, ")")
-            end
-        elseif rangeinfo == 2           # or print constructor info,
-            print(io, "(")              #   (1,3)
-            for i in 1:nfields(r)-1
-                print(io, getfield(r, i), ",")
-            end
-            print(io, getfield(r, nfields(r)), ")")
-        end
-        if rangelist && !isempty(r)     # list contents if there are any
-            println(io, ":")
-            with_output_limit(()->print_range(io,r))
-        end
-    else                                # terse behavior (like v0.4 and earlier)
-        show(io,r)                      # e.g., linspace(1.0, 3.0, 5)
+function writemime(io::IO, ::MIME"text/plain", r::Range)
+    print(io, summary(r))            # e.g., 5-element LinSpace{Float64}
+    print(io, " ")               #   1:3
+    if typeof(r) <: LinSpace
+        show(io, r)
+    else # FloatRange or OrdinalRange should be wrapped in parens
+        print(io, "(")
+        show(io,r)
+        print(io, ")")
+    end
+    if !isempty(r)     # list contents if there are any
+        println(io, ":")
+        with_output_limit(()->print_range(io,r))
     end
 end
 # Note that for above, one can select different options by overwriting, e.g.

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -561,14 +561,14 @@ end
 
 # stringmime/writemime should display the range or linspace nicely
 # to test print_range in range.jl
+#
+# test default: print out type, shorthand, and list behavior
 replstr(x) = stringmime("text/plain", x)
-@test replstr(1:4) == "4-element UnitRange{$Int}:\n 1,2,3,4"
-@test replstr(linspace(1,5,7)) == "7-element LinSpace{Float64}:\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"
-@test replstr(0:100.) == "101-element FloatRange{Float64}:\n 0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,…,94.0,95.0,96.0,97.0,98.0,99.0,100.0"
-# next is to test a very large range, which should be fast because print_range
-# only examines spacing of the left and right edges of the range, sufficient
-# to cover the designated screen size.
-@test replstr(0:10^9) == "1000000001-element UnitRange{$Int}:\n 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,…,999999998,999999999,1000000000"
+@test replstr(1:4) == "4-element UnitRange{$Int} (1:4):\n 1,2,3,4" # actually displays with ":\n" but is stripped by stringmime
+@test replstr(2:1) == "0-element UnitRange{$Int} (2:1)"
+@test replstr(linspace(1,5,7)) == "7-element LinSpace{Float64} linspace(1.0,5.0,7):\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"
+@test replstr(0:100.) == "101-element FloatRange{Float64} (0.0:1.0:100.0):\n 0.0,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,…,94.0,95.0,96.0,97.0,98.0,99.0,100.0"
+@test replstr(0:10^9) == "1000000001-element UnitRange{$Int} (0:1000000000):\n 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,…,999999998,999999999,1000000000"
 
 @test sprint(io -> show(io,UnitRange(1,2))) == "1:2"
 @test sprint(io -> show(io,StepRange(1,2,5))) == "1:2:5"


### PR DESCRIPTION
Suggestion by @rfourquet to include definition of Range in its repl display #13966. The recently added behavior was to show the elements in one line of text #13615. Suggestion was to also include the definition, like in 0.4. Looks like this:

```
julia> 1:3
3-element UnitRange{Int64} 1:3,
 1,2,3

julia> linspace(1,3,3)
3-element LinSpace{Float64} linspace(1.0,3.0,3),
 1.0,2.0,3.0

julia> 3:2
0-element UnitRange{Int64} 3:2
```

The alternatives to are to go back to 0.4 where linspace(1,3,3) just returns linspace(1.0,2.0,3) (which was complained about in user forum), or to just have linspace produce an actual array. But an array wouldn't address how to display things like 3:2 (e.g. clearly showing 0 elements), plus some of the complaints had to do with linspace not being consistent with logspace and not having a nice REPL display. My belief is that people will complain less about linspace if they can see its contents displayed, which we are trying to do here. In two lines of output, you see how your Range is defined (even if empty) and what it looks like.

Second attempt due to Appveyor running out of time #13981
