### PR TITLE
fix embedding docs of jl_atexit_hook

### DIFF
--- a/doc/devdocs/eval.rst
+++ b/doc/devdocs/eval.rst
@@ -53,7 +53,7 @@ The 10,000 foot view of the whole process is as follows:
    Whenever a Julia function is called for the first time with a given set of argument types, `type inference`_ will be run on that function.
    This information is used by the codegen_ step to generate faster code.
 #. Eventually, the user quits the REPL, or the end of the program is reached, and the :func:`_start` method returns.
-#. Just before exiting, :c:func:`main` calls `jl_atexit_hook() <https://github.com/JuliaLang/julia/blob/master/src/init.c>`_.
+#. Just before exiting, :c:func:`main` calls `jl_atexit_hook(exit_code) <https://github.com/JuliaLang/julia/blob/master/src/init.c>`_.
    This calls :func:`Base._atexit` (which calls any functions registered to :func:`atexit` inside Julia).
    Then it calls `jl_gc_run_all_finalizers() <https://github.com/JuliaLang/julia/blob/master/src/gc.c>`_.
    Finally, it gracefully cleans up all ``libuv`` handles and waits for them to flush and close.

--- a/doc/manual/embedding.rst
+++ b/doc/manual/embedding.rst
@@ -29,7 +29,7 @@ We start with a simple C program that initializes Julia and calls some Julia cod
            julia time to cleanup pending write requests
            and run all finalizers
       */
-      jl_atexit_hook();
+      jl_atexit_hook(0);
       return 0;
   }
 
@@ -73,7 +73,7 @@ now **JULIA_INIT_DIR** which is defined by *julia-config.jl*.::
   {
      jl_init(JULIA_INIT_DIR);
      (void)jl_eval_string("println(sqrt(2.0))");
-     jl_atexit_hook();
+     jl_atexit_hook(0);
      return 0;
   }
 


### PR DESCRIPTION
It seems that this now takes a return value parameter.
