### PR TITLE
Fix compilation on non-intel CPUs on Linux

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -322,30 +322,10 @@ static int jl_gc_finalizers_inhibited; // don't run finalizers during codegen #1
 #define malloc_a16(sz) malloc(sz)
 #define realloc_a16(p, sz, oldsz) realloc((p), (sz))
 #define free_a16(p) free(p)
-
-#elif defined(_OS_WINDOWS_) /* 32-bit OS is implicit here. */
-#define malloc_a16(sz) _aligned_malloc((sz)?(sz):1, 16)
-#define realloc_a16(p, sz, oldsz) _aligned_realloc((p), (sz)?(sz):1, 16)
-#define free_a16(p) _aligned_free(p)
-
 #else
-static inline void *malloc_a16(size_t sz)
-{
-    void *ptr;
-    if (posix_memalign(&ptr, 16, sz))
-        return NULL;
-    return ptr;
-}
-static inline void *realloc_a16(void *d, size_t sz, size_t oldsz)
-{
-    void *b = malloc_a16(sz);
-    if (b != NULL) {
-        memcpy(b, d, oldsz);
-        free(d);
-    }
-    return b;
-}
-#define free_a16(p) free(p)
+#define malloc_a16(sz) jl_malloc_aligned(sz, 16)
+#define realloc_a16(p, sz, oldsz) jl_realloc_aligned(p, sz, oldsz, 16)
+#define free_a16(p) jl_free_aligned(p)
 #endif
 
 static void schedule_finalization(void *o, void *f)

--- a/src/ia_misc.h
+++ b/src/ia_misc.h
@@ -4,7 +4,13 @@
 #define IA_MISC_H
 
 #include <stdint.h>
-#include <immintrin.h>
+#if defined(_CPU_X86_64_) || defined(_CPU_X86_)
+#  include <immintrin.h>
+#elif defined(__linux__)
+#  include <linux/perf_event.h>
+#  include <linux/hw_breakpoint.h>
+#  include <asm/unistd.h>
+#endif
 #include "support/dtypes.h"
 
 #if defined(__i386__) && defined(__GNUC__) && !defined(__SSE2__)
@@ -15,9 +21,9 @@
 
 STATIC_INLINE unsigned long long rdtsc(void)
 {
-      unsigned long long int x;
-           __asm__ volatile (".byte 0x0f, 0x31" : "=A" (x));
-	        return x;
+    unsigned long long int x;
+    __asm__ volatile (".byte 0x0f, 0x31" : "=A" (x));
+    return x;
 }
 
 #elif defined(__x86_64__)
@@ -38,6 +44,10 @@ STATIC_INLINE uint64_t rdtsc(void)
     return __rdtsc();
 }
 
+#elif defined(__linux__)
+
+long long rdtsc(void);
+
 #endif  /* __i386__ */
 
 #ifdef __MIC__
@@ -45,11 +55,6 @@ STATIC_INLINE uint64_t rdtsc(void)
 STATIC_INLINE void cpu_pause(void)
 {
     _mm_delay_64(100);
-}
-
-STATIC_INLINE void cpu_delay(int64_t cycles)
-{
-    _mm_delay_64(cycles);
 }
 
 STATIC_INLINE void cpu_mfence(void)
@@ -67,18 +72,11 @@ STATIC_INLINE void cpu_lfence(void)
     __asm__ __volatile__ ("":::"memory");
 }
 
-#else  /* !__MIC__ */
+#elif defined(_CPU_X86_64_) || defined(_CPU_X86_)  /* !__MIC__ */
 
 STATIC_INLINE void cpu_pause(void)
 {
     _mm_pause();
-}
-
-STATIC_INLINE void cpu_delay(int64_t cycles)
-{
-    uint64_t s = rdtsc();
-    while ((rdtsc() - s) < cycles)
-        _mm_pause();
 }
 
 STATIC_INLINE void cpu_mfence(void)
@@ -96,8 +94,51 @@ STATIC_INLINE void cpu_lfence(void)
     _mm_lfence();
 }
 
+#elif defined(_CPU_ARM_)
+
+STATIC_INLINE void cpu_pause(void)
+{
+    __asm__ volatile ("wfe" ::: "memory");
+}
+
+STATIC_INLINE void cpu_mfence(void)
+{
+    __asm__ volatile ("dmb" ::: "memory");
+}
+
+STATIC_INLINE void cpu_sfence(void)
+{
+    cpu_mfence();
+}
+
+STATIC_INLINE void cpu_lfence(void)
+{
+    cpu_mfence();
+}
+
+#else
+
+STATIC_INLINE void cpu_pause(void)
+{
+}
+
+STATIC_INLINE void cpu_mfence(void)
+{
+    // GCC intrinsic
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+}
+
+STATIC_INLINE void cpu_sfence(void)
+{
+    cpu_mfence();
+}
+
+STATIC_INLINE void cpu_lfence(void)
+{
+    cpu_mfence();
+}
+
 #endif /* __MIC__ */
 
 
 #endif  /* IA_MISC_H */
-

--- a/src/threading.c
+++ b/src/threading.c
@@ -245,9 +245,9 @@ void jl_init_threading(void)
     cpu_ghz = ((double)(rdtsc() - cpu_tim)) / 1e9;
 
     // set up space for profiling information
-    fork_ticks = (uint64_t *)_mm_malloc(jl_n_threads * sizeof (uint64_t), 64);
-    user_ticks = (uint64_t *)_mm_malloc(jl_n_threads * sizeof (uint64_t), 64);
-    join_ticks = (uint64_t *)_mm_malloc(jl_n_threads * sizeof (uint64_t), 64);
+    fork_ticks = (uint64_t*)jl_malloc_aligned(jl_n_threads * sizeof(uint64_t), 64);
+    user_ticks = (uint64_t*)jl_malloc_aligned(jl_n_threads * sizeof(uint64_t), 64);
+    join_ticks = (uint64_t*)jl_malloc_aligned(jl_n_threads * sizeof(uint64_t), 64);
     ti_reset_timings();
 #endif
 
@@ -327,9 +327,9 @@ void jl_shutdown_threading(void)
     // TODO: clean up and free the per-thread heaps
 
 #if PROFILE_JL_THREADING
-    _mm_free(join_ticks);
-    _mm_free(user_ticks);
-    _mm_free(fork_ticks);
+    jl_free_aligned(join_ticks);
+    jl_free_aligned(user_ticks);
+    jl_free_aligned(fork_ticks);
     fork_ticks = user_ticks = join_ticks = NULL;
 #endif
 }


### PR DESCRIPTION
This implements some of the low level functions used by threading for non-intel CPUs. The implementation is not optimal but should probably work (at least when compiling a non-threading version....).

As a related note, why do we have to implement the lock ourselves instead of using the OS or libuv ones?

Fixes https://github.com/JuliaLang/julia/issues/14039
