### PR TITLE
Use larger interval for pollfd test

### DIFF
--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -9,7 +9,7 @@
 # Writable ends are always tested for writability before a write
 
 n = 20
-intvls = [2, .2, .1, .002]
+intvls = [2, .2, .1, .005]
 
 pipe_fds = cell(n)
 for i in 1:n


### PR DESCRIPTION
This prevents frequent failures from happening on build VMs.
It is not clear whether the failure reflects an underlying
bug or not, but having the CI fail randomly doesn't help fixing it.

Fixes or works around https://github.com/JuliaLang/julia/issues/12824
