### PR TITLE
Use the inline asm version of cpu_pause and cpu_mfence only on ARMv7+

### DIFF
--- a/src/ia_misc.h
+++ b/src/ia_misc.h
@@ -94,7 +94,7 @@ STATIC_INLINE void cpu_lfence(void)
     _mm_lfence();
 }
 
-#elif defined(_CPU_ARM_)
+#elif defined(__ARM_ARCH) && __ARM_ARCH >= 7
 
 STATIC_INLINE void cpu_pause(void)
 {


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/issues/14152 ?
