### PR TITLE
normalize literal \r and \r\n chars in string literals to \n

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1833,6 +1833,14 @@
                (list* ex (tostr custom b) e)
                0)))
 
+      ; convert literal \r and \r\n in strings to \n (issue #11988)
+      ((eqv? c #\return) ; \r
+       (begin
+         (if (eqv? (peek-char p) #\linefeed) ; \r\n
+             (read-char p))
+         (write-char #\newline b)
+         (loop (read-char p) b e 0)))
+
       (else
        (write-char (not-eof-3 c) b)
        (loop (read-char p) b e 0)))))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -310,3 +310,7 @@ end
 @test parse("a||b→c&&d") == Expr(:call, :→,
                                  Expr(symbol("||"), :a, :b),
                                  Expr(symbol("&&"), :c, :d))
+
+# issue #11988 -- normalize \r and \r\n in literal strings to \n
+@test "foo\nbar" == parse("\"\"\"\r\nfoo\r\nbar\"\"\"") == parse("\"\"\"\nfoo\nbar\"\"\"") == parse("\"\"\"\rfoo\rbar\"\"\"") == parse("\"foo\r\nbar\"") == parse("\"foo\rbar\"") == parse("\"foo\nbar\"")
+@test '\r' == first("\r") == first("\r\n") # still allow explicit \r


### PR DESCRIPTION
This fixes #11988, by normalizing literal `\r` and `\r\n` characters in multiline string literals to `\n`.  Explicitly escaped `\r` chars are unaffected.

Also fixes #10833, I think (`unix2dos test/markdown.jl && make -C test markdown` passes).
