### PR TITLE
fixes issue with double-backtraces when printing test errors

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -136,7 +136,7 @@ Returns a `Pass` `Result` if it does, a `Fail` `Result` if it is
 """
 macro test(ex)
     # If the test is a comparison
-    if typeof(ex) == Expr && ex.head == :comparison
+    if isa(ex, Expr) && ex.head == :comparison
         # Generate a temporary for every term in the expression
         n = length(ex.args)
         terms = [gensym() for i in 1:n]
@@ -315,7 +315,9 @@ record(ts::DefaultTestSet, t::Pass) = (push!(ts.results, t); t)
 function record(ts::DefaultTestSet, t::Union{Fail,Error})
     print_with_color(:white, ts.description, ": ")
     print(t)
-    Base.show_backtrace(STDOUT, backtrace())
+    # don't print the backtrace for Errors because it gets printed in the show
+    # method
+    isa(t, Error) || Base.show_backtrace(STDOUT, backtrace())
     println()
     push!(ts.results, t)
     t


### PR DESCRIPTION
side-port of IainNZ/BaseTestNext.jl#7

When errors occurred outside of a `@test` expression we were printing the
original error backtrace but then also printing a backtrace inside the `record`
method.

This led to output like this:

```
SampleTypes Tests: Error During Test
  Got an exception of type LoadError outside of a @test
  LoadError: error compiling anonymous: unsupported or misplaced expression "import" in function anonymous
   in include at ./boot.jl:261
   in include_from_node1 at ./loading.jl:304
   [inlined code] from /home/sfr/.julia/v0.4/SampleTypes/test/runtests.jl:12
   in anonymous at no file:0
   in include at ./boot.jl:261
   in include_from_node1 at ./loading.jl:304
   in process_options at ./client.jl:280
   in _start at ./client.jl:378
  while loading /home/sfr/.julia/v0.4/SampleTypes/test/SampleBuf.jl, in expression starting on line 1
 in record at /home/sfr/.julia/v0.4/BaseTestNext/src/BaseTestNext.jl:318
 [inlined code] from /home/sfr/.julia/v0.4/BaseTestNext/src/BaseTestNext.jl:554
 in anonymous at no file:0
 in include at ./boot.jl:261
 in include_from_node1 at ./loading.jl:304
 in process_options at ./client.jl:280
 in _start at ./client.jl:378
```

Which makes it pretty unclear where the error happened, and which backtrace you should use.

Now we get:

```
SampleTypes Tests: Error During Test
  Got an exception of type LoadError outside of a @test
  LoadError: error compiling anonymous: unsupported or misplaced expression "import" in function anonymous
   in include at ./boot.jl:261
   in include_from_node1 at ./loading.jl:304
   [inlined code] from /home/sfr/.julia/v0.4/SampleTypes/test/runtests.jl:12
   in anonymous at no file:0
   in include at ./boot.jl:261
   in include_from_node1 at ./loading.jl:304
   in process_options at ./client.jl:280
   in _start at ./client.jl:378
  while loading /home/sfr/.julia/v0.4/SampleTypes/test/SampleBuf.jl, in expression starting on line 1
```

In this case the error was inside `SampleBuf.jl`, so at least this gets us to
the right file.
