### PR TITLE
Fix #14051, add a test

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -190,6 +190,9 @@ end
 
 function clone(url::AbstractString, pkg::AbstractString)
     info("Cloning $pkg from $url")
+    if !(':' in url) && !isfile(joinpath("METADATA",pkg,"url"))
+        throw(PkgError("package $pkg at $url doesn't appear to exist"))
+    end
     ispath(pkg) && throw(PkgError("$pkg already exists"))
     try
         LibGit2.with(LibGit2.clone(url, pkg)) do repo

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -92,7 +92,7 @@ temp_pkg_dir() do
             "need to update METADATA by running `Pkg.update()`"
     end
 
-    # trying to add, check availability, or pin a nonexistent package errors
+    # trying to add, clone, check availability, or pin a nonexistent package errors
     try
         Pkg.add("NonexistentPackage")
         error("unexpected")
@@ -113,6 +113,20 @@ temp_pkg_dir() do
     catch err
         @test isa(err, PkgError)
         @test err.msg == "NonexistentPackage is not a git repo"
+    end
+    try
+        Pkg.clone("NonexistentPackage")
+        error("unexpected")
+    catch err
+        @test isa(err, PkgError)
+        @test err.msg == "package NonexistentPackage at NonexistentPackage doesn't appear to exist"
+    end
+    try
+        Pkg.clone("ThisUrlIsFake","NonexistentPackage")
+        error("unexpected")
+    catch err
+        @test isa(err, PkgError)
+        @test err.msg == "package NonexistentPackage at ThisUrlIsFake doesn't appear to exist"
     end
 
     # trying to pin a git repo under Pkg.dir that is not an installed package errors


### PR DESCRIPTION
@wildart @tkelman 

I hope I did this in an ok way. The problem is that LibGit2 is actually not throwing an error (the C code seems happy with "NonexistentPackage" as a path or url).
