### PR TITLE
Add arpack to the apt-get install line.

### DIFF
--- a/README.arm.md
+++ b/README.arm.md
@@ -36,7 +36,9 @@ override USE_SYSTEM_ARPACK=1
 The following command will install all the necessary libraries on Ubuntu.
 
 ````
-sudo apt-get install libblas3gf liblapack3gf libfftw3-dev libgmp3-dev libmpfr-dev libblas-dev liblapack-dev cmake gcc-4.8 g++-4.8 gfortran libgfortran3 m4 libedit-dev
+sudo apt-get install libblas3gf liblapack3gf libfftw3-dev libgmp3-dev \
+                     libmpfr-dev libblas-dev liblapack-dev cmake gcc-4.8 \
+                     g++-4.8 gfortran libgfortran3 m4 libedit-dev libarpack2
 ````
 
 Note that OpenBLAS only supports ARMv7. For older ARM variants, using the reference BLAS


### PR DESCRIPTION
The ARM readme specifies `USE_SYSTEM_ARPACK` but doesn't list `libarpack` in the installation line below. Consequently, building Julia and running `testall` results in:

```
$ julia test/linalg/arnoldi.jl
ERROR: LoadError: error compiling naupd: could not load library "libarpack"
libarpack: cannot open shared object file: No such file or directory
while loading /home/tim/julia/test/linalg/arnoldi.jl, in expression starting on line 8
```

Add the library, and wrap the text to avoid the annoying horizontal scroll bar when viewing online.
