### PR TITLE
Output disassembly labels via the streamer

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -134,7 +134,8 @@ public:
     void insertAddress(uint64_t addr);
     // void createSymbol(const char *name, uint64_t addr);
     void createSymbols();
-    const char *lookupSymbol(uint64_t addr);
+    const char *lookupSymbolName(uint64_t addr);
+    MCSymbol *lookupSymbol(uint64_t addr);
     void setIP(uint64_t addr);
     uint64_t getIP() const;
 };
@@ -175,12 +176,17 @@ void SymbolTable::createSymbols()
         isymb->second = symb;
     }
 }
-const char *SymbolTable::lookupSymbol(uint64_t addr)
+const char *SymbolTable::lookupSymbolName(uint64_t addr)
 {
     if (!Table.count(addr)) return NULL;
     MCSymbol *symb = Table[addr];
     TempName = symb->getName().str();
     return TempName.c_str();
+}
+MCSymbol *SymbolTable::lookupSymbol(uint64_t addr)
+{
+    if (!Table.count(addr)) return NULL;
+    return Table[addr];
 }
 
 const char *SymbolLookup(void *DisInfo,
@@ -193,7 +199,7 @@ const char *SymbolLookup(void *DisInfo,
     if (SymTab->getPass() != 0) {
         if (*ReferenceType == LLVMDisassembler_ReferenceType_In_Branch) {
             uint64_t addr = ReferenceValue + SymTab->getIP();
-            const char *symbolName = SymTab->lookupSymbol(addr);
+            const char *symbolName = SymTab->lookupSymbolName(addr);
             *ReferenceType = LLVMDisassembler_ReferenceType_InOut_None;
             *ReferenceName = NULL;
             return symbolName;
@@ -272,7 +278,7 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
                           const object::ObjectFile *objectfile,
 #endif
 #ifdef LLVM37
-                          raw_ostream &stream
+                          raw_ostream &rstream
 #else
                           formatted_raw_ostream &stream
 #endif
@@ -388,7 +394,11 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
     }
 
 #ifdef LLVM37
-    auto ustream = llvm::make_unique<formatted_raw_ostream>(stream);
+    // createAsmStreamer expects a unique_ptr to a formatted stream, which means
+    // it will destruct the stream when it is done. We cannot have this, so we
+    // start out with a raw stream, and create formatted stream from it here.
+    // LLVM will desctruct the formatted stream, and we keep the raw stream.
+    auto ustream = llvm::make_unique<formatted_raw_ostream>(rstream);
     Streamer.reset(TheTarget->createAsmStreamer(Ctx, std::move(ustream), /*asmverbose*/true,
 #else
     Streamer.reset(TheTarget->createAsmStreamer(Ctx, stream, /*asmverbose*/true,
@@ -468,7 +478,11 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
         if (lineIter != lineEnd) {
             nextLineAddr = lineIter->first;
             if (pass != 0) {
-#ifdef LLVM35
+#ifdef LLVM37
+                std::ostringstream buf;
+                buf << "Filename: " << lineIter->second.FileName << "\n";
+                Streamer->EmitRawText(buf.str());
+#elif defined LLVM35
                 stream << "Filename: " << lineIter->second.FileName << "\n";
 #else
                 stream << "Filename: " << lineIter->second.getFileName() << "\n";
@@ -509,7 +523,13 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
 
             if (nextLineAddr != (uint64_t)-1 && Index + Fptr - slide == nextLineAddr) {
 #ifdef USE_MCJIT
-#ifdef LLVM35
+#ifdef LLVM37
+                if (pass != 0) {
+                    std::ostringstream buf;
+                    buf << "Source line: " << lineIter->second.Line << "\n";
+                    Streamer->EmitRawText(buf.str());
+                }
+#elif defined LLVM35
                 if (pass != 0)
                     stream << "Source line: " << lineIter->second.Line << "\n";
 #else
@@ -528,9 +548,16 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
             if (pass != 0) {
                 // Uncomment this to output addresses for all instructions
                 // stream << Index << ": ";
-                const char *symbolName = DisInfo.lookupSymbol(Fptr+Index);
+#ifdef LLVM37
+                MCSymbol *symbol = DisInfo.lookupSymbol(Fptr+Index);
+                if (symbol)
+                    Streamer->EmitLabel(symbol);
+                    // emitInstructionAnnot
+#else
+                const char *symbolName = DisInfo.lookupSymbolName(Fptr+Index);
                 if (symbolName)
                     stream << symbolName << ":";
+#endif
             }
 
             MCInst Inst;
@@ -551,15 +578,27 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
                                       /*REMOVE*/ nulls(), nulls());
             switch (S) {
             case MCDisassembler::Fail:
-                if (pass != 0)
+                if (pass != 0) {
 #if defined(_CPU_PPC_) || defined(_CPU_PPC64_) || defined(_CPU_ARM_)
-                    stream << "\t.long " << format_hex(*(uint32_t*)(Fptr+Index), 10) << "\n";
+#ifdef LLVM37
+                    std::ostringstream buf;
+                    buf << "\t.long " << format_hex(*(uint32_t*)(Fptr+Index), 10) << "\n";
+                    Streamer->EmitRawText(buf.str());
+#else
+                    streamer << "\t.long " << format_hex(*(uint32_t*)(Fptr+Index), 10) << "\n";
+#endif
 #elif defined(_CPU_X86_) || defined(_CPU_X86_64_)
                     SrcMgr.PrintMessage(SMLoc::getFromPointer((const char*)(Fptr + Index)),
                                         SourceMgr::DK_Warning,
                                         "invalid instruction encoding");
 #else
-                    stream << "\t.byte " << format_hex(*(uint8_t*)(Fptr+Index), 4) << "\n";
+#ifdef LLVM37
+                    std::ostringstream buf;
+                    buf << "\t.byte " << format_hex(*(uint8_t*)(Fptr+Index), 4) << "\n";
+                    Streamer->EmitRawText(buf.str());
+#else
+                    streamer << "\t.byte " << format_hex(*(uint8_t*)(Fptr+Index), 4) << "\n";
+#endif
 #endif
                 if (insSize == 0) // skip illegible bytes
 #if defined(_CPU_PPC_) || defined(_CPU_PPC64_) || defined(_CPU_ARM_)
@@ -567,17 +606,25 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
 #else
                     insSize = 1; // attempt to slide 1 byte forward
 #endif
+                }
                 break;
 
             case MCDisassembler::SoftFail:
-                if (pass != 0)
+                if (pass != 0) {
 #if !defined(_CPU_X86_) || !defined(_CPU_X86_64_)
+#ifdef LLVM37
+                    std::ostringstream buf;
+                    buf << "potentially undefined instruction encoding:\n";
+                    Streamer->EmitRawText(buf.str());
+#else
                     stream << "potentially undefined instruction encoding:\n";
+#endif
 #else
                     SrcMgr.PrintMessage(SMLoc::getFromPointer((const char*)(Fptr + Index)),
                                         SourceMgr::DK_Warning,
                                         "potentially undefined instruction encoding");
 #endif
+                }
                 // Fall through
 
             case MCDisassembler::Success:


### PR DESCRIPTION
This ensures they appear in the correct order.
Fixes #14184.
