### PR TITLE
Fix address sanitizer issue with LLVM 3.7.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6053,6 +6053,10 @@ static void init_julia_llvm_env(Module *m)
 
 #ifdef __has_feature
 #   if __has_feature(address_sanitizer)
+#   if defined(LLVM37) && !defined(LLVM38)
+    // LLVM 3.7 BUG: ASAN pass doesn't properly initialize its dependencies
+    initializeTargetLibraryInfoWrapperPassPass(*PassRegistry::getPassRegistry());
+#   endif
     FPM->add(createAddressSanitizerFunctionPass());
 #   endif
 #   if __has_feature(memory_sanitizer)


### PR DESCRIPTION
As discussed in #13858: LLVM 3.7 contains a bug where the ASAN pass doesn't properly initialize its dependencies. @keno fixed this [upstream](https://github.com/llvm-mirror/llvm/commit/bb5ca273e0ee58bededeab057f8b360181660b02), but that isn't part of LLVM 3.7.
