### PR TITLE
1.1+0.1==2.1 returns false, which is not expected

### DIFF
--- a/doc/manual/complex-and-rational-numbers.rst
+++ b/doc/manual/complex-and-rational-numbers.rst
@@ -11,7 +11,7 @@ numbers, and supports all :ref:`standard mathematical operations
 <man-mathematical-operations>` on them. :ref:`man-conversion-and-promotion`
 are defined so that operations on any combination of
 predefined numeric types, whether primitive or composite, behave as
-expected.
+defined by corresponding IEEE standards.
 
 .. _man-complex-numbers:
 


### PR DESCRIPTION
The documentation is where people now to `Julia` are supposed to learn it and get correct information. _behaves as expected_ is too general and includes many subjective concepts that it can hardly be true for different people; something that seems as expected to one person might not be as expected to the other. For example, that `1.1+0.1==2.1` returns `false` is _expected_ to a programmer who is familiar with floating points operations, it is **not** as expected to someone a) new to programming, or b) not exactly sure what `julia`'s Conversion and Promotion is, which comes way later in the documentation.

``` julia
julia> 1.0
1.0

julia> 0.1
0.1

julia> 1.1+0.1
1.2000000000000002
```
