### PR TITLE
define min(x), max(x) and minmax(x)

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -244,6 +244,10 @@ mod1{T<:Real}(x::T, y::T) = no_op_err("mod1", T)
 rem1{T<:Real}(x::T, y::T) = no_op_err("rem1", T)
 fld1{T<:Real}(x::T, y::T) = no_op_err("fld1", T)
 
+min(x::Real) = x
+max(x::Real) = x
+minmax(x::Real) = (x, x)
+
 max{T<:Real}(x::T, y::T) = ifelse(y < x, x, y)
 min{T<:Real}(x::T, y::T) = ifelse(y < x, y, x)
 minmax{T<:Real}(x::T, y::T) = y < x ? (y, x) : (x, y)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -55,6 +55,9 @@
 @test min(1.0,1) == 1
 
 # min, max and minmax
+@test min(1) === 1
+@test max(1) === 1
+@test minmax(1) === (1, 1)
 @test minmax(5, 3) == (3, 5)
 @test minmax(3., 5.) == (3., 5.)
 @test minmax(5., 3.) == (3., 5.)


### PR DESCRIPTION
This patch defines new `min`, `max` and `minmax` methods for a single argument, which can remove special handling for some macro-generated expressions. For example, in a case I encountered:

``` julia
macro update(args...)
    quote
        ...
        h = max($(args...))
        ...
    end
end
```
