### PR TITLE
Implement rm(..., force=true)

### DIFF
--- a/base/docs/helpdb.jl
+++ b/base/docs/helpdb.jl
@@ -8590,9 +8590,9 @@ As a special case, if `x` is an `AbstractString` (for textual MIME types) or a `
 reprmime
 
 doc"""
-    rm(path::AbstractString; recursive=false)
+    rm(path::AbstractString; force=false, recursive=false)
 
-Delete the file, link, or empty directory at the given path. If `recursive=true` is passed and the path is a directory, then all contents are removed recursively.
+Delete the file, link, or empty directory at the given path. If `force=true` is passed, a non-existing path is not treated as error. If `recursive=true` is passed and the path is a directory, then all contents are removed recursively.
 """
 rm
 

--- a/doc/stdlib/file.rst
+++ b/doc/stdlib/file.rst
@@ -178,11 +178,11 @@
 
    Move the file, link, or directory from ``src`` to ``dst``\ . ``remove_destination=true`` will first remove an existing ``dst``\ .
 
-.. function:: rm(path::AbstractString; recursive=false)
+.. function:: rm(path::AbstractString; force=false, recursive=false)
 
    .. Docstring generated from Julia source
 
-   Delete the file, link, or empty directory at the given path. If ``recursive=true`` is passed and the path is a directory, then all contents are removed recursively.
+   Delete the file, link, or empty directory at the given path. If ``force=true`` is passed, a non-existing path is not treated as error. If ``recursive=true`` is passed and the path is a directory, then all contents are removed recursively.
 
 .. function:: touch(path::AbstractString)
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -99,6 +99,7 @@ cp(newfile, c_file)
 @test isdir(c_subdir)
 @test isfile(c_file)
 @test_throws SystemError rm(c_tmpdir)
+@test_throws SystemError rm(c_tmpdir, force=true)
 
 # create temp dir in specific directory
 d_tmpdir = mktempdir(c_tmpdir)
@@ -113,6 +114,10 @@ close(f)
 
 rm(c_tmpdir, recursive=true)
 @test !isdir(c_tmpdir)
+@test_throws Base.UVError rm(c_tmpdir)
+@test rm(c_tmpdir, force=true) === nothing
+@test_throws Base.UVError rm(c_tmpdir, recursive=true)
+@test rm(c_tmpdir, force=true, recursive=true) === nothing
 
 
 #######################################################################


### PR DESCRIPTION
Implement a `force=true` option for `rm` that does not report an error when a path does not exist.
When returning an error, ensure it is always a `SystemError` and not a `UVError`.
Add test cases.
Update documentation.
