### PR TITLE
Fix MSVC build, broken by #13845

### DIFF
--- a/src/flisp/flisp.h
+++ b/src/flisp/flisp.h
@@ -38,7 +38,7 @@ typedef struct _symbol_t {
     // below fields are private
     struct _symbol_t *left;
     struct _symbol_t *right;
-    char name[] __attribute__((aligned(sizeof(void*))));
+    JL_ATTRIBUTE_ALIGN_PTRSIZE(char name[]);
 } symbol_t;
 
 typedef struct {

--- a/src/julia.h
+++ b/src/julia.h
@@ -49,18 +49,6 @@ extern "C" {
 #define container_of(ptr, type, member) \
     ((type *) ((char *)(ptr) - offsetof(type, member)))
 
-#ifdef _MSC_VER
-#if _WIN64
-#define JL_ATTRIBUTE_ALIGN_PTRSIZE(x) __declspec(align(8)) x
-#else
-#define JL_ATTRIBUTE_ALIGN_PTRSIZE(x) __declspec(align(4)) x
-#endif
-#elif __GNUC__
-#define JL_ATTRIBUTE_ALIGN_PTRSIZE(x) x __attribute__ ((aligned (sizeof(void*))))
-#else
-#define JL_ATTRIBUTE_ALIGN_PTRSIZE(x)
-#endif
-
 // threading ------------------------------------------------------------------
 
 // WARNING: Threading support is incomplete and experimental (and only works with llvm-svn)

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -120,6 +120,18 @@
 #  define NOINLINE_DECL(f) f __attribute__((noinline))
 #endif
 
+#ifdef _COMPILER_MICROSOFT_
+# ifdef _P64
+#  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x) __declspec(align(8)) x
+# else
+#  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x) __declspec(align(4)) x
+# endif
+#elif defined(__GNUC__)
+#  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x) x __attribute__ ((aligned (sizeof(void*))))
+#else
+#  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x)
+#endif
+
 typedef int bool_t;
 typedef unsigned char  byte_t;   /* 1 byte */
 


### PR DESCRIPTION
use alignment macro (had to move it to a different header since the change was in flisp) instead of gnu-ism `__attribute__`
