### PR TITLE
Make precompile output consistent

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -544,7 +544,7 @@ function recompile_stale(mod, cachefile)
         error("module $mod not found in current path; removed orphaned cache file $cachefile")
     end
     if stale_cachefile(path, cachefile)
-        info("Recompiling stale cache file $cachefile for module $mod.")
+        isinteractive() && info("Recompiling stale cache file $cachefile for module $mod.")
         if !success(create_expr_cache(path, cachefile))
             error("Failed to precompile $mod to $cachefile")
         end


### PR DESCRIPTION
This just brings the info output inline with [this line](https://github.com/JuliaLang/julia/blob/1f392db7eed47e3161f6b4856dbcb9504cd9cf3b/base/loading.jl#L338) above it.
