### PR TITLE
Add an openblas patch to fix #14174, windows openblas segfault

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1127,6 +1127,7 @@ OPENBLAS_BUILD_OPTS += NO_AVX2=1
 endif
 
 $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/config.status: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/Makefile
+	cd $(dir $@) && patch -p1 < $(SRCDIR)/openblas-win64.patch
 	perl -i -ple 's/^\s*(EXTRALIB\s*\+=\s*-lSystemStubs)\s*$$/# $$1/g' $<.system
 	touch $@
 $(OPENBLAS_OBJ_SOURCE): $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/config.status

--- a/deps/openblas-win64.patch
+++ b/deps/openblas-win64.patch
@@ -1,0 +1,75 @@
+commit 640cccc2b159dba6d99b9eea11b7f23f98d6c85d
+Author: Zhang Xianyi <traits.zhang@gmail.com>
+Date:   Mon Nov 30 15:19:45 2015 -0600
+
+    Refs #697. Fixed gemv bug for Windows.
+    
+    Thank matzeri's patch.
+
+diff --git a/interface/gemv.c b/interface/gemv.c
+index 0a222a6..97c68bf 100644
+--- a/interface/gemv.c
++++ b/interface/gemv.c
+@@ -37,6 +37,7 @@
+ /*********************************************************************/
+ 
+ #include <stdio.h>
++#include <assert.h>
+ #include "common.h"
+ #include "l1param.h"
+ #ifdef FUNCTION_PROFILE
+@@ -224,13 +225,17 @@ void CNAME(enum CBLAS_ORDER order,
+ #ifdef ALIGNED_ACCESS
+   stack_alloc_size += 3;
+ #endif
+-  if(stack_alloc_size < 128)
++//  if(stack_alloc_size < 128)
+     //dgemv_n.S require a 128 bytes buffer
+-    stack_alloc_size = 128;
++// increasing instead of capping 128 
++// ABI STACK for windows 288 bytes
++    stack_alloc_size += 288 / sizeof(FLOAT) ;
+ 
+   if(stack_alloc_size > MAX_STACK_ALLOC / sizeof(FLOAT))
+     stack_alloc_size = 0;
+ 
++// stack overflow check
++  volatile double stack_check = 3.14159265358979323846;
+   FLOAT stack_buffer[stack_alloc_size];
+   buffer = stack_alloc_size ? stack_buffer : (FLOAT *)blas_memory_alloc(1);
+   //  printf("stack_alloc_size=%d\n", stack_alloc_size);
+@@ -265,6 +270,8 @@ void CNAME(enum CBLAS_ORDER order,
+ 
+   }
+ #endif
++// stack overflow check
++assert(stack_check==3.14159265358979323846);
+ 
+ #ifdef MAX_STACK_ALLOC
+   if(!stack_alloc_size){
+diff --git a/exports/Makefile b/exports/Makefile
+index 177e975..29a9ca8 100644
+--- a/exports/Makefile
++++ b/exports/Makefile
+@@ -96,9 +96,9 @@ libgoto_hpl.def : gensymbol
+ ifeq (, $(SYMBOLPREFIX)$(SYMBOLSUFFIX))
+ $(LIBDYNNAME) : ../$(LIBNAME) osx.def
+ else
+-../$(LIBNAME).renamed : ../$(LIBNAME) objconv.def
+-	$(OBJCONV) @objconv.def ../$(LIBNAME) ../$(LIBNAME).renamed
+-$(LIBDYNNAME) : ../$(LIBNAME).renamed osx.def
++../$(LIBNAME).osx.renamed : ../$(LIBNAME) objconv.def
++	$(OBJCONV) @objconv.def ../$(LIBNAME) ../$(LIBNAME).osx.renamed
++$(LIBDYNNAME) : ../$(LIBNAME).osx.renamed osx.def
+ endif
+ ifeq ($(NOFORTRAN), $(filter $(NOFORTRAN),1 2))
+ #only build without Fortran
+@@ -220,7 +220,7 @@ linktest.c : gensymbol ../Makefile.system ../getarch.c
+ 	perl ./gensymbol linktest  $(ARCH) $(BU) $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" > linktest.c
+ 
+ clean ::
+-	@rm -f *.def *.dylib __.SYMDEF*
++	@rm -f *.def *.dylib __.SYMDEF* *.renamed
+ 
+ include ../Makefile.tail
+ 


### PR DESCRIPTION
ref #14174 and https://github.com/xianyi/OpenBLAS/issues/697

This is a little tricky to add a test for within the same PR, as it'll fail on AppVeyor until we get nightlies built that include a patched binary of OpenBLAS. `eigfact` or `svdfact` of a random matrix larger than around 150-by-150 should be enough to trigger this, and I can add a test for that as soon as a few hours after merging this.
