### PR TITLE
Don't declare something a long and pass it as a size_t

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -845,7 +845,7 @@ static jl_value_t *jl_type_intersect(jl_value_t *a, jl_value_t *b,
                 if (eqc->data[i] == lenvar) {
                     jl_value_t *v = eqc->data[i+1];
                     // N is already known in NTuple{N,...}
-                    if (jl_get_size(v, (size_t *)&alen)) break;
+                    if (jl_get_size(v, &alen)) break;
                 }
             }
             b = (jl_value_t*)jl_tupletype_fill(alen, elty);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -833,7 +833,7 @@ static jl_value_t *jl_type_intersect(jl_value_t *a, jl_value_t *b,
     if (b == (jl_value_t*)jl_any_type || b == jl_ANY_flag) return a;
     // tuple
     if (jl_is_tuple_type(a)) {
-        long alen = (long)jl_nparams(a);
+        size_t alen = jl_nparams(a);
         jl_value_t *temp=NULL;
         JL_GC_PUSH2(&b, &temp);
         if (jl_is_ntuple_type(b)) {


### PR DESCRIPTION
The two are not the same on Win64, causing type intersection to sometimes return incorrect answers (not fun!).

@JeffBezanson was there a specific reason you made this a long?
