### PR TITLE
Ignore non-rst files when generating stdlib documentation

### DIFF
--- a/doc/genstdlib.jl
+++ b/doc/genstdlib.jl
@@ -286,9 +286,11 @@ function translate(file)
 end
 
 for folder in ["stdlib", "manual", "devdocs"]
-    println("\nConverting $folder/\n")
+    println("\nConverting rst files in $folder/\n")
     for file in readdir("$folder")
-        translate("$folder/$file")
+        if endswith(file, ".rst")
+            translate("$folder/$file")
+        end
     end
 end
 


### PR DESCRIPTION
Most importantly this skips backup files left by some editors, which otherwise confuse the script.
