### PR TITLE
Comment out assertion on elapsed time in pollfd test

### DIFF
--- a/test/pollfd.jl
+++ b/test/pollfd.jl
@@ -56,7 +56,8 @@ function pfd_tst_timeout(idx, intvl)
     @test !evt.writable
     t_elapsed = toq()
 
-    @unix_only @test (intvl <= t_elapsed) # TODO: enable this test on windows when the libuv version is bumped
+    # Disabled since this assertion fails randomly, notably on build VMs (issue #12824)
+    # @unix_only @test (intvl <= t_elapsed) # TODO: enable this test on windows when the libuv version is bumped
     @test (t_elapsed <= (intvl + 1))
 end
 


### PR DESCRIPTION
Increasing the interval in db6d74c was not enough to fix the random failures.

Cf. #12824.
