### PR TITLE
Raise UndefRefError using SegFault handler

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1728,7 +1728,9 @@ static jl_cgval_t emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     FunctionType *functype = FunctionType::get(sret ? T_void : prt, fargt_sig, isVa);
 
     if (jl_ptr != NULL) {
-        null_pointer_check(jl_ptr,ctx);
+        // null_pointer_check(jl_ptr, ctx);
+        // We throw a UndefRefError in the SegFault handler if the pointer is
+        // NULL.
         Type *funcptype = PointerType::get(functype,0);
         llvmf = builder.CreateIntToPtr(jl_ptr, funcptype);
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5862,13 +5862,23 @@ static inline SmallVector<std::string,10> getTargetFeatures(std::string &cpu)
     return attr;
 }
 
+static void parse_single_llvm_arg(const char *arg, const char *overview)
+{
+    const char *const argv[] = {"", arg};
+    cl::ParseCommandLineOptions(sizeof(argv) / sizeof(void*), argv, overview);
+}
+
 extern "C" void jl_init_codegen(void)
 {
-    const char *const argv_tailmerge[] = {"", "-enable-tail-merge=0"}; // NOO TOUCHIE; NO TOUCH! See #922
-    cl::ParseCommandLineOptions(sizeof(argv_tailmerge)/sizeof(argv_tailmerge[0]), argv_tailmerge, "disable-tail-merge\n");
+    // NOO TOUCHIE; NO TOUCH! See #922
+    parse_single_llvm_arg("-enable-tail-merge=0", "disable-tail-merge\n");
 #if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
-    const char *const argv_copyprop[] = {"", "-disable-copyprop"}; // llvm bug 21743
-    cl::ParseCommandLineOptions(sizeof(argv_copyprop)/sizeof(argv_copyprop[0]), argv_copyprop, "disable-copyprop\n");
+    // llvm bug 21743
+    parse_single_llvm_arg("-disable-copyprop", "disable-copyprop\n");
+#endif
+#ifdef LLVM38
+    parse_single_llvm_arg("-enable-implicit-null-checks=1",
+                          "enable-implicit-null-checks\n");
 #endif
 #ifdef JL_DEBUG_BUILD
     cl::ParseEnvironmentOptions("Julia", "JULIA_LLVM_ARGS");

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -222,7 +222,7 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
         }
         return KERN_SUCCESS;
     }
-    if (!fault_addr) {
+    if (fault_addr <= jl_page_size * 2) {
         jl_throw_in_thread(tid, thread, jl_undefref_exception);
         return KERN_SUCCESS;
     }

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -236,7 +236,7 @@ static void segv_handler(int sig, siginfo_t *info, void *context)
         jl_unblock_signal(sig);
         jl_throw_in_ctx(ptls, jl_readonlymemory_exception, context);
     }
-    else if (!info->si_addr) {
+    else if ((uintptr_t)info->si_addr <= jl_page_size * 2) {
         jl_unblock_signal(sig);
 #ifdef _OS_LINUX_
         ucontext_t *ctx = (ucontext_t*)context;

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -236,7 +236,7 @@ static LONG WINAPI _exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo,
                         ExceptionInfo->ContextRecord,in_ctx);
                     return EXCEPTION_CONTINUE_EXECUTION;
                 }
-                else if (!ExceptionInfo->ExceptionRecord->ExceptionInformation[1]) {
+                else if (ExceptionInfo->ExceptionRecord->ExceptionInformation[1] <= jl_page_size * 2) {
                     jl_throw_in_ctx(jl_undefref_exception,
                                     ExceptionInfo->ContextRecord, in_ctx);
                     return EXCEPTION_CONTINUE_EXECUTION;

--- a/test/core.jl
+++ b/test/core.jl
@@ -4430,6 +4430,27 @@ f17147(::Tuple) = 1
 f17147{N}(::Vararg{Tuple,N}) = 2
 @test f17147((), ()) == 2
 
+module TestUndefRefErrors14147
+
+using Base.Test
+# Test different kinds of UndefRefError
+call_fptr(p) = ccall(p, Int, ())
+return_int_function() = 100
+@test call_fptr(cfunction(return_int_function, Int, Tuple{})) == 100
+@test_throws UndefRefError call_fptr(C_NULL)
+
+type TypeWithUndefField
+    a
+    TypeWithUndefField() = new()
+end
+copy_undef_field(a, b) = (a.a = b.a)
+get_undef_field(a) = a.a
+@test_throws UndefRefError copy_undef_field(TypeWithUndefField(),
+                                            TypeWithUndefField())
+@test_throws UndefRefError get_undef_field(TypeWithUndefField())
+
+end
+
 # issue #17449, argument evaluation order
 @noinline f17449(x, y) = nothing
 @noinline function g17449(r)


### PR DESCRIPTION
Now that we have https://github.com/JuliaLang/julia/issues/11691 (hopefully) sorted out we can try to use `SIGSEGV` to do other useful things.

The main reason for this PR is to check if we can reliably trigger SegFault on a load and throw an exception from the signal handler, which we might use for thread-safe GC safepoint.

I originally tried to omit the comparison and use the load both as a null pointer check and as a way to throw the exception. However, it seems that the memory read overhead is quick significant and it causes a measureable slow down in certain cases (up to 15%).

@vtjnash (sorry for stealing something you always wanted to implement but it seems that this is a perfect test for the GC safepoint implementation)
