### PR TITLE
Fix MEMDEBUG mode

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -605,6 +605,7 @@ static inline int gc_setmark_big(void *o, int mark_mode)
         return 0;
     }
 #endif
+    assert(find_region(o,1) == NULL);
     bigval_t* hdr = bigval_header(o);
     int bits = gc_bits(o);
     if (bits == GC_QUEUED || bits == GC_MARKED)
@@ -1087,6 +1088,9 @@ static NOINLINE void add_page(pool_t *p)
 
 static inline void *__pool_alloc(pool_t* p, int osize, int end_offset)
 {
+#ifdef MEMDEBUG
+    assert(0 && "Should not be using pools in MEMDEBUG mode");
+#endif
     gcval_t *v, *end;
     // FIXME - need JL_ATOMIC_FETCH_AND_ADD here
     if (__unlikely((allocd_bytes += osize) >= 0) || gc_debug_check_pool()) {
@@ -2370,9 +2374,10 @@ DLLEXPORT jl_value_t *jl_gc_alloc_0w(void)
     void *tag = NULL;
 #ifdef MEMDEBUG
     tag = alloc_big(sz);
-#endif
+#else
     FOR_CURRENT_HEAP ()
         tag = _pool_alloc(&pools[szclass(sz)], sz);
+#endif
     return jl_valueof(tag);
 }
 
@@ -2382,9 +2387,10 @@ DLLEXPORT jl_value_t *jl_gc_alloc_1w(void)
     void *tag = NULL;
 #ifdef MEMDEBUG
     tag = alloc_big(sz);
-#endif
+#else
     FOR_CURRENT_HEAP ()
         tag = _pool_alloc(&pools[szclass(sz)], sz);
+#endif
     return jl_valueof(tag);
 }
 
@@ -2394,9 +2400,10 @@ DLLEXPORT jl_value_t *jl_gc_alloc_2w(void)
     void *tag = NULL;
 #ifdef MEMDEBUG
     tag = alloc_big(sz);
-#endif
+#else
     FOR_CURRENT_HEAP ()
         tag = _pool_alloc(&pools[szclass(sz)], sz);
+#endif
     return jl_valueof(tag);
 }
 
@@ -2406,9 +2413,10 @@ DLLEXPORT jl_value_t *jl_gc_alloc_3w(void)
     void *tag = NULL;
 #ifdef MEMDEBUG
     tag = alloc_big(sz);
-#endif
+#else
     FOR_CURRENT_HEAP ()
         tag = _pool_alloc(&pools[szclass(sz)], sz);
+#endif
     return jl_valueof(tag);
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -96,9 +96,9 @@ static void jl_find_stack_bottom(void)
 #ifndef _OS_WINDOWS_
     struct rlimit rl;
 
-    // When using memory sanitizer, increase stack size because msan bloats stack usage
+    // When using the sanitizers, increase stack size because they bloat stack usage
 #if defined(__has_feature)
-#if __has_feature(memory_sanitizer)
+#if __has_feature(memory_sanitizer) || __has_feature(address_sanitizer)
     const rlim_t kStackSize = 32 * 1024 * 1024;   // 32MB stack
     int result;
 


### PR DESCRIPTION
As of #13960, MEMDEBUG mode would allocate in pools, but mark as if
it were a bigobj, leading to quite suble corruption (that only shows
up if you are trying to debug a memory problem).

cc @yuyichao @carnaval 
