### PR TITLE
Reenable ReadOnlyMemoryError test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
         sudo apt-get install jq -y;
         contrib/travis_fastfail.sh || exit 1;
         BUILDOPTS="-j3 USEGCC=1 LLVM_CONFIG=llvm-config-3.3 VERBOSE=1 USE_BLAS64=0 FORCE_ASSERTIONS=1 STAGE2_DEPS=utf8proc";
-        for lib in LLVM SUITESPARSE ARPACK BLAS FFTW LAPACK GMP MPFR LIBUNWIND OPENLIBM; do
+        for lib in LLVM SUITESPARSE ARPACK BLAS FFTW LAPACK GMP MPFR OPENLIBM; do
             export BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1";
         done;
         sudo add-apt-repository ppa:staticfloat/julia-deps -y;
@@ -35,10 +35,10 @@ before_install:
           export BUILDOPTS="$BUILDOPTS MARCH=pentium4";
           sudo apt-get remove libblas3gf liblapack3gf libarmadillo2 -y;
           sudo apt-get install binutils:i386 -y;
-          sudo apt-get install gcc:i386 g++:i386 make:i386 cpp:i386 g++-4.6:i386 gcc-4.6:i386 libssl-dev:i386 patchelf:i386 gfortran:i386 llvm-3.3-dev:i386 libsuitesparse-dev:i386 libopenblas-dev:i386 libopenblas-base:i386 libblas-dev:i386 liblapack-dev:i386 liblapack3:i386 libarpack2-dev:i386 libarpack2:i386 libfftw3-dev:i386 libgmp-dev:i386 libpcre3-dev:i386 libunwind7-dev:i386 libopenlibm-dev:i386 libmpfr-dev:i386 -y;
+          sudo apt-get install gcc:i386 g++:i386 make:i386 cpp:i386 g++-4.6:i386 gcc-4.6:i386 libssl-dev:i386 patchelf:i386 gfortran:i386 llvm-3.3-dev:i386 libsuitesparse-dev:i386 libopenblas-dev:i386 libopenblas-base:i386 libblas-dev:i386 liblapack-dev:i386 liblapack3:i386 libarpack2-dev:i386 libarpack2:i386 libfftw3-dev:i386 libgmp-dev:i386 libpcre3-dev:i386 libopenlibm-dev:i386 libmpfr-dev:i386 -y;
         else
           export JULIA_TEST_MAXRSS_MB="500";
-          sudo apt-get install patchelf gfortran llvm-3.3-dev libsuitesparse-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libopenlibm-dev libmpfr-dev -y;
+          sudo apt-get install patchelf gfortran llvm-3.3-dev libsuitesparse-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libopenlibm-dev libmpfr-dev -y;
         fi;
       elif [ `uname` = "Darwin" ]; then
         brew tap staticfloat/julia;

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -89,11 +89,10 @@ m = Mmap.mmap(file, Vector{UInt8}, 1, sz+1)
 @test m[1] == 0x00
 finalize(m); m=nothing; gc()
 
-# Uncomment out once #11351 is resolved
-# s = open(file, "r")
-# m = Mmap.mmap(s)
-# @test_throws ReadOnlyMemoryError m[5] = Vector{UInt8}('x') # tries to setindex! on read-only array
-# finalize(m); m=nothing; gc()
+s = open(file, "r")
+m = Mmap.mmap(s)
+@test_throws ReadOnlyMemoryError m[5] = UInt8('x') # tries to setindex! on read-only array
+finalize(m); m=nothing; gc()
 
 s = open(file, "w") do f
     write(f, "Hello World\n")


### PR DESCRIPTION
I believe I figured out why it is segfaulting on Travis lin32. As I [guessed before](https://github.com/JuliaLang/julia/pull/12380#issuecomment-126480608) it was caused by libunwind.

See https://github.com/yuyichao/julia/pull/2#issue-93647541 for the tests I did. If I just reenable the test, it crashes 7 out of 8 times. If the backtrace collection (which calls libunwind) is disabled, the crash disappeared. I noticed that the libunwind on Travis linux 32 (Ubuntu 12.04) is 0.99 and the latest version (also the one we bundle) is 1.1 so I tried to disable `USE_SYSTEM_LIBUNWIND` on travis linux and it seems to fix the issue (pass the test 8 out of 8 times).

Compilation of libunwind on travis seems to take ~0.5-1min so it's not bad (much less than libgit2). Maybe we could also use some pre-built binary?

Fix #11691
