### PR TITLE
Fix reverse(p::Pair) on release-0.4

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -445,7 +445,7 @@ isless(p::Pair, q::Pair) = ifelse(!isequal(p.first,q.first), isless(p.first,q.fi
                                                              isless(p.second,q.second))
 getindex(p::Pair,i::Int) = getfield(p,i)
 getindex(p::Pair,i::Real) = getfield(p, convert(Int, i))
-reverse(p::Pair) = Pair(p.second, p.first)
+reverse{A,B}(p::Pair{A,B}) = Pair{B,A}(p.second, p.first)
 
 endof(p::Pair) = 2
 

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -20,6 +20,7 @@ B = [true true false]
 
 @test reverse(Pair(1,2)) == Pair(2,1)
 @test reverse(Pair("13","24")) == Pair("24","13")
+@test typeof(reverse(Pair{ByteString,Int64}("a",1))) == Pair{Int64,ByteString}
 
 p = 1=>:foo
 @test first(p) == 1


### PR DESCRIPTION
The same as PR  #14246  which is added a "backport pending 0.4" label 
