### PR TITLE
improve deprecation warning for non-integer indexing

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -444,7 +444,7 @@ end
 to_index_nodep(i::Real) = convert(Int,i)::Int
 
 @noinline function to_index(i::Real)
-    depwarn("indexing with non Integer Reals is deprecated", :to_index)
+    depwarn("Indexing with non-Integer Reals is deprecated.  It may be that your index arose from an integer division of the form i/j, in which case you should consider using i÷j or div(i,j) instead.", :to_index)
     to_index_nodep(i)
 end
 


### PR DESCRIPTION
It seems that 99% of the real-world usages of floating-point indexes (deprecated in #10458) arise because people are using `/` for integer division when they really want `÷`, but the latter is not very intuitive or discoverable.

See also the [julia-users discussion](https://groups.google.com/d/msg/julia-users/sEUvnjvtryI/tH9RHJENMIQJ).

This simply includes a suggestion to replace `i/j` with `i÷j` in the deprecation warning.  Probably should be backported to 0.4.
