### PR TITLE
Add symbol / string versions of find_library

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -46,7 +46,7 @@ function dlclose(p::Ptr)
     0 == ccall(:jl_dlclose, Cint, (Ptr{Void},), p)
 end
 
-function find_library(libnames::Vector, extrapaths::Vector=ASCIIString[])
+function find_library(libnames, extrapaths=ASCIIString[])
     for lib in libnames
         for path in extrapaths
             l = joinpath(path, lib)
@@ -64,6 +64,8 @@ function find_library(libnames::Vector, extrapaths::Vector=ASCIIString[])
     end
     return ""
 end
+find_library(libname::Union{Symbol,AbstractString}, extrapaths=ASCIIString[]) =
+    find_library([string(libname)], extrapaths)
 
 function dlpath(handle::Ptr{Void})
     p = ccall(:jl_pathname_for_handle, Ptr{UInt8}, (Ptr{Void},), handle)

--- a/test/libdl.jl
+++ b/test/libdl.jl
@@ -22,14 +22,16 @@ end
 
 cd(dirname(@__FILE__)) do
 
-# @test !isempty(Libdl.find_library(["libccalltest"], [dirname(@__FILE__)]))
-
 # Find the private library directory by finding the path of libjulia (or libjulia-debug, as the case may be)
-if ccall(:jl_is_debugbuild, Cint, ()) != 0
-    private_libdir = dirname(abspath(Libdl.dlpath("libjulia-debug")))
+private_libdir = if ccall(:jl_is_debugbuild, Cint, ()) != 0
+    dirname(abspath(Libdl.dlpath("libjulia-debug")))
 else
-    private_libdir = dirname(abspath(Libdl.dlpath("libjulia")))
+    dirname(abspath(Libdl.dlpath("libjulia")))
 end
+
+@test !isempty(Libdl.find_library(["libccalltest"], [private_libdir]))
+@test !isempty(Libdl.find_library("libccalltest", [private_libdir]))
+@test !isempty(Libdl.find_library(:libccalltest, [private_libdir]))
 
 # dlopen should be able to handle absolute and relative paths, with and without dlext
 let dl = C_NULL


### PR DESCRIPTION
Relax `find_library` argument types to any iterable
