### PR TITLE
DLLEXPORT clean up

### DIFF
--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -7,7 +7,7 @@
 
 extern "C" {
 #include "APInt-C.h"
-DLLEXPORT void jl_error(const char *str);
+JL_DLLEXPORT void jl_error(const char *str);
 }
 
 using namespace llvm;
@@ -41,7 +41,7 @@ using namespace llvm;
     else \
         memcpy(p##r, a.getRawData(), RoundUpToAlignment(numbits, host_char_bit) / host_char_bit); \
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMNeg(unsigned numbits, integerPart *pa, integerPart *pr) {
     APInt z(numbits, 0);
     CREATE(a)
@@ -49,7 +49,7 @@ void LLVMNeg(unsigned numbits, integerPart *pa, integerPart *pr) {
     ASSIGN(r, z)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMAdd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -57,7 +57,7 @@ void LLVMAdd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMSub(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -65,7 +65,7 @@ void LLVMSub(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMMul(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -73,7 +73,7 @@ void LLVMMul(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMSDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -81,7 +81,7 @@ void LLVMSDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *p
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMUDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -89,7 +89,7 @@ void LLVMUDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *p
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMSRem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -97,7 +97,7 @@ void LLVMSRem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *p
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMURem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -105,49 +105,49 @@ void LLVMURem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *p
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMICmpEQ(unsigned numbits, integerPart *pa, integerPart *pb) {
     CREATE(a)
     CREATE(b)
     return a.eq(b);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMICmpNE(unsigned numbits, integerPart *pa, integerPart *pb) {
     CREATE(a)
     CREATE(b)
     return a.ne(b);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMICmpSLT(unsigned numbits, integerPart *pa, integerPart *pb) {
     CREATE(a)
     CREATE(b)
     return a.slt(b);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMICmpULT(unsigned numbits, integerPart *pa, integerPart *pb) {
     CREATE(a)
     CREATE(b)
     return a.ult(b);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMICmpSLE(unsigned numbits, integerPart *pa, integerPart *pb) {
     CREATE(a)
     CREATE(b)
     return a.sle(b);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMICmpULE(unsigned numbits, integerPart *pa, integerPart *pb) {
     CREATE(a)
     CREATE(b)
     return a.ule(b);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMAnd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -155,7 +155,7 @@ void LLVMAnd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMOr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -163,7 +163,7 @@ void LLVMOr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr)
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMXor(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -171,7 +171,7 @@ void LLVMXor(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMShl(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -179,14 +179,14 @@ void LLVMShl(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMLShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
     a = a.lshr(b);
     ASSIGN(r, a)
 }
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMAShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -194,14 +194,14 @@ void LLVMAShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *p
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMFlipAllBits(unsigned numbits, integerPart *pa, integerPart *pr) {
     CREATE(a)
     a.flipAllBits();
     ASSIGN(r, a)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMAdd_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -211,7 +211,7 @@ int LLVMAdd_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart 
     return Overflow;
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMAdd_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -221,7 +221,7 @@ int LLVMAdd_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart 
     return Overflow;
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMSub_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -231,7 +231,7 @@ int LLVMSub_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart 
     return Overflow;
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMSub_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -241,7 +241,7 @@ int LLVMSub_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart 
     return Overflow;
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMMul_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -251,7 +251,7 @@ int LLVMMul_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart 
     return Overflow;
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMMul_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -261,7 +261,7 @@ int LLVMMul_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart 
     return Overflow;
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMByteSwap(unsigned numbits, integerPart *pa, integerPart *pr) {
     CREATE(a)
     a = a.byteSwap();
@@ -312,31 +312,31 @@ void LLVMFPtoInt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPa
     }
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMFPtoSI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
     LLVMFPtoInt(numbits, pa, onumbits, pr, true, NULL);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMFPtoUI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
     LLVMFPtoInt(numbits, pa, onumbits, pr, false, NULL);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMFPtoSI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
     bool isExact;
     LLVMFPtoInt(numbits, pa, onumbits, pr, true, &isExact);
     return isExact;
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 int LLVMFPtoUI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
     bool isExact;
     LLVMFPtoInt(numbits, pa, onumbits, pr, false, &isExact);
     return isExact;
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMSItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
     CREATE(a)
     double val = a.roundToDouble(true);
@@ -348,7 +348,7 @@ void LLVMSItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPar
         jl_error("SItoFP: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMUItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
     CREATE(a)
     double val = a.roundToDouble(false);
@@ -360,7 +360,7 @@ void LLVMUItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPar
         jl_error("UItoFP: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMSExt(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
     assert(inumbits < onumbits);
     unsigned inumbytes = RoundUpToAlignment(inumbits, host_char_bit) / host_char_bit;
@@ -378,7 +378,7 @@ void LLVMSExt(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart
     memset((char*)pr + inumbytes, sign, onumbytes - inumbytes);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMZExt(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
     assert(inumbits < onumbits);
     unsigned inumbytes = RoundUpToAlignment(inumbits, host_char_bit) / host_char_bit;
@@ -394,14 +394,14 @@ void LLVMZExt(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart
     memset((char*)pr + inumbytes, 0, onumbytes - inumbytes);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void LLVMTrunc(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
     assert(inumbits > onumbits);
     unsigned onumbytes = RoundUpToAlignment(onumbits, host_char_bit) / host_char_bit;
     memcpy(pr, pa, onumbytes);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 unsigned countTrailingZeros_8(uint8_t Val) {
 #ifdef LLVM35
     return countTrailingZeros(Val);
@@ -410,7 +410,7 @@ unsigned countTrailingZeros_8(uint8_t Val) {
 #endif
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 unsigned countTrailingZeros_16(uint16_t Val) {
 #ifdef LLVM35
     return countTrailingZeros(Val);
@@ -419,7 +419,7 @@ unsigned countTrailingZeros_16(uint16_t Val) {
 #endif
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 unsigned countTrailingZeros_32(uint32_t Val) {
 #ifdef LLVM35
     return countTrailingZeros(Val);
@@ -428,7 +428,7 @@ unsigned countTrailingZeros_32(uint32_t Val) {
 #endif
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 unsigned countTrailingZeros_64(uint64_t Val) {
 #ifdef LLVM35
     return countTrailingZeros(Val);
@@ -437,7 +437,7 @@ unsigned countTrailingZeros_64(uint64_t Val) {
 #endif
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void jl_LLVMSMod(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     CREATE(a)
     CREATE(b)
@@ -448,7 +448,7 @@ void jl_LLVMSMod(unsigned numbits, integerPart *pa, integerPart *pb, integerPart
     ASSIGN(r, r)
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void jl_LLVMFlipSign(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr) {
     unsigned numbytes = RoundUpToAlignment(numbits, host_char_bit) / host_char_bit;
     int signbit = (numbits - 1) % host_char_bit;
@@ -459,31 +459,31 @@ void jl_LLVMFlipSign(unsigned numbits, integerPart *pa, integerPart *pb, integer
         memcpy(pr, pa,  numbytes);
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 unsigned LLVMCountPopulation(unsigned numbits, integerPart *pa) {
     CREATE(a)
     return a.countPopulation();
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 unsigned LLVMCountTrailingOnes(unsigned numbits, integerPart *pa) {
     CREATE(a)
     return a.countTrailingOnes();
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 unsigned LLVMCountTrailingZeros(unsigned numbits, integerPart *pa) {
     CREATE(a)
     return a.countTrailingZeros();
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 unsigned LLVMCountLeadingOnes(unsigned numbits, integerPart *pa) {
     CREATE(a)
     return a.countLeadingOnes();
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 unsigned LLVMCountLeadingZeros(unsigned numbits, integerPart *pa) {
     CREATE(a)
     return a.countLeadingZeros();

--- a/src/APInt-C.h
+++ b/src/APInt-C.h
@@ -14,63 +14,63 @@ using llvm::integerPart;
 typedef void integerPart;
 #endif
 
-DLLEXPORT void LLVMNeg(unsigned numbits, integerPart *pa, integerPart *pr);
-DLLEXPORT void LLVMByteSwap(unsigned numbits, integerPart *pa, integerPart *pr);
+JL_DLLEXPORT void LLVMNeg(unsigned numbits, integerPart *pa, integerPart *pr);
+JL_DLLEXPORT void LLVMByteSwap(unsigned numbits, integerPart *pa, integerPart *pr);
 
-DLLEXPORT void LLVMAdd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMSub(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMMul(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMSDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMUDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMSRem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMURem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMAdd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMSub(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMMul(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMSDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMUDiv(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMSRem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMURem(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 
-DLLEXPORT void LLVMAnd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMOr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMXor(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMShl(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMLShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMAShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void LLVMFlipAllBits(unsigned numbits, integerPart *pa, integerPart *pr);
+JL_DLLEXPORT void LLVMAnd(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMOr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMXor(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMShl(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMLShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMAShr(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void LLVMFlipAllBits(unsigned numbits, integerPart *pa, integerPart *pr);
 
-DLLEXPORT int LLVMICmpEQ(unsigned numbits, integerPart *pa, integerPart *pr);
-DLLEXPORT int LLVMICmpNE(unsigned numbits, integerPart *pa, integerPart *pb);
-DLLEXPORT int LLVMICmpSLT(unsigned numbits, integerPart *pa, integerPart *pb);
-DLLEXPORT int LLVMICmpULT(unsigned numbits, integerPart *pa, integerPart *pb);
-DLLEXPORT int LLVMICmpSLE(unsigned numbits, integerPart *pa, integerPart *pb);
-DLLEXPORT int LLVMICmpULE(unsigned numbits, integerPart *pa, integerPart *pb);
+JL_DLLEXPORT int LLVMICmpEQ(unsigned numbits, integerPart *pa, integerPart *pr);
+JL_DLLEXPORT int LLVMICmpNE(unsigned numbits, integerPart *pa, integerPart *pb);
+JL_DLLEXPORT int LLVMICmpSLT(unsigned numbits, integerPart *pa, integerPart *pb);
+JL_DLLEXPORT int LLVMICmpULT(unsigned numbits, integerPart *pa, integerPart *pb);
+JL_DLLEXPORT int LLVMICmpSLE(unsigned numbits, integerPart *pa, integerPart *pb);
+JL_DLLEXPORT int LLVMICmpULE(unsigned numbits, integerPart *pa, integerPart *pb);
 
-DLLEXPORT int LLVMAdd_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT int LLVMAdd_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT int LLVMSub_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT int LLVMSub_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT int LLVMMul_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT int LLVMMul_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT int LLVMAdd_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT int LLVMAdd_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT int LLVMSub_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT int LLVMSub_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT int LLVMMul_sov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT int LLVMMul_uov(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 
-DLLEXPORT unsigned LLVMCountPopulation(unsigned numbits, integerPart *pa);
-DLLEXPORT unsigned LLVMCountTrailingOnes(unsigned numbits, integerPart *pa);
-DLLEXPORT unsigned LLVMCountTrailingZeros(unsigned numbits, integerPart *pa);
-DLLEXPORT unsigned LLVMCountLeadingOnes(unsigned numbits, integerPart *pa);
-DLLEXPORT unsigned LLVMCountLeadingZeros(unsigned numbits, integerPart *pa);
+JL_DLLEXPORT unsigned LLVMCountPopulation(unsigned numbits, integerPart *pa);
+JL_DLLEXPORT unsigned LLVMCountTrailingOnes(unsigned numbits, integerPart *pa);
+JL_DLLEXPORT unsigned LLVMCountTrailingZeros(unsigned numbits, integerPart *pa);
+JL_DLLEXPORT unsigned LLVMCountLeadingOnes(unsigned numbits, integerPart *pa);
+JL_DLLEXPORT unsigned LLVMCountLeadingZeros(unsigned numbits, integerPart *pa);
 
-DLLEXPORT void LLVMFPtoSI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-DLLEXPORT void LLVMFPtoUI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-DLLEXPORT void LLVMSItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-DLLEXPORT void LLVMUItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-DLLEXPORT void LLVMSExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-DLLEXPORT void LLVMZExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-DLLEXPORT void LLVMTrunc(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+JL_DLLEXPORT void LLVMFPtoSI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+JL_DLLEXPORT void LLVMFPtoUI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+JL_DLLEXPORT void LLVMSItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+JL_DLLEXPORT void LLVMUItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+JL_DLLEXPORT void LLVMSExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+JL_DLLEXPORT void LLVMZExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+JL_DLLEXPORT void LLVMTrunc(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
 
-DLLEXPORT int LLVMFPtoSI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-DLLEXPORT int LLVMFPtoUI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+JL_DLLEXPORT int LLVMFPtoSI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+JL_DLLEXPORT int LLVMFPtoUI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
 
-DLLEXPORT void jl_LLVMSMod(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
-DLLEXPORT void jl_LLVMFlipSign(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void jl_LLVMSMod(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
+JL_DLLEXPORT void jl_LLVMFlipSign(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 
-DLLEXPORT unsigned countTrailingZeros_8(uint8_t Val);
-DLLEXPORT unsigned countTrailingZeros_16(uint16_t Val);
-DLLEXPORT unsigned countTrailingZeros_32(uint32_t Val);
-DLLEXPORT unsigned countTrailingZeros_64(uint64_t Val);
+JL_DLLEXPORT unsigned countTrailingZeros_8(uint8_t Val);
+JL_DLLEXPORT unsigned countTrailingZeros_16(uint16_t Val);
+JL_DLLEXPORT unsigned countTrailingZeros_32(uint32_t Val);
+JL_DLLEXPORT unsigned countTrailingZeros_64(uint64_t Val);
 
 //uint8_t getSwappedBytes_8(uint8_t Value); // no-op
 //uint16_t getSwappedBytes_16(uint16_t Value);

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -14,8 +14,8 @@
 extern "C" {
 #endif
 
-DLLEXPORT jl_value_t *jl_true;
-DLLEXPORT jl_value_t *jl_false;
+JL_DLLEXPORT jl_value_t *jl_true;
+JL_DLLEXPORT jl_value_t *jl_false;
 
 jl_tvar_t     *jl_typetype_tvar;
 jl_datatype_t *jl_typetype_type;
@@ -66,11 +66,11 @@ jl_value_t *jl_stackovf_exception;
 #ifdef SEGV_EXCEPTION
 jl_value_t *jl_segv_exception;
 #endif
-DLLEXPORT jl_value_t *jl_diverror_exception;
-DLLEXPORT jl_value_t *jl_domain_exception;
-DLLEXPORT jl_value_t *jl_overflow_exception;
-DLLEXPORT jl_value_t *jl_inexact_exception;
-DLLEXPORT jl_value_t *jl_undefref_exception;
+JL_DLLEXPORT jl_value_t *jl_diverror_exception;
+JL_DLLEXPORT jl_value_t *jl_domain_exception;
+JL_DLLEXPORT jl_value_t *jl_overflow_exception;
+JL_DLLEXPORT jl_value_t *jl_inexact_exception;
+JL_DLLEXPORT jl_value_t *jl_undefref_exception;
 jl_value_t *jl_interrupt_exception;
 jl_datatype_t *jl_boundserror_type;
 jl_value_t *jl_memory_exception;
@@ -153,7 +153,7 @@ static jl_value_t *jl_new_bits_internal(jl_value_t *dt, void *data, size_t *len)
     return v;
 }
 
-DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *bt, void *data)
+JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *bt, void *data)
 {
     size_t len = 0;
     return jl_new_bits_internal(bt, data, &len);
@@ -173,7 +173,7 @@ void jl_assign_bits(void *dest, jl_value_t *bits)
     }
 }
 
-DLLEXPORT int jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err)
+JL_DLLEXPORT int jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err)
 {
     jl_svec_t *fn = t->name->names;
     for(size_t i=0; i < jl_svec_len(fn); i++) {
@@ -187,7 +187,7 @@ DLLEXPORT int jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err)
     return -1;
 }
 
-DLLEXPORT jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
+JL_DLLEXPORT jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
     assert(i < jl_datatype_nfields(st));
@@ -198,7 +198,7 @@ DLLEXPORT jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
     return jl_new_bits(jl_field_type(st,i), (char*)v + offs);
 }
 
-DLLEXPORT jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i)
+JL_DLLEXPORT jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
     if (i >= jl_datatype_nfields(st))
@@ -213,7 +213,7 @@ DLLEXPORT jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i)
     return jl_new_bits(jl_field_type(st,i), (char*)v + offs);
 }
 
-DLLEXPORT void jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
+JL_DLLEXPORT void jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
     size_t offs = jl_field_offset(st,i);
@@ -226,7 +226,7 @@ DLLEXPORT void jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
     }
 }
 
-DLLEXPORT int jl_field_isdefined(jl_value_t *v, size_t i)
+JL_DLLEXPORT int jl_field_isdefined(jl_value_t *v, size_t i)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
     size_t offs = jl_field_offset(st,i);
@@ -236,7 +236,7 @@ DLLEXPORT int jl_field_isdefined(jl_value_t *v, size_t i)
     return 1;
 }
 
-DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...)
+JL_DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...)
 {
     if (type->instance != NULL) return type->instance;
     va_list args;
@@ -250,7 +250,8 @@ DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...)
     return jv;
 }
 
-DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args, uint32_t na)
+JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
+                                        uint32_t na)
 {
     if (type->instance != NULL) return type->instance;
     size_t nf = jl_datatype_nfields(type);
@@ -266,7 +267,7 @@ DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args, uin
     return jv;
 }
 
-DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type)
+JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type)
 {
     if (type->instance != NULL) return type->instance;
     jl_value_t *jv = newstruct(type);
@@ -275,8 +276,8 @@ DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type)
     return jv;
 }
 
-DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t fptr, jl_value_t *env,
-                                        jl_lambda_info_t *linfo)
+JL_DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t fptr, jl_value_t *env,
+                                           jl_lambda_info_t *linfo)
 {
     jl_function_t *f = (jl_function_t*)jl_gc_alloc_3w(); assert(NWORDS(sizeof(jl_function_t))==3);
     jl_set_typeof(f, jl_function_type);
@@ -286,13 +287,14 @@ DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t fptr, jl_value_t *env,
     return f;
 }
 
-DLLEXPORT jl_fptr_t jl_linfo_fptr(jl_lambda_info_t *linfo)
+JL_DLLEXPORT jl_fptr_t jl_linfo_fptr(jl_lambda_info_t *linfo)
 {
     return linfo->fptr;
 }
 
-DLLEXPORT
-jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams, jl_module_t *ctx)
+JL_DLLEXPORT
+jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams,
+                                     jl_module_t *ctx)
 {
     jl_lambda_info_t *li =
         (jl_lambda_info_t*)newobj((jl_value_t*)jl_lambda_info_type,
@@ -441,30 +443,30 @@ static jl_sym_t *_jl_symbol(const char *str, size_t len)
     return *pnode;
 }
 
-DLLEXPORT jl_sym_t *jl_symbol(const char *str)
+JL_DLLEXPORT jl_sym_t *jl_symbol(const char *str)
 {
     return _jl_symbol(str, strlen(str));
 }
 
-DLLEXPORT jl_sym_t *jl_symbol_lookup(const char *str)
+JL_DLLEXPORT jl_sym_t *jl_symbol_lookup(const char *str)
 {
     return *symtab_lookup(&symtab, str, strlen(str), NULL);
 }
 
-DLLEXPORT jl_sym_t *jl_symbol_n(const char *str, int32_t len)
+JL_DLLEXPORT jl_sym_t *jl_symbol_n(const char *str, int32_t len)
 {
     if (memchr(str, 0, len))
         jl_exceptionf(jl_argumenterror_type, "Symbol name may not contain \\0");
     return _jl_symbol(str, len);
 }
 
-DLLEXPORT jl_sym_t *jl_get_root_symbol(void) { return symtab; }
+JL_DLLEXPORT jl_sym_t *jl_get_root_symbol(void) { return symtab; }
 
 static uint32_t gs_ctr = 0;  // TODO: per-thread
 uint32_t jl_get_gs_ctr(void) { return gs_ctr; }
 void jl_set_gs_ctr(uint32_t ctr) { gs_ctr = ctr; }
 
-DLLEXPORT jl_sym_t *jl_gensym(void)
+JL_DLLEXPORT jl_sym_t *jl_gensym(void)
 {
     static char name[16];
     char *n;
@@ -474,7 +476,7 @@ DLLEXPORT jl_sym_t *jl_gensym(void)
     return jl_symbol(n);
 }
 
-DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len)
+JL_DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len)
 {
     static char gs_name[14];
     if (symbol_nbytes(len) >= SYM_POOL_SIZE)
@@ -496,7 +498,7 @@ DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len)
 
 // allocating types -----------------------------------------------------------
 
-DLLEXPORT jl_typename_t *jl_new_typename(jl_sym_t *name)
+JL_DLLEXPORT jl_typename_t *jl_new_typename(jl_sym_t *name)
 {
     jl_typename_t *tn=(jl_typename_t*)newobj((jl_value_t*)jl_typename_type, NWORDS(sizeof(jl_typename_t)));
     tn->name = name;
@@ -517,8 +519,8 @@ jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_datatype_t *super,
     return dt;
 }
 
-DLLEXPORT jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields,
-                                                       int8_t fielddesc_type)
+JL_DLLEXPORT jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields,
+                                                          int8_t fielddesc_type)
 {
     // fielddesc_type is specified manually for builtin types
     // and is (will be) calculated automatically for user defined types.
@@ -589,11 +591,11 @@ void jl_compute_field_offsets(jl_datatype_t *st)
 
 extern int jl_boot_file_loaded;
 
-DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
-                                         jl_svec_t *parameters,
-                                         jl_svec_t *fnames, jl_svec_t *ftypes,
-                                         int abstract, int mutabl,
-                                         int ninitialized)
+JL_DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
+                                            jl_svec_t *parameters,
+                                            jl_svec_t *fnames, jl_svec_t *ftypes,
+                                            int abstract, int mutabl,
+                                            int ninitialized)
 {
     jl_datatype_t *t=NULL;
     jl_typename_t *tn=NULL;
@@ -660,8 +662,9 @@ DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
     return t;
 }
 
-DLLEXPORT jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
-                                         jl_svec_t *parameters, size_t nbits)
+JL_DLLEXPORT jl_datatype_t *jl_new_bitstype(jl_value_t *name,
+                                            jl_datatype_t *super,
+                                            jl_svec_t *parameters, size_t nbits)
 {
     jl_datatype_t *bt = jl_new_datatype((jl_sym_t*)name, super, parameters,
                                         jl_emptysvec, jl_emptysvec, 0, 0, 0);
@@ -686,7 +689,7 @@ jl_typector_t *jl_new_type_ctor(jl_svec_t *params, jl_value_t *body)
 // bits constructors ----------------------------------------------------------
 
 #define BOXN_FUNC(nb,nw)                                                \
-    DLLEXPORT jl_value_t *jl_box##nb(jl_datatype_t *t, int##nb##_t x)   \
+    JL_DLLEXPORT jl_value_t *jl_box##nb(jl_datatype_t *t, int##nb##_t x) \
     {                                                                   \
         assert(jl_isbits(t));                                           \
         assert(jl_datatype_size(t) == sizeof(x));                       \
@@ -705,7 +708,7 @@ BOXN_FUNC(64, 2)
 #endif
 
 #define UNBOX_FUNC(j_type,c_type)                                       \
-    DLLEXPORT c_type jl_unbox_##j_type(jl_value_t *v)                   \
+    JL_DLLEXPORT c_type jl_unbox_##j_type(jl_value_t *v)                \
     {                                                                   \
         assert(jl_is_bitstype(jl_typeof(v)));                           \
         assert(jl_datatype_size(jl_typeof(v)) == sizeof(c_type));       \
@@ -726,7 +729,7 @@ UNBOX_FUNC(voidpointer, void*)
 UNBOX_FUNC(gensym, ssize_t)
 
 #define BOX_FUNC(typ,c_type,pfx,nw)                         \
-    DLLEXPORT jl_value_t *pfx##_##typ(c_type x)             \
+    JL_DLLEXPORT jl_value_t *pfx##_##typ(c_type x)          \
     {                                                       \
         jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w(); \
         jl_set_typeof(v, jl_##typ##_type);                  \
@@ -745,7 +748,7 @@ BOX_FUNC(float64, double, jl_box, 2)
 
 #define SIBOX_FUNC(typ,c_type,nw)                             \
     static jl_value_t *boxed_##typ##_cache[NBOX_C];           \
-    DLLEXPORT jl_value_t *jl_box_##typ(c_type x)              \
+    JL_DLLEXPORT jl_value_t *jl_box_##typ(c_type x)           \
     {                                                         \
         c_type idx = x+NBOX_C/2;                              \
         if ((u##c_type)idx < (u##c_type)NBOX_C)               \
@@ -757,7 +760,7 @@ BOX_FUNC(float64, double, jl_box, 2)
     }
 #define UIBOX_FUNC(typ,c_type,nw)                               \
     static jl_value_t *boxed_##typ##_cache[NBOX_C];             \
-    DLLEXPORT jl_value_t *jl_box_##typ(c_type x)                \
+    JL_DLLEXPORT jl_value_t *jl_box_##typ(c_type x)             \
     {                                                           \
         if (x < NBOX_C)                                         \
             return boxed_##typ##_cache[x];                      \
@@ -847,7 +850,7 @@ jl_value_t *jl_box_bool(int8_t x)
     return jl_false;
 }
 
-DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v)
+JL_DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v)
 {
     jl_value_t *box = (jl_value_t*)jl_gc_alloc_1w();
     jl_set_typeof(box, jl_box_any_type);

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -153,7 +153,7 @@ static jl_value_t *jl_new_bits_internal(jl_value_t *dt, void *data, size_t *len)
     return v;
 }
 
-jl_value_t *jl_new_bits(jl_value_t *bt, void *data)
+DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *bt, void *data)
 {
     size_t len = 0;
     return jl_new_bits_internal(bt, data, &len);
@@ -173,7 +173,7 @@ void jl_assign_bits(void *dest, jl_value_t *bits)
     }
 }
 
-int jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err)
+DLLEXPORT int jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err)
 {
     jl_svec_t *fn = t->name->names;
     for(size_t i=0; i < jl_svec_len(fn); i++) {
@@ -187,7 +187,7 @@ int jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err)
     return -1;
 }
 
-jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
+DLLEXPORT jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
     assert(i < jl_datatype_nfields(st));
@@ -198,7 +198,7 @@ jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
     return jl_new_bits(jl_field_type(st,i), (char*)v + offs);
 }
 
-jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i)
+DLLEXPORT jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
     if (i >= jl_datatype_nfields(st))
@@ -213,7 +213,7 @@ jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i)
     return jl_new_bits(jl_field_type(st,i), (char*)v + offs);
 }
 
-void jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
+DLLEXPORT void jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
     size_t offs = jl_field_offset(st,i);
@@ -226,7 +226,7 @@ void jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs)
     }
 }
 
-int jl_field_isdefined(jl_value_t *v, size_t i)
+DLLEXPORT int jl_field_isdefined(jl_value_t *v, size_t i)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
     size_t offs = jl_field_offset(st,i);
@@ -441,12 +441,12 @@ static jl_sym_t *_jl_symbol(const char *str, size_t len)
     return *pnode;
 }
 
-jl_sym_t *jl_symbol(const char *str)
+DLLEXPORT jl_sym_t *jl_symbol(const char *str)
 {
     return _jl_symbol(str, strlen(str));
 }
 
-jl_sym_t *jl_symbol_lookup(const char *str)
+DLLEXPORT jl_sym_t *jl_symbol_lookup(const char *str)
 {
     return *symtab_lookup(&symtab, str, strlen(str), NULL);
 }
@@ -496,7 +496,7 @@ DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len)
 
 // allocating types -----------------------------------------------------------
 
-jl_typename_t *jl_new_typename(jl_sym_t *name)
+DLLEXPORT jl_typename_t *jl_new_typename(jl_sym_t *name)
 {
     jl_typename_t *tn=(jl_typename_t*)newobj((jl_value_t*)jl_typename_type, NWORDS(sizeof(jl_typename_t)));
     tn->name = name;
@@ -517,8 +517,8 @@ jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_datatype_t *super,
     return dt;
 }
 
-jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields,
-                                             int8_t fielddesc_type)
+DLLEXPORT jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields,
+                                                       int8_t fielddesc_type)
 {
     // fielddesc_type is specified manually for builtin types
     // and is (will be) calculated automatically for user defined types.
@@ -589,10 +589,11 @@ void jl_compute_field_offsets(jl_datatype_t *st)
 
 extern int jl_boot_file_loaded;
 
-jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
-                               jl_svec_t *parameters,
-                               jl_svec_t *fnames, jl_svec_t *ftypes,
-                               int abstract, int mutabl, int ninitialized)
+DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
+                                         jl_svec_t *parameters,
+                                         jl_svec_t *fnames, jl_svec_t *ftypes,
+                                         int abstract, int mutabl,
+                                         int ninitialized)
 {
     jl_datatype_t *t=NULL;
     jl_typename_t *tn=NULL;
@@ -659,8 +660,8 @@ jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
     return t;
 }
 
-jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
-                               jl_svec_t *parameters, size_t nbits)
+DLLEXPORT jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
+                                         jl_svec_t *parameters, size_t nbits)
 {
     jl_datatype_t *bt = jl_new_datatype((jl_sym_t*)name, super, parameters,
                                         jl_emptysvec, jl_emptysvec, 0, 0, 0);
@@ -684,16 +685,16 @@ jl_typector_t *jl_new_type_ctor(jl_svec_t *params, jl_value_t *body)
 
 // bits constructors ----------------------------------------------------------
 
-#define BOXN_FUNC(nb,nw)                                       \
-jl_value_t *jl_box##nb(jl_datatype_t *t, int##nb##_t x)        \
-{                                                              \
-    assert(jl_isbits(t));                                      \
-    assert(jl_datatype_size(t) == sizeof(x));                  \
-    jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w();              \
-    jl_set_typeof(v, t);                                       \
-    *(int##nb##_t*)jl_data_ptr(v) = x;                         \
-    return v;                                                  \
-}
+#define BOXN_FUNC(nb,nw)                                                \
+    DLLEXPORT jl_value_t *jl_box##nb(jl_datatype_t *t, int##nb##_t x)   \
+    {                                                                   \
+        assert(jl_isbits(t));                                           \
+        assert(jl_datatype_size(t) == sizeof(x));                       \
+        jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w();             \
+        jl_set_typeof(v, t);                                            \
+        *(int##nb##_t*)jl_data_ptr(v) = x;                              \
+        return v;                                                       \
+    }
 BOXN_FUNC(8,  1)
 BOXN_FUNC(16, 1)
 BOXN_FUNC(32, 1)
@@ -704,12 +705,12 @@ BOXN_FUNC(64, 2)
 #endif
 
 #define UNBOX_FUNC(j_type,c_type)                                       \
-c_type jl_unbox_##j_type(jl_value_t *v)                                 \
-{                                                                       \
-    assert(jl_is_bitstype(jl_typeof(v)));                               \
-    assert(jl_datatype_size(jl_typeof(v)) == sizeof(c_type));           \
-    return *(c_type*)jl_data_ptr(v);                                    \
-}
+    DLLEXPORT c_type jl_unbox_##j_type(jl_value_t *v)                   \
+    {                                                                   \
+        assert(jl_is_bitstype(jl_typeof(v)));                           \
+        assert(jl_datatype_size(jl_typeof(v)) == sizeof(c_type));       \
+        return *(c_type*)jl_data_ptr(v);                                \
+    }
 UNBOX_FUNC(int8,   int8_t)
 UNBOX_FUNC(uint8,  uint8_t)
 UNBOX_FUNC(int16,  int16_t)
@@ -724,14 +725,14 @@ UNBOX_FUNC(float64, double)
 UNBOX_FUNC(voidpointer, void*)
 UNBOX_FUNC(gensym, ssize_t)
 
-#define BOX_FUNC(typ,c_type,pfx,nw)               \
-jl_value_t *pfx##_##typ(c_type x)                 \
-{                                                 \
-    jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w(); \
-    jl_set_typeof(v, jl_##typ##_type);            \
-    *(c_type*)jl_data_ptr(v) = x;                 \
-    return v;                                     \
-}
+#define BOX_FUNC(typ,c_type,pfx,nw)                         \
+    DLLEXPORT jl_value_t *pfx##_##typ(c_type x)             \
+    {                                                       \
+        jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w(); \
+        jl_set_typeof(v, jl_##typ##_type);                  \
+        *(c_type*)jl_data_ptr(v) = x;                       \
+        return v;                                           \
+    }
 BOX_FUNC(float32, float,  jl_box, 1)
 BOX_FUNC(voidpointer, void*,  jl_box, 1)
 #ifdef _P64
@@ -742,29 +743,29 @@ BOX_FUNC(float64, double, jl_box, 2)
 
 #define NBOX_C 1024
 
-#define SIBOX_FUNC(typ,c_type,nw)                       \
-static jl_value_t *boxed_##typ##_cache[NBOX_C];         \
-jl_value_t *jl_box_##typ(c_type x)                      \
-{                                                       \
-    c_type idx = x+NBOX_C/2;                            \
-    if ((u##c_type)idx < (u##c_type)NBOX_C)             \
-        return boxed_##typ##_cache[idx];                \
-    jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w();       \
-    jl_set_typeof(v, jl_##typ##_type);                  \
-    *(c_type*)jl_data_ptr(v) = x;                       \
-    return v;                                           \
-}
-#define UIBOX_FUNC(typ,c_type,nw)                  \
-static jl_value_t *boxed_##typ##_cache[NBOX_C];    \
-jl_value_t *jl_box_##typ(c_type x)                 \
-{                                                  \
-    if (x < NBOX_C)                                \
-        return boxed_##typ##_cache[x];             \
-    jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w();  \
-    jl_set_typeof(v, jl_##typ##_type);             \
-    *(c_type*)jl_data_ptr(v) = x;                  \
-    return v;                                      \
-}
+#define SIBOX_FUNC(typ,c_type,nw)                             \
+    static jl_value_t *boxed_##typ##_cache[NBOX_C];           \
+    DLLEXPORT jl_value_t *jl_box_##typ(c_type x)              \
+    {                                                         \
+        c_type idx = x+NBOX_C/2;                              \
+        if ((u##c_type)idx < (u##c_type)NBOX_C)               \
+            return boxed_##typ##_cache[idx];                  \
+        jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w();   \
+        jl_set_typeof(v, jl_##typ##_type);                    \
+        *(c_type*)jl_data_ptr(v) = x;                         \
+        return v;                                             \
+    }
+#define UIBOX_FUNC(typ,c_type,nw)                               \
+    static jl_value_t *boxed_##typ##_cache[NBOX_C];             \
+    DLLEXPORT jl_value_t *jl_box_##typ(c_type x)                \
+    {                                                           \
+        if (x < NBOX_C)                                         \
+            return boxed_##typ##_cache[x];                      \
+        jl_value_t *v = (jl_value_t*)jl_gc_alloc_##nw##w();     \
+        jl_set_typeof(v, jl_##typ##_type);                      \
+        *(c_type*)jl_data_ptr(v) = x;                           \
+        return v;                                               \
+    }
 SIBOX_FUNC(int16,  int16_t, 1)
 SIBOX_FUNC(int32,  int32_t, 1)
 UIBOX_FUNC(uint16, uint16_t, 1)

--- a/src/anticodegen.c
+++ b/src/anticodegen.c
@@ -18,11 +18,11 @@ void jl_generate_fptr(jl_function_t *f) {
     f->fptr = li->fptr;
 }
 
-DLLEXPORT void jl_clear_malloc_data(void) UNAVAILABLE
-DLLEXPORT void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name) UNAVAILABLE
-DLLEXPORT void *jl_function_ptr(jl_function_t *f, jl_value_t *rt, jl_value_t *argt) UNAVAILABLE
-DLLEXPORT const jl_value_t *jl_dump_function_asm(void *f, int raw_mc) UNAVAILABLE
-DLLEXPORT const jl_value_t *jl_dump_function_ir(void *f, uint8_t strip_ir_metadata, uint8_t dump_module) UNAVAILABLE
+JL_DLLEXPORT void jl_clear_malloc_data(void) UNAVAILABLE
+JL_DLLEXPORT void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name) UNAVAILABLE
+JL_DLLEXPORT void *jl_function_ptr(jl_function_t *f, jl_value_t *rt, jl_value_t *argt) UNAVAILABLE
+JL_DLLEXPORT const jl_value_t *jl_dump_function_asm(void *f, int raw_mc) UNAVAILABLE
+JL_DLLEXPORT const jl_value_t *jl_dump_function_ir(void *f, uint8_t strip_ir_metadata, uint8_t dump_module) UNAVAILABLE
 
 void jl_init_codegen(void) { }
 void jl_compile_linfo(jl_lambda_info_t *li) { }

--- a/src/array.c
+++ b/src/array.c
@@ -145,8 +145,8 @@ jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, 
     return _new_array_(atype, ndims, dims, isunboxed, elsz);
 }
 
-DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
-                                       jl_value_t *dims)
+JL_DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
+                                          jl_value_t *dims)
 {
     size_t i;
     jl_array_t *a;
@@ -215,8 +215,8 @@ DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
 }
 
 // own_buffer != 0 iff GC should call free() on this pointer eventually
-DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
-                                         size_t nel, int own_buffer)
+JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
+                                            size_t nel, int own_buffer)
 {
     size_t elsz;
     jl_array_t *a;
@@ -257,8 +257,8 @@ DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
     return a;
 }
 
-DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
-                                      jl_value_t *dims, int own_buffer)
+JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
+                                         jl_value_t *dims, int own_buffer)
 {
     size_t i, elsz, nel=1;
     jl_array_t *a;
@@ -319,7 +319,7 @@ DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
     return a;
 }
 
-DLLEXPORT jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims)
+JL_DLLEXPORT jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims)
 {
     size_t ndims = jl_nfields(dims);
     size_t *adims = (size_t*)alloca(ndims*sizeof(size_t));
@@ -329,32 +329,33 @@ DLLEXPORT jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims)
     return _new_array(atype, ndims, adims);
 }
 
-DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr)
+JL_DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr)
 {
     return _new_array(atype, 1, &nr);
 }
 
-DLLEXPORT jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc)
+JL_DLLEXPORT jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr,
+                                           size_t nc)
 {
     size_t d[2] = {nr, nc};
     return _new_array(atype, 2, &d[0]);
 }
 
-DLLEXPORT jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr,
-                                        size_t nc, size_t z)
+JL_DLLEXPORT jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr,
+                                           size_t nc, size_t z)
 {
     size_t d[3] = {nr, nc, z};
     return _new_array(atype, 3, &d[0]);
 }
 
-DLLEXPORT jl_array_t *jl_pchar_to_array(const char *str, size_t len)
+JL_DLLEXPORT jl_array_t *jl_pchar_to_array(const char *str, size_t len)
 {
     jl_array_t *a = jl_alloc_array_1d(jl_array_uint8_type, len);
     memcpy(a->data, str, len);
     return a;
 }
 
-DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a)
+JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a)
 {
     if (!jl_typeis(a, jl_array_uint8_type))
         jl_type_error("jl_array_to_string", (jl_value_t*)jl_array_uint8_type, (jl_value_t*)a);
@@ -366,7 +367,7 @@ DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a)
     return s;
 }
 
-DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len)
+JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len)
 {
     jl_array_t *a = jl_pchar_to_array(str, len);
     JL_GC_PUSH1(&a);
@@ -375,12 +376,12 @@ DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len)
     return s;
 }
 
-DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str)
+JL_DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str)
 {
     return jl_pchar_to_string(str, strlen(str));
 }
 
-DLLEXPORT jl_array_t *jl_alloc_cell_1d(size_t n)
+JL_DLLEXPORT jl_array_t *jl_alloc_cell_1d(size_t n)
 {
     return jl_alloc_array_1d(jl_array_any_type, n);
 }
@@ -397,7 +398,7 @@ jl_value_t *jl_apply_array_type(jl_datatype_t *type, size_t dim)
 // array primitives -----------------------------------------------------------
 
 #ifndef STORE_ARRAY_LEN
-DLLEXPORT size_t jl_array_len_(jl_array_t *a)
+JL_DLLEXPORT size_t jl_array_len_(jl_array_t *a)
 {
     size_t l = 1;
     for(size_t i=0; i < jl_array_ndims(a); i++)
@@ -421,7 +422,7 @@ JL_CALLABLE(jl_f_arraysize)
     return jl_box_long((&a->nrows)[dno-1]);
 }
 
-DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i)
+JL_DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i)
 {
     assert(i < jl_array_len(a));
     jl_value_t *elt;
@@ -470,7 +471,7 @@ JL_CALLABLE(jl_f_arrayref)
     return jl_arrayref(a, i);
 }
 
-DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i)
+JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i)
 {
     if (a->ptrarray)
         return ((jl_value_t**)jl_array_data(a))[i] != NULL;
@@ -506,7 +507,7 @@ int jl_array_isdefined(jl_value_t **args0, int nargs)
     return 1;
 }
 
-DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *rhs, size_t i)
+JL_DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *rhs, size_t i)
 {
     assert(i < jl_array_len(a));
     jl_value_t *el_type = jl_tparam0(jl_typeof(a));
@@ -537,7 +538,7 @@ JL_CALLABLE(jl_f_arrayset)
     return args[0];
 }
 
-DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i)
+JL_DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i)
 {
     if (i >= jl_array_len(a))
         jl_bounds_error_int((jl_value_t*)a, i+1);
@@ -623,7 +624,7 @@ static size_t limit_overallocation(jl_array_t *a, size_t alen, size_t newlen, si
     return newlen;
 }
 
-DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc)
+JL_DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc)
 {
     if (a->isshared && a->how!=3) jl_error("cannot resize array with shared data");
     // optimized for the case of only growing and shrinking at the end
@@ -642,7 +643,7 @@ DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc)
     a->nrows += inc;
 }
 
-DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec)
+JL_DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec)
 {
     if (dec == 0) return;
     if (dec > a->nrows)
@@ -662,7 +663,7 @@ DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec)
     a->nrows -= dec;
 }
 
-DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz)
+JL_DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz)
 {
     if (sz <= jl_array_len(a))
         return;
@@ -674,7 +675,7 @@ DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz)
     a->nrows -= inc;
 }
 
-DLLEXPORT void jl_array_grow_beg(jl_array_t *a, size_t inc)
+JL_DLLEXPORT void jl_array_grow_beg(jl_array_t *a, size_t inc)
 {
     if (inc == 0) return;
     // designed to handle the case of growing and shrinking at both ends
@@ -717,7 +718,7 @@ DLLEXPORT void jl_array_grow_beg(jl_array_t *a, size_t inc)
     a->nrows += inc;
 }
 
-DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec)
+JL_DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec)
 {
     if (dec == 0) return;
     if (dec > a->nrows)
@@ -754,14 +755,14 @@ DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec)
     a->offset = newoffs;
 }
 
-DLLEXPORT void jl_cell_1d_push(jl_array_t *a, jl_value_t *item)
+JL_DLLEXPORT void jl_cell_1d_push(jl_array_t *a, jl_value_t *item)
 {
     assert(jl_typeis(a, jl_array_any_type));
     jl_array_grow_end(a, 1);
     jl_cellset(a, jl_array_dim(a,0)-1, item);
 }
 
-DLLEXPORT void jl_cell_1d_push2(jl_array_t *a, jl_value_t *b, jl_value_t *c)
+JL_DLLEXPORT void jl_cell_1d_push2(jl_array_t *a, jl_value_t *b, jl_value_t *c)
 {
     assert(jl_typeis(a, jl_array_any_type));
     jl_array_grow_end(a, 2);

--- a/src/array.c
+++ b/src/array.c
@@ -145,7 +145,8 @@ jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, 
     return _new_array_(atype, ndims, dims, isunboxed, elsz);
 }
 
-jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data, jl_value_t *dims)
+DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
+                                       jl_value_t *dims)
 {
     size_t i;
     jl_array_t *a;
@@ -214,8 +215,8 @@ jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data, jl_value_t *di
 }
 
 // own_buffer != 0 iff GC should call free() on this pointer eventually
-jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data, size_t nel,
-                               int own_buffer)
+DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
+                                         size_t nel, int own_buffer)
 {
     size_t elsz;
     jl_array_t *a;
@@ -256,8 +257,8 @@ jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data, size_t nel,
     return a;
 }
 
-jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data, jl_value_t *dims,
-                            int own_buffer)
+DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
+                                      jl_value_t *dims, int own_buffer)
 {
     size_t i, elsz, nel=1;
     jl_array_t *a;
@@ -318,7 +319,7 @@ jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data, jl_value_t *dims,
     return a;
 }
 
-jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims)
+DLLEXPORT jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims)
 {
     size_t ndims = jl_nfields(dims);
     size_t *adims = (size_t*)alloca(ndims*sizeof(size_t));
@@ -328,31 +329,32 @@ jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims)
     return _new_array(atype, ndims, adims);
 }
 
-jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr)
+DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr)
 {
     return _new_array(atype, 1, &nr);
 }
 
-jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc)
+DLLEXPORT jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc)
 {
     size_t d[2] = {nr, nc};
     return _new_array(atype, 2, &d[0]);
 }
 
-jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr, size_t nc, size_t z)
+DLLEXPORT jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr,
+                                        size_t nc, size_t z)
 {
     size_t d[3] = {nr, nc, z};
     return _new_array(atype, 3, &d[0]);
 }
 
-jl_array_t *jl_pchar_to_array(const char *str, size_t len)
+DLLEXPORT jl_array_t *jl_pchar_to_array(const char *str, size_t len)
 {
     jl_array_t *a = jl_alloc_array_1d(jl_array_uint8_type, len);
     memcpy(a->data, str, len);
     return a;
 }
 
-jl_value_t *jl_array_to_string(jl_array_t *a)
+DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a)
 {
     if (!jl_typeis(a, jl_array_uint8_type))
         jl_type_error("jl_array_to_string", (jl_value_t*)jl_array_uint8_type, (jl_value_t*)a);
@@ -364,7 +366,7 @@ jl_value_t *jl_array_to_string(jl_array_t *a)
     return s;
 }
 
-jl_value_t *jl_pchar_to_string(const char *str, size_t len)
+DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len)
 {
     jl_array_t *a = jl_pchar_to_array(str, len);
     JL_GC_PUSH1(&a);
@@ -373,12 +375,12 @@ jl_value_t *jl_pchar_to_string(const char *str, size_t len)
     return s;
 }
 
-jl_value_t *jl_cstr_to_string(const char *str)
+DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str)
 {
     return jl_pchar_to_string(str, strlen(str));
 }
 
-jl_array_t *jl_alloc_cell_1d(size_t n)
+DLLEXPORT jl_array_t *jl_alloc_cell_1d(size_t n)
 {
     return jl_alloc_array_1d(jl_array_any_type, n);
 }
@@ -419,7 +421,7 @@ JL_CALLABLE(jl_f_arraysize)
     return jl_box_long((&a->nrows)[dno-1]);
 }
 
-jl_value_t *jl_arrayref(jl_array_t *a, size_t i)
+DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i)
 {
     assert(i < jl_array_len(a));
     jl_value_t *elt;
@@ -504,7 +506,7 @@ int jl_array_isdefined(jl_value_t **args0, int nargs)
     return 1;
 }
 
-void jl_arrayset(jl_array_t *a, jl_value_t *rhs, size_t i)
+DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *rhs, size_t i)
 {
     assert(i < jl_array_len(a));
     jl_value_t *el_type = jl_tparam0(jl_typeof(a));
@@ -535,7 +537,7 @@ JL_CALLABLE(jl_f_arrayset)
     return args[0];
 }
 
-void jl_arrayunset(jl_array_t *a, size_t i)
+DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i)
 {
     if (i >= jl_array_len(a))
         jl_bounds_error_int((jl_value_t*)a, i+1);
@@ -621,7 +623,7 @@ static size_t limit_overallocation(jl_array_t *a, size_t alen, size_t newlen, si
     return newlen;
 }
 
-void jl_array_grow_end(jl_array_t *a, size_t inc)
+DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc)
 {
     if (a->isshared && a->how!=3) jl_error("cannot resize array with shared data");
     // optimized for the case of only growing and shrinking at the end
@@ -640,7 +642,7 @@ void jl_array_grow_end(jl_array_t *a, size_t inc)
     a->nrows += inc;
 }
 
-void jl_array_del_end(jl_array_t *a, size_t dec)
+DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec)
 {
     if (dec == 0) return;
     if (dec > a->nrows)
@@ -660,7 +662,7 @@ void jl_array_del_end(jl_array_t *a, size_t dec)
     a->nrows -= dec;
 }
 
-void jl_array_sizehint(jl_array_t *a, size_t sz)
+DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz)
 {
     if (sz <= jl_array_len(a))
         return;
@@ -672,7 +674,7 @@ void jl_array_sizehint(jl_array_t *a, size_t sz)
     a->nrows -= inc;
 }
 
-void jl_array_grow_beg(jl_array_t *a, size_t inc)
+DLLEXPORT void jl_array_grow_beg(jl_array_t *a, size_t inc)
 {
     if (inc == 0) return;
     // designed to handle the case of growing and shrinking at both ends
@@ -715,7 +717,7 @@ void jl_array_grow_beg(jl_array_t *a, size_t inc)
     a->nrows += inc;
 }
 
-void jl_array_del_beg(jl_array_t *a, size_t dec)
+DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec)
 {
     if (dec == 0) return;
     if (dec > a->nrows)

--- a/src/ast.c
+++ b/src/ast.c
@@ -115,7 +115,6 @@ static builtinspec_t julia_flisp_ast_ext[] = {
     { NULL, NULL }
 };
 
-extern int jl_parse_depwarn(int warn);
 extern int jl_parse_deperror(int err);
 
 void jl_init_frontend(void)
@@ -592,8 +591,8 @@ jl_value_t *jl_parse_next(void)
     return scm_to_julia(c,0);
 }
 
-jl_value_t *jl_load_file_string(const char *text, size_t len,
-                                char *filename, size_t namelen)
+DLLEXPORT jl_value_t *jl_load_file_string(const char *text, size_t len,
+                                          char *filename, size_t namelen)
 {
     value_t t, f;
     t = cvalue_static_cstrn(text, len);
@@ -605,7 +604,7 @@ jl_value_t *jl_load_file_string(const char *text, size_t len,
 }
 
 // returns either an expression or a thunk
-jl_value_t *jl_expand(jl_value_t *expr)
+DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr)
 {
     int np = jl_gc_n_preserved_values();
     value_t arg = julia_to_scm(expr);
@@ -769,7 +768,7 @@ jl_sym_t *jl_decl_var(jl_value_t *ex)
     return (jl_sym_t*)jl_exprarg(ex, 0);
 }
 
-int jl_is_rest_arg(jl_value_t *ex)
+DLLEXPORT int jl_is_rest_arg(jl_value_t *ex)
 {
     if (!jl_is_expr(ex)) return 0;
     if (((jl_expr_t*)ex)->head != colons_sym) return 0;

--- a/src/ast.c
+++ b/src/ast.c
@@ -148,7 +148,7 @@ void jl_init_frontend(void)
         jl_parse_depwarn((int)jl_options.depwarn);
 }
 
-DLLEXPORT void jl_lisp_prompt(void)
+JL_DLLEXPORT void jl_lisp_prompt(void)
 {
     if (jvtype==NULL) jl_init_frontend();
     fl_applyn(1, symbol_value(symbol("__start")), fl_cons(FL_NIL,FL_NIL));
@@ -511,7 +511,7 @@ static value_t julia_to_scm_(jl_value_t *v)
 }
 
 // this is used to parse a line of repl input
-DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len)
+JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len)
 {
     value_t s = cvalue_static_cstrn(str, len);
     value_t e = fl_applyn(1, symbol_value(symbol("jl-parse-string")), s);
@@ -522,8 +522,8 @@ DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len)
 
 // this is for parsing one expression out of a string, keeping track of
 // the current position.
-DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
-                                      int pos0, int greedy)
+JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
+                                         int pos0, int greedy)
 {
     value_t s = cvalue_static_cstrn(str, len);
     value_t p = fl_applyn(3, symbol_value(symbol("jl-parse-one-string")),
@@ -556,7 +556,7 @@ void jl_stop_parsing(void)
     fl_applyn(0, symbol_value(symbol("jl-parser-close-stream")));
 }
 
-DLLEXPORT int jl_parse_depwarn(int warn)
+JL_DLLEXPORT int jl_parse_depwarn(int warn)
 {
     value_t prev = fl_applyn(1, symbol_value(symbol("jl-parser-depwarn")),
                              warn ? FL_T : FL_F);
@@ -591,8 +591,8 @@ jl_value_t *jl_parse_next(void)
     return scm_to_julia(c,0);
 }
 
-DLLEXPORT jl_value_t *jl_load_file_string(const char *text, size_t len,
-                                          char *filename, size_t namelen)
+JL_DLLEXPORT jl_value_t *jl_load_file_string(const char *text, size_t len,
+                                             char *filename, size_t namelen)
 {
     value_t t, f;
     t = cvalue_static_cstrn(text, len);
@@ -604,7 +604,7 @@ DLLEXPORT jl_value_t *jl_load_file_string(const char *text, size_t len,
 }
 
 // returns either an expression or a thunk
-DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr)
+JL_DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr)
 {
     int np = jl_gc_n_preserved_values();
     value_t arg = julia_to_scm(expr);
@@ -616,7 +616,7 @@ DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr)
     return result;
 }
 
-DLLEXPORT jl_value_t *jl_macroexpand(jl_value_t *expr)
+JL_DLLEXPORT jl_value_t *jl_macroexpand(jl_value_t *expr)
 {
     int np = jl_gc_n_preserved_values();
     value_t arg = julia_to_scm(expr);
@@ -768,7 +768,7 @@ jl_sym_t *jl_decl_var(jl_value_t *ex)
     return (jl_sym_t*)jl_exprarg(ex, 0);
 }
 
-DLLEXPORT int jl_is_rest_arg(jl_value_t *ex)
+JL_DLLEXPORT int jl_is_rest_arg(jl_value_t *ex)
 {
     if (!jl_is_expr(ex)) return 0;
     if (((jl_expr_t*)ex)->head != colons_sym) return 0;
@@ -859,7 +859,7 @@ static jl_value_t *copy_ast(jl_value_t *expr, jl_svec_t *sp, int do_sp)
     return expr;
 }
 
-DLLEXPORT jl_value_t *jl_copy_ast(jl_value_t *expr)
+JL_DLLEXPORT jl_value_t *jl_copy_ast(jl_value_t *expr)
 {
     if (expr == NULL) {
         return NULL;
@@ -967,7 +967,7 @@ jl_svec_t *jl_svec_tvars_to_symbols(jl_svec_t *t)
 // of the tree with declared types evaluated and static parameters passed
 // on to all enclosed functions.
 // this tree can then be further mutated by optimization passes.
-DLLEXPORT jl_value_t *jl_prepare_ast(jl_lambda_info_t *li, jl_svec_t *sparams)
+JL_DLLEXPORT jl_value_t *jl_prepare_ast(jl_lambda_info_t *li, jl_svec_t *sparams)
 {
     jl_svec_t *spenv = NULL;
     jl_value_t *ast = li->ast;
@@ -996,12 +996,12 @@ DLLEXPORT jl_value_t *jl_prepare_ast(jl_lambda_info_t *li, jl_svec_t *sparams)
     return ast;
 }
 
-DLLEXPORT int jl_is_operator(char *sym)
+JL_DLLEXPORT int jl_is_operator(char *sym)
 {
     return fl_applyn(1, symbol_value(symbol("operator?")), symbol(sym)) == FL_T;
 }
 
-DLLEXPORT int jl_operator_precedence(char *sym)
+JL_DLLEXPORT int jl_operator_precedence(char *sym)
 {
     return numval(fl_applyn(1, symbol_value(symbol("operator-precedence")), symbol(sym)));
 }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -31,7 +31,7 @@ extern "C" {
 
 // exceptions -----------------------------------------------------------------
 
-DLLEXPORT void NORETURN jl_error(const char *str)
+JL_DLLEXPORT void JL_NORETURN jl_error(const char *str)
 {
     if (jl_errorexception_type == NULL) {
         jl_printf(JL_STDERR, "ERROR: %s\n", str);
@@ -44,7 +44,8 @@ DLLEXPORT void NORETURN jl_error(const char *str)
 
 extern int vasprintf(char **str, const char *fmt, va_list ap);
 
-static void NORETURN jl_vexceptionf(jl_datatype_t *exception_type, const char *fmt, va_list args)
+static void JL_NORETURN jl_vexceptionf(jl_datatype_t *exception_type,
+                                       const char *fmt, va_list args)
 {
     if (exception_type == NULL) {
         jl_printf(JL_STDERR, "ERROR: ");
@@ -66,7 +67,7 @@ static void NORETURN jl_vexceptionf(jl_datatype_t *exception_type, const char *f
     jl_throw(jl_new_struct(exception_type, msg));
 }
 
-DLLEXPORT void NORETURN jl_errorf(const char *fmt, ...)
+JL_DLLEXPORT void JL_NORETURN jl_errorf(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
@@ -74,7 +75,8 @@ DLLEXPORT void NORETURN jl_errorf(const char *fmt, ...)
     va_end(args);
 }
 
-DLLEXPORT void NORETURN jl_exceptionf(jl_datatype_t *exception_type, const char *fmt, ...)
+JL_DLLEXPORT void JL_NORETURN jl_exceptionf(jl_datatype_t *exception_type,
+                                            const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
@@ -82,18 +84,19 @@ DLLEXPORT void NORETURN jl_exceptionf(jl_datatype_t *exception_type, const char 
     va_end(args);
 }
 
-DLLEXPORT void NORETURN jl_too_few_args(const char *fname, int min)
+JL_DLLEXPORT void JL_NORETURN jl_too_few_args(const char *fname, int min)
 {
     jl_exceptionf(jl_argumenterror_type, "%s: too few arguments (expected %d)", fname, min);
 }
 
-DLLEXPORT void NORETURN jl_too_many_args(const char *fname, int max)
+JL_DLLEXPORT void JL_NORETURN jl_too_many_args(const char *fname, int max)
 {
     jl_exceptionf(jl_argumenterror_type, "%s: too many arguments (expected %d)", fname, max);
 }
 
-DLLEXPORT void NORETURN jl_type_error_rt(const char *fname, const char *context,
-                                         jl_value_t *ty, jl_value_t *got)
+JL_DLLEXPORT void JL_NORETURN jl_type_error_rt(const char *fname,
+                                               const char *context,
+                                               jl_value_t *ty, jl_value_t *got)
 {
     jl_value_t *ctxt=NULL;
     JL_GC_PUSH2(&ctxt, &got);
@@ -103,13 +106,14 @@ DLLEXPORT void NORETURN jl_type_error_rt(const char *fname, const char *context,
     jl_throw(ex);
 }
 
-DLLEXPORT void NORETURN jl_type_error(const char *fname, jl_value_t *expected,
-                                      jl_value_t *got)
+JL_DLLEXPORT void JL_NORETURN jl_type_error(const char *fname,
+                                            jl_value_t *expected,
+                                            jl_value_t *got)
 {
     jl_type_error_rt(fname, "", expected, got);
 }
 
-DLLEXPORT void NORETURN jl_undefined_var_error(jl_sym_t *var)
+JL_DLLEXPORT void JL_NORETURN jl_undefined_var_error(jl_sym_t *var)
 {
     if (jl_symbol_name(var)[0] == '#') {
         // convention for renamed variables: #...#original_name
@@ -120,13 +124,14 @@ DLLEXPORT void NORETURN jl_undefined_var_error(jl_sym_t *var)
     jl_throw(jl_new_struct(jl_undefvarerror_type, var));
 }
 
-DLLEXPORT void NORETURN jl_bounds_error(jl_value_t *v, jl_value_t *t)
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error(jl_value_t *v, jl_value_t *t)
 {
     JL_GC_PUSH2(&v, &t); // root arguments so the caller doesn't need to
     jl_throw(jl_new_struct((jl_datatype_t*)jl_boundserror_type, v, t));
 }
 
-DLLEXPORT void NORETURN jl_bounds_error_v(jl_value_t *v, jl_value_t **idxs, size_t nidxs)
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_v(jl_value_t *v,
+                                                jl_value_t **idxs, size_t nidxs)
 {
     jl_value_t *t = NULL;
     // items in idxs are assumed to already be rooted
@@ -135,13 +140,16 @@ DLLEXPORT void NORETURN jl_bounds_error_v(jl_value_t *v, jl_value_t **idxs, size
     jl_throw(jl_new_struct((jl_datatype_t*)jl_boundserror_type, v, t));
 }
 
-DLLEXPORT void NORETURN jl_bounds_error_tuple_int(jl_value_t **v, size_t nv, size_t i)
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_tuple_int(jl_value_t **v,
+                                                        size_t nv, size_t i)
 {
     // values in v are expected to already be gc-rooted
     jl_bounds_error_int(jl_f_tuple(NULL, v, nv), i);
 }
 
-DLLEXPORT void NORETURN jl_bounds_error_unboxed_int(void *data, jl_value_t *vt, size_t i)
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_unboxed_int(void *data,
+                                                          jl_value_t *vt,
+                                                          size_t i)
 {
     jl_value_t *t = NULL, *v = NULL;
     // data is expected to be gc-safe (either gc-rooted, or alloca)
@@ -152,7 +160,7 @@ DLLEXPORT void NORETURN jl_bounds_error_unboxed_int(void *data, jl_value_t *vt, 
     jl_throw(jl_new_struct((jl_datatype_t*)jl_boundserror_type, v, t));
 }
 
-DLLEXPORT void NORETURN jl_bounds_error_int(jl_value_t *v, size_t i)
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_int(jl_value_t *v, size_t i)
 {
     jl_value_t *t = NULL;
     JL_GC_PUSH2(&v, &t); // root arguments so the caller doesn't need to
@@ -160,7 +168,8 @@ DLLEXPORT void NORETURN jl_bounds_error_int(jl_value_t *v, size_t i)
     jl_throw(jl_new_struct((jl_datatype_t*)jl_boundserror_type, v, t));
 }
 
-DLLEXPORT void NORETURN jl_bounds_error_ints(jl_value_t *v, size_t *idxs, size_t nidxs)
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_ints(jl_value_t *v, size_t *idxs,
+                                                   size_t nidxs)
 {
     size_t i;
     jl_value_t *t = NULL;
@@ -180,7 +189,7 @@ JL_CALLABLE(jl_f_throw)
     return jl_nothing;
 }
 
-DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
+JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
 {
     JL_SIGATOMIC_BEGIN();
     eh->prev = jl_current_task->eh;
@@ -191,7 +200,7 @@ DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
     JL_SIGATOMIC_END();
 }
 
-DLLEXPORT void jl_pop_handler(int n)
+JL_DLLEXPORT void jl_pop_handler(int n)
 {
     while (n > 0) {
         jl_eh_restore_state(jl_current_task->eh);
@@ -275,7 +284,7 @@ static int NOINLINE compare_fields(jl_value_t *a, jl_value_t *b, jl_datatype_t *
     return 1;
 }
 
-DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b)
+JL_DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b)
 {
     // warning: a,b may NOT have been gc-rooted by the caller
     if (a == b)
@@ -366,7 +375,7 @@ JL_CALLABLE(jl_f_isa)
     return (jl_subtype(args[0],args[1],1) ? jl_true : jl_false);
 }
 
-DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t)
+JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t)
 {
     if (!jl_subtype(x,t,1))
         jl_type_error("typeassert", t, x);
@@ -543,12 +552,14 @@ JL_CALLABLE(jl_f_kwcall)
 
 // eval -----------------------------------------------------------------------
 
-DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex)
+JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex)
 {
     return jl_toplevel_eval_in_warn(m, ex, 0);
 }
 
-DLLEXPORT jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex, int delay_warn)
+JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m,
+                                                  jl_value_t *ex,
+                                                  int delay_warn)
 {
     static int jl_warn_on_eval = 0;
     int last_delay_warn = jl_warn_on_eval;
@@ -765,17 +776,17 @@ JL_CALLABLE(jl_f_nfields)
 
 // conversion -----------------------------------------------------------------
 
-DLLEXPORT void *(jl_symbol_name)(jl_sym_t *s)
+JL_DLLEXPORT void *(jl_symbol_name)(jl_sym_t *s)
 {
     return jl_symbol_name(s);
 }
 
 //WARNING: THIS FUNCTION IS NEVER CALLED BUT INLINE BY CCALL
-DLLEXPORT void *jl_array_ptr(jl_array_t *a)
+JL_DLLEXPORT void *jl_array_ptr(jl_array_t *a)
 {
     return a->data;
 }
-DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a)
+JL_DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a)
 {
     return a;
 }
@@ -804,7 +815,8 @@ int str_isspace(char *p)
     return 1;
 }
 
-DLLEXPORT jl_nullable_float64_t jl_try_substrtod(char *str, size_t offset, size_t len)
+JL_DLLEXPORT jl_nullable_float64_t jl_try_substrtod(char *str, size_t offset,
+                                                    size_t len)
 {
     char *p;
     char *bstr = str+offset;
@@ -841,7 +853,7 @@ DLLEXPORT jl_nullable_float64_t jl_try_substrtod(char *str, size_t offset, size_
     return ret;
 }
 
-DLLEXPORT int jl_substrtod(char *str, size_t offset, size_t len, double *out)
+JL_DLLEXPORT int jl_substrtod(char *str, size_t offset, size_t len, double *out)
 {
     jl_nullable_float64_t nd = jl_try_substrtod(str, offset, len);
     if (0 == nd.isnull) {
@@ -856,7 +868,8 @@ DLLEXPORT int jl_substrtod(char *str, size_t offset, size_t len, double *out)
 #define HUGE_VALF (1e25f * 1e25f)
 #endif
 
-DLLEXPORT jl_nullable_float32_t jl_try_substrtof(char *str, size_t offset, size_t len)
+JL_DLLEXPORT jl_nullable_float32_t jl_try_substrtof(char *str, size_t offset,
+                                                    size_t len)
 {
     char *p;
     char *bstr = str+offset;
@@ -897,7 +910,7 @@ DLLEXPORT jl_nullable_float32_t jl_try_substrtof(char *str, size_t offset, size_
     return ret;
 }
 
-DLLEXPORT int jl_substrtof(char *str, int offset, size_t len, float *out)
+JL_DLLEXPORT int jl_substrtof(char *str, int offset, size_t len, float *out)
 {
     jl_nullable_float32_t nf = jl_try_substrtof(str, offset, len);
     if (0 == nf.isnull) {
@@ -909,13 +922,13 @@ DLLEXPORT int jl_substrtof(char *str, int offset, size_t len, float *out)
 
 // showing --------------------------------------------------------------------
 
-DLLEXPORT void jl_flush_cstdio(void)
+JL_DLLEXPORT void jl_flush_cstdio(void)
 {
     fflush(stdout);
     fflush(stderr);
 }
 
-DLLEXPORT jl_value_t *jl_stdout_obj(void)
+JL_DLLEXPORT jl_value_t *jl_stdout_obj(void)
 {
     if (jl_base_module == NULL) return NULL;
     jl_value_t *stdout_obj = jl_get_global(jl_base_module, jl_symbol("STDOUT"));
@@ -923,7 +936,7 @@ DLLEXPORT jl_value_t *jl_stdout_obj(void)
     return jl_get_global(jl_base_module, jl_symbol("OUTPUT_STREAM"));
 }
 
-DLLEXPORT jl_value_t *jl_stderr_obj(void)
+JL_DLLEXPORT jl_value_t *jl_stderr_obj(void)
 {
     if (jl_base_module == NULL) return NULL;
     jl_value_t *stderr_obj = jl_get_global(jl_base_module, jl_symbol("STDERR"));
@@ -933,7 +946,7 @@ DLLEXPORT jl_value_t *jl_stderr_obj(void)
 
 static jl_function_t *jl_show_gf=NULL;
 
-DLLEXPORT void jl_show(jl_value_t *stream, jl_value_t *v)
+JL_DLLEXPORT void jl_show(jl_value_t *stream, jl_value_t *v)
 {
     if (jl_base_module) {
         if (jl_show_gf == NULL) {
@@ -1029,7 +1042,7 @@ JL_CALLABLE(jl_f_instantiate_type)
     return jl_apply_type_(args[0], &args[1], nargs-1);
 }
 
-DLLEXPORT jl_value_t *jl_new_type_constructor(jl_svec_t *p, jl_value_t *t)
+JL_DLLEXPORT jl_value_t *jl_new_type_constructor(jl_svec_t *p, jl_value_t *t)
 {
     jl_value_t *tc = (jl_value_t*)jl_new_type_ctor(p, t);
     int i;
@@ -1168,7 +1181,7 @@ static uptrint_t jl_object_id_(jl_value_t *tv, jl_value_t *v)
     return h;
 }
 
-DLLEXPORT uptrint_t jl_object_id(jl_value_t *v)
+JL_DLLEXPORT uptrint_t jl_object_id(jl_value_t *v)
 {
     return jl_object_id_(jl_typeof(v), v);
 }
@@ -1596,12 +1609,12 @@ static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, int depth)
     return jl_static_show_x_(out, v, (jl_datatype_t*)jl_typeof(v), depth);
 }
 
-DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v)
+JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v)
 {
     return jl_static_show_x(out, v, 0);
 }
 
-DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type)
+JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type)
 {
     if (!jl_is_tuple_type(type))
         return jl_static_show(s, type);
@@ -1630,7 +1643,7 @@ DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type)
 }
 
 int in_jl_ = 0;
-DLLEXPORT void jl_(void *jl_value)
+JL_DLLEXPORT void jl_(void *jl_value)
 {
     in_jl_++;
     JL_TRY {
@@ -1643,7 +1656,7 @@ DLLEXPORT void jl_(void *jl_value)
     in_jl_--;
 }
 
-DLLEXPORT void jl_breakpoint(jl_value_t *v)
+JL_DLLEXPORT void jl_breakpoint(jl_value_t *v)
 {
     // put a breakpoint in you debugger here
 }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -82,18 +82,18 @@ DLLEXPORT void NORETURN jl_exceptionf(jl_datatype_t *exception_type, const char 
     va_end(args);
 }
 
-void NORETURN jl_too_few_args(const char *fname, int min)
+DLLEXPORT void NORETURN jl_too_few_args(const char *fname, int min)
 {
     jl_exceptionf(jl_argumenterror_type, "%s: too few arguments (expected %d)", fname, min);
 }
 
-void NORETURN jl_too_many_args(const char *fname, int max)
+DLLEXPORT void NORETURN jl_too_many_args(const char *fname, int max)
 {
     jl_exceptionf(jl_argumenterror_type, "%s: too many arguments (expected %d)", fname, max);
 }
 
-void NORETURN jl_type_error_rt(const char *fname, const char *context,
-                               jl_value_t *ty, jl_value_t *got)
+DLLEXPORT void NORETURN jl_type_error_rt(const char *fname, const char *context,
+                                         jl_value_t *ty, jl_value_t *got)
 {
     jl_value_t *ctxt=NULL;
     JL_GC_PUSH2(&ctxt, &got);
@@ -103,7 +103,8 @@ void NORETURN jl_type_error_rt(const char *fname, const char *context,
     jl_throw(ex);
 }
 
-void NORETURN jl_type_error(const char *fname, jl_value_t *expected, jl_value_t *got)
+DLLEXPORT void NORETURN jl_type_error(const char *fname, jl_value_t *expected,
+                                      jl_value_t *got)
 {
     jl_type_error_rt(fname, "", expected, got);
 }
@@ -179,7 +180,7 @@ JL_CALLABLE(jl_f_throw)
     return jl_nothing;
 }
 
-void jl_enter_handler(jl_handler_t *eh)
+DLLEXPORT void jl_enter_handler(jl_handler_t *eh)
 {
     JL_SIGATOMIC_BEGIN();
     eh->prev = jl_current_task->eh;
@@ -190,7 +191,7 @@ void jl_enter_handler(jl_handler_t *eh)
     JL_SIGATOMIC_END();
 }
 
-void jl_pop_handler(int n)
+DLLEXPORT void jl_pop_handler(int n)
 {
     while (n > 0) {
         jl_eh_restore_state(jl_current_task->eh);
@@ -274,8 +275,9 @@ static int NOINLINE compare_fields(jl_value_t *a, jl_value_t *b, jl_datatype_t *
     return 1;
 }
 
-int jl_egal(jl_value_t *a, jl_value_t *b) // warning: a,b may NOT have been gc-rooted by the caller
+DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b)
 {
+    // warning: a,b may NOT have been gc-rooted by the caller
     if (a == b)
         return 1;
     jl_value_t *ta = (jl_value_t*)jl_typeof(a);
@@ -907,13 +909,13 @@ DLLEXPORT int jl_substrtof(char *str, int offset, size_t len, float *out)
 
 // showing --------------------------------------------------------------------
 
-void jl_flush_cstdio(void)
+DLLEXPORT void jl_flush_cstdio(void)
 {
     fflush(stdout);
     fflush(stderr);
 }
 
-jl_value_t *jl_stdout_obj(void)
+DLLEXPORT jl_value_t *jl_stdout_obj(void)
 {
     if (jl_base_module == NULL) return NULL;
     jl_value_t *stdout_obj = jl_get_global(jl_base_module, jl_symbol("STDOUT"));
@@ -921,7 +923,7 @@ jl_value_t *jl_stdout_obj(void)
     return jl_get_global(jl_base_module, jl_symbol("OUTPUT_STREAM"));
 }
 
-jl_value_t *jl_stderr_obj(void)
+DLLEXPORT jl_value_t *jl_stderr_obj(void)
 {
     if (jl_base_module == NULL) return NULL;
     jl_value_t *stderr_obj = jl_get_global(jl_base_module, jl_symbol("STDERR"));
@@ -931,7 +933,7 @@ jl_value_t *jl_stderr_obj(void)
 
 static jl_function_t *jl_show_gf=NULL;
 
-void jl_show(jl_value_t *stream, jl_value_t *v)
+DLLEXPORT void jl_show(jl_value_t *stream, jl_value_t *v)
 {
     if (jl_base_module) {
         if (jl_show_gf == NULL) {

--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -27,7 +27,7 @@ int __declspec(noinline)
 #else
 int __attribute__((noinline))
 #endif
-DLLEXPORT testUcharX(unsigned char x) {
+JL_DLLEXPORT testUcharX(unsigned char x) {
     return xs[x];
 }
 
@@ -46,41 +46,41 @@ typedef struct {
     jint imag;
 } complex_t;
 
-DLLEXPORT complex_t ctest(complex_t a) {
+JL_DLLEXPORT complex_t ctest(complex_t a) {
     a.real += 1;
     a.imag -= 2;
     return a;
 }
 
-DLLEXPORT complex double cgtest(complex double a) {
+JL_DLLEXPORT complex double cgtest(complex double a) {
     //Unpack a ComplexPair{Float64} struct
     if (verbose) fprintf(stderr,"%g + %g i\n", creal(a), cimag(a));
     a += 1 - (2.0*I);
     return a;
 }
 
-DLLEXPORT complex double* cgptest(complex double *a) {
+JL_DLLEXPORT complex double* cgptest(complex double *a) {
     //Unpack a ComplexPair{Float64} struct
     if (verbose) fprintf(stderr,"%g + %g i\n", creal(*a), cimag(*a));
     *a += 1 - (2.0*I);
     return a;
 }
 
-DLLEXPORT complex float cftest(complex float a) {
+JL_DLLEXPORT complex float cftest(complex float a) {
     //Unpack a ComplexPair{Float32} struct
     if (verbose) fprintf(stderr,"%g + %g i\n", creal(a), cimag(a));
     a += 1 - (2.0*I);
     return a;
 }
 
-DLLEXPORT complex float* cfptest(complex float *a) {
+JL_DLLEXPORT complex float* cfptest(complex float *a) {
     //Unpack a ComplexPair{Float64} struct
     if (verbose) fprintf(stderr,"%g + %g i\n", creal(*a), cimag(*a));
     *a += 1 - (2.0*I);
     return a;
 }
 
-DLLEXPORT complex_t* cptest(complex_t *a) {
+JL_DLLEXPORT complex_t* cptest(complex_t *a) {
     //Unpack a ComplexPair{Int} struct pointer
     if (verbose) fprintf(stderr,"%lld + %lld i\n", (long long)a->real, (long long)a->imag);
     a->real += 1;
@@ -88,7 +88,7 @@ DLLEXPORT complex_t* cptest(complex_t *a) {
     return a;
 }
 
-DLLEXPORT complex_t* cptest_static(complex_t *a) {
+JL_DLLEXPORT complex_t* cptest_static(complex_t *a) {
     complex_t *b = (complex_t*)malloc(sizeof(complex_t));
     b->real = a->real;
     b->imag = a->imag;
@@ -96,7 +96,7 @@ DLLEXPORT complex_t* cptest_static(complex_t *a) {
 }
 
 // Native-like data types
-DLLEXPORT char* stest(char *x) {
+JL_DLLEXPORT char* stest(char *x) {
     //Print a character Array
     if (verbose) fprintf(stderr,"%s\n", x);
     return x;
@@ -204,7 +204,7 @@ typedef struct {
     char z;
 } struct_big;
 
-DLLEXPORT struct1 test_1(struct1 a) {
+JL_DLLEXPORT struct1 test_1(struct1 a) {
     //Unpack a "small" struct { float, double }
     if (verbose) fprintf(stderr,"%g + %g i\n", a.x, a.y);
     a.x += 1;
@@ -212,7 +212,7 @@ DLLEXPORT struct1 test_1(struct1 a) {
     return a;
 }
 
-DLLEXPORT struct1 add_1(struct1 a, struct1 b) {
+JL_DLLEXPORT struct1 add_1(struct1 a, struct1 b) {
     // Two small structs
     struct1 c;
     c.x = a.x + b.x;
@@ -220,7 +220,7 @@ DLLEXPORT struct1 add_1(struct1 a, struct1 b) {
     return c;
 }
 
-DLLEXPORT struct2a test_2a(struct2a a) {
+JL_DLLEXPORT struct2a test_2a(struct2a a) {
     //Unpack a ComplexPair{Int32} struct
     if (verbose) fprintf(stderr,"%" PRId32 " + %" PRId32 " i\n", a.x.x, a.y.y);
     a.x.x += 1;
@@ -228,7 +228,7 @@ DLLEXPORT struct2a test_2a(struct2a a) {
     return a;
 }
 
-DLLEXPORT struct2b test_2b(struct2b a) {
+JL_DLLEXPORT struct2b test_2b(struct2b a) {
     //Unpack a ComplexPair{Int32} struct
     if (verbose) fprintf(stderr,"%" PRId32 " + %" PRId32 " i\n", a.x, a.y);
     a.x += 1;
@@ -236,7 +236,7 @@ DLLEXPORT struct2b test_2b(struct2b a) {
     return a;
 }
 
-DLLEXPORT struct3a test_3a(struct3a a) {
+JL_DLLEXPORT struct3a test_3a(struct3a a) {
     //Unpack a ComplexPair{Int64} struct
     if (verbose) fprintf(stderr,"%" PRId64 " + %" PRId64 " i\n", a.x.x, a.y.y);
     a.x.x += 1;
@@ -244,7 +244,7 @@ DLLEXPORT struct3a test_3a(struct3a a) {
     return a;
 }
 
-DLLEXPORT struct3b test_3b(struct3b a) {
+JL_DLLEXPORT struct3b test_3b(struct3b a) {
     //Unpack a ComplexPair{Int64} struct
     if (verbose) fprintf(stderr,"%" PRId64 " + %" PRId64 " i\n", a.x, a.y);
     a.x += 1;
@@ -252,7 +252,7 @@ DLLEXPORT struct3b test_3b(struct3b a) {
     return a;
 }
 
-DLLEXPORT struct4 test_4(struct4 a)
+JL_DLLEXPORT struct4 test_4(struct4 a)
 {
     if (verbose) fprintf(stderr,"(%" PRId32 ",%" PRId32 ",%" PRId32 ")\n", a.x, a.y, a.z);
     a.x += 1;
@@ -262,7 +262,7 @@ DLLEXPORT struct4 test_4(struct4 a)
 }
 
 
-DLLEXPORT struct5 test_5(struct5 a)
+JL_DLLEXPORT struct5 test_5(struct5 a)
 {
     if (verbose) fprintf(stderr,"(%" PRId32 ",%" PRId32 ",%" PRId32 ",%" PRId32 ")\n", a.x, a.y, a.z, a.a);
     a.x += 1;
@@ -274,7 +274,7 @@ DLLEXPORT struct5 test_5(struct5 a)
 }
 
 
-DLLEXPORT struct6 test_6(struct6 a)
+JL_DLLEXPORT struct6 test_6(struct6 a)
 {
     if (verbose) fprintf(stderr,"(%" PRId64 ",%" PRId64 ",%" PRId64 ")\n", a.x, a.y, a.z);
     a.x += 1;
@@ -283,7 +283,7 @@ DLLEXPORT struct6 test_6(struct6 a)
     return a;
 }
 
-DLLEXPORT struct7 test_7(struct7 a)
+JL_DLLEXPORT struct7 test_7(struct7 a)
 {
     if (verbose) fprintf(stderr,"(%" PRId64 ",%" PRId8 ")\n", a.x, a.y);
     a.x += 1;
@@ -291,7 +291,7 @@ DLLEXPORT struct7 test_7(struct7 a)
     return a;
 }
 
-DLLEXPORT struct8 test_8(struct8 a)
+JL_DLLEXPORT struct8 test_8(struct8 a)
 {
     if (verbose) fprintf(stderr,"(%" PRId32 ",%" PRId8 ")\n", a.x, a.y);
     a.x += 1;
@@ -299,7 +299,7 @@ DLLEXPORT struct8 test_8(struct8 a)
     return a;
 }
 
-DLLEXPORT struct9 test_9(struct9 a)
+JL_DLLEXPORT struct9 test_9(struct9 a)
 {
     if (verbose) fprintf(stderr,"(%" PRId32 ",%" PRId16 ")\n", a.x, a.y);
     a.x += 1;
@@ -307,7 +307,7 @@ DLLEXPORT struct9 test_9(struct9 a)
     return a;
 }
 
-DLLEXPORT struct10 test_10(struct10 a)
+JL_DLLEXPORT struct10 test_10(struct10 a)
 {
     if (verbose) fprintf(stderr,"(%" PRId8 ",%" PRId8 ",%" PRId8 ",%" PRId8 ")\n", a.x, a.y, a.z, a.a);
     a.x += 1;
@@ -318,7 +318,7 @@ DLLEXPORT struct10 test_10(struct10 a)
     return a;
 }
 
-DLLEXPORT struct14 test_14(struct14 a) {
+JL_DLLEXPORT struct14 test_14(struct14 a) {
     //The C equivalent of a  ComplexPair{Float32} struct (but without special complex ABI)
     if (verbose) fprintf(stderr,"%g + %g i\n", a.x, a.y);
     a.x += 1;
@@ -326,7 +326,7 @@ DLLEXPORT struct14 test_14(struct14 a) {
     return a;
 }
 
-DLLEXPORT struct15 test_15(struct15 a) {
+JL_DLLEXPORT struct15 test_15(struct15 a) {
     //The C equivalent of a  ComplexPair{Float32} struct (but without special complex ABI)
     if (verbose) fprintf(stderr,"%g + %g i\n", a.x, a.y);
     a.x += 1;
@@ -335,7 +335,7 @@ DLLEXPORT struct15 test_15(struct15 a) {
 }
 
 #define int128_t struct3b
-DLLEXPORT int128_t test_128(int128_t a) {
+JL_DLLEXPORT int128_t test_128(int128_t a) {
     //Unpack a Int128
     if (verbose) fprintf(stderr,"0x%016" PRIx64 "%016" PRIx64 "\n", a.y, a.x);
     a.x += 1;
@@ -344,7 +344,7 @@ DLLEXPORT int128_t test_128(int128_t a) {
     return a;
 }
 
-DLLEXPORT struct_big test_big(struct_big a) {
+JL_DLLEXPORT struct_big test_big(struct_big a) {
     //Unpack a "big" struct { int, int, char }
     if (verbose) fprintf(stderr,"%lld %lld %c\n", (long long)a.x, (long long)a.y, a.z);
     a.x += 1;
@@ -355,10 +355,10 @@ DLLEXPORT struct_big test_big(struct_big a) {
 
 //////////////////////////////////
 // Turn off verbose for automated tests, leave on for debugging
-DLLEXPORT void set_verbose(int level) {
+JL_DLLEXPORT void set_verbose(int level) {
     verbose = level;
 }
 
-DLLEXPORT void *test_echo_p(void *p) {
+JL_DLLEXPORT void *test_echo_p(void *p) {
     return p;
 }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -83,7 +83,7 @@ static inline void add_named_global(GlobalValue *gv, void *addr, bool dllimport 
 #endif
 
 #ifdef _OS_WINDOWS_
-    // setting DLLEXPORT correctly only matters when building a binary
+    // setting JL_DLLEXPORT correctly only matters when building a binary
     if (dllimport && imaging_mode) {
         assert(gv->getLinkage() == GlobalValue::ExternalLinkage);
 #ifdef LLVM35
@@ -156,7 +156,7 @@ static GlobalVariable *stringConst(const std::string &txt)
 
 typedef struct {Value* gv; int32_t index;} jl_value_llvm; // uses 1-based indexing
 static std::map<void*, jl_value_llvm> jl_value_to_llvm;
-DLLEXPORT std::map<Value *, void*> jl_llvm_to_jl_value;
+JL_DLLEXPORT std::map<Value *, void*> jl_llvm_to_jl_value;
 
 // In imaging mode, cache a fast mapping of Function * to code address
 // because this is queried in the hot path
@@ -758,7 +758,7 @@ static Value *julia_binding_gv(jl_binding_t *b)
 static Type *julia_struct_to_llvm(jl_value_t *jt, bool *isboxed);
 
 extern "C" {
-DLLEXPORT Type *julia_type_to_llvm(jl_value_t *jt, bool *isboxed)
+JL_DLLEXPORT Type *julia_type_to_llvm(jl_value_t *jt, bool *isboxed)
 {
     // this function converts a Julia Type into the equivalent LLVM type
     if (isboxed) *isboxed = false;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -135,8 +135,8 @@ extern "C" {
 extern uintptr_t __stack_chk_guard;
 extern void __stack_chk_fail();
 #else
-DLLEXPORT uintptr_t __stack_chk_guard = (uintptr_t)0xBAD57ACCBAD67ACC; // 0xBADSTACKBADSTACK
-DLLEXPORT void __stack_chk_fail()
+JL_DLLEXPORT uintptr_t __stack_chk_guard = (uintptr_t)0xBAD57ACCBAD67ACC; // 0xBADSTACKBADSTACK
+JL_DLLEXPORT void __stack_chk_fail()
 {
     /* put your panic function or similar in here */
     fprintf(stderr, "fatal error: stack corruption detected\n");
@@ -172,7 +172,7 @@ extern void _chkstk(void);
 #define DISABLE_FLOAT16
 
 // llvm state
-DLLEXPORT LLVMContext &jl_LLVMContext = getGlobalContext();
+JL_DLLEXPORT LLVMContext &jl_LLVMContext = getGlobalContext();
 static IRBuilder<> builder(getGlobalContext());
 static bool nested_compile = false;
 static TargetMachine *jl_TargetMachine;
@@ -319,9 +319,9 @@ private:
         JuliaOJIT &JIT;
     };
 };
-DLLEXPORT JuliaOJIT *jl_ExecutionEngine;
+JL_DLLEXPORT JuliaOJIT *jl_ExecutionEngine;
 #else
-DLLEXPORT ExecutionEngine *jl_ExecutionEngine;
+JL_DLLEXPORT ExecutionEngine *jl_ExecutionEngine;
 #endif
 
 #ifdef USE_MCJIT
@@ -429,7 +429,7 @@ static Value *V_null;
 static Type *NoopType;
 static Value *literal_pointer_val(jl_value_t *p);
 extern "C" {
-DLLEXPORT Type *julia_type_to_llvm(jl_value_t *jt, bool *isboxed=NULL);
+JL_DLLEXPORT Type *julia_type_to_llvm(jl_value_t *jt, bool *isboxed=NULL);
 }
 static bool type_is_ghost(Type *ty)
 {
@@ -928,7 +928,7 @@ static void maybe_alloc_arrayvar(jl_sym_t *s, jl_codectx_t *ctx)
 // Snooping on which functions are being compiled, and how long it takes
 JL_STREAM *dump_compiles_stream = NULL;
 uint64_t last_time = 0;
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void jl_dump_compiles(void *s)
 {
     dump_compiles_stream = (JL_STREAM*)s;
@@ -1223,7 +1223,7 @@ static Function *jl_cfunction_object(jl_function_t *f, jl_value_t *rt, jl_tuplet
 }
 
 // get the address of a C-callable entry point for a function
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void *jl_function_ptr(jl_function_t *f, jl_value_t *rt, jl_value_t *argt)
 {
     JL_GC_PUSH1(&argt);
@@ -1256,7 +1256,7 @@ void *jl_function_ptr(jl_function_t *f, jl_value_t *rt, jl_value_t *argt)
 }
 
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void *jl_function_ptr_by_llvm_name(char* name) {
 #ifdef __has_feature
 #if __has_feature(memory_sanitizer)
@@ -1267,7 +1267,7 @@ void *jl_function_ptr_by_llvm_name(char* name) {
 }
 
 // export a C-callable entry point for a function, with a given name
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name)
 {
     assert(jl_is_tuple_type(argt));
@@ -1298,7 +1298,7 @@ extern int jl_get_llvmf_info(uint64_t fptr, uint64_t *symsize, uint64_t *slide,
 
 
 // Get pointer to llvm::Function instance, compiling if necessary
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void *jl_get_llvmf(jl_function_t *f, jl_tupletype_t *tt, bool getwrapper)
 {
     if (!jl_is_function(f)) {
@@ -1390,7 +1390,7 @@ Function* CloneFunctionToModule(Function *F, Module *destModule)
     return NewF;
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 const jl_value_t *jl_dump_function_ir(void *f, bool strip_ir_metadata, bool dump_module)
 {
     std::string code;
@@ -1461,7 +1461,7 @@ void jl_dump_asm_internal(uintptr_t Fptr, size_t Fsize, size_t slide,
 #endif
                           );
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 const jl_value_t *jl_dump_function_asm(void *f, int raw_mc)
 {
     std::string code;
@@ -1629,7 +1629,7 @@ static void mallocVisitLine(std::string filename, int line)
 
 // Resets the malloc counts. Needed to avoid including memory usage
 // from JITting.
-extern "C" DLLEXPORT void jl_clear_malloc_data(void)
+extern "C" JL_DLLEXPORT void jl_clear_malloc_data(void)
 {
     logdata_t::iterator it = mallocData.begin();
     for (; it != mallocData.end(); it++) {

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -83,7 +83,7 @@
 
 using namespace llvm;
 
-extern DLLEXPORT LLVMContext &jl_LLVMContext;
+extern JL_DLLEXPORT LLVMContext &jl_LLVMContext;
 
 namespace {
 #ifdef LLVM36

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -45,7 +45,7 @@ extern char *julia_home;
 #   endif
 #endif
 
-static void NORETURN jl_dlerror(const char *fmt, const char *sym) {
+static void JL_NORETURN jl_dlerror(const char *fmt, const char *sym) {
 #ifdef _OS_WINDOWS_
     CHAR reason[256];
     FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
@@ -58,7 +58,7 @@ static void NORETURN jl_dlerror(const char *fmt, const char *sym) {
     jl_errorf(fmt, sym, reason);
 }
 
-DLLEXPORT void* jl_dlopen(const char *filename, unsigned flags)
+JL_DLLEXPORT void* jl_dlopen(const char *filename, unsigned flags)
 {
 #if defined(_OS_WINDOWS_)
     needsSymRefreshModuleList = 1;
@@ -89,7 +89,7 @@ DLLEXPORT void* jl_dlopen(const char *filename, unsigned flags)
 #endif
 }
 
-DLLEXPORT int jl_dlclose(void *handle)
+JL_DLLEXPORT int jl_dlclose(void *handle)
 {
 #ifdef _OS_WINDOWS_
     if (!handle) return -1;
@@ -203,17 +203,17 @@ done:
     return handle;
 }
 
-DLLEXPORT void *jl_load_dynamic_library_e(const char *modname, unsigned flags)
+JL_DLLEXPORT void *jl_load_dynamic_library_e(const char *modname, unsigned flags)
 {
     return jl_load_dynamic_library_(modname, flags, 0);
 }
 
-DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags)
+JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags)
 {
     return jl_load_dynamic_library_(modname, flags, 1);
 }
 
-DLLEXPORT void *jl_dlsym_e(void *handle, const char *symbol)
+JL_DLLEXPORT void *jl_dlsym_e(void *handle, const char *symbol)
 {
 #ifdef _OS_WINDOWS_
     void *ptr = GetProcAddress((HMODULE) handle, symbol);
@@ -224,7 +224,7 @@ DLLEXPORT void *jl_dlsym_e(void *handle, const char *symbol)
     return ptr;
 }
 
-DLLEXPORT void *jl_dlsym(void *handle, const char *symbol)
+JL_DLLEXPORT void *jl_dlsym(void *handle, const char *symbol)
 {
     void *ptr = jl_dlsym_e(handle, symbol);
     if (!ptr)

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -203,17 +203,17 @@ done:
     return handle;
 }
 
-void *jl_load_dynamic_library_e(const char *modname, unsigned flags)
+DLLEXPORT void *jl_load_dynamic_library_e(const char *modname, unsigned flags)
 {
     return jl_load_dynamic_library_(modname, flags, 0);
 }
 
-void *jl_load_dynamic_library(const char *modname, unsigned flags)
+DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags)
 {
     return jl_load_dynamic_library_(modname, flags, 1);
 }
 
-void *jl_dlsym_e(void *handle, const char *symbol)
+DLLEXPORT void *jl_dlsym_e(void *handle, const char *symbol)
 {
 #ifdef _OS_WINDOWS_
     void *ptr = GetProcAddress((HMODULE) handle, symbol);
@@ -224,7 +224,7 @@ void *jl_dlsym_e(void *handle, const char *symbol)
     return ptr;
 }
 
-void *jl_dlsym(void *handle, const char *symbol)
+DLLEXPORT void *jl_dlsym(void *handle, const char *symbol)
 {
     void *ptr = jl_dlsym_e(handle, symbol);
     if (!ptr)

--- a/src/dump.c
+++ b/src/dump.c
@@ -1168,8 +1168,6 @@ static jl_value_t *jl_deserialize_datatype(ios_t *s, int pos, jl_value_t **loc)
     return (jl_value_t*)dt;
 }
 
-jl_array_t *jl_eqtable_put(jl_array_t *h, void *key, void *val);
-
 static jl_value_t *jl_deserialize_value_(ios_t *s, jl_value_t *vtag, jl_value_t **loc);
 static jl_value_t *jl_deserialize_value(ios_t *s, jl_value_t **loc)
 {

--- a/src/dump.c
+++ b/src/dump.c
@@ -212,7 +212,7 @@ uint64_t jl_sysimage_base = 0;
 #include <dbghelp.h>
 #endif
 
-DLLEXPORT int jl_running_on_valgrind(void)
+JL_DLLEXPORT int jl_running_on_valgrind(void)
 {
     return RUNNING_ON_VALGRIND;
 }
@@ -1650,7 +1650,7 @@ static int readstr_verify(ios_t *s, const char *str)
     return 1;
 }
 
-DLLEXPORT int jl_deserialize_verify_header(ios_t *s)
+JL_DLLEXPORT int jl_deserialize_verify_header(ios_t *s)
 {
     uint16_t bom;
     return (readstr_verify(s, JI_MAGIC) &&
@@ -1802,7 +1802,7 @@ void jl_save_system_image_to_stream(ios_t *f)
     JL_SIGATOMIC_END();
 }
 
-DLLEXPORT void jl_save_system_image(const char *fname)
+JL_DLLEXPORT void jl_save_system_image(const char *fname)
 {
     ios_t f;
     if (ios_file(&f, fname, 1, 1, 1, 1) == NULL) {
@@ -1814,7 +1814,7 @@ DLLEXPORT void jl_save_system_image(const char *fname)
     JL_SIGATOMIC_END();
 }
 
-DLLEXPORT ios_t *jl_create_system_image(void)
+JL_DLLEXPORT ios_t *jl_create_system_image(void)
 {
     ios_t *f; f = (ios_t*)malloc(sizeof(ios_t));
     ios_mem(f, 1000000);
@@ -1828,7 +1828,7 @@ extern void jl_get_builtin_hooks(void);
 extern void jl_get_system_hooks(void);
 
 // Takes in a path of the form "usr/lib/julia/sys.{ji,so}", as passed to jl_restore_system_image()
-DLLEXPORT void jl_preload_sysimg_so(const char *fname)
+JL_DLLEXPORT void jl_preload_sysimg_so(const char *fname)
 {
     // If passed NULL, don't even bother
     if (!fname)
@@ -1911,7 +1911,7 @@ void jl_restore_system_image_from_stream(ios_t *f)
     JL_SIGATOMIC_END();
 }
 
-DLLEXPORT void jl_restore_system_image(const char *fname)
+JL_DLLEXPORT void jl_restore_system_image(const char *fname)
 {
     char *dot = (char*) strrchr(fname, '.');
     int is_ji = (dot && !strcmp(dot, ".ji"));
@@ -1935,7 +1935,7 @@ DLLEXPORT void jl_restore_system_image(const char *fname)
     }
 }
 
-DLLEXPORT void jl_restore_system_image_data(const char *buf, size_t len)
+JL_DLLEXPORT void jl_restore_system_image_data(const char *buf, size_t len)
 {
     ios_t f;
     JL_SIGATOMIC_BEGIN();
@@ -1945,7 +1945,7 @@ DLLEXPORT void jl_restore_system_image_data(const char *buf, size_t len)
     JL_SIGATOMIC_END();
 }
 
-DLLEXPORT jl_value_t *jl_ast_rettype(jl_lambda_info_t *li, jl_value_t *ast)
+JL_DLLEXPORT jl_value_t *jl_ast_rettype(jl_lambda_info_t *li, jl_value_t *ast)
 {
     if (jl_is_expr(ast))
         return jl_lam_body((jl_expr_t*)ast)->etype;
@@ -1972,7 +1972,7 @@ DLLEXPORT jl_value_t *jl_ast_rettype(jl_lambda_info_t *li, jl_value_t *ast)
     return rt;
 }
 
-DLLEXPORT jl_value_t *jl_compress_ast(jl_lambda_info_t *li, jl_value_t *ast)
+JL_DLLEXPORT jl_value_t *jl_compress_ast(jl_lambda_info_t *li, jl_value_t *ast)
 {
     JL_SIGATOMIC_BEGIN();
     DUMP_MODES last_mode = mode;
@@ -2010,7 +2010,7 @@ DLLEXPORT jl_value_t *jl_compress_ast(jl_lambda_info_t *li, jl_value_t *ast)
     return v;
 }
 
-DLLEXPORT jl_value_t *jl_uncompress_ast(jl_lambda_info_t *li, jl_value_t *data)
+JL_DLLEXPORT jl_value_t *jl_uncompress_ast(jl_lambda_info_t *li, jl_value_t *data)
 {
     JL_SIGATOMIC_BEGIN();
     assert(jl_is_array(data));
@@ -2034,7 +2034,7 @@ DLLEXPORT jl_value_t *jl_uncompress_ast(jl_lambda_info_t *li, jl_value_t *data)
     return v;
 }
 
-DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist)
+JL_DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist)
 {
     char *tmpfname = strcat(strcpy((char *) alloca(strlen(fname)+8), fname), ".XXXXXX");
     ios_t f;
@@ -2270,7 +2270,8 @@ static jl_array_t *_jl_restore_incremental(ios_t *f)
     return restored;
 }
 
-DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf, size_t sz)
+JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf,
+                                                         size_t sz)
 {
     ios_t f;
     jl_array_t *modules;
@@ -2279,7 +2280,7 @@ DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf, size_t sz
     return modules ? (jl_value_t*) modules : jl_nothing;
 }
 
-DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname)
+JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname)
 {
     ios_t f;
     jl_array_t *modules;

--- a/src/flisp/dirname.c
+++ b/src/flisp/dirname.c
@@ -39,7 +39,7 @@
 extern "C" {
 #endif
 
-DLLEXPORT char *dirname( char *path )
+JL_DLLEXPORT char *dirname( char *path )
 {
     size_t len;
     static char *retfail = NULL;

--- a/src/flisp/flisp.c
+++ b/src/flisp/flisp.c
@@ -54,7 +54,7 @@ extern "C" {
 
 #if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
 #include <malloc.h>
-DLLEXPORT char * dirname(char *);
+JL_DLLEXPORT char * dirname(char *);
 #else
 #include <libgen.h>
 #endif

--- a/src/flisp/flisp.h
+++ b/src/flisp/flisp.h
@@ -387,8 +387,8 @@ int fl_load_system_image(value_t ios);
 int fl_load_system_image_str(char* str, size_t len);
 
 /* julia extensions */
-DLLEXPORT int jl_id_char(uint32_t wc);
-DLLEXPORT int jl_id_start_char(uint32_t wc);
+JL_DLLEXPORT int jl_id_char(uint32_t wc);
+JL_DLLEXPORT int jl_id_start_char(uint32_t wc);
 
 #ifdef __cplusplus
 }

--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -4,7 +4,7 @@
 #include <assert.h>
 
 #include "utf8proc.h"
-#undef DLLEXPORT /* avoid conflicting definition */
+#undef JL_DLLEXPORT /* avoid conflicting definition */
 
 #include "flisp.h"
 
@@ -104,7 +104,7 @@ static int is_wc_cat_id_start(uint32_t wc, utf8proc_propval_t cat)
             (wc >= 0x309B && wc <= 0x309C)); // katakana-hiragana sound marks
 }
 
-DLLEXPORT int jl_id_start_char(uint32_t wc)
+JL_DLLEXPORT int jl_id_start_char(uint32_t wc)
 {
     if ((wc >= 'A' && wc <= 'Z') || (wc >= 'a' && wc <= 'z') || wc == '_')
         return 1;
@@ -114,7 +114,7 @@ DLLEXPORT int jl_id_start_char(uint32_t wc)
     return is_wc_cat_id_start(wc, prop->category);
 }
 
-DLLEXPORT int jl_id_char(uint32_t wc)
+JL_DLLEXPORT int jl_id_char(uint32_t wc)
 {
     if ((wc >= 'A' && wc <= 'Z') || (wc >= 'a' && wc <= 'z') || wc == '_' ||
         (wc >= '0' && wc <= '9') || wc == '!')

--- a/src/flisp/string.c
+++ b/src/flisp/string.c
@@ -19,7 +19,7 @@
 #include <sys/time.h>
 #endif /* !_OS_WINDOWS_ */
 
-#undef DLLEXPORT /* avoid conflicting definition */
+#undef JL_DLLEXPORT /* avoid conflicting definition */
 #include "utf8proc.h"
 
 #ifdef __cplusplus

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -16,8 +16,8 @@ region_t *jl_gc_find_region(void *ptr, int maybe)
 // singleton object), this usually returns the same pointer which points to
 // the next object but it can also return NULL if the pointer is pointing to
 // the end of the page.
-DLLEXPORT jl_taggedvalue_t *jl_gc_find_taggedvalue_pool(char *p,
-                                                        size_t *osize_p)
+JL_DLLEXPORT jl_taggedvalue_t *jl_gc_find_taggedvalue_pool(char *p,
+                                                           size_t *osize_p)
 {
     region_t *r = find_region(p, 1);
     // Not in the pool
@@ -291,7 +291,7 @@ typedef struct {
     jl_alloc_num_t print;
 } jl_gc_debug_env_t;
 
-DLLEXPORT jl_gc_debug_env_t jl_gc_debug_env = {
+JL_DLLEXPORT jl_gc_debug_env_t jl_gc_debug_env = {
     GC_MARKED_NOESC,
     {0, 0, 0, 0},
     {0, 0, 0, 0},

--- a/src/gc.c
+++ b/src/gc.c
@@ -413,7 +413,7 @@ void jl_gc_run_all_finalizers(void)
     run_finalizers();
 }
 
-DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f)
+JL_DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f)
 {
     JL_LOCK(finalizers);
     arraylist_push(&finalizer_list, (void*)v);
@@ -421,7 +421,7 @@ DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f)
     JL_UNLOCK(finalizers);
 }
 
-DLLEXPORT void jl_finalize(jl_value_t *o)
+JL_DLLEXPORT void jl_finalize(jl_value_t *o)
 {
     JL_LOCK(finalizers);
     // No need to check the to_finalize list since the user is apparently
@@ -486,7 +486,7 @@ static htable_t obj_counts[3];
 static htable_t obj_sizes[3];
 #endif
 
-DLLEXPORT size_t jl_gc_total_freed_bytes=0;
+JL_DLLEXPORT size_t jl_gc_total_freed_bytes=0;
 #ifdef GC_FINAL_STATS
 static uint64_t max_pause = 0;
 static uint64_t total_sweep_time = 0;
@@ -803,7 +803,7 @@ static inline int maybe_collect(void)
 
 // preserved values
 
-DLLEXPORT int jl_gc_n_preserved_values(void)
+JL_DLLEXPORT int jl_gc_n_preserved_values(void)
 {
     int len = 0;
     FOR_CURRENT_HEAP ()
@@ -811,14 +811,14 @@ DLLEXPORT int jl_gc_n_preserved_values(void)
     return len;
 }
 
-DLLEXPORT void jl_gc_preserve(jl_value_t *v)
+JL_DLLEXPORT void jl_gc_preserve(jl_value_t *v)
 {
     FOR_CURRENT_HEAP () {
         arraylist_push(&preserved_values, (void*)v);
     }
 }
 
-DLLEXPORT void jl_gc_unpreserve(void)
+JL_DLLEXPORT void jl_gc_unpreserve(void)
 {
     FOR_CURRENT_HEAP () {
         (void)arraylist_pop(&preserved_values);
@@ -827,7 +827,7 @@ DLLEXPORT void jl_gc_unpreserve(void)
 
 // weak references
 
-DLLEXPORT jl_weakref_t *jl_gc_new_weakref(jl_value_t *value)
+JL_DLLEXPORT jl_weakref_t *jl_gc_new_weakref(jl_value_t *value)
 {
     jl_weakref_t *wr = (jl_weakref_t*)jl_gc_alloc_1w();
     jl_set_typeof(wr, jl_weakref_type);
@@ -1472,7 +1472,7 @@ static void reset_remset(void)
     }
 }
 
-DLLEXPORT void jl_gc_queue_root(jl_value_t *ptr)
+JL_DLLEXPORT void jl_gc_queue_root(jl_value_t *ptr)
 {
     FOR_CURRENT_HEAP () {
         jl_taggedvalue_t *o = jl_astaggedvalue(ptr);
@@ -1636,7 +1636,7 @@ NOINLINE static void gc_mark_task(jl_task_t *ta, int d)
 // for chasing down unwanted references
 /*
 static jl_value_t *lookforme = NULL;
-DLLEXPORT void jl_gc_lookfor(jl_value_t *v) { lookforme = v; }
+JL_DLLEXPORT void jl_gc_lookfor(jl_value_t *v) { lookforme = v; }
 */
 
 #define MAX_MARK_DEPTH 400
@@ -1952,19 +1952,19 @@ static void post_mark(arraylist_t *list, int dryrun)
 // collector entry point and control
 
 static int is_gc_enabled = 1;
-DLLEXPORT int jl_gc_enable(int on)
+JL_DLLEXPORT int jl_gc_enable(int on)
 {
     int prev = is_gc_enabled;
     is_gc_enabled = (on!=0);
     return prev;
 }
-DLLEXPORT int jl_gc_is_enabled(void) { return is_gc_enabled; }
+JL_DLLEXPORT int jl_gc_is_enabled(void) { return is_gc_enabled; }
 
-DLLEXPORT int64_t jl_gc_total_bytes(void) { return total_allocd_bytes + allocd_bytes + collect_interval; }
-DLLEXPORT uint64_t jl_gc_total_hrtime(void) { return total_gc_time; }
-DLLEXPORT GC_Num jl_gc_num(void) { return gc_num; }
+JL_DLLEXPORT int64_t jl_gc_total_bytes(void) { return total_allocd_bytes + allocd_bytes + collect_interval; }
+JL_DLLEXPORT uint64_t jl_gc_total_hrtime(void) { return total_gc_time; }
+JL_DLLEXPORT GC_Num jl_gc_num(void) { return gc_num; }
 
-DLLEXPORT int64_t jl_gc_diff_total_bytes(void)
+JL_DLLEXPORT int64_t jl_gc_diff_total_bytes(void)
 {
     int64_t oldtb = last_gc_total_bytes;
     int64_t newtb = jl_gc_total_bytes();
@@ -2027,7 +2027,7 @@ void prepare_sweep(void)
 {
 }
 
-DLLEXPORT void jl_gc_collect(int full)
+JL_DLLEXPORT void jl_gc_collect(int full)
 {
     if (!is_gc_enabled) return;
     if (jl_in_gc) return;
@@ -2332,7 +2332,7 @@ void *reallocb(void *b, size_t sz)
 }
 */
 
-DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz)
+JL_DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz)
 {
     size_t allocsz = sz + sizeof_jl_taggedvalue_t;
     if (allocsz < sz) // overflow in adding offs, size was "negative"
@@ -2348,7 +2348,7 @@ DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz)
     return jl_valueof(alloc_big(allocsz));
 }
 
-DLLEXPORT jl_value_t *jl_gc_alloc_0w(void)
+JL_DLLEXPORT jl_value_t *jl_gc_alloc_0w(void)
 {
     const int sz = sizeof_jl_taggedvalue_t;
     void *tag = NULL;
@@ -2361,7 +2361,7 @@ DLLEXPORT jl_value_t *jl_gc_alloc_0w(void)
     return jl_valueof(tag);
 }
 
-DLLEXPORT jl_value_t *jl_gc_alloc_1w(void)
+JL_DLLEXPORT jl_value_t *jl_gc_alloc_1w(void)
 {
     const int sz = LLT_ALIGN(sizeof_jl_taggedvalue_t + sizeof(void*), 16);
     void *tag = NULL;
@@ -2374,7 +2374,7 @@ DLLEXPORT jl_value_t *jl_gc_alloc_1w(void)
     return jl_valueof(tag);
 }
 
-DLLEXPORT jl_value_t *jl_gc_alloc_2w(void)
+JL_DLLEXPORT jl_value_t *jl_gc_alloc_2w(void)
 {
     const int sz = LLT_ALIGN(sizeof_jl_taggedvalue_t + sizeof(void*) * 2, 16);
     void *tag = NULL;
@@ -2387,7 +2387,7 @@ DLLEXPORT jl_value_t *jl_gc_alloc_2w(void)
     return jl_valueof(tag);
 }
 
-DLLEXPORT jl_value_t *jl_gc_alloc_3w(void)
+JL_DLLEXPORT jl_value_t *jl_gc_alloc_3w(void)
 {
     const int sz = LLT_ALIGN(sizeof_jl_taggedvalue_t + sizeof(void*) * 3, 16);
     void *tag = NULL;
@@ -2603,7 +2603,7 @@ static void big_obj_stats(void)
 }
 #endif //MEMPROFILE
 
-DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
+JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
 {
     maybe_collect();
     allocd_bytes += sz;
@@ -2614,7 +2614,7 @@ DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
     return b;
 }
 
-DLLEXPORT void *jl_gc_counted_calloc(size_t nm, size_t sz)
+JL_DLLEXPORT void *jl_gc_counted_calloc(size_t nm, size_t sz)
 {
     maybe_collect();
     allocd_bytes += nm*sz;
@@ -2625,14 +2625,15 @@ DLLEXPORT void *jl_gc_counted_calloc(size_t nm, size_t sz)
     return b;
 }
 
-DLLEXPORT void jl_gc_counted_free(void *p, size_t sz)
+JL_DLLEXPORT void jl_gc_counted_free(void *p, size_t sz)
 {
     free(p);
     freed_bytes += sz;
     gc_num.freecall++;
 }
 
-DLLEXPORT void *jl_gc_counted_realloc_with_old_size(void *p, size_t old, size_t sz)
+JL_DLLEXPORT void *jl_gc_counted_realloc_with_old_size(void *p, size_t old,
+                                                       size_t sz)
 {
     maybe_collect();
 
@@ -2647,14 +2648,14 @@ DLLEXPORT void *jl_gc_counted_realloc_with_old_size(void *p, size_t old, size_t 
     return b;
 }
 
-DLLEXPORT void *jl_malloc(size_t sz)
+JL_DLLEXPORT void *jl_malloc(size_t sz)
 {
     int64_t *p = (int64_t *)jl_gc_counted_malloc(sz + 16);
     p[0] = sz;
     return (void *)(p + 2);
 }
 
-DLLEXPORT void *jl_calloc(size_t nm, size_t sz)
+JL_DLLEXPORT void *jl_calloc(size_t nm, size_t sz)
 {
     int64_t *p;
     size_t nmsz = nm*sz;
@@ -2663,14 +2664,14 @@ DLLEXPORT void *jl_calloc(size_t nm, size_t sz)
     return (void *)(p + 2);
 }
 
-DLLEXPORT void jl_free(void *p)
+JL_DLLEXPORT void jl_free(void *p)
 {
     int64_t *pp = (int64_t *)p - 2;
     size_t sz = pp[0];
     jl_gc_counted_free(pp, sz + 16);
 }
 
-DLLEXPORT void *jl_realloc(void *p, size_t sz)
+JL_DLLEXPORT void *jl_realloc(void *p, size_t sz)
 {
     int64_t *pp = (int64_t *)p - 2;
     size_t szold = pp[0];
@@ -2679,7 +2680,7 @@ DLLEXPORT void *jl_realloc(void *p, size_t sz)
     return (void *)(pnew + 2);
 }
 
-DLLEXPORT void *jl_gc_managed_malloc(size_t sz)
+JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz)
 {
     maybe_collect();
     size_t allocsz = LLT_ALIGN(sz, 16);
@@ -2693,7 +2694,8 @@ DLLEXPORT void *jl_gc_managed_malloc(size_t sz)
     return b;
 }
 
-DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz, int isaligned, jl_value_t* owner)
+JL_DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz,
+                                         int isaligned, jl_value_t* owner)
 {
     maybe_collect();
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -421,7 +421,7 @@ DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f)
     JL_UNLOCK(finalizers);
 }
 
-void jl_finalize(jl_value_t *o)
+DLLEXPORT void jl_finalize(jl_value_t *o)
 {
     JL_LOCK(finalizers);
     // No need to check the to_finalize list since the user is apparently
@@ -2027,7 +2027,7 @@ void prepare_sweep(void)
 {
 }
 
-void jl_gc_collect(int full)
+DLLEXPORT void jl_gc_collect(int full)
 {
     if (!is_gc_enabled) return;
     if (jl_in_gc) return;

--- a/src/gf.c
+++ b/src/gf.c
@@ -923,7 +923,9 @@ static jl_value_t *lookup_match(jl_value_t *a, jl_value_t *b, jl_svec_t **penv,
     return ti;
 }
 
-DLLEXPORT jl_function_t *jl_instantiate_staged(jl_methlist_t *m, jl_tupletype_t *tt, jl_svec_t *env)
+JL_DLLEXPORT jl_function_t *jl_instantiate_staged(jl_methlist_t *m,
+                                                  jl_tupletype_t *tt,
+                                                  jl_svec_t *env)
 {
     jl_expr_t *ex = NULL;
     jl_expr_t *oldast = NULL;
@@ -1083,7 +1085,7 @@ static int sigs_eq(jl_value_t *a, jl_value_t *b, int useenv)
     return jl_subtype(a, b, 0) && jl_subtype(b, a, 0);
 }
 
-DLLEXPORT int jl_args_morespecific(jl_value_t *a, jl_value_t *b)
+JL_DLLEXPORT int jl_args_morespecific(jl_value_t *a, jl_value_t *b)
 {
     int msp = jl_type_morespecific(a,b);
     int btv = jl_has_typevars(b);
@@ -1370,7 +1372,7 @@ jl_methlist_t *jl_method_table_insert(jl_methtable_t *mt, jl_tupletype_t *type,
     return ml;
 }
 
-void NORETURN jl_no_method_error_bare(jl_function_t *f, jl_value_t *args)
+void JL_NORETURN jl_no_method_error_bare(jl_function_t *f, jl_value_t *args)
 {
     jl_value_t *fargs[3] = {
         (jl_value_t*)jl_methoderror_type,
@@ -1381,7 +1383,8 @@ void NORETURN jl_no_method_error_bare(jl_function_t *f, jl_value_t *args)
     // not reached
 }
 
-void NORETURN jl_no_method_error(jl_function_t *f, jl_value_t **args, size_t na)
+void JL_NORETURN jl_no_method_error(jl_function_t *f, jl_value_t **args,
+                                    size_t na)
 {
     jl_value_t *argtup = jl_f_tuple(NULL, args, na);
     JL_GC_PUSH1(&argtup);
@@ -1433,7 +1436,7 @@ jl_function_t *jl_method_lookup_by_type(jl_methtable_t *mt, jl_tupletype_t *type
     return sf;
 }
 
-DLLEXPORT int jl_method_exists(jl_methtable_t *mt, jl_tupletype_t *types)
+JL_DLLEXPORT int jl_method_exists(jl_methtable_t *mt, jl_tupletype_t *types)
 {
     return jl_method_lookup_by_type(mt, types, 0, 0) != jl_bottom_func;
 }
@@ -1450,7 +1453,8 @@ jl_function_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t na
     return sf;
 }
 
-DLLEXPORT jl_value_t *jl_matching_methods(jl_function_t *gf, jl_value_t *type, int lim);
+JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_function_t *gf,
+                                             jl_value_t *type, int lim);
 
 // compile-time method lookup
 jl_function_t *jl_get_specialization(jl_function_t *f, jl_tupletype_t *types)
@@ -1830,7 +1834,7 @@ void jl_compile_all(void)
     htable_free(&h);
 }
 
-DLLEXPORT void jl_compile_hint(jl_function_t *f, jl_tupletype_t *types)
+JL_DLLEXPORT void jl_compile_hint(jl_function_t *f, jl_tupletype_t *types)
 {
     (void)jl_get_specialization(f, types);
 }
@@ -1922,7 +1926,8 @@ JL_CALLABLE(jl_apply_generic)
     return res;
 }
 
-DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_function_t *gf, jl_datatype_t *types)
+JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_function_t *gf,
+                                             jl_datatype_t *types)
 {
     assert(jl_is_gf(gf));
     jl_methtable_t *mt = jl_gf_mtable(gf);
@@ -2050,7 +2055,7 @@ jl_function_t *jl_new_generic_function(jl_sym_t *name, jl_module_t *module)
     return f;
 }
 
-DLLEXPORT jl_function_t *jl_new_gf_internal(jl_value_t *env)
+JL_DLLEXPORT jl_function_t *jl_new_gf_internal(jl_value_t *env)
 {
     return jl_new_closure(jl_apply_generic, env, NULL);
 }
@@ -2082,7 +2087,8 @@ void jl_add_method(jl_function_t *gf, jl_tupletype_t *types, jl_function_t *meth
     JL_GC_POP();
 }
 
-DLLEXPORT jl_svec_t *jl_match_method(jl_value_t *type, jl_value_t *sig, jl_svec_t *tvars)
+JL_DLLEXPORT jl_svec_t *jl_match_method(jl_value_t *type, jl_value_t *sig,
+                                        jl_svec_t *tvars)
 {
     jl_svec_t *env = jl_emptysvec;
     jl_value_t *ti=NULL;
@@ -2226,7 +2232,7 @@ static jl_value_t *ml_matches(jl_methlist_t *ml, jl_value_t *type,
 //
 // lim is the max # of methods to return. if there are more return jl_false.
 // -1 for no limit.
-DLLEXPORT
+JL_DLLEXPORT
 jl_value_t *jl_matching_methods(jl_function_t *gf, jl_value_t *type, int lim)
 {
     assert(jl_is_func(gf));

--- a/src/init.c
+++ b/src/init.c
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 #ifdef _MSC_VER
-DLLEXPORT char * dirname(char *);
+JL_DLLEXPORT char * dirname(char *);
 #else
 #include <libgen.h>
 #endif
@@ -154,7 +154,7 @@ static struct uv_shutdown_queue_item *next_shutdown_queue_item(struct uv_shutdow
     return rv;
 }
 
-DLLEXPORT void jl_atexit_hook(int exitcode)
+JL_DLLEXPORT void jl_atexit_hook(int exitcode)
 {
     if (exitcode == 0) julia_save();
     jl_print_gc_stats(JL_STDERR);
@@ -250,10 +250,10 @@ DLLEXPORT void jl_atexit_hook(int exitcode)
 
 void jl_get_builtin_hooks(void);
 
-DLLEXPORT void *jl_dl_handle;
+JL_DLLEXPORT void *jl_dl_handle;
 void *jl_RTLD_DEFAULT_handle;
 #ifdef _OS_WINDOWS_
-DLLEXPORT void *jl_exe_handle;
+JL_DLLEXPORT void *jl_exe_handle;
 void *jl_ntdll_handle;
 void *jl_kernel32_handle;
 void *jl_crtdll_handle;
@@ -633,7 +633,7 @@ void _julia_init(JL_IMAGE_SEARCH rel)
 
 extern int asprintf(char **str, const char *fmt, ...);
 
-DLLEXPORT int jl_generating_output(void)
+JL_DLLEXPORT int jl_generating_output(void)
 {
     return jl_options.outputo || jl_options.outputbc || jl_options.outputji;
 }
@@ -702,7 +702,7 @@ static void julia_save(void)
 
 jl_function_t *jl_typeinf_func=NULL;
 
-DLLEXPORT void jl_set_typeinf_func(jl_value_t* f)
+JL_DLLEXPORT void jl_set_typeinf_func(jl_value_t* f)
 {
     if (!jl_is_function(f))
         jl_error("jl_set_typeinf_func must set a jl_function_t*");
@@ -771,7 +771,7 @@ void jl_get_builtin_hooks(void)
                                         jl_svec2(jl_uint8_type, jl_box_long(1)));
 }
 
-DLLEXPORT void jl_get_system_hooks(void)
+JL_DLLEXPORT void jl_get_system_hooks(void)
 {
     if (jl_errorexception_type) return; // only do this once
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -25,8 +25,10 @@ jl_value_t *jl_interpret_toplevel_expr(jl_value_t *e)
     return eval(e, NULL, 0, 0);
 }
 
-DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
-                                                    jl_value_t **locals, size_t nl)
+JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m,
+                                                       jl_value_t *e,
+                                                       jl_value_t **locals,
+                                                       size_t nl)
 {
     jl_value_t *v=NULL;
     jl_module_t *last_m = jl_current_module;

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -419,7 +419,7 @@ static void jl_write(uv_stream_t *stream, const char *str, size_t n)
 
 extern int vasprintf(char **str, const char *fmt, va_list ap);
 
-int jl_vprintf(uv_stream_t *s, const char *format, va_list args)
+DLLEXPORT int jl_vprintf(uv_stream_t *s, const char *format, va_list args)
 {
     char *str=NULL;
     int c;
@@ -440,7 +440,7 @@ int jl_vprintf(uv_stream_t *s, const char *format, va_list args)
     return c;
 }
 
-int jl_printf(uv_stream_t *s, const char *format, ...)
+DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...)
 {
     va_list args;
     int c;
@@ -485,7 +485,8 @@ DLLEXPORT int jl_getpid(void)
 }
 
 //NOTE: These function expects port/host to be in network byte-order (Big Endian)
-DLLEXPORT int jl_tcp_bind(uv_tcp_t *handle, uint16_t port, uint32_t host, unsigned int flags)
+DLLEXPORT int jl_tcp_bind(uv_tcp_t *handle, uint16_t port, uint32_t host,
+                          unsigned int flags)
 {
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(struct sockaddr_in));

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -65,7 +65,7 @@ static void jl_uv_call_close_callback(void *val)
     jl_apply((jl_function_t*)cb, (jl_value_t**)&val, 1);
 }
 
-DLLEXPORT void jl_uv_closeHandle(uv_handle_t *handle)
+JL_DLLEXPORT void jl_uv_closeHandle(uv_handle_t *handle)
 {
     // if the user killed a stdio handle,
     // revert back to direct stdio FILE* writes
@@ -82,7 +82,7 @@ DLLEXPORT void jl_uv_closeHandle(uv_handle_t *handle)
     free(handle);
 }
 
-DLLEXPORT void jl_uv_shutdownCallback(uv_shutdown_t *req, int status)
+JL_DLLEXPORT void jl_uv_shutdownCallback(uv_shutdown_t *req, int status)
 {
     /*
      * This happens if the remote machine closes the connecition while we're
@@ -96,20 +96,20 @@ DLLEXPORT void jl_uv_shutdownCallback(uv_shutdown_t *req, int status)
 }
 
 // getters and setters
-DLLEXPORT void *jl_uv_process_data(uv_process_t *p) { return p->data; }
-DLLEXPORT void *jl_uv_buf_base(const uv_buf_t *buf) { return buf->base; }
-DLLEXPORT size_t jl_uv_buf_len(const uv_buf_t *buf) { return buf->len; }
-DLLEXPORT void jl_uv_buf_set_base(uv_buf_t *buf, char *b) { buf->base = b; }
-DLLEXPORT void jl_uv_buf_set_len(uv_buf_t *buf, size_t n) { buf->len = n; }
-DLLEXPORT void *jl_uv_connect_handle(uv_connect_t *connect) { return connect->handle; }
-DLLEXPORT void *jl_uv_getaddrinfo_data(uv_getaddrinfo_t *req) { return req->data; }
-DLLEXPORT uv_file jl_uv_file_handle(jl_uv_file_t *f) { return f->file; }
-DLLEXPORT void *jl_uv_req_data(uv_req_t *req) { return req->data; }
-DLLEXPORT void jl_uv_req_set_data(uv_req_t *req, void *data) { req->data = data; }
-DLLEXPORT void *jl_uv_handle_data(uv_handle_t *handle) { return handle->data; }
-DLLEXPORT void *jl_uv_write_handle(uv_write_t *req) { return req->handle; }
+JL_DLLEXPORT void *jl_uv_process_data(uv_process_t *p) { return p->data; }
+JL_DLLEXPORT void *jl_uv_buf_base(const uv_buf_t *buf) { return buf->base; }
+JL_DLLEXPORT size_t jl_uv_buf_len(const uv_buf_t *buf) { return buf->len; }
+JL_DLLEXPORT void jl_uv_buf_set_base(uv_buf_t *buf, char *b) { buf->base = b; }
+JL_DLLEXPORT void jl_uv_buf_set_len(uv_buf_t *buf, size_t n) { buf->len = n; }
+JL_DLLEXPORT void *jl_uv_connect_handle(uv_connect_t *connect) { return connect->handle; }
+JL_DLLEXPORT void *jl_uv_getaddrinfo_data(uv_getaddrinfo_t *req) { return req->data; }
+JL_DLLEXPORT uv_file jl_uv_file_handle(jl_uv_file_t *f) { return f->file; }
+JL_DLLEXPORT void *jl_uv_req_data(uv_req_t *req) { return req->data; }
+JL_DLLEXPORT void jl_uv_req_set_data(uv_req_t *req, void *data) { req->data = data; }
+JL_DLLEXPORT void *jl_uv_handle_data(uv_handle_t *handle) { return handle->data; }
+JL_DLLEXPORT void *jl_uv_write_handle(uv_write_t *req) { return req->handle; }
 
-DLLEXPORT int jl_run_once(uv_loop_t *loop)
+JL_DLLEXPORT int jl_run_once(uv_loop_t *loop)
 {
     if (loop) {
         loop->stop_flag = 0;
@@ -118,7 +118,7 @@ DLLEXPORT int jl_run_once(uv_loop_t *loop)
     else return 0;
 }
 
-DLLEXPORT void jl_run_event_loop(uv_loop_t *loop)
+JL_DLLEXPORT void jl_run_event_loop(uv_loop_t *loop)
 {
     if (loop) {
         loop->stop_flag = 0;
@@ -126,7 +126,7 @@ DLLEXPORT void jl_run_event_loop(uv_loop_t *loop)
     }
 }
 
-DLLEXPORT int jl_process_events(uv_loop_t *loop)
+JL_DLLEXPORT int jl_process_events(uv_loop_t *loop)
 {
     if (loop) {
         loop->stop_flag = 0;
@@ -135,7 +135,8 @@ DLLEXPORT int jl_process_events(uv_loop_t *loop)
     else return 0;
 }
 
-DLLEXPORT int jl_init_pipe(uv_pipe_t *pipe, int writable, int readable, int julia_only)
+JL_DLLEXPORT int jl_init_pipe(uv_pipe_t *pipe, int writable, int readable,
+                              int julia_only)
 {
      int flags = 0;
      if (writable)
@@ -148,7 +149,7 @@ DLLEXPORT int jl_init_pipe(uv_pipe_t *pipe, int writable, int readable, int juli
      return err;
 }
 
-DLLEXPORT void jl_close_uv(uv_handle_t *handle)
+JL_DLLEXPORT void jl_close_uv(uv_handle_t *handle)
 {
     if (handle->type == UV_FILE) {
         uv_fs_t req;
@@ -192,27 +193,28 @@ DLLEXPORT void jl_close_uv(uv_handle_t *handle)
     }
 }
 
-DLLEXPORT void jl_forceclose_uv(uv_handle_t *handle)
+JL_DLLEXPORT void jl_forceclose_uv(uv_handle_t *handle)
 {
     uv_close(handle,&jl_uv_closeHandle);
 }
 
-DLLEXPORT void jl_uv_associate_julia_struct(uv_handle_t *handle, jl_value_t *data)
+JL_DLLEXPORT void jl_uv_associate_julia_struct(uv_handle_t *handle,
+                                               jl_value_t *data)
 {
     handle->data = data;
 }
 
-DLLEXPORT void jl_uv_disassociate_julia_struct(uv_handle_t *handle)
+JL_DLLEXPORT void jl_uv_disassociate_julia_struct(uv_handle_t *handle)
 {
     handle->data = NULL;
 }
 
-DLLEXPORT int jl_spawn(char *name, char **argv, uv_loop_t *loop,
-                       uv_process_t *proc, jl_value_t *julia_struct,
-                       uv_handle_type stdin_type, uv_pipe_t *stdin_pipe,
-                       uv_handle_type stdout_type, uv_pipe_t *stdout_pipe,
-                       uv_handle_type stderr_type, uv_pipe_t *stderr_pipe,
-                       int flags, char **env, char *cwd, uv_exit_cb cb)
+JL_DLLEXPORT int jl_spawn(char *name, char **argv, uv_loop_t *loop,
+                          uv_process_t *proc, jl_value_t *julia_struct,
+                          uv_handle_type stdin_type, uv_pipe_t *stdin_pipe,
+                          uv_handle_type stdout_type, uv_pipe_t *stdout_pipe,
+                          uv_handle_type stderr_type, uv_pipe_t *stderr_pipe,
+                          int flags, char **env, char *cwd, uv_exit_cb cb)
 {
     uv_process_options_t opts;
     uv_stdio_container_t stdio[3];
@@ -241,7 +243,7 @@ DLLEXPORT int jl_spawn(char *name, char **argv, uv_loop_t *loop,
 
 #ifdef _OS_WINDOWS_
 #include <time.h>
-DLLEXPORT struct tm* localtime_r(const time_t *t, struct tm *tm)
+JL_DLLEXPORT struct tm* localtime_r(const time_t *t, struct tm *tm)
 {
     struct tm *tmp = localtime(t); //localtime is reentrant on windows
     if (tmp)
@@ -250,12 +252,12 @@ DLLEXPORT struct tm* localtime_r(const time_t *t, struct tm *tm)
 }
 #endif
 
-DLLEXPORT uv_loop_t *jl_global_event_loop(void)
+JL_DLLEXPORT uv_loop_t *jl_global_event_loop(void)
 {
     return jl_io_loop;
 }
 
-DLLEXPORT int jl_fs_unlink(char *path)
+JL_DLLEXPORT int jl_fs_unlink(char *path)
 {
     uv_fs_t req;
     JL_SIGATOMIC_BEGIN();
@@ -265,7 +267,7 @@ DLLEXPORT int jl_fs_unlink(char *path)
     return ret;
 }
 
-DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path)
+JL_DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path)
 {
     uv_fs_t req;
     JL_SIGATOMIC_BEGIN();
@@ -275,8 +277,8 @@ DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path)
     return ret;
 }
 
-DLLEXPORT int jl_fs_sendfile(int src_fd, int dst_fd,
-                             int64_t in_offset, size_t len)
+JL_DLLEXPORT int jl_fs_sendfile(int src_fd, int dst_fd,
+                                int64_t in_offset, size_t len)
 {
     uv_fs_t req;
     JL_SIGATOMIC_BEGIN();
@@ -287,7 +289,7 @@ DLLEXPORT int jl_fs_sendfile(int src_fd, int dst_fd,
     return ret;
 }
 
-DLLEXPORT int jl_fs_symlink(char *path, char *new_path, int flags)
+JL_DLLEXPORT int jl_fs_symlink(char *path, char *new_path, int flags)
 {
     uv_fs_t req;
     int ret = uv_fs_symlink(jl_io_loop, &req, path, new_path, flags, NULL);
@@ -295,7 +297,7 @@ DLLEXPORT int jl_fs_symlink(char *path, char *new_path, int flags)
     return ret;
 }
 
-DLLEXPORT int jl_fs_chmod(char *path, int mode)
+JL_DLLEXPORT int jl_fs_chmod(char *path, int mode)
 {
     uv_fs_t req;
     int ret = uv_fs_chmod(jl_io_loop, &req, path, mode, NULL);
@@ -303,7 +305,8 @@ DLLEXPORT int jl_fs_chmod(char *path, int mode)
     return ret;
 }
 
-DLLEXPORT int jl_fs_write(int handle, const char *data, size_t len, int64_t offset)
+JL_DLLEXPORT int jl_fs_write(int handle, const char *data, size_t len,
+                             int64_t offset)
 {
     uv_fs_t req;
     uv_buf_t buf[1];
@@ -314,7 +317,7 @@ DLLEXPORT int jl_fs_write(int handle, const char *data, size_t len, int64_t offs
     return ret;
 }
 
-DLLEXPORT int jl_fs_read(int handle, char *data, size_t len)
+JL_DLLEXPORT int jl_fs_read(int handle, char *data, size_t len)
 {
     uv_fs_t req;
     uv_buf_t buf[1];
@@ -325,7 +328,7 @@ DLLEXPORT int jl_fs_read(int handle, char *data, size_t len)
     return ret;
 }
 
-DLLEXPORT int jl_fs_read_byte(int handle)
+JL_DLLEXPORT int jl_fs_read_byte(int handle)
 {
     uv_fs_t req;
     char c;
@@ -339,7 +342,7 @@ DLLEXPORT int jl_fs_read_byte(int handle)
     return (int)c;
 }
 
-DLLEXPORT int jl_fs_close(int handle)
+JL_DLLEXPORT int jl_fs_close(int handle)
 {
     uv_fs_t req;
     int ret = uv_fs_close(jl_io_loop, &req, handle, NULL);
@@ -347,7 +350,8 @@ DLLEXPORT int jl_fs_close(int handle)
     return ret;
 }
 
-DLLEXPORT int jl_uv_write(uv_stream_t *stream, const char *data, size_t n, uv_write_t *uvw, void *writecb)
+JL_DLLEXPORT int jl_uv_write(uv_stream_t *stream, const char *data, size_t n,
+                             uv_write_t *uvw, void *writecb)
 {
     uv_buf_t buf[1];
     buf[0].base = (char*)data;
@@ -358,7 +362,7 @@ DLLEXPORT int jl_uv_write(uv_stream_t *stream, const char *data, size_t n, uv_wr
     return err;
 }
 
-DLLEXPORT void jl_uv_writecb(uv_write_t *req, int status)
+JL_DLLEXPORT void jl_uv_writecb(uv_write_t *req, int status)
 {
     free(req);
     if (status < 0) {
@@ -419,7 +423,7 @@ static void jl_write(uv_stream_t *stream, const char *str, size_t n)
 
 extern int vasprintf(char **str, const char *fmt, va_list ap);
 
-DLLEXPORT int jl_vprintf(uv_stream_t *s, const char *format, va_list args)
+JL_DLLEXPORT int jl_vprintf(uv_stream_t *s, const char *format, va_list args)
 {
     char *str=NULL;
     int c;
@@ -440,7 +444,7 @@ DLLEXPORT int jl_vprintf(uv_stream_t *s, const char *format, va_list args)
     return c;
 }
 
-DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...)
+JL_DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...)
 {
     va_list args;
     int c;
@@ -451,7 +455,7 @@ DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...)
     return c;
 }
 
-DLLEXPORT void jl_safe_printf(const char *fmt, ...)
+JL_DLLEXPORT void jl_safe_printf(const char *fmt, ...)
 {
     static char buf[1000];
     buf[0] = '\0';
@@ -468,14 +472,14 @@ DLLEXPORT void jl_safe_printf(const char *fmt, ...)
     }
 }
 
-DLLEXPORT void jl_exit(int exitcode)
+JL_DLLEXPORT void jl_exit(int exitcode)
 {
     uv_tty_reset_mode();
     jl_atexit_hook(exitcode);
     exit(exitcode);
 }
 
-DLLEXPORT int jl_getpid(void)
+JL_DLLEXPORT int jl_getpid(void)
 {
 #ifdef _OS_WINDOWS_
     return GetCurrentProcessId();
@@ -485,8 +489,8 @@ DLLEXPORT int jl_getpid(void)
 }
 
 //NOTE: These function expects port/host to be in network byte-order (Big Endian)
-DLLEXPORT int jl_tcp_bind(uv_tcp_t *handle, uint16_t port, uint32_t host,
-                          unsigned int flags)
+JL_DLLEXPORT int jl_tcp_bind(uv_tcp_t *handle, uint16_t port, uint32_t host,
+                             unsigned int flags)
 {
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(struct sockaddr_in));
@@ -496,7 +500,8 @@ DLLEXPORT int jl_tcp_bind(uv_tcp_t *handle, uint16_t port, uint32_t host,
     return uv_tcp_bind(handle, (struct sockaddr*)&addr, flags);
 }
 
-DLLEXPORT int jl_tcp_bind6(uv_tcp_t *handle, uint16_t port, void *host, unsigned int flags)
+JL_DLLEXPORT int jl_tcp_bind6(uv_tcp_t *handle, uint16_t port, void *host,
+                              unsigned int flags)
 {
     struct sockaddr_in6 addr;
     memset(&addr, 0, sizeof(struct sockaddr_in6));
@@ -506,7 +511,8 @@ DLLEXPORT int jl_tcp_bind6(uv_tcp_t *handle, uint16_t port, void *host, unsigned
     return uv_tcp_bind(handle, (struct sockaddr*)&addr, flags);
 }
 
-DLLEXPORT int jl_tcp_getsockname(uv_tcp_t *handle, uint16_t* port, void* host, uint32_t* family)
+JL_DLLEXPORT int jl_tcp_getsockname(uv_tcp_t *handle, uint16_t* port,
+                                    void* host, uint32_t* family)
 {
     int namelen;
     struct sockaddr_storage addr;
@@ -528,7 +534,8 @@ DLLEXPORT int jl_tcp_getsockname(uv_tcp_t *handle, uint16_t* port, void* host, u
     return res;
 }
 
-DLLEXPORT int jl_tcp_getpeername(uv_tcp_t *handle, uint16_t* port, void* host, uint32_t* family)
+JL_DLLEXPORT int jl_tcp_getpeername(uv_tcp_t *handle, uint16_t* port,
+                                    void* host, uint32_t* family)
 {
     int namelen;
     struct sockaddr_storage addr;
@@ -550,7 +557,8 @@ DLLEXPORT int jl_tcp_getpeername(uv_tcp_t *handle, uint16_t* port, void* host, u
     return res;
 }
 
-DLLEXPORT int jl_udp_bind(uv_udp_t *handle, uint16_t port, uint32_t host, uint32_t flags)
+JL_DLLEXPORT int jl_udp_bind(uv_udp_t *handle, uint16_t port, uint32_t host,
+                             uint32_t flags)
 {
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(struct sockaddr_in));
@@ -560,7 +568,8 @@ DLLEXPORT int jl_udp_bind(uv_udp_t *handle, uint16_t port, uint32_t host, uint32
     return uv_udp_bind(handle, (struct sockaddr*)&addr, flags);
 }
 
-DLLEXPORT int jl_udp_bind6(uv_udp_t *handle, uint16_t port, void *host, uint32_t flags)
+JL_DLLEXPORT int jl_udp_bind6(uv_udp_t *handle, uint16_t port, void *host,
+                              uint32_t flags)
 {
     struct sockaddr_in6 addr;
     memset(&addr, 0, sizeof(struct sockaddr_in6));
@@ -570,7 +579,8 @@ DLLEXPORT int jl_udp_bind6(uv_udp_t *handle, uint16_t port, void *host, uint32_t
     return uv_udp_bind(handle, (struct sockaddr*)&addr, flags);
 }
 
-DLLEXPORT int jl_udp_send(uv_udp_t *handle, uint16_t port, uint32_t host, void *data, uint32_t size, uv_udp_send_cb cb)
+JL_DLLEXPORT int jl_udp_send(uv_udp_t *handle, uint16_t port, uint32_t host,
+                             void *data, uint32_t size, uv_udp_send_cb cb)
 {
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(struct sockaddr_in));
@@ -585,7 +595,8 @@ DLLEXPORT int jl_udp_send(uv_udp_t *handle, uint16_t port, uint32_t host, void *
     return uv_udp_send(req, handle, buf, 1, (struct sockaddr*)&addr, cb);
 }
 
-DLLEXPORT int jl_udp_send6(uv_udp_t *handle, uint16_t port, void *host, void *data, uint32_t size, uv_udp_send_cb cb)
+JL_DLLEXPORT int jl_udp_send6(uv_udp_t *handle, uint16_t port, void *host,
+                              void *data, uint32_t size, uv_udp_send_cb cb)
 {
     struct sockaddr_in6 addr;
     memset(&addr, 0, sizeof(struct sockaddr_in6));
@@ -600,27 +611,30 @@ DLLEXPORT int jl_udp_send6(uv_udp_t *handle, uint16_t port, void *host, void *da
     return uv_udp_send(req, handle, buf, 1, (struct sockaddr*)&addr, cb);
 }
 
-DLLEXPORT int jl_uv_sizeof_interface_address(void)
+JL_DLLEXPORT int jl_uv_sizeof_interface_address(void)
 {
     return sizeof(uv_interface_address_t);
 }
 
-DLLEXPORT int jl_uv_interface_addresses(uv_interface_address_t **ifAddrStruct,int *count)
+JL_DLLEXPORT int jl_uv_interface_addresses(uv_interface_address_t **ifAddrStruct,
+                                           int *count)
 {
     return uv_interface_addresses(ifAddrStruct,count);
 }
 
-DLLEXPORT int jl_uv_interface_address_is_internal(uv_interface_address_t *addr)
+JL_DLLEXPORT int jl_uv_interface_address_is_internal(uv_interface_address_t *addr)
 {
     return addr->is_internal;
 }
 
-DLLEXPORT struct sockaddr_in *jl_uv_interface_address_sockaddr(uv_interface_address_t *ifa)
+JL_DLLEXPORT struct sockaddr_in *jl_uv_interface_address_sockaddr(uv_interface_address_t *ifa)
 {
     return &ifa->address.address4;
 }
 
-DLLEXPORT int jl_getaddrinfo(uv_loop_t *loop, const char *host, const char *service, jl_function_t *cb, uv_getaddrinfo_cb uvcb)
+JL_DLLEXPORT int jl_getaddrinfo(uv_loop_t *loop, const char *host,
+                                const char *service, jl_function_t *cb,
+                                uv_getaddrinfo_cb uvcb)
 {
     uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
     struct addrinfo hints;
@@ -635,47 +649,48 @@ DLLEXPORT int jl_getaddrinfo(uv_loop_t *loop, const char *host, const char *serv
     return uv_getaddrinfo(loop,req,uvcb,host,service,&hints);
 }
 
-DLLEXPORT struct sockaddr *jl_sockaddr_from_addrinfo(struct addrinfo *addrinfo)
+JL_DLLEXPORT struct sockaddr *jl_sockaddr_from_addrinfo(struct addrinfo *addrinfo)
 {
     return addrinfo->ai_addr;
 }
-DLLEXPORT struct addrinfo *jl_next_from_addrinfo(struct addrinfo *addrinfo)
+JL_DLLEXPORT struct addrinfo *jl_next_from_addrinfo(struct addrinfo *addrinfo)
 {
     return addrinfo->ai_next;
 }
 
-DLLEXPORT int jl_sockaddr_in_is_ip4(struct sockaddr_in *addr)
+JL_DLLEXPORT int jl_sockaddr_in_is_ip4(struct sockaddr_in *addr)
 {
     return (addr->sin_family==AF_INET);
 }
 
-DLLEXPORT int jl_sockaddr_in_is_ip6(struct sockaddr_in *addr)
+JL_DLLEXPORT int jl_sockaddr_in_is_ip6(struct sockaddr_in *addr)
 {
     return (addr->sin_family==AF_INET6);
 }
 
-DLLEXPORT int jl_sockaddr_is_ip4(struct sockaddr_storage *addr)
+JL_DLLEXPORT int jl_sockaddr_is_ip4(struct sockaddr_storage *addr)
 {
     return (addr->ss_family==AF_INET);
 }
 
-DLLEXPORT int jl_sockaddr_is_ip6(struct sockaddr_storage *addr)
+JL_DLLEXPORT int jl_sockaddr_is_ip6(struct sockaddr_storage *addr)
 {
     return (addr->ss_family==AF_INET6);
 }
 
-DLLEXPORT unsigned int jl_sockaddr_host4(struct sockaddr_in *addr)
+JL_DLLEXPORT unsigned int jl_sockaddr_host4(struct sockaddr_in *addr)
 {
     return addr->sin_addr.s_addr;
 }
 
-DLLEXPORT unsigned int jl_sockaddr_host6(struct sockaddr_in6 *addr, char *host)
+JL_DLLEXPORT unsigned int jl_sockaddr_host6(struct sockaddr_in6 *addr, char *host)
 {
     memcpy(host, &addr->sin6_addr, 16);
     return addr->sin6_scope_id;
 }
 
-DLLEXPORT void jl_sockaddr_set_port(struct sockaddr_storage *addr,uint16_t port)
+JL_DLLEXPORT void jl_sockaddr_set_port(struct sockaddr_storage *addr,
+                                       uint16_t port)
 {
     if (addr->ss_family==AF_INET)
         ((struct sockaddr_in*)addr)->sin_port = port;
@@ -683,7 +698,8 @@ DLLEXPORT void jl_sockaddr_set_port(struct sockaddr_storage *addr,uint16_t port)
         ((struct sockaddr_in6*)addr)->sin6_port = port;
 }
 
-DLLEXPORT int jl_tcp4_connect(uv_tcp_t *handle,uint32_t host, uint16_t port, uv_connect_cb cb)
+JL_DLLEXPORT int jl_tcp4_connect(uv_tcp_t *handle,uint32_t host, uint16_t port,
+                                 uv_connect_cb cb)
 {
     struct sockaddr_in addr;
     uv_connect_t *req = (uv_connect_t*)malloc(sizeof(uv_connect_t));
@@ -695,7 +711,8 @@ DLLEXPORT int jl_tcp4_connect(uv_tcp_t *handle,uint32_t host, uint16_t port, uv_
     return uv_tcp_connect(req,handle,(struct sockaddr*)&addr,cb);
 }
 
-DLLEXPORT int jl_tcp6_connect(uv_tcp_t *handle, void *host, uint16_t port, uv_connect_cb cb)
+JL_DLLEXPORT int jl_tcp6_connect(uv_tcp_t *handle, void *host, uint16_t port,
+                                 uv_connect_cb cb)
 {
     struct sockaddr_in6 addr;
     uv_connect_t *req = (uv_connect_t*)malloc(sizeof(uv_connect_t));
@@ -707,7 +724,8 @@ DLLEXPORT int jl_tcp6_connect(uv_tcp_t *handle, void *host, uint16_t port, uv_co
     return uv_tcp_connect(req,handle,(struct sockaddr*)&addr,cb);
 }
 
-DLLEXPORT int jl_connect_raw(uv_tcp_t *handle,struct sockaddr_storage *addr, uv_connect_cb cb)
+JL_DLLEXPORT int jl_connect_raw(uv_tcp_t *handle,struct sockaddr_storage *addr,
+                                uv_connect_cb cb)
 {
     uv_connect_t *req = (uv_connect_t*)malloc(sizeof(uv_connect_t));
     req->data = 0;
@@ -715,7 +733,7 @@ DLLEXPORT int jl_connect_raw(uv_tcp_t *handle,struct sockaddr_storage *addr, uv_
 }
 
 #ifdef _OS_LINUX_
-DLLEXPORT int jl_tcp_quickack(uv_tcp_t *handle, int on)
+JL_DLLEXPORT int jl_tcp_quickack(uv_tcp_t *handle, int on)
 {
     int fd = (handle)->io_watcher.fd;
     if (fd != -1) {
@@ -728,7 +746,7 @@ DLLEXPORT int jl_tcp_quickack(uv_tcp_t *handle, int on)
 
 #endif
 
-DLLEXPORT int jl_tcp_reuseport(uv_tcp_t *handle)
+JL_DLLEXPORT int jl_tcp_reuseport(uv_tcp_t *handle)
 {
 #if defined(SO_REUSEPORT)
     int fd = (handle)->io_watcher.fd;
@@ -744,7 +762,8 @@ DLLEXPORT int jl_tcp_reuseport(uv_tcp_t *handle)
 
 #ifndef _OS_WINDOWS_
 
-DLLEXPORT int jl_uv_unix_fd_is_watched(int fd, uv_poll_t *handle, uv_loop_t *loop)
+JL_DLLEXPORT int jl_uv_unix_fd_is_watched(int fd, uv_poll_t *handle,
+                                          uv_loop_t *loop)
 {
     if (fd >= loop->nwatchers)
         return 0;
@@ -765,7 +784,7 @@ static inline int ishexchar(char c)
    return 0;
 }
 
-DLLEXPORT int jl_ispty(uv_pipe_t *pipe)
+JL_DLLEXPORT int jl_ispty(uv_pipe_t *pipe)
 {
     if (pipe->type != UV_NAMED_PIPE) return 0;
     size_t len = 0;
@@ -796,7 +815,7 @@ DLLEXPORT int jl_ispty(uv_pipe_t *pipe)
 }
 #endif
 
-DLLEXPORT uv_handle_type jl_uv_handle_type(uv_handle_t *handle)
+JL_DLLEXPORT uv_handle_type jl_uv_handle_type(uv_handle_t *handle)
 {
 #ifdef _OS_WINDOWS_
     if (jl_ispty((uv_pipe_t*)handle))
@@ -805,7 +824,7 @@ DLLEXPORT uv_handle_type jl_uv_handle_type(uv_handle_t *handle)
     return handle->type;
 }
 
-DLLEXPORT int jl_tty_set_mode(uv_tty_t *handle, int mode)
+JL_DLLEXPORT int jl_tty_set_mode(uv_tty_t *handle, int mode)
 {
     if (handle->type != UV_TTY) return 0;
     return uv_tty_set_mode(handle, mode);
@@ -818,12 +837,12 @@ int uv___stream_fd(uv_stream_t *handle);
 #else
 #define uv__stream_fd(handle) ((handle)->io_watcher.fd)
 #endif /* defined(__APPLE__) */
-DLLEXPORT int jl_uv_handle(uv_stream_t *handle)
+JL_DLLEXPORT int jl_uv_handle(uv_stream_t *handle)
 {
     return uv__stream_fd(handle);
 }
 #else
-DLLEXPORT HANDLE jl_uv_handle(uv_stream_t *handle)
+JL_DLLEXPORT HANDLE jl_uv_handle(uv_stream_t *handle)
 {
     switch (handle->type) {
     case UV_TTY:

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -18,12 +18,12 @@ extern "C" {
 #endif
 
 #if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
-DLLEXPORT char * __cdecl dirname(char *);
+JL_DLLEXPORT char * __cdecl dirname(char *);
 #else
 #include <libgen.h>
 #endif
 
-DLLEXPORT int jl_is_initialized(void) { return jl_main_module!=NULL; }
+JL_DLLEXPORT int jl_is_initialized(void) { return jl_main_module!=NULL; }
 
 // First argument is the usr/lib directory where libjulia is, or NULL to guess.
 // if that doesn't work, try the full path to the "lib" directory that
@@ -31,7 +31,8 @@ DLLEXPORT int jl_is_initialized(void) { return jl_main_module!=NULL; }
 // Second argument is the path of a system image file (*.ji) relative to the
 // first argument path, or relative to the default julia home dir. The default
 // is something like ../lib/julia/sys.ji
-DLLEXPORT void jl_init_with_image(const char *julia_home_dir, const char *image_relative_path)
+JL_DLLEXPORT void jl_init_with_image(const char *julia_home_dir,
+                                     const char *image_relative_path)
 {
     if (jl_is_initialized()) return;
     libsupport_init();
@@ -42,12 +43,12 @@ DLLEXPORT void jl_init_with_image(const char *julia_home_dir, const char *image_
     jl_exception_clear();
 }
 
-DLLEXPORT void jl_init(const char *julia_home_dir)
+JL_DLLEXPORT void jl_init(const char *julia_home_dir)
 {
     jl_init_with_image(julia_home_dir, NULL);
 }
 
-DLLEXPORT void *jl_eval_string(const char *str)
+JL_DLLEXPORT void *jl_eval_string(const char *str)
 {
     jl_value_t *r;
     JL_TRY {
@@ -64,19 +65,19 @@ DLLEXPORT void *jl_eval_string(const char *str)
     return r;
 }
 
-DLLEXPORT jl_value_t *jl_exception_occurred(void)
+JL_DLLEXPORT jl_value_t *jl_exception_occurred(void)
 {
     return jl_exception_in_transit == jl_nothing ? NULL :
         jl_exception_in_transit;
 }
 
-DLLEXPORT void jl_exception_clear(void)
+JL_DLLEXPORT void jl_exception_clear(void)
 {
     jl_exception_in_transit = jl_nothing;
 }
 
 // get the name of a type as a string
-DLLEXPORT const char *jl_typename_str(jl_value_t *v)
+JL_DLLEXPORT const char *jl_typename_str(jl_value_t *v)
 {
     if (!jl_is_datatype(v))
         return NULL;
@@ -84,32 +85,33 @@ DLLEXPORT const char *jl_typename_str(jl_value_t *v)
 }
 
 // get the name of typeof(v) as a string
-DLLEXPORT const char *jl_typeof_str(jl_value_t *v)
+JL_DLLEXPORT const char *jl_typeof_str(jl_value_t *v)
 {
     return jl_typename_str((jl_value_t*)jl_typeof(v));
 }
 
-DLLEXPORT void *jl_array_eltype(jl_value_t *a)
+JL_DLLEXPORT void *jl_array_eltype(jl_value_t *a)
 {
     return jl_tparam0(jl_typeof(a));
 }
 
-DLLEXPORT int jl_array_rank(jl_value_t *a)
+JL_DLLEXPORT int jl_array_rank(jl_value_t *a)
 {
     return jl_array_ndims(a);
 }
 
-DLLEXPORT size_t jl_array_size(jl_value_t *a, int d)
+JL_DLLEXPORT size_t jl_array_size(jl_value_t *a, int d)
 {
     return jl_array_dim(a, d);
 }
 
-DLLEXPORT const char *jl_bytestring_ptr(jl_value_t *s)
+JL_DLLEXPORT const char *jl_bytestring_ptr(jl_value_t *s)
 {
     return jl_string_data(s);
 }
 
-DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs)
+JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args,
+                                 int32_t nargs)
 {
     jl_value_t *v;
     JL_TRY {
@@ -128,7 +130,7 @@ DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs
     return v;
 }
 
-DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
+JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
 {
     jl_value_t *v;
     JL_TRY {
@@ -143,7 +145,7 @@ DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
     return v;
 }
 
-DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
+JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
 {
     jl_value_t *v;
     JL_TRY {
@@ -158,7 +160,7 @@ DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
     return v;
 }
 
-DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b)
+JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b)
 {
     jl_value_t *v;
     JL_TRY {
@@ -174,7 +176,8 @@ DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b)
     return v;
 }
 
-DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a, jl_value_t *b, jl_value_t *c)
+JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a,
+                                  jl_value_t *b, jl_value_t *c)
 {
     jl_value_t *v;
     JL_TRY {
@@ -190,7 +193,7 @@ DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a, jl_value_t *b, j
     return v;
 }
 
-DLLEXPORT void jl_yield(void)
+JL_DLLEXPORT void jl_yield(void)
 {
     static jl_function_t *yieldfunc = NULL;
     if (yieldfunc == NULL)
@@ -199,7 +202,7 @@ DLLEXPORT void jl_yield(void)
         jl_call0(yieldfunc);
 }
 
-DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld)
+JL_DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld)
 {
     jl_value_t *v;
     JL_TRY {
@@ -214,19 +217,19 @@ DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld)
     return v;
 }
 
-DLLEXPORT void jl_sigatomic_begin(void)
+JL_DLLEXPORT void jl_sigatomic_begin(void)
 {
     JL_SIGATOMIC_BEGIN();
 }
 
-DLLEXPORT void jl_sigatomic_end(void)
+JL_DLLEXPORT void jl_sigatomic_end(void)
 {
     if (jl_defer_signal == 0)
         jl_error("sigatomic_end called in non-sigatomic region");
     JL_SIGATOMIC_END();
 }
 
-DLLEXPORT int jl_is_debugbuild(void)
+JL_DLLEXPORT int jl_is_debugbuild(void)
 {
 #ifdef JL_DEBUG_BUILD
     return 1;
@@ -235,42 +238,42 @@ DLLEXPORT int jl_is_debugbuild(void)
 #endif
 }
 
-DLLEXPORT jl_value_t *jl_get_julia_home(void)
+JL_DLLEXPORT jl_value_t *jl_get_julia_home(void)
 {
     return jl_cstr_to_string(jl_options.julia_home);
 }
 
-DLLEXPORT jl_value_t *jl_get_julia_bin(void)
+JL_DLLEXPORT jl_value_t *jl_get_julia_bin(void)
 {
     return jl_cstr_to_string(jl_options.julia_bin);
 }
 
-DLLEXPORT jl_value_t *jl_get_image_file(void)
+JL_DLLEXPORT jl_value_t *jl_get_image_file(void)
 {
     return jl_cstr_to_string(jl_options.image_file);
 }
 
-DLLEXPORT int jl_ver_major(void)
+JL_DLLEXPORT int jl_ver_major(void)
 {
     return JULIA_VERSION_MAJOR;
 }
 
-DLLEXPORT int jl_ver_minor(void)
+JL_DLLEXPORT int jl_ver_minor(void)
 {
     return JULIA_VERSION_MINOR;
 }
 
-DLLEXPORT int jl_ver_patch(void)
+JL_DLLEXPORT int jl_ver_patch(void)
 {
     return JULIA_VERSION_PATCH;
 }
 
-DLLEXPORT int jl_ver_is_release(void)
+JL_DLLEXPORT int jl_ver_is_release(void)
 {
     return JULIA_VERSION_IS_RELEASE;
 }
 
-DLLEXPORT const char* jl_ver_string(void)
+JL_DLLEXPORT const char* jl_ver_string(void)
 {
    return JULIA_VERSION_STRING;
 }
@@ -285,14 +288,14 @@ static const char *git_info_string(const char *fld) {
     return jl_string_data(f);
 }
 
-DLLEXPORT const char *jl_git_branch(void)
+JL_DLLEXPORT const char *jl_git_branch(void)
 {
     static const char *branch = NULL;
     if (!branch) branch = git_info_string("branch");
     return branch;
 }
 
-DLLEXPORT const char *jl_git_commit(void)
+JL_DLLEXPORT const char *jl_git_commit(void)
 {
     static const char *commit = NULL;
     if (!commit) commit = git_info_string("commit");
@@ -300,17 +303,17 @@ DLLEXPORT const char *jl_git_commit(void)
 }
 
 // Create function versions of some useful macros
-DLLEXPORT jl_taggedvalue_t *(jl_astaggedvalue)(jl_value_t *v)
+JL_DLLEXPORT jl_taggedvalue_t *(jl_astaggedvalue)(jl_value_t *v)
 {
     return jl_astaggedvalue(v);
 }
 
-DLLEXPORT jl_value_t *(jl_valueof)(jl_taggedvalue_t *v)
+JL_DLLEXPORT jl_value_t *(jl_valueof)(jl_taggedvalue_t *v)
 {
     return jl_valueof(v);
 }
 
-DLLEXPORT jl_value_t *(jl_typeof)(jl_value_t *v)
+JL_DLLEXPORT jl_value_t *(jl_typeof)(jl_value_t *v)
 {
     return jl_typeof(v);
 }

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -23,9 +23,7 @@ DLLEXPORT char * __cdecl dirname(char *);
 #include <libgen.h>
 #endif
 
-DLLEXPORT void *jl_eval_string(const char *str);
-
-int jl_is_initialized(void) { return jl_main_module!=NULL; }
+DLLEXPORT int jl_is_initialized(void) { return jl_main_module!=NULL; }
 
 // First argument is the usr/lib directory where libjulia is, or NULL to guess.
 // if that doesn't work, try the full path to the "lib" directory that
@@ -105,8 +103,6 @@ DLLEXPORT size_t jl_array_size(jl_value_t *a, int d)
 {
     return jl_array_dim(a, d);
 }
-
-DLLEXPORT void *jl_array_ptr(jl_array_t *a);
 
 DLLEXPORT const char *jl_bytestring_ptr(jl_value_t *s)
 {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -146,7 +146,7 @@ DLLEXPORT int jl_has_typevars(jl_value_t *v)
     return jl_has_typevars__(v, 0, NULL, 0);
 }
 
-int jl_is_leaf_type(jl_value_t *v)
+DLLEXPORT int jl_is_leaf_type(jl_value_t *v)
 {
     if (jl_is_datatype(v)) {
         if (((jl_datatype_t*)v)->abstract) {
@@ -177,7 +177,7 @@ static int type_eqv_(jl_value_t *a, jl_value_t *b);
 
 // Return true for any type (Integer or Unsigned) that can fit in a
 // size_t and pass back value, else return false
-int jl_get_size(jl_value_t *val, size_t *pnt)
+DLLEXPORT int jl_get_size(jl_value_t *val, size_t *pnt)
 {
     if (jl_is_long(val)) {
         ssize_t slen = jl_unbox_long(val);
@@ -303,7 +303,7 @@ jl_value_t *jl_type_union_v(jl_value_t **ts, size_t n)
     return (jl_value_t*)tu;
 }
 
-jl_value_t *jl_type_union(jl_svec_t *types)
+DLLEXPORT jl_value_t *jl_type_union(jl_svec_t *types)
 {
     return jl_type_union_v(jl_svec_data(types), jl_svec_len(types));
 }
@@ -1082,7 +1082,7 @@ static jl_value_t *jl_type_intersect(jl_value_t *a, jl_value_t *b,
     return result;
 }
 
-jl_value_t *jl_type_intersection(jl_value_t *a, jl_value_t *b)
+DLLEXPORT jl_value_t *jl_type_intersection(jl_value_t *a, jl_value_t *b)
 {
     jl_svec_t *env = jl_emptysvec;
     JL_GC_PUSH1(&env);
@@ -1637,7 +1637,7 @@ static int type_eqv_(jl_value_t *a, jl_value_t *b)
     return type_eqv__(a, b, 0);
 }
 
-int jl_types_equal(jl_value_t *a, jl_value_t *b)
+DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b)
 {
     return type_eqv_(a, b);
 }
@@ -1776,7 +1776,7 @@ jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n)
     return (jl_value_t*)result;
 }
 
-jl_value_t *jl_apply_type(jl_value_t *tc, jl_svec_t *params)
+DLLEXPORT jl_value_t *jl_apply_type(jl_value_t *tc, jl_svec_t *params)
 {
     // NOTE: callers are supposed to root these arguments, but there are
     // several uses that don't, so root here just to be safe.
@@ -2568,7 +2568,7 @@ static int jl_subtype_le(jl_value_t *a, jl_value_t *b, int ta, int invariant)
     return jl_egal(a, b);
 }
 
-int jl_subtype(jl_value_t *a, jl_value_t *b, int ta)
+DLLEXPORT int jl_subtype(jl_value_t *a, jl_value_t *b, int ta)
 {
     return jl_subtype_le(a, b, ta, 0);
 }
@@ -3144,7 +3144,8 @@ DLLEXPORT jl_tvar_t *jl_new_typevar_(jl_sym_t *name, jl_value_t *lb, jl_value_t 
     return tv;
 }
 
-jl_tvar_t *jl_new_typevar(jl_sym_t *name, jl_value_t *lb, jl_value_t *ub)
+DLLEXPORT jl_tvar_t *jl_new_typevar(jl_sym_t *name, jl_value_t *lb,
+                                    jl_value_t *ub)
 {
     return jl_new_typevar_(name, lb, ub, jl_false);
 }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -57,7 +57,7 @@ jl_datatype_t *jl_number_type;
 jl_datatype_t *jl_complex_type;
 jl_datatype_t *jl_signed_type;
 
-DLLEXPORT jl_value_t *jl_emptytuple=NULL;
+JL_DLLEXPORT jl_value_t *jl_emptytuple=NULL;
 jl_svec_t *jl_emptysvec;
 jl_value_t *jl_nothing;
 
@@ -122,7 +122,7 @@ static int jl_has_typevars__(jl_value_t *v, int incl_wildcard, jl_value_t **p, s
     return 0;
 }
 
-DLLEXPORT int jl_has_typevars_(jl_value_t *v, int incl_wildcard)
+JL_DLLEXPORT int jl_has_typevars_(jl_value_t *v, int incl_wildcard)
 {
     if (jl_is_typevar(v)) return 1;
     return jl_has_typevars__(v, incl_wildcard, NULL, 0);
@@ -140,13 +140,13 @@ static int jl_has_typevars_from_v(jl_value_t *v, jl_value_t **p, size_t np)
     return jl_has_typevars__(v, 0, p, np);
 }
 
-DLLEXPORT int jl_has_typevars(jl_value_t *v)
+JL_DLLEXPORT int jl_has_typevars(jl_value_t *v)
 {
     if (jl_is_typevar(v)) return 1;
     return jl_has_typevars__(v, 0, NULL, 0);
 }
 
-DLLEXPORT int jl_is_leaf_type(jl_value_t *v)
+JL_DLLEXPORT int jl_is_leaf_type(jl_value_t *v)
 {
     if (jl_is_datatype(v)) {
         if (((jl_datatype_t*)v)->abstract) {
@@ -177,7 +177,7 @@ static int type_eqv_(jl_value_t *a, jl_value_t *b);
 
 // Return true for any type (Integer or Unsigned) that can fit in a
 // size_t and pass back value, else return false
-DLLEXPORT int jl_get_size(jl_value_t *val, size_t *pnt)
+JL_DLLEXPORT int jl_get_size(jl_value_t *val, size_t *pnt)
 {
     if (jl_is_long(val)) {
         ssize_t slen = jl_unbox_long(val);
@@ -303,7 +303,7 @@ jl_value_t *jl_type_union_v(jl_value_t **ts, size_t n)
     return (jl_value_t*)tu;
 }
 
-DLLEXPORT jl_value_t *jl_type_union(jl_svec_t *types)
+JL_DLLEXPORT jl_value_t *jl_type_union(jl_svec_t *types)
 {
     return jl_type_union_v(jl_svec_data(types), jl_svec_len(types));
 }
@@ -1082,7 +1082,7 @@ static jl_value_t *jl_type_intersect(jl_value_t *a, jl_value_t *b,
     return result;
 }
 
-DLLEXPORT jl_value_t *jl_type_intersection(jl_value_t *a, jl_value_t *b)
+JL_DLLEXPORT jl_value_t *jl_type_intersection(jl_value_t *a, jl_value_t *b)
 {
     jl_svec_t *env = jl_emptysvec;
     JL_GC_PUSH1(&env);
@@ -1637,7 +1637,7 @@ static int type_eqv_(jl_value_t *a, jl_value_t *b)
     return type_eqv__(a, b, 0);
 }
 
-DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b)
+JL_DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b)
 {
     return type_eqv_(a, b);
 }
@@ -1776,7 +1776,7 @@ jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n)
     return (jl_value_t*)result;
 }
 
-DLLEXPORT jl_value_t *jl_apply_type(jl_value_t *tc, jl_svec_t *params)
+JL_DLLEXPORT jl_value_t *jl_apply_type(jl_value_t *tc, jl_svec_t *params)
 {
     // NOTE: callers are supposed to root these arguments, but there are
     // several uses that don't, so root here just to be safe.
@@ -1786,7 +1786,7 @@ DLLEXPORT jl_value_t *jl_apply_type(jl_value_t *tc, jl_svec_t *params)
     return t;
 }
 
-DLLEXPORT jl_value_t *jl_tupletype_fill(size_t n, jl_value_t *v)
+JL_DLLEXPORT jl_value_t *jl_tupletype_fill(size_t n, jl_value_t *v)
 {
     // TODO: replace with just using NTuple
     jl_value_t *p = NULL;
@@ -2165,12 +2165,12 @@ static jl_tupletype_t *jl_apply_tuple_type_v_(jl_value_t **p, size_t np, jl_svec
     return ndt;
 }
 
-DLLEXPORT jl_tupletype_t *jl_apply_tuple_type(jl_svec_t *params)
+JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type(jl_svec_t *params)
 {
     return jl_apply_tuple_type_v_(jl_svec_data(params), jl_svec_len(params), params);
 }
 
-DLLEXPORT jl_tupletype_t *jl_apply_tuple_type_v(jl_value_t **p, size_t np)
+JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type_v(jl_value_t **p, size_t np)
 {
     return jl_apply_tuple_type_v_(p, np, NULL);
 }
@@ -2568,7 +2568,7 @@ static int jl_subtype_le(jl_value_t *a, jl_value_t *b, int ta, int invariant)
     return jl_egal(a, b);
 }
 
-DLLEXPORT int jl_subtype(jl_value_t *a, jl_value_t *b, int ta)
+JL_DLLEXPORT int jl_subtype(jl_value_t *a, jl_value_t *b, int ta)
 {
     return jl_subtype_le(a, b, ta, 0);
 }
@@ -2809,7 +2809,7 @@ static int jl_type_morespecific_(jl_value_t *a, jl_value_t *b, int invariant)
     return 0;
 }
 
-DLLEXPORT int jl_type_morespecific(jl_value_t *a, jl_value_t *b)
+JL_DLLEXPORT int jl_type_morespecific(jl_value_t *a, jl_value_t *b)
 {
     return jl_type_morespecific_(a, b, 0);
 }
@@ -3134,7 +3134,8 @@ jl_value_t *jl_type_match_morespecific(jl_value_t *a, jl_value_t *b)
 
 // initialization -------------------------------------------------------------
 
-DLLEXPORT jl_tvar_t *jl_new_typevar_(jl_sym_t *name, jl_value_t *lb, jl_value_t *ub, jl_value_t *b)
+JL_DLLEXPORT jl_tvar_t *jl_new_typevar_(jl_sym_t *name, jl_value_t *lb,
+                                        jl_value_t *ub, jl_value_t *b)
 {
     jl_tvar_t *tv = (jl_tvar_t*)newobj((jl_value_t*)jl_tvar_type, 4);
     tv->name = name;
@@ -3144,8 +3145,8 @@ DLLEXPORT jl_tvar_t *jl_new_typevar_(jl_sym_t *name, jl_value_t *lb, jl_value_t 
     return tv;
 }
 
-DLLEXPORT jl_tvar_t *jl_new_typevar(jl_sym_t *name, jl_value_t *lb,
-                                    jl_value_t *ub)
+JL_DLLEXPORT jl_tvar_t *jl_new_typevar(jl_sym_t *name, jl_value_t *lb,
+                                       jl_value_t *ub)
 {
     return jl_new_typevar_(name, lb, ub, jl_false);
 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -41,14 +41,14 @@ extern "C" {
 #endif
 
 #if defined(__GNUC__)
-#  define NORETURN __attribute__ ((noreturn))
+#  define JL_NORETURN __attribute__ ((noreturn))
 #  define JL_CONST_FUNC __attribute__((const))
 #elif defined(_COMPILER_MICROSOFT_)
-#  define NORETURN __declspec(noreturn)
+#  define JL_NORETURN __declspec(noreturn)
 // This is the closest I can find for __attribute__((const))
 #  define JL_CONST_FUNC __declspec(noalias)
 #else
-#  define NORETURN
+#  define JL_NORETURN
 #  define JL_CONST_FUNC
 #endif
 
@@ -64,10 +64,10 @@ extern "C" {
 // JULIA_ENABLE_THREADING is switched on in Make.inc if JULIA_THREADS is
 // set (in Make.user)
 
-DLLEXPORT int16_t jl_threadid(void);
-DLLEXPORT void *jl_threadgroup(void);
-DLLEXPORT void jl_cpu_pause(void);
-DLLEXPORT void jl_threading_profile(void);
+JL_DLLEXPORT int16_t jl_threadid(void);
+JL_DLLEXPORT void *jl_threadgroup(void);
+JL_DLLEXPORT void jl_cpu_pause(void);
+JL_DLLEXPORT void jl_threading_profile(void);
 
 #if defined(__GNUC__)
 #  define JL_ATOMIC_FETCH_AND_ADD(a,b)                                    \
@@ -432,101 +432,101 @@ typedef struct {
 
 // constants and type objects -------------------------------------------------
 
-extern DLLEXPORT jl_datatype_t *jl_any_type;
-extern DLLEXPORT jl_datatype_t *jl_type_type;
-extern DLLEXPORT jl_tvar_t     *jl_typetype_tvar;
-extern DLLEXPORT jl_datatype_t *jl_typetype_type;
-extern DLLEXPORT jl_value_t    *jl_ANY_flag;
-extern DLLEXPORT jl_datatype_t *jl_typename_type;
-extern DLLEXPORT jl_datatype_t *jl_typector_type;
-extern DLLEXPORT jl_datatype_t *jl_sym_type;
-extern DLLEXPORT jl_datatype_t *jl_symbol_type;
-extern DLLEXPORT jl_datatype_t *jl_gensym_type;
-extern DLLEXPORT jl_datatype_t *jl_simplevector_type;
-extern DLLEXPORT jl_typename_t *jl_tuple_typename;
-extern DLLEXPORT jl_datatype_t *jl_anytuple_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_any_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_type_type;
+extern JL_DLLEXPORT jl_tvar_t     *jl_typetype_tvar;
+extern JL_DLLEXPORT jl_datatype_t *jl_typetype_type;
+extern JL_DLLEXPORT jl_value_t    *jl_ANY_flag;
+extern JL_DLLEXPORT jl_datatype_t *jl_typename_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_typector_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_sym_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_symbol_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_gensym_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_simplevector_type;
+extern JL_DLLEXPORT jl_typename_t *jl_tuple_typename;
+extern JL_DLLEXPORT jl_datatype_t *jl_anytuple_type;
 #define jl_tuple_type jl_anytuple_type
-extern DLLEXPORT jl_datatype_t *jl_ntuple_type;
-extern DLLEXPORT jl_typename_t *jl_ntuple_typename;
-extern DLLEXPORT jl_datatype_t *jl_vararg_type;
-extern DLLEXPORT jl_datatype_t *jl_tvar_type;
-extern DLLEXPORT jl_datatype_t *jl_task_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_ntuple_type;
+extern JL_DLLEXPORT jl_typename_t *jl_ntuple_typename;
+extern JL_DLLEXPORT jl_datatype_t *jl_vararg_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_tvar_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_task_type;
 
-extern DLLEXPORT jl_datatype_t *jl_uniontype_type;
-extern DLLEXPORT jl_datatype_t *jl_datatype_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_uniontype_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_datatype_type;
 
-extern DLLEXPORT jl_value_t *jl_bottom_type;
-extern DLLEXPORT jl_datatype_t *jl_lambda_info_type;
-extern DLLEXPORT jl_datatype_t *jl_module_type;
-extern DLLEXPORT jl_datatype_t *jl_function_type;
-extern DLLEXPORT jl_datatype_t *jl_abstractarray_type;
-extern DLLEXPORT jl_datatype_t *jl_densearray_type;
-extern DLLEXPORT jl_datatype_t *jl_array_type;
-extern DLLEXPORT jl_typename_t *jl_array_typename;
-extern DLLEXPORT jl_datatype_t *jl_weakref_type;
-extern DLLEXPORT jl_datatype_t *jl_ascii_string_type;
-extern DLLEXPORT jl_datatype_t *jl_utf8_string_type;
-extern DLLEXPORT jl_datatype_t *jl_errorexception_type;
-extern DLLEXPORT jl_datatype_t *jl_argumenterror_type;
-extern DLLEXPORT jl_datatype_t *jl_loaderror_type;
-extern DLLEXPORT jl_datatype_t *jl_initerror_type;
-extern DLLEXPORT jl_datatype_t *jl_typeerror_type;
-extern DLLEXPORT jl_datatype_t *jl_methoderror_type;
-extern DLLEXPORT jl_datatype_t *jl_undefvarerror_type;
-extern DLLEXPORT jl_value_t *jl_stackovf_exception;
-extern DLLEXPORT jl_value_t *jl_memory_exception;
-extern DLLEXPORT jl_value_t *jl_readonlymemory_exception;
-extern DLLEXPORT jl_value_t *jl_diverror_exception;
-extern DLLEXPORT jl_value_t *jl_domain_exception;
-extern DLLEXPORT jl_value_t *jl_overflow_exception;
-extern DLLEXPORT jl_value_t *jl_inexact_exception;
-extern DLLEXPORT jl_value_t *jl_undefref_exception;
-extern DLLEXPORT jl_value_t *jl_interrupt_exception;
-extern DLLEXPORT jl_datatype_t *jl_boundserror_type;
-extern DLLEXPORT jl_value_t *jl_an_empty_cell;
+extern JL_DLLEXPORT jl_value_t *jl_bottom_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_lambda_info_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_module_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_function_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_abstractarray_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_densearray_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_array_type;
+extern JL_DLLEXPORT jl_typename_t *jl_array_typename;
+extern JL_DLLEXPORT jl_datatype_t *jl_weakref_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_ascii_string_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_utf8_string_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_errorexception_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_argumenterror_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_loaderror_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_initerror_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_typeerror_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_methoderror_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_undefvarerror_type;
+extern JL_DLLEXPORT jl_value_t *jl_stackovf_exception;
+extern JL_DLLEXPORT jl_value_t *jl_memory_exception;
+extern JL_DLLEXPORT jl_value_t *jl_readonlymemory_exception;
+extern JL_DLLEXPORT jl_value_t *jl_diverror_exception;
+extern JL_DLLEXPORT jl_value_t *jl_domain_exception;
+extern JL_DLLEXPORT jl_value_t *jl_overflow_exception;
+extern JL_DLLEXPORT jl_value_t *jl_inexact_exception;
+extern JL_DLLEXPORT jl_value_t *jl_undefref_exception;
+extern JL_DLLEXPORT jl_value_t *jl_interrupt_exception;
+extern JL_DLLEXPORT jl_datatype_t *jl_boundserror_type;
+extern JL_DLLEXPORT jl_value_t *jl_an_empty_cell;
 
-extern DLLEXPORT jl_datatype_t *jl_bool_type;
-extern DLLEXPORT jl_datatype_t *jl_char_type;
-extern DLLEXPORT jl_datatype_t *jl_int8_type;
-extern DLLEXPORT jl_datatype_t *jl_uint8_type;
-extern DLLEXPORT jl_datatype_t *jl_int16_type;
-extern DLLEXPORT jl_datatype_t *jl_uint16_type;
-extern DLLEXPORT jl_datatype_t *jl_int32_type;
-extern DLLEXPORT jl_datatype_t *jl_uint32_type;
-extern DLLEXPORT jl_datatype_t *jl_int64_type;
-extern DLLEXPORT jl_datatype_t *jl_uint64_type;
-extern DLLEXPORT jl_datatype_t *jl_float32_type;
-extern DLLEXPORT jl_datatype_t *jl_float64_type;
-extern DLLEXPORT jl_datatype_t *jl_floatingpoint_type;
-extern DLLEXPORT jl_datatype_t *jl_number_type;
-extern DLLEXPORT jl_datatype_t *jl_void_type;
-extern DLLEXPORT jl_datatype_t *jl_complex_type;
-extern DLLEXPORT jl_datatype_t *jl_signed_type;
-extern DLLEXPORT jl_datatype_t *jl_voidpointer_type;
-extern DLLEXPORT jl_datatype_t *jl_pointer_type;
-extern DLLEXPORT jl_datatype_t *jl_ref_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_bool_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_char_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_int8_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_uint8_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_int16_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_uint16_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_int32_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_uint32_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_int64_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_uint64_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_float32_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_float64_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_floatingpoint_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_number_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_void_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_complex_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_signed_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_voidpointer_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_pointer_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_ref_type;
 
-extern DLLEXPORT jl_value_t *jl_array_uint8_type;
-extern DLLEXPORT jl_value_t *jl_array_any_type;
-extern DLLEXPORT jl_value_t *jl_array_symbol_type;
-extern DLLEXPORT jl_datatype_t *jl_expr_type;
-extern DLLEXPORT jl_datatype_t *jl_symbolnode_type;
-extern DLLEXPORT jl_datatype_t *jl_globalref_type;
-extern DLLEXPORT jl_datatype_t *jl_linenumbernode_type;
-extern DLLEXPORT jl_datatype_t *jl_labelnode_type;
-extern DLLEXPORT jl_datatype_t *jl_gotonode_type;
-extern DLLEXPORT jl_datatype_t *jl_quotenode_type;
-extern DLLEXPORT jl_datatype_t *jl_newvarnode_type;
-extern DLLEXPORT jl_datatype_t *jl_topnode_type;
-extern DLLEXPORT jl_datatype_t *jl_intrinsic_type;
-extern DLLEXPORT jl_datatype_t *jl_methtable_type;
-extern DLLEXPORT jl_datatype_t *jl_method_type;
+extern JL_DLLEXPORT jl_value_t *jl_array_uint8_type;
+extern JL_DLLEXPORT jl_value_t *jl_array_any_type;
+extern JL_DLLEXPORT jl_value_t *jl_array_symbol_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_expr_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_symbolnode_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_globalref_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_linenumbernode_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_labelnode_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_gotonode_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_quotenode_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_newvarnode_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_topnode_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_intrinsic_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_methtable_type;
+extern JL_DLLEXPORT jl_datatype_t *jl_method_type;
 
-extern DLLEXPORT jl_svec_t *jl_emptysvec;
-extern DLLEXPORT jl_value_t *jl_emptytuple;
-extern DLLEXPORT jl_value_t *jl_true;
-extern DLLEXPORT jl_value_t *jl_false;
-extern DLLEXPORT jl_value_t *jl_nothing;
+extern JL_DLLEXPORT jl_svec_t *jl_emptysvec;
+extern JL_DLLEXPORT jl_value_t *jl_emptytuple;
+extern JL_DLLEXPORT jl_value_t *jl_true;
+extern JL_DLLEXPORT jl_value_t *jl_false;
+extern JL_DLLEXPORT jl_value_t *jl_nothing;
 
 // some important symbols
 extern jl_sym_t *call_sym;
@@ -534,7 +534,7 @@ extern jl_sym_t *dots_sym;    extern jl_sym_t *vararg_sym;
 extern jl_sym_t *quote_sym;   extern jl_sym_t *newvar_sym;
 extern jl_sym_t *top_sym;     extern jl_sym_t *dot_sym;
 extern jl_sym_t *line_sym;    extern jl_sym_t *toplevel_sym;
-extern DLLEXPORT jl_sym_t *jl_incomplete_sym;
+extern JL_DLLEXPORT jl_sym_t *jl_incomplete_sym;
 extern jl_sym_t *error_sym;   extern jl_sym_t *amp_sym;
 extern jl_sym_t *module_sym;  extern jl_sym_t *colons_sym;
 extern jl_sym_t *export_sym;  extern jl_sym_t *import_sym;
@@ -605,30 +605,30 @@ typedef struct _jl_gcframe_t {
 
 #define JL_GC_POP() (jl_pgcstack = jl_pgcstack->prev)
 
-DLLEXPORT int jl_gc_enable(int on);
-DLLEXPORT int jl_gc_is_enabled(void);
-DLLEXPORT int64_t jl_gc_total_bytes(void);
-DLLEXPORT uint64_t jl_gc_total_hrtime(void);
-DLLEXPORT int64_t jl_gc_diff_total_bytes(void);
+JL_DLLEXPORT int jl_gc_enable(int on);
+JL_DLLEXPORT int jl_gc_is_enabled(void);
+JL_DLLEXPORT int64_t jl_gc_total_bytes(void);
+JL_DLLEXPORT uint64_t jl_gc_total_hrtime(void);
+JL_DLLEXPORT int64_t jl_gc_diff_total_bytes(void);
 
-DLLEXPORT void jl_gc_collect(int);
-DLLEXPORT void jl_gc_preserve(jl_value_t *v);
-DLLEXPORT void jl_gc_unpreserve(void);
-DLLEXPORT int jl_gc_n_preserved_values(void);
+JL_DLLEXPORT void jl_gc_collect(int);
+JL_DLLEXPORT void jl_gc_preserve(jl_value_t *v);
+JL_DLLEXPORT void jl_gc_unpreserve(void);
+JL_DLLEXPORT int jl_gc_n_preserved_values(void);
 
-DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f);
-DLLEXPORT void jl_finalize(jl_value_t *o);
-DLLEXPORT jl_weakref_t *jl_gc_new_weakref(jl_value_t *value);
-DLLEXPORT jl_value_t *jl_gc_alloc_0w(void);
-DLLEXPORT jl_value_t *jl_gc_alloc_1w(void);
-DLLEXPORT jl_value_t *jl_gc_alloc_2w(void);
-DLLEXPORT jl_value_t *jl_gc_alloc_3w(void);
-DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz);
+JL_DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f);
+JL_DLLEXPORT void jl_finalize(jl_value_t *o);
+JL_DLLEXPORT jl_weakref_t *jl_gc_new_weakref(jl_value_t *value);
+JL_DLLEXPORT jl_value_t *jl_gc_alloc_0w(void);
+JL_DLLEXPORT jl_value_t *jl_gc_alloc_1w(void);
+JL_DLLEXPORT jl_value_t *jl_gc_alloc_2w(void);
+JL_DLLEXPORT jl_value_t *jl_gc_alloc_3w(void);
+JL_DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz);
 
-DLLEXPORT void jl_clear_malloc_data(void);
+JL_DLLEXPORT void jl_clear_malloc_data(void);
 
 // GC write barriers
-DLLEXPORT void jl_gc_queue_root(jl_value_t *root); // root isa jl_value_t*
+JL_DLLEXPORT void jl_gc_queue_root(jl_value_t *root); // root isa jl_value_t*
 
 STATIC_INLINE void jl_gc_wb(void *parent, void *ptr)
 {
@@ -646,9 +646,9 @@ STATIC_INLINE void jl_gc_wb_back(void *ptr) // ptr isa jl_value_t*
     }
 }
 
-DLLEXPORT void *jl_gc_managed_malloc(size_t sz);
-DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz,
-                                      int isaligned, jl_value_t* owner);
+JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz);
+JL_DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz,
+                                         int isaligned, jl_value_t* owner);
 
 // object accessors -----------------------------------------------------------
 
@@ -676,7 +676,7 @@ STATIC_INLINE jl_value_t *jl_svecset(void *t, size_t i, void *x)
 #ifdef STORE_ARRAY_LEN
 #define jl_array_len(a)   (((jl_array_t*)(a))->length)
 #else
-DLLEXPORT size_t jl_array_len_(jl_array_t *a);
+JL_DLLEXPORT size_t jl_array_len_(jl_array_t *a);
 #define jl_array_len(a)   jl_array_len_((jl_array_t*)(a))
 #endif
 #define jl_array_data(a)  ((void*)((jl_array_t*)(a))->data)
@@ -953,103 +953,105 @@ STATIC_INLINE int jl_is_type_type(jl_value_t *v)
 }
 
 // object identity
-DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b);
-DLLEXPORT uptrint_t jl_object_id(jl_value_t *v);
+JL_DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT uptrint_t jl_object_id(jl_value_t *v);
 
 // type predicates and basic operations
-DLLEXPORT int jl_is_leaf_type(jl_value_t *v);
-DLLEXPORT int jl_has_typevars(jl_value_t *v);
-DLLEXPORT int jl_subtype(jl_value_t *a, jl_value_t *b, int ta);
-DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_type_union(jl_svec_t *types);
-DLLEXPORT jl_value_t *jl_type_intersection(jl_value_t *a, jl_value_t *b);
-DLLEXPORT int jl_args_morespecific(jl_value_t *a, jl_value_t *b);
-DLLEXPORT const char *jl_typename_str(jl_value_t *v);
-DLLEXPORT const char *jl_typeof_str(jl_value_t *v);
-DLLEXPORT int jl_type_morespecific(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT int jl_is_leaf_type(jl_value_t *v);
+JL_DLLEXPORT int jl_has_typevars(jl_value_t *v);
+JL_DLLEXPORT int jl_subtype(jl_value_t *a, jl_value_t *b, int ta);
+JL_DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_type_union(jl_svec_t *types);
+JL_DLLEXPORT jl_value_t *jl_type_intersection(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT int jl_args_morespecific(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT const char *jl_typename_str(jl_value_t *v);
+JL_DLLEXPORT const char *jl_typeof_str(jl_value_t *v);
+JL_DLLEXPORT int jl_type_morespecific(jl_value_t *a, jl_value_t *b);
 
 // type constructors
-DLLEXPORT jl_typename_t *jl_new_typename(jl_sym_t *name);
-DLLEXPORT jl_tvar_t *jl_new_typevar(jl_sym_t *name,jl_value_t *lb,jl_value_t *ub);
-DLLEXPORT jl_value_t *jl_apply_type(jl_value_t *tc, jl_svec_t *params);
-DLLEXPORT jl_tupletype_t *jl_apply_tuple_type(jl_svec_t *params);
-DLLEXPORT jl_tupletype_t *jl_apply_tuple_type_v(jl_value_t **p, size_t np);
-DLLEXPORT jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields,
-                                                       int8_t fielddesc_type);
-DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
-                                         jl_svec_t *parameters,
-                                         jl_svec_t *fnames, jl_svec_t *ftypes,
-                                         int abstract, int mutabl,
-                                         int ninitialized);
-DLLEXPORT jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
-                                         jl_svec_t *parameters, size_t nbits);
+JL_DLLEXPORT jl_typename_t *jl_new_typename(jl_sym_t *name);
+JL_DLLEXPORT jl_tvar_t *jl_new_typevar(jl_sym_t *name,jl_value_t *lb,jl_value_t *ub);
+JL_DLLEXPORT jl_value_t *jl_apply_type(jl_value_t *tc, jl_svec_t *params);
+JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type(jl_svec_t *params);
+JL_DLLEXPORT jl_tupletype_t *jl_apply_tuple_type_v(jl_value_t **p, size_t np);
+JL_DLLEXPORT jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields,
+                                                          int8_t fielddesc_type);
+JL_DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
+                                            jl_svec_t *parameters,
+                                            jl_svec_t *fnames, jl_svec_t *ftypes,
+                                            int abstract, int mutabl,
+                                            int ninitialized);
+JL_DLLEXPORT jl_datatype_t *jl_new_bitstype(jl_value_t *name,
+                                            jl_datatype_t *super,
+                                            jl_svec_t *parameters, size_t nbits);
 
 // constructors
-DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *bt, void *data);
-DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...);
-DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args, uint32_t na);
-DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type);
-DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t proc, jl_value_t *env,
-                                        jl_lambda_info_t *li);
-DLLEXPORT jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast,
-                                               jl_svec_t *sparams,
-                                               jl_module_t *ctx);
-DLLEXPORT jl_svec_t *jl_svec(size_t n, ...);
-DLLEXPORT jl_svec_t *jl_svec1(void *a);
-DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b);
-DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n);
-DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n);
-DLLEXPORT jl_svec_t *jl_svec_append(jl_svec_t *a, jl_svec_t *b);
-DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a);
-DLLEXPORT jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x);
-DLLEXPORT jl_value_t *jl_tupletype_fill(size_t n, jl_value_t *v);
-DLLEXPORT jl_sym_t *jl_symbol(const char *str);
-DLLEXPORT jl_sym_t *jl_symbol_lookup(const char *str);
-DLLEXPORT jl_sym_t *jl_symbol_n(const char *str, int32_t len);
-DLLEXPORT jl_sym_t *jl_gensym(void);
-DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len);
-DLLEXPORT jl_sym_t *jl_get_root_symbol(void);
-DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name, jl_value_t **bp,
-                                              jl_value_t *bp_owner,
-                                              jl_binding_t *bnd);
-DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp,
-                                    jl_value_t *bp_owner, jl_binding_t *bnd,
-                                    jl_svec_t *argtypes, jl_function_t *f,
-                                    jl_value_t *isstaged, jl_value_t *call_func,
-                                    int iskw);
-DLLEXPORT jl_value_t *jl_box_bool(int8_t x);
-DLLEXPORT jl_value_t *jl_box_int8(int8_t x);
-DLLEXPORT jl_value_t *jl_box_uint8(uint8_t x);
-DLLEXPORT jl_value_t *jl_box_int16(int16_t x);
-DLLEXPORT jl_value_t *jl_box_uint16(uint16_t x);
-DLLEXPORT jl_value_t *jl_box_int32(int32_t x);
-DLLEXPORT jl_value_t *jl_box_uint32(uint32_t x);
-DLLEXPORT jl_value_t *jl_box_char(uint32_t x);
-DLLEXPORT jl_value_t *jl_box_int64(int64_t x);
-DLLEXPORT jl_value_t *jl_box_uint64(uint64_t x);
-DLLEXPORT jl_value_t *jl_box_float32(float x);
-DLLEXPORT jl_value_t *jl_box_float64(double x);
-DLLEXPORT jl_value_t *jl_box_voidpointer(void *x);
-DLLEXPORT jl_value_t *jl_box_gensym(size_t x);
-DLLEXPORT jl_value_t *jl_box8 (jl_datatype_t *t, int8_t  x);
-DLLEXPORT jl_value_t *jl_box16(jl_datatype_t *t, int16_t x);
-DLLEXPORT jl_value_t *jl_box32(jl_datatype_t *t, int32_t x);
-DLLEXPORT jl_value_t *jl_box64(jl_datatype_t *t, int64_t x);
-DLLEXPORT int8_t jl_unbox_bool(jl_value_t *v);
-DLLEXPORT int8_t jl_unbox_int8(jl_value_t *v);
-DLLEXPORT uint8_t jl_unbox_uint8(jl_value_t *v);
-DLLEXPORT int16_t jl_unbox_int16(jl_value_t *v);
-DLLEXPORT uint16_t jl_unbox_uint16(jl_value_t *v);
-DLLEXPORT int32_t jl_unbox_int32(jl_value_t *v);
-DLLEXPORT uint32_t jl_unbox_uint32(jl_value_t *v);
-DLLEXPORT int64_t jl_unbox_int64(jl_value_t *v);
-DLLEXPORT uint64_t jl_unbox_uint64(jl_value_t *v);
-DLLEXPORT float jl_unbox_float32(jl_value_t *v);
-DLLEXPORT double jl_unbox_float64(jl_value_t *v);
-DLLEXPORT void *jl_unbox_voidpointer(jl_value_t *v);
-DLLEXPORT ssize_t jl_unbox_gensym(jl_value_t *v);
+JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *bt, void *data);
+JL_DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...);
+JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
+                                        uint32_t na);
+JL_DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type);
+JL_DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t proc, jl_value_t *env,
+                                           jl_lambda_info_t *li);
+JL_DLLEXPORT jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast,
+                                                  jl_svec_t *sparams,
+                                                  jl_module_t *ctx);
+JL_DLLEXPORT jl_svec_t *jl_svec(size_t n, ...);
+JL_DLLEXPORT jl_svec_t *jl_svec1(void *a);
+JL_DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b);
+JL_DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n);
+JL_DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n);
+JL_DLLEXPORT jl_svec_t *jl_svec_append(jl_svec_t *a, jl_svec_t *b);
+JL_DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a);
+JL_DLLEXPORT jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x);
+JL_DLLEXPORT jl_value_t *jl_tupletype_fill(size_t n, jl_value_t *v);
+JL_DLLEXPORT jl_sym_t *jl_symbol(const char *str);
+JL_DLLEXPORT jl_sym_t *jl_symbol_lookup(const char *str);
+JL_DLLEXPORT jl_sym_t *jl_symbol_n(const char *str, int32_t len);
+JL_DLLEXPORT jl_sym_t *jl_gensym(void);
+JL_DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len);
+JL_DLLEXPORT jl_sym_t *jl_get_root_symbol(void);
+JL_DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name, jl_value_t **bp,
+                                                 jl_value_t *bp_owner,
+                                                 jl_binding_t *bnd);
+JL_DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp,
+                                       jl_value_t *bp_owner, jl_binding_t *bnd,
+                                       jl_svec_t *argtypes, jl_function_t *f,
+                                       jl_value_t *isstaged,
+                                       jl_value_t *call_func, int iskw);
+JL_DLLEXPORT jl_value_t *jl_box_bool(int8_t x);
+JL_DLLEXPORT jl_value_t *jl_box_int8(int8_t x);
+JL_DLLEXPORT jl_value_t *jl_box_uint8(uint8_t x);
+JL_DLLEXPORT jl_value_t *jl_box_int16(int16_t x);
+JL_DLLEXPORT jl_value_t *jl_box_uint16(uint16_t x);
+JL_DLLEXPORT jl_value_t *jl_box_int32(int32_t x);
+JL_DLLEXPORT jl_value_t *jl_box_uint32(uint32_t x);
+JL_DLLEXPORT jl_value_t *jl_box_char(uint32_t x);
+JL_DLLEXPORT jl_value_t *jl_box_int64(int64_t x);
+JL_DLLEXPORT jl_value_t *jl_box_uint64(uint64_t x);
+JL_DLLEXPORT jl_value_t *jl_box_float32(float x);
+JL_DLLEXPORT jl_value_t *jl_box_float64(double x);
+JL_DLLEXPORT jl_value_t *jl_box_voidpointer(void *x);
+JL_DLLEXPORT jl_value_t *jl_box_gensym(size_t x);
+JL_DLLEXPORT jl_value_t *jl_box8 (jl_datatype_t *t, int8_t  x);
+JL_DLLEXPORT jl_value_t *jl_box16(jl_datatype_t *t, int16_t x);
+JL_DLLEXPORT jl_value_t *jl_box32(jl_datatype_t *t, int32_t x);
+JL_DLLEXPORT jl_value_t *jl_box64(jl_datatype_t *t, int64_t x);
+JL_DLLEXPORT int8_t jl_unbox_bool(jl_value_t *v);
+JL_DLLEXPORT int8_t jl_unbox_int8(jl_value_t *v);
+JL_DLLEXPORT uint8_t jl_unbox_uint8(jl_value_t *v);
+JL_DLLEXPORT int16_t jl_unbox_int16(jl_value_t *v);
+JL_DLLEXPORT uint16_t jl_unbox_uint16(jl_value_t *v);
+JL_DLLEXPORT int32_t jl_unbox_int32(jl_value_t *v);
+JL_DLLEXPORT uint32_t jl_unbox_uint32(jl_value_t *v);
+JL_DLLEXPORT int64_t jl_unbox_int64(jl_value_t *v);
+JL_DLLEXPORT uint64_t jl_unbox_uint64(jl_value_t *v);
+JL_DLLEXPORT float jl_unbox_float32(jl_value_t *v);
+JL_DLLEXPORT double jl_unbox_float64(jl_value_t *v);
+JL_DLLEXPORT void *jl_unbox_voidpointer(jl_value_t *v);
+JL_DLLEXPORT ssize_t jl_unbox_gensym(jl_value_t *v);
 
-DLLEXPORT int jl_get_size(jl_value_t *val, size_t *pnt);
+JL_DLLEXPORT int jl_get_size(jl_value_t *val, size_t *pnt);
 
 #ifdef _P64
 #define jl_box_long(x)   jl_box_int64(x)
@@ -1066,127 +1068,137 @@ DLLEXPORT int jl_get_size(jl_value_t *val, size_t *pnt);
 #endif
 
 // structs
-DLLEXPORT int         jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err);
-DLLEXPORT jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i);
-DLLEXPORT jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i);
-DLLEXPORT void        jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs);
-DLLEXPORT int         jl_field_isdefined(jl_value_t *v, size_t i);
-DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld);
-DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a);
+JL_DLLEXPORT int         jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err);
+JL_DLLEXPORT jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i);
+JL_DLLEXPORT jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i);
+JL_DLLEXPORT void        jl_set_nth_field(jl_value_t *v, size_t i,
+                                          jl_value_t *rhs);
+JL_DLLEXPORT int         jl_field_isdefined(jl_value_t *v, size_t i);
+JL_DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld);
+JL_DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a);
 
 // arrays
 
-DLLEXPORT jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims);
-DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
-                                       jl_value_t *dims);
-DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
-                                         size_t nel, int own_buffer);
-DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
-                                      jl_value_t *dims, int own_buffer);
+JL_DLLEXPORT jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims);
+JL_DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
+                                          jl_value_t *dims);
+JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
+                                            size_t nel, int own_buffer);
+JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
+                                         jl_value_t *dims, int own_buffer);
 
-DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr);
-DLLEXPORT jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc);
-DLLEXPORT jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr, size_t nc,
-                                        size_t z);
-DLLEXPORT jl_array_t *jl_pchar_to_array(const char *str, size_t len);
-DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len);
-DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str);
-DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a);
-DLLEXPORT jl_array_t *jl_alloc_cell_1d(size_t n);
-DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i);  // 0-indexed
-DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *v, size_t i);  // 0-indexed
-DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i);  // 0-indexed
-DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc);
-DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec);
-DLLEXPORT void jl_array_grow_beg(jl_array_t *a, size_t inc);
-DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec);
-DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz);
-DLLEXPORT void jl_cell_1d_push(jl_array_t *a, jl_value_t *item);
-DLLEXPORT jl_value_t *jl_apply_array_type(jl_datatype_t *type, size_t dim);
+JL_DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr);
+JL_DLLEXPORT jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr,
+                                           size_t nc);
+JL_DLLEXPORT jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr,
+                                           size_t nc, size_t z);
+JL_DLLEXPORT jl_array_t *jl_pchar_to_array(const char *str, size_t len);
+JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len);
+JL_DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str);
+JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a);
+JL_DLLEXPORT jl_array_t *jl_alloc_cell_1d(size_t n);
+JL_DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i);  // 0-indexed
+JL_DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *v, size_t i);  // 0-indexed
+JL_DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i);  // 0-indexed
+JL_DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc);
+JL_DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec);
+JL_DLLEXPORT void jl_array_grow_beg(jl_array_t *a, size_t inc);
+JL_DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec);
+JL_DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz);
+JL_DLLEXPORT void jl_cell_1d_push(jl_array_t *a, jl_value_t *item);
+JL_DLLEXPORT jl_value_t *jl_apply_array_type(jl_datatype_t *type, size_t dim);
 // property access
-DLLEXPORT void *jl_array_ptr(jl_array_t *a);
-DLLEXPORT void *jl_array_eltype(jl_value_t *a);
-DLLEXPORT int jl_array_rank(jl_value_t *a);
-DLLEXPORT size_t jl_array_size(jl_value_t *a, int d);
+JL_DLLEXPORT void *jl_array_ptr(jl_array_t *a);
+JL_DLLEXPORT void *jl_array_eltype(jl_value_t *a);
+JL_DLLEXPORT int jl_array_rank(jl_value_t *a);
+JL_DLLEXPORT size_t jl_array_size(jl_value_t *a, int d);
 
 // strings
-DLLEXPORT const char *jl_bytestring_ptr(jl_value_t *s);
+JL_DLLEXPORT const char *jl_bytestring_ptr(jl_value_t *s);
 
 // modules and global variables
-extern DLLEXPORT jl_module_t *jl_main_module;
-extern DLLEXPORT jl_module_t *jl_internal_main_module;
-extern DLLEXPORT jl_module_t *jl_core_module;
-extern DLLEXPORT jl_module_t *jl_base_module;
-extern DLLEXPORT jl_module_t *jl_top_module;
-extern DLLEXPORT jl_module_t *jl_current_module;
-DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name);
+extern JL_DLLEXPORT jl_module_t *jl_main_module;
+extern JL_DLLEXPORT jl_module_t *jl_internal_main_module;
+extern JL_DLLEXPORT jl_module_t *jl_core_module;
+extern JL_DLLEXPORT jl_module_t *jl_base_module;
+extern JL_DLLEXPORT jl_module_t *jl_top_module;
+extern JL_DLLEXPORT jl_module_t *jl_current_module;
+JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name);
 // get binding for reading
-DLLEXPORT jl_binding_t *jl_get_binding(jl_module_t *m, jl_sym_t *var);
-DLLEXPORT jl_binding_t *jl_get_binding_or_error(jl_module_t *m, jl_sym_t *var);
-DLLEXPORT jl_value_t *jl_module_globalref(jl_module_t *m, jl_sym_t *var);
+JL_DLLEXPORT jl_binding_t *jl_get_binding(jl_module_t *m, jl_sym_t *var);
+JL_DLLEXPORT jl_binding_t *jl_get_binding_or_error(jl_module_t *m, jl_sym_t *var);
+JL_DLLEXPORT jl_value_t *jl_module_globalref(jl_module_t *m, jl_sym_t *var);
 // get binding for assignment
-DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var);
-DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *var);
-DLLEXPORT int jl_boundp(jl_module_t *m, jl_sym_t *var);
-DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var);
-DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var);
-DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var);
-DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var);
-DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val);
-DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val);
-DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs);
-DLLEXPORT void jl_declare_constant(jl_binding_t *b);
-DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from);
-DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
-DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
-DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from);
-DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
-DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s);
-DLLEXPORT jl_module_t *jl_new_main_module(void);
-DLLEXPORT void jl_add_standard_imports(jl_module_t *m);
+JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var);
+JL_DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m,
+                                                         jl_sym_t *var);
+JL_DLLEXPORT int jl_boundp(jl_module_t *m, jl_sym_t *var);
+JL_DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var);
+JL_DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var);
+JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var);
+JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var);
+JL_DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val);
+JL_DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val);
+JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs);
+JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b);
+JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from);
+JL_DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
+JL_DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from,
+                                   jl_sym_t *s);
+JL_DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from);
+JL_DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
+JL_DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s);
+JL_DLLEXPORT jl_module_t *jl_new_main_module(void);
+JL_DLLEXPORT void jl_add_standard_imports(jl_module_t *m);
 STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
 {
     return (jl_function_t*)jl_get_global(m, jl_symbol(name));
 }
-DLLEXPORT void jl_module_run_initializer(jl_module_t *m);
+JL_DLLEXPORT void jl_module_run_initializer(jl_module_t *m);
 
 // eq hash tables
-DLLEXPORT jl_array_t *jl_eqtable_put(jl_array_t *h, void *key, void *val);
-DLLEXPORT jl_value_t *jl_eqtable_get(jl_array_t *h, void *key, jl_value_t *deflt);
+JL_DLLEXPORT jl_array_t *jl_eqtable_put(jl_array_t *h, void *key, void *val);
+JL_DLLEXPORT jl_value_t *jl_eqtable_get(jl_array_t *h, void *key,
+                                        jl_value_t *deflt);
 
 // system information
-DLLEXPORT int jl_errno(void);
-DLLEXPORT void jl_set_errno(int e);
-DLLEXPORT int32_t jl_stat(const char *path, char *statbuf);
-DLLEXPORT int jl_cpu_cores(void);
-DLLEXPORT long jl_getpagesize(void);
-DLLEXPORT long jl_getallocationgranularity(void);
-DLLEXPORT int jl_is_debugbuild(void);
-DLLEXPORT jl_sym_t* jl_get_OS_NAME(void);
-DLLEXPORT jl_sym_t* jl_get_ARCH(void);
+JL_DLLEXPORT int jl_errno(void);
+JL_DLLEXPORT void jl_set_errno(int e);
+JL_DLLEXPORT int32_t jl_stat(const char *path, char *statbuf);
+JL_DLLEXPORT int jl_cpu_cores(void);
+JL_DLLEXPORT long jl_getpagesize(void);
+JL_DLLEXPORT long jl_getallocationgranularity(void);
+JL_DLLEXPORT int jl_is_debugbuild(void);
+JL_DLLEXPORT jl_sym_t* jl_get_OS_NAME(void);
+JL_DLLEXPORT jl_sym_t* jl_get_ARCH(void);
 
 // environment entries
-DLLEXPORT jl_value_t *jl_environ(int i);
+JL_DLLEXPORT jl_value_t *jl_environ(int i);
 
 // throwing common exceptions
-DLLEXPORT void NORETURN jl_error(const char *str);
-DLLEXPORT void NORETURN jl_errorf(const char *fmt, ...);
-DLLEXPORT void NORETURN jl_exceptionf(jl_datatype_t *ty, const char *fmt, ...);
-DLLEXPORT void NORETURN jl_too_few_args(const char *fname, int min);
-DLLEXPORT void NORETURN jl_too_many_args(const char *fname, int max);
-DLLEXPORT void NORETURN jl_type_error(const char *fname, jl_value_t *expected,
-                                      jl_value_t *got);
-DLLEXPORT void NORETURN jl_type_error_rt(const char *fname, const char *context,
-                                         jl_value_t *ty, jl_value_t *got);
-DLLEXPORT void NORETURN jl_undefined_var_error(jl_sym_t *var);
-DLLEXPORT void NORETURN jl_bounds_error(jl_value_t *v, jl_value_t *t);
-DLLEXPORT void NORETURN jl_bounds_error_v(jl_value_t *v, jl_value_t **idxs, size_t nidxs);
-DLLEXPORT void NORETURN jl_bounds_error_int(jl_value_t *v, size_t i);
-DLLEXPORT void NORETURN jl_bounds_error_tuple_int(jl_value_t **v, size_t nv, size_t i);
-DLLEXPORT void NORETURN jl_bounds_error_unboxed_int(void *v, jl_value_t *vt, size_t i);
-DLLEXPORT void NORETURN jl_bounds_error_ints(jl_value_t *v, size_t *idxs, size_t nidxs);
-DLLEXPORT jl_value_t *jl_exception_occurred(void);
-DLLEXPORT void jl_exception_clear(void);
+JL_DLLEXPORT void JL_NORETURN jl_error(const char *str);
+JL_DLLEXPORT void JL_NORETURN jl_errorf(const char *fmt, ...);
+JL_DLLEXPORT void JL_NORETURN jl_exceptionf(jl_datatype_t *ty,
+                                            const char *fmt, ...);
+JL_DLLEXPORT void JL_NORETURN jl_too_few_args(const char *fname, int min);
+JL_DLLEXPORT void JL_NORETURN jl_too_many_args(const char *fname, int max);
+JL_DLLEXPORT void JL_NORETURN jl_type_error(const char *fname,
+                                            jl_value_t *expected,
+                                            jl_value_t *got);
+JL_DLLEXPORT void JL_NORETURN jl_type_error_rt(const char *fname,
+                                               const char *context,
+                                               jl_value_t *ty, jl_value_t *got);
+JL_DLLEXPORT void JL_NORETURN jl_undefined_var_error(jl_sym_t *var);
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error(jl_value_t *v, jl_value_t *t);
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_v(jl_value_t *v,
+                                                jl_value_t **idxs, size_t nidxs);
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_int(jl_value_t *v, size_t i);
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_tuple_int(jl_value_t **v,
+                                                        size_t nv, size_t i);
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_unboxed_int(void *v, jl_value_t *vt, size_t i);
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_ints(jl_value_t *v, size_t *idxs, size_t nidxs);
+JL_DLLEXPORT jl_value_t *jl_exception_occurred(void);
+JL_DLLEXPORT void jl_exception_clear(void);
 
 #define JL_NARGS(fname, min, max)                               \
     if (nargs < min) jl_too_few_args(#fname, min);              \
@@ -1210,32 +1222,34 @@ typedef enum {
     JL_IMAGE_JULIA_HOME = 1,
     //JL_IMAGE_LIBJULIA = 2,
 } JL_IMAGE_SEARCH;
-DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel);
-DLLEXPORT void jl_init(const char *julia_home_dir);
-DLLEXPORT void jl_init_with_image(const char *julia_home_dir, const char *image_relative_path);
-DLLEXPORT int jl_is_initialized(void);
-DLLEXPORT void jl_atexit_hook(int status);
-DLLEXPORT void NORETURN jl_exit(int status);
+JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel);
+JL_DLLEXPORT void jl_init(const char *julia_home_dir);
+JL_DLLEXPORT void jl_init_with_image(const char *julia_home_dir,
+                                     const char *image_relative_path);
+JL_DLLEXPORT int jl_is_initialized(void);
+JL_DLLEXPORT void jl_atexit_hook(int status);
+JL_DLLEXPORT void JL_NORETURN jl_exit(int status);
 
-DLLEXPORT int jl_deserialize_verify_header(ios_t *s);
-DLLEXPORT void jl_preload_sysimg_so(const char *fname);
-DLLEXPORT ios_t *jl_create_system_image(void);
-DLLEXPORT void jl_save_system_image(const char *fname);
-DLLEXPORT void jl_restore_system_image(const char *fname);
-DLLEXPORT void jl_restore_system_image_data(const char *buf, size_t len);
-DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t* worklist);
-DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname);
-DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf, size_t sz);
+JL_DLLEXPORT int jl_deserialize_verify_header(ios_t *s);
+JL_DLLEXPORT void jl_preload_sysimg_so(const char *fname);
+JL_DLLEXPORT ios_t *jl_create_system_image(void);
+JL_DLLEXPORT void jl_save_system_image(const char *fname);
+JL_DLLEXPORT void jl_restore_system_image(const char *fname);
+JL_DLLEXPORT void jl_restore_system_image_data(const char *buf, size_t len);
+JL_DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t* worklist);
+JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname);
+JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf,
+                                                         size_t sz);
 
 // front end interface
-DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len);
-DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
-                                      int pos0, int greedy);
-DLLEXPORT int jl_parse_depwarn(int warn);
-DLLEXPORT jl_value_t *jl_load_file_string(const char *text, size_t len,
-                                          char *filename, size_t namelen);
-DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr);
-DLLEXPORT void *jl_eval_string(const char *str);
+JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len);
+JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
+                                         int pos0, int greedy);
+JL_DLLEXPORT int jl_parse_depwarn(int warn);
+JL_DLLEXPORT jl_value_t *jl_load_file_string(const char *text, size_t len,
+                                             char *filename, size_t namelen);
+JL_DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr);
+JL_DLLEXPORT void *jl_eval_string(const char *str);
 
 // external libraries
 enum JL_RTLD_CONSTANT {
@@ -1254,39 +1268,43 @@ enum JL_RTLD_CONSTANT {
 #define JL_RTLD_DEFAULT (JL_RTLD_LAZY | JL_RTLD_DEEPBIND)
 
 typedef void *jl_uv_libhandle; // compatible with dlopen (void*) / LoadLibrary (HMODULE)
-DLLEXPORT jl_uv_libhandle jl_load_dynamic_library(const char *fname, unsigned flags);
-DLLEXPORT jl_uv_libhandle jl_load_dynamic_library_e(const char *fname, unsigned flags);
-DLLEXPORT jl_uv_libhandle jl_dlopen(const char *filename, unsigned flags);
-DLLEXPORT int jl_dlclose(jl_uv_libhandle handle);
-DLLEXPORT void *jl_dlsym_e(jl_uv_libhandle handle, const char *symbol);
-DLLEXPORT void *jl_dlsym(jl_uv_libhandle handle, const char *symbol);
+JL_DLLEXPORT jl_uv_libhandle jl_load_dynamic_library(const char *fname,
+                                                     unsigned flags);
+JL_DLLEXPORT jl_uv_libhandle jl_load_dynamic_library_e(const char *fname,
+                                                       unsigned flags);
+JL_DLLEXPORT jl_uv_libhandle jl_dlopen(const char *filename, unsigned flags);
+JL_DLLEXPORT int jl_dlclose(jl_uv_libhandle handle);
+JL_DLLEXPORT void *jl_dlsym_e(jl_uv_libhandle handle, const char *symbol);
+JL_DLLEXPORT void *jl_dlsym(jl_uv_libhandle handle, const char *symbol);
 
 #if defined(__linux__) || defined(__FreeBSD__)
-DLLEXPORT const char *jl_lookup_soname(const char *pfx, size_t n);
+JL_DLLEXPORT const char *jl_lookup_soname(const char *pfx, size_t n);
 #endif
 
 // compiler
-DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v);
-DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex);
-DLLEXPORT jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex,
-                                               int delay_warn);
-DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len);
-DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
-                                                    jl_value_t **locals, size_t nl);
-DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m);
+JL_DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v);
+JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex);
+JL_DLLEXPORT jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex,
+                                                  int delay_warn);
+JL_DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len);
+JL_DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m,
+                                                       jl_value_t *e,
+                                                       jl_value_t **locals,
+                                                       size_t nl);
+JL_DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m);
 
 // AST access
-DLLEXPORT jl_value_t *jl_ast_rettype(jl_lambda_info_t *li, jl_value_t *ast);
-DLLEXPORT int jl_is_rest_arg(jl_value_t *ex);
+JL_DLLEXPORT jl_value_t *jl_ast_rettype(jl_lambda_info_t *li, jl_value_t *ast);
+JL_DLLEXPORT int jl_is_rest_arg(jl_value_t *ex);
 
-DLLEXPORT jl_value_t *jl_prepare_ast(jl_lambda_info_t *li, jl_svec_t *sparams);
-DLLEXPORT jl_value_t *jl_copy_ast(jl_value_t *expr);
+JL_DLLEXPORT jl_value_t *jl_prepare_ast(jl_lambda_info_t *li, jl_svec_t *sparams);
+JL_DLLEXPORT jl_value_t *jl_copy_ast(jl_value_t *expr);
 
-DLLEXPORT jl_value_t *jl_compress_ast(jl_lambda_info_t *li, jl_value_t *ast);
-DLLEXPORT jl_value_t *jl_uncompress_ast(jl_lambda_info_t *li, jl_value_t *data);
+JL_DLLEXPORT jl_value_t *jl_compress_ast(jl_lambda_info_t *li, jl_value_t *ast);
+JL_DLLEXPORT jl_value_t *jl_uncompress_ast(jl_lambda_info_t *li, jl_value_t *data);
 
-DLLEXPORT int jl_is_operator(char *sym);
-DLLEXPORT int jl_operator_precedence(char *sym);
+JL_DLLEXPORT int jl_is_operator(char *sym);
+JL_DLLEXPORT int jl_operator_precedence(char *sym);
 
 STATIC_INLINE int jl_vinfo_capt(jl_array_t *vi)
 {
@@ -1321,21 +1339,22 @@ jl_value_t *jl_apply(jl_function_t *f, jl_value_t **args, uint32_t nargs)
     return f->fptr((jl_value_t*)f, args, nargs);
 }
 
-DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs);
-DLLEXPORT jl_value_t *jl_call0(jl_function_t *f);
-DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a, jl_value_t *b, jl_value_t *c);
+JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs);
+JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f);
+JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a,
+                                  jl_value_t *b, jl_value_t *c);
 
 // interfacing with Task runtime
-DLLEXPORT void jl_yield(void);
+JL_DLLEXPORT void jl_yield(void);
 
 // async signal handling ------------------------------------------------------
 
 #include <signal.h>
 
-DLLEXPORT extern volatile sig_atomic_t jl_signal_pending;
-DLLEXPORT extern volatile sig_atomic_t jl_defer_signal;
+JL_DLLEXPORT extern volatile sig_atomic_t jl_signal_pending;
+JL_DLLEXPORT extern volatile sig_atomic_t jl_defer_signal;
 
 #define JL_SIGATOMIC_BEGIN() (JL_ATOMIC_FETCH_AND_ADD(jl_defer_signal,1))
 #define JL_SIGATOMIC_END()                                      \
@@ -1347,10 +1366,10 @@ DLLEXPORT extern volatile sig_atomic_t jl_defer_signal;
         }                                                       \
     } while(0)
 
-DLLEXPORT void jl_sigint_action(void);
-DLLEXPORT void jl_install_sigint_handler(void);
-DLLEXPORT void jl_sigatomic_begin(void);
-DLLEXPORT void jl_sigatomic_end(void);
+JL_DLLEXPORT void jl_sigint_action(void);
+JL_DLLEXPORT void jl_install_sigint_handler(void);
+JL_DLLEXPORT void jl_sigatomic_begin(void);
+JL_DLLEXPORT void jl_sigatomic_end(void);
 
 // tasks and exceptions -------------------------------------------------------
 
@@ -1417,19 +1436,19 @@ typedef struct {
 #define jl_exception_in_transit (jl_get_ptls_states()->exception_in_transit)
 #define jl_task_arg_in_transit (jl_get_ptls_states()->task_arg_in_transit)
 
-DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize);
-DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg);
-DLLEXPORT void NORETURN jl_throw(jl_value_t *e);
-DLLEXPORT void NORETURN jl_rethrow(void);
-DLLEXPORT void NORETURN jl_rethrow_other(jl_value_t *e);
+JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize);
+JL_DLLEXPORT jl_value_t *jl_switchto(jl_task_t *t, jl_value_t *arg);
+JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e);
+JL_DLLEXPORT void JL_NORETURN jl_rethrow(void);
+JL_DLLEXPORT void JL_NORETURN jl_rethrow_other(jl_value_t *e);
 
-DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void);
+JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void);
 #ifndef JULIA_ENABLE_THREADING
-extern DLLEXPORT jl_tls_states_t jl_tls_states;
+extern JL_DLLEXPORT jl_tls_states_t jl_tls_states;
 #define jl_get_ptls_states() (&jl_tls_states)
 #else
 typedef jl_tls_states_t *(*jl_get_ptls_states_func)(void);
-DLLEXPORT void jl_set_ptls_states_getter(jl_get_ptls_states_func f);
+JL_DLLEXPORT void jl_set_ptls_states_getter(jl_get_ptls_states_func f);
 #endif
 
 STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
@@ -1440,8 +1459,8 @@ STATIC_INLINE void jl_eh_restore_state(jl_handler_t *eh)
     JL_SIGATOMIC_END();
 }
 
-DLLEXPORT void jl_enter_handler(jl_handler_t *eh);
-DLLEXPORT void jl_pop_handler(int n);
+JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh);
+JL_DLLEXPORT void jl_pop_handler(int n);
 
 #if defined(_OS_WINDOWS_)
 #if defined(_COMPILER_MINGW_)
@@ -1494,23 +1513,23 @@ void jl_longjmp(jmp_buf _Buf,int _Value);
 #define JL_STDERR jl_uv_stderr
 #define JL_STDIN  jl_uv_stdin
 
-DLLEXPORT void jl_run_event_loop(uv_loop_t *loop);
-DLLEXPORT int jl_run_once(uv_loop_t *loop);
-DLLEXPORT int jl_process_events(uv_loop_t *loop);
+JL_DLLEXPORT void jl_run_event_loop(uv_loop_t *loop);
+JL_DLLEXPORT int jl_run_once(uv_loop_t *loop);
+JL_DLLEXPORT int jl_process_events(uv_loop_t *loop);
 
-DLLEXPORT uv_loop_t *jl_global_event_loop(void);
+JL_DLLEXPORT uv_loop_t *jl_global_event_loop(void);
 
-DLLEXPORT void jl_close_uv(uv_handle_t *handle);
+JL_DLLEXPORT void jl_close_uv(uv_handle_t *handle);
 
-DLLEXPORT int jl_tcp_bind(uv_tcp_t *handle, uint16_t port, uint32_t host,
-                          unsigned int flags);
+JL_DLLEXPORT int jl_tcp_bind(uv_tcp_t *handle, uint16_t port, uint32_t host,
+                             unsigned int flags);
 
-DLLEXPORT int jl_sizeof_ios_t(void);
+JL_DLLEXPORT int jl_sizeof_ios_t(void);
 
-DLLEXPORT jl_array_t *jl_takebuf_array(ios_t *s);
-DLLEXPORT jl_value_t *jl_takebuf_string(ios_t *s);
-DLLEXPORT void *jl_takebuf_raw(ios_t *s);
-DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim);
+JL_DLLEXPORT jl_array_t *jl_takebuf_array(ios_t *s);
+JL_DLLEXPORT jl_value_t *jl_takebuf_string(ios_t *s);
+JL_DLLEXPORT void *jl_takebuf_raw(ios_t *s);
+JL_DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim);
 
 typedef struct {
     void *data;
@@ -1526,29 +1545,29 @@ typedef struct {
 #define _JL_FORMAT_ATTR(type, str, arg)
 #endif
 
-DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...)
+JL_DLLEXPORT int jl_printf(uv_stream_t *s, const char *format, ...)
     _JL_FORMAT_ATTR(printf, 2, 3);
-DLLEXPORT int jl_vprintf(uv_stream_t *s, const char *format, va_list args)
+JL_DLLEXPORT int jl_vprintf(uv_stream_t *s, const char *format, va_list args)
     _JL_FORMAT_ATTR(printf, 2, 0);
-DLLEXPORT void jl_safe_printf(const char *str, ...)
+JL_DLLEXPORT void jl_safe_printf(const char *str, ...)
     _JL_FORMAT_ATTR(printf, 1, 2);
 
-extern DLLEXPORT JL_STREAM *JL_STDIN;
-extern DLLEXPORT JL_STREAM *JL_STDOUT;
-extern DLLEXPORT JL_STREAM *JL_STDERR;
+extern JL_DLLEXPORT JL_STREAM *JL_STDIN;
+extern JL_DLLEXPORT JL_STREAM *JL_STDOUT;
+extern JL_DLLEXPORT JL_STREAM *JL_STDERR;
 
-DLLEXPORT JL_STREAM *jl_stdout_stream(void);
-DLLEXPORT JL_STREAM *jl_stdin_stream(void);
-DLLEXPORT JL_STREAM *jl_stderr_stream(void);
+JL_DLLEXPORT JL_STREAM *jl_stdout_stream(void);
+JL_DLLEXPORT JL_STREAM *jl_stdin_stream(void);
+JL_DLLEXPORT JL_STREAM *jl_stderr_stream(void);
 
 // showing and std streams
-DLLEXPORT void jl_show(jl_value_t *stream, jl_value_t *v);
-DLLEXPORT void jl_flush_cstdio(void);
-DLLEXPORT jl_value_t *jl_stdout_obj(void);
-DLLEXPORT jl_value_t *jl_stderr_obj(void);
-DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v);
-DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type);
-DLLEXPORT void jlbacktrace(void);
+JL_DLLEXPORT void jl_show(jl_value_t *stream, jl_value_t *v);
+JL_DLLEXPORT void jl_flush_cstdio(void);
+JL_DLLEXPORT jl_value_t *jl_stdout_obj(void);
+JL_DLLEXPORT jl_value_t *jl_stderr_obj(void);
+JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v);
+JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type);
+JL_DLLEXPORT void jlbacktrace(void);
 
 // julia options -----------------------------------------------------------
 // NOTE: This struct needs to be kept in sync with JLOptions type in base/options.jl
@@ -1587,9 +1606,9 @@ typedef struct {
     int8_t incremental;
 } jl_options_t;
 
-extern DLLEXPORT jl_options_t jl_options;
+extern JL_DLLEXPORT jl_options_t jl_options;
 
-DLLEXPORT int jl_generating_output(void);
+JL_DLLEXPORT int jl_generating_output(void);
 
 // Settings for code_coverage and malloc_log
 // NOTE: if these numbers change, test/cmdlineargs.jl will have to be updated
@@ -1635,13 +1654,13 @@ DLLEXPORT int jl_generating_output(void);
 // Version information
 #include <julia_version.h>
 
-DLLEXPORT extern int jl_ver_major(void);
-DLLEXPORT extern int jl_ver_minor(void);
-DLLEXPORT extern int jl_ver_patch(void);
-DLLEXPORT extern int jl_ver_is_release(void);
-DLLEXPORT extern const char* jl_ver_string(void);
-DLLEXPORT const char *jl_git_branch(void);
-DLLEXPORT const char *jl_git_commit(void);
+JL_DLLEXPORT extern int jl_ver_major(void);
+JL_DLLEXPORT extern int jl_ver_minor(void);
+JL_DLLEXPORT extern int jl_ver_patch(void);
+JL_DLLEXPORT extern int jl_ver_is_release(void);
+JL_DLLEXPORT extern const char* jl_ver_string(void);
+JL_DLLEXPORT const char *jl_git_branch(void);
+JL_DLLEXPORT const char *jl_git_commit(void);
 
 // nullable struct representations
 typedef struct {

--- a/src/julia.h
+++ b/src/julia.h
@@ -605,14 +605,11 @@ typedef struct _jl_gcframe_t {
 
 #define JL_GC_POP() (jl_pgcstack = jl_pgcstack->prev)
 
-void jl_gc_init(void);
-void jl_gc_setmark(jl_value_t *v);
 DLLEXPORT int jl_gc_enable(int on);
 DLLEXPORT int jl_gc_is_enabled(void);
 DLLEXPORT int64_t jl_gc_total_bytes(void);
 DLLEXPORT uint64_t jl_gc_total_hrtime(void);
 DLLEXPORT int64_t jl_gc_diff_total_bytes(void);
-void jl_gc_sync_total_bytes(void);
 
 DLLEXPORT void jl_gc_collect(int);
 DLLEXPORT void jl_gc_preserve(jl_value_t *v);
@@ -622,50 +619,26 @@ DLLEXPORT int jl_gc_n_preserved_values(void);
 DLLEXPORT void jl_gc_add_finalizer(jl_value_t *v, jl_function_t *f);
 DLLEXPORT void jl_finalize(jl_value_t *o);
 DLLEXPORT jl_weakref_t *jl_gc_new_weakref(jl_value_t *value);
-void jl_gc_free_array(jl_array_t *a);
-void jl_gc_track_malloced_array(jl_array_t *a);
-void jl_gc_count_allocd(size_t sz);
-void jl_gc_run_all_finalizers(void);
 DLLEXPORT jl_value_t *jl_gc_alloc_0w(void);
 DLLEXPORT jl_value_t *jl_gc_alloc_1w(void);
 DLLEXPORT jl_value_t *jl_gc_alloc_2w(void);
 DLLEXPORT jl_value_t *jl_gc_alloc_3w(void);
-void *allocb(size_t sz);
-void *reallocb(void*, size_t);
 DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz);
 
 DLLEXPORT void jl_clear_malloc_data(void);
-DLLEXPORT int64_t jl_gc_num_pause(void);
-DLLEXPORT int64_t jl_gc_num_full_sweep(void);
 
 // GC write barriers
 DLLEXPORT void jl_gc_queue_root(jl_value_t *root); // root isa jl_value_t*
-void gc_queue_binding(jl_binding_t *bnd);
-void gc_setmark_buf(void *buf, int);
 
-static inline void jl_gc_wb_binding(jl_binding_t *bnd, void *val) // val isa jl_value_t*
+STATIC_INLINE void jl_gc_wb(void *parent, void *ptr)
 {
-    if (__unlikely((jl_astaggedvalue(bnd)->gc_bits & 1) == 1 &&
-                   (jl_astaggedvalue(val)->gc_bits & 1) == 0))
-        gc_queue_binding(bnd);
-}
-
-static inline void jl_gc_wb(void *parent, void *ptr) // parent and ptr isa jl_value_t*
-{
+    // parent and ptr isa jl_value_t*
     if (__unlikely((jl_astaggedvalue(parent)->gc_bits & 1) == 1 &&
                    (jl_astaggedvalue(ptr)->gc_bits & 1) == 0))
         jl_gc_queue_root((jl_value_t*)parent);
 }
 
-static inline void jl_gc_wb_buf(void *parent, void *bufptr) // parent isa jl_value_t*
-{
-    // if parent is marked and buf is not
-    if (__unlikely((jl_astaggedvalue(parent)->gc_bits & 1) == 1))
-        //            (jl_astaggedvalue(bufptr)->gc_bits) != 1))
-        gc_setmark_buf(bufptr, jl_astaggedvalue(parent)->gc_bits);
-}
-
-static inline void jl_gc_wb_back(void *ptr) // ptr isa jl_value_t*
+STATIC_INLINE void jl_gc_wb_back(void *ptr) // ptr isa jl_value_t*
 {
     // if ptr is marked
     if (__unlikely((jl_astaggedvalue(ptr)->gc_bits & 1) == 1)) {
@@ -674,7 +647,8 @@ static inline void jl_gc_wb_back(void *ptr) // ptr isa jl_value_t*
 }
 
 DLLEXPORT void *jl_gc_managed_malloc(size_t sz);
-DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz, int isaligned, jl_value_t* owner);
+DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz,
+                                      int isaligned, jl_value_t* owner);
 
 // object accessors -----------------------------------------------------------
 
@@ -983,15 +957,11 @@ DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b);
 DLLEXPORT uptrint_t jl_object_id(jl_value_t *v);
 
 // type predicates and basic operations
-int jl_is_type(jl_value_t *v);
 DLLEXPORT int jl_is_leaf_type(jl_value_t *v);
 DLLEXPORT int jl_has_typevars(jl_value_t *v);
 DLLEXPORT int jl_subtype(jl_value_t *a, jl_value_t *b, int ta);
 DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b);
 DLLEXPORT jl_value_t *jl_type_union(jl_svec_t *types);
-jl_value_t *jl_type_union_v(jl_value_t **ts, size_t n);
-jl_value_t *jl_type_intersection_matching(jl_value_t *a, jl_value_t *b,
-                                          jl_svec_t **penv, jl_svec_t *tvars);
 DLLEXPORT jl_value_t *jl_type_intersection(jl_value_t *a, jl_value_t *b);
 DLLEXPORT int jl_args_morespecific(jl_value_t *a, jl_value_t *b);
 DLLEXPORT const char *jl_typename_str(jl_value_t *v);
@@ -1001,41 +971,36 @@ DLLEXPORT int jl_type_morespecific(jl_value_t *a, jl_value_t *b);
 // type constructors
 DLLEXPORT jl_typename_t *jl_new_typename(jl_sym_t *name);
 DLLEXPORT jl_tvar_t *jl_new_typevar(jl_sym_t *name,jl_value_t *lb,jl_value_t *ub);
-jl_typector_t *jl_new_type_ctor(jl_svec_t *params, jl_value_t *body);
 DLLEXPORT jl_value_t *jl_apply_type(jl_value_t *tc, jl_svec_t *params);
 DLLEXPORT jl_tupletype_t *jl_apply_tuple_type(jl_svec_t *params);
 DLLEXPORT jl_tupletype_t *jl_apply_tuple_type_v(jl_value_t **p, size_t np);
-jl_value_t *jl_apply_type_(jl_value_t *tc, jl_value_t **params, size_t n);
-jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n);
-jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_datatype_t *super,
-                                   jl_svec_t *parameters);
 DLLEXPORT jl_datatype_t *jl_new_uninitialized_datatype(size_t nfields,
                                                        int8_t fielddesc_type);
 DLLEXPORT jl_datatype_t *jl_new_datatype(jl_sym_t *name, jl_datatype_t *super,
                                          jl_svec_t *parameters,
                                          jl_svec_t *fnames, jl_svec_t *ftypes,
-                                         int abstract, int mutabl, int ninitialized);
+                                         int abstract, int mutabl,
+                                         int ninitialized);
 DLLEXPORT jl_datatype_t *jl_new_bitstype(jl_value_t *name, jl_datatype_t *super,
                                          jl_svec_t *parameters, size_t nbits);
-jl_datatype_t *jl_wrap_Type(jl_value_t *t);  // x -> Type{x}
-jl_datatype_t *jl_wrap_vararg(jl_value_t *t);
 
 // constructors
 DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *bt, void *data);
-void jl_assign_bits(void *dest, jl_value_t *bits);
 DLLEXPORT jl_value_t *jl_new_struct(jl_datatype_t *type, ...);
 DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args, uint32_t na);
 DLLEXPORT jl_value_t *jl_new_struct_uninit(jl_datatype_t *type);
 DLLEXPORT jl_function_t *jl_new_closure(jl_fptr_t proc, jl_value_t *env,
                                         jl_lambda_info_t *li);
-DLLEXPORT jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast, jl_svec_t *sparams, jl_module_t *ctx);
+DLLEXPORT jl_lambda_info_t *jl_new_lambda_info(jl_value_t *ast,
+                                               jl_svec_t *sparams,
+                                               jl_module_t *ctx);
 DLLEXPORT jl_svec_t *jl_svec(size_t n, ...);
 DLLEXPORT jl_svec_t *jl_svec1(void *a);
 DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b);
 DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n);
 DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n);
 DLLEXPORT jl_svec_t *jl_svec_append(jl_svec_t *a, jl_svec_t *b);
-jl_svec_t *jl_svec_copy(jl_svec_t *a);
+DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a);
 DLLEXPORT jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x);
 DLLEXPORT jl_value_t *jl_tupletype_fill(size_t n, jl_value_t *v);
 DLLEXPORT jl_sym_t *jl_symbol(const char *str);
@@ -1044,15 +1009,14 @@ DLLEXPORT jl_sym_t *jl_symbol_n(const char *str, int32_t len);
 DLLEXPORT jl_sym_t *jl_gensym(void);
 DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, int32_t len);
 DLLEXPORT jl_sym_t *jl_get_root_symbol(void);
-jl_expr_t *jl_exprn(jl_sym_t *head, size_t n);
-jl_function_t *jl_new_generic_function(jl_sym_t *name, jl_module_t *module);
-void jl_add_method(jl_function_t *gf, jl_tupletype_t *types, jl_function_t *meth,
-                   jl_svec_t *tvars, int8_t isstaged);
-DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name, jl_value_t **bp, jl_value_t *bp_owner,
+DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name, jl_value_t **bp,
+                                              jl_value_t *bp_owner,
                                               jl_binding_t *bnd);
-DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_value_t *bp_owner, jl_binding_t *bnd,
-                                    jl_svec_t *argtypes, jl_function_t *f, jl_value_t *isstaged,
-                                    jl_value_t *call_func, int iskw);
+DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp,
+                                    jl_value_t *bp_owner, jl_binding_t *bnd,
+                                    jl_svec_t *argtypes, jl_function_t *f,
+                                    jl_value_t *isstaged, jl_value_t *call_func,
+                                    int iskw);
 DLLEXPORT jl_value_t *jl_box_bool(int8_t x);
 DLLEXPORT jl_value_t *jl_box_int8(int8_t x);
 DLLEXPORT jl_value_t *jl_box_uint8(uint8_t x);
@@ -1113,14 +1077,12 @@ DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a);
 // arrays
 
 DLLEXPORT jl_array_t *jl_new_array(jl_value_t *atype, jl_value_t *dims);
-DLLEXPORT jl_array_t *jl_new_arrayv(jl_value_t *atype, ...);
 DLLEXPORT jl_array_t *jl_reshape_array(jl_value_t *atype, jl_array_t *data,
                                        jl_value_t *dims);
 DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
                                          size_t nel, int own_buffer);
 DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
                                       jl_value_t *dims, int own_buffer);
-int jl_array_store_unboxed(jl_value_t *el_type);
 
 DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr);
 DLLEXPORT jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc);
@@ -1134,7 +1096,6 @@ DLLEXPORT jl_array_t *jl_alloc_cell_1d(size_t n);
 DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i);  // 0-indexed
 DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *v, size_t i);  // 0-indexed
 DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i);  // 0-indexed
-int jl_array_isdefined(jl_value_t **args, int nargs);
 DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc);
 DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec);
 DLLEXPORT void jl_array_grow_beg(jl_array_t *a, size_t inc);
@@ -1185,11 +1146,9 @@ DLLEXPORT jl_module_t *jl_new_main_module(void);
 DLLEXPORT void jl_add_standard_imports(jl_module_t *m);
 STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
 {
-    return  (jl_function_t*) jl_get_global(m, jl_symbol(name));
+    return (jl_function_t*)jl_get_global(m, jl_symbol(name));
 }
 DLLEXPORT void jl_module_run_initializer(jl_module_t *m);
-jl_function_t *jl_module_call_func(jl_module_t *m);
-int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
 
 // eq hash tables
 DLLEXPORT jl_array_t *jl_eqtable_put(jl_array_t *h, void *key, void *val);
@@ -1215,9 +1174,10 @@ DLLEXPORT void NORETURN jl_errorf(const char *fmt, ...);
 DLLEXPORT void NORETURN jl_exceptionf(jl_datatype_t *ty, const char *fmt, ...);
 DLLEXPORT void NORETURN jl_too_few_args(const char *fname, int min);
 DLLEXPORT void NORETURN jl_too_many_args(const char *fname, int max);
-DLLEXPORT void NORETURN jl_type_error(const char *fname, jl_value_t *expected, jl_value_t *got);
+DLLEXPORT void NORETURN jl_type_error(const char *fname, jl_value_t *expected,
+                                      jl_value_t *got);
 DLLEXPORT void NORETURN jl_type_error_rt(const char *fname, const char *context,
-                                jl_value_t *ty, jl_value_t *got);
+                                         jl_value_t *ty, jl_value_t *got);
 DLLEXPORT void NORETURN jl_undefined_var_error(jl_sym_t *var);
 DLLEXPORT void NORETURN jl_bounds_error(jl_value_t *v, jl_value_t *t);
 DLLEXPORT void NORETURN jl_bounds_error_v(jl_value_t *v, jl_value_t **idxs, size_t nidxs);
@@ -1254,7 +1214,6 @@ DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel);
 DLLEXPORT void jl_init(const char *julia_home_dir);
 DLLEXPORT void jl_init_with_image(const char *julia_home_dir, const char *image_relative_path);
 DLLEXPORT int jl_is_initialized(void);
-DLLEXPORT int julia_trampoline(int argc, const char *argv[], int (*pmain)(int ac,char *av[]));
 DLLEXPORT void jl_atexit_hook(int status);
 DLLEXPORT void NORETURN jl_exit(int status);
 
@@ -1267,21 +1226,15 @@ DLLEXPORT void jl_restore_system_image_data(const char *buf, size_t len);
 DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t* worklist);
 DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname);
 DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf, size_t sz);
-void jl_init_restored_modules(jl_array_t *init_order);
 
 // front end interface
 DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len);
 DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
                                       int pos0, int greedy);
 DLLEXPORT int jl_parse_depwarn(int warn);
-int jl_start_parsing_file(const char *fname);
-void jl_stop_parsing(void);
-jl_value_t *jl_parse_next(void);
 DLLEXPORT jl_value_t *jl_load_file_string(const char *text, size_t len,
                                           char *filename, size_t namelen);
 DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr);
-DLLEXPORT jl_value_t *jl_expand_in(jl_module_t *module, jl_value_t *expr);
-jl_lambda_info_t *jl_wrap_expr(jl_value_t *expr);
 DLLEXPORT void *jl_eval_string(const char *str);
 
 // external libraries
@@ -1307,52 +1260,23 @@ DLLEXPORT jl_uv_libhandle jl_dlopen(const char *filename, unsigned flags);
 DLLEXPORT int jl_dlclose(jl_uv_libhandle handle);
 DLLEXPORT void *jl_dlsym_e(jl_uv_libhandle handle, const char *symbol);
 DLLEXPORT void *jl_dlsym(jl_uv_libhandle handle, const char *symbol);
-const char *jl_dlfind_win32(const char *name);
-DLLEXPORT int add_library_mapping(char *lib, void *hnd);
 
 #if defined(__linux__) || defined(__FreeBSD__)
 DLLEXPORT const char *jl_lookup_soname(const char *pfx, size_t n);
 #endif
 
 // compiler
-void jl_compile_linfo(jl_lambda_info_t *li);
 DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v);
 DLLEXPORT jl_value_t *jl_toplevel_eval_in(jl_module_t *m, jl_value_t *ex);
-DLLEXPORT jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex, int delay_warn);
-jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e);
+DLLEXPORT jl_value_t *jl_toplevel_eval_in_warn(jl_module_t *m, jl_value_t *ex,
+                                               int delay_warn);
 DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len);
-jl_value_t *jl_parse_eval_all(const char *fname, size_t len);
-jl_value_t *jl_interpret_toplevel_thunk(jl_lambda_info_t *lam);
-jl_value_t *jl_interpret_toplevel_thunk_with(jl_lambda_info_t *lam,
-                                             jl_value_t **loc, size_t nl);
-jl_value_t *jl_interpret_toplevel_expr(jl_value_t *e);
 DLLEXPORT jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
                                                     jl_value_t **locals, size_t nl);
-jl_value_t *jl_static_eval(jl_value_t *ex, void *ctx_, jl_module_t *mod,
-                           jl_value_t *sp, jl_expr_t *ast, int sparams, int allow_alloc);
-int jl_is_toplevel_only_expr(jl_value_t *e);
 DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m);
-void jl_type_infer(jl_lambda_info_t *li, jl_tupletype_t *argtypes, jl_lambda_info_t *def);
-
-jl_function_t *jl_method_lookup_by_type(jl_methtable_t *mt, jl_tupletype_t *types,
-                                        int cache, int inexact);
-jl_function_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t nargs, int cache);
-jl_value_t *jl_gf_invoke(jl_function_t *gf, jl_tupletype_t *types,
-                         jl_value_t **args, size_t nargs);
 
 // AST access
-jl_array_t *jl_lam_args(jl_expr_t *l);
-jl_array_t *jl_lam_vinfo(jl_expr_t *l);
-jl_array_t *jl_lam_capt(jl_expr_t *l);
-jl_value_t *jl_lam_gensyms(jl_expr_t *l);
-jl_array_t *jl_lam_staticparams(jl_expr_t *l);
-jl_sym_t *jl_lam_argname(jl_lambda_info_t *li, int i);
-int jl_lam_vars_captured(jl_expr_t *ast);
-jl_expr_t *jl_lam_body(jl_expr_t *l);
-int jl_in_vinfo_array(jl_array_t *a, jl_sym_t *v);
-int jl_local_in_ast(jl_expr_t *ast, jl_sym_t *sym);
 DLLEXPORT jl_value_t *jl_ast_rettype(jl_lambda_info_t *li, jl_value_t *ast);
-jl_sym_t *jl_decl_var(jl_value_t *ex);
 DLLEXPORT int jl_is_rest_arg(jl_value_t *ex);
 
 DLLEXPORT jl_value_t *jl_prepare_ast(jl_lambda_info_t *li, jl_svec_t *sparams);
@@ -1576,24 +1500,10 @@ DLLEXPORT int jl_process_events(uv_loop_t *loop);
 
 DLLEXPORT uv_loop_t *jl_global_event_loop(void);
 
-DLLEXPORT uv_pipe_t *jl_make_pipe(int writable, int julia_only, jl_value_t *julia_struct);
 DLLEXPORT void jl_close_uv(uv_handle_t *handle);
 
-DLLEXPORT int32_t jl_start_reading(uv_stream_t *handle);
-
-DLLEXPORT void jl_callback(void *callback);
-
-DLLEXPORT uv_async_t *jl_make_async(uv_loop_t *loop, jl_value_t *julia_struct);
-DLLEXPORT void jl_async_send(uv_async_t *handle);
-DLLEXPORT uv_idle_t * jl_make_idle(uv_loop_t *loop, jl_value_t *julia_struct);
-DLLEXPORT int jl_idle_start(uv_idle_t *idle);
-DLLEXPORT int jl_idle_stop(uv_idle_t *idle);
-
-DLLEXPORT uv_timer_t *jl_make_timer(uv_loop_t *loop, jl_value_t *julia_struct);
-DLLEXPORT int jl_timer_stop(uv_timer_t *timer);
-
-DLLEXPORT uv_tcp_t *jl_tcp_init(uv_loop_t *loop);
-DLLEXPORT int jl_tcp_bind(uv_tcp_t *handle, uint16_t port, uint32_t host, unsigned int flags);
+DLLEXPORT int jl_tcp_bind(uv_tcp_t *handle, uint16_t port, uint32_t host,
+                          unsigned int flags);
 
 DLLEXPORT int jl_sizeof_ios_t(void);
 
@@ -1639,9 +1549,6 @@ DLLEXPORT jl_value_t *jl_stderr_obj(void);
 DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v);
 DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type);
 DLLEXPORT void jlbacktrace(void);
-
-// debugging
-void show_execution_point(char *filename, int lno);
 
 // julia options -----------------------------------------------------------
 // NOTE: This struct needs to be kept in sync with JLOptions type in base/options.jl

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -18,8 +18,8 @@ extern jl_function_t *jl_typeinf_func;
 extern unsigned sig_stack_size;
 #endif
 
-DLLEXPORT extern int jl_lineno;
-DLLEXPORT extern const char *jl_filename;
+JL_DLLEXPORT extern int jl_lineno;
+JL_DLLEXPORT extern const char *jl_filename;
 
 STATIC_INLINE jl_value_t *newobj(jl_value_t *type, size_t nfields)
 {
@@ -94,12 +94,13 @@ void jl_set_t_uid_ctr(int i);
 uint32_t jl_get_gs_ctr(void);
 void jl_set_gs_ctr(uint32_t ctr);
 
-void NORETURN jl_no_method_error_bare(jl_function_t *f, jl_value_t *args);
-void NORETURN jl_no_method_error(jl_function_t *f, jl_value_t **args, size_t na);
-DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t);
+void JL_NORETURN jl_no_method_error_bare(jl_function_t *f, jl_value_t *args);
+void JL_NORETURN jl_no_method_error(jl_function_t *f, jl_value_t **args,
+                                    size_t na);
+JL_DLLEXPORT void jl_typeassert(jl_value_t *x, jl_value_t *t);
 
 #define JL_CALLABLE(name)                                               \
-    DLLEXPORT jl_value_t *name(jl_value_t *F, jl_value_t **args, uint32_t nargs)
+    JL_DLLEXPORT jl_value_t *name(jl_value_t *F, jl_value_t **args, uint32_t nargs)
 
 JL_CALLABLE(jl_trampoline);
 JL_CALLABLE(jl_apply_generic);
@@ -128,9 +129,9 @@ ssize_t jl_max_jlgensym_in(jl_value_t *v);
 
 extern uv_loop_t *jl_io_loop;
 
-DLLEXPORT void jl_uv_associate_julia_struct(uv_handle_t *handle,
+JL_DLLEXPORT void jl_uv_associate_julia_struct(uv_handle_t *handle,
                                             jl_value_t *data);
-DLLEXPORT int jl_uv_fs_result(uv_fs_t *f);
+JL_DLLEXPORT int jl_uv_fs_result(uv_fs_t *f);
 
 
 int jl_tuple_subtype(jl_value_t **child, size_t cl, jl_datatype_t *pdt, int ta);
@@ -207,7 +208,7 @@ jl_value_t *jl_nth_slot_type(jl_tupletype_t *sig, size_t i);
 void jl_compute_field_offsets(jl_datatype_t *st);
 jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, size_t *dims,
                                              int isunboxed, int elsz);
-DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v);
+JL_DLLEXPORT jl_value_t *jl_new_box(jl_value_t *v);
 jl_lambda_info_t *jl_copy_lambda_info(jl_lambda_info_t *linfo);
 extern jl_array_t *jl_module_init_order;
 
@@ -274,20 +275,20 @@ typedef unw_context_t *bt_context_t;
 #endif
 #define jl_bt_data (jl_get_ptls_states()->bt_data)
 #define jl_bt_size (jl_get_ptls_states()->bt_size)
-DLLEXPORT size_t rec_backtrace(ptrint_t *data, size_t maxsize);
-DLLEXPORT size_t rec_backtrace_ctx(ptrint_t *data, size_t maxsize, bt_context_t ctx);
+JL_DLLEXPORT size_t rec_backtrace(ptrint_t *data, size_t maxsize);
+JL_DLLEXPORT size_t rec_backtrace_ctx(ptrint_t *data, size_t maxsize, bt_context_t ctx);
 #ifdef LIBOSXUNWIND
 size_t rec_backtrace_ctx_dwarf(ptrint_t *data, size_t maxsize, bt_context_t ctx);
 #endif
-DLLEXPORT void jl_raise_debugger(void);
+JL_DLLEXPORT void jl_raise_debugger(void);
 #ifdef _OS_DARWIN_
-DLLEXPORT void attach_exception_port(void);
+JL_DLLEXPORT void attach_exception_port(void);
 #endif
 // Set *name and *filename to either NULL or malloc'd string
 void jl_getFunctionInfo(char **name, char **filename, size_t *line,
                         char **inlinedat_file, size_t *inlinedat_line,
                         uintptr_t pointer, int *fromC, int skipC, int skipInline);
-DLLEXPORT void gdblookup(ptrint_t ip);
+JL_DLLEXPORT void gdblookup(ptrint_t ip);
 
 // *to is NULL or malloc'd pointer, from is allowed to be NULL
 static inline char *jl_copy_str(char **to, const char *from)
@@ -305,13 +306,13 @@ static inline char *jl_copy_str(char **to, const char *from)
 
 // timers
 // Returns time in nanosec
-DLLEXPORT uint64_t jl_hrtime(void);
+JL_DLLEXPORT uint64_t jl_hrtime(void);
 
 // libuv stuff:
-DLLEXPORT extern void *jl_dl_handle;
-DLLEXPORT extern void *jl_RTLD_DEFAULT_handle;
+JL_DLLEXPORT extern void *jl_dl_handle;
+JL_DLLEXPORT extern void *jl_RTLD_DEFAULT_handle;
 #if defined(_OS_WINDOWS_)
-DLLEXPORT extern void *jl_exe_handle;
+JL_DLLEXPORT extern void *jl_exe_handle;
 extern void *jl_ntdll_handle;
 extern void *jl_kernel32_handle;
 extern void *jl_crtdll_handle;
@@ -319,113 +320,113 @@ extern void *jl_winsock_handle;
 #endif
 
 void *jl_get_library(const char *f_lib);
-DLLEXPORT void *jl_load_and_lookup(const char *f_lib, const char *f_name,
+JL_DLLEXPORT void *jl_load_and_lookup(const char *f_lib, const char *f_name,
                                    void **hnd);
 const char *jl_dlfind_win32(const char *name);
 
 
 // libuv wrappers:
-DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path);
+JL_DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path);
 
 #if defined(_CPU_X86_) || defined(_CPU_X86_64_)
 #define HAVE_CPUID
 #endif
 
 #ifdef SEGV_EXCEPTION
-extern DLLEXPORT jl_value_t *jl_segv_exception;
+extern JL_DLLEXPORT jl_value_t *jl_segv_exception;
 #endif
 
 // Runtime intrinsics //
 const char* jl_intrinsic_name(int f);
 
-DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v);
-DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i);
-DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i);
+JL_DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v);
+JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i);
+JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i);
 
-DLLEXPORT jl_value_t *jl_neg_int(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_add_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_sub_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_mul_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_sdiv_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_udiv_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_srem_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_urem_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_smod_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_neg_int(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_add_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_sub_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_mul_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_sdiv_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_udiv_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_srem_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_urem_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_smod_int(jl_value_t *a, jl_value_t *b);
 
-DLLEXPORT jl_value_t *jl_neg_float(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_add_float(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_sub_float(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_mul_float(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_div_float(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_rem_float(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_fma_float(jl_value_t *a, jl_value_t *b, jl_value_t *c);
-DLLEXPORT jl_value_t *jl_muladd_float(jl_value_t *a, jl_value_t *b, jl_value_t *c);
+JL_DLLEXPORT jl_value_t *jl_neg_float(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_add_float(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_sub_float(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_mul_float(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_div_float(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_rem_float(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_fma_float(jl_value_t *a, jl_value_t *b, jl_value_t *c);
+JL_DLLEXPORT jl_value_t *jl_muladd_float(jl_value_t *a, jl_value_t *b, jl_value_t *c);
 
-DLLEXPORT jl_value_t *jl_eq_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_ne_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_slt_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_ult_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_sle_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_ule_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_eq_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_ne_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_slt_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_ult_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_sle_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_ule_int(jl_value_t *a, jl_value_t *b);
 
-DLLEXPORT jl_value_t *jl_eq_float(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_ne_float(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_lt_float(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_le_float(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_fpiseq(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_fpislt(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_eq_float(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_ne_float(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_lt_float(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_le_float(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_fpiseq(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_fpislt(jl_value_t *a, jl_value_t *b);
 
-DLLEXPORT jl_value_t *jl_not_int(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_and_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_or_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_xor_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_shl_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_lshr_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_ashr_int(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_bswap_int(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_ctpop_int(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_ctlz_int(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_cttz_int(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_not_int(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_and_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_or_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_xor_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_shl_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_lshr_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_ashr_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_bswap_int(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_ctpop_int(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_ctlz_int(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_cttz_int(jl_value_t *a);
 
-DLLEXPORT jl_value_t *jl_sext_int(jl_value_t *ty, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_zext_int(jl_value_t *ty, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_trunc_int(jl_value_t *ty, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_sitofp(jl_value_t *ty, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_uitofp(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_sext_int(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_zext_int(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_trunc_int(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_sitofp(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_uitofp(jl_value_t *ty, jl_value_t *a);
 
-DLLEXPORT jl_value_t *jl_fptoui(jl_value_t *ty, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_fptosi(jl_value_t *ty, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_fptrunc(jl_value_t *ty, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_fpext(jl_value_t *ty, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_fptoui_auto(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_fptosi_auto(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_fptoui(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_fptosi(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_fptrunc(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_fpext(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_fptoui_auto(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_fptosi_auto(jl_value_t *a);
 
-DLLEXPORT jl_value_t *jl_checked_fptoui(jl_value_t *ty, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_checked_fptosi(jl_value_t *ty, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_checked_trunc_sint(jl_value_t *ty, jl_value_t *a);
-DLLEXPORT jl_value_t *jl_checked_trunc_uint(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_checked_fptoui(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_checked_fptosi(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_checked_trunc_sint(jl_value_t *ty, jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_checked_trunc_uint(jl_value_t *ty, jl_value_t *a);
 
-DLLEXPORT jl_value_t *jl_check_top_bit(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_checked_sadd(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_checked_uadd(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_checked_ssub(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_checked_usub(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_checked_smul(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_checked_umul(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_check_top_bit(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_checked_sadd(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_checked_uadd(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_checked_ssub(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_checked_usub(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_checked_smul(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_checked_umul(jl_value_t *a, jl_value_t *b);
 
-DLLEXPORT jl_value_t *jl_nan_dom_err(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_ceil_llvm(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_floor_llvm(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_trunc_llvm(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_rint_llvm(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_sqrt_llvm(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_powi_llvm(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_abs_float(jl_value_t *a);
-DLLEXPORT jl_value_t *jl_copysign_float(jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_flipsign_int(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_nan_dom_err(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_ceil_llvm(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_floor_llvm(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_trunc_llvm(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_rint_llvm(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_sqrt_llvm(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_powi_llvm(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_abs_float(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_copysign_float(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_flipsign_int(jl_value_t *a, jl_value_t *b);
 
-DLLEXPORT jl_value_t *jl_select_value(jl_value_t *isfalse, jl_value_t *a, jl_value_t *b);
-DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_select_value(jl_value_t *isfalse, jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a);
 int jl_array_store_unboxed(jl_value_t *el_type);
 int jl_array_isdefined(jl_value_t **args, int nargs);
 

--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -194,7 +194,7 @@ static RegisterPass<LowerSIMDLoop> X("LowerSIMDLoop", "LowerSIMDLoop Pass",
                                      false /* Only looks at CFG */,
                                      false /* Analysis Pass */);
 
-DLLEXPORT Pass* createLowerSimdLoopPass() {
+JL_DLLEXPORT Pass* createLowerSimdLoopPass() {
     return new LowerSIMDLoop();
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -17,7 +17,7 @@ jl_module_t *jl_base_module=NULL;
 jl_module_t *jl_top_module=NULL;
 jl_module_t *jl_current_module=NULL;
 
-DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
+JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
 {
     jl_module_t *m = (jl_module_t*)jl_gc_allocobj(sizeof(jl_module_t));
     jl_set_typeof(m, jl_module_type);
@@ -42,7 +42,7 @@ DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
     return m;
 }
 
-DLLEXPORT jl_value_t *jl_f_new_module(jl_sym_t *name, uint8_t std_imports)
+JL_DLLEXPORT jl_value_t *jl_f_new_module(jl_sym_t *name, uint8_t std_imports)
 {
     jl_module_t *m = jl_new_module(name);
     JL_GC_PUSH1(&m);
@@ -53,14 +53,14 @@ DLLEXPORT jl_value_t *jl_f_new_module(jl_sym_t *name, uint8_t std_imports)
     return (jl_value_t*)m;
 }
 
-DLLEXPORT void jl_set_istopmod(uint8_t isprimary)
+JL_DLLEXPORT void jl_set_istopmod(uint8_t isprimary)
 {
     jl_current_module->istopmod = 1;
     if (isprimary)
         jl_top_module = jl_current_module;
 }
 
-DLLEXPORT uint8_t jl_istopmod(jl_module_t *mod)
+JL_DLLEXPORT uint8_t jl_istopmod(jl_module_t *mod)
 {
     return mod->istopmod;
 }
@@ -81,7 +81,7 @@ static jl_binding_t *new_binding(jl_sym_t *name)
 }
 
 // get binding for assignment
-DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
     jl_binding_t *b;
@@ -109,7 +109,7 @@ DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var)
 }
 
 // return module of binding
-DLLEXPORT jl_module_t *jl_get_module_of_binding(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT jl_module_t *jl_get_module_of_binding(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = jl_get_binding(m, var);
     if (b == NULL)
@@ -120,7 +120,8 @@ DLLEXPORT jl_module_t *jl_get_module_of_binding(jl_module_t *m, jl_sym_t *var)
 // get binding for adding a method
 // like jl_get_binding_wr, but uses existing imports instead of warning
 // and overwriting.
-DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m,
+                                                         jl_sym_t *var)
 {
     if (jl_base_module && m->std_imports && !jl_binding_resolved_p(m,var)) {
         jl_module_t *opmod = (jl_module_t*)jl_get_global(jl_base_module, jl_symbol("Operators"));
@@ -234,14 +235,14 @@ static jl_binding_t *jl_get_binding_(jl_module_t *m, jl_sym_t *var, modstack_t *
     return b;
 }
 
-DLLEXPORT jl_binding_t *jl_get_binding(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT jl_binding_t *jl_get_binding(jl_module_t *m, jl_sym_t *var)
 {
     return jl_get_binding_(m, var, NULL);
 }
 
 void jl_binding_deprecation_warning(jl_binding_t *b);
 
-DLLEXPORT jl_binding_t *jl_get_binding_or_error(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT jl_binding_t *jl_get_binding_or_error(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = jl_get_binding_(m, var, NULL);
     if (b == NULL)
@@ -251,7 +252,7 @@ DLLEXPORT jl_binding_t *jl_get_binding_or_error(jl_module_t *m, jl_sym_t *var)
     return b;
 }
 
-DLLEXPORT jl_value_t *jl_module_globalref(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT jl_value_t *jl_module_globalref(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = (jl_binding_t*)ptrhash_get(&m->bindings, var);
     if (b == HT_NOTFOUND) {
@@ -273,7 +274,7 @@ static int eq_bindings(jl_binding_t *a, jl_binding_t *b)
 }
 
 // does module m explicitly import s?
-DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s)
+JL_DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s)
 {
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, s);
     jl_binding_t *bto = *bp;
@@ -345,17 +346,18 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
     }
 }
 
-DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s)
+JL_DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from,
+                                   jl_sym_t *s)
 {
     module_import_(to, from, s, 1);
 }
 
-DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s)
+JL_DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s)
 {
     module_import_(to, from, s, 0);
 }
 
-DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from)
+JL_DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from)
 {
     void **table = from->bindings.table;
     for(size_t i=1; i < from->bindings.size; i+=2) {
@@ -367,7 +369,7 @@ DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from)
     }
 }
 
-DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from)
+JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from)
 {
     if (to == from)
         return;
@@ -402,7 +404,7 @@ DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from)
     arraylist_push(&to->usings, from);
 }
 
-DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s)
+JL_DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s)
 {
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&from->bindings, s);
     if (*bp == HT_NOTFOUND) {
@@ -416,34 +418,34 @@ DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s)
     (*bp)->exportp = 1;
 }
 
-DLLEXPORT int jl_boundp(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT int jl_boundp(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = jl_get_binding(m, var);
     return b && (b->value != NULL);
 }
 
-DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
     if (*bp == HT_NOTFOUND) return 0;
     return (*bp)->exportp || (*bp)->owner==m;
 }
 
-DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
     if (*bp == HT_NOTFOUND) return 0;
     return (*bp)->exportp;
 }
 
-DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
     if (*bp == HT_NOTFOUND) return 0;
     return (*bp)->owner != NULL;
 }
 
-DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = jl_get_binding(m, var);
     if (b == NULL) return NULL;
@@ -451,7 +453,7 @@ DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
     return b->value;
 }
 
-DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
+JL_DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var);
     if (!bp->constp) {
@@ -460,7 +462,7 @@ DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
     }
 }
 
-DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
+JL_DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var);
     if (!bp->constp) {
@@ -470,20 +472,20 @@ DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
     }
 }
 
-DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var)
 {
     if (m == NULL) m = jl_current_module;
     jl_binding_t *b = jl_get_binding(m, var);
     return b && b->constp;
 }
 
-DLLEXPORT void jl_deprecate_binding(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT void jl_deprecate_binding(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = jl_get_binding(m, var);
     if (b) b->deprecated = 1;
 }
 
-DLLEXPORT int jl_is_binding_deprecated(jl_module_t *m, jl_sym_t *var)
+JL_DLLEXPORT int jl_is_binding_deprecated(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = jl_get_binding(m, var);
     return b && b->deprecated;
@@ -532,7 +534,7 @@ void jl_binding_deprecation_warning(jl_binding_t *b)
     }
 }
 
-DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
+JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
 {
     if (b->constp && b->value != NULL) {
         if (!jl_egal(rhs, b->value)) {
@@ -549,7 +551,7 @@ DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
     jl_gc_wb_binding(b, rhs);
 }
 
-DLLEXPORT void jl_declare_constant(jl_binding_t *b)
+JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b)
 {
     if (b->value != NULL && !b->constp) {
         jl_errorf("cannot declare %s constant; it already has a value",
@@ -558,18 +560,18 @@ DLLEXPORT void jl_declare_constant(jl_binding_t *b)
     b->constp = 1;
 }
 
-DLLEXPORT jl_value_t *jl_get_current_module(void)
+JL_DLLEXPORT jl_value_t *jl_get_current_module(void)
 {
     return (jl_value_t*)jl_current_module;
 }
 
-DLLEXPORT void jl_set_current_module(jl_value_t *m)
+JL_DLLEXPORT void jl_set_current_module(jl_value_t *m)
 {
     assert(jl_typeis(m, jl_module_type));
     jl_current_module = (jl_module_t*)m;
 }
 
-DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
+JL_DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
 {
     jl_array_t *a = jl_alloc_array_1d(jl_array_any_type, 0);
     JL_GC_PUSH1(&a);
@@ -582,7 +584,7 @@ DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
     return (jl_value_t*)a;
 }
 
-DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
+JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
 {
     jl_array_t *a = jl_alloc_array_1d(jl_array_symbol_type, 0);
     JL_GC_PUSH1(&a);
@@ -603,9 +605,9 @@ DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
     return (jl_value_t*)a;
 }
 
-DLLEXPORT jl_sym_t *jl_module_name(jl_module_t *m) { return m->name; }
-DLLEXPORT jl_module_t *jl_module_parent(jl_module_t *m) { return m->parent; }
-DLLEXPORT uint64_t jl_module_uuid(jl_module_t *m) { return m->uuid; }
+JL_DLLEXPORT jl_sym_t *jl_module_name(jl_module_t *m) { return m->name; }
+JL_DLLEXPORT jl_module_t *jl_module_parent(jl_module_t *m) { return m->parent; }
+JL_DLLEXPORT uint64_t jl_module_uuid(jl_module_t *m) { return m->uuid; }
 
 jl_function_t *jl_module_get_initializer(jl_module_t *m)
 {
@@ -615,7 +617,7 @@ jl_function_t *jl_module_get_initializer(jl_module_t *m)
     return (jl_function_t*)f;
 }
 
-DLLEXPORT void jl_module_run_initializer(jl_module_t *m)
+JL_DLLEXPORT void jl_module_run_initializer(jl_module_t *m)
 {
     jl_function_t *f = jl_module_get_initializer(m);
     if (f == NULL)

--- a/src/module.c
+++ b/src/module.c
@@ -17,7 +17,7 @@ jl_module_t *jl_base_module=NULL;
 jl_module_t *jl_top_module=NULL;
 jl_module_t *jl_current_module=NULL;
 
-jl_module_t *jl_new_module(jl_sym_t *name)
+DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
 {
     jl_module_t *m = (jl_module_t*)jl_gc_allocobj(sizeof(jl_module_t));
     jl_set_typeof(m, jl_module_type);
@@ -273,7 +273,7 @@ static int eq_bindings(jl_binding_t *a, jl_binding_t *b)
 }
 
 // does module m explicitly import s?
-int jl_is_imported(jl_module_t *m, jl_sym_t *s)
+DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s)
 {
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, s);
     jl_binding_t *bto = *bp;
@@ -345,17 +345,17 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
     }
 }
 
-void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s)
+DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s)
 {
     module_import_(to, from, s, 1);
 }
 
-void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s)
+DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s)
 {
     module_import_(to, from, s, 0);
 }
 
-void jl_module_importall(jl_module_t *to, jl_module_t *from)
+DLLEXPORT void jl_module_importall(jl_module_t *to, jl_module_t *from)
 {
     void **table = from->bindings.table;
     for(size_t i=1; i < from->bindings.size; i+=2) {
@@ -367,7 +367,7 @@ void jl_module_importall(jl_module_t *to, jl_module_t *from)
     }
 }
 
-void jl_module_using(jl_module_t *to, jl_module_t *from)
+DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from)
 {
     if (to == from)
         return;
@@ -402,7 +402,7 @@ void jl_module_using(jl_module_t *to, jl_module_t *from)
     arraylist_push(&to->usings, from);
 }
 
-void jl_module_export(jl_module_t *from, jl_sym_t *s)
+DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s)
 {
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&from->bindings, s);
     if (*bp == HT_NOTFOUND) {
@@ -416,13 +416,13 @@ void jl_module_export(jl_module_t *from, jl_sym_t *s)
     (*bp)->exportp = 1;
 }
 
-int jl_boundp(jl_module_t *m, jl_sym_t *var)
+DLLEXPORT int jl_boundp(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = jl_get_binding(m, var);
     return b && (b->value != NULL);
 }
 
-int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var)
+DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
     if (*bp == HT_NOTFOUND) return 0;
@@ -436,14 +436,14 @@ DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var)
     return (*bp)->exportp;
 }
 
-int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var)
+DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
     if (*bp == HT_NOTFOUND) return 0;
     return (*bp)->owner != NULL;
 }
 
-jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
+DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = jl_get_binding(m, var);
     if (b == NULL) return NULL;
@@ -451,7 +451,7 @@ jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
     return b->value;
 }
 
-void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
+DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var);
     if (!bp->constp) {
@@ -460,7 +460,7 @@ void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
     }
 }
 
-void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
+DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var);
     if (!bp->constp) {
@@ -615,7 +615,7 @@ jl_function_t *jl_module_get_initializer(jl_module_t *m)
     return (jl_function_t*)f;
 }
 
-void jl_module_run_initializer(jl_module_t *m)
+DLLEXPORT void jl_module_run_initializer(jl_module_t *m)
 {
     jl_function_t *f = jl_module_get_initializer(m);
     if (f == NULL)

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -79,7 +79,7 @@ static void jl_read_sonames(void)
     pclose(ldc);
 }
 
-extern "C" DLLEXPORT const char *jl_lookup_soname(const char *pfx, size_t n)
+extern "C" JL_DLLEXPORT const char *jl_lookup_soname(const char *pfx, size_t n)
 {
     if (!got_sonames) {
         jl_read_sonames();
@@ -117,7 +117,7 @@ void *jl_get_library(const char *f_lib)
     return hnd;
 }
 
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 void *jl_load_and_lookup(const char *f_lib, const char *f_name, void **hnd)
 {
     void *handle = *hnd;
@@ -127,7 +127,7 @@ void *jl_load_and_lookup(const char *f_lib, const char *f_name, void **hnd)
 }
 
 // miscellany
-extern "C" DLLEXPORT
+extern "C" JL_DLLEXPORT
 jl_value_t *jl_get_cpu_name(void)
 {
 #if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR < 5

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -14,7 +14,7 @@
 const unsigned int host_char_bit = 8;
 
 // run time version of box/unbox intrinsic
-DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v)
+JL_DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v)
 {
     JL_TYPECHK(reinterpret, datatype, ty);
     if (!jl_is_leaf_type(ty) || !jl_is_bitstype(ty))
@@ -31,7 +31,7 @@ DLLEXPORT jl_value_t *jl_reinterpret(jl_value_t *ty, jl_value_t *v)
 }
 
 // run time version of pointerref intrinsic (warning: i is not rooted)
-DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i)
+JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i)
 {
     JL_TYPECHK(pointerref, pointer, p);
     JL_TYPECHK(pointerref, long, i);
@@ -50,7 +50,7 @@ DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i)
 }
 
 // run time version of pointerset intrinsic (warning: x is not gc-rooted)
-DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i)
+JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *i)
 {
     JL_TYPECHK(pointerset, pointer, p);
     JL_TYPECHK(pointerset, long, i);
@@ -221,7 +221,7 @@ static void jl_##name##nbits(unsigned runtime_nbits, void *pa, void *pb, void *p
 typedef void (*intrinsic_1_t)(unsigned, void*, void*);
 SELECTOR_FUNC(intrinsic_1)
 #define un_iintrinsic(name, u) \
-DLLEXPORT jl_value_t *jl_##name(jl_value_t *a) \
+JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a) \
 { \
     return jl_iintrinsic_1(jl_typeof(a), a, #name, u##signbitbyte, jl_intrinsiclambda_ty1, name##_list); \
 }
@@ -247,7 +247,7 @@ un_iintrinsic(name, u)
 typedef unsigned (*intrinsic_u1_t)(unsigned, void*);
 SELECTOR_FUNC(intrinsic_u1)
 #define uu_iintrinsic(name, u) \
-DLLEXPORT jl_value_t *jl_##name(jl_value_t *a) \
+JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a) \
 { \
     return jl_iintrinsic_1(jl_typeof(a), a, #name, u##signbitbyte, jl_intrinsiclambda_u1, name##_list); \
 }
@@ -329,7 +329,7 @@ static inline jl_value_t *jl_intrinsiclambda_u1(jl_value_t *ty, void *pa, unsign
 typedef void (*intrinsic_cvt_t)(unsigned, void*, unsigned, void*);
 typedef unsigned (*intrinsic_cvt_check_t)(unsigned, unsigned, void*);
 #define cvt_iintrinsic_checked(LLVMOP, check_op, name) \
-DLLEXPORT jl_value_t *jl_##name(jl_value_t *ty, jl_value_t *a) \
+JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *ty, jl_value_t *a) \
 { \
     return jl_intrinsic_cvt(ty, a, #name, LLVMOP, check_op); \
 }
@@ -361,14 +361,14 @@ static inline jl_value_t *jl_intrinsic_cvt(jl_value_t *ty, jl_value_t *a, const 
 #define un_fintrinsic_withtype(OP, name) \
 un_fintrinsic_ctype(OP, jl_##name##32, float) \
 un_fintrinsic_ctype(OP, jl_##name##64, double) \
-DLLEXPORT jl_value_t *jl_##name(jl_value_t *ty, jl_value_t *a) \
+JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *ty, jl_value_t *a) \
 { \
     return jl_fintrinsic_1(ty, a, #name, jl_##name##32, jl_##name##64); \
 }
 
 #define un_fintrinsic(OP, name) \
 un_fintrinsic_withtype(OP, name##_withtype) \
-DLLEXPORT jl_value_t *jl_##name(jl_value_t *a) \
+JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a) \
 { \
     return jl_##name##_withtype(jl_typeof(a), a); \
 }
@@ -406,7 +406,7 @@ static inline jl_value_t *jl_fintrinsic_1(jl_value_t *ty, jl_value_t *a, const c
 typedef void (*intrinsic_2_t)(unsigned, void*, void*, void*);
 SELECTOR_FUNC(intrinsic_2)
 #define bi_iintrinsic(name, u, cvtb) \
-DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
 { \
     return jl_iintrinsic_2(a, b, #name, u##signbitbyte, jl_intrinsiclambda_2, name##_list, cvtb); \
 }
@@ -429,7 +429,7 @@ bi_iintrinsic(name, u, cvtb)
 typedef int (*intrinsic_cmp_t)(unsigned, void*, void*);
 SELECTOR_FUNC(intrinsic_cmp)
 #define cmp_iintrinsic(name, u) \
-DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
 { \
     return jl_iintrinsic_2(a, b, #name, u##signbitbyte, jl_intrinsiclambda_cmp, name##_list, 0); \
 }
@@ -450,7 +450,7 @@ cmp_iintrinsic(name, u)
 typedef int (*intrinsic_checked_t)(unsigned, void*, void*, void*);
 SELECTOR_FUNC(intrinsic_checked)
 #define checked_iintrinsic(name, u) \
-DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
 { \
     return jl_iintrinsic_2(a, b, #name, u##signbitbyte, jl_intrinsiclambda_checked, name##_list, 0); \
 }
@@ -543,7 +543,7 @@ static inline jl_value_t *jl_intrinsiclambda_checked(jl_value_t *ty, void *pa, v
 #define bi_fintrinsic(OP, name) \
     bi_intrinsic_ctype(OP, name, 32, float) \
     bi_intrinsic_ctype(OP, name, 64, double) \
-DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
 { \
     jl_value_t *ty = jl_typeof(a); \
     if (jl_typeof(b) != ty) \
@@ -570,7 +570,7 @@ DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
 #define bool_fintrinsic(OP, name) \
     bool_intrinsic_ctype(OP, name, 32, float) \
     bool_intrinsic_ctype(OP, name, 64, double) \
-DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
 { \
     jl_value_t *ty = jl_typeof(a); \
     if (jl_typeof(b) != ty) \
@@ -597,7 +597,7 @@ DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
 #define ter_fintrinsic(OP, name) \
     ter_intrinsic_ctype(OP, name, 32, float) \
     ter_intrinsic_ctype(OP, name, 64, double) \
-DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b, jl_value_t *c) \
+JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b, jl_value_t *c) \
 { \
     jl_value_t *ty = jl_typeof(a); \
     if (jl_typeof(b) != ty || jl_typeof(c) != ty) \
@@ -767,7 +767,7 @@ cvt_iintrinsic(LLVMFPtoUI, fptoui)
 un_fintrinsic_withtype(fpcvt,fptrunc)
 un_fintrinsic_withtype(fpcvt,fpext)
 
-DLLEXPORT jl_value_t *jl_fptoui_auto(jl_value_t *a)
+JL_DLLEXPORT jl_value_t *jl_fptoui_auto(jl_value_t *a)
 {
     jl_datatype_t *ty;
     switch (jl_datatype_size(jl_typeof(a))) {
@@ -782,7 +782,7 @@ DLLEXPORT jl_value_t *jl_fptoui_auto(jl_value_t *a)
     }
     return jl_fptoui((jl_value_t*)ty, a);
 }
-DLLEXPORT jl_value_t *jl_fptosi_auto(jl_value_t *a)
+JL_DLLEXPORT jl_value_t *jl_fptosi_auto(jl_value_t *a)
 {
     jl_datatype_t *ty;
     switch (jl_datatype_size(jl_typeof(a))) {
@@ -827,7 +827,7 @@ un_fintrinsic_withtype(checked_fptosi, checked_fptosi)
             jl_throw(jl_inexact_exception);
 un_fintrinsic_withtype(checked_fptoui, checked_fptoui)
 
-DLLEXPORT jl_value_t *jl_check_top_bit(jl_value_t *a)
+JL_DLLEXPORT jl_value_t *jl_check_top_bit(jl_value_t *a)
 {
     jl_value_t *ty = jl_typeof(a);
     if (!jl_is_bitstype(ty))
@@ -856,7 +856,7 @@ checked_iintrinsic_fast(LLVMSub_uov, check_usub, sub, checked_usub, u)
 checked_iintrinsic_slow(LLVMMul_sov, checked_smul,  )
 checked_iintrinsic_slow(LLVMMul_uov, checked_umul, u)
 
-DLLEXPORT jl_value_t *jl_nan_dom_err(jl_value_t *a, jl_value_t *b)
+JL_DLLEXPORT jl_value_t *jl_nan_dom_err(jl_value_t *a, jl_value_t *b)
 {
     jl_value_t *ty = jl_typeof(a);
     if (jl_typeof(b) != ty)
@@ -902,7 +902,7 @@ un_fintrinsic(trunc_float,trunc_llvm)
 un_fintrinsic(rint_float,rint_llvm)
 un_fintrinsic(sqrt_float,sqrt_llvm)
 
-DLLEXPORT jl_value_t *jl_powi_llvm(jl_value_t *a, jl_value_t *b)
+JL_DLLEXPORT jl_value_t *jl_powi_llvm(jl_value_t *a, jl_value_t *b)
 {
     jl_value_t *ty = jl_typeof(a);
     if (!jl_is_bitstype(ty))
@@ -926,13 +926,13 @@ DLLEXPORT jl_value_t *jl_powi_llvm(jl_value_t *a, jl_value_t *b)
     return newv;
 }
 
-DLLEXPORT jl_value_t *jl_select_value(jl_value_t *isfalse, jl_value_t *a, jl_value_t *b)
+JL_DLLEXPORT jl_value_t *jl_select_value(jl_value_t *isfalse, jl_value_t *a, jl_value_t *b)
 {
     JL_TYPECHK(isfalse, bool, isfalse);
     return (isfalse == jl_false ? b : a);
 }
 
-DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a)
+JL_DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a)
 {
     return jl_box_long(jl_array_len((jl_array_t*)a));
 }

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -20,8 +20,8 @@ static volatile u_int64_t nsecprof = 0;
 static volatile int running = 0;
 static const    u_int64_t GIGA = 1000000000ULL;
 // Timers to take samples at intervals
-DLLEXPORT void jl_profile_stop_timer(void);
-DLLEXPORT int jl_profile_start_timer(void);
+JL_DLLEXPORT void jl_profile_stop_timer(void);
+JL_DLLEXPORT int jl_profile_start_timer(void);
 
 
 volatile sig_atomic_t jl_signal_pending = 0;
@@ -29,10 +29,10 @@ volatile sig_atomic_t jl_defer_signal = 0;
 
 
 int exit_on_sigint = 0;
-DLLEXPORT void jl_exit_on_sigint(int on) {exit_on_sigint = on;}
+JL_DLLEXPORT void jl_exit_on_sigint(int on) {exit_on_sigint = on;}
 
 // what to do on SIGINT
-DLLEXPORT void jl_sigint_action(void)
+JL_DLLEXPORT void jl_sigint_action(void)
 {
     if (exit_on_sigint) jl_exit(130); // 128+SIGINT
     jl_throw(jl_interrupt_exception);
@@ -64,7 +64,7 @@ static void jl_critical_error(int sig, bt_context_t context, ptrint_t *bt_data, 
 ///////////////////////
 // Utility functions //
 ///////////////////////
-DLLEXPORT int jl_profile_init(size_t maxsize, u_int64_t delay_nsec)
+JL_DLLEXPORT int jl_profile_init(size_t maxsize, u_int64_t delay_nsec)
 {
     bt_size_max = maxsize;
     nsecprof = delay_nsec;
@@ -77,32 +77,32 @@ DLLEXPORT int jl_profile_init(size_t maxsize, u_int64_t delay_nsec)
     return 0;
 }
 
-DLLEXPORT u_int8_t *jl_profile_get_data(void)
+JL_DLLEXPORT u_int8_t *jl_profile_get_data(void)
 {
     return (u_int8_t*) bt_data_prof;
 }
 
-DLLEXPORT size_t jl_profile_len_data(void)
+JL_DLLEXPORT size_t jl_profile_len_data(void)
 {
     return bt_size_cur;
 }
 
-DLLEXPORT size_t jl_profile_maxlen_data(void)
+JL_DLLEXPORT size_t jl_profile_maxlen_data(void)
 {
     return bt_size_max;
 }
 
-DLLEXPORT u_int64_t jl_profile_delay_nsec(void)
+JL_DLLEXPORT u_int64_t jl_profile_delay_nsec(void)
 {
     return nsecprof;
 }
 
-DLLEXPORT void jl_profile_clear_data(void)
+JL_DLLEXPORT void jl_profile_clear_data(void)
 {
     bt_size_cur = 0;
 }
 
-DLLEXPORT int jl_profile_is_running(void)
+JL_DLLEXPORT int jl_profile_is_running(void)
 {
     return running;
 }

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -100,7 +100,7 @@ void jl_throw_in_thread(int tid, mach_port_t thread, jl_value_t *exception)
 }
 
 //exc_server uses dlsym to find symbol
-DLLEXPORT
+JL_DLLEXPORT
 kern_return_t catch_exception_raise(mach_port_t            exception_port,
                                     mach_port_t            thread,
                                     mach_port_t            task,
@@ -153,7 +153,7 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
     }
 }
 
-DLLEXPORT void attach_exception_port(void)
+JL_DLLEXPORT void attach_exception_port(void)
 {
     kern_return_t ret;
     // http://www.opensource.apple.com/source/xnu/xnu-2782.1.97/osfmk/man/thread_set_exception_ports.html
@@ -327,7 +327,7 @@ void *mach_profile_listener(void *arg)
     }
 }
 
-DLLEXPORT int jl_profile_start_timer(void)
+JL_DLLEXPORT int jl_profile_start_timer(void)
 {
     kern_return_t ret;
     if (!profile_started) {
@@ -363,8 +363,7 @@ DLLEXPORT int jl_profile_start_timer(void)
     return 0;
 }
 
-DLLEXPORT void jl_profile_stop_timer(void)
+JL_DLLEXPORT void jl_profile_stop_timer(void)
 {
     running = 0;
 }
-

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -153,7 +153,7 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
     }
 }
 
-void attach_exception_port()
+DLLEXPORT void attach_exception_port(void)
 {
     kern_return_t ret;
     // http://www.opensource.apple.com/source/xnu/xnu-2782.1.97/osfmk/man/thread_set_exception_ports.html

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -189,7 +189,7 @@ void usr2_handler(int sig, siginfo_t *info, void *ctx)
 #if defined(HAVE_SIGTIMEDWAIT)
 
 static struct timespec timeoutprof;
-DLLEXPORT int jl_profile_start_timer(void)
+JL_DLLEXPORT int jl_profile_start_timer(void)
 {
     timeoutprof.tv_sec = nsecprof/GIGA;
     timeoutprof.tv_nsec = nsecprof%GIGA;
@@ -197,7 +197,7 @@ DLLEXPORT int jl_profile_start_timer(void)
     return 0;
 }
 
-DLLEXPORT void jl_profile_stop_timer(void)
+JL_DLLEXPORT void jl_profile_stop_timer(void)
 {
     pthread_kill(signals_thread, SIGUSR2);
 }
@@ -210,7 +210,7 @@ DLLEXPORT void jl_profile_stop_timer(void)
 static timer_t timerprof;
 static struct itimerspec itsprof;
 
-DLLEXPORT int jl_profile_start_timer(void)
+JL_DLLEXPORT int jl_profile_start_timer(void)
 {
     struct sigevent sigprof;
     struct sigaction sa;
@@ -236,7 +236,7 @@ DLLEXPORT int jl_profile_start_timer(void)
     return 0;
 }
 
-DLLEXPORT void jl_profile_stop_timer(void)
+JL_DLLEXPORT void jl_profile_stop_timer(void)
 {
     if (running)
         timer_delete(timerprof);
@@ -249,7 +249,7 @@ DLLEXPORT void jl_profile_stop_timer(void)
 #include <sys/time.h>
 struct itimerval timerprof;
 
-DLLEXPORT int jl_profile_start_timer(void)
+JL_DLLEXPORT int jl_profile_start_timer(void)
 {
     timerprof.it_interval.tv_sec = nsecprof/GIGA;
     timerprof.it_interval.tv_usec = (nsecprof%GIGA)/1000;
@@ -263,7 +263,7 @@ DLLEXPORT int jl_profile_start_timer(void)
     return 0;
 }
 
-DLLEXPORT void jl_profile_stop_timer(void)
+JL_DLLEXPORT void jl_profile_stop_timer(void)
 {
     if (running) {
         memset(&timerprof, 0, sizeof(timerprof));
@@ -509,7 +509,7 @@ void jl_install_default_signal_handlers(void)
 #endif
 }
 
-DLLEXPORT void jl_install_sigint_handler(void)
+JL_DLLEXPORT void jl_install_sigint_handler(void)
 {
     // TODO: ?
 }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -4,7 +4,7 @@
 #define sig_stack_size 131072 // 128k reserved for SEGV handling
 static BOOL (*pSetThreadStackGuarantee)(PULONG);
 
-DLLEXPORT void gdblookup(ptrint_t ip);
+JL_DLLEXPORT void gdblookup(ptrint_t ip);
 
 // Copied from MINGW_FLOAT_H which may not be found due to a collision with the builtin gcc float.h
 // eventually we can probably integrate this into OpenLibm.
@@ -260,7 +260,7 @@ EXCEPTION_DISPOSITION _seh_exception_handler(PEXCEPTION_RECORD ExceptionRecord, 
 }
 #endif
 
-DLLEXPORT void jl_install_sigint_handler(void)
+JL_DLLEXPORT void jl_install_sigint_handler(void)
 {
     SetConsoleCtrlHandler((PHANDLER_ROUTINE)sigint_handler,1);
 }
@@ -310,7 +310,7 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
     hBtThread = 0;
     return 0;
 }
-DLLEXPORT int jl_profile_start_timer(void)
+JL_DLLEXPORT int jl_profile_start_timer(void)
 {
     running = 1;
     if (hBtThread == 0) {
@@ -331,7 +331,7 @@ DLLEXPORT int jl_profile_start_timer(void)
     }
     return (hBtThread != NULL ? 0 : -1);
 }
-DLLEXPORT void jl_profile_stop_timer(void)
+JL_DLLEXPORT void jl_profile_stop_timer(void)
 {
     running = 0;
 }

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -7,7 +7,7 @@
 #include "julia.h"
 #include "julia_internal.h"
 
-DLLEXPORT jl_svec_t *jl_svec(size_t n, ...)
+JL_DLLEXPORT jl_svec_t *jl_svec(size_t n, ...)
 {
     va_list args;
     if (n == 0) return jl_emptysvec;
@@ -20,7 +20,7 @@ DLLEXPORT jl_svec_t *jl_svec(size_t n, ...)
     return jv;
 }
 
-DLLEXPORT jl_svec_t *jl_svec1(void *a)
+JL_DLLEXPORT jl_svec_t *jl_svec1(void *a)
 {
     jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_2w();
     jl_set_typeof(v, jl_simplevector_type);
@@ -29,7 +29,7 @@ DLLEXPORT jl_svec_t *jl_svec1(void *a)
     return v;
 }
 
-DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b)
+JL_DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b)
 {
     jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_3w();
     jl_set_typeof(v, jl_simplevector_type);
@@ -39,7 +39,7 @@ DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b)
     return v;
 }
 
-DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n)
+JL_DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n)
 {
     if (n == 0) return jl_emptysvec;
     jl_svec_t *jv = (jl_svec_t*)newobj((jl_value_t*)jl_simplevector_type, n+1);
@@ -47,7 +47,7 @@ DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n)
     return jv;
 }
 
-DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n)
+JL_DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n)
 {
     if (n == 0) return jl_emptysvec;
     jl_svec_t *jv = jl_alloc_svec_uninit(n);
@@ -57,7 +57,7 @@ DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n)
     return jv;
 }
 
-DLLEXPORT jl_svec_t *jl_svec_append(jl_svec_t *a, jl_svec_t *b)
+JL_DLLEXPORT jl_svec_t *jl_svec_append(jl_svec_t *a, jl_svec_t *b)
 {
     jl_svec_t *c = jl_alloc_svec_uninit(jl_svec_len(a) + jl_svec_len(b));
     size_t i=0, j;
@@ -72,12 +72,12 @@ DLLEXPORT jl_svec_t *jl_svec_append(jl_svec_t *a, jl_svec_t *b)
     return c;
 }
 
-DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a)
+JL_DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a)
 {
     return jl_svec_append(a, jl_emptysvec);
 }
 
-DLLEXPORT jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x)
+JL_DLLEXPORT jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x)
 {
     if (n==0) return jl_emptysvec;
     jl_svec_t *v = jl_alloc_svec_uninit(n);

--- a/src/simplevector.c
+++ b/src/simplevector.c
@@ -20,7 +20,7 @@ DLLEXPORT jl_svec_t *jl_svec(size_t n, ...)
     return jv;
 }
 
-jl_svec_t *jl_svec1(void *a)
+DLLEXPORT jl_svec_t *jl_svec1(void *a)
 {
     jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_2w();
     jl_set_typeof(v, jl_simplevector_type);
@@ -29,7 +29,7 @@ jl_svec_t *jl_svec1(void *a)
     return v;
 }
 
-jl_svec_t *jl_svec2(void *a, void *b)
+DLLEXPORT jl_svec_t *jl_svec2(void *a, void *b)
 {
     jl_svec_t *v = (jl_svec_t*)jl_gc_alloc_3w();
     jl_set_typeof(v, jl_simplevector_type);
@@ -39,7 +39,7 @@ jl_svec_t *jl_svec2(void *a, void *b)
     return v;
 }
 
-jl_svec_t *jl_alloc_svec_uninit(size_t n)
+DLLEXPORT jl_svec_t *jl_alloc_svec_uninit(size_t n)
 {
     if (n == 0) return jl_emptysvec;
     jl_svec_t *jv = (jl_svec_t*)newobj((jl_value_t*)jl_simplevector_type, n+1);
@@ -47,7 +47,7 @@ jl_svec_t *jl_alloc_svec_uninit(size_t n)
     return jv;
 }
 
-jl_svec_t *jl_alloc_svec(size_t n)
+DLLEXPORT jl_svec_t *jl_alloc_svec(size_t n)
 {
     if (n == 0) return jl_emptysvec;
     jl_svec_t *jv = jl_alloc_svec_uninit(n);
@@ -57,7 +57,7 @@ jl_svec_t *jl_alloc_svec(size_t n)
     return jv;
 }
 
-jl_svec_t *jl_svec_append(jl_svec_t *a, jl_svec_t *b)
+DLLEXPORT jl_svec_t *jl_svec_append(jl_svec_t *a, jl_svec_t *b)
 {
     jl_svec_t *c = jl_alloc_svec_uninit(jl_svec_len(a) + jl_svec_len(b));
     size_t i=0, j;
@@ -72,12 +72,12 @@ jl_svec_t *jl_svec_append(jl_svec_t *a, jl_svec_t *b)
     return c;
 }
 
-jl_svec_t *jl_svec_copy(jl_svec_t *a)
+DLLEXPORT jl_svec_t *jl_svec_copy(jl_svec_t *a)
 {
     return jl_svec_append(a, jl_emptysvec);
 }
 
-jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x)
+DLLEXPORT jl_svec_t *jl_svec_fill(size_t n, jl_value_t *x)
 {
     if (n==0) return jl_emptysvec;
     jl_svec_t *v = jl_alloc_svec_uninit(n);

--- a/src/support/bitvector.h
+++ b/src/support/bitvector.h
@@ -7,19 +7,19 @@
 extern "C" {
 #endif
 
-DLLEXPORT u_int32_t *bitvector_new(u_int64_t n, int initzero);
-DLLEXPORT
+JL_DLLEXPORT u_int32_t *bitvector_new(u_int64_t n, int initzero);
+JL_DLLEXPORT
 u_int32_t *bitvector_resize(u_int32_t *b, uint64_t oldsz, uint64_t newsz,
                             int initzero);
 size_t bitvector_nwords(u_int64_t nbits);
-DLLEXPORT void bitvector_set(u_int32_t *b, u_int64_t n, u_int32_t c);
-DLLEXPORT u_int32_t bitvector_get(u_int32_t *b, u_int64_t n);
+JL_DLLEXPORT void bitvector_set(u_int32_t *b, u_int64_t n, u_int32_t c);
+JL_DLLEXPORT u_int32_t bitvector_get(u_int32_t *b, u_int64_t n);
 
-DLLEXPORT uint64_t bitvector_next(uint32_t *b, uint64_t n0, uint64_t n);
+JL_DLLEXPORT uint64_t bitvector_next(uint32_t *b, uint64_t n0, uint64_t n);
 
-DLLEXPORT
+JL_DLLEXPORT
 u_int64_t bitvector_count(u_int32_t *b, u_int64_t offs, u_int64_t nbits);
-DLLEXPORT
+JL_DLLEXPORT
 u_int32_t bitvector_any1(u_int32_t *b, u_int64_t offs, u_int64_t nbits);
 
 #ifdef __cplusplus

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -60,13 +60,13 @@
 #ifdef _OS_WINDOWS_
 #define STDCALL __stdcall
 # ifdef LIBRARY_EXPORTS
-#  define DLLEXPORT __declspec(dllexport)
+#  define JL_DLLEXPORT __declspec(dllexport)
 # else
-#  define DLLEXPORT __declspec(dllimport)
+#  define JL_DLLEXPORT __declspec(dllimport)
 # endif
 #else
 #define STDCALL
-#define DLLEXPORT __attribute__ ((visibility("default")))
+#define JL_DLLEXPORT __attribute__ ((visibility("default")))
 #endif
 
 #ifdef _OS_LINUX_

--- a/src/support/hashing.h
+++ b/src/support/hashing.h
@@ -8,18 +8,18 @@ extern "C" {
 #endif
 
 uint_t nextipow2(uint_t i);
-DLLEXPORT u_int32_t int32hash(u_int32_t a);
-DLLEXPORT u_int64_t int64hash(u_int64_t key);
-DLLEXPORT u_int32_t int64to32hash(u_int64_t key);
+JL_DLLEXPORT u_int32_t int32hash(u_int32_t a);
+JL_DLLEXPORT u_int64_t int64hash(u_int64_t key);
+JL_DLLEXPORT u_int32_t int64to32hash(u_int64_t key);
 #ifdef _P64
 #define inthash int64hash
 #else
 #define inthash int32hash
 #endif
-DLLEXPORT u_int64_t memhash(const char *buf, size_t n);
-DLLEXPORT u_int64_t memhash_seed(const char *buf, size_t n, u_int32_t seed);
-DLLEXPORT u_int32_t memhash32(const char *buf, size_t n);
-DLLEXPORT u_int32_t memhash32_seed(const char *buf, size_t n, u_int32_t seed);
+JL_DLLEXPORT u_int64_t memhash(const char *buf, size_t n);
+JL_DLLEXPORT u_int64_t memhash_seed(const char *buf, size_t n, u_int32_t seed);
+JL_DLLEXPORT u_int32_t memhash32(const char *buf, size_t n);
+JL_DLLEXPORT u_int32_t memhash32_seed(const char *buf, size_t n, u_int32_t seed);
 
 #ifdef __cplusplus
 }

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -39,7 +39,7 @@ extern "C" {
 /* OS-level primitive wrappers */
 
 #if defined(__APPLE__) || defined(_OS_WINDOWS_)
-DLLEXPORT void *memrchr(const void *s, int c, size_t n)
+JL_DLLEXPORT void *memrchr(const void *s, int c, size_t n)
 {
     const unsigned char *src = (unsigned char*)s + n;
     unsigned char uc = c;
@@ -357,7 +357,7 @@ static void _write_update_pos(ios_t *s)
 }
 
 // directly copy a buffer to a descriptor
-DLLEXPORT size_t ios_write_direct(ios_t *dest, ios_t *src)
+JL_DLLEXPORT size_t ios_write_direct(ios_t *dest, ios_t *src)
 {
     char *data = src->buf;
     size_t n = src->size;

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -71,65 +71,65 @@ typedef struct {
 } ios_t;
 
 /* low-level interface functions */
-DLLEXPORT size_t ios_read(ios_t *s, char *dest, size_t n);
-DLLEXPORT size_t ios_readall(ios_t *s, char *dest, size_t n);
-DLLEXPORT size_t ios_write(ios_t *s, const char *data, size_t n);
-DLLEXPORT off_t ios_seek(ios_t *s, off_t pos);   // absolute seek
-DLLEXPORT off_t ios_seek_end(ios_t *s);
-DLLEXPORT off_t ios_skip(ios_t *s, off_t offs);  // relative seek
-DLLEXPORT off_t ios_pos(ios_t *s);  // get current position
-DLLEXPORT int ios_trunc(ios_t *s, size_t size);
-DLLEXPORT int ios_eof(ios_t *s);
-DLLEXPORT int ios_eof_blocking(ios_t *s);
-DLLEXPORT int ios_flush(ios_t *s);
-DLLEXPORT void ios_close(ios_t *s);
-DLLEXPORT int ios_isopen(ios_t *s);
-DLLEXPORT char *ios_takebuf(ios_t *s, size_t *psize);  // release buffer to caller
+JL_DLLEXPORT size_t ios_read(ios_t *s, char *dest, size_t n);
+JL_DLLEXPORT size_t ios_readall(ios_t *s, char *dest, size_t n);
+JL_DLLEXPORT size_t ios_write(ios_t *s, const char *data, size_t n);
+JL_DLLEXPORT off_t ios_seek(ios_t *s, off_t pos);   // absolute seek
+JL_DLLEXPORT off_t ios_seek_end(ios_t *s);
+JL_DLLEXPORT off_t ios_skip(ios_t *s, off_t offs);  // relative seek
+JL_DLLEXPORT off_t ios_pos(ios_t *s);  // get current position
+JL_DLLEXPORT int ios_trunc(ios_t *s, size_t size);
+JL_DLLEXPORT int ios_eof(ios_t *s);
+JL_DLLEXPORT int ios_eof_blocking(ios_t *s);
+JL_DLLEXPORT int ios_flush(ios_t *s);
+JL_DLLEXPORT void ios_close(ios_t *s);
+JL_DLLEXPORT int ios_isopen(ios_t *s);
+JL_DLLEXPORT char *ios_takebuf(ios_t *s, size_t *psize);  // release buffer to caller
 // set buffer space to use
-DLLEXPORT int ios_setbuf(ios_t *s, char *buf, size_t size, int own);
-DLLEXPORT int ios_bufmode(ios_t *s, bufmode_t mode);
-DLLEXPORT int ios_get_readable(ios_t *s);
-DLLEXPORT int ios_get_writable(ios_t *s);
-DLLEXPORT void ios_set_readonly(ios_t *s);
-DLLEXPORT size_t ios_copy(ios_t *to, ios_t *from, size_t nbytes);
-DLLEXPORT size_t ios_copyall(ios_t *to, ios_t *from);
-DLLEXPORT size_t ios_copyuntil(ios_t *to, ios_t *from, char delim);
+JL_DLLEXPORT int ios_setbuf(ios_t *s, char *buf, size_t size, int own);
+JL_DLLEXPORT int ios_bufmode(ios_t *s, bufmode_t mode);
+JL_DLLEXPORT int ios_get_readable(ios_t *s);
+JL_DLLEXPORT int ios_get_writable(ios_t *s);
+JL_DLLEXPORT void ios_set_readonly(ios_t *s);
+JL_DLLEXPORT size_t ios_copy(ios_t *to, ios_t *from, size_t nbytes);
+JL_DLLEXPORT size_t ios_copyall(ios_t *to, ios_t *from);
+JL_DLLEXPORT size_t ios_copyuntil(ios_t *to, ios_t *from, char delim);
 // ensure at least n bytes are buffered if possible. returns # available.
-DLLEXPORT size_t ios_readprep(ios_t *from, size_t n);
+JL_DLLEXPORT size_t ios_readprep(ios_t *from, size_t n);
 
 /* stream creation */
-DLLEXPORT
+JL_DLLEXPORT
 ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc);
-DLLEXPORT ios_t *ios_mkstemp(ios_t *f, char *fname);
-DLLEXPORT ios_t *ios_mem(ios_t *s, size_t initsize);
+JL_DLLEXPORT ios_t *ios_mkstemp(ios_t *f, char *fname);
+JL_DLLEXPORT ios_t *ios_mem(ios_t *s, size_t initsize);
 ios_t *ios_str(ios_t *s, char *str);
 ios_t *ios_static_buffer(ios_t *s, char *buf, size_t sz);
-DLLEXPORT ios_t *ios_fd(ios_t *s, long fd, int isfile, int own);
+JL_DLLEXPORT ios_t *ios_fd(ios_t *s, long fd, int isfile, int own);
 // todo: ios_socket
-extern DLLEXPORT ios_t *ios_stdin;
-extern DLLEXPORT ios_t *ios_stdout;
-extern DLLEXPORT ios_t *ios_stderr;
+extern JL_DLLEXPORT ios_t *ios_stdin;
+extern JL_DLLEXPORT ios_t *ios_stdout;
+extern JL_DLLEXPORT ios_t *ios_stderr;
 void ios_init_stdstreams(void);
 
 /* high-level functions - output */
-DLLEXPORT int ios_pututf8(ios_t *s, uint32_t wc);
-DLLEXPORT int ios_printf(ios_t *s, const char *format, ...);
-DLLEXPORT int ios_vprintf(ios_t *s, const char *format, va_list args);
+JL_DLLEXPORT int ios_pututf8(ios_t *s, uint32_t wc);
+JL_DLLEXPORT int ios_printf(ios_t *s, const char *format, ...);
+JL_DLLEXPORT int ios_vprintf(ios_t *s, const char *format, va_list args);
 
 /* high-level stream functions - input */
-DLLEXPORT int ios_getutf8(ios_t *s, uint32_t *pwc);
-DLLEXPORT int ios_peekutf8(ios_t *s, uint32_t *pwc);
-DLLEXPORT char *ios_readline(ios_t *s);
+JL_DLLEXPORT int ios_getutf8(ios_t *s, uint32_t *pwc);
+JL_DLLEXPORT int ios_peekutf8(ios_t *s, uint32_t *pwc);
+JL_DLLEXPORT char *ios_readline(ios_t *s);
 
 // discard data buffered for reading
-DLLEXPORT void ios_purge(ios_t *s);
+JL_DLLEXPORT void ios_purge(ios_t *s);
 
 /* stdio-style functions */
 #define IOS_EOF (-1)
-DLLEXPORT int ios_putc(int c, ios_t *s);
+JL_DLLEXPORT int ios_putc(int c, ios_t *s);
 //wint_t ios_putwc(ios_t *s, wchar_t wc);
-DLLEXPORT int ios_getc(ios_t *s);
-DLLEXPORT int ios_peekc(ios_t *s);
+JL_DLLEXPORT int ios_getc(ios_t *s);
+JL_DLLEXPORT int ios_peekc(ios_t *s);
 //wint_t ios_getwc(ios_t *s);
 int ios_ungetc(int c, ios_t *s);
 //wint_t ios_ungetwc(ios_t *s, wint_t wc);

--- a/src/support/libsupport.h
+++ b/src/support/libsupport.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-DLLEXPORT void libsupport_init(void);
+JL_DLLEXPORT void libsupport_init(void);
 
 #ifdef __cplusplus
 }

--- a/src/support/strtod.c
+++ b/src/support/strtod.c
@@ -28,12 +28,12 @@ locale_t get_c_locale(void)
   return c_locale;
 }
 
-DLLEXPORT double jl_strtod_c(const char *nptr, char **endptr)
+JL_DLLEXPORT double jl_strtod_c(const char *nptr, char **endptr)
 {
   return strtod_l(nptr, endptr, get_c_locale());
 }
 
-DLLEXPORT float jl_strtof_c(const char *nptr, char **endptr)
+JL_DLLEXPORT float jl_strtof_c(const char *nptr, char **endptr)
 {
   return strtof_l(nptr, endptr, get_c_locale());
 }
@@ -98,7 +98,7 @@ double parse_inf_or_nan(const char *p, char **endptr)
 }
 
 
-DLLEXPORT double jl_strtod_c(const char *nptr, char **endptr)
+JL_DLLEXPORT double jl_strtod_c(const char *nptr, char **endptr)
 {
     char *fail_pos;
     double val;
@@ -285,7 +285,7 @@ DLLEXPORT double jl_strtod_c(const char *nptr, char **endptr)
 }
 
 
-DLLEXPORT float jl_strtof_c(const char *nptr, char **endptr)
+JL_DLLEXPORT float jl_strtof_c(const char *nptr, char **endptr)
 {
   return (float) jl_strtod_c(nptr, endptr);
 }

--- a/src/support/strtod.h
+++ b/src/support/strtod.h
@@ -7,12 +7,11 @@
 extern "C" {
 #endif
 
-DLLEXPORT double jl_strtod_c(const char *nptr, char **endptr);
-DLLEXPORT float jl_strtof_c(const char *nptr, char **endptr);
+JL_DLLEXPORT double jl_strtod_c(const char *nptr, char **endptr);
+JL_DLLEXPORT float jl_strtof_c(const char *nptr, char **endptr);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif
-

--- a/src/support/timefuncs.h
+++ b/src/support/timefuncs.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-DLLEXPORT double clock_now(void);
+JL_DLLEXPORT double clock_now(void);
 void sleep_ms(int ms);
 
 #ifdef __cplusplus

--- a/src/support/utf8.c
+++ b/src/support/utf8.c
@@ -21,7 +21,7 @@
 #include <wctype.h>
 
 #include "utf8proc.h"
-#undef DLLEXPORT /* avoid conflicting definition */
+#undef JL_DLLEXPORT /* avoid conflicting definition */
 
 #include "dtypes.h"
 

--- a/src/support/utf8.h
+++ b/src/support/utf8.h
@@ -22,10 +22,10 @@ size_t u8_toutf8(char *dest, size_t sz, const uint32_t *src, size_t srcsz);
 size_t u8_wc_toutf8(char *dest, uint32_t ch);
 
 /* character number to byte offset */
-DLLEXPORT size_t u8_offset(const char *str, size_t charnum);
+JL_DLLEXPORT size_t u8_offset(const char *str, size_t charnum);
 
 /* byte offset to character number */
-DLLEXPORT size_t u8_charnum(const char *str, size_t offset);
+JL_DLLEXPORT size_t u8_charnum(const char *str, size_t offset);
 
 /* return next character, updating an index variable */
 uint32_t u8_nextchar(const char *s, size_t *i);
@@ -86,7 +86,7 @@ char *u8_memchr(const char *s, uint32_t ch, size_t sz, size_t *charn);
 char *u8_memrchr(const char *s, uint32_t ch, size_t sz);
 
 /* number of columns occupied by a string */
-DLLEXPORT size_t u8_strwidth(const char *s);
+JL_DLLEXPORT size_t u8_strwidth(const char *s);
 
 /* printf where the format string and arguments may be in UTF-8.
    you can avoid this function and just use ordinary printf() if the current
@@ -95,7 +95,7 @@ size_t u8_vprintf(const char *fmt, va_list ap);
 size_t u8_printf(const char *fmt, ...);
 
 /* determine whether a sequence of bytes is valid UTF-8. length is in bytes */
-DLLEXPORT int u8_isvalid(const char *str, size_t length);
+JL_DLLEXPORT int u8_isvalid(const char *str, size_t length);
 
 #ifdef __cplusplus
 }

--- a/src/support/utils.h
+++ b/src/support/utils.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-DLLEXPORT char *uint2str(char *dest, size_t len, uint64_t num, uint32_t base);
+JL_DLLEXPORT char *uint2str(char *dest, size_t len, uint64_t num, uint32_t base);
 int str2int(char *str, size_t len, int64_t *res, uint32_t base);
 int isdigit_base(char c, int base);
 

--- a/src/sys.c
+++ b/src/sys.c
@@ -59,65 +59,65 @@ extern "C" {
 #endif
 
 #if defined(_OS_WINDOWS_) && !defined(_COMPILER_MINGW_)
-DLLEXPORT char *dirname(char *);
+JL_DLLEXPORT char *dirname(char *);
 #else
 #include <libgen.h>
 #endif
 
-DLLEXPORT uint32_t jl_getutf8(ios_t *s)
+JL_DLLEXPORT uint32_t jl_getutf8(ios_t *s)
 {
     uint32_t wc=0;
     ios_getutf8(s, &wc);
     return wc;
 }
 
-DLLEXPORT int jl_sizeof_uv_mutex(void) { return sizeof(uv_mutex_t); }
-DLLEXPORT int jl_sizeof_off_t(void) { return sizeof(off_t); }
+JL_DLLEXPORT int jl_sizeof_uv_mutex(void) { return sizeof(uv_mutex_t); }
+JL_DLLEXPORT int jl_sizeof_off_t(void) { return sizeof(off_t); }
 #ifndef _OS_WINDOWS_
-DLLEXPORT off_t jl_lseek(int fd, off_t offset, int whence) { return lseek(fd, offset, whence); }
-DLLEXPORT ssize_t jl_pwrite(int fd, const void *buf, size_t count, off_t offset)
+JL_DLLEXPORT off_t jl_lseek(int fd, off_t offset, int whence) { return lseek(fd, offset, whence); }
+JL_DLLEXPORT ssize_t jl_pwrite(int fd, const void *buf, size_t count, off_t offset)
 {
     return pwrite(fd, buf, count, offset);
 }
-DLLEXPORT void *jl_mmap(void *addr, size_t length, int prot, int flags,
+JL_DLLEXPORT void *jl_mmap(void *addr, size_t length, int prot, int flags,
                         int fd, off_t offset)
 {
     return mmap(addr, length, prot, flags, fd, offset);
 }
 #else
-DLLEXPORT off_t jl_lseek(int fd, off_t offset, int whence) { return _lseek(fd, offset, whence); }
+JL_DLLEXPORT off_t jl_lseek(int fd, off_t offset, int whence) { return _lseek(fd, offset, whence); }
 #endif
-DLLEXPORT int jl_sizeof_ios_t(void) { return sizeof(ios_t); }
+JL_DLLEXPORT int jl_sizeof_ios_t(void) { return sizeof(ios_t); }
 
-DLLEXPORT long jl_ios_fd(ios_t *s) { return s->fd; }
+JL_DLLEXPORT long jl_ios_fd(ios_t *s) { return s->fd; }
 
-DLLEXPORT int32_t jl_nb_available(ios_t *s)
+JL_DLLEXPORT int32_t jl_nb_available(ios_t *s)
 {
     return (int32_t)(s->size - s->bpos);
 }
 
 // --- dir/file stuff ---
 
-DLLEXPORT int jl_sizeof_uv_fs_t(void) { return sizeof(uv_fs_t); }
-DLLEXPORT void jl_uv_fs_req_cleanup(uv_fs_t *req)
+JL_DLLEXPORT int jl_sizeof_uv_fs_t(void) { return sizeof(uv_fs_t); }
+JL_DLLEXPORT void jl_uv_fs_req_cleanup(uv_fs_t *req)
 {
     uv_fs_req_cleanup(req);
 }
 
-DLLEXPORT int jl_readdir(const char *path, uv_fs_t *readdir_req)
+JL_DLLEXPORT int jl_readdir(const char *path, uv_fs_t *readdir_req)
 {
     // Note that the flags field is mostly ignored by libuv
     return uv_fs_readdir(uv_default_loop(), readdir_req, path, 0 /*flags*/, NULL);
 }
 
-DLLEXPORT char *jl_uv_fs_t_ptr(uv_fs_t *req) { return (char*)req->ptr; }
-DLLEXPORT char *jl_uv_fs_t_ptr_offset(uv_fs_t *req, int offset) { return (char*)req->ptr + offset; }
-DLLEXPORT int jl_uv_fs_result(uv_fs_t *f) { return f->result; }
+JL_DLLEXPORT char *jl_uv_fs_t_ptr(uv_fs_t *req) { return (char*)req->ptr; }
+JL_DLLEXPORT char *jl_uv_fs_t_ptr_offset(uv_fs_t *req, int offset) { return (char*)req->ptr + offset; }
+JL_DLLEXPORT int jl_uv_fs_result(uv_fs_t *f) { return f->result; }
 
 // --- stat ---
-DLLEXPORT int jl_sizeof_stat(void) { return sizeof(uv_stat_t); }
+JL_DLLEXPORT int jl_sizeof_stat(void) { return sizeof(uv_stat_t); }
 
-DLLEXPORT int32_t jl_stat(const char *path, char *statbuf)
+JL_DLLEXPORT int32_t jl_stat(const char *path, char *statbuf)
 {
     uv_fs_t req;
     int ret;
@@ -131,7 +131,7 @@ DLLEXPORT int32_t jl_stat(const char *path, char *statbuf)
     return ret;
 }
 
-DLLEXPORT int32_t jl_lstat(const char *path, char *statbuf)
+JL_DLLEXPORT int32_t jl_lstat(const char *path, char *statbuf)
 {
     uv_fs_t req;
     int ret;
@@ -143,7 +143,7 @@ DLLEXPORT int32_t jl_lstat(const char *path, char *statbuf)
     return ret;
 }
 
-DLLEXPORT int32_t jl_fstat(int fd, char *statbuf)
+JL_DLLEXPORT int32_t jl_fstat(int fd, char *statbuf)
 {
     uv_fs_t req;
     int ret;
@@ -155,59 +155,59 @@ DLLEXPORT int32_t jl_fstat(int fd, char *statbuf)
     return ret;
 }
 
-DLLEXPORT unsigned int jl_stat_dev(char *statbuf)
+JL_DLLEXPORT unsigned int jl_stat_dev(char *statbuf)
 {
     return ((uv_stat_t*)statbuf)->st_dev;
 }
 
-DLLEXPORT unsigned int jl_stat_ino(char *statbuf)
+JL_DLLEXPORT unsigned int jl_stat_ino(char *statbuf)
 {
     return ((uv_stat_t*)statbuf)->st_ino;
 }
 
-DLLEXPORT unsigned int jl_stat_mode(char *statbuf)
+JL_DLLEXPORT unsigned int jl_stat_mode(char *statbuf)
 {
     return ((uv_stat_t*)statbuf)->st_mode;
 }
 
-DLLEXPORT unsigned int jl_stat_nlink(char *statbuf)
+JL_DLLEXPORT unsigned int jl_stat_nlink(char *statbuf)
 {
     return ((uv_stat_t*)statbuf)->st_nlink;
 }
 
-DLLEXPORT unsigned int jl_stat_uid(char *statbuf)
+JL_DLLEXPORT unsigned int jl_stat_uid(char *statbuf)
 {
     return ((uv_stat_t*)statbuf)->st_uid;
 }
 
-DLLEXPORT unsigned int jl_stat_gid(char *statbuf)
+JL_DLLEXPORT unsigned int jl_stat_gid(char *statbuf)
 {
     return ((uv_stat_t*)statbuf)->st_gid;
 }
 
-DLLEXPORT unsigned int jl_stat_rdev(char *statbuf)
+JL_DLLEXPORT unsigned int jl_stat_rdev(char *statbuf)
 {
     return ((uv_stat_t*)statbuf)->st_rdev;
 }
 
-DLLEXPORT uint64_t jl_stat_size(char *statbuf)
+JL_DLLEXPORT uint64_t jl_stat_size(char *statbuf)
 {
     return ((uv_stat_t*)statbuf)->st_size;
 }
 
-DLLEXPORT uint64_t jl_stat_blksize(char *statbuf)
+JL_DLLEXPORT uint64_t jl_stat_blksize(char *statbuf)
 {
     return ((uv_stat_t*)statbuf)->st_blksize;
 }
 
-DLLEXPORT uint64_t jl_stat_blocks(char *statbuf)
+JL_DLLEXPORT uint64_t jl_stat_blocks(char *statbuf)
 {
     return ((uv_stat_t*)statbuf)->st_blocks;
 }
 
 /*
 // atime is stupid, let's not support it
-DLLEXPORT double jl_stat_atime(char *statbuf)
+JL_DLLEXPORT double jl_stat_atime(char *statbuf)
 {
   uv_stat_t *s;
   s = (uv_stat_t*)statbuf;
@@ -215,14 +215,14 @@ DLLEXPORT double jl_stat_atime(char *statbuf)
 }
 */
 
-DLLEXPORT double jl_stat_mtime(char *statbuf)
+JL_DLLEXPORT double jl_stat_mtime(char *statbuf)
 {
     uv_stat_t *s;
     s = (uv_stat_t*)statbuf;
     return (double)s->st_mtim.tv_sec + (double)s->st_mtim.tv_nsec * 1e-9;
 }
 
-DLLEXPORT double jl_stat_ctime(char *statbuf)
+JL_DLLEXPORT double jl_stat_ctime(char *statbuf)
 {
     uv_stat_t *s;
     s = (uv_stat_t*)statbuf;
@@ -231,7 +231,7 @@ DLLEXPORT double jl_stat_ctime(char *statbuf)
 
 // --- buffer manipulation ---
 
-DLLEXPORT jl_array_t *jl_takebuf_array(ios_t *s)
+JL_DLLEXPORT jl_array_t *jl_takebuf_array(ios_t *s)
 {
     size_t n;
     jl_array_t *a;
@@ -248,7 +248,7 @@ DLLEXPORT jl_array_t *jl_takebuf_array(ios_t *s)
     return a;
 }
 
-DLLEXPORT jl_value_t *jl_takebuf_string(ios_t *s)
+JL_DLLEXPORT jl_value_t *jl_takebuf_string(ios_t *s)
 {
     jl_array_t *a = jl_takebuf_array(s);
     JL_GC_PUSH1(&a);
@@ -259,14 +259,14 @@ DLLEXPORT jl_value_t *jl_takebuf_string(ios_t *s)
 
 // the returned buffer must be manually freed. To determine the size,
 // call position(s) before using this function.
-DLLEXPORT void *jl_takebuf_raw(ios_t *s)
+JL_DLLEXPORT void *jl_takebuf_raw(ios_t *s)
 {
     size_t sz;
     void *buf = ios_takebuf(s, &sz);
     return buf;
 }
 
-DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim)
+JL_DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim)
 {
     jl_array_t *a;
     // manually inlined common case
@@ -297,14 +297,14 @@ DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim)
     return (jl_value_t*)a;
 }
 
-static void NORETURN throw_eof_error(void)
+static void JL_NORETURN throw_eof_error(void)
 {
     jl_datatype_t *eof_error = (jl_datatype_t*)jl_get_global(jl_base_module, jl_symbol("EOFError"));
     assert(eof_error != NULL);
     jl_exceptionf(eof_error, "");
 }
 
-DLLEXPORT uint64_t jl_ios_get_nbyte_int(ios_t *s, const size_t n)
+JL_DLLEXPORT uint64_t jl_ios_get_nbyte_int(ios_t *s, const size_t n)
 {
     assert(n <= 8);
     size_t space, ret;
@@ -338,8 +338,8 @@ DLLEXPORT uint64_t jl_ios_get_nbyte_int(ios_t *s, const size_t n)
 
 // -- syscall utilities --
 
-DLLEXPORT int jl_errno(void) { return errno; }
-DLLEXPORT void jl_set_errno(int e) { errno = e; }
+JL_DLLEXPORT int jl_errno(void) { return errno; }
+JL_DLLEXPORT void jl_set_errno(int e) { errno = e; }
 
 // -- get the number of CPU cores --
 
@@ -350,7 +350,7 @@ typedef DWORD (WINAPI *GAPC)(WORD);
 #endif
 #endif
 
-DLLEXPORT int jl_cpu_cores(void)
+JL_DLLEXPORT int jl_cpu_cores(void)
 {
 #if defined(HW_AVAILCPU) && defined(HW_NCPU)
     size_t len = 4;
@@ -387,7 +387,7 @@ DLLEXPORT int jl_cpu_cores(void)
 
 // -- high resolution timers --
 // Returns time in nanosec
-DLLEXPORT uint64_t jl_hrtime(void)
+JL_DLLEXPORT uint64_t jl_hrtime(void)
 {
     return uv_hrtime();
 }
@@ -402,7 +402,7 @@ extern char **environ;
 #endif
 #endif
 
-DLLEXPORT jl_value_t *jl_environ(int i)
+JL_DLLEXPORT jl_value_t *jl_environ(int i)
 {
 #ifdef __APPLE__
     char **environ = *_NSGetEnviron();
@@ -441,14 +441,14 @@ JL_STREAM *JL_STDIN  = (JL_STREAM*)STDIN_FILENO;
 JL_STREAM *JL_STDOUT = (JL_STREAM*)STDOUT_FILENO;
 JL_STREAM *JL_STDERR = (JL_STREAM*)STDERR_FILENO;
 
-DLLEXPORT JL_STREAM *jl_stdin_stream(void)  { return JL_STDIN; }
-DLLEXPORT JL_STREAM *jl_stdout_stream(void) { return JL_STDOUT; }
-DLLEXPORT JL_STREAM *jl_stderr_stream(void) { return JL_STDERR; }
+JL_DLLEXPORT JL_STREAM *jl_stdin_stream(void)  { return JL_STDIN; }
+JL_DLLEXPORT JL_STREAM *jl_stdout_stream(void) { return JL_STDOUT; }
+JL_DLLEXPORT JL_STREAM *jl_stderr_stream(void) { return JL_STDERR; }
 
 // CPUID
 
 #ifdef HAVE_CPUID
-DLLEXPORT void jl_cpuid(int32_t CPUInfo[4], int32_t InfoType)
+JL_DLLEXPORT void jl_cpuid(int32_t CPUInfo[4], int32_t InfoType)
 {
 #if defined _MSC_VER
     __cpuid(CPUInfo, InfoType);
@@ -506,14 +506,14 @@ static int32_t get_subnormal_flags(void)
 }
 
 // Returns non-zero if subnormals go to 0; zero otherwise.
-DLLEXPORT int32_t jl_get_zero_subnormals(int8_t isZero)
+JL_DLLEXPORT int32_t jl_get_zero_subnormals(int8_t isZero)
 {
     uint32_t flags = get_subnormal_flags();
     return _mm_getcsr() & flags;
 }
 
 // Return zero on success, non-zero on failure.
-DLLEXPORT int32_t jl_set_zero_subnormals(int8_t isZero)
+JL_DLLEXPORT int32_t jl_set_zero_subnormals(int8_t isZero)
 {
     uint32_t flags = get_subnormal_flags();
     if (flags) {
@@ -533,12 +533,12 @@ DLLEXPORT int32_t jl_set_zero_subnormals(int8_t isZero)
 
 #else
 
-DLLEXPORT int32_t jl_get_zero_subnormals(int8_t isZero)
+JL_DLLEXPORT int32_t jl_get_zero_subnormals(int8_t isZero)
 {
     return 0;
 }
 
-DLLEXPORT int32_t jl_set_zero_subnormals(int8_t isZero)
+JL_DLLEXPORT int32_t jl_set_zero_subnormals(int8_t isZero)
 {
     return isZero;
 }
@@ -547,7 +547,7 @@ DLLEXPORT int32_t jl_set_zero_subnormals(int8_t isZero)
 
 // -- processor native alignment information --
 
-DLLEXPORT void jl_native_alignment(uint_t *int8align, uint_t *int16align, uint_t *int32align,
+JL_DLLEXPORT void jl_native_alignment(uint_t *int8align, uint_t *int16align, uint_t *int32align,
                                    uint_t *int64align, uint_t *float32align, uint_t *float64align)
 {
     *int8align = __alignof(uint8_t);
@@ -558,12 +558,12 @@ DLLEXPORT void jl_native_alignment(uint_t *int8align, uint_t *int16align, uint_t
     *float64align = __alignof(double);
 }
 
-DLLEXPORT jl_value_t *jl_is_char_signed(void)
+JL_DLLEXPORT jl_value_t *jl_is_char_signed(void)
 {
     return ((char)255) < 0 ? jl_true : jl_false;
 }
 
-DLLEXPORT void jl_field_offsets(jl_datatype_t *dt, ssize_t *offsets)
+JL_DLLEXPORT void jl_field_offsets(jl_datatype_t *dt, ssize_t *offsets)
 {
     size_t i;
     for(i=0; i < jl_datatype_nfields(dt); i++) {
@@ -575,7 +575,7 @@ DLLEXPORT void jl_field_offsets(jl_datatype_t *dt, ssize_t *offsets)
 
 #ifdef _OS_WINDOWS_
 static long cachedPagesize = 0;
-DLLEXPORT long jl_getpagesize(void)
+JL_DLLEXPORT long jl_getpagesize(void)
 {
     if (!cachedPagesize) {
         SYSTEM_INFO systemInfo;
@@ -585,7 +585,7 @@ DLLEXPORT long jl_getpagesize(void)
     return cachedPagesize;
 }
 #else
-DLLEXPORT long jl_getpagesize(void)
+JL_DLLEXPORT long jl_getpagesize(void)
 {
     return sysconf(_SC_PAGESIZE);
 }
@@ -593,7 +593,7 @@ DLLEXPORT long jl_getpagesize(void)
 
 #ifdef _OS_WINDOWS_
 static long cachedAllocationGranularity = 0;
-DLLEXPORT long jl_getallocationgranularity(void)
+JL_DLLEXPORT long jl_getallocationgranularity(void)
 {
     if (!cachedAllocationGranularity) {
         SYSTEM_INFO systemInfo;
@@ -603,13 +603,13 @@ DLLEXPORT long jl_getallocationgranularity(void)
     return cachedAllocationGranularity;
 }
 #else
-DLLEXPORT long jl_getallocationgranularity(void)
+JL_DLLEXPORT long jl_getallocationgranularity(void)
 {
     return jl_getpagesize();
 }
 #endif
 
-DLLEXPORT long jl_SC_CLK_TCK(void)
+JL_DLLEXPORT long jl_SC_CLK_TCK(void)
 {
 #ifndef _OS_WINDOWS_
     return sysconf(_SC_CLK_TCK);
@@ -618,20 +618,20 @@ DLLEXPORT long jl_SC_CLK_TCK(void)
 #endif
 }
 
-DLLEXPORT size_t jl_get_field_offset(jl_datatype_t *ty, int field)
+JL_DLLEXPORT size_t jl_get_field_offset(jl_datatype_t *ty, int field)
 {
     if (field > jl_datatype_nfields(ty))
         jl_error("This type does not have that many fields");
     return jl_field_offset(ty, field);
 }
 
-DLLEXPORT size_t jl_get_alignment(jl_datatype_t *ty)
+JL_DLLEXPORT size_t jl_get_alignment(jl_datatype_t *ty)
 {
     return ty->alignment;
 }
 
 // Takes a handle (as returned from dlopen()) and returns the absolute path to the image loaded
-DLLEXPORT const char *jl_pathname_for_handle(void *handle)
+JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle)
 {
     if (!handle)
         return NULL;
@@ -708,13 +708,13 @@ static BOOL CALLBACK jl_EnumerateLoadedModulesProc64(
     return TRUE;
 }
 // Takes a handle (as returned from dlopen()) and returns the absolute path to the image loaded
-DLLEXPORT int jl_dllist(jl_array_t *list)
+JL_DLLEXPORT int jl_dllist(jl_array_t *list)
 {
     return EnumerateLoadedModules64(GetCurrentProcess(), jl_EnumerateLoadedModulesProc64, list);
 }
 #endif
 
-DLLEXPORT void jl_raise_debugger(void)
+JL_DLLEXPORT void jl_raise_debugger(void)
 {
 #if defined(_OS_WINDOWS_)
     if (IsDebuggerPresent() == 1)
@@ -724,7 +724,7 @@ DLLEXPORT void jl_raise_debugger(void)
 #endif // _OS_WINDOWS_
 }
 
-DLLEXPORT jl_sym_t* jl_get_OS_NAME(void)
+JL_DLLEXPORT jl_sym_t* jl_get_OS_NAME(void)
 {
 #if defined(_OS_WINDOWS_)
     return jl_symbol("Windows");
@@ -740,7 +740,7 @@ DLLEXPORT jl_sym_t* jl_get_OS_NAME(void)
 #endif
 }
 
-DLLEXPORT jl_sym_t* jl_get_ARCH(void)
+JL_DLLEXPORT jl_sym_t* jl_get_ARCH(void)
 {
     static jl_sym_t* ARCH = NULL;
     if (!ARCH)
@@ -748,7 +748,7 @@ DLLEXPORT jl_sym_t* jl_get_ARCH(void)
     return ARCH;
 }
 
-DLLEXPORT size_t jl_maxrss(void)
+JL_DLLEXPORT size_t jl_maxrss(void)
 {
 #if defined(_OS_WINDOWS_)
 	PROCESS_MEMORY_COUNTERS counter;

--- a/src/sys.c
+++ b/src/sys.c
@@ -231,7 +231,7 @@ DLLEXPORT double jl_stat_ctime(char *statbuf)
 
 // --- buffer manipulation ---
 
-jl_array_t *jl_takebuf_array(ios_t *s)
+DLLEXPORT jl_array_t *jl_takebuf_array(ios_t *s)
 {
     size_t n;
     jl_array_t *a;
@@ -248,7 +248,7 @@ jl_array_t *jl_takebuf_array(ios_t *s)
     return a;
 }
 
-jl_value_t *jl_takebuf_string(ios_t *s)
+DLLEXPORT jl_value_t *jl_takebuf_string(ios_t *s)
 {
     jl_array_t *a = jl_takebuf_array(s);
     JL_GC_PUSH1(&a);
@@ -259,14 +259,14 @@ jl_value_t *jl_takebuf_string(ios_t *s)
 
 // the returned buffer must be manually freed. To determine the size,
 // call position(s) before using this function.
-void *jl_takebuf_raw(ios_t *s)
+DLLEXPORT void *jl_takebuf_raw(ios_t *s)
 {
     size_t sz;
     void *buf = ios_takebuf(s, &sz);
     return buf;
 }
 
-jl_value_t *jl_readuntil(ios_t *s, uint8_t delim)
+DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim)
 {
     jl_array_t *a;
     // manually inlined common case
@@ -338,8 +338,8 @@ DLLEXPORT uint64_t jl_ios_get_nbyte_int(ios_t *s, const size_t n)
 
 // -- syscall utilities --
 
-int jl_errno(void) { return errno; }
-void jl_set_errno(int e) { errno = e; }
+DLLEXPORT int jl_errno(void) { return errno; }
+DLLEXPORT void jl_set_errno(int e) { errno = e; }
 
 // -- get the number of CPU cores --
 
@@ -402,7 +402,7 @@ extern char **environ;
 #endif
 #endif
 
-jl_value_t *jl_environ(int i)
+DLLEXPORT jl_value_t *jl_environ(int i)
 {
 #ifdef __APPLE__
     char **environ = *_NSGetEnviron();
@@ -441,9 +441,9 @@ JL_STREAM *JL_STDIN  = (JL_STREAM*)STDIN_FILENO;
 JL_STREAM *JL_STDOUT = (JL_STREAM*)STDOUT_FILENO;
 JL_STREAM *JL_STDERR = (JL_STREAM*)STDERR_FILENO;
 
-JL_STREAM *jl_stdin_stream(void)  { return JL_STDIN; }
-JL_STREAM *jl_stdout_stream(void) { return JL_STDOUT; }
-JL_STREAM *jl_stderr_stream(void) { return JL_STDERR; }
+DLLEXPORT JL_STREAM *jl_stdin_stream(void)  { return JL_STDIN; }
+DLLEXPORT JL_STREAM *jl_stdout_stream(void) { return JL_STDOUT; }
+DLLEXPORT JL_STREAM *jl_stderr_stream(void) { return JL_STDERR; }
 
 // CPUID
 
@@ -575,7 +575,7 @@ DLLEXPORT void jl_field_offsets(jl_datatype_t *dt, ssize_t *offsets)
 
 #ifdef _OS_WINDOWS_
 static long cachedPagesize = 0;
-long jl_getpagesize(void)
+DLLEXPORT long jl_getpagesize(void)
 {
     if (!cachedPagesize) {
         SYSTEM_INFO systemInfo;
@@ -585,7 +585,7 @@ long jl_getpagesize(void)
     return cachedPagesize;
 }
 #else
-long jl_getpagesize(void)
+DLLEXPORT long jl_getpagesize(void)
 {
     return sysconf(_SC_PAGESIZE);
 }
@@ -593,7 +593,7 @@ long jl_getpagesize(void)
 
 #ifdef _OS_WINDOWS_
 static long cachedAllocationGranularity = 0;
-long jl_getallocationgranularity(void)
+DLLEXPORT long jl_getallocationgranularity(void)
 {
     if (!cachedAllocationGranularity) {
         SYSTEM_INFO systemInfo;
@@ -603,7 +603,7 @@ long jl_getallocationgranularity(void)
     return cachedAllocationGranularity;
 }
 #else
-long jl_getallocationgranularity(void)
+DLLEXPORT long jl_getallocationgranularity(void)
 {
     return jl_getpagesize();
 }

--- a/src/table.c
+++ b/src/table.c
@@ -113,7 +113,7 @@ static void **jl_table_peek_bp(jl_array_t *a, void *key)
     return NULL;
 }
 
-DLLEXPORT
+JL_DLLEXPORT
 jl_array_t *jl_eqtable_put(jl_array_t *h, void *key, void *val)
 {
     void **bp = jl_table_lookup_bp(&h, key);
@@ -122,7 +122,7 @@ jl_array_t *jl_eqtable_put(jl_array_t *h, void *key, void *val)
     return h;
 }
 
-DLLEXPORT
+JL_DLLEXPORT
 jl_value_t *jl_eqtable_get(jl_array_t *h, void *key, jl_value_t *deflt)
 {
     void **bp = jl_table_peek_bp(h, key);
@@ -131,7 +131,7 @@ jl_value_t *jl_eqtable_get(jl_array_t *h, void *key, jl_value_t *deflt)
     return (jl_value_t*)*bp;
 }
 
-DLLEXPORT
+JL_DLLEXPORT
 jl_value_t *jl_eqtable_pop(jl_array_t *h, void *key, jl_value_t *deflt)
 {
     void **bp = jl_table_peek_bp(h, key);
@@ -143,7 +143,7 @@ jl_value_t *jl_eqtable_pop(jl_array_t *h, void *key, jl_value_t *deflt)
     return val;
 }
 
-DLLEXPORT
+JL_DLLEXPORT
 size_t jl_eqtable_nextind(jl_array_t *t, size_t i)
 {
     if (i&1) i++;

--- a/src/threading.c
+++ b/src/threading.c
@@ -87,11 +87,11 @@ static jl_tls_states_t *jl_get_ptls_states_init(void)
     jl_tls_states_cb = jl_get_ptls_states_fallback;
     return jl_get_ptls_states_fallback();
 }
-DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void)
+JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void)
 {
     return (*jl_tls_states_cb)();
 }
-DLLEXPORT void jl_set_ptls_states_getter(jl_get_ptls_states_func f)
+JL_DLLEXPORT void jl_set_ptls_states_getter(jl_get_ptls_states_func f)
 {
     // only allow setting this once
     if (f && f != jl_get_ptls_states_init &&
@@ -107,21 +107,21 @@ jl_get_ptls_states_func jl_get_ptls_states_getter(void)
     return jl_tls_states_cb;
 }
 #else
-DLLEXPORT jl_tls_states_t jl_tls_states;
-DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void)
+JL_DLLEXPORT jl_tls_states_t jl_tls_states;
+JL_DLLEXPORT JL_CONST_FUNC jl_tls_states_t *(jl_get_ptls_states)(void)
 {
     return &jl_tls_states;
 }
 #endif
 
 // thread ID
-DLLEXPORT int jl_n_threads;     // # threads we're actually using
-DLLEXPORT int jl_max_threads;   // # threads possible
+JL_DLLEXPORT int jl_n_threads;     // # threads we're actually using
+JL_DLLEXPORT int jl_max_threads;   // # threads possible
 jl_thread_task_state_t *jl_all_task_states;
 jl_gcframe_t ***jl_all_pgcstacks;
 
 // return calling thread's ID
-DLLEXPORT int16_t jl_threadid(void) { return ti_tid; }
+JL_DLLEXPORT int16_t jl_threadid(void) { return ti_tid; }
 
 struct _jl_thread_heap_t *jl_mk_thread_heap(void);
 // must be called by each thread at startup
@@ -388,14 +388,14 @@ void jl_shutdown_threading(void)
 }
 
 // return thread's thread group
-DLLEXPORT void *jl_threadgroup(void) { return (void *)tgworld; }
+JL_DLLEXPORT void *jl_threadgroup(void) { return (void *)tgworld; }
 
 // utility
-DLLEXPORT void jl_cpu_pause(void) { cpu_pause(); }
+JL_DLLEXPORT void jl_cpu_pause(void) { cpu_pause(); }
 
 // interface to user code: specialize and compile the user thread function
 // and run it in all threads
-DLLEXPORT jl_value_t *jl_threading_run(jl_function_t *f, jl_svec_t *args)
+JL_DLLEXPORT jl_value_t *jl_threading_run(jl_function_t *f, jl_svec_t *args)
 {
 #if PROFILE_JL_THREADING
     uint64_t tstart = rdtsc();
@@ -485,7 +485,7 @@ void ti_timings(uint64_t *times, uint64_t *min, uint64_t *max, uint64_t *avg)
 
 #define TICKS_TO_SECS(t)        (((double)(t)) / (cpu_ghz * 1e9))
 
-DLLEXPORT void jl_threading_profile(void)
+JL_DLLEXPORT void jl_threading_profile(void)
 {
     if (!fork_ticks) return;
 
@@ -506,7 +506,7 @@ DLLEXPORT void jl_threading_profile(void)
 
 #else //!PROFILE_JL_THREADING
 
-DLLEXPORT void jl_threading_profile(void)
+JL_DLLEXPORT void jl_threading_profile(void)
 {
 }
 
@@ -514,7 +514,7 @@ DLLEXPORT void jl_threading_profile(void)
 
 #else // !JULIA_ENABLE_THREADING
 
-DLLEXPORT jl_value_t *jl_threading_run(jl_function_t *f, jl_svec_t *args)
+JL_DLLEXPORT jl_value_t *jl_threading_run(jl_function_t *f, jl_svec_t *args)
 {
     if ((jl_value_t*)args == jl_emptytuple)
         args = jl_emptysvec;

--- a/src/threading.c
+++ b/src/threading.c
@@ -388,10 +388,10 @@ void jl_shutdown_threading(void)
 }
 
 // return thread's thread group
-void *jl_threadgroup(void) { return (void *)tgworld; }
+DLLEXPORT void *jl_threadgroup(void) { return (void *)tgworld; }
 
 // utility
-void jl_cpu_pause(void) { cpu_pause(); }
+DLLEXPORT void jl_cpu_pause(void) { cpu_pause(); }
 
 // interface to user code: specialize and compile the user thread function
 // and run it in all threads
@@ -485,7 +485,7 @@ void ti_timings(uint64_t *times, uint64_t *min, uint64_t *max, uint64_t *avg)
 
 #define TICKS_TO_SECS(t)        (((double)(t)) / (cpu_ghz * 1e9))
 
-void jl_threading_profile(void)
+DLLEXPORT void jl_threading_profile(void)
 {
     if (!fork_ticks) return;
 
@@ -506,7 +506,7 @@ void jl_threading_profile(void)
 
 #else //!PROFILE_JL_THREADING
 
-void jl_threading_profile(void)
+DLLEXPORT void jl_threading_profile(void)
 {
 }
 

--- a/src/threading.h
+++ b/src/threading.h
@@ -16,7 +16,7 @@ extern "C" {
 // thread ID
 #define ti_tid (jl_get_ptls_states()->tid)
 extern jl_thread_task_state_t *jl_all_task_states;
-extern DLLEXPORT int jl_n_threads;  // # threads we're actually using
+extern JL_DLLEXPORT int jl_n_threads;  // # threads we're actually using
 
 #ifdef JULIA_ENABLE_THREADING
 // GC

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -35,7 +35,7 @@ jl_module_t *jl_internal_main_module = NULL;
 
 jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast);
 
-void jl_add_standard_imports(jl_module_t *m)
+DLLEXPORT void jl_add_standard_imports(jl_module_t *m)
 {
     assert(jl_base_module != NULL);
     // using Base
@@ -45,7 +45,7 @@ void jl_add_standard_imports(jl_module_t *m)
     m->std_imports = 1;
 }
 
-jl_module_t *jl_new_main_module(void)
+DLLEXPORT jl_module_t *jl_new_main_module(void)
 {
     if (jl_generating_output() && jl_options.incremental)
         jl_error("cannot call workspace() in incremental compile mode");
@@ -549,7 +549,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast)
     return result;
 }
 
-jl_value_t *jl_toplevel_eval(jl_value_t *v)
+DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v)
 {
     return jl_toplevel_eval_flex(v, 1);
 }
@@ -602,7 +602,7 @@ jl_value_t *jl_parse_eval_all(const char *fname, size_t len)
     return result;
 }
 
-jl_value_t *jl_load(const char *fname, size_t len)
+DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len)
 {
     if (jl_current_module->istopmod) {
         jl_printf(JL_STDOUT, "%s\r\n", fname);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -25,9 +25,9 @@ extern "C" {
 #endif
 
 // current line number in a file
-DLLEXPORT int jl_lineno = 0;
+JL_DLLEXPORT int jl_lineno = 0;
 // current file name
-DLLEXPORT const char *jl_filename = "no file";
+JL_DLLEXPORT const char *jl_filename = "no file";
 
 jl_module_t *jl_old_base_module = NULL;
 // the Main we started with, in case it is switched
@@ -35,7 +35,7 @@ jl_module_t *jl_internal_main_module = NULL;
 
 jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast);
 
-DLLEXPORT void jl_add_standard_imports(jl_module_t *m)
+JL_DLLEXPORT void jl_add_standard_imports(jl_module_t *m)
 {
     assert(jl_base_module != NULL);
     // using Base
@@ -45,7 +45,7 @@ DLLEXPORT void jl_add_standard_imports(jl_module_t *m)
     m->std_imports = 1;
 }
 
-DLLEXPORT jl_module_t *jl_new_main_module(void)
+JL_DLLEXPORT jl_module_t *jl_new_main_module(void)
 {
     if (jl_generating_output() && jl_options.incremental)
         jl_error("cannot call workspace() in incremental compile mode");
@@ -228,7 +228,7 @@ jl_value_t *jl_eval_module_expr(jl_expr_t *ex)
 // this is only needed because of the bootstrapping process:
 // - initially Base doesn't exist and top === Core
 // - later, it refers to either old Base or new Base
-DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m)
+JL_DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m)
 {
     while (m != m->parent) {
         if (m->istopmod)
@@ -549,7 +549,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_value_t *e, int fast)
     return result;
 }
 
-DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v)
+JL_DLLEXPORT jl_value_t *jl_toplevel_eval(jl_value_t *v)
 {
     return jl_toplevel_eval_flex(v, 1);
 }
@@ -602,7 +602,7 @@ jl_value_t *jl_parse_eval_all(const char *fname, size_t len)
     return result;
 }
 
-DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len)
+JL_DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len)
 {
     if (jl_current_module->istopmod) {
         jl_printf(JL_STDOUT, "%s\r\n", fname);
@@ -624,7 +624,7 @@ DLLEXPORT jl_value_t *jl_load(const char *fname, size_t len)
 }
 
 // load from filename given as a ByteString object
-DLLEXPORT jl_value_t *jl_load_(jl_value_t *str)
+JL_DLLEXPORT jl_value_t *jl_load_(jl_value_t *str)
 {
     return jl_load(jl_string_data(str), jl_string_len(str));
 }
@@ -683,8 +683,9 @@ void print_func_loc(JL_STREAM *s, jl_lambda_info_t *li);
 
 // empty generic function def
 // TODO: maybe have jl_method_def call this
-DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name, jl_value_t **bp, jl_value_t *bp_owner,
-                                              jl_binding_t *bnd)
+JL_DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name, jl_value_t **bp,
+                                                 jl_value_t *bp_owner,
+                                                 jl_binding_t *bnd)
 {
     jl_value_t *gf=NULL;
 
@@ -708,10 +709,11 @@ DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name, jl_value_t **bp, j
     return gf;
 }
 
-DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp, jl_value_t *bp_owner,
-                                    jl_binding_t *bnd,
-                                    jl_svec_t *argdata, jl_function_t *f, jl_value_t *isstaged,
-                                    jl_value_t *call_func, int iskw)
+JL_DLLEXPORT jl_value_t *jl_method_def(jl_sym_t *name, jl_value_t **bp,
+                                       jl_value_t *bp_owner, jl_binding_t *bnd,
+                                       jl_svec_t *argdata, jl_function_t *f,
+                                       jl_value_t *isstaged,
+                                       jl_value_t *call_func, int iskw)
 {
     jl_module_t *module = (bnd ? bnd->owner : NULL);
     // argdata is svec({types...}, svec(typevars...))


### PR DESCRIPTION
While working on https://github.com/JuliaLang/julia/pull/14190 I need to know if a function is `DLLEXPORT`'ed when looking at the function definition (functions that will not be called from arbitrary places can have a relaxed requirement on the GC state convention). This PR sync all the `DLLEXPORT` attribute also to the function definition so it is easier to reason about where can the function be called without jumping between files.

This also removes non `DLLEXPORT`'ed functions and the declarations of removed functions from `julia.h`.
