### PR TITLE
Don't assume cmd.exe is on the PATH

### DIFF
--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -336,7 +336,7 @@ end
 @test_throws ErrorException collect(eachline(`cat _doesnt_exist__111_`))
 
 # make sure windows_verbatim strips quotes
-@windows_only readall(`cmd.exe /c dir /b spawn.jl`) == readall(Cmd(`cmd.exe /c dir /b "\"spawn.jl\""`, windows_verbatim=true))
+@windows_only readall(`$(ENV["COMSPEC"]) /c dir /b spawn.jl`) == readall(Cmd(`$(ENV["COMSPEC"]) /c dir /b "\"spawn.jl\""`, windows_verbatim=true))
 
 # make sure Cmd is nestable
 @test string(Cmd(Cmd(`ls`, detach=true))) == "`ls`"


### PR DESCRIPTION
On MSYS2, it's not by default.

@tkelman @vtjnash Would we get any problems in cross-compilation/wine here, or is that environment variable defined?
