### PR TITLE
Add specific instructions for building on Raspberry Pi 2

### DIFF
--- a/README.arm.md
+++ b/README.arm.md
@@ -55,12 +55,12 @@ If you run into issues building LLVM, see these notes:
 Note: Raspberry Pi is ARMv6, which is not well supported at the moment. However it is
 possible to get a working Julia build.
 
-The Raspberry Pi ARM CPU type is not detected by LLVM.  Before
-starting the build, it is recommended to explicitly set the CPU target
-at the shell with the following, which should produce a working build.
+The Raspberry Pi ARM CPU type is not detected by LLVM.  Before starting the
+build, it is recommended to explicitly set the CPU target by adding the
+following to `Make.user`:
 
 ````
-export JULIA_CPU_TARGET=arm1176jzf-s
+JULIA_CPU_TARGET=arm1176jzf-s
 ````
 
 It is also preferable to use various system provided dependencies on
@@ -68,16 +68,23 @@ ARMv6 as described in the Build Dependencies section above.
 
 ## Raspberry Pi 2
 
-For Raspberry Pi 2, which is ARMv7, the default build should work. In
-the case of Raspberry Pi 2, in case the default build fails, download
-LLVM binaries from the LLVM website.
+For Raspberry Pi 2, which is ARMv7, the default build should work. However, the
+CPU type is also not detected by LLVM. Fix this by adding
+`JULIA_CPU_TARGET=cortex-a7` to `Make.user`.
+
+Depending on the exact compiler and distribution, there might be a build failure
+due to unsupported inline assembly. In that case, add `MARCH=armv7-a` to
+`Make.user`.
+
+If building LLVM fails, you can download binaries from the LLVM website:
 
 1.  Download the [LLVM 3.7.0 binaries for ARMv7a] (http://llvm.org/releases/3.7.0/clang+llvm-3.7.0-armv7a-linux-gnueabihf.tar.xz) and extract them in a local directory.
-2.  For each file in the extracted `bin`, `include`, and `lib` subdirectories, create symlinks from the corresponding directory under `/usr/local`.
-3. Add the following to `Make.user` and then build:
-```
-override USE_SYSTEM_LLVM=1
-```
+2. Add the following to `Make.user` (adjusting the path to the `llvm-config` binary):
+
+    ```
+    override USE_SYSTEM_LLVM=1
+    LLVM_CONFIG=${EXTRACTED_LOCATION}/bin/llvm-config
+    ```
 
 Please do let us know if you had to download a pre-built LLVM in [#10235](https://github.com/JuliaLang/julia/issues/10235).
 


### PR DESCRIPTION
Building `master` on RPi2 needs `MARCH` and `JULIA_CPU_TARGET` (see  #14152).

I've also sneaked in a modification to the README about how downloaded LLVM binaries are used. Adjusting `LLVM_CONFIG` seems a better solution, compared to creating symlinks in `/usr/local`.
