### PR TITLE
Channels sometimes drop messages

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -40,6 +40,7 @@ end
 
 function put!(c::Channel, v)
     !isopen(c) && throw(closed_exception())
+    @label check
     d = c.take_pos - c.put_pos
     if (d == 1) || (d == -(c.szp1-1))
         # grow the channel if possible
@@ -63,6 +64,7 @@ function put!(c::Channel, v)
             c.data = newdata
         else
             wait(c.cond_put)
+            @goto check
         end
     end
 


### PR DESCRIPTION
I'm not 100% clear on what's going on here, but it seems as though it's occasionally possible to notify too many `put!`s, resulting in invalid ones happening. The number of available elements goes straight from 32 -> 0 and the elements in the channel are lost.

For reference, a test case that demonstrates this issue:

``` julia
function test(n = 10^4)
  size = 0
  inc() = size += 1
  dec() = size -= 1
  c = Channel()
  t = @schedule @sync for i = 1:n
    @async (sleep(rand()); put!(c, i); inc())
    @async (sleep(rand()); take!(c);   dec())
  end
  sleep(1)
  size, Base.n_avail(c)
end
```

This test will often return a result like `(33, 0)`, with `t` hanging as it waits for elements that have disappeared. With this patch `size` is always equal to `n_avail`.

cc @amitmurthy 
