### PR TITLE
Substitute symbols in NewvarNode after inlining

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2013,6 +2013,14 @@ function sym_replace(e::ANY, from1, from2, to1, to2)
             return SymbolNode(e2, e.typ)
         end
     end
+    if isa(e,NewvarNode)
+        e2 = _sym_repl(e.name::Symbol, from1, from2, to1, to2, e)
+        if isa(e2, NewvarNode) || !isa(e2, Symbol)
+             return e2
+        else
+            return NewvarNode(e2)
+        end
+    end
     if !isa(e,Expr)
         return e
     end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -32,7 +32,7 @@ function choosetests(choices = [])
         "nullable", "meta", "profile", "libgit2", "docs", "markdown",
         "base64", "serialize", "functors", "misc", "threads",
         "enums", "cmdlineargs", "i18n", "workspace", "libdl", "int",
-        "intset", "floatfuncs", "compile", "parallel"
+        "intset", "floatfuncs", "compile", "parallel", "inline"
     ]
 
     if Base.USE_GPL_LIBS

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -1,0 +1,67 @@
+
+using Base.Test
+
+"""
+Helper to walk the AST and call a function on every node.
+"""
+function walk(func, expr)
+    func(expr)
+    if isa(expr, Expr)
+        func(expr.head)
+        for o in expr.args
+            walk(func, o)
+        end
+    end
+end
+
+"""
+Helper to test that every SymbolNode/NewvarNode has a
+corresponding varinfo entry after inlining.
+"""
+function test_inlined_symbols(func, argtypes)
+    linfo = code_typed(func, argtypes)[1]
+    locals = linfo.args[2][1]
+    local_names = Set([name for (name, typ, flag) in locals])
+    ast = linfo.args[3]
+    walk(ast) do e
+        if isa(e, NewvarNode) || isa(e, SymbolNode)
+            @test e.name in local_names
+        end
+    end
+end
+
+# Test case 1:
+# Make sure that all symbols are properly escaped after inlining
+# https://github.com/JuliaLang/julia/issues/12620
+@inline function test_inner(count)
+    x = 1
+    i = 0
+    while i <= count
+        y = x
+        x = x + y
+        i += 1
+    end
+end
+function test_outer(a)
+    test_inner(a)
+end
+#test_inlined_symbols(test_outer, Tuple{Int64})
+
+# Test case 2:
+# Make sure that an error is thrown for the undeclared
+# y in the else branch.
+# https://github.com/JuliaLang/julia/issues/12620
+@inline function foo(x)
+    if x
+        y = 2
+    else
+        return y
+    end
+end
+function bar()
+    for i = 1:3 
+        foo(i==1)
+    end
+end
+@test_throws UndefVarError bar()
+

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -59,7 +59,7 @@ test_inlined_symbols(test_outer, Tuple{Int64})
     end
 end
 function bar()
-    for i = 1:3 
+    for i = 1:3
         foo(i==1)
     end
 end

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -45,7 +45,7 @@ end
 function test_outer(a)
     test_inner(a)
 end
-#test_inlined_symbols(test_outer, Tuple{Int64})
+test_inlined_symbols(test_outer, Tuple{Int64})
 
 # Test case 2:
 # Make sure that an error is thrown for the undeclared


### PR DESCRIPTION
Fix for issue https://github.com/JuliaLang/julia/issues/12620

Also added tests:
- check that all `SymbolNode`/`NewvarNode` exprs have a `varinfo` entry in the `LambdaStaticData` after inlining
- check that an `UndefVarError` is thrown in the example given by @vtjnash 
