### PR TITLE
Fix `UndefVarError: path_separator not defined`

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -275,7 +275,7 @@ Force reloading of a package, even if it has been loaded before. This is intende
 during package development as code is modified.
 """
 function reload(name::AbstractString)
-    if isfile(name) || contains(name,path_separator)
+    if isfile(name) || contains(name,Filesystem.path_separator)
         # for reload("path/file.jl") just ask for include instead
         error("use `include` instead of `reload` to load source files")
     else

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -133,3 +133,17 @@ let dir = mktempdir(),
         rm(dir, recursive=true)
     end
 end
+
+let module_name = string("a",randstring())
+    insert!(LOAD_PATH, 1, pwd())
+    file_name = string(module_name, ".jl")
+    touch(file_name)
+    code = """module $(module_name)\nend\n"""
+    open(file_name, "w") do file
+        write(file, code)
+    end
+    reload(module_name)
+    @test typeof(eval(symbol(module_name))) == Module
+    deleteat!(LOAD_PATH,1)
+    rm(file_name)
+end


### PR DESCRIPTION
Fix `UndefVarError: path_separator not defined` in `reload`
