### PR TITLE
simplify channel imp and fix missed put!s

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -2,26 +2,21 @@
 
 abstract AbstractChannel
 
+const DEF_CHANNEL_SZ=32
+
 type Channel{T} <: AbstractChannel
     cond_take::Condition    # waiting for data to become available
     cond_put::Condition     # waiting for a writeable slot
     state::Symbol
 
     data::Array{T,1}
-    szp1::Int               # current channel size plus one
     sz_max::Int             # maximum size of channel
-    take_pos::Int           # read position
-    put_pos::Int            # write position
 
     function Channel(sz)
         sz_max = sz == typemax(Int) ? typemax(Int) - 1 : sz
-        szp1 = sz > 32 ? 33 : sz+1
-        new(Condition(), Condition(), :open,
-            Array(T, szp1), szp1, sz_max, 1, 1)
+        new(Condition(), Condition(), :open, Array(T, 0), sz_max)
     end
 end
-
-const DEF_CHANNEL_SZ=32
 
 Channel(sz::Int = DEF_CHANNEL_SZ) = Channel{Any}(sz)
 
@@ -40,34 +35,10 @@ end
 
 function put!(c::Channel, v)
     !isopen(c) && throw(closed_exception())
-    d = c.take_pos - c.put_pos
-    if (d == 1) || (d == -(c.szp1-1))
-        # grow the channel if possible
-        if (c.szp1 - 1) < c.sz_max
-            if ((c.szp1-1) * 2) > c.sz_max
-                c.szp1 = c.sz_max + 1
-            else
-                c.szp1 = ((c.szp1-1) * 2) + 1
-            end
-            newdata = Array(eltype(c), c.szp1)
-            if c.put_pos > c.take_pos
-                copy!(newdata, 1, c.data, c.take_pos, (c.put_pos - c.take_pos))
-                c.put_pos = c.put_pos - c.take_pos + 1
-            else
-                len_first_part = length(c.data) - c.take_pos + 1
-                copy!(newdata, 1, c.data, c.take_pos, len_first_part)
-                copy!(newdata, len_first_part+1, c.data, 1, c.put_pos-1)
-                c.put_pos = len_first_part + c.put_pos
-            end
-            c.take_pos = 1
-            c.data = newdata
-        else
-            wait(c.cond_put)
-        end
+    while length(c.data) == c.sz_max
+        wait(c.cond_put)
     end
-
-    c.data[c.put_pos] = v
-    c.put_pos = (c.put_pos == c.szp1 ? 1 : c.put_pos + 1)
+    push!(c.data, v)
     notify(c.cond_take, nothing, true, false)  # notify all, since some of the waiters may be on a "fetch" call.
     v
 end
@@ -76,21 +47,20 @@ push!(c::Channel, v) = put!(c, v)
 
 function fetch(c::Channel)
     wait(c)
-    c.data[c.take_pos]
+    c.data[1]
 end
 
 function take!(c::Channel)
     !isopen(c) && !isready(c) && throw(closed_exception())
     wait(c)
-    v = c.data[c.take_pos]
-    c.take_pos = (c.take_pos == c.szp1 ? 1 : c.take_pos + 1)
+    v = shift!(c.data)
     notify(c.cond_put, nothing, false, false) # notify only one, since only one slot has become available for a put!.
     v
 end
 
 shift!(c::Channel) = take!(c)
 
-isready(c::Channel) = (c.take_pos == c.put_pos ? false : true)
+isready(c::Channel) = n_avail(c) > 0
 
 function wait(c::Channel)
     while !isready(c)
@@ -106,13 +76,7 @@ end
 
 eltype{T}(::Type{Channel{T}}) = T
 
-function n_avail(c::Channel)
-    if c.put_pos >= c.take_pos
-        return c.put_pos - c.take_pos
-    else
-        return c.szp1 - c.take_pos + c.put_pos
-    end
-end
+n_avail(c::Channel) = length(c.data)
 
 show(io::IO, c::Channel) = print(io, "$(typeof(c))(sz_max:$(c.sz_max),sz_curr:$(n_avail(c)))")
 


### PR DESCRIPTION
This is an alternative fix for https://github.com/JuliaLang/julia/pull/14056 . The issue in #14056 was being triggered when a Condition variable that a  `put!` was waiting on was notified, but the task that was scheduled to run next was not this task but another task also executing a `put!`. The fix for this was to check again as has been done in this PR as well as #14056

This PR also simplifies the channel implementation by eschewing a circular buffer in favor of a push!/shift! on a regular array.

For 100 million put!/take! calls on a channel:

On master:

```
const n = 8
const c=Channel()
function foo() 
    for i in 1:10^n
        put!(c, i)
        take!(c)
    end
end

julia> @time foo()
  6.472149 seconds (100.00 M allocations: 1.490 GB, 1.32% gc time)

julia> @time foo()
  6.453079 seconds (100.00 M allocations: 1.490 GB, 1.29% gc time)
```

This PR:

```
julia> @time foo()
  8.954134 seconds (100.00 M allocations: 1.490 GB, 1.22% gc time)

julia> @time foo()
  8.999642 seconds (100.00 M allocations: 1.490 GB, 0.88% gc time)
```
1. 2.5 extra seconds is over 100 million iterations and hence not a big issue
2. Simplifies the code
3. The  implementation in master does not shrink the array once it reaches max_size. `shift!` on an Array, as in this PR, would shrink the underlying memory buffer when possible.
