### PR TITLE
Don't use shared pkg .cache directory any more on Windows

### DIFF
--- a/base/pkg/cache.jl
+++ b/base/pkg/cache.jl
@@ -18,19 +18,13 @@ function mkcachedir()
         return
     end
 
-    @windows_only if Base.windows_version() < Base.WINDOWS_VISTA_VER
-        mkdir(cache)
-        return
-    end
-    if Dir.isversioned(pwd())
+    @unix_only if Dir.isversioned(pwd())
         rootcache = joinpath(realpath(".."), ".cache")
         if !isdir(rootcache)
             mkdir(rootcache)
         end
-        try
-            symlink(rootcache, cache)
-            return
-        end
+        symlink(rootcache, cache)
+        return
     end
     mkdir(cache)
 end


### PR DESCRIPTION
The directory junctions created by `symlink` are proving too problematic with respect to network drives.
This essentially reverts #7361. Ref #14026 and #14205.
