### PR TITLE
Fix zip() to return a tuple even when passed a single argument

### DIFF
--- a/base/iterator.jl
+++ b/base/iterator.jl
@@ -23,11 +23,23 @@ eltype{I}(::Type{Enumerate{I}}) = Tuple{Int, eltype(I)}
 
 abstract AbstractZipIterator
 
+immutable Zip1{I} <: AbstractZipIterator
+    a::I
+end
+zip(a) = Zip1(a)
+length(z::Zip1) = length(z.a)
+eltype{I}(::Type{Zip1{I}}) = Tuple{eltype(I)}
+start(z::Zip1) = (start(z.a),)
+function next(z::Zip1, st)
+    n = next(z.a,st[1])
+    return ((n[1],), (n[2],))
+end
+done(z::Zip1, st) = done(z.a,st[1])
+
 immutable Zip2{I1, I2} <: AbstractZipIterator
     a::I1
     b::I2
 end
-zip(a) = a
 zip(a, b) = Zip2(a, b)
 length(z::Zip2) = min(length(z.a), length(z.b))
 eltype{I1,I2}(::Type{Zip2{I1,I2}}) = Tuple{eltype(I1), eltype(I2)}

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -42,6 +42,22 @@ end
 # issue #4718
 @test collect(filter(x->x[1], zip([true, false, true, false],"abcd"))) == [(true,'a'),(true,'c')]
 
+let z = zip(1:2)
+    @test collect(z) == [(1,), (2,)]
+    # Issue #13979
+    @test eltype(z) == Tuple{Int}
+end
+
+let z = zip(1:2, 3:4)
+    @test collect(z) == [(1,3), (2,4)]
+    @test eltype(z) == Tuple{Int,Int}
+end
+
+let z = zip(1:2, 3:4, 5:6)
+    @test collect(z) == [(1,3,5), (2,4,6)]
+    @test eltype(z) == Tuple{Int,Int,Int}
+end
+
 # enumerate (issue #6284)
 let b = IOBuffer("1\n2\n3\n"), a = []
     for (i,x) in enumerate(eachline(b))


### PR DESCRIPTION
This wasn't the case since eaf5a959. Returning a tuple in all cases
is required to allow handling all cases with the same code.

Fixes https://github.com/JuliaLang/julia/issues/13979
