### PR TITLE
A few makefile tweaks for out-of-tree and debug flisp builds

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1018,6 +1018,7 @@ VERBOSE := 0
 endif
 
 WARNCOLOR:="\033[33;1m"
+ENDCOLOR:="\033[0m"
 
 ifeq ($(VERBOSE), 0)
 
@@ -1032,7 +1033,6 @@ JULIACOLOR:="\033[32;1m"
 SRCCOLOR:="\033[33m"
 BINCOLOR:="\033[37;1m"
 JULCOLOR:="\033[34;1m"
-ENDCOLOR:="\033[0m"
 
 GOAL=$(subst ','\'',$(subst $(abspath $(JULIAHOME))/,,$(abspath $@)))
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -85,7 +85,7 @@ all: debug release
 release debug: %: libjulia-%
 
 $(BUILDDIR):
-	mkdir $(BUILDDIR)
+	mkdir -p $(BUILDDIR)
 
 LLVM_CONFIG_ABSOLUTE := $(shell which $(LLVM_CONFIG))
 

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -48,7 +48,7 @@ release: $(BUILDDIR)/$(EXENAME)
 debug: $(BUILDDIR)/$(EXENAME)-debug
 
 $(BUILDDIR):
-	mkdir $(BUILDDIR)
+	mkdir -p $(BUILDDIR)
 
 $(BUILDDIR)/%.o: %.c $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(SHIPFLAGS) $(DISABLE_ASSERTIONS) -c $< -o $@)

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -79,8 +79,8 @@ else
 CCLD := $(LD)
 endif
 
-$(BUILDDIR)/$(EXENAME)-debug: $(DOBJS) $(LIBFILES_debug) $(BUILDDIR)/$(LIBTARGET)-debug.a $(BUILDDIR)/flmain.dbg.obj
-	@$(call PRINT_LINK, $(CCLD) $(DEBUGFLAGS) $(DOBJS) $(BUILDDIR)/flmain.dbg.obj -o $@ $(BUILDDIR)/$(LIBTARGET).a $(LIBFILES_debug) $(LIBS) $(OSLIBS))
+$(BUILDDIR)/$(EXENAME)-debug: $(DOBJS) $(LIBFILES_debug) $(BUILDDIR)/$(LIBTARGET)-debug.a $(BUILDDIR)/flmain.dbg.obj | $(BUILDDIR)/flisp.boot
+	@$(call PRINT_LINK, $(CCLD) $(DEBUGFLAGS) $(DOBJS) $(BUILDDIR)/flmain.dbg.obj -o $@ $(BUILDDIR)/$(LIBTARGET)-debug.a $(LIBFILES_debug) $(LIBS) $(OSLIBS))
 
 $(BUILDDIR)/$(EXENAME): $(OBJS) $(LIBFILES_release) $(BUILDDIR)/$(LIBTARGET).a $(BUILDDIR)/flmain.o | $(BUILDDIR)/flisp.boot
 	@$(call PRINT_LINK, $(CCLD) $(SHIPFLAGS) $(OBJS) $(BUILDDIR)/flmain.o -o $@ $(BUILDDIR)/$(LIBTARGET).a $(LIBFILES_release) $(LIBS) $(OSLIBS))

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -68,7 +68,6 @@ $(LLT_debug): $(LLTDIR)/*.h $(LLTDIR)/*.c
 $(BUILDDIR)/$(LIBTARGET)-debug.a: $(DOBJS) | $(BUILDDIR)
 	rm -rf $@
 	@$(call PRINT_LINK, $(AR) -rcs $@ $(DOBJS))
-	ln -sf $@ $(LIBTARGET).a
 
 $(BUILDDIR)/$(LIBTARGET).a: $(OBJS) | $(BUILDDIR)
 	rm -rf $@

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -37,7 +37,7 @@ SHIPFLAGS += $(FLAGS)
 default: release
 
 $(BUILDDIR):
-	mkdir $(BUILDDIR)
+	mkdir -p $(BUILDDIR)
 
 $(BUILDDIR)/%.o: %.c $(HEADERS) | $(BUILDDIR)
 	@$(call PRINT_CC, $(CC) $(CPPFLAGS) $(CFLAGS) $(SHIPFLAGS) $(DISABLE_ASSERTIONS) -c $< -o $@)


### PR DESCRIPTION
A few things found while working on #13569, some intermediate iterations of that were trying to use out-of-tree builds but I wound up giving up due to issues with system suitesparse on OSX Travis.

I think we have the flisp debug and release builds more separated now so we don't need to make a symlink to `libflisp.a` from `libflisp-debug.a` any more. That line hasn't been touched since 2010: https://github.com/JuliaLang/julia/commit/8b369dfee6daa2f5f24deb1d95703c1fd02fd380
