### PR TITLE
Document a few low-level parallel APIs

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -11569,3 +11569,29 @@ doc"""
 Get the IP address and the port that the given TCP socket is connected to (or bound to, in the case of TCPServer).
 """
 getsockname
+
+doc"""
+    Base.remoteref_id(r::AbstractRemoteRef) -> (whence, id)
+
+A low-level API which returns the unique identifying tuple for a remote reference. A reference id is a tuple of two
+elements - pid where the reference was created from and a one-up number from that node.
+"""
+Base.remoteref_id
+
+doc"""
+    Base.channel_from_id(refid) -> c
+
+A low-level API which returns the backing AbstractChannel for an id returned by `remoteref_id`. The call is valid only on the node where the backing channel exists.
+"""
+Base.channel_from_id
+
+doc"""
+    Base.worker_id_from_socket(s::IO) -> pid
+
+A low-level API which given a `IO` connection, returns the pid of the worker it is connected to. This is useful when writing custom `serialize` methods for a type, which
+optimizes the data written out depending on the receiving process id.
+"""
+Base.worker_id_from_socket
+
+
+

--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -471,6 +471,24 @@ General Parallel Computing Support
 
    Execute an expression on all processes. Errors on any of the processes are collected into a ``CompositeException`` and thrown.
 
+.. function:: Base.remoteref_id(r::AbstractRemoteRef) -> (whence, id)
+
+   .. Docstring generated from Julia source
+
+   A low-level API which returns the unique identifying tuple for a remote reference. A reference id is a tuple of two elements - pid where the reference was created from and a one-up number from that node.
+
+.. function:: Base.channel_from_id(refid) -> c
+
+   .. Docstring generated from Julia source
+
+   A low-level API which returns the backing AbstractChannel for an id returned by ``remoteref_id``\ . The call is valid only on the node where the backing channel exists.
+
+.. function:: Base.worker_id_from_socket(s::IO) -> pid
+
+   .. Docstring generated from Julia source
+
+   A low-level API which given a ``IO`` connection, returns the pid of the worker it is connected to. This is useful when writing custom ``serialize`` methods for a type, which optimizes the data written out depending on the receiving process id.
+
 Shared Arrays (Experimental, UNIX-only feature)
 -----------------------------------------------
 


### PR DESCRIPTION
These APIs are being used in `SharedArray` and `DistributedArrays` and are useful in optimizing out the overhead of distributed GC. While I don't foresee regular users needing them, they ought to be useful for any parallel library writers.

Open to debate and bikeshedding. We can avoid exporting them and require their use only in the qualified `Base.` form. But  we don't have a way where we can document and make their presence / use known. This also ensures that changes in Base are aware of their exported use. 
