### PR TITLE
Fix build with llvm older than v3.6(included)

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -233,9 +233,11 @@ public:
             // as codegen may make decisions based on the presence of certain attributes
             NewF->copyAttributesFrom(F);
 
+            #ifdef LLVM37
             // Declarations are not allowed to have personality routines, but
             // copyAttributesFrom sets them anyway, so clear them again manually
             NewF->setPersonalityFn(nullptr);
+            #endif
 
             AttributeSet OldAttrs = F->getAttributes();
             // Clone any argument attributes that are present in the VMap.


### PR DESCRIPTION
`Function::setPersonalityFn` is a new API introduced in LLVM version 3.7.
