### PR TITLE
Collapse at-testloop into at-testset

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -9,17 +9,12 @@ Simple unit testing functionality:
 All tests belong to a *test set*. There is a default, task-level
 test set that throws on the first failure. Users can choose to wrap
 their tests in (possibly nested) test sets that will store results
-and summarize them at the end of the test set. See:
-
-* `@testset`
-* `@testloop`
-
-for more information.
+and summarize them at the end of the test set with `@testset`.
 """
 module Test
 
 export @test, @test_throws
-export @testset, @testloop
+export @testset
 # Legacy approximate testing functions, yet to be included
 export @test_approx_eq, @test_approx_eq_eps, @inferred
 
@@ -490,25 +485,51 @@ end
 
 """
     @testset [CustomTestSet] [option=val  ...] ["description"] begin ... end
+    @testset [CustomTestSet] [option=val  ...] ["description \$v"] for v in (...) ... end
+    @testset [CustomTestSet] [option=val  ...] ["description \$v, \$w"] for v in (...), w in (...) ... end
 
-Starts a new test set. If no custom testset type is given it defaults to creating
-a `DefaultTestSet`. `DefaultTestSet` records all the results and, and if there
-are any `Fail`s or `Error`s, throws an exception at the end of the
-top-level (non-nested) test set, along with a summary of the test results.
+Starts a new test set, or multiple test sets if a `for` loop is provided.
+
+If no custom testset type is given it defaults to creating a `DefaultTestSet`.
+`DefaultTestSet` records all the results and, and if there are any `Fail`s or
+`Error`s, throws an exception at the end of the top-level (non-nested) test set,
+along with a summary of the test results.
 
 Any custom testset type (subtype of `AbstractTestSet`) can be given and it will
-also be used for any nested `@testset` or `@testloop` invocations. The given
-options are only applied to the test set where they are given. The default test
-set type does not take any options.
+also be used for any nested `@testset` invocations. The given options are only
+applied to the test set where they are given. The default test set type does
+not take any options.
+
+The description string accepts interpolation from the loop indices.
+If no description is provided, one is constructed based on the variables.
 
 By default the `@testset` macro will return the testset object itself, though
-this behavior can be customized in other testset types.
+this behavior can be customized in other testset types. If a `for` loop is used
+then the macro collects and returns a list of the return values of the `finish`
+method, which by default will return a list of the testset objects used in
+each iteration.
 """
 macro testset(args...)
     isempty(args) && error("No arguments to @testset")
 
     tests = args[end]
 
+    # Determine if a single block or for-loop style
+    if !isa(tests,Expr) || (tests.head != :for && tests.head != :block)
+        error("Expected begin/end block or for loop as argument to @testset")
+    end
+
+    if tests.head == :for
+        return testset_forloop(args, tests)
+    else
+        return testset_beginend(args, tests)
+    end
+end
+
+"""
+Generate the code for a `@testset` with a `begin`/`end` argument
+"""
+function testset_beginend(args, tests)
     desc, testsettype, options = parse_testset_args(args[1:end-1])
     if desc == nothing
         desc = "test set"
@@ -540,27 +561,9 @@ end
 
 
 """
-    @testloop [CustomTestSet] [option=val  ...] ["description \$v"] for v in (...) ... end
-    @testloop [CustomTestSet] [option=val  ...] ["description \$v, \$w"] for v in (...), w in (...) ... end
-
-Starts a new test set for each iteration of the loop. The description string
-accepts interpolation from the loop indices. If no description is provided, one
-is constructed based on the variables.
-
-Any custom testset type (subtype of `AbstractTestSet`) can be given and it will
-also be used for any nested `@testset` or `@testloop` invocations. The given
-options are only applied to the test sets where they are given. The default test
-set type does not take any options.
-
-The `@testloop` macro collects and returns a list of the return values of the
-`finish` method, which by default will return a list of the testset objects used
-in each iteration.
+Generate the code for a `@testset` with a `for` loop argument
 """
-macro testloop(args...)
-    isempty(args) && error("no arguments to @testloop")
-
-    testloop = args[end]
-    isa(testloop,Expr) && testloop.head == :for || error("Unexpected argument to @testloop")
+function testset_forloop(args, testloop)
     # pull out the loop variables. We might need them for generating the
     # description and we'll definitely need them for generating the
     # comprehension expression at the end
@@ -572,7 +575,7 @@ macro testloop(args...)
             push!(loopvars, loopvar)
         end
     else
-        error("Unexpected argument to @testloop")
+        error("Unexpected argument to @testset")
     end
 
     desc, testsettype, options = parse_testset_args(args[1:end-1])
@@ -612,10 +615,9 @@ macro testloop(args...)
 end
 
 """
-Parse the arguments to the `@testset` or `@testloop` macro to pull out
-the description, Testset Type, and options. Generally this should be called
-with all the macro arguments except the last one, which is the test expression
-itself.
+Parse the arguments to the `@testset` macro to pull out the description,
+Testset Type, and options. Generally this should be called with all the macro
+arguments except the last one, which is the test expression itself.
 """
 function parse_testset_args(args)
     desc = nothing

--- a/doc/stdlib/test.rst
+++ b/doc/stdlib/test.rst
@@ -106,35 +106,29 @@ Working with Test Sets
 Typically a large of number of tests are used to make sure functions
 work correctly over a range of inputs. In the event a test fails, the
 default behavior is to throw an exception immediately. However, it is
-normally preferrable to run the rest of the tests first to get a
+normally preferable to run the rest of the tests first to get a
 better picture of how many errors there are in the code being tested.
 
-The :func:`@testset` and :func:`@testloop` macros can be used to
-group tests into *sets*. All the tests in a test set will be run,
-and at the end of the test set a summary will be printed. If any of
-the tests failed, or could not be evaluated due to an error, the
-test set will then throw a ``TestSetException``.
+The :func:`@testset` macro can be used to group tests into *sets*.
+All the tests in a test set will be run, and at the end of the test set
+a summary will be printed. If any of the tests failed, or could not be
+evaluated due to an error, the test set will then throw a ``TestSetException``.
 
 .. function:: @testset [CustomTestSet] [option=val  ...] ["description"] begin ... end
+              @testset [CustomTestSet] [option=val  ...] ["description $v"] for v in (...) ... end
+              @testset [CustomTestSet] [option=val  ...] ["description $v, $w"] for v in (...), w in (...) ... end
 
    .. Docstring generated from Julia source
 
-   Starts a new test set. If no custom testset type is given it defaults to creating a ``DefaultTestSet``\ . ``DefaultTestSet`` records all the results and, and if there are any ``Fail``\ s or ``Error``\ s, throws an exception at the end of the top-level (non-nested) test set, along with a summary of the test results.
+   Starts a new test set, or multiple test sets if a ``for`` loop is provided.
 
-   Any custom testset type (subtype of ``AbstractTestSet``\ ) can be given and it will also be used for any nested ``@testset`` or ``@testloop`` invocations. The given options are only applied to the test set where they are given. The default test set type does not take any options.
+   If no custom testset type is given it defaults to creating a ``DefaultTestSet``\ . ``DefaultTestSet`` records all the results and, and if there are any ``Fail``\ s or ``Error``\ s, throws an exception at the end of the top-level (non-nested) test set, along with a summary of the test results.
 
-   By default the ``@testset`` macro will return the testset object itself, though this behavior can be customized in other testset types.
+   Any custom testset type (subtype of ``AbstractTestSet``\ ) can be given and it will also be used for any nested ``@testset`` invocations. The given options are only applied to the test set where they are given. The default test set type does not take any options.
 
-.. function:: @testloop [CustomTestSet] [option=val  ...] ["description $v"] for v in (...) ... end
-              @testloop [CustomTestSet] [option=val  ...] ["description $v, $w"] for v in (...), w in (...) ... end
+   The description string accepts interpolation from the loop indices. If no description is provided, one is constructed based on the variables.
 
-   .. Docstring generated from Julia source
-
-   Starts a new test set for each iteration of the loop. The description string accepts interpolation from the loop indices. If no description is provided, one is constructed based on the variables.
-
-   Any custom testset type (subtype of ``AbstractTestSet``\ ) can be given and it will also be used for any nested ``@testset`` or ``@testloop`` invocations. The given options are only applied to the test sets where they are given. The default test set type does not take any options.
-
-   The ``@testloop`` macro collects and returns a list of the return values of the ``finish`` method, which by default will return a list of the testset objects used in each iteration.
+   By default the ``@testset`` macro will return the testset object itself, though this behavior can be customized in other testset types. If a ``for`` loop is used then the macro collects and returns a list of the return values of the ``finish`` method, which by default will return a list of the testset objects used in each iteration.
 
 We can put our tests for the ``foo(x)`` function in a test set::
 
@@ -153,7 +147,7 @@ Test sets can all also be nested::
                    @test foo("cat") == 9
                    @test foo("dog") == foo("cat")
                end
-               @testloop "Arrays $i" for i in 1:3
+               @testset "Arrays $i" for i in 1:3
                    @test foo(zeros(i)) == i^2
                    @test foo(ones(i)) == i^2
                end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -365,7 +365,7 @@ temp_dir() do dir
                 cache_oids = LibGit2.with(LibGit2.GitRevWalker(cache)) do walker
                     LibGit2.map((oid,repo)->string(oid), walker, by = LibGit2.Consts.SORT_TIME)
                 end
-                @testloop for i in eachindex(oids)
+                @testset for i in eachindex(oids)
                     @test cache_oids[i] == test_oids[i]
                 end
             finally

--- a/test/test.jl
+++ b/test/test.jl
@@ -64,25 +64,25 @@ try
     end
 
     @testset "loop with desc" begin
-        @testloop "loop1 $T" for T in (Float32, Float64)
+        @testset "loop1 $T" for T in (Float32, Float64)
             @test 1 == T(1)
         end
     end
     @testset "loops without desc" begin
-        @testloop for T in (Float32, Float64)
+        @testset for T in (Float32, Float64)
             @test 1 == T(1)
         end
-        @testloop for T in (Float32, Float64), S in (Int32,Int64)
+        @testset for T in (Float32, Float64), S in (Int32,Int64)
             @test S(1) == T(1)
         end
     end
     srand(123)
     @testset "some loops fail" begin
-        @testloop for i in 1:5
+        @testset for i in 1:5
             @test i <= rand(1:10)
         end
         # should add 3 errors and 3 passing tests
-        @testloop for i in 1:6
+        @testset for i in 1:6
             iseven(i) || error("error outside of test")
             @test true # only gets run if the above passed
         end
@@ -116,7 +116,7 @@ end
 @test typeof(ts) == Base.Test.DefaultTestSet
 @test typeof(ts.results[1]) == Base.Test.Pass
 
-tss = @testloop "@testloop should return an array of testsets: $i" for i in 1:3
+tss = @testset "@testset/for should return an array of testsets: $i" for i in 1:3
     @test true
 end
 @test length(tss) == 3
@@ -194,12 +194,12 @@ end
 @test typeof(ts.results[2].results[2]) == CustomTestSet
 @test ts.results[2].results[2].foo == 3
 
-# test custom testset types on testloops
-tss = @testloop CustomTestSet foo=3 "custom testloop $i" for i in 1:6
-    @testloop "inner testloop $i-$j" for j in 1:3
+# test custom testset types on testset/for
+tss = @testset CustomTestSet foo=3 "custom testset $i" for i in 1:6
+    @testset "inner testset $i-$j" for j in 1:3
         @test iseven(i + j)
     end
-    # make sure a testset within a testloop works
+    # make sure a testset within a testset/for works
     @testset "inner testset $i" begin
         @test iseven(i)
     end


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/14011

There was nothing really gained, it seemed, by distinguishing between `@testset` and `@testloop`. So I took the path of least resistance/minimal diff and basically put an `if` in the `@testset` macro, updated the docs and updated the tests.
