### PR TITLE
Make constructors of Triangular matrices no op if the arguments is already of the right type

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -5,11 +5,13 @@
 abstract AbstractTriangular{T,S<:AbstractMatrix} <: AbstractMatrix{T} # could be renamed to Triangular when than name has been fully deprecated
 
 # First loop through all methods that don't need special care for upper/lower and unit diagonal
-for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular, :UnitUpperTriangular)
+for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
+          :UnitUpperTriangular)
     @eval begin
         immutable $t{T,S<:AbstractMatrix} <: AbstractTriangular{T,S}
             data::S
         end
+        $t(A::$t) = A
         function $t(A::AbstractMatrix)
             Base.LinAlg.chksquare(A)
             return $t{eltype(A), typeof(A)}(A)


### PR DESCRIPTION
@andreasnoack 

This fix point 1 in https://github.com/JuliaLang/LinearAlgebra.jl/issues/283 .
