### PR TITLE
mkdir: supply path to SystemError

### DIFF
--- a/base/base.jl
+++ b/base/base.jl
@@ -7,7 +7,9 @@ end
 type SystemError <: Exception
     prefix::AbstractString
     errnum::Int32
-    SystemError(p::AbstractString, e::Integer) = new(p, e)
+    extrainfo
+    SystemError(p::AbstractString, e::Integer, extrainfo) = new(p, e, extrainfo)
+    SystemError(p::AbstractString, e::Integer) = new(p, e, nothing)
     SystemError(p::AbstractString) = new(p, Libc.errno())
 end
 

--- a/base/error.jl
+++ b/base/error.jl
@@ -31,7 +31,7 @@ kwerr(kw) = error("unrecognized keyword argument \"", kw, "\"")
 
 ## system error handling ##
 
-systemerror(p, b::Bool) = b ? throw(Main.Base.SystemError(string(p))) : nothing
+systemerror(p, b::Bool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), extrainfo)) : nothing
 
 ## assertion functions and macros ##
 

--- a/base/file.jl
+++ b/base/file.jl
@@ -64,7 +64,7 @@ cd(f::Function) = cd(f, homedir())
 function mkdir(path::AbstractString, mode::Unsigned=0o777)
     @unix_only ret = ccall(:mkdir, Int32, (Cstring,UInt32), path, mode)
     @windows_only ret = ccall(:_wmkdir, Int32, (Cwstring,), path)
-    systemerror(:mkdir, ret != 0)
+    systemerror(:mkdir, ret != 0; extrainfo=path)
 end
 
 function mkpath(path::AbstractString, mode::Unsigned=0o777)

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -136,7 +136,13 @@ function showerror(io::IO, ex::DomainError, bt; backtrace=true)
     nothing
 end
 
-showerror(io::IO, ex::SystemError) = print(io, "SystemError: $(ex.prefix): $(Libc.strerror(ex.errnum))")
+function showerror(io::IO, ex::SystemError)
+    if ex.extrainfo == nothing
+        print(io, "SystemError: $(ex.prefix): $(Libc.strerror(ex.errnum))")
+    else
+        print(io, "SystemError (with $(ex.extrainfo)): $(ex.prefix): $(Libc.strerror(ex.errnum))")
+    end
+end
 showerror(io::IO, ::DivideError) = print(io, "DivideError: integer division error")
 showerror(io::IO, ::StackOverflowError) = print(io, "StackOverflowError:")
 showerror(io::IO, ::UndefRefError) = print(io, "UndefRefError: access to undefined reference")

--- a/test/file.jl
+++ b/test/file.jl
@@ -13,6 +13,16 @@ subdir = joinpath(dir, "adir")
 mkdir(subdir)
 subdir2 = joinpath(dir, "adir2")
 mkdir(subdir2)
+@test_throws SystemError mkdir(file)
+let err = nothing
+    try
+        mkdir(file)
+    catch err
+        io = IOBuffer()
+        showerror(io, err)
+        @test takebuf_string(io) == "SystemError (with $file): mkdir: File exists"
+    end
+end
 
 if @unix? true : (Base.windows_version() >= Base.WINDOWS_VISTA_VER)
     dirlink = joinpath(dir, "dirlink")


### PR DESCRIPTION
Some mkdir errors are very hard to debug unless you know what path it was trying to create. For example:

```
INFO: Upgrading Escher: v0.1.0 => v0.2.1
INFO: Upgrading Mux: v0.1.1 => v0.2.0
INFO: Installing Plots v0.4.2
INFO: Removing Color v0.2.11
INFO: Rolling back install of Plots
INFO: Rolling back Mux from v0.2.0 to v0.1.1
INFO: Rolling back Escher from v0.2.1 to v0.1.0
ERROR: SystemError: mkdir: File exists
 in mkdir at file.jl:42
 in cptree at file.jl:100
 in cp at file.jl:120
 in rename at fs.jl:121
 in remove at pkg/write.jl:50
 in resolve at ./pkg/entry.jl:459
 in resolve at pkg/entry.jl:404
 in anonymous at pkg/entry.jl:198
 in transact at pkg/git.jl:97
 in _checkout at pkg/entry.jl:190
 in free at pkg/entry.jl:220
 in anonymous at pkg/dir.jl:31
 in cd at file.jl:22
 in cd at pkg/dir.jl:31
 in free at pkg.jl:40
```

The problem turned out to be a symlink `~/.julia/v0.4/.trash/Color` (I was using symlinks to facilitate testing changes on both 0.3 and 0.4), but until I modified the error to show the path this was difficult to figure out.

The new version prints something like this:

```
"SystemError (with /home/tim/.julia/v0.4/.trash/Color): mkdir: File exists"
```
