### PR TITLE
Fix #13823, add logabsdet for complex matrices

### DIFF
--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -164,11 +164,11 @@ function det{T,S}(A::LU{T,S})
     return P * s
 end
 
-function logabsdet{T<:Real,S}(A::LU{T,S})  # return log(abs(det)) and sign(det)
+function logabsdet{T,S}(A::LU{T,S})  # return log(abs(det)) and sign(det)
     n = chksquare(A)
     c = 0
-    P = one(T)
-    abs_det = zero(T)
+    P = one(real(T))
+    abs_det = zero(real(T))
     @inbounds for i = 1:n
         dg_ii = A.factors[i,i]
         P *= sign(dg_ii)
@@ -177,7 +177,7 @@ function logabsdet{T<:Real,S}(A::LU{T,S})  # return log(abs(det)) and sign(det)
         end
         abs_det += log(abs(dg_ii))
     end
-    s = (isodd(c) ? -one(T) : one(T)) * P
+    s = (isodd(c) ? -one(real(T)) : one(real(T))) * P
     abs_det, s
 end
 

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -22,11 +22,13 @@ for elty in (Int, Rational{BigInt}, Float32, Float64, BigFloat, Complex{Float32}
     debug && println("element type: $elty")
 
     @test_approx_eq logdet(A) log(det(A))
+    @test_approx_eq logabsdet(A)[1] log(abs(det(A)))
+    @test logabsdet(convert(Matrix{elty}, -eye(n)))[2] == -1
     if elty <: Real
-        @test_approx_eq logabsdet(A)[1] log(abs(det(A)))
-        @test logabsdet(A)[2] == sign(abs(det(A)))
+        @test logabsdet(A)[2] == sign(det(A))
         @test_throws DomainError logdet(convert(Matrix{elty}, -eye(n)))
-        @test logabsdet(convert(Matrix{elty}, -eye(n)))[2] == -1
+    else
+        @test logabsdet(A)[2] ≈ sign(det(A))
     end
 end
 


### PR DESCRIPTION
Following the discussion over at JuliaLang/LinearAlgebra.jl#277, I added `logabsdet` for `Complex` types. I changed the test a little bit to make sure the `sign`s will match (they are only ever not exactly the same for the complex matrices).
