### PR TITLE
Fixes #14158

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -138,7 +138,7 @@ function nextind(s::AbstractString, i::Integer)
         return 1
     end
     if i > e
-        return i+1
+        return sizeof(s)+1
     end
     for j = i+1:e
         if isvalid(s,j)

--- a/doc/stdlib/strings.rst
+++ b/doc/stdlib/strings.rst
@@ -363,7 +363,7 @@
 
    .. Docstring generated from Julia source
 
-   Get the next valid string index after ``i``\ . Returns a value greater than ``endof(str)`` at or after the end of the string.
+   Get the next valid string index after ``i``\ . Returns a value greater than ``sizeof(str)`` at or after the end of the string.
 
 .. function:: prevind(str, i)
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -192,6 +192,16 @@ gstr = GenericString("12");
 @test getindex(gstr,AbstractVector([Bool(1):Bool(1);]))=="1"
 
 @test nextind(AbstractArray([Bool(1):Bool(1);]),1)==2
+let s = "🛀🛀" #a bath codepoint is 4 bytes long
+    @test nextind(s,1) == 5
+    @test nextind(s,2) == 5
+    @test nextind(s,3) == 5
+    @test nextind(s,4) == 5
+    @test nextind(s,5) > sizeof(s)
+    @test nextind(s,6) > sizeof(s)
+    @test nextind(s,7) > sizeof(s)
+    @test nextind(s,8) > sizeof(s)
+end
 
 @test ind2chr(gstr,2)==2
 


### PR DESCRIPTION
Fixes `nextind(s,i)` for s::UTF8String where `endof(s) < i < sizeof(s)`
See #14158 for more details
