### PR TITLE
Remove superfluous std::move

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6345,7 +6345,7 @@ extern "C" void jl_init_codegen(void)
 #endif
 
 #ifdef LLVM36
-    EngineBuilder eb(std::move(std::unique_ptr<Module>(engine_module)));
+    EngineBuilder eb((std::unique_ptr<Module>(engine_module)));
 #else
     EngineBuilder eb(engine_module);
 #endif


### PR DESCRIPTION
I see this warning on the master:

```
/Users/eschnett/src/julia05/src/codegen.cpp:6279:22: warning: moving a temporary
      object prevents copy elision [-Wpessimizing-move]
    EngineBuilder eb(std::move(std::unique_ptr<Module>(engine_module)));
                     ^
/Users/eschnett/src/julia05/src/codegen.cpp:6279:22: note: remove std::move call
      here
    EngineBuilder eb(std::move(std::unique_ptr<Module>(engine_module)));
                     ^~~~~~~~~~                                      ~
```

If I read this code correctly, the `std::move` is strictly superfluous and should be removed.
