### PR TITLE
RFC: more reliable & extensible ^C REPL interrupt

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1011,6 +1011,7 @@ export
     consume,
     current_task,
     istaskdone,
+    istaskstarted,
     lock,
     notify,
     produce,

--- a/base/task.jl
+++ b/base/task.jl
@@ -66,6 +66,7 @@ end
 
 current_task() = ccall(:jl_get_current_task, Any, ())::Task
 istaskdone(t::Task) = ((t.state == :done) | (t.state == :failed))
+istaskstarted(t::Task) = ccall(:jl_is_task_started, Cint, (Any,), t) != 0
 
 yieldto(t::Task, x::ANY = nothing) = ccall(:jl_switchto, Any, (Any, Any), t, x)
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -148,11 +148,6 @@ function task_done_hook(t::Task)
     end
 
     if err && !handled
-        if isa(result,InterruptException) && isdefined(Base,:active_repl_backend) &&
-            active_repl_backend.backend_task.state == :runnable && isempty(Workqueue) &&
-            active_repl_backend.in_eval
-            throwto(active_repl_backend.backend_task, result)
-        end
         if !suppress_excp_printing(t)
             let bt = t.backtrace
                 # run a new task to print the error for us

--- a/src/gc.c
+++ b/src/gc.c
@@ -1849,6 +1849,7 @@ double clock_now(void);
 
 extern jl_module_t *jl_old_base_module;
 extern jl_array_t *jl_module_init_order;
+extern jl_function_t *jl_unhandled_exception_handler;
 
 static int inc_count = 0;
 static int quick_count = 0;
@@ -1875,6 +1876,7 @@ static void pre_mark(void)
     if (jl_an_empty_cell) gc_push_root(jl_an_empty_cell, 0);
     gc_push_root(jl_exception_in_transit, 0);
     gc_push_root(jl_task_arg_in_transit, 0);
+    if (jl_unhandled_exception_handler) gc_push_root(jl_unhandled_exception_handler, 0);
     if (jl_module_init_order != NULL)
         gc_push_root(jl_module_init_order, 0);
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1465,7 +1465,8 @@ typedef struct _jl_task_t {
     jl_jmp_buf ctx;
     size_t bufsz;
     void *stkbuf;
-    size_t ssize;
+    size_t ssize:31;
+    size_t started:1;
 
     // current exception handler
     jl_handler_t *eh;

--- a/src/task.c
+++ b/src/task.c
@@ -240,6 +240,7 @@ static void NOINLINE NORETURN start_task(void)
     // this runs the first time we switch to a task
     jl_task_t *t = jl_current_task;
     jl_value_t *res;
+    t->started = 1;
     if (t->exception != NULL && t->exception != jl_nothing) {
         record_backtrace();
         res = t->exception;
@@ -863,6 +864,7 @@ DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
     t->gcstack = NULL;
     t->stkbuf = NULL;
     t->tid = 0;
+    t->started = 0;
 
 #ifdef COPY_STACKS
     t->bufsz = 0;
@@ -952,6 +954,7 @@ void jl_init_root_task(void *stack, size_t ssize)
     jl_current_task->ssize = ssize;
     jl_current_task->stkbuf = stack;
 #endif
+    jl_current_task->started = 1;
     jl_current_task->parent = jl_current_task;
     jl_current_task->current_module = jl_current_module;
     jl_current_task->tls = jl_nothing;
@@ -970,6 +973,11 @@ void jl_init_root_task(void *stack, size_t ssize)
 
     jl_exception_in_transit = (jl_value_t*)jl_nothing;
     jl_task_arg_in_transit = (jl_value_t*)jl_nothing;
+}
+
+DLLEXPORT int jl_is_task_started(jl_task_t *t)
+{
+    return t->started;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Instead of making task_done_hook aware of the REPL specifically,
this gives clients (such as the REPL) the ability to register a
handler for dealing with any exception that would otherwise not have a handler.

For example, the following code is valid. And while not recommended in this form,
this code is essentially a simple produce/consume pattern.
If you wait a few seconds, it will even finish.

``` julia
for i = 1:10^6; schedule(current_task()); yieldto(@task ()); end
```

However, on v0.4, hitting ^C might either accomplish nothing or infinitely cause a stack overflow segfault.

with this change, hitting ^C gets back to the REPL immediately.

---

This can handle other sorts of exceptions, although
in reality, the only unhandled exceptions are those that occur
when trying to run task_done_hook or early on the root task.
Accordingly, the most likely error is InterruptException,
but not exclusively.

This approach allows the REPL to print an error and return to a prompt,
even when the Task state of eval_user_input is too inconsistent or
unknown to be called directly.

If the last-chance exception handler returns or throws an error,
that that error is then considered to be finally fatal.
The return value when setting the exception handler allows the user
to chain and reset the handler.
