### PR TITLE
Shared Arrays no longer considered experimental

### DIFF
--- a/doc/stdlib/parallel.rst
+++ b/doc/stdlib/parallel.rst
@@ -489,8 +489,8 @@ General Parallel Computing Support
 
    A low-level API which given a ``IO`` connection, returns the pid of the worker it is connected to. This is useful when writing custom ``serialize`` methods for a type, which optimizes the data written out depending on the receiving process id.
 
-Shared Arrays (Experimental, UNIX-only feature)
------------------------------------------------
+Shared Arrays
+-------------
 
 .. function:: SharedArray(T::Type, dims::NTuple; init=false, pids=Int[])
 


### PR DESCRIPTION
Was removed elsewhere by @timholy in #12412
