### PR TITLE
initialize temp_dir to empty in Pkg.init

### DIFF
--- a/base/pkg/dir.jl
+++ b/base/pkg/dir.jl
@@ -40,7 +40,7 @@ function init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRA
         LibGit2.set_remote_url(metadata_dir, meta)
         return
     end
-    local temp_dir
+    local temp_dir = ""
     try
         mkpath(dir)
         temp_dir = mktempdir(dir)


### PR DESCRIPTION
fixes `UndefVarError: temp_dir not defined` if the initial call to `mkpath` fails
