### PR TITLE
Remove @threads for calls and blocks; generalize @threads for loops

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -1,22 +1,25 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-export threadid, maxthreads, nthreads, @threads
+export threadid, maxthreads, @threads
 
 threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
+
+# Inclusive upper bound on threadid()
 maxthreads() = Int(unsafe_load(cglobal(:jl_max_threads, Cint)))
+
+# Do not export - it will go away in work-stealing implementation
 nthreads() = Int(unsafe_load(cglobal(:jl_n_threads, Cint)))
 
-function _threadsfor(forexpr)
+function _threadsfor(iter,lbody)
     fun = gensym("_threadsfor")
-    lidx = forexpr.args[1].args[1]			# index
-    lf = forexpr.args[1].args[2].args[1]		# first
-    ll = forexpr.args[1].args[2].args[2]		# last
-    lbody = forexpr.args[2]				# body
+    lidx = iter.args[1]		# index
+    range = iter.args[2]
     quote
 	function $fun()
 	    tid = threadid()
+            r = $(esc(range))
 	    # divide loop iterations among threads
-	    len, rem = divrem($(esc(ll))-$(esc(lf))+1, nthreads())
+	    len, rem = divrem(length(r), nthreads())
             # not enough iterations for all the threads?
             if len == 0
                 if tid > rem
@@ -24,8 +27,8 @@ function _threadsfor(forexpr)
                 end
                 len, rem = 1, 0
             end
-            # compute this thread's range
-	    f = $(esc(lf)) + ((tid-1) * len)
+            # compute this thread's iterations
+	    f = 1 + ((tid-1) * len)
 	    l = f + len - 1
             # distribute remaining iterations evenly
 	    if rem > 0
@@ -38,7 +41,8 @@ function _threadsfor(forexpr)
 		end
 	    end
             # run this thread's iterations
-	    for $(esc(lidx)) = f:l
+	    for i = f:l
+                local $(esc(lidx)) = Base.unsafe_getindex(r,i)
 		$(esc(lbody))
 	    end
 	end
@@ -46,42 +50,17 @@ function _threadsfor(forexpr)
     end
 end
 
-function _threadsblock(blk)
-    fun = gensym("_threadsblock")
-    esc(quote
-        function $fun()
-            $blk
-        end
-        ccall(:jl_threading_run, Void, (Any, Any), $fun, ())
-    end)
-end
-
-function _threadscall(callexpr)
-    fun = callexpr.args[1]
-    esc(quote
-        ccall(:jl_threading_run, Void, (Any, Any), $fun, $(Expr(:call, Core.svec, callexpr.args[2:end]...)))
-    end)
-end
-
 macro threads(args...)
     na = length(args)
-    if na != 2
+    if na != 1
         throw(ArgumentError("wrong number of arguments in @threads"))
     end
-    tg = args[1]
-    if !is(tg, :all)
-        throw(ArgumentError("only 'all' supported as thread group for @threads"))
-    end
-    ex = args[2]
+    ex = args[1]
     if !isa(ex, Expr)
 	throw(ArgumentError("need an expression argument to @threads"))
     end
     if is(ex.head, :for)
-	return _threadsfor(ex)
-    elseif is(ex.head, :block)
-	return _threadsblock(ex)
-    elseif is(ex.head, :call)
-	return _threadscall(ex)
+	return _threadsfor(ex.args[1],ex.args[2])
     else
         throw(ArgumentError("unrecognized argument to @threads"))
     end

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -1,13 +1,10 @@
 # This file is a part of Julia. License is MIT: http://julialang.org/license
 
-export threadid, maxthreads, @threads
+export threadid, nthreads, @threads
 
 threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
 
 # Inclusive upper bound on threadid()
-maxthreads() = Int(unsafe_load(cglobal(:jl_max_threads, Cint)))
-
-# Do not export - it will go away in work-stealing implementation
 nthreads() = Int(unsafe_load(cglobal(:jl_n_threads, Cint)))
 
 function _threadsfor(iter,lbody)

--- a/src/threading.c
+++ b/src/threading.c
@@ -125,7 +125,6 @@ JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void)
 
 // thread ID
 JL_DLLEXPORT int jl_n_threads;     // # threads we're actually using
-JL_DLLEXPORT int jl_max_threads;   // # threads possible
 jl_thread_task_state_t *jl_all_task_states;
 jl_gcframe_t ***jl_all_pgcstacks;
 
@@ -280,14 +279,14 @@ void jl_init_threading(void)
     char *cp;
 
     // how many threads available, usable
-    jl_max_threads = jl_cpu_cores();
+    int max_threads = jl_cpu_cores();
     jl_n_threads = DEFAULT_NUM_THREADS;
     cp = getenv(NUM_THREADS_NAME);
     if (cp) {
         jl_n_threads = (uint64_t)strtol(cp, NULL, 10);
     }
-    if (jl_n_threads > jl_max_threads)
-        jl_n_threads = jl_max_threads;
+    if (jl_n_threads > max_threads)
+        jl_n_threads = max_threads;
 
     // set up space for per-thread heaps
     jl_all_heaps = (struct _jl_thread_heap_t **)malloc(jl_n_threads * sizeof(void*));
@@ -536,7 +535,6 @@ void jl_init_threading(void)
 {
     static jl_thread_task_state_t _jl_all_task_states;
     jl_all_task_states = &_jl_all_task_states;
-    jl_max_threads = 1;
     jl_n_threads = 1;
     jl_all_pgcstacks = (jl_gcframe_t***) malloc(jl_n_threads * sizeof(jl_gcframe_t**));
 

--- a/test/perf/threads/laplace3d/laplace3d.jl
+++ b/test/perf/threads/laplace3d/laplace3d.jl
@@ -48,7 +48,7 @@ function l3d_threadfun(u1, u3, nx, ny, nz)
     end
 end
 
-## @threads 'block' form
+#= @threads 'block' form no longer supported
 function l3d_threadblock(u1, u3, nx, ny, nz)
     @threads all begin
 	tid = threadid()
@@ -72,10 +72,11 @@ function l3d_threadblock(u1, u3, nx, ny, nz)
 	end
     end
 end
+=#
 
 ## @threads 'for' form
 function l3d_threadfor(u1, u3, nx, ny, nz)
-    @threads all for k_3=2:nz-1
+    @threads for k_3=2:nz-1
         for k_2 = 2:ny-1
             @simd for k_1 = 2:nx-1
                 @inbounds u3[k_1, k_2, k_3] = stencil3d(u1, k_1, k_2, k_3)

--- a/test/perf/threads/lbm3d/lbm3d.jl
+++ b/test/perf/threads/lbm3d/lbm3d.jl
@@ -125,9 +125,9 @@ function lbm3d(n)
     const omega = 1.0
     const density = 1.0
 
-    # Implementation note: setting nchunk to maxthreads() is a hack
+    # Implementation note: setting nchunk to nthreads() is a hack
     # to simulate the previous implementation's use of parallel regions.
-    nchunk = maxthreads()
+    nchunk = nthreads()
 
     tprop = 0
     trelax = 0

--- a/test/perf/threads/lbm3d/lbm3d.jl
+++ b/test/perf/threads/lbm3d/lbm3d.jl
@@ -36,10 +36,9 @@ const fourths = tuple([ 6, 8, 9,12,13], [ 7,10,11,14,15],
                       [ 2,12,14,16,18], [ 3,13,15,17,19])
 
 
-function relax!(F, UX, UY, UZ, nx, ny, nz, deltaU, t1D, t2D, t3D, sSQU)
-    tid = threadid()
-    outerrange = Base.splitrange(nx, nthreads())
-    for i = outerrange[tid]
+function relax!(F, UX, UY, UZ, nx, ny, nz, deltaU, t1D, t2D, t3D, sSQU, chunkid, nchunk)
+    outerrange = Base.splitrange(nx, nchunk)
+    for i = outerrange[chunkid]
     #@threads all for i = 1:nx
         for j = 1:ny
             for k = 1:nz
@@ -72,10 +71,9 @@ function relax!(F, UX, UY, UZ, nx, ny, nz, deltaU, t1D, t2D, t3D, sSQU)
 end
 
 
-function calc_equi!(F, FEQ, t1D, t2D, t3D, U, UX, UY, UZ, sSQU, nx, ny, nz, omega)
-    tid = threadid()
-    outerrange = Base.splitrange(nx, nthreads())
-    for i = outerrange[tid]
+function calc_equi!(F, FEQ, t1D, t2D, t3D, U, UX, UY, UZ, sSQU, nx, ny, nz, omega, chunkid, nchunk)
+    outerrange = Base.splitrange(nx, nchunk)
+    for i = outerrange[chunkid]
     #@threads all for i = 1:nx
         #tid = threadid()
         for j = 1:ny
@@ -91,22 +89,22 @@ function calc_equi!(F, FEQ, t1D, t2D, t3D, U, UX, UY, UZ, sSQU, nx, ny, nz, omeg
                 FEQ[i,j,k,6] = t2D[i,j,k,1] * (1 + 3*UX[i,j,k,1] + 9/2*UX[i,j,k,1]^2 - sSQU[i,j,k,1])
                 FEQ[i,j,k,7] = t2D[i,j,k,1] * (1 - 3*UX[i,j,k,1] + 9/2*UX[i,j,k,1]^2 - sSQU[i,j,k,1])
 
-                U[1,tid]  = UX[i,j,k,1] + UY[i,j,k,1]
-                U[2,tid]  = UX[i,j,k,1] - UY[i,j,k,1]
-                U[3,tid]  = -UX[i,j,k,1] + UY[i,j,k,1]
-                U[4,tid]  = -U[1,tid]
-                U[5,tid]  = UX[i,j,k,1] + UZ[i,j,k,1]
-                U[6,tid]  = UX[i,j,k,1] - UZ[i,j,k,1]
-                U[7,tid]  = -U[6,tid]
-                U[8,tid]  = -U[5,tid]
-                U[9,tid]  = UY[i,j,k,1] + UZ[i,j,k,1]
-                U[10,tid] = UY[i,j,k,1] - UZ[i,j,k,1]
-                U[11,tid] = -U[10,tid]
-                U[12,tid] = -U[9,tid]
+                U[1,chunkid]  = UX[i,j,k,1] + UY[i,j,k,1]
+                U[2,chunkid]  = UX[i,j,k,1] - UY[i,j,k,1]
+                U[3,chunkid]  = -UX[i,j,k,1] + UY[i,j,k,1]
+                U[4,chunkid]  = -U[1,chunkid]
+                U[5,chunkid]  = UX[i,j,k,1] + UZ[i,j,k,1]
+                U[6,chunkid]  = UX[i,j,k,1] - UZ[i,j,k,1]
+                U[7,chunkid]  = -U[6,chunkid]
+                U[8,chunkid]  = -U[5,chunkid]
+                U[9,chunkid]  = UY[i,j,k,1] + UZ[i,j,k,1]
+                U[10,chunkid] = UY[i,j,k,1] - UZ[i,j,k,1]
+                U[11,chunkid] = -U[10,chunkid]
+                U[12,chunkid] = -U[9,chunkid]
 
                 # next-nearest neighbors
                 for l = 1:12
-                    FEQ[i,j,k,l+7] = t3D[i,j,k,1] * (1 + 3*U[l,tid] + 9/2*(U[l,tid]^2) - sSQU[i,j,k,1])
+                    FEQ[i,j,k,l+7] = t3D[i,j,k,1] * (1 + 3*U[l,chunkid] + 9/2*(U[l,chunkid]^2) - sSQU[i,j,k,1])
                 end
 
                 for l = 1:19
@@ -126,6 +124,10 @@ function lbm3d(n)
     const nz = nx
     const omega = 1.0
     const density = 1.0
+
+    # Implementation note: setting nchunk to maxthreads() is a hack
+    # to simulate the previous implementation's use of parallel regions.
+    nchunk = maxthreads()
 
     tprop = 0
     trelax = 0
@@ -154,7 +156,7 @@ function lbm3d(n)
     UX = Array(Float64,nx,ny,nz)
     UY = Array(Float64,nx,ny,nz)
     UZ = Array(Float64,nx,ny,nz)
-    U  = Array(Float64,12,nthreads())
+    U  = Array(Float64,12,nchunk)
     t1D = Array(Float64,nx,ny,nz)
     t2D = Array(Float64,nx,ny,nz)
     t3D = Array(Float64,nx,ny,nz)
@@ -180,7 +182,9 @@ function lbm3d(n)
         tic()
 
         # Relax; calculate equilibrium state (FEQ) with equivalent speed and density to F
-        @threads all relax!(F, UX, UY, UZ, nx, ny, nz, deltaU, t1D, t2D, t3D, sSQU)
+        @threads for chunk=1:nchunk
+            relax!(F, UX, UY, UZ, nx, ny, nz, deltaU, t1D, t2D, t3D, sSQU, chunkid, nchunk)
+        end
         for o in ON
             UX[o] = UY[o] = UZ[o] = t1D[o] = t2D[o] = t3D[o] = sSQU[o] = 0.0
         end
@@ -189,7 +193,9 @@ function lbm3d(n)
         tic()
 
         # Calculate equilibrium distribution: stationary
-        @threads all calc_equi!(F, FEQ, t1D, t2D, t3D, U, UX, UY, UZ, sSQU, nx, ny, nz, omega)
+        @threads for chunk=1:nchunk
+            calc_equi!(F, FEQ, t1D, t2D, t3D, U, UX, UY, UZ, sSQU, nx, ny, nz, omega)
+        end
 
         tequi = tequi + toq()
 

--- a/test/perf/threads/stockcorr/pstockcorr.jl
+++ b/test/perf/threads/stockcorr/pstockcorr.jl
@@ -45,7 +45,7 @@ end
 # Run paths in parallel
 # NOTE: this has to be in its own function due to #10718
 function runpath!(n, Wiener, CorrWiener, SA, SB, T, UpperTriangle, k11, k12, k21, k22, rngs)
-    @threads all for i = 1:n
+    @threads for i = 1:n
     #for i = 1:n
         randn!(rngs[threadid()], Wiener)
         #randn!(rngs[1], Wiener)
@@ -89,7 +89,7 @@ function pstockcorr(n)
     CorrWiener = Array(Float64, T-1, 2)
 
     # Runtime requirement: need per-thread RNG since it stores state
-    rngs = [MersenneTwister(777+x) for x in 1:nthreads()]
+    rngs = [MersenneTwister(777+x) for x in 1:maxthreads()]
 
     # Optimization: pre-computable factors
     # NOTE: this should be automatically hoisted out of the loop

--- a/test/perf/threads/stockcorr/pstockcorr.jl
+++ b/test/perf/threads/stockcorr/pstockcorr.jl
@@ -89,7 +89,7 @@ function pstockcorr(n)
     CorrWiener = Array(Float64, T-1, 2)
 
     # Runtime requirement: need per-thread RNG since it stores state
-    rngs = [MersenneTwister(777+x) for x in 1:maxthreads()]
+    rngs = [MersenneTwister(777+x) for x in 1:nthreads()]
 
     # Optimization: pre-computable factors
     # NOTE: this should be automatically hoisted out of the loop


### PR DESCRIPTION
The intent of the patch is to set direction away from OpenMP-style parallel-regions model, so that we do not prematurely lock ourselves out of work-stealing approaches (e.g. Cilk, X10, TBB, Go) that offer better composition properties.

Here is a summary of the changes and rationale:
-  `nthreads()` is no longer exported.  It's retained internally to keep `@threads for` working.  The notion of `nthreads()` is tightly tied to parallel regions and fundamentally incompatible with work-stealing.
- `maxthreads()` and `threadid()` retained.  They are still useful for creating race-free storage for the moment.
- `@threads` no longer has the block or call forms, since these are the parallel-regions model.
-  Remove the `all` specifier from `@threads`.  We can add it back later as optional if we really want that level of control.   (TBB has a notion of "first class arenas" for this level of control; Cilk/Go do not.)
- Generalize `@threads` to work on any 1D range with random-access subscripting.  Long term, we can generalize it to more general ranges similar to how `@simd` works.
- Make test of `@threads` check that loop actually executed out of order.  I considered writing tests to check for actual parallel execution, but decided to defer that to another day.  Inorder execution causes a warning, not a failure, for now.  (Does our testing farm guarantees parallel resources required for a real parallel test?)

We may find a better term than `@threads` in the future, but however we spell it, I expect we'll have a similar syntax for parallel loops.

My apologies for a largely "negative patch", but I fear we'll otherwise get locked into a style of parallelism that is problematic in the long term for "convenience is winning". 

I've been trying to organize my thoughts on future directions.  There's a design spectrum ranging across Cilk, X10, TBB, and Go, with consequent trade-offs of guarantees and flexibility.
