### PR TITLE
Fix declname parsing when declaring a global variable in llvmcall.

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -621,12 +621,12 @@ static jl_cgval_t emit_llvmcall(jl_value_t **args, size_t nargs, jl_codectx_t *c
             while (std::getline(declarations, declstr, '\n')) {
                 u_int64_t declhash = memhash(declstr.c_str(), declstr.length());
                 if (llvmcallDecls.count(declhash) == 0) {
-                    // Findi  name of declaration by searching for '@'
+                    // Find the declaration name, starting right after '@'
+                    // - functions/intrinsics: declare @foo(...)
+                    // - global variables: @bar = ...
                     std::string::size_type atpos = declstr.find('@') + 1;
-                    // Find end of declaration by searching for '('
-                    std::string::size_type bracepos = declstr.find('(');
-                    // Declaration name is the string between @ and (
-                    std::string declname = declstr.substr(atpos, bracepos - atpos);
+                    std::string::size_type endpos = declstr.find_first_of("( =", atpos);
+                    std::string declname = declstr.substr(atpos, endpos - atpos);
 
                     // Check if declaration already present in module
                     if(jl_Module->getNamedValue(declname) == NULL) {

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -72,8 +72,8 @@ end
 # Test whether declarations work properly
 # This test only work properly for llvm 3.5+
 # On llvm <3.5+ even though the the compilation fails on the first try,
-# llvm still adds the intrinsice declaration to the module and subsequent calls
-# are succesfull.
+# llvm still adds the intrinsic declaration to the module and subsequent calls
+# are successful.
 if convert(VersionNumber, Base.libllvm_version) > v"3.5-"
 
 function undeclared_ceil(x::Float64)
@@ -140,3 +140,21 @@ function ceilfloor(x::Float64)
 end
 
 @test_approx_eq ceilfloor(7.4) 8.0
+
+# Test for global variables
+function gvar_set(x::Int64)
+    llvmcall(
+        ("""@gvar = common global i64 0""",
+         """store i64 %0, i64* @gvar
+            ret void"""),
+    Void, Tuple{Int64}, x)
+end
+function gvar_get()
+    llvmcall(
+        ("""@gvar = common global i64 0""",
+         """%1 = load i64, i64* @gvar
+            ret i64 %1"""),
+    Int64, Tuple{})
+end
+gvar_set(42)
+@test gvar_get() == 42


### PR DESCRIPTION
As per a comment in #11604, fix the parsing of the declaration name when declaring a global variable rather than a function or intrinsic.
