### PR TITLE
Extend and clean the ccall test suite.

### DIFF
--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -5,7 +5,6 @@
 #include <complex.h>
 #include <stdint.h>
 #include <inttypes.h>
-int verbose = 1;
 
 #include "../src/support/platform.h"
 #include "../src/support/dtypes.h"
@@ -15,6 +14,9 @@ int verbose = 1;
 #else
 #define jint int32_t
 #endif
+
+int verbose = 1;
+
 
 //////////////////////////////////
 // Test for proper argument register truncation
@@ -31,11 +33,6 @@ JL_DLLEXPORT testUcharX(unsigned char x) {
     return xs[x];
 }
 
-#define xstr(s) str(s)
-#define str(s) #s
-int (*volatile fptr)(unsigned char x);
-volatile int a;
-volatile int b;
 
 //////////////////////////////////
 // Tests for passing and returning Structs
@@ -93,19 +90,6 @@ JL_DLLEXPORT complex_t* cptest_static(complex_t *a) {
     b->real = a->real;
     b->imag = a->imag;
     return b;
-}
-
-// Native-like data types
-JL_DLLEXPORT char* stest(char *x) {
-    //Print a character Array
-    if (verbose) fprintf(stderr,"%s\n", x);
-    return x;
-}
-
-struct jl_asciistring_t { struct { void* type; char* data; } *data; };
-char* sptest(struct jl_asciistring_t str) {
-    //Unpack an ASCIIString
-    return stest(str.data->data);
 }
 
 // Various sized data types
@@ -199,148 +183,171 @@ typedef struct {
 } struct15;
 
 typedef struct {
+    float x,y,z;
+    double a,b,c;
+} struct16;
+
+typedef struct {
     jint x;
     jint y;
     char z;
 } struct_big;
 
-JL_DLLEXPORT struct1 test_1(struct1 a) {
+JL_DLLEXPORT struct1 test_1(struct1 a, float b) {
     //Unpack a "small" struct { float, double }
-    if (verbose) fprintf(stderr,"%g + %g i\n", a.x, a.y);
-    a.x += 1;
-    a.y -= 2;
+    if (verbose) fprintf(stderr,"%g + %g i & %g\n", a.x, a.y, b);
+    a.x += b*1;
+    a.y -= b*2;
     return a;
 }
 
-JL_DLLEXPORT struct1 add_1(struct1 a, struct1 b) {
-    // Two small structs
-    struct1 c;
-    c.x = a.x + b.x;
-    c.y = a.y + b.y;
-    return c;
-}
-
-JL_DLLEXPORT struct2a test_2a(struct2a a) {
+JL_DLLEXPORT struct2a test_2a(struct2a a, int32_t b) {
     //Unpack a ComplexPair{Int32} struct
-    if (verbose) fprintf(stderr,"%" PRId32 " + %" PRId32 " i\n", a.x.x, a.y.y);
-    a.x.x += 1;
-    a.y.y -= 2;
+    if (verbose) fprintf(stderr,"%" PRId32 " + %" PRId32 " i & %" PRId32 "\n", a.x.x, a.y.y, b);
+    a.x.x += b*1;
+    a.y.y -= b*2;
     return a;
 }
 
-JL_DLLEXPORT struct2b test_2b(struct2b a) {
+JL_DLLEXPORT struct2b test_2b(struct2b a, int32_t b) {
     //Unpack a ComplexPair{Int32} struct
-    if (verbose) fprintf(stderr,"%" PRId32 " + %" PRId32 " i\n", a.x, a.y);
-    a.x += 1;
-    a.y -= 2;
+    if (verbose) fprintf(stderr,"%" PRId32 " + %" PRId32 " i & %" PRId32 "\n", a.x, a.y, b);
+    a.x += b*1;
+    a.y -= b*2;
     return a;
 }
 
-JL_DLLEXPORT struct3a test_3a(struct3a a) {
+JL_DLLEXPORT struct3a test_3a(struct3a a, int64_t b) {
     //Unpack a ComplexPair{Int64} struct
-    if (verbose) fprintf(stderr,"%" PRId64 " + %" PRId64 " i\n", a.x.x, a.y.y);
-    a.x.x += 1;
-    a.y.y -= 2;
+    if (verbose) fprintf(stderr,"%" PRId64 " + %" PRId64 " i & %" PRId64 "\n", a.x.x, a.y.y, b);
+    a.x.x += b*1;
+    a.y.y -= b*2;
     return a;
 }
 
-JL_DLLEXPORT struct3b test_3b(struct3b a) {
+JL_DLLEXPORT struct3b test_3b(struct3b a, int64_t b) {
     //Unpack a ComplexPair{Int64} struct
-    if (verbose) fprintf(stderr,"%" PRId64 " + %" PRId64 " i\n", a.x, a.y);
-    a.x += 1;
-    a.y -= 2;
+    if (verbose) fprintf(stderr,"%" PRId64 " + %" PRId64 " i & %" PRId64 "\n", a.x, a.y, b);
+    a.x += b*1;
+    a.y -= b*2;
     return a;
 }
 
-JL_DLLEXPORT struct4 test_4(struct4 a)
-{
-    if (verbose) fprintf(stderr,"(%" PRId32 ",%" PRId32 ",%" PRId32 ")\n", a.x, a.y, a.z);
-    a.x += 1;
-    a.y -= 2;
-    a.z += 3;
+JL_DLLEXPORT struct4 test_4(struct4 a, int32_t b) {
+    if (verbose) fprintf(stderr,"%" PRId32 ",%" PRId32 ",%" PRId32 " & %" PRId32 "\n", a.x, a.y, a.z, b);
+    a.x += b*1;
+    a.y -= b*2;
+    a.z += b*3;
     return a;
 }
 
-
-JL_DLLEXPORT struct5 test_5(struct5 a)
-{
-    if (verbose) fprintf(stderr,"(%" PRId32 ",%" PRId32 ",%" PRId32 ",%" PRId32 ")\n", a.x, a.y, a.z, a.a);
-    a.x += 1;
-    a.y -= 2;
-    a.z += 3;
-    a.a -= 4;
-
-    return a;
-}
-
-
-JL_DLLEXPORT struct6 test_6(struct6 a)
-{
-    if (verbose) fprintf(stderr,"(%" PRId64 ",%" PRId64 ",%" PRId64 ")\n", a.x, a.y, a.z);
-    a.x += 1;
-    a.y -= 2;
-    a.z += 3;
-    return a;
-}
-
-JL_DLLEXPORT struct7 test_7(struct7 a)
-{
-    if (verbose) fprintf(stderr,"(%" PRId64 ",%" PRId8 ")\n", a.x, a.y);
-    a.x += 1;
-    a.y -= 2;
-    return a;
-}
-
-JL_DLLEXPORT struct8 test_8(struct8 a)
-{
-    if (verbose) fprintf(stderr,"(%" PRId32 ",%" PRId8 ")\n", a.x, a.y);
-    a.x += 1;
-    a.y -= 2;
-    return a;
-}
-
-JL_DLLEXPORT struct9 test_9(struct9 a)
-{
-    if (verbose) fprintf(stderr,"(%" PRId32 ",%" PRId16 ")\n", a.x, a.y);
-    a.x += 1;
-    a.y -= 2;
-    return a;
-}
-
-JL_DLLEXPORT struct10 test_10(struct10 a)
-{
-    if (verbose) fprintf(stderr,"(%" PRId8 ",%" PRId8 ",%" PRId8 ",%" PRId8 ")\n", a.x, a.y, a.z, a.a);
-    a.x += 1;
-    a.y -= 2;
-    a.z += 3;
-    a.a -= 4;
+JL_DLLEXPORT struct5 test_5(struct5 a, int32_t b) {
+    if (verbose) fprintf(stderr,"%" PRId32 ",%" PRId32 ",%" PRId32 ",%" PRId32 " & %" PRId32 "\n", a.x, a.y, a.z, a.a, b);
+    a.x += b*1;
+    a.y -= b*2;
+    a.z += b*3;
+    a.a -= b*4;
 
     return a;
 }
 
-JL_DLLEXPORT struct14 test_14(struct14 a) {
+JL_DLLEXPORT struct6 test_6(struct6 a, int64_t b) {
+    if (verbose) fprintf(stderr,"%" PRId64 ",%" PRId64 ",%" PRId64 " & %" PRId64 "\n", a.x, a.y, a.z, b);
+    a.x += b*1;
+    a.y -= b*2;
+    a.z += b*3;
+    return a;
+}
+
+JL_DLLEXPORT struct7 test_7(struct7 a, int8_t b) {
+    if (verbose) fprintf(stderr,"%" PRId64 ",%" PRId8 " & %" PRId8 "\n", a.x, a.y, b);
+    a.x += b*1;
+    a.y -= b*2;
+    return a;
+}
+
+JL_DLLEXPORT struct8 test_8(struct8 a, int8_t b) {
+    if (verbose) fprintf(stderr,"%" PRId32 ",%" PRId8 " & %" PRId8 "\n", a.x, a.y, b);
+    a.x += b*1;
+    a.y -= b*2;
+    return a;
+}
+
+JL_DLLEXPORT struct9 test_9(struct9 a, int16_t b) {
+    if (verbose) fprintf(stderr,"%" PRId32 ",%" PRId16 " & %" PRId16 "\n", a.x, a.y, b);
+    a.x += b*1;
+    a.y -= b*2;
+    return a;
+}
+
+JL_DLLEXPORT struct10 test_10(struct10 a, int8_t b) {
+    if (verbose) fprintf(stderr,"%" PRId8 ",%" PRId8 ",%" PRId8 ",%" PRId8 " & %" PRId8 "\n", a.x, a.y, a.z, a.a, b);
+    a.x += b*1;
+    a.y -= b*2;
+    a.z += b*3;
+    a.a -= b*4;
+
+    return a;
+}
+
+JL_DLLEXPORT struct11 test_11(struct11 a, float b) {
+    //Unpack a nested ComplexPair{Float32} struct
+    if (verbose) fprintf(stderr,"%g + %g i & %g\n", creal(a.x), cimag(a.x), b);
+    a.x += b*1 - (b*2.0*I);
+    return a;
+}
+
+JL_DLLEXPORT struct12 test_12(struct12 a, float b) {
+    //Unpack two nested ComplexPair{Float32} structs
+    if (verbose) fprintf(stderr,"%g + %g i & %g + %g i & %g\n",
+                         creal(a.x), cimag(a.x), creal(a.y), cimag(a.y), b);
+    a.x += b*1 - (b*2.0*I);
+    a.y += b*3 - (b*4.0*I);
+    return a;
+}
+
+JL_DLLEXPORT struct13 test_13(struct13 a, double b) {
+    //Unpack a nested ComplexPair{Float64} struct
+    if (verbose) fprintf(stderr,"%g + %g i & %g\n", creal(a.x), cimag(a.x), b);
+    a.x += b*1 - (b*2.0*I);
+    return a;
+}
+
+JL_DLLEXPORT struct14 test_14(struct14 a, float b) {
     //The C equivalent of a  ComplexPair{Float32} struct (but without special complex ABI)
-    if (verbose) fprintf(stderr,"%g + %g i\n", a.x, a.y);
-    a.x += 1;
-    a.y -= 2;
+    if (verbose) fprintf(stderr,"%g + %g i & %g\n", a.x, a.y, b);
+    a.x += b*1;
+    a.y -= b*2;
     return a;
 }
 
-JL_DLLEXPORT struct15 test_15(struct15 a) {
-    //The C equivalent of a  ComplexPair{Float32} struct (but without special complex ABI)
-    if (verbose) fprintf(stderr,"%g + %g i\n", a.x, a.y);
-    a.x += 1;
-    a.y -= 2;
+JL_DLLEXPORT struct15 test_15(struct15 a, double b) {
+    //The C equivalent of a  ComplexPair{Float64} struct (but without special complex ABI)
+    if (verbose) fprintf(stderr,"%g + %g i & %g\n", a.x, a.y, b);
+    a.x += b*1;
+    a.y -= b*2;
+    return a;
+}
+
+JL_DLLEXPORT struct16 test_16(struct16 a, float b) {
+    //Unpack a struct with non-obvious packing requirements
+    if (verbose) fprintf(stderr,"%g %g %g %g %g %g & %g\n", a.x, a.y, a.z, a.a, a.b, a.c, b);
+    a.x += b*1;
+    a.y -= b*2;
+    a.z += b*3;
+    a.a -= b*4;
+    a.b += b*5;
+    a.c -= b*6;
     return a;
 }
 
 #define int128_t struct3b
-JL_DLLEXPORT int128_t test_128(int128_t a) {
+JL_DLLEXPORT int128_t test_128(int128_t a, int64_t b) {
     //Unpack a Int128
-    if (verbose) fprintf(stderr,"0x%016" PRIx64 "%016" PRIx64 "\n", a.y, a.x);
-    a.x += 1;
+    if (verbose) fprintf(stderr,"0x%016" PRIx64 "%016" PRIx64 " & %" PRId64 "\n", a.y, a.x, b);
+    a.x += b*1;
     if (a.x == 0)
-        a.y += 1;
+        a.y += b*1;
     return a;
 }
 
@@ -353,8 +360,10 @@ JL_DLLEXPORT struct_big test_big(struct_big a) {
     return a;
 }
 
+
 //////////////////////////////////
 // Turn off verbose for automated tests, leave on for debugging
+
 JL_DLLEXPORT void set_verbose(int level) {
     verbose = level;
 }

--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -11,8 +11,10 @@
 
 #ifdef _P64
 #define jint int64_t
+#define PRIjint PRId64
 #else
 #define jint int32_t
+#define PRIjint PRId32
 #endif
 
 int verbose = 1;
@@ -79,7 +81,7 @@ JL_DLLEXPORT complex float* cfptest(complex float *a) {
 
 JL_DLLEXPORT complex_t* cptest(complex_t *a) {
     //Unpack a ComplexPair{Int} struct pointer
-    if (verbose) fprintf(stderr,"%lld + %lld i\n", (long long)a->real, (long long)a->imag);
+    if (verbose) fprintf(stderr,"%" PRIjint " + %" PRIjint " i\n", a->real, a->imag);
     a->real += 1;
     a->imag -= 2;
     return a;
@@ -353,7 +355,7 @@ JL_DLLEXPORT int128_t test_128(int128_t a, int64_t b) {
 
 JL_DLLEXPORT struct_big test_big(struct_big a) {
     //Unpack a "big" struct { int, int, char }
-    if (verbose) fprintf(stderr,"%lld %lld %c\n", (long long)a.x, (long long)a.y, a.z);
+    if (verbose) fprintf(stderr,"%" PRIjint " %" PRIjint " %c\n", a.x, a.y, a.z);
     a.x += 1;
     a.y -= 2;
     a.z -= 'A';


### PR DESCRIPTION
The current `ccall` test suite doesn't match/test all functionality in `libccalltest`. This PR removes some unused functionality from `libccalltest`, but mainly extends `libccalltest` and `test/ccall` to align the different structs and test methods.

As part of a small clean-up, I've also scoped most tests in a `let...end` block, and added a factor-like parameter to the struct test methods to catch cases where the ABI allocates too much memory for a certain parameter (it helped me discover issues with the ARM ABI from #14194).

I've only tested these changes on x86_64, so it's possible that it triggers some issues on other platforms...

cc @vtjnash

[edit by tkelman: fixes https://github.com/JuliaLang/julia/issues/13242]
