### PR TITLE
Add manual section about numerical conversions.

### DIFF
--- a/doc/manual/mathematical-operations.rst
+++ b/doc/manual/mathematical-operations.rst
@@ -347,6 +347,73 @@ Control flow      ``&&`` followed by ``||`` followed by ``?``
 Assignments       ``= += -= *= /= //= \= ^= ÷= %= |= &= $= <<= >>= >>>=`` and ``.+= .-= .*= ./= .//= .\= .^= .÷= .%=``
 ================= =============================================================================================
 
+.. _man-numerical-conversions:
+
+Numerical Conversions
+---------------------
+
+Julia supports three forms of numerical conversion, which differ in their
+handling of inexact conversions.
+
+- The notation ``T(x)`` or ``convert(T,x)`` converts ``x`` to a value of type ``T``.
+
+  -  If ``T`` is a floating-point type, the result is the nearest representable
+     value, which could be positive or negative infinity.
+
+  -  If ``T`` is an integer type, an ``InexactError`` is raised if ``x``
+     is not representable by ``T``.
+
+
+- ``x % T`` converts an integer ``x`` to a value of integer type ``T``
+  congruent to ``x`` modulo ``2^n``, where ``n`` is the number of bits in ``T``.
+  In other words, the binary representation is truncated to fit.
+
+- The :ref:`man-rounding-functions` take a type ``T`` as an optional argument.
+  For example, ``round(Int,x)`` is a shorthand for ``Int(round(x))``.
+
+The following examples show the different forms.
+
+.. doctest::
+
+    julia> Int8(127)
+    127
+
+    julia> Int8(128)
+    ERROR: InexactError()
+     in call at ./essentials.jl:58
+     in eval at ./boot.jl:263
+
+    julia> Int8(127.0)
+    127
+
+    julia> Int8(3.14)
+    ERROR: InexactError()
+     in call at ./essentials.jl:58
+     in eval at ./boot.jl:263
+
+    julia> Int8(128.0)
+    ERROR: InexactError()
+     in call at ./essentials.jl:58
+     in eval at ./boot.jl:263
+
+    julia> 127 % Int8
+    127
+
+    julia> 128 % Int8
+    -128
+
+    julia> round(Int8,127.4)
+    127
+
+    julia> round(Int8,127.6)
+    ERROR: InexactError()
+     in trunc at ./float.jl:357
+     in round at ./float.jl:177
+     in eval at ./boot.jl:263
+
+See :ref:`man-conversion-and-promotion` for how to define your own
+conversions and promotions.
+
 .. _man-elementary-functions:
 
 Elementary Functions
@@ -357,6 +424,8 @@ operators. These mathematical operations are defined over as broad a
 class of numerical values as permit sensible definitions, including
 integers, floating-point numbers, rationals, and complexes, wherever
 such definitions make sense.
+
+.. _man-rounding-functions:
 
 Rounding functions
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR extends the manual to describe the three common ways to do numerical conversions (re: #14031).

I placed the new section just before the Elementary Functions section since the topic is a logical segue into rounding.
