### PR TITLE
Fix spelling errors

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1153,7 +1153,7 @@ end
 function reverse!(B::BitVector)
     # Basic idea: each chunk is divided into two blocks of size k = n % 64, and
     # h = 64 - k. Walk from either end (with indexes i and j) reversing chunks
-    # and seperately ORing their two blocks into place.
+    # and separately ORing their two blocks into place.
     #
     #           chunk 3                  chunk 2                  chunk 1
     # ┌───────────────┬───────┐┌───────────────┬───────┐┌───────────────┬───────┐

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -455,7 +455,7 @@ keywords[symbol(";")] = doc"""
   `;` has a similar role in Julia as in many C-like languages,
   and is used to delimit the end of the previous statement.
   `;` is not necessary after new lines, but can be used to
-  seperate statements on a single line or to join statements into
+  separate statements on a single line or to join statements into
   a single expression:
 
       function foo()
@@ -539,7 +539,7 @@ keywords[:type] = doc"""
           y
       end
 
-  Fields can have type restrictions, which may be parametised:
+  Fields can have type restrictions, which may be parametrised:
 
       type Point{X}
           x::X

--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -1805,7 +1805,7 @@ If no ``type`` argument is specified, the default is ``Vector{UInt8}``.
 
 Optionally, you can specify an offset (in bytes) if, for example, you want to skip over a header in the file. The default value for the offset is the current stream position for an ``IOStream``.
 
-The ``grow`` keyword argument specifies whether the disk file should be grown to accomodate the requested size of array (if the total file size is < requested array size). Write privileges are required to grow the file.
+The ``grow`` keyword argument specifies whether the disk file should be grown to accommodate the requested size of array (if the total file size is < requested array size). Write privileges are required to grow the file.
 
 The ``shared`` keyword argument specifies whether the resulting ``Array`` and changes made to it will be visible to other processes mapping the same file.
 
@@ -8139,7 +8139,7 @@ MethodError
 doc"""
     cat(dims, A...)
 
-Concatenate the input arrays along the specified dimensions in the iterable `dims`. For dimensions not in `dims`, all input arrays should have the same size, which will also be the size of the output array along that dimension. For dimensions in `dims`, the size of the output array is the sum of the sizes of the input arrays along that dimension. If `dims` is a single number, the different arrays are tightly stacked along that dimension. If `dims` is an iterable containing several dimensions, this allows to construct block diagonal matrices and their higher-dimensional analogues by simultaneously increasing several dimensions for every new input array and putting zero blocks elsewhere. For example, `cat([1,2], matrices...)` builds a block diagonal matrix, i.e. a block matrix with `matrices[1]`, `matrices[2]`, ... as diagonal blocks and matching zero blocks away from the diagonal.
+Concatenate the input arrays along the specified dimensions in the iterable `dims`. For dimensions not in `dims`, all input arrays should have the same size, which will also be the size of the output array along that dimension. For dimensions in `dims`, the size of the output array is the sum of the sizes of the input arrays along that dimension. If `dims` is a single number, the different arrays are tightly stacked along that dimension. If `dims` is an iterable containing several dimensions, this allows one to construct block diagonal matrices and their higher-dimensional analogues by simultaneously increasing several dimensions for every new input array and putting zero blocks elsewhere. For example, `cat([1,2], matrices...)` builds a block diagonal matrix, i.e. a block matrix with `matrices[1]`, `matrices[2]`, ... as diagonal blocks and matching zero blocks away from the diagonal.
 """
 cat
 
@@ -10549,7 +10549,7 @@ eigfact(A,B)
 doc"""
     rowvals(A)
 
-Return a vector of the row indices of `A`, and any modifications to the returned vector will mutate `A` as well. Given the internal storage format of sparse matrices, providing access to how the row indices are stored internally can be useful in conjuction with iterating over structural nonzero values. See `nonzeros(A)` and `nzrange(A, col)`.
+Return a vector of the row indices of `A`, and any modifications to the returned vector will mutate `A` as well. Given the internal storage format of sparse matrices, providing access to how the row indices are stored internally can be useful in conjunction with iterating over structural nonzero values. See `nonzeros(A)` and `nzrange(A, col)`.
 """
 rowvals
 

--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -371,7 +371,7 @@ stripmd(x::Markdown.Table) =
 """
     apropos(string)
 
-Search through all documention for a string, ignoring case.
+Search through all documentation for a string, ignoring case.
 """
 apropos(string) = apropos(STDOUT, string)
 apropos(io::IO, string) = apropos(io, Regex("\\Q$string", "i"))

--- a/base/pkg/resolve/maxsum.jl
+++ b/base/pkg/resolve/maxsum.jl
@@ -65,7 +65,7 @@ type Graph
     gdir::Vector{Vector{Int}}
 
     # adjacency dict:
-    #   allows to retrieve the indices in gadj, so that
+    #   allows one to retrieve the indices in gadj, so that
     #   gadj[p0][adjdict[p1][p0]] = p1
     adjdict::Vector{Dict{Int,Int}}
 

--- a/base/random.jl
+++ b/base/random.jl
@@ -90,7 +90,7 @@ function gen_rand(r::MersenneTwister)
 end
 
 @inline reserve_1(r::MersenneTwister) = mt_empty(r) && gen_rand(r)
-# `reserve` allows to call `rand_inbounds` n times
+# `reserve` allows one to call `rand_inbounds` n times
 # precondition: n <= MTCacheLength
 @inline reserve(r::MersenneTwister, n::Int) = mt_avail(r) < n && gen_rand(r)
 

--- a/doc/manual/documentation.rst
+++ b/doc/manual/documentation.rst
@@ -70,7 +70,7 @@ example:
     arguments, i.e. `*(x,y,z...)`.
     """
     function *(x, y)
-      # ... [implementation sold seperately] ...
+      # ... [implementation sold separately] ...
     end
 
     "When applied to strings, concatenates them."

--- a/doc/manual/strings.rst
+++ b/doc/manual/strings.rst
@@ -935,7 +935,7 @@ would only run with stable ``0.2`` versions, and exclude such versions as
 ``0.2`` versions, the lower bound check should be modified like this: ``v"0.2-"
 <= VERSION``.
 
-Another non-standard version specification extension allows to use a trailing
+Another non-standard version specification extension allows one to use a trailing
 ``+`` to express an upper limit on build versions, e.g.  ``VERSION >
 "v"0.2-rc1+"`` can be used to mean any version above ``0.2-rc1`` and any of its
 builds: it will return ``false`` for version ``v"0.2-rc1+win64"`` and ``true``

--- a/doc/stdlib/arrays.rst
+++ b/doc/stdlib/arrays.rst
@@ -378,7 +378,7 @@ Indexing, Assignment, and Concatenation
 
    .. Docstring generated from Julia source
 
-   Concatenate the input arrays along the specified dimensions in the iterable ``dims``\ . For dimensions not in ``dims``\ , all input arrays should have the same size, which will also be the size of the output array along that dimension. For dimensions in ``dims``\ , the size of the output array is the sum of the sizes of the input arrays along that dimension. If ``dims`` is a single number, the different arrays are tightly stacked along that dimension. If ``dims`` is an iterable containing several dimensions, this allows to construct block diagonal matrices and their higher-dimensional analogues by simultaneously increasing several dimensions for every new input array and putting zero blocks elsewhere. For example, ``cat([1,2], matrices...)`` builds a block diagonal matrix, i.e. a block matrix with ``matrices[1]``\ , ``matrices[2]``\ , ... as diagonal blocks and matching zero blocks away from the diagonal.
+   Concatenate the input arrays along the specified dimensions in the iterable ``dims``\ . For dimensions not in ``dims``\ , all input arrays should have the same size, which will also be the size of the output array along that dimension. For dimensions in ``dims``\ , the size of the output array is the sum of the sizes of the input arrays along that dimension. If ``dims`` is a single number, the different arrays are tightly stacked along that dimension. If ``dims`` is an iterable containing several dimensions, this allows one to construct block diagonal matrices and their higher-dimensional analogues by simultaneously increasing several dimensions for every new input array and putting zero blocks elsewhere. For example, ``cat([1,2], matrices...)`` builds a block diagonal matrix, i.e. a block matrix with ``matrices[1]``\ , ``matrices[2]``\ , ... as diagonal blocks and matching zero blocks away from the diagonal.
 
 .. function:: vcat(A...)
 
@@ -1031,7 +1031,7 @@ Sparse matrices support much of the same set of operations as dense matrices. Th
 
    .. Docstring generated from Julia source
 
-   Return a vector of the row indices of ``A``\ , and any modifications to the returned vector will mutate ``A`` as well. Given the internal storage format of sparse matrices, providing access to how the row indices are stored internally can be useful in conjuction with iterating over structural nonzero values. See ``nonzeros(A)`` and ``nzrange(A, col)``\ .
+   Return a vector of the row indices of ``A``\ , and any modifications to the returned vector will mutate ``A`` as well. Given the internal storage format of sparse matrices, providing access to how the row indices are stored internally can be useful in conjunction with iterating over structural nonzero values. See ``nonzeros(A)`` and ``nzrange(A, col)``\ .
 
 .. function:: nzrange(A, col)
 

--- a/doc/stdlib/base.rst
+++ b/doc/stdlib/base.rst
@@ -166,7 +166,7 @@ Getting Around
 
    .. Docstring generated from Julia source
 
-   Search through all documention for a string, ignoring case.
+   Search through all documentation for a string, ignoring case.
 
 .. function:: which(f, types)
 

--- a/doc/stdlib/io-network.rst
+++ b/doc/stdlib/io-network.rst
@@ -727,7 +727,7 @@ Memory-mapped I/O
 
    Optionally, you can specify an offset (in bytes) if, for example, you want to skip over a header in the file. The default value for the offset is the current stream position for an ``IOStream``.
 
-   The ``grow`` keyword argument specifies whether the disk file should be grown to accomodate the requested size of array (if the total file size is < requested array size). Write privileges are required to grow the file.
+   The ``grow`` keyword argument specifies whether the disk file should be grown to accommodate the requested size of array (if the total file size is < requested array size). Write privileges are required to grow the file.
 
    The ``shared`` keyword argument specifies whether the resulting ``Array`` and changes made to it will be visible to other processes mapping the same file.
 


### PR DESCRIPTION
The spelling errors were detected by the lintian package checker.

(cherry-picked from commit 2a8e0abf679cdd0ee84b7257c8349604d6a4d3f1)
