### PR TITLE
Add \ method for SymTridiagonal. 

### DIFF
--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -116,6 +116,8 @@ function A_mul_B!(C::StridedVecOrMat, S::SymTridiagonal, B::StridedVecOrMat)
     return C
 end
 
+(\)(T::SymTridiagonal, B::StridedVecOrMat) = ldltfact(T)\B
+
 eigfact!{T<:BlasReal}(A::SymTridiagonal{T}) = Eigen(LAPACK.stegr!('V', A.dv, A.ev)...)
 eigfact{T}(A::SymTridiagonal{T}) = (S = promote_type(Float32, typeof(zero(T)/norm(one(T)))); eigfact!(S != T ? convert(SymTridiagonal{S}, A) : copy(A)))
 

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -86,7 +86,7 @@ for elty in (Float32, Float64, Complex64, Complex128, Int)
         Fs = full(Ts)
         invFsv = Fs\v
         Tldlt = factorize(Ts)
-        x = Tldlt\v
+        x = Ts\v
         @test_approx_eq x invFsv
         @test_approx_eq full(full(Tldlt)) Fs
         @test_throws DimensionMismatch Tldlt\rand(elty,n+1)


### PR DESCRIPTION
This used to be handled by a generic fallback `factorize(T)\b`.
