### PR TITLE
fix writedlm for vectors of iterable rows

### DIFF
--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -25,7 +25,7 @@ function choosetests(choices = [])
         "bigint", "sorting", "statistics", "spawn", "backtrace",
         "priorityqueue", "file", "mmap", "version", "resolve",
         "pollfd", "mpfr", "broadcast", "complex", "socket",
-        "floatapprox", "readdlm", "reflection", "regex", "float16",
+        "floatapprox", "datafmt", "reflection", "regex", "float16",
         "combinatorics", "sysinfo", "rounding", "ranges", "mod2pi",
         "euler", "show", "lineedit", "replcompletions", "repl",
         "replutil", "sets", "test", "goto", "llvmcall", "grisu",

--- a/test/datafmt.jl
+++ b/test/datafmt.jl
@@ -237,3 +237,19 @@ end
 # test writemime
 @test sprint(io -> writemime(io, "text/csv", [1 2; 3 4])) == "1,2\n3,4\n"
 
+for writefunc in ((io,x) -> writemime(io, "text/csv", x),
+                  (io,x) -> invoke(writedlm, (IO, Any, Any), io, x, ","))
+    # iterable collections of iterable rows:
+    let x = [(1,2), (3,4)], io = IOBuffer()
+        writefunc(io, x)
+        seek(io, 0)
+        @test readcsv(io) == [1 2; 3 4]
+    end
+    # vectors of strings:
+    let x = ["foo", "bar"], io = IOBuffer()
+        writefunc(io, x)
+        seek(io, 0)
+        @test collect(readcsv(io)) == x
+    end
+end
+


### PR DESCRIPTION
The `writedlm` function is documented as supporting "iterable collections of iterable rows".  However, the implementation had two inconsistencies, as noted [recently on the mailing list](https://groups.google.com/d/msg/julia-users/XuXcz9kSh58/isZAbsoWBgAJ):
- Iterable collections of iterable rows are written as a matrix, but an `AbstractVector` of iterable rows was written as a single column.  e.g. `[(1,2), (3,4)]` is written as `"1, 2\n3, 4"` if it is invoked as a generic iterable, but as `"(1, 2)\n(3, 4)"` if it is invoked as a vector.
- Because strings are iterable, an iterable collection of strings is written as a matrix of characters, but a vector of strings is written as a column of strings.

This PR fixes both of these inconsistencies.  Vectors _and_ iterable collections of iterable rows are written as a matrix, but vectors _and_ iterable collections of _strings_ are written as a column of strings.

I also noticed that `writemime(io, "text/csv", x)` was overtyped.   And I renamed the `test/readdlm.jl` file to `test/datafmt.jl` to better reflect the fact that it tests both reading and writing.
