### PR TITLE
WIP: Throw UnicodeError for s[i:j], where j is not at the start of a code point

### DIFF
--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -94,7 +94,7 @@ function DateFormat(f::AbstractString,locale::AbstractString="english")
         typ = SLOT_RULE[letter]
 
         width = length(m.match)
-        tran = f[last_offset:m.offset-1]
+        tran = f[last_offset:prevind(f, m.offset)]
 
         if isempty(params)
             prefix = tran

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -36,7 +36,8 @@ startswith(a::Vector{UInt8}, b::Vector{UInt8}) =
 
 # TODO: fast endswith
 
-chop(s::AbstractString) = s[1:end-1]
+chop(s::DirectIndexString) = s[1:end-1]
+chop(s::AbstractString) = s[1:prevind(s,endof(s))]
 
 function chomp(s::AbstractString)
     i = endof(s)
@@ -45,9 +46,9 @@ function chomp(s::AbstractString)
     if (j < 1 || s[j] != '\r') return s[1:i-1] end
     return s[1:j-1]
 end
-chomp(s::ByteString) =
-    (endof(s) < 1 || s.data[end]   != 0x0a) ? s :
-    (endof(s) < 2 || s.data[end-1] != 0x0d) ? s[1:end-1] : s[1:end-2]
+chomp{T<:ByteString}(s::T) =
+   (endof(s) < 1 || s.data[end]   != 0x0a) ? s :
+   (endof(s) < 2 || s.data[end-1] != 0x0d) ? T(s.data[1:end-1]) : T(s.data[1:end-2])
 
 # NOTE: use with caution -- breaks the immutable string convention!
 function chomp!(s::ByteString)

--- a/base/unicode/UnicodeError.jl
+++ b/base/unicode/UnicodeError.jl
@@ -18,7 +18,7 @@ const UTF_ERR_ODD_BYTES_32      = "UTF32String must have multiple of 4 bytes <<1
 const UTF_ERR_INVALID_CHAR      = "invalid Unicode character (0x<<2>> > 0x10ffff)"
 const UTF_ERR_INVALID_8         = "invalid UTF-8 data"
 const UTF_ERR_INVALID_16        = "invalid UTF-16 data"
-const UTF_ERR_INVALID_INDEX     = "invalid character index"
+const UTF_ERR_INVALID_INDEX     = "invalid character index <<1>> (0x<<2>>) the index must be at the start of a character (code point)"
 const UTF_ERR_MAP_CHAR          = "map(f,s::AbstractString) requires f to return Char; try map(f,collect(s)) or a comprehension instead"
 
 type UnicodeError <: Exception

--- a/base/unicode/utf16.jl
+++ b/base/unicode/utf16.jl
@@ -251,6 +251,26 @@ function utf16(p::Union{Ptr{UInt16}, Ptr{Int16}})
     utf16(p, len)
 end
 
+function getindex(s::UTF16String, r::UnitRange{Int})
+    i, j = first(r), last(r)
+    isempty(r) && return SubString(s,i,j)
+    d = s.data
+    endidx = length(d) - 1 #UTF16 are null terminated
+    if i < 1 || i > endidx
+        throw(BoundsError(s, i))
+    end
+    if j > endidx
+        throw(BoundsError(s, j))
+    end
+    if is_surrogate_trail(d[i])
+        throw(UnicodeError(UTF_ERR_INVALID_INDEX, i, d[i]))
+    end
+    if is_surrogate_trail(d[j])
+        throw(UnicodeError(UTF_ERR_INVALID_INDEX, j, d[j]))
+    end
+    return SubString(s,i,j)
+end
+
 function map(fun, str::UTF16String)
     buf = UInt16[]
     sizehint!(buf, length(str.data))

--- a/base/unicode/utf8.jl
+++ b/base/unicode/utf8.jl
@@ -101,10 +101,8 @@ sizeof(s::UTF8String) = sizeof(s.data)
 
 lastidx(s::UTF8String) = length(s.data)
 
-isfirstbyte(c::UInt8) = (c & 0xc0) != 0x80 # == !is_valid_continuation(c)
-
 isvalid(s::UTF8String, i::Integer) =
-    (1 <= i <= endof(s.data)) && isfirstbyte(s.data[i])
+    (1 <= i <= endof(s.data)) && !is_valid_continuation(s.data[i])
 
 const empty_utf8 = UTF8String(UInt8[])
 function getindex(s::UTF8String, r::UnitRange{Int})
@@ -114,20 +112,16 @@ function getindex(s::UTF8String, r::UnitRange{Int})
     if i < 1 || i > length(d)
         throw(BoundsError(s, i))
     end
+    if j > length(d)
+        throw(BoundsError(s, j))
+    end
     if is_valid_continuation(d[i])
         throw(UnicodeError(UTF_ERR_INVALID_INDEX, i, d[i]))
     end
-    if j < 1 || j > length(d)
-        throw(BoundsError(s, i))
-    end
-    #ensure j is the first or last byte of a character
-    if isfirstbyte(d[j])
-        UTF8String(d[i:j + utf8_trailing[d[j]+1]])
-    elseif j == length(d) || isfirstbyte(s.data[j+1])
-        UTF8String(d[i:j])
-    else
+    if is_valid_continuation(d[j])
         throw(UnicodeError(UTF_ERR_INVALID_INDEX, j, d[j]))
     end
+    UTF8String(d[i:j + utf8_trailing[d[j]+1]]) # +1 since utf_trailing is 1-based
 end
 
 function search(s::UTF8String, c::Char, i::Integer)

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -110,9 +110,9 @@ end
 @test last('\x00':'\x7f') === '\x7f'
 
 # make sure substrings handle last code unit even if not start of codepoint
-let s = "x\u0302"
-    @test s[1:3] == s
-end
+# let s = "x\u0302"
+#     @test s[1:3] == s
+# end
 
 # issue #9781
 # float(SubString) wasn't tolerant of trailing whitespace, which was different

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -231,9 +231,13 @@ let s = "\r\r\n"
 end
 
 @test chop("foob") == "foo"
-@test chop("fooƀ") == "foo"
-@test chop("fooƀä") == "fooƀ"
-@test chop("fooƀa") == "fooƀ"
+for StrT in (UTF8String, UTF16String, UTF32String)
+    for str in ("foo", "fooƀ")
+        for lastchr in ("ƀ", "🐨", "b")
+            @test chop(StrT(str*lastchr)) == StrT(str)
+        end
+    end
+end
 
 # bytes2hex and hex2bytes
 hex_str = "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -208,9 +208,32 @@ end
 # Issue 13332
 @test replace("abc", 'b', 2.1) == "a2.1c"
 
-# chomp/chop
-@test chomp("foo\n") == "foo"
+# chomp/chop for ASCII/UTF8
+for lineend in ["\n","\r\n"]
+    for str in ["foo", "foø", "føo", "fø", "ø", "\n", ""]
+        @test chomp(str*lineend) == str
+    end
+end
+@test chomp("\r\r\n") == "\r" # || "\r\r" ?
+
+import Base.chomp!
+for lineend in ("\n","\r\n")
+    for str in ("foo", "foø", "føo", "fø", "ø", "\n", "")
+        s = str*lineend
+        chomp!(s)
+        @test s == str
+    end
+end
+
+let s = "\r\r\n"
+    chomp!(s)
+    @test s == "\r" # || "\r\r" ?
+end
+
 @test chop("foob") == "foo"
+@test chop("fooƀ") == "foo"
+@test chop("fooƀä") == "fooƀ"
+@test chop("fooƀa") == "fooƀ"
 
 # bytes2hex and hex2bytes
 hex_str = "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"

--- a/test/unicode/utf16.jl
+++ b/test/unicode/utf16.jl
@@ -21,3 +21,30 @@ u16 = utf16(u8)
 @test map(lowercase, utf16("TEST\U1f596")) == "test\U1f596"
 @test typeof(Base.unsafe_convert(Ptr{UInt16}, utf16("test"))) == Ptr{UInt16}
 
+let s = UTF16String("🐨🐨x")
+    #each koala is 2 code-units
+    @test s[1:1] == "🐨"
+    @test s[1] == '🐨'
+    @test s[3:3] == "🐨"
+    @test s[3] == '🐨'
+    @test s[1:nextind(s,1)] == "🐨🐨"
+    @test s[1:3] == "🐨🐨"
+    @test s[1:end] == s
+    @test s[nextind(s,1):end] == "🐨x"
+    @test s[3:end] == "🐨x"
+    @test s[3:5] == "🐨x"
+    @test_throws UnicodeError s[2]
+    @test_throws UnicodeError s[4]
+    @test_throws UnicodeError s[1:2]
+    @test_throws UnicodeError s[1:end-1]
+    @test_throws UnicodeError s[1:4]
+    @test_throws UnicodeError s[2:3]
+    @test_throws UnicodeError s[2:4]
+    @test_throws UnicodeError s[3:4]
+    @test_throws BoundsError s[0:3]
+    @test_throws BoundsError s[-1:3]
+    @test_throws BoundsError s[-2:3]
+    @test_throws BoundsError s[3:6]
+    @test_throws BoundsError s[3:7]
+    @test_throws BoundsError s[3:8]
+end

--- a/test/unicode/utf8.jl
+++ b/test/unicode/utf8.jl
@@ -17,7 +17,7 @@ let str = UTF8String(b"this is a test\xed\x80")
     @test_throws BoundsError getindex(str, 0:3)
     @test_throws BoundsError getindex(str, 17:18)
     @test_throws BoundsError getindex(str, 2:17)
-    @test_throws UnicodeError getindex(str, 16:17)
+    @test_throws UnicodeError getindex(str, 16:16)
     @test string(Char(0x110000)) == "\ufffd"
     sa = SubString{ASCIIString}(ascii("This is a silly test"), 1, 14)
     s8 = convert(SubString{UTF8String}, sa)
@@ -28,18 +28,26 @@ end
 
 let s = UTF8String("🐨🐨")
     #each koala is 4 bytes
-    @test s[1:4] == "🐨"
     @test s[1:1] == "🐨"
     @test s[1] == '🐨'
-    @test s[5:8] == "🐨"
     @test s[5:5] == "🐨"
     @test s[5] == '🐨'
+    @test s[1:5] == "🐨🐨"
     @test_throws UnicodeError s[1:2]
     @test_throws UnicodeError s[1:3]
+    @test_throws UnicodeError s[1:4]
     @test_throws UnicodeError s[1:6]
     @test_throws UnicodeError s[1:7]
+    @test_throws UnicodeError s[1:8]
     @test_throws UnicodeError s[5:6]
     @test_throws UnicodeError s[5:7]
+    @test_throws UnicodeError s[5:8]
+    @test_throws UnicodeError s[1:end-1]
+    @test_throws UnicodeError s[1:end-2]
+    @test_throws UnicodeError s[1:end-3]
+    @test_throws BoundsError s[-1:4]
+    @test_throws BoundsError s[3:10]
+    @test_throws BoundsError s[-4:40]
 end
 
 ## Reverse of UTF8String

--- a/test/unicode/utf8.jl
+++ b/test/unicode/utf8.jl
@@ -26,6 +26,22 @@ let str = UTF8String(b"this is a test\xed\x80")
     @test convert(UTF8String, b"this is a test\xed\x80\x80") == "this is a test\ud000"
 end
 
+let s = UTF8String("🐨🐨")
+    #each koala is 4 bytes
+    @test s[1:4] == "🐨"
+    @test s[1:1] == "🐨"
+    @test s[1] == '🐨'
+    @test s[5:8] == "🐨"
+    @test s[5:5] == "🐨"
+    @test s[5] == '🐨'
+    @test_throws UnicodeError s[1:2]
+    @test_throws UnicodeError s[1:3]
+    @test_throws UnicodeError s[1:6]
+    @test_throws UnicodeError s[1:7]
+    @test_throws UnicodeError s[5:6]
+    @test_throws UnicodeError s[5:7]
+end
+
 ## Reverse of UTF8String
 @test reverse(UTF8String("")) == ""
 @test reverse(UTF8String("a")) == "a"


### PR DESCRIPTION
Previously if j was in the middle of a code point then it was moved to the end of the code point to be more forgiving. After discussion with @stevengj and @nalimilan in #14158 the recommendation was it would be more sensible to throw an error.
Also added some more tests.
