### PR TITLE
GC safepoint and transition support

### DIFF
--- a/doc/devdocs/debuggingtips.rst
+++ b/doc/devdocs/debuggingtips.rst
@@ -24,7 +24,7 @@ Similarly, if you're debugging some of julia's internals (e.g.,
 
 This is a good way to circumvent problems that arise from the order in which julia's output streams are initialized.
 
-Julia's flisp interpreter uses ``value_t*`` objects; these can be displayed
+Julia's flisp interpreter uses ``value_t`` objects; these can be displayed
 with ``call fl_print(ios_stdout, obj)``.
 
 Useful Julia variables for Inspecting
@@ -74,7 +74,7 @@ Another useful frame is ``to_function(jl_lambda_info_t *li, bool cstyle)``. The 
 
    #2  0x00007ffff7928bf7 in to_function (li=0x2812060, cstyle=false) at codegen.cpp:584
    584	        abort();
-   (gdb) p jl_(jl_uncompress_ast(li, li.ast))
+   (gdb) p jl_(jl_uncompress_ast(li, li->ast))
 
 Inserting breakpoints upon certain conditions
 ---------------------------------------------
@@ -91,9 +91,30 @@ Calling a particular method
 
 ::
 
-   (gdb) break jl_apply_generic if strcmp(F->name->name, "method_to_break")==0
+   (gdb) break jl_apply_generic if strcmp((char*)(jl_symbol_name)(jl_gf_mtable(F)->name), "method_to_break")==0
 
 Since this function is used for every call, you will make everything 1000x slower if you do this.
+
+Dealing with signals
+--------------------
+
+Julia requires a few signal to function property. The profiler uses ``SIGUSR2``
+for sampling and the garbage collector uses ``SIGSEGV`` for threads
+synchronization. If you are debugging some code that uses the profiler or
+multiple julia threads, you may want to let the debugger ignore these signals
+since they can be triggered very often during normal operations. The command to
+do this in GDB is (replace ``SIGSEGV`` with ``SIGUSRS`` or other signals you
+want to ignore)::
+
+   (gdb) handle SIGSEGV noprint nostop pass
+
+The corresponding LLDB command is (after the process is started)::
+
+   (lldb) pro hand -p true -s false -n false SIGSEGV
+
+If you are debugging a segfault with threaded code, you can set a breakpoint on
+``jl_critical_error`` (``sigdie_handler`` should also work on Linux and BSD) in
+order to only catch the actual segfault rather than the GC synchronization points.
 
 Debugging during julia's build process (bootstrap)
 --------------------------------------------------

--- a/src/ast.c
+++ b/src/ast.c
@@ -201,7 +201,7 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_lambda_info_t *lam);
 
 static jl_value_t *scm_to_julia(value_t e, int expronly)
 {
-    int en = jl_gc_enable(0);
+    int en = jl_gc_enable(0); // Might GC
     jl_value_t *v;
     JL_TRY {
         v = scm_to_julia_(e, expronly);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -194,6 +194,9 @@ JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
     JL_SIGATOMIC_BEGIN();
     eh->prev = jl_current_task->eh;
     eh->gcstack = jl_pgcstack;
+#ifdef JULIA_ENABLE_THREADING
+    eh->gc_state = jl_get_ptls_states()->gc_state;
+#endif
     jl_current_task->eh = eh;
     // TODO: this should really go after setjmp(). see comment in
     // ctx_switch in task.c.

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -477,6 +477,8 @@ JL_DLLEXPORT void ORCNotifyObjectEmitted(JITEventListener *Listener,
 extern "C"
 char *jl_demangle(const char *name)
 {
+    // This function is not allowed to reference any TLS variables since
+    // it can be called from an unmanaged thread on OSX.
     const char *start = name + 6;
     const char *end = name + strlen(name);
     char *ret;
@@ -508,6 +510,8 @@ void lookup_pointer(DIContext *context, char **name, size_t *line,
                     char **inlinedat_file, size_t pointer,
                     int demangle, int *fromC)
 {
+    // This function is not allowed to reference any TLS variables since
+    // it can be called from an unmanaged thread on OSX.
     DILineInfo info, topinfo;
     DIInliningInfo inlineinfo;
     if (demangle && *name != NULL) {
@@ -629,6 +633,8 @@ void jl_getDylibFunctionInfo(char **name, char **filename, size_t *line,
                              char** inlinedat_file, size_t *inlinedat_line,
                              size_t pointer, int *fromC, int skipC, int skipInline)
 {
+    // This function is not allowed to reference any TLS variables since
+    // it can be called from an unmanaged thread on OSX.
 #ifdef _OS_WINDOWS_
     IMAGEHLP_MODULE64 ModuleInfo;
     BOOL isvalid;
@@ -838,6 +844,8 @@ void jl_getFunctionInfo(char **name, char **filename, size_t *line,
                         char **inlinedat_file, size_t *inlinedat_line,
                         size_t pointer, int *fromC, int skipC, int skipInline)
 {
+    // This function is not allowed to reference any TLS variables since
+    // it can be called from an unmanaged thread on OSX.
     *name = NULL;
     *line = -1;
     *filename = NULL;

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -194,7 +194,9 @@ public:
     virtual void NotifyFunctionEmitted(const Function &F, void *Code,
                                        size_t Size, const EmittedFunctionDetails &Details)
     {
+        int8_t gc_state = jl_gc_safe_enter();
         uv_rwlock_wrlock(&threadsafe);
+        jl_gc_safe_leave(gc_state);
 #if defined(_OS_WINDOWS_)
         create_PRUNTIME_FUNCTION((uint8_t*)Code, Size, F.getName(), (uint8_t*)Code, Size, NULL);
 #endif
@@ -205,7 +207,9 @@ public:
 
     std::map<size_t, FuncInfo, revcomp>& getMap()
     {
+        int8_t gc_state = jl_gc_safe_enter();
         uv_rwlock_rdlock(&threadsafe);
+        jl_gc_safe_leave(gc_state);
         return info;
     }
 #endif // ifndef USE_MCJIT
@@ -225,7 +229,9 @@ public:
     virtual void NotifyObjectEmitted(const ObjectImage &obj)
 #endif
     {
+        int8_t gc_state = jl_gc_safe_enter();
         uv_rwlock_wrlock(&threadsafe);
+        jl_gc_safe_leave(gc_state);
 #ifdef LLVM36
         object::section_iterator Section = obj.section_begin();
         object::section_iterator EndSection = obj.section_end();
@@ -458,7 +464,9 @@ public:
 
     std::map<size_t, ObjectInfo, revcomp>& getObjectMap()
     {
+        int8_t gc_state = jl_gc_safe_enter();
         uv_rwlock_rdlock(&threadsafe);
+        jl_gc_safe_leave(gc_state);
         return objectmap;
     }
 #endif // USE_MCJIT

--- a/src/dump.c
+++ b/src/dump.c
@@ -1974,7 +1974,7 @@ JL_DLLEXPORT jl_value_t *jl_ast_rettype(jl_lambda_info_t *li, jl_value_t *ast)
     ios_mem(&src, 0);
     ios_setbuf(&src, (char*)bytes->data, jl_array_len(bytes), 0);
     src.size = jl_array_len(bytes);
-    int en = jl_gc_enable(0);
+    int en = jl_gc_enable(0); // Might GC
     jl_value_t *rt = jl_deserialize_value(&src, NULL);
     jl_gc_enable(en);
     tree_literal_values = NULL;
@@ -1994,7 +1994,7 @@ JL_DLLEXPORT jl_value_t *jl_compress_ast(jl_lambda_info_t *li, jl_value_t *ast)
     ios_mem(&dest, 0);
     jl_array_t *last_tlv = tree_literal_values;
     jl_module_t *last_tem = tree_enclosing_module;
-    int en = jl_gc_enable(0);
+    int en = jl_gc_enable(0); // Might GC
 
     if (li->module->constant_table == NULL) {
         li->module->constant_table = jl_alloc_cell_1d(0);
@@ -2038,7 +2038,7 @@ JL_DLLEXPORT jl_value_t *jl_uncompress_ast(jl_lambda_info_t *li, jl_value_t *dat
     ios_mem(&src, 0);
     ios_setbuf(&src, (char*)bytes->data, jl_array_len(bytes), 0);
     src.size = jl_array_len(bytes);
-    int en = jl_gc_enable(0);
+    int en = jl_gc_enable(0); // Might GC
     (void)jl_deserialize_value(&src, NULL); // skip ret type
     jl_value_t *v = jl_deserialize_value(&src, NULL);
     jl_gc_enable(en);

--- a/src/gc.c
+++ b/src/gc.c
@@ -2144,15 +2144,29 @@ static void post_mark(arraylist_t *list, int dryrun)
 }
 
 // collector entry point and control
+static volatile uint64_t jl_gc_disable_counter = 0;
 
-static int is_gc_enabled = 1;
 JL_DLLEXPORT int jl_gc_enable(int on)
 {
-    int prev = is_gc_enabled;
-    is_gc_enabled = (on!=0);
+    jl_tls_states_t *ptls = jl_get_ptls_states();
+    int prev = !ptls->disable_gc;
+    ptls->disable_gc = (on == 0);
+    if (on && !prev) {
+        // disable -> enable
+        JL_ATOMIC_FETCH_AND_ADD(jl_gc_disable_counter, -1);
+    }
+    else if (prev && !on) {
+        // enable -> disable
+        JL_ATOMIC_FETCH_AND_ADD(jl_gc_disable_counter, 1);
+        // check if the GC is running and wait for it to finish
+        jl_gc_safepoint();
+    }
     return prev;
 }
-JL_DLLEXPORT int jl_gc_is_enabled(void) { return is_gc_enabled; }
+JL_DLLEXPORT int jl_gc_is_enabled(void)
+{
+    return !jl_get_ptls_states()->disable_gc;
+}
 
 JL_DLLEXPORT int64_t jl_gc_total_bytes(void) { return total_allocd_bytes + allocd_bytes + collect_interval; }
 JL_DLLEXPORT uint64_t jl_gc_total_hrtime(void) { return total_gc_time; }
@@ -2455,7 +2469,7 @@ static void _jl_gc_collect(int full, char *stack_hi)
 
 JL_DLLEXPORT void jl_gc_collect(int full)
 {
-    if (!is_gc_enabled || jl_in_gc)
+    if (jl_gc_disable_counter || jl_in_gc)
         return;
     char *stack_hi = (char*)gc_get_stack_ptr();
     gc_debug_print();
@@ -2482,7 +2496,8 @@ JL_DLLEXPORT void jl_gc_collect(int full)
     jl_gc_signal_begin();
 
     jl_in_gc = 1;
-    _jl_gc_collect(full, stack_hi);
+    if (!jl_gc_disable_counter)
+        _jl_gc_collect(full, stack_hi);
     jl_in_gc = 0;
 
     // Need to reset the page protection before resetting the flag since

--- a/src/gc.c
+++ b/src/gc.c
@@ -412,6 +412,11 @@ void jl_gc_signal_init(void)
 
 static void jl_gc_signal_begin(void)
 {
+#ifdef __APPLE__
+    // This needs to be after setting `jl_gc_running` so that only one thread
+    // can talk to the signal handler
+    jl_mach_gc_begin();
+#endif
 #ifdef _OS_WINDOWS_
     DWORD old_prot;
     VirtualProtect((void*)jl_gc_signal_page, jl_page_size,
@@ -432,6 +437,9 @@ static void jl_gc_signal_end(void)
                    PAGE_READONLY, &old_prot);
 #else
     mprotect((void*)jl_gc_signal_page, jl_page_size, PROT_READ);
+#endif
+#ifdef __APPLE__
+    jl_mach_gc_end();
 #endif
 }
 #else

--- a/src/gf.c
+++ b/src/gf.c
@@ -424,7 +424,7 @@ jl_function_t *jl_method_cache_insert(jl_methtable_t *mt, jl_tupletype_t *type,
 int jl_in_inference = 0;
 void jl_type_infer(jl_lambda_info_t *li, jl_tupletype_t *argtypes, jl_lambda_info_t *def)
 {
-    JL_LOCK(codegen);
+    JL_LOCK(codegen); // Might GC
     int last_ii = jl_in_inference;
     jl_in_inference = 1;
     if (jl_typeinf_func != NULL) {
@@ -490,7 +490,7 @@ static jl_function_t *cache_method(jl_methtable_t *mt, jl_tupletype_t *type,
                                    jl_function_t *method, jl_tupletype_t *decl,
                                    jl_svec_t *sparams, int8_t isstaged)
 {
-    JL_LOCK(codegen);
+    JL_LOCK(codegen); // Might GC
     size_t i;
     int need_guard_entries = 0;
     jl_value_t *temp=NULL;

--- a/src/init.c
+++ b/src/init.c
@@ -677,6 +677,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
             jl_current_module;
     }
 
+    // This needs to be after jl_start_threads
     if (jl_options.handle_signals == JL_OPTIONS_HANDLE_SIGNALS_ON)
         jl_install_default_signal_handlers();
 

--- a/src/init.c
+++ b/src/init.c
@@ -528,6 +528,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 #ifdef JULIA_ENABLE_THREADING
     // Make sure we finalize the tls callback before starting any threads.
     jl_get_ptls_states_getter();
+    jl_gc_signal_init();
 #endif
     libsupport_init();
     jl_io_loop = uv_default_loop(); // this loop will internal events (spawning process etc.),

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -318,6 +318,26 @@ JL_DLLEXPORT jl_value_t *(jl_typeof)(jl_value_t *v)
     return jl_typeof(v);
 }
 
+JL_DLLEXPORT int8_t (jl_gc_unsafe_enter)(void)
+{
+    return jl_gc_unsafe_enter();
+}
+
+JL_DLLEXPORT void (jl_gc_unsafe_leave)(int8_t state)
+{
+    jl_gc_unsafe_leave(state);
+}
+
+JL_DLLEXPORT int8_t (jl_gc_safe_enter)(void)
+{
+    return jl_gc_safe_enter();
+}
+
+JL_DLLEXPORT void (jl_gc_safe_leave)(int8_t state)
+{
+    jl_gc_safe_leave(state);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1920,7 +1920,7 @@ static ssize_t lookup_type_idx(jl_typename_t *tn, jl_value_t **key, size_t n, in
 static jl_value_t *lookup_type(jl_typename_t *tn, jl_value_t **key, size_t n)
 {
     int ord = is_typekey_ordered(key, n);
-    JL_LOCK(typecache);
+    JL_LOCK(typecache); // Might GC
     ssize_t idx = lookup_type_idx(tn, key, n, ord);
     jl_value_t *t = (idx < 0) ? NULL : jl_svecref(ord ? tn->cache : tn->linearcache, idx);
     JL_UNLOCK(typecache);
@@ -2003,7 +2003,7 @@ jl_value_t *jl_cache_type_(jl_datatype_t *type)
 {
     if (is_cacheable(type)) {
         int ord = is_typekey_ordered(jl_svec_data(type->parameters), jl_svec_len(type->parameters));
-        JL_LOCK(typecache);
+        JL_LOCK(typecache); // Might GC
         ssize_t idx = lookup_type_idx(type->name, jl_svec_data(type->parameters),
                                       jl_svec_len(type->parameters), ord);
         if (idx >= 0)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1414,6 +1414,7 @@ typedef struct _jl_handler_t {
     jl_jmp_buf eh_ctx;
     jl_gcframe_t *gcstack;
     struct _jl_handler_t *prev;
+    int8_t gc_state;
 } jl_handler_t;
 
 typedef struct _jl_task_t {
@@ -1535,6 +1536,7 @@ STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
     JL_SIGATOMIC_BEGIN();
     jl_current_task->eh = eh->prev;
     jl_pgcstack = eh->gcstack;
+    jl_gc_state_save_and_set(eh->gc_state);
     JL_SIGATOMIC_END();
 }
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1459,6 +1459,7 @@ typedef struct _jl_tls_states_t {
     //              execute at the same time with the GC.
     volatile int8_t gc_state;
     volatile int8_t in_gc;
+    int8_t disable_gc;
     struct _jl_thread_heap_t *heap;
     jl_task_t *volatile current_task;
     jl_task_t *root_task;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1458,7 +1458,7 @@ typedef struct _jl_tls_states_t {
     // gc_state = 2 means the thread is running unmanaged code that can be
     //              execute at the same time with the GC.
     volatile int8_t gc_state;
-    volatile int8_t in_gc;
+    volatile int8_t in_finalizer;
     int8_t disable_gc;
     struct _jl_thread_heap_t *heap;
     jl_task_t *volatile current_task;

--- a/src/julia.h
+++ b/src/julia.h
@@ -67,6 +67,20 @@ extern "C" {
 // JULIA_ENABLE_THREADING is switched on in Make.inc if JULIA_THREADS is
 // set (in Make.user)
 
+#ifdef JULIA_ENABLE_THREADING
+JL_DLLEXPORT extern volatile size_t *jl_gc_signal_page;
+STATIC_INLINE void jl_gc_safepoint(void)
+{
+    // This triggers a SegFault when we are in GC
+    // Assign it to a variable to make sure the compiler emit the load
+    // and to avoid Clang warning for -Wunused-volatile-lvalue
+    size_t v = *jl_gc_signal_page;
+    (void)v;
+}
+#else // JULIA_ENABLE_THREADING
+#define jl_gc_safepoint()
+#endif // JULIA_ENABLE_THREADING
+
 JL_DLLEXPORT int16_t jl_threadid(void);
 JL_DLLEXPORT void *jl_threadgroup(void);
 JL_DLLEXPORT void jl_cpu_pause(void);
@@ -106,7 +120,7 @@ JL_DLLEXPORT void jl_threading_profile(void);
     extern uint64_t volatile m ## _mutex;                                 \
     extern int32_t m ## _lock_count;
 
-#define JL_LOCK(m) do {                                                 \
+#define JL_LOCK_WAIT(m, wait_ex) do {                                   \
         if (m ## _mutex == uv_thread_self()) {                          \
             ++m ## _lock_count;                                         \
         }                                                               \
@@ -118,6 +132,7 @@ JL_DLLEXPORT void jl_threading_profile(void);
                     m ## _lock_count = 1;                               \
                     break;                                              \
                 }                                                       \
+                wait_ex;                                                \
                 jl_cpu_pause();                                         \
             }                                                           \
         }                                                               \
@@ -134,10 +149,16 @@ JL_DLLEXPORT void jl_threading_profile(void);
 #else
 #define JL_DEFINE_MUTEX(m)
 #define JL_DEFINE_MUTEX_EXT(m)
-#define JL_LOCK(m) do {} while (0)
+#define JL_LOCK_WAIT(m, wait_ex) do {} while (0)
 #define JL_UNLOCK(m) do {} while (0)
 #endif
 
+// JL_LOCK is a GC safe point while JL_LOCK_NOGC is not
+// Always use JL_LOCK unless no one holding the lock can trigger a GC or GC
+// safepoint. JL_LOCK_NOGC should only be needed for GC internal locks.
+#define JL_LOCK(m) JL_LOCK_WAIT(m, jl_gc_safepoint())
+#define JL_LOCK_NOGC(m) JL_LOCK_WAIT(m, )
+#define JL_UNLOCK_NOGC(m) JL_UNLOCK(m)
 
 // core data types ------------------------------------------------------------
 
@@ -1428,6 +1449,15 @@ typedef struct _jl_task_t {
 typedef struct _jl_tls_states_t {
     jl_gcframe_t *pgcstack;
     jl_value_t *exception_in_transit;
+    // Whether it is safe to execute GC at the same time.
+#define JL_GC_STATE_WAITING 1
+    // gc_state = 1 means the thread is doing GC or is waiting for the GC to
+    //              finish.
+#define JL_GC_STATE_SAFE 2
+    // gc_state = 2 means the thread is running unmanaged code that can be
+    //              execute at the same time with the GC.
+    volatile int8_t gc_state;
+    volatile int8_t in_gc;
     struct _jl_thread_heap_t *heap;
     jl_task_t *volatile current_task;
     jl_task_t *root_task;
@@ -1464,10 +1494,41 @@ JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void);
 #ifndef JULIA_ENABLE_THREADING
 extern JL_DLLEXPORT jl_tls_states_t jl_tls_states;
 #define jl_get_ptls_states() (&jl_tls_states)
-#else
+STATIC_INLINE int8_t jl_gc_state_set(int8_t state, int8_t old_state)
+{
+    (void)state;
+    return old_state;
+}
+STATIC_INLINE int8_t jl_gc_state_save_and_set(int8_t state)
+{
+    (void)state;
+    return 0;
+}
+#define jl_gc_unsafe_enter() jl_gc_state_save_and_set(0)
+#define jl_gc_unsafe_leave(state) ((void)state)
+#define jl_gc_safe_enter() jl_gc_state_save_and_set(JL_GC_STATE_SAFE)
+#define jl_gc_safe_leave(state) ((void)state)
+#else // ifndef JULIA_ENABLE_THREADING
 typedef jl_tls_states_t *(*jl_get_ptls_states_func)(void);
 JL_DLLEXPORT void jl_set_ptls_states_getter(jl_get_ptls_states_func f);
-#endif
+STATIC_INLINE int8_t jl_gc_state_set(int8_t state, int8_t old_state)
+{
+    jl_get_ptls_states()->gc_state = state;
+    // A safe point is required if we transition from GC-safe region to
+    // non GC-safe region.
+    if (old_state && !state)
+        jl_gc_safepoint();
+    return old_state;
+}
+STATIC_INLINE int8_t jl_gc_state_save_and_set(int8_t state)
+{
+    return jl_gc_state_set(state, jl_get_ptls_states()->gc_state);
+}
+#define jl_gc_unsafe_enter() jl_gc_state_save_and_set(0)
+#define jl_gc_unsafe_leave(state) jl_gc_state_set((state), 0)
+#define jl_gc_safe_enter() jl_gc_state_save_and_set(JL_GC_STATE_SAFE)
+#define jl_gc_safe_leave(state) jl_gc_state_set((state), JL_GC_STATE_SAFE)
+#endif // ifndef JULIA_ENABLE_THREADING
 
 STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
 {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -285,9 +285,6 @@ JL_DLLEXPORT size_t rec_backtrace_ctx(ptrint_t *data, size_t maxsize, bt_context
 size_t rec_backtrace_ctx_dwarf(ptrint_t *data, size_t maxsize, bt_context_t ctx);
 #endif
 JL_DLLEXPORT void jl_raise_debugger(void);
-#ifdef _OS_DARWIN_
-JL_DLLEXPORT void attach_exception_port(void);
-#endif
 // Set *name and *filename to either NULL or malloc'd string
 void jl_getFunctionInfo(char **name, char **filename, size_t *line,
                         char **inlinedat_file, size_t *inlinedat_line,
@@ -438,6 +435,11 @@ int jl_array_store_unboxed(jl_value_t *el_type);
 int jl_array_isdefined(jl_value_t **args, int nargs);
 
 JL_DEFINE_MUTEX_EXT(codegen)
+
+#if defined(__APPLE__) && defined(JULIA_ENABLE_THREADING)
+void jl_mach_gc_begin(void);
+void jl_mach_gc_end(void);
+#endif
 
 #if defined(_OS_WINDOWS_)
 STATIC_INLINE void *jl_malloc_aligned(size_t sz, size_t align)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -21,6 +21,7 @@ extern unsigned sig_stack_size;
 
 JL_DLLEXPORT extern int jl_lineno;
 JL_DLLEXPORT extern const char *jl_filename;
+#define jl_in_gc (jl_get_ptls_states()->in_gc)
 
 STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
 {
@@ -246,6 +247,8 @@ void jl_start_threads(void);
 void jl_shutdown_threading(void);
 #ifdef JULIA_ENABLE_THREADING
 jl_get_ptls_states_func jl_get_ptls_states_getter(void);
+void jl_gc_signal_init(void);
+void jl_gc_signal_wait(void);
 #endif
 
 void jl_dump_bitcode(char *fname, const char *sysimg_data, size_t sysimg_len);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -21,7 +21,7 @@ extern unsigned sig_stack_size;
 
 JL_DLLEXPORT extern int jl_lineno;
 JL_DLLEXPORT extern const char *jl_filename;
-#define jl_in_gc (jl_get_ptls_states()->in_gc)
+#define jl_in_finalizer (jl_get_ptls_states()->in_finalizer)
 
 STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
 {

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -49,6 +49,9 @@ static void jl_critical_error(int sig, bt_context_t context, ptrint_t *bt_data, 
 // what to do on a critical error
 static void jl_critical_error(int sig, bt_context_t context, ptrint_t *bt_data, size_t *bt_size)
 {
+    // This function is not allowed to reference any TLS variables.
+    // We need to explicitly pass in the TLS buffer pointer when
+    // we make `jl_filename` and `jl_lineno` thread local.
     size_t n = *bt_size;
     if (sig)
         jl_safe_printf("\nsignal (%d): %s\n", sig, strsignal(sig));

--- a/src/task.c
+++ b/src/task.c
@@ -367,7 +367,7 @@ JL_DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg)
             jl_throw(t->exception);
         return t->result;
     }
-    if (jl_in_gc)
+    if (jl_in_finalizer)
         jl_error("task switch not allowed from inside gc finalizer");
     int8_t gc_state = jl_gc_unsafe_enter();
     jl_task_arg_in_transit = arg;

--- a/src/task.c
+++ b/src/task.c
@@ -355,7 +355,6 @@ static void ctx_switch(jl_task_t *t, jl_jmp_buf *where)
     //JL_SIGATOMIC_END();
 }
 
-extern int jl_in_gc;
 JL_DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg)
 {
     if (t == jl_current_task) {
@@ -884,8 +883,8 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize)
     stk += pagesz;
 
     init_task(t, stk);
-    JL_GC_POP();
     jl_gc_add_finalizer((jl_value_t*)t, jl_unprotect_stack_func);
+    JL_GC_POP();
 #endif
 
     return t;

--- a/src/task.c
+++ b/src/task.c
@@ -480,6 +480,8 @@ static int frame_info_from_ip(char **func_name,
                               char **inlinedat_file, size_t *inlinedat_line,
                               size_t ip, int skipC, int skipInline)
 {
+    // This function is not allowed to reference any TLS variables since
+    // it can be called from an unmanaged thread on OSX.
     static const char *name_unknown = "???";
     int fromC = 0;
 
@@ -757,6 +759,8 @@ JL_DLLEXPORT jl_value_t *jl_get_backtrace(void)
 //for looking up functions from gdb:
 JL_DLLEXPORT void gdblookup(ptrint_t ip)
 {
+    // This function is not allowed to reference any TLS variables since
+    // it can be called from an unmanaged thread on OSX.
     char *func_name;
     size_t line_num;
     char *file_name;

--- a/src/threadgroup.h
+++ b/src/threadgroup.h
@@ -49,4 +49,3 @@ int  ti_threadgroup_destroy(ti_threadgroup_t *tg);
 extern ti_threadgroup_t *tgworld;
 
 #endif  /* THREADGROUP_H */
-

--- a/src/threading.c
+++ b/src/threading.c
@@ -134,6 +134,8 @@ JL_DLLEXPORT int jl_n_threads;     // # threads we're actually using
 jl_thread_task_state_t *jl_all_task_states;
 
 // return calling thread's ID
+// Also update the suspended_threads list in signals-mach when changing the
+// type of the thread id.
 JL_DLLEXPORT int16_t jl_threadid(void) { return ti_tid; }
 
 struct _jl_thread_heap_t *jl_mk_thread_heap(void);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -25,9 +25,9 @@ extern "C" {
 #endif
 
 // current line number in a file
-JL_DLLEXPORT int jl_lineno = 0;
+JL_DLLEXPORT int jl_lineno = 0; // need to update jl_critical_error if this is TLS
 // current file name
-JL_DLLEXPORT const char *jl_filename = "no file";
+JL_DLLEXPORT const char *jl_filename = "no file"; // need to update jl_critical_error if this is TLS
 
 jl_module_t *jl_old_base_module = NULL;
 // the Main we started with, in case it is switched


### PR DESCRIPTION
This is a work in progress to make our GC a stop the world GC rather than a wait for the world (and maybe dead lock?) GC _(ok that probably doesn't sound too exciting...)_. ~~The first two commits are #14181 which I made as a general improvement to our finalizers handling while trying to figure out how to synchronize finalizers and the GC with threading for this PR.~~ (merged)

This is still missing the very important GC transition and safepoint support in codegen but I'm opening this as RFC now to make sure that the GC synchronization schematics I'm following makes sense.

I described the schmatics in [the comment in `gc.c`](https://github.com/JuliaLang/julia/commit/a08e6ba38321c46349b34da207c183096aee0240#diff-31b93f4272eaeede3738531e90317e0cR41). To summarize, we need GC safe point and GC transitions so that the GC doesn't have to wait for other threads forever (especially if the thread doing the GC is holding a lock). The safepoint is implemented using a volatile load from a special page which we `mprotect` to `PROT_NONE` during a GC and catch the SegFault in the signal handler. (This is similar to how the Java HotSpot GC does it.) The GC also makes sure (with a combination of lock and safe point) that no other thread can run the GC at the same time or modifying GC related data structures when the GC is running.
#### TODO/request for help:
- The segfault handler for OSX is missing. It seems that I can't just wait in the signal handler since it's running on a different thread processing the messages from the kernel in series and it is necessary to do some low level stuff to make sure the thread can return to it's previous state after waiting for the GC to finish. Doing this on a platform that I can't test locally is beyond what I can confidently do so I need help from someone who's more familiar with this to implement it.
- Codegen support:
  
  I'm currently planning to emit a GC transition around each critical region (store to object or stack) and allow the GC to run everywhere else. We can do a optimization pass to merge unnecessary GC transitions after the whole function is generated. I'm still deciding what I can assume about GC awareness for a function call and what's the convension of changing the GC state in a function. Note that this shouldn't require the LLVM statepoint support so it should work on LLVM 3.3 as well.

c.c. @vtjnash @kpamnany @carnaval @Keno 

Close https://github.com/JuliaLang/julia/issues/13380
Close https://github.com/JuliaLang/julia/issues/14343
Close https://github.com/JuliaLang/julia/issues/10317
##### TODO for this PR:
- [x] SegFault handler for OSX
- [x] Rename `managed` / `unmanaged` to `unsafe` / `safe`
- [x] Run finalizers after the GC is finished and allowing GC to run in finalizers ~~(_Still need to update the comment in `gc.c`_)~~ done.
- [x] ~~Easier way to breakpoint on actual segfault~~ (`jl_critical_error` should be good enough)
##### TODO that can be done in future PRs:
- [ ] Make sure the runtime satisfies the GC state transition requirements
- [ ] Insert safepoints and state transitions in codegen
- [ ] Optimization pass on state transitions
- [ ] Fix GC debugging code (stack grub) (~~requires https://github.com/JuliaLang/julia/pull/14473~~ merged)
