### PR TITLE
Add more tests for copysign

### DIFF
--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -477,31 +477,31 @@ end
 @test copysign(big(1.0),big(-2.0)) == big(-1.0)
 
 #copysign
-@test copysign(-1,1) == 1                  
+@test copysign(-1,1) == 1
 @test copysign(1,-1) == -1
 
-@test copysign(-1,1.0) == 1                  
+@test copysign(-1,1.0) == 1
 @test copysign(1,-1.0) == -1
 
-@test copysign(-1,1//2) == 1                 
+@test copysign(-1,1//2) == 1
 @test copysign(1,-1//2) == -1
 
-@test copysign(1.0,-1) == -1.0              
+@test copysign(1.0,-1) == -1.0
 @test copysign(-1.0,1) == 1.0
 
-@test copysign(1.0,-1.0) == -1.0            
+@test copysign(1.0,-1.0) == -1.0
 @test copysign(-1.0,1.0) == 1.0
 
-@test copysign(1.0,-1//2) == -1.0            
+@test copysign(1.0,-1//2) == -1.0
 @test copysign(-1.0,1//2) == 1.0
- 
-@test copysign(1//2,-1) == -1//2              
+
+@test copysign(1//2,-1) == -1//2
 @test copysign(-1//2,1) == 1//2
 
-@test copysign(1//2,-1//2) == -1//2          
+@test copysign(1//2,-1//2) == -1//2
 @test copysign(-1//2,1//2) == 1//2
 
-@test copysign(1//2,-1.0) == -1//2          
+@test copysign(1//2,-1.0) == -1//2
 @test copysign(-1//2,1.0) == 1//2
 
 # verify type stability with integer (x is negative)
@@ -581,19 +581,19 @@ end
 @test eltype(copysign(-1//2,-1//2)) <: Rational
 
 # test x = NaN
-@test isnan(copysign(0/0,1)) 
+@test isnan(copysign(0/0,1))
 @test isnan(copysign(0/0,-1))
 
 # test x = Inf
-@test isinf(copysign(1/0,1)) 
-@test isinf(copysign(1/0,-1)) 
+@test isinf(copysign(1/0,1))
+@test isinf(copysign(1/0,-1))
 
 # test y = NaN (BUG Julia 0.4.1 20/11/2015)
-#@test isnan(copysign(1,0.0)) 
+#@test isnan(copysign(1,0.0))
 #@test isnan(copysign(-1,0.0))
 
 # test y = Inf (BUG Julia 0.4.1 20/11/2015)
-#@test isinf(copysign(1,1/0)) 
+#@test isinf(copysign(1,1/0))
 #@test isinf(copysign(-1,1/0))
 
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -476,6 +476,127 @@ end
 
 @test copysign(big(1.0),big(-2.0)) == big(-1.0)
 
+#copysign
+@test copysign(-1,1) == 1                  
+@test copysign(1,-1) == -1
+
+@test copysign(-1,1.0) == 1                  
+@test copysign(1,-1.0) == -1
+
+@test copysign(-1,1//2) == 1                 
+@test copysign(1,-1//2) == -1
+
+@test copysign(1.0,-1) == -1.0              
+@test copysign(-1.0,1) == 1.0
+
+@test copysign(1.0,-1.0) == -1.0            
+@test copysign(-1.0,1.0) == 1.0
+
+@test copysign(1.0,-1//2) == -1.0            
+@test copysign(-1.0,1//2) == 1.0
+ 
+@test copysign(1//2,-1) == -1//2              
+@test copysign(-1//2,1) == 1//2
+
+@test copysign(1//2,-1//2) == -1//2          
+@test copysign(-1//2,1//2) == 1//2
+
+@test copysign(1//2,-1.0) == -1//2          
+@test copysign(-1//2,1.0) == 1//2
+
+# verify type stability with integer (x is negative)
+@test eltype(copysign(-1,1)) <: Integer
+@test eltype(copysign(-1,BigInt(1))) <: Integer
+@test eltype(copysign(-1,1.0)) <: Integer
+@test eltype(copysign(-1,1//2)) <: Integer
+@test eltype(copysign(-BigInt(1),1)) <: Integer
+@test eltype(copysign(-BigInt(1),1.0)) <: Integer
+@test eltype(copysign(-BigInt(1),1//2)) <: Integer
+@test eltype(copysign(-BigInt(1),BigInt(1))) <: Integer
+@test eltype(copysign(-1,-1)) <: Integer
+@test eltype(copysign(-1,-BigInt(1))) <: Integer
+@test eltype(copysign(-1,-1.0)) <: Integer
+@test eltype(copysign(-1,-1//2)) <: Integer
+@test eltype(copysign(-BigInt(1),-1)) <: Integer
+@test eltype(copysign(-BigInt(1),-1.0)) <: Integer
+@test eltype(copysign(-BigInt(1),-1//2)) <: Integer
+@test eltype(copysign(-BigInt(1),-BigInt(1))) <: Integer
+
+# verify type stability with integer (x is positive)
+@test eltype(copysign(1,1)) <: Integer
+@test eltype(copysign(1,BigInt(1))) <: Integer
+@test eltype(copysign(1,1.0)) <: Integer
+@test eltype(copysign(1,1//2)) <: Integer
+@test eltype(copysign(BigInt(1),1)) <: Integer
+@test eltype(copysign(BigInt(1),1.0)) <: Integer
+@test eltype(copysign(BigInt(1),1//2)) <: Integer
+@test eltype(copysign(BigInt(1),BigInt(1))) <: Integer
+@test eltype(copysign(1,-1)) <: Integer
+@test eltype(copysign(1,-BigInt(1))) <: Integer
+@test eltype(copysign(1,-1.0)) <: Integer
+@test eltype(copysign(1,-1//2)) <: Integer
+@test eltype(copysign(BigInt(1),-1)) <: Integer
+@test eltype(copysign(BigInt(1),-1.0)) <: Integer
+@test eltype(copysign(BigInt(1),-1//2)) <: Integer
+@test eltype(copysign(BigInt(1),-BigInt(1))) <: Integer
+
+# verify type stability with real (x is negative)
+@test eltype(copysign(-1.0,1)) <: Real
+@test eltype(copysign(-1.0,BigInt(1))) <: Real
+@test eltype(copysign(-1.0,1.0)) <: Real
+@test eltype(copysign(-1.0,1//2)) <: Real
+@test eltype(copysign(-1.0,-1)) <: Real
+@test eltype(copysign(-1.0,-BigInt(1))) <: Real
+@test eltype(copysign(-1.0,-1.0)) <: Real
+@test eltype(copysign(-1.0,-1//2)) <: Real
+
+# Verify type stability with real (x is positive)
+@test eltype(copysign(1.0,1)) <: Real
+@test eltype(copysign(1.0,BigInt(1))) <: Real
+@test eltype(copysign(1.0,1.0)) <: Real
+@test eltype(copysign(1.0,1//2)) <: Real
+@test eltype(copysign(1.0,-1)) <: Real
+@test eltype(copysign(1.0,-BigInt(1))) <: Real
+@test eltype(copysign(1.0,-1.0)) <: Real
+@test eltype(copysign(1.0,-1//2)) <: Real
+
+# Verify type stability with rational (x is negative)
+@test eltype(copysign(-1//2,1)) <: Rational
+@test eltype(copysign(-1//2,BigInt(1))) <: Rational
+@test eltype(copysign(-1//2,1.0)) <: Rational
+@test eltype(copysign(-1//2,1//2)) <: Rational
+@test eltype(copysign(-1//2,-1)) <: Rational
+@test eltype(copysign(-1//2,-BigInt(1))) <: Rational
+@test eltype(copysign(-1//2,-1.0)) <: Rational
+@test eltype(copysign(-1//2,-1//2)) <: Rational
+
+# Verify type stability with rational (x is positive)
+@test eltype(copysign(-1//2,1)) <: Rational
+@test eltype(copysign(-1//2,BigInt(1))) <: Rational
+@test eltype(copysign(-1//2,1.0)) <: Rational
+@test eltype(copysign(-1//2,1//2)) <: Rational
+@test eltype(copysign(-1//2,-1)) <: Rational
+@test eltype(copysign(-1//2,-BigInt(1))) <: Rational
+@test eltype(copysign(-1//2,-1.0)) <: Rational
+@test eltype(copysign(-1//2,-1//2)) <: Rational
+
+# test x = NaN
+@test isnan(copysign(0/0,1)) 
+@test isnan(copysign(0/0,-1))
+
+# test x = Inf
+@test isinf(copysign(1/0,1)) 
+@test isinf(copysign(1/0,-1)) 
+
+# test y = NaN (BUG Julia 0.4.1 20/11/2015)
+#@test isnan(copysign(1,0.0)) 
+#@test isnan(copysign(-1,0.0))
+
+# test y = Inf (BUG Julia 0.4.1 20/11/2015)
+#@test isinf(copysign(1,1/0)) 
+#@test isinf(copysign(-1,1/0))
+
+
 @test isnan(1)     == false
 @test isnan(1.0)   == false
 @test isnan(-1.0)  == false


### PR DESCRIPTION
Added numerous test cases for copysign function. Discovered bug with `copysign` 
when the second argument of `copysign` is `NaN` or `Inf`; e.g. `@test 
isinf(copysign(1,1/0))` and `@test isinf(copysign(-1,1/0))`. Added these 
two tests but have currently commented them out.
