### PR TITLE
Two little sparse tests and OS tests

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -193,3 +193,8 @@ catch ex
 end
     @test isa(ex, ErrorException) && ex.msg == "cannot assign variables in other modules"
 end
+
+@test Base.is_unix(:Darwin)
+@test Base.is_unix(:FreeBSD)
+@test_throws ArgumentError Base.is_unix(:BeOS)
+@unix_only @test Base.windows_version() == (0,0)

--- a/test/sparsedir/sparse.jl
+++ b/test/sparsedir/sparse.jl
@@ -2,6 +2,10 @@
 
 using Base.Test
 
+@test issparse(sparse(ones(5,5)))
+@test !issparse(ones(5,5))
+@test Base.SparseArrays.indtype(sparse(ones(Int8,2),ones(Int8,2),rand(2))) == Int8
+
 # check sparse matrix construction
 @test isequal(full(sparse(complex(ones(5,5),ones(5,5)))), complex(ones(5,5),ones(5,5)))
 


### PR DESCRIPTION
`is_unix` wasn't tested for two symbols.

`issparse` wasn't tested and neither was `indtype`.
