### PR TITLE
make sure Cmd constructor is nestable

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -19,9 +19,9 @@ immutable Cmd <: AbstractCmd
         new(cmd.exec, ignorestatus, flags, env,
             dir === cmd.dir ? dir : cstr(dir))
     function Cmd(cmd::Cmd; ignorestatus::Bool=cmd.ignorestatus, env=cmd.env, dir::AbstractString=cmd.dir,
-                 detach::Bool=Bool(cmd.flags & UV_PROCESS_DETACHED),
-                 windows_verbatim::Bool=Bool(cmd.flags & UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS),
-                 windows_hide::Bool=Bool(cmd.flags & UV_PROCESS_WINDOWS_HIDE))
+                 detach::Bool = 0 != cmd.flags & UV_PROCESS_DETACHED,
+                 windows_verbatim::Bool = 0 != cmd.flags & UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS,
+                 windows_hide::Bool = 0 != cmd.flags & UV_PROCESS_WINDOWS_HIDE)
         flags = detach*UV_PROCESS_DETACHED |
                 windows_verbatim*UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS |
                 windows_hide*UV_PROCESS_WINDOWS_HIDE

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -337,3 +337,6 @@ end
 
 # make sure windows_verbatim strips quotes
 @windows_only readall(`cmd.exe /c dir /b spawn.jl`) == readall(Cmd(`cmd.exe /c dir /b "\"spawn.jl\""`, windows_verbatim=true))
+
+# make sure Cmd is nestable
+@test string(Cmd(Cmd(`ls`, detach=true))) == "`ls`"


### PR DESCRIPTION
This fixes a bug I introduced in #13780, sorry!
