### PR TITLE
A couple of Makefile tweaks

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -938,7 +938,7 @@ endif
 
 # Custom libcxx
 ifeq ($(BUILD_CUSTOM_LIBCXX),1)
-LDFLAGS += -L$(build_libdir) -lc++abi
+LDFLAGS += -L$(build_libdir)
 CXXLDFLAGS += -L$(build_libdir) -lc++abi -stdlib=libc++ -lc++
 CPPFLAGS += -I$(build_includedir)/c++/v1
 CUSTOM_LD_LIBRARY_PATH := LD_LIBRARY_PATH="$(build_libdir)"

--- a/base/Makefile
+++ b/base/Makefile
@@ -77,7 +77,7 @@ endif
 
 $(BUILDDIR)/version_git.jl.phony: $(SRCDIR)/version_git.sh
 ifneq ($(NO_GIT), 1)
-	@sh $< > $@
+	sh $< $(SRCDIR) > $@
 	@# This to avoid touching git_version.jl when it is not modified,
 	@# so that the system image does not need to be rebuilt.
 	@if ! cmp -s $@ version_git.jl; then \
@@ -94,7 +94,7 @@ ifeq ($(shell [ -f $(BUILDDIR)/version_git.jl ] && echo "true"), true)
 	fi
 else
 	$(warning "WARNING: Generating boilerplate git version info")
-	@sh $(SRCDIR)/version_git.sh NO_GIT > $(BUILDDIR)/version_git.jl
+	@sh $(SRCDIR)/version_git.sh $(SRCDIR) NO_GIT > $(BUILDDIR)/version_git.jl
 endif
 endif
 

--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -15,8 +15,10 @@ echo "    fork_master_timestamp::Float64"
 echo "end"
 echo ""
 
+cd $1
+
 # If the script didn't ask not to use git info
-if [  "$#" = "1"  -a "$1" = "NO_GIT" ]; then
+if [  "$#" = "2"  -a "$2" = "NO_GIT" ]; then
     # this comment is used in base/Makefile to distinguish boilerplate
     echo "# Default output if git is not available."
     echo "const GIT_VERSION_INFO = GitVersionInfo(\"\" ,\"\" ,\"\" ,0 ,\"\" ,true ,0 ,0.)"

--- a/contrib/relative_path.sh
+++ b/contrib/relative_path.sh
@@ -17,7 +17,7 @@ fi
 common_part=$source # for now
 result="" # for now
 
-while [[ "${target#$common_part/}" == "${target}" ]] && [[ $common_part != "/" ]]; do
+while [[ "${target#$common_part/}" == "${target}" ]] && [[ "$common_part" != "/" ]]; do
     # no match, means that candidate common part is not correct
     # go up one level (reduce common part)
     common_part="$(dirname $common_part)"
@@ -29,7 +29,7 @@ while [[ "${target#$common_part/}" == "${target}" ]] && [[ $common_part != "/" ]
     fi
 done
 
-if [[ $common_part == "/" ]]; then
+if [[ "$common_part" == "/" ]]; then
     # special case for root (no common path)
     result="$result/"
 fi

--- a/contrib/relative_path.sh
+++ b/contrib/relative_path.sh
@@ -17,7 +17,7 @@ fi
 common_part=$source # for now
 result="" # for now
 
-while [[ "${target#$common_part/}" == "${target}" ]]; do
+while [[ "${target#$common_part/}" == "${target}" ]] && [[ $common_part != "/" ]]; do
     # no match, means that candidate common part is not correct
     # go up one level (reduce common part)
     common_part="$(dirname $common_part)"

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -111,6 +111,7 @@ else
 PATCHELF:=patchelf
 endif
 endif
+PATCHELF_BIN := $(CUSTOM_LD_LIBRARY_PATH) $(PATCHELF)
 
 ## USE_SYSTEM_LIBS options
 
@@ -451,6 +452,7 @@ LLVM_CC := CFLAGS="$(CFLAGS) -fsanitize=memory -fsanitize-memory-track-origins"
 LLVM_LDFLAGS += -fsanitize=memory -fsanitize-memory-track-origins
 LLVM_CXXFLAGS += -fsanitize=memory -fsanitize-memory-track-origins
 LLVM_CMAKE += -DLLVM_USE_SANITIZER="MemoryWithOrigins"
+LLVM_FLAGS += --disable-terminfo
 else
 LLVM_CC := CFLAGS="$(CFLAGS) -fsanitize=address"
 LLVM_LDFLAGS += -fsanitize=address
@@ -556,7 +558,7 @@ $(LLVM_BUILD_DIR)/libcxx-build/Makefile: | $(LLVM_SRC_DIR)/projects/libcxx $(LLV
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 		$(CMAKE) -G "Unix Makefiles" $(CMAKE_COMMON) $(LLVM_CMAKE) -DLIBCXX_CXX_ABI=libcxxabi -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$(LLVM_SRC_DIR)/projects/libcxxabi/include" $(LLVM_SRC_DIR)/projects/libcxx -DCMAKE_SHARED_LINKER_FLAGS="-L$(build_libdir) $(LIBCXX_EXTRA_FLAGS)" -DCMAKE_CXX_FLAGS="$(CXXFLAGS)"
-$(LLVM_BUILD_DIR)/libcxxabi-build/Makefile: | $(LLVM_SRC_DIR)/projects/libcxxabi llvm-$(LLVM_VER)/projects/libcxx
+$(LLVM_BUILD_DIR)/libcxxabi-build/Makefile: | $(LLVM_SRC_DIR)/projects/libcxxabi $(LLVM_SRC_DIR)/projects/libcxx
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
         $(CMAKE) -G "Unix Makefiles" $(CMAKE_COMMON) $(LLVM_CMAKE) -DLLVM_ABI_BREAKING_CHECKS="WITH_ASSERTS" -DLLVM_PATH="$(LLVM_SRC_DIR)" $(LLVM_SRC_DIR)/projects/libcxxabi -DLIBCXXABI_CXX_ABI_LIBRARIES="$(LIBCXX_EXTRA_FLAGS)" -DCMAKE_CXX_FLAGS="$(CXXFLAGS) -std=c++11"
@@ -1465,7 +1467,7 @@ else ifeq ($(OS), WINNT)
 	mv -f $(build_shlibdir)/libfftw3f-3.dll $@
 else ifeq ($(OS), Linux)
 	for filename in $(build_shlibdir)/libfftw3f_threads.so* ; do \
-		[ -L $$filename ] || $(PATCHELF) --set-rpath '$$ORIGIN' $$filename ;\
+		[ -L $$filename ] || $(PATCHELF_BIN) --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
 	touch -c $@
@@ -1488,7 +1490,7 @@ else ifeq ($(OS), WINNT)
 	mv -f $(build_shlibdir)/libfftw3-3.dll $@
 else ifeq ($(OS), Linux)
 	for filename in $(build_shlibdir)/libfftw3_threads.so* ; do \
-		[ -L $$filename ] || $(PATCHELF) --set-rpath '$$ORIGIN' $$filename ;\
+		[ -L $$filename ] || $(PATCHELF_BIN) --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
 	touch -c $@
@@ -1902,10 +1904,10 @@ $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/configure: $(SRCDIR)/srccache/patche
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) zxf $<
 	touch -c $@
-$(BUILDDIR)/patchelf-$(PATCHELF_VER)/config.status: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/configure
+$(BUILDDIR)/patchelf-$(PATCHELF_VER)/config.status: $(SRCDIR)/srccache/patchelf-$(PATCHELF_VER)/configure | $(LIBCXX_DEPENDENCY)
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
-	$< $(CONFIGURE_COMMON)
+	$< $(CONFIGURE_COMMON) LDFLAGS="$(CXXLDFLAGS)" CPPFLAGS="$(CPPFLAGS)"
 	touch -c $@
 $(PATCHELF_SOURCE): $(BUILDDIR)/patchelf-$(PATCHELF_VER)/config.status
 	$(MAKE) -C $(dir $<)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1381,7 +1381,7 @@ endif
 	$(INSTALL_NAME_CMD)libarpack.$(SHLIB_EXT) $(build_shlibdir)/libarpack.$(SHLIB_EXT)
 ifeq ($(OS), Linux)
 	for filename in $(build_shlibdir)/libarpack.so* ; do \
-		[ -L $$filename ] || $(PATCHELF) --set-rpath '$$ORIGIN' $$filename ;\
+		[ -L $$filename ] || $(PATCHELF_BIN) --set-rpath '$$ORIGIN' $$filename ;\
 	done
 endif
 	touch -c $@

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -790,7 +790,6 @@ endif
 $(BUILDDIR)/$(LIBUV_SRC_DIR)/config.status: $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/configure
 	touch -c $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/aclocal.m4 # touch a few files to prevent autogen from getting called
 	touch -c $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/Makefile.in
-	touch -c $(SRCDIR)/srccache/$(LIBUV_SRC_DIR)/configure
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$< --with-pic $(CONFIGURE_COMMON) $(UV_FLAGS)


### PR DESCRIPTION
- If we're building the world with a custom C++ library, make sure
  PATCHELF picks up the correct flags both at build time and when
  we use it.
- Fix base/version_git.sh to also work when using O= out of tree
  builds (important for Compat, etc.)
- Don't link against the C++ ABI level in C-only dependencies (because it might not be built yet)
