### PR TITLE
Preserve function attributes in prepare_call (plus clean up)

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2120,3 +2120,13 @@ static jl_cgval_t emit_new_struct(jl_value_t *ty, size_t nargs, jl_value_t **arg
         return mark_julia_const(sty->instance);
     }
 }
+
+static Value *emit_pgcstack()
+{
+    return prepare_global(jlpgcstack_var);
+}
+
+static Value *emit_exc_in_transit()
+{
+    return prepare_global(jlexc_var);
+}

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -53,10 +53,13 @@ static llvm::Value *prepare_call(llvm::Value* Callee)
             return ModuleF;
         }
         else {
-            return Function::Create(F->getFunctionType(),
-                                    Function::ExternalLinkage,
-                                    F->getName(),
-                                    jl_Module);
+            Function *func = Function::Create(F->getFunctionType(),
+                                              Function::ExternalLinkage,
+                                              F->getName(),
+                                              jl_Module);
+            func->setAttributes(AttributeSet());
+            func->copyAttributesFrom(F);
+            return func;
         }
     }
 #endif

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -517,7 +517,6 @@ static Function *box8_func;
 static Function *box16_func;
 static Function *box32_func;
 static Function *box64_func;
-static Function *wbfunc;
 static Function *queuerootfun;
 static Function *expect_func;
 static Function *jldlsym_func;
@@ -539,11 +538,6 @@ static std::vector<Type *> two_pvalue_llvmt;
 static std::vector<Type *> three_pvalue_llvmt;
 
 static std::map<jl_fptr_t, Function*> builtin_func_map;
-
-extern "C" DLLEXPORT void jl_gc_wb_slow(jl_value_t* parent, jl_value_t* ptr)
-{
-    jl_gc_wb(parent, ptr);
-}
 
 // --- code generation ---
 
@@ -5808,14 +5802,6 @@ static void init_julia_llvm_env(Module *m)
                                     Function::ExternalLinkage,
                                     "jl_gc_queue_root", m);
     add_named_global(queuerootfun, (void*)&jl_gc_queue_root);
-
-    std::vector<Type *> wbargs(0);
-    wbargs.push_back(T_pjlvalue);
-    wbargs.push_back(T_pjlvalue);
-    wbfunc = Function::Create(FunctionType::get(T_void, wbargs, false),
-                              Function::ExternalLinkage,
-                              "jl_gc_wb_slow", m);
-    add_named_global(wbfunc, (void*)&jl_gc_wb_slow);
 
     std::vector<Type *> exp_args(0);
     exp_args.push_back(T_int1);

--- a/src/gc.c
+++ b/src/gc.c
@@ -2443,10 +2443,11 @@ void jl_print_gc_stats(JL_STREAM *s)
 #endif
 
 // Per-thread initialization (when threading is fully implemented)
-struct _jl_thread_heap_t *jl_mk_thread_heap(void)
+jl_thread_heap_t *jl_mk_thread_heap(void)
 {
 #ifdef JULIA_ENABLE_THREADING
-    jl_thread_heap = malloc(sizeof(jl_thread_heap_t)); // FIXME - should be cache-aligned malloc
+    // FIXME - should be cache-aligned malloc
+    jl_thread_heap = (jl_thread_heap_t*)malloc(sizeof(jl_thread_heap_t));
 #endif
     FOR_CURRENT_HEAP () {
         const int* szc = sizeclasses;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1862,7 +1862,6 @@ static void visit_mark_stack(int mark_mode)
 
 void jl_mark_box_caches(void);
 
-extern JL_THREAD jl_value_t * volatile jl_task_arg_in_transit;
 #if defined(GCTIME) || defined(GC_FINAL_STATS)
 double clock_now(void);
 #endif

--- a/src/julia.h
+++ b/src/julia.h
@@ -40,10 +40,16 @@ extern "C" {
 #define NWORDS(sz) (((sz)+3)>>2)
 #endif
 
-#if __GNUC__
-#define NORETURN __attribute__ ((noreturn))
+#if defined(__GNUC__)
+#  define NORETURN __attribute__ ((noreturn))
+#  define JL_CONST_FUNC __attribute__((const))
+#elif defined(_COMPILER_MICROSOFT_)
+#  define NORETURN __declspec(noreturn)
+// This is the closest I can find for __attribute__((const))
+#  define JL_CONST_FUNC __declspec(noalias)
 #else
-#define NORETURN
+#  define NORETURN
+#  define JL_CONST_FUNC
 #endif
 
 #define container_of(ptr, type, member) \


### PR DESCRIPTION
This is the bug fix and clean up part of https://github.com/JuliaLang/julia/pull/14083 (which will probably take some time before it is ready...). Hopefully this can be merged earlier than https://github.com/JuliaLang/julia/pull/14083 and avoid some merge/rebase conflict
