### PR TITLE
Set jl_stackbase for worker threads

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -259,16 +259,15 @@ static void NOINLINE NORETURN start_task(void)
 }
 
 #ifdef COPY_STACKS
-#ifndef ASM_COPY_STACKS
 void NOINLINE jl_set_base_ctx(char *__stk)
 {
+    jl_stackbase = (char*)(((uptrint_t)__stk + sizeof(*__stk))&-16); // also ensures stackbase is 16-byte aligned
+#ifndef ASM_COPY_STACKS
     if (jl_setjmp(jl_base_ctx, 1)) {
         start_task();
     }
-}
-#else
-void jl_set_base_ctx(char *__stk) { }
 #endif
+}
 #endif
 
 DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
@@ -277,7 +276,6 @@ DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
     _julia_init(rel);
 #ifdef COPY_STACKS
     char __stk;
-    jl_stackbase = (char*)(((uptrint_t)&__stk + sizeof(__stk))&-16); // also ensures stackbase is 16-byte aligned
     jl_set_base_ctx(&__stk); // separate function, to record the size of a stack frame
 #endif
 }


### PR DESCRIPTION
Fixes #14028.  An earlier commit removed `jl_set_stackbase`, but it was still required when building with `JULIA_THREADS=1`.  The fix makes `jl_set_base_ctx` do the work that `jl_set_stackbase` did, which seems appropriate since calls to the two routines had to travel together anyway.  

The PR also eliminates some nanny warnings from gcc about a C++ incompatibility of the C code. 
