### PR TITLE
Optimize TLS access in sysimg.

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -231,6 +231,12 @@ static int jl_load_sysimg_so(void)
     if (!imaging_mode && jl_options.use_precompiled==JL_OPTIONS_USE_PRECOMPILED_YES) {
         sysimg_gvars = (jl_value_t***)jl_dlsym(jl_sysimg_handle, "jl_sysimg_gvars");
         globalUnique = *(size_t*)jl_dlsym(jl_sysimg_handle, "jl_globalUnique");
+#ifdef JULIA_ENABLE_THREADING
+        size_t tls_getter_idx = *(size_t*)jl_dlsym(jl_sysimg_handle,
+                                                   "jl_ptls_states_getter_idx");
+        *sysimg_gvars[tls_getter_idx - 1] =
+            (jl_value_t*)jl_get_ptls_states_getter();
+#endif
         const char *cpu_target = (const char*)jl_dlsym(jl_sysimg_handle, "jl_sysimg_cpu_target");
         if (strcmp(cpu_target,jl_options.cpu_target) != 0)
             jl_error("Julia and the system image were compiled for different architectures.\n"


### PR DESCRIPTION
Instead of letting the linker resolve `jl_get_ptls_states` to the wrapper function in `libjulia.so`, use our own symbol table (`jl_sysimg_gvars`) to resolve the address to the actual getter function at initialization time.

This saves one load and one jump for each tls address access.

Using [the same benchmark](https://github.com/JuliaLang/julia/pull/14083#issuecomment-158987618) I used in the PR that introduce `jl_get_ptls_states`. Only the `gcframe (sysimg)` and `gcframe` ones for threading on (shown as sysimg and JIT respectively) are included since nothing else is changed by this PR.

|  | master threading | this pr threading |
| --- | --- | --- |
| sysimg | 3.26 | 2.88 |
| JIT | 2.93 | 2.93 |

It's a little funny to see that the sysimg version is now consistently faster than the JIT version (by ~ `0.22` clock cycle...).

Comparing the assembly of the JIT version with function address inlined

``` asm
   0x00007ffff7e11122 <+18>:    movq   $0x4,-0x30(%rbp)
   0x00007ffff7e1112a <+26>:    movabs $0x4018b0,%rax
   0x00007ffff7e11134 <+36>:    callq  *%rax
```

to the sysimg version with the function address loaded from the data section

``` asm
   0x00007ffff1f111c2 <+18>:    mov    0x1847237(%rip),%rax        # 0x7ffff3758400 <jl_get_ptls_states.ptr>
   0x00007ffff1f111c9 <+25>:    movq   $0x4,-0x30(%rbp)
   0x00007ffff1f111d1 <+33>:    callq  *%rax
```

Maybe it's the instruction order and/or the difference in code size that matter?
