### PR TITLE
Don't allow strncmp'ing arbitrary vectors.

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -32,7 +32,7 @@ endswith(str::AbstractString, chars::Chars) = !isempty(str) && last(str) in char
 
 startswith(a::ByteString, b::ByteString) = startswith(a.data, b.data)
 startswith(a::Vector{UInt8}, b::Vector{UInt8}) =
-    (length(a) >= length(b) && ccall(:strncmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, length(b)) == 0)
+    (length(a) >= length(b) && ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, length(b)) == 0)
 
 # TODO: fast endswith
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -11,6 +11,8 @@
 @test endswith("abcd", "cd")
 @test !endswith("abcd", "dc")
 @test !endswith("cd", "abcd")
+@test startswith("ab\0cd", "ab\0c")
+@test !startswith("ab\0cd", "ab\0d")
 
 @test filter(x -> x ∈ ['f', 'o'], "foobar") == "foo"
 


### PR DESCRIPTION
The current `startswith` can be called with arbitrary `Vector{UInt8}` inputs, an undocumented and unused use case as far as I can see. This is implemented in terms of `strncmp`, but according to the [POSIX spec](http://pubs.opengroup.org/onlinepubs/009695399/functions/strncmp.html) `bytes that follow a null byte are not compared`.

For example, current master yields the following incorrect result:

``` julia
julia> startswith(bytestring("foo\0bar"), bytestring("foo\0NO"))
true
```

I've opted to remove the `Vector{UInt8}` definition, which seems unused anyway, but I'm unsure about the remaining `ByteString` implementation. I've currently implemented it in terms of `ccall(:strncmp, ..., (Cstring, Cstring))` which disallows NULL characters altogether:

``` julia
> startswith(bytestring("foo\0bar"), bytestring("foo\0NO"))
ERROR: ArgumentError: embedded NUL chars are not allowed in C strings: "foo\0bar"
```

Maybe this should only be the case for `startswith(Cstring)`, with `startswith(ByteString)` resolving to the in-Julia version `startswith(AbstractString)`? Or just replace `strncmp` by `memcmp`?
