### PR TITLE
Adjust to LLVM 3.8 API changes

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1414,8 +1414,13 @@ static Value *emit_ccall(jl_value_t **args, size_t nargs, jl_codectx_t *ctx)
     if (needStackRestore) {
         stacksave = CallInst::Create(Intrinsic::getDeclaration(jl_Module,
                                                                Intrinsic::stacksave));
-        if (savespot)
-            instList.insertAfter((Instruction*)savespot, (Instruction*)stacksave);
+        if (savespot) {
+#ifdef LLVM38
+                instList.insertAfter(savespot->getIterator(), (Instruction*)stacksave);
+#else
+                instList.insertAfter((Instruction*)savespot, (Instruction*)stacksave);
+#endif
+        }
         else
             instList.push_front((Instruction*)stacksave);
     }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -190,7 +190,7 @@ public:
         Function::arg_iterator DestI = NewF->arg_begin();
         for (Function::const_arg_iterator I = F->arg_begin(), E = F->arg_end(); I != E; ++I) {
             DestI->setName(I->getName());    // Copy the name over...
-            VMap[I] = DestI++;        // Add mapping to VMap
+            VMap[&*I] = &*(DestI++);        // Add mapping to VMap
         }
 
     #ifdef LLVM36
@@ -1205,7 +1205,7 @@ static Value *emit_bounds_check(Value *a, jl_value_t *ty, Value *i, Value *len, 
 // --- loading and storing ---
 
 static AllocaInst *emit_static_alloca(Type *lty, jl_codectx_t *ctx) {
-    return new AllocaInst(lty, "", /*InsertBefore=*/ctx->gc.gcframe);
+    return new AllocaInst(lty, "", /*InsertBefore=*/&*ctx->gc.gcframe);
 }
 
 static Value *emit_reg2mem(Value *v, jl_codectx_t *ctx) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1008,7 +1008,7 @@ Function* CloneFunctionToModule(Function *F, Module *destModule)
     Function::arg_iterator DestI = NewF->arg_begin();
     for (Function::const_arg_iterator I = F->arg_begin(), E = F->arg_end(); I != E; ++I) {
         DestI->setName(I->getName());    // Copy the name over...
-        VMap[I] = DestI++;        // Add mapping to VMap
+        VMap[&*I] = &*DestI++;        // Add mapping to VMap
     }
 
     SmallVector<ReturnInst*, 8> Returns;
@@ -1043,7 +1043,7 @@ const jl_value_t *jl_dump_function_ir(void *f, bool strip_ir_metadata, bool dump
                 BasicBlock::InstListType::iterator f2_il = (*f2_bb).getInstList().begin();
                 // iterate over instructions in basic block
                 for (; f2_il != (*f2_bb).getInstList().end(); ) {
-                    Instruction *inst = f2_il++;
+                    Instruction *inst = &*f2_il++;
                     // remove dbg.declare and dbg.value calls
                     if (isa<DbgDeclareInst>(inst) || isa<DbgValueInst>(inst)) {
                         inst->eraseFromParent();
@@ -3071,7 +3071,7 @@ static void emit_assignment(jl_value_t *l, jl_value_t *r, jl_codectx_t *ctx)
                 !is_stable_expr(r, ctx)) {
             Instruction *newroot = cast<Instruction>(emit_local_slot(ctx->gc.argSpaceSize++, ctx));
             newroot->removeFromParent(); // move it to the gc frame basic block so it can be reused as needed
-            newroot->insertAfter(ctx->gc.last_gcframe_inst);
+            newroot->insertAfter(&*ctx->gc.last_gcframe_inst);
             vi.memvalue = bp = newroot;
             vi.hasGCRoot = true; // this has been discovered to need a gc root, add it now
             //TODO: move this logic after the emit_expr
@@ -3554,7 +3554,7 @@ static void finalize_gc_frame(jl_codectx_t *ctx)
     }
     BasicBlock::iterator bbi(gc->gcframe);
     AllocaInst *newgcframe = gc->gcframe;
-    builder.SetInsertPoint(++gc->last_gcframe_inst); // set insert *before* point, e.g. after the gcframe
+    builder.SetInsertPoint(&*++gc->last_gcframe_inst); // set insert *before* point, e.g. after the gcframe
     // Allocate the real GC frame
     // n_frames++;
     newgcframe->setOperand(0, ConstantInt::get(T_int32, 2 + gc->argSpaceSize + gc->maxDepth)); // fix up the size of the gc frame
@@ -3692,7 +3692,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     Function::arg_iterator AI = cw->arg_begin();
     Value *sretPtr = NULL;
     if (sret)
-        sretPtr = AI++;
+        sretPtr = &*AI++;
 
     Value *result;
     size_t FParamIndex = 0;
@@ -3706,7 +3706,7 @@ static Function *gen_cfun_wrapper(jl_function_t *ff, jl_value_t *jlrettype, jl_t
     }
 
     for (size_t i = 0; i < nargs; i++) {
-        Value *val = AI++;
+        Value *val = &*AI++;
         jl_value_t *jargty = jl_nth_slot_type(lam->specTypes, i);
 
         // figure out how to unpack this type
@@ -3878,7 +3878,7 @@ static Function *gen_jlcall_wrapper(jl_lambda_info_t *lam, jl_expr_t *ast, Funct
     addComdat(w);
     Function::arg_iterator AI = w->arg_begin();
     /* const Argument &fArg = */ *AI++;
-    Value *argArray = AI++;
+    Value *argArray = &*AI++;
     /* const Argument &argCount = *AI++; */
     BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", w);
 
@@ -4271,9 +4271,16 @@ static Function *emit_function(jl_lambda_info_t *lam)
                                     0,            // ScopeLine
                                     0,            // Flags
                                     true,         // isOptimized
-                                    f);           // Fn
+        #ifdef LLVM38
+                                    nullptr);       // Template Parameters
+        #else
+                                    f);             // Function
+        #endif
         // set initial line number
         builder.SetCurrentDebugLocation(DebugLoc::get(lno, 0, (MDNode*)SP, NULL));
+        #ifdef LLVM38
+        f->setSubprogram(SP);
+        #endif
         #ifndef LLVM37
         assert(SP.Verify() && SP.describes(f) && SP.getFunction() == f);
         #endif
@@ -4387,9 +4394,9 @@ static Function *emit_function(jl_lambda_info_t *lam)
     unsigned argIdx = 0;
     if (!specsig) {
         Function::arg_iterator AI = f->arg_begin();
-        fArg = AI++;
-        argArray = AI++;
-        argCount = AI++;
+        fArg = &*AI++;
+        argArray = &*AI++;
+        argCount = &*AI++;
         ctx.argArray = argArray;
         ctx.argCount = argCount;
 
@@ -4566,7 +4573,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
         if (specsig) {
             argType = jl_nth_slot_type(lam->specTypes,i);
             if (!vi.isGhost) {
-                argPtr = AI++;
+                argPtr = &*AI++;
                 argPtr = mark_julia_type(argPtr, argType);
             }
         }
@@ -4797,7 +4804,7 @@ static Function *emit_function(jl_lambda_info_t *lam)
                 mallocVisitLine(filename, lno);
 
             if (ctx.sret)
-                builder.CreateStore(retval, ctx.f->arg_begin());
+                builder.CreateStore(retval, &*ctx.f->arg_begin());
             if (type_is_ghost(retty) || ctx.sret)
                 builder.CreateRetVoid();
             else


### PR DESCRIPTION
This backports commit 4e6d502 to allow compiling Julia 0.4.2 (#14186) with LLVM 3.8.
