### PR TITLE
Fix MSYS2 GMP build

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1785,6 +1785,10 @@ ifeq ($(SANITIZE),1)
 GMP_CONFIGURE_OPTS += --disable-assembly
 endif
 
+ifeq ($(BUILD_OS),WINNT)
+GMP_CONFIGURE_OPTS += --srcdir="$(subst \,/,$(call mingw_to_dos,$(SRCDIR)/srccache/gmp-$(GMP_VER)))"
+endif
+
 $(SRCDIR)/srccache/gmp-$(GMP_VER).tar.bz2: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ https://gmplib.org/download/gmp/$(notdir $@)
 $(SRCDIR)/srccache/gmp-$(GMP_VER)/configure: $(SRCDIR)/srccache/gmp-$(GMP_VER).tar.bz2


### PR DESCRIPTION
Fixes `oops mp_limb_t doesn't seem to work` caused by configure embedding a unix-style path in a `#include` which mingw doesn't seem to like. @tkelman 
