### PR TITLE
stream.jl: Remove error when server is closed while waiting for a client to connect (shutdown HttpServer gracefully)

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1057,7 +1057,6 @@ function accept(server::LibuvServer, client::LibuvStream)
         end
         stream_wait(server,server.connectnotify)
     end
-    uv_error("accept", UV_ECONNABORTED)
 end
 
 const BACKLOG_DEFAULT = 511


### PR DESCRIPTION
In reference to:

https://groups.google.com/forum/?fromgroups=#!topic/julia-dev/0eEXAGuja4U
